### PR TITLE
Remove panic in ReportFatalError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [CHANGE] From path.Join to filepath.Join [#338](https://github.com/grafana/tempo/pull/338)
 * [BUGFIX] Frequent errors logged by compactor regarding meta not found [#327](https://github.com/grafana/tempo/pull/327)
+* [BUGFIX] Fix distributors panicking on rollout [#343](https://github.com/grafana/tempo/pull/343)
 
 ## v0.3.0
 

--- a/modules/distributor/receiver/shim.go
+++ b/modules/distributor/receiver/shim.go
@@ -184,7 +184,6 @@ func (r *receiversShim) ConsumeTraces(ctx context.Context, td pdata.Traces) erro
 // implements component.Host
 func (r *receiversShim) ReportFatalError(err error) {
 	level.Error(util.Logger).Log("msg", "fatal error reported", "err", err)
-	panic(fmt.Sprintf("Fatal error %v", err))
 }
 
 // implements component.Host


### PR DESCRIPTION
**What this PR does**:
Removes the `panic()` in ReportFatalError().  This is causing distributors to panic on rollout with a simple "http: Server Closed" message.  Obviously it is intentional that the http server is closed and panic'ing at this point would be silly. 

**Which issue(s) this PR fixes**:
Fixes #342 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`