### PR TITLE
Disable polling ingesters

### DIFF
--- a/operations/helm/tempo-microservices/templates/configmap-tempo.yaml
+++ b/operations/helm/tempo-microservices/templates/configmap-tempo.yaml
@@ -30,7 +30,7 @@ data:
     storage:
         trace:
             {{- toYaml .Values.backend | nindent 12 }}
-            blocklist_poll: 5m
+            blocklist_poll: '0'
             memcached:
                 consistent_hash: true
                 host: memcached

--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -18,7 +18,7 @@
     compactor: null,
     storage: {
       trace: {
-        blocklist_poll: '5m',
+        blocklist_poll: '0',
         backend: $._config.backend,
         wal: {
           path: '/var/tempo/wal',
@@ -76,6 +76,7 @@
     },
     storage+: {
       trace+: {
+        blocklist_poll: '5m',
         pool+: {
           max_workers: 200,
         },


### PR DESCRIPTION
**What this PR does**:
Our helm and jsonnet deployments configure the ingesters to unnecessarily poll the blocklist.  This is a small cost, but it's unnecessary so let's eliminate it!

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`