### PR TITLE
Rename auth.enabled to multitenancy.enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * [CHANGE] `ingestion_rate_limit` limit override has been removed in favour of `ingestion_rate_limit_bytes`.
   `ingestion_burst_size` limit override has been removed in favour of `ingestion_burst_size_bytes`.
   This is a **breaking change** to the overrides config section. [#630](https://github.com/grafana/tempo/pull/630)
-* [CHANGE] Rename auth.enabled to multitenancy.enabled and set it as false by default. This is not a breaking change, but auth.enabled has been set as deprecated. 
+* [CHANGE] Rename auth.enabled to multitenancy.enabled and set it as false by default. This is a **breaking change** if you were relying on auth/multitenancy being enabled by default. [#646](https://github.com/grafana/tempo/pull/646)
 * [FEATURE] Add page based access to the index file. [#557](https://github.com/grafana/tempo/pull/557)
 * [FEATURE] (Experimental) WAL Compression/checksums. [#638](https://github.com/grafana/tempo/pull/638)
 * [ENHANCEMENT] Add a Shutdown handler to flush data to backend, at "/shutdown". [#526](https://github.com/grafana/tempo/pull/526)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [CHANGE] `ingestion_rate_limit` limit override has been removed in favour of `ingestion_rate_limit_bytes`.
   `ingestion_burst_size` limit override has been removed in favour of `ingestion_burst_size_bytes`.
   This is a **breaking change** to the overrides config section. [#630](https://github.com/grafana/tempo/pull/630)
+* [CHANGE] Rename auth.enabled to multitenancy.enabled and set it as false by default. This is not a breaking change, but auth.enabled has been set as deprecated. 
 * [FEATURE] Add page based access to the index file. [#557](https://github.com/grafana/tempo/pull/557)
 * [FEATURE] (Experimental) WAL Compression/checksums. [#638](https://github.com/grafana/tempo/pull/638)
 * [ENHANCEMENT] Add a Shutdown handler to flush data to backend, at "/shutdown". [#526](https://github.com/grafana/tempo/pull/526)

--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -62,7 +62,7 @@ func (c *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 	c.Target = All
 	// global settings
 	f.StringVar(&c.Target, "target", All, "target module")
-	f.BoolVar(&c.AuthEnabled, "auth.enabled", true, "Set to false to disable auth.")
+	f.BoolVar(&c.AuthEnabled, "auth.enabled", false, "Set to true to enable auth.")
 	f.StringVar(&c.HTTPAPIPrefix, "http-api-prefix", "", "String prefix for all http api endpoints.")
 
 	// Server settings

--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -41,9 +41,10 @@ const metricsNamespace = "tempo"
 
 // Config is the root config for App.
 type Config struct {
-	Target        string `yaml:"target,omitempty"`
-	AuthEnabled   bool   `yaml:"auth_enabled,omitempty"`
-	HTTPAPIPrefix string `yaml:"http_api_prefix"`
+	Target              string `yaml:"target,omitempty"`
+	AuthEnabled         bool   `yaml:"auth_enabled,omitempty"`
+	MultitenancyEnabled bool   `yaml:"multitenancy_enabled,omitempty"`
+	HTTPAPIPrefix       string `yaml:"http_api_prefix"`
 
 	Server         server.Config          `yaml:"server,omitempty"`
 	Distributor    distributor.Config     `yaml:"distributor,omitempty"`
@@ -62,7 +63,8 @@ func (c *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 	c.Target = All
 	// global settings
 	f.StringVar(&c.Target, "target", All, "target module")
-	f.BoolVar(&c.AuthEnabled, "auth.enabled", false, "Set to true to enable auth.")
+	f.BoolVar(&c.AuthEnabled, "auth.enabled", false, "Set to true to enable auth (deprecated: use multitenancy.enabled)")
+	f.BoolVar(&c.MultitenancyEnabled, "multitenancy.enabled", false, "Set to true to enable multitenancy.")
 	f.StringVar(&c.HTTPAPIPrefix, "http-api-prefix", "", "String prefix for all http api endpoints.")
 
 	// Server settings
@@ -154,7 +156,7 @@ func New(cfg Config) (*App, error) {
 }
 
 func (t *App) setupAuthMiddleware() {
-	if t.cfg.AuthEnabled {
+	if t.cfg.MultitenancyEnabled || t.cfg.AuthEnabled {
 
 		// don't check auth for these gRPC methods, since single call is used for multiple users
 		noGRPCAuthOn := []string{

--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -94,6 +94,11 @@ func (c *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 
 }
 
+// MultitenancyIsEnabled checks if multitenancy is enabled
+func (c *Config) MultitenancyIsEnabled() bool {
+	return c.MultitenancyEnabled || c.AuthEnabled
+}
+
 // CheckConfig checks if config values are suspect.
 func (c *Config) CheckConfig() {
 	if c.Ingester.CompleteBlockTimeout < c.StorageConfig.Trace.BlocklistPoll {
@@ -156,7 +161,7 @@ func New(cfg Config) (*App, error) {
 }
 
 func (t *App) setupAuthMiddleware() {
-	if t.cfg.MultitenancyEnabled || t.cfg.AuthEnabled {
+	if t.cfg.MultitenancyIsEnabled() {
 
 		// don't check auth for these gRPC methods, since single call is used for multiple users
 		noGRPCAuthOn := []string{

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -98,7 +98,7 @@ func (t *App) initOverrides() (services.Service, error) {
 
 func (t *App) initDistributor() (services.Service, error) {
 	// todo: make ingester client a module instead of passing the config everywhere
-	distributor, err := distributor.New(t.cfg.Distributor, t.cfg.IngesterClient, t.ring, t.overrides, t.cfg.AuthEnabled, t.cfg.Server.LogLevel)
+	distributor, err := distributor.New(t.cfg.Distributor, t.cfg.IngesterClient, t.ring, t.overrides, t.cfg.MultitenancyIsEnabled(), t.cfg.Server.LogLevel)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create distributor %w", err)
 	}

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -21,7 +21,7 @@ This section explains the configuration options for Tempo as well as the details
 Tempo uses the Weaveworks/common server.  See [here](https://github.com/weaveworks/common/blob/main/server/server.go#L45) for all configuration options.
 
 ```
-auth_enabled: true            # optional. Require X-Scope-OrgID. By default it's set to false (disabled).
+auth_enabled: true            # Optional. Require X-Scope-OrgID. By default, it's set to false (disabled).
 server:
   http_listen_port: 3100
 ```

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -21,7 +21,7 @@ This section explains the configuration options for Tempo as well as the details
 Tempo uses the Weaveworks/common server.  See [here](https://github.com/weaveworks/common/blob/main/server/server.go#L45) for all configuration options.
 
 ```
-auth_enabled: false            # do not require X-Scope-OrgID
+auth_enabled: true            # optional. Require X-Scope-OrgID. By default it's set to false (disabled).
 server:
   http_listen_port: 3100
 ```

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -21,7 +21,7 @@ This section explains the configuration options for Tempo as well as the details
 Tempo uses the Weaveworks/common server.  See [here](https://github.com/weaveworks/common/blob/main/server/server.go#L45) for all configuration options.
 
 ```
-auth_enabled: true            # Optional. Require X-Scope-OrgID. By default, it's set to false (disabled).
+multitenancy_enabled: true            # Optional. Require X-Scope-OrgID. By default, it's set to false.
 server:
   http_listen_port: 3100
 ```

--- a/docs/tempo/website/configuration/manifest.md
+++ b/docs/tempo/website/configuration/manifest.md
@@ -18,7 +18,7 @@ go run ./cmd/tempo --storage.trace.backend=local --storage.trace.local.path=/tmp
 
 ```yaml
 target: all
-auth_enabled: true
+multitenancy_enabled: true
 http_api_prefix: ""
 server:
     http_listen_address: ""

--- a/docs/tempo/website/guides/multitenancy.md
+++ b/docs/tempo/website/guides/multitenancy.md
@@ -3,7 +3,7 @@ title: Multitenancy
 ---
 
 Tempo is a multitenant distributed tracing backend. It supports multitenancy through the use
-of a header: `X-Scope-OrgID`. This guide details how to setup or disable multitenancy.
+of a header: `X-Scope-OrgID`. This guide details how to setup multitenancy.
 
 ## Multitenancy
 
@@ -50,12 +50,12 @@ exporters:
 ## Enabling Multitenancy
 If this is desired simply set the following config value on all Tempo components:
 ```
-auth_enabled: true
+multitenancy_enabled: true
 ```
 
 or from the command line:
 ```
---auth.enabled=true
+--multitenancy.enabled=true
 ```
 
 This option will force all Tempo components to require the `X-Scope-OrgID` header.

--- a/docs/tempo/website/guides/multitenancy.md
+++ b/docs/tempo/website/guides/multitenancy.md
@@ -47,17 +47,15 @@ exporters:
 - Multitenancy on ingestion is currently [only working](https://github.com/grafana/tempo/issues/495) with GPRC and this may never change. It is strongly recommended to use the OpenTelemetry Collector to support multitenancy as described above.
 - The way the read path is configured is temporary and should be much more straightforward once the [tempo-query dependency is removed](https://github.com/grafana/tempo/issues/382).
 
-## Disabling Multitenancy
-Most Tempo installations will be single tenant. If this is desired simply set the following config
-value on all Tempo components:
+## Enabling Multitenancy
+If this is desired simply set the following config value on all Tempo components:
 ```
-auth_enabled: false
+auth_enabled: true
 ```
 
 or from the command line:
 ```
---auth.enabled=false
+--auth.enabled=true
 ```
 
-This option will force all Tempo components to ignore the `X-Scope-OrgID` header and use the hardcoded
-value of `single-tenant`.
+This option will force all Tempo components to require the `X-Scope-OrgID` header.

--- a/docs/tempo/website/guides/pushing-spans-with-http.md
+++ b/docs/tempo/website/guides/pushing-spans-with-http.md
@@ -11,8 +11,6 @@ pushing spans with http/json from a Bash script using the [Zipkin](https://zipki
 Let's first start Tempo with the Zipkin receiver configured.  In order to do this create a config file like so:
 
 ```yaml
-auth_enabled: false
-
 server:
   http_listen_port: 3100
 

--- a/example/docker-compose/docker-compose.loki.yaml
+++ b/example/docker-compose/docker-compose.loki.yaml
@@ -7,7 +7,6 @@ services:
       - "-storage.trace.backend=local"                  # tell tempo where to permanently put traces
       - "-storage.trace.local.path=/tmp/tempo/traces"   
       - "-storage.trace.wal.path=/tmp/tempo/wal"        # tell tempo where to store the wal
-      - "-auth.enabled=false"                           # disables the requirement for the X-Scope-OrgID header
       - "-server.http-listen-port=3100" 
     volumes:
       - ./example-data/tempo:/tmp/tempo

--- a/example/docker-compose/docker-compose.multitenant.yaml
+++ b/example/docker-compose/docker-compose.multitenant.yaml
@@ -20,7 +20,7 @@ services:
   # To eventually offload to Tempo...
   tempo:
     image: grafana/tempo:latest
-    command: ["--target=all","--auth.enabled=true","--storage.trace.backend=local", "--storage.trace.local.path=/var/tempo"]
+    command: ["--target=all","--multitenancy.enabled=true","--storage.trace.backend=local", "--storage.trace.local.path=/var/tempo"]
     ports:
     - 8081:80
 

--- a/example/docker-compose/docker-compose.multitenant.yaml
+++ b/example/docker-compose/docker-compose.multitenant.yaml
@@ -20,7 +20,7 @@ services:
   # To eventually offload to Tempo...
   tempo:
     image: grafana/tempo:latest
-    command: ["--target=all", "--storage.trace.backend=local", "--storage.trace.local.path=/var/tempo"]
+    command: ["--target=all","--auth.enabled=true","--storage.trace.backend=local", "--storage.trace.local.path=/var/tempo"]
     ports:
     - 8081:80
 

--- a/example/docker-compose/etc/tempo-azure.yaml
+++ b/example/docker-compose/etc/tempo-azure.yaml
@@ -1,5 +1,3 @@
-auth_enabled: false
-
 server:
   http_listen_port: 3100
 

--- a/example/docker-compose/etc/tempo-gcs-fake.yaml
+++ b/example/docker-compose/etc/tempo-gcs-fake.yaml
@@ -1,5 +1,3 @@
-auth_enabled: false
-
 server:
   http_listen_port: 3100
 

--- a/example/docker-compose/etc/tempo-local.yaml
+++ b/example/docker-compose/etc/tempo-local.yaml
@@ -1,5 +1,3 @@
-auth_enabled: false
-
 server:
   http_listen_port: 3100
 

--- a/example/docker-compose/etc/tempo-s3-minio.yaml
+++ b/example/docker-compose/etc/tempo-s3-minio.yaml
@@ -1,5 +1,3 @@
-auth_enabled: false
-
 server:
   http_listen_port: 3100
 

--- a/example/tk/tempo-microservices/main.jsonnet
+++ b/example/tk/tempo-microservices/main.jsonnet
@@ -36,7 +36,6 @@ minio + load + tempo {
 
     // manually overriding to get tempo to talk to minio
     tempo_config +:: {
-        auth_enabled: false,
         storage+: {
             trace+: {
                 s3+: {

--- a/integration/bench/config.yaml
+++ b/integration/bench/config.yaml
@@ -1,5 +1,3 @@
-auth_enabled: false
-
 target: all
 
 server:

--- a/integration/e2e/config-all-in-one-azurite.yaml
+++ b/integration/e2e/config-all-in-one-azurite.yaml
@@ -1,5 +1,3 @@
-auth_enabled: false
-
 target: all
 
 server:

--- a/integration/e2e/config-all-in-one.yaml
+++ b/integration/e2e/config-all-in-one.yaml
@@ -1,5 +1,3 @@
-auth_enabled: false
-
 target: all
 
 server:

--- a/integration/e2e/config-limits.yaml
+++ b/integration/e2e/config-limits.yaml
@@ -1,5 +1,3 @@
-auth_enabled: false
-
 target: all
 
 server:

--- a/integration/e2e/config-microservices.yaml
+++ b/integration/e2e/config-microservices.yaml
@@ -1,5 +1,3 @@
-auth_enabled: false
-
 server:
   http_listen_port: 3100
 

--- a/integration/microservices/tempo.yaml
+++ b/integration/microservices/tempo.yaml
@@ -1,4 +1,3 @@
-auth_enabled: false
 compactor: null
 distributor:
     receivers:

--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -102,7 +102,7 @@ type Distributor struct {
 }
 
 // New a distributor creates.
-func New(cfg Config, clientCfg ingester_client.Config, ingestersRing ring.ReadRing, o *overrides.Overrides, authEnabled bool, level logging.Level) (*Distributor, error) {
+func New(cfg Config, clientCfg ingester_client.Config, ingestersRing ring.ReadRing, o *overrides.Overrides, multitenancyEnabled bool, level logging.Level) (*Distributor, error) {
 	factory := cfg.factory
 	if factory == nil {
 		factory = func(addr string) (ring_client.PoolClient, error) {
@@ -158,7 +158,7 @@ func New(cfg Config, clientCfg ingester_client.Config, ingestersRing ring.ReadRi
 		cfgReceivers = defaultReceivers
 	}
 
-	receivers, err := receiver.New(cfgReceivers, d, authEnabled, level)
+	receivers, err := receiver.New(cfgReceivers, d, multitenancyEnabled, level)
 	if err != nil {
 		return nil, err
 	}

--- a/operations/jsonnet/single-binary/configmap.libsonnet
+++ b/operations/jsonnet/single-binary/configmap.libsonnet
@@ -2,7 +2,6 @@
   local configMap = $.core.v1.configMap,
 
   tempo_config:: {
-    auth_enabled: false,
     server: {
       http_listen_port: $._config.port
     },


### PR DESCRIPTION
**What this PR does**:
This PR renames `auth.enabled` to `multitenancy.enabled` and changes its default value to false.

**Which issue(s) this PR fixes**:
Fixes #639

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`