### PR TITLE
Add Hot R.O.D demo

### DIFF
--- a/example/docker-compose/docker-compose.hotrod.yaml
+++ b/example/docker-compose/docker-compose.hotrod.yaml
@@ -1,0 +1,87 @@
+version: "2"
+services:
+
+  tempo:
+    image: grafana/tempo:latest
+    command: 
+      - "-storage.trace.backend=local"                  # tell tempo where to permanently put traces
+      - "-storage.trace.local.path=/tmp/tempo/traces"   
+      - "-storage.trace.wal.path=/tmp/tempo/wal"        # tell tempo where to store the wal
+      - "-auth.enabled=false"                           # disables the requirement for the X-Scope-OrgID header
+      - "-server.http-listen-port=3100" 
+    volumes:
+      - ./tempo.yaml:/etc/tempo.yaml
+      - /tmp/tempo:/tmp/tempo
+    ports:
+      - "14268"  # jaeger ingest
+    logging:
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/api/prom/push'
+
+  tempo-query:
+    image: grafana/tempo-query:latest
+    command: ["--grpc-storage-plugin.configuration-file=/etc/tempo-query.yaml"]
+    volumes:
+      - ./tempo-query.yaml:/etc/tempo-query.yaml
+    ports:
+      - "16686:16686"  # jaeger-ui
+    logging:
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/api/prom/push'
+
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus.yaml:/etc/prometheus.yaml
+    entrypoint:
+      - /bin/prometheus
+      - --config.file=/etc/prometheus.yaml
+    ports:
+      - "9090:9090"
+    logging:
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/api/prom/push'
+
+  grafana:
+    image: grafana/grafana:7.3.0-beta1
+    volumes:
+      - ./datasources:/etc/grafana/provisioning/datasources
+      - ./dashboards-provisioning:/etc/grafana/provisioning/dashboards
+      - ../../operations/tempo-mixin/out:/var/lib/grafana/dashboards
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+    ports:
+      - "3000:3000"
+    logging:
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/api/prom/push'
+
+  loki:
+    image: grafana/loki:latest
+    command: -config.file=/etc/loki/local-config.yaml
+    ports:
+      - "3100:3100"                                   # loki needs to be exposed so it receives logs
+    logging:
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/api/prom/push'
+  hotrod:
+    image: dgzlopes/hotrod
+    ports: 
+      - "8080:8080"
+    command: ["all","-j","http://localhost:3000"]
+    environment:
+      - JAEGER_AGENT_HOST=tempo
+      - JAEGER_ENDPOINT=http://tempo:14268/api/traces # send traces to Tempo
+    depends_on:
+      - tempo
+    logging:
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/api/prom/push'

--- a/example/docker-compose/docker-compose.hotrod.yaml
+++ b/example/docker-compose/docker-compose.hotrod.yaml
@@ -10,8 +10,7 @@ services:
       - "-auth.enabled=false"                           # disables the requirement for the X-Scope-OrgID header
       - "-server.http-listen-port=3100" 
     volumes:
-      - ./tempo.yaml:/etc/tempo.yaml
-      - /tmp/tempo:/tmp/tempo
+      - ./example-data/tempo:/tmp/tempo
     ports:
       - "14268"  # jaeger ingest
     logging:
@@ -23,7 +22,7 @@ services:
     image: grafana/tempo-query:latest
     command: ["--grpc-storage-plugin.configuration-file=/etc/tempo-query.yaml"]
     volumes:
-      - ./tempo-query.yaml:/etc/tempo-query.yaml
+      - ./etc/tempo-query.yaml:/etc/tempo-query.yaml
     ports:
       - "16686:16686"  # jaeger-ui
     logging:
@@ -34,7 +33,7 @@ services:
   prometheus:
     image: prom/prometheus:latest
     volumes:
-      - ./prometheus.yaml:/etc/prometheus.yaml
+      - ./etc/prometheus.yaml:/etc/prometheus.yaml
     entrypoint:
       - /bin/prometheus
       - --config.file=/etc/prometheus.yaml
@@ -48,8 +47,8 @@ services:
   grafana:
     image: grafana/grafana:7.3.0-beta1
     volumes:
-      - ./datasources:/etc/grafana/provisioning/datasources
-      - ./dashboards-provisioning:/etc/grafana/provisioning/dashboards
+      - ./example-data/datasources:/etc/grafana/provisioning/datasources
+      - ./example-data/dashboards-provisioning:/etc/grafana/provisioning/dashboards
       - ../../operations/tempo-mixin/out:/var/lib/grafana/dashboards
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true

--- a/example/docker-compose/docker-compose.hotrod.yaml
+++ b/example/docker-compose/docker-compose.hotrod.yaml
@@ -75,7 +75,7 @@ services:
     image: dgzlopes/hotrod
     ports: 
       - "8080:8080"
-    command: ["all","-j","http://localhost:3000"]
+    command: ["all","-j","http://localhost:3000","-m","prometheus"]
     environment:
       - JAEGER_AGENT_HOST=tempo
       - JAEGER_ENDPOINT=http://tempo:14268/api/traces # send traces to Tempo

--- a/example/docker-compose/etc/prometheus.yaml
+++ b/example/docker-compose/etc/prometheus.yaml
@@ -9,3 +9,6 @@ scrape_configs:
   - job_name: 'tempo'
     static_configs:
     - targets: ['tempo:3100']
+  - job_name: 'hotrod'
+    static_configs:
+    - targets: ['hotrod:8083']

--- a/example/docker-compose/example-data/datasources/datasource.yml
+++ b/example/docker-compose/example-data/datasources/datasource.yml
@@ -41,3 +41,7 @@ datasources:
         matcherRegex: (?:traceID|trace_id)=(\w+)
         name: TraceID
         url: $${__value.raw}
+      - datasourceUid: tempo
+        matcherRegex: \"(?:traceID|trace_id)\":\"(\w+)\"
+        name: TraceIDjson
+        url: $${__value.raw}


### PR DESCRIPTION
![search](https://user-images.githubusercontent.com/8228060/97675080-f00d1700-1a8e-11eb-9d48-41f279241484.gif)

**What this PR does**:
This PR adds a new docker-compose example! This one is based on the Hot R.O.D demo created by the Jaeger team.

**Things to discuss**:

I built my own Hot R.O.D [image](https://hub.docker.com/r/dgzlopes/hotrod) from this [modified](https://github.com/dgzlopes/jaeger/tree/add-changes-for-tempo) Jaeger branch. Why?

- I changed the Zap preset from NewDevelopment to NewProduction. 
    - Grafana parse fields doesn't work with the NewDevelopment format.
- I changed the path for the `Find Trace` feature on the frontend. 
    - Now, it points to `Grafana>Explore>Loki>{compose_service="hotrod"} |~ "CarID"`

Probably the first change would be accepted on Jaeger repo, the second one... I'm not sure.

I suppose here we've some options:
- Use the default Hot R.O.D image provided by Jaeger.
- Build a `grafana/hotrod` image:
   - From a Jaeger fork
   - Moving the example to the Tempo repo
- Build a microservices example from scratch.

**Which issue(s) this PR fixes**:
Fixes #282

**Checklist**
- [ ] Tests updated
- [ ] Documentation added --> Not yet, waiting for discussion
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`