### PR TITLE
Prune in-memory blocks from missing tenants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 * [ENHANCEMENT] Add command line flags for s3 credentials. [#308](https://github.com/grafana/tempo/pull/308)
 * [BUGFIX] Increase Prometheus `notfound` metric on tempo-vulture. [#301](https://github.com/grafana/tempo/pull/301)
 * [BUGFIX] Return 404 if searching for a tenant id that does not exist in the backend. [#321](https://github.com/grafana/tempo/pull/321)
+* [BUGFIX] Prune in-memory blocks from missing tenants. [#314](https://github.com/grafana/tempo/pull/314)

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -446,12 +446,6 @@ func (rw *readerWriter) pollBlocklist() {
 			return nil, nil
 		})
 
-		if len(compactedBlocklist) == 0 {
-			rw.blockListsMtx.Lock()
-			delete(rw.compactedBlockLists, tenantID)
-			rw.blockListsMtx.Unlock()
-			level.Info(rw.logger).Log("msg", "deleted in-memory compacted blocklists", "tenantID", tenantID)
-		}
 		if err != nil {
 			metricBlocklistErrors.WithLabelValues(tenantID).Inc()
 			level.Error(rw.logger).Log("msg", "run blocklist jobs", "tenantID", tenantID, "err", err)

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -548,9 +548,9 @@ func (rw *readerWriter) compactedBlocklist(tenantID string) []*encoding.Compacte
 }
 
 func (rw *readerWriter) cleanMissingTenants(tenants []string) {
-	tenantSet := make(map[string]bool)
+	tenantSet := make(map[string]struct{})
 	for _, tenantID := range tenants {
-		tenantSet[tenantID] = true
+		tenantSet[tenantID] = struct{}{}
 	}
 
 	for tenantID := range rw.blockLists {

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -382,11 +382,13 @@ func (rw *readerWriter) pollBlocklist() {
 		if err != nil {
 			metricBlocklistErrors.WithLabelValues(tenantID).Inc()
 			level.Error(rw.logger).Log("msg", "error polling blocklist", "tenantID", tenantID, "err", err)
+		}
+		if len(blockIDs) == 0 {
 			rw.blockListsMtx.Lock()
 			delete(rw.blockLists, tenantID)
 			delete(rw.compactedBlockLists, tenantID)
 			rw.blockListsMtx.Unlock()
-			level.Error(rw.logger).Log("msg", "deleted in-memory blocklists", "tenantID", tenantID)
+			level.Info(rw.logger).Log("msg", "deleted in-memory blocklists", "tenantID", tenantID)
 		}
 
 		interfaceSlice := make([]interface{}, 0, len(blockIDs))

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -382,6 +382,11 @@ func (rw *readerWriter) pollBlocklist() {
 		if err != nil {
 			metricBlocklistErrors.WithLabelValues(tenantID).Inc()
 			level.Error(rw.logger).Log("msg", "error polling blocklist", "tenantID", tenantID, "err", err)
+			rw.blockListsMtx.Lock()
+			delete(rw.blockLists, tenantID)
+			delete(rw.compactedBlockLists, tenantID)
+			rw.blockListsMtx.Unlock()
+			level.Error(rw.logger).Log("msg", "deleted in-memory blocklists", "tenantID", tenantID)
 		}
 
 		interfaceSlice := make([]interface{}, 0, len(blockIDs))

--- a/tempodb/tempodb_test.go
+++ b/tempodb/tempodb_test.go
@@ -218,13 +218,18 @@ func TestBlockCleanup(t *testing.T) {
 
 	rw := r.(*readerWriter)
 
+	// poll
+	rw.pollBlocklist()
+
+	assert.Len(t, rw.blockLists[testTenantID], 1)
+
 	os.RemoveAll(tempDir + "/traces/" + testTenantID)
 
 	// poll
 	rw.pollBlocklist()
 
-	assert.Len(t, rw.blockLists[testTenantID], 0)
-	assert.Len(t, rw.compactedBlockLists[testTenantID], 0)
+	_, ok := rw.blockLists[testTenantID]
+	assert.False(t, ok)
 }
 
 func checkBlocklists(t *testing.T, expectedID uuid.UUID, expectedB int, expectedCB int, rw *readerWriter) {

--- a/tempodb/tempodb_test.go
+++ b/tempodb/tempodb_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/util/test"
 	"github.com/grafana/tempo/tempodb/backend/local"
+	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/grafana/tempo/tempodb/wal"
 	"github.com/stretchr/testify/assert"
 )

--- a/tempodb/tempodb_test.go
+++ b/tempodb/tempodb_test.go
@@ -211,7 +211,6 @@ func TestBlockCleanup(t *testing.T) {
 
 	complete, err := head.Complete(wal, &mockSharder{})
 	assert.NoError(t, err)
-	blockID = complete.BlockMeta().BlockID
 
 	err = w.WriteBlock(context.Background(), complete)
 	assert.NoError(t, err)


### PR DESCRIPTION
**What this PR does**:
If a tenant disappears blocks are pruned from the in-memory blocklist.

**Which issue(s) this PR fixes**:
Fixes #285

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`