### PR TITLE
Made compactions and flushes failed configurable

### DIFF
--- a/operations/tempo-mixin/alerts.libsonnet
+++ b/operations/tempo-mixin/alerts.libsonnet
@@ -70,26 +70,26 @@
           {
             alert: 'TempoCompactionsFailing',
             expr: |||
-              sum by (cluster, namespace) (increase(tempodb_compaction_errors_total{}[1h])) > 1
-            |||,
+              sum by (cluster, namespace) (increase(tempodb_compaction_errors_total{}[1h])) > %s
+            ||| % $._config.alerts.compactions_per_hour_failed,
             labels: {
               severity: 'critical',
             },
             annotations: {
-              message: 'Greater than 1 compactions have failed in the past hour.',
+              message: 'Greater than %s compactions have failed in the past hour.' % $._config.alerts.compactions_per_hour_failed,
               runbook_url: 'https://github.com/grafana/tempo/tree/master/operations/tempo-mixin/runbook.md#TempoCompactionsFailing'
             },
           },
           {
             alert: 'TempoFlushesFailing',
             expr: |||
-              sum by (cluster, namespace) (increase(tempo_ingester_failed_flushes_total{}[1h])) > 1
-            |||,
+              sum by (cluster, namespace) (increase(tempo_ingester_failed_flushes_total{}[1h])) > %s
+            ||| % $._config.alerts.flushes_per_hour_failed,
             labels: {
               severity: 'critical',
             },
             annotations: {
-              message: 'Greater than 1 flushes have failed in the past hour.',
+              message: 'Greater than %s flushes have failed in the past hour.' % $._config.alerts.flushes_per_hour_failed,
               runbook_url: 'https://github.com/grafana/tempo/tree/master/operations/tempo-mixin/runbook.md#TempoFlushesFailing'
             },
           },

--- a/operations/tempo-mixin/config.libsonnet
+++ b/operations/tempo-mixin/config.libsonnet
@@ -7,5 +7,9 @@
       distributor: 'distributor',
       compactor: 'compactor',
     },
+    alerts: {
+      compactions_per_hour_failed: 2,
+      flushes_per_hour_failed: 2,
+    },
   },
 }

--- a/operations/tempo-mixin/out/alerts.yaml
+++ b/operations/tempo-mixin/out/alerts.yaml
@@ -44,17 +44,17 @@
       "severity": "critical"
   - "alert": "TempoCompactionsFailing"
     "annotations":
-      "message": "Greater than 1 compactions have failed in the past hour."
+      "message": "Greater than 2 compactions have failed in the past hour."
       "runbook_url": "https://github.com/grafana/tempo/tree/master/operations/tempo-mixin/runbook.md#TempoCompactionsFailing"
     "expr": |
-      sum by (cluster, namespace) (increase(tempodb_compaction_errors_total{}[1h])) > 1
+      sum by (cluster, namespace) (increase(tempodb_compaction_errors_total{}[1h])) > 2
     "labels":
       "severity": "critical"
   - "alert": "TempoFlushesFailing"
     "annotations":
-      "message": "Greater than 1 flushes have failed in the past hour."
+      "message": "Greater than 2 flushes have failed in the past hour."
       "runbook_url": "https://github.com/grafana/tempo/tree/master/operations/tempo-mixin/runbook.md#TempoFlushesFailing"
     "expr": |
-      sum by (cluster, namespace) (increase(tempo_ingester_failed_flushes_total{}[1h])) > 1
+      sum by (cluster, namespace) (increase(tempo_ingester_failed_flushes_total{}[1h])) > 2
     "labels":
       "severity": "critical"


### PR DESCRIPTION
**What this PR does**:
Makes the compations and flushes failed per hour to be configurable thresholds instead of the hardcoded value.

**Which issue(s) this PR fixes**:
Fixes #

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`