### PR TITLE
Readiness probe updates

### DIFF
--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -300,6 +300,15 @@ func (t *App) readyHandler(sm *services.Manager) http.HandlerFunc {
 			}
 		}
 
+		// Query Frontend has a special check that makes sure that a querier is attached before it signals
+		// itself as ready
+		if t.frontend != nil {
+			if err := t.frontend.CheckReady(r.Context()); err != nil {
+				http.Error(w, "Query Frontend not ready: "+err.Error(), http.StatusServiceUnavailable)
+				return
+			}
+		}
+
 		http.Error(w, "ready", http.StatusOK)
 	}
 }

--- a/operations/jsonnet/microservices/common.libsonnet
+++ b/operations/jsonnet/microservices/common.libsonnet
@@ -1,0 +1,11 @@
+{
+  util+:: {
+    local container = $.core.v1.container,
+
+    readinessProbe::
+      container.mixin.readinessProbe.httpGet.withPath('/ready') +
+      container.mixin.readinessProbe.httpGet.withPort($._config.port) +
+      container.mixin.readinessProbe.withInitialDelaySeconds(15) +
+      container.mixin.readinessProbe.withTimeoutSeconds(1),
+  },
+}

--- a/operations/jsonnet/microservices/compactor.libsonnet
+++ b/operations/jsonnet/microservices/compactor.libsonnet
@@ -23,7 +23,8 @@
     ]) +
     container.withVolumeMounts([
       volumeMount.new(tempo_config_volume, '/conf'),
-    ]),
+    ]) +
+    $.util.readinessProbe,
 
   tempo_compactor_deployment:
     deployment.new(target_name,

--- a/operations/jsonnet/microservices/distributor.libsonnet
+++ b/operations/jsonnet/microservices/distributor.libsonnet
@@ -23,7 +23,8 @@
     ]) +
     container.withVolumeMounts([
       volumeMount.new(tempo_config_volume, '/conf'),
-    ]),
+    ]) +
+    $.util.readinessProbe,
 
   tempo_distributor_deployment:
     deployment.new(target_name,

--- a/operations/jsonnet/microservices/frontend.libsonnet
+++ b/operations/jsonnet/microservices/frontend.libsonnet
@@ -24,7 +24,8 @@
     ]) +
     container.withVolumeMounts([
       volumeMount.new(tempo_config_volume, '/conf'),
-    ]),
+    ]) +
+    $.util.readinessProbe,
 
   tempo_query_container::
     container.new('tempo-query', $._images.tempo_query) +

--- a/operations/jsonnet/microservices/ingester.libsonnet
+++ b/operations/jsonnet/microservices/ingester.libsonnet
@@ -34,7 +34,8 @@
     container.withVolumeMounts([
       volumeMount.new(tempo_config_volume, '/conf'),
       volumeMount.new(tempo_data_volume, '/var/tempo'),
-    ]),
+    ]) +
+    $.util.readinessProbe,
 
   tempo_ingester_statefulset:
     statefulset.new(

--- a/operations/jsonnet/microservices/querier.libsonnet
+++ b/operations/jsonnet/microservices/querier.libsonnet
@@ -22,7 +22,8 @@
     ]) +
     container.withVolumeMounts([
       volumeMount.new(tempo_config_volume, '/conf'),
-    ]),
+    ]) +
+    $.util.readinessProbe,
 
   tempo_querier_deployment:
     deployment.new(

--- a/operations/jsonnet/microservices/tempo.libsonnet
+++ b/operations/jsonnet/microservices/tempo.libsonnet
@@ -1,4 +1,5 @@
 (import 'ksonnet-util/kausal.libsonnet') +
+(import 'common.libsonnet') +
 (import 'configmap.libsonnet') +
 (import 'config.libsonnet') +
 (import 'compactor.libsonnet') +


### PR DESCRIPTION
**What this PR does**:
Update /ready handler for more detailed check for query-frontend: only return ready when at least 1 querier has connected (this is duplicated from cortex).    Add readiness probes to all jsonnet/microservices containers.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`