### PR TITLE
refactor(example/tk): Remove kausal from the root element

### DIFF
--- a/example/tk/lib/grafana/main.libsonnet
+++ b/example/tk/lib/grafana/main.libsonnet
@@ -1,12 +1,11 @@
-local k = import 'ksonnet-util/kausal.libsonnet';
-
 {
-  local configMap = $.core.v1.configMap,
-  local container = $.core.v1.container,
-  local volumeMount = $.core.v1.volumeMount,
-  local deployment = $.apps.v1.deployment,
-  local volume = $.core.v1.volume,
-  local service = $.core.v1.service,
+  local k = import 'ksonnet-util/kausal.libsonnet',
+  local configMap = k.core.v1.configMap,
+  local container = k.core.v1.container,
+  local volumeMount = k.core.v1.volumeMount,
+  local deployment = k.apps.v1.deployment,
+  local volume = k.core.v1.volume,
+  local service = k.core.v1.service,
   local servicePort = service.mixin.spec.portsType,
 
   _config +:: {
@@ -54,7 +53,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     ]),
 
   grafana_service:
-    $.util.serviceFor($.grafana_deployment)
+    k.util.serviceFor($.grafana_deployment)
     + service.mixin.spec.withPortsMixin([
       servicePort.withName('http').withPort(3000).withTargetPort(3000),
     ]),

--- a/example/tk/lib/minio/minio.libsonnet
+++ b/example/tk/lib/minio/minio.libsonnet
@@ -1,8 +1,9 @@
 {
-  local configMap = $.core.v1.configMap,
-  local container = $.core.v1.container,
-  local containerPort = $.core.v1.containerPort,
-  local deployment = $.apps.v1.deployment,
+  local k = import 'ksonnet-util/kausal.libsonnet',
+  local configMap = k.core.v1.configMap,
+  local container = k.core.v1.container,
+  local containerPort = k.core.v1.containerPort,
+  local deployment = k.apps.v1.deployment,
 
   minio_container::
     container.new('minio', 'minio/minio:RELEASE.2021-05-26T00-22-46Z') +
@@ -26,5 +27,5 @@
                    { app: 'minio' }),
 
   minio_service:
-    $.util.serviceFor($.minio_deployment)
+    k.util.serviceFor($.minio_deployment)
 }

--- a/example/tk/lib/synthetic-load-generator/main.libsonnet
+++ b/example/tk/lib/synthetic-load-generator/main.libsonnet
@@ -1,9 +1,10 @@
 {
-  local configMap = $.core.v1.configMap,
-  local container = $.core.v1.container,
-  local volumeMount = $.core.v1.volumeMount,
-  local deployment = $.apps.v1.deployment,
-  local volume = $.core.v1.volume,
+  local k = import 'ksonnet-util/kausal.libsonnet',
+  local configMap = k.core.v1.configMap,
+  local container = k.core.v1.container,
+  local volumeMount = k.core.v1.volumeMount,
+  local deployment = k.apps.v1.deployment,
+  local volume = k.core.v1.volume,
 
   synthetic_load_generator_configmap:
     configMap.new('synthetic-load-generator') +

--- a/example/tk/tempo-microservices/main.jsonnet
+++ b/example/tk/tempo-microservices/main.jsonnet
@@ -52,26 +52,27 @@ minio + grafana + load + tempo {
             },
         },
     },
-    
-    local service = $.core.v1.service,
+
+    local k = import 'ksonnet-util/kausal.libsonnet',
+    local service = k.core.v1.service,
     tempo_service:
-        $.util.serviceFor($.tempo_distributor_deployment)
+        k.util.serviceFor($.tempo_distributor_deployment)
         + service.mixin.metadata.withName('tempo'),
 
-    local container = $.core.v1.container,
-    local containerPort = $.core.v1.containerPort,
+    local container = k.core.v1.container,
+    local containerPort = k.core.v1.containerPort,
     tempo_compactor_container+::
-        $.util.resourcesRequests('500m', '500Mi'),
+        k.util.resourcesRequests('500m', '500Mi'),
 
     tempo_distributor_container+::
-        $.util.resourcesRequests('500m', '500Mi') +
+        k.util.resourcesRequests('500m', '500Mi') +
         container.withPortsMixin([
             containerPort.new('opencensus', 55678),
             containerPort.new('jaeger-http', 14268),
         ]),
 
     tempo_ingester_container+::
-        $.util.resourcesRequests('500m', '500Mi'),
+        k.util.resourcesRequests('500m', '500Mi'),
 
     // clear affinity so we can run multiple ingesters on a single node
     tempo_ingester_statefulset+: {
@@ -85,10 +86,10 @@ minio + grafana + load + tempo {
     },
 
     tempo_querier_container+::
-        $.util.resourcesRequests('500m', '500Mi'),
+        k.util.resourcesRequests('500m', '500Mi'),
 
     tempo_query_frontend_container+::
-        $.util.resourcesRequests('300m', '500Mi'),
+        k.util.resourcesRequests('300m', '500Mi'),
 
     // clear affinity so we can run multiple instances of memcached on a single node
     memcached_all+: {

--- a/example/tk/tempo-single-binary/main.jsonnet
+++ b/example/tk/tempo-single-binary/main.jsonnet
@@ -20,14 +20,15 @@ grafana + load + tempo {
         }
     },
 
-    local container = $.core.v1.container,
-    local containerPort = $.core.v1.containerPort,
+    local k = import 'ksonnet-util/kausal.libsonnet',
+    local container = k.core.v1.container,
+    local containerPort = k.core.v1.containerPort,
     tempo_container+::
         container.withPortsMixin([
             containerPort.new('jaeger-http', 14268),
         ]),
 
-    local ingress = $.networking.v1beta1.ingress,
+    local ingress = k.networking.v1beta1.ingress,
     ingress:
         ingress.new() +
         ingress.mixin.metadata


### PR DESCRIPTION
**What this PR does**:
Pretty much the same thing as #781 and #782 but for the tanka examples instead.

> Remove the assumption that kausal is always available in the root element, instead we declare it explicitly, because it is an implementation detail that is leaking to the consumers of the libraries.

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [ ] ~~Tests updated~~
- [ ] ~~Documentation added~~
- [ ] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~