### PR TITLE
Reuse hash in CombineTraceProtos to reduce memory allocations

### DIFF
--- a/pkg/util/trace_test.go
+++ b/pkg/util/trace_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"bytes"
+	"fmt"
 	"math/rand"
 	"sort"
 	"testing"
@@ -184,5 +185,21 @@ func BenchmarkCombineTracesIdentical(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		CombineTraces(b1, b2)
+	}
+}
+
+func BenchmarkCombineTraceProtos(b *testing.B) {
+	sizes := []int{1, 10, 1000, 10000, 100000}
+
+	for _, size := range sizes {
+		b.Run(fmt.Sprint(size), func(b *testing.B) {
+			t1 := test.MakeTraceWithSpanCount(1, size, []byte{0x01, 0x02})
+			t2 := test.MakeTraceWithSpanCount(1, size, []byte{0x01, 0x03})
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				CombineTraceProtos(t1, t2)
+			}
+		})
 	}
 }


### PR DESCRIPTION
**What this PR does**:
Small optimization to CombineTraceProtos method to reuse hash instead of allocating a new one inside TokenForTraceID. This eliminates ~3 allocations per span.  Benchmarks were added to show effects for trace sizes between 1 and 100K spans.  Increment was also moved out of the loops.

Benchmarks before:
```
$ go test -bench . -benchmem -cpu=1
goos: darwin
goarch: amd64
pkg: github.com/grafana/tempo/pkg/util
BenchmarkCombineTraces                      13558	     98462 ns/op	   79911 B/op	    1724 allocs/op
BenchmarkCombineTracesIdentical          17060538	        79.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkCombineTraceProtos/1            10671867	       119 ns/op	      12 B/op	       3 allocs/op
BenchmarkCombineTraceProtos/10             596056	      2123 ns/op	     457 B/op	      33 allocs/op
BenchmarkCombineTraceProtos/1000             4954	    251206 ns/op	   71395 B/op	    3106 allocs/op
BenchmarkCombineTraceProtos/10000             464	   2502371 ns/op	  592041 B/op	   30474 allocs/op
BenchmarkCombineTraceProtos/100000             69	  34123675 ns/op	 5313627 B/op	  306487 allocs/op
PASS
ok  	github.com/grafana/tempo/pkg/util	11.794s
```

After:
```
$ go test -bench . -benchmem -cpu=1
goos: darwin
goarch: amd64
pkg: github.com/grafana/tempo/pkg/util
BenchmarkCombineTraces                      13867	     96550 ns/op	   79092 B/op	    1521 allocs/op
BenchmarkCombineTracesIdentical          16559887	        80.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkCombineTraceProtos/1            13449312	        91.8 ns/op	       4 B/op	       1 allocs/op
BenchmarkCombineTraceProtos/10             770596	      1693 ns/op	     341 B/op	       4 allocs/op
BenchmarkCombineTraceProtos/1000             5792	    210638 ns/op	   59404 B/op	     107 allocs/op
BenchmarkCombineTraceProtos/10000             558	   2120566 ns/op	  471926 B/op	     495 allocs/op
BenchmarkCombineTraceProtos/100000             84	  31763484 ns/op	 4125196 B/op	    7953 allocs/op
PASS
ok  	github.com/grafana/tempo/pkg/util	12.985s
```

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`