### PR TITLE
Refactor Blocklist Polling

### DIFF
--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -1,0 +1,162 @@
+package blocklist
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/grafana/tempo/pkg/boundedwaitgroup"
+	"github.com/grafana/tempo/tempodb/backend"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.uber.org/atomic"
+)
+
+var (
+	metricBlocklistErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "tempodb",
+		Name:      "blocklist_poll_errors_total",
+		Help:      "Total number of times an error occurred while polling the blocklist.",
+	}, []string{"tenant"})
+	metricBlocklistPollDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "tempodb",
+		Name:      "blocklist_poll_duration_seconds",
+		Help:      "Records the amount of time to poll and update the blocklist.",
+		Buckets:   prometheus.LinearBuckets(0, 60, 5),
+	})
+	metricBlocklistLength = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "tempodb",
+		Name:      "blocklist_length",
+		Help:      "Total number of blocks per tenant.",
+	}, []string{"tenant"})
+)
+
+// PerTenant is a map of tenant ids to backend.BlockMetas
+type PerTenant map[string][]*backend.BlockMeta
+
+// PerTenantCompacted is a map of tenant ids to backend.CompactedBlockMetas
+type PerTenantCompacted map[string][]*backend.CompactedBlockMeta
+
+// Poller retrieves the blocklist
+type Poller struct {
+	reader          backend.Reader
+	compactor       backend.Compactor
+	pollConcurrency uint
+}
+
+// NewPoller creates the Poller
+func NewPoller(pollConcurrency uint, reader backend.Reader, compactor backend.Compactor) *Poller {
+	return &Poller{
+		reader:          reader,
+		compactor:       compactor,
+		pollConcurrency: pollConcurrency,
+	}
+}
+
+// Do does the doing of getting a blocklist
+func (p *Poller) Do() (PerTenant, PerTenantCompacted, error) {
+	start := time.Now()
+	defer func() { metricBlocklistPollDuration.Observe(time.Since(start).Seconds()) }()
+
+	ctx := context.Background()
+	tenants, err := p.reader.Tenants(ctx)
+	if err != nil {
+		metricBlocklistErrors.WithLabelValues("").Inc()
+		return nil, nil, err
+	}
+
+	blocklist := PerTenant{}
+	compactedBlocklist := PerTenantCompacted{}
+
+	for _, tenantID := range tenants {
+		newBlockList, newCompactedBlockList, err := p.pollTenant(ctx, tenantID)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		metricBlocklistLength.WithLabelValues(tenantID).Set(float64(len(newBlockList)))
+
+		blocklist[tenantID] = newBlockList
+		compactedBlocklist[tenantID] = newCompactedBlockList
+	}
+
+	return blocklist, compactedBlocklist, nil
+}
+
+func (p *Poller) pollTenant(ctx context.Context, tenantID string) ([]*backend.BlockMeta, []*backend.CompactedBlockMeta, error) {
+	blockIDs, err := p.reader.Blocks(ctx, tenantID)
+	if err != nil {
+		metricBlocklistErrors.WithLabelValues(tenantID).Inc()
+		return []*backend.BlockMeta{}, []*backend.CompactedBlockMeta{}, err
+	}
+
+	bg := boundedwaitgroup.New(p.pollConcurrency)
+	chMeta := make(chan *backend.BlockMeta, len(blockIDs))
+	chCompactedMeta := make(chan *backend.CompactedBlockMeta, len(blockIDs))
+	anyError := atomic.Error{}
+
+	for _, blockID := range blockIDs {
+		bg.Add(1)
+		go func(uuid uuid.UUID) {
+			defer bg.Done()
+			m, cm, err := p.pollBlock(ctx, tenantID, uuid)
+			if m != nil {
+				chMeta <- m
+			} else if cm != nil {
+				chCompactedMeta <- cm
+			} else if err != nil {
+				anyError.Store(err)
+			}
+		}(blockID)
+	}
+
+	bg.Wait()
+	close(chMeta)
+	close(chCompactedMeta)
+
+	if err = anyError.Load(); err != nil {
+		return nil, nil, err
+	}
+
+	newBlockList := make([]*backend.BlockMeta, 0, len(blockIDs))
+	for m := range chMeta {
+		newBlockList = append(newBlockList, m)
+	}
+	sort.Slice(newBlockList, func(i, j int) bool {
+		return newBlockList[i].StartTime.Before(newBlockList[j].StartTime)
+	})
+
+	newCompactedBlocklist := make([]*backend.CompactedBlockMeta, 0, len(blockIDs))
+	for cm := range chCompactedMeta {
+		newCompactedBlocklist = append(newCompactedBlocklist, cm)
+	}
+	sort.Slice(newCompactedBlocklist, func(i, j int) bool {
+		return newCompactedBlocklist[i].StartTime.Before(newCompactedBlocklist[j].StartTime)
+	})
+
+	return newBlockList, newCompactedBlocklist, nil
+}
+
+func (p *Poller) pollBlock(ctx context.Context, tenantID string, blockID uuid.UUID) (*backend.BlockMeta, *backend.CompactedBlockMeta, error) {
+	var compactedBlockMeta *backend.CompactedBlockMeta
+	blockMeta, err := p.reader.BlockMeta(ctx, blockID, tenantID)
+	// if the normal meta doesn't exist maybe it's compacted.
+	if err == backend.ErrMetaDoesNotExist {
+		blockMeta = nil
+		compactedBlockMeta, err = p.compactor.CompactedBlockMeta(blockID, tenantID)
+	}
+
+	// blocks in intermediate states may not have a compacted or normal block meta.
+	//   this is not necessarily an error, just bail out
+	if err == backend.ErrMetaDoesNotExist {
+		return nil, nil, nil
+	}
+
+	if err != nil {
+		metricBlocklistErrors.WithLabelValues(tenantID).Inc()
+		return nil, nil, err
+	}
+
+	return blockMeta, compactedBlockMeta, nil
+}

--- a/tempodb/blocklist/poller_test.go
+++ b/tempodb/blocklist/poller_test.go
@@ -58,6 +58,76 @@ func TestDo(t *testing.T) {
 				"test": []*backend.CompactedBlockMeta{},
 			},
 		},
+		{
+			name: "compacted block meta",
+			compactedList: PerTenantCompacted{
+				"test": []*backend.CompactedBlockMeta{
+					{
+						BlockMeta: backend.BlockMeta{
+							BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+						},
+					},
+				},
+			},
+			expectedList: PerTenant{
+				"test": []*backend.BlockMeta{},
+			},
+			expectedCompactedList: PerTenantCompacted{
+				"test": []*backend.CompactedBlockMeta{
+					{
+						BlockMeta: backend.BlockMeta{
+							BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "all",
+			list: PerTenant{
+				"test2": []*backend.BlockMeta{
+					{
+						BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000003"),
+					},
+				},
+				"test": []*backend.BlockMeta{
+					{
+						BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
+					},
+				},
+			},
+			compactedList: PerTenantCompacted{
+				"test": []*backend.CompactedBlockMeta{
+					{
+						BlockMeta: backend.BlockMeta{
+							BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+						},
+					},
+				},
+			},
+			expectedList: PerTenant{
+				"test2": []*backend.BlockMeta{
+					{
+						BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000003"),
+					},
+				},
+				"test": []*backend.BlockMeta{
+					{
+						BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
+					},
+				},
+			},
+			expectedCompactedList: PerTenantCompacted{
+				"test": []*backend.CompactedBlockMeta{
+					{
+						BlockMeta: backend.BlockMeta{
+							BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+						},
+					},
+				},
+				"test2": []*backend.CompactedBlockMeta{},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/tempodb/blocklist/poller_test.go
+++ b/tempodb/blocklist/poller_test.go
@@ -1,0 +1,237 @@
+package blocklist
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/grafana/tempo/tempodb/backend"
+	"github.com/grafana/tempo/tempodb/backend/util"
+	"github.com/stretchr/testify/assert"
+)
+
+var testPollConcurrency = uint(10)
+
+func TestDo(t *testing.T) {
+	tests := []struct {
+		name                  string
+		list                  PerTenant
+		compactedList         PerTenantCompacted
+		expectedList          PerTenant
+		expectedCompactedList PerTenantCompacted
+		expectsError          bool
+	}{
+		{
+			name:                  "nothing!",
+			expectedList:          PerTenant{},
+			expectedCompactedList: PerTenantCompacted{},
+		},
+		{
+			name: "err",
+			list: PerTenant{
+				"test": []*backend.BlockMeta{
+					{
+						BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+					},
+				},
+			},
+			expectsError: true,
+		},
+		{
+			name: "block meta",
+			list: PerTenant{
+				"test": []*backend.BlockMeta{
+					{
+						BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+					},
+				},
+			},
+			expectedList: PerTenant{
+				"test": []*backend.BlockMeta{
+					{
+						BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+					},
+				},
+			},
+			expectedCompactedList: PerTenantCompacted{
+				"test": []*backend.CompactedBlockMeta{},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newMockCompactor(tc.compactedList, tc.expectsError)
+			r := newMockReader(tc.list, tc.compactedList, tc.expectsError)
+
+			poller := NewPoller(testPollConcurrency, r, c)
+			actualList, actualCompactedList, err := poller.Do()
+
+			assert.Equal(t, tc.expectedList, actualList)
+			assert.Equal(t, tc.expectedCompactedList, actualCompactedList)
+			if tc.expectsError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestPollBlock(t *testing.T) {
+	tests := []struct {
+		name                  string
+		list                  PerTenant
+		compactedList         PerTenantCompacted
+		pollTenantID          string
+		pollBlockID           uuid.UUID
+		expectedMeta          *backend.BlockMeta
+		expectedCompactedMeta *backend.CompactedBlockMeta
+		expectsError          bool
+	}{
+		{
+			name:         "block and tenant don't exist",
+			pollTenantID: "test",
+			pollBlockID:  uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+		},
+		{
+			name:         "block exists",
+			pollTenantID: "test",
+			pollBlockID:  uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+			list: PerTenant{
+				"test": []*backend.BlockMeta{
+					{
+						BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+					},
+				},
+			},
+			expectedMeta: &backend.BlockMeta{
+				BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+			},
+		},
+		{
+			name:         "compactedblock exists",
+			pollTenantID: "test",
+			pollBlockID:  uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+			compactedList: PerTenantCompacted{
+				"test": []*backend.CompactedBlockMeta{
+					{
+						BlockMeta: backend.BlockMeta{
+							BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+						},
+					},
+				},
+			},
+			expectedCompactedMeta: &backend.CompactedBlockMeta{
+				BlockMeta: backend.BlockMeta{
+					BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+				},
+			},
+		},
+		{
+			name:         "errors",
+			pollTenantID: "test",
+			pollBlockID:  uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+			compactedList: PerTenantCompacted{
+				"test": []*backend.CompactedBlockMeta{
+					{
+						BlockMeta: backend.BlockMeta{
+							BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+						},
+					},
+				},
+			},
+			expectsError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newMockCompactor(tc.compactedList, tc.expectsError)
+			r := newMockReader(tc.list, nil, tc.expectsError)
+
+			poller := NewPoller(testPollConcurrency, r, c)
+			actualMeta, actualCompactedMeta, err := poller.pollBlock(context.Background(), tc.pollTenantID, tc.pollBlockID)
+
+			assert.Equal(t, tc.expectedMeta, actualMeta)
+			assert.Equal(t, tc.expectedCompactedMeta, actualCompactedMeta)
+			if tc.expectsError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func newMockCompactor(list PerTenantCompacted, expectsError bool) backend.Compactor {
+	return &util.MockCompactor{
+		BlockMetaFn: func(blockID uuid.UUID, tenantID string) (*backend.CompactedBlockMeta, error) {
+			if expectsError {
+				return nil, errors.New("!!")
+			}
+
+			l, ok := list[tenantID]
+			if !ok {
+				return nil, backend.ErrMetaDoesNotExist
+			}
+
+			for _, m := range l {
+				if m.BlockID == blockID {
+					return m, nil
+				}
+			}
+
+			return nil, backend.ErrMetaDoesNotExist
+		},
+	}
+}
+
+func newMockReader(list PerTenant, compactedList PerTenantCompacted, expectsError bool) backend.Reader {
+	tenants := []string{}
+	for t := range list {
+		tenants = append(tenants, t)
+	}
+	for t := range compactedList {
+		tenants = append(tenants, t)
+	}
+
+	return &util.MockReader{
+		T: tenants,
+		BlockFn: func(ctx context.Context, tenantID string) ([]uuid.UUID, error) {
+			if expectsError {
+				return nil, errors.New("!!")
+			}
+			blocks := list[tenantID]
+			uuids := []uuid.UUID{}
+			for _, b := range blocks {
+				uuids = append(uuids, b.BlockID)
+			}
+			compactedBlocks := compactedList[tenantID]
+			for _, b := range compactedBlocks {
+				uuids = append(uuids, b.BlockID)
+			}
+
+			return uuids, nil
+		},
+		BlockMetaFn: func(ctx context.Context, blockID uuid.UUID, tenantID string) (*backend.BlockMeta, error) {
+			if expectsError {
+				return nil, errors.New("!!")
+			}
+
+			l, ok := list[tenantID]
+			if !ok {
+				return nil, backend.ErrMetaDoesNotExist
+			}
+
+			for _, m := range l {
+				if m.BlockID == blockID {
+					return m, nil
+				}
+			}
+
+			return nil, backend.ErrMetaDoesNotExist
+		},
+	}
+}

--- a/tempodb/blocklist/poller_test.go
+++ b/tempodb/blocklist/poller_test.go
@@ -239,7 +239,7 @@ func newMockCompactor(list PerTenantCompacted, expectsError bool) backend.Compac
 	return &util.MockCompactor{
 		BlockMetaFn: func(blockID uuid.UUID, tenantID string) (*backend.CompactedBlockMeta, error) {
 			if expectsError {
-				return nil, errors.New("!!")
+				return nil, errors.New("err")
 			}
 
 			l, ok := list[tenantID]
@@ -271,7 +271,7 @@ func newMockReader(list PerTenant, compactedList PerTenantCompacted, expectsErro
 		T: tenants,
 		BlockFn: func(ctx context.Context, tenantID string) ([]uuid.UUID, error) {
 			if expectsError {
-				return nil, errors.New("!!")
+				return nil, errors.New("err")
 			}
 			blocks := list[tenantID]
 			uuids := []uuid.UUID{}
@@ -287,7 +287,7 @@ func newMockReader(list PerTenant, compactedList PerTenantCompacted, expectsErro
 		},
 		BlockMetaFn: func(ctx context.Context, blockID uuid.UUID, tenantID string) (*backend.BlockMeta, error) {
 			if expectsError {
-				return nil, errors.New("!!")
+				return nil, errors.New("err")
 			}
 
 			l, ok := list[tenantID]

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"sort"
 	"sync"
 	"time"
 
@@ -19,7 +18,6 @@ import (
 
 	cortex_cache "github.com/cortexproject/cortex/pkg/chunk/cache"
 	log_util "github.com/cortexproject/cortex/pkg/util/log"
-	"github.com/grafana/tempo/pkg/boundedwaitgroup"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/azure"
 	"github.com/grafana/tempo/tempodb/backend/cache"
@@ -30,6 +28,7 @@ import (
 	"github.com/grafana/tempo/tempodb/backend/s3"
 	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/grafana/tempo/tempodb/encoding/common"
+	"github.com/grafana/tempo/tempodb/polling"
 	"github.com/grafana/tempo/tempodb/pool"
 	"github.com/grafana/tempo/tempodb/wal"
 	"github.com/opentracing/opentracing-go"
@@ -44,22 +43,6 @@ const (
 )
 
 var (
-	metricBlocklistErrors = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "tempodb",
-		Name:      "blocklist_poll_errors_total",
-		Help:      "Total number of times an error occurred while polling the blocklist.",
-	}, []string{"tenant"})
-	metricBlocklistPollDuration = promauto.NewHistogram(prometheus.HistogramOpts{
-		Namespace: "tempodb",
-		Name:      "blocklist_poll_duration_seconds",
-		Help:      "Records the amount of time to poll and update the blocklist.",
-		Buckets:   prometheus.LinearBuckets(0, 60, 5),
-	})
-	metricBlocklistLength = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "tempodb",
-		Name:      "blocklist_length",
-		Help:      "Total number of blocks per tenant.",
-	}, []string{"tenant"})
 	metricRetentionDuration = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: "tempodb",
 		Name:      "retention_duration_seconds",
@@ -120,13 +103,15 @@ type readerWriter struct {
 	wal  *wal.WAL
 	pool *pool.Pool
 
-	logger        log.Logger
-	cfg           *Config
-	blockLists    map[string][]*backend.BlockMeta
-	blockListsMtx sync.Mutex
+	logger log.Logger
+	cfg    *Config
+
+	blockListsMtx       sync.Mutex
+	blockLists          map[string][]*backend.BlockMeta
+	compactedBlockLists map[string][]*backend.CompactedBlockMeta
+	blocklistPoller     *polling.BlocklistPoller
 
 	compactorCfg          *CompactorConfig
-	compactedBlockLists   map[string][]*backend.CompactedBlockMeta
 	compactorSharder      CompactorSharder
 	compactorOverrides    CompactorOverrides
 	compactorTenantOffset uint
@@ -182,13 +167,14 @@ func New(cfg *Config, logger log.Logger) (Reader, Writer, Compactor, error) {
 
 	rw := &readerWriter{
 		c:                   c,
-		compactedBlockLists: make(map[string][]*backend.CompactedBlockMeta),
 		r:                   r,
 		w:                   w,
 		cfg:                 cfg,
 		logger:              logger,
 		pool:                pool.NewPool(cfg.Pool),
 		blockLists:          make(map[string][]*backend.BlockMeta),
+		compactedBlockLists: make(map[string][]*backend.CompactedBlockMeta),
+		blocklistPoller:     polling.NewBlocklistPoller(cfg.BlocklistPollConcurrency, r, c),
 	}
 
 	rw.wal, err = wal.New(rw.cfg.WAL)
@@ -389,101 +375,18 @@ func (rw *readerWriter) maintenanceLoop() {
 }
 
 func (rw *readerWriter) pollBlocklist() {
-	start := time.Now()
-	defer func() { metricBlocklistPollDuration.Observe(time.Since(start).Seconds()) }()
-
-	ctx := context.Background()
-	tenants, err := rw.r.Tenants(ctx)
-	if err != nil {
-		metricBlocklistErrors.WithLabelValues("").Inc()
-		level.Error(rw.logger).Log("msg", "error retrieving tenants while polling blocklist", "err", err)
-	}
-
-	rw.cleanMissingTenants(tenants)
-
-	for _, tenantID := range tenants {
-
-		newBlockList, newCompactedBlockList := rw.pollTenant(ctx, tenantID)
-
-		metricBlocklistLength.WithLabelValues(tenantID).Set(float64(len(newBlockList)))
-
-		rw.blockListsMtx.Lock()
-		rw.blockLists[tenantID] = newBlockList
-		rw.compactedBlockLists[tenantID] = newCompactedBlockList
-		rw.blockListsMtx.Unlock()
-	}
-}
-
-func (rw *readerWriter) pollTenant(ctx context.Context, tenantID string) ([]*backend.BlockMeta, []*backend.CompactedBlockMeta) {
-	blockIDs, err := rw.r.Blocks(ctx, tenantID)
-	if err != nil {
-		metricBlocklistErrors.WithLabelValues(tenantID).Inc()
-		level.Error(rw.logger).Log("msg", "error polling blocklist", "tenantID", tenantID, "err", err)
-		return []*backend.BlockMeta{}, []*backend.CompactedBlockMeta{}
-	}
-
-	bg := boundedwaitgroup.New(rw.cfg.BlocklistPollConcurrency)
-	chMeta := make(chan *backend.BlockMeta, len(blockIDs))
-	chCompactedMeta := make(chan *backend.CompactedBlockMeta, len(blockIDs))
-
-	for _, blockID := range blockIDs {
-		bg.Add(1)
-		go func(b uuid.UUID) {
-			defer bg.Done()
-			m, cm := rw.pollBlock(ctx, tenantID, b)
-			if m != nil {
-				chMeta <- m
-			} else if cm != nil {
-				chCompactedMeta <- cm
-			}
-		}(blockID)
-	}
-
-	bg.Wait()
-	close(chMeta)
-	close(chCompactedMeta)
-
-	newBlockList := make([]*backend.BlockMeta, 0, len(blockIDs))
-	for m := range chMeta {
-		newBlockList = append(newBlockList, m)
-	}
-	sort.Slice(newBlockList, func(i, j int) bool {
-		return newBlockList[i].StartTime.Before(newBlockList[j].StartTime)
-	})
-
-	newCompactedBlocklist := make([]*backend.CompactedBlockMeta, 0, len(blockIDs))
-	for cm := range chCompactedMeta {
-		newCompactedBlocklist = append(newCompactedBlocklist, cm)
-	}
-	sort.Slice(newCompactedBlocklist, func(i, j int) bool {
-		return newCompactedBlocklist[i].StartTime.Before(newCompactedBlocklist[j].StartTime)
-	})
-
-	return newBlockList, newCompactedBlocklist
-}
-
-func (rw *readerWriter) pollBlock(ctx context.Context, tenantID string, blockID uuid.UUID) (*backend.BlockMeta, *backend.CompactedBlockMeta) {
-	var compactedBlockMeta *backend.CompactedBlockMeta
-	blockMeta, err := rw.r.BlockMeta(ctx, blockID, tenantID)
-	// if the normal meta doesn't exist maybe it's compacted.
-	if err == backend.ErrMetaDoesNotExist {
-		blockMeta = nil
-		compactedBlockMeta, err = rw.c.CompactedBlockMeta(blockID, tenantID)
-	}
-
-	// blocks in intermediate states may not have a compacted or normal block meta.
-	//   this is not necessarily an error, just bail out
-	if err == backend.ErrMetaDoesNotExist {
-		return nil, nil
-	}
+	blocklist, compactedBlocklist, err := rw.blocklistPoller.Poll()
 
 	if err != nil {
-		metricBlocklistErrors.WithLabelValues(tenantID).Inc()
-		level.Error(rw.logger).Log("msg", "failed to retrieve block meta", "tenantID", tenantID, "blockID", blockID, "err", err)
-		return nil, nil
+		level.Error(rw.logger).Log("msg", "failed to poll blocklist. using previously polled lists", "err", err)
+		return
 	}
 
-	return blockMeta, compactedBlockMeta
+	rw.blockListsMtx.Lock()
+	defer rw.blockListsMtx.Unlock()
+
+	rw.blockLists = blocklist
+	rw.compactedBlockLists = compactedBlocklist
 }
 
 func (rw *readerWriter) blocklistTenants() []interface{} {
@@ -524,29 +427,6 @@ func (rw *readerWriter) compactedBlocklist(tenantID string) []*backend.Compacted
 	copiedBlocklist = append(copiedBlocklist, rw.compactedBlockLists[tenantID]...)
 
 	return copiedBlocklist
-}
-
-func (rw *readerWriter) cleanMissingTenants(tenants []string) {
-	tenantSet := make(map[string]struct{})
-	for _, tenantID := range tenants {
-		tenantSet[tenantID] = struct{}{}
-	}
-
-	rw.blockListsMtx.Lock()
-	for tenantID := range rw.blockLists {
-		if _, present := tenantSet[tenantID]; !present {
-			delete(rw.blockLists, tenantID)
-			level.Info(rw.logger).Log("msg", "deleted in-memory blocklists", "tenantID", tenantID)
-		}
-	}
-
-	for tenantID := range rw.compactedBlockLists {
-		if _, present := tenantSet[tenantID]; !present {
-			delete(rw.compactedBlockLists, tenantID)
-			level.Info(rw.logger).Log("msg", "deleted in-memory compacted blocklists", "tenantID", tenantID)
-		}
-	}
-	rw.blockListsMtx.Unlock()
 }
 
 // updateBlocklist Add and remove regular or compacted blocks from the in-memory blocklist.

--- a/tempodb/tempodb_test.go
+++ b/tempodb/tempodb_test.go
@@ -214,46 +214,6 @@ func TestBlockCleanup(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestCleanMissingTenants(t *testing.T) {
-	tests := []struct {
-		name      string
-		tenants   []string
-		blocklist map[string][]*backend.BlockMeta
-		expected  map[string][]*backend.BlockMeta
-	}{
-		{
-			name:      "one missing tenant",
-			tenants:   []string{"foo"},
-			blocklist: map[string][]*backend.BlockMeta{"foo": {{}}, "bar": {{}}},
-			expected:  map[string][]*backend.BlockMeta{"foo": {{}}},
-		},
-		{
-			name:      "no missing tenants",
-			tenants:   []string{"foo", "bar"},
-			blocklist: map[string][]*backend.BlockMeta{"foo": {{}}, "bar": {{}}},
-			expected:  map[string][]*backend.BlockMeta{"foo": {{}}, "bar": {{}}},
-		},
-		{
-			name:      "all missing tenants",
-			tenants:   []string{},
-			blocklist: map[string][]*backend.BlockMeta{"foo": {{}}, "bar": {{}}},
-			expected:  map[string][]*backend.BlockMeta{},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			r, _, _, tempDir := testConfig(t, backend.EncLZ4_256k, 0)
-			defer os.RemoveAll(tempDir)
-
-			rw := r.(*readerWriter)
-
-			rw.blockLists = tt.blocklist
-			rw.cleanMissingTenants(tt.tenants)
-			assert.Equal(t, rw.blockLists, tt.expected)
-		})
-	}
-}
-
 func checkBlocklists(t *testing.T, expectedID uuid.UUID, expectedB int, expectedCB int, rw *readerWriter) {
 	rw.pollBlocklist()
 


### PR DESCRIPTION
**What this PR does**:
Refactors blocklist polling code by moving it into its own package and adding tests. This is in preparation for adding a bucket index.

