### PR TITLE
Add s3 options region and forcepathstyle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [CHANGE] Ingester cut blocks based on size instead of trace count.  Replace ingester `traces_per_block` setting with `max_block_bytes`. This is a **breaking change**. [#474](https://github.com/grafana/tempo/issues/474)
 * [ENHANCEMENT] Serve config at the "/config" endpoint. [#446](https://github.com/grafana/tempo/pull/446)
 * [ENHANCEMENT] Switch blocklist polling and retention to different concurrency mechanism, add configuration options. [#475](https://github.com/grafana/tempo/issues/475)
+* [ENHANCEMENT] Add S3 options region and forcepathstyle [#431](https://github.com/grafana/tempo/issues/431)
 * [BUGFIX] Upgrade cortex dependency to 1.6 to address issue with forgetting ring membership [#442](https://github.com/grafana/tempo/pull/442)
 * [BUGFIX] No longer raise the `tempodb_blocklist_poll_errors_total` metric if a block doesn't have meta or compacted meta. [#481](https://github.com/grafana/tempo/pull/481)
 

--- a/docs/tempo/website/configuration/s3.md
+++ b/docs/tempo/website/configuration/s3.md
@@ -12,9 +12,12 @@ storage:
         s3:
             bucket: tempo                                   # store traces in this bucket
             endpoint: s3.dualstack.us-east-2.amazonaws.com  # api endpoint
+            region: us-east-2                               # optional. By default the region is inferred from the endpoint
+                                                            #           but is required for some S3-compatible storage engines.
             access_key: ...                                 # optional. access key when using static credentials. 
             secret_key: ...                                 # optional. secret key when using static credentials.
             insecure: false                                 # optional. enable if endpoint is http
+            forcepathstyle: false                           # optional. enable to use path-style requests.
 ```
 
 ## Permissions

--- a/tempodb/backend/s3/config.go
+++ b/tempodb/backend/s3/config.go
@@ -5,10 +5,12 @@ import "github.com/cortexproject/cortex/pkg/util/flagext"
 type Config struct {
 	Bucket    string         `yaml:"bucket"`
 	Endpoint  string         `yaml:"endpoint"`
+	Region    string         `yaml:"region"`
 	AccessKey flagext.Secret `yaml:"access_key"`
 	SecretKey flagext.Secret `yaml:"secret_key"`
 	Insecure  bool           `yaml:"insecure"`
 	PartSize  uint64         `yaml:"part_size"`
 	// SignatureV2 configures the object storage to use V2 signing instead of V4
-	SignatureV2 bool `yaml:"signature_v2"`
+	SignatureV2    bool `yaml:"signature_v2"`
+	ForcePathStyle bool `yaml:"forcepathstyle"`
 }

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -90,10 +90,17 @@ func New(cfg *Config) (backend.Reader, backend.Writer, backend.Compactor, error)
 			},
 		}),
 	})
+
 	opts := &minio.Options{
+		Region: cfg.Region,
 		Secure: !cfg.Insecure,
 		Creds:  creds,
 	}
+
+	if cfg.ForcePathStyle {
+		opts.BucketLookup = minio.BucketLookupPath
+	}
+
 	core, err := minio.NewCore(cfg.Endpoint, opts)
 	if err != nil {
 		return nil, nil, nil, err


### PR DESCRIPTION
**What this PR does**:
Re-add s3 region and add forcepathstyle config options.   Digging deeper, the cortex s3 client does not support multipart uploads which is critical to tempo, therefore it is not the right fit at this time, and stayed with the minio client.

**Which issue(s) this PR fixes**:
Fixes #431 

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`