### PR TITLE
Add runbook section for 'queue doesn't have room for' error

### DIFF
--- a/operations/tempo-mixin/runbook.md
+++ b/operations/tempo-mixin/runbook.md
@@ -45,6 +45,31 @@ Another way to increase parallelism is by increasing the size of the worker pool
 A theoretically ideal value for this config to avoid _any_ queueing would be (Size of blocklist / Max Concurrent Queries).
 But also factor in the resources provided to the querier.
 
+### Trace Lookup Failures
+
+If trace lookups are fail with the error: `error querying store in Querier.FindTraceByID: queue doesn't have room for <xyz> jobs`, this 
+means that the number of blocks has exceeded the queriers' ability to check them all.  This can be caused by an increase in
+the number of blocks, or if the number of queriers was reduced.
+
+Check the following metrics and data points:
+- Metric: `tempodb_blocklist_length` - Look for a recent increase in blocks
+- The number of queriers
+- The queue_depth setting in the queriers:
+    ```
+    storage:
+      trace:
+        pool:
+          queue_depth: xyz (default 10000)
+    ```
+
+The queue won't have room when the number of blocks per querier exceeds the queue_depth:
+  (blocklist_length / number of queriers) > queue_depth
+
+Consider the following resolutions:
+- Increase the number of queriers
+- Increase the queue_depth size to do more work per querier
+- Adjust compaction settings to reduce the number of blocks
+
 ### Serverless/External Endpoints
 
 If the request latency issues are due to backend searches with serverless/external endpoints there may be additional configuration


### PR DESCRIPTION
**What this PR does**:
This PR adds a runbook section for troubleshooting the `queue doesn't have room for <xyz> jobs` error.

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`