### PR TITLE
Iterate through tenants for compaction instead of choosing randomly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [CHANGE] Redo tempo-cli with basic command structure and improvements [#385](https://github.com/grafana/tempo/pull/385)
 * [CHANGE] Add content negotiation support and sharding parameters to Querier [#375](https://github.com/grafana/tempo/pull/375)
 * [CHANGE] Remove S3 automatic bucket creation [#404](https://github.com/grafana/tempo/pull/404)
+* [CHANGE] Compactors should round robin tenants instead of choosing randomly [#420](https://github.com/grafana/tempo/issues/420)
 * [ENHANCEMENT] Add docker-compose example for GCS along with new backend options [#397](https://github.com/grafana/tempo/pull/397)
 * [ENHANCEMENT] tempo-cli list blocks usability improvements [#403](https://github.com/grafana/tempo/pull/403)
 * [BUGFIX] Compactor without GCS permissions fail silently [#379](https://github.com/grafana/tempo/issues/379)

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math/rand"
+	"sort"
 	"strconv"
 	"time"
 
@@ -69,16 +69,19 @@ func (rw *readerWriter) doCompaction() {
 		return
 	}
 
-	// pick a random tenant and find some blocks to compact
-	rand.Seed(time.Now().Unix())
-	tenantID := tenants[rand.Intn(len(tenants))].(string)
+	// Iterate through tenants each cycle
+	// Sort tenants for stability (since original map does not guarantee order)
+	sort.Slice(tenants, func(i, j int) bool { return tenants[i].(string) < tenants[j].(string) })
+	rw.compactorTenantOffset = (rw.compactorTenantOffset + 1) % uint(len(tenants))
+
+	tenantID := tenants[rw.compactorTenantOffset].(string)
 	blocklist := rw.blocklist(tenantID)
 
 	blockSelector := newTimeWindowBlockSelector(blocklist, rw.compactorCfg.MaxCompactionRange, rw.compactorCfg.MaxCompactionObjects, defaultMinInputBlocks, defaultMaxInputBlocks)
 
 	start := time.Now()
 
-	level.Info(rw.logger).Log("msg", "starting compaction cycle", "tenantID", tenantID)
+	level.Info(rw.logger).Log("msg", "starting compaction cycle", "tenantID", tenantID, "offset", rw.compactorTenantOffset)
 	for {
 		toBeCompacted, hashString := blockSelector.BlocksToCompact()
 		if len(toBeCompacted) == 0 {

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -120,9 +120,10 @@ type readerWriter struct {
 	blockLists    map[string][]*encoding.BlockMeta
 	blockListsMtx sync.Mutex
 
-	compactorCfg        *CompactorConfig
-	compactedBlockLists map[string][]*encoding.CompactedBlockMeta
-	compactorSharder    CompactorSharder
+	compactorCfg          *CompactorConfig
+	compactedBlockLists   map[string][]*encoding.CompactedBlockMeta
+	compactorSharder      CompactorSharder
+	compactorTenantOffset uint
 }
 
 func New(cfg *Config, logger log.Logger) (Reader, Writer, Compactor, error) {

--- a/tempodb/tempodb_test.go
+++ b/tempodb/tempodb_test.go
@@ -22,7 +22,8 @@ import (
 )
 
 const (
-	testTenantID = "fake"
+	testTenantID  = "fake"
+	testTenantID2 = "fake2"
 )
 
 func TestDB(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:
Changes compactor to iterate through one tenant each cycle, instead of choosing randomly.

**Which issue(s) this PR fixes**:
Fixes #420 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`