### PR TITLE
From path.Join to filepath.Join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master / unreleased
 
+* [CHANGE] From path.Join to filepath.Join [#338](https://github.com/grafana/tempo/pull/338)
 * [BUGFIX] Frequent errors logged by compactor regarding meta not found [#327](https://github.com/grafana/tempo/pull/327)
 
 ## v0.3.0

--- a/tempodb/backend/diskcache/disk_cache.go
+++ b/tempodb/backend/diskcache/disk_cache.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -19,7 +19,7 @@ func (r *reader) readOrCacheBloom(ctx context.Context, blockID uuid.UUID, tenant
 	var skippableError error
 
 	k := bloomKey(blockID, tenantID, typeBloom, shardNum)
-	filename := path.Join(r.cfg.Path, k)
+	filename := filepath.Join(r.cfg.Path, k)
 
 	bytes, err := ioutil.ReadFile(filename)
 
@@ -51,7 +51,7 @@ func (r *reader) readOrCacheIndex(ctx context.Context, blockID uuid.UUID, tenant
 	var skippableError error
 
 	k := key(blockID, tenantID, typeIndex)
-	filename := path.Join(r.cfg.Path, k)
+	filename := filepath.Join(r.cfg.Path, k)
 
 	bytes, err := ioutil.ReadFile(filename)
 
@@ -152,7 +152,7 @@ func clean(folder string, allowedMBs int, pruneCount int) (bool, error) {
 			continue
 		}
 
-		err = os.Remove(path.Join(folder, info.Name()))
+		err = os.Remove(filepath.Join(folder, info.Name()))
 	}
 
 	return true, err

--- a/tempodb/wal/wal.go
+++ b/tempodb/wal/wal.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/google/uuid"
@@ -46,7 +46,7 @@ func New(c *Config) (*WAL, error) {
 	}
 
 	if c.CompletedFilepath == "" {
-		completedFilepath := path.Join(c.Filepath, completedDir)
+		completedFilepath := filepath.Join(c.Filepath, completedDir)
 		err = os.RemoveAll(completedFilepath)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
**What this PR does**:
This PR changes `path.Join` to `filepath.Join` in:
- tempodb/backend/diskcache/disk_cache.go
- tempodb/wal/wal.go

**Which issue(s) this PR fixes**:
Fixes #136

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`