### PR TITLE
Fix an inconsistency in wal search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Additionally, default label `span_status` is renamed to `status_code`.
 * [BUGFIX] Update tempo microservices Helm values example which missed the 'enabled' key for thriftHttp. [#1472](https://github.com/grafana/tempo/pull/1472) (@hajowieland)
 * [BUGFIX] Fix race condition in forwarder overrides loop. [1468](https://github.com/grafana/tempo/pull/1468) (@mapno)
 * [BUGFIX] Fix v2 backend check on span name to be substring [#1538](https://github.com/grafana/tempo/pull/1538) (@mdisibio)
+* [BUGFIX] Fix wal check on span name to be substring [#1548](https://github.com/grafana/tempo/pull/1548) (@mdisibio)
 * [ENHANCEMENT] Add a config to query single ingester instance based on trace id hash for Trace By ID API. (1484)[https://github.com/grafana/tempo/pull/1484] (@sagarwala, @bikashmishra100, @ashwinidulams)
 * [ENHANCEMENT] Add blocklist metrics for total backend objects and total backend bytes [#1519](https://github.com/grafana/tempo/pull/1519) (@ie-pham)
 

--- a/modules/distributor/search_data.go
+++ b/modules/distributor/search_data.go
@@ -1,113 +1,14 @@
 package distributor
 
-import (
-	"strconv"
-
-	"github.com/grafana/tempo/pkg/model/trace"
-	"github.com/grafana/tempo/pkg/tempofb"
-	"github.com/grafana/tempo/pkg/tempopb"
-	common_v1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
-)
-
-type extractTagFunc func(tag string) bool
+import "github.com/grafana/tempo/pkg/model/trace"
 
 // extractSearchDataAll returns flatbuffer search data for every trace.
-func extractSearchDataAll(traces []*rebatchedTrace, extractTag extractTagFunc) [][]byte {
+func extractSearchDataAll(traces []*rebatchedTrace, extractTag trace.ExtractTagFunc) [][]byte {
 	headers := make([][]byte, len(traces))
 
 	for i, t := range traces {
-		headers[i] = extractSearchData(t.trace, t.id, extractTag)
+		headers[i] = trace.ExtractSearchData(t.trace, t.id, extractTag)
 	}
 
 	return headers
-}
-
-// extractSearchData returns the flatbuffer search data for the given trace.  It is extracted here
-// in the distributor because this is the only place on the ingest path where the trace is available
-// in object form.
-func extractSearchData(tr *tempopb.Trace, id []byte, extractTag extractTagFunc) []byte {
-	data := &tempofb.SearchEntryMutable{}
-
-	data.TraceID = id
-
-	for _, b := range tr.Batches {
-		// Batch attrs
-		if b.Resource != nil {
-			for _, a := range b.Resource.Attributes {
-				if !extractTag(a.Key) {
-					continue
-				}
-				if s, ok := extractValueAsString(a.Value); ok {
-					data.AddTag(a.Key, s)
-				}
-			}
-		}
-
-		for _, ils := range b.InstrumentationLibrarySpans {
-			for _, s := range ils.Spans {
-
-				// Root span
-				if len(s.ParentSpanId) == 0 {
-
-					// Collect root.name
-					data.AddTag(trace.RootSpanNameTag, s.Name)
-
-					// Collect root.service.name
-					if b.Resource != nil {
-						for _, a := range b.Resource.Attributes {
-							if a.Key == trace.ServiceNameTag {
-								if s, ok := extractValueAsString(a.Value); ok {
-									data.AddTag(trace.RootServiceNameTag, s)
-								}
-							}
-						}
-					}
-				}
-
-				// Collect for any spans
-				data.AddTag(trace.SpanNameTag, s.Name)
-				if s.Status != nil {
-					data.AddTag(trace.StatusCodeTag, strconv.Itoa(int(s.Status.Code)))
-				}
-				data.SetStartTimeUnixNano(s.StartTimeUnixNano)
-				data.SetEndTimeUnixNano(s.EndTimeUnixNano)
-
-				for _, a := range s.Attributes {
-					if !extractTag(a.Key) {
-						continue
-					}
-					if s, ok := extractValueAsString(a.Value); ok {
-						data.AddTag(a.Key, s)
-					}
-				}
-			}
-		}
-	}
-
-	return data.ToBytes()
-}
-
-func extractValueAsString(v *common_v1.AnyValue) (s string, ok bool) {
-	vv := v.GetValue()
-	if vv == nil {
-		return "", false
-	}
-
-	if s, ok := vv.(*common_v1.AnyValue_StringValue); ok {
-		return s.StringValue, true
-	}
-
-	if b, ok := vv.(*common_v1.AnyValue_BoolValue); ok {
-		return strconv.FormatBool(b.BoolValue), true
-	}
-
-	if i, ok := vv.(*common_v1.AnyValue_IntValue); ok {
-		return strconv.FormatInt(i.IntValue, 10), true
-	}
-
-	if d, ok := vv.(*common_v1.AnyValue_DoubleValue); ok {
-		return strconv.FormatFloat(d.DoubleValue, 'g', -1, 64), true
-	}
-
-	return "", false
 }

--- a/pkg/model/trace/search_data.go
+++ b/pkg/model/trace/search_data.go
@@ -1,0 +1,101 @@
+package trace
+
+import (
+	"strconv"
+
+	"github.com/grafana/tempo/pkg/tempofb"
+	"github.com/grafana/tempo/pkg/tempopb"
+	common_v1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
+)
+
+type ExtractTagFunc func(tag string) bool
+
+// ExtractSearchData returns the flatbuffer search data for the given trace.  It is extracted here
+// in the distributor because this is the only place on the ingest path where the trace is available
+// in object form.
+func ExtractSearchData(tr *tempopb.Trace, id []byte, extractTag ExtractTagFunc) []byte {
+	data := &tempofb.SearchEntryMutable{}
+
+	data.TraceID = id
+
+	for _, b := range tr.Batches {
+		// Batch attrs
+		if b.Resource != nil {
+			for _, a := range b.Resource.Attributes {
+				if !extractTag(a.Key) {
+					continue
+				}
+				if s, ok := extractValueAsString(a.Value); ok {
+					data.AddTag(a.Key, s)
+				}
+			}
+		}
+
+		for _, ils := range b.InstrumentationLibrarySpans {
+			for _, s := range ils.Spans {
+
+				// Root span
+				if len(s.ParentSpanId) == 0 {
+
+					// Collect root.name
+					data.AddTag(RootSpanNameTag, s.Name)
+
+					// Collect root.service.name
+					if b.Resource != nil {
+						for _, a := range b.Resource.Attributes {
+							if a.Key == ServiceNameTag {
+								if s, ok := extractValueAsString(a.Value); ok {
+									data.AddTag(RootServiceNameTag, s)
+								}
+							}
+						}
+					}
+				}
+
+				// Collect for any spans
+				data.AddTag(SpanNameTag, s.Name)
+				if s.Status != nil {
+					data.AddTag(StatusCodeTag, strconv.Itoa(int(s.Status.Code)))
+				}
+				data.SetStartTimeUnixNano(s.StartTimeUnixNano)
+				data.SetEndTimeUnixNano(s.EndTimeUnixNano)
+
+				for _, a := range s.Attributes {
+					if !extractTag(a.Key) {
+						continue
+					}
+					if s, ok := extractValueAsString(a.Value); ok {
+						data.AddTag(a.Key, s)
+					}
+				}
+			}
+		}
+	}
+
+	return data.ToBytes()
+}
+
+func extractValueAsString(v *common_v1.AnyValue) (s string, ok bool) {
+	vv := v.GetValue()
+	if vv == nil {
+		return "", false
+	}
+
+	if s, ok := vv.(*common_v1.AnyValue_StringValue); ok {
+		return s.StringValue, true
+	}
+
+	if b, ok := vv.(*common_v1.AnyValue_BoolValue); ok {
+		return strconv.FormatBool(b.BoolValue), true
+	}
+
+	if i, ok := vv.(*common_v1.AnyValue_IntValue); ok {
+		return strconv.FormatInt(i.IntValue, 10), true
+	}
+
+	if d, ok := vv.(*common_v1.AnyValue_DoubleValue); ok {
+		return strconv.FormatFloat(d.DoubleValue, 'g', -1, 64), true
+	}
+
+	return "", false
+}

--- a/pkg/model/trace/search_data_test.go
+++ b/pkg/model/trace/search_data_test.go
@@ -1,11 +1,10 @@
-package distributor
+package trace
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempofb"
 	"github.com/grafana/tempo/pkg/tempopb"
 	v1_common "github.com/grafana/tempo/pkg/tempopb/common/v1"
@@ -20,7 +19,7 @@ func TestExtractSearchData(t *testing.T) {
 		name       string
 		trace      *tempopb.Trace
 		id         []byte
-		extractTag extractTagFunc
+		extractTag ExtractTagFunc
 		searchData *tempofb.SearchEntryMutable
 	}{
 		{
@@ -64,11 +63,11 @@ func TestExtractSearchData(t *testing.T) {
 			searchData: &tempofb.SearchEntryMutable{
 				TraceID: traceIDA,
 				Tags: tempofb.NewSearchDataMapWithData(map[string][]string{
-					"foo":                    {"bar"},
-					trace.RootSpanNameTag:    {"firstSpan"},
-					trace.SpanNameTag:        {"firstSpan"},
-					trace.RootServiceNameTag: {"baz"},
-					trace.ServiceNameTag:     {"baz"},
+					"foo":              {"bar"},
+					RootSpanNameTag:    {"firstSpan"},
+					SpanNameTag:        {"firstSpan"},
+					RootServiceNameTag: {"baz"},
+					ServiceNameTag:     {"baz"},
 				}),
 				StartTimeUnixNano: 0,
 				EndTimeUnixNano:   0,
@@ -118,7 +117,7 @@ func TestExtractSearchData(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.searchData.ToBytes(), extractSearchData(tc.trace, tc.id, tc.extractTag))
+			assert.Equal(t, tc.searchData.ToBytes(), ExtractSearchData(tc.trace, tc.id, tc.extractTag))
 		})
 	}
 }

--- a/pkg/model/trace/search_test_suite.go
+++ b/pkg/model/trace/search_test_suite.go
@@ -92,7 +92,7 @@ func SearchTestSuite() (
 			{
 				Resource: &v1_resource.Resource{
 					Attributes: []*v1_common.KeyValue{
-						stringKV("service.name", "RootService"),
+						stringKV("service.name", "rootservice"),
 					},
 				},
 				InstrumentationLibrarySpans: []*v1.InstrumentationLibrarySpans{
@@ -100,7 +100,7 @@ func SearchTestSuite() (
 						Spans: []*v1.Span{
 							{
 								TraceId:           id,
-								Name:              "RootSpan",
+								Name:              "rootspan",
 								StartTimeUnixNano: uint64(1000 * time.Second),
 								EndTimeUnixNano:   uint64(1001 * time.Second),
 								Status:            &v1.Status{},
@@ -116,8 +116,8 @@ func SearchTestSuite() (
 		TraceID:           util.TraceIDToHexString(id),
 		StartTimeUnixNano: uint64(1000 * time.Second),
 		DurationMs:        1000,
-		RootServiceName:   "RootService",
-		RootTraceName:     "RootSpan",
+		RootServiceName:   "rootservice",
+		RootTraceName:     "rootspan",
 	}
 
 	// Matches

--- a/pkg/model/trace/search_test_suite.go
+++ b/pkg/model/trace/search_test_suite.go
@@ -1,0 +1,211 @@
+package trace
+
+import (
+	"time"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	v1_common "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	v1_resource "github.com/grafana/tempo/pkg/tempopb/resource/v1"
+	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	"github.com/grafana/tempo/pkg/util"
+	"github.com/grafana/tempo/pkg/util/test"
+)
+
+func stringKV(k, v string) *v1_common.KeyValue {
+	return &v1_common.KeyValue{
+		Key:   k,
+		Value: &v1_common.AnyValue{Value: &v1_common.AnyValue_StringValue{StringValue: v}},
+	}
+}
+
+func intKV(k string, v int) *v1_common.KeyValue {
+	return &v1_common.KeyValue{
+		Key:   k,
+		Value: &v1_common.AnyValue{Value: &v1_common.AnyValue_IntValue{IntValue: int64(v)}},
+	}
+}
+
+// Helper function to make a tag search
+func makeReq(k, v string) *tempopb.SearchRequest {
+	return &tempopb.SearchRequest{
+		Tags: map[string]string{
+			k: v,
+		},
+	}
+}
+
+// This is a fully-populated trace that we search for every condition
+func SearchTestSuite() (
+	id []byte,
+	tr *tempopb.Trace,
+	start, end uint32,
+	expected *tempopb.TraceSearchMetadata,
+	searchesThatMatch []*tempopb.SearchRequest,
+	searchesThatDontMatch []*tempopb.SearchRequest) {
+
+	id = test.ValidTraceID(nil)
+
+	start = 1000
+	end = 1001
+
+	tr = &tempopb.Trace{
+		Batches: []*v1.ResourceSpans{
+			{
+				Resource: &v1_resource.Resource{
+					Attributes: []*v1_common.KeyValue{
+						stringKV("service.name", "myservice"),
+						stringKV("cluster", "cluster"),
+						stringKV("namespace", "namespace"),
+						stringKV("pod", "pod"),
+						stringKV("container", "container"),
+						stringKV("k8s.cluster.name", "k8scluster"),
+						stringKV("k8s.namespace.name", "k8snamespace"),
+						stringKV("k8s.pod.name", "k8spod"),
+						stringKV("k8s.container.name", "k8scontainer"),
+						stringKV("bat", "baz"),
+					},
+				},
+				InstrumentationLibrarySpans: []*v1.InstrumentationLibrarySpans{
+					{
+						Spans: []*v1.Span{
+							{
+								TraceId:           id,
+								Name:              "hello",
+								SpanId:            []byte{1, 2, 3},
+								ParentSpanId:      []byte{4, 5, 6},
+								StartTimeUnixNano: uint64(1000 * time.Second),
+								EndTimeUnixNano:   uint64(1001 * time.Second),
+								Status: &v1.Status{
+									Code: v1.Status_STATUS_CODE_ERROR,
+								},
+								Attributes: []*v1_common.KeyValue{
+									stringKV("http.method", "get"),
+									stringKV("http.url", "url/hello/world"),
+									intKV("http.status_code", 500),
+									stringKV("foo", "bar"),
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Resource: &v1_resource.Resource{
+					Attributes: []*v1_common.KeyValue{
+						stringKV("service.name", "RootService"),
+					},
+				},
+				InstrumentationLibrarySpans: []*v1.InstrumentationLibrarySpans{
+					{
+						Spans: []*v1.Span{
+							{
+								TraceId:           id,
+								Name:              "RootSpan",
+								StartTimeUnixNano: uint64(1000 * time.Second),
+								EndTimeUnixNano:   uint64(1001 * time.Second),
+								Status:            &v1.Status{},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expected = &tempopb.TraceSearchMetadata{
+		TraceID:           util.TraceIDToHexString(id),
+		StartTimeUnixNano: uint64(1000 * time.Second),
+		DurationMs:        1000,
+		RootServiceName:   "RootService",
+		RootTraceName:     "RootSpan",
+	}
+
+	// Matches
+	searchesThatMatch = []*tempopb.SearchRequest{
+		{
+			// Empty request
+		},
+		{
+			MinDurationMs: 999,
+			MaxDurationMs: 1001,
+		},
+		{
+			Start: 1000,
+			End:   2000,
+		},
+		{
+			// Overlaps start
+			Start: 999,
+			End:   1001,
+		},
+		{
+			// Overlaps end
+			Start: 1001,
+			End:   1002,
+		},
+
+		// Well-known resource attributes
+		makeReq("service.name", "service"),
+		makeReq("cluster", "cluster"),
+		makeReq("namespace", "namespace"),
+		makeReq("pod", "pod"),
+		makeReq("container", "container"),
+		makeReq("k8s.cluster.name", "k8scluster"),
+		makeReq("k8s.namespace.name", "k8snamespace"),
+		makeReq("k8s.pod.name", "k8spod"),
+		makeReq("k8s.container.name", "k8scontainer"),
+
+		// Well-known span attributes
+		makeReq("name", "ell"),
+		makeReq("http.method", "get"),
+		makeReq("http.url", "hello"),
+		makeReq("http.status_code", "500"),
+		makeReq("status.code", "error"),
+
+		// Span attributes
+		makeReq("foo", "bar"),
+		// Resource attributes
+		makeReq("bat", "baz"),
+
+		// Multiple
+		{
+			Tags: map[string]string{
+				"service.name": "service",
+				"http.method":  "get",
+				"foo":          "bar",
+			},
+		},
+	}
+
+	// Excludes
+	searchesThatDontMatch = []*tempopb.SearchRequest{
+		{
+			MinDurationMs: 1001,
+		},
+		{
+			MaxDurationMs: 999,
+		},
+		{
+			Start: 100,
+			End:   200,
+		},
+
+		// Well-known resource attributes
+		makeReq("service.name", "foo"),
+		makeReq("cluster", "foo"),
+		makeReq("namespace", "foo"),
+		makeReq("pod", "foo"),
+		makeReq("container", "foo"),
+
+		// Well-known span attributes
+		makeReq("http.method", "post"),
+		makeReq("http.url", "asdf"),
+		makeReq("http.status_code", "200"),
+		makeReq("status.code", "ok"),
+
+		// Span attributes
+		makeReq("foo", "baz"),
+	}
+
+	return
+}

--- a/pkg/model/trace/search_test_suite.go
+++ b/pkg/model/trace/search_test_suite.go
@@ -34,7 +34,16 @@ func makeReq(k, v string) *tempopb.SearchRequest {
 	}
 }
 
-// This is a fully-populated trace that we search for every condition
+// SearchTestSuite returns a set of search test cases that ensure
+// search behavior is consistent across block types and modules.
+// The return parameters are:
+// * trace ID
+// * trace - a fully-populated trace that is searched for every condition. If testing a
+//           block format, then write this trace to the block.
+// * start, end - the unix second start/end times for the trace, i.e. slack-adjusted timestamps
+// * expected - The exact search result that should be returned for every matching request
+// * searchesThatMatch - List of search requests that are expected to match the trace
+// * searchesThatDontMatch - List of requests that don't match the trace
 func SearchTestSuite() (
 	id []byte,
 	tr *tempopb.Trace,

--- a/pkg/tempofb/search_entry_mutable.go
+++ b/pkg/tempofb/search_entry_mutable.go
@@ -2,12 +2,11 @@ package tempofb
 
 import (
 	flatbuffers "github.com/google/flatbuffers/go"
-	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
 // SearchEntryMutable is a mutable form of the flatbuffer-compiled SearchEntry struct to make building and transporting easier.
 type SearchEntryMutable struct {
-	TraceID           common.ID
+	TraceID           []byte
 	Tags              SearchDataMap
 	StartTimeUnixNano uint64
 	EndTimeUnixNano   uint64

--- a/pkg/tempofb/searchdatamap.go
+++ b/pkg/tempofb/searchdatamap.go
@@ -42,10 +42,12 @@ func (s SearchDataMap) Add(k, v string) {
 	}
 }
 
+// Contains is an exact match on key, but substring on value
 func (s SearchDataMap) Contains(k, v string) bool {
-	if values, ok := s[k]; ok {
-		_, ok := values[v]
-		return ok
+	for vv := range s[k] {
+		if strings.Contains(vv, v) {
+			return true
+		}
 	}
 	return false
 }

--- a/tempodb/search/backend_search_block_test.go
+++ b/tempodb/search/backend_search_block_test.go
@@ -73,7 +73,7 @@ func TestBackendSearchBlockSearch(t *testing.T) {
 			b1, err := NewStreamingSearchBlockForFile(f, uuid.New(), enc)
 			require.NoError(t, err)
 
-			b1.Append(ctx, id, [][]byte{data})
+			require.NoError(t, b1.Append(ctx, id, [][]byte{data}))
 
 			l, err := local.NewBackend(&local.Config{
 				Path: t.TempDir(),

--- a/tempodb/search/backend_search_block_test.go
+++ b/tempodb/search/backend_search_block_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempofb"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/tempodb/backend"
@@ -56,35 +57,69 @@ func newBackendSearchBlockWithTraces(t testing.TB, traceCount int, enc backend.E
 }
 
 func TestBackendSearchBlockSearch(t *testing.T) {
-	traceCount := 10_000
+	ctx := context.Background()
 
 	for _, enc := range backend.SupportedEncoding {
 		t.Run(enc.String(), func(t *testing.T) {
 
-			b2 := newBackendSearchBlockWithTraces(t, traceCount, enc, 0)
+			id, wantTr, _, _, meta, searchesThatMatch, searchesThatDontMatch := trace.SearchTestSuite()
 
-			p := NewSearchPipeline(&tempopb.SearchRequest{
-				Tags: map[string]string{"key20": "value_B_20"},
+			// Create backend search block with the test trace
+			data := trace.ExtractSearchData(wantTr, id, func(s string) bool { return true })
+
+			f, err := os.OpenFile(path.Join(t.TempDir(), "searchdata"), os.O_CREATE|os.O_RDWR, 0644)
+			require.NoError(t, err)
+
+			b1, err := NewStreamingSearchBlockForFile(f, uuid.New(), enc)
+			require.NoError(t, err)
+
+			b1.Append(ctx, id, [][]byte{data})
+
+			l, err := local.NewBackend(&local.Config{
+				Path: t.TempDir(),
 			})
+			require.NoError(t, err)
 
-			sr := NewResults()
+			blockID := uuid.New()
+			err = NewBackendSearchBlock(b1, backend.NewWriter(l), blockID, testTenantID, enc, 0)
+			require.NoError(t, err)
 
-			sr.StartWorker()
-			go func() {
-				defer sr.FinishWorker()
-				err := b2.Search(context.TODO(), p, sr)
-				require.NoError(t, err)
-			}()
-			sr.AllWorkersStarted()
+			b2 := OpenBackendSearchBlock(blockID, testTenantID, backend.NewReader(l))
 
-			var results []*tempopb.TraceSearchMetadata
-			for r := range sr.Results() {
-				results = append(results, r)
+			// Perform test suite
+
+			for _, req := range searchesThatMatch {
+				resp := search(t, b2, req)
+				require.Equal(t, 1, len(resp.Traces), "search request:", req)
+				require.Equal(t, meta, resp.Traces[0])
 			}
-			require.Equal(t, 1, len(results))
-			require.Equal(t, traceCount, int(sr.TracesInspected()))
+
+			for _, req := range searchesThatDontMatch {
+				resp := search(t, b2, req)
+				require.Equal(t, 0, len(resp.Traces), "search request:", req)
+			}
 		})
 	}
+}
+
+func search(t *testing.T, block SearchableBlock, req *tempopb.SearchRequest) *tempopb.SearchResponse {
+	p := NewSearchPipeline(req)
+
+	sr := NewResults()
+
+	sr.StartWorker()
+	go func() {
+		defer sr.FinishWorker()
+		err := block.Search(context.TODO(), p, sr)
+		require.NoError(t, err)
+	}()
+	sr.AllWorkersStarted()
+
+	resp := &tempopb.SearchResponse{}
+	for r := range sr.Results() {
+		resp.Traces = append(resp.Traces, r)
+	}
+	return resp
 }
 
 func TestBackendSearchBlockFinalSize(t *testing.T) {

--- a/tempodb/search/streaming_search_block_test.go
+++ b/tempodb/search/streaming_search_block_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempofb"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/tempodb/backend"
@@ -98,7 +99,7 @@ func TestStreamingSearchBlockReplay(t *testing.T) {
 	}
 }
 
-func TestStreamingSearchBlockSearchBlock(t *testing.T) {
+func TestStreamingSearchBlockSearchMetrics(t *testing.T) {
 	traceCount := 10
 	_, sb := newStreamingSearchBlockWithTraces(t, traceCount, backend.EncNone)
 
@@ -150,6 +151,36 @@ func TestStreamingSearchBlockSearchBlock(t *testing.T) {
 			require.Equal(t, tc.expectedTracesInspected, int(sr.TracesInspected()))
 			require.Equal(t, tc.expectedBlocksSkipped, int(sr.BlocksSkipped()))
 		})
+	}
+}
+
+func TestStreamingSearchBlock(t *testing.T) {
+	ctx := context.Background()
+
+	id, wantTr, _, _, meta, searchesThatMatch, searchesThatDontMatch := trace.SearchTestSuite()
+
+	// Create backend search block with the test trace
+	data := trace.ExtractSearchData(wantTr, id, func(s string) bool { return true })
+
+	f, err := os.OpenFile(path.Join(t.TempDir(), "searchdata"), os.O_CREATE|os.O_RDWR, 0644)
+	require.NoError(t, err)
+
+	b1, err := NewStreamingSearchBlockForFile(f, uuid.New(), backend.EncGZIP)
+	require.NoError(t, err)
+
+	b1.Append(ctx, id, [][]byte{data})
+
+	// Perform test suite
+
+	for _, req := range searchesThatMatch {
+		resp := search(t, b1, req)
+		require.Equal(t, 1, len(resp.Traces), "search request:", req)
+		require.Equal(t, meta, resp.Traces[0])
+	}
+
+	for _, req := range searchesThatDontMatch {
+		resp := search(t, b1, req)
+		require.Equal(t, 0, len(resp.Traces), "search request:", req)
 	}
 }
 

--- a/tempodb/search/streaming_search_block_test.go
+++ b/tempodb/search/streaming_search_block_test.go
@@ -168,7 +168,7 @@ func TestStreamingSearchBlock(t *testing.T) {
 	b1, err := NewStreamingSearchBlockForFile(f, uuid.New(), backend.EncGZIP)
 	require.NoError(t, err)
 
-	b1.Append(ctx, id, [][]byte{data})
+	require.NoError(t, b1.Append(ctx, id, [][]byte{data}))
 
 	// Perform test suite
 

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -9,12 +9,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/pkg/model"
-	"github.com/grafana/tempo/pkg/tempopb"
-	v1_common "github.com/grafana/tempo/pkg/tempopb/common/v1"
-	v1_resource "github.com/grafana/tempo/pkg/tempopb/resource/v1"
-	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
-	"github.com/grafana/tempo/pkg/util"
-	"github.com/grafana/tempo/pkg/util/test"
+	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/tempodb/backend/local"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 	v2 "github.com/grafana/tempo/tempodb/encoding/v2"
@@ -65,90 +60,24 @@ func testSearchCompleteBlock(t *testing.T, blockVersion string) {
 	r.EnablePolling(&mockJobSharder{})
 	rw := r.(*readerWriter)
 
-	id, wantTr, wantMeta := fullyPopulatedSearchTrace()
+	id, wantTr, start, end, wantMeta, searchesThatMatch, searchesThatDontMatch := trace.SearchTestSuite()
 
 	// Write to wal
 	wal := w.WAL()
 	head, err := wal.NewBlock(uuid.New(), testTenantID, model.CurrentEncoding)
 	require.NoError(t, err)
 	dec := model.MustNewSegmentDecoder(model.CurrentEncoding)
-	b1, err := dec.PrepareForWrite(wantTr, 1000, 1001)
+	b1, err := dec.PrepareForWrite(wantTr, start, end)
 	require.NoError(t, err)
 	b2, err := dec.ToObject([][]byte{b1})
 	require.NoError(t, err)
-	err = head.Append(id, b2, 1000, 1001)
+	err = head.Append(id, b2, start, end)
 	require.NoError(t, err, "unexpected error writing req")
 
 	// Complete block
 	block, err := w.CompleteBlock(head, &mockCombiner{})
 	require.NoError(t, err)
 	meta := block.BlockMeta()
-
-	// Helper function to make a tag search
-	makeReq := func(k, v string) *tempopb.SearchRequest {
-		return &tempopb.SearchRequest{
-			Tags: map[string]string{
-				k: v,
-			},
-		}
-	}
-
-	// Matches
-	searchesThatMatch := []*tempopb.SearchRequest{
-		{
-			// Empty request
-		},
-		{
-			MinDurationMs: 999,
-			MaxDurationMs: 1001,
-		},
-		{
-			Start: 1000,
-			End:   2000,
-		},
-		{
-			// Overlaps start
-			Start: 999,
-			End:   1001,
-		},
-		{
-			// Overlaps end
-			Start: 1001,
-			End:   1002,
-		},
-
-		// Well-known resource attributes
-		makeReq("service.name", "service"),
-		makeReq("cluster", "cluster"),
-		makeReq("namespace", "namespace"),
-		makeReq("pod", "pod"),
-		makeReq("container", "container"),
-		makeReq("k8s.cluster.name", "k8scluster"),
-		makeReq("k8s.namespace.name", "k8snamespace"),
-		makeReq("k8s.pod.name", "k8spod"),
-		makeReq("k8s.container.name", "k8scontainer"),
-
-		// Well-known span attributes
-		makeReq("name", "ell"),
-		makeReq("http.method", "get"),
-		makeReq("http.url", "hello"),
-		makeReq("http.status_code", "500"),
-		makeReq("status.code", "error"),
-
-		// Span attributes
-		makeReq("foo", "bar"),
-		// Resource attributes
-		makeReq("bat", "baz"),
-
-		// Multiple
-		{
-			Tags: map[string]string{
-				"service.name": "service",
-				"http.method":  "get",
-				"foo":          "bar",
-			},
-		},
-	}
 
 	for _, req := range searchesThatMatch {
 		res, err := r.Search(ctx, meta, req, common.DefaultSearchOptions())
@@ -157,130 +86,10 @@ func testSearchCompleteBlock(t *testing.T, blockVersion string) {
 		require.Equal(t, wantMeta, res.Traces[0], "search request:", req)
 	}
 
-	// Excludes
-	searchesThatDontMatch := []*tempopb.SearchRequest{
-		{
-			MinDurationMs: 1001,
-		},
-		{
-			MaxDurationMs: 999,
-		},
-		{
-			Start: 100,
-			End:   200,
-		},
-
-		// Well-known resource attributes
-		makeReq("service.name", "foo"),
-		makeReq("cluster", "foo"),
-		makeReq("namespace", "foo"),
-		makeReq("pod", "foo"),
-		makeReq("container", "foo"),
-
-		// Well-known span attributes
-		makeReq("http.method", "post"),
-		makeReq("http.url", "asdf"),
-		makeReq("http.status_code", "200"),
-		makeReq("status.code", "ok"),
-
-		// Span attributes
-		makeReq("foo", "baz"),
-	}
 	for _, req := range searchesThatDontMatch {
 		res, err := rw.Search(ctx, meta, req, common.DefaultSearchOptions())
 		require.NoError(t, err)
 		require.Empty(t, res.Traces, "search request:", req)
 	}
 
-}
-
-// This is a fully-populated trace that we search for every condition
-func fullyPopulatedSearchTrace() (common.ID, *tempopb.Trace, *tempopb.TraceSearchMetadata) {
-	stringKV := func(k, v string) *v1_common.KeyValue {
-		return &v1_common.KeyValue{
-			Key:   k,
-			Value: &v1_common.AnyValue{Value: &v1_common.AnyValue_StringValue{StringValue: v}},
-		}
-	}
-
-	intKV := func(k string, v int) *v1_common.KeyValue {
-		return &v1_common.KeyValue{
-			Key:   k,
-			Value: &v1_common.AnyValue{Value: &v1_common.AnyValue_IntValue{IntValue: int64(v)}},
-		}
-	}
-	id := test.ValidTraceID(nil)
-	tr := &tempopb.Trace{
-		Batches: []*v1.ResourceSpans{
-			{
-				Resource: &v1_resource.Resource{
-					Attributes: []*v1_common.KeyValue{
-						stringKV("service.name", "myservice"),
-						stringKV("cluster", "cluster"),
-						stringKV("namespace", "namespace"),
-						stringKV("pod", "pod"),
-						stringKV("container", "container"),
-						stringKV("k8s.cluster.name", "k8scluster"),
-						stringKV("k8s.namespace.name", "k8snamespace"),
-						stringKV("k8s.pod.name", "k8spod"),
-						stringKV("k8s.container.name", "k8scontainer"),
-						stringKV("bat", "baz"),
-					},
-				},
-				InstrumentationLibrarySpans: []*v1.InstrumentationLibrarySpans{
-					{
-						Spans: []*v1.Span{
-							{
-								TraceId:           id,
-								Name:              "hello",
-								SpanId:            []byte{1, 2, 3},
-								ParentSpanId:      []byte{4, 5, 6},
-								StartTimeUnixNano: uint64(1000 * time.Second),
-								EndTimeUnixNano:   uint64(1001 * time.Second),
-								Status: &v1.Status{
-									Code: v1.Status_STATUS_CODE_ERROR,
-								},
-								Attributes: []*v1_common.KeyValue{
-									stringKV("http.method", "get"),
-									stringKV("http.url", "url/hello/world"),
-									intKV("http.status_code", 500),
-									stringKV("foo", "bar"),
-								},
-							},
-						},
-					},
-				},
-			},
-			{
-				Resource: &v1_resource.Resource{
-					Attributes: []*v1_common.KeyValue{
-						stringKV("service.name", "RootService"),
-					},
-				},
-				InstrumentationLibrarySpans: []*v1.InstrumentationLibrarySpans{
-					{
-						Spans: []*v1.Span{
-							{
-								TraceId:           id,
-								Name:              "RootSpan",
-								StartTimeUnixNano: uint64(1000 * time.Second),
-								EndTimeUnixNano:   uint64(1001 * time.Second),
-								Status:            &v1.Status{},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	expected := &tempopb.TraceSearchMetadata{
-		TraceID:           util.TraceIDToHexString(id),
-		StartTimeUnixNano: uint64(1000 * time.Second),
-		DurationMs:        1000,
-		RootServiceName:   "RootService",
-		RootTraceName:     "RootSpan",
-	}
-
-	return id, tr, expected
 }


### PR DESCRIPTION
**What this PR does**:
This PR is a followup to #1538.  It runs the same comprehensive search tests against the two block types in the ingester: wal (StreamingSearchBlock) and completed (BackendSearchBlock).  A bug was found and addressed in the StreamingSearchBlock header tag check.

The comprehensive test cases in /tempodb/ were moved to /pkg/model/trace and made reusable, as well as the tag extraction logic from the distributor.  These two PRs are in preparation for #1547.

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`