### PR TITLE
Docs: update links to agent configuration

### DIFF
--- a/docs/tempo/website/getting-started/_index.md
+++ b/docs/tempo/website/getting-started/_index.md
@@ -71,7 +71,7 @@ Getting started with Tempo is easy.
 - If you're looking for examples of how to get started with Tempo, check out the [examples]({{< relref "example-demo-app.md" >}}) topic.
 - For production workloads, refer to the [deployment]({{< relref "../operations/deployment" >}}) section.
 
-> **Note:** The Grafana Agent is already set up to use Tempo. Refer to the [configuration](https://github.com/grafana/agent/blob/main/docs/configuration-reference.md#tempo_config) and [example](https://github.com/grafana/agent/blob/main/example/docker-compose/agent/config/agent.yaml) for details.
+> **Note:** The Grafana Agent is already set up to use Tempo. Refer to the [configuration](https://github.com/grafana/agent/blob/main/docs/configuration/tempo-config.md) and [example](https://github.com/grafana/agent/blob/main/example/docker-compose/agent/config/agent.yaml) for details.
 
 
 ## 4. Visualization (Grafana)

--- a/docs/tempo/website/grafana-agent/_index.md
+++ b/docs/tempo/website/grafana-agent/_index.md
@@ -25,7 +25,7 @@ leverages all the data that is processed in the pipeline.
 The Grafana Agent can be configured to run a set of tracing pipelines to collect data from your applications and write it to Tempo.
 Pipelines are built using OpenTelemetry,
 and consist of `receivers`, `processors` and `exporters`. The architecture mirrors that of the OTel Collector's [design](https://github.com/open-telemetry/opentelemetry-collector/blob/846b971758c92b833a9efaf742ec5b3e2fbd0c89/docs/design.md).
-See the [configuration reference](https://github.com/grafana/agent/blob/main/docs/configuration-reference.md#tempo_instance_config) for all available config options. 
+See the [configuration reference](https://github.com/grafana/agent/blob/main/docs/configuration/tempo-config.md) for all available config options. 
 For a quick start, refer to this [blog post](https://grafana.com/blog/2020/11/17/tracing-with-the-grafana-agent-and-grafana-tempo/).
 
 <p align="center"><img src="https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector/846b971758c92b833a9efaf742ec5b3e2fbd0c89/docs/images/design-pipelines.png" alt="Tracing pipeline architecture"></p>
@@ -50,13 +50,13 @@ The Grafana Agent processes tracing data as it flows through the pipeline to mak
 
 The Agent supports batching of traces.
 Batching helps better compress the data, reduces the number of outgoing connections, and is a recommended best practice.
-To configure it, refer to the `batch` block in the [config reference](https://github.com/grafana/agent/blob/main/docs/configuration-reference.md#tempo_instance_config).
+To configure it, refer to the `batch` block in the [config reference](https://github.com/grafana/agent/blob/main/docs/configuration/tempo-config.md).
 
 #### Attributes manipulation
 
 The Grafana Agent allows for general manipulation of attributes on spans that pass through this agent.
 A common use may be to add an environment or cluster variable.
-To configure it, refer to the `attributes` block in the [config reference](https://github.com/grafana/agent/blob/main/docs/configuration-reference.md#tempo_instance_config).
+To configure it, refer to the `attributes` block in the [config reference](https://github.com/grafana/agent/blob/main/docs/configuration/tempo-config.md).
 
 #### Attaching metadata with Prometheus Service Discovery
 
@@ -88,7 +88,7 @@ All of Prometheus' [various service discovery mechanisms](https://prometheus.io/
 This means you can use the same scrape_configs between your metrics, logs, and traces to get the same set of labels,
 and easily transition between your observability data when moving from your metrics, logs, and traces.
 
-To configure it, refer to the `scrape_configs` block in the [config reference](https://github.com/grafana/agent/blob/main/docs/configuration-reference.md#tempo_instance_config).
+To configure it, refer to the `scrape_configs` block in the [config reference](https://github.com/grafana/agent/blob/main/docs/configuration/tempo-config.md).
 
 #### Trace discovery through automatic logging
 
@@ -119,4 +119,4 @@ Aside from endpoint and authentication, the exporter also provides mechanisms fo
 and implements a queue buffering mechanism for transient failures, such as networking issues.
 
 To see all available options,
-refer to the `remote_write` block in the [config reference](https://github.com/grafana/agent/blob/main/docs/configuration-reference.md#tempo_instance_config).
+refer to the `remote_write` block in the [config reference](https://github.com/grafana/agent/blob/main/docs/configuration/tempo-config.md).

--- a/docs/tempo/website/grafana-agent/automatic-logging.md
+++ b/docs/tempo/website/grafana-agent/automatic-logging.md
@@ -25,7 +25,7 @@ This allows searching by those key-value pairs in Loki.
 ## Quickstart
 
 To configure it, you need to select your preferred backend and what trace data to log.
-To see all the available config options, refer to the [configuration reference](https://github.com/grafana/agent/blob/main/docs/configuration-reference.md#tempo_instance_config).
+To see all the available config options, refer to the [configuration reference](https://github.com/grafana/agent/blob/main/docs/configuration/tempo-config.md).
 
 ```
 tempo:

--- a/docs/tempo/website/grafana-agent/tail-based-sampling.md
+++ b/docs/tempo/website/grafana-agent/tail-based-sampling.md
@@ -38,7 +38,7 @@ This overhead will increase with the number of Agent instances that share the sa
 To start using tail-based sampling, define a sampling policy.
 If you're using a multi-instance deployment of the agent,
 add load balancing and specify the resolving mechanism to find other Agents in the setup.
-To see all the available config options, refer to the [configuration reference](https://github.com/grafana/agent/blob/main/docs/configuration-reference.md#tempo_instance_config).
+To see all the available config options, refer to the [configuration reference](https://github.com/grafana/agent/blob/main/docs/configuration/tempo-config.md).
 
 ```
 tempo:


### PR DESCRIPTION
Agent docs have been restructured moving the tempo config into a separate file. This PR updates all references.