### PR TITLE
fixed listing blocks for backend/s3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   This is a **breaking change** and will likely result in query errors on rollout as the query signature b/n QueryFrontend & Querier has changed. [#557](https://github.com/grafana/tempo/pull/557)
 * [BUGFIX] Fixes permissions errors on startup in GCS. [#554](https://github.com/grafana/tempo/pull/554)
 * [BUGFIX] Fixes error where Dell ECS cannot list objects. [#561](https://github.com/grafana/tempo/pull/561)
-
+* [BUGFIX] Fixes listing blocks in S3 when the list is truncated. [#567](https://github.com/grafana/tempo/pull/567)
 
 ## v0.6.0
 

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -272,21 +272,31 @@ func (rw *readerWriter) Tenants(ctx context.Context) ([]string, error) {
 // Blocks implements backend.Reader
 func (rw *readerWriter) Blocks(ctx context.Context, tenantID string) ([]uuid.UUID, error) {
 	prefix := tenantID + "/"
-	// ListObjects(bucket, prefix, marker, delimiter string, maxKeys int)
-	res, err := rw.core.ListObjects(rw.cfg.Bucket, prefix, "", "/", 0)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error listing blocks in s3 bucket, bucket: %s", rw.cfg.Bucket)
+	var blockIDs []uuid.UUID
+
+	nextMarker := ""
+	isTruncated := true
+	for isTruncated {
+		// ListObjects(bucket, prefix, nextMarker, delimiter string, maxKeys int)
+		res, err := rw.core.ListObjects(rw.cfg.Bucket, prefix, nextMarker, "/", 0)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error listing blocks in s3 bucket, bucket: %s", rw.cfg.Bucket)
+		}
+		isTruncated = res.IsTruncated
+		nextMarker = res.NextMarker
+
+		level.Debug(rw.logger).Log("msg", "listing blocks", "tenantID", tenantID,
+			"found", len(res.CommonPrefixes), "IsTruncated", res.IsTruncated, "NextMarker", res.NextMarker)
+
+		for _, cp := range res.CommonPrefixes {
+			blockID, err := uuid.Parse(strings.Split(strings.TrimPrefix(cp.Prefix, prefix), "/")[0])
+			if err != nil {
+				return nil, errors.Wrapf(err, "error parsing uuid of obj, objectName: %s", cp.Prefix)
+			}
+			blockIDs = append(blockIDs, blockID)
+		}
 	}
 
-	level.Debug(rw.logger).Log("msg", "listing blocks", "tenantID", tenantID, "found", len(res.CommonPrefixes))
-	var blockIDs []uuid.UUID
-	for _, cp := range res.CommonPrefixes {
-		blockID, err := uuid.Parse(strings.Split(strings.TrimPrefix(cp.Prefix, prefix), "/")[0])
-		if err != nil {
-			return nil, errors.Wrapf(err, "error parsing uuid of obj, objectName: %s", cp.Prefix)
-		}
-		blockIDs = append(blockIDs, blockID)
-	}
 	return blockIDs, nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This PR fixes `tempodb/backend/s3/Blocks()` to fetch the complete list of blocks in case the `ListObjects()` result is truncated. 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`