### PR TITLE
Improve frontend and querier error handling

### DIFF
--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -410,6 +410,12 @@ func (t *App) setupModuleManager() error {
 		deps[SingleBinary] = append(deps[SingleBinary], MetricsGenerator)
 	}
 
+	// If the querier and the query-frontend are both enabled, the querier will depend on the query-frontend during startup.  During shutdown, this dependency relationship will ensure that the querier is stopped before the query-frontend, which allows proper notification and clean shutodwn.
+	switch t.cfg.Target {
+	case SingleBinary, ScalableSingleBinary:
+		deps[Querier] = append(deps[Querier], QueryFrontend)
+	}
+
 	for mod, targets := range deps {
 		if err := mm.AddDependency(mod, targets...); err != nil {
 			return err

--- a/modules/frontend/v1/frontend.go
+++ b/modules/frontend/v1/frontend.go
@@ -140,8 +140,6 @@ func (f *Frontend) running(ctx context.Context) error {
 }
 
 func (f *Frontend) stopping(_ error) error {
-	// Allow some time for queriers to disconnect when both modules are running in the same binary.
-	time.Sleep(1 * time.Second)
 	// This will also stop the requests queue, which stop accepting new requests and errors out any pending requests.
 	return services.StopManagerAndAwaitStopped(context.Background(), f.subservices)
 }

--- a/modules/frontend/v1/frontend.go
+++ b/modules/frontend/v1/frontend.go
@@ -140,6 +140,8 @@ func (f *Frontend) running(ctx context.Context) error {
 }
 
 func (f *Frontend) stopping(_ error) error {
+	// Allow some time for queriers to disconnect when both modules are running in the same binary.
+	time.Sleep(1 * time.Second)
 	// This will also stop the requests queue, which stop accepting new requests and errors out any pending requests.
 	return services.StopManagerAndAwaitStopped(context.Background(), f.subservices)
 }

--- a/modules/querier/worker/processor_manager.go
+++ b/modules/querier/worker/processor_manager.go
@@ -41,7 +41,7 @@ func newProcessorManager(ctx context.Context, p processor, conn *grpc.ClientConn
 }
 
 func (pm *processorManager) stop() {
-	// Notify the remote query-frontend or query-scheduler we're shutting down.
+	// Notify the remote query-frontend we're shutting down.
 	// We use a new context to make sure it's not cancelled.
 	notifyCtx, cancel := context.WithTimeout(context.Background(), notifyShutdownTimeout)
 	defer cancel()


### PR DESCRIPTION
Here we aim to improve the error handling between the querier and the frontend.  Several errors can be passed in either direction depending on the situation, including context cancellation and gRPC "queue stopped" messages.

In some cases, we simply avoid logging the error, recognizing it as part of the normal connection lifecycle in worker-frontend relationship. In the case a worker fails to contact the frontend, the worker will will retry regardless of the error.  This behavior is unchanged.  Frontends only get removed from the worker by the DNS record handling for the frontend address.

Additionally, a 1 second delay was added to the frotnend shutdown.  This is to allow the situation where both the frontend and querier modules are running in the same binary.  Without this delay, there is a race between the frontend and the querier to determine who can tell who a shutdown has been requested.  This delay allows the query worker to notify the frontend of a shutdown request so that both components can shut down cleanly.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`