### PR TITLE
Add S3 block tags configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [FEATURE] Add parquet block format [#1479](https://github.com/grafana/tempo/pull/1479) [#1531](https://github.com/grafana/tempo/pull/1531) (@annanay25, @mdisibio)
 * [FEATURE] Mark `log_received_traces` as deprecated. New flag is `log_received_spans`.
   Extend distributor spans logger with optional features to include span attributes and a filter by error status. [#1465](https://github.com/grafana/tempo/pull/1465) (@faustodavid)
+* [FEATURE] Add block_tags option for s3 backends.  This allows new objects to be written with the configured tags. [#1442](https://github.com/grafana/tempo/pull/1442) (@stevenbrookes)
 * [CHANGE] metrics-generator: Changed added metric label `instance` to `__metrics_gen_instance` to reduce collisions with custom dimensions. [#1439](https://github.com/grafana/tempo/pull/1439) (@joe-elliott)
 * [CHANGE] Don't enforce `max_bytes_per_tag_values_query` when set to 0. [#1447](https://github.com/grafana/tempo/pull/1447) (@joe-elliott)
 * [CHANGE] Add new querier service in deployment jsonnet to serve `/status` endpoint. [#1474](https://github.com/grafana/tempo/pull/1474) (@annanay25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * [FEATURE] Add parquet block format [#1479](https://github.com/grafana/tempo/pull/1479) [#1531](https://github.com/grafana/tempo/pull/1531) (@annanay25, @mdisibio)
 * [FEATURE] Mark `log_received_traces` as deprecated. New flag is `log_received_spans`.
   Extend distributor spans logger with optional features to include span attributes and a filter by error status. [#1465](https://github.com/grafana/tempo/pull/1465) (@faustodavid)
-* [FEATURE] Add block_tags option for s3 backends.  This allows new objects to be written with the configured tags. [#1442](https://github.com/grafana/tempo/pull/1442) (@stevenbrookes)
+* [FEATURE] Add tags option for s3 backends.  This allows new objects to be written with the configured tags. [#1442](https://github.com/grafana/tempo/pull/1442) (@stevenbrookes)
 * [CHANGE] metrics-generator: Changed added metric label `instance` to `__metrics_gen_instance` to reduce collisions with custom dimensions. [#1439](https://github.com/grafana/tempo/pull/1439) (@joe-elliott)
 * [CHANGE] Don't enforce `max_bytes_per_tag_values_query` when set to 0. [#1447](https://github.com/grafana/tempo/pull/1447) (@joe-elliott)
 * [CHANGE] Add new querier service in deployment jsonnet to serve `/status` endpoint. [#1474](https://github.com/grafana/tempo/pull/1474) (@annanay25)

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -569,12 +569,11 @@ storage:
             # The maximum number of requests to execute when hedging. Requires hedge_requests_at to be set.
             [hedge_requests_up_to: <int>]
 
-           # Optional
-           # Example: "block_tags: {'key': 'value'}"
-           # A map key value string for user tags to store on the S3 block objects. This string helps set up filters in S3 lifecycles.
-           # The tags are not set on index.json.gz files since these files are rewritten often.
-           # See the [S3 documentation on object tagging](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html) for more detail. 
-            [block_tags: <map[string]string>]
+            # Optional
+            # Example: "tags: {'key': 'value'}"
+            # A map of key value strings for user tags to store on the S3 objects. This helps set up filters in S3 lifecycles.
+            # See the [S3 documentation on object tagging](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html) for more detail. 
+            [tags: <map[string]string>]
 
         # azure configuration. Will be used only if value of backend is "azure"
         # EXPERIMENTAL

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -569,6 +569,13 @@ storage:
             # The maximum number of requests to execute when hedging. Requires hedge_requests_at to be set.
             [hedge_requests_up_to: <int>]
 
+              # Optional
+              # Example: "block_tags: {'key': 'value'}"
+              # A map key value strings for user tags to store on the S3 block objects, to aid setup of filters in S3 lifecycles.
+              # The tags are not set on index.json.gz files as these are rewritten often.
+              # See the S3 documentation for more detail: https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html
+              [block_tags: <map[string]string>]
+
         # azure configuration. Will be used only if value of backend is "azure"
         # EXPERIMENTAL
         azure:

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -569,12 +569,12 @@ storage:
             # The maximum number of requests to execute when hedging. Requires hedge_requests_at to be set.
             [hedge_requests_up_to: <int>]
 
-              # Optional
-              # Example: "block_tags: {'key': 'value'}"
-              # A map key value strings for user tags to store on the S3 block objects, to aid setup of filters in S3 lifecycles.
-              # The tags are not set on index.json.gz files as these are rewritten often.
-              # See the S3 documentation for more detail: https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html
-              [block_tags: <map[string]string>]
+           # Optional
+           # Example: "block_tags: {'key': 'value'}"
+           # A map key value string for user tags to store on the S3 block objects. This string helps set up filters in S3 lifecycles.
+           # The tags are not set on index.json.gz files since these files are rewritten often.
+           # See the [S3 documentation on object tagging](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html) for more detail. 
+            [block_tags: <map[string]string>]
 
         # azure configuration. Will be used only if value of backend is "azure"
         # EXPERIMENTAL

--- a/tempodb/backend/s3/config.go
+++ b/tempodb/backend/s3/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	HedgeRequestsAt    time.Duration  `yaml:"hedge_requests_at"`
 	HedgeRequestsUpTo  int            `yaml:"hedge_requests_up_to"`
 	// SignatureV2 configures the object storage to use V2 signing instead of V4
-	SignatureV2    bool `yaml:"signature_v2"`
-	ForcePathStyle bool `yaml:"forcepathstyle"`
+	SignatureV2    bool              `yaml:"signature_v2"`
+	ForcePathStyle bool              `yaml:"forcepathstyle"`
+	BlockTags      map[string]string `yaml:"block_tags"`
 }

--- a/tempodb/backend/s3/config.go
+++ b/tempodb/backend/s3/config.go
@@ -20,5 +20,5 @@ type Config struct {
 	// SignatureV2 configures the object storage to use V2 signing instead of V4
 	SignatureV2    bool              `yaml:"signature_v2"`
 	ForcePathStyle bool              `yaml:"forcepathstyle"`
-	BlockTags      map[string]string `yaml:"block_tags"`
+	Tags           map[string]string `yaml:"tags"`
 }

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -108,7 +108,7 @@ func (rw *readerWriter) Write(ctx context.Context, name string, keypath backend.
 	objName := backend.ObjectFileName(keypath, name)
 
 	putObjectOptions := minio.PutObjectOptions{PartSize: rw.cfg.PartSize}
-	putObjectOptions.UserTags = rw.cfg.BlockTags
+	putObjectOptions.UserTags = rw.cfg.Tags
 
 	info, err := rw.core.Client.PutObject(
 		ctx,

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -108,10 +108,7 @@ func (rw *readerWriter) Write(ctx context.Context, name string, keypath backend.
 	objName := backend.ObjectFileName(keypath, name)
 
 	putObjectOptions := minio.PutObjectOptions{PartSize: rw.cfg.PartSize}
-
-	if name != backend.TenantIndexName {
-		putObjectOptions.UserTags = rw.cfg.BlockTags
-	}
+	putObjectOptions.UserTags = rw.cfg.BlockTags
 
 	info, err := rw.core.Client.PutObject(
 		ctx,

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -107,13 +107,19 @@ func internalNew(cfg *Config, confirm bool) (backend.RawReader, backend.RawWrite
 func (rw *readerWriter) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, size int64, _ bool) error {
 	objName := backend.ObjectFileName(keypath, name)
 
+	putObjectOptions := minio.PutObjectOptions{PartSize: rw.cfg.PartSize}
+
+	if name != backend.TenantIndexName {
+		putObjectOptions.UserTags = rw.cfg.BlockTags
+	}
+
 	info, err := rw.core.Client.PutObject(
 		ctx,
 		rw.cfg.Bucket,
 		objName,
 		data,
 		size,
-		minio.PutObjectOptions{PartSize: rw.cfg.PartSize},
+		putObjectOptions,
 	)
 	if err != nil {
 		return errors.Wrapf(err, "error writing object to s3 backend, object %s", objName)

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -107,8 +107,10 @@ func internalNew(cfg *Config, confirm bool) (backend.RawReader, backend.RawWrite
 func (rw *readerWriter) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, size int64, _ bool) error {
 	objName := backend.ObjectFileName(keypath, name)
 
-	putObjectOptions := minio.PutObjectOptions{PartSize: rw.cfg.PartSize}
-	putObjectOptions.UserTags = rw.cfg.Tags
+	putObjectOptions := minio.PutObjectOptions{
+		PartSize: rw.cfg.PartSize,
+		UserTags: rw.cfg.Tags,
+	}
 
 	info, err := rw.core.Client.PutObject(
 		ctx,

--- a/tempodb/backend/s3/s3_test.go
+++ b/tempodb/backend/s3/s3_test.go
@@ -118,7 +118,7 @@ func TestReadError(t *testing.T) {
 	assert.Equal(t, wups, errB)
 }
 
-func fakeServerWithBlockTags(t *testing.T, obj *url.Values) *httptest.Server {
+func fakeServerWithTags(t *testing.T, obj *url.Values) *httptest.Server {
 	require.NotNil(t, obj)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -148,8 +148,8 @@ func fakeServerWithBlockTags(t *testing.T, obj *url.Values) *httptest.Server {
 func TestObjectBlockTags(t *testing.T) {
 
 	tests := []struct {
-		name      string
-		blocktags map[string]string
+		name string
+		tags map[string]string
 		// expectedObject raw.Object
 	}{
 		{
@@ -162,7 +162,7 @@ func TestObjectBlockTags(t *testing.T) {
 			// rawObject := raw.Object{}
 			var obj url.Values
 
-			server := fakeServerWithBlockTags(t, &obj)
+			server := fakeServerWithTags(t, &obj)
 			_, w, _, err := New(&Config{
 				Region:    "blerg",
 				AccessKey: "test",
@@ -170,14 +170,14 @@ func TestObjectBlockTags(t *testing.T) {
 				Bucket:    "blerg",
 				Insecure:  true,
 				Endpoint:  server.URL[7:], // [7:] -> strip http://
-				BlockTags: tc.blocktags,
+				Tags:      tc.tags,
 			})
 			require.NoError(t, err)
 
 			ctx := context.Background()
 			_ = w.Write(ctx, "object", backend.KeyPath{"test"}, bytes.NewReader([]byte{}), 0, false)
 
-			for k, v := range tc.blocktags {
+			for k, v := range tc.tags {
 				vv := obj.Get(k)
 				require.NotEmpty(t, vv)
 				require.Equal(t, v, vv)

--- a/tempodb/backend/s3/s3_test.go
+++ b/tempodb/backend/s3/s3_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -115,4 +116,72 @@ func TestReadError(t *testing.T) {
 	wups := fmt.Errorf("wups")
 	errB = readError(wups)
 	assert.Equal(t, wups, errB)
+}
+
+func fakeServerWithBlockTags(t *testing.T, obj *url.Values) *httptest.Server {
+	require.NotNil(t, obj)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch method := r.Method; method {
+		case "PUT":
+			// https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
+			switch tagHeaders := r.Header.Get("X-Amz-Tagging"); tagHeaders {
+			case "":
+			default:
+				value, err := url.ParseQuery(tagHeaders)
+				require.NoError(t, err)
+				*obj = value
+			}
+		case "GET":
+			// return fake list response b/c it's the only call that has to succeed
+			_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+		<ListBucketResult>
+		</ListBucketResult>`))
+		}
+
+	}))
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+func TestObjectBlockTags(t *testing.T) {
+
+	tests := []struct {
+		name      string
+		blocktags map[string]string
+		// expectedObject raw.Object
+	}{
+		{
+			"env", map[string]string{"env": "prod", "app": "thing"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// rawObject := raw.Object{}
+			var obj url.Values
+
+			server := fakeServerWithBlockTags(t, &obj)
+			_, w, _, err := New(&Config{
+				Region:    "blerg",
+				AccessKey: "test",
+				SecretKey: flagext.SecretWithValue("test"),
+				Bucket:    "blerg",
+				Insecure:  true,
+				Endpoint:  server.URL[7:], // [7:] -> strip http://
+				BlockTags: tc.blocktags,
+			})
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			_ = w.Write(ctx, "object", backend.KeyPath{"test"}, bytes.NewReader([]byte{}), 0, false)
+
+			for k, v := range tc.blocktags {
+				vv := obj.Get(k)
+				require.NotEmpty(t, vv)
+				require.Equal(t, v, vv)
+			}
+		})
+	}
 }


### PR DESCRIPTION
**What this PR does**:
Builds on #1442 to include block_tags for new s3 objects.

**Which issue(s) this PR fixes**:
Fixes #1442

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`