### PR TITLE
add local port to docker-compose.yaml

### DIFF
--- a/example/docker-compose/local/docker-compose.yaml
+++ b/example/docker-compose/local/docker-compose.yaml
@@ -8,11 +8,11 @@ services:
       - ./tempo-local.yaml:/etc/tempo.yaml
       - ./tempo-data:/tmp/tempo
     ports:
-      - "14268"  # jaeger ingest
-      - "3200"   # tempo
-      - "4317"  # otlp grpc
-      - "4318"  # otlp http
-      - "9411"   # zipkin
+      - "14268:14268"  # jaeger ingest
+      - "3200:3200"   # tempo
+      - "4317:4317"  # otlp grpc
+      - "4318:4318"  # otlp http
+      - "9411:9411"   # zipkin
 
   synthetic-load-generator:
     image: omnition/synthetic-load-generator:1.0.25


### PR DESCRIPTION
I was banging my head against the wall yesterday trying to figure out why my local application was unable to push traces to tempo, and why I was unable to `curl localhost:3200` without getting `connection refused`.

I assumed that this port stuff worked when looking at it, but the only thing that fixed it for me was explicitly setting the local port in the docker-compose file.