### PR TITLE
Delay tempo start to make sure that minio is running

### DIFF
--- a/example/docker-compose/docker-compose.s3.minio.yaml
+++ b/example/docker-compose/docker-compose.s3.minio.yaml
@@ -3,13 +3,18 @@ services:
 
   tempo:
     image: grafana/tempo:latest
-    command: ["-config.file=/etc/tempo.yaml"]
+    entrypoint:
+      - sh
+      - -euc
+      - sleep 5 && /tempo -config.file=/etc/tempo.yaml
     volumes:
       - ./etc/tempo-s3-minio.yaml:/etc/tempo.yaml
       - ./example-data/tempo:/tmp/tempo
     ports:
       - "14268"      # jaeger
       - "3100:3100"  # tempo
+    depends_on: 
+      - minio
 
   minio:
     image: minio/minio:RELEASE.2020-07-27T18-37-02Z


### PR DESCRIPTION
**What this PR does**:
While experimenting with the local minio example I noticed that Tempo was regularly refusing to start b/c the minio backend was not ready.  First, I attempted to use `depends_on`, but even this was not sufficient to prevent Tempo from failing on startup. 

I am not happy with this fix, but I'm unable to find a better way.