### PR TITLE
Bug fix relating to Cluster Seed File

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Jsonnet users will now need to specify a storage request and limit for the gener
 * [BUGFIX] metrics-generator: do not remove x-scope-orgid header in single tenant modus [#1554](https://github.com/grafana/tempo/pull/1554) (@kvrhdn)
 * [BUGFIX] Fixed issue where backend does not support `root.name` and `root.service.name` [#1589](https://github.com/grafana/tempo/pull/1589) (@kvrhdn)
 * [BUGFIX] Fixed ingester to continue starting up after block replay error [#1603](https://github.com/grafana/tempo/issues/1603) (@mdisibio)
+* [BUGFIX] Fix issue relating to usage stats and GCS returning empty strings as tenantID [#1625](https://github.com/grafana/tempo/pull/1625) (@ie-pham)
 
 ## v1.4.1 / 2022-05-05
 

--- a/pkg/usagestats/reporter.go
+++ b/pkg/usagestats/reporter.go
@@ -23,8 +23,6 @@ import (
 )
 
 const (
-	// File name for the cluster seed file.
-	ClusterSeedFileName = "tempo_cluster_seed.json"
 	// attemptNumber how many times we will try to read a corrupted cluster seed before deleting it.
 	attemptNumber = 4
 	// seedKey is the key for the cluster seed to use with the kv store.
@@ -200,7 +198,7 @@ func (rep *Reporter) fetchSeed(ctx context.Context, continueFn func(err error) b
 
 // readSeedFile reads the cluster seed file from the object store.
 func (rep *Reporter) readSeedFile(ctx context.Context) (*ClusterSeed, error) {
-	reader, _, err := rep.reader.Read(ctx, ClusterSeedFileName, backend.KeyPath{}, false)
+	reader, _, err := rep.reader.Read(ctx, backend.ClusterSeedFileName, backend.KeyPath{}, false)
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +224,7 @@ func (rep *Reporter) writeSeedFile(ctx context.Context, seed ClusterSeed) error 
 	if err != nil {
 		return err
 	}
-	return rep.writer.Write(ctx, ClusterSeedFileName, []string{}, bytes.NewReader(data), -1, false)
+	return rep.writer.Write(ctx, backend.ClusterSeedFileName, []string{}, bytes.NewReader(data), -1, false)
 }
 
 // running inits the reporter seed and start sending report for every interval

--- a/pkg/usagestats/reporter_test.go
+++ b/pkg/usagestats/reporter_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/local"
 )
 
@@ -81,7 +82,7 @@ func Test_LeaderElectionWithBrokenSeedFile(t *testing.T) {
 	// Ensure that leader election succeeds even when the seed file has been
 	// corrupted.  This means that we don't need to extend the interface of the
 	// backend in order to delete a corrupted seed file.
-	err = objectClient.Write(context.Background(), ClusterSeedFileName, []string{}, bytes.NewReader([]byte("{")), -1, false)
+	err = objectClient.Write(context.Background(), backend.ClusterSeedFileName, []string{}, bytes.NewReader([]byte("{")), -1, false)
 	require.NoError(t, err)
 
 	for i := 0; i < 3; i++ {

--- a/tempodb/backend/gcs/gcs.go
+++ b/tempodb/backend/gcs/gcs.go
@@ -126,7 +126,7 @@ func (rw *readerWriter) List(ctx context.Context, keypath backend.KeyPath) ([]st
 		Versions:  false,
 	})
 
-	objects := make([]string, 0)
+	var objects []string
 	for {
 		attrs, err := iter.Next()
 		if err == iterator.Done {

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -132,6 +132,8 @@ func (r *reader) ReadRange(ctx context.Context, name string, blockID uuid.UUID, 
 
 func (r *reader) Tenants(ctx context.Context) ([]string, error) {
 	list, err := r.r.List(ctx, nil)
+
+	// this filter is added to fix a GCS usage stats issue that would result in ""
 	filteredList := make([]string, 0)
 	for _, tenant := range list {
 		if tenant != "" && tenant != ClusterSeedFileName {

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -134,7 +134,7 @@ func (r *reader) Tenants(ctx context.Context) ([]string, error) {
 	list, err := r.r.List(ctx, nil)
 
 	// this filter is added to fix a GCS usage stats issue that would result in ""
-	filteredList := make([]string, 0)
+	var filteredList []string
 	for _, tenant := range list {
 		if tenant != "" && tenant != ClusterSeedFileName {
 			filteredList = append(filteredList, tenant)

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -17,6 +17,8 @@ const (
 	MetaName          = "meta.json"
 	CompactedMetaName = "meta.compacted.json"
 	TenantIndexName   = "index.json.gz"
+	// File name for the cluster seed file.
+	ClusterSeedFileName = "tempo_cluster_seed.json"
 )
 
 // KeyPath is an ordered set of strings that govern where data is read/written from the backend
@@ -129,7 +131,15 @@ func (r *reader) ReadRange(ctx context.Context, name string, blockID uuid.UUID, 
 }
 
 func (r *reader) Tenants(ctx context.Context) ([]string, error) {
-	return r.r.List(ctx, nil)
+	list, err := r.r.List(ctx, nil)
+	filteredList := make([]string, 0)
+	for _, tenant := range list {
+		if tenant != "" && tenant != ClusterSeedFileName {
+			filteredList = append(filteredList, tenant)
+		}
+	}
+
+	return filteredList, err
 }
 
 func (r *reader) Blocks(ctx context.Context, tenantID string) ([]uuid.UUID, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: This PR fixes an issue for GCS when anonymous usage stats is enabled. Due to the cluster seed file being in the same folder, an incorrect tenant id of an empty string gets returned in the List() call. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`