### PR TITLE
metrics-generator: do not remove x-scope-orgid header in single tenant modus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Additionally, default label `span_status` is renamed to `status_code`.
 * [BUGFIX] Fix race condition in forwarder overrides loop. [1468](https://github.com/grafana/tempo/pull/1468) (@mapno)
 * [BUGFIX] Fix v2 backend check on span name to be substring [#1538](https://github.com/grafana/tempo/pull/1538) (@mdisibio)
 * [BUGFIX] Fix wal check on span name to be substring [#1548](https://github.com/grafana/tempo/pull/1548) (@mdisibio)
+* [BUGFIX] metrics-generator: do not remove x-scope-orgid header in single tenant modus [#1554](https://github.com/grafana/tempo/pull/1554) (@kvrhdn)
 * [ENHANCEMENT] Add a config to query single ingester instance based on trace id hash for Trace By ID API. (1484)[https://github.com/grafana/tempo/pull/1484] (@sagarwala, @bikashmishra100, @ashwinidulams)
 * [ENHANCEMENT] Add blocklist metrics for total backend objects and total backend bytes [#1519](https://github.com/grafana/tempo/pull/1519) (@ie-pham)
 

--- a/modules/generator/storage/config_util_test.go
+++ b/modules/generator/storage/config_util_test.go
@@ -49,13 +49,27 @@ func Test_generateTenantRemoteWriteConfigs_singleTenant(t *testing.T) {
 			URL:     &prometheus_common_config.URL{URL: urlMustParse("http://prometheus-1/api/prom/push")},
 			Headers: map[string]string{},
 		},
+		{
+			URL: &prometheus_common_config.URL{URL: urlMustParse("http://prometheus-2/api/prom/push")},
+			Headers: map[string]string{
+				"x-scope-orgid": "my-custom-tenant-id",
+			},
+		},
 	}
 
 	result := generateTenantRemoteWriteConfigs(original, util.FakeTenantID, logger)
 
 	assert.Equal(t, original[0].URL, result[0].URL)
+
+	assert.Equal(t, original[0].URL, result[0].URL)
+	assert.Equal(t, map[string]string{}, original[0].Headers, "Original headers have been modified")
 	// X-Scope-OrgID has not been injected
-	assert.Empty(t, result[0].Headers)
+	assert.Equal(t, map[string]string{}, result[0].Headers)
+
+	assert.Equal(t, original[1].URL, result[1].URL)
+	assert.Equal(t, map[string]string{"x-scope-orgid": "my-custom-tenant-id"}, original[1].Headers, "Original headers have been modified")
+	// X-Scope-OrgID has not been modified
+	assert.Equal(t, map[string]string{"x-scope-orgid": "my-custom-tenant-id"}, result[1].Headers)
 }
 
 func Test_copyMap(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:
When metrics-generator is run in single-tenant modus and an `x-scope-orgid` header is set in the remote write config, do not remove it. This is a protection added to multitenant system, in which you don't want each tenant to use the same remote write config. This doesn't make sense in single-tenant setups.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/tempo/issues/1448

**Checklist**
- [x] Tests updated
- [ ] ~~Documentation added~~
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`