### PR TITLE
Memberlist: removed unncessary postfix

### DIFF
--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -3,7 +3,6 @@ package app
 import (
 	"fmt"
 	"net/http"
-	"os"
 
 	"github.com/cortexproject/cortex/pkg/cortex"
 	cortex_frontend "github.com/cortexproject/cortex/pkg/frontend"
@@ -227,12 +226,6 @@ func (t *App) initMemberlistKV() (services.Service, error) {
 	t.cfg.MemberlistKV.Codecs = []codec.Codec{
 		ring.GetCodec(),
 	}
-
-	hostname, err := os.Hostname()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get hostname %w", err)
-	}
-	t.cfg.MemberlistKV.NodeName = hostname
 
 	t.memberlistKV = memberlist.NewKVInitService(&t.cfg.MemberlistKV, log.Logger)
 

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -3,7 +3,6 @@ package app
 import (
 	"fmt"
 	"net/http"
-	"os"
 
 	"github.com/cortexproject/cortex/pkg/cortex"
 	cortex_frontend "github.com/cortexproject/cortex/pkg/frontend"
@@ -16,7 +15,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/modules"
 	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/go-kit/kit/log/level"
-	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/server"
@@ -228,13 +226,6 @@ func (t *App) initMemberlistKV() (services.Service, error) {
 	t.cfg.MemberlistKV.Codecs = []codec.Codec{
 		ring.GetCodec(),
 	}
-
-	hostname, err := os.Hostname()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get hostname %w", err)
-	}
-	// todo: do we still need this?  does the package do this by default now?
-	t.cfg.MemberlistKV.NodeName = hostname + "-" + uuid.New().String()
 
 	t.memberlistKV = memberlist.NewKVInitService(&t.cfg.MemberlistKV, log.Logger)
 

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/cortexproject/cortex/pkg/cortex"
 	cortex_frontend "github.com/cortexproject/cortex/pkg/frontend"
@@ -226,6 +227,12 @@ func (t *App) initMemberlistKV() (services.Service, error) {
 	t.cfg.MemberlistKV.Codecs = []codec.Codec{
 		ring.GetCodec(),
 	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get hostname %w", err)
+	}
+	t.cfg.MemberlistKV.NodeName = hostname
 
 	t.memberlistKV = memberlist.NewKVInitService(&t.cfg.MemberlistKV, log.Logger)
 


### PR DESCRIPTION
**What this PR does**:
Previously we were postfixing the memberlist name with a guid to force uniqueness on restarts. This functionality, however, has been added to memberlist directly so let's remove this confusing bit of code.

https://github.com/grafana/tempo/blob/master/vendor/github.com/cortexproject/cortex/pkg/ring/kv/memberlist/memberlist_client.go#L131