### PR TITLE
Remove usage reporting's depedency on store

### DIFF
--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -391,7 +391,7 @@ func (t *App) setupModuleManager() error {
 		Compactor:            {Store, Server, Overrides, MemberlistKV, UsageReport},
 		SingleBinary:         {Compactor, QueryFrontend, Querier, Ingester, Distributor},
 		ScalableSingleBinary: {SingleBinary},
-		UsageReport:          {MemberlistKV, Store},
+		UsageReport:          {MemberlistKV},
 	}
 
 	if t.cfg.MetricsGeneratorEnabled {

--- a/pkg/usagestats/reporter.go
+++ b/pkg/usagestats/reporter.go
@@ -31,7 +31,7 @@ const (
 
 var (
 	reportCheckInterval = time.Minute
-	reportInterval      = 5 * time.Minute
+	reportInterval      = 4 * time.Hour
 
 	stabilityCheckInterval   = 5 * time.Second
 	stabilityMinimunRequired = 6

--- a/pkg/usagestats/reporter.go
+++ b/pkg/usagestats/reporter.go
@@ -31,7 +31,7 @@ const (
 
 var (
 	reportCheckInterval = time.Minute
-	reportInterval      = 4 * time.Hour
+	reportInterval      = 5 * time.Minute
 
 	stabilityCheckInterval   = 5 * time.Second
 	stabilityMinimunRequired = 6


### PR DESCRIPTION
**What this PR does**:

Removes the dependency on the store for usage reporting. This dependency is not necessary and was causing the process to access the disk as noticed here: #1648

Thanks to @rlex for highlighting the change in v1.5.0 rc.2