### PR TITLE
Wrap error messages in querier

### DIFF
--- a/cmd/tempo-query/tempo/plugin.go
+++ b/cmd/tempo-query/tempo/plugin.go
@@ -7,17 +7,16 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/jsonpb"
+	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/weaveworks/common/user"
 	"google.golang.org/grpc/metadata"
 
 	jaeger "github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 	jaeger_spanstore "github.com/jaegertracing/jaeger/storage/spanstore"
+
 	ot_pdata "go.opentelemetry.io/collector/consumer/pdata"
 	ot_jaeger "go.opentelemetry.io/collector/translator/trace/jaeger"
-
-	"github.com/grafana/tempo/pkg/tempopb"
-	"github.com/grafana/tempo/pkg/util"
 )
 
 type Backend struct {
@@ -45,8 +44,6 @@ func (b *Backend) GetTrace(ctx context.Context, traceID jaeger.TraceID) (*jaeger
 	tenantID, found := extractBearerToken(ctx)
 	if found {
 		req.Header.Set(user.OrgIDHeaderName, tenantID)
-	} else {
-		req.Header.Set(user.OrgIDHeaderName, util.FakeTenantID)
 	}
 
 	resp, err := http.DefaultClient.Do(req)


### PR DESCRIPTION
PR does two things:
- wrap error messages in querier
- add FakeTenantID to query plugin if no tenantID is found, (for cortex-gw auth) - need confirmation on this (works with the local compose, going to try in k8s cluster)

Signed-off-by: Annanay <annanayagarwal@gmail.com>