### PR TITLE
Push images with commit hash

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -24,6 +24,8 @@ jobs:
           }
           if [[ "${GITHUB_REF}" == "refs/heads/master" ]]; then
             tag_and_push "latest"
+            git_hash=$(git rev-parse --short "$GITHUB_SHA")
+            tag_and_push git_hash
           elif [[ "${GITHUB_REF}" =~ refs/tags/v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
               TAG="${GITHUB_REF#"refs/tags/v"}"
               tag_and_push "${TAG}"


### PR DESCRIPTION
`:latest` is tricky to use. But this will push 6 images, I can drop `:latest` and just use `:sha` as well. 

Signed-off-by: Annanay <annanayagarwal@gmail.com>