### PR TITLE
Refactor some logging to avoid global use

### DIFF
--- a/modules/compactor/compactor.go
+++ b/modules/compactor/compactor.go
@@ -60,6 +60,7 @@ func New(cfg Config, store storage.Store, overrides *overrides.Overrides, reg pr
 		cfg:       &cfg,
 		store:     store,
 		overrides: overrides,
+		logger:    log.With(logger, "component", "compactor"),
 	}
 
 	if c.isSharded() {

--- a/modules/compactor/compactor_test.go
+++ b/modules/compactor/compactor_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/go-kit/log"
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/pkg/model/trace"
@@ -15,9 +16,10 @@ import (
 )
 
 func TestCombineLimitsNotHit(t *testing.T) {
+	logger := log.NewNopLogger()
 	o, err := overrides.NewOverrides(overrides.Limits{
 		MaxBytesPerTrace: math.MaxInt,
-	})
+	}, logger)
 	require.NoError(t, err)
 
 	c := &Compactor{
@@ -45,9 +47,10 @@ func TestCombineLimitsNotHit(t *testing.T) {
 }
 
 func TestCombineLimitsHit(t *testing.T) {
+	logger := log.NewNopLogger()
 	o, err := overrides.NewOverrides(overrides.Limits{
 		MaxBytesPerTrace: 1,
-	})
+	}, logger)
 	require.NoError(t, err)
 
 	c := &Compactor{
@@ -75,9 +78,10 @@ func TestCombineLimitsHit(t *testing.T) {
 }
 
 func TestCombineDoesntEnforceZero(t *testing.T) {
+	logger := log.NewNopLogger()
 	o, err := overrides.NewOverrides(overrides.Limits{
 		MaxBytesPerTrace: 0,
-	})
+	}, logger)
 	require.NoError(t, err)
 
 	c := &Compactor{

--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -209,7 +209,7 @@ func New(cfg Config, clientCfg ingester_client.Config, ingestersRing ring.ReadRi
 		globalTagsToDrop:        tagsToDrop,
 		overrides:               o,
 		traceEncoder:            model.MustNewSegmentDecoder(model.CurrentEncoding),
-		logger:                  logger,
+		logger:                  log.With(logger, "component", "distributor"),
 	}
 
 	if metricsGeneratorEnabled {

--- a/modules/distributor/distributor_test.go
+++ b/modules/distributor/distributor_test.go
@@ -988,7 +988,7 @@ func prepare(t *testing.T, limits *overrides.Limits, kvStore kv.Client, logger l
 	)
 	flagext.DefaultValues(&clientConfig)
 
-	overrides, err := overrides.NewOverrides(*limits)
+	overrides, err := overrides.NewOverrides(*limits, logger)
 	require.NoError(t, err)
 
 	// Mock the ingesters ring

--- a/modules/distributor/ingestion_rate_strategy_test.go
+++ b/modules/distributor/ingestion_rate_strategy_test.go
@@ -3,6 +3,7 @@ package distributor
 import (
 	"testing"
 
+	"github.com/go-kit/log"
 	"github.com/grafana/dskit/limiter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -12,6 +13,7 @@ import (
 )
 
 func TestIngestionRateStrategy(t *testing.T) {
+	logger := log.NewNopLogger()
 	tests := map[string]struct {
 		limits        overrides.Limits
 		ring          ReadLifecycler
@@ -51,7 +53,7 @@ func TestIngestionRateStrategy(t *testing.T) {
 			var strategy limiter.RateLimiterStrategy
 
 			// Init limits overrides
-			o, err := overrides.NewOverrides(testData.limits)
+			o, err := overrides.NewOverrides(testData.limits, logger)
 			require.NoError(t, err)
 
 			// Instance the strategy

--- a/modules/frontend/searchsharding_test.go
+++ b/modules/frontend/searchsharding_test.go
@@ -354,6 +354,7 @@ func TestBackendRange(t *testing.T) {
 }
 
 func TestSearchSharderRoundTrip(t *testing.T) {
+	logger := log.NewNopLogger()
 	tests := []struct {
 		name             string
 		status1          int
@@ -535,7 +536,7 @@ func TestSearchSharderRoundTrip(t *testing.T) {
 				}, nil
 			})
 
-			o, err := overrides.NewOverrides(overrides.Limits{})
+			o, err := overrides.NewOverrides(overrides.Limits{}, logger)
 			require.NoError(t, err)
 
 			sharder := newSearchSharder(&mockReader{
@@ -586,11 +587,12 @@ func TestSearchSharderRoundTrip(t *testing.T) {
 }
 
 func TestSearchSharderRoundTripBadRequest(t *testing.T) {
+	logger := log.NewNopLogger()
 	next := RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 		return nil, nil
 	})
 
-	o, err := overrides.NewOverrides(overrides.Limits{})
+	o, err := overrides.NewOverrides(overrides.Limits{}, logger)
 	require.NoError(t, err)
 
 	sharder := newSearchSharder(&mockReader{}, o, SearchSharderConfig{
@@ -619,7 +621,7 @@ func TestSearchSharderRoundTripBadRequest(t *testing.T) {
 	// test max duration error with overrides
 	o, err = overrides.NewOverrides(overrides.Limits{
 		MaxSearchDuration: model.Duration(time.Minute),
-	})
+	}, logger)
 	require.NoError(t, err)
 
 	sharder = newSearchSharder(&mockReader{}, o, SearchSharderConfig{
@@ -651,8 +653,8 @@ func TestAdjustLimit(t *testing.T) {
 }
 
 func TestMaxDuration(t *testing.T) {
-	//
-	o, err := overrides.NewOverrides(overrides.Limits{})
+	logger := log.NewNopLogger()
+	o, err := overrides.NewOverrides(overrides.Limits{}, logger)
 	require.NoError(t, err)
 	sharder := searchSharder{
 		cfg: SearchSharderConfig{
@@ -665,7 +667,7 @@ func TestMaxDuration(t *testing.T) {
 
 	o, err = overrides.NewOverrides(overrides.Limits{
 		MaxSearchDuration: model.Duration(10 * time.Minute),
-	})
+	}, logger)
 	require.NoError(t, err)
 	sharder = searchSharder{
 		cfg: SearchSharderConfig{

--- a/modules/generator/generator.go
+++ b/modules/generator/generator.go
@@ -73,7 +73,7 @@ func New(cfg *Config, overrides metricsGeneratorOverrides, reg prometheus.Regist
 		instances: map[string]*instance{},
 
 		reg:    reg,
-		logger: logger,
+		logger: log.With(logger, "component", "metrics-generator"),
 	}
 
 	// Lifecycler and ring

--- a/modules/ingester/ingester_test.go
+++ b/modules/ingester/ingester_test.go
@@ -313,8 +313,9 @@ func TestFlush(t *testing.T) {
 }
 
 func defaultIngesterModule(t testing.TB, tmpDir string) *Ingester {
+	logger := log.NewNopLogger()
 	ingesterConfig := defaultIngesterTestConfig()
-	limits, err := overrides.NewOverrides(defaultLimitsTestConfig())
+	limits, err := overrides.NewOverrides(defaultLimitsTestConfig(), logger)
 	require.NoError(t, err, "unexpected error creating overrides")
 
 	s, err := storage.NewStore(storage.Config{
@@ -338,7 +339,7 @@ func defaultIngesterModule(t testing.TB, tmpDir string) *Ingester {
 	}, log.NewNopLogger())
 	require.NoError(t, err, "unexpected error store")
 
-	ingester, err := New(ingesterConfig, s, limits, prometheus.NewPedanticRegistry())
+	ingester, err := New(ingesterConfig, s, limits, prometheus.NewPedanticRegistry(), logger)
 	require.NoError(t, err, "unexpected error creating ingester")
 	ingester.replayJitter = false
 

--- a/modules/ingester/instance_search_test.go
+++ b/modules/ingester/instance_search_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -160,11 +161,13 @@ func testSearchTagsAndValues(t *testing.T, ctx context.Context, i *instance, tag
 // TestInstanceSearchMaxBytesPerTagValuesQueryReturnsPartial confirms that SearchTagValues returns
 // partial results if the bytes of the found tag value exceeds the MaxBytesPerTagValuesQuery limit
 func TestInstanceSearchMaxBytesPerTagValuesQueryReturnsPartial(t *testing.T) {
+	logger := log.NewNopLogger()
+
 	for _, b := range []bool{true, false} {
 		t.Run(fmt.Sprintf("flatbufferSearch:%t", b), func(t *testing.T) {
 			limits, err := overrides.NewOverrides(overrides.Limits{
 				MaxBytesPerTagValuesQuery: 10,
-			})
+			}, logger)
 			assert.NoError(t, err, "unexpected error creating limits")
 			limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
 
@@ -254,7 +257,8 @@ func TestInstanceSearchNoData(t *testing.T) {
 }
 
 func TestInstanceSearchDoesNotRace(t *testing.T) {
-	limits, err := overrides.NewOverrides(overrides.Limits{})
+	logger := log.NewNopLogger()
+	limits, err := overrides.NewOverrides(overrides.Limits{}, logger)
 	require.NoError(t, err)
 	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
 

--- a/modules/ingester/instance_test.go
+++ b/modules/ingester/instance_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -199,10 +200,11 @@ func TestInstanceDoesNotRace(t *testing.T) {
 }
 
 func TestInstanceLimits(t *testing.T) {
+	logger := log.NewNopLogger()
 	limits, err := overrides.NewOverrides(overrides.Limits{
 		MaxBytesPerTrace:      1000,
 		MaxLocalTracesPerUser: 4,
-	})
+	}, logger)
 	require.NoError(t, err, "unexpected error creating limits")
 	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
 
@@ -478,6 +480,7 @@ func TestInstanceMetrics(t *testing.T) {
 }
 
 func TestInstanceFailsLargeTracesEvenAfterFlushing(t *testing.T) {
+	logger := log.NewNopLogger()
 	ctx := context.Background()
 	maxTraceBytes := 100
 	id := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
@@ -486,7 +489,7 @@ func TestInstanceFailsLargeTracesEvenAfterFlushing(t *testing.T) {
 
 	limits, err := overrides.NewOverrides(overrides.Limits{
 		MaxBytesPerTrace: maxTraceBytes,
-	})
+	}, logger)
 	require.NoError(t, err)
 	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
 
@@ -560,7 +563,8 @@ func defaultInstance(t testing.TB) (*instance, *Ingester) {
 }
 
 func defaultInstanceWithFlatBufferSearch(t testing.TB, fbSearch bool) (*instance, *Ingester, string) {
-	limits, err := overrides.NewOverrides(overrides.Limits{})
+	logger := log.NewNopLogger()
+	limits, err := overrides.NewOverrides(overrides.Limits{}, logger)
 	require.NoError(t, err, "unexpected error creating limits")
 	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
 

--- a/modules/overrides/overrides_test.go
+++ b/modules/overrides/overrides_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -16,6 +17,7 @@ import (
 )
 
 func TestOverrides(t *testing.T) {
+	logger := log.NewNopLogger()
 
 	tests := []struct {
 		name                        string
@@ -125,7 +127,7 @@ func TestOverrides(t *testing.T) {
 			}
 
 			prometheus.DefaultRegisterer = prometheus.NewRegistry() // have to overwrite the registry or test panics with multiple metric reg
-			overrides, err := NewOverrides(tt.limits)
+			overrides, err := NewOverrides(tt.limits, logger)
 			require.NoError(t, err)
 			err = services.StartAndAwaitRunning(context.TODO(), overrides)
 			require.NoError(t, err)

--- a/modules/querier/querier_test.go
+++ b/modules/querier/querier_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/grafana/tempo/modules/ingester/client"
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/pkg/tempopb"
@@ -16,6 +17,7 @@ import (
 )
 
 func TestQuerierUsesSearchExternalEndpoint(t *testing.T) {
+	logger := log.NewNopLogger()
 	numExternalRequests := atomic.NewInt32(0)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -63,10 +65,10 @@ func TestQuerierUsesSearchExternalEndpoint(t *testing.T) {
 	for _, tc := range tests {
 		numExternalRequests.Store(0)
 
-		o, err := overrides.NewOverrides(overrides.Limits{})
+		o, err := overrides.NewOverrides(overrides.Limits{}, logger)
 		require.NoError(t, err)
 
-		q, err := New(tc.cfg, client.Config{}, nil, nil, o)
+		q, err := New(tc.cfg, client.Config{}, nil, nil, o, logger)
 		require.NoError(t, err)
 
 		for i := 0; i < tc.queriesToExecute; i++ {

--- a/modules/storage/store.go
+++ b/modules/storage/store.go
@@ -31,7 +31,8 @@ type Store interface {
 type store struct {
 	services.Service
 
-	cfg Config
+	cfg    Config
+	logger log.Logger
 
 	tempodb.Reader
 	tempodb.Writer
@@ -58,6 +59,7 @@ func NewStore(cfg Config, logger log.Logger) (Store, error) {
 		Reader:    r,
 		Writer:    w,
 		Compactor: c,
+		logger:    log.With(logger, "component", "store"),
 	}
 
 	s.Service = services.NewIdleService(s.starting, s.stopping)

--- a/pkg/usagestats/reporter.go
+++ b/pkg/usagestats/reporter.go
@@ -56,7 +56,7 @@ func NewReporter(config Config, kvConfig kv.Config, reader backend.RawReader, wr
 		return nil, nil
 	}
 	r := &Reporter{
-		logger:   logger,
+		logger:   log.With(logger, "component", "usage-reporter"),
 		reader:   reader,
 		writer:   writer,
 		conf:     config,


### PR DESCRIPTION
**What this PR does**:

Here we update most of the modules to receive a logger and then use that logger on the struct for non-global logging purposes.  Additionally, for each of the refactored components, a `logger` has been included or updated on the struct to include a new field of `component` that would identify which component is doing the logging.

If this approach seems reasonable, I could potentially include #14, but would need to look closer.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`