### PR TITLE
Better default options

### DIFF
--- a/modules/ingester/instance_search.go
+++ b/modules/ingester/instance_search.go
@@ -223,7 +223,10 @@ func (i *instance) searchLocalBlocks(ctx context.Context, req *tempopb.SearchReq
 			span.LogFields(ot_log.Event("local block entry mtx acquired"))
 			span.SetTag("blockID", blockID)
 
-			resp, err := e.Search(ctx, req, common.SearchOptions{})
+			resp, err := e.Search(ctx, req, common.SearchOptions{
+				ReadBufferCount: 32,
+				ReadBufferSize:  1024 * 1024,
+			})
 			if err != nil {
 				level.Error(log.Logger).Log("msg", "error searching local block", "blockID", blockID, "err", err)
 				return
@@ -283,7 +286,10 @@ func (i *instance) SearchTags(ctx context.Context) (*tempopb.SearchTagsResponse,
 				continue
 			}
 
-			err = b.SearchTags(ctx, distinctValues.Collect, common.SearchOptions{})
+			err = b.SearchTags(ctx, distinctValues.Collect, common.SearchOptions{
+				ReadBufferCount: 32,
+				ReadBufferSize:  1024 * 1024,
+			})
 			if err == common.ErrUnsupported {
 				level.Warn(log.Logger).Log("msg", "block does not support tag search", "blockID", b.BlockMeta().BlockID)
 				continue
@@ -352,7 +358,10 @@ func (i *instance) SearchTagValues(ctx context.Context, tagName string) (*tempop
 				continue
 			}
 
-			err = b.SearchTagValues(ctx, tagName, distinctValues.Collect, common.SearchOptions{})
+			err = b.SearchTagValues(ctx, tagName, distinctValues.Collect, common.SearchOptions{
+				ReadBufferCount: 32,
+				ReadBufferSize:  1024 * 1024,
+			})
 			if err == common.ErrUnsupported {
 				level.Warn(log.Logger).Log("msg", "block does not support tag value search", "blockID", b.BlockMeta().BlockID)
 				continue


### PR DESCRIPTION
**What this PR does**:
Sets hardcoded default options to prevent repeated disk i/os on local searches.

```
name                             old time/op    new time/op    delta
InstanceSearchCompleteParquet-8     253ms ±15%      84ms ± 7%  -66.83%  (p=0.000 n=10+9)

name                             old alloc/op   new alloc/op   delta
InstanceSearchCompleteParquet-8    42.4MB ± 3%    25.3MB ± 2%  -40.20%  (p=0.000 n=10+9)

name                             old allocs/op  new allocs/op  delta
InstanceSearchCompleteParquet-8      476k ± 3%      228k ± 1%  -52.01%  (p=0.000 n=10+9)
```