### PR TITLE
examples: enable exemplars in distributed docker-compose example

### DIFF
--- a/example/docker-compose/distributed/docker-compose.yaml
+++ b/example/docker-compose/distributed/docker-compose.yaml
@@ -97,6 +97,7 @@ services:
     command:
       - --config.file=/etc/prometheus.yaml
       - --web.enable-remote-write-receiver
+      - --enable-feature=exemplar-storage
     volumes:
       - ./prometheus.yaml:/etc/prometheus.yaml
     ports:

--- a/example/docker-compose/distributed/grafana-datasources.yaml
+++ b/example/docker-compose/distributed/grafana-datasources.yaml
@@ -10,6 +10,10 @@ datasources:
   isDefault: false
   version: 1
   editable: false
+  jsonData:
+    exemplarTraceIdDestinations:
+      - datasourceUid: tempo
+        name: 'traceID'
   uid: prometheus
 - name: Tempo
   type: tempo


### PR DESCRIPTION
**What this PR does**:
Enable exemplars in Prometheus, configure Grafana to link exemplars to Tempo. Together with the latest Tempo image (containing #1364) this should show the full flow.

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`