### PR TITLE
Prepare CI for our internal release train

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -36,6 +36,8 @@ trigger:
   ref:
   - refs/heads/main
   - refs/tags/**
+  - refs/heads/r? # For weekly release
+  - refs/heads/r?? # For weekly release
 
 ---
 ##  AMD64  ##
@@ -90,6 +92,8 @@ trigger:
   ref:
   - refs/heads/main
   - refs/tags/v*
+  - refs/heads/r? # For weekly release
+  - refs/heads/r?? # For weekly release
 
 ---
 ##  ARM64  ##
@@ -144,6 +148,8 @@ trigger:
   ref:
   - refs/heads/main
   - refs/tags/v*
+  - refs/heads/r? # For weekly release
+  - refs/heads/r?? # For weekly release
 
 ---
 ##  MANIFEST  ##
@@ -189,6 +195,8 @@ trigger:
   ref:
   - refs/heads/main
   - refs/tags/v*
+  - refs/heads/r? # For weekly release
+  - refs/heads/r?? # For weekly release
 
 ---
 kind: secret

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -11,6 +11,7 @@ steps:
 - name: image-tag
   image: alpine/git
   commands:
+  - apk --update --no-cache add bash
   - git fetch origin --tags
   - echo $(./tools/image-tag) > .tags
 
@@ -52,6 +53,7 @@ steps:
 - name: image-tag
   image: alpine/git
   commands:
+  - apk --update --no-cache add bash
   - git fetch origin --tags
   - echo $(./tools/image-tag)-amd64 > .tags
 
@@ -108,6 +110,7 @@ steps:
 - name: image-tag
   image: alpine/git
   commands:
+  - apk --update --no-cache add bash
   - git fetch origin --tags
   - echo $(./tools/image-tag)-arm64 > .tags
 
@@ -164,6 +167,7 @@ steps:
 - name: image-tag
   image: alpine/git
   commands:
+  - apk --update --no-cache add bash
   - git fetch origin --tags
   - echo $(./tools/image-tag) > .tags
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [ENHANCEMENT] Add `-config.expand-env` cli flag to support environment variables expansion in config file. [#796](https://github.com/grafana/tempo/pull/796) (@Ashmita152)
 * [ENHANCEMENT] Emit traces for ingester flush operations. [#812](https://github.com/grafana/tempo/pull/812) (@bboreham)
 * [ENHANCEMENT] Add retry middleware in query-frontend. [#814](https://github.com/grafana/tempo/pull/814) (@kvrhdn)
+* [CHANGE] Docker images are now prefixed by their branch name [#828](https://github.com/grafana/tempo/pull/828) (@jvrplmlmn)
 
 ## v1.0.1
 

--- a/tools/image-tag
+++ b/tools/image-tag
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -o errexit
 set -o nounset

--- a/tools/image-tag
+++ b/tools/image-tag
@@ -2,14 +2,20 @@
 
 set -o errexit
 set -o nounset
+set -o pipefail
 
-SHA="$(git rev-parse --short HEAD)"
+WIP=$(git diff --quiet || echo '-WIP')
+BRANCH=$(git rev-parse --abbrev-ref HEAD | sed 's#/#-#g')
+# When 7 chars are not enough to be unique, git automatically uses more.
+# We are forcing to 7 here, as we are doing for grafana/grafana as well.
+SHA=$(git rev-parse --short=7 HEAD | head -c7)
 
-# If tag, use tag
-TAG=$( (git describe --exact-match 2> /dev/null || echo "") | sed 's/v//g')
+# If not a tag, use branch-hash else use tag
+TAG=$((git describe --exact-match 2> /dev/null || echo "") | sed 's/v//g')
+
 if [ -z "$TAG" ]
 then
-      echo ${SHA}
+      echo ${BRANCH}-${SHA}${WIP}
 else
       echo ${TAG}
 fi


### PR DESCRIPTION
This PR lays the groundwork to adopt an internal weekly release cycle. This simply adds an additional trigger to CI so it can build and push artifacts on `r?` and `r??` branches, which are later consumed by our internal automation.