### PR TITLE
Updated this page to refer to 'monolithic' instead of 'single binary'

### DIFF
--- a/docs/tempo/website/api_docs/_index.md
+++ b/docs/tempo/website/api_docs/_index.md
@@ -8,7 +8,7 @@ weight: 350
 Tempo exposes an API for pushing and querying traces, and operating the cluster itself.
 
 For the sake of clarity, in this document we have grouped API endpoints by service, but keep in mind that they're exposed both when running Tempo in microservices and monolithic mode:
-- **Microservices**: each service exposes its own endpoints
+- **microservices**: each service exposes its own endpoints
 - **monolithic**: the Tempo process exposes all API endpoints for the services running internally
 
 ## Endpoints

--- a/docs/tempo/website/api_docs/_index.md
+++ b/docs/tempo/website/api_docs/_index.md
@@ -7,9 +7,9 @@ weight: 350
 
 Tempo exposes an API for pushing and querying traces, and operating the cluster itself.
 
-For the sake of clarity, in this document we have grouped API endpoints by service, but keep in mind that they're exposed both when running Tempo in microservices and singly-binary mode:
+For the sake of clarity, in this document we have grouped API endpoints by service, but keep in mind that they're exposed both when running Tempo in microservices and monolithic mode:
 - **Microservices**: each service exposes its own endpoints
-- **Single-binary**: the Tempo process exposes all API endpoints for the services running internally
+- **monolithic**: the Tempo process exposes all API endpoints for the services running internally
 
 ## Endpoints
 
@@ -87,7 +87,7 @@ _For information on how to use the Zipkin endpoint with curl (for debugging purp
 ### Query
 
 Tempo's Query API is simple. The following request is used to retrieve a trace from the query frontend service in 
-a microservices deployment, or the Tempo endpoint in a single binary deployment.
+a microservices deployment, or the Tempo endpoint in a monolithic mode deployment.
 
 ```
 GET /api/traces/<traceid>
@@ -123,7 +123,7 @@ but if it can also send OpenTelemetry proto if `Accept: application/protobuf` is
 <span style="background-color:#f3f973;">This experimental endpoint is disabled by default and can be enabled via the `search_enabled` YAML config option.</span>
 
 Tempo's Search API finds traces based on span and process attributes (tags and values).  The API is available in the query frontend service in
-a microservices deployment, or the Tempo endpoint in a single binary deployment.  The following request is used to find traces containing spans
+a microservices deployment, or the Tempo endpoint in a monolithic mode deployment.  The following request is used to find traces containing spans
 from service "myservice" and the url contains "api/myapi".
 
 ```
@@ -180,7 +180,7 @@ $ curl -G -s http://localhost:3200/api/search --data-urlencode 'tags=service.nam
 <span style="background-color:#f3f973;">This experimental endpoint is disabled by default and can be enabled via the `search_enabled` YAML config option.</span>
 
 This endpoint retrieves all discovered tag names that can be used in search.  The endpoint is available in the query frontend service in
-a microservices deployment, or the Tempo endpoint in a single binary deployment.
+a microservices deployment, or the Tempo endpoint in a monolithic mode deployment.
 
 ```
 GET /api/search/tags
@@ -221,7 +221,7 @@ $ curl -G -s http://localhost:3200/api/search/tags  | jq
 <span style="background-color:#f3f973;">This experimental endpoint is disabled by default and can be enabled via the `search_enabled` YAML config option.</span>
 
 This endpoint retrieves all discovered values for the given tag, which can be used in search.  The endpoint is available in the query frontend service in
-a microservices deployment, or the Tempo endpoint in a single binary deployment.  The following request will return all discovered service names.
+a microservices deployment, or the Tempo endpoint in a monolithic mode deployment.  The following request will return all discovered service names.
 
 ```
 GET /api/search/tag/service.name/values

--- a/docs/tempo/website/configuration/querying.md
+++ b/docs/tempo/website/configuration/querying.md
@@ -8,8 +8,7 @@ and help you set up your datasources appropriately.
 
 ## Grafana 7.5.x and higher (easy mode)
 
-Grafana 7.5.x and higher can query Tempo directly. Point the Grafana data source at your Tempo query frontend (or single
-binary) and enter the URL: `http://<tempo hostname>:<http port number>`. For most of [our examples](https://github.com/grafana/tempo/tree/main/example/docker-compose) the following works.
+Grafana 7.5.x and higher can query Tempo directly. Point the Grafana data source at your Tempo query frontend (or monolithic mode Tempo) and enter the URL: `http://<tempo hostname>:<http port number>`. For most of [our examples](https://github.com/grafana/tempo/tree/main/example/docker-compose) the following works.
 
 <p align="center"><img src="../ds75.png" alt="Grafana 7.5.x datasource"></p>
 

--- a/docs/tempo/website/getting-started/example-demo-app.md
+++ b/docs/tempo/website/getting-started/example-demo-app.md
@@ -27,12 +27,12 @@ Check the above link for all kinds of examples including:
 ## Tanka
 
 The Jsonnet based [example](https://github.com/grafana/tempo/tree/main/example/tk) shows a complete microservice based deployment. 
-There are single binary and microservices examples.
+There are monolithic mode and microservices examples.
 
 ## Helm
 
 The Helm [example](https://github.com/grafana/tempo/tree/main/example/helm) shows a complete microservice based deployment. 
-There are single binary and microservices examples.
+There are monolithic mode and microservices examples.
 
 ## The New Stack (TNS) Demo
 

--- a/docs/tempo/website/operations/deployment.md
+++ b/docs/tempo/website/operations/deployment.md
@@ -17,8 +17,8 @@ Tempo can be easily deployed through a number of tools as explained in this docu
 
 The Jsonnet files that you need to deploy Tempo with Tanka are available here:
 
-- [single binary](https://github.com/grafana/tempo/tree/main/operations/jsonnet/single-binary)
-- [microservices](https://github.com/grafana/tempo/tree/main/operations/jsonnet/microservices)
+- [monolithic mode](https://github.com/grafana/tempo/tree/main/operations/jsonnet/single-binary)
+- [microservices mode](https://github.com/grafana/tempo/tree/main/operations/jsonnet/microservices)
 
 Here are a few [examples](https://github.com/grafana/tempo/tree/main/example/tk) that use official Jsonnet files.
 They display the full range of configurations available to Tempo.
@@ -27,8 +27,8 @@ They display the full range of configurations available to Tempo.
 
 Helm charts are available in the grafana/helm-charts repo:
 
-- [single binary](https://github.com/grafana/helm-charts/tree/main/charts/tempo)
-- [microservices](https://github.com/grafana/helm-charts/tree/main/charts/tempo-distributed)
+- [monolithic mode](https://github.com/grafana/helm-charts/tree/main/charts/tempo)
+- [microservices mode](https://github.com/grafana/helm-charts/tree/main/charts/tempo-distributed)
 
 ## Kubernetes manifests
 
@@ -46,7 +46,9 @@ Tempo can be deployed in one of three modes:
 
 Which mode is deployed is determined by the runtime configuration `target`, or
 by using the `-target` flag on the command line. The default target is `all`,
-which is the single binary deployment mode.
+which is the monolithic deployment mode.
+
+> **Note:** _Monolithic mode_ was previously called _single binary mode_. Similarly _scalable monolithic mode_ was previously called _scalable single binary mode_. While the documentation has been updated to reflect this change, some URL names and deployment tooling (e.g. Helm charts) may still not reflect this change. 
 
 ## Monolithic
 

--- a/docs/tempo/website/operations/deployment.md
+++ b/docs/tempo/website/operations/deployment.md
@@ -38,20 +38,20 @@ folder.  These are generated using the Tanka / Jsonnet.
 
 # Deployment scenarios
 
-Tempo can be deployed in one of three modes.
+Tempo can be deployed in one of three modes:
 
-- Single binary
-- Scalable single binary
+- monolithic
+- Scalable monolithic
 - Microservices
 
 Which mode is deployed is determined by the runtime configuration `target`, or
 by using the `-target` flag on the command line. The default target is `all`,
 which is the single binary deployment mode.
 
-## Single binary
+## Monolithic
 
-A single binary mode deployment runs all top-level components in a single
-process, forming an instance of Tempo.  The single binary mode is the simplest
+Monolithic mode deployment runs all top-level components in a single
+process, forming an instance of Tempo.  The monolithic mode is the simplest
 to deploy, but can not horizontally scale out by increasing the quantity of
 components.  Refer to [Architecture]({{< relref "./architecture" >}}) for
 descriptions of the components.
@@ -63,18 +63,18 @@ Find docker-compose deployment examples at:
 - [https://github.com/grafana/tempo/tree/main/example/docker-compose/local](https://github.com/grafana/tempo/tree/main/example/docker-compose/local)
 - [https://github.com/grafana/tempo/tree/main/example/docker-compose/s3](https://github.com/grafana/tempo/tree/main/example/docker-compose/s3)
 
-## Scalable single binary
+## Scalable monolithic
 
-A scalable single binary deployment is similar to the single binary mode in
-that all components are deployed within one binary. Horizontal scale out is
-achieved by instantiating more than one single binary. This mode offers some
+Scalable monolithic mode is similar to the monolithic mode in
+that all components are run within one binary. Horizontal scale out is
+achieved by instantiating more than one binary, with each binary having `-target` set to `scalable-single-binary`. 
+
+This mode offers some
 flexibility of scaling without the configuration complexity of the full
 microservices deployment.
 
 Each of the `queriers` will perform a DNS lookup for the `frontend_address` and
 connect to the addresses found within the DNS record.
-
-To enable this mode, `-target=scalable-single-binary` is used.
 
 Find a docker-compose deployment example at:
 

--- a/docs/tempo/website/operations/deployment.md
+++ b/docs/tempo/website/operations/deployment.md
@@ -66,8 +66,8 @@ Find docker-compose deployment examples at:
 ## Scalable monolithic
 
 Scalable monolithic mode is similar to the monolithic mode in
-that all components are run within one binary. Horizontal scale out is
-achieved by instantiating more than one binary, with each binary having `-target` set to `scalable-single-binary`. 
+that all components are run within one process. Horizontal scale out is
+achieved by instantiating more than one process, with each having `-target` set to `scalable-single-binary`. 
 
 This mode offers some
 flexibility of scaling without the configuration complexity of the full

--- a/docs/tempo/website/operations/deployment.md
+++ b/docs/tempo/website/operations/deployment.md
@@ -41,8 +41,8 @@ folder.  These are generated using the Tanka / Jsonnet.
 Tempo can be deployed in one of three modes:
 
 - monolithic
-- Scalable monolithic
-- Microservices
+- scalable monolithic
+- microservices
 
 Which mode is deployed is determined by the runtime configuration `target`, or
 by using the `-target` flag on the command line. The default target is `all`,

--- a/docs/tempo/website/operations/deployment.md
+++ b/docs/tempo/website/operations/deployment.md
@@ -48,7 +48,7 @@ Which mode is deployed is determined by the runtime configuration `target`, or
 by using the `-target` flag on the command line. The default target is `all`,
 which is the monolithic deployment mode.
 
-> **Note:** _Monolithic mode_ was previously called _single binary mode_. Similarly _scalable monolithic mode_ was previously called _scalable single binary mode_. While the documentation has been updated to reflect this change, some URL names and deployment tooling (e.g. Helm charts) may still not reflect this change. 
+> **Note:** _Monolithic mode_ was previously called _single binary mode_. Similarly _scalable monolithic mode_ was previously called _scalable single binary mode_. While the documentation has been updated to reflect this change, some URL names and deployment tooling (e.g. Helm charts) do not yet reflect this change. 
 
 ## Monolithic
 

--- a/docs/tempo/website/release-notes/v1-2.md
+++ b/docs/tempo/website/release-notes/v1-2.md
@@ -10,7 +10,7 @@ The Tempo team is excited to announce the release of Tempo 1.2. This release int
 ## Features and enhancements
 
 * **Recent traces search** The headline feature of Tempo 1.2 is the ability to search for data that is still in the ingester component. This experimental feature must be enabled using feature flags in both Grafana and Tempo. Refer to [Tempo search](https://grafana.com/docs/tempo/latest/getting-started/tempo-in-grafana/#tempo-search) for details.
-* **Scalable single binary deployment mode** The new [scalable single binary](https://grafana.com/docs/tempo/latest/operations/deployment/#scalable-single-binary) deployment mode is operationally simpler, although less robust than a fully distributed deployment. We consider it a balanced operational mode that some may find attractive.
+* **Scalable monolithic deployment mode (formerly scalable single binary deployment mode)** The new [scalable monolithic](https://grafana.com/docs/tempo/latest/operations/deployment/#scalable-monolithic) deployment mode is operationally simpler, although less robust than a fully distributed deployment. We consider it a balanced operational mode that some may find attractive. 
 * **Massive performance improvements** were achieved by more efficiently batching trace data being ingested. In terms of CPU needed, Tempo v1.2 is twice as efficient as Tempo v1.1. Refer to [PR 1075](https://github.com/grafana/tempo/pull/1075) for details.
 * **API improvements** Some informational endpoints were consolidated within the [`status` endpoint](https://grafana.com/docs/tempo/latest/api_docs/#status). New endpoints were also added.
 

--- a/example/docker-compose/scalable-single-binary/readme.md
+++ b/example/docker-compose/scalable-single-binary/readme.md
@@ -1,6 +1,6 @@
 ## Scalable Single Binary
 
-** Note: This method of deploying Tempo is referred to by documentation as "monolithic mode" **
+** Note: This method of deploying Tempo is referred to by documentation as "scalable monolithic mode" **
 
 In this example Tempo is configured to write data to MinIO which presents an
 S3-compatible API.  Additionally, `memberlist` is enabled to demonstrate how a

--- a/example/docker-compose/scalable-single-binary/readme.md
+++ b/example/docker-compose/scalable-single-binary/readme.md
@@ -1,5 +1,7 @@
 ## Scalable Single Binary
 
+** Note: This method of deploying Tempo is referred to by documentation as "monolithic mode" **
+
 In this example Tempo is configured to write data to MinIO which presents an
 S3-compatible API.  Additionally, `memberlist` is enabled to demonstrate how a
 single binary can run all services and still make use of the cluster-awareness

--- a/example/helm/readme.md
+++ b/example/helm/readme.md
@@ -40,6 +40,9 @@ kubectl create -f microservices-extras.yaml
 ```
 
 ### Single Binary
+
+** Note: This method of deploying Tempo is referred to by documentation as "monolithic mode" **
+
 The Tempo single binary configuration is currently setup to store traces locally on disk, but can easily be configured to
 store them in an S3 or GCS bucket.  See configuration docs or some of the other examples for help.
 

--- a/example/tk/readme.md
+++ b/example/tk/readme.md
@@ -37,6 +37,9 @@ tk apply tempo-microservices
 ```
 
 ### Single Binary
+
+** Note: This method of deploying Tempo is referred to by documentation as "monolithic mode" **
+
 The Tempo single binary configuration is currently setup to store traces locally on disk, but can easily be configured to
 store them in an S3 or GCS bucket.  See configuration docs or some of the other examples for help.
 


### PR DESCRIPTION
We've standardized on this as the terminology we want to use for all of our backends, and have already made the changes in [Loki](https://grafana.com/docs/loki/next/fundamentals/architecture/deployment-modes/) and Mimir. See related slack [thread](https://raintank-corp.slack.com/archives/C02RJ13QB4K/p1645818793120839).

The rationale for moving away from 'single binary' is that Tempo (and Loki, and Mimir) are always a 'single binary', whether or not you are deploying as microservices.(In a microservices deployment, each component is the same 'single binary', but it just has a different value of the target flag.)