### PR TITLE
Add block_tags option

### DIFF
--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -550,6 +550,13 @@ storage:
             # The maximum number of requests to execute when hedging. Requires hedge_requests_at to be set.
             [hedge_requests_up_to: <int>]
 
+              # Optional
+              # Example: "block_tags: {'key': 'value'}"
+              # A map key value strings for user tags to store on the S3 block objects, to aid setup of filters in S3 lifecycles.
+              # The tags are not set on index.json.gz files as these are rewritten often.
+              # See the S3 documentation for more detail: https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html
+              [block_tags: <map[string]string>]
+
         # azure configuration. Will be used only if value of backend is "azure"
         # EXPERIMENTAL
         azure:

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -550,12 +550,12 @@ storage:
             # The maximum number of requests to execute when hedging. Requires hedge_requests_at to be set.
             [hedge_requests_up_to: <int>]
 
-              # Optional
-              # Example: "block_tags: {'key': 'value'}"
-              # A map key value strings for user tags to store on the S3 block objects, to aid setup of filters in S3 lifecycles.
-              # The tags are not set on index.json.gz files as these are rewritten often.
-              # See the S3 documentation for more detail: https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html
-              [block_tags: <map[string]string>]
+           # Optional
+           # Example: "block_tags: {'key': 'value'}"
+           # A map key value string for user tags to store on the S3 block objects. This string helps set up filters in S3 lifecycles.
+           # The tags are not set on index.json.gz files since these files are rewritten often.
+           # See the [S3 documentation on object tagging](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html) for more detail. 
+            [block_tags: <map[string]string>]
 
         # azure configuration. Will be used only if value of backend is "azure"
         # EXPERIMENTAL

--- a/tempodb/backend/s3/config.go
+++ b/tempodb/backend/s3/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	HedgeRequestsAt   time.Duration  `yaml:"hedge_requests_at"`
 	HedgeRequestsUpTo int            `yaml:"hedge_requests_up_to"`
 	// SignatureV2 configures the object storage to use V2 signing instead of V4
-	SignatureV2    bool `yaml:"signature_v2"`
-	ForcePathStyle bool `yaml:"forcepathstyle"`
+	SignatureV2    bool              `yaml:"signature_v2"`
+	ForcePathStyle bool              `yaml:"forcepathstyle"`
+	BlockTags      map[string]string `yaml:"block_tags"`
 }

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -107,13 +107,19 @@ func internalNew(cfg *Config, confirm bool) (backend.RawReader, backend.RawWrite
 func (rw *readerWriter) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, size int64, _ bool) error {
 	objName := backend.ObjectFileName(keypath, name)
 
+	putObjectOptions := minio.PutObjectOptions{PartSize: rw.cfg.PartSize}
+
+	if name != backend.TenantIndexName {
+		putObjectOptions.UserTags = rw.cfg.BlockTags
+	}
+
 	info, err := rw.core.Client.PutObject(
 		ctx,
 		rw.cfg.Bucket,
 		objName,
 		data,
 		size,
-		minio.PutObjectOptions{PartSize: rw.cfg.PartSize},
+		putObjectOptions,
 	)
 	if err != nil {
 		return errors.Wrapf(err, "error writing object to s3 backend, object %s", objName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds the ability to set tags when blocks are saved to S3 storage.  This is useful for creating lifecycles in S3.
https://community.grafana.com/t/configuration-for-s3-intelligent-tiering/66028

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Tests updated
- [*] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`