### PR TITLE
Metric live traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [ENHANCEMENT] Allow environment variables for Azure storage credentials [#1147](https://github.com/grafana/tempo/pull/1147) (@zalegrala)
 * [ENHANCEMENT] jsonnet: set rollingUpdate.maxSurge to 3 for distributor, frontend and queriers [#1164](https://github.com/grafana/tempo/pull/1164) (@kvrhdn)
 * [ENHANCEMENT] Reduce search data file sizes by optimizing contents [#1165](https://github.com/grafana/tempo/pull/1165) (@mdisibio)
+* [ENHANCEMENT] Add `tempo_ingester_live_traces` metric [#1170](https://github.com/grafana/tempo/pull/1170) (@mdisibio)
 * [BUGFIX] Add process name to vulture traces to work around display issues [#1127](https://github.com/grafana/tempo/pull/1127) (@mdisibio)
 * [BUGFIX] Fixed issue where compaction sometimes dropped spans. [#1130](https://github.com/grafana/tempo/pull/1130) (@joe-elliott)
 * [BUGFIX] Ensure that the admin client jsonnet has correct S3 bucket property. (@hedss)

--- a/pkg/util/test/metrics.go
+++ b/pkg/util/test/metrics.go
@@ -23,6 +23,15 @@ func GetGaugeValue(metric prometheus.Gauge) (float64, error) {
 	return m.Gauge.GetValue(), nil
 }
 
+func GetGaugeVecValue(metric *prometheus.GaugeVec, labels ...string) (float64, error) {
+	var m = &dto.Metric{}
+	err := metric.WithLabelValues(labels...).Write(m)
+	if err != nil {
+		return 0, err
+	}
+	return m.Gauge.GetValue(), nil
+}
+
 func GetCounterVecValue(metric *prometheus.CounterVec, label string) (float64, error) {
 	var m = &dto.Metric{}
 	if err := metric.WithLabelValues(label).Write(m); err != nil {


### PR DESCRIPTION
**What this PR does**:
Adds metric for ingester live traces per tenant.  It is updated each sweep interval.

**Which issue(s) this PR fixes**:
Fixes #1120 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`