### PR TITLE
feat: add option to S3 backend for V2 signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [ENHANCEMENT] Add tempodb_compaction_objects_written metric. [#360](https://github.com/grafana/tempo/pull/360)
 * [ENHANCEMENT] Add tempodb_compaction_bytes_written metric. [#360](https://github.com/grafana/tempo/pull/360)
 * [ENHANCEMENT] Add tempodb_compaction_blocks_total metric. [#360](https://github.com/grafana/tempo/pull/360)
+* [ENHANCEMENT] Add support for S3 V2 signatures. [#352](https://github.com/grafana/tempo/pull/352)
 * [BUGFIX] Frequent errors logged by compactor regarding meta not found [#327](https://github.com/grafana/tempo/pull/327)
 * [BUGFIX] Fix distributors panicking on rollout [#343](https://github.com/grafana/tempo/pull/343)
 

--- a/tempodb/backend/s3/config.go
+++ b/tempodb/backend/s3/config.go
@@ -8,4 +8,6 @@ type Config struct {
 	SecretKey string `yaml:"secret_key"`
 	Insecure  bool   `yaml:"insecure"`
 	PartSize  uint64 `yaml:"part_size"`
+	// SignatureV2 configures the object storage to use V2 signing instead of V4
+	SignatureV2 bool `yaml:"signature_v2"`
 }


### PR DESCRIPTION
**What this PR does**:

Adds a config option/flag to use signature version 2 in the S3 backend. This will switch from the default V4 auth to a V2, which might be necessary for some object storage implementations.

**Which issue(s) this PR fixes**:
Fixes #<issue number
**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`