### PR TITLE
Move resource requests and limits into $._config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [ENHANCEMENT] Add `azure_request_duration_seconds` metric. [#767](https://github.com/grafana/tempo/pull/767) (@JosephWoodward)
 * [ENHANCEMENT] Add `s3_request_duration_seconds` metric. [#776](https://github.com/grafana/tempo/pull/776) (@JosephWoodward)
 * [ENHANCEMENT] Add `tempo_ingester_flush_size_bytes` metric. [#777](https://github.com/grafana/tempo/pull/777) (@bboreham)
+* [ENHANCEMENT] Microservices jsonnet: resource requests and limits can be set in `$._config`. [#793](https://github.com/grafana/tempo/pull/793) (@kvrhdn)  
 
 ## v1.0.1
 

--- a/operations/jsonnet/microservices/common.libsonnet
+++ b/operations/jsonnet/microservices/common.libsonnet
@@ -3,6 +3,10 @@
     local k = import 'ksonnet-util/kausal.libsonnet',
     local container = k.core.v1.container,
 
+    withResources(resources)::
+        k.util.resourcesRequests(resources.requests.cpu, resources.requests.memory) +
+        k.util.resourcesLimits(resources.limits.cpu, resources.limits.memory),
+
     readinessProbe::
       container.mixin.readinessProbe.httpGet.withPath('/ready') +
       container.mixin.readinessProbe.httpGet.withPort($._config.port) +

--- a/operations/jsonnet/microservices/compactor.libsonnet
+++ b/operations/jsonnet/microservices/compactor.libsonnet
@@ -25,6 +25,7 @@
     container.withVolumeMounts([
       volumeMount.new(tempo_config_volume, '/conf'),
     ]) +
+    $.util.withResources($._config.compactor.resources) +
     $.util.readinessProbe,
 
   tempo_compactor_deployment:

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -11,21 +11,71 @@
     gossip_member_label: 'tempo-gossip-member',
     compactor: {
       replicas: 1,
+      resources: {
+        requests: {
+          cpu: '500m',
+          memory: '3Gi',
+        },
+        limits: {
+          cpu: '1',
+          memory: '5Gi',
+        },
+      },
     },
     query_frontend: {
       replicas: 1,
+      resources: {
+        requests: {
+          cpu: '500m',
+          memory: '1Gi',
+        },
+        limits: {
+          cpu: '1',
+          memory: '2Gi',
+        },
+      },
     },
     querier: {
       replicas: 2,
+      resources: {
+        requests: {
+          cpu: '500m',
+          memory: '1Gi',
+        },
+        limits: {
+          cpu: '1',
+          memory: '2Gi',
+        },
+      },
     },
     ingester: {
       pvc_size: error 'Must specify an ingester pvc size',
       pvc_storage_class: error 'Must specify an ingester pvc storage class',
       replicas: 3,
+      resources: {
+        requests: {
+          cpu: '3',
+          memory: '3Gi',
+        },
+        limits: {
+          cpu: '5',
+          memory: '5Gi',
+        },
+      },
     },
     distributor: {
       receivers: error 'Must specify receivers',
       replicas: 1,
+      resources: {
+        requests: {
+          cpu: '3',
+          memory: '3Gi',
+        },
+        limits: {
+          cpu: '5',
+          memory: '5Gi',
+        },
+      },
     },
     memcached: {
       replicas: 3,
@@ -56,26 +106,4 @@
       },
     },
   },
-
-  // TODO: Move this out of config.libsonnet into their respective libsonnet files
-  local k = import 'ksonnet-util/kausal.libsonnet',
-  tempo_compactor_container+::
-    k.util.resourcesRequests('500m', '3Gi') +
-    k.util.resourcesLimits('1', '5Gi'),
-
-  tempo_distributor_container+::
-    k.util.resourcesRequests('3', '3Gi') +
-    k.util.resourcesLimits('5', '5Gi'),
-
-  tempo_ingester_container+::
-    k.util.resourcesRequests('3', '3Gi') +
-    k.util.resourcesLimits('5', '5Gi'),
-
-  tempo_query_frontend_container+::
-    k.util.resourcesRequests('500m', '1Gi') +
-    k.util.resourcesLimits('1', '2Gi'),
-
-  tempo_querier_container+::
-    k.util.resourcesRequests('500m', '1Gi') +
-    k.util.resourcesLimits('1', '2Gi'),
 }

--- a/operations/jsonnet/microservices/distributor.libsonnet
+++ b/operations/jsonnet/microservices/distributor.libsonnet
@@ -25,6 +25,7 @@
     container.withVolumeMounts([
       volumeMount.new(tempo_config_volume, '/conf'),
     ]) +
+    $.util.withResources($._config.distributor.resources) +
     $.util.readinessProbe,
 
   tempo_distributor_deployment:

--- a/operations/jsonnet/microservices/frontend.libsonnet
+++ b/operations/jsonnet/microservices/frontend.libsonnet
@@ -26,6 +26,7 @@
     container.withVolumeMounts([
       volumeMount.new(tempo_config_volume, '/conf'),
     ]) +
+    $.util.withResources($._config.query_frontend.resources) +
     $.util.readinessProbe,
 
   tempo_query_container::

--- a/operations/jsonnet/microservices/ingester.libsonnet
+++ b/operations/jsonnet/microservices/ingester.libsonnet
@@ -36,6 +36,7 @@
       volumeMount.new(tempo_config_volume, '/conf'),
       volumeMount.new(tempo_data_volume, '/var/tempo'),
     ]) +
+    $.util.withResources($._config.ingester.resources) +
     $.util.readinessProbe,
 
   tempo_ingester_statefulset:

--- a/operations/jsonnet/microservices/querier.libsonnet
+++ b/operations/jsonnet/microservices/querier.libsonnet
@@ -24,7 +24,7 @@
     container.withVolumeMounts([
       volumeMount.new(tempo_config_volume, '/conf'),
     ]) +
-    // This depends on common.libsonnet
+    $.util.withResources($._config.querier.resources) +
     $.util.readinessProbe,
 
   tempo_querier_deployment:


### PR DESCRIPTION
**What this PR does**:
Move all Kubernetes resource settings into `$._config`, this way users only need to override `$._config` and don't need to know about the internals (`tempo_compactor_container` etc.).


**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/tempo/issues/701: resource settings were not applied correctly due to import ordering.

**Checklist**
- [ ] ~~Tests updated~~
- [ ] ~~Documentation added~~
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`