### PR TITLE
fix(jsonnet): % is not an unary operator

### DIFF
--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -87,7 +87,7 @@
     vulture: {
       replicas: 0,
       tempoPushUrl: 'http://distributor',
-      tempoQueryUrl: 'http://query-frontend:%s' % %._config.port,
+      tempoQueryUrl: 'http://query-frontend:%s' % $._config.port,
       tempoOrgId: '',
     },
     ballast_size_mbs: '1024',


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: Fixes a runtime error in the jsonnet library introduced in https://github.com/grafana/tempo/pull/832

```
$ tk diff environments/tempo/<a-tempo-environment>
Error: evaluating jsonnet: RUNTIME ERROR:
<path-to-vendored-library>/microservices/config.libsonnet:90:51-52 Not a unary operator: %
```
