### PR TITLE
Delete completed local blocks when replaying wal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [FEATURE] Add ability to search ingesters for traces [#806](https://github.com/grafana/tempo/pull/806) (@mdisibio)
 * [BUGFIX] Update port spec for GCS docker-compose example [#869](https://github.com/grafana/tempo/pull/869) (@zalegrala)
 * [BUGFIX] Cortex upgrade to fix an issue where unhealthy compactors can't be forgotten [#878](https://github.com/grafana/tempo/pull/878) (@joe-elliott)
+* [BUGFIX] Fix "magic number" errors and other block mishandling when an ingester forcefully shuts down [#937](https://github.com/grafana/tempo/issues/937) (@mdisibio)
 * [ENHANCEMENT] Added "query blocks" cli option. [#876](https://github.com/grafana/tempo/pull/876) (@joe-elliott)
 * [ENHANCEMENT] Added traceid to `trace too large message`. [#888](https://github.com/grafana/tempo/pull/888) (@mritunjaysharma394)
 * [ENHANCEMENT] Add support to tempo workloads to `overrides` from single configmap in microservice mode. [#896](https://github.com/grafana/tempo/pull/896) (@kavirajk)

--- a/modules/ingester/ingester.go
+++ b/modules/ingester/ingester.go
@@ -343,6 +343,17 @@ func (i *Ingester) replayWal() error {
 			return err
 		}
 
+		// Delete anything remaining for the completed version of this
+		// wal block. This handles the case where a wal file is partially
+		// or fully completed to the local store, but the wal file wasn't
+		// deleted (because it wa rescanned above). This can happen for reasons
+		// such as a crash or restart. In this situation we err on the side of
+		// caution and replay the wal block.
+		err = instance.local.ClearBlock(b.Meta().BlockID, tenantID)
+		if err != nil {
+			return err
+		}
+
 		instance.AddCompletingBlock(b)
 
 		i.enqueue(&flushOp{

--- a/modules/ingester/ingester.go
+++ b/modules/ingester/ingester.go
@@ -346,7 +346,7 @@ func (i *Ingester) replayWal() error {
 		// Delete anything remaining for the completed version of this
 		// wal block. This handles the case where a wal file is partially
 		// or fully completed to the local store, but the wal file wasn't
-		// deleted (because it wa rescanned above). This can happen for reasons
+		// deleted (because it was rescanned above). This can happen for reasons
 		// such as a crash or restart. In this situation we err on the side of
 		// caution and replay the wal block.
 		err = instance.local.ClearBlock(b.Meta().BlockID, tenantID)

--- a/modules/ingester/ingester_test.go
+++ b/modules/ingester/ingester_test.go
@@ -238,7 +238,8 @@ func TestWalReplayDeletesLocalBlocks(t *testing.T) {
 	// Simulate a restart.
 	inst.completeBlocks = []*wal.LocalBlock{}
 	inst.completingBlocks = []*wal.AppendBlock{}
-	i.starting(ctx)
+	err = i.starting(ctx)
+	require.NoError(t, err)
 
 	// After restart we only have the 1 wal block
 	require.Len(t, inst.completingBlocks, 1)

--- a/pkg/flushqueues/exclusivequeues.go
+++ b/pkg/flushqueues/exclusivequeues.go
@@ -11,7 +11,7 @@ type ExclusiveQueues struct {
 	queues     []*PriorityQueue
 	index      *atomic.Int32
 	activeKeys sync.Map
-	stopped    bool
+	stopped    atomic.Bool
 }
 
 // New creates a new set of flush queues with a prom gauge to track current depth
@@ -70,7 +70,7 @@ func (f *ExclusiveQueues) IsEmpty() bool {
 
 // Stop closes all queues
 func (f *ExclusiveQueues) Stop() {
-	f.stopped = true
+	f.stopped.Store(true)
 
 	for _, q := range f.queues {
 		q.Close()
@@ -78,5 +78,5 @@ func (f *ExclusiveQueues) Stop() {
 }
 
 func (f *ExclusiveQueues) IsStopped() bool {
-	return f.stopped
+	return f.stopped.Load()
 }


### PR DESCRIPTION
**What this PR does**:
This PR fixes #937 by deleting locally complete blocks during wal replay, and another race condition on ingester startup.  Here is a description of the situation and why this should fix it.

1. An ingester may restart or crash while completing the wal file. It can happen after creating the new local block, but before deleting the wal file.
2. On restart the ingester replays wal, and rediscovers local blocks.  Both exist it ends up with 2 queue entries instead of 1.  It will both recomplete the wal and reflush the local block.  These occur independently and there are no consistency checks while processing the queue entry.
3. This is a race condition in multiple ways. 
  a. The wal complete is in progress, writing over top of `data` when it is flushed to the backend. The flush will reach EOF and assume all went well. This creates a partially written block in the backend.
  b. The wal complete can entirely finish before the flush.   It appends another entry into `completedBlocks`.  When the flush occurs it reads the first entry from `completedBlocks` and saves it as the meta data. This is the actual condition for `magic number` errors and incorrect meta. It uses the meta as rediscovered in step 2, which may be a different encoding, etc.
  c. The wal complete can start on a new block before rediscoverLocalBlocks begins. rediscoverLocalBlocks sees a bad block (missing meta) and deletes it.  I think this ends up in a situation similar to (a) but different causes. This is handled by not rediscovering the local block is there is still a wal for it.

A couple more notes:
* Enabling search increased the risk of these errors because it added more work between creating the local block and deleting the wal in step 1.
* We've also seen issues with partially flushed blocks like 3a and 3b, but afaik there isn't an issue tracking them.  

**Which issue(s) this PR fixes**:
Fixes #937 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`