### PR TITLE
Added build arg so drone will build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -30,6 +30,8 @@ steps:
       from_secret: docker_username
     password:
       from_secret: docker_password
+    build_args:
+    - TARGETARCH=amd64
 
 - name: build-tempo-query-image
   image: plugins/docker
@@ -40,6 +42,8 @@ steps:
       from_secret: docker_username
     password:
       from_secret: docker_password
+    build_args:
+    - TARGETARCH=amd64
 
 - name: build-tempo-vulture-image
   image: plugins/docker
@@ -50,6 +54,8 @@ steps:
       from_secret: docker_username
     password:
       from_secret: docker_password
+    build_args:
+    - TARGETARCH=amd64
 
 trigger:
   ref:


### PR DESCRIPTION
**What this PR does**:
Adds the targetarch build arg so our drone builds will work again.  This was broken in #311 when multi arch support was added.

