### PR TITLE
Ensure all operational dashboard panels follow cluster/namespace variables

### DIFF
--- a/operations/tempo-mixin/tempo-operational.json
+++ b/operations/tempo-mixin/tempo-operational.json
@@ -853,7 +853,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "tempodb_work_queue_length{job=~\"$namespace/$component\"} / tempodb_work_queue_max{job=~\"$namespace/$component\"}",
+          "expr": "tempodb_work_queue_length{cluster=\"$cluster\", namespace=\"$namespace\", job=~\"$namespace/$component\"} / tempodb_work_queue_max{cluster=\"$cluster\", namespace=\"$namespace\", job=~\"$namespace/$component\"}",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -946,17 +946,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(increase(tempodb_compaction_errors_total{job=~\"$namespace/$component\"}[$__rate_interval])) by (job)",
+          "expr": "sum(increase(tempodb_compaction_errors_total{cluster=\"$cluster\", namespace=\"$namespace\", job=~\"$namespace/$component\"}[$__rate_interval])) by (job)",
           "legendFormat": "compaction_err",
           "refId": "B"
         },
         {
-          "expr": "sum(increase(tempodb_retention_errors_total{job=~\"$namespace/$component\"}[$__rate_interval])) by (job)",
+          "expr": "sum(increase(tempodb_retention_errors_total{cluster=\"$cluster\", namespace=\"$namespace\", job=~\"$namespace/$component\"}[$__rate_interval])) by (job)",
           "legendFormat": "retention_err",
           "refId": "C"
         },
         {
-          "expr": "sum(increase(tempodb_blocklist_poll_errors_total{job=~\"$namespace/$component\"}[$__rate_interval])) by (job)",
+          "expr": "sum(increase(tempodb_blocklist_poll_errors_total{cluster=\"$cluster\", namespace=\"$namespace\", job=~\"$namespace/$component\"}[$__rate_interval])) by (job)",
           "legendFormat": "blocklist_err",
           "refId": "D"
         }
@@ -1048,18 +1048,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(.99, sum(rate(tempodb_blocklist_poll_duration_seconds_bucket{job=~\"$namespace/$component\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.99, sum(rate(tempodb_blocklist_poll_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=~\"$namespace/$component\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(.9, sum(rate(tempodb_blocklist_poll_duration_seconds_bucket{job=~\"$namespace/$component\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.9, sum(rate(tempodb_blocklist_poll_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=~\"$namespace/$component\"}[$__rate_interval])) by (le))",
           "legendFormat": ".9",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(.5, sum(rate(tempodb_blocklist_poll_duration_seconds_bucket{job=~\"$namespace/$component\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.5, sum(rate(tempodb_blocklist_poll_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=~\"$namespace/$component\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".5",
           "refId": "C"
@@ -1152,7 +1152,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(tempodb_blocklist_length{job=~\"$namespace/$component\"}) by (tenant)",
+          "expr": "avg(tempodb_blocklist_length{cluster=\"$cluster\", namespace=\"$namespace\", job=~\"$namespace/$component\"}) by (tenant)",
           "instant": false,
           "interval": "",
           "legendFormat": "{{tenant}}",
@@ -1246,19 +1246,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(.99, sum(rate(tempodb_retention_duration_seconds_bucket{job=~\"$namespace/compactor\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.99, sum(rate(tempodb_retention_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=~\"$namespace/compactor\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(.9, sum(rate(tempodb_retention_duration_seconds_bucket{job=~\"$namespace/compactor\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.9, sum(rate(tempodb_retention_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=~\"$namespace/compactor\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".9",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(.5, sum(rate(tempodb_retention_duration_seconds_bucket{job=~\"$namespace/compactor\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.5, sum(rate(tempodb_retention_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=~\"$namespace/compactor\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".5",
           "refId": "C"
@@ -1351,13 +1351,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(increase(tempodb_retention_deleted_total{job=~\"$namespace/$component\"}[$__rate_interval]))",
+          "expr": "sum(increase(tempodb_retention_deleted_total{cluster=\"$cluster\", namespace=\"$namespace\", job=~\"$namespace/$component\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "deleted",
           "refId": "A"
         },
         {
-          "expr": "sum(increase(tempodb_retention_marked_for_deletion_total{job=~\"$namespace/$component\"}[$__rate_interval]))",
+          "expr": "sum(increase(tempodb_retention_marked_for_deletion_total{cluster=\"$cluster\", namespace=\"$namespace\", job=~\"$namespace/$component\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "marked_for_deletion",
           "refId": "B"
@@ -1558,7 +1558,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(tempo_request_duration_seconds_count{route=\"tempo_api_traces_traceid\", job=\"$namespace/cortex-gw\"}[$__rate_interval])) by (status_code)",
+          "expr": "sum(rate(tempo_request_duration_seconds_count{route=\"tempo_api_traces_traceid\", cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/cortex-gw\"}[$__rate_interval])) by (status_code)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{status_code}}",
@@ -1652,19 +1652,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(.99, sum(rate(tempo_request_duration_seconds_bucket{job=\"$namespace/cortex-gw\", route=\"tempo_api_traces_traceid\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.99, sum(rate(tempo_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/cortex-gw\", route=\"tempo_api_traces_traceid\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(.9, sum(rate(tempo_request_duration_seconds_bucket{job=\"$namespace/cortex-gw\", route=\"tempo_api_traces_traceid\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.9, sum(rate(tempo_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/cortex-gw\", route=\"tempo_api_traces_traceid\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".9",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(.5, sum(rate(tempo_request_duration_seconds_bucket{job=\"$namespace/cortex-gw\", route=\"tempo_api_traces_traceid\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.5, sum(rate(tempo_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/cortex-gw\", route=\"tempo_api_traces_traceid\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".5",
           "refId": "C"
@@ -1757,7 +1757,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(tempo_request_duration_seconds_count{route=\"tempo_api_traces_traceid\", job=\"$namespace/query-frontend\"}[$__rate_interval])) by (status_code)",
+          "expr": "sum(rate(tempo_request_duration_seconds_count{cluster=\"$cluster\", namespace=\"$namespace\", route=\"tempo_api_traces_traceid\", job=\"$namespace/query-frontend\"}[$__rate_interval])) by (status_code)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{status_code}}",
@@ -1851,19 +1851,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(.99, sum(rate(tempo_request_duration_seconds_bucket{job=\"$namespace/query-frontend\", route=\"tempo_api_traces_traceid\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.99, sum(rate(tempo_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/query-frontend\", route=\"tempo_api_traces_traceid\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(.9, sum(rate(tempo_request_duration_seconds_bucket{job=\"$namespace/query-frontend\", route=\"tempo_api_traces_traceid\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.9, sum(rate(tempo_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/query-frontend\", route=\"tempo_api_traces_traceid\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".9",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(.5, sum(rate(tempo_request_duration_seconds_bucket{job=\"$namespace/query-frontend\", route=\"tempo_api_traces_traceid\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.5, sum(rate(tempo_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/query-frontend\", route=\"tempo_api_traces_traceid\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".5",
           "refId": "C"
@@ -1956,7 +1956,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(tempo_request_duration_seconds_count{route=\"querier_tempo_api_traces_traceid\", job=\"$namespace/querier\"}[$__rate_interval])) by (status_code)",
+          "expr": "sum(rate(tempo_request_duration_seconds_count{route=\"querier_tempo_api_traces_traceid\", cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/querier\"}[$__rate_interval])) by (status_code)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{status_code}}",
@@ -2050,19 +2050,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(.99, sum(rate(tempo_request_duration_seconds_bucket{job=\"$namespace/querier\", route=\"querier_tempo_api_traces_traceid\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.99, sum(rate(tempo_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/querier\", route=\"querier_tempo_api_traces_traceid\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(.9, sum(rate(tempo_request_duration_seconds_bucket{job=\"$namespace/querier\", route=\"querier_tempo_api_traces_traceid\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.9, sum(rate(tempo_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/querier\", route=\"querier_tempo_api_traces_traceid\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".9",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(.5, sum(rate(tempo_request_duration_seconds_bucket{job=\"$namespace/querier\", route=\"querier_tempo_api_traces_traceid\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.5, sum(rate(tempo_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/querier\", route=\"querier_tempo_api_traces_traceid\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".5",
           "refId": "C"
@@ -2155,7 +2155,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(tempo_request_duration_seconds_count{route=\"/tempopb.Querier/FindTraceByID\", job=\"$namespace/ingester\"}[$__rate_interval])) by (status_code)",
+          "expr": "sum(rate(tempo_request_duration_seconds_count{route=\"/tempopb.Querier/FindTraceByID\", cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/ingester\"}[$__rate_interval])) by (status_code)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{status_code}}",
@@ -2249,19 +2249,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(.99, sum(rate(tempo_request_duration_seconds_bucket{job=\"$namespace/ingester\", route=\"/tempopb.Querier/FindTraceByID\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.99, sum(rate(tempo_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/ingester\", route=\"/tempopb.Querier/FindTraceByID\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(.9, sum(rate(tempo_request_duration_seconds_bucket{job=\"$namespace/ingester\", route=\"/tempopb.Querier/FindTraceByID\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.9, sum(rate(tempo_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/ingester\", route=\"/tempopb.Querier/FindTraceByID\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".9",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(.5, sum(rate(tempo_request_duration_seconds_bucket{job=\"$namespace/ingester\", route=\"/tempopb.Querier/FindTraceByID\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.5, sum(rate(tempo_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/ingester\", route=\"/tempopb.Querier/FindTraceByID\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".5",
           "refId": "C"
@@ -2554,7 +2554,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(increase(tempo_ingester_blocks_flushed_total{job=\"$namespace/ingester\"}[1h]))",
+          "expr": "sum(increase(tempo_ingester_blocks_flushed_total{cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/ingester\"}[1h]))",
           "interval": "",
           "legendFormat": "{{pod}}",
           "refId": "A"
@@ -2938,7 +2938,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(tempo_request_duration_seconds_count{job=\"$namespace/cortex-gw\", route=\"opentelemetry_proto_collector_trace_v1_traceservice_export\"}[$__rate_interval])) by (status_code)",
+          "expr": "sum(rate(tempo_request_duration_seconds_count{cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/cortex-gw\", route=\"opentelemetry_proto_collector_trace_v1_traceservice_export\"}[$__rate_interval])) by (status_code)",
           "interval": "",
           "legendFormat": "{{status_code}}",
           "refId": "A"
@@ -3130,19 +3130,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(.99, sum(rate(tempo_request_duration_seconds_bucket{job=\"$namespace/cortex-gw\", route=\"opentelemetry_proto_collector_trace_v1_traceservice_export\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.99, sum(rate(tempo_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/cortex-gw\", route=\"opentelemetry_proto_collector_trace_v1_traceservice_export\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(.9, sum(rate(tempo_request_duration_seconds_bucket{job=\"$namespace/cortex-gw\", route=\"opentelemetry_proto_collector_trace_v1_traceservice_export\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.9, sum(rate(tempo_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/cortex-gw\", route=\"opentelemetry_proto_collector_trace_v1_traceservice_export\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".9",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(.5, sum(rate(tempo_request_duration_seconds_bucket{job=\"$namespace/cortex-gw\", route=\"opentelemetry_proto_collector_trace_v1_traceservice_export\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.5, sum(rate(tempo_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/cortex-gw\", route=\"opentelemetry_proto_collector_trace_v1_traceservice_export\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".5",
           "refId": "C"
@@ -3235,19 +3235,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(.99, sum(rate(tempo_request_duration_seconds_bucket{job=\"$namespace/ingester\", route=~\"/tempopb.Pusher/Push.*\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.99, sum(rate(tempo_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/ingester\", route=~\"/tempopb.Pusher/Push.*\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(.9, sum(rate(tempo_request_duration_seconds_bucket{job=\"$namespace/ingester\", route=~\"/tempopb.Pusher/Push.*\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.9, sum(rate(tempo_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/ingester\", route=~\"/tempopb.Pusher/Push.*\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".9",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(.5, sum(rate(tempo_request_duration_seconds_bucket{job=\"$namespace/ingester\", route=~\"/tempopb.Pusher/Push.*\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(.5, sum(rate(tempo_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/ingester\", route=~\"/tempopb.Pusher/Push.*\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": ".5",
           "refId": "C"
@@ -3356,7 +3356,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cortex_memcache_request_duration_seconds_count{job=~\"$namespace/$component\"}[$__rate_interval])) by (status_code, method)",
+          "expr": "sum(rate(cortex_memcache_request_duration_seconds_count{cluster=\"$cluster\", namespace=\"$namespace\", job=~\"$namespace/$component\"}[$__rate_interval])) by (status_code, method)",
           "interval": "",
           "legendFormat": "{{status_code}}-{{method}}",
           "refId": "A"
@@ -3451,19 +3451,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(.99, sum(rate(cortex_memcache_request_duration_seconds_bucket{job=~\"$namespace/$component\"}[$__rate_interval])) by (method, le))",
+          "expr": "histogram_quantile(.99, sum(rate(cortex_memcache_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=~\"$namespace/$component\"}[$__rate_interval])) by (method, le))",
           "interval": "",
           "legendFormat": ".99-{{method}}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(.9, sum(rate(cortex_memcache_request_duration_seconds_bucket{job=~\"$namespace/$component\"}[$__rate_interval])) by (method, le))",
+          "expr": "histogram_quantile(.9, sum(rate(cortex_memcache_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=~\"$namespace/$component\"}[$__rate_interval])) by (method, le))",
           "interval": "",
           "legendFormat": ".9-{{method}}",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(.5, sum(rate(cortex_memcache_request_duration_seconds_bucket{job=~\"$namespace/$component\"}[$__rate_interval])) by (method, le))",
+          "expr": "histogram_quantile(.5, sum(rate(cortex_memcache_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=~\"$namespace/$component\"}[$__rate_interval])) by (method, le))",
           "interval": "",
           "legendFormat": ".5-{{method}}",
           "refId": "C"
@@ -3570,7 +3570,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(tempodb_gcs_request_duration_seconds_count{job=~\"$namespace/$component\"}[$__rate_interval])) by (status_code, operation)",
+              "expr": "sum(rate(tempodb_gcs_request_duration_seconds_count{cluster=\"$cluster\", namespace=\"$namespace\", job=~\"$namespace/$component\"}[$__rate_interval])) by (status_code, operation)",
               "interval": "",
               "legendFormat": "{{status_code}}-{{operation}}",
               "refId": "A"
@@ -3666,17 +3666,17 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(.99, sum(rate(tempodb_gcs_request_duration_seconds_bucket{job=~\"$namespace/$component\"}[$__rate_interval])) by (operation, le))",
+              "expr": "histogram_quantile(.99, sum(rate(tempodb_gcs_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=~\"$namespace/$component\"}[$__rate_interval])) by (operation, le))",
               "legendFormat": ".99-{{operation}}",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(.9, sum(rate(tempodb_gcs_request_duration_seconds_bucket{job=~\"$namespace/$component\"}[$__rate_interval])) by (operation, le))",
+              "expr": "histogram_quantile(.9, sum(rate(tempodb_gcs_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=~\"$namespace/$component\"}[$__rate_interval])) by (operation, le))",
               "legendFormat": ".9-{{operation}}",
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(.5, sum(rate(tempodb_gcs_request_duration_seconds_bucket{job=~\"$namespace/$component\"}[$__rate_interval])) by (operation, le))",
+              "expr": "histogram_quantile(.5, sum(rate(tempodb_gcs_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\", job=~\"$namespace/$component\"}[$__rate_interval])) by (operation, le))",
               "legendFormat": ".5-{{operation}}",
               "refId": "C"
             }
@@ -4475,7 +4475,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(tempodb_compaction_objects_combined_total{cluster=\"$cluster\",job=~\"$namespace/compactor\"}[$__rate_interval])) by (level)",
+          "expr": "sum(rate(tempodb_compaction_objects_combined_total{cluster=\"$cluster\", namespace=\"$namespace\", job=~\"$namespace/compactor\"}[$__rate_interval])) by (level)",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -4571,7 +4571,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(tempodb_compaction_objects_written_total{cluster=\"$cluster\",job=\"$namespace/compactor\"}[$__rate_interval])) by (level)",
+          "expr": "sum(rate(tempodb_compaction_objects_written_total{cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/compactor\"}[$__rate_interval])) by (level)",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -4623,7 +4623,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "$ds",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -4664,7 +4664,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(tempodb_compaction_bytes_written_total{cluster=\"$cluster\",job=\"$namespace/compactor\"}[$__rate_interval])) by (level)",
+          "expr": "sum(rate(tempodb_compaction_bytes_written_total{cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/compactor\"}[$__rate_interval])) by (level)",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -4757,7 +4757,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(increase(tempodb_compaction_blocks_total{cluster=\"$cluster\",job=\"$namespace/compactor\"}[5m])) by (level)",
+          "expr": "sum(increase(tempodb_compaction_blocks_total{cluster=\"$cluster\", namespace=\"$namespace\", job=\"$namespace/compactor\"}[5m])) by (level)",
           "interval": "",
           "legendFormat": "",
           "refId": "A"


### PR DESCRIPTION
**What this PR does**:
Some operational dashboard panels did not match on the cluster or namespace variable, so the data would be misleading for any environments with multiple clusters sharing the same namespace.  This PR adds those filters to all relevant panels.  it's probably not necessary to match on both namespace and job, but it seemed good for consistency.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`