### PR TITLE
Added root.name and root.service.name support to v2 and parquet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Jsonnet users will now need to specify a storage request and limit for the gener
 * [BUGFIX] Fix wal check on span name to be substring [#1548](https://github.com/grafana/tempo/pull/1548) (@mdisibio)
 * [BUGFIX] Prevent ingester panic "cannot grow buffer" [#1258](https://github.com/grafana/tempo/issues/1258) (@mdisibio)
 * [BUGFIX] metrics-generator: do not remove x-scope-orgid header in single tenant modus [#1554](https://github.com/grafana/tempo/pull/1554) (@kvrhdn)
+* [BUGFIX] Fixed issue where backend does not support `root.name` and `root.service.name` [#1589](https://github.com/grafana/tempo/pull/1589) (@kvrhdn)
 
 ## v1.4.1 / 2022-05-05
 

--- a/pkg/model/trace/search_test_suite.go
+++ b/pkg/model/trace/search_test_suite.go
@@ -166,6 +166,8 @@ func SearchTestSuite() (
 		makeReq("k8s.namespace.name", "k8sNamespace"),
 		makeReq("k8s.pod.name", "k8sPod"),
 		makeReq("k8s.container.name", "k8sContainer"),
+		makeReq("root.service.name", "RootService"),
+		makeReq("root.name", "RootSpan"),
 
 		// Well-known span attributes
 		makeReq("name", "Span"),
@@ -214,6 +216,8 @@ func SearchTestSuite() (
 		makeReq("http.url", "asdf"),
 		makeReq("http.status_code", "200"),
 		makeReq("status.code", "ok"),
+		makeReq("root.service.name", "NotRootService"),
+		makeReq("root.name", "NotRootSpan"),
 
 		// Span attributes
 		makeReq("foo", "baz"), // wrong case

--- a/tempodb/encoding/vparquet/block_search.go
+++ b/tempodb/encoding/vparquet/block_search.go
@@ -101,6 +101,10 @@ func makePipelineWithRowGroups(ctx context.Context, req *tempopb.SearchRequest, 
 
 	for k, v := range req.Tags {
 		switch k {
+		case LabelRootServiceName:
+			traceIters = append(traceIters, makeIter("RootServiceName", pq.NewSubstringPredicate(v), ""))
+		case LabelRootSpanName:
+			traceIters = append(traceIters, makeIter("RootSpanName", pq.NewSubstringPredicate(v), ""))
 		case LabelServiceName:
 			resourceIters = append(resourceIters, makeIter("rs.Resource.ServiceName", pq.NewSubstringPredicate(v), ""))
 		case LabelCluster:

--- a/tempodb/encoding/vparquet/schema.go
+++ b/tempodb/encoding/vparquet/schema.go
@@ -15,6 +15,9 @@ import (
 // Label names for conversion b/n Proto <> Parquet
 
 const (
+	LabelRootSpanName    = "root.name"
+	LabelRootServiceName = "root.service.name"
+
 	LabelServiceName = "service.name"
 	LabelCluster     = "cluster"
 	LabelNamespace   = "namespace"


### PR DESCRIPTION
**What this PR does**:
Adds support for two special tags to both parquet and v2. Unsure how this is currently not supported in v2. Both of these special tags are supported in ingester/flatbuffer search.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`