### PR TITLE
Add runbook reference

### DIFF
--- a/operations/tempo-mixin/runbook.md
+++ b/operations/tempo-mixin/runbook.md
@@ -264,3 +264,6 @@ After compaction has been scaled out, it'll take a time for compactors to catch
 up with their outstanding blocks.
 Take a look at `tempodb_compaction_outstanding_blocks` and check if blocks start
 going down. If not, further scaling may be necessary.
+
+Since the number of blocks is elevated, it may also be necessary to review the queue-related
+settings to prevent [trace lookup failures](#trace-lookup-failures).


### PR DESCRIPTION
**What this PR does**:
Oops, merged without resolving https://github.com/grafana/tempo/pull/1572#issuecomment-1183489326  This PR adds a reference between compactor too many outstanding blocks and the trace lookup failure sections.

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`