### PR TITLE
Parquet: Use proto instead of json for events

### DIFF
--- a/tempodb/encoding/vparquet/schema.go
+++ b/tempodb/encoding/vparquet/schema.go
@@ -59,7 +59,7 @@ type Attribute struct {
 
 type EventAttribute struct {
 	Key   string `parquet:",snappy,dict"`
-	Value string `parquet:",snappy"` // Json-encoded data
+	Value string `parquet:",snappy"` // Was json-encoded data, is now proto encoded data
 }
 
 type Event struct {
@@ -324,11 +324,12 @@ func eventToParquet(e *v1_trace.Span_Event) Event {
 	}
 
 	for _, a := range e.Attributes {
-		jsonBytes := &bytes.Buffer{}
-		_ = jsonMarshaler.Marshal(jsonBytes, a.Value)
+		b := make([]byte, a.Value.Size())
+		a.Value.MarshalToSizedBuffer(b)
+
 		ee.Attrs = append(ee.Attrs, EventAttribute{
 			Key:   a.Key,
-			Value: jsonBytes.String(),
+			Value: string(b),
 		})
 	}
 
@@ -396,7 +397,13 @@ func parquetToProtoEvents(parquetEvents []Event) []*v1_trace.Span_Event {
 						Value: &v1.AnyValue{},
 					}
 
-					_ = jsonpb.Unmarshal(bytes.NewBufferString(a.Value), protoAttr.Value)
+					// event attributes are currently encoded as proto, but were previously json.
+					//  this code attempts proto first and, if there was an error, falls back to json
+					err := protoAttr.Value.Unmarshal([]byte(a.Value))
+					if err != nil {
+						_ = jsonpb.Unmarshal(bytes.NewBufferString(a.Value), protoAttr.Value)
+					}
+
 					protoEvent.Attributes = append(protoEvent.Attributes, protoAttr)
 				}
 			}

--- a/tempodb/encoding/vparquet/schema.go
+++ b/tempodb/encoding/vparquet/schema.go
@@ -399,7 +399,7 @@ func parquetToProtoEvents(parquetEvents []Event) []*v1_trace.Span_Event {
 
 					// event attributes are currently encoded as proto, but were previously json.
 					//  this code attempts proto first and, if there was an error, falls back to json
-					err := protoAttr.Value.Unmarshal([]byte(a.Value))
+					err := protoAttr.Value.Unmarshal(a.Value)
 					if err != nil {
 						_ = jsonpb.Unmarshal(bytes.NewBuffer(a.Value), protoAttr.Value)
 					}

--- a/tempodb/encoding/vparquet/schema_test.go
+++ b/tempodb/encoding/vparquet/schema_test.go
@@ -218,7 +218,7 @@ func BenchmarkEventToParquet(b *testing.B) {
 		},
 	}
 
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < b.N; i++ {
 		eventToParquet(e)
 	}
 }

--- a/tempodb/encoding/vparquet/schema_test.go
+++ b/tempodb/encoding/vparquet/schema_test.go
@@ -187,6 +187,42 @@ func BenchmarkProtoToParquet(b *testing.B) {
 	}
 }
 
+func BenchmarkEventToParquet(b *testing.B) {
+	e := &v1_trace.Span_Event{
+		TimeUnixNano: 1000,
+		Name:         "blerg",
+		Attributes: []*v1.KeyValue{
+			// String
+			{Key: "s", Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "s2"}}},
+
+			// Int
+			{Key: "i", Value: &v1.AnyValue{Value: &v1.AnyValue_IntValue{IntValue: 123}}},
+
+			// Double
+			{Key: "d", Value: &v1.AnyValue{Value: &v1.AnyValue_DoubleValue{DoubleValue: 123.456}}},
+
+			// Bool
+			{Key: "b", Value: &v1.AnyValue{Value: &v1.AnyValue_BoolValue{BoolValue: true}}},
+
+			// KVList
+			{Key: "kv", Value: &v1.AnyValue{Value: &v1.AnyValue_KvlistValue{KvlistValue: &v1.KeyValueList{Values: []*v1.KeyValue{
+				{Key: "s2", Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "s3"}}},
+				{Key: "i2", Value: &v1.AnyValue{Value: &v1.AnyValue_IntValue{IntValue: 789}}},
+			}}}}},
+
+			// Array
+			{Key: "a", Value: &v1.AnyValue{Value: &v1.AnyValue_ArrayValue{ArrayValue: &v1.ArrayValue{Values: []*v1.AnyValue{
+				{Value: &v1.AnyValue_StringValue{StringValue: "s4"}},
+				{Value: &v1.AnyValue_IntValue{IntValue: 101112}},
+			}}}}},
+		},
+	}
+
+	for i := 0; i < 1000; i++ {
+		eventToParquet(e)
+	}
+}
+
 func BenchmarkDeconstruct(b *testing.B) {
 
 	batchCount := 100


### PR DESCRIPTION
**What this PR does**:
When encoding events we are currently using json. This format is extremely easy to read but currently accounts for 8% of all alloc'ed memory and 12% of all cpu cycles in an ingester. This PR changes the encoded format from json to proto. It is backwards compatible in that it attempts to read proto first and, if that fails, attempts json.

Benchmarks (json -> proto implementation in this PR)
```
name              old time/op    new time/op    delta
EventToParquet-8    11.8µs ± 2%     0.8µs ± 8%  -93.59%  (p=0.000 n=10+9)

name              old alloc/op   new alloc/op   delta
EventToParquet-8    2.91kB ± 0%    0.67kB ± 0%  -76.94%  (p=0.000 n=10+10)

name              old allocs/op  new allocs/op  delta
EventToParquet-8      91.0 ± 0%      10.0 ± 0%  -89.01%  (p=0.000 n=10+10)
```

Given the performance gains, I think we need to do something with this field. Another option on the table is a custom text based format, but that would require significantly more work. The one major con with this approach is that it will be more difficult for other consumers of our parquet file to use this field if it's proto encoded

Todo:
- Reevaluate performance vs size of various compressions. zstd gave ~6% better compression on blocks from ops then snappy. Traditionally zstd is more resource intensive than snappy, however, my tests were inconclusive.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`