### PR TITLE
Added docs for GCP configuration.

### DIFF
--- a/docs/tempo/website/configuration/gcs.md
+++ b/docs/tempo/website/configuration/gcs.md
@@ -9,10 +9,19 @@ GCS backend is configured in the storage block. Tempo requires a dedicated bucke
 storage:
     trace:
         backend: gcs                                              # store traces in gcs
-        s3:
+        gcs:
             bucket_name: tempo                                    # store traces in this bucket
             chunk_buffer_size: 10485760                           # optional. buffer size for reads. default = 10MiB
             endpoint: https://storage.googleapis.com/storage/v1/  # optional. api endpoint override
             insecure: false                                       # optional. Set to true to disable authentication 
                                                                   #   and certificate checks.
 ```
+## Permissions
+The following authentication methods are supported:
+- GCP environment variable GOOGLE_APPLICATION_CREDENTIALS
+
+The (service-)account that will communicate towards GCS should be assigned to the bucket which will receive the traces and should have the following IAM polices within the bucket:
+
+- `storage.objects.create`
+- `storage.objects.delete`
+- `storage.objects.get`


### PR DESCRIPTION
Signed-off-by: Whyeasy <Whyeasy@users.noreply.github.com>

**What this PR does**:
- Fixed a typo in the config example regarding gcs.
- Added a small description which IAM policies should be in place for the service account.
