### PR TITLE
Used syncpool in distributor

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -264,7 +264,7 @@ func (d *Distributor) routeRequest(req *friggpb.PushRequest, userID string, span
 			routedReq = pushRequestPool.Get().(*friggpb.PushRequest)
 			resourceSpans := resourceSpansPool.Get().(*opentelemetry_proto_trace_v1.ResourceSpans)
 
-			resourceSpans.Spans = make([]*opentelemetry_proto_trace_v1.Span, 0, spanCount), // assume most spans belong to the same trace
+			resourceSpans.Spans = make([]*opentelemetry_proto_trace_v1.Span, 0, spanCount) // assume most spans belong to the same trace
 			resourceSpans.Resource = req.Batch.Resource
 			routedReq.Batch = resourceSpans
 

--- a/pkg/distributor/pool.go
+++ b/pkg/distributor/pool.go
@@ -13,15 +13,17 @@ var pushRequestPool = sync.Pool{
 	},
 }
 
-var pushResourceSpansPool = sync.Pool{
+var resourceSpansPool = sync.Pool{
 	New: func() interface{} {
 		return &opentelemetry_proto_trace_v1.ResourceSpans{}
 	},
 }
 
-func resetPushRequests(reqs map[string][]*friggpb.PushRequest) {
-	for _, req := range reqs {
-		req.Batch.Spans = nil
-		req.Batch.Resource = nil
+func resetPushRequests(reqsPerIngester map[string][]*friggpb.PushRequest) {
+	for _, reqs := range reqsPerIngester {
+		for _, req := range reqs {
+			req.Batch.Spans = nil
+			req.Batch.Resource = nil
+		}
 	}
 }


### PR DESCRIPTION
- Added a syncpool in distributor for commonly allocated objects.
- Explored gogoslick usage, but was not compatible with otel proto