### PR TITLE
Fix doc links and add space

### DIFF
--- a/docs/tempo/website/architecture/architecture.md
+++ b/docs/tempo/website/architecture/architecture.md
@@ -13,7 +13,7 @@ This document provides an overview of the major components that comprise Tempo. 
 ### Distributor
 
 Accepts spans in multiple formats including Jaeger, OpenTelemetry, Zipkin.
-Routes spans to ingesters by hashing the `traceID` and using a [distributed consistent hash ring](consistent-hash-ring/).
+Routes spans to ingesters by hashing the `traceID` and using a [distributed consistent hash ring]({{< relref "consistent-hash-ring" >}}).
 
 The distributor uses the receiver layer from the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector).
 For best performance it is recommended to ingest [OTel Proto](https://github.com/open-telemetry/opentelemetry-proto).  For this reason

--- a/docs/tempo/website/getting-started/_index.md
+++ b/docs/tempo/website/getting-started/_index.md
@@ -5,7 +5,7 @@ weight: 100
 
 # Getting started with Tempo
 
-Getting started with Tempo is easy.  For an application already instrumented for tracing, this guide can help quickly set it up with Tempo. If you're looking for a demo application to play around with Tempo, skip to the [examples with demo app]({{< relref "example-demo-app.md" >}})topic.
+Getting started with Tempo is easy.  For an application already instrumented for tracing, this guide can help quickly set it up with Tempo. If you're looking for a demo application to play around with Tempo, skip to the [examples with demo app]({{< relref "example-demo-app.md" >}}) topic.
 
 > **Note:** The Grafana Cloud Agent is already set up to use Tempo. Refer to the [configuration](https://github.com/grafana/agent/blob/master/docs/configuration-reference.md#tempo_config) and [example](https://github.com/grafana/agent/blob/master/example/docker-compose/agent/config/agent.yaml) for details.
 ### Step 1: Spin up Tempo backend

--- a/docs/tempo/website/getting-started/example-demo-app.md
+++ b/docs/tempo/website/getting-started/example-demo-app.md
@@ -4,7 +4,7 @@ title: Examples with demo app
 
 # Examples with demo app
 
-If you don't have an application to instrument at the moment, fret not! A number of [examples](https://github.com/grafana/tempo/tree/master/example) have been provided which show off various deployment and [configuration](../configuration) options.
+If you don't have an application to instrument at the moment, fret not! A number of [examples](https://github.com/grafana/tempo/tree/master/example) have been provided which show off various deployment and [configuration]({{< relref "../configuration" >}}) options.
 
 Some highlights:
 - [Configuration](https://github.com/grafana/tempo/blob/master/example/docker-compose/etc/tempo-s3-minio.yaml)


### PR DESCRIPTION
Previously the markdown links were merging the relative url with the url
of the current page, rather than the base url of the parent folder. E.g.
we were linking to architecture/architecture/consistent-hash-ring instead
of architecture/consistent-hash-ring).

Used relrefs for fixing links instead of modifying the markdown link, as
relrefs will throw errors if the page doesn't exist.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Minor documentation update for broken links and a whitespace. 

Tested with `make docs` and checking the updated links worked locally. Also ran `make docs-test`.

**Which issue(s) this PR fixes**:
~Fixes #<issue number>~

**Checklist**
~- [ ] Tests updated~
~- [ ] Documentation added~
~- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~