### PR TITLE
Fix search data mutable to not inadvertently save zero start time. Up…

### DIFF
--- a/pkg/tempofb/searchdata_test.go
+++ b/pkg/tempofb/searchdata_test.go
@@ -3,6 +3,8 @@ package tempofb
 import (
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func sizeWithCounts(traceCount, tagCount, valueCount int) int {
@@ -20,6 +22,54 @@ func sizeWithCounts(traceCount, tagCount, valueCount int) int {
 	}
 
 	return len(b.Finish())
+}
+
+func TestSearchEntryMutableSetStartTimeUnixNano(t *testing.T) {
+
+	testCases := []struct {
+		name     string
+		inputs   []uint64
+		expected uint64
+	}{
+		{"save smallest", []uint64{2, 1, 3}, 1},
+		{"don't save zeros", []uint64{1000, 0}, 1000},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &SearchEntryMutable{}
+
+			for _, i := range tc.inputs {
+				e.SetStartTimeUnixNano(i)
+			}
+
+			require.Equal(t, tc.expected, e.StartTimeUnixNano)
+		})
+	}
+}
+
+func TestSearchEntryMutableSetEndTimeUnixNano(t *testing.T) {
+
+	testCases := []struct {
+		name     string
+		inputs   []uint64
+		expected uint64
+	}{
+		{"save largest", []uint64{2, 3, 1}, 3},
+		{"don't save zeros", []uint64{1000, 0}, 1000},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &SearchEntryMutable{}
+
+			for _, i := range tc.inputs {
+				e.SetEndTimeUnixNano(i)
+			}
+
+			require.Equal(t, tc.expected, e.EndTimeUnixNano)
+		})
+	}
 }
 
 func TestEncodingSize(t *testing.T) {

--- a/pkg/tempofb/searchdata_util.go
+++ b/pkg/tempofb/searchdata_util.go
@@ -106,7 +106,7 @@ func (s *SearchEntryMutable) AddTag(k string, v string) {
 
 // SetStartTimeUnixNano records the earliest of all timestamps passed to this function.
 func (s *SearchEntryMutable) SetStartTimeUnixNano(t uint64) {
-	if t > 0 && s.StartTimeUnixNano == 0 || s.StartTimeUnixNano > t {
+	if t > 0 && (s.StartTimeUnixNano == 0 || s.StartTimeUnixNano > t) {
 		s.StartTimeUnixNano = t
 	}
 }


### PR DESCRIPTION
**What this PR does**:
Fixes a few small issues with search:
(1) When combining multiple segments, the logic was not right for saving the earliest span start time.  Added missing parens.
(2) Updated streaming search block to only unpack/repack FB segments when needed (i.e. trace has multiple batches).  It was unpacking/repacking even a single segment unnecessarily.

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`