### PR TITLE
[Feature] Add error span logging processor

### DIFF
--- a/example/docker-compose/error-span-logging/docker-compose.yaml
+++ b/example/docker-compose/error-span-logging/docker-compose.yaml
@@ -1,0 +1,71 @@
+version: "3"
+services:
+
+  tempo:
+    image: grafana/tempo:latest
+    command: [ "-config.file=/etc/tempo.yaml" ]
+    volumes:
+      - ./tempo.yaml:/etc/tempo.yaml
+      - ./tempo-data/:/tmp/tempo
+    ports:
+      - "3200:3200"   # tempo
+      - "14268"  # jaeger ingest
+    depends_on:
+      - loki
+    logging:
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/loki/api/v1/push'
+
+  synthetic-load-generator:
+    image: omnition/synthetic-load-generator:1.0.25
+    volumes:
+      - ../shared/load-generator.json:/etc/load-generator.json
+    environment:
+      - TOPOLOGY_FILE=/etc/load-generator.json
+      - JAEGER_COLLECTOR_URL=http://tempo:14268
+    depends_on:
+      - tempo
+
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ../shared/prometheus.yaml:/etc/prometheus.yaml
+    ports:
+      - "9090:9090"
+    command: [
+      "--config.file=/etc/prometheus/prometheus.yml",
+      "--storage.tsdb.path=/prometheus",
+      "--web.console.libraries=/usr/share/prometheus/console_libraries",
+      "--web.console.templates=/usr/share/prometheus/consoles",
+      "--enable-feature=exemplar-storage",
+      "--web.enable-remote-write-receiver"
+    ]
+
+  grafana:
+    image: grafana/grafana:latest
+    volumes:
+      - ./grafana.ini:/etc/grafana/grafana.ini
+      - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+    ports:
+      - "3000:3000"
+    depends_on:
+      - loki
+    logging:
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/loki/api/v1/push'
+
+  loki:
+    image: grafana/loki:latest
+    command: [ "-config.file=/etc/loki/local-config.yaml" ]
+    ports:
+      - "3100:3100"
+    logging:
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/loki/api/v1/push'

--- a/example/docker-compose/error-span-logging/grafana-datasources.yaml
+++ b/example/docker-compose/error-span-logging/grafana-datasources.yaml
@@ -1,0 +1,39 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    uid: prometheus
+    url: http://prometheus:9090
+    jsonData:
+      exemplarTraceIdDestinations:
+        - datasourceUid: tempo
+          name: traceID
+      httpMethod: POST
+      timeInterval: "2s"
+  - name: Tempo
+    type: tempo
+    access: proxy
+    uid: tempo
+    url: http://tempo:3200
+    jsonData:
+      nodeGraph:
+        enabled: true
+      serviceMap:
+        datasourceUid: 'Prometheus'
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    basicAuth: false
+    isDefault: false
+    version: 1
+    editable: false
+    apiVersion: 1
+    jsonData:
+      derivedFields:
+        - datasourceUid: tempo
+          matcherRegex: (?:traceID|trace_id)=(\w+)
+          name: TraceID
+          url: $${__value.raw}

--- a/example/docker-compose/error-span-logging/grafana.ini
+++ b/example/docker-compose/error-span-logging/grafana.ini
@@ -1,0 +1,2 @@
+[feature_toggles]
+enable = tempoSearch tempoServiceGraph

--- a/example/docker-compose/error-span-logging/tempo-query.yaml
+++ b/example/docker-compose/error-span-logging/tempo-query.yaml
@@ -1,0 +1,1 @@
+backend: "tempo:3200"

--- a/example/docker-compose/error-span-logging/tempo.yaml
+++ b/example/docker-compose/error-span-logging/tempo.yaml
@@ -1,0 +1,67 @@
+search_enabled: true
+metrics_generator_enabled: true
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  search_tags_deny_list:
+    - "instance"
+    - "version"
+  receivers:                           # this configuration will listen on all ports and protocols that tempo is capable of.
+    jaeger:                            # the receives all come from the OpenTelemetry collector.  more configuration information can
+      protocols:                       # be found there: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver
+        thrift_http:                   #
+        grpc:                          # for a production deployment you should only enable the receivers you need!
+        thrift_binary:
+        thrift_compact:
+    zipkin:
+    otlp:
+      protocols:
+        http:
+        grpc:
+    opencensus:
+
+ingester:
+  trace_idle_period: 10s               # the length of time after a trace has not received spans to consider it complete and flush it
+  max_block_bytes: 1_000_000           # cut the head block when it hits this size or ...
+  max_block_duration: 5m               #   this much time passes
+
+compactor:
+  compaction:
+    compaction_window: 1h              # blocks in this time window will be compacted together
+    max_block_bytes: 100_000_000       # maximum size of compacted blocks
+    block_retention: 1h
+    compacted_block_retention: 10m
+
+storage:
+  trace:
+    backend: local                     # backend configuration to use
+    block:
+      bloom_filter_false_positive: .05 # bloom filter false positive rate.  lower values create larger filters but fewer false positives
+      index_downsample_bytes: 1000     # number of bytes per index record
+      encoding: zstd                   # block encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd, s2
+    wal:
+      path: /tmp/tempo/wal             # where to store the the wal locally
+      encoding: snappy                 # wal encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd, s2
+    local:
+      path: /tmp/tempo/blocks
+    pool:
+      max_workers: 100                 # worker pool determines the number of parallel requests to the object store backend
+      queue_depth: 10000
+
+metrics_generator:
+  processor:
+    span_metrics:
+      dimensions:
+        - http.method
+        - http.status_code
+        - http.target
+  storage:
+    path: /tmp/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true
+
+overrides:
+  metrics_generator_processors: ['service-graphs', 'span-metrics', 'error-span-logging']

--- a/modules/generator/config.go
+++ b/modules/generator/config.go
@@ -3,6 +3,7 @@ package generator
 import (
 	"flag"
 
+	"github.com/grafana/tempo/modules/generator/processor/errorspanlogging"
 	"github.com/grafana/tempo/modules/generator/processor/servicegraphs"
 	"github.com/grafana/tempo/modules/generator/processor/spanmetrics"
 	"github.com/grafana/tempo/modules/generator/registry"
@@ -34,8 +35,9 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 }
 
 type ProcessorConfig struct {
-	ServiceGraphs servicegraphs.Config `yaml:"service_graphs"`
-	SpanMetrics   spanmetrics.Config   `yaml:"span_metrics"`
+	ServiceGraphs    servicegraphs.Config    `yaml:"service_graphs"`
+	SpanMetrics      spanmetrics.Config      `yaml:"span_metrics"`
+	ErrorSpanLogging errorspanlogging.Config `yaml:"error_span_logs"`
 }
 
 func (cfg *ProcessorConfig) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {

--- a/modules/generator/instance.go
+++ b/modules/generator/instance.go
@@ -181,6 +181,10 @@ func (i *instance) diffProcessors(desiredProcessors map[string]struct{}, desired
 			if !reflect.DeepEqual(p.Cfg, desiredCfg.ServiceGraphs) {
 				toReplace = append(toReplace, processorName)
 			}
+		case *errorspanlogging.Processor:
+			if !reflect.DeepEqual(p.Cfg, desiredCfg.ErrorSpanLogging) {
+				toReplace = append(toReplace, processorName)
+			}
 		default:
 			level.Error(i.logger).Log(
 				"msg", fmt.Sprintf("processor does not exist, supported processors: [%s]", strings.Join(allSupportedProcessors, ", ")),

--- a/modules/generator/instance.go
+++ b/modules/generator/instance.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/grafana/tempo/modules/generator/processor"
+	"github.com/grafana/tempo/modules/generator/processor/errorspanlogging"
 	"github.com/grafana/tempo/modules/generator/processor/servicegraphs"
 	"github.com/grafana/tempo/modules/generator/processor/spanmetrics"
 	"github.com/grafana/tempo/modules/generator/registry"
@@ -22,7 +23,7 @@ import (
 )
 
 var (
-	allSupportedProcessors = []string{servicegraphs.Name, spanmetrics.Name}
+	allSupportedProcessors = []string{servicegraphs.Name, spanmetrics.Name, errorspanlogging.Name}
 
 	metricActiveProcessors = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "tempo",
@@ -203,6 +204,8 @@ func (i *instance) addProcessor(processorName string, cfg ProcessorConfig) error
 		newProcessor = spanmetrics.New(cfg.SpanMetrics, i.registry)
 	case servicegraphs.Name:
 		newProcessor = servicegraphs.New(cfg.ServiceGraphs, i.instanceID, i.registry, i.logger)
+	case errorspanlogging.Name:
+		newProcessor = errorspanlogging.New(cfg.ErrorSpanLogging, i.logger)
 	default:
 		level.Error(i.logger).Log(
 			"msg", fmt.Sprintf("processor does not exist, supported processors: [%s]", strings.Join(allSupportedProcessors, ", ")),

--- a/modules/generator/processor/errorspanlogging/config.go
+++ b/modules/generator/processor/errorspanlogging/config.go
@@ -1,0 +1,8 @@
+package errorspanlogging
+
+const (
+	Name = "error-span-logging"
+)
+
+type Config struct {
+}

--- a/modules/generator/processor/errorspanlogging/errorspanlogging.go
+++ b/modules/generator/processor/errorspanlogging/errorspanlogging.go
@@ -1,0 +1,90 @@
+package errorspanlogging
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/prometheus/util/strutil"
+
+	gen "github.com/grafana/tempo/modules/generator/processor"
+	processor_util "github.com/grafana/tempo/modules/generator/processor/util"
+	"github.com/grafana/tempo/pkg/tempopb"
+	v1_trace "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	tempo_util "github.com/grafana/tempo/pkg/util"
+)
+
+type processor struct {
+	cfg Config
+
+	logger log.Logger
+
+	// for testing
+	now func() time.Time
+}
+
+func New(cfg Config, logger log.Logger) gen.Processor {
+	return &processor{
+		cfg:    cfg,
+		logger: logger,
+		now:    time.Now,
+	}
+}
+
+func (p *processor) Name() string { return Name }
+
+func (p *processor) PushSpans(ctx context.Context, req *tempopb.PushSpansRequest) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "errorspanlogging.PushSpans")
+	defer span.Finish()
+
+	p.logIfSpanHasError(req.Batches)
+}
+
+func (p *processor) Shutdown(_ context.Context) {
+}
+
+func (p *processor) logIfSpanHasError(resourceSpans []*v1_trace.ResourceSpans) {
+	for _, rs := range resourceSpans {
+		// already extract service name, and resources attributes, so we only have to do it once per batch of spans
+		svcName, _ := processor_util.FindServiceName(rs.Resource.Attributes)
+		logger := p.logger
+		for _, a := range rs.Resource.GetAttributes() {
+			logger = log.With(
+				logger,
+				"span_"+strutil.SanitizeLabelName(a.GetKey()),
+				tempo_util.StringifyAnyValue(a.GetValue()))
+		}
+
+		for _, ils := range rs.InstrumentationLibrarySpans {
+			for _, span := range ils.Spans {
+				if span.GetStatus().GetCode() != v1_trace.Status_STATUS_CODE_ERROR {
+					continue
+				}
+				p.logSpan(svcName, span, logger)
+			}
+		}
+	}
+}
+
+func (p *processor) logSpan(svcName string, span *v1_trace.Span, logger log.Logger) {
+	latencySeconds := float64(span.GetEndTimeUnixNano()-span.GetStartTimeUnixNano()) / float64(time.Second.Nanoseconds())
+
+	logger = log.With(
+		logger,
+		"span_service_name", svcName,
+		"span_name", span.GetName(),
+		"span_kind", span.GetKind().String(),
+		"span_status", span.GetStatus().GetCode().String(),
+		"span_duration_seconds", latencySeconds,
+		"span_trace_id", tempo_util.TraceIDToHexString(span.TraceId))
+
+	for _, a := range span.GetAttributes() {
+		logger = log.With(
+			logger,
+			"span_"+strutil.SanitizeLabelName(a.GetKey()),
+			tempo_util.StringifyAnyValue(a.GetValue()))
+	}
+
+	logger.Log("msg", "error_spans_received")
+}

--- a/modules/generator/processor/errorspanlogging/errorspanlogging.go
+++ b/modules/generator/processor/errorspanlogging/errorspanlogging.go
@@ -15,8 +15,8 @@ import (
 	tempo_util "github.com/grafana/tempo/pkg/util"
 )
 
-type processor struct {
-	cfg Config
+type Processor struct {
+	Cfg Config
 
 	logger log.Logger
 
@@ -25,26 +25,26 @@ type processor struct {
 }
 
 func New(cfg Config, logger log.Logger) gen.Processor {
-	return &processor{
-		cfg:    cfg,
+	return &Processor{
+		Cfg:    cfg,
 		logger: logger,
 		now:    time.Now,
 	}
 }
 
-func (p *processor) Name() string { return Name }
+func (p *Processor) Name() string { return Name }
 
-func (p *processor) PushSpans(ctx context.Context, req *tempopb.PushSpansRequest) {
+func (p *Processor) PushSpans(ctx context.Context, req *tempopb.PushSpansRequest) {
 	span, _ := opentracing.StartSpanFromContext(ctx, "errorspanlogging.PushSpans")
 	defer span.Finish()
 
 	p.logIfSpanHasError(req.Batches)
 }
 
-func (p *processor) Shutdown(_ context.Context) {
+func (p *Processor) Shutdown(_ context.Context) {
 }
 
-func (p *processor) logIfSpanHasError(resourceSpans []*v1_trace.ResourceSpans) {
+func (p *Processor) logIfSpanHasError(resourceSpans []*v1_trace.ResourceSpans) {
 	for _, rs := range resourceSpans {
 		// already extract service name, and resources attributes, so we only have to do it once per batch of spans
 		svcName, _ := processor_util.FindServiceName(rs.Resource.Attributes)
@@ -67,7 +67,7 @@ func (p *processor) logIfSpanHasError(resourceSpans []*v1_trace.ResourceSpans) {
 	}
 }
 
-func (p *processor) logSpan(svcName string, span *v1_trace.Span, logger log.Logger) {
+func (p *Processor) logSpan(svcName string, span *v1_trace.Span, logger log.Logger) {
 	latencySeconds := float64(span.GetEndTimeUnixNano()-span.GetStartTimeUnixNano()) / float64(time.Second.Nanoseconds())
 
 	logger = log.With(

--- a/modules/generator/processor/errorspanlogging/errorspanlogging_test.go
+++ b/modules/generator/processor/errorspanlogging/errorspanlogging_test.go
@@ -1,0 +1,69 @@
+package errorspanlogging
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/go-kit/log"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	trace_v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	"github.com/grafana/tempo/pkg/util/test"
+)
+
+func TestErrorSpanLogging(t *testing.T) {
+	cfg := Config{}
+
+	buf := &bytes.Buffer{}
+	logger := log.NewLogfmtLogger(buf)
+	p := New(cfg, logger)
+	defer p.Shutdown(context.Background())
+
+	batch := test.MakeBatch(1, nil)
+	batch.InstrumentationLibrarySpans[0].Spans[0].Status.Code = trace_v1.Status_STATUS_CODE_ERROR
+
+	p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{batch}})
+
+	logResult := buf.String()
+	if logResult == "" {
+		t.Error("Expected log result to be non-empty")
+	}
+
+	if !strings.Contains(logResult, "span_service_name=test-service") {
+		t.Errorf("Expected log result to contain span_service_name=test-service, got %s", logResult)
+	}
+
+	if !strings.Contains(logResult, "span_name=test") {
+		t.Errorf("Expected log result to contain span_name=test, got %s", logResult)
+	}
+
+	if !strings.Contains(logResult, "span_kind=SPAN_KIND_CLIENT") {
+		t.Errorf("Expected log result to contain span_kind=SPAN_KIND_CLIENT, got %s", logResult)
+	}
+
+	if !strings.Contains(logResult, "span_status=STATUS_CODE_ERROR") {
+		t.Errorf("Expected log result to contain span_status=STATUS_CODE_ERROR, got %s", logResult)
+	}
+}
+
+func TestErrorSpanLogging_status_code_is_not_error_should_ignore(t *testing.T) {
+	cfg := Config{}
+
+	buf := &bytes.Buffer{}
+	logger := log.NewLogfmtLogger(buf)
+	p := New(cfg, logger)
+	defer p.Shutdown(context.Background())
+
+	batch := test.MakeBatch(2, nil)
+	batch.InstrumentationLibrarySpans[0].Spans[0].Status.Code = trace_v1.Status_STATUS_CODE_OK
+	batch.InstrumentationLibrarySpans[0].Spans[1].Status.Code = trace_v1.Status_STATUS_CODE_UNSET
+
+	p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{batch}})
+
+	logResult := buf.String()
+	if logResult != "" {
+		t.Errorf("Expected log result to be empty, got %s", logResult)
+	}
+}


### PR DESCRIPTION
**What this PR does**:

I would like to keep a small discussion that I started on the Tempo Slack channel, where I wonder what would you think about having an error-span logging processor, similar to the one that Grafana Agent has but this one just log span with status error.

The motivation is to have a way to do aggregation over high cardinality span tags like for example `http.url`  without overwhelming the logging tool and an easy way to discover old traces that have errors while Tempo search performance keep being optimized.

Because the metrics and the logs use the same label sanitizers will be easy to jump between metrics to logs using data links.

Example usage:

Create a Grafana panel using the span generated metrics and group it by  (span_name, http_status_code and http_method)

The `span_name` is the URL template, that the libraries use to keep the cardinality down.

We get a graph like the following

![image](https://user-images.githubusercontent.com/2423149/169701096-d575f1d0-a0ba-4a70-a97e-e452d4978df4.png)

From it, we can create data links that use the same label set of the series that have a high error percentage and query our logging tool.

From the logs now we can aggregate the tags to find correlations with the failure, sometimes developers add more tags to enrich the context of some spans and those tags can be very useful to understand the error correlation.

![image](https://user-images.githubusercontent.com/2423149/169701263-2cb343b1-7622-470e-a510-3c2b1324f89e.png)


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`