### PR TITLE
Skip workflow runs if the change only affects the docs folder

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,5 +1,8 @@
 name: Benchmark
-on: [pull_request]
+on: 
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
 jobs:
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
-on: [pull_request]
+on: 
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
 jobs:
 
   build:


### PR DESCRIPTION
**What this PR does**:
If a PR only changes the contents of the `docs/` folder, there is no need to run the `benchmark` and the `ci` workflows.

I tried it on a private repo, and looks like it's working! Hopefully here will work too.

My tests:
- Change file inside `docs/` -> Workflow skiped.
- Change file outside `docs/` -> Workflow run.
- Change file inside `docs/` and file outside `docs/` -> Workflow run.

**Which issue(s) this PR fixes**:
This was discussed with @annanay25 on Slack.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`