### PR TITLE
Fix Query Frontend grpc settings to avoid noisy error log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [ENHANCEMENT] Add config option to disable write extension to the ingesters. [#677](https://github.com/grafana/tempo/pull/677)
 * [ENHANCEMENT] Preallocate byte slices on ingester request unmarshal. [#679](https://github.com/grafana/tempo/pull/679)
 * [ENHANCEMENT] Zipkin Support - CombineTraces. [#688](https://github.com/grafana/tempo/pull/688)
+* [CHANGE] Fix Query Frontend grpc settings to avoid noisy error log. [#690](https://github.com/grafana/tempo/pull/690)
 
 ## v0.7.0
 

--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -71,8 +71,13 @@ func (c *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 	// Server settings
 	flagext.DefaultValues(&c.Server)
 	c.Server.LogLevel.RegisterFlags(f)
+
+	// The following GRPC server settings are added to address this issue - https://github.com/grafana/tempo/issues/493
+	// The settings prevent the grpc server from sending a GOAWAY message if a client sends heartbeat messages
+	// too frequently (due to lack of real traffic).
 	c.Server.GRPCServerMinTimeBetweenPings = 10 * time.Second
 	c.Server.GRPCServerPingWithoutStreamAllowed = true
+
 	f.IntVar(&c.Server.HTTPListenPort, "server.http-listen-port", 80, "HTTP server listen port.")
 	f.IntVar(&c.Server.GRPCListenPort, "server.grpc-listen-port", 9095, "gRPC server listen port.")
 

--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"time"
 
 	cortex_frontend "github.com/cortexproject/cortex/pkg/frontend/v1"
 	"github.com/cortexproject/cortex/pkg/ring"
@@ -70,6 +71,8 @@ func (c *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 	// Server settings
 	flagext.DefaultValues(&c.Server)
 	c.Server.LogLevel.RegisterFlags(f)
+	c.Server.GRPCServerMinTimeBetweenPings = 10 * time.Second
+	c.Server.GRPCServerPingWithoutStreamAllowed = true
 	f.IntVar(&c.Server.HTTPListenPort, "server.http-listen-port", 80, "HTTP server listen port.")
 	f.IntVar(&c.Server.GRPCListenPort, "server.grpc-listen-port", 9095, "gRPC server listen port.")
 

--- a/operations/kube-manifests/Namespace-tracing.yaml
+++ b/operations/kube-manifests/Namespace-tracing.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tracing


### PR DESCRIPTION
Signed-off-by: Annanay <annanayagarwal@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Fix Query Frontend GRPC settings to fix the noisy error message 

```
caller=frontend_processor.go:59 msg="error processing requests" address=127.0.0.1:9095 err="rpc error: code = Unavailable desc = transport is closing"
```

Thanks to @pstibrany for digging into this in Cortex - https://github.com/cortexproject/cortex/issues/3606#issuecomment-745179803

**Which issue(s) this PR fixes**:
Fixes #493 

**Checklist**
- NA Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`