### PR TITLE
Improve configuration warnings testing and presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [CHANGE] tempo: check configuration returns now a list of warnings [#1663](https://github.com/grafana/tempo/pull/1663) (@frzifus)
 * [ENHANCEMENT] metrics-generator: expose span size as a metric [#1662](https://github.com/grafana/tempo/pull/1662) (@ie-pham)
 * [ENHANCEMENT] Set Max Idle connections to 100 for Azure, should reduce DNS errors in Azure [#1632](https://github.com/grafana/tempo/pull/1632) (@electron0zero)
 

--- a/cmd/tempo/app/config_test.go
+++ b/cmd/tempo/app/config_test.go
@@ -1,0 +1,62 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/tempo/modules/distributor"
+	"github.com/grafana/tempo/modules/storage"
+	"github.com/grafana/tempo/tempodb"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfig_CheckConfig(t *testing.T) {
+	tt := []struct {
+		name   string
+		config *Config
+		expect int
+	}{
+		{
+			name:   "check default cfg and expect no warnings",
+			config: newDefaultConfig(),
+			expect: 0,
+		},
+		{
+			name: "hit all except local backend warnings",
+			config: &Config{
+				Target: MetricsGenerator,
+				StorageConfig: storage.Config{
+					Trace: tempodb.Config{
+						Backend:       "s3",
+						BlocklistPoll: time.Minute,
+					},
+				},
+				Distributor: distributor.Config{
+					LogReceivedTraces: true,
+				},
+			},
+			expect: 7,
+		},
+		{
+			name: "hit local backend warnings",
+			config: func() *Config {
+				cfg := newDefaultConfig()
+				cfg.StorageConfig.Trace = tempodb.Config{
+					Backend:                  "local",
+					BlocklistPollConcurrency: 1,
+				}
+				cfg.Target = "something"
+				return cfg
+			}(),
+			expect: 1,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			warnings := tc.config.CheckConfig()
+			assert.Equal(t, tc.expect, len(warnings))
+		})
+	}
+}

--- a/cmd/tempo/app/config_test.go
+++ b/cmd/tempo/app/config_test.go
@@ -15,12 +15,12 @@ func TestConfig_CheckConfig(t *testing.T) {
 	tt := []struct {
 		name   string
 		config *Config
-		expect int
+		expect []ConfigWarning
 	}{
 		{
 			name:   "check default cfg and expect no warnings",
 			config: newDefaultConfig(),
-			expect: 0,
+			expect: nil,
 		},
 		{
 			name: "hit all except local backend warnings",
@@ -36,7 +36,15 @@ func TestConfig_CheckConfig(t *testing.T) {
 					LogReceivedTraces: true,
 				},
 			},
-			expect: 7,
+			expect: []ConfigWarning{
+				warnMetricsGenerator,
+				warnCompleteBlockTimeout,
+				warnBlockRetention,
+				warnRetentionConcurrency,
+				warnStorageTraceBackendS3,
+				warnBlocklistPollConcurrency,
+				warnLogReceivedTraces,
+			},
 		},
 		{
 			name: "hit local backend warnings",
@@ -49,14 +57,14 @@ func TestConfig_CheckConfig(t *testing.T) {
 				cfg.Target = "something"
 				return cfg
 			}(),
-			expect: 1,
+			expect: []ConfigWarning{warnStorageTraceBackendLocal},
 		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			warnings := tc.config.CheckConfig()
-			assert.Equal(t, tc.expect, len(warnings))
+			assert.Equal(t, tc.expect, warnings)
 		})
 	}
 }

--- a/cmd/tempo/main.go
+++ b/cmd/tempo/main.go
@@ -94,7 +94,16 @@ func main() {
 	ballast := make([]byte, *ballastMBs*1024*1024)
 
 	// Warn the user for suspect configurations
-	config.CheckConfig()
+	if warnings := config.CheckConfig(); len(warnings) != 0 {
+		level.Warn(log.Logger).Log("-- CONFIGURATION WARNINGS --")
+		for _, w := range warnings {
+			output := []any{"msg", w.Message}
+			if w.Explain != "" {
+				output = append(output, "explain", w.Explain)
+			}
+			level.Warn(log.Logger).Log(output...)
+		}
+	}
 
 	// Start Tempo
 	t, err := app.New(*config)


### PR DESCRIPTION
~Hey, would be nice to get some feedback if [this](https://github.com/grafana/tempo/pull/1663/commits/2556b099b05f72da76190a915eff9da1c424e088) roughly looks like what you aimed for. If so, i will continue with persisting the change with some tests. :)~

~cc @joe-elliott @zalegrala~

---

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This PR changes the behavior of the `cmd/tempo/app/config.CheckConfig` method. Previously, suspicious values were logged individually. Now a list of warnings and descriptions is returned. The caller can then decide whether and how to use this information. In this PR we decided to reproduce the existing logging behavior.

**Which issue(s) this PR fixes**:
Fixes #1575

**Checklist**
- [x] Tests updated
- [ ] ~Documentation added~
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`