### PR TITLE
docs: fix examples in getting-started documentation

### DIFF
--- a/docs/tempo/website/getting-started/_index.md
+++ b/docs/tempo/website/getting-started/_index.md
@@ -37,7 +37,7 @@ Choose the port corresponding to the protocol you wish to use to send traces to 
 Compact format (port 6831).
 
 ```
-docker run -d --rm -p 6831:6831/udp --name tempo -v $(PWD)/tempo-local.yaml:/etc/tempo-local.yaml \
+docker run -d --rm -p 6831:6831/udp --name tempo -v $(pwd)/tempo-local.yaml:/etc/tempo-local.yaml \
     --network docker-tempo \
     grafana/tempo:latest \
     -config.file=/etc/tempo-local.yaml
@@ -54,7 +54,7 @@ curl -o tempo-query.yaml https://raw.githubusercontent.com/grafana/tempo/master/
 Use this config file to fire up the Tempo Query container -
 
 ```
-docker run -d --rm -p 16686:16686 -v $(PWD)/tempo-query.yaml:/etc/tempo-query.yaml \
+docker run -d --rm -p 16686:16686 -v $(pwd)/tempo-query.yaml:/etc/tempo-query.yaml \
     --network docker-tempo \
     grafana/tempo-query:latest \
     --grpc-storage-plugin.configuration-file=/etc/tempo-query.yaml


### PR DESCRIPTION
In the getting started guide the docker command used "$(PWD)" to get the
working directory. That works in macOS (zsh), but doesn't work in bash
for example.

Examples on the docker site uses $(pwd), so this changes to lower case.
E.g. https://docs.docker.com/storage/volumes/#backup-a-container

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Updates examples in documentation to work in bash.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`