### PR TITLE
Docs: Remove TOC entry that links to nothing

### DIFF
--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -15,7 +15,6 @@ This document explains the configuration options for Tempo as well as the detail
   - [compactor](#compactor)
   - [storage](#storage)
   - [memberlist](#memberlist)
-  - [polling](#polling)
   - [overrides](#overrides)
   - [search](#search)
 


### PR DESCRIPTION
**What this PR does**:
The polling link is broken in this doc. Removing!