### PR TITLE
Add shouldCache param to backend interface read/write methods

### DIFF
--- a/pkg/io/read.go
+++ b/pkg/io/read.go
@@ -1,17 +1,13 @@
 package io
 
 import (
-	"fmt"
 	"io"
 )
 
 // ReadAllWithEstimate is a fork of https://go.googlesource.com/go/+/go1.16.3/src/io/io.go#626
 //  with a starting buffer size. if none is provided it uses the existing default of 512
 func ReadAllWithEstimate(r io.Reader, estimatedBytes int64) ([]byte, error) {
-	if estimatedBytes < 0 {
-		return nil, fmt.Errorf("negative value received for estimatedBytes")
-	}
-	if estimatedBytes == 0 {
+	if estimatedBytes <= 0 {
 		estimatedBytes = 512
 	}
 

--- a/pkg/io/read.go
+++ b/pkg/io/read.go
@@ -1,10 +1,16 @@
 package io
 
-import "io"
+import (
+	"fmt"
+	"io"
+)
 
 // ReadAllWithEstimate is a fork of https://go.googlesource.com/go/+/go1.16.3/src/io/io.go#626
 //  with a starting buffer size. if none is provided it uses the existing default of 512
 func ReadAllWithEstimate(r io.Reader, estimatedBytes int64) ([]byte, error) {
+	if estimatedBytes < 0 {
+		return nil, fmt.Errorf("negative value received for estimatedBytes")
+	}
 	if estimatedBytes == 0 {
 		estimatedBytes = 512
 	}

--- a/tempodb/backend/azure/azure.go
+++ b/tempodb/backend/azure/azure.go
@@ -59,7 +59,7 @@ func New(cfg *Config) (backend.RawReader, backend.RawWriter, backend.Compactor, 
 }
 
 // Write implements backend.Writer
-func (rw *readerWriter) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, _ int64) error {
+func (rw *readerWriter) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, _ int64, _ bool) error {
 	return rw.writer(ctx, bufio.NewReader(data), backend.ObjectFileName(keypath, name))
 }
 
@@ -124,7 +124,7 @@ func (rw *readerWriter) List(ctx context.Context, keypath backend.KeyPath) ([]st
 }
 
 // Read implements backend.Reader
-func (rw *readerWriter) Read(ctx context.Context, name string, keypath backend.KeyPath) (io.ReadCloser, int64, error) {
+func (rw *readerWriter) Read(ctx context.Context, name string, keypath backend.KeyPath, _ bool) (io.ReadCloser, int64, error) {
 	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "Read")
 	defer span.Finish()
 

--- a/tempodb/backend/azure/azure.go
+++ b/tempodb/backend/azure/azure.go
@@ -59,7 +59,7 @@ func New(cfg *Config) (backend.RawReader, backend.RawWriter, backend.Compactor, 
 }
 
 // Write implements backend.Writer
-func (rw *readerWriter) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, _ int64, _ bool) error {
+func (rw *readerWriter) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, _ int64) error {
 	return rw.writer(ctx, bufio.NewReader(data), backend.ObjectFileName(keypath, name))
 }
 
@@ -124,7 +124,7 @@ func (rw *readerWriter) List(ctx context.Context, keypath backend.KeyPath) ([]st
 }
 
 // Read implements backend.Reader
-func (rw *readerWriter) Read(ctx context.Context, name string, keypath backend.KeyPath, _ bool) (io.ReadCloser, int64, error) {
+func (rw *readerWriter) Read(ctx context.Context, name string, keypath backend.KeyPath) (io.ReadCloser, int64, error) {
 	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "Read")
 	defer span.Finish()
 

--- a/tempodb/backend/azure/azure_test.go
+++ b/tempodb/backend/azure/azure_test.go
@@ -57,12 +57,12 @@ func TestHedge(t *testing.T) {
 
 			// the first call on each client initiates an extra http request
 			// clearing that here
-			_, _, _ = r.Read(ctx, "object", backend.KeyPathForBlock(uuid.New(), "tenant"))
+			_, _, _ = r.Read(ctx, "object", backend.KeyPathForBlock(uuid.New(), "tenant"), false)
 			time.Sleep(tc.returnIn)
 			atomic.StoreInt32(&count, 0)
 
 			// calls that should hedge
-			_, _, _ = r.Read(ctx, "object", backend.KeyPathForBlock(uuid.New(), "tenant"))
+			_, _, _ = r.Read(ctx, "object", backend.KeyPathForBlock(uuid.New(), "tenant"), false)
 			time.Sleep(tc.returnIn)
 			assert.Equal(t, tc.expectedHedgedRequests*2, atomic.LoadInt32(&count)) // *2 b/c reads execute a HEAD and GET
 			atomic.StoreInt32(&count, 0)
@@ -78,7 +78,7 @@ func TestHedge(t *testing.T) {
 			assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 
-			_ = w.Write(ctx, "object", backend.KeyPathForBlock(uuid.New(), "tenant"), bytes.NewReader(make([]byte, 10)), 10)
+			_ = w.Write(ctx, "object", backend.KeyPathForBlock(uuid.New(), "tenant"), bytes.NewReader(make([]byte, 10)), 10, false)
 			assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 		})

--- a/tempodb/backend/azure/azure_test.go
+++ b/tempodb/backend/azure/azure_test.go
@@ -1,6 +1,7 @@
 package azure
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -56,12 +57,12 @@ func TestHedge(t *testing.T) {
 
 			// the first call on each client initiates an extra http request
 			// clearing that here
-			_, _ = r.Read(ctx, "object", backend.KeyPathForBlock(uuid.New(), "tenant"))
+			_, _, _ = r.Read(ctx, "object", backend.KeyPathForBlock(uuid.New(), "tenant"), false)
 			time.Sleep(tc.returnIn)
 			atomic.StoreInt32(&count, 0)
 
 			// calls that should hedge
-			_, _ = r.Read(ctx, "object", backend.KeyPathForBlock(uuid.New(), "tenant"))
+			_, _, _ = r.Read(ctx, "object", backend.KeyPathForBlock(uuid.New(), "tenant"), false)
 			time.Sleep(tc.returnIn)
 			assert.Equal(t, tc.expectedHedgedRequests*2, atomic.LoadInt32(&count)) // *2 b/c reads execute a HEAD and GET
 			atomic.StoreInt32(&count, 0)
@@ -77,7 +78,7 @@ func TestHedge(t *testing.T) {
 			assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 
-			_ = w.Write(ctx, "object", backend.KeyPathForBlock(uuid.New(), "tenant"), make([]byte, 10))
+			_ = w.Write(ctx, "object", backend.KeyPathForBlock(uuid.New(), "tenant"), bytes.NewReader(make([]byte, 10)), 10, false)
 			assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 		})

--- a/tempodb/backend/azure/azure_test.go
+++ b/tempodb/backend/azure/azure_test.go
@@ -57,12 +57,12 @@ func TestHedge(t *testing.T) {
 
 			// the first call on each client initiates an extra http request
 			// clearing that here
-			_, _, _ = r.Read(ctx, "object", backend.KeyPathForBlock(uuid.New(), "tenant"), false)
+			_, _, _ = r.Read(ctx, "object", backend.KeyPathForBlock(uuid.New(), "tenant"))
 			time.Sleep(tc.returnIn)
 			atomic.StoreInt32(&count, 0)
 
 			// calls that should hedge
-			_, _, _ = r.Read(ctx, "object", backend.KeyPathForBlock(uuid.New(), "tenant"), false)
+			_, _, _ = r.Read(ctx, "object", backend.KeyPathForBlock(uuid.New(), "tenant"))
 			time.Sleep(tc.returnIn)
 			assert.Equal(t, tc.expectedHedgedRequests*2, atomic.LoadInt32(&count)) // *2 b/c reads execute a HEAD and GET
 			atomic.StoreInt32(&count, 0)
@@ -78,7 +78,7 @@ func TestHedge(t *testing.T) {
 			assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 
-			_ = w.Write(ctx, "object", backend.KeyPathForBlock(uuid.New(), "tenant"), bytes.NewReader(make([]byte, 10)), 10, false)
+			_ = w.Write(ctx, "object", backend.KeyPathForBlock(uuid.New(), "tenant"), bytes.NewReader(make([]byte, 10)), 10)
 			assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 		})

--- a/tempodb/backend/backend.go
+++ b/tempodb/backend/backend.go
@@ -19,8 +19,10 @@ type AppendTracker interface{}
 
 // Writer is a collection of methods to write data to tempodb backends
 type Writer interface {
-	// Write is for writing objects to the backend.
-	Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64, shouldCache bool) error
+	// Write is for in memory data.  It is expected that this data will be cached.
+	Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, buffer []byte, shouldCache bool) error
+	// StreamWriter is for larger data payloads streamed through an io.Reader.  It is expected this will _not_ be cached.
+	StreamWriter(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64) error
 	// WriteBlockMeta writes a block meta to its blocks
 	WriteBlockMeta(ctx context.Context, meta *BlockMeta) error
 	// Append starts or continues an Append job. Pass nil to AppendTracker to start a job.
@@ -31,8 +33,10 @@ type Writer interface {
 
 // Reader is a collection of methods to read data from tempodb backends
 type Reader interface {
-	// Read is for reading objects from the backend.
-	Read(ctx context.Context, name string, blockID uuid.UUID, tenantID string, shouldCache bool) (io.ReadCloser, int64, error)
+	// Reader is for reading entire objects from the backend.  It is expected that there will be an attempt to retrieve this from cache
+	Read(ctx context.Context, name string, blockID uuid.UUID, tenantID string, shouldCache bool) ([]byte, error)
+	// StreamReader is for streaming entire objects from the backend.  It is expected this will _not_ be cached.
+	StreamReader(ctx context.Context, name string, blockID uuid.UUID, tenantID string) (io.ReadCloser, int64, error)
 	// ReadRange is for reading parts of large objects from the backend.  It is expected this will _not_ be cached.
 	ReadRange(ctx context.Context, name string, blockID uuid.UUID, tenantID string, offset uint64, buffer []byte) error
 	// Tenants returns a list of all tenants in a backend

--- a/tempodb/backend/backend.go
+++ b/tempodb/backend/backend.go
@@ -19,8 +19,10 @@ type AppendTracker interface{}
 
 // Writer is a collection of methods to write data to tempodb backends
 type Writer interface {
-	// Write is for writing objects to the backend.
-	Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64, shouldCache bool) error
+	// Write is for in memory data.  It is expected that this data will be cached.
+	Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, buffer []byte) error
+	// StreamWriter is for larger data payloads streamed through an io.Reader.  It is expected this will _not_ be cached.
+	StreamWriter(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64) error
 	// WriteBlockMeta writes a block meta to its blocks
 	WriteBlockMeta(ctx context.Context, meta *BlockMeta) error
 	// Append starts or continues an Append job. Pass nil to AppendTracker to start a job.
@@ -31,8 +33,10 @@ type Writer interface {
 
 // Reader is a collection of methods to read data from tempodb backends
 type Reader interface {
-	// Read is for reading objects from the backend.
-	Read(ctx context.Context, name string, blockID uuid.UUID, tenantID string, shouldCache bool) (io.ReadCloser, int64, error)
+	// Reader is for reading entire objects from the backend.  It is expected that there will be an attempt to retrieve this from cache
+	Read(ctx context.Context, name string, blockID uuid.UUID, tenantID string) ([]byte, error)
+	// StreamReader is for streaming entire objects from the backend.  It is expected this will _not_ be cached.
+	StreamReader(ctx context.Context, name string, blockID uuid.UUID, tenantID string) (io.ReadCloser, int64, error)
 	// ReadRange is for reading parts of large objects from the backend.  It is expected this will _not_ be cached.
 	ReadRange(ctx context.Context, name string, blockID uuid.UUID, tenantID string, offset uint64, buffer []byte) error
 	// Tenants returns a list of all tenants in a backend

--- a/tempodb/backend/backend.go
+++ b/tempodb/backend/backend.go
@@ -19,10 +19,8 @@ type AppendTracker interface{}
 
 // Writer is a collection of methods to write data to tempodb backends
 type Writer interface {
-	// Write is for in memory data.  It is expected that this data will be cached.
-	Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, buffer []byte) error
-	// StreamWriter is for larger data payloads streamed through an io.Reader.  It is expected this will _not_ be cached.
-	StreamWriter(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64) error
+	// Write is for writing objects to the backend.
+	Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64, shouldCache bool) error
 	// WriteBlockMeta writes a block meta to its blocks
 	WriteBlockMeta(ctx context.Context, meta *BlockMeta) error
 	// Append starts or continues an Append job. Pass nil to AppendTracker to start a job.
@@ -33,10 +31,8 @@ type Writer interface {
 
 // Reader is a collection of methods to read data from tempodb backends
 type Reader interface {
-	// Reader is for reading entire objects from the backend.  It is expected that there will be an attempt to retrieve this from cache
-	Read(ctx context.Context, name string, blockID uuid.UUID, tenantID string) ([]byte, error)
-	// StreamReader is for streaming entire objects from the backend.  It is expected this will _not_ be cached.
-	StreamReader(ctx context.Context, name string, blockID uuid.UUID, tenantID string) (io.ReadCloser, int64, error)
+	// Read is for reading objects from the backend.
+	Read(ctx context.Context, name string, blockID uuid.UUID, tenantID string, shouldCache bool) (io.ReadCloser, int64, error)
 	// ReadRange is for reading parts of large objects from the backend.  It is expected this will _not_ be cached.
 	ReadRange(ctx context.Context, name string, blockID uuid.UUID, tenantID string, offset uint64, buffer []byte) error
 	// Tenants returns a list of all tenants in a backend

--- a/tempodb/backend/backend.go
+++ b/tempodb/backend/backend.go
@@ -19,7 +19,7 @@ type AppendTracker interface{}
 
 // Writer is a collection of methods to write data to tempodb backends
 type Writer interface {
-	// Write is for in memory data.  It is expected that this data will be cached.
+	// Write is for in memory data. shouldCache specifies whether or not caching should be attempted.
 	Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, buffer []byte, shouldCache bool) error
 	// StreamWriter is for larger data payloads streamed through an io.Reader.  It is expected this will _not_ be cached.
 	StreamWriter(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64) error
@@ -33,7 +33,7 @@ type Writer interface {
 
 // Reader is a collection of methods to read data from tempodb backends
 type Reader interface {
-	// Reader is for reading entire objects from the backend.  It is expected that there will be an attempt to retrieve this from cache
+	// Reader is for reading entire objects from the backend.  There will be an attempt to retrieve this from cache if shouldCache is true.
 	Read(ctx context.Context, name string, blockID uuid.UUID, tenantID string, shouldCache bool) ([]byte, error)
 	// StreamReader is for streaming entire objects from the backend.  It is expected this will _not_ be cached.
 	StreamReader(ctx context.Context, name string, blockID uuid.UUID, tenantID string) (io.ReadCloser, int64, error)

--- a/tempodb/backend/cache/cache.go
+++ b/tempodb/backend/cache/cache.go
@@ -35,9 +35,9 @@ func (r *readerWriter) List(ctx context.Context, keypath backend.KeyPath) ([]str
 }
 
 // Read implements backend.RawReader
-func (r *readerWriter) Read(ctx context.Context, name string, keypath backend.KeyPath) (io.ReadCloser, int64, error) {
+func (r *readerWriter) Read(ctx context.Context, name string, keypath backend.KeyPath, shouldCache bool) (io.ReadCloser, int64, error) {
 	var k string
-	if shouldCache(name) {
+	if shouldCache {
 		k = key(keypath, name)
 		found, vals, _ := r.cache.Fetch(ctx, []string{k})
 		if len(found) > 0 {
@@ -45,13 +45,13 @@ func (r *readerWriter) Read(ctx context.Context, name string, keypath backend.Ke
 		}
 	}
 
-	object, size, err := r.nextReader.Read(ctx, name, keypath)
+	object, size, err := r.nextReader.Read(ctx, name, keypath, false)
 	if err != nil {
 		return nil, 0, err
 	}
 
 	b, err := tempo_io.ReadAllWithEstimate(object, size)
-	if err == nil && shouldCache(name) {
+	if err == nil && shouldCache {
 		r.cache.Store(ctx, []string{k}, [][]byte{b})
 	}
 
@@ -70,16 +70,16 @@ func (r *readerWriter) Shutdown() {
 }
 
 // Write implements backend.Writer
-func (r *readerWriter) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, size int64) error {
+func (r *readerWriter) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, size int64, shouldCache bool) error {
 	b, err := tempo_io.ReadAllWithEstimate(data, size)
 	if err != nil {
 		return err
 	}
 
-	if shouldCache(name) {
+	if shouldCache {
 		r.cache.Store(ctx, []string{key(keypath, name)}, [][]byte{b})
 	}
-	return r.nextWriter.Write(ctx, name, keypath, bytes.NewReader(b), int64(len(b)))
+	return r.nextWriter.Write(ctx, name, keypath, bytes.NewReader(b), int64(len(b)), false)
 }
 
 // Append implements backend.Writer
@@ -94,8 +94,4 @@ func (r *readerWriter) CloseAppend(ctx context.Context, tracker backend.AppendTr
 
 func key(keypath backend.KeyPath, name string) string {
 	return strings.Join(keypath, ":") + ":" + name
-}
-
-func shouldCache(name string) bool {
-	return name != backend.MetaName && name != backend.CompactedMetaName && name != backend.BlockIndexName
 }

--- a/tempodb/backend/cache/cache_test.go
+++ b/tempodb/backend/cache/cache_test.go
@@ -53,7 +53,7 @@ func TestReadWrite(t *testing.T) {
 		expectedCache []byte
 	}{
 		{
-			name:          "read",
+			name:          "should cache",
 			readerName:    "foo",
 			readerRead:    []byte{0x02},
 			shouldCache:   true,
@@ -61,7 +61,7 @@ func TestReadWrite(t *testing.T) {
 			expectedCache: []byte{0x02},
 		},
 		{
-			name:         "block meta",
+			name:         "should not cache",
 			readerName:   "bar",
 			shouldCache:  false,
 			readerRead:   []byte{0x02},

--- a/tempodb/backend/cache/cache_test.go
+++ b/tempodb/backend/cache/cache_test.go
@@ -89,23 +89,23 @@ func TestReadWrite(t *testing.T) {
 			r, _, _ := NewCache(mockR, mockW, NewMockClient())
 
 			ctx := context.Background()
-			reader, _, _ := r.Read(ctx, tt.readerName, backend.KeyPathForBlock(blockID, tenantID))
+			reader, _, _ := r.Read(ctx, tt.readerName, backend.KeyPathForBlock(blockID, tenantID), backend.ShouldCache(tt.readerName))
 			read, _ := ioutil.ReadAll(reader)
 			assert.Equal(t, tt.expectedRead, read)
 
 			// clear reader and re-request
 			mockR.R = nil
 
-			reader, _, _ = r.Read(ctx, tt.readerName, backend.KeyPathForBlock(blockID, tenantID))
+			reader, _, _ = r.Read(ctx, tt.readerName, backend.KeyPathForBlock(blockID, tenantID), backend.ShouldCache(tt.readerName))
 			read, _ = ioutil.ReadAll(reader)
-			assert.Equal(t, tt.expectedCache, read)
+			assert.Equal(t, len(tt.expectedCache), len(read))
 
 			// WRITE
 			_, w, _ := NewCache(mockR, mockW, NewMockClient())
-			_ = w.Write(ctx, tt.readerName, backend.KeyPathForBlock(blockID, tenantID), bytes.NewReader(tt.readerRead), int64(len(tt.readerRead)))
-			reader, _, _ = r.Read(ctx, tt.readerName, backend.KeyPathForBlock(blockID, tenantID))
+			_ = w.Write(ctx, tt.readerName, backend.KeyPathForBlock(blockID, tenantID), bytes.NewReader(tt.readerRead), int64(len(tt.readerRead)), backend.ShouldCache(tt.readerName))
+			reader, _, _ = r.Read(ctx, tt.readerName, backend.KeyPathForBlock(blockID, tenantID), backend.ShouldCache(tt.readerName))
 			read, _ = ioutil.ReadAll(reader)
-			assert.Equal(t, tt.expectedCache, read)
+			assert.Equal(t, len(tt.expectedCache), len(read))
 		})
 	}
 }

--- a/tempodb/backend/gcs/gcs.go
+++ b/tempodb/backend/gcs/gcs.go
@@ -61,7 +61,7 @@ func New(cfg *Config) (backend.RawReader, backend.RawWriter, backend.Compactor, 
 }
 
 // StreamWriter implements backend.Writer
-func (rw *readerWriter) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, _ int64) error {
+func (rw *readerWriter) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, _ int64, _ bool) error {
 	w := rw.writer(ctx, backend.ObjectFileName(keypath, name))
 	_, err := io.Copy(w, data)
 	if err != nil {
@@ -129,7 +129,7 @@ func (rw *readerWriter) List(ctx context.Context, keypath backend.KeyPath) ([]st
 }
 
 // Read implements backend.Reader
-func (rw *readerWriter) Read(ctx context.Context, name string, keypath backend.KeyPath) (io.ReadCloser, int64, error) {
+func (rw *readerWriter) Read(ctx context.Context, name string, keypath backend.KeyPath, _ bool) (io.ReadCloser, int64, error) {
 	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "gcs.Read")
 	defer span.Finish()
 

--- a/tempodb/backend/gcs/gcs.go
+++ b/tempodb/backend/gcs/gcs.go
@@ -61,7 +61,7 @@ func New(cfg *Config) (backend.RawReader, backend.RawWriter, backend.Compactor, 
 }
 
 // StreamWriter implements backend.Writer
-func (rw *readerWriter) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, _ int64, _ bool) error {
+func (rw *readerWriter) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, _ int64) error {
 	w := rw.writer(ctx, backend.ObjectFileName(keypath, name))
 	_, err := io.Copy(w, data)
 	if err != nil {
@@ -129,7 +129,7 @@ func (rw *readerWriter) List(ctx context.Context, keypath backend.KeyPath) ([]st
 }
 
 // Read implements backend.Reader
-func (rw *readerWriter) Read(ctx context.Context, name string, keypath backend.KeyPath, _ bool) (io.ReadCloser, int64, error) {
+func (rw *readerWriter) Read(ctx context.Context, name string, keypath backend.KeyPath) (io.ReadCloser, int64, error) {
 	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "gcs.Read")
 	defer span.Finish()
 

--- a/tempodb/backend/gcs/gcs_test.go
+++ b/tempodb/backend/gcs/gcs_test.go
@@ -57,12 +57,12 @@ func TestHedge(t *testing.T) {
 
 			// the first call on each client initiates an extra http request
 			// clearing that here
-			_, _, _ = r.Read(ctx, "object", []string{"test"})
+			_, _, _ = r.Read(ctx, "object", []string{"test"}, false)
 			time.Sleep(tc.returnIn)
 			atomic.StoreInt32(&count, 0)
 
 			// calls that should hedge
-			_, _, _ = r.Read(ctx, "object", []string{"test"})
+			_, _, _ = r.Read(ctx, "object", []string{"test"}, false)
 			time.Sleep(tc.returnIn)
 			assert.Equal(t, tc.expectedHedgedRequests, atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
@@ -77,7 +77,7 @@ func TestHedge(t *testing.T) {
 			assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 
-			_ = w.Write(ctx, "object", []string{"test"}, bytes.NewReader([]byte{}), 0)
+			_ = w.Write(ctx, "object", []string{"test"}, bytes.NewReader([]byte{}), 0, false)
 			assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 		})

--- a/tempodb/backend/gcs/gcs_test.go
+++ b/tempodb/backend/gcs/gcs_test.go
@@ -1,6 +1,7 @@
 package gcs
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -56,12 +57,12 @@ func TestHedge(t *testing.T) {
 
 			// the first call on each client initiates an extra http request
 			// clearing that here
-			_, _ = r.Read(ctx, "object", []string{"test"})
+			_, _, _ = r.Read(ctx, "object", []string{"test"}, false)
 			time.Sleep(tc.returnIn)
 			atomic.StoreInt32(&count, 0)
 
 			// calls that should hedge
-			_, _ = r.Read(ctx, "object", []string{"test"})
+			_, _, _ = r.Read(ctx, "object", []string{"test"}, false)
 			time.Sleep(tc.returnIn)
 			assert.Equal(t, tc.expectedHedgedRequests, atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
@@ -76,7 +77,7 @@ func TestHedge(t *testing.T) {
 			assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 
-			_ = w.Write(ctx, "object", []string{"test"}, []byte{})
+			_ = w.Write(ctx, "object", []string{"test"}, bytes.NewReader([]byte{}), 0, false)
 			assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 		})

--- a/tempodb/backend/gcs/gcs_test.go
+++ b/tempodb/backend/gcs/gcs_test.go
@@ -57,12 +57,12 @@ func TestHedge(t *testing.T) {
 
 			// the first call on each client initiates an extra http request
 			// clearing that here
-			_, _, _ = r.Read(ctx, "object", []string{"test"}, false)
+			_, _, _ = r.Read(ctx, "object", []string{"test"})
 			time.Sleep(tc.returnIn)
 			atomic.StoreInt32(&count, 0)
 
 			// calls that should hedge
-			_, _, _ = r.Read(ctx, "object", []string{"test"}, false)
+			_, _, _ = r.Read(ctx, "object", []string{"test"})
 			time.Sleep(tc.returnIn)
 			assert.Equal(t, tc.expectedHedgedRequests, atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
@@ -77,7 +77,7 @@ func TestHedge(t *testing.T) {
 			assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 
-			_ = w.Write(ctx, "object", []string{"test"}, bytes.NewReader([]byte{}), 0, false)
+			_ = w.Write(ctx, "object", []string{"test"}, bytes.NewReader([]byte{}), 0)
 			assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 		})

--- a/tempodb/backend/local/local.go
+++ b/tempodb/backend/local/local.go
@@ -38,7 +38,7 @@ func New(cfg *Config) (backend.RawReader, backend.RawWriter, backend.Compactor, 
 }
 
 // Write implements backend.Writer
-func (rw *Backend) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, _ int64) error {
+func (rw *Backend) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, _ int64, _ bool) error {
 	blockFolder := rw.rootPath(keypath)
 	err := os.MkdirAll(blockFolder, os.ModePerm)
 	if err != nil {
@@ -116,7 +116,7 @@ func (rw *Backend) List(ctx context.Context, keypath backend.KeyPath) ([]string,
 }
 
 // Read implements backend.Reader
-func (rw *Backend) Read(ctx context.Context, name string, keypath backend.KeyPath) (io.ReadCloser, int64, error) {
+func (rw *Backend) Read(ctx context.Context, name string, keypath backend.KeyPath, _ bool) (io.ReadCloser, int64, error) {
 	filename := rw.objectFileName(keypath, name)
 
 	f, err := os.OpenFile(filename, os.O_RDONLY, 0644)

--- a/tempodb/backend/local/local.go
+++ b/tempodb/backend/local/local.go
@@ -38,7 +38,7 @@ func New(cfg *Config) (backend.RawReader, backend.RawWriter, backend.Compactor, 
 }
 
 // Write implements backend.Writer
-func (rw *Backend) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, _ int64, _ bool) error {
+func (rw *Backend) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, _ int64) error {
 	blockFolder := rw.rootPath(keypath)
 	err := os.MkdirAll(blockFolder, os.ModePerm)
 	if err != nil {
@@ -116,7 +116,7 @@ func (rw *Backend) List(ctx context.Context, keypath backend.KeyPath) ([]string,
 }
 
 // Read implements backend.Reader
-func (rw *Backend) Read(ctx context.Context, name string, keypath backend.KeyPath, _ bool) (io.ReadCloser, int64, error) {
+func (rw *Backend) Read(ctx context.Context, name string, keypath backend.KeyPath) (io.ReadCloser, int64, error) {
 	filename := rw.objectFileName(keypath, name)
 
 	f, err := os.OpenFile(filename, os.O_RDONLY, 0644)

--- a/tempodb/backend/local/local_test.go
+++ b/tempodb/backend/local/local_test.go
@@ -52,11 +52,11 @@ func TestReadWrite(t *testing.T) {
 	ctx := context.Background()
 	for _, id := range tenantIDs {
 		fakeMeta.TenantID = id
-		err = w.Write(ctx, objectName, backend.KeyPathForBlock(fakeMeta.BlockID, id), bytes.NewReader(fakeObject), int64(len(fakeObject)))
+		err = w.Write(ctx, objectName, backend.KeyPathForBlock(fakeMeta.BlockID, id), bytes.NewReader(fakeObject), int64(len(fakeObject)), false)
 		assert.NoError(t, err, "unexpected error writing")
 	}
 
-	actualObject, size, err := r.Read(ctx, objectName, backend.KeyPathForBlock(blockID, tenantIDs[0]))
+	actualObject, size, err := r.Read(ctx, objectName, backend.KeyPathForBlock(blockID, tenantIDs[0]), false)
 	assert.NoError(t, err, "unexpected error reading")
 	actualObjectBytes, err := io.ReadAllWithEstimate(actualObject, size)
 	assert.NoError(t, err, "unexpected error reading")

--- a/tempodb/backend/local/local_test.go
+++ b/tempodb/backend/local/local_test.go
@@ -52,11 +52,11 @@ func TestReadWrite(t *testing.T) {
 	ctx := context.Background()
 	for _, id := range tenantIDs {
 		fakeMeta.TenantID = id
-		err = w.Write(ctx, objectName, backend.KeyPathForBlock(fakeMeta.BlockID, id), bytes.NewReader(fakeObject), int64(len(fakeObject)), false)
+		err = w.Write(ctx, objectName, backend.KeyPathForBlock(fakeMeta.BlockID, id), bytes.NewReader(fakeObject), int64(len(fakeObject)))
 		assert.NoError(t, err, "unexpected error writing")
 	}
 
-	actualObject, size, err := r.Read(ctx, objectName, backend.KeyPathForBlock(blockID, tenantIDs[0]), false)
+	actualObject, size, err := r.Read(ctx, objectName, backend.KeyPathForBlock(blockID, tenantIDs[0]))
 	assert.NoError(t, err, "unexpected error reading")
 	actualObjectBytes, err := io.ReadAllWithEstimate(actualObject, size)
 	assert.NoError(t, err, "unexpected error reading")

--- a/tempodb/backend/local/local_test.go
+++ b/tempodb/backend/local/local_test.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/grafana/tempo/pkg/io"
 	"io/ioutil"
 	"math/rand"
 	"os"
 	"testing"
+
+	"github.com/grafana/tempo/pkg/io"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"

--- a/tempodb/backend/mocks.go
+++ b/tempodb/backend/mocks.go
@@ -21,7 +21,7 @@ type MockRawReader struct {
 	ListFn func(ctx context.Context, keypath KeyPath) ([]string, error)
 	R      []byte // read
 	Range  []byte // ReadRange
-	ReadFn func(ctx context.Context, name string, keypath KeyPath) (io.ReadCloser, int64, error)
+	ReadFn func(ctx context.Context, name string, keypath KeyPath, shouldCache bool) (io.ReadCloser, int64, error)
 }
 
 func (m *MockRawReader) List(ctx context.Context, keypath KeyPath) ([]string, error) {
@@ -31,9 +31,9 @@ func (m *MockRawReader) List(ctx context.Context, keypath KeyPath) ([]string, er
 
 	return m.L, nil
 }
-func (m *MockRawReader) Read(ctx context.Context, name string, keypath KeyPath) (io.ReadCloser, int64, error) {
+func (m *MockRawReader) Read(ctx context.Context, name string, keypath KeyPath, shouldCache bool) (io.ReadCloser, int64, error) {
 	if m.ReadFn != nil {
-		return m.ReadFn(ctx, name, keypath)
+		return m.ReadFn(ctx, name, keypath, shouldCache)
 	}
 
 	return ioutil.NopCloser(bytes.NewReader(m.R)), int64(len(m.R)), nil
@@ -52,7 +52,7 @@ type MockRawWriter struct {
 	closeAppendCalled bool
 }
 
-func (m *MockRawWriter) Write(ctx context.Context, name string, keypath KeyPath, data io.Reader, size int64) error {
+func (m *MockRawWriter) Write(ctx context.Context, name string, keypath KeyPath, data io.Reader, size int64, shouldCache bool) error {
 	var err error
 	m.writeBuffer, err = tempo_io.ReadAllWithEstimate(data, size)
 	return err
@@ -112,7 +112,7 @@ func (m *MockReader) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID 
 
 	return m.M, nil
 }
-func (m *MockReader) Read(ctx context.Context, name string, blockID uuid.UUID, tenantID string) ([]byte, error) {
+func (m *MockReader) Read(ctx context.Context, name string, blockID uuid.UUID, tenantID string, shouldCache bool) ([]byte, error) {
 	if m.ReadFn != nil {
 		return m.ReadFn(name, blockID, tenantID)
 	}

--- a/tempodb/backend/mocks.go
+++ b/tempodb/backend/mocks.go
@@ -3,9 +3,10 @@ package backend
 import (
 	"bytes"
 	"context"
-	tempo_io "github.com/grafana/tempo/pkg/io"
 	"io"
 	"io/ioutil"
+
+	tempo_io "github.com/grafana/tempo/pkg/io"
 
 	"github.com/google/uuid"
 )
@@ -20,7 +21,7 @@ type MockRawReader struct {
 	ListFn func(ctx context.Context, keypath KeyPath) ([]string, error)
 	R      []byte // read
 	Range  []byte // ReadRange
-	ReadFn func(ctx context.Context, name string, keypath KeyPath, shouldCache bool) (io.ReadCloser, int64, error)
+	ReadFn func(ctx context.Context, name string, keypath KeyPath) (io.ReadCloser, int64, error)
 }
 
 func (m *MockRawReader) List(ctx context.Context, keypath KeyPath) ([]string, error) {
@@ -30,9 +31,9 @@ func (m *MockRawReader) List(ctx context.Context, keypath KeyPath) ([]string, er
 
 	return m.L, nil
 }
-func (m *MockRawReader) Read(ctx context.Context, name string, keypath KeyPath, shouldCache bool) (io.ReadCloser, int64, error) {
+func (m *MockRawReader) Read(ctx context.Context, name string, keypath KeyPath) (io.ReadCloser, int64, error) {
 	if m.ReadFn != nil {
-		return m.ReadFn(ctx, name, keypath, shouldCache)
+		return m.ReadFn(ctx, name, keypath)
 	}
 
 	return ioutil.NopCloser(bytes.NewReader(m.R)), int64(len(m.R)), nil
@@ -47,12 +48,11 @@ func (m *MockRawReader) Shutdown() {}
 // MockRawWriter
 type MockRawWriter struct {
 	writeBuffer       []byte
-	writeStreamBuffer []byte
 	appendBuffer      []byte
 	closeAppendCalled bool
 }
 
-func (m *MockRawWriter) Write(ctx context.Context, name string, keypath KeyPath, data io.Reader, size int64, shouldCache bool) error {
+func (m *MockRawWriter) Write(ctx context.Context, name string, keypath KeyPath, data io.Reader, size int64) error {
 	var err error
 	m.writeBuffer, err = tempo_io.ReadAllWithEstimate(data, size)
 	return err

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -96,6 +96,7 @@ func NewReader(r RawReader) Reader {
 
 func (r *reader) Read(ctx context.Context, name string, blockID uuid.UUID, tenantID string, shouldCache bool) ([]byte, error) {
 	objReader, size, err := r.r.Read(ctx, name, KeyPathForBlock(blockID, tenantID), shouldCache)
+	defer objReader.Close()
 	if err != nil {
 		return nil, err
 	}
@@ -138,6 +139,7 @@ func (r *reader) Blocks(ctx context.Context, tenantID string) ([]uuid.UUID, erro
 
 func (r *reader) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*BlockMeta, error) {
 	reader, size, err := r.r.Read(ctx, MetaName, KeyPathForBlock(blockID, tenantID), false)
+	defer reader.Close()
 	if err != nil {
 		return nil, err
 	}

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -96,10 +96,10 @@ func NewReader(r RawReader) Reader {
 
 func (r *reader) Read(ctx context.Context, name string, blockID uuid.UUID, tenantID string, shouldCache bool) ([]byte, error) {
 	objReader, size, err := r.r.Read(ctx, name, KeyPathForBlock(blockID, tenantID), shouldCache)
-	defer objReader.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer objReader.Close()
 	return tempo_io.ReadAllWithEstimate(objReader, size)
 }
 
@@ -139,10 +139,10 @@ func (r *reader) Blocks(ctx context.Context, tenantID string) ([]uuid.UUID, erro
 
 func (r *reader) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*BlockMeta, error) {
 	reader, size, err := r.r.Read(ctx, MetaName, KeyPathForBlock(blockID, tenantID), false)
-	defer reader.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer reader.Close()
 
 	bytes, err := tempo_io.ReadAllWithEstimate(reader, size)
 	if err != nil {

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -17,6 +17,7 @@ const (
 	MetaName          = "meta.json"
 	CompactedMetaName = "meta.compacted.json"
 	BlockIndexName    = "blockindex.json.gz"
+	BloomName         = "bloom"
 )
 
 // KeyPath is an ordered set of strings that govern where data is read/written from the backend
@@ -173,4 +174,8 @@ func CompactedMetaFileName(blockID uuid.UUID, tenantID string) string {
 // nolint:interfacer
 func RootPath(blockID uuid.UUID, tenantID string) string {
 	return path.Join(tenantID, blockID.String())
+}
+
+func ShouldCache(name string) bool {
+	return name != MetaName && name != CompactedMetaName && name != BlockIndexName
 }

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -8,6 +9,8 @@ import (
 	"path"
 
 	"github.com/google/uuid"
+
+	tempo_io "github.com/grafana/tempo/pkg/io"
 )
 
 const (
@@ -22,9 +25,7 @@ type KeyPath []string
 // RawWriter is a collection of methods to write data to tempodb backends
 type RawWriter interface {
 	// Write is for in memory data.  It is expected that this data will be cached.
-	Write(ctx context.Context, name string, keypath KeyPath, buffer []byte) error
-	// StreamWriter is for larger data payloads streamed through an io.Reader.  It is expected this will _not_ be cached.
-	StreamWriter(ctx context.Context, name string, keypath KeyPath, data io.Reader, size int64) error
+	Write(ctx context.Context, name string, keypath KeyPath, data io.Reader, size int64, shouldCache bool) error
 	// Append starts or continues an Append job. Pass nil to AppendTracker to start a job.
 	Append(ctx context.Context, name string, keypath KeyPath, tracker AppendTracker, buffer []byte) (AppendTracker, error)
 	// Closes any resources associated with the AppendTracker
@@ -33,14 +34,12 @@ type RawWriter interface {
 
 // RawReader is a collection of methods to read data from tempodb backends
 type RawReader interface {
-	// Read is for reading entire objects from the backend.  It is expected that there will be an attempt to retrieve this from cache
-	Read(ctx context.Context, name string, keypath KeyPath) ([]byte, error)
-	// StreamReader is for streaming entire objects from the backend.  It is expected this will _not_ be cached.
-	StreamReader(ctx context.Context, name string, keypath KeyPath) (io.ReadCloser, int64, error)
-	// ReadRange is for reading parts of large objects from the backend.  It is expected this will _not_ be cached.
-	ReadRange(ctx context.Context, name string, keypath KeyPath, offset uint64, buffer []byte) error
 	// List returns all objects one level beneath the provided keypath
 	List(ctx context.Context, keypath KeyPath) ([]string, error)
+	// Read is for streaming entire objects from the backend.  It is expected this will _not_ be cached.
+	Read(ctx context.Context, name string, keyPath KeyPath, shouldCache bool) (io.ReadCloser, int64, error)
+	// ReadRange is for reading parts of large objects from the backend.  It is expected this will _not_ be cached.
+	ReadRange(ctx context.Context, name string, keypath KeyPath, offset uint64, buffer []byte) error
 	// Shutdown must be called when the Reader is finished and cleans up any associated resources.
 	Shutdown()
 }
@@ -56,12 +55,8 @@ func NewWriter(w RawWriter) Writer {
 	}
 }
 
-func (w *writer) Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, buffer []byte) error {
-	return w.w.Write(ctx, name, KeyPathForBlock(blockID, tenantID), buffer)
-}
-
-func (w *writer) StreamWriter(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64) error {
-	return w.w.StreamWriter(ctx, name, KeyPathForBlock(blockID, tenantID), data, size)
+func (w *writer) Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64, shouldCache bool) error {
+	return w.w.Write(ctx, name, KeyPathForBlock(blockID, tenantID), data, size, shouldCache)
 }
 
 func (w *writer) WriteBlockMeta(ctx context.Context, meta *BlockMeta) error {
@@ -73,7 +68,7 @@ func (w *writer) WriteBlockMeta(ctx context.Context, meta *BlockMeta) error {
 		return err
 	}
 
-	return w.w.Write(ctx, MetaName, KeyPathForBlock(blockID, tenantID), bMeta)
+	return w.w.Write(ctx, MetaName, KeyPathForBlock(blockID, tenantID), bytes.NewReader(bMeta), int64(len(bMeta)), false)
 }
 
 func (w *writer) Append(ctx context.Context, name string, blockID uuid.UUID, tenantID string, tracker AppendTracker, buffer []byte) (AppendTracker, error) {
@@ -95,12 +90,8 @@ func NewReader(r RawReader) Reader {
 	}
 }
 
-func (r *reader) Read(ctx context.Context, name string, blockID uuid.UUID, tenantID string) ([]byte, error) {
-	return r.r.Read(ctx, name, KeyPathForBlock(blockID, tenantID))
-}
-
-func (r *reader) StreamReader(ctx context.Context, name string, blockID uuid.UUID, tenantID string) (io.ReadCloser, int64, error) {
-	return r.r.StreamReader(ctx, name, KeyPathForBlock(blockID, tenantID))
+func (r *reader) Read(ctx context.Context, name string, blockID uuid.UUID, tenantID string, shouldCache bool) (io.ReadCloser, int64, error) {
+	return r.r.Read(ctx, name, KeyPathForBlock(blockID, tenantID), shouldCache)
 }
 
 func (r *reader) ReadRange(ctx context.Context, name string, blockID uuid.UUID, tenantID string, offset uint64, buffer []byte) error {
@@ -134,7 +125,12 @@ func (r *reader) Blocks(ctx context.Context, tenantID string) ([]uuid.UUID, erro
 }
 
 func (r *reader) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*BlockMeta, error) {
-	bytes, err := r.r.Read(ctx, MetaName, KeyPathForBlock(blockID, tenantID))
+	reader, size, err := r.r.Read(ctx, MetaName, KeyPathForBlock(blockID, tenantID), false)
+	if err != nil {
+		return nil, err
+	}
+
+	bytes, err := tempo_io.ReadAllWithEstimate(reader, size)
 	if err != nil {
 		return nil, err
 	}

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -26,7 +26,7 @@ type KeyPath []string
 // RawWriter is a collection of methods to write data to tempodb backends
 type RawWriter interface {
 	// Write is for in memory data.  It is expected that this data will be cached.
-	Write(ctx context.Context, name string, keypath KeyPath, data io.Reader, size int64) error
+	Write(ctx context.Context, name string, keypath KeyPath, data io.Reader, size int64, shouldCache bool) error
 	// Append starts or continues an Append job. Pass nil to AppendTracker to start a job.
 	Append(ctx context.Context, name string, keypath KeyPath, tracker AppendTracker, buffer []byte) (AppendTracker, error)
 	// Closes any resources associated with the AppendTracker
@@ -38,7 +38,7 @@ type RawReader interface {
 	// List returns all objects one level beneath the provided keypath
 	List(ctx context.Context, keypath KeyPath) ([]string, error)
 	// Read is for streaming entire objects from the backend.  It is expected this will _not_ be cached.
-	Read(ctx context.Context, name string, keyPath KeyPath) (io.ReadCloser, int64, error)
+	Read(ctx context.Context, name string, keyPath KeyPath, shouldCache bool) (io.ReadCloser, int64, error)
 	// ReadRange is for reading parts of large objects from the backend.  It is expected this will _not_ be cached.
 	ReadRange(ctx context.Context, name string, keypath KeyPath, offset uint64, buffer []byte) error
 	// Shutdown must be called when the Reader is finished and cleans up any associated resources.
@@ -56,12 +56,8 @@ func NewWriter(w RawWriter) Writer {
 	}
 }
 
-func (w *writer) Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, buffer []byte) error {
-	return w.w.Write(ctx, name, KeyPathForBlock(blockID, tenantID), bytes.NewReader(buffer), int64(len(buffer)))
-}
-
-func (w *writer) StreamWriter(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64) error {
-	return w.w.Write(ctx, name, KeyPathForBlock(blockID, tenantID), data, size)
+func (w *writer) Write(ctx context.Context, name string, blockID uuid.UUID, tenantID string, data io.Reader, size int64, shouldCache bool) error {
+	return w.w.Write(ctx, name, KeyPathForBlock(blockID, tenantID), data, size, shouldCache)
 }
 
 func (w *writer) WriteBlockMeta(ctx context.Context, meta *BlockMeta) error {
@@ -73,7 +69,7 @@ func (w *writer) WriteBlockMeta(ctx context.Context, meta *BlockMeta) error {
 		return err
 	}
 
-	return w.w.Write(ctx, MetaName, KeyPathForBlock(blockID, tenantID), bytes.NewReader(bMeta), int64(len(bMeta)))
+	return w.w.Write(ctx, MetaName, KeyPathForBlock(blockID, tenantID), bytes.NewReader(bMeta), int64(len(bMeta)), false)
 }
 
 func (w *writer) Append(ctx context.Context, name string, blockID uuid.UUID, tenantID string, tracker AppendTracker, buffer []byte) (AppendTracker, error) {
@@ -95,16 +91,8 @@ func NewReader(r RawReader) Reader {
 	}
 }
 
-func (r *reader) Read(ctx context.Context, name string, blockID uuid.UUID, tenantID string) ([]byte, error) {
-	objReader, size, err := r.r.Read(ctx, name, KeyPathForBlock(blockID, tenantID))
-	if err != nil {
-		return nil, err
-	}
-	return tempo_io.ReadAllWithEstimate(objReader, size)
-}
-
-func (r *reader) StreamReader(ctx context.Context, name string, blockID uuid.UUID, tenantID string) (io.ReadCloser, int64, error) {
-	return r.r.Read(ctx, name, KeyPathForBlock(blockID, tenantID))
+func (r *reader) Read(ctx context.Context, name string, blockID uuid.UUID, tenantID string, shouldCache bool) (io.ReadCloser, int64, error) {
+	return r.r.Read(ctx, name, KeyPathForBlock(blockID, tenantID), shouldCache)
 }
 
 func (r *reader) ReadRange(ctx context.Context, name string, blockID uuid.UUID, tenantID string, offset uint64, buffer []byte) error {
@@ -138,7 +126,7 @@ func (r *reader) Blocks(ctx context.Context, tenantID string) ([]uuid.UUID, erro
 }
 
 func (r *reader) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*BlockMeta, error) {
-	reader, size, err := r.r.Read(ctx, MetaName, KeyPathForBlock(blockID, tenantID))
+	reader, size, err := r.r.Read(ctx, MetaName, KeyPathForBlock(blockID, tenantID), false)
 	if err != nil {
 		return nil, err
 	}
@@ -186,4 +174,8 @@ func CompactedMetaFileName(blockID uuid.UUID, tenantID string) string {
 // nolint:interfacer
 func RootPath(blockID uuid.UUID, tenantID string) string {
 	return path.Join(tenantID, blockID.String())
+}
+
+func ShouldCache(name string) bool {
+	return name != MetaName && name != CompactedMetaName && name != BlockIndexName
 }

--- a/tempodb/backend/raw_test.go
+++ b/tempodb/backend/raw_test.go
@@ -17,13 +17,9 @@ func TestWriter(t *testing.T) {
 
 	expected := []byte{0x01, 0x02, 0x03, 0x04}
 
-	err := w.Write(ctx, "test", uuid.New(), "test", expected)
+	err := w.Write(ctx, "test", uuid.New(), "test", bytes.NewReader(expected), int64(len(expected)),false)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, m.writeBuffer)
-
-	err = w.StreamWriter(ctx, "test", uuid.New(), "test", bytes.NewReader(expected), 0)
-	assert.NoError(t, err)
-	assert.Equal(t, expected, m.writeStreamBuffer)
 
 	_, err = w.Append(ctx, "test", uuid.New(), "test", nil, expected)
 	assert.NoError(t, err)

--- a/tempodb/backend/raw_test.go
+++ b/tempodb/backend/raw_test.go
@@ -16,7 +16,7 @@ func TestWriter(t *testing.T) {
 
 	expected := []byte{0x01, 0x02, 0x03, 0x04}
 
-	err := w.Write(ctx, "test", uuid.New(), "test", expected)
+	err := w.Write(ctx, "test", uuid.New(), "test", expected, false)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, m.writeBuffer)
 
@@ -42,7 +42,7 @@ func TestReader(t *testing.T) {
 
 	expected := []byte{0x01, 0x02, 0x03, 0x04}
 	m.R = expected
-	actual, err := r.Read(ctx, "test", uuid.New(), "test")
+	actual, err := r.Read(ctx, "test", uuid.New(), "test", false)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 

--- a/tempodb/backend/raw_test.go
+++ b/tempodb/backend/raw_test.go
@@ -1,7 +1,6 @@
 package backend
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"testing"
@@ -17,7 +16,7 @@ func TestWriter(t *testing.T) {
 
 	expected := []byte{0x01, 0x02, 0x03, 0x04}
 
-	err := w.Write(ctx, "test", uuid.New(), "test", bytes.NewReader(expected), int64(len(expected)),false)
+	err := w.Write(ctx, "test", uuid.New(), "test", expected)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, m.writeBuffer)
 

--- a/tempodb/backend/readerat.go
+++ b/tempodb/backend/readerat.go
@@ -19,17 +19,19 @@ type ContextReader interface {
 
 // backendReader is a shim that allows a backend.Reader to be used as a ContextReader
 type backendReader struct {
-	meta *BlockMeta
-	name string
-	r    Reader
+	meta        *BlockMeta
+	name        string
+	r           Reader
+	shouldCache bool
 }
 
 // NewContextReader creates a ReaderAt for the given BlockMeta
-func NewContextReader(meta *BlockMeta, name string, r Reader) ContextReader {
+func NewContextReader(meta *BlockMeta, name string, r Reader, shouldCache bool) ContextReader {
 	return &backendReader{
-		meta: meta,
-		name: name,
-		r:    r,
+		meta:        meta,
+		name:        name,
+		r:           r,
+		shouldCache: shouldCache,
 	}
 }
 
@@ -41,7 +43,7 @@ func (b *backendReader) ReadAt(ctx context.Context, p []byte, off int64) (int, e
 
 // ReadAll implements ContextReader
 func (b *backendReader) ReadAll(ctx context.Context) ([]byte, error) {
-	return b.r.Read(ctx, b.name, b.meta.BlockID, b.meta.TenantID, ShouldCache(b.name))
+	return b.r.Read(ctx, b.name, b.meta.BlockID, b.meta.TenantID, b.shouldCache)
 }
 
 // Reader implements ContextReader

--- a/tempodb/backend/readerat.go
+++ b/tempodb/backend/readerat.go
@@ -41,7 +41,7 @@ func (b *backendReader) ReadAt(ctx context.Context, p []byte, off int64) (int, e
 
 // ReadAll implements ContextReader
 func (b *backendReader) ReadAll(ctx context.Context) ([]byte, error) {
-	return b.r.Read(ctx, b.name, b.meta.BlockID, b.meta.TenantID)
+	return b.r.Read(ctx, b.name, b.meta.BlockID, b.meta.TenantID, ShouldCache(b.name))
 }
 
 // Reader implements ContextReader

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -97,7 +97,7 @@ func New(cfg *Config) (backend.RawReader, backend.RawWriter, backend.Compactor, 
 }
 
 // Write implements backend.Writer
-func (rw *readerWriter) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, size int64, _ bool) error {
+func (rw *readerWriter) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, size int64) error {
 	objName := backend.ObjectFileName(keypath, name)
 
 	info, err := rw.core.Client.PutObject(
@@ -224,7 +224,7 @@ func (rw *readerWriter) List(ctx context.Context, keypath backend.KeyPath) ([]st
 }
 
 // Read implements backend.Reader
-func (rw *readerWriter) Read(ctx context.Context, name string, keypath backend.KeyPath, _ bool) (io.ReadCloser, int64, error) {
+func (rw *readerWriter) Read(ctx context.Context, name string, keypath backend.KeyPath) (io.ReadCloser, int64, error) {
 	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "Read")
 	defer span.Finish()
 

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -97,7 +97,7 @@ func New(cfg *Config) (backend.RawReader, backend.RawWriter, backend.Compactor, 
 }
 
 // Write implements backend.Writer
-func (rw *readerWriter) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, size int64) error {
+func (rw *readerWriter) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, size int64, _ bool) error {
 	objName := backend.ObjectFileName(keypath, name)
 
 	info, err := rw.core.Client.PutObject(
@@ -224,7 +224,7 @@ func (rw *readerWriter) List(ctx context.Context, keypath backend.KeyPath) ([]st
 }
 
 // Read implements backend.Reader
-func (rw *readerWriter) Read(ctx context.Context, name string, keypath backend.KeyPath) (io.ReadCloser, int64, error) {
+func (rw *readerWriter) Read(ctx context.Context, name string, keypath backend.KeyPath, _ bool) (io.ReadCloser, int64, error) {
 	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "Read")
 	defer span.Finish()
 

--- a/tempodb/backend/s3/s3_test.go
+++ b/tempodb/backend/s3/s3_test.go
@@ -60,12 +60,12 @@ func TestHedge(t *testing.T) {
 
 			// the first call on each client initiates an extra http request
 			// clearing that here
-			_, _, _ = r.Read(ctx, "object", backend.KeyPath{"test"})
+			_, _, _ = r.Read(ctx, "object", backend.KeyPath{"test"}, false)
 			time.Sleep(tc.returnIn)
 			atomic.StoreInt32(&count, 0)
 
 			// calls that should hedge
-			_, _, _ = r.Read(ctx, "object", backend.KeyPath{"test"})
+			_, _, _ = r.Read(ctx, "object", backend.KeyPath{"test"}, false)
 			time.Sleep(tc.returnIn)
 			assert.Equal(t, tc.expectedHedgedRequests, atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
@@ -80,7 +80,7 @@ func TestHedge(t *testing.T) {
 			assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 
-			_ = w.Write(ctx, "object", backend.KeyPath{"test"}, bytes.NewReader([]byte{}), 0)
+			_ = w.Write(ctx, "object", backend.KeyPath{"test"}, bytes.NewReader([]byte{}), 0, false)
 			assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 		})

--- a/tempodb/backend/s3/s3_test.go
+++ b/tempodb/backend/s3/s3_test.go
@@ -60,12 +60,12 @@ func TestHedge(t *testing.T) {
 
 			// the first call on each client initiates an extra http request
 			// clearing that here
-			_, _, _ = r.Read(ctx, "object", backend.KeyPath{"test"}, false)
+			_, _, _ = r.Read(ctx, "object", backend.KeyPath{"test"})
 			time.Sleep(tc.returnIn)
 			atomic.StoreInt32(&count, 0)
 
 			// calls that should hedge
-			_, _, _ = r.Read(ctx, "object", backend.KeyPath{"test"}, false)
+			_, _, _ = r.Read(ctx, "object", backend.KeyPath{"test"})
 			time.Sleep(tc.returnIn)
 			assert.Equal(t, tc.expectedHedgedRequests, atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
@@ -80,7 +80,7 @@ func TestHedge(t *testing.T) {
 			assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 
-			_ = w.Write(ctx, "object", backend.KeyPath{"test"}, bytes.NewReader([]byte{}), 0, false)
+			_ = w.Write(ctx, "object", backend.KeyPath{"test"}, bytes.NewReader([]byte{}), 0)
 			assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 		})

--- a/tempodb/backend/s3/s3_test.go
+++ b/tempodb/backend/s3/s3_test.go
@@ -1,6 +1,7 @@
 package s3
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -59,12 +60,12 @@ func TestHedge(t *testing.T) {
 
 			// the first call on each client initiates an extra http request
 			// clearing that here
-			_, _ = r.Read(ctx, "object", backend.KeyPath{"test"})
+			_, _, _ = r.Read(ctx, "object", backend.KeyPath{"test"}, false)
 			time.Sleep(tc.returnIn)
 			atomic.StoreInt32(&count, 0)
 
 			// calls that should hedge
-			_, _ = r.Read(ctx, "object", backend.KeyPath{"test"})
+			_, _, _ = r.Read(ctx, "object", backend.KeyPath{"test"}, false)
 			time.Sleep(tc.returnIn)
 			assert.Equal(t, tc.expectedHedgedRequests, atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
@@ -79,7 +80,7 @@ func TestHedge(t *testing.T) {
 			assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 
-			_ = w.Write(ctx, "object", backend.KeyPath{"test"}, []byte{})
+			_ = w.Write(ctx, "object", backend.KeyPath{"test"}, bytes.NewReader([]byte{}), 0, false)
 			assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 		})

--- a/tempodb/encoding/backend_block.go
+++ b/tempodb/encoding/backend_block.go
@@ -1,6 +1,7 @@
 package encoding
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
@@ -51,13 +52,13 @@ func (b *BackendBlock) Find(ctx context.Context, id common.ID) ([]byte, error) {
 	blockID := b.meta.BlockID
 	tenantID := b.meta.TenantID
 
-	bloomReader, _, err := b.reader.Read(ctx, bloomName(shardKey), blockID, tenantID, backend.ShouldCache(backend.BloomName))
+	bloomBytes, err := b.reader.Read(ctx, bloomName(shardKey), blockID, tenantID)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving bloom (%s, %s): %w", b.meta.TenantID, b.meta.BlockID, err)
 	}
 
 	filter := &willf_bloom.BloomFilter{}
-	_, err = filter.ReadFrom(bloomReader)
+	_, err = filter.ReadFrom(bytes.NewReader(bloomBytes))
 	if err != nil {
 		return nil, fmt.Errorf("error parsing bloom (%s, %s): %w", b.meta.TenantID, b.meta.BlockID, err)
 	}

--- a/tempodb/encoding/backend_block.go
+++ b/tempodb/encoding/backend_block.go
@@ -52,7 +52,8 @@ func (b *BackendBlock) Find(ctx context.Context, id common.ID) ([]byte, error) {
 	blockID := b.meta.BlockID
 	tenantID := b.meta.TenantID
 
-	bloomBytes, err := b.reader.Read(ctx, bloomName(shardKey), blockID, tenantID)
+	nameBloom := bloomName(shardKey)
+	bloomBytes, err := b.reader.Read(ctx, nameBloom, blockID, tenantID, backend.ShouldCache(nameBloom))
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving bloom (%s, %s): %w", b.meta.TenantID, b.meta.BlockID, err)
 	}

--- a/tempodb/encoding/backend_block.go
+++ b/tempodb/encoding/backend_block.go
@@ -1,7 +1,6 @@
 package encoding
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 
@@ -52,13 +51,13 @@ func (b *BackendBlock) Find(ctx context.Context, id common.ID) ([]byte, error) {
 	blockID := b.meta.BlockID
 	tenantID := b.meta.TenantID
 
-	bloomBytes, err := b.reader.Read(ctx, bloomName(shardKey), blockID, tenantID)
+	bloomReader, _, err := b.reader.Read(ctx, bloomName(shardKey), blockID, tenantID, backend.ShouldCache(backend.BloomName))
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving bloom (%s, %s): %w", b.meta.TenantID, b.meta.BlockID, err)
 	}
 
 	filter := &willf_bloom.BloomFilter{}
-	_, err = filter.ReadFrom(bytes.NewReader(bloomBytes))
+	_, err = filter.ReadFrom(bloomReader)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing bloom (%s, %s): %w", b.meta.TenantID, b.meta.BlockID, err)
 	}

--- a/tempodb/encoding/backend_block.go
+++ b/tempodb/encoding/backend_block.go
@@ -53,7 +53,7 @@ func (b *BackendBlock) Find(ctx context.Context, id common.ID) ([]byte, error) {
 	tenantID := b.meta.TenantID
 
 	nameBloom := bloomName(shardKey)
-	bloomBytes, err := b.reader.Read(ctx, nameBloom, blockID, tenantID, backend.ShouldCache(nameBloom))
+	bloomBytes, err := b.reader.Read(ctx, nameBloom, blockID, tenantID, true)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving bloom (%s, %s): %w", b.meta.TenantID, b.meta.BlockID, err)
 	}
@@ -68,13 +68,13 @@ func (b *BackendBlock) Find(ctx context.Context, id common.ID) ([]byte, error) {
 		return nil, nil
 	}
 
-	indexReaderAt := backend.NewContextReader(b.meta, nameIndex, b.reader)
+	indexReaderAt := backend.NewContextReader(b.meta, nameIndex, b.reader, false)
 	indexReader, err := b.encoding.NewIndexReader(indexReaderAt, int(b.meta.IndexPageSize), int(b.meta.TotalRecords))
 	if err != nil {
 		return nil, fmt.Errorf("error building index reader (%s, %s): %w", b.meta.TenantID, b.meta.BlockID, err)
 	}
 
-	ra := backend.NewContextReader(b.meta, nameObjects, b.reader)
+	ra := backend.NewContextReader(b.meta, nameObjects, b.reader, false)
 	dataReader, err := b.encoding.NewDataReader(ra, b.meta.Encoding)
 	if err != nil {
 		return nil, fmt.Errorf("error building page reader (%s, %s): %w", b.meta.TenantID, b.meta.BlockID, err)
@@ -95,7 +95,7 @@ func (b *BackendBlock) Find(ctx context.Context, id common.ID) ([]byte, error) {
 // Iterator returns an Iterator that iterates over the objects in the block from the backend
 func (b *BackendBlock) Iterator(chunkSizeBytes uint32) (Iterator, error) {
 	// read index
-	ra := backend.NewContextReader(b.meta, nameObjects, b.reader)
+	ra := backend.NewContextReader(b.meta, nameObjects, b.reader, false)
 	dataReader, err := b.encoding.NewDataReader(ra, b.meta.Encoding)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create dataReader (%s, %s): %w", b.meta.TenantID, b.meta.BlockID, err)
@@ -110,7 +110,7 @@ func (b *BackendBlock) Iterator(chunkSizeBytes uint32) (Iterator, error) {
 }
 
 func (b *BackendBlock) NewIndexReader() (common.IndexReader, error) {
-	indexReaderAt := backend.NewContextReader(b.meta, nameIndex, b.reader)
+	indexReaderAt := backend.NewContextReader(b.meta, nameIndex, b.reader, false)
 	reader, err := b.encoding.NewIndexReader(indexReaderAt, int(b.meta.IndexPageSize), int(b.meta.TotalRecords))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create index reader (%s, %s): %w", b.meta.TenantID, b.meta.BlockID, err)

--- a/tempodb/encoding/block.go
+++ b/tempodb/encoding/block.go
@@ -32,14 +32,15 @@ func writeBlockMeta(ctx context.Context, w backend.Writer, meta *backend.BlockMe
 	}
 
 	// index
-	err = w.Write(ctx, nameIndex, meta.BlockID, meta.TenantID, indexBytes)
+	err = w.Write(ctx, nameIndex, meta.BlockID, meta.TenantID, indexBytes, backend.ShouldCache(nameIndex))
 	if err != nil {
 		return fmt.Errorf("unexpected error writing index %w", err)
 	}
 
 	// bloom
 	for i, bloom := range blooms {
-		err := w.Write(ctx, bloomName(i), meta.BlockID, meta.TenantID, bloom)
+		nameBloom := bloomName(i)
+		err := w.Write(ctx, nameBloom, meta.BlockID, meta.TenantID, bloom, backend.ShouldCache(nameBloom))
 		if err != nil {
 			return fmt.Errorf("unexpected error writing bloom-%d %w", i, err)
 		}

--- a/tempodb/encoding/block.go
+++ b/tempodb/encoding/block.go
@@ -32,7 +32,7 @@ func writeBlockMeta(ctx context.Context, w backend.Writer, meta *backend.BlockMe
 	}
 
 	// index
-	err = w.Write(ctx, nameIndex, meta.BlockID, meta.TenantID, indexBytes, backend.ShouldCache(nameIndex))
+	err = w.Write(ctx, nameIndex, meta.BlockID, meta.TenantID, indexBytes, false)
 	if err != nil {
 		return fmt.Errorf("unexpected error writing index %w", err)
 	}
@@ -40,7 +40,7 @@ func writeBlockMeta(ctx context.Context, w backend.Writer, meta *backend.BlockMe
 	// bloom
 	for i, bloom := range blooms {
 		nameBloom := bloomName(i)
-		err := w.Write(ctx, nameBloom, meta.BlockID, meta.TenantID, bloom, backend.ShouldCache(nameBloom))
+		err := w.Write(ctx, nameBloom, meta.BlockID, meta.TenantID, bloom, true)
 		if err != nil {
 			return fmt.Errorf("unexpected error writing bloom-%d %w", i, err)
 		}

--- a/tempodb/wal/local_block.go
+++ b/tempodb/wal/local_block.go
@@ -33,7 +33,7 @@ func NewLocalBlock(ctx context.Context, existingBlock *encoding.BackendBlock, l 
 		writer:       backend.NewWriter(l),
 	}
 
-	flushedBytes, err := c.reader.Read(ctx, nameFlushed, c.BlockMeta().BlockID, c.BlockMeta().TenantID, backend.ShouldCache(nameFlushed))
+	flushedBytes, err := c.reader.Read(ctx, nameFlushed, c.BlockMeta().BlockID, c.BlockMeta().TenantID, false)
 	if err == nil {
 		flushedTime := time.Time{}
 		err = flushedTime.UnmarshalText(flushedBytes)
@@ -66,7 +66,7 @@ func (c *LocalBlock) SetFlushed(ctx context.Context) error {
 		return errors.Wrap(err, "error marshalling flush time to text")
 	}
 
-	err = c.writer.Write(ctx, nameFlushed, c.BlockMeta().BlockID, c.BlockMeta().TenantID, flushedBytes, backend.ShouldCache(nameFlushed))
+	err = c.writer.Write(ctx, nameFlushed, c.BlockMeta().BlockID, c.BlockMeta().TenantID, flushedBytes, false)
 	if err != nil {
 		return errors.Wrap(err, "error writing ingester block flushed file")
 	}

--- a/tempodb/wal/local_block.go
+++ b/tempodb/wal/local_block.go
@@ -33,7 +33,7 @@ func NewLocalBlock(ctx context.Context, existingBlock *encoding.BackendBlock, l 
 		writer:       backend.NewWriter(l),
 	}
 
-	flushedBytes, err := c.reader.Read(ctx, nameFlushed, c.BlockMeta().BlockID, c.BlockMeta().TenantID)
+	flushedBytes, err := c.reader.Read(ctx, nameFlushed, c.BlockMeta().BlockID, c.BlockMeta().TenantID, backend.ShouldCache(nameFlushed))
 	if err == nil {
 		flushedTime := time.Time{}
 		err = flushedTime.UnmarshalText(flushedBytes)
@@ -66,7 +66,7 @@ func (c *LocalBlock) SetFlushed(ctx context.Context) error {
 		return errors.Wrap(err, "error marshalling flush time to text")
 	}
 
-	err = c.writer.Write(ctx, nameFlushed, c.BlockMeta().BlockID, c.BlockMeta().TenantID, flushedBytes)
+	err = c.writer.Write(ctx, nameFlushed, c.BlockMeta().BlockID, c.BlockMeta().TenantID, flushedBytes, backend.ShouldCache(nameFlushed))
 	if err != nil {
 		return errors.Wrap(err, "error writing ingester block flushed file")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This PR adds a new `shouldCache` parameter to the Backend interface on the Read/Write functions.

Pros:
- Cleaner interface, follow up of #804 
- Ability to cache based on some custom parameters. Will be useful in #805 

Cons:
- Lots of `ioutil.NopCloser(bytes.NewReader(buffer))` usage while translating byte slices <> io.ReadCloser 

_Note: I'm still working on tests and CI, opened the PR for early review of the general direction._

**Which issue(s) this PR fixes**:
Fixes #na!

**Checklist**
- [x] Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`