### PR TITLE
Fix 500s on query frontend rollout

### DIFF
--- a/modules/querier/config.go
+++ b/modules/querier/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	cortex_worker "github.com/cortexproject/cortex/pkg/querier/worker"
+	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/grpcclient"
 )
 
@@ -29,6 +30,11 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 			MaxRecvMsgSize:  100 << 20,
 			MaxSendMsgSize:  16 << 20,
 			GRPCCompression: "gzip",
+			BackoffConfig: util.BackoffConfig{ // the max possible backoff should be lesser than QueryTimeout, with room for actual query response time
+				MinBackoff: 100 * time.Millisecond,
+				MaxBackoff: 1 * time.Second,
+				MaxRetries: 5,
+			},
 		},
 		DNSLookupPeriod: 10 * time.Second,
 	}

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -124,7 +124,6 @@ func (q *Querier) running(ctx context.Context) error {
 	return nil
 }
 
-// Called after distributor is asked to stop via StopAsync.
 func (q *Querier) stopping(_ error) error {
 	if q.subservices != nil {
 		return services.StopManagerAndAwaitStopped(context.Background(), q.subservices)


### PR DESCRIPTION
Cortex was setting these defaults using flags, we did not port them over correctly when we added these configs to our querier.

Signed-off-by: Annanay <annanayagarwal@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
-->
