### PR TITLE
Remove http_listen_port from server Agent config

### DIFF
--- a/docs/tempo/website/grafana-agent/service-graphs.md
+++ b/docs/tempo/website/grafana-agent/service-graphs.md
@@ -34,12 +34,10 @@ traces:
 To see all the available config options, refer to the [configuration reference](https://grafana.com/docs/agent/latest/configuration/traces-config/).
 
 Metrics are registered in the Agent's default registerer.
-Therefore, they are exposed at `/metrics` in the Agent's server port.
+Therefore, they are exposed at `/metrics` in the Agent's server port (default 12345).
 One option is to use the Agent self-scrape capabilities to export the metrics to a prometheus compatible backend.
 
 ```
-server:
-  http_listen_port: 12345
 metrics:
   configs:
     - name: default


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This PR removes `http_listen_port` field from `server` config for the Agent.
See more details about the deprecation [here](https://grafana.com/docs/agent/v0.26/upgrade-guide/#breaking-change-deprecated-yaml-fields-in-server-block-removed).

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`