### PR TITLE
Query Path Observability Improvements

### DIFF
--- a/cmd/tempo-query/main.go
+++ b/cmd/tempo-query/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/jaegertracing/jaeger/plugin/storage/grpc"
 	"github.com/jaegertracing/jaeger/storage/dependencystore"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
-	jaeger_config "github.com/uber/jaeger-client-go/config"
 )
 
 func main() {
@@ -43,8 +42,6 @@ func main() {
 	cfg := &tempo.Config{}
 	cfg.InitFromViper(v)
 
-	initJaeger("grpc-plugin")
-
 	backend := tempo.New(cfg)
 	grpc.Serve(&plugin{backend: backend})
 }
@@ -63,14 +60,4 @@ func (p *plugin) SpanReader() spanstore.Reader {
 
 func (p *plugin) SpanWriter() spanstore.Writer {
 	return p.backend
-}
-
-func initJaeger(service string) {
-	// .FromEnv() uses standard environment variables to allow for easy configuration
-	cfg, err := jaeger_config.FromEnv()
-	if err != nil {
-		panic(err)
-	}
-
-	cfg.InitGlobalTracer(service)
 }

--- a/cmd/tempo-query/main.go
+++ b/cmd/tempo-query/main.go
@@ -44,7 +44,7 @@ func main() {
 	cfg.InitFromViper(v)
 
 	backend := tempo.New(cfg)
-	initJaeger("grpc-plugin")
+	initJaeger("tempo-grpc-plugin")
 	grpc.Serve(&plugin{backend: backend})
 }
 

--- a/cmd/tempo-query/main.go
+++ b/cmd/tempo-query/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jaegertracing/jaeger/plugin/storage/grpc"
 	"github.com/jaegertracing/jaeger/storage/dependencystore"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
+	jaeger_config "github.com/uber/jaeger-client-go/config"
 )
 
 func main() {
@@ -42,6 +43,8 @@ func main() {
 	cfg := &tempo.Config{}
 	cfg.InitFromViper(v)
 
+	initJaeger("grpc-plugin")
+
 	backend := tempo.New(cfg)
 	grpc.Serve(&plugin{backend: backend})
 }
@@ -60,4 +63,14 @@ func (p *plugin) SpanReader() spanstore.Reader {
 
 func (p *plugin) SpanWriter() spanstore.Writer {
 	return p.backend
+}
+
+func initJaeger(service string) {
+	// .FromEnv() uses standard environment variables to allow for easy configuration
+	cfg, err := jaeger_config.FromEnv()
+	if err != nil {
+		panic(err)
+	}
+
+	cfg.InitGlobalTracer(service)
 }

--- a/cmd/tempo-query/main.go
+++ b/cmd/tempo-query/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jaegertracing/jaeger/plugin/storage/grpc"
 	"github.com/jaegertracing/jaeger/storage/dependencystore"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
+	jaeger_config "github.com/uber/jaeger-client-go/config"
 )
 
 func main() {
@@ -43,6 +44,7 @@ func main() {
 	cfg.InitFromViper(v)
 
 	backend := tempo.New(cfg, logger)
+	initJaeger("grpc-plugin")
 	grpc.Serve(&plugin{backend: backend})
 }
 
@@ -60,4 +62,14 @@ func (p *plugin) SpanReader() spanstore.Reader {
 
 func (p *plugin) SpanWriter() spanstore.Writer {
 	return p.backend
+}
+
+func initJaeger(service string) {
+	// .FromEnv() uses standard environment variables to allow for easy configuration
+	cfg, err := jaeger_config.FromEnv()
+	if err != nil {
+		panic(err)
+	}
+
+	cfg.InitGlobalTracer(service)
 }

--- a/cmd/tempo-query/main.go
+++ b/cmd/tempo-query/main.go
@@ -42,7 +42,7 @@ func main() {
 	cfg := &tempo.Config{}
 	cfg.InitFromViper(v)
 
-	backend := tempo.New(cfg)
+	backend := tempo.New(cfg, logger)
 	grpc.Serve(&plugin{backend: backend})
 }
 

--- a/cmd/tempo-query/main.go
+++ b/cmd/tempo-query/main.go
@@ -43,7 +43,7 @@ func main() {
 	cfg := &tempo.Config{}
 	cfg.InitFromViper(v)
 
-	backend := tempo.New(cfg, logger)
+	backend := tempo.New(cfg)
 	initJaeger("grpc-plugin")
 	grpc.Serve(&plugin{backend: backend})
 }

--- a/cmd/tempo-query/tempo/plugin.go
+++ b/cmd/tempo-query/tempo/plugin.go
@@ -27,9 +27,10 @@ type Backend struct {
 	logger        hclog.Logger
 }
 
-func New(cfg *Config) *Backend {
+func New(cfg *Config, logger hclog.Logger) *Backend {
 	return &Backend{
 		tempoEndpoint: "http://" + cfg.Backend + "/api/traces/",
+		logger:        logger,
 	}
 }
 

--- a/cmd/tempo-query/tempo/plugin.go
+++ b/cmd/tempo-query/tempo/plugin.go
@@ -11,6 +11,8 @@ import (
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/hashicorp/go-hclog"
+	"github.com/opentracing/opentracing-go"
+	ot_log "github.com/opentracing/opentracing-go/log"
 	"github.com/weaveworks/common/user"
 	"google.golang.org/grpc/metadata"
 
@@ -39,9 +41,17 @@ func (b *Backend) GetDependencies(endTs time.Time, lookback time.Duration) ([]ja
 }
 func (b *Backend) GetTrace(ctx context.Context, traceID jaeger.TraceID) (*jaeger.Trace, error) {
 	hexID := fmt.Sprintf("%016x%016x", traceID.High, traceID.Low)
+
+	span, _ := opentracing.StartSpanFromContext(ctx, "GRPC Plugin GetTrace")
+	defer span.Finish()
+
 	req, err := http.NewRequestWithContext(ctx, "GET", b.tempoEndpoint+hexID, nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if tracer := opentracing.GlobalTracer(); tracer != nil {
+		tracer.Inject(span.Context(), opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(req.Header))
 	}
 
 	// currently Jaeger Query will only propagate bearer token to the grpc backend and no other headers
@@ -73,6 +83,7 @@ func (b *Backend) GetTrace(ctx context.Context, traceID jaeger.TraceID) (*jaeger
 	}
 
 	b.logger.Error("starting otlp to jaeger", "findTraceID", hexID)
+	span.LogFields(ot_log.String("msg", "otlp to Jaeger"))
 	otTrace := ot_pdata.TracesFromOtlp(out.Batches)
 	jaegerBatches, err := ot_jaeger.InternalTracesToJaegerProto(otTrace)
 
@@ -86,8 +97,9 @@ func (b *Backend) GetTrace(ctx context.Context, traceID jaeger.TraceID) (*jaeger
 	}
 
 	b.logger.Error("add process information", "findTraceID", hexID)
+	span.LogFields(ot_log.String("msg", "build process map"))
+	// otel proto conversion doesn't set jaeger processes
 	for _, batch := range jaegerBatches {
-		// otel proto conversion doesn't set jaeger spans for some reason.
 		for _, s := range batch.Spans {
 			s.Process = batch.Process
 		}

--- a/cmd/tempo-query/tempo/plugin.go
+++ b/cmd/tempo-query/tempo/plugin.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/opentracing/opentracing-go"
+	ot_log "github.com/opentracing/opentracing-go/log"
 	"github.com/weaveworks/common/user"
 	"google.golang.org/grpc/metadata"
 
@@ -36,9 +38,17 @@ func (b *Backend) GetDependencies(endTs time.Time, lookback time.Duration) ([]ja
 }
 func (b *Backend) GetTrace(ctx context.Context, traceID jaeger.TraceID) (*jaeger.Trace, error) {
 	hexID := fmt.Sprintf("%016x%016x", traceID.High, traceID.Low)
+
+	span, _ := opentracing.StartSpanFromContext(ctx, "GRPC Plugin GetTrace")
+	defer span.Finish()
+
 	req, err := http.NewRequestWithContext(ctx, "GET", b.tempoEndpoint+hexID, nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if tracer := opentracing.GlobalTracer(); tracer != nil {
+		tracer.Inject(span.Context(), opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(req.Header))
 	}
 
 	// currently Jaeger Query will only propagate bearer token to the grpc backend and no other headers
@@ -69,6 +79,7 @@ func (b *Backend) GetTrace(ctx context.Context, traceID jaeger.TraceID) (*jaeger
 		return nil, fmt.Errorf("failed to unmarshal trace json, err: %w. Tempo response body: %s", err, string(body))
 	}
 
+	span.LogFields(ot_log.String("msg", "otlp to Jaeger"))
 	otTrace := ot_pdata.TracesFromOtlp(out.Batches)
 	jaegerBatches, err := ot_jaeger.InternalTracesToJaegerProto(otTrace)
 
@@ -81,8 +92,9 @@ func (b *Backend) GetTrace(ctx context.Context, traceID jaeger.TraceID) (*jaeger
 		ProcessMap: []jaeger.Trace_ProcessMapping{},
 	}
 
+	span.LogFields(ot_log.String("msg", "build process map"))
+	// otel proto conversion doesn't set jaeger processes
 	for _, batch := range jaegerBatches {
-		// otel proto conversion doesn't set jaeger spans for some reason.
 		for _, s := range batch.Spans {
 			s.Process = batch.Process
 		}

--- a/cmd/tempo-query/tempo/plugin.go
+++ b/cmd/tempo-query/tempo/plugin.go
@@ -39,7 +39,7 @@ func (b *Backend) GetDependencies(endTs time.Time, lookback time.Duration) ([]ja
 func (b *Backend) GetTrace(ctx context.Context, traceID jaeger.TraceID) (*jaeger.Trace, error) {
 	hexID := fmt.Sprintf("%016x%016x", traceID.High, traceID.Low)
 
-	span, _ := opentracing.StartSpanFromContext(ctx, "GRPC Plugin GetTrace")
+	span, _ := opentracing.StartSpanFromContext(ctx, "GetTrace")
 	defer span.Finish()
 
 	req, err := http.NewRequestWithContext(ctx, "GET", b.tempoEndpoint+hexID, nil)
@@ -48,7 +48,8 @@ func (b *Backend) GetTrace(ctx context.Context, traceID jaeger.TraceID) (*jaeger
 	}
 
 	if tracer := opentracing.GlobalTracer(); tracer != nil {
-		tracer.Inject(span.Context(), opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(req.Header))
+		// this is not really loggable or anything we can react to.  just ignoring this error
+		_ = tracer.Inject(span.Context(), opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(req.Header))
 	}
 
 	// currently Jaeger Query will only propagate bearer token to the grpc backend and no other headers

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.6.1
 	github.com/uber-go/atomic v1.4.0
+	github.com/uber/jaeger-client-go v2.25.0+incompatible
 	github.com/weaveworks/common v0.0.0-20200914083218-61ffdd448099
 	github.com/willf/bitset v1.1.10 // indirect
 	github.com/willf/bloom v2.0.3+incompatible

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -36,7 +36,7 @@ var (
 		Namespace: "tempo",
 		Name:      "query_bytes_read",
 		Help:      "bytes read",
-		Buckets:   prometheus.ExponentialBuckets(1024, 2, 10),
+		Buckets:   prometheus.ExponentialBuckets(1024*1024, 2, 8),
 	}, []string{"layer"})
 	metricIngesterClients = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "tempo",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1091,6 +1091,7 @@ github.com/tommy-muehle/go-mnd/config
 ## explicit
 github.com/uber-go/atomic
 # github.com/uber/jaeger-client-go v2.25.0+incompatible
+## explicit
 github.com/uber/jaeger-client-go
 github.com/uber/jaeger-client-go/config
 github.com/uber/jaeger-client-go/internal/baggage


### PR DESCRIPTION
**What this PR does**:
Further improvements on query path observability.

- Added tracing to the GRPC plugin.  For some reason context does not propagate from jaeger-query to the plugin, but this additional span still gives us insight into what's happening in the plugin
- Fixed the bytes/query histogram.  It was always capping out.
- Removed the block.Find span.  Agreed with @annanay25 it made the trace harder to read.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`