### PR TITLE
Consolidate status information onto /status endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * [CHANGE] Renamed CLI flag from `--storage.trace.maintenance-cycle` to `--storage.trace.blocklist_poll`. This is a **breaking change**  [#897](https://github.com/grafana/tempo/pull/897) (@mritunjaysharma394)
 * [CHANGE] update jsonnet alerts and recording rules to use `job_selectors` and `cluster_selectors` for configurable unique identifier labels [#935](https://github.com/grafana/tempo/pull/935) (@kevinschoonover)
 * [CHANGE] Modify generated tag keys in Vulture for easier filtering [#934](https://github.com/grafana/tempo/pull/934) (@zalegrala)
+* [CHANGE] Consolidate status information onto /status endpoint [ #952 ](https://github.com/grafana/tempo/pull/952) @zalegrala)
 * [FEATURE] Add runtime config handler  [#936](https://github.com/grafana/tempo/pull/936) (@mapno)
 
 ## v1.1.0 / 2021-08-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,11 @@
 * [CHANGE] Renamed CLI flag from `--storage.trace.maintenance-cycle` to `--storage.trace.blocklist_poll`. This is a **breaking change**  [#897](https://github.com/grafana/tempo/pull/897) (@mritunjaysharma394)
 * [CHANGE] update jsonnet alerts and recording rules to use `job_selectors` and `cluster_selectors` for configurable unique identifier labels [#935](https://github.com/grafana/tempo/pull/935) (@kevinschoonover)
 * [CHANGE] Modify generated tag keys in Vulture for easier filtering [#934](https://github.com/grafana/tempo/pull/934) (@zalegrala)
-* [CHANGE] Consolidate status information onto /status endpoint [ #952 ](https://github.com/grafana/tempo/pull/952) @zalegrala)
+* [CHANGE] **BREAKING CHANGE** Consolidate status information onto /status endpoint [ #952 ](https://github.com/grafana/tempo/pull/952) @zalegrala)
+The following endpoints moved.
+`/runtime_config` moved to `/status/runtime_config`
+`/config` moved to `/status/config`
+`/services` moved to `/status/services`
 * [FEATURE] Add runtime config handler  [#936](https://github.com/grafana/tempo/pull/936) (@mapno)
 
 ## v1.1.0 / 2021-08-26

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -103,8 +103,6 @@ func (t *App) initOverrides() (services.Service, error) {
 	}
 	t.overrides = overrides
 
-	t.Server.HTTP.Handle("/runtime_config", overrides.Handler())
-
 	return t.overrides, nil
 }
 

--- a/docs/tempo/website/api_docs/_index.md
+++ b/docs/tempo/website/api_docs/_index.md
@@ -190,9 +190,36 @@ GET /status
 ```
 Print all available information by default.
 
+```
+GET /status/version
+```
+
+Print the version information.
+
+```
+GET /status/services
+```
+
+Displays a list of services and their status. If a service failed it will show the failure case.
+
+```
+GET /status/endpoints
+```
+
+Displays status information about the API endpoints.
+
+```
+GET /status/runtime_config
+```
+
+Displays the override configuration.
+
 Query Parameter:
-- `endpoints`: Displays status information about the API endpoints.
-- `config`: Displays the configuration currently applied to Tempo (in YAML format), including default values and settings via CLI flags.
+- `mode = (diff)`: Used to show the difference between defaults and overrides.
+
+```
+GET /status/runtime_config
+```
+
+Displays the configuration currently applied to Tempo (in YAML format), including default values and settings via CLI flags.
 Sensitive data is masked. Please be aware that the exported configuration **doesn't include the per-tenant overrides**.
-- `services`: Displays a list of services and their status. If a service failed it will show the failure case.
-- `runtime_config = (diff)`: Displays the override configuration.  Optionally setting a value of `diff` can be used to show the difference between defaults and overrides.

--- a/docs/tempo/website/api_docs/_index.md
+++ b/docs/tempo/website/api_docs/_index.md
@@ -33,16 +33,6 @@ For the sake of clarity, in this document we have grouped API endpoints by servi
 
 _(*) This endpoint is not always available, check the specific section for more details._
 
-### Configuration
-
-```
-GET /config
-```
-
-Displays the configuration currently applied to Tempo (in YAML format), including default values and settings via CLI flags.
-Sensitive data is masked. Please be aware that the exported configuration **doesn't include the per-tenant overrides**.
-
-
 ### Readiness probe
 
 ```
@@ -50,14 +40,6 @@ GET /ready
 ```
 
 Returns status code 200 when Tempo is ready to serve traffic.
-
-### Services
-
-```
-GET /services
-```
-
-Displays a list of services and their status. If a service failed it will show the failure case.
 
 ### Metrics
 
@@ -209,4 +191,8 @@ GET /status
 Print all available information by default.
 
 Query Parameter:
-- `endpoints`: Prints status information about the API endpoints.
+- `endpoints`: Displays status information about the API endpoints.
+- `config`: Displays the configuration currently applied to Tempo (in YAML format), including default values and settings via CLI flags.
+Sensitive data is masked. Please be aware that the exported configuration **doesn't include the per-tenant overrides**.
+- `services`: Displays a list of services and their status. If a service failed it will show the failure case.
+- `runtime_config = (diff)`: Displays the override configuration.  Optionally setting a value of `diff` can be used to show the difference between defaults and overrides.

--- a/modules/overrides/overrides.go
+++ b/modules/overrides/overrides.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/util"
@@ -147,7 +148,7 @@ func (o *Overrides) tenantOverrides() *perTenantOverrides {
 	return cfg
 }
 
-func (o *Overrides) WriteStatusRuntimeConfig(w io.Writer, mode string) error {
+func (o *Overrides) WriteStatusRuntimeConfig(w io.Writer, r *http.Request) error {
 	var tenantOverrides perTenantOverrides
 	if o.tenantOverrides() != nil {
 		tenantOverrides = *o.tenantOverrides()
@@ -157,6 +158,8 @@ func (o *Overrides) WriteStatusRuntimeConfig(w io.Writer, mode string) error {
 		Defaults:           o.defaultLimits,
 		PerTenantOverrides: tenantOverrides,
 	}
+
+	mode := r.URL.Query().Get("mode")
 	switch mode {
 	case "diff":
 		// Default runtime config is just empty struct, but to make diff work,


### PR DESCRIPTION
**What this PR does**:
Here we move a few status endpoints onto the `/status` endpoint.  Optionally, users can pass a few query parameters that will reduce the amount of output.

**Which issue(s) this PR fixes**:
Fixes #949

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`