### PR TITLE
Fix ldflags set by goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,9 +14,9 @@ builds:
     ldflags:
       - -s
       - -w
-      - -X main.version={{ .Version }}
-      - -X main.commit={{ .Commit }}
-      - -X main.date={{ .CommitDate }}
+      - -X main.Branch={{ .Branch }}
+      - -X main.Revision={{ .ShortCommit }}
+      - -X main.Version={{ .Version }}
     mod_timestamp: '{{ .CommitTimestamp }}'
   - id: "tempo-query"
     main: ./cmd/tempo-query
@@ -33,9 +33,9 @@ builds:
     ldflags:
       - -s
       - -w
-      - -X main.version={{ .Version }}
-      - -X main.commit={{ .Commit }}
-      - -X main.date={{ .CommitDate }}
+      - -X main.Branch={{ .Branch }}
+      - -X main.Revision={{ .ShortCommit }}
+      - -X main.Version={{ .Version }}
     mod_timestamp: '{{ .CommitTimestamp }}'
 changelog:
   skip: true


### PR DESCRIPTION
Signed-off-by: Martin Disibio <mdisibio@gmail.com>

**What this PR does**:
`make release`/goreleaser was setting the wrong ldflags (-X) leading to `tempo -version` printing empty values.  Docker images were ok because they are built using `make exe` and set here: https://github.com/grafana/tempo/blob/main/Makefile#L26

**Which issue(s) this PR fixes**:
Fixes #669 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`