### PR TITLE
Increase operations-per-run for stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/stale@v6.0.1
         with:
           close-issue-reason: not_planned
+          operations-per-run: 100
           days-before-stale: 60
           days-before-close: 15
           stale-issue-message: >


### PR DESCRIPTION
**What this PR does**:
Increase operations-per-run config for stale workflow, it's defaults to 30 and we have way more issues & PRs to scan.

It fails to scan all issues & PRs with default limit, incrasing it to 100.

See: 
- https://github.com/grafana/tempo/actions/runs/3441389540/jobs/5740868546#step:2:1074
- https://github.com/actions/stale#operations-per-run

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`