### PR TITLE
Added option to disable extended writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main / unreleased
 
 * [ENHANCEMENT] Improve WAL Replay by not rebuilding the WAL. [#668](https://github.com/grafana/tempo/pull/668)
+* [ENHANCEMENT] Add config option to disable write extension to the ingesters. [#677](https://github.com/grafana/tempo/pull/677)
 
 ## v0.7.0
 

--- a/docs/tempo/website/configuration/manifest.md
+++ b/docs/tempo/website/configuration/manifest.md
@@ -95,6 +95,7 @@ distributor:
         instance_addr: ""
     receivers: {}
     override_ring_key: distributor
+    extend_writes: true
 ingester_client:
     pool_config:
         checkinterval: 15s

--- a/modules/distributor/config.go
+++ b/modules/distributor/config.go
@@ -33,7 +33,10 @@ type Config struct {
 	//  otel collector: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver
 	Receivers       map[string]interface{} `yaml:"receivers"`
 	OverrideRingKey string                 `yaml:"override_ring_key"`
-	ExtendWrites    bool                   `yaml:"extend_writes"` // disables write extension with inactive ingesters. Use this along with ingester.lifecycler.unregister_on_shutdown = true
+
+	// disables write extension with inactive ingesters. Use this along with ingester.lifecycler.unregister_on_shutdown = true
+	//  note that setting these two config values reduces tolerance to failures on rollout b/c there is always one guaranteed to be failing replica
+	ExtendWrites bool `yaml:"extend_writes"`
 
 	// For testing.
 	factory func(addr string) (ring_client.PoolClient, error) `yaml:"-"`

--- a/modules/distributor/config.go
+++ b/modules/distributor/config.go
@@ -33,7 +33,7 @@ type Config struct {
 	//  otel collector: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver
 	Receivers       map[string]interface{} `yaml:"receivers"`
 	OverrideRingKey string                 `yaml:"override_ring_key"`
-	ExtendWrites    bool                   `yaml:"extend_writes"`
+	ExtendWrites    bool                   `yaml:"extend_writes"` // disables write extension with inactive ingesters. Use this along with ingester.lifecycler.unregister_on_shutdown = true
 
 	// For testing.
 	factory func(addr string) (ring_client.PoolClient, error) `yaml:"-"`

--- a/modules/distributor/config.go
+++ b/modules/distributor/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	//  otel collector: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver
 	Receivers       map[string]interface{} `yaml:"receivers"`
 	OverrideRingKey string                 `yaml:"override_ring_key"`
+	ExtendWrites    bool                   `yaml:"extend_writes"`
 
 	// For testing.
 	factory func(addr string) (ring_client.PoolClient, error) `yaml:"-"`
@@ -45,4 +46,5 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.DistributorRing.HeartbeatTimeout = 5 * time.Minute
 
 	cfg.OverrideRingKey = ring.DistributorRingKey
+	cfg.ExtendWrites = true
 }

--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -261,7 +261,12 @@ func (d *Distributor) sendToIngestersViaBytes(ctx context.Context, userID string
 		rawRequests[i] = b
 	}
 
-	err := ring.DoBatch(ctx, ring.Write, d.ingestersRing, keys, func(ingester ring.InstanceDesc, indexes []int) error {
+	op := ring.WriteNoExtend
+	if d.cfg.ExtendWrites {
+		op = ring.Write
+	}
+
+	err := ring.DoBatch(ctx, op, d.ingestersRing, keys, func(ingester ring.InstanceDesc, indexes []int) error {
 
 		localCtx, cancel := context.WithTimeout(context.Background(), d.clientCfg.RemoteTimeout)
 		defer cancel()


### PR DESCRIPTION
**What this PR does**:
Adds the ability to not extend writes to other ingesters when it sees an inactive ingester. This is useful during rollouts to prevent amplifying traces across all ingesters.

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`