### PR TITLE
Parquet Ingester: Perf Improvements

### DIFF
--- a/pkg/tempopb/prealloc.go
+++ b/pkg/tempopb/prealloc.go
@@ -3,8 +3,8 @@ package tempopb
 import "github.com/grafana/tempo/pkg/tempopb/pool"
 
 var (
-	// buckets: [0.5KiB, 1KiB, 2KiB, 4KiB, 8KiB, 16KiB]
-	bytePool = pool.New(500, 16_000, 2, func(size int) []byte { return make([]byte, 0, size) })
+	// buckets: [0.5KiB, 1KiB, 2KiB, 4KiB, 8KiB, 16KiB] ...
+	bytePool = pool.New(500, 64_000, 2, func(size int) []byte { return make([]byte, 0, size) })
 )
 
 // PreallocBytes is a (repeated bytes slices) which preallocs slices on Unmarshal.

--- a/tempodb/encoding/v2/create_block.go
+++ b/tempodb/encoding/v2/create_block.go
@@ -64,6 +64,10 @@ func CreateBlock(ctx context.Context, cfg *common.BlockConfig, meta *backend.Blo
 			break
 		}
 
+		// jpe why does this fail vparquet -> v2 but not vparquet -> vparquet?
+		//      does this copy need to be in the parquet iterator?
+		id = append([]byte(nil), id...)
+
 		// This assumes the incoming bytes are the same data encoding.
 		err = newBlock.AddObject(id, trBytes)
 		if err != nil {

--- a/tempodb/encoding/v2/create_block.go
+++ b/tempodb/encoding/v2/create_block.go
@@ -43,6 +43,9 @@ func CreateBlock(ctx context.Context, cfg *common.BlockConfig, meta *backend.Blo
 				return nil, nil, err
 			}
 
+			// copy the id to escape the iterator
+			id = append([]byte(nil), id...)
+
 			traceBytes, err := dec.PrepareForWrite(tr, 0, 0) // start/end of the blockmeta are used
 			if err != nil {
 				return nil, nil, err
@@ -63,10 +66,6 @@ func CreateBlock(ctx context.Context, cfg *common.BlockConfig, meta *backend.Blo
 		if id == nil {
 			break
 		}
-
-		// jpe why does this fail vparquet -> v2 but not vparquet -> vparquet?
-		//      does this copy need to be in the parquet iterator?
-		id = append([]byte(nil), id...)
 
 		// This assumes the incoming bytes are the same data encoding.
 		err = newBlock.AddObject(id, trBytes)

--- a/tempodb/encoding/vparquet/schema.go
+++ b/tempodb/encoding/vparquet/schema.go
@@ -619,5 +619,7 @@ func extendReuseSlice[T any](sz int, in []T) []T {
 		return in[:sz]
 	}
 
-	return make([]T, sz)
+	// append until we're large enough
+	in = in[:cap(in)]
+	return append(in, make([]T, sz-len(in))...)
 }

--- a/tempodb/encoding/vparquet/schema_test.go
+++ b/tempodb/encoding/vparquet/schema_test.go
@@ -244,3 +244,34 @@ func estimateRowSize(t *testing.T, name string) {
 
 	fmt.Println(pf.Size(), ",", len(pf.RowGroups()), ",", totalProtoSize, ",", totalTraceSize)
 }
+
+func TestExtendReuseSlice(t *testing.T) {
+	tcs := []struct {
+		sz       int
+		in       []int
+		expected []int
+	}{
+		{
+			sz:       0,
+			in:       []int{1, 2, 3},
+			expected: []int{},
+		},
+		{
+			sz:       2,
+			in:       []int{1, 2, 3},
+			expected: []int{1, 2},
+		},
+		{
+			sz:       5,
+			in:       []int{1, 2, 3},
+			expected: []int{1, 2, 3, 0, 0},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(fmt.Sprintf("%v", tc.sz), func(t *testing.T) {
+			out := extendReuseSlice(tc.sz, tc.in)
+			assert.Equal(t, tc.expected, out)
+		})
+	}
+}

--- a/tempodb/encoding/vparquet/schema_test.go
+++ b/tempodb/encoding/vparquet/schema_test.go
@@ -275,3 +275,10 @@ func TestExtendReuseSlice(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkExtendReuseSlice(b *testing.B) {
+	in := []int{1, 2, 3}
+	for i := 0; i < b.N; i++ {
+		_ = extendReuseSlice(100, in)
+	}
+}

--- a/tempodb/encoding/vparquet/wal_block.go
+++ b/tempodb/encoding/vparquet/wal_block.go
@@ -560,6 +560,7 @@ func (i *rowIterator) Next(ctx context.Context) (common.ID, parquet.Row, error) 
 	for _, v := range row {
 		if v.Column() == i.traceIDIndex {
 			id = v.ByteArray()
+			break
 		}
 	}
 

--- a/tempodb/encoding/vparquet/wal_block.go
+++ b/tempodb/encoding/vparquet/wal_block.go
@@ -523,12 +523,12 @@ func parseName(filename string) (uuid.UUID, string, string, error) {
 // traces are iterated according to the given row numbers, because there is
 // not a guarantee that the underlying parquet file is sorted
 type rowIterator struct {
-	reader       *parquet.Reader
+	reader       *parquet.Reader //nolint:all //deprecated
 	rowNumbers   []int64
 	traceIDIndex int
 }
 
-func newRowIterator(r *parquet.Reader, rowNumbers []int64, traceIDIndex int) *rowIterator {
+func newRowIterator(r *parquet.Reader, rowNumbers []int64, traceIDIndex int) *rowIterator { //nolint:all //deprecated
 	return &rowIterator{
 		reader:       r,
 		rowNumbers:   rowNumbers,

--- a/tempodb/encoding/vparquet/wal_block.go
+++ b/tempodb/encoding/vparquet/wal_block.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/pkg/model/trace"
+	"github.com/grafana/tempo/pkg/parquetquery"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/traceql"
 	"github.com/grafana/tempo/pkg/warnings"
@@ -36,7 +36,7 @@ var _ common.WALBlock = (*walBlock)(nil)
 
 // openWALBlock opens an existing appendable block.  It is read-only by
 // not assigning a decoder.
-func openWALBlock(filename string, path string, ingestionSlack time.Duration, _ time.Duration) (common.WALBlock, error, error) { // jpe what returns a warning?
+func openWALBlock(filename string, path string, ingestionSlack time.Duration, _ time.Duration) (common.WALBlock, error, error) {
 	dir := filepath.Join(path, filename)
 	_, _, version, err := parseName(filename)
 	if err != nil {
@@ -333,30 +333,48 @@ func (b *walBlock) DataLength() uint64 {
 }
 
 func (b *walBlock) Iterator() (common.Iterator, error) {
-	bookmarks := make([]*bookmark[*Trace], 0, len(b.flushed))
+	pool := newRowPool(100000) // jpe should be based on config somewhere?
+	bookmarks := make([]*bookmark[parquet.Row], 0, len(b.flushed))
+
 	for _, page := range b.flushed {
+		idx, _ := parquetquery.GetColumnIndexByPath(page.file, TraceIDColumnName)
+		r := parquet.NewReader(page.file)
+		iter := newRowIterator(r, page.ids.ValuesSortedByID(), pool, idx)
 
-		r := parquet.NewGenericReader[*Trace](page.file)
-		iter := &traceIterator{reader: r, rowNumbers: page.ids.ValuesSortedByID()}
-
-		bookmarks = append(bookmarks, newBookmark[*Trace](iter))
+		bookmarks = append(bookmarks, newBookmark[parquet.Row](iter))
 	}
 
-	iter := newMultiblockIterator(bookmarks, func(ts []*Trace) (*Trace, error) {
+	sch := parquet.SchemaOf(new(Trace))
+	iter := newMultiblockIterator(bookmarks, func(rows []parquet.Row) (parquet.Row, error) {
+		if len(rows) == 1 {
+			return rows[0], nil
+		}
+
+		ts := make([]*Trace, 0, len(rows))
+		for _, row := range rows {
+			tr := &Trace{}
+			err := sch.Reconstruct(tr, row) // jpe - how much is this called? outsized impact on mem?
+			if err != nil {
+				return nil, err
+			}
+			ts = append(ts, tr)
+			pool.Put(row)
+		}
+
 		t := CombineTraces(ts...)
-		return t, nil
+		row := pool.Get()
+		row = sch.Deconstruct(row, t)
+
+		return row, nil
 	})
 
-	return &commonIterator{
-		iter: iter,
-	}, nil
+	return newCommonIterator(iter, pool), nil
 }
 
 func (b *walBlock) Clear() error {
 	return os.RemoveAll(b.walPath())
 }
 
-// jpe what to do with common.SearchOptions?
 func (b *walBlock) FindTraceByID(ctx context.Context, id common.ID, _ common.SearchOptions) (*tempopb.Trace, error) {
 	trs := make([]*tempopb.Trace, 0)
 
@@ -394,7 +412,6 @@ func (b *walBlock) Search(ctx context.Context, req *tempopb.SearchRequest, opts 
 		Metrics: &tempopb.SearchMetrics{},
 	}
 
-	// jpe parrallelize?
 	for i, page := range b.flushed {
 		r, err := searchParquetFile(ctx, page.file, req, page.file.RowGroups())
 		if err != nil {
@@ -415,7 +432,6 @@ func (b *walBlock) Search(ctx context.Context, req *tempopb.SearchRequest, opts 
 }
 
 func (b *walBlock) SearchTags(ctx context.Context, cb common.TagCallback, opts common.SearchOptions) error {
-	// jpe parallelize?
 	for i, page := range b.flushed {
 		err := searchTags(ctx, cb, page.file)
 		if err != nil {
@@ -427,7 +443,6 @@ func (b *walBlock) SearchTags(ctx context.Context, cb common.TagCallback, opts c
 }
 
 func (b *walBlock) SearchTagValues(ctx context.Context, tag string, cb common.TagCallback, opts common.SearchOptions) error {
-	// jpe parallelize?
 	for i, f := range b.flushed {
 		err := searchTagValues(ctx, tag, cb, f.file)
 		if err != nil {
@@ -496,32 +511,26 @@ func parseName(filename string) (uuid.UUID, string, string, error) {
 	return id, tenant, version, nil
 }
 
-// jpe iterators feel like a mess, clean up ?
-
-var tracePool sync.Pool
-
-func tracePoolGet() *Trace {
-	o := tracePool.Get()
-	if o == nil {
-		return &Trace{}
-	}
-
-	return o.(*Trace)
-}
-
-func tracePoolPut(t *Trace) {
-	tracePool.Put(t)
-}
-
-// traceIterator is used to iterate a parquet file and implement iterIterator
+// rowIterator is used to iterate a parquet file and implement iterIterator
 // traces are iterated according to the given row numbers, because there is
 // not a guarantee that the underlying parquet file is sorted
-type traceIterator struct {
-	reader     *parquet.GenericReader[*Trace]
-	rowNumbers []int64
+type rowIterator struct {
+	reader       *parquet.Reader
+	rowNumbers   []int64
+	pool         *rowPool
+	traceIDIndex int
 }
 
-func (i *traceIterator) Next(ctx context.Context) (common.ID, *Trace, error) {
+func newRowIterator(r *parquet.Reader, rowNumbers []int64, pool *rowPool, traceIDIndex int) *rowIterator {
+	return &rowIterator{
+		reader:       r,
+		rowNumbers:   rowNumbers,
+		pool:         pool,
+		traceIDIndex: traceIDIndex,
+	}
+}
+
+func (i *rowIterator) Next(ctx context.Context) (common.ID, parquet.Row, error) {
 	if len(i.rowNumbers) == 0 {
 		return nil, nil, nil
 	}
@@ -534,43 +543,66 @@ func (i *traceIterator) Next(ctx context.Context) (common.ID, *Trace, error) {
 		return nil, nil, err
 	}
 
-	tr := tracePoolGet()
-	_, err = i.reader.Read([]*Trace{tr})
+	rows := []parquet.Row{i.pool.Get()}
+	_, err = i.reader.ReadRows(rows)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return tr.TraceID, tr, nil
+	row := rows[0]
+	var id common.ID
+	for _, v := range row {
+		if v.Column() == i.traceIDIndex {
+			id = v.ByteArray()
+		}
+	}
+
+	return id, row, nil
 }
 
-func (i *traceIterator) Close() {
+func (i *rowIterator) Close() {
 	i.reader.Close()
 }
 
-var _ TraceIterator = (*commonIterator)(nil)
 var _ common.Iterator = (*commonIterator)(nil)
 
-// commonIterator implements both TraceIterator and common.Iterator. it is returned from the AppendFile and is meant
+// commonIterator implements common.Iterator. it is returned from the AppendFile and is meant
 // to be passed to a CreateBlock
 type commonIterator struct {
-	iter *MultiBlockIterator[*Trace]
+	iter   *MultiBlockIterator[parquet.Row]
+	schema *parquet.Schema
+	pool   *rowPool
+}
+
+func newCommonIterator(iter *MultiBlockIterator[parquet.Row], pool *rowPool) *commonIterator {
+	return &commonIterator{
+		iter:   iter,
+		schema: parquet.SchemaOf(&Trace{}),
+		pool:   pool,
+	}
 }
 
 func (i *commonIterator) Next(ctx context.Context) (common.ID, *tempopb.Trace, error) {
-	id, obj, err := i.iter.Next(ctx)
+	id, row, err := i.iter.Next(ctx)
 	if err != nil && err != io.EOF {
 		return nil, nil, err
 	}
 
-	if obj == nil || err == io.EOF {
+	if row == nil || err == io.EOF {
 		return nil, nil, nil
 	}
 
-	tr := parquetTraceToTempopbTrace(obj)
+	t := &Trace{}
+	err = i.schema.Reconstruct(t, row)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tr := parquetTraceToTempopbTrace(t)
 	return id, tr, nil
 }
 
-func (i *commonIterator) NextTrace(ctx context.Context) (common.ID, *Trace, error) {
+func (i *commonIterator) NextRow(ctx context.Context) (common.ID, parquet.Row, error) {
 	return i.iter.Next(ctx)
 }
 


### PR DESCRIPTION
**What this PR does**:
A collection of performance improvements for a Parquet ingester. Specifically targeting the parquet wal.

- Adjust prealloc bytes pool to catch a larger percentage of write sizes
- Rewrite the complete block logic to use rows instead of Trace objects for better pooling
- Improve extendReuseSlice() to keep existing values on extension

This is observed to improve:
- Heap Bytes by 25%
- Working set by 15%
- CPU by 20%
