### PR TITLE
Frontend Refactor

### DIFF
--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -192,11 +192,11 @@ func (t *App) initQueryFrontend() (services.Service, error) {
 	t.frontend = v1
 
 	// jpe call NewFrontend and pass next, NewFrontend will impleement http.RoundTripper
-	tripperware, err := frontend.NewTripperware(t.cfg.Frontend, t.cfg.HTTPAPIPrefix, log.Logger, prometheus.DefaultRegisterer)
+	tripperware, err := frontend.NewMiddleware(t.cfg.Frontend, t.cfg.HTTPAPIPrefix, log.Logger, prometheus.DefaultRegisterer)
 	if err != nil {
 		return nil, err
 	}
-	roundTripper := tripperware(cortexTripper)
+	roundTripper := tripperware.Wrap(cortexTripper)
 
 	// wrap http.RoundTripper with a http.Handler
 	frontendHandler := frontend.NewHandler(roundTripper)

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/cortex"
 	cortex_frontend "github.com/cortexproject/cortex/pkg/frontend"
-	cortex_transport "github.com/cortexproject/cortex/pkg/frontend/transport"
 	cortex_frontend_v1pb "github.com/cortexproject/cortex/pkg/frontend/v1/frontendv1pb"
 	"github.com/cortexproject/cortex/pkg/ring"
 	"github.com/cortexproject/cortex/pkg/util/log"
@@ -198,11 +197,11 @@ func (t *App) initQueryFrontend() (services.Service, error) {
 	}
 	roundTripper := tripperware(cortexTripper)
 
-	frontendHandler := cortex_transport.NewHandler(t.cfg.Frontend.Config.Handler, roundTripper, log.Logger, prometheus.DefaultRegisterer)
+	// wrap http.RoundTripper with a http.Handler
+	frontendHandler := frontend.NewHandler(roundTripper)
 
-	frontendHandler = middleware.Merge(
-		t.HTTPAuthMiddleware,
-	).Wrap(frontendHandler)
+	// wrap handler with auth
+	frontendHandler = t.HTTPAuthMiddleware.Wrap(frontendHandler)
 
 	// register grpc server for queriers to connect to
 	cortex_frontend_v1pb.RegisterFrontendServer(t.Server.GRPC, t.frontend)

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -181,11 +181,6 @@ func (t *App) initQuerier() (services.Service, error) {
 }
 
 func (t *App) initQueryFrontend() (services.Service, error) {
-	// jpe move this test into NewMiddleware, maybe all the way into ShardingWare?
-	if t.cfg.Frontend.QueryShards < frontend.MinQueryShards || t.cfg.Frontend.QueryShards > frontend.MaxQueryShards {
-		return nil, fmt.Errorf("frontend query shards should be between %d and %d (both inclusive)", frontend.MinQueryShards, frontend.MaxQueryShards)
-	}
-
 	// cortexTripper is a bridge between http and httpgrpc. it does the job of passing data to the cortex
 	// frontend code
 	cortexTripper, v1, _, err := cortex_frontend.InitFrontend(t.cfg.Frontend.Config, frontend.CortexNoQuerierLimits{}, 0, log.Logger, prometheus.DefaultRegisterer)

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -181,6 +181,7 @@ func (t *App) initQuerier() (services.Service, error) {
 }
 
 func (t *App) initQueryFrontend() (services.Service, error) {
+	// jpe move this test into NewMiddleware, maybe all the way into ShardingWare?
 	if t.cfg.Frontend.QueryShards < frontend.MinQueryShards || t.cfg.Frontend.QueryShards > frontend.MaxQueryShards {
 		return nil, fmt.Errorf("frontend query shards should be between %d and %d (both inclusive)", frontend.MinQueryShards, frontend.MaxQueryShards)
 	}

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -191,6 +191,7 @@ func (t *App) initQueryFrontend() (services.Service, error) {
 	}
 	t.frontend = v1
 
+	// jpe call NewFrontend and pass next, NewFrontend will impleement http.RoundTripper
 	tripperware, err := frontend.NewTripperware(t.cfg.Frontend, t.cfg.HTTPAPIPrefix, log.Logger, prometheus.DefaultRegisterer)
 	if err != nil {
 		return nil, err

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -201,7 +201,7 @@ func (t *App) initQueryFrontend() (services.Service, error) {
 	roundTripper := httpPipeline.Wrap(cortexTripper)
 
 	// wrap http.RoundTripper with a http.Handler
-	frontendHandler := frontend.NewHandler(roundTripper)
+	frontendHandler := frontend.NewHandler(roundTripper, log.Logger)
 
 	// wrap handler with auth
 	frontendHandler = t.HTTPAuthMiddleware.Wrap(frontendHandler)

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/drone/envsubst v1.0.3
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-kit/kit v0.11.0
+	github.com/go-kit/log v0.1.0
 	github.com/go-test/deep v1.0.7
 	github.com/gogo/protobuf v1.3.2
 	github.com/gogo/status v1.1.0
@@ -122,7 +123,6 @@ require (
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/fsouza/fake-gcs-server v1.7.0 // indirect
-	github.com/go-kit/log v0.1.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.0 // indirect
 	github.com/go-openapi/analysis v0.20.0 // indirect
 	github.com/go-openapi/errors v0.20.0 // indirect

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -30,8 +30,8 @@ const (
 	apiPathSearch = "/api/search"
 )
 
-// NewTripperware returns a Tripperware configured with a middleware to route, split and dedupe requests.
-func NewTripperware(cfg Config, apiPrefix string, logger log.Logger, registerer prometheus.Registerer) (Middleware, error) {
+// NewMiddleware returns a Tripperware configured with a middleware to route, split and dedupe requests.
+func NewMiddleware(cfg Config, apiPrefix string, logger log.Logger, registerer prometheus.Registerer) (Middleware, error) {
 	level.Info(logger).Log("msg", "creating tripperware in query frontend")
 
 	tracesTripperware := NewTracesTripperware(cfg, logger, registerer)

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -2,6 +2,7 @@ package frontend
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -29,6 +30,11 @@ const (
 // NewMiddleware returns a Middleware configured with a middleware to route, split and dedupe requests.
 func NewMiddleware(cfg Config, apiPrefix string, logger log.Logger, registerer prometheus.Registerer) (Middleware, error) {
 	level.Info(logger).Log("msg", "creating middleware in query frontend")
+
+	// todo: push this farther down? into the actual creation of the shardingware?
+	if cfg.QueryShards < minQueryShards || cfg.QueryShards > maxQueryShards {
+		return nil, fmt.Errorf("frontend query shards should be between %d and %d (both inclusive)", minQueryShards, maxQueryShards)
+	}
 
 	tracesMiddleware := NewTracesMiddleware(cfg, logger, registerer)
 	searchMiddleware := NewSearchMiddleware()

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -122,9 +122,6 @@ func NewTracesMiddleware(cfg Config, logger log.Logger, registerer prometheus.Re
 		rt := NewRoundTripper(next, Deduper(logger), ShardingWare(cfg.QueryShards, logger), RetryWare(cfg.MaxRetries, registerer))
 
 		return RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
-			// don't start a new span, this is already handled by frontendRoundTripper
-			span := opentracing.SpanFromContext(r.Context())
-
 			// validate traceID
 			_, err := util.ParseTraceID(r)
 			if err != nil {
@@ -168,6 +165,7 @@ func NewTracesMiddleware(cfg Config, logger log.Logger, registerer prometheus.Re
 				}
 				resp.Body = ioutil.NopCloser(bytes.NewReader(jsonTrace.Bytes()))
 			}
+			span := opentracing.SpanFromContext(r.Context())
 			if span != nil {
 				span.SetTag("contentType", marshallingFormat)
 			}

--- a/modules/frontend/handler.go
+++ b/modules/frontend/handler.go
@@ -43,7 +43,7 @@ func NewHandler(rt http.RoundTripper, logger log.Logger) http.Handler {
 	}
 }
 
-// ServeHTTP implments http.Handler
+// ServeHTTP implements http.Handler
 func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		_ = r.Body.Close()

--- a/modules/frontend/handler.go
+++ b/modules/frontend/handler.go
@@ -1,0 +1,63 @@
+package frontend
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/weaveworks/common/httpgrpc"
+	"github.com/weaveworks/common/httpgrpc/server"
+)
+
+const (
+	// StatusClientClosedRequest is the status code for when a client request cancellation of an http request
+	StatusClientClosedRequest = 499
+)
+
+var (
+	errCanceled              = httpgrpc.Errorf(StatusClientClosedRequest, context.Canceled.Error())
+	errDeadlineExceeded      = httpgrpc.Errorf(http.StatusGatewayTimeout, context.DeadlineExceeded.Error())
+	errRequestEntityTooLarge = httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "http: request body too large")
+)
+
+type HandlerBlerg struct { //jpe better name
+	roundTripper http.RoundTripper
+}
+
+func NewHandler(rt http.RoundTripper) http.Handler {
+	return &HandlerBlerg{
+		roundTripper: rt,
+	}
+}
+
+func (f *HandlerBlerg) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	defer func() {
+		_ = r.Body.Close()
+	}()
+
+	resp, err := f.roundTripper.RoundTrip(r)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+
+	w.WriteHeader(resp.StatusCode)
+	// we don't check for copy error as there is no much we can do at this point
+	_, _ = io.Copy(w, resp.Body)
+}
+
+func writeError(w http.ResponseWriter, err error) {
+	switch err {
+	case context.Canceled:
+		err = errCanceled
+	case context.DeadlineExceeded:
+		err = errDeadlineExceeded
+	default:
+		if util.IsRequestBodyTooLarge(err) {
+			err = errRequestEntityTooLarge
+		}
+	}
+	// use server.WriteError b/c it will handle the httpgrpc error bridge
+	server.WriteError(w, err)
+}

--- a/modules/frontend/handler.go
+++ b/modules/frontend/handler.go
@@ -21,17 +21,17 @@ var (
 	errRequestEntityTooLarge = httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "http: request body too large")
 )
 
-type HandlerBlerg struct { //jpe better name
+type Handler struct {
 	roundTripper http.RoundTripper
 }
 
 func NewHandler(rt http.RoundTripper) http.Handler {
-	return &HandlerBlerg{
+	return &Handler{
 		roundTripper: rt,
 	}
 }
 
-func (f *HandlerBlerg) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		_ = r.Body.Close()
 	}()

--- a/modules/frontend/handler.go
+++ b/modules/frontend/handler.go
@@ -66,7 +66,7 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if resp == nil {
-		writeError(w, errors.New("nil resp in ServerHTTP"))
+		writeError(w, errors.New("nil resp in ServeHTTP"))
 		return
 	}
 

--- a/modules/frontend/middleware.go
+++ b/modules/frontend/middleware.go
@@ -5,6 +5,7 @@ import "net/http"
 // middleware.go contains types and code related to building http pipelines
 
 // RoundTripperFunc is like http.HandlerFunc, but for RoundTripper
+//   chosen for pipeline building over queryrange.Handler b/c of how similar queryrange.Handler is to this existing interface.
 type RoundTripperFunc func(*http.Request) (*http.Response, error)
 
 // RoundTrip implememnts http.RoundTripper

--- a/modules/frontend/middleware.go
+++ b/modules/frontend/middleware.go
@@ -12,7 +12,7 @@ func (fn RoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) 
 	return fn(req)
 }
 
-// Middleware is used to
+// Middleware is used to build pipelines of http.Roundtrippers
 type Middleware interface {
 	Wrap(http.RoundTripper) http.RoundTripper
 }

--- a/modules/frontend/middleware.go
+++ b/modules/frontend/middleware.go
@@ -48,8 +48,3 @@ func NewRoundTripper(next http.RoundTripper, middlewares ...Middleware) http.Rou
 func (q roundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	return q.handler.RoundTrip(r)
 }
-
-// Do implements Handler.
-func (q roundTripper) Do(r *http.Request) (*http.Response, error) {
-	return q.next.RoundTrip(r)
-}

--- a/modules/frontend/middleware.go
+++ b/modules/frontend/middleware.go
@@ -36,18 +36,15 @@ func MergeMiddlewares(middleware ...Middleware) Middleware {
 }
 
 type roundTripper struct {
-	next    http.RoundTripper
 	handler http.RoundTripper
 }
 
 // NewRoundTripper takes an ordered set of middlewares and builds a http.RoundTripper
 // around them
 func NewRoundTripper(next http.RoundTripper, middlewares ...Middleware) http.RoundTripper {
-	transport := roundTripper{
-		next: next,
+	return roundTripper{
+		handler: MergeMiddlewares(middlewares...).Wrap(next),
 	}
-	transport.handler = MergeMiddlewares(middlewares...).Wrap(&transport)
-	return transport
 }
 
 func (q roundTripper) RoundTrip(r *http.Request) (*http.Response, error) {

--- a/modules/frontend/middleware.go
+++ b/modules/frontend/middleware.go
@@ -2,14 +2,17 @@ package frontend
 
 import "net/http"
 
+// middleware.go contains types and code related to building http pipelines
+
 // RoundTripperFunc is like http.HandlerFunc, but for RoundTripper
 type RoundTripperFunc func(*http.Request) (*http.Response, error)
 
+// RoundTrip implememnts http.RoundTripper
 func (fn RoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return fn(req)
 }
 
-// Basic pipeline building block
+// Middleware is used to
 type Middleware interface {
 	Wrap(http.RoundTripper) http.RoundTripper
 }
@@ -22,6 +25,7 @@ func (q MiddlewareFunc) Wrap(h http.RoundTripper) http.RoundTripper {
 	return q(h)
 }
 
+// MergeMiddlewares takes a set of ordered middlewares and merges them into a pipeline
 func MergeMiddlewares(middleware ...Middleware) Middleware {
 	return MiddlewareFunc(func(next http.RoundTripper) http.RoundTripper {
 		for i := len(middleware) - 1; i >= 0; i-- {
@@ -36,7 +40,8 @@ type roundTripper struct {
 	handler http.RoundTripper
 }
 
-// NewRoundTripper merges a set of middlewares into an handler, then inject it into the `next` roundtripper
+// NewRoundTripper takes an ordered set of middlewares and builds a http.RoundTripper
+// around them
 func NewRoundTripper(next http.RoundTripper, middlewares ...Middleware) http.RoundTripper {
 	transport := roundTripper{
 		next: next,

--- a/modules/frontend/querysharding.go
+++ b/modules/frontend/querysharding.go
@@ -119,7 +119,8 @@ func (s shardQuery) RoundTrip(r *http.Request) (*http.Response, error) {
 			}
 
 			// marshal into a trace to combine
-			trace, err := model.Unmarshal(buff, model.TracePBEncoding)
+			trace := &tempopb.Trace{}
+			err = proto.Unmarshal(buff, trace)
 			if err != nil {
 				_ = level.Error(s.logger).Log("msg", "error unmarshalling response", "url", innerR.RequestURI, "err", err, "body", string(buff))
 				overallError = err

--- a/modules/frontend/querysharding.go
+++ b/modules/frontend/querysharding.go
@@ -138,6 +138,13 @@ func (s shardQuery) RoundTrip(r *http.Request) (*http.Response, error) {
 	}
 
 	if overallTrace == nil || statusCode != http.StatusOK {
+		// translate non-404s into 500s. if, for intance, we get a 400 back from an internal component
+		// it means that we created a bad request. 400 should not be propagated back to the user b/c
+		// the bad request was due to a bug on our side, so return 500 instead.
+		if statusCode != http.StatusNotFound {
+			statusCode = 500
+		}
+
 		return &http.Response{
 			StatusCode: statusCode,
 			Body:       io.NopCloser(strings.NewReader(statusMsg)),

--- a/modules/frontend/querysharding.go
+++ b/modules/frontend/querysharding.go
@@ -22,8 +22,8 @@ import (
 )
 
 const (
-	MinQueryShards = 2
-	MaxQueryShards = 256
+	minQueryShards = 2
+	maxQueryShards = 256
 
 	querierPrefix  = "/querier"
 	queryDelimiter = "?"

--- a/modules/frontend/querysharding.go
+++ b/modules/frontend/querysharding.go
@@ -88,7 +88,7 @@ func (s shardQuery) RoundTrip(r *http.Request) (*http.Response, error) {
 
 			// check http error
 			if err != nil {
-				level.Error(s.logger).Log("msg", "error querying proxy target", "url", innerR.RequestURI, "err", err)
+				_ = level.Error(s.logger).Log("msg", "error querying proxy target", "url", innerR.RequestURI, "err", err)
 				overallError = err
 				return
 			}
@@ -104,7 +104,7 @@ func (s shardQuery) RoundTrip(r *http.Request) (*http.Response, error) {
 				statusCode = resp.StatusCode
 				bytesMsg, err := io.ReadAll(resp.Body)
 				if err != nil {
-					level.Error(s.logger).Log("msg", "error reading response body status != ok", "url", innerR.RequestURI, "err", err)
+					_ = level.Error(s.logger).Log("msg", "error reading response body status != ok", "url", innerR.RequestURI, "err", err)
 				}
 				statusMsg = string(bytesMsg)
 				return
@@ -113,7 +113,7 @@ func (s shardQuery) RoundTrip(r *http.Request) (*http.Response, error) {
 			// successful query, read the body
 			buff, err := io.ReadAll(resp.Body)
 			if err != nil {
-				level.Error(s.logger).Log("msg", "error reading response body status == ok", "url", innerR.RequestURI, "err", err)
+				_ = level.Error(s.logger).Log("msg", "error reading response body status == ok", "url", innerR.RequestURI, "err", err)
 				overallError = err
 				return
 			}
@@ -121,7 +121,7 @@ func (s shardQuery) RoundTrip(r *http.Request) (*http.Response, error) {
 			// marshal into a trace to combine
 			trace, err := model.Unmarshal(buff, model.TracePBEncoding)
 			if err != nil {
-				level.Error(s.logger).Log("msg", "error unmarshalling response", "url", innerR.RequestURI, "err", err, "body", string(buff))
+				_ = level.Error(s.logger).Log("msg", "error unmarshalling response", "url", innerR.RequestURI, "err", err, "body", string(buff))
 				overallError = err
 				return
 			}
@@ -147,7 +147,7 @@ func (s shardQuery) RoundTrip(r *http.Request) (*http.Response, error) {
 
 	buff, err := proto.Marshal(overallTrace)
 	if err != nil {
-		level.Error(s.logger).Log("msg", "error marshalling response to proto", "err", err)
+		_ = level.Error(s.logger).Log("msg", "error marshalling response to proto", "err", err)
 		return nil, err
 	}
 

--- a/modules/frontend/querysharding.go
+++ b/modules/frontend/querysharding.go
@@ -141,7 +141,7 @@ func (s shardQuery) RoundTrip(r *http.Request) (*http.Response, error) {
 	}
 
 	if overallTrace == nil || statusCode != http.StatusOK {
-		// translate non-404s into 500s. if, for intance, we get a 400 back from an internal component
+		// translate non-404s into 500s. if, for instance, we get a 400 back from an internal component
 		// it means that we created a bad request. 400 should not be propagated back to the user b/c
 		// the bad request was due to a bug on our side, so return 500 instead.
 		if statusCode != http.StatusNotFound {

--- a/modules/frontend/querysharding.go
+++ b/modules/frontend/querysharding.go
@@ -170,7 +170,7 @@ func (s *shardQuery) buildShardedRequests(parent *http.Request) ([]*http.Request
 
 	reqs := make([]*http.Request, s.queryShards)
 	// build sharded block queries
-	for i := 0; i < s.queryShards; i++ {
+	for i := 0; i < len(s.blockBoundaries); i++ {
 		reqs[i] = parent.Clone(ctx)
 
 		q := reqs[i].URL.Query()

--- a/modules/frontend/querysharding.go
+++ b/modules/frontend/querysharding.go
@@ -118,7 +118,9 @@ func (s shardQuery) RoundTrip(r *http.Request) (*http.Response, error) {
 				return
 			}
 
-			// marshal into a trace to combine
+			// marshal into a trace to combine.
+			// todo: better define responsibilities between middleware. the parent middleware in frontend.go actually sets the header
+			//  which forces the body here to be a proto encoded tempopb.Trace{}
 			trace := &tempopb.Trace{}
 			err = proto.Unmarshal(buff, trace)
 			if err != nil {

--- a/modules/frontend/querysharding.go
+++ b/modules/frontend/querysharding.go
@@ -193,7 +193,7 @@ func mergeResponses(ctx context.Context, rrs []RequestResponse) (*http.Response,
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       ioutil.NopCloser(bytes.NewReader(combinedTrace)),
-			// ContentLength header is added to log the size of response in the Tripperware in frontend.go
+			// ContentLength header is added to log the size of response in the Middleware in frontend.go
 			// This could be overwritten if the query client and Tempo negotiate compression
 			ContentLength: int64(len(combinedTrace)),
 			Header:        http.Header{},

--- a/modules/frontend/querysharding_test.go
+++ b/modules/frontend/querysharding_test.go
@@ -1,9 +1,24 @@
 package frontend
 
 import (
+	"bytes"
+	"errors"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 
+	"github.com/go-kit/kit/log"
+	"github.com/gogo/protobuf/proto"
+	"github.com/grafana/tempo/pkg/model"
+	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/grafana/tempo/pkg/util/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/user"
 )
 
 func TestCreateBlockBoundaries(t *testing.T) {
@@ -39,6 +54,207 @@ func TestCreateBlockBoundaries(t *testing.T) {
 
 			for i := 0; i < len(bb); i++ {
 				assert.Equal(t, tt.expected[i], bb[i])
+			}
+		})
+	}
+}
+
+type resp struct {
+	status int
+	body   []byte
+}
+
+func TestFindTraceByIDHandler(t *testing.T) {
+	// create and split a trace
+	trace := test.MakeTrace(10, []byte{0x01, 0x02})
+	trace1 := &tempopb.Trace{}
+	trace2 := &tempopb.Trace{}
+
+	for _, b := range trace.Batches {
+		if rand.Int()%2 == 0 {
+			trace1.Batches = append(trace1.Batches, b)
+		} else {
+			trace2.Batches = append(trace2.Batches, b)
+		}
+	}
+
+	tests := []struct {
+		name           string
+		status1        int
+		status2        int
+		trace1         *tempopb.Trace
+		trace2         *tempopb.Trace
+		err1           error
+		err2           error
+		expectedStatus int
+		expectedTrace  *tempopb.Trace
+		expectedError  error
+	}{
+		{
+			name:           "empty returns",
+			status1:        200,
+			status2:        200,
+			expectedStatus: 200,
+			expectedTrace:  &tempopb.Trace{},
+		},
+		{
+			name:           "404",
+			status1:        404,
+			status2:        404,
+			expectedStatus: 404,
+		},
+		{
+			name:           "500+404",
+			status1:        500,
+			status2:        404,
+			expectedStatus: 500,
+		},
+		{
+			name:           "404+500",
+			status1:        404,
+			status2:        500,
+			expectedStatus: 500,
+		},
+		{
+			name:           "500+200",
+			status1:        500,
+			status2:        200,
+			trace2:         trace2,
+			expectedStatus: 500,
+		},
+		{
+			name:           "200+500",
+			status1:        200,
+			trace1:         trace1,
+			status2:        500,
+			expectedStatus: 500,
+		},
+		{
+			name:           "503+200",
+			status1:        503,
+			status2:        200,
+			trace2:         trace2,
+			expectedStatus: 503,
+		},
+		{
+			name:           "200+503",
+			status1:        200,
+			trace1:         trace1,
+			status2:        503,
+			expectedStatus: 503,
+		},
+		{
+			name:           "200+404",
+			status1:        200,
+			trace1:         trace1,
+			status2:        404,
+			expectedStatus: 200,
+			expectedTrace:  trace1,
+		},
+		{
+			name:           "404+200",
+			status1:        404,
+			status2:        200,
+			trace2:         trace1,
+			expectedStatus: 200,
+			expectedTrace:  trace1,
+		},
+		{
+			name:           "200+200",
+			status1:        200,
+			trace1:         trace1,
+			status2:        200,
+			trace2:         trace2,
+			expectedStatus: 200,
+			expectedTrace:  trace,
+		},
+		{
+			name:          "200+err",
+			status1:       200,
+			trace1:        trace1,
+			err2:          errors.New("booo"),
+			expectedError: errors.New("booo"),
+		},
+		{
+			name:          "err+200",
+			err1:          errors.New("booo"),
+			status2:       200,
+			trace2:        trace1,
+			expectedError: errors.New("booo"),
+		},
+
+		{
+			name:          "500+err",
+			status1:       500,
+			trace1:        trace1,
+			err2:          errors.New("booo"),
+			expectedError: errors.New("booo"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sharder := ShardingWare(2, log.NewNopLogger())
+
+			mtx := sync.Mutex{}
+			firstResponse := true
+			next := RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+				mtx.Lock()
+				defer mtx.Unlock()
+				var trace *tempopb.Trace
+				var statusCode int
+				var err error
+				if firstResponse {
+					trace = tc.trace1
+					statusCode = tc.status1
+					err = tc.err1
+					firstResponse = false
+				} else {
+					trace = tc.trace2
+					err = tc.err2
+					statusCode = tc.status2
+				}
+
+				if err != nil {
+					return nil, err
+				}
+
+				var traceBytes []byte
+				if trace != nil {
+					traceBytes, err = proto.Marshal(trace)
+					require.NoError(t, err)
+				}
+
+				return &http.Response{
+					Body:       ioutil.NopCloser(bytes.NewReader(traceBytes)),
+					StatusCode: statusCode,
+				}, nil
+			})
+
+			testRT := NewRoundTripper(next, sharder)
+
+			req := httptest.NewRequest("GET", "/api/traces/1234", nil)
+			ctx := req.Context()
+			ctx = user.InjectOrgID(ctx, "blerg")
+			req = req.WithContext(ctx)
+
+			resp, err := testRT.RoundTrip(req)
+			if tc.expectedError != nil {
+				assert.Equal(t, tc.expectedError, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedStatus, resp.StatusCode)
+			if tc.expectedTrace != nil {
+				actualTrace := &tempopb.Trace{}
+				bytesTrace, err := io.ReadAll(resp.Body)
+				require.NoError(t, err)
+				err = proto.Unmarshal(bytesTrace, actualTrace)
+				require.NoError(t, err)
+
+				model.SortTrace(tc.expectedTrace)
+				model.SortTrace(actualTrace)
+				assert.True(t, proto.Equal(tc.expectedTrace, actualTrace))
 			}
 		})
 	}

--- a/modules/frontend/querysharding_test.go
+++ b/modules/frontend/querysharding_test.go
@@ -1,21 +1,12 @@
 package frontend
 
 import (
-	"bytes"
-	"context"
-	"io"
-	"io/ioutil"
-	"net/http"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/grafana/tempo/pkg/model"
-	"github.com/grafana/tempo/pkg/util/test"
 )
 
-func TestCreateBlockShards(t *testing.T) {
+func TestCreateBlockBoundaries(t *testing.T) {
 	tests := []struct {
 		name        string
 		queryShards int
@@ -51,131 +42,4 @@ func TestCreateBlockShards(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestMergeResponses(t *testing.T) {
-	t1 := test.MakeTrace(10, []byte{0x01, 0x02})
-	t2 := test.MakeTrace(10, []byte{0x01, 0x03})
-
-	b1, err := proto.Marshal(t1)
-	assert.NoError(t, err)
-	b2, err := proto.Marshal(t2)
-	assert.NoError(t, err)
-
-	combinedTrace, _, err := model.CombineTraceBytes(b1, b2, model.TracePBEncoding, model.TracePBEncoding)
-	assert.NoError(t, err)
-
-	tests := []struct {
-		name            string
-		requestResponse []RequestResponse
-		expected        *http.Response
-	}{
-		{
-			name: "combine status ok responses",
-			requestResponse: []RequestResponse{
-				{
-					Response: &http.Response{
-						StatusCode: http.StatusOK,
-						Body:       ioutil.NopCloser(bytes.NewReader(b1)),
-					},
-				},
-				{
-					Response: &http.Response{
-						StatusCode: http.StatusOK,
-						Body:       ioutil.NopCloser(bytes.NewReader(b2)),
-					},
-				},
-				{
-					Response: &http.Response{
-						StatusCode: http.StatusNotFound,
-						Body:       ioutil.NopCloser(bytes.NewReader([]byte("foo"))),
-					},
-				},
-			},
-			expected: &http.Response{
-				StatusCode:    http.StatusOK,
-				Body:          ioutil.NopCloser(bytes.NewReader(combinedTrace)),
-				ContentLength: int64(len(combinedTrace)),
-			},
-		},
-		{
-			name: "report 5xx with hit",
-			requestResponse: []RequestResponse{
-				{
-					Response: &http.Response{
-						StatusCode: http.StatusOK,
-						Body:       ioutil.NopCloser(bytes.NewReader(b1)),
-					},
-				},
-				{
-					Response: &http.Response{
-						StatusCode: http.StatusInternalServerError,
-						Body:       ioutil.NopCloser(bytes.NewReader([]byte("bar"))),
-					},
-				},
-			},
-			expected: &http.Response{
-				StatusCode: http.StatusInternalServerError,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("bar"))),
-			},
-		},
-		{
-			name: "report 5xx with no hit",
-			requestResponse: []RequestResponse{
-				{
-					Response: &http.Response{
-						StatusCode: http.StatusNotFound,
-						Body:       ioutil.NopCloser(bytes.NewReader([]byte("foo"))),
-					},
-				},
-				{
-					Response: &http.Response{
-						StatusCode: http.StatusInternalServerError,
-						Body:       ioutil.NopCloser(bytes.NewReader([]byte("bar"))),
-					},
-				},
-			},
-			expected: &http.Response{
-				StatusCode: http.StatusInternalServerError,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("bar"))),
-			},
-		},
-		{
-			name: "translate 4xx other than 404 to 500",
-			requestResponse: []RequestResponse{
-				{
-					Response: &http.Response{
-						StatusCode: http.StatusOK,
-						Body:       ioutil.NopCloser(bytes.NewReader(b1)),
-					},
-				},
-				{
-					Response: &http.Response{
-						StatusCode: http.StatusForbidden,
-						Body:       ioutil.NopCloser(bytes.NewReader([]byte("foo"))),
-					},
-				},
-			},
-			expected: &http.Response{
-				StatusCode: http.StatusInternalServerError,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("foo"))),
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			merged, err := mergeResponses(context.Background(), tt.requestResponse)
-			assert.NoError(t, err)
-			assert.Equal(t, tt.expected.StatusCode, merged.StatusCode)
-			expectedBody, err := io.ReadAll(tt.expected.Body)
-			assert.NoError(t, err)
-			actualBody, err := io.ReadAll(merged.Body)
-			assert.NoError(t, err)
-			assert.Equal(t, expectedBody, actualBody)
-			if tt.expected.ContentLength > 0 {
-				assert.Equal(t, tt.expected.ContentLength, merged.ContentLength)
-			}
-		})
-	}
-
 }

--- a/modules/frontend/querysharding_test.go
+++ b/modules/frontend/querysharding_test.go
@@ -64,7 +64,7 @@ type resp struct {
 	body   []byte
 }
 
-func TestFindTraceByIDHandler(t *testing.T) {
+func TestShardingWareDoRequest(t *testing.T) {
 	// create and split a trace
 	trace := test.MakeTrace(10, []byte{0x01, 0x02})
 	trace1 := &tempopb.Trace{}

--- a/modules/frontend/retry.go
+++ b/modules/frontend/retry.go
@@ -78,7 +78,7 @@ func (r retryWare) RoundTrip(req *http.Request) (*http.Response, error) {
 			statusCode = int(httpResp.Code)
 		}
 
-		// avoid calling err.Error() on an error returned by frontend tripperware
+		// avoid calling err.Error() on an error returned by frontend middleware
 		// https://github.com/grafana/tempo/issues/857
 		errMsg := fmt.Sprint(err)
 

--- a/modules/frontend/retry_test.go
+++ b/modules/frontend/retry_test.go
@@ -13,13 +13,6 @@ import (
 	"go.uber.org/atomic"
 )
 
-type HandlerFunc func(req *http.Request) (*http.Response, error)
-
-// Wrap implements Handler.
-func (q HandlerFunc) Do(req *http.Request) (*http.Response, error) {
-	return q(req)
-}
-
 func TestRetry(t *testing.T) {
 	var try atomic.Int32
 

--- a/modules/querier/http.go
+++ b/modules/querier/http.go
@@ -78,7 +78,7 @@ func (q *Querier) TraceByIDHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.Header.Get(util.AcceptHeaderKey) == util.ProtobufTypeHeaderValue {
-		span.SetTag("response marshalling format", util.ProtobufTypeHeaderValue)
+		span.SetTag("contentType", util.ProtobufTypeHeaderValue)
 		b, err := proto.Marshal(resp.Trace)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -92,7 +92,7 @@ func (q *Querier) TraceByIDHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	span.SetTag("response marshalling format", util.JSONTypeHeaderValue)
+	span.SetTag("contentType", util.JSONTypeHeaderValue)
 	marshaller := &jsonpb.Marshaler{}
 	err = marshaller.Marshal(w, resp.Trace)
 	if err != nil {


### PR DESCRIPTION
**What this PR does**:
Frontend cleanup in preparation for additional work. More can be done here, but I think this is a good start. Improvements include.

- Rewritten query sharder that more efficiently combines and does so in parallel with incoming requests. We will save ms!
- More detailed comments
- Removal of frontend.Handler which was the exact same as http.Roundtripper
- Reduction of 3 methods of middleware merging to a mere 2. Begone tripperware!
- Dropped dependency on Cortex queryrange package
- Moved request/response logging up to our http.Handler to catch both trace by id and search queries (and all future queries)
- Moved query shards config test into NewMiddleware
- Added "op" label to `query_frontend_queries_total` metric
- Mused about whether our routing should be handled by mux.Router instead of in middleware
- Additional "blerg"s are now in the codebase
