### PR TITLE
Update the vult to use backend search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## main / unreleased
 
+* [CHANGE] Vulture now exercises search at any point during the block retention to test full backend search. 
+  **BREAKING CHANGE** Dropped `tempo-search-retention-duration` parameter.  [#1297](https://github.com/grafana/tempo/pull/1297) (@joe-elliott)
 * [FEATURE]: v2 object encoding added. This encoding adds a start/end timestamp to every record to reduce proto marshalling and increase search speed.  
   **BREAKING CHANGE** After this rollout the distributors will use a new API on the ingesters. As such you must rollout all ingesters before rolling the 
   distributors. Also, during this period, the ingesters will use considerably more resources and as such should be scaled up (or incoming traffic should be

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -37,7 +37,6 @@ var (
 	tempoReadBackoffDuration      time.Duration
 	tempoSearchBackoffDuration    time.Duration
 	tempoRetentionDuration        time.Duration
-	tempoSearchRetentionDuration  time.Duration
 
 	logger *zap.Logger
 )


### PR DESCRIPTION
**What this PR does**:
- Updates the vult to search for tags over the entire range using the `tempo-retention-duration` parameter.
- Drops the `tempo-search-retention-duration` parameter.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`