### PR TITLE
fix: raise log level in pkg/usagestats/reporter.go

### DIFF
--- a/pkg/usagestats/reporter.go
+++ b/pkg/usagestats/reporter.go
@@ -70,7 +70,7 @@ func NewReporter(config Config, kvConfig kv.Config, reader backend.RawReader, wr
 func (rep *Reporter) initLeader(ctx context.Context) *ClusterSeed {
 	kvClient, err := kv.NewClient(rep.kvConfig, JSONCodec, nil, rep.logger)
 	if err != nil {
-		level.Info(rep.logger).Log("msg", "failed to create kv client", "err", err)
+		level.Warn(rep.logger).Log("msg", "failed to create kv client", "err", err)
 		return nil
 	}
 	// Try to become leader via the kv client
@@ -93,7 +93,7 @@ func (rep *Reporter) initLeader(ctx context.Context) *ClusterSeed {
 			}
 			return &copySeed, true, nil
 		}); err != nil {
-			level.Info(rep.logger).Log("msg", "failed to CAS cluster seed key", "err", err)
+			level.Warn(rep.logger).Log("msg", "failed to CAS cluster seed key", "err", err)
 			continue
 		}
 		// ensure stability of the cluster seed
@@ -109,7 +109,7 @@ func (rep *Reporter) initLeader(ctx context.Context) *ClusterSeed {
 			if err == backend.ErrDoesNotExist || err == backend.ErrBadSeedFile {
 				// we are the leader and we need to save the file.
 				if err := rep.writeSeedFile(ctx, seed); err != nil {
-					level.Info(rep.logger).Log("msg", "failed to CAS cluster seed key", "err", err)
+					level.Warn(rep.logger).Log("msg", "failed to CAS cluster seed key", "err", err)
 					backoff.Wait()
 					continue
 				}


### PR DESCRIPTION
Signed-off-by: David <davidcalvertfr@gmail.com>
**What this PR does**:

Raised the log level of a few msg in `pkg/usagestats/reporter.go` from `INFO` to `WARN`.

This is a more accurate level for these logs messages.

Example:
`level=info ts=2022-10-18T09:29:37.761854634Z caller=reporter.go:111 msg="failed to CAS cluster seed key" err="error writing object to s3 backend, object tempo_cluster_seed.json: Access Denied"`

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`