### PR TITLE
Extend tempodb_gcs_request_duration_seconds histogram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [ENHANCEMENT] Improve readability of cpu and memory metrics on operational dashboard [#764](https://github.com/grafana/tempo/pull/764) (@bboreham)
 * [ENHANCEMENT] Add `azure_request_duration_seconds` metric. [#767](https://github.com/grafana/tempo/pull/767) (@JosephWoodward)
 * [ENHANCEMENT] Add `s3_request_duration_seconds` metric. [#776](https://github.com/grafana/tempo/pull/776) (@JosephWoodward)
+* [ENHANCEMENT] Extend `tempodb_gcs_request_duration_seconds` histogram to 80s and include errors. [#779](https://github.com/grafana/tempo/pull/779) (@bboreham)
 
 ## v1.0.1
 

--- a/tempodb/backend/gcs/instrumentation.go
+++ b/tempodb/backend/gcs/instrumentation.go
@@ -36,8 +36,12 @@ func newInstrumentedTransport(next http.RoundTripper) http.RoundTripper {
 func (i instrumentedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	start := time.Now()
 	resp, err := i.next.RoundTrip(req)
+	var status string
 	if err == nil {
-		i.observer.WithLabelValues(req.Method, strconv.Itoa(resp.StatusCode)).Observe(time.Since(start).Seconds())
+		status = strconv.Itoa(resp.StatusCode)
+	} else {
+		status = "500"
 	}
+	i.observer.WithLabelValues(req.Method, status).Observe(time.Since(start).Seconds())
 	return resp, err
 }

--- a/tempodb/backend/gcs/instrumentation.go
+++ b/tempodb/backend/gcs/instrumentation.go
@@ -15,9 +15,8 @@ var (
 		Name:      "gcs_request_duration_seconds",
 		Help:      "Time spent doing GCS requests.",
 
-		// GCS latency seems to range from a few ms to a few secs and is
-		// important.  So use 6 buckets from 5ms to 5s.
-		Buckets: prometheus.ExponentialBuckets(0.005, 4, 6),
+		// We often write large blocks to GCS, so use buckets from 5ms to 80s.
+		Buckets: prometheus.ExponentialBuckets(0.005, 4, 8),
 	}, []string{"operation", "status_code"})
 )
 


### PR DESCRIPTION
**What this PR does**:

 - Record duration of requests that error - requests that cannot get an http response should be included in timings, particularly if the reason for failure is a timeout.
 - Extend GCS histogram buckets to 80s - the previous cap of 5 seconds is too short to see patterns when writing large blocks.

**Checklist**
- NA Tests updated
- NA Documentation added
- [x] `CHANGELOG.md` updated