### PR TITLE
Add Jita as docs owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 * @joe-elliott @annanay25
+/docs/ @achatterjee-grafana


### PR DESCRIPTION
**What this PR does**:
Adds @achatterjee-grafana as a docs owner which will help her to contribute and review PRs to the docs folder and its subdirs.