### PR TITLE
Remove usage of min/max id in trace by id search

### DIFF
--- a/tempodb/encoding/vparquet/block_findtracebyid.go
+++ b/tempodb/encoding/vparquet/block_findtracebyid.go
@@ -90,8 +90,9 @@ func (b *backendBlock) FindTraceByID(ctx context.Context, traceID common.ID, opt
 
 	// Cache of row group bounds
 	rowGroupMins := make([]common.ID, numRowGroups+1)
-	rowGroupMins[0] = b.meta.MinID
-	rowGroupMins[numRowGroups] = b.meta.MaxID // This is actually inclusive and the logic is special for the last row group below
+	// todo: restore using meta min/max id once it works
+	rowGroupMins[0] = bytes.Repeat([]byte{0}, 16)
+	rowGroupMins[numRowGroups] = bytes.Repeat([]byte{255}, 16) // This is actually inclusive and the logic is special for the last row group below
 
 	// Gets the minimum trace ID within the row group. Since the column is sorted
 	// ascending we just read the first value from the first page.

--- a/tempodb/encoding/vparquet/block_findtracebyid.go
+++ b/tempodb/encoding/vparquet/block_findtracebyid.go
@@ -91,6 +91,7 @@ func (b *backendBlock) FindTraceByID(ctx context.Context, traceID common.ID, opt
 	// Cache of row group bounds
 	rowGroupMins := make([]common.ID, numRowGroups+1)
 	// todo: restore using meta min/max id once it works
+	//    https://github.com/grafana/tempo/issues/1903
 	rowGroupMins[0] = bytes.Repeat([]byte{0}, 16)
 	rowGroupMins[numRowGroups] = bytes.Repeat([]byte{255}, 16) // This is actually inclusive and the logic is special for the last row group below
 

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -494,6 +494,8 @@ func (rw *readerWriter) getWriterForBlock(meta *backend.BlockMeta, curTime time.
 
 // includeBlock indicates whether a given block should be included in a backend search
 func includeBlock(b *backend.BlockMeta, id common.ID, blockStart []byte, blockEnd []byte, timeStart int64, timeEnd int64) bool {
+	// todo: restore this functionality once it works. min/max ids are currently not recorded
+	//  correctly in a block
 	// if bytes.Compare(id, b.MinID) == -1 || bytes.Compare(id, b.MaxID) == 1 {
 	// 	return false
 	// }

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -493,7 +493,7 @@ func (rw *readerWriter) getWriterForBlock(meta *backend.BlockMeta, curTime time.
 }
 
 // includeBlock indicates whether a given block should be included in a backend search
-func includeBlock(b *backend.BlockMeta, id common.ID, blockStart []byte, blockEnd []byte, timeStart int64, timeEnd int64) bool {
+func includeBlock(b *backend.BlockMeta, _ common.ID, blockStart []byte, blockEnd []byte, timeStart int64, timeEnd int64) bool {
 	// todo: restore this functionality once it works. min/max ids are currently not recorded
 	//    https://github.com/grafana/tempo/issues/1903
 	//  correctly in a block

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -495,6 +495,7 @@ func (rw *readerWriter) getWriterForBlock(meta *backend.BlockMeta, curTime time.
 // includeBlock indicates whether a given block should be included in a backend search
 func includeBlock(b *backend.BlockMeta, id common.ID, blockStart []byte, blockEnd []byte, timeStart int64, timeEnd int64) bool {
 	// todo: restore this functionality once it works. min/max ids are currently not recorded
+	//    https://github.com/grafana/tempo/issues/1903
 	//  correctly in a block
 	// if bytes.Compare(id, b.MinID) == -1 || bytes.Compare(id, b.MaxID) == 1 {
 	// 	return false

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -494,9 +494,9 @@ func (rw *readerWriter) getWriterForBlock(meta *backend.BlockMeta, curTime time.
 
 // includeBlock indicates whether a given block should be included in a backend search
 func includeBlock(b *backend.BlockMeta, id common.ID, blockStart []byte, blockEnd []byte, timeStart int64, timeEnd int64) bool {
-	if bytes.Compare(id, b.MinID) == -1 || bytes.Compare(id, b.MaxID) == 1 {
-		return false
-	}
+	// if bytes.Compare(id, b.MinID) == -1 || bytes.Compare(id, b.MaxID) == 1 {
+	// 	return false
+	// }
 
 	if timeStart != 0 && timeEnd != 0 {
 		if b.StartTime.Unix() >= timeEnd || b.EndTime.Unix() <= timeStart {

--- a/tempodb/tempodb_test.go
+++ b/tempodb/tempodb_test.go
@@ -355,28 +355,29 @@ func TestIncludeBlock(t *testing.T) {
 				MaxID:   []byte{0x10},
 			},
 		},
-		{
-			name:       "exclude - min id range",
-			searchID:   []byte{0x00},
-			blockStart: uuid.MustParse(BlockIDMin),
-			blockEnd:   uuid.MustParse(BlockIDMax),
-			meta: &backend.BlockMeta{
-				BlockID: uuid.MustParse("50000000-0000-0000-0000-000000000000"),
-				MinID:   []byte{0x01},
-				MaxID:   []byte{0x10},
-			},
-		},
-		{
-			name:       "exclude - max id range",
-			searchID:   []byte{0x11},
-			blockStart: uuid.MustParse(BlockIDMin),
-			blockEnd:   uuid.MustParse(BlockIDMax),
-			meta: &backend.BlockMeta{
-				BlockID: uuid.MustParse("50000000-0000-0000-0000-000000000000"),
-				MinID:   []byte{0x01},
-				MaxID:   []byte{0x10},
-			},
-		},
+		// todo: restore when this is fixed: https://github.com/grafana/tempo/issues/1903
+		// {
+		// 	name:       "exclude - min id range",
+		// 	searchID:   []byte{0x00},
+		// 	blockStart: uuid.MustParse(BlockIDMin),
+		// 	blockEnd:   uuid.MustParse(BlockIDMax),
+		// 	meta: &backend.BlockMeta{
+		// 		BlockID: uuid.MustParse("50000000-0000-0000-0000-000000000000"),
+		// 		MinID:   []byte{0x01},
+		// 		MaxID:   []byte{0x10},
+		// 	},
+		// },
+		// {
+		// 	name:       "exclude - max id range",
+		// 	searchID:   []byte{0x11},
+		// 	blockStart: uuid.MustParse(BlockIDMin),
+		// 	blockEnd:   uuid.MustParse(BlockIDMax),
+		// 	meta: &backend.BlockMeta{
+		// 		BlockID: uuid.MustParse("50000000-0000-0000-0000-000000000000"),
+		// 		MinID:   []byte{0x01},
+		// 		MaxID:   []byte{0x10},
+		// 	},
+		// },
 		{
 			name:       "exclude - min block range",
 			searchID:   []byte{0x05},


### PR DESCRIPTION
**What this PR does**:
There is currently a [bug](https://github.com/grafana/tempo/issues/1903) with setting the min/max id in the block meta. This PR removes all usage of these values since they are not accurate. In extreme edge cases performance will be very narrowly impacted.

Once the linked issue is fixed this PR can be reverted.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`