### PR TITLE
Fix object prefix not being stripped for Dell ECS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * [ENHANCEMENT] Add a Shutdown handler to flush data to backend, at "/shutdown". [#526](https://github.com/grafana/tempo/pull/526)
 * [BUGFIX] Fixes permissions errors on startup in GCS. [#554](https://github.com/grafana/tempo/pull/554)
-* [BUGFIX] Fixes error were Dell ECS cannot list objects. [#561](https://github.com/grafana/tempo/pull/561)
+* [BUGFIX] Fixes error where Dell ECS cannot list objects. [#561](https://github.com/grafana/tempo/pull/561)
 
 
 ## v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * [ENHANCEMENT] Add a Shutdown handler to flush data to backend, at "/shutdown". [#526](https://github.com/grafana/tempo/pull/526)
 * [BUGFIX] Fixes permissions errors on startup in GCS. [#554](https://github.com/grafana/tempo/pull/554)
+* [BUGFIX] Fixes error were Dell ECS cannot list objects. [#561](https://github.com/grafana/tempo/pull/561)
+
 
 ## v0.6.0
 

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -271,8 +271,9 @@ func (rw *readerWriter) Tenants(ctx context.Context) ([]string, error) {
 
 // Blocks implements backend.Reader
 func (rw *readerWriter) Blocks(ctx context.Context, tenantID string) ([]uuid.UUID, error) {
+	prefix := tenantID + "/"
 	// ListObjects(bucket, prefix, marker, delimiter string, maxKeys int)
-	res, err := rw.core.ListObjects(rw.cfg.Bucket, tenantID+"/", "", "/", 0)
+	res, err := rw.core.ListObjects(rw.cfg.Bucket, prefix, "", "/", 0)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error listing blocks in s3 bucket, bucket: %s", rw.cfg.Bucket)
 	}
@@ -280,7 +281,7 @@ func (rw *readerWriter) Blocks(ctx context.Context, tenantID string) ([]uuid.UUI
 	level.Debug(rw.logger).Log("msg", "listing blocks", "tenantID", tenantID, "found", len(res.CommonPrefixes))
 	var blockIDs []uuid.UUID
 	for _, cp := range res.CommonPrefixes {
-		blockID, err := uuid.Parse(strings.Split(strings.TrimPrefix(cp.Prefix, res.Prefix), "/")[0])
+		blockID, err := uuid.Parse(strings.Split(strings.TrimPrefix(cp.Prefix, prefix), "/")[0])
 		if err != nil {
 			return nil, errors.Wrapf(err, "error parsing uuid of obj, objectName: %s", cp.Prefix)
 		}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This commit ensure that the same object prefix string is used to query and strip
an object when listing all the objects in a bucket.

Some S3 implementations (in this case Dell ECS) cannot be relied upon to return
the correct `res.Prefix`. Dell ECS will return it URLencoded, e.g. "traceID%2F"
instead of "traceID/".

I am able to test this on ECS, but I do not have access to other blob storage, so help with testing additional storage backend would be appreciated.

**Which issue(s) this PR fixes**:
Fixes #558 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`