### PR TITLE
Fix bench flaky test

### DIFF
--- a/integration/bench/stress_test_write_path.js
+++ b/integration/bench/stress_test_write_path.js
@@ -15,8 +15,8 @@ export let options = {
       exec: 'writePath',
       startVUs: 1,
       stages: [
-        { duration: '2m', target: 5 },
-        { duration: '1m', target: 10 },
+        { duration: '2m', target: 2 },
+        { duration: '1m', target: 5 },
         { duration: '1m', target: 0 },
         { duration: '1m', target: 5 },
       ],

--- a/integration/bench/stress_test_write_path.js
+++ b/integration/bench/stress_test_write_path.js
@@ -15,10 +15,10 @@ export let options = {
       exec: 'writePath',
       startVUs: 1,
       stages: [
-        { duration: '2m', target: 2 },
-        { duration: '1m', target: 5 },
+        { duration: '2m', target: 15 },
+        { duration: '1m', target: 30 },
         { duration: '1m', target: 0 },
-        { duration: '1m', target: 5 },
+        { duration: '1m', target: 20 },
       ],
       gracefulRampDown: '5s',
     },
@@ -53,6 +53,7 @@ export function writePath() {
   check(res, {
     'write is status 202': (r) => r.status === 202
   }, { type: 'write' });
+  sleep(0.01)
 }
 
 


### PR DESCRIPTION
**What this PR does**:
- Increases the number of VUs on the bench stress test.
- Adds sleep to the `writePath` scenario.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/tempo/pull/580/checks?check_run_id=2068246653

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`