### PR TITLE
frontend: ensure failure watcher has been initialized

### DIFF
--- a/modules/frontend/v1/frontend.go
+++ b/modules/frontend/v1/frontend.go
@@ -118,6 +118,7 @@ func New(cfg Config, limits Limits, log log.Logger, registerer prometheus.Regist
 }
 
 func (f *Frontend) starting(ctx context.Context) error {
+	f.subservicesWatcher = services.NewFailureWatcher()
 	f.subservicesWatcher.WatchManager(f.subservices)
 
 	if err := services.StartManagerAndAwaitHealthy(ctx, f.subservices); err != nil {


### PR DESCRIPTION
**What this PR does**:

This change ensures that the `FailureWatcher` is listening to subservices before any services are added to the frontend.  This appears to be the expectation  of the `WatchManager`.

```
panic: FailureWatcher has not been initialized

goroutine 330 [running]:
github.com/grafana/dskit/services.(*FailureWatcher).WatchManager(0x36bad20?, 0xc00070c310?)
	/home/zach/go/src/github.com/grafana/tempo/vendor/github.com/grafana/dskit/services/failure_watcher.go:47 +0xdb
github.com/grafana/tempo/modules/frontend/v1.(*Frontend).starting(0xc0006d8750, {0x25c2860, 0xc0002ba500})
	/home/zach/go/src/github.com/grafana/tempo/modules/frontend/v1/frontend.go:121 +0x36
github.com/grafana/dskit/services.(*BasicService).main(0xc000758a00)
	/home/zach/go/src/github.com/grafana/tempo/vendor/github.com/grafana/dskit/services/basic_service.go:157 +0x78
created by github.com/grafana/dskit/services.(*BasicService).StartAsync.func1
	/home/zach/go/src/github.com/grafana/tempo/vendor/github.com/grafana/dskit/services/basic_service.go:119 +0x10a
```

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`