### PR TITLE
Return 404 on unknown tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 * [ENHANCEMENT] Add warnings for suspect configs. [#294](https://github.com/grafana/tempo/pull/294)
 * [ENHANCEMENT] Add command line flags for s3 credentials. [#308](https://github.com/grafana/tempo/pull/308)
 * [BUGFIX] Increase Prometheus `notfound` metric on tempo-vulture. [#301](https://github.com/grafana/tempo/pull/301)
+* [BUGFIX] Return 404 if searching for a tenant id that does not exist in the backend. [#321](https://github.com/grafana/tempo/pull/321)

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -255,7 +255,7 @@ func (rw *readerWriter) Find(ctx context.Context, tenantID string, id encoding.I
 	rw.blockListsMtx.Unlock()
 
 	if !found {
-		return nil, metrics, fmt.Errorf("tenantID %s not found", tenantID)
+		return nil, metrics, nil
 	}
 
 	foundBytes, err := rw.pool.RunJobs(derivedCtx, copiedBlocklist, func(ctx context.Context, payload interface{}) ([]byte, error) {

--- a/tempodb/tempodb_test.go
+++ b/tempodb/tempodb_test.go
@@ -97,6 +97,30 @@ func TestDB(t *testing.T) {
 	}
 }
 
+func TestNilOnUnknownTenantID(t *testing.T) {
+	tempDir, err := ioutil.TempDir("/tmp", "")
+	defer os.RemoveAll(tempDir)
+	assert.NoError(t, err, "unexpected error creating temp dir")
+
+	r, _, _, err := New(&Config{
+		Backend: "local",
+		Local: &local.Config{
+			Path: path.Join(tempDir, "traces"),
+		},
+		WAL: &wal.Config{
+			Filepath:        path.Join(tempDir, "wal"),
+			IndexDownsample: 17,
+			BloomFP:         .01,
+		},
+		BlocklistPoll: 0,
+	}, log.NewNopLogger())
+	assert.NoError(t, err)
+
+	buff, _, err := r.Find(context.Background(), "unknown", []byte{0x01})
+	assert.Nil(t, buff)
+	assert.Nil(t, err)
+}
+
 func TestRetention(t *testing.T) {
 	tempDir, err := ioutil.TempDir("/tmp", "")
 	defer os.RemoveAll(tempDir)


### PR DESCRIPTION
**What this PR does**:
People are seeing this in the beta, so I felt like we should just fix it.  I don't see a reason to distinguish between asking for a tenant that does not exist and asking for a trace that does not exist so just returned nil if the tenant was not found.

**Which issue(s) this PR fixes**:
Fixes #94 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`