### PR TITLE
Dependabot permissions and run interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - package-ecosystem: 'gomod'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
 
   - package-ecosystem: 'docker'
     directory: '/'
@@ -18,4 +18,4 @@ updates:
     # default location of `.github/workflows`
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'

--- a/.github/workflows/dependabot_serverless_gomod.yml
+++ b/.github/workflows/dependabot_serverless_gomod.yml
@@ -4,8 +4,6 @@ on: pull_request
 permissions:
   contents: write
   pull-requests: write
-  checks: write
-  actions: write
 
 jobs:
   dependabot:

--- a/.github/workflows/dependabot_serverless_gomod.yml
+++ b/.github/workflows/dependabot_serverless_gomod.yml
@@ -4,6 +4,8 @@ on: pull_request
 permissions:
   contents: write
   pull-requests: write
+  checks: write
+  actions: write
 
 jobs:
   dependabot:

--- a/.github/workflows/dependabot_serverless_gomod.yml
+++ b/.github/workflows/dependabot_serverless_gomod.yml
@@ -35,6 +35,6 @@ jobs:
 
       - name: Push changes
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
         run: |
           git push origin ${{ github.head_ref }}


### PR DESCRIPTION
**What this PR does**:

Here we attempt to grant the correct permissions necessary to allow the extra commit action to run the workflow after committing the serverless updates.

Also here is to reduce the run interval of the dependabot jobs.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`