### PR TITLE
Add alert for failed polling of the blocklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * [CHANGE] Fixed ingester latency spikes on read [#461](https://github.com/grafana/tempo/pull/461)
 * [ENHANCEMENT] Serve config at the "/config" endpoint. [#446](https://github.com/grafana/tempo/pull/446)
 * [BUGFIX] Upgrade cortex dependency to 1.6 to address issue with forgetting ring membership [#442](https://github.com/grafana/tempo/pull/442)
+* [BUGFIX] No longer raise the `tempodb_blocklist_poll_errors_total` metric if a block doesn't have meta or compacted meta. [#481](https://github.com/grafana/tempo/pull/481)
 
 ## v0.5.0
 

--- a/operations/tempo-mixin/alerts.libsonnet
+++ b/operations/tempo-mixin/alerts.libsonnet
@@ -93,6 +93,19 @@
               runbook_url: 'https://github.com/grafana/tempo/tree/master/operations/tempo-mixin/runbook.md#TempoFlushesFailing'
             },
           },
+          {
+            alert: 'TempoPollsFailing',
+            expr: |||
+              sum by (cluster, namespace) (increase(tempodb_blocklist_poll_errors_total{}[1h])) > %s
+            ||| % $._config.alerts.polls_per_hour_failed,
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              message: 'Greater than %s polls have failed in the past hour.' % $._config.alerts.polls_per_hour_failed,
+              runbook_url: 'https://github.com/grafana/tempo/tree/master/operations/tempo-mixin/runbook.md#TempoPollsFailing'
+            },
+          },
         ],
       },
     ],

--- a/operations/tempo-mixin/config.libsonnet
+++ b/operations/tempo-mixin/config.libsonnet
@@ -11,6 +11,7 @@
     alerts: {
       compactions_per_hour_failed: 2,
       flushes_per_hour_failed: 2,
+      polls_per_hour_failed: 2,
     },
   },
 }

--- a/operations/tempo-mixin/runbook.md
+++ b/operations/tempo-mixin/runbook.md
@@ -46,3 +46,12 @@ remove them.
 In the case of failed flushes your local WAL disk is now filling up.  Tempo will continue to retry sending the blocks
 until it succeeds, but at some point your WAL files will start failing to write due to out of disk issues.  If the problem 
 persists consider killing the block that's failing to upload in `/var/tempo/wal` and restarting the ingester.
+
+## TempoPollsFailing
+
+If polls are failing check the component that is raising this metric and look for any obvious logs that may indicate a quick fix.
+If you see logs about the number of blocks being too long for the job queue then raise the `storage.traces.pool.max_workers` value
+to compensate.
+
+Generally, failure to poll just means that the component is not aware of the current state of the backend but will continue working 
+otherwise.  Queriers, for instance, will start returning 404s as their internal representation of the backend grows stale.

--- a/tempodb/backend/gcs/gcs.go
+++ b/tempodb/backend/gcs/gcs.go
@@ -193,7 +193,7 @@ func (rw *readerWriter) Blocks(ctx context.Context, tenantID string) ([]uuid.UUI
 	return blocks, warning
 }
 
-// Tenants implements backend.Reader
+// BlockMeta implements backend.Reader
 func (rw *readerWriter) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*backend.BlockMeta, error) {
 	name := util.MetaFileName(blockID, tenantID)
 

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -334,6 +334,12 @@ func (rw *readerWriter) pollBlocklist() {
 				compactedBlockMeta, err = rw.c.CompactedBlockMeta(blockID, tenantID)
 			}
 
+			// blocks in intermediate states may not have a compacted or normal block meta.
+			//   this is not necessarily an error, just bail out
+			if err == backend.ErrMetaDoesNotExist {
+				return nil, nil
+			}
+
 			if err != nil {
 				metricBlocklistErrors.WithLabelValues(tenantID).Inc()
 				level.Error(rw.logger).Log("msg", "failed to retrieve block meta", "tenantID", tenantID, "blockID", blockID, "err", err)


### PR DESCRIPTION
**What this PR does**:
- Adds alert and runbook for failure to poll blocklist
- No longer considers it an error if a block does not have a meta or compacted block meta (this was artificially raising failure to poll blocklist)

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`