### PR TITLE
Add more buckets to tempo_distributor_traces_per_batch metric

### DIFF
--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -57,7 +57,7 @@ var (
 		Namespace: "tempo",
 		Name:      "distributor_traces_per_batch",
 		Help:      "The number of traces in each batch",
-		Buckets:   prometheus.LinearBuckets(0, 3, 5),
+		Buckets:   prometheus.LinearBuckets(0, 3, 10),
 	})
 	metricIngesterClients = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "tempo",


### PR DESCRIPTION
**What this PR does**:
About 25% of traces are falling into the +Inf bucket for the tempo_distributor_traces_per_batch metric.  This PR doubles the number of buckets, increasing the ceiling from 12 to 27.  It's kind of a guess as to most appropriate buckets, but this is a step in that direction.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`