### PR TITLE
Bump version of minio

### DIFF
--- a/example/docker-compose/docker-compose.s3.minio.yaml
+++ b/example/docker-compose/docker-compose.s3.minio.yaml
@@ -17,7 +17,7 @@ services:
       - minio
 
   minio:
-    image: minio/minio:RELEASE.2020-07-27T18-37-02Z
+    image: minio/minio:RELEASE.2021-05-26T00-22-46Z
     environment:
       - MINIO_ACCESS_KEY=tempo
       - MINIO_SECRET_KEY=supersecret

--- a/example/tk/lib/minio/minio.libsonnet
+++ b/example/tk/lib/minio/minio.libsonnet
@@ -5,7 +5,7 @@
   local deployment = $.apps.v1.deployment,
 
   minio_container::
-    container.new('minio', 'minio/minio:RELEASE.2020-07-27T18-37-02Z') +
+    container.new('minio', 'minio/minio:RELEASE.2021-05-26T00-22-46Z') +
     container.withPorts([
       containerPort.new('minio', 9000),
     ]) +

--- a/integration/microservices/docker-compose.yaml
+++ b/integration/microservices/docker-compose.yaml
@@ -50,7 +50,7 @@ services:
       - distributor # inverted relationship here to add delay for minio
 
   minio:
-    image: minio/minio:RELEASE.2020-07-27T18-37-02Z
+    image: minio/minio:RELEASE.2021-05-26T00-22-46Z
     environment:
       - MINIO_ACCESS_KEY=tempo
       - MINIO_SECRET_KEY=supersecret


### PR DESCRIPTION
The older version of minio does not work on Apple M1.

FYI, Minio has quietly changed their license to AGPL a month ago, but this shouldn't impact us.
https://github.com/minio/minio/commit/069432566fcfac1f1053677cc925ddafd750730a