### PR TITLE
update golint-ci to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.45.2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.41.1
+          version: v1.45.2
 
   unit-tests:
     name: Test packages


### PR DESCRIPTION
**What this PR does**:
Update golangci-lint to latest which includes support for 1.18 (even though Tempo isn't using it directly). This PR was having issues:  https://github.com/grafana/tempo/runs/5818491537?check_suite_focus=true  and I think it's related and something changed recently.  Notably the previous step sets up 1.17, but then golangci-lint sets up 1.18 anyway.   The docker images are using 1.18 now too:

```
$ docker run -it golangci/golangci-lint:v1.45.2-alpine go version
go version go1.18 linux/amd64
```

~This means there is more cleanup to do:  golangci-lint has a parameter `skip-go-installation` which can be set to `true` that we aren't using. Options:~

~1. Turn on `skip-go-installation` and stick with 1.17.~
~2. Remove the first `setup-go` step and let golangci-lint do it~

~I lean towards option 2.~

See comment below about v3:

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`