### PR TITLE
Fix issue where presence of http.status_code tag may cause other criteria to be skipped

### DIFF
--- a/tempodb/encoding/vparquet/block_search.go
+++ b/tempodb/encoding/vparquet/block_search.go
@@ -276,7 +276,7 @@ func makePipelineWithRowGroups(ctx context.Context, req *tempopb.SearchRequest, 
 		if k == LabelHTTPStatusCode {
 			if i, err := strconv.Atoi(v); err == nil {
 				resourceIters = append(resourceIters, makeIter(column, pq.NewIntBetweenPredicate(int64(i), int64(i)), ""))
-				break
+				continue
 			}
 			// Non-numeric string field
 			otherAttrConditions[k] = v

--- a/tempodb/encoding/vparquet/block_search_test.go
+++ b/tempodb/encoding/vparquet/block_search_test.go
@@ -211,6 +211,14 @@ func TestBackendBlockSearch(t *testing.T) {
 
 		// Span attributes
 		makeReq("foo", "baz"),
+
+		// Multiple
+		{
+			Tags: map[string]string{
+				"http.status_code": "500",
+				"service.name":     "asdf",
+			},
+		},
 	}
 	for _, req := range searchesThatDontMatch {
 		res, err := b.Search(ctx, req, defaultSearchOptions())


### PR DESCRIPTION
**What this PR does**:
Fixes a bug with handling of http.status_code filtering in parquet block search.

**Which issue(s) this PR fixes**:
Fixes n/a - Didn't see this reported in the repo yet

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`