### PR TITLE
Compact more than 2 blocks at a time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [CHANGE] From path.Join to filepath.Join [#338](https://github.com/grafana/tempo/pull/338)
 * [CHANGE] Upgrade Cortex from v1.3.0 to v.1.4.0 [#341](https://github.com/grafana/tempo/pull/341)
+* [CHANGE] Compact more than 2 blocks at a time [#348](https://github.com/grafana/tempo/pull/348)
 * [ENHANCEMENT] Add tempodb_compaction_objects_combined metric. [#339](https://github.com/grafana/tempo/pull/339)
 * [BUGFIX] Frequent errors logged by compactor regarding meta not found [#327](https://github.com/grafana/tempo/pull/327)
 * [BUGFIX] Fix distributors panicking on rollout [#343](https://github.com/grafana/tempo/pull/343)

--- a/tempodb/compaction_block_selector.go
+++ b/tempodb/compaction_block_selector.go
@@ -147,9 +147,8 @@ func (twbs *timeWindowBlockSelector) BlocksToCompact() ([]*encoding.BlockMeta, s
 			if activeWindow <= blockWindow {
 				// search forward for inputBlocks in a row that have the same compaction level
 				// Gather as many as possible while staying within limits
-				maxOffset := len(windowBlocks) - (twbs.MinInputBlocks - 1)
-				for i := 0; i <= maxOffset; i++ {
-					for j := i + 1; j <= maxOffset &&
+				for i := 0; i <= len(windowBlocks)-twbs.MinInputBlocks+1; i++ {
+					for j := i + 1; j <= len(windowBlocks)-1 &&
 						windowBlocks[i].CompactionLevel == windowBlocks[j].CompactionLevel &&
 						len(compactBlocks)+1 <= twbs.MaxInputBlocks &&
 						totalObjects(compactBlocks)+windowBlocks[j].TotalObjects <= twbs.MaxCompactionObjects; j++ {
@@ -162,7 +161,7 @@ func (twbs *timeWindowBlockSelector) BlocksToCompact() ([]*encoding.BlockMeta, s
 				}
 
 				compact = false
-				if len(compactBlocks) > 0 {
+				if len(compactBlocks) >= twbs.MinInputBlocks {
 					compact = true
 					hashString = fmt.Sprintf("%v-%v-%v", compactBlocks[0].TenantID, compactBlocks[0].CompactionLevel, currentWindow)
 				}

--- a/tempodb/compaction_block_selector_test.go
+++ b/tempodb/compaction_block_selector_test.go
@@ -473,6 +473,72 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 			},
 			expectedHash2: fmt.Sprintf("%v-%v-%v", tenantID, 0, now.Unix()),
 		},
+		{
+			name: "honors minimum block count",
+			blocklist: []*encoding.BlockMeta{
+				{
+					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+					EndTime: now,
+				},
+				{
+					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
+					EndTime: now,
+				},
+			},
+			minInputBlocks: 3,
+			maxInputBlocks: 3,
+			expected:       nil,
+			expectedHash:   "",
+			expectedSecond: nil,
+			expectedHash2:  "",
+		},
+		{
+			name: "can choose blocks not at the lowest compaction level",
+			blocklist: []*encoding.BlockMeta{
+				{
+					BlockID:         uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+					EndTime:         now,
+					CompactionLevel: 0,
+				},
+				{
+					BlockID:         uuid.MustParse("00000000-0000-0000-0000-000000000002"),
+					EndTime:         now,
+					CompactionLevel: 1,
+				},
+				{
+					BlockID:         uuid.MustParse("00000000-0000-0000-0000-000000000003"),
+					EndTime:         now,
+					CompactionLevel: 1,
+				},
+				{
+					BlockID:         uuid.MustParse("00000000-0000-0000-0000-000000000004"),
+					EndTime:         now,
+					CompactionLevel: 1,
+				},
+			},
+			minInputBlocks: 3,
+			maxInputBlocks: 3,
+			expected: []*encoding.BlockMeta{
+				{
+					BlockID:         uuid.MustParse("00000000-0000-0000-0000-000000000002"),
+					EndTime:         now,
+					CompactionLevel: 1,
+				},
+				{
+					BlockID:         uuid.MustParse("00000000-0000-0000-0000-000000000003"),
+					EndTime:         now,
+					CompactionLevel: 1,
+				},
+				{
+					BlockID:         uuid.MustParse("00000000-0000-0000-0000-000000000004"),
+					EndTime:         now,
+					CompactionLevel: 1,
+				},
+			},
+			expectedHash:   fmt.Sprintf("%v-%v-%v", tenantID, 1, now.Unix()),
+			expectedSecond: nil,
+			expectedHash2:  "",
+		},
 	}
 
 	for _, tt := range tests {

--- a/tempodb/compaction_block_selector_test.go
+++ b/tempodb/compaction_block_selector_test.go
@@ -358,6 +358,59 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 			expectedHash2:  "",
 		},
 		{
+			name: "doesn't exceed max compaction objects",
+			blocklist: []*encoding.BlockMeta{
+				{
+					BlockID:      uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+					TotalObjects: 99,
+					EndTime:      now,
+				},
+				{
+					BlockID:      uuid.MustParse("00000000-0000-0000-0000-000000000002"),
+					TotalObjects: 2,
+					EndTime:      now,
+				},
+			},
+			expected:       nil,
+			expectedHash:   "",
+			expectedSecond: nil,
+			expectedHash2:  "",
+		},
+		{
+			name: "Returns as many blocks as possible without exceeding max compaction objects",
+			blocklist: []*encoding.BlockMeta{
+				{
+					BlockID:      uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+					TotalObjects: 50,
+					EndTime:      now,
+				},
+				{
+					BlockID:      uuid.MustParse("00000000-0000-0000-0000-000000000002"),
+					TotalObjects: 50,
+					EndTime:      now,
+				},
+				{
+					BlockID:      uuid.MustParse("00000000-0000-0000-0000-000000000003"),
+					TotalObjects: 50,
+					EndTime:      now,
+				}},
+			expected: []*encoding.BlockMeta{
+				{
+					BlockID:      uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+					TotalObjects: 50,
+					EndTime:      now,
+				},
+				{
+					BlockID:      uuid.MustParse("00000000-0000-0000-0000-000000000002"),
+					TotalObjects: 50,
+					EndTime:      now,
+				},
+			},
+			expectedHash:   fmt.Sprintf("%v-%v-%v", tenantID, 0, now.Unix()),
+			expectedSecond: nil,
+			expectedHash2:  "",
+		},
+		{
 			// First compaction gets 3 blocks, second compaction gets 2 more
 			name:           "choose more than 2 blocks",
 			maxInputBlocks: 3,

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -65,7 +65,7 @@ func (rw *readerWriter) doCompaction() {
 	tenantID := tenants[rand.Intn(len(tenants))].(string)
 	blocklist := rw.blocklist(tenantID)
 
-	blockSelector := newTimeWindowBlockSelector(blocklist, rw.compactorCfg.MaxCompactionRange, rw.compactorCfg.MaxCompactionObjects)
+	blockSelector := newTimeWindowBlockSelector(blocklist, rw.compactorCfg.MaxCompactionRange, rw.compactorCfg.MaxCompactionObjects, defaultMinInputBlocks, defaultMaxInputBlocks)
 
 	start := time.Now()
 

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -125,7 +125,7 @@ func TestCompaction(t *testing.T) {
 	rw.pollBlocklist()
 
 	blocklist := rw.blocklist(testTenantID)
-	blockSelector := newTimeWindowBlockSelector(blocklist, rw.compactorCfg.MaxCompactionRange, 10000)
+	blockSelector := newTimeWindowBlockSelector(blocklist, rw.compactorCfg.MaxCompactionRange, 10000, defaultMinInputBlocks, 2)
 
 	expectedCompactions := len(blocklist) / inputBlocks
 	compactions := 0
@@ -230,7 +230,7 @@ func TestSameIDCompaction(t *testing.T) {
 
 	var blocks []*encoding.BlockMeta
 	blocklist := rw.blocklist(testTenantID)
-	blockSelector := newTimeWindowBlockSelector(blocklist, rw.compactorCfg.MaxCompactionRange, 10000)
+	blockSelector := newTimeWindowBlockSelector(blocklist, rw.compactorCfg.MaxCompactionRange, 10000, defaultMinInputBlocks, 2)
 	blocks, _ = blockSelector.BlocksToCompact()
 	assert.Len(t, blocks, inputBlocks)
 


### PR DESCRIPTION
**What this PR does**:
Enhance TimeWindowBlockSelector to allow choosing more than 2 blocks in the active window to compact at a time, controllable by parameters.   Hard-coded default values are min=2 (same behavior as before) and max=8.   Blocks outside the active window are compacted using the minimum block count always (same behavior as before).  The min/max parameters are not exposed as configuration values but could be if it makes sense.

Existing tests were updated to specify max=2 to preserve prior behavior as needed.  New test was added for choosing more than 2 blocks.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`