### PR TITLE
Add ephemeral storage to generator for wal storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,14 @@ Additionally, default label `span_status` is renamed to `status_code`.
       external_hedge_requests_at: 4s    -> 8s
       external_hedge_requests_up_to: 3  -> 2
   ```
-* [CHANGE] Include emptyDir for metrics generator wal storage [#1556](https://github.com/grafana/tempo/pull/1556) (@zalegrala)
+* [CHANGE] **BREAKING CHANGE** Include emptyDir for metrics generator wal storage in jsonnet [#1556](https://github.com/grafana/tempo/pull/1556) (@zalegrala)
+Jsonnet users will now need to specify a storage request and limit for the generator wal.
+    _config+:: {
+      metrics_generator+: {
+        ephemeral_storage_request_size: '10Gi',
+        ephemeral_storage_limit_size: '11Gi',
+      },
+    }
 * [FEATURE] metrics-generator: support per-tenant processor configuration [#1434](https://github.com/grafana/tempo/pull/1434) (@kvrhdn)
 * [FEATURE] Include rollout dashboard [#1456](https://github.com/grafana/tempo/pull/1456) (@zalegrala)
 * [FEATURE] Add SentinelPassword configuration for Redis [#1463](https://github.com/grafana/tempo/pull/1463) (@zalegrala)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Additionally, default label `span_status` is renamed to `status_code`.
       external_hedge_requests_at: 4s    -> 8s
       external_hedge_requests_up_to: 3  -> 2
   ```
+* [CHANGE] Include emptyDir for metrics generator wal storage [#1556](https://github.com/grafana/tempo/pull/1556) (@zalegrala)
 * [FEATURE] metrics-generator: support per-tenant processor configuration [#1434](https://github.com/grafana/tempo/pull/1434) (@kvrhdn)
 * [FEATURE] Include rollout dashboard [#1456](https://github.com/grafana/tempo/pull/1456) (@zalegrala)
 * [FEATURE] Add SentinelPassword configuration for Redis [#1463](https://github.com/grafana/tempo/pull/1463) (@zalegrala)

--- a/operations/jsonnet-compiled/ConfigMap-tempo-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/ConfigMap-tempo-metrics-generator.yaml
@@ -13,6 +13,9 @@ data:
         bind_port: 7946
         join_members:
             - gossip-ring.tracing.svc.cluster.local:7946
+    metrics_generator:
+        storage:
+            path: /var/tempo/generator_wal
     metrics_generator_enabled: false
     overrides:
         per_tenant_override_config: /overrides/overrides.yaml

--- a/operations/jsonnet-compiled/Deployment-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/Deployment-metrics-generator.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        config_hash: 345364f17b5771460510d3d5b9028e3c
+        config_hash: 38371b26593e9c469c05ce32310ccdc9
       labels:
         app: metrics-generator
         name: metrics-generator
@@ -45,13 +45,17 @@ spec:
         resources:
           limits:
             cpu: "1"
+            ephemeral-storage: 11Gi
             memory: 2Gi
           requests:
             cpu: 500m
+            ephemeral-storage: 10Gi
             memory: 1Gi
         volumeMounts:
         - mountPath: /conf
           name: tempo-conf
+        - mountPath: /var/tempo/generator_wal
+          name: metrics-generator-wal-data
         - mountPath: /overrides
           name: overrides
       volumes:
@@ -61,3 +65,5 @@ spec:
       - configMap:
           name: tempo-overrides
         name: overrides
+      - emptyDir: {}
+        name: metrics-generator-wal-data

--- a/operations/jsonnet-compiled/Service-querier.yaml
+++ b/operations/jsonnet-compiled/Service-querier.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: querier
+  name: querier
+  namespace: tracing
+spec:
+  ports:
+  - name: querier-prom-metrics
+    port: 3200
+    targetPort: 3200
+  selector:
+    app: querier
+    name: querier
+    tempo-gossip-member: "true"

--- a/operations/jsonnet-compiled/util/example/main.jsonnet
+++ b/operations/jsonnet-compiled/util/example/main.jsonnet
@@ -44,6 +44,10 @@ tempo {
         },
       },
     },
+    metrics_generator+: {
+      ephemeral_storage_request: '10Gi',
+      ephemeral_storage_limit: '11Gi',
+    },
     memcached+: {
       replicas: 5,
     },

--- a/operations/jsonnet-compiled/util/example/main.jsonnet
+++ b/operations/jsonnet-compiled/util/example/main.jsonnet
@@ -45,8 +45,8 @@ tempo {
       },
     },
     metrics_generator+: {
-      ephemeral_storage_request: '10Gi',
-      ephemeral_storage_limit: '11Gi',
+      ephemeral_storage_request_size: '10Gi',
+      ephemeral_storage_limit_size: '11Gi',
     },
     memcached+: {
       replicas: 5,

--- a/operations/jsonnet-compiled/util/jsonnetfile.lock.json
+++ b/operations/jsonnet-compiled/util/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "03d32a72a2a0bf0ee00ffc853be5f07ad3bafcbe",
-      "sum": "JDsc/bUs5Yv1RkGKcm0hMteqCKZqemxA3qP6eiEATr8="
+      "version": "1aa353b7afc7ce46351b88d52235ae7a17f4ec0e",
+      "sum": "QiIOYQ0mdyVXStdPxu99M5CYGtYAXczWAC62EAQmWBM="
     },
     {
       "source": {
@@ -18,8 +18,8 @@
           "subdir": "memcached"
         }
       },
-      "version": "03d32a72a2a0bf0ee00ffc853be5f07ad3bafcbe",
-      "sum": "dTOeEux3t9bYSqP2L/uCuLo/wUDpCKH4w+4OD9fePUk="
+      "version": "1aa353b7afc7ce46351b88d52235ae7a17f4ec0e",
+      "sum": "8hXTN4QOMkpad75LESkdfRD4/Sl81fMqZcD0ZPx2SNc="
     },
     {
       "source": {

--- a/operations/jsonnet-compiled/util/vendor/github.com/grafana/jsonnet-libs/ksonnet-util/legacy-subtypes.libsonnet
+++ b/operations/jsonnet-compiled/util/vendor/github.com/grafana/jsonnet-libs/ksonnet-util/legacy-subtypes.libsonnet
@@ -111,13 +111,13 @@
 
   local rbacPatch = {
     local role = {
-      rulesType: $.rbac.v1beta1.policyRule,
+      rulesType: $.rbac.v1.policyRule,
     },
     role+: role,
     clusterRole+: role,
 
     local binding = {
-      subjectsType: $.rbac.v1beta1.subject,
+      subjectsType: $.rbac.v1.subject,
     },
     roleBinding+: binding,
     clusterRoleBinding+: binding,
@@ -130,6 +130,7 @@
   },
   rbac+: {
     v1+: rbacPatch,
+    // TODO: the v1beta1 RBAC API has been removed in Kubernetes 1.22 and should get removed once 1.22 is the oldest supported version
     v1beta1+: rbacPatch,
   },
 

--- a/operations/jsonnet-compiled/util/vendor/github.com/grafana/jsonnet-libs/ksonnet-util/legacy-types.libsonnet
+++ b/operations/jsonnet-compiled/util/vendor/github.com/grafana/jsonnet-libs/ksonnet-util/legacy-types.libsonnet
@@ -15,12 +15,13 @@
   },
   rbac+: {
     v1+: {
-      policyRule:: $.rbac.v1beta1.clusterRole.rulesType,
-      subject:: $.rbac.v1beta1.clusterRoleBinding.subjectsType,
+      policyRule:: $.rbac.v1.clusterRole.rulesType,
+      subject:: $.rbac.v1.clusterRoleBinding.subjectsType,
     },
+    // TODO: the v1beta1 RBAC API has been removed in Kubernetes 1.22 and should get removed once 1.22 is the oldest supported version
     v1beta1+: {
-      policyRule:: $.rbac.v1beta1.clusterRole.rulesType,
-      subject:: $.rbac.v1beta1.clusterRoleBinding.subjectsType,
+      policyRule:: $.rbac.v1.clusterRole.rulesType,
+      subject:: $.rbac.v1.clusterRoleBinding.subjectsType,
     },
   },
 }

--- a/operations/jsonnet-compiled/util/vendor/github.com/grafana/jsonnet-libs/ksonnet-util/util.libsonnet
+++ b/operations/jsonnet-compiled/util/vendor/github.com/grafana/jsonnet-libs/ksonnet-util/util.libsonnet
@@ -162,7 +162,7 @@ local util(k) = {
     ])
     + (if annotations != {} then deployment.mixin.spec.template.metadata.withAnnotationsMixin(annotations) else {}),
 
-  hostVolumeMount(name, hostPath, path, readOnly=false, volumeMountMixin={})::
+  hostVolumeMount(name, hostPath, path, readOnly=false, volumeMountMixin={}, volumeMixin={})::
     local container = k.core.v1.container,
           deployment = k.apps.v1.deployment,
           volumeMount = k.core.v1.volumeMount,
@@ -174,7 +174,8 @@ local util(k) = {
 
     deployment.mapContainers(addMount) +
     deployment.mixin.spec.template.spec.withVolumesMixin([
-      volume.fromHostPath(name, hostPath),
+      volume.fromHostPath(name, hostPath) +
+      volumeMixin,
     ]),
 
   pvcVolumeMount(pvcName, path, readOnly=false, volumeMountMixin={})::

--- a/operations/jsonnet-compiled/util/vendor/github.com/grafana/jsonnet-libs/memcached/memcached.libsonnet
+++ b/operations/jsonnet-compiled/util/vendor/github.com/grafana/jsonnet-libs/memcached/memcached.libsonnet
@@ -23,6 +23,7 @@ k {
     max_item_size:: '1m',
     memory_limit_mb:: 1024,
     overprovision_factor:: 1.2,
+    cpu_requests:: '500m',
     cpu_limits:: '3',
     connection_limit:: 1024,
     memory_request_overhead_mb:: 100,
@@ -43,7 +44,7 @@ k {
         '-c %(connection_limit)s' % self,
         '-v',
       ]) +
-      $.util.resourcesRequests('500m', $.util.bytesToK8sQuantity(self.memory_request_bytes)) +
+      $.util.resourcesRequests(self.cpu_requests, $.util.bytesToK8sQuantity(self.memory_request_bytes)) +
       $.util.resourcesLimits(self.cpu_limits, $.util.bytesToK8sQuantity(self.memory_limits_bytes)),
 
     memcached_exporter::

--- a/operations/jsonnet/microservices/common.libsonnet
+++ b/operations/jsonnet/microservices/common.libsonnet
@@ -1,11 +1,14 @@
 {
+  local k = import 'ksonnet-util/kausal.libsonnet',
+  local pvc = k.core.v1.persistentVolumeClaim,
+
   util+:: {
     local k = import 'ksonnet-util/kausal.libsonnet',
     local container = k.core.v1.container,
 
     withResources(resources)::
-        k.util.resourcesRequests(resources.requests.cpu, resources.requests.memory) +
-        k.util.resourcesLimits(resources.limits.cpu, resources.limits.memory),
+      k.util.resourcesRequests(resources.requests.cpu, resources.requests.memory) +
+      k.util.resourcesLimits(resources.limits.cpu, resources.limits.memory),
 
     readinessProbe::
       container.mixin.readinessProbe.httpGet.withPath('/ready') +

--- a/operations/jsonnet/microservices/common.libsonnet
+++ b/operations/jsonnet/microservices/common.libsonnet
@@ -1,7 +1,4 @@
 {
-  local k = import 'ksonnet-util/kausal.libsonnet',
-  local pvc = k.core.v1.persistentVolumeClaim,
-
   util+:: {
     local k = import 'ksonnet-util/kausal.libsonnet',
     local container = k.core.v1.container,

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -80,8 +80,8 @@
       },
     },
     metrics_generator: {
-      pvc_size: error 'Must specify an ingester pvc size',
-      pvc_storage_class: error 'Must specify an ingester pvc storage class',
+      ephemeral_storage_request: error 'Must specify a generator ephemeral_storage_request size',
+      ephemeral_storage_limit: error 'Must specify a metrics generator ephemeral_storage_limit size',
       replicas: 0,
       resources: {
         requests: {

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -80,8 +80,8 @@
       },
     },
     metrics_generator: {
-      ephemeral_storage_request: error 'Must specify a generator ephemeral_storage_request size',
-      ephemeral_storage_limit: error 'Must specify a metrics generator ephemeral_storage_limit size',
+      ephemeral_storage_request_size: error 'Must specify a generator ephemeral_storage_request size',
+      ephemeral_storage_limit_size: error 'Must specify a metrics generator ephemeral_storage_limit size',
       replicas: 0,
       resources: {
         requests: {

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -80,11 +80,13 @@
       },
     },
     metrics_generator: {
+      pvc_size: error 'Must specify an ingester pvc size',
+      pvc_storage_class: error 'Must specify an ingester pvc storage class',
       replicas: 0,
       resources: {
-        requests:{
+        requests: {
           cpu: '500m',
-          memory: '1Gi'
+          memory: '1Gi',
         },
         limits: {
           cpu: '1',

--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -66,7 +66,13 @@
 
   tempo_ingester_config:: $.tempo_config {},
 
-  tempo_metrics_generator_config:: $.tempo_config{},
+  tempo_metrics_generator_config:: $.tempo_config {
+    metrics_generator+: {
+      storage+: {
+        path: '/var/tempo/generator_wal',
+      },
+    },
+  },
 
   tempo_compactor_config:: $.tempo_config {
     compactor+: {

--- a/operations/jsonnet/microservices/generator.libsonnet
+++ b/operations/jsonnet/microservices/generator.libsonnet
@@ -3,26 +3,15 @@
 
   local container = k.core.v1.container,
   local containerPort = k.core.v1.containerPort,
+  local deployment = k.apps.v1.deployment,
   local statefulset = k.apps.v1.statefulSet,
-  local pvc = k.core.v1.persistentVolumeClaim,
   local volume = k.core.v1.volume,
   local volumeMount = k.core.v1.volumeMount,
 
   local target_name = 'metrics-generator',
   local tempo_config_volume = 'tempo-conf',
-  local tempo_data_volume = 'metrics-generator-data',
+  local tempo_generator_wal_volume = 'metrics-generator-wal-data',
   local tempo_overrides_config_volume = 'overrides',
-
-  tempo_metrics_generator_pvc::
-    pvc.new()
-    + pvc.mixin.metadata.withName(tempo_data_volume)
-    + pvc.mixin.metadata.withLabels({ app: target_name })
-    + pvc.mixin.metadata.withNamespace($._config.namespace)
-    // waiting for k 1.23
-    // + pvc.mixin.spec.persistentVolumeClaimRetentionPolicy.withWhenScaled('delete')
-    + pvc.mixin.spec.resources.withRequests({ storage: $._config.metrics_generator.pvc_size })
-    + pvc.mixin.spec.withAccessModes(['ReadWriteOnce'])
-    + pvc.mixin.spec.withStorageClassName($._config.metrics_generator.pvc_storage_class),
 
   tempo_metrics_generator_container::
     container.new(target_name, $._images.tempo) +
@@ -36,31 +25,35 @@
     ]) +
     container.withVolumeMounts([
       volumeMount.new(tempo_config_volume, '/conf'),
-      volumeMount.new(tempo_data_volume, $.tempo_metrics_generator_config.metrics_generator.storage.path),
+      volumeMount.new(tempo_generator_wal_volume, $.tempo_metrics_generator_config.metrics_generator.storage.path),
       volumeMount.new(tempo_overrides_config_volume, '/overrides'),
     ]) +
     $.util.withResources($._config.metrics_generator.resources) +
+    container.mixin.resources.withRequestsMixin({ 'ephemeral-storage': $._config.metrics_generator.ephemeral_storage_request }) +
+    container.mixin.resources.withLimitsMixin({ 'ephemeral-storage': $._config.metrics_generator.ephemeral_storage_limit }) +
     $.util.readinessProbe,
 
-  tempo_metrics_generator_statefulset:
-    statefulset.new(
+  tempo_metrics_generator_deployment:
+    deployment.new(
       target_name,
       $._config.metrics_generator.replicas,
       $.tempo_metrics_generator_container,
-      $.tempo_metrics_generator_pvc,
       {
         app: target_name,
         [$._config.gossip_member_label]: 'true',
       },
     ) +
-    statefulset.mixin.spec.template.metadata.withAnnotations({
+    deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(3) +
+    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
+    deployment.mixin.spec.template.metadata.withAnnotations({
       config_hash: std.md5(std.toString($.tempo_metrics_generator_configmap.data['tempo.yaml'])),
     }) +
-    statefulset.mixin.spec.template.spec.withVolumes([
+    deployment.mixin.spec.template.spec.withVolumes([
       volume.fromConfigMap(tempo_config_volume, $.tempo_metrics_generator_configmap.metadata.name),
       volume.fromConfigMap(tempo_overrides_config_volume, $._config.overrides_configmap_name),
+      volume.fromEmptyDir(tempo_generator_wal_volume),
     ]),
 
   tempo_metrics_generator_service:
-    k.util.serviceFor($.tempo_metrics_generator_statefulset),
+    k.util.serviceFor($.tempo_metrics_generator_deployment),
 }

--- a/operations/jsonnet/microservices/generator.libsonnet
+++ b/operations/jsonnet/microservices/generator.libsonnet
@@ -28,8 +28,8 @@
       volumeMount.new(tempo_overrides_config_volume, '/overrides'),
     ]) +
     $.util.withResources($._config.metrics_generator.resources) +
-    container.mixin.resources.withRequestsMixin({ 'ephemeral-storage': $._config.metrics_generator.ephemeral_storage_request }) +
-    container.mixin.resources.withLimitsMixin({ 'ephemeral-storage': $._config.metrics_generator.ephemeral_storage_limit }) +
+    container.mixin.resources.withRequestsMixin({ 'ephemeral-storage': $._config.metrics_generator.ephemeral_storage_request_size }) +
+    container.mixin.resources.withLimitsMixin({ 'ephemeral-storage': $._config.metrics_generator.ephemeral_storage_limit_size }) +
     $.util.readinessProbe,
 
   tempo_metrics_generator_deployment:

--- a/operations/jsonnet/microservices/generator.libsonnet
+++ b/operations/jsonnet/microservices/generator.libsonnet
@@ -4,7 +4,6 @@
   local container = k.core.v1.container,
   local containerPort = k.core.v1.containerPort,
   local deployment = k.apps.v1.deployment,
-  local statefulset = k.apps.v1.statefulSet,
   local volume = k.core.v1.volume,
   local volumeMount = k.core.v1.volumeMount,
 

--- a/operations/jsonnet/microservices/generator.libsonnet
+++ b/operations/jsonnet/microservices/generator.libsonnet
@@ -3,7 +3,7 @@
 
   local container = k.core.v1.container,
   local containerPort = k.core.v1.containerPort,
-  local deployment = k.apps.v1.deployment,
+  local statefulset = k.apps.v1.statefulSet,
   local pvc = k.core.v1.persistentVolumeClaim,
   local volume = k.core.v1.volume,
   local volumeMount = k.core.v1.volumeMount,
@@ -16,11 +16,13 @@
   tempo_metrics_generator_pvc::
     pvc.new()
     + pvc.mixin.metadata.withName(tempo_data_volume)
-    + pvc.mixin.spec.resources.withRequests({ storage: $._config.generator.pvc_size })
-    + pvc.mixin.spec.withAccessModes(['ReadWriteOnce'])
-    + pvc.mixin.spec.withStorageClassName($._config.generator.pvc_storage_class)
     + pvc.mixin.metadata.withLabels({ app: target_name })
-    + pvc.mixin.metadata.withNamespace($._config.namespace),
+    + pvc.mixin.metadata.withNamespace($._config.namespace)
+    // waiting for k 1.23
+    // + pvc.mixin.spec.persistentVolumeClaimRetentionPolicy.withWhenScaled('delete')
+    + pvc.mixin.spec.resources.withRequests({ storage: $._config.metrics_generator.pvc_size })
+    + pvc.mixin.spec.withAccessModes(['ReadWriteOnce'])
+    + pvc.mixin.spec.withStorageClassName($._config.metrics_generator.pvc_storage_class),
 
   tempo_metrics_generator_container::
     container.new(target_name, $._images.tempo) +
@@ -34,33 +36,31 @@
     ]) +
     container.withVolumeMounts([
       volumeMount.new(tempo_config_volume, '/conf'),
-      volumeMount.new(tempo_data_volume, '/var/tempo'),
+      volumeMount.new(tempo_data_volume, $.tempo_metrics_generator_config.metrics_generator.storage.path),
       volumeMount.new(tempo_overrides_config_volume, '/overrides'),
     ]) +
     $.util.withResources($._config.metrics_generator.resources) +
     $.util.readinessProbe,
 
-  tempo_metrics_generator_deployment:
-    deployment.new(
+  tempo_metrics_generator_statefulset:
+    statefulset.new(
       target_name,
       $._config.metrics_generator.replicas,
       $.tempo_metrics_generator_container,
+      $.tempo_metrics_generator_pvc,
       {
         app: target_name,
         [$._config.gossip_member_label]: 'true',
       },
     ) +
-    deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(3) +
-    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
-    deployment.mixin.spec.template.metadata.withAnnotations({
+    statefulset.mixin.spec.template.metadata.withAnnotations({
       config_hash: std.md5(std.toString($.tempo_metrics_generator_configmap.data['tempo.yaml'])),
     }) +
-    deployment.mixin.spec.template.spec.withVolumes([
+    statefulset.mixin.spec.template.spec.withVolumes([
       volume.fromConfigMap(tempo_config_volume, $.tempo_metrics_generator_configmap.metadata.name),
       volume.fromConfigMap(tempo_overrides_config_volume, $._config.overrides_configmap_name),
-      volume.fromPersistentVolumeClaim(tempo_data_volume, $.tempo_metrics_generator_pvc.metadata.name),
     ]),
 
   tempo_metrics_generator_service:
-    k.util.serviceFor($.tempo_metrics_generator_deployment),
+    k.util.serviceFor($.tempo_metrics_generator_statefulset),
 }

--- a/operations/jsonnet/microservices/generator.libsonnet
+++ b/operations/jsonnet/microservices/generator.libsonnet
@@ -1,14 +1,26 @@
 {
   local k = import 'ksonnet-util/kausal.libsonnet',
+
   local container = k.core.v1.container,
   local containerPort = k.core.v1.containerPort,
-  local volumeMount = k.core.v1.volumeMount,
   local deployment = k.apps.v1.deployment,
+  local pvc = k.core.v1.persistentVolumeClaim,
   local volume = k.core.v1.volume,
+  local volumeMount = k.core.v1.volumeMount,
 
   local target_name = 'metrics-generator',
   local tempo_config_volume = 'tempo-conf',
+  local tempo_data_volume = 'metrics-generator-data',
   local tempo_overrides_config_volume = 'overrides',
+
+  tempo_metrics_generator_pvc::
+    pvc.new()
+    + pvc.mixin.metadata.withName(tempo_data_volume)
+    + pvc.mixin.spec.resources.withRequests({ storage: $._config.generator.pvc_size })
+    + pvc.mixin.spec.withAccessModes(['ReadWriteOnce'])
+    + pvc.mixin.spec.withStorageClassName($._config.generator.pvc_storage_class)
+    + pvc.mixin.metadata.withLabels({ app: target_name })
+    + pvc.mixin.metadata.withNamespace($._config.namespace),
 
   tempo_metrics_generator_container::
     container.new(target_name, $._images.tempo) +
@@ -22,6 +34,7 @@
     ]) +
     container.withVolumeMounts([
       volumeMount.new(tempo_config_volume, '/conf'),
+      volumeMount.new(tempo_data_volume, '/var/tempo'),
       volumeMount.new(tempo_overrides_config_volume, '/overrides'),
     ]) +
     $.util.withResources($._config.metrics_generator.resources) +
@@ -35,7 +48,7 @@
       {
         app: target_name,
         [$._config.gossip_member_label]: 'true',
-      }
+      },
     ) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(3) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
@@ -45,6 +58,7 @@
     deployment.mixin.spec.template.spec.withVolumes([
       volume.fromConfigMap(tempo_config_volume, $.tempo_metrics_generator_configmap.metadata.name),
       volume.fromConfigMap(tempo_overrides_config_volume, $._config.overrides_configmap_name),
+      volume.fromPersistentVolumeClaim(tempo_data_volume, $.tempo_metrics_generator_pvc.metadata.name),
     ]),
 
   tempo_metrics_generator_service:


### PR DESCRIPTION
**What this PR does**:

Without this change, the generator uses node storage and is not constrianed, and could lead to resource contention on the node.

Here we include a request/limit resource on the generator deployment and an emptydir to constrian the use of local storage.. A side effect of this change is that metrics generator instances will be asked to terminate if the limit is exceeeded, and a new instance will be created.  Storage values should be sufficiently high in order to prevent unnecessary churn on the deployment and memberlist.  If the requested size is not available, the pod will fail to schedule and could lead to data loss.

**Which issue(s) this PR fixes**:
Fixes grafana/tempo-squad#91

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`