### PR TITLE
metrics-generator: verify WAL is writeable

### DIFF
--- a/modules/generator/storage/instance.go
+++ b/modules/generator/storage/instance.go
@@ -50,7 +50,6 @@ func New(cfg *Config, tenant string, reg prometheus.Registerer, logger log.Logge
 	// subdirectory remote storage logs a scary error.
 	err := os.MkdirAll(filepath.Join(walDir, "wal"), 0o755)
 	if err != nil {
-		level.Error(logger).Log("msg", "could not create directory for metrics WAL", "err", err)
 		return nil, fmt.Errorf("could not create directory for metrics WAL: %w", err)
 	}
 

--- a/modules/generator/storage/instance.go
+++ b/modules/generator/storage/instance.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -49,7 +50,8 @@ func New(cfg *Config, tenant string, reg prometheus.Registerer, logger log.Logge
 	// subdirectory remote storage logs a scary error.
 	err := os.MkdirAll(filepath.Join(walDir, "wal"), 0o755)
 	if err != nil {
-		level.Warn(logger).Log("msg", "could not create directory for metrics WAL", "err", err)
+		level.Error(logger).Log("msg", "could not create directory for metrics WAL", "err", err)
+		return nil, fmt.Errorf("could not create directory for metrics WAL: %w", err)
 	}
 
 	// Set up remote storage writer

--- a/modules/generator/storage/instance_test.go
+++ b/modules/generator/storage/instance_test.go
@@ -167,6 +167,20 @@ func TestInstance_multiTenancy(t *testing.T) {
 	}
 }
 
+func TestInstance_cantWriteToWAL(t *testing.T) {
+	var cfg Config
+	cfg.RegisterFlagsAndApplyDefaults("", nil)
+
+	// We are obviously not allowed to write here
+	cfg.Path = "/root"
+
+	// We should be able to attempt to create the instance multiple times
+	_, err := New(&cfg, "test-tenant", prometheus.DefaultRegisterer, log.NewNopLogger())
+	require.Error(t, err)
+	_, err = New(&cfg, "test-tenant", prometheus.DefaultRegisterer, log.NewNopLogger())
+	require.Error(t, err)
+}
+
 type mockPrometheusRemoteWriteServer struct {
 	mtx sync.Mutex
 


### PR DESCRIPTION
**What this PR does**:
When creating a metrics-generator `storage.Instance`, verify we can write to the given path before creating any resources. If we create Prometheus' `remote.Storage` twice, it will panic as metrics are registered twice.

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [x] Tests updated
- [ ] ~~Documentation added~~
- [ ] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~