### PR TITLE
Pin version of tanka used in CI, update kube-manifests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Install jsonnet, jsonnet-bundler & tanka
         run: |
-          brew install jsonnet tanka@0.19.0
+          brew install jsonnet tanka@0.19
           go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0
 
       - name: Check out code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,8 @@ jobs:
 
       - name: Install jsonnet, jsonnet-bundler & tanka
         run: |
-          curl -fSL -o /usr/local/bin/jsonnet.tar.gz https://github.com/google/jsonnet/releases/download/v0.17.0/jsonnet-bin-v0.17.0-linux.tar.gz
-          tar -xvf jsonnet.tar.gz
+          curl -fSL -o jsonnet.tar.gz https://github.com/google/jsonnet/releases/download/v0.17.0/jsonnet-bin-v0.17.0-linux.tar.gz
+          tar -xvf jsonnet.tar.gz -C /usr/local/bin/
           chmod a+x /usr/local/bin/jsonnet
           
           go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Install jsonnet, jsonnet-bundler & tanka
         run: |
-          brew install jsonnet tanka
+          brew install jsonnet tanka@v0.19.0
           go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0
 
       - name: Check out code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,11 @@ jobs:
 
       - name: Install jsonnet, jsonnet-bundler & tanka
         run: |
-          brew install jsonnet tanka@0.19
+          # download formula for Jsonnet v0.17.0 and Tanka v0.19.0
+          curl https://raw.githubusercontent.com/Homebrew/homebrew-core/628aed8b9e1e0d95a834615a9ee57c20bf4b6e5d/Formula/jsonnet.rb --output jsonnet.rb
+          curl https://raw.githubusercontent.com/Homebrew/homebrew-core/628aed8b9e1e0d95a834615a9ee57c20bf4b6e5d/Formula/tanka.rb --output tanka.rb
+          brew install --formula ./jsonnet.rb ./tanka.rb
+          
           go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0
 
       - name: Check out code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,12 +109,14 @@ jobs:
 
       - name: Install jsonnet, jsonnet-bundler & tanka
         run: |
-          # download formula for Jsonnet v0.17.0 and Tanka v0.19.0
-          curl https://raw.githubusercontent.com/Homebrew/homebrew-core/628aed8b9e1e0d95a834615a9ee57c20bf4b6e5d/Formula/jsonnet.rb --output jsonnet.rb
-          curl https://raw.githubusercontent.com/Homebrew/homebrew-core/628aed8b9e1e0d95a834615a9ee57c20bf4b6e5d/Formula/tanka.rb --output tanka.rb
-          brew install --formula ./jsonnet.rb ./tanka.rb
+          curl -fSL -o /usr/local/bin/jsonnet.tar.gz https://github.com/google/jsonnet/releases/download/v0.17.0/jsonnet-bin-v0.17.0-linux.tar.gz
+          tar -xvf jsonnet.tar.gz
+          chmod a+x /usr/local/bin/jsonnet
           
           go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0
+
+          curl -fSL -o /usr/local/bin/tk https://github.com/grafana/tanka/releases/download/v0.19.0/tk-linux-amd64
+          chmod a+x /usr/local/bin/tk
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Install jsonnet, jsonnet-bundler & tanka
         run: |
-          brew install jsonnet tanka@v0.19.0
+          brew install jsonnet tanka@0.19.0
           go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0
 
       - name: Check out code

--- a/operations/kube-manifests/ConfigMap-tempo-compactor.yaml
+++ b/operations/kube-manifests/ConfigMap-tempo-compactor.yaml
@@ -18,7 +18,7 @@ data:
         abort_if_cluster_join_fails: false
         bind_port: 7946
         join_members:
-          - gossip-ring.tracing.svc.cluster.local:7946
+            - gossip-ring.tracing.svc.cluster.local:7946
     overrides:
         per_tenant_override_config: /overrides/overrides.yaml
     search_enabled: false

--- a/operations/kube-manifests/ConfigMap-tempo-distributor.yaml
+++ b/operations/kube-manifests/ConfigMap-tempo-distributor.yaml
@@ -21,7 +21,7 @@ data:
         abort_if_cluster_join_fails: false
         bind_port: 7946
         join_members:
-          - gossip-ring.tracing.svc.cluster.local:7946
+            - gossip-ring.tracing.svc.cluster.local:7946
     overrides:
         per_tenant_override_config: /overrides/overrides.yaml
     search_enabled: false

--- a/operations/kube-manifests/ConfigMap-tempo-ingester.yaml
+++ b/operations/kube-manifests/ConfigMap-tempo-ingester.yaml
@@ -12,7 +12,7 @@ data:
         abort_if_cluster_join_fails: false
         bind_port: 7946
         join_members:
-          - gossip-ring.tracing.svc.cluster.local:7946
+            - gossip-ring.tracing.svc.cluster.local:7946
     overrides:
         per_tenant_override_config: /overrides/overrides.yaml
     search_enabled: false

--- a/operations/kube-manifests/ConfigMap-tempo-querier.yaml
+++ b/operations/kube-manifests/ConfigMap-tempo-querier.yaml
@@ -12,7 +12,7 @@ data:
         abort_if_cluster_join_fails: false
         bind_port: 7946
         join_members:
-          - gossip-ring.tracing.svc.cluster.local:7946
+            - gossip-ring.tracing.svc.cluster.local:7946
     overrides:
         per_tenant_override_config: /overrides/overrides.yaml
     querier:

--- a/operations/kube-manifests/ConfigMap-tempo-query-frontend.yaml
+++ b/operations/kube-manifests/ConfigMap-tempo-query-frontend.yaml
@@ -12,7 +12,7 @@ data:
         abort_if_cluster_join_fails: false
         bind_port: 7946
         join_members:
-          - gossip-ring.tracing.svc.cluster.local:7946
+            - gossip-ring.tracing.svc.cluster.local:7946
     overrides:
         per_tenant_override_config: /overrides/overrides.yaml
     search_enabled: false

--- a/operations/kube-manifests/Deployment-compactor.yaml
+++ b/operations/kube-manifests/Deployment-compactor.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        config_hash: 032f910723ddd3da0551644ee2db68c1
+        config_hash: abfd77a19b6b815eb65e02b71c2f393b
       labels:
         app: compactor
         name: compactor

--- a/operations/kube-manifests/Deployment-distributor.yaml
+++ b/operations/kube-manifests/Deployment-distributor.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        config_hash: cbac2ba3a3dacc4cff00935d6e309cc8
+        config_hash: ffc07a671ffa7524e2d82dfbbc5515cb
       labels:
         app: distributor
         name: distributor

--- a/operations/kube-manifests/Deployment-querier.yaml
+++ b/operations/kube-manifests/Deployment-querier.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        config_hash: aaa069186e50a272903a5e0e38de02c3
+        config_hash: 73a2c6511fc19b5ceabb53d8a80a4400
       labels:
         app: querier
         name: querier

--- a/operations/kube-manifests/Deployment-query-frontend.yaml
+++ b/operations/kube-manifests/Deployment-query-frontend.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        config_hash: fbe5395186d4d543947100523de19ad2
+        config_hash: 51dafa410364d46a0bdfd0d5922c2039
       labels:
         app: query-frontend
         name: query-frontend

--- a/operations/kube-manifests/StatefulSet-ingester.yaml
+++ b/operations/kube-manifests/StatefulSet-ingester.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        config_hash: fbe5395186d4d543947100523de19ad2
+        config_hash: 51dafa410364d46a0bdfd0d5922c2039
       labels:
         app: ingester
         name: ingester

--- a/operations/kube-manifests/util/jsonnetfile.lock.json
+++ b/operations/kube-manifests/util/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "71640f24289af8deca742763feec3c0dbd22b7ae",
+      "version": "ad31de265551c5577fed96d4f5a8b818027a2d85",
       "sum": "fFVlCoa/N0qiqTbDhZAEdRm2Vv76Z9Clxp3/haJ+PyA="
     },
     {
@@ -18,7 +18,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "71640f24289af8deca742763feec3c0dbd22b7ae",
+      "version": "ad31de265551c5577fed96d4f5a8b818027a2d85",
       "sum": "dTOeEux3t9bYSqP2L/uCuLo/wUDpCKH4w+4OD9fePUk="
     },
     {


### PR DESCRIPTION
**What this PR does**:
CI has been failing since Tanka has released v0.19: https://github.com/grafana/tanka/blob/main/CHANGELOG.md#0190-2021-11-22
This pins the version to 0.19 and updates the kube-manifests.
