### PR TITLE
Fix OpenTelemetry typos on the Getting Started docs page.

### DIFF
--- a/docs/tempo/website/getting-started/_index.md
+++ b/docs/tempo/website/getting-started/_index.md
@@ -9,8 +9,8 @@ Distributed tracing visualizes the lifecycle of a request as it passes through
 a set of applications. There are a few components that must be configured in order to get a
 working distributed tracing visualization.
 
-This document discusses the four major pieces necessary to build out a tracing system: 
-Instrumentation, Pipeline, Backend and Visualization. If one were to build a diagram laying 
+This document discusses the four major pieces necessary to build out a tracing system:
+Instrumentation, Pipeline, Backend and Visualization. If one were to build a diagram laying
 out these pieces it may look something like this:
 
 <p align="center"><img src="getting-started.png" alt="Tracing Overview"></p>
@@ -20,24 +20,24 @@ out these pieces it may look something like this:
 #### Instrumentation SDKs
 
 The first building block to a functioning distributed tracing visualization pipeline
-is client instrumentation, which is the process of adding instrumentation points in the application that 
-creates and offloads spans. 
+is client instrumentation, which is the process of adding instrumentation points in the application that
+creates and offloads spans.
 
-Below is a list of the most popular frameworks used for client instrumentation. Each of these have SDKs 
+Below is a list of the most popular frameworks used for client instrumentation. Each of these have SDKs
 in most commonly used programming languages and you should pick one according to your application needs.
 
 * [OpenTracing/Jaeger](https://www.jaegertracing.io/docs/latest/client-libraries/)
 * [Zipkin](https://zipkin.io/pages/tracers_instrumentation)
-* [OpenTemeletry](https://opentelemetry.io/docs/concepts/instrumenting/)
+* [OpenTelemetry](https://opentelemetry.io/docs/concepts/instrumenting/)
 
 #### OpenTelemetry Auto Instrumentation
 
 Some languages have support for auto-instrumentation. These libraries capture telemetry
 information from a client application with minimal manual instrumentation of the codebase.
 
-* [OpenTemeletry Java Autoinstrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation)
-* [OpenTemeletry .NET Autoinstrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation)
-* [OpenTemeletry Python Autoinstrumentation](https://github.com/open-telemetry/opentelemetry-python-contrib)
+* [OpenTelemetry Java Autoinstrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation)
+* [OpenTelemetry .NET Autoinstrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation)
+* [OpenTelemetry Python Autoinstrumentation](https://github.com/open-telemetry/opentelemetry-python-contrib)
 
 > Note: Check out our [instrumentation examples]({{< relref "./instrumentation" >}}) to learn how to instrument your
 > favourite language for distributed tracing.
@@ -45,14 +45,14 @@ information from a client application with minimal manual instrumentation of the
 ## 2. Pipeline (Grafana Agent)
 
 Once your application is instrumented for tracing, the next step is to send these traces
-to a backend for storage and visualization. It is common to build a tracing pipeline that 
+to a backend for storage and visualization. It is common to build a tracing pipeline that
 offloads spans from your application, buffers them and eventually forwards them to a backend. Tracing
 pipelines are optional (most clients can send directly to Tempo), but you will find that
 they become more critical the larger and more robust your tracing system is.
 
-The Grafana Agent is a service that is deployed close to the application, either on the same node or 
-within the same cluster (in kubernetes) to quickly offload traces from the application and forward them to 
-a storage backend. It also abstracts features like trace batching and backend routing away from the client. 
+The Grafana Agent is a service that is deployed close to the application, either on the same node or
+within the same cluster (in kubernetes) to quickly offload traces from the application and forward them to
+a storage backend. It also abstracts features like trace batching and backend routing away from the client.
 
 To learn more about the Grafana Agent and how to set it up for tracing with Tempo,
 refer to [this blog post](https://grafana.com/blog/2020/11/17/tracing-with-the-grafana-agent-and-grafana-tempo/).
@@ -63,7 +63,7 @@ refer to [this blog post](https://grafana.com/blog/2020/11/17/tracing-with-the-g
 
 ## 3. Backend (Tempo)
 
-Grafana Tempo is an easy-to-use and high-scale distributed tracing backend used to store and query traces. The purpose of 
+Grafana Tempo is an easy-to-use and high-scale distributed tracing backend used to store and query traces. The purpose of
 the tracing backend is to store and retrieve traces on demand.
 
 Getting started with Tempo is easy.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Fixed 4 typos in the documentation of `OpenTelemetry`, my editor has also apparently cleared out some space characters at the end of some lines. 
**Which issue(s) this PR fixes**:
None, just noticed it.

**Checklist**
- [N/A] Tests updated
- [X] Documentation added
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`