### PR TITLE
Search no root attrs

### DIFF
--- a/modules/distributor/search_data.go
+++ b/modules/distributor/search_data.go
@@ -1,7 +1,6 @@
 package distributor
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/grafana/tempo/pkg/tempofb"
@@ -50,26 +49,16 @@ func extractSearchData(trace *tempopb.Trace, id []byte, extractTag extractTagFun
 				// Root span
 				if len(s.ParentSpanId) == 0 {
 
+					// Collect root.name
 					data.AddTag(search.RootSpanNameTag, s.Name)
 
-					// Span attrs
-					for _, a := range s.Attributes {
-						if !extractTag(a.Key) {
-							continue
-						}
-						if s, ok := extractValueAsString(a.Value); ok {
-							data.AddTag(fmt.Sprint(search.RootSpanPrefix, a.Key), s)
-						}
-					}
-
-					// Batch attrs
+					// Collect root.service.name
 					if b.Resource != nil {
 						for _, a := range b.Resource.Attributes {
-							if !extractTag(a.Key) {
-								continue
-							}
-							if s, ok := extractValueAsString(a.Value); ok {
-								data.AddTag(fmt.Sprint(search.RootSpanPrefix, a.Key), s)
+							if a.Key == search.ServiceNameTag {
+								if s, ok := extractValueAsString(a.Value); ok {
+									data.AddTag(search.RootServiceNameTag, s)
+								}
 							}
 						}
 					}

--- a/modules/distributor/search_data_test.go
+++ b/modules/distributor/search_data_test.go
@@ -64,12 +64,11 @@ func TestExtractSearchData(t *testing.T) {
 			searchData: &tempofb.SearchEntryMutable{
 				TraceID: traceIDA,
 				Tags: tempofb.SearchDataMap{
-					"foo":                         []string{"bar"},
-					search.RootSpanPrefix + "foo": []string{"bar"},
-					search.RootSpanNameTag:        []string{"firstSpan"},
-					search.SpanNameTag:            []string{"firstSpan"},
-					search.RootServiceNameTag:     []string{"baz"},
-					search.ServiceNameTag:         []string{"baz"},
+					"foo":                     []string{"bar"},
+					search.RootSpanNameTag:    []string{"firstSpan"},
+					search.SpanNameTag:        []string{"firstSpan"},
+					search.RootServiceNameTag: []string{"baz"},
+					search.ServiceNameTag:     []string{"baz"},
 				},
 				StartTimeUnixNano: 0,
 				EndTimeUnixNano:   0,

--- a/tempodb/search/util.go
+++ b/tempodb/search/util.go
@@ -9,7 +9,6 @@ import (
 const (
 	RootServiceNameTag = "root.service.name"
 	ServiceNameTag     = "service.name"
-	RootSpanPrefix     = "root."
 	RootSpanNameTag    = "root.name"
 	SpanNameTag        = "name"
 )


### PR DESCRIPTION
**What this PR does**:
This PR removes capturing of `root.<xyz>` search attributes.  This reduces the size of the search data by ~30%, and seems worth it as in practice these attributes were not very useful to search on.  `root.name` and `root.service.name` are still captured because they are used for display.    

**Which issue(s) this PR fixes**:
Fixes part of #932 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`