### PR TITLE
Docs: remove unneeded v1.3.0 bug fix release notes subsection

### DIFF
--- a/docs/tempo/website/release-notes/v1-3.md
+++ b/docs/tempo/website/release-notes/v1-3.md
@@ -44,8 +44,3 @@ Configuration option `querier.search_default_result_limit` is renamed to `query_
 - [PR 1173](https://github.com/grafana/tempo/pull/1173): Removed the
 deprecated `Push` method from `tempopb.Pusher`.
 
-## Bug fixes
-
-### 1.3.0 bug fixes
-
-- Bug fix description here. [PR #nnnn](PR URL here) (@name-of-PR-submitter)


### PR DESCRIPTION
We're not listing any of the bugs fixed for v1.3.0, so remove the subsection from the release notes.