### PR TITLE
query-frontend/retry: properly handle grpc errors; lower default max_retries

### DIFF
--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -161,7 +161,7 @@ The Query Frontend is responsible for sharding incoming requests for faster proc
 query_frontend:
 
     # number of times to retry a request sent to a querier
-    # (default: 5)
+    # (default: 2)
     [max_retries: <int>]
 
     # number of shards to split the query into

--- a/modules/frontend/config.go
+++ b/modules/frontend/config.go
@@ -17,7 +17,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.Config.DownstreamURL = ""
 	cfg.Config.Handler.LogQueriesLongerThan = 0
 	cfg.Config.FrontendV1.MaxOutstandingPerTenant = 100
-	cfg.MaxRetries = 5
+	cfg.MaxRetries = 2
 	cfg.QueryShards = 2
 }
 

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -39,7 +39,7 @@ func NewTripperware(cfg Config, logger log.Logger, registerer prometheus.Registe
 		// - the Deduper dedupes Span IDs for Zipkin support
 		// - the ShardingWare shards queries by splitting the block ID space
 		// - the RetryWare retries requests that have failed (error or http status 500)
-		rt := NewRoundTripper(next, Deduper(logger), ShardingWare(cfg.QueryShards, logger), RetryWare(cfg.MaxRetries, logger))
+		rt := NewRoundTripper(next, Deduper(logger), ShardingWare(cfg.QueryShards, logger), RetryWare(cfg.MaxRetries, registerer))
 
 		return queryrange.RoundTripFunc(func(r *http.Request) (*http.Response, error) {
 			start := time.Now()

--- a/modules/frontend/retry.go
+++ b/modules/frontend/retry.go
@@ -50,7 +50,7 @@ func (r retryWare) Do(req *http.Request) (*http.Response, error) {
 
 		resp, err := r.next.Do(req)
 
-		// do not retry if no error and reponse is not HTTP 5xx
+		// do not retry if no error and response is not HTTP 5xx
 		if err == nil && resp.StatusCode/100 != 5 {
 			return resp, nil
 		}


### PR DESCRIPTION
**What this PR does**:
Improves the retry middleware in query-frontend:
- when err is a grpc error, extract http response and check status code (fixes #844)
- lower default retry to 2
- add a prometheus metric `query_frontend_retries`
- don't log errors (avoids #843)

**Which issue(s) this PR fixes**:
Closes #844
Closes #843
Supersedes #849
Closes #824

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`