### PR TITLE
V1.2 compaction error fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [ENHANCEMENT] Jsonnet: add `$._config.namespace` to filter by namespace in cortex metrics [#1098](https://github.com/grafana/tempo/pull/1098) (@mapno)
 * [ENHANCEMENT] Add middleware to compress frontend HTTP responses with gzip if requested [#1080](https://github.com/grafana/tempo/pull/1080) (@kvrhdn, @zalegrala)
 * [BUGFIX] Fix defaults for MaxBytesPerTrace (ingester.max-bytes-per-trace) and MaxSearchBytesPerTrace (ingester.max-search-bytes-per-trace) (@bitprocessor)
+* [BUGFIX] Ignore empty objects during compaction [#1113](https://github.com/grafana/tempo/pull/1113) (@mdisibio)
 
 ## v1.2.0 / 2021-11-05
 * [CHANGE] **BREAKING CHANGE** Drop support for v0 and v1 blocks. See [1.1 changelog](https://github.com/grafana/tempo/releases/tag/v1.1.0) for details [#919](https://github.com/grafana/tempo/pull/919) (@joe-elliott)

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -181,7 +181,7 @@ func (rw *readerWriter) compact(blockMetas []*backend.BlockMeta, tenantID string
 		compactionLevelLabel: compactionLevelLabel,
 	}
 
-	iter := encoding.NewMultiblockIterator(ctx, iters, rw.compactorCfg.IteratorBufferSize, combiner, dataEncoding)
+	iter := encoding.NewMultiblockIterator(ctx, iters, rw.compactorCfg.IteratorBufferSize, combiner, dataEncoding, rw.logger)
 	defer iter.Close()
 
 	for {

--- a/tempodb/encoding/iterator_multiblock.go
+++ b/tempodb/encoding/iterator_multiblock.go
@@ -201,7 +201,6 @@ func (b *bookmark) current(ctx context.Context) ([]byte, []byte, error) {
 		return nil, nil, b.currentErr
 	}
 
-	// If the next
 	b.currentID, b.currentObject, b.currentErr = b.iter.Next(ctx)
 	return b.currentID, b.currentObject, b.currentErr
 }

--- a/tempodb/encoding/iterator_multiblock.go
+++ b/tempodb/encoding/iterator_multiblock.go
@@ -179,7 +179,6 @@ func newBookmark(iter Iterator) *bookmark {
 }
 
 func (b *bookmark) current(ctx context.Context) ([]byte, []byte, error) {
-	//fmt.Println("current")
 	// This check is how the bookmark knows to iterate after being cleared,
 	// but it also unintentionally skips empty objects that somehow got in
 	// the block (b.currentObject is empty slice).  Normal usage of the bookmark
@@ -195,11 +194,8 @@ func (b *bookmark) current(ctx context.Context) ([]byte, []byte, error) {
 	// * Last object is empty: This is an issue in multiblock-iterator, see
 	//   notes there.
 	if len(b.currentID) != 0 && len(b.currentObject) != 0 {
-		//fmt.Println("returning current:", b.currentID)
 		return b.currentID, b.currentObject, nil
 	}
-
-	//fmt.Println("skipped", b.currentID)
 
 	if b.currentErr != nil {
 		return nil, nil, b.currentErr
@@ -207,19 +203,16 @@ func (b *bookmark) current(ctx context.Context) ([]byte, []byte, error) {
 
 	// If the next
 	b.currentID, b.currentObject, b.currentErr = b.iter.Next(ctx)
-	//fmt.Println("returning next:", b.currentID)
 	return b.currentID, b.currentObject, b.currentErr
 }
 
 func (b *bookmark) done(ctx context.Context) bool {
-	//fmt.Println("done")
 	_, _, err := b.current(ctx)
 
 	return err != nil
 }
 
 func (b *bookmark) clear() {
-	//fmt.Println("cleared")
 	b.currentID = nil
 	b.currentObject = nil
 }

--- a/tempodb/encoding/iterator_multiblock_test.go
+++ b/tempodb/encoding/iterator_multiblock_test.go
@@ -202,7 +202,7 @@ func TestMultiblockIteratorSkipsEmptyObjects(t *testing.T) {
 	inner.Add([]byte{2}, []byte{2}, nil)
 	inner.Add([]byte{3}, []byte{3}, nil)
 	inner.Add([]byte{4}, []byte{}, nil) // Two empties in a row
-	inner.Add([]byte{5, 6}, []byte{}, nil)
+	inner.Add([]byte{5}, []byte{}, nil)
 	inner.Add([]byte{6}, []byte{6}, nil)
 	inner.Add([]byte{7}, []byte{7}, nil)
 	inner.Add([]byte{8}, []byte{}, nil)

--- a/tempodb/encoding/iterator_multiblock_test.go
+++ b/tempodb/encoding/iterator_multiblock_test.go
@@ -3,13 +3,18 @@ package encoding
 import (
 	"context"
 	"io"
+	"os"
 	"testing"
 	"time"
+
+	"github.com/go-kit/log"
 
 	"github.com/grafana/tempo/tempodb/encoding/common"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 )
+
+var testLogger log.Logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
 
 var _ Iterator = (*testIterator)(nil)
 
@@ -81,7 +86,7 @@ func TestMultiblockSorts(t *testing.T) {
 	iterOdds.Add([]byte{3}, []byte{3}, nil)
 	iterOdds.Add([]byte{5}, []byte{5}, nil)
 
-	iter := NewMultiblockIterator(context.TODO(), []Iterator{iterEvens, iterOdds}, 10, nil, "")
+	iter := NewMultiblockIterator(context.TODO(), []Iterator{iterEvens, iterOdds}, 10, nil, "", testLogger)
 
 	count := 0
 	lastID := -1
@@ -132,7 +137,7 @@ func TestMultiblockIteratorCanBeCancelled(t *testing.T) {
 			ctx, cancel := context.WithCancel(ctx)
 
 			// Create iterator and cancel/close it after 100ms
-			iter := NewMultiblockIterator(ctx, []Iterator{inner}, recordCount/2, nil, "")
+			iter := NewMultiblockIterator(ctx, []Iterator{inner}, recordCount/2, nil, "", testLogger)
 			time.Sleep(100 * time.Millisecond)
 			if tc.close {
 				iter.Close()
@@ -160,7 +165,7 @@ func TestMultiblockIteratorCanBeCancelled(t *testing.T) {
 func TestMultiblockIteratorCanBeCancelledMultipleTimes(t *testing.T) {
 	inner := &testIterator{}
 
-	iter := NewMultiblockIterator(context.TODO(), []Iterator{inner}, 1, nil, "")
+	iter := NewMultiblockIterator(context.TODO(), []Iterator{inner}, 1, nil, "", testLogger)
 
 	iter.Close()
 	iter.Close()
@@ -178,7 +183,7 @@ func TestMultiblockIteratorPropogatesErrors(t *testing.T) {
 	inner2.Add([]byte{2}, []byte{2}, nil)
 	inner2.Add([]byte{3}, []byte{3}, nil)
 
-	iter := NewMultiblockIterator(ctx, []Iterator{inner, inner2}, 10, nil, "")
+	iter := NewMultiblockIterator(ctx, []Iterator{inner, inner2}, 10, nil, "", testLogger)
 
 	_, _, err := iter.Next(ctx)
 	require.NoError(t, err)
@@ -186,4 +191,39 @@ func TestMultiblockIteratorPropogatesErrors(t *testing.T) {
 	_, _, err = iter.Next(ctx)
 
 	require.Equal(t, io.ErrClosedPipe, err)
+}
+
+func TestMultiblockIteratorSkipsEmptyObjects(t *testing.T) {
+	ctx := context.TODO()
+
+	// Empty objects a beginning, middle, and end.
+	inner := &testIterator{}
+	inner.Add([]byte{1}, []byte{}, nil)
+	inner.Add([]byte{2}, []byte{2}, nil)
+	inner.Add([]byte{3}, []byte{3}, nil)
+	inner.Add([]byte{4}, []byte{}, nil) // Two empties in a row
+	inner.Add([]byte{5, 6}, []byte{}, nil)
+	inner.Add([]byte{6}, []byte{6}, nil)
+	inner.Add([]byte{7}, []byte{7}, nil)
+	inner.Add([]byte{8}, []byte{}, nil)
+
+	expected := []struct {
+		id  common.ID
+		obj []byte
+		err error
+	}{
+		{[]byte{2}, []byte{2}, nil},
+		{[]byte{3}, []byte{3}, nil},
+		{[]byte{6}, []byte{6}, nil},
+		{[]byte{7}, []byte{7}, nil},
+		{nil, nil, io.EOF},
+	}
+
+	iter := NewMultiblockIterator(ctx, []Iterator{inner}, 10, nil, "", testLogger)
+	for i := 0; i < len(expected); i++ {
+		id, obj, err := iter.Next(ctx)
+		require.Equal(t, expected[i].err, err)
+		require.Equal(t, expected[i].id, id)
+		require.Equal(t, expected[i].obj, obj)
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This PR patches over https://github.com/grafana/tempo/issues/1107 by logging a warning and continuing instead of failing with an error. Research concludes that somehow empty traces are being written to blocks.  The compactor bookmarks have already been unintentionally skipping empties in _most_ cases, but there are a few edge cases that are not skipped and led to this error.  Therefore skipping all seems ok.  We have not yet determined how the empty traces originate, or what changed between 1.1 and 1.2, but this fix should alleviate 1.2 troubles for the users encountering this bug.  

**Which issue(s) this PR fixes**:
Fixes #1107 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`