### PR TITLE
Reduce Parquet Reads

### DIFF
--- a/tempodb/encoding/vparquet/block_findtracebyid.go
+++ b/tempodb/encoding/vparquet/block_findtracebyid.go
@@ -69,7 +69,7 @@ func (b *backendBlock) FindTraceByID(ctx context.Context, traceID common.ID, opt
 		return nil, nil
 	}
 
-	pf, rr, err := b.openForSearch(derivedCtx, opts, parquet.SkipPageIndex(true))
+	pf, rr, err := b.openForSearch(derivedCtx, opts)
 	if err != nil {
 		return nil, fmt.Errorf("unexpected error opening parquet file: %w", err)
 	}

--- a/tempodb/encoding/vparquet/block_iterator.go
+++ b/tempodb/encoding/vparquet/block_iterator.go
@@ -19,7 +19,7 @@ func (b *backendBlock) open(ctx context.Context) (*parquet.File, *parquet.Reader
 	// 128 MB memory buffering
 	br := tempo_io.NewBufferedReaderAt(rr, int64(b.meta.Size), 2*1024*1024, 64)
 
-	pf, err := parquet.OpenFile(br, int64(b.meta.Size))
+	pf, err := parquet.OpenFile(br, int64(b.meta.Size), parquet.SkipBloomFilters(true), parquet.SkipPageIndex(true))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/tempodb/encoding/vparquet/block_traceql.go
+++ b/tempodb/encoding/vparquet/block_traceql.go
@@ -90,7 +90,7 @@ func (b *backendBlock) Fetch(ctx context.Context, req traceql.FetchSpansRequest)
 	}
 
 	// TODO - route global search options here
-	pf, _, err := b.openForSearch(ctx, common.SearchOptions{}, parquet.SkipPageIndex(true))
+	pf, _, err := b.openForSearch(ctx, common.SearchOptions{})
 	if err != nil {
 		return traceql.FetchSpansResponse{}, err
 	}


### PR DESCRIPTION
**What this PR does**:
Removes bloom filter and page index reads for compactors and queriers on all code paths. We never use them.
