### PR TITLE
Fix ingester push latency metric on operational dashboard

### DIFF
--- a/operations/tempo-mixin/tempo-operational.json
+++ b/operations/tempo-mixin/tempo-operational.json
@@ -3312,19 +3312,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(.99, sum(rate(tempo_request_duration_seconds_bucket{job=\"$namespace/ingester\", route=\"/tempopb.Pusher/Push\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.99, sum(rate(tempo_request_duration_seconds_bucket{job=\"$namespace/ingester\", route=~\"/tempopb.Pusher/Push.*\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(.9, sum(rate(tempo_request_duration_seconds_bucket{job=\"$namespace/ingester\", route=\"/tempopb.Pusher/Push\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.9, sum(rate(tempo_request_duration_seconds_bucket{job=\"$namespace/ingester\", route=~\"/tempopb.Pusher/Push.*\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".9",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(.5, sum(rate(tempo_request_duration_seconds_bucket{job=\"$namespace/ingester\", route=\"/tempopb.Pusher/Push\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.5, sum(rate(tempo_request_duration_seconds_bucket{job=\"$namespace/ingester\", route=~\"/tempopb.Pusher/Push.*\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".5",
           "refId": "C"


### PR DESCRIPTION
**What this PR does**:
Fix ingester push latency metric on tempo operational dashboard, that was broken with introduction of new PushBytes method.

**Which issue(s) this PR fixes**:
Fixes n/a
Related to #430 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`