### PR TITLE
Add s3 backend to tempo-cli

### DIFF
--- a/cmd/tempo-cli/main.go
+++ b/cmd/tempo-cli/main.go
@@ -20,11 +20,11 @@ import (
 )
 
 var (
-	bucket   string
-	s3Endpoint string
-	s3User string
-	s3Pass string
-	backend   string
+	bucket      string
+	s3Endpoint  string
+	s3User      string
+	s3Pass      string
+	backend     string
 	tenantID    string
 	windowRange time.Duration
 	blockID     string
@@ -78,11 +78,11 @@ func main() {
 func getBackendUtils(backend, bucket, s3Endpoint, s3User, s3Pass string) (tempodb_backend.Reader, tempodb_backend.Writer, tempodb_backend.Compactor, error) {
 	if backend == "s3" {
 		return s3.New(&s3.Config{
-			Bucket: bucket,
-			Endpoint: s3Endpoint,
+			Bucket:    bucket,
+			Endpoint:  s3Endpoint,
 			AccessKey: s3User,
 			SecretKey: s3Pass,
-			Insecure: true,
+			Insecure:  true,
 		})
 	}
 	return gcs.New(&gcs.Config{

--- a/tempodb/backend/s3/compactor.go
+++ b/tempodb/backend/s3/compactor.go
@@ -74,7 +74,7 @@ func (rw *readerWriter) CompactedBlockMeta(blockID uuid.UUID, tenantID string) (
 
 	compactedMetaFileName := util.CompactedMetaFileName(blockID, tenantID)
 	bytes, info, err := rw.readAllWithObjInfo(context.TODO(), compactedMetaFileName)
-	if err != nil && err.Error() == s3KeyDoesNotExist {
+	if err != nil && err == backend.ErrMetaDoesNotExist {
 		return nil, backend.ErrMetaDoesNotExist
 	} else if err != nil {
 		return nil, errors.Wrapf(err, "error fetching compacted meta file %s", compactedMetaFileName)

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -311,9 +311,10 @@ func (rw *readerWriter) readAll(ctx context.Context, name string) ([]byte, error
 
 func (rw *readerWriter) readAllWithObjInfo(ctx context.Context, name string) ([]byte, minio.ObjectInfo, error) {
 	reader, info, _, err := rw.core.GetObjectWithContext(ctx, rw.cfg.Bucket, name, minio.GetObjectOptions{})
-	if err != nil {
-		// do not modify error message here
-		return nil, minio.ObjectInfo{}, err
+	if err != nil && err.Error() == s3KeyDoesNotExist {
+		return nil, minio.ObjectInfo{}, backend.ErrMetaDoesNotExist
+	} else if err != nil {
+		return nil, minio.ObjectInfo{}, errors.Wrap(err, "error fetching object from s3 backend")
 	}
 	defer reader.Close()
 


### PR DESCRIPTION
```
$ go run cmd/tempo-cli/main.go -bucket tempo -backend s3 -s3-endpoint 0.0.0.0:9000 -s3-user tempo -s3-pass supersecret -tenant-id single-tenant
total blocks:  15
+--------------------------------------+-----+-----+-------+--------+------+----------------------+----------------------+
|                  ID                  | LVL | IDX | COUNT | WINDOW | DUPE |        START         |         END          |
+--------------------------------------+-----+-----+-------+--------+------+----------------------+----------------------+
| 66f8ab9e-2651-41fe-a0d9-c90431fed78f |   0 |  16 |   153 | 111074 |    0 | 2020-09-07T10:59:02Z | 2020-09-07T10:59:32Z |
| f6a550bf-2ee0-415c-b644-2ee8afcbbe1d |   0 |  16 |   154 | 111074 |    0 | 2020-09-07T11:13:01Z | 2020-09-07T11:13:31Z |
| e91783b8-4287-4ded-a07e-e868abe68a44 |   0 |  16 |   154 | 111074 |    0 | 2020-09-07T11:14:31Z | 2020-09-07T11:15:00Z |
| 2b9514c8-84ee-4c58-84d6-58181c521f0f |   0 |  16 |   154 | 111074 |    0 | 2020-09-07T11:12:31Z | 2020-09-07T11:13:01Z |
| 0af93b7d-a0e8-4b81-b7ca-b29e5ae1adc9 |   0 |  16 |   154 | 111074 |    0 | 2020-09-07T11:13:31Z | 2020-09-07T11:14:00Z |
| 713f31c0-6f06-44a2-80f6-5a4f1fb7f434 |   0 |  16 |   153 | 111074 |    0 | 2020-09-07T11:14:01Z | 2020-09-07T11:14:31Z |
| 35f6fcd3-02f7-4934-9c12-bad8c9523691 |   1 |  31 |   307 | 111074 |    0 | 2020-09-07T11:13:31Z | 2020-09-07T11:14:31Z |
| d4bef7fa-bf5c-48cb-9acc-82303b3d0c75 |   1 |  31 |   309 | 111074 |    0 | 2020-09-07T10:58:02Z | 2020-09-07T10:59:02Z |
| abcaf6d2-2e79-4e92-acd5-f3a2e90e24f9 |   1 |  31 |   308 | 111074 |    0 | 2020-09-07T11:12:31Z | 2020-09-07T11:13:31Z |
| 68c23d85-0234-4170-a391-46ad9cee59e9 |   1 |  31 |   308 | 111074 |    0 | 2020-09-07T11:11:31Z | 2020-09-07T11:12:31Z |
| fafc0fc0-57f7-4211-ba45-7bbcd84a9aaf |   1 |  31 |   308 | 111074 |    0 | 2020-09-07T10:57:02Z | 2020-09-07T10:58:02Z |
| 1fcce74f-f066-4b17-a2da-3d99bc35012c |   2 |  62 |   616 | 111074 |    0 | 2020-09-07T11:11:31Z | 2020-09-07T11:13:31Z |
| 11d3a65d-ce33-4704-8733-a9b9320b477a |   3 | 124 |  1231 | 111074 |    0 | 2020-09-07T11:07:31Z | 2020-09-07T11:11:31Z |
| 8aae57fc-3d61-4a68-b81b-bbe8e01c8d14 |   4 | 372 |  3713 | 111074 |    0 | 2020-09-07T10:49:01Z | 2020-09-07T10:57:02Z |
| 6231da80-c8d2-4ca9-a5d4-d70267ed5646 |   4 | 247 |  2463 | 111074 |    0 | 2020-09-07T10:59:32Z | 2020-09-07T11:07:31Z |
+--------------------------------------+-----+-----+-------+--------+------+----------------------+----------------------+
|                                                    10485 |
+--------------------------------------+-----+-----+-------+--------+------+----------------------+----------------------+




$ go run cmd/tempo-cli/main.go -bucket tempo -backend s3 -s3-endpoint 0.0.0.0:9000 -s3-user tempo -s3-pass supersecret -tenant-id single-tenant -block-id 6231da80-c8d2-4ca9-a5d4-d70267ed5646
ID            :  6231da80-c8d2-4ca9-a5d4-d70267ed5646
Total Objects :  2463
Level         :  4
Window        :  111074
Start         :  2020-09-07 10:59:32.3622316 +0000 UTC
End           :  2020-09-07 11:07:31.4674819 +0000 UTC
Searching for dupes ...
total:  2463
dupes:  0

```


Signed-off-by: Annanay <annanayagarwal@gmail.com>