### PR TITLE
[Docs] Fix link and block headings on automatic logging page

### DIFF
--- a/docs/tempo/website/grafana-agent/automatic-logging.md
+++ b/docs/tempo/website/grafana-agent/automatic-logging.md
@@ -25,7 +25,7 @@ This allows searching by those key-value pairs in Loki.
 ## Quickstart
 
 To configure it, you need to select your preferred backend and what trace data to log.
-To see all the available config options, refer to the [configuration reference](https://github.com/grafana/agent/blob/main/docs/configuration/traces-config.md).
+To see all the available config options, refer to the [configuration reference](https://grafana.com/docs/agent/latest/configuration/traces-config/).
 
 This simple example logs trace roots to stdout and is a good way to get started using automatic logging:
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
The configuration reference link on the https://grafana.com/docs/tempo/latest/grafana-agent/automatic-logging/ page is broken because the destination file was renamed to `traces-config.md` from `tempo-config.md` - this fixes that link.

It also updates the `tempo` block examples to `traces` to conform with changes in Grafana Agent v0.19.0.

**Checklist**
- [NA] Tests updated
- [X] Documentation added
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`