### PR TITLE
Register `/ingester/ring` endpoint when running ingester target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * [BUGFIX] Fix "magic number" errors and other block mishandling when an ingester forcefully shuts down [#937](https://github.com/grafana/tempo/issues/937) (@mdisibio)
 * [BUGFIX] Fix compactor memory leak [#806](https://github.com/grafana/tempo/pull/806) (@mdisibio)
 * [BUGFIX] Fix an issue with WAL replay of zero-length search data when search is disabled. [#968](https://github.com/grafana/tempo/pull/968) (@annanay25)
+* [BUGFIX] Register the `/ingester/ring` endpoint correctly when running ingester in microservice mode. [#982](https://github.com/grafana/tempo/pull/982) (@chaudum)
 
 ## v1.1.0 / 2021-08-26
 * [CHANGE] Upgrade Cortex from v1.9.0 to v1.9.0-131-ga4bf10354 [#841](https://github.com/grafana/tempo/pull/841) (@aknuds1)

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -299,7 +299,7 @@ func (t *App) setupModuleManager() error {
 		QueryFrontend: {Server},
 		Ring:          {Server, MemberlistKV},
 		Distributor:   {Ring, Server, Overrides},
-		Ingester:      {Store, Server, Overrides, MemberlistKV},
+		Ingester:      {Store, Overrides, Ring},
 		Querier:       {Store, Ring},
 		Compactor:     {Store, Server, Overrides, MemberlistKV},
 		All:           {Compactor, QueryFrontend, Querier, Ingester, Distributor},

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -151,6 +151,11 @@ func TestMicroservices(t *testing.T) {
 	}
 	require.NoError(t, tempoDistributor.WaitSumMetricsWithOptions(cortex_e2e.Equals(3), []string{`cortex_ring_members`}, cortex_e2e.WithLabelMatchers(matchers...)))
 
+	// Ensure the /ingester/ring endpoint is registered when running ingester target
+	res, err := cortex_e2e.GetRequest("http://" + tempoIngester1.Endpoint(3200) + "/ingester/ring")
+	require.NoError(t, err)
+	require.Equal(t, 200, res.StatusCode)
+
 	// Get port for the Jaeger gRPC receiver endpoint
 	c, err := newJaegerGRPCClient(tempoDistributor.Endpoint(14250))
 	require.NoError(t, err)
@@ -176,7 +181,7 @@ func TestMicroservices(t *testing.T) {
 	queryAndAssertTrace(t, "http://"+tempoQueryFrontend.Endpoint(3200)+"/api/traces/"+hexID, "my operation", 1)
 
 	// flush trace to backend
-	res, err := cortex_e2e.GetRequest("http://" + tempoIngester1.Endpoint(3200) + "/flush")
+	res, err = cortex_e2e.GetRequest("http://" + tempoIngester1.Endpoint(3200) + "/flush")
 	require.NoError(t, err)
 	require.Equal(t, 204, res.StatusCode)
 


### PR DESCRIPTION
**What this PR does**:

This commit fixes the problem that the ring endpoint for the ingester
(`/ingester/ring`) was only registered when running the `all` target, but not
when running the `ingester` target.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`