### PR TITLE
Use bytes.Equal instead of hash in CombineTraces

### DIFF
--- a/pkg/util/trace.go
+++ b/pkg/util/trace.go
@@ -11,7 +11,7 @@ import (
 
 func CombineTraces(objA []byte, objB []byte) []byte {
 	// if the byte arrays are the same, we can return quickly
-	if bytes.Compare(objA, objB) == 0 {
+	if bytes.Equal(objA, objB) {
 		return objA
 	}
 

--- a/pkg/util/trace.go
+++ b/pkg/util/trace.go
@@ -1,7 +1,7 @@
 package util
 
 import (
-	"hash/fnv"
+	"bytes"
 
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/go-kit/kit/log/level"
@@ -11,14 +11,7 @@ import (
 
 func CombineTraces(objA []byte, objB []byte) []byte {
 	// if the byte arrays are the same, we can return quickly
-	hasher := fnv.New32a()
-
-	_, _ = hasher.Write(objA)
-	hashA := hasher.Sum32()
-	hasher.Reset()
-	_, _ = hasher.Write(objB)
-	hashB := hasher.Sum32()
-	if hashA == hashB {
+	if bytes.Compare(objA, objB) == 0 {
 		return objA
 	}
 

--- a/pkg/util/trace_test.go
+++ b/pkg/util/trace_test.go
@@ -156,3 +156,33 @@ func TestCombineProtos(t *testing.T) {
 		assert.Equal(t, tt.expectedTotal, actualTotal)
 	}
 }
+
+func BenchmarkCombineTraces(b *testing.B) {
+	t1 := test.MakeTrace(10, []byte{0x01, 0x02})
+	t2 := test.MakeTrace(10, []byte{0x01, 0x03})
+
+	b1, err := proto.Marshal(t1)
+	assert.NoError(b, err)
+	b2, err := proto.Marshal(t2)
+	assert.NoError(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		CombineTraces(b1, b2)
+	}
+}
+
+func BenchmarkCombineTracesIdentical(b *testing.B) {
+	t1 := test.MakeTrace(10, []byte{0x01, 0x02})
+
+	b1, err := proto.Marshal(t1)
+	assert.NoError(b, err)
+
+	var b2 []byte
+	b2 = append(b2, b1...)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		CombineTraces(b1, b1)
+	}
+}

--- a/pkg/util/trace_test.go
+++ b/pkg/util/trace_test.go
@@ -183,6 +183,6 @@ func BenchmarkCombineTracesIdentical(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		CombineTraces(b1, b1)
+		CombineTraces(b1, b2)
 	}
 }


### PR DESCRIPTION
**What this PR does**:
Use bytes.Equal instead of fnv hash to compare inputs in CombineTraces.  Benchmarks show a modest improvement when inputs differ (5-10%), and an extremely large improvement when inputs are identical.

Before:
```
BenchmarkCombineTraces-12             	   13642	     98505 ns/op
BenchmarkCombineTracesIdentical-12    	  184737	      6696 ns/op
```

After
```
BenchmarkCombineTraces-12             	   14634	     91460 ns/op
BenchmarkCombineTracesIdentical-12    	16753951	        76.9 ns/op
```

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`