### PR TITLE
Return 200 on partial results

### DIFF
--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -142,10 +142,6 @@ func newTraceByIDMiddleware(cfg Config, logger log.Logger) Middleware {
 					return nil, err
 				}
 
-				if responseObject.Metrics.FailedBlocks > 0 {
-					resp.StatusCode = http.StatusPartialContent
-				}
-
 				if marshallingFormat == api.HeaderAcceptJSON {
 					var jsonTrace bytes.Buffer
 					marshaller := &jsonpb.Marshaler{}

--- a/modules/frontend/tracebyidsharding.go
+++ b/modules/frontend/tracebyidsharding.go
@@ -150,6 +150,10 @@ func (s shardQuery) RoundTrip(r *http.Request) (*http.Response, error) {
 		return nil, overallError
 	}
 
+	if totalFailedBlocks > 0 {
+		_ = level.Warn(s.logger).Log("msg", "some blocks failed. returning success due to tolerate_failed_blocks", "failed", totalFailedBlocks, "tolerate_failed_blocks", s.maxFailedBlocks)
+	}
+
 	overallTrace, _ := combiner.Result()
 	if overallTrace == nil || statusCode != http.StatusOK {
 		// translate non-404s into 500s. if, for instance, we get a 400 back from an internal component


### PR DESCRIPTION
**What this PR does**:
Currently we return 206 if the number of failed blocks is < the tolerate_failed_blocks setting. However, Grafana doesn't know what to do with this and displays this:

![image](https://user-images.githubusercontent.com/2272392/189170666-e914d91c-9933-4be0-a932-d81348eaa6a9.png)

Just return 200 in this case and log an error instead.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`