### PR TITLE
Disable docs test in GitHub Actions

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -8,17 +8,17 @@ on:
       - 'docs/tempo/website/**'
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v1
-      - name: Build Website
-        run: |
-          docker run -v ${PWD}/docs/tempo/website:/hugo/content/docs/tempo/latest --rm grafana/docs-base:latest /bin/bash -c 'make prod'
+  # test:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v1
+  #     - name: Build Website
+  #       run: |
+  #         docker run -v ${PWD}/docs/sources:/hugo/content/docs/loki/latest --rm grafana/docs-base:latest /bin/bash -c 'mkdir -p content/docs/grafana/latest/ && touch content/docs/grafana/latest/menu.yaml && make prod'
   sync:
     runs-on: ubuntu-latest
-    needs: test
+    # needs: test
     steps:
       - uses: actions/checkout@v1
       - run: git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync


### PR DESCRIPTION
**What this PR does**:
The `publish_docs` GitHub Actions workflow is timing out during the test job. This disables the job for now.
This also happened to Loki: https://github.com/grafana/loki/pull/4090

List of previous workflow runs: https://github.com/grafana/tempo/actions/workflows/website.yml