### PR TITLE
Properly handle max_retries set to 0 or lower

### DIFF
--- a/modules/frontend/retry.go
+++ b/modules/frontend/retry.go
@@ -33,7 +33,7 @@ func (r retryWare) Do(req *http.Request) (*http.Response, error) {
 	// context propagation
 	req = req.WithContext(ctx)
 
-	triesLeft := r.maxRetries
+	try := 0
 
 	for {
 		if ctx.Err() != nil {
@@ -42,8 +42,8 @@ func (r retryWare) Do(req *http.Request) (*http.Response, error) {
 
 		resp, err := r.next.Do(req)
 
-		triesLeft--
-		if triesLeft == 0 {
+		try++
+		if try >= r.maxRetries {
 			return resp, err
 		}
 
@@ -60,7 +60,7 @@ func (r retryWare) Do(req *http.Request) (*http.Response, error) {
 			ot_log.String("msg", "error processing request"),
 			ot_log.Int("status_code", statusCode),
 			ot_log.Error(err),
-			ot_log.Int("triesLeft", triesLeft),
+			ot_log.Int("try", try),
 		)
 	}
 }


### PR DESCRIPTION
**What this PR does**:
If `max_retries` was set to 0 or lower, this would lead to up to infinite retries. This PR fixes this.

Bad code: https://github.com/grafana/tempo/blob/d50c64ba9df22e20fb895562aec3e04c107bf6a2/modules/frontend/retry.go#L45-L48

`triesLeft` starts at the value of `max_retries`, so if its 0 we never match `triesLeft == 0`.

**Which issue(s) this PR fixes**:
Spotted while investigating #843.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`