### PR TITLE
Reload search blocks and replay search WAL

### DIFF
--- a/modules/ingester/ingester.go
+++ b/modules/ingester/ingester.go
@@ -335,6 +335,11 @@ func (i *Ingester) replayWal() error {
 		return fmt.Errorf("fatal error replaying wal %w", err)
 	}
 
+	searchBlocks, err := search.RescanBlocks(i.store.WAL().GetFilepath())
+	if err != nil {
+		return fmt.Errorf("fatal error replaying search wal %w", err)
+	}
+
 	for _, b := range blocks {
 		tenantID := b.Meta().TenantID
 

--- a/modules/ingester/ingester_search.go
+++ b/modules/ingester/ingester_search.go
@@ -3,8 +3,6 @@ package ingester
 import (
 	"context"
 
-	"github.com/cortexproject/cortex/pkg/util/log"
-	"github.com/go-kit/kit/log/level"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/weaveworks/common/user"
 )
@@ -65,12 +63,4 @@ func (i *Ingester) SearchTagValues(ctx context.Context, req *tempopb.SearchTagVa
 	}
 
 	return resp, nil
-}
-
-func (i *Ingester) clearSearchData() {
-	// clear wal
-	err := i.store.WAL().ClearFolder(searchDir)
-	if err != nil {
-		level.Error(log.Logger).Log("msg", "error clearing search data from wal")
-	}
 }

--- a/modules/ingester/ingester_test.go
+++ b/modules/ingester/ingester_test.go
@@ -212,6 +212,42 @@ func TestWal(t *testing.T) {
 	}
 }
 
+//func TestSearchWAL(t *testing.T) {
+//	tmpDir := t.TempDir()
+//
+//	i, _, _ := defaultIngester(t, tmpDir)
+//	inst, ok := i.getInstanceByID("test")
+//	require.True(t, ok)
+//
+//	// Write wal
+//	err := inst.CutCompleteTraces(0, true)
+//	require.NoError(t, err)
+//	_, err = inst.CutBlockIfReady(0, 0, true)
+//	require.NoError(t, err)
+//
+//	// assert that search WAL is being searched
+//	ctx := user.InjectOrgID(context.Background(), "test")
+//	searchReq := &tempopb.SearchRequest{Tags: map[string]string{
+//		search.SecretExhaustiveSearchTag: "",
+//	}}
+//	results, err := inst.Search(ctx, searchReq)
+//	assert.NoError(t, err)
+//	assert.Greater(t, results.Metrics.InspectedTraces, 0)
+//
+//	// Shutdown
+//	err = i.stopping(nil)
+//	require.NoError(t, err)
+//
+//	// replay wal
+//	i, _, _ = defaultIngester(t, tmpDir)
+//	inst, ok = i.getInstanceByID("test")
+//	require.True(t, ok)
+//
+//	results, err = inst.Search(ctx, searchReq)
+//	assert.NoError(t, err)
+//	assert.Greater(t, results.Metrics.InspectedTraces, 0)
+//}
+
 // TestWalReplayDeletesLocalBlocks simulates the condition where an ingester restarts after a wal is completed
 // to the local disk, but before the wal is deleted. On startup both blocks exist, and the ingester now errs
 // on the side of caution and chooses to replay the wal instead of rediscovering the local block.

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -629,7 +629,7 @@ func (i *instance) rediscoverLocalBlocks(ctx context.Context) error {
 
 		i.blocksMtx.Lock()
 		i.completeBlocks = append(i.completeBlocks, ib)
-		//i.searchCompleteBlocks[ib] = sb
+		//i.searchCompleteBlocks[ib] = &searchLocalBlockEntry{b: sb}
 		i.blocksMtx.Unlock()
 
 		level.Info(log.Logger).Log("msg", "reloaded local block", "tenantID", i.instanceID, "block", id.String(), "flushed", ib.FlushedTime())

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -447,11 +447,17 @@ func (i *instance) FindTraceByID(ctx context.Context, id []byte) (*tempopb.Trace
 // AddCompletingBlock adds an AppendBlock directly to the slice of completing blocks.
 // This is used during wal replay. It is expected that calling code will add the appropriate
 // jobs to the queue to eventually flush these.
-func (i *instance) AddCompletingBlock(b *wal.AppendBlock) {
+func (i *instance) AddCompletingBlock(b *wal.AppendBlock, s *search.StreamingSearchBlock) {
 	i.blocksMtx.Lock()
 	defer i.blocksMtx.Unlock()
 
 	i.completingBlocks = append(i.completingBlocks, b)
+
+	// search WAL
+	if s == nil {
+		return
+	}
+	i.searchAppendBlocks[b] = &searchStreamingBlockEntry{b: s}
 }
 
 // getOrCreateTrace will return a new trace object for the given request

--- a/tempodb/search/rescan_blocks.go
+++ b/tempodb/search/rescan_blocks.go
@@ -1,0 +1,120 @@
+package search
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	cortex_util "github.com/cortexproject/cortex/pkg/util/log"
+	"github.com/go-kit/log/level"
+	"github.com/google/uuid"
+
+	"github.com/grafana/tempo/pkg/tempofb"
+	"github.com/grafana/tempo/tempodb/backend"
+	"github.com/grafana/tempo/tempodb/encoding"
+	"github.com/grafana/tempo/tempodb/wal"
+)
+
+// RescanBlocks scans through the search directory in the WAL folder and replays files
+// todo: copied from wal.RescanBlocks(), see if we can reduce duplication?
+func RescanBlocks(walPath string) ([]*StreamingSearchBlock, error) {
+	searchFilepath := filepath.Join(walPath, "search")
+	files, err := ioutil.ReadDir(searchFilepath)
+	if err != nil {
+		return nil, err
+	}
+
+	blocks := make([]*StreamingSearchBlock, 0, len(files))
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
+		start := time.Now()
+		level.Info(cortex_util.Logger).Log("msg", "beginning replay", "file", f.Name(), "size", f.Size())
+
+		b, warning, err := newStreamingSearchBlockFromWALReplay(f.Name())
+
+		remove := false
+		if err != nil {
+			// wal replay failed, clear and warn
+			level.Warn(cortex_util.Logger).Log("msg", "failed to replay block. removing.", "file", f.Name(), "err", err)
+			remove = true
+		}
+
+		if b != nil && b.appender.Length() == 0 {
+			level.Warn(cortex_util.Logger).Log("msg", "empty wal file. ignoring.", "file", f.Name(), "err", err)
+			remove = true
+		}
+
+		if warning != nil {
+			level.Warn(cortex_util.Logger).Log("msg", "received warning while replaying block. partial replay likely.", "file", f.Name(), "warning", warning, "records", b.appender.Length())
+		}
+
+		if remove {
+			err = os.Remove(filepath.Join(searchFilepath, f.Name()))
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		level.Info(cortex_util.Logger).Log("msg", "replay complete", "file", f.Name(), "duration", time.Since(start))
+
+		blocks = append(blocks, b)
+	}
+
+	return blocks, nil
+}
+
+// newStreamingSearchBlockFromWALReplay creates a StreamingSearchBlock with in-memory records from a search WAL file
+func newStreamingSearchBlockFromWALReplay(filename string) (*StreamingSearchBlock, error, error) {
+	f, err := os.OpenFile(filename, os.O_RDONLY, 0644)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	blockID, _, _, _, _, err := parseFilename(filename)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// version is pinned to v2 for now
+	v, err := encoding.FromVersion("v2")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	blockHeader := tempofb.NewSearchBlockHeaderMutable()
+	records, warning, err := wal.ReplayWALAndGetRecords(f, v, backend.EncNone, func(bytes []byte) error {
+		entry := tempofb.SearchEntryFromBytes(bytes)
+		blockHeader.AddEntry(entry)
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return &StreamingSearchBlock{
+		BlockID:  blockID,
+		file:     f,
+		appender: encoding.NewRecordAppender(records),
+		header:   blockHeader,
+		encoding: v,
+	}, warning, nil
+}
+
+func parseFilename(filename string) (blockID uuid.UUID, tenantID string, version string, encoding string, dataEncoding string, err error) {
+	splits := strings.Split(filename, ":")
+
+	if len(splits) < 6 {
+		return uuid.Nil, "", "", "", "", err
+	}
+
+	id, err := uuid.Parse(splits[0])
+	if err != nil {
+		return uuid.Nil, "", "", "", "", err
+	}
+	// todo: any other validation?
+	return id, splits[1], splits[2], splits[3], splits[4], nil
+}

--- a/tempodb/search/streaming_search_block.go
+++ b/tempodb/search/streaming_search_block.go
@@ -57,7 +57,15 @@ func NewStreamingSearchBlockForFile(f *os.File) (*StreamingSearchBlock, error) {
 	return s, nil
 }
 
-func NewStreamingSearchBlockFromWALReplay(f *os.File) (*StreamingSearchBlock, error) {
+func NewStreamingSearchBlockFromWALReplay(filename string) (*StreamingSearchBlock, error) {
+	f, err := os.OpenFile(filename, os.O_RDONLY, 0644)
+	if err != nil {
+		if os.IsNotExist(err) {  // this is fine, don't return error
+			return nil, nil
+		}
+		return nil, err
+	}
+
 	// version is pinned to v2 for now
 	v, err := encoding.FromVersion("v2")
 	if err != nil {

--- a/tempodb/search/streaming_search_block_test.go
+++ b/tempodb/search/streaming_search_block_test.go
@@ -17,6 +17,7 @@ import (
 func newStreamingSearchBlockWithTraces(traceCount int, t testing.TB) *StreamingSearchBlock {
 	id := []byte{1, 2, 3, 4, 5, 6, 7, 8}
 	searchData := [][]byte{(&tempofb.SearchEntryMutable{
+		TraceID: id,
 		Tags: tempofb.SearchDataMap{
 			"key1": {"value10", "value11"},
 			"key2": {"value20", "value21"},

--- a/tempodb/search/streaming_search_block_test.go
+++ b/tempodb/search/streaming_search_block_test.go
@@ -44,15 +44,17 @@ func TestStreamingSearchBlockReplay(t *testing.T) {
 	sb := newStreamingSearchBlockWithTraces(traceCount, t)
 	assert.NotNil(t, sb)
 
+	// grab the wal filename from the block and close the old file handler
 	walFile := sb.file.Name()
-
 	assert.NoError(t, sb.Close())
 
+	// create new block from the same wal file
 	newSearchBlock, warning, err := newStreamingSearchBlockFromWALReplay(walFile)
 	assert.NoError(t, warning)
 	assert.NoError(t, err)
 	assert.Equal(t, traceCount, len(newSearchBlock.appender.Records()))
 
+	// search the new block
 	p := NewSearchPipeline(&tempopb.SearchRequest{
 		Tags: map[string]string{"key1": "value10"},
 	})

--- a/tempodb/wal/append_block.go
+++ b/tempodb/wal/append_block.go
@@ -91,7 +91,9 @@ func newAppendBlockFromFile(filename string, path string) (*AppendBlock, error, 
 		return nil, nil, err
 	}
 
-	records, warning, err := ReplayWALAndGetRecords(f, v, e)
+	records, warning, err := ReplayWALAndGetRecords(f, v, e, func(bytes []byte) error {
+		return nil
+	})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/tempodb/wal/replay.go
+++ b/tempodb/wal/replay.go
@@ -1,0 +1,62 @@
+package wal
+
+import (
+	"bytes"
+	"io"
+	"os"
+
+	"github.com/grafana/tempo/tempodb/backend"
+	"github.com/grafana/tempo/tempodb/encoding"
+	"github.com/grafana/tempo/tempodb/encoding/common"
+)
+
+// ReplayWALAndGetRecords replays a WAL file that could contain either traces or searchdata
+//nolint:interfacer
+func ReplayWALAndGetRecords(file *os.File, v encoding.VersionedEncoding, enc backend.Encoding) ([]common.Record, error, error) {
+	dataReader, err := v.NewDataReader(backend.NewContextReaderWithAllReader(file), enc)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var buffer []byte
+	var records []common.Record
+	var warning error
+	objectReader := v.NewObjectReaderWriter()
+	currentOffset := uint64(0)
+	for {
+		buffer, pageLen, err := dataReader.NextPage(buffer)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			warning = err
+			break
+		}
+
+		reader := bytes.NewReader(buffer)
+		id, _, err := objectReader.UnmarshalObjectFromReader(reader)
+		if err != nil {
+			warning = err
+			break
+		}
+		// wal should only ever have one object per page, test that here
+		_, _, err = objectReader.UnmarshalObjectFromReader(reader)
+		if err != io.EOF {
+			warning = err
+			break
+		}
+
+		// make a copy so we don't hold onto the iterator buffer
+		recordID := append([]byte(nil), id...)
+		records = append(records, common.Record{
+			ID:     recordID,
+			Start:  currentOffset,
+			Length: pageLen,
+		})
+		currentOffset += uint64(pageLen)
+	}
+
+	common.SortRecords(records)
+
+	return records, warning, nil
+}

--- a/tempodb/wal/wal.go
+++ b/tempodb/wal/wal.go
@@ -138,6 +138,10 @@ func (w *WAL) NewFile(blockid uuid.UUID, tenantid string, dir string, name strin
 	return os.OpenFile(filepath.Join(p, fmt.Sprintf("%v:%v:%v", blockid, tenantid, name)), os.O_CREATE|os.O_RDWR, 0644)
 }
 
+func (w *WAL) GetFilepath() string {
+	return w.c.Filepath
+}
+
 func (w *WAL) ClearFolder(dir string) error {
 	p := filepath.Join(w.c.Filepath, dir)
 	return os.RemoveAll(p)

--- a/tempodb/wal/wal.go
+++ b/tempodb/wal/wal.go
@@ -135,7 +135,10 @@ func (w *WAL) NewFile(blockid uuid.UUID, tenantid string, dir string, name strin
 	if err != nil {
 		return nil, err
 	}
-	return os.OpenFile(filepath.Join(p, fmt.Sprintf("%v:%v:%v", blockid, tenantid, name)), os.O_CREATE|os.O_RDWR, 0644)
+
+	// blockID, tenantID, version, encoding (compression), dataEncoding, searchFileSuffix
+	filename := fmt.Sprintf("%v:%v:%v:%v:%v:%v", blockid, tenantid, "v2", backend.EncNone, "", name)
+	return os.OpenFile(filepath.Join(p, filename), os.O_CREATE|os.O_RDWR, 0644)
 }
 
 func (w *WAL) GetFilepath() string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
- Rescan search wal folder and replay all available files
- Handle blocks with no search file
- Add support for encoding & dataEncoding as part of search WAL file name

also
- dibs on PR 1000!

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`