### PR TITLE
metrics-generator: expose active_series metric

### DIFF
--- a/modules/generator/instance.go
+++ b/modules/generator/instance.go
@@ -68,7 +68,7 @@ func newInstance(cfg *Config, instanceID string, overrides metricsGeneratorOverr
 		instanceID: instanceID,
 		overrides:  overrides,
 
-		registry:   processor.NewRegistry(cfg.ExternalLabels),
+		registry:   processor.NewRegistry(cfg.ExternalLabels, instanceID),
 		appendable: appendable,
 
 		processors: make(map[string]processor.Processor),

--- a/modules/generator/processor/registry.go
+++ b/modules/generator/processor/registry.go
@@ -75,7 +75,7 @@ func (r *Registry) Gather(appender storage.Appender) (err error) {
 				if err != nil {
 					return err
 				}
-				activeSeriesCount += 1
+				activeSeriesCount++
 			}
 
 		case prometheus_model.MetricType_HISTOGRAM:
@@ -90,7 +90,7 @@ func (r *Registry) Gather(appender storage.Appender) (err error) {
 				if err != nil {
 					return err
 				}
-				activeSeriesCount += 1
+				activeSeriesCount++
 
 				// _sum
 				sumLabels := copyWithLabel(labels, "__name__", fmt.Sprintf("%s_sum", metricFamily.GetName()))
@@ -98,7 +98,7 @@ func (r *Registry) Gather(appender storage.Appender) (err error) {
 				if err != nil {
 					return err
 				}
-				activeSeriesCount += 1
+				activeSeriesCount++
 
 				addedInfBucket := false
 
@@ -115,7 +115,7 @@ func (r *Registry) Gather(appender storage.Appender) (err error) {
 					if err != nil {
 						return err
 					}
-					activeSeriesCount += 1
+					activeSeriesCount++
 
 					e := bucket.GetExemplar()
 					if e != nil {
@@ -138,7 +138,7 @@ func (r *Registry) Gather(appender storage.Appender) (err error) {
 					if err != nil {
 						return err
 					}
-					activeSeriesCount += 1
+					activeSeriesCount++
 				}
 			}
 

--- a/modules/generator/processor/registry_test.go
+++ b/modules/generator/processor/registry_test.go
@@ -16,7 +16,7 @@ func TestRegistry(t *testing.T) {
 	now := time.Now()
 	theTime := &now
 
-	registry := NewRegistry(nil)
+	registry := NewRegistry(nil, "test-tenant")
 	registry.SetTimeNow(func() time.Time {
 		return *theTime
 	})
@@ -110,7 +110,7 @@ func TestRegistry_exemplars(t *testing.T) {
 	now := time.Now()
 	theTime := &now
 
-	registry := NewRegistry(nil)
+	registry := NewRegistry(nil, "test-tenant")
 	registry.SetTimeNow(func() time.Time {
 		return *theTime
 	})
@@ -171,7 +171,7 @@ func TestRegisterer_externalLabels(t *testing.T) {
 	registry := NewRegistry(map[string]string{
 		"external_label1": "constant_value1",
 		"external_label2": "constant_value2",
-	})
+	}, "test-tenant")
 	registry.SetTimeNow(func() time.Time {
 		return *theTime
 	})

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -20,7 +20,7 @@ func TestServiceGraphs(t *testing.T) {
 	cfg.RegisterFlagsAndApplyDefaults("", nil)
 	p := New(cfg, "test")
 
-	registry := gen.NewRegistry(nil)
+	registry := gen.NewRegistry(nil, "test-tenant")
 	err := p.RegisterMetrics(registry)
 	assert.NoError(t, err)
 

--- a/modules/generator/processor/spanmetrics/spanmetrics_test.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics_test.go
@@ -20,7 +20,7 @@ func TestSpanMetrics(t *testing.T) {
 	cfg.RegisterFlagsAndApplyDefaults("", nil)
 	p := New(cfg, "test")
 
-	registry := gen.NewRegistry(nil)
+	registry := gen.NewRegistry(nil, "test-tenant")
 	err := p.RegisterMetrics(registry)
 	assert.NoError(t, err)
 
@@ -71,7 +71,7 @@ func TestSpanMetrics_dimensions(t *testing.T) {
 	cfg.Dimensions = []string{"foo", "bar"}
 	p := New(cfg, "test")
 
-	registry := gen.NewRegistry(nil)
+	registry := gen.NewRegistry(nil, "test-tenant")
 	err := p.RegisterMetrics(registry)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
**What this PR does**:
Add a metric `tempo_metrics_generator_active_series` that exposes the amount of active series managed by this instance (and per tenant). From tests this matches exactly with what Prometheus reports in its status pages ✨ 

**Which issue(s) this PR fixes**:
Linked to https://github.com/grafana/tempo/issues/1303

**Checklist**
- [ ] Tests updated
- [ ] ~~Documentation added~~
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`