### PR TITLE
Return value of error tooManySpansError instead of reference

### DIFF
--- a/modules/generator/generator.go
+++ b/modules/generator/generator.go
@@ -214,10 +214,7 @@ func (g *Generator) PushSpans(ctx context.Context, req *tempopb.PushSpansRequest
 		return nil, err
 	}
 
-	err = instance.pushSpans(ctx, req)
-	if err != nil {
-		return nil, err
-	}
+	instance.pushSpans(ctx, req)
 
 	return &tempopb.PushResponse{}, nil
 }

--- a/modules/generator/instance.go
+++ b/modules/generator/instance.go
@@ -213,19 +213,15 @@ func (i *instance) updateProcessorMetrics() {
 	}
 }
 
-func (i *instance) pushSpans(ctx context.Context, req *tempopb.PushSpansRequest) error {
+func (i *instance) pushSpans(ctx context.Context, req *tempopb.PushSpansRequest) {
 	i.updatePushMetrics(req)
 
 	i.processorsMtx.RLock()
 	defer i.processorsMtx.RUnlock()
 
 	for _, processor := range i.processors {
-		if err := processor.PushSpans(ctx, req); err != nil {
-			return err
-		}
+		processor.PushSpans(ctx, req)
 	}
-
-	return nil
 }
 
 func (i *instance) updatePushMetrics(req *tempopb.PushSpansRequest) {

--- a/modules/generator/instance_test.go
+++ b/modules/generator/instance_test.go
@@ -33,8 +33,7 @@ func Test_instance_concurrency(t *testing.T) {
 
 	go accessor(func() {
 		req := test.MakeBatch(1, nil)
-		err := instance.pushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*v1.ResourceSpans{req}})
-		assert.NoError(t, err)
+		instance.pushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*v1.ResourceSpans{req}})
 	})
 
 	go accessor(func() {

--- a/modules/generator/processor/interface.go
+++ b/modules/generator/processor/interface.go
@@ -16,7 +16,7 @@ type Processor interface {
 	RegisterMetrics(reg prometheus.Registerer) error
 
 	// PushSpans processes a batch of spans and updates the metrics registered in RegisterMetrics.
-	PushSpans(ctx context.Context, req *tempopb.PushSpansRequest) error
+	PushSpans(ctx context.Context, req *tempopb.PushSpansRequest)
 
 	// Shutdown releases any resources allocated by the processor and unregisters metrics registered
 	// by RegisterMetrics. Once the processor is shut down, PushSpans should not be called anymore.

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -235,7 +235,7 @@ func (p *processor) consume(resourceSpans []*v1.ResourceSpans) error {
 	}
 
 	if totalDroppedSpans > 0 {
-		return &tooManySpansError{
+		return tooManySpansError{
 			droppedSpans: totalDroppedSpans,
 		}
 	}

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -166,7 +166,7 @@ func (p *processor) unregisterMetrics(reg prometheus.Registerer) {
 	}
 }
 
-func (p *processor) PushSpans(ctx context.Context, req *tempopb.PushSpansRequest) error {
+func (p *processor) PushSpans(ctx context.Context, req *tempopb.PushSpansRequest) {
 	span, _ := opentracing.StartSpanFromContext(ctx, "servicegraphs.PushSpans")
 	defer span.Finish()
 
@@ -177,8 +177,6 @@ func (p *processor) PushSpans(ctx context.Context, req *tempopb.PushSpansRequest
 			level.Error(log.Logger).Log("msg", "failed consuming traces", "err", err)
 		}
 	}
-
-	return nil
 }
 
 func (p *processor) consume(resourceSpans []*v1.ResourceSpans) error {

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -2,6 +2,7 @@ package servicegraphs
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 	"time"
@@ -95,6 +96,17 @@ func TestServiceGraphs(t *testing.T) {
 		{Labels: `{client="lb", server="app", __name__="traces_service_graph_request_total"}`, Value: 3},
 	}
 	appender.ContainsAll(t, expectedMetrics, collectTime)
+}
+
+func TestServiceGraphs_tooManySpansErr(t *testing.T) {
+	cfg := Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", nil)
+	cfg.MaxItems = 0
+	p := New(cfg, "test")
+
+	traces := testData(t, "testdata/test-sample.json")
+	err := p.(*processor).consume(traces.Batches)
+	assert.True(t, errors.As(err, &tooManySpansError{}))
 }
 
 func testData(t *testing.T, path string) *tempopb.Trace {

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -31,8 +31,7 @@ func TestServiceGraphs(t *testing.T) {
 	})
 
 	traces := testData(t, "testdata/test-sample.json")
-	err = p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: traces.Batches})
-	assert.NoError(t, err)
+	p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: traces.Batches})
 
 	// Manually call expire to force collection of edges.
 	sgp := p.(*processor)

--- a/modules/generator/processor/spanmetrics/spanmetrics.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics.go
@@ -76,13 +76,11 @@ func (p *processor) unregisterMetrics(reg prometheus.Registerer) {
 	}
 }
 
-func (p *processor) PushSpans(ctx context.Context, req *tempopb.PushSpansRequest) error {
+func (p *processor) PushSpans(ctx context.Context, req *tempopb.PushSpansRequest) {
 	span, _ := opentracing.StartSpanFromContext(ctx, "spanmetrics.PushSpans")
 	defer span.Finish()
 
 	p.aggregateMetrics(req.Batches)
-
-	return nil
 }
 
 func (p *processor) Shutdown(ctx context.Context, reg prometheus.Registerer) error {

--- a/modules/generator/processor/spanmetrics/spanmetrics_test.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics_test.go
@@ -32,8 +32,7 @@ func TestSpanMetrics(t *testing.T) {
 	// TODO give these spans some duration so we can verify latencies are recorded correctly, in fact we should also test with various span names etc.
 	req := test.MakeBatch(10, nil)
 
-	err = p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{req}})
-	assert.NoError(t, err)
+	p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{req}})
 
 	appender := &test_util.Appender{}
 
@@ -93,8 +92,7 @@ func TestSpanMetrics_dimensions(t *testing.T) {
 			})
 		}
 	}
-	err = p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{batch}})
-	assert.NoError(t, err)
+	p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{batch}})
 
 	appender := &test_util.Appender{}
 


### PR DESCRIPTION
**What this PR does**:

* Return value of error tooManySpansError instead of reference. As a consequence, `errors.Is` was failing to detect it.
*  Remove error return in PushSpans method
    * We don't want to stop processing due to an error in one of the processor. Errors can be handled and logging inside the processors.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`