### PR TITLE
Reuse hash in instance.Push to reduce memory allocations

### DIFF
--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -222,7 +222,7 @@ func (i *instance) FindTraceByID(id []byte) (*tempopb.Trace, error) {
 
 	// live traces
 	i.tracesMtx.Lock()
-	if liveTrace, ok := i.traces[util.TokenForTraceID(id)]; ok {
+	if liveTrace, ok := i.traces[i.tokenForTraceID(id)]; ok {
 		foundBytes, err := proto.Marshal(liveTrace.trace)
 		if err != nil {
 			i.tracesMtx.Unlock()

--- a/modules/ingester/instance_test.go
+++ b/modules/ingester/instance_test.go
@@ -304,3 +304,22 @@ func BenchmarkInstancePushExistingTrace(b *testing.B) {
 		assert.NoError(b, err)
 	}
 }
+
+func BenchmarkInstanceFindTraceByID(b *testing.B) {
+	tempDir, err := ioutil.TempDir("/tmp", "")
+	assert.NoError(b, err, "unexpected error getting temp dir")
+	defer os.RemoveAll(tempDir)
+
+	instance := defaultInstance(b, tempDir)
+	traceID := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	request := test.MakeRequest(10, traceID)
+	err = instance.Push(context.Background(), request)
+	assert.NoError(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		trace, err := instance.FindTraceByID(traceID)
+		assert.NotNil(b, trace)
+		assert.NoError(b, err)
+	}
+}

--- a/modules/ingester/instance_test.go
+++ b/modules/ingester/instance_test.go
@@ -285,7 +285,8 @@ func BenchmarkInstancePush(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		// Rotate trace ID
 		binary.LittleEndian.PutUint32(request.Batch.InstrumentationLibrarySpans[0].Spans[0].TraceId, uint32(i))
-		instance.Push(context.Background(), request)
+		err = instance.Push(context.Background(), request)
+		assert.NoError(b, err)
 	}
 }
 
@@ -299,6 +300,7 @@ func BenchmarkInstancePushExistingTrace(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		instance.Push(context.Background(), request)
+		err = instance.Push(context.Background(), request)
+		assert.NoError(b, err)
 	}
 }


### PR DESCRIPTION
**What this PR does**:
Small optimization to ingester instance.getOrCreateTrace method to reuse hash instead of allocating a new one inside TokenForTraceID. This eliminates 1 allocation per Push.   Basic benchmarks were added:

Before:
```
$ go test -bench . -benchmem
goos: darwin
goarch: amd64
pkg: github.com/grafana/tempo/modules/ingester
BenchmarkInstancePush-12                 	 1817228	       650 ns/op	     197 B/op	       4 allocs/op
BenchmarkInstancePushExistingTrace-12    	 7747898	       152 ns/op	      47 B/op	       1 allocs/op
BenchmarkInstanceFindTraceByID-12        	   90445	     12661 ns/op	   11035 B/op	     209 allocs/op
PASS
ok  	github.com/grafana/tempo/modules/ingester	3.801s
```

After:
```
$ go test -bench . -benchmem       
goos: darwin
goarch: amd64
pkg: github.com/grafana/tempo/modules/ingester
BenchmarkInstancePush-12                 	 1887462	       644 ns/op	     190 B/op	       3 allocs/op
BenchmarkInstancePushExistingTrace-12    	 8306944	       138 ns/op	      40 B/op	       0 allocs/op
BenchmarkInstanceFindTraceByID-12        	   82716	     12498 ns/op	   11035 B/op	     208 allocs/op
PASS
ok  	github.com/grafana/tempo/modules/ingester	3.786s
```

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`