### PR TITLE
Unforgettable ring member cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main / unreleased
 
 * [BUGFIX] Update port spec for GCS docker-compose example [#869](https://github.com/grafana/tempo/pull/869) (@zalegrala)
+* [BUGFIX] Fix issue where unhealthy compactors can't be forgotten [#878](https://github.com/grafana/tempo/pull/878) (@joe-elliott)
 * [ENHANCEMENT] Added "query blocks" cli option. [#876](https://github.com/grafana/tempo/pull/876) (@joe-elliott)
 
 ## v1.1.0-rc.0 / 2021-08-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## main / unreleased
 
 * [BUGFIX] Update port spec for GCS docker-compose example [#869](https://github.com/grafana/tempo/pull/869) (@zalegrala)
-* [BUGFIX] Fix issue where unhealthy compactors can't be forgotten [#878](https://github.com/grafana/tempo/pull/878) (@joe-elliott)
+* [BUGFIX] Cortex upgrade to fix an issue where unhealthy compactors can't be forgotten [#878](https://github.com/grafana/tempo/pull/878) (@joe-elliott)
 * [ENHANCEMENT] Added "query blocks" cli option. [#876](https://github.com/grafana/tempo/pull/876) (@joe-elliott)
 
 ## v1.1.0-rc.0 / 2021-08-11

--- a/operations/tempo-mixin/runbook.md
+++ b/operations/tempo-mixin/runbook.md
@@ -50,26 +50,15 @@ But also factor in the resources provided to the querier.
 
 ## TempoCompactorUnhealthy
 
-Tempo by default uses [Memberlist](https://github.com/hashicorp/memberlist) to persist the ring state between components.
-Occasionally this results in old components staying in the ring which particularly impacts compactors because they start
-falling behind on the blocklist.  If this occurs port-forward to 3200 on a compactor and bring up `/compactor/ring`.  Use the
-"Forget" button to drop any unhealthy compactors.
-
-If unhealthy components persist then do rollouts of the processes that participate in the memberlist cluster.  Start
-with the least impactful components to the most while attempting to forget the unhealthy compactors after each rollout.  For
-the official jsonnet this would be: queriers, compactors, distributors and then ingesters.
+If this occurs port-forward to 3200 on a compactor and bring up `/compactor/ring`.  Use the "Forget" button to drop any unhealthy 
+compactors. An unhealthy compactor or two has no immediate impact. Long term, however, it will cause the blocklist to grow
+unnecessarily long.
 
 ## TempoDistributorUnhealthy
 
-Tempo by default uses [Memberlist](https://github.com/hashicorp/memberlist) to persist the ring state between components.
-Occasionally this results in old components staying in the ring which does not impact distributors directly, but at some point
-your components will be passing around a lot of unnecessary information. It may also indicate that a component shut down
-unexpectedly and may be worth investigating. If this occurs port-forward to 3200 on a distributor and bring up `/distributor/ring`.
-Use the "Forget" button to drop any unhealthy distributors.
-
-If unhealthy components persist then do rollouts of the processes that participate in the memberlist cluster.  Start
-with the least impactful components to the most while attempting to forget the unhealthy distributors after each rollout.  For
-the official jsonnet this would be: queriers, compactors, distributors and then ingesters.
+If this occurs port-forward to 3200 on a distributor and bring up `/distributor/ring`.  Use the "Forget" button to drop any unhealthy 
+distributors. An unhealthy distributor or two has virtually no impact except to slightly increase the amount of memberlist
+traffic propagated by the cluster.
 
 ## TempoCompactionsFailing
 


### PR DESCRIPTION
**What this PR does**:
Now that the unforgettable ring member issue is finally cleared:

- Remove references in runbooks
- Add a changelog entry

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`