### PR TITLE
Traceql more functionality

### DIFF
--- a/tempodb/encoding/vparquet/block_traceql.go
+++ b/tempodb/encoding/vparquet/block_traceql.go
@@ -904,7 +904,7 @@ func (c *spanCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			default:
 				status = traceql.Status(kv.Value.Uint64())
 			}
-			span.Attributes[traceql.NewIntrinsic(traceql.IntrinsicStatus)] = traceql.NewStaticStatus(traceql.Status(status))
+			span.Attributes[traceql.NewIntrinsic(traceql.IntrinsicStatus)] = traceql.NewStaticStatus(status)
 		default:
 			// TODO - This exists for span-level dedicated columns like http.status_code
 			// Are nils possible here?

--- a/tempodb/encoding/vparquet/block_traceql.go
+++ b/tempodb/encoding/vparquet/block_traceql.go
@@ -366,8 +366,6 @@ func createSpanIterator(makeIter makeIterFn, conditions []traceql.Condition, sta
 			if err != nil {
 				return nil, err
 			}
-			//addPredicate(columnPathSpanDuration, pred)
-			//columnSelectAs[columnPathSpanDuration] = columnPathSpanDuration
 			durationPredicates = append(durationPredicates, pred)
 			continue
 

--- a/tempodb/encoding/vparquet/block_traceql_test.go
+++ b/tempodb/encoding/vparquet/block_traceql_test.go
@@ -26,9 +26,11 @@ func TestBackendBlockSearchTraceQL(t *testing.T) {
 		},
 		// Intrinsics
 		makeReq(parse(t, `{`+LabelName+` = "hello"}`)),
-		// makeReq(parse(t, `{`+LabelDuration+` = 100s}`)),
-		// makeReq(parse(t, `{`+LabelDuration+` >  99s}`)),
-		// makeReq(parse(t, `{`+LabelDuration+` < 101s}`)),
+		makeReq(parse(t, `{`+LabelDuration+` =  100s}`)),
+		makeReq(parse(t, `{`+LabelDuration+` >  99s}`)),
+		makeReq(parse(t, `{`+LabelDuration+` >= 100s}`)),
+		makeReq(parse(t, `{`+LabelDuration+` <  101s}`)),
+		makeReq(parse(t, `{`+LabelDuration+` <= 100s}`)),
 		// Resource well-known attributes
 		makeReq(parse(t, `{.`+LabelServiceName+` = "spanservicename"}`)), // Overridden at span
 		makeReq(parse(t, `{.`+LabelCluster+` = "cluster"}`)),
@@ -120,6 +122,7 @@ func TestBackendBlockSearchTraceQL(t *testing.T) {
 		// makeReq(parse(t, `{.foo = "abc"}`)),                           // This should not return results because the span has overridden this attribute to "def".
 		makeReq(parse(t, `{.foo =~ "xyz.*"}`)),                        // Regex IN
 		makeReq(parse(t, `{span.bool = true}`)),                       // Bool not match
+		makeReq(parse(t, `{`+LabelDuration+` >  100s}`)),              // Intrinsic: duration
 		makeReq(parse(t, `{`+LabelName+` = "nothello"}`)),             // Well-known attribute: name not match
 		makeReq(parse(t, `{.`+LabelServiceName+` = "notmyservice"}`)), // Well-known attribute: service.name not match
 		makeReq(parse(t, `{.`+LabelHTTPStatusCode+` = 200}`)),         // Well-known attribute: http.status_code not match

--- a/tempodb/encoding/vparquet/block_traceql_test.go
+++ b/tempodb/encoding/vparquet/block_traceql_test.go
@@ -56,10 +56,22 @@ func TestBackendBlockSearchTraceQL(t *testing.T) {
 		makeReq(parse(t, `{span.`+LabelHTTPMethod+` = "get"}`)),
 		makeReq(parse(t, `{span.`+LabelHTTPUrl+` = "url/hello/world"}`)),
 		// Basic data types and operations
+		makeReq(parse(t, `{.float = 456.78}`)),      // Float ==
+		makeReq(parse(t, `{.float != 456.79}`)),     // Float !=
 		makeReq(parse(t, `{.float > 456.7}`)),       // Float >
+		makeReq(parse(t, `{.float >= 456.78}`)),     // Float >=
 		makeReq(parse(t, `{.float < 456.781}`)),     // Float <
-		makeReq(parse(t, `{.bool = false}`)),        // Bool
-		makeReq(parse(t, `{.foo =~ "d.*"}`)),        // Regex
+		makeReq(parse(t, `{.bool = false}`)),        // Bool ==
+		makeReq(parse(t, `{.bool != true}`)),        // Bool !=
+		makeReq(parse(t, `{.bar = 123}`)),           // Int ==
+		makeReq(parse(t, `{.bar != 124}`)),          // Int !=
+		makeReq(parse(t, `{.bar > 122}`)),           // Int >
+		makeReq(parse(t, `{.bar >= 123}`)),          // Int >=
+		makeReq(parse(t, `{.bar < 124}`)),           // Int <
+		makeReq(parse(t, `{.bar <= 123}`)),          // Int <=
+		makeReq(parse(t, `{.foo = "def"}`)),         // String ==
+		makeReq(parse(t, `{.foo != "deg"}`)),        // String !=
+		makeReq(parse(t, `{.foo =~ "d.*"}`)),        // String Regex
 		makeReq(parse(t, `{resource.foo = "abc"}`)), // Resource-level only
 		makeReq(parse(t, `{span.foo = "def"}`)),     // Span-level only
 		makeReq(parse(t, `{.foo}`)),                 // Projection only

--- a/tempodb/encoding/vparquet/schema.go
+++ b/tempodb/encoding/vparquet/schema.go
@@ -33,6 +33,7 @@ const (
 	LabelHTTPUrl        = "http.url"
 	LabelHTTPStatusCode = "http.status_code"
 	LabelStatusCode     = "status.code"
+	LabelStatus         = "status"
 )
 
 // These definition levels match the schema below


### PR DESCRIPTION
**What this PR does**:
This PR adds more TraceQL functionality at the storage layer for parquet format.

1. Re-add duration filtering with original implementation as End-Start (it was removed in #1724). This is not optimal and we still want to add a dedicated column, but introducing new columns still has some things to research, and better to have the traceql functionality.
2. Add remaining operators (!=, >=, <=, etc)
3. Add support for `status` intrinsic

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`