### PR TITLE
metrics-generator: consistently pass log.Logger around

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ALL_DOC := $(shell find . \( -name "*.md" -o -name "*.yaml" \) \
 ALL_PKGS := $(shell go list $(sort $(dir $(ALL_SRC))))
 
 GO_OPT= -mod vendor -ldflags "-X main.Branch=$(GIT_BRANCH) -X main.Revision=$(GIT_REVISION) -X main.Version=$(VERSION)"
-GOTEST_OPT?= -race -timeout 13m -count=1
+GOTEST_OPT?= -race -timeout 16m -count=1
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -cover
 GOTEST=go test
 LINT=golangci-lint

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -149,7 +149,7 @@ func (t *App) initIngester() (services.Service, error) {
 
 func (t *App) initGenerator() (services.Service, error) {
 	t.cfg.Generator.Ring.ListenPort = t.cfg.Server.GRPCListenPort
-	generator, err := generator.New(&t.cfg.Generator, t.overrides, prometheus.DefaultRegisterer)
+	generator, err := generator.New(&t.cfg.Generator, t.overrides, prometheus.DefaultRegisterer, log.Logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create metrics-generator %w", err)
 	}

--- a/modules/generator/instance_test.go
+++ b/modules/generator/instance_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
 	prometheus_storage "github.com/prometheus/prometheus/storage"
@@ -18,7 +20,7 @@ import (
 )
 
 func Test_instance_concurrency(t *testing.T) {
-	instance, err := newInstance(&Config{}, "test", &mockOverrides{}, &noopStorage{})
+	instance, err := newInstance(&Config{}, "test", &mockOverrides{}, &noopStorage{}, prometheus.DefaultRegisterer, log.NewNopLogger())
 	assert.NoError(t, err)
 
 	end := make(chan struct{})
@@ -70,7 +72,7 @@ func Test_instance_concurrency(t *testing.T) {
 }
 
 func Test_instance_updateProcessors(t *testing.T) {
-	instance, err := newInstance(&Config{}, "test", &mockOverrides{}, &noopStorage{})
+	instance, err := newInstance(&Config{}, "test", &mockOverrides{}, &noopStorage{}, prometheus.DefaultRegisterer, log.NewNopLogger())
 	assert.NoError(t, err)
 
 	// stop the update goroutine

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,7 +20,7 @@ import (
 func TestServiceGraphs(t *testing.T) {
 	cfg := Config{}
 	cfg.RegisterFlagsAndApplyDefaults("", nil)
-	p := New(cfg, "test")
+	p := New(cfg, "test", log.NewNopLogger())
 
 	registry := gen.NewRegistry(nil, "test-tenant")
 	err := p.RegisterMetrics(registry)
@@ -101,7 +102,7 @@ func TestServiceGraphs_tooManySpansErr(t *testing.T) {
 	cfg := Config{}
 	cfg.RegisterFlagsAndApplyDefaults("", nil)
 	cfg.MaxItems = 0
-	p := New(cfg, "test")
+	p := New(cfg, "test", log.NewNopLogger())
 
 	traces := testData(t, "testdata/test-sample.json")
 	err := p.(*processor).consume(traces.Batches)

--- a/modules/generator/storage/instance_test.go
+++ b/modules/generator/storage/instance_test.go
@@ -63,6 +63,10 @@ func TestInstance(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
+		if sendCtx.Err() != nil {
+			return
+		}
+
 		err = appender.Commit()
 		assert.NoError(t, err)
 	})
@@ -127,6 +131,10 @@ func TestInstance_multiTenancy(t *testing.T) {
 			lbls := labels.FromMap(map[string]string{"__name__": "my-metric"})
 			_, err := appender.Append(0, lbls, time.Now().UnixMilli(), float64(i))
 			assert.NoError(t, err)
+
+			if sendCtx.Err() != nil {
+				return
+			}
 
 			err = appender.Commit()
 			assert.NoError(t, err)


### PR DESCRIPTION
**What this PR does**:
Small refactor to pass `log.Logger` to every component that logs something instead of relying on the global logger variable. This makes it easier to add common labels to logs and allows us to control logging better in tests.
