### PR TITLE
Jsonnet: use dedicated configmaps for distributors and ingesters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [ENHANCEMENT] Performance: improve compaction speed with concurrent reads and writes [#754](https://github.com/grafana/tempo/pull/754) (@mdisibio)
 * [ENHANCEMENT] Improve readability of cpu and memory metrics on operational dashboard [#764](https://github.com/grafana/tempo/pull/764) (@bboreham)
 * [ENHANCEMENT] Add `azure_request_duration_seconds` metric. [#767](https://github.com/grafana/tempo/pull/767) (@JosephWoodward)
+* [ENHANCEMENT] Jsonnet: split up config map used by distributor and ingester. [#...] (@kvrhdn) 
 
 ## v1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## main / unreleased
 
+* [CHANGE] Jsonnet: use dedicated configmaps for distributors and ingesters [#775](https://github.com/grafana/tempo/pull/775) (@kvrhdn)
 * [FEATURE] Added the ability to hedge requests with all backends [#750](https://github.com/grafana/tempo/pull/750) (@joe-elliott)
 * [ENHANCEMENT] Performance: improve compaction speed with concurrent reads and writes [#754](https://github.com/grafana/tempo/pull/754) (@mdisibio)
 * [ENHANCEMENT] Improve readability of cpu and memory metrics on operational dashboard [#764](https://github.com/grafana/tempo/pull/764) (@bboreham)
 * [ENHANCEMENT] Add `azure_request_duration_seconds` metric. [#767](https://github.com/grafana/tempo/pull/767) (@JosephWoodward)
-* [ENHANCEMENT] Jsonnet: split up config map used by distributor and ingester. [#...] (@kvrhdn) 
 
 ## v1.0.1
 

--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -52,6 +52,10 @@
     },
   },
 
+  tempo_distributor_config:: $.tempo_config{},
+
+  tempo_ingester_config:: $.tempo_config{},
+
   tempo_compactor_config:: $.tempo_config {
     compactor: {
       compaction: {
@@ -93,10 +97,23 @@
     }
   },
 
-  tempo_configmap:
-    configMap.new('tempo') +
+  tempo_query_frontend_config:: $.tempo_config{},
+
+  tempo_distributor_configmap:
+    configMap.new('tempo-distributor') +
     configMap.withData({
-      'tempo.yaml': $.util.manifestYaml($.tempo_config),
+      'tempo.yaml': $.util.manifestYaml($.tempo_distributor_config),
+    }) +
+    configMap.withDataMixin({
+      'overrides.yaml': $.util.manifestYaml({
+        overrides: $._config.overrides,
+      }),
+    }),
+
+  tempo_ingester_configmap:
+    configMap.new('tempo-ingester') +
+    configMap.withData({
+      'tempo.yaml': $.util.manifestYaml($.tempo_ingester_config),
     }) +
     configMap.withDataMixin({
       'overrides.yaml': $.util.manifestYaml({
@@ -114,8 +131,6 @@
         overrides: $._config.overrides,
       }),
     }),
-
-  tempo_query_frontend_config:: $.tempo_config{},
 
   tempo_querier_configmap:
     configMap.new('tempo-querier') +

--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -5,9 +5,7 @@
     server: {
       http_listen_port: $._config.port,
     },
-    distributor: {
-      receivers: $._config.distributor.receivers,
-    },
+    distributor: null,
     ingester: {
       lifecycler: {
         ring: {
@@ -52,7 +50,11 @@
     },
   },
 
-  tempo_distributor_config:: $.tempo_config{},
+  tempo_distributor_config:: $.tempo_config {
+    distributor: {
+      receivers: $._config.distributor.receivers,
+    },
+  },
 
   tempo_ingester_config:: $.tempo_config{},
 

--- a/operations/jsonnet/microservices/distributor.libsonnet
+++ b/operations/jsonnet/microservices/distributor.libsonnet
@@ -40,10 +40,10 @@
     deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
     deployment.mixin.spec.template.spec.withTerminationGracePeriodSeconds(60) +
     deployment.mixin.spec.template.metadata.withAnnotations({
-      config_hash: std.md5(std.toString($.tempo_configmap.data['tempo.yaml'])),
+      config_hash: std.md5(std.toString($.tempo_distributor_configmap.data['tempo.yaml'])),
     }) +
     deployment.mixin.spec.template.spec.withVolumes([
-      volume.fromConfigMap(tempo_config_volume, $.tempo_configmap.metadata.name),
+      volume.fromConfigMap(tempo_config_volume, $.tempo_distributor_configmap.metadata.name),
     ]),
 
   tempo_distributor_service:

--- a/operations/jsonnet/microservices/ingester.libsonnet
+++ b/operations/jsonnet/microservices/ingester.libsonnet
@@ -50,8 +50,11 @@
     )
     + $.util.antiAffinityStatefulSet
     + statefulset.mixin.spec.withServiceName(target_name)
+    + statefulset.mixin.spec.template.metadata.withAnnotations({
+      config_hash: std.md5(std.toString($.tempo_ingester_configmap.data['tempo.yaml'])),
+    })
     + statefulset.mixin.spec.template.spec.withVolumes([
-      volume.fromConfigMap(tempo_config_volume, $.tempo_configmap.metadata.name),
+      volume.fromConfigMap(tempo_config_volume, $.tempo_ingester_configmap.metadata.name),
     ]),
 
   tempo_ingester_service:

--- a/operations/kube-manifests/ConfigMap-tempo-distributor.yaml
+++ b/operations/kube-manifests/ConfigMap-tempo-distributor.yaml
@@ -3,14 +3,17 @@ data:
   overrides.yaml: |
     overrides: {}
   tempo.yaml: |
-    compactor:
-        compaction:
-            block_retention: 144h
-            chunk_size_bytes: 1.048576e+07
-        ring:
-            kvstore:
-                store: memberlist
-    distributor: null
+    compactor: null
+    distributor:
+        receivers:
+            jaeger:
+                protocols:
+                    grpc:
+                        endpoint: 0.0.0.0:14250
+            otlp:
+                protocols:
+                    grpc:
+                        endpoint: 0.0.0.0:55680
     ingester:
         lifecycler:
             ring:
@@ -27,7 +30,7 @@ data:
     storage:
         trace:
             backend: gcs
-            blocklist_poll: 10m
+            blocklist_poll: "0"
             cache: memcached
             gcs:
                 bucket_name: tempo
@@ -45,5 +48,5 @@ data:
                 path: /var/tempo/wal
 kind: ConfigMap
 metadata:
-  name: tempo-compactor
+  name: tempo-distributor
   namespace: tracing

--- a/operations/kube-manifests/ConfigMap-tempo-ingester.yaml
+++ b/operations/kube-manifests/ConfigMap-tempo-ingester.yaml
@@ -3,13 +3,7 @@ data:
   overrides.yaml: |
     overrides: {}
   tempo.yaml: |
-    compactor:
-        compaction:
-            block_retention: 144h
-            chunk_size_bytes: 1.048576e+07
-        ring:
-            kvstore:
-                store: memberlist
+    compactor: null
     distributor: null
     ingester:
         lifecycler:
@@ -27,7 +21,7 @@ data:
     storage:
         trace:
             backend: gcs
-            blocklist_poll: 10m
+            blocklist_poll: "0"
             cache: memcached
             gcs:
                 bucket_name: tempo
@@ -45,5 +39,5 @@ data:
                 path: /var/tempo/wal
 kind: ConfigMap
 metadata:
-  name: tempo-compactor
+  name: tempo-ingester
   namespace: tracing

--- a/operations/kube-manifests/ConfigMap-tempo-querier.yaml
+++ b/operations/kube-manifests/ConfigMap-tempo-querier.yaml
@@ -2,16 +2,7 @@ apiVersion: v1
 data:
   tempo.yaml: |
     compactor: null
-    distributor:
-        receivers:
-            jaeger:
-                protocols:
-                    grpc:
-                        endpoint: 0.0.0.0:14250
-            otlp:
-                protocols:
-                    grpc:
-                        endpoint: 0.0.0.0:55680
+    distributor: null
     ingester:
         lifecycler:
             ring:

--- a/operations/kube-manifests/ConfigMap-tempo-query-frontend.yaml
+++ b/operations/kube-manifests/ConfigMap-tempo-query-frontend.yaml
@@ -2,16 +2,7 @@ apiVersion: v1
 data:
   tempo.yaml: |
     compactor: null
-    distributor:
-        receivers:
-            jaeger:
-                protocols:
-                    grpc:
-                        endpoint: 0.0.0.0:14250
-            otlp:
-                protocols:
-                    grpc:
-                        endpoint: 0.0.0.0:55680
+    distributor: null
     ingester:
         lifecycler:
             ring:

--- a/operations/kube-manifests/Deployment-compactor.yaml
+++ b/operations/kube-manifests/Deployment-compactor.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        config_hash: 3bc06ce225fc97d13d89fbee2dd6ea25
+        config_hash: 391906d5363b2172f5ef468fcc2fca50
       labels:
         app: compactor
         name: compactor

--- a/operations/kube-manifests/Deployment-distributor.yaml
+++ b/operations/kube-manifests/Deployment-distributor.yaml
@@ -48,5 +48,5 @@ spec:
       terminationGracePeriodSeconds: 60
       volumes:
       - configMap:
-          name: tempo
+          name: tempo-distributor
         name: tempo-conf

--- a/operations/kube-manifests/Deployment-querier.yaml
+++ b/operations/kube-manifests/Deployment-querier.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        config_hash: af35e647b8504eed98436ddd2f35360c
+        config_hash: 5ae9881ddd5abc1d3609268198a0aacd
       labels:
         app: querier
         name: querier

--- a/operations/kube-manifests/Deployment-query-frontend.yaml
+++ b/operations/kube-manifests/Deployment-query-frontend.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        config_hash: 76b3caf721a80349e206778e56d41a66
+        config_hash: 215474a01327c5068b4236ec4a327838
       labels:
         app: query-frontend
         name: query-frontend

--- a/operations/kube-manifests/StatefulSet-ingester.yaml
+++ b/operations/kube-manifests/StatefulSet-ingester.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: ingester
   template:
     metadata:
+      annotations:
+        config_hash: 215474a01327c5068b4236ec4a327838
       labels:
         app: ingester
         name: ingester
@@ -50,7 +52,7 @@ spec:
           name: ingester-data
       volumes:
       - configMap:
-          name: tempo
+          name: tempo-ingester
         name: tempo-conf
   updateStrategy:
     type: RollingUpdate

--- a/operations/kube-manifests/StatefulSet-memcached.yaml
+++ b/operations/kube-manifests/StatefulSet-memcached.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -m 1024
         - -I 5m
-        - -c 1024
+        - -c 4096
         - -v
         image: memcached:1.5.17-alpine
         imagePullPolicy: IfNotPresent
@@ -50,3 +50,4 @@ spec:
           name: http-metrics
   updateStrategy:
     type: RollingUpdate
+  volumeClaimTemplates: []


### PR DESCRIPTION
**What this PR does**:
Split the `tempo` configmap into `tempo-distributor` and `tempo-ingester`. This will allow both services to be updated independently (changing the config of the ingesters should not impact the distributor and vice versa).

I've also added `config_hash` annotation to both so they get replaced when the config changes.

**Which issue(s) this PR fixes**:
Fixes #742 

**Checklist**
- [ ] ~~Tests updated~~
- [ ] ~~Documentation added~~
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`