### PR TITLE
Add tenant label to failed batches metric in distributor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 * [CHANGE] Bloom filters are now sharded to reduce size and improve caching, as blocks grow. This is a **breaking change** and all data stored before this change will **not** be queryable. [192](https://github.com/grafana/tempo/pull/192)
 * [ENHANCEMENT] CI checks for vendored dependencies using `make vendor-check`. Update CONTRIBUTING.md to reflect the same before checking in files in a PR. [#274](https://github.com/grafana/tempo/pull/274)
 * [ENHANCEMENT] Add warnings for suspect configs. [#294](https://github.com/grafana/tempo/pull/294)
+* [ENHANCEMENT] Add `tenantID` label to metric `distributor_ingester_append_failures_total`. [#304](https://github.com/grafana/tempo/pull/304)


### PR DESCRIPTION
Signed-off-by: Annanay <annanayagarwal@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Adds tenantID label to the failed batches metric. This is useful to inform each tenant about failed batches.

**Which issue(s) this PR fixes**:
Fixes NA

**Checklist**
- NA Tests updated
- NA Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`