### PR TITLE
Add sampling policies examples

### DIFF
--- a/docs/tempo/website/grafana-agent/tail-based-sampling.md
+++ b/docs/tempo/website/grafana-agent/tail-based-sampling.md
@@ -45,7 +45,7 @@ If you're using a multi-instance deployment of the agent,
 add load balancing and specify the resolving mechanism to find other Agents in the setup.
 To see all the available configuration options, refer to the [configuration reference](https://grafana.com/docs/agent/latest/configuration/traces-config/).
 
-```
+```yaml
 traces:
   configs:
     - name: default
@@ -63,4 +63,175 @@ traces:
         resolver:
           dns:
             hostname: host.namespace.svc.cluster.local
+```
+
+## Examples
+
+Sampling logic can be summarized into two rules:
+
+1. If a policy is met, the trace is sampled. Even if other policies are not met.
+2. If any of the spans of the trace meet the policy requirements, the trace is sampled.
+
+Next, there are a couple of examples of `tail_sampling` configurations,
+with descriptions of the policies and the expected behavior.
+
+### Sampling by latency and status
+
+Sampling traces that have a total duration longer than 100ms and traces that contain at least one span with status code `ERROR`.
+Total duration is determined by looking at the earliest start time and latest end time.
+
+```yaml
+traces:
+  configs:
+    - name: default
+      ...
+      tail_sampling:
+        policies:
+          - type: latency
+            latency:
+              threshold_ms: 100
+          - type: status_code
+            status_code:
+              status_codes:
+                - "ERROR"
+```
+
+### Sampling by attributes
+
+Sampling traces that do not contain the attribute `http.endpoint` equal to `/status` and `/metrics`.
+
+```yaml
+traces:
+  configs:
+    - name: default
+      ...
+      tail_sampling:
+        policies:
+        - attributes:
+          - name: http.endpoint
+            values: 
+              - /status
+              - /metrics
+            invert_match: true
+```
+
+### Sampling with `and` policy
+
+Sampling traces that have an attribute `http.endpoint` that matches `/api/v1/*`
+and that have a total duration longer than 100ms.
+
+```yaml
+traces:
+  configs:
+    - name: default
+      ...
+      tail_sampling:
+      policies:
+      - type: and
+        and:
+          and_sub_policy:
+            - type: string_attribute
+              string_attribute:
+              - name: http.endpoint
+                value: /api/v1/*
+                enabled_regex_matching: true
+                cache_max_size: 10
+            - type: latency
+              latency:
+                threshold_ms: 100
+```
+
+### Multi-requirement sampling
+
+Sampling requirements are the following:
+
+- Service A: latency> 3s
+- Service B: only error spans or latency> 5s
+- Service C: all spans
+
+```yaml
+traces:
+  configs:
+    - name: default
+      ...
+      tail_sampling:
+        policies:
+        # Service A: latency> 3s
+        - type: and
+          and:
+            and_sub_policy:
+              - type: latency
+                name: latency
+                latency:
+                  threshold_ms: 3000
+              - type: string_attribute
+                name: service-name
+                string_attribute:
+                  name: service.name
+                  values:
+                    - serviceA
+        # Service B requires two and policies
+        # 1. spans with status code ERROR
+        - type: and
+          and:
+            and_sub_policy:
+              - type: status_code
+                name: status_code
+                status_code:
+                  status_codes:
+                    - "ERROR"
+              - type: string_attribute
+                name: service-name
+                string_attribute:
+                  name: service.name
+                  values:
+                    - serviceB
+        # 2. latency> 5s
+        - type: and
+          and:
+            and_sub_policy:
+              - type: latency
+                name: latency
+                latency:
+                  threshold_ms: 5000
+              - type: string_attribute
+                name: service name
+                string_attribute:
+                  name: service.name
+                  values:
+                    - serviceB
+        # Service C: all spans
+        - type: string_attribute
+          string_attribute:
+            name: service.name
+            values:
+              - serviceC
+```
+
+## Sampling based on k8s metadata
+
+In this example, the Agent will sample traces that come from pods from the namespace `default`.
+Via `scrape_configs`, spans are relabeled with kubernetes metadata,
+in this case injecting the namespace attribute.
+
+```yaml
+traces:
+  configs:
+    - name: default
+    ...
+    scrape_configs:
+      - job_name: kubernetes-pods
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - action: replace
+            source_labels:
+              - __meta_kubernetes_namespace
+    tail_sampling:
+      policies:
+      - type: string_attribute
+        string_attribute:
+          name: namespace
+          values:
+          - default
 ```

--- a/docs/tempo/website/grafana-agent/tail-based-sampling.md
+++ b/docs/tempo/website/grafana-agent/tail-based-sampling.md
@@ -227,6 +227,7 @@ traces:
           - action: replace
             source_labels:
               - __meta_kubernetes_namespace
+            target_label: namespace
     tail_sampling:
       policies:
       - type: string_attribute


### PR DESCRIPTION
**What this PR does**:

Adds tail sampling policies examples to the documentation.
Used the new policy format (same as OTel), merged in https://github.com/grafana/agent/pull/1851

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`