### PR TITLE
Add Hedged metrics for external endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Additionally, default label `span_status` is renamed to `status_code`.
 * [ENHANCEMENT] Add a config to query single ingester instance based on trace id hash for Trace By ID API. (1484)[https://github.com/grafana/tempo/pull/1484] (@sagarwala, @bikashmishra100, @ashwinidulams)
 * [ENHANCEMENT] Add blocklist metrics for total backend objects and total backend bytes [#1519](https://github.com/grafana/tempo/pull/1519) (@ie-pham)
 * [ENHANCEMENT] Adds `tempo_querier_external_endpoint_hedged_roundtrips_total` to count the total hedged requests [#1558](https://github.com/grafana/tempo/pull/1558) (@joe-elliott)
+  **BREAKING CHANGE** Removed deprecated metrics `tempodb_(gcs|s3|azure)_request_duration_seconds` in favor of `tempodb_backend_request_duration_seconds`. These metrics 
+  have been deprecated since v1.1.
 * [BUGFIX] Fix nil pointer panic when the trace by id path errors. [#1441](https://github.com/grafana/tempo/pull/1441) (@joe-elliott)
 * [BUGFIX] Update tempo microservices Helm values example which missed the 'enabled' key for thriftHttp. [#1472](https://github.com/grafana/tempo/pull/1472) (@hajowieland)
 * [BUGFIX] Fix race condition in forwarder overrides loop. [1468](https://github.com/grafana/tempo/pull/1468) (@mapno)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,14 +28,15 @@ Additionally, default label `span_status` is renamed to `status_code`.
 * [ENHANCEMENT] Add metric to track feature enablement [#1459](https://github.com/grafana/tempo/pull/1459) (@zalegrala)
 * [ENHANCEMENT] Added s3 config option `insecure_skip_verify` [#1470](https://github.com/grafana/tempo/pull/1470) (@zalegrala)
 * [ENHANCEMENT] Added polling option to reduce issues in Azure `blocklist_poll_jitter_ms` [#1518](https://github.com/grafana/tempo/pull/1518) (@joe-elliott)
+* [ENHANCEMENT] Add a config to query single ingester instance based on trace id hash for Trace By ID API. (1484)[https://github.com/grafana/tempo/pull/1484] (@sagarwala, @bikashmishra100, @ashwinidulams)
+* [ENHANCEMENT] Add blocklist metrics for total backend objects and total backend bytes [#1519](https://github.com/grafana/tempo/pull/1519) (@ie-pham)
+* [ENHANCEMENT] Adds `tempo_querier_external_endpoint_hedged_roundtrips_total` to count the total hedged requests [#1558](https://github.com/grafana/tempo/pull/1558) (@joe-elliott)
 * [BUGFIX] Fix nil pointer panic when the trace by id path errors. [#1441](https://github.com/grafana/tempo/pull/1441) (@joe-elliott)
 * [BUGFIX] Update tempo microservices Helm values example which missed the 'enabled' key for thriftHttp. [#1472](https://github.com/grafana/tempo/pull/1472) (@hajowieland)
 * [BUGFIX] Fix race condition in forwarder overrides loop. [1468](https://github.com/grafana/tempo/pull/1468) (@mapno)
 * [BUGFIX] Fix v2 backend check on span name to be substring [#1538](https://github.com/grafana/tempo/pull/1538) (@mdisibio)
 * [BUGFIX] Fix wal check on span name to be substring [#1548](https://github.com/grafana/tempo/pull/1548) (@mdisibio)
 * [BUGFIX] metrics-generator: do not remove x-scope-orgid header in single tenant modus [#1554](https://github.com/grafana/tempo/pull/1554) (@kvrhdn)
-* [ENHANCEMENT] Add a config to query single ingester instance based on trace id hash for Trace By ID API. (1484)[https://github.com/grafana/tempo/pull/1484] (@sagarwala, @bikashmishra100, @ashwinidulams)
-* [ENHANCEMENT] Add blocklist metrics for total backend objects and total backend bytes [#1519](https://github.com/grafana/tempo/pull/1519) (@ie-pham)
 
 ## v1.4.1 / 2022-05-05
 

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -32,13 +32,13 @@ import (
 	"github.com/grafana/tempo/modules/querier/worker"
 	"github.com/grafana/tempo/modules/storage"
 	"github.com/grafana/tempo/pkg/api"
+	"github.com/grafana/tempo/pkg/hedgedmetrics"
 	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/pkg/util/log"
 	"github.com/grafana/tempo/pkg/validation"
 	"github.com/grafana/tempo/tempodb/backend"
-	"github.com/grafana/tempo/tempodb/backend/instrumentation"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 	"github.com/grafana/tempo/tempodb/search"
 )
@@ -115,7 +115,7 @@ func New(cfg Config, clientCfg ingester_client.Config, ring ring.ReadRing, store
 		if err != nil {
 			return nil, err
 		}
-		instrumentation.PublishHedgedMetricsToGauge(stats, metricExternalHedgedRequests)
+		hedgedmetrics.Publish(stats, metricExternalHedgedRequests)
 	}
 
 	q.Service = services.NewBasicService(q.starting, q.running, q.stopping)

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -55,6 +55,13 @@ var (
 		Help:      "The duration of the external endpoints.",
 		Buckets:   prometheus.DefBuckets,
 	}, []string{"endpoint"})
+	metricExternalHedgedRequests = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "tempo",
+			Name:      "querier_external_endpoint_hedged_roundtrips_total",
+			Help:      "Total number of hedged external requests. Registered as a gauge for code sanity. This is a counter.",
+		},
+	)
 )
 
 // Querier handlers queries.
@@ -108,7 +115,7 @@ func New(cfg Config, clientCfg ingester_client.Config, ring ring.ReadRing, store
 		if err != nil {
 			return nil, err
 		}
-		instrumentation.PublishHedgedMetrics(stats)
+		instrumentation.PublishHedgedMetricsToGauge(stats, metricExternalHedgedRequests)
 	}
 
 	q.Service = services.NewBasicService(q.starting, q.running, q.stopping)

--- a/pkg/hedgedmetrics/metrics.go
+++ b/pkg/hedgedmetrics/metrics.go
@@ -1,0 +1,27 @@
+package hedgedmetrics
+
+import (
+	"time"
+
+	"github.com/cristalhq/hedgedhttp"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	hedgedMetricsPublishDuration = 10 * time.Second
+)
+
+// PublishHedgedMetrics flushes metrics from hedged requests every 10 seconds
+func Publish(s *hedgedhttp.Stats, gauge prometheus.Gauge) {
+	ticker := time.NewTicker(hedgedMetricsPublishDuration)
+	go func() {
+		for range ticker.C {
+			snap := s.Snapshot()
+			hedgedRequests := int64(snap.ActualRoundTrips) - int64(snap.RequestedRoundTrips)
+			if hedgedRequests < 0 {
+				hedgedRequests = 0
+			}
+			gauge.Set(float64(hedgedRequests))
+		}
+	}()
+}

--- a/tempodb/backend/azure/azure_helpers.go
+++ b/tempodb/backend/azure/azure_helpers.go
@@ -37,7 +37,7 @@ func GetContainerURL(ctx context.Context, cfg *Config, hedge bool) (blob.Contain
 	customTransport := http.DefaultTransport.(*http.Transport).Clone()
 
 	// add instrumentation
-	transport := instrumentation.NewAzureTransport(customTransport)
+	transport := instrumentation.NewTransport(customTransport)
 	var stats *hedgedhttp.Stats
 
 	// hedge if desired (0 means disabled)

--- a/tempodb/backend/gcs/gcs.go
+++ b/tempodb/backend/gcs/gcs.go
@@ -253,7 +253,7 @@ func createBucket(ctx context.Context, cfg *Config, hedge bool) (*storage.Bucket
 	}
 
 	// add instrumentation
-	transport = instrumentation.NewGCSTransport(transport)
+	transport = instrumentation.NewTransport(transport)
 	var stats *hedgedhttp.Stats
 
 	// hedge if desired (0 means disabled)

--- a/tempodb/backend/instrumentation/backend_transports.go
+++ b/tempodb/backend/instrumentation/backend_transports.go
@@ -10,27 +10,6 @@ import (
 )
 
 var (
-	gcsRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "tempodb",
-		Name:      "gcs_request_duration_seconds",
-		Help:      "Time spent doing GCS requests. (DEPRECATED: See tempodb_backend_request_duration_seconds)",
-		Buckets:   prometheus.ExponentialBuckets(0.005, 4, 6),
-	}, []string{"operation", "status_code"})
-
-	s3RequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "tempodb",
-		Name:      "s3_request_duration_seconds",
-		Help:      "Time spent doing AWS S3 requests. (DEPRECATED: See tempodb_backend_request_duration_seconds)",
-		Buckets:   prometheus.ExponentialBuckets(0.005, 4, 6),
-	}, []string{"operation", "status_code"})
-
-	azureRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "tempodb",
-		Name:      "azure_request_duration_seconds",
-		Help:      "Time spent doing Azure requests. (DEPRECATED: See tempodb_backend_request_duration_seconds)",
-		Buckets:   prometheus.ExponentialBuckets(0.005, 4, 6),
-	}, []string{"operation", "status_code"})
-
 	requestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "tempodb",
 		Name:      "backend_request_duration_seconds",
@@ -40,32 +19,14 @@ var (
 )
 
 type instrumentedTransport struct {
-	legacyObserver prometheus.ObserverVec
-	observer       prometheus.ObserverVec
-	next           http.RoundTripper
+	observer prometheus.ObserverVec
+	next     http.RoundTripper
 }
 
-func NewGCSTransport(next http.RoundTripper) http.RoundTripper {
+func NewTransport(next http.RoundTripper) http.RoundTripper {
 	return instrumentedTransport{
-		next:           next,
-		observer:       requestDuration,
-		legacyObserver: gcsRequestDuration,
-	}
-}
-
-func NewS3Transport(next http.RoundTripper) http.RoundTripper {
-	return instrumentedTransport{
-		next:           next,
-		observer:       requestDuration,
-		legacyObserver: s3RequestDuration,
-	}
-}
-
-func NewAzureTransport(next http.RoundTripper) http.RoundTripper {
-	return instrumentedTransport{
-		next:           next,
-		observer:       requestDuration,
-		legacyObserver: azureRequestDuration,
+		next:     next,
+		observer: requestDuration,
 	}
 }
 
@@ -73,7 +34,6 @@ func (i instrumentedTransport) RoundTrip(req *http.Request) (*http.Response, err
 	start := time.Now()
 	resp, err := i.next.RoundTrip(req)
 	if err == nil {
-		i.legacyObserver.WithLabelValues(req.Method, strconv.Itoa(resp.StatusCode)).Observe(time.Since(start).Seconds())
 		i.observer.WithLabelValues(req.Method, strconv.Itoa(resp.StatusCode)).Observe(time.Since(start).Seconds())
 	}
 	return resp, err

--- a/tempodb/backend/instrumentation/hedged_requests.go
+++ b/tempodb/backend/instrumentation/hedged_requests.go
@@ -1,15 +1,10 @@
 package instrumentation
 
 import (
-	"time"
-
 	"github.com/cristalhq/hedgedhttp"
+	"github.com/grafana/tempo/pkg/hedgedmetrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-)
-
-const (
-	hedgedMetricsPublishDuration = 10 * time.Second
 )
 
 var (
@@ -24,20 +19,5 @@ var (
 
 // PublishHedgedMetrics flushes metrics from hedged requests every 10 seconds
 func PublishHedgedMetrics(s *hedgedhttp.Stats) {
-	PublishHedgedMetricsToGauge(s, hedgedRequestsMetrics)
-}
-
-// PublishHedgedMetrics flushes metrics from hedged requests every 10 seconds
-func PublishHedgedMetricsToGauge(s *hedgedhttp.Stats, gauge prometheus.Gauge) {
-	ticker := time.NewTicker(hedgedMetricsPublishDuration)
-	go func() {
-		for range ticker.C {
-			snap := s.Snapshot()
-			hedgedRequests := int64(snap.ActualRoundTrips) - int64(snap.RequestedRoundTrips)
-			if hedgedRequests < 0 {
-				hedgedRequests = 0
-			}
-			gauge.Set(float64(hedgedRequests))
-		}
-	}()
+	hedgedmetrics.Publish(s, hedgedRequestsMetrics)
 }

--- a/tempodb/backend/instrumentation/hedged_requests.go
+++ b/tempodb/backend/instrumentation/hedged_requests.go
@@ -24,6 +24,11 @@ var (
 
 // PublishHedgedMetrics flushes metrics from hedged requests every 10 seconds
 func PublishHedgedMetrics(s *hedgedhttp.Stats) {
+	PublishHedgedMetricsToGauge(s, hedgedRequestsMetrics)
+}
+
+// PublishHedgedMetrics flushes metrics from hedged requests every 10 seconds
+func PublishHedgedMetricsToGauge(s *hedgedhttp.Stats, gauge prometheus.Gauge) {
 	ticker := time.NewTicker(hedgedMetricsPublishDuration)
 	go func() {
 		for range ticker.C {
@@ -32,7 +37,7 @@ func PublishHedgedMetrics(s *hedgedhttp.Stats) {
 			if hedgedRequests < 0 {
 				hedgedRequests = 0
 			}
-			hedgedRequestsMetrics.Set(float64(hedgedRequests))
+			gauge.Set(float64(hedgedRequests))
 		}
 	}()
 }

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -351,7 +351,7 @@ func createCore(cfg *Config, hedge bool) (*minio.Core, error) {
 	}
 
 	// add instrumentation
-	transport := instrumentation.NewS3Transport(customTransport)
+	transport := instrumentation.NewTransport(customTransport)
 	var stats *hedgedhttp.Stats
 
 	if hedge && cfg.HedgeRequestsAt != 0 {


### PR DESCRIPTION
**What this PR does**:
- Adds a counter of hedged calls for queriers to external endpoints.
- Moves common code from tempodb to a new shared package: `/pkg/hedgedmetrics`.
- Changelog cleanup

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`