### PR TITLE
query-frontend: attempt to log response status code from grpc error

### DIFF
--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/user"
 
@@ -106,6 +107,9 @@ func NewTripperware(cfg Config, logger log.Logger, registerer prometheus.Registe
 			if resp != nil {
 				statusCode = resp.StatusCode
 				contentLength = resp.ContentLength
+			} else if httpResp, ok := httpgrpc.HTTPResponseFromError(err); ok {
+				statusCode = int(httpResp.Code)
+				contentLength = int64(len(httpResp.Body))
 			}
 
 			level.Info(logger).Log(


### PR DESCRIPTION
**What this PR does**:
If the query-frontend uses a GRPC stream to communicate with the querier, HTTP error responses are wrapped in the returned error. When logging the response status code, we should try to extract a HTTP response from this grpc error as well.

**Which issue(s) this PR fixes**:
Closes #845

**Checklist**
- [ ] ~~Tests updated~~
- [ ] ~~Documentation added~~
- [ ] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~