### PR TITLE
Add two new commands to dump and summarize a block index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [ENHANCEMENT] Queriers now query all (healthy) ingesters for a trace to mitigate 404s on ingester rollouts/scaleups.
   This is a **breaking change** and will likely result in query errors on rollout as the query signature b/n QueryFrontend & Querier has changed. [#557](https://github.com/grafana/tempo/pull/557)
 * [ENHANCEMENT] Add list compaction-summary command to tempo-cli [#588](https://github.com/grafana/tempo/pull/588)
+* [ENHANCEMENT] Add list and view index commands to tempo-cli [#611](https://github.com/grafana/tempo/pull/611)
 * [BUGFIX] Fixes permissions errors on startup in GCS. [#554](https://github.com/grafana/tempo/pull/554)
 * [BUGFIX] Fixes error where Dell ECS cannot list objects. [#561](https://github.com/grafana/tempo/pull/561)
 * [BUGFIX] Fixes listing blocks in S3 when the list is truncated. [#567](https://github.com/grafana/tempo/pull/567)

--- a/cmd/tempo-cli/cmd-list-index.go
+++ b/cmd/tempo-cli/cmd-list-index.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/grafana/tempo/tempodb/encoding"
+	"github.com/grafana/tempo/tempodb/encoding/common"
+)
+
+type listIndexCmd struct {
+	backendOptions
+
+	TenantID string `arg:"" help:"tenant-id within the bucket"`
+	BlockID  string `arg:"" help:"block ID to list"`
+}
+
+func (cmd *listIndexCmd) Run(ctx *globalOptions) error {
+	blockID, err := uuid.Parse(cmd.BlockID)
+	if err != nil {
+		return err
+	}
+
+	r, _, err := loadBackend(&cmd.backendOptions, ctx)
+	if err != nil {
+		return err
+	}
+
+	meta, err := r.BlockMeta(context.TODO(), blockID, cmd.TenantID)
+	if err != nil {
+		return err
+	}
+
+	b, err := encoding.NewBackendBlock(meta, r)
+	if err != nil {
+		return err
+	}
+
+	reader, err := b.NewIndexReader()
+	if err != nil {
+		return err
+	}
+
+	var minRecord *common.Record
+	var maxRecord *common.Record
+	count := 0
+
+	for i := 0; ; i++ {
+		record, err := reader.At(context.TODO(), i)
+		if err != nil {
+			return err
+		}
+
+		if record == nil {
+			break
+		}
+
+		count++
+
+		if minRecord == nil || record.Length < minRecord.Length {
+			minRecord = record
+		}
+
+		if maxRecord == nil || record.Length > maxRecord.Length {
+			maxRecord = record
+		}
+	}
+
+	fmt.Println("Index entries:", count)
+
+	if minRecord != nil {
+		fmt.Printf("Min record: ID:%s Start:%v Length:%v\n", hex.EncodeToString(minRecord.ID), minRecord.Start, minRecord.Length)
+	}
+
+	if maxRecord != nil {
+		fmt.Printf("Max record: ID:%s Start:%v Length:%v\n", hex.EncodeToString(maxRecord.ID), maxRecord.Start, maxRecord.Length)
+	}
+
+	return nil
+}

--- a/cmd/tempo-cli/cmd-view-index.go
+++ b/cmd/tempo-cli/cmd-view-index.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/grafana/tempo/tempodb/encoding"
+)
+
+type viewIndexCmd struct {
+	backendOptions
+
+	TenantID string `arg:"" help:"tenant-id within the bucket"`
+	BlockID  string `arg:"" help:"block ID to list"`
+}
+
+func (cmd *viewIndexCmd) Run(ctx *globalOptions) error {
+	blockID, err := uuid.Parse(cmd.BlockID)
+	if err != nil {
+		return err
+	}
+
+	r, _, err := loadBackend(&cmd.backendOptions, ctx)
+	if err != nil {
+		return err
+	}
+
+	meta, err := r.BlockMeta(context.TODO(), blockID, cmd.TenantID)
+	if err != nil {
+		return err
+	}
+
+	b, err := encoding.NewBackendBlock(meta, r)
+	if err != nil {
+		return err
+	}
+
+	reader, err := b.NewIndexReader()
+	if err != nil {
+		return err
+	}
+
+	pageSize := 20
+
+	for i := 0; ; i++ {
+		record, err := reader.At(context.TODO(), i)
+		if err != nil {
+			return err
+		}
+
+		if record == nil {
+			return nil
+		}
+
+		fmt.Printf("Index entry: %10v     ID: %s     Start: %10v     Length: %10v\n", i, hex.EncodeToString(record.ID), record.Start, record.Length)
+
+		if (i+1)%pageSize == 0 {
+			fmt.Printf("Press enter to continue\r")
+			fmt.Scanln()
+		}
+	}
+}

--- a/cmd/tempo-cli/main.go
+++ b/cmd/tempo-cli/main.go
@@ -36,6 +36,11 @@ var cli struct {
 		Block             listBlockCmd             `cmd:"" help:"List information about a block"`
 		Blocks            listBlocksCmd            `cmd:"" help:"List information about all blocks in a bucket"`
 		CompactionSummary listCompactionSummaryCmd `cmd:"" help:"List summary of data by compaction level"`
+		Index             listIndexCmd             `cmd:"" help:"List information about a block index"`
+	} `cmd:""`
+
+	View struct {
+		Index viewIndexCmd `cmd:"" help:"View contents of block index"`
 	} `cmd:""`
 
 	Query queryCmd `cmd:"" help:"query tempo api"`

--- a/tempodb/encoding/backend_block.go
+++ b/tempodb/encoding/backend_block.go
@@ -108,11 +108,19 @@ func (b *BackendBlock) Iterator(chunkSizeBytes uint32) (Iterator, error) {
 		return nil, fmt.Errorf("failed to create dataReader (%s, %s): %w", b.meta.TenantID, b.meta.BlockID, err)
 	}
 
+	reader, err := b.NewIndexReader()
+	if err != nil {
+		return nil, err
+	}
+
+	return newPagedIterator(chunkSizeBytes, reader, dataReader), nil
+}
+
+func (b *BackendBlock) NewIndexReader() (common.IndexReader, error) {
 	indexReaderAt := backend.NewContextReader(b.meta, nameIndex, b.reader)
 	reader, err := b.encoding.newIndexReader(indexReaderAt, int(b.meta.IndexPageSize), int(b.meta.TotalRecords))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create index reader (%s, %s): %w", b.meta.TenantID, b.meta.BlockID, err)
 	}
-
-	return newPagedIterator(chunkSizeBytes, reader, dataReader), nil
+	return reader, nil
 }


### PR DESCRIPTION
**What this PR does**:
This PR adds two new commands that may be helpful for analysis:

`list index` Displays count/smallest/largest index entries for the block
Example: 
```
$ ./tempo-cli -c ~/tempo.gcs.yaml list index 1 eb9097da-ce9b-4c79-a95e-2544e47eb600
Index entries: 85565
Min record: ID:000000000000000000f98dff14b6d9d8 Start:376637542 Length:88266
Max record: ID:00000000000000003ac4feb1e33cb8be Start:8797836709 Length:16873958
```

`view index` Dumps index entries to stdout with pauses for enter key
Example:
```
$ ./tempo-cli -c ~/tempo.gcs.yaml view index 1 8007402d-e2bf-4867-885b-56667d1a21bb
.
.
.
Index entry:      27694     ID: 0000000000000000091531809b380fca     Start: 3681618906     Length:     131629
Index entry:      27695     ID: 000000000000000009154701495d4bcc     Start: 3681750535     Length:     143781
Index entry:      27696     ID: 0000000000000000091557765faccdba     Start: 3681894316     Length:     135249
Index entry:      27697     ID: 000000000000000009156dc402f1a74a     Start: 3682029565     Length:     130927
Index entry:      27698     ID: 00000000000000000915821eebbb210c     Start: 3682160492     Length:     138300
Index entry:      27699     ID: 0000000000000000091594c70025a539     Start: 3682298792     Length:     132232
Press enter to continue
```


**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`