### PR TITLE
Parquet Ingester Stability

### DIFF
--- a/tempodb/encoding/vparquet/create.go
+++ b/tempodb/encoding/vparquet/create.go
@@ -118,7 +118,7 @@ func newStreamingBlock(ctx context.Context, cfg *common.BlockConfig, meta *backe
 		r:     r,
 		to:    to,
 		sch:   sch,
-		pool:  newRowPool(0),
+		pool:  newRowPool(10_000),
 	}
 }
 

--- a/tempodb/encoding/vparquet/schema.go
+++ b/tempodb/encoding/vparquet/schema.go
@@ -58,8 +58,8 @@ type Attribute struct {
 }
 
 type EventAttribute struct {
-	Key   string `parquet:",zstd,dict"`
-	Value string `parquet:",zstd"` // Json-encoded data
+	Key   string `parquet:",snappy,dict"`
+	Value string `parquet:",snappy"` // Json-encoded data
 }
 
 type Event struct {


### PR DESCRIPTION
Small improvements to help with ingester stability.

- snappy is less resource intensive then zstd
- providing an initial slice of 10k parquet values improves ingester memory reqs.