### PR TITLE
Extend ReadRange interface to accept shouldCache parameter

### DIFF
--- a/tempodb/backend/azure/azure.go
+++ b/tempodb/backend/azure/azure.go
@@ -155,7 +155,7 @@ func (rw *readerWriter) Read(ctx context.Context, name string, keypath backend.K
 }
 
 // ReadRange implements backend.Reader
-func (rw *readerWriter) ReadRange(ctx context.Context, name string, keypath backend.KeyPath, offset uint64, buffer []byte) error {
+func (rw *readerWriter) ReadRange(ctx context.Context, name string, keypath backend.KeyPath, offset uint64, buffer []byte, _ bool) error {
 	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "azure.ReadRange", opentracing.Tags{
 		"len":    len(buffer),
 		"offset": offset,

--- a/tempodb/backend/backend.go
+++ b/tempodb/backend/backend.go
@@ -39,8 +39,9 @@ type Reader interface {
 	Read(ctx context.Context, name string, blockID uuid.UUID, tenantID string, shouldCache bool) ([]byte, error)
 	// StreamReader is for streaming entire objects from the backend.  It is expected this will _not_ be cached.
 	StreamReader(ctx context.Context, name string, blockID uuid.UUID, tenantID string) (io.ReadCloser, int64, error)
-	// ReadRange is for reading parts of large objects from the backend.  It is expected this will _not_ be cached.
-	ReadRange(ctx context.Context, name string, blockID uuid.UUID, tenantID string, offset uint64, buffer []byte) error
+	// ReadRange is for reading parts of large objects from the backend.
+	// There will be an attempt to retrieve this from cache if shouldCache is true. Cache key will be tenantID:blockID:offset:bufferLength
+	ReadRange(ctx context.Context, name string, blockID uuid.UUID, tenantID string, offset uint64, buffer []byte, shouldCache bool) error
 	// Tenants returns a list of all tenants in a backend
 	Tenants(ctx context.Context) ([]string, error)
 	// Blocks returns returns a list of block UUIDs given a tenant

--- a/tempodb/backend/cache/cache.go
+++ b/tempodb/backend/cache/cache.go
@@ -74,9 +74,7 @@ func (r *readerWriter) ReadRange(ctx context.Context, name string, keypath backe
 
 	err := r.nextReader.ReadRange(ctx, name, keypath, offset, buffer, false)
 	if err == nil && shouldCache {
-		bufCopy := make([]byte, len(buffer))
-		copy(bufCopy, buffer)
-		r.cache.Store(ctx, []string{k}, [][]byte{bufCopy})
+		r.cache.Store(ctx, []string{k}, [][]byte{buffer})
 	}
 
 	return err

--- a/tempodb/backend/cache/cache.go
+++ b/tempodb/backend/cache/cache.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"strconv"
 	"strings"
 
 	"github.com/grafana/tempo/pkg/cache"
@@ -58,8 +59,27 @@ func (r *readerWriter) Read(ctx context.Context, name string, keypath backend.Ke
 }
 
 // ReadRange implements backend.RawReader
-func (r *readerWriter) ReadRange(ctx context.Context, name string, keypath backend.KeyPath, offset uint64, buffer []byte) error {
-	return r.nextReader.ReadRange(ctx, name, keypath, offset, buffer)
+func (r *readerWriter) ReadRange(ctx context.Context, name string, keypath backend.KeyPath, offset uint64, buffer []byte, shouldCache bool) error {
+	var k string
+	if shouldCache {
+		// cache key is tenantID:blockID:offset:length - file name is not needed in key
+		keyGen := keypath
+		keyGen = append(keyGen, strconv.Itoa(int(offset)), strconv.Itoa(len(buffer)))
+		k = strings.Join(keyGen, ":")
+		found, vals, _ := r.cache.Fetch(ctx, []string{k})
+		if len(found) > 0 {
+			copy(buffer, vals[0])
+		}
+	}
+
+	err := r.nextReader.ReadRange(ctx, name, keypath, offset, buffer, false)
+	if err == nil && shouldCache {
+		bufCopy := make([]byte, len(buffer))
+		copy(bufCopy, buffer)
+		r.cache.Store(ctx, []string{k}, [][]byte{bufCopy})
+	}
+
+	return err
 }
 
 // Shutdown implements backend.RawReader

--- a/tempodb/backend/gcs/gcs.go
+++ b/tempodb/backend/gcs/gcs.go
@@ -153,7 +153,7 @@ func (rw *readerWriter) Read(ctx context.Context, name string, keypath backend.K
 }
 
 // ReadRange implements backend.Reader
-func (rw *readerWriter) ReadRange(ctx context.Context, name string, keypath backend.KeyPath, offset uint64, buffer []byte) error {
+func (rw *readerWriter) ReadRange(ctx context.Context, name string, keypath backend.KeyPath, offset uint64, buffer []byte, _ bool) error {
 	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "gcs.ReadRange", opentracing.Tags{
 		"len":    len(buffer),
 		"offset": offset,

--- a/tempodb/backend/gcs/gcs_test.go
+++ b/tempodb/backend/gcs/gcs_test.go
@@ -74,7 +74,7 @@ func TestHedge(t *testing.T) {
 			assert.Equal(t, tc.expectedHedgedRequests, atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 
-			_ = r.ReadRange(ctx, "object", []string{"test"}, 10, []byte{})
+			_ = r.ReadRange(ctx, "object", []string{"test"}, 10, []byte{}, false)
 			time.Sleep(tc.returnIn)
 			assert.Equal(t, tc.expectedHedgedRequests, atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)

--- a/tempodb/backend/local/local.go
+++ b/tempodb/backend/local/local.go
@@ -133,7 +133,7 @@ func (rw *Backend) Read(ctx context.Context, name string, keypath backend.KeyPat
 }
 
 // ReadRange implements backend.Reader
-func (rw *Backend) ReadRange(ctx context.Context, name string, keypath backend.KeyPath, offset uint64, buffer []byte) error {
+func (rw *Backend) ReadRange(ctx context.Context, name string, keypath backend.KeyPath, offset uint64, buffer []byte, _ bool) error {
 	span, _ := opentracing.StartSpanFromContext(ctx, "local.ReadRange", opentracing.Tags{
 		"len":    len(buffer),
 		"offset": offset,

--- a/tempodb/backend/local/local_test.go
+++ b/tempodb/backend/local/local_test.go
@@ -58,7 +58,7 @@ func TestReadWrite(t *testing.T) {
 	assert.Equal(t, fakeObject, actualObjectBytes)
 
 	actualReadRange := make([]byte, 5)
-	err = r.ReadRange(ctx, objectName, backend.KeyPathForBlock(blockID, tenantIDs[0]), 5, actualReadRange)
+	err = r.ReadRange(ctx, objectName, backend.KeyPathForBlock(blockID, tenantIDs[0]), 5, actualReadRange, false)
 	assert.NoError(t, err, "unexpected error range")
 	assert.Equal(t, fakeObject[5:10], actualReadRange)
 

--- a/tempodb/backend/mocks.go
+++ b/tempodb/backend/mocks.go
@@ -39,7 +39,7 @@ func (m *MockRawReader) Read(ctx context.Context, name string, keypath KeyPath, 
 
 	return io.NopCloser(bytes.NewReader(m.R)), int64(len(m.R)), nil
 }
-func (m *MockRawReader) ReadRange(ctx context.Context, name string, keypath KeyPath, offset uint64, buffer []byte) error {
+func (m *MockRawReader) ReadRange(ctx context.Context, name string, keypath KeyPath, offset uint64, buffer []byte, _ bool) error {
 	copy(buffer, m.Range)
 
 	return nil
@@ -126,7 +126,7 @@ func (m *MockReader) StreamReader(ctx context.Context, name string, blockID uuid
 	panic("StreamReader is not yet supported for mock reader")
 }
 
-func (m *MockReader) ReadRange(ctx context.Context, name string, blockID uuid.UUID, tenantID string, offset uint64, buffer []byte) error {
+func (m *MockReader) ReadRange(ctx context.Context, name string, blockID uuid.UUID, tenantID string, offset uint64, buffer []byte, _ bool) error {
 	copy(buffer, m.Range)
 
 	return nil

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -38,8 +38,9 @@ type RawReader interface {
 	List(ctx context.Context, keypath KeyPath) ([]string, error)
 	// Read is for streaming entire objects from the backend.  There will be an attempt to retrieve this from cache if shouldCache is true.
 	Read(ctx context.Context, name string, keyPath KeyPath, shouldCache bool) (io.ReadCloser, int64, error)
-	// ReadRange is for reading parts of large objects from the backend.  It is expected this will _not_ be cached.
-	ReadRange(ctx context.Context, name string, keypath KeyPath, offset uint64, buffer []byte) error
+	// ReadRange is for reading parts of large objects from the backend.
+	// There will be an attempt to retrieve this from cache if shouldCache is true. Cache key will be tenantID:blockID:offset:bufferLength
+	ReadRange(ctx context.Context, name string, keypath KeyPath, offset uint64, buffer []byte, shouldCache bool) error
 	// Shutdown must be called when the Reader is finished and cleans up any associated resources.
 	Shutdown()
 }
@@ -123,8 +124,8 @@ func (r *reader) StreamReader(ctx context.Context, name string, blockID uuid.UUI
 	return r.r.Read(ctx, name, KeyPathForBlock(blockID, tenantID), false)
 }
 
-func (r *reader) ReadRange(ctx context.Context, name string, blockID uuid.UUID, tenantID string, offset uint64, buffer []byte) error {
-	return r.r.ReadRange(ctx, name, KeyPathForBlock(blockID, tenantID), offset, buffer)
+func (r *reader) ReadRange(ctx context.Context, name string, blockID uuid.UUID, tenantID string, offset uint64, buffer []byte, shouldCache bool) error {
+	return r.r.ReadRange(ctx, name, KeyPathForBlock(blockID, tenantID), offset, buffer, shouldCache)
 }
 
 func (r *reader) Tenants(ctx context.Context) ([]string, error) {

--- a/tempodb/backend/raw_test.go
+++ b/tempodb/backend/raw_test.go
@@ -59,7 +59,7 @@ func TestReader(t *testing.T) {
 	assert.Equal(t, expected, actual)
 
 	m.Range = expected
-	err = r.ReadRange(ctx, "test", uuid.New(), "test", 10, actual)
+	err = r.ReadRange(ctx, "test", uuid.New(), "test", 10, actual, false)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 

--- a/tempodb/backend/readerat.go
+++ b/tempodb/backend/readerat.go
@@ -37,7 +37,7 @@ func NewContextReader(meta *BlockMeta, name string, r Reader, shouldCache bool) 
 
 // ReadAt implements ContextReader
 func (b *backendReader) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
-	err := b.r.ReadRange(ctx, b.name, b.meta.BlockID, b.meta.TenantID, uint64(off), p)
+	err := b.r.ReadRange(ctx, b.name, b.meta.BlockID, b.meta.TenantID, uint64(off), p, false)
 	return len(p), err
 }
 

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -245,7 +245,7 @@ func (rw *readerWriter) Read(ctx context.Context, name string, keypath backend.K
 }
 
 // ReadRange implements backend.Reader
-func (rw *readerWriter) ReadRange(ctx context.Context, name string, keypath backend.KeyPath, offset uint64, buffer []byte) error {
+func (rw *readerWriter) ReadRange(ctx context.Context, name string, keypath backend.KeyPath, offset uint64, buffer []byte, _ bool) error {
 	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "s3.ReadRange", opentracing.Tags{
 		"len":    len(buffer),
 		"offset": offset,

--- a/tempodb/backend/s3/s3_test.go
+++ b/tempodb/backend/s3/s3_test.go
@@ -73,7 +73,7 @@ func TestHedge(t *testing.T) {
 			assert.Equal(t, tc.expectedHedgedRequests, atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 
-			_ = r.ReadRange(ctx, "object", backend.KeyPath{"test"}, 10, []byte{})
+			_ = r.ReadRange(ctx, "object", backend.KeyPath{"test"}, 10, []byte{}, false)
 			time.Sleep(tc.returnIn)
 			assert.Equal(t, tc.expectedHedgedRequests, atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)

--- a/tempodb/encoding/vparquet/block_search.go
+++ b/tempodb/encoding/vparquet/block_search.go
@@ -55,7 +55,7 @@ func NewBackendReaderAt(ctx context.Context, r backend.Reader, name string, bloc
 
 func (b *BackendReaderAt) ReadAt(p []byte, off int64) (int, error) {
 	b.TotalBytesRead += uint64(len(p))
-	err := b.r.ReadRange(b.ctx, b.name, b.blockID, b.tenantID, uint64(off), p)
+	err := b.r.ReadRange(b.ctx, b.name, b.blockID, b.tenantID, uint64(off), p, false)
 	return len(p), err
 }
 

--- a/tempodb/encoding/vparquet/create.go
+++ b/tempodb/encoding/vparquet/create.go
@@ -183,7 +183,7 @@ func (b *streamingBlock) Complete() (int, error) {
 
 	// Read the footer size out of the parquet footer
 	buf := make([]byte, 8)
-	err = b.r.ReadRange(b.ctx, DataFileName, b.meta.BlockID, b.meta.TenantID, b.meta.Size-8, buf)
+	err = b.r.ReadRange(b.ctx, DataFileName, b.meta.BlockID, b.meta.TenantID, b.meta.Size-8, buf, false)
 	if err != nil {
 		return 0, errors.Wrap(err, "error reading parquet file footer")
 	}


### PR DESCRIPTION
Signed-off-by: Annanay <annanayagarwal@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds a (currently unused) `shouldCache` parameter to the ReadRange interface. This will only be needed for the cache implementation and all other backends can ignore it. PR is in preparation to introduce metadata caching for parquet blocks to speed up queries.

**Which issue(s) this PR fixes**:
Part of #1480 

**Checklist**
- N/A Tests updated
- N/A Documentation added
- N/A `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`