### PR TITLE
Add `blocklist_poll_jitter_ms` config value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Additionally, default label `span_status` is renamed to `status_code`.
 * [ENHANCEMENT] Azure Backend: Add support for authentication with Managed Identities. [#1457](https://github.com/grafana/tempo/pull/1457) (@joe-elliott)
 * [ENHANCEMENT] Add metric to track feature enablement [#1459](https://github.com/grafana/tempo/pull/1459) (@zalegrala)
 * [ENHANCEMENT] Added s3 config option `insecure_skip_verify` [#1470](https://github.com/grafana/tempo/pull/1470) (@zalegrala)
+* [ENHANCEMENT] Added polling option to reduce issues in Azure `blocklist_poll_jitter_ms` [#1518](https://github.com/grafana/tempo/pull/1518) (@joe-elliott)
 * [BUGFIX] Fix nil pointer panic when the trace by id path errors. [#1441](https://github.com/grafana/tempo/pull/1441) (@joe-elliott)
 * [BUGFIX] Update tempo microservices Helm values example which missed the 'enabled' key for thriftHttp. [#1472](https://github.com/grafana/tempo/pull/1472) (@hajowieland)
 * [BUGFIX] Fix race condition in forwarder overrides loop. [1468](https://github.com/grafana/tempo/pull/1468) (@mapno)

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -632,6 +632,12 @@ storage:
         # Default 0 (disabled).
         [blocklist_poll_stale_tenant_index: <duration>]
 
+        # Offsets the concurrent blocklist polling by a random amount. The maximum amount of offset
+        # is the provided value in milliseconds. This configuration value can be used if the polling
+        # cycle is overwhelming your backend with concurrent requests.
+        # Default 0 (disabled)
+        [blocklist_poll_jitter_ms: <int>]
+
         # Cache type to use. Should be one of "redis", "memcached"
         # Example: "cache: memcached"
         [cache: <string>]

--- a/docs/tempo/website/configuration/azure.md
+++ b/docs/tempo/website/configuration/azure.md
@@ -14,6 +14,24 @@ For Tempo to authenticate to and access Azure blob storage, the following config
       - For a system-assigned managed identity, no additional configuration is required.
       - For a user-assigned managed identity, you'll need to set `user-assigned-id` to the client ID for the managed identity in the configuration file.
 
+## Azure Blocklist Polling
+
+If you are hosting Tempo on Azure two values may need to be tweaked to ensure consistently successful blocklist polling. If you are 
+experiencing [this issue](https://stackoverflow.com/questions/12917857/the-specified-block-list-is-invalid-while-uploading-blobs-in-parallel/55902744#55902744) we would recommend to set `blocklist_poll_tenant_index_builders` to 1.
+
+Additionally if you are seeing DNS failures like the following you may want to try increasing `blocklist_poll_jitter_ms`. Discussion [here](https://github.com/grafana/tempo/issues/1462).
+```
+reading storage container: Head "https://tempoe**************.blob.core.windows.net/tempo/single-tenant/d8aafc48-5796-4221-ac0b-58e001d18515/meta.compacted.json?timeout=61": dial tcp: lookup tempoe**************.blob.core.windows.net on 10.0.0.10:53: dial udp 10.0.0.10:53: operation was canceled
+```
+
+Your final config may look something like:
+```
+  storage:
+    trace:
+      blocklist_poll_tenant_index_builders: 1
+      blocklist_poll_jitter_ms: 500
+```
+
 ## (Optional) Storage Account management policy for cleaning up the storage container
 
 The following Storage Account management policy shows an example of cleaning up

--- a/docs/tempo/website/configuration/azure.md
+++ b/docs/tempo/website/configuration/azure.md
@@ -14,12 +14,12 @@ For Tempo to authenticate to and access Azure blob storage, the following config
       - For a system-assigned managed identity, no additional configuration is required.
       - For a user-assigned managed identity, you'll need to set `user-assigned-id` to the client ID for the managed identity in the configuration file.
 
-## Azure Blocklist Polling
+## Azure blocklist polling
 
-If you are hosting Tempo on Azure two values may need to be tweaked to ensure consistently successful blocklist polling. If you are 
-experiencing [this issue](https://stackoverflow.com/questions/12917857/the-specified-block-list-is-invalid-while-uploading-blobs-in-parallel/55902744#55902744) we would recommend to set `blocklist_poll_tenant_index_builders` to 1.
+If you are hosting Tempo on Azure, two values may need to be updated to ensure consistent successful blocklist polling. If you are 
+experiencing [this issue](https://stackoverflow.com/questions/12917857/the-specified-block-list-is-invalid-while-uploading-blobs-in-parallel/55902744#55902744), we recommend to set `blocklist_poll_tenant_index_builders` to 1.
 
-Additionally if you are seeing DNS failures like the following you may want to try increasing `blocklist_poll_jitter_ms`. Discussion [here](https://github.com/grafana/tempo/issues/1462).
+Additionally, if you are seeing DNS failures like the ones below, try increasing `blocklist_poll_jitter_ms`. Discussion [here](https://github.com/grafana/tempo/issues/1462).
 ```
 reading storage container: Head "https://tempoe**************.blob.core.windows.net/tempo/single-tenant/d8aafc48-5796-4221-ac0b-58e001d18515/meta.compacted.json?timeout=61": dial tcp: lookup tempoe**************.blob.core.windows.net on 10.0.0.10:53: dial udp 10.0.0.10:53: operation was canceled
 ```

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -3,6 +3,7 @@ package blocklist
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"sort"
 	"strconv"
 	"time"
@@ -192,6 +193,8 @@ func (p *Poller) pollTenantBlocks(ctx context.Context, tenantID string) ([]*back
 		bg.Add(1)
 		go func(uuid uuid.UUID) {
 			defer bg.Done()
+
+			time.Sleep(time.Duration(rand.Intn(500)) * time.Millisecond)
 			m, cm, err := p.pollBlock(ctx, tenantID, uuid)
 			if m != nil {
 				chMeta <- m

--- a/tempodb/config.go
+++ b/tempodb/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	BlocklistPollFallback            bool          `yaml:"blocklist_poll_fallback"`
 	BlocklistPollTenantIndexBuilders int           `yaml:"blocklist_poll_tenant_index_builders"`
 	BlocklistPollStaleTenantIndex    time.Duration `yaml:"blocklist_poll_stale_tenant_index"`
+	BlocklistPollJitterMs            int           `yaml:"blocklist_poll_jitter_ms"`
 
 	// backends
 	Backend string        `yaml:"backend"`

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -412,6 +412,7 @@ func (rw *readerWriter) EnablePolling(sharder blocklist.JobSharder) {
 		PollFallback:        rw.cfg.BlocklistPollFallback,
 		TenantIndexBuilders: rw.cfg.BlocklistPollTenantIndexBuilders,
 		StaleTenantIndex:    rw.cfg.BlocklistPollStaleTenantIndex,
+		PollJitterMs:        rw.cfg.BlocklistPollJitterMs,
 	}, sharder, rw.r, rw.c, rw.w, rw.logger)
 
 	rw.blocklistPoller = blocklistPoller


### PR DESCRIPTION
**What this PR does**:
Adds a configurable number of maximum milliseconds to sleep before pulling a block in the poller. This is useful when hosting on Azure to reduce pressure on DNS.

**Which issue(s) this PR fixes**:
Fixes #1462 

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`