### PR TITLE
Mark compacted blocks as compacted after errors within maintanence cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Old config will still work but will be removed in a future release. [#1735](http
 * [ENHANCEMENT] metrics-generator: filter out older spans before metrics are aggregated [#1612](https://github.com/grafana/tempo/pull/1612) (@ie-pham)
 * * [ENHANCEMENT] Add hedging to trace by ID lookups created by the frontend. [#1735](https://github.com/grafana/tempo/pull/1735) (@mapno)
     New config options and defaults:
+* [BUGFIX] Mark compacted blocks as compacted after errors within maintanence cycle. [#1772](https://github.com/grafana/tempo/pull/1772) @amitsetty
 ```
 query_frontend:
   trace_by_id:

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -202,7 +202,9 @@ func (rw *readerWriter) compact(blockMetas []*backend.BlockMeta, tenantID string
 	compactor := enc.NewCompactor(opts)
 
 	newCompactedBlocks, err := compactor.Compact(ctx, rw.logger, rw.r, rw.getWriterForBlock, blockMetas)
-
+	if newCompactedBlocks == nil {
+		return err
+	}
 	// mark old blocks compacted so they don't show up in polling
 	markCompacted(rw, tenantID, blockMetas, newCompactedBlocks)
 

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -202,9 +202,6 @@ func (rw *readerWriter) compact(blockMetas []*backend.BlockMeta, tenantID string
 	compactor := enc.NewCompactor(opts)
 
 	newCompactedBlocks, err := compactor.Compact(ctx, rw.logger, rw.r, rw.getWriterForBlock, blockMetas)
-	if err != nil {
-		return err
-	}
 
 	// mark old blocks compacted so they don't show up in polling
 	markCompacted(rw, tenantID, blockMetas, newCompactedBlocks)
@@ -222,7 +219,7 @@ func (rw *readerWriter) compact(blockMetas []*backend.BlockMeta, tenantID string
 	}
 	level.Info(rw.logger).Log(logArgs...)
 
-	return nil
+	return err
 }
 
 func markCompacted(rw *readerWriter, tenantID string, oldBlocks []*backend.BlockMeta, newBlocks []*backend.BlockMeta) {


### PR DESCRIPTION
**What this PR does**:
Since the compactor first compacts many blocks and then marks them for compaction it is important that if the compactor stops compacting blocks during a maintenance cycle due to an error the code will mark compacted blocks as compacted regardless of whether or not an error occurs after they are shipped 

**Which issue(s) this PR fixes**:
Partially addresses  #1769

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`