### PR TITLE
 Increase Prometheus not found metric on tempo-vulture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 * [CHANGE] Bloom filters are now sharded to reduce size and improve caching, as blocks grow. This is a **breaking change** and all data stored before this change will **not** be queryable. [192](https://github.com/grafana/tempo/pull/192)
 * [ENHANCEMENT] CI checks for vendored dependencies using `make vendor-check`. Update CONTRIBUTING.md to reflect the same before checking in files in a PR. [#274](https://github.com/grafana/tempo/pull/274)
 * [ENHANCEMENT] Add warnings for suspect configs. [#294](https://github.com/grafana/tempo/pull/294)
+* [BUGFIX] Increase Prometheus `notfound` metric on tempo-vulture. [#301](https://github.com/grafana/tempo/pull/301)

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -115,7 +115,7 @@ func queryTempoAndAnalyze(baseURL string, backoff time.Duration, traceIDs []stri
 		glog.Error("tempo url ", baseURL+"/api/traces/"+id)
 		trace, err := util.QueryTrace(baseURL, id, tempoOrgID)
 		if err != nil {
-			if strings.Contains(err.Error(), "not found") {
+			if err == util.ErrTraceNotFound {
 				glog.Error("trace not found ", id)
 				tm.notfound++
 				continue

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -114,12 +114,12 @@ func queryTempoAndAnalyze(baseURL string, backoff time.Duration, traceIDs []stri
 
 		glog.Error("tempo url ", baseURL+"/api/traces/"+id)
 		trace, err := util.QueryTrace(baseURL, id, tempoOrgID)
+		if err == util.ErrTraceNotFound {
+			glog.Error("trace not found ", id)
+			tm.notfound++
+			continue
+		}
 		if err != nil {
-			if err == util.ErrTraceNotFound {
-				glog.Error("trace not found ", id)
-				tm.notfound++
-				continue
-			}
 			return nil, err
 		}
 

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -115,6 +115,11 @@ func queryTempoAndAnalyze(baseURL string, backoff time.Duration, traceIDs []stri
 		glog.Error("tempo url ", baseURL+"/api/traces/"+id)
 		trace, err := util.QueryTrace(baseURL, id, tempoOrgID)
 		if err != nil {
+			if strings.Contains(err.Error(), "not found") {
+				glog.Error("trace not found ", id)
+				tm.notfound++
+				continue
+			}
 			return nil, err
 		}
 

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -2,11 +2,15 @@ package util
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// ErrTraceNotFound can be used when we don't find a trace
+var ErrTraceNotFound = errors.New("trace not found")
 
 // The MultiError type implements the error interface, and contains the
 // Errors used to construct it.

--- a/pkg/util/query.go
+++ b/pkg/util/query.go
@@ -30,7 +30,7 @@ func QueryTrace(baseURL, id, orgID string) (*tempopb.Trace, error) {
 		}
 	}()
 
-	if resp.StatusCode == 404 {
+	if resp.StatusCode == http.StatusNotFound {
 		return nil, fmt.Errorf("not found traceID: %s", id)
 	}
 

--- a/pkg/util/query.go
+++ b/pkg/util/query.go
@@ -31,7 +31,7 @@ func QueryTrace(baseURL, id, orgID string) (*tempopb.Trace, error) {
 	}()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("not found traceID: %s", id)
+		return nil, ErrTraceNotFound
 	}
 
 	trace := &tempopb.Trace{}

--- a/pkg/util/query.go
+++ b/pkg/util/query.go
@@ -30,6 +30,10 @@ func QueryTrace(baseURL, id, orgID string) (*tempopb.Trace, error) {
 		}
 	}()
 
+	if resp.StatusCode == 404 {
+		return nil, fmt.Errorf("not found traceID: %s", id)
+	}
+
 	trace := &tempopb.Trace{}
 	unmarshaller := &jsonpb.Unmarshaler{}
 	err = unmarshaller.Unmarshal(resp.Body, trace)


### PR DESCRIPTION
**What this PR does**:
This PR adds some things:
- Return a `not found error` in case we don't find the traceID.
- Increase Prometheus not found metric on tempo-vulture.

I'm not a Go expert, but this approach seemed "reasonable" :smile:

**Which issue(s) this PR fixes**:
Fixes #286

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`