### PR TITLE
Fix Azure Error Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
       prefer_self: 2
       external_endpoints: []
   ```
+* [BUGFIX] Correct issue where Azure "Blob Not Found" errors were sometimes not handled correctly [#1390](https://github.com/grafana/tempo/pull/1390) (@joe-elliott)
 * [BUGFIX]: Enable compaction and retention in Tanka single-binary [#1352](https://github.com/grafana/tempo/issues/1352)
 * [BUGFIX]: Remove unnecessary PersistentVolumeClaim [#1245](https://github.com/grafana/tempo/issues/1245)
 * [BUGFIX] Fixed issue when query-frontend doesn't log request details when request is cancelled [#1136](https://github.com/grafana/tempo/issues/1136) (@adityapwr)

--- a/tempodb/backend/azure/azure.go
+++ b/tempodb/backend/azure/azure.go
@@ -303,12 +303,14 @@ func (rw *readerWriter) readAll(ctx context.Context, name string) ([]byte, error
 }
 
 func readError(err error) error {
-	ret, ok := err.(blob.StorageError)
-	if !ok {
+	var storageError blob.StorageError
+	errors.As(err, &storageError)
+
+	if storageError == nil {
 		return errors.Wrap(err, "reading storage container")
 	}
-	if ret.ServiceCode() == blob.ServiceCodeBlobNotFound {
+	if storageError.ServiceCode() == blob.ServiceCodeBlobNotFound {
 		return backend.ErrDoesNotExist
 	}
-	return errors.Wrap(err, "reading Azure blob container")
+	return errors.Wrap(storageError, "reading Azure blob container")
 }

--- a/tempodb/backend/azure/azure.go
+++ b/tempodb/backend/azure/azure.go
@@ -264,7 +264,7 @@ func (rw *readerWriter) readRange(ctx context.Context, name string, offset int64
 			},
 		},
 	); err != nil {
-		return errors.Wrapf(err, "cannot download blob, name: %s", name)
+		return err
 	}
 
 	_, err = bytes.NewReader(destBuffer).Read(destBuffer)
@@ -296,7 +296,7 @@ func (rw *readerWriter) readAll(ctx context.Context, name string) ([]byte, error
 			},
 		},
 	); err != nil {
-		return nil, errors.Wrapf(err, "cannot download blob, name: %s", name)
+		return nil, err
 	}
 
 	return destBuffer, nil
@@ -307,7 +307,7 @@ func readError(err error) error {
 	if !ok {
 		return errors.Wrap(err, "reading storage container")
 	}
-	if ret.ServiceCode() == "BlobNotFound" {
+	if ret.ServiceCode() == blob.ServiceCodeBlobNotFound {
 		return backend.ErrDoesNotExist
 	}
 	return errors.Wrap(err, "reading Azure blob container")

--- a/tempodb/backend/azure/azure_test.go
+++ b/tempodb/backend/azure/azure_test.go
@@ -136,7 +136,7 @@ func TestReadError(t *testing.T) {
 	require.Equal(t, backend.ErrDoesNotExist, err)
 
 	// wrap blob not found error and confirm it still converts to ErrDoesNotExist
-	wrappedBlobNotFoundError := errors.Wrap(blobNotFoundError, "wrap!")
+	wrappedBlobNotFoundError := errors.Wrap(blobNotFoundError, "wrap")
 	err = readError(wrappedBlobNotFoundError)
 	require.Equal(t, backend.ErrDoesNotExist, err)
 


### PR DESCRIPTION
**What this PR does**:
In certain cases we were not correctly translating errors from ABS into `backend.ErrDoesNotExist`. This PR corrects that issue by doing the following:

- Update `readError` to descend wrapped errors to find errors of type `blob.StorageError`
- Removes the wrapping that was causing the initial issue. It didn't add anything of value.
- Appropriate testing added 

**Which issue(s) this PR fixes**:
Fixes the other part of #1372 along with #1389

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`