### PR TITLE
Add local storage warning to startup

### DIFF
--- a/cmd/tempo/app/config.go
+++ b/cmd/tempo/app/config.go
@@ -148,6 +148,10 @@ func (c *Config) CheckConfig() {
 	if c.Distributor.LogReceivedTraces {
 		level.Warn(log.Logger).Log("msg", "c.Distributor.LogReceivedTraces is deprecated. The new flag is c.Distributor.log_received_spans.enabled")
 	}
+
+	if c.StorageConfig.Trace.Backend == "local" && c.Target != SingleBinary {
+		level.Warn(log.Logger).Log("msg", "Local backend will not correctly retrieve traces unless all components have access to the same disk. You should probably be using object storage as a backend.")
+	}
 }
 
 func (c *Config) Describe(ch chan<- *prometheus.Desc) {

--- a/cmd/tempo/app/config.go
+++ b/cmd/tempo/app/config.go
@@ -150,7 +150,7 @@ func (c *Config) CheckConfig() {
 	}
 
 	if c.StorageConfig.Trace.Backend == "local" && c.Target != SingleBinary {
-		level.Warn(log.Logger).Log("msg", "Local backend will not correctly retrieve traces unless all components have access to the same disk. You should probably be using object storage as a backend.")
+		level.Warn(log.Logger).Log("msg", "Local backend will not correctly retrieve traces with a distributed deployment unless all components have access to the same disk. You should probably be using object storage as a backend.")
 	}
 }
 


### PR DESCRIPTION
Several times we have seen users confused b/c they are using local storage with their distributed Tempo setup and they can not access their traces after they have been flushed to disk.