### PR TITLE
Parquet Compaction: Restore discarded rows to pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [ENHANCEMENT] metrics-generator: expose span size as a metric [#1662](https://github.com/grafana/tempo/pull/1662) (@ie-pham)
 * [ENHANCEMENT] Set Max Idle connections to 100 for Azure, should reduce DNS errors in Azure [#1632](https://github.com/grafana/tempo/pull/1632) (@electron0zero)
 * [CHANGE] Make DNS address fully qualified to reduce DNS lookups in Kubernetes [#1687](https://github.com/grafana/tempo/pull/1687) (@electron0zero)
+* [CHANGE] Improve parquet compaction memory profile when dropping spans [#1692](https://github.com/grafana/tempo/pull/1692) (@joe-elliott)
 
 ## v1.5.0 / 2022-08-17
 

--- a/tempodb/encoding/vparquet/compactor.go
+++ b/tempodb/encoding/vparquet/compactor.go
@@ -101,8 +101,9 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 			}
 			if sum > c.opts.MaxBytesPerTrace {
 				// Trace too large to compact
-				for _, discardedRow := range rows[1:] {
-					c.opts.SpansDiscarded(countSpans(sch, discardedRow))
+				for i := 1; i < len(rows); i++ {
+					c.opts.SpansDiscarded(countSpans(sch, rows[i]))
+					pool.Put(rows[i])
 				}
 				return rows[0], nil
 			}


### PR DESCRIPTION
**What this PR does**:
Restores discarded spans to the row pool. Previously these were dropped. Also technically creates one less allocation by not creating a subslice :P.

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`