### PR TITLE
Fix Ingesters Occassionally Double Flushing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [ENHANCEMENT] Add support for S3 V2 signatures. [#352](https://github.com/grafana/tempo/pull/352)
 * [BUGFIX] Frequent errors logged by compactor regarding meta not found [#327](https://github.com/grafana/tempo/pull/327)
 * [BUGFIX] Fix distributors panicking on rollout [#343](https://github.com/grafana/tempo/pull/343)
+* [BUGFIX] Fix ingesters occassionally double flushing [#364](https://github.com/grafana/tempo/pull/364)
 
 ## v0.3.0
 

--- a/modules/ingester/flush.go
+++ b/modules/ingester/flush.go
@@ -136,7 +136,7 @@ func (i *Ingester) flushLoop(j int) {
 			continue
 		}
 
-		i.flushQueues.ClearKey(op.Key())
+		i.flushQueues.Clear(op)
 	}
 }
 

--- a/modules/ingester/flush.go
+++ b/modules/ingester/flush.go
@@ -104,9 +104,7 @@ func (i *Ingester) sweepInstance(instance *instance, immediate bool) {
 
 	// see if any complete blocks are ready to be flushed
 	if instance.GetBlockToBeFlushed() != nil {
-		i.flushQueueIndex++
-		flushQueueIndex := i.flushQueueIndex % i.cfg.ConcurrentFlushes
-		i.flushQueues[flushQueueIndex].Enqueue(&flushOp{
+		i.flushQueues.Enqueue(&flushOp{
 			time.Now().Unix(),
 			instance.instanceID,
 		})
@@ -120,7 +118,7 @@ func (i *Ingester) flushLoop(j int) {
 	}()
 
 	for {
-		o := i.flushQueues[j].Dequeue()
+		o := i.flushQueues.Dequeue(j)
 		if o == nil {
 			return
 		}
@@ -134,7 +132,7 @@ func (i *Ingester) flushLoop(j int) {
 
 			// re-queue failed flush
 			op.from += int64(flushBackoff)
-			i.flushQueues[j].Enqueue(op)
+			i.flushQueues.Enqueue(op)
 		}
 	}
 }

--- a/modules/ingester/flush.go
+++ b/modules/ingester/flush.go
@@ -107,7 +107,7 @@ func (i *Ingester) sweepInstance(instance *instance, immediate bool) {
 		i.flushQueues.Enqueue(&flushOp{
 			time.Now().Unix(),
 			instance.instanceID,
-		}, false)
+		})
 	}
 }
 
@@ -132,7 +132,7 @@ func (i *Ingester) flushLoop(j int) {
 
 			// re-queue failed flush
 			op.from += int64(flushBackoff)
-			i.flushQueues.Enqueue(op, true)
+			i.flushQueues.Requeue(op)
 			continue
 		}
 

--- a/modules/ingester/flush.go
+++ b/modules/ingester/flush.go
@@ -126,14 +126,13 @@ func (i *Ingester) flushLoop(j int) {
 		}
 		op := o.(*flushOp)
 
-		level.Debug(util.Logger).Log("msg", "flushing stream", "userid", op.userID, "fp")
+		level.Debug(util.Logger).Log("msg", "flushing block", "userid", op.userID, "fp")
 
 		err := i.flushUserTraces(op.userID)
 		if err != nil {
 			level.Error(util.WithUserID(op.userID, util.Logger)).Log("msg", "failed to flush user", "err", err)
-		}
 
-		if err != nil {
+			// re-queue failed flush
 			op.from += int64(flushBackoff)
 			i.flushQueues[j].Enqueue(op)
 		}

--- a/modules/ingester/flush.go
+++ b/modules/ingester/flush.go
@@ -107,7 +107,7 @@ func (i *Ingester) sweepInstance(instance *instance, immediate bool) {
 		i.flushQueues.Enqueue(&flushOp{
 			time.Now().Unix(),
 			instance.instanceID,
-		})
+		}, false)
 	}
 }
 
@@ -132,8 +132,11 @@ func (i *Ingester) flushLoop(j int) {
 
 			// re-queue failed flush
 			op.from += int64(flushBackoff)
-			i.flushQueues.Enqueue(op)
+			i.flushQueues.Enqueue(op, true)
+			continue
 		}
+
+		i.flushQueues.ClearKey(op.Key())
 	}
 }
 

--- a/modules/ingester/flush.go
+++ b/modules/ingester/flush.go
@@ -52,8 +52,8 @@ func (i *Ingester) Flush() {
 	}
 }
 
-// FlushHandler triggers a flush of all in memory chunks.  Mainly used for
-// local testing.
+// FlushHandler calls sweepUsers(true) which will force push all traces into the WAL and force
+//  mark all head blocks as ready to flush.
 func (i *Ingester) FlushHandler(w http.ResponseWriter, _ *http.Request) {
 	i.sweepUsers(true)
 	w.WriteHeader(http.StatusNoContent)

--- a/modules/ingester/ingester.go
+++ b/modules/ingester/ingester.go
@@ -48,7 +48,7 @@ type Ingester struct {
 	lifecycler *ring.Lifecycler
 	store      storage.Store
 
-	flushQueues     *flushqueues.FlushQueues
+	flushQueues     *flushqueues.ExclusiveQueues
 	flushQueuesDone sync.WaitGroup
 
 	limiter *Limiter

--- a/modules/ingester/ingester.go
+++ b/modules/ingester/ingester.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/modules/storage"
+	"github.com/grafana/tempo/pkg/flushqueues"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/validation"
 	tempodb_wal "github.com/grafana/tempo/tempodb/wal"
@@ -47,9 +48,7 @@ type Ingester struct {
 	lifecycler *ring.Lifecycler
 	store      storage.Store
 
-	// One queue per flush thread.
-	flushQueues     []*util.PriorityQueue
-	flushQueueIndex int
+	flushQueues     *flushqueues.FlushQueues
 	flushQueuesDone sync.WaitGroup
 
 	limiter *Limiter
@@ -63,12 +62,11 @@ func New(cfg Config, store storage.Store, limits *overrides.Overrides) (*Ingeste
 		cfg:         cfg,
 		instances:   map[string]*instance{},
 		store:       store,
-		flushQueues: make([]*util.PriorityQueue, cfg.ConcurrentFlushes),
+		flushQueues: flushqueues.New(cfg.ConcurrentFlushes, metricFlushQueueLength),
 	}
 
 	i.flushQueuesDone.Add(cfg.ConcurrentFlushes)
 	for j := 0; j < cfg.ConcurrentFlushes; j++ {
-		i.flushQueues[j] = util.NewPriorityQueue(metricFlushQueueLength)
 		go i.flushLoop(j)
 	}
 
@@ -134,6 +132,11 @@ func (i *Ingester) stopping(_ error) error {
 	if i.lifecycler != nil {
 		// Next initiate our graceful exit from the ring.
 		return services.StopAndAwaitTerminated(context.Background(), i.lifecycler)
+	}
+
+	if i.flushQueues != nil {
+		i.flushQueues.Stop()
+		i.flushQueuesDone.Wait()
 	}
 
 	return nil

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -53,7 +53,8 @@ type instance struct {
 	headBlock       *tempodb_wal.AppendBlock
 	completingBlock *tempodb_wal.AppendBlock
 	completeBlocks  []*tempodb_wal.CompleteBlock
-	lastBlockCut    time.Time
+
+	lastBlockCut time.Time
 
 	instanceID         string
 	tracesCreatedTotal prometheus.Counter

--- a/pkg/flushqueues/exclusivequeues.go
+++ b/pkg/flushqueues/exclusivequeues.go
@@ -51,7 +51,7 @@ func (f *ExclusiveQueues) Requeue(op util.Op) {
 	f.queues[flushQueueIndex].Enqueue(op)
 }
 
-// ClearKey unblocks the requested key.  This should be called only after a flush has been successful
+// Clear unblocks the requested op.  This should be called only after a flush has been successful
 func (f *ExclusiveQueues) Clear(op util.Op) {
 	f.activeKeys.Delete(op.Key())
 }

--- a/pkg/flushqueues/exclusivequeues.go
+++ b/pkg/flushqueues/exclusivequeues.go
@@ -56,10 +56,8 @@ func (f *ExclusiveQueues) ClearKey(key string) {
 }
 
 // Stop closes all queues
-func (f *ExclusiveQueues) Stop() error {
+func (f *ExclusiveQueues) Stop() {
 	for _, q := range f.queues {
 		q.Close()
 	}
-
-	return nil
 }

--- a/pkg/flushqueues/exclusivequeues.go
+++ b/pkg/flushqueues/exclusivequeues.go
@@ -51,8 +51,8 @@ func (f *ExclusiveQueues) Requeue(op util.Op) {
 }
 
 // ClearKey unblocks the requested key.  This should be called only after a flush has been successful
-func (f *ExclusiveQueues) ClearKey(key string) {
-	f.activeKeys.Delete(key)
+func (f *ExclusiveQueues) Clear(op util.Op) {
+	f.activeKeys.Delete(op.Key())
 }
 
 // Stop closes all queues

--- a/pkg/flushqueues/exclusivequeues_test.go
+++ b/pkg/flushqueues/exclusivequeues_test.go
@@ -1,0 +1,106 @@
+package flushqueues
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/grafana/tempo/pkg/util/test"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockOp struct {
+	key string
+}
+
+func (m mockOp) Key() string {
+	return m.key
+}
+
+func (m mockOp) Priority() int64 {
+	return 0
+}
+
+func TestExclusiveQueues(t *testing.T) {
+	gauge := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "test",
+		Name:      "testersons",
+	})
+
+	q := New(1, gauge)
+	op := mockOp{
+		key: "not unique",
+	}
+
+	// enqueue twice
+	q.Enqueue(op)
+	length, err := test.GetGaugeValue(gauge)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, int(length))
+
+	q.Enqueue(op)
+	length, err = test.GetGaugeValue(gauge)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, int(length))
+
+	// dequeue -> requeue
+	_ = q.Dequeue(0)
+	length, err = test.GetGaugeValue(gauge)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, int(length))
+
+	q.Requeue(op)
+	length, err = test.GetGaugeValue(gauge)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, int(length))
+
+	// dequeue -> clearkey -> enqueue
+	_ = q.Dequeue(0)
+	length, err = test.GetGaugeValue(gauge)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, int(length))
+
+	q.ClearKey(op.key)
+	length, err = test.GetGaugeValue(gauge)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, int(length))
+
+	q.Enqueue(op)
+	length, err = test.GetGaugeValue(gauge)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, int(length))
+}
+
+func TestMultipleQueues(t *testing.T) {
+	gauge := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "test",
+		Name:      "testersons",
+	})
+
+	totalQueues := 10
+	totalItems := 10
+	q := New(totalQueues, gauge)
+
+	// add stuff to the queue and confirm the length matches expected
+	for i := 0; i < totalItems; i++ {
+		op := mockOp{
+			key: uuid.New().String(),
+		}
+
+		q.Enqueue(op)
+
+		length, err := test.GetGaugeValue(gauge)
+		assert.NoError(t, err)
+		assert.Equal(t, i+1, int(length))
+	}
+
+	// each queue should have 1 thing
+	for i := 0; i < totalQueues; i++ {
+		op := q.Dequeue(i)
+		assert.NotNil(t, op)
+
+		length, err := test.GetGaugeValue(gauge)
+		assert.NoError(t, err)
+		assert.Equal(t, totalQueues-(i+1), int(length))
+	}
+}

--- a/pkg/flushqueues/exclusivequeues_test.go
+++ b/pkg/flushqueues/exclusivequeues_test.go
@@ -60,7 +60,7 @@ func TestExclusiveQueues(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 0, int(length))
 
-	q.ClearKey(op.key)
+	q.Clear(op)
 	length, err = test.GetGaugeValue(gauge)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, int(length))

--- a/pkg/flushqueues/flushqueues.go
+++ b/pkg/flushqueues/flushqueues.go
@@ -1,15 +1,19 @@
 package flushqueues
 
 import (
+	"sync"
+
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 type FlushQueues struct {
-	queues []*util.PriorityQueue
-	index  int
+	queues     []*util.PriorityQueue
+	index      int
+	activeKeys sync.Map
 }
 
+// New creates a new set of flush queues with a prom gauge to track current depth
 func New(queues int, metric prometheus.Gauge) *FlushQueues {
 	f := &FlushQueues{
 		queues: make([]*util.PriorityQueue, queues),
@@ -22,16 +26,30 @@ func New(queues int, metric prometheus.Gauge) *FlushQueues {
 	return f
 }
 
-func (f *FlushQueues) Enqueue(op util.Op) {
+// Enqueue adds the op to the next queue and prevents any other items to be added with this key
+func (f *FlushQueues) Enqueue(op util.Op, force bool) {
+	_, ok := f.activeKeys.Load(op.Key())
+	if ok && !force {
+		return
+	}
+
+	f.activeKeys.Store(op.Key(), struct{}{})
 	f.index++
 	flushQueueIndex := f.index % len(f.queues)
 	f.queues[flushQueueIndex].Enqueue(op)
 }
 
+// Dequeue removes the next op from the requested queue
 func (f *FlushQueues) Dequeue(q int) util.Op {
 	return f.queues[q].Dequeue()
 }
 
+// ClearKey unblocks the requested key.  This should be called only after a flush has been successful
+func (f *FlushQueues) ClearKey(key string) {
+	f.activeKeys.Delete(key)
+}
+
+// Stop closes all queues
 func (f *FlushQueues) Stop() error {
 	for _, q := range f.queues {
 		q.Close()

--- a/pkg/flushqueues/flushqueues.go
+++ b/pkg/flushqueues/flushqueues.go
@@ -1,0 +1,41 @@
+package flushqueues
+
+import (
+	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type FlushQueues struct {
+	queues []*util.PriorityQueue
+	index  int
+}
+
+func New(queues int, metric prometheus.Gauge) *FlushQueues {
+	f := &FlushQueues{
+		queues: make([]*util.PriorityQueue, queues),
+	}
+
+	for j := 0; j < queues; j++ {
+		f.queues[j] = util.NewPriorityQueue(metric)
+	}
+
+	return f
+}
+
+func (f *FlushQueues) Enqueue(op util.Op) {
+	f.index++
+	flushQueueIndex := f.index % len(f.queues)
+	f.queues[flushQueueIndex].Enqueue(op)
+}
+
+func (f *FlushQueues) Dequeue(q int) util.Op {
+	return f.queues[q].Dequeue()
+}
+
+func (f *FlushQueues) Stop() error {
+	for _, q := range f.queues {
+		q.Close()
+	}
+
+	return nil
+}

--- a/pkg/util/test/metrics.go
+++ b/pkg/util/test/metrics.go
@@ -22,3 +22,11 @@ func GetGaugeValue(metric prometheus.Gauge) (float64, error) {
 	}
 	return m.Gauge.GetValue(), nil
 }
+
+func GetCounterVecValue(metric *prometheus.CounterVec, label string) (float64, error) {
+	var m = &dto.Metric{}
+	if err := metric.WithLabelValues(label).Write(m); err != nil {
+		return 0, err
+	}
+	return m.Counter.GetValue(), nil
+}

--- a/pkg/util/test/metrics.go
+++ b/pkg/util/test/metrics.go
@@ -1,0 +1,24 @@
+package test
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func GetCounterValue(metric prometheus.Counter) (float64, error) {
+	var m = &dto.Metric{}
+	err := metric.Write(m)
+	if err != nil {
+		return 0, err
+	}
+	return m.Counter.GetValue(), nil
+}
+
+func GetGaugeValue(metric prometheus.Gauge) (float64, error) {
+	var m = &dto.Metric{}
+	err := metric.Write(m)
+	if err != nil {
+		return 0, err
+	}
+	return m.Gauge.GetValue(), nil
+}

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -20,9 +20,6 @@ import (
 	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/grafana/tempo/tempodb/pool"
 	"github.com/grafana/tempo/tempodb/wal"
-	"github.com/prometheus/client_golang/prometheus"
-
-	dto "github.com/prometheus/client_model/go"
 )
 
 type mockSharder struct {
@@ -222,7 +219,7 @@ func TestSameIDCompaction(t *testing.T) {
 
 	rw := r.(*readerWriter)
 
-	combinedStart, err := GetCounterValue(metricCompactionObjectsCombined)
+	combinedStart, err := test.GetCounterValue(metricCompactionObjectsCombined)
 	assert.NoError(t, err)
 
 	// poll
@@ -246,18 +243,9 @@ func TestSameIDCompaction(t *testing.T) {
 	}
 	assert.Equal(t, blockCount-blocksPerCompaction, records)
 
-	combinedFinish, err := GetCounterValue(metricCompactionObjectsCombined)
+	combinedFinish, err := test.GetCounterValue(metricCompactionObjectsCombined)
 	assert.NoError(t, err)
 	assert.Equal(t, float64(1), combinedFinish-combinedStart)
-}
-
-func GetCounterValue(metric prometheus.Counter) (float64, error) {
-	var m = &dto.Metric{}
-	err := metric.Write(m)
-	if err != nil {
-		return 0, err
-	}
-	return m.Counter.GetValue(), nil
 }
 
 func TestCompactionUpdatesBlocklist(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:
Occassionally ingesters fail to flush due to a double queuing (#217) issue discovered by @calvernaz.  This PR looks to fix that by:

- Creating a shim in front of the priority queues `ExclusiveQueues` that prevents multiple items from being queued with the same key
- Adjusting the `flushLoop()` to either call `.Requeue()` or `.ClearKey()` after flush has failed or succeeded
- Consolidated helper methods to extract prometheus metric values to `./pkg/util/test`
- Actually wait for flush queues to clear in `stopping()` eep!

**Which issue(s) this PR fixes**:
Fixes #217 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`