### PR TITLE
Per tenant max search duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main / unreleased
 
 * [BUGFIX] metrics-generator: don't inject X-Scope-OrgID header for single-tenant setups [1417](https://github.com/grafana/tempo/pull/1417) (@kvrhdn)
+* [ENHANCEMENT] Added the ability to have a per tenant max search duration. [#1421](https://github.com/grafana/tempo/pull/1421) (@joe-elliott)
 
 ## v1.4.0 / 2022-04-28
 

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -215,7 +215,7 @@ func (t *App) initQueryFrontend() (services.Service, error) {
 	t.frontend = v1
 
 	// create query frontend
-	queryFrontend, err := frontend.New(t.cfg.Frontend, cortexTripper, t.store, log.Logger, prometheus.DefaultRegisterer)
+	queryFrontend, err := frontend.New(t.cfg.Frontend, cortexTripper, t.overrides, t.store, log.Logger, prometheus.DefaultRegisterer)
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +327,7 @@ func (t *App) setupModuleManager() error {
 		// Store:        nil,
 		Overrides:            {Server},
 		MemberlistKV:         {Server},
-		QueryFrontend:        {Store, Server},
+		QueryFrontend:        {Store, Server, Overrides},
 		Ring:                 {Server, MemberlistKV},
 		MetricsGeneratorRing: {Server, MemberlistKV},
 		Distributor:          {Ring, Server, Overrides},

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -988,12 +988,12 @@ overrides:
     # actually writing these metrics.
     [metrics_generator_disable_collection: <bool> | default = false]
 
-    # Per-user block retention. If this value is set to 0 (default) then block_retention
-    #  in the compactor config is used.
+    # Per-user block retention. If this value is set to 0 (default), then block_retention
+    #  in the compactor configuration is used.
     [block_retention: <duration> | default = 0s]
 
-    # Per-user max search duration. If this value is set to 0 (default) then max_duration
-    #  in the frontend config is used.
+    # Per-user max search duration. If this value is set to 0 (default), then max_duration
+    #  in the front-end configuration is used.
     [max_search_duration: <duration> | default = 0s]
 
     # Tenant-specific overrides settings configuration file. The empty string (default

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -987,7 +987,15 @@ overrides:
     # This setting is useful if you wish to test how many active series a tenant will generate, without
     # actually writing these metrics.
     [metrics_generator_disable_collection: <bool> | default = false]
-      
+
+    # Per-user block retention. If this value is set to 0 (default) then block_retention
+    #  in the compactor config is used.
+    [block_retention: <duration> | default = 0s]
+
+    # Per-user max search duration. If this value is set to 0 (default) then max_duration
+    #  in the frontend config is used.
+    [max_search_duration: <duration> | default = 0s]
+
     # Tenant-specific overrides settings configuration file. The empty string (default
     # value) disables using an overrides file.
     [per_tenant_override_config: <string> | default = ""]

--- a/docs/tempo/website/configuration/manifest.md
+++ b/docs/tempo/website/configuration/manifest.md
@@ -112,7 +112,7 @@ ingester_client:
   remote_timeout: 5s
   grpc_client_config:
     max_recv_msg_size: 104857600
-    max_send_msg_size: 16777216
+    max_send_msg_size: 104857600
     grpc_compression: snappy
     rate_limit: 0
     rate_limit_burst: 0
@@ -135,7 +135,7 @@ metrics_generator_client:
   remote_timeout: 5s
   grpc_client_config:
     max_recv_msg_size: 104857600
-    max_send_msg_size: 16777216
+    max_send_msg_size: 104857600
     grpc_compression: snappy
     rate_limit: 0
     rate_limit_burst: 0
@@ -316,9 +316,13 @@ ingester:
     join_after: 0s
     min_ready_duration: 15s
     interface_names:
-      - eth0
-      - en0
-    final_sleep: 30s
+      - wlp2s0
+      - docker0
+      - br-f163873defd4
+      - br-f56e9de73d01
+      - br-16536cce4aa3
+      - br-3bc02eb7efdd
+    final_sleep: 0s
     tokens_file_path: ""
     availability_zone: ""
     unregister_on_shutdown: true
@@ -384,6 +388,7 @@ metrics_generator:
         - 3.2
         - 6.4
         - 12.8
+      dimensions: []
     span_metrics:
       histogram_buckets:
         - 0.002
@@ -448,9 +453,9 @@ storage:
       bucket_name: ""
       chunk_buffer_size: 10485760
       endpoint: ""
-      insecure: false
       hedge_requests_at: 0s
       hedge_requests_up_to: 2
+      insecure: false
       object_cache_control: ""
       object_metadata: {}
     s3:
@@ -494,8 +499,12 @@ overrides:
   metrics_generator_processors: null
   metrics_generator_max_active_series: 0
   metrics_generator_collection_interval: 0s
+  metrics_generator_disable_collection: false
+  metrics_generator_forwarder_queue_size: 0
+  metrics_generator_forwarder_workers: 0
   block_retention: 0s
   max_bytes_per_tag_values_query: 5000000
+  max_search_duration: 0s
   max_bytes_per_trace: 5000000
   per_tenant_override_config: ""
   per_tenant_override_period: 10s

--- a/example/tk/lib/dashboards/grafana.libsonnet
+++ b/example/tk/lib/dashboards/grafana.libsonnet
@@ -7,7 +7,7 @@ local mixins = import 'mixins.libsonnet';
   deploy(frontend_url='http://query-frontend'):
     grafana
     + grafana.withReplicas(1)
-    + grafana.withImage('grafana/grafana:8.3.0-beta2')
+    + grafana.withImage('grafana/grafana:8.5.2')
     + grafana.withRootUrl('http://grafana')
     + grafana.withTheme('dark')
     + grafana.withAnonymous()
@@ -15,7 +15,7 @@ local mixins = import 'mixins.libsonnet';
     + grafana.withGrafanaIniConfig({
       sections+: {
         feature_toggles: {
-          enable: 'tempoSearch',
+          enable: 'tempoSearch tempoBackendSearch',
         },
       },
     })

--- a/modules/frontend/config.go
+++ b/modules/frontend/config.go
@@ -25,7 +25,7 @@ type Config struct {
 }
 
 type SearchConfig struct {
-	Sharder SearchSharderConfig `yaml:",inline"` // jpe - what did this look like before
+	Sharder SearchSharderConfig `yaml:",inline"`
 }
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {

--- a/modules/frontend/frontend_test.go
+++ b/modules/frontend/frontend_test.go
@@ -31,7 +31,7 @@ func TestFrontendRoundTripsSearch(t *testing.T) {
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			},
 		},
-	}, next, nil, log.NewNopLogger(), nil)
+	}, next, nil, nil, log.NewNopLogger(), nil)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest("GET", "/", nil)
@@ -50,7 +50,7 @@ func TestFrontendBadConfigFails(t *testing.T) {
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			},
 		},
-	}, nil, nil, log.NewNopLogger(), nil)
+	}, nil, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "frontend query shards should be between 2 and 256 (both inclusive)")
 	assert.Nil(t, f)
 
@@ -61,7 +61,7 @@ func TestFrontendBadConfigFails(t *testing.T) {
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			},
 		},
-	}, nil, nil, log.NewNopLogger(), nil)
+	}, nil, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "frontend query shards should be between 2 and 256 (both inclusive)")
 	assert.Nil(t, f)
 
@@ -72,7 +72,7 @@ func TestFrontendBadConfigFails(t *testing.T) {
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			},
 		},
-	}, nil, nil, log.NewNopLogger(), nil)
+	}, nil, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "frontend search concurrent requests should be greater than 0")
 	assert.Nil(t, f)
 
@@ -83,7 +83,7 @@ func TestFrontendBadConfigFails(t *testing.T) {
 				TargetBytesPerRequest: 0,
 			},
 		},
-	}, nil, nil, log.NewNopLogger(), nil)
+	}, nil, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "frontend search target bytes per request should be greater than 0")
 	assert.Nil(t, f)
 
@@ -96,7 +96,7 @@ func TestFrontendBadConfigFails(t *testing.T) {
 				QueryBackendAfter:     time.Hour,
 			},
 		},
-	}, nil, nil, log.NewNopLogger(), nil)
+	}, nil, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "query backend after should be less than or equal to query ingester until")
 	assert.Nil(t, f)
 }

--- a/modules/frontend/searchsharding.go
+++ b/modules/frontend/searchsharding.go
@@ -191,7 +191,7 @@ func (s searchSharder) RoundTrip(r *http.Request) (*http.Response, error) {
 	if maxDuration != 0 && time.Duration(searchReq.End-searchReq.Start)*time.Second > maxDuration {
 		return &http.Response{
 			StatusCode: http.StatusBadRequest,
-			Body:       io.NopCloser(strings.NewReader(fmt.Sprintf("range specified by start and end exceeds %s. received start=%d end=%d", s.cfg.MaxDuration, searchReq.Start, searchReq.End))),
+			Body:       io.NopCloser(strings.NewReader(fmt.Sprintf("range specified by start and end exceeds %s. received start=%d end=%d", maxDuration, searchReq.Start, searchReq.End))),
 		}, nil
 	}
 

--- a/modules/overrides/limits.go
+++ b/modules/overrides/limits.go
@@ -70,6 +70,9 @@ type Limits struct {
 	// Querier enforced limits.
 	MaxBytesPerTagValuesQuery int `yaml:"max_bytes_per_tag_values_query" json:"max_bytes_per_tag_values_query"`
 
+	// QueryFrontend enforced limits
+	MaxSearchDuration model.Duration `yaml:"max_search_duration" json:"max_search_duration"`
+
 	// MaxBytesPerTrace is enforced in the Ingester, Compactor, Querier (Search) and Serverless (Search). It
 	//  it not enforce currently when doing a trace by id lookup.
 	MaxBytesPerTrace int `yaml:"max_bytes_per_trace" json:"max_bytes_per_trace"`

--- a/modules/overrides/limits_test.go
+++ b/modules/overrides/limits_test.go
@@ -53,6 +53,8 @@ per_tenant_override_period: 1m
 
 metrics_generator_send_queue_size: 10
 metrics_generator_send_workers: 1
+
+max_search_duration: 5m
 `
 	inputJSON := `
 {
@@ -73,7 +75,9 @@ metrics_generator_send_workers: 1
 	"per_tenant_override_period": "1m",
 
 	"metrics_generator_send_queue_size": 10,
-	"metrics_generator_send_workers": 1
+	"metrics_generator_send_workers": 1,
+
+	"max_search_duration": "5m"
 }`
 
 	limitsYAML := Limits{}

--- a/modules/overrides/overrides.go
+++ b/modules/overrides/overrides.go
@@ -307,6 +307,11 @@ func (o *Overrides) BlockRetention(userID string) time.Duration {
 	return time.Duration(o.getOverridesForUser(userID).BlockRetention)
 }
 
+// MaxSearchDuration is the duration of the max search duration for this tenant.
+func (o *Overrides) MaxSearchDuration(userID string) time.Duration {
+	return time.Duration(o.getOverridesForUser(userID).MaxSearchDuration)
+}
+
 func (o *Overrides) getOverridesForUser(userID string) *Limits {
 	if tenantOverrides := o.tenantOverrides(); tenantOverrides != nil {
 		l := tenantOverrides.forUser(userID)

--- a/modules/overrides/overrides_test.go
+++ b/modules/overrides/overrides_test.go
@@ -28,22 +28,22 @@ func TestOverrides(t *testing.T) {
 		expectedIngestionBurstSpans map[string]int
 		expectedMaxSearchDuration   map[string]int
 	}{
-		// {
-		// 	name: "limits only",
-		// 	limits: Limits{
-		// 		MaxGlobalTracesPerUser:  1,
-		// 		MaxLocalTracesPerUser:   2,
-		// 		MaxBytesPerTrace:        3,
-		// 		IngestionBurstSizeBytes: 4,
-		// 		IngestionRateLimitBytes: 5,
-		// 	},
-		// 	expectedMaxGlobalTraces:     map[string]int{"user1": 1, "user2": 1},
-		// 	expectedMaxLocalTraces:      map[string]int{"user1": 2, "user2": 2},
-		// 	expectedMaxBytesPerTrace:    map[string]int{"user1": 3, "user2": 3},
-		// 	expectedIngestionBurstSpans: map[string]int{"user1": 4, "user2": 4},
-		// 	expectedIngestionRateSpans:  map[string]int{"user1": 5, "user2": 5},
-		// 	expectedMaxSearchDuration:   map[string]int{"user1": 0, "user2": 0},
-		// },
+		{
+			name: "limits only",
+			limits: Limits{
+				MaxGlobalTracesPerUser:  1,
+				MaxLocalTracesPerUser:   2,
+				MaxBytesPerTrace:        3,
+				IngestionBurstSizeBytes: 4,
+				IngestionRateLimitBytes: 5,
+			},
+			expectedMaxGlobalTraces:     map[string]int{"user1": 1, "user2": 1},
+			expectedMaxLocalTraces:      map[string]int{"user1": 2, "user2": 2},
+			expectedMaxBytesPerTrace:    map[string]int{"user1": 3, "user2": 3},
+			expectedIngestionBurstSpans: map[string]int{"user1": 4, "user2": 4},
+			expectedIngestionRateSpans:  map[string]int{"user1": 5, "user2": 5},
+			expectedMaxSearchDuration:   map[string]int{"user1": 0, "user2": 0},
+		},
 		{
 			name: "basic overrides",
 			limits: Limits{

--- a/modules/overrides/overrides_test.go
+++ b/modules/overrides/overrides_test.go
@@ -26,22 +26,24 @@ func TestOverrides(t *testing.T) {
 		expectedMaxBytesPerTrace    map[string]int
 		expectedIngestionRateSpans  map[string]int
 		expectedIngestionBurstSpans map[string]int
+		expectedMaxSearchDuration   map[string]int
 	}{
-		{
-			name: "limits only",
-			limits: Limits{
-				MaxGlobalTracesPerUser:  1,
-				MaxLocalTracesPerUser:   2,
-				MaxBytesPerTrace:        3,
-				IngestionBurstSizeBytes: 4,
-				IngestionRateLimitBytes: 5,
-			},
-			expectedMaxGlobalTraces:     map[string]int{"user1": 1, "user2": 1},
-			expectedMaxLocalTraces:      map[string]int{"user1": 2, "user2": 2},
-			expectedMaxBytesPerTrace:    map[string]int{"user1": 3, "user2": 3},
-			expectedIngestionBurstSpans: map[string]int{"user1": 4, "user2": 4},
-			expectedIngestionRateSpans:  map[string]int{"user1": 5, "user2": 5},
-		},
+		// {
+		// 	name: "limits only",
+		// 	limits: Limits{
+		// 		MaxGlobalTracesPerUser:  1,
+		// 		MaxLocalTracesPerUser:   2,
+		// 		MaxBytesPerTrace:        3,
+		// 		IngestionBurstSizeBytes: 4,
+		// 		IngestionRateLimitBytes: 5,
+		// 	},
+		// 	expectedMaxGlobalTraces:     map[string]int{"user1": 1, "user2": 1},
+		// 	expectedMaxLocalTraces:      map[string]int{"user1": 2, "user2": 2},
+		// 	expectedMaxBytesPerTrace:    map[string]int{"user1": 3, "user2": 3},
+		// 	expectedIngestionBurstSpans: map[string]int{"user1": 4, "user2": 4},
+		// 	expectedIngestionRateSpans:  map[string]int{"user1": 5, "user2": 5},
+		// 	expectedMaxSearchDuration:   map[string]int{"user1": 0, "user2": 0},
+		// },
 		{
 			name: "basic overrides",
 			limits: Limits{
@@ -59,6 +61,7 @@ func TestOverrides(t *testing.T) {
 						MaxBytesPerTrace:        8,
 						IngestionBurstSizeBytes: 9,
 						IngestionRateLimitBytes: 10,
+						MaxSearchDuration:       model.Duration(11 * time.Second),
 					},
 				},
 			},
@@ -67,6 +70,7 @@ func TestOverrides(t *testing.T) {
 			expectedMaxBytesPerTrace:    map[string]int{"user1": 8, "user2": 3},
 			expectedIngestionBurstSpans: map[string]int{"user1": 9, "user2": 4},
 			expectedIngestionRateSpans:  map[string]int{"user1": 10, "user2": 5},
+			expectedMaxSearchDuration:   map[string]int{"user1": int(11 * time.Second), "user2": 0},
 		},
 		{
 			name: "wildcard override",
@@ -92,6 +96,7 @@ func TestOverrides(t *testing.T) {
 						MaxBytesPerTrace:        13,
 						IngestionBurstSizeBytes: 14,
 						IngestionRateLimitBytes: 15,
+						MaxSearchDuration:       model.Duration(16 * time.Second),
 					},
 				},
 			},
@@ -100,11 +105,12 @@ func TestOverrides(t *testing.T) {
 			expectedMaxBytesPerTrace:    map[string]int{"user1": 8, "user2": 13},
 			expectedIngestionBurstSpans: map[string]int{"user1": 9, "user2": 14},
 			expectedIngestionRateSpans:  map[string]int{"user1": 10, "user2": 15},
+			expectedMaxSearchDuration:   map[string]int{"user1": 0, "user2": int(16 * time.Second)},
 		},
 	}
 
 	for _, tt := range tests {
-		t.Run(t.Name(), func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			if tt.overrides != nil {
 				overridesFile := filepath.Join(t.TempDir(), "overrides.yaml")
 
@@ -138,6 +144,10 @@ func TestOverrides(t *testing.T) {
 
 			for user, expectedVal := range tt.expectedIngestionRateSpans {
 				assert.Equal(t, float64(expectedVal), overrides.IngestionRateLimitBytes(user))
+			}
+
+			for user, expectedVal := range tt.expectedMaxSearchDuration {
+				assert.Equal(t, time.Duration(expectedVal), overrides.MaxSearchDuration(user))
 			}
 
 			//if srv != nil {

--- a/operations/jsonnet/microservices/frontend.libsonnet
+++ b/operations/jsonnet/microservices/frontend.libsonnet
@@ -12,6 +12,7 @@
   local tempo_config_volume = 'tempo-conf',
   local tempo_query_config_volume = 'tempo-query-conf',
   local tempo_data_volume = 'tempo-data',
+  local tempo_overrides_config_volume = 'overrides',
 
   tempo_query_frontend_container::
     container.new(target_name, $._images.tempo) +
@@ -26,6 +27,7 @@
     (if $._config.variables_expansion then container.withEnvMixin($._config.variables_expansion_env_mixin) else {}) +
     container.withVolumeMounts([
       volumeMount.new(tempo_config_volume, '/conf'),
+      volumeMount.new(tempo_overrides_config_volume, '/overrides'),
     ]) +
     $.util.withResources($._config.query_frontend.resources) +
     $.util.readinessProbe +
@@ -63,6 +65,7 @@
     deployment.mixin.spec.template.spec.withVolumes([
       volume.fromConfigMap(tempo_query_config_volume, $.tempo_query_configmap.metadata.name),
       volume.fromConfigMap(tempo_config_volume, $.tempo_query_frontend_configmap.metadata.name),
+      volume.fromConfigMap(tempo_overrides_config_volume, $._config.overrides_configmap_name),
     ]),
 
   tempo_query_frontend_service:

--- a/operations/kube-manifests/Deployment-query-frontend.yaml
+++ b/operations/kube-manifests/Deployment-query-frontend.yaml
@@ -50,6 +50,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: tempo-conf
+        - mountPath: /overrides
+          name: overrides
       - args:
         - --query.base-path=/tempo
         - --grpc-storage-plugin.configuration-file=/conf/tempo-query.yaml
@@ -72,3 +74,6 @@ spec:
       - configMap:
           name: tempo-query-frontend
         name: tempo-conf
+      - configMap:
+          name: tempo-overrides
+        name: overrides

--- a/tempodb/wal/wal_test.go
+++ b/tempodb/wal/wal_test.go
@@ -165,7 +165,7 @@ func TestErrorConditions(t *testing.T) {
 	require.NoFileExists(t, filepath.Join(tempDir, "fe0b83eb-a86b-4b6c-9a74-dc272cd5700e:blerg:v2:gzip"))
 }
 
-func TestAppendBlockStartEnd(t *testing.T) { // jpe extend
+func TestAppendBlockStartEnd(t *testing.T) {
 	wal, err := New(&Config{
 		Filepath:       t.TempDir(),
 		Encoding:       backend.EncNone,


### PR DESCRIPTION
**What this PR does**:
Adds the ability to have a per tenant max search duration. By default, if there is no per tenant configuration, the original config value is used. This PR also updates the jsonnet under `./operations` to mount the overrides yaml onto the frontend.

Additional changes
- Documentation as well as catching the missing `block_retention` override
- Updated the jsonnet example to use full backend search

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`