### PR TITLE
Fix context error reference in querier logging

### DIFF
--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -293,7 +293,7 @@ func (q *Querier) forGivenIngesters(ctx context.Context, replicationSet ring.Rep
 
 	doFunc := func(funcCtx context.Context, ingester *ring.InstanceDesc) (interface{}, error) {
 		if funcCtx.Err() != nil {
-			_ = level.Warn(log.Logger).Log("funcCtx.Err()", ctx.Err().Error())
+			_ = level.Warn(log.Logger).Log("funcCtx.Err()", funcCtx.Err().Error())
 			return nil, funcCtx.Err()
 		}
 


### PR DESCRIPTION
**What this PR does**:

Fixes a context reference to avoid a nil pointer introduced in #1853.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`