### PR TITLE
Wal improvements

### DIFF
--- a/pkg/io/read.go
+++ b/pkg/io/read.go
@@ -25,3 +25,33 @@ func ReadAllWithEstimate(r io.Reader, estimatedBytes int) ([]byte, error) {
 		}
 	}
 }
+
+// ReadAllWithBuffer is a fork of https://go.googlesource.com/go/+/go1.16.3/src/io/io.go#626
+//  with a buffer to read into. if the provided buffer is not large enough it will be extended
+//  and returned to the caller
+func ReadAllWithBuffer(r io.Reader, estimatedBytes int, b []byte) ([]byte, error) {
+	if estimatedBytes == 0 {
+		estimatedBytes = 512
+	}
+
+	if cap(b) < estimatedBytes {
+		b = make([]byte, 0, estimatedBytes)
+	} else {
+		b = b[0:0]
+	}
+
+	for {
+		if len(b) == cap(b) {
+			// Add more capacity (let append pick how much).
+			b = append(b, 0)[:len(b)]
+		}
+		n, err := r.Read(b[len(b):cap(b)])
+		b = b[:len(b)+n]
+		if err != nil {
+			if err == io.EOF {
+				err = nil
+			}
+			return b, err
+		}
+	}
+}

--- a/pkg/io/read.go
+++ b/pkg/io/read.go
@@ -1,0 +1,27 @@
+package io
+
+import "io"
+
+// ReadAllWithEstimate is a fork of https://go.googlesource.com/go/+/go1.16.3/src/io/io.go#626
+//  with a starting buffer size. if none is provided it uses the existing default of 512
+func ReadAllWithEstimate(r io.Reader, estimatedBytes int) ([]byte, error) {
+	if estimatedBytes == 0 {
+		estimatedBytes = 512
+	}
+
+	b := make([]byte, 0, estimatedBytes)
+	for {
+		if len(b) == cap(b) {
+			// Add more capacity (let append pick how much).
+			b = append(b, 0)[:len(b)]
+		}
+		n, err := r.Read(b[len(b):cap(b)])
+		b = b[:len(b)+n]
+		if err != nil {
+			if err == io.EOF {
+				err = nil
+			}
+			return b, err
+		}
+	}
+}

--- a/tempodb/encoding/common/types.go
+++ b/tempodb/encoding/common/types.go
@@ -33,7 +33,7 @@ type ObjectCombiner interface {
 // DataReader is the primary abstraction point for supporting multiple data
 // formats.
 type DataReader interface {
-	Read(context.Context, []*Record) ([][]byte, error)
+	Read(context.Context, []*Record, []byte) ([][]byte, []byte, error)
 	Close()
 
 	// NextPage can be used to iterate at a page at a time. May return ErrUnsupported for older formats

--- a/tempodb/encoding/common/types.go
+++ b/tempodb/encoding/common/types.go
@@ -37,7 +37,8 @@ type DataReader interface {
 	Close()
 
 	// NextPage can be used to iterate at a page at a time. May return ErrUnsupported for older formats
-	NextPage() ([]byte, error)
+	//  NextPage takes a reusable buffer to read the page into and returns it in case it needs to resize
+	NextPage([]byte) ([]byte, error)
 }
 
 // IndexReader is used to abstract away the details of an index.  Currently

--- a/tempodb/encoding/finder_paged.go
+++ b/tempodb/encoding/finder_paged.go
@@ -74,7 +74,7 @@ func (f *pagedFinder) Find(ctx context.Context, id common.ID) ([]byte, error) {
 }
 
 func (f *pagedFinder) findOne(ctx context.Context, id common.ID, record *common.Record) ([]byte, error) {
-	pages, err := f.r.Read(ctx, []*common.Record{record})
+	pages, _, err := f.r.Read(ctx, []*common.Record{record}, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/tempodb/encoding/iterator_paged.go
+++ b/tempodb/encoding/iterator_paged.go
@@ -17,6 +17,8 @@ type pagedIterator struct {
 	chunkSizeBytes uint32
 	pages          [][]byte
 	activePage     []byte
+
+	buffer []byte
 }
 
 // newPagedIterator returns a backendIterator.  This iterator is used to iterate
@@ -83,7 +85,7 @@ func (i *pagedIterator) Next(ctx context.Context) (common.ID, []byte, error) {
 		}
 	}
 
-	i.pages, err = i.dataReader.Read(ctx, records)
+	i.pages, i.buffer, err = i.dataReader.Read(ctx, records, i.buffer)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error iterating through object in backend")
 	}

--- a/tempodb/encoding/iterator_record.go
+++ b/tempodb/encoding/iterator_record.go
@@ -15,6 +15,8 @@ type recordIterator struct {
 	dataR    common.DataReader
 
 	currentIterator Iterator
+
+	buffer []byte
 }
 
 // NewRecordIterator returns a recordIterator.  This iterator is used for iterating through
@@ -40,7 +42,9 @@ func (i *recordIterator) Next(ctx context.Context) (common.ID, []byte, error) {
 
 	// read the next record and create an iterator
 	if len(i.records) > 0 {
-		pages, err := i.dataR.Read(ctx, i.records[:1])
+		var pages [][]byte
+		var err error
+		pages, i.buffer, err = i.dataR.Read(ctx, i.records[:1], i.buffer)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/tempodb/encoding/iterator_recordless.go
+++ b/tempodb/encoding/iterator_recordless.go
@@ -30,7 +30,7 @@ func (i *recordlessIterator) Next(_ context.Context) (common.ID, []byte, error) 
 	)
 	i.currentPage, id, obj, err = i.o.UnmarshalAndAdvanceBuffer(i.currentPage)
 	if err == io.EOF {
-		i.currentPage, err = i.d.NextPage()
+		i.currentPage, err = i.d.NextPage(i.currentPage)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/tempodb/encoding/streaming_block_test.go
+++ b/tempodb/encoding/streaming_block_test.go
@@ -107,3 +107,251 @@ func TestCompactorBlockAddObject(t *testing.T) {
 	assert.Equal(t, expectedRecords, len(records))
 	assert.Equal(t, numObjects, cb.CurrentBufferedObjects())
 }
+
+/* jpe - restore
+func TestStreamingBlockAll(t *testing.T) {
+	for _, enc := range backend.SupportedEncoding {
+		t.Run(enc.String(), func(t *testing.T) {
+			testCompleteBlockToBackendBlock(t,
+				&BlockConfig{
+					IndexDownsampleBytes: 1000,
+					BloomFP:              .01,
+					Encoding:             enc,
+					IndexPageSizeBytes:   1000,
+				},
+			)
+		})
+	}
+}
+
+func testCompleteBlockToBackendBlock(t *testing.T, cfg *BlockConfig) {
+	tempDir, err := ioutil.TempDir("/tmp", "")
+	defer os.RemoveAll(tempDir)
+	require.NoError(t, err, "unexpected error creating temp dir")
+
+	block, ids, reqs := completeBlock(t, cfg, tempDir)
+
+	backendTmpDir, err := ioutil.TempDir("/tmp", "")
+	defer os.RemoveAll(backendTmpDir)
+	require.NoError(t, err, "unexpected error creating temp dir")
+
+	r, w, _, err := local.New(&local.Config{
+		Path: backendTmpDir,
+	})
+	require.NoError(t, err, "error creating backend")
+
+	err = block.Write(context.Background(), w)
+	require.NoError(t, err, "error writing backend")
+
+	// meta?
+	uuids, err := r.Blocks(context.Background(), testTenantID)
+	require.NoError(t, err, "error listing blocks")
+	require.Len(t, uuids, 1)
+
+	meta, err := r.BlockMeta(context.Background(), uuids[0], testTenantID)
+	require.NoError(t, err, "error getting meta")
+
+	backendBlock, err := NewBackendBlock(meta, r)
+	require.NoError(t, err, "error creating block")
+
+	// test Find
+	for i, id := range ids {
+		foundBytes, err := backendBlock.Find(context.Background(), id)
+		assert.NoError(t, err)
+
+		assert.Equal(t, reqs[i], foundBytes)
+	}
+
+	// test Iterator
+	idsToObjs := map[uint32][]byte{}
+	for i, id := range ids {
+		idsToObjs[util.TokenForTraceID(id)] = reqs[i]
+	}
+	sort.Slice(ids, func(i int, j int) bool { return bytes.Compare(ids[i], ids[j]) == -1 })
+
+	iterator, err := backendBlock.Iterator(10 * 1024 * 1024)
+	require.NoError(t, err, "error getting iterator")
+	i := 0
+	for {
+		id, obj, err := iterator.Next(context.Background())
+		if id == nil {
+			break
+		}
+
+		assert.NoError(t, err)
+		assert.Equal(t, ids[i], []byte(id))
+		assert.Equal(t, idsToObjs[util.TokenForTraceID(id)], obj)
+		i++
+	}
+	assert.Equal(t, len(ids), i)
+}
+
+func completeBlock(t *testing.T, cfg *BlockConfig, tempDir string) (*CompleteBlock, [][]byte, [][]byte) {
+	rand.Seed(time.Now().Unix())
+
+	buffer := &bytes.Buffer{}
+	writer := bufio.NewWriter(buffer)
+	appender := NewAppender(v0.NewDataWriter(writer))
+
+	numMsgs := 1000
+	reqs := make([][]byte, 0, numMsgs)
+	ids := make([][]byte, 0, numMsgs)
+	var maxID, minID []byte
+	for i := 0; i < numMsgs; i++ {
+		id := make([]byte, 16)
+		rand.Read(id)
+		req := test.MakeRequest(rand.Int()%10, id)
+		ids = append(ids, id)
+		bReq, err := proto.Marshal(req)
+		require.NoError(t, err)
+		reqs = append(reqs, bReq)
+
+		err = appender.Append(id, bReq)
+		require.NoError(t, err, "unexpected error writing req")
+
+		if len(maxID) == 0 || bytes.Compare(id, maxID) == 1 {
+			maxID = id
+		}
+		if len(minID) == 0 || bytes.Compare(id, minID) == -1 {
+			minID = id
+		}
+	}
+	err := appender.Complete()
+	require.NoError(t, err)
+	err = writer.Flush()
+	require.NoError(t, err, "unexpected error flushing writer")
+
+	originatingMeta := backend.NewBlockMeta(testTenantID, uuid.New(), "should_be_ignored", backend.EncGZIP)
+	originatingMeta.StartTime = time.Now().Add(-5 * time.Minute)
+	originatingMeta.EndTime = time.Now().Add(5 * time.Minute)
+
+	// calc expected records
+	byteCounter := 0
+	expectedRecords := 0
+	for _, rec := range appender.Records() {
+		byteCounter += int(rec.Length)
+		if byteCounter > cfg.IndexDownsampleBytes {
+			byteCounter = 0
+			expectedRecords++
+		}
+	}
+	if byteCounter > 0 {
+		expectedRecords++
+	}
+
+	iterator := NewRecordIterator(appender.Records(), bytes.NewReader(buffer.Bytes()), v0.NewObjectReaderWriter())
+	block, err := NewCompleteBlock(cfg, originatingMeta, iterator, numMsgs, tempDir)
+	require.NoError(t, err, "unexpected error completing block")
+
+	// test downsample config
+	require.Equal(t, expectedRecords, len(block.records))
+	require.True(t, block.FlushedTime().IsZero())
+	require.True(t, bytes.Equal(block.meta.MinID, minID))
+	require.True(t, bytes.Equal(block.meta.MaxID, maxID))
+	require.Equal(t, originatingMeta.StartTime, block.meta.StartTime)
+	require.Equal(t, originatingMeta.EndTime, block.meta.EndTime)
+	require.Equal(t, originatingMeta.TenantID, block.meta.TenantID)
+
+	// Verify block size was written
+	require.Greater(t, block.meta.Size, uint64(0))
+
+	return block, ids, reqs
+}
+
+const benchDownsample = 200
+
+func BenchmarkWriteGzip(b *testing.B) {
+	benchmarkCompressBlock(b, backend.EncGZIP, benchDownsample, false)
+}
+func BenchmarkWriteSnappy(b *testing.B) {
+	benchmarkCompressBlock(b, backend.EncSnappy, benchDownsample, false)
+}
+func BenchmarkWriteLZ4256(b *testing.B) {
+	benchmarkCompressBlock(b, backend.EncLZ4_256k, benchDownsample, false)
+}
+func BenchmarkWriteLZ41M(b *testing.B) {
+	benchmarkCompressBlock(b, backend.EncLZ4_1M, benchDownsample, false)
+}
+func BenchmarkWriteNone(b *testing.B) {
+	benchmarkCompressBlock(b, backend.EncNone, benchDownsample, false)
+}
+
+func BenchmarkWriteZstd(b *testing.B) {
+	benchmarkCompressBlock(b, backend.EncZstd, benchDownsample, false)
+}
+
+func BenchmarkReadGzip(b *testing.B) {
+	benchmarkCompressBlock(b, backend.EncGZIP, benchDownsample, true)
+}
+func BenchmarkReadSnappy(b *testing.B) {
+	benchmarkCompressBlock(b, backend.EncSnappy, benchDownsample, true)
+}
+func BenchmarkReadLZ4256(b *testing.B) {
+	benchmarkCompressBlock(b, backend.EncLZ4_256k, benchDownsample, true)
+}
+func BenchmarkReadLZ41M(b *testing.B) {
+	benchmarkCompressBlock(b, backend.EncLZ4_1M, benchDownsample, true)
+}
+func BenchmarkReadNone(b *testing.B) {
+	benchmarkCompressBlock(b, backend.EncNone, benchDownsample, true)
+}
+
+func BenchmarkReadZstd(b *testing.B) {
+	benchmarkCompressBlock(b, backend.EncZstd, benchDownsample, true)
+}
+
+// Download a block from your backend and place in ./benchmark_block/fake/<guid>
+//nolint:unparam
+func benchmarkCompressBlock(b *testing.B, encoding backend.Encoding, indexDownsample int, benchRead bool) {
+	tempDir, err := ioutil.TempDir("/tmp", "")
+	defer os.RemoveAll(tempDir)
+	require.NoError(b, err, "unexpected error creating temp dir")
+
+	r, _, _, err := local.New(&local.Config{
+		Path: "./benchmark_block",
+	})
+	require.NoError(b, err, "error creating backend")
+
+	backendBlock, err := NewBackendBlock(backend.NewBlockMeta("fake", uuid.MustParse("9f15417a-1242-40e4-9de3-a057d3b176c1"), "v0", backend.EncNone), r)
+	require.NoError(b, err, "error creating backend block")
+
+	iterator, err := backendBlock.Iterator(10 * 1024 * 1024)
+	require.NoError(b, err, "error creating iterator")
+
+	if !benchRead {
+		b.ResetTimer()
+	}
+
+	originatingMeta := backend.NewBlockMeta(testTenantID, uuid.New(), "should_be_ignored", backend.EncGZIP)
+	cb, err := NewCompleteBlock(&BlockConfig{
+		IndexDownsampleBytes: indexDownsample,
+		BloomFP:              .05,
+		Encoding:             encoding,
+	}, originatingMeta, iterator, 10000, tempDir)
+	require.NoError(b, err, "error creating block")
+
+	lastRecord := cb.records[len(cb.records)-1]
+	fmt.Println("size: ", lastRecord.Start+uint64(lastRecord.Length))
+
+	if !benchRead {
+		return
+	}
+
+	b.ResetTimer()
+	file, err := os.Open(cb.fullFilename())
+	require.NoError(b, err)
+	pr, err := v2.NewDataReader(v0.NewDataReader(backend.NewContextReaderWithAllReader(file)), encoding)
+	require.NoError(b, err)
+	iterator = newPagedIterator(10*1024*1024, common.Records(cb.records), pr, backendBlock.encoding.newObjectReaderWriter())
+
+	for {
+		id, _, err := iterator.Next(context.Background())
+		if err != io.EOF {
+			require.NoError(b, err)
+		}
+		if id == nil {
+			break
+		}
+	}
+}
+*/

--- a/tempodb/encoding/v0/data_reader.go
+++ b/tempodb/encoding/v0/data_reader.go
@@ -70,7 +70,7 @@ func (r *dataReader) Close() {
 }
 
 // NextPage implements common.DataReader
-func (r *dataReader) NextPage() ([]byte, error) {
+func (r *dataReader) NextPage(buffer []byte) ([]byte, error) {
 	reader, err := r.r.Reader()
 	if err != nil {
 		return nil, err
@@ -83,13 +83,17 @@ func (r *dataReader) NextPage() ([]byte, error) {
 		return nil, err
 	}
 
-	page := make([]byte, totalLength)
-	binary.LittleEndian.PutUint32(page, totalLength)
+	if cap(buffer) < int(totalLength) {
+		buffer = make([]byte, totalLength)
+	} else {
+		buffer = buffer[:totalLength]
+	}
+	binary.LittleEndian.PutUint32(buffer, totalLength)
 
-	_, err = reader.Read(page[uint32Size:])
+	_, err = reader.Read(buffer[uint32Size:])
 	if err != nil {
 		return nil, err
 	}
 
-	return page, nil
+	return buffer, nil
 }

--- a/tempodb/encoding/v0/data_reader.go
+++ b/tempodb/encoding/v0/data_reader.go
@@ -27,9 +27,9 @@ func NewDataReader(r backend.ContextReader) common.DataReader {
 // Read returns the pages requested in the passed records.  It
 // assumes that if there are multiple records they are ordered
 // and contiguous
-func (r *dataReader) Read(ctx context.Context, records []*common.Record) ([][]byte, error) {
+func (r *dataReader) Read(ctx context.Context, records []*common.Record, buffer []byte) ([][]byte, []byte, error) {
 	if len(records) == 0 {
-		return nil, nil
+		return nil, buffer, nil
 	}
 
 	start := records[0].Start
@@ -38,10 +38,10 @@ func (r *dataReader) Read(ctx context.Context, records []*common.Record) ([][]by
 		length += record.Length
 	}
 
-	contiguousPages := make([]byte, length)
-	_, err := r.r.ReadAt(ctx, contiguousPages, int64(start))
+	buffer = make([]byte, length)
+	_, err := r.r.ReadAt(ctx, buffer, int64(start))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	slicePages := make([][]byte, 0, len(records))
@@ -49,20 +49,20 @@ func (r *dataReader) Read(ctx context.Context, records []*common.Record) ([][]by
 	previousEnd := uint64(0)
 	for _, record := range records {
 		end := cursor + record.Length
-		if end > uint32(len(contiguousPages)) {
-			return nil, fmt.Errorf("record out of bounds while reading pages: %d, %d, %d, %d", cursor, record.Length, end, len(contiguousPages))
+		if end > uint32(len(buffer)) {
+			return nil, nil, fmt.Errorf("record out of bounds while reading pages: %d, %d, %d, %d", cursor, record.Length, end, len(buffer))
 		}
 
 		if previousEnd != record.Start && previousEnd != 0 {
-			return nil, fmt.Errorf("non-contiguous pages requested from dataReader: %d, %+v", previousEnd, record)
+			return nil, nil, fmt.Errorf("non-contiguous pages requested from dataReader: %d, %+v", previousEnd, record)
 		}
 
-		slicePages = append(slicePages, contiguousPages[cursor:end])
+		slicePages = append(slicePages, buffer[cursor:end])
 		cursor += record.Length
 		previousEnd = record.Start + uint64(record.Length)
 	}
 
-	return slicePages, nil
+	return slicePages, buffer, nil
 }
 
 // Close implements common.DataReader

--- a/tempodb/encoding/v0/data_reader_test.go
+++ b/tempodb/encoding/v0/data_reader_test.go
@@ -161,7 +161,7 @@ func TestWriterReaderNextPage(t *testing.T) {
 	reader := NewDataReader(backend.NewContextReaderWithAllReader(bytes.NewReader(buff.Bytes())))
 	i := 0
 	for {
-		page, err := reader.NextPage()
+		page, err := reader.NextPage(nil) // jpe test this (i.e. various sizes being passed in here)
 		if err == io.EOF {
 			break
 		}

--- a/tempodb/encoding/v0/data_reader_test.go
+++ b/tempodb/encoding/v0/data_reader_test.go
@@ -126,7 +126,7 @@ func TestDataReader(t *testing.T) {
 
 	for _, tc := range tests {
 		reader := NewDataReader(backend.NewContextReaderWithAllReader(bytes.NewReader(tc.readerBytes)))
-		actual, err := reader.Read(context.Background(), tc.records)
+		actual, _, err := reader.Read(context.Background(), tc.records, nil)
 		reader.Close()
 
 		if tc.expectedError {

--- a/tempodb/encoding/v1/data_reader.go
+++ b/tempodb/encoding/v1/data_reader.go
@@ -83,7 +83,7 @@ func (r *dataReader) NextPage(buffer []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	page, err = tempo_io.ReadAllWithEstimate(reader, 2*len(page))
+	page, err = tempo_io.ReadAllWithEstimate(reader, len(page)+1) // +1 prevents an extra alloc on uncompressed
 	if err != nil {
 		return nil, err
 	}

--- a/tempodb/encoding/v1/data_reader.go
+++ b/tempodb/encoding/v1/data_reader.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 
+	tempo_io "github.com/grafana/tempo/pkg/io"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 	v0 "github.com/grafana/tempo/tempodb/encoding/v0"
@@ -73,8 +74,8 @@ func (r *dataReader) Close() {
 }
 
 // NextPage implements common.DataReader (kind of)
-func (r *dataReader) NextPage() ([]byte, error) {
-	page, err := r.dataReader.NextPage()
+func (r *dataReader) NextPage(buffer []byte) ([]byte, error) {
+	page, err := r.dataReader.NextPage(buffer)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +83,7 @@ func (r *dataReader) NextPage() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	page, err = ioutil.ReadAll(reader)
+	page, err = tempo_io.ReadAllWithEstimate(reader, 2*len(page))
 	if err != nil {
 		return nil, err
 	}

--- a/tempodb/encoding/v1/data_reader.go
+++ b/tempodb/encoding/v1/data_reader.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 
 	tempo_io "github.com/grafana/tempo/pkg/io"
 	"github.com/grafana/tempo/tempodb/backend"
@@ -54,7 +53,7 @@ func (r *dataReader) Read(ctx context.Context, records []*common.Record) ([][]by
 			return nil, err
 		}
 
-		page, err := ioutil.ReadAll(reader)
+		page, err := tempo_io.ReadAllWithEstimate(reader, len(page)+1) // +1 prevents an extra alloc on uncompressed
 		if err != nil {
 			return nil, err
 		}

--- a/tempodb/encoding/v1/data_reader_test.go
+++ b/tempodb/encoding/v1/data_reader_test.go
@@ -43,12 +43,12 @@ func TestAllEncodings(t *testing.T) {
 				require.NoError(t, err)
 				defer reader.Close()
 
-				actual, err := reader.Read(context.Background(), []*common.Record{
+				actual, _, err := reader.Read(context.Background(), []*common.Record{
 					{
 						Start:  0,
 						Length: uint32(mw.bytesWritten),
 					},
-				})
+				}, nil)
 
 				assert.NoError(t, err)
 				assert.Len(t, actual, 1)

--- a/tempodb/encoding/v2/data_reader.go
+++ b/tempodb/encoding/v2/data_reader.go
@@ -38,23 +38,23 @@ func NewDataReader(r backend.ContextReader, encoding backend.Encoding) (common.D
 }
 
 // Read implements common.DataReader
-func (r *dataReader) Read(ctx context.Context, records []*common.Record) ([][]byte, error) {
-	v0Pages, err := r.dataReader.Read(ctx, records)
+func (r *dataReader) Read(ctx context.Context, records []*common.Record, buffer []byte) ([][]byte, []byte, error) {
+	v0Pages, buffer, err := r.dataReader.Read(ctx, records, buffer)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	pages := make([][]byte, 0, len(v0Pages))
 	for _, v0Page := range v0Pages {
 		page, err := unmarshalPageFromBytes(v0Page, constDataHeader)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		pages = append(pages, page.data)
 	}
 
-	return pages, nil
+	return pages, buffer, nil
 }
 
 func (r *dataReader) Close() {

--- a/tempodb/encoding/v2/data_reader.go
+++ b/tempodb/encoding/v2/data_reader.go
@@ -12,6 +12,8 @@ import (
 type dataReader struct {
 	contextReader backend.ContextReader
 	dataReader    common.DataReader
+
+	pageBuffer []byte
 }
 
 // constDataHeader is a singleton data header.  the data header is
@@ -60,16 +62,17 @@ func (r *dataReader) Close() {
 }
 
 // NextPage implements common.DataReader
-func (r *dataReader) NextPage() ([]byte, error) {
+func (r *dataReader) NextPage(buffer []byte) ([]byte, error) {
 	reader, err := r.contextReader.Reader()
 	if err != nil {
 		return nil, err
 	}
 
-	page, err := unmarshalPageFromReader(reader, constDataHeader)
+	page, err := unmarshalPageFromReader(reader, constDataHeader, r.pageBuffer)
 	if err != nil {
 		return nil, err
 	}
+	r.pageBuffer = page.data
 
 	return page.data, nil
 }

--- a/tempodb/encoding/v2/page.go
+++ b/tempodb/encoding/v2/page.go
@@ -51,7 +51,7 @@ func unmarshalPageFromBytes(b []byte, header pageHeader) (*page, error) {
 	}, nil
 }
 
-func unmarshalPageFromReader(r io.Reader, header pageHeader) (*page, error) {
+func unmarshalPageFromReader(r io.Reader, header pageHeader, buffer []byte) (*page, error) {
 	totalHeaderSize := baseHeaderSize + header.headerLength()
 
 	var totalLength uint32
@@ -75,14 +75,20 @@ func unmarshalPageFromReader(r io.Reader, header pageHeader) (*page, error) {
 		return nil, err
 	}
 	dataLength := int(totalLength) - totalHeaderSize
-	pageBytes := make([]byte, dataLength)
-	_, err = r.Read(pageBytes)
+
+	if cap(buffer) < dataLength {
+		buffer = make([]byte, dataLength)
+	} else {
+		buffer = buffer[:dataLength]
+	}
+
+	_, err = r.Read(buffer)
 	if err != nil {
 		return nil, err
 	}
 
 	return &page{
-		data:   pageBytes,
+		data:   buffer,
 		header: header,
 	}, nil
 }

--- a/tempodb/encoding/v2/page_test.go
+++ b/tempodb/encoding/v2/page_test.go
@@ -68,7 +68,7 @@ func TestPageMarshalToWriter(t *testing.T) {
 		assert.Equal(t, tc.expected, page.data)
 		assert.Equal(t, tc.field, page.header.(*testHeader).field)
 
-		page, err = unmarshalPageFromReader(buff, &testHeader{})
+		page, err = unmarshalPageFromReader(buff, &testHeader{}, []byte{})
 		require.NoError(t, err)
 		assert.Equal(t, tc.expected, page.data)
 		assert.Equal(t, tc.field, page.header.(*testHeader).field)

--- a/tempodb/encoding/versioned_test.go
+++ b/tempodb/encoding/versioned_test.go
@@ -61,12 +61,12 @@ func testDataWriterReader(t *testing.T, v VersionedEncoding, e backend.Encoding)
 		require.NoError(t, err)
 		defer dataReader.Close()
 
-		actual, err := dataReader.Read(context.Background(), []*common.Record{
+		actual, _, err := dataReader.Read(context.Background(), []*common.Record{
 			{
 				Start:  0,
 				Length: uint32(bytesWritten),
 			},
-		})
+		}, nil)
 		require.NoError(t, err)
 		require.Len(t, actual, 1)
 

--- a/tempodb/wal/wal_test.go
+++ b/tempodb/wal/wal_test.go
@@ -254,7 +254,7 @@ func benchmarkWriteFindReplay(b *testing.B, encoding backend.Encoding) {
 	for i := 0; i < objects; i++ {
 		id := make([]byte, 16)
 		rand.Read(id)
-		obj := test.MakeRequest(rand.Int()%10, id)
+		obj := test.MakeRequest(rand.Int()%1000, id)
 		ids = append(ids, id)
 		bObj, err := proto.Marshal(obj)
 		require.NoError(b, err)


### PR DESCRIPTION
**What this PR does**:
Performance improvements on wal and backend block iterating.

- Added `ReadAllWithEstimate` and `ReadAllWithBuffer` to allow for more efficient 
- Added a reusable buffer parameter to the `DataReader.Read()` method for use in iteration
- Restored some lost tests/benchmarks on Complete/Streaming blocks