### PR TITLE
Refactor for alternative block formats

### DIFF
--- a/cmd/tempo-cli/cmd-query-blocks.go
+++ b/cmd/tempo-cli/cmd-query-blocks.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/pkg/boundedwaitgroup"
-	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/util"
@@ -149,18 +148,13 @@ func queryBlock(ctx context.Context, r backend.Reader, c backend.Compactor, bloc
 		return nil, err
 	}
 
-	obj, err := block.Find(ctx, traceID)
+	trace, err := block.FindTraceByID(ctx, traceID)
 	if err != nil {
 		return nil, err
 	}
 
-	if obj == nil {
+	if trace == nil {
 		return nil, nil
-	}
-
-	trace, err := model.MustNewObjectDecoder(meta.DataEncoding).PrepareForRead(obj)
-	if err != nil {
-		return nil, err
 	}
 
 	return &queryResults{

--- a/cmd/tempo-serverless/handler.go
+++ b/cmd/tempo-serverless/handler.go
@@ -3,7 +3,6 @@ package serverless
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"net/http"
 	"reflect"
 	"runtime"
@@ -13,7 +12,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/tempo/pkg/api"
-	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/tempodb"
 	"github.com/grafana/tempo/tempodb/backend"
@@ -95,53 +93,13 @@ func Handler(r *http.Request) (*tempopb.SearchResponse, *HTTPError) {
 		return nil, httpError("creating backend block", err, http.StatusInternalServerError)
 	}
 
-	// tempodb exposes an IterateObjects() method to basically perform the below loop. currently we are purposefully
-	// not using that so that the serverless function doesn't have to instantiate a full tempodb instance.
-	iter, err := block.PartialIterator(cfg.Search.ChunkSizeBytes, int(searchReq.StartPage), int(searchReq.PagesToSearch))
+	resp, err := block.Search(r.Context(), searchReq.SearchReq,
+		encoding.WithPages(int(searchReq.StartPage), int(searchReq.PagesToSearch)),
+		encoding.WithPrefetchTraceCount(cfg.Search.PrefetchTraceCount),
+		encoding.WithMaxBytes(maxBytes),
+	)
 	if err != nil {
-		return nil, httpError("creating partial iterator", err, http.StatusInternalServerError)
-	}
-	iter = encoding.NewPrefetchIterator(r.Context(), iter, cfg.Search.PrefetchTraceCount)
-	defer iter.Close()
-
-	resp := &tempopb.SearchResponse{
-		Metrics: &tempopb.SearchMetrics{},
-	}
-
-	decoder, err := model.NewObjectDecoder(searchReq.DataEncoding)
-	if err != nil {
-		return nil, httpError("creating decoder", err, http.StatusInternalServerError)
-	}
-
-	for {
-		id, obj, err := iter.Next(r.Context())
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, httpError("iterating", err, http.StatusInternalServerError)
-		}
-
-		resp.Metrics.InspectedTraces++
-		resp.Metrics.InspectedBytes += uint64(len(obj))
-
-		if maxBytes > 0 && len(obj) > maxBytes {
-			resp.Metrics.SkippedTraces++
-			continue
-		}
-
-		metadata, err := decoder.Matches(id, obj, searchReq.SearchReq)
-		if err != nil {
-			return nil, httpError("matching", err, http.StatusInternalServerError)
-		}
-		if metadata == nil {
-			continue
-		}
-
-		resp.Traces = append(resp.Traces, metadata)
-		if len(resp.Traces) >= int(searchReq.SearchReq.Limit) {
-			break
-		}
+		return nil, httpError("searching block", err, http.StatusInternalServerError)
 	}
 
 	runtime.GC()

--- a/modules/compactor/compactor.go
+++ b/modules/compactor/compactor.go
@@ -215,7 +215,7 @@ func (c *Compactor) Owns(hash string) bool {
 
 // Combine implements tempodb.CompactorSharder
 func (c *Compactor) Combine(dataEncoding string, tenantID string, objs ...[]byte) ([]byte, bool, error) {
-	combinedObj, wasCombined, err := model.ObjectCombiner.Combine(dataEncoding, objs...)
+	combinedObj, wasCombined, err := model.StaticCombiner.Combine(dataEncoding, objs...)
 	if err != nil {
 		return nil, false, err
 	}

--- a/modules/distributor/search_data_test.go
+++ b/modules/distributor/search_data_test.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempofb"
 	"github.com/grafana/tempo/pkg/tempopb"
 	v1_common "github.com/grafana/tempo/pkg/tempopb/common/v1"
 	v1_resource "github.com/grafana/tempo/pkg/tempopb/resource/v1"
 	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
-	"github.com/grafana/tempo/tempodb/search"
 )
 
 func TestExtractSearchData(t *testing.T) {
@@ -64,11 +64,11 @@ func TestExtractSearchData(t *testing.T) {
 			searchData: &tempofb.SearchEntryMutable{
 				TraceID: traceIDA,
 				Tags: tempofb.NewSearchDataMapWithData(map[string][]string{
-					"foo":                     {"bar"},
-					search.RootSpanNameTag:    {"firstSpan"},
-					search.SpanNameTag:        {"firstSpan"},
-					search.RootServiceNameTag: {"baz"},
-					search.ServiceNameTag:     {"baz"},
+					"foo":                    {"bar"},
+					trace.RootSpanNameTag:    {"firstSpan"},
+					trace.SpanNameTag:        {"firstSpan"},
+					trace.RootServiceNameTag: {"baz"},
+					trace.ServiceNameTag:     {"baz"},
 				}),
 				StartTimeUnixNano: 0,
 				EndTimeUnixNano:   0,

--- a/modules/frontend/searchsharding_test.go
+++ b/modules/frontend/searchsharding_test.go
@@ -32,8 +32,8 @@ type mockReader struct {
 	metas []*backend.BlockMeta
 }
 
-func (m *mockReader) Find(ctx context.Context, tenantID string, id common.ID, blockStart string, blockEnd string) ([][]byte, []string, []error, error) {
-	return nil, nil, nil, nil
+func (m *mockReader) Find(ctx context.Context, tenantID string, id common.ID, blockStart string, blockEnd string) ([]*tempopb.Trace, []error, error) {
+	return nil, nil, nil
 }
 
 func (m *mockReader) BlockMetas(tenantID string) []*backend.BlockMeta {

--- a/modules/frontend/searchsharding_test.go
+++ b/modules/frontend/searchsharding_test.go
@@ -18,9 +18,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/tempopb"
-	"github.com/grafana/tempo/tempodb"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/blocklist"
+	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -39,8 +39,8 @@ func (m *mockReader) Find(ctx context.Context, tenantID string, id common.ID, bl
 func (m *mockReader) BlockMetas(tenantID string) []*backend.BlockMeta {
 	return m.metas
 }
-func (m *mockReader) IterateObjects(ctx context.Context, meta *backend.BlockMeta, startPage int, totalPages int, callback tempodb.IterateObjectCallback) error {
-	return nil
+func (m *mockReader) Search(ctx context.Context, meta *backend.BlockMeta, req *tempopb.SearchRequest, opts ...encoding.SearchOption) (*tempopb.SearchResponse, error) {
+	return nil, nil
 }
 func (m *mockReader) EnablePolling(sharder blocklist.JobSharder) {}
 func (m *mockReader) Shutdown()                                  {}

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -288,7 +288,7 @@ func (i *instance) CompleteBlock(blockID uuid.UUID) error {
 
 	ctx := context.Background()
 
-	backendBlock, err := i.writer.CompleteBlockWithBackend(ctx, completingBlock, model.ObjectCombiner, i.localReader, i.localWriter)
+	backendBlock, err := i.writer.CompleteBlockWithBackend(ctx, completingBlock, model.StaticCombiner, i.localReader, i.localWriter)
 	if err != nil {
 		return errors.Wrap(err, "error completing wal block with local backend")
 	}
@@ -419,7 +419,7 @@ func (i *instance) FindTraceByID(ctx context.Context, id []byte) (*tempopb.Trace
 	defer i.blocksMtx.RUnlock()
 
 	// headBlock
-	foundBytes, err := i.headBlock.Find(id, model.ObjectCombiner)
+	foundBytes, err := i.headBlock.Find(id, model.StaticCombiner)
 	if err != nil {
 		return nil, fmt.Errorf("headBlock.Find failed: %w", err)
 	}
@@ -430,7 +430,7 @@ func (i *instance) FindTraceByID(ctx context.Context, id []byte) (*tempopb.Trace
 
 	// completingBlock
 	for _, c := range i.completingBlocks {
-		foundBytes, err = c.Find(id, model.ObjectCombiner)
+		foundBytes, err = c.Find(id, model.StaticCombiner)
 		if err != nil {
 			return nil, fmt.Errorf("completingBlock.Find failed: %w", err)
 		}

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/pkg/model"
+	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/util/log"
 	"github.com/grafana/tempo/pkg/validation"
@@ -441,18 +442,18 @@ func (i *instance) FindTraceByID(ctx context.Context, id []byte) (*tempopb.Trace
 	}
 
 	// completeBlock
+	combiner := trace.NewCombiner()
+	combiner.Consume(completeTrace)
 	for _, c := range i.completeBlocks {
-		foundBytes, err = c.Find(ctx, id)
+		found, err := c.FindTraceByID(ctx, id)
 		if err != nil {
-			return nil, fmt.Errorf("completeBlock.Find failed: %w", err)
+			return nil, fmt.Errorf("completeBlock.FindTraceByID failed: %w", err)
 		}
-		completeTrace, err = model.CombineForRead(foundBytes, c.BlockMeta().DataEncoding, completeTrace)
-		if err != nil {
-			return nil, fmt.Errorf("completeBlock combine failed in FindTraceByID: %w", err)
-		}
+		combiner.Consume(found)
 	}
 
-	return completeTrace, nil
+	result, _ := combiner.Result()
+	return result, nil
 }
 
 // AddCompletingBlock adds an AppendBlock directly to the slice of completing blocks.

--- a/pkg/model/combine.go
+++ b/pkg/model/combine.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/grafana/tempo/tempodb/encoding/common"
-
 	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/pkg/errors"
@@ -13,9 +11,11 @@ import (
 
 type objectCombiner struct{}
 
-var ObjectCombiner = objectCombiner{}
+type ObjectCombiner interface {
+	Combine(dataEncoding string, objs ...[]byte) ([]byte, bool, error)
+}
 
-var _ common.ObjectCombiner = (*objectCombiner)(nil)
+var StaticCombiner = objectCombiner{}
 
 // Combine implements tempodb/encoding/common.ObjectCombiner
 func (o objectCombiner) Combine(dataEncoding string, objs ...[]byte) ([]byte, bool, error) {

--- a/pkg/model/combine_test.go
+++ b/pkg/model/combine_test.go
@@ -86,7 +86,7 @@ func TestCombine(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual, combined, err := ObjectCombiner.Combine(CurrentEncoding, tt.traces...)
+			actual, combined, err := StaticCombiner.Combine(CurrentEncoding, tt.traces...)
 			assert.Equal(t, tt.expectCombined, combined)
 			if tt.expectError {
 				require.Error(t, err)

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -34,14 +34,14 @@ func (m *mockSharder) Owns(hash string) bool {
 }
 
 func (m *mockSharder) Combine(dataEncoding string, tenantID string, objs ...[]byte) ([]byte, bool, error) {
-	return model.ObjectCombiner.Combine(dataEncoding, objs...)
+	return model.StaticCombiner.Combine(dataEncoding, objs...)
 }
 
 type mockCombiner struct {
 }
 
 func (m *mockCombiner) Combine(dataEncoding string, objs ...[]byte) ([]byte, bool, error) {
-	return model.ObjectCombiner.Combine(dataEncoding, objs...)
+	return model.StaticCombiner.Combine(dataEncoding, objs...)
 }
 
 type mockJobSharder struct{}
@@ -295,10 +295,10 @@ func TestSameIDCompaction(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Nil(t, failedBlocks)
 
-		actualBytes, _, err := model.ObjectCombiner.Combine(v1.Encoding, b...)
+		actualBytes, _, err := model.StaticCombiner.Combine(v1.Encoding, b...)
 		require.NoError(t, err)
 
-		expectedBytes, _, err := model.ObjectCombiner.Combine(v1.Encoding, allReqs[i]...)
+		expectedBytes, _, err := model.StaticCombiner.Combine(v1.Encoding, allReqs[i]...)
 		require.NoError(t, err)
 
 		assert.Equal(t, expectedBytes, actualBytes)

--- a/tempodb/encoding/backend_block.go
+++ b/tempodb/encoding/backend_block.go
@@ -153,6 +153,10 @@ func (b *BackendBlock) FindTraceByID(ctx context.Context, id common.ID) (*tempop
 	if err != nil {
 		return nil, err
 	}
+	if obj == nil {
+		// Not found in this block
+		return nil, nil
+	}
 
 	dec, err := model.NewObjectDecoder(b.meta.DataEncoding)
 	if err != nil {
@@ -173,6 +177,11 @@ func (b *BackendBlock) Search(ctx context.Context, req *tempopb.SearchRequest, o
 		o(&opt)
 	}
 
+	decoder, err := model.NewObjectDecoder(b.meta.DataEncoding)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create NewDecoder: %w", err)
+	}
+
 	// Iterator
 	var iter Iterator
 	if opt.totalPages > 0 {
@@ -191,11 +200,6 @@ func (b *BackendBlock) Search(ctx context.Context, req *tempopb.SearchRequest, o
 	respMtx := sync.Mutex{}
 	resp = &tempopb.SearchResponse{
 		Metrics: &tempopb.SearchMetrics{},
-	}
-
-	decoder, err := model.NewObjectDecoder(b.meta.DataEncoding)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create NewDecoder: %w", err)
 	}
 
 	var searchErr error

--- a/tempodb/encoding/backend_block_test.go
+++ b/tempodb/encoding/backend_block_test.go
@@ -60,7 +60,7 @@ func testLegacyBlock(t *testing.T, ids [][]byte, objs [][]byte, meta *backend.Bl
 
 	// test Find
 	for i, id := range ids {
-		foundBytes, err := backendBlock.Find(context.Background(), id)
+		foundBytes, err := backendBlock.find(context.Background(), id)
 		assert.NoError(t, err)
 
 		assert.Equal(t, objs[i], foundBytes)

--- a/tempodb/encoding/blocker.go
+++ b/tempodb/encoding/blocker.go
@@ -1,0 +1,51 @@
+package encoding
+
+import (
+	"context"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/grafana/tempo/tempodb/encoding/common"
+)
+
+type Finder interface {
+	FindTraceByID(ctx context.Context, id common.ID) (*tempopb.Trace, error)
+}
+
+type Searcher interface {
+	Search(ctx context.Context, req *tempopb.SearchRequest, opts ...SearchOption) (*tempopb.SearchResponse, error)
+}
+
+type SearchOptions struct {
+	chunkSizeBytes     uint32
+	startPage          int
+	totalPages         int
+	maxBytes           int
+	prefetchTraceCount int
+}
+
+type SearchOption func(*SearchOptions)
+
+func WithPages(startPage, totalPages int) SearchOption {
+	return func(opt *SearchOptions) {
+		opt.startPage = startPage
+		opt.totalPages = totalPages
+	}
+}
+
+func WithChunkSize(chunkSizeBytes uint32) SearchOption {
+	return func(opt *SearchOptions) {
+		opt.chunkSizeBytes = chunkSizeBytes
+	}
+}
+
+func WithMaxBytes(maxBytes int) SearchOption {
+	return func(opt *SearchOptions) {
+		opt.maxBytes = maxBytes
+	}
+}
+
+func WithPrefetchTraceCount(count int) SearchOption {
+	return func(opt *SearchOptions) {
+		opt.prefetchTraceCount = count
+	}
+}

--- a/tempodb/encoding/common/types.go
+++ b/tempodb/encoding/common/types.go
@@ -22,14 +22,6 @@ type Record struct {
 	Length uint32
 }
 
-// ObjectCombiner is used to combine two objects in the backend
-type ObjectCombiner interface {
-	// Combine objects encoded using dataEncoding. The returned object must
-	// use the same dataEncoding. Returns a bool indicating if it the objects required combining and
-	// the combined slice
-	Combine(dataEncoding string, objs ...[]byte) ([]byte, bool, error)
-}
-
 // DataReader returns a slice of pages in the encoding/v0 format referenced by
 // the slice of *Records passed in.  The length of the returned slice is guaranteed
 // to be equal to the length of the provided records unless error is non nil.

--- a/tempodb/encoding/finder_paged.go
+++ b/tempodb/encoding/finder_paged.go
@@ -7,18 +7,14 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
-
-// Finder is capable of finding the requested ID
-type Finder interface {
-	Find(context.Context, common.ID) ([]byte, error)
-}
 
 type pagedFinder struct {
 	r            common.DataReader
 	index        common.IndexReader
-	combiner     common.ObjectCombiner
+	combiner     model.ObjectCombiner
 	objectRW     common.ObjectReaderWriter
 	dataEncoding string
 }
@@ -26,7 +22,7 @@ type pagedFinder struct {
 // NewPagedFinder returns a paged. This finder is used for searching
 //  a set of records and returning an object. If a set of consecutive records has
 //  matching ids they will be combined using the ObjectCombiner.
-func NewPagedFinder(index common.IndexReader, r common.DataReader, combiner common.ObjectCombiner, objectRW common.ObjectReaderWriter, dataEncoding string) Finder {
+func NewPagedFinder(index common.IndexReader, r common.DataReader, combiner model.ObjectCombiner, objectRW common.ObjectReaderWriter, dataEncoding string) *pagedFinder {
 	return &pagedFinder{
 		r:            r,
 		index:        index,

--- a/tempodb/encoding/iterator_deduping.go
+++ b/tempodb/encoding/iterator_deduping.go
@@ -6,12 +6,13 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
 type dedupingIterator struct {
 	iter          Iterator
-	combiner      common.ObjectCombiner
+	combiner      model.ObjectCombiner
 	currentID     []byte
 	currentObject []byte
 	dataEncoding  string
@@ -19,7 +20,7 @@ type dedupingIterator struct {
 
 // NewDedupingIterator returns a dedupingIterator.  This iterator is used to wrap another
 //  iterator.  It will dedupe consecutive objects with the same id using the ObjectCombiner.
-func NewDedupingIterator(iter Iterator, combiner common.ObjectCombiner, dataEncoding string) (Iterator, error) {
+func NewDedupingIterator(iter Iterator, combiner model.ObjectCombiner, dataEncoding string) (Iterator, error) {
 	i := &dedupingIterator{
 		iter:         iter,
 		combiner:     combiner,

--- a/tempodb/encoding/iterator_multiblock.go
+++ b/tempodb/encoding/iterator_multiblock.go
@@ -10,13 +10,14 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 
+	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 
 	"github.com/uber-go/atomic"
 )
 
 type multiblockIterator struct {
-	combiner     common.ObjectCombiner
+	combiner     model.ObjectCombiner
 	bookmarks    []*bookmark
 	dataEncoding string
 	resultsCh    chan iteratorResult
@@ -34,7 +35,7 @@ type iteratorResult struct {
 
 // NewMultiblockIterator Creates a new multiblock iterator. Iterates concurrently in a separate goroutine and results are buffered.
 // Traces are deduped and combined using the object combiner.
-func NewMultiblockIterator(ctx context.Context, inputs []Iterator, bufferSize int, combiner common.ObjectCombiner, dataEncoding string, logger log.Logger) Iterator {
+func NewMultiblockIterator(ctx context.Context, inputs []Iterator, bufferSize int, combiner model.ObjectCombiner, dataEncoding string, logger log.Logger) Iterator {
 	i := multiblockIterator{
 		combiner:     combiner,
 		dataEncoding: dataEncoding,

--- a/tempodb/encoding/streaming_block_test.go
+++ b/tempodb/encoding/streaming_block_test.go
@@ -175,7 +175,7 @@ func testStreamingBlockToBackendBlock(t *testing.T, cfg *BlockConfig) {
 
 	// test Find
 	for i, id := range ids {
-		foundBytes, err := backendBlock.Find(context.Background(), id)
+		foundBytes, err := backendBlock.find(context.Background(), id)
 		assert.NoError(t, err)
 
 		assert.Equal(t, reqs[i], foundBytes)

--- a/tempodb/search/data_combiner.go
+++ b/tempodb/search/data_combiner.go
@@ -2,12 +2,9 @@ package search
 
 import (
 	"github.com/grafana/tempo/pkg/tempofb"
-	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
 type DataCombiner struct{}
-
-var _ common.ObjectCombiner = (*DataCombiner)(nil)
 
 var staticCombiner = DataCombiner{}
 

--- a/tempodb/search/pipeline.go
+++ b/tempodb/search/pipeline.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempofb"
 	"github.com/grafana/tempo/pkg/tempopb"
 	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
@@ -117,18 +118,18 @@ func (p *Pipeline) rewriteTagLookup(k, v string) (skip bool, newk, newv string) 
 		// Skip
 		return true, "", ""
 
-	case ErrorTag:
+	case trace.ErrorTag:
 		if v == "true" {
 			// Error = true
-			return false, StatusCodeTag, strconv.Itoa(int(v1.Status_STATUS_CODE_ERROR))
+			return false, trace.StatusCodeTag, strconv.Itoa(int(v1.Status_STATUS_CODE_ERROR))
 		}
 		// Else fall-through
 
-	case StatusCodeTag:
+	case trace.StatusCodeTag:
 		// Convert status.code=string into status.code=int
-		for statusStr, statusID := range StatusCodeMapping {
+		for statusStr, statusID := range trace.StatusCodeMapping {
 			if v == statusStr {
-				return false, StatusCodeTag, strconv.Itoa(statusID)
+				return false, trace.StatusCodeTag, strconv.Itoa(statusID)
 			}
 		}
 		// Unknown mapping = fall-through

--- a/tempodb/search/pipeline_test.go
+++ b/tempodb/search/pipeline_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempofb"
 	"github.com/grafana/tempo/pkg/tempopb"
 	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
@@ -51,14 +52,14 @@ func TestPipelineMatchesTags(t *testing.T) {
 		},
 		{
 			name:        "rewriteError",
-			searchData:  map[string][]string{StatusCodeTag: {strconv.Itoa(int(v1.Status_STATUS_CODE_ERROR))}},
+			searchData:  map[string][]string{trace.StatusCodeTag: {strconv.Itoa(int(v1.Status_STATUS_CODE_ERROR))}},
 			request:     map[string]string{"error": "true"},
 			shouldMatch: true,
 		},
 		{
 			name:        "rewriteStatusCode",
-			searchData:  map[string][]string{StatusCodeTag: {strconv.Itoa(int(v1.Status_STATUS_CODE_ERROR))}},
-			request:     map[string]string{StatusCodeTag: StatusCodeError},
+			searchData:  map[string][]string{trace.StatusCodeTag: {strconv.Itoa(int(v1.Status_STATUS_CODE_ERROR))}},
+			request:     map[string]string{trace.StatusCodeTag: trace.StatusCodeError},
 			shouldMatch: true,
 		},
 	}

--- a/tempodb/search/util.go
+++ b/tempodb/search/util.go
@@ -1,41 +1,23 @@
 package search
 
 import (
+	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempofb"
 	"github.com/grafana/tempo/pkg/tempopb"
-	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	"github.com/grafana/tempo/pkg/util"
 )
 
-const (
-	RootServiceNameTag = "root.service.name"
-	ServiceNameTag     = "service.name"
-	RootSpanNameTag    = "root.name"
-	SpanNameTag        = "name"
-	ErrorTag           = "error"
-	StatusCodeTag      = "status.code"
-	StatusCodeUnset    = "unset"
-	StatusCodeOK       = "ok"
-	StatusCodeError    = "error"
-)
-
-var StatusCodeMapping = map[string]int{
-	StatusCodeUnset: int(v1.Status_STATUS_CODE_UNSET),
-	StatusCodeOK:    int(v1.Status_STATUS_CODE_OK),
-	StatusCodeError: int(v1.Status_STATUS_CODE_ERROR),
-}
-
 func GetVirtualTags() []string {
-	return []string{ErrorTag}
+	return []string{trace.ErrorTag}
 }
 
 func GetVirtualTagValues(tagName string) []string {
 	switch tagName {
 
-	case StatusCodeTag:
-		return []string{StatusCodeUnset, StatusCodeOK, StatusCodeError}
+	case trace.StatusCodeTag:
+		return []string{trace.StatusCodeUnset, trace.StatusCodeOK, trace.StatusCodeError}
 
-	case ErrorTag:
+	case trace.ErrorTag:
 		return []string{"true"}
 	}
 
@@ -45,8 +27,8 @@ func GetVirtualTagValues(tagName string) []string {
 func GetSearchResultFromData(s *tempofb.SearchEntry) *tempopb.TraceSearchMetadata {
 	return &tempopb.TraceSearchMetadata{
 		TraceID:           util.TraceIDToHexString(s.Id()),
-		RootServiceName:   s.Get(RootServiceNameTag),
-		RootTraceName:     s.Get(RootSpanNameTag),
+		RootServiceName:   s.Get(trace.RootServiceNameTag),
+		RootTraceName:     s.Get(trace.RootSpanNameTag),
 		StartTimeUnixNano: s.StartTimeUnixNano(),
 		DurationMs:        uint32((s.EndTimeUnixNano() - s.StartTimeUnixNano()) / 1_000_000),
 	}

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/grafana/tempo/pkg/boundedwaitgroup"
 	pkg_cache "github.com/grafana/tempo/pkg/cache"
+	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/pkg/util/log"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/azure"
@@ -69,8 +70,8 @@ var (
 
 type Writer interface {
 	WriteBlock(ctx context.Context, block WriteableBlock) error
-	CompleteBlock(block *wal.AppendBlock, combiner common.ObjectCombiner) (*encoding.BackendBlock, error)
-	CompleteBlockWithBackend(ctx context.Context, block *wal.AppendBlock, combiner common.ObjectCombiner, r backend.Reader, w backend.Writer) (*encoding.BackendBlock, error)
+	CompleteBlock(block *wal.AppendBlock, combiner model.ObjectCombiner) (*encoding.BackendBlock, error)
+	CompleteBlockWithBackend(ctx context.Context, block *wal.AppendBlock, combiner model.ObjectCombiner, r backend.Reader, w backend.Writer) (*encoding.BackendBlock, error)
 	CompleteSearchBlockWithBackend(block *search.StreamingSearchBlock, blockID uuid.UUID, tenantID string, r backend.Reader, w backend.Writer) (*search.BackendSearchBlock, error)
 	WAL() *wal.WAL
 }
@@ -202,13 +203,13 @@ func (rw *readerWriter) WriteBlock(ctx context.Context, c WriteableBlock) error 
 }
 
 // CompleteBlock iterates the given WAL block and flushes it to the TempoDB backend.
-func (rw *readerWriter) CompleteBlock(block *wal.AppendBlock, combiner common.ObjectCombiner) (*encoding.BackendBlock, error) {
+func (rw *readerWriter) CompleteBlock(block *wal.AppendBlock, combiner model.ObjectCombiner) (*encoding.BackendBlock, error) {
 	return rw.CompleteBlockWithBackend(context.TODO(), block, combiner, rw.r, rw.w)
 }
 
 // CompleteBlock iterates the given WAL block but flushes it to the given backend instead of the default TempoDB backend. The
 // new block will have the same ID as the input block.
-func (rw *readerWriter) CompleteBlockWithBackend(ctx context.Context, block *wal.AppendBlock, combiner common.ObjectCombiner, r backend.Reader, w backend.Writer) (*encoding.BackendBlock, error) {
+func (rw *readerWriter) CompleteBlockWithBackend(ctx context.Context, block *wal.AppendBlock, combiner model.ObjectCombiner, r backend.Reader, w backend.Writer) (*encoding.BackendBlock, error) {
 	meta := block.Meta()
 	blockID := meta.BlockID
 	tenantID := meta.TenantID

--- a/tempodb/tempodb_test.go
+++ b/tempodb/tempodb_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/pkg/tempopb"
-	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	"github.com/grafana/tempo/pkg/util/test"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/local"
@@ -25,9 +25,8 @@ import (
 )
 
 const (
-	testTenantID     = "fake"
-	testTenantID2    = "fake2"
-	testDataEncoding = "blerg"
+	testTenantID  = "fake"
+	testTenantID2 = "fake2"
 )
 
 func testConfig(t *testing.T, enc backend.Encoding, blocklistPoll time.Duration) (Reader, Writer, Compactor, string) {
@@ -70,24 +69,27 @@ func TestDB(t *testing.T) {
 
 	wal := w.WAL()
 
-	head, err := wal.NewBlock(blockID, testTenantID, testDataEncoding)
+	head, err := wal.NewBlock(blockID, testTenantID, model.CurrentEncoding)
 	assert.NoError(t, err)
+
+	dec := model.MustNewSegmentDecoder(model.CurrentEncoding)
 
 	// write
 	numMsgs := 10
-	reqs := make([]*v1.ResourceSpans, 0, numMsgs)
-	ids := make([][]byte, 0, numMsgs)
+	reqs := make([]*tempopb.Trace, numMsgs)
+	ids := make([]common.ID, numMsgs)
 	for i := 0; i < numMsgs; i++ {
-		id := make([]byte, 16)
-		rand.Read(id)
-		req := test.MakeBatch(rand.Int()%1000, id)
-		reqs = append(reqs, req)
-		ids = append(ids, id)
+		ids[i] = test.ValidTraceID(nil)
+		reqs[i] = test.MakeTrace(10, ids[i])
 
-		bReq, err := proto.Marshal(req)
-		assert.NoError(t, err)
-		err = head.Append(id, bReq, 0, 0)
-		assert.NoError(t, err, "unexpected error writing req")
+		bReq, err := dec.PrepareForWrite(reqs[i], 0, 0)
+		require.NoError(t, err)
+
+		bReq2, err := dec.ToObject([][]byte{bReq})
+		require.NoError(t, err)
+
+		err = head.Append(ids[i], bReq2, 0, 0)
+		require.NoError(t, err, "unexpected error writing req")
 	}
 
 	_, err = w.CompleteBlock(head, &mockCombiner{})
@@ -98,16 +100,10 @@ func TestDB(t *testing.T) {
 
 	// read
 	for i, id := range ids {
-		bFound, actualDataEncoding, failedBlocks, err := r.Find(context.Background(), testTenantID, id, BlockIDMin, BlockIDMax)
+		bFound, failedBlocks, err := r.Find(context.Background(), testTenantID, id, BlockIDMin, BlockIDMax)
 		assert.NoError(t, err)
 		assert.Nil(t, failedBlocks)
-		assert.Equal(t, []string{testDataEncoding}, actualDataEncoding)
-
-		out := &v1.ResourceSpans{}
-		err = proto.Unmarshal(bFound[0], out)
-		assert.NoError(t, err)
-
-		assert.True(t, proto.Equal(out, reqs[i]))
+		assert.True(t, proto.Equal(bFound[0], reqs[i]))
 	}
 }
 
@@ -123,17 +119,21 @@ func TestBlockSharding(t *testing.T) {
 	blockID := uuid.New()
 	wal := w.WAL()
 
-	head, err := wal.NewBlock(blockID, testTenantID, "")
+	dec := model.MustNewSegmentDecoder(model.CurrentEncoding)
+	head, err := wal.NewBlock(blockID, testTenantID, model.CurrentEncoding)
 	assert.NoError(t, err)
 
 	// add a trace to the block
-	id := make([]byte, 16)
-	rand.Read(id)
-	req := test.MakeTrace(rand.Int()%1000, id)
+	id := test.ValidTraceID(nil)
+	req := test.MakeTrace(1, id)
 
-	bReq, err := proto.Marshal(req)
+	b1, err := dec.PrepareForWrite(req, 0, 0)
+	require.NoError(t, err)
+	b2, err := dec.ToObject([][]byte{b1})
+	require.NoError(t, err)
+
 	assert.NoError(t, err)
-	err = head.Append(id, bReq, 0, 0)
+	err = head.Append(id, b2, 0, 0)
 	assert.NoError(t, err, "unexpected error writing req")
 
 	// write block to backend
@@ -150,20 +150,16 @@ func TestBlockSharding(t *testing.T) {
 	// check if it respects the blockstart/blockend params - case1: hit
 	blockStart := uuid.MustParse(BlockIDMin).String()
 	blockEnd := uuid.MustParse(BlockIDMax).String()
-	bFound, _, failedBlocks, err := r.Find(context.Background(), testTenantID, id, blockStart, blockEnd)
+	bFound, failedBlocks, err := r.Find(context.Background(), testTenantID, id, blockStart, blockEnd)
 	assert.NoError(t, err)
 	assert.Nil(t, failedBlocks)
 	assert.Greater(t, len(bFound), 0)
-
-	out := &tempopb.Trace{}
-	err = proto.Unmarshal(bFound[0], out)
-	assert.NoError(t, err)
-	assert.True(t, proto.Equal(out, req))
+	assert.True(t, proto.Equal(bFound[0], req))
 
 	// check if it respects the blockstart/blockend params - case2: miss
 	blockStart = uuid.MustParse(BlockIDMin).String()
 	blockEnd = uuid.MustParse(BlockIDMin).String()
-	bFound, _, failedBlocks, err = r.Find(context.Background(), testTenantID, id, blockStart, blockEnd)
+	bFound, failedBlocks, err = r.Find(context.Background(), testTenantID, id, blockStart, blockEnd)
 	assert.NoError(t, err)
 	assert.Nil(t, failedBlocks)
 	assert.Len(t, bFound, 0)
@@ -172,7 +168,7 @@ func TestBlockSharding(t *testing.T) {
 func TestNilOnUnknownTenantID(t *testing.T) {
 	r, _, _, _ := testConfig(t, backend.EncLZ4_256k, 0)
 
-	buff, _, failedBlocks, err := r.Find(context.Background(), "unknown", []byte{0x01}, BlockIDMin, BlockIDMax)
+	buff, failedBlocks, err := r.Find(context.Background(), "unknown", []byte{0x01}, BlockIDMin, BlockIDMax)
 	assert.Nil(t, buff)
 	assert.Nil(t, err)
 	assert.Nil(t, failedBlocks)
@@ -481,8 +477,10 @@ func TestSearchCompactedBlocks(t *testing.T) {
 
 	wal := w.WAL()
 
-	head, err := wal.NewBlock(uuid.New(), testTenantID, "")
+	head, err := wal.NewBlock(uuid.New(), testTenantID, model.CurrentEncoding)
 	assert.NoError(t, err)
+
+	dec := model.MustNewSegmentDecoder(model.CurrentEncoding)
 
 	// write
 	numMsgs := 10
@@ -495,14 +493,18 @@ func TestSearchCompactedBlocks(t *testing.T) {
 		reqs = append(reqs, req)
 		ids = append(ids, id)
 
-		bReq, err := proto.Marshal(req)
-		assert.NoError(t, err)
-		err = head.Append(id, bReq, 0, 0)
-		assert.NoError(t, err, "unexpected error writing req")
+		bReq, err := dec.PrepareForWrite(req, 0, 0)
+		require.NoError(t, err)
+
+		bReq2, err := dec.ToObject([][]byte{bReq})
+		require.NoError(t, err)
+
+		err = head.Append(id, bReq2, 0, 0)
+		require.NoError(t, err, "unexpected error writing req")
 	}
 
 	complete, err := w.CompleteBlock(head, &mockCombiner{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	blockID := complete.BlockMeta().BlockID.String()
 
@@ -513,21 +515,16 @@ func TestSearchCompactedBlocks(t *testing.T) {
 
 	// read
 	for i, id := range ids {
-		bFound, _, failedBlocks, err := r.Find(context.Background(), testTenantID, id, blockID, blockID)
-		assert.NoError(t, err)
-		assert.Nil(t, failedBlocks)
-
-		out := &tempopb.Trace{}
-		err = proto.Unmarshal(bFound[0], out)
-		assert.NoError(t, err)
-
-		assert.True(t, proto.Equal(out, reqs[i]))
+		bFound, failedBlocks, err := r.Find(context.Background(), testTenantID, id, blockID, blockID)
+		require.NoError(t, err)
+		require.Nil(t, failedBlocks)
+		require.True(t, proto.Equal(bFound[0], reqs[i]))
 	}
 
 	// compact
 	var blockMetas []*backend.BlockMeta
 	blockMetas = append(blockMetas, complete.BlockMeta())
-	assert.NoError(t, rw.compact(blockMetas, testTenantID))
+	require.NoError(t, rw.compact(blockMetas, testTenantID))
 
 	// poll
 	rw.pollBlocklist()
@@ -535,22 +532,17 @@ func TestSearchCompactedBlocks(t *testing.T) {
 	// make sure the block is compacted
 	compactedBlocks := rw.blocklist.CompactedMetas(testTenantID)
 	require.Len(t, compactedBlocks, 1)
-	assert.Equal(t, compactedBlocks[0].BlockID.String(), blockID)
+	require.Equal(t, compactedBlocks[0].BlockID.String(), blockID)
 	blocks := rw.blocklist.Metas(testTenantID)
 	require.Len(t, blocks, 1)
-	assert.NotEqual(t, blocks[0].BlockID.String(), blockID)
+	require.NotEqual(t, blocks[0].BlockID.String(), blockID)
 
 	// find should succeed with old block range
 	for i, id := range ids {
-		bFound, _, failedBlocks, err := r.Find(context.Background(), testTenantID, id, blockID, blockID)
-		assert.NoError(t, err)
-		assert.Nil(t, failedBlocks)
-
-		out := &tempopb.Trace{}
-		err = proto.Unmarshal(bFound[0], out)
-		assert.NoError(t, err)
-
-		assert.True(t, proto.Equal(out, reqs[i]))
+		bFound, failedBlocks, err := r.Find(context.Background(), testTenantID, id, blockID, blockID)
+		require.NoError(t, err)
+		require.Nil(t, failedBlocks)
+		require.True(t, proto.Equal(bFound[0], reqs[i]))
 	}
 }
 

--- a/tempodb/wal/append_block.go
+++ b/tempodb/wal/append_block.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/grafana/tempo/tempodb/encoding/common"
@@ -149,7 +150,7 @@ func (a *AppendBlock) Meta() *backend.BlockMeta {
 	return a.meta
 }
 
-func (a *AppendBlock) Iterator(combiner common.ObjectCombiner) (encoding.Iterator, error) {
+func (a *AppendBlock) Iterator(combiner model.ObjectCombiner) (encoding.Iterator, error) {
 	if a.appendFile != nil {
 		err := a.appendFile.Close()
 		if err != nil {
@@ -178,7 +179,7 @@ func (a *AppendBlock) Iterator(combiner common.ObjectCombiner) (encoding.Iterato
 	return iterator, nil
 }
 
-func (a *AppendBlock) Find(id common.ID, combiner common.ObjectCombiner) ([]byte, error) {
+func (a *AppendBlock) Find(id common.ID, combiner model.ObjectCombiner) ([]byte, error) {
 	records := a.appender.RecordsForID(id)
 	file, err := a.file()
 	if err != nil {

--- a/tempodb/wal/local_block.go
+++ b/tempodb/wal/local_block.go
@@ -6,6 +6,7 @@ import (
 
 	"go.uber.org/atomic"
 
+	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/local"
 	"github.com/grafana/tempo/tempodb/encoding"
@@ -24,6 +25,8 @@ type LocalBlock struct {
 
 	flushedTime atomic.Int64 // protecting flushedTime b/c it's accessed from the store on flush and from the ingester instance checking flush time
 }
+
+var _ encoding.Finder = (*LocalBlock)(nil)
 
 func NewLocalBlock(ctx context.Context, existingBlock *encoding.BackendBlock, l *local.Backend) (*LocalBlock, error) {
 
@@ -45,8 +48,8 @@ func NewLocalBlock(ctx context.Context, existingBlock *encoding.BackendBlock, l 
 	return c, nil
 }
 
-func (c *LocalBlock) Find(ctx context.Context, id common.ID) ([]byte, error) {
-	return c.BackendBlock.Find(ctx, id)
+func (c *LocalBlock) FindTraceByID(ctx context.Context, id common.ID) (*tempopb.Trace, error) {
+	return c.BackendBlock.FindTraceByID(ctx, id)
 }
 
 // FlushedTime returns the time the block was flushed.  Will return 0


### PR DESCRIPTION
**What this PR does**:
This PR has a variety of refactors to support the goal of non-byte-slice (i.e. columnar) block formats.  Overview of changes:
* BackendBlock is oriented around new `FindByTraceID` and `Search` which use `tempopb` data types (`Trace` and `SearchRequest/SearchResponse`.  These methods internalize all the work of searching the block, and callers were all updated (querier, ingester, serverless, tempodb, cli).  Offline we discussed this is as good interface for blocks in general, going forward.
* Some of the overlap between `pkg/model`, `pkg/model/trace`, and `tempodb/search` was unwound up by moving `ObjectCombiner` and other search constants to `pkg`.  The goal is to have `tempodb` use `pkg` and not the other way around.
* For the above `FindTraceByID` and `Search` methods, new interfaces are introduced `Finder` and `Searcher`. These aren't super necessary in this PR, but will make more sense in future refactoring as we cover more block types or tweak the `readerWriter` interface.

Future refactoring:  There is more refactoring needed but this PR is already a good size, it seems better to visit separately.  TODOs:
* Compaction - What does compaction look like? TBD
* BackendBlock still exposes some things like `Iterate` which returns byte slices. This is only used by compaction.
* Append/Streaming blocks - Need similar changes for non-byte slice content. StreamingBlock changes might depend on decisions for compaction.

This PR is draft so we can check CI. 

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`