### PR TITLE
Ingester prevent writes to large traces even after flushing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,12 @@
 * [ENHANCEMENT] Reduce search data file sizes by optimizing contents [#1165](https://github.com/grafana/tempo/pull/1165) (@mdisibio)
 * [ENHANCEMENT] Add `tempo_ingester_live_traces` metric [#1170](https://github.com/grafana/tempo/pull/1170) (@mdisibio)
 * [ENHANCEMENT] Update compactor ring to automatically forget unhealthy entries [#1178](https://github.com/grafana/tempo/pull/1178) (@mdisibio)
+* [ENHANCEMENT] Prevent writes to large traces even after flushing to disk [#1199](https://github.com/grafana/tempo/pull/1199) (@mdisibio)
 * [BUGFIX] Add process name to vulture traces to work around display issues [#1127](https://github.com/grafana/tempo/pull/1127) (@mdisibio)
 * [BUGFIX] Fixed issue where compaction sometimes dropped spans. [#1130](https://github.com/grafana/tempo/pull/1130) (@joe-elliott)
 * [BUGFIX] Ensure that the admin client jsonnet has correct S3 bucket property. (@hedss)
 * [BUGFIX] Publish tenant index age correctly for tenant index writers. [#1146](https://github.com/grafana/tempo/pull/1146) (@joe-elliott)
 * [BUGFIX] Ingester startup panic `slice bounds out of range` [#1195](https://github.com/grafana/tempo/issues/1195) (@mdisibio)
-* [BUGFIX] Prevent writes to large traces even after flushing to disk [#1199](https://github.com/grafana/tempo/pull/1199) (@mdisibio)
 
 ## v1.2.1 / 2021-11-15
 * [BUGFIX] Fix defaults for MaxBytesPerTrace (ingester.max-bytes-per-trace) and MaxSearchBytesPerTrace (ingester.max-search-bytes-per-trace) [#1109](https://github.com/grafana/tempo/pull/1109) (@bitprocessor)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [BUGFIX] Fixed issue where compaction sometimes dropped spans. [#1130](https://github.com/grafana/tempo/pull/1130) (@joe-elliott)
 * [BUGFIX] Ensure that the admin client jsonnet has correct S3 bucket property. (@hedss)
 * [BUGFIX] Publish tenant index age correctly for tenant index writers. [#1146](https://github.com/grafana/tempo/pull/1146) (@joe-elliott)
+* [BUGFIX] Prevent writes to large traces even after flushing to disk [#1199](https://github.com/grafana/tempo/pull/1199) (@mdisibio)
 
 ## v1.2.1 / 2021-11-15
 * [BUGFIX] Fix defaults for MaxBytesPerTrace (ingester.max-bytes-per-trace) and MaxSearchBytesPerTrace (ingester.max-search-bytes-per-trace) [#1109](https://github.com/grafana/tempo/pull/1109) (@bitprocessor)

--- a/modules/ingester/instance_test.go
+++ b/modules/ingester/instance_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/grafana/tempo/tempodb/wal"
 )
 
+const testTenantID = "fake"
+
 type ringCountMock struct {
 	count int
 }
@@ -45,7 +47,7 @@ func TestInstance(t *testing.T) {
 	ingester, _, _ := defaultIngester(t, tempDir)
 	request := test.MakeRequest(10, []byte{})
 
-	i, err := newInstance("fake", limiter, ingester.store, ingester.local)
+	i, err := newInstance(testTenantID, limiter, ingester.store, ingester.local)
 	assert.NoError(t, err, "unexpected error creating new instance")
 	err = i.Push(context.Background(), request)
 	assert.NoError(t, err)
@@ -94,7 +96,7 @@ func TestInstanceFind(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	ingester, _, _ := defaultIngester(t, tempDir)
-	i, err := newInstance("fake", limiter, ingester.store, ingester.local)
+	i, err := newInstance(testTenantID, limiter, ingester.store, ingester.local)
 	assert.NoError(t, err, "unexpected error creating new instance")
 
 	numTraces := 500
@@ -177,7 +179,7 @@ func TestInstanceDoesNotRace(t *testing.T) {
 
 	ingester, _, _ := defaultIngester(t, tempDir)
 
-	i, err := newInstance("fake", limiter, ingester.store, ingester.local)
+	i, err := newInstance(testTenantID, limiter, ingester.store, ingester.local)
 	assert.NoError(t, err, "unexpected error creating new instance")
 
 	end := make(chan struct{})
@@ -321,7 +323,7 @@ func TestInstanceLimits(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			i, err := newInstance("fake", limiter, ingester.store, ingester.local)
+			i, err := newInstance(testTenantID, limiter, ingester.store, ingester.local)
 			require.NoError(t, err, "unexpected error creating new instance")
 
 			for j, push := range tt.pushes {
@@ -501,8 +503,6 @@ func TestInstanceCutBlockIfReady(t *testing.T) {
 }
 
 func TestInstanceMetrics(t *testing.T) {
-	tenantID := "fake"
-
 	limits, err := overrides.NewOverrides(overrides.Limits{})
 	assert.NoError(t, err, "unexpected error creating limits")
 	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
@@ -513,14 +513,14 @@ func TestInstanceMetrics(t *testing.T) {
 
 	ingester, _, _ := defaultIngester(t, tempDir)
 
-	i, err := newInstance(tenantID, limiter, ingester.store, ingester.local)
+	i, err := newInstance(testTenantID, limiter, ingester.store, ingester.local)
 	assert.NoError(t, err, "unexpected error creating new instance")
 
 	cutAndVerify := func(v int) {
 		err := i.CutCompleteTraces(0, true)
 		require.NoError(t, err)
 
-		liveTraces, err := test.GetGaugeVecValue(metricLiveTraces, tenantID)
+		liveTraces, err := test.GetGaugeVecValue(metricLiveTraces, testTenantID)
 		require.NoError(t, err)
 		require.Equal(t, v, int(liveTraces))
 	}
@@ -541,7 +541,6 @@ func TestInstanceMetrics(t *testing.T) {
 
 func TestInstanceFailsLargeTracesEvenAfterFlushing(t *testing.T) {
 	ctx := context.Background()
-	tenantID := "fake"
 	maxTraceBytes := 100
 	id := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 
@@ -557,7 +556,7 @@ func TestInstanceFailsLargeTracesEvenAfterFlushing(t *testing.T) {
 	require.NoError(t, err)
 	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
 
-	i, err := newInstance(tenantID, limiter, ingester.store, ingester.local)
+	i, err := newInstance(testTenantID, limiter, ingester.store, ingester.local)
 	require.NoError(t, err)
 
 	pushFn := func(byteCount int) error {
@@ -616,7 +615,7 @@ func defaultInstance(t require.TestingT, tmpDir string) *instance {
 	}, log.NewNopLogger())
 	assert.NoError(t, err, "unexpected error creating store")
 
-	instance, err := newInstance("fake", limiter, s, l)
+	instance, err := newInstance(testTenantID, limiter, s, l)
 	assert.NoError(t, err, "unexpected error creating new instance")
 
 	return instance

--- a/modules/ingester/trace.go
+++ b/modules/ingester/trace.go
@@ -2,17 +2,13 @@ package ingester
 
 import (
 	"context"
-	"encoding/hex"
 	"time"
 
 	cortex_util "github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/go-kit/log/level"
-	"github.com/gogo/status"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"google.golang.org/grpc/codes"
 
-	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/pkg/tempopb"
 )
 
@@ -54,7 +50,8 @@ func (t *trace) Push(_ context.Context, instanceID string, trace []byte, searchD
 	if t.maxBytes != 0 {
 		reqSize := len(trace)
 		if t.currentBytes+reqSize > t.maxBytes {
-			return status.Errorf(codes.FailedPrecondition, "%s max size of trace (%d) exceeded while adding %d bytes to trace %s", overrides.ErrorPrefixTraceTooLarge, t.maxBytes, reqSize, hex.EncodeToString(t.traceID))
+			//return status.Errorf(codes.FailedPrecondition, "%s max size of trace (%d) exceeded while adding %d bytes to trace %s", overrides.ErrorPrefixTraceTooLarge, t.maxBytes, reqSize, hex.EncodeToString(t.traceID))
+			return newTraceTooLargeError(t.traceID, t.maxBytes, reqSize)
 		}
 
 		t.currentBytes += reqSize

--- a/modules/ingester/trace.go
+++ b/modules/ingester/trace.go
@@ -50,7 +50,6 @@ func (t *trace) Push(_ context.Context, instanceID string, trace []byte, searchD
 	if t.maxBytes != 0 {
 		reqSize := len(trace)
 		if t.currentBytes+reqSize > t.maxBytes {
-			//return status.Errorf(codes.FailedPrecondition, "%s max size of trace (%d) exceeded while adding %d bytes to trace %s", overrides.ErrorPrefixTraceTooLarge, t.maxBytes, reqSize, hex.EncodeToString(t.traceID))
 			return newTraceTooLargeError(t.traceID, t.maxBytes, reqSize)
 		}
 


### PR DESCRIPTION
**What this PR does**:
This PR updates the ingester to keep track of traces that exceeded max size and reject further writes to them, even after they are flushed to disk. The list of traces is reset when cutting the head block. 

**Which issue(s) this PR fixes**:
Fixes part of #1133 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`