### PR TITLE
Emit traces for ingester flush operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [ENHANCEMENT] Add `tempo_ingester_flush_size_bytes` metric. [#777](https://github.com/grafana/tempo/pull/777) (@bboreham)
 * [ENHANCEMENT] Microservices jsonnet: resource requests and limits can be set in `$._config`. [#793](https://github.com/grafana/tempo/pull/793) (@kvrhdn)
 * [ENHANCEMENT] Add `-config.expand-env` cli flag to support environment variables expansion in config file. [#796](https://github.com/grafana/tempo/pull/796) (@Ashmita152)
+* [ENHANCEMENT] Emit traces for ingester flush operations. [#812](https://github.com/grafana/tempo/pull/812) (@bboreham)
 
 ## v1.0.1
 


### PR DESCRIPTION
**What this PR does**:
Create a new span for each flush, log the trace ID, and any error that comes back.

Passing a context in to `handleFlush()` seems more natural than having it assume it is only called in background context.

**Checklist**
- NA Tests updated
- NA Documentation added
- [x] `CHANGELOG.md` updated