### PR TITLE
Jsonnet: replace null with {}

### DIFF
--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -5,7 +5,7 @@
     server: {
       http_listen_port: $._config.port,
     },
-    distributor: null,
+    distributor: {},
     ingester: {
       lifecycler: {
         ring: {
@@ -13,7 +13,7 @@
         },
       },
     },
-    compactor: null,
+    compactor: {},
     storage: {
       trace: {
         blocklist_poll: '0',


### PR DESCRIPTION
**What this PR does**:
Converting `null` or `{}` to YAML both result in `null`. But null in Jsonnnet can trip someone up that expects the value to be there. For instance when extending tempo_config they might do something like this:

```
  tempo_config+:: {
    distributor+: {
      // ...
    }
  }
```

Using +: is generally preferred because it doesn't overwrite previous values, but would not work if tempo_config.distributor is null.
