### PR TITLE
Update lastAppend on a trace even if spans refused

### DIFF
--- a/modules/ingester/trace.go
+++ b/modules/ingester/trace.go
@@ -30,6 +30,7 @@ func newTrace(maxSpans int, token uint32, traceID []byte) *trace {
 }
 
 func (t *trace) Push(_ context.Context, req *tempopb.PushRequest) error {
+	t.lastAppend = time.Now()
 	if t.maxSpans != 0 {
 		// count spans
 		spanCount := 0
@@ -45,7 +46,6 @@ func (t *trace) Push(_ context.Context, req *tempopb.PushRequest) error {
 	}
 
 	t.trace.Batches = append(t.trace.Batches, req.Batch)
-	t.lastAppend = time.Now()
 
 	return nil
 }


### PR DESCRIPTION
**What this PR does**:
Previously if a span was refused due to "trace too large" it would not update the last append time. This would make the very large trace flush and then begin accepting even more spans for the same already enormous trace.