### PR TITLE
Compactor Memory Improvements

### DIFF
--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -3,6 +3,7 @@ package tempodb
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"math/rand"
 	"os"
 	"path"
@@ -32,8 +33,12 @@ func (m *mockSharder) Owns(hash string) bool {
 }
 
 func (m *mockSharder) Combine(dataEncoding string, objs ...[]byte) ([]byte, bool, error) {
+	if len(objs) == 1 {
+		return objs[0], false, nil
+	}
+
 	if len(objs) != 2 {
-		return nil, false, nil
+		return nil, false, fmt.Errorf("this combiner is dumb and didn't expect this")
 	}
 
 	if len(objs[0]) > len(objs[1]) {

--- a/tempodb/encoding/iterator_multiblock.go
+++ b/tempodb/encoding/iterator_multiblock.go
@@ -134,7 +134,7 @@ func (i *multiblockIterator) iterate(ctx context.Context) {
 			b.clear()
 		}
 
-		if len(lowestID) == 0 || len(lowestObjects) == 0 || len(lowestBookmarks) == 0 {
+		if len(lowestID) == 0 || len(lowestObject) == 0 || len(lowestBookmarks) == 0 {
 			// Skip empty objects or when the bookmarks failed to return an object.
 			// This intentional here because we concluded that the bookmarks have already
 			// been skipping most empties (but not all) and there is no reason to treat the

--- a/tempodb/encoding/iterator_multiblock_test.go
+++ b/tempodb/encoding/iterator_multiblock_test.go
@@ -86,7 +86,7 @@ func TestMultiblockSorts(t *testing.T) {
 	iterOdds.Add([]byte{3}, []byte{3}, nil)
 	iterOdds.Add([]byte{5}, []byte{5}, nil)
 
-	iter := NewMultiblockIterator(context.TODO(), []Iterator{iterEvens, iterOdds}, 10, nil, "", testLogger)
+	iter := NewMultiblockIterator(context.TODO(), []Iterator{iterEvens, iterOdds}, 10, &mockCombiner{}, "", testLogger)
 
 	count := 0
 	lastID := -1
@@ -137,7 +137,7 @@ func TestMultiblockIteratorCanBeCancelled(t *testing.T) {
 			ctx, cancel := context.WithCancel(ctx)
 
 			// Create iterator and cancel/close it after 100ms
-			iter := NewMultiblockIterator(ctx, []Iterator{inner}, recordCount/2, nil, "", testLogger)
+			iter := NewMultiblockIterator(ctx, []Iterator{inner}, recordCount/2, &mockCombiner{}, "", testLogger)
 			time.Sleep(100 * time.Millisecond)
 			if tc.close {
 				iter.Close()
@@ -165,7 +165,7 @@ func TestMultiblockIteratorCanBeCancelled(t *testing.T) {
 func TestMultiblockIteratorCanBeCancelledMultipleTimes(t *testing.T) {
 	inner := &testIterator{}
 
-	iter := NewMultiblockIterator(context.TODO(), []Iterator{inner}, 1, nil, "", testLogger)
+	iter := NewMultiblockIterator(context.TODO(), []Iterator{inner}, 1, &mockCombiner{}, "", testLogger)
 
 	iter.Close()
 	iter.Close()
@@ -183,7 +183,7 @@ func TestMultiblockIteratorPropogatesErrors(t *testing.T) {
 	inner2.Add([]byte{2}, []byte{2}, nil)
 	inner2.Add([]byte{3}, []byte{3}, nil)
 
-	iter := NewMultiblockIterator(ctx, []Iterator{inner, inner2}, 10, nil, "", testLogger)
+	iter := NewMultiblockIterator(ctx, []Iterator{inner, inner2}, 10, &mockCombiner{}, "", testLogger)
 
 	_, _, err := iter.Next(ctx)
 	require.NoError(t, err)
@@ -219,7 +219,7 @@ func TestMultiblockIteratorSkipsEmptyObjects(t *testing.T) {
 		{nil, nil, io.EOF},
 	}
 
-	iter := NewMultiblockIterator(ctx, []Iterator{inner}, 10, nil, "", testLogger)
+	iter := NewMultiblockIterator(ctx, []Iterator{inner}, 10, &mockCombiner{}, "", testLogger)
 	for i := 0; i < len(expected); i++ {
 		id, obj, err := iter.Next(ctx)
 		require.Equal(t, expected[i].err, err)


### PR DESCRIPTION
**What this PR does**:
- Improves memory usage 
- Possibly fixes a bug with calling `b.clear()` on bookmarks that did not represent the lowest id

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`