### PR TITLE
refactor(jsonnet/single-binary): Remove kausal from the root element

### DIFF
--- a/operations/jsonnet/single-binary/config.libsonnet
+++ b/operations/jsonnet/single-binary/config.libsonnet
@@ -15,8 +15,4 @@
             base_path: '/',
         }
     },
-
-    tempo_container+::
-        $.util.resourcesRequests('3', '3Gi') +
-        $.util.resourcesLimits('5', '5Gi')
 }

--- a/operations/jsonnet/single-binary/configmap.libsonnet
+++ b/operations/jsonnet/single-binary/configmap.libsonnet
@@ -1,5 +1,6 @@
 {
-  local configMap = $.core.v1.configMap,
+  local k = import 'ksonnet-util/kausal.libsonnet',
+  local configMap = k.core.v1.configMap,
 
   tempo_config:: {
     server: {
@@ -31,7 +32,7 @@
   tempo_configmap:
     configMap.new('tempo') +
     configMap.withData({
-      'tempo.yaml': $.util.manifestYaml($.tempo_config),
+      'tempo.yaml': k.util.manifestYaml($.tempo_config),
     }) +
     configMap.withDataMixin({
       'overrides.yaml': |||
@@ -42,7 +43,7 @@
   tempo_query_configmap:
     configMap.new('tempo-query') +
     configMap.withData({
-      'tempo-query.yaml': $.util.manifestYaml({
+      'tempo-query.yaml': k.util.manifestYaml({
         backend: 'localhost:%d' % $._config.port
       })
     }),

--- a/operations/jsonnet/single-binary/tempo.libsonnet
+++ b/operations/jsonnet/single-binary/tempo.libsonnet
@@ -1,14 +1,14 @@
-(import 'ksonnet-util/kausal.libsonnet') +
 (import 'configmap.libsonnet') +
 (import 'config.libsonnet') + 
 {
-  local container = $.core.v1.container,
-  local containerPort = $.core.v1.containerPort,
-  local volumeMount = $.core.v1.volumeMount,
-  local pvc = $.core.v1.persistentVolumeClaim,
-  local statefulset = $.apps.v1.statefulSet,
-  local volume = $.core.v1.volume,
-  local service = $.core.v1.service,
+  local k = import 'ksonnet-util/kausal.libsonnet',
+  local container = k.core.v1.container,
+  local containerPort = k.core.v1.containerPort,
+  local volumeMount = k.core.v1.volumeMount,
+  local pvc = k.core.v1.persistentVolumeClaim,
+  local statefulset = k.apps.v1.statefulSet,
+  local volume = k.core.v1.volume,
+  local service = k.core.v1.service,
   local servicePort = service.mixin.spec.portsType,
 
   local tempo_config_volume = 'tempo-conf',
@@ -16,7 +16,7 @@
   local tempo_data_volume = 'tempo-data',
 
   namespace:
-    $.core.v1.namespace.new($._config.namespace),
+    k.core.v1.namespace.new($._config.namespace),
 
   tempo_pvc:
     pvc.new() +
@@ -43,7 +43,9 @@
     container.withVolumeMounts([
       volumeMount.new(tempo_config_volume, '/conf'),
       volumeMount.new(tempo_data_volume, '/var/tempo'),
-    ]),
+    ]) +
+    k.util.resourcesRequests('3', '3Gi') +
+    k.util.resourcesLimits('5', '5Gi'),
 
   tempo_query_container::
     container.new('tempo-query', $._images.tempo_query) +
@@ -81,7 +83,7 @@
     ]),
 
   tempo_service:
-    $.util.serviceFor($.tempo_statefulset)
+    k.util.serviceFor($.tempo_statefulset)
     + service.mixin.spec.withPortsMixin([
       servicePort.withName('http').withPort(80).withTargetPort(16686),
     ]),


### PR DESCRIPTION
**What this PR does**: Remove the assumption that kausal is always available in the root element, instead we declare it explicitly, because it is an implementation detail that is leaking to the consumers of the libraries.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] ~~Tests updated~~
- [ ] ~~Documentation added~~
- [ ] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~