### PR TITLE
Update website docs with release v1.4.1

### DIFF
--- a/docs/tempo/website/release-notes/v1-4.md
+++ b/docs/tempo/website/release-notes/v1-4.md
@@ -68,8 +68,8 @@ When upgrading to Tempo v1.4, be aware of these breaking changes:
 
 ### 1.4.1 bug fixes
 
-- [PR 1417](https://github.com/grafana/tempo/pull/1417) metrics-generator: don't inject X-Scope-OrgID header for single-tenant setups.
+- [PR 1417](https://github.com/grafana/tempo/pull/1417) Metrics-generator: don't inject X-Scope-OrgID header for single-tenant setups.
 
-- [PR 1420](https://github.com/grafana/tempo/pull/1420) compactor: populate `compaction_objects_combined_total` and `tempo_discarded_spans_total{reason="trace_too_large_to_compact"}` metrics again.
+- [PR 1420](https://github.com/grafana/tempo/pull/1420) Compactor: populate `compaction_objects_combined_total` and `tempo_discarded_spans_total{reason="trace_too_large_to_compact"}` metrics again.
 
-- [PR 1422](https://github.com/grafana/tempo/pull/1422) distributor: prevent panics when concurrently calling `shutdown` to forwarder's queueManager.
+- [PR 1422](https://github.com/grafana/tempo/pull/1422) Distributor: prevent panics when concurrently calling `shutdown` to forwarder's queueManager.

--- a/docs/tempo/website/release-notes/v1-4.md
+++ b/docs/tempo/website/release-notes/v1-4.md
@@ -65,3 +65,11 @@ When upgrading to Tempo v1.4, be aware of these breaking changes:
 - [PR 1389](https://github.com/grafana/tempo/pull/1389) Eliminate spurious "failed to mark block compacted during retention" errors.
 
 - [PR 1379](https://github.com/grafana/tempo/pull/1379) Eliminate an error with the message "Writer is closed" by resetting the compression writer correctly on the error path.
+
+### 1.4.1 bug fixes
+
+- [PR 1417](https://github.com/grafana/tempo/pull/1417) metrics-generator: don't inject X-Scope-OrgID header for single-tenant setups.
+
+- [PR 1420](https://github.com/grafana/tempo/pull/1420) compactor: populate `compaction_objects_combined_total` and `tempo_discarded_spans_total{reason="trace_too_large_to_compact"}` metrics again.
+
+- [PR 1422](https://github.com/grafana/tempo/pull/1422) distributor: prevent panics when concurrently calling `shutdown` to forwarder's queueManager.


### PR DESCRIPTION
**What this PR does**:

Update release notes for patch release [v1.4.1](https://github.com/grafana/tempo/releases/tag/v1.4.1)