### PR TITLE
ci: use GITHUB_TOKEN in setup-protoc to avoid rate-limtiing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,7 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           version: '3.11.2'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check vendor
         run: make vendor-check


### PR DESCRIPTION
**What this PR does**:
The vendor-check job is getting rate-limited when downloading protoc.
Example: https://github.com/grafana/tempo/runs/5233640313?check_suite_focus=true

The documentation says to use GITHUB_TOKEN to authenticate requests: https://github.com/arduino/setup-protoc#usage

Permissions this token has by default seem limited: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [ ] ~~Tests updated~~
- [ ] ~~Documentation added~~
- [ ] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~