### PR TITLE
Upgrade to latest parquet

### DIFF
--- a/cmd/tempo-serverless/cloud-run/go.mod
+++ b/cmd/tempo-serverless/cloud-run/go.mod
@@ -101,7 +101,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rs/xid v1.2.1 // indirect
 	github.com/segmentio/encoding v0.3.5 // indirect
-	github.com/segmentio/parquet-go v0.0.0-20220802221544-d84ed320251d // indirect
+	github.com/segmentio/parquet-go v0.0.0-20220811205829-7efc157d28af // indirect
 	github.com/sercand/kuberesolver v2.4.0+incompatible // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/sony/gobreaker v0.4.1 // indirect

--- a/cmd/tempo-serverless/cloud-run/go.sum
+++ b/cmd/tempo-serverless/cloud-run/go.sum
@@ -1738,8 +1738,8 @@ github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oH
 github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e/go.mod h1:tm/wZFQ8e24NYaBGIlnO2WGCAi67re4HHuOm0sftE/M=
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
-github.com/segmentio/parquet-go v0.0.0-20220802221544-d84ed320251d h1:IxYmTiYCMaR3B0fjD9igXDr1AE5M8KRFbhEhEJ1WYx4=
-github.com/segmentio/parquet-go v0.0.0-20220802221544-d84ed320251d/go.mod h1:BuMbRhCCg3gFchup9zucJaUjQ4m6RxX+iVci37CoMPQ=
+github.com/segmentio/parquet-go v0.0.0-20220811205829-7efc157d28af h1:DTVh/gwrdXKC418tn2hLECLC+/XaYZ+5yngQZtHlzzw=
+github.com/segmentio/parquet-go v0.0.0-20220811205829-7efc157d28af/go.mod h1:PxYdAI6cGd+s1j4hZDQbz3VFgobF5fDA0weLeNWKTE4=
 github.com/sercand/kuberesolver v2.1.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=
 github.com/sercand/kuberesolver v2.4.0+incompatible h1:WE2OlRf6wjLxHwNkkFLQGaZcVLEXjMjBPjjEU5vksH8=
 github.com/sercand/kuberesolver v2.4.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=

--- a/cmd/tempo-serverless/lambda/go.mod
+++ b/cmd/tempo-serverless/lambda/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rs/xid v1.2.1 // indirect
 	github.com/segmentio/encoding v0.3.5 // indirect
-	github.com/segmentio/parquet-go v0.0.0-20220802221544-d84ed320251d // indirect
+	github.com/segmentio/parquet-go v0.0.0-20220811205829-7efc157d28af // indirect
 	github.com/sercand/kuberesolver v2.4.0+incompatible // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/sony/gobreaker v0.4.1 // indirect

--- a/cmd/tempo-serverless/lambda/go.sum
+++ b/cmd/tempo-serverless/lambda/go.sum
@@ -1740,8 +1740,8 @@ github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oH
 github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e/go.mod h1:tm/wZFQ8e24NYaBGIlnO2WGCAi67re4HHuOm0sftE/M=
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
-github.com/segmentio/parquet-go v0.0.0-20220802221544-d84ed320251d h1:IxYmTiYCMaR3B0fjD9igXDr1AE5M8KRFbhEhEJ1WYx4=
-github.com/segmentio/parquet-go v0.0.0-20220802221544-d84ed320251d/go.mod h1:BuMbRhCCg3gFchup9zucJaUjQ4m6RxX+iVci37CoMPQ=
+github.com/segmentio/parquet-go v0.0.0-20220811205829-7efc157d28af h1:DTVh/gwrdXKC418tn2hLECLC+/XaYZ+5yngQZtHlzzw=
+github.com/segmentio/parquet-go v0.0.0-20220811205829-7efc157d28af/go.mod h1:PxYdAI6cGd+s1j4hZDQbz3VFgobF5fDA0weLeNWKTE4=
 github.com/sercand/kuberesolver v2.1.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=
 github.com/sercand/kuberesolver v2.4.0+incompatible h1:WE2OlRf6wjLxHwNkkFLQGaZcVLEXjMjBPjjEU5vksH8=
 github.com/sercand/kuberesolver v2.4.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/prometheus/prometheus v1.8.2-0.20220228151929-e25a59925555
 	github.com/prometheus/statsd_exporter v0.21.0 // indirect
 	github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e
-	github.com/segmentio/parquet-go v0.0.0-20220802221544-d84ed320251d
+	github.com/segmentio/parquet-go v0.0.0-20220811205829-7efc157d28af
 	github.com/sirupsen/logrus v1.8.1
 	github.com/sony/gobreaker v0.4.1
 	github.com/spf13/viper v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -1935,6 +1935,8 @@ github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfP
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/parquet-go v0.0.0-20220802221544-d84ed320251d h1:IxYmTiYCMaR3B0fjD9igXDr1AE5M8KRFbhEhEJ1WYx4=
 github.com/segmentio/parquet-go v0.0.0-20220802221544-d84ed320251d/go.mod h1:BuMbRhCCg3gFchup9zucJaUjQ4m6RxX+iVci37CoMPQ=
+github.com/segmentio/parquet-go v0.0.0-20220811205829-7efc157d28af h1:DTVh/gwrdXKC418tn2hLECLC+/XaYZ+5yngQZtHlzzw=
+github.com/segmentio/parquet-go v0.0.0-20220811205829-7efc157d28af/go.mod h1:PxYdAI6cGd+s1j4hZDQbz3VFgobF5fDA0weLeNWKTE4=
 github.com/sercand/kuberesolver v2.1.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=
 github.com/sercand/kuberesolver v2.4.0+incompatible h1:WE2OlRf6wjLxHwNkkFLQGaZcVLEXjMjBPjjEU5vksH8=
 github.com/sercand/kuberesolver v2.4.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=
@@ -2686,7 +2688,6 @@ golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220502124256-b6088ccd6cba/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d h1:/m5NbqQelATgoSPVC2Z23sR4kVNokFwDDyWh/3rGY+I=
 golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/vendor/github.com/segmentio/parquet-go/bloom/filter.go
+++ b/vendor/github.com/segmentio/parquet-go/bloom/filter.go
@@ -43,7 +43,6 @@ func MakeSplitBlockFilter(data []byte) SplitBlockFilter {
 // filters in memory, for example:
 //
 //	f := make(bloom.SplitBlockFilter, bloom.NumSplitBlocksOf(n, 10))
-//
 func NumSplitBlocksOf(numValues int64, bitsPerValue uint) int {
 	numBytes := ((uint(numValues) * bitsPerValue) + 7) / 8
 	numBlocks := (numBytes + (BlockSize - 1)) / BlockSize

--- a/vendor/github.com/segmentio/parquet-go/column_buffer_go18.go
+++ b/vendor/github.com/segmentio/parquet-go/column_buffer_go18.go
@@ -19,9 +19,8 @@ import (
 //
 // - rows is the array of Go values to write to the column buffers.
 //
-// - levels is used to track the column index, repetition and definition levels
-//   of values when writing optional or repeated columns.
-//
+//   - levels is used to track the column index, repetition and definition levels
+//     of values when writing optional or repeated columns.
 type writeRowsFunc func(columns []ColumnBuffer, rows sparse.Array, levels columnLevels) error
 
 // writeRowsFuncOf generates a writeRowsFunc function for the given Go type and

--- a/vendor/github.com/segmentio/parquet-go/config.go
+++ b/vendor/github.com/segmentio/parquet-go/config.go
@@ -28,7 +28,6 @@ const (
 //		SkipPageIndex:    true,
 //		SkipBloomFilters: true,
 //	})
-//
 type FileConfig struct {
 	SkipPageIndex    bool
 	SkipBloomFilters bool
@@ -82,7 +81,6 @@ func (c *FileConfig) Validate() error {
 //	reader := parquet.NewReader(output, schema, &parquet.ReaderConfig{
 //		// ...
 //	})
-//
 type ReaderConfig struct {
 	Schema *Schema
 }
@@ -131,7 +129,6 @@ func (c *ReaderConfig) Validate() error {
 //	writer := parquet.NewWriter(output, schema, &parquet.WriterConfig{
 //		CreatedBy: "my test program",
 //	})
-//
 type WriterConfig struct {
 	CreatedBy            string
 	ColumnPageBuffers    PageBufferPool
@@ -225,7 +222,6 @@ func (c *WriterConfig) Validate() error {
 //	buffer := parquet.NewBuffer(&parquet.RowGroupConfig{
 //		ColumnBufferCapacity: 10_000,
 //	})
-//
 type RowGroupConfig struct {
 	ColumnBufferCapacity int
 	SortingColumns       []SortingColumn

--- a/vendor/github.com/segmentio/parquet-go/convert.go
+++ b/vendor/github.com/segmentio/parquet-go/convert.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"sync"
+
+	"github.com/segmentio/parquet-go/encoding"
 )
 
 // ConvertError is an error type returned by calls to Convert when the conversion
@@ -331,11 +333,13 @@ func (p missingPage) NumRows() int64                    { return p.numRows }
 func (p missingPage) NumValues() int64                  { return p.numValues }
 func (p missingPage) NumNulls() int64                   { return p.numNulls }
 func (p missingPage) Bounds() (min, max Value, ok bool) { return }
+func (p missingPage) Clone() Page                       { return p }
+func (p missingPage) Slice(i, j int64) Page             { return p }
 func (p missingPage) Size() int64                       { return 0 }
+func (p missingPage) RepetitionLevels() []byte          { return nil }
+func (p missingPage) DefinitionLevels() []byte          { return nil }
+func (p missingPage) Data() encoding.Values             { return p.typ.NewValues(nil, nil) }
 func (p missingPage) Values() ValueReader               { return &missingPageValues{page: p} }
-func (p missingPage) Buffer() BufferedPage {
-	return newErrorPage(p.Type(), p.Column(), "cannot buffer missing page")
-}
 
 type missingPageValues struct {
 	page missingPage

--- a/vendor/github.com/segmentio/parquet-go/dictionary.go
+++ b/vendor/github.com/segmentio/parquet-go/dictionary.go
@@ -75,11 +75,11 @@ type Dictionary interface {
 	// Resets the dictionary to its initial state, removing all values.
 	Reset()
 
-	// Returns a BufferedPage representing the content of the dictionary.
+	// Returns a Page representing the content of the dictionary.
 	//
 	// The returned page shares the underlying memory of the buffer, it remains
 	// valid to use until the dictionary's Reset method is called.
-	Page() BufferedPage
+	Page() Page
 
 	// See ColumnBuffer.writeValues for details on the use of unexported methods
 	// on interfaces.
@@ -211,7 +211,7 @@ func (d *booleanDictionary) Reset() {
 	d.table = [2]int32{-1, -1}
 }
 
-func (d *booleanDictionary) Page() BufferedPage {
+func (d *booleanDictionary) Page() Page {
 	return &d.booleanPage
 }
 
@@ -311,7 +311,7 @@ func (d *int32Dictionary) Reset() {
 	}
 }
 
-func (d *int32Dictionary) Page() BufferedPage {
+func (d *int32Dictionary) Page() Page {
 	return &d.int32Page
 }
 
@@ -398,7 +398,7 @@ func (d *int64Dictionary) Reset() {
 	}
 }
 
-func (d *int64Dictionary) Page() BufferedPage {
+func (d *int64Dictionary) Page() Page {
 	return &d.int64Page
 }
 
@@ -493,7 +493,7 @@ func (d *int96Dictionary) Reset() {
 	d.hashmap = nil
 }
 
-func (d *int96Dictionary) Page() BufferedPage {
+func (d *int96Dictionary) Page() Page {
 	return &d.int96Page
 }
 
@@ -580,7 +580,7 @@ func (d *floatDictionary) Reset() {
 	}
 }
 
-func (d *floatDictionary) Page() BufferedPage {
+func (d *floatDictionary) Page() Page {
 	return &d.floatPage
 }
 
@@ -667,7 +667,7 @@ func (d *doubleDictionary) Reset() {
 	}
 }
 
-func (d *doubleDictionary) Page() BufferedPage {
+func (d *doubleDictionary) Page() Page {
 	return &d.doublePage
 }
 
@@ -794,7 +794,7 @@ func (d *byteArrayDictionary) Reset() {
 	}
 }
 
-func (d *byteArrayDictionary) Page() BufferedPage {
+func (d *byteArrayDictionary) Page() Page {
 	return &d.byteArrayPage
 }
 
@@ -909,7 +909,7 @@ func (d *fixedLenByteArrayDictionary) Reset() {
 	d.hashmap = nil
 }
 
-func (d *fixedLenByteArrayDictionary) Page() BufferedPage {
+func (d *fixedLenByteArrayDictionary) Page() Page {
 	return &d.fixedLenByteArrayPage
 }
 
@@ -996,7 +996,7 @@ func (d *uint32Dictionary) Reset() {
 	}
 }
 
-func (d *uint32Dictionary) Page() BufferedPage {
+func (d *uint32Dictionary) Page() Page {
 	return &d.uint32Page
 }
 
@@ -1083,7 +1083,7 @@ func (d *uint64Dictionary) Reset() {
 	}
 }
 
-func (d *uint64Dictionary) Page() BufferedPage {
+func (d *uint64Dictionary) Page() Page {
 	return &d.uint64Page
 }
 
@@ -1201,7 +1201,7 @@ func (d *be128Dictionary) Reset() {
 	}
 }
 
-func (d *be128Dictionary) Page() BufferedPage {
+func (d *be128Dictionary) Page() Page {
 	return &d.be128Page
 }
 
@@ -1229,7 +1229,7 @@ func (t *indexedType) NewValues(values []byte, _ []uint32) encoding.Values {
 	return encoding.Int32ValuesFromBytes(values)
 }
 
-// indexedPage is an implementation of the BufferedPage interface which stores
+// indexedPage is an implementation of the Page interface which stores
 // indexes instead of plain value. The indexes reference the values in a
 // dictionary that the page was created for.
 type indexedPage struct {
@@ -1288,8 +1288,6 @@ func (page *indexedPage) Data() encoding.Values { return encoding.Int32Values(pa
 
 func (page *indexedPage) Values() ValueReader { return &indexedPageValues{page: page} }
 
-func (page *indexedPage) Buffer() BufferedPage { return page }
-
 func (page *indexedPage) Bounds() (min, max Value, ok bool) {
 	if ok = len(page.values) > 0; ok {
 		min, max = page.typ.dict.Bounds(page.values)
@@ -1299,7 +1297,7 @@ func (page *indexedPage) Bounds() (min, max Value, ok bool) {
 	return min, max, ok
 }
 
-func (page *indexedPage) Clone() BufferedPage {
+func (page *indexedPage) Clone() Page {
 	return &indexedPage{
 		typ:         page.typ,
 		values:      append([]int32{}, page.values...),
@@ -1307,7 +1305,7 @@ func (page *indexedPage) Clone() BufferedPage {
 	}
 }
 
-func (page *indexedPage) Slice(i, j int64) BufferedPage {
+func (page *indexedPage) Slice(i, j int64) Page {
 	return &indexedPage{
 		typ:         page.typ,
 		values:      page.values[i:j],
@@ -1383,7 +1381,7 @@ func (col *indexedColumnBuffer) Dictionary() Dictionary { return col.typ.dict }
 
 func (col *indexedColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *indexedColumnBuffer) Page() BufferedPage { return &col.indexedPage }
+func (col *indexedColumnBuffer) Page() Page { return &col.indexedPage }
 
 func (col *indexedColumnBuffer) Reset() { col.values = col.values[:0] }
 

--- a/vendor/github.com/segmentio/parquet-go/file.go
+++ b/vendor/github.com/segmentio/parquet-go/file.go
@@ -147,19 +147,19 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 // Only leaf columns have indexes, the returned indexes are arranged using the
 // following layout:
 //
-//	+ -------------- +
-//	| col 0: chunk 0 |
-//	+ -------------- +
-//	| col 1: chunk 0 |
-//	+ -------------- +
-//	| ...            |
-//	+ -------------- +
-//	| col 0: chunk 1 |
-//	+ -------------- +
-//	| col 1: chunk 1 |
-//	+ -------------- +
-//	| ...            |
-//	+ -------------- +
+//   - -------------- +
+//     | col 0: chunk 0 |
+//   - -------------- +
+//     | col 1: chunk 0 |
+//   - -------------- +
+//     | ...            |
+//   - -------------- +
+//     | col 0: chunk 1 |
+//   - -------------- +
+//     | col 1: chunk 1 |
+//   - -------------- +
+//     | ...            |
+//   - -------------- +
 //
 // This method is useful in combination with the SkipPageIndex option to delay
 // reading the page index section until after the file was opened. Note that in
@@ -452,11 +452,9 @@ func (c *fileColumnChunk) NumValues() int64 {
 }
 
 type filePages struct {
-	chunk    *fileColumnChunk
-	dictPage *dictPage
-	dataPage *dataPage
-	rbuf     *bufio.Reader
-	section  io.SectionReader
+	chunk   *fileColumnChunk
+	rbuf    *bufio.Reader
+	section io.SectionReader
 
 	protocol thrift.CompactProtocol
 	decoder  thrift.Decoder
@@ -466,10 +464,10 @@ type filePages struct {
 	dictOffset int64
 	index      int
 	skip       int64
+	dictionary Dictionary
 }
 
 func (f *filePages) init(c *fileColumnChunk) {
-	f.dataPage = acquireDataPage()
 	f.chunk = c
 	f.baseOffset = c.chunk.MetaData.DataPageOffset
 	f.dataOffset = f.baseOffset
@@ -480,7 +478,7 @@ func (f *filePages) init(c *fileColumnChunk) {
 	}
 
 	f.section = *io.NewSectionReader(c.file, f.baseOffset, c.chunk.MetaData.TotalCompressedSize)
-	f.rbuf = acquireReadBuffer(&f.section)
+	f.rbuf = getBufioReader(&f.section)
 	f.decoder.Reset(f.protocol.NewReader(f.rbuf))
 }
 
@@ -494,58 +492,61 @@ func (f *filePages) ReadPage() (Page, error) {
 		if err := f.decoder.Decode(header); err != nil {
 			return nil, err
 		}
-		if err := f.readPage(header, f.dataPage, f.rbuf); err != nil {
+		data, err := f.readPage(header, f.rbuf)
+		if err != nil {
 			return nil, err
 		}
 
 		var page Page
-		var err error
-
 		switch header.Type {
 		case format.DataPageV2:
-			page, err = f.readDataPageV2(header)
+			page, err = f.readDataPageV2(header, data)
 		case format.DataPage:
-			page, err = f.readDataPageV1(header)
+			page, err = f.readDataPageV1(header, data)
 		case format.DictionaryPage:
 			// Sometimes parquet files do not have the dictionary page offset
 			// recorded in the column metadata. We account for this by lazily
 			// reading dictionary pages when we encounter them.
-			err = f.readDictionaryPage(header, f.dataPage)
+			err = f.readDictionaryPage(header, data)
 		default:
 			err = fmt.Errorf("cannot read values of type %s from page", header.Type)
 		}
+
+		data.unref()
 
 		if err != nil {
 			return nil, fmt.Errorf("decoding page %d of column %q: %w", f.index, f.columnPath(), err)
 		}
 
-		if page != nil {
-			f.index++
-			if f.skip == 0 {
-				return page, nil
-			}
-
-			// TODO: what about pages that don't embed the number of rows?
-			// (data page v1 with no offset index in the column chunk).
-			numRows := page.NumRows()
-			if numRows > f.skip {
-				seek := f.skip
-				f.skip = 0
-				if seek > 0 {
-					page = page.Buffer().Slice(seek, numRows)
-				}
-				return page, nil
-			}
-
-			f.skip -= numRows
+		if page == nil {
+			continue
 		}
+
+		f.index++
+		if f.skip == 0 {
+			return page, nil
+		}
+
+		// TODO: what about pages that don't embed the number of rows?
+		// (data page v1 with no offset index in the column chunk).
+		numRows := page.NumRows()
+		if numRows > f.skip {
+			seek := f.skip
+			f.skip = 0
+			if seek > 0 {
+				page = page.Slice(seek, numRows)
+			}
+			return page, nil
+		}
+
+		f.skip -= numRows
 	}
 }
 
 func (f *filePages) readDictionary() error {
 	chunk := io.NewSectionReader(f.chunk.file, f.baseOffset, f.chunk.chunk.MetaData.TotalCompressedSize)
-	rbuf := acquireReadBuffer(chunk)
-	defer releaseReadBuffer(rbuf)
+	rbuf := getBufioReader(chunk)
+	defer putBufioReader(rbuf)
 
 	decoder := thrift.NewDecoder(f.protocol.NewReader(rbuf))
 	header := new(format.PageHeader)
@@ -554,49 +555,47 @@ func (f *filePages) readDictionary() error {
 		return err
 	}
 
-	page := acquireDataPage()
-	defer releaseDataPage(page)
+	page := compressedPageBufferPool.get()
+	defer page.unref()
 
-	if err := f.readPage(header, page, rbuf); err != nil {
+	page.resize(int(header.CompressedPageSize))
+
+	if _, err := io.ReadFull(rbuf, page.data); err != nil {
 		return err
 	}
 
 	return f.readDictionaryPage(header, page)
 }
 
-func (f *filePages) readDictionaryPage(header *format.PageHeader, page *dataPage) (err error) {
+func (f *filePages) readDictionaryPage(header *format.PageHeader, page *buffer) error {
 	if header.DictionaryPageHeader == nil {
 		return ErrMissingPageHeader
 	}
-	f.dictPage, _ = dictPagePool.Get().(*dictPage)
-	if f.dictPage == nil {
-		f.dictPage = new(dictPage)
+	d, err := f.chunk.column.decodeDictionary(DictionaryPageHeader{header.DictionaryPageHeader}, page, header.UncompressedPageSize)
+	if err != nil {
+		return err
 	}
-	f.dataPage.dictionary, err = f.chunk.column.decodeDictionary(
-		DictionaryPageHeader{header.DictionaryPageHeader},
-		page,
-		f.dictPage,
-	)
-	return err
+	f.dictionary = d
+	return nil
 }
 
-func (f *filePages) readDataPageV1(header *format.PageHeader) (Page, error) {
+func (f *filePages) readDataPageV1(header *format.PageHeader, page *buffer) (Page, error) {
 	if header.DataPageHeader == nil {
 		return nil, ErrMissingPageHeader
 	}
-	if isDictionaryFormat(header.DataPageHeader.Encoding) && f.dataPage.dictionary == nil {
+	if isDictionaryFormat(header.DataPageHeader.Encoding) && f.dictionary == nil {
 		if err := f.readDictionary(); err != nil {
 			return nil, err
 		}
 	}
-	return f.chunk.column.decodeDataPageV1(DataPageHeaderV1{header.DataPageHeader}, f.dataPage)
+	return f.chunk.column.decodeDataPageV1(DataPageHeaderV1{header.DataPageHeader}, page, f.dictionary, header.UncompressedPageSize)
 }
 
-func (f *filePages) readDataPageV2(header *format.PageHeader) (Page, error) {
+func (f *filePages) readDataPageV2(header *format.PageHeader, page *buffer) (Page, error) {
 	if header.DataPageHeaderV2 == nil {
 		return nil, ErrMissingPageHeader
 	}
-	if isDictionaryFormat(header.DataPageHeaderV2.Encoding) && f.dataPage.dictionary == nil {
+	if isDictionaryFormat(header.DataPageHeaderV2.Encoding) && f.dictionary == nil {
 		// If the program seeked to a row passed the first page, the dictionary
 		// page may not have been seen, in which case we have to lazily load it
 		// from the beginning of column chunk.
@@ -604,23 +603,17 @@ func (f *filePages) readDataPageV2(header *format.PageHeader) (Page, error) {
 			return nil, err
 		}
 	}
-	return f.chunk.column.decodeDataPageV2(DataPageHeaderV2{header.DataPageHeaderV2}, f.dataPage)
+	return f.chunk.column.decodeDataPageV2(DataPageHeaderV2{header.DataPageHeaderV2}, page, f.dictionary, header.UncompressedPageSize)
 }
 
-func (f *filePages) readPage(header *format.PageHeader, page *dataPage, reader *bufio.Reader) error {
-	compressedPageSize, uncompressedPageSize := int(header.CompressedPageSize), int(header.UncompressedPageSize)
+func (f *filePages) readPage(header *format.PageHeader, reader *bufio.Reader) (*buffer, error) {
+	page := compressedPageBufferPool.get()
+	defer page.unref()
 
-	if cap(page.data) < compressedPageSize {
-		page.data = make([]byte, compressedPageSize)
-	} else {
-		page.data = page.data[:compressedPageSize]
-	}
-	if cap(page.values) < uncompressedPageSize {
-		page.values = make([]byte, 0, uncompressedPageSize)
-	}
+	page.resize(int(header.CompressedPageSize))
 
 	if _, err := io.ReadFull(reader, page.data); err != nil {
-		return err
+		return nil, err
 	}
 
 	if header.CRC != 0 {
@@ -646,7 +639,7 @@ func (f *filePages) readPage(header *format.PageHeader, page *dataPage, reader *
 			// For now, we assume these errors to be fatal, but we may
 			// revisit later and improve error handling to be more resilient
 			// to data corruption.
-			return fmt.Errorf("crc32 checksum mismatch in page of column %q: want=0x%08X got=0x%08X: %w",
+			return nil, fmt.Errorf("crc32 checksum mismatch in page of column %q: want=0x%08X got=0x%08X: %w",
 				f.columnPath(),
 				headerChecksum,
 				bufferChecksum,
@@ -655,7 +648,8 @@ func (f *filePages) readPage(header *format.PageHeader, page *dataPage, reader *
 		}
 	}
 
-	return nil
+	page.ref()
+	return page, nil
 }
 
 func (f *filePages) SeekToRow(rowIndex int64) (err error) {
@@ -686,12 +680,8 @@ func (f *filePages) SeekToRow(rowIndex int64) (err error) {
 }
 
 func (f *filePages) Close() error {
-	releaseDictPage(f.dictPage)
-	releaseDataPage(f.dataPage)
-	releaseReadBuffer(f.rbuf)
+	putBufioReader(f.rbuf)
 	f.chunk = nil
-	f.dictPage = nil
-	f.dataPage = nil
 	f.section = io.SectionReader{}
 	f.rbuf = nil
 	f.baseOffset = 0
@@ -699,6 +689,7 @@ func (f *filePages) Close() error {
 	f.dictOffset = 0
 	f.index = 0
 	f.skip = 0
+	f.dictionary = nil
 	return nil
 }
 
@@ -707,54 +698,22 @@ func (f *filePages) columnPath() columnPath {
 }
 
 var (
-	dictPagePool   sync.Pool // *dictPage
-	dataPagePool   sync.Pool // *dataPage
-	readBufferPool sync.Pool // *bufio.Reader
+	bufioReaderPool sync.Pool
 )
 
-func acquireDictPage() *dictPage {
-	p, _ := dictPagePool.Get().(*dictPage)
-	if p == nil {
-		p = new(dictPage)
-	}
-	return p
-}
-
-func releaseDictPage(p *dictPage) {
-	if p != nil {
-		p.reset()
-		dictPagePool.Put(p)
-	}
-}
-
-func acquireDataPage() *dataPage {
-	p, _ := dataPagePool.Get().(*dataPage)
-	if p == nil {
-		p = new(dataPage)
-	}
-	return p
-}
-
-func releaseDataPage(p *dataPage) {
-	if p != nil {
-		p.reset()
-		dataPagePool.Put(p)
-	}
-}
-
-func acquireReadBuffer(r io.Reader) *bufio.Reader {
-	b, _ := readBufferPool.Get().(*bufio.Reader)
-	if b == nil {
-		b = bufio.NewReaderSize(r, defaultReadBufferSize)
+func getBufioReader(r io.Reader) *bufio.Reader {
+	rbuf, _ := bufioReaderPool.Get().(*bufio.Reader)
+	if rbuf == nil {
+		rbuf = bufio.NewReaderSize(r, defaultReadBufferSize)
 	} else {
-		b.Reset(r)
+		rbuf.Reset(r)
 	}
-	return b
+	return rbuf
 }
 
-func releaseReadBuffer(b *bufio.Reader) {
-	if b != nil {
-		b.Reset(nil)
-		readBufferPool.Put(b)
+func putBufioReader(rbuf *bufio.Reader) {
+	if rbuf != nil {
+		rbuf.Reset(nil)
+		bufioReaderPool.Put(rbuf)
 	}
 }

--- a/vendor/github.com/segmentio/parquet-go/format/parquet.go
+++ b/vendor/github.com/segmentio/parquet-go/format/parquet.go
@@ -281,11 +281,11 @@ func (t *LogicalType) String() string {
 
 // Represents a element inside a schema definition.
 //
-//	- if it is a group (inner node) then type is undefined and num_children is
-//    defined
+//   - if it is a group (inner node) then type is undefined and num_children is
+//     defined
 //
-//	- if it is a primitive type (leaf) then type is defined and num_children is
-//    undefined
+//   - if it is a primitive type (leaf) then type is defined and num_children is
+//     undefined
 //
 // The nodes are listed in depth first traversal order.
 type SchemaElement struct {

--- a/vendor/github.com/segmentio/parquet-go/hashprobe/hashprobe.go
+++ b/vendor/github.com/segmentio/parquet-go/hashprobe/hashprobe.go
@@ -149,7 +149,7 @@ func (t *Uint32Table) ProbeArray(keys sparse.Uint32Array, values []int32) int {
 //
 // The table uses the following memory layout:
 //
-//		[group 0][group 1][...][group N]
+//	[group 0][group 1][...][group N]
 //
 // Each group contains up to 7 key/value pairs, and is exactly 64 bytes in size,
 // which allows it to fit within a single cache line, and ensures that probes
@@ -598,7 +598,7 @@ func (t *Uint128Table) ProbeArray(keys sparse.Uint128Array, values []int32) int 
 //
 // This table uses the following memory layout:
 //
-//		[key A][key B][...][value A][value B][...]
+//	[key A][key B][...][value A][value B][...]
 //
 // The table stores values as their actual value plus one, and uses zero as a
 // sentinel to determine whether a slot is occupied. A linear probing strategy

--- a/vendor/github.com/segmentio/parquet-go/internal/bytealg/count_amd64.go
+++ b/vendor/github.com/segmentio/parquet-go/internal/bytealg/count_amd64.go
@@ -12,7 +12,6 @@ package bytealg
 // name       old speed      new speed      delta
 // CountByte  49.6GB/s ± 0%  93.2GB/s ± 0%  +87.74%  (p=0.000 n=10+10)
 //
-//
 // On systems that do not have AVX-512, the AVX2 version of the code is also
 // optimized to make use of multiple register lanes, which gives a bit better
 // throughput than the standard library function:
@@ -22,7 +21,6 @@ package bytealg
 //
 // name       old speed      new speed      delta
 // CountByte  49.6GB/s ± 0%  67.1GB/s ± 0%  +35.21%  (p=0.000 n=10+10)
-//
 //
 //go:noescape
 func Count(data []byte, value byte) int

--- a/vendor/github.com/segmentio/parquet-go/internal/unsafecast/unsafecast_go18.go
+++ b/vendor/github.com/segmentio/parquet-go/internal/unsafecast/unsafecast_go18.go
@@ -8,8 +8,7 @@
 // casting a [][16]byte to a []byte in order to use functions of the standard
 // bytes package on the slices.
 //
-//		With great power comes great responsibility.
-//
+//	With great power comes great responsibility.
 package unsafecast
 
 import (

--- a/vendor/github.com/segmentio/parquet-go/page.go
+++ b/vendor/github.com/segmentio/parquet-go/page.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"runtime"
 
 	"github.com/segmentio/parquet-go/deprecated"
 	"github.com/segmentio/parquet-go/encoding"
@@ -41,7 +42,7 @@ type Page interface {
 	NumValues() int64
 	NumNulls() int64
 
-	// Returns the min and max values currently buffered in the writer.
+	// Returns the page's min and max values.
 	//
 	// The third value is a boolean indicating whether the page bounds were
 	// available. Page bounds may not be known if the page contained no values
@@ -61,23 +62,13 @@ type Page interface {
 	// available.
 	Values() ValueReader
 
-	// Buffer returns the page as a BufferedPage, which may be the page itself
-	// if it was already buffered.
-	Buffer() BufferedPage
-}
-
-// BufferedPage is an extension of the Page interface implemented by pages
-// that are buffered in memory.
-type BufferedPage interface {
-	Page
-
 	// Returns a copy of the page which does not share any of the buffers, but
 	// contains the same values, repetition and definition levels.
-	Clone() BufferedPage
+	Clone() Page
 
 	// Returns a new page which is as slice of the receiver between row indexes
 	// i and j.
-	Slice(i, j int64) BufferedPage
+	Slice(i, j int64) Page
 
 	// Expose the lists of repetition and definition levels of the page.
 	//
@@ -95,24 +86,6 @@ type BufferedPage interface {
 	// multiple calls to this method, applications must treat the content as
 	// immutable.
 	Data() encoding.Values
-}
-
-// CompressedPage is an extension of the Page interface implemented by pages
-// that have been compressed to their on-file representation.
-type CompressedPage interface {
-	Page
-
-	// Returns a representation of the page header.
-	PageHeader() PageHeader
-
-	// Returns a reader exposing the content of the compressed page.
-	PageData() io.Reader
-
-	// Returns the size of the page data.
-	PageSize() int64
-
-	// CRC returns the IEEE CRC32 checksum of the page.
-	CRC() uint32
 }
 
 // PageReader is an interface implemented by types that support producing a
@@ -144,23 +117,145 @@ type Pages interface {
 	io.Closer
 }
 
+// AsyncPages wraps the given Pages instance to perform page reads
+// asynchronously in a separate goroutine.
+//
+// Performing page reads asynchronously is important when the application may
+// be reading pages from a high latency backend, and the last
+// page read may be processed while initiating reading of the next page.
+func AsyncPages(pages Pages) Pages {
+	p := new(asyncPages)
+	p.init(pages, nil)
+	// If the pages object gets garbage collected without Close being called,
+	// this finalizer would ensure that the goroutine is stopped and doesn't
+	// leak.
+	runtime.SetFinalizer(p, func(p *asyncPages) { p.Close() })
+	return p
+}
+
+type asyncPages struct {
+	read    <-chan asyncPage
+	seek    chan<- int64
+	done    chan<- struct{}
+	version int64
+}
+
+type asyncPage struct {
+	page    Page
+	err     error
+	version int64
+}
+
+func (pages *asyncPages) init(base Pages, done chan struct{}) {
+	read := make(chan asyncPage)
+	seek := make(chan int64, 1)
+
+	pages.read = read
+	pages.seek = seek
+
+	if done == nil {
+		done = make(chan struct{})
+		pages.done = done
+	}
+
+	go readPages(base, read, seek, done)
+}
+
+func (pages *asyncPages) Close() (err error) {
+	if pages.done != nil {
+		close(pages.done)
+		pages.done = nil
+	}
+	for p := range pages.read {
+		// Capture the last error, which is the value returned from closing the
+		// underlying Pages instance.
+		err = p.err
+	}
+	pages.seek = nil
+	return err
+}
+
+func (pages *asyncPages) ReadPage() (Page, error) {
+	for {
+		p, ok := <-pages.read
+		if !ok {
+			return nil, io.EOF
+		}
+		// Because calls to SeekToRow might be made concurrently to reading
+		// pages, it is possible for ReadPage to see pages that were read before
+		// the last SeekToRow call.
+		//
+		// A version number is attached to each page read asynchronously to
+		// discard outdated pages and ensure that we maintain a consistent view
+		// of the sequence of pages read.
+		if p.version == pages.version {
+			return p.page, p.err
+		}
+	}
+}
+
+func (pages *asyncPages) SeekToRow(rowIndex int64) error {
+	if pages.seek == nil {
+		return io.ErrClosedPipe
+	}
+	// The seek channel has a capacity of 1 to allow the first SeekToRow call to
+	// be non-blocking.
+	//
+	// If SeekToRow calls are performed faster than they can be handled by the
+	// goroutine reading pages, this path might become a contention point.
+	pages.seek <- rowIndex
+	pages.version++
+	return nil
+}
+
+func readPages(pages Pages, read chan<- asyncPage, seek <-chan int64, done <-chan struct{}) {
+	defer func() {
+		read <- asyncPage{err: pages.Close(), version: -1}
+		close(read)
+	}()
+
+	version := int64(0)
+	for {
+		page, err := pages.ReadPage()
+
+		for {
+			select {
+			case <-done:
+				return
+			case read <- asyncPage{
+				page:    page,
+				err:     err,
+				version: version,
+			}:
+			case rowIndex := <-seek:
+				version++
+				err = pages.SeekToRow(rowIndex)
+			}
+			if err == nil {
+				break
+			}
+		}
+	}
+}
+
 func copyPagesAndClose(w PageWriter, r Pages) (int64, error) {
 	defer r.Close()
 	return CopyPages(w, r)
 }
 
 type singlePage struct {
-	page Page
-	seek int64
+	page    Page
+	seek    int64
+	numRows int64
 }
 
 func (r *singlePage) ReadPage() (Page, error) {
 	if r.page != nil {
-		if numRows := r.page.NumRows(); r.seek < numRows {
+		if r.seek < r.numRows {
 			seek := r.seek
-			r.seek = numRows
+			r.seek = r.numRows
 			if seek > 0 {
-				return r.page.Buffer().Slice(seek, numRows), nil
+				return r.page.Slice(seek, r.numRows), nil
 			}
 			return r.page, nil
 		}
@@ -179,7 +274,9 @@ func (r *singlePage) Close() error {
 	return nil
 }
 
-func onePage(page Page) Pages { return &singlePage{page: page} }
+func onePage(page Page) Pages {
+	return &singlePage{page: page, numRows: page.NumRows()}
+}
 
 // CopyPages copies pages from src to dst, returning the number of values that
 // were copied.
@@ -204,7 +301,7 @@ func CopyPages(dst PageWriter, src PageReader) (numValues int64, err error) {
 	}
 }
 
-func forEachPageSlice(page BufferedPage, wantSize int64, do func(BufferedPage) error) error {
+func forEachPageSlice(page Page, wantSize int64, do func(Page) error) error {
 	numRows := page.NumRows()
 	if numRows == 0 {
 		return nil
@@ -219,7 +316,10 @@ func forEachPageSlice(page BufferedPage, wantSize int64, do func(BufferedPage) e
 
 	for numPages > 0 {
 		lastRowIndex := rowIndex + ((numRows - rowIndex) / numPages)
-		if err := do(page.Slice(rowIndex, lastRowIndex)); err != nil {
+		pageSlice := page.Slice(rowIndex, lastRowIndex)
+		err := do(pageSlice)
+		unref(pageSlice)
+		if err != nil {
 			return err
 		}
 		rowIndex = lastRowIndex
@@ -256,14 +356,13 @@ func (page *errorPage) NumRows() int64                    { return 1 }
 func (page *errorPage) NumValues() int64                  { return 1 }
 func (page *errorPage) NumNulls() int64                   { return 0 }
 func (page *errorPage) Bounds() (min, max Value, ok bool) { return }
-func (page *errorPage) Clone() BufferedPage               { return page }
-func (page *errorPage) Slice(i, j int64) BufferedPage     { return page }
+func (page *errorPage) Clone() Page                       { return page }
+func (page *errorPage) Slice(i, j int64) Page             { return page }
 func (page *errorPage) Size() int64                       { return 1 }
 func (page *errorPage) RepetitionLevels() []byte          { return nil }
 func (page *errorPage) DefinitionLevels() []byte          { return nil }
 func (page *errorPage) Data() encoding.Values             { return encoding.Values{} }
 func (page *errorPage) Values() ValueReader               { return errorPageValues{page: page} }
-func (page *errorPage) Buffer() BufferedPage              { return page }
 
 type errorPageValues struct{ page *errorPage }
 
@@ -275,12 +374,12 @@ func errPageBoundsOutOfRange(i, j, n int64) error {
 }
 
 type optionalPage struct {
-	base               BufferedPage
+	base               Page
 	maxDefinitionLevel byte
-	definitionLevels   []byte
+	definitionLevels   bufferRef
 }
 
-func newOptionalPage(base BufferedPage, maxDefinitionLevel byte, definitionLevels []byte) *optionalPage {
+func newOptionalPage(base Page, maxDefinitionLevel byte, definitionLevels bufferRef) *optionalPage {
 	return &optionalPage{
 		base:               base,
 		maxDefinitionLevel: maxDefinitionLevel,
@@ -294,21 +393,21 @@ func (page *optionalPage) Column() int { return page.base.Column() }
 
 func (page *optionalPage) Dictionary() Dictionary { return page.base.Dictionary() }
 
-func (page *optionalPage) NumRows() int64 { return int64(len(page.definitionLevels)) }
+func (page *optionalPage) NumRows() int64 { return int64(page.definitionLevels.len) }
 
-func (page *optionalPage) NumValues() int64 { return int64(len(page.definitionLevels)) }
+func (page *optionalPage) NumValues() int64 { return int64(page.definitionLevels.len) }
 
 func (page *optionalPage) NumNulls() int64 {
-	return int64(countLevelsNotEqual(page.definitionLevels, page.maxDefinitionLevel))
+	return int64(countLevelsNotEqual(page.definitionLevels.data(), page.maxDefinitionLevel))
 }
 
 func (page *optionalPage) Bounds() (min, max Value, ok bool) { return page.base.Bounds() }
 
-func (page *optionalPage) Size() int64 { return page.base.Size() + int64(len(page.definitionLevels)) }
+func (page *optionalPage) Size() int64 { return page.base.Size() + int64(page.definitionLevels.len) }
 
 func (page *optionalPage) RepetitionLevels() []byte { return nil }
 
-func (page *optionalPage) DefinitionLevels() []byte { return page.definitionLevels }
+func (page *optionalPage) DefinitionLevels() []byte { return page.definitionLevels.data() }
 
 func (page *optionalPage) Data() encoding.Values { return page.base.Data() }
 
@@ -319,35 +418,34 @@ func (page *optionalPage) Values() ValueReader {
 	}
 }
 
-func (page *optionalPage) Buffer() BufferedPage { return page }
-
-func (page *optionalPage) Clone() BufferedPage {
+func (page *optionalPage) Clone() Page {
 	return newOptionalPage(
 		page.base.Clone(),
 		page.maxDefinitionLevel,
-		append([]byte{}, page.definitionLevels...),
+		page.definitionLevels.clone(),
 	)
 }
 
-func (page *optionalPage) Slice(i, j int64) BufferedPage {
-	numNulls1 := int64(countLevelsNotEqual(page.definitionLevels[:i], page.maxDefinitionLevel))
-	numNulls2 := int64(countLevelsNotEqual(page.definitionLevels[i:j], page.maxDefinitionLevel))
+func (page *optionalPage) Slice(i, j int64) Page {
+	definitionLevels := page.definitionLevels.data()
+	numNulls1 := int64(countLevelsNotEqual(definitionLevels[:i], page.maxDefinitionLevel))
+	numNulls2 := int64(countLevelsNotEqual(definitionLevels[i:j], page.maxDefinitionLevel))
 	return newOptionalPage(
 		page.base.Slice(i-numNulls1, j-(numNulls1+numNulls2)),
 		page.maxDefinitionLevel,
-		page.definitionLevels[i:j],
+		page.definitionLevels.slice(int(i), int(j)),
 	)
 }
 
 type repeatedPage struct {
-	base               BufferedPage
+	base               Page
 	maxRepetitionLevel byte
 	maxDefinitionLevel byte
-	definitionLevels   []byte
-	repetitionLevels   []byte
+	definitionLevels   bufferRef
+	repetitionLevels   bufferRef
 }
 
-func newRepeatedPage(base BufferedPage, maxRepetitionLevel, maxDefinitionLevel byte, repetitionLevels, definitionLevels []byte) *repeatedPage {
+func newRepeatedPage(base Page, maxRepetitionLevel, maxDefinitionLevel byte, repetitionLevels, definitionLevels bufferRef) *repeatedPage {
 	return &repeatedPage{
 		base:               base,
 		maxRepetitionLevel: maxRepetitionLevel,
@@ -363,23 +461,27 @@ func (page *repeatedPage) Column() int { return page.base.Column() }
 
 func (page *repeatedPage) Dictionary() Dictionary { return page.base.Dictionary() }
 
-func (page *repeatedPage) NumRows() int64 { return int64(countLevelsEqual(page.repetitionLevels, 0)) }
+func (page *repeatedPage) NumRows() int64 {
+	return int64(countLevelsEqual(page.repetitionLevels.data(), 0))
+}
 
-func (page *repeatedPage) NumValues() int64 { return int64(len(page.definitionLevels)) }
+func (page *repeatedPage) NumValues() int64 {
+	return int64(page.definitionLevels.len)
+}
 
 func (page *repeatedPage) NumNulls() int64 {
-	return int64(countLevelsNotEqual(page.definitionLevels, page.maxDefinitionLevel))
+	return int64(countLevelsNotEqual(page.definitionLevels.data(), page.maxDefinitionLevel))
 }
 
 func (page *repeatedPage) Bounds() (min, max Value, ok bool) { return page.base.Bounds() }
 
 func (page *repeatedPage) Size() int64 {
-	return int64(len(page.repetitionLevels)) + int64(len(page.definitionLevels)) + page.base.Size()
+	return int64(page.repetitionLevels.len) + int64(page.definitionLevels.len) + page.base.Size()
 }
 
-func (page *repeatedPage) RepetitionLevels() []byte { return page.repetitionLevels }
+func (page *repeatedPage) RepetitionLevels() []byte { return page.repetitionLevels.data() }
 
-func (page *repeatedPage) DefinitionLevels() []byte { return page.definitionLevels }
+func (page *repeatedPage) DefinitionLevels() []byte { return page.definitionLevels.data() }
 
 func (page *repeatedPage) Data() encoding.Values { return page.base.Data() }
 
@@ -390,19 +492,17 @@ func (page *repeatedPage) Values() ValueReader {
 	}
 }
 
-func (page *repeatedPage) Buffer() BufferedPage { return page }
-
-func (page *repeatedPage) Clone() BufferedPage {
+func (page *repeatedPage) Clone() Page {
 	return newRepeatedPage(
 		page.base.Clone(),
 		page.maxRepetitionLevel,
 		page.maxDefinitionLevel,
-		append([]byte{}, page.repetitionLevels...),
-		append([]byte{}, page.definitionLevels...),
+		page.repetitionLevels.clone(),
+		page.definitionLevels.clone(),
 	)
 }
 
-func (page *repeatedPage) Slice(i, j int64) BufferedPage {
+func (page *repeatedPage) Slice(i, j int64) Page {
 	numRows := page.NumRows()
 	if i < 0 || i > numRows {
 		panic(errPageBoundsOutOfRange(i, j, numRows))
@@ -414,11 +514,12 @@ func (page *repeatedPage) Slice(i, j int64) BufferedPage {
 		panic(errPageBoundsOutOfRange(i, j, numRows))
 	}
 
+	repetitionLevels := page.repetitionLevels.data()
 	rowIndex0 := 0
-	rowIndex1 := len(page.repetitionLevels)
-	rowIndex2 := len(page.repetitionLevels)
+	rowIndex1 := len(repetitionLevels)
+	rowIndex2 := len(repetitionLevels)
 
-	for k, def := range page.repetitionLevels {
+	for k, def := range repetitionLevels {
 		if def == 0 {
 			if rowIndex0 == int(i) {
 				rowIndex1 = k
@@ -428,7 +529,7 @@ func (page *repeatedPage) Slice(i, j int64) BufferedPage {
 		}
 	}
 
-	for k, def := range page.repetitionLevels[rowIndex1:] {
+	for k, def := range repetitionLevels[rowIndex1:] {
 		if def == 0 {
 			if rowIndex0 == int(j) {
 				rowIndex2 = rowIndex1 + k
@@ -438,8 +539,9 @@ func (page *repeatedPage) Slice(i, j int64) BufferedPage {
 		}
 	}
 
-	numNulls1 := countLevelsNotEqual(page.definitionLevels[:rowIndex1], page.maxDefinitionLevel)
-	numNulls2 := countLevelsNotEqual(page.definitionLevels[rowIndex1:rowIndex2], page.maxDefinitionLevel)
+	definitionLevels := page.definitionLevels.data()
+	numNulls1 := countLevelsNotEqual(definitionLevels[:rowIndex1], page.maxDefinitionLevel)
+	numNulls2 := countLevelsNotEqual(definitionLevels[rowIndex1:rowIndex2], page.maxDefinitionLevel)
 
 	i = int64(rowIndex1 - numNulls1)
 	j = int64(rowIndex2 - (numNulls1 + numNulls2))
@@ -448,8 +550,8 @@ func (page *repeatedPage) Slice(i, j int64) BufferedPage {
 		page.base.Slice(i, j),
 		page.maxRepetitionLevel,
 		page.maxDefinitionLevel,
-		page.repetitionLevels[rowIndex1:rowIndex2],
-		page.definitionLevels[rowIndex1:rowIndex2],
+		page.repetitionLevels.slice(int(rowIndex1), int(rowIndex2)),
+		page.definitionLevels.slice(int(rowIndex1), int(rowIndex2)),
 	)
 }
 
@@ -491,8 +593,6 @@ func (page *booleanPage) DefinitionLevels() []byte { return nil }
 func (page *booleanPage) Data() encoding.Values { return encoding.BooleanValues(page.bits) }
 
 func (page *booleanPage) Values() ValueReader { return &booleanPageValues{page: page} }
-
-func (page *booleanPage) Buffer() BufferedPage { return page }
 
 func (page *booleanPage) valueAt(i int) bool {
 	j := uint32(int(page.offset)+i) / 8
@@ -547,7 +647,7 @@ func (page *booleanPage) Bounds() (min, max Value, ok bool) {
 	return min, max, ok
 }
 
-func (page *booleanPage) Clone() BufferedPage {
+func (page *booleanPage) Clone() Page {
 	return &booleanPage{
 		typ:         page.typ,
 		bits:        append([]byte{}, page.bits...),
@@ -557,7 +657,7 @@ func (page *booleanPage) Clone() BufferedPage {
 	}
 }
 
-func (page *booleanPage) Slice(i, j int64) BufferedPage {
+func (page *booleanPage) Slice(i, j int64) Page {
 	off := i / 8
 	end := j / 8
 
@@ -616,8 +716,6 @@ func (page *int32Page) Data() encoding.Values { return encoding.Int32Values(page
 
 func (page *int32Page) Values() ValueReader { return &int32PageValues{page: page} }
 
-func (page *int32Page) Buffer() BufferedPage { return page }
-
 func (page *int32Page) min() int32 { return minInt32(page.values) }
 
 func (page *int32Page) max() int32 { return maxInt32(page.values) }
@@ -633,7 +731,7 @@ func (page *int32Page) Bounds() (min, max Value, ok bool) {
 	return min, max, ok
 }
 
-func (page *int32Page) Clone() BufferedPage {
+func (page *int32Page) Clone() Page {
 	return &int32Page{
 		typ:         page.typ,
 		values:      append([]int32{}, page.values...),
@@ -641,7 +739,7 @@ func (page *int32Page) Clone() BufferedPage {
 	}
 }
 
-func (page *int32Page) Slice(i, j int64) BufferedPage {
+func (page *int32Page) Slice(i, j int64) Page {
 	return &int32Page{
 		typ:         page.typ,
 		values:      page.values[i:j],
@@ -691,8 +789,6 @@ func (page *int64Page) Data() encoding.Values { return encoding.Int64Values(page
 
 func (page *int64Page) Values() ValueReader { return &int64PageValues{page: page} }
 
-func (page *int64Page) Buffer() BufferedPage { return page }
-
 func (page *int64Page) min() int64 { return minInt64(page.values) }
 
 func (page *int64Page) max() int64 { return maxInt64(page.values) }
@@ -708,7 +804,7 @@ func (page *int64Page) Bounds() (min, max Value, ok bool) {
 	return min, max, ok
 }
 
-func (page *int64Page) Clone() BufferedPage {
+func (page *int64Page) Clone() Page {
 	return &int64Page{
 		typ:         page.typ,
 		values:      append([]int64{}, page.values...),
@@ -716,7 +812,7 @@ func (page *int64Page) Clone() BufferedPage {
 	}
 }
 
-func (page *int64Page) Slice(i, j int64) BufferedPage {
+func (page *int64Page) Slice(i, j int64) Page {
 	return &int64Page{
 		typ:         page.typ,
 		values:      page.values[i:j],
@@ -766,8 +862,6 @@ func (page *int96Page) Data() encoding.Values { return encoding.Int96Values(page
 
 func (page *int96Page) Values() ValueReader { return &int96PageValues{page: page} }
 
-func (page *int96Page) Buffer() BufferedPage { return page }
-
 func (page *int96Page) min() deprecated.Int96 { return deprecated.MinInt96(page.values) }
 
 func (page *int96Page) max() deprecated.Int96 { return deprecated.MaxInt96(page.values) }
@@ -785,7 +879,7 @@ func (page *int96Page) Bounds() (min, max Value, ok bool) {
 	return min, max, ok
 }
 
-func (page *int96Page) Clone() BufferedPage {
+func (page *int96Page) Clone() Page {
 	return &int96Page{
 		typ:         page.typ,
 		values:      append([]deprecated.Int96{}, page.values...),
@@ -793,7 +887,7 @@ func (page *int96Page) Clone() BufferedPage {
 	}
 }
 
-func (page *int96Page) Slice(i, j int64) BufferedPage {
+func (page *int96Page) Slice(i, j int64) Page {
 	return &int96Page{
 		typ:         page.typ,
 		values:      page.values[i:j],
@@ -843,8 +937,6 @@ func (page *floatPage) Data() encoding.Values { return encoding.FloatValues(page
 
 func (page *floatPage) Values() ValueReader { return &floatPageValues{page: page} }
 
-func (page *floatPage) Buffer() BufferedPage { return page }
-
 func (page *floatPage) min() float32 { return minFloat32(page.values) }
 
 func (page *floatPage) max() float32 { return maxFloat32(page.values) }
@@ -860,7 +952,7 @@ func (page *floatPage) Bounds() (min, max Value, ok bool) {
 	return min, max, ok
 }
 
-func (page *floatPage) Clone() BufferedPage {
+func (page *floatPage) Clone() Page {
 	return &floatPage{
 		typ:         page.typ,
 		values:      append([]float32{}, page.values...),
@@ -868,7 +960,7 @@ func (page *floatPage) Clone() BufferedPage {
 	}
 }
 
-func (page *floatPage) Slice(i, j int64) BufferedPage {
+func (page *floatPage) Slice(i, j int64) Page {
 	return &floatPage{
 		typ:         page.typ,
 		values:      page.values[i:j],
@@ -918,8 +1010,6 @@ func (page *doublePage) Data() encoding.Values { return encoding.DoubleValues(pa
 
 func (page *doublePage) Values() ValueReader { return &doublePageValues{page: page} }
 
-func (page *doublePage) Buffer() BufferedPage { return page }
-
 func (page *doublePage) min() float64 { return minFloat64(page.values) }
 
 func (page *doublePage) max() float64 { return maxFloat64(page.values) }
@@ -935,7 +1025,7 @@ func (page *doublePage) Bounds() (min, max Value, ok bool) {
 	return min, max, ok
 }
 
-func (page *doublePage) Clone() BufferedPage {
+func (page *doublePage) Clone() Page {
 	return &doublePage{
 		typ:         page.typ,
 		values:      append([]float64{}, page.values...),
@@ -943,7 +1033,7 @@ func (page *doublePage) Clone() BufferedPage {
 	}
 }
 
-func (page *doublePage) Slice(i, j int64) BufferedPage {
+func (page *doublePage) Slice(i, j int64) Page {
 	return &doublePage{
 		typ:         page.typ,
 		values:      page.values[i:j],
@@ -997,8 +1087,6 @@ func (page *byteArrayPage) Data() encoding.Values {
 }
 
 func (page *byteArrayPage) Values() ValueReader { return &byteArrayPageValues{page: page} }
-
-func (page *byteArrayPage) Buffer() BufferedPage { return page }
 
 func (page *byteArrayPage) len() int { return len(page.offsets) - 1 }
 
@@ -1078,7 +1166,7 @@ func (page *byteArrayPage) cloneOffsets() []uint32 {
 	return offsets
 }
 
-func (page *byteArrayPage) Clone() BufferedPage {
+func (page *byteArrayPage) Clone() Page {
 	return &byteArrayPage{
 		typ:         page.typ,
 		values:      page.cloneValues(),
@@ -1087,7 +1175,7 @@ func (page *byteArrayPage) Clone() BufferedPage {
 	}
 }
 
-func (page *byteArrayPage) Slice(i, j int64) BufferedPage {
+func (page *byteArrayPage) Slice(i, j int64) Page {
 	return &byteArrayPage{
 		typ:         page.typ,
 		values:      page.values,
@@ -1151,8 +1239,6 @@ func (page *fixedLenByteArrayPage) Values() ValueReader {
 	return &fixedLenByteArrayPageValues{page: page}
 }
 
-func (page *fixedLenByteArrayPage) Buffer() BufferedPage { return page }
-
 func (page *fixedLenByteArrayPage) min() []byte { return minFixedLenByteArray(page.data, page.size) }
 
 func (page *fixedLenByteArrayPage) max() []byte { return maxFixedLenByteArray(page.data, page.size) }
@@ -1170,7 +1256,7 @@ func (page *fixedLenByteArrayPage) Bounds() (min, max Value, ok bool) {
 	return min, max, ok
 }
 
-func (page *fixedLenByteArrayPage) Clone() BufferedPage {
+func (page *fixedLenByteArrayPage) Clone() Page {
 	return &fixedLenByteArrayPage{
 		typ:         page.typ,
 		data:        append([]byte{}, page.data...),
@@ -1179,7 +1265,7 @@ func (page *fixedLenByteArrayPage) Clone() BufferedPage {
 	}
 }
 
-func (page *fixedLenByteArrayPage) Slice(i, j int64) BufferedPage {
+func (page *fixedLenByteArrayPage) Slice(i, j int64) Page {
 	return &fixedLenByteArrayPage{
 		typ:         page.typ,
 		data:        page.data[i*int64(page.size) : j*int64(page.size)],
@@ -1236,8 +1322,6 @@ func (page *uint32Page) Data() encoding.Values { return encoding.Uint32Values(pa
 
 func (page *uint32Page) Values() ValueReader { return &uint32PageValues{page: page} }
 
-func (page *uint32Page) Buffer() BufferedPage { return page }
-
 func (page *uint32Page) min() uint32 { return minUint32(page.values) }
 
 func (page *uint32Page) max() uint32 { return maxUint32(page.values) }
@@ -1253,7 +1337,7 @@ func (page *uint32Page) Bounds() (min, max Value, ok bool) {
 	return min, max, ok
 }
 
-func (page *uint32Page) Clone() BufferedPage {
+func (page *uint32Page) Clone() Page {
 	return &uint32Page{
 		typ:         page.typ,
 		values:      append([]uint32{}, page.values...),
@@ -1261,7 +1345,7 @@ func (page *uint32Page) Clone() BufferedPage {
 	}
 }
 
-func (page *uint32Page) Slice(i, j int64) BufferedPage {
+func (page *uint32Page) Slice(i, j int64) Page {
 	return &uint32Page{
 		typ:         page.typ,
 		values:      page.values[i:j],
@@ -1311,8 +1395,6 @@ func (page *uint64Page) Data() encoding.Values { return encoding.Uint64Values(pa
 
 func (page *uint64Page) Values() ValueReader { return &uint64PageValues{page: page} }
 
-func (page *uint64Page) Buffer() BufferedPage { return page }
-
 func (page *uint64Page) min() uint64 { return minUint64(page.values) }
 
 func (page *uint64Page) max() uint64 { return maxUint64(page.values) }
@@ -1328,7 +1410,7 @@ func (page *uint64Page) Bounds() (min, max Value, ok bool) {
 	return min, max, ok
 }
 
-func (page *uint64Page) Clone() BufferedPage {
+func (page *uint64Page) Clone() Page {
 	return &uint64Page{
 		typ:         page.typ,
 		values:      append([]uint64{}, page.values...),
@@ -1336,7 +1418,7 @@ func (page *uint64Page) Clone() BufferedPage {
 	}
 }
 
-func (page *uint64Page) Slice(i, j int64) BufferedPage {
+func (page *uint64Page) Slice(i, j int64) Page {
 	return &uint64Page{
 		typ:         page.typ,
 		values:      page.values[i:j],
@@ -1386,8 +1468,6 @@ func (page *be128Page) Data() encoding.Values { return encoding.Uint128Values(pa
 
 func (page *be128Page) Values() ValueReader { return &be128PageValues{page: page} }
 
-func (page *be128Page) Buffer() BufferedPage { return page }
-
 func (page *be128Page) min() []byte { return minBE128(page.values) }
 
 func (page *be128Page) max() []byte { return maxBE128(page.values) }
@@ -1403,7 +1483,7 @@ func (page *be128Page) Bounds() (min, max Value, ok bool) {
 	return min, max, ok
 }
 
-func (page *be128Page) Clone() BufferedPage {
+func (page *be128Page) Clone() Page {
 	return &be128Page{
 		typ:         page.typ,
 		values:      append([][16]byte{}, page.values...),
@@ -1411,7 +1491,7 @@ func (page *be128Page) Clone() BufferedPage {
 	}
 }
 
-func (page *be128Page) Slice(i, j int64) BufferedPage {
+func (page *be128Page) Slice(i, j int64) Page {
 	return &be128Page{
 		typ:         page.typ,
 		values:      page.values[i:j],
@@ -1460,9 +1540,8 @@ func (page *nullPage) Size() int64                       { return 1 }
 func (page *nullPage) Values() ValueReader {
 	return &nullPageValues{column: page.column, remain: page.count}
 }
-func (page *nullPage) Buffer() BufferedPage { return page }
-func (page *nullPage) Clone() BufferedPage  { return page }
-func (page *nullPage) Slice(i, j int64) BufferedPage {
+func (page *nullPage) Clone() Page { return page }
+func (page *nullPage) Slice(i, j int64) Page {
 	return &nullPage{column: page.column, count: page.count - int(j-i)}
 }
 func (page *nullPage) RepetitionLevels() []byte { return nil }

--- a/vendor/github.com/segmentio/parquet-go/page_bounds_amd64.go
+++ b/vendor/github.com/segmentio/parquet-go/page_bounds_amd64.go
@@ -23,7 +23,6 @@ package parquet
 // running more AVX-512 instructions in the tight loops causes more contention
 // on CPU ports.
 //
-//
 // Optimizations being trade offs, using min/max functions independently appears
 // to yield better throughput when the data resides in CPU caches:
 //

--- a/vendor/github.com/segmentio/parquet-go/page_values.go
+++ b/vendor/github.com/segmentio/parquet-go/page_values.go
@@ -16,12 +16,13 @@ type optionalPageValues struct {
 
 func (r *optionalPageValues) ReadValues(values []Value) (n int, err error) {
 	maxDefinitionLevel := r.page.maxDefinitionLevel
+	definitionLevels := r.page.definitionLevels.data()
 	columnIndex := ^int16(r.page.Column())
 
-	for n < len(values) && r.offset < len(r.page.definitionLevels) {
-		for n < len(values) && r.offset < len(r.page.definitionLevels) && r.page.definitionLevels[r.offset] != maxDefinitionLevel {
+	for n < len(values) && r.offset < len(definitionLevels) {
+		for n < len(values) && r.offset < len(definitionLevels) && definitionLevels[r.offset] != maxDefinitionLevel {
 			values[n] = Value{
-				definitionLevel: r.page.definitionLevels[r.offset],
+				definitionLevel: definitionLevels[r.offset],
 				columnIndex:     columnIndex,
 			}
 			r.offset++
@@ -30,7 +31,7 @@ func (r *optionalPageValues) ReadValues(values []Value) (n int, err error) {
 
 		i := n
 		j := r.offset
-		for i < len(values) && j < len(r.page.definitionLevels) && r.page.definitionLevels[j] == maxDefinitionLevel {
+		for i < len(values) && j < len(definitionLevels) && definitionLevels[j] == maxDefinitionLevel {
 			i++
 			j++
 		}
@@ -49,7 +50,7 @@ func (r *optionalPageValues) ReadValues(values []Value) (n int, err error) {
 		}
 	}
 
-	if r.offset == len(r.page.definitionLevels) {
+	if r.offset == len(definitionLevels) {
 		err = io.EOF
 	}
 	return n, err
@@ -63,13 +64,15 @@ type repeatedPageValues struct {
 
 func (r *repeatedPageValues) ReadValues(values []Value) (n int, err error) {
 	maxDefinitionLevel := r.page.maxDefinitionLevel
+	definitionLevels := r.page.definitionLevels.data()
+	repetitionLevels := r.page.repetitionLevels.data()
 	columnIndex := ^int16(r.page.Column())
 
-	for n < len(values) && r.offset < len(r.page.definitionLevels) {
-		for n < len(values) && r.offset < len(r.page.definitionLevels) && r.page.definitionLevels[r.offset] != maxDefinitionLevel {
+	for n < len(values) && r.offset < len(definitionLevels) {
+		for n < len(values) && r.offset < len(definitionLevels) && definitionLevels[r.offset] != maxDefinitionLevel {
 			values[n] = Value{
-				repetitionLevel: r.page.repetitionLevels[r.offset],
-				definitionLevel: r.page.definitionLevels[r.offset],
+				repetitionLevel: repetitionLevels[r.offset],
+				definitionLevel: definitionLevels[r.offset],
 				columnIndex:     columnIndex,
 			}
 			r.offset++
@@ -78,14 +81,14 @@ func (r *repeatedPageValues) ReadValues(values []Value) (n int, err error) {
 
 		i := n
 		j := r.offset
-		for i < len(values) && j < len(r.page.definitionLevels) && r.page.definitionLevels[j] == maxDefinitionLevel {
+		for i < len(values) && j < len(definitionLevels) && definitionLevels[j] == maxDefinitionLevel {
 			i++
 			j++
 		}
 
 		if n < i {
 			for j, err = r.values.ReadValues(values[n:i]); j > 0; j-- {
-				values[n].repetitionLevel = r.page.repetitionLevels[r.offset]
+				values[n].repetitionLevel = repetitionLevels[r.offset]
 				values[n].definitionLevel = maxDefinitionLevel
 				r.offset++
 				n++
@@ -97,7 +100,7 @@ func (r *repeatedPageValues) ReadValues(values []Value) (n int, err error) {
 		}
 	}
 
-	if r.offset == len(r.page.definitionLevels) {
+	if r.offset == len(definitionLevels) {
 		err = io.EOF
 	}
 	return n, err

--- a/vendor/github.com/segmentio/parquet-go/reader.go
+++ b/vendor/github.com/segmentio/parquet-go/reader.go
@@ -28,7 +28,6 @@ import (
 //		...
 //	}
 //
-//
 // For programs building with Go 1.18 or later, the GenericReader[T] type
 // supersedes this one.
 type Reader struct {
@@ -61,7 +60,6 @@ type Reader struct {
 //		reader := parquet.NewReader(input, config)
 //		...
 //	}
-//
 func NewReader(input io.ReaderAt, options ...ReaderOption) *Reader {
 	c, err := NewReaderConfig(options...)
 	if err != nil {

--- a/vendor/github.com/segmentio/parquet-go/row_group.go
+++ b/vendor/github.com/segmentio/parquet-go/row_group.go
@@ -3,6 +3,7 @@ package parquet
 import (
 	"fmt"
 	"io"
+	"runtime"
 )
 
 // RowGroup is an interface representing a parquet row group. From the Parquet
@@ -255,21 +256,33 @@ type rowGroupRows struct {
 	seek     int64
 	inited   bool
 	closed   bool
+	done     chan<- struct{}
 }
 
 func (r *rowGroupRows) init() {
 	const columnBufferSize = defaultValueBufferSize
 	columns := r.rowGroup.ColumnChunks()
+	readers := make([]asyncPages, len(columns))
 	buffer := make([]Value, columnBufferSize*len(columns))
 	r.columns = make([]columnChunkReader, len(columns))
 
+	done := make(chan struct{})
+	r.done = done
+
 	for i, column := range columns {
+		reader := &readers[i]
+		reader.init(column.Pages(), done)
+
 		r.columns[i].buffer = buffer[:0:columnBufferSize]
-		r.columns[i].reader = column.Pages()
+		r.columns[i].reader = reader
 		buffer = buffer[columnBufferSize:]
 	}
 
 	r.inited = true
+	// This finalizer is used to ensure that the goroutines started by calling
+	// init on the underlying page readers will be shutdown in the event that
+	// Close isn't called and the rowGroupRows object is garbage collected.
+	runtime.SetFinalizer(r, func(r *rowGroupRows) { r.Close() })
 }
 
 func (r *rowGroupRows) Reset() {
@@ -284,6 +297,11 @@ func (r *rowGroupRows) Reset() {
 
 func (r *rowGroupRows) Close() error {
 	var lastErr error
+
+	if r.done != nil {
+		close(r.done)
+		r.done = nil
+	}
 
 	for i := range r.columns {
 		if err := r.columns[i].close(); err != nil {

--- a/vendor/github.com/segmentio/parquet-go/schema.go
+++ b/vendor/github.com/segmentio/parquet-go/schema.go
@@ -59,14 +59,14 @@ type Schema struct {
 //	timestamp | for int64 types use the TIMESTAMP logical type with, by default, millisecond precision
 //	split     | for float32/float64, use the BYTE_STREAM_SPLIT encoding
 //
-// The date logical type is an int32 value of the number of days since the unix epoch
+// # The date logical type is an int32 value of the number of days since the unix epoch
 //
 // The timestamp precision can be changed by defining which precision to use as an argument.
 // Supported precisions are: nanosecond, millisecond and microsecond. Example:
 //
-//  type Message struct {
-//    TimestrampMicros int64 `parquet:"timestamp_micros,timestamp(microsecond)"
-//  }
+//	type Message struct {
+//	  TimestrampMicros int64 `parquet:"timestamp_micros,timestamp(microsecond)"
+//	}
 //
 // The decimal tag must be followed by two integer parameters, the first integer
 // representing the scale and the second the precision; for example:
@@ -90,9 +90,9 @@ type Schema struct {
 //
 // For example, the following will set the int64 key of the map to be a timestamp:
 //
-//  type Actions struct {
-//    Action map[int64]string `parquet:"," parquet-key:",timestamp"`
-//  }
+//	type Actions struct {
+//	  Action map[int64]string `parquet:"," parquet-key:",timestamp"`
+//	}
 //
 // The schema name is the Go type name of the value.
 func SchemaOf(model interface{}) *Schema {

--- a/vendor/github.com/segmentio/parquet-go/search.go
+++ b/vendor/github.com/segmentio/parquet-go/search.go
@@ -56,7 +56,6 @@ func Search(index ColumnIndex, value Value, typ Type) int {
 //	pageIndex := parquet.Find(columnIndex, value,
 //		parquet.CompareNullsFirst(typ.Compare),
 //	)
-//
 func Find(index ColumnIndex, value Value, cmp func(Value, Value) int) int {
 	switch {
 	case index.IsAscending():

--- a/vendor/github.com/segmentio/parquet-go/sort.go
+++ b/vendor/github.com/segmentio/parquet-go/sort.go
@@ -10,7 +10,6 @@ package parquet
 //		Descending: true,
 //		NullsFirst: true,
 //	})
-//
 type SortConfig struct {
 	MaxRepetitionLevel int
 	MaxDefinitionLevel int

--- a/vendor/github.com/segmentio/parquet-go/value.go
+++ b/vendor/github.com/segmentio/parquet-go/value.go
@@ -447,19 +447,19 @@ func (v Value) AppendBytes(b []byte) []byte {
 //
 // The following formatting options are supported:
 //
-//		%c	prints the column index
-//		%+c	prints the column index, prefixed with "C:"
-//		%d	prints the definition level
-//		%+d	prints the definition level, prefixed with "D:"
-//		%r	prints the repetition level
-//		%+r	prints the repetition level, prefixed with "R:"
-//		%q	prints the quoted representation of v
-//		%+q	prints the quoted representation of v, prefixed with "V:"
-//		%s	prints the string representation of v
-//		%+s	prints the string representation of v, prefixed with "V:"
-//		%v	same as %s
-//		%+v	prints a verbose representation of v
-//		%#v	prints a Go value representation of v
+//	%c	prints the column index
+//	%+c	prints the column index, prefixed with "C:"
+//	%d	prints the definition level
+//	%+d	prints the definition level, prefixed with "D:"
+//	%r	prints the repetition level
+//	%+r	prints the repetition level, prefixed with "R:"
+//	%q	prints the quoted representation of v
+//	%+q	prints the quoted representation of v, prefixed with "V:"
+//	%s	prints the string representation of v
+//	%+s	prints the string representation of v, prefixed with "V:"
+//	%v	same as %s
+//	%+v	prints a verbose representation of v
+//	%#v	prints a Go value representation of v
 //
 // Format satisfies the fmt.Formatter interface.
 func (v Value) Format(w fmt.State, r rune) {

--- a/vendor/github.com/segmentio/parquet-go/writer_go18.go
+++ b/vendor/github.com/segmentio/parquet-go/writer_go18.go
@@ -12,29 +12,29 @@ import (
 //
 // Using this type over Writer has multiple advantages:
 //
-// - By leveraging type information, the Go compiler can provide greater
-//   guarantees that the code is correct. For example, the parquet.Writer.Write
-//   method accepts an argument of type interface{}, which delays type checking
-//   until runtime. The parquet.GenericWriter[T].Write method ensures at
-//   compile time that the values it receives will be of type T, reducing the
-//   risk of introducing errors.
+//   - By leveraging type information, the Go compiler can provide greater
+//     guarantees that the code is correct. For example, the parquet.Writer.Write
+//     method accepts an argument of type interface{}, which delays type checking
+//     until runtime. The parquet.GenericWriter[T].Write method ensures at
+//     compile time that the values it receives will be of type T, reducing the
+//     risk of introducing errors.
 //
-// - Since type information is known at compile time, the implementation of
-//   parquet.GenericWriter[T] can make safe assumptions, removing the need for
-//   runtime validation of how the parameters are passed to its methods.
-//   Optimizations relying on type information are more effective, some of the
-//   writer's state can be precomputed at initialization, which was not possible
-//   with parquet.Writer.
+//   - Since type information is known at compile time, the implementation of
+//     parquet.GenericWriter[T] can make safe assumptions, removing the need for
+//     runtime validation of how the parameters are passed to its methods.
+//     Optimizations relying on type information are more effective, some of the
+//     writer's state can be precomputed at initialization, which was not possible
+//     with parquet.Writer.
 //
-// - The parquet.GenericWriter[T].Write method uses a data-oriented design,
-//   accepting an slice of T instead of a single value, creating more
-//   opportunities to amortize the runtime cost of abstractions.
-//   This optimization is not available for parquet.Writer because its Write
-//   method's argument would be of type []interface{}, which would require
-//   conversions back and forth from concrete types to empty interfaces (since
-//   a []T cannot be interpreted as []interface{} in Go), would make the API
-//   more difficult to use and waste compute resources in the type conversions,
-//   defeating the purpose of the optimization in the first place.
+//   - The parquet.GenericWriter[T].Write method uses a data-oriented design,
+//     accepting an slice of T instead of a single value, creating more
+//     opportunities to amortize the runtime cost of abstractions.
+//     This optimization is not available for parquet.Writer because its Write
+//     method's argument would be of type []interface{}, which would require
+//     conversions back and forth from concrete types to empty interfaces (since
+//     a []T cannot be interpreted as []interface{} in Go), would make the API
+//     more difficult to use and waste compute resources in the type conversions,
+//     defeating the purpose of the optimization in the first place.
 //
 // Note that this type is only available when compiling with Go 1.18 or later.
 type GenericWriter[T any] struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -848,8 +848,8 @@ github.com/segmentio/encoding/thrift
 # github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e
 ## explicit
 github.com/segmentio/fasthash/fnv1a
-# github.com/segmentio/parquet-go v0.0.0-20220802221544-d84ed320251d
-## explicit; go 1.18
+# github.com/segmentio/parquet-go v0.0.0-20220811205829-7efc157d28af
+## explicit; go 1.19
 github.com/segmentio/parquet-go
 github.com/segmentio/parquet-go/bloom
 github.com/segmentio/parquet-go/bloom/xxhash


### PR DESCRIPTION
**What this PR does**:

Updates our parquet dependency to the latest to catch some buffering and performance improvements. Impact:

- Elevated compactor CPU and throughput
- Possible fix for #1592.
  - Unable to repro using tempo-search docker-compose. Previously was able to reproduce it almost immediately.
- Querier slice OOB panic no longer seen
- Slow compactor memory leak no longer seen

After ~24hours of testing with the single binary we are not seeing this anymore. However, we are seeing this rarely in compactors now.