### PR TITLE
Add search block headers for wal blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [ENHANCEMENT] Dedupe search records while replaying WAL [#940](https://github.com/grafana/tempo/pull/940) (@annanay25)
 * [ENHANCEMENT] Add status endpoint to list the available endpoints [#938](https://github.com/grafana/tempo/pull/938) (@zalegrala)
 * [ENHANCEMENT] Add search block headers [#943](https://github.com/grafana/tempo/pull/943) (@mdisibio)
+* [ENHANCEMENT] Add search block headers for wal blocks [#963](https://github.com/grafana/tempo/pull/963) (@mdisibio)
 * [CHANGE] Renamed CLI flag from `--storage.trace.maintenance-cycle` to `--storage.trace.blocklist_poll`. This is a **breaking change**  [#897](https://github.com/grafana/tempo/pull/897) (@mritunjaysharma394)
 * [CHANGE] update jsonnet alerts and recording rules to use `job_selectors` and `cluster_selectors` for configurable unique identifier labels [#935](https://github.com/grafana/tempo/pull/935) (@kevinschoonover)
 * [CHANGE] Modify generated tag keys in Vulture for easier filtering [#934](https://github.com/grafana/tempo/pull/934) (@zalegrala)

--- a/pkg/tempofb/SearchPage_util.go
+++ b/pkg/tempofb/SearchPage_util.go
@@ -1,0 +1,5 @@
+package tempofb
+
+func (s *SearchPage) Contains(k []byte, v []byte, buffer *KeyValues) bool {
+	return ContainsTag(s, buffer, k, v)
+}

--- a/pkg/tempofb/types.go
+++ b/pkg/tempofb/types.go
@@ -1,0 +1,30 @@
+package tempofb
+
+// TagContainer is anything with KeyValues (tags). This is implemented by both
+// SearchPage and SearchEntry.
+type TagContainer interface {
+	Contains(k []byte, v []byte, buffer *KeyValues) bool
+}
+
+type Trace interface {
+	TagContainer
+	StartTimeUnixNano() uint64
+	EndTimeUnixNano() uint64
+}
+
+var _ Trace = (*SearchEntry)(nil)
+
+type Page interface {
+	TagContainer
+}
+
+var _ Page = (*SearchPage)(nil)
+
+type Block interface {
+	TagContainer
+	MinDurationNanos() uint64
+	MaxDurationNanos() uint64
+}
+
+var _ Block = (*SearchBlockHeader)(nil)
+var _ Block = (*SearchBlockHeaderMutable)(nil)

--- a/tempodb/search/backend_search_block.go
+++ b/tempodb/search/backend_search_block.go
@@ -45,7 +45,7 @@ func NewBackendSearchBlock(input *StreamingSearchBlock, l *local.Backend, blockI
 		pageSizeBytes = defaultBackendSearchBlockPageSize
 	}
 
-	header := tempofb.NewSearchBlockHeaderBuilder()
+	header := tempofb.NewSearchBlockHeaderMutable()
 
 	w, err := newBackendSearchBlockWriter(blockID, tenantID, l, version, enc)
 	if err != nil {

--- a/tempodb/search/pipeline_test.go
+++ b/tempodb/search/pipeline_test.go
@@ -136,7 +136,7 @@ func TestPipelineMatchesTraceDuration(t *testing.T) {
 func TestPipelineMatchesBlock(t *testing.T) {
 
 	// Run all tests against this header
-	commonBlock := tempofb.NewSearchBlockHeaderBuilder()
+	commonBlock := tempofb.NewSearchBlockHeaderMutable()
 	commonBlock.AddTag("tag", "value")
 	commonBlock.MinDur = uint64(1 * time.Second)
 	commonBlock.MaxDur = uint64(10 * time.Second)


### PR DESCRIPTION
**What this PR does**:
Maintains a search blocker header for wal blocks like #943 did for completed blocks. This helps eliminate blocks from the search faster for non-existent or sparse values.

The wal requires a mutable header, so some refactoring was done to better fit the search pipeline and the various trace/page/block structs together, i.e. the pipeline can now match directly against a SearchBlockHeaderMutable.

**Which issue(s) this PR fixes**:
Fixes some of #932 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`