### PR TITLE
Exclude blocks in last active window from compaction

### DIFF
--- a/tempodb/compaction_block_selector_test.go
+++ b/tempodb/compaction_block_selector_test.go
@@ -539,6 +539,21 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 			expectedSecond: nil,
 			expectedHash2:  "",
 		},
+		{
+			name: "doesn't select blocks in last active window",
+			blocklist: []*encoding.BlockMeta{
+				{
+					BlockID:         uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+					EndTime:         now.Add(-activeWindowDuration),
+					CompactionLevel: 0,
+				},
+				{
+					BlockID:         uuid.MustParse("00000000-0000-0000-0000-000000000002"),
+					EndTime:         now.Add(-activeWindowDuration),
+					CompactionLevel: 0,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -569,7 +584,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 
 func TestTimeWindowBlockSelectorSort(t *testing.T) {
 	now := time.Now()
-	timeWindow := 12 * time.Hour
+	timeWindow := time.Hour
 
 	tests := []struct {
 		name      string


### PR DESCRIPTION
**What this PR does**:
Excludes blocks in the last active time window from compaction. This prevents errors from ownership conflicts where two compactors process the same block at the same time, which can occur at the boundary from active to inactive sharding schemes. 

**Example**: compactor A starts a compaction on data 23:59 ago, and 2 minutes later compactor B starts a compaction on data 24:01 ago.   The same blocks can be chosen by both, and compactor B will experience errors marking the blocks as compacted at the end of compaction.   Additionally the data in the shared blocks will be duplicated into the new blocks.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`