### PR TITLE
Add Grafana to Tanka examples

### DIFF
--- a/example/tk/lib/grafana/main.libsonnet
+++ b/example/tk/lib/grafana/main.libsonnet
@@ -1,0 +1,61 @@
+local k = import 'ksonnet-util/kausal.libsonnet';
+
+{
+  local configMap = $.core.v1.configMap,
+  local container = $.core.v1.container,
+  local volumeMount = $.core.v1.volumeMount,
+  local deployment = $.apps.v1.deployment,
+  local volume = $.core.v1.volume,
+  local service = $.core.v1.service,
+  local servicePort = service.mixin.spec.portsType,
+
+  _config +:: {
+    tempo_query_url: 'http://tempo:3100',
+  },
+
+  grafana_configmap:
+    configMap.new('grafana-datasources') +
+    configMap.withData({
+      'datasource.yaml': k.util.manifestYaml({
+        apiVersion: 1,
+        datasources: [
+          {
+            name: 'Tempo',
+            type: 'tempo',
+            access: 'proxy',
+            orgId: 1,
+            url: $._config.tempo_query_url,
+            basicAuth: false,
+            isDefault: true,
+            version: 1,
+            editable: false,
+            apiVersion: 1,
+            uid: 'tempo',
+          },
+        ],
+      }),
+    }),
+
+  grafana_container::
+    container.new('grafana', 'grafana/grafana:7.5.7') +
+    container.withVolumeMounts([
+      volumeMount.new('grafana-datasources', '/etc/grafana/provisioning/datasources'),
+    ]) +
+    container.withEnvMap({
+      GF_AUTH_ANONYMOUS_ENABLED: 'true',
+      GF_AUTH_ANONYMOUS_ORG_ROLE: 'Admin',
+      GF_AUTH_DISABLE_LOGIN_FORM: 'true',
+    }),
+
+  grafana_deployment:
+    deployment.new('grafana', 1, [ $.grafana_container ], { app: 'grafana' }) +
+    deployment.mixin.spec.template.spec.withVolumes([
+      volume.fromConfigMap('grafana-datasources', $.grafana_configmap.metadata.name),
+    ]),
+
+  grafana_service:
+    $.util.serviceFor($.grafana_deployment)
+    + service.mixin.spec.withPortsMixin([
+      servicePort.withName('http').withPort(3000).withTargetPort(3000),
+    ]),
+}

--- a/example/tk/readme.md
+++ b/example/tk/readme.md
@@ -16,7 +16,7 @@ The Jsonnet is meant to be applied to with [tanka](https://github.com/grafana/ta
 Create a cluster with 3 nodes
 
 ```console
-k3d cluster create tempo --api-port 6443 --port "16686:80@loadbalancer"
+k3d cluster create tempo --api-port 6443 --port "3000:80@loadbalancer"
 ```
 
 If you wish to use a local image, you can import these into k3d
@@ -60,7 +60,7 @@ kubectl logs synthetic-load-generator-???
 20/03/03 21:30:02 INFO ScheduledTraceGenerator: Emitted traceId 23a09a0efd0d1ef0 for service frontend route /cart
 ```
 
-Extract a trace id and view it in your browser at `http://localhost:16686/trace/<traceid>`
+Extract a trace id and view it in Grafana at http://localhost:3000/explore
 
 ### Clean up
 

--- a/example/tk/tempo-single-binary/main.jsonnet
+++ b/example/tk/tempo-single-binary/main.jsonnet
@@ -1,7 +1,8 @@
 local tempo = import '../../../operations/jsonnet/single-binary/tempo.libsonnet';
 local load = import 'synthetic-load-generator/main.libsonnet';
+local grafana = import 'grafana/main.libsonnet';
 
-load + tempo {
+grafana + load + tempo {
     _images+:: {
         // override images here if desired
     },
@@ -26,7 +27,7 @@ load + tempo {
             containerPort.new('jaeger-http', 14268),
         ]),
 
-    local ingress = $.extensions.v1beta1.ingress,
+    local ingress = $.networking.v1beta1.ingress,
     ingress:
         ingress.new() +
         ingress.mixin.metadata
@@ -37,8 +38,8 @@ load + tempo {
         ingress.mixin.spec.withRules(
             ingress.mixin.specType.rulesType.mixin.http.withPaths(
                 ingress.mixin.spec.rulesType.mixin.httpType.pathsType.withPath('/') +
-                ingress.mixin.specType.mixin.backend.withServiceName('tempo') +
-                ingress.mixin.specType.mixin.backend.withServicePort(16686)
+                ingress.mixin.specType.mixin.backend.withServiceName('grafana') +
+                ingress.mixin.specType.mixin.backend.withServicePort(3000)
             ),
         ),
 }


### PR DESCRIPTION
**What this PR does**

- Replace Jaeger UI in example by Grafana
- Reduce replicas of memcached to 1, with 3 replicas the cluster will often run out of CPU (on my machine at least)

Follow up from #720