### PR TITLE
metrics-generator: add override to disable metrics collection

### DIFF
--- a/modules/generator/instance_test.go
+++ b/modules/generator/instance_test.go
@@ -125,6 +125,10 @@ func (m *mockOverrides) MetricsGeneratorProcessors(userID string) map[string]str
 	return m.processors
 }
 
+func (m *mockOverrides) MetricsGeneratorDisableCollection(userID string) bool {
+	return false
+}
+
 type noopStorage struct{}
 
 var _ storage.Storage = (*noopStorage)(nil)

--- a/modules/generator/registry/overrides.go
+++ b/modules/generator/registry/overrides.go
@@ -9,6 +9,7 @@ import (
 type Overrides interface {
 	MetricsGeneratorMaxActiveSeries(userID string) uint32
 	MetricsGeneratorCollectionInterval(userID string) time.Duration
+	MetricsGeneratorDisableCollection(userID string) bool
 }
 
 var _ Overrides = (*overrides.Overrides)(nil)

--- a/modules/generator/registry/registry.go
+++ b/modules/generator/registry/registry.go
@@ -158,6 +158,10 @@ func (r *ManagedRegistry) onRemoveMetricSeries(count uint32) {
 }
 
 func (r *ManagedRegistry) collectMetrics(ctx context.Context) {
+	if r.overrides.MetricsGeneratorDisableCollection(r.tenant) {
+		return
+	}
+
 	r.metricsMtx.RLock()
 	defer r.metricsMtx.RUnlock()
 

--- a/modules/generator/registry/registry_test.go
+++ b/modules/generator/registry/registry_test.go
@@ -170,6 +170,26 @@ func TestManagedRegistry_maxSeries(t *testing.T) {
 	collectRegistryMetricsAndAssert(t, registry, appender, expectedSamples)
 }
 
+func TestManagedRegistry_disableCollection(t *testing.T) {
+	appender := &capturingAppender{}
+
+	overrides := &mockOverrides{
+		disableCollection: true,
+	}
+	registry := New(&Config{}, overrides, "test", appender, log.NewNopLogger())
+	defer registry.Close()
+
+	counter := registry.NewCounter("metric_1", nil)
+	counter.Inc(nil, 1.0)
+
+	// active series are still tracked
+	assert.Equal(t, uint32(1), registry.activeSeries.Load())
+	// but no samples are collected and sent out
+	registry.collectMetrics(context.Background())
+	assert.Empty(t, appender.samples)
+	assert.Empty(t, appender.exemplars)
+}
+
 func collectRegistryMetricsAndAssert(t *testing.T, r *ManagedRegistry, appender *capturingAppender, expectedSamples []sample) {
 	assert.Equal(t, uint32(len(expectedSamples)), r.activeSeries.Load())
 
@@ -186,7 +206,8 @@ func collectRegistryMetricsAndAssert(t *testing.T, r *ManagedRegistry, appender 
 }
 
 type mockOverrides struct {
-	maxActiveSeries uint32
+	maxActiveSeries   uint32
+	disableCollection bool
 }
 
 var _ Overrides = (*mockOverrides)(nil)
@@ -197,6 +218,10 @@ func (m *mockOverrides) MetricsGeneratorMaxActiveSeries(userID string) uint32 {
 
 func (m *mockOverrides) MetricsGeneratorCollectionInterval(userID string) time.Duration {
 	return 15 * time.Second
+}
+
+func (m *mockOverrides) MetricsGeneratorDisableCollection(userID string) bool {
+	return m.disableCollection
 }
 
 func mustGetHostname() string {

--- a/modules/overrides/limits.go
+++ b/modules/overrides/limits.go
@@ -60,6 +60,7 @@ type Limits struct {
 	MetricsGeneratorProcessors         ListToMap     `yaml:"metrics_generator_processors" json:"metrics_generator_processors"`
 	MetricsGeneratorMaxActiveSeries    uint32        `yaml:"metrics_generator_max_active_series" json:"metrics_generator_max_active_series"`
 	MetricsGeneratorCollectionInterval time.Duration `yaml:"metrics_generator_collection_interval" json:"metrics_generator_collection_interval"`
+	MetricsGeneratorDisableCollection  bool          `yaml:"metrics_generator_disable_collection" json:"metrics_generator_disable_collection"`
 
 	// Compactor enforced limits.
 	BlockRetention model.Duration `yaml:"block_retention" json:"block_retention"`

--- a/modules/overrides/overrides.go
+++ b/modules/overrides/overrides.go
@@ -286,6 +286,11 @@ func (o *Overrides) MetricsGeneratorCollectionInterval(userID string) time.Durat
 	return o.getOverridesForUser(userID).MetricsGeneratorCollectionInterval
 }
 
+// MetricsGeneratorDisableRemoteWrite controls whether metrics are remote written for this tenant.
+func (o *Overrides) MetricsGeneratorDisableCollection(userID string) bool {
+	return o.getOverridesForUser(userID).MetricsGeneratorDisableCollection
+}
+
 // BlockRetention is the duration of the block retention for this tenant.
 func (o *Overrides) BlockRetention(userID string) time.Duration {
 	return time.Duration(o.getOverridesForUser(userID).BlockRetention)


### PR DESCRIPTION
**What this PR does**:
Add an override `metrics_generator_disable_collection` which tells the registry to not collect and write samples for this tenant. This will break the link between the registry and the storage layer (which is responsible for remote writing metrics).

The metrics-generator will still generate metrics and keep track of all the counters and histograms. If you don't want to generate metrics at all, you should clear `metrics_generator_processors` for this tenant.

This setting is useful if you want to ingest data into the metrics-generator, observe resource usage and active series, but don't want to write real metrics. This should be especially handy if you are concerned about the generated active series overwhelming a downstream TSDB.

**Which issue(s) this PR fixes**:
Related to #1303 

**Checklist**
- [x] Tests updated
- [ ] Documentation added, will do in #1328 
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`