### PR TITLE
traceql: fix how timestamps are converted from search request

### DIFF
--- a/pkg/traceql/engine.go
+++ b/pkg/traceql/engine.go
@@ -106,8 +106,8 @@ func (e *Engine) createFetchSpansRequest(searchReq *tempopb.SearchRequest, pipel
 	// TODO handle SearchRequest.MinDurationMs and MaxDurationMs, this refers to the trace level duration which is not the same as the intrinsic duration
 
 	req := FetchSpansRequest{
-		StartTimeUnixNanos: unixMilliToNano(searchReq.Start),
-		EndTimeUnixNanos:   unixMilliToNano(searchReq.End),
+		StartTimeUnixNanos: unixSecToNano(searchReq.Start),
+		EndTimeUnixNanos:   unixSecToNano(searchReq.End),
 		Conditions:         nil,
 		AllConditions:      true,
 	}
@@ -165,8 +165,8 @@ func (e *Engine) asTraceSearchMetadata(spanset Spanset) *tempopb.TraceSearchMeta
 	return metadata
 }
 
-func unixMilliToNano(ts uint32) uint64 {
-	return uint64(ts) * 1000
+func unixSecToNano(ts uint32) uint64 {
+	return uint64(ts) * 1_000_000_000
 }
 
 func (s Static) asAnyValue() *common_v1.AnyValue {

--- a/pkg/traceql/engine_test.go
+++ b/pkg/traceql/engine_test.go
@@ -282,6 +282,12 @@ func newCondition(attr Attribute, op Operator, operands ...Static) Condition {
 	}
 }
 
+func TestUnixSecToNano(t *testing.T) {
+	now := time.Now()
+	// tolerate delta's up to 1 second
+	assert.InDelta(t, uint64(now.UnixNano()), unixSecToNano(uint32(now.Unix())), float64(time.Second.Nanoseconds()))
+}
+
 func TestStatic_AsAnyValue(t *testing.T) {
 	tt := []struct {
 		s        Static


### PR DESCRIPTION
**What this PR does**:
We had a (pretty dumb) bug in the conversion from `SearchRequest.StartTime`/`EndTime` to `FetchSpansRequest.StartTimeUnixNanos`/`EndTimeUnixNanos`. The time range in `SearchRequest` is in unix seconds, not milliseconds.

**Which issue(s) this PR fixes**:
Part of https://github.com/grafana/tempo/issues/1854

**Checklist**
- [x] Tests updated
- [ ] ~~Documentation added~~
- [ ] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~