### PR TITLE
Compaction load metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * [ENHANCEMENT] Add Envoy Proxy panel to `Tempo / Writes` dashboard [#1137](https://github.com/grafana/tempo/pull/1137) (@kvrhdn)
 * [ENHANCEMENT] Reduce compactionCycle to improve performance in large multitenant environments [#1145](https://github.com/grafana/tempo/pull/1145) (@joe-elliott)
 * [ENHANCEMENT] Added max_compaction_cycle to allow for independently configuring polling and compaction cycle. [#1145](https://github.com/grafana/tempo/pull/1145) (@joe-elliott)
-* [ENHANCEMENT] Add `tempodb_compaction_load` metric to measure compaction load [#1143](https://github.com/grafana/tempo/pull/1143) (@mapno)
+* [ENHANCEMENT] Add `tempodb_compaction_outstanding_jobs` metric to measure compaction load [#1143](https://github.com/grafana/tempo/pull/1143) (@mapno)
 * [BUGFIX] Fix defaults for MaxBytesPerTrace (ingester.max-bytes-per-trace) and MaxSearchBytesPerTrace (ingester.max-search-bytes-per-trace) (@bitprocessor)
 * [BUGFIX] Ignore empty objects during compaction [#1113](https://github.com/grafana/tempo/pull/1113) (@mdisibio)
 * [BUGFIX] Add process name to vulture traces to work around display issues [#1127](https://github.com/grafana/tempo/pull/1127) (@mdisibio)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * [ENHANCEMENT] Add Envoy Proxy panel to `Tempo / Writes` dashboard [#1137](https://github.com/grafana/tempo/pull/1137) (@kvrhdn)
 * [ENHANCEMENT] Reduce compactionCycle to improve performance in large multitenant environments [#1145](https://github.com/grafana/tempo/pull/1145) (@joe-elliott)
 * [ENHANCEMENT] Added max_compaction_cycle to allow for independently configuring polling and compaction cycle. [#1145](https://github.com/grafana/tempo/pull/1145) (@joe-elliott)
-* [ENHANCEMENT] Add `tempodb_compaction_outstanding_jobs` metric to measure compaction load [#1143](https://github.com/grafana/tempo/pull/1143) (@mapno)
+* [ENHANCEMENT] Add `tempodb_compaction_outstanding_blocks` metric to measure compaction load [#1143](https://github.com/grafana/tempo/pull/1143) (@mapno)
 * [BUGFIX] Fix defaults for MaxBytesPerTrace (ingester.max-bytes-per-trace) and MaxSearchBytesPerTrace (ingester.max-search-bytes-per-trace) (@bitprocessor)
 * [BUGFIX] Ignore empty objects during compaction [#1113](https://github.com/grafana/tempo/pull/1113) (@mdisibio)
 * [BUGFIX] Add process name to vulture traces to work around display issues [#1127](https://github.com/grafana/tempo/pull/1127) (@mdisibio)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [ENHANCEMENT] Add Envoy Proxy panel to `Tempo / Writes` dashboard [#1137](https://github.com/grafana/tempo/pull/1137) (@kvrhdn)
 * [ENHANCEMENT] Reduce compactionCycle to improve performance in large multitenant environments [#1145](https://github.com/grafana/tempo/pull/1145) (@joe-elliott)
 * [ENHANCEMENT] Added max_compaction_cycle to allow for independently configuring polling and compaction cycle. [#1145](https://github.com/grafana/tempo/pull/1145) (@joe-elliott)
+* [ENHANCEMENT] Add `tempodb_compaction_load` metric to measure compaction load [#1143](https://github.com/grafana/tempo/pull/1143) (@mapno)
 * [BUGFIX] Fix defaults for MaxBytesPerTrace (ingester.max-bytes-per-trace) and MaxSearchBytesPerTrace (ingester.max-search-bytes-per-trace) (@bitprocessor)
 * [BUGFIX] Ignore empty objects during compaction [#1113](https://github.com/grafana/tempo/pull/1113) (@mdisibio)
 * [BUGFIX] Add process name to vulture traces to work around display issues [#1127](https://github.com/grafana/tempo/pull/1127) (@mdisibio)

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -46,6 +46,11 @@ var (
 		Name:      "compaction_objects_combined_total",
 		Help:      "Total number of objects combined during compaction.",
 	}, []string{"level"})
+	metricCompactionLoad = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "tempodb",
+		Name:      "compaction_load",
+		Help:      "Number of blocks to be compacted in the latest compaction cycle",
+	})
 )
 
 const (
@@ -93,6 +98,8 @@ func (rw *readerWriter) doCompaction() {
 	level.Info(rw.logger).Log("msg", "starting compaction cycle", "tenantID", tenantID, "offset", rw.compactorTenantOffset)
 	for {
 		toBeCompacted, hashString := blockSelector.BlocksToCompact()
+		metricCompactionLoad.Set(float64(len(toBeCompacted)))
+
 		if len(toBeCompacted) == 0 {
 			level.Info(rw.logger).Log("msg", "compaction cycle complete. No more blocks to compact", "tenantID", tenantID)
 			break

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -325,9 +325,7 @@ func measureOutstandingBlocks(tenantID string, blockSelector CompactionBlockSele
 		if len(leftToBeCompacted) == 0 {
 			break
 		}
-		for range leftToBeCompacted {
-			totalOutstandingBlocks++
-		}
+		totalOutstandingBlocks += len(leftToBeCompacted)
 	}
 	metricCompactionOutstandingBlocks.WithLabelValues(tenantID).Set(float64(totalOutstandingBlocks))
 }

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -118,7 +118,7 @@ func (rw *readerWriter) doCompaction() {
 
 		// after a maintenance cycle bail out
 		if start.Add(rw.cfg.MaxCompactionCycle).Before(time.Now()) {
-			// count number of oustanding compaction jobs remaining before next maintenance cycle
+			// count number of outstanding compaction jobs remaining before next maintenance cycle
 			for {
 				leftToBeCompacted, _ := blockSelector.BlocksToCompact()
 				if len(leftToBeCompacted) == 0 {

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -46,10 +46,10 @@ var (
 		Name:      "compaction_objects_combined_total",
 		Help:      "Total number of objects combined during compaction.",
 	}, []string{"level"})
-	metricCompactionOutstandingJobs = promauto.NewCounterVec(prometheus.CounterOpts{
+	metricCompactionOutstandingBlocks = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "tempodb",
-		Name:      "compaction_outstanding_jobs",
-		Help:      "Number of outstanding compaction jobs remaining before next maintenance cycle",
+		Name:      "compaction_outstanding_blocks",
+		Help:      "Number of blocks remaining to be compacted before next maintenance cycle",
 	}, []string{"tenant"})
 )
 
@@ -118,14 +118,14 @@ func (rw *readerWriter) doCompaction() {
 
 		// after a maintenance cycle bail out
 		if start.Add(rw.cfg.MaxCompactionCycle).Before(time.Now()) {
-			// count number of outstanding compaction jobs remaining before next maintenance cycle
+			// count number of outstanding blocks remaining before next maintenance cycle
 			for {
 				leftToBeCompacted, _ := blockSelector.BlocksToCompact()
 				if len(leftToBeCompacted) == 0 {
 					break
 				}
 				for _, block := range leftToBeCompacted {
-					metricCompactionOutstandingJobs.WithLabelValues(block.TenantID).Inc()
+					metricCompactionOutstandingBlocks.WithLabelValues(block.TenantID).Inc()
 				}
 			}
 


### PR DESCRIPTION
**What this PR does**:

Adds new metric to measure compaction load. It counts the number of blocks that are yet to be compacted before the next maintenance cycle. It's higher, the greater the compaction load is.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`