### PR TITLE
Fixed the filename in getting started

### DIFF
--- a/docs/tempo/website/getting-started/_index.md
+++ b/docs/tempo/website/getting-started/_index.md
@@ -19,7 +19,7 @@ docker network create docker-tempo
 Next, download the [configuration file](https://github.com/grafana/tempo/blob/master/example/docker-compose/etc/tempo-local.yaml) using the following command -
 
 ```
-curl -o tempo.yaml https://raw.githubusercontent.com/grafana/tempo/master/example/docker-compose/etc/tempo-local.yaml
+curl -o tempo-local.yaml https://raw.githubusercontent.com/grafana/tempo/master/example/docker-compose/etc/tempo-local.yaml
 ```
 
 The config file above configures Tempo to listen on default ports for a number of protocols.


### PR DESCRIPTION
The `curl` command downloads the sample configuration to tempo.yaml, but the docker container is looking for `tempo-local.yaml`

**What this PR does**:

Fixes the filename of the config file in the "Getting Started" guide.

**Checklist**
- [ ] Tests updated
- [x] Documentation added
