### PR TITLE
Add Tempo / Tenants dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /example/docker-compose/**/gcs-data/
 .DS_Store
 /tempodb/encoding/benchmark_block
+lsp

--- a/operations/tempo-mixin/dashboards.libsonnet
+++ b/operations/tempo-mixin/dashboards.libsonnet
@@ -1,4 +1,5 @@
 (import 'dashboards/tempo-operational.libsonnet') +
 (import 'dashboards/tempo-reads.libsonnet') +
 (import 'dashboards/tempo-resources.libsonnet') +
+(import 'dashboards/tempo-tenants.libsonnet') +
 (import 'dashboards/tempo-writes.libsonnet')

--- a/operations/tempo-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/tempo-mixin/dashboards/dashboard-utils.libsonnet
@@ -26,6 +26,53 @@ grafana {
 
         d.addMultiTemplate('cluster', 'tempo_build_info', 'cluster')
         .addMultiTemplate('namespace', 'tempo_build_info', 'namespace', allValue=null),
+
+      addLogsDatasourceTemplate():: self {
+        templating+: {
+          list+: [{
+            current: {
+              text: 'Loki',
+              value: 'Loki',
+            },
+            hide: 0,
+            label: 'Logs Data Source',
+            name: 'logsDatasource',
+            options: [],
+            query: 'loki',
+            refresh: 1,
+            regex: '',
+            type: 'datasource',
+          }],
+        },
+      },
+
+      addQueryResultTemplate(name, query):: self {
+        templating+: {
+          list+: [{
+            allValue: null,
+            current: {
+              text: 'prod',
+              value: 'prod',
+            },
+            datasource: '$datasource',
+            hide: 0,
+            includeAll: false,
+            label: name,
+            multi: false,
+            name: name,
+            options: [],
+            query: 'query_result(%s)' % [query],
+            refresh: 1,
+            regex: '/"([^"]+)"/',
+            sort: 2,
+            tagValuesQuery: '',
+            tags: [],
+            tagsQuery: '',
+            type: 'query',
+            useTags: false,
+          }],
+        },
+      },
     },
 
   jobMatcher(job)::
@@ -94,6 +141,28 @@ grafana {
       },
     ],
     yaxes: $.yaxes('ms'),
+  },
+
+  logsPanel(title, query):: {
+    type: 'logs',
+    title: title,
+    options: {
+      dedupStrategy: 'none',
+      enableLogDetails: true,
+      prettifyLogMessage: false,
+      showCommonLabels: false,
+      showLabels: false,
+      showTime: true,
+      sortOrder: 'Descending',
+      wrapLogMessage: false,
+    },
+    datasource: '$logsDatasource',
+    targets: [
+      {
+        expr: query,
+        refId: 'A',
+      },
+    ],
   },
 
   namespaceMatcher()::

--- a/operations/tempo-mixin/dashboards/tempo-operational.json
+++ b/operations/tempo-mixin/dashboards/tempo-operational.json
@@ -5438,7 +5438,7 @@
           "value": "tempo-ops"
         },
         "datasource": "$ds",
-        "definition": "label_values(kube_pod_container_info{image=~\".*tempo.*\", cluster=\"$cluster\"}, namespace)",
+        "definition": "label_values(tempo_build_info{cluster=\"$cluster\"}, namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -5448,7 +5448,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_pod_container_info{image=~\".*tempo.*\", cluster=\"$cluster\"}, namespace)",
+          "query": "label_values(tempo_build_info{cluster=\"$cluster\"}, namespace)",
           "refId": "ops-cortex-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/operations/tempo-mixin/dashboards/tempo-tenants.libsonnet
+++ b/operations/tempo-mixin/dashboards/tempo-tenants.libsonnet
@@ -1,0 +1,126 @@
+local dashboard_utils = import 'dashboard-utils.libsonnet';
+local g = import 'grafana-builder/grafana.libsonnet';
+
+dashboard_utils {
+  grafanaDashboards+: {
+    'tempo-tenants.json':
+      $.dashboard('Tempo / Tenants')
+
+      .addLogsDatasourceTemplate()
+      .addClusterSelectorTemplates()
+      .addQueryResultTemplate('tenant', 'sum(tempodb_blocklist_length{cluster=~"$cluster", namespace=~"$namespace"}) by (tenant) > 0')
+
+      .addRow(
+        g.row('Cluster')
+        .addPanel(
+          g.panel('Distributor Spans/Second (topk 10)') +
+          $.queryPanel(
+            |||
+              topk(10,
+                sum(
+                  rate(tempo_distributor_spans_received_total{%s}[$__rate_interval])
+                ) by (tenant)
+              )
+            ||| % $.jobMatcher($._config.jobs.distributor),
+            '{{tenant}}',
+          ),
+        )
+        .addPanel(
+          g.panel('Ingester Traces Created/Second (topk 10)') +
+          $.queryPanel(
+            |||
+              topk(10,
+                sum(
+                  rate(tempo_ingester_traces_created_total{%s}[$__rate_interval])
+                ) by (tenant)
+              )
+            ||| % $.jobMatcher($._config.jobs.ingester),
+            '{{tenant}}',
+          ),
+        ),
+      )
+      .addRow(
+        g.row('Cluster')
+        .addPanel(
+          g.panel('Distributor Bytes/Second (topk 10)') +
+          $.queryPanel(
+            |||
+              topk(10,
+                sum(
+                  rate(tempo_distributor_bytes_received_total{%s}[$__rate_interval])
+                ) by (tenant)
+              )
+            ||| % $.jobMatcher($._config.jobs.distributor),
+            '{{tenant}}',
+          ),
+        )
+        .addPanel(
+          g.panel('Blocklist Length (topk 10)') +
+          $.queryPanel(
+            |||
+              topk(10,
+                avg(
+                  tempodb_blocklist_length{%s}
+                ) by (tenant)
+              )
+            ||| % $.jobMatcher($._config.jobs.compactor),
+            '{{tenant}}',
+          ),
+        )
+      )
+      .addRow(
+        g.row('Tenant')
+        .addPanel(
+          g.panel('Distributor Spans/Second') +
+          $.queryPanel(
+            |||
+              sum(rate(tempo_distributor_spans_received_total{job=~".*/distributor", tenant=~"$tenant"}[$__rate_interval])) by (cluster, namespace)
+            |||,
+            'Received ({{cluster}}, {{namespace}})',
+          ) +
+          $.queryPanel(
+            |||
+              sum(rate(tempo_discarded_spans_total{job=~".*/distributor", tenant=~"$tenant"}[$__rate_interval])) by (cluster, namespace, reason)
+            |||,
+            'Discarded: {{reason}} ({{cluster}}, {{namespace}})',
+          ),
+        )
+        .addPanel(
+          g.panel('Queries/Second') +
+          $.queryPanel(
+            |||
+              sum(
+                rate(tempo_query_frontend_queries_total{job=~".*/query-frontend", tenant=~"$tenant"}[$__rate_interval])
+              ) by (cluster, namespace, op)
+            |||,
+            '{{op}} ({{cluster}}, {{namespace}})',
+          ),
+        )
+        .addPanel(
+          g.panel('Blocklist Length') +
+          $.queryPanel(
+            |||
+              avg(tempodb_blocklist_length{tenant=~"$tenant"}) by (cluster, namespace)
+            |||,
+            '{{cluster}}, {{namespace}}',
+          ),
+        )
+      )
+      .addRow(
+        g.row('Tenant - Queries')
+        .addPanel(
+          g.panel('Queries') +
+          $.logsPanel(
+            'Queries',
+            |||
+              {job=~".*/query-frontend"}
+              |= "caller=handler.go"
+              | logfmt
+              | tenant="$tenant"
+              | line_format `{{printf "%-12.12s" .duration}}  {{printf "%-6.6s" .response_size}}  {{.url}}`
+            |||,
+          )
+        )
+      ),
+  },
+}

--- a/operations/tempo-mixin/yamls/tempo-operational.json
+++ b/operations/tempo-mixin/yamls/tempo-operational.json
@@ -6040,7 +6040,7 @@
      "value": "tempo-ops"
     },
     "datasource": "$ds",
-    "definition": "label_values(kube_pod_container_info{image=~\".*tempo.*\", cluster=\"$cluster\"}, namespace)",
+    "definition": "label_values(tempo_build_info{cluster=\"$cluster\"}, namespace)",
     "description": null,
     "error": null,
     "hide": 0,
@@ -6052,7 +6052,7 @@
 
     ],
     "query": {
-     "query": "label_values(kube_pod_container_info{image=~\".*tempo.*\", cluster=\"$cluster\"}, namespace)",
+     "query": "label_values(tempo_build_info{cluster=\"$cluster\"}, namespace)",
      "refId": "ops-cortex-namespace-Variable-Query"
     },
     "refresh": 1,

--- a/operations/tempo-mixin/yamls/tempo-tenants.json
+++ b/operations/tempo-mixin/yamls/tempo-tenants.json
@@ -1,0 +1,943 @@
+{
+ "annotations": {
+  "list": [
+
+  ]
+ },
+ "editable": true,
+ "gnetId": null,
+ "graphTooltip": 0,
+ "hideControls": false,
+ "links": [
+  {
+   "asDropdown": true,
+   "icon": "external link",
+   "includeVars": true,
+   "keepTime": true,
+   "tags": [
+    "tempo"
+   ],
+   "targetBlank": false,
+   "title": "Tempo Dashboards",
+   "type": "dashboards"
+  }
+ ],
+ "refresh": "10s",
+ "rows": [
+  {
+   "collapse": false,
+   "height": "250px",
+   "panels": [
+    {
+     "aliasColors": {
+
+     },
+     "bars": false,
+     "dashLength": 10,
+     "dashes": false,
+     "datasource": "$datasource",
+     "fill": 1,
+     "id": 1,
+     "legend": {
+      "avg": false,
+      "current": false,
+      "max": false,
+      "min": false,
+      "show": true,
+      "total": false,
+      "values": false
+     },
+     "lines": true,
+     "linewidth": 1,
+     "links": [
+
+     ],
+     "nullPointMode": "null as zero",
+     "percentage": false,
+     "pointradius": 5,
+     "points": false,
+     "renderer": "flot",
+     "seriesOverrides": [
+
+     ],
+     "spaceLength": 10,
+     "span": 6,
+     "stack": false,
+     "steppedLine": false,
+     "targets": [
+      {
+       "expr": "topk(10,\n  sum(\n    rate(tempo_distributor_spans_received_total{cluster=~\"$cluster\", job=~\"($namespace)/distributor\"}[$__rate_interval])\n  ) by (tenant)\n)\n",
+       "format": "time_series",
+       "interval": "1m",
+       "intervalFactor": 2,
+       "legendFormat": "{{tenant}}",
+       "legendLink": null,
+       "step": 10
+      }
+     ],
+     "thresholds": [
+
+     ],
+     "timeFrom": null,
+     "timeShift": null,
+     "title": "Distributor Spans/Second (topk 10)",
+     "tooltip": {
+      "shared": true,
+      "sort": 2,
+      "value_type": "individual"
+     },
+     "type": "graph",
+     "xaxis": {
+      "buckets": null,
+      "mode": "time",
+      "name": null,
+      "show": true,
+      "values": [
+
+      ]
+     },
+     "yaxes": [
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": 0,
+       "show": true
+      },
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": null,
+       "show": false
+      }
+     ]
+    },
+    {
+     "aliasColors": {
+
+     },
+     "bars": false,
+     "dashLength": 10,
+     "dashes": false,
+     "datasource": "$datasource",
+     "fill": 1,
+     "id": 2,
+     "legend": {
+      "avg": false,
+      "current": false,
+      "max": false,
+      "min": false,
+      "show": true,
+      "total": false,
+      "values": false
+     },
+     "lines": true,
+     "linewidth": 1,
+     "links": [
+
+     ],
+     "nullPointMode": "null as zero",
+     "percentage": false,
+     "pointradius": 5,
+     "points": false,
+     "renderer": "flot",
+     "seriesOverrides": [
+
+     ],
+     "spaceLength": 10,
+     "span": 6,
+     "stack": false,
+     "steppedLine": false,
+     "targets": [
+      {
+       "expr": "topk(10,\n  sum(\n    rate(tempo_ingester_traces_created_total{cluster=~\"$cluster\", job=~\"($namespace)/ingester\"}[$__rate_interval])\n  ) by (tenant)\n)\n",
+       "format": "time_series",
+       "interval": "1m",
+       "intervalFactor": 2,
+       "legendFormat": "{{tenant}}",
+       "legendLink": null,
+       "step": 10
+      }
+     ],
+     "thresholds": [
+
+     ],
+     "timeFrom": null,
+     "timeShift": null,
+     "title": "Ingester Traces Created/Second (topk 10)",
+     "tooltip": {
+      "shared": true,
+      "sort": 2,
+      "value_type": "individual"
+     },
+     "type": "graph",
+     "xaxis": {
+      "buckets": null,
+      "mode": "time",
+      "name": null,
+      "show": true,
+      "values": [
+
+      ]
+     },
+     "yaxes": [
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": 0,
+       "show": true
+      },
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": null,
+       "show": false
+      }
+     ]
+    }
+   ],
+   "repeat": null,
+   "repeatIteration": null,
+   "repeatRowId": null,
+   "showTitle": true,
+   "title": "Cluster",
+   "titleSize": "h6"
+  },
+  {
+   "collapse": false,
+   "height": "250px",
+   "panels": [
+    {
+     "aliasColors": {
+
+     },
+     "bars": false,
+     "dashLength": 10,
+     "dashes": false,
+     "datasource": "$datasource",
+     "fill": 1,
+     "id": 3,
+     "legend": {
+      "avg": false,
+      "current": false,
+      "max": false,
+      "min": false,
+      "show": true,
+      "total": false,
+      "values": false
+     },
+     "lines": true,
+     "linewidth": 1,
+     "links": [
+
+     ],
+     "nullPointMode": "null as zero",
+     "percentage": false,
+     "pointradius": 5,
+     "points": false,
+     "renderer": "flot",
+     "seriesOverrides": [
+
+     ],
+     "spaceLength": 10,
+     "span": 6,
+     "stack": false,
+     "steppedLine": false,
+     "targets": [
+      {
+       "expr": "topk(10,\n  sum(\n    rate(tempo_distributor_bytes_received_total{cluster=~\"$cluster\", job=~\"($namespace)/distributor\"}[$__rate_interval])\n  ) by (tenant)\n)\n",
+       "format": "time_series",
+       "interval": "1m",
+       "intervalFactor": 2,
+       "legendFormat": "{{tenant}}",
+       "legendLink": null,
+       "step": 10
+      }
+     ],
+     "thresholds": [
+
+     ],
+     "timeFrom": null,
+     "timeShift": null,
+     "title": "Distributor Bytes/Second (topk 10)",
+     "tooltip": {
+      "shared": true,
+      "sort": 2,
+      "value_type": "individual"
+     },
+     "type": "graph",
+     "xaxis": {
+      "buckets": null,
+      "mode": "time",
+      "name": null,
+      "show": true,
+      "values": [
+
+      ]
+     },
+     "yaxes": [
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": 0,
+       "show": true
+      },
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": null,
+       "show": false
+      }
+     ]
+    },
+    {
+     "aliasColors": {
+
+     },
+     "bars": false,
+     "dashLength": 10,
+     "dashes": false,
+     "datasource": "$datasource",
+     "fill": 1,
+     "id": 4,
+     "legend": {
+      "avg": false,
+      "current": false,
+      "max": false,
+      "min": false,
+      "show": true,
+      "total": false,
+      "values": false
+     },
+     "lines": true,
+     "linewidth": 1,
+     "links": [
+
+     ],
+     "nullPointMode": "null as zero",
+     "percentage": false,
+     "pointradius": 5,
+     "points": false,
+     "renderer": "flot",
+     "seriesOverrides": [
+
+     ],
+     "spaceLength": 10,
+     "span": 6,
+     "stack": false,
+     "steppedLine": false,
+     "targets": [
+      {
+       "expr": "topk(10,\n  avg(\n    tempodb_blocklist_length{cluster=~\"$cluster\", job=~\"($namespace)/compactor\"}\n  ) by (tenant)\n)\n",
+       "format": "time_series",
+       "interval": "1m",
+       "intervalFactor": 2,
+       "legendFormat": "{{tenant}}",
+       "legendLink": null,
+       "step": 10
+      }
+     ],
+     "thresholds": [
+
+     ],
+     "timeFrom": null,
+     "timeShift": null,
+     "title": "Blocklist Length (topk 10)",
+     "tooltip": {
+      "shared": true,
+      "sort": 2,
+      "value_type": "individual"
+     },
+     "type": "graph",
+     "xaxis": {
+      "buckets": null,
+      "mode": "time",
+      "name": null,
+      "show": true,
+      "values": [
+
+      ]
+     },
+     "yaxes": [
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": 0,
+       "show": true
+      },
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": null,
+       "show": false
+      }
+     ]
+    }
+   ],
+   "repeat": null,
+   "repeatIteration": null,
+   "repeatRowId": null,
+   "showTitle": true,
+   "title": "Cluster",
+   "titleSize": "h6"
+  },
+  {
+   "collapse": false,
+   "height": "250px",
+   "panels": [
+    {
+     "aliasColors": {
+
+     },
+     "bars": false,
+     "dashLength": 10,
+     "dashes": false,
+     "datasource": "$datasource",
+     "fill": 1,
+     "id": 5,
+     "legend": {
+      "avg": false,
+      "current": false,
+      "max": false,
+      "min": false,
+      "show": true,
+      "total": false,
+      "values": false
+     },
+     "lines": true,
+     "linewidth": 1,
+     "links": [
+
+     ],
+     "nullPointMode": "null as zero",
+     "percentage": false,
+     "pointradius": 5,
+     "points": false,
+     "renderer": "flot",
+     "seriesOverrides": [
+
+     ],
+     "spaceLength": 10,
+     "span": 4,
+     "stack": false,
+     "steppedLine": false,
+     "targets": [
+      {
+       "expr": "sum(rate(tempo_distributor_spans_received_total{job=~\".*/distributor\", tenant=~\"$tenant\"}[$__rate_interval])) by (cluster, namespace)\n",
+       "format": "time_series",
+       "interval": "1m",
+       "intervalFactor": 2,
+       "legendFormat": "Received ({{cluster}}, {{namespace}})",
+       "legendLink": null,
+       "step": 10
+      },
+      {
+       "expr": "sum(rate(tempo_discarded_spans_total{job=~\".*/distributor\", tenant=~\"$tenant\"}[$__rate_interval])) by (cluster, namespace, reason)\n",
+       "format": "time_series",
+       "interval": "1m",
+       "intervalFactor": 2,
+       "legendFormat": "Discarded: {{reason}} ({{cluster}}, {{namespace}})",
+       "legendLink": null,
+       "step": 10
+      }
+     ],
+     "thresholds": [
+
+     ],
+     "timeFrom": null,
+     "timeShift": null,
+     "title": "Distributor Spans/Second",
+     "tooltip": {
+      "shared": true,
+      "sort": 2,
+      "value_type": "individual"
+     },
+     "type": "graph",
+     "xaxis": {
+      "buckets": null,
+      "mode": "time",
+      "name": null,
+      "show": true,
+      "values": [
+
+      ]
+     },
+     "yaxes": [
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": 0,
+       "show": true
+      },
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": null,
+       "show": false
+      }
+     ]
+    },
+    {
+     "aliasColors": {
+
+     },
+     "bars": false,
+     "dashLength": 10,
+     "dashes": false,
+     "datasource": "$datasource",
+     "fill": 1,
+     "id": 6,
+     "legend": {
+      "avg": false,
+      "current": false,
+      "max": false,
+      "min": false,
+      "show": true,
+      "total": false,
+      "values": false
+     },
+     "lines": true,
+     "linewidth": 1,
+     "links": [
+
+     ],
+     "nullPointMode": "null as zero",
+     "percentage": false,
+     "pointradius": 5,
+     "points": false,
+     "renderer": "flot",
+     "seriesOverrides": [
+
+     ],
+     "spaceLength": 10,
+     "span": 4,
+     "stack": false,
+     "steppedLine": false,
+     "targets": [
+      {
+       "expr": "sum(\n  rate(tempo_query_frontend_queries_total{job=~\".*/query-frontend\", tenant=~\"$tenant\"}[$__rate_interval])\n) by (cluster, namespace, op)\n",
+       "format": "time_series",
+       "interval": "1m",
+       "intervalFactor": 2,
+       "legendFormat": "{{op}} ({{cluster}}, {{namespace}})",
+       "legendLink": null,
+       "step": 10
+      }
+     ],
+     "thresholds": [
+
+     ],
+     "timeFrom": null,
+     "timeShift": null,
+     "title": "Queries/Second",
+     "tooltip": {
+      "shared": true,
+      "sort": 2,
+      "value_type": "individual"
+     },
+     "type": "graph",
+     "xaxis": {
+      "buckets": null,
+      "mode": "time",
+      "name": null,
+      "show": true,
+      "values": [
+
+      ]
+     },
+     "yaxes": [
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": 0,
+       "show": true
+      },
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": null,
+       "show": false
+      }
+     ]
+    },
+    {
+     "aliasColors": {
+
+     },
+     "bars": false,
+     "dashLength": 10,
+     "dashes": false,
+     "datasource": "$datasource",
+     "fill": 1,
+     "id": 7,
+     "legend": {
+      "avg": false,
+      "current": false,
+      "max": false,
+      "min": false,
+      "show": true,
+      "total": false,
+      "values": false
+     },
+     "lines": true,
+     "linewidth": 1,
+     "links": [
+
+     ],
+     "nullPointMode": "null as zero",
+     "percentage": false,
+     "pointradius": 5,
+     "points": false,
+     "renderer": "flot",
+     "seriesOverrides": [
+
+     ],
+     "spaceLength": 10,
+     "span": 4,
+     "stack": false,
+     "steppedLine": false,
+     "targets": [
+      {
+       "expr": "avg(tempodb_blocklist_length{tenant=~\"$tenant\"}) by (cluster, namespace)\n",
+       "format": "time_series",
+       "interval": "1m",
+       "intervalFactor": 2,
+       "legendFormat": "{{cluster}}, {{namespace}}",
+       "legendLink": null,
+       "step": 10
+      }
+     ],
+     "thresholds": [
+
+     ],
+     "timeFrom": null,
+     "timeShift": null,
+     "title": "Blocklist Length",
+     "tooltip": {
+      "shared": true,
+      "sort": 2,
+      "value_type": "individual"
+     },
+     "type": "graph",
+     "xaxis": {
+      "buckets": null,
+      "mode": "time",
+      "name": null,
+      "show": true,
+      "values": [
+
+      ]
+     },
+     "yaxes": [
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": 0,
+       "show": true
+      },
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": null,
+       "show": false
+      }
+     ]
+    }
+   ],
+   "repeat": null,
+   "repeatIteration": null,
+   "repeatRowId": null,
+   "showTitle": true,
+   "title": "Tenant",
+   "titleSize": "h6"
+  },
+  {
+   "collapse": false,
+   "height": "250px",
+   "panels": [
+    {
+     "aliasColors": {
+
+     },
+     "bars": false,
+     "dashLength": 10,
+     "dashes": false,
+     "datasource": "$logsDatasource",
+     "fill": 1,
+     "id": 8,
+     "legend": {
+      "avg": false,
+      "current": false,
+      "max": false,
+      "min": false,
+      "show": true,
+      "total": false,
+      "values": false
+     },
+     "lines": true,
+     "linewidth": 1,
+     "links": [
+
+     ],
+     "nullPointMode": "null as zero",
+     "options": {
+      "dedupStrategy": "none",
+      "enableLogDetails": true,
+      "prettifyLogMessage": false,
+      "showCommonLabels": false,
+      "showLabels": false,
+      "showTime": true,
+      "sortOrder": "Descending",
+      "wrapLogMessage": false
+     },
+     "percentage": false,
+     "pointradius": 5,
+     "points": false,
+     "renderer": "flot",
+     "seriesOverrides": [
+
+     ],
+     "spaceLength": 10,
+     "span": 12,
+     "stack": false,
+     "steppedLine": false,
+     "targets": [
+      {
+       "expr": "{job=~\".*/query-frontend\"}\n|= \"caller=handler.go\"\n| logfmt\n| tenant=\"$tenant\"\n| line_format `{{printf \"%-12.12s\" .duration}}  {{printf \"%-6.6s\" .response_size}}  {{.url}}`\n",
+       "refId": "A"
+      }
+     ],
+     "thresholds": [
+
+     ],
+     "timeFrom": null,
+     "timeShift": null,
+     "title": "Queries",
+     "tooltip": {
+      "shared": true,
+      "sort": 2,
+      "value_type": "individual"
+     },
+     "type": "logs",
+     "xaxis": {
+      "buckets": null,
+      "mode": "time",
+      "name": null,
+      "show": true,
+      "values": [
+
+      ]
+     },
+     "yaxes": [
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": 0,
+       "show": true
+      },
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": null,
+       "show": false
+      }
+     ]
+    }
+   ],
+   "repeat": null,
+   "repeatIteration": null,
+   "repeatRowId": null,
+   "showTitle": true,
+   "title": "Tenant - Queries",
+   "titleSize": "h6"
+  }
+ ],
+ "schemaVersion": 14,
+ "style": "dark",
+ "tags": [
+  "tempo"
+ ],
+ "templating": {
+  "list": [
+   {
+    "current": {
+     "text": "default",
+     "value": "default"
+    },
+    "hide": 0,
+    "label": "Data Source",
+    "name": "datasource",
+    "options": [
+
+    ],
+    "query": "prometheus",
+    "refresh": 1,
+    "regex": "",
+    "type": "datasource"
+   },
+   {
+    "current": {
+     "text": "Loki",
+     "value": "Loki"
+    },
+    "hide": 0,
+    "label": "Logs Data Source",
+    "name": "logsDatasource",
+    "options": [
+
+    ],
+    "query": "loki",
+    "refresh": 1,
+    "regex": "",
+    "type": "datasource"
+   },
+   {
+    "allValue": ".+",
+    "current": {
+     "selected": true,
+     "text": "All",
+     "value": "$__all"
+    },
+    "datasource": "$datasource",
+    "hide": 0,
+    "includeAll": true,
+    "label": "cluster",
+    "multi": true,
+    "name": "cluster",
+    "options": [
+
+    ],
+    "query": "label_values(tempo_build_info, cluster)",
+    "refresh": 1,
+    "regex": "",
+    "sort": 2,
+    "tagValuesQuery": "",
+    "tags": [
+
+    ],
+    "tagsQuery": "",
+    "type": "query",
+    "useTags": false
+   },
+   {
+    "allValue": null,
+    "current": {
+     "selected": true,
+     "text": "All",
+     "value": "$__all"
+    },
+    "datasource": "$datasource",
+    "hide": 0,
+    "includeAll": true,
+    "label": "namespace",
+    "multi": true,
+    "name": "namespace",
+    "options": [
+
+    ],
+    "query": "label_values(tempo_build_info, namespace)",
+    "refresh": 1,
+    "regex": "",
+    "sort": 2,
+    "tagValuesQuery": "",
+    "tags": [
+
+    ],
+    "tagsQuery": "",
+    "type": "query",
+    "useTags": false
+   },
+   {
+    "allValue": null,
+    "current": {
+     "text": "prod",
+     "value": "prod"
+    },
+    "datasource": "$datasource",
+    "hide": 0,
+    "includeAll": false,
+    "label": "tenant",
+    "multi": false,
+    "name": "tenant",
+    "options": [
+
+    ],
+    "query": "query_result(sum(tempodb_blocklist_length{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (tenant) > 0)",
+    "refresh": 1,
+    "regex": "/\"([^\"]+)\"/",
+    "sort": 2,
+    "tagValuesQuery": "",
+    "tags": [
+
+    ],
+    "tagsQuery": "",
+    "type": "query",
+    "useTags": false
+   }
+  ]
+ },
+ "time": {
+  "from": "now-1h",
+  "to": "now"
+ },
+ "timepicker": {
+  "refresh_intervals": [
+   "5s",
+   "10s",
+   "30s",
+   "1m",
+   "5m",
+   "15m",
+   "30m",
+   "1h",
+   "2h",
+   "1d"
+  ],
+  "time_options": [
+   "5m",
+   "15m",
+   "1h",
+   "6h",
+   "12h",
+   "24h",
+   "2d",
+   "7d",
+   "30d"
+  ]
+ },
+ "timezone": "utc",
+ "title": "Tempo / Tenants",
+ "uid": "",
+ "version": 0
+}


### PR DESCRIPTION
**What this PR does**:
Adds a new dashboard: Tempo / Tenants.
Example (with single tenant data unfortunately):

![Screenshot 2021-12-29 at 17 28 58](https://user-images.githubusercontent.com/7748404/147683355-4f3bf06e-3c48-46bf-9ec2-62d9255b3be1.png)

Features:
- first half contains cluster-level information, grouped by tenant. This is useful to get an overview of the cluster and the size of the tenants present. We always show the `topk(10)` tenants.
- the lower rows are all tenant-specific graphs allowing you to see how a specific tenant is doing.

I've also tweaked the namespace selector in Tempo Operational, this didn't work if you don't have the `kube_pod_container_info` metric. Using `tempo_build_info` is similar to all the other dashboards.

**Which issue(s) this PR fixes**:
Closes https://github.com/grafana/tempo/issues/813 (I think?)

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`