### PR TITLE
Compression buffer

### DIFF
--- a/pkg/io/read.go
+++ b/pkg/io/read.go
@@ -35,7 +35,7 @@ func ReadAllWithBuffer(r io.Reader, estimatedBytes int, b []byte) ([]byte, error
 	}
 
 	if cap(b) < estimatedBytes {
-		b = make([]byte, 0, estimatedBytes)
+		b = make([]byte, 0, estimatedBytes+1) // if the calling code knows the exact bytes needed the below logic will do one extra allocation unless we add 1
 	} else {
 		b = b[0:0]
 	}

--- a/tempodb/encoding/streaming_block_test.go
+++ b/tempodb/encoding/streaming_block_test.go
@@ -173,7 +173,7 @@ func testStreamingBlockToBackendBlock(t *testing.T, cfg *BlockConfig) {
 	}
 	sort.Slice(ids, func(i int, j int) bool { return bytes.Compare(ids[i], ids[j]) == -1 })
 
-	iterator, err := backendBlock.Iterator(10 * 1024 * 1024)
+	iterator, err := backendBlock.Iterator(50 * 1024)
 	require.NoError(t, err, "error getting iterator")
 	i := 0
 	for {

--- a/tempodb/encoding/v1/data_reader.go
+++ b/tempodb/encoding/v1/data_reader.go
@@ -63,7 +63,7 @@ func (r *dataReader) Read(ctx context.Context, records []*common.Record, buffer 
 			return nil, nil, err
 		}
 
-		r.compressedPagesBuffer[i], err = tempo_io.ReadAllWithBuffer(reader, len(page)+1, r.compressedPagesBuffer[i])
+		r.compressedPagesBuffer[i], err = tempo_io.ReadAllWithBuffer(reader, len(page), r.compressedPagesBuffer[i])
 		if err != nil {
 			return nil, nil, err
 		}
@@ -90,7 +90,7 @@ func (r *dataReader) NextPage(buffer []byte) ([]byte, uint32, error) {
 	if err != nil {
 		return nil, 0, err
 	}
-	r.buffer, err = tempo_io.ReadAllWithBuffer(reader, len(page)+1, r.buffer)
+	r.buffer, err = tempo_io.ReadAllWithBuffer(reader, len(page), r.buffer)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/tempodb/encoding/v1/data_reader.go
+++ b/tempodb/encoding/v1/data_reader.go
@@ -48,7 +48,6 @@ func (r *dataReader) Read(ctx context.Context, records []*common.Record, buffer 
 		return nil, nil, err
 	}
 
-	// now decompress
 	if cap(r.compressedPagesBuffer) < len(compressedPages) {
 		// extend r.compressedPagesBuffer
 		diff := len(compressedPages) - cap(r.compressedPagesBuffer)
@@ -57,7 +56,7 @@ func (r *dataReader) Read(ctx context.Context, records []*common.Record, buffer 
 		r.compressedPagesBuffer = r.compressedPagesBuffer[:len(compressedPages)]
 	}
 
-	r.compressedPagesBuffer = r.compressedPagesBuffer[:]
+	// now decompress
 	for i, page := range compressedPages {
 		reader, err := r.getCompressedReader(page)
 		if err != nil {


### PR DESCRIPTION
**What this PR does**:
PProf is showing that ~20% of ingester allocations during a CompleteBlock operation occur in `v1.dataReader => tempo_io.ReadAllWithEstimate`. This change adds a reusable buffer slice to the `v1.dataReader` to reduce allocations.

Also moved the +1 bytes into `ReadAllWithEstimate()`