### PR TITLE
Jsonnet: update memcached image and timeout setting

### DIFF
--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -3,7 +3,7 @@
     tempo: 'grafana/tempo:latest',
     tempo_query: 'grafana/tempo-query:latest',
     tempo_vulture: 'grafana/tempo-vulture:latest',
-    memcached: 'memcached:1.5.17-alpine',
+    memcached: 'memcached:1.6.9-alpine',
     memcachedExporter: 'prom/memcached-exporter:v0.6.0',
   },
 

--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -36,7 +36,7 @@
         cache: 'memcached',
         memcached: {
           consistent_hash: true,
-          timeout: '500ms',
+          timeout: '200ms',
           host: 'memcached',
           service: 'memcached-client',
         },
@@ -80,9 +80,6 @@
         blocklist_poll: '5m',
         pool+: {
           max_workers: 200,
-        },
-        memcached+: {
-          timeout: '1s',
         },
       },
     },


### PR DESCRIPTION
**What this PR does**:
Updates the jsonnet library:
- bump image of memcached to `1.6.9-alpine`
- decrease the memcached timeout to `200ms`

From running Tempo at Grafana Labs we see latencies are well below 200ms. The P999 latency will occasionally peak above 200ms.

![Screenshot 2021-06-18 at 13 49 56](https://user-images.githubusercontent.com/7748404/122556669-142c6100-d03c-11eb-9bfd-5d52d23aaec0.png)

In this image, spikes are caused by deployments of memcached.