### PR TITLE
e2e: reduce flakiness

### DIFF
--- a/integration/e2e/backend/backend.go
+++ b/integration/e2e/backend/backend.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/e2e"
 	e2e_db "github.com/grafana/e2e/db"
+
 	"github.com/grafana/tempo/cmd/tempo/app"
 	util "github.com/grafana/tempo/integration"
 	"github.com/grafana/tempo/tempodb/backend/azure"
@@ -15,7 +16,7 @@ import (
 
 const (
 	azuriteImage = "mcr.microsoft.com/azure-storage/azurite"
-	gcsImage     = "fsouza/fake-gcs-server"
+	gcsImage     = "fsouza/fake-gcs-server:1.36.3"
 )
 
 func parsePort(endpoint string) (int, error) {

--- a/integration/e2e/config-all-in-one-azurite.yaml
+++ b/integration/e2e/config-all-in-one-azurite.yaml
@@ -24,7 +24,7 @@ ingester:
         store: inmemory
       replication_factor: 1
     final_sleep: 0s
-  trace_idle_period: 100ms
+  trace_idle_period: 1s
   max_block_bytes: 1
   max_block_duration: 2s
   complete_block_timeout: 1s

--- a/integration/e2e/config-all-in-one-gcs.yaml
+++ b/integration/e2e/config-all-in-one-gcs.yaml
@@ -24,7 +24,7 @@ ingester:
         store: inmemory
       replication_factor: 1
     final_sleep: 0s
-  trace_idle_period: 100ms
+  trace_idle_period: 1s
   max_block_bytes: 1
   max_block_duration: 2s
   complete_block_timeout: 1s

--- a/integration/e2e/config-all-in-one-local.yaml
+++ b/integration/e2e/config-all-in-one-local.yaml
@@ -27,7 +27,7 @@ ingester:
         store: inmemory
       replication_factor: 1
     final_sleep: 0s
-  trace_idle_period: 100ms
+  trace_idle_period: 1s
   max_block_bytes: 1
   max_block_duration: 2s
   complete_block_timeout: 1s

--- a/integration/e2e/config-all-in-one-s3.yaml
+++ b/integration/e2e/config-all-in-one-s3.yaml
@@ -24,7 +24,7 @@ ingester:
         store: inmemory
       replication_factor: 1
     final_sleep: 0s
-  trace_idle_period: 100ms
+  trace_idle_period: 1s
   max_block_bytes: 1
   max_block_duration: 2s
   complete_block_timeout: 1s

--- a/integration/e2e/config-microservices.tmpl.yaml
+++ b/integration/e2e/config-microservices.tmpl.yaml
@@ -15,7 +15,7 @@ ingester:
       kvstore: {{ .KVStore }}
       replication_factor: 3
     heartbeat_period: 100ms
-  trace_idle_period: 1s
+  trace_idle_period: 2s
   max_block_duration: 2s
   complete_block_timeout: 5s
   flush_check_period: 1s

--- a/integration/e2e/config-microservices.tmpl.yaml
+++ b/integration/e2e/config-microservices.tmpl.yaml
@@ -23,6 +23,7 @@ ingester:
 storage:
   trace:
     blocklist_poll: 2s
+    blocklist_poll_stale_tenant_index: 15s
     backend: s3
     s3:
       bucket: tempo

--- a/integration/e2e/config-microservices.tmpl.yaml
+++ b/integration/e2e/config-microservices.tmpl.yaml
@@ -23,7 +23,7 @@ ingester:
 storage:
   trace:
     blocklist_poll: 2s
-    blocklist_poll_stale_tenant_index: 15s
+    blocklist_poll_stale_tenant_index: 1s # force components to always fall back to polling
     backend: s3
     s3:
       bucket: tempo

--- a/integration/e2e/config-scalable-single-binary.yaml
+++ b/integration/e2e/config-scalable-single-binary.yaml
@@ -19,7 +19,7 @@ ingester:
   max_block_bytes: 1
   max_block_duration: 2s
   flush_check_period: 1s
-  trace_idle_period: 100ms
+  trace_idle_period: 1s
 
 storage:
   trace:

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -92,8 +92,9 @@ func TestAllInOne(t *testing.T) {
 			// test echo
 			assertEcho(t, "http://"+tempo.Endpoint(3200)+"/api/echo")
 
-			// ensure trace is created in ingester (trace_idle_time has passed)
-			require.NoError(t, tempo.WaitSumMetrics(e2e.Greater(0), "tempo_ingester_traces_created_total"))
+			// wait trace_idle_time and ensure trace is created in ingester
+			time.Sleep(2 * time.Second)
+			require.NoError(t, tempo.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_traces_created_total"))
 
 			apiClient := tempoUtil.NewClient("http://"+tempo.Endpoint(3200), "")
 
@@ -242,10 +243,11 @@ func TestMicroservicesWithKVStores(t *testing.T) {
 			// test echo
 			assertEcho(t, "http://"+tempoQueryFrontend.Endpoint(3200)+"/api/echo")
 
-			// ensure trace is created in ingester (trace_idle_time has passed)
-			require.NoError(t, tempoIngester1.WaitSumMetrics(e2e.Greater(0), "tempo_ingester_traces_created_total"))
-			require.NoError(t, tempoIngester2.WaitSumMetrics(e2e.Greater(0), "tempo_ingester_traces_created_total"))
-			require.NoError(t, tempoIngester3.WaitSumMetrics(e2e.Greater(0), "tempo_ingester_traces_created_total"))
+			// wait trace_idle_time and ensure trace is created in ingester
+			time.Sleep(1 * time.Second)
+			require.NoError(t, tempoIngester1.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_traces_created_total"))
+			require.NoError(t, tempoIngester2.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_traces_created_total"))
+			require.NoError(t, tempoIngester3.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_traces_created_total"))
 
 			apiClient := tempoUtil.NewClient("http://"+tempoQueryFrontend.Endpoint(3200), "")
 
@@ -374,7 +376,10 @@ func TestScalableSingleBinary(t *testing.T) {
 
 	// test metrics
 	require.NoError(t, tempo1.WaitSumMetrics(e2e.Equals(spanCount(expected)), "tempo_distributor_spans_received_total"))
-	require.NoError(t, tempo1.WaitSumMetrics(e2e.Greater(0), "tempo_ingester_traces_created_total"))
+
+	// wait trace_idle_time and ensure trace is created in ingester
+	time.Sleep(1 * time.Second)
+	require.NoError(t, tempo1.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_traces_created_total"))
 
 	for _, i := range []*e2e.HTTPService{tempo1, tempo2, tempo3} {
 		callFlush(t, i)

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/grafana/e2e"
 	e2edb "github.com/grafana/e2e/db"
+
 	"github.com/grafana/tempo/cmd/tempo/app"
 	util "github.com/grafana/tempo/integration"
 	"github.com/grafana/tempo/integration/e2e/backend"
@@ -92,7 +93,7 @@ func TestAllInOne(t *testing.T) {
 			assertEcho(t, "http://"+tempo.Endpoint(3200)+"/api/echo")
 
 			// ensure trace is created in ingester (trace_idle_time has passed)
-			require.NoError(t, tempo.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_traces_created_total"))
+			require.NoError(t, tempo.WaitSumMetrics(e2e.Greater(0), "tempo_ingester_traces_created_total"))
 
 			apiClient := tempoUtil.NewClient("http://"+tempo.Endpoint(3200), "")
 
@@ -246,9 +247,9 @@ func TestMicroservicesWithKVStores(t *testing.T) {
 			assertEcho(t, "http://"+tempoQueryFrontend.Endpoint(3200)+"/api/echo")
 
 			// ensure trace is created in ingester (trace_idle_time has passed)
-			require.NoError(t, tempoIngester1.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_traces_created_total"))
-			require.NoError(t, tempoIngester2.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_traces_created_total"))
-			require.NoError(t, tempoIngester3.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_traces_created_total"))
+			require.NoError(t, tempoIngester1.WaitSumMetrics(e2e.Greater(0), "tempo_ingester_traces_created_total"))
+			require.NoError(t, tempoIngester2.WaitSumMetrics(e2e.Greater(0), "tempo_ingester_traces_created_total"))
+			require.NoError(t, tempoIngester3.WaitSumMetrics(e2e.Greater(0), "tempo_ingester_traces_created_total"))
 
 			apiClient := tempoUtil.NewClient("http://"+tempoQueryFrontend.Endpoint(3200), "")
 
@@ -385,7 +386,7 @@ func TestScalableSingleBinary(t *testing.T) {
 
 	// test metrics
 	require.NoError(t, tempo1.WaitSumMetrics(e2e.Equals(spanCount(expected)), "tempo_distributor_spans_received_total"))
-	require.NoError(t, tempo1.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_traces_created_total"))
+	require.NoError(t, tempo1.WaitSumMetrics(e2e.Greater(0), "tempo_ingester_traces_created_total"))
 
 	for _, i := range []*e2e.HTTPService{tempo1, tempo2, tempo3} {
 		res, err := e2e.DoGet("http://" + i.Endpoint(3200) + "/flush")

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -104,17 +104,13 @@ func TestAllInOne(t *testing.T) {
 			util.SearchAndAssertTrace(t, apiClient, info)
 
 			// flush trace to backend
-			res, err := e2e.DoGet("http://" + tempo.Endpoint(3200) + "/flush")
-			require.NoError(t, err)
-			require.Equal(t, 204, res.StatusCode)
+			callFlush(t, tempo)
 
 			// sleep for one maintenance cycle
 			time.Sleep(5 * time.Second)
 
 			// force clear completed block
-			res, err = e2e.DoGet("http://" + tempo.Endpoint(3200) + "/flush")
-			require.NoError(t, err)
-			require.Equal(t, 204, res.StatusCode)
+			callFlush(t, tempo)
 
 			// test metrics
 			require.NoError(t, tempo.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_blocks_flushed_total"))
@@ -260,17 +256,9 @@ func TestMicroservicesWithKVStores(t *testing.T) {
 			util.SearchAndAssertTrace(t, apiClient, info)
 
 			// flush trace to backend
-			res, err := e2e.DoGet("http://" + tempoIngester1.Endpoint(3200) + "/flush")
-			require.NoError(t, err)
-			require.Equal(t, 204, res.StatusCode)
-
-			res, err = e2e.DoGet("http://" + tempoIngester2.Endpoint(3200) + "/flush")
-			require.NoError(t, err)
-			require.Equal(t, 204, res.StatusCode)
-
-			res, err = e2e.DoGet("http://" + tempoIngester3.Endpoint(3200) + "/flush")
-			require.NoError(t, err)
-			require.Equal(t, 204, res.StatusCode)
+			callFlush(t, tempoIngester1)
+			callFlush(t, tempoIngester2)
+			callFlush(t, tempoIngester3)
 
 			// sleep for one maintenance cycle
 			time.Sleep(5 * time.Second)
@@ -389,10 +377,7 @@ func TestScalableSingleBinary(t *testing.T) {
 	require.NoError(t, tempo1.WaitSumMetrics(e2e.Greater(0), "tempo_ingester_traces_created_total"))
 
 	for _, i := range []*e2e.HTTPService{tempo1, tempo2, tempo3} {
-		res, err := e2e.DoGet("http://" + i.Endpoint(3200) + "/flush")
-		require.NoError(t, err)
-		require.Equal(t, 204, res.StatusCode)
-
+		callFlush(t, i)
 		require.NoError(t, i.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_blocks_flushed_total"))
 	}
 
@@ -445,6 +430,13 @@ func makeThriftBatchWithSpanCount(n int) *thrift.Batch {
 	}
 
 	return &thrift.Batch{Spans: spans}
+}
+
+func callFlush(t *testing.T, ingester *e2e.HTTPService) {
+	fmt.Printf("Calling /flush on %s\n", ingester.Name())
+	res, err := e2e.DoGet("http://" + ingester.Endpoint(3200) + "/flush")
+	require.NoError(t, err)
+	require.Equal(t, 204, res.StatusCode)
 }
 
 func assertEcho(t *testing.T, url string) {

--- a/integration/e2e/serverless/config-serverless.yaml
+++ b/integration/e2e/serverless/config-serverless.yaml
@@ -21,7 +21,7 @@ ingester:
         store: memberlist
       replication_factor: 3
     heartbeat_period: 100ms
-  trace_idle_period: 100ms
+  trace_idle_period: 1s
   max_block_duration: 2s
   complete_block_timeout: 5s
   flush_check_period: 1s

--- a/integration/e2e/serverless/serverless_test.go
+++ b/integration/e2e/serverless/serverless_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/grafana/e2e"
 	e2e_db "github.com/grafana/e2e/db"
+
 	util "github.com/grafana/tempo/integration"
 	tempoUtil "github.com/grafana/tempo/pkg/util"
 )
@@ -60,10 +61,11 @@ func TestServerless(t *testing.T) {
 	info := tempoUtil.NewTraceInfo(time.Now(), "")
 	require.NoError(t, info.EmitAllBatches(c))
 
-	// ensure trace is created in ingester (trace_idle_time has passed)
-	require.NoError(t, tempoIngester1.WaitSumMetrics(e2e.Greater(0), "tempo_ingester_traces_created_total"))
-	require.NoError(t, tempoIngester2.WaitSumMetrics(e2e.Greater(0), "tempo_ingester_traces_created_total"))
-	require.NoError(t, tempoIngester3.WaitSumMetrics(e2e.Greater(0), "tempo_ingester_traces_created_total"))
+	// wait trace_idle_time and ensure trace is created in ingester
+	time.Sleep(1 * time.Second)
+	require.NoError(t, tempoIngester1.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_traces_created_total"))
+	require.NoError(t, tempoIngester2.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_traces_created_total"))
+	require.NoError(t, tempoIngester3.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_traces_created_total"))
 
 	apiClient := tempoUtil.NewClient("http://"+tempoQueryFrontend.Endpoint(3200), "")
 


### PR DESCRIPTION
**What this PR does**:

Changes:

- Always check `tempo_ingester_traces_created_total` is _at least_ 1.  Some tests expect exactly 1 trace was created, others just expected more than 0. Let's always check traces created is >0. I saw tests fail because 2 traces were created while 1 was expected.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`