### PR TITLE
[docs] document the use of TLS

### DIFF
--- a/docs/tempo/website/configuration/_index.md
+++ b/docs/tempo/website/configuration/_index.md
@@ -22,6 +22,8 @@ This document explains the configuration options for Tempo as well as the detail
   - [search](#search)
   - [usage-report](#usage-report)
 
+Additionally, you may wish to review [TLS]({{< relref "tls/" >}}) to configure the cluster components to communicate over TLS, or receive traces over TLS.
+
 ## Use environment variables in the configuration
 
 You can use environment variable references in the configuration file to set values that need to be configurable during deployment using `--config.expand-env` option.

--- a/docs/tempo/website/configuration/querying.md
+++ b/docs/tempo/website/configuration/querying.md
@@ -1,6 +1,6 @@
 ---
 title: Querying with Grafana
-weight: 30
+weight: 40
 ---
 
 The way Grafana queries Tempo changed from 7.4.x to 7.5.x. This document aims to explain the difference between the two

--- a/docs/tempo/website/configuration/tls.md
+++ b/docs/tempo/website/configuration/tls.md
@@ -82,7 +82,7 @@ tls:
   min_version: VersionTLS12
 ```
 
-The above structure can be set on the following receiver configurations.
+The above structure can be set on the following receiver configurations:
 
 - `distributor.receivers.otlp.protocols.grpc.tls`
 - `distributor.receivers.otlp.protocols.http.tls`

--- a/docs/tempo/website/configuration/tls.md
+++ b/docs/tempo/website/configuration/tls.md
@@ -50,7 +50,7 @@ grpc_client_config:
   tls_min_version: VersionTLS12
 ```
 
-The above configuration block needs to be set at the following configuration locations.
+The configuration block needs to be set at the following configuration locations.
 
 - `ingester_client.grpc_client_config`
 - `metrics_generator_client.grpc_client_config`

--- a/docs/tempo/website/configuration/tls.md
+++ b/docs/tempo/website/configuration/tls.md
@@ -72,7 +72,7 @@ memberlist:
 
 Additional receiver configuration can be added to support TLS communication for traces being sent to Tempo. The receiver configuration is pulled in from the Open Telemetry collector, and is [documented upstream here](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/config.md#configtls-tlsserversetting).
 
-An example `tls` block might look like the following.
+An example `tls` block might look like the following:
 
 ```yaml
 tls:

--- a/docs/tempo/website/configuration/tls.md
+++ b/docs/tempo/website/configuration/tls.md
@@ -3,7 +3,7 @@ title: Configure TLS Communication
 weight: 70
 ---
 
-# Configure TLS Communication
+# Configure TLS communication
 
 Tempo can be configured to communicate between the components using Transport Layer Security, or TLS.
 

--- a/docs/tempo/website/configuration/tls.md
+++ b/docs/tempo/website/configuration/tls.md
@@ -1,0 +1,91 @@
+---
+title: Configure TLS Communication
+weight: 70
+---
+
+# Configure TLS Communication
+
+Tempo can be configured to communicate between the components using Transport Layer Security, or TLS.
+
+Please note, the ciphers and TLS version here are for example purposes only. We are in no way recommending which ciphers or TLS versions for use in production environments, and are here for example purposes only.
+
+## Server Configuration
+
+```yaml
+server:
+  tls_cipher_suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+  tls_min_version: VersionTLS12
+
+  grpc_tls_config:
+    cert_file: /tls/tls.crt
+    key_file: /tls/tls.key
+    client_auth_type: VerifyClientCertIfGiven
+    client_ca_file: /tls/ca.crt
+  http_tls_config:
+    cert_file: /tls/tls.crt
+    key_file: /tls/tls.key
+    client_auth_type: VerifyClientCertIfGiven
+    client_ca_file: /tls/ca.crt
+```
+
+Valid values for the `client_auth_type` are documented in the standard `crypt/tls` package under `ClientAuthType` [here](https://pkg.go.dev/crypto/tls#ClientAuthType).
+
+## Client Configuration
+
+Several components of Tempo need to configure the gRPC clients they use to communicate with other components. For example, when the `querier` contacts the `query-frontend` to request work, the client in use must enable TLS if the server is serving a TLS endpoint.
+
+The Tempo configuration uses a standard configuration stanza for each of these client configurations. Below is an example of the configuration.
+
+The optional configuration elements `tls_min_version`, `tls_cipher_suites`, and `tls_insecure_skip_verify` may be omitted. The option `tls_server_name` may or may not be required, depending on the environment.
+
+```yaml
+grpc_client_config:
+  tls_enabled: true
+  tls_cert_path: /tls/tls.crt
+  tls_key_path: /tls/tls.key
+  tls_ca_path: /tls/ca.crt
+  tls_server_name: tempo.trace.svc.cluster.local
+  tls_insecure_skip_verify: false
+  tls_cipher_suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+  tls_min_version: VersionTLS12
+```
+
+The above configuration block needs to be set at the following configuration locations.
+
+- `ingester_client.grpc_client_config`
+- `metrics_generator_client.grpc_client_config`
+- `querier.query-frontend.grpc_client_config`
+
+Additionally, `memberlist` must also be configured, but the client configuration is nested directly under `memberlist` as follows. The same configuration options are available as above.
+
+```
+memberlist:
+    tls_enabled: true
+    tls_cert_path: /tls/tls.crt
+    tls_key_path: /tls/tls.key
+    tls_ca_path: /tls/ca.crt
+    tls_server_name: tempo.trace.svc.cluster.local
+    tls_insecure_skip_verify: false
+```
+
+### Receiver TLS
+
+Additional receiver configuration can be added to support TLS communication for traces being sent to Tempo. The receiver configuration is pulled in from the Open Telemetry collector, and is [documented upstream here](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/config.md#configtls-tlsserversetting).
+
+An example `tls` block might look like the following.
+
+```yaml
+tls:
+  ca_file: /tls/ca.crt
+  cert_file: /tls/tls.crt
+  key_file: /tls/tls.key
+  min_version: VersionTLS12
+```
+
+The above structure can be set on the following receiver configurations.
+
+- `distributor.receivers.otlp.protocols.grpc.tls`
+- `distributor.receivers.otlp.protocols.http.tls`
+- `distributor.receivers.zipkin.tls`
+- `distributor.receivers.jaeger.grpc.tls`
+- `distributor.receivers.jaeger.thrift_http.tls`

--- a/docs/tempo/website/configuration/tls.md
+++ b/docs/tempo/website/configuration/tls.md
@@ -1,17 +1,17 @@
 ---
 title: Configure TLS Communication
-weight: 70
+weight: 35
 ---
 
 # Configure TLS communication
 
 Tempo can be configured to communicate between the components using Transport Layer Security, or TLS.
 
->**Note:** The ciphers and TLS version here are for example purposes only. We are not recommending which ciphers or TLS versions for use in production environments.
+> **Note:** The ciphers and TLS version here are for example purposes only. We are not recommending which ciphers or TLS versions for use in production environments.
 
 ## Server configuration
 
-This sample TLS server configuration shows supported options. 
+This sample TLS server configuration shows supported options.
 
 ```yaml
 server:

--- a/docs/tempo/website/configuration/tls.md
+++ b/docs/tempo/website/configuration/tls.md
@@ -9,7 +9,9 @@ Tempo can be configured to communicate between the components using Transport La
 
 >**Note:** The ciphers and TLS version here are for example purposes only. We are not recommending which ciphers or TLS versions for use in production environments.
 
-## Server Configuration
+## Server configuration
+
+This sample TLS server configuration shows supported options. 
 
 ```yaml
 server:

--- a/docs/tempo/website/configuration/tls.md
+++ b/docs/tempo/website/configuration/tls.md
@@ -30,7 +30,7 @@ server:
 
 Valid values for the `client_auth_type` are documented in the standard `crypt/tls` package under `ClientAuthType` [here](https://pkg.go.dev/crypto/tls#ClientAuthType).
 
-## Client Configuration
+## Client configuration
 
 Several components of Tempo need to configure the gRPC clients they use to communicate with other components. For example, when the `querier` contacts the `query-frontend` to request work, the client in use must enable TLS if the server is serving a TLS endpoint.
 

--- a/docs/tempo/website/configuration/tls.md
+++ b/docs/tempo/website/configuration/tls.md
@@ -7,7 +7,7 @@ weight: 70
 
 Tempo can be configured to communicate between the components using Transport Layer Security, or TLS.
 
-Please note, the ciphers and TLS version here are for example purposes only. We are in no way recommending which ciphers or TLS versions for use in production environments, and are here for example purposes only.
+>**Note:** The ciphers and TLS version here are for example purposes only. We are not recommending which ciphers or TLS versions for use in production environments.
 
 ## Server Configuration
 


### PR DESCRIPTION
**What this PR does**:

Here we include a new page in our docs about how to configure TLS, or Transport Layer Security.  Much of the configuration objects are pulled in from our dependencies, but we also include examples that have been tested to work.

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`