### PR TITLE
Update golangci linters for deprecation warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,19 +47,18 @@ linters:
     - goconst
     - gofmt
     - goimports
-    - golint
     - gosimple
+    - govet
     - ineffassign
     - megacheck
     - misspell
+    - revive
     - structcheck
+    - typecheck
     - unconvert
     - unparam
-    - varcheck
-    - govet
     - unused
-    - interfacer
-    - typecheck
+    - varcheck
 
 linters-settings:
   errcheck:

--- a/pkg/model/encoding.go
+++ b/pkg/model/encoding.go
@@ -57,7 +57,6 @@ func Unmarshal(obj []byte, dataEncoding string) (*tempopb.Trace, error) {
 }
 
 // marshal converts a tempopb.Trace into a byte slice encoded using dataEncoding
-// nolint:interfacer
 func marshal(trace *tempopb.Trace, dataEncoding string) ([]byte, error) {
 	switch dataEncoding {
 	case "":

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -201,7 +201,6 @@ func (r *reader) Shutdown() {
 }
 
 // KeyPathForBlock returns a correctly ordered keypath given a block id and tenantid
-// nolint:interfacer
 func KeyPathForBlock(blockID uuid.UUID, tenantID string) KeyPath {
 	return []string{tenantID, blockID.String()}
 }
@@ -222,7 +221,6 @@ func CompactedMetaFileName(blockID uuid.UUID, tenantID string) string {
 }
 
 // RootPath returns the root path for a block given a block id and tenantid
-// nolint:interfacer
 func RootPath(blockID uuid.UUID, tenantID string) string {
 	return path.Join(tenantID, blockID.String())
 }

--- a/tempodb/backend/tenantindex.go
+++ b/tempodb/backend/tenantindex.go
@@ -62,9 +62,5 @@ func (b *TenantIndex) unmarshal(buffer []byte) error {
 	defer gzipReader.Close()
 
 	d := json.NewDecoder(gzipReader)
-	if err = d.Decode(b); err != nil {
-		return err
-	}
-
-	return nil
+	return d.Decode(b)
 }

--- a/tempodb/search/pipeline.go
+++ b/tempodb/search/pipeline.go
@@ -143,7 +143,6 @@ func (p *Pipeline) Matches(e tempofb.Trace) bool {
 	return true
 }
 
-// nolint:interfacer
 func (p *Pipeline) MatchesPage(pg tempofb.Page) bool {
 	for _, f := range p.tagfilters {
 		if !f(pg) {

--- a/tempodb/wal/replay.go
+++ b/tempodb/wal/replay.go
@@ -11,7 +11,6 @@ import (
 )
 
 // ReplayWALAndGetRecords replays a WAL file that could contain either traces or searchdata
-//nolint:interfacer
 func ReplayWALAndGetRecords(file *os.File, v encoding.VersionedEncoding, enc backend.Encoding, handleObj func([]byte) error) ([]common.Record, error, error) {
 	dataReader, err := v.NewDataReader(backend.NewContextReaderWithAllReader(file), enc)
 	if err != nil {


### PR DESCRIPTION
**What this PR does**:

Here we make the necessary updates to address the deprecations warning.  Replace `golint` with `revive` and remove `interfacer` due to non-maintenance and limited functionality.  Also sort.