### PR TITLE
Add default DNSLookupPeriod option in querier frontend_worker initialization 

### DIFF
--- a/modules/querier/config.go
+++ b/modules/querier/config.go
@@ -30,6 +30,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 			MaxSendMsgSize:  16 << 20,
 			GRPCCompression: "gzip",
 		},
+		DNSLookupPeriod: 10 * time.Second,
 	}
 
 	f.StringVar(&cfg.Worker.FrontendAddress, prefix+".frontend-address", "", "Address of query frontend service, in host:port format.")


### PR DESCRIPTION
**What this PR does**:
Add default DNSLookupPeriod option in querier frontend_worker initialization 

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

Querier was resolving the frontend_worker dns at every access, which made it use 100% of the cpu and DDOS our dns server.
Adding the option `dns_lookup_duration: 10s` to tempo config worked but I think this option should be set to a default value anyway:
```
...
  querier:
    frontend_worker:
      dns_lookup_duration: 10s
      frontend_address: query-frontend-discovery.tempo.svc.cluster.local.:9095
```

I got the default value from [here](https://github.com/cortexproject/cortex/blob/89a0232eee0dd60f3a502a14da8f54bbe2d7e031/pkg/querier/worker/worker.go#L40)