### PR TITLE
refactor(jsonnet/microservices): Remove kausal from the root element

### DIFF
--- a/operations/jsonnet/microservices/common.libsonnet
+++ b/operations/jsonnet/microservices/common.libsonnet
@@ -1,6 +1,7 @@
 {
   util+:: {
-    local container = $.core.v1.container,
+    local k = import 'ksonnet-util/kausal.libsonnet',
+    local container = k.core.v1.container,
 
     readinessProbe::
       container.mixin.readinessProbe.httpGet.withPath('/ready') +

--- a/operations/jsonnet/microservices/compactor.libsonnet
+++ b/operations/jsonnet/microservices/compactor.libsonnet
@@ -1,11 +1,12 @@
 {
-  local container = $.core.v1.container,
-  local containerPort = $.core.v1.containerPort,
-  local volumeMount = $.core.v1.volumeMount,
-  local deployment = $.apps.v1.deployment,
-  local volume = $.core.v1.volume,
-  local service = $.core.v1.service,
-  local servicePort = $.core.v1.servicePort,
+  local k = import 'ksonnet-util/kausal.libsonnet',
+  local container = k.core.v1.container,
+  local containerPort = k.core.v1.containerPort,
+  local volumeMount = k.core.v1.volumeMount,
+  local deployment = k.apps.v1.deployment,
+  local volume = k.core.v1.volume,
+  local service = k.core.v1.service,
+  local servicePort = k.core.v1.servicePort,
 
   local target_name = 'compactor',
   local tempo_config_volume = 'tempo-conf',
@@ -43,5 +44,5 @@
     ]),
 
   tempo_compactor_service:
-    $.util.serviceFor($.tempo_compactor_deployment),
+    k.util.serviceFor($.tempo_compactor_deployment),
 }

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -57,23 +57,25 @@
     },
   },
 
+  // TODO: Move this out of config.libsonnet into their respective libsonnet files
+  local k = import 'ksonnet-util/kausal.libsonnet',
   tempo_compactor_container+::
-    $.util.resourcesRequests('500m', '3Gi') +
-    $.util.resourcesLimits('1', '5Gi'),
+    k.util.resourcesRequests('500m', '3Gi') +
+    k.util.resourcesLimits('1', '5Gi'),
 
   tempo_distributor_container+::
-    $.util.resourcesRequests('3', '3Gi') +
-    $.util.resourcesLimits('5', '5Gi'),
+    k.util.resourcesRequests('3', '3Gi') +
+    k.util.resourcesLimits('5', '5Gi'),
 
   tempo_ingester_container+::
-    $.util.resourcesRequests('3', '3Gi') +
-    $.util.resourcesLimits('5', '5Gi'),
+    k.util.resourcesRequests('3', '3Gi') +
+    k.util.resourcesLimits('5', '5Gi'),
 
   tempo_query_frontend_container+::
-    $.util.resourcesRequests('500m', '1Gi') +
-    $.util.resourcesLimits('1', '2Gi'),
+    k.util.resourcesRequests('500m', '1Gi') +
+    k.util.resourcesLimits('1', '2Gi'),
 
   tempo_querier_container+::
-    $.util.resourcesRequests('500m', '1Gi') +
-    $.util.resourcesLimits('1', '2Gi'),
+    k.util.resourcesRequests('500m', '1Gi') +
+    k.util.resourcesLimits('1', '2Gi'),
 }

--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -1,5 +1,6 @@
 {
-  local configMap = $.core.v1.configMap,
+  local k = import 'ksonnet-util/kausal.libsonnet',
+  local configMap = k.core.v1.configMap,
 
   tempo_config:: {
     server: {
@@ -101,10 +102,10 @@
   tempo_distributor_configmap:
     configMap.new('tempo-distributor') +
     configMap.withData({
-      'tempo.yaml': $.util.manifestYaml($.tempo_distributor_config),
+      'tempo.yaml': k.util.manifestYaml($.tempo_distributor_config),
     }) +
     configMap.withDataMixin({
-      'overrides.yaml': $.util.manifestYaml({
+      'overrides.yaml': k.util.manifestYaml({
         overrides: $._config.overrides,
       }),
     }),
@@ -112,10 +113,10 @@
   tempo_ingester_configmap:
     configMap.new('tempo-ingester') +
     configMap.withData({
-      'tempo.yaml': $.util.manifestYaml($.tempo_ingester_config),
+      'tempo.yaml': k.util.manifestYaml($.tempo_ingester_config),
     }) +
     configMap.withDataMixin({
-      'overrides.yaml': $.util.manifestYaml({
+      'overrides.yaml': k.util.manifestYaml({
         overrides: $._config.overrides,
       }),
     }),
@@ -123,10 +124,10 @@
   tempo_compactor_configmap:
     configMap.new('tempo-compactor') +
     configMap.withData({
-      'tempo.yaml': $.util.manifestYaml($.tempo_compactor_config),
+      'tempo.yaml': k.util.manifestYaml($.tempo_compactor_config),
     }) +
     configMap.withDataMixin({
-      'overrides.yaml': $.util.manifestYaml({
+      'overrides.yaml': k.util.manifestYaml({
         overrides: $._config.overrides,
       }),
     }),

--- a/operations/jsonnet/microservices/distributor.libsonnet
+++ b/operations/jsonnet/microservices/distributor.libsonnet
@@ -1,12 +1,13 @@
 {
-  local container = $.core.v1.container,
-  local containerPort = $.core.v1.containerPort,
-  local volumeMount = $.core.v1.volumeMount,
-  local pv = $.core.v1.persistentVolume,
-  local deployment = $.apps.v1.deployment,
-  local volume = $.core.v1.volume,
-  local service = $.core.v1.service,
-  local servicePort = $.core.v1.servicePort,
+  local k = import 'ksonnet-util/kausal.libsonnet',
+  local container = k.core.v1.container,
+  local containerPort = k.core.v1.containerPort,
+  local volumeMount = k.core.v1.volumeMount,
+  local pv = k.core.v1.persistentVolume,
+  local deployment = k.apps.v1.deployment,
+  local volume = k.core.v1.volume,
+  local service = k.core.v1.service,
+  local servicePort = k.core.v1.servicePort,
 
   local target_name = 'distributor',
   local tempo_config_volume = 'tempo-conf',
@@ -47,10 +48,10 @@
     ]),
 
   tempo_distributor_service:
-    $.util.serviceFor($.tempo_distributor_deployment),
+    k.util.serviceFor($.tempo_distributor_deployment),
 
   ingest_service:
-    $.util.serviceFor($.tempo_distributor_deployment)
+    k.util.serviceFor($.tempo_distributor_deployment)
     + service.mixin.metadata.withName('ingest')
     + service.mixin.spec.withClusterIp('None'),
 }

--- a/operations/jsonnet/microservices/frontend.libsonnet
+++ b/operations/jsonnet/microservices/frontend.libsonnet
@@ -1,11 +1,12 @@
 {
-  local container = $.core.v1.container,
-  local containerPort = $.core.v1.containerPort,
-  local volumeMount = $.core.v1.volumeMount,
-  local deployment = $.apps.v1.deployment,
-  local volume = $.core.v1.volume,
-  local service = $.core.v1.service,
-  local servicePort = $.core.v1.servicePort,
+  local k = import 'ksonnet-util/kausal.libsonnet',
+  local container = k.core.v1.container,
+  local containerPort = k.core.v1.containerPort,
+  local volumeMount = k.core.v1.volumeMount,
+  local deployment = k.apps.v1.deployment,
+  local volume = k.core.v1.volume,
+  local service = k.core.v1.service,
+  local servicePort = k.core.v1.servicePort,
 
   local target_name = 'query-frontend',
   local tempo_config_volume = 'tempo-conf',
@@ -65,7 +66,7 @@
     ]),
 
   tempo_query_frontend_service:
-    $.util.serviceFor($.tempo_query_frontend_deployment)
+    k.util.serviceFor($.tempo_query_frontend_deployment)
     + service.mixin.spec.withPortsMixin([
       servicePort.withName('http')
       + servicePort.withPort(80)
@@ -73,7 +74,7 @@
     ]),
 
   tempo_query_frontend_discovery_service:
-    $.util.serviceFor($.tempo_query_frontend_deployment)
+    k.util.serviceFor($.tempo_query_frontend_deployment)
     + service.mixin.spec.withPortsMixin([
       servicePort.withName('grpc')
       + servicePort.withPort(9095)

--- a/operations/jsonnet/microservices/ingester.libsonnet
+++ b/operations/jsonnet/microservices/ingester.libsonnet
@@ -1,12 +1,13 @@
 {
-  local container = $.core.v1.container,
-  local containerPort = $.core.v1.containerPort,
-  local volumeMount = $.core.v1.volumeMount,
-  local pvc = $.core.v1.persistentVolumeClaim,
-  local statefulset = $.apps.v1.statefulSet,
-  local volume = $.core.v1.volume,
-  local service = $.core.v1.service,
-  local servicePort = $.core.v1.servicePort,
+  local k = import 'ksonnet-util/kausal.libsonnet',
+  local container = k.core.v1.container,
+  local containerPort = k.core.v1.containerPort,
+  local volumeMount = k.core.v1.volumeMount,
+  local pvc = k.core.v1.persistentVolumeClaim,
+  local statefulset = k.apps.v1.statefulSet,
+  local volume = k.core.v1.volume,
+  local service = k.core.v1.service,
+  local servicePort = k.core.v1.servicePort,
 
   local target_name = 'ingester',
   local tempo_config_volume = 'tempo-conf',
@@ -48,7 +49,7 @@
         [$._config.gossip_member_label]: 'true',
       },
     )
-    + $.util.antiAffinityStatefulSet
+    + k.util.antiAffinityStatefulSet
     + statefulset.mixin.spec.withServiceName(target_name)
     + statefulset.mixin.spec.template.metadata.withAnnotations({
       config_hash: std.md5(std.toString($.tempo_ingester_configmap.data['tempo.yaml'])),
@@ -58,7 +59,7 @@
     ]),
 
   tempo_ingester_service:
-    $.util.serviceFor($.tempo_ingester_statefulset),
+    k.util.serviceFor($.tempo_ingester_statefulset),
 
   gossip_ring_service:
     service.new(

--- a/operations/jsonnet/microservices/memcached.libsonnet
+++ b/operations/jsonnet/microservices/memcached.libsonnet
@@ -7,7 +7,8 @@ memcached {
 
     deployment: {},
 
-    local statefulSet = $.apps.v1.statefulSet,
+    local k = import 'ksonnet-util/kausal.libsonnet',
+    local statefulSet = k.apps.v1.statefulSet,
 
     statefulSet:
       statefulSet.new(self.name, $._config.memcached.replicas, [
@@ -15,12 +16,12 @@ memcached {
         self.memcached_exporter,
       ], []) +
       statefulSet.mixin.spec.withServiceName(self.name) +
-      $.util.antiAffinityStatefulSet,
+      k.util.antiAffinityStatefulSet,
 
-    local service = $.core.v1.service,
+    local service = k.core.v1.service,
 
     service:
-      $.util.serviceFor(self.statefulSet) +
+      k.util.serviceFor(self.statefulSet) +
       service.mixin.spec.withClusterIp('None'),
   },
 

--- a/operations/jsonnet/microservices/querier.libsonnet
+++ b/operations/jsonnet/microservices/querier.libsonnet
@@ -1,11 +1,12 @@
 {
-  local container = $.core.v1.container,
-  local containerPort = $.core.v1.containerPort,
-  local volumeMount = $.core.v1.volumeMount,
-  local deployment = $.apps.v1.deployment,
-  local volume = $.core.v1.volume,
-  local service = $.core.v1.service,
-  local servicePort = $.core.v1.servicePort,
+  local k = import 'ksonnet-util/kausal.libsonnet',
+  local container = k.core.v1.container,
+  local containerPort = k.core.v1.containerPort,
+  local volumeMount = k.core.v1.volumeMount,
+  local deployment = k.apps.v1.deployment,
+  local volume = k.core.v1.volume,
+  local service = k.core.v1.service,
+  local servicePort = k.core.v1.servicePort,
 
   local target_name = 'querier',
   local tempo_config_volume = 'tempo-conf',
@@ -23,6 +24,7 @@
     container.withVolumeMounts([
       volumeMount.new(tempo_config_volume, '/conf'),
     ]) +
+    // This depends on common.libsonnet
     $.util.readinessProbe,
 
   tempo_querier_deployment:

--- a/operations/jsonnet/microservices/tempo.libsonnet
+++ b/operations/jsonnet/microservices/tempo.libsonnet
@@ -1,4 +1,3 @@
-(import 'ksonnet-util/kausal.libsonnet') +
 (import 'common.libsonnet') +
 (import 'configmap.libsonnet') +
 (import 'config.libsonnet') +
@@ -10,6 +9,7 @@
 (import 'vulture.libsonnet') +
 (import 'memcached.libsonnet') +
 {
+  local k = import 'ksonnet-util/kausal.libsonnet',
   namespace:
-    $.core.v1.namespace.new($._config.namespace),
+    k.core.v1.namespace.new($._config.namespace),
 }

--- a/operations/jsonnet/microservices/vulture.libsonnet
+++ b/operations/jsonnet/microservices/vulture.libsonnet
@@ -1,7 +1,8 @@
 {
-  local container = $.core.v1.container,
-  local containerPort = $.core.v1.containerPort,
-  local deployment = $.apps.v1.deployment,
+  local k = import 'ksonnet-util/kausal.libsonnet',
+  local container = k.core.v1.container,
+  local containerPort = k.core.v1.containerPort,
+  local deployment = k.apps.v1.deployment,
 
   local target_name = 'vulture',
   local port = 8080,
@@ -18,8 +19,8 @@
       '-logtostderr=true',
       '-tempo-org-id=' + $._config.vulture.tempoOrgId,
     ]) +
-    $.util.resourcesRequests('50m', '100Mi') +
-    $.util.resourcesLimits('100m', '500Mi'),
+    k.util.resourcesRequests('50m', '100Mi') +
+    k.util.resourcesLimits('100m', '500Mi'),
 
   tempo_vulture_deployment:
     deployment.new(target_name,


### PR DESCRIPTION
**What this PR does**: Remove the assumption that kausal is always available in the root element, instead we declare it explicitly, because it is an implementation detail that is leaking to the consumers of the libraries.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] ~~Tests updated~~
- [ ] ~~Documentation added~~
- [ ] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~