### PR TITLE
Remove -o pipefail from image-tag script

### DIFF
--- a/tools/image-tag
+++ b/tools/image-tag
@@ -2,7 +2,6 @@
 
 set -o errexit
 set -o nounset
-set -o pipefail
 
 SHA="$(git rev-parse --short HEAD)"
 


### PR DESCRIPTION
**What this PR does**:
Remove -o pipefail from image-tag script

It is a bash-ism so not supported in some environments

Script doesn't have any pipelines where we could get a failure protected by pipefail

**Which issue(s) this PR fixes**:
Fixes #815 

**Checklist**
- NA Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated - this is not a user-visible change