### PR TITLE
Added private-key.key to gitignore for drone builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /tempodb/encoding/benchmark_block
 /cmd/tempo-serverless/vendor/
 /pkg/traceql/y.output
+private-key.key


### PR DESCRIPTION
Drone goreleaser builds are broken with:

```
/go/bin/goreleaser release --rm-dist
  • starting release...
  • loading config file                              file=.goreleaser.yml
  • loading environment variables
  • getting and validating git state
    • building...                                    commit=d3b3bca96a4cd040f68372fadc6485122669aec0 latest tag=v1.5.0-rc.0
  ⨯ release failed after 0s                  error=git is currently in a dirty state
Please check in your pipeline what can be changing the following files:
?? private-key.key
```

Adding `private-key.key` to rectify.