### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/modules/ingester/ingester_test.go
+++ b/modules/ingester/ingester_test.go
@@ -47,10 +47,7 @@ func TestPushQueryAllEncodings(t *testing.T) {
 				t.Fatal("unsupported encoding", e)
 			}
 
-			tmpDir, err := os.MkdirTemp("/tmp", "")
-			require.NoError(t, err, "unexpected error getting tempdir")
-			defer os.RemoveAll(tmpDir)
-
+			tmpDir := t.TempDir()
 			ctx := user.InjectOrgID(context.Background(), "test")
 			ingester, traces, traceIDs := defaultIngesterWithPush(t, tmpDir, push)
 
@@ -65,7 +62,7 @@ func TestPushQueryAllEncodings(t *testing.T) {
 
 			// force cut all traces
 			for _, instance := range ingester.instances {
-				err = instance.CutCompleteTraces(0, true)
+				err := instance.CutCompleteTraces(0, true)
 				require.NoError(t, err, "unexpected error cutting traces")
 			}
 
@@ -83,15 +80,11 @@ func TestPushQueryAllEncodings(t *testing.T) {
 }
 
 func TestFullTraceReturned(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("/tmp", "")
-	require.NoError(t, err, "unexpected error getting tempdir")
-	defer os.RemoveAll(tmpDir)
-
 	ctx := user.InjectOrgID(context.Background(), "test")
-	ingester, _, _ := defaultIngester(t, tmpDir)
+	ingester, _, _ := defaultIngester(t, t.TempDir())
 
 	traceID := make([]byte, 16)
-	_, err = rand.Read(traceID)
+	_, err := rand.Read(traceID)
 	require.NoError(t, err)
 	testTrace := test.MakeTrace(2, traceID) // 2 batches
 	trace.SortTrace(testTrace)
@@ -130,9 +123,7 @@ func TestFullTraceReturned(t *testing.T) {
 }
 
 func TestWal(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("/tmp", "")
-	require.NoError(t, err, "unexpected error getting tempdir")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	ctx := user.InjectOrgID(context.Background(), "test")
 	ingester, traces, traceIDs := defaultIngester(t, tmpDir)
@@ -288,9 +279,7 @@ func TestSearchWAL(t *testing.T) {
 */
 
 func TestFlush(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("/tmp", "")
-	require.NoError(t, err, "unexpected error getting tempdir")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	ctx := user.InjectOrgID(context.Background(), "test")
 	ingester, traces, traceIDs := defaultIngester(t, tmpDir)

--- a/modules/ingester/instance_search_test.go
+++ b/modules/ingester/instance_search_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -44,9 +43,7 @@ func TestInstanceSearch(t *testing.T) {
 	assert.NoError(t, err, "unexpected error creating limits")
 	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
 
-	tempDir, err := os.MkdirTemp("/tmp", "")
-	assert.NoError(t, err, "unexpected error getting temp dir")
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	ingester, _, _ := defaultIngester(t, tempDir)
 	i, err := newInstance("fake", limiter, ingester.store, ingester.local)
@@ -148,11 +145,7 @@ func TestInstanceSearchNoData(t *testing.T) {
 	assert.NoError(t, err, "unexpected error creating limits")
 	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
 
-	tempDir, err := os.MkdirTemp("/tmp", "")
-	assert.NoError(t, err, "unexpected error getting temp dir")
-	defer os.RemoveAll(tempDir)
-
-	ingester, _, _ := defaultIngester(t, tempDir)
+	ingester, _, _ := defaultIngester(t, t.TempDir())
 	i, err := newInstance("fake", limiter, ingester.store, ingester.local)
 	assert.NoError(t, err, "unexpected error creating new instance")
 

--- a/tempodb/backend/local/local_test.go
+++ b/tempodb/backend/local/local_test.go
@@ -19,16 +19,12 @@ import (
 const objectName = "test"
 
 func TestReadWrite(t *testing.T) {
-	tempDir, err := os.MkdirTemp("/tmp", "")
-	defer os.RemoveAll(tempDir)
-	assert.NoError(t, err, "unexpected error creating temp dir")
-
 	fakeTracesFile, err := os.CreateTemp("/tmp", "")
 	defer os.Remove(fakeTracesFile.Name())
 	assert.NoError(t, err, "unexpected error creating temp file")
 
 	r, w, _, err := New(&Config{
-		Path: tempDir,
+		Path: t.TempDir(),
 	})
 	assert.NoError(t, err, "unexpected error creating local backend")
 

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/binary"
 	"math/rand"
-	"os"
 	"path"
 	"testing"
 	"time"
@@ -51,9 +50,7 @@ func (m *mockOverrides) BlockRetentionForTenant(_ string) time.Duration {
 }
 
 func TestCompaction(t *testing.T) {
-	tempDir, err := os.MkdirTemp("/tmp", "")
-	defer os.RemoveAll(tempDir)
-	assert.NoError(t, err, "unexpected error creating temp dir")
+	tempDir := t.TempDir()
 
 	r, w, c, err := New(&Config{
 		Backend: "local",
@@ -184,9 +181,7 @@ func TestCompaction(t *testing.T) {
 // TestSameIDCompaction is a bit gross in that it has a bad dependency with on the /pkg/model
 // module to do a full e2e compaction/combination test.
 func TestSameIDCompaction(t *testing.T) {
-	tempDir, err := os.MkdirTemp("/tmp", "")
-	defer os.RemoveAll(tempDir)
-	assert.NoError(t, err, "unexpected error creating temp dir")
+	tempDir := t.TempDir()
 
 	r, w, c, err := New(&Config{
 		Backend: "local",
@@ -304,9 +299,7 @@ func TestSameIDCompaction(t *testing.T) {
 }
 
 func TestCompactionUpdatesBlocklist(t *testing.T) {
-	tempDir, err := os.MkdirTemp("/tmp", "")
-	defer os.RemoveAll(tempDir)
-	assert.NoError(t, err, "unexpected error creating temp dir")
+	tempDir := t.TempDir()
 
 	r, w, c, err := New(&Config{
 		Backend: "local",
@@ -374,9 +367,7 @@ func TestCompactionUpdatesBlocklist(t *testing.T) {
 }
 
 func TestCompactionMetrics(t *testing.T) {
-	tempDir, err := os.MkdirTemp("/tmp", "")
-	defer os.RemoveAll(tempDir)
-	assert.NoError(t, err, "unexpected error creating temp dir")
+	tempDir := t.TempDir()
 
 	r, w, c, err := New(&Config{
 		Backend: "local",
@@ -447,9 +438,7 @@ func TestCompactionMetrics(t *testing.T) {
 }
 
 func TestCompactionIteratesThroughTenants(t *testing.T) {
-	tempDir, err := os.MkdirTemp("/tmp", "")
-	defer os.RemoveAll(tempDir)
-	assert.NoError(t, err, "unexpected error creating temp dir")
+	tempDir := t.TempDir()
 
 	r, w, c, err := New(&Config{
 		Backend: "local",

--- a/tempodb/encoding/streaming_block_test.go
+++ b/tempodb/encoding/streaming_block_test.go
@@ -153,12 +153,8 @@ func TestStreamingBlockAll(t *testing.T) {
 }
 
 func testStreamingBlockToBackendBlock(t *testing.T, cfg *BlockConfig) {
-	backendTmpDir, err := os.MkdirTemp("/tmp", "")
-	defer os.RemoveAll(backendTmpDir)
-	require.NoError(t, err, "unexpected error creating temp dir")
-
 	rawR, rawW, _, err := local.New(&local.Config{
-		Path: backendTmpDir,
+		Path: t.TempDir(),
 	})
 
 	r := backend.NewReader(rawR)
@@ -348,10 +344,6 @@ func BenchmarkReadS2(b *testing.B) {
 // Download a block from your backend and place in ./benchmark_block/<tenant id>/<guid>
 //nolint:unparam
 func benchmarkCompressBlock(b *testing.B, encoding backend.Encoding, indexDownsample int, benchRead bool) {
-	tempDir, err := os.MkdirTemp("/tmp", "")
-	defer os.RemoveAll(tempDir)
-	require.NoError(b, err, "unexpected error creating temp dir")
-
 	rawR, _, _, err := local.New(&local.Config{
 		Path: "./benchmark_block",
 	})
@@ -367,9 +359,7 @@ func benchmarkCompressBlock(b *testing.B, encoding backend.Encoding, indexDownsa
 	iter, err := backendBlock.Iterator(10 * 1024 * 1024)
 	require.NoError(b, err, "error creating iterator")
 
-	backendTmpDir, err := os.MkdirTemp("/tmp", "")
-	defer os.RemoveAll(backendTmpDir)
-	require.NoError(b, err, "unexpected error creating temp dir")
+	backendTmpDir := b.TempDir()
 
 	_, rawW, _, err := local.New(&local.Config{
 		Path: backendTmpDir,

--- a/tempodb/retention_test.go
+++ b/tempodb/retention_test.go
@@ -1,7 +1,6 @@
 package tempodb
 
 import (
-	"os"
 	"path"
 	"testing"
 	"time"
@@ -17,9 +16,7 @@ import (
 )
 
 func TestRetention(t *testing.T) {
-	tempDir, err := os.MkdirTemp("/tmp", "")
-	defer os.RemoveAll(tempDir)
-	assert.NoError(t, err, "unexpected error creating temp dir")
+	tempDir := t.TempDir()
 
 	r, w, c, err := New(&Config{
 		Backend: "local",
@@ -75,9 +72,7 @@ func TestRetention(t *testing.T) {
 }
 
 func TestBlockRetentionOverride(t *testing.T) {
-	tempDir, err := os.MkdirTemp("/tmp", "")
-	defer os.RemoveAll(tempDir)
-	assert.NoError(t, err, "unexpected error creating temp dir")
+	tempDir := t.TempDir()
 
 	r, w, c, err := New(&Config{
 		Backend: "local",

--- a/tempodb/wal/wal_test.go
+++ b/tempodb/wal/wal_test.go
@@ -41,12 +41,8 @@ func (m *mockCombiner) Combine(dataEncoding string, objs ...[]byte) ([]byte, boo
 }
 
 func TestAppend(t *testing.T) {
-	tempDir, err := os.MkdirTemp("/tmp", "")
-	defer os.RemoveAll(tempDir)
-	require.NoError(t, err, "unexpected error creating temp dir")
-
 	wal, err := New(&Config{
-		Filepath: tempDir,
+		Filepath: t.TempDir(),
 	})
 	require.NoError(t, err, "unexpected error creating temp wal")
 
@@ -96,11 +92,9 @@ func TestAppend(t *testing.T) {
 func TestCompletedDirIsRemoved(t *testing.T) {
 	// Create /completed/testfile and verify it is removed.
 
-	tempDir, err := os.MkdirTemp("/tmp", "")
-	defer os.RemoveAll(tempDir)
-	require.NoError(t, err, "unexpected error creating temp dir")
+	tempDir := t.TempDir()
 
-	err = os.MkdirAll(path.Join(tempDir, completedDir), os.ModePerm)
+	err := os.MkdirAll(path.Join(tempDir, completedDir), os.ModePerm)
 	require.NoError(t, err, "unexpected error creating completedDir")
 
 	_, err = os.Create(path.Join(tempDir, completedDir, "testfile"))
@@ -116,9 +110,7 @@ func TestCompletedDirIsRemoved(t *testing.T) {
 }
 
 func TestErrorConditions(t *testing.T) {
-	tempDir, err := os.MkdirTemp("/tmp", "")
-	defer os.RemoveAll(tempDir)
-	require.NoError(t, err, "unexpected error creating temp dir")
+	tempDir := t.TempDir()
 
 	wal, err := New(&Config{
 		Filepath: tempDir,
@@ -178,12 +170,8 @@ func TestAppendReplayFind(t *testing.T) {
 }
 
 func testAppendReplayFind(t *testing.T, e backend.Encoding) {
-	tempDir, err := os.MkdirTemp("/tmp", "")
-	defer os.RemoveAll(tempDir)
-	require.NoError(t, err, "unexpected error creating temp dir")
-
 	wal, err := New(&Config{
-		Filepath: tempDir,
+		Filepath: t.TempDir(),
 		Encoding: e,
 	})
 	require.NoError(t, err, "unexpected error creating temp wal")
@@ -432,9 +420,8 @@ func benchmarkWriteFindReplay(b *testing.B, encoding backend.Encoding) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		tempDir, _ := os.MkdirTemp("/tmp", "")
 		wal, _ := New(&Config{
-			Filepath: tempDir,
+			Filepath: b.TempDir(),
 			Encoding: encoding,
 		})
 
@@ -457,7 +444,5 @@ func benchmarkWriteFindReplay(b *testing.B, encoding backend.Encoding) {
 		// replay
 		_, err = wal.RescanBlocks(log.NewNopLogger())
 		require.NoError(b, err)
-
-		os.RemoveAll(tempDir)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
A testing enhancement.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir

**Which issue(s) this PR fixes**:


**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`