### PR TITLE
Only fire TempoNoTenantIndexBuilders if blocklist is not empty

### DIFF
--- a/operations/tempo-mixin/alerts.libsonnet
+++ b/operations/tempo-mixin/alerts.libsonnet
@@ -126,7 +126,8 @@
           {
             alert: 'TempoNoTenantIndexBuilders',
             expr: |||
-              sum by (%(group_by_tenant)s) (tempodb_blocklist_tenant_index_builder{}) == 0
+              sum by (%(group_by_tenant)s) (tempodb_blocklist_tenant_index_builder{}) == 0 and
+              max by (%(group_by_tenant)s) (tempodb_blocklist_length{}) > 0
             ||| % $._config,
             'for': '5m',
             labels: {

--- a/operations/tempo-mixin/alerts.libsonnet
+++ b/operations/tempo-mixin/alerts.libsonnet
@@ -127,7 +127,7 @@
             alert: 'TempoNoTenantIndexBuilders',
             expr: |||
               sum by (%(group_by_tenant)s) (tempodb_blocklist_tenant_index_builder{}) == 0 and
-              max by (%(group_by_tenant)s) (tempodb_blocklist_length{}) > 0
+              max by (%(group_by_cluster)s) (tempodb_blocklist_length{}) > 0
             ||| % $._config,
             'for': '5m',
             labels: {

--- a/operations/tempo-mixin/yamls/alerts.yaml
+++ b/operations/tempo-mixin/yamls/alerts.yaml
@@ -83,7 +83,8 @@
       "message": "No tenant index builders for tenant {{ $labels.tenant }}. Tenant index will quickly become stale."
       "runbook_url": "https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoNoTenantIndexBuilders"
     "expr": |
-      sum by (cluster, namespace, tenant) (tempodb_blocklist_tenant_index_builder{}) == 0
+      sum by (cluster, namespace, tenant) (tempodb_blocklist_tenant_index_builder{}) == 0 and
+      max by (cluster, namespace) (tempodb_blocklist_length{}) > 0
     "for": "5m"
     "labels":
       "severity": "critical"


### PR DESCRIPTION
**What this PR does**:
Tweak the expression of `TempoNoTenantIndexBuilders` so it only fires if there a no tenant index builders _and_ the blocklist is not empty.

In a Tempo cluster that has not received any data yet, there will also not be any tenant index builders.
