### PR TITLE
Improve distributor rollouts

### DIFF
--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -196,11 +196,7 @@ func (d *Distributor) running(ctx context.Context) error {
 
 // Called after distributor is asked to stop via StopAsync.
 func (d *Distributor) stopping(_ error) error {
-	err := services.StopManagerAndAwaitStopped(context.Background(), d.subservices)
-
-	time.Sleep(time.Hour)
-
-	return err
+	return services.StopManagerAndAwaitStopped(context.Background(), d.subservices)
 }
 
 // Push a set of streams.

--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -196,9 +196,7 @@ func (d *Distributor) running(ctx context.Context) error {
 
 // Called after distributor is asked to stop via StopAsync.
 func (d *Distributor) stopping(_ error) error {
-	time.Sleep(30 * time.Second)
 	err := services.StopManagerAndAwaitStopped(context.Background(), d.subservices)
-	time.Sleep(30 * time.Second)
 	return err
 }
 

--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -196,7 +196,11 @@ func (d *Distributor) running(ctx context.Context) error {
 
 // Called after distributor is asked to stop via StopAsync.
 func (d *Distributor) stopping(_ error) error {
-	return services.StopManagerAndAwaitStopped(context.Background(), d.subservices)
+	err := services.StopManagerAndAwaitStopped(context.Background(), d.subservices)
+
+	time.Sleep(time.Hour)
+
+	return err
 }
 
 // Push a set of streams.

--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -196,6 +196,7 @@ func (d *Distributor) running(ctx context.Context) error {
 
 // Called after distributor is asked to stop via StopAsync.
 func (d *Distributor) stopping(_ error) error {
+	time.Sleep(30 * time.Second)
 	err := services.StopManagerAndAwaitStopped(context.Background(), d.subservices)
 	time.Sleep(30 * time.Second)
 	return err

--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -196,8 +196,7 @@ func (d *Distributor) running(ctx context.Context) error {
 
 // Called after distributor is asked to stop via StopAsync.
 func (d *Distributor) stopping(_ error) error {
-	err := services.StopManagerAndAwaitStopped(context.Background(), d.subservices)
-	return err
+	return services.StopManagerAndAwaitStopped(context.Background(), d.subservices)
 }
 
 // Push a set of streams.

--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -196,7 +196,9 @@ func (d *Distributor) running(ctx context.Context) error {
 
 // Called after distributor is asked to stop via StopAsync.
 func (d *Distributor) stopping(_ error) error {
-	return services.StopManagerAndAwaitStopped(context.Background(), d.subservices)
+	err := services.StopManagerAndAwaitStopped(context.Background(), d.subservices)
+	time.Sleep(30 * time.Second)
+	return err
 }
 
 // Push a set of streams.

--- a/modules/distributor/receiver/shim.go
+++ b/modules/distributor/receiver/shim.go
@@ -135,6 +135,8 @@ func (r *receiversShim) starting(ctx context.Context) error {
 
 // Called after distributor is asked to stop via StopAsync.
 func (r *receiversShim) stopping(_ error) error {
+	fmt.Println("!!stopping!!", time.Now())
+
 	ctx, cancelFn := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelFn()
 
@@ -152,6 +154,9 @@ func (r *receiversShim) stopping(_ error) error {
 	}
 
 	view.Unregister(r.metricViews...)
+
+	fmt.Println("!!done stopping!!", time.Now())
+	time.Sleep(time.Hour)
 	return nil
 }
 

--- a/modules/distributor/receiver/shim.go
+++ b/modules/distributor/receiver/shim.go
@@ -135,7 +135,10 @@ func (r *receiversShim) starting(ctx context.Context) error {
 
 // Called after distributor is asked to stop via StopAsync.
 func (r *receiversShim) stopping(_ error) error {
-	// when shutdown is called the receiver immediately begins dropping requests
+	// when shutdown is called on the receiver it immediately shuts down its connection
+	// which drops requests on the floor. at this point in the shutdown process
+	// the readiness handler is already down so we are not receiving any more requests.
+	// sleep for 30 seconds to here to all pending requests to finish.
 	time.Sleep(30 * time.Second)
 
 	ctx, cancelFn := context.WithTimeout(context.Background(), 30*time.Second)

--- a/modules/distributor/receiver/shim.go
+++ b/modules/distributor/receiver/shim.go
@@ -135,8 +135,6 @@ func (r *receiversShim) starting(ctx context.Context) error {
 
 // Called after distributor is asked to stop via StopAsync.
 func (r *receiversShim) stopping(_ error) error {
-	fmt.Println("!!stopping!!", time.Now())
-
 	ctx, cancelFn := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelFn()
 
@@ -154,9 +152,6 @@ func (r *receiversShim) stopping(_ error) error {
 	}
 
 	view.Unregister(r.metricViews...)
-
-	fmt.Println("!!done stopping!!", time.Now())
-	time.Sleep(time.Hour)
 	return nil
 }
 

--- a/modules/distributor/receiver/shim.go
+++ b/modules/distributor/receiver/shim.go
@@ -135,6 +135,9 @@ func (r *receiversShim) starting(ctx context.Context) error {
 
 // Called after distributor is asked to stop via StopAsync.
 func (r *receiversShim) stopping(_ error) error {
+	// when shutdown is called the receiver immediately begins dropping requests
+	time.Sleep(30 * time.Second)
+
 	ctx, cancelFn := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelFn()
 

--- a/operations/jsonnet/microservices/distributor.libsonnet
+++ b/operations/jsonnet/microservices/distributor.libsonnet
@@ -36,6 +36,7 @@
                      app: target_name,
                      [$._config.gossip_member_label]: 'true',
                    }) +
+    deployment.mixin.spec.template.spec.withTerminationGracePeriodSeconds(60) +
     deployment.mixin.spec.template.metadata.withAnnotations({
       config_hash: std.md5(std.toString($.tempo_configmap.data['tempo.yaml'])),
     }) +

--- a/operations/jsonnet/microservices/distributor.libsonnet
+++ b/operations/jsonnet/microservices/distributor.libsonnet
@@ -36,6 +36,8 @@
                      app: target_name,
                      [$._config.gossip_member_label]: 'true',
                    }) +
+    deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(0) +
+    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
     deployment.mixin.spec.template.spec.withTerminationGracePeriodSeconds(60) +
     deployment.mixin.spec.template.metadata.withAnnotations({
       config_hash: std.md5(std.toString($.tempo_configmap.data['tempo.yaml'])),


### PR DESCRIPTION
**What this PR does**:
A handful of fixes to reduce the dropped spans during rollout.

- Adds a 30 second sleep before shutting down the OTel receiver and after the pod readiness probe is down.
- Adjusts the rollout
  - Only roll one 1 distributor at a time
  - Wait 1 minute after issuing SIGTERM to force kill the pod
 
![image](https://user-images.githubusercontent.com/2272392/111835687-a1d8a300-88cb-11eb-9344-95699a5e41e7.png)

Before changes we were dropping 100k+ spans in ops.  On the latest rollout with all changes this was reduced to ~100.

**Which issue(s) this PR fixes**:
Fixes #530

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`