### PR TITLE
Fork the Prometheus Byte Pool

### DIFF
--- a/pkg/tempopb/pool/pool.go
+++ b/pkg/tempopb/pool/pool.go
@@ -1,0 +1,74 @@
+// Forked with love from: https://github.com/prometheus/prometheus/tree/c954cd9d1d4e3530be2939d39d8633c38b70913f/util/pool
+// This package was forked to provide better protection against putting byte slices back into the pool that
+// did not originate from it.
+
+package pool
+
+import (
+	"sync"
+)
+
+// Pool is a bucketed pool for variably sized byte slices.
+type Pool struct {
+	buckets []sync.Pool
+	sizes   []int
+	// make is the function used to create an empty slice when none exist yet.
+	make func(int) []byte
+}
+
+// New returns a new Pool with size buckets for minSize to maxSize
+// increasing by the given factor.
+func New(minSize, maxSize int, factor float64, makeFunc func(int) []byte) *Pool {
+	if minSize < 1 {
+		panic("invalid minimum pool size")
+	}
+	if maxSize < 1 {
+		panic("invalid maximum pool size")
+	}
+	if factor < 1 {
+		panic("invalid factor")
+	}
+
+	var sizes []int
+
+	for s := minSize; s <= maxSize; s = int(float64(s) * factor) {
+		sizes = append(sizes, s)
+	}
+
+	p := &Pool{
+		buckets: make([]sync.Pool, len(sizes)),
+		sizes:   sizes,
+		make:    makeFunc,
+	}
+
+	return p
+}
+
+// Get returns a new byte slices that fits the given size.
+func (p *Pool) Get(sz int) []byte {
+	for i, bktSize := range p.sizes {
+		if sz > bktSize {
+			continue
+		}
+		b := p.buckets[i].Get()
+		if b == nil {
+			b = p.make(bktSize)
+		}
+		return b.([]byte)
+	}
+	return p.make(sz)
+}
+
+// Put adds a slice to the right bucket in the pool. This method has been adjusted from its initial
+// implementation to ignore byte slices that dont have the correct size
+func (p *Pool) Put(s []byte) {
+	c := cap(s)
+	for i, size := range p.sizes {
+		if c == size {
+			p.buckets[i].Put(s)
+		}
+		if c < size {
+			return
+		}
+	}
+}

--- a/pkg/tempopb/pool/pool_test.go
+++ b/pkg/tempopb/pool/pool_test.go
@@ -1,0 +1,74 @@
+// Forked with love from: https://github.com/prometheus/prometheus/tree/c954cd9d1d4e3530be2939d39d8633c38b70913f/util/pool
+
+package pool
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func makeFunc(size int) []byte {
+	return make([]byte, 0, size)
+}
+
+func TestPool(t *testing.T) {
+	testPool := New(1, 8, 2, makeFunc)
+	cases := []struct {
+		size        int
+		expectedCap int
+	}{
+		{
+			size:        -1,
+			expectedCap: 1,
+		},
+		{
+			size:        3,
+			expectedCap: 4,
+		},
+		{
+			size:        10,
+			expectedCap: 10,
+		},
+	}
+	for _, c := range cases {
+		ret := testPool.Get(c.size)
+		require.Equal(t, c.expectedCap, cap(ret))
+		testPool.Put(ret)
+	}
+}
+
+func TestPoolIgnoresRandomCapSlices(t *testing.T) {
+	testPool := New(1, 1024, 2, makeFunc)
+
+	for i := 0; i < 10000; i++ {
+		size := rand.Intn(1000)
+		externalSlice := make([]byte, 0, size)
+		testPool.Put(externalSlice)
+
+		size = rand.Intn(1000)
+		ret := testPool.Get(size)
+
+		require.True(t, cap(ret) >= size)
+	}
+}
+
+// TestPoolReusesSlice checks to make sure if a slice is reused in the pool. Since this depends on
+// the underlying sync.Pool implementation it's a bad-ish test and should be removed if it gets flakey.
+// Added to confirm that the Get/Put []byte methods choose the same buckets.
+func TestPoolReusesSlice(t *testing.T) {
+	testPool := New(1, 1024, 2, makeFunc)
+	size := 33
+	mark := byte(0x42)
+	markPos := 5
+
+	// get a slice and mark it so we can check its reused
+	s := testPool.Get(size)[:size]
+	s[markPos] = mark
+	testPool.Put(s)
+
+	// request a slice of the same size
+	s = testPool.Get(size)[:size]
+	require.Equal(t, mark, s[markPos])
+}

--- a/pkg/tempopb/prealloc.go
+++ b/pkg/tempopb/prealloc.go
@@ -1,12 +1,12 @@
 package tempopb
 
 import (
-	"github.com/prometheus/prometheus/util/pool"
+	"github.com/grafana/tempo/pkg/tempopb/pool"
 )
 
 var (
 	// buckets: [0.5KiB, 1KiB, 2KiB, 4KiB, 8KiB, 16KiB]
-	bytePool = pool.New(500, 16_000, 2, func(size int) interface{} { return make([]byte, 0, size) })
+	bytePool = pool.New(500, 16_000, 2, func(size int) []byte { return make([]byte, 0, size) })
 )
 
 // PreallocBytes is a (repeated bytes slices) which preallocs slices on Unmarshal.
@@ -16,7 +16,7 @@ type PreallocBytes struct {
 
 // Unmarshal implements proto.Message.
 func (r *PreallocBytes) Unmarshal(dAtA []byte) error {
-	r.Slice = bytePool.Get(len(dAtA)).([]byte)
+	r.Slice = bytePool.Get(len(dAtA))
 	r.Slice = r.Slice[:len(dAtA)]
 	copy(r.Slice, dAtA)
 	return nil
@@ -46,5 +46,5 @@ func ReuseTraceBytes(trace *TraceBytes) {
 
 // SliceFromBytePool gets a slice from the byte pool
 func SliceFromBytePool(size int) []byte {
-	return bytePool.Get(size).([]byte)[:size]
+	return bytePool.Get(size)[:size]
 }


### PR DESCRIPTION
**What this PR does**:
Forks the [prometheus byte pool](https://github.com/prometheus/prometheus/tree/c954cd9d1d4e3530be2939d39d8633c38b70913f/util/pool) in order to make a few small changes:

- Updated to work with `[]byte` only
- `Put` changed to only accept byte slices whose lengths align with the created buckets. This prevents panics when byte slices are added to the pool that did not originate from it. Given our use of the byte pool it is very difficult to guarantee that those slices we add back to the pool came from it. 

This PR is required for #1227.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`