### PR TITLE
Additional Backend Refactoring : Versioned Blocks

### DIFF
--- a/tempodb/backend/azure/azure.go
+++ b/tempodb/backend/azure/azure.go
@@ -51,7 +51,12 @@ func New(cfg *Config) (backend.Reader, backend.Writer, backend.Compactor, error)
 }
 
 // Write implements backend.Writer
-func (rw *readerWriter) Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, _ int64) error {
+func (rw *readerWriter) Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, buffer []byte) error {
+	return rw.WriteReader(ctx, name, blockID, tenantID, bytes.NewBuffer(buffer), int64(len(buffer)))
+}
+
+// WriteReader implements backend.Writer
+func (rw *readerWriter) WriteReader(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, _ int64) error {
 	return rw.writer(ctx, bufio.NewReader(data), util.ObjectFileName(blockID, tenantID, name))
 }
 

--- a/tempodb/backend/backend.go
+++ b/tempodb/backend/backend.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/google/uuid"
 )
@@ -16,10 +17,11 @@ var (
 type AppendTracker interface{}
 
 type Writer interface {
-	Write(ctx context.Context, meta *BlockMeta, bBloom [][]byte, bIndex []byte, objectFilePath string) error
+	Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64) error
+	WriteBlockMeta(ctx context.Context, meta *BlockMeta) error
 
-	WriteBlockMeta(ctx context.Context, tracker AppendTracker, meta *BlockMeta, bBloom [][]byte, bIndex []byte) error
-	AppendObject(ctx context.Context, tracker AppendTracker, meta *BlockMeta, bObject []byte) (AppendTracker, error)
+	Append(ctx context.Context, name string, blockID uuid.UUID, tenantID string, tracker AppendTracker, buffer []byte) (AppendTracker, error)
+	CloseAppend(ctx context.Context, tracker AppendTracker) error
 }
 
 type Reader interface {

--- a/tempodb/backend/backend.go
+++ b/tempodb/backend/backend.go
@@ -19,7 +19,9 @@ var (
 type AppendTracker interface{}
 
 type Writer interface {
-	Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64) error
+	// jpe : add comment about write and writereader (as well as matching reader methods)
+	Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, buffer []byte) error
+	WriteReader(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64) error
 	WriteBlockMeta(ctx context.Context, meta *BlockMeta) error
 
 	Append(ctx context.Context, name string, blockID uuid.UUID, tenantID string, tracker AppendTracker, buffer []byte) (AppendTracker, error)

--- a/tempodb/backend/backend.go
+++ b/tempodb/backend/backend.go
@@ -12,15 +12,16 @@ var (
 	ErrMetaDoesNotExist = fmt.Errorf("meta does not exist")
 	ErrEmptyTenantID    = fmt.Errorf("empty tenant id")
 	ErrEmptyBlockID     = fmt.Errorf("empty block id")
-
-	MaxCacheSizeBytes = int64(1024 * 1024)
 )
 
+// AppendTracker is an empty interface usable by the backend to track a long running append operation
 type AppendTracker interface{}
 
+// Writer is a collection of methods to write data to tempodb backends
 type Writer interface {
-	// jpe : add comment about write and writereader (as well as matching reader methods)
+	// Write is for in memory data.  It is expected that this data will be cached.
 	Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, buffer []byte) error
+	// WriteReader is for larger data payloads streamed through an io.Reader.  It is expected this will _not_ be cached.
 	WriteReader(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64) error
 	WriteBlockMeta(ctx context.Context, meta *BlockMeta) error
 
@@ -28,17 +29,21 @@ type Writer interface {
 	CloseAppend(ctx context.Context, tracker AppendTracker) error
 }
 
+// Reader is a collection of methods to read data from tempodb backends
 type Reader interface {
+	// Reader is for reading entire objects from the backend.  It is expected that there will be an attempt to retrieve this from cache
+	Read(ctx context.Context, name string, blockID uuid.UUID, tenantID string) ([]byte, error)
+	// ReadRange is for reading parts of large objects from the backend.  It is expected this will _not_ be cached.
+	ReadRange(ctx context.Context, name string, blockID uuid.UUID, tenantID string, offset uint64, buffer []byte) error
+
 	Tenants(ctx context.Context) ([]string, error)
 	Blocks(ctx context.Context, tenantID string) ([]uuid.UUID, error)
 	BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*BlockMeta, error)
-	Bloom(ctx context.Context, blockID uuid.UUID, tenantID string, bloomShard int) ([]byte, error)
-	Index(ctx context.Context, blockID uuid.UUID, tenantID string) ([]byte, error)
-	Object(ctx context.Context, blockID uuid.UUID, tenantID string, offset uint64, buffer []byte) error
 
 	Shutdown()
 }
 
+// Compactor is a collection of methods to interact with compacted elements of a tempodb block
 type Compactor interface {
 	MarkBlockCompacted(blockID uuid.UUID, tenantID string) error
 	ClearBlock(blockID uuid.UUID, tenantID string) error

--- a/tempodb/backend/backend.go
+++ b/tempodb/backend/backend.go
@@ -12,6 +12,8 @@ var (
 	ErrMetaDoesNotExist = fmt.Errorf("meta does not exist")
 	ErrEmptyTenantID    = fmt.Errorf("empty tenant id")
 	ErrEmptyBlockID     = fmt.Errorf("empty block id")
+
+	MaxCacheSizeBytes = int64(1024 * 1024)
 )
 
 type AppendTracker interface{}

--- a/tempodb/backend/gcs/gcs.go
+++ b/tempodb/backend/gcs/gcs.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -300,9 +299,4 @@ func (rw *readerWriter) readRange(ctx context.Context, name string, offset int64
 		}
 		totalBytes += byteCount
 	}
-}
-
-func fileExists(filename string) bool {
-	_, err := os.Stat(filename)
-	return !os.IsNotExist(err)
 }

--- a/tempodb/backend/gcs/gcs.go
+++ b/tempodb/backend/gcs/gcs.go
@@ -1,6 +1,7 @@
 package gcs
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -79,7 +80,12 @@ func New(cfg *Config) (backend.Reader, backend.Writer, backend.Compactor, error)
 }
 
 // Write implements backend.Writer
-func (rw *readerWriter) Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, _ int64) error {
+func (rw *readerWriter) Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, buffer []byte) error {
+	return rw.WriteReader(ctx, name, blockID, tenantID, bytes.NewBuffer(buffer), int64(len(buffer)))
+}
+
+// WriteReader implements backend.Writer
+func (rw *readerWriter) WriteReader(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, _ int64) error {
 	w := rw.writer(ctx, util.ObjectFileName(blockID, tenantID, name))
 	_, err := io.Copy(w, data)
 	if err != nil {

--- a/tempodb/backend/gcs/gcs.go
+++ b/tempodb/backend/gcs/gcs.go
@@ -87,12 +87,7 @@ func (rw *readerWriter) Write(ctx context.Context, name string, blockID uuid.UUI
 		return err
 	}
 
-	err = w.Close()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return w.Close()
 }
 
 // WriteBlockMeta implements backend.Writer

--- a/tempodb/backend/local/local.go
+++ b/tempodb/backend/local/local.go
@@ -1,6 +1,7 @@
 package local
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -32,7 +33,12 @@ func New(cfg *Config) (backend.Reader, backend.Writer, backend.Compactor, error)
 }
 
 // Write implements backend.Writer
-func (rw *readerWriter) Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64) error {
+func (rw *readerWriter) Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, buffer []byte) error {
+	return rw.WriteReader(ctx, name, blockID, tenantID, bytes.NewBuffer(buffer), int64(len(buffer)))
+}
+
+// WriteReader implements backend.Writer
+func (rw *readerWriter) WriteReader(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64) error {
 	blockFolder := rw.rootPath(blockID, tenantID)
 	err := os.MkdirAll(blockFolder, os.ModePerm)
 	if err != nil {

--- a/tempodb/backend/local/local.go
+++ b/tempodb/backend/local/local.go
@@ -3,11 +3,11 @@ package local
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 
 	"github.com/google/uuid"
@@ -31,52 +31,32 @@ func New(cfg *Config) (backend.Reader, backend.Writer, backend.Compactor, error)
 	return rw, rw, rw, nil
 }
 
-func (rw *readerWriter) Write(ctx context.Context, meta *backend.BlockMeta, bBloom [][]byte, bIndex []byte, tracesFilePath string) error {
-	err := rw.WriteBlockMeta(ctx, nil, meta, bBloom, bIndex)
-	if err != nil {
-		return err
-	}
-
-	blockID := meta.BlockID
-	tenantID := meta.TenantID
+// Write implements backend.Writer
+func (rw *readerWriter) Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64) error {
 	blockFolder := rw.rootPath(blockID, tenantID)
-
-	if !fileExists(tracesFilePath) {
-		os.RemoveAll(blockFolder)
-		return fmt.Errorf("traces file not found %s", tracesFilePath)
-	}
-
-	// copy traces file.
-	src, err := os.Open(tracesFilePath)
+	err := os.MkdirAll(blockFolder, os.ModePerm)
 	if err != nil {
-		os.RemoveAll(blockFolder)
 		return err
 	}
-	defer src.Close()
 
 	tracesFileName := rw.tracesFileName(blockID, tenantID)
 	dst, err := os.Create(tracesFileName)
 	if err != nil {
-		os.RemoveAll(blockFolder)
 		return err
 	}
 	defer dst.Close()
 
-	_, err = io.Copy(dst, src)
+	_, err = io.Copy(dst, data)
 	if err != nil {
-		os.RemoveAll(blockFolder)
+		return err
 	}
 	return err
 }
 
-func (rw *readerWriter) WriteBlockMeta(_ context.Context, tracker backend.AppendTracker, meta *backend.BlockMeta, bBloom [][]byte, bIndex []byte) error {
+// WriteBlockMeta implements backend.Writer
+func (rw *readerWriter) WriteBlockMeta(ctx context.Context, meta *backend.BlockMeta) error {
 	blockID := meta.BlockID
 	tenantID := meta.TenantID
-
-	if tracker != nil {
-		var dst *os.File = tracker.(*os.File)
-		_ = dst.Close()
-	}
 
 	blockFolder := rw.rootPath(blockID, tenantID)
 	err := os.MkdirAll(blockFolder, os.ModePerm)
@@ -92,33 +72,14 @@ func (rw *readerWriter) WriteBlockMeta(_ context.Context, tracker backend.Append
 	metaFileName := rw.metaFileName(blockID, tenantID)
 	err = ioutil.WriteFile(metaFileName, bMeta, 0644)
 	if err != nil {
-		os.RemoveAll(blockFolder)
-		return err
-	}
-
-	for i, b := range bBloom {
-		bloomFileName := rw.bloomFileName(blockID, tenantID, i)
-		err = ioutil.WriteFile(bloomFileName, b, 0644)
-		if err != nil {
-			os.RemoveAll(blockFolder)
-			return err
-		}
-	}
-
-	indexFileName := rw.indexFileName(blockID, tenantID)
-	err = ioutil.WriteFile(indexFileName, bIndex, 0644)
-	if err != nil {
-		os.RemoveAll(blockFolder)
 		return err
 	}
 
 	return nil
 }
 
-func (rw *readerWriter) AppendObject(ctx context.Context, tracker backend.AppendTracker, meta *backend.BlockMeta, bObject []byte) (backend.AppendTracker, error) {
-	blockID := meta.BlockID
-	tenantID := meta.TenantID
-
+// Append implements backend.Writer
+func (rw *readerWriter) Append(ctx context.Context, name string, blockID uuid.UUID, tenantID string, tracker backend.AppendTracker, buffer []byte) (backend.AppendTracker, error) {
 	var dst *os.File
 	if tracker == nil {
 		blockFolder := rw.rootPath(blockID, tenantID)
@@ -136,12 +97,18 @@ func (rw *readerWriter) AppendObject(ctx context.Context, tracker backend.Append
 		dst = tracker.(*os.File)
 	}
 
-	_, err := dst.Write(bObject)
+	_, err := dst.Write(buffer)
 	if err != nil {
 		return nil, err
 	}
 
 	return dst, nil
+}
+
+// CloseAppend implements backend.Writer
+func (rw *readerWriter) CloseAppend(ctx context.Context, tracker backend.AppendTracker) error {
+	var dst *os.File = tracker.(*os.File)
+	return dst.Close()
 }
 
 func (rw *readerWriter) Tenants(ctx context.Context) ([]string, error) {
@@ -236,26 +203,21 @@ func (rw *readerWriter) Shutdown() {
 }
 
 func (rw *readerWriter) metaFileName(blockID uuid.UUID, tenantID string) string {
-	return path.Join(rw.rootPath(blockID, tenantID), "meta.json")
+	return filepath.Join(rw.rootPath(blockID, tenantID), "meta.json")
 }
 
 func (rw *readerWriter) bloomFileName(blockID uuid.UUID, tenantID string, bloomShard int) string {
-	return path.Join(rw.rootPath(blockID, tenantID), "bloom-"+strconv.Itoa(bloomShard))
+	return filepath.Join(rw.rootPath(blockID, tenantID), "bloom-"+strconv.Itoa(bloomShard))
 }
 
 func (rw *readerWriter) indexFileName(blockID uuid.UUID, tenantID string) string {
-	return path.Join(rw.rootPath(blockID, tenantID), "index")
+	return filepath.Join(rw.rootPath(blockID, tenantID), "index")
 }
 
 func (rw *readerWriter) tracesFileName(blockID uuid.UUID, tenantID string) string {
-	return path.Join(rw.rootPath(blockID, tenantID), "traces")
+	return filepath.Join(rw.rootPath(blockID, tenantID), "traces")
 }
 
 func (rw *readerWriter) rootPath(blockID uuid.UUID, tenantID string) string {
-	return path.Join(rw.cfg.Path, tenantID, blockID.String())
-}
-
-func fileExists(filename string) bool {
-	_, err := os.Stat(filename)
-	return !os.IsNotExist(err)
+	return filepath.Join(rw.cfg.Path, tenantID, blockID.String())
 }

--- a/tempodb/backend/memcached/cache.go
+++ b/tempodb/backend/memcached/cache.go
@@ -13,11 +13,6 @@ import (
 	"github.com/google/uuid"
 )
 
-const (
-	typeBloom = "bloom"
-	typeIndex = "index"
-)
-
 type Config struct {
 	ClientConfig cache.MemcachedClientConfig `yaml:",inline"`
 

--- a/tempodb/backend/memcached/cache.go
+++ b/tempodb/backend/memcached/cache.go
@@ -1,10 +1,8 @@
 package memcached
 
 import (
-	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
@@ -114,21 +112,15 @@ func (r *readerWriter) Shutdown() {
 }
 
 // Write implements backend.Writer
-func (r *readerWriter) Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64) error {
-	if size > 0 && size < backend.MaxCacheSizeBytes {
-		var bytesBuffer bytes.Buffer
-		tee := io.TeeReader(data, &bytesBuffer)
+func (r *readerWriter) Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, buffer []byte) error {
+	r.set(ctx, key(blockID, tenantID, name), buffer)
 
-		object, err := ioutil.ReadAll(tee)
-		if err != nil {
-			return err
-		}
+	return r.nextWriter.Write(ctx, name, blockID, tenantID, buffer)
+}
 
-		r.set(ctx, key(blockID, tenantID, name), object)
-		data = &bytesBuffer
-	}
-
-	return r.nextWriter.Write(ctx, name, blockID, tenantID, data, size)
+// Write implements backend.Writer
+func (r *readerWriter) WriteReader(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64) error {
+	return r.nextWriter.WriteReader(ctx, name, blockID, tenantID, data, size)
 }
 
 // WriteBlockMeta implements backend.Writer

--- a/tempodb/backend/memcached/cache_test.go
+++ b/tempodb/backend/memcached/cache_test.go
@@ -2,6 +2,7 @@ package memcached
 
 import (
 	"context"
+	"io"
 	"testing"
 
 	"github.com/bradfitz/gomemcache/memcache"
@@ -17,9 +18,7 @@ type mockReader struct {
 	tenants []string
 	blocks  []uuid.UUID
 	meta    *backend.BlockMeta
-	bloom   []byte
-	index   []byte
-	object  []byte
+	read    []byte
 }
 
 func (m *mockReader) Tenants(ctx context.Context) ([]string, error) {
@@ -31,14 +30,10 @@ func (m *mockReader) Blocks(ctx context.Context, tenantID string) ([]uuid.UUID, 
 func (m *mockReader) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*backend.BlockMeta, error) {
 	return m.meta, nil
 }
-func (m *mockReader) Bloom(ctx context.Context, blockID uuid.UUID, tenantID string, shardNum int) ([]byte, error) {
-	return m.bloom, nil
+func (m *mockReader) Read(ctx context.Context, name string, blockID uuid.UUID, tenantID string) ([]byte, error) {
+	return m.read, nil
 }
-func (m *mockReader) Index(ctx context.Context, blockID uuid.UUID, tenantID string) ([]byte, error) {
-	return m.index, nil
-}
-func (m *mockReader) Object(ctx context.Context, blockID uuid.UUID, tenantID string, offset uint64, buffer []byte) error {
-	copy(buffer, m.object)
+func (m *mockReader) ReadRange(ctx context.Context, name string, blockID uuid.UUID, tenantID string, offset uint64, buffer []byte) error {
 	return nil
 }
 func (m *mockReader) Shutdown() {}
@@ -46,14 +41,20 @@ func (m *mockReader) Shutdown() {}
 type mockWriter struct {
 }
 
-func (m *mockWriter) Write(ctx context.Context, meta *backend.BlockMeta, bBloom [][]byte, bIndex []byte, objectFilePath string) error {
+func (m *mockWriter) Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, buffer []byte) error {
 	return nil
 }
-func (m *mockWriter) WriteBlockMeta(ctx context.Context, tracker backend.AppendTracker, meta *backend.BlockMeta, bBloom [][]byte, bIndex []byte) error {
+func (m *mockWriter) WriteReader(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64) error {
 	return nil
 }
-func (m *mockWriter) AppendObject(ctx context.Context, tracker backend.AppendTracker, meta *backend.BlockMeta, bObject []byte) (backend.AppendTracker, error) {
+func (m *mockWriter) WriteBlockMeta(ctx context.Context, meta *backend.BlockMeta) error {
+	return nil
+}
+func (m *mockWriter) Append(ctx context.Context, name string, blockID uuid.UUID, tenantID string, tracker backend.AppendTracker, buffer []byte) (backend.AppendTracker, error) {
 	return nil, nil
+}
+func (m *mockWriter) CloseAppend(ctx context.Context, tracker backend.AppendTracker) error {
+	return nil
 }
 
 type mockCache struct {
@@ -79,22 +80,17 @@ func (m *mockCache) Set(item *memcache.Item) error {
 func TestCache(t *testing.T) {
 	tenantID := "test"
 	blockID := uuid.New()
-	shardNum := 0
 
 	tests := []struct {
 		name            string
 		readerTenants   []string
 		readerBlocks    []uuid.UUID
 		readerMeta      *backend.BlockMeta
-		readerBloom     []byte
-		readerIndex     []byte
-		readerObject    []byte
+		readerRead      []byte
 		expectedTenants []string
 		expectedBlocks  []uuid.UUID
 		expectedMeta    *backend.BlockMeta
-		expectedBloom   []byte
-		expectedIndex   []byte
-		expectedObject  []byte
+		expectedRead    []byte
 	}{
 		{
 			name:            "tenants passthrough",
@@ -107,19 +103,9 @@ func TestCache(t *testing.T) {
 			readerBlocks:   []uuid.UUID{blockID},
 		},
 		{
-			name:          "index",
-			expectedIndex: []byte{0x01},
-			readerIndex:   []byte{0x01},
-		},
-		{
-			name:          "bloom",
-			expectedBloom: []byte{0x02},
-			readerBloom:   []byte{0x02},
-		},
-		{
-			name:           "object",
-			expectedObject: []byte{0x03},
-			readerObject:   []byte{0x03},
+			name:         "read",
+			expectedRead: []byte{0x02},
+			readerRead:   []byte{0x02},
 		},
 	}
 
@@ -129,9 +115,7 @@ func TestCache(t *testing.T) {
 				tenants: tt.readerTenants,
 				blocks:  tt.readerBlocks,
 				meta:    tt.readerMeta,
-				bloom:   tt.readerBloom,
-				index:   tt.readerIndex,
-				object:  tt.readerObject,
+				read:    tt.readerRead,
 			}
 			mockW := &mockWriter{}
 			mockC := &mockCache{
@@ -153,28 +137,16 @@ func TestCache(t *testing.T) {
 			assert.Equal(t, tt.expectedBlocks, blocks)
 			meta, _ := rw.BlockMeta(ctx, blockID, tenantID)
 			assert.Equal(t, tt.expectedMeta, meta)
-			bloom, _ := rw.Bloom(ctx, blockID, tenantID, shardNum)
-			assert.Equal(t, tt.expectedBloom, bloom)
-			index, _ := rw.Index(ctx, blockID, tenantID)
-			assert.Equal(t, tt.expectedIndex, index)
-
-			if tt.expectedObject != nil {
-				object := make([]byte, 1)
-				_ = rw.Object(ctx, blockID, tenantID, 0, object)
-				assert.Equal(t, tt.expectedObject, object)
-			}
+			read, _ := rw.Read(ctx, "test", blockID, tenantID)
+			assert.Equal(t, tt.expectedRead, read)
 
 			// clear reader and re-request.  things should be cached!
-			mockR.bloom = nil
-			mockR.index = nil
 			mockR.tenants = nil
 			mockR.blocks = nil
 			mockR.meta = nil
 
-			bloom, _ = rw.Bloom(ctx, blockID, tenantID, shardNum)
-			assert.Equal(t, tt.expectedBloom, bloom)
-			index, _ = rw.Index(ctx, blockID, tenantID)
-			assert.Equal(t, tt.expectedIndex, index)
+			read, _ = rw.Read(ctx, "test", blockID, tenantID)
+			assert.Equal(t, tt.expectedRead, read)
 
 			// others should be nil
 			tenants, _ = rw.Tenants(ctx)

--- a/tempodb/backend/redis/cache.go
+++ b/tempodb/backend/redis/cache.go
@@ -12,11 +12,6 @@ import (
 	"github.com/google/uuid"
 )
 
-const (
-	typeBloom = "bloom"
-	typeIndex = "index"
-)
-
 type Config struct {
 	ClientConfig cache.RedisConfig `yaml:",inline"`
 

--- a/tempodb/backend/redis/cache.go
+++ b/tempodb/backend/redis/cache.go
@@ -1,8 +1,10 @@
 package redis
 
 import (
+	"bytes"
 	"context"
-	"strconv"
+	"io"
+	"io/ioutil"
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
@@ -102,27 +104,37 @@ func (r *readerWriter) Shutdown() {
 	r.client.Stop()
 }
 
-// Writer
-func (r *readerWriter) Write(ctx context.Context, meta *backend.BlockMeta, bBloom [][]byte, bIndex []byte, objectFilePath string) error {
-	for i, b := range bBloom {
-		r.set(ctx, bloomKey(meta.BlockID, meta.TenantID, i), b)
-	}
-	r.set(ctx, key(meta.BlockID, meta.TenantID), bIndex)
+// Write implements backend.Writer
+func (r *readerWriter) Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64) error {
+	if size > 0 && size < backend.MaxCacheSizeBytes {
+		var bytesBuffer bytes.Buffer
+		tee := io.TeeReader(data, &bytesBuffer)
 
-	return r.nextWriter.Write(ctx, meta, bBloom, bIndex, objectFilePath)
+		object, err := ioutil.ReadAll(tee)
+		if err != nil {
+			return err
+		}
+
+		r.set(ctx, key(blockID, tenantID, name), object)
+		data = &bytesBuffer
+	}
+
+	return r.nextWriter.Write(ctx, name, blockID, tenantID, data, size)
 }
 
-func (r *readerWriter) WriteBlockMeta(ctx context.Context, tracker backend.AppendTracker, meta *backend.BlockMeta, bBloom [][]byte, bIndex []byte) error {
-	for i, b := range bBloom {
-		r.set(ctx, bloomKey(meta.BlockID, meta.TenantID, i), b)
-	}
-	r.set(ctx, key(meta.BlockID, meta.TenantID), bIndex)
-
-	return r.nextWriter.WriteBlockMeta(ctx, tracker, meta, bBloom, bIndex)
+// WriteBlockMeta implements backend.Writer
+func (r *readerWriter) WriteBlockMeta(ctx context.Context, meta *backend.BlockMeta) error {
+	return r.nextWriter.WriteBlockMeta(ctx, meta)
 }
 
-func (r *readerWriter) AppendObject(ctx context.Context, tracker backend.AppendTracker, meta *backend.BlockMeta, bObject []byte) (backend.AppendTracker, error) {
-	return r.nextWriter.AppendObject(ctx, tracker, meta, bObject)
+// Append implements backend.Writer
+func (r *readerWriter) Append(ctx context.Context, name string, blockID uuid.UUID, tenantID string, tracker backend.AppendTracker, buffer []byte) (backend.AppendTracker, error) {
+	return r.nextWriter.Append(ctx, name, blockID, tenantID, tracker, buffer)
+}
+
+// CloseAppend implements backend.Writer
+func (r *readerWriter) CloseAppend(ctx context.Context, tracker backend.AppendTracker) error {
+	return r.nextWriter.CloseAppend(ctx, tracker)
 }
 
 func (r *readerWriter) get(ctx context.Context, key string) []byte {
@@ -137,10 +149,6 @@ func (r *readerWriter) set(ctx context.Context, key string, val []byte) {
 	r.client.Store(ctx, []string{key}, [][]byte{val})
 }
 
-func key(blockID uuid.UUID, tenantID string) string {
-	return blockID.String() + ":" + tenantID + ":" + typeIndex
-}
-
-func bloomKey(blockID uuid.UUID, tenantID string, shardNum int) string {
-	return blockID.String() + ":" + tenantID + ":" + typeBloom + strconv.Itoa(shardNum)
+func key(blockID uuid.UUID, tenantID string, name string) string {
+	return blockID.String() + ":" + tenantID + ":" + name
 }

--- a/tempodb/backend/redis/cache.go
+++ b/tempodb/backend/redis/cache.go
@@ -50,27 +50,30 @@ func New(nextReader backend.Reader, nextWriter backend.Writer, cfg *Config, logg
 	return rw, rw, nil
 }
 
-// Reader
+// Tenants implements backend.Reader
 func (r *readerWriter) Tenants(ctx context.Context) ([]string, error) {
 	return r.nextReader.Tenants(ctx)
 }
 
+// Blocks implements backend.Reader
 func (r *readerWriter) Blocks(ctx context.Context, tenantID string) ([]uuid.UUID, error) {
 	return r.nextReader.Blocks(ctx, tenantID)
 }
 
+// BlockMeta implements backend.Reader
 func (r *readerWriter) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*backend.BlockMeta, error) {
 	return r.nextReader.BlockMeta(ctx, blockID, tenantID)
 }
 
-func (r *readerWriter) Bloom(ctx context.Context, blockID uuid.UUID, tenantID string, shardNum int) ([]byte, error) {
-	key := bloomKey(blockID, tenantID, shardNum)
+// Read implements backend.Reader
+func (r *readerWriter) Read(ctx context.Context, name string, blockID uuid.UUID, tenantID string) ([]byte, error) {
+	key := key(blockID, tenantID, name)
 	val := r.get(ctx, key)
 	if val != nil {
 		return val, nil
 	}
 
-	val, err := r.nextReader.Bloom(ctx, blockID, tenantID, shardNum)
+	val, err := r.nextReader.Read(ctx, name, blockID, tenantID)
 	if err == nil {
 		r.set(ctx, key, val)
 	}
@@ -78,25 +81,12 @@ func (r *readerWriter) Bloom(ctx context.Context, blockID uuid.UUID, tenantID st
 	return val, err
 }
 
-func (r *readerWriter) Index(ctx context.Context, blockID uuid.UUID, tenantID string) ([]byte, error) {
-	key := key(blockID, tenantID)
-	val := r.get(ctx, key)
-	if val != nil {
-		return val, nil
-	}
-
-	val, err := r.nextReader.Index(ctx, blockID, tenantID)
-	if err == nil {
-		r.set(ctx, key, val)
-	}
-
-	return val, err
+// ReadRange implements backend.Reader
+func (r *readerWriter) ReadRange(ctx context.Context, name string, blockID uuid.UUID, tenantID string, offset uint64, buffer []byte) error {
+	return r.nextReader.ReadRange(ctx, name, blockID, tenantID, offset, buffer)
 }
 
-func (r *readerWriter) Object(ctx context.Context, blockID uuid.UUID, tenantID string, start uint64, buffer []byte) error {
-	return r.nextReader.Object(ctx, blockID, tenantID, start, buffer)
-}
-
+// Shutdown implements backend.Reader
 func (r *readerWriter) Shutdown() {
 	r.nextReader.Shutdown()
 	r.client.Stop()

--- a/tempodb/backend/redis/cache_test.go
+++ b/tempodb/backend/redis/cache_test.go
@@ -2,7 +2,6 @@ package redis
 
 import (
 	"context"
-	"io"
 	"testing"
 
 	"github.com/alicebob/miniredis"
@@ -10,51 +9,9 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/tempodb/backend"
+	"github.com/grafana/tempo/tempodb/backend/util"
 	"github.com/stretchr/testify/assert"
 )
-
-type mockReader struct {
-	tenants []string
-	blocks  []uuid.UUID
-	meta    *backend.BlockMeta
-	read    []byte
-}
-
-func (m *mockReader) Tenants(ctx context.Context) ([]string, error) {
-	return m.tenants, nil
-}
-func (m *mockReader) Blocks(ctx context.Context, tenantID string) ([]uuid.UUID, error) {
-	return m.blocks, nil
-}
-func (m *mockReader) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*backend.BlockMeta, error) {
-	return m.meta, nil
-}
-func (m *mockReader) Read(ctx context.Context, name string, blockID uuid.UUID, tenantID string) ([]byte, error) {
-	return m.read, nil
-}
-func (m *mockReader) ReadRange(ctx context.Context, name string, blockID uuid.UUID, tenantID string, offset uint64, buffer []byte) error {
-	return nil
-}
-func (m *mockReader) Shutdown() {}
-
-type mockWriter struct {
-}
-
-func (m *mockWriter) Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, buffer []byte) error {
-	return nil
-}
-func (m *mockWriter) WriteReader(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64) error {
-	return nil
-}
-func (m *mockWriter) WriteBlockMeta(ctx context.Context, meta *backend.BlockMeta) error {
-	return nil
-}
-func (m *mockWriter) Append(ctx context.Context, name string, blockID uuid.UUID, tenantID string, tracker backend.AppendTracker, buffer []byte) (backend.AppendTracker, error) {
-	return nil, nil
-}
-func (m *mockWriter) CloseAppend(ctx context.Context, tracker backend.AppendTracker) error {
-	return nil
-}
 
 func TestCache(t *testing.T) {
 	tenantID := "test"
@@ -91,13 +48,13 @@ func TestCache(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mr, _ := miniredis.Run()
-			mockR := &mockReader{
-				tenants: tt.readerTenants,
-				blocks:  tt.readerBlocks,
-				meta:    tt.readerMeta,
-				read:    tt.readerRead,
+			mockR := &util.MockReader{
+				T: tt.readerTenants,
+				B: tt.readerBlocks,
+				M: tt.readerMeta,
+				R: tt.readerRead,
 			}
-			mockW := &mockWriter{}
+			mockW := &util.MockWriter{}
 			mockC := cache.NewRedisClient(&cache.RedisConfig{
 				Endpoint: mr.Addr(),
 			})
@@ -121,9 +78,9 @@ func TestCache(t *testing.T) {
 			assert.Equal(t, tt.expectedRead, read)
 
 			// clear reader and re-request.  things should be cached!
-			mockR.tenants = nil
-			mockR.blocks = nil
-			mockR.meta = nil
+			mockR.T = nil
+			mockR.B = nil
+			mockR.M = nil
 
 			read, _ = rw.Read(ctx, "test", blockID, tenantID)
 			assert.Equal(t, tt.expectedRead, read)

--- a/tempodb/backend/s3/compactor.go
+++ b/tempodb/backend/s3/compactor.go
@@ -53,7 +53,7 @@ func (rw *readerWriter) ClearBlock(blockID uuid.UUID, tenantID string) error {
 	// ListObjects(bucket, prefix, marker, delimiter string, maxKeys int)
 	res, err := rw.core.ListObjects(rw.cfg.Bucket, path, "", "/", 0)
 	if err != nil {
-		return errors.Wrapf(err, "error listing tenants in bucket %s", rw.cfg.Bucket)
+		return errors.Wrapf(err, "error listing objects in bucket %s", rw.cfg.Bucket)
 	}
 
 	level.Debug(rw.logger).Log("msg", "listing objects", "found", len(res.Contents))

--- a/tempodb/backend/s3/compactor.go
+++ b/tempodb/backend/s3/compactor.go
@@ -47,7 +47,7 @@ func (rw *readerWriter) ClearBlock(blockID uuid.UUID, tenantID string) error {
 		return backend.ErrEmptyBlockID
 	}
 
-	path = util.RootPath(blockID, tenantID) + "/"
+	path := util.RootPath(blockID, tenantID) + "/"
 	level.Debug(rw.logger).Log("msg", "deleting block", "block path", path)
 
 	// ListObjects(bucket, prefix, marker, delimiter string, maxKeys int)
@@ -57,7 +57,6 @@ func (rw *readerWriter) ClearBlock(blockID uuid.UUID, tenantID string) error {
 	}
 
 	level.Debug(rw.logger).Log("msg", "listing objects", "found", len(res.Contents))
-	var tenants []string
 	for _, obj := range res.Contents {
 		err = rw.core.RemoveObject(context.TODO(), rw.cfg.Bucket, obj.Key, minio.RemoveObjectOptions{})
 		if err != nil {

--- a/tempodb/backend/s3/compactor.go
+++ b/tempodb/backend/s3/compactor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/grafana/tempo/tempodb/encoding/bloom"
 	"github.com/minio/minio-go/v7"
 
 	"github.com/go-kit/kit/log/level"
@@ -48,18 +47,19 @@ func (rw *readerWriter) ClearBlock(blockID uuid.UUID, tenantID string) error {
 		return backend.ErrEmptyBlockID
 	}
 
-	level.Debug(rw.logger).Log("msg", "deleting block", "block path", util.BlockFileName(blockID, tenantID))
+	path = util.RootPath(blockID, tenantID) + "/"
+	level.Debug(rw.logger).Log("msg", "deleting block", "block path", path)
 
-	// list of objects that need to be deleted
-	var delObjects []string
-	delObjects = append(delObjects, util.CompactedMetaFileName(blockID, tenantID))
-	for i := 0; i < bloom.GetShardNum(); i++ {
-		delObjects = append(delObjects, util.BloomFileName(blockID, tenantID, i))
+	// ListObjects(bucket, prefix, marker, delimiter string, maxKeys int)
+	res, err := rw.core.ListObjects(rw.cfg.Bucket, path, "", "/", 0)
+	if err != nil {
+		return errors.Wrapf(err, "error listing tenants in bucket %s", rw.cfg.Bucket)
 	}
-	delObjects = append(delObjects, util.IndexFileName(blockID, tenantID))
-	delObjects = append(delObjects, util.ObjectFileName(blockID, tenantID))
-	for _, obj := range delObjects {
-		err := rw.core.RemoveObject(context.TODO(), rw.cfg.Bucket, obj, minio.RemoveObjectOptions{})
+
+	level.Debug(rw.logger).Log("msg", "listing objects", "found", len(res.Contents))
+	var tenants []string
+	for _, obj := range res.Contents {
+		err = rw.core.RemoveObject(context.TODO(), rw.cfg.Bucket, obj.Key, minio.RemoveObjectOptions{})
 		if err != nil {
 			return errors.Wrapf(err, "error deleting obj from s3: %s", obj)
 		}

--- a/tempodb/backend/s3/compactor.go
+++ b/tempodb/backend/s3/compactor.go
@@ -60,7 +60,7 @@ func (rw *readerWriter) ClearBlock(blockID uuid.UUID, tenantID string) error {
 	for _, obj := range res.Contents {
 		err = rw.core.RemoveObject(context.TODO(), rw.cfg.Bucket, obj.Key, minio.RemoveObjectOptions{})
 		if err != nil {
-			return errors.Wrapf(err, "error deleting obj from s3: %s", obj)
+			return errors.Wrapf(err, "error deleting obj from s3: %s", obj.Key)
 		}
 	}
 

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -32,6 +32,14 @@ type readerWriter struct {
 	core   *minio.Core
 }
 
+// appendTracker is a struct used to track multipart uploads
+type appendTracker struct {
+	uploadID   string
+	partNum    int
+	parts      []minio.ObjectPart
+	objectName string
+}
+
 type overrideSignatureVersion struct {
 	useV2    bool
 	upstream credentials.Provider
@@ -116,99 +124,39 @@ func New(cfg *Config) (backend.Reader, backend.Writer, backend.Compactor, error)
 }
 
 // Write implements backend.Writer
-func (rw *readerWriter) Write(ctx context.Context, meta *backend.BlockMeta, bBloom [][]byte, bIndex []byte, objectFilePath string) error {
-	if err := util.FileExists(objectFilePath); err != nil {
-		return err
-	}
+func (rw *readerWriter) Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64) error {
+	objName := util.ObjectFileName(blockID, tenantID, name)
 
-	objName := util.ObjectFileName(meta.BlockID, meta.TenantID)
-	info, err := rw.core.FPutObject(
+	info, err := rw.core.Client.PutObject(
 		ctx,
 		rw.cfg.Bucket,
 		objName,
-		objectFilePath,
+		data,
+		size,
 		minio.PutObjectOptions{PartSize: rw.cfg.PartSize},
 	)
 	if err != nil {
 		return errors.Wrapf(err, "error writing object to s3 backend, object %s", objName)
 	}
-
 	level.Debug(rw.logger).Log("msg", "object uploaded to s3", "objectName", objName, "size", info.Size)
-
-	err = rw.WriteBlockMeta(ctx, nil, meta, bBloom, bIndex)
-	if err != nil {
-		return err
-	}
 
 	return nil
 }
 
 // WriteBlockMeta implements backend.Writer
-func (rw *readerWriter) WriteBlockMeta(ctx context.Context, tracker backend.AppendTracker, meta *backend.BlockMeta, bBloom [][]byte, bIndex []byte) error {
-	if tracker != nil {
-		a := tracker.(AppenderTracker)
-		completeParts := make([]minio.CompletePart, 0)
-		for _, p := range a.parts {
-			completeParts = append(completeParts, minio.CompletePart{
-				PartNumber: p.PartNumber,
-				ETag:       p.ETag,
-			})
-		}
-		level.Debug(rw.logger).Log("msg", "marking compacted block complete", "parts", len(completeParts))
-		objName := util.ObjectFileName(meta.BlockID, meta.TenantID)
-		etag, err := rw.core.CompleteMultipartUpload(
-			ctx,
-			rw.cfg.Bucket,
-			objName,
-			a.uploadID,
-			completeParts,
-		)
-		if err != nil {
-			return errors.Wrapf(err, "error completing multipart upload, object: %s, obj etag: %s", objName, etag)
-		}
-	}
-
+func (rw *readerWriter) WriteBlockMeta(ctx context.Context, meta *backend.BlockMeta) error {
 	blockID := meta.BlockID
 	tenantID := meta.TenantID
 	options := minio.PutObjectOptions{
 		PartSize: rw.cfg.PartSize,
 	}
 
-	for i, b := range bBloom {
-		info, err := rw.core.Client.PutObject(
-			ctx,
-			rw.cfg.Bucket,
-			util.BloomFileName(blockID, tenantID, i),
-			bytes.NewReader(b),
-			int64(len(b)),
-			options,
-		)
-		if err != nil {
-			return errors.Wrap(err, "error uploading bloom filter to s3")
-		}
-		level.Debug(rw.logger).Log("msg", "block bloom uploaded to s3", "shard", i, "size", info.Size)
-	}
-
-	info, err := rw.core.Client.PutObject(
-		ctx,
-		rw.cfg.Bucket,
-		util.IndexFileName(blockID, tenantID),
-		bytes.NewReader(bIndex),
-		int64(len(bIndex)),
-		options,
-	)
-	if err != nil {
-		return errors.Wrap(err, "error uploading index to s3")
-	}
-	level.Debug(rw.logger).Log("msg", "block index uploaded to s3", "size", info.Size)
-
 	bMeta, err := json.Marshal(meta)
 	if err != nil {
 		return errors.Wrap(err, "error unmarshalling block meta json")
 	}
 
-	// write meta last.  this will prevent blocklist from returning a partial block
-	info, err = rw.core.Client.PutObject(
+	info, err := rw.core.Client.PutObject(
 		ctx,
 		rw.cfg.Bucket,
 		util.MetaFileName(blockID, tenantID),
@@ -224,44 +172,41 @@ func (rw *readerWriter) WriteBlockMeta(ctx context.Context, tracker backend.Appe
 	return nil
 }
 
-type AppenderTracker struct {
-	uploadID string
-	partNum  int
-	parts    []minio.ObjectPart
-}
-
 // AppendObject implements backend.Writer
-func (rw *readerWriter) AppendObject(ctx context.Context, tracker backend.AppendTracker, meta *backend.BlockMeta, bObject []byte) (backend.AppendTracker, error) {
-	var a AppenderTracker
+func (rw *readerWriter) Append(ctx context.Context, name string, blockID uuid.UUID, tenantID string, tracker backend.AppendTracker, buffer []byte) (backend.AppendTracker, error) {
+	var a appendTracker
+	objectName := util.ObjectFileName(blockID, tenantID, name)
+
 	options := minio.PutObjectOptions{
 		PartSize: rw.cfg.PartSize,
 	}
 	if tracker != nil {
-		a = tracker.(AppenderTracker)
+		a = tracker.(appendTracker)
 	} else {
 		id, err := rw.core.NewMultipartUpload(
 			ctx,
 			rw.cfg.Bucket,
-			util.ObjectFileName(meta.BlockID, meta.TenantID),
+			objectName,
 			options,
 		)
 		if err != nil {
 			return nil, err
 		}
 		a.uploadID = id
+		a.objectName = objectName
 	}
 
-	level.Debug(rw.logger).Log("msg", "appending object to s3", "objectName", util.ObjectFileName(meta.BlockID, meta.TenantID))
+	level.Debug(rw.logger).Log("msg", "appending object to s3", "objectName", objectName)
 
 	a.partNum++
 	objPart, err := rw.core.PutObjectPart(
 		ctx,
 		rw.cfg.Bucket,
-		util.ObjectFileName(meta.BlockID, meta.TenantID),
+		objectName,
 		a.uploadID,
 		a.partNum,
-		bytes.NewReader(bObject),
-		int64(len(bObject)),
+		bytes.NewReader(buffer),
+		int64(len(buffer)),
 		"",
 		"",
 		nil,
@@ -272,6 +217,31 @@ func (rw *readerWriter) AppendObject(ctx context.Context, tracker backend.Append
 	a.parts = append(a.parts, objPart)
 
 	return a, nil
+}
+
+// CloseAppend implements backend.Writer
+func (rw *readerWriter) CloseAppend(ctx context.Context, tracker backend.AppendTracker) error {
+	a := tracker.(appendTracker)
+	completeParts := make([]minio.CompletePart, 0)
+	for _, p := range a.parts {
+		completeParts = append(completeParts, minio.CompletePart{
+			PartNumber: p.PartNumber,
+			ETag:       p.ETag,
+		})
+	}
+
+	etag, err := rw.core.CompleteMultipartUpload(
+		ctx,
+		rw.cfg.Bucket,
+		a.objectName,
+		a.uploadID,
+		completeParts,
+	)
+	if err != nil {
+		return errors.Wrapf(err, "error completing multipart upload, object: %s, obj etag: %s", objName, etag)
+	}
+
+	return nil
 }
 
 // Tenants implements backend.Reader

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -244,7 +244,7 @@ func (rw *readerWriter) CloseAppend(ctx context.Context, tracker backend.AppendT
 		completeParts,
 	)
 	if err != nil {
-		return errors.Wrapf(err, "error completing multipart upload, object: %s, obj etag: %s", objName, etag)
+		return errors.Wrapf(err, "error completing multipart upload, object: %s, obj etag: %s", a.objectName, etag)
 	}
 
 	return nil

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -124,7 +124,12 @@ func New(cfg *Config) (backend.Reader, backend.Writer, backend.Compactor, error)
 }
 
 // Write implements backend.Writer
-func (rw *readerWriter) Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64) error {
+func (rw *readerWriter) Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, buffer []byte) error {
+	return rw.WriteReader(ctx, name, blockID, tenantID, bytes.NewBuffer(buffer), int64(len(buffer)))
+}
+
+// WriteReader implements backend.Writer
+func (rw *readerWriter) WriteReader(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64) error {
 	objName := util.ObjectFileName(blockID, tenantID, name)
 
 	info, err := rw.core.Client.PutObject(

--- a/tempodb/backend/util/test.go
+++ b/tempodb/backend/util/test.go
@@ -1,0 +1,60 @@
+package util
+
+import (
+	"context"
+	"io"
+
+	"github.com/google/uuid"
+	"github.com/grafana/tempo/tempodb/backend"
+)
+
+type MockReader struct {
+	T      []string
+	B      []uuid.UUID        // blocks
+	M      *backend.BlockMeta // meta
+	R      []byte             // read
+	Range  []byte             // ReadRange
+	ReadFn func(name string, blockID uuid.UUID, tenantID string) ([]byte, error)
+}
+
+func (m *MockReader) Tenants(ctx context.Context) ([]string, error) {
+	return m.T, nil
+}
+func (m *MockReader) Blocks(ctx context.Context, tenantID string) ([]uuid.UUID, error) {
+	return m.B, nil
+}
+func (m *MockReader) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*backend.BlockMeta, error) {
+	return m.M, nil
+}
+func (m *MockReader) Read(ctx context.Context, name string, blockID uuid.UUID, tenantID string) ([]byte, error) {
+	if m.ReadFn != nil {
+		return m.ReadFn(name, blockID, tenantID)
+	}
+
+	return m.R, nil
+}
+func (m *MockReader) ReadRange(ctx context.Context, name string, blockID uuid.UUID, tenantID string, offset uint64, buffer []byte) error {
+	copy(buffer, m.Range)
+
+	return nil
+}
+func (m *MockReader) Shutdown() {}
+
+type MockWriter struct {
+}
+
+func (m *MockWriter) Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, buffer []byte) error {
+	return nil
+}
+func (m *MockWriter) WriteReader(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64) error {
+	return nil
+}
+func (m *MockWriter) WriteBlockMeta(ctx context.Context, meta *backend.BlockMeta) error {
+	return nil
+}
+func (m *MockWriter) Append(ctx context.Context, name string, blockID uuid.UUID, tenantID string, tracker backend.AppendTracker, buffer []byte) (backend.AppendTracker, error) {
+	return nil, nil
+}
+func (m *MockWriter) CloseAppend(ctx context.Context, tracker backend.AppendTracker) error {
+	return nil
+}

--- a/tempodb/backend/util/util.go
+++ b/tempodb/backend/util/util.go
@@ -20,8 +20,8 @@ func IndexFileName(blockID uuid.UUID, tenantID string) string {
 	return path.Join(RootPath(blockID, tenantID), "index")
 }
 
-func ObjectFileName(blockID uuid.UUID, tenantID string) string {
-	return path.Join(RootPath(blockID, tenantID), "data")
+func ObjectFileName(blockID uuid.UUID, tenantID string, name string) string {
+	return path.Join(RootPath(blockID, tenantID), name)
 }
 
 func CompactedMetaFileName(blockID uuid.UUID, tenantID string) string {

--- a/tempodb/backend/util/util.go
+++ b/tempodb/backend/util/util.go
@@ -3,7 +3,6 @@ package util
 import (
 	"os"
 	"path"
-	"strconv"
 
 	"github.com/google/uuid"
 )
@@ -12,24 +11,12 @@ func MetaFileName(blockID uuid.UUID, tenantID string) string {
 	return path.Join(RootPath(blockID, tenantID), "meta.json")
 }
 
-func BloomFileName(blockID uuid.UUID, tenantID string, bloomShard int) string {
-	return path.Join(RootPath(blockID, tenantID), "bloom-"+strconv.Itoa(bloomShard))
-}
-
-func IndexFileName(blockID uuid.UUID, tenantID string) string {
-	return path.Join(RootPath(blockID, tenantID), "index")
-}
-
 func ObjectFileName(blockID uuid.UUID, tenantID string, name string) string {
 	return path.Join(RootPath(blockID, tenantID), name)
 }
 
 func CompactedMetaFileName(blockID uuid.UUID, tenantID string) string {
 	return path.Join(RootPath(blockID, tenantID), "meta.compacted.json")
-}
-
-func BlockFileName(blockID uuid.UUID, tenantID string) string {
-	return RootPath(blockID, tenantID) + "/"
 }
 
 // nolint:interfacer

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -256,9 +256,14 @@ func finishBlock(rw *readerWriter, tracker backend.AppendTracker, block *encodin
 	if err != nil {
 		return err
 	}
-	block.Complete()
 
-	err = block.Write(context.TODO(), tracker, rw.w) // todo:  add timeout
+	ctx := context.TODO()
+	err = block.Complete(ctx, tracker, rw.w)
+	if err != nil {
+		return err
+	}
+
+	err = block.Write(ctx, rw.w) // todo:  add timeout
 	if err != nil {
 		return err
 	}

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -235,14 +235,14 @@ func (rw *readerWriter) compact(blockMetas []*backend.BlockMeta, tenantID string
 }
 
 func appendBlock(rw *readerWriter, tracker backend.AppendTracker, block *encoding.CompactorBlock) (backend.AppendTracker, error) {
+	compactionLevelLabel := strconv.Itoa(int(block.BlockMeta().CompactionLevel - 1))
+	metricCompactionObjectsWritten.WithLabelValues(compactionLevelLabel).Add(float64(block.CurrentBufferedObjects()))
+	metricCompactionBytesWritten.WithLabelValues(compactionLevelLabel).Add(float64(block.CurrentBufferLength()))
+
 	tracker, err := block.FlushBuffer(context.TODO(), tracker, rw.w)
 	if err != nil {
 		return nil, err
 	}
-
-	compactionLevelLabel := strconv.Itoa(int(block.BlockMeta().CompactionLevel - 1))
-	metricCompactionObjectsWritten.WithLabelValues(compactionLevelLabel).Add(float64(block.CurrentBufferedObjects()))
-	metricCompactionBytesWritten.WithLabelValues(compactionLevelLabel).Add(float64(block.CurrentBufferLength()))
 
 	return tracker, nil
 }

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -51,10 +51,6 @@ func TestCompaction(t *testing.T) {
 		Local: &local.Config{
 			Path: path.Join(tempDir, "traces"),
 		},
-		/*GCS: &gcs.Config{
-			BucketName:      "temp-jelliott",
-			ChunkBufferSize: 10 * 1024 * 1024,
-		},*/
 		WAL: &wal.Config{
 			Filepath:        path.Join(tempDir, "wal"),
 			IndexDownsample: 11,

--- a/tempodb/encoding/backend_block.go
+++ b/tempodb/encoding/backend_block.go
@@ -1,0 +1,104 @@
+package encoding
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/grafana/tempo/tempodb/backend"
+	"github.com/grafana/tempo/tempodb/encoding/bloom"
+
+	willf_bloom "github.com/willf/bloom"
+	"go.uber.org/atomic"
+)
+
+// FindMetrics is a threadsafe struct for tracking metrics related to a parallelized query
+type FindMetrics struct {
+	BloomFilterReads     *atomic.Int32
+	BloomFilterBytesRead *atomic.Int32
+	IndexReads           *atomic.Int32
+	IndexBytesRead       *atomic.Int32
+	BlockReads           *atomic.Int32
+	BlockBytesRead       *atomic.Int32
+}
+
+// BackendBlock defines an object that can find traces
+type BackendBlock interface {
+	Find(ctx context.Context, r backend.Reader, id ID, metrics *FindMetrics) ([]byte, error)
+}
+
+type backendBlock struct {
+	meta *backend.BlockMeta
+}
+
+// NewBackendBlock returns a block used for finding traces in the backend
+func NewBackendBlock(meta *backend.BlockMeta) BackendBlock {
+	return &backendBlock{
+		meta: meta,
+	}
+}
+
+// Find searches a block for the ID and returns an object if found.
+func (b *backendBlock) Find(ctx context.Context, r backend.Reader, id ID, metrics *FindMetrics) ([]byte, error) {
+	shardKey := bloom.ShardKeyForTraceID(id)
+	blockID := b.meta.BlockID
+	tenantID := b.meta.TenantID
+
+	bloomBytes, err := r.Read(ctx, bloomName(shardKey), blockID, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving bloom %v", err)
+	}
+
+	filter := &willf_bloom.BloomFilter{}
+	_, err = filter.ReadFrom(bytes.NewReader(bloomBytes))
+	if err != nil {
+		return nil, fmt.Errorf("error parsing bloom %v", err)
+	}
+
+	metrics.BloomFilterReads.Inc()
+	metrics.BloomFilterBytesRead.Add(int32(len(bloomBytes)))
+	if !filter.Test(id) {
+		return nil, nil
+	}
+
+	indexBytes, err := r.Read(ctx, nameIndex, blockID, tenantID)
+	metrics.IndexReads.Inc()
+	metrics.IndexBytesRead.Add(int32(len(indexBytes)))
+	if err != nil {
+		return nil, fmt.Errorf("error reading index %v", err)
+	}
+
+	record, err := FindRecord(id, indexBytes) // todo: replace with backend.Finder
+	if err != nil {
+		return nil, fmt.Errorf("error finding record %v", err)
+	}
+
+	if record == nil {
+		return nil, nil
+	}
+
+	objectBytes := make([]byte, record.Length)
+	err = r.ReadRange(ctx, nameObjects, blockID, tenantID, record.Start, objectBytes)
+	metrics.BlockReads.Inc()
+	metrics.BlockBytesRead.Add(int32(len(objectBytes)))
+	if err != nil {
+		return nil, fmt.Errorf("error reading object %v", err)
+	}
+
+	iter := NewIterator(bytes.NewReader(objectBytes))
+	var foundObject []byte
+	for {
+		iterID, iterObject, err := iter.Next()
+		if iterID == nil {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if bytes.Equal(iterID, id) {
+			foundObject = iterObject
+			break
+		}
+	}
+	return foundObject, nil
+}

--- a/tempodb/encoding/backend_block_test.go
+++ b/tempodb/encoding/backend_block_test.go
@@ -1,0 +1,129 @@
+package encoding
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/grafana/tempo/tempodb/backend"
+	"github.com/grafana/tempo/tempodb/backend/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/willf/bloom"
+)
+
+func TestBackendBlock(t *testing.T) {
+	id := []byte{0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01}
+	object := []byte{0x01, 0x02}
+
+	bloom := bloom.New(1, 1)
+	bloom.Add(id)
+
+	bloomBuffer := bytes.Buffer{}
+	_, err := bloom.WriteTo(&bloomBuffer)
+	require.NoError(t, err)
+
+	objectBuffer := bytes.Buffer{}
+	_, err = marshalObjectToWriter(id, object, &objectBuffer)
+	require.NoError(t, err)
+
+	record := newRecord()
+	record.ID = id
+	record.Length = uint32(objectBuffer.Len())
+	index, err := MarshalRecords([]*Record{record})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name               string
+		id                 []byte
+		readerError        error
+		readerBloom        []byte
+		readerIndex        []byte
+		readerRange        []byte
+		expected           []byte
+		expectedBloomReads int32
+		expectedBloomBytes int32
+		expectedIndexReads int32
+		expectedIndexBytes int32
+		expectedBlockReads int32
+		expectedBlockBytes int32
+	}{
+		{
+			name:        "error",
+			id:          id,
+			readerError: errors.New("wups"),
+		},
+		{
+			name:               "bloom passes",
+			id:                 id,
+			readerBloom:        bloomBuffer.Bytes(),
+			expectedBloomReads: 1,
+			expectedBloomBytes: int32(bloomBuffer.Len()),
+			expectedIndexReads: 1,
+		},
+		{
+			name:               "index passes",
+			id:                 id,
+			readerBloom:        bloomBuffer.Bytes(),
+			readerIndex:        index,
+			expectedBloomReads: 1,
+			expectedBloomBytes: int32(bloomBuffer.Len()),
+			expectedIndexReads: 1,
+			expectedIndexBytes: int32(len(index)),
+			expectedBlockReads: 1,
+			expectedBlockBytes: int32(objectBuffer.Len()),
+		},
+		{
+			name:               "obj found",
+			id:                 id,
+			readerBloom:        bloomBuffer.Bytes(),
+			readerIndex:        index,
+			readerRange:        objectBuffer.Bytes(),
+			expected:           object,
+			expectedBloomReads: 1,
+			expectedBloomBytes: int32(bloomBuffer.Len()),
+			expectedIndexReads: 1,
+			expectedIndexBytes: int32(len(index)),
+			expectedBlockReads: 1,
+			expectedBlockBytes: int32(objectBuffer.Len()),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fn := func(name string, blockID uuid.UUID, tenantID string) ([]byte, error) {
+				if tt.readerError != nil {
+					return nil, tt.readerError
+				}
+
+				if strings.Contains(name, nameBloomPrefix) {
+					return tt.readerBloom, nil
+				}
+
+				return tt.readerIndex, nil
+			}
+
+			mockR := &util.MockReader{
+				ReadFn: fn,
+				Range:  tt.readerRange,
+			}
+
+			findMetrics := NewFindMetrics()
+			block := NewBackendBlock(&backend.BlockMeta{})
+			actual, err := block.Find(context.Background(), mockR, tt.id, &findMetrics)
+
+			assert.True(t, errors.Is(err, tt.readerError))
+			assert.Equal(t, tt.expected, actual)
+			assert.Equal(t, tt.expectedBloomReads, findMetrics.BloomFilterReads.Load())
+			assert.Equal(t, tt.expectedBloomBytes, findMetrics.BloomFilterBytesRead.Load())
+			assert.Equal(t, tt.expectedIndexReads, findMetrics.IndexReads.Load())
+			assert.Equal(t, tt.expectedIndexBytes, findMetrics.IndexBytesRead.Load())
+			assert.Equal(t, tt.expectedBlockReads, findMetrics.BlockReads.Load())
+			assert.Equal(t, tt.expectedBlockBytes, findMetrics.BlockBytesRead.Load())
+		})
+	}
+
+}

--- a/tempodb/encoding/block.go
+++ b/tempodb/encoding/block.go
@@ -1,0 +1,43 @@
+package encoding
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/grafana/tempo/tempodb/backend"
+)
+
+const (
+	nameObjects     = "data"
+	nameIndex       = "index"
+	nameBloomPrefix = "bloom-"
+)
+
+func bloomName(shard int) string {
+	return nameBloomPrefix + strconv.Itoa(shard)
+}
+
+func writeBlock(ctx context.Context, w backend.Writer, meta *backend.BlockMeta, index []byte, blooms [][]byte) error {
+	// index
+	err := w.Write(ctx, nameIndex, meta.BlockID, meta.TenantID, index)
+	if err != nil {
+		return fmt.Errorf("unexpected error writing index %w", err)
+	}
+
+	// bloom
+	for i, bloom := range blooms {
+		err := w.Write(ctx, bloomName(i), meta.BlockID, meta.TenantID, bloom)
+		if err != nil {
+			return fmt.Errorf("unexpected error writing bloom-%d %w", i, err)
+		}
+	}
+
+	// meta
+	err = w.WriteBlockMeta(ctx, meta)
+	if err != nil {
+		return fmt.Errorf("unexpected error writing meta %w", err)
+	}
+
+	return nil
+}

--- a/tempodb/encoding/compactor_block.go
+++ b/tempodb/encoding/compactor_block.go
@@ -97,7 +97,7 @@ func (c *CompactorBlock) Complete(ctx context.Context, tracker backend.AppendTra
 	}
 
 	meta := c.BlockMeta()
-	writeBlock(ctx, w, meta, indexBytes, bloomBuffers)
+	err = writeBlock(ctx, w, meta, indexBytes, bloomBuffers)
 	if err != nil {
 		return err
 	}

--- a/tempodb/encoding/compactor_block.go
+++ b/tempodb/encoding/compactor_block.go
@@ -53,10 +53,6 @@ func (c *CompactorBlock) AddObject(id ID, object []byte) error {
 	return nil
 }
 
-func (c *CompactorBlock) CurrentBuffer() []byte {
-	return c.appendBuffer.Bytes()
-}
-
 func (c *CompactorBlock) CurrentBufferLength() int {
 	return c.appendBuffer.Len()
 }
@@ -72,7 +68,7 @@ func (c *CompactorBlock) Length() int {
 // FlushBuffer flushes any existing objects to the backend
 func (c *CompactorBlock) FlushBuffer(ctx context.Context, tracker backend.AppendTracker, w backend.Writer) (backend.AppendTracker, error) {
 	meta := c.BlockMeta()
-	tracker, err := w.Append(ctx, nameObjects, meta.BlockID, meta.TenantID, tracker, block.CurrentBuffer())
+	tracker, err := w.Append(ctx, nameObjects, meta.BlockID, meta.TenantID, tracker, c.appendBuffer.Bytes())
 	if err != nil {
 		return nil, err
 	}

--- a/tempodb/encoding/compactor_block_test.go
+++ b/tempodb/encoding/compactor_block_test.go
@@ -2,10 +2,8 @@ package encoding
 
 import (
 	"bytes"
-	"io/ioutil"
 	"math"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -24,13 +22,7 @@ func TestCompactorBlockError(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestCompactorBlockWrite(t *testing.T) {
-	tempDir, err := ioutil.TempDir("/tmp", "")
-	defer os.RemoveAll(tempDir)
-	assert.NoError(t, err, "unexpected error creating temp dir")
-
-	assert.NoError(t, err)
-
+func TestCompactorBlockAddObject(t *testing.T) {
 	indexDownsample := 3
 	bloomFP := .01
 
@@ -74,7 +66,7 @@ func TestCompactorBlockWrite(t *testing.T) {
 			maxID = id
 		}
 	}
-	cb.Complete()
+	cb.appender.Complete()
 
 	assert.Equal(t, numObjects, cb.Length())
 

--- a/tempodb/encoding/iterator_backend.go
+++ b/tempodb/encoding/iterator_backend.go
@@ -21,7 +21,7 @@ type backendIterator struct {
 }
 
 func NewBackendIterator(tenantID string, blockID uuid.UUID, chunkSizeBytes uint32, reader backend.Reader) (Iterator, error) {
-	index, err := reader.Index(context.TODO(), blockID, tenantID)
+	index, err := reader.Read(context.TODO(), nameIndex, blockID, tenantID)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func (i *backendIterator) Next() (ID, []byte, error) {
 		i.objectsBuffer = make([]byte, length)
 	}
 	i.activeObjectsBuffer = i.objectsBuffer[:length]
-	err = i.r.Object(context.TODO(), i.blockID, i.tenantID, start, i.activeObjectsBuffer)
+	err = i.r.ReadRange(context.TODO(), nameObjects, i.blockID, i.tenantID, start, i.activeObjectsBuffer)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error iterating through object in backend")
 	}

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -83,7 +83,7 @@ type Writer interface {
 }
 
 type Reader interface {
-	Find(ctx context.Context, tenantID string, id encoding.ID, blockStart string, blockEnd string) ([]byte, FindMetrics, error)
+	Find(ctx context.Context, tenantID string, id encoding.ID, blockStart string, blockEnd string) ([]byte, encoding.FindMetrics, error)
 	Shutdown()
 }
 
@@ -187,7 +187,7 @@ func (rw *readerWriter) WAL() *wal.WAL {
 	return rw.wal
 }
 
-func (rw *readerWriter) Find(ctx context.Context, tenantID string, id encoding.ID, blockStart string, blockEnd string) ([]byte, FindMetrics, error) {
+func (rw *readerWriter) Find(ctx context.Context, tenantID string, id encoding.ID, blockStart string, blockEnd string) ([]byte, encoding.FindMetrics, error) {
 	metrics := encoding.FindMetrics{
 		BloomFilterReads:     atomic.NewInt32(0),
 		BloomFilterBytesRead: atomic.NewInt32(0),

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -14,7 +14,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"go.uber.org/atomic"
 
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/opentracing/opentracing-go"
@@ -188,14 +187,7 @@ func (rw *readerWriter) WAL() *wal.WAL {
 }
 
 func (rw *readerWriter) Find(ctx context.Context, tenantID string, id encoding.ID, blockStart string, blockEnd string) ([]byte, encoding.FindMetrics, error) {
-	metrics := encoding.FindMetrics{
-		BloomFilterReads:     atomic.NewInt32(0),
-		BloomFilterBytesRead: atomic.NewInt32(0),
-		IndexReads:           atomic.NewInt32(0),
-		IndexBytesRead:       atomic.NewInt32(0),
-		BlockReads:           atomic.NewInt32(0),
-		BlockBytesRead:       atomic.NewInt32(0),
-	}
+	metrics := encoding.NewFindMetrics()
 
 	// tracing instrumentation
 	logger := util.WithContext(ctx, util.Logger)


### PR DESCRIPTION
**What this PR does**:
This started as a smaller PR that has gotten fairly intense.  List of changes
- Refactor of backend.Reader and Writer interfaces to be agnostic to the underlying data layout
  - Changes to all backends to match the new interfaces
- Removal of index functionality in the cli (not worth further complication of the BackendBlock interface)
- Minor refactor/simplification of CompactorBlock methods
- Changed s3 backend's ClearBlock method to not be reliant on knowledge of individual objects
- Added BackendBlock interface and used it in tempodb Find method
This is close to being done, but still requires some additional testing.

**Which issue(s) this PR fixes**:
Fixes #

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`