### PR TITLE
Remove InstrumentedPredicate Locking

### DIFF
--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -294,12 +294,12 @@ func (c *ColumnIterator) iterate(ctx context.Context, readSize int) {
 		"column":      c.colName,
 	})
 	defer func() {
-		span.SetTag("inspectedColumnChunks", c.filter.InspectedColumnChunks.Load())
-		span.SetTag("inspectedPages", c.filter.InspectedPages.Load())
-		span.SetTag("inspectedValues", c.filter.InspectedValues.Load())
-		span.SetTag("keptColumnChunks", c.filter.KeptColumnChunks.Load())
-		span.SetTag("keptPages", c.filter.KeptPages.Load())
-		span.SetTag("keptValues", c.filter.KeptValues.Load())
+		span.SetTag("inspectedColumnChunks", c.filter.InspectedColumnChunks)
+		span.SetTag("inspectedPages", c.filter.InspectedPages)
+		span.SetTag("inspectedValues", c.filter.InspectedValues)
+		span.SetTag("keptColumnChunks", c.filter.KeptColumnChunks)
+		span.SetTag("keptPages", c.filter.KeptPages)
+		span.SetTag("keptValues", c.filter.KeptValues)
 		span.Finish()
 	}()
 

--- a/pkg/parquetquery/predicate_test.go
+++ b/pkg/parquetquery/predicate_test.go
@@ -77,9 +77,9 @@ func testPredicate(t *testing.T, tc predicateTestCase) {
 		}
 	}
 
-	require.Equal(t, tc.keptChunks, int(p.KeptColumnChunks.Load()), "keptChunks")
-	require.Equal(t, tc.keptPages, int(p.KeptPages.Load()), "keptPages")
-	require.Equal(t, tc.keptValues, int(p.KeptValues.Load()), "keptValues")
+	require.Equal(t, tc.keptChunks, int(p.KeptColumnChunks), "keptChunks")
+	require.Equal(t, tc.keptPages, int(p.KeptPages), "keptPages")
+	require.Equal(t, tc.keptValues, int(p.KeptValues), "keptValues")
 }
 
 func BenchmarkSubstringPredicate(b *testing.B) {

--- a/pkg/parquetquery/predicates.go
+++ b/pkg/parquetquery/predicates.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	pq "github.com/segmentio/parquet-go"
-	"github.com/uber-go/atomic"
 )
 
 // Predicate is a pushdown predicate that can be applied at
@@ -443,21 +442,21 @@ func (p *OrPredicate) KeepValue(v pq.Value) bool {
 
 type InstrumentedPredicate struct {
 	pred                  Predicate // Optional, if missing then just keeps metrics with no filtering
-	InspectedColumnChunks atomic.Int64
-	InspectedPages        atomic.Int64
-	InspectedValues       atomic.Int64
-	KeptColumnChunks      atomic.Int64
-	KeptPages             atomic.Int64
-	KeptValues            atomic.Int64
+	InspectedColumnChunks int64
+	InspectedPages        int64
+	InspectedValues       int64
+	KeptColumnChunks      int64
+	KeptPages             int64
+	KeptValues            int64
 }
 
 var _ Predicate = (*InstrumentedPredicate)(nil)
 
 func (p *InstrumentedPredicate) KeepColumnChunk(c pq.ColumnChunk) bool {
-	p.InspectedColumnChunks.Inc()
+	p.InspectedColumnChunks++
 
 	if p.pred == nil || p.pred.KeepColumnChunk(c) {
-		p.KeptColumnChunks.Inc()
+		p.KeptColumnChunks++
 		return true
 	}
 
@@ -465,10 +464,10 @@ func (p *InstrumentedPredicate) KeepColumnChunk(c pq.ColumnChunk) bool {
 }
 
 func (p *InstrumentedPredicate) KeepPage(page pq.Page) bool {
-	p.InspectedPages.Inc()
+	p.InspectedPages++
 
 	if p.pred == nil || p.pred.KeepPage(page) {
-		p.KeptPages.Inc()
+		p.KeptPages++
 		return true
 	}
 
@@ -476,10 +475,10 @@ func (p *InstrumentedPredicate) KeepPage(page pq.Page) bool {
 }
 
 func (p *InstrumentedPredicate) KeepValue(v pq.Value) bool {
-	p.InspectedValues.Inc()
+	p.InspectedValues++
 
 	if p.pred == nil || p.pred.KeepValue(v) {
-		p.KeptValues.Inc()
+		p.KeptValues++
 		return true
 	}
 


### PR DESCRIPTION
**What this PR does**:
Removes locking on the predicate filter. Evaluating the usage in ColumnIterator this seems safe as it's all accessed from the same goroutine.

For larger queries accessing millions or 10s of millions of values this can save 5-7% on query time.

Benchmarks are run against real trace data and evaluating ~30M values:
```
name                             old time/op    new time/op    delta
InstanceSearchCompleteParquet-8     1.77s ± 6%     1.66s ± 5%  -6.25%  (p=0.004 n=9+9)

name                             old alloc/op   new alloc/op   delta
InstanceSearchCompleteParquet-8     320MB ± 1%     320MB ± 1%    ~     (p=0.897 n=10+8)

name                             old allocs/op  new allocs/op  delta
InstanceSearchCompleteParquet-8     2.32M ± 0%     2.32M ± 0%    ~     (p=0.666 n=9+9)
```