### PR TITLE
docs: document metrics-generator ring

### DIFF
--- a/docs/tempo/website/api_docs/_index.md
+++ b/docs/tempo/website/api_docs/_index.md
@@ -29,6 +29,7 @@ For the sake of clarity, in this document we have grouped API endpoints by servi
 | [Shutdown](#shutdown) | Ingester |  HTTP | `GET,POST /shutdown` |
 | [Distributor ring status](#distributor-ring-status) (*) | Distributor |  HTTP | `GET /distributor/ring` |
 | [Ingesters ring status](#ingesters-ring-status) | Distributor, Querier |  HTTP | `GET /ingester/ring` |
+| [Metrics-generator ring status](#metrics-generator-ring-status) (*) | Distributor |  HTTP | `GET /metrics-generator/ring` |
 | [Compactor ring status](#compactor-ring-status) | Compactor |  HTTP | `GET /compactor/ring` |
 | [Status](#status) | Status |  HTTP | `GET /status` |
 
@@ -299,7 +300,17 @@ Displays a web page with the ingesters hash ring status, including the state, he
 
 _For more information, check the page on [consistent hash ring](../operations/consistent_hash_ring)._
 
+### Metrics-generators ring status
 
+> Note: this endpoint is only available when the metrics-generator is enabled. See [configuration](../configuration/_index.md#metrics-generator).
+
+```
+GET /metrics-generator/ring
+```
+
+Displays a web page with the metrics-generators hash ring status, including the state, healthy and last heartbeat time of each metrics-generator.
+
+_For more information, check the page on [consistent hash ring](../operations/consistent_hash_ring)._
 
 ### Compactor ring status
 

--- a/docs/tempo/website/api_docs/_index.md
+++ b/docs/tempo/website/api_docs/_index.md
@@ -300,15 +300,15 @@ Displays a web page with the ingesters hash ring status, including the state, he
 
 _For more information, check the page on [consistent hash ring](../operations/consistent_hash_ring)._
 
-### Metrics-generators ring status
-
-> Note: this endpoint is only available when the metrics-generator is enabled. See [configuration](../configuration/_index.md#metrics-generator).
+### Metrics-generator ring status
 
 ```
 GET /metrics-generator/ring
 ```
 
-Displays a web page with the metrics-generators hash ring status, including the state, healthy and last heartbeat time of each metrics-generator.
+Displays a web page with the metrics-generator hash ring status, including the state, health, and last heartbeat time of each metrics-generator.
+
+This endpoint is only available when the metrics-generator is enabled. See [metrics-generator](../configuration/_index.md#metrics-generator).
 
 _For more information, check the page on [consistent hash ring](../operations/consistent_hash_ring)._
 

--- a/docs/tempo/website/operations/consistent_hash_ring.md
+++ b/docs/tempo/website/operations/consistent_hash_ring.md
@@ -9,7 +9,7 @@ Tempo uses the [Consistent Hash Ring](https://cortexmetrics.io/docs/architecture
 
 ### Lord of the Rings?
 
-In Tempo there are four consistent hash rings that are used for four distinct reasons: distributor, ingester, metrics-generator and compactor. 
+There are four consistent hash rings : distributor, ingester, metrics-generator, and compactor. Each exists for a distinct reason.
 
 #### Distributor
 **Participants:** Distributors  
@@ -29,7 +29,7 @@ This ring is used by the distributors to load balance traffic into the ingesters
 **Participants:** Metrics-generators  
 **Used by:** Distributors
 
-This ring is used by the distributors to load balance traffic into the metrics-generators. When spans are received the trace id is hashed and they are sent to the appropriate metrics-generators based on token ownership in the ring.
+This ring is used by distributors to load balance traffic to the metrics-generators. When spans are received, the trace ID is hashed, and the traces are sent to the appropriate metrics-generators based on token ownership in the ring.
 
 #### Compactor
 **Participants:** Compactors  
@@ -58,7 +58,7 @@ Unhealthy ingesters will cause writes to fail. If the ingester is really gone fo
 **Available on:** Distributors  
 **Path:** `/metrics-generator/ring`
 
-Unhealthy metrics-generators will cause writes to fail. If the metrics-generator is really gone forget immediately!
+Unhealthy metrics-generators will cause writes to fail. If the metrics-generator is really gone, forget it immediately.
 
 #### Compactor
 **Available on:** Compactors  

--- a/docs/tempo/website/operations/consistent_hash_ring.md
+++ b/docs/tempo/website/operations/consistent_hash_ring.md
@@ -9,7 +9,7 @@ Tempo uses the [Consistent Hash Ring](https://cortexmetrics.io/docs/architecture
 
 ### Lord of the Rings?
 
-In Tempo there are three consistent hash rings that are used for three distinct reasons: distributor, ingester and compactor. 
+In Tempo there are four consistent hash rings that are used for four distinct reasons: distributor, ingester, metrics-generator and compactor. 
 
 #### Distributor
 **Participants:** Distributors  
@@ -24,6 +24,12 @@ This ring is only used when "global" rate limits are used. The distributors use 
 **Used by:** Distributors,Queriers
 
 This ring is used by the distributors to load balance traffic into the ingesters. When spans are received the trace id is hashed and they are sent to the appropriate ingesters based on token ownership in the ring. Queriers also use this ring to find the ingesters for querying recent traces.
+
+#### Metrics-generator
+**Participants:** Metrics-generators  
+**Used by:** Distributors
+
+This ring is used by the distributors to load balance traffic into the metrics-generators. When spans are received the trace id is hashed and they are sent to the appropriate metrics-generators based on token ownership in the ring.
 
 #### Compactor
 **Participants:** Compactors  
@@ -47,6 +53,12 @@ Unhealthy distributors have little impact but should be forgotten to reduce cost
 **Path:** `/ingester/ring`
 
 Unhealthy ingesters will cause writes to fail. If the ingester is really gone forget immediately!
+
+#### Metrics-generators
+**Available on:** Distributors  
+**Path:** `/metrics-generator/ring`
+
+Unhealthy metrics-generators will cause writes to fail. If the metrics-generator is really gone forget immediately!
 
 #### Compactor
 **Available on:** Compactors  


### PR DESCRIPTION
**What this PR does**:
Extend the API reference and the consistent hash ring page to list the new metrics-generator ring.

This is the first (of many) PRs to document the metrics-generator. We will also have to describe the new config options in the configuration section and update various other pages.

**Which issue(s) this PR fixes**:
Related to https://github.com/grafana/tempo/issues/1303

**Checklist**
- [ ] ~~Tests updated~~
- [x] Documentation added
- [ ] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~