### PR TITLE
Added PushBytes to the race test

### DIFF
--- a/modules/ingester/instance_test.go
+++ b/modules/ingester/instance_test.go
@@ -178,6 +178,13 @@ func TestInstanceDoesNotRace(t *testing.T) {
 	})
 
 	go concurrent(func() {
+		id := make([]byte, 16)
+		_, _ = rand.Read(id)
+		err := i.PushBytes(context.Background(), id, []byte{0x01})
+		assert.NoError(t, err, "error pushing traces")
+	})
+
+	go concurrent(func() {
 		err := i.CutCompleteTraces(0, true)
 		assert.NoError(t, err, "error cutting complete traces")
 	})


### PR DESCRIPTION
**What this PR does**:
Adds `PushBytes()` to the `TestInstanceDoesNotRace()` test.  This should have been part of the previous PR, but it was Saturday and I didn't think about it.

Also confirmed that reverting the previous fix causes this test to fail.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`