### PR TITLE
e2e: store the metrics-generator WAL in /var/tempo

### DIFF
--- a/integration/e2e/config-metrics-generator.yaml
+++ b/integration/e2e/config-metrics-generator.yaml
@@ -18,7 +18,7 @@ ingester:
 metrics_generator:
   collection_interval: 1s
   storage:
-    path: /var/tempo-metrics-generator
+    path: /var/tempo
     remote_write:
       - url: http://tempo_e2e-prometheus:9090/api/v1/write
         send_exemplars: true


### PR DESCRIPTION
**What this PR does**:
Tweak the `TestMetricsGenerator` e2e test to use the same path for the ingester and the metrics-generator WAL. This is more consistent.
Since Tempo runs in microservices mode they don't share this directory, it's just the same path.
