### PR TITLE
[TraceQL] I/O Improvements

### DIFF
--- a/tempodb/encoding/vparquet/wal_block.go
+++ b/tempodb/encoding/vparquet/wal_block.go
@@ -471,7 +471,7 @@ func (b *walBlock) Fetch(ctx context.Context, req traceql.FetchSpansRequest, opt
 
 	iters := make([]*spansetIterator, 0, len(b.flushed))
 	for _, f := range b.flushed {
-		iter, err := fetch(ctx, req, f.file)
+		iter, err := fetch(ctx, req, f.file, opts)
 		if err != nil {
 			return traceql.FetchSpansResponse{}, errors.Wrap(err, "creating fetch iter")
 		}

--- a/tempodb/wal/wal_test.go
+++ b/tempodb/wal/wal_test.go
@@ -278,9 +278,8 @@ func testFetch(t *testing.T, e encoding.VersionedEncoding) {
 			require.NotEmpty(t, v)
 
 			query := fmt.Sprintf("{ .%s = \"%s\" }", k, v)
-			condition := traceql.MustExtractCondition(query)
 			resp, err := block.Fetch(ctx, traceql.FetchSpansRequest{
-				Conditions: []traceql.Condition{condition},
+				Conditions: traceql.MustExtractConditions(query),
 			}, common.DefaultSearchOptions())
 			// not all blocks support fetch
 			if err == common.ErrUnsupported {


### PR DESCRIPTION
**What this PR does**:
This PR reduces the amount of data read during parquet search by not starting column iterators until the first call to `Next()`, and reordering iterators a bit. This benefits highly selective queries in that it will never open/scan the metadata columns such span.ID, traceID, rootServiceName, etc, until results are found.  This benefits TraceQL primarily because it contains more metadata columns (span ID, start, end), but 

Benchmarks:

Tag search:
```
name                                      old time/op    new time/op    delta
BackendBlockSearchTraces/noMatch-12          174ms ±11%      55ms ± 3%  -68.04%  (p=0.000 n=10+10)
BackendBlockSearchTraces/partialMatch-12     2.49s ± 6%     2.47s ± 2%     ~     (p=0.863 n=9+9)
BackendBlockSearchTraces/service.name-12    1.38ms ± 8%    1.65ms ± 9%  +20.22%  (p=0.000 n=10+10)

name                                      old MB_io/op   new MB_io/op   delta
BackendBlockSearchTraces/noMatch-12           56.8 ± 6%      21.2 ± 0%  -62.68%  (p=0.000 n=10+10)
BackendBlockSearchTraces/partialMatch-12      66.5 ± 0%      51.8 ± 0%  -22.12%  (p=0.000 n=9+10)
BackendBlockSearchTraces/service.name-12      4.89 ± 0%      4.92 ± 0%   +0.59%  (p=0.000 n=9+10)

name                                      old alloc/op   new alloc/op   delta
BackendBlockSearchTraces/noMatch-12         55.0MB ± 9%     4.1MB ±15%  -92.50%  (p=0.000 n=10+10)
BackendBlockSearchTraces/partialMatch-12     329MB ± 4%     292MB ± 2%  -11.16%  (p=0.000 n=9+10)
BackendBlockSearchTraces/service.name-12    1.71MB ± 2%    2.03MB ± 3%  +18.50%  (p=0.000 n=10+10)

name                                      old allocs/op  new allocs/op  delta
BackendBlockSearchTraces/noMatch-12          90.9k ± 5%     50.4k ± 0%  -44.54%  (p=0.000 n=10+9)
BackendBlockSearchTraces/partialMatch-12     17.9M ± 0%     17.9M ± 0%   -0.09%  (p=0.000 n=9+9)
BackendBlockSearchTraces/service.name-12     39.2k ± 0%     39.2k ± 0%   +0.02%  (p=0.011 n=10+10)
```

TraceQL:
```
name                                 old time/op    new time/op    delta
BackendBlockTraceQL/noMatch-12          126ms ±26%      51ms ± 3%  -59.21%  (p=0.000 n=10+9)
BackendBlockTraceQL/partialMatch-12     1.03s ± 1%     1.12s ± 9%   +7.83%  (p=0.000 n=8+10)
BackendBlockTraceQL/service.name-12    13.3ms ±62%     2.9ms ± 9%  -78.08%  (p=0.000 n=10+10)

name                                 old MB_io/op   new MB_io/op   delta
BackendBlockTraceQL/noMatch-12           46.3 ± 6%      17.0 ± 0%  -63.19%  (p=0.000 n=9+10)
BackendBlockTraceQL/partialMatch-12      24.5 ± 0%      24.5 ± 0%     ~     (all equal)
BackendBlockTraceQL/service.name-12      4.29 ± 0%      0.73 ± 0%  -83.08%  (p=0.000 n=10+10)

name                                 old alloc/op   new alloc/op   delta
BackendBlockTraceQL/noMatch-12         35.4MB ± 8%     2.9MB ±17%  -91.80%  (p=0.000 n=10+10)
BackendBlockTraceQL/partialMatch-12    51.3MB ± 2%    50.3MB ± 3%   -1.96%  (p=0.036 n=8+9)
BackendBlockTraceQL/service.name-12    11.7MB ± 0%     0.3MB ± 1%  -97.81%  (p=0.000 n=10+10)

name                                 old allocs/op  new allocs/op  delta
BackendBlockTraceQL/noMatch-12          73.6k ±10%     35.6k ± 0%  -51.60%  (p=0.000 n=10+8)
BackendBlockTraceQL/partialMatch-12     70.0k ± 0%     70.0k ± 0%   -0.04%  (p=0.026 n=8+9)
BackendBlockTraceQL/service.name-12     12.5k ± 0%      3.8k ± 0%  -69.82%  (p=0.000 n=10+10)
```

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`