### PR TITLE
Fix retention to immediately update the in-memory blocklists for changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
     ```
   * Includes a new metric to determine how often this range is exceeded: `tempo_warnings_total{reason="outside_ingestion_time_slack"}`
 * [BUGFIX] Prevent data race / ingester crash during searching by trace id by using xxhash instance as a local variable. [#1387](https://github.com/grafana/tempo/pull/1387) (@bikashmishra100, @sagarwala, @ashwinidulams)
+* [BUGFIX] Fix spurious "failed to mark block compacted during retention" errors [#1372](https://github.com/grafana/tempo/issues/1372) (@mdisibio)
 
 ## v1.3.2 / 2022-02-23
 * [BUGFIX] Fixed an issue where the query-frontend would corrupt start/end time ranges on searches which included the ingesters [#1295] (@joe-elliott)

--- a/tempodb/blocklist/list.go
+++ b/tempodb/blocklist/list.go
@@ -20,9 +20,10 @@ type List struct {
 	compactedMetas PerTenantCompacted
 
 	// used by the compactor to track local changes it is aware of
-	added          PerTenant
-	removed        PerTenant
-	compactedAdded PerTenantCompacted
+	added            PerTenant
+	removed          PerTenant
+	compactedAdded   PerTenantCompacted
+	compactedRemoved PerTenantCompacted
 }
 
 func New() *List {
@@ -30,9 +31,10 @@ func New() *List {
 		metas:          make(PerTenant),
 		compactedMetas: make(PerTenantCompacted),
 
-		added:          make(PerTenant),
-		removed:        make(PerTenant),
-		compactedAdded: make(PerTenantCompacted),
+		added:            make(PerTenant),
+		removed:          make(PerTenant),
+		compactedAdded:   make(PerTenantCompacted),
+		compactedRemoved: make(PerTenantCompacted),
 	}
 }
 
@@ -88,17 +90,18 @@ func (l *List) ApplyPollResults(m PerTenant, c PerTenantCompacted) {
 
 	// now reapply all updates and clear
 	for tenantID := range l.added {
-		l.updateInternal(tenantID, l.added[tenantID], l.removed[tenantID], l.compactedAdded[tenantID])
+		l.updateInternal(tenantID, l.added[tenantID], l.removed[tenantID], l.compactedAdded[tenantID], l.compactedRemoved[tenantID])
 	}
 
 	l.added = make(PerTenant)
 	l.removed = make(PerTenant)
 	l.compactedAdded = make(PerTenantCompacted)
+	l.compactedRemoved = make(PerTenantCompacted)
 }
 
 // Update Adds and removes regular or compacted blocks from the in-memory blocklist.
 // Changes are temporary and will be preserved only for one poll
-func (l *List) Update(tenantID string, add []*backend.BlockMeta, remove []*backend.BlockMeta, compactedAdd []*backend.CompactedBlockMeta) {
+func (l *List) Update(tenantID string, add []*backend.BlockMeta, remove []*backend.BlockMeta, compactedAdd []*backend.CompactedBlockMeta, compactedRemove []*backend.CompactedBlockMeta) {
 	if tenantID == "" {
 		return
 	}
@@ -106,17 +109,18 @@ func (l *List) Update(tenantID string, add []*backend.BlockMeta, remove []*backe
 	l.mtx.Lock()
 	defer l.mtx.Unlock()
 
-	l.updateInternal(tenantID, add, remove, compactedAdd)
+	l.updateInternal(tenantID, add, remove, compactedAdd, compactedRemove)
 
 	// save off, they are retained for an additional polling cycle
 	l.added[tenantID] = append(l.added[tenantID], add...)
 	l.removed[tenantID] = append(l.removed[tenantID], remove...)
 	l.compactedAdded[tenantID] = append(l.compactedAdded[tenantID], compactedAdd...)
+	l.compactedRemoved[tenantID] = append(l.compactedRemoved[tenantID], compactedRemove...)
 }
 
 // updateInternal exists to do the work of applying updates to held PerTenant and PerTenantCompacted maps
 //  it must be called under lock
-func (l *List) updateInternal(tenantID string, add []*backend.BlockMeta, remove []*backend.BlockMeta, compactedAdd []*backend.CompactedBlockMeta) {
+func (l *List) updateInternal(tenantID string, add []*backend.BlockMeta, remove []*backend.BlockMeta, compactedAdd []*backend.CompactedBlockMeta, compactedRemove []*backend.CompactedBlockMeta) {
 	// ******** Regular blocks ********
 	blocklist := l.metas[tenantID]
 
@@ -148,12 +152,26 @@ func (l *List) updateInternal(tenantID string, add []*backend.BlockMeta, remove 
 
 	// ******** Compacted blocks ********
 	compactedBlocklist := l.compactedMetas[tenantID]
+
+	compactedRemovals := map[uuid.UUID]struct{}{}
+	for _, c := range compactedBlocklist {
+		for _, rem := range compactedRemove {
+			if c.BlockID == rem.BlockID {
+				compactedRemovals[rem.BlockID] = struct{}{}
+				break
+			}
+		}
+	}
+
 	existingMetas = make(map[uuid.UUID]struct{})
-	newCompactedBlocklist := make([]*backend.CompactedBlockMeta, 0, len(compactedBlocklist)+len(compactedAdd))
+	newCompactedBlocklist := make([]*backend.CompactedBlockMeta, 0, len(compactedBlocklist)-len(compactedRemovals)+len(compactedAdd))
+	// rebuild the blocklist dropping all removals
 	for _, b := range compactedBlocklist {
 		existingMetas[b.BlockID] = struct{}{}
+		if _, ok := compactedRemovals[b.BlockID]; !ok {
+			newCompactedBlocklist = append(newCompactedBlocklist, b)
+		}
 	}
-	newCompactedBlocklist = append(newCompactedBlocklist, compactedBlocklist...)
 	for _, b := range compactedAdd {
 		if _, ok := existingMetas[b.BlockID]; !ok {
 			newCompactedBlocklist = append(newCompactedBlocklist, b)

--- a/tempodb/blocklist/list.go
+++ b/tempodb/blocklist/list.go
@@ -129,6 +129,7 @@ func (l *List) updateInternal(tenantID string, add []*backend.BlockMeta, remove 
 		for _, rem := range remove {
 			if b.BlockID == rem.BlockID {
 				matchedRemovals[rem.BlockID] = struct{}{}
+				break
 			}
 		}
 	}

--- a/tempodb/blocklist/list_test.go
+++ b/tempodb/blocklist/list_test.go
@@ -302,7 +302,7 @@ func TestUpdate(t *testing.T) {
 			l := New()
 
 			l.metas[testTenantID] = tt.existing
-			l.Update(testTenantID, tt.add, tt.remove, nil)
+			l.Update(testTenantID, tt.add, tt.remove, nil, nil)
 
 			assert.Equal(t, len(tt.expected), len(l.metas[testTenantID]))
 
@@ -318,6 +318,7 @@ func TestUpdateCompacted(t *testing.T) {
 		name     string
 		existing []*backend.CompactedBlockMeta
 		add      []*backend.CompactedBlockMeta
+		remove   []*backend.CompactedBlockMeta
 		expected []*backend.CompactedBlockMeta
 	}{
 		{
@@ -407,6 +408,47 @@ func TestUpdateCompacted(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "add and remove",
+			existing: []*backend.CompactedBlockMeta{
+				{
+					BlockMeta: backend.BlockMeta{
+						BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+					},
+				},
+				{
+					BlockMeta: backend.BlockMeta{
+						BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
+					},
+				},
+			},
+			add: []*backend.CompactedBlockMeta{
+				{
+					BlockMeta: backend.BlockMeta{
+						BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000003"),
+					},
+				},
+			},
+			remove: []*backend.CompactedBlockMeta{
+				{
+					BlockMeta: backend.BlockMeta{
+						BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
+					},
+				},
+			},
+			expected: []*backend.CompactedBlockMeta{
+				{
+					BlockMeta: backend.BlockMeta{
+						BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+					},
+				},
+				{
+					BlockMeta: backend.BlockMeta{
+						BlockID: uuid.MustParse("00000000-0000-0000-0000-000000000003"),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -414,7 +456,7 @@ func TestUpdateCompacted(t *testing.T) {
 			l := New()
 
 			l.compactedMetas[testTenantID] = tt.existing
-			l.Update(testTenantID, nil, nil, tt.add)
+			l.Update(testTenantID, nil, nil, tt.add, tt.remove)
 
 			assert.Equal(t, len(tt.expected), len(l.compactedMetas[testTenantID]))
 
@@ -585,7 +627,7 @@ func TestUpdatesSaved(t *testing.T) {
 	for _, tc := range tests {
 		l.ApplyPollResults(tc.applyMetas, tc.applyCompacted)
 		if tc.updateTenant != "" {
-			l.Update(tc.updateTenant, tc.addMetas, tc.removeMetas, tc.addCompacted)
+			l.Update(tc.updateTenant, tc.addMetas, tc.removeMetas, tc.addCompacted, nil)
 		}
 
 		actualTenants := l.Tenants()

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -172,7 +172,7 @@ func markCompacted(rw *readerWriter, tenantID string, oldBlocks []*backend.Block
 	}
 
 	// Update blocklist in memory
-	rw.blocklist.Update(tenantID, newBlocks, oldBlocks, newCompactions)
+	rw.blocklist.Update(tenantID, newBlocks, oldBlocks, newCompactions, nil)
 }
 
 func measureOutstandingBlocks(tenantID string, blockSelector CompactionBlockSelector, owned func(hash string) bool) {

--- a/tempodb/retention_test.go
+++ b/tempodb/retention_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/local"
@@ -69,6 +70,76 @@ func TestRetention(t *testing.T) {
 	// retention again should clear it
 	r.(*readerWriter).doRetention()
 	checkBlocklists(t, blockID, 0, 0, rw)
+}
+
+func TestRetentionUpdatesBlocklistImmediately(t *testing.T) {
+	// Test that retention updates the in-memory blocklist
+	// immediately to reflect affected blocks and doesn't
+	// wait for the next polling cycle.
+
+	tempDir := t.TempDir()
+
+	r, w, c, err := New(&Config{
+		Backend: "local",
+		Local: &local.Config{
+			Path: path.Join(tempDir, "traces"),
+		},
+		Block: &common.BlockConfig{
+			IndexDownsampleBytes: 17,
+			BloomFP:              0.01,
+			BloomShardSizeBytes:  100_000,
+			Encoding:             backend.EncLZ4_256k,
+			IndexPageSizeBytes:   1000,
+		},
+		WAL: &wal.Config{
+			Filepath: path.Join(tempDir, "wal"),
+		},
+		BlocklistPoll: 0,
+	}, log.NewNopLogger())
+	assert.NoError(t, err)
+
+	r.EnablePolling(&mockJobSharder{})
+
+	c.EnableCompaction(&CompactorConfig{
+		ChunkSizeBytes:          10,
+		MaxCompactionRange:      time.Hour,
+		BlockRetention:          0,
+		CompactedBlockRetention: 0,
+	}, &mockSharder{}, &mockOverrides{})
+
+	wal := w.WAL()
+	assert.NoError(t, err)
+
+	blockID := uuid.New()
+
+	head, err := wal.NewBlock(blockID, testTenantID, "")
+	assert.NoError(t, err)
+
+	complete, err := w.CompleteBlock(head, &mockCombiner{})
+	assert.NoError(t, err)
+	blockID = complete.BlockMeta().BlockID
+
+	// We have a block
+	rw := r.(*readerWriter)
+	rw.pollBlocklist()
+	require.Equal(t, blockID, rw.blocklist.Metas(testTenantID)[0].BlockID)
+
+	// Mark it compacted
+	r.(*readerWriter).compactorCfg.BlockRetention = 0 // Immediately delete
+	r.(*readerWriter).compactorCfg.CompactedBlockRetention = time.Hour
+	r.(*readerWriter).doRetention()
+
+	// Immediately compacted
+	require.Empty(t, rw.blocklist.Metas(testTenantID))
+	require.Equal(t, blockID, rw.blocklist.CompactedMetas(testTenantID)[0].BlockID)
+
+	// Now delete it permanently
+	r.(*readerWriter).compactorCfg.BlockRetention = time.Hour
+	r.(*readerWriter).compactorCfg.CompactedBlockRetention = 0 // Immediately delete
+	r.(*readerWriter).doRetention()
+
+	require.Empty(t, rw.blocklist.Metas(testTenantID))
+	require.Empty(t, rw.blocklist.CompactedMetas(testTenantID))
 }
 
 func TestBlockRetentionOverride(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:
This PR fixes retention to immediately update the in-memory blocklist for changes.  This prevents errors if retention runs twice before the next polling cycle, where it would try to retain the same block twice.

Note - We already do this [after compaction](https://github.com/grafana/tempo/blob/main/tempodb/compactor.go#L175), but it only added compactedMeta.  Now we are removing too, so there is a new function param and test cases in `blocklist.Update`.

**Which issue(s) this PR fixes**:
Fixes part of #1372 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`