### PR TITLE
Make sure counters have _total suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [CHANGE] Ingester cut blocks based on size instead of trace count.  Replace ingester `traces_per_block` setting with `max_block_bytes`. This is a **breaking change**. [#474](https://github.com/grafana/tempo/issues/474)
 * [CHANGE] Refactor cache section in tempodb. This is a **breaking change** b/c the cache config section has changed. [#485](https://github.com/grafana/tempo/pull/485)
 * [CHANGE] New compactor setting for max block size data instead of traces. [#520](https://github.com/grafana/tempo/pull/520)
+* [CHANGE/BUGFIX] Rename `tempodb_compaction_objects_written` and `tempodb_compaction_bytes_written` metrics to `tempodb_compaction_objects_written_total` and `tempodb_compaction_bytes_written_total`. [#524](https://github.com/grafana/tempo/pull/524)
 * [FEATURE] Added block compression.  This is a **breaking change** b/c some configuration fields moved. [#504](https://github.com/grafana/tempo/pull/504)
 * [ENHANCEMENT] Serve config at the "/config" endpoint. [#446](https://github.com/grafana/tempo/pull/446)
 * [ENHANCEMENT] Switch blocklist polling and retention to different concurrency mechanism, add configuration options. [#475](https://github.com/grafana/tempo/issues/475)

--- a/docs/tempo/website/troubleshooting/_index.md
+++ b/docs/tempo/website/troubleshooting/_index.md
@@ -118,7 +118,7 @@ Possible reasons why the compactor may not be running are:
 - Compactor sitting idle because no block is hashing to it.
 - Incorrect configuration settings.
 ### Diagnosing the issue
-- Check metric `tempodb_compaction_bytes_written`
+- Check metric `tempodb_compaction_bytes_written_total`
 If this is greater than zero (0), it means the compactor is running and writing to the backend.
 - Check metric `tempodb_compaction_errors_total`
 If this metric is greater than zero (0), check the logs of the compactor for an error message.

--- a/operations/tempo-mixin/out/tempo-operational.json
+++ b/operations/tempo-mixin/out/tempo-operational.json
@@ -4958,7 +4958,7 @@
    "steppedLine": false,
    "targets": [
     {
-     "expr": "sum(rate(tempodb_compaction_objects_written{cluster=\"$cluster\",job=\"$namespace/compactor\"}[$__rate_interval])) by (level)",
+     "expr": "sum(rate(tempodb_compaction_objects_written_total{cluster=\"$cluster\",job=\"$namespace/compactor\"}[$__rate_interval])) by (level)",
      "interval": "",
      "legendFormat": "",
      "refId": "A"
@@ -5067,7 +5067,7 @@
    "steppedLine": false,
    "targets": [
     {
-     "expr": "sum(rate(tempodb_compaction_bytes_written{cluster=\"$cluster\",job=\"$namespace/compactor\"}[$__rate_interval])) by (level)",
+     "expr": "sum(rate(tempodb_compaction_bytes_written_total{cluster=\"$cluster\",job=\"$namespace/compactor\"}[$__rate_interval])) by (level)",
      "interval": "",
      "legendFormat": "",
      "refId": "A"

--- a/operations/tempo-mixin/tempo-operational.json
+++ b/operations/tempo-mixin/tempo-operational.json
@@ -4358,7 +4358,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(tempodb_compaction_objects_written{cluster=\"$cluster\",job=\"$namespace/compactor\"}[$__rate_interval])) by (level)",
+          "expr": "sum(rate(tempodb_compaction_objects_written_total{cluster=\"$cluster\",job=\"$namespace/compactor\"}[$__rate_interval])) by (level)",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -4453,7 +4453,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(tempodb_compaction_bytes_written{cluster=\"$cluster\",job=\"$namespace/compactor\"}[$__rate_interval])) by (level)",
+          "expr": "sum(rate(tempodb_compaction_bytes_written_total{cluster=\"$cluster\",job=\"$namespace/compactor\"}[$__rate_interval])) by (level)",
           "interval": "",
           "legendFormat": "",
           "refId": "A"

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -27,12 +27,12 @@ var (
 	}, []string{"level"})
 	metricCompactionObjectsWritten = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "tempodb",
-		Name:      "compaction_objects_written",
+		Name:      "compaction_objects_written_total",
 		Help:      "Total number of objects written to backend during compaction.",
 	}, []string{"level"})
 	metricCompactionBytesWritten = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "tempodb",
-		Name:      "compaction_bytes_written",
+		Name:      "compaction_bytes_written_total",
 		Help:      "Total number of bytes written to backend during compaction.",
 	}, []string{"level"})
 	metricCompactionErrors = promauto.NewCounter(prometheus.CounterOpts{


### PR DESCRIPTION
Prompted by the metric: `tempo_receiver_accepted_spans` but that comes from OTel so not touching that. Found these two are missing _total so added it.