### PR TITLE
Add Tempo tag and link to operational dashboard

### DIFF
--- a/operations/tempo-mixin/tempo-operational.json
+++ b/operations/tempo-mixin/tempo-operational.json
@@ -27,7 +27,20 @@
   "graphTooltip": 1,
   "id": 152,
   "iteration": 1625468849630,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "tempo"
+      ],
+      "targetBlank": false,
+      "title": "Tempo Dashboards",
+      "type": "dashboards"
+    }
+  ],
   "panels": [
     {
       "collapsed": false,
@@ -4567,7 +4580,7 @@
   "refresh": "",
   "schemaVersion": 30,
   "style": "dark",
-  "tags": [],
+  "tags": ["tempo"],
   "templating": {
     "list": [
       {

--- a/operations/tempo-mixin/yamls/tempo-operational.json
+++ b/operations/tempo-mixin/yamls/tempo-operational.json
@@ -30,7 +30,18 @@
  "id": 152,
  "iteration": 1625468849630,
  "links": [
-
+  {
+   "asDropdown": true,
+   "icon": "external link",
+   "includeVars": true,
+   "keepTime": true,
+   "tags": [
+    "tempo"
+   ],
+   "targetBlank": false,
+   "title": "Tempo Dashboards",
+   "type": "dashboards"
+  }
  ],
  "panels": [
   {
@@ -5132,7 +5143,7 @@
  "schemaVersion": 30,
  "style": "dark",
  "tags": [
-
+  "tempo"
  ],
  "templating": {
   "list": [


### PR DESCRIPTION
**What this PR does**:
This change simplifies navigating between Tempo dashboards:

- the `tempo` tag adds it to the dropdown

![Screenshot 2021-07-16 at 11 41 51](https://user-images.githubusercontent.com/7748404/125927795-d425fab7-62e8-46c2-8170-03402b7d1c17.png)

- the link adds the same dropdown to Tempo Operational

![Screenshot 2021-07-16 at 11 42 59](https://user-images.githubusercontent.com/7748404/125927926-c63dba6c-1362-49c2-a9c7-a6660fce3037.png)
