### PR TITLE
Docs: improve overrides configuration parameter section

### DIFF
--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -777,50 +777,55 @@ overrides:
     
     # Global ingestion limits configurations
 
-    # Specifies whether the ingestion rate limits should be applied by each instance of the distributor and ingester
-    # individually, or the limits are to be shared across all instances. See the "override strategies" section for an example.
+    # Specifies whether the ingestion rate limits should be applied by each instance
+    # of the distributor and ingester individually, or the limits are to be shared
+    # across all instances. See the "override strategies" section for an example.
     [ingestion_rate_strategy: <global|local> | default = local]
 
     # Burst size (bytes) used in ingestion.
     # Results in errors like
-    #   RATE_LIMITED: ingestion rate limit (20000000 bytes) exceeded while adding 10 bytes
+    #   RATE_LIMITED: ingestion rate limit (20000000 bytes) exceeded while
+    #   adding 10 bytes
     [ingestion_burst_size_bytes: <int> | default = 20000000 (20MB) ]
 
     # Per-user ingestion rate limit (bytes) used in ingestion. 
     # Results in errors like
-    #   RATE_LIMITED: ingestion rate limit (15000000 bytes) exceeded while adding 10 bytes
+    #   RATE_LIMITED: ingestion rate limit (15000000 bytes) exceeded while
+    #   adding 10 bytes
     [ingestion_rate_limit_bytes: <int> | default = 15000000 (15MB) ]
 
-    # Maximum size of a single trace in bytes.  `0` to disable
+    # Maximum size of a single trace in bytes.  A value of 0 disables the size
+    # check.
     # This limit is used in 3 places:
-    #  - During search traces will be skipped when they exceed this threshold.
-    #  - During ingestion traces that exceeds this threshold will be refused.
-    #  - During compaction traces that exceed this threshold will be partially dropped.
-    # During ingestion it results in errors like
+    #  - During search, traces will be skipped when they exceed this threshold.
+    #  - During ingestion, traces that exceed this threshold will be refused.
+    #  - During compaction, traces that exceed this threshold will be partially dropped.
+    # Exceeding the threshold results in errors like
     #    TRACE_TOO_LARGE: max size of trace (5000000) exceeded while adding 387 bytes
     [max_bytes_per_trace: <int> | default = 5000000 (5MB) ]
 
-    # Maximum number of active traces per user, per ingester. `0` to disable. 
+    # Maximum number of active traces per user, per ingester. A value of 0
+    # disables the check.
     # Results in errors like
-    #    LIVE_TRACES_EXCEEDED: max live traces per tenant exceeded: per-user traces limit (local: 10000 global: 0 actual local: 1) exceeded
+    #    LIVE_TRACES_EXCEEDED: max live traces per tenant exceeded:
+    #    per-user traces limit (local: 10000 global: 0 actual local: 1) exceeded
     # This override limit is used by the ingester.
     [max_traces_per_user: <int> | default = 10000]
 
-    # Maximum size of search data for a single trace in bytes. `0` to disable.
-    # From an operational perspective, the size of search data is proportional to the total size of all tags in a trace
+    # Maximum size of search data for a single trace in bytes. A value of 0 
+    # disables the check. From an operational perspective, the size of search
+    # data is proportional to the total size of all tags in a trace.
     [max_search_bytes_per_trace: <int> | default = 5000]
 
-    # Maximum size in bytes of a tag-values query. Tag-values query is used mainly to populate the autocomplete dropdown.
-    # Limit added to protect from tags with high cardinality or large values (like HTTP URLs or SQL queries)
+    # Maximum size in bytes of a tag-values query. Tag-values query is used mainly
+    # to populate the autocomplete dropdown. This limit protects the system from
+    # tags with high cardinality or large values such as HTTP URLs or SQL queries.
     # This override limit is used by the ingester and the querier.
     [max_bytes_per_tag_values_query: <int> | default = 5000000 (5MB) ]
 
-    # Tenant-specific overrides
-
-    # Tenant-specific overrides settings configuration file. See the "Tenant-specific overrides" section for an example.
-    [per_tenant_override_config: /conf/overrides.yaml]
+    # Tenant-specific overrides settings configuration file.
+    [per_tenant_override_config: <string> | default = "/conf/overrides.yaml"]
 ```
-
 
 #### Tenant-specific overrides
 


### PR DESCRIPTION
PR https://github.com/grafana/tempo/pull/1318 got merged in without a docs review. It had a typo. This PR was originally to fix that typo.  Then I decided to correct the formatting and wording throughout the `overrides` section of the configuration documentation section.

Reviewers: please check that I corrected the definition of `per_tenant_override_config` correctly. I believe it had only the default value listed, but not in quote marks.