### PR TITLE
Add README to docs folder

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+# Tempo Documentation
+
+<p align="center"> <img src="tempo/website/logo_and_name.png" alt="Tempo Logo"> <br>
+  
+Please see the [Documentation Site](https://grafana.com/docs/tempo/latest/) The files in this directory are used to generate it but consequently the links don't work in Github.


### PR DESCRIPTION
This PR adds a small readme on the docs folder. Explains link behavior. I used the same structure as [Loki](https://github.com/grafana/loki/blob/master/docs/README.md).