### PR TITLE
Update objects_combined metric to only increment if combination actually took place

### DIFF
--- a/modules/compactor/compactor.go
+++ b/modules/compactor/compactor.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/modules/storage"
-	tempo_util "github.com/grafana/tempo/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -150,15 +149,6 @@ func (c *Compactor) Owns(hash string) bool {
 	level.Debug(log.Logger).Log("msg", "checking addresses", "owning_addr", rs.Ingesters[0].Addr, "this_addr", c.ringLifecycler.Addr)
 
 	return rs.Ingesters[0].Addr == c.ringLifecycler.Addr
-}
-
-// Combine implements CompactorSharder
-func (c *Compactor) Combine(objA []byte, objB []byte) []byte {
-	combinedTrace, err := tempo_util.CombineTraces(objA, objB)
-	if err != nil {
-		level.Error(log.Logger).Log("msg", "error combining trace protos", "err", err.Error())
-	}
-	return combinedTrace
 }
 
 // BlockRetentionForTenant implements CompactorOverrides

--- a/modules/frontend/querysharding.go
+++ b/modules/frontend/querysharding.go
@@ -172,7 +172,7 @@ func mergeResponses(ctx context.Context, marshallingFormat string, rrs []Request
 			if len(combinedTrace) == 0 {
 				combinedTrace = body
 			} else {
-				combinedTrace, err = util.CombineTraces(combinedTrace, body)
+				combinedTrace, _, err = util.CombineTraces(combinedTrace, body)
 				if err != nil {
 					// will result in a 500 internal server error
 					return nil, errors.Wrap(err, "error combining traces at query frontend")

--- a/modules/frontend/querysharding_test.go
+++ b/modules/frontend/querysharding_test.go
@@ -63,7 +63,7 @@ func TestMergeResponses(t *testing.T) {
 	b2, err := proto.Marshal(t2)
 	assert.NoError(t, err)
 
-	combinedTrace, err := util.CombineTraces(b1, b2)
+	combinedTrace, _, err := util.CombineTraces(b1, b2)
 	assert.NoError(t, err)
 
 	traceObject := &tempopb.Trace{}

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -380,7 +380,7 @@ func (i *instance) writeTraceToHeadBlock(id common.ID, b []byte) error {
 }
 
 func (i *instance) Combine(objA []byte, objB []byte) []byte {
-	combinedTrace, err := util.CombineTraces(objA, objB)
+	combinedTrace, _, err := util.CombineTraces(objA, objB)
 	if err != nil {
 		level.Error(log.Logger).Log("msg", "error combining trace protos", "err", err.Error())
 	}

--- a/modules/querier/querier_test.go
+++ b/modules/querier/querier_test.go
@@ -35,7 +35,7 @@ func (m *mockSharder) Owns(hash string) bool {
 }
 
 func (m *mockSharder) Combine(objA []byte, objB []byte) []byte {
-	combined, _ := util.CombineTraces(objA, objB)
+	combined, _, _ := util.CombineTraces(objA, objB)
 	return combined
 }
 
@@ -111,7 +111,7 @@ func TestReturnAllHits(t *testing.T) {
 	util.SortTrace(expectedTrace)
 
 	// actual trace
-	actualTraceBytes, err := util.CombineTraces(foundBytes[1], foundBytes[0])
+	actualTraceBytes, _, err := util.CombineTraces(foundBytes[1], foundBytes[0])
 	assert.NoError(t, err)
 	actualTrace := &tempopb.Trace{}
 	err = proto.Unmarshal(actualTraceBytes, actualTrace)

--- a/pkg/util/trace_test.go
+++ b/pkg/util/trace_test.go
@@ -83,7 +83,7 @@ func TestCombine(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		actual, err := CombineTraces(tt.trace1, tt.trace2)
+		actual, _, err := CombineTraces(tt.trace1, tt.trace2)
 		if len(tt.errString) > 0 {
 			assert.EqualError(t, err, tt.errString)
 		} else {

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -220,7 +220,9 @@ func TestSameIDCompaction(t *testing.T) {
 		head, err := wal.NewBlock(blockID, testTenantID)
 		assert.NoError(t, err)
 		id := []byte{0x01, 0x02, 0x01, 0x02, 0x01, 0x02, 0x01, 0x02, 0x01, 0x02, 0x01, 0x02, 0x01, 0x02, 0x01, 0x02}
-		rec := []byte{0x01, 0x02, 0x03}
+
+		// Different content to ensure that object combination takes place
+		rec, _ := proto.Marshal(test.MakeTrace(1, id))
 
 		err = head.Write(id, rec)
 		assert.NoError(t, err, "unexpected error writing req")
@@ -235,7 +237,7 @@ func TestSameIDCompaction(t *testing.T) {
 	rw := r.(*readerWriter)
 
 	combinedStart, err := test.GetCounterVecValue(metricCompactionObjectsCombined, "0")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// poll
 	checkBlocklists(t, uuid.Nil, blockCount, 0, rw)
@@ -247,7 +249,7 @@ func TestSameIDCompaction(t *testing.T) {
 	assert.Len(t, blocks, inputBlocks)
 
 	err = rw.compact(blocks, testTenantID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	checkBlocklists(t, uuid.Nil, blockCount-blocksPerCompaction, inputBlocks, rw)
 

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -97,7 +97,6 @@ type Compactor interface {
 }
 
 type CompactorSharder interface {
-	Combine(objA []byte, objB []byte) []byte
 	Owns(hash string) bool
 }
 


### PR DESCRIPTION
**What this PR does**:
This PR is a follow up to #606 that updates the object_combined metric to only increment when combination actually took place.  

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`