### PR TITLE
metrics-generator: don't inject X-Scope-OrgID header for single-tenant setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## main / unreleased
 
+* [BUGFIX] metrics-generator: don't inject X-Scope-OrgID header for single-tenant setups [1417](https://github.com/grafana/tempo/pull/1417) (@kvrhdn)
+
 ## v1.4.0 / 2022-04-28
 
 * [CHANGE] Vulture now exercises search at any point during the block retention to test full backend search.

--- a/modules/generator/storage/config_util.go
+++ b/modules/generator/storage/config_util.go
@@ -7,6 +7,8 @@ import (
 	"github.com/go-kit/log/level"
 	prometheus_config "github.com/prometheus/prometheus/config"
 	"github.com/weaveworks/common/user"
+
+	"github.com/grafana/tempo/pkg/util"
 )
 
 // generateTenantRemoteWriteConfigs creates a copy of the remote write configurations with the
@@ -31,7 +33,9 @@ func generateTenantRemoteWriteConfigs(originalCfgs []prometheus_config.RemoteWri
 		}
 
 		// inject the X-Scope-OrgId header for multi-tenant metrics backends
-		cloneCfg.Headers[user.OrgIDHeaderName] = tenant
+		if tenant != util.FakeTenantID {
+			cloneCfg.Headers[user.OrgIDHeaderName] = tenant
+		}
 
 		cloneCfgs = append(cloneCfgs, cloneCfg)
 	}


### PR DESCRIPTION
**What this PR does**:
The metrics-generator will always inject the `X-Scope-OrgID` header set to the current tenant. This doesn't make sense when run in single tenant modus.

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`