### PR TITLE
Add level label to tempodb_compaction_objects_combined_total metric

### DIFF
--- a/operations/tempo-mixin/tempo-operational.json
+++ b/operations/tempo-mixin/tempo-operational.json
@@ -4446,7 +4446,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "increase(tempodb_compaction_objects_combined_total{cluster=\"$cluster\",job=~\"$namespace/compactor\"}[$__rate_interval])",
+            "expr": "sum(rate(tempodb_compaction_objects_combined_total{cluster=\"$cluster\",job=~\"$namespace/compactor\"}[$__rate_interval])) by (level)",
             "interval": "",
             "legendFormat": "",
             "refId": "A"
@@ -4456,7 +4456,7 @@
         "timeFrom": null,
         "timeRegions": [],
         "timeShift": null,
-        "title": "Objects Combined",
+        "title": "Objects Combined / s",
         "tooltip": {
           "shared": true,
           "sort": 0,

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -41,11 +41,11 @@ var (
 		Name:      "compaction_errors_total",
 		Help:      "Total number of errors occurring during compaction.",
 	})
-	metricCompactionObjectsCombined = promauto.NewCounter(prometheus.CounterOpts{
+	metricCompactionObjectsCombined = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "tempodb",
 		Name:      "compaction_objects_combined_total",
 		Help:      "Total number of objects combined during compaction.",
-	})
+	}, []string{"level"})
 )
 
 const (
@@ -167,7 +167,7 @@ func (rw *readerWriter) compact(blockMetas []*encoding.BlockMeta, tenantID strin
 			if bytes.Equal(currentID, lowestID) {
 				lowestObject = rw.compactorSharder.Combine(currentObject, lowestObject)
 				b.clear()
-				metricCompactionObjectsCombined.Inc()
+				metricCompactionObjectsCombined.WithLabelValues(compactionLevelLabel).Inc()
 			} else if len(lowestID) == 0 || bytes.Compare(currentID, lowestID) == -1 {
 				lowestID = currentID
 				lowestObject = currentObject

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -219,7 +219,7 @@ func TestSameIDCompaction(t *testing.T) {
 
 	rw := r.(*readerWriter)
 
-	combinedStart, err := test.GetCounterValue(metricCompactionObjectsCombined)
+	combinedStart, err := test.GetCounterVecValue(metricCompactionObjectsCombined, "0")
 	assert.NoError(t, err)
 
 	// poll
@@ -243,7 +243,7 @@ func TestSameIDCompaction(t *testing.T) {
 	}
 	assert.Equal(t, blockCount-blocksPerCompaction, records)
 
-	combinedFinish, err := test.GetCounterValue(metricCompactionObjectsCombined)
+	combinedFinish, err := test.GetCounterVecValue(metricCompactionObjectsCombined, "0")
 	assert.NoError(t, err)
 	assert.Equal(t, float64(1), combinedFinish-combinedStart)
 }


### PR DESCRIPTION
**What this PR does**:
Add "level" label to tempodb_compaction_objects_combined_total. Update operational dashboard to match.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`