### PR TITLE
Add depends to docker-compose examples

### DIFF
--- a/example/docker-compose/docker-compose.loki.yaml
+++ b/example/docker-compose/docker-compose.loki.yaml
@@ -25,6 +25,8 @@ services:
       - ./etc/tempo-query.yaml:/etc/tempo-query.yaml
     ports:
       - "16686:16686"  # jaeger-ui
+    depends_on:
+      - tempo
     logging:
       driver: loki
       options:

--- a/example/docker-compose/docker-compose.s3.minio.yaml
+++ b/example/docker-compose/docker-compose.s3.minio.yaml
@@ -28,6 +28,8 @@ services:
     command: ["--grpc-storage-plugin.configuration-file=/etc/tempo-query.yaml"]
     volumes:
       - ./etc/tempo-query.yaml:/etc/tempo-query.yaml
+    depends_on:
+      - tempo
     ports:
       - "16686:16686"  # jaeger-ui
 

--- a/example/docker-compose/docker-compose.yaml
+++ b/example/docker-compose/docker-compose.yaml
@@ -18,6 +18,8 @@ services:
       - ./etc/tempo-query.yaml:/etc/tempo-query.yaml
     ports:
       - "16686:16686"  # jaeger-ui
+    depends_on:
+      - tempo
 
   synthetic-load-generator:
     image: omnition/synthetic-load-generator:1.0.25


### PR DESCRIPTION
**What this PR does**:
Tempo query crashes when it starts before Tempo. I added a `depends` condition to the docker-compose examples.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`