### PR TITLE
Log span name when include_all_attributes is on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ query_frontend:
 * [ENHANCEMENT] Upgrade opentelemetry-proto submodule to v0.18.0 [#1754](https://github.com/grafana/tempo/pull/1754) (@mapno)
 Internal types are updated to use `scope` instead of `instrumentation_library`. This is a breaking change in trace by ID queries if JSON is requested.
 * [ENHANCEMENT] Metrics generator: extract `status_message` field from spans [#1786](https://github.com/grafana/tempo/pull/1786) (@stoewer)
+* [ENHANCEMENT] distributor: Log span names when `distributor.log_received_spans.include_all_attributes` is on [#1790](https://github.com/grafana/tempo/pull/1790) (@suraciii)
 * [BUGFIX] Honor caching and buffering settings when finding traces by id [#1697](https://github.com/grafana/tempo/pull/1697) (@joe-elliott)
 * [BUGFIX] Correctly propagate errors from the iterator layer up through the queriers [#1723](https://github.com/grafana/tempo/pull/1723) (@joe-elliott)
 * [BUGFIX] Make multitenancy work with HTTP [#1781](https://github.com/grafana/tempo/pull/1781) (@gouthamve)

--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -589,6 +589,7 @@ func logSpanWithAllAttributes(s *v1.Span, logger log.Logger) {
 	latencySeconds := float64(s.GetEndTimeUnixNano()-s.GetStartTimeUnixNano()) / float64(time.Second.Nanoseconds())
 	logger = log.With(
 		logger,
+		"span_name", s.Name,
 		"span_duration_seconds", latencySeconds,
 		"span_kind", s.GetKind().String(),
 		"span_status", s.GetStatus().GetCode().String())

--- a/modules/distributor/distributor_test.go
+++ b/modules/distributor/distributor_test.go
@@ -679,7 +679,7 @@ func TestLogSpans(t *testing.T) {
 			batches: []*v1.ResourceSpans{
 				makeResourceSpans("test", []*v1.ScopeSpans{
 					makeScope(
-						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", nil)),
+						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", "Test Span", nil)),
 				}),
 			},
 			expectedLogsSpan: []logSpan{},
@@ -689,7 +689,7 @@ func TestLogSpans(t *testing.T) {
 			batches: []*v1.ResourceSpans{
 				makeResourceSpans("test", []*v1.ScopeSpans{
 					makeScope(
-						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", nil)),
+						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", "Test Span", nil)),
 				}),
 			},
 			expectedLogsSpan: []logSpan{
@@ -707,14 +707,14 @@ func TestLogSpans(t *testing.T) {
 			batches: []*v1.ResourceSpans{
 				makeResourceSpans("test-service", []*v1.ScopeSpans{
 					makeScope(
-						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", nil),
-						makeSpan("e3210a2b38097332d1fe43083ea93d29", "6c21c48da4dbd1a7", nil)),
+						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", "Test Span1", nil),
+						makeSpan("e3210a2b38097332d1fe43083ea93d29", "6c21c48da4dbd1a7", "Test Span2", nil)),
 					makeScope(
-						makeSpan("bb42ec04df789ff04b10ea5274491685", "1b3a296034f4031e", nil)),
+						makeSpan("bb42ec04df789ff04b10ea5274491685", "1b3a296034f4031e", "Test Span3", nil)),
 				}),
 				makeResourceSpans("test-service2", []*v1.ScopeSpans{
 					makeScope(
-						makeSpan("b1c792dea27d511c145df8402bdd793a", "56afb9fe18b6c2d6", nil)),
+						makeSpan("b1c792dea27d511c145df8402bdd793a", "56afb9fe18b6c2d6", "Test Span", nil)),
 				}),
 			},
 			expectedLogsSpan: []logSpan{
@@ -750,14 +750,14 @@ func TestLogSpans(t *testing.T) {
 			batches: []*v1.ResourceSpans{
 				makeResourceSpans("test-service", []*v1.ScopeSpans{
 					makeScope(
-						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", nil),
-						makeSpan("e3210a2b38097332d1fe43083ea93d29", "6c21c48da4dbd1a7", &v1.Status{Code: v1.Status_STATUS_CODE_ERROR})),
+						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", "Test Span1", nil),
+						makeSpan("e3210a2b38097332d1fe43083ea93d29", "6c21c48da4dbd1a7", "Test Span2", &v1.Status{Code: v1.Status_STATUS_CODE_ERROR})),
 					makeScope(
-						makeSpan("bb42ec04df789ff04b10ea5274491685", "1b3a296034f4031e", nil)),
+						makeSpan("bb42ec04df789ff04b10ea5274491685", "1b3a296034f4031e", "Test Span3", nil)),
 				}),
 				makeResourceSpans("test-service2", []*v1.ScopeSpans{
 					makeScope(
-						makeSpan("b1c792dea27d511c145df8402bdd793a", "56afb9fe18b6c2d6", &v1.Status{Code: v1.Status_STATUS_CODE_ERROR})),
+						makeSpan("b1c792dea27d511c145df8402bdd793a", "56afb9fe18b6c2d6", "Test Span", &v1.Status{Code: v1.Status_STATUS_CODE_ERROR})),
 				}),
 			},
 			expectedLogsSpan: []logSpan{
@@ -782,21 +782,22 @@ func TestLogSpans(t *testing.T) {
 			batches: []*v1.ResourceSpans{
 				makeResourceSpans("test-service", []*v1.ScopeSpans{
 					makeScope(
-						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", nil,
+						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", "Test Span1", nil,
 							makeAttribute("tag1", "value1")),
-						makeSpan("e3210a2b38097332d1fe43083ea93d29", "6c21c48da4dbd1a7", &v1.Status{Code: v1.Status_STATUS_CODE_ERROR},
+						makeSpan("e3210a2b38097332d1fe43083ea93d29", "6c21c48da4dbd1a7", "Test Span2", &v1.Status{Code: v1.Status_STATUS_CODE_ERROR},
 							makeAttribute("tag1", "value1"),
 							makeAttribute("tag2", "value2"))),
 					makeScope(
-						makeSpan("bb42ec04df789ff04b10ea5274491685", "1b3a296034f4031e", nil)),
+						makeSpan("bb42ec04df789ff04b10ea5274491685", "1b3a296034f4031e", "Test Span3", nil)),
 				}, makeAttribute("resource_attribute1", "value1")),
 				makeResourceSpans("test-service2", []*v1.ScopeSpans{
 					makeScope(
-						makeSpan("b1c792dea27d511c145df8402bdd793a", "56afb9fe18b6c2d6", &v1.Status{Code: v1.Status_STATUS_CODE_ERROR})),
+						makeSpan("b1c792dea27d511c145df8402bdd793a", "56afb9fe18b6c2d6", "Test Span", &v1.Status{Code: v1.Status_STATUS_CODE_ERROR})),
 				}, makeAttribute("resource_attribute2", "value2")),
 			},
 			expectedLogsSpan: []logSpan{
 				{
+					Name:               "Test Span2",
 					Msg:                "received",
 					Level:              "info",
 					TraceID:            "e3210a2b38097332d1fe43083ea93d29",
@@ -809,6 +810,7 @@ func TestLogSpans(t *testing.T) {
 					ResourceAttribute1: "value1",
 				},
 				{
+					Name:               "Test Span",
 					Msg:                "received",
 					Level:              "info",
 					TraceID:            "b1c792dea27d511c145df8402bdd793a",
@@ -827,11 +829,12 @@ func TestLogSpans(t *testing.T) {
 			batches: []*v1.ResourceSpans{
 				makeResourceSpans("test-service", []*v1.ScopeSpans{
 					makeScope(
-						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", nil, makeAttribute("tag1", "value1"))),
+						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", "Test Span", nil, makeAttribute("tag1", "value1"))),
 				}),
 			},
 			expectedLogsSpan: []logSpan{
 				{
+					Name:            "Test Span",
 					Msg:             "received",
 					Level:           "info",
 					TraceID:         "0a0102030405060708090a0b0c0d0e0f",
@@ -884,6 +887,7 @@ type logSpan struct {
 	Level              string `json:"level"`
 	TraceID            string `json:"traceid"`
 	SpanID             string `json:"spanid"`
+	Name               string `json:"span_name"`
 	SpanStatus         string `json:"span_status,omitempty"`
 	SpanKind           string `json:"span_kind,omitempty"`
 	SpanServiceName    string `json:"span_service_name,omitempty"`
@@ -900,7 +904,7 @@ func makeAttribute(key string, value string) *v1_common.KeyValue {
 	}
 }
 
-func makeSpan(traceID string, spanID string, status *v1.Status, attributes ...*v1_common.KeyValue) *v1.Span {
+func makeSpan(traceID string, spanID string, name string, status *v1.Status, attributes ...*v1_common.KeyValue) *v1.Span {
 	if status == nil {
 		status = &v1.Status{Code: v1.Status_STATUS_CODE_OK}
 	}
@@ -915,6 +919,7 @@ func makeSpan(traceID string, spanID string, status *v1.Status, attributes ...*v
 	}
 
 	return &v1.Span{
+		Name:       name,
 		TraceId:    traceIDBytes,
 		SpanId:     spanIDBytes,
 		Status:     status,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Add a `span_name` field into span logs of distributors, `span.Name` will only be logged if `include_all_attributes` is set to true.

**Which issue(s) this PR fixes**:
Fixes #1788 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`