### PR TITLE
Update build image of tempo-query - fixes Drone build

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -15,7 +15,7 @@ steps:
   - echo $(./tools/image-tag) > .tags
 
 - name: build-tempo-binary
-  image: golang:1.15.3-alpine
+  image: golang:1.16.0-alpine
   commands:
   - apk add make git
   - COMPONENT=tempo-query make exe


### PR DESCRIPTION
**What this PR does**:
The drone build of tempo-query is broken: https://drone.grafana.net/grafana/tempo/402/1/3

Relevant step:
```
1.15.3-alpine: Pulling from library/golang
Digest: sha256:df0119b970c8e5e9f0f5c40f6b55edddf616bab2b911927ebc3b361c469ea29c
Status: Downloaded newer image for golang:1.15.3-alpine
+ apk add make git
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/x86_64/APKINDEX.tar.gz
(1/6) Installing nghttp2-libs (1.41.0-r0)
(2/6) Installing libcurl (7.77.0-r0)
(3/6) Installing expat (2.2.9-r1)
(4/6) Installing pcre2 (10.35-r0)
(5/6) Installing git (2.26.3-r0)
(6/6) Installing make (4.3-r0)
Executing busybox-1.31.1-r19.trigger
OK: 22 MiB in 21 packages
+ COMPONENT=tempo-query make exe
GOOS=linux make tempo-query
make[1]: Entering directory '/drone/src'
GO111MODULE=on CGO_ENABLED=0 go build -mod vendor -ldflags "-X main.Branch=main -X main.Revision=efe07903 -X main.Version=efe07903" -o ./bin/linux/tempo-query-amd64  ./cmd/tempo-query
# github.com/grafana/tempo/cmd/tempo-query/tempo
cmd/tempo-query/tempo/plugin.go:77:15: undefined: io.ReadAll
note: module requires Go 1.16
make[1]: *** [Makefile:47: tempo-query] Error 2
make[1]: Leaving directory '/drone/src'
make: *** [Makefile:59: exe] Error 2
```

This is due to the PR #755 which introduced io.ReadAll [which is new in Go 1.16](https://golang.org/doc/go1.16#ioutil). Our Drone build for tempo-query was still using a Go 1.15 image.
