### PR TITLE
Drop error in worker pool if msg != nil

### DIFF
--- a/tempodb/pool/pool.go
+++ b/tempodb/pool/pool.go
@@ -125,7 +125,13 @@ func (p *Pool) RunJobs(ctx context.Context, payloads []interface{}, fn JobFunc) 
 	default:
 	}
 
-	return msg, err.Load()
+	// ignore err if msg != nil.  otherwise errors like "context cancelled"
+	//  will take precedence over the err
+	if msg != nil {
+		return msg, nil
+	}
+
+	return nil, err.Load()
 }
 
 func (p *Pool) Shutdown() {


### PR DESCRIPTION
If the message is not nil then always return a nil error.  The issue is that even when the query is successful we will very often have "context cancelled" messages returned here which will fail the query.