### PR TITLE
Docs: Add v1.2.1 release note items (#1125)

### DIFF
--- a/docs/tempo/website/release-notes/v1-2.md
+++ b/docs/tempo/website/release-notes/v1-2.md
@@ -26,6 +26,11 @@ When upgrading to Tempo v1.2, be aware of these changes:
 
 ## Bug fixes
 
+### 1.2.1 bug fixes
+
+* Honor the default values of configuration parameters `max_bytes_per_trace` and `max_search_bytes_per_trace`. [PR #1109](https://github.com/grafana/tempo/pull/1109) (@BitProcessor)
+* Reclassify the writing of empty traces to be a warning instead of an error. [PR #1113](https://github.com/grafana/tempo/pull/1113) (@mdisibio)
+
 ### 1.2.0 bug fixes
 
 * Fixed errors with magic numbers and other block mishandling when an ingester forcefully shuts down.  [Issue #937](https://github.com/grafana/tempo/issues/937) (@mdisibio)


### PR DESCRIPTION
This backports the addition of the v1.2.1 release notes to the published v1.2.1 docs. (They were only in the "next" version.)