### PR TITLE
Minor docs cleanup

### DIFF
--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -919,10 +919,9 @@ memberlist:
 ## Overrides
 
 Tempo provides an overrides module for users to set global or per-tenant override settings.
-**Currenly only ingestion limits can be overridden.**
 
 ### Ingestion limits
-The default limits in Tempo may not be sufficient in high volume tracing environments. Errors including `RATE_LIMITED`/`TRACE_TOO_LARGE`/`LIVE_TRACES_EXCEEDED` will occur when these limits are exceeded.
+The default limits in Tempo may not be sufficient in high volume tracing environments. Errors including `RATE_LIMITED`/`TRACE_TOO_LARGE`/`LIVE_TRACES_EXCEEDED` will occur when these limits are exceeded. See below for how to override these limits globally or per tenant.
 
 #### Standard overrides
 You can create an `overrides` section to configure new ingestion limits that applies to all tenants of the cluster.  
@@ -1042,7 +1041,7 @@ overrides:
 
 #### Tenant-specific overrides
 
-You can set tenant-specific overrides settings in a separate file and point `per_tenant_override_config` to it. This overrides file is dynamically loaded.  It can be changed at runtime and will be reloaded by Tempo without restarting the application.
+You can set tenant-specific overrides settings in a separate file and point `per_tenant_override_config` to it. This overrides file is dynamically loaded.  It can be changed at runtime and will be reloaded by Tempo without restarting the application. All of the override settings detailed above can be set per tenant.
 ```yaml
 # /conf/tempo.yaml
 # Overrides configuration block

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -1041,7 +1041,7 @@ overrides:
 
 #### Tenant-specific overrides
 
-You can set tenant-specific overrides settings in a separate file and point `per_tenant_override_config` to it. This overrides file is dynamically loaded.  It can be changed at runtime and will be reloaded by Tempo without restarting the application. All of the override settings detailed above can be set per tenant.
+You can set tenant-specific overrides settings in a separate file and point `per_tenant_override_config` to it. This overrides file is dynamically loaded. It can be changed at runtime and reloaded by Tempo without restarting the application. These override settings can be set per tenant.
 ```yaml
 # /conf/tempo.yaml
 # Overrides configuration block

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -921,7 +921,7 @@ memberlist:
 Tempo provides an overrides module for users to set global or per-tenant override settings.
 
 ### Ingestion limits
-The default limits in Tempo may not be sufficient in high volume tracing environments. Errors including `RATE_LIMITED`/`TRACE_TOO_LARGE`/`LIVE_TRACES_EXCEEDED` will occur when these limits are exceeded. See below for how to override these limits globally or per tenant.
+The default limits in Tempo may not be sufficient in high-volume tracing environments. Errors including `RATE_LIMITED`/`TRACE_TOO_LARGE`/`LIVE_TRACES_EXCEEDED` occur when these limits are exceeded. See below for how to override these limits globally or per tenant.
 
 #### Standard overrides
 You can create an `overrides` section to configure new ingestion limits that applies to all tenants of the cluster.  


### PR DESCRIPTION
**What this PR does**:
Removes the phrase "**Currenly only ingestion limits can be overridden.**" pointed out here:

https://github.com/grafana/tempo/pull/508#issuecomment-1157011094

Adds two other sentences for clarity.  Thanks @bputt-e!

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`