### PR TITLE
Minor improvement to join iterator

### DIFF
--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -506,8 +506,8 @@ func (j *JoinIterator) Next() *IteratorResult {
 	for {
 		lowestRowNumber := MaxRowNumber()
 		highestRowNumber := EmptyRowNumber()
-		lowestIters := make([]int, 0, len(j.iters))
 
+		foundMatch := true
 		for iterNum := range j.iters {
 			res := j.peek(iterNum)
 
@@ -516,27 +516,24 @@ func (j *JoinIterator) Next() *IteratorResult {
 				return nil
 			}
 
-			c := CompareRowNumbers(j.definitionLevel, res.RowNumber, lowestRowNumber)
-			switch c {
-			case -1:
-				// New lowest, reset
-				lowestIters = lowestIters[:0]
-				lowestRowNumber = res.RowNumber
-				fallthrough
-
-			case 0:
-				// Same, append
-				lowestIters = append(lowestIters, iterNum)
-			}
-
 			if CompareRowNumbers(j.definitionLevel, res.RowNumber, highestRowNumber) == 1 {
 				// New high water mark
 				highestRowNumber = res.RowNumber
 			}
+
+			c := CompareRowNumbers(j.definitionLevel, res.RowNumber, lowestRowNumber)
+			if c == -1 && iterNum != 0 {
+				// if we have a new lowest that is not the first iterator there's no way for
+				//  all iterators to match
+				foundMatch = false
+				break
+			}
+
+			lowestRowNumber = res.RowNumber
 		}
 
 		// All iterators pointing at same row?
-		if len(lowestIters) == len(j.iters) {
+		if foundMatch {
 			// Get the data
 			result := j.collect(lowestRowNumber)
 


### PR DESCRIPTION
**What this PR does**:
This is a minor improvement to the join iterator. It causes the iterator loop to bail early if there is no chance of a matching "lowest row number". I also experimented with moving `j.seekAll(highestRowNumber, j.definitionLevel)` into the loop, but found that in practice it often increased backend i/o.

There is some room for improvement here, but there are no obvious wins. Most improvements would be query dependent.