### PR TITLE
[Parquet] Improve ingester search and find trace by id time

### DIFF
--- a/tempodb/encoding/vparquet/block.go
+++ b/tempodb/encoding/vparquet/block.go
@@ -1,8 +1,11 @@
 package vparquet
 
 import (
+	"sync"
+
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
+	"github.com/segmentio/parquet-go"
 )
 
 const (
@@ -12,12 +15,19 @@ const (
 type backendBlock struct {
 	meta *backend.BlockMeta
 	r    backend.Reader
+
+	openMtx  sync.Mutex
+	pf       *parquet.File
+	readerAt *BackendReaderAt
 }
 
 var _ common.BackendBlock = (*backendBlock)(nil)
 
 func newBackendBlock(meta *backend.BlockMeta, r backend.Reader) *backendBlock {
-	return &backendBlock{meta, r}
+	return &backendBlock{
+		meta: meta,
+		r:    r,
+	}
 }
 
 func (b *backendBlock) BlockMeta() *backend.BlockMeta {

--- a/tempodb/encoding/vparquet/block_findtracebyid_test.go
+++ b/tempodb/encoding/vparquet/block_findtracebyid_test.go
@@ -98,7 +98,6 @@ func TestBackendBlockFindTraceByID(t *testing.T) {
 
 		gotProto, err := b.FindTraceByID(ctx, tr.TraceID, common.SearchOptions{})
 		require.NoError(t, err)
-
 		require.Equal(t, wantProto, gotProto)
 	}
 }

--- a/tempodb/encoding/vparquet/block_search.go
+++ b/tempodb/encoding/vparquet/block_search.go
@@ -36,11 +36,14 @@ var StatusCodeMapping = map[string]int{
 	StatusCodeError: int(v1.Status_STATUS_CODE_ERROR),
 }
 
-// openForSearch consolidates all the logic regarding opening a parquet file in object storage
+// openForSearch consolidates all the logic for opening a parquet file
 func (b *backendBlock) openForSearch(ctx context.Context, opts common.SearchOptions) (*parquet.File, *BackendReaderAt, error) {
 	b.openMtx.Lock()
 	defer b.openMtx.Unlock()
 
+	// if this is parquet file is repeatedly used for search/searchtags/findtracebyid/etc then this is a nice
+	// performance improvement. this does not happen currently for full backend search, but does happen
+	// if this is a complete block held on disk by the ingester
 	if b.pf != nil && b.readerAt != nil {
 		return b.pf, b.readerAt, nil
 	}

--- a/tempodb/encoding/vparquet/block_search.go
+++ b/tempodb/encoding/vparquet/block_search.go
@@ -79,8 +79,10 @@ func (b *backendBlock) openForSearch(ctx context.Context, opts common.SearchOpti
 	defer span.Finish()
 	pf, err := parquet.OpenFile(readerAt, int64(b.meta.Size), o...)
 
-	b.pf = pf
-	b.readerAt = backendReaderAt
+	if err == nil {
+		b.pf = pf
+		b.readerAt = backendReaderAt
+	}
 
 	return pf, backendReaderAt, err
 }

--- a/tempodb/encoding/vparquet/block_search.go
+++ b/tempodb/encoding/vparquet/block_search.go
@@ -41,7 +41,7 @@ func (b *backendBlock) openForSearch(ctx context.Context, opts common.SearchOpti
 	b.openMtx.Lock()
 	defer b.openMtx.Unlock()
 
-	// if this is parquet file is repeatedly used for search/searchtags/findtracebyid/etc then this is a nice
+	// if this backend block is repeatedly used for search/searchtags/findtracebyid/etc then this is a nice
 	// performance improvement. this does not happen currently for full backend search, but does happen
 	// if this is a complete block held on disk by the ingester
 	if b.pf != nil && b.readerAt != nil {


### PR DESCRIPTION
**What this PR does**:
Updates the backendBlock to hold a reference to the backend reader and parquet file so it only has to open a complete block once. Stumbled on this while working on the parquet wal.

```
name                                      old time/op    new time/op    delta
InstanceFindTraceByIDFromCompleteBlock-8    1.75ms ± 4%    1.40ms ± 9%  -19.73%  (p=0.000 n=9+10)

name                                      old alloc/op   new alloc/op   delta
InstanceFindTraceByIDFromCompleteBlock-8    1.02MB ± 1%    0.88MB ± 1%  -12.86%  (p=0.000 n=9+10)

name                                      old allocs/op  new allocs/op  delta
InstanceFindTraceByIDFromCompleteBlock-8     4.28k ± 1%     2.31k ± 2%  -46.11%  (p=0.000 n=10+10)
```

Prior to this change a cpu profile of repeated opens showed large amounts of time spent reopening the parquet file:

![image](https://user-images.githubusercontent.com/2272392/197031184-d28547cb-f996-4519-b012-f6a38e45eaee.png)

For full backend search this will have minimal impact as backend blocks are created, used and discarded.