### PR TITLE
Docs: fix broken link on a Troubleshooting page

### DIFF
--- a/docs/tempo/website/troubleshooting/max-trace-limit-reached.md
+++ b/docs/tempo/website/troubleshooting/max-trace-limit-reached.md
@@ -36,4 +36,4 @@ You will also see the following metric incremented. The `reason` label on this m
 tempo_discarded_spans_total
 ```
 
-In this case use available configuration options to [increase limits]({{< relref "../configuration/ingestion-limit" >}}).
+In this case use available configuration options to [increase limits]({{< relref "../configuration/#ingestion-limits" >}}).


### PR DESCRIPTION
There was a bad "relref." This PR fixes it, thereby fixing the bad link.