### PR TITLE
[Doc] Fix next branch links to latest, update Parquet

### DIFF
--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -1168,7 +1168,9 @@ Additional search-related settings are available in the [distributor](#distribut
 
 By default, Tempo will report anonymous usage data about the shape of a deployment to Grafana Labs. 
 This data is used to determine how common the deployment of certain features are, if a feature flag has been enabled,
-replication factor or compression levels, etc.
+and which replication factor or compression levels are used.
+
+By providing information on how people use Tempo, usage reporting helps the Tempo team decide where to focus their development and documentation efforts. No private information is collected, and all reports are completely anonymous.
 
 Reporting is controlled by a configuration option.
 You can disable the automatic reporting of this generic information using the following

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -1173,6 +1173,15 @@ and which replication factor or compression levels are used.
 By providing information on how people use Tempo, usage reporting helps the Tempo team decide where to focus their development and documentation efforts. No private information is collected, and all reports are completely anonymous.
 
 Reporting is controlled by a configuration option.
+
+The following configuration values are used: 
+
+- Receivers enabled
+- Frontend concurrency and version
+- Storage cache, backend, wal and block encodings
+- Ring replication factor, and `kvstore` 
+- Features toggles enabled
+
 You can disable the automatic reporting of this generic information using the following
 configuration:
 

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -1182,6 +1182,8 @@ The following configuration values are used:
 - Ring replication factor, and `kvstore` 
 - Features toggles enabled
 
+No performance data is collected. 
+
 You can disable the automatic reporting of this generic information using the following
 configuration:
 

--- a/docs/tempo/website/configuration/parquet.md
+++ b/docs/tempo/website/configuration/parquet.md
@@ -27,6 +27,29 @@ To use Parquet, set the block format option to `vParquet` in the Storage section
 [version: vParquet | default = v2]
 ```
 
+The following adjustments are recommended for your querier configuration: 
+
+```yaml
+querier:
+  max_concurrent_queries: 100
+  search:
+    prefer_self: 50   # only if you're using external endpoints
+
+query_frontend:
+  max_outstanding_per_tenant: 2000
+  search:
+    concurrent_jobs: 2000
+    target_bytes_per_job: 400_000_000
+
+storage:
+  trace:
+    <gcs|s3|azure>:
+      hedge_requests_at: 1s
+      hedge_requests_up_to: 2
+```
+
+
+
 ## Parquet configuration parameters
 
 Some parameters in the Tempo configuration are specific to Parquet.  

--- a/docs/tempo/website/configuration/parquet.md
+++ b/docs/tempo/website/configuration/parquet.md
@@ -5,21 +5,20 @@ weight: 75
 
 # Apache Parquet backend
 
+<span style="background-color:#f3f973;">This is an experimental feature released with [Tempo 1.5]({{< relref "../release-notes/v1.5/" >}}). For more information about how to enable it, continue reading.</span>
+
 Tempo now has a columnar block format based on Apache Parquet.
 A columnar block format may result in improved search performance and also enables a large ecosystem of tools access to the underlying trace data.
-
-<span style="background-color:#f3f973;">This is an experimental feature. For more information about how to enable it, continue reading.</span>
 
 For more information, refer to the [Parquet design document](https://github.com/mdisibio/tempo/blob/design-proposal-parquet/docs/design-proposals/2022-04%20Parquet.md) and [Issue 1480](https://github.com/grafana/tempo/issues/1480).
 
 ## Considerations
 
-While Parquet can be used as a drop-in replacement, Parquet requires more CPU and memory resources.
+The new Parquet block format can be used as a drop-in replacement for Tempo's existing block format.
 No data conversion or upgrade process is necessary.
-Once Parquet is enabled, Tempo starts writing new data in the new format.
-Existing data are left as-is. 
+As soon as the Parquet format is enabled, Tempo starts writing data in that format, leaving existing data as-is.
 
-## Enable Parquet 
+## Enable Parquet
 
 To use Parquet, set the block format option to `vParquet` in the Storage section of the configuration file.
 

--- a/docs/tempo/website/configuration/parquet.md
+++ b/docs/tempo/website/configuration/parquet.md
@@ -18,6 +18,9 @@ The new Parquet block format can be used as a drop-in replacement for Tempo's ex
 No data conversion or upgrade process is necessary.
 As soon as the Parquet format is enabled, Tempo starts writing data in that format, leaving existing data as-is.
 
+Please note, however, that enabling the Parquet block format means Tempo will require more CPU and memory resources than it previously did. 
+
+
 ## Enable Parquet
 
 To use Parquet, set the block format option to `vParquet` in the Storage section of the configuration file.

--- a/docs/tempo/website/configuration/parquet.md
+++ b/docs/tempo/website/configuration/parquet.md
@@ -30,7 +30,7 @@ To use Parquet, set the block format option to `vParquet` in the Storage section
 [version: vParquet | default = v2]
 ```
 
-The following adjustments are recommended for your querier configuration: 
+The following adjustments are recommended for your configuration: 
 
 ```yaml
 querier:

--- a/docs/tempo/website/configuration/parquet.md
+++ b/docs/tempo/website/configuration/parquet.md
@@ -48,8 +48,6 @@ storage:
       hedge_requests_up_to: 2
 ```
 
-
-
 ## Parquet configuration parameters
 
 Some parameters in the Tempo configuration are specific to Parquet.  

--- a/docs/tempo/website/metrics-generator/app-performance-mgmt.md
+++ b/docs/tempo/website/metrics-generator/app-performance-mgmt.md
@@ -32,12 +32,12 @@ To use the APM dashboard, you need:
 
 * Tempo or Grafana Cloud Traces with either 1) the metrics generator enabled and configured or 2) the Grafana Agent enabled and configured to send data to a Prometheus-compatible metrics store
 * [Services graphs]({{< relref "../metrics-generator/service_graphs/#how-to-run" >}}), which are enabled by default in Grafana
-* [APM table enabled](https://grafana.com/docs/grafana/next/datasources/tempo/) within the service graph tab (use the `tempoApmTable` feature flag in Grafana to enable)
+* [APM table enabled](https://grafana.com/docs/grafana/latest/datasources/tempo/) within the service graph tab (use the `tempoApmTable` feature flag in Grafana to enable)
 * [Span metrics]({{< relref "../metrics-generator/span_metrics/#how-to-run" >}}) enabled in your Tempo data source configuration
 
 The APM dashboard can be generated with the metrics-generator or Grafana Agent.
 
-For information on how to configure these features, refer to the [Grafana Tempo data sources documentation](https://grafana.com/docs/grafana/next/datasources/tempo/).
+For information on how to configure these features, refer to the [Grafana Tempo data sources documentation](https://grafana.com/docs/grafana/latest/datasources/tempo/).
 
 ## APM dashboard
 
@@ -134,7 +134,7 @@ In the APM table, you can select items in the **Rate**, **Error Rate**, **Durati
 
 You can view request rate, request histogram, failed request rate, and traces for any node in the service graph.
 To view more information, select the node in the service graph and then choose an option from the popup.
-For details on navigating the service graph, refer to the [Node graph panel](https://grafana.com/docs/grafana/next/visualizations/node-graph/) documentation.
+For details on navigating the service graph, refer to the [Node graph panel](https://grafana.com/docs/grafana/latest/visualizations/node-graph/) documentation.
 
 <p align="center"><img src="../apm-service-graph-drilldown.png" alt="APM service graph with drill-down"></p>
 


### PR DESCRIPTION
**What this PR does**:

The APM dashboard documentation linked to the /next doc in Grafana. These links have been changed to /latest since those pages are now live. 

Updated the content in the Parquet documentation to match the updated phrasing Jen used in the release notes. 

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`