### PR TITLE
Update docker-compose examples

### DIFF
--- a/example/docker-compose/agent/agent.yaml
+++ b/example/docker-compose/agent/agent.yaml
@@ -1,7 +1,7 @@
 server:
-  http_listen_port: 12345
+  log_level: debug
 
-tempo:
+traces:
   configs:
   - name: default
     receivers:

--- a/example/docker-compose/agent/docker-compose.yaml
+++ b/example/docker-compose/agent/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
 
   # Generate fake traces...
   synthetic-load-generator:
-    image: omnition/synthetic-load-generator:1.0.25
+    image: omnition/synthetic-load-generator:1.0.29
     volumes:
       - ../shared/load-generator.json:/etc/load-generator.json
     environment:
@@ -12,10 +12,12 @@ services:
 
   # And put them in a Grafana Agent pipeline...
   agent:
-    image: grafana/agent:v0.18.2
-    command: [ "-config.file=/etc/agent.yaml" ]
+    image: grafana/agent:v0.27.1
     volumes:
       - ./agent.yaml:/etc/agent.yaml
+    entrypoint:
+     - /bin/agent
+     - -config.file=/etc/agent.yaml
 
   # To eventually offload to Tempo...
   tempo:
@@ -33,14 +35,17 @@ services:
 
   prometheus:
     image: prom/prometheus:latest
-    command: [ "--config.file=/etc/prometheus.yaml" ]
+    command:
+      - --config.file=/etc/prometheus.yaml
+      - --web.enable-remote-write-receiver
+      - --enable-feature=exemplar-storage
     volumes:
       - ../shared/prometheus.yaml:/etc/prometheus.yaml
     ports:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:8.1.6
+    image: grafana/grafana:9.1.6
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/azure/docker-compose.yaml
+++ b/example/docker-compose/azure/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
       - azurite
 
   synthetic-load-generator:
-    image: omnition/synthetic-load-generator:1.0.25
+    image: omnition/synthetic-load-generator:1.0.29
     volumes:
       - ../shared/load-generator.json:/etc/load-generator.json
     environment:
@@ -43,11 +43,13 @@ services:
       - ../shared/prometheus.yaml:/etc/prometheus.yaml
     command:
       - --config.file=/etc/prometheus.yaml
+      - --web.enable-remote-write-receiver
+      - --enable-feature=exemplar-storage
     ports:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:8.1.6
+    image: grafana/grafana:9.1.6
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/azure/tempo-azure.yaml
+++ b/example/docker-compose/azure/tempo-azure.yaml
@@ -1,3 +1,6 @@
+search_enabled: true
+metrics_generator_enabled: true
+
 server:
   http_listen_port: 3200
 
@@ -28,6 +31,17 @@ compactor:
     block_retention: 1h
     compacted_block_retention: 10m
 
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+      cluster: docker-compose
+  storage:
+    path: /tmp/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true
+
 storage:
   trace:
     backend: azure                     # backend configuration to use
@@ -46,3 +60,6 @@ storage:
     pool:
       max_workers: 100                 # worker pool determines the number of parallel requests to the object store backend
       queue_depth: 10000
+
+overrides:
+  metrics_generator_processors: [service-graphs, span-metrics]

--- a/example/docker-compose/distributed/docker-compose.yaml
+++ b/example/docker-compose/distributed/docker-compose.yaml
@@ -2,15 +2,16 @@ version: "3"
 services:
 
   distributor:
-    image: tempo:latest
+    image: grafana/tempo:latest
     command: "-target=distributor -config.file=/etc/tempo.yaml"
+    restart: always
     volumes:
       - ./tempo-distributed.yaml:/etc/tempo.yaml
     ports:
       - "3200"   # tempo
 
   ingester-0:
-    image: tempo:latest
+    image: grafana/tempo:latest
     command: "-target=ingester -config.file=/etc/tempo.yaml"
     restart: always
     volumes:
@@ -19,7 +20,7 @@ services:
       - "3200"   # tempo
 
   ingester-1:
-    image: tempo:latest
+    image: grafana/tempo:latest
     command: "-target=ingester -config.file=/etc/tempo.yaml"
     restart: always
     volumes:
@@ -28,7 +29,7 @@ services:
       - "3200"   # tempo
 
   ingester-2:
-    image: tempo:latest
+    image: grafana/tempo:latest
     command: "-target=ingester -config.file=/etc/tempo.yaml"
     restart: always
     volumes:
@@ -37,7 +38,7 @@ services:
       - "3200"   # tempo
 
   query-frontend:
-    image: tempo:latest
+    image: grafana/tempo:latest
     command: "-target=query-frontend -config.file=/etc/tempo.yaml"
     restart: always
     volumes:
@@ -46,7 +47,7 @@ services:
       - "3200:3200"   # tempo
 
   querier:
-    image: tempo:latest
+    image: grafana/tempo:latest
     command: "-target=querier -config.file=/etc/tempo.yaml"
     restart: always
     volumes:
@@ -55,7 +56,7 @@ services:
       - "3200"   # tempo
 
   compactor:
-    image: tempo:latest
+    image: grafana/tempo:latest
     command: "-target=compactor -config.file=/etc/tempo.yaml"
     restart: always
     volumes:
@@ -63,8 +64,8 @@ services:
     ports:
       - "3200"   # tempo
 
-  metrics_generator:
-    image: tempo:latest
+  metrics-generator:
+    image: grafana/tempo:latest
     command: "-target=metrics-generator -config.file=/etc/tempo.yaml"
     restart: always
     volumes:
@@ -85,7 +86,7 @@ services:
       - mkdir -p /data/tempo && minio server /data --console-address ':9001'
 
   synthetic-load-generator:
-    image: omnition/synthetic-load-generator:1.0.25
+    image: omnition/synthetic-load-generator:1.0.29
     volumes:
       - ../shared/load-generator.json:/etc/load-generator.json
     environment:
@@ -104,7 +105,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:8.3.6
+    image: grafana/grafana:9.1.6
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/distributed/grafana-datasources.yaml
+++ b/example/docker-compose/distributed/grafana-datasources.yaml
@@ -3,6 +3,7 @@ apiVersion: 1
 datasources:
 - name: Prometheus
   type: prometheus
+  uid: prometheus
   access: proxy
   orgId: 1
   url: http://prometheus:9090
@@ -11,10 +12,7 @@ datasources:
   version: 1
   editable: false
   jsonData:
-    exemplarTraceIdDestinations:
-      - datasourceUid: tempo
-        name: 'traceID'
-  uid: prometheus
+    httpMethod: GET
 - name: Tempo
   type: tempo
   access: proxy
@@ -25,7 +23,8 @@ datasources:
   version: 1
   editable: false
   apiVersion: 1
+  uid: tempo
   jsonData:
+    httpMethod: GET
     serviceMap:
       datasourceUid: prometheus
-  uid: tempo

--- a/example/docker-compose/distributed/tempo-distributed.yaml
+++ b/example/docker-compose/distributed/tempo-distributed.yaml
@@ -48,8 +48,12 @@ querier:
     frontend_address: query-frontend:9095
 
 metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+      cluster: docker-compose
   storage:
-    path: /tmp/tempo/wal
+    path: /tmp/tempo/generator/wal
     remote_write:
       - url: http://prometheus:9090/api/v1/write
         send_exemplars: true

--- a/example/docker-compose/gcs/docker-compose.yaml
+++ b/example/docker-compose/gcs/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
       - gcs
 
   gcs:
-    image: fsouza/fake-gcs-server
+    image: fsouza/fake-gcs-server:latest
     command: [ "-public-host=gcs -port=4443"]
     ports:
       - "4443:4443"
@@ -23,7 +23,7 @@ services:
       - ./gcs-data/:/data/tempo/
 
   synthetic-load-generator:
-    image: omnition/synthetic-load-generator:1.0.25
+    image: omnition/synthetic-load-generator:1.0.29
     volumes:
       - ../shared/load-generator.json:/etc/load-generator.json
     environment:
@@ -34,14 +34,17 @@ services:
 
   prometheus:
     image: prom/prometheus:latest
+    command:
+      - --config.file=/etc/prometheus.yaml
+      - --web.enable-remote-write-receiver
+      - --enable-feature=exemplar-storage
     volumes:
       - ../shared/prometheus.yaml:/etc/prometheus.yaml
-    command: --config.file=/etc/prometheus.yaml
     ports:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:8.1.6
+    image: grafana/grafana:9.1.6
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/gcs/tempo-gcs.yaml
+++ b/example/docker-compose/gcs/tempo-gcs.yaml
@@ -1,3 +1,6 @@
+search_enabled: true
+metrics_generator_enabled: true
+
 server:
   http_listen_port: 3200
 
@@ -29,6 +32,17 @@ compactor:
     compacted_block_retention: 10m
     flush_size_bytes: 5242880
 
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+      cluster: docker-compose
+  storage:
+    path: /tmp/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true
+
 storage:
   trace:
     backend: gcs                       # backend configuration to use
@@ -46,3 +60,6 @@ storage:
     pool:
       max_workers: 100                 # worker pool determines the number of parallel requests to the object store backend
       queue_depth: 10000
+
+overrides:
+  metrics_generator_processors: [service-graphs, span-metrics]

--- a/example/docker-compose/local/docker-compose.yaml
+++ b/example/docker-compose/local/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       - "9411:9411"   # zipkin
 
   synthetic-load-generator:
-    image: omnition/synthetic-load-generator:1.0.25
+    image: omnition/synthetic-load-generator:1.0.29
     volumes:
       - ../shared/load-generator.json:/etc/load-generator.json
     environment:
@@ -36,7 +36,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:8.1.6
+    image: grafana/grafana:9.1.6
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/local/tempo-local.yaml
+++ b/example/docker-compose/local/tempo-local.yaml
@@ -1,3 +1,4 @@
+search_enabled: true
 metrics_generator_enabled: true
 
 server:

--- a/example/docker-compose/loki/docker-compose.yaml
+++ b/example/docker-compose/loki/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
         loki-url: 'http://localhost:3100/loki/api/v1/push'
 
   loki:
-    image: grafana/loki:2.3.0
+    image: grafana/loki:2.6.1
     command: [ "-config.file=/etc/loki/local-config.yaml" ]
     ports:
       - "3100:3100"                                   # loki needs to be exposed so it receives logs
@@ -31,7 +31,10 @@ services:
 
   prometheus:
     image: prom/prometheus:latest
-    command: [ "--config.file=/etc/prometheus.yaml" ]
+    command:
+      - --config.file=/etc/prometheus.yaml
+      - --web.enable-remote-write-receiver
+      - --enable-feature=exemplar-storage
     volumes:
       - ../shared/prometheus.yaml:/etc/prometheus.yaml
     ports:
@@ -42,7 +45,7 @@ services:
         loki-url: 'http://localhost:3100/loki/api/v1/push'
 
   grafana:
-    image: grafana/grafana:8.1.6
+    image: grafana/grafana:9.1.6
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/loki/grafana-datasources.yaml
+++ b/example/docker-compose/loki/grafana-datasources.yaml
@@ -3,6 +3,7 @@ apiVersion: 1
 datasources:
 - name: Prometheus
   type: prometheus
+  uid: prometheus
   access: proxy
   orgId: 1
   url: http://prometheus:9090
@@ -10,6 +11,8 @@ datasources:
   isDefault: false
   version: 1
   editable: false
+  jsonData:
+    httpMethod: GET
 - name: Tempo
   type: tempo
   access: proxy
@@ -21,6 +24,10 @@ datasources:
   editable: false
   apiVersion: 1
   uid: tempo
+  jsonData:
+    httpMethod: GET
+    serviceMap:
+      datasourceUid: prometheus
 - name: Loki
   type: loki
   access: proxy

--- a/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
+++ b/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
 
   # Generate fake traces...
   synthetic-load-generator:
-    image: omnition/synthetic-load-generator:1.0.25
+    image: omnition/synthetic-load-generator:1.0.29
     volumes:
       - ../shared/load-generator.json:/etc/load-generator.json
     environment:
@@ -12,7 +12,7 @@ services:
 
   # And put them in an OTEL collector pipeline...
   otel-collector:
-    image: otel/opentelemetry-collector:0.32.0
+    image: otel/opentelemetry-collector:0.61.0
     command: [ "--config=/etc/otel-collector.yaml" ]
     volumes:
       - ./otel-collector.multitenant.yaml:/etc/otel-collector.yaml
@@ -33,14 +33,17 @@ services:
 
   prometheus:
     image: prom/prometheus:latest
-    command: [ "--config.file=/etc/prometheus.yaml" ]
+    command: 
+      - --config.file=/etc/prometheus.yaml
+      - --web.enable-remote-write-receiver
+      - --enable-feature=exemplar-storage
     volumes:
       - ../shared/prometheus.yaml:/etc/prometheus.yaml
     ports:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:8.1.6
+    image: grafana/grafana:9.1.6
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/otel-collector-multitenant/grafana-datasources.yaml
+++ b/example/docker-compose/otel-collector-multitenant/grafana-datasources.yaml
@@ -3,6 +3,7 @@ apiVersion: 1
 datasources:
 - name: Prometheus
   type: prometheus
+  uid: prometheus
   access: proxy
   orgId: 1
   url: http://prometheus:9090
@@ -10,6 +11,8 @@ datasources:
   isDefault: false
   version: 1
   editable: false
+  jsonData:
+    httpMethod: GET
 - name: Tempo-Multitenant
   type: tempo
   access: proxy
@@ -23,5 +26,8 @@ datasources:
   uid: tempo-authed
   jsonData:
     httpHeaderName1: 'X-Scope-OrgID'
+    httpMethod: GET
+    serviceMap:
+      datasourceUid: prometheus
   secureJsonData:
     httpHeaderValue1: 'foo-bar-baz'

--- a/example/docker-compose/otel-collector-multitenant/otel-collector.multitenant.yaml
+++ b/example/docker-compose/otel-collector-multitenant/otel-collector.multitenant.yaml
@@ -5,7 +5,8 @@ receivers:
 exporters:
   otlp:
     endpoint: tempo:4317
-    insecure: true
+    tls:
+      insecure: true
     headers:
       x-scope-orgid: foo-bar-baz
 service:

--- a/example/docker-compose/otel-collector/docker-compose.yaml
+++ b/example/docker-compose/otel-collector/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
 
   # Generate fake traces...
   synthetic-load-generator:
-    image: omnition/synthetic-load-generator:1.0.25
+    image: omnition/synthetic-load-generator:1.0.29
     volumes:
       - ../shared/load-generator.json:/etc/load-generator.json
     environment:
@@ -12,7 +12,7 @@ services:
 
   # And put them in an OTEL collector pipeline...
   otel-collector:
-    image: otel/opentelemetry-collector:0.32.0
+    image: otel/opentelemetry-collector:0.61.0
     command: [ "--config=/etc/otel-collector.yaml" ]
     volumes:
       - ./otel-collector.yaml:/etc/otel-collector.yaml
@@ -33,14 +33,17 @@ services:
 
   prometheus:
     image: prom/prometheus:latest
-    command: [ "--config.file=/etc/prometheus.yaml" ]
+    command:
+      - --config.file=/etc/prometheus.yaml
+      - --web.enable-remote-write-receiver
+      - --enable-feature=exemplar-storage
     volumes:
       - ../shared/prometheus.yaml:/etc/prometheus.yaml
     ports:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:8.1.6
+    image: grafana/grafana:9.1.6
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/otel-collector/otel-collector.yaml
+++ b/example/docker-compose/otel-collector/otel-collector.yaml
@@ -5,7 +5,8 @@ receivers:
 exporters:
   otlp:
     endpoint: tempo:4317
-    insecure: true
+    tls:
+      insecure: true
 service:
   pipelines:
     traces:

--- a/example/docker-compose/s3/docker-compose.yaml
+++ b/example/docker-compose/s3/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
       - mkdir -p /data/tempo && /opt/bin/minio server /data --console-address ':9001'
 
   synthetic-load-generator:
-    image: omnition/synthetic-load-generator:1.0.25
+    image: omnition/synthetic-load-generator:1.0.29
     volumes:
       - ../shared/load-generator.json:/etc/load-generator.json
     environment:
@@ -38,14 +38,17 @@ services:
 
   prometheus:
     image: prom/prometheus:latest
-    command: [ "--config.file=/etc/prometheus.yaml" ]
+    command:
+      - --config.file=/etc/prometheus.yaml
+      - --web.enable-remote-write-receiver
+      - --enable-feature=exemplar-storage
     volumes:
       - ../shared/prometheus.yaml:/etc/prometheus.yaml
     ports:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:8.1.6
+    image: grafana/grafana:9.1.6
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/s3/tempo-s3.yaml
+++ b/example/docker-compose/s3/tempo-s3.yaml
@@ -1,3 +1,6 @@
+search_enabled: true
+metrics_generator_enabled: true
+
 server:
   http_listen_port: 3200
 
@@ -29,6 +32,17 @@ compactor:
     compacted_block_retention: 10m
     flush_size_bytes: 5242880
 
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+      cluster: docker-compose
+  storage:
+    path: /tmp/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true
+
 storage:
   trace:
     backend: s3                        # backend configuration to use
@@ -51,3 +65,6 @@ storage:
     pool:
       max_workers: 100                 # worker pool determines the number of parallel requests to the object store backend
       queue_depth: 10000
+
+overrides:
+  metrics_generator_processors: [service-graphs, span-metrics]

--- a/example/docker-compose/scalable-single-binary/docker-compose.yaml
+++ b/example/docker-compose/scalable-single-binary/docker-compose.yaml
@@ -52,12 +52,15 @@ services:
 
   prometheus:
     image: prom/prometheus:latest
-    command: [ "--config.file=/etc/prometheus.yaml" ]
+    command:
+      - --config.file=/etc/prometheus.yaml
+      - --web.enable-remote-write-receiver
+      - --enable-feature=exemplar-storage
     volumes:
       - ./prometheus.yaml:/etc/prometheus.yaml
 
   grafana:
-    image: grafana/grafana:8.1.6
+    image: grafana/grafana:9.1.6
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:
@@ -80,7 +83,7 @@ services:
       - 9001:9001
 
   synthetic-load-generator:
-    image: omnition/synthetic-load-generator:1.0.25
+    image: omnition/synthetic-load-generator:1.0.29
     volumes:
       - ../shared/load-generator.json:/etc/load-generator.json
     environment:

--- a/example/docker-compose/scalable-single-binary/grafana-datasources.yaml
+++ b/example/docker-compose/scalable-single-binary/grafana-datasources.yaml
@@ -3,6 +3,7 @@ apiVersion: 1
 datasources:
 - name: Prometheus
   type: prometheus
+  uid: prometheus
   access: proxy
   orgId: 1
   url: http://prometheus:9090
@@ -10,6 +11,8 @@ datasources:
   isDefault: false
   version: 1
   editable: false
+  jsonData:
+    httpMethod: GET
 - name: Tempo
   type: tempo
   access: proxy
@@ -21,3 +24,7 @@ datasources:
   editable: false
   apiVersion: 1
   uid: tempo
+  jsonData:
+    httpMethod: GET
+    serviceMap:
+      datasourceUid: prometheus

--- a/example/docker-compose/scalable-single-binary/prometheus.yaml
+++ b/example/docker-compose/scalable-single-binary/prometheus.yaml
@@ -8,11 +8,10 @@ scrape_configs:
       - targets: [ 'localhost:9090' ]
   - job_name: 'tempo'
     static_configs:
-      - targets: [
-        'tempo1:3200',
-        'tempo2:3200',
-        'tempo3:3200',
-      ]
+      - targets:
+        - 'tempo1:3200'
+        - 'tempo2:3200'
+        - 'tempo3:3200'
   - job_name: 'vulture'
     static_configs:
       - targets: [ 'vulture:3201' ]

--- a/example/docker-compose/scalable-single-binary/tempo-scalable-single-binary.yaml
+++ b/example/docker-compose/scalable-single-binary/tempo-scalable-single-binary.yaml
@@ -1,7 +1,8 @@
+search_enabled: true
+metrics_generator_enabled: true
+
 server:
   http_listen_port: 3200
-
-search_enabled: true
 
 distributor:
   receivers:                           # this configuration will listen on all ports and protocols that tempo is capable of.
@@ -47,6 +48,17 @@ memberlist:
   - tempo2:7946
   - tempo3:7946
 
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+      cluster: docker-compose
+  storage:
+    path: /tmp/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true
+
 storage:
   trace:
     backend: s3                        # backend configuration to use
@@ -73,3 +85,6 @@ storage:
 querier:
   frontend_worker:
     frontend_address: tempo:9095
+
+overrides:
+  metrics_generator_processors: ['service-graphs', 'span-metrics']

--- a/example/docker-compose/shared/grafana-datasources.yaml
+++ b/example/docker-compose/shared/grafana-datasources.yaml
@@ -3,6 +3,7 @@ apiVersion: 1
 datasources:
 - name: Prometheus
   type: prometheus
+  uid: prometheus
   access: proxy
   orgId: 1
   url: http://prometheus:9090
@@ -10,6 +11,8 @@ datasources:
   isDefault: false
   version: 1
   editable: false
+  jsonData:
+    httpMethod: GET
 - name: Tempo
   type: tempo
   access: proxy
@@ -21,3 +24,7 @@ datasources:
   editable: false
   apiVersion: 1
   uid: tempo
+  jsonData:
+    httpMethod: GET
+    serviceMap:
+      datasourceUid: prometheus


### PR DESCRIPTION
**What this PR does**:
Update all docker-compose examples:
* Update versions of components with pinned versions
* Enable backend search, metrics generation and service graphs

*Note on service graphs:* the respective examples are configured such, that service graphs should work correctly. However, the traces generated by the load generator do not comply with [otel semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/README.md) and therefore service graphs do not show in the UI. This might be fixed along with  grafana/tempo#902. 

**Which issue(s) this PR fixes**:
Fixes grafana/tempo-squad#136

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`