### PR TITLE
Cleanup tempo-cli block meta handling and docs

### DIFF
--- a/cmd/tempo-cli/cmd-list-block.go
+++ b/cmd/tempo-cli/cmd-list-block.go
@@ -53,32 +53,22 @@ func dumpBlock(r tempodb_backend.Reader, c tempodb_backend.Compactor, tenantID s
 
 	unifiedMeta := getMeta(meta, compactedMeta, windowRange)
 
-	fmt.Println("ID            : ", unifiedMeta.id)
-	fmt.Println("Version       : ", unifiedMeta.version)
-	fmt.Println("Total Objects : ", unifiedMeta.objects)
-	fmt.Println("Data Size     : ", humanize.Bytes(unifiedMeta.size))
-	fmt.Println("Encoding      : ", unifiedMeta.encoding)
-	fmt.Println("Level         : ", unifiedMeta.compactionLevel)
+	fmt.Println("ID            : ", unifiedMeta.BlockID)
+	fmt.Println("Version       : ", unifiedMeta.Version)
+	fmt.Println("Total Objects : ", unifiedMeta.TotalObjects)
+	fmt.Println("Data Size     : ", humanize.Bytes(unifiedMeta.Size))
+	fmt.Println("Encoding      : ", unifiedMeta.Encoding)
+	fmt.Println("Level         : ", unifiedMeta.CompactionLevel)
 	fmt.Println("Window        : ", unifiedMeta.window)
-	fmt.Println("Start         : ", unifiedMeta.start)
-	fmt.Println("End           : ", unifiedMeta.end)
-	fmt.Println("Duration      : ", fmt.Sprint(unifiedMeta.end.Sub(unifiedMeta.start).Round(time.Second)))
-	fmt.Println("Age           : ", fmt.Sprint(time.Since(unifiedMeta.end).Round(time.Second)))
+	fmt.Println("Start         : ", unifiedMeta.StartTime)
+	fmt.Println("End           : ", unifiedMeta.EndTime)
+	fmt.Println("Duration      : ", fmt.Sprint(unifiedMeta.EndTime.Sub(unifiedMeta.StartTime).Round(time.Second)))
+	fmt.Println("Age           : ", fmt.Sprint(time.Since(unifiedMeta.EndTime).Round(time.Second)))
 
 	if scan {
 		fmt.Println("Scanning block contents.  Press CRTL+C to quit ...")
 
-		en, err := tempodb_backend.ParseEncoding(unifiedMeta.encoding)
-		if err != nil {
-			return err
-		}
-
-		block, err := encoding.NewBackendBlock(&tempodb_backend.BlockMeta{
-			Encoding: en,
-			Version:  unifiedMeta.version,
-			TenantID: tenantID,
-			BlockID:  id,
-		}, r)
+		block, err := encoding.NewBackendBlock(&unifiedMeta.BlockMeta, r)
 		if err != nil {
 			return err
 		}
@@ -118,6 +108,7 @@ func dumpBlock(r tempodb_backend.Reader, c tempodb_backend.Compactor, tenantID s
 		for {
 			objID, obj, err := iter.Next(ctx)
 			if err == io.EOF {
+				fmt.Println("got eof")
 				break
 			} else if err != nil {
 				return err

--- a/cmd/tempo-cli/cmd-list-block.go
+++ b/cmd/tempo-cli/cmd-list-block.go
@@ -108,7 +108,6 @@ func dumpBlock(r tempodb_backend.Reader, c tempodb_backend.Compactor, tenantID s
 		for {
 			objID, obj, err := iter.Next(ctx)
 			if err == io.EOF {
-				fmt.Println("got eof")
 				break
 			} else if err != nil {
 				return err

--- a/cmd/tempo-cli/cmd-list-blocks.go
+++ b/cmd/tempo-cli/cmd-list-blocks.go
@@ -53,30 +53,30 @@ func displayResults(results []blockStats, windowDuration time.Duration, includeC
 			s := ""
 			switch c {
 			case "id":
-				s = r.id.String()
+				s = r.BlockID.String()
 			case "lvl":
-				s = strconv.Itoa(int(r.compactionLevel))
+				s = strconv.Itoa(int(r.CompactionLevel))
 			case "objects":
-				s = strconv.Itoa(r.objects)
+				s = strconv.Itoa(r.TotalObjects)
 			case "size":
-				s = fmt.Sprintf("%v", humanize.Bytes(r.size))
+				s = fmt.Sprintf("%v", humanize.Bytes(r.Size))
 			case "encoding":
-				s = r.encoding
+				s = r.Encoding.String()
 			case "vers":
-				s = r.version
+				s = r.Version
 			case "window":
 				// Display compaction window in human-readable format
 				window := time.Unix(r.window*int64(windowDuration.Seconds()), 0).UTC()
 				s = window.Format(time.RFC3339)
 			case "start":
-				s = r.start.Format(time.RFC3339)
+				s = r.StartTime.Format(time.RFC3339)
 			case "end":
-				s = r.end.Format(time.RFC3339)
+				s = r.EndTime.Format(time.RFC3339)
 			case "duration":
 				// Time range included in bucket
-				s = fmt.Sprint(r.end.Sub(r.start).Round(time.Second))
+				s = fmt.Sprint(r.EndTime.Sub(r.StartTime).Round(time.Second))
 			case "age":
-				s = fmt.Sprint(time.Since(r.end).Round(time.Second))
+				s = fmt.Sprint(time.Since(r.EndTime).Round(time.Second))
 			case "cmp":
 				// Compacted?
 				if r.compacted {
@@ -90,8 +90,8 @@ func displayResults(results []blockStats, windowDuration time.Duration, includeC
 		}
 
 		out = append(out, line)
-		totalObjects += r.objects
-		totalBytes += r.size
+		totalObjects += r.TotalObjects
+		totalBytes += r.Size
 	}
 
 	footer := make([]string, 0)

--- a/cmd/tempo-cli/cmd-list-compactionsummary.go
+++ b/cmd/tempo-cli/cmd-list-compactionsummary.go
@@ -40,7 +40,7 @@ func displayCompactionSummary(results []blockStats) {
 	resultsByLevel := make(map[int][]blockStats)
 	var levels []int
 	for _, r := range results {
-		l := int(r.compactionLevel)
+		l := int(r.CompactionLevel)
 
 		s, ok := resultsByLevel[l]
 		if !ok {
@@ -68,26 +68,26 @@ func displayCompactionSummary(results []blockStats) {
 		var newest time.Time
 		var oldest time.Time
 		for _, r := range resultsByLevel[l] {
-			sizeSum += r.size
-			countSum += r.objects
+			sizeSum += r.Size
+			countSum += r.TotalObjects
 
-			if r.size < sizeMin || sizeMin == 0 {
-				sizeMin = r.size
+			if r.Size < sizeMin || sizeMin == 0 {
+				sizeMin = r.Size
 			}
-			if r.size > sizeMax {
-				sizeMax = r.size
+			if r.Size > sizeMax {
+				sizeMax = r.Size
 			}
-			if r.objects < countMin || countMin == 0 {
-				countMin = r.objects
+			if r.TotalObjects < countMin || countMin == 0 {
+				countMin = r.TotalObjects
 			}
-			if r.objects > countMax {
-				countMax = r.objects
+			if r.TotalObjects > countMax {
+				countMax = r.TotalObjects
 			}
-			if r.start.Before(oldest) || oldest.IsZero() {
-				oldest = r.start
+			if r.StartTime.Before(oldest) || oldest.IsZero() {
+				oldest = r.StartTime
 			}
-			if r.end.After(newest) {
-				newest = r.end
+			if r.EndTime.After(newest) {
+				newest = r.EndTime
 			}
 		}
 

--- a/docs/tempo/website/operations/tempo_cli.md
+++ b/docs/tempo/website/operations/tempo_cli.md
@@ -74,20 +74,20 @@ Arguments:
 
 Options:
 - `--include-compacted` Include blocks that have been compacted. Default behavior is to display only active blocks.
-- `--load-index` Also load the block indexes and perform integrity checks for duplicates. **Note:** This can be a resource intensive process.
 
 **Output:**
 Explanation of output:
 - `ID` Block ID.
 - `Lvl` Compaction level of the block.
-- `Count` Number of objects stored in the block.
+- `Objects` Number of objects stored in the block.
+- `Size` Data size of the block after any compression.
+- `Encoding` Block encoding (compression algorithm).
+- `Vers` Block version.
 - `Window` The window of time that was considered for compaction purposes.
 - `Start` The earliest timestamp stored in the block.
 - `End` The latest timestamp stored in the block.
-- `Age` The age of the block.
 - `Duration`Duration between the start and end time.
-- `Idx` Number of records stored in the index (present when --load-index is specified).
-- `Dupe` Number of duplicate entries in the index (present when --load-index is specified). Should be zero.
+- `Age` The age of the block.
 - `Cmp` Whether the block has been compacted (present when --include-compacted is specified).
 
 **Example:**
@@ -112,4 +112,51 @@ Options:
 **Example:**
 ```bash
 tempo-cli list block -c ./tempo.yaml single-tenant ca314fba-efec-4852-ba3f-8d2b0bbf69f1
+```
+
+## List Compaction Summary
+Summarizes information about all blocks for the given tenant based on compaction level. This command is useful to analyze or troubleshoot compactor behavior.
+
+```bash
+tempo-cli list compaction-summary <tenant-id>
+```
+
+Arguments:
+- `tenant-id` The tenant ID.  Use `single-tenant` for single tenant setups.
+
+**Example:**
+```bash
+tempo-cli list compaction-summary -c ./tempo.yaml single-tenant
+```
+
+## List Index
+Lists basic index info for the given block.
+
+```bash
+tempo-cli list index <tenant-id> <block-id>
+```
+
+Arguments:
+- `tenant-id` The tenant ID.  Use `single-tenant` for single tenant setups.
+- `block-id` The block ID as UUID string.
+
+**Example:**
+```bash
+tempo-cli list index -c ./tempo.yaml single-tenant ca314fba-efec-4852-ba3f-8d2b0bbf69f1
+```
+
+## View Index
+View the index contents for the given block.
+
+```bash
+tempo-cli view index <tenant-id> <block-id>
+```
+
+Arguments:
+- `tenant-id` The tenant ID.  Use `single-tenant` for single tenant setups.
+- `block-id` The block ID as UUID string.
+
+**Example:**
+```bash
+tempo-cli view index -c ./tempo.yaml single-tenant ca314fba-efec-4852-ba3f-8d2b0bbf69f1
 ```


### PR DESCRIPTION
**What this PR does**:
The tempo-cli list block --scan command was broken when new meta fields were added such as DataEncoding, and IndexPageSizeBytes. This cleans up the meta handling so that it is less brittle.  Also updates documentation for recently added commands.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`