### PR TITLE
[Doc] Removed "experimental" warning for service graphs and backend search

### DIFF
--- a/docs/tempo/website/api_docs/_index.md
+++ b/docs/tempo/website/api_docs/_index.md
@@ -133,8 +133,6 @@ but if it can also send OpenTelemetry proto if `Accept: application/protobuf` is
 
 ### Search
 
-<span style="background-color:#f3f973;">This experimental endpoint is disabled by default and can be enabled via the `search_enabled` YAML config option.</span>
-
 Tempo's Search API finds traces based on span and process attributes (tags and values).  The API is available in the query frontend service in
 a microservices deployment, or the Tempo endpoint in a monolithic mode deployment.  The following request is used to find traces containing spans
 from service "myservice" and the url contains "api/myapi".
@@ -191,8 +189,6 @@ $ curl -G -s http://localhost:3200/api/search --data-urlencode 'tags=service.nam
 
 ### Search Tags
 
-<span style="background-color:#f3f973;">This experimental endpoint is disabled by default and can be enabled via the `search_enabled` YAML config option.</span>
-
 Ingester configuration `complete_block_timeout` affects how long tags are available for search.
 
 This endpoint retrieves all discovered tag names that can be used in search.  The endpoint is available in the query frontend service in
@@ -233,8 +229,6 @@ $ curl -G -s http://localhost:3200/api/search/tags  | jq
 ```
 
 ### Search Tag Values
-
-<span style="background-color:#f3f973;">This experimental endpoint is disabled by default and can be enabled via the `search_enabled` YAML config option.</span>
 
 Ingester configuration `complete_block_timeout` affects how long tags are available for search.
 

--- a/docs/tempo/website/getting-started/tempo-in-grafana.md
+++ b/docs/tempo/website/getting-started/tempo-in-grafana.md
@@ -18,13 +18,13 @@ Traces can be discovered by searching logs for entries containing trace IDs.  Th
 
 
 ## Tempo search
-<span style="background-color:#f3f973;">Tempo search is an experimental feature.</span>
-
-### Search of recent traces
 
 Tempo includes the ability to search recent traces held in ingesters.
 Traces can be searched for data originating from a specific service,
 duration range, span, or process-level attributes included in your application's instrumentation, such as HTTP status code and customer ID.
+
+### Search of recent traces
+
 Search of recent traces is disabled by default.
 Ingesters default to storing the last 15 minutes of traces.
 

--- a/docs/tempo/website/metrics-generator/service_graphs.md
+++ b/docs/tempo/website/metrics-generator/service_graphs.md
@@ -8,8 +8,6 @@ weight: 500
 
 # Service graphs
 
-<span style="background-color:#f3f973;">This is an experimental feature. For more information about how to enable it, continue reading.</span>
-
 A service graph is a visual representation of the interrelationships between various services.
 Service graphs help you to understand the structure of a distributed system,
 and the connections and dependencies between its components:

--- a/docs/tempo/website/operations/backend_search.md
+++ b/docs/tempo/website/operations/backend_search.md
@@ -5,8 +5,6 @@ weight: 9
 
 # Backend search
 
-<span style="background-color:#f3f973;">Search is an experimental feature.</span>
-
 Backend search is not yet mature. It can therefore be operationally more complex.
 The defaults do not yet support Tempo well.
 

--- a/docs/tempo/website/operations/server_side_metrics.md
+++ b/docs/tempo/website/operations/server_side_metrics.md
@@ -5,8 +5,6 @@ weight: 12
 
 # Server-side metrics
 
-<span style="background-color:#f3f973;">Server-side metrics is an experimental feature.</span>
-
 Server-side metrics is a feature that derive metrics from ingested traces.
 
 To generate metrics, it uses an additional component: the metrics-generator.
@@ -54,4 +52,4 @@ This results in a clean division of responsibility and limits the blast radius f
 
 ## Configuration
 
-For a detailed view of all the config options for the metrics generator, visit [its config page]({{< relref "../configuration/#metrics-generator" >}})
+For a detailed view of all the config options for the metrics generator, visit [its config page]({{< relref "../configuration/#metrics-generator" >}}).


### PR DESCRIPTION
**What this PR does**:

Removes the experimental warning banner from service graphs and backend search features. 

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`