### PR TITLE
Update parquet-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/prometheus/prometheus v1.8.2-0.20220315145411-881111fec433
 	github.com/prometheus/statsd_exporter v0.21.0 // indirect
 	github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e
-	github.com/segmentio/parquet-go v0.0.0-20221003204439-948ea8c65f19
+	github.com/segmentio/parquet-go v0.0.0-20221018184815-acc0bae1e2e0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/sony/gobreaker v0.4.1
 	github.com/spf13/viper v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -2015,6 +2015,8 @@ github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfP
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/parquet-go v0.0.0-20221003204439-948ea8c65f19 h1:VFwf4u4+AbJF8XAsKSofTMc4nOmwRSiR3ekhh5ZITUQ=
 github.com/segmentio/parquet-go v0.0.0-20221003204439-948ea8c65f19/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
+github.com/segmentio/parquet-go v0.0.0-20221018184815-acc0bae1e2e0 h1:axivglUNPCwihjp/2V7tMX95SuqEiYoRrm63RSEM9k4=
+github.com/segmentio/parquet-go v0.0.0-20221018184815-acc0bae1e2e0/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/sercand/kuberesolver v2.1.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=
 github.com/sercand/kuberesolver v2.4.0+incompatible h1:WE2OlRf6wjLxHwNkkFLQGaZcVLEXjMjBPjjEU5vksH8=
 github.com/sercand/kuberesolver v2.4.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=


### PR DESCRIPTION
Updates parquet-go to latest primarily to catch: 

https://github.com/segmentio/parquet-go/pull/376

This fixes #1592 