### PR TITLE
Add wildcard tenant

### DIFF
--- a/docs/tempo/website/configuration/ingestion-limit.md
+++ b/docs/tempo/website/configuration/ingestion-limit.md
@@ -81,6 +81,16 @@ Sometimes you don't want all tenants within the cluster to have the same setting
 
 This overrides file is dynamically loaded.  It can be changed at runtime and will be reloaded by Tempo without restarting the application.
 
+1. Additionally a "wildcard" override can be used that will apply to all tenants if a match is not found otherwise.
+```
+    overrides:
+        "*":
+            ingestion_max_batch_size: 5000
+            ingestion_rate_limit: 400000
+            max_spans_per_trace: 250000
+            max_traces_per_user: 100000
+```
+
 ## Override strategies
 
 The trace limits specified by the various parameters are, by default, applied as per-distributor limits. For example, a `max_traces_per_user` setting of 10000 means that each distributor within the cluster has a limit of 10000 traces per user. This is known as a `local` strategy in that the specified trace limits are local to each distributor.

--- a/modules/overrides/overrides.go
+++ b/modules/overrides/overrides.go
@@ -16,6 +16,8 @@ import (
 // nil, if there are no tenant-specific limits.
 type TenantLimits func(userID string) *Limits
 
+const wildcardTenant = "*"
+
 // perTenantOverrides represents the overrides config file
 type perTenantOverrides struct {
 	TenantLimits map[string]*Limits `yaml:"overrides"`
@@ -162,6 +164,11 @@ func (o *Overrides) BlockRetention(userID string) time.Duration {
 func (o *Overrides) getOverridesForUser(userID string) *Limits {
 	if o.tenantLimits != nil {
 		l := o.tenantLimits(userID)
+		if l != nil {
+			return l
+		}
+
+		l = o.tenantLimits(wildcardTenant)
 		if l != nil {
 			return l
 		}


### PR DESCRIPTION
**What this PR does**:
Adds the ability set a wildcard override in our override file.  This will allow us to feel comfortable that defaults are coming from within the file and that the override file is loaded.
