### PR TITLE
Improve Combine Efficiency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [ENHANCEMENT] Expose `upto` parameter on hedged requests for each backend with `hedge_requests_up_to`. [#1085](https://github.com/grafana/tempo/pull/1085) (@joe-elliott)
 * [ENHANCEMENT] Jsonnet: add `$._config.namespace` to filter by namespace in cortex metrics [#1098](https://github.com/grafana/tempo/pull/1098) (@mapno)
 * [ENHANCEMENT] Add middleware to compress frontend HTTP responses with gzip if requested [#1080](https://github.com/grafana/tempo/pull/1080) (@kvrhdn, @zalegrala)
+* [ENHANCEMENT] Improve memory efficiency of compaction and block cutting. [#1121](https://github.com/grafana/tempo/pull/1121) (@joe-elliott)
 * [BUGFIX] Fix defaults for MaxBytesPerTrace (ingester.max-bytes-per-trace) and MaxSearchBytesPerTrace (ingester.max-search-bytes-per-trace) (@bitprocessor)
 * [BUGFIX] Ignore empty objects during compaction [#1113](https://github.com/grafana/tempo/pull/1113) (@mdisibio)
 

--- a/modules/compactor/compactor.go
+++ b/modules/compactor/compactor.go
@@ -157,7 +157,7 @@ func (c *Compactor) Owns(hash string) bool {
 }
 
 // Combine implements common.ObjectCombiner
-func (c *Compactor) Combine(dataEncoding string, objs ...[]byte) ([]byte, bool) {
+func (c *Compactor) Combine(dataEncoding string, objs ...[]byte) ([]byte, bool, error) {
 	return model.ObjectCombiner.Combine(dataEncoding, objs...)
 }
 

--- a/modules/querier/querier_test.go
+++ b/modules/querier/querier_test.go
@@ -34,12 +34,12 @@ func (m *mockSharder) Owns(string) bool {
 	return true
 }
 
-func (m *mockSharder) Combine(dataEncoding string, objs ...[]byte) ([]byte, bool) {
+func (m *mockSharder) Combine(dataEncoding string, objs ...[]byte) ([]byte, bool, error) {
 	if len(objs) != 2 {
-		return nil, false
+		return nil, false, nil
 	}
 	combined, wasCombined, _ := model.CombineTraceBytes(objs[0], objs[1], dataEncoding, dataEncoding)
-	return combined, wasCombined
+	return combined, wasCombined, nil
 }
 
 func TestReturnAllHits(t *testing.T) {

--- a/pkg/model/combine.go
+++ b/pkg/model/combine.go
@@ -20,7 +20,7 @@ var ObjectCombiner = objectCombiner{}
 var _ common.ObjectCombiner = (*objectCombiner)(nil)
 
 // Combine implements tempodb/encoding/common.ObjectCombiner
-func (o objectCombiner) Combine(dataEncoding string, objs ...[]byte) ([]byte, bool, error) { // jpe test additional cases
+func (o objectCombiner) Combine(dataEncoding string, objs ...[]byte) ([]byte, bool, error) {
 	if len(objs) <= 0 {
 		return nil, false, errors.New("no objects provided")
 	}

--- a/pkg/model/combine.go
+++ b/pkg/model/combine.go
@@ -25,10 +25,6 @@ func (o objectCombiner) Combine(dataEncoding string, objs ...[]byte) ([]byte, bo
 		return nil, false, errors.New("no objects provided")
 	}
 
-	if len(objs) == 1 {
-		return objs[0], false, nil
-	}
-
 	// check to see if we need to combine
 	needCombine := false
 	for i := 1; i < len(objs); i++ {
@@ -50,10 +46,6 @@ func (o objectCombiner) Combine(dataEncoding string, objs ...[]byte) ([]byte, bo
 		}
 
 		combinedTrace, _, _, _ = CombineTraceProtos(combinedTrace, trace)
-	}
-
-	if combinedTrace == nil {
-		return nil, false, nil
 	}
 
 	combinedBytes, err := marshal(combinedTrace, dataEncoding)

--- a/pkg/model/combine_test.go
+++ b/pkg/model/combine_test.go
@@ -208,7 +208,7 @@ func TestCombine(t *testing.T) {
 	}
 }
 
-func TestCombineNils(t *testing.T) {
+func TestCombineTraceBytesNils(t *testing.T) {
 	test := test.MakeTrace(1, nil)
 	SortTrace(test)
 

--- a/pkg/model/combine_test.go
+++ b/pkg/model/combine_test.go
@@ -186,14 +186,8 @@ func TestCombine(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(fmt.Sprintf("%s", tt.name), func(t *testing.T) {
-			traceBytes := [][]byte{}
-
-			for _, trace := range tt.traces {
-				traceBytes = append(traceBytes, trace)
-			}
-
-			actual, combined, err := ObjectCombiner.Combine(CurrentEncoding, traceBytes...)
+		t.Run(tt.name, func(t *testing.T) {
+			actual, combined, err := ObjectCombiner.Combine(CurrentEncoding, tt.traces...)
 			assert.Equal(t, tt.expectCombined, combined)
 			if tt.expectError {
 				require.Error(t, err)

--- a/pkg/model/combine_test.go
+++ b/pkg/model/combine_test.go
@@ -48,14 +48,14 @@ func TestCombine(t *testing.T) {
 			name:        "t2 is bad",
 			trace1:      t1,
 			trace2:      nil,
-			expected:    t1,
+			expected:    nil,
 			expectError: true,
 		},
 		{
 			name:        "t1 is bad",
 			trace1:      nil,
 			trace2:      t2,
-			expected:    t2,
+			expected:    nil,
 			expectError: true,
 		},
 		{
@@ -90,7 +90,26 @@ func TestCombine(t *testing.T) {
 						b2 = []byte{0x01, 0x02, 0x03}
 					}
 
+					// CombineTraceBytes()
 					actual, _, err := CombineTraceBytes(b1, b2, enc1, enc2)
+					if tt.expectError {
+						require.Error(t, err)
+					} else {
+						require.NoError(t, err)
+					}
+
+					if tt.expected != nil {
+						expected := mustMarshal(tt.expected, enc1)
+						assert.Equal(t, expected, actual)
+					}
+
+					// Combine() only works if all byte slices have the same encoding
+					if enc1 != enc2 {
+						return
+					}
+
+					actual, _, err = ObjectCombiner.Combine(enc1, b1, b2)
+
 					if tt.expectError {
 						require.Error(t, err)
 					} else {

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -314,10 +314,10 @@ type instrumentedObjectCombiner struct {
 }
 
 // Combine wraps the inner combiner with combined metrics
-func (i instrumentedObjectCombiner) Combine(dataEncoding string, objs ...[]byte) ([]byte, bool) {
-	b, wasCombined := i.inner.Combine(dataEncoding, objs...)
+func (i instrumentedObjectCombiner) Combine(dataEncoding string, objs ...[]byte) ([]byte, bool, error) {
+	b, wasCombined, err := i.inner.Combine(dataEncoding, objs...)
 	if wasCombined {
 		metricCompactionObjectsCombined.WithLabelValues(i.compactionLevelLabel).Inc()
 	}
-	return b, wasCombined
+	return b, wasCombined, err
 }

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -31,16 +31,16 @@ func (m *mockSharder) Owns(hash string) bool {
 	return true
 }
 
-func (m *mockSharder) Combine(dataEncoding string, objs ...[]byte) ([]byte, bool) {
+func (m *mockSharder) Combine(dataEncoding string, objs ...[]byte) ([]byte, bool, error) {
 	if len(objs) != 2 {
-		return nil, false
+		return nil, false, nil
 	}
 
 	if len(objs[0]) > len(objs[1]) {
-		return objs[0], true
+		return objs[0], true, nil
 	}
 
-	return objs[1], true
+	return objs[1], true, nil
 }
 
 type mockJobSharder struct{}

--- a/tempodb/encoding/common/types.go
+++ b/tempodb/encoding/common/types.go
@@ -27,7 +27,7 @@ type ObjectCombiner interface {
 	// Combine objects encoded using dataEncoding. The returned object must
 	// use the same dataEncoding. Returns a bool indicating if it the objects required combining and
 	// the combined slice
-	Combine(dataEncoding string, objs ...[]byte) ([]byte, bool)
+	Combine(dataEncoding string, objs ...[]byte) ([]byte, bool, error)
 }
 
 // DataReader returns a slice of pages in the encoding/v0 format referenced by

--- a/tempodb/encoding/finder_paged.go
+++ b/tempodb/encoding/finder_paged.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/grafana/tempo/tempodb/encoding/common"
@@ -57,7 +58,10 @@ func (f *pagedFinder) Find(ctx context.Context, id common.ID) ([]byte, error) {
 			break
 		}
 
-		bytesFound, _ = f.combiner.Combine(f.dataEncoding, bytesFound, bytesOne)
+		bytesFound, _, err = f.combiner.Combine(f.dataEncoding, bytesFound, bytesOne)
+		if err != nil {
+			return nil, fmt.Errorf("failed to combine in Find: %w", err)
+		}
 
 		// we need to check the next record to see if it also matches our id
 		i++

--- a/tempodb/encoding/iterator_deduping.go
+++ b/tempodb/encoding/iterator_deduping.go
@@ -35,7 +35,7 @@ func NewDedupingIterator(iter Iterator, combiner common.ObjectCombiner, dataEnco
 	return i, nil
 }
 
-// jpe - test
+// Next implements Iterator
 func (i *dedupingIterator) Next(ctx context.Context) (common.ID, []byte, error) {
 	if i.currentID == nil {
 		return nil, nil, io.EOF
@@ -74,6 +74,7 @@ func (i *dedupingIterator) Next(ctx context.Context) (common.ID, []byte, error) 
 	return dedupedID, dedupedObject, nil
 }
 
+// Close implements Iterator
 func (i *dedupingIterator) Close() {
 	i.iter.Close()
 }

--- a/tempodb/encoding/iterator_deduping_test.go
+++ b/tempodb/encoding/iterator_deduping_test.go
@@ -6,9 +6,40 @@ import (
 	"io"
 	"testing"
 
+	"github.com/grafana/tempo/tempodb/encoding/common"
 	v2 "github.com/grafana/tempo/tempodb/encoding/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type mockIterator struct {
+	ids  []common.ID
+	objs [][]byte
+}
+
+func (i *mockIterator) Next(context.Context) (common.ID, []byte, error) {
+	if len(i.ids) == 0 {
+		return nil, nil, io.EOF
+	}
+
+	id := i.ids[0]
+	i.ids = i.ids[1:]
+	obj := i.objs[0]
+	i.objs = i.objs[1:]
+
+	return id, obj, nil
+}
+func (i *mockIterator) Close() {}
+
+type mockCombiner struct{}
+
+func (*mockCombiner) Combine(_ string, objs ...[]byte) ([]byte, bool, error) {
+	var ret []byte
+	for _, obj := range objs {
+		ret = append(ret, obj...)
+	}
+	return ret, false, nil
+}
 
 func TestEmptyNestedIterator(t *testing.T) {
 	r := bytes.NewReader([]byte{})
@@ -18,4 +49,79 @@ func TestEmptyNestedIterator(t *testing.T) {
 	assert.Nil(t, id)
 	assert.Nil(t, obj)
 	assert.Equal(t, io.EOF, err)
+}
+
+func TestDedupingIterator(t *testing.T) {
+	tests := []struct {
+		ids          []common.ID
+		objs         [][]byte
+		expectedIDs  []common.ID
+		expectedObjs [][]byte
+	}{
+		// nothing!
+		{},
+		// one object
+		{
+			ids:          []common.ID{{0x01}},
+			objs:         [][]byte{{0x01}},
+			expectedIDs:  []common.ID{{0x01}},
+			expectedObjs: [][]byte{{0x01}},
+		},
+		// two objects
+		{
+			ids:          []common.ID{{0x01}, {0x02}},
+			objs:         [][]byte{{0x01}, {0x02}},
+			expectedIDs:  []common.ID{{0x01}, {0x02}},
+			expectedObjs: [][]byte{{0x01}, {0x02}},
+		},
+		// combines stuff!
+		{
+			ids:          []common.ID{{0x01}, {0x01}},
+			objs:         [][]byte{{0x01}, {0x01}},
+			expectedIDs:  []common.ID{{0x01}},
+			expectedObjs: [][]byte{{0x01, 0x01}},
+		},
+		// combines a bunch of stuff!
+		{
+			ids:          []common.ID{{0x01}, {0x01}, {0x01}, {0x01}, {0x02}, {0x02}, {0x02}, {0x02}},
+			objs:         [][]byte{{0x01}, {0x01}, {0x01}, {0x01}, {0x02}, {0x02}, {0x02}, {0x02}},
+			expectedIDs:  []common.ID{{0x01}, {0x02}},
+			expectedObjs: [][]byte{{0x01, 0x01, 0x01, 0x01}, {0x02, 0x02, 0x02, 0x02}},
+		},
+		// only works with ordered input
+		{
+			ids:          []common.ID{{0x01}, {0x02}, {0x01}},
+			objs:         [][]byte{{0x01}, {0x02}, {0x01}},
+			expectedIDs:  []common.ID{{0x01}, {0x02}, {0x01}},
+			expectedObjs: [][]byte{{0x01}, {0x02}, {0x01}},
+		},
+		// rando
+		{
+			ids:          []common.ID{{0x01}, {0x02}, {0x02}, {0x03}, {0x03}, {0x03}, {0x04}, {0x05}},
+			objs:         [][]byte{{0x01}, {0x02}, {0x02}, {0x03}, {0x03}, {0x03}, {0x04}, {0x05}},
+			expectedIDs:  []common.ID{{0x01}, {0x02}, {0x03}, {0x04}, {0x05}},
+			expectedObjs: [][]byte{{0x01}, {0x02, 0x02}, {0x03, 0x03, 0x03}, {0x04}, {0x05}},
+		},
+	}
+
+	for _, tc := range tests {
+		iter, err := NewDedupingIterator(&mockIterator{ids: tc.ids, objs: tc.objs}, &mockCombiner{}, "")
+		require.NoError(t, err)
+
+		var actualIDs []common.ID
+		var actualObjs [][]byte
+
+		for {
+			id, obj, err := iter.Next(context.Background())
+			if err == io.EOF {
+				break
+			}
+			assert.NoError(t, err)
+			actualIDs = append(actualIDs, id)
+			actualObjs = append(actualObjs, obj)
+		}
+
+		assert.Equal(t, tc.expectedIDs, actualIDs)
+		assert.Equal(t, tc.expectedObjs, actualObjs)
+	}
 }

--- a/tempodb/encoding/iterator_multiblock.go
+++ b/tempodb/encoding/iterator_multiblock.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"fmt"
 	"io"
 
 	"github.com/go-kit/log"
@@ -115,7 +116,11 @@ func (i *multiblockIterator) iterate(ctx context.Context) {
 			comparison := bytes.Compare(currentID, lowestID)
 
 			if comparison == 0 {
-				lowestObject, _ = i.combiner.Combine(i.dataEncoding, currentObject, lowestObject)
+				lowestObject, _, err = i.combiner.Combine(i.dataEncoding, currentObject, lowestObject)
+				if err != nil {
+					i.err.Store(fmt.Errorf("error combining while Nexting: %w", err))
+					return
+				}
 				b.clear()
 			} else if len(lowestID) == 0 || comparison == -1 {
 				lowestID = currentID

--- a/tempodb/search/data_combiner.go
+++ b/tempodb/search/data_combiner.go
@@ -11,14 +11,14 @@ var _ common.ObjectCombiner = (*DataCombiner)(nil)
 
 var staticCombiner = DataCombiner{}
 
-func (*DataCombiner) Combine(_ string, searchData ...[]byte) ([]byte, bool) {
+func (*DataCombiner) Combine(_ string, searchData ...[]byte) ([]byte, bool, error) {
 
 	if len(searchData) <= 0 {
-		return nil, false
+		return nil, false, nil
 	}
 
 	if len(searchData) == 1 {
-		return searchData[0], false
+		return searchData[0], false, nil
 	}
 
 	// Squash all datas into 1
@@ -42,5 +42,5 @@ func (*DataCombiner) Combine(_ string, searchData ...[]byte) ([]byte, bool) {
 		data.TraceID = sd.Id()
 	}
 
-	return data.ToBytes(), true
+	return data.ToBytes(), true, nil
 }

--- a/tempodb/search/streaming_search_block.go
+++ b/tempodb/search/streaming_search_block.go
@@ -3,6 +3,7 @@ package search
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"sync"
@@ -76,7 +77,10 @@ func (s *StreamingSearchBlock) BlockID() uuid.UUID {
 // Append the given search data to the streaming block. Multiple byte buffers of search data for
 // the same trace can be passed and are merged into one entry.
 func (s *StreamingSearchBlock) Append(ctx context.Context, id common.ID, searchData [][]byte) error {
-	combined, _ := staticCombiner.Combine("", searchData...)
+	combined, _, err := staticCombiner.Combine("", searchData...)
+	if err != nil {
+		return fmt.Errorf("error combining: %w", err)
+	}
 
 	if len(combined) <= 0 {
 		return nil

--- a/tempodb/wal/wal_test.go
+++ b/tempodb/wal/wal_test.go
@@ -29,16 +29,16 @@ const (
 type mockCombiner struct {
 }
 
-func (m *mockCombiner) Combine(dataEncoding string, objs ...[]byte) ([]byte, bool) {
+func (m *mockCombiner) Combine(dataEncoding string, objs ...[]byte) ([]byte, bool, error) {
 	if len(objs) != 2 {
-		return nil, false
+		return nil, false, nil
 	}
 
 	if len(objs[0]) > len(objs[1]) {
-		return objs[0], true
+		return objs[0], true, nil
 	}
 
-	return objs[1], true
+	return objs[1], true, nil
 }
 
 func TestAppend(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:
- Improves combine efficiency when combining more than 2 objects with the same id by only marshalling to/from proto once
- Adds an error return from the ObjectCombiner.Combine() method and bubbles it up. (replaces #1111)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`