### PR TITLE
Handle ingester panic with corrupt buffers

### DIFF
--- a/tempodb/encoding/base/object.go
+++ b/tempodb/encoding/base/object.go
@@ -66,6 +66,9 @@ func UnmarshalObjectFromReader(r io.Reader) (common.ID, []byte, error) {
 	if uint32(readLength) != protoLength {
 		return nil, nil, fmt.Errorf("read %d but expected %d", readLength, protoLength)
 	}
+	if int(idLength) > len(b) {
+		return nil, nil, fmt.Errorf("id length %d outside bounds of buffer %d. corrupt buffer?", idLength, len(b))
+	}
 
 	bytesID := b[:idLength]
 	bytesObject := b[idLength:]


### PR DESCRIPTION
**What this PR does**:
Everytime we've seen this error it has been on wal replay due to a corrupt wal.  The following guard code is a fine bandaid that will allow the ingester to start, but the bigger fix is #418 

**Which issue(s) this PR fixes**:
Fixes #597 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`