### PR TITLE
jsonnet: set rollingUpdate.maxSurge to 3 for distributor, frontend and queriers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [ENHANCEMENT] Make `TempoIngesterFlushesFailing` alert more actionable [#1157](https://github.com/grafana/tempo/pull/1157) (@dannykopping)
 * [ENHANCEMENT] Switch open-telemetry/opentelemetry-collector to grafana/opentelemetry-collectorl fork, update it to 0.40.0 and add missing dependencies due to the change [#1142](https://github.com/grafana/tempo/pull/1142) (@tete17)
 * [ENHANCEMENT] Allow environment variables for Azure storage credentials [#1147](https://github.com/grafana/tempo/pull/1147) (@zalegrala)
+* [ENHANCEMENT] jsonnet: set rollingUpdate.maxSurge to 3 for distributor, frontend and queriers [#1164](https://github.com/grafana/tempo/pull/1164) (@kvrhdn)
 * [BUGFIX] Add process name to vulture traces to work around display issues [#1127](https://github.com/grafana/tempo/pull/1127) (@mdisibio)
 * [BUGFIX] Fixed issue where compaction sometimes dropped spans. [#1130](https://github.com/grafana/tempo/pull/1130) (@joe-elliott)
 * [BUGFIX] Ensure that the admin client jsonnet has correct S3 bucket property. (@hedss)

--- a/operations/jsonnet/microservices/compactor.libsonnet
+++ b/operations/jsonnet/microservices/compactor.libsonnet
@@ -5,8 +5,6 @@
   local volumeMount = k.core.v1.volumeMount,
   local deployment = k.apps.v1.deployment,
   local volume = k.core.v1.volume,
-  local service = k.core.v1.service,
-  local servicePort = k.core.v1.servicePort,
 
   local target_name = 'compactor',
   local tempo_config_volume = 'tempo-conf',

--- a/operations/jsonnet/microservices/distributor.libsonnet
+++ b/operations/jsonnet/microservices/distributor.libsonnet
@@ -3,11 +3,9 @@
   local container = k.core.v1.container,
   local containerPort = k.core.v1.containerPort,
   local volumeMount = k.core.v1.volumeMount,
-  local pv = k.core.v1.persistentVolume,
   local deployment = k.apps.v1.deployment,
   local volume = k.core.v1.volume,
   local service = k.core.v1.service,
-  local servicePort = k.core.v1.servicePort,
 
   local target_name = 'distributor',
   local tempo_config_volume = 'tempo-conf',
@@ -40,7 +38,7 @@
                      app: target_name,
                      [$._config.gossip_member_label]: 'true',
                    }) +
-    deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(0) +
+    deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(3) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
     deployment.mixin.spec.template.spec.withTerminationGracePeriodSeconds(60) +
     deployment.mixin.spec.template.metadata.withAnnotations({

--- a/operations/jsonnet/microservices/frontend.libsonnet
+++ b/operations/jsonnet/microservices/frontend.libsonnet
@@ -53,7 +53,7 @@
         app: target_name,
       }
     ) +
-    deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(0) +
+    deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(3) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
     deployment.mixin.spec.template.metadata.withAnnotations({
       config_hash: std.md5(std.toString($.tempo_query_frontend_configmap.data['tempo.yaml'])),

--- a/operations/jsonnet/microservices/querier.libsonnet
+++ b/operations/jsonnet/microservices/querier.libsonnet
@@ -5,8 +5,6 @@
   local volumeMount = k.core.v1.volumeMount,
   local deployment = k.apps.v1.deployment,
   local volume = k.core.v1.volume,
-  local service = k.core.v1.service,
-  local servicePort = k.core.v1.servicePort,
 
   local target_name = 'querier',
   local tempo_config_volume = 'tempo-conf',
@@ -39,7 +37,7 @@
         [$._config.gossip_member_label]: 'true',
       }
     ) +
-    deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(0) +
+    deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(3) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
     deployment.mixin.spec.template.metadata.withAnnotations({
       config_hash: std.md5(std.toString($.tempo_querier_configmap.data['tempo.yaml'])),

--- a/operations/kube-manifests/Deployment-distributor.yaml
+++ b/operations/kube-manifests/Deployment-distributor.yaml
@@ -14,7 +14,7 @@ spec:
       tempo-gossip-member: "true"
   strategy:
     rollingUpdate:
-      maxSurge: 0
+      maxSurge: 3
       maxUnavailable: 1
   template:
     metadata:

--- a/operations/kube-manifests/Deployment-querier.yaml
+++ b/operations/kube-manifests/Deployment-querier.yaml
@@ -14,7 +14,7 @@ spec:
       tempo-gossip-member: "true"
   strategy:
     rollingUpdate:
-      maxSurge: 0
+      maxSurge: 3
       maxUnavailable: 1
   template:
     metadata:

--- a/operations/kube-manifests/Deployment-query-frontend.yaml
+++ b/operations/kube-manifests/Deployment-query-frontend.yaml
@@ -13,7 +13,7 @@ spec:
       name: query-frontend
   strategy:
     rollingUpdate:
-      maxSurge: 0
+      maxSurge: 3
       maxUnavailable: 1
   template:
     metadata:

--- a/operations/kube-manifests/util/jsonnetfile.lock.json
+++ b/operations/kube-manifests/util/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "9927be87af4be9ff6b009e4503868b1b5493011b",
+      "version": "b102f9ac7d1290ac025c2a7ac99f7fd9a9948503",
       "sum": "fFVlCoa/N0qiqTbDhZAEdRm2Vv76Z9Clxp3/haJ+PyA="
     },
     {
@@ -18,7 +18,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "9927be87af4be9ff6b009e4503868b1b5493011b",
+      "version": "b102f9ac7d1290ac025c2a7ac99f7fd9a9948503",
       "sum": "dTOeEux3t9bYSqP2L/uCuLo/wUDpCKH4w+4OD9fePUk="
     },
     {


### PR DESCRIPTION
**What this PR does**:
Increase max surge for all components except ingesters and compactor. This should speed up rollouts by a factor of 3 without increasing risks.
