### PR TITLE
Downgraded the distributor alert to warning

### DIFF
--- a/operations/tempo-mixin/alerts.libsonnet
+++ b/operations/tempo-mixin/alerts.libsonnet
@@ -60,7 +60,7 @@
               max by (cluster, namespace) (cortex_ring_members{state="Unhealthy", name="distributor"}) > 0
             |||,
             labels: {
-              severity: 'critical',
+              severity: 'warning',
             },
             annotations: {
               message: 'There are {{ printf "%f" $value }} unhealthy distributor(s).',

--- a/operations/tempo-mixin/out/alerts.yaml
+++ b/operations/tempo-mixin/out/alerts.yaml
@@ -20,7 +20,7 @@
         {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency.
       "runbook_url": "https://github.com/grafana/tempo/tree/master/operations/tempo-mixin/runbook.md#TempoRequestLatency"
     "expr": |
-      namespace_job_route:tempo_request_duration_seconds:99quantile{} > 3
+      namespace_job_route:tempo_request_duration_seconds:99quantile{route!~"metrics|/frontend.Frontend/Process"} > 3
     "for": "15m"
     "labels":
       "severity": "critical"
@@ -41,7 +41,7 @@
       max by (cluster, namespace) (cortex_ring_members{state="Unhealthy", name="distributor"}) > 0
     "for": "15m"
     "labels":
-      "severity": "critical"
+      "severity": "warning"
   - "alert": "TempoCompactionsFailing"
     "annotations":
       "message": "Greater than 2 compactions have failed in the past hour."

--- a/operations/tempo-mixin/runbook.md
+++ b/operations/tempo-mixin/runbook.md
@@ -23,9 +23,10 @@ Note that this more of an art than a science: https://github.com/grafana/tempo/i
 ## TempoDistributorUnhealthy
 
 Tempo by default uses [Memberlist](https://github.com/hashicorp/memberlist) to persist the ring state between components.
-Occasionally this results in old components staying in the ring which impacts distributors only if you are using the 
-global rate limiting strategy.  If this occurs port-forward to 3100 on a distributor and bring up `/distributor/ring`.  Use the
-"Forget" button to drop any unhealthy distributors.
+Occasionally this results in old components staying in the ring which does not impact distributors directly, but at some point 
+your components will be passing around a lot of unnecessary information. It may also indicate that a component shut down
+unexpectedly and may be worth investigating. If this occurs port-forward to 3100 on a distributor and bring up `/distributor/ring`. 
+Use the "Forget" button to drop any unhealthy distributors.
 
 Note that this more of an art than a science: https://github.com/grafana/tempo/issues/142
 


### PR DESCRIPTION
**What this PR does**:
The distributor alert in the mixin does not actually indicate any kind of degraded functionality in Tempo, but rather that something perhaps should be investigated.  Unlike previously thought unhealthy distributors does _not_ impact global rate limiting.

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`