### PR TITLE
Add HTTP endpoint /api/echo to query-frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   This change requires a specific rollout process to prevent dropped spans. First, rollout everything except distributors. After all ingesters have updated
   you can then rollout distributors to the latest version. This is due to changes in the communication between ingesters <-> distributors.
 * [ENHANCEMENT] Allow setting the bloom filter shard size with support dynamic shard count.[#644](https://github.com/grafana/tempo/pull/644)
+* [ENHANCEMENT] Add a new endpoint `/api/echo` to test the query frontend is reachable. [#714](https://github.com/grafana/tempo/pull/714)
 * [CHANGE] Fix Query Frontend grpc settings to avoid noisy error log. [#690](https://github.com/grafana/tempo/pull/690)
 * [CHANGE] GCS SDK update v1.12.0 => v.15.0, ReadAllWithEstimate used in GCS/S3 backends. [#693](https://github.com/grafana/tempo/pull/693)
 

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -58,6 +58,9 @@ func TestAllInOne(t *testing.T) {
 
 	hexID := fmt.Sprintf("%016x%016x", batch.Spans[0].TraceIdHigh, batch.Spans[0].TraceIdLow)
 
+	// test echo
+	assertEcho(t, "http://"+tempo.Endpoint(3100)+"/api/echo")
+
 	// ensure trace is created in ingester (trace_idle_time has passed)
 	require.NoError(t, tempo.WaitSumMetrics(cortex_e2e.Equals(1), "tempo_ingester_traces_created_total"))
 
@@ -116,6 +119,9 @@ func TestAzuriteAllInOne(t *testing.T) {
 	require.NoError(t, tempo.WaitSumMetrics(cortex_e2e.Equals(1), "tempo_distributor_spans_received_total"))
 
 	hexID := fmt.Sprintf("%016x%016x", batch.Spans[0].TraceIdHigh, batch.Spans[0].TraceIdLow)
+
+	// test echo
+	assertEcho(t, "http://"+tempo.Endpoint(3100)+"/api/echo")
 
 	// ensure trace is created in ingester (trace_idle_time has passed)
 	require.NoError(t, tempo.WaitSumMetrics(cortex_e2e.Equals(1), "tempo_ingester_traces_created_total"))
@@ -185,6 +191,9 @@ func TestMicroservices(t *testing.T) {
 	require.NoError(t, tempoDistributor.WaitSumMetrics(cortex_e2e.Equals(1), "tempo_distributor_spans_received_total"))
 
 	hexID := fmt.Sprintf("%016x%016x", batch.Spans[0].TraceIdHigh, batch.Spans[0].TraceIdLow)
+
+	// test echo
+	assertEcho(t, "http://"+tempoQueryFrontend.Endpoint(3100)+"/api/echo")
 
 	// ensure trace is created in ingester (trace_idle_time has passed)
 	require.NoError(t, tempoIngester1.WaitSumMetrics(cortex_e2e.Equals(1), "tempo_ingester_traces_created_total"))
@@ -263,6 +272,13 @@ func makeThriftBatchWithSpanCount(n int) *thrift.Batch {
 		})
 	}
 	return &thrift.Batch{Spans: spans}
+}
+
+func assertEcho(t *testing.T, url string) {
+	res, err := cortex_e2e.GetRequest(url)
+	require.NoError(t, err)
+	require.Equal(t, 200, res.StatusCode)
+	defer res.Body.Close()
 }
 
 //nolint:unparam


### PR DESCRIPTION
**What this PR does**:
Adds a new endpoint `/api/echo` that always returns with 200  and a body `echo`.

**Which issue(s) this PR fixes**:
Closes #624

**Checklist**
- [x] Tests updated
- [ ] Documentation added --> should be captured in #428
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`