### PR TITLE
[DNM] adds dlq to handle flushes that error out

### DIFF
--- a/modules/ingester/config.go
+++ b/modules/ingester/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	MaxBlockDuration     time.Duration `yaml:"max_block_duration"`
 	CompleteBlockTimeout time.Duration `yaml:"complete_block_timeout"`
 	OverrideRingKey      string        `yaml:"override_ring_key"`
+	MaxFlushTries        int  `yaml:"max_flush_tries"`
 }
 
 // RegisterFlagsAndApplyDefaults registers the flags.

--- a/modules/ingester/config.go
+++ b/modules/ingester/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	MaxBlockDuration     time.Duration `yaml:"max_block_duration"`
 	CompleteBlockTimeout time.Duration `yaml:"complete_block_timeout"`
 	OverrideRingKey      string        `yaml:"override_ring_key"`
-	MaxFlushTries        int  `yaml:"max_flush_tries"`
+	MaxFlushTries        int           `yaml:"max_flush_tries"`
 }
 
 // RegisterFlagsAndApplyDefaults registers the flags.

--- a/pkg/flushqueues/exclusivequeues.go
+++ b/pkg/flushqueues/exclusivequeues.go
@@ -19,7 +19,7 @@ type ExclusiveQueues struct {
 func New(queues int, metric prometheus.Gauge) *ExclusiveQueues {
 	f := &ExclusiveQueues{
 		queues: make([]*util.PriorityQueue, queues),
-		dlq: util.NewPriorityQueue(metric),
+		dlq:    util.NewPriorityQueue(metric),
 		index:  atomic.NewInt32(0),
 	}
 
@@ -56,7 +56,6 @@ func (f *ExclusiveQueues) Requeue(op util.Op) {
 func (f *ExclusiveQueues) EnqueueInDLQ(op util.Op) {
 	f.dlq.Enqueue(op)
 }
-
 
 func (f *ExclusiveQueues) DequeueFromDQL() util.Op {
 	return f.dlq.Dequeue()


### PR DESCRIPTION
Do not merge, this is just a conceptual approach to avoid repeatedly slam the backend trying to flush.

**What this PR does**:

Without much information about the error, this is just a conceptual fix for badly behaved flushes. After failing `MaxFlushTries` times flushing the operation is moved into the dead-letter-queue that handles operations every 60 seconds.

1. After `MaxFlushTries` enqueues in DQL
2. After 60secs de-queues from DQL
3. Reset the `tries` counter and puts it back in the normal queue
4. Rinse and repeat

**Which issue(s) this PR fixes**:
Fixes #357

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`