### PR TITLE
tempo-mixin: tweak dashboards to support metrics without cluster label present

### DIFF
--- a/operations/tempo-mixin-compiled/dashboards/tempo-reads.json
+++ b/operations/tempo-mixin-compiled/dashboards/tempo-reads.json
@@ -1519,7 +1519,7 @@
     "type": "datasource"
    },
    {
-    "allValue": ".+",
+    "allValue": null,
     "current": {
      "selected": true,
      "text": "All",

--- a/operations/tempo-mixin-compiled/dashboards/tempo-resources.json
+++ b/operations/tempo-mixin-compiled/dashboards/tempo-resources.json
@@ -2142,7 +2142,7 @@
     "type": "datasource"
    },
    {
-    "allValue": ".+",
+    "allValue": null,
     "current": {
      "selected": true,
      "text": "All",

--- a/operations/tempo-mixin-compiled/dashboards/tempo-rollout-progress.json
+++ b/operations/tempo-mixin-compiled/dashboards/tempo-rollout-progress.json
@@ -1466,7 +1466,7 @@
     "type": "datasource"
    },
    {
-    "allValue": ".+",
+    "allValue": null,
     "current": {
      "selected": true,
      "text": "All",

--- a/operations/tempo-mixin-compiled/dashboards/tempo-writes.json
+++ b/operations/tempo-mixin-compiled/dashboards/tempo-writes.json
@@ -1645,7 +1645,7 @@
     "type": "datasource"
    },
    {
-    "allValue": ".+",
+    "allValue": null,
     "current": {
      "selected": true,
      "text": "All",

--- a/operations/tempo-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/tempo-mixin/dashboards/dashboard-utils.libsonnet
@@ -24,7 +24,7 @@ grafana {
           ],
         };
 
-        d.addMultiTemplate('cluster', 'tempo_build_info', $._config.per_cluster_label)
+        d.addMultiTemplate('cluster', 'tempo_build_info', $._config.per_cluster_label, allValue=null)
         .addMultiTemplate('namespace', 'tempo_build_info{' + $._config.per_cluster_label + "=~'$cluster'}", 'namespace', allValue=null),
     },
 


### PR DESCRIPTION
**What this PR does**:
If metrics don't have the `cluster` label they won't show up because queries have `cluster=.+`. This PR sets the `cluster` AllValue to null so it doesn't filter, just like we already do for `namespace`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/tempo/issues/1911

**Checklist**
- [ ] ~~Tests updated~~
- [ ] ~~Documentation added~~
- [ ] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~