### PR TITLE
metrics-generator: handle missing dimensions

### DIFF
--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -218,8 +218,7 @@ func (p *processor) collectEdge(e *store.Edge) {
 		labelValues = append(labelValues, e.ClientService, e.ServerService)
 
 		for _, dimension := range p.cfg.Dimensions {
-			value, _ := e.Dimensions[dimension]
-			labelValues = append(labelValues, value)
+			labelValues = append(labelValues, e.Dimensions[dimension])
 		}
 
 		registryLabelValues := registry.NewLabelValues(labelValues)

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -16,11 +16,11 @@ import (
 
 	gen "github.com/grafana/tempo/modules/generator/processor"
 	"github.com/grafana/tempo/modules/generator/processor/servicegraphs/store"
-	"github.com/grafana/tempo/modules/generator/processor/util"
+	processor_util "github.com/grafana/tempo/modules/generator/processor/util"
 	"github.com/grafana/tempo/modules/generator/registry"
 	"github.com/grafana/tempo/pkg/tempopb"
-	v1common "github.com/grafana/tempo/pkg/tempopb/common/v1"
-	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	v1_common "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	v1_trace "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	tempo_util "github.com/grafana/tempo/pkg/util"
 )
 
@@ -73,7 +73,6 @@ type processor struct {
 
 func New(cfg Config, tenant string, registry registry.Registry, logger log.Logger) gen.Processor {
 	labels := []string{"client", "server"}
-
 	for _, d := range cfg.Dimensions {
 		labels = append(labels, strutil.SanitizeLabelName(d))
 	}
@@ -133,12 +132,12 @@ func (p *processor) PushSpans(ctx context.Context, req *tempopb.PushSpansRequest
 	}
 }
 
-func (p *processor) consume(resourceSpans []*v1.ResourceSpans) error {
+func (p *processor) consume(resourceSpans []*v1_trace.ResourceSpans) error {
 	var totalDroppedSpans int
 
 	for _, rs := range resourceSpans {
-		svcName := util.GetServiceName(rs.Resource)
-		if svcName == "" {
+		svcName, ok := processor_util.FindServiceName(rs.Resource.Attributes)
+		if !ok {
 			continue
 		}
 
@@ -150,7 +149,7 @@ func (p *processor) consume(resourceSpans []*v1.ResourceSpans) error {
 			)
 			for _, span := range ils.Spans {
 				switch span.Kind {
-				case v1.Span_SPAN_KIND_CLIENT:
+				case v1_trace.Span_SPAN_KIND_CLIENT:
 					k = key(hex.EncodeToString(span.TraceId), hex.EncodeToString(span.SpanId))
 					edge, err = p.store.UpsertEdge(k, func(e *store.Edge) {
 						e.TraceID = tempo_util.TraceIDToHexString(span.TraceId)
@@ -159,7 +158,7 @@ func (p *processor) consume(resourceSpans []*v1.ResourceSpans) error {
 						e.Failed = e.Failed || p.spanFailed(span)
 						p.upsertDimensions(e.Dimensions, rs.Resource.Attributes, span.Attributes)
 					})
-				case v1.Span_SPAN_KIND_SERVER:
+				case v1_trace.Span_SPAN_KIND_SERVER:
 					k = key(hex.EncodeToString(span.TraceId), hex.EncodeToString(span.ParentSpanId))
 					edge, err = p.store.UpsertEdge(k, func(e *store.Edge) {
 						e.TraceID = tempo_util.TraceIDToHexString(span.TraceId)
@@ -199,6 +198,14 @@ func (p *processor) consume(resourceSpans []*v1.ResourceSpans) error {
 	return nil
 }
 
+func (p *processor) upsertDimensions(m map[string]string, resourceAttr []*v1_common.KeyValue, spanAttr []*v1_common.KeyValue) {
+	for _, dim := range p.cfg.Dimensions {
+		if v, ok := processor_util.FindAttributeValue(dim, resourceAttr, spanAttr); ok {
+			m[dim] = v
+		}
+	}
+}
+
 func (p *processor) Shutdown(_ context.Context) {
 	close(p.closeCh)
 }
@@ -207,51 +214,33 @@ func (p *processor) Shutdown(_ context.Context) {
 // Returns true if the edge is completed or expired and should be deleted.
 func (p *processor) collectEdge(e *store.Edge) {
 	if e.IsCompleted() {
-		values := make([]string, 0, 2+len(p.cfg.Dimensions))
-		values = append(values, e.ClientService)
-		values = append(values, e.ServerService)
+		labelValues := make([]string, 0, 2+len(p.cfg.Dimensions))
+		labelValues = append(labelValues, e.ClientService, e.ServerService)
 
 		for _, dimension := range p.cfg.Dimensions {
-			values = append(values, e.Dimensions[dimension])
+			value, _ := e.Dimensions[dimension]
+			labelValues = append(labelValues, value)
 		}
-		labelValues := registry.NewLabelValues(values)
 
-		p.serviceGraphRequestTotal.Inc(labelValues, 1)
+		registryLabelValues := registry.NewLabelValues(labelValues)
+
+		p.serviceGraphRequestTotal.Inc(registryLabelValues, 1)
 		if e.Failed {
-			p.serviceGraphRequestFailedTotal.Inc(labelValues, 1)
+			p.serviceGraphRequestFailedTotal.Inc(registryLabelValues, 1)
 		}
 
-		p.serviceGraphRequestServerSecondsHistogram.ObserveWithExemplar(labelValues, e.ServerLatencySec, e.TraceID)
-		p.serviceGraphRequestClientSecondsHistogram.ObserveWithExemplar(labelValues, e.ClientLatencySec, e.TraceID)
+		p.serviceGraphRequestServerSecondsHistogram.ObserveWithExemplar(registryLabelValues, e.ServerLatencySec, e.TraceID)
+		p.serviceGraphRequestClientSecondsHistogram.ObserveWithExemplar(registryLabelValues, e.ClientLatencySec, e.TraceID)
 	} else if e.IsExpired() {
 		p.metricExpiredSpans.Inc()
 	}
 }
 
-func (p *processor) upsertDimensions(m map[string]string, resourceAttr []*v1common.KeyValue, spanAttr []*v1common.KeyValue) {
-	for _, dim := range p.cfg.Dimensions {
-		if v, found := p.findAttrValue(dim, resourceAttr, spanAttr); found {
-			m[dim] = v
-		}
-	}
-}
-
-func (p *processor) findAttrValue(key string, attrSlices ...[]*v1common.KeyValue) (string, bool) {
-	for _, attrs := range attrSlices {
-		for _, kv := range attrs {
-			if key == kv.Key {
-				return tempo_util.StringifyAnyValue(kv.Value), true
-			}
-		}
-	}
-	return "", false
-}
-
-func (p *processor) spanFailed(_ *v1.Span) bool {
+func (p *processor) spanFailed(_ *v1_trace.Span) bool {
 	return false
 }
 
-func spanDurationSec(span *v1.Span) float64 {
+func spanDurationSec(span *v1_trace.Span) float64 {
 	return float64(span.EndTimeUnixNano-span.StartTimeUnixNano) / float64(time.Second.Nanoseconds())
 }
 

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -26,7 +26,7 @@ func TestServiceGraphs(t *testing.T) {
 	cfg.RegisterFlagsAndApplyDefaults("", nil)
 
 	cfg.HistogramBuckets = []float64{2.0, 3.0}
-	cfg.Dimensions = []string{"component"}
+	cfg.Dimensions = []string{"component", "does-not-exist"}
 
 	p := New(cfg, "test", testRegistry, log.NewNopLogger())
 	defer p.Shutdown(context.Background())
@@ -41,14 +41,16 @@ func TestServiceGraphs(t *testing.T) {
 	sgp.store.Expire()
 
 	lbAppLabels := labels.FromMap(map[string]string{
-		"client":    "lb",
-		"server":    "app",
-		"component": "net/http",
+		"client":         "lb",
+		"server":         "app",
+		"component":      "net/http",
+		"does_not_exist": "",
 	})
 	appDbLabels := labels.FromMap(map[string]string{
-		"client":    "app",
-		"server":    "db",
-		"component": "net/http",
+		"client":         "app",
+		"server":         "db",
+		"component":      "net/http",
+		"does_not_exist": "",
 	})
 
 	fmt.Println(testRegistry)

--- a/modules/generator/processor/spanmetrics/spanmetrics.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics.go
@@ -4,14 +4,16 @@ import (
 	"context"
 	"time"
 
-	"github.com/grafana/tempo/pkg/util"
 	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/prometheus/util/strutil"
 
 	gen "github.com/grafana/tempo/modules/generator/processor"
 	processor_util "github.com/grafana/tempo/modules/generator/processor/util"
 	"github.com/grafana/tempo/modules/generator/registry"
 	"github.com/grafana/tempo/pkg/tempopb"
+	v1 "github.com/grafana/tempo/pkg/tempopb/resource/v1"
 	v1_trace "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	tempo_util "github.com/grafana/tempo/pkg/util"
 )
 
 const (
@@ -31,9 +33,8 @@ type processor struct {
 
 func New(cfg Config, registry registry.Registry) gen.Processor {
 	labels := []string{"service", "span_name", "span_kind", "span_status"}
-	if cfg.Dimensions != nil {
-		// TODO we should convert keys into valid prometheus labels, i.e. k8s.ip -> k8s_ip
-		labels = append(labels, cfg.Dimensions...)
+	for _, d := range cfg.Dimensions {
+		labels = append(labels, strutil.SanitizeLabelName(d))
 	}
 
 	return &processor{
@@ -53,39 +54,35 @@ func (p *processor) PushSpans(ctx context.Context, req *tempopb.PushSpansRequest
 	p.aggregateMetrics(req.Batches)
 }
 
-func (p *processor) Shutdown(ctx context.Context) {
+func (p *processor) Shutdown(_ context.Context) {
 }
 
 func (p *processor) aggregateMetrics(resourceSpans []*v1_trace.ResourceSpans) {
 	for _, rs := range resourceSpans {
-		svcName := processor_util.GetServiceName(rs.Resource)
-		if svcName == "" {
-			continue
-		}
+		// already extract service name, so we only have to do it once per batch of spans
+		svcName, _ := processor_util.FindServiceName(rs.Resource.Attributes)
+
 		for _, ils := range rs.InstrumentationLibrarySpans {
 			for _, span := range ils.Spans {
-				p.aggregateMetricsForSpan(svcName, span)
+				p.aggregateMetricsForSpan(svcName, rs.Resource, span)
 			}
 		}
 	}
 }
 
-func (p *processor) aggregateMetricsForSpan(svcName string, span *v1_trace.Span) {
+func (p *processor) aggregateMetricsForSpan(svcName string, rs *v1.Resource, span *v1_trace.Span) {
 	latencySeconds := float64(span.GetEndTimeUnixNano()-span.GetStartTimeUnixNano()) / float64(time.Second.Nanoseconds())
 
 	labelValues := make([]string, 0, 4+len(p.cfg.Dimensions))
 	labelValues = append(labelValues, svcName, span.GetName(), span.GetKind().String(), span.GetStatus().GetCode().String())
 
 	for _, d := range p.cfg.Dimensions {
-		for _, attr := range span.Attributes {
-			if d == attr.Key {
-				labelValues = append(labelValues, util.StringifyAnyValue(attr.Value))
-			}
-		}
+		value, _ := processor_util.FindAttributeValue(d, rs.Attributes, span.Attributes)
+		labelValues = append(labelValues, value)
 	}
 
-	registrylabelValues := registry.NewLabelValues(labelValues)
+	registryLabelValues := registry.NewLabelValues(labelValues)
 
-	p.spanMetricsCallsTotal.Inc(registrylabelValues, 1)
-	p.spanMetricsDurationSeconds.ObserveWithExemplar(registrylabelValues, latencySeconds, util.TraceIDToHexString(span.TraceId))
+	p.spanMetricsCallsTotal.Inc(registryLabelValues, 1)
+	p.spanMetricsDurationSeconds.ObserveWithExemplar(registryLabelValues, latencySeconds, tempo_util.TraceIDToHexString(span.TraceId))
 }

--- a/modules/generator/processor/spanmetrics/spanmetrics_test.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics_test.go
@@ -56,7 +56,7 @@ func TestSpanMetrics_dimensions(t *testing.T) {
 	cfg := Config{}
 	cfg.RegisterFlagsAndApplyDefaults("", nil)
 	cfg.HistogramBuckets = []float64{0.5, 1}
-	cfg.Dimensions = []string{"foo", "bar"}
+	cfg.Dimensions = []string{"foo", "bar", "does-not-exist"}
 
 	p := New(cfg, testRegistry)
 	defer p.Shutdown(context.Background())
@@ -83,12 +83,13 @@ func TestSpanMetrics_dimensions(t *testing.T) {
 	fmt.Println(testRegistry)
 
 	lbls := labels.FromMap(map[string]string{
-		"service":     "test-service",
-		"span_name":   "test",
-		"span_kind":   "SPAN_KIND_CLIENT",
-		"span_status": "STATUS_CODE_OK",
-		"foo":         "foo-value",
-		"bar":         "bar-value",
+		"service":        "test-service",
+		"span_name":      "test",
+		"span_kind":      "SPAN_KIND_CLIENT",
+		"span_status":    "STATUS_CODE_OK",
+		"foo":            "foo-value",
+		"bar":            "bar-value",
+		"does_not_exist": "",
 	})
 
 	assert.Equal(t, 10.0, testRegistry.Query("traces_spanmetrics_calls_total", lbls))

--- a/modules/generator/processor/util/util.go
+++ b/modules/generator/processor/util/util.go
@@ -1,16 +1,23 @@
 package util
 
 import (
-	v1_resource "github.com/grafana/tempo/pkg/tempopb/resource/v1"
 	semconv "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+
+	v1_common "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	tempo_util "github.com/grafana/tempo/pkg/util"
 )
 
-func GetServiceName(rs *v1_resource.Resource) string {
-	for _, attr := range rs.Attributes {
-		if attr.Key == semconv.AttributeServiceName {
-			return attr.Value.GetStringValue()
+func FindServiceName(attributes []*v1_common.KeyValue) (string, bool) {
+	return FindAttributeValue(semconv.AttributeServiceName, attributes)
+}
+
+func FindAttributeValue(key string, attributes ...[]*v1_common.KeyValue) (string, bool) {
+	for _, attrs := range attributes {
+		for _, kv := range attrs {
+			if key == kv.Key {
+				return tempo_util.StringifyAnyValue(kv.Value), true
+			}
 		}
 	}
-
-	return ""
+	return "", false
 }

--- a/modules/generator/processor/util/util_test.go
+++ b/modules/generator/processor/util/util_test.go
@@ -1,0 +1,101 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	v1_common "github.com/grafana/tempo/pkg/tempopb/common/v1"
+)
+
+func TestFindServiceName(t *testing.T) {
+	testCases := []struct {
+		name                string
+		attributes          []*v1_common.KeyValue
+		expectedServiceName string
+		expectedOk          bool
+	}{
+		{
+			"empty attributes",
+			nil,
+			"",
+			false,
+		},
+		{
+			"service name",
+			[]*v1_common.KeyValue{
+				{
+					Key: "cluster",
+					Value: &v1_common.AnyValue{
+						Value: &v1_common.AnyValue_StringValue{
+							StringValue: "test",
+						},
+					},
+				},
+				{
+					Key: "service.name",
+					Value: &v1_common.AnyValue{
+						Value: &v1_common.AnyValue_StringValue{
+							StringValue: "my-service",
+						},
+					},
+				},
+			},
+			"my-service",
+			true,
+		},
+		{
+			"service name",
+			[]*v1_common.KeyValue{
+				{
+					Key: "service.name",
+					Value: &v1_common.AnyValue{
+						Value: &v1_common.AnyValue_StringValue{
+							StringValue: "",
+						},
+					},
+				},
+			},
+			"",
+			true,
+		},
+		{
+			"no service name",
+			[]*v1_common.KeyValue{
+				{
+					Key: "cluster",
+					Value: &v1_common.AnyValue{
+						Value: &v1_common.AnyValue_StringValue{
+							StringValue: "test",
+						},
+					},
+				},
+			},
+			"",
+			false,
+		},
+		{
+			"service name is other type",
+			[]*v1_common.KeyValue{
+				{
+					Key: "service.name",
+					Value: &v1_common.AnyValue{
+						Value: &v1_common.AnyValue_BoolValue{
+							BoolValue: false,
+						},
+					},
+				},
+			},
+			"false",
+			true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			svcName, ok := FindServiceName(tc.attributes)
+
+			assert.Equal(t, tc.expectedOk, ok)
+			assert.Equal(t, tc.expectedServiceName, svcName)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does**:
If the span metrics processor can not find the custom dimension on the span, updating the metric will panic as our label values will be incomplete.

Changes:
- ensure we always add a label value, even if it's empty (`""`)
- look in both the resource attributes and the span attributes for custom dimensions
- sanitize dimensions to ensure they are valid Prometheus labels
- some formatting/naming changes to make the imports consistent across the processors

Note that if we can't find the dimension in the attributes we will add a label with an empty value (`label=""`). This is fine as empty labels are filtered out before writing them to the WAL.

https://github.com/prometheus/prometheus/blob/main/tsdb/agent/db.go#L706-L708

Just appending an empty label value keeps logic simple in the processors and registry.

**Which issue(s) this PR fixes**:
Related to #1303 

**Checklist**
- [x] Tests updated
- [ ] ~~Documentation added~~
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`