### PR TITLE
tempo-mixin: clear allValue so selecting All namespaces only queries Tempo namespaces

### DIFF
--- a/operations/tempo-mixin/Makefile
+++ b/operations/tempo-mixin/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all check install dashboards alerts rules
 
-all: dashboards alerts rules
+all: install dashboards alerts rules
 
 check: all
 	git diff --exit-code -- yamls/
@@ -8,11 +8,11 @@ check: all
 install:
 	jb install
 
-dashboards: install
+dashboards:
 	jsonnet -J vendor -S dashboards.jsonnet -m yamls
 
-alerts: install
+alerts:
 	jsonnet -J vendor -S alerts.jsonnet > yamls/alerts.yaml
 
-rules: install
+rules:
 	jsonnet -J vendor -S rules.jsonnet > yamls/rules.yaml

--- a/operations/tempo-mixin/dashboard-utils.libsonnet
+++ b/operations/tempo-mixin/dashboard-utils.libsonnet
@@ -7,37 +7,6 @@ grafana {
   // - some links that propagate the selected cluster.
   dashboard(title)::
     super.dashboard(title) + {
-      // Override addMultipleTempalte to make allValue configurable
-      // Remove when https://github.com/grafana/jsonnet-libs/pull/703 is merged
-      addMultiTemplate(name, metric_name, label_name, hide=0, allValue='.+'):: self {
-        templating+: {
-          list+: [{
-            allValue: allValue,
-            current: {
-              selected: true,
-              text: 'All',
-              value: '$__all',
-            },
-            datasource: '$datasource',
-            hide: hide,
-            includeAll: true,
-            label: name,
-            multi: true,
-            name: name,
-            options: [],
-            query: 'label_values(%s, %s)' % [metric_name, label_name],
-            refresh: 1,
-            regex: '',
-            sort: 2,
-            tagValuesQuery: '',
-            tags: [],
-            tagsQuery: '',
-            type: 'query',
-            useTags: false,
-          }],
-        },
-      },
-
       addClusterSelectorTemplates()::
         local d = self {
           tags: ['tempo'],

--- a/operations/tempo-mixin/dashboard-utils.libsonnet
+++ b/operations/tempo-mixin/dashboard-utils.libsonnet
@@ -7,6 +7,37 @@ grafana {
   // - some links that propagate the selected cluster.
   dashboard(title)::
     super.dashboard(title) + {
+      // Override addMultipleTempalte to make allValue configurable
+      // Remove when https://github.com/grafana/jsonnet-libs/pull/703 is merged
+      addMultiTemplate(name, metric_name, label_name, hide=0, allValue='.+'):: self {
+        templating+: {
+          list+: [{
+            allValue: allValue,
+            current: {
+              selected: true,
+              text: 'All',
+              value: '$__all',
+            },
+            datasource: '$datasource',
+            hide: hide,
+            includeAll: true,
+            label: name,
+            multi: true,
+            name: name,
+            options: [],
+            query: 'label_values(%s, %s)' % [metric_name, label_name],
+            refresh: 1,
+            regex: '',
+            sort: 2,
+            tagValuesQuery: '',
+            tags: [],
+            tagsQuery: '',
+            type: 'query',
+            useTags: false,
+          }],
+        },
+      },
+
       addClusterSelectorTemplates()::
         local d = self {
           tags: ['tempo'],
@@ -25,7 +56,7 @@ grafana {
         };
 
         d.addMultiTemplate('cluster', 'tempo_build_info', 'cluster')
-         .addMultiTemplate('namespace', 'tempo_build_info', 'namespace'),
+         .addMultiTemplate('namespace', 'tempo_build_info', 'namespace', allValue=null),
     },
 
   jobMatcher(job)::

--- a/operations/tempo-mixin/jsonnetfile.lock.json
+++ b/operations/tempo-mixin/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "c4975f7c4a7ab4c21020c4afbf247aa49142174d",
-      "sum": "y8uA/daOROErelzoo2p1rtqABhUPArg2alsfcb0PQBk="
+      "version": "84900d9dc450116ad66864f48088f92ccae36c54",
+      "sum": "0KkygBQd/AFzUvVzezE4qF/uDYgrwUXVpZfINBti0oc="
     },
     {
       "source": {
@@ -18,7 +18,7 @@
           "subdir": "mixin-utils"
         }
       },
-      "version": "c4975f7c4a7ab4c21020c4afbf247aa49142174d",
+      "version": "84900d9dc450116ad66864f48088f92ccae36c54",
       "sum": "v6fuqqQp9rHZbsxN9o79QzOpUlwYZEJ84DxTCZMCYeU="
     }
   ],

--- a/operations/tempo-mixin/vendor/github.com/grafana/jsonnet-libs/grafana-builder/grafana.libsonnet
+++ b/operations/tempo-mixin/vendor/github.com/grafana/jsonnet-libs/grafana-builder/grafana.libsonnet
@@ -13,10 +13,10 @@
       rows+: [row { panels: panels }],
     },
 
-    addTemplate(name, metric_name, label_name, hide=0):: self {
+    addTemplate(name, metric_name, label_name, hide=0, allValue=null):: self {
       templating+: {
         list+: [{
-          allValue: null,
+          allValue: allValue,
           current: {
             text: 'prod',
             value: 'prod',
@@ -41,10 +41,10 @@
       },
     },
 
-    addMultiTemplate(name, metric_name, label_name, hide=0):: self {
+    addMultiTemplate(name, metric_name, label_name, hide=0, allValue='.+'):: self {
       templating+: {
         list+: [{
-          allValue: '.+',
+          allValue: allValue,
           current: {
             selected: true,
             text: 'All',

--- a/operations/tempo-mixin/yamls/tempo-reads.json
+++ b/operations/tempo-mixin/yamls/tempo-reads.json
@@ -1623,7 +1623,7 @@
     "useTags": false
    },
    {
-    "allValue": ".+",
+    "allValue": null,
     "current": {
      "selected": true,
      "text": "All",

--- a/operations/tempo-mixin/yamls/tempo-resources.json
+++ b/operations/tempo-mixin/yamls/tempo-resources.json
@@ -1871,7 +1871,7 @@
     "useTags": false
    },
    {
-    "allValue": ".+",
+    "allValue": null,
     "current": {
      "selected": true,
      "text": "All",

--- a/operations/tempo-mixin/yamls/tempo-writes.json
+++ b/operations/tempo-mixin/yamls/tempo-writes.json
@@ -1673,7 +1673,7 @@
     "useTags": false
    },
    {
-    "allValue": ".+",
+    "allValue": null,
     "current": {
      "selected": true,
      "text": "All",


### PR DESCRIPTION
**What this PR does**:

~~This is a temporary patch until https://github.com/grafana/jsonnet-libs/pull/703 is merged.~~ Update the grafana-builder jsonnet library to include https://github.com/grafana/jsonnet-libs/pull/703
More details can be found in that issue as well.

> This dropdown is populated with the namespaces a Tempo cluster is running in. The current behaviour (with allValue: '.+') is confusing, because selecting All in the dropdown ends up querying all namespaces.
The previous behaviour (with allValue: null) only queries the namespaces that are returned by the query.
>
> The reason we got confused is that in our dashboard you can select a cluster and if you know there is only 1 Tempo namespace in that cluster you kind of expect to only see data from that namespace. But with allValue: '.+' you get data from all the namespaces in that cluster. So we were mistakenly looking at queriers from a non-Tempo cluster and wondering why CPU was so high.
