### PR TITLE
Increase distributor_traces_per_batch buckets

### DIFF
--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -57,7 +57,7 @@ var (
 		Namespace: "tempo",
 		Name:      "distributor_traces_per_batch",
 		Help:      "The number of traces in each batch",
-		Buckets:   prometheus.LinearBuckets(0, 3, 10),
+		Buckets:   prometheus.ExponentialBuckets(2, 2, 10),
 	})
 	metricIngesterClients = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "tempo",


### PR DESCRIPTION
**What this PR does**:
This is a continuation of #439 to increase the bucket range even further, up to 1024.  Testing in internal environment was showing +Inf bucket still receiving a significant amount of traffic and local testing with the synthetic-load-generator was able to produce batches with 300+ traces, which far exceeds the current limit.   

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`