### PR TITLE
searchsharding: ensure limit is never exceeded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Internal types are updated to use `scope` instead of `instrumentation_library`. 
 * [BUGFIX] Make multitenancy work with HTTP [#1781](https://github.com/grafana/tempo/pull/1781) (@gouthamve)
 * [BUGFIX] Fix parquet search bug fix on http.status_code that may cause incorrect results to be returned [#1799](https://github.com/grafana/tempo/pull/1799) (@mdisibio)
 * [BUGFIX] Fix failing SearchTagValues endpoint after startup [#1813](https://github.com/grafana/tempo/pull/1813) (@stoewer)
+* [BUGFIX] Searchsharding: ensure limit is never exceeded [#1839](https://github.com/grafana/tempo/pull/839) (@kvrhdn)
 
 
 ## v1.5.0 / 2022-08-17

--- a/modules/frontend/search_response.go
+++ b/modules/frontend/search_response.go
@@ -72,6 +72,9 @@ func (r *searchResponse) addResponse(res *tempopb.SearchResponse) {
 		if _, ok := r.resultsMap[t.TraceID]; !ok {
 			r.resultsMap[t.TraceID] = t
 		}
+		if len(r.resultsMap) >= r.limit {
+			break
+		}
 	}
 
 	// purposefully ignoring InspectedBlocks as that value is set by the sharder


### PR DESCRIPTION
**What this PR does**:
Ensure the search response from Tempo always contain at most `limit` traces. We were missing a check when appending results to the response object, this way additional traces could sneak into the response object.

Example: you already have 5 results, limit is 6. If a subquery returns 2 more results we would end up with 7 results. By checking the limit every time a trace is appended this won't happen anymore.

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`