### PR TITLE
Increment discarded spans metric for all limit reasons

### DIFF
--- a/integration/e2e/config-limits.yaml
+++ b/integration/e2e/config-limits.yaml
@@ -14,6 +14,8 @@ distributor:
 overrides:
   max_spans_per_trace: 1
   max_traces_per_user: 1
+  ingestion_rate_limit: 5
+  ingestion_burst_size: 5
 
 ingester:
   lifecycler:

--- a/integration/e2e/config-limits.yaml
+++ b/integration/e2e/config-limits.yaml
@@ -1,0 +1,35 @@
+auth_enabled: false
+
+target: all
+
+server:
+  http_listen_port: 3100
+
+distributor:
+  receivers:
+    jaeger:
+      protocols:
+        grpc:
+
+overrides:
+  max_spans_per_trace: 1
+  max_traces_per_user: 1
+
+ingester:
+  lifecycler:
+    address: 127.0.0.1
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+    final_sleep: 0s
+  trace_idle_period: 3600s
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo
+    pool:
+      max_workers: 10
+      queue_depth: 100

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -234,20 +234,29 @@ func TestMicroservices(t *testing.T) {
 }
 
 func makeThriftBatch() *thrift.Batch {
+	return makeThriftBatchWithSpanCount(1)
+}
+
+func makeThriftBatchWithSpanCount(n int) *thrift.Batch {
 	var spans []*thrift.Span
-	spans = append(spans, &thrift.Span{
-		TraceIdLow:    rand.Int63(),
-		TraceIdHigh:   0,
-		SpanId:        rand.Int63(),
-		ParentSpanId:  0,
-		OperationName: "my operation",
-		References:    nil,
-		Flags:         0,
-		StartTime:     time.Now().Unix(),
-		Duration:      1,
-		Tags:          nil,
-		Logs:          nil,
-	})
+
+	traceIDLow := rand.Int63()
+	traceIDHigh := rand.Int63()
+	for i := 0; i < n; i++ {
+		spans = append(spans, &thrift.Span{
+			TraceIdLow:    traceIDLow,
+			TraceIdHigh:   traceIDHigh,
+			SpanId:        rand.Int63(),
+			ParentSpanId:  0,
+			OperationName: "my operation",
+			References:    nil,
+			Flags:         0,
+			StartTime:     time.Now().Unix(),
+			Duration:      1,
+			Tags:          nil,
+			Logs:          nil,
+		})
+	}
 	return &thrift.Batch{Spans: spans}
 }
 

--- a/integration/e2e/limits_test.go
+++ b/integration/e2e/limits_test.go
@@ -47,7 +47,7 @@ func TestLimits(t *testing.T) {
 	require.NoError(t, err)
 	err = tempo.WaitSumMetricsWithOptions(cortex_e2e.Equals(1),
 		[]string{"tempo_discarded_spans_total"},
-		cortex_e2e.WithLabelMatchers(labels.MustNewMatcher(labels.MatchEqual, "reason", "too_many_traces")),
+		cortex_e2e.WithLabelMatchers(labels.MustNewMatcher(labels.MatchEqual, "reason", "live_traces_exceeded")),
 	)
 	require.NoError(t, err)
 	err = tempo.WaitSumMetricsWithOptions(cortex_e2e.Equals(10),

--- a/integration/e2e/limits_test.go
+++ b/integration/e2e/limits_test.go
@@ -1,0 +1,50 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	util "github.com/grafana/tempo/integration"
+	"github.com/prometheus/prometheus/pkg/labels"
+
+	cortex_e2e "github.com/cortexproject/cortex/integration/e2e"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	configLimits = "config-limits.yaml"
+)
+
+func TestLimits(t *testing.T) {
+	s, err := cortex_e2e.NewScenario("tempo_e2e")
+	require.NoError(t, err)
+	defer s.Close()
+
+	require.NoError(t, util.CopyFileToSharedDir(s, configLimits, "config.yaml"))
+	tempo := util.NewTempoAllInOne()
+	require.NoError(t, s.StartAndWaitReady(tempo))
+
+	// Get port for the otlp receiver endpoint
+	c, err := newJaegerGRPCClient(tempo.Endpoint(14250))
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	// should fail b/c the trace is too large
+	batch := makeThriftBatchWithSpanCount(2)
+	require.Error(t, c.EmitBatch(context.Background(), batch))
+	// should fail b/c this will be too many traces
+	batch = makeThriftBatch()
+	require.Error(t, c.EmitBatch(context.Background(), batch))
+
+	// test limit metrics
+	err = tempo.WaitSumMetricsWithOptions(cortex_e2e.Equals(2),
+		[]string{"tempo_discarded_spans_total"},
+		cortex_e2e.WithLabelMatchers(labels.MustNewMatcher(labels.MatchEqual, "reason", "trace_too_large")),
+	)
+	require.NoError(t, err)
+	err = tempo.WaitSumMetricsWithOptions(cortex_e2e.Equals(1),
+		[]string{"tempo_discarded_spans_total"},
+		cortex_e2e.WithLabelMatchers(labels.MustNewMatcher(labels.MatchEqual, "reason", "too_many_traces")),
+	)
+	require.NoError(t, err)
+}

--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -40,8 +40,6 @@ const (
 	reasonTraceTooLarge = "trace_too_large"
 	// reasonTooManyTraces indicates that tempo is already tracking too many live traces in the ingesters for this user
 	reasonTooManyTraces = "too_many_traces"
-	// reasonInternalError indicates that spans were rejected b/c of a failure in Tempo
-	reasonInternalError = "internal_error"
 )
 
 var (
@@ -233,7 +231,6 @@ func (d *Distributor) Push(ctx context.Context, req *tempopb.PushRequest) (*temp
 
 	keys, traces, err := requestsByTraceID(req, userID, spanCount)
 	if err != nil {
-		metricDiscardedSpans.WithLabelValues(reasonInternalError, userID).Add(float64(spanCount))
 		return nil, err
 	}
 
@@ -366,5 +363,5 @@ func reasonForError(err error) string {
 		return reasonTraceTooLarge
 	}
 
-	return reasonInternalError
+	return ""
 }

--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -19,7 +19,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/weaveworks/common/logging"
 	"github.com/weaveworks/common/user"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
@@ -358,7 +357,11 @@ func requestsByTraceID(req *tempopb.PushRequest, userID string, spanCount int) (
 }
 
 func recordDiscaredSpans(err error, userID string, spanCount int) {
-	desc := grpc.ErrorDesc(err)
+	s := status.Convert(err)
+	if s == nil {
+		return
+	}
+	desc := s.Message()
 
 	if strings.HasPrefix(desc, overrides.ErrorPrefixLiveTracesExceeded) {
 		metricDiscardedSpans.WithLabelValues(reasonLiveTracesExceeded, userID).Add(float64(spanCount))

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -288,7 +288,7 @@ func (i *instance) getOrCreateTrace(req *tempopb.PushRequest) (*trace, error) {
 
 	err = i.limiter.AssertMaxTracesPerUser(i.instanceID, len(i.traces))
 	if err != nil {
-		return nil, status.Errorf(codes.FailedPrecondition, "%s max live traces per tenant exceeded: %v", overrides.ErrorPrefixTooManyTraces, err)
+		return nil, status.Errorf(codes.FailedPrecondition, "%s max live traces per tenant exceeded: %v", overrides.ErrorPrefixLiveTracesExceeded, err)
 	}
 
 	maxSpans := i.limiter.limits.MaxSpansPerTrace(i.instanceID)

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"google.golang.org/grpc/codes"
 
+	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/tempodb"
@@ -287,7 +288,7 @@ func (i *instance) getOrCreateTrace(req *tempopb.PushRequest) (*trace, error) {
 
 	err = i.limiter.AssertMaxTracesPerUser(i.instanceID, len(i.traces))
 	if err != nil {
-		return nil, status.Errorf(codes.FailedPrecondition, "max live traces per tenant exceeded: %v", err)
+		return nil, status.Errorf(codes.FailedPrecondition, "%s max live traces per tenant exceeded: %v", overrides.ErrorPrefixTooManyTraces, err)
 	}
 
 	maxSpans := i.limiter.limits.MaxSpansPerTrace(i.instanceID)

--- a/modules/ingester/trace.go
+++ b/modules/ingester/trace.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/gogo/status"
+	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"google.golang.org/grpc/codes"
 )
@@ -37,7 +38,7 @@ func (t *trace) Push(_ context.Context, req *tempopb.PushRequest) error {
 		}
 
 		if t.currentSpans+spanCount > t.maxSpans {
-			return status.Errorf(codes.FailedPrecondition, "totalSpans (%d) exceeded while adding %d spans", t.maxSpans, spanCount)
+			return status.Errorf(codes.FailedPrecondition, "%s totalSpans (%d) exceeded while adding %d spans", overrides.ErrorPrefixTraceTooLarge, t.maxSpans, spanCount)
 		}
 
 		t.currentSpans += spanCount

--- a/modules/overrides/limits.go
+++ b/modules/overrides/limits.go
@@ -11,10 +11,12 @@ const (
 	// GlobalIngestionRateStrategy indicates that an attempt should be made to consider this limit across the entire Tempo cluster
 	GlobalIngestionRateStrategy = "global"
 
-	// ErrorPrefixTooManyTraces is used to flag batches from the ingester that were rejected b/c they had too many traces
-	ErrorPrefixTooManyTraces = "TOO_MANY_TRACES:"
+	// ErrorPrefixLiveTracesExceeded is used to flag batches from the ingester that were rejected b/c they had too many traces
+	ErrorPrefixLiveTracesExceeded = "LIVE_TRACES_EXCEEDED:"
 	// ErrorPrefixTraceTooLarge is used to flag batches from the ingester that were rejected b/c they exceeded the single trace limit
 	ErrorPrefixTraceTooLarge = "TRACE_TOO_LARGE:"
+	// ErrorPrefixRateLimited is used to flag batches that have exceeded the spans/second of the tenant
+	ErrorPrefixRateLimited = "RATE_LIMITED:"
 )
 
 // Limits describe all the limits for users; can be used to describe global default

--- a/modules/overrides/limits.go
+++ b/modules/overrides/limits.go
@@ -6,11 +6,15 @@ import (
 )
 
 const (
-	// Local ingestion rate strategy
+	// LocalIngestionRateStrategy indicates that this limit can be evaluated in local terms only
 	LocalIngestionRateStrategy = "local"
-
-	// Global ingestion rate strategy
+	// GlobalIngestionRateStrategy indicates that an attempt should be made to consider this limit across the entire Tempo cluster
 	GlobalIngestionRateStrategy = "global"
+
+	// ErrorPrefixTooManyTraces is used to flag batches from the ingester that were rejected b/c they had too many traces
+	ErrorPrefixTooManyTraces = "TOO_MANY_TRACES:"
+	// ErrorPrefixTraceTooLarge is used to flag batches from the ingester that were rejected b/c they exceeded the single trace limit
+	ErrorPrefixTraceTooLarge = "TRACE_TOO_LARGE:"
 )
 
 // Limits describe all the limits for users; can be used to describe global default


### PR DESCRIPTION
**What this PR does**:
`tempo_discarded_spans_total` is meant to be a metric to inform tenants as to why they may be getting refused spans.  Previously it only covered the most basic rate limiting case.   This PR looks to extend that to include all limit based reasons that a span might be refused.

There is unfortunately no 100% correct way to metric this.  For instance, in the provided solution we are only including spans from the one trace that was rejected however the distributor will refuse the entire batch.  

We could try to metric this in the distributor which would make the metric more authentic.  It would be gross to try to get the rejection reason.  Substring matching?  It is also true that if a batch is rejected in the ingester it has already probably succeeded on other traces.

No great answers here.  Suggestions welcome.