### PR TITLE
Parquet: Compaction - Don't combine equal traces

### DIFF
--- a/tempodb/encoding/vparquet/compactor.go
+++ b/tempodb/encoding/vparquet/compactor.go
@@ -87,6 +87,9 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 			isEqual = rows[i-1].Equal(rows[i])
 		}
 		if isEqual {
+			for i := 1; i < len(rows); i++ {
+				pool.Put(rows[i])
+			}
 			return rows[0], nil
 		}
 

--- a/tempodb/encoding/vparquet/compactor.go
+++ b/tempodb/encoding/vparquet/compactor.go
@@ -82,6 +82,14 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 			return rows[0], nil
 		}
 
+		isEqual := true
+		for i := 1; i < len(rows) && isEqual; i++ {
+			isEqual = rows[i-1].Equal(rows[i])
+		}
+		if isEqual {
+			return rows[0], nil
+		}
+
 		// Total
 		if c.opts.MaxBytesPerTrace > 0 {
 			sum := 0

--- a/tempodb/encoding/vparquet/compactor.go
+++ b/tempodb/encoding/vparquet/compactor.go
@@ -84,7 +84,7 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 
 		isEqual := true
 		for i := 1; i < len(rows) && isEqual; i++ {
-			isEqual = rows[i-1].Equal(rows[i])
+			isEqual = rows[0].Equal(rows[i])
 		}
 		if isEqual {
 			for i := 1; i < len(rows); i++ {


### PR DESCRIPTION
**What this PR does**:
Improves compaction performance with parquet blocks by skipping equal rows before attempting to combine them.