### PR TITLE
Set omitempty on yaml serialization config

### DIFF
--- a/cmd/tempo-serverless/handler.go
+++ b/cmd/tempo-serverless/handler.go
@@ -154,7 +154,7 @@ func loadBackend() (backend.Reader, *tempodb.Config, error) {
 
 func loadConfig() (*tempodb.Config, error) {
 	defaultConfig := &tempodb.Config{
-		Search: &tempodb.SearchConfig{
+		Search: tempodb.SearchConfig{
 			ChunkSizeBytes:     tempodb.DefaultSearchChunkSizeBytes,
 			PrefetchTraceCount: tempodb.DefaultPrefetchTraceCount,
 		},
@@ -176,8 +176,14 @@ func loadConfig() (*tempodb.Config, error) {
 	}
 
 	v.AutomaticEnv()
+
 	v.SetEnvPrefix(envConfigPrefix)
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
+	err = bindEnvs(v, defaultConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to bind env vars from config")
+
+	}
 
 	cfg := &tempodb.Config{}
 	err = v.Unmarshal(cfg, setTagName, setDecodeHooks)

--- a/cmd/tempo-serverless/utils.go
+++ b/cmd/tempo-serverless/utils.go
@@ -1,0 +1,43 @@
+package serverless
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+func bindEnvs(v *viper.Viper, in interface{}) error {
+	return bindEnvsFromValue(v, reflect.ValueOf(in))
+}
+
+func bindEnvsFromValue(v *viper.Viper, in reflect.Value, path ...string) error {
+	if !in.IsValid() || in.Kind() == reflect.Ptr && in.IsNil() {
+		return nil
+	}
+	switch in.Kind() {
+	case reflect.Ptr:
+		return bindEnvsFromValue(v, in.Elem(), path...)
+	case reflect.Struct:
+		st := in.Type()
+		n := st.NumField()
+		for i := 0; i != n; i++ {
+			field := st.Field(i)
+			tag := field.Tag.Get("yaml")
+			if tag != "" {
+				fields := strings.Split(tag, ",")
+				name := fields[0]
+				path := append(path, name)
+				if err := bindEnvsFromValue(v, in.Field(i), path...); err != nil {
+					return err
+				}
+			}
+		}
+	default:
+		err := v.BindEnv(strings.Join(path, "."))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/tempo/app/config.go
+++ b/cmd/tempo/app/config.go
@@ -31,11 +31,11 @@ type Config struct {
 	AuthEnabled             bool   `yaml:"auth_enabled,omitempty"`
 	MultitenancyEnabled     bool   `yaml:"multitenancy_enabled,omitempty"`
 	SearchEnabled           bool   `yaml:"search_enabled,omitempty"`
-	MetricsGeneratorEnabled bool   `yaml:"metrics_generator_enabled"`
-	HTTPAPIPrefix           string `yaml:"http_api_prefix"`
+	MetricsGeneratorEnabled bool   `yaml:"metrics_generator_enabled,omitempty"`
+	HTTPAPIPrefix           string `yaml:"http_api_prefix,omitempty"`
 	UseOTelTracer           bool   `yaml:"use_otel_tracer,omitempty"`
 
-	Server          server.Config           `yaml:"server,omitempty"`
+	Server          *server.Config          `yaml:"server,omitempty"`
 	Distributor     distributor.Config      `yaml:"distributor,omitempty"`
 	IngesterClient  ingester_client.Config  `yaml:"ingester_client,omitempty"`
 	GeneratorClient generator_client.Config `yaml:"metrics_generator_client,omitempty"`
@@ -51,7 +51,9 @@ type Config struct {
 }
 
 func newDefaultConfig() *Config {
-	defaultConfig := &Config{}
+	defaultConfig := &Config{
+		Server: &server.Config{},
+	}
 	defaultFS := flag.NewFlagSet("", flag.PanicOnError)
 	defaultConfig.RegisterFlagsAndApplyDefaults("", defaultFS)
 	return defaultConfig
@@ -69,7 +71,7 @@ func (c *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 	f.BoolVar(&c.UseOTelTracer, "use-otel-tracer", false, "Set to true to replace the OpenTracing tracer with the OpenTelemetry tracer")
 
 	// Server settings
-	flagext.DefaultValues(&c.Server)
+	flagext.DefaultValues(c.Server)
 	c.Server.LogLevel.RegisterFlags(f)
 
 	// Increase max message size to 16MB

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -63,9 +63,9 @@ func (t *App) initServer() (services.Service, error) {
 
 	prometheus.MustRegister(&t.cfg)
 
-	DisableSignalHandling(&t.cfg.Server)
+	DisableSignalHandling(t.cfg.Server)
 
-	server, err := server.New(t.cfg.Server)
+	server, err := server.New(*t.cfg.Server)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create server %w", err)
 	}

--- a/cmd/tempo/main.go
+++ b/cmd/tempo/main.go
@@ -70,7 +70,7 @@ func main() {
 		level.Error(log.Logger).Log("msg", "invalid log level")
 		os.Exit(1)
 	}
-	log.InitLogger(&config.Server)
+	log.InitLogger(config.Server)
 
 	// Init tracer
 	var shutdownTracer func()

--- a/modules/compactor/compactor.go
+++ b/modules/compactor/compactor.go
@@ -64,7 +64,7 @@ func New(cfg Config, store storage.Store, overrides *overrides.Overrides, reg pr
 		reg = prometheus.WrapRegistererWithPrefix("cortex_", reg)
 
 		lifecyclerStore, err := kv.NewClient(
-			cfg.ShardingRing.KVStore,
+			*cfg.ShardingRing.KVStore,
 			ring.GetCodec(),
 			kv.RegistererWithKVName(reg, compactorRingKey+"-lifecycler"),
 			log.Logger,

--- a/modules/compactor/compactor_ring.go
+++ b/modules/compactor/compactor_ring.go
@@ -18,24 +18,24 @@ import (
 // is used to strip down the config to the minimum, and avoid confusion
 // to the user.
 type RingConfig struct {
-	KVStore          kv.Config     `yaml:"kvstore"`
-	HeartbeatPeriod  time.Duration `yaml:"heartbeat_period"`
-	HeartbeatTimeout time.Duration `yaml:"heartbeat_timeout"`
+	KVStore          *kv.Config    `yaml:"kvstore,omitempty"`
+	HeartbeatPeriod  time.Duration `yaml:"heartbeat_period,omitempty"`
+	HeartbeatTimeout time.Duration `yaml:"heartbeat_timeout,omitempty"`
 
 	// Wait ring stability.
-	WaitStabilityMinDuration time.Duration `yaml:"wait_stability_min_duration"`
-	WaitStabilityMaxDuration time.Duration `yaml:"wait_stability_max_duration"`
+	WaitStabilityMinDuration time.Duration `yaml:"wait_stability_min_duration,omitempty"`
+	WaitStabilityMaxDuration time.Duration `yaml:"wait_stability_max_duration,omitempty"`
 
 	// Instance details
-	InstanceID             string   `yaml:"instance_id" doc:"hidden"`
-	InstanceInterfaceNames []string `yaml:"instance_interface_names"`
-	InstancePort           int      `yaml:"instance_port" doc:"hidden"`
-	InstanceAddr           string   `yaml:"instance_addr" doc:"hidden"`
+	InstanceID             string   `yaml:"instance_id,omitempty" doc:"hidden"`
+	InstanceInterfaceNames []string `yaml:"instance_interface_names,omitempty"`
+	InstancePort           int      `yaml:"instance_port,omitempty" doc:"hidden"`
+	InstanceAddr           string   `yaml:"instance_addr,omitempty" doc:"hidden"`
 
 	// Injected internally
 	ListenPort int `yaml:"-"`
 
-	WaitActiveInstanceTimeout time.Duration `yaml:"wait_active_instance_timeout"`
+	WaitActiveInstanceTimeout time.Duration `yaml:"wait_active_instance_timeout,omitempty"`
 
 	ObservePeriod time.Duration `yaml:"-"`
 }
@@ -80,7 +80,7 @@ func (cfg *RingConfig) ToLifecyclerConfig() ring.LifecyclerConfig {
 	flagext.DefaultValues(&rc)
 
 	// Configure ring
-	rc.KVStore = cfg.KVStore
+	rc.KVStore = *cfg.KVStore
 	rc.HeartbeatTimeout = cfg.HeartbeatTimeout
 	rc.ReplicationFactor = 1
 

--- a/modules/distributor/config.go
+++ b/modules/distributor/config.go
@@ -30,25 +30,25 @@ type Config struct {
 	// receivers map for shim.
 	//  This receivers node is equivalent in format to the receiver node in the
 	//  otel collector: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver
-	Receivers         map[string]interface{} `yaml:"receivers"`
-	OverrideRingKey   string                 `yaml:"override_ring_key"`
-	LogReceivedTraces bool                   `yaml:"log_received_traces"` // Deprecated
+	Receivers         map[string]interface{} `yaml:"receivers,omitempty"`
+	OverrideRingKey   string                 `yaml:"override_ring_key,omitempty"`
+	LogReceivedTraces bool                   `yaml:"log_received_traces,omitempty"` // Deprecated
 	LogReceivedSpans  LogReceivedSpansConfig `yaml:"log_received_spans,omitempty"`
 
 	// disables write extension with inactive ingesters. Use this along with ingester.lifecycler.unregister_on_shutdown = true
 	//  note that setting these two config values reduces tolerance to failures on rollout b/c there is always one guaranteed to be failing replica
-	ExtendWrites bool `yaml:"extend_writes"`
+	ExtendWrites bool `yaml:"extend_writes,omitempty"`
 
-	SearchTagsDenyList []string `yaml:"search_tags_deny_list"`
+	SearchTagsDenyList []string `yaml:"search_tags_deny_list,omitempty"`
 
 	// For testing.
 	factory func(addr string) (ring_client.PoolClient, error) `yaml:"-"`
 }
 
 type LogReceivedSpansConfig struct {
-	Enabled              bool `yaml:"enabled"`
-	IncludeAllAttributes bool `yaml:"include_all_attributes"`
-	FilterByStatusError  bool `yaml:"filter_by_status_error"`
+	Enabled              bool `yaml:"enabled,omitempty"`
+	IncludeAllAttributes bool `yaml:"include_all_attributes,omitempty"`
+	FilterByStatusError  bool `yaml:"filter_by_status_error,omitempty"`
 }
 
 // RegisterFlagsAndApplyDefaults registers flags and applies defaults
@@ -64,4 +64,5 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	f.BoolVar(&cfg.LogReceivedSpans.Enabled, util.PrefixConfig(prefix, "log-received-spans.enabled"), false, "Enable to log every received span to help debug ingestion or calculate span error distributions using the logs.")
 	f.BoolVar(&cfg.LogReceivedSpans.IncludeAllAttributes, util.PrefixConfig(prefix, "log-received-spans.include-attributes"), false, "Enable to include span attributes in the logs.")
 	f.BoolVar(&cfg.LogReceivedSpans.FilterByStatusError, util.PrefixConfig(prefix, "log-received-spans.filter-by-status-error"), false, "Enable to filter out spans without status error.")
+
 }

--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -211,7 +211,7 @@ func New(cfg Config, clientCfg ingester_client.Config, ingestersRing ring.ReadRi
 	if metricsGeneratorEnabled {
 		d.generatorsPool = ring_client.NewPool(
 			"distributor_metrics_generator_pool",
-			generatorClientCfg.PoolConfig,
+			*generatorClientCfg.PoolConfig,
 			ring_client.NewRingServiceDiscovery(generatorsRing),
 			func(addr string) (ring_client.PoolClient, error) {
 				return generator_client.New(addr, generatorClientCfg)

--- a/modules/distributor/distributor_ring.go
+++ b/modules/distributor/distributor_ring.go
@@ -18,15 +18,15 @@ import (
 // is used to strip down the config to the minimum, and avoid confusion
 // to the user.
 type RingConfig struct {
-	KVStore          kv.Config     `yaml:"kvstore"`
-	HeartbeatPeriod  time.Duration `yaml:"heartbeat_period"`
-	HeartbeatTimeout time.Duration `yaml:"heartbeat_timeout"`
+	KVStore          *kv.Config    `yaml:"kvstore,omitempty"`
+	HeartbeatPeriod  time.Duration `yaml:"heartbeat_period,omitempty"`
+	HeartbeatTimeout time.Duration `yaml:"heartbeat_timeout,omitempty"`
 
 	// Instance details
-	InstanceID             string   `yaml:"instance_id" doc:"hidden"`
-	InstanceInterfaceNames []string `yaml:"instance_interface_names"`
-	InstancePort           int      `yaml:"instance_port" doc:"hidden"`
-	InstanceAddr           string   `yaml:"instance_addr" doc:"hidden"`
+	InstanceID             string   `yaml:"instance_id,omitempty" doc:"hidden"`
+	InstanceInterfaceNames []string `yaml:"instance_interface_names,omitempty"`
+	InstancePort           int      `yaml:"instance_port,omitempty" doc:"hidden"`
+	InstanceAddr           string   `yaml:"instance_addr,omitempty" doc:"hidden"`
 
 	// Injected internally
 	ListenPort int `yaml:"-"`
@@ -40,6 +40,9 @@ func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet) {
 		os.Exit(1)
 	}
 
+	if cfg.KVStore == nil {
+		cfg.KVStore = &kv.Config{}
+	}
 	// Ring flags
 	cfg.KVStore.RegisterFlagsWithPrefix("distributor.ring.", "collectors/", f)
 	f.DurationVar(&cfg.HeartbeatPeriod, "distributor.ring.heartbeat-period", 5*time.Second, "Period at which to heartbeat to the ring. 0 = disabled.")
@@ -65,7 +68,7 @@ func (cfg *RingConfig) ToLifecyclerConfig() ring.LifecyclerConfig {
 	flagext.DefaultValues(&rc)
 
 	// Configure ring
-	rc.KVStore = cfg.KVStore
+	rc.KVStore = *cfg.KVStore
 	rc.HeartbeatTimeout = cfg.HeartbeatTimeout
 	rc.ReplicationFactor = 1
 

--- a/modules/distributor/distributor_test.go
+++ b/modules/distributor/distributor_test.go
@@ -991,6 +991,7 @@ func prepare(t *testing.T, limits *overrides.Limits, kvStore kv.Client, logger l
 
 	distributorConfig.DistributorRing.HeartbeatPeriod = 100 * time.Millisecond
 	distributorConfig.DistributorRing.InstanceID = strconv.Itoa(rand.Int())
+	distributorConfig.DistributorRing.KVStore = &kv.Config{}
 	distributorConfig.DistributorRing.KVStore.Mock = kvStore
 	distributorConfig.DistributorRing.InstanceInterfaceNames = []string{"eth0", "en0", "lo0"}
 	distributorConfig.factory = func(addr string) (ring_client.PoolClient, error) {

--- a/modules/frontend/config.go
+++ b/modules/frontend/config.go
@@ -22,11 +22,11 @@ type Config struct {
 	Config               v1.Config    `yaml:",inline"`
 	MaxRetries           int          `yaml:"max_retries,omitempty"`
 	TolerateFailedBlocks int          `yaml:"tolerate_failed_blocks,omitempty"`
-	Search               SearchConfig `yaml:"search"`
+	Search               SearchConfig `yaml:"search,omitempty"`
 	// Deprecated: Use TraceByID.QueryShards instead.
 	// TODO: Remove QueryShards with Tempo v2
-	QueryShards int             `yaml:"query_shards,omitempty"`
-	TraceByID   TraceByIDConfig `yaml:"trace_by_id"`
+	QueryShards int              `yaml:"query_shards,omitempty"`
+	TraceByID   *TraceByIDConfig `yaml:"trace_by_id,omitempty"`
 }
 
 type SearchConfig struct {
@@ -39,8 +39,8 @@ type TraceByIDConfig struct {
 }
 
 type HedgingConfig struct {
-	HedgeRequestsAt   time.Duration `yaml:"hedge_requests_at"`
-	HedgeRequestsUpTo int           `yaml:"hedge_requests_up_to"`
+	HedgeRequestsAt   time.Duration `yaml:"hedge_requests_at,omitempty"`
+	HedgeRequestsUpTo int           `yaml:"hedge_requests_up_to,omitempty"`
 }
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {
@@ -58,7 +58,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {
 			TargetBytesPerRequest: defaultTargetBytesPerRequest,
 		},
 	}
-	cfg.TraceByID = TraceByIDConfig{
+	cfg.TraceByID = &TraceByIDConfig{
 		QueryShards: 20,
 		Hedging: HedgingConfig{
 			HedgeRequestsAt:   2 * time.Second,

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -42,6 +42,9 @@ type QueryFrontend struct {
 func New(cfg Config, next http.RoundTripper, o *overrides.Overrides, store storage.Store, logger log.Logger, registerer prometheus.Registerer) (*QueryFrontend, error) {
 	level.Info(logger).Log("msg", "creating middleware in query frontend")
 
+	if cfg.TraceByID == nil {
+		cfg.TraceByID = &TraceByIDConfig{}
+	}
 	if cfg.QueryShards != 0 {
 		cfg.TraceByID.QueryShards = cfg.QueryShards
 		level.Warn(logger).Log("msg", "query_shards is deprecated, use trace_by_id.query_shards instead")

--- a/modules/frontend/searchsharding.go
+++ b/modules/frontend/searchsharding.go
@@ -39,9 +39,9 @@ type searchSharder struct {
 type SearchSharderConfig struct {
 	ConcurrentRequests    int           `yaml:"concurrent_jobs,omitempty"`
 	TargetBytesPerRequest int           `yaml:"target_bytes_per_job,omitempty"`
-	DefaultLimit          uint32        `yaml:"default_result_limit"`
-	MaxLimit              uint32        `yaml:"max_result_limit"`
-	MaxDuration           time.Duration `yaml:"max_duration"`
+	DefaultLimit          uint32        `yaml:"default_result_limit,omitempty"`
+	MaxLimit              uint32        `yaml:"max_result_limit,omitempty"`
+	MaxDuration           time.Duration `yaml:"max_duration,omitempty"`
 	QueryBackendAfter     time.Duration `yaml:"query_backend_after,omitempty"`
 	QueryIngestersUntil   time.Duration `yaml:"query_ingesters_until,omitempty"`
 }

--- a/modules/frontend/v1/frontend.go
+++ b/modules/frontend/v1/frontend.go
@@ -30,8 +30,8 @@ var (
 
 // Config for a Frontend.
 type Config struct {
-	MaxOutstandingPerTenant int           `yaml:"max_outstanding_per_tenant"`
-	QuerierForgetDelay      time.Duration `yaml:"querier_forget_delay"`
+	MaxOutstandingPerTenant int           `yaml:"max_outstanding_per_tenant,omitempty"`
+	QuerierForgetDelay      time.Duration `yaml:"querier_forget_delay,omitempty"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.

--- a/modules/generator/client/client.go
+++ b/modules/generator/client/client.go
@@ -19,9 +19,9 @@ import (
 
 // Config for a generator client.
 type Config struct {
-	PoolConfig       ring_client.PoolConfig `yaml:"pool_config,omitempty"`
-	RemoteTimeout    time.Duration          `yaml:"remote_timeout,omitempty"`
-	GRPCClientConfig grpcclient.Config      `yaml:"grpc_client_config"`
+	PoolConfig       *ring_client.PoolConfig `yaml:"pool_config,omitempty"`
+	RemoteTimeout    time.Duration           `yaml:"remote_timeout,omitempty"`
+	GRPCClientConfig *grpcclient.Config      `yaml:"grpc_client_config,omitempty"`
 }
 
 type Client struct {
@@ -32,7 +32,14 @@ type Client struct {
 
 // RegisterFlags registers flags.
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
+	if cfg.GRPCClientConfig == nil {
+		cfg.GRPCClientConfig = &grpcclient.Config{}
+	}
 	cfg.GRPCClientConfig.RegisterFlagsWithPrefix("generator.client", f)
+
+	if cfg.PoolConfig == nil {
+		cfg.PoolConfig = &ring_client.PoolConfig{}
+	}
 
 	f.DurationVar(&cfg.PoolConfig.HealthCheckTimeout, "generator.client.healthcheck-timeout", 1*time.Second, "Timeout for healthcheck rpcs.")
 	f.DurationVar(&cfg.PoolConfig.CheckInterval, "generator.client.healthcheck-interval", 15*time.Second, "Interval to healthcheck generators")

--- a/modules/generator/config.go
+++ b/modules/generator/config.go
@@ -20,13 +20,13 @@ const (
 
 // Config for a generator.
 type Config struct {
-	Ring      RingConfig      `yaml:"ring"`
-	Processor ProcessorConfig `yaml:"processor"`
-	Registry  registry.Config `yaml:"registry"`
-	Storage   storage.Config  `yaml:"storage"`
+	Ring      RingConfig      `yaml:"ring,omitempty"`
+	Processor ProcessorConfig `yaml:"processor,omitempty"`
+	Registry  registry.Config `yaml:"registry,omitempty"`
+	Storage   storage.Config  `yaml:"storage,omitempty"`
 	// MetricsIngestionSlack is the max amount of time passed since a span's start time
 	// for the span to be considered in metrics generation
-	MetricsIngestionSlack time.Duration `yaml:"metrics_ingestion_time_range_slack"`
+	MetricsIngestionSlack time.Duration `yaml:"metrics_ingestion_time_range_slack,omitempty"`
 }
 
 // RegisterFlagsAndApplyDefaults registers the flags.
@@ -40,8 +40,8 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 }
 
 type ProcessorConfig struct {
-	ServiceGraphs servicegraphs.Config `yaml:"service_graphs"`
-	SpanMetrics   spanmetrics.Config   `yaml:"span_metrics"`
+	ServiceGraphs servicegraphs.Config `yaml:"service_graphs,omitempty"`
+	SpanMetrics   spanmetrics.Config   `yaml:"span_metrics,omitempty"`
 }
 
 func (cfg *ProcessorConfig) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {

--- a/modules/generator/generator.go
+++ b/modules/generator/generator.go
@@ -78,7 +78,7 @@ func New(cfg *Config, overrides metricsGeneratorOverrides, reg prometheus.Regist
 
 	// Lifecycler and ring
 	ringStore, err := kv.NewClient(
-		cfg.Ring.KVStore,
+		*cfg.Ring.KVStore,
 		ring.GetCodec(),
 		kv.RegistererWithKVName(prometheus.WrapRegistererWithPrefix("cortex_", reg), "metrics-generator"),
 		g.logger,

--- a/modules/generator/generator_ring.go
+++ b/modules/generator/generator_ring.go
@@ -15,7 +15,7 @@ import (
 )
 
 type RingConfig struct {
-	KVStore          kv.Config     `yaml:"kvstore"`
+	KVStore          *kv.Config    `yaml:"kvstore"`
 	HeartbeatPeriod  time.Duration `yaml:"heartbeat_period"`
 	HeartbeatTimeout time.Duration `yaml:"heartbeat_timeout"`
 
@@ -28,6 +28,9 @@ type RingConfig struct {
 }
 
 func (cfg *RingConfig) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
+	if cfg.KVStore == nil {
+		cfg.KVStore = &kv.Config{}
+	}
 	cfg.KVStore.RegisterFlagsWithPrefix(prefix, "collectors/", f)
 	cfg.KVStore.Store = "memberlist"
 
@@ -47,7 +50,7 @@ func (cfg *RingConfig) ToRingConfig() ring.Config {
 	rc := ring.Config{}
 	flagext.DefaultValues(&rc)
 
-	rc.KVStore = cfg.KVStore
+	rc.KVStore = *cfg.KVStore
 	rc.HeartbeatTimeout = cfg.HeartbeatTimeout
 	rc.ReplicationFactor = 1
 	rc.SubringCacheDisabled = true

--- a/modules/generator/processor/servicegraphs/config.go
+++ b/modules/generator/processor/servicegraphs/config.go
@@ -13,20 +13,20 @@ const (
 
 type Config struct {
 	// Wait is the value to wait for an edge to be completed
-	Wait time.Duration `yaml:"wait"`
+	Wait time.Duration `yaml:"wait,omitempty"`
 	// MaxItems is the amount of edges that will be stored in the storeMap
-	MaxItems int `yaml:"max_items"`
+	MaxItems int `yaml:"max_items,omitempty"`
 
 	// Workers is the amount of workers that will be used to process the edges
-	Workers int `yaml:"workers"`
+	Workers int `yaml:"workers,omitempty"`
 
 	// Buckets for latency histogram in seconds.
-	HistogramBuckets []float64 `yaml:"histogram_buckets"`
+	HistogramBuckets []float64 `yaml:"histogram_buckets,omitempty"`
 
 	// Additional dimensions (labels) to be added to the metric along with the default ones.
 	// If client and server spans have the same attribute, behaviour is undetermined
 	// (either value could get used)
-	Dimensions []string `yaml:"dimensions"`
+	Dimensions []string `yaml:"dimensions,omitempty"`
 }
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {

--- a/modules/generator/processor/spanmetrics/config.go
+++ b/modules/generator/processor/spanmetrics/config.go
@@ -12,10 +12,10 @@ const (
 
 type Config struct {
 	// Buckets for latency histogram in seconds.
-	HistogramBuckets []float64 `yaml:"histogram_buckets"`
+	HistogramBuckets []float64 `yaml:"histogram_buckets,omitempty"`
 	// Additional dimensions (labels) to be added to the metric,
 	// along with the default ones (service, span_name, span_kind and span_status).
-	Dimensions []string `yaml:"dimensions"`
+	Dimensions []string `yaml:"dimensions,omitempty"`
 }
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {

--- a/modules/ingester/client/client.go
+++ b/modules/ingester/client/client.go
@@ -21,7 +21,7 @@ import (
 type Config struct {
 	PoolConfig       ring_client.PoolConfig `yaml:"pool_config,omitempty"`
 	RemoteTimeout    time.Duration          `yaml:"remote_timeout,omitempty"`
-	GRPCClientConfig grpcclient.Config      `yaml:"grpc_client_config"`
+	GRPCClientConfig grpcclient.Config      `yaml:"grpc_client_config,omitempty"`
 }
 
 type Client struct {

--- a/modules/ingester/ingester.go
+++ b/modules/ingester/ingester.go
@@ -88,7 +88,7 @@ func New(cfg Config, store storage.Store, limits *overrides.Overrides, reg prome
 		go i.flushLoop(j)
 	}
 
-	lc, err := ring.NewLifecycler(cfg.LifecyclerConfig, i, "ingester", cfg.OverrideRingKey, true, log.Logger, prometheus.WrapRegistererWithPrefix("cortex_", reg))
+	lc, err := ring.NewLifecycler(*cfg.LifecyclerConfig, i, "ingester", cfg.OverrideRingKey, true, log.Logger, prometheus.WrapRegistererWithPrefix("cortex_", reg))
 	if err != nil {
 		return nil, fmt.Errorf("NewLifecycler failed: %w", err)
 	}

--- a/modules/ingester/ingester_test.go
+++ b/modules/ingester/ingester_test.go
@@ -381,9 +381,11 @@ func defaultIngesterWithPush(t testing.TB, tmpDir string, push func(testing.TB, 
 }
 
 func defaultIngesterTestConfig() Config {
-	cfg := Config{}
+	cfg := Config{
+		LifecyclerConfig: &ring.LifecyclerConfig{},
+	}
 
-	flagext.DefaultValues(&cfg.LifecyclerConfig)
+	flagext.DefaultValues(cfg.LifecyclerConfig)
 	mockStore, _ := consul.NewInMemoryClient(
 		ring.GetCodec(),
 		log.NewNopLogger(),

--- a/modules/overrides/limits.go
+++ b/modules/overrides/limits.go
@@ -45,45 +45,45 @@ var (
 // limits via flags, or per-user limits via yaml config.
 type Limits struct {
 	// Distributor enforced limits.
-	IngestionRateStrategy   string    `yaml:"ingestion_rate_strategy" json:"ingestion_rate_strategy"`
-	IngestionRateLimitBytes int       `yaml:"ingestion_rate_limit_bytes" json:"ingestion_rate_limit_bytes"`
-	IngestionBurstSizeBytes int       `yaml:"ingestion_burst_size_bytes" json:"ingestion_burst_size_bytes"`
-	SearchTagsAllowList     ListToMap `yaml:"search_tags_allow_list" json:"search_tags_allow_list"`
+	IngestionRateStrategy   string    `yaml:"ingestion_rate_strategy,omitempty" json:"ingestion_rate_strategy,omitempty"`
+	IngestionRateLimitBytes int       `yaml:"ingestion_rate_limit_bytes,omitempty" json:"ingestion_rate_limit_bytes,omitempty"`
+	IngestionBurstSizeBytes int       `yaml:"ingestion_burst_size_bytes,omitempty" json:"ingestion_burst_size_bytes,omitempty"`
+	SearchTagsAllowList     ListToMap `yaml:"search_tags_allow_list,omitempty" json:"search_tags_allow_list,omitempty"`
 
 	// Ingester enforced limits.
-	MaxLocalTracesPerUser  int `yaml:"max_traces_per_user" json:"max_traces_per_user"`
-	MaxGlobalTracesPerUser int `yaml:"max_global_traces_per_user" json:"max_global_traces_per_user"`
-	MaxSearchBytesPerTrace int `yaml:"max_search_bytes_per_trace" json:"max_search_bytes_per_trace"`
+	MaxLocalTracesPerUser  int `yaml:"max_traces_per_user,omitempty" json:"max_traces_per_user"`
+	MaxGlobalTracesPerUser int `yaml:"max_global_traces_per_user,omitempty" json:"max_global_traces_per_user"`
+	MaxSearchBytesPerTrace int `yaml:"max_search_bytes_per_trace,omitempty" json:"max_search_bytes_per_trace"`
 
 	// Metrics-generator config
-	MetricsGeneratorRingSize                               int           `yaml:"metrics_generator_ring_size" json:"metrics_generator_ring_size"`
-	MetricsGeneratorProcessors                             ListToMap     `yaml:"metrics_generator_processors" json:"metrics_generator_processors"`
-	MetricsGeneratorMaxActiveSeries                        uint32        `yaml:"metrics_generator_max_active_series" json:"metrics_generator_max_active_series"`
-	MetricsGeneratorCollectionInterval                     time.Duration `yaml:"metrics_generator_collection_interval" json:"metrics_generator_collection_interval"`
-	MetricsGeneratorDisableCollection                      bool          `yaml:"metrics_generator_disable_collection" json:"metrics_generator_disable_collection"`
-	MetricsGeneratorForwarderQueueSize                     int           `yaml:"metrics_generator_forwarder_queue_size" json:"metrics_generator_forwarder_queue_size"`
-	MetricsGeneratorForwarderWorkers                       int           `yaml:"metrics_generator_forwarder_workers" json:"metrics_generator_forwarder_workers"`
-	MetricsGeneratorProcessorServiceGraphsHistogramBuckets []float64     `yaml:"metrics_generator_processor_service_graphs_histogram_buckets" json:"metrics_generator_processor_service_graphs_histogram_buckets"`
-	MetricsGeneratorProcessorServiceGraphsDimensions       []string      `yaml:"metrics_generator_processor_service_graphs_dimensions" json:"metrics_generator_processor_service_graphs_dimensions"`
-	MetricsGeneratorProcessorSpanMetricsHistogramBuckets   []float64     `yaml:"metrics_generator_processor_span_metrics_histogram_buckets" json:"metrics_generator_processor_span_metrics_histogram_buckets"`
-	MetricsGeneratorProcessorSpanMetricsDimensions         []string      `yaml:"metrics_generator_processor_span_metrics_dimensions" json:"metrics_generator_processor_span_metrics_dimensions"`
+	MetricsGeneratorRingSize                               int           `yaml:"metrics_generator_ring_size,omitempty" json:"metrics_generator_ring_size,omitempty"`
+	MetricsGeneratorProcessors                             ListToMap     `yaml:"metrics_generator_processors,omitempty" json:"metrics_generator_processors,omitempty"`
+	MetricsGeneratorMaxActiveSeries                        uint32        `yaml:"metrics_generator_max_active_series,omitempty" json:"metrics_generator_max_active_series,omitempty"`
+	MetricsGeneratorCollectionInterval                     time.Duration `yaml:"metrics_generator_collection_interval,omitempty" json:"metrics_generator_collection_interval,omitempty"`
+	MetricsGeneratorDisableCollection                      bool          `yaml:"metrics_generator_disable_collection,omitempty" json:"metrics_generator_disable_collection,omitempty"`
+	MetricsGeneratorForwarderQueueSize                     int           `yaml:"metrics_generator_forwarder_queue_size,omitempty" json:"metrics_generator_forwarder_queue_size,omitempty"`
+	MetricsGeneratorForwarderWorkers                       int           `yaml:"metrics_generator_forwarder_workers,omitempty" json:"metrics_generator_forwarder_workers,omitempty"`
+	MetricsGeneratorProcessorServiceGraphsHistogramBuckets []float64     `yaml:"metrics_generator_processor_service_graphs_histogram_buckets,omitempty" json:"metrics_generator_processor_service_graphs_histogram_buckets,omitempty"`
+	MetricsGeneratorProcessorServiceGraphsDimensions       []string      `yaml:"metrics_generator_processor_service_graphs_dimensions,omitempty" json:"metrics_generator_processor_service_graphs_dimensions,omitempty"`
+	MetricsGeneratorProcessorSpanMetricsHistogramBuckets   []float64     `yaml:"metrics_generator_processor_span_metrics_histogram_buckets,omitempty" json:"metrics_generator_processor_span_metrics_histogram_buckets,omitempty"`
+	MetricsGeneratorProcessorSpanMetricsDimensions         []string      `yaml:"metrics_generator_processor_span_metrics_dimensions,omitempty" json:"metrics_generator_processor_span_metrics_dimensions,omitempty"`
 
 	// Compactor enforced limits.
-	BlockRetention model.Duration `yaml:"block_retention" json:"block_retention"`
+	BlockRetention model.Duration `yaml:"block_retention,omitempty" json:"block_retention,omitempty"`
 
 	// Querier and Ingester enforced limits.
-	MaxBytesPerTagValuesQuery int `yaml:"max_bytes_per_tag_values_query" json:"max_bytes_per_tag_values_query"`
+	MaxBytesPerTagValuesQuery int `yaml:"max_bytes_per_tag_values_query,omitempty" json:"max_bytes_per_tag_values_query,omitempty"`
 
 	// QueryFrontend enforced limits
-	MaxSearchDuration model.Duration `yaml:"max_search_duration" json:"max_search_duration"`
+	MaxSearchDuration model.Duration `yaml:"max_search_duration,omitempty" json:"max_search_duration,omitempty"`
 
 	// MaxBytesPerTrace is enforced in the Ingester, Compactor, Querier (Search) and Serverless (Search). It
 	//  is not used when doing a trace by id lookup.
-	MaxBytesPerTrace int `yaml:"max_bytes_per_trace" json:"max_bytes_per_trace"`
+	MaxBytesPerTrace int `yaml:"max_bytes_per_trace,omitempty" json:"max_bytes_per_trace,omitempty"`
 
 	// Configuration for overrides, convenient if it goes here.
-	PerTenantOverrideConfig string         `yaml:"per_tenant_override_config" json:"per_tenant_override_config"`
-	PerTenantOverridePeriod model.Duration `yaml:"per_tenant_override_period" json:"per_tenant_override_period"`
+	PerTenantOverrideConfig string         `yaml:"per_tenant_override_config,omitempty" json:"per_tenant_override_config,omitempty"`
+	PerTenantOverridePeriod model.Duration `yaml:"per_tenant_override_period,omitempty" json:"per_tenant_override_period,omitempty"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet

--- a/modules/querier/config.go
+++ b/modules/querier/config.go
@@ -13,19 +13,19 @@ import (
 type Config struct {
 	Search SearchConfig `yaml:"search"`
 
-	TraceLookupQueryTimeout time.Duration `yaml:"query_timeout"`
+	TraceLookupQueryTimeout time.Duration `yaml:"query_timeout,omitempty"`
 	ExtraQueryDelay         time.Duration `yaml:"extra_query_delay,omitempty"`
-	MaxConcurrentQueries    int           `yaml:"max_concurrent_queries"`
-	Worker                  worker.Config `yaml:"frontend_worker"`
-	QueryRelevantIngesters  bool          `yaml:"query_relevant_ingesters"`
+	MaxConcurrentQueries    int           `yaml:"max_concurrent_queries,omitempty"`
+	Worker                  worker.Config `yaml:"frontend_worker,omitempty"`
+	QueryRelevantIngesters  bool          `yaml:"query_relevant_ingesters,omitempty"`
 }
 
 type SearchConfig struct {
-	QueryTimeout      time.Duration `yaml:"query_timeout"`
-	PreferSelf        int           `yaml:"prefer_self"`
-	ExternalEndpoints []string      `yaml:"external_endpoints"`
-	HedgeRequestsAt   time.Duration `yaml:"external_hedge_requests_at"`
-	HedgeRequestsUpTo int           `yaml:"external_hedge_requests_up_to"`
+	QueryTimeout      time.Duration `yaml:"query_timeout,omitempty"`
+	PreferSelf        int           `yaml:"prefer_self,omitempty"`
+	ExternalEndpoints []string      `yaml:"external_endpoints,omitempty"`
+	HedgeRequestsAt   time.Duration `yaml:"external_hedge_requests_at,omitempty"`
+	HedgeRequestsUpTo int           `yaml:"external_hedge_requests_up_to,omitempty"`
 }
 
 // RegisterFlagsAndApplyDefaults register flags.

--- a/modules/storage/config.go
+++ b/modules/storage/config.go
@@ -21,12 +21,11 @@ import (
 
 // Config is the Tempo storage configuration
 type Config struct {
-	Trace tempodb.Config `yaml:"trace"`
+	Trace tempodb.Config `yaml:"trace,omitempty"`
 }
 
 // RegisterFlagsAndApplyDefaults registers the flags.
 func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
-
 	cfg.Trace.BlocklistPollFallback = true
 	cfg.Trace.BlocklistPollConcurrency = tempodb.DefaultBlocklistPollConcurrency
 	cfg.Trace.BlocklistPollTenantIndexBuilders = tempodb.DefaultTenantIndexBuilders
@@ -40,7 +39,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.Trace.WAL.SearchEncoding = backend.EncNone
 	cfg.Trace.WAL.IngestionSlack = 2 * time.Minute
 
-	cfg.Trace.Search = &tempodb.SearchConfig{}
+	cfg.Trace.Search = tempodb.SearchConfig{}
 	cfg.Trace.Search.ChunkSizeBytes = tempodb.DefaultSearchChunkSizeBytes
 	cfg.Trace.Search.PrefetchTraceCount = tempodb.DefaultPrefetchTraceCount
 	cfg.Trace.Search.ReadBufferCount = tempodb.DefaultReadBufferCount

--- a/pkg/usagestats/config.go
+++ b/pkg/usagestats/config.go
@@ -8,14 +8,17 @@ import (
 )
 
 type Config struct {
-	Enabled bool           `yaml:"reporting_enabled"`
-	Leader  bool           `yaml:"-"`
-	Backoff backoff.Config `yaml:"backoff"`
+	Enabled bool            `yaml:"reporting_enabled,omitempty"`
+	Leader  bool            `yaml:"-"`
+	Backoff *backoff.Config `yaml:"backoff,omitempty"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
 func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 	f.BoolVar(&cfg.Enabled, util.PrefixConfig(prefix, "enabled"), true, "Enable anonymous usage reporting.")
+	if cfg.Backoff == nil {
+		cfg.Backoff = &backoff.Config{}
+	}
 	cfg.Backoff.RegisterFlagsWithPrefix(prefix, f)
 	cfg.Backoff.MaxRetries = 0
 }

--- a/pkg/usagestats/reporter.go
+++ b/pkg/usagestats/reporter.go
@@ -73,8 +73,11 @@ func (rep *Reporter) initLeader(ctx context.Context) *ClusterSeed {
 		level.Warn(rep.logger).Log("msg", "failed to create kv client", "err", err)
 		return nil
 	}
+	if rep.conf.Backoff == nil {
+		rep.conf.Backoff = &backoff.Config{}
+	}
 	// Try to become leader via the kv client
-	backoff := backoff.New(ctx, rep.conf.Backoff)
+	backoff := backoff.New(ctx, *rep.conf.Backoff)
 	for backoff.Ongoing() {
 		// create a new cluster seed
 		seed := ClusterSeed{
@@ -170,8 +173,11 @@ func (rep *Reporter) init(ctx context.Context) {
 // fetchSeed fetches the cluster seed from the object store and try until it succeeds.
 // continueFn allow you to decide if we should continue retrying. Nil means always retry
 func (rep *Reporter) fetchSeed(ctx context.Context, continueFn func(err error) bool) (*ClusterSeed, error) {
+	if rep.conf.Backoff == nil {
+		rep.conf.Backoff = &backoff.Config{}
+	}
 	var (
-		backoff    = backoff.New(ctx, rep.conf.Backoff)
+		backoff    = backoff.New(ctx, *rep.conf.Backoff)
 		readingErr = 0
 	)
 	for backoff.Ongoing() {

--- a/tempodb/config.go
+++ b/tempodb/config.go
@@ -1,7 +1,6 @@
 package tempodb
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -35,45 +34,45 @@ const (
 // Defaults are in modules/storage/config.go
 type Config struct {
 	Pool   *pool.Config        `yaml:"pool,omitempty"`
-	WAL    *wal.Config         `yaml:"wal"`
-	Block  *common.BlockConfig `yaml:"block"`
-	Search *SearchConfig       `yaml:"search"`
+	WAL    *wal.Config         `yaml:"wal,omitempty"`
+	Block  *common.BlockConfig `yaml:"block,omitempty"`
+	Search SearchConfig        `yaml:"search,omitempty"`
 
-	BlocklistPoll                    time.Duration `yaml:"blocklist_poll"`
-	BlocklistPollConcurrency         uint          `yaml:"blocklist_poll_concurrency"`
-	BlocklistPollFallback            bool          `yaml:"blocklist_poll_fallback"`
-	BlocklistPollTenantIndexBuilders int           `yaml:"blocklist_poll_tenant_index_builders"`
-	BlocklistPollStaleTenantIndex    time.Duration `yaml:"blocklist_poll_stale_tenant_index"`
-	BlocklistPollJitterMs            int           `yaml:"blocklist_poll_jitter_ms"`
+	BlocklistPoll                    time.Duration `yaml:"blocklist_poll,omitempty"`
+	BlocklistPollConcurrency         uint          `yaml:"blocklist_poll_concurrency,omitempty"`
+	BlocklistPollFallback            bool          `yaml:"blocklist_poll_fallback,omitempty"`
+	BlocklistPollTenantIndexBuilders int           `yaml:"blocklist_poll_tenant_index_builders,omitempty"`
+	BlocklistPollStaleTenantIndex    time.Duration `yaml:"blocklist_poll_stale_tenant_index,omitempty"`
+	BlocklistPollJitterMs            int           `yaml:"blocklist_poll_jitter_ms,omitempty"`
 
 	// backends
-	Backend string        `yaml:"backend"`
-	Local   *local.Config `yaml:"local"`
-	GCS     *gcs.Config   `yaml:"gcs"`
-	S3      *s3.Config    `yaml:"s3"`
-	Azure   *azure.Config `yaml:"azure"`
+	Backend string        `yaml:"backend,omitempty"`
+	Local   *local.Config `yaml:"local,omitempty"`
+	GCS     *gcs.Config   `yaml:"gcs,omitempty"`
+	S3      *s3.Config    `yaml:"s3,omitempty"`
+	Azure   *azure.Config `yaml:"azure,omitempty"`
 
 	// caches
-	Cache                   string                  `yaml:"cache"`
-	CacheMinCompactionLevel uint8                   `yaml:"cache_min_compaction_level"`
-	CacheMaxBlockAge        time.Duration           `yaml:"cache_max_block_age"`
-	BackgroundCache         *cache.BackgroundConfig `yaml:"background_cache"`
-	Memcached               *memcached.Config       `yaml:"memcached"`
-	Redis                   *redis.Config           `yaml:"redis"`
+	Cache                   string                  `yaml:"cache,omitempty"`
+	CacheMinCompactionLevel uint8                   `yaml:"cache_min_compaction_level,omitempty"`
+	CacheMaxBlockAge        time.Duration           `yaml:"cache_max_block_age,omitempty"`
+	BackgroundCache         *cache.BackgroundConfig `yaml:"background_cache,omitempty"`
+	Memcached               *memcached.Config       `yaml:"memcached,omitempty"`
+	Redis                   *redis.Config           `yaml:"redis,omitempty"`
 }
 
 type SearchConfig struct {
 	// v2 blocks
-	ChunkSizeBytes     uint32 `yaml:"chunk_size_bytes"`
-	PrefetchTraceCount int    `yaml:"prefetch_trace_count"`
+	ChunkSizeBytes     uint32 `yaml:"chunk_size_bytes,omitempty"`
+	PrefetchTraceCount int    `yaml:"prefetch_trace_count,omitempty"`
 
 	// vParquet blocks
-	ReadBufferCount     int `yaml:"read_buffer_count"`
-	ReadBufferSizeBytes int `yaml:"read_buffer_size_bytes"`
+	ReadBufferCount     int `yaml:"read_buffer_count,omitempty"`
+	ReadBufferSizeBytes int `yaml:"read_buffer_size_bytes,omitempty"`
 	CacheControl        struct {
-		Footer      bool `yaml:"footer"`
-		ColumnIndex bool `yaml:"column_index"`
-		OffsetIndex bool `yaml:"offset_index"`
+		Footer      bool `yaml:"footer,omitempty"`
+		ColumnIndex bool `yaml:"column_index,omitempty"`
+		OffsetIndex bool `yaml:"offset_index,omitempty"`
 	} `yaml:"cache_control"`
 }
 
@@ -103,28 +102,20 @@ func (c SearchConfig) ApplyToOptions(o *common.SearchOptions) {
 
 // CompactorConfig contains compaction configuration options
 type CompactorConfig struct {
-	ChunkSizeBytes          uint32        `yaml:"chunk_size_bytes"`
-	FlushSizeBytes          uint32        `yaml:"flush_size_bytes"`
-	MaxCompactionRange      time.Duration `yaml:"compaction_window"`
-	MaxCompactionObjects    int           `yaml:"max_compaction_objects"`
-	MaxBlockBytes           uint64        `yaml:"max_block_bytes"`
-	BlockRetention          time.Duration `yaml:"block_retention"`
-	CompactedBlockRetention time.Duration `yaml:"compacted_block_retention"`
-	RetentionConcurrency    uint          `yaml:"retention_concurrency"`
-	IteratorBufferSize      int           `yaml:"iterator_buffer_size"`
-	MaxTimePerTenant        time.Duration `yaml:"max_time_per_tenant"`
-	CompactionCycle         time.Duration `yaml:"compaction_cycle"`
+	ChunkSizeBytes          uint32        `yaml:"chunk_size_bytes,omitempty"`
+	FlushSizeBytes          uint32        `yaml:"flush_size_bytes,omitempty"`
+	MaxCompactionRange      time.Duration `yaml:"compaction_window,omitempty"`
+	MaxCompactionObjects    int           `yaml:"max_compaction_objects,omitempty"`
+	MaxBlockBytes           uint64        `yaml:"max_block_bytes,omitempty"`
+	BlockRetention          time.Duration `yaml:"block_retention,omitempty"`
+	CompactedBlockRetention time.Duration `yaml:"compacted_block_retention,omitempty"`
+	RetentionConcurrency    uint          `yaml:"retention_concurrency,omitempty"`
+	IteratorBufferSize      int           `yaml:"iterator_buffer_size,omitempty"`
+	MaxTimePerTenant        time.Duration `yaml:"max_time_per_tenant,omitempty"`
+	CompactionCycle         time.Duration `yaml:"compaction_cycle,omitempty"`
 }
 
 func validateConfig(cfg *Config) error {
-	if cfg.WAL == nil {
-		return errors.New("wal config should be non-nil")
-	}
-
-	if cfg.Block == nil {
-		return errors.New("block config should be non-nil")
-	}
-
 	err := common.ValidateConfig(cfg.Block)
 	if err != nil {
 		return fmt.Errorf("block config validation failed: %w", err)

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -315,7 +315,7 @@ func (rw *readerWriter) Find(ctx context.Context, tenantID string, id common.ID,
 	}
 
 	opts := common.SearchOptions{}
-	if rw.cfg != nil && rw.cfg.Search != nil {
+	if rw.cfg != nil {
 		rw.cfg.Search.ApplyToOptions(&opts)
 	}
 

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -46,7 +46,7 @@ func testSearchCompleteBlock(t *testing.T, blockVersion string) {
 			Filepath:       path.Join(tempDir, "wal"),
 			IngestionSlack: time.Since(time.Time{}),
 		},
-		Search: &SearchConfig{
+		Search: SearchConfig{
 			ChunkSizeBytes:      1_000_000,
 			ReadBufferCount:     8,
 			ReadBufferSizeBytes: 4 * 1024 * 1024,


### PR DESCRIPTION
Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This PR sets `omitempty` on the config fields of different components. This allow us to serialized the config structures into a YAML  and omit fields that has empty values (empty string, 0s or nil), In this way we can use the structures to generate a valid config YAML with only the fields we want to specify, and use default config values for the fields that are not appear in the serialized configuration.

If we don't specify `omitempty` the config structure will generate a YAML with all the fields with empty strings, 0s etc.., this will override the default values for the different fields.

The concrete use case for this is to use the same tempo config structures to generate the configuration for the tempo operator.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`