### PR TITLE
Set MaxIdleConns and MaxIdleConnsPerHost for Azure backend

### DIFF
--- a/tempodb/backend/azure/azure_helpers.go
+++ b/tempodb/backend/azure/azure_helpers.go
@@ -35,6 +35,10 @@ func GetContainerURL(ctx context.Context, cfg *Config, hedge bool) (blob.Contain
 	}
 
 	customTransport := http.DefaultTransport.(*http.Transport).Clone()
+	// Default MaxIdleConnsPerHost is 2, increase that to reduce connection turnover
+	customTransport.MaxIdleConnsPerHost = 200
+	// set total max idle connections to a high number
+	customTransport.MaxIdleConns = 20000
 
 	// add instrumentation
 	transport := instrumentation.NewTransport(customTransport)

--- a/tempodb/backend/azure/azure_helpers.go
+++ b/tempodb/backend/azure/azure_helpers.go
@@ -36,9 +36,9 @@ func GetContainerURL(ctx context.Context, cfg *Config, hedge bool) (blob.Contain
 
 	customTransport := http.DefaultTransport.(*http.Transport).Clone()
 	// Default MaxIdleConnsPerHost is 2, increase that to reduce connection turnover
-	customTransport.MaxIdleConnsPerHost = 200
+	customTransport.MaxIdleConnsPerHost = 100
 	// set total max idle connections to a high number
-	customTransport.MaxIdleConns = 20000
+	customTransport.MaxIdleConns = 100
 
 	// add instrumentation
 	transport := instrumentation.NewTransport(customTransport)


### PR DESCRIPTION
**What this PR does**:
We are setting MaxIdleConnsPerHost in the customTransport used by Azure backend.

Default MaxIdleConnsPerHost is 2, Increase that to reduce connection turnover and hopefully fix the DNS failures seen in #1462 

**Which issue(s) this PR fixes**:
Possible fix for https://github.com/grafana/tempo/issues/1462

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`