### PR TITLE
Fix otlp receiver port in documentation

### DIFF
--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -59,7 +59,7 @@ server:
 See [here](https://github.com/grafana/tempo/blob/main/modules/distributor/config.go) for all configuration options.
 
 Distributors are responsible for receiving spans and forwarding them to the appropriate ingesters.  The below configuration
-exposes the otlp receiver on port 0.0.0.0:5680.  [This configuration](https://github.com/grafana/tempo/blob/main/example/docker-compose/local/tempo-local.yaml) shows how to
+exposes the otlp receiver on port 0.0.0.0:55680.  [This configuration](https://github.com/grafana/tempo/blob/main/example/docker-compose/local/tempo-local.yaml) shows how to
 configure all available receiver options.
 
 ```


### PR DESCRIPTION
**What this PR does**:
The otlp grpc receiver uses port 55680 not 5680.
