### PR TITLE
Backend Search: Add the ability to use a pool of external endpoints

### DIFF
--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -253,7 +253,7 @@ querier:
     # take and return the same value as /api/search endpoint on the querier. This is intended to be
     # used with serverless technologies for massive parrallelization of the search path.
     # The default value of "" disables this feature.
-    [search_external_endpoint: <string> | default = ""]
+    [search_external_endpoints: <list of strings> | default = <empty list>]
 
     # config of the worker that connects to the query frontend
     frontend_worker:

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -249,7 +249,7 @@ querier:
     # Timeout for search requests    
     [search_query_timeout: <duration> | default = 30s]
 
-    # An list of external endpoints that the querier will use to offload backend search requests. It must  
+    # A list of external endpoints that the querier will use to offload backend search requests. They must  
     # take and return the same value as /api/search endpoint on the querier. This is intended to be
     # used with serverless technologies for massive parrallelization of the search path.
     # The default value of "" disables this feature.

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -249,7 +249,7 @@ querier:
     # Timeout for search requests    
     [search_query_timeout: <duration> | default = 30s]
 
-    # An external endpoint that the querier will use to offload backend search requests. It must  
+    # An list of external endpoints that the querier will use to offload backend search requests. It must  
     # take and return the same value as /api/search endpoint on the querier. This is intended to be
     # used with serverless technologies for massive parrallelization of the search path.
     # The default value of "" disables this feature.

--- a/docs/tempo/website/configuration/manifest.md
+++ b/docs/tempo/website/configuration/manifest.md
@@ -129,7 +129,7 @@ ingester_client:
 querier:
   query_timeout: 10s
   search_query_timeout: 30s
-  search_external_endpoint: ""
+  search_external_endpoints: []
   max_concurrent_queries: 5
   frontend_worker:
     frontend_address: 127.0.0.1:9095

--- a/integration/e2e/config-serverless.yaml
+++ b/integration/e2e/config-serverless.yaml
@@ -51,6 +51,7 @@ memberlist:
   - tempo_e2e-querier:7946
 
 querier:
-  search_external_endpoint: "http://tempo_e2e-serverless:8080/"
+  search_external_endpoints: 
+  - http://tempo_e2e-serverless:8080/
   frontend_worker:
     frontend_address: tempo_e2e-query-frontend:9095

--- a/modules/querier/config.go
+++ b/modules/querier/config.go
@@ -13,7 +13,7 @@ import (
 type Config struct {
 	TraceLookupQueryTimeout time.Duration        `yaml:"query_timeout"`
 	SearchQueryTimeout      time.Duration        `yaml:"search_query_timeout"`
-	SearchExternalEndponts  []string             `yaml:"search_external_endpoints"`
+	SearchExternalEndpoints []string             `yaml:"search_external_endpoints"`
 	ExtraQueryDelay         time.Duration        `yaml:"extra_query_delay,omitempty"`
 	MaxConcurrentQueries    int                  `yaml:"max_concurrent_queries"`
 	Worker                  cortex_worker.Config `yaml:"frontend_worker"`

--- a/modules/querier/config.go
+++ b/modules/querier/config.go
@@ -13,7 +13,7 @@ import (
 type Config struct {
 	TraceLookupQueryTimeout time.Duration        `yaml:"query_timeout"`
 	SearchQueryTimeout      time.Duration        `yaml:"search_query_timeout"`
-	SearchExternalEndpont   string               `yaml:"search_external_endpoint"`
+	SearchExternalEndponts  []string             `yaml:"search_external_endpoints"`
 	ExtraQueryDelay         time.Duration        `yaml:"extra_query_delay,omitempty"`
 	MaxConcurrentQueries    int                  `yaml:"max_concurrent_queries"`
 	Worker                  cortex_worker.Config `yaml:"frontend_worker"`

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"sort"
 	"sync"
@@ -391,9 +392,10 @@ func (q *Querier) SearchTagValues(ctx context.Context, req *tempopb.SearchTagVal
 func (q *Querier) SearchBlock(ctx context.Context, req *tempopb.SearchBlockRequest) (*tempopb.SearchResponse, error) {
 	// todo: if the querier is not currently doing anything it should prefer handling the request itself to
 	//  offloading to the external endpoint
-	// check if we should offload this it to another endpoint
-	if q.cfg.SearchExternalEndpont != "" {
-		return searchExternalEndpoint(ctx, q.cfg.SearchExternalEndpont, req)
+	// todo: metrics per endpoint
+	if len(q.cfg.SearchExternalEndponts) != 0 {
+		endpoint := q.cfg.SearchExternalEndponts[rand.Intn(len(q.cfg.SearchExternalEndponts))]
+		return searchExternalEndpoint(ctx, endpoint, req)
 	}
 
 	tenantID, err := user.ExtractOrgID(ctx)


### PR DESCRIPTION
**What this PR does**:
- Changes the `search_external_endpoint` setting to `search_external_endpoints` and takes a list of strings.
- Randomly choose one of the endpoints in the list
- Adds a per external endpoint duration metric.

**Which issue(s) this PR fixes**:
Ticks a box on #1175 

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`