### PR TITLE
Replace default tempo port from 3100 to 3200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main / unreleased
 
-* [ENHANCEMENT] Added hedged request metric `tempodb_backend_hedged_roundtrips_total` and a new storage agnostic `tempodb_backend_request_duration_seconds` metric that 
+* [CHANGE] Change default tempo port from 3100 to 3200 [#770](https://github.com/grafana/tempo/pull/809) (@MurzNN)
+* [ENHANCEMENT] Added hedged request metric `tempodb_backend_hedged_roundtrips_total` and a new storage agnostic `tempodb_backend_request_duration_seconds` metric that
   supersedes the soon-to-be deprecated storage specific metrics (`tempodb_azure_request_duration_seconds`, `tempodb_s3_request_duration_seconds` and `tempodb_gcs_request_duration_seconds`). [#790](https://github.com/grafana/tempo/pull/790) (@JosephWoodward)
 * [CHANGE] Jsonnet: use dedicated configmaps for distributors and ingesters [#775](https://github.com/grafana/tempo/pull/775) (@kvrhdn)
 * [FEATURE] Added the ability to hedge requests with all backends [#750](https://github.com/grafana/tempo/pull/750) (@joe-elliott)

--- a/docs/tempo/website/api_docs/pushing-spans-with-http.md
+++ b/docs/tempo/website/api_docs/pushing-spans-with-http.md
@@ -14,7 +14,7 @@ Let's first start Tempo with the Zipkin receiver configured.  In order to do thi
 
 ```yaml
 server:
-  http_listen_port: 3100
+  http_listen_port: 3200
 
 distributor:
   receivers:
@@ -30,7 +30,7 @@ storage:
 and run Tempo using it:
 
 ```bash
-docker run -p 9411:9411 -p 3100:3100 -v $(pwd)/config.yaml:/config.yaml grafana/tempo:latest -config.file /config.yaml
+docker run -p 9411:9411 -p 3200:3200 -v $(pwd)/config.yaml:/config.yaml grafana/tempo:latest -config.file /config.yaml
 ```
 
 ## Pushing Spans
@@ -61,7 +61,7 @@ Note that the `timestamp` field is in microseconds and was obtained by running `
 The easiest way to get the trace is to execute a simple curl command to Tempo.  The returned format is [OTLP](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/trace/v1/trace.proto).
 
 ```bash
-curl http://localhost:3100/api/traces/0123456789abcdef
+curl http://localhost:3200/api/traces/0123456789abcdef
 
 {"batches":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"shell script"}}]},"instrumentationLibrarySpans":[{"spans":[{"traceId":"AAAAAAAAAAABI0VniavN7w==","spanId":"AAAAAAAAEjQ=","name":"span from bash!","startTimeUnixNano":"1608239395286533000","endTimeUnixNano":"1608239395386533000","attributes":[{"key":"http.path","value":{"stringValue":"/api"}},{"key":"http.method","value":{"stringValue":"GET"}}]}]}]}]}
 ```
@@ -69,7 +69,7 @@ curl http://localhost:3100/api/traces/0123456789abcdef
 However, staring at a json blob in bash is not very fun.  Let's start up Tempo query so we can visualize our trace.  Tempo query is [Jaeger Query](https://hub.docker.com/r/jaegertracing/jaeger-query/) with a [GRPC Plugin](https://github.com/jaegertracing/jaeger/tree/master/plugin/storage/grpc) that allows it to query Tempo.
 
 ```bash
-docker run --env BACKEND=localhost:3100 --net host grafana/tempo-query:latest
+docker run --env BACKEND=localhost:3200 --net host grafana/tempo-query:latest
 ```
 
 And open `http://localhost:16686/trace/0123456789abcdef` in the browser of your choice to see:

--- a/docs/tempo/website/configuration/querying.md
+++ b/docs/tempo/website/configuration/querying.md
@@ -8,17 +8,17 @@ and help you set up your datasources appropriately.
 
 ## Grafana 7.5.x (easy mode)
 
-Grafana 7.5.x is able to query Tempo directly. Point the Grafana datasource at your Tempo query frontend (or single 
+Grafana 7.5.x is able to query Tempo directly. Point the Grafana datasource at your Tempo query frontend (or single
 binary) and enter the url: `http://<tempo hostname>:<http port number>`. For most of [our examples](https://github.com/grafana/tempo/tree/main/example/docker-compose) the following works.
 
-<p align="center"><img src="../ds75.png" alt="Grafana 7.5.x datasource"></p>  
+<p align="center"><img src="../ds75.png" alt="Grafana 7.5.x datasource"></p>
 
-Note that the port of 3100 is a common port used in our examples. Tempo default for http is 80.
+Note that the port of 3200 is a common port used in our examples. Tempo default for http is 80.
 
 
 ## Grafana 7.4.x
 
-Grafana 7.4.x is *not* able to query Tempo directly and requires the tempo-query component as an intermediary. In this case 
+Grafana 7.4.x is *not* able to query Tempo directly and requires the tempo-query component as an intermediary. In this case
 you need to run Tempo-Query and direct it at Tempo proper. Check out [the Grafana 7.4.x example](https://github.com/grafana/tempo/tree/main/example/docker-compose/grafana7.4) to help with configuration.
 
 The url entered will be `http://<tempo-query hostname>:16686/`.

--- a/docs/tempo/website/operations/tempo_cli.md
+++ b/docs/tempo/website/operations/tempo_cli.md
@@ -63,7 +63,7 @@ Options:
 
 **Example:**
 ```bash
-tempo-cli query http://tempo:3100 f1cfe82a8eef933b
+tempo-cli query http://tempo:3200 f1cfe82a8eef933b
 ```
 
 ## List Blocks

--- a/docs/tempo/website/troubleshooting/unable-to-see-trace.md
+++ b/docs/tempo/website/troubleshooting/unable-to-see-trace.md
@@ -25,7 +25,7 @@ The value of both metrics should be greater than `0` within a few minutes of the
 You can check both metrics using -
 - The metrics page exposed from Tempo at `http://<tempo-address>:<tempo-http-port>/metrics`, or
 - In Prometheus, if it is being used to scrape metrics
- 
+
 ### Case 1 - tempo_distributor_spans_received_total is 0
 If the value of `tempo_distributor_spans_received_total` is 0, possible reasons are:
 - Use of incorrect protocol/port combination while initializing the tracer in the application.
@@ -102,7 +102,7 @@ The presence of the following errors in the log may explain issues with querying
 
 - `level=info ts=XXXXXXX caller=frontend.go:63 method=GET traceID=XXXXXXXXX url=/api/traces/XXXXXXXXX duration=5m41.729449877s status=500`
 - `no org id`
-- `could not dial 10.X.X.X:3100 connection refused`
+- `could not dial 10.X.X.X:3200 connection refused`
 - `tenant-id not found`
 
 Possible reasons for the above errors are:

--- a/example/docker-compose/agent/docker-compose.yaml
+++ b/example/docker-compose/agent/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
       - ./tempo-data:/tmp/tempo
     ports:
       - "14268"  # jaeger ingest
-      - "3100"   # tempo
+      - "3200"   # tempo
       - "55680"  # otlp grpc
       - "55681"  # otlp http
       - "9411"   # zipkin

--- a/example/docker-compose/azure/docker-compose.yaml
+++ b/example/docker-compose/azure/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       - ./tempo-data:/tmp/tempo
     ports:
       - "14268"      # jaeger
-      - "3100:3100"  # tempo
+      - "3200:3200"  # tempo
     depends_on:
       - azure-cli
       - azurite

--- a/example/docker-compose/azure/readme.md
+++ b/example/docker-compose/azure/readme.md
@@ -20,7 +20,7 @@ azure_azurite_1                    docker-entrypoint.sh azuri ...   Up       0.0
 azure_grafana_1                    /run.sh                          Up       0.0.0.0:3000->3000/tcp
 azure_prometheus_1                 /bin/prometheus --config.f ...   Up       0.0.0.0:9090->9090/tcp
 azure_synthetic-load-generator_1   ./start.sh                       Up
-azure_tempo_1                      /tempo -config.file=/etc/t ...   Up       0.0.0.0:32768->14268/tcp, 0.0.0.0:3100->3100/tcp
+azure_tempo_1                      /tempo -config.file=/etc/t ...   Up       0.0.0.0:32768->14268/tcp, 0.0.0.0:3200->3200/tcp
 ```
 
 2. If you're interested you can see the wal/blocks as they are being created.  Check [Azure Storage Explorer](https://azure.microsoft.com/en-us/features/storage-explorer/) and [Azurite docs](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azurite).

--- a/example/docker-compose/azure/tempo-azure.yaml
+++ b/example/docker-compose/azure/tempo-azure.yaml
@@ -1,5 +1,5 @@
 server:
-  http_listen_port: 3100
+  http_listen_port: 3200
 
 distributor:
   receivers:                           # this configuration will listen on all ports and protocols that tempo is capable of.

--- a/example/docker-compose/gcs/docker-compose.yaml
+++ b/example/docker-compose/gcs/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       - ./tempo-data:/tmp/tempo
     ports:
       - "14268"      # jaeger
-      - "3100:3100"  # tempo
+      - "3200:3200"  # tempo
     depends_on:
       - gcs
 

--- a/example/docker-compose/gcs/readme.md
+++ b/example/docker-compose/gcs/readme.md
@@ -13,13 +13,13 @@ At this point, the following containers should be spun up -
 docker-compose ps
 ```
 ```
-                  Name                                Command               State                        Ports                      
+                  Name                                Command               State                        Ports
 ------------------------------------------------------------------------------------------------------------------------------------
-gcs_gcs_1                        /bin/fake-gcs-server -data ...   Up      0.0.0.0:4443->4443/tcp                          
-gcs_grafana_1                    /run.sh                          Up      0.0.0.0:3000->3000/tcp                          
-gcs_prometheus_1                 /bin/prometheus --config.f ...   Up      0.0.0.0:9090->9090/tcp                          
-gcs_synthetic-load-generator_1   ./start.sh                       Up                                                      
-gcs_tempo_1                      /tempo -config.file=/etc/t ...   Up      0.0.0.0:59543->14268/tcp, 0.0.0.0:3100->3100/tcp
+gcs_gcs_1                        /bin/fake-gcs-server -data ...   Up      0.0.0.0:4443->4443/tcp
+gcs_grafana_1                    /run.sh                          Up      0.0.0.0:3000->3000/tcp
+gcs_prometheus_1                 /bin/prometheus --config.f ...   Up      0.0.0.0:9090->9090/tcp
+gcs_synthetic-load-generator_1   ./start.sh                       Up
+gcs_tempo_1                      /tempo -config.file=/etc/t ...   Up      0.0.0.0:59543->14268/tcp, 0.0.0.0:3200->3200/tcp
 ```
 
 2. If you're interested you can kind of see the wal/blocks as they are being created. Navigate to https://localhost:4443/storage/v1/b/tempo/o

--- a/example/docker-compose/gcs/tempo-gcs.yaml
+++ b/example/docker-compose/gcs/tempo-gcs.yaml
@@ -1,5 +1,5 @@
 server:
-  http_listen_port: 3100
+  http_listen_port: 3200
 
 distributor:
   receivers:                           # this configuration will listen on all ports and protocols that tempo is capable of.

--- a/example/docker-compose/grafana7.4/docker-compose.yaml
+++ b/example/docker-compose/grafana7.4/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       - ./tempo-data/:/tmp/tempo
     ports:
       - "14268"  # jaeger ingest
-      - "3100"   # tempo
+      - "3200"   # tempo
 
   tempo-query:
     image: grafana/tempo-query:latest

--- a/example/docker-compose/grafana7.4/readme.md
+++ b/example/docker-compose/grafana7.4/readme.md
@@ -15,13 +15,13 @@ At this point, the following containers should be spun up -
 docker-compose ps
 ```
 ```
-                  Name                                Command               State                         Ports                      
+                  Name                                Command               State                         Ports
 -------------------------------------------------------------------------------------------------------------------------------------
-grafana74_grafana_1                    /run.sh                          Up      0.0.0.0:3000->3000/tcp                           
-grafana74_prometheus_1                 /bin/prometheus --config.f ...   Up      0.0.0.0:9090->9090/tcp                           
-grafana74_synthetic-load-generator_1   ./start.sh                       Up                                                       
-grafana74_tempo-query_1                /go/bin/query-linux --grpc ...   Up      0.0.0.0:16686->16686/tcp                         
-grafana74_tempo_1                      /tempo -config.file=/etc/t ...   Up      0.0.0.0:59541->14268/tcp, 0.0.0.0:59542->3100/tcp
+grafana74_grafana_1                    /run.sh                          Up      0.0.0.0:3000->3000/tcp
+grafana74_prometheus_1                 /bin/prometheus --config.f ...   Up      0.0.0.0:9090->9090/tcp
+grafana74_synthetic-load-generator_1   ./start.sh                       Up
+grafana74_tempo-query_1                /go/bin/query-linux --grpc ...   Up      0.0.0.0:16686->16686/tcp
+grafana74_tempo_1                      /tempo -config.file=/etc/t ...   Up      0.0.0.0:59541->14268/tcp, 0.0.0.0:59542->3200/tcp
 ```
 
 2. If you're interested you can see the wal/blocks as they are being created.

--- a/example/docker-compose/grafana7.4/tempo-query.yaml
+++ b/example/docker-compose/grafana7.4/tempo-query.yaml
@@ -1,1 +1,1 @@
-backend: "tempo:3100"
+backend: "tempo:3200"

--- a/example/docker-compose/local/docker-compose.yaml
+++ b/example/docker-compose/local/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       - ./tempo-data:/tmp/tempo
     ports:
       - "14268"  # jaeger ingest
-      - "3100"   # tempo
+      - "3200"   # tempo
       - "55680"  # otlp grpc
       - "55681"  # otlp http
       - "9411"   # zipkin

--- a/example/docker-compose/local/readme.md
+++ b/example/docker-compose/local/readme.md
@@ -2,7 +2,7 @@
 In this example all data is stored locally in the `tempo-data` folder. Local storage is fine for experimenting with Tempo
 or when using the single binary, but does not work in a distributed/microservices scenario.
 
-1. First start up the local stack. 
+1. First start up the local stack.
 
 ```console
 docker-compose up -d
@@ -19,7 +19,7 @@ docker-compose ps
 docker-compose_grafana_1                    /run.sh                          Up      0.0.0.0:3000->3000/tcp
 docker-compose_prometheus_1                 /bin/prometheus --config.f ...   Up      0.0.0.0:9090->9090/tcp
 docker-compose_synthetic-load-generator_1   ./start.sh                       Up
-docker-compose_tempo_1                      /tempo -storage.trace.back ...   Up      0.0.0.0:32772->14268/tcp, 0.0.0.0:32773->3100/tcp
+docker-compose_tempo_1                      /tempo -storage.trace.back ...   Up      0.0.0.0:32772->14268/tcp, 0.0.0.0:32773->3200/tcp
 ```
 
 2. If you're interested you can see the wal/blocks as they are being created.

--- a/example/docker-compose/local/tempo-local.yaml
+++ b/example/docker-compose/local/tempo-local.yaml
@@ -1,5 +1,5 @@
 server:
-  http_listen_port: 3100
+  http_listen_port: 3200
 
 distributor:
   receivers:                           # this configuration will listen on all ports and protocols that tempo is capable of.

--- a/example/docker-compose/loki/grafana-datasources.yaml
+++ b/example/docker-compose/loki/grafana-datasources.yaml
@@ -14,7 +14,7 @@ datasources:
   type: tempo
   access: proxy
   orgId: 1
-  url: http://tempo:3100
+  url: http://tempo:3200
   basicAuth: false
   isDefault: true
   version: 1

--- a/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
+++ b/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
       - ./tempo-data:/tmp/tempo
     ports:
       - "14268"  # jaeger ingest
-      - "3100"   # tempo
+      - "3200"   # tempo
       - "55680"  # otlp grpc
       - "55681"  # otlp http
       - "9411"   # zipkin

--- a/example/docker-compose/otel-collector-multitenant/grafana-datasources.yaml
+++ b/example/docker-compose/otel-collector-multitenant/grafana-datasources.yaml
@@ -14,7 +14,7 @@ datasources:
   type: tempo
   access: proxy
   orgId: 1
-  url: http://tempo:3100
+  url: http://tempo:3200
   basicAuth: false
   isDefault: true
   version: 1

--- a/example/docker-compose/otel-collector/docker-compose.yaml
+++ b/example/docker-compose/otel-collector/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
       - ./tempo-data:/tmp/tempo
     ports:
       - "14268"  # jaeger ingest
-      - "3100"   # tempo
+      - "3200"   # tempo
       - "55680"  # otlp grpc
       - "55681"  # otlp http
       - "9411"   # zipkin

--- a/example/docker-compose/otel-collector/readme.md
+++ b/example/docker-compose/otel-collector/readme.md
@@ -13,14 +13,14 @@ At this point, the following containers should be spun up -
 docker-compose ps
 ```
 ```
-                  Name                                Command               State           Ports         
+                  Name                                Command               State           Ports
 ----------------------------------------------------------------------------------------------------------
-otel-collector_grafana_1                    /run.sh                          Up      0.0.0.0:3000->3000/tcp                                      
-otel-collector_otel-collector_1             /otelcol --config=/etc/ote ...   Up      55678/tcp, 55679/tcp                                        
-otel-collector_synthetic-load-generator_1   ./start.sh                       Up                                                                  
-otel-collector_tempo_1                      /tempo -config.file=/etc/t ...   Up      0.0.0.0:59538->14268/tcp, 0.0.0.0:59540->3100/tcp,          
-                                                                                    0.0.0.0:59537->55680/tcp, 0.0.0.0:59536->55681/tcp,         
-                                                                                    0.0.0.0:59539->9411/tcp               
+otel-collector_grafana_1                    /run.sh                          Up      0.0.0.0:3000->3000/tcp
+otel-collector_otel-collector_1             /otelcol --config=/etc/ote ...   Up      55678/tcp, 55679/tcp
+otel-collector_synthetic-load-generator_1   ./start.sh                       Up
+otel-collector_tempo_1                      /tempo -config.file=/etc/t ...   Up      0.0.0.0:59538->14268/tcp, 0.0.0.0:59540->3200/tcp,
+                                                                                    0.0.0.0:59537->55680/tcp, 0.0.0.0:59536->55681/tcp,
+                                                                                    0.0.0.0:59539->9411/tcp
 ```
 
 2. If you're interested you can see the wal/blocks as they are being created.

--- a/example/docker-compose/s3/docker-compose.yaml
+++ b/example/docker-compose/s3/docker-compose.yaml
@@ -9,8 +9,8 @@ services:
       - ./tempo-data:/tmp/tempo
     ports:
       - "14268"      # jaeger
-      - "3100:3100"  # tempo
-    depends_on: 
+      - "3200:3200"  # tempo
+    depends_on:
       - minio
 
   minio:

--- a/example/docker-compose/s3/readme.md
+++ b/example/docker-compose/s3/readme.md
@@ -18,7 +18,7 @@ s3_grafana_1                    /run.sh                          Up      0.0.0.0
 s3_minio_1                      sh -euc mkdir -p /data/tem ...   Up      0.0.0.0:9000->9000/tcp
 s3_prometheus_1                 /bin/prometheus --config.f ...   Up      0.0.0.0:9090->9090/tcp
 s3_synthetic-load-generator_1   ./start.sh                       Up
-s3_tempo_1                      /tempo -config.file=/etc/t ...   Up      0.0.0.0:32770->14268/tcp, 0.0.0.0:3100->3100/tcp
+s3_tempo_1                      /tempo -config.file=/etc/t ...   Up      0.0.0.0:32770->14268/tcp, 0.0.0.0:3200->3200/tcp
 ```
 
 2. If you're interested you can see the wal/blocks as they are being created.  Navigate to minio at

--- a/example/docker-compose/s3/tempo-s3.yaml
+++ b/example/docker-compose/s3/tempo-s3.yaml
@@ -1,5 +1,5 @@
 server:
-  http_listen_port: 3100
+  http_listen_port: 3200
 
 distributor:
   receivers:                           # this configuration will listen on all ports and protocols that tempo is capable of.

--- a/example/docker-compose/shared/grafana-datasources.yaml
+++ b/example/docker-compose/shared/grafana-datasources.yaml
@@ -14,7 +14,7 @@ datasources:
   type: tempo
   access: proxy
   orgId: 1
-  url: http://tempo:3100
+  url: http://tempo:3200
   basicAuth: false
   isDefault: true
   version: 1

--- a/example/docker-compose/shared/prometheus.yaml
+++ b/example/docker-compose/shared/prometheus.yaml
@@ -8,4 +8,4 @@ scrape_configs:
       - targets: [ 'localhost:9090' ]
   - job_name: 'tempo'
     static_configs:
-      - targets: [ 'tempo:3100' ]
+      - targets: [ 'tempo:3200' ]

--- a/example/helm/microservices-grafana-values.yaml
+++ b/example/helm/microservices-grafana-values.yaml
@@ -12,7 +12,7 @@ datasources:
         type: tempo
         access: proxy
         orgId: 1
-        url: http://tempo-tempo-distributed-query-frontend:3100
+        url: http://tempo-tempo-distributed-query-frontend:3200
         basicAuth: false
         isDefault: true
         version: 1

--- a/example/helm/single-binary-grafana-values.yaml
+++ b/example/helm/single-binary-grafana-values.yaml
@@ -12,7 +12,7 @@ datasources:
         type: tempo
         access: proxy
         orgId: 1
-        url: http://tempo:3100
+        url: http://tempo:3200
         basicAuth: false
         isDefault: true
         version: 1

--- a/example/tk/lib/grafana/main.libsonnet
+++ b/example/tk/lib/grafana/main.libsonnet
@@ -9,7 +9,7 @@
   local servicePort = service.mixin.spec.portsType,
 
   _config +:: {
-    tempo_query_url: 'http://tempo:3100',
+    tempo_query_url: 'http://tempo:3200',
   },
 
   grafana_configmap:

--- a/example/tk/tempo-microservices/main.jsonnet
+++ b/example/tk/tempo-microservices/main.jsonnet
@@ -36,7 +36,7 @@ minio + grafana + load + tempo {
         },
         backend: 's3',
         bucket: 'tempo',
-        tempo_query_url: 'http://query-frontend:3100',
+        tempo_query_url: 'http://query-frontend:3200',
     },
 
     // manually overriding to get tempo to talk to minio

--- a/integration/bench/config.yaml
+++ b/integration/bench/config.yaml
@@ -1,7 +1,7 @@
 target: all
 
 server:
-  http_listen_port: 3100
+  http_listen_port: 3200
   log_level: error
 
 distributor:

--- a/integration/bench/load_test.go
+++ b/integration/bench/load_test.go
@@ -64,7 +64,7 @@ func newK6Runner(tempo *cortex_e2e.HTTPService) *cortex_e2e.ConcreteService {
 
 	s.SetUser("0") // required so k6 can read the js files passed in
 
-	tempoHTTP := "http://" + tempo.NetworkEndpoint(3100)
+	tempoHTTP := "http://" + tempo.NetworkEndpoint(3200)
 	tempoZipkin := "http://" + tempo.NetworkEndpoint(9411)
 	s.SetEnvVars(map[string]string{
 		"WRITE_ENDPOINT":       tempoZipkin,

--- a/integration/bench/smoke_test.js
+++ b/integration/bench/smoke_test.js
@@ -3,10 +3,10 @@ import http from "k6/http";
 import { generateId, Span } from './modules/util.js';
 
 const WRITE_ENDPOINT = __ENV.WRITE_ENDPOINT || "http://0.0.0.0:9411";
-const DISTRIBUTOR_ENDPOINT = __ENV.DISTRIBUTOR_ENDPOINT || "http://0.0.0.0:3100";
-const INGESTER_ENDPOINT = __ENV.INGESTER_ENDPOINT || "http://0.0.0.0:3100";
-const QUERY_ENDPOINT = __ENV.QUERY_ENDPOINT || "http://0.0.0.0:3100";
-const QUERIER_ENDPOINT = __ENV.QUERIER_ENDPOINT || "http://0.0.0.0:3100";
+const DISTRIBUTOR_ENDPOINT = __ENV.DISTRIBUTOR_ENDPOINT || "http://0.0.0.0:3200";
+const INGESTER_ENDPOINT = __ENV.INGESTER_ENDPOINT || "http://0.0.0.0:3200";
+const QUERY_ENDPOINT = __ENV.QUERY_ENDPOINT || "http://0.0.0.0:3200";
+const QUERIER_ENDPOINT = __ENV.QUERIER_ENDPOINT || "http://0.0.0.0:3200";
 
 const WRITE_WAIT = 1;
 const READ_WAIT = 1;

--- a/integration/bench/stress_test_write_path.js
+++ b/integration/bench/stress_test_write_path.js
@@ -3,8 +3,8 @@ import http from "k6/http";
 import { Span } from './modules/util.js';
 
 const WRITE_ENDPOINT = __ENV.WRITE_ENDPOINT || "http://0.0.0.0:9411";
-const DISTRIBUTOR_ENDPOINT = __ENV.DISTRIBUTOR_ENDPOINT || "http://0.0.0.0:3100";
-const INGESTER_ENDPOINT = __ENV.INGESTER_ENDPOINT || "http://0.0.0.0:3100";
+const DISTRIBUTOR_ENDPOINT = __ENV.DISTRIBUTOR_ENDPOINT || "http://0.0.0.0:3200";
+const INGESTER_ENDPOINT = __ENV.INGESTER_ENDPOINT || "http://0.0.0.0:3200";
 
 const STEADY_CHECK_WAIT = 5;
 

--- a/integration/e2e/config-all-in-one-azurite.yaml
+++ b/integration/e2e/config-all-in-one-azurite.yaml
@@ -1,7 +1,7 @@
 target: all
 
 server:
-  http_listen_port: 3100
+  http_listen_port: 3200
 
 distributor:
   receivers:

--- a/integration/e2e/config-all-in-one.yaml
+++ b/integration/e2e/config-all-in-one.yaml
@@ -1,8 +1,8 @@
 target: all
 
 server:
-  http_listen_port: 3100
-  
+  http_listen_port: 3200
+
 distributor:
   receivers:
     jaeger:

--- a/integration/e2e/config-limits.yaml
+++ b/integration/e2e/config-limits.yaml
@@ -1,7 +1,7 @@
 target: all
 
 server:
-  http_listen_port: 3100
+  http_listen_port: 3200
 
 distributor:
   receivers:

--- a/integration/e2e/config-microservices.yaml
+++ b/integration/e2e/config-microservices.yaml
@@ -1,5 +1,5 @@
 server:
-  http_listen_port: 3100
+  http_listen_port: 3200
 
 distributor:
   receivers:

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -59,16 +59,16 @@ func TestAllInOne(t *testing.T) {
 	hexID := fmt.Sprintf("%016x%016x", batch.Spans[0].TraceIdHigh, batch.Spans[0].TraceIdLow)
 
 	// test echo
-	assertEcho(t, "http://"+tempo.Endpoint(3100)+"/api/echo")
+	assertEcho(t, "http://"+tempo.Endpoint(3200)+"/api/echo")
 
 	// ensure trace is created in ingester (trace_idle_time has passed)
 	require.NoError(t, tempo.WaitSumMetrics(cortex_e2e.Equals(1), "tempo_ingester_traces_created_total"))
 
 	// query an in-memory trace
-	queryAndAssertTrace(t, "http://"+tempo.Endpoint(3100)+"/api/traces/"+hexID, "my operation", 1)
+	queryAndAssertTrace(t, "http://"+tempo.Endpoint(3200)+"/api/traces/"+hexID, "my operation", 1)
 
 	// flush trace to backend
-	res, err := cortex_e2e.GetRequest("http://" + tempo.Endpoint(3100) + "/flush")
+	res, err := cortex_e2e.GetRequest("http://" + tempo.Endpoint(3200) + "/flush")
 	require.NoError(t, err)
 	require.Equal(t, 204, res.StatusCode)
 
@@ -76,7 +76,7 @@ func TestAllInOne(t *testing.T) {
 	time.Sleep(5 * time.Second)
 
 	// force clear completed block
-	res, err = cortex_e2e.GetRequest("http://" + tempo.Endpoint(3100) + "/flush")
+	res, err = cortex_e2e.GetRequest("http://" + tempo.Endpoint(3200) + "/flush")
 	require.NoError(t, err)
 	require.Equal(t, 204, res.StatusCode)
 
@@ -86,7 +86,7 @@ func TestAllInOne(t *testing.T) {
 	require.NoError(t, tempo.WaitSumMetrics(cortex_e2e.Equals(1), "tempo_query_frontend_queries_total"))
 
 	// query trace - should fetch from backend
-	queryAndAssertTrace(t, "http://"+tempo.Endpoint(3100)+"/api/traces/"+hexID, "my operation", 1)
+	queryAndAssertTrace(t, "http://"+tempo.Endpoint(3200)+"/api/traces/"+hexID, "my operation", 1)
 }
 
 func TestAzuriteAllInOne(t *testing.T) {
@@ -126,16 +126,16 @@ func TestAzuriteAllInOne(t *testing.T) {
 	hexID := fmt.Sprintf("%016x%016x", batch.Spans[0].TraceIdHigh, batch.Spans[0].TraceIdLow)
 
 	// test echo
-	assertEcho(t, "http://"+tempo.Endpoint(3100)+"/api/echo")
+	assertEcho(t, "http://"+tempo.Endpoint(3200)+"/api/echo")
 
 	// ensure trace is created in ingester (trace_idle_time has passed)
 	require.NoError(t, tempo.WaitSumMetrics(cortex_e2e.Equals(1), "tempo_ingester_traces_created_total"))
 
 	// query an in-memory trace
-	queryAndAssertTrace(t, "http://"+tempo.Endpoint(3100)+"/api/traces/"+hexID, "my operation", 1)
+	queryAndAssertTrace(t, "http://"+tempo.Endpoint(3200)+"/api/traces/"+hexID, "my operation", 1)
 
 	// flush trace to backend
-	res, err := cortex_e2e.GetRequest("http://" + tempo.Endpoint(3100) + "/flush")
+	res, err := cortex_e2e.GetRequest("http://" + tempo.Endpoint(3200) + "/flush")
 	require.NoError(t, err)
 	require.Equal(t, 204, res.StatusCode)
 
@@ -143,7 +143,7 @@ func TestAzuriteAllInOne(t *testing.T) {
 	time.Sleep(5 * time.Second)
 
 	// force clear completed block
-	res, err = cortex_e2e.GetRequest("http://" + tempo.Endpoint(3100) + "/flush")
+	res, err = cortex_e2e.GetRequest("http://" + tempo.Endpoint(3200) + "/flush")
 	require.NoError(t, err)
 	require.Equal(t, 204, res.StatusCode)
 
@@ -152,7 +152,7 @@ func TestAzuriteAllInOne(t *testing.T) {
 	require.NoError(t, tempo.WaitSumMetrics(cortex_e2e.Equals(1), "tempodb_blocklist_length"))
 
 	// query trace - should fetch from backend
-	queryAndAssertTrace(t, "http://"+tempo.Endpoint(3100)+"/api/traces/"+hexID, "my operation", 1)
+	queryAndAssertTrace(t, "http://"+tempo.Endpoint(3200)+"/api/traces/"+hexID, "my operation", 1)
 
 }
 func TestMicroservices(t *testing.T) {
@@ -203,7 +203,7 @@ func TestMicroservices(t *testing.T) {
 	hexID := fmt.Sprintf("%016x%016x", batch.Spans[0].TraceIdHigh, batch.Spans[0].TraceIdLow)
 
 	// test echo
-	assertEcho(t, "http://"+tempoQueryFrontend.Endpoint(3100)+"/api/echo")
+	assertEcho(t, "http://"+tempoQueryFrontend.Endpoint(3200)+"/api/echo")
 
 	// ensure trace is created in ingester (trace_idle_time has passed)
 	require.NoError(t, tempoIngester1.WaitSumMetrics(cortex_e2e.Equals(1), "tempo_ingester_traces_created_total"))
@@ -211,14 +211,14 @@ func TestMicroservices(t *testing.T) {
 	require.NoError(t, tempoIngester3.WaitSumMetrics(cortex_e2e.Equals(1), "tempo_ingester_traces_created_total"))
 
 	// query an in-memory trace
-	queryAndAssertTrace(t, "http://"+tempoQueryFrontend.Endpoint(3100)+"/api/traces/"+hexID, "my operation", 1)
+	queryAndAssertTrace(t, "http://"+tempoQueryFrontend.Endpoint(3200)+"/api/traces/"+hexID, "my operation", 1)
 
 	// flush trace to backend
-	res, err := cortex_e2e.GetRequest("http://" + tempoIngester1.Endpoint(3100) + "/flush")
+	res, err := cortex_e2e.GetRequest("http://" + tempoIngester1.Endpoint(3200) + "/flush")
 	require.NoError(t, err)
 	require.Equal(t, 204, res.StatusCode)
 
-	res, err = cortex_e2e.GetRequest("http://" + tempoIngester2.Endpoint(3100) + "/flush")
+	res, err = cortex_e2e.GetRequest("http://" + tempoIngester2.Endpoint(3200) + "/flush")
 	require.NoError(t, err)
 	require.Equal(t, 204, res.StatusCode)
 
@@ -233,7 +233,7 @@ func TestMicroservices(t *testing.T) {
 	require.NoError(t, tempoQueryFrontend.WaitSumMetrics(cortex_e2e.Equals(1), "tempo_query_frontend_queries_total"))
 
 	// query trace - should fetch from backend
-	queryAndAssertTrace(t, "http://"+tempoQueryFrontend.Endpoint(3100)+"/api/traces/"+hexID, "my operation", 1)
+	queryAndAssertTrace(t, "http://"+tempoQueryFrontend.Endpoint(3200)+"/api/traces/"+hexID, "my operation", 1)
 
 	// stop an ingester and confirm we can still write and query
 	err = tempoIngester2.Stop()
@@ -247,7 +247,7 @@ func TestMicroservices(t *testing.T) {
 	hexID = fmt.Sprintf("%016x%016x", batch.Spans[0].TraceIdHigh, batch.Spans[0].TraceIdLow)
 
 	// query an in-memory trace
-	queryAndAssertTrace(t, "http://"+tempoQueryFrontend.Endpoint(3100)+"/api/traces/"+hexID, "my operation", 1)
+	queryAndAssertTrace(t, "http://"+tempoQueryFrontend.Endpoint(3200)+"/api/traces/"+hexID, "my operation", 1)
 
 	// stop another ingester and confirm things fail
 	err = tempoIngester1.Stop()

--- a/integration/microservices/docker-compose.yaml
+++ b/integration/microservices/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       - ./tempo.yaml:/etc/tempo.yaml
     ports:
       - "14268"  # jaeger ingest
-      - "3100"   # tempo
+      - "3200"   # tempo
       - "7946"
     depends_on:
       - minio
@@ -21,7 +21,7 @@ services:
       - ./tempo.yaml:/etc/tempo.yaml
     ports:
       - "14268"  # jaeger ingest
-      - "3100"   # tempo
+      - "3200"   # tempo
       - "7946"
     depends_on:
       - distributor # inverted relationship here to add delay for minio
@@ -34,7 +34,7 @@ services:
       - ./tempo.yaml:/etc/tempo.yaml
     ports:
       - "14268"  # jaeger ingest
-      - "3100"   # tempo
+      - "3200"   # tempo
       - "7946"
     depends_on:
       - distributor # inverted relationship here to add delay for minio
@@ -47,7 +47,7 @@ services:
       - ./tempo.yaml:/etc/tempo.yaml
     ports:
       - "14268"  # jaeger ingest
-      - "3100"   # tempo
+      - "3200"   # tempo
       - "7946"
     depends_on:
       - distributor # inverted relationship here to add delay for minio
@@ -62,7 +62,7 @@ services:
     entrypoint:
       - sh
       - -euc
-      - mkdir -p /data/tempo && /usr/bin/minio server /data      
+      - mkdir -p /data/tempo && /usr/bin/minio server /data
 
   synthetic-load-generator:
     image: omnition/synthetic-load-generator:1.0.25

--- a/integration/microservices/prometheus.yaml
+++ b/integration/microservices/prometheus.yaml
@@ -16,7 +16,7 @@ scrape_configs:
   - job_name: tempo
     static_configs:
     - targets:
-      - distributor:3100
-      - ingester-0:3100
-      - ingester-1:3100
-      - ingester-2:3100
+      - distributor:3200
+      - ingester-0:3200
+      - ingester-1:3200
+      - ingester-2:3200

--- a/integration/microservices/tempo.yaml
+++ b/integration/microservices/tempo.yaml
@@ -25,7 +25,7 @@ overrides:
   max_traces_per_user: 1000000
 
 server:
-    http_listen_port: 3100
+    http_listen_port: 3200
 
 storage:
   trace:
@@ -40,4 +40,4 @@ storage:
     pool:
         queue_depth: 2000
     wal:
-        path: /var/tempo/wal  
+        path: /var/tempo/wal

--- a/integration/util.go
+++ b/integration/util.go
@@ -27,8 +27,8 @@ func NewTempoAllInOne() *cortex_e2e.HTTPService {
 		"tempo",
 		image,
 		cortex_e2e.NewCommandWithoutEntrypoint("/tempo", args),
-		cortex_e2e.NewHTTPReadinessProbe(3100, "/ready", 200, 299),
-		3100,  // http all things
+		cortex_e2e.NewHTTPReadinessProbe(3200, "/ready", 200, 299),
+		3200,  // http all things
 		14250, // jaeger grpc ingest
 		9411,  // zipkin ingest (used by load)
 	)
@@ -59,8 +59,8 @@ func NewTempoDistributor() *cortex_e2e.HTTPService {
 		"distributor",
 		image,
 		cortex_e2e.NewCommandWithoutEntrypoint("/tempo", args...),
-		cortex_e2e.NewHTTPReadinessProbe(3100, "/ready", 200, 299),
-		3100,
+		cortex_e2e.NewHTTPReadinessProbe(3200, "/ready", 200, 299),
+		3200,
 		14250,
 	)
 
@@ -76,8 +76,8 @@ func NewTempoIngester(replica int) *cortex_e2e.HTTPService {
 		"ingester-"+strconv.Itoa(replica),
 		image,
 		cortex_e2e.NewCommandWithoutEntrypoint("/tempo", args...),
-		cortex_e2e.NewHTTPReadinessProbe(3100, "/ready", 200, 299),
-		3100,
+		cortex_e2e.NewHTTPReadinessProbe(3200, "/ready", 200, 299),
+		3200,
 	)
 
 	s.SetBackoff(tempoBackoff())
@@ -92,8 +92,8 @@ func NewTempoQueryFrontend() *cortex_e2e.HTTPService {
 		"query-frontend",
 		image,
 		cortex_e2e.NewCommandWithoutEntrypoint("/tempo", args...),
-		cortex_e2e.NewHTTPReadinessProbe(3100, "/ready", 200, 299),
-		3100,
+		cortex_e2e.NewHTTPReadinessProbe(3200, "/ready", 200, 299),
+		3200,
 	)
 
 	s.SetBackoff(tempoBackoff())
@@ -108,8 +108,8 @@ func NewTempoQuerier() *cortex_e2e.HTTPService {
 		"querier",
 		image,
 		cortex_e2e.NewCommandWithoutEntrypoint("/tempo", args...),
-		cortex_e2e.NewHTTPReadinessProbe(3100, "/ready", 200, 299),
-		3100,
+		cortex_e2e.NewHTTPReadinessProbe(3200, "/ready", 200, 299),
+		3200,
 	)
 
 	s.SetBackoff(tempoBackoff())

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -87,11 +87,11 @@
     vulture: {
       replicas: 0,
       tempoPushUrl: 'http://distributor',
-      tempoQueryUrl: 'http://query-frontend:3100',
+      tempoQueryUrl: 'http://query-frontend:3200',
       tempoOrgId: '',
     },
     ballast_size_mbs: '1024',
-    port: 3100,
+    port: 3200,
     http_api_prefix: '',
     gossip_ring_port: 7946,
     backend: error 'Must specify a backend',  // gcs|s3

--- a/operations/jsonnet/microservices/frontend.libsonnet
+++ b/operations/jsonnet/microservices/frontend.libsonnet
@@ -71,7 +71,7 @@
     + service.mixin.spec.withPortsMixin([
       servicePort.withName('http')
       + servicePort.withPort(80)
-      + servicePort.withTargetPort(3100),
+      + servicePort.withTargetPort(3200),
     ]),
 
   tempo_query_frontend_discovery_service:

--- a/operations/jsonnet/single-binary/config.libsonnet
+++ b/operations/jsonnet/single-binary/config.libsonnet
@@ -6,7 +6,7 @@
     },
 
     _config+:: {
-        port: 3100,
+        port: 3200,
         pvc_size: error 'Must specify a pvc size',
         pvc_storage_class: error 'Must specify a pvc storage class',
         receivers: error 'Must specify receivers',

--- a/operations/kube-manifests/ConfigMap-tempo-compactor.yaml
+++ b/operations/kube-manifests/ConfigMap-tempo-compactor.yaml
@@ -23,7 +23,7 @@ data:
     overrides:
         per_tenant_override_config: /conf/overrides.yaml
     server:
-        http_listen_port: 3100
+        http_listen_port: 3200
     storage:
         trace:
             backend: gcs

--- a/operations/kube-manifests/ConfigMap-tempo-distributor.yaml
+++ b/operations/kube-manifests/ConfigMap-tempo-distributor.yaml
@@ -26,7 +26,7 @@ data:
     overrides:
         per_tenant_override_config: /conf/overrides.yaml
     server:
-        http_listen_port: 3100
+        http_listen_port: 3200
     storage:
         trace:
             backend: gcs

--- a/operations/kube-manifests/ConfigMap-tempo-ingester.yaml
+++ b/operations/kube-manifests/ConfigMap-tempo-ingester.yaml
@@ -17,7 +17,7 @@ data:
     overrides:
         per_tenant_override_config: /conf/overrides.yaml
     server:
-        http_listen_port: 3100
+        http_listen_port: 3200
     storage:
         trace:
             backend: gcs

--- a/operations/kube-manifests/ConfigMap-tempo-querier.yaml
+++ b/operations/kube-manifests/ConfigMap-tempo-querier.yaml
@@ -18,7 +18,7 @@ data:
         frontend_worker:
             frontend_address: query-frontend-discovery.tracing.svc.cluster.local:9095
     server:
-        http_listen_port: 3100
+        http_listen_port: 3200
         log_level: debug
     storage:
         trace:

--- a/operations/kube-manifests/ConfigMap-tempo-query-frontend.yaml
+++ b/operations/kube-manifests/ConfigMap-tempo-query-frontend.yaml
@@ -15,7 +15,7 @@ data:
     overrides:
         per_tenant_override_config: /conf/overrides.yaml
     server:
-        http_listen_port: 3100
+        http_listen_port: 3200
     storage:
         trace:
             backend: gcs

--- a/operations/kube-manifests/ConfigMap-tempo-query.yaml
+++ b/operations/kube-manifests/ConfigMap-tempo-query.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   tempo-query.yaml: |
-    backend: localhost:3100
+    backend: localhost:3200
 kind: ConfigMap
 metadata:
   name: tempo-query

--- a/operations/kube-manifests/ConfigMap-tempo.yaml
+++ b/operations/kube-manifests/ConfigMap-tempo.yaml
@@ -26,7 +26,7 @@ data:
     overrides:
         per_tenant_override_config: /conf/overrides.yaml
     server:
-        http_listen_port: 3100
+        http_listen_port: 3200
     storage:
         trace:
             backend: gcs

--- a/operations/kube-manifests/Deployment-compactor.yaml
+++ b/operations/kube-manifests/Deployment-compactor.yaml
@@ -32,12 +32,12 @@ spec:
         imagePullPolicy: IfNotPresent
         name: compactor
         ports:
-        - containerPort: 3100
+        - containerPort: 3200
           name: prom-metrics
         readinessProbe:
           httpGet:
             path: /ready
-            port: 3100
+            port: 3200
           initialDelaySeconds: 15
           timeoutSeconds: 1
         volumeMounts:

--- a/operations/kube-manifests/Deployment-distributor.yaml
+++ b/operations/kube-manifests/Deployment-distributor.yaml
@@ -34,12 +34,12 @@ spec:
         imagePullPolicy: IfNotPresent
         name: distributor
         ports:
-        - containerPort: 3100
+        - containerPort: 3200
           name: prom-metrics
         readinessProbe:
           httpGet:
             path: /ready
-            port: 3100
+            port: 3200
           initialDelaySeconds: 15
           timeoutSeconds: 1
         volumeMounts:

--- a/operations/kube-manifests/Deployment-querier.yaml
+++ b/operations/kube-manifests/Deployment-querier.yaml
@@ -34,12 +34,12 @@ spec:
         imagePullPolicy: IfNotPresent
         name: querier
         ports:
-        - containerPort: 3100
+        - containerPort: 3200
           name: prom-metrics
         readinessProbe:
           httpGet:
             path: /ready
-            port: 3100
+            port: 3200
           initialDelaySeconds: 15
           timeoutSeconds: 1
         volumeMounts:

--- a/operations/kube-manifests/Deployment-query-frontend.yaml
+++ b/operations/kube-manifests/Deployment-query-frontend.yaml
@@ -32,12 +32,12 @@ spec:
         imagePullPolicy: IfNotPresent
         name: query-frontend
         ports:
-        - containerPort: 3100
+        - containerPort: 3200
           name: prom-metrics
         readinessProbe:
           httpGet:
             path: /ready
-            port: 3100
+            port: 3200
           initialDelaySeconds: 15
           timeoutSeconds: 1
         volumeMounts:

--- a/operations/kube-manifests/Deployment-vulture.yaml
+++ b/operations/kube-manifests/Deployment-vulture.yaml
@@ -21,7 +21,7 @@ spec:
       - args:
         - -prometheus-listen-address=:8080
         - -tempo-push-url=http://distributor
-        - -tempo-query-url=http://query-frontend:3100/tempo
+        - -tempo-query-url=http://query-frontend:3200/tempo
         - -logtostderr=true
         - -tempo-org-id=1
         image: grafana/tempo-vulture:latest

--- a/operations/kube-manifests/Service-compactor.yaml
+++ b/operations/kube-manifests/Service-compactor.yaml
@@ -8,8 +8,8 @@ metadata:
 spec:
   ports:
   - name: compactor-prom-metrics
-    port: 3100
-    targetPort: 3100
+    port: 3200
+    targetPort: 3200
   selector:
     app: compactor
     name: compactor

--- a/operations/kube-manifests/Service-distributor.yaml
+++ b/operations/kube-manifests/Service-distributor.yaml
@@ -8,8 +8,8 @@ metadata:
 spec:
   ports:
   - name: distributor-prom-metrics
-    port: 3100
-    targetPort: 3100
+    port: 3200
+    targetPort: 3200
   selector:
     app: distributor
     name: distributor

--- a/operations/kube-manifests/Service-ingest.yaml
+++ b/operations/kube-manifests/Service-ingest.yaml
@@ -9,8 +9,8 @@ spec:
   clusterIP: None
   ports:
   - name: distributor-prom-metrics
-    port: 3100
-    targetPort: 3100
+    port: 3200
+    targetPort: 3200
   selector:
     app: distributor
     name: distributor

--- a/operations/kube-manifests/Service-ingester.yaml
+++ b/operations/kube-manifests/Service-ingester.yaml
@@ -8,8 +8,8 @@ metadata:
 spec:
   ports:
   - name: ingester-prom-metrics
-    port: 3100
-    targetPort: 3100
+    port: 3200
+    targetPort: 3200
   selector:
     app: ingester
     name: ingester

--- a/operations/kube-manifests/Service-query-frontend-discovery.yaml
+++ b/operations/kube-manifests/Service-query-frontend-discovery.yaml
@@ -9,8 +9,8 @@ spec:
   clusterIP: None
   ports:
   - name: query-frontend-prom-metrics
-    port: 3100
-    targetPort: 3100
+    port: 3200
+    targetPort: 3200
   - name: tempo-query-jaeger-ui
     port: 16686
     targetPort: 16686

--- a/operations/kube-manifests/Service-query-frontend.yaml
+++ b/operations/kube-manifests/Service-query-frontend.yaml
@@ -8,8 +8,8 @@ metadata:
 spec:
   ports:
   - name: query-frontend-prom-metrics
-    port: 3100
-    targetPort: 3100
+    port: 3200
+    targetPort: 3200
   - name: tempo-query-jaeger-ui
     port: 16686
     targetPort: 16686
@@ -18,7 +18,7 @@ spec:
     targetPort: 16687
   - name: http
     port: 80
-    targetPort: 3100
+    targetPort: 3200
   selector:
     app: query-frontend
     name: query-frontend

--- a/operations/kube-manifests/StatefulSet-ingester.yaml
+++ b/operations/kube-manifests/StatefulSet-ingester.yaml
@@ -37,12 +37,12 @@ spec:
         imagePullPolicy: IfNotPresent
         name: ingester
         ports:
-        - containerPort: 3100
+        - containerPort: 3200
           name: prom-metrics
         readinessProbe:
           httpGet:
             path: /ready
-            port: 3100
+            port: 3200
           initialDelaySeconds: 15
           timeoutSeconds: 1
         volumeMounts:

--- a/operations/kube-manifests/util/generator/main.jsonnet
+++ b/operations/kube-manifests/util/generator/main.jsonnet
@@ -51,7 +51,7 @@ tempo {
       replicas: 1,
       tempoOrgId: '1',
       tempoPushUrl: 'http://distributor',
-      tempoQueryUrl: 'http://query-frontend:3100/tempo',
+      tempoQueryUrl: 'http://query-frontend:3200/tempo',
     },
     jaeger_ui: {
       base_path: '/tempo',


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Replaces default port in documentation and tests from 3100 to 3200, regarding to #770

**Which issue(s) this PR fixes**:
Fixes #770

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`