### PR TITLE
metrics-generator: track failed requests in service-graphs processor

### DIFF
--- a/modules/generator/processor/servicegraphs/config.go
+++ b/modules/generator/processor/servicegraphs/config.go
@@ -27,8 +27,6 @@ type Config struct {
 	// If client and server spans have the same attribute, behaviour is undetermined
 	// (either value could get used)
 	Dimensions []string `yaml:"dimensions"`
-
-	// SuccessCodes *successCodes `yaml:"success_codes"`
 }
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -235,8 +235,8 @@ func (p *processor) collectEdge(e *store.Edge) {
 	}
 }
 
-func (p *processor) spanFailed(_ *v1_trace.Span) bool {
-	return false
+func (p *processor) spanFailed(span *v1_trace.Span) bool {
+	return span.GetStatus().GetCode() == v1_trace.Status_STATUS_CODE_ERROR
 }
 
 func spanDurationSec(span *v1_trace.Span) float64 {

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -56,6 +56,7 @@ func TestServiceGraphs(t *testing.T) {
 	fmt.Println(testRegistry)
 
 	assert.Equal(t, 3.0, testRegistry.Query(`traces_service_graph_request_total`, appDbLabels))
+	assert.Equal(t, 0.0, testRegistry.Query(`traces_service_graph_request_failed_total`, appDbLabels))
 
 	assert.Equal(t, 2.0, testRegistry.Query(`traces_service_graph_request_client_seconds_bucket`, withLe(appDbLabels, 2.0)))
 	assert.Equal(t, 3.0, testRegistry.Query(`traces_service_graph_request_client_seconds_bucket`, withLe(appDbLabels, 3.0)))
@@ -70,6 +71,7 @@ func TestServiceGraphs(t *testing.T) {
 	assert.Equal(t, 5.0, testRegistry.Query(`traces_service_graph_request_server_seconds_sum`, appDbLabels))
 
 	assert.Equal(t, 3.0, testRegistry.Query(`traces_service_graph_request_total`, lbAppLabels))
+	assert.Equal(t, 1.0, testRegistry.Query(`traces_service_graph_request_failed_total`, lbAppLabels))
 
 	assert.Equal(t, 1.0, testRegistry.Query(`traces_service_graph_request_client_seconds_bucket`, withLe(lbAppLabels, 2.0)))
 	assert.Equal(t, 2.0, testRegistry.Query(`traces_service_graph_request_client_seconds_bucket`, withLe(lbAppLabels, 3.0)))


### PR DESCRIPTION
**What this PR does**:
The service-graphs processor can track failed requests with `traces_service_graph_request_failed_total`. For now we just check the status code of the span (client or server).

fyi the agent has more configurability in this area: you can configure http and grpc status codes that are also considered successfully.

**Which issue(s) this PR fixes**:
Related to #1303 

**Checklist**
- [x] Tests updated
- [ ] ~~Documentation added~~
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`