### PR TITLE
Change label name for metrics generator instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## main / unreleased
 
-* [CHANGE] metrics-generator: Changed added metric label `instance` to `__metrics_gen_instance` to prevent reduce collisions with custom dimensions. [#1439](https://github.com/grafana/tempo/pull/1439) (@joe-elliott)
+* [CHANGE] metrics-generator: Changed added metric label `instance` to `__metrics_gen_instance` to reduce collisions with custom dimensions. [#1439](https://github.com/grafana/tempo/pull/1439) (@joe-elliott)
 * [FEATURE] metrics-generator: support per-tenant processor configuration [#1434](https://github.com/grafana/tempo/pull/1434) (@kvrhdn)
 * [ENHANCEMENT] Added the ability to have a per tenant max search duration. [#1421](https://github.com/grafana/tempo/pull/1421) (@joe-elliott)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [CHANGE] metrics-generator: Changed added metric label `instance` to `__metrics_gen_instance` to prevent reduce collisions with custom dimensions. [#1439](https://github.com/grafana/tempo/pull/1439) (@joe-elliott)
 * [FEATURE] metrics-generator: support per-tenant processor configuration [#1434](https://github.com/grafana/tempo/pull/1434) (@kvrhdn)
 * [ENHANCEMENT] Added the ability to have a per tenant max search duration. [#1421](https://github.com/grafana/tempo/pull/1421) (@joe-elliott)
 

--- a/modules/generator/registry/registry.go
+++ b/modules/generator/registry/registry.go
@@ -89,7 +89,7 @@ func New(cfg *Config, overrides Overrides, tenant string, appendable storage.App
 		externalLabels[k] = v
 	}
 	hostname, _ := os.Hostname()
-	externalLabels["instance"] = hostname
+	externalLabels["__metrics_gen_instance"] = hostname
 
 	r := &ManagedRegistry{
 		onShutdown: cancel,

--- a/modules/generator/registry/registry_test.go
+++ b/modules/generator/registry/registry_test.go
@@ -64,7 +64,7 @@ func TestManagedRegistry_counter(t *testing.T) {
 	counter.Inc(NewLabelValues([]string{"value-1"}), 1.0)
 
 	expectedSamples := []sample{
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-1", "instance": mustGetHostname()}, 0, 1.0),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 1.0),
 	}
 	collectRegistryMetricsAndAssert(t, registry, appender, expectedSamples)
 }
@@ -80,11 +80,11 @@ func TestManagedRegistry_histogram(t *testing.T) {
 	histogram.ObserveWithExemplar(NewLabelValues([]string{"value-1"}), 1.0, "")
 
 	expectedSamples := []sample{
-		newSample(map[string]string{"__name__": "histogram_count", "label": "value-1", "instance": mustGetHostname()}, 0, 1.0),
-		newSample(map[string]string{"__name__": "histogram_sum", "label": "value-1", "instance": mustGetHostname()}, 0, 1.0),
-		newSample(map[string]string{"__name__": "histogram_bucket", "label": "value-1", "instance": mustGetHostname(), "le": "1"}, 0, 1.0),
-		newSample(map[string]string{"__name__": "histogram_bucket", "label": "value-1", "instance": mustGetHostname(), "le": "2"}, 0, 1.0),
-		newSample(map[string]string{"__name__": "histogram_bucket", "label": "value-1", "instance": mustGetHostname(), "le": "+Inf"}, 0, 1.0),
+		newSample(map[string]string{"__name__": "histogram_count", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 1.0),
+		newSample(map[string]string{"__name__": "histogram_sum", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 1.0),
+		newSample(map[string]string{"__name__": "histogram_bucket", "label": "value-1", "__metrics_gen_instance": mustGetHostname(), "le": "1"}, 0, 1.0),
+		newSample(map[string]string{"__name__": "histogram_bucket", "label": "value-1", "__metrics_gen_instance": mustGetHostname(), "le": "2"}, 0, 1.0),
+		newSample(map[string]string{"__name__": "histogram_bucket", "label": "value-1", "__metrics_gen_instance": mustGetHostname(), "le": "+Inf"}, 0, 1.0),
 	}
 	collectRegistryMetricsAndAssert(t, registry, appender, expectedSamples)
 }
@@ -107,8 +107,8 @@ func TestManagedRegistry_removeStaleSeries(t *testing.T) {
 	registry.removeStaleSeries(context.Background())
 
 	expectedSamples := []sample{
-		newSample(map[string]string{"__name__": "metric_1", "instance": mustGetHostname()}, 0, 1),
-		newSample(map[string]string{"__name__": "metric_2", "instance": mustGetHostname()}, 0, 2),
+		newSample(map[string]string{"__name__": "metric_1", "__metrics_gen_instance": mustGetHostname()}, 0, 1),
+		newSample(map[string]string{"__name__": "metric_2", "__metrics_gen_instance": mustGetHostname()}, 0, 2),
 	}
 	collectRegistryMetricsAndAssert(t, registry, appender, expectedSamples)
 
@@ -121,7 +121,7 @@ func TestManagedRegistry_removeStaleSeries(t *testing.T) {
 	registry.removeStaleSeries(context.Background())
 
 	expectedSamples = []sample{
-		newSample(map[string]string{"__name__": "metric_2", "instance": mustGetHostname()}, 0, 4),
+		newSample(map[string]string{"__name__": "metric_2", "__metrics_gen_instance": mustGetHostname()}, 0, 4),
 	}
 	collectRegistryMetricsAndAssert(t, registry, appender, expectedSamples)
 }
@@ -141,7 +141,7 @@ func TestManagedRegistry_externalLabels(t *testing.T) {
 	counter.Inc(nil, 1.0)
 
 	expectedSamples := []sample{
-		newSample(map[string]string{"__name__": "my_counter", "instance": mustGetHostname(), "foo": "bar"}, 0, 1),
+		newSample(map[string]string{"__name__": "my_counter", "__metrics_gen_instance": mustGetHostname(), "foo": "bar"}, 0, 1),
 	}
 	collectRegistryMetricsAndAssert(t, registry, appender, expectedSamples)
 }
@@ -165,7 +165,7 @@ func TestManagedRegistry_maxSeries(t *testing.T) {
 
 	assert.Equal(t, uint32(1), registry.activeSeries.Load())
 	expectedSamples := []sample{
-		newSample(map[string]string{"__name__": "metric_1", "label": "value-1", "instance": mustGetHostname()}, 0, 1),
+		newSample(map[string]string{"__name__": "metric_1", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 1),
 	}
 	collectRegistryMetricsAndAssert(t, registry, appender, expectedSamples)
 }


### PR DESCRIPTION
**What this PR does**:
The metrics generators add an `instance` label to distinguish between metrics series. This prevents out of order issues with remote write. Unfortunately `instance` is a very common label name and may conflict with custom dimensions on service graphs or span metrics.

This PR proposes a much more unique label name that is far less likely to conflict `__metrics_gen_instance`. Feel free to suggest other options if desired.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`