### PR TITLE
Add ability to set receivers in tempo_config

### DIFF
--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -60,7 +60,7 @@
 
   tempo_distributor_config:: $.tempo_config {
     distributor+: {
-      receivers: $._config.distributor.receivers,
+      receivers+: $._config.distributor.receivers,
     },
   },
 


### PR DESCRIPTION
So, the problem is this:
```
{
  person1: {
    address: {
      country: error "must provide address",
    },
  } + {
    address+: {
      country+: "india",
    },
  },
}
```

will fail with "must provide address" until `+` is removed after country.

Now, in the way we (Grafana Labs) deploy Tempo, we do the following:

`this_lib + weekly_release + tempo.libsonnet` where we set the receivers in `tempo.libsonnet`.

I can't update receivers in `weekly_release` because `tempo.libsonnet` overwrites them. And I can't do a `+:` because https://github.com/grafana/tempo/blob/main/operations/jsonnet/microservices/config.libsonnet#L69

This lets me update `tempo_config` in `weekly_release` and hence update receivers in a sane way.