### PR TITLE
jsonnet: add connection_limit to $._config.memcached - increase default to 4096

### DIFF
--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -29,6 +29,7 @@
     },
     memcached: {
       replicas: 3,
+      connection_limit: 1024,
     },
     jaeger_ui: {
       base_path: '/',

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -29,7 +29,7 @@
     },
     memcached: {
       replicas: 3,
-      connection_limit: 1024,
+      connection_limit: 4096,
     },
     jaeger_ui: {
       base_path: '/',

--- a/operations/jsonnet/microservices/memcached.libsonnet
+++ b/operations/jsonnet/microservices/memcached.libsonnet
@@ -3,6 +3,7 @@ local memcached = import 'memcached/memcached.libsonnet';
 memcached {
   memcached+:: {
     cpu_limits:: null,
+    connection_limit: $._config.memcached.connection_limit,
 
     deployment: {},
 


### PR DESCRIPTION
**What this PR does**:
This makes overriding the connection limit more consistent with other configurations. Before you had to override connection limit at `$.memcached.connection_limit`, now you can use `$._config.memcached.connection_limit`
