### PR TITLE
metrics-generator: respect remote_write.client.send_exemplars

### DIFF
--- a/modules/generator/remotewrite/appendable.go
+++ b/modules/generator/remotewrite/appendable.go
@@ -45,10 +45,11 @@ func (a *remoteWriteAppendable) Appender(ctx context.Context) storage.Appender {
 	}
 
 	return &remoteWriteAppender{
-		logger:       a.logger,
-		ctx:          ctx,
-		remoteWriter: client,
-		userID:       a.tenantID,
-		metrics:      a.metrics,
+		logger:        a.logger,
+		ctx:           ctx,
+		remoteWriter:  client,
+		sendExamplars: a.cfg.Client.SendExemplars,
+		userID:        a.tenantID,
+		metrics:       a.metrics,
 	}
 }

--- a/modules/generator/remotewrite/appendable_test.go
+++ b/modules/generator/remotewrite/appendable_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	prometheus_common_config "github.com/prometheus/common/config"
 	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/storage/remote"
@@ -24,19 +25,10 @@ func Test_remoteWriteAppendable(t *testing.T) {
 	theTime := time.Now()
 
 	var capturedTimeseries []prompb.TimeSeries
-	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		writeRequest, err := remote.DecodeWriteRequest(req.Body)
-		assert.NoError(t, err)
+	clientCfg, cleanup := createTimeSeriesServer(t, &capturedTimeseries)
+	defer cleanup()
 
-		capturedTimeseries = writeRequest.GetTimeseries()
-	}))
-	defer server.Close()
-
-	url, err := url.Parse(fmt.Sprintf("http://%s/receive", server.Listener.Addr().String()))
-	assert.NoError(t, err)
-
-	clientCfg := config.DefaultRemoteWriteConfig
-	clientCfg.URL = &prometheus_common_config.URL{URL: url}
+	clientCfg.SendExemplars = true
 
 	cfg := &Config{
 		Enabled: true,
@@ -48,7 +40,7 @@ func Test_remoteWriteAppendable(t *testing.T) {
 
 	appender := appendable.Appender(context.Background())
 
-	_, err = appender.Append(0, labels.Labels{{Name: "label", Value: "append-before-rollback"}}, theTime.UnixMilli(), 0.1)
+	_, err := appender.Append(0, labels.Labels{{Name: "label", Value: "append-before-rollback"}}, theTime.UnixMilli(), 0.1)
 	assert.NoError(t, err)
 
 	// Rollback the appender, this should discard previously appended samples
@@ -62,15 +54,23 @@ func Test_remoteWriteAppendable(t *testing.T) {
 
 	_, err = appender.Append(0, labels.Labels{{Name: "label", Value: "value"}}, theTime.UnixMilli(), 0.2)
 	assert.NoError(t, err)
+	_, err = appender.AppendExemplar(0, labels.Labels{{Name: "label", Value: "value"}}, exemplar.Exemplar{
+		Labels: labels.Labels{{Name: "traceID", Value: "123"}},
+		Value:  0.2,
+		Ts:     theTime.UnixMilli(),
+		HasTs:  true,
+	})
+	assert.NoError(t, err)
 
 	err = appender.Commit()
 	assert.NoError(t, err)
 
-	assert.Len(t, capturedTimeseries, 1)
+	assert.Len(t, capturedTimeseries, 2)
 	assert.Len(t, capturedTimeseries[0].Labels, 1)
 	assert.Equal(t, `name:"label" value:"value" `, capturedTimeseries[0].Labels[0].String())
 	assert.Len(t, capturedTimeseries[0].Samples, 1)
 	assert.Equal(t, fmt.Sprintf(`value:0.2 timestamp:%d `, theTime.UnixMilli()), capturedTimeseries[0].Samples[0].String())
+	assert.Len(t, capturedTimeseries[1].Exemplars, 1)
 }
 
 func Test_remoteWriteAppendable_disabled(t *testing.T) {
@@ -99,4 +99,56 @@ func Test_remoteWriteAppendable_disabled(t *testing.T) {
 
 	err = appender.Commit()
 	assert.NoError(t, err)
+}
+
+func Test_remoteWriteAppendable_dontSendExemplars(t *testing.T) {
+	theTime := time.Now()
+
+	var capturedTimeseries []prompb.TimeSeries
+	clientCfg, cleanup := createTimeSeriesServer(t, &capturedTimeseries)
+	defer cleanup()
+
+	clientCfg.SendExemplars = false
+
+	cfg := &Config{
+		Enabled: true,
+		Client:  clientCfg,
+	}
+	tenantID := "my-tenant"
+
+	appendable := NewAppendable(cfg, gokitlog.NewLogfmtLogger(os.Stdout), tenantID, NewMetrics(prometheus.NewRegistry()))
+
+	appender := appendable.Appender(context.Background())
+
+	_, err := appender.AppendExemplar(0, labels.Labels{{Name: "label", Value: "value"}}, exemplar.Exemplar{
+		Labels: labels.Labels{{Name: "traceID", Value: "123"}},
+		Value:  0.2,
+		Ts:     theTime.UnixMilli(),
+		HasTs:  true,
+	})
+	assert.NoError(t, err)
+
+	err = appender.Commit()
+	assert.NoError(t, err)
+
+	assert.Len(t, capturedTimeseries, 0)
+}
+
+func createTimeSeriesServer(t *testing.T, capturedTimeseries *[]prompb.TimeSeries) (config.RemoteWriteConfig, func()) {
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		writeRequest, err := remote.DecodeWriteRequest(req.Body)
+		assert.NoError(t, err)
+
+		*capturedTimeseries = append(*capturedTimeseries, writeRequest.GetTimeseries()...)
+	}))
+
+	url, err := url.Parse(fmt.Sprintf("http://%s/receive", server.Listener.Addr().String()))
+	assert.NoError(t, err)
+
+	clientCfg := config.DefaultRemoteWriteConfig
+	clientCfg.URL = &prometheus_common_config.URL{URL: url}
+
+	return clientCfg, func() {
+		server.Close()
+	}
 }

--- a/modules/generator/remotewrite/appender_test.go
+++ b/modules/generator/remotewrite/appender_test.go
@@ -30,11 +30,12 @@ func Test_remoteWriteAppendable_splitRequests(t *testing.T) {
 	mockWriteClient := &mockWriteClient{}
 
 	appender := &remoteWriteAppender{
-		logger:       gokitlog.NewLogfmtLogger(os.Stdout),
-		ctx:          context.Background(),
-		remoteWriter: &remoteWriteClient{WriteClient: mockWriteClient},
-		userID:       "",
-		metrics:      NewMetrics(prometheus.NewRegistry()),
+		logger:        gokitlog.NewLogfmtLogger(os.Stdout),
+		ctx:           context.Background(),
+		remoteWriter:  &remoteWriteClient{WriteClient: mockWriteClient},
+		userID:        "",
+		sendExamplars: true,
+		metrics:       NewMetrics(prometheus.NewRegistry()),
 	}
 
 	// Send samples


### PR DESCRIPTION
**What this PR does**:
Make sending exemplars configurable by respecting the send_exemplars field on the remote write config.

**Which issue(s) this PR fixes**:
Linked to https://github.com/grafana/tempo/issues/1303

**Checklist**
- [x] Tests updated
- [ ] ~~Documentation added~~
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`