### PR TITLE
Avoid data race by unlocked access to instance.completeBlocks

### DIFF
--- a/modules/ingester/ingester.go
+++ b/modules/ingester/ingester.go
@@ -415,13 +415,13 @@ func (i *Ingester) rediscoverLocalBlocks() error {
 			return err
 		}
 
-		err = inst.rediscoverLocalBlocks(ctx)
+		newBlocks, err := inst.rediscoverLocalBlocks(ctx)
 		if err != nil {
 			return errors.Wrapf(err, "getting local blocks for tenant %v", t)
 		}
 
 		// Requeue needed flushes
-		for _, b := range inst.completeBlocks {
+		for _, b := range newBlocks {
 			if b.FlushedTime().IsZero() {
 				i.enqueue(&flushOp{
 					kind:    opKindFlush,

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -571,10 +571,10 @@ func pushRequestTraceID(req *tempopb.PushRequest) ([]byte, error) {
 	return req.Batch.InstrumentationLibrarySpans[0].Spans[0].TraceId, nil
 }
 
-func (i *instance) rediscoverLocalBlocks(ctx context.Context) error {
+func (i *instance) rediscoverLocalBlocks(ctx context.Context) ([]*wal.LocalBlock, error) {
 	ids, err := i.localReader.Blocks(ctx, i.instanceID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	hasWal := func(id uuid.UUID) bool {
@@ -587,6 +587,8 @@ func (i *instance) rediscoverLocalBlocks(ctx context.Context) error {
 		}
 		return false
 	}
+
+	var rediscoveredBlocks []*wal.LocalBlock
 
 	for _, id := range ids {
 
@@ -605,23 +607,25 @@ func (i *instance) rediscoverLocalBlocks(ctx context.Context) error {
 				level.Warn(log.Logger).Log("msg", "Unable to reload meta for local block. This indicates an incomplete block and will be deleted", "tenant", i.instanceID, "block", id.String())
 				err = i.local.ClearBlock(id, i.instanceID)
 				if err != nil {
-					return errors.Wrapf(err, "deleting bad local block tenant %v block %v", i.instanceID, id.String())
+					return nil, errors.Wrapf(err, "deleting bad local block tenant %v block %v", i.instanceID, id.String())
 				}
 				continue
 			}
 
-			return err
+			return nil, err
 		}
 
 		b, err := encoding.NewBackendBlock(meta, i.localReader)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		ib, err := wal.NewLocalBlock(ctx, b, i.local)
 		if err != nil {
-			return err
+			return nil, err
 		}
+
+		rediscoveredBlocks = append(rediscoveredBlocks, ib)
 
 		sb := search.OpenBackendSearchBlock(b.BlockMeta().BlockID, b.BlockMeta().TenantID, i.localReader)
 
@@ -633,5 +637,5 @@ func (i *instance) rediscoverLocalBlocks(ctx context.Context) error {
 		level.Info(log.Logger).Log("msg", "reloaded local block", "tenantID", i.instanceID, "block", id.String(), "flushed", ib.FlushedTime())
 	}
 
-	return nil
+	return rediscoveredBlocks, nil
 }


### PR DESCRIPTION
**What this PR does**:
Fixes a flakey test data race error by avoiding unprotected access to `instance.completeBlocks` in `rediscoverLocalBlocks`.

~This is WIP because we're unable to reproduce locally, and will run CI for awhile to establish confidence in this fix.~ 

Done. See comment.

```
WARNING: DATA RACE
62 Write at 0x00c000570b90 by goroutine 312:
63  github.com/grafana/tempo/modules/ingester.(*instance).CompleteBlock()
64      /home/runner/work/tempo/tempo/modules/ingester/instance.go:300 +0x879
65  github.com/grafana/tempo/modules/ingester.(*Ingester).handleComplete()
66      /home/runner/work/tempo/tempo/modules/ingester/flush.go:252 +0x4a4
67  github.com/grafana/tempo/modules/ingester.(*Ingester).flushLoop()
68      /home/runner/work/tempo/tempo/modules/ingester/flush.go:205 +0x239
69  github.com/grafana/tempo/modules/ingester.New·dwrap·2()
70      /home/runner/work/tempo/tempo/modules/ingester/ingester.go:80 +0x47
71
72 Previous read at 0x00c000570b90 by goroutine 240:
73  github.com/grafana/tempo/modules/ingester.(*Ingester).rediscoverLocalBlocks()
74      /home/runner/work/tempo/tempo/modules/ingester/ingester.go:424 +0x4f7
75  github.com/grafana/tempo/modules/ingester.(*Ingester).starting()
76      /home/runner/work/tempo/tempo/modules/ingester/ingester.go:106 +0x159
77  github.com/grafana/tempo/modules/ingester.defaultIngesterModule()
78      /home/runner/work/tempo/tempo/modules/ingester/ingester_test.go:376 +0x604
79  github.com/grafana/tempo/modules/ingester.TestSearchWAL()
80      /home/runner/work/tempo/tempo/modules/ingester/ingester_test.go:255 +0x651
81  testing.tRunner()
82      /opt/hostedtoolcache/go/1.17.2/x64/src/testing/testing.go:1259 +0x22f
83  testing.(*T).Run·dwrap·21()
84      /opt/hostedtoolcache/go/1.17.2/x64/src/testing/testing.go:1306 +0x47
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`