### PR TITLE
Update bench test for k6 v0.38.0 release

### DIFF
--- a/integration/bench/load_test.go
+++ b/integration/bench/load_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	k6Image = "loadimpact/k6:0.37.0"
+	k6Image = "loadimpact/k6:latest"
 )
 
 func TestAllInOne(t *testing.T) {

--- a/integration/bench/smoke_test.js
+++ b/integration/bench/smoke_test.js
@@ -25,7 +25,6 @@ export const options = {
     readPath: {
       exec: 'readPath',
       executor: 'constant-vus',
-      startTime: '2s',
       vus: 1,
       duration: '30s',
     },
@@ -63,6 +62,8 @@ export function writePath() {
 }
 
 export function readPath() {
+  sleep(READ_WAIT);
+
   randomSeed(START_TIME + __ITER);
 
   var traceId = generateId(14);
@@ -76,8 +77,6 @@ export function readPath() {
   check(res, {
     'read status is 200': (r) => r.status === 200,
   }, { type: 'read' });
-
-  sleep(READ_WAIT);
 }
 
 export function steadyStateCheck() {

--- a/integration/bench/stress_test_write_path.js
+++ b/integration/bench/stress_test_write_path.js
@@ -59,13 +59,13 @@ export function writePath() {
 
 export function steadyStateCheck() {
   // Check Distributors health
-  res = http.get(`${DISTRIBUTOR_ENDPOINT}/ready`);
+  let res = http.get(`${DISTRIBUTOR_ENDPOINT}/ready`);
   check(res, {
     'distributor is status 200': (r) => r.status === 200
   }, { type: 'steady', service: 'ingester' });
 
   // Check Ingesters health
-  let res = http.get(`${INGESTER_ENDPOINT}/ready`);
+  res = http.get(`${INGESTER_ENDPOINT}/ready`);
   check(res, {
     'ingester is status 200': (r) => r.status === 200
   }, { type: 'steady', service: 'ingester' });


### PR DESCRIPTION
**What this PR does**:

Release v0.38.0 from k6 introduced a series of bugfixes and enhancements so our bench tests no longer pass. This PR updates the scripts for this new version.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`