### PR TITLE
Simplify store.Find span

### DIFF
--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -352,7 +352,7 @@ func (rw *readerWriter) Find(ctx context.Context, tenantID string, id common.ID,
 	span.SetTag("blockErrs", len(funcErrs))
 	span.SetTag("liveBlocks", len(blocklist))
 	span.SetTag("liveBlocksSearched", blocksSearched)
-	span.SetTag("compactedBlocks", len(compactedBlocklist)
+	span.SetTag("compactedBlocks", len(compactedBlocklist))
 	span.SetTag("compactedBlocksSearched", compactedBlocksSearched)
 
 	return partialTraces, dataEncodings, funcErrs, err


### PR DESCRIPTION
**What this PR does**:
Our `store.Find` span can grow to be quite large. As a result it is often dropped by our trace pipeline. This PR reduces the amount of data it records in order to improve it's usefulness and decrease its impact on tracing Tempo.

![image](https://user-images.githubusercontent.com/2272392/138867291-8578f5e3-1a3e-488b-bd60-214884d68b93.png)

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`