### PR TITLE
Vulture: use logfmt logging, update zap-logfmt to v1.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/hashicorp/go-hclog v0.14.0
 	github.com/hashicorp/go-plugin v1.3.0 // indirect
 	github.com/jaegertracing/jaeger v1.21.0
-	github.com/jsternberg/zap-logfmt v1.0.0
+	github.com/jsternberg/zap-logfmt v1.2.0
 	github.com/klauspost/compress v1.11.7
 	github.com/minio/minio-go/v7 v7.0.10
 	github.com/olekukonko/tablewriter v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -896,8 +896,9 @@ github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
-github.com/jsternberg/zap-logfmt v1.0.0 h1:0Dz2s/eturmdUS34GM82JwNEdQ9hPoJgqptcEKcbpzY=
 github.com/jsternberg/zap-logfmt v1.0.0/go.mod h1:uvPs/4X51zdkcm5jXl5SYoN+4RK21K8mysFmDaM/h+o=
+github.com/jsternberg/zap-logfmt v1.2.0 h1:1v+PK4/B48cy8cfQbxL4FmmNZrjnIMr2BsnyEmXqv2o=
+github.com/jsternberg/zap-logfmt v1.2.0/go.mod h1:kz+1CUmCutPWABnNkOu9hOHKdT2q3TDYCcsFy9hpqb0=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -576,7 +576,7 @@ github.com/json-iterator/go
 github.com/jstemmer/go-junit-report
 github.com/jstemmer/go-junit-report/formatter
 github.com/jstemmer/go-junit-report/parser
-# github.com/jsternberg/zap-logfmt v1.0.0
+# github.com/jsternberg/zap-logfmt v1.2.0
 ## explicit
 github.com/jsternberg/zap-logfmt
 # github.com/julienschmidt/httprouter v1.3.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Change logging format of tempo-vulture from json to logfmt to be more consistent with the other applications.

Before:
```
2021-05-03T16:47:41.490+0200    INFO    tempo-vulture/main.go:84        sending trace   {"write_trace_id": "0f76bf113f57aa7b4acb6bfd29f97c20"}
2021-05-03T16:47:56.485+0200    INFO    tempo-vulture/main.go:84        sending trace   {"write_trace_id": "06739b5d43f529657602bebb64ab056a"}
2021-05-03T16:47:56.485+0200    INFO    tempo-vulture/main.go:227       querying Tempo  {"query_trace_id": "7602bebb64ab056a06739b5d43f52965", "tempo_query_url": "http://localhost:3100/api/traces/7602bebb64ab056a06739b5d43f52965"}
2021-05-03T16:48:11.489+0200    INFO    tempo-vulture/main.go:84        sending trace   {"write_trace_id": "7e56ec89b470e7cd245e8b73b82edab5"}
2021-05-03T16:48:26.483+0200    INFO    tempo-vulture/main.go:227       querying Tempo  {"query_trace_id": "245e8b73b82edab57e56ec89b470e7cd", "tempo_query_url": "http://localhost:3100/api/traces/245e8b73b82edab57e56ec89b470e7cd"}
2021-05-03T16:48:26.483+0200    INFO    tempo-vulture/main.go:84        sending trace   {"write_trace_id": "686f4176266c66a753bc094f645fe387"}
```
After:
```
T=2021-05-03T17:56:22.763+0200 L=INFO M="sending trace" write_trace_id=6065a3f47309d31e102bc65a859065da
T=2021-05-03T17:56:37.757+0200 L=INFO M="querying Tempo" query_trace_id=1bcb82f885c4270c4410d4120603b69a tempo_query_url=http://localhost:3100/api/traces/1bcb82f885c4270c4410d4120603b69a
T=2021-05-03T17:56:37.757+0200 L=INFO M="sending trace" write_trace_id=5ac93de0aa1551ff3b7f37152c943aa4
T=2021-05-03T17:56:52.762+0200 L=INFO M="sending trace" write_trace_id=51c8d70c36b2906169b5d4e8c74583ef
T=2021-05-03T17:57:07.756+0200 L=INFO M="querying Tempo" query_trace_id=4ccf3eae510fad3622f3b702365d3d1c tempo_query_url=http://localhost:3100/api/traces/4ccf3eae510fad3622f3b702365d3d1c
T=2021-05-03T17:57:07.756+0200 L=INFO M="sending trace" write_trace_id=4adf6cd8a34e0f42190ecca53b190d41
T=2021-05-03T17:57:22.760+0200 L=INFO M="sending trace" write_trace_id=35c21f05186fcdab47e58c6f046b828c
```

I've also updated the version of zap-logfmt from v1.0.0 to v1.2.0, which gives us the [exact same configuration as the agent](https://github.com/grafana/agent/blob/main/go.mod#L17).

⚠️  I've not been able to run `make vendor-check` successfully yet (proto gen crashes on Apple M1)
