### PR TITLE
Add binary name in goreleaser config to avoid overwrite

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,7 @@
 builds:
   - id: "tempo"
     main: ./cmd/tempo
+    binary: tempo
     env:
       - CGO_ENABLED=0
     goos:
@@ -19,6 +20,7 @@ builds:
     mod_timestamp: '{{ .CommitTimestamp }}'
   - id: "tempo-query"
     main: ./cmd/tempo-query
+    binary: tempo-query
     env:
       - CGO_ENABLED=0
     goos:


### PR DESCRIPTION
Signed-off-by: Annanay <annanayagarwal@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Fixes this error in the goreleaser release process - 
```
   ⨯ release failed after 13.59s error=failed to add /home/runner/work/tempo/tempo/dist/tempo-query_linux_amd64/tempo -> tempo to the archive: file tempo already exists in the archive
```
CI run ID: https://github.com/grafana/tempo/runs/1927489321


**Which issue(s) this PR fixes**:
Fixes #na!

**Checklist**
- NA Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`