### PR TITLE
Support for Zipkin: CombineTraces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [ENHANCEMENT] Improve WAL Replay by not rebuilding the WAL. [#668](https://github.com/grafana/tempo/pull/668)
 * [ENHANCEMENT] Add config option to disable write extension to the ingesters. [#677](https://github.com/grafana/tempo/pull/677)
 * [ENHANCEMENT] Preallocate byte slices on ingester request unmarshal. [#679](https://github.com/grafana/tempo/pull/679)
+* [ENHANCEMENT] Zipkin Support - CombineTraces. [#688](https://github.com/grafana/tempo/pull/688)
 
 ## v0.7.0
 

--- a/pkg/util/trace_test.go
+++ b/pkg/util/trace_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"bytes"
 	"fmt"
+	"hash/fnv"
 	"math/rand"
 	"testing"
 
@@ -272,5 +273,16 @@ func TestSortTrace(t *testing.T) {
 		SortTrace(tt.input)
 
 		assert.Equal(t, tt.expected, tt.input)
+	}
+}
+
+func BenchmarkTokenForID(b *testing.B) {
+	h := fnv.New32()
+	id := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	buffer := make([]byte, 4)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = tokenForID(h, buffer, 0, id)
 	}
 }


### PR DESCRIPTION
**What this PR does**:
Uses span.Kind to differentiate between zipkin client/server spans in combine.

**Which issue(s) this PR fixes**:
Related to #682 and #687 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`