### PR TITLE
replace ioutil.ReadAll with io.ReadAll

### DIFF
--- a/cmd/tempo-query/tempo/plugin.go
+++ b/cmd/tempo-query/tempo/plugin.go
@@ -3,7 +3,7 @@ package tempo
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -74,7 +74,7 @@ func (b *Backend) GetTrace(ctx context.Context, traceID jaeger.TraceID) (*jaeger
 		return nil, jaeger_spanstore.ErrTraceNotFound
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading response from tempo: %w", err)
 	}

--- a/modules/frontend/deduper.go
+++ b/modules/frontend/deduper.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -54,7 +55,7 @@ func (s spanIDDeduper) Do(req *http.Request) (*http.Response, error) {
 	}
 
 	if resp.StatusCode == http.StatusOK {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		defer resp.Body.Close()
 		if err != nil {
 			return nil, err

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -2,6 +2,7 @@ package frontend
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -75,7 +76,7 @@ func NewTripperware(cfg Config, logger log.Logger, registerer prometheus.Registe
 
 			if resp != nil && resp.StatusCode == http.StatusOK && marshallingFormat == util.JSONTypeHeaderValue {
 				// if request is for application/json, unmarshal into proto object and re-marshal into json bytes
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				resp.Body.Close()
 				if err != nil {
 					return nil, errors.Wrap(err, "error reading response body at query frontend")

--- a/modules/frontend/querysharding.go
+++ b/modules/frontend/querysharding.go
@@ -155,7 +155,7 @@ func mergeResponses(ctx context.Context, rrs []RequestResponse) (*http.Response,
 	var shardMissCount = 0
 	for _, rr := range rrs {
 		if rr.Response.StatusCode == http.StatusOK {
-			body, err := ioutil.ReadAll(rr.Response.Body)
+			body, err := io.ReadAll(rr.Response.Body)
 			rr.Response.Body.Close()
 			if err != nil {
 				return nil, errors.Wrap(err, "error reading response body at query frontend")

--- a/modules/frontend/querysharding_test.go
+++ b/modules/frontend/querysharding_test.go
@@ -3,6 +3,7 @@ package frontend
 import (
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -166,9 +167,9 @@ func TestMergeResponses(t *testing.T) {
 			merged, err := mergeResponses(context.Background(), tt.requestResponse)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected.StatusCode, merged.StatusCode)
-			expectedBody, err := ioutil.ReadAll(tt.expected.Body)
+			expectedBody, err := io.ReadAll(tt.expected.Body)
 			assert.NoError(t, err)
-			actualBody, err := ioutil.ReadAll(merged.Body)
+			actualBody, err := io.ReadAll(merged.Body)
 			assert.NoError(t, err)
 			assert.Equal(t, expectedBody, actualBody)
 			if tt.expected.ContentLength > 0 {

--- a/tempodb/backend/readerat.go
+++ b/tempodb/backend/readerat.go
@@ -3,7 +3,6 @@ package backend
 import (
 	"context"
 	"io"
-	"io/ioutil"
 
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
@@ -75,7 +74,7 @@ func (r *allReader) ReadAt(ctx context.Context, p []byte, off int64) (int, error
 
 // ReadAll implements ContextReader
 func (r *allReader) ReadAll(ctx context.Context) ([]byte, error) {
-	return ioutil.ReadAll(r.r)
+	return io.ReadAll(r.r)
 }
 
 // Reader implements ContextReader


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Update usage of `ioutil.ReadAll` to `io.ReadAll` since the former was marked as deprecated in Go v1.16. From discussion on Slack with @mdisibio I gather that `ReadAllWithEstimate` is typically the preferred way now, however looking at the places where that function is used, there's usually a way to estimate the size of the buffer beforehand. The remaining uses of `ioutil.ReadAll` on the other hand are used to read the `Response` from an HTTP request; while it's entirely possible that the response has a `Content-Length` header, it's also not a guarantee.

**Which issue(s) this PR fixes**:
_none_

**Checklist**
- [ N/A ] Tests updated
- [ N/A ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`