### PR TITLE
Parquet iterator memory improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/prometheus/prometheus v1.8.2-0.20220315145411-881111fec433
 	github.com/prometheus/statsd_exporter v0.21.0 // indirect
 	github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e
-	github.com/segmentio/parquet-go v0.0.0-20221018184815-acc0bae1e2e0
+	github.com/segmentio/parquet-go v0.0.0-20221019213850-8b6e2b21a101
 	github.com/sirupsen/logrus v1.8.1
 	github.com/sony/gobreaker v0.4.1
 	github.com/spf13/viper v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -2015,6 +2015,8 @@ github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfP
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/parquet-go v0.0.0-20221018184815-acc0bae1e2e0 h1:axivglUNPCwihjp/2V7tMX95SuqEiYoRrm63RSEM9k4=
 github.com/segmentio/parquet-go v0.0.0-20221018184815-acc0bae1e2e0/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
+github.com/segmentio/parquet-go v0.0.0-20221019213850-8b6e2b21a101 h1:EAHbI5CHJtFCjcn06YK7ACGfd8RcuGo9Cr0Z2MdgM6c=
+github.com/segmentio/parquet-go v0.0.0-20221019213850-8b6e2b21a101/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/sercand/kuberesolver v2.1.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=
 github.com/sercand/kuberesolver v2.4.0+incompatible h1:WE2OlRf6wjLxHwNkkFLQGaZcVLEXjMjBPjjEU5vksH8=
 github.com/sercand/kuberesolver v2.4.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=

--- a/tempodb/encoding/vparquet/block_search.go
+++ b/tempodb/encoding/vparquet/block_search.go
@@ -170,10 +170,18 @@ func (b *backendBlock) SearchTags(ctx context.Context, cb common.TagCallback, op
 						return err
 					}
 
-					// if a special attribute has any non-null values, include it
-					if pg.NumNulls() < pg.NumValues() {
-						cb(lbl)
-						delete(specialAttrIdxs, idx) // remove from map so we won't search again
+					stop := func(page parquet.Page) bool {
+						defer parquet.Release(pg)
+
+						// if a special attribute has any non-null values, include it
+						if pg.NumNulls() < pg.NumValues() {
+							cb(lbl)
+							delete(specialAttrIdxs, idx) // remove from map so we won't search again
+							return true
+						}
+						return false
+					}(pg)
+					if stop {
 						break
 					}
 				}
@@ -199,15 +207,19 @@ func (b *backendBlock) SearchTags(ctx context.Context, cb common.TagCallback, op
 						return err
 					}
 
-					dict := pg.Dictionary()
-					if dict == nil {
-						continue
-					}
+					func(page parquet.Page) {
+						defer parquet.Release(pg)
 
-					for i := 0; i < dict.Len(); i++ {
-						s := string(dict.Index(int32(i)).ByteArray())
-						cb(s)
-					}
+						dict := pg.Dictionary()
+						if dict == nil {
+							return
+						}
+
+						for i := 0; i < dict.Len(); i++ {
+							s := string(dict.Index(int32(i)).ByteArray())
+							cb(s)
+						}
+					}(pg)
 				}
 				return nil
 			}()
@@ -490,7 +502,7 @@ func searchStandardTagValues(ctx context.Context, tag string, pf *parquet.File, 
 		return errors.Wrap(err, "search resource key values")
 	}
 
-	err = searchKeyValues(DefinitionLevelResourceSpansILSSpan, FieldSpanAttrKey, FieldSpanAttrVal, makeIter, keyPred, cb)
+	err = searchKeyValues(DefinitionLevelResourceSpansILSSpanAttrs, FieldSpanAttrKey, FieldSpanAttrVal, makeIter, keyPred, cb)
 	if err != nil {
 		return errors.Wrap(err, "search span key values")
 	}

--- a/vendor/github.com/segmentio/parquet-go/page.go
+++ b/vendor/github.com/segmentio/parquet-go/page.go
@@ -318,7 +318,7 @@ func forEachPageSlice(page Page, wantSize int64, do func(Page) error) error {
 		lastRowIndex := rowIndex + ((numRows - rowIndex) / numPages)
 		pageSlice := page.Slice(rowIndex, lastRowIndex)
 		err := do(pageSlice)
-		unref(pageSlice)
+		Release(pageSlice)
 		if err != nil {
 			return err
 		}

--- a/vendor/github.com/segmentio/parquet-go/row_group.go
+++ b/vendor/github.com/segmentio/parquet-go/row_group.go
@@ -300,7 +300,7 @@ func (r *rowGroupRows) init() {
 
 func (r *rowGroupRows) clear() {
 	for i := range r.columns {
-		unref(r.columns[i].page)
+		Release(r.columns[i].page)
 	}
 
 	for i := range r.columns {
@@ -395,7 +395,7 @@ func (r *rowGroupRows) ReadRows(rows []Row) (int, error) {
 			c.offset = 0
 			c.length = 0
 			c.values = nil
-			unref(c.page)
+			Release(c.page)
 
 			c.page, err = r.readers[i].ReadPage()
 			if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -848,7 +848,7 @@ github.com/segmentio/encoding/thrift
 # github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e
 ## explicit
 github.com/segmentio/fasthash/fnv1a
-# github.com/segmentio/parquet-go v0.0.0-20221018184815-acc0bae1e2e0
+# github.com/segmentio/parquet-go v0.0.0-20221019213850-8b6e2b21a101
 ## explicit; go 1.19
 github.com/segmentio/parquet-go
 github.com/segmentio/parquet-go/bloom


### PR DESCRIPTION
**What this PR does**:
This PR updates column iterators to make use of the new `page.Release()` method [added to parquet-go](https://github.com/segmentio/parquet-go/issues/370). This reduces memory usage by repooling the page and its buffers to the pools internal to the library.   Overall memory usage for column iteration is significantly reduced in the areas where this is used:  Search, SearchTags, and SearchTagValues.  However in some cases there is an increase in `allocs` which is explained below.  Overall the savings look worth it. There is also a small bump in iterator speed.

**Allocs**
String values returned from the parquet library are unsafe casts pointing to the underlying page bytes.  Because Tempo channelizes results and those strings may live on past the lifetime of the iterator (i.e. into http results, etc), we have to copy them to disconnect and allow the page to be reused.  This is the increase in allocs and is from the new `value.Clone()` in the iterator loop.  Previously, this wasn't necessary because pages weren't reused, they were resident until no longer referenced by a string and GCed.  `partialMatch` exhibits this behavior the most because it matches many values in a column but throws them away via overall mismatch.  An area for improvement.

**DistinctStringCollector**
SearchTags and SearchTagValues use DistinctStringCollector to gather unique strings.  Much of this comes from page header dictionaries.  This also needs to disconnect the string from the underlying page to allow it to be reused, but instead it was added to `DistinctStringCollector.Collect()` only for kept (unique) values.  This is responsible for the, frankly insane, memory reduction in `SearchTagValues/http.url` (it was cloning all values whether they were unique or not using `string(dict.index(i).ByteArray())`.

```
name                                      old time/op    new time/op    delta
BackendBlockSearchTraces/noMatch-12          258ms ±22%     222ms ±12%    -14.25%  (p=0.002 n=10+9)
BackendBlockSearchTraces/partialMatch-12     2.86s ±12%     2.77s ± 9%       ~     (p=0.549 n=10+9)
BackendBlockSearchTraces/service.name-12    13.6ms ±13%    11.5ms ± 5%    -15.71%  (p=0.000 n=10+9)
BackendBlockSearchTags-12                    2.36s ±13%     1.54s ±18%    -34.65%  (p=0.000 n=10+10)
BackendBlockSearchTagValues/foo-12           1.52s ± 6%     1.01s ± 1%    -33.48%  (p=0.000 n=10+9)
BackendBlockSearchTagValues/http.url-12      41.0s ± 3%     23.2s ± 2%    -43.40%  (p=0.000 n=10+9)

name                                      old speed      new speed      delta
BackendBlockSearchTraces/noMatch-12        112MB/s ±12%   126MB/s ±11%    +12.70%  (p=0.001 n=9+9)
BackendBlockSearchTraces/partialMatch-12  23.6MB/s ±12%  24.2MB/s ± 9%       ~     (p=0.534 n=10+9)
BackendBlockSearchTraces/service.name-12   107MB/s ±14%   121MB/s ± 6%    +12.89%  (p=0.000 n=10+10)

name                                      old alloc/op   new alloc/op   delta
BackendBlockSearchTraces/noMatch-12         1.06GB ± 7%    0.34GB ± 4%    -68.08%  (p=0.000 n=9+9)
BackendBlockSearchTraces/partialMatch-12    1.09GB ± 1%    0.61GB ± 2%    -43.46%  (p=0.000 n=9+9)
BackendBlockSearchTraces/service.name-12    34.3MB ± 4%    11.7MB ±18%    -65.85%  (p=0.000 n=10+10)
BackendBlockSearchTags-12                   6.27GB ± 0%    1.76GB ± 2%    -71.93%  (p=0.000 n=10+10)
BackendBlockSearchTagValues/foo-12          6.34GB ± 0%    2.31GB ± 1%    -63.57%  (p=0.000 n=9+9)
BackendBlockSearchTagValues/http.url-12     75.7GB ± 0%     1.2GB ± 2%    -98.48%  (p=0.000 n=6+9)

name                                      old allocs/op  new allocs/op  delta
BackendBlockSearchTraces/noMatch-12           258k ± 5%      179k ± 2%    -30.69%  (p=0.000 n=9+9)
BackendBlockSearchTraces/partialMatch-12      281k ± 0%    18011k ± 0%  +6300.41%  (p=0.000 n=9+9)
BackendBlockSearchTraces/service.name-12     63.1k ± 0%     99.2k ± 0%    +57.14%  (p=0.000 n=10+10)
BackendBlockSearchTags-12                    13.8M ± 0%      1.0M ± 0%    -92.73%  (p=0.000 n=10+9)
BackendBlockSearchTagValues/foo-12           1.23M ± 0%     1.02M ± 0%    -17.37%  (p=0.000 n=9+9)
BackendBlockSearchTagValues/http.url-12       398M ± 0%        1M ± 0%    -99.87%  (p=0.000 n=9+9)

```



**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`