### PR TITLE
Add per tenant bytes counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [ENHANCEMENT] Add warnings for suspect configs. [#294](https://github.com/grafana/tempo/pull/294)
 * [ENHANCEMENT] Add command line flags for s3 credentials. [#308](https://github.com/grafana/tempo/pull/308)
 * [ENHANCEMENT] Support multiple authentication methods for S3 (IRSA, IAM role, static). [#320](https://github.com/grafana/tempo/pull/320)
+* [ENHANCEMENT] Add  per tenant bytes counter. [#331](https://github.com/grafana/tempo/pull/331)
 * [BUGFIX] S3 multi-part upload errors [#306](https://github.com/grafana/tempo/pull/325)
 * [BUGFIX] Increase Prometheus `notfound` metric on tempo-vulture. [#301](https://github.com/grafana/tempo/pull/301)
 * [BUGFIX] Return 404 if searching for a tenant id that does not exist in the backend. [#321](https://github.com/grafana/tempo/pull/321)

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -118,12 +118,11 @@ func (i *instance) CutCompleteTraces(cutoff time.Duration, immediate bool) error
 			if err != nil {
 				return err
 			}
-			i.bytesWrittenTotal.Add(float64(len(out)))
 			err = i.headBlock.Write(trace.traceID, out)
 			if err != nil {
 				return err
 			}
-
+			i.bytesWrittenTotal.Add(float64(len(out)))
 			delete(i.traces, key)
 		}
 	}

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -33,10 +33,10 @@ var (
 		Name:      "ingester_traces_created_total",
 		Help:      "The total number of traces created per tenant.",
 	}, []string{"tenant"})
-	metricBytesProcessedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	metricBytesWrittenTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "tempo",
-		Name:      "ingester_bytes_processed_total",
-		Help:      "The total bytes processed per tenant.",
+		Name:      "ingester_bytes_written_total",
+		Help:      "The total bytes written per tenant.",
 	}, []string{"tenant"})
 	metricBlocksClearedTotal = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: "tempo",
@@ -55,22 +55,22 @@ type instance struct {
 	completeBlocks  []*tempodb_wal.CompleteBlock
 	lastBlockCut    time.Time
 
-	instanceID          string
-	tracesCreatedTotal  prometheus.Counter
-	bytesProcessedTotal prometheus.Counter
-	limiter             *Limiter
-	wal                 *tempodb_wal.WAL
+	instanceID         string
+	tracesCreatedTotal prometheus.Counter
+	bytesWrittenTotal  prometheus.Counter
+	limiter            *Limiter
+	wal                *tempodb_wal.WAL
 }
 
 func newInstance(instanceID string, limiter *Limiter, wal *tempodb_wal.WAL) (*instance, error) {
 	i := &instance{
 		traces: map[uint32]*trace{},
 
-		instanceID:          instanceID,
-		tracesCreatedTotal:  metricTracesCreatedTotal.WithLabelValues(instanceID),
-		bytesProcessedTotal: metricBytesProcessedTotal.WithLabelValues(instanceID),
-		limiter:             limiter,
-		wal:                 wal,
+		instanceID:         instanceID,
+		tracesCreatedTotal: metricTracesCreatedTotal.WithLabelValues(instanceID),
+		bytesWrittenTotal:  metricBytesWrittenTotal.WithLabelValues(instanceID),
+		limiter:            limiter,
+		wal:                wal,
 	}
 	err := i.resetHeadBlock()
 	if err != nil {
@@ -118,7 +118,7 @@ func (i *instance) CutCompleteTraces(cutoff time.Duration, immediate bool) error
 			if err != nil {
 				return err
 			}
-			i.bytesProcessedTotal.Add(float64(len(out)))
+			i.bytesWrittenTotal.Add(float64(len(out)))
 			err = i.headBlock.Write(trace.traceID, out)
 			if err != nil {
 				return err


### PR DESCRIPTION
**What this PR does**:
This PR adds a `per tenant bytes counter` metric. I went with the distributor approach!

The metric is increased when we cut the complete traces.

**Which issue(s) this PR fixes**:
Fixes #223

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`