### PR TITLE
Made memcached replica count configurable

### DIFF
--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -27,6 +27,9 @@
       receivers: error 'Must specify receivers',
       replicas: 1,
     },
+    memcached: {
+      replicas: 3,
+    },
     jaeger_ui: {
       base_path: '/',
     },

--- a/operations/jsonnet/microservices/memcached.libsonnet
+++ b/operations/jsonnet/microservices/memcached.libsonnet
@@ -9,7 +9,7 @@ memcached {
     local statefulSet = $.apps.v1.statefulSet,
 
     statefulSet:
-      statefulSet.new(self.name, 3, [
+      statefulSet.new(self.name, $._config.memcached.replicas, [
         self.memcached_container,
         self.memcached_exporter,
       ], []) +


### PR DESCRIPTION
**What this PR does**:
Made the number of memcached replicas configurable in the tempo-microservices jsonnet.   Was previously hardcoded to 3.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`