### PR TITLE
Fix nil pointer panic

### DIFF
--- a/tempodb/encoding/vparquet/block_search.go
+++ b/tempodb/encoding/vparquet/block_search.go
@@ -574,7 +574,7 @@ func (r *rowNumberIterator) Next() (*pq.IteratorResult, error) {
 func (r *rowNumberIterator) SeekTo(to pq.RowNumber, definitionLevel int) (*pq.IteratorResult, error) {
 	var at *pq.IteratorResult
 
-	for at, _ = r.Next(); r != nil && pq.CompareRowNumbers(definitionLevel, at.RowNumber, to) < 0; {
+	for at, _ = r.Next(); r != nil && at != nil && pq.CompareRowNumbers(definitionLevel, at.RowNumber, to) < 0; {
 		at, _ = r.Next()
 	}
 


### PR DESCRIPTION
**What this PR does**:
This PR https://github.com/grafana/tempo/pull/1759 occasionally panics due to a nil pointer dereference:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x13a1122]

goroutine 56643 [running]:
github.com/grafana/tempo/tempodb/encoding/vparquet.(*rowNumberIterator).SeekTo(0xc08e0f8f48, {0x7d0, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff}, 0x0)
	/drone/src/tempodb/encoding/vparquet/block_search.go:577 +0xe2
github.com/grafana/tempo/pkg/parquetquery.(*JoinIterator).seekAll(0xc0660b1a50, {0x7d0, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff}, 0x0)
	/drone/src/pkg/parquetquery/iters.go:636 +0x2a6
github.com/grafana/tempo/pkg/parquetquery.(*JoinIterator).Next(0xc0660b1a50)
	/drone/src/pkg/parquetquery/iters.go:615 +0x1ab
github.com/grafana/tempo/tempodb/encoding/vparquet.rawToResults({0x2586ea8?, 0xc084340750?}, 0xc088138210?, {0xc084341d10?, 0xc084341d10?, 0x0?}, {0xc1064c00c0, 0x4, 0x4})
	/drone/src/tempodb/encoding/vparquet/block_search.go:458 +0x4e5
github.com/grafana/tempo/tempodb/encoding/vparquet.searchParquetFile({0x2586ea8, 0xc084340750}, 0x0?, 0x0?, {0xc084341d10, 0x3, 0x3})
	/drone/src/tempodb/encoding/vparquet/block_search.go:406 +0xfc
github.com/grafana/tempo/tempodb/encoding/vparquet.(*backendBlock).Search(0xc0c8c7f3e0, {0x2586ea8, 0xc084340690}, 0x361cad8?, {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...})
	/drone/src/tempodb/encoding/vparquet/block_search.go:107 +0x4d4
github.com/grafana/tempo/modules/ingester.(*instance).searchLocalBlocks.func2(0xc0a99d2900)
	/drone/src/modules/ingester/instance_search.go:216 +0x2d5
created by github.com/grafana/tempo/modules/ingester.(*instance).searchLocalBlocks
	/drone/src/modules/ingester/instance_search.go:205 +0x459
```

This PR protects against nil panic by checking `at`