### PR TITLE
Allow compactor disablement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ overrides:
 * [ENHANCEMENT] Exit early from sharded search requests [#1742](https://github.com/grafana/tempo/pull/1742) (@electron0zero)
 * [ENHANCEMENT] Upgrade prometheus/prometheus to `51a44e6657c3` [#1829](https://github.com/grafana/tempo/pull/1829) (@mapno)
 * [ENHANCEMENT] Avoid running tempodb pool jobs with a cancelled context [#1852](https://github.com/grafana/tempo/pull/1852) (@zalegrala)
+* [ENHANCEMENT] Add config flag to allow for compactor disablement for debug purposes [#1850](https://github.com/grafana/tempo/pull/1850) (@zalegrala)
 * [CHANGE] Identify bloom that could not be retrieved from backend block [#1737](https://github.com/grafana/tempo/pull/1737) (@AlexDHoffer)
 * [CHANGE] tempo: check configuration returns now a list of warnings [#1663](https://github.com/grafana/tempo/pull/1663) (@frzifus)
 * [CHANGE] Make DNS address fully qualified to reduce DNS lookups in Kubernetes [#1687](https://github.com/grafana/tempo/pull/1687) (@electron0zero)

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -435,7 +435,6 @@ compactor:
     # Note: This should only be used in a non-prodution context for debugging purposes.  This will allow blocks to say in the backend for further investigation if desired.
     [disabled: <bool>]
 
-
     ring:
 
         kvstore:

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -431,6 +431,11 @@ Compactors stream blocks from the storage backend, combine them and write them b
 ```yaml
 compactor:
 
+    # Optional. Disables backend compaction.  Default is false.
+    # Note: This should only be used in a non-prodution context for debugging purposes.  This will allow blocks to say in the backend for further investigation if desired.
+    [disabled: <bool>]
+
+
     ring:
 
         kvstore:
@@ -476,6 +481,7 @@ compactor:
         # Optional. The time between compaction cycles. Default is 30s.
         # Note: The default will be used if the value is set to 0.
         [compaction_cycle: <duration>]
+
 ```
 
 ## Storage

--- a/modules/compactor/compactor.go
+++ b/modules/compactor/compactor.go
@@ -157,8 +157,10 @@ func (c *Compactor) starting(ctx context.Context) (err error) {
 }
 
 func (c *Compactor) running(ctx context.Context) error {
-	level.Info(log.Logger).Log("msg", "enabling compaction")
-	c.store.EnableCompaction(&c.cfg.Compactor, c, c)
+	if !c.cfg.Disabled {
+		level.Info(log.Logger).Log("msg", "enabling compaction")
+		c.store.EnableCompaction(&c.cfg.Compactor, c, c)
+	}
 
 	if c.subservices != nil {
 		select {

--- a/modules/compactor/config.go
+++ b/modules/compactor/config.go
@@ -38,7 +38,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	f.IntVar(&cfg.Compactor.MaxCompactionObjects, util.PrefixConfig(prefix, "compaction.max-objects-per-block"), 6000000, "Maximum number of traces in a compacted block.")
 	f.Uint64Var(&cfg.Compactor.MaxBlockBytes, util.PrefixConfig(prefix, "compaction.max-block-bytes"), 100*1024*1024*1024 /* 100GB */, "Maximum size of a compacted block.")
 	f.DurationVar(&cfg.Compactor.MaxCompactionRange, util.PrefixConfig(prefix, "compaction.compaction-window"), time.Hour, "Maximum time window across which to compact blocks.")
-	f.BoolVar(&cfg.Disabled, util.PrefixConfig(prefix, "compaction.disabled"), false, "Disable compaction.")
+	f.BoolVar(&cfg.Disabled, util.PrefixConfig(prefix, "disabled"), false, "Disable compaction.")
 	cfg.OverrideRingKey = compactorRingKey
 }
 

--- a/modules/compactor/config.go
+++ b/modules/compactor/config.go
@@ -13,6 +13,7 @@ import (
 )
 
 type Config struct {
+	Disabled        bool                    `yaml:"disabled,omitempty"`
 	ShardingRing    RingConfig              `yaml:"ring,omitempty"`
 	Compactor       tempodb.CompactorConfig `yaml:"compaction"`
 	OverrideRingKey string                  `yaml:"override_ring_key"`
@@ -37,6 +38,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	f.IntVar(&cfg.Compactor.MaxCompactionObjects, util.PrefixConfig(prefix, "compaction.max-objects-per-block"), 6000000, "Maximum number of traces in a compacted block.")
 	f.Uint64Var(&cfg.Compactor.MaxBlockBytes, util.PrefixConfig(prefix, "compaction.max-block-bytes"), 100*1024*1024*1024 /* 100GB */, "Maximum size of a compacted block.")
 	f.DurationVar(&cfg.Compactor.MaxCompactionRange, util.PrefixConfig(prefix, "compaction.compaction-window"), time.Hour, "Maximum time window across which to compact blocks.")
+	f.BoolVar(&cfg.Disabled, util.PrefixConfig(prefix, "compaction.disabled"), false, "Disable compaction.")
 	cfg.OverrideRingKey = compactorRingKey
 }
 


### PR DESCRIPTION
Without this change, there isn't a good way to disable compaction when running in single binary or scalable single binary mode.  Normally, when running in microservices mode, operators can simply scale down the compactors to 0 to effectively disable compaction, though this will have other consequences, since the compactors are doing a little more than compaction.

Here we include a config option to disable compaction at the compactor level.  This allows the compactor module to run, but disable compaction, allowing blocks to remain in the backend for debug or investigation purposes.

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`