### PR TITLE
Update changelog for v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * [BUGFIX] Update OTLP port in examples (docker-compose & kubernetes) from legacy ports (55680/55681) to new ports (4317/4318) [#1294](https://github.com/grafana/tempo/pull/1294) (@mapno)
 
 ## v1.3.2 / 2022-02-23
-* [BUGFIX] Fixed an issue where the query-frontend would mangle start/end time ranges on searches which included the ingesters [#1295] (@joe-elliott)
+* [BUGFIX] Fixed an issue where the query-frontend would corrupt start/end time ranges on searches which included the ingesters [#1295] (@joe-elliott)
 
 ## v1.3.1 / 2022-02-02
 * [BUGFIX] Fixed panic when using etcd as ring's kvstore [#1260](https://github.com/grafana/tempo/pull/1260) (@mapno)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@
 * [ENHANCEMENT] Add new scaling alerts to the tempo-mixin [#1292](https://github.com/grafana/tempo/pull/1292) (@mapno)
 * [BUGFIX]: Remove unnecessary PersistentVolumeClaim [#1245](https://github.com/grafana/tempo/issues/1245)
 * [BUGFIX] Fixed issue when query-frontend doesn't log request details when request is cancelled [#1136](https://github.com/grafana/tempo/issues/1136) (@adityapwr)
-* [BUGFIX] Fixed an issue where the query-frontend would mangle start/end time ranges on searches which included the ingesters [#1295] (@joe-elliott)
 * [BUGFIX] Update OTLP port in examples (docker-compose & kubernetes) from legacy ports (55680/55681) to new ports (4317/4318) [#1294](https://github.com/grafana/tempo/pull/1294) (@mapno)
+
+## v1.3.2 / 2022-02-23
+* [BUGFIX] Fixed an issue where the query-frontend would mangle start/end time ranges on searches which included the ingesters [#1295] (@joe-elliott)
 
 ## v1.3.1 / 2022-02-02
 * [BUGFIX] Fixed panic when using etcd as ring's kvstore [#1260](https://github.com/grafana/tempo/pull/1260) (@mapno)

--- a/docs/tempo/website/getting-started/tempo-in-grafana.md
+++ b/docs/tempo/website/getting-started/tempo-in-grafana.md
@@ -45,7 +45,7 @@ Refer to the [search](../../configuration#search) configuration documentation.
 Further configration information is in [backend search](../../operations/backend_search).
 The Tempo configuration is the same for searching recent traces or
 for search of the backend datastore. 
--  This feature is not yet available in Grafana. When Grafana is updated, you will be able to run the most recent version of Grafana and enable the `tempoBackendSearch` [feature toggle](https://github.com/grafana/tempo/blob/main/example/docker-compose/tempo-search/grafana.ini). This will cause Grafana to pass the `start` and `end` parameters necessary for the backend datastore search.
+-  Run Grafana 8.3.6 or a more recent version. Enable the `tempoBackendSearch` [feature toggle](https://github.com/grafana/tempo/blob/main/example/docker-compose/tempo-search/grafana.ini). This will cause Grafana to pass the `start` and `end` parameters necessary for the backend datastore search.
 
 ## View JSON file
 A local JSON file containing a trace can be uploaded and viewed in the Grafana UI.  This is useful in cases where access to the original Tempo datasource is limited, or for preserving traces outside of Tempo.  The JSON data can be downloaded via the Tempo API or the Inspector panel while viewing the trace in Grafana.

--- a/docs/tempo/website/release-notes/v1-3.md
+++ b/docs/tempo/website/release-notes/v1-3.md
@@ -53,5 +53,8 @@ to enable searches in the backend datastore.
 
 ### 1.3.1 bug fixes
 
-* [BUGFIX] Fixed panic when using etcd as ring's kvstore [#1260](https://github.com/grafana/tempo/pull/1260) (@mapno)
+- [PR 1260](https://github.com/grafana/tempo/pull/1260): Fixed panic when using etcd as ring's kvstore.
 
+### 1.3.2 bug fixes
+
+- [PR 1295](https://github.com/grafana/tempo/pull/1295): Fixed an issue where the query-frontend would mangle start/end time ranges on searches which included the ingesters.

--- a/docs/tempo/website/release-notes/v1-3.md
+++ b/docs/tempo/website/release-notes/v1-3.md
@@ -57,4 +57,4 @@ to enable searches in the backend datastore.
 
 ### 1.3.2 bug fixes
 
-- [PR 1295](https://github.com/grafana/tempo/pull/1295) **joe-elliot**: Fixed an issue which corrupted the start/end time ranges of Tempo searches that targeted ingesters.
+- [PR 1295](https://github.com/grafana/tempo/pull/1295) **joe-elliott**: Fixed an issue which corrupted the start/end time ranges of Tempo searches that targeted ingesters.

--- a/docs/tempo/website/release-notes/v1-3.md
+++ b/docs/tempo/website/release-notes/v1-3.md
@@ -53,8 +53,8 @@ to enable searches in the backend datastore.
 
 ### 1.3.1 bug fixes
 
-- [PR 1260](https://github.com/grafana/tempo/pull/1260): Fixed panic when using etcd as ring's kvstore.
+- [PR 1260](https://github.com/grafana/tempo/pull/1260) **mapno**: Fixed a panic that occurred when using etcd as the ring's backend storage.
 
 ### 1.3.2 bug fixes
 
-- [PR 1295](https://github.com/grafana/tempo/pull/1295): Fixed an issue where the query-frontend would mangle start/end time ranges on searches which included the ingesters.
+- [PR 1295](https://github.com/grafana/tempo/pull/1295) **joe-elliot**: Fixed an issue which corrupted the start/end time ranges of Tempo searches that targeted ingesters.


### PR DESCRIPTION
**What this PR does**:
- Updates the changelog for the 1.3.2 release
- Updates the release notes with the 1.3.2 bug fix
- Adds the Grafana version for backend search capabilities.