### PR TITLE
Updated blocklist histogram

### DIFF
--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -53,7 +53,7 @@ var (
 		Namespace: "tempodb",
 		Name:      "blocklist_poll_duration_seconds",
 		Help:      "Records the amount of time to poll and update the blocklist.",
-		Buckets:   prometheus.ExponentialBuckets(10, 2, 6),
+		Buckets:   prometheus.LinearBuckets(0, 60, 5),
 	})
 	metricBlocklistLength = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "tempodb",

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -53,7 +53,7 @@ var (
 		Namespace: "tempodb",
 		Name:      "blocklist_poll_duration_seconds",
 		Help:      "Records the amount of time to poll and update the blocklist.",
-		Buckets:   prometheus.ExponentialBuckets(.25, 2, 6),
+		Buckets:   prometheus.ExponentialBuckets(10, 2, 6),
 	})
 	metricBlocklistLength = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "tempodb",


### PR DESCRIPTION
**What this PR does**:
Based on previous values the max the histogram covered was `8s` which we were capping constantly. Changed to have each bucket cover a full minute and give us vision up to 5 minutes.
