### PR TITLE
Address frequent errors logged by compactor regarding meta not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 /tempo-vulture
 /bin
 .idea
+.vscode
 /dist
 /example/docker-compose/example-data/tempo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master / unreleased
 
+* [BUGFIX] Frequent errors logged by compactor regarding meta not found [#327](https://github.com/grafana/tempo/pull/327)
+
 ## v0.3.0
 
 * [CHANGE] Bloom filters are now sharded to reduce size and improve caching, as blocks grow. This is a **breaking change** and all data stored before this change will **not** be queryable. [#192](https://github.com/grafana/tempo/pull/192)

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -287,5 +287,5 @@ func markCompacted(rw *readerWriter, tenantID string, oldBlocks []*encoding.Bloc
 	}
 
 	// Update blocklist in memory
-	rw.updateBlocklist(tenantID, newBlocks, oldBlocks, newCompactions, nil)
+	rw.updateBlocklist(tenantID, newBlocks, oldBlocks, newCompactions)
 }

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -291,6 +291,16 @@ func TestCompactionUpdatesBlocklist(t *testing.T) {
 
 	// Compacted list contains all old blocks
 	assert.Equal(t, blockCount, len(rw.compactedBlocklist(testTenantID)))
+
+	// Make sure all expected traces are found.
+	for i := 0; i < blockCount; i++ {
+		for j := 0; j < recordCount; j++ {
+			trace, _, err := rw.Find(context.TODO(), testTenantID, makeTraceID(i, j))
+			assert.NotNil(t, trace)
+			assert.Greater(t, len(trace), 0)
+			assert.NoError(t, err)
+		}
+	}
 }
 
 func cutTestBlocks(t *testing.T, w Writer, blockCount int, recordCount int) {
@@ -302,7 +312,7 @@ func cutTestBlocks(t *testing.T, w Writer, blockCount int, recordCount int) {
 		for j := 0; j < recordCount; j++ {
 			// Use i and j to ensure unique ids
 			err = head.Write(
-				[]byte{byte(i), byte(j), 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+				makeTraceID(i, j),
 				[]byte{0x01, 0x02, 0x03})
 			assert.NoError(t, err, "unexpected error writing rec")
 		}
@@ -313,4 +323,8 @@ func cutTestBlocks(t *testing.T, w Writer, blockCount int, recordCount int) {
 		err = w.WriteBlock(context.Background(), complete)
 		assert.NoError(t, err)
 	}
+}
+
+func makeTraceID(i int, j int) []byte {
+	return []byte{byte(i), byte(j), 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 }

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -574,9 +574,7 @@ func (rw *readerWriter) cleanMissingTenants(tenants []string) {
 
 // updateBlocklist Add and remove regular or compacted blocks from the in-memory blocklist.
 // Changes are temporary and will be overwritten on the next poll.
-func (rw *readerWriter) updateBlocklist(tenantID string,
-	add []*encoding.BlockMeta, remove []*encoding.BlockMeta,
-	compactedAdd []*encoding.CompactedBlockMeta, compactedRemove []*encoding.CompactedBlockMeta) {
+func (rw *readerWriter) updateBlocklist(tenantID string, add []*encoding.BlockMeta, remove []*encoding.BlockMeta, compactedAdd []*encoding.CompactedBlockMeta) {
 	if tenantID == "" {
 		return
 	}
@@ -601,18 +599,5 @@ func (rw *readerWriter) updateBlocklist(tenantID string,
 	rw.blockLists[tenantID] = newblocklist
 
 	// ******** Compacted blocks ********
-	toRemoveCompacted := make(map[*encoding.CompactedBlockMeta]bool)
-	for _, m := range compactedRemove {
-		toRemoveCompacted[m] = true
-	}
-
-	compactedBlocklist := rw.compactedBlockLists[tenantID]
-	newcompactedBlocklist := make([]*encoding.CompactedBlockMeta, 0, len(compactedBlocklist)-len(compactedRemove)+len(compactedAdd))
-	for _, m := range blocklist {
-		if _, ok := toRemove[m]; !ok {
-			newblocklist = append(newblocklist, m)
-		}
-	}
-	newcompactedBlocklist = append(newcompactedBlocklist, compactedAdd...)
-	rw.compactedBlockLists[tenantID] = newcompactedBlocklist
+	rw.compactedBlockLists[tenantID] = append(rw.compactedBlockLists[tenantID], compactedAdd...)
 }


### PR DESCRIPTION
**What this PR does**:
The compactor can log frequent errors like the following:  `msg="unable to find meta during compaction.  trying again on this block list"`. The root cause seems to be that when a block is compacted, it is updated in the storage backend, but not in the in-memory blocklist until the next polling cycle.  This causes the stale entry to be considered for compaction on subsequent runs, causing the errors for several minutes (based on default timings). 

This PR updates the compactor to immediately update the in-memory blocklist to be aware of changes it makes:  add the new blocks created during compaction, move the old ones to the compacted section.  The changes are temporary and get overwritten during the next poll cycle, but are still helpful to cut down on the noise, and additionally will prevent failing/extra calls to the storage backend to load the meta.

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`