### PR TITLE
Run Release GitHub Action workflow only on tag pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,32 +2,28 @@ name: Release
 on:
   push:
     tags:
-      - '**'
-    branches:
-      - main
+      - v*
 
 jobs:
   release:
+    name: Release
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.17
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
-        id: go
 
       - name: Check out code
         uses: actions/checkout@v2
         
       - name: Release
-        if: startsWith(github.ref, 'refs/tags/v')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           make release
 
       - name: Upload release artifacts
-        if: startsWith(github.ref, 'refs/tags/v')
         uses: actions/upload-artifact@v2
         with:
           name: release-artifacts


### PR DESCRIPTION
**What this PR does**:
I noticed we are running the Release action on every push to main. This is needless as the steps that do something are disabled with a `if` clause.
List of workflow runs: https://github.com/grafana/tempo/actions/workflows/release.yml

This modifies the `on` condition so the workflow only runs when a tag matching `v*` is pushed.