### PR TITLE
Fix broken link to blog post

### DIFF
--- a/docs/tempo/website/grafana-agent/_index.md
+++ b/docs/tempo/website/grafana-agent/_index.md
@@ -26,7 +26,7 @@ The Grafana Agent can be configured to run a set of tracing pipelines to collect
 Pipelines are built using OpenTelemetry,
 and consist of `receivers`, `processors` and `exporters`. The architecture mirrors that of the OTel Collector's [design](https://github.com/open-telemetry/opentelemetry-collector/blob/846b971758c92b833a9efaf742ec5b3e2fbd0c89/docs/design.md).
 See the [configuration reference](https://grafana.com/docs/agent/latest/configuration/traces-config/) for all available config options. 
-For a quick start, refer to this [blog post](https://grafana.com/blog/2020/11/17/tracing-with-the-grafana-agent-and-grafana-tempo/).
+For a quick start, refer to this [blog post](https://grafana.com/blog/2020/11/17/tracing-with-the-grafana-cloud-agent-and-grafana-tempo/).
 
 <p align="center"><img src="https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector/846b971758c92b833a9efaf742ec5b3e2fbd0c89/docs/images/design-pipelines.png" alt="Tracing pipeline architecture"></p>
 


### PR DESCRIPTION
This URL changed at some point [after August 15, 2021](https://web.archive.org/web/20210815012958/https://grafana.com/blog/2020/11/17/tracing-with-the-grafana-agent-and-grafana-tempo/). I'd also ask you to pass a note to whoever runs the blog: please [don't change URLs like this](https://www.w3.org/Provider/Style/URI.html), especially without a redirect, it's really poor practice.

The headline appears to have been changed for branding reasons ("Grafana Agent" -> "Grafana Cloud Agent"), which is fine, but that headline change should _not_ be propagated back to the URL as well. Most blogging platforms allow you to do this (and should do so by default), and news sites and such properly change headlines while preserving the URL all the time.

In the meantime, this fixes the one reference I happened to stumble across, out of the probably-many references to the old URL across the web. The actual fix is to set up a redirect from the old URL to the new URL, but I can't submit a PR for that, so please forward that request along as well!

Also, while I'm at it, I ran across [a blogpost on grafanalabs](https://grafanalabs.com/blog/2021/04/13/how-to-send-traces-to-grafana-clouds-tempo-service-with-opentelemetry-collector/), which is another place with a now-broken link, and noticed that the certificate I got is invalid - it doesn't include `grafanalabs.com` in its alt names, and thus is not a valid certificate for that domain. So, probably pass that onto your web folks as well.

**What this PR does**:
Fixes a broken link to a blogpost in the documentation
**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ N/A ] Tests updated
- [x] Documentation added
- [?] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`