### PR TITLE
Update port spec for GCS docker-compose example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## main / unreleased
 
+* [BUGFIX] Update port spec for GCS docker-compose example [#869](https://github.com/grafana/tempo/pull/869) (@zalegrala)
+
 ## v1.1.0-rc.0 / 2021-08-11
 
 * [BUGFIX] Allow only valid trace ID characters when decoding [#854](https://github.com/grafana/tempo/pull/854) (@zalegrala)

--- a/example/docker-compose/gcs/docker-compose.yaml
+++ b/example/docker-compose/gcs/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
 
   gcs:
     image: fsouza/fake-gcs-server
-    command: [ "-public-host gcs:4443"]
+    command: [ "-public-host=gcs -port=4443"]
     ports:
       - "4443:4443"
     volumes:


### PR DESCRIPTION
Without this change, the fake GCS server does not start properly due to
incorrect port specification.  Here we make the necessary update to ensure that
the fake server is started.

**Which issue(s) this PR fixes**:
Fixes #869

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`