### PR TITLE
Stop Distributor on fatal error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## main / unreleased
+* [BUGFIX] Stop distributors on Otel receiver fatal error[#1887](https://github.com/grafana/tempo/pull/1887) (@rdooley)
 * [CHANGE] **BREAKING CHANGE** Use snake case on Azure Storage config [#1879](https://github.com/grafana/tempo/issues/1879) (@faustodavid)
 Example of using snake case on Azure Storage config:
 ```

--- a/modules/distributor/receiver/shim.go
+++ b/modules/distributor/receiver/shim.go
@@ -279,6 +279,7 @@ func (r *receiversShim) ConsumeTraces(ctx context.Context, td ptrace.Traces) err
 // ReportFatalError implements component.Host
 func (r *receiversShim) ReportFatalError(err error) {
 	_ = level.Error(log.Logger).Log("msg", "fatal error reported", "err", err)
+	r.StopAsync()
 }
 
 // GetFactory implements component.Host

--- a/modules/distributor/receiver/shim.go
+++ b/modules/distributor/receiver/shim.go
@@ -69,6 +69,7 @@ type receiversShim struct {
 	pusher      TracesPusher
 	logger      *log.RateLimitedLogger
 	metricViews []*view.View
+	fatal       chan error
 }
 
 func (r *receiversShim) Capabilities() consumer.Capabilities {
@@ -94,6 +95,7 @@ func New(receiverCfg map[string]interface{}, pusher TracesPusher, middleware Mid
 	shim := &receiversShim{
 		pusher: pusher,
 		logger: log.NewRateLimitedLogger(logsPerSecond, level.Error(log.Logger)),
+		fatal:  make(chan error),
 	}
 
 	// shim otel observability
@@ -217,10 +219,20 @@ func New(receiverCfg map[string]interface{}, pusher TracesPusher, middleware Mid
 		shim.receivers = append(shim.receivers, receiver)
 	}
 
-	shim.Service = services.NewIdleService(shim.starting, shim.stopping)
+	shim.Service = services.NewBasicService(shim.starting, shim.running, shim.stopping)
 
 	return shim, nil
 }
+
+func (r *receiversShim) running(ctx context.Context) error {
+	select {
+	case err := <-r.fatal:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 func (r *receiversShim) starting(ctx context.Context) error {
 	for _, receiver := range r.receivers {
 		err := receiver.Start(ctx, r)
@@ -279,7 +291,7 @@ func (r *receiversShim) ConsumeTraces(ctx context.Context, td ptrace.Traces) err
 // ReportFatalError implements component.Host
 func (r *receiversShim) ReportFatalError(err error) {
 	_ = level.Error(log.Logger).Log("msg", "fatal error reported", "err", err)
-	r.StopAsync()
+	r.fatal <- err
 }
 
 // GetFactory implements component.Host


### PR DESCRIPTION

**What this PR does**:
* occasionally otel receivers will report a fatal error, and expected behavior is that the Host is stopped
* match this behavior by stopping the receiver shim service and letting the distributor stop itself

If you think we need a test added to prevent regression, let me know

**Which issue(s) this PR fixes**:
No Issue

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`