### PR TITLE
Several fixes and improvements to block flushing, wal replay, file deletion, and logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [BUGFIX] Fixes listing blocks in S3 when the list is truncated. [#567](https://github.com/grafana/tempo/pull/567)
 * [BUGFIX] Fixes where ingester may leave file open [#570](https://github.com/grafana/tempo/pull/570)
 * [BUGFIX] Fixes a bug where some blocks were not searched due to query sharding and randomness in blocklist poll. [#583](https://github.com/grafana/tempo/pull/583)
+* [BUGFIX] Fixes issue where wal was deleted before successful flush and adds exponential backoff for flush errors [#593](https://github.com/grafana/tempo/pull/593)
 
 ## v0.6.0
 

--- a/modules/ingester/flush.go
+++ b/modules/ingester/flush.go
@@ -301,7 +301,10 @@ func (i *Ingester) enqueue(op *flushOp, jitter bool) {
 			return
 		}
 
-		i.flushQueues.Enqueue(op)
+		err := i.flushQueues.Enqueue(op)
+		if err != nil {
+			handleFailedOp(op, err)
+		}
 	}()
 }
 
@@ -328,6 +331,9 @@ func (i *Ingester) requeue(op *flushOp) {
 			return
 		}
 
-		i.flushQueues.Requeue(op)
+		err := i.flushQueues.Requeue(op)
+		if err != nil {
+			handleFailedOp(op, err)
+		}
 	}()
 }

--- a/modules/ingester/flush.go
+++ b/modules/ingester/flush.go
@@ -3,7 +3,6 @@ package ingester
 import (
 	"context"
 	"fmt"
-	"math"
 	"net/http"
 	"strconv"
 	"time"
@@ -38,9 +37,9 @@ var (
 )
 
 const (
-	// Backoff for retrying 'immediate' flushes. Only counts for queue
-	// position, not wallclock time.
-	flushBackoff = 1 * time.Second
+	initialBackoff      = 1 * time.Second
+	maxBackoff          = time.Minute
+	maxCompleteAttempts = 10
 )
 
 const (
@@ -99,18 +98,22 @@ func (i *Ingester) FlushHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 type flushOp struct {
-	kind    int
-	from    int64
-	userID  string
-	blockID uuid.UUID
+	kind     int
+	at       time.Time // When to execute
+	attempts uint
+	backoff  time.Duration
+	userID   string
+	blockID  uuid.UUID
 }
 
 func (o *flushOp) Key() string {
 	return o.userID + "/" + strconv.Itoa(o.kind) + "/" + o.blockID.String()
 }
 
+// Priority orders entries in the queue. The larger the number the higher the priority, so inverted here to
+// prioritize entries with earliest timestamps.
 func (o *flushOp) Priority() int64 {
-	return -o.from
+	return -o.at.Unix()
 }
 
 // sweepAllInstances periodically schedules series for flushing and garbage collects instances with no series
@@ -140,7 +143,7 @@ func (i *Ingester) sweepInstance(instance *instance, immediate bool) {
 	if blockID != uuid.Nil {
 		i.flushQueues.Enqueue(&flushOp{
 			kind:    opKindComplete,
-			from:    math.MaxInt64,
+			at:      time.Now(),
 			userID:  instance.instanceID,
 			blockID: blockID,
 		})
@@ -165,47 +168,62 @@ func (i *Ingester) flushLoop(j int) {
 			return
 		}
 		op := o.(*flushOp)
+		op.attempts++
 
-		var completeBlockID uuid.UUID
-		var err error
+		retry := false
+
 		if op.kind == opKindComplete {
 			level.Debug(log.Logger).Log("msg", "completing block", "userid", op.userID)
 			instance, exists := i.getInstanceByID(op.userID)
 			if !exists {
 				// instance no longer exists? that's bad, log and continue
-				level.Error(log.Logger).Log("msg", "instance not found", "tenantID", op.userID)
+				level.Error(log.Logger).Log("msg", "instance not found", "userID", op.userID, "block", op.blockID.String())
 				continue
 			}
 
-			completeBlockID, err = instance.CompleteBlock(op.blockID)
-			if completeBlockID != uuid.Nil {
+			err := instance.CompleteBlock(op.blockID)
+			if err != nil {
+				handleFlushError(op, err)
+
+				if op.attempts >= maxCompleteAttempts {
+					level.Error(log.WithUserID(op.userID, log.Logger)).Log("msg", "Block exceeded max completion errors. Deleting. POSSIBLE DATA LOSS",
+						"userID", op.userID, "attempts", op.attempts, "block", op.blockID.String())
+					instance.ClearCompletingBlock(op.blockID)
+				} else {
+					retry = true
+				}
+			} else {
 				// add a flushOp for the block we just completed
 				i.flushQueues.Enqueue(&flushOp{
 					kind:    opKindFlush,
-					from:    time.Now().Unix(),
+					at:      time.Now(),
 					userID:  instance.instanceID,
-					blockID: completeBlockID,
+					blockID: op.blockID,
 				})
 			}
 
 		} else {
-			level.Debug(log.Logger).Log("msg", "flushing block", "userid", op.userID, "fp")
+			level.Info(log.Logger).Log("msg", "flushing block", "userid", op.userID, "block", op.blockID.String())
 
-			err = i.flushBlock(op.userID, op.blockID)
+			err := i.flushBlock(op.userID, op.blockID)
+			if err != nil {
+				handleFlushError(op, err)
+				retry = true
+			}
 		}
 
-		if err != nil {
-			level.Error(log.WithUserID(op.userID, log.Logger)).Log("msg", "error performing op in flushQueue",
-				"op", op.kind, "block", op.blockID.String(), "err", err)
-			metricFailedFlushes.Inc()
-			// re-queue op with backoff
-			op.from += int64(flushBackoff)
-			i.flushQueues.Requeue(op)
-			continue
+		if retry {
+			i.requeue(op)
+		} else {
+			i.flushQueues.Clear(op)
 		}
-
-		i.flushQueues.Clear(op)
 	}
+}
+
+func handleFlushError(op *flushOp, err error) {
+	level.Error(log.WithUserID(op.userID, log.Logger)).Log("msg", "error performing op in flushQueue",
+		"op", op.kind, "block", op.blockID.String(), "attempts", op.attempts, "err", err)
+	metricFailedFlushes.Inc()
 }
 
 func (i *Ingester) flushBlock(userID string, blockID uuid.UUID) error {
@@ -229,10 +247,32 @@ func (i *Ingester) flushBlock(userID string, blockID uuid.UUID) error {
 		if err != nil {
 			return err
 		}
+		// Delete original wal only after successful flush
+		instance.ClearCompletingBlock(blockID)
 		metricBlocksFlushed.Inc()
 	} else {
 		return fmt.Errorf("error getting block to flush")
 	}
 
 	return nil
+}
+
+func (i *Ingester) requeue(op *flushOp) {
+	op.backoff *= 2
+	if op.backoff < initialBackoff {
+		op.backoff = initialBackoff
+	}
+	if op.backoff > maxBackoff {
+		op.backoff = maxBackoff
+	}
+
+	op.at = time.Now().Add(op.backoff)
+
+	level.Info(log.WithUserID(op.userID, log.Logger)).Log("msg", "retrying op in flushQueue",
+		"op", op.kind, "block", op.blockID.String(), "backoff", op.backoff)
+
+	go func() {
+		time.Sleep(op.backoff)
+		i.flushQueues.Requeue(op)
+	}()
 }

--- a/modules/ingester/flush.go
+++ b/modules/ingester/flush.go
@@ -38,10 +38,10 @@ var (
 )
 
 const (
-	initialBackoff      = 1 * time.Second
+	initialBackoff      = 30 * time.Second
 	flushJitter         = 10 * time.Second
-	maxBackoff          = time.Minute
-	maxCompleteAttempts = 10
+	maxBackoff          = 120 * time.Second
+	maxCompleteAttempts = 3
 )
 
 const (

--- a/modules/ingester/ingester.go
+++ b/modules/ingester/ingester.go
@@ -302,6 +302,8 @@ func (i *Ingester) replayWal() error {
 		}
 	}
 
+	level.Info(log.Logger).Log("msg", "wal replay complete")
+
 	return nil
 }
 

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -192,7 +192,8 @@ func (i *instance) CompleteBlock(blockID uuid.UUID) error {
 	return nil
 }
 
-func (i *instance) ClearCompletingBlock(blockID uuid.UUID) {
+// nolint:interfacer
+func (i *instance) ClearCompletingBlock(blockID uuid.UUID) error {
 	i.blocksMtx.Lock()
 	var completingBlock *wal.AppendBlock
 	for j, iterBlock := range i.completingBlocks {
@@ -205,13 +206,14 @@ func (i *instance) ClearCompletingBlock(blockID uuid.UUID) {
 	i.blocksMtx.Unlock()
 
 	if completingBlock != nil {
-		err := completingBlock.Clear()
-		if err != nil {
-			level.Error(log.Logger).Log("msg", "Error clearing wal", "tenantID", i.instanceID, "blockID", blockID.String(), "err", err)
-		}
-	} else {
-		level.Error(log.Logger).Log("msg", "Error finding wal completingBlock to clear")
+		return completingBlock.Clear()
+		//if err != nil {
+		//	return err
+		//level.Error(log.Logger).Log("msg", "Error clearing wal", "tenantID", i.instanceID, "blockID", blockID.String(), "err", err)
+		//}
 	}
+
+	return fmt.Errorf("Error finding wal completingBlock to clear")
 }
 
 // GetBlockToBeFlushed gets a list of blocks that can be flushed to the backend

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -160,8 +160,8 @@ func (i *instance) CutBlockIfReady(maxBlockLifetime time.Duration, maxBlockBytes
 	return uuid.Nil, nil
 }
 
-// CompleteBlock() moves a completingBlock to a completeBlock
-func (i *instance) CompleteBlock(blockID uuid.UUID) (uuid.UUID, error) {
+// CompleteBlock() moves a completingBlock to a completeBlock. The new completeBlock has the same ID
+func (i *instance) CompleteBlock(blockID uuid.UUID) error {
 	i.blocksMtx.Lock()
 
 	var completingBlock *wal.AppendBlock
@@ -174,7 +174,7 @@ func (i *instance) CompleteBlock(blockID uuid.UUID) (uuid.UUID, error) {
 	i.blocksMtx.Unlock()
 
 	if completingBlock == nil {
-		return uuid.Nil, fmt.Errorf("error finding completingBlock")
+		return fmt.Errorf("error finding completingBlock")
 	}
 
 	// potentially long running operation placed outside blocksMtx
@@ -182,27 +182,36 @@ func (i *instance) CompleteBlock(blockID uuid.UUID) (uuid.UUID, error) {
 	if err != nil {
 		metricFailedFlushes.Inc()
 		level.Error(log.Logger).Log("msg", "unable to complete block.", "tenantID", i.instanceID, "err", err)
-		return uuid.Nil, err
+		return err
 	}
 
-	// remove completingBlock and add completeBlock
 	i.blocksMtx.Lock()
+	i.completeBlocks = append(i.completeBlocks, completeBlock)
+	i.blocksMtx.Unlock()
+
+	return nil
+}
+
+func (i *instance) ClearCompletingBlock(blockID uuid.UUID) {
+	i.blocksMtx.Lock()
+	var completingBlock *wal.AppendBlock
 	for j, iterBlock := range i.completingBlocks {
 		if iterBlock.BlockID() == blockID {
+			completingBlock = iterBlock
 			i.completingBlocks = append(i.completingBlocks[:j], i.completingBlocks[j+1:]...)
 			break
 		}
 	}
-	completeBlockID := completeBlock.BlockMeta().BlockID
-	i.completeBlocks = append(i.completeBlocks, completeBlock)
 	i.blocksMtx.Unlock()
 
-	err = completingBlock.Clear()
-	if err != nil {
-		level.Error(log.Logger).Log("msg", "Error clearing wal", "tenantID", i.instanceID, "err", err)
+	if completingBlock != nil {
+		err := completingBlock.Clear()
+		if err != nil {
+			level.Error(log.Logger).Log("msg", "Error clearing wal", "tenantID", i.instanceID, "blockID", blockID.String(), "err", err)
+		}
+	} else {
+		level.Error(log.Logger).Log("msg", "Error finding wal completingBlock to clear")
 	}
-
-	return completeBlockID, nil
 }
 
 // GetBlockToBeFlushed gets a list of blocks that can be flushed to the backend

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -207,10 +207,6 @@ func (i *instance) ClearCompletingBlock(blockID uuid.UUID) error {
 
 	if completingBlock != nil {
 		return completingBlock.Clear()
-		//if err != nil {
-		//	return err
-		//level.Error(log.Logger).Log("msg", "Error clearing wal", "tenantID", i.instanceID, "blockID", blockID.String(), "err", err)
-		//}
 	}
 
 	return fmt.Errorf("Error finding wal completingBlock to clear")

--- a/pkg/flushqueues/exclusivequeues.go
+++ b/pkg/flushqueues/exclusivequeues.go
@@ -12,6 +12,7 @@ type ExclusiveQueues struct {
 	queues     []*util.PriorityQueue
 	index      *atomic.Int32
 	activeKeys sync.Map
+	stopped    bool
 }
 
 // New creates a new set of flush queues with a prom gauge to track current depth
@@ -69,7 +70,13 @@ func (f *ExclusiveQueues) IsEmpty() bool {
 
 // Stop closes all queues
 func (f *ExclusiveQueues) Stop() {
+	f.stopped = true
+
 	for _, q := range f.queues {
 		q.Close()
 	}
+}
+
+func (f *ExclusiveQueues) IsStopped() bool {
+	return f.stopped
 }

--- a/pkg/flushqueues/exclusivequeues.go
+++ b/pkg/flushqueues/exclusivequeues.go
@@ -3,13 +3,12 @@ package flushqueues
 import (
 	"sync"
 
-	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/uber-go/atomic"
 )
 
 type ExclusiveQueues struct {
-	queues     []*util.PriorityQueue
+	queues     []*PriorityQueue
 	index      *atomic.Int32
 	activeKeys sync.Map
 	stopped    bool
@@ -18,42 +17,43 @@ type ExclusiveQueues struct {
 // New creates a new set of flush queues with a prom gauge to track current depth
 func New(queues int, metric prometheus.Gauge) *ExclusiveQueues {
 	f := &ExclusiveQueues{
-		queues: make([]*util.PriorityQueue, queues),
+		queues: make([]*PriorityQueue, queues),
 		index:  atomic.NewInt32(0),
 	}
 
 	for j := 0; j < queues; j++ {
-		f.queues[j] = util.NewPriorityQueue(metric)
+		f.queues[j] = NewPriorityQueue(metric)
 	}
 
 	return f
 }
 
 // Enqueue adds the op to the next queue and prevents any other items to be added with this key
-func (f *ExclusiveQueues) Enqueue(op util.Op) {
+func (f *ExclusiveQueues) Enqueue(op Op) error {
 	_, ok := f.activeKeys.Load(op.Key())
 	if ok {
-		return
+		return nil
 	}
 
 	f.activeKeys.Store(op.Key(), struct{}{})
-	f.Requeue(op)
+	return f.Requeue(op)
 }
 
 // Dequeue removes the next op from the requested queue.  After dequeueing the calling
 //  process either needs to call ClearKey or Requeue
-func (f *ExclusiveQueues) Dequeue(q int) util.Op {
+func (f *ExclusiveQueues) Dequeue(q int) Op {
 	return f.queues[q].Dequeue()
 }
 
 // Requeue adds an op that is presumed to already be covered by activeKeys
-func (f *ExclusiveQueues) Requeue(op util.Op) {
+func (f *ExclusiveQueues) Requeue(op Op) error {
 	flushQueueIndex := int(f.index.Inc()) % len(f.queues)
-	f.queues[flushQueueIndex].Enqueue(op)
+	_, err := f.queues[flushQueueIndex].Enqueue(op)
+	return err
 }
 
 // Clear unblocks the requested op.  This should be called only after a flush has been successful
-func (f *ExclusiveQueues) Clear(op util.Op) {
+func (f *ExclusiveQueues) Clear(op Op) {
 	f.activeKeys.Delete(op.Key())
 }
 

--- a/pkg/flushqueues/exclusivequeues_test.go
+++ b/pkg/flushqueues/exclusivequeues_test.go
@@ -33,12 +33,16 @@ func TestExclusiveQueues(t *testing.T) {
 	}
 
 	// enqueue twice
-	q.Enqueue(op)
+	err := q.Enqueue(op)
+	assert.NoError(t, err)
+
 	length, err := test.GetGaugeValue(gauge)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, int(length))
 
-	q.Enqueue(op)
+	err = q.Enqueue(op)
+	assert.NoError(t, err)
+
 	length, err = test.GetGaugeValue(gauge)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, int(length))
@@ -49,7 +53,9 @@ func TestExclusiveQueues(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 0, int(length))
 
-	q.Requeue(op)
+	err = q.Requeue(op)
+	assert.NoError(t, err)
+
 	length, err = test.GetGaugeValue(gauge)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, int(length))
@@ -65,7 +71,9 @@ func TestExclusiveQueues(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 0, int(length))
 
-	q.Enqueue(op)
+	err = q.Enqueue(op)
+	assert.NoError(t, err)
+
 	length, err = test.GetGaugeValue(gauge)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, int(length))
@@ -87,7 +95,8 @@ func TestMultipleQueues(t *testing.T) {
 			key: uuid.New().String(),
 		}
 
-		q.Enqueue(op)
+		err := q.Enqueue(op)
+		assert.NoError(t, err)
 
 		length, err := test.GetGaugeValue(gauge)
 		assert.NoError(t, err)

--- a/pkg/flushqueues/priority_queue.go
+++ b/pkg/flushqueues/priority_queue.go
@@ -1,0 +1,130 @@
+package flushqueues
+
+import (
+	"container/heap"
+	"errors"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// PriorityQueue is a priority queue.
+type PriorityQueue struct {
+	lock        sync.Mutex
+	cond        *sync.Cond
+	closing     bool
+	closed      bool
+	hit         map[string]struct{}
+	queue       queue
+	lengthGauge prometheus.Gauge
+}
+
+// Op is an operation on the priority queue.
+type Op interface {
+	Key() string
+	Priority() int64 // The larger the number the higher the priority.
+}
+
+type queue []Op
+
+func (q queue) Len() int           { return len(q) }
+func (q queue) Less(i, j int) bool { return q[i].Priority() > q[j].Priority() }
+func (q queue) Swap(i, j int)      { q[i], q[j] = q[j], q[i] }
+
+// Push and Pop use pointer receivers because they modify the slice's length,
+// not just its contents.
+func (q *queue) Push(x interface{}) {
+	*q = append(*q, x.(Op))
+}
+
+func (q *queue) Pop() interface{} {
+	old := *q
+	n := len(old)
+	x := old[n-1]
+	*q = old[0 : n-1]
+	return x
+}
+
+// NewPriorityQueue makes a new priority queue.
+func NewPriorityQueue(lengthGauge prometheus.Gauge) *PriorityQueue {
+	pq := &PriorityQueue{
+		hit:         map[string]struct{}{},
+		lengthGauge: lengthGauge,
+	}
+	pq.cond = sync.NewCond(&pq.lock)
+	heap.Init(&pq.queue)
+	return pq
+}
+
+// Length returns the length of the queue.
+func (pq *PriorityQueue) Length() int {
+	pq.lock.Lock()
+	defer pq.lock.Unlock()
+	return len(pq.queue)
+}
+
+// Close signals that the queue should be closed when it is empty.
+// A closed queue will not accept new items.
+func (pq *PriorityQueue) Close() {
+	pq.lock.Lock()
+	defer pq.lock.Unlock()
+	pq.closing = true
+	pq.cond.Broadcast()
+}
+
+// DiscardAndClose closes the queue and removes all the items from it.
+func (pq *PriorityQueue) DiscardAndClose() {
+	pq.lock.Lock()
+	defer pq.lock.Unlock()
+	pq.closed = true
+	pq.queue = nil
+	pq.hit = map[string]struct{}{}
+	pq.cond.Broadcast()
+}
+
+// Enqueue adds an operation to the queue in priority order. Returns
+// true if added; false if the operation was already on the queue.
+func (pq *PriorityQueue) Enqueue(op Op) (bool, error) {
+	pq.lock.Lock()
+	defer pq.lock.Unlock()
+
+	if pq.closed {
+		return false, errors.New("enqueue on closed queue")
+	}
+
+	_, enqueued := pq.hit[op.Key()]
+	if enqueued {
+		return false, nil
+	}
+
+	pq.hit[op.Key()] = struct{}{}
+	heap.Push(&pq.queue, op)
+	pq.cond.Broadcast()
+	if pq.lengthGauge != nil {
+		pq.lengthGauge.Inc()
+	}
+	return true, nil
+}
+
+// Dequeue will return the op with the highest priority; block if queue is
+// empty; returns nil if queue is closed.
+func (pq *PriorityQueue) Dequeue() Op {
+	pq.lock.Lock()
+	defer pq.lock.Unlock()
+
+	for len(pq.queue) == 0 && !(pq.closing || pq.closed) {
+		pq.cond.Wait()
+	}
+
+	if len(pq.queue) == 0 && (pq.closing || pq.closed) {
+		pq.closed = true
+		return nil
+	}
+
+	op := heap.Pop(&pq.queue).(Op)
+	delete(pq.hit, op.Key())
+	if pq.lengthGauge != nil {
+		pq.lengthGauge.Dec()
+	}
+	return op
+}

--- a/pkg/flushqueues/priority_queue_test.go
+++ b/pkg/flushqueues/priority_queue_test.go
@@ -1,0 +1,86 @@
+package flushqueues
+
+import (
+	"runtime"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type simpleItem int64
+
+func (i simpleItem) Priority() int64 {
+	return int64(i)
+}
+
+func (i simpleItem) Key() string {
+	return strconv.FormatInt(int64(i), 10)
+}
+
+func TestPriorityQueueBasic(t *testing.T) {
+	queue := NewPriorityQueue(nil)
+	assert.Equal(t, 0, queue.Length(), "Expected length = 0")
+
+	_, err := queue.Enqueue(simpleItem(1))
+	assert.NoError(t, err)
+	assert.Equal(t, 1, queue.Length(), "Expected length = 1")
+
+	i, ok := queue.Dequeue().(simpleItem)
+	assert.True(t, ok, "Expected cast to succeed")
+	assert.Equal(t, simpleItem(1), i, "Expected to dequeue simpleItem(1)")
+
+	queue.Close()
+	assert.Nil(t, queue.Dequeue(), "Expect nil dequeue")
+}
+
+func TestPriorityQueuePriorities(t *testing.T) {
+	queue := NewPriorityQueue(nil)
+
+	_, err := queue.Enqueue(simpleItem(1))
+	assert.NoError(t, err)
+
+	_, err = queue.Enqueue(simpleItem(2))
+	assert.NoError(t, err)
+
+	assert.Equal(t, simpleItem(2), queue.Dequeue().(simpleItem), "Expected to dequeue simpleItem(2)")
+	assert.Equal(t, simpleItem(1), queue.Dequeue().(simpleItem), "Expected to dequeue simpleItem(1)")
+
+	queue.Close()
+	assert.Nil(t, queue.Dequeue(), "Expect nil dequeue")
+}
+
+func TestPriorityQueuePriorities2(t *testing.T) {
+	queue := NewPriorityQueue(nil)
+
+	_, err := queue.Enqueue(simpleItem(2))
+	assert.NoError(t, err)
+
+	_, err = queue.Enqueue(simpleItem(1))
+	assert.NoError(t, err)
+
+	assert.Equal(t, simpleItem(2), queue.Dequeue().(simpleItem), "Expected to dequeue simpleItem(2)")
+	assert.Equal(t, simpleItem(1), queue.Dequeue().(simpleItem), "Expected to dequeue simpleItem(1)")
+
+	queue.Close()
+	assert.Nil(t, queue.Dequeue(), "Expect nil dequeue")
+}
+
+func TestPriorityQueueWait(t *testing.T) {
+	queue := NewPriorityQueue(nil)
+
+	done := make(chan struct{})
+	go func() {
+		assert.Nil(t, queue.Dequeue(), "Expect nil dequeue")
+		close(done)
+	}()
+
+	queue.Close()
+	runtime.Gosched()
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Close didn't unblock Dequeue.")
+	}
+}

--- a/tempodb/encoding/complete_block.go
+++ b/tempodb/encoding/complete_block.go
@@ -9,7 +9,6 @@ import (
 
 	"go.uber.org/atomic"
 
-	"github.com/google/uuid"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
@@ -37,7 +36,7 @@ type CompleteBlock struct {
 func NewCompleteBlock(cfg *BlockConfig, originatingMeta *backend.BlockMeta, iterator Iterator, estimatedObjects int, filepath string) (*CompleteBlock, error) {
 	c := &CompleteBlock{
 		encoding: latestEncoding(),
-		meta:     backend.NewBlockMeta(originatingMeta.TenantID, uuid.New(), currentVersion, cfg.Encoding),
+		meta:     backend.NewBlockMeta(originatingMeta.TenantID, originatingMeta.BlockID, currentVersion, cfg.Encoding),
 		bloom:    common.NewWithEstimates(uint(estimatedObjects), cfg.BloomFP),
 		records:  make([]*common.Record, 0),
 		filepath: filepath,

--- a/tempodb/wal/append_block.go
+++ b/tempodb/wal/append_block.go
@@ -73,6 +73,7 @@ func (h *AppendBlock) Complete(cfg *encoding.BlockConfig, w *WAL, combiner commo
 		if err != nil {
 			return nil, err
 		}
+		h.appendFile = nil
 	}
 
 	records := h.appender.Records()
@@ -113,10 +114,12 @@ func (h *AppendBlock) Find(id common.ID, combiner common.ObjectCombiner) ([]byte
 func (h *AppendBlock) Clear() error {
 	if h.readFile != nil {
 		_ = h.readFile.Close()
+		h.readFile = nil
 	}
 
 	if h.appendFile != nil {
 		_ = h.appendFile.Close()
+		h.appendFile = nil
 	}
 
 	name := h.fullFilename()

--- a/tempodb/wal/replay_block.go
+++ b/tempodb/wal/replay_block.go
@@ -24,6 +24,10 @@ func (r *ReplayBlock) TenantID() string {
 	return r.meta.TenantID
 }
 
+func (r *ReplayBlock) BlockID() string {
+	return r.meta.BlockID.String()
+}
+
 func (r *ReplayBlock) Clear() error {
 	if r.readFile != nil {
 		_ = r.readFile.Close()


### PR DESCRIPTION
**What this PR does**:
This PR improves some stability, error handling, and logging for various things:

Main changes:
* Introduce exponential backoff for flushing blocks to backend (s3/gcs/etc), with a max backoff of 120s.  Flushes are attempted forever
* Introduce exponential backoff for converting wal->complete blocks. We have seen this error due to a corrupted wal file when the disk was full.  Backoff is from 30s->60s with 3 attempts, yielding around 120 seconds of retry time, after which the wal file is permanently deleted and data is (probably) lost.
* Fix regression where the WAL file was deleted as soon as the complete block was created, instead of only after a successful flush to the backend. This was broken unintentionally in the previous round of flush changes.
* Introduce jitter up to 10s for regular flushes which will help when flushing many tenants. Flushes initiated by /flush or /shutdown do not have jitter.

Minor changes:
* Fix "file already closed" errors by nil'ing out file handles as soon as they are closed
* Fix "enqueue on closed queue" panic by forking priority queues from cortex and changing method to return error instead of panic.  Additionally to cut down on noisy errors, a guard flag is kept on the state of the flush queues, when shutting down the flusher abandons the tasks (no data is lost because wal still exists)
* Completed blocks now use the same ID as the source WAL block, which should make troubleshooting easier (i.e. file in /wal/completed/ matches its source file in /wal/)
* WAL replay doesn't create the ingester instance for that tenant until data is encountered, which lets 0-length files be replayed and deleted like expected (instead of creating a new instance+head block thus perpetuating the problem)
* Increment `ingester_failed_flushes_total` metric if error occurs deleting WAL block
* Various log message changes

**Which issue(s) this PR fixes**:
Fixes #357 #579 #598 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`