### PR TITLE
Ignore metrics and query-frontend call for latency alert.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [BUGFIX] Compactor without GCS permissions fail silently [#379](https://github.com/grafana/tempo/issues/379)
 * [BUGFIX] Prevent race conditions between querier polling and ingesters clearing complete blocks [#421](https://github.com/grafana/tempo/issues/421)
 * [BUGFIX] Exclude blocks in last active window from compaction [#411](https://github.com/grafana/tempo/pull/411)
+* [BUGFIX] Mixin: Ignore metrics and query-frontend route when checking for TempoRequestLatency alert. [#440](https://github.com/grafana/tempo/pull/440)
 * [FEATURE] Add support for Azure Blob Storage backend [#340](https://github.com/grafana/tempo/issues/340)
 
 ## v0.4.0

--- a/operations/tempo-mixin/alerts.libsonnet
+++ b/operations/tempo-mixin/alerts.libsonnet
@@ -26,7 +26,7 @@
           {
             alert: 'TempoRequestLatency',
             expr: |||
-              namespace_job_route:tempo_request_duration_seconds:99quantile{} > 3
+              namespace_job_route:tempo_request_duration_seconds:99quantile{route!~"metrics|/frontend.Frontend/Process"} > 3
             |||,
             'for': '15m',
             labels: {


### PR DESCRIPTION
**What this PR does**: This PR ignores some routes when checking for `TempoRequestLatency` alert. Specifically query-frontend route is designed to be called as long-running request, so we should ignore it.

**Checklist**
- [NA] Tests updated
- [NA] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`