### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/cmd/tempo-cli/main.go
+++ b/cmd/tempo-cli/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/grafana/tempo/cmd/tempo/app"
 	"github.com/grafana/tempo/tempodb/backend"
@@ -83,7 +83,7 @@ func loadBackend(b *backendOptions, g *globalOptions) (backend.Reader, backend.W
 
 	// Existing config
 	if g.ConfigFile != "" {
-		buff, err := ioutil.ReadFile(g.ConfigFile)
+		buff, err := os.ReadFile(g.ConfigFile)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to read configFile %s: %w", g.ConfigFile, err)
 		}

--- a/cmd/tempo/main.go
+++ b/cmd/tempo/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"reflect"
 	"runtime"
@@ -132,7 +132,7 @@ func loadConfig() (*app.Config, error) {
 
 	// first get the config file
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
-	fs.SetOutput(ioutil.Discard)
+	fs.SetOutput(io.Discard)
 
 	fs.StringVar(&configFile, configFileOption, "", "")
 	fs.BoolVar(&configExpandEnv, configExpandEnvOption, false, "")
@@ -150,7 +150,7 @@ func loadConfig() (*app.Config, error) {
 
 	// overlay with config file if provided
 	if configFile != "" {
-		buff, err := ioutil.ReadFile(configFile)
+		buff, err := os.ReadFile(configFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read configFile %s: %w", configFile, err)
 		}

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -3,8 +3,8 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
@@ -61,7 +61,7 @@ func TestAllInOne(t *testing.T) {
 
 			// set up the backend
 			cfg := app.Config{}
-			buff, err := ioutil.ReadFile(tc.configFile)
+			buff, err := os.ReadFile(tc.configFile)
 			require.NoError(t, err)
 			err = yaml.UnmarshalStrict(buff, &cfg)
 			require.NoError(t, err)

--- a/integration/util.go
+++ b/integration/util.go
@@ -3,7 +3,6 @@ package integration
 // Collection of utilities to share between our various load tests
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -110,14 +109,14 @@ func WriteFileToSharedDir(s *e2e.Scenario, dst string, content []byte) error {
 		return err
 	}
 
-	return ioutil.WriteFile(
+	return os.WriteFile(
 		dst,
 		content,
 		os.ModePerm)
 }
 
 func CopyFileToSharedDir(s *e2e.Scenario, src, dst string) error {
-	content, err := ioutil.ReadFile(src)
+	content, err := os.ReadFile(src)
 	if err != nil {
 		return errors.Wrapf(err, "unable to read local file %s", src)
 	}

--- a/modules/frontend/deduper.go
+++ b/modules/frontend/deduper.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/go-kit/kit/log"
@@ -80,7 +79,7 @@ func (s spanIDDeduper) Do(req *http.Request) (*http.Response, error) {
 
 		return &http.Response{
 			StatusCode:    http.StatusOK,
-			Body:          ioutil.NopCloser(bytes.NewReader(traceBytes)),
+			Body:          io.NopCloser(bytes.NewReader(traceBytes)),
 			Header:        http.Header{},
 			ContentLength: resp.ContentLength,
 		}, nil

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -3,7 +3,6 @@ package frontend
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -162,7 +161,7 @@ func NewTracesTripperware(cfg Config, logger log.Logger, registerer prometheus.R
 			if err != nil {
 				return &http.Response{
 					StatusCode: http.StatusBadRequest,
-					Body:       ioutil.NopCloser(strings.NewReader(err.Error())),
+					Body:       io.NopCloser(strings.NewReader(err.Error())),
 					Header:     http.Header{},
 				}, nil
 			}
@@ -198,7 +197,7 @@ func NewTracesTripperware(cfg Config, logger log.Logger, registerer prometheus.R
 				if err != nil {
 					return nil, err
 				}
-				resp.Body = ioutil.NopCloser(bytes.NewReader(jsonTrace.Bytes()))
+				resp.Body = io.NopCloser(bytes.NewReader(jsonTrace.Bytes()))
 			}
 			span.SetTag("response marshalling format", marshallingFormat)
 

--- a/modules/frontend/frontend_test.go
+++ b/modules/frontend/frontend_test.go
@@ -2,7 +2,7 @@ package frontend
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -17,7 +17,7 @@ type mockNextTripperware struct{}
 
 func (s *mockNextTripperware) RoundTrip(_ *http.Request) (*http.Response, error) {
 	return &http.Response{
-		Body: ioutil.NopCloser(bytes.NewReader([]byte("next"))),
+		Body: io.NopCloser(bytes.NewReader([]byte("next"))),
 	}, nil
 }
 
@@ -25,7 +25,7 @@ type mockTracesTripperware struct{}
 
 func (s *mockTracesTripperware) RoundTrip(_ *http.Request) (*http.Response, error) {
 	return &http.Response{
-		Body: ioutil.NopCloser(bytes.NewReader([]byte("traces"))),
+		Body: io.NopCloser(bytes.NewReader([]byte("traces"))),
 	}, nil
 }
 
@@ -33,7 +33,7 @@ type mockSearchTripperware struct{}
 
 func (s *mockSearchTripperware) RoundTrip(_ *http.Request) (*http.Response, error) {
 	return &http.Response{
-		Body: ioutil.NopCloser(bytes.NewReader([]byte("search"))),
+		Body: io.NopCloser(bytes.NewReader([]byte("search"))),
 	}, nil
 }
 
@@ -93,7 +93,7 @@ func TestFrontendRoundTripper(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, resp)
 
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			assert.Equal(t, body, []byte(tt.response))
 		})

--- a/modules/frontend/querysharding.go
+++ b/modules/frontend/querysharding.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -184,7 +183,7 @@ func mergeResponses(ctx context.Context, rrs []RequestResponse) (*http.Response,
 	if shardMissCount == len(rrs) {
 		return &http.Response{
 			StatusCode: http.StatusNotFound,
-			Body:       ioutil.NopCloser(strings.NewReader("trace not found in Tempo")),
+			Body:       io.NopCloser(strings.NewReader("trace not found in Tempo")),
 			Header:     http.Header{},
 		}, nil
 	}
@@ -192,7 +191,7 @@ func mergeResponses(ctx context.Context, rrs []RequestResponse) (*http.Response,
 	if errCode == http.StatusOK {
 		return &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       ioutil.NopCloser(bytes.NewReader(combinedTrace)),
+			Body:       io.NopCloser(bytes.NewReader(combinedTrace)),
 			// ContentLength header is added to log the size of response in the Tripperware in frontend.go
 			// This could be overwritten if the query client and Tempo negotiate compression
 			ContentLength: int64(len(combinedTrace)),

--- a/modules/frontend/querysharding_test.go
+++ b/modules/frontend/querysharding_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -76,25 +75,25 @@ func TestMergeResponses(t *testing.T) {
 				{
 					Response: &http.Response{
 						StatusCode: http.StatusOK,
-						Body:       ioutil.NopCloser(bytes.NewReader(b1)),
+						Body:       io.NopCloser(bytes.NewReader(b1)),
 					},
 				},
 				{
 					Response: &http.Response{
 						StatusCode: http.StatusOK,
-						Body:       ioutil.NopCloser(bytes.NewReader(b2)),
+						Body:       io.NopCloser(bytes.NewReader(b2)),
 					},
 				},
 				{
 					Response: &http.Response{
 						StatusCode: http.StatusNotFound,
-						Body:       ioutil.NopCloser(bytes.NewReader([]byte("foo"))),
+						Body:       io.NopCloser(bytes.NewReader([]byte("foo"))),
 					},
 				},
 			},
 			expected: &http.Response{
 				StatusCode:    http.StatusOK,
-				Body:          ioutil.NopCloser(bytes.NewReader(combinedTrace)),
+				Body:          io.NopCloser(bytes.NewReader(combinedTrace)),
 				ContentLength: int64(len(combinedTrace)),
 			},
 		},
@@ -104,19 +103,19 @@ func TestMergeResponses(t *testing.T) {
 				{
 					Response: &http.Response{
 						StatusCode: http.StatusOK,
-						Body:       ioutil.NopCloser(bytes.NewReader(b1)),
+						Body:       io.NopCloser(bytes.NewReader(b1)),
 					},
 				},
 				{
 					Response: &http.Response{
 						StatusCode: http.StatusInternalServerError,
-						Body:       ioutil.NopCloser(bytes.NewReader([]byte("bar"))),
+						Body:       io.NopCloser(bytes.NewReader([]byte("bar"))),
 					},
 				},
 			},
 			expected: &http.Response{
 				StatusCode: http.StatusInternalServerError,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("bar"))),
+				Body:       io.NopCloser(bytes.NewReader([]byte("bar"))),
 			},
 		},
 		{
@@ -125,19 +124,19 @@ func TestMergeResponses(t *testing.T) {
 				{
 					Response: &http.Response{
 						StatusCode: http.StatusNotFound,
-						Body:       ioutil.NopCloser(bytes.NewReader([]byte("foo"))),
+						Body:       io.NopCloser(bytes.NewReader([]byte("foo"))),
 					},
 				},
 				{
 					Response: &http.Response{
 						StatusCode: http.StatusInternalServerError,
-						Body:       ioutil.NopCloser(bytes.NewReader([]byte("bar"))),
+						Body:       io.NopCloser(bytes.NewReader([]byte("bar"))),
 					},
 				},
 			},
 			expected: &http.Response{
 				StatusCode: http.StatusInternalServerError,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("bar"))),
+				Body:       io.NopCloser(bytes.NewReader([]byte("bar"))),
 			},
 		},
 		{
@@ -146,19 +145,19 @@ func TestMergeResponses(t *testing.T) {
 				{
 					Response: &http.Response{
 						StatusCode: http.StatusOK,
-						Body:       ioutil.NopCloser(bytes.NewReader(b1)),
+						Body:       io.NopCloser(bytes.NewReader(b1)),
 					},
 				},
 				{
 					Response: &http.Response{
 						StatusCode: http.StatusForbidden,
-						Body:       ioutil.NopCloser(bytes.NewReader([]byte("foo"))),
+						Body:       io.NopCloser(bytes.NewReader([]byte("foo"))),
 					},
 				},
 			},
 			expected: &http.Response{
 				StatusCode: http.StatusInternalServerError,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("foo"))),
+				Body:       io.NopCloser(bytes.NewReader([]byte("foo"))),
 			},
 		},
 	}

--- a/modules/ingester/ingester_test.go
+++ b/modules/ingester/ingester_test.go
@@ -2,7 +2,6 @@ package ingester
 
 import (
 	"context"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"testing"
@@ -31,7 +30,7 @@ import (
 )
 
 func TestPushQuery(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("/tmp", "")
+	tmpDir, err := os.MkdirTemp("/tmp", "")
 	assert.NoError(t, err, "unexpected error getting tempdir")
 	defer os.RemoveAll(tmpDir)
 
@@ -64,7 +63,7 @@ func TestPushQuery(t *testing.T) {
 }
 
 func TestFullTraceReturned(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("/tmp", "")
+	tmpDir, err := os.MkdirTemp("/tmp", "")
 	assert.NoError(t, err, "unexpected error getting tempdir")
 	defer os.RemoveAll(tmpDir)
 
@@ -111,7 +110,7 @@ func TestFullTraceReturned(t *testing.T) {
 }
 
 func TestDeprecatedPush(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("/tmp", "")
+	tmpDir, err := os.MkdirTemp("/tmp", "")
 	assert.NoError(t, err, "unexpected error getting tempdir")
 	defer os.RemoveAll(tmpDir)
 
@@ -158,7 +157,7 @@ func TestDeprecatedPush(t *testing.T) {
 }
 
 func TestWal(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("/tmp", "")
+	tmpDir, err := os.MkdirTemp("/tmp", "")
 	require.NoError(t, err, "unexpected error getting tempdir")
 	defer os.RemoveAll(tmpDir)
 
@@ -260,7 +259,7 @@ func TestWalReplayDeletesLocalBlocks(t *testing.T) {
 }
 
 func TestFlush(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("/tmp", "")
+	tmpDir, err := os.MkdirTemp("/tmp", "")
 	require.NoError(t, err, "unexpected error getting tempdir")
 	defer os.RemoveAll(tmpDir)
 

--- a/modules/ingester/instance_search_test.go
+++ b/modules/ingester/instance_search_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"testing"
@@ -42,7 +41,7 @@ func TestInstanceSearch(t *testing.T) {
 	assert.NoError(t, err, "unexpected error creating limits")
 	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
 
-	tempDir, err := ioutil.TempDir("/tmp", "")
+	tempDir, err := os.MkdirTemp("/tmp", "")
 	assert.NoError(t, err, "unexpected error getting temp dir")
 	defer os.RemoveAll(tempDir)
 
@@ -146,7 +145,7 @@ func TestInstanceSearchNoData(t *testing.T) {
 	assert.NoError(t, err, "unexpected error creating limits")
 	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
 
-	tempDir, err := ioutil.TempDir("/tmp", "")
+	tempDir, err := os.MkdirTemp("/tmp", "")
 	assert.NoError(t, err, "unexpected error getting temp dir")
 	defer os.RemoveAll(tempDir)
 

--- a/modules/ingester/instance_test.go
+++ b/modules/ingester/instance_test.go
@@ -3,7 +3,6 @@ package ingester
 import (
 	"context"
 	"encoding/binary"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"testing"
@@ -39,7 +38,7 @@ func TestInstance(t *testing.T) {
 	assert.NoError(t, err, "unexpected error creating limits")
 	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
 
-	tempDir, err := ioutil.TempDir("/tmp", "")
+	tempDir, err := os.MkdirTemp("/tmp", "")
 	assert.NoError(t, err, "unexpected error getting temp dir")
 	defer os.RemoveAll(tempDir)
 
@@ -90,7 +89,7 @@ func TestInstanceFind(t *testing.T) {
 	assert.NoError(t, err, "unexpected error creating limits")
 	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
 
-	tempDir, err := ioutil.TempDir("/tmp", "")
+	tempDir, err := os.MkdirTemp("/tmp", "")
 	assert.NoError(t, err, "unexpected error getting temp dir")
 	defer os.RemoveAll(tempDir)
 
@@ -172,7 +171,7 @@ func TestInstanceDoesNotRace(t *testing.T) {
 	assert.NoError(t, err, "unexpected error creating limits")
 	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
 
-	tempDir, err := ioutil.TempDir("/tmp", "")
+	tempDir, err := os.MkdirTemp("/tmp", "")
 	assert.NoError(t, err, "unexpected error getting temp dir")
 	defer os.RemoveAll(tempDir)
 
@@ -241,7 +240,7 @@ func TestInstanceLimits(t *testing.T) {
 	require.NoError(t, err, "unexpected error creating limits")
 	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
 
-	tempDir, err := ioutil.TempDir("/tmp", "")
+	tempDir, err := os.MkdirTemp("/tmp", "")
 	require.NoError(t, err, "unexpected error getting temp dir")
 	defer os.RemoveAll(tempDir)
 
@@ -335,7 +334,7 @@ func TestInstanceLimits(t *testing.T) {
 }
 
 func TestInstanceCutCompleteTraces(t *testing.T) {
-	tempDir, _ := ioutil.TempDir("/tmp", "")
+	tempDir, _ := os.MkdirTemp("/tmp", "")
 	defer os.RemoveAll(tempDir)
 
 	id := make([]byte, 16)
@@ -419,7 +418,7 @@ func TestInstanceCutCompleteTraces(t *testing.T) {
 }
 
 func TestInstanceCutBlockIfReady(t *testing.T) {
-	tempDir, _ := ioutil.TempDir("/tmp", "")
+	tempDir, _ := os.MkdirTemp("/tmp", "")
 	defer os.RemoveAll(tempDir)
 
 	tt := []struct {
@@ -538,7 +537,7 @@ func defaultInstance(t require.TestingT, tmpDir string) *instance {
 }
 
 func BenchmarkInstancePush(b *testing.B) {
-	tempDir, err := ioutil.TempDir("/tmp", "")
+	tempDir, err := os.MkdirTemp("/tmp", "")
 	assert.NoError(b, err, "unexpected error getting temp dir")
 	defer os.RemoveAll(tempDir)
 
@@ -555,7 +554,7 @@ func BenchmarkInstancePush(b *testing.B) {
 }
 
 func BenchmarkInstancePushExistingTrace(b *testing.B) {
-	tempDir, err := ioutil.TempDir("/tmp", "")
+	tempDir, err := os.MkdirTemp("/tmp", "")
 	assert.NoError(b, err, "unexpected error getting temp dir")
 	defer os.RemoveAll(tempDir)
 
@@ -570,7 +569,7 @@ func BenchmarkInstancePushExistingTrace(b *testing.B) {
 }
 
 func BenchmarkInstanceFindTraceByID(b *testing.B) {
-	tempDir, err := ioutil.TempDir("/tmp", "")
+	tempDir, err := os.MkdirTemp("/tmp", "")
 	assert.NoError(b, err, "unexpected error getting temp dir")
 	defer os.RemoveAll(tempDir)
 

--- a/modules/overrides/overrides_test.go
+++ b/modules/overrides/overrides_test.go
@@ -2,7 +2,6 @@ package overrides
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -112,7 +111,7 @@ func TestOverrides(t *testing.T) {
 				buff, err := yaml.Marshal(tt.overrides)
 				require.NoError(t, err)
 
-				err = ioutil.WriteFile(overridesFile, buff, os.ModePerm)
+				err = os.WriteFile(overridesFile, buff, os.ModePerm)
 				require.NoError(t, err)
 
 				tt.limits.PerTenantOverrideConfig = overridesFile

--- a/modules/querier/querier_test.go
+++ b/modules/querier/querier_test.go
@@ -2,7 +2,6 @@ package querier
 
 import (
 	"context"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -44,7 +43,7 @@ func (m *mockSharder) Combine(dataEncoding string, objs ...[]byte) ([]byte, bool
 }
 
 func TestReturnAllHits(t *testing.T) {
-	tempDir, err := ioutil.TempDir("/tmp", "")
+	tempDir, err := os.MkdirTemp("/tmp", "")
 	defer os.RemoveAll(tempDir)
 	assert.NoError(t, err, "unexpected error creating temp dir")
 

--- a/tempodb/backend/azure/azure.go
+++ b/tempodb/backend/azure/azure.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"io"
-	"io/ioutil"
 	"path"
 	"strings"
 
@@ -134,7 +133,7 @@ func (rw *readerWriter) Read(ctx context.Context, name string, keypath backend.K
 		return nil, 0, readError(err)
 	}
 
-	return ioutil.NopCloser(bytes.NewReader(b)), int64(len(b)), nil
+	return io.NopCloser(bytes.NewReader(b)), int64(len(b)), nil
 }
 
 // ReadRange implements backend.Reader

--- a/tempodb/backend/cache/cache.go
+++ b/tempodb/backend/cache/cache.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	cortex_cache "github.com/cortexproject/cortex/pkg/chunk/cache"
@@ -41,7 +40,7 @@ func (r *readerWriter) Read(ctx context.Context, name string, keypath backend.Ke
 		k = key(keypath, name)
 		found, vals, _ := r.cache.Fetch(ctx, []string{k})
 		if len(found) > 0 {
-			return ioutil.NopCloser(bytes.NewReader(vals[0])), int64(len(vals[0])), nil
+			return io.NopCloser(bytes.NewReader(vals[0])), int64(len(vals[0])), nil
 		}
 	}
 
@@ -55,7 +54,7 @@ func (r *readerWriter) Read(ctx context.Context, name string, keypath backend.Ke
 		r.cache.Store(ctx, []string{k}, [][]byte{b})
 	}
 
-	return ioutil.NopCloser(bytes.NewReader(b)), size, err
+	return io.NopCloser(bytes.NewReader(b)), size, err
 }
 
 // ReadRange implements backend.RawReader

--- a/tempodb/backend/cache/cache_test.go
+++ b/tempodb/backend/cache/cache_test.go
@@ -3,7 +3,7 @@ package cache
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	cortex_cache "github.com/cortexproject/cortex/pkg/chunk/cache"
@@ -81,21 +81,21 @@ func TestReadWrite(t *testing.T) {
 
 			ctx := context.Background()
 			reader, _, _ := r.Read(ctx, tt.readerName, backend.KeyPathForBlock(blockID, tenantID), tt.shouldCache)
-			read, _ := ioutil.ReadAll(reader)
+			read, _ := io.ReadAll(reader)
 			assert.Equal(t, tt.expectedRead, read)
 
 			// clear reader and re-request
 			mockR.R = nil
 
 			reader, _, _ = r.Read(ctx, tt.readerName, backend.KeyPathForBlock(blockID, tenantID), tt.shouldCache)
-			read, _ = ioutil.ReadAll(reader)
+			read, _ = io.ReadAll(reader)
 			assert.Equal(t, len(tt.expectedCache), len(read))
 
 			// WRITE
 			_, w, _ := NewCache(mockR, mockW, NewMockClient())
 			_ = w.Write(ctx, tt.readerName, backend.KeyPathForBlock(blockID, tenantID), bytes.NewReader(tt.readerRead), int64(len(tt.readerRead)), tt.shouldCache)
 			reader, _, _ = r.Read(ctx, tt.readerName, backend.KeyPathForBlock(blockID, tenantID), tt.shouldCache)
-			read, _ = ioutil.ReadAll(reader)
+			read, _ = io.ReadAll(reader)
 			assert.Equal(t, len(tt.expectedCache), len(read))
 		})
 	}

--- a/tempodb/backend/gcs/gcs.go
+++ b/tempodb/backend/gcs/gcs.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/tls"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"path"
 	"strings"
@@ -139,7 +138,7 @@ func (rw *readerWriter) Read(ctx context.Context, name string, keypath backend.K
 	if err != nil {
 		span.SetTag("error", true)
 	}
-	return ioutil.NopCloser(bytes.NewReader(b)), int64(len(b)), readError(err)
+	return io.NopCloser(bytes.NewReader(b)), int64(len(b)), readError(err)
 }
 
 // ReadRange implements backend.Reader

--- a/tempodb/backend/local/compactor.go
+++ b/tempodb/backend/local/compactor.go
@@ -3,7 +3,6 @@ package local
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -39,7 +38,7 @@ func (rw *Backend) CompactedBlockMeta(blockID uuid.UUID, tenantID string) (*back
 		return nil, readError(err)
 	}
 
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, readError(err)
 	}

--- a/tempodb/backend/local/local.go
+++ b/tempodb/backend/local/local.go
@@ -3,7 +3,6 @@ package local
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -99,7 +98,7 @@ func (rw *Backend) CloseAppend(ctx context.Context, tracker backend.AppendTracke
 // List implements backend.Reader
 func (rw *Backend) List(ctx context.Context, keypath backend.KeyPath) ([]string, error) {
 	path := rw.rootPath(keypath)
-	folders, err := ioutil.ReadDir(path)
+	folders, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}

--- a/tempodb/backend/local/local_test.go
+++ b/tempodb/backend/local/local_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"testing"
@@ -20,11 +19,11 @@ import (
 const objectName = "test"
 
 func TestReadWrite(t *testing.T) {
-	tempDir, err := ioutil.TempDir("/tmp", "")
+	tempDir, err := os.MkdirTemp("/tmp", "")
 	defer os.RemoveAll(tempDir)
 	assert.NoError(t, err, "unexpected error creating temp dir")
 
-	fakeTracesFile, err := ioutil.TempFile("/tmp", "")
+	fakeTracesFile, err := os.CreateTemp("/tmp", "")
 	defer os.Remove(fakeTracesFile.Name())
 	assert.NoError(t, err, "unexpected error creating temp file")
 

--- a/tempodb/backend/mocks.go
+++ b/tempodb/backend/mocks.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 
 	tempo_io "github.com/grafana/tempo/pkg/io"
 
@@ -38,7 +37,7 @@ func (m *MockRawReader) Read(ctx context.Context, name string, keypath KeyPath, 
 		return m.ReadFn(ctx, name, keypath, shouldCache)
 	}
 
-	return ioutil.NopCloser(bytes.NewReader(m.R)), int64(len(m.R)), nil
+	return io.NopCloser(bytes.NewReader(m.R)), int64(len(m.R)), nil
 }
 func (m *MockRawReader) ReadRange(ctx context.Context, name string, keypath KeyPath, offset uint64, buffer []byte) error {
 	copy(buffer, m.Range)

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"path"
 	"strings"
@@ -233,7 +232,7 @@ func (rw *readerWriter) Read(ctx context.Context, name string, keypath backend.K
 		return nil, 0, readError(err)
 	}
 
-	return ioutil.NopCloser(bytes.NewReader(b)), int64(len(b)), err
+	return io.NopCloser(bytes.NewReader(b)), int64(len(b)), err
 }
 
 // ReadRange implements backend.Reader

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -3,7 +3,6 @@ package tempodb
 import (
 	"context"
 	"encoding/binary"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -57,7 +56,7 @@ func (m *mockOverrides) BlockRetentionForTenant(_ string) time.Duration {
 }
 
 func TestCompaction(t *testing.T) {
-	tempDir, err := ioutil.TempDir("/tmp", "")
+	tempDir, err := os.MkdirTemp("/tmp", "")
 	defer os.RemoveAll(tempDir)
 	assert.NoError(t, err, "unexpected error creating temp dir")
 
@@ -187,7 +186,7 @@ func TestCompaction(t *testing.T) {
 }
 
 func TestSameIDCompaction(t *testing.T) {
-	tempDir, err := ioutil.TempDir("/tmp", "")
+	tempDir, err := os.MkdirTemp("/tmp", "")
 	defer os.RemoveAll(tempDir)
 	assert.NoError(t, err, "unexpected error creating temp dir")
 
@@ -277,7 +276,7 @@ func TestSameIDCompaction(t *testing.T) {
 }
 
 func TestCompactionUpdatesBlocklist(t *testing.T) {
-	tempDir, err := ioutil.TempDir("/tmp", "")
+	tempDir, err := os.MkdirTemp("/tmp", "")
 	defer os.RemoveAll(tempDir)
 	assert.NoError(t, err, "unexpected error creating temp dir")
 
@@ -346,7 +345,7 @@ func TestCompactionUpdatesBlocklist(t *testing.T) {
 }
 
 func TestCompactionMetrics(t *testing.T) {
-	tempDir, err := ioutil.TempDir("/tmp", "")
+	tempDir, err := os.MkdirTemp("/tmp", "")
 	defer os.RemoveAll(tempDir)
 	assert.NoError(t, err, "unexpected error creating temp dir")
 
@@ -419,7 +418,7 @@ func TestCompactionMetrics(t *testing.T) {
 }
 
 func TestCompactionIteratesThroughTenants(t *testing.T) {
-	tempDir, err := ioutil.TempDir("/tmp", "")
+	tempDir, err := os.MkdirTemp("/tmp", "")
 	defer os.RemoveAll(tempDir)
 	assert.NoError(t, err, "unexpected error creating temp dir")
 

--- a/tempodb/encoding/streaming_block_test.go
+++ b/tempodb/encoding/streaming_block_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -156,7 +155,7 @@ func TestStreamingBlockAll(t *testing.T) {
 }
 
 func testStreamingBlockToBackendBlock(t *testing.T, cfg *BlockConfig) {
-	backendTmpDir, err := ioutil.TempDir("/tmp", "")
+	backendTmpDir, err := os.MkdirTemp("/tmp", "")
 	defer os.RemoveAll(backendTmpDir)
 	require.NoError(t, err, "unexpected error creating temp dir")
 
@@ -352,7 +351,7 @@ func BenchmarkReadS2(b *testing.B) {
 // Download a block from your backend and place in ./benchmark_block/<tenant id>/<guid>
 //nolint:unparam
 func benchmarkCompressBlock(b *testing.B, encoding backend.Encoding, indexDownsample int, benchRead bool) {
-	tempDir, err := ioutil.TempDir("/tmp", "")
+	tempDir, err := os.MkdirTemp("/tmp", "")
 	defer os.RemoveAll(tempDir)
 	require.NoError(b, err, "unexpected error creating temp dir")
 
@@ -371,7 +370,7 @@ func benchmarkCompressBlock(b *testing.B, encoding backend.Encoding, indexDownsa
 	iter, err := backendBlock.Iterator(10 * 1024 * 1024)
 	require.NoError(b, err, "error creating iterator")
 
-	backendTmpDir, err := ioutil.TempDir("/tmp", "")
+	backendTmpDir, err := os.MkdirTemp("/tmp", "")
 	defer os.RemoveAll(backendTmpDir)
 	require.NoError(b, err, "unexpected error creating temp dir")
 

--- a/tempodb/retention_test.go
+++ b/tempodb/retention_test.go
@@ -1,7 +1,6 @@
 package tempodb
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -18,7 +17,7 @@ import (
 )
 
 func TestRetention(t *testing.T) {
-	tempDir, err := ioutil.TempDir("/tmp", "")
+	tempDir, err := os.MkdirTemp("/tmp", "")
 	defer os.RemoveAll(tempDir)
 	assert.NoError(t, err, "unexpected error creating temp dir")
 
@@ -76,7 +75,7 @@ func TestRetention(t *testing.T) {
 }
 
 func TestBlockRetentionOverride(t *testing.T) {
-	tempDir, err := ioutil.TempDir("/tmp", "")
+	tempDir, err := os.MkdirTemp("/tmp", "")
 	defer os.RemoveAll(tempDir)
 	assert.NoError(t, err, "unexpected error creating temp dir")
 

--- a/tempodb/tempodb_test.go
+++ b/tempodb/tempodb_test.go
@@ -2,7 +2,6 @@ package tempodb
 
 import (
 	"context"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -32,7 +31,7 @@ const (
 )
 
 func testConfig(t *testing.T, enc backend.Encoding, blocklistPoll time.Duration) (Reader, Writer, Compactor, string) {
-	tempDir, err := ioutil.TempDir(tmpdir, "")
+	tempDir, err := os.MkdirTemp(tmpdir, "")
 	require.NoError(t, err)
 
 	r, w, c, err := New(&Config{
@@ -597,7 +596,7 @@ func TestCompleteBlock(t *testing.T) {
 }
 
 func TestShouldCache(t *testing.T) {
-	tempDir, err := ioutil.TempDir(tmpdir, "")
+	tempDir, err := os.MkdirTemp(tmpdir, "")
 	defer os.RemoveAll(tempDir)
 	require.NoError(t, err)
 

--- a/tempodb/wal/wal.go
+++ b/tempodb/wal/wal.go
@@ -2,7 +2,6 @@ package wal
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -78,7 +77,7 @@ func New(c *Config) (*WAL, error) {
 
 // RescanBlocks returns a slice of append blocks from the wal folder
 func (w *WAL) RescanBlocks(log log.Logger) ([]*AppendBlock, error) {
-	files, err := ioutil.ReadDir(w.c.Filepath)
+	files, err := os.ReadDir(w.c.Filepath)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +89,12 @@ func (w *WAL) RescanBlocks(log log.Logger) ([]*AppendBlock, error) {
 		}
 
 		start := time.Now()
-		level.Info(log).Log("msg", "beginning replay", "file", f.Name(), "size", f.Size())
+		fileInfo, err := f.Info()
+		if err != nil {
+			return nil, err
+		}
+
+		level.Info(log).Log("msg", "beginning replay", "file", f.Name(), "size", fileInfo.Size())
 		b, warning, err := newAppendBlockFromFile(f.Name(), w.c.Filepath)
 
 		remove := false

--- a/tempodb/wal/wal_test.go
+++ b/tempodb/wal/wal_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -43,7 +42,7 @@ func (m *mockCombiner) Combine(dataEncoding string, objs ...[]byte) ([]byte, boo
 }
 
 func TestAppend(t *testing.T) {
-	tempDir, err := ioutil.TempDir("/tmp", "")
+	tempDir, err := os.MkdirTemp("/tmp", "")
 	defer os.RemoveAll(tempDir)
 	assert.NoError(t, err, "unexpected error creating temp dir")
 
@@ -98,7 +97,7 @@ func TestAppend(t *testing.T) {
 func TestCompletedDirIsRemoved(t *testing.T) {
 	// Create /completed/testfile and verify it is removed.
 
-	tempDir, err := ioutil.TempDir("/tmp", "")
+	tempDir, err := os.MkdirTemp("/tmp", "")
 	defer os.RemoveAll(tempDir)
 	assert.NoError(t, err, "unexpected error creating temp dir")
 
@@ -118,7 +117,7 @@ func TestCompletedDirIsRemoved(t *testing.T) {
 }
 
 func TestErrorConditions(t *testing.T) {
-	tempDir, err := ioutil.TempDir("/tmp", "")
+	tempDir, err := os.MkdirTemp("/tmp", "")
 	defer os.RemoveAll(tempDir)
 	require.NoError(t, err, "unexpected error creating temp dir")
 
@@ -180,7 +179,7 @@ func TestAppendReplayFind(t *testing.T) {
 }
 
 func testAppendReplayFind(t *testing.T, e backend.Encoding) {
-	tempDir, err := ioutil.TempDir("/tmp", "")
+	tempDir, err := os.MkdirTemp("/tmp", "")
 	defer os.RemoveAll(tempDir)
 	require.NoError(t, err, "unexpected error creating temp dir")
 
@@ -307,7 +306,7 @@ func benchmarkWriteFindReplay(b *testing.B, encoding backend.Encoding) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		tempDir, _ := ioutil.TempDir("/tmp", "")
+		tempDir, _ := os.MkdirTemp("/tmp", "")
 		wal, _ := New(&Config{
 			Filepath: tempDir,
 			Encoding: encoding,


### PR DESCRIPTION
**What this PR does**:
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since tempo has upgraded to Go 1.17 (#953), this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages. This change is transparent to end users.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- ~~[ ] Tests updated~~
- ~~[ ] Documentation added~~
- ~~[ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~