### PR TITLE
Add gzip middleware to HTTP endpoints

### DIFF
--- a/cmd/tempo/app/http.go
+++ b/cmd/tempo/app/http.go
@@ -1,0 +1,23 @@
+package app
+
+import (
+	"net/http"
+
+	"github.com/NYTimes/gziphandler"
+	"github.com/weaveworks/common/middleware"
+)
+
+func httpGzipMiddleware() middleware.Interface {
+	return middleware.Func(func(handler http.Handler) http.Handler {
+		gzipHandler := gziphandler.GzipHandler(handler)
+
+		return http.HandlerFunc(func(writer http.ResponseWriter, r *http.Request) {
+			// do not gzip the response when requesting protobuf as this will mess up the encoding
+			if r.Header.Get("Accept") == "application/protobuf" {
+				handler.ServeHTTP(writer, r)
+			} else {
+				gzipHandler.ServeHTTP(writer, r)
+			}
+		})
+	})
+}

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -158,6 +158,7 @@ func (t *App) initQuerier() (services.Service, error) {
 
 	tracesHandler := middleware.Merge(
 		t.httpAuthMiddleware,
+		httpGzipMiddleware(),
 	).Wrap(http.HandlerFunc(t.querier.TraceByIDHandler))
 
 	t.Server.HTTP.Handle(path.Join("/querier", addHTTPAPIPrefix(&t.cfg, apiPathTraces)), tracesHandler)
@@ -187,6 +188,7 @@ func (t *App) initQueryFrontend() (services.Service, error) {
 
 	tracesHandler := middleware.Merge(
 		t.httpAuthMiddleware,
+		httpGzipMiddleware(),
 	).Wrap(cortexHandler)
 
 	// register grpc server for queriers to connect to

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.3.0
 	github.com/Azure/azure-pipeline-go v0.2.2
 	github.com/Azure/azure-storage-blob-go v0.8.0
+	github.com/NYTimes/gziphandler v1.1.1
 	github.com/alecthomas/kong v0.2.11
 	github.com/cespare/xxhash v1.1.0
 	github.com/cortexproject/cortex v1.10.1-0.20210816080356-090988c40f3e

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -44,6 +44,7 @@ github.com/Azure/go-autorest/tracing
 # github.com/Masterminds/squirrel v0.0.0-20161115235646-20f192218cf5
 github.com/Masterminds/squirrel
 # github.com/NYTimes/gziphandler v1.1.1
+## explicit
 github.com/NYTimes/gziphandler
 # github.com/PuerkitoBio/purell v1.1.1
 github.com/PuerkitoBio/purell


### PR DESCRIPTION
**What this PR does**:
Adds gzip middleware to the query endpoints. See the description of https://github.com/grafana/tempo/pull/810 for why this needed.

The gzip middleware will compress responses if

1. the clients requests this by setting `Accept-Encoding: gzip`
2. the response is larger than 1500 bytes

This uses [nytimes/gziphandler](https://github.com/nytimes/gziphandler), which is also used by Cortex.

To test this, you can use `curl` with the `--compressed` switch.
The following trick prints the actual download size. `size_download` is _the total amount of bytes that were downloaded._

- Get trace without asking for compression
```
$ curl -sv -o /dev/null localhost:3200/api/traces/7295a9c7bfcb3ace40d6d55fd082ef78 -w '%{size_download}'

> GET /api/traces/7295a9c7bfcb3ace40d6d55fd082ef78 HTTP/1.1
> Host: localhost:3200
> User-Agent: curl/7.64.1
> Accept: */*
>
< HTTP/1.1 200 OK
< Vary: Accept-Encoding
< Date: Wed, 18 Aug 2021 15:49:42 GMT
< Content-Type: text/plain; charset=utf-8
< Transfer-Encoding: chunked
<

79975
```
- Ask for compression by setting `--compressed`
```
$ curl --compressed -sv -o /dev/null localhost:3200/api/traces/7295a9c7bfcb3ace40d6d55fd082ef78 -w '%{size_download}'

> GET /api/traces/7295a9c7bfcb3ace40d6d55fd082ef78 HTTP/1.1
> Host: localhost:3200
> User-Agent: curl/7.64.1
> Accept: */*
> Accept-Encoding: deflate, gzip
>
< HTTP/1.1 200 OK
< Content-Encoding: gzip
< Content-Type: text/plain; charset=utf-8
< Vary: Accept-Encoding
< Date: Wed, 18 Aug 2021 15:50:29 GMT
< Transfer-Encoding: chunked
<

22562
```

To test this make sure you have large traces, I'm using traces generated by vulture.

**Which issue(s) this PR fixes**:
Fixes #

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`