### PR TITLE
Close gaps where append/completeblock file handles would rely on GC to close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * [BUGFIX] Fixes permissions errors on startup in GCS. [#554](https://github.com/grafana/tempo/pull/554)
 * [BUGFIX] Fixes error where Dell ECS cannot list objects. [#561](https://github.com/grafana/tempo/pull/561)
 * [BUGFIX] Fixes listing blocks in S3 when the list is truncated. [#567](https://github.com/grafana/tempo/pull/567)
-* [BUGFIX] [#569](https://github.com/grafana/tempo/issues/569)
+* [BUGFIX] Fixes where ingester may leave file open [#569](https://github.com/grafana/tempo/issues/569)
 
 ## v0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * [BUGFIX] Fixes permissions errors on startup in GCS. [#554](https://github.com/grafana/tempo/pull/554)
 * [BUGFIX] Fixes error where Dell ECS cannot list objects. [#561](https://github.com/grafana/tempo/pull/561)
 * [BUGFIX] Fixes listing blocks in S3 when the list is truncated. [#567](https://github.com/grafana/tempo/pull/567)
-* [BUGFIX] Fixes where ingester may leave file open [#569](https://github.com/grafana/tempo/issues/569)
+* [BUGFIX] Fixes where ingester may leave file open [#570](https://github.com/grafana/tempo/pull/570)
 
 ## v0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [BUGFIX] Fixes permissions errors on startup in GCS. [#554](https://github.com/grafana/tempo/pull/554)
 * [BUGFIX] Fixes error where Dell ECS cannot list objects. [#561](https://github.com/grafana/tempo/pull/561)
 * [BUGFIX] Fixes listing blocks in S3 when the list is truncated. [#567](https://github.com/grafana/tempo/pull/567)
+* [BUGFIX] [#569](https://github.com/grafana/tempo/issues/569)
 
 ## v0.6.0
 

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -187,6 +187,12 @@ func (i *instance) CompleteBlock(blockID uuid.UUID) (uuid.UUID, error) {
 		i.blocksMtx.Unlock()
 		return uuid.Nil, err
 	}
+
+	err = completingBlock.Clear()
+	if err != nil {
+		level.Error(log.Logger).Log("msg", "Error clearing wal", "tenantID", i.instanceID, "err", err)
+	}
+
 	// remove completingBlock from list
 	for j, iterBlock := range i.completingBlocks {
 		if iterBlock.BlockID() == blockID {
@@ -194,6 +200,7 @@ func (i *instance) CompleteBlock(blockID uuid.UUID) (uuid.UUID, error) {
 			break
 		}
 	}
+
 	completeBlockID := completeBlock.BlockMeta().BlockID
 	i.completeBlocks = append(i.completeBlocks, completeBlock)
 	i.blocksMtx.Unlock()

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -179,31 +179,28 @@ func (i *instance) CompleteBlock(blockID uuid.UUID) (uuid.UUID, error) {
 
 	// potentially long running operation placed outside blocksMtx
 	completeBlock, err := i.writer.CompleteBlock(completingBlock, i)
-
-	i.blocksMtx.Lock()
 	if err != nil {
 		metricFailedFlushes.Inc()
 		level.Error(log.Logger).Log("msg", "unable to complete block.", "tenantID", i.instanceID, "err", err)
-		i.blocksMtx.Unlock()
 		return uuid.Nil, err
 	}
 
-	err = completingBlock.Clear()
-	if err != nil {
-		level.Error(log.Logger).Log("msg", "Error clearing wal", "tenantID", i.instanceID, "err", err)
-	}
-
-	// remove completingBlock from list
+	// remove completingBlock and add completeBlock
+	i.blocksMtx.Lock()
 	for j, iterBlock := range i.completingBlocks {
 		if iterBlock.BlockID() == blockID {
 			i.completingBlocks = append(i.completingBlocks[:j], i.completingBlocks[j+1:]...)
 			break
 		}
 	}
-
 	completeBlockID := completeBlock.BlockMeta().BlockID
 	i.completeBlocks = append(i.completeBlocks, completeBlock)
 	i.blocksMtx.Unlock()
+
+	err = completingBlock.Clear()
+	if err != nil {
+		level.Error(log.Logger).Log("msg", "Error clearing wal", "tenantID", i.instanceID, "err", err)
+	}
 
 	return completeBlockID, nil
 }

--- a/tempodb/encoding/complete_block_test.go
+++ b/tempodb/encoding/complete_block_test.go
@@ -99,7 +99,7 @@ func testCompleteBlockToBackendBlock(t *testing.T, cfg *BlockConfig) {
 	require.NoError(t, err, "error creating backend")
 
 	err = block.Write(context.Background(), w)
-	require.EqualError(t, err, "remove : no such file or directory") // we expect an error here b/c there is no wal file to clear
+	require.NoError(t, err, "error writing backend")
 
 	// meta?
 	uuids, err := r.Blocks(context.Background(), testTenantID)
@@ -198,7 +198,7 @@ func completeBlock(t *testing.T, cfg *BlockConfig, tempDir string) (*CompleteBlo
 	}
 
 	iterator := NewRecordIterator(appender.Records(), bytes.NewReader(buffer.Bytes()))
-	block, err := NewCompleteBlock(cfg, originatingMeta, iterator, numMsgs, tempDir, "")
+	block, err := NewCompleteBlock(cfg, originatingMeta, iterator, numMsgs, tempDir)
 	require.NoError(t, err, "unexpected error completing block")
 
 	// test downsample config
@@ -285,7 +285,7 @@ func benchmarkCompressBlock(b *testing.B, encoding backend.Encoding, indexDownsa
 		IndexDownsampleBytes: indexDownsample,
 		BloomFP:              .05,
 		Encoding:             encoding,
-	}, originatingMeta, iterator, 10000, tempDir, "")
+	}, originatingMeta, iterator, 10000, tempDir)
 	require.NoError(b, err, "error creating block")
 
 	lastRecord := cb.records[len(cb.records)-1]

--- a/tempodb/wal/append_block.go
+++ b/tempodb/wal/append_block.go
@@ -35,13 +35,8 @@ func newAppendBlock(id uuid.UUID, tenantID string, filepath string) (*AppendBloc
 	}
 
 	name := h.fullFilename()
-	unused, err := os.Create(name)
-	if err != nil {
-		return nil, err
-	}
-	unused.Close()
 
-	f, err := os.OpenFile(name, os.O_APPEND|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(name, os.O_APPEND|os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +88,7 @@ func (h *AppendBlock) Complete(cfg *encoding.BlockConfig, w *WAL, combiner commo
 	}
 	defer iterator.Close()
 
-	orderedBlock, err := encoding.NewCompleteBlock(cfg, h.meta, iterator, len(records), w.c.CompletedFilepath, h.fullFilename())
+	orderedBlock, err := encoding.NewCompleteBlock(cfg, h.meta, iterator, len(records), w.c.CompletedFilepath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does**:
This PR addresses a few instances where Append/CompleteBlock file handles would be left open and rely on GC to cleanup. The split of the deletion of WAL (AppendBlock) from creation of CompleteBlock also helps to ensure that AppendBlock.Clear is called, closing all handles.

**Which issue(s) this PR fixes**:
Fixes #569

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`