### PR TITLE
Jsonnet: add $._config.memcached.memory_limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 * [ENHANCEMENT] Add support for vulture sending long running traces [#951](https://github.com/grafana/tempo/pull/951) (@zalegrala)
 * [ENHANCEMENT] Support global denylist and per-tenant allowlist of tags for search data. [#960](https://github.com/grafana/tempo/pull/960) (@annanay25)
 * [ENHANCEMENT] Add `search_query_timeout` to Querier config. [#984](https://github.com/grafana/tempo/pull/984) (@kvrhdn)
-* [ENHANCEMENT] Jsonnet: add `$._config.memcached.memory_limit` [#987](https://github.com/grafana/tempo/pull/987) (@kvrhdn)
+* [ENHANCEMENT] Jsonnet: add `$._config.memcached.memory_limit_mb` [#987](https://github.com/grafana/tempo/pull/987) (@kvrhdn)
 * [BUGFIX] Update port spec for GCS docker-compose example [#869](https://github.com/grafana/tempo/pull/869) (@zalegrala)
 * [BUGFIX] Fix "magic number" errors and other block mishandling when an ingester forcefully shuts down [#937](https://github.com/grafana/tempo/issues/937) (@mdisibio)
 * [BUGFIX] Fix compactor memory leak [#806](https://github.com/grafana/tempo/pull/806) (@mdisibio)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * [ENHANCEMENT] Add support for vulture sending long running traces [#951](https://github.com/grafana/tempo/pull/951) (@zalegrala)
 * [ENHANCEMENT] Support global denylist and per-tenant allowlist of tags for search data. [#960](https://github.com/grafana/tempo/pull/960) (@annanay25)
 * [ENHANCEMENT] Add `search_query_timeout` to Querier config. [#984](https://github.com/grafana/tempo/pull/984) (@kvrhdn)
+* [ENHANCEMENT] Jsonnet: add `$._config.memcached.memory_limit` [#987](https://github.com/grafana/tempo/pull/987) (@kvrhdn)
 * [BUGFIX] Update port spec for GCS docker-compose example [#869](https://github.com/grafana/tempo/pull/869) (@zalegrala)
 * [BUGFIX] Fix "magic number" errors and other block mishandling when an ingester forcefully shuts down [#937](https://github.com/grafana/tempo/issues/937) (@mdisibio)
 * [BUGFIX] Fix compactor memory leak [#806](https://github.com/grafana/tempo/pull/806) (@mdisibio)

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -80,6 +80,7 @@
     memcached: {
       replicas: 3,
       connection_limit: 4096,
+      memory_limit: 1024,
     },
     jaeger_ui: {
       base_path: '/',

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -80,7 +80,7 @@
     memcached: {
       replicas: 3,
       connection_limit: 4096,
-      memory_limit: 1024,
+      memory_limit_mb: 1024,
     },
     jaeger_ui: {
       base_path: '/',

--- a/operations/jsonnet/microservices/memcached.libsonnet
+++ b/operations/jsonnet/microservices/memcached.libsonnet
@@ -4,7 +4,7 @@ memcached {
   memcached+:: {
     cpu_limits:: null,
     connection_limit: $._config.memcached.connection_limit,
-    memory_limit: $._config.memcached.memory_limit
+    memory_limit_mb: $._config.memcached.memory_limit_mb,
 
     deployment: {},
 

--- a/operations/jsonnet/microservices/memcached.libsonnet
+++ b/operations/jsonnet/microservices/memcached.libsonnet
@@ -4,6 +4,7 @@ memcached {
   memcached+:: {
     cpu_limits:: null,
     connection_limit: $._config.memcached.connection_limit,
+    memory_limit: $._config.memcached.memory_limit
 
     deployment: {},
 


### PR DESCRIPTION

**What this PR does**:

Add `memcached.memory_limit` to the `$._config` structure. This will make it easier to increase this as necessary. Since we already expose `connection_limit`, having `memory_limit` seems useful as well.

Default was already 1024
https://github.com/grafana/jsonnet-libs/blob/bc9b685050691a78ee414cd8f789857de0eabe8d/memcached/memcached.libsonnet#L24

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [ ] ~~Tests updated~~
- [ ] ~~Documentation added~~
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`