### PR TITLE
Parquet iterator improvements

### DIFF
--- a/tempodb/encoding/vparquet/block_search.go
+++ b/tempodb/encoding/vparquet/block_search.go
@@ -322,7 +322,7 @@ func makePipelineWithRowGroups(ctx context.Context, req *tempopb.SearchRequest, 
 				makeIter(FieldResourceAttrVal, valPred, "values"),
 			}, nil),
 			// This iterator finds all keys/values at the span level
-			pq.NewJoinIterator(DefinitionLevelResourceSpansILSSpan, []pq.Iterator{
+			pq.NewJoinIterator(DefinitionLevelResourceSpansILSSpanAttrs, []pq.Iterator{
 				makeIter(FieldSpanAttrKey, keyPred, "keys"),
 				makeIter(FieldSpanAttrVal, valPred, "values"),
 			}, nil),

--- a/tempodb/encoding/vparquet/block_search_test.go
+++ b/tempodb/encoding/vparquet/block_search_test.go
@@ -398,7 +398,7 @@ func makeTraces() ([]*Trace, map[string]string) {
 func BenchmarkBackendBlockSearch(b *testing.B) {
 	ctx := context.TODO()
 	tenantID := "1"
-	blockID := uuid.MustParse("ad0cc772-5554-48d5-a60e-3a6d2f4e3e50")
+	blockID := uuid.MustParse("3685ee3d-cbbf-4f36-bf28-93447a19dea6")
 
 	r, _, _, err := local.New(&local.Config{
 		Path: path.Join("/Users/marty/src/tmp/"),
@@ -420,10 +420,14 @@ func BenchmarkBackendBlockSearch(b *testing.B) {
 		Limit: 20,
 	}
 
+	opts := defaultSearchOptions()
+	opts.StartPage = 10
+	opts.TotalPages = 10
+
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		res, err := block.Search(ctx, req, defaultSearchOptions())
+		res, err := block.Search(ctx, req, opts)
 		require.NoError(b, err)
 		fmt.Println("inspectedBytes:", humanize.Bytes(res.Metrics.InspectedBytes))
 	}

--- a/tempodb/encoding/vparquet/block_search_test.go
+++ b/tempodb/encoding/vparquet/block_search_test.go
@@ -415,7 +415,8 @@ func BenchmarkBackendBlockSearch(b *testing.B) {
 		Start: 1663849486,
 		End:   1663935886,
 		Tags: map[string]string{
-			"foo": "bar",
+			"foo":       "bar",
+			"component": "gRPC",
 		},
 		Limit: 20,
 	}


### PR DESCRIPTION
**What this PR does**:
This PR contains a variety of cpu and memory improvements for parquet iterators.  They significantly help the cases where spans partially match the given tags, but not entirely and are discarded halfway up the chain.  This scenario exercises the iterators a lot and hadn't gotten as much profiling as the other cases.  For example on real data: `foo=...` matches nothing and was performing quite well, but `foo=... && component=...` still matches nothing overall but the component tag caused a lot of churn in joining/filtering.

The changes:
* The join level for span tag-search was wrong which didn't affect accuracy but it wasn't throwing out non-matching spans as early as possible.
* Didn't realize `atomic.Value.Store()` was allocing on every call in `ColumnIterator.SeekTo()`, was replaced with a standard mutex and field.
* Patch a few places for better buffer handling.

Benchmarks for searching a stripe of pages from a real block, ~1GB.
```
name                                old time/op    new time/op    delta
BackendBlockSearch/noMatch-12          277ms ±11%     260ms ±11%     ~     (p=0.094 n=9+9)
BackendBlockSearch/partialMatch-12     3.53s ± 2%     2.56s ± 2%  -27.53%  (p=0.000 n=9+9)

name                                old alloc/op   new alloc/op   delta
BackendBlockSearch/noMatch-12         1.06GB ± 5%    1.05GB ± 3%     ~     (p=0.489 n=9+9)
BackendBlockSearch/partialMatch-12    3.30GB ± 0%    1.09GB ± 0%  -67.10%  (p=0.000 n=7+9)

name                                old allocs/op  new allocs/op  delta
BackendBlockSearch/noMatch-12           371k ± 5%      367k ± 2%     ~     (p=0.436 n=9+9)
BackendBlockSearch/partialMatch-12     14.5M ± 0%      0.4M ± 0%  -97.29%  (p=0.000 n=9+9)
```

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`