### PR TITLE
use per_cluster_label in dashboard-utils.libsonnet

### DIFF
--- a/operations/tempo-mixin/config.libsonnet
+++ b/operations/tempo-mixin/config.libsonnet
@@ -26,6 +26,7 @@
     },
 
     per_cluster_label: 'cluster',
+    namespace_selector_separator: '/',
 
     // Groups labels to uniquely identify and group by {jobs, clusters, tenants}
     cluster_selectors: [$._config.per_cluster_label, 'namespace'],

--- a/operations/tempo-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/tempo-mixin/dashboards/dashboard-utils.libsonnet
@@ -24,12 +24,12 @@ grafana {
           ],
         };
 
-        d.addMultiTemplate('cluster', 'tempo_build_info', 'cluster')
-        .addMultiTemplate('namespace', "tempo_build_info{cluster=~'$cluster'}", 'namespace', allValue=null),
+        d.addMultiTemplate('cluster', 'tempo_build_info', $._config.per_cluster_label)
+        .addMultiTemplate('namespace', 'tempo_build_info{' + $._config.per_cluster_label + "=~'$cluster'}", 'namespace', allValue=null),
     },
 
   jobMatcher(job)::
-    'cluster=~"$cluster", job=~"($namespace)/%s"' % job,
+    $._config.per_cluster_label + '=~"$cluster", job=~"($namespace)' + $._config.namespace_selector_separator + '%s"' % job,
 
   queryPanel(queries, legends, legendLink=null)::
     super.queryPanel(queries, legends, legendLink) + {
@@ -97,7 +97,7 @@ grafana {
   },
 
   namespaceMatcher()::
-    'cluster=~"$cluster", namespace=~"$namespace"',
+    $._config.per_cluster_label + '=~"$cluster", namespace=~"$namespace"',
 
   containerCPUUsagePanel(title, containerName)::
     $.panel(title) +


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Changes `tempo-mixin/dashboards/dashboard-utils.libsonnet` to respect `per_cluster_label` from config.libsonnet

Also adds a configurable `namespace_selector_separator` to config.libsonnet. The reason for this is that serviceMonitors from the helm chart don't have job names matching `($namespace)/%s` , but rather `($namespace)-%s`. The config value defaults to current `/`.

