### PR TITLE
Snappy mem fix

### DIFF
--- a/tempodb/encoding/v2/pool.go
+++ b/tempodb/encoding/v2/pool.go
@@ -248,7 +248,8 @@ func (pool *LZ4Pool) ResetWriter(dst io.Writer, resetWriter io.WriteCloser) (io.
 	return writer, nil
 }
 
-// SnappyPool is a really cool looking pool.  Dang that pool is _snappy_.
+// SnappyPool is a really cool looking pool.  Dang that pool is _snappy_. Reusing readers/writers causes a memory leak. So the pool acts more like
+// a traditional factory.
 type SnappyPool struct {
 }
 
@@ -387,7 +388,8 @@ func (pool *ZstdPool) ResetWriter(dst io.Writer, resetWriter io.WriteCloser) (io
 	return writer, nil
 }
 
-// S2Pool is one s short of s3
+// S2Pool is one s short of S3Pool. Reusing readers/writers causes a memory leak. So the pool acts more like
+// a traditional factory.
 type S2Pool struct {
 }
 

--- a/tempodb/encoding/v2/pool.go
+++ b/tempodb/encoding/v2/pool.go
@@ -293,8 +293,10 @@ func (pool *SnappyPool) GetWriter(dst io.Writer) (io.WriteCloser, error) {
 
 // PutWriter places back in the pool a CompressionWriter
 func (pool *SnappyPool) PutWriter(writer io.WriteCloser) {
-	writer.(*snappy.Writer).Close()
-	pool.writers.Put(writer)
+	// only put the writer back in the pool if close succeeds (in case erroring puts it in a bad state)
+	if err := writer.(*snappy.Writer).Close(); err == nil {
+		pool.writers.Put(writer)
+	}
 }
 
 // ResetWriter implements WriterPool
@@ -446,8 +448,10 @@ func (pool *S2Pool) GetWriter(dst io.Writer) (io.WriteCloser, error) {
 
 // PutWriter places back in the pool a CompressionWriter
 func (pool *S2Pool) PutWriter(writer io.WriteCloser) {
-	writer.(*s2.Writer).Close()
-	pool.writers.Put(writer)
+	// only put the writer back in the pool if close succeeds (in case erroring puts it in a bad state)
+	if err := writer.(*s2.Writer).Close(); err == nil {
+		pool.writers.Put(writer)
+	}
 }
 
 // ResetWriter implements WriterPool

--- a/tempodb/encoding/v2/pool.go
+++ b/tempodb/encoding/v2/pool.go
@@ -293,6 +293,7 @@ func (pool *SnappyPool) GetWriter(dst io.Writer) (io.WriteCloser, error) {
 
 // PutWriter places back in the pool a CompressionWriter
 func (pool *SnappyPool) PutWriter(writer io.WriteCloser) {
+	writer.(*s2.Writer).Close()
 	pool.writers.Put(writer)
 }
 

--- a/tempodb/encoding/v2/pool.go
+++ b/tempodb/encoding/v2/pool.go
@@ -446,6 +446,7 @@ func (pool *S2Pool) GetWriter(dst io.Writer) (io.WriteCloser, error) {
 
 // PutWriter places back in the pool a CompressionWriter
 func (pool *S2Pool) PutWriter(writer io.WriteCloser) {
+	writer.(*s2.Writer).Close()
 	pool.writers.Put(writer)
 }
 

--- a/tempodb/encoding/v2/pool.go
+++ b/tempodb/encoding/v2/pool.go
@@ -276,7 +276,7 @@ func (pool *SnappyPool) PutReader(reader io.Reader) {
 
 // ResetReader implements ReaderPool
 func (pool *SnappyPool) ResetReader(src io.Reader, resetReader io.Reader) (io.Reader, error) {
-	reader := resetReader.(*s2.Reader)
+	reader := resetReader.(*snappy.Reader)
 	reader.Reset(src)
 	return reader, nil
 }
@@ -293,7 +293,7 @@ func (pool *SnappyPool) GetWriter(dst io.Writer) (io.WriteCloser, error) {
 
 // PutWriter places back in the pool a CompressionWriter
 func (pool *SnappyPool) PutWriter(writer io.WriteCloser) {
-	writer.(*s2.Writer).Close()
+	writer.(*snappy.Writer).Close()
 	pool.writers.Put(writer)
 }
 


### PR DESCRIPTION
**What this PR does**:
Fixes a memory leak issue using the klauspost snappy/s2 readers.

Created here: https://github.com/grafana/tempo/pull/961