### PR TITLE
Adding tenant ID (instance ID) to the trace too large error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
       prefer_self: 2
       external_endpoints: []
   ```
+* [ENHANCEMENT] Added tenant ID (instance ID) to `trace too large message`. [#1385](https://github.com/grafana/tempo/pull/1385) (@cristiangsp)
 * [BUGFIX]: Enable compaction and retention in Tanka single-binary [#1352](https://github.com/grafana/tempo/issues/1352)
 * [BUGFIX]: Remove unnecessary PersistentVolumeClaim [#1245](https://github.com/grafana/tempo/issues/1245)
 * [BUGFIX] Fixed issue when query-frontend doesn't log request details when request is cancelled [#1136](https://github.com/grafana/tempo/issues/1136) (@adityapwr)

--- a/docs/tempo/website/troubleshooting/max-trace-limit-reached.md
+++ b/docs/tempo/website/troubleshooting/max-trace-limit-reached.md
@@ -25,7 +25,7 @@ and prevent it from OOMing, crashing or otherwise allow tenants to not DOS each 
 will see logs like this at the distributor:
 
 ```
-msg="pusher failed to consume trace data" err="rpc error: code = FailedPrecondition desc = TRACE_TOO_LARGE: max size of trace (52428800) exceeded while adding 15632 bytes"
+msg="pusher failed to consume trace data" err="rpc error: code = FailedPrecondition desc = TRACE_TOO_LARGE: max size of trace (52428800) exceeded while adding 15632 bytes to trace a0fbd6f9ac5e2077d90a19551dd67b6f for tenant single-tenant"
 msg="pusher failed to consume trace data" err="rpc error: code = FailedPrecondition desc = LIVE_TRACES_EXCEEDED: max live traces per tenant exceeded: per-user traces limit (local: 60000 global: 0 actual local: 60000) exceeded"
 msg="pusher failed to consume trace data" err="rpc error: code = ResourceExhausted desc = RATE_LIMITED: ingestion rate limit (15000000 bytes) exceeded while adding 10 bytes"
 ```

--- a/modules/ingester/instance_test.go
+++ b/modules/ingester/instance_test.go
@@ -541,13 +541,13 @@ func TestInstanceFailsLargeTracesEvenAfterFlushing(t *testing.T) {
 
 	// Pushing again fails
 	err = pushFn(3)
-	require.Contains(t, err.Error(), (newTraceTooLargeError(id, maxTraceBytes, 3)).Error())
+	require.Contains(t, err.Error(), (newTraceTooLargeError(id, i.instanceID, maxTraceBytes, 3)).Error())
 
 	// Pushing still fails after flush
 	err = i.CutCompleteTraces(0, true)
 	require.NoError(t, err)
 	err = pushFn(5)
-	require.Contains(t, err.Error(), (newTraceTooLargeError(id, maxTraceBytes, 5)).Error())
+	require.Contains(t, err.Error(), (newTraceTooLargeError(id, i.instanceID, maxTraceBytes, 5)).Error())
 
 	// Cut block and then pushing works again
 	_, err = i.CutBlockIfReady(0, 0, true)

--- a/modules/ingester/trace.go
+++ b/modules/ingester/trace.go
@@ -55,7 +55,7 @@ func (t *liveTrace) Push(_ context.Context, instanceID string, trace []byte, sea
 	if t.maxBytes != 0 {
 		reqSize := len(trace)
 		if t.currentBytes+reqSize > t.maxBytes {
-			return newTraceTooLargeError(t.traceID, t.maxBytes, reqSize)
+			return newTraceTooLargeError(t.traceID, instanceID, t.maxBytes, reqSize)
 		}
 
 		t.currentBytes += reqSize


### PR DESCRIPTION
**What this PR does**:
This PR adds the tenant ID (internally called instance ID) to the trace too large error messages.

**How to test it**:
Set the `max_bytes_per_trace` override to a pretty small number so sending traces will trigger the "trace too large" error easily and you should see a similar message as the following one:
```
level=warn ts=2022-04-14T12:51:52.707097Z caller=grpc_logging.go:38 method=/tempopb.Pusher/PushBytesV2 duration=275.917µs err="rpc error: code = FailedPrecondition desc = TRACE_TOO_LARGE: max size of trace (1) exceeded while adding 283 bytes to trace a0fbd6f9ac5e2077d90a19551dd67b6f for tenant single-tenant" msg="gRPC\n"
```

**Which issue(s) this PR fixes**:
Fixes #1367 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`