### PR TITLE
Substitute help text instead of blank search result name

### DIFF
--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -36,6 +36,8 @@ var (
 	})
 )
 
+const rootSpanNotYetReceivedText = "<root span not yet received>"
+
 // Querier handlers queries.
 type Querier struct {
 	services.Service
@@ -382,6 +384,9 @@ func (q *Querier) postProcessSearchResults(req *tempopb.SearchRequest, rr []resp
 	}
 
 	for _, t := range traces {
+		if t.RootServiceName == "" {
+			t.RootServiceName = rootSpanNotYetReceivedText
+		}
 		response.Traces = append(response.Traces, t)
 	}
 


### PR DESCRIPTION
**What this PR does**:
When searching live traces some root spans have not yet been received and the returned root service.name and span names are blank. This substitutes some helpful text instead of showing blank in the Grafana UI.

<img width="881" alt="image" src="https://user-images.githubusercontent.com/13524475/137967544-fad3479b-fca2-4fee-a8d0-73ff4fb81d20.png">


**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`