### PR TITLE
Tempo query license cleanup

### DIFF
--- a/cmd/tempo-query/tempo/plugin.go
+++ b/cmd/tempo-query/tempo/plugin.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/grafana/tempo/pkg/util"
 	"github.com/opentracing/opentracing-go"
 	ot_log "github.com/opentracing/opentracing-go/log"
 	"github.com/weaveworks/common/user"
@@ -19,6 +18,11 @@ import (
 
 	ot_pdata "go.opentelemetry.io/collector/consumer/pdata"
 	ot_jaeger "go.opentelemetry.io/collector/translator/trace/jaeger"
+)
+
+const (
+	AcceptHeaderKey         = "Accept"
+	ProtobufTypeHeaderValue = "application/protobuf"
 )
 
 type Backend struct {
@@ -58,7 +62,7 @@ func (b *Backend) GetTrace(ctx context.Context, traceID jaeger.TraceID) (*jaeger
 	}
 
 	// Set content type to grpc
-	req.Header.Set(util.AcceptHeaderKey, util.ProtobufTypeHeaderValue)
+	req.Header.Set(AcceptHeaderKey, ProtobufTypeHeaderValue)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/pkg/util/http_test.go
+++ b/pkg/util/http_test.go
@@ -54,7 +54,7 @@ func TestHexStringToTraceID(t *testing.T) {
 	}
 }
 
-// For licensing reasons they strings exist in two packages. This test exists to make sure they don't 
+// For licensing reasons they strings exist in two packages. This test exists to make sure they don't
 // drift.
 func TestEquality(t *testing.T) {
 	assert.Equal(t, AcceptHeaderKey, tempo.AcceptHeaderKey)

--- a/pkg/util/http_test.go
+++ b/pkg/util/http_test.go
@@ -3,6 +3,8 @@ package util
 import (
 	"testing"
 
+	"github.com/grafana/tempo/cmd/tempo-query/tempo"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -50,4 +52,11 @@ func TestHexStringToTraceID(t *testing.T) {
 			assert.Equal(t, tt.expected, actual)
 		})
 	}
+}
+
+// For licensing reasons they strings exist in two packages. This test exists to make sure they don't 
+// drift.
+func TestEquality(t *testing.T) {
+	assert.Equal(t, AcceptHeaderKey, tempo.AcceptHeaderKey)
+	assert.Equal(t, ProtobufTypeHeaderValue, tempo.ProtobufTypeHeaderValue)
 }


### PR DESCRIPTION
**What this PR does**:
Two AGPL licensed strings were referenced from an APACHE2 licensed folder. This PR copies the strings into the folder to prevent licensing issues and sets up a test to make sure they don't drift.

Fixes #663 
