### PR TITLE
Additional Guard code while parsing the header

### DIFF
--- a/tempodb/encoding/v2/page.go
+++ b/tempodb/encoding/v2/page.go
@@ -35,6 +35,9 @@ func unmarshalPageFromBytes(b []byte, header pageHeader) (*page, error) {
 	b = b[uint32Size:]
 	headerLength := binary.LittleEndian.Uint16(b[:uint16Size])
 	b = b[uint16Size:]
+	if int(headerLength) > len(b) {
+		return nil, fmt.Errorf("headerLen %d greater than remaining len %d", headerLength, len(b))
+	}
 	err := header.unmarshalHeader(b[:headerLength])
 	if err != nil {
 		return nil, err

--- a/tempodb/encoding/v2/page_test.go
+++ b/tempodb/encoding/v2/page_test.go
@@ -130,4 +130,16 @@ func TestCorruptHeader(t *testing.T) {
 	page, err = unmarshalPageFromReader(bytes.NewReader(buffBytes), constDataHeader, nil)
 	assert.Nil(t, page)
 	assert.EqualError(t, err, "unexpected negative dataLength unmarshalling page: -6")
+
+	// overwrite the base header with FFs
+	zeroHeader = bytes.Repeat([]byte{0xFF}, baseHeaderSize)
+	copy(buffBytes, zeroHeader)
+
+	page, err = unmarshalPageFromBytes(buffBytes, constDataHeader)
+	assert.Nil(t, page)
+	assert.EqualError(t, err, "headerLen 65535 greater than remaining len 3")
+
+	page, err = unmarshalPageFromReader(bytes.NewReader(buffBytes), constDataHeader, nil)
+	assert.Nil(t, page)
+	assert.EqualError(t, err, "unexpected non-zero len data header")
 }


### PR DESCRIPTION
**What this PR does**:
Adds guard code to catch corrupt blocks and return an error instead of panic'ing.