### PR TITLE
Parquet Search: Clean up leaks

### DIFF
--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -195,6 +195,14 @@ func columnIteratorPoolGet(capacity, len int) *columnIteratorBuffer {
 	return res
 }
 
+func columnIteratorPoolPut(b *columnIteratorBuffer) {
+	b.values = b.values[:cap(b.values)]
+	for i := range b.values {
+		b.values[i] = pq.Value{}
+	
+	columnIteratorPool.Put(b)
+}
+
 var columnIteratorResultPool = sync.Pool{
 	New: func() interface{} {
 		return &IteratorResult{Entries: make([]struct {
@@ -371,7 +379,7 @@ func (c *ColumnIterator) iterate(ctx context.Context, readSize int) {
 					} else {
 						// All values excluded, we go ahead and immediately
 						// return the buffer to the pool.
-						columnIteratorPool.Put(newBuffer)
+						columnIteratorPoolPut(newBuffer)
 					}
 				}
 
@@ -413,7 +421,7 @@ func (c *ColumnIterator) next() (RowNumber, pq.Value) {
 		}
 
 		// Done with this buffer
-		columnIteratorPool.Put(c.curr)
+		columnIteratorPoolPut(c.curr)
 		c.curr = nil
 	}
 

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -199,7 +199,7 @@ func columnIteratorPoolPut(b *columnIteratorBuffer) {
 	b.values = b.values[:cap(b.values)]
 	for i := range b.values {
 		b.values[i] = pq.Value{}
-	
+	}
 	columnIteratorPool.Put(b)
 }
 

--- a/tempodb/encoding/vparquet/block_search.go
+++ b/tempodb/encoding/vparquet/block_search.go
@@ -295,6 +295,7 @@ func rawToResults(ctx context.Context, pf *parquet.File, rgs []parquet.RowGroup,
 		makeIter("StartTimeUnixNano"),
 		makeIter("DurationNanos"),
 	}, nil)
+	defer iter2.Close()
 
 	for {
 		match := iter2.Next()


### PR DESCRIPTION
**What this PR does**:
- Cleans up a goroutine/memory leak that occurs during search when the search finds matches
- Makes a common "pool put" method for columnIteratorBuffers that cleans up references to memory buffers