### PR TITLE
Docs: correct grammar/spelling/formatting of PR 1005

### DIFF
--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -386,9 +386,10 @@ storage:
         # the index.  Default 2.
         [blocklist_poll_tenant_index_builders: <int>]
 
-        # The oldest allowable tenant index. If an index is pulled that is older than this duration the polling
-        # will consider this an error. Note that `blocklist_poll_fallback` applies here. i.e. if fallback is true
-        # and a tenant index exceeds this duration it will fallback to listing the bucket contents.
+        # The oldest allowable tenant index. If an index is pulled that is older than this duration,
+        # the polling will consider this an error. Note that `blocklist_poll_fallback` applies here.
+        # If fallback is true and a tenant index exceeds this duration, it will fall back to listing
+        # the bucket contents.
         # Default 0 (disabled).
         [blocklist_poll_stale_tenant_index: <duration>]
 

--- a/docs/tempo/website/configuration/polling.md
+++ b/docs/tempo/website/configuration/polling.md
@@ -1,6 +1,9 @@
 ---
 title: Polling
+weight: 8
 ---
+
+# Polling
 
 The polling cycle is controlled by a number of configuration options detailed here.
 
@@ -21,15 +24,16 @@ storage:
         # the index.  Default 2.
         [blocklist_poll_tenant_index_builders: <int>]
 
-        # The oldest allowable tenant index. If an index is pulled that is older than this duration the polling
-        # will consider this an error. Note that `blocklist_poll_fallback` applies here. i.e. if fallback is true
-        # and a tenant index exceeds this duration it will fallback to listing the bucket contents.
+        # The oldest allowable tenant index. If an index is pulled that is older than this duration,
+        # the polling will consider this an error. Note that `blocklist_poll_fallback` applies here.
+        # If fallback is true and a tenant index exceeds this duration, it will fall back to listing
+        # the bucket contents.
         # Default 0 (disabled).
         [blocklist_poll_stale_tenant_index: <duration>]
 ```
 
 Due to the mechanics of the [tenant index]({{< relref "../operations/polling" >}}) the blocklist will be stale by
-at most 2x the configured `blocklist_poll` duration. There are two configuration options that need to be balanced 
+at most 2 times the configured `blocklist_poll` duration. There are two configuration options that need to be balanced 
 against the `blockist_poll` to handle this:
 
 The ingester `complete_block_timeout` is used to hold a block in the ingester for a given period of time after


### PR DESCRIPTION
This PR improves the docs associated with blocklist_poll_stale_tenant_index.
https://github.com/grafana/tempo/pull/1005 was merged in without a
doc review.