### PR TITLE
Rename maintenance cycle to blocklist poll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master / unreleased
 
-* [CHANGE] Bloom filters are now sharded to reduce size and improve caching, as blocks grow. This is a **breaking change** and all data stored before this change will **not** be queryable. [192](https://github.com/grafana/tempo/pull/192)
+* [CHANGE] Bloom filters are now sharded to reduce size and improve caching, as blocks grow. This is a **breaking change** and all data stored before this change will **not** be queryable. [#192](https://github.com/grafana/tempo/pull/192)
+* [CHANGE] Rename maintenance cycle to blocklist poll. [#315](https://github.com/grafana/tempo/pull/315)
 * [ENHANCEMENT] CI checks for vendored dependencies using `make vendor-check`. Update CONTRIBUTING.md to reflect the same before checking in files in a PR. [#274](https://github.com/grafana/tempo/pull/274)
 * [ENHANCEMENT] Add warnings for suspect configs. [#294](https://github.com/grafana/tempo/pull/294)
 * [ENHANCEMENT] Add command line flags for s3 credentials. [#308](https://github.com/grafana/tempo/pull/308)

--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -85,12 +85,12 @@ func (c *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 
 // CheckConfig checks if config values are suspect.
 func (c *Config) CheckConfig() {
-	if c.Ingester.CompleteBlockTimeout < c.StorageConfig.Trace.MaintenanceCycle {
+	if c.Ingester.CompleteBlockTimeout < c.StorageConfig.Trace.BlocklistPoll {
 		level.Warn(util.Logger).Log("msg", "3ingester.CompleteBlockTimeout < storage.trace.maintenance-cycle",
 			"explan", "You may receive 404s between the time the ingesters have flushed a trace and the querier is aware of the new block")
 	}
 
-	if c.Compactor.Compactor.BlockRetention < c.StorageConfig.Trace.MaintenanceCycle {
+	if c.Compactor.Compactor.BlockRetention < c.StorageConfig.Trace.BlocklistPoll {
 		level.Warn(util.Logger).Log("msg", "compactor.CompactedBlockRetention < storage.trace.maintenance-cycle",
 			"explan", "Queriers and Compactors may attempt to read a block that no longer exists")
 	}

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -62,7 +62,7 @@ storage:
         backend: gcs                             # store traces in gcs
         gcs:
             bucket_name: ops-tools-tracing-ops   # store traces in this bucket
-        maintenance_cycle: 5m                    # how often to repoll the backend for new blocks
+        blocklist_poll: 5m                    # how often to repoll the backend for new blocks
         memcached:                               # optional memcached configuration
             consistent_hash: true
             host: memcached

--- a/integration/e2e/config-all-in-one.yaml
+++ b/integration/e2e/config-all-in-one.yaml
@@ -27,7 +27,7 @@ ingester:
 
 storage:
   trace:
-    maintenance_cycle: 2s
+    blocklist_poll: 2s
     backend: s3
     s3:
       bucket: tempo

--- a/integration/e2e/config-microservices.yaml
+++ b/integration/e2e/config-microservices.yaml
@@ -23,7 +23,7 @@ ingester:
 
 storage:
   trace:
-    maintenance_cycle: 2s
+    blocklist_poll: 2s
     backend: s3
     s3:
       bucket: tempo

--- a/modules/ingester/config.go
+++ b/modules/ingester/config.go
@@ -38,6 +38,6 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	f.DurationVar(&cfg.MaxTraceIdle, "ingester.trace-idle-period", 30*time.Second, "Duration after which to consider a trace complete if no spans have been received")
 	f.IntVar(&cfg.MaxTracesPerBlock, "ingester.traces-per-block", 50000, "Maximum number of traces allowed in the head block before cutting it")
 	f.DurationVar(&cfg.MaxBlockDuration, "ingester.max-block-duration", time.Hour, "Maximum duration which the head block can be appended to before cutting it.")
-	f.DurationVar(&cfg.CompleteBlockTimeout, "ingester.complete-block-timeout", storage.DefaultMaintenanceCycle, "Duration to keep the headb blocks in the ingester after it has been cut.")
+	f.DurationVar(&cfg.CompleteBlockTimeout, "ingester.complete-block-timeout", storage.DefaultBlocklistPoll, "Duration to keep the headb blocks in the ingester after it has been cut.")
 	cfg.OverrideRingKey = ring.IngesterRingKey
 }

--- a/modules/storage/config.go
+++ b/modules/storage/config.go
@@ -18,12 +18,12 @@ type Config struct {
 	Trace tempodb.Config `yaml:"trace"`
 }
 
-var DefaultMaintenanceCycle = 5 * time.Minute
+var DefaultBlocklistPoll = 5 * time.Minute
 
 // RegisterFlagsAndApplyDefaults registers the flags.
 func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 	f.StringVar(&cfg.Trace.Backend, util.PrefixConfig(prefix, "trace.backend"), "", "Trace backend (s3, gcs, local)")
-	f.DurationVar(&cfg.Trace.MaintenanceCycle, util.PrefixConfig(prefix, "trace.maintenance-cycle"), DefaultMaintenanceCycle, "Period at which to run the maintenance cycle.")
+	f.DurationVar(&cfg.Trace.BlocklistPoll, util.PrefixConfig(prefix, "trace.maintenance-cycle"), DefaultBlocklistPoll, "Period at which to run the maintenance cycle.")
 
 	cfg.Trace.WAL = &wal.Config{}
 	f.StringVar(&cfg.Trace.WAL.Filepath, util.PrefixConfig(prefix, "trace.wal.path"), "/var/tempo/wal", "Path at which store WAL blocks.")

--- a/operations/helm/tempo-microservices/templates/configmap-tempo-compactor.yaml
+++ b/operations/helm/tempo-microservices/templates/configmap-tempo-compactor.yaml
@@ -21,7 +21,7 @@ data:
     storage:
         trace:
             {{- toYaml .Values.backend | nindent 12 }}
-            maintenance_cycle: 10m
+            blocklist_poll: 10m
             memcached:
                 consistent_hash: true
                 host: memcached

--- a/operations/helm/tempo-microservices/templates/configmap-tempo-querier.yaml
+++ b/operations/helm/tempo-microservices/templates/configmap-tempo-querier.yaml
@@ -18,7 +18,7 @@ data:
     storage:
         trace:
             {{- toYaml .Values.backend | nindent 12 }}
-            maintenance_cycle: 5m
+            blocklist_poll: 5m
             memcached:
                 consistent_hash: true
                 host: memcached

--- a/operations/helm/tempo-microservices/templates/configmap-tempo.yaml
+++ b/operations/helm/tempo-microservices/templates/configmap-tempo.yaml
@@ -30,7 +30,7 @@ data:
     storage:
         trace:
             {{- toYaml .Values.backend | nindent 12 }}
-            maintenance_cycle: 5m
+            blocklist_poll: 5m
             memcached:
                 consistent_hash: true
                 host: memcached

--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -18,7 +18,7 @@
     compactor: null,
     storage: {
       trace: {
-        maintenance_cycle: '5m',
+        blocklist_poll: '5m',
         backend: $._config.backend,
         wal: {
           path: '/var/tempo/wal',
@@ -65,7 +65,7 @@
     },
     storage+: {
       trace+: {
-        maintenance_cycle: '10m',
+        blocklist_poll: '10m',
       },
     },
   },

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -86,7 +86,7 @@ func (rw *readerWriter) doCompaction() {
 		}
 
 		// after a maintenance cycle bail out
-		if start.Add(rw.cfg.MaintenanceCycle).Before(time.Now()) {
+		if start.Add(rw.cfg.BlocklistPoll).Before(time.Now()) {
 			level.Info(rw.logger).Log("msg", "compacted blocks for a maintenance cycle, bailing out", "tenantID", tenantID)
 			break
 		}

--- a/tempodb/compactor_bookmark_test.go
+++ b/tempodb/compactor_bookmark_test.go
@@ -35,7 +35,7 @@ func TestCurrentClear(t *testing.T) {
 			IndexDownsample: 17,
 			BloomFP:         .01,
 		},
-		MaintenanceCycle: 0,
+		BlocklistPoll: 0,
 	}, log.NewNopLogger())
 	assert.NoError(t, err)
 

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -60,7 +60,7 @@ func TestCompaction(t *testing.T) {
 			IndexDownsample: 11,
 			BloomFP:         .01,
 		},
-		MaintenanceCycle: 0,
+		BlocklistPoll: 0,
 	}, log.NewNopLogger())
 
 	c.EnableCompaction(&CompactorConfig{
@@ -183,7 +183,7 @@ func TestSameIDCompaction(t *testing.T) {
 			IndexDownsample: rand.Int()%20 + 1,
 			BloomFP:         .01,
 		},
-		MaintenanceCycle: 0,
+		BlocklistPoll: 0,
 	}, log.NewNopLogger())
 	assert.NoError(t, err)
 

--- a/tempodb/config.go
+++ b/tempodb/config.go
@@ -23,7 +23,7 @@ type Config struct {
 	Diskcache *diskcache.Config `yaml:"disk_cache"`
 	Memcached *memcached.Config `yaml:"memcached"`
 
-	MaintenanceCycle time.Duration `yaml:"maintenance_cycle"`
+	BlocklistPoll time.Duration `yaml:"blocklist_poll"`
 }
 
 type CompactorConfig struct {

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -340,7 +340,7 @@ func (rw *readerWriter) EnableCompaction(cfg *CompactorConfig, c CompactorSharde
 	rw.compactorCfg = cfg
 	rw.compactorSharder = c
 
-	if rw.cfg.MaintenanceCycle == 0 {
+	if rw.cfg.BlocklistPoll == 0 {
 		level.Info(rw.logger).Log("msg", "maintenance cycle unset.  compaction and retention disabled.")
 		return
 	}
@@ -353,14 +353,14 @@ func (rw *readerWriter) EnableCompaction(cfg *CompactorConfig, c CompactorSharde
 }
 
 func (rw *readerWriter) maintenanceLoop() {
-	if rw.cfg.MaintenanceCycle == 0 {
+	if rw.cfg.BlocklistPoll == 0 {
 		level.Info(rw.logger).Log("msg", "maintenance cycle unset.  blocklist polling disabled.")
 		return
 	}
 
 	rw.pollBlocklist()
 
-	ticker := time.NewTicker(rw.cfg.MaintenanceCycle)
+	ticker := time.NewTicker(rw.cfg.BlocklistPoll)
 	for range ticker.C {
 		rw.pollBlocklist()
 	}
@@ -448,7 +448,7 @@ func (rw *readerWriter) pollBlocklist() {
 // todo: pass a context/chan in to cancel this cleanly
 //  once a maintenance cycle cleanup any blocks
 func (rw *readerWriter) retentionLoop() {
-	ticker := time.NewTicker(rw.cfg.MaintenanceCycle)
+	ticker := time.NewTicker(rw.cfg.BlocklistPoll)
 	for range ticker.C {
 		rw.doRetention()
 	}

--- a/tempodb/tempodb_test.go
+++ b/tempodb/tempodb_test.go
@@ -39,7 +39,7 @@ func TestDB(t *testing.T) {
 			IndexDownsample: 17,
 			BloomFP:         .01,
 		},
-		MaintenanceCycle: 0,
+		BlocklistPoll: 0,
 	}, log.NewNopLogger())
 	assert.NoError(t, err)
 
@@ -112,7 +112,7 @@ func TestRetention(t *testing.T) {
 			IndexDownsample: 17,
 			BloomFP:         .01,
 		},
-		MaintenanceCycle: 0,
+		BlocklistPoll: 0,
 	}, log.NewNopLogger())
 	assert.NoError(t, err)
 


### PR DESCRIPTION
**What this PR does**:
Renames maintenance cycle to blocklist poll as proposed on https://github.com/grafana/tempo/pull/195#discussion_r498038769
- s/MaintenanceCycle/BlocklistPoll/
- s/maintenance_cycle/blocklist_poll/
- s/DefaultMaintenanceCycle/DefaultBlocklistPoll/

**Which issue(s) this PR fixes**:
Fixes #198

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`