### PR TITLE
Write block meta last to prevent bad blocks

### DIFF
--- a/tempodb/encoding/complete_block.go
+++ b/tempodb/encoding/complete_block.go
@@ -89,11 +89,6 @@ func (c *CompleteBlock) BlockMeta() *backend.BlockMeta {
 
 // Write implements WriteableBlock
 func (c *CompleteBlock) Write(ctx context.Context, w backend.Writer) error {
-	err := writeBlockMeta(ctx, w, c.meta, c.records, c.bloom)
-	if err != nil {
-		return err
-	}
-
 	// write object file
 	src, err := os.Open(c.fullFilename())
 	if err != nil {
@@ -107,6 +102,11 @@ func (c *CompleteBlock) Write(ctx context.Context, w backend.Writer) error {
 	}
 
 	err = writeBlockData(ctx, w, c.meta, src, fileStat.Size())
+	if err != nil {
+		return err
+	}
+
+	err = writeBlockMeta(ctx, w, c.meta, c.records, c.bloom)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does**:
Write the block meta last.  This will prevent components from attempting to access a block that does not yet exist.
