### PR TITLE
Make DNS address fully qualified to reduce DNS lookups in Kubernetes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [ENHANCEMENT] metrics-generator: expose span size as a metric [#1662](https://github.com/grafana/tempo/pull/1662) (@ie-pham)
 * [ENHANCEMENT] Set Max Idle connections to 100 for Azure, should reduce DNS errors in Azure [#1632](https://github.com/grafana/tempo/pull/1632) (@electron0zero)
+* [CHANGE] Make DNS address fully qualified to reduce DNS lookups in Kubernetes [#1687](https://github.com/grafana/tempo/pull/1687) (@electron0zero)
 
 ## v1.5.0 / 2022-08-17
 

--- a/operations/jsonnet-compiled/ConfigMap-tempo-compactor.yaml
+++ b/operations/jsonnet-compiled/ConfigMap-tempo-compactor.yaml
@@ -18,7 +18,7 @@ data:
         abort_if_cluster_join_fails: false
         bind_port: 7946
         join_members:
-            - gossip-ring.tracing.svc.cluster.local:7946
+            - gossip-ring.tracing.svc.cluster.local.:7946
     metrics_generator_enabled: false
     overrides:
         per_tenant_override_config: /overrides/overrides.yaml

--- a/operations/jsonnet-compiled/ConfigMap-tempo-distributor.yaml
+++ b/operations/jsonnet-compiled/ConfigMap-tempo-distributor.yaml
@@ -21,7 +21,7 @@ data:
         abort_if_cluster_join_fails: false
         bind_port: 7946
         join_members:
-            - gossip-ring.tracing.svc.cluster.local:7946
+            - gossip-ring.tracing.svc.cluster.local.:7946
     metrics_generator_enabled: false
     overrides:
         per_tenant_override_config: /overrides/overrides.yaml

--- a/operations/jsonnet-compiled/ConfigMap-tempo-ingester.yaml
+++ b/operations/jsonnet-compiled/ConfigMap-tempo-ingester.yaml
@@ -12,7 +12,7 @@ data:
         abort_if_cluster_join_fails: false
         bind_port: 7946
         join_members:
-            - gossip-ring.tracing.svc.cluster.local:7946
+            - gossip-ring.tracing.svc.cluster.local.:7946
     metrics_generator_enabled: false
     overrides:
         per_tenant_override_config: /overrides/overrides.yaml

--- a/operations/jsonnet-compiled/ConfigMap-tempo-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/ConfigMap-tempo-metrics-generator.yaml
@@ -12,7 +12,7 @@ data:
         abort_if_cluster_join_fails: false
         bind_port: 7946
         join_members:
-            - gossip-ring.tracing.svc.cluster.local:7946
+            - gossip-ring.tracing.svc.cluster.local.:7946
     metrics_generator:
         storage:
             path: /var/tempo/generator_wal

--- a/operations/jsonnet-compiled/ConfigMap-tempo-querier.yaml
+++ b/operations/jsonnet-compiled/ConfigMap-tempo-querier.yaml
@@ -12,13 +12,13 @@ data:
         abort_if_cluster_join_fails: false
         bind_port: 7946
         join_members:
-            - gossip-ring.tracing.svc.cluster.local:7946
+            - gossip-ring.tracing.svc.cluster.local.:7946
     metrics_generator_enabled: false
     overrides:
         per_tenant_override_config: /overrides/overrides.yaml
     querier:
         frontend_worker:
-            frontend_address: query-frontend-discovery.tracing.svc.cluster.local:9095
+            frontend_address: query-frontend-discovery.tracing.svc.cluster.local.:9095
     search_enabled: false
     server:
         http_listen_port: 3200

--- a/operations/jsonnet-compiled/ConfigMap-tempo-query-frontend.yaml
+++ b/operations/jsonnet-compiled/ConfigMap-tempo-query-frontend.yaml
@@ -12,7 +12,7 @@ data:
         abort_if_cluster_join_fails: false
         bind_port: 7946
         join_members:
-            - gossip-ring.tracing.svc.cluster.local:7946
+            - gossip-ring.tracing.svc.cluster.local.:7946
     metrics_generator_enabled: false
     overrides:
         per_tenant_override_config: /overrides/overrides.yaml

--- a/operations/jsonnet-compiled/Deployment-compactor.yaml
+++ b/operations/jsonnet-compiled/Deployment-compactor.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        config_hash: 39135b35e93010b0064838bd8f37a47f
+        config_hash: 04977ed074a986f446c93be0dbcd59cc
       labels:
         app: compactor
         name: compactor

--- a/operations/jsonnet-compiled/Deployment-distributor.yaml
+++ b/operations/jsonnet-compiled/Deployment-distributor.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        config_hash: 1419befab9a6b69d88896bd1f4394654
+        config_hash: b18e8715d189e60852d11f32653473a9
       labels:
         app: distributor
         name: distributor

--- a/operations/jsonnet-compiled/Deployment-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/Deployment-metrics-generator.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        config_hash: 38371b26593e9c469c05ce32310ccdc9
+        config_hash: 264025c7ed58d6666fe3c7278e8993f2
       labels:
         app: metrics-generator
         name: metrics-generator

--- a/operations/jsonnet-compiled/Deployment-querier.yaml
+++ b/operations/jsonnet-compiled/Deployment-querier.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        config_hash: a584f6c6479c64143d0008609e0b0c25
+        config_hash: 15acd5511dbb9b46b5e58e3fa1059843
       labels:
         app: querier
         name: querier

--- a/operations/jsonnet-compiled/Deployment-query-frontend.yaml
+++ b/operations/jsonnet-compiled/Deployment-query-frontend.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        config_hash: 345364f17b5771460510d3d5b9028e3c
+        config_hash: df848edaed79a9620eb44a18be4ce4f5
       labels:
         app: query-frontend
         name: query-frontend

--- a/operations/jsonnet-compiled/StatefulSet-ingester.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-ingester.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        config_hash: 345364f17b5771460510d3d5b9028e3c
+        config_hash: df848edaed79a9620eb44a18be4ce4f5
       labels:
         app: ingester
         name: ingester

--- a/operations/jsonnet-compiled/util/jsonnetfile.lock.json
+++ b/operations/jsonnet-compiled/util/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "1aa353b7afc7ce46351b88d52235ae7a17f4ec0e",
-      "sum": "QiIOYQ0mdyVXStdPxu99M5CYGtYAXczWAC62EAQmWBM="
+      "version": "c132c4afcf17491718539db4c2d94c0ea4346120",
+      "sum": "2++XoPslyz02LRgsxREWxjLgYgiCIqhAtXCyVSvYcoE="
     },
     {
       "source": {
@@ -18,7 +18,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "1aa353b7afc7ce46351b88d52235ae7a17f4ec0e",
+      "version": "c132c4afcf17491718539db4c2d94c0ea4346120",
       "sum": "8hXTN4QOMkpad75LESkdfRD4/Sl81fMqZcD0ZPx2SNc="
     },
     {

--- a/operations/jsonnet-compiled/util/vendor/github.com/grafana/jsonnet-libs/ksonnet-util/grafana.libsonnet
+++ b/operations/jsonnet-compiled/util/vendor/github.com/grafana/jsonnet-libs/ksonnet-util/grafana.libsonnet
@@ -60,10 +60,6 @@
     },
   },
 
-  extensions+: {
-    v1beta1+: appsExtentions,
-  },
-
   apps+: {
     v1beta1+: appsExtentions,
     v1+: appsExtentions,

--- a/operations/jsonnet-compiled/util/vendor/github.com/grafana/jsonnet-libs/ksonnet-util/legacy-custom.libsonnet
+++ b/operations/jsonnet-compiled/util/vendor/github.com/grafana/jsonnet-libs/ksonnet-util/legacy-custom.libsonnet
@@ -144,10 +144,6 @@
     },
   },
 
-  extensions+: {
-    v1beta1+: appsExtentions,
-  },
-
   apps+: {
     v1beta1+: appsExtentions,
     v1+: appsExtentions,

--- a/operations/jsonnet-compiled/util/vendor/github.com/grafana/jsonnet-libs/ksonnet-util/legacy-noname.libsonnet
+++ b/operations/jsonnet-compiled/util/vendor/github.com/grafana/jsonnet-libs/ksonnet-util/legacy-noname.libsonnet
@@ -5,11 +5,6 @@ function(noNewEmptyNameMixin) {
   core+: { v1+: {
     persistentVolumeClaim+: noNewEmptyNameMixin,
   } },
-  extensions+: {
-    v1beta1+: {
-      ingress+: noNewEmptyNameMixin,
-    },
-  },
   networking+: {
     v1beta1+: {
       ingress+: noNewEmptyNameMixin,

--- a/operations/jsonnet-compiled/util/vendor/github.com/grafana/jsonnet-libs/ksonnet-util/legacy-subtypes.libsonnet
+++ b/operations/jsonnet-compiled/util/vendor/github.com/grafana/jsonnet-libs/ksonnet-util/legacy-subtypes.libsonnet
@@ -79,17 +79,6 @@
     v1+: appsPatch,
     v1beta1+: appsPatch,
   },
-  extensions+: {
-    v1beta1+: appsPatch {
-      ingress+: {
-        spec+: {
-          rulesType: $.extensions.v1beta1.ingressRule {
-            httpType+: { pathsType: $.extensions.v1beta1.httpIngressPath },
-          },
-        },
-      },
-    },
-  },
 
   batch+: {
     local patch = {

--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -54,7 +54,7 @@
     memberlist: {
       abort_if_cluster_join_fails: false,
       bind_port: $._config.gossip_ring_port,
-      join_members: ['gossip-ring.%s.svc.cluster.local:%d' % [$._config.namespace, $._config.gossip_ring_port]],
+      join_members: ['gossip-ring.%s.svc.cluster.local.:%d' % [$._config.namespace, $._config.gossip_ring_port]],
     },
   },
 
@@ -107,7 +107,7 @@
     },
     querier+: {
       frontend_worker+: {
-        frontend_address: 'query-frontend-discovery.%s.svc.cluster.local:9095' % [$._config.namespace],
+        frontend_address: 'query-frontend-discovery.%s.svc.cluster.local.:9095' % [$._config.namespace],
       },
     },
   },


### PR DESCRIPTION
Change DNS address fully qualified to reduce DNS lookups in Kubernetes.

See https://pracucci.com/kubernetes-dns-resolution-ndots-options-and-why-it-may-affect-application-performances.html
for more details.

also see: similar change in Loki https://github.com/grafana/loki/pull/5789

**What this PR does**:

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`