### PR TITLE
Make Koenraad Verheyden a maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-* @joe-elliott @annanay25 @mdisibio @dgzlopes @mapno
-/docs/ @achatterjee-grafana @joe-elliott @annanay25 @mdisibio @dgzlopes @mapno
+* @joe-elliott @annanay25 @mdisibio @dgzlopes @mapno @kvrhdn
+/docs/ @achatterjee-grafana @joe-elliott @annanay25 @mdisibio @dgzlopes @mapno @kvrhdn

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -49,6 +49,7 @@ The current team members are:
 - Annanay Agarwal - [annanay25](https://github.com/annanay25) ([Grafana Labs](https://grafana.com/))
 - Daniel González - [dgzlopes](https://github.com/dgzlopes) ([k6.io](https://k6.io/))
 - Joe Elliott - [joe-elliott](https://github.com/joe-elliott) ([Grafana Labs](https://grafana.com/))
+- Koenraad Verheyden - [kvrhdn](https://github.com/kvrhdn) ([Grafana Labs](https://grafana.com/))
 - Mario Rodriguez - [mapno](https://github.com/mapno) ([Grafana Labs](https://grafana.com/))
 - Marty Disibio - [mdisibio](https://github.com/mdisibio) ([Grafana Labs](https://grafana.com/))
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,5 +1,6 @@
 * @annanay25
 * @dgzlopes
 * @joe-elliott
+* @kvrhdn
 * @mapno
 * @mdisibio


### PR DESCRIPTION
**What this PR does**:
Proposal to make @kvrhdn a maintainer. An approving review is a vote in favor.

- [Agent Work](https://github.com/grafana/agent/pulls?q=is%3Apr+author%3Akvrhdn+is%3Aclosed)
- [Tempo Work](https://github.com/grafana/tempo/pulls?q=is%3Apr+author%3Akvrhdn+is%3Aclosed)
- [Tempo Reviews](https://github.com/grafana/tempo/pulls?q=is%3Apr+reviewed-by%3Akvrhdn+is%3Aclosed)

Additionally Koenraad has participated in the public slack and community forums as well as contributed to the OpenTelemetry project.