### PR TITLE
Backend Search: Hedged Requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,15 +15,16 @@
 * [ENHANCEMENT] Make trace combination/compaction more efficient [#1291](https://github.com/grafana/tempo/pull/1291) (@mdisibio)
 * [ENHANCEMENT] Add Content-Type headers to query-frontend paths [#1306](https://github.com/grafana/tempo/pull/1306) (@wperron)
 * [ENHANCEMENT] Partially persist traces that exceed `max_bytes_per_trace` during compaction [#1317](https://github.com/grafana/tempo/pull/1317) (@joe-elliott)
-  ```
-  query_frontend:
-  search:
-    hedge_requests_at: 5s
-    hedge_requests_up_to: 3
-  ```
 * [ENHANCEMENT] Make search respect per tenant `max_bytes_per_trace` and added `skippedTraces` to returned search metrics. [#1318](https://github.com/grafana/tempo/pull/1318) (@joe-elliott)
 * [ENHANCEMENT] Improve serverless consistency by forcing a GC before returning. [#1324](https://github.com/grafana/tempo/pull/1324) (@joe-elliott)
 * [ENHANCEMENT] Add hedging to sharded search queries created by the frontend. [#1334](https://github.com/grafana/tempo/pull/1334) (@joe-elliott)
+  New config options and defaults:
+  ```
+  query_frontend:
+    search:
+      hedge_requests_at: 5s
+      hedge_requests_up_to: 3
+  ```
 * [BUGFIX]: Remove unnecessary PersistentVolumeClaim [#1245](https://github.com/grafana/tempo/issues/1245)
 * [BUGFIX] Fixed issue when query-frontend doesn't log request details when request is cancelled [#1136](https://github.com/grafana/tempo/issues/1136) (@adityapwr)
 * [BUGFIX] Update OTLP port in examples (docker-compose & kubernetes) from legacy ports (55680/55681) to new ports (4317/4318) [#1294](https://github.com/grafana/tempo/pull/1294) (@mapno)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,15 @@
 * [ENHANCEMENT] Make trace combination/compaction more efficient [#1291](https://github.com/grafana/tempo/pull/1291) (@mdisibio)
 * [ENHANCEMENT] Add Content-Type headers to query-frontend paths [#1306](https://github.com/grafana/tempo/pull/1306) (@wperron)
 * [ENHANCEMENT] Partially persist traces that exceed `max_bytes_per_trace` during compaction [#1317](https://github.com/grafana/tempo/pull/1317) (@joe-elliott)
+  ```
+  query_frontend:
+  search:
+    hedge_requests_at: 5s
+    hedge_requests_up_to: 3
+  ```
 * [ENHANCEMENT] Make search respect per tenant `max_bytes_per_trace` and added `skippedTraces` to returned search metrics. [#1318](https://github.com/grafana/tempo/pull/1318) (@joe-elliott)
 * [ENHANCEMENT] Improve serverless consistency by forcing a GC before returning. [#1324](https://github.com/grafana/tempo/pull/1324) (@joe-elliott)
+* [ENHANCEMENT] Add hedging to sharded search queries created by the frontend. [#1334](https://github.com/grafana/tempo/pull/1334) (@joe-elliott)
 * [BUGFIX]: Remove unnecessary PersistentVolumeClaim [#1245](https://github.com/grafana/tempo/issues/1245)
 * [BUGFIX] Fixed issue when query-frontend doesn't log request details when request is cancelled [#1136](https://github.com/grafana/tempo/issues/1136) (@adityapwr)
 * [BUGFIX] Update OTLP port in examples (docker-compose & kubernetes) from legacy ports (55680/55681) to new ports (4317/4318) [#1294](https://github.com/grafana/tempo/pull/1294) (@mapno)

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -231,6 +231,15 @@ query_frontend:
 
         # (default: 1h)
         [query_ingesters_until: <duration>]
+
+        # If set to a non-zero value a second request will be issued at the provided duration. Recommended to
+        # be set to p99 of search requests to reduce long tail latency.
+        # (default: 5s)
+        [hedge_requests_at: <duration>]
+
+        # The maximum number of requests to execute when hedging. Requires hedge_requests_at to be set.
+        # (default: 3)
+        [hedge_requests_up_to: <int>]
 ```
 
 ## Querier

--- a/docs/tempo/website/configuration/manifest.md
+++ b/docs/tempo/website/configuration/manifest.md
@@ -16,7 +16,7 @@ go run ./cmd/tempo --storage.trace.backend=local --storage.trace.local.path=/tmp
 
 ## Complete Configuration
 
-> **Note**: This manifest was generated on 2021-10-27.
+> **Note**: This manifest was generated on 2022-03-09.
 
 ```yaml
 target: all

--- a/modules/frontend/config.go
+++ b/modules/frontend/config.go
@@ -25,9 +25,9 @@ type Config struct {
 }
 
 type SearchConfig struct {
-	SearchSharderConfig
-	HedgeRequestsAt   time.Duration `yaml:"hedge_requests_at"`
-	HedgeRequestsUpTo int           `yaml:"hedge_requests_up_to"`
+	Sharder           SearchSharderConfig `yaml:",inline"`
+	HedgeRequestsAt   time.Duration       `yaml:"hedge_requests_at"`
+	HedgeRequestsUpTo int                 `yaml:"hedge_requests_up_to"`
 }
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
@@ -40,7 +40,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.Search = SearchConfig{
 		HedgeRequestsAt:   5 * time.Second,
 		HedgeRequestsUpTo: 3,
-		SearchSharderConfig: SearchSharderConfig{
+		Sharder: SearchSharderConfig{
 			QueryBackendAfter:     15 * time.Minute,
 			QueryIngestersUntil:   time.Hour,
 			DefaultLimit:          20,

--- a/modules/frontend/config.go
+++ b/modules/frontend/config.go
@@ -21,7 +21,13 @@ type Config struct {
 	MaxRetries           int                    `yaml:"max_retries,omitempty"`
 	QueryShards          int                    `yaml:"query_shards,omitempty"`
 	TolerateFailedBlocks int                    `yaml:"tolerate_failed_blocks,omitempty"`
-	Search               SearchSharderConfig    `yaml:"search"`
+	Search               SearchConfig           `yaml:"search"`
+}
+
+type SearchConfig struct {
+	SearchSharderConfig
+	HedgeRequestsAt   time.Duration `yaml:"hedge_requests_at"`
+	HedgeRequestsUpTo int           `yaml:"hedge_requests_up_to"`
 }
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
@@ -31,14 +37,18 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.MaxRetries = 2
 	cfg.QueryShards = 20
 	cfg.TolerateFailedBlocks = 0
-	cfg.Search = SearchSharderConfig{
-		QueryBackendAfter:     15 * time.Minute,
-		QueryIngestersUntil:   time.Hour,
-		DefaultLimit:          20,
-		MaxLimit:              0,
-		MaxDuration:           61 * time.Minute,
-		ConcurrentRequests:    defaultConcurrentRequests,
-		TargetBytesPerRequest: defaultTargetBytesPerRequest,
+	cfg.Search = SearchConfig{
+		HedgeRequestsAt:   5 * time.Second,
+		HedgeRequestsUpTo: 3,
+		SearchSharderConfig: SearchSharderConfig{
+			QueryBackendAfter:     15 * time.Minute,
+			QueryIngestersUntil:   time.Hour,
+			DefaultLimit:          20,
+			MaxLimit:              0,
+			MaxDuration:           61 * time.Minute,
+			ConcurrentRequests:    defaultConcurrentRequests,
+			TargetBytesPerRequest: defaultTargetBytesPerRequest,
+		},
 	}
 }
 

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -8,9 +8,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
-	"time"
 
-	"github.com/cristalhq/hedgedhttp"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/golang/protobuf/jsonpb"
@@ -209,14 +207,4 @@ func buildUpstreamRequestURI(originalURI string, params url.Values) string {
 	}
 
 	return uri
-}
-
-func newHedgedRequestWare(hedgeRequestsAt time.Duration, hedgeRequestsUpTo int) Middleware {
-	return MiddlewareFunc(func(r http.RoundTripper) http.RoundTripper {
-		ret, err := hedgedhttp.NewRoundTripper(hedgeRequestsAt, hedgeRequestsUpTo, r)
-		if err != nil {
-			panic(err)
-		}
-		return ret
-	})
 }

--- a/modules/frontend/frontend_test.go
+++ b/modules/frontend/frontend_test.go
@@ -25,7 +25,7 @@ func TestFrontendRoundTripsSearch(t *testing.T) {
 	next := &mockNextTripperware{}
 	f, err := New(Config{QueryShards: minQueryShards,
 		Search: SearchConfig{
-			SearchSharderConfig: SearchSharderConfig{
+			Sharder: SearchSharderConfig{
 				ConcurrentRequests:    defaultConcurrentRequests,
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			},
@@ -44,7 +44,7 @@ func TestFrontendRoundTripsSearch(t *testing.T) {
 func TestFrontendBadConfigFails(t *testing.T) {
 	f, err := New(Config{QueryShards: minQueryShards - 1,
 		Search: SearchConfig{
-			SearchSharderConfig: SearchSharderConfig{
+			Sharder: SearchSharderConfig{
 				ConcurrentRequests:    defaultConcurrentRequests,
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			},
@@ -55,7 +55,7 @@ func TestFrontendBadConfigFails(t *testing.T) {
 
 	f, err = New(Config{QueryShards: maxQueryShards + 1,
 		Search: SearchConfig{
-			SearchSharderConfig: SearchSharderConfig{
+			Sharder: SearchSharderConfig{
 				ConcurrentRequests:    defaultConcurrentRequests,
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			},
@@ -66,7 +66,7 @@ func TestFrontendBadConfigFails(t *testing.T) {
 
 	f, err = New(Config{QueryShards: maxQueryShards,
 		Search: SearchConfig{
-			SearchSharderConfig: SearchSharderConfig{
+			Sharder: SearchSharderConfig{
 				ConcurrentRequests:    defaultConcurrentRequests,
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			},
@@ -77,7 +77,7 @@ func TestFrontendBadConfigFails(t *testing.T) {
 
 	f, err = New(Config{QueryShards: maxQueryShards,
 		Search: SearchConfig{
-			SearchSharderConfig: SearchSharderConfig{
+			Sharder: SearchSharderConfig{
 				ConcurrentRequests:    defaultConcurrentRequests,
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			},
@@ -88,7 +88,7 @@ func TestFrontendBadConfigFails(t *testing.T) {
 
 	f, err = New(Config{QueryShards: maxQueryShards,
 		Search: SearchConfig{
-			SearchSharderConfig: SearchSharderConfig{
+			Sharder: SearchSharderConfig{
 				ConcurrentRequests:    defaultConcurrentRequests,
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			},

--- a/modules/frontend/frontend_test.go
+++ b/modules/frontend/frontend_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
@@ -67,7 +68,7 @@ func TestFrontendBadConfigFails(t *testing.T) {
 	f, err = New(Config{QueryShards: maxQueryShards,
 		Search: SearchConfig{
 			Sharder: SearchSharderConfig{
-				ConcurrentRequests:    defaultConcurrentRequests,
+				ConcurrentRequests:    0,
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			},
 		},
@@ -79,7 +80,7 @@ func TestFrontendBadConfigFails(t *testing.T) {
 		Search: SearchConfig{
 			Sharder: SearchSharderConfig{
 				ConcurrentRequests:    defaultConcurrentRequests,
-				TargetBytesPerRequest: defaultTargetBytesPerRequest,
+				TargetBytesPerRequest: 0,
 			},
 		},
 	}, nil, nil, log.NewNopLogger(), nil)
@@ -91,6 +92,8 @@ func TestFrontendBadConfigFails(t *testing.T) {
 			Sharder: SearchSharderConfig{
 				ConcurrentRequests:    defaultConcurrentRequests,
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
+				QueryIngestersUntil:   time.Minute,
+				QueryBackendAfter:     time.Hour,
 			},
 		},
 	}, nil, nil, log.NewNopLogger(), nil)

--- a/modules/frontend/frontend_test.go
+++ b/modules/frontend/frontend_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
@@ -25,9 +24,11 @@ func (s *mockNextTripperware) RoundTrip(_ *http.Request) (*http.Response, error)
 func TestFrontendRoundTripsSearch(t *testing.T) {
 	next := &mockNextTripperware{}
 	f, err := New(Config{QueryShards: minQueryShards,
-		Search: SearchSharderConfig{
-			ConcurrentRequests:    defaultConcurrentRequests,
-			TargetBytesPerRequest: defaultTargetBytesPerRequest,
+		Search: SearchConfig{
+			SearchSharderConfig: SearchSharderConfig{
+				ConcurrentRequests:    defaultConcurrentRequests,
+				TargetBytesPerRequest: defaultTargetBytesPerRequest,
+			},
 		},
 	}, next, nil, log.NewNopLogger(), nil)
 	require.NoError(t, err)
@@ -42,47 +43,55 @@ func TestFrontendRoundTripsSearch(t *testing.T) {
 
 func TestFrontendBadConfigFails(t *testing.T) {
 	f, err := New(Config{QueryShards: minQueryShards - 1,
-		Search: SearchSharderConfig{
-			ConcurrentRequests:    defaultConcurrentRequests,
-			TargetBytesPerRequest: defaultTargetBytesPerRequest,
+		Search: SearchConfig{
+			SearchSharderConfig: SearchSharderConfig{
+				ConcurrentRequests:    defaultConcurrentRequests,
+				TargetBytesPerRequest: defaultTargetBytesPerRequest,
+			},
 		},
 	}, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "frontend query shards should be between 2 and 256 (both inclusive)")
 	assert.Nil(t, f)
 
 	f, err = New(Config{QueryShards: maxQueryShards + 1,
-		Search: SearchSharderConfig{
-			ConcurrentRequests:    defaultConcurrentRequests,
-			TargetBytesPerRequest: defaultTargetBytesPerRequest,
+		Search: SearchConfig{
+			SearchSharderConfig: SearchSharderConfig{
+				ConcurrentRequests:    defaultConcurrentRequests,
+				TargetBytesPerRequest: defaultTargetBytesPerRequest,
+			},
 		},
 	}, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "frontend query shards should be between 2 and 256 (both inclusive)")
 	assert.Nil(t, f)
 
 	f, err = New(Config{QueryShards: maxQueryShards,
-		Search: SearchSharderConfig{
-			ConcurrentRequests:    0,
-			TargetBytesPerRequest: defaultTargetBytesPerRequest,
+		Search: SearchConfig{
+			SearchSharderConfig: SearchSharderConfig{
+				ConcurrentRequests:    defaultConcurrentRequests,
+				TargetBytesPerRequest: defaultTargetBytesPerRequest,
+			},
 		},
 	}, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "frontend search concurrent requests should be greater than 0")
 	assert.Nil(t, f)
 
 	f, err = New(Config{QueryShards: maxQueryShards,
-		Search: SearchSharderConfig{
-			ConcurrentRequests:    defaultConcurrentRequests,
-			TargetBytesPerRequest: 0,
+		Search: SearchConfig{
+			SearchSharderConfig: SearchSharderConfig{
+				ConcurrentRequests:    defaultConcurrentRequests,
+				TargetBytesPerRequest: defaultTargetBytesPerRequest,
+			},
 		},
 	}, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "frontend search target bytes per request should be greater than 0")
 	assert.Nil(t, f)
 
 	f, err = New(Config{QueryShards: maxQueryShards,
-		Search: SearchSharderConfig{
-			ConcurrentRequests:    defaultConcurrentRequests,
-			TargetBytesPerRequest: defaultTargetBytesPerRequest,
-			QueryIngestersUntil:   time.Minute,
-			QueryBackendAfter:     time.Hour,
+		Search: SearchConfig{
+			SearchSharderConfig: SearchSharderConfig{
+				ConcurrentRequests:    defaultConcurrentRequests,
+				TargetBytesPerRequest: defaultTargetBytesPerRequest,
+			},
 		},
 	}, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "query backend after should be less than or equal to query ingester until")

--- a/modules/frontend/hedged_requests.go
+++ b/modules/frontend/hedged_requests.go
@@ -1,0 +1,50 @@
+package frontend
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/cristalhq/hedgedhttp"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	hedgedMetricsPublishDuration = 10 * time.Second
+)
+
+var (
+	hedgedRequestsMetrics = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "tempo",
+			Name:      "query_frontend_hedged_roundtrips_total",
+			Help:      "Total number of hedged search requests. Registered as a gauge for code sanity. This is a counter.",
+		},
+	)
+)
+
+func newHedgedRequestWare(hedgeRequestsAt time.Duration, hedgeRequestsUpTo int) Middleware {
+	return MiddlewareFunc(func(r http.RoundTripper) http.RoundTripper {
+		ret, stats, err := hedgedhttp.NewRoundTripperAndStats(hedgeRequestsAt, hedgeRequestsUpTo, r)
+		if err != nil {
+			panic(err)
+		}
+		publishHedgedMetrics(stats)
+		return ret
+	})
+}
+
+// PublishHedgedMetrics flushes metrics from hedged requests every 10 seconds
+func publishHedgedMetrics(s *hedgedhttp.Stats) {
+	ticker := time.NewTicker(hedgedMetricsPublishDuration)
+	go func() {
+		for range ticker.C {
+			snap := s.Snapshot()
+			hedgedRequests := int64(snap.ActualRoundTrips) - int64(snap.RequestedRoundTrips)
+			if hedgedRequests < 0 {
+				hedgedRequests = 0
+			}
+			hedgedRequestsMetrics.Set(float64(hedgedRequests))
+		}
+	}()
+}


### PR DESCRIPTION
**What this PR does**:
Drastically reduces variance in search requests by hedging. Adds two new config options with defaults:

```
query_frontend:
  search:
    hedge_requests_at: 5s
    hedge_requests_up_to: 3
```

These two defaults were chosen b/c they work well internally.

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`