### PR TITLE
Parquet: Minor compactor tweaks

### DIFF
--- a/tempodb/encoding/vparquet/block_iterator.go
+++ b/tempodb/encoding/vparquet/block_iterator.go
@@ -17,7 +17,7 @@ func (b *backendBlock) open(ctx context.Context) (*parquet.File, *parquet.Reader
 	rr := NewBackendReaderAt(ctx, b.r, DataFileName, b.meta.BlockID, b.meta.TenantID)
 
 	// 32 MB memory buffering
-	br := tempo_io.NewBufferedReaderAt(rr, int64(b.meta.Size), 512*1024, 64)
+	br := tempo_io.NewBufferedReaderAt(rr, int64(b.meta.Size), 4*1024*1024, 64)
 
 	pf, err := parquet.OpenFile(br, int64(b.meta.Size))
 	if err != nil {

--- a/tempodb/encoding/vparquet/block_iterator.go
+++ b/tempodb/encoding/vparquet/block_iterator.go
@@ -16,7 +16,7 @@ import (
 func (b *backendBlock) open(ctx context.Context) (*parquet.File, *parquet.Reader, error) {
 	rr := NewBackendReaderAt(ctx, b.r, DataFileName, b.meta.BlockID, b.meta.TenantID)
 
-	// 32 MB memory buffering
+	// 128 MB memory buffering
 	br := tempo_io.NewBufferedReaderAt(rr, int64(b.meta.Size), 2*1024*1024, 64)
 
 	pf, err := parquet.OpenFile(br, int64(b.meta.Size))

--- a/tempodb/encoding/vparquet/block_iterator.go
+++ b/tempodb/encoding/vparquet/block_iterator.go
@@ -17,7 +17,7 @@ func (b *backendBlock) open(ctx context.Context) (*parquet.File, *parquet.Reader
 	rr := NewBackendReaderAt(ctx, b.r, DataFileName, b.meta.BlockID, b.meta.TenantID)
 
 	// 32 MB memory buffering
-	br := tempo_io.NewBufferedReaderAt(rr, int64(b.meta.Size), 4*1024*1024, 64)
+	br := tempo_io.NewBufferedReaderAt(rr, int64(b.meta.Size), 2*1024*1024, 64)
 
 	pf, err := parquet.OpenFile(br, int64(b.meta.Size))
 	if err != nil {

--- a/tempodb/encoding/vparquet/compactor.go
+++ b/tempodb/encoding/vparquet/compactor.go
@@ -36,7 +36,7 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 		minBlockStart   time.Time
 		maxBlockEnd     time.Time
 		bookmarks       = make([]*bookmark, 0, len(inputs))
-		pool            = newRowPool(c.opts.MaxBytesPerTrace) // This is largest trace that can be expected, and assumes 1 byte per value on average (same as flushing)
+		pool            = newRowPool(c.opts.MaxBytesPerTrace / 3) // This is largest trace that can be expected, and assumes 1 byte per value on average (same as flushing)
 	)
 	for _, blockMeta := range inputs {
 		totalRecords += blockMeta.TotalObjects

--- a/tempodb/encoding/vparquet/compactor.go
+++ b/tempodb/encoding/vparquet/compactor.go
@@ -65,7 +65,7 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 			return nil, err
 		}
 
-		bookmarks = append(bookmarks, newBookmark(newPrefetchIterator(derivedCtx, iter, prefetchSize)))
+		bookmarks = append(bookmarks, newBookmark(iter))
 	}
 
 	var (

--- a/tempodb/encoding/vparquet/compactor.go
+++ b/tempodb/encoding/vparquet/compactor.go
@@ -36,7 +36,9 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 		minBlockStart   time.Time
 		maxBlockEnd     time.Time
 		bookmarks       = make([]*bookmark, 0, len(inputs))
-		pool            = newRowPool(c.opts.MaxBytesPerTrace / 3) // This is largest trace that can be expected, and assumes 1 byte per value on average (same as flushing)
+		// MaxBytesPerTrace is the largest trace that can be expected, and assumes 1 byte per value on average (same as flushing).
+		// Divide by 4 to presumably require 2 slice allocations if we ever see a trace this large
+		pool = newRowPool(c.opts.MaxBytesPerTrace / 4)
 	)
 	for _, blockMeta := range inputs {
 		totalRecords += blockMeta.TotalObjects

--- a/tempodb/encoding/vparquet/compactor.go
+++ b/tempodb/encoding/vparquet/compactor.go
@@ -38,8 +38,7 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 		bookmarks       = make([]*bookmark, 0, len(inputs))
 		// MaxBytesPerTrace is the largest trace that can be expected, and assumes 1 byte per value on average (same as flushing).
 		// Divide by 4 to presumably require 2 slice allocations if we ever see a trace this large
-		pool         = newRowPool(c.opts.MaxBytesPerTrace / 4)
-		prefetchSize = c.opts.IteratorBufferSize / len(inputs)
+		pool = newRowPool(c.opts.MaxBytesPerTrace / 4)
 	)
 	for _, blockMeta := range inputs {
 		totalRecords += blockMeta.TotalObjects


### PR DESCRIPTION
**What this PR does**:
- Lowers size of preallocated slice to reduce total consumption.
- Increases buffer size to reduce calls to the backend.