### PR TITLE
Increase limits for integration tests to account for large vulture traces

### DIFF
--- a/integration/e2e/config-all-in-one-local.yaml
+++ b/integration/e2e/config-all-in-one-local.yaml
@@ -31,3 +31,6 @@ storage:
     pool:
       max_workers: 10
       queue_depth: 100
+
+overrides:
+  max_search_bytes_per_trace: 50_000

--- a/integration/e2e/config-limits.yaml
+++ b/integration/e2e/config-limits.yaml
@@ -12,6 +12,7 @@ distributor:
 overrides:
   max_bytes_per_trace: 100
   max_traces_per_user: 1
+  max_search_bytes_per_trace: 50_000
   ingestion_rate_limit_bytes: 500
   ingestion_burst_size_bytes: 500
 
@@ -33,6 +34,3 @@ storage:
     pool:
       max_workers: 10
       queue_depth: 100
-
-overrides:
-  max_search_bytes_per_trace: 50_000

--- a/integration/e2e/config-limits.yaml
+++ b/integration/e2e/config-limits.yaml
@@ -33,3 +33,6 @@ storage:
     pool:
       max_workers: 10
       queue_depth: 100
+
+overrides:
+  max_search_bytes_per_trace: 50_000

--- a/integration/e2e/config-microservices.yaml
+++ b/integration/e2e/config-microservices.yaml
@@ -48,3 +48,6 @@ memberlist:
 querier:
   frontend_worker:
     frontend_address: tempo_e2e-query-frontend:9095
+
+overrides:
+  max_search_bytes_per_trace: 50_000

--- a/integration/e2e/config-microservices.yaml
+++ b/integration/e2e/config-microservices.yaml
@@ -16,7 +16,7 @@ ingester:
         store: memberlist
       replication_factor: 3
     heartbeat_period: 100ms
-  trace_idle_period: 100ms
+  trace_idle_period: 1s
   max_block_duration: 2s
   complete_block_timeout: 5s
   flush_check_period: 1s

--- a/integration/e2e/config-scalable-single-binary.yaml
+++ b/integration/e2e/config-scalable-single-binary.yaml
@@ -47,3 +47,6 @@ memberlist:
 querier:
   frontend_worker:
     frontend_address: tempo-1:9095
+
+overrides:
+  max_search_bytes_per_trace: 50_000

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -149,7 +149,7 @@ func TestMicroservices(t *testing.T) {
 	tempoQuerier := util.NewTempoQuerier()
 	require.NoError(t, s.StartAndWaitReady(tempoIngester1, tempoIngester2, tempoIngester3, tempoDistributor, tempoQueryFrontend, tempoQuerier))
 
-	// wait for 2 active ingesters
+	// wait for active ingesters
 	time.Sleep(1 * time.Second)
 	matchers := []*labels.Matcher{
 		{


### PR DESCRIPTION
Two changes:
- One was to increase the `max_search_bytes_per_trace` to account for large vulture traces (actually a lot of search tags added in any given trace)
- Increase `trace_idle_period` in TestMicroservices. It was set to `100ms` and vulture was emitting multiple batches (taking longer than 100ms for each send I guess) and this was counted as multiple traces at the ingester -> taking the ingester traces created metric to 2 instead of the expected value of 1 which we were waiting on

Signed-off-by: Annanay <annanayagarwal@gmail.com>