### PR TITLE
Support returning compressed responses from query-frontend

### DIFF
--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"path"
 
+	"github.com/NYTimes/gziphandler"
 	"github.com/cortexproject/cortex/pkg/cortex"
 	cortex_frontend "github.com/cortexproject/cortex/pkg/frontend"
 	cortex_transport "github.com/cortexproject/cortex/pkg/frontend/transport"
@@ -185,6 +186,8 @@ func (t *App) initQueryFrontend() (services.Service, error) {
 	tracesHandler := middleware.Merge(
 		t.httpAuthMiddleware,
 	).Wrap(cortexHandler)
+
+	tracesHandler = gziphandler.GzipHandler(tracesHandler)
 
 	// register grpc server for queriers to connect to
 	cortex_frontend_v1pb.RegisterFrontendServer(t.Server.GRPC, t.frontend)

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -183,11 +183,11 @@ func (t *App) initQueryFrontend() (services.Service, error) {
 
 	cortexHandler := cortex_transport.NewHandler(t.cfg.Frontend.Config.Handler, shardingTripper, log.Logger, prometheus.DefaultRegisterer)
 
+	cortexHandler = gziphandler.GzipHandler(cortexHandler)
+
 	tracesHandler := middleware.Merge(
 		t.httpAuthMiddleware,
 	).Wrap(cortexHandler)
-
-	tracesHandler = gziphandler.GzipHandler(tracesHandler)
 
 	// register grpc server for queriers to connect to
 	cortex_frontend_v1pb.RegisterFrontendServer(t.Server.GRPC, t.frontend)

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -183,11 +183,11 @@ func (t *App) initQueryFrontend() (services.Service, error) {
 
 	cortexHandler := cortex_transport.NewHandler(t.cfg.Frontend.Config.Handler, shardingTripper, log.Logger, prometheus.DefaultRegisterer)
 
-	cortexHandler = gziphandler.GzipHandler(cortexHandler)
-
 	tracesHandler := middleware.Merge(
 		t.httpAuthMiddleware,
 	).Wrap(cortexHandler)
+
+	tracesHandler = gziphandler.GzipHandler(tracesHandler)
 
 	// register grpc server for queriers to connect to
 	cortex_frontend_v1pb.RegisterFrontendServer(t.Server.GRPC, t.frontend)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.2.0
 	github.com/Azure/azure-pipeline-go v0.2.2
 	github.com/Azure/azure-storage-blob-go v0.8.0
+	github.com/NYTimes/gziphandler v1.1.1
 	github.com/alecthomas/kong v0.2.11
 	github.com/cespare/xxhash v1.1.0
 	github.com/cortexproject/cortex v1.8.1-0.20210422151339-cf1c444e0905

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -1,13 +1,10 @@
 package e2e
 
 import (
-	"compress/gzip"
 	"context"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"math/rand"
-	"net/http"
 	"testing"
 	"time"
 
@@ -23,6 +20,7 @@ import (
 	jaeger_grpc "github.com/jaegertracing/jaeger/cmd/agent/app/reporter/grpc"
 	thrift "github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -68,9 +66,6 @@ func TestAllInOne(t *testing.T) {
 
 	// query an in-memory trace
 	queryAndAssertTrace(t, "http://"+tempo.Endpoint(3100)+"/api/traces/"+hexID, "my operation", 1)
-
-	// ensure queries are compressed when requested
-	queryAndAssertCompression(t, "http://"+tempo.Endpoint(3100)+"/api/traces/"+hexID, "my operation", 1)
 
 	// flush trace to backend
 	res, err := cortex_e2e.GetRequest("http://" + tempo.Endpoint(3100) + "/flush")
@@ -160,7 +155,6 @@ func TestAzuriteAllInOne(t *testing.T) {
 	queryAndAssertTrace(t, "http://"+tempo.Endpoint(3100)+"/api/traces/"+hexID, "my operation", 1)
 
 }
-
 func TestMicroservices(t *testing.T) {
 	s, err := cortex_e2e.NewScenario("tempo_e2e")
 	require.NoError(t, err)
@@ -262,6 +256,7 @@ func TestMicroservices(t *testing.T) {
 	batch = makeThriftBatch()
 	require.Error(t, c.EmitBatch(context.Background(), batch))
 }
+
 func makeThriftBatch() *thrift.Batch {
 	return makeThriftBatchWithSpanCount(1)
 }
@@ -300,37 +295,12 @@ func assertEcho(t *testing.T, url string) {
 func queryAndAssertTrace(t *testing.T, url string, expectedName string, expectedBatches int) {
 	res, err := cortex_e2e.GetRequest(url)
 	require.NoError(t, err)
-	defer res.Body.Close()
-
-	assertTrace(t, res.Body, expectedBatches, expectedName)
-}
-
-func queryAndAssertCompression(t *testing.T, url string, expectedName string, expectedBatches int) {
-	client := &http.Client{Timeout: 1 * time.Second}
-
-	request, err := http.NewRequest("GET", url, nil)
-	require.NoError(t, err)
-	request.Header.Add("Accept-Encoding", "gzip")
-
-	res, err := client.Do(request)
-	require.NoError(t, err)
-	defer res.Body.Close()
-
-	require.Equal(t, "gzip", res.Header.Get("Content-Encoding"))
-
-	gzipReader, err := gzip.NewReader(res.Body)
-	require.NoError(t, err)
-	defer gzipReader.Close()
-
-	assertTrace(t, gzipReader, expectedBatches, expectedName)
-}
-
-func assertTrace(t *testing.T, reader io.Reader, expectedBatches int, expectedName string) {
 	out := &tempopb.Trace{}
 	unmarshaller := &jsonpb.Unmarshaler{}
-	require.NoError(t, unmarshaller.Unmarshal(reader, out))
+	require.NoError(t, unmarshaller.Unmarshal(res.Body, out))
 	require.Len(t, out.Batches, expectedBatches)
-	require.Equal(t, expectedName, out.Batches[0].InstrumentationLibrarySpans[0].Spans[0].Name)
+	assert.Equal(t, expectedName, out.Batches[0].InstrumentationLibrarySpans[0].Spans[0].Name)
+	defer res.Body.Close()
 }
 
 func newJaegerGRPCClient(endpoint string) (*jaeger_grpc.Reporter, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -27,6 +27,7 @@ github.com/Azure/azure-storage-blob-go/azblob
 # github.com/Masterminds/squirrel v0.0.0-20161115235646-20f192218cf5
 github.com/Masterminds/squirrel
 # github.com/NYTimes/gziphandler v1.1.1
+## explicit
 github.com/NYTimes/gziphandler
 # github.com/PuerkitoBio/purell v1.1.1
 github.com/PuerkitoBio/purell


### PR DESCRIPTION
**What this PR does**:
The query-frontend will now gzip compress its response if the client requests this.

You can test this with curl by setting `--compressed`.

_But... I thought this was already supported?_

Despite what this config option might make you believe...

https://github.com/grafana/tempo/blob/026cff3910becf3ff9855f769149ce753cd2805f/modules/frontend/config.go#L16

...Tempo does not compress responses yet

While updating Cortex to v1.9 (#808) I noticed this flag has been deprecated and removed. When I investigated how this was being used, I noticed it isn't part of the code Tempo uses.
https://github.com/cortexproject/cortex/blob/4afaa357469fb37fd92cb1e2a0c1d10cdddc5ecd/pkg/cortex/modules.go#L557-L559