### PR TITLE
Fix integration tests

### DIFF
--- a/integration/e2e/config-all-in-one-azurite.yaml
+++ b/integration/e2e/config-all-in-one-azurite.yaml
@@ -25,14 +25,13 @@ ingester:
       replication_factor: 1
     final_sleep: 0s
   trace_idle_period: 1s
-  max_block_bytes: 1
-  max_block_duration: 2s
-  complete_block_timeout: 1s
+  max_block_duration: 5s
+  complete_block_timeout: 5s
   flush_check_period: 1s
 
 storage:
   trace:
-    blocklist_poll: 2s
+    blocklist_poll: 1s
     backend: azure
     azure:
       container-name: tempo                    # how to store data in azure

--- a/integration/e2e/config-all-in-one-gcs.yaml
+++ b/integration/e2e/config-all-in-one-gcs.yaml
@@ -37,9 +37,6 @@ storage:
       bucket_name: tempo
       endpoint: https://tempo_e2e-gcs:4443/storage/v1/
       insecure: true
-      object_cache_control: "no-cache"
-      object_metadata:
-        testing: "yes"
     pool:
       max_workers: 10
       queue_depth: 1000

--- a/integration/e2e/config-all-in-one-gcs.yaml
+++ b/integration/e2e/config-all-in-one-gcs.yaml
@@ -25,14 +25,13 @@ ingester:
       replication_factor: 1
     final_sleep: 0s
   trace_idle_period: 1s
-  max_block_bytes: 1
-  max_block_duration: 2s
-  complete_block_timeout: 1s
+  max_block_duration: 5s
+  complete_block_timeout: 5s
   flush_check_period: 1s
 
 storage:
   trace:
-    blocklist_poll: 2s
+    blocklist_poll: 1s
     backend: gcs
     gcs:
       bucket_name: tempo

--- a/integration/e2e/config-all-in-one-s3.yaml
+++ b/integration/e2e/config-all-in-one-s3.yaml
@@ -25,14 +25,13 @@ ingester:
       replication_factor: 1
     final_sleep: 0s
   trace_idle_period: 1s
-  max_block_bytes: 1
-  max_block_duration: 2s
-  complete_block_timeout: 1s
+  max_block_duration: 5s
+  complete_block_timeout: 5s
   flush_check_period: 1s
 
 storage:
   trace:
-    blocklist_poll: 2s
+    blocklist_poll: 1s
     backend: s3
     s3:
       bucket: tempo

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -107,14 +107,11 @@ func TestAllInOne(t *testing.T) {
 			// flush trace to backend
 			callFlush(t, tempo)
 
-			// sleep for one maintenance cycle
-			time.Sleep(5 * time.Second)
+			// sleep
+			time.Sleep(10 * time.Second)
 
 			// force clear completed block
 			callFlush(t, tempo)
-
-			// sleep for one maintenance cycle
-			time.Sleep(5 * time.Second)
 
 			// test metrics
 			require.NoError(t, tempo.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_blocks_flushed_total"))

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -93,7 +93,6 @@ func TestAllInOne(t *testing.T) {
 			assertEcho(t, "http://"+tempo.Endpoint(3200)+"/api/echo")
 
 			// wait trace_idle_time and ensure trace is created in ingester
-			time.Sleep(2 * time.Second)
 			require.NoError(t, tempo.WaitSumMetricsWithOptions(e2e.Less(3), []string{"tempo_ingester_traces_created_total"}, e2e.WaitMissingMetrics))
 
 			apiClient := tempoUtil.NewClient("http://"+tempo.Endpoint(3200), "")
@@ -244,7 +243,6 @@ func TestMicroservicesWithKVStores(t *testing.T) {
 			assertEcho(t, "http://"+tempoQueryFrontend.Endpoint(3200)+"/api/echo")
 
 			// wait trace_idle_time and ensure trace is created in ingester
-			time.Sleep(1 * time.Second)
 			require.NoError(t, tempoIngester1.WaitSumMetricsWithOptions(e2e.Less(3), []string{"tempo_ingester_traces_created_total"}, e2e.WaitMissingMetrics))
 			require.NoError(t, tempoIngester2.WaitSumMetricsWithOptions(e2e.Less(3), []string{"tempo_ingester_traces_created_total"}, e2e.WaitMissingMetrics))
 			require.NoError(t, tempoIngester3.WaitSumMetricsWithOptions(e2e.Less(3), []string{"tempo_ingester_traces_created_total"}, e2e.WaitMissingMetrics))

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -94,7 +94,7 @@ func TestAllInOne(t *testing.T) {
 
 			// wait trace_idle_time and ensure trace is created in ingester
 			time.Sleep(2 * time.Second)
-			require.NoError(t, tempo.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_traces_created_total"))
+			require.NoError(t, tempo.WaitSumMetricsWithOptions(e2e.Less(3), []string{"tempo_ingester_traces_created_total"}, e2e.WaitMissingMetrics))
 
 			apiClient := tempoUtil.NewClient("http://"+tempo.Endpoint(3200), "")
 
@@ -245,9 +245,9 @@ func TestMicroservicesWithKVStores(t *testing.T) {
 
 			// wait trace_idle_time and ensure trace is created in ingester
 			time.Sleep(1 * time.Second)
-			require.NoError(t, tempoIngester1.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_traces_created_total"))
-			require.NoError(t, tempoIngester2.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_traces_created_total"))
-			require.NoError(t, tempoIngester3.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_traces_created_total"))
+			require.NoError(t, tempoIngester1.WaitSumMetricsWithOptions(e2e.Less(3), []string{"tempo_ingester_traces_created_total"}, e2e.WaitMissingMetrics))
+			require.NoError(t, tempoIngester2.WaitSumMetricsWithOptions(e2e.Less(3), []string{"tempo_ingester_traces_created_total"}, e2e.WaitMissingMetrics))
+			require.NoError(t, tempoIngester3.WaitSumMetricsWithOptions(e2e.Less(3), []string{"tempo_ingester_traces_created_total"}, e2e.WaitMissingMetrics))
 
 			apiClient := tempoUtil.NewClient("http://"+tempoQueryFrontend.Endpoint(3200), "")
 
@@ -379,7 +379,7 @@ func TestScalableSingleBinary(t *testing.T) {
 
 	// wait trace_idle_time and ensure trace is created in ingester
 	time.Sleep(1 * time.Second)
-	require.NoError(t, tempo1.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_traces_created_total"))
+	require.NoError(t, tempo1.WaitSumMetricsWithOptions(e2e.Less(3), []string{"tempo_ingester_traces_created_total"}, e2e.WaitMissingMetrics))
 
 	for _, i := range []*e2e.HTTPService{tempo1, tempo2, tempo3} {
 		callFlush(t, i)

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -113,6 +113,9 @@ func TestAllInOne(t *testing.T) {
 			// force clear completed block
 			callFlush(t, tempo)
 
+			// sleep for one maintenance cycle
+			time.Sleep(5 * time.Second)
+
 			// test metrics
 			require.NoError(t, tempo.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_blocks_flushed_total"))
 			require.NoError(t, tempo.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"tempodb_blocklist_length"}, e2e.WaitMissingMetrics))

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -92,9 +92,6 @@ func TestAllInOne(t *testing.T) {
 			// test echo
 			assertEcho(t, "http://"+tempo.Endpoint(3200)+"/api/echo")
 
-			// wait trace_idle_time and ensure trace is created in ingester
-			require.NoError(t, tempo.WaitSumMetricsWithOptions(e2e.Less(3), []string{"tempo_ingester_traces_created_total"}, e2e.WaitMissingMetrics))
-
 			apiClient := tempoUtil.NewClient("http://"+tempo.Endpoint(3200), "")
 
 			// query an in-memory trace
@@ -102,6 +99,9 @@ func TestAllInOne(t *testing.T) {
 
 			// search an in-memory trace
 			util.SearchAndAssertTrace(t, apiClient, info)
+
+			// wait trace_idle_time and ensure trace is created in ingester
+			require.NoError(t, tempo.WaitSumMetricsWithOptions(e2e.Less(3), []string{"tempo_ingester_traces_created_total"}, e2e.WaitMissingMetrics))
 
 			// flush trace to backend
 			callFlush(t, tempo)
@@ -242,11 +242,6 @@ func TestMicroservicesWithKVStores(t *testing.T) {
 			// test echo
 			assertEcho(t, "http://"+tempoQueryFrontend.Endpoint(3200)+"/api/echo")
 
-			// wait trace_idle_time and ensure trace is created in ingester
-			require.NoError(t, tempoIngester1.WaitSumMetricsWithOptions(e2e.Less(3), []string{"tempo_ingester_traces_created_total"}, e2e.WaitMissingMetrics))
-			require.NoError(t, tempoIngester2.WaitSumMetricsWithOptions(e2e.Less(3), []string{"tempo_ingester_traces_created_total"}, e2e.WaitMissingMetrics))
-			require.NoError(t, tempoIngester3.WaitSumMetricsWithOptions(e2e.Less(3), []string{"tempo_ingester_traces_created_total"}, e2e.WaitMissingMetrics))
-
 			apiClient := tempoUtil.NewClient("http://"+tempoQueryFrontend.Endpoint(3200), "")
 
 			// query an in-memory trace
@@ -254,6 +249,11 @@ func TestMicroservicesWithKVStores(t *testing.T) {
 
 			// search an in-memory trace
 			util.SearchAndAssertTrace(t, apiClient, info)
+
+			// wait trace_idle_time and ensure trace is created in ingester
+			require.NoError(t, tempoIngester1.WaitSumMetricsWithOptions(e2e.Less(3), []string{"tempo_ingester_traces_created_total"}, e2e.WaitMissingMetrics))
+			require.NoError(t, tempoIngester2.WaitSumMetricsWithOptions(e2e.Less(3), []string{"tempo_ingester_traces_created_total"}, e2e.WaitMissingMetrics))
+			require.NoError(t, tempoIngester3.WaitSumMetricsWithOptions(e2e.Less(3), []string{"tempo_ingester_traces_created_total"}, e2e.WaitMissingMetrics))
 
 			// flush trace to backend
 			callFlush(t, tempoIngester1)

--- a/integration/e2e/serverless/serverless_test.go
+++ b/integration/e2e/serverless/serverless_test.go
@@ -84,9 +84,9 @@ func TestServerless(t *testing.T) {
 
 			// wait trace_idle_time and ensure trace is created in ingester
 			time.Sleep(1 * time.Second)
-			require.NoError(t, tempoIngester1.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_traces_created_total"))
-			require.NoError(t, tempoIngester2.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_traces_created_total"))
-			require.NoError(t, tempoIngester3.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_traces_created_total"))
+			require.NoError(t, tempoIngester1.WaitSumMetricsWithOptions(e2e.Less(3), []string{"tempo_ingester_traces_created_total"}, e2e.WaitMissingMetrics))
+			require.NoError(t, tempoIngester2.WaitSumMetricsWithOptions(e2e.Less(3), []string{"tempo_ingester_traces_created_total"}, e2e.WaitMissingMetrics))
+			require.NoError(t, tempoIngester3.WaitSumMetricsWithOptions(e2e.Less(3), []string{"tempo_ingester_traces_created_total"}, e2e.WaitMissingMetrics))
 
 			apiClient := tempoUtil.NewClient("http://"+tempoQueryFrontend.Endpoint(3200), "")
 

--- a/integration/e2e/serverless/serverless_test.go
+++ b/integration/e2e/serverless/serverless_test.go
@@ -83,7 +83,6 @@ func TestServerless(t *testing.T) {
 			require.NoError(t, info.EmitAllBatches(c))
 
 			// wait trace_idle_time and ensure trace is created in ingester
-			time.Sleep(1 * time.Second)
 			require.NoError(t, tempoIngester1.WaitSumMetricsWithOptions(e2e.Less(3), []string{"tempo_ingester_traces_created_total"}, e2e.WaitMissingMetrics))
 			require.NoError(t, tempoIngester2.WaitSumMetricsWithOptions(e2e.Less(3), []string{"tempo_ingester_traces_created_total"}, e2e.WaitMissingMetrics))
 			require.NoError(t, tempoIngester3.WaitSumMetricsWithOptions(e2e.Less(3), []string{"tempo_ingester_traces_created_total"}, e2e.WaitMissingMetrics))


### PR DESCRIPTION
Some tweaks to make our integration tests more consistent. Changes made:

**All In One Improvements**
- Removed `max_block_bytes` preferring `max_block_duration` to cut the head block.
- Halved blocklist poll to reduce the chance of failures due to not seeing blocks in the backend
- Removed innocuous `object_` fields from all in one gcs tests
- Increased `max_block_duration` and `complete_block_timeout` to `5s` and retimed tests around it

**All Integration Test Improvements**
- Changed all `tempo_ingester_traces_created_total` to both wait for missing metrics and to pass as long as the value of the metric is less than 3. We were seeing a lot of failures b/c this metric was equal to 2 sometimes. This was likely occuring due to unfortunate timing on pushing a trace in multiple batches.
- Moved initial query for a trace to before the first check of `tempo_ingester_traces_created_total` to guarantee it was being requested from memory.