### PR TITLE
Allow querying for a traceID in tempo-cli

### DIFF
--- a/cmd/tempo-cli/main.go
+++ b/cmd/tempo-cli/main.go
@@ -32,7 +32,7 @@ var (
 	blockID     string
 
 	queryEndpoint string
-	traceID string
+	traceID       string
 )
 
 func init() {
@@ -53,14 +53,14 @@ func main() {
 	flag.Parse()
 
 	if len(queryEndpoint) > 0 && len(traceID) > 0 {
-		trace, err := util.QueryTempo(queryEndpoint, traceID)
+		trace, err := util.QueryTrace(queryEndpoint, traceID)
 		if err != nil {
 			fmt.Println("error querying tempo, err:", err)
 			return
 		}
 
-		traceJson, _ := json.Marshal(trace)
-		fmt.Println(string(traceJson))
+		traceJSON, _ := json.Marshal(trace)
+		fmt.Println(string(traceJSON))
 		fmt.Println("------------------------------------")
 		return
 	}

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -111,7 +111,7 @@ func queryTempoAndAnalyze(baseURL string, backoff time.Duration, traceIDs []stri
 		time.Sleep(backoff)
 
 		glog.Error("tempo url ", baseURL+"/api/traces/"+id)
-		trace, err := util.QueryTempo(baseURL, id)
+		trace, err := util.QueryTrace(baseURL, id)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/util/query.go
+++ b/pkg/util/query.go
@@ -9,7 +9,7 @@ import (
 	"github.com/grafana/tempo/pkg/tempopb"
 )
 
-func QueryTempo(baseURL, id string) (*tempopb.Trace, error) {
+func QueryTrace(baseURL, id string) (*tempopb.Trace, error) {
 	resp, err := http.Get(baseURL + "/api/traces/" + id)
 	if err != nil {
 		return nil, fmt.Errorf("error querying tempo %v", err)
@@ -29,4 +29,3 @@ func QueryTempo(baseURL, id string) (*tempopb.Trace, error) {
 
 	return trace, nil
 }
-


### PR DESCRIPTION
```
$ go run cmd/tempo-cli/main.go -query-endpoint http://localhost:3100 -traceID 2a61c34ff39a1518
{"batches":[{"resource":{"attributes":[{"key":"service.name","value":{"Value":{"string_value":"cortex-ingester"}}}.....}
```