### PR TITLE
Make all Iterators return io.EOF

### DIFF
--- a/tempodb/encoding/finder_paged.go
+++ b/tempodb/encoding/finder_paged.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
@@ -93,7 +94,7 @@ func (f *pagedFinder) findOne(ctx context.Context, id common.ID, record *common.
 
 	for {
 		foundID, b, err := iter.Next(ctx)
-		if foundID == nil {
+		if err == io.EOF {
 			break
 		}
 		if err != nil {

--- a/tempodb/encoding/iterator_deduping.go
+++ b/tempodb/encoding/iterator_deduping.go
@@ -25,7 +25,7 @@ func NewDedupingIterator(iter Iterator, combiner common.ObjectCombiner) (Iterato
 
 	var err error
 	i.currentID, i.currentObject, err = i.iter.Next(context.Background())
-	if err != nil && err != io.EOF { // jpe test this directly
+	if err != nil && err != io.EOF {
 		return nil, err
 	}
 

--- a/tempodb/encoding/iterator_deduping.go
+++ b/tempodb/encoding/iterator_deduping.go
@@ -25,7 +25,7 @@ func NewDedupingIterator(iter Iterator, combiner common.ObjectCombiner) (Iterato
 
 	var err error
 	i.currentID, i.currentObject, err = i.iter.Next(context.Background())
-	if err != nil {
+	if err != nil && err != io.EOF { // jpe test this directly
 		return nil, err
 	}
 
@@ -42,11 +42,7 @@ func (i *dedupingIterator) Next(ctx context.Context) (common.ID, []byte, error) 
 
 	for {
 		id, obj, err := i.iter.Next(ctx)
-		if err == io.EOF {
-			i.currentID = nil
-			i.currentObject = nil
-		}
-		if err != nil {
+		if err != nil && err != io.EOF {
 			return nil, nil, err
 		}
 

--- a/tempodb/encoding/iterator_deduping_test.go
+++ b/tempodb/encoding/iterator_deduping_test.go
@@ -1,0 +1,21 @@
+package encoding
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	v0 "github.com/grafana/tempo/tempodb/encoding/v0"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmptyNestedIterator(t *testing.T) {
+	r := bytes.NewReader([]byte{})
+	i := NewIterator(r, v0.NewObjectReaderWriter())
+
+	id, obj, err := i.Next(context.Background())
+	assert.Nil(t, id)
+	assert.Nil(t, obj)
+	assert.Equal(t, io.EOF, err)
+}

--- a/tempodb/encoding/iterator_record.go
+++ b/tempodb/encoding/iterator_record.go
@@ -29,7 +29,7 @@ func NewRecordIterator(r []*common.Record, ra io.ReaderAt, objectRW common.Objec
 func (i *recordIterator) Next(ctx context.Context) (common.ID, []byte, error) {
 	if i.currentIterator != nil {
 		id, object, err := i.currentIterator.Next(ctx)
-		if err != nil {
+		if err != nil && err != io.EOF {
 			return nil, nil, err
 		}
 		if id != nil {
@@ -54,7 +54,7 @@ func (i *recordIterator) Next(ctx context.Context) (common.ID, []byte, error) {
 	}
 
 	// done
-	return nil, nil, nil
+	return nil, nil, io.EOF
 }
 
 func (i *recordIterator) Close() {

--- a/tempodb/encoding/v0/object.go
+++ b/tempodb/encoding/v0/object.go
@@ -54,9 +54,7 @@ func (object) MarshalObjectToWriter(id common.ID, b []byte, w io.Writer) (int, e
 func (object) UnmarshalObjectFromReader(r io.Reader) (common.ID, []byte, error) {
 	var totalLength uint32
 	err := binary.Read(r, binary.LittleEndian, &totalLength)
-	if err == io.EOF {
-		return nil, nil, nil
-	} else if err != nil {
+	if err != nil {
 		return nil, nil, err
 	}
 

--- a/tempodb/wal/wal_test.go
+++ b/tempodb/wal/wal_test.go
@@ -2,6 +2,7 @@ package wal
 
 import (
 	"context"
+	"io"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -118,11 +119,11 @@ func TestAppend(t *testing.T) {
 	i := 0
 
 	for {
-		bytesID, bytesObject, err := iterator.Next(context.Background())
-		assert.NoError(t, err)
-		if bytesID == nil {
+		_, bytesObject, err := iterator.Next(context.Background())
+		if err == io.EOF {
 			break
 		}
+		assert.NoError(t, err)
 
 		req := &tempopb.PushRequest{}
 		err = proto.Unmarshal(bytesObject, req)


### PR DESCRIPTION
**What this PR does**:
When working on the versioned WAL I noticed that the iterators inconsistently returned io.EOF. The deduping and standard iterator just returned all `nil` when complete. This is kind of a scary change, but important that all iterators behave the same.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`