### PR TITLE
Change parquet FindTraceByID to not use page index

### DIFF
--- a/tempodb/encoding/vparquet/block_findtracebyid.go
+++ b/tempodb/encoding/vparquet/block_findtracebyid.go
@@ -293,7 +293,7 @@ func (b *backendBlock) FindTraceByID2(ctx context.Context, traceID common.ID, op
 
 		// Read first value from the row group
 		rgs := pf.RowGroups()
-		iter := parquetquery.NewColumnIterator(ctx, rgs[rgIdx:rgIdx+1], colIndex, "", 1, nil, "id")
+		iter := parquetquery.NewColumnIterator(derivedCtx, rgs[rgIdx:rgIdx+1], colIndex, "", 1, nil, "id")
 		defer iter.Close()
 
 		res, err := iter.Next()
@@ -367,7 +367,7 @@ func (b *backendBlock) FindTraceByID2(ctx context.Context, traceID common.ID, op
 	}
 
 	// Now iterate the matching row group
-	iter := parquetquery.NewColumnIterator(ctx, pf.RowGroups()[rowGroup:rowGroup+1], colIndex, "", 1000, parquetquery.NewStringInPredicate([]string{string(traceID)}), "")
+	iter := parquetquery.NewColumnIterator(derivedCtx, pf.RowGroups()[rowGroup:rowGroup+1], colIndex, "", 1000, parquetquery.NewStringInPredicate([]string{string(traceID)}), "")
 	defer iter.Close()
 
 	res, err := iter.Next()

--- a/tempodb/encoding/vparquet/block_findtracebyid.go
+++ b/tempodb/encoding/vparquet/block_findtracebyid.go
@@ -12,6 +12,7 @@ import (
 	"github.com/segmentio/parquet-go"
 	"github.com/willf/bloom"
 
+	"github.com/grafana/tempo/pkg/parquetquery"
 	pq "github.com/grafana/tempo/pkg/parquetquery"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/tempodb/encoding/common"
@@ -160,6 +161,10 @@ func (b *backendBlock) checkBloom(ctx context.Context, id common.ID) (found bool
 }
 
 func (b *backendBlock) FindTraceByID(ctx context.Context, traceID common.ID, opts common.SearchOptions) (_ *tempopb.Trace, err error) {
+	return b.FindTraceByID2(ctx, traceID, opts)
+}
+
+func (b *backendBlock) FindTraceByID1(ctx context.Context, traceID common.ID, opts common.SearchOptions) (_ *tempopb.Trace, err error) {
 	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "parquet.backendBlock.FindTraceByID",
 		opentracing.Tags{
 			"blockID":   b.meta.BlockID,
@@ -180,7 +185,10 @@ func (b *backendBlock) FindTraceByID(ctx context.Context, traceID common.ID, opt
 	if err != nil {
 		return nil, fmt.Errorf("unexpected error opening parquet file: %w", err)
 	}
-	defer func() { span.SetTag("inspectedBytes", rr.TotalBytesRead.Load()) }()
+	defer func() {
+		span.SetTag("inspectedBytes", rr.TotalBytesRead.Load())
+		//fmt.Println("read bytes:", rr.TotalBytesRead.Load())
+	}()
 
 	// traceID column index
 	colIndex, _ := pq.GetColumnIndexByPath(pf, TraceIDColumnName)
@@ -233,6 +241,175 @@ func (b *backendBlock) FindTraceByID(ctx context.Context, traceID common.ID, opt
 
 	// convert to proto trace and return
 	return parquetTraceToTempopbTrace(tr), nil
+}
+
+func (b *backendBlock) FindTraceByID2(ctx context.Context, traceID common.ID, opts common.SearchOptions) (_ *tempopb.Trace, err error) {
+	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "parquet.backendBlock.FindTraceByID",
+		opentracing.Tags{
+			"blockID":   b.meta.BlockID,
+			"tenantID":  b.meta.TenantID,
+			"blockSize": b.meta.Size,
+		})
+	defer span.Finish()
+
+	found, err := b.checkBloom(derivedCtx, traceID)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, nil
+	}
+
+	pf, rr, err := b.openForSearch(derivedCtx, opts, parquet.SkipPageIndex(true))
+	if err != nil {
+		return nil, fmt.Errorf("unexpected error opening parquet file: %w", err)
+	}
+	defer func() {
+		span.SetTag("inspectedBytes", rr.TotalBytesRead.Load())
+		//fmt.Println("read bytes:", rr.TotalBytesRead.Load())
+	}()
+
+	// traceID column index
+	colIndex, _ := pq.GetColumnIndexByPath(pf, TraceIDColumnName)
+	if colIndex == -1 {
+		return nil, fmt.Errorf("unable to get index for column: %s", TraceIDColumnName)
+	}
+
+	numRowGroups := len(pf.RowGroups())
+
+	// Cache of row group bounds
+	rowGroupMins := make([]common.ID, numRowGroups)
+	rowGroupMins[0] = b.meta.MinID
+	rowGroupMaxs := make([]common.ID, numRowGroups)
+	rowGroupMaxs[numRowGroups-1] = b.meta.MaxID // This is actually inclusive and the logic is special for the last row group below
+
+	getRowGroupMin := func(rgIdx int) common.ID {
+		min := rowGroupMins[rgIdx]
+		if len(min) > 0 {
+			// Already loaded
+			return min
+		}
+
+		// Read first value from the row group
+		rgs := pf.RowGroups()
+		iter := parquetquery.NewColumnIterator(ctx, rgs[rgIdx:rgIdx+1], colIndex, "", 1, nil, "id")
+		defer iter.Close()
+
+		res, err := iter.Next()
+		if err != nil {
+			panic("failed to read 1 value for row group min")
+		}
+		if res == nil {
+			panic("failed to read 1 value from row group")
+		}
+
+		min = res.ToMap()["id"][0].ByteArray()
+		rowGroupMins[rgIdx] = min
+
+		return min
+	}
+
+	getRowGroupMax := func(rgIdx int) common.ID {
+		max := rowGroupMaxs[rgIdx]
+		if len(max) > 0 {
+			// Already loaded
+			return max
+		}
+
+		// Read the min of the next row group is the best we can do
+		max = getRowGroupMin(rgIdx + 1)
+		rowGroupMaxs[rgIdx] = max
+		return max
+	}
+
+	rowGroup := binarySearch(numRowGroups, func(rgIdx int) int {
+		min := getRowGroupMin(rgIdx)
+		if check := bytes.Compare(traceID, min); check <= 0 {
+			// Trace is before or in this group
+			return check
+		}
+
+		max := getRowGroupMax(rgIdx)
+		// This is actually the min of the next group, so check is exclusive not inclusive like min
+		// Except for the last group, it is inclusive
+		check := bytes.Compare(traceID, max)
+		if check > 0 || (check == 0 && rgIdx < (numRowGroups-1)) {
+			// Trace is after this group
+			return 1
+		}
+
+		// Must be in this group
+		return 0
+	})
+
+	if rowGroup == -1 {
+		// Not within the bounds of any row group
+		return nil, nil
+	}
+
+	// Now iterate the matching row group
+	iter := parquetquery.NewColumnIterator(ctx, pf.RowGroups()[rowGroup:rowGroup+1], colIndex, "", 1000, parquetquery.NewStringInPredicate([]string{string(traceID)}), "")
+	defer iter.Close()
+
+	res, err := iter.Next()
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		// TraceID not found in this block
+		return nil, nil
+	}
+
+	// The row number coming out of the iterator is relative,
+	// so offset it using the num rows in all previous groups
+	rowMatch := int64(0)
+	for _, rg := range pf.RowGroups()[0:rowGroup] {
+		rowMatch += rg.NumRows()
+	}
+	rowMatch += res.RowNumber[0]
+
+	// seek to row and read
+	r := parquet.NewReader(pf)
+	err = r.SeekToRow(int64(rowMatch))
+	if err != nil {
+		return nil, errors.Wrap(err, "seek to row")
+	}
+
+	span.LogFields(log.Message("seeked to row"), log.Int64("row", rowMatch))
+
+	tr := new(Trace)
+	err = r.Read(tr)
+	if err != nil {
+		return nil, errors.Wrap(err, "error reading row from backend")
+	}
+
+	span.LogFields(log.Message("read trace"))
+
+	// convert to proto trace and return
+	return parquetTraceToTempopbTrace(tr), nil
+}
+
+// binarySearch that finds exact matching entry. Returns non-zero index when found, or -1 when not found
+// Inspired by sort.Search but makes uses of tri-state comparator to eliminate the last comparison when
+// we want to find exact match, not insertion point.
+func binarySearch(n int, compare func(int) int) int {
+	i, j := 0, n
+	for i < j {
+		h := int(uint(i+j) >> 1) // avoid overflow when computing h
+		// i ≤ h < j
+		switch compare(h) {
+		case 0:
+			// Found exact match
+			return h
+		case -1:
+			j = h
+		case 1:
+			i = h + 1
+		}
+	}
+
+	// No match
+	return -1
 }
 
 /*func dumpParquetRow(sch parquet.Schema, row parquet.Row) {

--- a/tempodb/encoding/vparquet/block_findtracebyid_test.go
+++ b/tempodb/encoding/vparquet/block_findtracebyid_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	tempo_io "github.com/grafana/tempo/pkg/io"
+	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/pkg/util/test"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/local"
@@ -143,7 +144,8 @@ func TestBackendBlockFindTraceByID_TestData(t *testing.T) {
 func BenchmarkFindTraceByID(b *testing.B) {
 	ctx := context.TODO()
 	tenantID := "1"
-	blockID := uuid.MustParse("3685ee3d-cbbf-4f36-bf28-93447a19dea6")
+	//blockID := uuid.MustParse("3685ee3d-cbbf-4f36-bf28-93447a19dea6")
+	blockID := uuid.MustParse("1a2d50d7-f10e-41f0-850d-158b19ead23d")
 
 	r, _, _, err := local.New(&local.Config{
 		Path: path.Join("/Users/marty/src/tmp/"),
@@ -155,10 +157,14 @@ func BenchmarkFindTraceByID(b *testing.B) {
 	meta, err := rr.BlockMeta(ctx, blockID, tenantID)
 	require.NoError(b, err)
 
+	// traceID := meta.minID
+	traceID, err := util.HexStringToTraceID("1a029f7ace79c7f2")
+	require.NoError(b, err)
+
 	block := newBackendBlock(meta, rr)
 
 	for i := 0; i < b.N; i++ {
-		tr, err := block.FindTraceByID2(ctx, meta.MinID, defaultSearchOptions())
+		tr, err := block.FindTraceByID2(ctx, traceID, defaultSearchOptions())
 		require.NoError(b, err)
 		require.NotNil(b, tr)
 	}

--- a/tempodb/encoding/vparquet/block_findtracebyid_test.go
+++ b/tempodb/encoding/vparquet/block_findtracebyid_test.go
@@ -3,6 +3,7 @@ package vparquet
 import (
 	"bytes"
 	"context"
+	"path"
 	"sort"
 	"testing"
 
@@ -136,5 +137,29 @@ func TestBackendBlockFindTraceByID_TestData(t *testing.T) {
 		protoTr, err := b.FindTraceByID(ctx, tr.TraceID, common.SearchOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, protoTr)
+	}
+}
+
+func BenchmarkFindTraceByID(b *testing.B) {
+	ctx := context.TODO()
+	tenantID := "1"
+	blockID := uuid.MustParse("3685ee3d-cbbf-4f36-bf28-93447a19dea6")
+
+	r, _, _, err := local.New(&local.Config{
+		Path: path.Join("/Users/marty/src/tmp/"),
+	})
+	require.NoError(b, err)
+
+	rr := backend.NewReader(r)
+
+	meta, err := rr.BlockMeta(ctx, blockID, tenantID)
+	require.NoError(b, err)
+
+	block := newBackendBlock(meta, rr)
+
+	for i := 0; i < b.N; i++ {
+		tr, err := block.FindTraceByID2(ctx, meta.MinID, defaultSearchOptions())
+		require.NoError(b, err)
+		require.NotNil(b, tr)
 	}
 }


### PR DESCRIPTION
**What this PR does**:
This PR introduces an alternate version of parquet.FindTraceByID which doesn't load the page index.  It still does a binary search over rowgroup min/max bounds to find the trace, but instead of using the bounds in the page index, it establishes the lower bound of each row group by reading a single trace ID from it.   We have found that with larger blocks (10-30GB) the page index can become quite large (250+MB) and costly to unmarshal.  Although this implementation will perform `log2(numRowGroups)` reads they are much smaller and overall faster and more efficient.

Of course, there is a breakpoint depending on the object store read latency and block size.  Below are benchmarks with three levels of simulated latency (time.Sleep in the ReaderAt) and two block sizes.  Above 100ms latency or smaller blocks, it becomes worse.  Not sure the explanation for the variable alloc/op after the change, it should be deterministic but perhaps it has to do with number of iterations per benchmark and reused buffers which get amortized.

PR is marked draft because I'd like to gather some thoughts on it, perhaps we could choose the approach dynamically based on the block. 

9GB block:
```
name              old time/op    new time/op    delta
FindTraceByID-12     539ms ± 1%     255ms ± 2%  -52.62%  (p=0.000 n=8+8)    20ms simulated latency
FindTraceByID-12     764ms ± 4%     589ms ± 2%  -22.98%  (p=0.000 n=9+10)   50ms simulated latency
FindTraceByID-12     1.11s ± 3%     1.13s ± 0%     ~     (p=0.059 n=8+9)   100ms simulated latency

name              old alloc/op   new alloc/op   delta
FindTraceByID-12     185MB ± 3%     115MB ±36%  -37.66%  (p=0.000 n=10+10)
FindTraceByID-12     184MB ± 2%     138MB ± 4%  -25.22%  (p=0.000 n=9+10)
FindTraceByID-12     188MB ± 2%      32MB ±20%  -82.72%  (p=0.000 n=9+9)

name              old allocs/op  new allocs/op  delta
FindTraceByID-12     2.06M ± 0%     0.07M ± 0%  -96.83%  (p=0.000 n=9+9)
FindTraceByID-12     2.06M ± 0%     0.07M ± 0%  -96.83%  (p=0.000 n=10+10)
FindTraceByID-12     2.06M ± 0%     0.07M ± 0%  -96.83%  (p=0.000 n=9+9)
```

700MB block
```
FindTraceByID-12     256ms ±28%     278ms ±12%     ~     (p=0.065 n=10+9)
FindTraceByID-12     453ms ± 2%     556ms ± 3%  +22.76%  (p=0.000 n=8+10)
FindTraceByID-12     862ms ± 1%    1063ms ± 3%  +23.22%  (p=0.000 n=10+8)
FindTraceByID-12     823MB ±16%     746MB ±20%     ~     (p=0.065 n=10+9)

name              old alloc/op   new alloc/op   delta
FindTraceByID-12     780MB ±12%     805MB ±15%     ~     (p=0.315 n=10+10)
FindTraceByID-12     780MB ±10%     735MB ±12%     ~     (p=0.063 n=10+10)

name              old allocs/op  new allocs/op  delta
FindTraceByID-12     29.9k ± 1%     16.2k ± 1%  -45.69%  (p=0.000 n=10+10)
FindTraceByID-12     30.0k ± 1%     16.3k ± 1%  -45.69%  (p=0.000 n=10+10)
FindTraceByID-12     30.1k ± 1%     16.3k ± 6%  -45.74%  (p=0.000 n=10+9)
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`