### PR TITLE
Cancel running workflows on new pushes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,14 @@ on:
 #      - 'docs/**'
 #      - 'example/**'
 #      - 'tools/**'
+
+concurrency:
+  # Cancel any running workflow for the same branch when new commits are pushed.
+  # We group both by ref_name (available when CI is triggered by a push to a branch/tag)
+  # and head_ref (available when CI is triggered by a PR).
+  group: "${{ github.ref_name }}-${{ github.head_ref }}"
+  cancel-in-progress: true
+
 jobs:
 
   lint:


### PR DESCRIPTION
**What this PR does**:
This PR configures Github actions to cancel running workflows if new push is done on a branch or PR. Previous workflow has little value at that point. (Copied from Mimir)

**Checklist**
- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`