### PR TITLE
Test bloom filter before finding in a complete block

### DIFF
--- a/tempodb/wal/complete_block.go
+++ b/tempodb/wal/complete_block.go
@@ -38,6 +38,10 @@ func (c *CompleteBlock) ObjectFilePath() string {
 }
 
 func (c *CompleteBlock) Find(id encoding.ID, combiner encoding.ObjectCombiner) ([]byte, error) {
+	if !c.bloom.Test(id) {
+		return nil, nil
+	}
+
 	file, err := c.file()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does**:
A performance improvement I noticed while reviewing the ingester query path.  A complete block should always have a valid bloom filter so we should test it before bothering to read the index/object file.