### PR TITLE
Tweak CPU and memory display on operational dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main / unreleased
 
 * [FEATURE] Added the ability to hedge requests with all backends [#750](https://github.com/grafana/tempo/pull/750) (@joe-elliott)
+* [ENHANCEMENT] Improve readability of cpu and memory metrics on operational dashboard [#764](https://github.com/grafana/tempo/pull/764) (@bboreham)
 
 ## v1.0.0
 

--- a/operations/tempo-mixin/tempo-operational.json
+++ b/operations/tempo-mixin/tempo-operational.json
@@ -369,7 +369,7 @@
           "expr": "rate(container_cpu_usage_seconds_total{cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$component.*\", container!=\"POD\"}[$__rate_interval])",
           "interval": "",
           "intervalFactor": 5,
-          "legendFormat": "{{pod}}",
+          "legendFormat": "{{pod}} {{container}}",
           "refId": "A"
         }
       ],
@@ -462,7 +462,7 @@
         {
           "expr": "container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$component.*\", container!=\"POD\"}",
           "interval": "",
-          "legendFormat": "{{pod}}",
+          "legendFormat": "{{pod}} {{container}}",
           "refId": "A"
         }
       ],

--- a/operations/tempo-mixin/tempo-operational.json
+++ b/operations/tempo-mixin/tempo-operational.json
@@ -366,7 +366,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(container_cpu_usage_seconds_total{cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$component.*\", container!=\"POD\"}[$__rate_interval])",
+          "expr": "rate(container_cpu_usage_seconds_total{cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$component.*\", container!=\"POD\", container!=\"\"}[$__rate_interval])",
           "interval": "",
           "intervalFactor": 5,
           "legendFormat": "{{pod}} {{container}}",
@@ -460,7 +460,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$component.*\", container!=\"POD\"}",
+          "expr": "container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$component.*\", container!=\"POD\", container!=\"\"}",
           "interval": "",
           "legendFormat": "{{pod}} {{container}}",
           "refId": "A"


### PR DESCRIPTION
**What this PR does**:

Add container name to Memory and CPU metrics. They are reported per cgroup, so pods with more than one container have several lines. This change allows them to be distinguished.

Also filter out 'pause' container - these metrics are typically very low because the "pause" container is a piece of Kubernetes internals that sits and does nothing. Filtering them out of the display aids readability.

Note in some Kubernetes installations the pause container is labled "POD", which was previously filtered out from the dashboard in #496. See containerd/cri#922 for background on the name.

**Which issue(s) this PR fixes**:
None

**Checklist**
- [ ] N/A Tests updated
- [ ] N/A Documentation added
- [x] `CHANGELOG.md` updated