### PR TITLE
metrics-generator: drop traces_spanmetrics_calls_total

### DIFF
--- a/integration/e2e/metrics_generator_test.go
+++ b/integration/e2e/metrics_generator_test.go
@@ -145,7 +145,6 @@ func TestMetricsGenerator(t *testing.T) {
 	assert.Equal(t, 2.0, sumValues(metricFamilies, "traces_spanmetrics_duration_seconds_sum", lbls))
 
 	lbls = []string{"service", "app", "span_name", "app-handle", "span_kind", "SPAN_KIND_SERVER", "span_status", "STATUS_CODE_UNSET"}
-	assert.Equal(t, 1.0, sumValues(metricFamilies, "traces_spanmetrics_calls_total", lbls))
 	assert.Equal(t, 1.0, sumValues(metricFamilies, "traces_spanmetrics_duration_seconds_bucket", append(lbls, "le", "1")))
 	assert.Equal(t, 1.0, sumValues(metricFamilies, "traces_spanmetrics_duration_seconds_bucket", append(lbls, "le", "2")))
 	assert.Equal(t, 1.0, sumValues(metricFamilies, "traces_spanmetrics_duration_seconds_bucket", append(lbls, "le", "+Inf")))

--- a/modules/generator/processor/spanmetrics/spanmetrics.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics.go
@@ -17,14 +17,12 @@ import (
 )
 
 const (
-	metricCallsTotal      = "traces_spanmetrics_calls_total"
 	metricDurationSeconds = "traces_spanmetrics_duration_seconds"
 )
 
 type processor struct {
 	cfg Config
 
-	spanMetricsCallsTotal      registry.Counter
 	spanMetricsDurationSeconds registry.Histogram
 
 	// for testing
@@ -39,7 +37,6 @@ func New(cfg Config, registry registry.Registry) gen.Processor {
 
 	return &processor{
 		cfg:                        cfg,
-		spanMetricsCallsTotal:      registry.NewCounter(metricCallsTotal, labels),
 		spanMetricsDurationSeconds: registry.NewHistogram(metricDurationSeconds, labels, cfg.HistogramBuckets),
 		now:                        time.Now,
 	}
@@ -83,6 +80,5 @@ func (p *processor) aggregateMetricsForSpan(svcName string, rs *v1.Resource, spa
 
 	registryLabelValues := registry.NewLabelValues(labelValues)
 
-	p.spanMetricsCallsTotal.Inc(registryLabelValues, 1)
 	p.spanMetricsDurationSeconds.ObserveWithExemplar(registryLabelValues, latencySeconds, tempo_util.TraceIDToHexString(span.TraceId))
 }

--- a/modules/generator/processor/spanmetrics/spanmetrics_test.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics_test.go
@@ -41,8 +41,6 @@ func TestSpanMetrics(t *testing.T) {
 		"span_status": "STATUS_CODE_OK",
 	})
 
-	assert.Equal(t, 10.0, testRegistry.Query("traces_spanmetrics_calls_total", lbls))
-
 	assert.Equal(t, 0.0, testRegistry.Query("traces_spanmetrics_duration_seconds_bucket", withLe(lbls, 0.5)))
 	assert.Equal(t, 10.0, testRegistry.Query("traces_spanmetrics_duration_seconds_bucket", withLe(lbls, 1)))
 	assert.Equal(t, 10.0, testRegistry.Query("traces_spanmetrics_duration_seconds_bucket", withLe(lbls, math.Inf(1))))
@@ -91,8 +89,6 @@ func TestSpanMetrics_dimensions(t *testing.T) {
 		"bar":            "bar-value",
 		"does_not_exist": "",
 	})
-
-	assert.Equal(t, 10.0, testRegistry.Query("traces_spanmetrics_calls_total", lbls))
 
 	assert.Equal(t, 0.0, testRegistry.Query("traces_spanmetrics_duration_seconds_bucket", withLe(lbls, 0.5)))
 	assert.Equal(t, 10.0, testRegistry.Query("traces_spanmetrics_duration_seconds_bucket", withLe(lbls, 1)))


### PR DESCRIPTION
**What this PR does**:
The value of `traces_spanmetrics_calls_total` always matches with `traces_spanmetrics_duration_seconds_count`. So to reduce cardinality we can just drop these.

**Which issue(s) this PR fixes**:
Related to #1303 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`