### PR TITLE
Backport CI fix to weekly release r61

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -422,6 +422,6 @@ kind: secret
 name: gpg_passphrase
 ---
 kind: signature
-hmac: 63a7ae0db4d5c09efef4a24cb0019dd08bef208ba7a4462a8e882d34d3bc706b
+hmac: 215c5fbe3d1611d09447d29da3f0b2fe1e901b0ce3f152f1023ce1beccd5c7db
 
 ...


### PR DESCRIPTION
**What this PR does**:
Build was broken when r61 was created and no docker image has been created. This PR cherry-picks the CI fix.

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [ ] ~~Tests updated~~
- [ ] ~~Documentation added~~
- [ ] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~