### PR TITLE
Allow spaces in path for make vendor-check. Fixes #451

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ endif
 
 ### Dependencies
 DOCKER_PROTOBUF ?= otel/build-protobuf:0.2.1
-PROTOC = docker run --rm -u ${shell id -u} -v${PWD}:${PWD} -w${PWD} ${DOCKER_PROTOBUF} --proto_path=${PWD}
+PROTOC = docker run --rm -u ${shell id -u} -v"${PWD}":"${PWD}" -w"${PWD}" ${DOCKER_PROTOBUF} --proto_path=./
 PROTO_INTERMEDIATE_DIR = pkg/.patched-proto
 PROTO_INCLUDES = -I$(PROTO_INTERMEDIATE_DIR)
 PROTO_GEN = $(PROTOC) $(PROTO_INCLUDES) --gogofaster_out=plugins=grpc,paths=source_relative:$(2) $(1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #451 

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`


I didn't update the CHANGELOG since it seemed a very trivial fix. Let me know if I should.

Although, I was able to fix the original bug where paths with spaces were not working, I ran into another issue with go mod

```
go mod tidy -e
github.com/grafana/tempo/modules/distributor/receiver imports
	go.opentelemetry.io/collector/receiver/opencensusreceiver imports
	github.com/soheilhy/cmux tested by
	github.com/soheilhy/cmux.test imports
	google.golang.org/grpc/examples/helloworld/helloworld: ambiguous import: found package google.golang.org/grpc/examples/helloworld/helloworld in multiple modules:
	google.golang.org/grpc v1.33.2 (/home/yash/go/pkg/mod/google.golang.org/grpc@v1.29.1/examples/helloworld/helloworld)
	google.golang.org/grpc/examples v0.0.0-20200728065043-dfc0c05b2da9 (/home/yash/go/pkg/mod/google.golang.org/grpc/examples@v0.0.0-20200728065043-dfc0c05b2da9/helloworld/helloworld)
git diff --exit-code -- go.sum go.mod vendor/ pkg/tempopb/
```

This is however irrespective of the spaces problem that #451 is about and probably should be tackled in a different issue