### PR TITLE
Backend Refactoring:  Paged Index Preparation

### DIFF
--- a/cmd/tempo-cli/cmd-list-block.go
+++ b/cmd/tempo-cli/cmd-list-block.go
@@ -113,9 +113,10 @@ func dumpBlock(r tempodb_backend.Reader, c tempodb_backend.Compactor, tenantID s
 			os.Exit(0)
 		}()
 
+		ctx := context.Background()
 		prevID := make([]byte, 16)
 		for {
-			objID, obj, err := iter.Next()
+			objID, obj, err := iter.Next(ctx)
 			if err == io.EOF {
 				break
 			} else if err != nil {

--- a/modules/ingester/ingester.go
+++ b/modules/ingester/ingester.go
@@ -312,8 +312,10 @@ func (i *Ingester) replayBlock(b *tempodb_wal.ReplayBlock, instance *instance) e
 		return err
 	}
 	defer iterator.Close()
+
+	ctx := context.Background()
 	for {
-		id, obj, err := iterator.Next()
+		id, obj, err := iterator.Next(ctx)
 		if id == nil {
 			break
 		}

--- a/tempodb/backend/readerat.go
+++ b/tempodb/backend/readerat.go
@@ -29,13 +29,13 @@ func NewContextReader(meta *BlockMeta, name string, r Reader) ContextReader {
 	}
 }
 
-// ReadAt implements ReaderAtContext
+// ReadAt implements ContextReader
 func (b *backendReader) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
 	err := b.r.ReadRange(ctx, b.name, b.meta.BlockID, b.meta.TenantID, uint64(off), p)
 	return len(p), err
 }
 
-// ReadAll implements ReaderAtContext
+// ReadAll implements ContextReader
 func (b *backendReader) ReadAll(ctx context.Context) ([]byte, error) {
 	return b.r.Read(ctx, b.name, b.meta.BlockID, b.meta.TenantID)
 }
@@ -46,7 +46,7 @@ type AllReader interface {
 	io.ReaderAt
 }
 
-// allReader wraps an AllReader and implements backend.ReaderAtContext
+// allReader wraps an AllReader and implements backend.ContextReader
 type allReader struct {
 	r AllReader
 }
@@ -58,12 +58,12 @@ func NewContextReaderWithAllReader(r AllReader) ContextReader {
 	}
 }
 
-// ReadAt implements ReaderAtContext
+// ReadAt implements ContextReader
 func (r *allReader) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
 	return r.r.ReadAt(p, off)
 }
 
-// ReadAll implements ReaderAtContext
+// ReadAll implements ContextReader
 func (r *allReader) ReadAll(ctx context.Context) ([]byte, error) {
 	return ioutil.ReadAll(r.r)
 }

--- a/tempodb/backend/readerat.go
+++ b/tempodb/backend/readerat.go
@@ -3,12 +3,14 @@ package backend
 import (
 	"context"
 	"io"
+	"io/ioutil"
 )
 
 // ReaderAtContext is an io.ReaderAt interface that passes context.  It is used to simplify access to backend objects
 // and abstract away the name/meta and other details so that the data can be accessed directly and simply
-type ReaderAtContext interface {
+type ReaderAtContext interface { // jpe ContextReader
 	ReadAt(ctx context.Context, p []byte, off int64) (int, error)
+	ReadAll(ctx context.Context) ([]byte, error)
 }
 
 // readerAt is a shim that allows a backend.Reader to be used as an io.ReaderAt
@@ -29,22 +31,40 @@ func NewReaderAt(meta *BlockMeta, name string, r Reader) ReaderAtContext {
 
 // ReadAt implements ReaderAtContext
 func (b *readerAt) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
-	err := b.r.ReadRange(context.Background(), b.name, b.meta.BlockID, b.meta.TenantID, uint64(off), p)
+	err := b.r.ReadRange(ctx, b.name, b.meta.BlockID, b.meta.TenantID, uint64(off), p)
 	return len(p), err
+}
+
+// ReadAll implements ReaderAtContext
+func (b *readerAt) ReadAll(ctx context.Context) ([]byte, error) {
+	return b.r.Read(ctx, b.name, b.meta.BlockID, b.meta.TenantID)
+}
+
+// AllReader is an interface that supports both io.Reader and io.ReaderAt methods
+type AllReader interface {
+	io.Reader
+	io.ReaderAt
 }
 
 // readerAtContext wraps a file and implements backend.ReaderAtContext
 type readerAtContext struct {
-	ra io.ReaderAt
+	r      AllReader
+	length int
 }
 
 // NewReaderAtWithReaderAt wraps a normal ReaderAt and drops the context
-func NewReaderAtWithReaderAt(ra io.ReaderAt) ReaderAtContext {
+func NewReaderAtWithReaderAt(r AllReader) ReaderAtContext { // jpe change name (all names in this file)
 	return &readerAtContext{
-		ra: ra,
+		r: r,
 	}
 }
 
+// ReadAt implements ReaderAtContext
 func (r *readerAtContext) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
-	return r.ra.ReadAt(p, off)
+	return r.r.ReadAt(p, off)
+}
+
+// ReadAll implements ReaderAtContext
+func (r *readerAtContext) ReadAll(ctx context.Context) ([]byte, error) {
+	return ioutil.ReadAll(r.r)
 }

--- a/tempodb/backend/readerat.go
+++ b/tempodb/backend/readerat.go
@@ -1,26 +1,50 @@
 package backend
 
-import "context"
+import (
+	"context"
+	"io"
+)
 
-// ReaderAt is a shim that allows a backend.Reader to be used as an io.ReaderAt
-type ReaderAt struct {
+// ReaderAtContext is an io.ReaderAt interface that passes context.  It is used to simplify access to backend objects
+// and abstract away the name/meta and other details so that the data can be accessed directly and simply
+type ReaderAtContext interface {
+	ReadAt(ctx context.Context, p []byte, off int64) (int, error)
+}
+
+// readerAt is a shim that allows a backend.Reader to be used as an io.ReaderAt
+type readerAt struct {
 	meta *BlockMeta
 	name string
 	r    Reader
 }
 
 // NewReaderAt creates a ReaderAt for the given BlockMeta
-func NewReaderAt(meta *BlockMeta, name string, r Reader) *ReaderAt {
-	return &ReaderAt{
+func NewReaderAt(meta *BlockMeta, name string, r Reader) ReaderAtContext {
+	return &readerAt{
 		meta: meta,
 		name: name,
 		r:    r,
 	}
 }
 
-// ReadAt implements ReaderAt
-func (b *ReaderAt) ReadAt(p []byte, off int64) (int, error) {
-	// todo:  how to preserve context?  len(p) is cheating
+// ReadAt implements ReaderAtContext
+func (b *readerAt) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
 	err := b.r.ReadRange(context.Background(), b.name, b.meta.BlockID, b.meta.TenantID, uint64(off), p)
 	return len(p), err
+}
+
+// readerAtContext wraps a file and implements backend.ReaderAtContext
+type readerAtContext struct {
+	ra io.ReaderAt
+}
+
+// NewReaderAtWithReaderAt wraps a normal ReaderAt and drops the context
+func NewReaderAtWithReaderAt(ra io.ReaderAt) ReaderAtContext {
+	return &readerAtContext{
+		ra: ra,
+	}
+}
+
+func (r *readerAtContext) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
+	return r.ra.ReadAt(p, off)
 }

--- a/tempodb/compactor_bookmark.go
+++ b/tempodb/compactor_bookmark.go
@@ -3,17 +3,17 @@ package tempodb
 import (
 	"context"
 
-	"github.com/grafana/tempo/tempodb/encoding/common"
+	"github.com/grafana/tempo/tempodb/encoding"
 )
 
 type bookmark struct {
-	iter common.Iterator
+	iter encoding.Iterator
 
 	currentID     []byte
 	currentObject []byte
 }
 
-func newBookmark(iter common.Iterator) *bookmark {
+func newBookmark(iter encoding.Iterator) *bookmark {
 	return &bookmark{
 		iter: iter,
 	}

--- a/tempodb/compactor_bookmark.go
+++ b/tempodb/compactor_bookmark.go
@@ -1,6 +1,8 @@
 package tempodb
 
 import (
+	"context"
+
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
@@ -17,13 +19,13 @@ func newBookmark(iter common.Iterator) *bookmark {
 	}
 }
 
-func (b *bookmark) current() ([]byte, []byte, error) {
+func (b *bookmark) current(ctx context.Context) ([]byte, []byte, error) {
 	if len(b.currentID) != 0 && len(b.currentObject) != 0 {
 		return b.currentID, b.currentObject, nil
 	}
 
 	var err error
-	b.currentID, b.currentObject, err = b.iter.Next()
+	b.currentID, b.currentObject, err = b.iter.Next(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -31,8 +33,8 @@ func (b *bookmark) current() ([]byte, []byte, error) {
 	return b.currentID, b.currentObject, nil
 }
 
-func (b *bookmark) done() bool {
-	_, _, err := b.current()
+func (b *bookmark) done(ctx context.Context) bool {
+	_, _, err := b.current(ctx)
 
 	return err != nil
 }

--- a/tempodb/compactor_bookmark_test.go
+++ b/tempodb/compactor_bookmark_test.go
@@ -83,7 +83,7 @@ func TestCurrentClear(t *testing.T) {
 
 	i := 0
 	for {
-		_, _, err = bm.current()
+		_, _, err = bm.current(context.Background())
 		if err == io.EOF {
 			break
 		}

--- a/tempodb/encoding/appender.go
+++ b/tempodb/encoding/appender.go
@@ -7,6 +7,15 @@ import (
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
+// Appender is capable of tracking objects and ids that are added to it
+type Appender interface {
+	Append(common.ID, []byte) error
+	Complete() error
+	Records() []*common.Record
+	Length() int
+	DataLength() uint64
+}
+
 type appender struct {
 	pageWriter    common.PageWriter
 	records       []*common.Record
@@ -15,7 +24,7 @@ type appender struct {
 
 // NewAppender returns an appender.  This appender simply appends new objects
 //  to the provided pageWriter.
-func NewAppender(pageWriter common.PageWriter) common.Appender {
+func NewAppender(pageWriter common.PageWriter) Appender {
 	return &appender{
 		pageWriter: pageWriter,
 	}

--- a/tempodb/encoding/appender_buffered.go
+++ b/tempodb/encoding/appender_buffered.go
@@ -23,7 +23,7 @@ type bufferedAppender struct {
 
 // NewBufferedAppender returns an bufferedAppender.  This appender builds a writes to
 //  the provided writer and also builds a downsampled records slice.
-func NewBufferedAppender(writer common.PageWriter, indexDownsample int, totalObjectsEstimate int) (common.Appender, error) {
+func NewBufferedAppender(writer common.PageWriter, indexDownsample int, totalObjectsEstimate int) (Appender, error) {
 	return &bufferedAppender{
 		writer:               writer,
 		indexDownsampleBytes: indexDownsample,

--- a/tempodb/encoding/backend_block.go
+++ b/tempodb/encoding/backend_block.go
@@ -73,13 +73,13 @@ func (b *BackendBlock) Find(ctx context.Context, id common.ID) ([]byte, error) {
 		return nil, nil
 	}
 
-	indexReaderAt := backend.NewReaderAt(b.meta, nameIndex, b.reader)
+	indexReaderAt := backend.NewContextReader(b.meta, nameIndex, b.reader)
 	indexReader, err := b.encoding.newIndexReader(indexReaderAt)
 	if err != nil {
 		return nil, fmt.Errorf("error building index reader (%s, %s): %w", b.meta.TenantID, b.meta.BlockID, err)
 	}
 
-	ra := backend.NewReaderAt(b.meta, nameObjects, b.reader)
+	ra := backend.NewContextReader(b.meta, nameObjects, b.reader)
 	pageReader, err := b.encoding.newPageReader(ra, b.meta.Encoding)
 	if err != nil {
 		return nil, fmt.Errorf("error building page reader (%s, %s): %w", b.meta.TenantID, b.meta.BlockID, err)
@@ -100,13 +100,13 @@ func (b *BackendBlock) Find(ctx context.Context, id common.ID) ([]byte, error) {
 // Iterator returns an Iterator that iterates over the objects in the block from the backend
 func (b *BackendBlock) Iterator(chunkSizeBytes uint32) (common.Iterator, error) {
 	// read index
-	ra := backend.NewReaderAt(b.meta, nameObjects, b.reader)
+	ra := backend.NewContextReader(b.meta, nameObjects, b.reader)
 	pageReader, err := b.encoding.newPageReader(ra, b.meta.Encoding)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pageReader (%s, %s): %w", b.meta.TenantID, b.meta.BlockID, err)
 	}
 
-	indexReaderAt := backend.NewReaderAt(b.meta, nameIndex, b.reader)
+	indexReaderAt := backend.NewContextReader(b.meta, nameIndex, b.reader)
 	reader, err := b.encoding.newIndexReader(indexReaderAt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create index reader (%s, %s): %w", b.meta.TenantID, b.meta.BlockID, err)

--- a/tempodb/encoding/backend_block.go
+++ b/tempodb/encoding/backend_block.go
@@ -73,12 +73,8 @@ func (b *BackendBlock) Find(ctx context.Context, id common.ID) ([]byte, error) {
 		return nil, nil
 	}
 
-	indexBytes, err := b.reader.Read(ctx, nameIndex, blockID, tenantID)
-	if err != nil {
-		return nil, fmt.Errorf("error reading index (%s, %s): %w", b.meta.TenantID, b.meta.BlockID, err)
-	}
-
-	indexReader, err := b.encoding.newIndexReader(indexBytes)
+	indexReaderAt := backend.NewReaderAt(b.meta, nameIndex, b.reader)
+	indexReader, err := b.encoding.newIndexReader(indexReaderAt)
 	if err != nil {
 		return nil, fmt.Errorf("error building index reader (%s, %s): %w", b.meta.TenantID, b.meta.BlockID, err)
 	}
@@ -104,18 +100,14 @@ func (b *BackendBlock) Find(ctx context.Context, id common.ID) ([]byte, error) {
 // Iterator returns an Iterator that iterates over the objects in the block from the backend
 func (b *BackendBlock) Iterator(chunkSizeBytes uint32) (common.Iterator, error) {
 	// read index
-	indexBytes, err := b.reader.Read(context.TODO(), nameIndex, b.meta.BlockID, b.meta.TenantID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read index (%s, %s): %w", b.meta.TenantID, b.meta.BlockID, err)
-	}
-
 	ra := backend.NewReaderAt(b.meta, nameObjects, b.reader)
 	pageReader, err := b.encoding.newPageReader(ra, b.meta.Encoding)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pageReader (%s, %s): %w", b.meta.TenantID, b.meta.BlockID, err)
 	}
 
-	reader, err := b.encoding.newIndexReader(indexBytes)
+	indexReaderAt := backend.NewReaderAt(b.meta, nameIndex, b.reader)
+	reader, err := b.encoding.newIndexReader(indexReaderAt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create index reader (%s, %s): %w", b.meta.TenantID, b.meta.BlockID, err)
 	}

--- a/tempodb/encoding/backend_block.go
+++ b/tempodb/encoding/backend_block.go
@@ -98,7 +98,7 @@ func (b *BackendBlock) Find(ctx context.Context, id common.ID) ([]byte, error) {
 }
 
 // Iterator returns an Iterator that iterates over the objects in the block from the backend
-func (b *BackendBlock) Iterator(chunkSizeBytes uint32) (common.Iterator, error) {
+func (b *BackendBlock) Iterator(chunkSizeBytes uint32) (Iterator, error) {
 	// read index
 	ra := backend.NewContextReader(b.meta, nameObjects, b.reader)
 	pageReader, err := b.encoding.newPageReader(ra, b.meta.Encoding)

--- a/tempodb/encoding/backend_block.go
+++ b/tempodb/encoding/backend_block.go
@@ -92,7 +92,7 @@ func (b *BackendBlock) Find(ctx context.Context, id common.ID) ([]byte, error) {
 
 	// passing nil for objectCombiner here.  this is fine b/c a backend block should never have dupes
 	finder := NewPagedFinder(indexReader, pageReader, nil)
-	objectBytes, err := finder.Find(id)
+	objectBytes, err := finder.Find(ctx, id)
 
 	if err != nil {
 		return nil, fmt.Errorf("error using pageFinder (%s, %s): %w", b.meta.TenantID, b.meta.BlockID, err)

--- a/tempodb/encoding/backend_block_test.go
+++ b/tempodb/encoding/backend_block_test.go
@@ -98,7 +98,7 @@ func testLegacyBlock(t *testing.T, ids [][]byte, objs [][]byte, meta *backend.Bl
 	require.NoError(t, err, "error getting iterator")
 	i := 0
 	for {
-		id, obj, err := iterator.Next()
+		id, obj, err := iterator.Next(context.Background())
 		if id == nil {
 			break
 		}

--- a/tempodb/encoding/block.go
+++ b/tempodb/encoding/block.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
-	v0 "github.com/grafana/tempo/tempodb/encoding/v0"
 )
 
 const (
@@ -26,19 +25,14 @@ func bloomName(shard int) string {
 }
 
 // writeBlockMeta writes the bloom filter, meta and index to the passed in backend.Writer
-func writeBlockMeta(ctx context.Context, w backend.Writer, meta *backend.BlockMeta, records []*common.Record, b *common.ShardedBloomFilter) error {
-	index, err := v0.MarshalRecords(records)
-	if err != nil {
-		return err
-	}
-
+func writeBlockMeta(ctx context.Context, w backend.Writer, meta *backend.BlockMeta, indexBytes []byte, b *common.ShardedBloomFilter) error {
 	blooms, err := b.WriteTo()
 	if err != nil {
 		return err
 	}
 
 	// index
-	err = w.Write(ctx, nameIndex, meta.BlockID, meta.TenantID, index)
+	err = w.Write(ctx, nameIndex, meta.BlockID, meta.TenantID, indexBytes)
 	if err != nil {
 		return fmt.Errorf("unexpected error writing index %w", err)
 	}

--- a/tempodb/encoding/common/index_reader.go
+++ b/tempodb/encoding/common/index_reader.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"bytes"
+	"context"
 	"sort"
 )
 
@@ -9,23 +10,23 @@ import (
 type Records []*Record
 
 // At implements IndexReader
-func (r Records) At(i int) *Record {
+func (r Records) At(_ context.Context, i int) (*Record, error) {
 	if i < 0 || i >= len(r) {
-		return nil
+		return nil, nil
 	}
 
-	return r[i]
+	return r[i], nil
 }
 
 // Find implements IndexReader
-func (r Records) Find(id ID) (*Record, int) {
+func (r Records) Find(_ context.Context, id ID) (*Record, int, error) {
 	i := sort.Search(len(r), func(idx int) bool {
 		return bytes.Compare(r[idx].ID, id) >= 0
 	})
 
 	if i < 0 || i >= len(r) {
-		return nil, -1
+		return nil, -1, nil
 	}
 
-	return r[i], i
+	return r[i], i, nil
 }

--- a/tempodb/encoding/common/types.go
+++ b/tempodb/encoding/common/types.go
@@ -56,7 +56,7 @@ type PageReader interface {
 // IndexReader is the primary abstraction point for supporting multiple index
 // formats.
 type IndexReader interface {
-	At(i int) *Record
+	At(i int) *Record // jpe take context
 	Find(id ID) (*Record, int)
 }
 

--- a/tempodb/encoding/common/types.go
+++ b/tempodb/encoding/common/types.go
@@ -68,3 +68,9 @@ type PageWriter interface {
 	// Complete must be called when the operation pagewriter is done.
 	Complete() error
 }
+
+// IndexWriter is used to write paged indexes
+type IndexWriter interface {
+	// Write returns a byte representation of the provided Records
+	Write([]*Record) ([]byte, error)
+}

--- a/tempodb/encoding/common/types.go
+++ b/tempodb/encoding/common/types.go
@@ -56,8 +56,8 @@ type PageReader interface {
 // IndexReader is the primary abstraction point for supporting multiple index
 // formats.
 type IndexReader interface {
-	At(i int) *Record // jpe take context
-	Find(id ID) (*Record, int)
+	At(ctx context.Context, i int) (*Record, error)
+	Find(ctx context.Context, id ID) (*Record, int, error)
 }
 
 // PageWriter is used to write paged data to the backend

--- a/tempodb/encoding/common/types.go
+++ b/tempodb/encoding/common/types.go
@@ -1,5 +1,7 @@
 package common
 
+import "context"
+
 // This file contains types that need to be referenced by both the ./encoding and ./encoding/vX packages.
 // It primarily exists here to break dependency loops.
 
@@ -15,13 +17,13 @@ type Record struct {
 
 // Iterator is capable of iterating through a set of objects
 type Iterator interface {
-	Next() (ID, []byte, error)
+	Next(context.Context) (ID, []byte, error)
 	Close()
 }
 
 // Finder is capable of finding the requested ID
 type Finder interface {
-	Find(id ID) ([]byte, error)
+	Find(context.Context, ID) ([]byte, error)
 }
 
 // Appender is capable of tracking objects and ids that are added to it
@@ -44,7 +46,7 @@ type ObjectCombiner interface {
 // PageReader is the primary abstraction point for supporting multiple data
 // formats.
 type PageReader interface {
-	Read([]*Record) ([][]byte, error)
+	Read(context.Context, []*Record) ([][]byte, error)
 	Close()
 }
 

--- a/tempodb/encoding/common/types.go
+++ b/tempodb/encoding/common/types.go
@@ -15,26 +15,6 @@ type Record struct {
 	Length uint32
 }
 
-// Iterator is capable of iterating through a set of objects
-type Iterator interface {
-	Next(context.Context) (ID, []byte, error)
-	Close()
-}
-
-// Finder is capable of finding the requested ID
-type Finder interface {
-	Find(context.Context, ID) ([]byte, error)
-}
-
-// Appender is capable of tracking objects and ids that are added to it
-type Appender interface {
-	Append(ID, []byte) error
-	Complete() error
-	Records() []*Record
-	Length() int
-	DataLength() uint64
-}
-
 // ObjectCombiner is used to combine two objects in the backend
 type ObjectCombiner interface {
 	Combine(objA []byte, objB []byte) []byte

--- a/tempodb/encoding/compactor_block.go
+++ b/tempodb/encoding/compactor_block.go
@@ -112,7 +112,13 @@ func (c *CompactorBlock) Complete(ctx context.Context, tracker backend.AppendTra
 	records := c.appender.Records()
 	meta := c.BlockMeta()
 
-	err = writeBlockMeta(ctx, w, meta, records, c.bloom)
+	indexWriter := c.encoding.newIndexWriter()
+	indexBytes, err := indexWriter.Write(records)
+	if err != nil {
+		return 0, err
+	}
+
+	err = writeBlockMeta(ctx, w, meta, indexBytes, c.bloom)
 	if err != nil {
 		return 0, err
 	}

--- a/tempodb/encoding/compactor_block.go
+++ b/tempodb/encoding/compactor_block.go
@@ -20,7 +20,7 @@ type CompactorBlock struct {
 
 	bufferedObjects int
 	appendBuffer    *bytes.Buffer
-	appender        common.Appender
+	appender        Appender
 }
 
 // NewCompactorBlock creates a ... new compactor block!

--- a/tempodb/encoding/complete_block.go
+++ b/tempodb/encoding/complete_block.go
@@ -121,7 +121,13 @@ func (c *CompleteBlock) Write(ctx context.Context, w backend.Writer) error {
 		return err
 	}
 
-	err = writeBlockMeta(ctx, w, c.meta, c.records, c.bloom)
+	indexWriter := c.encoding.newIndexWriter()
+	indexBytes, err := indexWriter.Write(c.records)
+	if err != nil {
+		return err
+	}
+
+	err = writeBlockMeta(ctx, w, c.meta, indexBytes, c.bloom)
 	if err != nil {
 		return err
 	}

--- a/tempodb/encoding/complete_block.go
+++ b/tempodb/encoding/complete_block.go
@@ -157,7 +157,7 @@ func (c *CompleteBlock) Find(id common.ID, combiner common.ObjectCombiner) ([]by
 		return nil, err
 	}
 
-	pageReader, err := c.encoding.newPageReader(backend.NewReaderAtWithReaderAt(file), c.meta.Encoding)
+	pageReader, err := c.encoding.newPageReader(backend.NewContextReaderWithAllReader(file), c.meta.Encoding)
 	if err != nil {
 		return nil, err
 	}

--- a/tempodb/encoding/complete_block.go
+++ b/tempodb/encoding/complete_block.go
@@ -33,7 +33,7 @@ type CompleteBlock struct {
 }
 
 // NewCompleteBlock creates a new block and takes _ALL_ the parameters necessary to build the ordered, deduped file on disk
-func NewCompleteBlock(cfg *BlockConfig, originatingMeta *backend.BlockMeta, iterator common.Iterator, estimatedObjects int, filepath string, walFilename string) (*CompleteBlock, error) {
+func NewCompleteBlock(cfg *BlockConfig, originatingMeta *backend.BlockMeta, iterator Iterator, estimatedObjects int, filepath string, walFilename string) (*CompleteBlock, error) {
 	c := &CompleteBlock{
 		encoding:    latestEncoding(),
 		meta:        backend.NewBlockMeta(originatingMeta.TenantID, uuid.New(), currentVersion, cfg.Encoding),

--- a/tempodb/encoding/complete_block.go
+++ b/tempodb/encoding/complete_block.go
@@ -62,8 +62,11 @@ func NewCompleteBlock(cfg *BlockConfig, originatingMeta *backend.BlockMeta, iter
 	if err != nil {
 		return nil, err
 	}
+
+	// todo: add a timeout?  propagage context from completing?
+	ctx := context.Background()
 	for {
-		bytesID, bytesObject, err := iterator.Next()
+		bytesID, bytesObject, err := iterator.Next(ctx)
 		if bytesID == nil {
 			break
 		}
@@ -154,14 +157,14 @@ func (c *CompleteBlock) Find(id common.ID, combiner common.ObjectCombiner) ([]by
 		return nil, err
 	}
 
-	pageReader, err := c.encoding.newPageReader(file, c.meta.Encoding)
+	pageReader, err := c.encoding.newPageReader(backend.NewReaderAtWithReaderAt(file), c.meta.Encoding)
 	if err != nil {
 		return nil, err
 	}
 	defer pageReader.Close()
 
 	finder := NewPagedFinder(common.Records(c.records), pageReader, combiner)
-	return finder.Find(id)
+	return finder.Find(context.Background(), id)
 }
 
 // Clear removes the backing file.

--- a/tempodb/encoding/complete_block_test.go
+++ b/tempodb/encoding/complete_block_test.go
@@ -298,7 +298,7 @@ func benchmarkCompressBlock(b *testing.B, encoding backend.Encoding, indexDownsa
 	b.ResetTimer()
 	file, err := os.Open(cb.fullFilename())
 	require.NoError(b, err)
-	pr, err := v1.NewPageReader(backend.NewReaderAtWithReaderAt(file), encoding)
+	pr, err := v1.NewPageReader(backend.NewContextReaderWithAllReader(file), encoding)
 	require.NoError(b, err)
 	iterator = newPagedIterator(10*1024*1024, common.Records(cb.records), pr)
 

--- a/tempodb/encoding/complete_block_test.go
+++ b/tempodb/encoding/complete_block_test.go
@@ -131,7 +131,7 @@ func testCompleteBlockToBackendBlock(t *testing.T, cfg *BlockConfig) {
 	require.NoError(t, err, "error getting iterator")
 	i := 0
 	for {
-		id, obj, err := iterator.Next()
+		id, obj, err := iterator.Next(context.Background())
 		if id == nil {
 			break
 		}
@@ -298,12 +298,12 @@ func benchmarkCompressBlock(b *testing.B, encoding backend.Encoding, indexDownsa
 	b.ResetTimer()
 	file, err := os.Open(cb.fullFilename())
 	require.NoError(b, err)
-	pr, err := v1.NewPageReader(file, encoding)
+	pr, err := v1.NewPageReader(backend.NewReaderAtWithReaderAt(file), encoding)
 	require.NoError(b, err)
 	iterator = newPagedIterator(10*1024*1024, common.Records(cb.records), pr)
 
 	for {
-		id, _, err := iterator.Next()
+		id, _, err := iterator.Next(context.Background())
 		if err != io.EOF {
 			require.NoError(b, err)
 		}

--- a/tempodb/encoding/finder_paged.go
+++ b/tempodb/encoding/finder_paged.go
@@ -27,7 +27,10 @@ func NewPagedFinder(index common.IndexReader, r common.PageReader, combiner comm
 
 func (f *pagedFinder) Find(ctx context.Context, id common.ID) ([]byte, error) {
 	var bytesFound []byte
-	record, i := f.index.Find(id)
+	record, i, err := f.index.Find(ctx, id)
+	if err != nil {
+		return nil, err
+	}
 
 	if record == nil {
 		return nil, nil
@@ -48,7 +51,10 @@ func (f *pagedFinder) Find(ctx context.Context, id common.ID) ([]byte, error) {
 
 		// we need to check the next record to see if it also matches our id
 		i++
-		record = f.index.At(i)
+		record, err = f.index.At(ctx, i)
+		if err != nil {
+			return nil, err
+		}
 		if record == nil {
 			break
 		}

--- a/tempodb/encoding/finder_paged.go
+++ b/tempodb/encoding/finder_paged.go
@@ -8,6 +8,11 @@ import (
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
+// Finder is capable of finding the requested ID
+type Finder interface {
+	Find(context.Context, common.ID) ([]byte, error)
+}
+
 type pagedFinder struct {
 	r        common.PageReader
 	index    common.IndexReader
@@ -17,7 +22,7 @@ type pagedFinder struct {
 // NewPagedFinder returns a paged. This finder is used for searching
 //  a set of records and returning an object. If a set of consecutive records has
 //  matching ids they will be combined using the ObjectCombiner.
-func NewPagedFinder(index common.IndexReader, r common.PageReader, combiner common.ObjectCombiner) common.Finder {
+func NewPagedFinder(index common.IndexReader, r common.PageReader, combiner common.ObjectCombiner) Finder {
 	return &pagedFinder{
 		r:        r,
 		index:    index,

--- a/tempodb/encoding/iterator.go
+++ b/tempodb/encoding/iterator.go
@@ -8,13 +8,19 @@ import (
 	v0 "github.com/grafana/tempo/tempodb/encoding/v0"
 )
 
+// Iterator is capable of iterating through a set of objects
+type Iterator interface {
+	Next(context.Context) (common.ID, []byte, error)
+	Close()
+}
+
 type iterator struct {
 	reader io.Reader
 }
 
 // NewIterator returns the most basic iterator.  It iterates over
 // raw objects.
-func NewIterator(reader io.Reader) common.Iterator {
+func NewIterator(reader io.Reader) Iterator {
 	return &iterator{
 		reader: reader,
 	}

--- a/tempodb/encoding/iterator.go
+++ b/tempodb/encoding/iterator.go
@@ -1,6 +1,7 @@
 package encoding
 
 import (
+	"context"
 	"io"
 
 	"github.com/grafana/tempo/tempodb/encoding/common"
@@ -19,7 +20,7 @@ func NewIterator(reader io.Reader) common.Iterator {
 	}
 }
 
-func (i *iterator) Next() (common.ID, []byte, error) {
+func (i *iterator) Next(_ context.Context) (common.ID, []byte, error) {
 	return v0.UnmarshalObjectFromReader(i.reader)
 }
 

--- a/tempodb/encoding/iterator_deduping.go
+++ b/tempodb/encoding/iterator_deduping.go
@@ -2,6 +2,7 @@ package encoding
 
 import (
 	"bytes"
+	"context"
 	"io"
 
 	"github.com/grafana/tempo/tempodb/encoding/common"
@@ -23,7 +24,7 @@ func NewDedupingIterator(iter common.Iterator, combiner common.ObjectCombiner) (
 	}
 
 	var err error
-	i.currentID, i.currentObject, err = i.iter.Next()
+	i.currentID, i.currentObject, err = i.iter.Next(context.Background())
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +32,7 @@ func NewDedupingIterator(iter common.Iterator, combiner common.ObjectCombiner) (
 	return i, nil
 }
 
-func (i *dedupingIterator) Next() (common.ID, []byte, error) {
+func (i *dedupingIterator) Next(ctx context.Context) (common.ID, []byte, error) {
 	if i.currentID == nil {
 		return nil, nil, io.EOF
 	}
@@ -40,7 +41,7 @@ func (i *dedupingIterator) Next() (common.ID, []byte, error) {
 	var dedupedObject []byte
 
 	for {
-		id, obj, err := i.iter.Next()
+		id, obj, err := i.iter.Next(ctx)
 		if err == io.EOF {
 			i.currentID = nil
 			i.currentObject = nil

--- a/tempodb/encoding/iterator_deduping.go
+++ b/tempodb/encoding/iterator_deduping.go
@@ -9,7 +9,7 @@ import (
 )
 
 type dedupingIterator struct {
-	iter          common.Iterator
+	iter          Iterator
 	combiner      common.ObjectCombiner
 	currentID     []byte
 	currentObject []byte
@@ -17,7 +17,7 @@ type dedupingIterator struct {
 
 // NewDedupingIterator returns a dedupingIterator.  This iterator is used to wrap another
 //  iterator.  It will dedupe consecutive objects with the same id using the ObjectCombiner.
-func NewDedupingIterator(iter common.Iterator, combiner common.ObjectCombiner) (common.Iterator, error) {
+func NewDedupingIterator(iter Iterator, combiner common.ObjectCombiner) (Iterator, error) {
 	i := &dedupingIterator{
 		iter:     iter,
 		combiner: combiner,

--- a/tempodb/encoding/iterator_paged.go
+++ b/tempodb/encoding/iterator_paged.go
@@ -22,7 +22,7 @@ type pagedIterator struct {
 
 // newPagedIterator returns a backendIterator.  This iterator is used to iterate
 //  through objects stored in object storage.
-func newPagedIterator(chunkSizeBytes uint32, indexReader common.IndexReader, pageReader common.PageReader) common.Iterator {
+func newPagedIterator(chunkSizeBytes uint32, indexReader common.IndexReader, pageReader common.PageReader) Iterator {
 	return &pagedIterator{
 		pageReader:     pageReader,
 		indexReader:    indexReader,

--- a/tempodb/encoding/iterator_paged.go
+++ b/tempodb/encoding/iterator_paged.go
@@ -1,6 +1,7 @@
 package encoding
 
 import (
+	"context"
 	"io"
 
 	"github.com/grafana/tempo/tempodb/encoding/common"
@@ -32,7 +33,7 @@ func newPagedIterator(chunkSizeBytes uint32, indexReader common.IndexReader, pag
 // For performance reasons the ID and object slices returned from this method are owned by
 // the iterator.  If you have need to keep these values for longer than a single iteration
 // you need to make a copy of them.
-func (i *pagedIterator) Next() (common.ID, []byte, error) {
+func (i *pagedIterator) Next(ctx context.Context) (common.ID, []byte, error) {
 	var err error
 	var id common.ID
 	var object []byte
@@ -77,7 +78,7 @@ func (i *pagedIterator) Next() (common.ID, []byte, error) {
 		currentRecord = i.indexReader.At(i.currentIndex)
 	}
 
-	i.pages, err = i.pageReader.Read(records)
+	i.pages, err = i.pageReader.Read(ctx, records)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error iterating through object in backend")
 	}

--- a/tempodb/encoding/iterator_paged.go
+++ b/tempodb/encoding/iterator_paged.go
@@ -54,7 +54,10 @@ func (i *pagedIterator) Next(ctx context.Context) (common.ID, []byte, error) {
 
 	// objects reader was empty, check the index
 	// if no index left, EOF
-	currentRecord := i.indexReader.At(i.currentIndex)
+	currentRecord, err := i.indexReader.At(ctx, i.currentIndex)
+	if err != nil {
+		return nil, nil, err
+	}
 	if currentRecord == nil {
 		return nil, nil, io.EOF
 	}
@@ -75,7 +78,10 @@ func (i *pagedIterator) Next(ctx context.Context) (common.ID, []byte, error) {
 
 		// get next
 		i.currentIndex++
-		currentRecord = i.indexReader.At(i.currentIndex)
+		currentRecord, err = i.indexReader.At(ctx, i.currentIndex)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	i.pages, err = i.pageReader.Read(ctx, records)

--- a/tempodb/encoding/iterator_record.go
+++ b/tempodb/encoding/iterator_record.go
@@ -12,12 +12,12 @@ type recordIterator struct {
 	records []*common.Record
 	ra      io.ReaderAt
 
-	currentIterator common.Iterator
+	currentIterator Iterator
 }
 
 // NewRecordIterator returns a recordIterator.  This iterator is used for iterating through
 //  a series of objects by reading them one at a time from Records.
-func NewRecordIterator(r []*common.Record, ra io.ReaderAt) common.Iterator {
+func NewRecordIterator(r []*common.Record, ra io.ReaderAt) Iterator {
 	return &recordIterator{
 		records: r,
 		ra:      ra,

--- a/tempodb/encoding/iterator_record.go
+++ b/tempodb/encoding/iterator_record.go
@@ -2,6 +2,7 @@ package encoding
 
 import (
 	"bytes"
+	"context"
 	"io"
 
 	"github.com/grafana/tempo/tempodb/encoding/common"
@@ -23,9 +24,9 @@ func NewRecordIterator(r []*common.Record, ra io.ReaderAt) common.Iterator {
 	}
 }
 
-func (i *recordIterator) Next() (common.ID, []byte, error) {
+func (i *recordIterator) Next(ctx context.Context) (common.ID, []byte, error) {
 	if i.currentIterator != nil {
-		id, object, err := i.currentIterator.Next()
+		id, object, err := i.currentIterator.Next(ctx)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -47,7 +48,7 @@ func (i *recordIterator) Next() (common.ID, []byte, error) {
 		i.currentIterator = NewIterator(bytes.NewReader(buff))
 		i.records = i.records[1:]
 
-		return i.currentIterator.Next()
+		return i.currentIterator.Next(ctx)
 	}
 
 	// done

--- a/tempodb/encoding/v0/index_reader.go
+++ b/tempodb/encoding/v0/index_reader.go
@@ -16,7 +16,7 @@ type readerBytes struct {
 
 // NewIndexReader returns an index reader for a byte slice of marshalled
 // ordered records.
-func NewIndexReader(r backend.ReaderAtContext) (common.IndexReader, error) {
+func NewIndexReader(r backend.ContextReader) (common.IndexReader, error) {
 	index, err := r.ReadAll(context.Background())
 	if err != nil {
 		return nil, err

--- a/tempodb/encoding/v0/index_reader.go
+++ b/tempodb/encoding/v0/index_reader.go
@@ -2,9 +2,11 @@ package v0
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"sort"
 
+	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
@@ -14,7 +16,12 @@ type readerBytes struct {
 
 // NewIndexReader returns an index reader for a byte slice of marshalled
 // ordered records.
-func NewIndexReader(index []byte) (common.IndexReader, error) {
+func NewIndexReader(r backend.ReaderAtContext) (common.IndexReader, error) {
+	index, err := r.ReadAll(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
 	mod := len(index) % recordLength
 	if mod != 0 {
 		return nil, fmt.Errorf("records are an unexpected number of bytes %d", len(index))

--- a/tempodb/encoding/v0/index_reader.go
+++ b/tempodb/encoding/v0/index_reader.go
@@ -32,16 +32,16 @@ func NewIndexReader(r backend.ReaderAtContext) (common.IndexReader, error) {
 	}, nil
 }
 
-func (r *readerBytes) At(i int) *common.Record {
+func (r *readerBytes) At(_ context.Context, i int) (*common.Record, error) {
 	if i < 0 || i >= len(r.index)/recordLength {
-		return nil
+		return nil, nil
 	}
 
 	buff := r.index[i*recordLength : (i+1)*recordLength]
-	return unmarshalRecord(buff)
+	return unmarshalRecord(buff), nil
 }
 
-func (r *readerBytes) Find(id common.ID) (*common.Record, int) {
+func (r *readerBytes) Find(_ context.Context, id common.ID) (*common.Record, int, error) {
 	numRecords := recordCount(r.index)
 	var record *common.Record
 
@@ -56,8 +56,8 @@ func (r *readerBytes) Find(id common.ID) (*common.Record, int) {
 		buff := r.index[i*recordLength : (i+1)*recordLength]
 		record = unmarshalRecord(buff)
 
-		return record, i
+		return record, i, nil
 	}
 
-	return nil, -1
+	return nil, -1, nil
 }

--- a/tempodb/encoding/v0/index_reader_test.go
+++ b/tempodb/encoding/v0/index_reader_test.go
@@ -2,6 +2,7 @@ package v0
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/grafana/tempo/tempodb/backend"
@@ -84,8 +85,11 @@ func TestIndexReader(t *testing.T) {
 			continue
 		}
 
-		assert.Equal(t, tc.expectedAt, reader.At(tc.at))
-		actualFind, actualIndex := reader.Find(tc.find)
+		at, err := reader.At(context.Background(), tc.at)
+		assert.NoError(t, err)
+		assert.Equal(t, tc.expectedAt, at)
+		actualFind, actualIndex, err := reader.Find(context.Background(), tc.find)
+		assert.NoError(t, err)
 		assert.Equal(t, tc.expectedFind, actualFind)
 		assert.Equal(t, tc.expectedFindIndex, actualIndex)
 	}

--- a/tempodb/encoding/v0/index_reader_test.go
+++ b/tempodb/encoding/v0/index_reader_test.go
@@ -1,8 +1,10 @@
 package v0
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -76,7 +78,7 @@ func TestIndexReader(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		reader, err := NewIndexReader(tc.recordBytes)
+		reader, err := NewIndexReader(backend.NewReaderAtWithReaderAt(bytes.NewReader(tc.recordBytes)))
 		if tc.expectedError {
 			assert.Error(t, err)
 			continue

--- a/tempodb/encoding/v0/index_reader_test.go
+++ b/tempodb/encoding/v0/index_reader_test.go
@@ -79,7 +79,7 @@ func TestIndexReader(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		reader, err := NewIndexReader(backend.NewReaderAtWithReaderAt(bytes.NewReader(tc.recordBytes)))
+		reader, err := NewIndexReader(backend.NewContextReaderWithAllReader(bytes.NewReader(tc.recordBytes)))
 		if tc.expectedError {
 			assert.Error(t, err)
 			continue

--- a/tempodb/encoding/v0/index_writer.go
+++ b/tempodb/encoding/v0/index_writer.go
@@ -1,0 +1,18 @@
+package v0
+
+import (
+	"github.com/grafana/tempo/tempodb/encoding/common"
+)
+
+type indexWriter struct {
+}
+
+// NewIndexWriter returns an index writer
+func NewIndexWriter() common.IndexWriter {
+	return &indexWriter{}
+}
+
+// Write implements common.IndexWriter
+func (w *indexWriter) Write(records []*common.Record) ([]byte, error) {
+	return MarshalRecords(records)
+}

--- a/tempodb/encoding/v0/page_reader.go
+++ b/tempodb/encoding/v0/page_reader.go
@@ -1,14 +1,15 @@
 package v0
 
 import (
+	"context"
 	"fmt"
-	"io"
 
+	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
 type pageReader struct {
-	r io.ReaderAt
+	r backend.ReaderAtContext
 }
 
 // NewPageReader returns a new v0 pageReader.  A v0 pageReader
@@ -16,7 +17,7 @@ type pageReader struct {
 // ranges and returns them as is.
 // A pages "format" is a contiguous collection of objects
 // | -- object -- | -- object -- | ...
-func NewPageReader(r io.ReaderAt) common.PageReader {
+func NewPageReader(r backend.ReaderAtContext) common.PageReader {
 	return &pageReader{
 		r: r,
 	}
@@ -25,7 +26,7 @@ func NewPageReader(r io.ReaderAt) common.PageReader {
 // Read returns the pages requested in the passed records.  It
 // assumes that if there are multiple records they are ordered
 // and contiguous
-func (r *pageReader) Read(records []*common.Record) ([][]byte, error) {
+func (r *pageReader) Read(ctx context.Context, records []*common.Record) ([][]byte, error) {
 	if len(records) == 0 {
 		return nil, nil
 	}
@@ -37,7 +38,7 @@ func (r *pageReader) Read(records []*common.Record) ([][]byte, error) {
 	}
 
 	contiguousPages := make([]byte, length)
-	_, err := r.r.ReadAt(contiguousPages, int64(start))
+	_, err := r.r.ReadAt(ctx, contiguousPages, int64(start))
 	if err != nil {
 		return nil, err
 	}

--- a/tempodb/encoding/v0/page_reader.go
+++ b/tempodb/encoding/v0/page_reader.go
@@ -9,7 +9,7 @@ import (
 )
 
 type pageReader struct {
-	r backend.ReaderAtContext
+	r backend.ContextReader
 }
 
 // NewPageReader returns a new v0 pageReader.  A v0 pageReader
@@ -17,7 +17,7 @@ type pageReader struct {
 // ranges and returns them as is.
 // A pages "format" is a contiguous collection of objects
 // | -- object -- | -- object -- | ...
-func NewPageReader(r backend.ReaderAtContext) common.PageReader {
+func NewPageReader(r backend.ContextReader) common.PageReader {
 	return &pageReader{
 		r: r,
 	}

--- a/tempodb/encoding/v0/page_reader_test.go
+++ b/tempodb/encoding/v0/page_reader_test.go
@@ -2,8 +2,10 @@ package v0
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
+	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 	"github.com/stretchr/testify/assert"
 )
@@ -121,8 +123,8 @@ func TestPageReader(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		reader := NewPageReader(bytes.NewReader(tc.readerBytes))
-		actual, err := reader.Read(tc.records)
+		reader := NewPageReader(backend.NewReaderAtWithReaderAt(bytes.NewReader(tc.readerBytes)))
+		actual, err := reader.Read(context.Background(), tc.records)
 		reader.Close()
 
 		if tc.expectedError {

--- a/tempodb/encoding/v0/page_reader_test.go
+++ b/tempodb/encoding/v0/page_reader_test.go
@@ -123,7 +123,7 @@ func TestPageReader(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		reader := NewPageReader(backend.NewReaderAtWithReaderAt(bytes.NewReader(tc.readerBytes)))
+		reader := NewPageReader(backend.NewContextReaderWithAllReader(bytes.NewReader(tc.readerBytes)))
 		actual, err := reader.Read(context.Background(), tc.records)
 		reader.Close()
 

--- a/tempodb/encoding/v0/record.go
+++ b/tempodb/encoding/v0/record.go
@@ -38,7 +38,7 @@ func (t *recordSorter) Swap(i, j int) {
 }
 
 // MarshalRecords converts a slice of records into a byte slice
-func MarshalRecords(records []*common.Record) ([]byte, error) { // jpe change to take a writer or preallocated buffer for v2 index
+func MarshalRecords(records []*common.Record) ([]byte, error) {
 	recordBytes := make([]byte, len(records)*recordLength)
 
 	for i, r := range records {

--- a/tempodb/encoding/v0/record.go
+++ b/tempodb/encoding/v0/record.go
@@ -38,7 +38,7 @@ func (t *recordSorter) Swap(i, j int) {
 }
 
 // MarshalRecords converts a slice of records into a byte slice
-func MarshalRecords(records []*common.Record) ([]byte, error) {
+func MarshalRecords(records []*common.Record) ([]byte, error) { // jpe change to take a writer or preallocated buffer for v2 index
 	recordBytes := make([]byte, len(records)*recordLength)
 
 	for i, r := range records {

--- a/tempodb/encoding/v1/index_reader.go
+++ b/tempodb/encoding/v1/index_reader.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 	v0 "github.com/grafana/tempo/tempodb/encoding/v0"
 )
@@ -8,6 +9,6 @@ import (
 // NewIndexReader returns an index reader for a byte slice of marshalled
 // ordered records.
 // The index has not changed between v0 and v1.
-func NewIndexReader(index []byte) (common.IndexReader, error) {
-	return v0.NewIndexReader(index)
+func NewIndexReader(r backend.ReaderAtContext) (common.IndexReader, error) {
+	return v0.NewIndexReader(r)
 }

--- a/tempodb/encoding/v1/index_reader.go
+++ b/tempodb/encoding/v1/index_reader.go
@@ -9,6 +9,6 @@ import (
 // NewIndexReader returns an index reader for a byte slice of marshalled
 // ordered records.
 // The index has not changed between v0 and v1.
-func NewIndexReader(r backend.ReaderAtContext) (common.IndexReader, error) {
+func NewIndexReader(r backend.ContextReader) (common.IndexReader, error) {
 	return v0.NewIndexReader(r)
 }

--- a/tempodb/encoding/v1/index_writer.go
+++ b/tempodb/encoding/v1/index_writer.go
@@ -1,0 +1,12 @@
+package v1
+
+import (
+	"github.com/grafana/tempo/tempodb/encoding/common"
+	v0 "github.com/grafana/tempo/tempodb/encoding/v0"
+)
+
+// NewIndexWriter returns an index writer that writes to the provided io.Writer.
+// The index has not changed between v0 and v1.
+func NewIndexWriter() common.IndexWriter {
+	return v0.NewIndexWriter()
+}

--- a/tempodb/encoding/v1/page_reader.go
+++ b/tempodb/encoding/v1/page_reader.go
@@ -19,7 +19,7 @@ type pageReader struct {
 }
 
 // NewPageReader constructs a v1 PageReader that handles compression
-func NewPageReader(r backend.ReaderAtContext, encoding backend.Encoding) (common.PageReader, error) {
+func NewPageReader(r backend.ContextReader, encoding backend.Encoding) (common.PageReader, error) {
 	pool, err := getReaderPool(encoding)
 	if err != nil {
 		return nil, err

--- a/tempodb/encoding/v1/page_reader.go
+++ b/tempodb/encoding/v1/page_reader.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"io/ioutil"
 
@@ -18,7 +19,7 @@ type pageReader struct {
 }
 
 // NewPageReader constructs a v1 PageReader that handles compression
-func NewPageReader(r io.ReaderAt, encoding backend.Encoding) (common.PageReader, error) {
+func NewPageReader(r backend.ReaderAtContext, encoding backend.Encoding) (common.PageReader, error) {
 	pool, err := getReaderPool(encoding)
 	if err != nil {
 		return nil, err
@@ -33,8 +34,8 @@ func NewPageReader(r io.ReaderAt, encoding backend.Encoding) (common.PageReader,
 // Read returns the pages requested in the passed records.  It
 // assumes that if there are multiple records they are ordered
 // and contiguous
-func (r *pageReader) Read(records []*common.Record) ([][]byte, error) {
-	compressedPages, err := r.v0PageReader.Read(records)
+func (r *pageReader) Read(ctx context.Context, records []*common.Record) ([][]byte, error) {
+	compressedPages, err := r.v0PageReader.Read(ctx, records)
 	if err != nil {
 		return nil, err
 	}

--- a/tempodb/encoding/v1/page_reader_test.go
+++ b/tempodb/encoding/v1/page_reader_test.go
@@ -39,7 +39,7 @@ func TestAllEncodings(t *testing.T) {
 				require.NoError(t, err)
 
 				encryptedBytes := buff.Bytes()
-				reader, err := NewPageReader(backend.NewReaderAtWithReaderAt(bytes.NewReader(encryptedBytes)), enc)
+				reader, err := NewPageReader(backend.NewContextReaderWithAllReader(bytes.NewReader(encryptedBytes)), enc)
 				require.NoError(t, err)
 				defer reader.Close()
 

--- a/tempodb/encoding/v1/page_reader_test.go
+++ b/tempodb/encoding/v1/page_reader_test.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/grafana/tempo/tempodb/backend"
@@ -38,11 +39,11 @@ func TestAllEncodings(t *testing.T) {
 				require.NoError(t, err)
 
 				encryptedBytes := buff.Bytes()
-				reader, err := NewPageReader(bytes.NewReader(encryptedBytes), enc)
+				reader, err := NewPageReader(backend.NewReaderAtWithReaderAt(bytes.NewReader(encryptedBytes)), enc)
 				require.NoError(t, err)
 				defer reader.Close()
 
-				actual, err := reader.Read([]*common.Record{
+				actual, err := reader.Read(context.Background(), []*common.Record{
 					{
 						Start:  0,
 						Length: uint32(mw.bytesWritten),

--- a/tempodb/encoding/versioned.go
+++ b/tempodb/encoding/versioned.go
@@ -32,7 +32,7 @@ type versionedEncoding interface {
 	newIndexWriter() common.IndexWriter
 
 	newPageReader(ra backend.ReaderAtContext, encoding backend.Encoding) (common.PageReader, error)
-	newIndexReader(indexBytes []byte) (common.IndexReader, error) // jpe indexBytes => readerAtContextThing.  Needs plain ol' read function to
+	newIndexReader(ra backend.ReaderAtContext) (common.IndexReader, error)
 }
 
 // v0Encoding
@@ -44,8 +44,8 @@ func (v v0Encoding) newIndexWriter() common.IndexWriter {
 func (v v0Encoding) newPageWriter(writer io.Writer, encoding backend.Encoding) (common.PageWriter, error) {
 	return v0.NewPageWriter(writer), nil // ignore encoding.  v0 PageWriter writes raw bytes
 }
-func (v v0Encoding) newIndexReader(indexBytes []byte) (common.IndexReader, error) {
-	return v0.NewIndexReader(indexBytes)
+func (v v0Encoding) newIndexReader(ra backend.ReaderAtContext) (common.IndexReader, error) {
+	return v0.NewIndexReader(ra)
 }
 func (v v0Encoding) newPageReader(ra backend.ReaderAtContext, encoding backend.Encoding) (common.PageReader, error) {
 	return v0.NewPageReader(ra), nil
@@ -63,6 +63,6 @@ func (v v1Encoding) newPageWriter(writer io.Writer, encoding backend.Encoding) (
 func (v v1Encoding) newPageReader(ra backend.ReaderAtContext, encoding backend.Encoding) (common.PageReader, error) {
 	return v1.NewPageReader(ra, encoding)
 }
-func (v v1Encoding) newIndexReader(indexBytes []byte) (common.IndexReader, error) {
-	return v1.NewIndexReader(indexBytes)
+func (v v1Encoding) newIndexReader(ra backend.ReaderAtContext) (common.IndexReader, error) {
+	return v1.NewIndexReader(ra)
 }

--- a/tempodb/encoding/versioned.go
+++ b/tempodb/encoding/versioned.go
@@ -31,8 +31,8 @@ type versionedEncoding interface {
 	newPageWriter(writer io.Writer, encoding backend.Encoding) (common.PageWriter, error)
 	newIndexWriter() common.IndexWriter
 
-	newPageReader(ra io.ReaderAt, encoding backend.Encoding) (common.PageReader, error) // jpe pass context through readerAt
-	newIndexReader(indexBytes []byte) (common.IndexReader, error)                       // jpe indexBytes => readerAtContextThing.  Needs plain ol' read function to
+	newPageReader(ra backend.ReaderAtContext, encoding backend.Encoding) (common.PageReader, error)
+	newIndexReader(indexBytes []byte) (common.IndexReader, error) // jpe indexBytes => readerAtContextThing.  Needs plain ol' read function to
 }
 
 // v0Encoding
@@ -47,7 +47,7 @@ func (v v0Encoding) newPageWriter(writer io.Writer, encoding backend.Encoding) (
 func (v v0Encoding) newIndexReader(indexBytes []byte) (common.IndexReader, error) {
 	return v0.NewIndexReader(indexBytes)
 }
-func (v v0Encoding) newPageReader(ra io.ReaderAt, encoding backend.Encoding) (common.PageReader, error) {
+func (v v0Encoding) newPageReader(ra backend.ReaderAtContext, encoding backend.Encoding) (common.PageReader, error) {
 	return v0.NewPageReader(ra), nil
 }
 
@@ -60,7 +60,7 @@ func (v v1Encoding) newIndexWriter() common.IndexWriter {
 func (v v1Encoding) newPageWriter(writer io.Writer, encoding backend.Encoding) (common.PageWriter, error) {
 	return v1.NewPageWriter(writer, encoding)
 }
-func (v v1Encoding) newPageReader(ra io.ReaderAt, encoding backend.Encoding) (common.PageReader, error) {
+func (v v1Encoding) newPageReader(ra backend.ReaderAtContext, encoding backend.Encoding) (common.PageReader, error) {
 	return v1.NewPageReader(ra, encoding)
 }
 func (v v1Encoding) newIndexReader(indexBytes []byte) (common.IndexReader, error) {

--- a/tempodb/encoding/versioned.go
+++ b/tempodb/encoding/versioned.go
@@ -29,14 +29,18 @@ func allEncodings() []versionedEncoding {
 //  but it is what it is for now!
 type versionedEncoding interface {
 	newPageWriter(writer io.Writer, encoding backend.Encoding) (common.PageWriter, error)
+	newIndexWriter() common.IndexWriter
 
-	newPageReader(ra io.ReaderAt, encoding backend.Encoding) (common.PageReader, error)
-	newIndexReader(indexBytes []byte) (common.IndexReader, error)
+	newPageReader(ra io.ReaderAt, encoding backend.Encoding) (common.PageReader, error) // jpe pass context through readerAt
+	newIndexReader(indexBytes []byte) (common.IndexReader, error)                       // jpe indexBytes => readerAtContextThing.  Needs plain ol' read function to
 }
 
 // v0Encoding
 type v0Encoding struct{}
 
+func (v v0Encoding) newIndexWriter() common.IndexWriter {
+	return v0.NewIndexWriter()
+}
 func (v v0Encoding) newPageWriter(writer io.Writer, encoding backend.Encoding) (common.PageWriter, error) {
 	return v0.NewPageWriter(writer), nil // ignore encoding.  v0 PageWriter writes raw bytes
 }
@@ -50,6 +54,9 @@ func (v v0Encoding) newPageReader(ra io.ReaderAt, encoding backend.Encoding) (co
 // v1Encoding
 type v1Encoding struct{}
 
+func (v v1Encoding) newIndexWriter() common.IndexWriter {
+	return v1.NewIndexWriter()
+}
 func (v v1Encoding) newPageWriter(writer io.Writer, encoding backend.Encoding) (common.PageWriter, error) {
 	return v1.NewPageWriter(writer, encoding)
 }

--- a/tempodb/encoding/versioned.go
+++ b/tempodb/encoding/versioned.go
@@ -31,8 +31,8 @@ type versionedEncoding interface {
 	newPageWriter(writer io.Writer, encoding backend.Encoding) (common.PageWriter, error)
 	newIndexWriter() common.IndexWriter
 
-	newPageReader(ra backend.ReaderAtContext, encoding backend.Encoding) (common.PageReader, error)
-	newIndexReader(ra backend.ReaderAtContext) (common.IndexReader, error)
+	newPageReader(ra backend.ContextReader, encoding backend.Encoding) (common.PageReader, error)
+	newIndexReader(ra backend.ContextReader) (common.IndexReader, error)
 }
 
 // v0Encoding
@@ -44,10 +44,10 @@ func (v v0Encoding) newIndexWriter() common.IndexWriter {
 func (v v0Encoding) newPageWriter(writer io.Writer, encoding backend.Encoding) (common.PageWriter, error) {
 	return v0.NewPageWriter(writer), nil // ignore encoding.  v0 PageWriter writes raw bytes
 }
-func (v v0Encoding) newIndexReader(ra backend.ReaderAtContext) (common.IndexReader, error) {
+func (v v0Encoding) newIndexReader(ra backend.ContextReader) (common.IndexReader, error) {
 	return v0.NewIndexReader(ra)
 }
-func (v v0Encoding) newPageReader(ra backend.ReaderAtContext, encoding backend.Encoding) (common.PageReader, error) {
+func (v v0Encoding) newPageReader(ra backend.ContextReader, encoding backend.Encoding) (common.PageReader, error) {
 	return v0.NewPageReader(ra), nil
 }
 
@@ -60,9 +60,9 @@ func (v v1Encoding) newIndexWriter() common.IndexWriter {
 func (v v1Encoding) newPageWriter(writer io.Writer, encoding backend.Encoding) (common.PageWriter, error) {
 	return v1.NewPageWriter(writer, encoding)
 }
-func (v v1Encoding) newPageReader(ra backend.ReaderAtContext, encoding backend.Encoding) (common.PageReader, error) {
+func (v v1Encoding) newPageReader(ra backend.ContextReader, encoding backend.Encoding) (common.PageReader, error) {
 	return v1.NewPageReader(ra, encoding)
 }
-func (v v1Encoding) newIndexReader(ra backend.ReaderAtContext) (common.IndexReader, error) {
+func (v v1Encoding) newIndexReader(ra backend.ContextReader) (common.IndexReader, error) {
 	return v1.NewIndexReader(ra)
 }

--- a/tempodb/encoding/versioned_test.go
+++ b/tempodb/encoding/versioned_test.go
@@ -46,7 +46,7 @@ func testPageWriterReader(t *testing.T, v versionedEncoding, e backend.Encoding)
 		require.NoError(t, err)
 
 		reader := bytes.NewReader(buff.Bytes())
-		pageReader, err := v.newPageReader(backend.NewReaderAtWithReaderAt(reader), e)
+		pageReader, err := v.newPageReader(backend.NewContextReaderWithAllReader(reader), e)
 		require.NoError(t, err)
 		defer pageReader.Close()
 

--- a/tempodb/encoding/versioned_test.go
+++ b/tempodb/encoding/versioned_test.go
@@ -2,6 +2,7 @@ package encoding
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/grafana/tempo/tempodb/backend"
@@ -45,11 +46,11 @@ func testPageWriterReader(t *testing.T, v versionedEncoding, e backend.Encoding)
 		require.NoError(t, err)
 
 		reader := bytes.NewReader(buff.Bytes())
-		pageReader, err := v.newPageReader(reader, e)
+		pageReader, err := v.newPageReader(backend.NewReaderAtWithReaderAt(reader), e)
 		require.NoError(t, err)
 		defer pageReader.Close()
 
-		actual, err := pageReader.Read([]*common.Record{
+		actual, err := pageReader.Read(context.Background(), []*common.Record{
 			{
 				Start:  0,
 				Length: uint32(bytesWritten),
@@ -61,7 +62,7 @@ func testPageWriterReader(t *testing.T, v versionedEncoding, e backend.Encoding)
 		i := NewIterator(bytes.NewReader(actual[0]))
 		defer i.Close()
 
-		id, obj, err := i.Next()
+		id, obj, err := i.Next(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, tc.readerBytes, obj)
 		assert.Equal(t, []byte{0x01}, []byte(id))

--- a/tempodb/wal/append_block.go
+++ b/tempodb/wal/append_block.go
@@ -1,6 +1,7 @@
 package wal
 
 import (
+	"context"
 	"os"
 
 	"github.com/google/uuid"
@@ -107,11 +108,11 @@ func (h *AppendBlock) Find(id common.ID, combiner common.ObjectCombiner) ([]byte
 		return nil, err
 	}
 
-	pageReader := v0.NewPageReader(file)
+	pageReader := v0.NewPageReader(backend.NewReaderAtWithReaderAt(file))
 	defer pageReader.Close()
 	finder := encoding.NewPagedFinder(common.Records(records), pageReader, combiner)
 
-	return finder.Find(id)
+	return finder.Find(context.Background(), id)
 }
 
 func (h *AppendBlock) Clear() error {

--- a/tempodb/wal/append_block.go
+++ b/tempodb/wal/append_block.go
@@ -23,7 +23,7 @@ type AppendBlock struct {
 	block
 
 	appendFile *os.File
-	appender   common.Appender
+	appender   encoding.Appender
 }
 
 func newAppendBlock(id uuid.UUID, tenantID string, filepath string) (*AppendBlock, error) {

--- a/tempodb/wal/append_block.go
+++ b/tempodb/wal/append_block.go
@@ -108,7 +108,7 @@ func (h *AppendBlock) Find(id common.ID, combiner common.ObjectCombiner) ([]byte
 		return nil, err
 	}
 
-	pageReader := v0.NewPageReader(backend.NewReaderAtWithReaderAt(file))
+	pageReader := v0.NewPageReader(backend.NewContextReaderWithAllReader(file))
 	defer pageReader.Close()
 	finder := encoding.NewPagedFinder(common.Records(records), pageReader, combiner)
 

--- a/tempodb/wal/replay_block.go
+++ b/tempodb/wal/replay_block.go
@@ -4,14 +4,13 @@ import (
 	"os"
 
 	"github.com/grafana/tempo/tempodb/encoding"
-	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
 type ReplayBlock struct {
 	block
 }
 
-func (r *ReplayBlock) Iterator() (common.Iterator, error) {
+func (r *ReplayBlock) Iterator() (encoding.Iterator, error) {
 	name := r.fullFilename()
 	f, err := os.OpenFile(name, os.O_RDONLY, 0644)
 	if err != nil {

--- a/tempodb/wal/wal_test.go
+++ b/tempodb/wal/wal_test.go
@@ -1,6 +1,7 @@
 package wal
 
 import (
+	"context"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -117,7 +118,7 @@ func TestAppend(t *testing.T) {
 	i := 0
 
 	for {
-		bytesID, bytesObject, err := iterator.Next()
+		bytesID, bytesObject, err := iterator.Next(context.Background())
 		assert.NoError(t, err)
 		if bytesID == nil {
 			break


### PR DESCRIPTION
**What this PR does**:
Final refactoring before attempting paged indexes.

- Correctly propagates context down through Iterator, Finder, PageReader and IndexReader interfaces
- Adds IndexWriter interface to versioned encoding
- Moves Appender, Finder and Iterator out of common and into encoding