### PR TITLE
Test compactor ring for SSB target

### DIFF
--- a/example/docker-compose/scalable-single-binary/docker-compose.yaml
+++ b/example/docker-compose/scalable-single-binary/docker-compose.yaml
@@ -13,6 +13,8 @@ services:
           - tempo
     depends_on:
       - minio
+    ports:
+      - 3200:3200
 
   tempo2:
     image: grafana/tempo:latest

--- a/example/docker-compose/scalable-single-binary/tempo-scalable-single-binary.yaml
+++ b/example/docker-compose/scalable-single-binary/tempo-scalable-single-binary.yaml
@@ -30,6 +30,9 @@ ingester:
     heartbeat_period: 100ms
 
 compactor:
+  ring:
+    kvstore:
+      store: memberlist
   compaction:
     compaction_window: 1h              # blocks in this time window will be compacted together
     max_block_bytes: 100_000_000       # maximum size of compacted blocks

--- a/integration/e2e/config-scalable-single-binary.yaml
+++ b/integration/e2e/config-scalable-single-binary.yaml
@@ -7,6 +7,11 @@ distributor:
       protocols:
         grpc:
 
+compactor:
+  ring:
+    kvstore:
+      store: memberlist
+
 ingester:
   lifecycler:
     # address: 127.0.0.1
@@ -27,7 +32,7 @@ storage:
     backend: s3
     s3:
       bucket: tempo
-      endpoint: tempo_e2e-minio-9000:9000  # TODO: this is brittle, fix this eventually
+      endpoint: tempo_e2e-minio-9000:9000 # TODO: this is brittle, fix this eventually
       access_key: Cheescake # TODO: use cortex_e2e.MinioAccessKey
       secret_key: supersecret # TODO: use cortex_e2e.MinioSecretKey
       insecure: true
@@ -39,9 +44,9 @@ memberlist:
   abort_if_cluster_join_fails: false
   bind_port: 7946
   join_members:
-  - tempo-1:7946
-  - tempo-2:7946
-  - tempo-3:7946
+    - tempo-1:7946
+    - tempo-2:7946
+    - tempo-3:7946
 
 querier:
   frontend_worker:

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -459,7 +459,7 @@ func callIngesterRing(t *testing.T, svc *e2e.HTTPService) {
 	fmt.Printf("Calling %s on %s\n", endpoint, svc.Name())
 	res, err := e2e.DoGet("http://" + svc.Endpoint(3200) + endpoint)
 	require.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
+	require.Equal(t, 200, res.StatusCode)
 }
 
 func callCompactorRing(t *testing.T, svc *e2e.HTTPService) {
@@ -467,7 +467,7 @@ func callCompactorRing(t *testing.T, svc *e2e.HTTPService) {
 	fmt.Printf("Calling %s on %s\n", endpoint, svc.Name())
 	res, err := e2e.DoGet("http://" + svc.Endpoint(3200) + endpoint)
 	require.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
+	require.Equal(t, 200, res.StatusCode)
 }
 
 func callStatus(t *testing.T, svc *e2e.HTTPService) {
@@ -478,7 +478,7 @@ func callStatus(t *testing.T, svc *e2e.HTTPService) {
 	// body, err := ioutil.ReadAll(res.Body)
 	// require.NoError(t, err)
 	// t.Logf("body: %+v", string(body))
-	assert.Equal(t, 200, res.StatusCode)
+	require.Equal(t, 200, res.StatusCode)
 }
 
 func assertEcho(t *testing.T, url string) {

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -391,6 +391,9 @@ func TestScalableSingleBinary(t *testing.T) {
 	for _, i := range []*e2e.HTTPService{tempo1, tempo2, tempo3} {
 		callFlush(t, i)
 		require.NoError(t, i.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_blocks_flushed_total"))
+		callIngesterRing(t, i)
+		callCompactorRing(t, i)
+		callStatus(t, i)
 	}
 
 	apiClient1 := tempoUtil.NewClient("http://"+tempo1.Endpoint(3200), "")
@@ -449,6 +452,33 @@ func callFlush(t *testing.T, ingester *e2e.HTTPService) {
 	res, err := e2e.DoGet("http://" + ingester.Endpoint(3200) + "/flush")
 	require.NoError(t, err)
 	require.Equal(t, 204, res.StatusCode)
+}
+
+func callIngesterRing(t *testing.T, svc *e2e.HTTPService) {
+	endpoint := "/ingester/ring"
+	fmt.Printf("Calling %s on %s\n", endpoint, svc.Name())
+	res, err := e2e.DoGet("http://" + svc.Endpoint(3200) + endpoint)
+	require.NoError(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+}
+
+func callCompactorRing(t *testing.T, svc *e2e.HTTPService) {
+	endpoint := "/compactor/ring"
+	fmt.Printf("Calling %s on %s\n", endpoint, svc.Name())
+	res, err := e2e.DoGet("http://" + svc.Endpoint(3200) + endpoint)
+	require.NoError(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+}
+
+func callStatus(t *testing.T, svc *e2e.HTTPService) {
+	endpoint := "/status/endpoints"
+	fmt.Printf("Calling %s on %s\n", endpoint, svc.Name())
+	res, err := e2e.DoGet("http://" + svc.Endpoint(3200) + endpoint)
+	require.NoError(t, err)
+	// body, err := ioutil.ReadAll(res.Body)
+	// require.NoError(t, err)
+	// t.Logf("body: %+v", string(body))
+	assert.Equal(t, 200, res.StatusCode)
 }
 
 func assertEcho(t *testing.T, url string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Without this change, the examples for SSB (Scalabe Single Binary) are missing the configuration necessary for the compactor module to establish cluster membership and coordinate the work of compacting.  Here we ensure that the configuration in the examples works as desired.

**Which issue(s) this PR fixes**:
Fixes #1594

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`