### PR TITLE
Docs: Reword to note Grafana does not yet have tempoBackendSearch toggle

### DIFF
--- a/docs/tempo/website/getting-started/tempo-in-grafana.md
+++ b/docs/tempo/website/getting-started/tempo-in-grafana.md
@@ -45,7 +45,7 @@ Refer to the [search](../../configuration#search) configuration documentation.
 Further configration information is in [backend search](../../operations/backend_search).
 The Tempo configuration is the same for searching recent traces or
 for search of the backend datastore. 
--  Run Grafana 8.3.6 (coming soon) or a more recent version. Enable the `tempoBackendSearch` [feature toggle](https://github.com/grafana/tempo/blob/main/example/docker-compose/tempo-search/grafana.ini). This will cause Grafana to pass the `start` and `end` parameters necessary for the backend datastore search.
+-  This feature is not yet available in Grafana. When Grafana is updated, you will be able to run the most recent version of Grafana and enable the `tempoBackendSearch` [feature toggle](https://github.com/grafana/tempo/blob/main/example/docker-compose/tempo-search/grafana.ini). This will cause Grafana to pass the `start` and `end` parameters necessary for the backend datastore search.
 
 ## View JSON file
 A local JSON file containing a trace can be uploaded and viewed in the Grafana UI.  This is useful in cases where access to the original Tempo datasource is limited, or for preserving traces outside of Tempo.  The JSON data can be downloaded via the Tempo API or the Inspector panel while viewing the trace in Grafana.

--- a/docs/tempo/website/release-notes/v1-3.md
+++ b/docs/tempo/website/release-notes/v1-3.md
@@ -44,3 +44,8 @@ Configuration option `querier.search_default_result_limit` is renamed to `query_
 - [PR 1173](https://github.com/grafana/tempo/pull/1173): Removed the
 deprecated `Push` method from `tempopb.Pusher`.
 
+## Known issues
+
+- Grafana does not yet support the `tempoBackendSearch` feature toggle
+to enable searches in the backend datastore.
+


### PR DESCRIPTION
Add this in the release notes and in the feature documentation.