### PR TITLE
Fix location of max compaction parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * [ENHANCEMENT] Include metrics for configured limit overrides and defaults: tempo_limits_overrides, tempo_limits_defaults [#1089](https://github.com/grafana/tempo/pull/1089) (@zalegrala)
 * [ENHANCEMENT] Add Envoy Proxy panel to `Tempo / Writes` dashboard [#1137](https://github.com/grafana/tempo/pull/1137) (@kvrhdn)
 * [ENHANCEMENT] Reduce compactionCycle to improve performance in large multitenant environments [#1145](https://github.com/grafana/tempo/pull/1145) (@joe-elliott)
-* [ENHANCEMENT] Added max_compaction_cycle to allow for independently configuring polling and compaction cycle. [#1145](https://github.com/grafana/tempo/pull/1145) (@joe-elliott)
+* [ENHANCEMENT] Added max_time_per_tenant to allow for independently configuring polling and compaction cycle. [#1145](https://github.com/grafana/tempo/pull/1145) (@joe-elliott)
 * [ENHANCEMENT] Add `tempodb_compaction_outstanding_blocks` metric to measure compaction load [#1143](https://github.com/grafana/tempo/pull/1143) (@mapno)
 * [BUGFIX] Fix defaults for MaxBytesPerTrace (ingester.max-bytes-per-trace) and MaxSearchBytesPerTrace (ingester.max-search-bytes-per-trace) (@bitprocessor)
 * [BUGFIX] Ignore empty objects during compaction [#1113](https://github.com/grafana/tempo/pull/1113) (@mdisibio)

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -278,6 +278,9 @@ compactor:
 
         # Optional. Number of traces to buffer in memory during compaction. Increasing may improve performance but will also increase memory usage. Default is 1000.
         [iterator_buffer_size: <int>]
+
+        # Optional. The maximum amount of time to spend compacting a single tenant before moving to the next. Default is 5m.
+        [max_time_per_tenant: <duration>] 
 ```
 
 ## Storage
@@ -437,10 +440,6 @@ storage:
         # the bucket contents.
         # Default 0 (disabled).
         [blocklist_poll_stale_tenant_index: <duration>]
-
-        # The maximum amount of time to spend compacting a single tenant before moving to the next.
-        # Default is 5m.
-        [max_compaction_cycle: <duration>] 
 
         # Cache type to use. Should be one of "redis", "memcached"
         # Example: "cache: memcached"

--- a/docs/tempo/website/configuration/manifest.md
+++ b/docs/tempo/website/configuration/manifest.md
@@ -238,6 +238,7 @@ compactor:
     compacted_block_retention: 1h0m0s
     retention_concurrency: 10
     iterator_buffer_size: 1000
+    max_time_per_tenant: 5m0s
   override_ring_key: compactor
 ingester:
   lifecycler:
@@ -321,7 +322,6 @@ storage:
     blocklist_poll_fallback: true
     blocklist_poll_tenant_index_builders: 2
     blocklist_poll_stale_tenant_index: 0s
-    max_compaction_cycle: 5m0s
     backend: local
     local:
       path: /tmp/tempo/traces

--- a/docs/tempo/website/configuration/polling.md
+++ b/docs/tempo/website/configuration/polling.md
@@ -30,10 +30,6 @@ storage:
         # the bucket contents.
         # Default 0 (disabled).
         [blocklist_poll_stale_tenant_index: <duration>]
-
-        # The maximum amount of time to spend compacting a single tenant before moving to the next.
-        # Default is 5m.
-        [max_compaction_cycle: <duration>]
 ```
 
 Due to the mechanics of the [tenant index]({{< relref "../operations/polling" >}}) the blocklist will be stale by

--- a/modules/compactor/config.go
+++ b/modules/compactor/config.go
@@ -25,6 +25,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 		CompactedBlockRetention: time.Hour,
 		RetentionConcurrency:    tempodb.DefaultRetentionConcurrency,
 		IteratorBufferSize:      tempodb.DefaultIteratorBufferSize,
+		MaxCompactionCycle:      tempodb.DefaultMaxCompactionCycle,
 	}
 
 	flagext.DefaultValues(&cfg.ShardingRing)

--- a/modules/compactor/config.go
+++ b/modules/compactor/config.go
@@ -25,7 +25,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 		CompactedBlockRetention: time.Hour,
 		RetentionConcurrency:    tempodb.DefaultRetentionConcurrency,
 		IteratorBufferSize:      tempodb.DefaultIteratorBufferSize,
-		MaxCompactionCycle:      tempodb.DefaultMaxCompactionCycle,
+		MaxTimePerTenant:        tempodb.DefaultMaxCompactionCycle,
 	}
 
 	flagext.DefaultValues(&cfg.ShardingRing)

--- a/modules/compactor/config.go
+++ b/modules/compactor/config.go
@@ -25,7 +25,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 		CompactedBlockRetention: time.Hour,
 		RetentionConcurrency:    tempodb.DefaultRetentionConcurrency,
 		IteratorBufferSize:      tempodb.DefaultIteratorBufferSize,
-		MaxTimePerTenant:        tempodb.DefaultMaxCompactionCycle,
+		MaxTimePerTenant:        tempodb.DefaultMaxTimePerTenant,
 	}
 
 	flagext.DefaultValues(&cfg.ShardingRing)

--- a/modules/storage/config.go
+++ b/modules/storage/config.go
@@ -28,7 +28,6 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.Trace.BlocklistPollFallback = true
 	cfg.Trace.BlocklistPollConcurrency = tempodb.DefaultBlocklistPollConcurrency
 	cfg.Trace.BlocklistPollTenantIndexBuilders = tempodb.DefaultTenantIndexBuilders
-	cfg.Trace.MaxCompactionCycle = tempodb.DefaultMaxCompactionCycle
 
 	f.StringVar(&cfg.Trace.Backend, util.PrefixConfig(prefix, "trace.backend"), "", "Trace backend (s3, azure, gcs, local)")
 	f.DurationVar(&cfg.Trace.BlocklistPoll, util.PrefixConfig(prefix, "trace.blocklist_poll"), tempodb.DefaultBlocklistPoll, "Period at which to run the maintenance cycle.")

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -119,7 +119,7 @@ func (rw *readerWriter) doCompaction() {
 		}
 
 		// after a maintenance cycle bail out
-		if start.Add(rw.cfg.MaxCompactionCycle).Before(time.Now()) {
+		if start.Add(rw.compactorCfg.MaxCompactionCycle).Before(time.Now()) {
 			measureOutstandingBlocks(tenantID, blockSelector)
 
 			level.Info(rw.logger).Log("msg", "compacted blocks for a maintenance cycle, bailing out", "tenantID", tenantID)

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -119,7 +119,7 @@ func (rw *readerWriter) doCompaction() {
 		}
 
 		// after a maintenance cycle bail out
-		if start.Add(rw.compactorCfg.MaxCompactionCycle).Before(time.Now()) {
+		if start.Add(rw.compactorCfg.MaxTimePerTenant).Before(time.Now()) {
 			measureOutstandingBlocks(tenantID, blockSelector)
 
 			level.Info(rw.logger).Log("msg", "compacted blocks for a maintenance cycle, bailing out", "tenantID", tenantID)

--- a/tempodb/config.go
+++ b/tempodb/config.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	DefaultBlocklistPoll            = 5 * time.Minute
-	DefaultMaxCompactionCycle       = 5 * time.Minute
+	DefaultMaxTimePerTenant         = 5 * time.Minute
 	DefaultBlocklistPollConcurrency = uint(50)
 	DefaultRetentionConcurrency     = uint(10)
 	DefaultTenantIndexBuilders      = 2
@@ -65,7 +65,7 @@ type CompactorConfig struct {
 	CompactedBlockRetention time.Duration `yaml:"compacted_block_retention"`
 	RetentionConcurrency    uint          `yaml:"retention_concurrency"`
 	IteratorBufferSize      int           `yaml:"iterator_buffer_size"`
-	MaxCompactionCycle      time.Duration `yaml:"max_time_per_tenant"`
+	MaxTimePerTenant        time.Duration `yaml:"max_time_per_tenant"`
 }
 
 func validateConfig(cfg *Config) error {

--- a/tempodb/config.go
+++ b/tempodb/config.go
@@ -37,7 +37,6 @@ type Config struct {
 	BlocklistPollFallback            bool          `yaml:"blocklist_poll_fallback"`
 	BlocklistPollTenantIndexBuilders int           `yaml:"blocklist_poll_tenant_index_builders"`
 	BlocklistPollStaleTenantIndex    time.Duration `yaml:"blocklist_poll_stale_tenant_index"`
-	MaxCompactionCycle               time.Duration `yaml:"max_compaction_cycle"`
 
 	// backends
 	Backend string        `yaml:"backend"`
@@ -66,6 +65,7 @@ type CompactorConfig struct {
 	CompactedBlockRetention time.Duration `yaml:"compacted_block_retention"`
 	RetentionConcurrency    uint          `yaml:"retention_concurrency"`
 	IteratorBufferSize      int           `yaml:"iterator_buffer_size"`
+	MaxCompactionCycle      time.Duration `yaml:"max_time_per_tenant"`
 }
 
 func validateConfig(cfg *Config) error {


### PR DESCRIPTION
**What this PR does**:
- Moves the max_compaction_cycle parameter to the appropriate config block
- Renames it to be more descriptive `max_time_per_tenant`

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`