### PR TITLE
Return partial results for tags and tag values lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ traces_spanmetrics_latency_{sum,count,bucket}
 ```
 Additionally, default label `span_status` is renamed to `status_code`.
 * [CHANGE] Update to Go 1.18 [#1504](https://github.com/grafana/tempo/pull/1504) (@annanay25)
+* [CHANGE] Change tag/value lookups to return partial results when reaching response size limit instead of failing [#1517](https://github.com/grafana/tempo/pull/1517) (@mdisibio)
 * [FEATURE] metrics-generator: support per-tenant processor configuration [#1434](https://github.com/grafana/tempo/pull/1434) (@kvrhdn)
 * [FEATURE] Include rollout dashboard [#1456](https://github.com/grafana/tempo/pull/1456) (@zalegrala)
 * [FEATURE] Add SentinelPassword configuration for Redis [#1463](https://github.com/grafana/tempo/pull/1463) (@zalegrala)

--- a/pkg/tempofb/searchdatamap.go
+++ b/pkg/tempofb/searchdatamap.go
@@ -9,6 +9,8 @@ import (
 	flatbuffers "github.com/google/flatbuffers/go"
 )
 
+type TagCallback func(t string)
+
 type SearchDataMap map[string]map[string]struct{}
 
 func NewSearchDataMap() SearchDataMap {
@@ -56,13 +58,13 @@ func (s SearchDataMap) Range(f func(k, v string)) {
 	}
 }
 
-func (s SearchDataMap) RangeKeys(f func(k string)) {
+func (s SearchDataMap) RangeKeys(f TagCallback) {
 	for k := range s {
 		f(k)
 	}
 }
 
-func (s SearchDataMap) RangeKeyValues(k string, f func(v string)) {
+func (s SearchDataMap) RangeKeyValues(k string, f TagCallback) {
 	for v := range s[k] {
 		f(v)
 	}

--- a/pkg/util/distinct_string_collector.go
+++ b/pkg/util/distinct_string_collector.go
@@ -1,0 +1,61 @@
+package util
+
+import "sort"
+
+type DistinctStringCollector struct {
+	values   map[string]struct{}
+	maxLen   int
+	currLen  int
+	totalLen int
+}
+
+// NewDistinctStringCollector with the given maximum data size. This is calculated
+// as the total length of the recorded strings. For ease of use, maximum=0
+// is interpreted as unlimited.
+func NewDistinctStringCollector(maxDataSize int) *DistinctStringCollector {
+	return &DistinctStringCollector{
+		values: make(map[string]struct{}),
+		maxLen: maxDataSize,
+	}
+}
+
+func (d *DistinctStringCollector) Collect(s string) {
+	if _, ok := d.values[s]; ok {
+		// Already present
+		return
+	}
+
+	// New entry
+	d.totalLen += len(s)
+
+	// Can it fit?
+	if d.maxLen > 0 && d.currLen+len(s) > d.maxLen {
+		// No
+		return
+	}
+
+	d.values[s] = struct{}{}
+	d.currLen += len(s)
+}
+
+// Strings returns the final list of distinct values collected and sorted.
+func (d *DistinctStringCollector) Strings() []string {
+	ss := make([]string, 0, len(d.values))
+
+	for k := range d.values {
+		ss = append(ss, k)
+	}
+
+	sort.Strings(ss)
+	return ss
+}
+
+// Exceeded indicates if some values were lost because the maximum size limit was met.
+func (d *DistinctStringCollector) Exceeded() bool {
+	return d.totalLen > d.currLen
+}
+
+// TotalDataSize is the total size of all distinct strings encountered.
+func (d *DistinctStringCollector) TotalDataSize() int {
+	return d.totalLen
+}

--- a/pkg/util/distinct_string_collector_test.go
+++ b/pkg/util/distinct_string_collector_test.go
@@ -1,0 +1,20 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDistinctStringCollector(t *testing.T) {
+
+	d := NewDistinctStringCollector(10)
+
+	d.Collect("123")
+	d.Collect("4567")
+	d.Collect("890")
+	d.Collect("11")
+
+	require.True(t, d.Exceeded())
+	require.Equal(t, []string{"123", "4567", "890"}, d.Strings())
+}

--- a/tempodb/search/backend_search_block.go
+++ b/tempodb/search/backend_search_block.go
@@ -135,7 +135,7 @@ func (s *BackendSearchBlock) BlockID() uuid.UUID {
 	return s.id
 }
 
-func (s *BackendSearchBlock) Tags(ctx context.Context, tags map[string]struct{}) error {
+func (s *BackendSearchBlock) Tags(ctx context.Context, cb tagCallback) error {
 	header, err := s.readSearchHeader(ctx)
 	if err != nil {
 		return err
@@ -145,16 +145,13 @@ func (s *BackendSearchBlock) Tags(ctx context.Context, tags map[string]struct{})
 	for i, ii := 0, header.TagsLength(); i < ii; i++ {
 		header.Tags(kv, i)
 		key := string(kv.Key())
-		// check the tag is already set, this is more performant with repetitive values
-		if _, ok := tags[key]; !ok {
-			tags[key] = struct{}{}
-		}
+		cb(key)
 	}
 
 	return nil
 }
 
-func (s *BackendSearchBlock) TagValues(ctx context.Context, tagName string, tagValues map[string]struct{}) error {
+func (s *BackendSearchBlock) TagValues(ctx context.Context, tagName string, cb tagCallback) error {
 	header, err := s.readSearchHeader(ctx)
 	if err != nil {
 		return err
@@ -164,10 +161,7 @@ func (s *BackendSearchBlock) TagValues(ctx context.Context, tagName string, tagV
 	if kv != nil {
 		for j, valueLength := 0, kv.ValueLength(); j < valueLength; j++ {
 			value := string(kv.Value(j))
-			// check the value is already set, this is more performant with repetitive values
-			if _, ok := tagValues[value]; !ok {
-				tagValues[value] = struct{}{}
-			}
+			cb(value)
 		}
 	}
 	return nil

--- a/tempodb/search/searchable_block.go
+++ b/tempodb/search/searchable_block.go
@@ -4,9 +4,11 @@ import (
 	"context"
 )
 
+type tagCallback func(t string)
+
 type SearchableBlock interface {
-	Tags(ctx context.Context, tags map[string]struct{}) error
-	TagValues(ctx context.Context, tagName string, tagValues map[string]struct{}) error
+	Tags(ctx context.Context, cb tagCallback) error
+	TagValues(ctx context.Context, tagName string, cb tagCallback) error
 	Search(ctx context.Context, p Pipeline, sr *Results) error
 }
 

--- a/tempodb/search/streaming_search_block.go
+++ b/tempodb/search/streaming_search_block.go
@@ -87,23 +87,13 @@ func (s *StreamingSearchBlock) Append(ctx context.Context, id common.ID, searchD
 	return s.appender.Append(id, combined)
 }
 
-func (s *StreamingSearchBlock) Tags(ctx context.Context, tags map[string]struct{}) error {
-	s.header.Tags.RangeKeys(func(k string) {
-		// check the tag is already set, this is more performant with repetitive values
-		if _, ok := tags[k]; !ok {
-			tags[k] = struct{}{}
-		}
-	})
+func (s *StreamingSearchBlock) Tags(_ context.Context, cb tagCallback) error {
+	s.header.Tags.RangeKeys((tempofb.TagCallback)(cb))
 	return nil
 }
 
-func (s *StreamingSearchBlock) TagValues(ctx context.Context, tagName string, tagValues map[string]struct{}) error {
-	s.header.Tags.RangeKeyValues(tagName, func(v string) {
-		// check the value is already set, this is more performant with repetitive values
-		if _, ok := tagValues[v]; !ok {
-			tagValues[v] = struct{}{}
-		}
-	})
+func (s *StreamingSearchBlock) TagValues(_ context.Context, tagName string, cb tagCallback) error {
+	s.header.Tags.RangeKeyValues(tagName, (tempofb.TagCallback)(cb))
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does**:
This PR adjusts the tags and tag values lookup apis to return partial results up to the size limit instead of failing.  The warning message was updated to include the limit and total size of tags/values encountered.   The core string handling was moved into `pkg/util/distinct_string_collector.go`

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`