### PR TITLE
instrumentation: fix trace context propagation distributor -> ingester

### DIFF
--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/dskit/ring"
 	ring_client "github.com/grafana/dskit/ring/client"
 	"github.com/grafana/dskit/services"
+	"github.com/opentracing/opentracing-go"
 	"github.com/segmentio/fasthash/fnv1a"
 
 	"github.com/pkg/errors"
@@ -217,6 +218,9 @@ func (d *Distributor) stopping(_ error) error {
 
 // PushBatches pushes a batch of traces
 func (d *Distributor) PushBatches(ctx context.Context, batches []*v1.ResourceSpans) (*tempopb.PushResponse, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "distributor.PushBatches")
+	defer span.Finish()
+
 	userID, err := user.ExtractOrgID(ctx)
 	if err != nil {
 		// can't record discarded spans here b/c there's no tenant
@@ -301,7 +305,7 @@ func (d *Distributor) sendToIngestersViaBytes(ctx context.Context, userID string
 	}
 
 	err := ring.DoBatch(ctx, op, d.ingestersRing, keys, func(ingester ring.InstanceDesc, indexes []int) error {
-		localCtx, cancel := context.WithTimeout(context.Background(), d.clientCfg.RemoteTimeout)
+		localCtx, cancel := context.WithTimeout(ctx, d.clientCfg.RemoteTimeout)
 		defer cancel()
 		localCtx = user.InjectOrgID(localCtx, userID)
 

--- a/modules/distributor/receiver/shim.go
+++ b/modules/distributor/receiver/shim.go
@@ -15,6 +15,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver"
+	"github.com/opentracing/opentracing-go"
 	prom_client "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sirupsen/logrus"
@@ -170,8 +171,11 @@ func (r *receiversShim) stopping(_ error) error {
 	return nil
 }
 
-// implements consumer.Trace
+// ConsumeTraces implements consumer.Trace
 func (r *receiversShim) ConsumeTraces(ctx context.Context, td pdata.Traces) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "distributor.ConsumeTraces")
+	defer span.Finish()
+
 	var err error
 
 	// Convert to bytes and back. This is unfortunate for efficiency but it works


### PR DESCRIPTION
**What this PR does**:
Ensure the trace context is propagated to all ingesters and add a couple of spans.

Result:

![Screenshot 2021-12-27 at 14 15 19](https://user-images.githubusercontent.com/7748404/147475271-ded5b796-b184-45de-917e-3e4aca172184.png)
