### PR TITLE
Jsonnet: prefer $._config.port over hardcoding the server port

### DIFF
--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -87,7 +87,7 @@
     vulture: {
       replicas: 0,
       tempoPushUrl: 'http://distributor',
-      tempoQueryUrl: 'http://query-frontend:3200',
+      tempoQueryUrl: 'http://query-frontend:%s' % %._config.port,
       tempoOrgId: '',
     },
     ballast_size_mbs: '1024',

--- a/operations/jsonnet/microservices/frontend.libsonnet
+++ b/operations/jsonnet/microservices/frontend.libsonnet
@@ -71,7 +71,7 @@
     + service.mixin.spec.withPortsMixin([
       servicePort.withName('http')
       + servicePort.withPort(80)
-      + servicePort.withTargetPort(3200),
+      + servicePort.withTargetPort($._config.port),
     ]),
 
   tempo_query_frontend_discovery_service:


### PR DESCRIPTION
**What this PR does**:
Avoid repeating the server port across our jsonnet. This allows you to use a different port by changing just one setting.
