### PR TITLE
Parquet performance improvements

### DIFF
--- a/cmd/tempo-serverless/cloud-run/go.mod
+++ b/cmd/tempo-serverless/cloud-run/go.mod
@@ -100,7 +100,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rs/xid v1.2.1 // indirect
 	github.com/segmentio/encoding v0.3.5 // indirect
-	github.com/segmentio/parquet-go v0.0.0-20221019213850-8b6e2b21a101 // indirect
+	github.com/segmentio/parquet-go v0.0.0-20221103170249-ef6062d06d9f // indirect
 	github.com/sercand/kuberesolver v2.4.0+incompatible // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/sony/gobreaker v0.4.1 // indirect

--- a/cmd/tempo-serverless/cloud-run/go.sum
+++ b/cmd/tempo-serverless/cloud-run/go.sum
@@ -1707,8 +1707,8 @@ github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oH
 github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e/go.mod h1:tm/wZFQ8e24NYaBGIlnO2WGCAi67re4HHuOm0sftE/M=
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
-github.com/segmentio/parquet-go v0.0.0-20221019213850-8b6e2b21a101 h1:EAHbI5CHJtFCjcn06YK7ACGfd8RcuGo9Cr0Z2MdgM6c=
-github.com/segmentio/parquet-go v0.0.0-20221019213850-8b6e2b21a101/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
+github.com/segmentio/parquet-go v0.0.0-20221103170249-ef6062d06d9f h1:qqBLtgUF0WfUCxFuFey1ko665UfvjyFTJ/UIfJXKiao=
+github.com/segmentio/parquet-go v0.0.0-20221103170249-ef6062d06d9f/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/sercand/kuberesolver v2.1.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=
 github.com/sercand/kuberesolver v2.4.0+incompatible h1:WE2OlRf6wjLxHwNkkFLQGaZcVLEXjMjBPjjEU5vksH8=
 github.com/sercand/kuberesolver v2.4.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=

--- a/cmd/tempo-serverless/lambda/go.mod
+++ b/cmd/tempo-serverless/lambda/go.mod
@@ -101,7 +101,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rs/xid v1.2.1 // indirect
 	github.com/segmentio/encoding v0.3.5 // indirect
-	github.com/segmentio/parquet-go v0.0.0-20221019213850-8b6e2b21a101 // indirect
+	github.com/segmentio/parquet-go v0.0.0-20221103170249-ef6062d06d9f // indirect
 	github.com/sercand/kuberesolver v2.4.0+incompatible // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/sony/gobreaker v0.4.1 // indirect

--- a/cmd/tempo-serverless/lambda/go.sum
+++ b/cmd/tempo-serverless/lambda/go.sum
@@ -1709,8 +1709,8 @@ github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oH
 github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e/go.mod h1:tm/wZFQ8e24NYaBGIlnO2WGCAi67re4HHuOm0sftE/M=
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
-github.com/segmentio/parquet-go v0.0.0-20221019213850-8b6e2b21a101 h1:EAHbI5CHJtFCjcn06YK7ACGfd8RcuGo9Cr0Z2MdgM6c=
-github.com/segmentio/parquet-go v0.0.0-20221019213850-8b6e2b21a101/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
+github.com/segmentio/parquet-go v0.0.0-20221103170249-ef6062d06d9f h1:qqBLtgUF0WfUCxFuFey1ko665UfvjyFTJ/UIfJXKiao=
+github.com/segmentio/parquet-go v0.0.0-20221103170249-ef6062d06d9f/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/sercand/kuberesolver v2.1.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=
 github.com/sercand/kuberesolver v2.4.0+incompatible h1:WE2OlRf6wjLxHwNkkFLQGaZcVLEXjMjBPjjEU5vksH8=
 github.com/sercand/kuberesolver v2.4.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/prometheus/prometheus v1.8.2-0.20221021121301-51a44e6657c3
 	github.com/prometheus/statsd_exporter v0.21.0 // indirect
 	github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e
-	github.com/segmentio/parquet-go v0.0.0-20221019213850-8b6e2b21a101
+	github.com/segmentio/parquet-go v0.0.0-20221103170249-ef6062d06d9f
 	github.com/sirupsen/logrus v1.8.1
 	github.com/sony/gobreaker v0.4.1
 	github.com/spf13/viper v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -1983,8 +1983,6 @@ github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e h1:uO75wNGioszj
 github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e/go.mod h1:tm/wZFQ8e24NYaBGIlnO2WGCAi67re4HHuOm0sftE/M=
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
-github.com/segmentio/parquet-go v0.0.0-20221019213850-8b6e2b21a101 h1:EAHbI5CHJtFCjcn06YK7ACGfd8RcuGo9Cr0Z2MdgM6c=
-github.com/segmentio/parquet-go v0.0.0-20221019213850-8b6e2b21a101/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/segmentio/parquet-go v0.0.0-20221103170249-ef6062d06d9f h1:qqBLtgUF0WfUCxFuFey1ko665UfvjyFTJ/UIfJXKiao=
 github.com/segmentio/parquet-go v0.0.0-20221103170249-ef6062d06d9f/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/sercand/kuberesolver v2.1.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=

--- a/go.sum
+++ b/go.sum
@@ -1985,6 +1985,8 @@ github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfP
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/parquet-go v0.0.0-20221019213850-8b6e2b21a101 h1:EAHbI5CHJtFCjcn06YK7ACGfd8RcuGo9Cr0Z2MdgM6c=
 github.com/segmentio/parquet-go v0.0.0-20221019213850-8b6e2b21a101/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
+github.com/segmentio/parquet-go v0.0.0-20221103170249-ef6062d06d9f h1:qqBLtgUF0WfUCxFuFey1ko665UfvjyFTJ/UIfJXKiao=
+github.com/segmentio/parquet-go v0.0.0-20221103170249-ef6062d06d9f/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/sercand/kuberesolver v2.1.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=
 github.com/sercand/kuberesolver v2.4.0+incompatible h1:WE2OlRf6wjLxHwNkkFLQGaZcVLEXjMjBPjjEU5vksH8=
 github.com/sercand/kuberesolver v2.4.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=

--- a/vendor/github.com/segmentio/parquet-go/buffer.go
+++ b/vendor/github.com/segmentio/parquet-go/buffer.go
@@ -418,12 +418,6 @@ func (p *bufferedPage) Release() {
 	bufferUnref(p.offsets)
 	bufferUnref(p.definitionLevels)
 	bufferUnref(p.repetitionLevels)
-
-	p.Page = nil
-	p.values = nil
-	p.offsets = nil
-	p.definitionLevels = nil
-	p.repetitionLevels = nil
 }
 
 func bufferRef(buf *buffer) {

--- a/vendor/github.com/segmentio/parquet-go/column.go
+++ b/vendor/github.com/segmentio/parquet-go/column.go
@@ -633,7 +633,9 @@ func (c *Column) decodeDataPage(header DataPageHeader, numValues int, repetition
 	pageValues = vbuf.data
 
 	pageKind := pageType.Kind()
-	if pageKind == ByteArray {
+
+	// Page offsets not needed when dictionary-encoded
+	if pageKind == ByteArray && !isDictionaryEncoding(pageEncoding) {
 		obuf = buffers.get(4 * (numValues + 1))
 		defer obuf.unref()
 		pageOffsets = unsafecast.BytesToUint32(obuf.data)

--- a/vendor/github.com/segmentio/parquet-go/encoding/bitpacked/bitpacked.go
+++ b/vendor/github.com/segmentio/parquet-go/encoding/bitpacked/bitpacked.go
@@ -44,7 +44,7 @@ func encodeLevels(dst, src []byte, bitWidth uint) ([]byte, error) {
 	c := n + 1
 
 	if cap(dst) < c {
-		dst = make([]byte, c)
+		dst = make([]byte, c, 2*c)
 	} else {
 		dst = dst[:c]
 		for i := range dst {
@@ -80,7 +80,7 @@ func decodeLevels(dst, src []byte, bitWidth uint) ([]byte, error) {
 	}
 
 	if cap(dst) < numValues {
-		dst = make([]byte, numValues)
+		dst = make([]byte, numValues, 2*numValues)
 	} else {
 		dst = dst[:numValues]
 		for i := range dst {

--- a/vendor/github.com/segmentio/parquet-go/encoding/bytestreamsplit/bytestreamsplit.go
+++ b/vendor/github.com/segmentio/parquet-go/encoding/bytestreamsplit/bytestreamsplit.go
@@ -52,7 +52,7 @@ func (e *Encoding) DecodeDouble(dst []float64, src []byte) ([]float64, error) {
 
 func resize(buf []byte, size int) []byte {
 	if cap(buf) < size {
-		buf = make([]byte, size)
+		buf = make([]byte, size, 2*size)
 	} else {
 		buf = buf[:size]
 	}

--- a/vendor/github.com/segmentio/parquet-go/encoding/delta/length_byte_array.go
+++ b/vendor/github.com/segmentio/parquet-go/encoding/delta/length_byte_array.go
@@ -46,7 +46,7 @@ func (e *LengthByteArrayEncoding) DecodeByteArray(dst []byte, src []byte, offset
 	}
 
 	if size := len(length.values) + 1; cap(offsets) < size {
-		offsets = make([]uint32, size)
+		offsets = make([]uint32, size, 2*size)
 	} else {
 		offsets = offsets[:size]
 	}

--- a/vendor/github.com/segmentio/parquet-go/errors.go
+++ b/vendor/github.com/segmentio/parquet-go/errors.go
@@ -52,7 +52,7 @@ var (
 
 	// ErrTooManyRowGroups is returned when attempting to generate a parquet
 	// file with more than MaxRowGroups row groups.
-	ErrTooManyRowGroups = errors.New("the limit of 65535 row groups has been reached")
+	ErrTooManyRowGroups = errors.New("the limit of 32767 row groups has been reached")
 )
 
 type errno int

--- a/vendor/github.com/segmentio/parquet-go/row.go
+++ b/vendor/github.com/segmentio/parquet-go/row.go
@@ -739,10 +739,13 @@ func reconstructFuncOfGroup(columnIndex int16, node Node) (int16, reconstructFun
 
 //go:noinline
 func reconstructFuncOfLeaf(columnIndex int16, node Node) (int16, reconstructFunc) {
+	typ := node.Type()
 	return columnIndex + 1, func(value reflect.Value, _ levels, row Row) (Row, error) {
 		if !row.startsWith(columnIndex) {
 			return row, fmt.Errorf("no values found in parquet row for column %d", columnIndex)
 		}
-		return row[1:], assignValue(value, row[0])
+
+		err := typ.AssignValue(value, row[0])
+		return row[1:], err
 	}
 }

--- a/vendor/github.com/segmentio/parquet-go/search.go
+++ b/vendor/github.com/segmentio/parquet-go/search.go
@@ -75,33 +75,65 @@ func Find(index ColumnIndex, value Value, cmp func(Value, Value) int) int {
 
 func binarySearch(index ColumnIndex, value Value, cmp func(Value, Value) int) int {
 	n := index.NumPages()
-	i := 0
-	j := n
+	curIdx := 0
+	topIdx := n
 
-	for (j - i) > 1 {
-		k := ((j - i) / 2) + i
-		c := cmp(value, index.MinValue(k))
+	// while there's at least one more page to check
+	for (topIdx - curIdx) > 1 {
+
+		// nextIdx is set to halfway between curIdx and topIdx
+		nextIdx := ((topIdx - curIdx) / 2) + curIdx
+
+		smallerThanMin := cmp(value, index.MinValue(nextIdx))
 
 		switch {
-		case c < 0:
-			j = k
-		case c > 0:
-			i = k
-		default:
-			return k
+		// search below pages[nextIdx]
+		case smallerThanMin < 0:
+			topIdx = nextIdx
+		// search pages[nextIdx] and above
+		case smallerThanMin > 0:
+			curIdx = nextIdx
+		case smallerThanMin == 0:
+			// this case is hit when winValue == value of nextIdx
+			// we must check below this index to find if there's
+			// another page before this.
+			// e.g. searching for first page 3 is in:
+			// [1,2,3]
+			// [3,4,5]
+			// [6,7,8]
+
+			// if the page proceeding this has a maxValue matching the value we're
+			// searching, continue the search.
+			// otherwise, we can return early
+			//
+			// cases covered by else block
+			// if cmp(value, index.MaxValue(nextIdx-1)) < 0: the value is only in this page
+			// if cmp(value, index.MaxValue(nextIdx-1)) > 0: we've got a sorting problem with overlapping pages
+			//
+			// bounds check not needed for nextIdx-1 because nextIdx is guaranteed to be at least curIdx + 1
+			// line 82 & 85 above
+			if cmp(value, index.MaxValue(nextIdx-1)) == 0 {
+				topIdx = nextIdx
+			} else {
+				return nextIdx
+			}
 		}
 	}
 
-	if i < n {
-		min := index.MinValue(i)
-		max := index.MaxValue(i)
+	// last page check, if it wasn't explicitly found above
+	if curIdx < n {
 
-		if cmp(value, min) < 0 || cmp(max, value) < 0 {
-			i = n
+		// check pages[curIdx] for value
+		min := index.MinValue(curIdx)
+		max := index.MaxValue(curIdx)
+
+		// if value is not in pages[curIdx], then it's not in this columnChunk
+		if cmp(value, min) < 0 || cmp(value, max) > 0 {
+			curIdx = n
 		}
 	}
 
-	return i
+	return curIdx
 }
 
 func linearSearch(index ColumnIndex, value Value, cmp func(Value, Value) int) int {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -895,7 +895,7 @@ github.com/segmentio/encoding/thrift
 # github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e
 ## explicit
 github.com/segmentio/fasthash/fnv1a
-# github.com/segmentio/parquet-go v0.0.0-20221019213850-8b6e2b21a101
+# github.com/segmentio/parquet-go v0.0.0-20221103170249-ef6062d06d9f
 ## explicit; go 1.19
 github.com/segmentio/parquet-go
 github.com/segmentio/parquet-go/bloom


### PR DESCRIPTION
**What this PR does**:
Updates parquet-go dependency to catch a couple performance improvements:
* https://github.com/segmentio/parquet-go/pull/386
* https://github.com/segmentio/parquet-go/pull/398

Benchmark comparisons, huge memory improvements and also benefits to cpu in some cases. These are on top of the improvements already done in #1818 

```
name                                      old time/op    new time/op    delta
BackendBlockSearchTraces/noMatch-12          239ms ±16%     157ms ±10%  -34.32%  (p=0.000 n=9+10)
BackendBlockSearchTraces/partialMatch-12     2.79s ± 2%     2.54s ± 2%   -8.92%  (p=0.000 n=9+9)
BackendBlockSearchTraces/service.name-12    1.62ms ±14%    1.46ms ±20%     ~     (p=0.165 n=10+10)
BackendBlockSearchTags-12                    1.41s ± 6%     1.08s ± 3%  -23.55%  (p=0.000 n=9+9)
BackendBlockSearchTagValues/foo-12           977ms ± 2%     683ms ± 1%  -30.14%  (p=0.000 n=10+8)
BackendBlockSearchTagValues/http.url-12      22.6s ± 2%     22.5s ± 2%     ~     (p=0.447 n=9+10)

name                                      old speed      new speed      delta
BackendBlockSearchTraces/noMatch-12        258MB/s ±10%   342MB/s ± 9%  +32.31%  (p=0.000 n=9+10)
BackendBlockSearchTraces/partialMatch-12  23.8MB/s ± 2%  26.1MB/s ± 2%   +9.81%  (p=0.000 n=9+9)
BackendBlockSearchTraces/service.name-12  3.05GB/s ±14%  3.28GB/s ± 7%     ~     (p=0.243 n=10+9)

name                                      old alloc/op   new alloc/op   delta
BackendBlockSearchTraces/noMatch-12          341MB ± 7%      47MB ±16%  -86.17%  (p=0.000 n=9+10)
BackendBlockSearchTraces/partialMatch-12     604MB ± 2%     307MB ± 5%  -49.08%  (p=0.000 n=9+9)
BackendBlockSearchTraces/service.name-12    3.67MB ± 2%    1.53MB ± 2%  -58.38%  (p=0.000 n=10+10)
BackendBlockSearchTags-12                   1.76GB ± 1%    0.07GB ±25%  -96.03%  (p=0.000 n=8+10)
BackendBlockSearchTagValues/foo-12          2.30GB ± 1%    0.66GB ± 1%  -71.45%  (p=0.000 n=10+10)
BackendBlockSearchTagValues/http.url-12     1.14GB ± 0%    1.08GB ± 2%   -5.29%  (p=0.000 n=7+9)

name                                      old allocs/op  new allocs/op  delta
BackendBlockSearchTraces/noMatch-12           119k ± 6%       86k ± 4%  -28.27%  (p=0.000 n=9+10)
BackendBlockSearchTraces/partialMatch-12     18.0M ± 0%     17.9M ± 0%   -0.15%  (p=0.000 n=9+9)
BackendBlockSearchTraces/service.name-12     39.2k ± 0%     39.2k ± 0%   -0.16%  (p=0.000 n=10+10)
BackendBlockSearchTags-12                    1.00M ± 0%     0.81M ± 0%  -19.05%  (p=0.000 n=9+10)
BackendBlockSearchTagValues/foo-12            957k ± 0%      810k ± 0%  -15.41%  (p=0.000 n=9+9)
BackendBlockSearchTagValues/http.url-12       468k ± 0%      377k ± 0%  -19.32%  (p=0.000 n=9+9)
```

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`