### PR TITLE
Fixed helm examples

### DIFF
--- a/example/helm/microservices-grafana-values.yaml
+++ b/example/helm/microservices-grafana-values.yaml
@@ -12,7 +12,7 @@ datasources:
         type: tempo
         access: proxy
         orgId: 1
-        url: http://tempo-tempo-distributed-query-frontend:3200
+        url: http://tempo-tempo-distributed-query-frontend:3100
         basicAuth: false
         isDefault: true
         version: 1

--- a/example/helm/readme.md
+++ b/example/helm/readme.md
@@ -19,12 +19,6 @@ Create a cluster
 k3d cluster create tempo --api-port 6443 --port "3000:80@loadbalancer"
 ```
 
-If you wish to use a local image, you can import these into k3d
-
-```console
-k3d image import grafana/tempo:latest --cluster tempo
-```
-
 Next either deploy the microservices or the single binary.
 
 ### Microservices

--- a/example/helm/single-binary-grafana-values.yaml
+++ b/example/helm/single-binary-grafana-values.yaml
@@ -12,7 +12,7 @@ datasources:
         type: tempo
         access: proxy
         orgId: 1
-        url: http://tempo:3200
+        url: http://tempo:3100
         basicAuth: false
         isDefault: true
         version: 1


### PR DESCRIPTION
**What this PR does**:
When testing the latest 1.1 helm packages I found that the ports are configured incorrectly in our helm examples. Fixed.

Also removed the line about using a custom image b/c the helm charts pull specific stable versions and do not use `:latest`.

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`