### PR TITLE
Swapped to latest minio

### DIFF
--- a/example/docker-compose/s3/docker-compose.yaml
+++ b/example/docker-compose/s3/docker-compose.yaml
@@ -3,17 +3,14 @@ services:
 
   tempo:
     image: grafana/tempo:latest
-    # command: [ "-config.file=/etc/tempo.yaml" ]
+    command: [ "-config.file=/etc/tempo.yaml" ]
     volumes:
       - ./tempo-s3.yaml:/etc/tempo.yaml
       - ./tempo-data:/tmp/tempo
     ports:
       - "14268"      # jaeger
       - "3200:3200"  # tempo
-    entrypoint:
-      - sh
-      - -euc
-      - sleep 5 && /tempo -config.file=/etc/tempo.yaml
+    restart: on-failure
     depends_on:
       - minio
 

--- a/example/docker-compose/s3/docker-compose.yaml
+++ b/example/docker-compose/s3/docker-compose.yaml
@@ -3,18 +3,22 @@ services:
 
   tempo:
     image: grafana/tempo:latest
-    command: [ "-config.file=/etc/tempo.yaml" ]
+    # command: [ "-config.file=/etc/tempo.yaml" ]
     volumes:
       - ./tempo-s3.yaml:/etc/tempo.yaml
       - ./tempo-data:/tmp/tempo
     ports:
       - "14268"      # jaeger
       - "3200:3200"  # tempo
+    entrypoint:
+      - sh
+      - -euc
+      - sleep 5 && /tempo -config.file=/etc/tempo.yaml
     depends_on:
       - minio
 
   minio:
-    image: minio/minio:RELEASE.2021-05-26T00-22-46Z
+    image: minio/minio:latest
     environment:
       - MINIO_ACCESS_KEY=tempo
       - MINIO_SECRET_KEY=supersecret

--- a/example/docker-compose/s3/docker-compose.yaml
+++ b/example/docker-compose/s3/docker-compose.yaml
@@ -20,11 +20,11 @@ services:
       - MINIO_ACCESS_KEY=tempo
       - MINIO_SECRET_KEY=supersecret
     ports:
-      - "9000:9000"
+      - "9001:9001"
     entrypoint:
       - sh
       - -euc
-      - mkdir -p /data/tempo && /usr/bin/minio server /data
+      - mkdir -p /data/tempo && /usr/bin/minio server /data --console-address ':9001'
 
   synthetic-load-generator:
     image: omnition/synthetic-load-generator:1.0.25

--- a/example/docker-compose/s3/readme.md
+++ b/example/docker-compose/s3/readme.md
@@ -15,14 +15,14 @@ docker-compose ps
                   Name                                 Command               State                        Ports
 -------------------------------------------------------------------------------------------------------------------------------------
 s3_grafana_1                    /run.sh                          Up      0.0.0.0:3000->3000/tcp
-s3_minio_1                      sh -euc mkdir -p /data/tem ...   Up      0.0.0.0:9000->9000/tcp
+s3_minio_1                      sh -euc mkdir -p /data/tem ...   Up      0.0.0.0:9001->9001/tcp
 s3_prometheus_1                 /bin/prometheus --config.f ...   Up      0.0.0.0:9090->9090/tcp
 s3_synthetic-load-generator_1   ./start.sh                       Up
 s3_tempo_1                      /tempo -config.file=/etc/t ...   Up      0.0.0.0:32770->14268/tcp, 0.0.0.0:3200->3200/tcp
 ```
 
 2. If you're interested you can see the wal/blocks as they are being created.  Navigate to minio at
-http://localhost:9000 and use the username/password of `tempo`/`supersecret`.
+http://localhost:9001 and use the username/password of `tempo`/`supersecret`.
 
 3. The synthetic-load-generator is now printing out trace ids it's flushing into Tempo.  To view its logs use -
 

--- a/example/tk/lib/minio/minio.libsonnet
+++ b/example/tk/lib/minio/minio.libsonnet
@@ -6,7 +6,7 @@
   local deployment = k.apps.v1.deployment,
 
   minio_container::
-    container.new('minio', 'minio/minio:RELEASE.2021-05-26T00-22-46Z') +
+    container.new('minio', 'minio/minio:latest') +
     container.withPorts([
       containerPort.new('minio', 9000),
     ]) +

--- a/integration/microservices/docker-compose.yaml
+++ b/integration/microservices/docker-compose.yaml
@@ -53,7 +53,7 @@ services:
       - distributor # inverted relationship here to add delay for minio
 
   minio:
-    image: minio/minio:RELEASE.2021-06-14T01-29-23Z
+    image: minio/minio:latest
     environment:
       - MINIO_ACCESS_KEY=tempo
       - MINIO_SECRET_KEY=supersecret


### PR DESCRIPTION
**What this PR does**:
Minio is aggressive about removing old tags.  The `RELEASE.2021-05-26T00-22-46Z` tag no longer exists in dockerhub. I normally hate using latest, but I think we should here so we don't have to constantly update this.

Also added `restart: on-failure` for when Tempo starts faster than minio.