### PR TITLE
[TraceQL] Implement SpansetOperations And and Union

### DIFF
--- a/pkg/traceql/ast.go
+++ b/pkg/traceql/ast.go
@@ -196,10 +196,6 @@ func newSpansetOperation(op Operator, lhs SpansetExpression, rhs SpansetExpressi
 // nolint: revive
 func (SpansetOperation) __spansetExpression() {}
 
-func (SpansetOperation) evaluate(ss []Spanset) ([]Spanset, error) {
-	return ss, nil
-}
-
 type SpansetFilter struct {
 	Expression FieldExpression
 }

--- a/pkg/traceql/engine_test.go
+++ b/pkg/traceql/engine_test.go
@@ -113,6 +113,21 @@ func TestEngine_Execute(t *testing.T) {
 			},
 		},
 	}
+
+	// Sort attributes for consistent equality checks
+	// This is needed because they are internally stored in maps
+	sort := func(mm []*tempopb.TraceSearchMetadata) {
+		for _, m := range mm {
+			for _, s := range m.SpanSet.Spans {
+				sort.Slice(s.Attributes, func(i, j int) bool {
+					return s.Attributes[i].Key < s.Attributes[j].Key
+				})
+			}
+		}
+	}
+	sort(expectedTraceSearchMetadata)
+	sort(response.Traces)
+
 	assert.Equal(t, expectedTraceSearchMetadata, response.Traces)
 }
 


### PR DESCRIPTION
**What this PR does**:
This PR implements the And (&&) and Union (||) spanset operators.  Other operators are unsupported and will return an error.  Also fixes a flaky test by sorting span attributes.

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`