### PR TITLE
Tempo Serverless: defer iter.Close()

### DIFF
--- a/cmd/tempo-serverless/handler.go
+++ b/cmd/tempo-serverless/handler.go
@@ -102,6 +102,7 @@ func Handler(r *http.Request) (*tempopb.SearchResponse, *HTTPError) {
 		return nil, httpError("creating partial iterator", err, http.StatusInternalServerError)
 	}
 	iter = encoding.NewPrefetchIterator(r.Context(), iter, cfg.Search.PrefetchTraceCount)
+	defer iter.Close()
 
 	resp := &tempopb.SearchResponse{
 		Metrics: &tempopb.SearchMetrics{},


### PR DESCRIPTION
**What this PR does**:
While trying to find some performance improvements in the serverless handler I noticed we weren't closing the iterator. 