### PR TITLE
A few dashboard tweaks

### DIFF
--- a/operations/tempo-mixin/tempo-operational.json
+++ b/operations/tempo-mixin/tempo-operational.json
@@ -281,7 +281,7 @@
       "targets": [
         {
           "expr": "go_goroutines{cluster=\"$cluster\", namespace=\"$namespace\", job=~\"$namespace/$component\"}",
-          "legendFormat": "{{job}}",
+          "legendFormat": "{{pod}}",
           "refId": "A"
         }
       ],
@@ -470,7 +470,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$component.*\"}",
+          "expr": "container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$component.*\", container!=\"POD\"}",
           "interval": "",
           "legendFormat": "{{pod}}",
           "refId": "A"


### PR DESCRIPTION
**What this PR does**:
A few tempo operational dashboard tweaks:
1. goroutines panel use {{pod}} instead of {{job}}.  Job is a constant value like "ingester". Pod is what we want "ingester-nn"
2. Working set panel ignore container=POD, which yields not useful metrics like memory = 3MB.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`