### PR TITLE
Docs: add Grafana Agent to list

### DIFF
--- a/docs/tempo/website/_index.md
+++ b/docs/tempo/website/_index.md
@@ -16,5 +16,6 @@ Grafana Tempo is an open source, easy-to-use and high-volume distributed tracing
 - [Configuration](configuration/)
 - [Deployment and Operations](operations/)
 - [API](api_docs/) 
+- [Grafana Agent](grafana-agent/)
 - [Troubleshooting](troubleshooting/)
 - [Community](community/)


### PR DESCRIPTION
_Grafana Agent_ was missing in this list.

This will update https://grafana.com/docs/tempo/latest/ to add a link to https://grafana.com/docs/tempo/latest/grafana-agent/