### PR TITLE
Upgraded Jaeger-Query to 1.20.0

### DIFF
--- a/cmd/tempo-query/Dockerfile
+++ b/cmd/tempo-query/Dockerfile
@@ -1,4 +1,4 @@
-FROM jaegertracing/jaeger-query:1.19.2
+FROM jaegertracing/jaeger-query:1.20.0
 
 ENV SPAN_STORAGE_TYPE=grpc-plugin \
     GRPC_STORAGE_PLUGIN_BINARY=/tmp/tempo-query


### PR DESCRIPTION
Jaeger 1.20.0 was recently release.  This should fix our 404 -> 500 query issue.