### PR TITLE
Update release workflow to ensure go 1.16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,22 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.16
+        id: go
+
+      - name: Check out code
+        uses: actions/checkout@v2
+        
       - name: Release
         if: startsWith(github.ref, 'refs/tags/v')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           make release
+
       - name: Upload release artifacts
         if: startsWith(github.ref, 'refs/tags/v')
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
**What this PR does**:
Github release workflow is failing with error.  This adds a step to install go 1.16 similar to ci and bench workflows. This solves the issue as best I can tell locally using https://github.com/nektos/act  
```
# github.com/grafana/tempo/tempodb/backend
tempodb/backend/readerat.go:79:9: undefined: "io".ReadAll
note: module requires Go 1.16
```

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`