### PR TITLE
Fix Ingester Stutter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [ENHANCEMENT] Add docker-compose example for GCS along with new backend options [#397](https://github.com/grafana/tempo/pull/397)
 * [ENHANCEMENT] tempo-cli list blocks usability improvements [#403](https://github.com/grafana/tempo/pull/403)
 * [ENHANCEMENT] Add Query Frontend module to allow scaling the query path [#400](https://github.com/grafana/tempo/pull/400)
+* [ENHANCEMENT] Reduce active traces locking time. [#449](https://github.com/grafana/tempo/pull/449)
 * [BUGFIX] Compactor without GCS permissions fail silently [#379](https://github.com/grafana/tempo/issues/379)
 * [BUGFIX] Prevent race conditions between querier polling and ingesters clearing complete blocks [#421](https://github.com/grafana/tempo/issues/421)
 * [BUGFIX] Exclude blocks in last active window from compaction [#411](https://github.com/grafana/tempo/pull/411)

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -318,11 +318,11 @@ func (i *instance) tracesToCut(cutoff time.Duration, immediate bool) []*trace {
 	i.tracesMtx.Lock()
 	defer i.tracesMtx.Unlock()
 
-	now := time.Now()
+	cutoffTime := time.Now().Add(cutoff)
 	tracesToCut := make([]*trace, 0, len(i.traces))
 
 	for key, trace := range i.traces {
-		if now.Add(cutoff).After(trace.lastAppend) || immediate {
+		if cutoffTime.After(trace.lastAppend) || immediate {
 			tracesToCut = append(tracesToCut, trace)
 			delete(i.traces, key)
 		}

--- a/modules/ingester/instance_test.go
+++ b/modules/ingester/instance_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/tempo/tempodb/wal"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type ringCountMock struct {
@@ -324,7 +325,7 @@ func TestInstanceCutCompleteTraces(t *testing.T) {
 			}
 
 			err := instance.CutCompleteTraces(tc.cutoff, tc.immediate)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			assert.Equal(t, len(tc.expectedExist), len(instance.traces))
 			for _, expectedExist := range tc.expectedExist {

--- a/modules/ingester/instance_test.go
+++ b/modules/ingester/instance_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"testing"
 	"time"
@@ -250,6 +251,90 @@ func TestInstanceLimits(t *testing.T) {
 				err := i.Push(context.Background(), push.req)
 
 				assert.Equalf(t, push.expectsError, err != nil, "push %d failed", j)
+			}
+		})
+	}
+}
+
+func TestInstanceCutCompleteTraces(t *testing.T) {
+	tempDir, _ := ioutil.TempDir("/tmp", "")
+	defer os.RemoveAll(tempDir)
+
+	id := make([]byte, 16)
+	rand.Read(id)
+	tracepb := test.MakeTrace(10, id)
+	pastTrace := &trace{
+		traceID:    id,
+		trace:      tracepb,
+		lastAppend: time.Now().Add(-time.Hour),
+	}
+
+	id = make([]byte, 16)
+	rand.Read(id)
+	nowTrace := &trace{
+		traceID:    id,
+		trace:      tracepb,
+		lastAppend: time.Now().Add(time.Hour),
+	}
+
+	tt := []struct {
+		name             string
+		cutoff           time.Duration
+		immediate        bool
+		input            []*trace
+		expectedExist    []*trace
+		expectedNotExist []*trace
+	}{
+		{
+			name:      "empty",
+			cutoff:    0,
+			immediate: false,
+		},
+		{
+			name:             "cut immediate",
+			cutoff:           0,
+			immediate:        true,
+			input:            []*trace{pastTrace, nowTrace},
+			expectedNotExist: []*trace{pastTrace, nowTrace},
+		},
+		{
+			name:             "cut recent",
+			cutoff:           0,
+			immediate:        false,
+			input:            []*trace{pastTrace, nowTrace},
+			expectedExist:    []*trace{nowTrace},
+			expectedNotExist: []*trace{pastTrace},
+		},
+		{
+			name:             "cut all time",
+			cutoff:           2 * time.Hour,
+			immediate:        false,
+			input:            []*trace{pastTrace, nowTrace},
+			expectedNotExist: []*trace{pastTrace, nowTrace},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			instance := defaultInstance(t, tempDir)
+
+			for _, trace := range tc.input {
+				fp := instance.tokenForTraceID(trace.traceID)
+				instance.traces[fp] = trace
+			}
+
+			err := instance.CutCompleteTraces(tc.cutoff, tc.immediate)
+			assert.NoError(t, err)
+
+			assert.Equal(t, len(tc.expectedExist), len(instance.traces))
+			for _, expectedExist := range tc.expectedExist {
+				_, ok := instance.traces[instance.tokenForTraceID(expectedExist.traceID)]
+				assert.True(t, ok)
+			}
+
+			for _, expectedNotExist := range tc.expectedNotExist {
+				_, ok := instance.traces[instance.tokenForTraceID(expectedNotExist.traceID)]
+				assert.False(t, ok)
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does**:
Ingesters currently show unreasonably high p99's on read and write.  This is likely due to slow appends to the headblock.   Note that under the hood it is [inserting into a slice](https://github.com/grafana/tempo/blob/a7961951f136e323ada598b26f0ff38f34da2174/tempodb/encoding/appender.go#L30).

This PR reduces the time that we lock the active traces map by simply adding them to a linked list.  Then we drop the active traces lock and only lock the blocks while we are adding them to the append block.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`