### PR TITLE
Add OTLP port to docker-compose example

### DIFF
--- a/example/docker-compose/docker-compose.yaml
+++ b/example/docker-compose/docker-compose.yaml
@@ -10,6 +10,8 @@ services:
     ports:
       - "14268"  # jaeger ingest
       - "3100"   # tempo
+      - "55680"  # otlp grpc
+      - "55681"  # otlp http
       - "9411"   # zipkin
 
   synthetic-load-generator:


### PR DESCRIPTION
**What this PR does**:

Expose the OpenTelemetry ports in the default `docker-compose.yaml` file. OpenTelemetry is one if the most commonly used frameworks to work with traces and a lot of tools use OTLP so I think it would make sense to expose the OTLP ports similar to Jaeger and Zipkin by default.

**Which issue(s) this PR fixes**:
No issues

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`