### PR TITLE
Clean up CI linting

### DIFF
--- a/.errcheck-exclude.txt
+++ b/.errcheck-exclude.txt
@@ -1,0 +1,3 @@
+// the following functions will be excluded from errcheck
+// https://github.com/kisielk/errcheck#excluding-functions
+(github.com/go-kit/kit/log.Logger).Log

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,6 +61,10 @@ linters:
     - interfacer
     - typecheck
 
+linters-settings:
+  errcheck:
+    exclude: ./.errcheck-exclude.txt
+
 issues:
   exclude:
     - Error return value of .*log\.Logger\)\.Log\x60 is not checked

--- a/cmd/tempo-cli/cmd-list-block.go
+++ b/cmd/tempo-cli/cmd-list-block.go
@@ -96,6 +96,7 @@ func dumpBlock(r tempodb_backend.Reader, c tempodb_backend.Compactor, tenantID s
 
 		// Print stats on ctrl+c
 		c := make(chan os.Signal)
+		// nolint:govet
 		signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 		go func() {
 			<-c

--- a/modules/distributor/receiver/shim.go
+++ b/modules/distributor/receiver/shim.go
@@ -102,22 +102,12 @@ func New(receiverCfg map[string]interface{}, pusher tempopb.PusherServer, multit
 			return nil, fmt.Errorf("receiver factory not found for type: %s", cfg.Type())
 		}
 
-		if factory, ok := factoryBase.(component.ReceiverFactory); ok {
-			receiver, err := factory.CreateTracesReceiver(ctx, params, cfg, shim)
-			if err != nil {
-				return nil, err
-			}
-
-			shim.receivers = append(shim.receivers, receiver)
-			continue
-		}
-
-		/*factory := factoryBase.(component.ReceiverFactoryOld)
-		receiver, err := factory.CreateTraceReceiver(ctx, zapLogger, cfg, converter.NewOCToInternalTraceConverter(shim))
+		receiver, err := factoryBase.CreateTracesReceiver(ctx, params, cfg, shim)
 		if err != nil {
 			return nil, err
 		}
-		shim.receivers = append(shim.receivers, receiver)*/
+
+		shim.receivers = append(shim.receivers, receiver)
 	}
 
 	shim.Service = services.NewIdleService(shim.starting, shim.stopping)


### PR DESCRIPTION
**What this PR does**:
Attempt to tweak golangci-lint and its linters to avoid CI failing on unrelated issues (as happened in https://github.com/grafana/tempo/pull/808).
