### PR TITLE
Don't run CI and benchmarks when non-code folders change

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
+      - 'example/**'
+      - 'operations/**'
+      - 'tools/**'
 jobs:
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
+      - 'example/**'
+      - 'operations/**'
+      - 'tools/**'
 jobs:
 
   build:


### PR DESCRIPTION
**What this PR does**:
Noticed this when creating https://github.com/grafana/tempo/pull/832: CI and benchmarks run even though some of these folders don't contain code impacting Tempo or its tests. Waiting until CI is green is thus unnecessary and might give a false sense of safety.
