### PR TITLE
"Fix" row group size bytes

### DIFF
--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -923,7 +923,7 @@ storage:
             # an estimate of the number of bytes per row group when cutting Parquet blocks. lower values will
             #  create larger footers but will be harder to shard when searching. It is difficult to calculate
             #  this field directly and it may vary based on workload. This is roughly a lower bound.
-            [row_group_size_bytes: <int> | default = 50MB]
+            [row_group_size_bytes: <int> | default = 100MB]
 ```
 
 ## Memberlist

--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -919,6 +919,11 @@ storage:
 
             # number of bytes per search page
             [search_page_size_bytes: <int> | default = 1MiB]
+
+            # an estimate of the number of bytes per row group when cutting Parquet blocks. lower values will
+            #  create larger footers but will be harder to shard when searching. It is difficult to calculate
+            #  this field directly and it may vary based on workload. This is roughly a lower bound.
+            [row_group_size_bytes: <int> | default = 50MB]
 ```
 
 ## Memberlist

--- a/docs/tempo/website/configuration/manifest.md
+++ b/docs/tempo/website/configuration/manifest.md
@@ -447,7 +447,7 @@ storage:
       encoding: zstd
       search_encoding: snappy
       search_page_size_bytes: 1048576
-      row_group_size_bytes: 30000000
+      row_group_size_bytes: 50000000
     search:
       chunk_size_bytes: 1000000
       prefetch_trace_count: 1000

--- a/docs/tempo/website/configuration/manifest.md
+++ b/docs/tempo/website/configuration/manifest.md
@@ -447,7 +447,7 @@ storage:
       encoding: zstd
       search_encoding: snappy
       search_page_size_bytes: 1048576
-      row_group_size_bytes: 50000000
+      row_group_size_bytes: 100000000
     search:
       chunk_size_bytes: 1000000
       prefetch_trace_count: 1000

--- a/modules/storage/config.go
+++ b/modules/storage/config.go
@@ -55,7 +55,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.Trace.Block.Encoding = backend.EncZstd
 	cfg.Trace.Block.SearchEncoding = backend.EncSnappy
 	cfg.Trace.Block.SearchPageSizeBytes = 1024 * 1024 // 1 MB
-	cfg.Trace.Block.RowGroupSizeBytes = 50_000_000    // 50 MB
+	cfg.Trace.Block.RowGroupSizeBytes = 100_000_000   // 100 MB
 
 	cfg.Trace.Azure = &azure.Config{}
 	f.StringVar(&cfg.Trace.Azure.StorageAccountName, util.PrefixConfig(prefix, "trace.azure.storage-account-name"), "", "Azure storage account name.")

--- a/modules/storage/config.go
+++ b/modules/storage/config.go
@@ -55,7 +55,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.Trace.Block.Encoding = backend.EncZstd
 	cfg.Trace.Block.SearchEncoding = backend.EncSnappy
 	cfg.Trace.Block.SearchPageSizeBytes = 1024 * 1024 // 1 MB
-	cfg.Trace.Block.RowGroupSizeBytes = 30_000_000    // 30 MB
+	cfg.Trace.Block.RowGroupSizeBytes = 50_000_000    // 50 MB
 
 	cfg.Trace.Azure = &azure.Config{}
 	f.StringVar(&cfg.Trace.Azure.StorageAccountName, util.PrefixConfig(prefix, "trace.azure.storage-account-name"), "", "Azure storage account name.")

--- a/tempodb/encoding/vparquet/compactor.go
+++ b/tempodb/encoding/vparquet/compactor.go
@@ -97,7 +97,7 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 		if c.opts.MaxBytesPerTrace > 0 {
 			sum := 0
 			for _, row := range rows {
-				sum += esimateMarshalledSizeFromParquetRow(row)
+				sum += estimateProtoSizeFromParquetRow(row)
 			}
 			if sum > c.opts.MaxBytesPerTrace {
 				// Trace too large to compact
@@ -160,7 +160,7 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 		}
 
 		// Flush existing block data if the next trace can't fit
-		if currentBlock.EstimatedBufferedBytes() > 0 && currentBlock.EstimatedBufferedBytes()+esimateMarshalledSizeFromParquetRow(lowestObject) > c.opts.BlockConfig.RowGroupSizeBytes {
+		if currentBlock.EstimatedBufferedBytes() > 0 && currentBlock.EstimatedBufferedBytes()+estimateMarshalledSizeFromParquetRow(lowestObject) > c.opts.BlockConfig.RowGroupSizeBytes {
 			runtime.GC()
 			err = c.appendBlock(ctx, currentBlock, l)
 			if err != nil {
@@ -328,10 +328,31 @@ func (r *rowPool) Put(row parquet.Row) {
 	r.pool.Put(row[:0]) //nolint:all //SA6002
 }
 
-// esimateMarshalledSizeFromParquetRow estimates the byte-length of the corresponding
+// estimateMarshalledSizeFromParquetRow estimates the byte-length of the corresponding
 // trace in tempopb.Trace format. This method is unreasonably effective.
 // Testing on real blocks shows 90-98% accuracy.
-func esimateMarshalledSizeFromParquetRow(row parquet.Row) (size int) {
+func estimateProtoSizeFromParquetRow(row parquet.Row) (size int) {
+	for _, v := range row {
+		size++ // Field identifier
+
+		switch v.Kind() {
+		case parquet.ByteArray:
+			size += len(v.ByteArray())
+
+		case parquet.FixedLenByteArray:
+			size += len(v.ByteArray())
+
+		default:
+			// All other types (ints, bools) approach 1 byte per value
+			size++
+		}
+	}
+	return
+}
+
+// estimateMarshalledSizeFromParquetRow estimates the byte size as marshalled into parquet.
+// this is a very rough estimate and is generally 66%-100% of actual size.
+func estimateMarshalledSizeFromParquetRow(row parquet.Row) (size int) {
 	return len(row)
 }
 

--- a/tempodb/encoding/vparquet/compactor.go
+++ b/tempodb/encoding/vparquet/compactor.go
@@ -328,7 +328,7 @@ func (r *rowPool) Put(row parquet.Row) {
 	r.pool.Put(row[:0]) //nolint:all //SA6002
 }
 
-// estimateMarshalledSizeFromParquetRow estimates the byte-length of the corresponding
+// estimateProtoSizeFromParquetRow estimates the byte-length of the corresponding
 // trace in tempopb.Trace format. This method is unreasonably effective.
 // Testing on real blocks shows 90-98% accuracy.
 func estimateProtoSizeFromParquetRow(row parquet.Row) (size int) {

--- a/tempodb/encoding/vparquet/create.go
+++ b/tempodb/encoding/vparquet/create.go
@@ -133,7 +133,7 @@ func (b *streamingBlock) AddRaw(id []byte, row parquet.Row, start, end uint32) e
 	b.bloom.Add(id)
 	b.meta.ObjectAdded(id, start, end)
 	b.currentBufferedTraces++
-	b.currentBufferedBytes += esimateMarshalledSizeFromParquetRow(row)
+	b.currentBufferedBytes += estimateMarshalledSizeFromParquetRow(row)
 
 	return nil
 }

--- a/tempodb/encoding/vparquet/create.go
+++ b/tempodb/encoding/vparquet/create.go
@@ -119,7 +119,7 @@ func (b *streamingBlock) Add(tr *Trace, start, end uint32) error {
 	b.bloom.Add(id)
 	b.meta.ObjectAdded(id, start, end)
 	b.currentBufferedTraces++
-	b.currentBufferedBytes += estimateTraceSize(tr)
+	b.currentBufferedBytes += estimateMarshalledSizeFromTrace(tr)
 
 	return nil
 }
@@ -133,7 +133,7 @@ func (b *streamingBlock) AddRaw(id []byte, row parquet.Row, start, end uint32) e
 	b.bloom.Add(id)
 	b.meta.ObjectAdded(id, start, end)
 	b.currentBufferedTraces++
-	b.currentBufferedBytes += estimateProtoSize(row)
+	b.currentBufferedBytes += esimateMarshalledSizeFromParquetRow(row)
 
 	return nil
 }
@@ -211,51 +211,25 @@ func (b *streamingBlock) Complete() (int, error) {
 	return n, writeBlockMeta(b.ctx, b.to, b.meta, b.bloom)
 }
 
-// estimateTraceSize attempts to estimate the size of trace in bytes. This is used to make choose
+// estimateMarshalledSizeFromTrace attempts to estimate the size of trace in bytes. This is used to make choose
 // when to cut a row group during block creation.
 // TODO: This function regularly estimates lower values then estimateProtoSize() and the size
 // of the actual proto. It's also quite inefficient. Perhaps just using static values per span or attribute
 // would be a better choice?
-func estimateTraceSize(tr *Trace) (size int) {
-	size += len(tr.TraceID)
-	size += len(tr.TraceIDText)
-	size += len(tr.RootServiceName)
-	size += len(tr.RootSpanName)
-	size += 8 + 8 + 8 // start/end/duration
-	size += 7
+func estimateMarshalledSizeFromTrace(tr *Trace) (size int) {
+	size += 7 // 7 trace lvl fields
 
 	for _, rs := range tr.ResourceSpans {
 		size += estimateAttrSize(rs.Resource.Attrs)
-		size += len(rs.Resource.ServiceName)
-		size += strLen(rs.Resource.Namespace)
-		size += strLen(rs.Resource.Cluster)
-		size += strLen(rs.Resource.Pod)
-		size += strLen(rs.Resource.Container)
-		size += strLen(rs.Resource.K8sClusterName)
-		size += strLen(rs.Resource.K8sContainerName)
-		size += strLen(rs.Resource.K8sNamespaceName)
-		size += strLen(rs.Resource.K8sPodName)
-		size += 9
+		size += 10 // 10 resource span lvl fields
 
 		for _, ils := range rs.ScopeSpans {
-			size += len(ils.Scope.Name)
-			size += len(ils.Scope.Version)
-			size += 2
+			size += 2 // 2 scope span lvl fields
+
 			for _, s := range ils.Spans {
-				size += 8 + 8 + 8 + 8 + 4 + 4 // start/end/kind/statuscode/dropped events/dropped attrs
-				size += len(s.ID)
-				size += len(s.ParentSpanID)
-				size += len(s.Name)
-				size += strLen(s.HttpMethod)
-				size += strLen(s.HttpUrl)
-				size += len(s.StatusMessage)
-				size += len(s.TraceState)
-				if s.HttpStatusCode != nil {
-					size += 8
-				}
+				size += 14 // 14 span lvl fields
 				size += estimateAttrSize(s.Attrs)
 				size += estimateEventsSize(s.Events)
-				size += 14
 			}
 		}
 	}
@@ -263,40 +237,13 @@ func estimateTraceSize(tr *Trace) (size int) {
 }
 
 func estimateAttrSize(attrs []Attribute) (size int) {
-	for _, a := range attrs {
-		size += len(a.Key)
-		size += strLen(a.Value)
-		size += len(a.ValueArray)
-		size += len(a.ValueKVList)
-		if a.ValueBool != nil {
-			size++
-		}
-		if a.ValueDouble != nil {
-			size += 8
-		}
-		if a.ValueInt != nil {
-			size += 8
-		}
-	}
-	return
+	return len(attrs) * 7 // 7 attribute lvl fields
 }
 
 func estimateEventsSize(events []Event) (size int) {
 	for _, e := range events {
-		size += 8 + 4 // time/dropped attributes
-		size += len(e.Name)
-
-		for _, eva := range e.Attrs {
-			size += len(eva.Value)
-			size += len(eva.Key)
-		}
+		size += 4                // 4 event lvl fields
+		size += 4 * len(e.Attrs) // 2 event attribute fields
 	}
 	return
-}
-
-func strLen(s *string) (size int) {
-	if s == nil {
-		return 0
-	}
-	return len(*s)
 }

--- a/tempodb/encoding/vparquet/schema_test.go
+++ b/tempodb/encoding/vparquet/schema_test.go
@@ -2,7 +2,9 @@ package vparquet
 
 import (
 	"fmt"
+	"io"
 	"math/rand"
+	"os"
 	"testing"
 
 	"github.com/dustin/go-humanize"
@@ -200,28 +202,45 @@ func BenchmarkDeconstruct(b *testing.B) {
 }
 
 func TestParquetRowSizeEstimate(t *testing.T) {
+	// use this test to parse actual Parquet files and compare the two methods of estimating row size
+	s := []string{}
 
-	batchCount := 100
-	spanCounts := []int{
-		100, 1000,
-		// 10000, this crashes in GitHub
+	for _, s := range s {
+		estimateRowSize(t, s)
+	}
+}
+
+func estimateRowSize(t *testing.T, name string) {
+	f, err := os.OpenFile(name, os.O_RDONLY, 0644)
+	require.NoError(t, err)
+
+	fi, err := f.Stat()
+	require.NoError(t, err)
+
+	pf, err := parquet.OpenFile(f, fi.Size())
+	require.NoError(t, err)
+
+	r := parquet.NewGenericReader[*Trace](pf)
+	row := make([]*Trace, 1)
+
+	totalProtoSize := int64(0)
+	totalTraceSize := int64(0)
+	for {
+		_, err := r.Read(row)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+		}
+
+		tr := row[0]
+		sch := parquet.SchemaOf(tr)
+		row := sch.Deconstruct(nil, tr)
+
+		totalProtoSize += int64(esimateMarshalledSizeFromParquetRow(row))
+		totalTraceSize += int64(estimateMarshalledSizeFromTrace(tr))
 	}
 
-	for _, spanCount := range spanCounts {
-		ss := humanize.SI(float64(batchCount*spanCount), "")
-		t.Run(fmt.Sprintf("SpanCount%v", ss), func(t *testing.T) {
-
-			id := test.ValidTraceID(nil)
-			tr := test.MakeTraceWithSpanCount(batchCount, spanCount, id)
-			proto, _ := tr.Marshal()
-			fmt.Println("Size of proto is:", len(proto))
-
-			parq := traceToParquet(id, tr, nil)
-			sch := parquet.SchemaOf(parq)
-			row := sch.Deconstruct(nil, parq)
-
-			fmt.Println("Size of parquet row is:", estimateProtoSize(row))
-			fmt.Println("Size of parquet is:", estimateTraceSize(parq))
-		})
-	}
+	fmt.Println(pf.Size(), ",", len(pf.RowGroups()), ",", totalProtoSize, ",", totalTraceSize)
 }

--- a/tempodb/encoding/vparquet/schema_test.go
+++ b/tempodb/encoding/vparquet/schema_test.go
@@ -238,7 +238,7 @@ func estimateRowSize(t *testing.T, name string) {
 		sch := parquet.SchemaOf(tr)
 		row := sch.Deconstruct(nil, tr)
 
-		totalProtoSize += int64(esimateMarshalledSizeFromParquetRow(row))
+		totalProtoSize += int64(estimateMarshalledSizeFromParquetRow(row))
 		totalTraceSize += int64(estimateMarshalledSizeFromTrace(tr))
 	}
 


### PR DESCRIPTION
**What this PR does**:
Currently there are two methods that estimate trace size when building row groups in parquet blocks. Both of these methods do a decent job of estimating the uncompressed proto size of a trace, but are poor at estimating a compressed and encoded version in parquet. The result of this is that the actual row group created has been observed to be anywhere between 5->30% of the configured row_group_bytes.

This PR
- Adjusts the two methods to be lower bounds on row_group_size bytes. In practice on real data the created row groups are 100->150% of the configured size.
- Roughly aligns both methods around the concept of counting the total number of parquet values pushed with the assumption that across enough traces we approach 1 byte per value stored.
- Renames both methods for clarity.
- Sets the default to 100MB.
- Adds documentation for `row_group_size_bytes`.