### PR TITLE
[TraceQL] Fix duration filtering

### DIFF
--- a/tempodb/encoding/vparquet/block_search.go
+++ b/tempodb/encoding/vparquet/block_search.go
@@ -45,6 +45,8 @@ func (b *backendBlock) openForSearch(ctx context.Context, opts common.SearchOpti
 	// performance improvement. this does not happen currently for full backend search, but does happen
 	// if this is a complete block held on disk by the ingester
 	if b.pf != nil && b.readerAt != nil {
+		// Reset metrics, is there a better way to do this?
+		b.readerAt.TotalBytesRead.Store(0)
 		return b.pf, b.readerAt, nil
 	}
 

--- a/tempodb/encoding/vparquet/block_traceql_test.go
+++ b/tempodb/encoding/vparquet/block_traceql_test.go
@@ -423,7 +423,7 @@ func TestBackendBlockSearchTraceQLResults(t *testing.T) {
 						StartTimeUnixNanos: wantTr.ResourceSpans[0].ScopeSpans[0].Spans[0].StartUnixNanos,
 						EndtimeUnixNanos:   wantTr.ResourceSpans[0].ScopeSpans[0].Spans[0].EndUnixNanos,
 						Attributes: map[traceql.Attribute]traceql.Static{
-							traceql.NewIntrinsic(traceql.IntrinsicDuration): traceql.NewStaticDuration(time.Duration(100 * time.Second)),
+							traceql.NewIntrinsic(traceql.IntrinsicDuration): traceql.NewStaticDuration(100 * time.Second),
 						},
 					},
 					traceql.Span{
@@ -431,7 +431,7 @@ func TestBackendBlockSearchTraceQLResults(t *testing.T) {
 						StartTimeUnixNanos: wantTr.ResourceSpans[1].ScopeSpans[0].Spans[0].StartUnixNanos,
 						EndtimeUnixNanos:   wantTr.ResourceSpans[1].ScopeSpans[0].Spans[0].EndUnixNanos,
 						Attributes: map[traceql.Attribute]traceql.Static{
-							traceql.NewIntrinsic(traceql.IntrinsicDuration): traceql.NewStaticDuration(time.Duration(0 * time.Second)),
+							traceql.NewIntrinsic(traceql.IntrinsicDuration): traceql.NewStaticDuration(0 * time.Second),
 						},
 					},
 				),

--- a/tempodb/encoding/vparquet/block_traceql_test.go
+++ b/tempodb/encoding/vparquet/block_traceql_test.go
@@ -101,6 +101,11 @@ func TestBackendBlockSearchTraceQL(t *testing.T) {
 			parse(t, `{.`+LabelHTTPStatusCode+` = 500}`),
 			parse(t, `{.`+LabelHTTPStatusCode+` > 500}`),
 		),
+		makeReq(
+			// Mix of duration with other conditions
+			parse(t, `{`+LabelName+` = "hello"}`),   // Match
+			parse(t, `{`+LabelDuration+` < 100s }`), // No match
+		),
 
 		// Edge cases
 		makeReq(parse(t, `{.name = "Bob"}`)),                             // Almost conflicts with intrinsic but still works
@@ -188,6 +193,14 @@ func TestBackendBlockSearchTraceQL(t *testing.T) {
 			Conditions: []traceql.Condition{
 				parse(t, `{resource.foo = "abc"}`), // match
 				parse(t, `{resource.bar = 123}`),   // no match
+			},
+		},
+		{
+			// Mix of duration with other conditions
+			AllConditions: true,
+			Conditions: []traceql.Condition{
+				parse(t, `{`+LabelName+` = "nothello"}`), // No match
+				parse(t, `{`+LabelDuration+` = 100s }`),  // Match
 			},
 		},
 	}
@@ -395,9 +408,9 @@ func TestBackendBlockSearchTraceQLResults(t *testing.T) {
 				),
 			),
 		},
-		/*{
-			// Intrinsic duraction. 1st span only
-			makeReq(parse(t, `{ duration > 30s }`)),
+		{
+			// Intrinsic duration with no filtering
+			traceql.FetchSpansRequest{Conditions: []traceql.Condition{{Attribute: traceql.NewIntrinsic(traceql.IntrinsicDuration)}}},
 			makeSpansets(
 				makeSpanset(
 					wantTr.TraceID,
@@ -410,12 +423,20 @@ func TestBackendBlockSearchTraceQLResults(t *testing.T) {
 						StartTimeUnixNanos: wantTr.ResourceSpans[0].ScopeSpans[0].Spans[0].StartUnixNanos,
 						EndtimeUnixNanos:   wantTr.ResourceSpans[0].ScopeSpans[0].Spans[0].EndUnixNanos,
 						Attributes: map[traceql.Attribute]traceql.Static{
-							traceql.NewIntrinsic(traceql.IntrinsicDuration): traceql.NewStaticDuration(time.Duration(wantTr.ResourceSpans[0].ScopeSpans[0].Spans[0].DurationNanos)),
+							traceql.NewIntrinsic(traceql.IntrinsicDuration): traceql.NewStaticDuration(time.Duration(100 * time.Second)),
+						},
+					},
+					traceql.Span{
+						ID:                 wantTr.ResourceSpans[1].ScopeSpans[0].Spans[0].ID,
+						StartTimeUnixNanos: wantTr.ResourceSpans[1].ScopeSpans[0].Spans[0].StartUnixNanos,
+						EndtimeUnixNanos:   wantTr.ResourceSpans[1].ScopeSpans[0].Spans[0].EndUnixNanos,
+						Attributes: map[traceql.Attribute]traceql.Static{
+							traceql.NewIntrinsic(traceql.IntrinsicDuration): traceql.NewStaticDuration(time.Duration(0 * time.Second)),
 						},
 					},
 				),
 			),
-		},*/
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
**What this PR does**:
This PR fixes the behavior of span duration filtering for some TraceQL queries.  Span duration is handled specially because it's a computed column, and it wasn't working correctly for these cases:

* `{ } | avg(duration) > 1ms` Projecting the duration column from storage with no filtering. This is fixed with nil check.
* `{ name = "x" || duration 1ms }` Filtering on duration when `AllConditions=false`, it was always rejecting all spans that didn't pass the duration filter. 

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`