### PR TITLE
Guard against negative dataLength while reading a page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main / unreleased
 
 * [FEATURE] Added the ability to hedge requests with all backends [#750](https://github.com/grafana/tempo/pull/750) (@joe-elliott)
+* [BUGFIX] Guard against negative dataLength [#763](https://github.com/grafana/tempo/pull/763) (@joe-elliott)
 
 ## v1.0.0
 

--- a/integration/microservices/docker-compose.yaml
+++ b/integration/microservices/docker-compose.yaml
@@ -16,6 +16,7 @@ services:
   ingester-0:
     image: tempo:latest
     command: "-target=ingester -config.file=/etc/tempo.yaml"
+    restart: always
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml
     ports:
@@ -28,6 +29,7 @@ services:
   ingester-1:
     image: tempo:latest
     command: "-target=ingester -config.file=/etc/tempo.yaml"
+    restart: always
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml
     ports:
@@ -40,6 +42,7 @@ services:
   ingester-2:
     image: tempo:latest
     command: "-target=ingester -config.file=/etc/tempo.yaml"
+    restart: always
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml
     ports:
@@ -50,7 +53,7 @@ services:
       - distributor # inverted relationship here to add delay for minio
 
   minio:
-    image: minio/minio:RELEASE.2021-05-26T00-22-46Z
+    image: minio/minio:RELEASE.2021-06-14T01-29-23Z
     environment:
       - MINIO_ACCESS_KEY=tempo
       - MINIO_SECRET_KEY=supersecret

--- a/tempodb/encoding/v2/page.go
+++ b/tempodb/encoding/v2/page.go
@@ -79,7 +79,7 @@ func unmarshalPageFromReader(r io.Reader, header pageHeader, buffer []byte) (*pa
 	dataLength := int(totalLength) - totalHeaderSize
 
 	if dataLength < 0 {
-		return nil, fmt.Errorf("Unexpected negative dataLength unmarshalling page: %d", dataLength)
+		return nil, fmt.Errorf("unexpected negative dataLength unmarshalling page: %d", dataLength)
 	}
 
 	if cap(buffer) < dataLength {

--- a/tempodb/encoding/v2/page.go
+++ b/tempodb/encoding/v2/page.go
@@ -78,6 +78,10 @@ func unmarshalPageFromReader(r io.Reader, header pageHeader, buffer []byte) (*pa
 	}
 	dataLength := int(totalLength) - totalHeaderSize
 
+	if dataLength < 0 {
+		return nil, fmt.Errorf("Unexpected negative dataLength unmarshalling page: %d", dataLength)
+	}
+
 	if cap(buffer) < dataLength {
 		buffer = make([]byte, dataLength)
 	} else {


### PR DESCRIPTION
**What this PR does**:
Adds guard code against a negative page length. This issue appears to occur when an ingester undergoes an unexpected shutdown. Details in issue.

**Which issue(s) this PR fixes**:
Fixes #752 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`