### PR TITLE
Parquet Ingester/Compactor memory improvements

### DIFF
--- a/cmd/tempo-cli/cmd-query-search.go
+++ b/cmd/tempo-cli/cmd-query-search.go
@@ -21,41 +21,33 @@ func (cmd *querySearchCmd) Run(_ *globalOptions) error {
 
 	var start, end int64
 
-	// if cmd.Start != "" {
-	// 	startDate, err := time.Parse(time.RFC3339, cmd.Start)
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// 	start = startDate.Unix()
-	// }
-
-	// if cmd.End != "" {
-	// 	endDate, err := time.Parse(time.RFC3339, cmd.End)
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// 	end = endDate.Unix()
-	// }
-
-	for {
-		start = time.Now().Add(-15 * time.Minute).Unix()
-		end = time.Now().Unix()
-
-		var tagValues *tempopb.SearchResponse
-		var err error
-		if start == 0 && end == 0 {
-			tagValues, err = client.Search(cmd.Tags)
-		} else {
-			tagValues, err = client.SearchWithRange(cmd.Tags, start, end)
-		}
-
+	if cmd.Start != "" {
+		startDate, err := time.Parse(time.RFC3339, cmd.Start)
 		if err != nil {
 			return err
 		}
-
-		printAsJSON(tagValues)
-
-		time.Sleep(500 * time.Millisecond)
+		start = startDate.Unix()
 	}
 
+	if cmd.End != "" {
+		endDate, err := time.Parse(time.RFC3339, cmd.End)
+		if err != nil {
+			return err
+		}
+		end = endDate.Unix()
+	}
+
+	var tagValues *tempopb.SearchResponse
+	var err error
+	if start == 0 && end == 0 {
+		tagValues, err = client.Search(cmd.Tags)
+	} else {
+		tagValues, err = client.SearchWithRange(cmd.Tags, start, end)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return printAsJSON(tagValues)
 }

--- a/cmd/tempo-cli/cmd-query-search.go
+++ b/cmd/tempo-cli/cmd-query-search.go
@@ -21,33 +21,41 @@ func (cmd *querySearchCmd) Run(_ *globalOptions) error {
 
 	var start, end int64
 
-	if cmd.Start != "" {
-		startDate, err := time.Parse(time.RFC3339, cmd.Start)
+	// if cmd.Start != "" {
+	// 	startDate, err := time.Parse(time.RFC3339, cmd.Start)
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// 	start = startDate.Unix()
+	// }
+
+	// if cmd.End != "" {
+	// 	endDate, err := time.Parse(time.RFC3339, cmd.End)
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// 	end = endDate.Unix()
+	// }
+
+	for {
+		start = time.Now().Add(-15 * time.Minute).Unix()
+		end = time.Now().Unix()
+
+		var tagValues *tempopb.SearchResponse
+		var err error
+		if start == 0 && end == 0 {
+			tagValues, err = client.Search(cmd.Tags)
+		} else {
+			tagValues, err = client.SearchWithRange(cmd.Tags, start, end)
+		}
+
 		if err != nil {
 			return err
 		}
-		start = startDate.Unix()
+
+		printAsJSON(tagValues)
+
+		time.Sleep(500 * time.Millisecond)
 	}
 
-	if cmd.End != "" {
-		endDate, err := time.Parse(time.RFC3339, cmd.End)
-		if err != nil {
-			return err
-		}
-		end = endDate.Unix()
-	}
-
-	var tagValues *tempopb.SearchResponse
-	var err error
-	if start == 0 && end == 0 {
-		tagValues, err = client.Search(cmd.Tags)
-	} else {
-		tagValues, err = client.SearchWithRange(cmd.Tags, start, end)
-	}
-
-	if err != nil {
-		return err
-	}
-
-	return printAsJSON(tagValues)
 }

--- a/pkg/tempopb/prealloc.go
+++ b/pkg/tempopb/prealloc.go
@@ -1,8 +1,6 @@
 package tempopb
 
-import (
-	"github.com/grafana/tempo/pkg/tempopb/pool"
-)
+import "github.com/grafana/tempo/pkg/tempopb/pool"
 
 var (
 	// buckets: [0.5KiB, 1KiB, 2KiB, 4KiB, 8KiB, 16KiB]
@@ -42,9 +40,4 @@ func ReuseByteSlices(buffs [][]byte) {
 	for _, b := range buffs {
 		bytePool.Put(b[:0])
 	}
-}
-
-// SliceFromBytePool gets a slice from the byte pool
-func SliceFromBytePool(size int) []byte {
-	return bytePool.Get(size)[:size]
 }

--- a/tempodb/encoding/v2/append_block.go
+++ b/tempodb/encoding/v2/append_block.go
@@ -182,15 +182,7 @@ func (a *v2AppendBlock) Iterator() (common.Iterator, error) {
 		return nil, err
 	}
 
-	dec, err := model.NewObjectDecoder(a.meta.DataEncoding)
-	if err != nil {
-		return nil, fmt.Errorf("creating object decoder: %w", err)
-	}
-
-	return &commonIterator{
-		iter: iterator,
-		dec:  dec,
-	}, nil
+	return iterator.(*dedupingIterator), nil
 }
 
 func (a *v2AppendBlock) Clear() error {
@@ -359,36 +351,4 @@ func ParseFilename(filename string) (uuid.UUID, string, string, backend.Encoding
 	}
 
 	return id, tenant, version, encoding, dataEncoding, nil
-}
-
-var _ BytesIterator = (*commonIterator)(nil)
-var _ common.Iterator = (*commonIterator)(nil)
-
-// commonIterator implements both BytesIterator and common.Iterator. it is returned from the AppendFile and is meant
-// to be passed to a CreateBlock
-type commonIterator struct {
-	iter BytesIterator
-	dec  model.ObjectDecoder
-}
-
-func (i *commonIterator) Next(ctx context.Context) (common.ID, *tempopb.Trace, error) {
-	id, obj, err := i.iter.NextBytes(ctx)
-	if err != nil || obj == nil {
-		return id, nil, err
-	}
-
-	tr, err := i.dec.PrepareForRead(obj)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return id, tr, nil
-}
-
-func (i *commonIterator) NextBytes(ctx context.Context) (common.ID, []byte, error) {
-	return i.iter.NextBytes(ctx)
-}
-
-func (i *commonIterator) Close() {
-	i.iter.Close()
 }

--- a/tempodb/encoding/v2/iterator_deduping.go
+++ b/tempodb/encoding/v2/iterator_deduping.go
@@ -24,6 +24,7 @@ type dedupingIterator struct {
 // NewDedupingIterator returns a dedupingIterator.  This iterator is used to wrap another
 // iterator.  It will dedupe consecutive objects with the same id using the ObjectCombiner.
 func NewDedupingIterator(iter BytesIterator, combiner model.ObjectCombiner, dataEncoding string) (BytesIterator, error) {
+	// jpe fix this
 	decoder, err := model.NewObjectDecoder(dataEncoding)
 	if err != nil {
 		return nil, err

--- a/tempodb/encoding/vparquet/block_findtracebyid_test.go
+++ b/tempodb/encoding/vparquet/block_findtracebyid_test.go
@@ -80,7 +80,8 @@ func TestBackendBlockFindTraceByID(t *testing.T) {
 	// Write test data, occasionally flushing (cutting new row group)
 	rowGroupSize := 5
 	for _, tr := range traces {
-		s.Add(tr, 0, 0)
+		err := s.Add(tr, 0, 0)
+		require.NoError(t, err)
 		if s.CurrentBufferedObjects() >= rowGroupSize {
 			_, err = s.Flush()
 			require.NoError(t, err)

--- a/tempodb/encoding/vparquet/block_search_test.go
+++ b/tempodb/encoding/vparquet/block_search_test.go
@@ -280,7 +280,8 @@ func makeBackendBlockWithTraces(t *testing.T, trs []*Trace) *backendBlock {
 	s := newStreamingBlock(ctx, cfg, meta, r, w, tempo_io.NewBufferedWriter)
 
 	for i, tr := range trs {
-		s.Add(tr, 0, 0)
+		err = s.Add(tr, 0, 0)
+		require.NoError(t, err)
 		if i%100 == 0 {
 			_, err := s.Flush()
 			require.NoError(t, err)

--- a/tempodb/encoding/vparquet/block_search_test.go
+++ b/tempodb/encoding/vparquet/block_search_test.go
@@ -85,8 +85,8 @@ func TestBackendBlockSearch(t *testing.T) {
 
 		id := test.ValidTraceID(nil)
 		pbTrace := test.MakeTrace(10, id)
-		pqTrace := traceToParquet(id, pbTrace)
-		allTraces = append(allTraces, &pqTrace)
+		pqTrace := traceToParquet(id, pbTrace, nil)
+		allTraces = append(allTraces, pqTrace)
 	}
 
 	b := makeBackendBlockWithTraces(t, allTraces)

--- a/tempodb/encoding/vparquet/combiner_test.go
+++ b/tempodb/encoding/vparquet/combiner_test.go
@@ -151,17 +151,17 @@ func BenchmarkCombine(b *testing.B) {
 	for _, spanCount := range spanCounts {
 		b.Run("SpanCount:"+humanize.SI(float64(batchCount*spanCount), ""), func(b *testing.B) {
 			id1 := test.ValidTraceID(nil)
-			tr1 := traceToParquet(id1, test.MakeTraceWithSpanCount(batchCount, spanCount, id1))
+			tr1 := traceToParquet(id1, test.MakeTraceWithSpanCount(batchCount, spanCount, id1), nil)
 
 			id2 := test.ValidTraceID(nil)
-			tr2 := traceToParquet(id2, test.MakeTraceWithSpanCount(batchCount, spanCount, id2))
+			tr2 := traceToParquet(id2, test.MakeTraceWithSpanCount(batchCount, spanCount, id2), nil)
 
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
 				c := NewCombiner()
-				c.ConsumeWithFinal(&tr1, false)
-				c.ConsumeWithFinal(&tr2, true)
+				c.ConsumeWithFinal(tr1, false)
+				c.ConsumeWithFinal(tr2, true)
 				c.Result()
 			}
 		})
@@ -179,12 +179,12 @@ func BenchmarkSortTrace(b *testing.B) {
 		b.Run("SpanCount:"+humanize.SI(float64(batchCount*spanCount), ""), func(b *testing.B) {
 
 			id := test.ValidTraceID(nil)
-			tr := traceToParquet(id, test.MakeTraceWithSpanCount(batchCount, spanCount, id))
+			tr := traceToParquet(id, test.MakeTraceWithSpanCount(batchCount, spanCount, id), nil)
 
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
-				SortTrace(&tr)
+				SortTrace(tr)
 			}
 		})
 	}

--- a/tempodb/encoding/vparquet/compactor_test.go
+++ b/tempodb/encoding/vparquet/compactor_test.go
@@ -125,7 +125,8 @@ func createTestBlock(t testing.TB, ctx context.Context, cfg *common.BlockConfig,
 		tr := test.MakeTraceWithSpanCount(batchCount, spanCount, id)
 		trp := traceToParquet(id, tr, nil)
 
-		sb.Add(trp, 0, 0)
+		err := sb.Add(trp, 0, 0)
+		require.NoError(t, err)
 		if sb.EstimatedBufferedBytes() > 20_000_000 {
 			_, err := sb.Flush()
 			require.NoError(t, err)

--- a/tempodb/encoding/vparquet/compactor_test.go
+++ b/tempodb/encoding/vparquet/compactor_test.go
@@ -3,7 +3,6 @@ package vparquet
 import (
 	"context"
 	"encoding/binary"
-	"fmt"
 	"time"
 
 	"testing"
@@ -56,7 +55,6 @@ func benchmarkCompactor(b *testing.B, traceCount, batchCount, spanCount int) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		fmt.Println(b.N)
 		c := NewCompactor(common.CompactionOptions{
 			BlockConfig:      *cfg,
 			OutputBlocks:     1,
@@ -125,9 +123,9 @@ func createTestBlock(t testing.TB, ctx context.Context, cfg *common.BlockConfig,
 		binary.LittleEndian.PutUint64(id, uint64(i))
 
 		tr := test.MakeTraceWithSpanCount(batchCount, spanCount, id)
-		trp := traceToParquet(id, tr)
+		trp := traceToParquet(id, tr, nil)
 
-		sb.Add(&trp, 0, 0)
+		sb.Add(trp, 0, 0)
 		if sb.EstimatedBufferedBytes() > 20_000_000 {
 			_, err := sb.Flush()
 			require.NoError(t, err)

--- a/tempodb/encoding/vparquet/create.go
+++ b/tempodb/encoding/vparquet/create.go
@@ -3,7 +3,6 @@ package vparquet
 import (
 	"context"
 	"encoding/binary"
-	"fmt"
 	"io"
 
 	"github.com/google/uuid"
@@ -48,7 +47,10 @@ func CreateBlock(ctx context.Context, cfg *common.BlockConfig, meta *backend.Blo
 		id = append([]byte(nil), id...)
 
 		trp = traceToParquet(id, tr, trp)
-		s.Add(trp, 0, 0) // start and end time of the wal meta are used.
+		err = s.Add(trp, 0, 0) // start and end time of the wal meta are used.
+		if err != nil {
+			return nil, err
+		}
 
 		// Here we repurpose RowGroupSizeBytes as number of raw column values.
 		// This is a fairly close approximation.
@@ -78,7 +80,6 @@ type streamingBlock struct {
 	r     backend.Reader
 	to    backend.Writer
 
-	bufferedTraces        []*Trace
 	currentBufferedTraces int
 	currentBufferedBytes  int
 }
@@ -97,26 +98,30 @@ func newStreamingBlock(ctx context.Context, cfg *common.BlockConfig, meta *backe
 	pw := parquet.NewGenericWriter[*Trace](bw)
 
 	return &streamingBlock{
-		ctx:            ctx,
-		meta:           newMeta,
-		bloom:          bloom,
-		bw:             bw,
-		pw:             pw,
-		w:              w,
-		r:              r,
-		to:             to,
-		bufferedTraces: make([]*Trace, 0, 1000),
+		ctx:   ctx,
+		meta:  newMeta,
+		bloom: bloom,
+		bw:    bw,
+		pw:    pw,
+		w:     w,
+		r:     r,
+		to:    to,
 	}
 }
 
-func (b *streamingBlock) Add(tr *Trace, start, end uint32) {
-	b.pw.Write([]*Trace{tr})
+func (b *streamingBlock) Add(tr *Trace, start, end uint32) error {
+	_, err := b.pw.Write([]*Trace{tr})
+	if err != nil {
+		return err
+	}
 	id := tr.TraceID
 
 	b.bloom.Add(id)
 	b.meta.ObjectAdded(id, start, end)
 	b.currentBufferedTraces++
 	b.currentBufferedBytes += estimateTraceSize(tr)
+
+	return nil
 }
 
 func (b *streamingBlock) AddRaw(id []byte, row parquet.Row, start, end uint32) error {
@@ -142,11 +147,6 @@ func (b *streamingBlock) CurrentBufferedObjects() int {
 }
 
 func (b *streamingBlock) Flush() (int, error) {
-	// batch write traces
-	if err := b.flushBufferedTraces(); err != nil {
-		return 0, fmt.Errorf("flushing buffered traces: %w", err)
-	}
-
 	// Flush row group
 	err := b.pw.Flush()
 	if err != nil {
@@ -164,11 +164,6 @@ func (b *streamingBlock) Flush() (int, error) {
 }
 
 func (b *streamingBlock) Complete() (int, error) {
-	// batch write traces
-	if err := b.flushBufferedTraces(); err != nil {
-		return 0, fmt.Errorf("flushing buffered traces: %w", err)
-	}
-
 	// Flush final row group
 	b.meta.TotalRecords++
 	err := b.pw.Flush()
@@ -214,23 +209,6 @@ func (b *streamingBlock) Complete() (int, error) {
 	b.meta.BloomShardCount = uint16(b.bloom.GetShardCount())
 
 	return n, writeBlockMeta(b.ctx, b.to, b.meta, b.bloom)
-}
-
-func (b *streamingBlock) flushBufferedTraces() error {
-	// batch write traces
-	if len(b.bufferedTraces) > 0 {
-		_, err := b.pw.Write(b.bufferedTraces)
-		if err != nil {
-			return err
-		}
-		// zero out traces to allow the GC to collect
-		for i := range b.bufferedTraces {
-			b.bufferedTraces[i] = nil
-		}
-		b.bufferedTraces = b.bufferedTraces[:0]
-	}
-
-	return nil
 }
 
 // estimateTraceSize attempts to estimate the size of trace in bytes. This is used to make choose

--- a/tempodb/encoding/vparquet/schema_test.go
+++ b/tempodb/encoding/vparquet/schema_test.go
@@ -15,16 +15,14 @@ import (
 	v1_resource "github.com/grafana/tempo/pkg/tempopb/resource/v1"
 	v1_trace "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	"github.com/grafana/tempo/pkg/util/test"
-	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
 func TestProtoParquetRoundTrip(t *testing.T) {
-
 	// This test round trips a proto trace and checks that the transformation works as expected
 	// Proto -> Parquet -> Proto
 
 	traceIDA := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}
-	expectedTrace := allFieldsTrace(traceIDA)
+	expectedTrace := parquetTraceToTempopbTrace(fullyPopulatedTestTrace(traceIDA))
 
 	parquetTrace := traceToParquet(traceIDA, expectedTrace, nil)
 	actualTrace := parquetTraceToTempopbTrace(parquetTrace)
@@ -56,7 +54,7 @@ func TestProtoParquetRando(t *testing.T) {
 
 func TestFieldsAreCleared(t *testing.T) {
 	traceID := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}
-	complexTrace := allFieldsTrace(traceID)
+	complexTrace := parquetTraceToTempopbTrace(fullyPopulatedTestTrace(traceID))
 	simpleTrace := &tempopb.Trace{
 		Batches: []*v1_trace.ResourceSpans{
 			{
@@ -104,192 +102,6 @@ func TestFieldsAreCleared(t *testing.T) {
 	parqTr := traceToParquet(traceID, simpleTrace, tr)
 	actualTrace := parquetTraceToTempopbTrace(parqTr)
 	require.Equal(t, simpleTrace, actualTrace)
-}
-
-func allFieldsTrace(id common.ID) *tempopb.Trace {
-	return &tempopb.Trace{
-		Batches: []*v1_trace.ResourceSpans{
-			{
-				Resource: &v1_resource.Resource{
-					Attributes: []*v1.KeyValue{
-						{
-							Key: "rs.string.key",
-							Value: &v1.AnyValue{
-								Value: &v1.AnyValue_StringValue{StringValue: "foo"},
-							},
-						},
-						{
-							Key: "rs.int.key",
-							Value: &v1.AnyValue{
-								Value: &v1.AnyValue_IntValue{IntValue: 1},
-							},
-						},
-						{
-							Key: "rs.bool.key",
-							Value: &v1.AnyValue{
-								Value: &v1.AnyValue_BoolValue{BoolValue: true},
-							},
-						},
-						{
-							Key: "rs.kv.key",
-							Value: &v1.AnyValue{Value: &v1.AnyValue_KvlistValue{KvlistValue: &v1.KeyValueList{Values: []*v1.KeyValue{
-								{Key: "s2", Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "s3"}}},
-								{Key: "i2", Value: &v1.AnyValue{Value: &v1.AnyValue_IntValue{IntValue: 789}}},
-							}}}},
-						},
-						{ // special columns
-							Key: "service.name",
-							Value: &v1.AnyValue{
-								Value: &v1.AnyValue_StringValue{StringValue: "bar"},
-							},
-						},
-						{
-							Key: "cluster",
-							Value: &v1.AnyValue{
-								Value: &v1.AnyValue_StringValue{StringValue: "clust"},
-							},
-						},
-						{
-							Key: "namespace",
-							Value: &v1.AnyValue{
-								Value: &v1.AnyValue_StringValue{StringValue: "ns"},
-							},
-						},
-						{
-							Key: "pod",
-							Value: &v1.AnyValue{
-								Value: &v1.AnyValue_StringValue{StringValue: "po"},
-							},
-						},
-						{
-							Key: "container",
-							Value: &v1.AnyValue{
-								Value: &v1.AnyValue_StringValue{StringValue: "container"},
-							},
-						},
-						{
-							Key: "k8s.cluster.name",
-							Value: &v1.AnyValue{
-								Value: &v1.AnyValue_StringValue{StringValue: "k8sclust"},
-							},
-						},
-						{
-							Key: "k8s.namespace.name",
-							Value: &v1.AnyValue{
-								Value: &v1.AnyValue_StringValue{StringValue: "k8sns"},
-							},
-						},
-						{
-							Key: "k8s.pod.name",
-							Value: &v1.AnyValue{
-								Value: &v1.AnyValue_StringValue{StringValue: "k8spo"},
-							},
-						},
-						{
-							Key: "k8s.container.name",
-							Value: &v1.AnyValue{
-								Value: &v1.AnyValue_StringValue{StringValue: "k8scontainer"},
-							},
-						},
-					},
-				},
-				ScopeSpans: []*v1_trace.ScopeSpans{
-					{
-						Scope: &v1.InstrumentationScope{
-							Name:    "test",
-							Version: "1.1",
-						},
-						Spans: []*v1_trace.Span{
-							{
-								TraceId: id,
-								SpanId:  []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
-								Name:    "firstSpan",
-								Kind:    v1_trace.Span_SPAN_KIND_CLIENT,
-								Status: &v1_trace.Status{
-									Code: v1_trace.Status_STATUS_CODE_OK,
-								},
-								Attributes: []*v1.KeyValue{
-									{
-										Key: "span.int.key",
-										Value: &v1.AnyValue{
-											Value: &v1.AnyValue_IntValue{IntValue: 100},
-										},
-									},
-									{
-										Key: "span.bool.key",
-										Value: &v1.AnyValue{
-											Value: &v1.AnyValue_BoolValue{BoolValue: true},
-										},
-									},
-									{ // special columns
-										Key: "http.method",
-										Value: &v1.AnyValue{
-											Value: &v1.AnyValue_StringValue{StringValue: "GET"},
-										},
-									},
-									{
-										Key: "http.url",
-										Value: &v1.AnyValue{
-											Value: &v1.AnyValue_StringValue{StringValue: "https://grafana.com"},
-										},
-									},
-									{
-										Key: "http.status_code",
-										Value: &v1.AnyValue{
-											Value: &v1.AnyValue_IntValue{IntValue: 200},
-										},
-									},
-								},
-								Events: []*v1_trace.Span_Event{
-									{
-										// Basic fields
-										TimeUnixNano:           123,
-										Name:                   "456",
-										DroppedAttributesCount: 789,
-
-										// An attribute of every type
-										Attributes: []*v1.KeyValue{
-											// String
-											{Key: "s", Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "s2"}}},
-
-											// Int
-											{Key: "i", Value: &v1.AnyValue{Value: &v1.AnyValue_IntValue{IntValue: 123}}},
-
-											// Double
-											{Key: "d", Value: &v1.AnyValue{Value: &v1.AnyValue_DoubleValue{DoubleValue: 123.456}}},
-
-											// Bool
-											{Key: "b", Value: &v1.AnyValue{Value: &v1.AnyValue_BoolValue{BoolValue: true}}},
-
-											// KVList
-											{Key: "kv", Value: &v1.AnyValue{Value: &v1.AnyValue_KvlistValue{KvlistValue: &v1.KeyValueList{Values: []*v1.KeyValue{
-												{Key: "s2", Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "s3"}}},
-												{Key: "i2", Value: &v1.AnyValue{Value: &v1.AnyValue_IntValue{IntValue: 789}}},
-											}}}}},
-
-											// Array
-											{Key: "a", Value: &v1.AnyValue{Value: &v1.AnyValue_ArrayValue{ArrayValue: &v1.ArrayValue{Values: []*v1.AnyValue{
-												{Value: &v1.AnyValue_StringValue{StringValue: "s4"}},
-												{Value: &v1.AnyValue_IntValue{IntValue: 101112}},
-											}}}}},
-										},
-									},
-								},
-							},
-							{
-								TraceId: id,
-								Name:    "secondSpan",
-								Status: &v1_trace.Status{
-									Code: v1_trace.Status_STATUS_CODE_ERROR,
-								},
-								ParentSpanId: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
 }
 
 func BenchmarkProtoToParquet(b *testing.B) {


### PR DESCRIPTION
**What this PR does**:
Refactoring to reduce allocations in `traceToParquet` and `CreateBlock`

- `traceToParquet` use pooled slices. ~levelled pooling would be preferred but we are still seeing a performance improvement with this change only.~
- `v2.DedupingIterator` changed to support both `common.Iterator` and `BytesIterator` allowing it to be used directly when completing a block. Previously, if a trace needed to deduped, we would unmarshal the individual byte slices to `*tempopb.Trace`, deupe, marshal back to a byte slice and finall back to `*tempopb.Trace` to be written to the complete block. This change allows the deduping iterator to directly pass the results of the combine to the caller which reduces allocations significantly.
- Added a leveled pooling object for pooling generic slices.

Previous In Use Space:
![image](https://user-images.githubusercontent.com/2272392/192833346-c14cad2a-5405-449d-a157-98de4f7404a8.png)

Previous alloc objects:
![image](https://user-images.githubusercontent.com/2272392/192833830-b0f2d45c-7ec4-4a64-b0e2-40ec37875b2f.png)

New In Use Space:
![image](https://user-images.githubusercontent.com/2272392/192834037-31f2fe86-89e7-40a6-ab4b-d9f24729617d.png)

New alloc objects:
![image](https://user-images.githubusercontent.com/2272392/192834102-08d4492a-f2ca-4223-adf8-25f99850a24c.png)

Average old memory usage vs average of this branch:
![image](https://user-images.githubusercontent.com/2272392/192834245-e54d93f6-532e-4be3-9d28-237729371c06.png)


