### PR TITLE
Backend Search: Added cli option to query a range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [ENHANCEMENT] Reduce search data file sizes by optimizing contents [#1165](https://github.com/grafana/tempo/pull/1165) (@mdisibio)
 * [ENHANCEMENT] Add `tempo_ingester_live_traces` metric [#1170](https://github.com/grafana/tempo/pull/1170) (@mdisibio)
 * [ENHANCEMENT] Update compactor ring to automatically forget unhealthy entries [#1178](https://github.com/grafana/tempo/pull/1178) (@mdisibio)
+* [ENHANCEMENT] Added the ability to pass ISO8601 date/times for start/end date to tempo-cli query api search [#1208](https://github.com/grafana/tempo/pull/1208) (@joe-elliott)
 * [BUGFIX] Add process name to vulture traces to work around display issues [#1127](https://github.com/grafana/tempo/pull/1127) (@mdisibio)
 * [BUGFIX] Fixed issue where compaction sometimes dropped spans. [#1130](https://github.com/grafana/tempo/pull/1130) (@joe-elliott)
 * [BUGFIX] Ensure that the admin client jsonnet has correct S3 bucket property. (@hedss)

--- a/cmd/tempo-cli/cmd-query-search.go
+++ b/cmd/tempo-cli/cmd-query-search.go
@@ -1,12 +1,17 @@
 package main
 
 import (
+	"time"
+
+	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/util"
 )
 
 type querySearchCmd struct {
 	APIEndpoint string `arg:"" help:"tempo api endpoint"`
 	Tags        string `arg:"" optional:"" help:"tags in logfmt format"`
+	Start       string `arg:"" optional:"" help:"start time in ISO8601 format"`
+	End         string `arg:"" optional:"" help:"end time in ISO8601 format"`
 
 	OrgID string `help:"optional orgID"`
 }
@@ -14,7 +19,32 @@ type querySearchCmd struct {
 func (cmd *querySearchCmd) Run(_ *globalOptions) error {
 	client := util.NewClient(cmd.APIEndpoint, cmd.OrgID)
 
-	tagValues, err := client.Search(cmd.Tags)
+	var start, end int64
+
+	if cmd.Start != "" {
+		startDate, err := time.Parse(time.RFC3339, cmd.Start)
+		if err != nil {
+			return err
+		}
+		start = startDate.Unix()
+	}
+
+	if cmd.End != "" {
+		endDate, err := time.Parse(time.RFC3339, cmd.End)
+		if err != nil {
+			return err
+		}
+		end = endDate.Unix()
+	}
+
+	var tagValues *tempopb.SearchResponse
+	var err error
+	if start == 0 && end == 0 {
+		tagValues, err = client.Search(cmd.Tags)
+	} else {
+		tagValues, err = client.SearchWithRange(cmd.Tags, start, end)
+	}
+
 	if err != nil {
 		return err
 	}

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -126,7 +126,7 @@ func TestAllInOne(t *testing.T) {
 
 			// search the backend. this works b/c we're passing a start/end AND setting query ingesters within min/max to 0
 			now := time.Now()
-			searchAndAssertTraceBackend(t, apiClient, info, int(now.Add(-20*time.Minute).Unix()), int(now.Unix()))
+			searchAndAssertTraceBackend(t, apiClient, info, now.Add(-20*time.Minute).Unix(), now.Unix())
 		})
 	}
 }
@@ -240,7 +240,7 @@ func TestMicroservices(t *testing.T) {
 
 	// search the backend. this works b/c we're passing a start/end AND setting query ingesters within min/max to 0
 	now := time.Now()
-	searchAndAssertTraceBackend(t, apiClient, info, int(now.Add(-20*time.Minute).Unix()), int(now.Unix()))
+	searchAndAssertTraceBackend(t, apiClient, info, now.Add(-20*time.Minute).Unix(), now.Unix())
 
 	// stop another ingester and confirm things fail
 	err = tempoIngester1.Kill()
@@ -436,7 +436,7 @@ func searchAndAssertTrace(t *testing.T, client *tempoUtil.Client, info *tempoUti
 
 // by passing a time range and using a query_ingesters_until/backend_after of 0 we can force the queriers
 // to look in the backend blocks
-func searchAndAssertTraceBackend(t *testing.T, client *tempoUtil.Client, info *tempoUtil.TraceInfo, start int, end int) {
+func searchAndAssertTraceBackend(t *testing.T, client *tempoUtil.Client, info *tempoUtil.TraceInfo, start int64, end int64) {
 	expected, err := info.ConstructTraceFromEpoch()
 	require.NoError(t, err)
 

--- a/integration/e2e/serverless_test.go
+++ b/integration/e2e/serverless_test.go
@@ -80,7 +80,7 @@ func TestServerless(t *testing.T) {
 
 	// search the backend. this works b/c we're passing a start/end AND setting query ingesters within min/max to 0
 	now := time.Now()
-	searchAndAssertTraceBackend(t, apiClient, info, int(now.Add(-20*time.Minute).Unix()), int(now.Unix()))
+	searchAndAssertTraceBackend(t, apiClient, info, now.Add(-20*time.Minute).Unix(), now.Unix())
 }
 
 func newTempoServerless() *cortex_e2e.HTTPService {

--- a/pkg/util/client.go
+++ b/pkg/util/client.go
@@ -112,9 +112,11 @@ func (c *Client) Search(tags string) (*tempopb.SearchResponse, error) {
 	return m, nil
 }
 
-func (c *Client) SearchWithRange(tags string, start int, end int) (*tempopb.SearchResponse, error) {
+// SearchWithRange calls the /api/search endpoint. tags is expected to be in logfmt format and start/end are unix
+// epoch timestamps in seconds.
+func (c *Client) SearchWithRange(tags string, start int64, end int64) (*tempopb.SearchResponse, error) {
 	m := &tempopb.SearchResponse{}
-	_, err := c.getFor(c.BaseURL+"/api/search?tags="+url.QueryEscape(tags)+"&start="+strconv.Itoa(start)+"&end="+strconv.Itoa(end), m)
+	_, err := c.getFor(c.BaseURL+"/api/search?tags="+url.QueryEscape(tags)+"&start="+strconv.FormatInt(start, 10)+"&end="+strconv.FormatInt(end, 10), m)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does**:
Backend search is triggered by passing the `start` and `end` parameters to the `/api/search` endpoint. This PR adds some cli options to do exactly that. Also straightens out some type wrangling with the `client.SearchWithRange` function. 

**Which issue(s) this PR fixes**:
Ticks a box on #1175 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`