### PR TITLE
feat(docs): auto assign type/docs label to docs project

### DIFF
--- a/.github/issue_commands.json
+++ b/.github/issue_commands.json
@@ -1,0 +1,10 @@
+[   
+    {
+      "type": "label",
+      "name": "type/docs",
+      "action": "addToProject",
+      "addToProject": {
+        "url": "https://github.com/orgs/grafana/projects/69"
+      }
+    }
+]

--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -1,0 +1,21 @@
+name: Run commands when issues are labeled
+on:
+  issues:
+    types: [labeled]
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: "grafana/grafana-github-actions"
+          path: ./actions
+          ref: main
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run Commands
+        uses: ./actions/commands
+        with:          
+          token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          configPath: issue_commands


### PR DESCRIPTION
**Why?**
We want to automate assigning issues to projects. This PR uses a github action that we use in other projects and is triggered on label events and when the labels match `type/docs` it adds it to the [technical documentation project](https://github.com/orgs/grafana/projects/69)

**Additional changes**
- I had to add a new secret to this repository called `GH_BOT_ACCESS_TOKEN` as required by this action to work