### PR TITLE
Add a for statement for TempoCompactionsFailing alert

### DIFF
--- a/operations/tempo-mixin/alerts.libsonnet
+++ b/operations/tempo-mixin/alerts.libsonnet
@@ -69,6 +69,7 @@
           },
           {
             alert: 'TempoCompactionsFailing',
+            'for': '5m',
             expr: |||
               sum by (%s) (increase(tempodb_compaction_errors_total{}[1h])) > %s and
               sum by (%s) (increase(tempodb_compaction_errors_total{}[5m])) > 0

--- a/operations/tempo-mixin/yamls/alerts.yaml
+++ b/operations/tempo-mixin/yamls/alerts.yaml
@@ -49,6 +49,7 @@
     "expr": |
       sum by (cluster, namespace) (increase(tempodb_compaction_errors_total{}[1h])) > 2 and
       sum by (cluster, namespace) (increase(tempodb_compaction_errors_total{}[5m])) > 0
+    "for": "5m"
     "labels":
       "severity": "critical"
   - "alert": "TempoIngesterFlushesFailing"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Introduce a `for: 5m` statement in the TempoComapctiosnFailing alert in order to reduce its sensitivity.

**Which issue(s) this PR fixes**:
Fixes #1270

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`