### PR TITLE
Fixed docs for http prefix

### DIFF
--- a/docs/tempo/website/guides/pushing-spans-with-http.md
+++ b/docs/tempo/website/guides/pushing-spans-with-http.md
@@ -61,7 +61,7 @@ Note that the `timestamp` field is in microseconds and was obtained by running `
 The easiest way to get the trace is to execute a simple curl command to Tempo.  The returned format is [OTLP](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/trace/v1/trace.proto).
 
 ```bash
-curl http://localhost:3100/tempo/api/traces/0123456789abcdef
+curl http://localhost:3100/api/traces/0123456789abcdef
 
 {"batches":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"shell script"}}]},"instrumentationLibrarySpans":[{"spans":[{"traceId":"AAAAAAAAAAABI0VniavN7w==","spanId":"AAAAAAAAEjQ=","name":"span from bash!","startTimeUnixNano":"1608239395286533000","endTimeUnixNano":"1608239395386533000","attributes":[{"key":"http.path","value":{"stringValue":"/api"}},{"key":"http.method","value":{"stringValue":"GET"}}]}]}]}]}
 ```


### PR DESCRIPTION
**What this PR does**:
Fixes pushing spans with http documentation given the recent configurable http prefix change.

**Which issue(s) this PR fixes**:
Fixes #670 

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`