### PR TITLE
Update required s3 permissions

### DIFF
--- a/docs/tempo/website/configuration/s3.md
+++ b/docs/tempo/website/configuration/s3.md
@@ -43,7 +43,9 @@ The following IAM policy shows minimal permissions required by Tempo, where the 
                 "s3:PutObject",
                 "s3:GetObject",
                 "s3:ListBucket",
-                "s3:DeleteObject"
+                "s3:DeleteObject",
+                "s3:GetObjectTagging",
+                "s3:PutObjectTagging"
             ],
             "Resource": [
                 "arn:aws:s3:::<bucketname>/*",


### PR DESCRIPTION
**What this PR does**:
Adds "s3:PutObjectTagging" and "s3:GetObjectTagging" to the list of required permissions for s3. If an object has tags s3 copy will fail (which we use to move meta.json -> meta.compacted.json) in the compactors.

https://medium.com/collaborne-engineering/s3-copyobject-access-denied-5f7a6fe0393e