### PR TITLE
Additional refactoring for versioned blocks

### DIFF
--- a/cmd/tempo-cli/main.go
+++ b/cmd/tempo-cli/main.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/cmd/tempo/app"
+	"github.com/grafana/tempo/tempodb/backend"
 	tempodb_backend "github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/local"
-	"github.com/grafana/tempo/tempodb/encoding"
 	"gopkg.in/yaml.v2"
 
 	"github.com/alecthomas/kong"
@@ -119,7 +119,7 @@ type unifiedBlockMeta struct {
 	compacted       bool
 }
 
-func getMeta(meta *encoding.BlockMeta, compactedMeta *encoding.CompactedBlockMeta, windowRange time.Duration) unifiedBlockMeta {
+func getMeta(meta *backend.BlockMeta, compactedMeta *backend.CompactedBlockMeta, windowRange time.Duration) unifiedBlockMeta {
 	if meta != nil {
 		return unifiedBlockMeta{
 			id:              meta.BlockID,

--- a/tempodb/backend/backend.go
+++ b/tempodb/backend/backend.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	"github.com/grafana/tempo/tempodb/encoding"
 )
 
 var (
@@ -17,16 +16,16 @@ var (
 type AppendTracker interface{}
 
 type Writer interface {
-	Write(ctx context.Context, meta *encoding.BlockMeta, bBloom [][]byte, bIndex []byte, objectFilePath string) error
+	Write(ctx context.Context, meta *BlockMeta, bBloom [][]byte, bIndex []byte, objectFilePath string) error
 
-	WriteBlockMeta(ctx context.Context, tracker AppendTracker, meta *encoding.BlockMeta, bBloom [][]byte, bIndex []byte) error
-	AppendObject(ctx context.Context, tracker AppendTracker, meta *encoding.BlockMeta, bObject []byte) (AppendTracker, error)
+	WriteBlockMeta(ctx context.Context, tracker AppendTracker, meta *BlockMeta, bBloom [][]byte, bIndex []byte) error
+	AppendObject(ctx context.Context, tracker AppendTracker, meta *BlockMeta, bObject []byte) (AppendTracker, error)
 }
 
 type Reader interface {
 	Tenants(ctx context.Context) ([]string, error)
 	Blocks(ctx context.Context, tenantID string) ([]uuid.UUID, error)
-	BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*encoding.BlockMeta, error)
+	BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*BlockMeta, error)
 	Bloom(ctx context.Context, blockID uuid.UUID, tenantID string, bloomShard int) ([]byte, error)
 	Index(ctx context.Context, blockID uuid.UUID, tenantID string) ([]byte, error)
 	Object(ctx context.Context, blockID uuid.UUID, tenantID string, offset uint64, buffer []byte) error
@@ -37,5 +36,5 @@ type Reader interface {
 type Compactor interface {
 	MarkBlockCompacted(blockID uuid.UUID, tenantID string) error
 	ClearBlock(blockID uuid.UUID, tenantID string) error
-	CompactedBlockMeta(blockID uuid.UUID, tenantID string) (*encoding.CompactedBlockMeta, error)
+	CompactedBlockMeta(blockID uuid.UUID, tenantID string) (*CompactedBlockMeta, error)
 }

--- a/tempodb/backend/block_meta.go
+++ b/tempodb/backend/block_meta.go
@@ -1,4 +1,4 @@
-package encoding
+package backend
 
 import (
 	"bytes"
@@ -16,8 +16,8 @@ type CompactedBlockMeta struct {
 type BlockMeta struct {
 	Version         string    `json:"format"`
 	BlockID         uuid.UUID `json:"blockID"`
-	MinID           ID        `json:"minID"`
-	MaxID           ID        `json:"maxID"`
+	MinID           []byte    `json:"minID"`
+	MaxID           []byte    `json:"maxID"`
 	TenantID        string    `json:"tenantID"`
 	StartTime       time.Time `json:"startTime"`
 	EndTime         time.Time `json:"endTime"`
@@ -40,7 +40,7 @@ func NewBlockMeta(tenantID string, blockID uuid.UUID) *BlockMeta {
 	return b
 }
 
-func (b *BlockMeta) ObjectAdded(id ID) {
+func (b *BlockMeta) ObjectAdded(id []byte) {
 	b.EndTime = time.Now()
 
 	if len(b.MinID) == 0 || bytes.Compare(id, b.MinID) == -1 {

--- a/tempodb/backend/block_meta_test.go
+++ b/tempodb/backend/block_meta_test.go
@@ -1,4 +1,4 @@
-package encoding
+package backend
 
 import (
 	"bytes"

--- a/tempodb/backend/diskcache/cache.go
+++ b/tempodb/backend/diskcache/cache.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/grafana/tempo/tempodb/backend"
-	"github.com/grafana/tempo/tempodb/encoding"
 
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
@@ -93,7 +92,7 @@ func (r *reader) Blocks(ctx context.Context, tenantID string) ([]uuid.UUID, erro
 	return r.next.Blocks(ctx, tenantID)
 }
 
-func (r *reader) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*encoding.BlockMeta, error) {
+func (r *reader) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*backend.BlockMeta, error) {
 	return r.next.BlockMeta(ctx, blockID, tenantID)
 }
 

--- a/tempodb/backend/gcs/compactor.go
+++ b/tempodb/backend/gcs/compactor.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/util"
-	"github.com/grafana/tempo/tempodb/encoding"
 	"google.golang.org/api/iterator"
 )
 
@@ -64,7 +63,7 @@ func (rw *readerWriter) ClearBlock(blockID uuid.UUID, tenantID string) error {
 	return nil
 }
 
-func (rw *readerWriter) CompactedBlockMeta(blockID uuid.UUID, tenantID string) (*encoding.CompactedBlockMeta, error) {
+func (rw *readerWriter) CompactedBlockMeta(blockID uuid.UUID, tenantID string) (*backend.CompactedBlockMeta, error) {
 	name := util.CompactedMetaFileName(blockID, tenantID)
 
 	bytes, modTime, err := rw.readAllWithModTime(context.Background(), name)
@@ -75,7 +74,7 @@ func (rw *readerWriter) CompactedBlockMeta(blockID uuid.UUID, tenantID string) (
 		return nil, err
 	}
 
-	out := &encoding.CompactedBlockMeta{}
+	out := &backend.CompactedBlockMeta{}
 	err = json.Unmarshal(bytes, out)
 	if err != nil {
 		return nil, err

--- a/tempodb/backend/gcs/gcs.go
+++ b/tempodb/backend/gcs/gcs.go
@@ -19,7 +19,6 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/tempodb/backend"
-	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/opentracing/opentracing-go"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
@@ -80,7 +79,7 @@ func New(cfg *Config) (backend.Reader, backend.Writer, backend.Compactor, error)
 	return rw, rw, rw, nil
 }
 
-func (rw *readerWriter) Write(ctx context.Context, meta *encoding.BlockMeta, bBloom [][]byte, bIndex []byte, objectFilePath string) error {
+func (rw *readerWriter) Write(ctx context.Context, meta *backend.BlockMeta, bBloom [][]byte, bIndex []byte, objectFilePath string) error {
 	blockID := meta.BlockID
 	tenantID := meta.TenantID
 
@@ -115,7 +114,7 @@ func (rw *readerWriter) Write(ctx context.Context, meta *encoding.BlockMeta, bBl
 	return nil
 }
 
-func (rw *readerWriter) WriteBlockMeta(ctx context.Context, tracker backend.AppendTracker, meta *encoding.BlockMeta, bBloom [][]byte, bIndex []byte) error {
+func (rw *readerWriter) WriteBlockMeta(ctx context.Context, tracker backend.AppendTracker, meta *backend.BlockMeta, bBloom [][]byte, bIndex []byte) error {
 	if tracker != nil {
 		w := tracker.(*storage.Writer)
 		_ = w.Close()
@@ -150,7 +149,7 @@ func (rw *readerWriter) WriteBlockMeta(ctx context.Context, tracker backend.Appe
 	return nil
 }
 
-func (rw *readerWriter) AppendObject(ctx context.Context, tracker backend.AppendTracker, meta *encoding.BlockMeta, bObject []byte) (backend.AppendTracker, error) {
+func (rw *readerWriter) AppendObject(ctx context.Context, tracker backend.AppendTracker, meta *backend.BlockMeta, bObject []byte) (backend.AppendTracker, error) {
 	var w *storage.Writer
 	if tracker == nil {
 		blockID := meta.BlockID
@@ -224,7 +223,7 @@ func (rw *readerWriter) Blocks(ctx context.Context, tenantID string) ([]uuid.UUI
 	return blocks, warning
 }
 
-func (rw *readerWriter) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*encoding.BlockMeta, error) {
+func (rw *readerWriter) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*backend.BlockMeta, error) {
 	name := util.MetaFileName(blockID, tenantID)
 
 	bytes, err := rw.readAll(ctx, name)
@@ -235,7 +234,7 @@ func (rw *readerWriter) BlockMeta(ctx context.Context, blockID uuid.UUID, tenant
 		return nil, errors.Wrap(err, "read block meta from gcs")
 	}
 
-	out := &encoding.BlockMeta{}
+	out := &backend.BlockMeta{}
 	err = json.Unmarshal(bytes, out)
 	if err != nil {
 		return nil, err

--- a/tempodb/backend/local/compactor.go
+++ b/tempodb/backend/local/compactor.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/grafana/tempo/tempodb/backend"
-	"github.com/grafana/tempo/tempodb/encoding"
 )
 
 func (rw *readerWriter) MarkBlockCompacted(blockID uuid.UUID, tenantID string) error {
@@ -33,7 +32,7 @@ func (rw *readerWriter) ClearBlock(blockID uuid.UUID, tenantID string) error {
 	return os.RemoveAll(rw.rootPath(blockID, tenantID))
 }
 
-func (rw *readerWriter) CompactedBlockMeta(blockID uuid.UUID, tenantID string) (*encoding.CompactedBlockMeta, error) {
+func (rw *readerWriter) CompactedBlockMeta(blockID uuid.UUID, tenantID string) (*backend.CompactedBlockMeta, error) {
 	filename := rw.compactedMetaFileName(blockID, tenantID)
 
 	fi, err := os.Stat(filename)
@@ -49,7 +48,7 @@ func (rw *readerWriter) CompactedBlockMeta(blockID uuid.UUID, tenantID string) (
 		return nil, err
 	}
 
-	out := &encoding.CompactedBlockMeta{}
+	out := &backend.CompactedBlockMeta{}
 	err = json.Unmarshal(bytes, out)
 	if err != nil {
 		return nil, err

--- a/tempodb/backend/local/local.go
+++ b/tempodb/backend/local/local.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/tempodb/backend"
-	"github.com/grafana/tempo/tempodb/encoding"
 )
 
 type readerWriter struct {
@@ -32,7 +31,7 @@ func New(cfg *Config) (backend.Reader, backend.Writer, backend.Compactor, error)
 	return rw, rw, rw, nil
 }
 
-func (rw *readerWriter) Write(ctx context.Context, meta *encoding.BlockMeta, bBloom [][]byte, bIndex []byte, tracesFilePath string) error {
+func (rw *readerWriter) Write(ctx context.Context, meta *backend.BlockMeta, bBloom [][]byte, bIndex []byte, tracesFilePath string) error {
 	err := rw.WriteBlockMeta(ctx, nil, meta, bBloom, bIndex)
 	if err != nil {
 		return err
@@ -70,7 +69,7 @@ func (rw *readerWriter) Write(ctx context.Context, meta *encoding.BlockMeta, bBl
 	return err
 }
 
-func (rw *readerWriter) WriteBlockMeta(_ context.Context, tracker backend.AppendTracker, meta *encoding.BlockMeta, bBloom [][]byte, bIndex []byte) error {
+func (rw *readerWriter) WriteBlockMeta(_ context.Context, tracker backend.AppendTracker, meta *backend.BlockMeta, bBloom [][]byte, bIndex []byte) error {
 	blockID := meta.BlockID
 	tenantID := meta.TenantID
 
@@ -116,7 +115,7 @@ func (rw *readerWriter) WriteBlockMeta(_ context.Context, tracker backend.Append
 	return nil
 }
 
-func (rw *readerWriter) AppendObject(ctx context.Context, tracker backend.AppendTracker, meta *encoding.BlockMeta, bObject []byte) (backend.AppendTracker, error) {
+func (rw *readerWriter) AppendObject(ctx context.Context, tracker backend.AppendTracker, meta *backend.BlockMeta, bObject []byte) (backend.AppendTracker, error) {
 	blockID := meta.BlockID
 	tenantID := meta.TenantID
 
@@ -186,7 +185,7 @@ func (rw *readerWriter) Blocks(ctx context.Context, tenantID string) ([]uuid.UUI
 	return blocks, warning
 }
 
-func (rw *readerWriter) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*encoding.BlockMeta, error) {
+func (rw *readerWriter) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*backend.BlockMeta, error) {
 	filename := rw.metaFileName(blockID, tenantID)
 	bytes, err := ioutil.ReadFile(filename)
 	if os.IsNotExist(err) {
@@ -196,7 +195,7 @@ func (rw *readerWriter) BlockMeta(ctx context.Context, blockID uuid.UUID, tenant
 		return nil, err
 	}
 
-	out := &encoding.BlockMeta{}
+	out := &backend.BlockMeta{}
 	err = json.Unmarshal(bytes, out)
 	if err != nil {
 		return nil, err

--- a/tempodb/backend/local/local_test.go
+++ b/tempodb/backend/local/local_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/tempodb/backend"
-	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/grafana/tempo/tempodb/encoding/bloom"
 	"github.com/stretchr/testify/assert"
 )
@@ -37,7 +36,7 @@ func TestReadWrite(t *testing.T) {
 		tenantIDs = append(tenantIDs, fmt.Sprintf("%d", rand.Int()))
 	}
 
-	fakeMeta := &encoding.BlockMeta{
+	fakeMeta := &backend.BlockMeta{
 		BlockID: blockID,
 	}
 
@@ -106,7 +105,7 @@ func TestWriteFail(t *testing.T) {
 
 	blockID := uuid.New()
 	tenantID := "fake"
-	fakeMeta := &encoding.BlockMeta{
+	fakeMeta := &backend.BlockMeta{
 		BlockID:  blockID,
 		TenantID: tenantID,
 	}
@@ -139,7 +138,7 @@ func TestCompaction(t *testing.T) {
 		tenantIDs = append(tenantIDs, fmt.Sprintf("%d", rand.Int()))
 	}
 
-	fakeMeta := &encoding.BlockMeta{
+	fakeMeta := &backend.BlockMeta{
 		BlockID: blockID,
 	}
 

--- a/tempodb/backend/memcached/cache.go
+++ b/tempodb/backend/memcached/cache.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
 	"github.com/go-kit/kit/log"
 	"github.com/grafana/tempo/tempodb/backend"
-	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/google/uuid"
@@ -69,7 +68,7 @@ func (r *readerWriter) Blocks(ctx context.Context, tenantID string) ([]uuid.UUID
 	return r.nextReader.Blocks(ctx, tenantID)
 }
 
-func (r *readerWriter) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*encoding.BlockMeta, error) {
+func (r *readerWriter) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*backend.BlockMeta, error) {
 	return r.nextReader.BlockMeta(ctx, blockID, tenantID)
 }
 
@@ -113,7 +112,7 @@ func (r *readerWriter) Shutdown() {
 }
 
 // Writer
-func (r *readerWriter) Write(ctx context.Context, meta *encoding.BlockMeta, bBloom [][]byte, bIndex []byte, objectFilePath string) error {
+func (r *readerWriter) Write(ctx context.Context, meta *backend.BlockMeta, bBloom [][]byte, bIndex []byte, objectFilePath string) error {
 	for i, b := range bBloom {
 		r.set(ctx, bloomKey(meta.BlockID, meta.TenantID, typeBloom, i), b)
 	}
@@ -122,7 +121,7 @@ func (r *readerWriter) Write(ctx context.Context, meta *encoding.BlockMeta, bBlo
 	return r.nextWriter.Write(ctx, meta, bBloom, bIndex, objectFilePath)
 }
 
-func (r *readerWriter) WriteBlockMeta(ctx context.Context, tracker backend.AppendTracker, meta *encoding.BlockMeta, bBloom [][]byte, bIndex []byte) error {
+func (r *readerWriter) WriteBlockMeta(ctx context.Context, tracker backend.AppendTracker, meta *backend.BlockMeta, bBloom [][]byte, bIndex []byte) error {
 	for i, b := range bBloom {
 		r.set(ctx, bloomKey(meta.BlockID, meta.TenantID, typeBloom, i), b)
 	}
@@ -131,7 +130,7 @@ func (r *readerWriter) WriteBlockMeta(ctx context.Context, tracker backend.Appen
 	return r.nextWriter.WriteBlockMeta(ctx, tracker, meta, bBloom, bIndex)
 }
 
-func (r *readerWriter) AppendObject(ctx context.Context, tracker backend.AppendTracker, meta *encoding.BlockMeta, bObject []byte) (backend.AppendTracker, error) {
+func (r *readerWriter) AppendObject(ctx context.Context, tracker backend.AppendTracker, meta *backend.BlockMeta, bObject []byte) (backend.AppendTracker, error) {
 	return r.nextWriter.AppendObject(ctx, tracker, meta, bObject)
 }
 

--- a/tempodb/backend/memcached/cache_test.go
+++ b/tempodb/backend/memcached/cache_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/tempodb/backend"
-	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )
@@ -17,7 +16,7 @@ import (
 type mockReader struct {
 	tenants []string
 	blocks  []uuid.UUID
-	meta    *encoding.BlockMeta
+	meta    *backend.BlockMeta
 	bloom   []byte
 	index   []byte
 	object  []byte
@@ -29,7 +28,7 @@ func (m *mockReader) Tenants(ctx context.Context) ([]string, error) {
 func (m *mockReader) Blocks(ctx context.Context, tenantID string) ([]uuid.UUID, error) {
 	return m.blocks, nil
 }
-func (m *mockReader) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*encoding.BlockMeta, error) {
+func (m *mockReader) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*backend.BlockMeta, error) {
 	return m.meta, nil
 }
 func (m *mockReader) Bloom(ctx context.Context, blockID uuid.UUID, tenantID string, shardNum int) ([]byte, error) {
@@ -47,13 +46,13 @@ func (m *mockReader) Shutdown() {}
 type mockWriter struct {
 }
 
-func (m *mockWriter) Write(ctx context.Context, meta *encoding.BlockMeta, bBloom [][]byte, bIndex []byte, objectFilePath string) error {
+func (m *mockWriter) Write(ctx context.Context, meta *backend.BlockMeta, bBloom [][]byte, bIndex []byte, objectFilePath string) error {
 	return nil
 }
-func (m *mockWriter) WriteBlockMeta(ctx context.Context, tracker backend.AppendTracker, meta *encoding.BlockMeta, bBloom [][]byte, bIndex []byte) error {
+func (m *mockWriter) WriteBlockMeta(ctx context.Context, tracker backend.AppendTracker, meta *backend.BlockMeta, bBloom [][]byte, bIndex []byte) error {
 	return nil
 }
-func (m *mockWriter) AppendObject(ctx context.Context, tracker backend.AppendTracker, meta *encoding.BlockMeta, bObject []byte) (backend.AppendTracker, error) {
+func (m *mockWriter) AppendObject(ctx context.Context, tracker backend.AppendTracker, meta *backend.BlockMeta, bObject []byte) (backend.AppendTracker, error) {
 	return nil, nil
 }
 
@@ -86,13 +85,13 @@ func TestCache(t *testing.T) {
 		name            string
 		readerTenants   []string
 		readerBlocks    []uuid.UUID
-		readerMeta      *encoding.BlockMeta
+		readerMeta      *backend.BlockMeta
 		readerBloom     []byte
 		readerIndex     []byte
 		readerObject    []byte
 		expectedTenants []string
 		expectedBlocks  []uuid.UUID
-		expectedMeta    *encoding.BlockMeta
+		expectedMeta    *backend.BlockMeta
 		expectedBloom   []byte
 		expectedIndex   []byte
 		expectedObject  []byte

--- a/tempodb/backend/redis/cache.go
+++ b/tempodb/backend/redis/cache.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
 	"github.com/go-kit/kit/log"
 	"github.com/grafana/tempo/tempodb/backend"
-	"github.com/grafana/tempo/tempodb/encoding"
 
 	"github.com/google/uuid"
 )
@@ -60,7 +59,7 @@ func (r *readerWriter) Blocks(ctx context.Context, tenantID string) ([]uuid.UUID
 	return r.nextReader.Blocks(ctx, tenantID)
 }
 
-func (r *readerWriter) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*encoding.BlockMeta, error) {
+func (r *readerWriter) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*backend.BlockMeta, error) {
 	return r.nextReader.BlockMeta(ctx, blockID, tenantID)
 }
 
@@ -104,7 +103,7 @@ func (r *readerWriter) Shutdown() {
 }
 
 // Writer
-func (r *readerWriter) Write(ctx context.Context, meta *encoding.BlockMeta, bBloom [][]byte, bIndex []byte, objectFilePath string) error {
+func (r *readerWriter) Write(ctx context.Context, meta *backend.BlockMeta, bBloom [][]byte, bIndex []byte, objectFilePath string) error {
 	for i, b := range bBloom {
 		r.set(ctx, bloomKey(meta.BlockID, meta.TenantID, i), b)
 	}
@@ -113,7 +112,7 @@ func (r *readerWriter) Write(ctx context.Context, meta *encoding.BlockMeta, bBlo
 	return r.nextWriter.Write(ctx, meta, bBloom, bIndex, objectFilePath)
 }
 
-func (r *readerWriter) WriteBlockMeta(ctx context.Context, tracker backend.AppendTracker, meta *encoding.BlockMeta, bBloom [][]byte, bIndex []byte) error {
+func (r *readerWriter) WriteBlockMeta(ctx context.Context, tracker backend.AppendTracker, meta *backend.BlockMeta, bBloom [][]byte, bIndex []byte) error {
 	for i, b := range bBloom {
 		r.set(ctx, bloomKey(meta.BlockID, meta.TenantID, i), b)
 	}
@@ -122,7 +121,7 @@ func (r *readerWriter) WriteBlockMeta(ctx context.Context, tracker backend.Appen
 	return r.nextWriter.WriteBlockMeta(ctx, tracker, meta, bBloom, bIndex)
 }
 
-func (r *readerWriter) AppendObject(ctx context.Context, tracker backend.AppendTracker, meta *encoding.BlockMeta, bObject []byte) (backend.AppendTracker, error) {
+func (r *readerWriter) AppendObject(ctx context.Context, tracker backend.AppendTracker, meta *backend.BlockMeta, bObject []byte) (backend.AppendTracker, error) {
 	return r.nextWriter.AppendObject(ctx, tracker, meta, bObject)
 }
 

--- a/tempodb/backend/redis/cache_test.go
+++ b/tempodb/backend/redis/cache_test.go
@@ -9,14 +9,13 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/tempodb/backend"
-	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/stretchr/testify/assert"
 )
 
 type mockReader struct {
 	tenants []string
 	blocks  []uuid.UUID
-	meta    *encoding.BlockMeta
+	meta    *backend.BlockMeta
 	bloom   []byte
 	index   []byte
 	object  []byte
@@ -28,7 +27,7 @@ func (m *mockReader) Tenants(ctx context.Context) ([]string, error) {
 func (m *mockReader) Blocks(ctx context.Context, tenantID string) ([]uuid.UUID, error) {
 	return m.blocks, nil
 }
-func (m *mockReader) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*encoding.BlockMeta, error) {
+func (m *mockReader) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*backend.BlockMeta, error) {
 	return m.meta, nil
 }
 func (m *mockReader) Bloom(ctx context.Context, blockID uuid.UUID, tenantID string, shardNum int) ([]byte, error) {
@@ -46,13 +45,13 @@ func (m *mockReader) Shutdown() {}
 type mockWriter struct {
 }
 
-func (m *mockWriter) Write(ctx context.Context, meta *encoding.BlockMeta, bBloom [][]byte, bIndex []byte, objectFilePath string) error {
+func (m *mockWriter) Write(ctx context.Context, meta *backend.BlockMeta, bBloom [][]byte, bIndex []byte, objectFilePath string) error {
 	return nil
 }
-func (m *mockWriter) WriteBlockMeta(ctx context.Context, tracker backend.AppendTracker, meta *encoding.BlockMeta, bBloom [][]byte, bIndex []byte) error {
+func (m *mockWriter) WriteBlockMeta(ctx context.Context, tracker backend.AppendTracker, meta *backend.BlockMeta, bBloom [][]byte, bIndex []byte) error {
 	return nil
 }
-func (m *mockWriter) AppendObject(ctx context.Context, tracker backend.AppendTracker, meta *encoding.BlockMeta, bObject []byte) (backend.AppendTracker, error) {
+func (m *mockWriter) AppendObject(ctx context.Context, tracker backend.AppendTracker, meta *backend.BlockMeta, bObject []byte) (backend.AppendTracker, error) {
 	return nil, nil
 }
 
@@ -65,13 +64,13 @@ func TestCache(t *testing.T) {
 		name            string
 		readerTenants   []string
 		readerBlocks    []uuid.UUID
-		readerMeta      *encoding.BlockMeta
+		readerMeta      *backend.BlockMeta
 		readerBloom     []byte
 		readerIndex     []byte
 		readerObject    []byte
 		expectedTenants []string
 		expectedBlocks  []uuid.UUID
-		expectedMeta    *encoding.BlockMeta
+		expectedMeta    *backend.BlockMeta
 		expectedBloom   []byte
 		expectedIndex   []byte
 		expectedObject  []byte

--- a/tempodb/backend/s3/compactor.go
+++ b/tempodb/backend/s3/compactor.go
@@ -11,7 +11,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/util"
-	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/pkg/errors"
 )
 
@@ -69,7 +68,7 @@ func (rw *readerWriter) ClearBlock(blockID uuid.UUID, tenantID string) error {
 	return nil
 }
 
-func (rw *readerWriter) CompactedBlockMeta(blockID uuid.UUID, tenantID string) (*encoding.CompactedBlockMeta, error) {
+func (rw *readerWriter) CompactedBlockMeta(blockID uuid.UUID, tenantID string) (*backend.CompactedBlockMeta, error) {
 	if len(tenantID) == 0 {
 		return nil, backend.ErrEmptyTenantID
 	}
@@ -85,7 +84,7 @@ func (rw *readerWriter) CompactedBlockMeta(blockID uuid.UUID, tenantID string) (
 		return nil, errors.Wrapf(err, "error fetching compacted meta file %s", compactedMetaFileName)
 	}
 
-	out := &encoding.CompactedBlockMeta{}
+	out := &backend.CompactedBlockMeta{}
 	err = json.Unmarshal(bytes, out)
 	if err != nil {
 		return nil, err

--- a/tempodb/compaction_block_selector_test.go
+++ b/tempodb/compaction_block_selector_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/grafana/tempo/tempodb/encoding"
+	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,12 +17,12 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		blocklist      []*encoding.BlockMeta
+		blocklist      []*backend.BlockMeta
 		minInputBlocks int // optional, defaults to global const
 		maxInputBlocks int // optional, defaults to global const
-		expected       []*encoding.BlockMeta
+		expected       []*backend.BlockMeta
 		expectedHash   string
-		expectedSecond []*encoding.BlockMeta
+		expectedSecond []*backend.BlockMeta
 		expectedHash2  string
 	}{
 		{
@@ -32,12 +32,12 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 		},
 		{
 			name:      "empty - nil",
-			blocklist: []*encoding.BlockMeta{},
+			blocklist: []*backend.BlockMeta{},
 			expected:  nil,
 		},
 		{
 			name: "only two",
-			blocklist: []*encoding.BlockMeta{
+			blocklist: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000000"),
 					EndTime: now,
@@ -47,7 +47,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 					EndTime: now,
 				},
 			},
-			expected: []*encoding.BlockMeta{
+			expected: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000000"),
 					EndTime: now,
@@ -61,7 +61,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 		},
 		{
 			name: "choose smallest two",
-			blocklist: []*encoding.BlockMeta{
+			blocklist: []*backend.BlockMeta{
 				{
 					BlockID:      uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 					TotalObjects: 0,
@@ -79,7 +79,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 				},
 			},
 			maxInputBlocks: 2,
-			expected: []*encoding.BlockMeta{
+			expected: []*backend.BlockMeta{
 				{
 					BlockID:      uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 					TotalObjects: 0,
@@ -95,7 +95,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 		},
 		{
 			name: "different windows",
-			blocklist: []*encoding.BlockMeta{
+			blocklist: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 					EndTime: now,
@@ -113,7 +113,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 					EndTime: now.Add(-timeWindow),
 				},
 			},
-			expected: []*encoding.BlockMeta{
+			expected: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 					EndTime: now,
@@ -124,7 +124,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 				},
 			},
 			expectedHash: fmt.Sprintf("%v-%v-%v", tenantID, 0, now.Unix()),
-			expectedSecond: []*encoding.BlockMeta{
+			expectedSecond: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000000"),
 					EndTime: now.Add(-timeWindow),
@@ -138,7 +138,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 		},
 		{
 			name: "different sizes",
-			blocklist: []*encoding.BlockMeta{
+			blocklist: []*backend.BlockMeta{
 				{
 					BlockID:      uuid.MustParse("00000000-0000-0000-0000-000000000004"),
 					EndTime:      now,
@@ -161,7 +161,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 				},
 			},
 			maxInputBlocks: 2,
-			expected: []*encoding.BlockMeta{
+			expected: []*backend.BlockMeta{
 				{
 					BlockID:      uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 					EndTime:      now,
@@ -174,7 +174,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 				},
 			},
 			expectedHash: fmt.Sprintf("%v-%v-%v", tenantID, 0, now.Unix()),
-			expectedSecond: []*encoding.BlockMeta{
+			expectedSecond: []*backend.BlockMeta{
 				{
 					BlockID:      uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 					EndTime:      now,
@@ -190,7 +190,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 		},
 		{
 			name: "different compaction lvls",
-			blocklist: []*encoding.BlockMeta{
+			blocklist: []*backend.BlockMeta{
 				{
 					BlockID:         uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 					EndTime:         now,
@@ -210,7 +210,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 					EndTime: now,
 				},
 			},
-			expected: []*encoding.BlockMeta{
+			expected: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000000"),
 					EndTime: now,
@@ -221,7 +221,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 				},
 			},
 			expectedHash: fmt.Sprintf("%v-%v-%v", tenantID, 0, now.Unix()),
-			expectedSecond: []*encoding.BlockMeta{
+			expectedSecond: []*backend.BlockMeta{
 				{
 					BlockID:         uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 					EndTime:         now,
@@ -237,7 +237,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 		},
 		{
 			name: "active time window vs not",
-			blocklist: []*encoding.BlockMeta{
+			blocklist: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 					EndTime: now,
@@ -262,7 +262,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 					CompactionLevel: 0,
 				},
 			},
-			expected: []*encoding.BlockMeta{
+			expected: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 					EndTime: now,
@@ -273,7 +273,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 				},
 			},
 			expectedHash: fmt.Sprintf("%v-%v-%v", tenantID, 0, now.Unix()),
-			expectedSecond: []*encoding.BlockMeta{
+			expectedSecond: []*backend.BlockMeta{
 				{
 					BlockID:         uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 					EndTime:         now.Add(-activeWindowDuration - time.Minute),
@@ -289,7 +289,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 		},
 		{
 			name: "choose lowest compaction level",
-			blocklist: []*encoding.BlockMeta{
+			blocklist: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 					EndTime: now,
@@ -317,7 +317,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 					EndTime: now.Add(-timeWindow),
 				},
 			},
-			expected: []*encoding.BlockMeta{
+			expected: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 					EndTime: now,
@@ -328,7 +328,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 				},
 			},
 			expectedHash: fmt.Sprintf("%v-%v-%v", tenantID, 0, now.Unix()),
-			expectedSecond: []*encoding.BlockMeta{
+			expectedSecond: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000004"),
 					EndTime: now.Add(-timeWindow),
@@ -342,7 +342,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 		},
 		{
 			name: "doesn't choose across time windows",
-			blocklist: []*encoding.BlockMeta{
+			blocklist: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 					EndTime: now,
@@ -359,7 +359,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 		},
 		{
 			name: "doesn't exceed max compaction objects",
-			blocklist: []*encoding.BlockMeta{
+			blocklist: []*backend.BlockMeta{
 				{
 					BlockID:      uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 					TotalObjects: 99,
@@ -378,7 +378,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 		},
 		{
 			name: "Returns as many blocks as possible without exceeding max compaction objects",
-			blocklist: []*encoding.BlockMeta{
+			blocklist: []*backend.BlockMeta{
 				{
 					BlockID:      uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 					TotalObjects: 50,
@@ -394,7 +394,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 					TotalObjects: 50,
 					EndTime:      now,
 				}},
-			expected: []*encoding.BlockMeta{
+			expected: []*backend.BlockMeta{
 				{
 					BlockID:      uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 					TotalObjects: 50,
@@ -414,7 +414,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 			// First compaction gets 3 blocks, second compaction gets 2 more
 			name:           "choose more than 2 blocks",
 			maxInputBlocks: 3,
-			blocklist: []*encoding.BlockMeta{
+			blocklist: []*backend.BlockMeta{
 				{
 					BlockID:      uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 					EndTime:      now,
@@ -441,7 +441,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 					TotalObjects: 5,
 				},
 			},
-			expected: []*encoding.BlockMeta{
+			expected: []*backend.BlockMeta{
 				{
 					BlockID:      uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 					EndTime:      now,
@@ -459,7 +459,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 				},
 			},
 			expectedHash: fmt.Sprintf("%v-%v-%v", tenantID, 0, now.Unix()),
-			expectedSecond: []*encoding.BlockMeta{
+			expectedSecond: []*backend.BlockMeta{
 				{
 					BlockID:      uuid.MustParse("00000000-0000-0000-0000-000000000004"),
 					EndTime:      now,
@@ -475,7 +475,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 		},
 		{
 			name: "honors minimum block count",
-			blocklist: []*encoding.BlockMeta{
+			blocklist: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 					EndTime: now,
@@ -494,7 +494,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 		},
 		{
 			name: "can choose blocks not at the lowest compaction level",
-			blocklist: []*encoding.BlockMeta{
+			blocklist: []*backend.BlockMeta{
 				{
 					BlockID:         uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 					EndTime:         now,
@@ -518,7 +518,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 			},
 			minInputBlocks: 3,
 			maxInputBlocks: 3,
-			expected: []*encoding.BlockMeta{
+			expected: []*backend.BlockMeta{
 				{
 					BlockID:         uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 					EndTime:         now,
@@ -541,7 +541,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 		},
 		{
 			name: "doesn't select blocks in last active window",
-			blocklist: []*encoding.BlockMeta{
+			blocklist: []*backend.BlockMeta{
 				{
 					BlockID:         uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 					EndTime:         now.Add(-activeWindowDuration),
@@ -588,8 +588,8 @@ func TestTimeWindowBlockSelectorSort(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		blocklist []*encoding.BlockMeta
-		expected  []*encoding.BlockMeta
+		blocklist []*backend.BlockMeta
+		expected  []*backend.BlockMeta
 	}{
 		{
 			name:      "nil - nil",
@@ -598,12 +598,12 @@ func TestTimeWindowBlockSelectorSort(t *testing.T) {
 		},
 		{
 			name:      "empty - nil",
-			blocklist: []*encoding.BlockMeta{},
+			blocklist: []*backend.BlockMeta{},
 			expected:  nil,
 		},
 		{
 			name: "different time windows",
-			blocklist: []*encoding.BlockMeta{
+			blocklist: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 					EndTime: now.Add(-2 * timeWindow),
@@ -617,7 +617,7 @@ func TestTimeWindowBlockSelectorSort(t *testing.T) {
 					EndTime: now,
 				},
 			},
-			expected: []*encoding.BlockMeta{
+			expected: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 					EndTime: now,
@@ -634,7 +634,7 @@ func TestTimeWindowBlockSelectorSort(t *testing.T) {
 		},
 		{
 			name: "different compaction lvls",
-			blocklist: []*encoding.BlockMeta{
+			blocklist: []*backend.BlockMeta{
 				{
 					BlockID:         uuid.MustParse("00000000-0000-0000-0000-000000000000"),
 					CompactionLevel: 1,
@@ -651,7 +651,7 @@ func TestTimeWindowBlockSelectorSort(t *testing.T) {
 					EndTime:         now,
 				},
 			},
-			expected: []*encoding.BlockMeta{
+			expected: []*backend.BlockMeta{
 				{
 					BlockID:         uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 					CompactionLevel: 0,
@@ -671,7 +671,7 @@ func TestTimeWindowBlockSelectorSort(t *testing.T) {
 		},
 		{
 			name: "different sizes",
-			blocklist: []*encoding.BlockMeta{
+			blocklist: []*backend.BlockMeta{
 				{
 					BlockID:      uuid.MustParse("00000000-0000-0000-0000-000000000000"),
 					EndTime:      now,
@@ -688,7 +688,7 @@ func TestTimeWindowBlockSelectorSort(t *testing.T) {
 					TotalObjects: 0,
 				},
 			},
-			expected: []*encoding.BlockMeta{
+			expected: []*backend.BlockMeta{
 				{
 					BlockID:      uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 					EndTime:      now,
@@ -708,7 +708,7 @@ func TestTimeWindowBlockSelectorSort(t *testing.T) {
 		},
 		{
 			name: "all things",
-			blocklist: []*encoding.BlockMeta{
+			blocklist: []*backend.BlockMeta{
 				{
 					BlockID:         uuid.MustParse("00000000-0000-0000-0000-000000000000"),
 					CompactionLevel: 1,
@@ -731,7 +731,7 @@ func TestTimeWindowBlockSelectorSort(t *testing.T) {
 					EndTime:         now,
 				},
 			},
-			expected: []*encoding.BlockMeta{
+			expected: []*backend.BlockMeta{
 				{
 					BlockID:         uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 					CompactionLevel: 0,

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -108,7 +108,7 @@ func (rw *readerWriter) doCompaction() {
 
 // todo : this method is brittle and has weird failure conditions.  if it fails after it has written a new block then it will not clean up the old
 //   in these cases it's possible that the compact method actually will start making more blocks.
-func (rw *readerWriter) compact(blockMetas []*encoding.BlockMeta, tenantID string) error {
+func (rw *readerWriter) compact(blockMetas []*backend.BlockMeta, tenantID string) error {
 	level.Debug(rw.logger).Log("msg", "beginning compaction", "num blocks compacting", len(blockMetas))
 
 	if len(blockMetas) == 0 {
@@ -145,7 +145,7 @@ func (rw *readerWriter) compact(blockMetas []*encoding.BlockMeta, tenantID strin
 	}
 
 	recordsPerBlock := (totalRecords / outputBlocks)
-	var newCompactedBlocks []*encoding.BlockMeta
+	var newCompactedBlocks []*backend.BlockMeta
 	var currentBlock *encoding.CompactorBlock
 	var tracker backend.AppendTracker
 
@@ -276,7 +276,7 @@ func allDone(bookmarks []*bookmark) bool {
 	return true
 }
 
-func compactionLevelForBlocks(blockMetas []*encoding.BlockMeta) uint8 {
+func compactionLevelForBlocks(blockMetas []*backend.BlockMeta) uint8 {
 	level := uint8(0)
 
 	for _, m := range blockMetas {
@@ -288,7 +288,7 @@ func compactionLevelForBlocks(blockMetas []*encoding.BlockMeta) uint8 {
 	return level
 }
 
-func markCompacted(rw *readerWriter, tenantID string, oldBlocks []*encoding.BlockMeta, newBlocks []*encoding.BlockMeta) {
+func markCompacted(rw *readerWriter, tenantID string, oldBlocks []*backend.BlockMeta, newBlocks []*backend.BlockMeta) {
 	for _, meta := range oldBlocks {
 		// Mark in the backend
 		if err := rw.c.MarkBlockCompacted(meta.BlockID, tenantID); err != nil {
@@ -298,9 +298,9 @@ func markCompacted(rw *readerWriter, tenantID string, oldBlocks []*encoding.Bloc
 	}
 
 	// Converted outgoing blocks into compacted entries.
-	newCompactions := make([]*encoding.CompactedBlockMeta, 0, len(oldBlocks))
+	newCompactions := make([]*backend.CompactedBlockMeta, 0, len(oldBlocks))
 	for _, newBlock := range oldBlocks {
-		newCompactions = append(newCompactions, &encoding.CompactedBlockMeta{
+		newCompactions = append(newCompactions, &backend.CompactedBlockMeta{
 			BlockMeta:     *newBlock,
 			CompactedTime: time.Now(),
 		})

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -190,7 +190,7 @@ func (rw *readerWriter) compact(blockMetas []*backend.BlockMeta, tenantID string
 
 		// writing to the current block will cause the id to escape the iterator so we need to make a copy of it
 		writeID := append([]byte(nil), lowestID...)
-		err = currentBlock.Write(writeID, lowestObject)
+		err = currentBlock.AddObject(writeID, lowestObject)
 		if err != nil {
 			return err
 		}
@@ -255,13 +255,9 @@ func finishBlock(rw *readerWriter, tracker backend.AppendTracker, block *encodin
 	}
 	block.Complete()
 
-	err = rw.WriteBlockMeta(context.TODO(), tracker, block) // todo:  add timeout
+	err = block.Write(context.TODO(), tracker, rw.w) // todo:  add timeout
 	if err != nil {
 		return err
-	}
-	err = block.Clear()
-	if err != nil {
-		level.Error(rw.logger).Log("msg", "error cleaning up currentBlock in compaction", "err", err)
 	}
 
 	return nil

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/util/test"
+	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/local"
-	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/grafana/tempo/tempodb/pool"
 	"github.com/grafana/tempo/tempodb/wal"
 )
@@ -225,7 +225,7 @@ func TestSameIDCompaction(t *testing.T) {
 	// poll
 	checkBlocklists(t, uuid.Nil, blockCount, 0, rw)
 
-	var blocks []*encoding.BlockMeta
+	var blocks []*backend.BlockMeta
 	blocklist := rw.blocklist(testTenantID)
 	blockSelector := newTimeWindowBlockSelector(blocklist, rw.compactorCfg.MaxCompactionRange, 10000, defaultMinInputBlocks, 2)
 	blocks, _ = blockSelector.BlocksToCompact()

--- a/tempodb/encoding/compactor_block.go
+++ b/tempodb/encoding/compactor_block.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/bloom"
 )
 
 type CompactorBlock struct {
-	compactedMeta *BlockMeta
-	inMetas       []*BlockMeta
+	compactedMeta *backend.BlockMeta
+	inMetas       []*backend.BlockMeta
 
 	bloom *bloom.ShardedBloomFilter
 
@@ -19,7 +20,7 @@ type CompactorBlock struct {
 	appender        Appender
 }
 
-func NewCompactorBlock(id uuid.UUID, tenantID string, bloomFP float64, indexDownsample int, metas []*BlockMeta, estimatedObjects int) (*CompactorBlock, error) {
+func NewCompactorBlock(id uuid.UUID, tenantID string, bloomFP float64, indexDownsample int, metas []*backend.BlockMeta, estimatedObjects int) (*CompactorBlock, error) {
 	if len(metas) == 0 {
 		return nil, fmt.Errorf("empty block meta list")
 	}
@@ -29,7 +30,7 @@ func NewCompactorBlock(id uuid.UUID, tenantID string, bloomFP float64, indexDown
 	}
 
 	c := &CompactorBlock{
-		compactedMeta: NewBlockMeta(tenantID, id),
+		compactedMeta: backend.NewBlockMeta(tenantID, id),
 		bloom:         bloom.NewWithEstimates(uint(estimatedObjects), bloomFP),
 		inMetas:       metas,
 	}
@@ -81,7 +82,7 @@ func (c *CompactorBlock) Clear() error {
 }
 
 // implements WriteableBlock
-func (c *CompactorBlock) BlockMeta() *BlockMeta {
+func (c *CompactorBlock) BlockMeta() *backend.BlockMeta {
 	meta := c.compactedMeta
 
 	meta.StartTime = c.inMetas[0].StartTime

--- a/tempodb/encoding/compactor_block_test.go
+++ b/tempodb/encoding/compactor_block_test.go
@@ -10,8 +10,13 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/grafana/tempo/tempodb/backend"
 
 	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testTenantID = "fake"
 )
 
 func TestCompactorBlockError(t *testing.T) {
@@ -29,7 +34,7 @@ func TestCompactorBlockWrite(t *testing.T) {
 	indexDownsample := 3
 	bloomFP := .01
 
-	metas := []*BlockMeta{
+	metas := []*backend.BlockMeta{
 		{
 			StartTime: time.Unix(10000, 0),
 			EndTime:   time.Unix(20000, 0),
@@ -78,8 +83,8 @@ func TestCompactorBlockWrite(t *testing.T) {
 
 	assert.Equal(t, time.Unix(10000, 0), meta.StartTime)
 	assert.Equal(t, time.Unix(25000, 0), meta.EndTime)
-	assert.Equal(t, minID, meta.MinID)
-	assert.Equal(t, maxID, meta.MaxID)
+	assert.Equal(t, minID, ID(meta.MinID))
+	assert.Equal(t, maxID, ID(meta.MaxID))
 	assert.Equal(t, testTenantID, meta.TenantID)
 	assert.Equal(t, numObjects, meta.TotalObjects)
 

--- a/tempodb/encoding/compactor_block_test.go
+++ b/tempodb/encoding/compactor_block_test.go
@@ -64,7 +64,7 @@ func TestCompactorBlockWrite(t *testing.T) {
 
 		ids = append(ids, id)
 
-		err = cb.Write(id, object)
+		err = cb.AddObject(id, object)
 		assert.NoError(t, err)
 
 		if len(minID) == 0 || bytes.Compare(id, minID) == -1 {
@@ -89,13 +89,12 @@ func TestCompactorBlockWrite(t *testing.T) {
 	assert.Equal(t, numObjects, meta.TotalObjects)
 
 	// bloom
-	bloom := cb.BloomFilter()
 	for _, id := range ids {
-		has := bloom.Test(id)
+		has := cb.bloom.Test(id)
 		assert.True(t, has)
 	}
 
-	records := cb.Records()
+	records := cb.appender.Records()
 	assert.Equal(t, math.Ceil(float64(numObjects)/float64(indexDownsample)), float64(len(records)))
 
 	assert.Equal(t, numObjects, cb.CurrentBufferedObjects())

--- a/tempodb/encoding/complete_block.go
+++ b/tempodb/encoding/complete_block.go
@@ -6,16 +6,18 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
-	"github.com/grafana/tempo/tempodb/encoding/bloom"
 	"go.uber.org/atomic"
+
+	"github.com/google/uuid"
+	"github.com/grafana/tempo/tempodb/backend"
+	"github.com/grafana/tempo/tempodb/encoding/bloom"
 )
 
 // CompleteBlock represent a block that has been "cut", is ready to be flushed and is not appendable.
 // A CompleteBlock also knows the filepath of the append wal file it was cut from.  It is responsible for
 // cleaning this block up once it has been flushed to the backend.
 type CompleteBlock struct {
-	meta    *BlockMeta
+	meta    *backend.BlockMeta
 	bloom   *bloom.ShardedBloomFilter
 	records []*Record
 
@@ -28,9 +30,9 @@ type CompleteBlock struct {
 }
 
 // NewCompleteBlock creates a new block and takes _ALL_ the parameters necessary to build the ordered, deduped file on disk
-func NewCompleteBlock(originatingMeta *BlockMeta, iterator Iterator, bloomFP float64, estimatedObjects int, indexDownsample int, filepath string, walFilename string) (*CompleteBlock, error) {
+func NewCompleteBlock(originatingMeta *backend.BlockMeta, iterator Iterator, bloomFP float64, estimatedObjects int, indexDownsample int, filepath string, walFilename string) (*CompleteBlock, error) {
 	c := &CompleteBlock{
-		meta:        NewBlockMeta(originatingMeta.TenantID, uuid.New()),
+		meta:        backend.NewBlockMeta(originatingMeta.TenantID, uuid.New()),
 		bloom:       bloom.NewWithEstimates(uint(estimatedObjects), bloomFP),
 		records:     make([]*Record, 0),
 		filepath:    filepath,
@@ -97,7 +99,7 @@ func (c *CompleteBlock) Flushed() error {
 }
 
 // BlockMeta implements WriteableBlock
-func (c *CompleteBlock) BlockMeta() *BlockMeta {
+func (c *CompleteBlock) BlockMeta() *backend.BlockMeta {
 	return c.meta
 }
 

--- a/tempodb/encoding/complete_block_test.go
+++ b/tempodb/encoding/complete_block_test.go
@@ -97,7 +97,7 @@ func TestCompleteBlock(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.True(t, proto.Equal(out, reqs[i]))
-		assert.True(t, block.BloomFilter().Test(id))
+		assert.True(t, block.bloom.Test(id))
 	}
 
 	// confirm order

--- a/tempodb/encoding/complete_block_test.go
+++ b/tempodb/encoding/complete_block_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/util/test"
+	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -67,7 +68,7 @@ func TestCompleteBlock(t *testing.T) {
 	err = writer.Flush()
 	assert.NoError(t, err, "unexpected error flushing writer")
 
-	originatingMeta := NewBlockMeta(testTenantID, uuid.New())
+	originatingMeta := backend.NewBlockMeta(testTenantID, uuid.New())
 	originatingMeta.StartTime = time.Now().Add(-5 * time.Minute)
 	originatingMeta.EndTime = time.Now().Add(5 * time.Minute)
 

--- a/tempodb/encoding/iterator_backend.go
+++ b/tempodb/encoding/iterator_backend.go
@@ -6,25 +6,21 @@ import (
 	"math"
 
 	"github.com/google/uuid"
+	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/pkg/errors"
 )
-
-type Reader interface {
-	Index(ctx context.Context, blockID uuid.UUID, tenantID string) ([]byte, error)
-	Object(ctx context.Context, blockID uuid.UUID, tenantID string, start uint64, buffer []byte) error
-}
 
 type backendIterator struct {
 	tenantID string
 	blockID  uuid.UUID
-	r        Reader
+	r        backend.Reader
 
 	indexBuffer         []byte
 	objectsBuffer       []byte
 	activeObjectsBuffer []byte
 }
 
-func NewBackendIterator(tenantID string, blockID uuid.UUID, chunkSizeBytes uint32, reader Reader) (Iterator, error) {
+func NewBackendIterator(tenantID string, blockID uuid.UUID, chunkSizeBytes uint32, reader backend.Reader) (Iterator, error) {
 	index, err := reader.Index(context.TODO(), blockID, tenantID)
 	if err != nil {
 		return nil, err

--- a/tempodb/tempodb_test.go
+++ b/tempodb/tempodb_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/util/test"
+	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/local"
-	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/grafana/tempo/tempodb/wal"
 	"github.com/stretchr/testify/assert"
 )
@@ -257,26 +257,26 @@ func TestCleanMissingTenants(t *testing.T) {
 	tests := []struct {
 		name      string
 		tenants   []string
-		blocklist map[string][]*encoding.BlockMeta
-		expected  map[string][]*encoding.BlockMeta
+		blocklist map[string][]*backend.BlockMeta
+		expected  map[string][]*backend.BlockMeta
 	}{
 		{
 			name:      "one missing tenant",
 			tenants:   []string{"foo"},
-			blocklist: map[string][]*encoding.BlockMeta{"foo": {{}}, "bar": {{}}},
-			expected:  map[string][]*encoding.BlockMeta{"foo": {{}}},
+			blocklist: map[string][]*backend.BlockMeta{"foo": {{}}, "bar": {{}}},
+			expected:  map[string][]*backend.BlockMeta{"foo": {{}}},
 		},
 		{
 			name:      "no missing tenants",
 			tenants:   []string{"foo", "bar"},
-			blocklist: map[string][]*encoding.BlockMeta{"foo": {{}}, "bar": {{}}},
-			expected:  map[string][]*encoding.BlockMeta{"foo": {{}}, "bar": {{}}},
+			blocklist: map[string][]*backend.BlockMeta{"foo": {{}}, "bar": {{}}},
+			expected:  map[string][]*backend.BlockMeta{"foo": {{}}, "bar": {{}}},
 		},
 		{
 			name:      "all missing tenants",
 			tenants:   []string{},
-			blocklist: map[string][]*encoding.BlockMeta{"foo": {{}}, "bar": {{}}},
-			expected:  map[string][]*encoding.BlockMeta{},
+			blocklist: map[string][]*backend.BlockMeta{"foo": {{}}, "bar": {{}}},
+			expected:  map[string][]*backend.BlockMeta{},
 		},
 	}
 	for _, tt := range tests {
@@ -356,10 +356,10 @@ func TestUpdateBlocklist(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		existing []*encoding.BlockMeta
-		add      []*encoding.BlockMeta
-		remove   []*encoding.BlockMeta
-		expected []*encoding.BlockMeta
+		existing []*backend.BlockMeta
+		add      []*backend.BlockMeta
+		remove   []*backend.BlockMeta
+		expected []*backend.BlockMeta
 	}{
 		{
 			name:     "all nil",
@@ -371,13 +371,13 @@ func TestUpdateBlocklist(t *testing.T) {
 		{
 			name:     "add to nil",
 			existing: nil,
-			add: []*encoding.BlockMeta{
+			add: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 				},
 			},
 			remove: nil,
-			expected: []*encoding.BlockMeta{
+			expected: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 				},
@@ -385,18 +385,18 @@ func TestUpdateBlocklist(t *testing.T) {
 		},
 		{
 			name: "add to existing",
-			existing: []*encoding.BlockMeta{
+			existing: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 				},
 			},
-			add: []*encoding.BlockMeta{
+			add: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 				},
 			},
 			remove: nil,
-			expected: []*encoding.BlockMeta{
+			expected: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 				},
@@ -409,7 +409,7 @@ func TestUpdateBlocklist(t *testing.T) {
 			name:     "remove from nil",
 			existing: nil,
 			add:      nil,
-			remove: []*encoding.BlockMeta{
+			remove: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 				},
@@ -418,14 +418,14 @@ func TestUpdateBlocklist(t *testing.T) {
 		},
 		{
 			name: "remove nil",
-			existing: []*encoding.BlockMeta{
+			existing: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 				},
 			},
 			add:    nil,
 			remove: nil,
-			expected: []*encoding.BlockMeta{
+			expected: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 				},
@@ -433,7 +433,7 @@ func TestUpdateBlocklist(t *testing.T) {
 		},
 		{
 			name: "remove existing",
-			existing: []*encoding.BlockMeta{
+			existing: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 				},
@@ -442,12 +442,12 @@ func TestUpdateBlocklist(t *testing.T) {
 				},
 			},
 			add: nil,
-			remove: []*encoding.BlockMeta{
+			remove: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 				},
 			},
-			expected: []*encoding.BlockMeta{
+			expected: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 				},
@@ -455,18 +455,18 @@ func TestUpdateBlocklist(t *testing.T) {
 		},
 		{
 			name: "remove no match",
-			existing: []*encoding.BlockMeta{
+			existing: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 				},
 			},
 			add: nil,
-			remove: []*encoding.BlockMeta{
+			remove: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 				},
 			},
-			expected: []*encoding.BlockMeta{
+			expected: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 				},
@@ -474,7 +474,7 @@ func TestUpdateBlocklist(t *testing.T) {
 		},
 		{
 			name: "add and remove",
-			existing: []*encoding.BlockMeta{
+			existing: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 				},
@@ -482,17 +482,17 @@ func TestUpdateBlocklist(t *testing.T) {
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 				},
 			},
-			add: []*encoding.BlockMeta{
+			add: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000003"),
 				},
 			},
-			remove: []*encoding.BlockMeta{
+			remove: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 				},
 			},
-			expected: []*encoding.BlockMeta{
+			expected: []*backend.BlockMeta{
 				{
 					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 				},
@@ -540,9 +540,9 @@ func TestUpdateBlocklistCompacted(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		existing []*encoding.CompactedBlockMeta
-		add      []*encoding.CompactedBlockMeta
-		expected []*encoding.CompactedBlockMeta
+		existing []*backend.CompactedBlockMeta
+		add      []*backend.CompactedBlockMeta
+		expected []*backend.CompactedBlockMeta
 	}{
 		{
 			name:     "all nil",
@@ -553,16 +553,16 @@ func TestUpdateBlocklistCompacted(t *testing.T) {
 		{
 			name:     "add to nil",
 			existing: nil,
-			add: []*encoding.CompactedBlockMeta{
+			add: []*backend.CompactedBlockMeta{
 				{
-					BlockMeta: encoding.BlockMeta{
+					BlockMeta: backend.BlockMeta{
 						BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 					},
 				},
 			},
-			expected: []*encoding.CompactedBlockMeta{
+			expected: []*backend.CompactedBlockMeta{
 				{
-					BlockMeta: encoding.BlockMeta{
+					BlockMeta: backend.BlockMeta{
 						BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 					},
 				},
@@ -570,28 +570,28 @@ func TestUpdateBlocklistCompacted(t *testing.T) {
 		},
 		{
 			name: "add to existing",
-			existing: []*encoding.CompactedBlockMeta{
+			existing: []*backend.CompactedBlockMeta{
 				{
-					BlockMeta: encoding.BlockMeta{
+					BlockMeta: backend.BlockMeta{
 						BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 					},
 				},
 			},
-			add: []*encoding.CompactedBlockMeta{
+			add: []*backend.CompactedBlockMeta{
 				{
-					BlockMeta: encoding.BlockMeta{
+					BlockMeta: backend.BlockMeta{
 						BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 					},
 				},
 			},
-			expected: []*encoding.CompactedBlockMeta{
+			expected: []*backend.CompactedBlockMeta{
 				{
-					BlockMeta: encoding.BlockMeta{
+					BlockMeta: backend.BlockMeta{
 						BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 					},
 				},
 				{
-					BlockMeta: encoding.BlockMeta{
+					BlockMeta: backend.BlockMeta{
 						BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 					},
 				},

--- a/tempodb/wal/append_block.go
+++ b/tempodb/wal/append_block.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/google/uuid"
+	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding"
 )
 
@@ -19,7 +20,7 @@ type AppendBlock struct {
 func newAppendBlock(id uuid.UUID, tenantID string, filepath string) (*AppendBlock, error) {
 	h := &AppendBlock{
 		block: block{
-			meta:     encoding.NewBlockMeta(tenantID, id),
+			meta:     backend.NewBlockMeta(tenantID, id),
 			filepath: filepath,
 		},
 	}

--- a/tempodb/wal/block.go
+++ b/tempodb/wal/block.go
@@ -5,11 +5,11 @@ import (
 	"os"
 	"sync"
 
-	"github.com/grafana/tempo/tempodb/encoding"
+	"github.com/grafana/tempo/tempodb/backend"
 )
 
 type block struct {
-	meta     *encoding.BlockMeta
+	meta     *backend.BlockMeta
 	filepath string
 	readFile *os.File
 

--- a/tempodb/wal/wal.go
+++ b/tempodb/wal/wal.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/grafana/tempo/tempodb/encoding"
+	"github.com/grafana/tempo/tempodb/backend"
 )
 
 const (
@@ -84,7 +84,7 @@ func (w *WAL) AllBlocks() ([]*ReplayBlock, error) {
 
 		blocks = append(blocks, &ReplayBlock{
 			block: block{
-				meta:     encoding.NewBlockMeta(tenantID, blockID),
+				meta:     backend.NewBlockMeta(tenantID, blockID),
 				filepath: w.c.Filepath,
 			},
 		})

--- a/tempodb/wal/wal_test.go
+++ b/tempodb/wal/wal_test.go
@@ -183,7 +183,6 @@ func TestAppendBlockComplete(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.True(t, proto.Equal(out, reqs[i]))
-		assert.True(t, complete.BloomFilter().Test(id))
 	}
 }
 


### PR DESCRIPTION
**What this PR does**:
Additional groundwork for eventually adding support for versioned blocks.  This is a followup to #422.

- Moves BlockMeta and CompactedBlockMeta to backend.  These files will not be part of versioned blocks and are now a property of the backend.
- Remove Reader interface in the encoding package now that encoding can depend on backend.
- Invert relationship w/r to Writing Complete and Compactor blocks.  This functionality is now available encapsulated in the blocks which will allow the blocks to own their own formats.
