### PR TITLE
Docs: add empty release notes section to docs

### DIFF
--- a/docs/tempo/website/getting-started/_index.md
+++ b/docs/tempo/website/getting-started/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Getting started
-weight: 100
+weight: 150
 ---
 
 # Getting started with Tempo

--- a/docs/tempo/website/release-notes/_index.md
+++ b/docs/tempo/website/release-notes/_index.md
@@ -1,0 +1,10 @@
+---
+title: Release notes
+weight: 100
+---
+# Release notes
+
+Release notes for Grafana Tempo are in the CHANGELOG for the release and
+listed here by version number.
+
+- [V1.2 release notes](../release-notes/v1-2/)

--- a/docs/tempo/website/release-notes/v1-2.md
+++ b/docs/tempo/website/release-notes/v1-2.md
@@ -1,0 +1,17 @@
+---
+title: V1.2
+---
+
+# Version 1.2 release notes
+
+## Features and enhancements
+
+* Item listed here
+
+## Upgrade considerations
+
+## Bug fixes
+
+### 1.2.0 bug fixes
+
+* Bug fix itemized here


### PR DESCRIPTION
For now, there's nothing in the yet-to-be-released section for v1.2.