### PR TITLE
Add filtering by namespace in non-tempo alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main / unreleased
 
 * [ENHANCEMENT] Expose `upto` parameter on hedged requests for each backend with `hedge_requests_up_to`. [#1085](https://github.com/grafana/tempo/pull/1085) (@joe-elliott)
+* [ENHANCEMENT] Jsonnet: add `$._config.namespace` to filter by namespace in cortex metrics [#1098](https://github.com/grafana/tempo/pull/1098) (@mapno)
 
 ## v1.2.0 / 2021-11-05
 * [CHANGE] **BREAKING CHANGE** Drop support for v0 and v1 blocks. See [1.1 changelog](https://github.com/grafana/tempo/releases/tag/v1.1.0) for details [#919](https://github.com/grafana/tempo/pull/919) (@joe-elliott)
@@ -77,7 +78,6 @@
 * [ENHANCEMENT] Include tempo-cli in the release [#1086](https://github.com/grafana/tempo/pull/1086) (@zalegrala)
 * [ENHANCEMENT] Add search on span status [#1093](https://github.com/grafana/tempo/pull/1093) (@mdisibio)
 * [ENHANCEMENT] Slightly improved compression performance [#1094](https://github.com/grafana/tempo/pull/1094) (@bboreham)
-* [ENHANCEMENT] Jsonnet: add `$._config.namespace` to filter by namespace in cortex metrics [#1098](https://github.com/grafana/tempo/pull/1098) (@kvrhdn)
 * [BUGFIX] Update port spec for GCS docker-compose example [#869](https://github.com/grafana/tempo/pull/869) (@zalegrala)
 * [BUGFIX] Fix "magic number" errors and other block mishandling when an ingester forcefully shuts down [#937](https://github.com/grafana/tempo/issues/937) (@mdisibio)
 * [BUGFIX] Fix compactor memory leak [#806](https://github.com/grafana/tempo/pull/806) (@mdisibio)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 * [ENHANCEMENT] Include tempo-cli in the release [#1086](https://github.com/grafana/tempo/pull/1086) (@zalegrala)
 * [ENHANCEMENT] Add search on span status [#1093](https://github.com/grafana/tempo/pull/1093) (@mdisibio)
 * [ENHANCEMENT] Slightly improved compression performance [#1094](https://github.com/grafana/tempo/pull/1094) (@bboreham)
+* [ENHANCEMENT] Jsonnet: add `$._config.namespace` to filter by namespace in cortex metrics [#1098](https://github.com/grafana/tempo/pull/1098) (@kvrhdn)
 * [BUGFIX] Update port spec for GCS docker-compose example [#869](https://github.com/grafana/tempo/pull/869) (@zalegrala)
 * [BUGFIX] Fix "magic number" errors and other block mishandling when an ingester forcefully shuts down [#937](https://github.com/grafana/tempo/issues/937) (@mdisibio)
 * [BUGFIX] Fix compactor memory leak [#806](https://github.com/grafana/tempo/pull/806) (@mdisibio)

--- a/operations/tempo-mixin/alerts.libsonnet
+++ b/operations/tempo-mixin/alerts.libsonnet
@@ -42,8 +42,8 @@
           {
             alert: 'TempoCompactorUnhealthy',
             expr: |||
-              max by (%s) (cortex_ring_members{state="Unhealthy", name="%s"}) > 0
-            ||| % [$._config.group_by_cluster, $._config.jobs.compactor],
+              max by (%s) (cortex_ring_members{state="Unhealthy", name="%s", namespace=~"%s"}) > 0
+            ||| % [$._config.group_by_cluster, $._config.jobs.compactor, $._config.namespace],
             'for': '15m',
             labels: {
               severity: 'critical',
@@ -57,8 +57,8 @@
             alert: 'TempoDistributorUnhealthy',
             'for': '15m',
             expr: |||
-              max by (%s) (cortex_ring_members{state="Unhealthy", name="%s"}) > 0
-            ||| % [$._config.group_by_cluster, $._config.jobs.distributor],
+              max by (%s) (cortex_ring_members{state="Unhealthy", name="%s", namespace=~"%s"}) > 0
+            ||| % [$._config.group_by_cluster, $._config.jobs.distributor, $._config.namespace],
             labels: {
               severity: 'warning',
             },

--- a/operations/tempo-mixin/config.libsonnet
+++ b/operations/tempo-mixin/config.libsonnet
@@ -4,6 +4,7 @@
 
   _config+:: {
     http_api_prefix: '',
+    namespace: '.*',
     jobs: {
       gateway: 'cortex-gw',
       query_frontend: 'query-frontend',

--- a/operations/tempo-mixin/yamls/alerts.yaml
+++ b/operations/tempo-mixin/yamls/alerts.yaml
@@ -29,7 +29,7 @@
       "message": "There are {{ printf \"%f\" $value }} unhealthy compactor(s)."
       "runbook_url": "https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoCompactorUnhealthy"
     "expr": |
-      max by (cluster, namespace) (cortex_ring_members{state="Unhealthy", name="compactor"}) > 0
+      max by (cluster, namespace) (cortex_ring_members{state="Unhealthy", name="compactor", namespace=~".*"}) > 0
     "for": "15m"
     "labels":
       "severity": "critical"
@@ -38,7 +38,7 @@
       "message": "There are {{ printf \"%f\" $value }} unhealthy distributor(s)."
       "runbook_url": "https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoDistributorUnhealthy"
     "expr": |
-      max by (cluster, namespace) (cortex_ring_members{state="Unhealthy", name="distributor"}) > 0
+      max by (cluster, namespace) (cortex_ring_members{state="Unhealthy", name="distributor", namespace=~".*"}) > 0
     "for": "15m"
     "labels":
       "severity": "warning"


### PR DESCRIPTION
**What this PR does**:

Adds a configurable namespace label to cortex metrics used for alerts. This can be useful if you're running tempo and cortex in the same cluster.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`