### PR TITLE
Update read dash to include relevant tempo endpoints

### DIFF
--- a/operations/tempo-mixin/dashboards.libsonnet
+++ b/operations/tempo-mixin/dashboards.libsonnet
@@ -12,55 +12,44 @@ dashboard_utils {
         g.row('Gateway')
         .addPanel(
           $.panel('QPS') +
-          $.qpsPanel('tempo_request_duration_seconds_count{%s, route="%sapi_traces_traceid"}' % [$.jobMatcher($._config.jobs.gateway), $._config.http_api_prefix])
+          $.qpsPanel('tempo_request_duration_seconds_count{%s, route=~"%stempo_api_.*"}' % [$.jobMatcher($._config.jobs.gateway), $._config.http_api_prefix])
         )
         .addPanel(
           $.panel('Latency') +
-          $.latencyPanel('tempo_request_duration_seconds', '{%s,route="%sapi_traces_traceid"}' % [$.jobMatcher($._config.jobs.gateway), $._config.http_api_prefix])
-        )
-      )
-      .addRow(
-        g.row('Jaeger Query')
-        .addPanel(
-          $.panel('QPS') +
-          $.qpsPanel('jaeger_rpc_http_requests_total{%s, endpoint="/api/traces/-traceID-"}' % $.jobMatcher($._config.jobs.querier))
-        )
-        .addPanel(
-          $.panel('Latency') +
-          $.latencyPanel('jaeger_query_latency', '{%s,operation="get_trace"}' % $.jobMatcher($._config.jobs.querier))
+          $.latencyPanel('tempo_request_duration_seconds', '{%s,route=~"%stempo_api_.*"}' % [$.jobMatcher($._config.jobs.gateway), $._config.http_api_prefix], additional_grouping='route')
         )
       )
       .addRow(
         g.row('Query Frontend')
         .addPanel(
           $.panel('QPS') +
-          $.qpsPanel('tempo_request_duration_seconds_count{%s, route="%sapi_traces_traceid"}' % [$.jobMatcher($._config.jobs.query_frontend), $._config.http_api_prefix])
+          $.qpsPanel('tempo_request_duration_seconds_count{%s, route=~"%stempo_api_.*"}' % [$.jobMatcher($._config.jobs.query_frontend), $._config.http_api_prefix])
         )
         .addPanel(
           $.panel('Latency') +
-          $.latencyPanel('tempo_request_duration_seconds', '{%s,route="%sapi_traces_traceid"}' % [$.jobMatcher($._config.jobs.query_frontend), $._config.http_api_prefix])
+          $.latencyPanel('tempo_request_duration_seconds', '{%s,route=~"%stempo_api_.*"}' % [$.jobMatcher($._config.jobs.query_frontend), $._config.http_api_prefix], additional_grouping='route')
         )
       )
       .addRow(
         g.row('Querier')
         .addPanel(
           $.panel('QPS') +
-          $.qpsPanel('tempo_request_duration_seconds_count{%s, route="querier_%sapi_traces_traceid"}' % [$.jobMatcher($._config.jobs.querier), $._config.http_api_prefix])
+          $.qpsPanel('tempo_request_duration_seconds_count{%s, route=~"querier_%stempo_api_.*"}' % [$.jobMatcher($._config.jobs.querier), $._config.http_api_prefix])
         )
         .addPanel(
           $.panel('Latency') +
-          $.latencyPanel('tempo_request_duration_seconds', '{%s,route="querier_%sapi_traces_traceid"}' % [$.jobMatcher($._config.jobs.querier), $._config.http_api_prefix])
+          $.latencyPanel('tempo_request_duration_seconds', '{%s,route=~"querier_%stempo_api_.*"}' % [$.jobMatcher($._config.jobs.querier), $._config.http_api_prefix], additional_grouping='route')
         )
       )
       .addRow(
         g.row('Ingester')
         .addPanel(
           $.panel('QPS') +
-          $.qpsPanel('tempo_request_duration_seconds_count{%s, route="/tempopb.Querier/FindTraceByID"}' % $.jobMatcher($._config.jobs.ingester))
+          $.qpsPanel('tempo_request_duration_seconds_count{%s, route=~"/tempopb.Querier/.*"}' % $.jobMatcher($._config.jobs.ingester))
         )
         .addPanel(
           $.panel('Latency') +
-          $.latencyPanel('tempo_request_duration_seconds', '{%s,route="/tempopb.Querier/FindTraceByID"}' % $.jobMatcher($._config.jobs.ingester))
+          $.latencyPanel('tempo_request_duration_seconds', '{%s,route=~"/tempopb.Querier/.*"}' % $.jobMatcher($._config.jobs.ingester), additional_grouping='route')
         )
       )
       .addRow(

--- a/operations/tempo-mixin/yamls/tempo-reads.json
+++ b/operations/tempo-mixin/yamls/tempo-reads.json
@@ -72,7 +72,7 @@
      "steppedLine": false,
      "targets": [
       {
-       "expr": "sum by (status) (label_replace(label_replace(rate(tempo_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw\", route=\"api_traces_traceid\"}[$__interval]), \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"), \"status\", \"${1}\",   \"status_code\", \"([a-z]+)\"))",
+       "expr": "sum by (status) (label_replace(label_replace(rate(tempo_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw\", route=~\"tempo_api_.*\"}[$__interval]), \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"), \"status\", \"${1}\",   \"status_code\", \"([a-z]+)\"))",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
@@ -159,29 +159,29 @@
      "steppedLine": false,
      "targets": [
       {
-       "expr": "histogram_quantile(0.99, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw\",route=\"api_traces_traceid\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.99, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw\",route=~\"tempo_api_.*\"}[$__interval])) by (le,route)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "99th Percentile",
+       "legendFormat": "{{route}} 99th",
        "refId": "A",
        "step": 10
       },
       {
-       "expr": "histogram_quantile(0.50, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw\",route=\"api_traces_traceid\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.50, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw\",route=~\"tempo_api_.*\"}[$__interval])) by (le,route)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "50th Percentile",
+       "legendFormat": "{{route}} 50th",
        "refId": "B",
        "step": 10
       },
       {
-       "expr": "sum(rate(tempo_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw\",route=\"api_traces_traceid\"}[$__interval])) * 1e3 / sum(rate(tempo_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw\",route=\"api_traces_traceid\"}[$__interval]))",
+       "expr": "sum(rate(tempo_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw\",route=~\"tempo_api_.*\"}[$__interval])) by (route) * 1e3 / sum(rate(tempo_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw\",route=~\"tempo_api_.*\"}[$__interval])) by (route)",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "Average",
+       "legendFormat": "{{route}} Average",
        "refId": "C",
        "step": 10
       }
@@ -282,7 +282,7 @@
      "steppedLine": false,
      "targets": [
       {
-       "expr": "sum by (status) (label_replace(label_replace(rate(jaeger_rpc_http_requests_total{cluster=~\"$cluster\", job=~\"($namespace)/querier\", endpoint=\"/api/traces/-traceID-\"}[$__interval]), \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"), \"status\", \"${1}\",   \"status_code\", \"([a-z]+)\"))",
+       "expr": "sum by (status) (label_replace(label_replace(rate(tempo_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/query-frontend\", route=~\"tempo_api_.*\"}[$__interval]), \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"), \"status\", \"${1}\",   \"status_code\", \"([a-z]+)\"))",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
@@ -369,29 +369,29 @@
      "steppedLine": false,
      "targets": [
       {
-       "expr": "histogram_quantile(0.99, sum(rate(jaeger_query_latency_bucket{cluster=~\"$cluster\", job=~\"($namespace)/querier\",operation=\"get_trace\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.99, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/query-frontend\",route=~\"tempo_api_.*\"}[$__interval])) by (le,route)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "99th Percentile",
+       "legendFormat": "{{route}} 99th",
        "refId": "A",
        "step": 10
       },
       {
-       "expr": "histogram_quantile(0.50, sum(rate(jaeger_query_latency_bucket{cluster=~\"$cluster\", job=~\"($namespace)/querier\",operation=\"get_trace\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.50, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/query-frontend\",route=~\"tempo_api_.*\"}[$__interval])) by (le,route)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "50th Percentile",
+       "legendFormat": "{{route}} 50th",
        "refId": "B",
        "step": 10
       },
       {
-       "expr": "sum(rate(jaeger_query_latency_sum{cluster=~\"$cluster\", job=~\"($namespace)/querier\",operation=\"get_trace\"}[$__interval])) * 1e3 / sum(rate(jaeger_query_latency_count{cluster=~\"$cluster\", job=~\"($namespace)/querier\",operation=\"get_trace\"}[$__interval]))",
+       "expr": "sum(rate(tempo_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/query-frontend\",route=~\"tempo_api_.*\"}[$__interval])) by (route) * 1e3 / sum(rate(tempo_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/query-frontend\",route=~\"tempo_api_.*\"}[$__interval])) by (route)",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "Average",
+       "legendFormat": "{{route}} Average",
        "refId": "C",
        "step": 10
       }
@@ -441,7 +441,7 @@
    "repeatIteration": null,
    "repeatRowId": null,
    "showTitle": true,
-   "title": "Jaeger Query",
+   "title": "Query Frontend",
    "titleSize": "h6"
   },
   {
@@ -492,7 +492,7 @@
      "steppedLine": false,
      "targets": [
       {
-       "expr": "sum by (status) (label_replace(label_replace(rate(tempo_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/query-frontend\", route=\"api_traces_traceid\"}[$__interval]), \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"), \"status\", \"${1}\",   \"status_code\", \"([a-z]+)\"))",
+       "expr": "sum by (status) (label_replace(label_replace(rate(tempo_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/querier\", route=~\"querier_tempo_api_.*\"}[$__interval]), \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"), \"status\", \"${1}\",   \"status_code\", \"([a-z]+)\"))",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
@@ -579,29 +579,29 @@
      "steppedLine": false,
      "targets": [
       {
-       "expr": "histogram_quantile(0.99, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/query-frontend\",route=\"api_traces_traceid\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.99, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/querier\",route=~\"querier_tempo_api_.*\"}[$__interval])) by (le,route)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "99th Percentile",
+       "legendFormat": "{{route}} 99th",
        "refId": "A",
        "step": 10
       },
       {
-       "expr": "histogram_quantile(0.50, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/query-frontend\",route=\"api_traces_traceid\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.50, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/querier\",route=~\"querier_tempo_api_.*\"}[$__interval])) by (le,route)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "50th Percentile",
+       "legendFormat": "{{route}} 50th",
        "refId": "B",
        "step": 10
       },
       {
-       "expr": "sum(rate(tempo_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/query-frontend\",route=\"api_traces_traceid\"}[$__interval])) * 1e3 / sum(rate(tempo_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/query-frontend\",route=\"api_traces_traceid\"}[$__interval]))",
+       "expr": "sum(rate(tempo_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/querier\",route=~\"querier_tempo_api_.*\"}[$__interval])) by (route) * 1e3 / sum(rate(tempo_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/querier\",route=~\"querier_tempo_api_.*\"}[$__interval])) by (route)",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "Average",
+       "legendFormat": "{{route}} Average",
        "refId": "C",
        "step": 10
       }
@@ -651,7 +651,7 @@
    "repeatIteration": null,
    "repeatRowId": null,
    "showTitle": true,
-   "title": "Query Frontend",
+   "title": "Querier",
    "titleSize": "h6"
   },
   {
@@ -702,7 +702,7 @@
      "steppedLine": false,
      "targets": [
       {
-       "expr": "sum by (status) (label_replace(label_replace(rate(tempo_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/querier\", route=\"querier_api_traces_traceid\"}[$__interval]), \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"), \"status\", \"${1}\",   \"status_code\", \"([a-z]+)\"))",
+       "expr": "sum by (status) (label_replace(label_replace(rate(tempo_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/ingester\", route=~\"/tempopb.Querier/.*\"}[$__interval]), \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"), \"status\", \"${1}\",   \"status_code\", \"([a-z]+)\"))",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
@@ -789,239 +789,29 @@
      "steppedLine": false,
      "targets": [
       {
-       "expr": "histogram_quantile(0.99, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/querier\",route=\"querier_api_traces_traceid\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.99, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",route=~\"/tempopb.Querier/.*\"}[$__interval])) by (le,route)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "99th Percentile",
+       "legendFormat": "{{route}} 99th",
        "refId": "A",
        "step": 10
       },
       {
-       "expr": "histogram_quantile(0.50, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/querier\",route=\"querier_api_traces_traceid\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.50, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",route=~\"/tempopb.Querier/.*\"}[$__interval])) by (le,route)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "50th Percentile",
+       "legendFormat": "{{route}} 50th",
        "refId": "B",
        "step": 10
       },
       {
-       "expr": "sum(rate(tempo_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/querier\",route=\"querier_api_traces_traceid\"}[$__interval])) * 1e3 / sum(rate(tempo_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/querier\",route=\"querier_api_traces_traceid\"}[$__interval]))",
+       "expr": "sum(rate(tempo_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",route=~\"/tempopb.Querier/.*\"}[$__interval])) by (route) * 1e3 / sum(rate(tempo_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",route=~\"/tempopb.Querier/.*\"}[$__interval])) by (route)",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "Average",
-       "refId": "C",
-       "step": 10
-      }
-     ],
-     "thresholds": [
-
-     ],
-     "timeFrom": null,
-     "timeShift": null,
-     "title": "Latency",
-     "tooltip": {
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-     },
-     "type": "graph",
-     "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": [
-
-      ]
-     },
-     "yaxes": [
-      {
-       "format": "ms",
-       "label": null,
-       "logBase": 1,
-       "max": null,
-       "min": 0,
-       "show": true
-      },
-      {
-       "format": "short",
-       "label": null,
-       "logBase": 1,
-       "max": null,
-       "min": null,
-       "show": false
-      }
-     ]
-    }
-   ],
-   "repeat": null,
-   "repeatIteration": null,
-   "repeatRowId": null,
-   "showTitle": true,
-   "title": "Querier",
-   "titleSize": "h6"
-  },
-  {
-   "collapse": false,
-   "height": "250px",
-   "panels": [
-    {
-     "aliasColors": {
-      "1xx": "#EAB839",
-      "2xx": "#7EB26D",
-      "3xx": "#6ED0E0",
-      "4xx": "#EF843C",
-      "5xx": "#E24D42",
-      "error": "#E24D42",
-      "success": "#7EB26D"
-     },
-     "bars": false,
-     "dashLength": 10,
-     "dashes": false,
-     "datasource": "$datasource",
-     "fill": 10,
-     "id": 9,
-     "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-     },
-     "lines": true,
-     "linewidth": 0,
-     "links": [
-
-     ],
-     "nullPointMode": "null as zero",
-     "percentage": false,
-     "pointradius": 5,
-     "points": false,
-     "renderer": "flot",
-     "seriesOverrides": [
-
-     ],
-     "spaceLength": 10,
-     "span": 6,
-     "stack": true,
-     "steppedLine": false,
-     "targets": [
-      {
-       "expr": "sum by (status) (label_replace(label_replace(rate(tempo_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/ingester\", route=\"/tempopb.Querier/FindTraceByID\"}[$__interval]), \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"), \"status\", \"${1}\",   \"status_code\", \"([a-z]+)\"))",
-       "format": "time_series",
-       "interval": "1m",
-       "intervalFactor": 2,
-       "legendFormat": "{{status}}",
-       "refId": "A",
-       "step": 10
-      }
-     ],
-     "thresholds": [
-
-     ],
-     "timeFrom": null,
-     "timeShift": null,
-     "title": "QPS",
-     "tooltip": {
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-     },
-     "type": "graph",
-     "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": [
-
-      ]
-     },
-     "yaxes": [
-      {
-       "format": "short",
-       "label": null,
-       "logBase": 1,
-       "max": null,
-       "min": 0,
-       "show": true
-      },
-      {
-       "format": "short",
-       "label": null,
-       "logBase": 1,
-       "max": null,
-       "min": null,
-       "show": false
-      }
-     ]
-    },
-    {
-     "aliasColors": {
-
-     },
-     "bars": false,
-     "dashLength": 10,
-     "dashes": false,
-     "datasource": "$datasource",
-     "fill": 1,
-     "id": 10,
-     "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-     },
-     "lines": true,
-     "linewidth": 1,
-     "links": [
-
-     ],
-     "nullPointMode": "null as zero",
-     "percentage": false,
-     "pointradius": 5,
-     "points": false,
-     "renderer": "flot",
-     "seriesOverrides": [
-
-     ],
-     "spaceLength": 10,
-     "span": 6,
-     "stack": false,
-     "steppedLine": false,
-     "targets": [
-      {
-       "expr": "histogram_quantile(0.99, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",route=\"/tempopb.Querier/FindTraceByID\"}[$__interval])) by (le)) * 1e3",
-       "format": "time_series",
-       "interval": "1m",
-       "intervalFactor": 2,
-       "legendFormat": "99th Percentile",
-       "refId": "A",
-       "step": 10
-      },
-      {
-       "expr": "histogram_quantile(0.50, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",route=\"/tempopb.Querier/FindTraceByID\"}[$__interval])) by (le)) * 1e3",
-       "format": "time_series",
-       "interval": "1m",
-       "intervalFactor": 2,
-       "legendFormat": "50th Percentile",
-       "refId": "B",
-       "step": 10
-      },
-      {
-       "expr": "sum(rate(tempo_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",route=\"/tempopb.Querier/FindTraceByID\"}[$__interval])) * 1e3 / sum(rate(tempo_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",route=\"/tempopb.Querier/FindTraceByID\"}[$__interval]))",
-       "format": "time_series",
-       "interval": "1m",
-       "intervalFactor": 2,
-       "legendFormat": "Average",
+       "legendFormat": "{{route}} Average",
        "refId": "C",
        "step": 10
       }
@@ -1093,7 +883,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 10,
-     "id": 11,
+     "id": 9,
      "legend": {
       "avg": false,
       "current": false,
@@ -1180,7 +970,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 1,
-     "id": 12,
+     "id": 10,
      "legend": {
       "avg": false,
       "current": false,
@@ -1209,29 +999,29 @@
      "steppedLine": false,
      "targets": [
       {
-       "expr": "histogram_quantile(0.99, sum(rate(cortex_memcache_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/querier\",method=~\"Memcache.Get|Memcache.GetMulti\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.99, sum(rate(cortex_memcache_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/querier\",method=~\"Memcache.Get|Memcache.GetMulti\"}[$__interval])) by (le,)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "99th Percentile",
+       "legendFormat": "{{route}} 99th",
        "refId": "A",
        "step": 10
       },
       {
-       "expr": "histogram_quantile(0.50, sum(rate(cortex_memcache_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/querier\",method=~\"Memcache.Get|Memcache.GetMulti\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.50, sum(rate(cortex_memcache_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/querier\",method=~\"Memcache.Get|Memcache.GetMulti\"}[$__interval])) by (le,)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "50th Percentile",
+       "legendFormat": "{{route}} 50th",
        "refId": "B",
        "step": 10
       },
       {
-       "expr": "sum(rate(cortex_memcache_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/querier\",method=~\"Memcache.Get|Memcache.GetMulti\"}[$__interval])) * 1e3 / sum(rate(cortex_memcache_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/querier\",method=~\"Memcache.Get|Memcache.GetMulti\"}[$__interval]))",
+       "expr": "sum(rate(cortex_memcache_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/querier\",method=~\"Memcache.Get|Memcache.GetMulti\"}[$__interval])) by () * 1e3 / sum(rate(cortex_memcache_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/querier\",method=~\"Memcache.Get|Memcache.GetMulti\"}[$__interval])) by ()",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "Average",
+       "legendFormat": "{{route}} Average",
        "refId": "C",
        "step": 10
       }
@@ -1303,7 +1093,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 10,
-     "id": 13,
+     "id": 11,
      "legend": {
       "avg": false,
       "current": false,
@@ -1390,7 +1180,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 1,
-     "id": 14,
+     "id": 12,
      "legend": {
       "avg": false,
       "current": false,
@@ -1419,29 +1209,29 @@
      "steppedLine": false,
      "targets": [
       {
-       "expr": "histogram_quantile(0.99, sum(rate(tempodb_gcs_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/querier\",operation=\"GET\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.99, sum(rate(tempodb_gcs_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/querier\",operation=\"GET\"}[$__interval])) by (le,)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "99th Percentile",
+       "legendFormat": "{{route}} 99th",
        "refId": "A",
        "step": 10
       },
       {
-       "expr": "histogram_quantile(0.50, sum(rate(tempodb_gcs_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/querier\",operation=\"GET\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.50, sum(rate(tempodb_gcs_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/querier\",operation=\"GET\"}[$__interval])) by (le,)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "50th Percentile",
+       "legendFormat": "{{route}} 50th",
        "refId": "B",
        "step": 10
       },
       {
-       "expr": "sum(rate(tempodb_gcs_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/querier\",operation=\"GET\"}[$__interval])) * 1e3 / sum(rate(tempodb_gcs_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/querier\",operation=\"GET\"}[$__interval]))",
+       "expr": "sum(rate(tempodb_gcs_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/querier\",operation=\"GET\"}[$__interval])) by () * 1e3 / sum(rate(tempodb_gcs_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/querier\",operation=\"GET\"}[$__interval])) by ()",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "Average",
+       "legendFormat": "{{route}} Average",
        "refId": "C",
        "step": 10
       }
@@ -1507,7 +1297,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 1,
-     "id": 15,
+     "id": 13,
      "legend": {
       "avg": false,
       "current": false,
@@ -1593,7 +1383,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 1,
-     "id": 16,
+     "id": 14,
      "legend": {
       "avg": false,
       "current": false,
@@ -1679,7 +1469,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 1,
-     "id": 17,
+     "id": 15,
      "legend": {
       "avg": false,
       "current": false,

--- a/operations/tempo-mixin/yamls/tempo-writes.json
+++ b/operations/tempo-mixin/yamls/tempo-writes.json
@@ -159,29 +159,29 @@
      "steppedLine": false,
      "targets": [
       {
-       "expr": "histogram_quantile(0.99, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw\",route=\"opentelemetry_proto_collector_trace_v1_traceservice_export\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.99, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw\",route=\"opentelemetry_proto_collector_trace_v1_traceservice_export\"}[$__interval])) by (le,)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "99th Percentile",
+       "legendFormat": "{{route}} 99th",
        "refId": "A",
        "step": 10
       },
       {
-       "expr": "histogram_quantile(0.50, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw\",route=\"opentelemetry_proto_collector_trace_v1_traceservice_export\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.50, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw\",route=\"opentelemetry_proto_collector_trace_v1_traceservice_export\"}[$__interval])) by (le,)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "50th Percentile",
+       "legendFormat": "{{route}} 50th",
        "refId": "B",
        "step": 10
       },
       {
-       "expr": "sum(rate(tempo_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw\",route=\"opentelemetry_proto_collector_trace_v1_traceservice_export\"}[$__interval])) * 1e3 / sum(rate(tempo_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw\",route=\"opentelemetry_proto_collector_trace_v1_traceservice_export\"}[$__interval]))",
+       "expr": "sum(rate(tempo_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw\",route=\"opentelemetry_proto_collector_trace_v1_traceservice_export\"}[$__interval])) by () * 1e3 / sum(rate(tempo_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw\",route=\"opentelemetry_proto_collector_trace_v1_traceservice_export\"}[$__interval])) by ()",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "Average",
+       "legendFormat": "{{route}} Average",
        "refId": "C",
        "step": 10
       }
@@ -372,29 +372,29 @@
      "steppedLine": false,
      "targets": [
       {
-       "expr": "histogram_quantile(0.99, sum(rate(tempo_distributor_push_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/distributor\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.99, sum(rate(tempo_distributor_push_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/distributor\"}[$__interval])) by (le,)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "99th Percentile",
+       "legendFormat": "{{route}} 99th",
        "refId": "A",
        "step": 10
       },
       {
-       "expr": "histogram_quantile(0.50, sum(rate(tempo_distributor_push_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/distributor\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.50, sum(rate(tempo_distributor_push_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/distributor\"}[$__interval])) by (le,)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "50th Percentile",
+       "legendFormat": "{{route}} 50th",
        "refId": "B",
        "step": 10
       },
       {
-       "expr": "sum(rate(tempo_distributor_push_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/distributor\"}[$__interval])) * 1e3 / sum(rate(tempo_distributor_push_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/distributor\"}[$__interval]))",
+       "expr": "sum(rate(tempo_distributor_push_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/distributor\"}[$__interval])) by () * 1e3 / sum(rate(tempo_distributor_push_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/distributor\"}[$__interval])) by ()",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "Average",
+       "legendFormat": "{{route}} Average",
        "refId": "C",
        "step": 10
       }
@@ -582,29 +582,29 @@
      "steppedLine": false,
      "targets": [
       {
-       "expr": "histogram_quantile(0.99, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",route=~\"/tempopb.Pusher/Push.*\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.99, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",route=~\"/tempopb.Pusher/Push.*\"}[$__interval])) by (le,)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "99th Percentile",
+       "legendFormat": "{{route}} 99th",
        "refId": "A",
        "step": 10
       },
       {
-       "expr": "histogram_quantile(0.50, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",route=~\"/tempopb.Pusher/Push.*\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.50, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",route=~\"/tempopb.Pusher/Push.*\"}[$__interval])) by (le,)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "50th Percentile",
+       "legendFormat": "{{route}} 50th",
        "refId": "B",
        "step": 10
       },
       {
-       "expr": "sum(rate(tempo_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",route=~\"/tempopb.Pusher/Push.*\"}[$__interval])) * 1e3 / sum(rate(tempo_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",route=~\"/tempopb.Pusher/Push.*\"}[$__interval]))",
+       "expr": "sum(rate(tempo_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",route=~\"/tempopb.Pusher/Push.*\"}[$__interval])) by () * 1e3 / sum(rate(tempo_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",route=~\"/tempopb.Pusher/Push.*\"}[$__interval])) by ()",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "Average",
+       "legendFormat": "{{route}} Average",
        "refId": "C",
        "step": 10
       }
@@ -792,29 +792,29 @@
      "steppedLine": false,
      "targets": [
       {
-       "expr": "histogram_quantile(0.99, sum(rate(cortex_memcache_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",method=\"Memcache.Put\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.99, sum(rate(cortex_memcache_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",method=\"Memcache.Put\"}[$__interval])) by (le,)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "99th Percentile",
+       "legendFormat": "{{route}} 99th",
        "refId": "A",
        "step": 10
       },
       {
-       "expr": "histogram_quantile(0.50, sum(rate(cortex_memcache_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",method=\"Memcache.Put\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.50, sum(rate(cortex_memcache_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",method=\"Memcache.Put\"}[$__interval])) by (le,)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "50th Percentile",
+       "legendFormat": "{{route}} 50th",
        "refId": "B",
        "step": 10
       },
       {
-       "expr": "sum(rate(cortex_memcache_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",method=\"Memcache.Put\"}[$__interval])) * 1e3 / sum(rate(cortex_memcache_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",method=\"Memcache.Put\"}[$__interval]))",
+       "expr": "sum(rate(cortex_memcache_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",method=\"Memcache.Put\"}[$__interval])) by () * 1e3 / sum(rate(cortex_memcache_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",method=\"Memcache.Put\"}[$__interval])) by ()",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "Average",
+       "legendFormat": "{{route}} Average",
        "refId": "C",
        "step": 10
       }
@@ -1002,29 +1002,29 @@
      "steppedLine": false,
      "targets": [
       {
-       "expr": "histogram_quantile(0.99, sum(rate(tempodb_gcs_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",operation=\"POST\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.99, sum(rate(tempodb_gcs_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",operation=\"POST\"}[$__interval])) by (le,)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "99th Percentile",
+       "legendFormat": "{{route}} 99th",
        "refId": "A",
        "step": 10
       },
       {
-       "expr": "histogram_quantile(0.50, sum(rate(tempodb_gcs_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",operation=\"POST\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.50, sum(rate(tempodb_gcs_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",operation=\"POST\"}[$__interval])) by (le,)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "50th Percentile",
+       "legendFormat": "{{route}} 50th",
        "refId": "B",
        "step": 10
       },
       {
-       "expr": "sum(rate(tempodb_gcs_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",operation=\"POST\"}[$__interval])) * 1e3 / sum(rate(tempodb_gcs_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",operation=\"POST\"}[$__interval]))",
+       "expr": "sum(rate(tempodb_gcs_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",operation=\"POST\"}[$__interval])) by () * 1e3 / sum(rate(tempodb_gcs_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/ingester\",operation=\"POST\"}[$__interval])) by ()",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "Average",
+       "legendFormat": "{{route}} Average",
        "refId": "C",
        "step": 10
       }
@@ -1212,29 +1212,29 @@
      "steppedLine": false,
      "targets": [
       {
-       "expr": "histogram_quantile(0.99, sum(rate(cortex_memcache_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/compactor\",method=\"Memcache.Put\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.99, sum(rate(cortex_memcache_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/compactor\",method=\"Memcache.Put\"}[$__interval])) by (le,)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "99th Percentile",
+       "legendFormat": "{{route}} 99th",
        "refId": "A",
        "step": 10
       },
       {
-       "expr": "histogram_quantile(0.50, sum(rate(cortex_memcache_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/compactor\",method=\"Memcache.Put\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.50, sum(rate(cortex_memcache_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/compactor\",method=\"Memcache.Put\"}[$__interval])) by (le,)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "50th Percentile",
+       "legendFormat": "{{route}} 50th",
        "refId": "B",
        "step": 10
       },
       {
-       "expr": "sum(rate(cortex_memcache_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/compactor\",method=\"Memcache.Put\"}[$__interval])) * 1e3 / sum(rate(cortex_memcache_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/compactor\",method=\"Memcache.Put\"}[$__interval]))",
+       "expr": "sum(rate(cortex_memcache_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/compactor\",method=\"Memcache.Put\"}[$__interval])) by () * 1e3 / sum(rate(cortex_memcache_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/compactor\",method=\"Memcache.Put\"}[$__interval])) by ()",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "Average",
+       "legendFormat": "{{route}} Average",
        "refId": "C",
        "step": 10
       }
@@ -1422,29 +1422,29 @@
      "steppedLine": false,
      "targets": [
       {
-       "expr": "histogram_quantile(0.99, sum(rate(tempodb_gcs_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/compactor\",operation=\"POST\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.99, sum(rate(tempodb_gcs_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/compactor\",operation=\"POST\"}[$__interval])) by (le,)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "99th Percentile",
+       "legendFormat": "{{route}} 99th",
        "refId": "A",
        "step": 10
       },
       {
-       "expr": "histogram_quantile(0.50, sum(rate(tempodb_gcs_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/compactor\",operation=\"POST\"}[$__interval])) by (le)) * 1e3",
+       "expr": "histogram_quantile(0.50, sum(rate(tempodb_gcs_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/compactor\",operation=\"POST\"}[$__interval])) by (le,)) * 1e3",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "50th Percentile",
+       "legendFormat": "{{route}} 50th",
        "refId": "B",
        "step": 10
       },
       {
-       "expr": "sum(rate(tempodb_gcs_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/compactor\",operation=\"POST\"}[$__interval])) * 1e3 / sum(rate(tempodb_gcs_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/compactor\",operation=\"POST\"}[$__interval]))",
+       "expr": "sum(rate(tempodb_gcs_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/compactor\",operation=\"POST\"}[$__interval])) by () * 1e3 / sum(rate(tempodb_gcs_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/compactor\",operation=\"POST\"}[$__interval])) by ()",
        "format": "time_series",
        "interval": "1m",
        "intervalFactor": 2,
-       "legendFormat": "Average",
+       "legendFormat": "{{route}} Average",
        "refId": "C",
        "step": 10
       }


### PR DESCRIPTION
**What this PR does**:
- Updates the Tempo / Reads dashboard to include search endpoints
- Latency graphs group by route, status/qps graphs group all together (mimics Loki)
- Forks underlying latency_panel function to allow grouping by additional fields

![image](https://user-images.githubusercontent.com/2272392/139865536-930d9817-ab38-43ef-b68a-e5adfc99bbbb.png)

**Which issue(s) this PR fixes**:
Fixes #924 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`