### PR TITLE
Docs: Clarify search_max_result_limit config knob description

### DIFF
--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -216,9 +216,9 @@ querier:
     # Limit used for search requests if none is set by the caller
     [search_default_result_limit: <int> | default = 20]
 
-    # The maximum quantity of trace results that will be searched for, imposed as a limit within the server.
-    # If this value is lower than a limit parameter set in a query request, this value sets the maximum.
-    # The default value of 0 does not limit the quantity of trace results. 
+    # The maximum allowed value of the limit parameter on search requests. If the search request limit parameter 
+    # exceeds the value configured here it will be set to the value configured here.
+    # The default value of 0 disables this limit.
     [search_max_result_limit: <int> | default = 0]
 
     # config of the worker that connects to the query frontend


### PR DESCRIPTION
search_max_result_limit was added in PR 1044. PR was merged in without a docs reviewer.

