### PR TITLE
Nil check overrides module in /status endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 * [BUGFIX] Fix compactor memory leak [#806](https://github.com/grafana/tempo/pull/806) (@mdisibio)
 * [BUGFIX] Fix an issue with WAL replay of zero-length search data when search is disabled. [#968](https://github.com/grafana/tempo/pull/968) (@annanay25)
 * [BUGFIX] Set span's tag `span.kind` to `client` in query-frontend [#975](https://github.com/grafana/tempo/pull/975) (@mapno)
+* [BUGFIX] Nil check overrides module in the `/status` handler [#994](https://github.com/grafana/tempo/pull/994) (@mapno)
 
 ## v1.1.0 / 2021-08-26
 * [CHANGE] Upgrade Cortex from v1.9.0 to v1.9.0-131-ga4bf10354 [#841](https://github.com/grafana/tempo/pull/841) (@aknuds1)

--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -358,6 +358,15 @@ func (t *App) readyHandler(sm *services.Manager) http.HandlerFunc {
 	}
 }
 
+func (t *App) writeRuntimeConfig(w io.Writer, r *http.Request) error {
+	// Querier and query-frontend services do not run the overrides module
+	if t.overrides == nil {
+		_, err := w.Write([]byte(fmt.Sprintf("overrides module not loaded in %s\n", t.cfg.Target)))
+		return err
+	}
+	return t.overrides.WriteStatusRuntimeConfig(w, r)
+}
+
 func (t *App) statusHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var errs []error
@@ -376,7 +385,7 @@ func (t *App) statusHandler() http.HandlerFunc {
 
 			switch endpoint {
 			case "runtime_config":
-				err := t.overrides.WriteStatusRuntimeConfig(&msg, r)
+				err := t.writeRuntimeConfig(&msg, r)
 				if err != nil {
 					errs = append(errs, err)
 				}

--- a/example/docker-compose/distributed/docker-compose.yaml
+++ b/example/docker-compose/distributed/docker-compose.yaml
@@ -72,7 +72,7 @@ services:
     entrypoint:
       - sh
       - -euc
-      - mkdir -p /data/tempo && /usr/bin/minio server /data --console-address ':9001'
+      - mkdir -p /data/tempo && minio server /data --console-address ':9001'
 
   synthetic-load-generator:
     image: omnition/synthetic-load-generator:1.0.25


### PR DESCRIPTION
**What this PR does**:

Nil check overrides module in /status endpoint

Querier and query-frontend do not run the overrides module. The status handler now checks in that module is being run and skips it in case it isn't.

It also modifies the distributed docker-compose to run minio with `minio` command, instead of executing the binary.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`