### PR TITLE
Correct imports

### DIFF
--- a/tempodb/backend/azure/azure.go
+++ b/tempodb/backend/azure/azure.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/util"
-	"github.com/grafana/tempo/tempodb/encoding"
 )
 
 const (
@@ -48,7 +47,7 @@ func New(cfg *Config) (backend.Reader, backend.Writer, backend.Compactor, error)
 	return rw, rw, rw, nil
 }
 
-func (rw *readerWriter) Write(ctx context.Context, meta *encoding.BlockMeta, bBloom [][]byte, bIndex []byte, objectFilePath string) error {
+func (rw *readerWriter) Write(ctx context.Context, meta *backend.BlockMeta, bBloom [][]byte, bIndex []byte, objectFilePath string) error {
 	blockID := meta.BlockID
 	tenantID := meta.TenantID
 
@@ -73,7 +72,7 @@ func (rw *readerWriter) Write(ctx context.Context, meta *encoding.BlockMeta, bBl
 	return nil
 }
 
-func (rw *readerWriter) WriteBlockMeta(ctx context.Context, tracker backend.AppendTracker, meta *encoding.BlockMeta, bBloom [][]byte, bIndex []byte) error {
+func (rw *readerWriter) WriteBlockMeta(ctx context.Context, tracker backend.AppendTracker, meta *backend.BlockMeta, bBloom [][]byte, bIndex []byte) error {
 
 	blockID := meta.BlockID
 	tenantID := meta.TenantID
@@ -107,7 +106,7 @@ type AppenderTracker struct {
 	Name string
 }
 
-func (rw *readerWriter) AppendObject(ctx context.Context, tracker backend.AppendTracker, meta *encoding.BlockMeta, bObject []byte) (backend.AppendTracker, error) {
+func (rw *readerWriter) AppendObject(ctx context.Context, tracker backend.AppendTracker, meta *backend.BlockMeta, bObject []byte) (backend.AppendTracker, error) {
 	var a AppenderTracker
 	if tracker == nil {
 		blockID := meta.BlockID
@@ -190,7 +189,7 @@ func (rw *readerWriter) Blocks(ctx context.Context, tenantID string) ([]uuid.UUI
 	return blocks, nil
 }
 
-func (rw *readerWriter) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*encoding.BlockMeta, error) {
+func (rw *readerWriter) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*backend.BlockMeta, error) {
 
 	name := util.MetaFileName(blockID, tenantID)
 
@@ -206,7 +205,7 @@ func (rw *readerWriter) BlockMeta(ctx context.Context, blockID uuid.UUID, tenant
 		return nil, errors.Wrapf(err, "reading Azure blob container: %s", name)
 	}
 
-	out := &encoding.BlockMeta{}
+	out := &backend.BlockMeta{}
 	err = json.Unmarshal(bytes, out)
 	if err != nil {
 		return nil, err

--- a/tempodb/backend/azure/compactor.go
+++ b/tempodb/backend/azure/compactor.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/util"
-	"github.com/grafana/tempo/tempodb/encoding"
 )
 
 type BlobAttributes struct {
@@ -92,7 +91,7 @@ func (rw *readerWriter) ClearBlock(blockID uuid.UUID, tenantID string) error {
 	return warning
 }
 
-func (rw *readerWriter) CompactedBlockMeta(blockID uuid.UUID, tenantID string) (*encoding.CompactedBlockMeta, error) {
+func (rw *readerWriter) CompactedBlockMeta(blockID uuid.UUID, tenantID string) (*backend.CompactedBlockMeta, error) {
 	if len(tenantID) == 0 {
 		return nil, backend.ErrEmptyTenantID
 	}
@@ -106,7 +105,7 @@ func (rw *readerWriter) CompactedBlockMeta(blockID uuid.UUID, tenantID string) (
 		return nil, err
 	}
 
-	out := &encoding.CompactedBlockMeta{}
+	out := &backend.CompactedBlockMeta{}
 	err = json.Unmarshal(bytes, out)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Corrects build https://github.com/grafana/tempo/pull/432/checks?check_run_id=1619853512

```
  Running [/home/runner/golangci-lint-1.32.2-linux-amd64/golangci-lint run --out-format=github-actions] in [] ...
  level=warning msg="[runner] Can't run linter goanalysis_metalinter: S1037: failed prerequisites: [(inspect@github.com/grafana/tempo/tempodb/backend/azure, isgenerated@github.com/grafana/tempo/tempodb/backend/azure): analysis skipped: errors in package: [/home/runner/work/tempo/tempo/tempodb/backend/azure/azure.go:51:67: BlockMeta not declared by package encoding /home/runner/work/tempo/tempo/tempodb/backend/azure/azure.go:76:107: BlockMeta not declared by package encoding /home/runner/work/tempo/tempo/tempodb/backend/azure/azure.go:110:105: BlockMeta not declared by package encoding /home/runner/work/tempo/tempo/tempodb/backend/azure/azure.go:193:103: BlockMeta not declared by package encoding /home/runner/work/tempo/tempo/tempodb/backend/azure/compactor.go:95:91: CompactedBlockMeta not declared by package encoding /home/runner/work/tempo/tempo/tempodb/backend/azure/azure.go:209:19: BlockMeta not declared by package encoding /home/runner/work/tempo/tempo/tempodb/backend/azure/compactor.go:109:19: CompactedBlockMeta not declared by package encoding]]"
  level=warning msg="[runner] Can't run linter unused: buildir: analysis skipped: errors in package: [/home/runner/work/tempo/tempo/tempodb/backend/azure/azure.go:51:67: BlockMeta not declared by package encoding /home/runner/work/tempo/tempo/tempodb/backend/azure/azure.go:76:107: BlockMeta not declared by package encoding /home/runner/work/tempo/tempo/tempodb/backend/azure/azure.go:110:105: BlockMeta not declared by package encoding /home/runner/work/tempo/tempo/tempodb/backend/azure/azure.go:193:103: BlockMeta not declared by package encoding /home/runner/work/tempo/tempo/tempodb/backend/azure/compactor.go:95:91: CompactedBlockMeta not declared by package encoding /home/runner/work/tempo/tempo/tempodb/backend/azure/azure.go:209:19: BlockMeta not declared by package encoding /home/runner/work/tempo/tempo/tempodb/backend/azure/compactor.go:109:19: CompactedBlockMeta not declared by package encoding]"
  level=error msg="Running error: buildir: analysis skipped: errors in package: [/home/runner/work/tempo/tempo/tempodb/backend/azure/azure.go:51:67: BlockMeta not declared by package encoding /home/runner/work/tempo/tempo/tempodb/backend/azure/azure.go:76:107: BlockMeta not declared by package encoding /home/runner/work/tempo/tempo/tempodb/backend/azure/azure.go:110:105: BlockMeta not declared by package encoding /home/runner/work/tempo/tempo/tempodb/backend/azure/azure.go:193:103: BlockMeta not declared by package encoding /home/runner/work/tempo/tempo/tempodb/backend/azure/compactor.go:95:91: CompactedBlockMeta not declared by package encoding /home/runner/work/tempo/tempo/tempodb/backend/azure/azure.go:209:19: BlockMeta not declared by package encoding /home/runner/work/tempo/tempo/tempodb/backend/azure/compactor.go:109:19: CompactedBlockMeta not declared by package encoding]"
```

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`