### PR TITLE
Change "Grafana Agent" to "Grafana Cloud Agent"

### DIFF
--- a/docs/tempo/website/getting-started/_index.md
+++ b/docs/tempo/website/getting-started/_index.md
@@ -101,6 +101,6 @@ Some highlights:
   - This jsonnet based example shows a complete microservice based deployment.
 
 
-## Grafana Agent
+## Grafana Cloud Agent
 
-The Grafana Agent is already set up to use Tempo.  Refer to the [configuration](https://github.com/grafana/agent/blob/master/docs/configuration-reference.md#tempo_config) and [example](https://github.com/grafana/agent/blob/master/example/docker-compose/agent/config/agent.yaml) for details.
+The Grafana Cloud Agent is already set up to use Tempo. Refer to the [configuration](https://github.com/grafana/agent/blob/master/docs/configuration-reference.md#tempo_config) and [example](https://github.com/grafana/agent/blob/master/example/docker-compose/agent/config/agent.yaml) for details.


### PR DESCRIPTION
Small nit: the `grafana/agent` repo's project name should be "Grafana Cloud Agent."