### PR TITLE
Use single configmap for overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [BUGFIX] Cortex upgrade to fix an issue where unhealthy compactors can't be forgotten [#878](https://github.com/grafana/tempo/pull/878) (@joe-elliott)
 * [ENHANCEMENT] Added "query blocks" cli option. [#876](https://github.com/grafana/tempo/pull/876) (@joe-elliott)
 * [ENHANCEMENT] Added traceid to `trace too large message`. [#888](https://github.com/grafana/tempo/pull/888) (@mritunjaysharma394)
+* [ENHANCEMENT] Add support to tempo workloads to `overrides` from single configmap in microservice mode. [#896](https://github.com/grafana/tempo/pull/896) (@kavirajk)
 
 ## v1.1.0-rc.0 / 2021-08-11
 

--- a/operations/jsonnet/microservices/compactor.libsonnet
+++ b/operations/jsonnet/microservices/compactor.libsonnet
@@ -25,7 +25,8 @@
     ]) +
     container.withVolumeMounts([
       volumeMount.new(tempo_config_volume, '/conf'),
-    ] + if $._config.use_overrides_configmap then [volumeMount.new(tempo_overrides_config_volume, '/overrides')] else []) +
+      volumeMount.new(tempo_overrides_config_volume, '/overrides'),
+    ]) +
     $.util.withResources($._config.compactor.resources) +
     $.util.readinessProbe,
 
@@ -43,9 +44,8 @@
     }) +
     deployment.mixin.spec.template.spec.withVolumes([
       volume.fromConfigMap(tempo_config_volume, $.tempo_compactor_configmap.metadata.name),
-    ] + if $._config.use_overrides_configmap then
-	  [volume.fromConfigMap(tempo_overrides_config_volume, $._config.overrides_configmap_name)]
-	else []),
+      volume.fromConfigMap(tempo_overrides_config_volume, $._config.overrides_configmap_name),
+    ]),
 
   tempo_compactor_service:
     k.util.serviceFor($.tempo_compactor_deployment),

--- a/operations/jsonnet/microservices/compactor.libsonnet
+++ b/operations/jsonnet/microservices/compactor.libsonnet
@@ -44,7 +44,7 @@
     }) +
     deployment.mixin.spec.template.spec.withVolumes([
       volume.fromConfigMap(tempo_config_volume, $.tempo_compactor_configmap.metadata.name),
-      volume.fromConfigMap(tempo_overrides_config_volume, $._config.overrides_configmap_name),
+      volume.fromConfigMap(tempo_overrides_config_volume, $.overrides_configmap.metadata.name),
     ]),
 
   tempo_compactor_service:

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -97,6 +97,7 @@
     backend: error 'Must specify a backend',  // gcs|s3
     bucket: error 'Must specify a bucket',
 
+    // `use_overrides_configmap` enables the tempo workloads read `overrides.yaml` from single configmap
     // Eventually, once we enable it everywhere, we remove this and default will be true.
     use_overrides_configmap: false,
     overrides_configmap_name: 'overrides',

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -97,6 +97,10 @@
     backend: error 'Must specify a backend',  // gcs|s3
     bucket: error 'Must specify a bucket',
 
+    // Eventually, once we enable it everywhere, we remove this and default will be true.
+    use_overrides_configmap: false,
+    overrides_configmap_name: 'overrides',
+
     overrides+:: {
       super_user:: {
         max_traces_per_user: 100000,

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -97,11 +97,7 @@
     backend: error 'Must specify a backend',  // gcs|s3
     bucket: error 'Must specify a bucket',
 
-    // `use_overrides_configmap` enables the tempo workloads read `overrides.yaml` from single configmap
-    // Eventually, once we enable it everywhere, we remove this and default will be true.
-    use_overrides_configmap: false,
     overrides_configmap_name: 'overrides',
-
     overrides+:: {
       super_user:: {
         max_traces_per_user: 100000,

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -97,7 +97,7 @@
     backend: error 'Must specify a backend',  // gcs|s3
     bucket: error 'Must specify a bucket',
 
-    overrides_configmap_name: 'overrides',
+    overrides_configmap_name: 'tempo-overrides',
     overrides+:: {
       super_user:: {
         max_traces_per_user: 100000,

--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -101,7 +101,7 @@
 
   // This will be the single configmap that stores `overrides.yaml`.
   overrides_configmap:
-    configMap.new('overrides') +
+    configMap.new($._config.overrides_configmap_name) +
     configMap.withData({
       'overrides.yaml': k.util.manifestYaml({
         overrides: $._config.overrides,

--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -102,7 +102,7 @@
   // This will be the single configmap that stores `overrides.yaml`.
   overrides_configmap:
     configMap.new('overrides') +
-    configMap.withDataMixin({
+    configMap.withData({
       'overrides.yaml': k.util.manifestYaml({
         overrides: $._config.overrides,
       }),

--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -42,7 +42,7 @@
       },
     },
     overrides: {
-      per_tenant_override_config: if ! $._config.use_overrides_configmap then '/conf/overrides.yaml' else '/overrides/overrides.yaml',
+      per_tenant_override_config: '/overrides/overrides.yaml',
     },
     memberlist: {
       abort_if_cluster_join_fails: false,
@@ -100,47 +100,31 @@
   tempo_query_frontend_config:: $.tempo_config{},
 
   // This will be the single configmap that stores `overrides.yaml`.
-  overrides_configmap: if $._config.use_overrides_configmap then
+  overrides_configmap:
     configMap.new('overrides') +
     configMap.withDataMixin({
       'overrides.yaml': k.util.manifestYaml({
         overrides: $._config.overrides,
       }),
-    })
-  else {},
+    }),
 
   tempo_distributor_configmap:
     configMap.new('tempo-distributor') +
     configMap.withData({
       'tempo.yaml': k.util.manifestYaml($.tempo_distributor_config),
-    }) +
-    if ! $._config.use_overrides_configmap then configMap.withDataMixin({
-      'overrides.yaml': k.util.manifestYaml({
-        overrides: $._config.overrides,
-      }),
-    }) else {},
+    }),
 
   tempo_ingester_configmap:
     configMap.new('tempo-ingester') +
     configMap.withData({
       'tempo.yaml': k.util.manifestYaml($.tempo_ingester_config),
-    }) +
-    if ! $._config.use_overrides_configmap then configMap.withDataMixin({
-      'overrides.yaml': k.util.manifestYaml({
-        overrides: $._config.overrides,
-      }),
-    }) else {},
+    }),
 
   tempo_compactor_configmap:
     configMap.new('tempo-compactor') +
     configMap.withData({
       'tempo.yaml': k.util.manifestYaml($.tempo_compactor_config),
-    }) +
-    if ! $._config.use_overrides_configmap then configMap.withDataMixin({
-      'overrides.yaml': k.util.manifestYaml({
-        overrides: $._config.overrides,
-      }),
-    }) else {},
+    }),
 
   tempo_querier_configmap:
     configMap.new('tempo-querier') +

--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -99,6 +99,7 @@
 
   tempo_query_frontend_config:: $.tempo_config{},
 
+  // This will be the single configmap that stores `overrides.yaml`.
   overrides_configmap: if $._config.use_overrides_configmap then
     configMap.new('overrides') +
     configMap.withDataMixin({

--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -42,7 +42,7 @@
       },
     },
     overrides: {
-      per_tenant_override_config: '/conf/overrides.yaml',
+      per_tenant_override_config: if ! $._config.use_overrides_configmap then '/conf/overrides.yaml' else '/overrides/overrides.yaml',
     },
     memberlist: {
       abort_if_cluster_join_fails: false,
@@ -99,38 +99,47 @@
 
   tempo_query_frontend_config:: $.tempo_config{},
 
+  overrides_configmap: if $._config.use_overrides_configmap then
+    configMap.new('overrides') +
+    configMap.withDataMixin({
+      'overrides.yaml': k.util.manifestYaml({
+        overrides: $._config.overrides,
+      }),
+    })
+  else {},
+
   tempo_distributor_configmap:
     configMap.new('tempo-distributor') +
     configMap.withData({
       'tempo.yaml': k.util.manifestYaml($.tempo_distributor_config),
     }) +
-    configMap.withDataMixin({
+    if ! $._config.use_overrides_configmap then configMap.withDataMixin({
       'overrides.yaml': k.util.manifestYaml({
         overrides: $._config.overrides,
       }),
-    }),
+    }) else {},
 
   tempo_ingester_configmap:
     configMap.new('tempo-ingester') +
     configMap.withData({
       'tempo.yaml': k.util.manifestYaml($.tempo_ingester_config),
     }) +
-    configMap.withDataMixin({
+    if ! $._config.use_overrides_configmap then configMap.withDataMixin({
       'overrides.yaml': k.util.manifestYaml({
         overrides: $._config.overrides,
       }),
-    }),
+    }) else {},
 
   tempo_compactor_configmap:
     configMap.new('tempo-compactor') +
     configMap.withData({
       'tempo.yaml': k.util.manifestYaml($.tempo_compactor_config),
     }) +
-    configMap.withDataMixin({
+    if ! $._config.use_overrides_configmap then configMap.withDataMixin({
       'overrides.yaml': k.util.manifestYaml({
         overrides: $._config.overrides,
       }),
-    }),
+    }) else {},
 
   tempo_querier_configmap:
     configMap.new('tempo-querier') +

--- a/operations/jsonnet/microservices/distributor.libsonnet
+++ b/operations/jsonnet/microservices/distributor.libsonnet
@@ -25,7 +25,8 @@
     ]) +
     container.withVolumeMounts([
       volumeMount.new(tempo_config_volume, '/conf'),
-    ] + if $._config.use_overrides_configmap then [volumeMount.new(tempo_overrides_config_volume, '/overrides')] else []) +
+      volumeMount.new(tempo_overrides_config_volume, '/overrides'),
+    ]) +
     $.util.withResources($._config.distributor.resources) +
     $.util.readinessProbe,
 
@@ -47,10 +48,8 @@
     }) +
     deployment.mixin.spec.template.spec.withVolumes([
       volume.fromConfigMap(tempo_config_volume, $.tempo_distributor_configmap.metadata.name),
-    ] + if $._config.use_overrides_configmap then
-	  [volume.fromConfigMap(tempo_overrides_config_volume, $._config.overrides_configmap_name)]
-	else []),
-
+      volume.fromConfigMap(tempo_overrides_config_volume, $._config.overrides_configmap_name),
+    ]),
 
   tempo_distributor_service:
     k.util.serviceFor($.tempo_distributor_deployment),

--- a/operations/jsonnet/microservices/distributor.libsonnet
+++ b/operations/jsonnet/microservices/distributor.libsonnet
@@ -48,7 +48,7 @@
     }) +
     deployment.mixin.spec.template.spec.withVolumes([
       volume.fromConfigMap(tempo_config_volume, $.tempo_distributor_configmap.metadata.name),
-      volume.fromConfigMap(tempo_overrides_config_volume, $._config.overrides_configmap_name),
+      volume.fromConfigMap(tempo_overrides_config_volume, $.overrides_configmap.metadata.name),
     ]),
 
   tempo_distributor_service:

--- a/operations/jsonnet/microservices/ingester.libsonnet
+++ b/operations/jsonnet/microservices/ingester.libsonnet
@@ -59,7 +59,7 @@
     })
     + statefulset.mixin.spec.template.spec.withVolumes([
       volume.fromConfigMap(tempo_config_volume, $.tempo_ingester_configmap.metadata.name),
-      volume.fromConfigMap(tempo_overrides_config_volume, $._config.overrides_configmap_name),
+      volume.fromConfigMap(tempo_overrides_config_volume, $.overrides_configmap.metadata.name),
     ]),
 
   tempo_ingester_service:

--- a/operations/jsonnet/microservices/ingester.libsonnet
+++ b/operations/jsonnet/microservices/ingester.libsonnet
@@ -36,7 +36,8 @@
     container.withVolumeMounts([
       volumeMount.new(tempo_config_volume, '/conf'),
       volumeMount.new(tempo_data_volume, '/var/tempo'),
-    ] + if $._config.use_overrides_configmap then [volumeMount.new(tempo_overrides_config_volume, '/overrides')] else []) +
+      volumeMount.new(tempo_overrides_config_volume, '/overrides'),
+    ]) +
     $.util.withResources($._config.ingester.resources) +
     $.util.readinessProbe,
 
@@ -58,10 +59,8 @@
     })
     + statefulset.mixin.spec.template.spec.withVolumes([
       volume.fromConfigMap(tempo_config_volume, $.tempo_ingester_configmap.metadata.name),
-    ]+ if $._config.use_overrides_configmap then
-	  [volume.fromConfigMap(tempo_overrides_config_volume, $._config.overrides_configmap_name)]
-	else []),
-
+      volume.fromConfigMap(tempo_overrides_config_volume, $._config.overrides_configmap_name),
+    ]),
 
   tempo_ingester_service:
     k.util.serviceFor($.tempo_ingester_statefulset),

--- a/operations/jsonnet/microservices/ingester.libsonnet
+++ b/operations/jsonnet/microservices/ingester.libsonnet
@@ -12,6 +12,7 @@
   local target_name = 'ingester',
   local tempo_config_volume = 'tempo-conf',
   local tempo_data_volume = 'ingester-data',
+  local tempo_overrides_config_volume = 'overrides',
 
   tempo_ingester_pvc::
     pvc.new()
@@ -35,7 +36,7 @@
     container.withVolumeMounts([
       volumeMount.new(tempo_config_volume, '/conf'),
       volumeMount.new(tempo_data_volume, '/var/tempo'),
-    ]) +
+    ] + if $._config.use_overrides_configmap then [volumeMount.new(tempo_overrides_config_volume, '/overrides')] else []) +
     $.util.withResources($._config.ingester.resources) +
     $.util.readinessProbe,
 
@@ -57,7 +58,10 @@
     })
     + statefulset.mixin.spec.template.spec.withVolumes([
       volume.fromConfigMap(tempo_config_volume, $.tempo_ingester_configmap.metadata.name),
-    ]),
+    ]+ if $._config.use_overrides_configmap then
+	  [volume.fromConfigMap(tempo_overrides_config_volume, $._config.overrides_configmap_name)]
+	else []),
+
 
   tempo_ingester_service:
     k.util.serviceFor($.tempo_ingester_statefulset),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Add support to tempo workloads to read `overrides` values from single configmap in microservice mode.

**Which issue(s) this PR fixes**:
Fixes #875

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`