### PR TITLE
revert PR 1706

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 * [ENHANCEMENT] metrics-generator: expose span size as a metric [#1662](https://github.com/grafana/tempo/pull/1662) (@ie-pham)
 * [ENHANCEMENT] Set Max Idle connections to 100 for Azure, should reduce DNS errors in Azure [#1632](https://github.com/grafana/tempo/pull/1632) (@electron0zero)
 * [ENHANCEMENT] Add PodDisruptionBudget to ingesters in jsonnet [#1691](https://github.com/grafana/tempo/pull/1691) (@joe-elliott)
-* [ENHANCEMENT] Add span-level duration column [#1706](https://github.com/grafana/tempo/pull/1706) (@mdisibio)
 * [ENHANCEMENT] Add cli command an existing file to tempodb's current parquet schema. [#1706](https://github.com/grafana/tempo/pull/1707) (@joe-elliott)
 * [BUGFIX] Honor caching and buffering settings when finding traces by id [#1697](https://github.com/grafana/tempo/pull/1697) (@joe-elliott)
 * [BUGFIX] Correctly propagate errors from the iterator layer up through the queriers [#1723](https://github.com/grafana/tempo/pull/1723) (@joe-elliott)

--- a/tempodb/encoding/vparquet/schema.go
+++ b/tempodb/encoding/vparquet/schema.go
@@ -82,7 +82,6 @@ type Span struct {
 	TraceState             string      `parquet:",snappy"`
 	StartUnixNanos         uint64      `parquet:",delta"`
 	EndUnixNanos           uint64      `parquet:",delta"`
-	DurationNanos          uint64      `parquet:",delta"`
 	StatusCode             int         `parquet:",delta"`
 	StatusMessage          string      `parquet:",snappy"`
 	Attrs                  []Attribute `parquet:""`
@@ -266,7 +265,6 @@ func traceToParquet(id common.ID, tr *tempopb.Trace) Trace {
 					StatusMessage:          s.Status.Message,
 					StartUnixNanos:         s.StartTimeUnixNano,
 					EndUnixNanos:           s.EndTimeUnixNano,
-					DurationNanos:          s.EndTimeUnixNano - s.StartTimeUnixNano,
 					Attrs:                  make([]Attribute, 0, len(s.Attributes)),
 					DroppedAttributesCount: int32(s.DroppedAttributesCount),
 					Events:                 events,


### PR DESCRIPTION
**What this PR does**:
This PR reverts #1706 . We encountered some errors during compaction after deploying this change, which prevents some blocks from being compacted.  Example: `error iterating input blocks: combining: rs → ils → Spans → DurationNanos → no values found in parquet row for column 27`.   We will bring this column back after determining the cause, but reverting now so that the codebase is functional.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`