### PR TITLE
Avoid error return when usage stats context is canceled

### DIFF
--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -201,11 +201,14 @@ func (t *App) Run() error {
 		// let's find out which module failed
 		for m, s := range serviceMap {
 			if s == service {
-				if service.FailureCase() == modules.ErrStopProcess {
+				switch service.FailureCase() {
+				case modules.ErrStopProcess:
 					level.Info(log.Logger).Log("msg", "received stop signal via return error", "module", m, "err", service.FailureCase())
-				} else {
+				case context.Canceled:
+				default:
 					level.Error(log.Logger).Log("msg", "module failed", "module", m, "err", service.FailureCase())
 				}
+
 				return
 			}
 		}

--- a/pkg/usagestats/reporter.go
+++ b/pkg/usagestats/reporter.go
@@ -261,7 +261,12 @@ func (rep *Reporter) running(ctx context.Context) error {
 			rep.lastReport = next
 			next = next.Add(reportInterval)
 		case <-ctx.Done():
-			return ctx.Err()
+			switch ctx.Err() {
+			case context.Canceled:
+				return nil
+			default:
+				return ctx.Err()
+			}
 		}
 	}
 }

--- a/pkg/usagestats/reporter_test.go
+++ b/pkg/usagestats/reporter_test.go
@@ -159,7 +159,7 @@ func Test_ReportLoop(t *testing.T) {
 		<-time.After(6*time.Second + (stabilityCheckInterval * time.Duration(stabilityMinimunRequired+1)))
 		cancel()
 	}()
-	require.Equal(t, context.Canceled, r.running(ctx))
+	require.Equal(t, nil, r.running(ctx))
 	require.GreaterOrEqual(t, totalReport, 5)
 	first := clusterIDs[0]
 	for _, uid := range clusterIDs {


### PR DESCRIPTION
**What this PR does**:
Here we avoid logging an error when the context is canceled on the usage stats.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`