### PR TITLE
Metrics generator: extract status_message field from spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ query_frontend:
 * [BUGFIX] Correctly propagate errors from the iterator layer up through the queriers [#1723](https://github.com/grafana/tempo/pull/1723) (@joe-elliott)
 * [ENHANCEMENT] Upgrade opentelemetry-proto submodule to v0.18.0 [#1754](https://github.com/grafana/tempo/pull/1754) (@mapno)
 Internal types are updated to use `scope` instead of `instrumentation_library`. This is a breaking change in trace by ID queries if JSON is requested.
+* [ENHANCEMENT] Metrics generator: extract `status_message` field from spans [#1786](https://github.com/grafana/tempo/pull/1786) (@stoewer)
 
 ## v1.5.0 / 2022-08-17
 

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -249,7 +249,7 @@ metrics_generator:
 
             # Additional dimensions to add to the metrics along with the default dimensions
             # (service, span_name, span_kind and span_status). Dimensions are searched for in the
-            # resource and span attributes as well as the span status. Listed dimensions are 
+            # resource and span attributes as well as `status.message`. Listed dimensions are 
             # added to the metrics if present.
             [dimensions: <list of string>]
 

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -249,7 +249,8 @@ metrics_generator:
 
             # Additional dimensions to add to the metrics along with the default dimensions
             # (service, span_name, span_kind and span_status). Dimensions are searched for in the
-            # resource and span attributes and are added to the metrics if present.
+            # resource and span attributes as well as the span status. Listed dimensions are 
+            # added to the metrics if present.
             [dimensions: <list of string>]
 
     # Registry configuration

--- a/modules/generator/processor/spanmetrics/spanmetrics.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics.go
@@ -82,7 +82,13 @@ func (p *Processor) aggregateMetricsForSpan(svcName string, rs *v1.Resource, spa
 	labelValues = append(labelValues, svcName, span.GetName(), span.GetKind().String(), span.GetStatus().GetCode().String())
 
 	for _, d := range p.Cfg.Dimensions {
-		value, _ := processor_util.FindAttributeValue(d, rs.Attributes, span.Attributes)
+		var value string
+		switch d {
+		case "status.message", "status_message":
+			value = span.Status.GetMessage()
+		default:
+			value, _ = processor_util.FindAttributeValue(d, rs.Attributes, span.Attributes)
+		}
 		labelValues = append(labelValues, value)
 	}
 

--- a/modules/generator/processor/spanmetrics/spanmetrics_test.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics_test.go
@@ -56,7 +56,7 @@ func TestSpanMetrics_dimensions(t *testing.T) {
 	cfg := Config{}
 	cfg.RegisterFlagsAndApplyDefaults("", nil)
 	cfg.HistogramBuckets = []float64{0.5, 1}
-	cfg.Dimensions = []string{"foo", "bar", "does-not-exist"}
+	cfg.Dimensions = []string{"status.message", "foo", "bar", "does-not-exist"}
 
 	p := New(cfg, testRegistry)
 	defer p.Shutdown(context.Background())
@@ -67,6 +67,7 @@ func TestSpanMetrics_dimensions(t *testing.T) {
 	// Add some attributes
 	for _, rs := range batch.ScopeSpans {
 		for _, s := range rs.Spans {
+			s.Status.Message = "OK"
 			s.Attributes = append(s.Attributes, &common_v1.KeyValue{
 				Key:   "foo",
 				Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "foo-value"}},
@@ -87,6 +88,7 @@ func TestSpanMetrics_dimensions(t *testing.T) {
 		"span_name":      "test",
 		"span_kind":      "SPAN_KIND_CLIENT",
 		"status_code":    "STATUS_CODE_OK",
+		"status_message": "OK",
 		"foo":            "foo-value",
 		"bar":            "bar-value",
 		"does_not_exist": "",


### PR DESCRIPTION
**What this PR does**:
When generating span metrics, extract the non attribute field `status_message` or `status.message`, when it is provided in the span_metrics dimensions.

**Which issue(s) this PR fixes**:
Fixes #1764

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`