### PR TITLE
Cherry-pick: drone: pin alpine/git image to avoid APK errors on arm64

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -43,14 +43,14 @@ local gh_token_secret = secret('gh_token', 'infra/data/ci/github/grafanabot', 'p
 
 ## Steps ##
 
+// the alpine/git image has apk errors when run on aarch64, this is the most recent image that does not have this issue
+// https://github.com/alpine-docker/git/issues/35
+local alpine_git_image = 'alpine/git:v2.30.2';
+
 local image_tag(arch = '') = {
   name: 'image-tag',
-  image: 'alpine/git',
-  commands: (
-    // the alpine/git image has apk errors when run in arm64, fix them before running any other apk command
-    // https://github.com/alpine-docker/git/issues/35
-    if arch == 'arm64' then ['apk fix'] else []
-  ) + [
+  image: alpine_git_image,
+  commands: [
     'apk --update --no-cache add bash',
     'git fetch origin --tags',
   ] + (
@@ -64,7 +64,7 @@ local image_tag(arch = '') = {
 
 local image_tag_for_cd() = {
     name: 'image-tag-for-cd',
-    image: 'alpine/git',
+    image: alpine_git_image,
     commands: [
       'apk --update --no-cache add bash',
       'git fetch origin --tags',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -8,7 +8,7 @@ platform:
 
 steps:
 - name: image-tag
-  image: alpine/git
+  image: alpine/git:v2.30.2
   commands:
   - apk --update --no-cache add bash
   - git fetch origin --tags
@@ -75,9 +75,8 @@ platform:
 
 steps:
 - name: image-tag
-  image: alpine/git
+  image: alpine/git:v2.30.2
   commands:
-  - apk fix
   - apk --update --no-cache add bash
   - git fetch origin --tags
   - echo $(./tools/image-tag)-arm64 > .tags
@@ -143,7 +142,7 @@ platform:
 
 steps:
 - name: image-tag
-  image: alpine/git
+  image: alpine/git:v2.30.2
   commands:
   - apk --update --no-cache add bash
   - git fetch origin --tags
@@ -200,7 +199,7 @@ platform:
 
 steps:
 - name: image-tag-for-cd
-  image: alpine/git
+  image: alpine/git:v2.30.2
   commands:
   - apk --update --no-cache add bash
   - git fetch origin --tags
@@ -259,6 +258,6 @@ get:
 
 ---
 kind: signature
-hmac: 5c2e81faa8e2b8958c2873f92194c48a17a4780472405b918470ce95895e4e1c
+hmac: dbde127696cdb509254bc4a59f8da3d09f9059ddad5062aab407594964897588
 
 ...


### PR DESCRIPTION
(cherry picked from commit be6476d9a1d171055f284c434f3432615258ca1c)

**What this PR does**:
Cherry pick #1242 onto r28, this is needed to build a Docker image for this branch.