### PR TITLE
Add tenant and request size info to query frontend log

### DIFF
--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -64,7 +64,7 @@ func NewTripperware(cfg Config, logger log.Logger, registerer prometheus.Registe
 			}
 
 			level.Info(logger).Log(
-				"orgID", orgID,
+				"tenant", orgID,
 				"method", r.Method,
 				"traceID", traceID,
 				"url", r.URL.RequestURI(),

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -71,7 +71,7 @@ func NewTripperware(cfg Config, logger log.Logger, registerer prometheus.Registe
 				"duration", time.Since(start).String(),
 				"response_size", contentLength,
 				"status", statusCode,
-				)
+			)
 
 			return resp, err
 		})

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -57,10 +57,21 @@ func NewTripperware(cfg Config, logger log.Logger, registerer prometheus.Registe
 
 			traceID, _ := middleware.ExtractTraceID(ctx)
 			statusCode := 500
+			var contentLength int64 = 0
 			if resp != nil {
 				statusCode = resp.StatusCode
+				contentLength = resp.ContentLength
 			}
-			level.Info(logger).Log("method", r.Method, "traceID", traceID, "url", r.URL.RequestURI(), "duration", time.Since(start).String(), "status", statusCode)
+
+			level.Info(logger).Log(
+				"orgID", orgID,
+				"method", r.Method,
+				"traceID", traceID,
+				"url", r.URL.RequestURI(),
+				"duration", time.Since(start).String(),
+				"response_size", contentLength,
+				"status", statusCode,
+				)
 
 			return resp, err
 		})

--- a/modules/frontend/querysharding.go
+++ b/modules/frontend/querysharding.go
@@ -214,8 +214,10 @@ func mergeResponses(ctx context.Context, marshallingFormat string, rrs []Request
 
 		span.SetTag("response marshalling format", marshallingFormat)
 		return &http.Response{
-			StatusCode:    http.StatusOK,
-			Body:          ioutil.NopCloser(bytes.NewReader(combinedTrace)),
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewReader(combinedTrace)),
+			// ContentLength header is added to log the size of response in the Tripperware in frontend.go
+			// This could be overwritten if the query client and Tempo negotiate compression
 			ContentLength: int64(len(combinedTrace)),
 			Header:        http.Header{},
 		}, nil

--- a/modules/frontend/querysharding.go
+++ b/modules/frontend/querysharding.go
@@ -214,9 +214,10 @@ func mergeResponses(ctx context.Context, marshallingFormat string, rrs []Request
 
 		span.SetTag("response marshalling format", marshallingFormat)
 		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       ioutil.NopCloser(bytes.NewReader(combinedTrace)),
-			Header:     http.Header{},
+			StatusCode:    http.StatusOK,
+			Body:          ioutil.NopCloser(bytes.NewReader(combinedTrace)),
+			ContentLength: int64(len(combinedTrace)),
+			Header:        http.Header{},
 		}, nil
 	}
 


### PR DESCRIPTION
Signed-off-by: Annanay <annanayagarwal@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Add information about tenant and the size of response for better discoverability in query frontend.
**Which issue(s) this PR fixes**:
Fixes #649

**Checklist**
- NA Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`