### PR TITLE
Expose jaeger metrics

### DIFF
--- a/operations/helm/tempo-microservices/templates/deployment-querier.yaml
+++ b/operations/helm/tempo-microservices/templates/deployment-querier.yaml
@@ -48,6 +48,8 @@ spec:
         ports:
         - containerPort: 16686
           name: jaeger-ui
+        - containerPort: 16687
+          name: jaeger-metrics
         resources:
             {{- toYaml .Values.tempoQuery.resources | nindent 10 }}
         volumeMounts:

--- a/operations/helm/tempo-single-binary/templates/statefulset.yaml
+++ b/operations/helm/tempo-single-binary/templates/statefulset.yaml
@@ -43,6 +43,8 @@ spec:
         ports:
         - containerPort: 16686
           name: jaeger-ui
+        - containerPort: 16687
+          name: jaeger-metrics
         resources:
           {{- toYaml .Values.tempoQuery.resources | nindent 10 }}  
         volumeMounts:

--- a/operations/jsonnet/microservices/querier.libsonnet
+++ b/operations/jsonnet/microservices/querier.libsonnet
@@ -30,6 +30,7 @@
     container.new('tempo-query', $._images.tempo_query) +
     container.withPorts([
       containerPort.new('jaeger-ui', 16686),
+      containerPort.new('jaeger-metrics', 16687),
     ]) +
     container.withArgs([
       '--query.base-path=' + $._config.jaeger_ui.base_path,

--- a/operations/jsonnet/single-binary/tempo.libsonnet
+++ b/operations/jsonnet/single-binary/tempo.libsonnet
@@ -49,6 +49,7 @@
     container.new('tempo-query', $._images.tempo_query) +
     container.withPorts([
       containerPort.new('jaeger-ui', 16686),
+      containerPort.new('jaeger-metrics', 16687),
     ]) +
     container.withArgs([
       '--query.base-path=' + $._config.jaeger_ui.base_path,

--- a/operations/tempo-mixin/dashboards.libsonnet
+++ b/operations/tempo-mixin/dashboards.libsonnet
@@ -23,7 +23,7 @@ dashboard_utils {
         g.row('Jaeger Query')
         .addPanel(
           $.panel('QPS') +
-          $.qpsPanel('jaeger_query_latency_count{%s, operation="get_trace"}' % $.jobMatcher($._config.jobs.querier))
+          $.qpsPanel('jaeger_rpc_http_requests_total{%s, endpoint="/api/traces/-traceID-"}' % $.jobMatcher($._config.jobs.querier))
         )
         .addPanel(
           $.panel('Latency') +

--- a/operations/tempo-mixin/dashboards.libsonnet
+++ b/operations/tempo-mixin/dashboards.libsonnet
@@ -20,6 +20,17 @@ dashboard_utils {
         )
       )
       .addRow(
+        g.row('Jaeger Query')
+        .addPanel(
+          $.panel('QPS') +
+          $.qpsPanel('jaeger_query_latency_count{%s, operation="get_trace"}' % $.jobMatcher($._config.jobs.querier))
+        )
+        .addPanel(
+          $.panel('Latency') +
+          $.latencyPanel('jaeger_query_latency', '{%s,operation="get_trace"}' % $.jobMatcher($._config.jobs.querier))
+        )
+      )
+      .addRow(
         g.row('Querier')
         .addPanel(
           $.panel('QPS') +

--- a/operations/tempo-mixin/out/tempo-operational.json
+++ b/operations/tempo-mixin/out/tempo-operational.json
@@ -27,8 +27,8 @@
  "editable": true,
  "gnetId": null,
  "graphTooltip": 1,
- "id": 1425,
- "iteration": 1603745012490,
+ "id": 6,
+ "iteration": 1603829138071,
  "links": [
 
  ],
@@ -2294,8 +2294,9 @@
    "steppedLine": false,
    "targets": [
     {
-     "expr": "histogram_quantile(.5, sum(rate(tempo_query_reads_bucket[$__rate_interval])) by (layer, le))",
+     "expr": "histogram_quantile(.5, sum(rate(tempo_query_reads_bucket{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (layer, le))",
      "hide": false,
+     "interval": "",
      "legendFormat": "{{layer}}",
      "refId": "A"
     }
@@ -2403,18 +2404,20 @@
    "steppedLine": false,
    "targets": [
     {
-     "expr": "histogram_quantile(.99, sum(rate(tempo_query_bytes_read_bucket[$__rate_interval])) by (le))",
+     "expr": "histogram_quantile(.99, sum(rate(tempo_query_bytes_read_bucket{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (le))",
      "interval": "",
      "legendFormat": ".99",
      "refId": "A"
     },
     {
-     "expr": "histogram_quantile(.9, sum(rate(tempo_query_bytes_read_bucket[$__rate_interval])) by (le))",
+     "expr": "histogram_quantile(.9, sum(rate(tempo_query_bytes_read_bucket{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (le))",
+     "interval": "",
      "legendFormat": ".9",
      "refId": "B"
     },
     {
-     "expr": "histogram_quantile(.5, sum(rate(tempo_query_bytes_read_bucket[$__rate_interval])) by (le))",
+     "expr": "histogram_quantile(.5, sum(rate(tempo_query_bytes_read_bucket{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (le))",
+     "interval": "",
      "legendFormat": ".5",
      "refId": "C"
     }
@@ -2643,8 +2646,9 @@
    "steppedLine": false,
    "targets": [
     {
-     "expr": "histogram_quantile(.99, sum(rate(tempo_query_reads_bucket[$__rate_interval])) by (layer, le))",
+     "expr": "histogram_quantile(.99, sum(rate(tempo_query_reads_bucket{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (layer, le))",
      "hide": false,
+     "interval": "",
      "legendFormat": "{{layer}}",
      "refId": "A"
     }
@@ -2768,7 +2772,7 @@
    "steppedLine": false,
    "targets": [
     {
-     "expr": "rate(tempo_distributor_spans_received_total[$__rate_interval])",
+     "expr": "rate(tempo_distributor_spans_received_total{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])",
      "interval": "",
      "legendFormat": "{{pod}}",
      "refId": "A"
@@ -2877,7 +2881,7 @@
    "steppedLine": false,
    "targets": [
     {
-     "expr": "rate(tempo_ingester_traces_created_total[$__rate_interval])",
+     "expr": "rate(tempo_ingester_traces_created_total{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])",
      "interval": "",
      "legendFormat": "",
      "refId": "A"
@@ -3095,7 +3099,7 @@
    "steppedLine": false,
    "targets": [
     {
-     "expr": "increase(tempo_ingester_failed_flushes_total[5m]) > 0",
+     "expr": "increase(tempo_ingester_failed_flushes_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) > 0",
      "interval": "",
      "legendFormat": "{{pod}}",
      "refId": "A"
@@ -3204,7 +3208,7 @@
    "steppedLine": false,
    "targets": [
     {
-     "expr": "sum(increase(tempo_ingester_blocks_cleared_total[1h]))",
+     "expr": "sum(increase(tempo_ingester_blocks_cleared_total{cluster=\"$cluster\", namespace=\"$namespace\"}[1h]))",
      "interval": "",
      "legendFormat": "",
      "refId": "A"
@@ -3313,17 +3317,19 @@
    "steppedLine": false,
    "targets": [
     {
-     "expr": "histogram_quantile(.99, sum(rate(tempo_ingester_flush_duration_seconds_bucket[$__rate_interval])) by (le))",
+     "expr": "histogram_quantile(.99, sum(rate(tempo_ingester_flush_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (le))",
+     "interval": "",
      "legendFormat": ".99",
      "refId": "A"
     },
     {
-     "expr": "histogram_quantile(.9, sum(rate(tempo_ingester_flush_duration_seconds_bucket[$__rate_interval])) by (le))",
+     "expr": "histogram_quantile(.9, sum(rate(tempo_ingester_flush_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (le))",
+     "interval": "",
      "legendFormat": ".9",
      "refId": "B"
     },
     {
-     "expr": "histogram_quantile(.5, sum(rate(tempo_ingester_flush_duration_seconds_bucket[$__rate_interval])) by (le))",
+     "expr": "histogram_quantile(.5, sum(rate(tempo_ingester_flush_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (le))",
      "interval": "",
      "legendFormat": ".5",
      "refId": "C"
@@ -3541,13 +3547,13 @@
    "steppedLine": false,
    "targets": [
     {
-     "expr": "sum(rate(tempo_receiver_accepted_spans{namespace=\"tracing-ops\"}[$__rate_interval]))",
+     "expr": "sum(rate(tempo_receiver_accepted_spans{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
      "interval": "",
      "legendFormat": "accepted",
      "refId": "A"
     },
     {
-     "expr": "sum(rate(tempo_receiver_refused_spans{namespace=\"tracing-ops\"}[$__rate_interval]))",
+     "expr": "sum(rate(tempo_receiver_refused_spans{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
      "interval": "",
      "legendFormat": "refused",
      "refId": "B"
@@ -4949,7 +4955,7 @@
      "pluginVersion": "7.2.1",
      "targets": [
       {
-       "expr": "sum(rate(tempo_vulture_trace_error_total{error=\"notfound\"}[1h])) by (secondsago) / sum(rate(tempo_vulture_trace_total[1h])) by (secondsago)",
+       "expr": "sum(rate(tempo_vulture_trace_error_total{cluster=\"$cluster\", namespace=\"$namespace\", error=\"notfound\"}[1h])) by (secondsago) / sum(rate(tempo_vulture_trace_total{cluster=\"$cluster\", namespace=\"$namespace\"}[1h])) by (secondsago)",
        "interval": "",
        "legendFormat": "{{secondsago}}",
        "refId": "A"
@@ -5082,7 +5088,7 @@
      "pluginVersion": "7.2.1",
      "targets": [
       {
-       "expr": "sum(rate(tempo_vulture_trace_error_total{error=\"missingspans\"}[1h])) by (secondsago) / sum(rate(tempo_vulture_trace_total[1h])) by (secondsago)",
+       "expr": "sum(rate(tempo_vulture_trace_error_total{cluster=\"$cluster\", namespace=\"$namespace\", error=\"missingspans\"}[1h])) by (secondsago) / sum(rate(tempo_vulture_trace_total{cluster=\"$cluster\", namespace=\"$namespace\"}[1h])) by (secondsago)",
        "interval": "",
        "legendFormat": "{{secondsago}}",
        "refId": "A"
@@ -5110,6 +5116,7 @@
     "current": {
 
     },
+    "error": null,
     "hide": 0,
     "includeAll": false,
     "label": null,
@@ -5128,6 +5135,7 @@
     "current": {
 
     },
+    "error": null,
     "hide": 0,
     "includeAll": false,
     "label": null,
@@ -5150,6 +5158,7 @@
     },
     "datasource": "$ds",
     "definition": "label_values(tempo_build_info, cluster)",
+    "error": null,
     "hide": 0,
     "includeAll": false,
     "label": null,
@@ -5178,6 +5187,7 @@
     },
     "datasource": "$ds",
     "definition": "label_values(kube_pod_container_info{image=~\".*tempo.*\", cluster=\"$cluster\"}, namespace)",
+    "error": null,
     "hide": 0,
     "includeAll": false,
     "label": null,
@@ -5202,10 +5212,11 @@
    {
     "allValue": ".*",
     "current": {
-     "selected": true,
+     "selected": false,
      "text": "All",
      "value": "$__all"
     },
+    "error": null,
     "hide": 0,
     "includeAll": true,
     "label": null,
@@ -5270,5 +5281,5 @@
  "timezone": "",
  "title": "Tempo Operational",
  "uid": "AOFXrRUZz",
- "version": 86
+ "version": 1
 }

--- a/operations/tempo-mixin/out/tempo-reads.json
+++ b/operations/tempo-mixin/out/tempo-reads.json
@@ -282,7 +282,7 @@
      "steppedLine": false,
      "targets": [
       {
-       "expr": "sum by (status) (label_replace(label_replace(rate(jaeger_query_latency_count{cluster=~\"$cluster\", job=~\"($namespace)/querier\", operation=\"get_trace\"}[$__interval]), \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"), \"status\", \"${1}\",   \"status_code\", \"([a-z]+)\"))",
+       "expr": "sum by (status) (label_replace(label_replace(rate(jaeger_rpc_http_requests_total{cluster=~\"$cluster\", job=~\"($namespace)/querier\", endpoint=\"/api/traces/-traceID-\"}[$__interval]), \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"), \"status\", \"${1}\",   \"status_code\", \"([a-z]+)\"))",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,

--- a/operations/tempo-mixin/out/tempo-reads.json
+++ b/operations/tempo-mixin/out/tempo-reads.json
@@ -282,7 +282,7 @@
      "steppedLine": false,
      "targets": [
       {
-       "expr": "sum by (status) (label_replace(label_replace(rate(tempo_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/querier\", route=\"api_traces_traceid\"}[$__interval]), \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"), \"status\", \"${1}\",   \"status_code\", \"([a-z]+)\"))",
+       "expr": "sum by (status) (label_replace(label_replace(rate(jaeger_query_latency_count{cluster=~\"$cluster\", job=~\"($namespace)/querier\", operation=\"get_trace\"}[$__interval]), \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"), \"status\", \"${1}\",   \"status_code\", \"([a-z]+)\"))",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
@@ -341,6 +341,216 @@
      "datasource": "$datasource",
      "fill": 1,
      "id": 4,
+     "legend": {
+      "avg": false,
+      "current": false,
+      "max": false,
+      "min": false,
+      "show": true,
+      "total": false,
+      "values": false
+     },
+     "lines": true,
+     "linewidth": 1,
+     "links": [
+
+     ],
+     "nullPointMode": "null as zero",
+     "percentage": false,
+     "pointradius": 5,
+     "points": false,
+     "renderer": "flot",
+     "seriesOverrides": [
+
+     ],
+     "spaceLength": 10,
+     "span": 6,
+     "stack": false,
+     "steppedLine": false,
+     "targets": [
+      {
+       "expr": "histogram_quantile(0.99, sum(rate(jaeger_query_latency_bucket{cluster=~\"$cluster\", job=~\"($namespace)/querier\",operation=\"get_trace\"}[$__interval])) by (le)) * 1e3",
+       "format": "time_series",
+       "interval": "1m",
+       "intervalFactor": 2,
+       "legendFormat": "99th Percentile",
+       "refId": "A",
+       "step": 10
+      },
+      {
+       "expr": "histogram_quantile(0.50, sum(rate(jaeger_query_latency_bucket{cluster=~\"$cluster\", job=~\"($namespace)/querier\",operation=\"get_trace\"}[$__interval])) by (le)) * 1e3",
+       "format": "time_series",
+       "interval": "1m",
+       "intervalFactor": 2,
+       "legendFormat": "50th Percentile",
+       "refId": "B",
+       "step": 10
+      },
+      {
+       "expr": "sum(rate(jaeger_query_latency_sum{cluster=~\"$cluster\", job=~\"($namespace)/querier\",operation=\"get_trace\"}[$__interval])) * 1e3 / sum(rate(jaeger_query_latency_count{cluster=~\"$cluster\", job=~\"($namespace)/querier\",operation=\"get_trace\"}[$__interval]))",
+       "format": "time_series",
+       "interval": "1m",
+       "intervalFactor": 2,
+       "legendFormat": "Average",
+       "refId": "C",
+       "step": 10
+      }
+     ],
+     "thresholds": [
+
+     ],
+     "timeFrom": null,
+     "timeShift": null,
+     "title": "Latency",
+     "tooltip": {
+      "shared": true,
+      "sort": 0,
+      "value_type": "individual"
+     },
+     "type": "graph",
+     "xaxis": {
+      "buckets": null,
+      "mode": "time",
+      "name": null,
+      "show": true,
+      "values": [
+
+      ]
+     },
+     "yaxes": [
+      {
+       "format": "ms",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": 0,
+       "show": true
+      },
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": null,
+       "show": false
+      }
+     ]
+    }
+   ],
+   "repeat": null,
+   "repeatIteration": null,
+   "repeatRowId": null,
+   "showTitle": true,
+   "title": "Jaeger Query",
+   "titleSize": "h6"
+  },
+  {
+   "collapse": false,
+   "height": "250px",
+   "panels": [
+    {
+     "aliasColors": {
+      "1xx": "#EAB839",
+      "2xx": "#7EB26D",
+      "3xx": "#6ED0E0",
+      "4xx": "#EF843C",
+      "5xx": "#E24D42",
+      "error": "#E24D42",
+      "success": "#7EB26D"
+     },
+     "bars": false,
+     "dashLength": 10,
+     "dashes": false,
+     "datasource": "$datasource",
+     "fill": 10,
+     "id": 5,
+     "legend": {
+      "avg": false,
+      "current": false,
+      "max": false,
+      "min": false,
+      "show": true,
+      "total": false,
+      "values": false
+     },
+     "lines": true,
+     "linewidth": 0,
+     "links": [
+
+     ],
+     "nullPointMode": "null as zero",
+     "percentage": false,
+     "pointradius": 5,
+     "points": false,
+     "renderer": "flot",
+     "seriesOverrides": [
+
+     ],
+     "spaceLength": 10,
+     "span": 6,
+     "stack": true,
+     "steppedLine": false,
+     "targets": [
+      {
+       "expr": "sum by (status) (label_replace(label_replace(rate(tempo_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/querier\", route=\"api_traces_traceid\"}[$__interval]), \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"), \"status\", \"${1}\",   \"status_code\", \"([a-z]+)\"))",
+       "format": "time_series",
+       "interval": "1m",
+       "intervalFactor": 2,
+       "legendFormat": "{{status}}",
+       "refId": "A",
+       "step": 10
+      }
+     ],
+     "thresholds": [
+
+     ],
+     "timeFrom": null,
+     "timeShift": null,
+     "title": "QPS",
+     "tooltip": {
+      "shared": true,
+      "sort": 0,
+      "value_type": "individual"
+     },
+     "type": "graph",
+     "xaxis": {
+      "buckets": null,
+      "mode": "time",
+      "name": null,
+      "show": true,
+      "values": [
+
+      ]
+     },
+     "yaxes": [
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": 0,
+       "show": true
+      },
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": null,
+       "show": false
+      }
+     ]
+    },
+    {
+     "aliasColors": {
+
+     },
+     "bars": false,
+     "dashLength": 10,
+     "dashes": false,
+     "datasource": "$datasource",
+     "fill": 1,
+     "id": 6,
      "legend": {
       "avg": false,
       "current": false,
@@ -463,7 +673,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 10,
-     "id": 5,
+     "id": 7,
      "legend": {
       "avg": false,
       "current": false,
@@ -550,7 +760,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 1,
-     "id": 6,
+     "id": 8,
      "legend": {
       "avg": false,
       "current": false,
@@ -673,7 +883,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 10,
-     "id": 7,
+     "id": 9,
      "legend": {
       "avg": false,
       "current": false,
@@ -760,7 +970,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 1,
-     "id": 8,
+     "id": 10,
      "legend": {
       "avg": false,
       "current": false,
@@ -883,7 +1093,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 10,
-     "id": 9,
+     "id": 11,
      "legend": {
       "avg": false,
       "current": false,
@@ -970,7 +1180,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 1,
-     "id": 10,
+     "id": 12,
      "legend": {
       "avg": false,
       "current": false,
@@ -1087,7 +1297,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 1,
-     "id": 11,
+     "id": 13,
      "legend": {
       "avg": false,
       "current": false,
@@ -1173,7 +1383,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 1,
-     "id": 12,
+     "id": 14,
      "legend": {
       "avg": false,
       "current": false,
@@ -1259,7 +1469,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 1,
-     "id": 13,
+     "id": 15,
      "legend": {
       "avg": false,
       "current": false,


### PR DESCRIPTION
**What this PR does**:
- Exposes port 16687 to allow scraping of Jaeger-Query metrics
- Adds Jaeger Query metrics to the Tempo Reads dashboard

**Which issue(s) this PR fixes**:
Fixes #None

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`