### PR TITLE
Avoid spurious startup message

### DIFF
--- a/cmd/tempo/main.go
+++ b/cmd/tempo/main.go
@@ -118,8 +118,6 @@ func main() {
 		os.Exit(1)
 	}
 	runtime.KeepAlive(ballast)
-
-	level.Info(log.Logger).Log("msg", "Tempo running")
 }
 
 func loadConfig() (*app.Config, error) {


### PR DESCRIPTION
Without this change, when Tempo is completely shut down, the last message printed to the console is "Tempo running".  The startup/shutdown messages are currently handled in `cmd/tempo/app/app.go`.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`