### PR TITLE
drone: run apk fix when using alpine/git on ARM

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -81,7 +81,8 @@ steps:
 - name: image-tag
   image: alpine/git
   commands:
-  # the alpine/git image has one apk error when run in arm64, fix it before running apk add
+  # the alpine/git image has apk errors when run in arm64, fix them before running any other apk command
+  # https://github.com/alpine-docker/git/issues/35
   - apk fix
   - apk --update --no-cache add bash
   - git fetch origin --tags

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -81,6 +81,8 @@ steps:
 - name: image-tag
   image: alpine/git
   commands:
+  # the alpine/git image has one apk error when run in arm64, fix it before running apk add
+  - apk fix
   - apk --update --no-cache add bash
   - git fetch origin --tags
   - echo $(./tools/image-tag)-arm64 > .tags
@@ -214,6 +216,6 @@ get:
 
 ---
 kind: signature
-hmac: c7a010ef640a51af2104c7c3c76f0072ba031aab6053c81b7dd3849a61c03646
+hmac: 55a36b8b2f35f3fd9dad18c163b490f27ec986d022463155a4b4b3486a8324c7
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -222,4 +222,7 @@ tempo-mixin-check:
 # this requires the drone-cli https://docs.drone.io/cli/install/
 drone:
 	drone lint .drone/drone.yml
-	drone sign --save grafana/tempo .drone/drone.yml || echo "You probably forgot to set DRONE_SERVER and DRONE_TOKEN"
+ifndef DRONE_TOKEN
+	$(error DRONE_TOKEN is not set, visit https://drone.grafana.net/account)
+endif
+	DRONE_SERVER=https://drone.grafana.net drone sign --save grafana/tempo .drone/drone.yml


### PR DESCRIPTION
**What this PR does**:
Drone CI has been failing during the docker-arm image-tag step. Log from the Drone runner:
```
latest: Pulling from alpine/git
Digest: sha256:f73275dbb1a12e4322778e8d1cc7bda1656a849fb4b0e6b7fb935e8cf06c5cee
Status: Downloaded newer image for alpine/git:latest
+ apk --update --no-cache add bash
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/aarch64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/aarch64/APKINDEX.tar.gz
(1/2) Installing readline (8.1.0-r0)
(2/2) Installing bash (5.1.4-r0)
Executing bash-5.1.4-r0.post-install
Executing busybox-1.33.1-r3.trigger
1 error; 27 MiB in 34 packages
```

You can reproduce this by running alpine/git locally on a ARM machine:

```
$ docker run -it --entrypoint=/bin/sh alpine/git
/git # apk --update --no-cache add bash
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/aarch64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/aarch64/APKINDEX.tar.gz
(1/2) Installing readline (8.1.0-r0)
(2/2) Installing bash (5.1.4-r0)
Executing bash-5.1.4-r0.post-install
Executing busybox-1.33.1-r3.trigger
1 error; 27 MiB in 34 packages
/git # echo $?
1
```

By running `apk fix` before `apk add` we fix any broken installed packages:

```
$ docker run -it --entrypoint=/bin/sh alpine/git
/git # apk fix
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/aarch64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/aarch64/APKINDEX.tar.gz
(1/1) Reinstalling ca-certificates (20191127-r5)
Executing busybox-1.33.1-r3.trigger
Executing ca-certificates-20191127-r5.trigger
OK: 25 MiB in 32 packages
/git # apk --update --no-cache add bash
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/aarch64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/aarch64/APKINDEX.tar.gz
(1/2) Installing readline (8.1.0-r0)
(2/2) Installing bash (5.1.4-r0)
Executing bash-5.1.4-r0.post-install
Executing busybox-1.33.1-r3.trigger
OK: 27 MiB in 34 packages
```

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [ ] ~~Tests updated~~
- [ ] ~~Documentation added~~
- [ ] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~