### PR TITLE
Fix Blocks() on GCS

### DIFF
--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -140,6 +140,8 @@ func (r *reader) Blocks(ctx context.Context, tenantID string) ([]uuid.UUID, erro
 	// translate everything to UUIDs, if we see a bucket index we can skip that
 	blockIDs := make([]uuid.UUID, 0, len(objects))
 	for _, id := range objects {
+		// TODO: this line exists due to behavior differences in backends: https://github.com/grafana/tempo/issues/880
+		// revisit once #880 is resolved.
 		if id == TenantIndexName || id == "" {
 			continue
 		}

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -140,7 +140,7 @@ func (r *reader) Blocks(ctx context.Context, tenantID string) ([]uuid.UUID, erro
 	// translate everything to UUIDs, if we see a bucket index we can skip that
 	blockIDs := make([]uuid.UUID, 0, len(objects))
 	for _, id := range objects {
-		if id == TenantIndexName {
+		if id == TenantIndexName || id == "" {
 			continue
 		}
 		uuid, err := uuid.Parse(id)


### PR DESCRIPTION
**What this PR does**:
Fixes an issue where `Blocks()` fails on GCS when there is a tenant index present with error message `failed to poll blocklist. using previously polled lists" err="failed to parse : invalid UUID length: 0`.  This fix is a bandaid. A more correct fix requires #880 to be resolved.

