### PR TITLE
Parquet: Expose ReadBufferSize and ReadBufferCount to be configurable

### DIFF
--- a/cmd/tempo-cli/cmd-search.go
+++ b/cmd/tempo-cli/cmd-search.go
@@ -8,16 +8,15 @@ import (
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/pkg/boundedwaitgroup"
 	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/grafana/tempo/tempodb"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
 const (
-	layoutString   = "2006-01-02T15:04:05"
-	chunkSize      = 10 * 1024 * 1024
-	iteratorBuffer = 10000
-	limit          = 20
+	layoutString = "2006-01-02T15:04:05"
+	limit        = 20
 )
 
 type searchBlocksCmd struct {
@@ -92,9 +91,8 @@ func (cmd *searchBlocksCmd) Run(opts *globalOptions) error {
 		blockmetas = append(blockmetas, q)
 	}
 
-	searchOpts := common.DefaultSearchOptions()
-	searchOpts.ChunkSizeBytes = chunkSize
-	searchOpts.PrefetchTraceCount = iteratorBuffer
+	searchOpts := common.SearchOptions{}
+	tempodb.SearchConfig{}.ApplyToOptions(&searchOpts)
 
 	fmt.Println("Blocks In Range:", len(blockmetas))
 	foundids := []string{}

--- a/cmd/tempo-serverless/handler.go
+++ b/cmd/tempo-serverless/handler.go
@@ -97,11 +97,12 @@ func Handler(r *http.Request) (*tempopb.SearchResponse, *HTTPError) {
 		return nil, httpError("creating backend block", err, http.StatusInternalServerError)
 	}
 
-	opts := common.DefaultSearchOptions()
-	opts.StartPage = int(searchReq.StartPage)
-	opts.TotalPages = int(searchReq.PagesToSearch)
-	opts.PrefetchTraceCount = cfg.Search.PrefetchTraceCount
-	opts.MaxBytes = maxBytes
+	opts := common.SearchOptions{
+		StartPage:  int(searchReq.StartPage),
+		TotalPages: int(searchReq.PagesToSearch),
+		MaxBytes:   maxBytes,
+	}
+	cfg.Search.ApplyToOptions(&opts)
 
 	resp, err := block.Search(r.Context(), searchReq.SearchReq, opts)
 	if err != nil {

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -438,7 +438,7 @@ func (q *Querier) internalSearchBlock(ctx context.Context, req *tempopb.SearchBl
 		DataEncoding:  req.DataEncoding,
 	}
 
-	opts := common.DefaultSearchOptions()
+	opts := common.SearchOptions{}
 	opts.StartPage = int(req.StartPage)
 	opts.TotalPages = int(req.PagesToSearch)
 	opts.MaxBytes = q.limits.MaxBytesPerTrace(tenantID)

--- a/modules/storage/config.go
+++ b/modules/storage/config.go
@@ -43,6 +43,8 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.Trace.Search = &tempodb.SearchConfig{}
 	cfg.Trace.Search.ChunkSizeBytes = tempodb.DefaultSearchChunkSizeBytes
 	cfg.Trace.Search.PrefetchTraceCount = tempodb.DefaultPrefetchTraceCount
+	cfg.Trace.Search.ReadBufferCount = tempodb.DefaultReadBufferCount
+	cfg.Trace.Search.ReadBufferSize = tempodb.DefaultReadBufferSize
 
 	cfg.Trace.Block = &common.BlockConfig{}
 	f.Float64Var(&cfg.Trace.Block.BloomFP, util.PrefixConfig(prefix, "trace.block.bloom-filter-false-positive"), .01, "Bloom Filter False Positive.")

--- a/tempodb/config.go
+++ b/tempodb/config.go
@@ -24,8 +24,11 @@ const (
 	DefaultBlocklistPollConcurrency = uint(50)
 	DefaultRetentionConcurrency     = uint(10)
 	DefaultTenantIndexBuilders      = 2
-	DefaultPrefetchTraceCount       = 1000
-	DefaultSearchChunkSizeBytes     = 1_000_000
+
+	DefaultPrefetchTraceCount   = 1000
+	DefaultSearchChunkSizeBytes = 1_000_000
+	DefaultReadBufferCount      = 8
+	DefaultReadBufferSize       = 4 * 1024 * 1024
 )
 
 // Config holds the entirety of tempodb configuration
@@ -60,8 +63,33 @@ type Config struct {
 }
 
 type SearchConfig struct {
+	// v2 blocks
 	ChunkSizeBytes     uint32 `yaml:"chunk_size_bytes"`
 	PrefetchTraceCount int    `yaml:"prefetch_trace_count"`
+
+	// vParquet blocks
+	ReadBufferCount int `yaml:"read_buffer_count"`
+	ReadBufferSize  int `yaml:"read_buffer_size"`
+}
+
+func (c SearchConfig) ApplyToOptions(o *common.SearchOptions) {
+	o.ChunkSizeBytes = c.ChunkSizeBytes
+	o.PrefetchTraceCount = c.PrefetchTraceCount
+	o.ReadBufferCount = c.ReadBufferCount
+	o.ReadBufferSize = c.ReadBufferSize
+
+	if o.ChunkSizeBytes == 0 {
+		o.ChunkSizeBytes = DefaultSearchChunkSizeBytes
+	}
+	if o.PrefetchTraceCount <= 0 {
+		o.PrefetchTraceCount = DefaultPrefetchTraceCount
+	}
+	if o.ReadBufferSize <= 0 {
+		o.ReadBufferSize = DefaultReadBufferSize
+	}
+	if o.ReadBufferCount <= 0 {
+		o.ReadBufferCount = DefaultReadBufferCount
+	}
 }
 
 // CompactorConfig contains compaction configuration options

--- a/tempodb/config_test.go
+++ b/tempodb/config_test.go
@@ -1,0 +1,40 @@
+package tempodb
+
+import (
+	"testing"
+
+	"github.com/grafana/tempo/tempodb/encoding/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyToOptions(t *testing.T) {
+	opts := common.SearchOptions{}
+	cfg := SearchConfig{}
+
+	// test defaults
+	cfg.ApplyToOptions(&opts)
+	require.Equal(t, opts.PrefetchTraceCount, DefaultPrefetchTraceCount)
+	require.Equal(t, opts.ChunkSizeBytes, uint32(DefaultSearchChunkSizeBytes))
+	require.Equal(t, opts.ReadBufferCount, DefaultReadBufferCount)
+	require.Equal(t, opts.ReadBufferSize, DefaultReadBufferSize)
+
+	// test parameter fields are left alone
+	opts.StartPage = 1
+	opts.TotalPages = 2
+	opts.MaxBytes = 3
+	cfg.ApplyToOptions(&opts)
+	require.Equal(t, opts.StartPage, 1)
+	require.Equal(t, opts.TotalPages, 2)
+	require.Equal(t, opts.MaxBytes, 3)
+
+	// test non defaults
+	cfg.ChunkSizeBytes = 4
+	cfg.PrefetchTraceCount = 5
+	cfg.ReadBufferCount = 6
+	cfg.ReadBufferSize = 7
+	cfg.ApplyToOptions(&opts)
+	require.Equal(t, cfg.ChunkSizeBytes, uint32(4))
+	require.Equal(t, cfg.PrefetchTraceCount, 5)
+	require.Equal(t, cfg.ReadBufferCount, 6)
+	require.Equal(t, cfg.ReadBufferSize, 7)
+}

--- a/tempodb/encoding/common/interfaces.go
+++ b/tempodb/encoding/common/interfaces.go
@@ -28,16 +28,6 @@ type SearchOptions struct {
 	ReadBufferSize     int
 }
 
-func DefaultSearchOptions() SearchOptions {
-	return SearchOptions{
-		ChunkSizeBytes: 1_000_000,
-
-		// 32 MB buffering
-		ReadBufferCount: 8,
-		ReadBufferSize:  4 * 1024 * 1024,
-	}
-}
-
 type Compactor interface {
 	Compact(ctx context.Context, l log.Logger, r backend.Reader, writerCallback func(*backend.BlockMeta, time.Time) backend.Writer, inputs []*backend.BlockMeta) ([]*backend.BlockMeta, error)
 }

--- a/tempodb/encoding/vparquet/block_search_test.go
+++ b/tempodb/encoding/vparquet/block_search_test.go
@@ -146,7 +146,7 @@ func TestBackendBlockSearch(t *testing.T) {
 		RootTraceName:     wantTr.RootSpanName,
 	}
 	for _, req := range searchesThatMatch {
-		res, err := b.Search(ctx, req, common.DefaultSearchOptions())
+		res, err := b.Search(ctx, req, defaultSearchOptions())
 		require.NoError(t, err)
 		require.Equal(t, 1, len(res.Traces), req)
 		require.Equal(t, expected, res.Traces[0], "search request:", req)
@@ -182,7 +182,7 @@ func TestBackendBlockSearch(t *testing.T) {
 		makeReq("foo", "baz"),
 	}
 	for _, req := range searchesThatDontMatch {
-		res, err := b.Search(ctx, req, common.DefaultSearchOptions())
+		res, err := b.Search(ctx, req, defaultSearchOptions())
 		require.NoError(t, err)
 		require.Empty(t, res.Traces, "search request:", req)
 	}
@@ -217,4 +217,12 @@ func makeBackendBlockWithTrace(t *testing.T, tr *Trace) *backendBlock {
 	b := newBackendBlock(s.meta, r)
 
 	return b
+}
+
+func defaultSearchOptions() common.SearchOptions {
+	return common.SearchOptions{
+		ChunkSizeBytes:  1_000_000,
+		ReadBufferCount: 8,
+		ReadBufferSize:  4 * 1024 * 1024,
+	}
 }

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -354,6 +354,7 @@ func (rw *readerWriter) Search(ctx context.Context, meta *backend.BlockMeta, req
 		return nil, err
 	}
 
+	rw.cfg.Search.ApplyToOptions(&opts)
 	return block.Search(ctx, req, opts)
 }
 


### PR DESCRIPTION
**What this PR does**:
Exposes two major parameters that control Parquet search to be configurable. This was a little awkward b/c the SearchOptions is a combination struct of configurable fields and http params. Also, some solutions create circular dependencies. Did what I could, suggestions welcome.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`