### PR TITLE
BufferedReaderAt Concurrency Fix

### DIFF
--- a/pkg/io/buffered.go
+++ b/pkg/io/buffered.go
@@ -127,12 +127,12 @@ func (r *BufferedReaderAt) ReadAt(b []byte, offset int64) (int, error) {
 	if buf == nil {
 		// No buffer satisfied read, overwrite least-recently-used
 		buf = lru
-		r.prep(buf, offset, int64(len(b)))
 
 		// Here we exchange the top-level lock for
 		// the buffer's individual write lock
 		buf.mtx.Lock()
 		defer buf.mtx.Unlock()
+		r.prep(buf, offset, int64(len(b)))
 		buf.count = r.count
 		r.mtx.Unlock()
 

--- a/pkg/io/buffered_test.go
+++ b/pkg/io/buffered_test.go
@@ -2,6 +2,7 @@ package io
 
 import (
 	"bytes"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -95,6 +96,24 @@ func TestBufferedReaderAt(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, input[tr.offset:tr.offset+tr.length], b)
 		}
+	}
+}
+
+func TestBufferedReaderConcurrency(t *testing.T) {
+	input := make([]byte, 1024)
+	inputReader := bytes.NewReader(input)
+
+	r := NewBufferedReaderAt(inputReader, int64(len(input)), 50, 1)
+
+	for i := 0; i < 1000; i++ {
+		length := rand.Intn(100)
+		offset := rand.Intn(len(input) - length)
+		b := make([]byte, length)
+
+		go func() {
+			_, err := r.ReadAt(b, int64(offset))
+			require.NoError(t, err)
+		}()
 	}
 }
 


### PR DESCRIPTION
**What this PR does**:
Fixes a concurrency issue in the BufferedReaderAt and adds a test. Before this fix a buffer could be chosen twice for two different reads and the "prep" method would be run on a buffer that was currently in use by a different read.

Panics looked like:
```
panic: runtime error: slice bounds out of range [:-361]

goroutine 77 [running]:
github.com/grafana/tempo/pkg/io.(*BufferedReaderAt).read(...)
	/home/joe/dev/joe-elliott/tempo/pkg/io/buffered.go:50
github.com/grafana/tempo/pkg/io.(*BufferedReaderAt).ReadAt(0xc000100500, {0xc000186540, 0x62, 0x62}, 0x199)
	/home/joe/dev/joe-elliott/tempo/pkg/io/buffered.go:144 +0x545
github.com/grafana/tempo/pkg/io.TestBufferedReaderConcurrency.func1()
	/home/joe/dev/joe-elliott/tempo/pkg/io/buffered_test.go:114 +0x36
created by github.com/grafana/tempo/pkg/io.TestBufferedReaderConcurrency
	/home/joe/dev/joe-elliott/tempo/pkg/io/buffered_test.go:113 +0x12d
exit status 2
FAIL	github.com/grafana/tempo/pkg/io	0.006s
```