### PR TITLE
Rename and clarify TempoFlushesFailing -> TempoIngesterFlushesFailing

### DIFF
--- a/operations/tempo-mixin/alerts.libsonnet
+++ b/operations/tempo-mixin/alerts.libsonnet
@@ -82,7 +82,7 @@
             },
           },
           {
-            alert: 'TempoFlushesFailing',
+            alert: 'TempoIngesterFlushesFailing',
             expr: |||
               sum by (cluster, namespace) (increase(tempo_ingester_failed_flushes_total{}[1h])) > %s and
               sum by (cluster, namespace) (increase(tempo_ingester_failed_flushes_total{}[5m])) > 0
@@ -92,7 +92,7 @@
             },
             annotations: {
               message: 'Greater than %s flushes have failed in the past hour.' % $._config.alerts.flushes_per_hour_failed,
-              runbook_url: 'https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoFlushesFailing'
+              runbook_url: 'https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoIngesterFlushesFailing'
             },
           },
           {


### PR DESCRIPTION
**What this PR does**:
Clarifies the `TempoFlushesFailing` alert and renames it to `TempoIngesterFlushesFailing`.

- The original description mentions failed compactions, but this alert can only be triggered by ingesters. It uses the `tempo_ingester_failed_flushes_total` metric that is created in `modules/ingester/flush.go`
- The section about the compactor creating orphaned blocks seems useful, maybe we should move it to another alert?

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~
