### PR TITLE
Switch default ingester_client grpc compression from gzip to snappy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [CHANGE] Ingester cut blocks based on size instead of trace count.  Replace ingester `traces_per_block` setting with `max_block_bytes`. This is a **breaking change**. [#474](https://github.com/grafana/tempo/issues/474)
 * [CHANGE] Refactor cache section in tempodb. This is a **breaking change** b/c the cache config section has changed. [#485](https://github.com/grafana/tempo/pull/485)
 * [CHANGE] New compactor setting for max block size data instead of traces. [#520](https://github.com/grafana/tempo/pull/520)
+* [CHANGE] Change default ingester_client compression from gzip to snappy. [#522](https://github.com/grafana/tempo/pull/522)
 * [FEATURE] Added block compression.  This is a **breaking change** b/c some configuration fields moved. [#504](https://github.com/grafana/tempo/pull/504)
 * [ENHANCEMENT] Serve config at the "/config" endpoint. [#446](https://github.com/grafana/tempo/pull/446)
 * [ENHANCEMENT] Switch blocklist polling and retention to different concurrency mechanism, add configuration options. [#475](https://github.com/grafana/tempo/issues/475)

--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -79,6 +79,7 @@ func (c *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 
 	// Everything else
 	flagext.DefaultValues(&c.IngesterClient)
+	c.IngesterClient.GRPCClientConfig.GRPCCompression = "snappy"
 	flagext.DefaultValues(&c.LimitsConfig)
 
 	c.Distributor.RegisterFlagsAndApplyDefaults(tempo_util.PrefixConfig(prefix, "distributor"), f)

--- a/modules/ingester/client/client.go
+++ b/modules/ingester/client/client.go
@@ -45,7 +45,7 @@ func New(addr string, cfg Config) (*Client, error) {
 	opts := []grpc.DialOption{
 		grpc.WithInsecure(),
 		grpc.WithDefaultCallOptions(
-			grpc.UseCompressor("gzip"),
+			grpc.UseCompressor("snappy"),
 		),
 	}
 

--- a/modules/ingester/client/client.go
+++ b/modules/ingester/client/client.go
@@ -44,9 +44,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 func New(addr string, cfg Config) (*Client, error) {
 	opts := []grpc.DialOption{
 		grpc.WithInsecure(),
-		grpc.WithDefaultCallOptions(
-			grpc.UseCompressor("snappy"),
-		),
 	}
 
 	instrumentationOpts, err := cfg.GRPCClientConfig.DialOption(instrumentation())


### PR DESCRIPTION
**What this PR does**:
Switches the default compression for ingester_client from gzip to snappy. This is primarily used for distributor->ingester traffic, but also for querier->ingester.   

Internal testing shows that snappy outperforms gzip:
* 53% reduction in distributor cpu
* 12% reduction in ingester cpu
* 10% reduction in Push latency
* Minor improvements to mem usage (working set)

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`