### PR TITLE
Use existing bot token for dependabot job checkout

### DIFF
--- a/.github/workflows/dependabot_serverless_gomod.yml
+++ b/.github/workflows/dependabot_serverless_gomod.yml
@@ -19,14 +19,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
+          token: ${{ secrets.GH_BOT_ACCESS_TOKEN}}
 
       - name: Update serverless gomod
         run: make -C cmd/tempo-serverless update-mod
 
       - name: Commit serverless gomod changes
         run: |
-          git config user.name github-actions[bot]
-          git config user.email github-actions[bot]@users.noreply.github.com
           git add cmd/tempo-serverless/lambda/go.mod
           git add cmd/tempo-serverless/lambda/go.sum
           git add cmd/tempo-serverless/cloud-run/go.mod
@@ -34,7 +33,5 @@ jobs:
           git diff --quiet --staged || git commit -m 'Update serverless gomod'
 
       - name: Push changes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
         run: |
           git push origin ${{ github.head_ref }}


### PR DESCRIPTION
**What this PR does**:

Here we try another approach to get the amendment job on dependabot to have the needed access to run the workflow after commit.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`