### PR TITLE
Also mount overrides.yaml for the compactor now that it reads them

### DIFF
--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -108,6 +108,11 @@
     configMap.new('tempo-compactor') +
     configMap.withData({
       'tempo.yaml': $.util.manifestYaml($.tempo_compactor_config),
+    }) +
+    configMap.withDataMixin({
+      'overrides.yaml': $.util.manifestYaml({
+        overrides: $._config.overrides,
+      }),
     }),
 
   tempo_query_frontend_config:: $.tempo_config{},


### PR DESCRIPTION
**What this PR does**:
The jsonnet for compactors sets the per_tenant_override_file, but doesn't mount the configmap, so it was always pointing to a non-existent file.  Now that compactors read the overrides, they fail since it doesn't exist.   This PR updates the jsonnet to mount it as expected.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`