### PR TITLE
Fix 32/64-bit issue in search duration filtering

### DIFF
--- a/tempodb/search/pipeline.go
+++ b/tempodb/search/pipeline.go
@@ -20,16 +20,16 @@ func NewSearchPipeline(req *tempopb.SearchRequest) Pipeline {
 	p := Pipeline{}
 
 	if req.MinDurationMs > 0 {
-		minDuration := req.MinDurationMs * uint32(time.Millisecond)
+		minDuration := uint64(time.Duration(req.MinDurationMs) * time.Millisecond)
 		p.tracefilters = append(p.tracefilters, func(s *tempofb.SearchEntry) bool {
-			return (s.EndTimeUnixNano()-s.StartTimeUnixNano())*uint64(time.Nanosecond) >= uint64(minDuration)
+			return (s.EndTimeUnixNano() - s.StartTimeUnixNano()) >= minDuration
 		})
 	}
 
 	if req.MaxDurationMs > 0 {
-		maxDuration := req.MaxDurationMs * uint32(time.Millisecond)
+		maxDuration := uint64(time.Duration(req.MaxDurationMs) * time.Millisecond)
 		p.tracefilters = append(p.tracefilters, func(s *tempofb.SearchEntry) bool {
-			return (s.EndTimeUnixNano()-s.StartTimeUnixNano())*uint64(time.Nanosecond) <= uint64(maxDuration)
+			return (s.EndTimeUnixNano() - s.StartTimeUnixNano()) <= maxDuration
 		})
 	}
 


### PR DESCRIPTION
**What this PR does**:
Search duration filtering had incorrect results when trying to filter durations above ~4s. This was due to inadvertently storing nanos in uint32. This fixes to use uint64.

**Which issue(s) this PR fixes**:
Fixes some of #932 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`