### PR TITLE
Expand buffer to its capacity before appending more slices

### DIFF
--- a/tempodb/encoding/v1/data_reader.go
+++ b/tempodb/encoding/v1/data_reader.go
@@ -51,7 +51,7 @@ func (r *dataReader) Read(ctx context.Context, records []*common.Record, buffer 
 	if cap(r.compressedPagesBuffer) < len(compressedPages) {
 		// extend r.compressedPagesBuffer
 		diff := len(compressedPages) - cap(r.compressedPagesBuffer)
-		r.compressedPagesBuffer = append(r.compressedPagesBuffer, make([][]byte, diff)...)
+		r.compressedPagesBuffer = append(r.compressedPagesBuffer[:cap(r.compressedPagesBuffer)], make([][]byte, diff)...)
 	} else {
 		r.compressedPagesBuffer = r.compressedPagesBuffer[:len(compressedPages)]
 	}


### PR DESCRIPTION
**What this PR does**:
Expand buffer to its capacity before appending more slices to make up for the difference to the length of compressed pages to read. Otherwise we're first filling already allocated elements before actually expanding the buffer.

**Which issue(s) this PR fixes**:
None

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`