### PR TITLE
Require for CI checks to always pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,13 @@
 name: CI
 on:
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - 'example/**'
-      - 'tools/**'
+# Requiring certain checks for PRs to be merge-able in Github, forces for those checks to be *always* run.
+# Even if the changes do not require them (i.e. the paths indicated below). That's why `paths-ignore` is commented out.
+#
+#    paths-ignore:
+#      - 'docs/**'
+#      - 'example/**'
+#      - 'tools/**'
 jobs:
 
   lint:


### PR DESCRIPTION
**What this PR does**:

In order to require CI checks to pass for PRs to be merge-able, those checks need to be *always* run.  Even if the changes do not require them (i.e. `docs/**`, `example/**` and `tools/**` paths).

This PR comments out the ignore of said paths, so CI is always run.