### PR TITLE
Enable mutex profiling. Fix load shedding.

### DIFF
--- a/cmd/tempo/main.go
+++ b/cmd/tempo/main.go
@@ -40,10 +40,9 @@ func init() {
 }
 
 func main() {
-	runtime.SetMutexProfileFraction(5)
-
 	printVersion := flag.Bool("version", false, "Print this builds version information")
 	ballastMBs := flag.Int("mem-ballast-size-mbs", 0, "Size of memory ballast to allocate in MBs.")
+	mutexProfileFraction := flag.Int("mutex-profile-fraction", 0, "Enable mutex profiling.")
 
 	config, err := loadConfig()
 	if err != nil {
@@ -74,6 +73,10 @@ func main() {
 			os.Exit(1)
 		}
 	}()
+
+	if *mutexProfileFraction > 0 {
+		runtime.SetMutexProfileFraction(*mutexProfileFraction)
+	}
 
 	// Allocate a block of memory to alter GC behaviour. See https://github.com/golang/go/issues/23044
 	ballast := make([]byte, *ballastMBs*1024*1024)

--- a/cmd/tempo/main.go
+++ b/cmd/tempo/main.go
@@ -40,6 +40,8 @@ func init() {
 }
 
 func main() {
+	runtime.SetMutexProfileFraction(5)
+
 	printVersion := flag.Bool("version", false, "Print this builds version information")
 	ballastMBs := flag.Int("mem-ballast-size-mbs", 0, "Size of memory ballast to allocate in MBs.")
 

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -94,6 +94,11 @@ func newInstance(instanceID string, limiter *Limiter, writer tempodb.Writer, l *
 }
 
 func (i *instance) Push(ctx context.Context, req *tempopb.PushRequest) error {
+	err := i.limiter.AssertMaxTracesPerUser(i.instanceID, len(i.traces))
+	if err != nil {
+		return status.Errorf(codes.FailedPrecondition, "%s max live traces per tenant exceeded: %v", overrides.ErrorPrefixLiveTracesExceeded, err)
+	}
+
 	i.tracesMtx.Lock()
 	defer i.tracesMtx.Unlock()
 
@@ -335,11 +340,6 @@ func (i *instance) getOrCreateTrace(req *tempopb.PushRequest) (*trace, error) {
 	trace, ok := i.traces[fp]
 	if ok {
 		return trace, nil
-	}
-
-	err = i.limiter.AssertMaxTracesPerUser(i.instanceID, len(i.traces))
-	if err != nil {
-		return nil, status.Errorf(codes.FailedPrecondition, "%s max live traces per tenant exceeded: %v", overrides.ErrorPrefixLiveTracesExceeded, err)
 	}
 
 	maxBytes := i.limiter.limits.MaxBytesPerTrace(i.instanceID)


### PR DESCRIPTION
**What this PR does**:
- Adds a cli parameter `mutex-profile-fraction` allowing us to dynamically enable mutex profiling
- Moves max traces check before grabbing the traces mutex and uses an atomic.Int32. This will relieve pressure on the traces mutex and allow more effective load shedding.