### PR TITLE
Drop incorrect vulture flag from operations manifests

### DIFF
--- a/operations/jsonnet/microservices/vulture.libsonnet
+++ b/operations/jsonnet/microservices/vulture.libsonnet
@@ -16,7 +16,6 @@
       '-prometheus-listen-address=:' + port,
       '-tempo-push-url=' + $._config.vulture.tempoPushUrl,
       '-tempo-query-url=' + $._config.vulture.tempoQueryUrl,
-      '-logtostderr=true',
       '-tempo-org-id=' + $._config.vulture.tempoOrgId,
     ]) +
     k.util.resourcesRequests('50m', '100Mi') +

--- a/operations/kube-manifests/Deployment-vulture.yaml
+++ b/operations/kube-manifests/Deployment-vulture.yaml
@@ -22,7 +22,6 @@ spec:
         - -prometheus-listen-address=:8080
         - -tempo-push-url=http://distributor
         - -tempo-query-url=http://query-frontend:3200/tempo
-        - -logtostderr=true
         - -tempo-org-id=1
         image: grafana/tempo-vulture:latest
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
**What this PR does**:

Remove incorrect CLI flag when using vulture in jsonnet or kube-manifest.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`