### PR TITLE
Tempo Backend Search: Actual Fixes

### DIFF
--- a/pkg/model/matches_test.go
+++ b/pkg/model/matches_test.go
@@ -299,7 +299,7 @@ func TestMatches(t *testing.T) {
 			req: &tempopb.SearchRequest{
 				Start: 12,
 				End:   15,
-				Tags:  map[string]string{"foo": "bar", "boolFoo": "true"},
+				Tags:  map[string]string{"foo": "bar", "boolfoo": "true"},
 			},
 			expected: testMetadata,
 		},

--- a/pkg/model/matches_test.go
+++ b/pkg/model/matches_test.go
@@ -22,6 +22,10 @@ func TestMatches(t *testing.T) {
 							Key:   "service.name",
 							Value: &v1common.AnyValue{Value: &v1common.AnyValue_StringValue{StringValue: "svc"}},
 						},
+						{
+							Key:   "cluster",
+							Value: &v1common.AnyValue{Value: &v1common.AnyValue_StringValue{StringValue: "prod"}},
+						},
 					},
 				},
 				InstrumentationLibrarySpans: []*v1.InstrumentationLibrarySpans{
@@ -48,6 +52,9 @@ func TestMatches(t *testing.T) {
 										Key:   "boolfoo",
 										Value: &v1common.AnyValue{Value: &v1common.AnyValue_BoolValue{BoolValue: true}},
 									},
+								},
+								Status: &v1.Status{
+									Code: v1.Status_STATUS_CODE_OK,
 								},
 							},
 						},
@@ -293,6 +300,86 @@ func TestMatches(t *testing.T) {
 				Start: 12,
 				End:   15,
 				Tags:  map[string]string{"foo": "bar", "boolFoo": "true"},
+			},
+			expected: testMetadata,
+		},
+		{
+			name:  "two resource tags. one excludes",
+			trace: testTrace,
+			req: &tempopb.SearchRequest{
+				Start: 12,
+				End:   15,
+				Tags:  map[string]string{"cluster": "prod", "service.name": "not"},
+			},
+			expected: nil,
+		},
+		{
+			name:  "name includes",
+			trace: testTrace,
+			req: &tempopb.SearchRequest{
+				Start: 12,
+				End:   15,
+				Tags:  map[string]string{"name": "test"},
+			},
+			expected: testMetadata,
+		},
+		{
+			name:  "name excludes",
+			trace: testTrace,
+			req: &tempopb.SearchRequest{
+				Start: 12,
+				End:   15,
+				Tags:  map[string]string{"name": "no"},
+			},
+			expected: nil,
+		},
+		{
+			name:  "name excludes with resource tag",
+			trace: testTrace,
+			req: &tempopb.SearchRequest{
+				Start: 12,
+				End:   15,
+				Tags:  map[string]string{"name": "no", "cluster": "prod"},
+			},
+			expected: nil,
+		},
+		{
+			name:  "name excludes with span tag",
+			trace: testTrace,
+			req: &tempopb.SearchRequest{
+				Start: 12,
+				End:   15,
+				Tags:  map[string]string{"name": "no", "foo": "barricus"},
+			},
+			expected: nil,
+		},
+		{
+			name:  "error excludes",
+			trace: testTrace,
+			req: &tempopb.SearchRequest{
+				Start: 12,
+				End:   15,
+				Tags:  map[string]string{"error": "true"},
+			},
+			expected: nil,
+		},
+		{
+			name:  "status.code excludes",
+			trace: testTrace,
+			req: &tempopb.SearchRequest{
+				Start: 12,
+				End:   15,
+				Tags:  map[string]string{"status.code": "error"},
+			},
+			expected: nil,
+		},
+		{
+			name:  "status.code includes",
+			trace: testTrace,
+			req: &tempopb.SearchRequest{
+				Start: 12,
+				End:   15,
+				Tags:  map[string]string{"status.code": "ok"},
 			},
 			expected: testMetadata,
 		},

--- a/pkg/model/trace/matches.go
+++ b/pkg/model/trace/matches.go
@@ -14,31 +14,23 @@ import (
 
 const RootSpanNotYetReceivedText = "<root span not yet received>"
 
-const (
-	notFound    = 1
-	failedMatch = 2
-	passedMatch = 3
-)
-
 func MatchesProto(id []byte, trace *tempopb.Trace, req *tempopb.SearchRequest) (*tempopb.TraceSearchMetadata, error) {
 	traceStart := uint64(math.MaxUint64)
 	traceEnd := uint64(0)
 
-	traceMatch := notFound
-	if len(req.Tags) == 0 {
-		traceMatch = passedMatch
+	// copy the tags from tempopb.SearchRequest. This map is then mutated by the two match* functions below
+	// if, at the end of this loop, there are no more entries in the map then we matched all tags
+	tagsToFind := map[string]string{}
+	for k, v := range req.Tags {
+		tagsToFind[k] = v
 	}
 
 	var rootSpan *v1.Span
 	var rootBatch *v1.ResourceSpans
 	// todo: is it possible to shortcircuit this loop?
 	for _, b := range trace.Batches {
-		// check if the batch matches. we will use the value of batchMatch later to determine if
-		//  - we need to bother checking if the spans match
-		//  - we can mark the entire trace as matching
-		batchMatch := notFound
-		if traceMatch != passedMatch {
-			batchMatch = matchAttributes(req.Tags, b.Resource.Attributes)
+		if !allTagsFound(tagsToFind) {
+			matchAttributes(tagsToFind, b.Resource.Attributes)
 		}
 
 		for _, ils := range b.InstrumentationLibrarySpans {
@@ -55,31 +47,18 @@ func MatchesProto(id []byte, trace *tempopb.Trace, req *tempopb.SearchRequest) (
 				}
 
 				// if the trace has already matched we don't have to bother
-				if traceMatch == passedMatch {
-					continue
-				}
-
-				// if the batch explicitly doesn't match we don't have to bother
-				if batchMatch == failedMatch {
+				if allTagsFound(tagsToFind) {
 					continue
 				}
 
 				// checks non attribute span properties for matching
-				spanMatch := matchSpan(req.Tags, s)
-				if spanMatch == failedMatch {
-					continue
-				}
-
-				spanAttsMatch := matchAttributes(req.Tags, s.Attributes)
-				// if batch, span attributes or the span itself match then the trace matches
-				if spanAttsMatch == passedMatch || batchMatch == passedMatch || spanMatch == passedMatch {
-					traceMatch = passedMatch
-				}
+				matchSpan(tagsToFind, s)
+				matchAttributes(tagsToFind, s.Attributes)
 			}
 		}
 	}
 
-	if traceMatch != passedMatch {
+	if !allTagsFound(tagsToFind) {
 		return nil, nil
 	}
 
@@ -120,45 +99,37 @@ func MatchesProto(id []byte, trace *tempopb.Trace, req *tempopb.SearchRequest) (
 	}, nil
 }
 
-// matchSpan searches for two reserved tag names "name" and "error" and maps them to actual
-// properties of the span. it returns false if the span explicitly fails to match based on the
-// passed conditions and true otherwise.
-func matchSpan(tags map[string]string, s *v1.Span) int {
-	match := notFound
+func allTagsFound(tagsToFind map[string]string) bool {
+	return len(tagsToFind) == 0
+}
 
+// matchSpan searches for reserved tag names and maps them to actual
+// properties of the span. it removes any matches it finds from
+// the provided tags map
+func matchSpan(tags map[string]string, s *v1.Span) {
 	if name, ok := tags[search.SpanNameTag]; ok {
-		if name != s.Name {
-			return failedMatch
-		} else {
-			match = passedMatch
+		if name == s.Name {
+			delete(tags, search.SpanNameTag)
 		}
 	}
 
 	if err, ok := tags[search.ErrorTag]; ok {
-		if err == "true" && s.Status.Code != v1.Status_STATUS_CODE_ERROR {
-			return failedMatch
-		} else {
-			match = passedMatch
+		if err == "true" && s.Status.Code == v1.Status_STATUS_CODE_ERROR {
+			delete(tags, search.ErrorTag)
 		}
 	}
 
 	if status, ok := tags[search.StatusCodeTag]; ok {
-		if search.StatusCodeMapping[status] != int(s.Status.Code) {
-			return failedMatch
-		} else {
-			match = passedMatch
+		if search.StatusCodeMapping[status] == int(s.Status.Code) {
+			delete(tags, search.StatusCodeTag)
 		}
 	}
-
-	return match
 }
 
-// matchAttributes returns an int that indicates if the passed tags match the trace attributes
-//  possible values: attributesNotFound, attributesFailedMatch, attributesPassedMatch
-func matchAttributes(tags map[string]string, atts []*v1common.KeyValue) int {
+// matchAttributes tests to see if any tags in the map match any passed attributes
+//  if it finds a match it removes the key from the map
+func matchAttributes(tags map[string]string, atts []*v1common.KeyValue) {
 	// start with the assumption that we won't find any matching attributes
-	allMatch := notFound
-
 	for _, a := range atts {
 		var searchString string
 		var ok bool
@@ -190,15 +161,8 @@ func matchAttributes(tags map[string]string, atts []*v1common.KeyValue) int {
 			}
 		}
 
-		// if an individual attribute failed to match we can bail here
-		if !match {
-			return failedMatch
+		if match {
+			delete(tags, a.Key)
 		}
-
-		// if we're here we've found a match but we need to continue searching in case
-		//  a future tag fails to match
-		allMatch = passedMatch
 	}
-
-	return allMatch
 }

--- a/pkg/model/trace/matches.go
+++ b/pkg/model/trace/matches.go
@@ -71,7 +71,7 @@ func MatchesProto(id []byte, trace *tempopb.Trace, req *tempopb.SearchRequest) (
 				}
 
 				spanAttsMatch := matchAttributes(req.Tags, s.Attributes)
-				// if either the batch OR the span explicitly match us then we're good
+				// if batch, span attributes or the span itself match then the trace matches
 				if spanAttsMatch == passedMatch || batchMatch == passedMatch || spanMatch == passedMatch {
 					traceMatch = passedMatch
 				}

--- a/tempodb/search/pipeline.go
+++ b/tempodb/search/pipeline.go
@@ -126,7 +126,7 @@ func (p *Pipeline) rewriteTagLookup(k, v string) (skip bool, newk, newv string) 
 
 	case StatusCodeTag:
 		// Convert status.code=string into status.code=int
-		for statusStr, statusID := range statusCodeMapping {
+		for statusStr, statusID := range StatusCodeMapping {
 			if v == statusStr {
 				return false, StatusCodeTag, strconv.Itoa(statusID)
 			}

--- a/tempodb/search/util.go
+++ b/tempodb/search/util.go
@@ -19,7 +19,7 @@ const (
 	StatusCodeError    = "error"
 )
 
-var statusCodeMapping = map[string]int{
+var StatusCodeMapping = map[string]int{
 	StatusCodeUnset: int(v1.Status_STATUS_CODE_UNSET),
 	StatusCodeOK:    int(v1.Status_STATUS_CODE_OK),
 	StatusCodeError: int(v1.Status_STATUS_CODE_ERROR),


### PR DESCRIPTION
**What this PR does**:
The previous PR (#1234) incorrectly tested for all conditions to be true on a single span which would make backend search behave differently then ingester search. This PR

- correctly tests to make sure query conditions are true across the entire trace
- adds support for `name`, `status.code` and `error` tags
- removes an errant .zip file from the repo

Respect to @annanay25 for his earlier suggestion. My approach of asserting conditions per span was wrong from the start! Using a map to track conditions across the entire trace was the correct approach.