### PR TITLE
Detect incomplete page read and return error

### DIFF
--- a/tempodb/encoding/v2/page.go
+++ b/tempodb/encoding/v2/page.go
@@ -91,7 +91,10 @@ func unmarshalPageFromReader(r io.Reader, header pageHeader, buffer []byte) (*pa
 		buffer = buffer[:dataLength]
 	}
 
-	_, err = r.Read(buffer)
+	actualLength, err := r.Read(buffer)
+	if actualLength != len(buffer) {
+		return nil, fmt.Errorf("unexpected incomplete page read: expected:%d read:%d", len(buffer), actualLength)
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does**:
Detects incomplete pages during unmarshalling and raises an error.   Previously it would have silently returned the partially read buffer.  This is primarily for None encoding, as the other compression encodings would have caught it already during decompression.

**Which issue(s) this PR fixes**:
Fixes #1195 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`