### PR TITLE
Parquet: Honor WAL meta Start/End time

### DIFF
--- a/tempodb/encoding/vparquet/create.go
+++ b/tempodb/encoding/vparquet/create.go
@@ -8,7 +8,6 @@ import (
 	"github.com/google/uuid"
 	tempo_io "github.com/grafana/tempo/pkg/io"
 	"github.com/grafana/tempo/pkg/model"
-	"github.com/grafana/tempo/pkg/model/decoder"
 	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
@@ -45,18 +44,13 @@ func CreateBlock(ctx context.Context, cfg *common.BlockConfig, meta *backend.Blo
 			break
 		}
 
-		start, end, err := dec.FastRange(obj)
-		if err != nil && err != decoder.ErrUnsupported {
-			return nil, err
-		}
-
 		tr, err := dec.PrepareForRead(obj)
 		if err != nil {
 			return nil, err
 		}
 
 		trp := traceToParquet(tr)
-		err = s.Add(&trp, start, end)
+		err = s.Add(&trp, 0, 0) // start and end time of the wal meta are used.
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What this PR does**:
Parquet is currently extracting the start/end time from individual objects in the WAL when building the block. Some of these objects could be outside the configured ingestion slack time causing the block to have a very large start/end time.

Instead the Parquet block building logic should honor the Start/EndTime in the wal meta.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`