### PR TITLE
Make Mario Rodriguez a maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-* @joe-elliott @annanay25 @mdisibio @dgzlopes
-/docs/ @achatterjee-grafana @joe-elliott @annanay25 @mdisibio @dgzlopes
+* @joe-elliott @annanay25 @mdisibio @dgzlopes @mapno
+/docs/ @achatterjee-grafana @joe-elliott @annanay25 @mdisibio @dgzlopes @mapno

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -49,6 +49,7 @@ The current team members are:
 - Annanay Agarwal - [annanay25](https://github.com/annanay25) ([Grafana Labs](https://grafana.com/))
 - Daniel González - [dgzlopes](https://github.com/dgzlopes) ([k6.io](https://k6.io/))
 - Joe Elliott - [joe-elliott](https://github.com/joe-elliott) ([Grafana Labs](https://grafana.com/))
+- Mario Rodriguez - [mapno](https://github.com/mapno) ([Grafana Labs](https://grafana.com/))
 - Marty Disibio - [mdisibio](https://github.com/mdisibio) ([Grafana Labs](https://grafana.com/))
 
 ### Maintainers

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,4 +1,5 @@
 * @annanay25
 * @dgzlopes
 * @joe-elliott
+* @mapno
 * @mdisibio


### PR DESCRIPTION
Proposal to make Mario Rodriguez @mapno a maintainer. An approving review is a vote in favor.

- [Agent Work](https://github.com/grafana/agent/pulls?q=is%3Apr+author%3Amapno+is%3Aclosed)
- [Tempo Work](https://github.com/grafana/tempo/pulls?q=is%3Apr+author%3Amapno+is%3Aclosed)
- [Tempo Reviews](https://github.com/grafana/tempo/pulls?q=is%3Apr+reviewed-by%3Amapno+is%3Aclosed)

Additionally Mario has participated in the public slack and community forums helping people get started with and operate Tempo.
