### PR TITLE
Fix tempo-cli list block encoding and add some helpful things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [CHANGE] New compactor setting for max block size data instead of traces. [#520](https://github.com/grafana/tempo/pull/520)
 * [CHANGE] Change default ingester_client compression from gzip to snappy. [#522](https://github.com/grafana/tempo/pull/522)
 * [CHANGE/BUGFIX] Rename `tempodb_compaction_objects_written` and `tempodb_compaction_bytes_written` metrics to `tempodb_compaction_objects_written_total` and `tempodb_compaction_bytes_written_total`. [#524](https://github.com/grafana/tempo/pull/524)
+* [CHANGE] Replace tempo-cli `list block` `--check-dupes` option with `--scan` and collect additional stats [#534](https://github.com/grafana/tempo/pull/534) 
 * [FEATURE] Added block compression.  This is a **breaking change** b/c some configuration fields moved. [#504](https://github.com/grafana/tempo/pull/504)
 * [ENHANCEMENT] Serve config at the "/config" endpoint. [#446](https://github.com/grafana/tempo/pull/446)
 * [ENHANCEMENT] Switch blocklist polling and retention to different concurrency mechanism, add configuration options. [#475](https://github.com/grafana/tempo/issues/475)

--- a/docs/tempo/website/cli/_index.md
+++ b/docs/tempo/website/cli/_index.md
@@ -97,7 +97,7 @@ tempo-cli list blocks -c ./tempo.yaml single-tenant
 ```
 
 ## List Block
-Lists information about a single block, and optionally, perform an integrity check for duplicate records.
+Lists information about a single block, and optionally, scan its contents.
 
 ```bash
 tempo-cli list block <tenant-id> <block-id>
@@ -108,7 +108,7 @@ Arguments:
 - `block-id` The block ID as UUID string.
 
 Options:
-- `--check-dupes` Also load the block data and perform integrity check for duplicates. **Note:** can be intense.
+- `--scan` Also load the block data, perform integrity check for duplicates, and collect statistics. **Note:** can be intense.
 
 **Example:**
 ```bash


### PR DESCRIPTION
**What this PR does**:
The tempo-cli `list block --check-dupes` option was broken for compressed blocks because it did not properly set the encoding.  This PR fixes that but also changes the option to `--scan` and adds some help things:  min/max object size, and ability to exit early and print current stats with CRTL+C.  These things were useful during a recent investigation.

The output looks like this:
```
$ ./tempo-cli -c ~/tempo.gcs.yaml list block ............ --scan
ID            :  700f39bb-219a-4bfd-a7c4-24df06cd6db7
Version       :  v1
Total Objects :  273967
Data Size     :  427 MB
Encoding      :  zstd
Level         :  0
Window        :  448220
Start         :  2021-02-17 20:34:00.405224842 +0000 UTC
End           :  2021-02-17 20:38:59.463662752 +0000 UTC
Duration      :  4m59s
Age           :  18m22s
Scanning block contents.  Press CRTL+C to quit ...
Record:  100000
^C
Scanning results:
Objects scanned :  109510
Duplicates      :  0
Smallest object :  371 B
Largest object  :  2.3 MB
```

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`