### PR TITLE
Makefile: add update-mod to tidy go.mod's

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ gen-flat:
 ### Check vendored files and generated proto
 .PHONY: vendor-check
 vendor-check: gen-proto gen-flat update-mod
-	git diff --exit-code -- go.sum go.mod vendor/ pkg/tempopb/ pkg/tempofb/
+	git diff --exit-code -- **/go.sum **/go.mod vendor/ pkg/tempopb/ pkg/tempofb/
 
 ### Tidy dependencies for tempo and tempo-serverless modules
 .PHONY: update-mod

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ vendor-check: gen-proto gen-flat update-mod
 update-mod:
 	go mod vendor
 	go mod tidy -e
-	cd cmd/tempo-serverless && go mod tidy -e
+	$(MAKE) -C cmd/tempo-serverless update-mod
 
 
 ### Release (intended to be used in the .github/workflows/release.yml)

--- a/Makefile
+++ b/Makefile
@@ -178,10 +178,15 @@ gen-flat:
 
 ### Check vendored files and generated proto
 .PHONY: vendor-check
-vendor-check: gen-proto gen-flat
+vendor-check: gen-proto gen-flat update-mod
+	git diff --exit-code -- go.sum go.mod vendor/ pkg/tempopb/ pkg/tempofb/
+
+### Tidy dependencies for tempo and tempo-serverless modules
+.PHONY: update-mod
+update-mod:
 	go mod vendor
 	go mod tidy -e
-	git diff --exit-code -- go.sum go.mod vendor/ pkg/tempopb/ pkg/tempofb/
+	cd cmd/tempo-serverless && go mod tidy -e
 
 
 ### Release (intended to be used in the .github/workflows/release.yml)

--- a/cmd/tempo-serverless/Makefile
+++ b/cmd/tempo-serverless/Makefile
@@ -32,7 +32,7 @@ test:
 	go test -v .
 
 
-### Tidy dependencies for tempo and tempo-serverless modules
+### Tidy dependencies for tempo-serverless module
 .PHONY: update-mod
 update-mod:
 	go mod tidy -e

--- a/cmd/tempo-serverless/Makefile
+++ b/cmd/tempo-serverless/Makefile
@@ -30,3 +30,9 @@ build-zip:
 
 test:
 	go test -v .
+
+
+### Tidy dependencies for tempo and tempo-serverless modules
+.PHONY: update-mod
+update-mod:
+	go mod tidy -e


### PR DESCRIPTION
**What this PR does**:

Break vendor-check into a new command update-mod, which is responsible
for keeping tempo's and tempo serverless' go.mod and tempo vendor file tidy.