### PR TITLE
Procect forwarder watchOverrides from race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@
 * [FEATURE] metrics-generator: support per-tenant processor configuration [#1434](https://github.com/grafana/tempo/pull/1434) (@kvrhdn)
 * [FEATURE] Include rollout dashboard [#1456](https://github.com/grafana/tempo/pull/1456) (@zalegrala)
 * [ENHANCEMENT] Added the ability to have a per tenant max search duration. [#1421](https://github.com/grafana/tempo/pull/1421) (@joe-elliott)
-* [ENHANCEMENT] Azure Backend: Add support for authentication with Managed Identities. [#1457](https://github.com/grafana/tempo/pull/1457) (@joe-elliott)
 * [ENHANCEMENT] metrics-generator: expose max_active_series as a metric [#1471](https://github.com/grafana/tempo/pull/1471) (@kvrhdn)
+* [ENHANCEMENT] Azure Backend: Add support for authentication with Managed Identities.
 * [BUGFIX] Fix nil pointer panic when the trace by id path errors. [#1441](https://github.com/grafana/tempo/pull/1441) (@joe-elliott)
 * [BUGFIX] Update tempo microservices Helm values example which missed the 'enabled' key for thriftHttp. [#1472](https://github.com/grafana/tempo/pull/1472) (@hajowieland)
-* [ENHANCEMENT] Azure Backend: Add support for authentication with Managed Identities.
+* [BUGFIX] Fix race condition in forwarder overrides loop. [1468](https://github.com/grafana/tempo/pull/1468) (@mapno)
 
 ## v1.4.1 / 2022-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * [FEATURE] Include rollout dashboard [#1456](https://github.com/grafana/tempo/pull/1456) (@zalegrala)
 * [ENHANCEMENT] Added the ability to have a per tenant max search duration. [#1421](https://github.com/grafana/tempo/pull/1421) (@joe-elliott)
 * [ENHANCEMENT] metrics-generator: expose max_active_series as a metric [#1471](https://github.com/grafana/tempo/pull/1471) (@kvrhdn)
-* [ENHANCEMENT] Azure Backend: Add support for authentication with Managed Identities.
+* [ENHANCEMENT] Azure Backend: Add support for authentication with Managed Identities. [#1457](https://github.com/grafana/tempo/pull/1457) (@joe-elliott)
 * [BUGFIX] Fix nil pointer panic when the trace by id path errors. [#1441](https://github.com/grafana/tempo/pull/1441) (@joe-elliott)
 * [BUGFIX] Update tempo microservices Helm values example which missed the 'enabled' key for thriftHttp. [#1472](https://github.com/grafana/tempo/pull/1472) (@hajowieland)
 * [BUGFIX] Fix race condition in forwarder overrides loop. [1468](https://github.com/grafana/tempo/pull/1468) (@mapno)

--- a/modules/distributor/forwarder.go
+++ b/modules/distributor/forwarder.go
@@ -134,9 +134,11 @@ func (f *forwarder) getQueueManager(tenantID string) (*queueManager, bool) {
 // watchOverrides watches the overrides for changes
 // and updates the queueManagers accordingly
 func (f *forwarder) watchOverrides() {
+	ticker := time.NewTicker(f.overridesInterval)
+
 	for {
 		select {
-		case <-time.After(f.overridesInterval):
+		case <-ticker.C:
 			f.mutex.Lock()
 
 			var (
@@ -181,6 +183,7 @@ func (f *forwarder) watchOverrides() {
 
 			f.mutex.Unlock()
 		case <-f.shutdown:
+			ticker.Stop()
 			return
 		}
 	}

--- a/modules/distributor/forwarder.go
+++ b/modules/distributor/forwarder.go
@@ -336,7 +336,7 @@ func (m *queueManager) stopWorkers(ctx context.Context) error {
 }
 
 // shouldUpdate returns true if the queue size or worker count (alive or total) has changed
-func (m *queueManager) shouldUpdate(numWorkers int, queueSize int) bool {
+func (m *queueManager) shouldUpdate(queueSize, numWorkers int) bool {
 	// TODO: worker alive count could be 0 and shutting down the queue manager would be impossible
 	//  it'd be better if we were able to spawn new workers instead of just closing the queueManager
 	//  and creating a new one


### PR DESCRIPTION
**What this PR does**:

Reworks update logic in watchOverrides loop.
The race condition comes from the unpredictable behaviour of ranging over a map.

This could cause that a newly created queueManagers was added to the ranged map,
and be evaluated for update.
Since the queueManager was _just_ created, it wouldn't have enough running workers,
which would trigger another update.


**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`