### PR TITLE
Service graphs: add dimensions and rename expired edges metric

### DIFF
--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -332,7 +332,7 @@ func searchTag(client *util.Client, seed time.Time) (traceMetrics, error) {
 		zap.String("hexID", hexID),
 		zap.Duration("ago", time.Since(seed)),
 		zap.String("key", attr.Key),
-		zap.String("value", attr.Value.GetStringValue()),
+		zap.String("value", util.StringifyAnyValue(attr.Value)),
 	)
 	logger.Info("searching Tempo")
 

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -340,7 +340,7 @@ func searchTag(client *util.Client, seed time.Time) (traceMetrics, error) {
 	//  around the seed.
 	start := seed.Add(-30 * time.Minute).Unix()
 	end := seed.Add(30 * time.Minute).Unix()
-	resp, err := client.SearchWithRange(fmt.Sprintf("%s=%s", attr.Key, attr.Value.GetStringValue()), start, end)
+	resp, err := client.SearchWithRange(fmt.Sprintf("%s=%s", attr.Key, util.StringifyAnyValue(attr.Value)), start, end)
 	if err != nil {
 		logger.Error(fmt.Sprintf("failed to search traces with tag %s: %s", attr.Key, err.Error()))
 		tm.requestFailed++

--- a/modules/generator/processor/servicegraphs/config.go
+++ b/modules/generator/processor/servicegraphs/config.go
@@ -23,6 +23,11 @@ type Config struct {
 	// Buckets for latency histogram in seconds.
 	HistogramBuckets []float64 `yaml:"histogram_buckets"`
 
+	// Additional dimensions (labels) to be added to the metric along with the default ones.
+	// If client and server spans have the same attribute, behaviour is undetermined
+	// (either value could get used)
+	Dimensions []string `yaml:"dimensions"`
+
 	// SuccessCodes *successCodes `yaml:"success_codes"`
 }
 

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -26,6 +26,7 @@ func TestServiceGraphs(t *testing.T) {
 	cfg.RegisterFlagsAndApplyDefaults("", nil)
 
 	cfg.HistogramBuckets = []float64{2.0, 3.0}
+	cfg.Dimensions = []string{"component"}
 
 	p := New(cfg, "test", testRegistry, log.NewNopLogger())
 	defer p.Shutdown(context.Background())
@@ -40,12 +41,14 @@ func TestServiceGraphs(t *testing.T) {
 	sgp.store.Expire()
 
 	lbAppLabels := labels.FromMap(map[string]string{
-		"client": "lb",
-		"server": "app",
+		"client":    "lb",
+		"server":    "app",
+		"component": "net/http",
 	})
 	appDbLabels := labels.FromMap(map[string]string{
-		"client": "app",
-		"server": "db",
+		"client":    "app",
+		"server":    "db",
+		"component": "net/http",
 	})
 
 	fmt.Println(testRegistry)

--- a/modules/generator/processor/servicegraphs/store/edge.go
+++ b/modules/generator/processor/servicegraphs/store/edge.go
@@ -14,14 +14,17 @@ type Edge struct {
 	// the Edge will be considered as failed.
 	Failed bool
 
+	// Additional dimension to add to the metrics
+	Dimensions map[string]string
+
 	// expiration is the time at which the Edge expires, expressed as Unix time
 	expiration int64
 }
 
 func NewEdge(key string, ttl time.Duration) *Edge {
 	return &Edge{
-		key: key,
-
+		key:        key,
+		Dimensions: make(map[string]string),
 		expiration: time.Now().Add(ttl).Unix(),
 	}
 }

--- a/modules/generator/processor/spanmetrics/spanmetrics.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/grafana/tempo/pkg/util"
 	"github.com/opentracing/opentracing-go"
 
 	gen "github.com/grafana/tempo/modules/generator/processor"
@@ -79,7 +80,7 @@ func (p *processor) aggregateMetricsForSpan(svcName string, span *v1_trace.Span)
 	for _, d := range p.cfg.Dimensions {
 		for _, attr := range span.Attributes {
 			if d == attr.Key {
-				labelValues = append(labelValues, attr.GetValue().GetStringValue())
+				labelValues = append(labelValues, util.StringifyAnyValue(attr.Value))
 			}
 		}
 	}

--- a/modules/generator/processor/spanmetrics/spanmetrics.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics.go
@@ -12,7 +12,6 @@ import (
 	"github.com/grafana/tempo/modules/generator/registry"
 	"github.com/grafana/tempo/pkg/tempopb"
 	v1_trace "github.com/grafana/tempo/pkg/tempopb/trace/v1"
-	"github.com/grafana/tempo/pkg/util"
 )
 
 const (

--- a/pkg/util/attributes.go
+++ b/pkg/util/attributes.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"regexp"
 	"strconv"
 
 	v1common "github.com/grafana/tempo/pkg/tempopb/common/v1"
@@ -34,11 +33,4 @@ func StringifyAnyValue(anyValue *v1common.AnyValue) string {
 	}
 
 	return ""
-}
-
-var invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
-
-// SanitizeLabelName sanitizes a label name for Prometheus.
-func SanitizeLabelName(name string) string {
-	return invalidLabelCharRE.ReplaceAllString(name, "_")
 }

--- a/pkg/util/attributes.go
+++ b/pkg/util/attributes.go
@@ -1,0 +1,44 @@
+package util
+
+import (
+	"regexp"
+	"strconv"
+
+	v1common "github.com/grafana/tempo/pkg/tempopb/common/v1"
+)
+
+func StringifyAnyValue(anyValue *v1common.AnyValue) string {
+	switch anyValue.Value.(type) {
+	case *v1common.AnyValue_BoolValue:
+		return strconv.FormatBool(anyValue.GetBoolValue())
+	case *v1common.AnyValue_IntValue:
+		return strconv.FormatInt(anyValue.GetIntValue(), 10)
+	case *v1common.AnyValue_ArrayValue:
+		arrStr := "["
+		for _, v := range anyValue.GetArrayValue().Values {
+			arrStr += StringifyAnyValue(v)
+		}
+		arrStr += "]"
+		return arrStr
+	case *v1common.AnyValue_DoubleValue:
+		return strconv.FormatFloat(anyValue.GetDoubleValue(), 'f', -1, 64)
+	case *v1common.AnyValue_KvlistValue:
+		mapStr := "{"
+		for _, kv := range anyValue.GetKvlistValue().Values {
+			mapStr += kv.Key + ":" + StringifyAnyValue(kv.Value)
+		}
+		mapStr += "}"
+		return mapStr
+	case *v1common.AnyValue_StringValue:
+		return anyValue.GetStringValue()
+	}
+
+	return ""
+}
+
+var invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+
+// SanitizeLabelName sanitizes a label name for Prometheus.
+func SanitizeLabelName(name string) string {
+	return invalidLabelCharRE.ReplaceAllString(name, "_")
+}

--- a/pkg/util/attributes_test.go
+++ b/pkg/util/attributes_test.go
@@ -1,0 +1,119 @@
+package util
+
+import (
+	"testing"
+
+	v1common "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringifyAnyValue(t *testing.T) {
+	testCases := []struct {
+		name     string
+		v        *v1common.AnyValue
+		expected string
+	}{
+		{
+			name: "string value",
+			v: &v1common.AnyValue{
+				Value: &v1common.AnyValue_StringValue{
+					StringValue: "test",
+				},
+			},
+			expected: "test",
+		},
+		{
+			name: "int value",
+			v: &v1common.AnyValue{
+				Value: &v1common.AnyValue_IntValue{
+					IntValue: 1,
+				},
+			},
+			expected: "1",
+		},
+		{
+			name: "bool value",
+			v: &v1common.AnyValue{
+				Value: &v1common.AnyValue_BoolValue{
+					BoolValue: true,
+				},
+			},
+			expected: "true",
+		},
+		{
+			name: "float value",
+			v: &v1common.AnyValue{
+				Value: &v1common.AnyValue_DoubleValue{
+					DoubleValue: 1.1,
+				},
+			},
+			expected: "1.1",
+		},
+		{
+			name: "array value",
+			v: &v1common.AnyValue{
+				Value: &v1common.AnyValue_ArrayValue{
+					ArrayValue: &v1common.ArrayValue{
+						Values: []*v1common.AnyValue{
+							{
+								Value: &v1common.AnyValue_StringValue{
+									StringValue: "test",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: "[test]",
+		},
+		{
+			name: "map value",
+			v: &v1common.AnyValue{
+				Value: &v1common.AnyValue_KvlistValue{
+					KvlistValue: &v1common.KeyValueList{
+						Values: []*v1common.KeyValue{
+							{
+								Key:   "key",
+								Value: &v1common.AnyValue{Value: &v1common.AnyValue_StringValue{StringValue: "value"}},
+							},
+						},
+					},
+				},
+			},
+			expected: "{key:value}",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			str := StringifyAnyValue(tc.v)
+			assert.Equal(t, tc.expected, str)
+		})
+	}
+}
+
+func TestSanitizeLabelName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		label    string
+		expected string
+	}{
+		{
+			name:     "label with no special characters",
+			label:    "label",
+			expected: "label",
+		},
+		{
+			name:     "label with special characters",
+			label:    "label-with.special/characters",
+			expected: "label_with_special_characters",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			str := SanitizeLabelName(tc.label)
+			assert.Equal(t, tc.expected, str)
+		})
+	}
+}

--- a/pkg/util/attributes_test.go
+++ b/pkg/util/attributes_test.go
@@ -91,29 +91,3 @@ func TestStringifyAnyValue(t *testing.T) {
 		})
 	}
 }
-
-func TestSanitizeLabelName(t *testing.T) {
-	testCases := []struct {
-		name     string
-		label    string
-		expected string
-	}{
-		{
-			name:     "label with no special characters",
-			label:    "label",
-			expected: "label",
-		},
-		{
-			name:     "label with special characters",
-			label:    "label-with.special/characters",
-			expected: "label_with_special_characters",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			str := SanitizeLabelName(tc.label)
-			assert.Equal(t, tc.expected, str)
-		})
-	}
-}

--- a/vendor/github.com/prometheus/prometheus/util/strutil/quote.go
+++ b/vendor/github.com/prometheus/prometheus/util/strutil/quote.go
@@ -1,0 +1,255 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// NOTE: The functions in this file (Unquote, unquoteChar, contains, unhex)
+// have been adapted from the "strconv" package of the Go standard library
+// to work for Prometheus-style strings. Go's special-casing for single
+// quotes was removed and single quoted strings are now treated the same as
+// double-quoted ones.
+//
+// The original copyright notice from the Go project for these parts is
+// reproduced here:
+//
+// ========================================================================
+// Copyright (c) 2009 The Go Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// ========================================================================
+
+package strutil
+
+import (
+	"errors"
+	"unicode/utf8"
+)
+
+// ErrSyntax indicates that a value does not have the right syntax for the target type.
+var ErrSyntax = errors.New("invalid syntax")
+
+// Unquote interprets s as a single-quoted, double-quoted, or backquoted
+// Prometheus query language string literal, returning the string value that s
+// quotes.
+func Unquote(s string) (t string, err error) {
+	n := len(s)
+	if n < 2 {
+		return "", ErrSyntax
+	}
+	quote := s[0]
+	if quote != s[n-1] {
+		return "", ErrSyntax
+	}
+	s = s[1 : n-1]
+
+	if quote == '`' {
+		if contains(s, '`') {
+			return "", ErrSyntax
+		}
+		return s, nil
+	}
+	if quote != '"' && quote != '\'' {
+		return "", ErrSyntax
+	}
+	if contains(s, '\n') {
+		return "", ErrSyntax
+	}
+
+	// Is it trivial?  Avoid allocation.
+	if !contains(s, '\\') && !contains(s, quote) {
+		return s, nil
+	}
+
+	var runeTmp [utf8.UTFMax]byte
+	buf := make([]byte, 0, 3*len(s)/2) // Try to avoid more allocations.
+	for len(s) > 0 {
+		c, multibyte, ss, err := unquoteChar(s, quote)
+		if err != nil {
+			return "", err
+		}
+		s = ss
+		if c < utf8.RuneSelf || !multibyte {
+			buf = append(buf, byte(c))
+		} else {
+			n := utf8.EncodeRune(runeTmp[:], c)
+			buf = append(buf, runeTmp[:n]...)
+		}
+	}
+	return string(buf), nil
+}
+
+// unquoteChar decodes the first character or byte in the escaped string
+// or character literal represented by the string s.
+// It returns four values:
+//
+//	1) value, the decoded Unicode code point or byte value;
+//	2) multibyte, a boolean indicating whether the decoded character requires a multibyte UTF-8 representation;
+//	3) tail, the remainder of the string after the character; and
+//	4) an error that will be nil if the character is syntactically valid.
+//
+// The second argument, quote, specifies the type of literal being parsed
+// and therefore which escaped quote character is permitted.
+// If set to a single quote, it permits the sequence \' and disallows unescaped '.
+// If set to a double quote, it permits \" and disallows unescaped ".
+// If set to zero, it does not permit either escape and allows both quote characters to appear unescaped.
+func unquoteChar(s string, quote byte) (value rune, multibyte bool, tail string, err error) {
+	// easy cases
+	switch c := s[0]; {
+	case c == quote && (quote == '\'' || quote == '"'):
+		err = ErrSyntax
+		return
+	case c >= utf8.RuneSelf:
+		r, size := utf8.DecodeRuneInString(s)
+		return r, true, s[size:], nil
+	case c != '\\':
+		return rune(s[0]), false, s[1:], nil
+	}
+
+	// Hard case: c is backslash.
+	if len(s) <= 1 {
+		err = ErrSyntax
+		return
+	}
+	c := s[1]
+	s = s[2:]
+
+	switch c {
+	case 'a':
+		value = '\a'
+	case 'b':
+		value = '\b'
+	case 'f':
+		value = '\f'
+	case 'n':
+		value = '\n'
+	case 'r':
+		value = '\r'
+	case 't':
+		value = '\t'
+	case 'v':
+		value = '\v'
+	case 'x', 'u', 'U':
+		n := 0
+		switch c {
+		case 'x':
+			n = 2
+		case 'u':
+			n = 4
+		case 'U':
+			n = 8
+		}
+		var v rune
+		if len(s) < n {
+			err = ErrSyntax
+			return
+		}
+		for j := 0; j < n; j++ {
+			x, ok := unhex(s[j])
+			if !ok {
+				err = ErrSyntax
+				return
+			}
+			v = v<<4 | x
+		}
+		s = s[n:]
+		if c == 'x' {
+			// Single-byte string, possibly not UTF-8.
+			value = v
+			break
+		}
+		if v > utf8.MaxRune {
+			err = ErrSyntax
+			return
+		}
+		value = v
+		multibyte = true
+	case '0', '1', '2', '3', '4', '5', '6', '7':
+		v := rune(c) - '0'
+		if len(s) < 2 {
+			err = ErrSyntax
+			return
+		}
+		for j := 0; j < 2; j++ { // One digit already; two more.
+			x := rune(s[j]) - '0'
+			if x < 0 || x > 7 {
+				err = ErrSyntax
+				return
+			}
+			v = (v << 3) | x
+		}
+		s = s[2:]
+		if v > 255 {
+			err = ErrSyntax
+			return
+		}
+		value = v
+	case '\\':
+		value = '\\'
+	case '\'', '"':
+		if c != quote {
+			err = ErrSyntax
+			return
+		}
+		value = rune(c)
+	default:
+		err = ErrSyntax
+		return
+	}
+	tail = s
+	return
+}
+
+// contains reports whether the string contains the byte c.
+func contains(s string, c byte) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] == c {
+			return true
+		}
+	}
+	return false
+}
+
+func unhex(b byte) (v rune, ok bool) {
+	c := rune(b)
+	switch {
+	case '0' <= c && c <= '9':
+		return c - '0', true
+	case 'a' <= c && c <= 'f':
+		return c - 'a' + 10, true
+	case 'A' <= c && c <= 'F':
+		return c - 'A' + 10, true
+	}
+	return
+}

--- a/vendor/github.com/prometheus/prometheus/util/strutil/strconv.go
+++ b/vendor/github.com/prometheus/prometheus/util/strutil/strconv.go
@@ -1,0 +1,43 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strutil
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/grafana/regexp"
+)
+
+var invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+
+// TableLinkForExpression creates an escaped relative link to the table view of
+// the provided expression.
+func TableLinkForExpression(expr string) string {
+	escapedExpression := url.QueryEscape(expr)
+	return fmt.Sprintf("/graph?g0.expr=%s&g0.tab=1", escapedExpression)
+}
+
+// GraphLinkForExpression creates an escaped relative link to the graph view of
+// the provided expression.
+func GraphLinkForExpression(expr string) string {
+	escapedExpression := url.QueryEscape(expr)
+	return fmt.Sprintf("/graph?g0.expr=%s&g0.tab=0", escapedExpression)
+}
+
+// SanitizeLabelName replaces anything that doesn't match
+// client_label.LabelNameRE with an underscore.
+func SanitizeLabelName(name string) string {
+	return invalidLabelCharRE.ReplaceAllString(name, "_")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -749,6 +749,7 @@ github.com/prometheus/prometheus/util/gate
 github.com/prometheus/prometheus/util/logging
 github.com/prometheus/prometheus/util/osutil
 github.com/prometheus/prometheus/util/pool
+github.com/prometheus/prometheus/util/strutil
 github.com/prometheus/prometheus/util/testutil
 # github.com/prometheus/statsd_exporter v0.21.0
 ## explicit; go 1.13


### PR DESCRIPTION
Add dimensions to the service graphs processor config, which attaches
additional labels to the metrics from spans attributes.

It also renames the expired edges internal metric.