### PR TITLE
Fix panic in RegexInPredicate

### DIFF
--- a/pkg/parquetquery/predicates.go
+++ b/pkg/parquetquery/predicates.go
@@ -98,7 +98,8 @@ var _ Predicate = (*RegexInPredicate)(nil)
 
 func NewRegexInPredicate(regs []string) (*RegexInPredicate, error) {
 	p := &RegexInPredicate{
-		regs: make([]*regexp.Regexp, 0, len(regs)),
+		regs:    make([]*regexp.Regexp, 0, len(regs)),
+		matches: make(map[string]bool),
 	}
 	for _, reg := range regs {
 		r, err := regexp.Compile(reg)


### PR DESCRIPTION
**What this PR does**:
This PR fixes a panic in RegexInPredicate where the `matches` map is nil.  When used inside an `OrPredicate` then `KeepColumnChunk` may not be called.

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`