### PR TITLE
Allow environment variables for Azure storage credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [ENHANCEMENT] Update mixin to use new backend metric [#1151](https://github.com/grafana/tempo/pull/1151) (@zalegrala)
 * [ENHANCEMENT] Make `TempoIngesterFlushesFailing` alert more actionable [#1157](https://github.com/grafana/tempo/pull/1157) (@dannykopping)
 * [ENHANCEMENT] Switch open-telemetry/opentelemetry-collector to grafana/opentelemetry-collectorl fork, update it to 0.40.0 and add missing dependencies due to the change (@tete17)
+* [ENHANCEMENT] Allow environment variables for Azure storage credentials [#1147](https://github.com/grafana/tempo/pull/1147) (@zalegrala)
 * [BUGFIX] Fix defaults for MaxBytesPerTrace (ingester.max-bytes-per-trace) and MaxSearchBytesPerTrace (ingester.max-search-bytes-per-trace) (@bitprocessor)
 * [BUGFIX] Ignore empty objects during compaction [#1113](https://github.com/grafana/tempo/pull/1113) (@mdisibio)
 * [BUGFIX] Add process name to vulture traces to work around display issues [#1127](https://github.com/grafana/tempo/pull/1127) (@mdisibio)

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -291,6 +291,7 @@ The storage block is used to configure TempoDB. It supports S3, GCS, Azure, loca
 The following example shows common options.  For further platform-specific information refer to the following:
 * [GCS](gcs/)
 * [S3](s3/)
+* [Azure](azure/)
 
 ```yaml
 # Storage configuration for traces

--- a/docs/tempo/website/configuration/azure.md
+++ b/docs/tempo/website/configuration/azure.md
@@ -1,0 +1,87 @@
+---
+title: Azure Permissions and Management
+weight: 3
+---
+
+# Azure Blob Storage Permissions and Management
+
+In order for Tempo to authenticate to Azure blob storage, the following is
+required to access the container.
+
+* Storage account
+* Storage account access key
+* Storage account management policy
+
+The `AZURE_STORAGE_ACCOUNT` and `AZURE_STORAGE_KEY` environment variables can
+be used instead of setting the credentials in the Tempo configuration file.
+
+The following storage account management policy shows an example of cleaning up
+files from the container after they have been deleted for a period of time.
+
+```json
+{
+  "id": "/subscriptions/00000000-0000-0000000000000000000000/resourceGroups/resourceGroupName/providers/Microsoft.Storage/storageAccounts/accountName/managementPolicies/default",
+  "lastModifiedTime": "2021-11-30T19:19:54.855455+00:00",
+  "name": "DefaultManagementPolicy",
+  "policy": {
+    "rules": [
+      {
+        "definition": {
+          "actions": {
+            "baseBlob": {
+              "delete": {
+                "daysAfterLastAccessTimeGreaterThan": null,
+                "daysAfterModificationGreaterThan": 60.0
+              },
+              "enableAutoTierToHotFromCool": null,
+              "tierToArchive": null,
+              "tierToCool": null
+            },
+            "snapshot": null,
+            "version": null
+          },
+          "filters": {
+            "blobIndexMatch": null,
+            "blobTypes": [
+              "blockBlob"
+            ],
+            "prefixMatch": [
+              "tempo-data"
+            ]
+          }
+        },
+        "enabled": true,
+        "name": "TempoBlobRetention",
+        "type": "Lifecycle"
+      },
+      {
+        "definition": {
+          "actions": {
+            "baseBlob": null,
+            "snapshot": null,
+            "version": {
+              "delete": {
+                "daysAfterCreationGreaterThan": 7.0
+              },
+              "tierToArchive": null,
+              "tierToCool": null
+            }
+          },
+          "filters": {
+            "blobIndexMatch": null,
+            "blobTypes": [
+              "blockBlob"
+            ],
+            "prefixMatch": []
+          }
+        },
+        "enabled": true,
+        "name": "VersionRetention",
+        "type": "Lifecycle"
+      }
+    ]
+  },
+  "resourceGroup": "resource-group-name",
+  "type": "Microsoft.Storage/storageAccounts/managementPolicies"
+}
+```

--- a/modules/storage/config.go
+++ b/modules/storage/config.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"flag"
+	"os"
 
 	cortex_cache "github.com/cortexproject/cortex/pkg/chunk/cache"
 
@@ -47,8 +48,8 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.Trace.Block.SearchPageSizeBytes = 1024 * 1024 // 1 MB
 
 	cfg.Trace.Azure = &azure.Config{}
-	f.StringVar(&cfg.Trace.Azure.StorageAccountName.Value, util.PrefixConfig(prefix, "trace.azure.storage-account-name"), "", "Azure storage account name.")
-	f.StringVar(&cfg.Trace.Azure.StorageAccountKey.Value, util.PrefixConfig(prefix, "trace.azure.storage-account-key"), "", "Azure storage access key.")
+	f.StringVar(&cfg.Trace.Azure.StorageAccountName.Value, util.PrefixConfig(prefix, "trace.azure.storage-account-name"), os.Getenv("AZURE_STORAGE_ACCOUNT"), "Azure storage account name.")
+	f.StringVar(&cfg.Trace.Azure.StorageAccountKey.Value, util.PrefixConfig(prefix, "trace.azure.storage-account-key"), os.Getenv("AZURE_STORAGE_KEY"), "Azure storage access key.")
 	f.StringVar(&cfg.Trace.Azure.ContainerName, util.PrefixConfig(prefix, "trace.azure.container-name"), "", "Azure container name to store blocks in.")
 	f.StringVar(&cfg.Trace.Azure.Endpoint, util.PrefixConfig(prefix, "trace.azure.endpoint"), "blob.core.windows.net", "Azure endpoint to push blocks to.")
 	f.IntVar(&cfg.Trace.Azure.MaxBuffers, util.PrefixConfig(prefix, "trace.azure.max-buffers"), 4, "Number of simultaneous uploads.")

--- a/modules/storage/config.go
+++ b/modules/storage/config.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"flag"
-	"os"
 
 	cortex_cache "github.com/cortexproject/cortex/pkg/chunk/cache"
 
@@ -48,8 +47,8 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.Trace.Block.SearchPageSizeBytes = 1024 * 1024 // 1 MB
 
 	cfg.Trace.Azure = &azure.Config{}
-	f.StringVar(&cfg.Trace.Azure.StorageAccountName.Value, util.PrefixConfig(prefix, "trace.azure.storage-account-name"), os.Getenv("AZURE_STORAGE_ACCOUNT"), "Azure storage account name.")
-	f.StringVar(&cfg.Trace.Azure.StorageAccountKey.Value, util.PrefixConfig(prefix, "trace.azure.storage-account-key"), os.Getenv("AZURE_STORAGE_KEY"), "Azure storage access key.")
+	f.StringVar(&cfg.Trace.Azure.StorageAccountName.Value, util.PrefixConfig(prefix, "trace.azure.storage-account-name"), "", "Azure storage account name.")
+	f.StringVar(&cfg.Trace.Azure.StorageAccountKey.Value, util.PrefixConfig(prefix, "trace.azure.storage-account-key"), "", "Azure storage access key.")
 	f.StringVar(&cfg.Trace.Azure.ContainerName, util.PrefixConfig(prefix, "trace.azure.container-name"), "", "Azure container name to store blocks in.")
 	f.StringVar(&cfg.Trace.Azure.Endpoint, util.PrefixConfig(prefix, "trace.azure.endpoint"), "blob.core.windows.net", "Azure endpoint to push blocks to.")
 	f.IntVar(&cfg.Trace.Azure.MaxBuffers, util.PrefixConfig(prefix, "trace.azure.max-buffers"), 4, "Number of simultaneous uploads.")

--- a/tempodb/backend/azure/azure_helpers.go
+++ b/tempodb/backend/azure/azure_helpers.go
@@ -32,10 +32,6 @@ func GetContainerURL(ctx context.Context, cfg *Config, hedge bool) (blob.Contain
 		accountKey = os.Getenv("AZURE_STORAGE_KEY")
 	}
 
-	if accountKey == "" || accountName == "" {
-		return blob.ContainerURL{}, fmt.Errorf("unable to get storage container URL with incomplete credentials")
-	}
-
 	c, err := blob.NewSharedKeyCredential(accountName, accountKey)
 	if err != nil {
 		return blob.ContainerURL{}, err

--- a/tempodb/backend/azure/azure_helpers.go
+++ b/tempodb/backend/azure/azure_helpers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -20,7 +21,18 @@ const (
 )
 
 func GetContainerURL(ctx context.Context, cfg *Config, hedge bool) (blob.ContainerURL, error) {
-	c, err := blob.NewSharedKeyCredential(cfg.StorageAccountName.String(), cfg.StorageAccountKey.String())
+	accountName := cfg.StorageAccountName.String()
+	accountKey := cfg.StorageAccountKey.String()
+
+	if accountName == "" {
+		accountName = os.Getenv("AZURE_STORAGE_ACCOUNT")
+	}
+
+	if accountKey == "" {
+		accountKey = os.Getenv("AZURE_STORAGE_KEY")
+	}
+
+	c, err := blob.NewSharedKeyCredential(accountName, accountKey)
 	if err != nil {
 		return blob.ContainerURL{}, err
 	}

--- a/tempodb/backend/azure/azure_helpers.go
+++ b/tempodb/backend/azure/azure_helpers.go
@@ -32,6 +32,10 @@ func GetContainerURL(ctx context.Context, cfg *Config, hedge bool) (blob.Contain
 		accountKey = os.Getenv("AZURE_STORAGE_KEY")
 	}
 
+	if accountKey == "" || accountName == "" {
+		return blob.ContainerURL{}, fmt.Errorf("unable to get storage container URL with incomplete credentials")
+	}
+
 	c, err := blob.NewSharedKeyCredential(accountName, accountKey)
 	if err != nil {
 		return blob.ContainerURL{}, err
@@ -75,12 +79,12 @@ func GetContainerURL(ctx context.Context, cfg *Config, hedge bool) (blob.Contain
 		HTTPSender: httpSender,
 	})
 
-	u, err := url.Parse(fmt.Sprintf("https://%s.%s", cfg.StorageAccountName, cfg.Endpoint))
+	u, err := url.Parse(fmt.Sprintf("https://%s.%s", accountName, cfg.Endpoint))
 
 	// If the endpoint doesn't start with blob.core we can assume Azurite is being used
 	// So the endpoint should follow Azurite URL style
 	if !strings.HasPrefix(cfg.Endpoint, "blob.core") {
-		u, err = url.Parse(fmt.Sprintf("http://%s/%s", cfg.Endpoint, cfg.StorageAccountName))
+		u, err = url.Parse(fmt.Sprintf("http://%s/%s", cfg.Endpoint, accountName))
 	}
 
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Allow default values for Azure storage to be pulled from the environment.
Update examples and operations to use the newer backend-agnostic metric name.

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`