### PR TITLE
Vulture: fix segmentation fault that occurs if queryTempoAndAnalyse returns nil, err

### DIFF
--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -67,6 +67,8 @@ func main() {
 		zapcore.DebugLevel,
 	))
 
+	logger.Info("Tempo Vulture starting")
+
 	startTime := time.Now().Unix()
 	tickerWrite := time.NewTicker(tempoWriteBackoffDuration)
 	tickerRead := time.NewTicker(tempoReadBackoffDuration)
@@ -221,8 +223,8 @@ func generateRandomInt(min int64, max int64) int64 {
 	return number
 }
 
-func queryTempoAndAnalyze(baseURL string, traceID string) (*traceMetrics, error) {
-	tm := &traceMetrics{
+func queryTempoAndAnalyze(baseURL string, traceID string) (traceMetrics, error) {
+	tm := traceMetrics{
 		requested: 1,
 	}
 
@@ -240,7 +242,7 @@ func queryTempoAndAnalyze(baseURL string, traceID string) (*traceMetrics, error)
 			tm.requestFailed++
 		}
 		logger.Error("error querying Tempo", zap.Error(err))
-		return nil, err
+		return tm, err
 	}
 
 	if len(trace.Batches) == 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Fixes segmentation fault if `queryTempoAndAnalyse` returns nil, err. Introduced by the previous PR #689 🙈 

The log _Tempo Vulture starting_ accidentally got removed in a previous PR.
