### PR TITLE
export trace id constant in api package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [CHANGE] **BREAKING CHANGE** The OTEL GRPC receiver's default port changed from 55680 to 4317. [#1142](https://github.com/grafana/tempo/pull/1142) (@tete17)
 * [CHANGE] Remove deprecated method `Push` from `tempopb.Pusher` [#1173](https://github.com/grafana/tempo/pull/1173) (@kvrhdn)
 * [CHANGE] Upgrade cristalhq/hedgedhttp from v0.6.0 to v0.7.0 [#1159](https://github.com/grafana/tempo/pull/1159) (@cristaloleg)
+* [CHANGE] Export trace id constant in api package [#1176](https://github.com/grafana/tempo/pull/1176)
 * [FEATURE] Added support for full backend search. [#1174](https://github.com/grafana/tempo/pull/1174) (@joe-elliott)
   **BREAKING CHANGE** Moved `querier.search_max_result_limit` and `querier.search_default_result_limit` to `query_frontend.search.max_result_limit` and `query_frontend.search.default_result_limit`
 * [ENHANCEMENT] Expose `upto` parameter on hedged requests for each backend with `hedge_requests_up_to`. [#1085](https://github.com/grafana/tempo/pull/1085) (@joe-elliott)

--- a/pkg/api/http.go
+++ b/pkg/api/http.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	urlParamTraceID = "traceID"
+	URLParamTraceID = "traceID"
 	// search
 	urlParamTags        = "tags"
 	urlParamMinDuration = "minDuration"
@@ -54,7 +54,7 @@ const (
 
 func ParseTraceID(r *http.Request) ([]byte, error) {
 	vars := mux.Vars(r)
-	traceID, ok := vars[urlParamTraceID]
+	traceID, ok := vars[URLParamTraceID]
 	if !ok {
 		return nil, fmt.Errorf("please provide a traceID")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Export the `URLParamTraceID` constant in the `api` package as this constant was already exported in the `util` package prior to version 1.2.

**Checklist**
- ~[ ] Tests updated~
- ~[ ] Documentation added~
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`