### PR TITLE
distributor: prevent panics when concurrently calling  to forwarder's…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [BUGFIX] metrics-generator: don't inject X-Scope-OrgID header for single-tenant setups [1417](https://github.com/grafana/tempo/pull/1417) (@kvrhdn)
 * [BUGFIX] compactor: populate `compaction_objects_combined_total` and `tempo_discarded_spans_total{reason="trace_too_large_to_compact"}` metrics again [1420](https://github.com/grafana/tempo/pull/1420) (@mdisibio)
+* [BUGFIX] distributor: prevent panics when concurrently calling `shutdown` to forwarder's queueManager [](https://github.com/grafana/tempo/pull/) (@mapno)
 
 ## v1.4.0 / 2022-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * [BUGFIX] metrics-generator: don't inject X-Scope-OrgID header for single-tenant setups [1417](https://github.com/grafana/tempo/pull/1417) (@kvrhdn)
 * [BUGFIX] compactor: populate `compaction_objects_combined_total` and `tempo_discarded_spans_total{reason="trace_too_large_to_compact"}` metrics again [1420](https://github.com/grafana/tempo/pull/1420) (@mdisibio)
-* [BUGFIX] distributor: prevent panics when concurrently calling `shutdown` to forwarder's queueManager [](https://github.com/grafana/tempo/pull/) (@mapno)
+* [BUGFIX] distributor: prevent panics when concurrently calling `shutdown` to forwarder's queueManager [1422](https://github.com/grafana/tempo/pull/1422) (@mapno)
 
 ## v1.4.0 / 2022-04-28
 

--- a/integration/bench/load_test.go
+++ b/integration/bench/load_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	k6Image = "loadimpact/k6:latest"
+	k6Image = "loadimpact/k6:0.37.0"
 )
 
 func TestAllInOne(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:

Prevent panics when concurrently calling `shutdown` to forwarder's queueManager.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`