### PR TITLE
Jsonnet: fix tempoPushUrl of vulture

### DIFF
--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -35,7 +35,7 @@
     },
     vulture: {
       replicas: 0,
-      tempoPushUrl: 'http://distributor:14250',
+      tempoPushUrl: 'http://distributor',
       tempoQueryUrl: 'http://query-frontend:3100',
       tempoOrgId: '',
     },


### PR DESCRIPTION
**What this PR does**:

The port number is already added by vulture itself. Specifying the port again in the Jsonnet config leads to a double entry and causes the following error message:

```
T=2021-05-27T13:49:10.966Z L=ERROR M="error pushing batch to Tempo" org_id= write_trace_id=65d82e9fe247036e0a9086c9f4a8eebb seed=1622123340 error="rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp: address distributor:14250:14250: too many colons in address\""
```

The port is already added here:
https://github.com/grafana/tempo/blob/85bdea314ac7100948d3069021ff410f5d153917/cmd/tempo-vulture/main.go#L157-L158

Alternative solution is to not add the port in the Go code and leave it in the Jsonnet config, but this will have more impact downstream.

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`