### PR TITLE
Jsonnet improvements

### DIFF
--- a/operations/jsonnet/microservices/compactor.libsonnet
+++ b/operations/jsonnet/microservices/compactor.libsonnet
@@ -37,8 +37,8 @@
                      $.tempo_compactor_container,
                    ],
                    { app: target_name }) +
-    deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(0) +
-    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
+    deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge('50%') +
+    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable('100%') +
     deployment.mixin.spec.template.metadata.withAnnotations({
       config_hash: std.md5(std.toString($.tempo_compactor_configmap.data['tempo.yaml'])),
     }) +

--- a/operations/jsonnet/microservices/ingester.libsonnet
+++ b/operations/jsonnet/microservices/ingester.libsonnet
@@ -60,7 +60,8 @@
     + statefulset.mixin.spec.template.spec.withVolumes([
       volume.fromConfigMap(tempo_config_volume, $.tempo_ingester_configmap.metadata.name),
       volume.fromConfigMap(tempo_overrides_config_volume, $._config.overrides_configmap_name),
-    ]),
+    ])
+    + statefulset.mixin.spec.withPodManagementPolicy('Parallel'),
 
   tempo_ingester_service:
     k.util.serviceFor($.tempo_ingester_statefulset),


### PR DESCRIPTION
**What this PR does**:
Improves jsonnet with:

- Parallel pod management policy on ingesters. This allows for rapid scale up/down in the event of emergencies
- Settings to roll compactors faster. The previous settings were there to reduce "unforgettable" compactors but that is no longer an issue. The below settings will reduce compaction errors due to ring settling on deployment.