### PR TITLE
Make overrides configmap block name consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [ENHANCEMENT] Added "query blocks" cli option. [#876](https://github.com/grafana/tempo/pull/876) (@joe-elliott)
 * [ENHANCEMENT] Added traceid to `trace too large message`. [#888](https://github.com/grafana/tempo/pull/888) (@mritunjaysharma394)
 * [ENHANCEMENT] Add support to tempo workloads to `overrides` from single configmap in microservice mode. [#896](https://github.com/grafana/tempo/pull/896) (@kavirajk)
+* [ENHANCEMENT] Make `overrides_config` block name consistent with Loki and Cortex in microservice mode. [#906](https://github.com/grafana/tempo/pull/906) (@kavirajk)
 
 ## v1.1.0-rc.0 / 2021-08-11
 

--- a/operations/jsonnet/microservices/compactor.libsonnet
+++ b/operations/jsonnet/microservices/compactor.libsonnet
@@ -44,7 +44,7 @@
     }) +
     deployment.mixin.spec.template.spec.withVolumes([
       volume.fromConfigMap(tempo_config_volume, $.tempo_compactor_configmap.metadata.name),
-      volume.fromConfigMap(tempo_overrides_config_volume, $.overrides_configmap.metadata.name),
+      volume.fromConfigMap(tempo_overrides_config_volume, $.overrides_config.metadata.name),
     ]),
 
   tempo_compactor_service:

--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -100,7 +100,7 @@
   tempo_query_frontend_config:: $.tempo_config{},
 
   // This will be the single configmap that stores `overrides.yaml`.
-  overrides_configmap:
+  overrides_config:
     configMap.new($._config.overrides_configmap_name) +
     configMap.withData({
       'overrides.yaml': k.util.manifestYaml({

--- a/operations/jsonnet/microservices/distributor.libsonnet
+++ b/operations/jsonnet/microservices/distributor.libsonnet
@@ -48,7 +48,7 @@
     }) +
     deployment.mixin.spec.template.spec.withVolumes([
       volume.fromConfigMap(tempo_config_volume, $.tempo_distributor_configmap.metadata.name),
-      volume.fromConfigMap(tempo_overrides_config_volume, $.overrides_configmap.metadata.name),
+      volume.fromConfigMap(tempo_overrides_config_volume, $.overrides_config.metadata.name),
     ]),
 
   tempo_distributor_service:

--- a/operations/jsonnet/microservices/ingester.libsonnet
+++ b/operations/jsonnet/microservices/ingester.libsonnet
@@ -59,7 +59,7 @@
     })
     + statefulset.mixin.spec.template.spec.withVolumes([
       volume.fromConfigMap(tempo_config_volume, $.tempo_ingester_configmap.metadata.name),
-      volume.fromConfigMap(tempo_overrides_config_volume, $.overrides_configmap.metadata.name),
+      volume.fromConfigMap(tempo_overrides_config_volume, $.overrides_config.metadata.name),
     ]),
 
   tempo_ingester_service:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
It edit tempo microservices jsonnet and makes the `overrides_config` block name consistent with Loki and Cortex

1. Loki - https://github.com/grafana/loki/blob/main/production/ksonnet/loki/overrides.libsonnet#L21
2. Cortex - https://github.com/grafana/cortex-jsonnet/blob/main/cortex/config.libsonnet#L469

**Which issue(s) this PR fixes**:
Fixes #NA

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`