### PR TITLE
[1513] Fix mismatch H1 and titles

### DIFF
--- a/docs/tempo/website/api_docs/_index.md
+++ b/docs/tempo/website/api_docs/_index.md
@@ -1,13 +1,13 @@
 ---
-title: API documentation
+title: Tempo API
 weight: 500
 ---
 
-# Tempo's API
+# Tempo API 
 
 Tempo exposes an API for pushing and querying traces, and operating the cluster itself.
 
-For the sake of clarity, in this document we have grouped API endpoints by service, but keep in mind that they're exposed both when running Tempo in microservices and monolithic mode:
+For the sake of clarity, API endpoints are grouped by service. These endpoints are exposed both when running Tempo in microservices and monolithic mode:
 - **microservices**: each service exposes its own endpoints
 - **monolithic**: the Tempo process exposes all API endpoints for the services running internally
 

--- a/docs/tempo/website/api_docs/_index.md
+++ b/docs/tempo/website/api_docs/_index.md
@@ -1,5 +1,7 @@
 ---
 title: Tempo API
+description: Grafana Tempo exposes an API for pushing and querying traces, and operating the cluster itself.
+menuTitle: Tempo API
 weight: 500
 ---
 

--- a/docs/tempo/website/configuration/azure.md
+++ b/docs/tempo/website/configuration/azure.md
@@ -1,11 +1,11 @@
 ---
-title: Azure permissions and management
+title: Azure blob storage permissions and management
 weight: 3
 ---
 
 # Azure blob storage permissions and management
 
-For Tempo to authenticate to and access Azure blob storage, the following configuration is required:
+Tempo requires the following configuration to authenticate to and access Azure blob storage:
 
 - Storage Account name specified in the configuration file as `storage-account-name` or in the environment variable `AZURE_STORAGE_ACCOUNT`
 - Credentials for accessing the Storage Account; can be one of the following

--- a/docs/tempo/website/getting-started/_index.md
+++ b/docs/tempo/website/getting-started/_index.md
@@ -41,7 +41,7 @@ information from a client application with minimal manual instrumentation of the
 * [OpenTelemetry .NET Autoinstrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation)
 * [OpenTelemetry Python Autoinstrumentation](https://github.com/open-telemetry/opentelemetry-python-contrib)
 
-> Note: Check out our [instrumentation examples]({{< relref "./instrumentation" >}}) to learn how to instrument your
+> Note: Check out our [instrumentation references]({{< relref "./instrumentation" >}}) to learn how to instrument your
 > favourite language for distributed tracing.
 
 ## 2. Pipeline (Grafana Agent)

--- a/docs/tempo/website/getting-started/_index.md
+++ b/docs/tempo/website/getting-started/_index.md
@@ -3,7 +3,7 @@ title: Getting started
 weight: 150
 ---
 
-# Getting started with Tempo
+# Getting started 
 
 Distributed tracing visualizes the lifecycle of a request as it passes through
 a set of applications. There are a few components that must be configured in order to get a
@@ -11,7 +11,7 @@ working distributed tracing visualization.
 
 This document discusses the four major pieces necessary to build out a tracing system:
 Instrumentation, Pipeline, Backend and Visualization. If one were to build a diagram laying
-out these pieces it may look something like this:
+out these pieces, it may look something like this:
 
 <p align="center"><img src="getting-started.png" alt="Tracing Overview"></p>
 

--- a/docs/tempo/website/getting-started/example-demo-app.md
+++ b/docs/tempo/website/getting-started/example-demo-app.md
@@ -1,12 +1,12 @@
 ---
-title: Example configurations
+title: Example setups
 aliases:
 - /docs/tempo/latest/getting-started/quickstart-tempo/
 - /docs/tempo/latest/guides/loki-derived-fields/
 weight: 200
 ---
 
-# Example configurations
+# Example setups
 
 These examples show various deployment and [configuration]({{< relref "../configuration" >}}) options. They include trace
 generators so an existing application is not necessary to get started experimenting with Tempo. If you are interested in

--- a/docs/tempo/website/getting-started/example-demo-app.md
+++ b/docs/tempo/website/getting-started/example-demo-app.md
@@ -1,12 +1,12 @@
 ---
-title: Example setups
+title: Example configurations
 aliases:
 - /docs/tempo/latest/getting-started/quickstart-tempo/
 - /docs/tempo/latest/guides/loki-derived-fields/
 weight: 200
 ---
 
-# Running the Tempo backend
+# Example configurations
 
 These examples show various deployment and [configuration]({{< relref "../configuration" >}}) options. They include trace
 generators so an existing application is not necessary to get started experimenting with Tempo. If you are interested in
@@ -36,7 +36,8 @@ There are monolithic mode and microservices examples.
 
 ## The New Stack demo
 
-The [New Stack (TNS) demo](https://github.com/grafana/tns) demonstrates a fully-instrumented three-tier application and the integration of Grafana, Prometheus, Loki, and Tempo [features](https://github.com/grafana/tns#demoable-things), including metrics to traces (exemplars), logs to traces, and traces to logs. A good place to start is the [docker-compose setup](https://github.com/grafana/tns/tree/main/production/docker-compose) which includes a pre-built dashboard, load generator, and exemplars.
+The [New Stack (TNS) demo](https://github.com/grafana/tns) demonstrates a fully instrumented three-tier application and the integration of Grafana, Prometheus, Loki, and Tempo [features](https://github.com/grafana/tns#demoable-things), including metrics to traces (exemplars), logs to traces, and traces to logs. 
+A good place to start is the [docker-compose setup](https://github.com/grafana/tns/tree/main/production/docker-compose) which includes a pre-built dashboard, load generator, and exemplars.
 
 Explanation:
 - Metrics To Traces (Exemplars)

--- a/docs/tempo/website/getting-started/instrumentation.md
+++ b/docs/tempo/website/getting-started/instrumentation.md
@@ -1,5 +1,5 @@
 ---
-title: Instrumentation
+title: Instrumentation references
 aliases:
 - /docs/tempo/latest/guides/instrumentation/
 weight: 100

--- a/docs/tempo/website/metrics-generator/span_metrics.md
+++ b/docs/tempo/website/metrics-generator/span_metrics.md
@@ -1,10 +1,10 @@
 ---
 aliases:
 - /docs/tempo/latest/server_side_metrics/span_metrics/
-title: Span metrics
+title: Generate metrics from spans
 ---
 
-# Generating metrics from spans
+# Generate metrics from spans
 
 The span metrics processor generates metrics from ingested tracing data automatically.
 Span metrics aggregates request, error and duration (RED) metrics from span data.

--- a/docs/tempo/website/metrics-generator/span_metrics.md
+++ b/docs/tempo/website/metrics-generator/span_metrics.md
@@ -6,8 +6,7 @@ title: Generate metrics from spans
 
 # Generate metrics from spans
 
-The span metrics processor generates metrics from ingested tracing data automatically.
-Span metrics aggregates request, error and duration (RED) metrics from span data.
+The span metrics processor generates metrics from ingested tracing data, including request, error, and duration (RED) metrics.
 
 Span metrics generate two metrics:
 * A counter that computes requests

--- a/docs/tempo/website/operations/ingester_pvcs.md
+++ b/docs/tempo/website/operations/ingester_pvcs.md
@@ -5,13 +5,13 @@ weight: 5
 
 # Ingester persistent volume operations
 
-Tempo ingesters make heavy use of local disks to store write-ahead logs and blocks before being flushed to the backend (GCS, S3, etc).  It is important to monitor the free volume space as full disks can lead to data loss and other errors. The amount of disk space available affects how much volume a Tempo ingester can process, and the length of time an outage to the backend can be tolerated.
+Tempo ingesters make heavy use of local disks to store write-ahead logs and blocks before being flushed to the backend (GCS, S3, etc.).  It is important to monitor the free volume space as full disks can lead to data loss and other errors. The amount of disk space available affects how much volume a Tempo ingester can process and the length of time an outage to the backend can be tolerated.
 
 Therefore it may be necessary to increase the disk space for ingesters as usage increases. 
 
 ## Deploying 
 
-When deployed as a StatefulSet with Persistent Volume Claims (PVC), some manual steps are required. The following has worked successfully on GKE with GCS:
+When deployed as a StatefulSet with Persistent Volume Claims (PVC), some manual steps are required. The following configuration has worked successfully on GKE with GCS:
 
 1. Edit the persistent volume claim (pvc) for each ingester to the new size.
 

--- a/docs/tempo/website/operations/monitoring.md
+++ b/docs/tempo/website/operations/monitoring.md
@@ -1,5 +1,5 @@
 ---
-title: Monitoring
+title: Monitoring Tempo
 weight: 4
 ---
 

--- a/docs/tempo/website/operations/polling.md
+++ b/docs/tempo/website/operations/polling.md
@@ -3,7 +3,7 @@ title: Polling and monitoring
 weight: 8
 ---
 
-# Polling and monitoring
+# Polling 
 
 Tempo maintains knowledge of the state of the backend by polling it on regular intervals. There are currently
 only two components that need this knowledge and, consequently, only two that poll the backend: compactors

--- a/docs/tempo/website/operations/polling.md
+++ b/docs/tempo/website/operations/polling.md
@@ -3,7 +3,7 @@ title: Polling and monitoring
 weight: 8
 ---
 
-# Polling
+# Polling and monitoring
 
 Tempo maintains knowledge of the state of the backend by polling it on regular intervals. There are currently
 only two components that need this knowledge and, consequently, only two that poll the backend: compactors

--- a/docs/tempo/website/operations/serverless_aws.md
+++ b/docs/tempo/website/operations/serverless_aws.md
@@ -31,7 +31,7 @@ For more guidance on configuration options for full backend search [check here](
     aws s3 cp lambda/tempo-serverless-backend-search-297172a.zip gs://<newly provisioned gcs bucket>
     ```
 
-4. Provision the Lambda. In order for a Lambda function to be invoked via http we also need to create an
+4. Provision the Lambda. For a Lambda function to be invoked via HTTP, we also need to create an
    ALB and some other resources. This example uses Terraform and only includes the function definition.
    Additionally, you will need a VPC, security groups, IAM roles, an ALB, target groups, etc., but that is
    beyond the scope of this guide.

--- a/docs/tempo/website/troubleshooting/max-trace-limit-reached.md
+++ b/docs/tempo/website/troubleshooting/max-trace-limit-reached.md
@@ -3,7 +3,7 @@ title: Distributor refusing spans
 weight: 471
 ---
 
-# Distributors refusing spans
+# Distributor refusing spans
 
 The two most likely causes of refused spans are unhealthy ingesters or trace limits being exceeded.
 

--- a/docs/tempo/website/troubleshooting/too-many-jobs-in-queue.md
+++ b/docs/tempo/website/troubleshooting/too-many-jobs-in-queue.md
@@ -3,7 +3,7 @@ title: Too many jobs in the queue
 weight: 474
 ---
 
-# Error message ‘Too many jobs in the queue’
+# Error message: ‘Too many jobs in the queue’
 
 The error message might also be
 - `queue doesn't have room for 100 jobs`

--- a/docs/tempo/website/troubleshooting/unable-to-see-trace.md
+++ b/docs/tempo/website/troubleshooting/unable-to-see-trace.md
@@ -1,11 +1,11 @@
 ---
-title: Unable to Find Traces
+title: Unable to find traces
 weight: 473
 aliases:
 - /docs/tempo/latest/troubleshooting/missing-trace
 ---
 
-# Unable to find traces in Tempo
+# Unable to find traces
 
 **Potential causes**
 - There could be issues in ingestion of the data into Tempo, that is, spans are either not being sent correctly to Tempo or they are not getting sampled.
@@ -36,6 +36,7 @@ Receiver specific traffic information can also be obtained using `tempo_receiver
 
 ### Solutions
 
+There are three possible solutiosn. 
 #### Fixing protocol/port problems
 - Find out which communication protocol is being used by the application to emit traces. This is unique to every client SDK. For instance: Jaeger Golang Client uses `Thrift Compact over UDP` by default.
 - Check the list of supported protocols and their ports and ensure that the correct combination is being used. You will find the list of supported protocols and ports here: https://grafana.com/docs/tempo/latest/getting-started/#step-1-spin-up-tempo-backend

--- a/docs/tempo/website/troubleshooting/unable-to-see-trace.md
+++ b/docs/tempo/website/troubleshooting/unable-to-see-trace.md
@@ -36,7 +36,7 @@ Receiver specific traffic information can also be obtained using `tempo_receiver
 
 ### Solutions
 
-There are three possible solutiosn. 
+There are three possible solutions. 
 #### Fixing protocol/port problems
 - Find out which communication protocol is being used by the application to emit traces. This is unique to every client SDK. For instance: Jaeger Golang Client uses `Thrift Compact over UDP` by default.
 - Check the list of supported protocols and their ports and ensure that the correct combination is being used. You will find the list of supported protocols and ports here: https://grafana.com/docs/tempo/latest/getting-started/#step-1-spin-up-tempo-backend


### PR DESCRIPTION


Fixes #1513 to address mismatched h1 and page titles, with some exceptions. The backend search pages were not changed since they will eventually be nested. The release notes were also not changed. 

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`