### PR TITLE
metrics-generator: use yaml struct tags instead of mapstructure

### DIFF
--- a/modules/generator/processor/servicegraphs/config.go
+++ b/modules/generator/processor/servicegraphs/config.go
@@ -13,17 +13,17 @@ const (
 
 type Config struct {
 	// Wait is the value to wait for an edge to be completed
-	Wait time.Duration `mapstructure:"wait"`
+	Wait time.Duration `yaml:"wait"`
 	// MaxItems is the amount of edges that will be stored in the storeMap
-	MaxItems int `mapstructure:"max_items"`
+	MaxItems int `yaml:"max_items"`
 
 	// Workers is the amount of workers that will be used to process the edges
-	Workers int `mapstructure:"workers"`
+	Workers int `yaml:"workers"`
 
 	// Buckets for latency histogram in seconds.
 	HistogramBuckets []float64 `yaml:"histogram_buckets"`
 
-	// SuccessCodes *successCodes `mapstructure:"success_codes"`
+	// SuccessCodes *successCodes `yaml:"success_codes"`
 }
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {


### PR DESCRIPTION
**What this PR does**:
We accidentally copied `mapstructure` struct tags from the agent code, this don't work when reading from a yaml file 😅 

**Checklist**
- [ ] ~~Tests updated~~
- [ ] ~~Documentation added~~
- [ ] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~