### PR TITLE
Update goreleaser install method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * [BUGFIX] Ensure that the admin client jsonnet has correct S3 bucket property. (@hedss)
 * [BUGFIX] Publish tenant index age correctly for tenant index writers. [#1146](https://github.com/grafana/tempo/pull/1146) (@joe-elliott)
 * [BUGFIX] Ingester startup panic `slice bounds out of range` [#1195](https://github.com/grafana/tempo/issues/1195) (@mdisibio)
+* [BUGFIX] Update goreleaser install method from deprecated goreleaser/godownloader. [#](https://github.com/grafana/tempo/) (@mapno)
 
 ## v1.2.1 / 2021-11-15
 * [BUGFIX] Fix defaults for MaxBytesPerTrace (ingester.max-bytes-per-trace) and MaxSearchBytesPerTrace (ingester.max-search-bytes-per-trace) [#1109](https://github.com/grafana/tempo/pull/1109) (@bitprocessor)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 * [BUGFIX] Ensure that the admin client jsonnet has correct S3 bucket property. (@hedss)
 * [BUGFIX] Publish tenant index age correctly for tenant index writers. [#1146](https://github.com/grafana/tempo/pull/1146) (@joe-elliott)
 * [BUGFIX] Ingester startup panic `slice bounds out of range` [#1195](https://github.com/grafana/tempo/issues/1195) (@mdisibio)
-* [BUGFIX] Update goreleaser install method from deprecated goreleaser/godownloader. [#](https://github.com/grafana/tempo/) (@mapno)
+* [BUGFIX] Update goreleaser install method to `go install`. [#](https://github.com/grafana/tempo/) (@mapno)
 
 ## v1.2.1 / 2021-11-15
 * [BUGFIX] Fix defaults for MaxBytesPerTrace (ingester.max-bytes-per-trace) and MaxSearchBytesPerTrace (ingester.max-search-bytes-per-trace) [#1109](https://github.com/grafana/tempo/pull/1109) (@bitprocessor)

--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ vendor-check: gen-proto gen-flat
 	git diff --exit-code -- go.sum go.mod vendor/ pkg/tempopb/ pkg/tempofb/
 
 
-### Release (intended to be used in the .github/workflows/images.yml)
+### Release (intended to be used in the .github/workflows/release.yml)
 $(GORELEASER):
 	go install github.com/goreleaser/goreleaser@latest
 

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ vendor-check: gen-proto gen-flat
 
 ### Release (intended to be used in the .github/workflows/images.yml)
 $(GORELEASER):
-	curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | BINDIR=$(GOPATH)/bin sh
+	go install github.com/goreleaser/goreleaser@latest
 
 release: $(GORELEASER)
 	$(GORELEASER) build --skip-validate --rm-dist


### PR DESCRIPTION
**What this PR does**:

It update goreleaser install method from [deprecated](https://github.com/goreleaser/godownloader/issues/207) goreleaser/godowlowader to [go install](https://goreleaser.com/install/#go-install).

goreleaser is mainly used in the release CI job, in which we previously [set up go](https://github.com/grafana/tempo/blob/main/.github/workflows/release.yml#L10).

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`