### PR TITLE
metrics-generator: change []*RemoteWriteConfig to []RemoteWriteConfig

### DIFF
--- a/modules/generator/storage/config.go
+++ b/modules/generator/storage/config.go
@@ -19,7 +19,7 @@ type Config struct {
 
 	// Prometheus remote write config
 	// https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
-	RemoteWrite []*prometheus_config.RemoteWriteConfig `yaml:"remote_write,omitempty"`
+	RemoteWrite []prometheus_config.RemoteWriteConfig `yaml:"remote_write,omitempty"`
 }
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {

--- a/modules/generator/storage/config_test.go
+++ b/modules/generator/storage/config_test.go
@@ -32,7 +32,7 @@ remote_write:
 	walCfg := agentDefaultOptions()
 	walCfg.WALCompression = true
 
-	remoteWriteConfig := &prometheus_config.DefaultRemoteWriteConfig
+	remoteWriteConfig := prometheus_config.DefaultRemoteWriteConfig
 	prometheusURL, err := url.Parse("http://prometheus/api/prom/push")
 	assert.NoError(t, err)
 	remoteWriteConfig.URL = &prometheus_common_config.URL{URL: prometheusURL}
@@ -44,7 +44,7 @@ remote_write:
 		Path:                     "/var/wal/tempo",
 		Wal:                      walCfg,
 		RemoteWriteFlushDeadline: 5 * time.Minute,
-		RemoteWrite: []*prometheus_config.RemoteWriteConfig{
+		RemoteWrite: []prometheus_config.RemoteWriteConfig{
 			remoteWriteConfig,
 		},
 	}

--- a/modules/generator/storage/config_util.go
+++ b/modules/generator/storage/config_util.go
@@ -12,12 +12,12 @@ import (
 // generateTenantRemoteWriteConfigs creates a copy of the remote write configurations with the
 // X-Scope-OrgID header present for the given tenant. If the remote write config already contains
 // this header it will be overwritten.
-func generateTenantRemoteWriteConfigs(originalCfgs []*prometheus_config.RemoteWriteConfig, tenant string, logger log.Logger) []*prometheus_config.RemoteWriteConfig {
+func generateTenantRemoteWriteConfigs(originalCfgs []prometheus_config.RemoteWriteConfig, tenant string, logger log.Logger) []*prometheus_config.RemoteWriteConfig {
 	var cloneCfgs []*prometheus_config.RemoteWriteConfig
 
 	for _, originalCfg := range originalCfgs {
 		cloneCfg := &prometheus_config.RemoteWriteConfig{}
-		*cloneCfg = *originalCfg
+		*cloneCfg = originalCfg
 
 		// Copy headers so we can modify them
 		cloneCfg.Headers = copyMap(cloneCfg.Headers)

--- a/modules/generator/storage/config_util_test.go
+++ b/modules/generator/storage/config_util_test.go
@@ -14,7 +14,7 @@ import (
 func Test_generateTenantRemoteWriteConfigs(t *testing.T) {
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
 
-	original := []*prometheus_config.RemoteWriteConfig{
+	original := []prometheus_config.RemoteWriteConfig{
 		{
 			URL:     &prometheus_common_config.URL{URL: urlMustParse("http://prometheus-1/api/prom/push")},
 			Headers: map[string]string{},

--- a/modules/generator/storage/instance_test.go
+++ b/modules/generator/storage/instance_test.go
@@ -216,13 +216,13 @@ func newMockPrometheusRemoteWriterServer(logger log.Logger) *mockPrometheusRemot
 	return m
 }
 
-func (m *mockPrometheusRemoteWriteServer) remoteWriteConfig() []*config.RemoteWriteConfig {
-	rwCfg := &config.DefaultRemoteWriteConfig
+func (m *mockPrometheusRemoteWriteServer) remoteWriteConfig() []config.RemoteWriteConfig {
+	rwCfg := config.DefaultRemoteWriteConfig
 	rwCfg.URL = &prometheus_common_config.URL{URL: urlMustParse(fmt.Sprintf("%s/receive", m.server.URL))}
 	rwCfg.SendExemplars = true
 	// Aggressive queue settings to speed up tests
 	rwCfg.QueueConfig.BatchSendDeadline = model.Duration(10 * time.Millisecond)
-	return []*config.RemoteWriteConfig{rwCfg}
+	return []config.RemoteWriteConfig{rwCfg}
 }
 
 func (m *mockPrometheusRemoteWriteServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
**What this PR does**:
Simplify the config a bit. This does not change how config is parsed.

**Which issue(s) this PR fixes**:
Related to #1303

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`