### PR TITLE
Docs: search API limit defaults to 20

### DIFF
--- a/docs/tempo/website/api_docs/_index.md
+++ b/docs/tempo/website/api_docs/_index.md
@@ -136,7 +136,7 @@ Each query parameter is of the form <name>=<value>, where <name> is the name of 
 - `maxDuration = (go duration value)`
   Optional.  Find traces with no greater than this duration.  Uses the same form as `minDuration`.
 - `limit = (integer)`
-  Optional.  Limit the number of search results. Default is 20 but this is configurable in the querier, see [Configuration](../configuration#querier)
+  Optional.  Limit the number of search results. Default is 20, but this is configurable in the querier. Refer to [Configuration](../configuration#querier).
 
 ### Search Tags
 


### PR DESCRIPTION
**What this PR does**:
Fixes a small mistake: the search API defaults `limit` to 20 not 100.

I'm not sure if using backticks (`) is a real improvement as it breaks the highlight...
![Screenshot 2021-10-18 at 16 17 45](https://user-images.githubusercontent.com/7748404/137749069-2d3009d2-fed5-425c-9319-ece2bacc3fde.png)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`