### PR TITLE
Stats: Adding GitHub action to collect GitHub repo & issue stats

### DIFF
--- a/.github/workflows/metrics-collector.yml
+++ b/.github/workflows/metrics-collector.yml
@@ -20,4 +20,3 @@ jobs:
         with:
           metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
           token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
-          configPath: "metrics-collector"

--- a/.github/workflows/metrics-collector.yml
+++ b/.github/workflows/metrics-collector.yml
@@ -1,0 +1,23 @@
+name: Github repo and issue stats collection
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: "grafana/grafana-github-actions"
+          path: ./actions
+          ref: main
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run metrics collector
+        uses: ./actions/metrics-collector
+        with:
+          metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
+          token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          configPath: "metrics-collector"


### PR DESCRIPTION
This adds a metric collector github action that sends metrics to a grafana cloud graphite instance: 

We use it for Grafana for this dashboard:
https://play.grafana.org/d/aw0AkS5Gz/grafana-issue-triage?orgId=1 

This just adds the basic metrics like stars, forks, open issue count etc. 

You can then add custom github queries to get a trending for how different issue counts change with time (like open PRs, bugs issues with no label).
https://github.com/grafana/grafana/blob/master/.github/metrics-collector.json 

The code for this action is here:
https://github.com/grafana/grafana-github-actions 

Can see that the GH_BOT_ACCESS_TOKEN secret is already added to this repo, will add another one for the GRAFANA_MISC_STATS_API_KEY 