### PR TITLE
Ingester continue startup after rediscover block error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Jsonnet users will now need to specify a storage request and limit for the gener
 * [BUGFIX] Prevent ingester panic "cannot grow buffer" [#1258](https://github.com/grafana/tempo/issues/1258) (@mdisibio)
 * [BUGFIX] metrics-generator: do not remove x-scope-orgid header in single tenant modus [#1554](https://github.com/grafana/tempo/pull/1554) (@kvrhdn)
 * [BUGFIX] Fixed issue where backend does not support `root.name` and `root.service.name` [#1589](https://github.com/grafana/tempo/pull/1589) (@kvrhdn)
+* [BUGFIX] Fixed ingester to continue starting up after block replay error [#1603](https://github.com/grafana/tempo/issues/1603) (@mdisibio)
 
 ## v1.4.1 / 2022-05-05
 

--- a/operations/tempo-mixin-compiled/alerts.yaml
+++ b/operations/tempo-mixin-compiled/alerts.yaml
@@ -145,3 +145,12 @@
     "for": "24h"
     "labels":
       "severity": "critical"
+  - "alert": "TempoIngesterReplayErrors"
+    "annotations":
+      "message": "Tempo ingester has encountered errors while replaying a block on startup in {{ $labels.cluster }}/{{ $labels.namespace }} for tenant {{ $labels.tenant }}"
+      "runbook_url": "https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoIngesterReplayErrors"
+    "expr": |
+      sum by (cluster, namespace, tenant) (increase(tempo_ingester_replay_errors_total{namespace=~".*"}[5m])) > 0
+    "for": "5m"
+    "labels":
+      "severity": "critical"

--- a/operations/tempo-mixin/alerts.libsonnet
+++ b/operations/tempo-mixin/alerts.libsonnet
@@ -230,6 +230,20 @@
               runbook_url: 'https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoCompactorsTooManyOutstandingBlocks',
             },
           },
+          {
+            alert: 'TempoIngesterReplayErrors',
+            'for': '5m',
+            expr: |||
+              sum by (%s) (increase(tempo_ingester_replay_errors_total{namespace=~"%s"}[5m])) > 0
+            ||| % [$._config.group_by_tenant, $._config.namespace],
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              message: 'Tempo ingester has encountered errors while replaying a block on startup in {{ $labels.cluster }}/{{ $labels.namespace }} for tenant {{ $labels.tenant }}',
+              runbook_url: 'https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoIngesterReplayErrors',
+            },
+          },
         ],
       },
     ],

--- a/operations/tempo-mixin/runbook.md
+++ b/operations/tempo-mixin/runbook.md
@@ -267,3 +267,18 @@ going down. If not, further scaling may be necessary.
 
 Since the number of blocks is elevated, it may also be necessary to review the queue-related
 settings to prevent [trace lookup failures](#trace-lookup-failures).
+
+## TempoIngesterReplayErrors
+
+This alert fires when an ingester has encountered an error while replaying a block on startup.
+
+How to fix:
+
+Check the ingester logs for errors to identify the culprit ingester, tenant, and block ID. 
+
+If an ingester is restarted unexpectedly while writing a block to disk, the files might be corrupted.
+The error "Unexpected error reloading meta for local block. Ignoring and continuing." indicates there was an error parsing the
+meta.json.  Repair the meta.json and then restart the ingester to successfully recover the block. Or if
+it is not able to be repaired then the block files can be simply deleted as the ingester has already started
+without it.  As long as the replication factor is 2 or higher, then there will be no data loss as the
+same data was also written to another ingester.


### PR DESCRIPTION
**What this PR does**:
This PR changes the ingester to continue starting up after encountering an error during block rediscovery.  The suspect block is ignored and left on disk for investigation.  Introduces a new metric and alert when this happens.

**Which issue(s) this PR fixes**:
Fixes #1603 

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`