### PR TITLE
Fix Ingester Query Latency Spikes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## master / unreleased
+* [CHANGE] Fixed ingester latency spikes on read [#461](https://github.com/grafana/tempo/pull/461)
 
 ## v0.5.0
 


### PR DESCRIPTION
**What this PR does**:
Reduces the locking range on the block mutex during an active traces flush.  This significantly improves Ingester query latency:

![image](https://user-images.githubusercontent.com/2272392/104775932-334e5c00-5747-11eb-9797-4e84fcdca610.png)

I was surprised to not immediately see similar improvement at the query frontend.  However, I did find that the impact of querier scaling is now much more apparent with the ingester fix:

![image](https://user-images.githubusercontent.com/2272392/104776097-81fbf600-5747-11eb-97e9-0268e045ffbb.png)

First annotation is the new ingester being deployed.  Second annotation is scaling the queriers to 10.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`