### PR TITLE
Shard retention to eliminate contention

### DIFF
--- a/tempodb/retention.go
+++ b/tempodb/retention.go
@@ -1,0 +1,68 @@
+package tempodb
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-kit/kit/log/level"
+)
+
+// todo: pass a context/chan in to cancel this cleanly
+//  once a maintenance cycle cleanup any blocks
+func (rw *readerWriter) retentionLoop() {
+	ticker := time.NewTicker(rw.cfg.BlocklistPoll)
+	for range ticker.C {
+		rw.doRetention()
+	}
+}
+
+func (rw *readerWriter) doRetention() {
+	tenants := rw.blocklistTenants()
+
+	// todo: continued abuse of runJobs.  need a runAllJobs() method or something
+	_, err := rw.pool.RunJobs(context.TODO(), tenants, func(_ context.Context, payload interface{}) ([]byte, error) {
+		start := time.Now()
+		defer func() { metricRetentionDuration.Observe(time.Since(start).Seconds()) }()
+
+		tenantID := payload.(string)
+
+		// iterate through block list.  make compacted anything that is past retention.
+		cutoff := time.Now().Add(-rw.compactorCfg.BlockRetention)
+		blocklist := rw.blocklist(tenantID)
+		for _, b := range blocklist {
+			if b.EndTime.Before(cutoff) {
+				level.Info(rw.logger).Log("msg", "marking block for deletion", "blockID", b.BlockID, "tenantID", tenantID)
+				err := rw.c.MarkBlockCompacted(b.BlockID, tenantID)
+				if err != nil {
+					level.Error(rw.logger).Log("msg", "failed to mark block compacted during retention", "blockID", b.BlockID, "tenantID", tenantID, "err", err)
+					metricRetentionErrors.Inc()
+				} else {
+					metricMarkedForDeletion.Inc()
+				}
+			}
+		}
+
+		// iterate through compacted list looking for blocks ready to be cleared
+		cutoff = time.Now().Add(-rw.compactorCfg.CompactedBlockRetention)
+		compactedBlocklist := rw.compactedBlocklist(tenantID)
+		for _, b := range compactedBlocklist {
+			if b.CompactedTime.Before(cutoff) {
+				level.Info(rw.logger).Log("msg", "deleting block", "blockID", b.BlockID, "tenantID", tenantID)
+				err := rw.c.ClearBlock(b.BlockID, tenantID)
+				if err != nil {
+					level.Error(rw.logger).Log("msg", "failed to clear compacted block during retention", "blockID", b.BlockID, "tenantID", tenantID, "err", err)
+					metricRetentionErrors.Inc()
+				} else {
+					metricDeleted.Inc()
+				}
+			}
+		}
+
+		return nil, nil
+	})
+
+	if err != nil {
+		level.Error(rw.logger).Log("msg", "failure to start retention.  retention disabled until the next maintenance cycle", "err", err)
+		metricRetentionErrors.Inc()
+	}
+}

--- a/tempodb/retention_test.go
+++ b/tempodb/retention_test.go
@@ -1,0 +1,71 @@
+package tempodb
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/tempo/tempodb/backend/local"
+	"github.com/grafana/tempo/tempodb/wal"
+)
+
+func TestRetention(t *testing.T) {
+	tempDir, err := ioutil.TempDir("/tmp", "")
+	defer os.RemoveAll(tempDir)
+	assert.NoError(t, err, "unexpected error creating temp dir")
+
+	r, w, c, err := New(&Config{
+		Backend: "local",
+		Local: &local.Config{
+			Path: path.Join(tempDir, "traces"),
+		},
+		WAL: &wal.Config{
+			Filepath:        path.Join(tempDir, "wal"),
+			IndexDownsample: 17,
+			BloomFP:         .01,
+		},
+		BlocklistPoll: 0,
+	}, log.NewNopLogger())
+	assert.NoError(t, err)
+
+	c.EnableCompaction(&CompactorConfig{
+		ChunkSizeBytes:          10,
+		MaxCompactionRange:      time.Hour,
+		BlockRetention:          0,
+		CompactedBlockRetention: 0,
+	}, &mockSharder{})
+
+	blockID := uuid.New()
+
+	wal := w.WAL()
+	assert.NoError(t, err)
+
+	head, err := wal.NewBlock(blockID, testTenantID)
+	assert.NoError(t, err)
+
+	complete, err := head.Complete(wal, &mockSharder{})
+	assert.NoError(t, err)
+	blockID = complete.BlockMeta().BlockID
+
+	err = w.WriteBlock(context.Background(), complete)
+	assert.NoError(t, err)
+
+	rw := r.(*readerWriter)
+	// poll
+	checkBlocklists(t, blockID, 1, 0, rw)
+
+	// retention should mark it compacted
+	r.(*readerWriter).doRetention()
+	checkBlocklists(t, blockID, 0, 1, rw)
+
+	// retention again should clear it
+	r.(*readerWriter).doRetention()
+	checkBlocklists(t, blockID, 0, 0, rw)
+}

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -447,66 +447,6 @@ func (rw *readerWriter) pollBlocklist() {
 	}
 }
 
-// todo: pass a context/chan in to cancel this cleanly
-//  once a maintenance cycle cleanup any blocks
-func (rw *readerWriter) retentionLoop() {
-	ticker := time.NewTicker(rw.cfg.BlocklistPoll)
-	for range ticker.C {
-		rw.doRetention()
-	}
-}
-
-func (rw *readerWriter) doRetention() {
-	tenants := rw.blocklistTenants()
-
-	// todo: continued abuse of runJobs.  need a runAllJobs() method or something
-	_, err := rw.pool.RunJobs(context.TODO(), tenants, func(_ context.Context, payload interface{}) ([]byte, error) {
-		start := time.Now()
-		defer func() { metricRetentionDuration.Observe(time.Since(start).Seconds()) }()
-
-		tenantID := payload.(string)
-
-		// iterate through block list.  make compacted anything that is past retention.
-		cutoff := time.Now().Add(-rw.compactorCfg.BlockRetention)
-		blocklist := rw.blocklist(tenantID)
-		for _, b := range blocklist {
-			if b.EndTime.Before(cutoff) {
-				level.Info(rw.logger).Log("msg", "marking block for deletion", "blockID", b.BlockID, "tenantID", tenantID)
-				err := rw.c.MarkBlockCompacted(b.BlockID, tenantID)
-				if err != nil {
-					level.Error(rw.logger).Log("msg", "failed to mark block compacted during retention", "blockID", b.BlockID, "tenantID", tenantID, "err", err)
-					metricRetentionErrors.Inc()
-				} else {
-					metricMarkedForDeletion.Inc()
-				}
-			}
-		}
-
-		// iterate through compacted list looking for blocks ready to be cleared
-		cutoff = time.Now().Add(-rw.compactorCfg.CompactedBlockRetention)
-		compactedBlocklist := rw.compactedBlocklist(tenantID)
-		for _, b := range compactedBlocklist {
-			if b.CompactedTime.Before(cutoff) {
-				level.Info(rw.logger).Log("msg", "deleting block", "blockID", b.BlockID, "tenantID", tenantID)
-				err := rw.c.ClearBlock(b.BlockID, tenantID)
-				if err != nil {
-					level.Error(rw.logger).Log("msg", "failed to clear compacted block during retention", "blockID", b.BlockID, "tenantID", tenantID, "err", err)
-					metricRetentionErrors.Inc()
-				} else {
-					metricDeleted.Inc()
-				}
-			}
-		}
-
-		return nil, nil
-	})
-
-	if err != nil {
-		level.Error(rw.logger).Log("msg", "failure to start retention.  retention disabled until the next maintenance cycle", "err", err)
-		metricRetentionErrors.Inc()
-	}
-}
-
 func (rw *readerWriter) blocklistTenants() []interface{} {
 	rw.blockListsMtx.Lock()
 	defer rw.blockListsMtx.Unlock()

--- a/tempodb/tempodb_test.go
+++ b/tempodb/tempodb_test.go
@@ -122,60 +122,6 @@ func TestNilOnUnknownTenantID(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestRetention(t *testing.T) {
-	tempDir, err := ioutil.TempDir("/tmp", "")
-	defer os.RemoveAll(tempDir)
-	assert.NoError(t, err, "unexpected error creating temp dir")
-
-	r, w, c, err := New(&Config{
-		Backend: "local",
-		Local: &local.Config{
-			Path: path.Join(tempDir, "traces"),
-		},
-		WAL: &wal.Config{
-			Filepath:        path.Join(tempDir, "wal"),
-			IndexDownsample: 17,
-			BloomFP:         .01,
-		},
-		BlocklistPoll: 0,
-	}, log.NewNopLogger())
-	assert.NoError(t, err)
-
-	c.EnableCompaction(&CompactorConfig{
-		ChunkSizeBytes:          10,
-		MaxCompactionRange:      time.Hour,
-		BlockRetention:          0,
-		CompactedBlockRetention: 0,
-	}, &mockSharder{})
-
-	blockID := uuid.New()
-
-	wal := w.WAL()
-	assert.NoError(t, err)
-
-	head, err := wal.NewBlock(blockID, testTenantID)
-	assert.NoError(t, err)
-
-	complete, err := head.Complete(wal, &mockSharder{})
-	assert.NoError(t, err)
-	blockID = complete.BlockMeta().BlockID
-
-	err = w.WriteBlock(context.Background(), complete)
-	assert.NoError(t, err)
-
-	rw := r.(*readerWriter)
-	// poll
-	checkBlocklists(t, blockID, 1, 0, rw)
-
-	// retention should mark it compacted
-	r.(*readerWriter).doRetention()
-	checkBlocklists(t, blockID, 0, 1, rw)
-
-	// retention again should clear it
-	r.(*readerWriter).doRetention()
-	checkBlocklists(t, blockID, 0, 0, rw)
-}
-
 func TestBlockCleanup(t *testing.T) {
 	tempDir, err := ioutil.TempDir("/tmp", "")
 	defer os.RemoveAll(tempDir)


### PR DESCRIPTION
**What this PR does**:
Introduce sharding by block ID in the retention logic so that compactors don't work on the same blocks.  We could also shard by tenantID (meaning 1 compactor would perform all retention for the tenant), but at the risk of less evenly distributed work.  

This PR also moves retention to a separate file.

**Which issue(s) this PR fixes**:
Fixes #330

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`