### PR TITLE
Support error and status.code searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 * [ENHANCEMENT] Jsonnet: add `$._config.search_enabled`, correctly set `http_api_prefix` in config [#1072](https://github.com/grafana/tempo/pull/1072) (@kvrhdn)
 * [ENHANCEMENT] Performance: Remove WAL contention between ingest and searches [#1076](https://github.com/grafana/tempo/pull/1076) (@mdisibio)
 * [ENHANCEMENT] Include tempo-cli in the release [#1086](https://github.com/grafana/tempo/pull/1086) (@zalegrala)
+* [ENHANCEMENT] Add search on span status [#1093](https://github.com/grafana/tempo/pull/1093) (@mdisibio)
 * [BUGFIX] Update port spec for GCS docker-compose example [#869](https://github.com/grafana/tempo/pull/869) (@zalegrala)
 * [BUGFIX] Fix "magic number" errors and other block mishandling when an ingester forcefully shuts down [#937](https://github.com/grafana/tempo/issues/937) (@mdisibio)
 * [BUGFIX] Fix compactor memory leak [#806](https://github.com/grafana/tempo/pull/806) (@mdisibio)

--- a/modules/distributor/search_data.go
+++ b/modules/distributor/search_data.go
@@ -67,7 +67,7 @@ func extractSearchData(trace *tempopb.Trace, id []byte, extractTag extractTagFun
 				// Collect for any spans
 				data.AddTag(search.SpanNameTag, s.Name)
 				if s.Status != nil {
-					data.AddTag(search.StatusCodeTag, strconv.FormatInt(int64(s.Status.Code), 10))
+					data.AddTag(search.StatusCodeTag, strconv.Itoa(int(s.Status.Code)))
 				}
 				data.SetStartTimeUnixNano(s.StartTimeUnixNano)
 				data.SetEndTimeUnixNano(s.EndTimeUnixNano)

--- a/modules/distributor/search_data.go
+++ b/modules/distributor/search_data.go
@@ -66,6 +66,9 @@ func extractSearchData(trace *tempopb.Trace, id []byte, extractTag extractTagFun
 
 				// Collect for any spans
 				data.AddTag(search.SpanNameTag, s.Name)
+				if s.Status != nil {
+					data.AddTag(search.StatusCodeTag, strconv.FormatInt(int64(s.Status.Code), 10))
+				}
 				data.SetStartTimeUnixNano(s.StartTimeUnixNano)
 				data.SetEndTimeUnixNano(s.EndTimeUnixNano)
 

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -310,8 +310,8 @@ func (q *Querier) SearchTags(ctx context.Context, req *tempopb.SearchTagsRequest
 		}
 	}
 
-	// Extra hard-coded values (for now)
-	for _, k := range search.GetStaticTags() {
+	// Extra tags
+	for _, k := range search.GetVirtualTags() {
 		uniqueMap[k] = struct{}{}
 	}
 
@@ -333,14 +333,6 @@ func (q *Querier) SearchTagValues(ctx context.Context, req *tempopb.SearchTagVal
 		return nil, errors.Wrap(err, "error extracting org id in Querier.SearchTagValues")
 	}
 
-	// Hard-coded values?
-	staticValues := search.GetStaticTagValues(req.TagName)
-	if len(staticValues) > 0 {
-		return &tempopb.SearchTagValuesResponse{
-			TagValues: staticValues,
-		}, nil
-	}
-
 	replicationSet, err := q.ring.GetReplicationSetForOperation(ring.Read)
 	if err != nil {
 		return nil, errors.Wrap(err, "error finding ingesters in Querier.SearchTagValues")
@@ -360,6 +352,11 @@ func (q *Querier) SearchTagValues(ctx context.Context, req *tempopb.SearchTagVal
 		for _, res := range resp.response.(*tempopb.SearchTagValuesResponse).TagValues {
 			uniqueMap[res] = struct{}{}
 		}
+	}
+
+	// Extra values
+	for _, v := range search.GetVirtualTagValues(req.TagName) {
+		uniqueMap[v] = struct{}{}
 	}
 
 	// Final response (sorted)

--- a/tempodb/search/pipeline.go
+++ b/tempodb/search/pipeline.go
@@ -106,14 +106,7 @@ func (p *Pipeline) rewriteTagLookup(k, v string) (skip bool, newk, newv string) 
 		return true, "", ""
 
 	case ErrorTag:
-		// Convert error=true|false into status.code=2|1
-		b, err := strconv.ParseBool(v)
-		if err != nil {
-			// Not a bool string = fall-through
-			break
-		}
-
-		if b {
+		if v == "true" {
 			// Error = true
 			return false, StatusCodeTag, strconv.Itoa(int(v1.Status_STATUS_CODE_ERROR))
 		}

--- a/tempodb/search/pipeline.go
+++ b/tempodb/search/pipeline.go
@@ -1,11 +1,13 @@
 package search
 
 import (
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/grafana/tempo/pkg/tempofb"
 	"github.com/grafana/tempo/pkg/tempopb"
+	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 )
 
 const SecretExhaustiveSearchTag = "x-dbg-exhaustive"
@@ -59,14 +61,8 @@ func NewSearchPipeline(req *tempopb.SearchRequest) Pipeline {
 		vb := make([][]byte, 0, len(req.Tags))
 
 		for k, v := range req.Tags {
-			if k == SecretExhaustiveSearchTag {
-				// Perform an exhaustive search by:
-				// * no block or page filters means all blocks and pages match
-				// * substitute this trace filter instead rejects everything. therefore it never
-				//   quits early due to enough results
-				p.tracefilters = append(p.tracefilters, func(s tempofb.Trace) bool {
-					return false
-				})
+			skip, k, v := p.rewriteTagLookup(k, v)
+			if skip {
 				continue
 			}
 
@@ -89,6 +85,54 @@ func NewSearchPipeline(req *tempopb.SearchRequest) Pipeline {
 	}
 
 	return p
+}
+
+// rewriteTagLookup intercepts certain tag/value lookups and rewrites them. It returns
+// true if the tag lookup should be excluded from the remaining tag/value lookups because
+// the it was rewritten into a different filter altogehter.  Otherwise it returns false,
+// and a new set of tag/value strings to use, which will either be the original inputs
+// or rewritten lookups.
+func (p *Pipeline) rewriteTagLookup(k, v string) (skip bool, newk, newv string) {
+	switch k {
+	case SecretExhaustiveSearchTag:
+		// Perform an exhaustive search by:
+		// * no block or page filters means all blocks and pages match
+		// * substitute this trace filter instead rejects everything. therefore it never
+		//   quits early due to enough results
+		p.tracefilters = append(p.tracefilters, func(s tempofb.Trace) bool {
+			return false
+		})
+		// Skip
+		return true, "", ""
+
+	case ErrorTag:
+		// Convert error=true|false into status.code=2|1
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			// Not a bool string = fall-through
+			break
+		}
+
+		if b {
+			// Error = true
+			return false, StatusCodeTag, strconv.Itoa(int(v1.Status_STATUS_CODE_ERROR))
+		} else {
+			// Error = false
+			return false, StatusCodeTag, strconv.Itoa(int(v1.Status_STATUS_CODE_OK))
+		}
+
+	case StatusCodeTag:
+		// Convert status.code=string into status.code=int
+		for statusStr, statusID := range StatusCodeValues {
+			if v == statusStr {
+				return false, StatusCodeTag, strconv.Itoa(statusID)
+			}
+		}
+		// Unknown mapping = fall-through
+	}
+
+	// No rewrite
+	return false, k, v
 }
 
 func (p *Pipeline) Matches(e tempofb.Trace) bool {

--- a/tempodb/search/pipeline.go
+++ b/tempodb/search/pipeline.go
@@ -116,14 +116,12 @@ func (p *Pipeline) rewriteTagLookup(k, v string) (skip bool, newk, newv string) 
 		if b {
 			// Error = true
 			return false, StatusCodeTag, strconv.Itoa(int(v1.Status_STATUS_CODE_ERROR))
-		} else {
-			// Error = false
-			return false, StatusCodeTag, strconv.Itoa(int(v1.Status_STATUS_CODE_OK))
 		}
+		// Else fall-through
 
 	case StatusCodeTag:
 		// Convert status.code=string into status.code=int
-		for statusStr, statusID := range StatusCodeValues {
+		for statusStr, statusID := range statusCodeMapping {
 			if v == statusStr {
 				return false, StatusCodeTag, strconv.Itoa(statusID)
 			}

--- a/tempodb/search/pipeline.go
+++ b/tempodb/search/pipeline.go
@@ -89,7 +89,7 @@ func NewSearchPipeline(req *tempopb.SearchRequest) Pipeline {
 
 // rewriteTagLookup intercepts certain tag/value lookups and rewrites them. It returns
 // true if the tag lookup should be excluded from the remaining tag/value lookups because
-// the it was rewritten into a different filter altogehter.  Otherwise it returns false,
+// the it was rewritten into a different filter altogether.  Otherwise it returns false,
 // and a new set of tag/value strings to use, which will either be the original inputs
 // or rewritten lookups.
 func (p *Pipeline) rewriteTagLookup(k, v string) (skip bool, newk, newv string) {

--- a/tempodb/search/pipeline_test.go
+++ b/tempodb/search/pipeline_test.go
@@ -1,11 +1,13 @@
 package search
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/grafana/tempo/pkg/tempofb"
 	"github.com/grafana/tempo/pkg/tempopb"
+	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,7 +48,20 @@ func TestPipelineMatchesTags(t *testing.T) {
 			searchData:  map[string][]string{"key1": {"value1"}, "key2": {"value2"}},
 			request:     map[string]string{"key1": "value1", "key3": "value3"},
 			shouldMatch: false,
-		}}
+		},
+		{
+			name:        "rewriteError",
+			searchData:  map[string][]string{StatusCodeTag: {strconv.Itoa(int(v1.Status_STATUS_CODE_ERROR))}},
+			request:     map[string]string{"error": "t"},
+			shouldMatch: true,
+		},
+		{
+			name:        "rewriteStatusCode",
+			searchData:  map[string][]string{StatusCodeTag: {strconv.Itoa(int(v1.Status_STATUS_CODE_ERROR))}},
+			request:     map[string]string{StatusCodeTag: StatusCodeError},
+			shouldMatch: true,
+		},
+	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/tempodb/search/pipeline_test.go
+++ b/tempodb/search/pipeline_test.go
@@ -52,7 +52,7 @@ func TestPipelineMatchesTags(t *testing.T) {
 		{
 			name:        "rewriteError",
 			searchData:  map[string][]string{StatusCodeTag: {strconv.Itoa(int(v1.Status_STATUS_CODE_ERROR))}},
-			request:     map[string]string{"error": "t"},
+			request:     map[string]string{"error": "true"},
 			shouldMatch: true,
 		},
 		{

--- a/tempodb/search/util.go
+++ b/tempodb/search/util.go
@@ -19,24 +19,24 @@ const (
 	StatusCodeError    = "error"
 )
 
-var StatusCodeValues = map[string]int{
+var statusCodeMapping = map[string]int{
 	StatusCodeUnset: int(v1.Status_STATUS_CODE_UNSET),
 	StatusCodeOK:    int(v1.Status_STATUS_CODE_OK),
 	StatusCodeError: int(v1.Status_STATUS_CODE_ERROR),
 }
 
-func GetStaticTags() []string {
-	return []string{StatusCodeTag, ErrorTag}
+func GetVirtualTags() []string {
+	return []string{ErrorTag}
 }
 
-func GetStaticTagValues(tagName string) []string {
+func GetVirtualTagValues(tagName string) []string {
 	switch tagName {
 
 	case StatusCodeTag:
 		return []string{StatusCodeUnset, StatusCodeOK, StatusCodeError}
 
 	case ErrorTag:
-		return []string{"true", "false"}
+		return []string{"true"}
 	}
 
 	return nil

--- a/tempodb/search/util.go
+++ b/tempodb/search/util.go
@@ -3,6 +3,7 @@ package search
 import (
 	"github.com/grafana/tempo/pkg/tempofb"
 	"github.com/grafana/tempo/pkg/tempopb"
+	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	"github.com/grafana/tempo/pkg/util"
 )
 
@@ -11,7 +12,35 @@ const (
 	ServiceNameTag     = "service.name"
 	RootSpanNameTag    = "root.name"
 	SpanNameTag        = "name"
+	ErrorTag           = "error"
+	StatusCodeTag      = "status.code"
+	StatusCodeUnset    = "unset"
+	StatusCodeOK       = "ok"
+	StatusCodeError    = "error"
 )
+
+var StatusCodeValues = map[string]int{
+	StatusCodeUnset: int(v1.Status_STATUS_CODE_UNSET),
+	StatusCodeOK:    int(v1.Status_STATUS_CODE_OK),
+	StatusCodeError: int(v1.Status_STATUS_CODE_ERROR),
+}
+
+func GetStaticTags() []string {
+	return []string{StatusCodeTag, ErrorTag}
+}
+
+func GetStaticTagValues(tagName string) []string {
+	switch tagName {
+
+	case StatusCodeTag:
+		return []string{StatusCodeUnset, StatusCodeOK, StatusCodeError}
+
+	case ErrorTag:
+		return []string{"true", "false"}
+	}
+
+	return nil
+}
 
 func GetSearchResultFromData(s *tempofb.SearchEntry) *tempopb.TraceSearchMetadata {
 	return &tempopb.TraceSearchMetadata{


### PR DESCRIPTION
**What this PR does**:
This PR adds support for searching on span status.   Raw span status in OTLP is an integer, and this is recorded as the new tag `status.code=<int>` (this matches the way Grafana already displays this data).   This can be searched directly, or via the following more user-friendly methods:
1.  `status.code=unset|ok|error` - The search pipeline will rewrite the text versions into a lookup for the corresponding integer. The tag name/value lookup apis will return these user-friendly texts and not the integers.
2. `error=true|false` - A new virtual "error" tag can be searched that is rewritten into a lookup on status.code integer. Similarly, the tag name/value lookup apis will return this tag and the two values.

**Which issue(s) this PR fixes**:
Fixes part of #932 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`