### PR TITLE
rename legacy datasource

### DIFF
--- a/operations/tempo-mixin/tempo-operational.json
+++ b/operations/tempo-mixin/tempo-operational.json
@@ -4586,8 +4586,8 @@
       {
         "current": {
           "selected": false,
-          "text": "1-ops-tools1",
-          "value": "1-ops-tools1"
+          "text": "ops-cortex",
+          "value": "ops-cortex"
         },
         "description": null,
         "error": null,
@@ -4643,7 +4643,7 @@
         "options": [],
         "query": {
           "query": "label_values(tempo_build_info, cluster)",
-          "refId": "1-ops-tools1-cluster-Variable-Query"
+          "refId": "ops-cortex-cluster-Variable-Query"
         },
         "refresh": 1,
         "regex": "",
@@ -4673,7 +4673,7 @@
         "options": [],
         "query": {
           "query": "label_values(kube_pod_container_info{image=~\".*tempo.*\", cluster=\"$cluster\"}, namespace)",
-          "refId": "1-ops-tools1-namespace-Variable-Query"
+          "refId": "ops-cortex-namespace-Variable-Query"
         },
         "refresh": 1,
         "regex": "",

--- a/operations/tempo-mixin/yamls/tempo-operational.json
+++ b/operations/tempo-mixin/yamls/tempo-operational.json
@@ -5150,8 +5150,8 @@
    {
     "current": {
      "selected": false,
-     "text": "1-ops-tools1",
-     "value": "1-ops-tools1"
+     "text": "ops-cortex",
+     "value": "ops-cortex"
     },
     "description": null,
     "error": null,
@@ -5213,7 +5213,7 @@
     ],
     "query": {
      "query": "label_values(tempo_build_info, cluster)",
-     "refId": "1-ops-tools1-cluster-Variable-Query"
+     "refId": "ops-cortex-cluster-Variable-Query"
     },
     "refresh": 1,
     "regex": "",
@@ -5245,7 +5245,7 @@
     ],
     "query": {
      "query": "label_values(kube_pod_container_info{image=~\".*tempo.*\", cluster=\"$cluster\"}, namespace)",
-     "refId": "1-ops-tools1-namespace-Variable-Query"
+     "refId": "ops-cortex-namespace-Variable-Query"
     },
     "refresh": 1,
     "regex": "",


### PR DESCRIPTION
Operations removed a legacy cluster. The old name shouldn't be used anymore. Therefore we also renamed the data source.