### PR TITLE
Improved query docs

### DIFF
--- a/docs/tempo/website/api_docs/_index.md
+++ b/docs/tempo/website/api_docs/_index.md
@@ -121,7 +121,11 @@ Parameters:
 Note that this API is not meant to be used directly unless for debugging the sharding functionality of the query 
 frontend.
 
-### Query Path Readiness Check
+Returns:
+By default this endpoint returns [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-proto/tree/main/opentelemetry/proto/trace/v1) JSON,
+but if it can also send OpenTelemetry proto if `Accept: application/protobuf` is passed.
+
+### Query Echo Endpoint
 
 ```
 GET /api/echo

--- a/docs/tempo/website/api_docs/_index.md
+++ b/docs/tempo/website/api_docs/_index.md
@@ -21,7 +21,7 @@ For the sake of clarity, in this document we have grouped API endpoints by servi
 | [Pprof](#pprof) | _All services_ |  HTTP | `GET /debug/pprof` |
 | [Ingest traces](#ingest) | Distributor |  - | See section for details |
 | [Querying traces](#query) | Query-frontend |  HTTP | `GET /api/traces/<traceID>` |
-| [Query Path Readiness Check](#query-path-readiness-check) | Query-frontend |  HTTP | `GET /api/echo` |
+| [Query Echo Endpoint](#query-path-readiness-check) | Query-frontend |  HTTP | `GET /api/echo` |
 | [Memberlist](#memberlist) | Distributor, Ingester, Querier, Compactor |  HTTP | `GET /memberlist` |
 | [Flush](#flush) | Ingester |  HTTP | `GET,POST /flush` |
 | [Shutdown](#shutdown) | Ingester |  HTTP | `GET,POST /shutdown` |

--- a/docs/tempo/website/api_docs/_index.md
+++ b/docs/tempo/website/api_docs/_index.md
@@ -21,7 +21,7 @@ For the sake of clarity, in this document we have grouped API endpoints by servi
 | [Pprof](#pprof) | _All services_ |  HTTP | `GET /debug/pprof` |
 | [Ingest traces](#ingest) | Distributor |  - | See section for details |
 | [Querying traces](#query) | Query-frontend |  HTTP | `GET /api/traces/<traceID>` |
-| [Query Echo Endpoint](#query-path-readiness-check) | Query-frontend |  HTTP | `GET /api/echo` |
+| [Query Echo Endpoint](#query-echo-endpoint) | Query-frontend |  HTTP | `GET /api/echo` |
 | [Memberlist](#memberlist) | Distributor, Ingester, Querier, Compactor |  HTTP | `GET /memberlist` |
 | [Flush](#flush) | Ingester |  HTTP | `GET,POST /flush` |
 | [Shutdown](#shutdown) | Ingester |  HTTP | `GET,POST /shutdown` |
@@ -190,4 +190,3 @@ Displays a web page with the compactor hash ring status, including the state, he
 compactor.
 
 _For more information, check the page on [consistent hash ring](../operations/consistent_hash_ring)._
-


### PR DESCRIPTION
**What this PR does**:
- Adds details about return value of the querier endpoint
- Changed heading for `/api/echo` to better reflect what it does. (don't want to get mixed up with k8s /readiness handlers)