### PR TITLE
Update examples and configs OTLP ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [ENHACEMENT] Enterprise jsonnet: add config to create tokengen job explicitly [#1256](https://github.com/grafana/tempo/pull/1256) (@kvrhdn)
 * [BUGFIX]: Remove unnecessary PersistentVolumeClaim [#1245](https://github.com/grafana/tempo/issues/1245)
 * [BUGFIX] Fixed issue when query-frontend doesn't log request details when request is cancelled [#1136](https://github.com/grafana/tempo/issues/1136) (@adityapwr)
+* [BUGFIX] Update OTLP port in examples (docker-compose & kubernetes) from legacy ports (55680/55681) to new ports (4317/4318) [#1294](https://github.com/grafana/tempo/pull/1294) (@mapno)
 
 ## v1.3.1 / 2022-02-02
 * [BUGFIX] Fixed panic when using etcd as ring's kvstore [#1260](https://github.com/grafana/tempo/pull/1260) (@mapno)

--- a/example/docker-compose/agent/agent.yaml
+++ b/example/docker-compose/agent/agent.yaml
@@ -9,7 +9,7 @@ tempo:
         protocols:
           thrift_http:
     remote_write:
-      - endpoint: tempo:55680
+      - endpoint: tempo:4317
         insecure: true
     batch:
       timeout: 5s

--- a/example/docker-compose/agent/docker-compose.yaml
+++ b/example/docker-compose/agent/docker-compose.yaml
@@ -27,8 +27,8 @@ services:
     ports:
       - "14268"  # jaeger ingest
       - "3200"   # tempo
-      - "55680"  # otlp grpc
-      - "55681"  # otlp http
+      - "4317"  # otlp grpc
+      - "4318"  # otlp http
       - "9411"   # zipkin
 
   prometheus:

--- a/example/docker-compose/local/docker-compose.yaml
+++ b/example/docker-compose/local/docker-compose.yaml
@@ -10,8 +10,8 @@ services:
     ports:
       - "14268"  # jaeger ingest
       - "3200"   # tempo
-      - "55680"  # otlp grpc
-      - "55681"  # otlp http
+      - "4317"  # otlp grpc
+      - "4318"  # otlp http
       - "9411"   # zipkin
 
   synthetic-load-generator:

--- a/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
+++ b/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
@@ -27,8 +27,8 @@ services:
     ports:
       - "14268"  # jaeger ingest
       - "3200"   # tempo
-      - "55680"  # otlp grpc
-      - "55681"  # otlp http
+      - "4317"  # otlp grpc
+      - "4318"  # otlp http
       - "9411"   # zipkin
 
   prometheus:

--- a/example/docker-compose/otel-collector/docker-compose.yaml
+++ b/example/docker-compose/otel-collector/docker-compose.yaml
@@ -27,8 +27,8 @@ services:
     ports:
       - "14268"  # jaeger ingest
       - "3200"   # tempo
-      - "55680"  # otlp grpc
-      - "55681"  # otlp http
+      - "4317"  # otlp grpc
+      - "4318"  # otlp http
       - "9411"   # zipkin
 
   prometheus:

--- a/example/docker-compose/otel-collector/readme.md
+++ b/example/docker-compose/otel-collector/readme.md
@@ -19,7 +19,7 @@ otel-collector_grafana_1                    /run.sh                          Up 
 otel-collector_otel-collector_1             /otelcol --config=/etc/ote ...   Up      55678/tcp, 55679/tcp
 otel-collector_synthetic-load-generator_1   ./start.sh                       Up
 otel-collector_tempo_1                      /tempo -config.file=/etc/t ...   Up      0.0.0.0:59538->14268/tcp, 0.0.0.0:59540->3200/tcp,
-                                                                                    0.0.0.0:59537->55680/tcp, 0.0.0.0:59536->55681/tcp,
+                                                                                    0.0.0.0:59537->4317/tcp, 0.0.0.0:59536->4318/tcp,
                                                                                     0.0.0.0:59539->9411/tcp
 ```
 

--- a/operations/kube-manifests/ConfigMap-tempo-distributor.yaml
+++ b/operations/kube-manifests/ConfigMap-tempo-distributor.yaml
@@ -11,7 +11,7 @@ data:
             otlp:
                 protocols:
                     grpc:
-                        endpoint: 0.0.0.0:55680
+                        endpoint: 0.0.0.0:4317
     http_api_prefix: ""
     ingester:
         lifecycler:

--- a/operations/kube-manifests/Deployment-distributor.yaml
+++ b/operations/kube-manifests/Deployment-distributor.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        config_hash: 06c3e6109f628a0f5a41db2a4ebd73a8
+        config_hash: 1d576bcfcaa599ba1cac6892924b561a
       labels:
         app: distributor
         name: distributor

--- a/operations/kube-manifests/util/example/main.jsonnet
+++ b/operations/kube-manifests/util/example/main.jsonnet
@@ -38,7 +38,7 @@ tempo {
         otlp: {
           protocols: {
             grpc: {
-              endpoint: '0.0.0.0:55680',
+              endpoint: '0.0.0.0:4317',
             },
           },
         },


### PR DESCRIPTION
**What this PR does**:

OTLP listening port was changed from 55680/55681 to 4317/4318, updated in Tempo in https://github.com/grafana/tempo/pull/1142. This PR cleans all references (docker-compose examples mainly) from the legacy ports and uses the new ones.

**Which issue(s) this PR fixes**:
Fixes #1293

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`