### PR TITLE
Bump Grafana and Loki versions

### DIFF
--- a/example/docker-compose/docker-compose.azure.azurite.yaml
+++ b/example/docker-compose/docker-compose.azure.azurite.yaml
@@ -58,7 +58,7 @@ services:
       - tempo
       
   grafana:
-    image: grafana/grafana:7.3.0-beta1
+    image: grafana/grafana:7.4.2
     volumes:
       - ./example-data/datasources:/etc/grafana/provisioning/datasources
       - ./example-data/dashboards-provisioning:/etc/grafana/provisioning/dashboards

--- a/example/docker-compose/docker-compose.gcs.fake.yaml
+++ b/example/docker-compose/docker-compose.gcs.fake.yaml
@@ -53,7 +53,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:7.3.0-beta1
+    image: grafana/grafana:7.4.2
     volumes:
       - ./example-data/datasources:/etc/grafana/provisioning/datasources
       - ./example-data/dashboards-provisioning:/etc/grafana/provisioning/dashboards

--- a/example/docker-compose/docker-compose.loki.yaml
+++ b/example/docker-compose/docker-compose.loki.yaml
@@ -47,7 +47,7 @@ services:
         loki-url: 'http://localhost:3100/api/prom/push'
 
   grafana:
-    image: grafana/grafana:7.3.0-beta1
+    image: grafana/grafana:7.4.2
     volumes:
       - ./example-data/datasources:/etc/grafana/provisioning/datasources
       - ./example-data/dashboards-provisioning:/etc/grafana/provisioning/dashboards
@@ -64,7 +64,7 @@ services:
         loki-url: 'http://localhost:3100/api/prom/push'
 
   loki:
-    image: grafana/loki:1.6.1
+    image: grafana/loki:2.1.0
     command: -config.file=/etc/loki/local-config.yaml
     ports:
       - "3100:3100"                                   # loki needs to be exposed so it receives logs

--- a/example/docker-compose/docker-compose.multitenant.yaml
+++ b/example/docker-compose/docker-compose.multitenant.yaml
@@ -42,7 +42,7 @@ services:
     - tempo
 
   grafana:
-    image: grafana/grafana:7.3.0-beta1
+    image: grafana/grafana:7.4.2
     volumes:
       - ./example-data/datasources:/etc/grafana/provisioning/datasources
       - ./example-data/dashboards-provisioning:/etc/grafana/provisioning/dashboards

--- a/example/docker-compose/docker-compose.s3.minio.yaml
+++ b/example/docker-compose/docker-compose.s3.minio.yaml
@@ -59,7 +59,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:7.3.0-beta1
+    image: grafana/grafana:7.4.2
     volumes:
       - ./example-data/datasources:/etc/grafana/provisioning/datasources
       - ./example-data/dashboards-provisioning:/etc/grafana/provisioning/dashboards

--- a/example/docker-compose/docker-compose.yaml
+++ b/example/docker-compose/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:7.3.0-beta1
+    image: grafana/grafana:7.4.2
     volumes:
       - ./example-data/datasources:/etc/grafana/provisioning/datasources
       - ./example-data/dashboards-provisioning:/etc/grafana/provisioning/dashboards

--- a/integration/microservices/docker-compose.yaml
+++ b/integration/microservices/docker-compose.yaml
@@ -73,7 +73,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:7.3.0-beta1
+    image: grafana/grafana:7.4.2
     volumes:
       - ./grafana/datasources/:/etc/grafana/provisioning/datasources/
       - ./grafana/dashboards-provisioning/:/etc/grafana/provisioning/dashboards/


### PR DESCRIPTION
**What this PR does**:
Bumps Grafana from `7.3.0-beta1` to `7.4.2`.
Bumps Loki from `1.6.1` to `2.1.0`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`