### PR TITLE
Enterprise jsonnet: add config to create tokengen job explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## main / unreleased
+* [ENHACEMENT] Enterprise jsonnet: add config to create tokengen job explicitly [#1256](https://github.com/grafana/tempo/pull/1256) (@kvrhdn)
 * [BUGFIX]: Remove unnecessary PersistentVolumeClaim [#1245](https://github.com/grafana/tempo/issues/1245)
 * [BUGFIX] Fixed issue when query-frontend doesn't log request details when request is cancelled [#1136](https://github.com/grafana/tempo/issues/1136) (@adityapwr)
 

--- a/operations/jsonnet/enterprise/main.libsonnet
+++ b/operations/jsonnet/enterprise/main.libsonnet
@@ -34,10 +34,10 @@ tempo {
   },
 
   _config+:: {
-    // enable to create the tokengen job, this job has to run once to create a token from the GET
-    // license. Once the token has been generated, this setting should be disabled to not update
-    // the job anymore.
-    run_tokengen_job: false,
+    // Enable to create the tokengen job, this job has to run once when installing GET to create a
+    // token from the GET license. Once the token has been generated, this setting should be
+    // disabled to not update the job anymore.
+    create_tokengen_job: false,
 
     http_api_prefix: '/tempo',
     otlp_port: 4317,
@@ -140,7 +140,7 @@ tempo {
 
   // tokengen target
   tokengen: {}
-    + (if $._config.run_tokengen_job then {
+    + (if $._config.create_tokengen_job then {
     local tokengen_args = {
       target: 'tokengen',
       'config.file': '/conf/tempo.yaml',

--- a/operations/jsonnet/enterprise/main.libsonnet
+++ b/operations/jsonnet/enterprise/main.libsonnet
@@ -34,6 +34,11 @@ tempo {
   },
 
   _config+:: {
+    // enable to create the tokengen job, this job has to run once to create a token from the GET
+    // license. Once the token has been generated, this setting should be disabled to not update
+    // the job anymore.
+    run_tokengen_job: false,
+
     http_api_prefix: '/tempo',
     otlp_port: 4317,
     distributor+: {
@@ -53,7 +58,6 @@ tempo {
       pvc_size: '50Gi',
       pvc_storage_class: 'fast',
     },
-
   },
 
   tempo_config+:: {
@@ -135,63 +139,66 @@ tempo {
     util.serviceFor($.gateway_deployment),
 
   // tokengen target
-  tokengen_args:: {
-    target: 'tokengen',
-    'config.file': '/conf/tempo.yaml',
-    'tokengen.token-file': '/shared/admin-token',
-  },
-  tokengen_container::
-    container.new('tokengen', $._images.tempo)
-    + container.withArgs(util.mapToFlags($.tokengen_args))
-    + container.withVolumeMounts([
-      { mountPath: '/conf', name: $.tempo_config_map.metadata.name },
-      { mountPath: '/shared', name: 'shared' },
-    ])
-    + container.resources.withLimits({ memory: '4Gi' })
-    + container.resources.withRequests({ cpu: '500m', memory: '500Mi' }),
-  tokengen_create_secret_container::
-    container.new('create-secret', $._images.kubectl)
-    + container.withCommand([
-      '/bin/bash',
-      '-euc',
-      'kubectl create secret generic get-admin-token --from-file=token=/shared/admin-token --from-literal=grafana-token="$(base64 <(echo :$(cat /shared/admin-token)))"',
-    ])
-    + container.withVolumeMounts([{ mountPath: '/shared', name: 'shared' }]),
-  tokengen_job:
-    job.new('tokengen')
-    + job.spec.withCompletions(1)
-    + job.spec.withParallelism(1)
-    + job.spec.template.spec.withContainers([$.tokengen_create_secret_container])
-    + job.spec.template.spec.withInitContainers([$.tokengen_container])
-    + job.spec.template.spec.withRestartPolicy('OnFailure')
-    + job.spec.template.spec.withServiceAccount('tokengen')
-    + job.spec.template.spec.withServiceAccountName('tokengen')
-    + job.spec.template.spec.withVolumes([
-      { name: $.tempo_config_map.metadata.name, configMap: { name: $.tempo_config_map.metadata.name } },
-      { name: 'shared', emptyDir: {} },
-    ])
-    + util.withNonRootSecurityContext(uid=10001),
-  tokengen_service_account:
-    serviceAccount.new('tokengen'),
-  tokengen_cluster_role:
-    clusterRole.new('tokengen')
-    + clusterRole.withRules([
-      policyRule.withApiGroups([''])
-      + policyRule.withResources(['secrets'])
-      + policyRule.withVerbs(['create']),
-    ]),
-  tokengen_cluster_role_binding:
-    clusterRoleBinding.new()
-    + clusterRoleBinding.metadata.withName('tokengen')
-    + clusterRoleBinding.roleRef.withApiGroup('rbac.authorization.k8s.io')
-    + clusterRoleBinding.roleRef.withKind('ClusterRole')
-    + clusterRoleBinding.roleRef.withName('tokengen')
-    + clusterRoleBinding.withSubjects([
-      subject.new()
-      + subject.withName('tokengen')
-      + subject.withKind('ServiceAccount')
-      + { namespace: $._config.namespace },
-    ]),
+  tokengen: {}
+    + (if $._config.run_tokengen_job then {
+    local tokengen_args = {
+      target: 'tokengen',
+      'config.file': '/conf/tempo.yaml',
+      'tokengen.token-file': '/shared/admin-token',
+    },
+    local tokengen_container =
+      container.new('tokengen', $._images.tempo)
+      + container.withArgs(util.mapToFlags(tokengen_args))
+      + container.withVolumeMounts([
+        { mountPath: '/conf', name: $.tempo_config_map.metadata.name },
+        { mountPath: '/shared', name: 'shared' },
+      ])
+      + container.resources.withLimits({ memory: '4Gi' })
+      + container.resources.withRequests({ cpu: '500m', memory: '500Mi' }),
+    local tokengen_create_secret_container =
+      container.new('create-secret', $._images.kubectl)
+      + container.withCommand([
+        '/bin/bash',
+        '-euc',
+        'kubectl create secret generic get-admin-token --from-file=token=/shared/admin-token --from-literal=grafana-token="$(base64 <(echo :$(cat /shared/admin-token)))"',
+      ])
+      + container.withVolumeMounts([{ mountPath: '/shared', name: 'shared' }]),
+    tokengen_job:
+      job.new('tokengen')
+      + job.spec.withCompletions(1)
+      + job.spec.withParallelism(1)
+      + job.spec.template.spec.withContainers([tokengen_create_secret_container])
+      + job.spec.template.spec.withInitContainers([tokengen_container])
+      + job.spec.template.spec.withRestartPolicy('OnFailure')
+      + job.spec.template.spec.withServiceAccount('tokengen')
+      + job.spec.template.spec.withServiceAccountName('tokengen')
+      + job.spec.template.spec.withVolumes([
+        { name: $.tempo_config_map.metadata.name, configMap: { name: $.tempo_config_map.metadata.name } },
+        { name: 'shared', emptyDir: {} },
+      ])
+      + util.withNonRootSecurityContext(uid=10001),
+    tokengen_service_account:
+      serviceAccount.new('tokengen'),
+    tokengen_cluster_role:
+      clusterRole.new('tokengen')
+      + clusterRole.withRules([
+        policyRule.withApiGroups([''])
+        + policyRule.withResources(['secrets'])
+        + policyRule.withVerbs(['create']),
+      ]),
+    tokengen_cluster_role_binding:
+      clusterRoleBinding.new()
+      + clusterRoleBinding.metadata.withName('tokengen')
+      + clusterRoleBinding.roleRef.withApiGroup('rbac.authorization.k8s.io')
+      + clusterRoleBinding.roleRef.withKind('ClusterRole')
+      + clusterRoleBinding.roleRef.withName('tokengen')
+      + clusterRoleBinding.withSubjects([
+        subject.new()
+        + subject.withName('tokengen')
+        + subject.withKind('ServiceAccount')
+        + { namespace: $._config.namespace },
+      ]),
+    } else {}),
 
   // upstream configuration overrides
 


### PR DESCRIPTION
**What this PR does**:
The jsonnet for GET creates a job to generate the token from a GET license (`tokengen`). This job should be created once when installing GET and the job can not be modified afterwards. To make this easier to manage, this PR adds a config option `run_tokengen_job` which is disabled by default and can be set to explicitly create the tokengen job.

_How it works:_

The first time a GET cluster is created the user should set:

```jsonnet
  _config+:: {
    run_tokengen_job: true,
  },
```

During `tk apply`, tanka will create the tokengen job (just like before). After the job has run, the user should remove this line and the tokengen job will not be modified anymore by tanka.

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [ ] ~~Tests updated~~
- [ ] Documentation added: update https://grafana.com/docs/enterprise-traces/next/setup/tanka/
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`