### PR TITLE
Fix compactor missing compaction_objects_combined_total metric and not honoring max_bytes_per_trace 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main / unreleased
 
 * [BUGFIX] metrics-generator: don't inject X-Scope-OrgID header for single-tenant setups [1417](https://github.com/grafana/tempo/pull/1417) (@kvrhdn)
+* [BUGFIX] compactor: populate `compaction_objects_combined_total` and `tempo_discarded_spans_total{reason="trace_too_large_to_compact"}` metrics again [1420](https://github.com/grafana/tempo/pull/1420) (@mdisibio)
 
 ## v1.4.0 / 2022-04-28
 

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 type mockSharder struct {
+	combinerCallCount int
 }
 
 func (m *mockSharder) Owns(hash string) bool {
@@ -36,6 +37,7 @@ func (m *mockSharder) Owns(hash string) bool {
 }
 
 func (m *mockSharder) Combine(dataEncoding string, tenantID string, objs ...[]byte) ([]byte, bool, error) {
+	m.combinerCallCount++
 	return model.StaticCombiner.Combine(dataEncoding, objs...)
 }
 
@@ -230,6 +232,7 @@ func TestSameIDCompaction(t *testing.T) {
 	// make a bunch of sharded requests
 	allReqs := make([][][]byte, 0, recordCount)
 	allIds := make([][]byte, 0, recordCount)
+	sharded := 0
 	for i := 0; i < recordCount; i++ {
 		id := test.ValidTraceID(nil)
 
@@ -245,6 +248,9 @@ func TestSameIDCompaction(t *testing.T) {
 			reqs = append(reqs, buff2)
 		}
 
+		if requestShards > 1 {
+			sharded++
+		}
 		allReqs = append(allReqs, reqs)
 		allIds = append(allIds, id)
 	}
@@ -280,6 +286,9 @@ func TestSameIDCompaction(t *testing.T) {
 	blocks, _ = blockSelector.BlocksToCompact()
 	assert.Len(t, blocks, blockCount)
 
+	combinedStart, err := test.GetCounterVecValue(metrics.MetricCompactionObjectsCombined, "0")
+	require.NoError(t, err)
+
 	err = rw.compact(blocks, testTenantID)
 	require.NoError(t, err)
 
@@ -308,9 +317,12 @@ func TestSameIDCompaction(t *testing.T) {
 
 		expectedBytes, _, err := model.StaticCombiner.Combine(v1.Encoding, allReqs[i]...)
 		require.NoError(t, err)
-
 		require.Equal(t, expectedBytes, b2)
 	}
+
+	combinedEnd, err := test.GetCounterVecValue(metrics.MetricCompactionObjectsCombined, "0")
+	require.NoError(t, err)
+	require.Equal(t, float64(sharded), combinedEnd-combinedStart)
 }
 
 func TestCompactionUpdatesBlocklist(t *testing.T) {
@@ -418,7 +430,7 @@ func TestCompactionMetrics(t *testing.T) {
 
 	// Cut x blocks with y records each
 	blockCount := 5
-	recordCount := 1
+	recordCount := 10
 	cutTestBlocks(t, w, testTenantID, blockCount, recordCount)
 
 	rw := r.(*readerWriter)
@@ -450,6 +462,58 @@ func TestCompactionMetrics(t *testing.T) {
 	bytesEnd, err := test.GetCounterVecValue(metrics.MetricCompactionBytesWritten, "0")
 	assert.NoError(t, err)
 	assert.Greater(t, bytesEnd, bytesStart) // calculating the exact bytes requires knowledge of the bytes as written in the blocks.  just make sure it goes up
+}
+
+func TestCompactionUsesCombiner(t *testing.T) {
+	tempDir := t.TempDir()
+
+	r, w, c, err := New(&Config{
+		Backend: "local",
+		Pool: &pool.Config{
+			MaxWorkers: 10,
+			QueueDepth: 100,
+		},
+		Local: &local.Config{
+			Path: path.Join(tempDir, "traces"),
+		},
+		Block: &common.BlockConfig{
+			IndexDownsampleBytes: 11,
+			BloomFP:              .01,
+			BloomShardSizeBytes:  100_000,
+			Encoding:             backend.EncNone,
+			IndexPageSizeBytes:   1000,
+		},
+		WAL: &wal.Config{
+			Filepath: path.Join(tempDir, "wal"),
+		},
+		BlocklistPoll: 0,
+	}, log.NewNopLogger())
+	assert.NoError(t, err)
+
+	sharder := &mockSharder{}
+
+	c.EnableCompaction(&CompactorConfig{
+		ChunkSizeBytes:          10,
+		MaxCompactionRange:      24 * time.Hour,
+		BlockRetention:          0,
+		CompactedBlockRetention: 0,
+	}, sharder, &mockOverrides{})
+
+	r.EnablePolling(&mockJobSharder{})
+
+	// Cut x blocks with y records each
+	blockCount := 5
+	recordCount := 7
+	cutTestBlocks(t, w, testTenantID, blockCount, recordCount)
+
+	rw := r.(*readerWriter)
+	rw.pollBlocklist()
+
+	// compact everything
+	err = rw.compact(rw.blocklist.Metas(testTenantID), testTenantID)
+	assert.NoError(t, err)
+
+	require.Equal(t, blockCount*recordCount, sharder.combinerCallCount)
 }
 
 func TestCompactionIteratesThroughTenants(t *testing.T) {

--- a/tempodb/encoding/common/interfaces.go
+++ b/tempodb/encoding/common/interfaces.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/tempodb/backend"
 )
@@ -41,6 +42,7 @@ type CompactionOptions struct {
 	PrefetchTraceCount int // How many traces to prefetch async.
 	OutputBlocks       uint8
 	BlockConfig        BlockConfig
+	Combiner           model.ObjectCombiner
 }
 
 func DefaultCompactionOptions() CompactionOptions {

--- a/tempodb/encoding/v2/compactor.go
+++ b/tempodb/encoding/v2/compactor.go
@@ -64,12 +64,14 @@ func (*Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader, w
 		iters = append(iters, iter)
 	}
 
-	//compactionLevelLabel := strconv.Itoa(int(compactionLevel))
 	nextCompactionLevel := compactionLevel + 1
 
 	recordsPerBlock := (totalRecords / int(opts.OutputBlocks))
 
-	combiner := model.StaticCombiner
+	combiner := opts.Combiner
+	if combiner == nil {
+		combiner = model.StaticCombiner
+	}
 
 	var currentBlock *StreamingBlock
 	var tracker backend.AppendTracker


### PR DESCRIPTION
**What this PR does**:
This PR fixes some things that were broken by refactor #1351.  (1) the `compaction_objects_combined_total` metric is now populated again.  (2) the per-tenant override `max_bytes_per_trace` is honored again, and the corresponding metric `tempo_discarded_spans_total{reason="trace_too_large_to_compact"}` populated.  

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`