### PR TITLE
Add /config endpoint

### DIFF
--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -150,6 +150,13 @@ func (c *Config) CheckConfig() {
 	}
 }
 
+func newDefaultConfig() *Config {
+	defaultConfig := &Config{}
+	defaultFS := flag.NewFlagSet("", flag.PanicOnError)
+	defaultConfig.RegisterFlagsAndApplyDefaults("", defaultFS)
+	return defaultConfig
+}
+
 // App is the root datastructure.
 type App struct {
 	cfg Config
@@ -257,6 +264,9 @@ func (t *App) Run() error {
 	t.Server.HTTP.Path("/status").Handler(t.statusHandler()).Methods("GET")
 	t.Server.HTTP.Path("/status/{endpoint}").Handler(t.statusHandler()).Methods("GET")
 	grpc_health_v1.RegisterHealthServer(t.Server.GRPC, healthcheck.New(sm))
+
+	// Add a way to see the config
+	t.Server.HTTP.Path("/config").Handler(configHandler(t.cfg, newDefaultConfig()))
 
 	// Let's listen for events from this manager, and log them.
 	healthy := func() { level.Info(log.Logger).Log("msg", "Tempo started") }

--- a/cmd/tempo/app/config_handler.go
+++ b/cmd/tempo/app/config_handler.go
@@ -1,0 +1,132 @@
+package app
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+
+	"gopkg.in/yaml.v2"
+)
+
+func yamlMarshalUnmarshal(in interface{}) (map[interface{}]interface{}, error) {
+	yamlBytes, err := yaml.Marshal(in)
+	if err != nil {
+		return nil, err
+	}
+
+	object := make(map[interface{}]interface{})
+	if err := yaml.Unmarshal(yamlBytes, object); err != nil {
+		return nil, err
+	}
+
+	return object, nil
+}
+
+func diffConfig(defaultConfig, actualConfig map[interface{}]interface{}) (map[interface{}]interface{}, error) {
+	output := make(map[interface{}]interface{})
+
+	for key, value := range actualConfig {
+
+		defaultValue, ok := defaultConfig[key]
+		if !ok {
+			output[key] = value
+			continue
+		}
+
+		switch v := value.(type) {
+		case int:
+			defaultV, ok := defaultValue.(int)
+			if !ok || defaultV != v {
+				output[key] = v
+			}
+		case string:
+			defaultV, ok := defaultValue.(string)
+			if !ok || defaultV != v {
+				output[key] = v
+			}
+		case bool:
+			defaultV, ok := defaultValue.(bool)
+			if !ok || defaultV != v {
+				output[key] = v
+			}
+		case []interface{}:
+			defaultV, ok := defaultValue.([]interface{})
+			if !ok || !reflect.DeepEqual(defaultV, v) {
+				output[key] = v
+			}
+		case float64:
+			defaultV, ok := defaultValue.(float64)
+			if !ok || !reflect.DeepEqual(defaultV, v) {
+				output[key] = v
+			}
+		case map[interface{}]interface{}:
+			defaultV, ok := defaultValue.(map[interface{}]interface{})
+			if !ok {
+				output[key] = value
+			}
+			diff, err := diffConfig(defaultV, v)
+			if err != nil {
+				return nil, err
+			}
+			if len(diff) > 0 {
+				output[key] = diff
+			}
+		default:
+			return nil, fmt.Errorf("unsupported type %T", v)
+		}
+	}
+
+	return output, nil
+}
+
+func configHandler(actualCfg interface{}, defaultCfg interface{}) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var output interface{}
+		switch r.URL.Query().Get("mode") {
+		case "diff":
+			defaultCfgObj, err := yamlMarshalUnmarshal(defaultCfg)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			actualCfgObj, err := yamlMarshalUnmarshal(actualCfg)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			diff, err := diffConfig(defaultCfgObj, actualCfgObj)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			output = diff
+
+		case "defaults":
+			output = defaultCfg
+		default:
+			output = actualCfg
+		}
+
+		writeYAMLResponse(w, output)
+	}
+}
+
+// writeYAMLResponse writes some YAML as a HTTP response.
+func writeYAMLResponse(w http.ResponseWriter, v interface{}) {
+	// There is not standardised content-type for YAML, text/plain ensures the
+	// YAML is displayed in the browser instead of offered as a download
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+
+	data, err := yaml.Marshal(v)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// We ignore errors here, because we cannot do anything about them.
+	// Write will trigger sending Status code, so we cannot send a different status code afterwards.
+	// Also this isn't internal error, but error communicating with client.
+	_, _ = w.Write(data)
+}

--- a/cmd/tempo/app/config_handler_test.go
+++ b/cmd/tempo/app/config_handler_test.go
@@ -1,0 +1,115 @@
+package app
+
+import (
+	"io/ioutil"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type diffConfigMock struct {
+	MyInt          int          `yaml:"my_int"`
+	MyFloat        float64      `yaml:"my_float"`
+	MySlice        []string     `yaml:"my_slice"`
+	IgnoredField   func() error `yaml:"-"`
+	MyNestedStruct struct {
+		MyString      string   `yaml:"my_string"`
+		MyBool        bool     `yaml:"my_bool"`
+		MyEmptyStruct struct{} `yaml:"my_empty_struct"`
+	} `yaml:"my_nested_struct"`
+}
+
+func newDefaultDiffConfigMock() *diffConfigMock {
+	c := &diffConfigMock{
+		MyInt:        666,
+		MyFloat:      6.66,
+		MySlice:      []string{"value1", "value2"},
+		IgnoredField: func() error { return nil },
+	}
+	c.MyNestedStruct.MyString = "string1"
+	return c
+}
+
+func TestConfigDiffHandler(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		expectedStatusCode int
+		expectedBody       string
+		actualConfig       func() interface{}
+	}{
+		{
+			name:               "no config parameters overridden",
+			expectedStatusCode: 200,
+			expectedBody:       "{}\n",
+		},
+		{
+			name: "slice changed",
+			actualConfig: func() interface{} {
+				c := newDefaultDiffConfigMock()
+				c.MySlice = append(c.MySlice, "value3")
+				return c
+			},
+			expectedStatusCode: 200,
+			expectedBody: "my_slice:\n" +
+				"- value1\n" +
+				"- value2\n" +
+				"- value3\n",
+		},
+		{
+			name: "string in nested struct changed",
+			actualConfig: func() interface{} {
+				c := newDefaultDiffConfigMock()
+				c.MyNestedStruct.MyString = "string2"
+				return c
+			},
+			expectedStatusCode: 200,
+			expectedBody: "my_nested_struct:\n" +
+				"  my_string: string2\n",
+		},
+		{
+			name: "bool in nested struct changed",
+			actualConfig: func() interface{} {
+				c := newDefaultDiffConfigMock()
+				c.MyNestedStruct.MyBool = true
+				return c
+			},
+			expectedStatusCode: 200,
+			expectedBody: "my_nested_struct:\n" +
+				"  my_bool: true\n",
+		},
+		{
+			name: "test invalid input",
+			actualConfig: func() interface{} {
+				c := "x"
+				return &c
+			},
+			expectedStatusCode: 500,
+			expectedBody: "yaml: unmarshal errors:\n" +
+				"  line 1: cannot unmarshal !!str `x` into map[interface {}]interface {}\n",
+		},
+	} {
+		defaultCfg := newDefaultDiffConfigMock()
+		t.Run(tc.name, func(t *testing.T) {
+
+			var actualCfg interface{}
+			if tc.actualConfig != nil {
+				actualCfg = tc.actualConfig()
+			} else {
+				actualCfg = newDefaultDiffConfigMock()
+			}
+
+			req := httptest.NewRequest("GET", "http://test.com/config?mode=diff", nil)
+			w := httptest.NewRecorder()
+
+			h := configHandler(actualCfg, defaultCfg)
+			h(w, req)
+			resp := w.Result()
+			assert.Equal(t, tc.expectedStatusCode, resp.StatusCode)
+
+			body, err := ioutil.ReadAll(resp.Body)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedBody, string(body))
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does**:

Add a /config endpoint that shows the current configuration, default configuration or differences between these two.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

Signed-off-by: Michel Hollands <michel.hollands@grafana.com>