### PR TITLE
Add max active series limit to limit metrics

### DIFF
--- a/modules/overrides/limits.go
+++ b/modules/overrides/limits.go
@@ -22,14 +22,15 @@ const (
 	ErrorPrefixRateLimited = "RATE_LIMITED:"
 
 	// metrics
-	MetricMaxLocalTracesPerUser     = "max_local_traces_per_user"
-	MetricMaxGlobalTracesPerUser    = "max_global_traces_per_user"
-	MetricMaxBytesPerTrace          = "max_bytes_per_trace"
-	MetricMaxSearchBytesPerTrace    = "max_search_bytes_per_trace"
-	MetricMaxBytesPerTagValuesQuery = "max_bytes_per_tag_values_query"
-	MetricIngestionRateLimitBytes   = "ingestion_rate_limit_bytes"
-	MetricIngestionBurstSizeBytes   = "ingestion_burst_size_bytes"
-	MetricBlockRetention            = "block_retention"
+	MetricMaxLocalTracesPerUser           = "max_local_traces_per_user"
+	MetricMaxGlobalTracesPerUser          = "max_global_traces_per_user"
+	MetricMaxBytesPerTrace                = "max_bytes_per_trace"
+	MetricMaxSearchBytesPerTrace          = "max_search_bytes_per_trace"
+	MetricMaxBytesPerTagValuesQuery       = "max_bytes_per_tag_values_query"
+	MetricIngestionRateLimitBytes         = "ingestion_rate_limit_bytes"
+	MetricIngestionBurstSizeBytes         = "ingestion_burst_size_bytes"
+	MetricBlockRetention                  = "block_retention"
+	MetricMetricsGeneratorMaxActiveSeries = "metrics_generator_max_active_series"
 )
 
 var (
@@ -123,4 +124,5 @@ func (l *Limits) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(metricLimitsDesc, prometheus.GaugeValue, float64(l.IngestionRateLimitBytes), MetricIngestionRateLimitBytes)
 	ch <- prometheus.MustNewConstMetric(metricLimitsDesc, prometheus.GaugeValue, float64(l.IngestionBurstSizeBytes), MetricIngestionBurstSizeBytes)
 	ch <- prometheus.MustNewConstMetric(metricLimitsDesc, prometheus.GaugeValue, float64(l.BlockRetention), MetricBlockRetention)
+	ch <- prometheus.MustNewConstMetric(metricLimitsDesc, prometheus.GaugeValue, float64(l.MetricsGeneratorMaxActiveSeries), MetricMetricsGeneratorMaxActiveSeries)
 }

--- a/modules/overrides/overrides.go
+++ b/modules/overrides/overrides.go
@@ -389,5 +389,6 @@ func (o *Overrides) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(metricOverridesLimitsDesc, prometheus.GaugeValue, float64(limits.IngestionRateLimitBytes), MetricIngestionRateLimitBytes, tenant)
 		ch <- prometheus.MustNewConstMetric(metricOverridesLimitsDesc, prometheus.GaugeValue, float64(limits.IngestionBurstSizeBytes), MetricIngestionBurstSizeBytes, tenant)
 		ch <- prometheus.MustNewConstMetric(metricOverridesLimitsDesc, prometheus.GaugeValue, float64(limits.BlockRetention), MetricBlockRetention, tenant)
+		ch <- prometheus.MustNewConstMetric(metricOverridesLimitsDesc, prometheus.GaugeValue, float64(limits.MetricsGeneratorMaxActiveSeries), MetricMetricsGeneratorMaxActiveSeries, tenant)
 	}
 }

--- a/pkg/tempopb/tempo.pb.go
+++ b/pkg/tempopb/tempo.pb.go
@@ -1013,8 +1013,7 @@ func (m *PushResponse) XXX_DiscardUnknown() {
 var xxx_messageInfo_PushResponse proto.InternalMessageInfo
 
 // PushBytesRequest pushes slices of traces, ids and searchdata. Traces are encoded using the
-//
-//	current BatchDecoder in ./pkg/model
+//  current BatchDecoder in ./pkg/model
 type PushBytesRequest struct {
 	// pre-marshalled Traces. length must match ids
 	Traces []PreallocBytes `protobuf:"bytes,2,rep,name=traces,proto3,customtype=PreallocBytes" json:"traces"`

--- a/pkg/tempopb/tempo.pb.go
+++ b/pkg/tempopb/tempo.pb.go
@@ -1013,7 +1013,8 @@ func (m *PushResponse) XXX_DiscardUnknown() {
 var xxx_messageInfo_PushResponse proto.InternalMessageInfo
 
 // PushBytesRequest pushes slices of traces, ids and searchdata. Traces are encoded using the
-//  current BatchDecoder in ./pkg/model
+//
+//	current BatchDecoder in ./pkg/model
 type PushBytesRequest struct {
 	// pre-marshalled Traces. length must match ids
 	Traces []PreallocBytes `protobuf:"bytes,2,rep,name=traces,proto3,customtype=PreallocBytes" json:"traces"`


### PR DESCRIPTION
**What this PR does**:

Adds `metrics_generator_max_active_series` to limits metrics