### PR TITLE
Add /services endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [ENHANCEMENT] Emit traces for ingester flush operations. [#812](https://github.com/grafana/tempo/pull/812) (@bboreham)
 * [ENHANCEMENT] Add retry middleware in query-frontend. [#814](https://github.com/grafana/tempo/pull/814) (@kvrhdn)
 * [ENHANCEMENT] Add `-use-otel-tracer` to use the OpenTelemetry tracer, this will also capture traces emitted by the gcs sdk. Experimental: not all features are supported (i.e. remote sampling). [#842](https://github.com/grafana/tempo/pull/842) (@kvrhdn)
+* [ENHANCEMENT] Add `/services` endpoint. [#863](https://github.com/grafana/tempo/pull/863) (@kvrhdn)
 * [CHANGE] Docker images are now prefixed by their branch name [#828](https://github.com/grafana/tempo/pull/828) (@jvrplmlmn)
 
 ## v1.0.1

--- a/docs/tempo/website/api_docs/_index.md
+++ b/docs/tempo/website/api_docs/_index.md
@@ -17,6 +17,7 @@ For the sake of clarity, in this document we have grouped API endpoints by servi
 | --- | ------- | ---- | -------- |
 | [Configuration](#configuration) | _All services_ |  HTTP | `GET /config` |
 | [Readiness probe](#readiness-probe) | _All services_ |  HTTP | `GET /ready` |
+| [Services](#services) | _All services_ |  HTTP | `GET /services` |
 | [Metrics](#metrics) | _All services_ |  HTTP | `GET /metrics` |
 | [Pprof](#pprof) | _All services_ |  HTTP | `GET /debug/pprof` |
 | [Ingest traces](#ingest) | Distributor |  - | See section for details |
@@ -48,6 +49,14 @@ GET /ready
 ```
 
 Returns status code 200 when Tempo is ready to serve traffic.
+
+### Services
+
+```
+GET /services
+```
+
+Displays a list of services and their status. If a service failed it will show the failure case.
 
 ### Metrics
 


### PR DESCRIPTION
**What this PR does**:
Add `/services` which prints a plaintext list of all the services in the service map with their status and optional failure case.

```
$ curl  localhost:3201/services
memberlist-kv: Running
querier: Running
ring: Running
server: Running
store: Running
```

Cortex has a similar endpoint which returns HTML, but I decided to keep this simple and plaintext.
https://github.com/cortexproject/cortex/blob/master/pkg/cortex/status.go

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`