### PR TITLE
Fix local backend filesystem permissions on OpenShift

### DIFF
--- a/cmd/tempo/Dockerfile
+++ b/cmd/tempo/Dockerfile
@@ -1,5 +1,12 @@
-FROM alpine:3.16 as certs
+FROM alpine:3.15 as certs
 RUN apk --update add ca-certificates
 ARG TARGETARCH
 COPY bin/linux/tempo-${TARGETARCH} /tempo
+
+# /var/tempo is a default directory used by Tempo components.
+# At runtime the Tempo process creates this dectory and it needs write access to it.
+# On OpenShift the tempo user is not root (but in root group) and it needs access to the directory.
+RUN mkdir -p /var/tempo
+RUN chgrp -R 0 /var/tempo && chmod -R g+rwX /var/tempo
+
 ENTRYPOINT ["/tempo"]


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes  #1657 

Fixes:
```
k logs tempo-simplest-querier-5997764574-pclft                                                                                                                                                                                                                                 ploffay@fedora
.level=info ts=2022-11-24T09:51:52.664423051Z caller=main.go:191 msg="initialising OpenTracing tracer"
level=info ts=2022-11-24T09:51:52.665287818Z caller=main.go:106 msg="Starting Tempo" version="(version=, branch=HEAD, revision=fd5743d5d)"
level=info ts=2022-11-24T09:51:52.666282026Z caller=server.go:306 http=[::]:3100 grpc=[::]:9095 msg="server listening on addresses"
level=error ts=2022-11-24T09:51:52.672652494Z caller=main.go:109 msg="error running Tempo" err="failed to init module services error initialising module: store: failed to create store mkdir /var/tempo: permission denied"
```

This is how the filesystem looks like:
```
~ $ ls -al /var/
total 0
drwxr-xr-x    1 root     root            19 Aug  9 08:58 .
dr-xr-xr-x    1 root     root            40 Nov 24 09:55 ..
drwxr-xr-x    1 root     root            29 Aug  9 08:58 cache
dr-xr-xr-x    2 root     root             6 Aug  9 08:58 empty
drwxr-xr-x    5 root     root            43 Aug  9 08:58 lib
drwxr-xr-x    2 root     root             6 Aug  9 08:58 local
drwxr-xr-x    3 root     root            20 Aug  9 08:58 lock
drwxr-xr-x    2 root     root             6 Aug  9 08:58 log
drwxr-xr-x    2 root     root             6 Aug  9 08:58 mail
drwxr-xr-x    2 root     root             6 Aug  9 08:58 opt
lrwxrwxrwx    1 root     root             4 Aug  9 08:58 run -> /run
drwxr-xr-x    3 root     root            30 Aug  9 08:58 spool
drwxrwxrwt    2 root     root             6 Aug  9 08:58 tmp
~ $ ls -al /tempo 
-rwxr-xr-x    1 root     root      73217428 Aug 17 17:36 /tempo
~ $ 
```

```
oc debug -t  tempo-simplest-querier-5997764574-pclft --  /bin/sh                                                                                                                                                                                                                   ploffay@fedora
Starting pod/tempo-simplest-querier-5997764574-pclft-debug ...
Pod IP: 10.217.1.59
If you don't see a command prompt, try pressing enter.
~ $ ls
bin    conf   dev    etc    home   lib    media  mnt    opt    proc   root   run    sbin   srv    sys    tempo  tmp    usr    var
~ $ ls -al /var/
total 0
drwxr-xr-x    1 root     root            19 Aug  9 08:58 .
dr-xr-xr-x    1 root     root            40 Nov 24 09:55 ..
drwxr-xr-x    1 root     root            29 Aug  9 08:58 cache
dr-xr-xr-x    2 root     root             6 Aug  9 08:58 empty
drwxr-xr-x    5 root     root            43 Aug  9 08:58 lib
drwxr-xr-x    2 root     root             6 Aug  9 08:58 local
drwxr-xr-x    3 root     root            20 Aug  9 08:58 lock
drwxr-xr-x    2 root     root             6 Aug  9 08:58 log
drwxr-xr-x    2 root     root             6 Aug  9 08:58 mail
drwxr-xr-x    2 root     root             6 Aug  9 08:58 opt
lrwxrwxrwx    1 root     root             4 Aug  9 08:58 run -> /run
drwxr-xr-x    3 root     root            30 Aug  9 08:58 spool
drwxrwxrwt    2 root     root             6 Aug  9 08:58 tmp
~ $ ls -al /tempo 
-rwxr-xr-x    1 root     root      73217428 Aug 17 17:36 /tempo
~ $ touch /tmp/foo
~ $ ls -al /tmp/foo
-rw-r--r--    1 10006800 root             0 Nov 24 10:15 /tmp/foo
~ $ mkdir /var/tempo
mkdir: can't create directory '/var/tempo': Permission denied
~ $ 

```

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`