### PR TITLE
Adjusted distributor return codes to prevent retries

### DIFF
--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -277,7 +277,7 @@ func (i *instance) getOrCreateTrace(req *tempopb.PushRequest) (*trace, error) {
 
 	err = i.limiter.AssertMaxTracesPerUser(i.instanceID, len(i.traces))
 	if err != nil {
-		return nil, status.Errorf(codes.ResourceExhausted, "max live traces per tenant exceeded: %v", err)
+		return nil, status.Errorf(codes.FailedPrecondition, "max live traces per tenant exceeded: %v", err)
 	}
 
 	maxSpans := i.limiter.limits.MaxSpansPerTrace(i.instanceID)

--- a/modules/ingester/trace.go
+++ b/modules/ingester/trace.go
@@ -37,7 +37,7 @@ func (t *trace) Push(_ context.Context, req *tempopb.PushRequest) error {
 		}
 
 		if t.currentSpans+spanCount > t.maxSpans {
-			return status.Errorf(codes.ResourceExhausted, "totalSpans (%d) exceeded while adding %d spans", t.maxSpans, spanCount)
+			return status.Errorf(codes.FailedPrecondition, "totalSpans (%d) exceeded while adding %d spans", t.maxSpans, spanCount)
 		}
 
 		t.currentSpans += spanCount


### PR DESCRIPTION
**What this PR does**:
Adjusts the return codes on errors from the distributor to prevent retries.  If one of these return codes hits it would cause repeated retries of batches that are partially saved.  Possibly resulting in broken traces.

**Which issue(s) this PR fixes**:
Fixes #None

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`