### PR TITLE
Update examples to use grafana:8.1.6

### DIFF
--- a/example/docker-compose/agent/docker-compose.yaml
+++ b/example/docker-compose/agent/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:8.1.1
+    image: grafana/grafana:8.1.6
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/azure/docker-compose.yaml
+++ b/example/docker-compose/azure/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:8.1.1
+    image: grafana/grafana:8.1.6
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/distributed/docker-compose.yaml
+++ b/example/docker-compose/distributed/docker-compose.yaml
@@ -91,7 +91,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:8.1.1
+    image: grafana/grafana:8.1.6
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/gcs/docker-compose.yaml
+++ b/example/docker-compose/gcs/docker-compose.yaml
@@ -41,7 +41,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:8.1.1
+    image: grafana/grafana:8.1.6
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/local/docker-compose.yaml
+++ b/example/docker-compose/local/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:8.1.1
+    image: grafana/grafana:8.1.6
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/loki/docker-compose.yaml
+++ b/example/docker-compose/loki/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
         loki-url: 'http://localhost:3100/loki/api/v1/push'
 
   grafana:
-    image: grafana/grafana:8.1.1
+    image: grafana/grafana:8.1.6
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
+++ b/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:8.1.1
+    image: grafana/grafana:8.1.6
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/otel-collector/docker-compose.yaml
+++ b/example/docker-compose/otel-collector/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:8.1.1
+    image: grafana/grafana:8.1.6
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/s3/docker-compose.yaml
+++ b/example/docker-compose/s3/docker-compose.yaml
@@ -45,7 +45,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:8.1.1
+    image: grafana/grafana:8.1.6
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:


### PR DESCRIPTION
**What this PR does**:
* update examples to patch for https://grafana.com/blog/2021/10/05/grafana-7.5.11-and-8.1.6-released-with-critical-security-fix/