### PR TITLE
Avoid libc for serverless lambda build

### DIFF
--- a/cmd/tempo-serverless/Makefile
+++ b/cmd/tempo-serverless/Makefile
@@ -40,7 +40,7 @@ build-docker-lambda-test:
 # as that should the handler config option in aws
 .PHONY: build-lambda-zip
 build-lambda-zip:
-	$(IN_LAMBDA) GOOS=linux GOARCH=amd64 go build -o main
+	$(IN_LAMBDA) CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o main
 	$(IN_LAMBDA) zip tempo-serverless-$(VERSION).zip main
 	$(IN_LAMBDA) rm main
 


### PR DESCRIPTION
**What this PR does**:

Here we update the build flags for Lambda to avoid using libc.  This will allow us to compile and execute on platforms that differ in their libc version by building the dependencies we require into the binary.
