### PR TITLE
Additional default latency buckets for spanmetrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Jsonnet users will now need to specify a storage request and limit for the gener
         ephemeral_storage_limit_size: '11Gi',
       },
     }
+* [CHANGE] Wider default latency buckets for metrics-generator spanmetrics. [#1593](https://github.com/grafana/tempo/pull/1593) (@fredr)
 * [FEATURE] metrics-generator: support per-tenant processor configuration [#1434](https://github.com/grafana/tempo/pull/1434) (@kvrhdn)
 * [FEATURE] Include rollout dashboard [#1456](https://github.com/grafana/tempo/pull/1456) (@zalegrala)
 * [FEATURE] Add SentinelPassword configuration for Redis [#1463](https://github.com/grafana/tempo/pull/1463) (@zalegrala)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ Jsonnet users will now need to specify a storage request and limit for the gener
         ephemeral_storage_limit_size: '11Gi',
       },
     }
-* [CHANGE] Wider default latency buckets for metrics-generator spanmetrics. [#1593](https://github.com/grafana/tempo/pull/1593) (@fredr)
+* [CHANGE] Two additional latency buckets added to the default settings for generated spanmetrics. Note that this will increase cardinality when using the defaults. [#1593](https://github.com/grafana/tempo/pull/1593) (@fredr)
 * [FEATURE] metrics-generator: support per-tenant processor configuration [#1434](https://github.com/grafana/tempo/pull/1434) (@kvrhdn)
 * [FEATURE] Include rollout dashboard [#1456](https://github.com/grafana/tempo/pull/1456) (@zalegrala)
 * [FEATURE] Add SentinelPassword configuration for Redis [#1463](https://github.com/grafana/tempo/pull/1463) (@zalegrala)

--- a/modules/generator/processor/spanmetrics/config.go
+++ b/modules/generator/processor/spanmetrics/config.go
@@ -2,6 +2,8 @@ package spanmetrics
 
 import (
 	"flag"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
@@ -17,5 +19,5 @@ type Config struct {
 }
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
-	cfg.HistogramBuckets = []float64{.002, .004, .006, .01, .05, .1, .2, .4, .8, 1., 1.4, 2., 5., 10., 15.}
+	cfg.HistogramBuckets = prometheus.ExponentialBuckets(0.002, 2, 14)
 }

--- a/modules/generator/processor/spanmetrics/config.go
+++ b/modules/generator/processor/spanmetrics/config.go
@@ -2,8 +2,6 @@ package spanmetrics
 
 import (
 	"flag"
-
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
@@ -19,6 +17,5 @@ type Config struct {
 }
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
-	// TODO: Revisit this default value.
-	cfg.HistogramBuckets = prometheus.ExponentialBuckets(0.002, 2, 12)
+	cfg.HistogramBuckets = []float64{.002, .004, .006, .01, .05, .1, .2, .4, .8, 1., 1.4, 2., 5., 10., 15.}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Changes the default spanmetric latency bucket sizes to match the default sizes in https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/spanmetricsprocessor

It will be hard to size these default buckets to a size that fits all systems, but I think wider is better than narrower for a default. The current default maxes out at 4 seconds which imo is a bit low.

**Checklist**
- [x] ~Tests updated~ Tests pass
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`