### PR TITLE
Upgrade parquet-go

### DIFF
--- a/cmd/tempo-serverless/cloud-run/go.mod
+++ b/cmd/tempo-serverless/cloud-run/go.mod
@@ -99,7 +99,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rs/xid v1.2.1 // indirect
 	github.com/segmentio/encoding v0.3.5 // indirect
-	github.com/segmentio/parquet-go v0.0.0-20221103170249-ef6062d06d9f // indirect
+	github.com/segmentio/parquet-go v0.0.0-20221205175245-39e02a5ed102 // indirect
 	github.com/sercand/kuberesolver v2.4.0+incompatible // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/sony/gobreaker v0.4.1 // indirect

--- a/cmd/tempo-serverless/cloud-run/go.sum
+++ b/cmd/tempo-serverless/cloud-run/go.sum
@@ -458,8 +458,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/encoding v0.3.5 h1:UZEiaZ55nlXGDL92scoVuw00RmiRCazIEmvPSbSvt8Y=
 github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
-github.com/segmentio/parquet-go v0.0.0-20221103170249-ef6062d06d9f h1:qqBLtgUF0WfUCxFuFey1ko665UfvjyFTJ/UIfJXKiao=
-github.com/segmentio/parquet-go v0.0.0-20221103170249-ef6062d06d9f/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
+github.com/segmentio/parquet-go v0.0.0-20221205175245-39e02a5ed102 h1:l8FsX3vlG/KMWi/PrJZyjKfV5ytjte6KL8kRL+ekaFE=
+github.com/segmentio/parquet-go v0.0.0-20221205175245-39e02a5ed102/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/sercand/kuberesolver v2.4.0+incompatible h1:WE2OlRf6wjLxHwNkkFLQGaZcVLEXjMjBPjjEU5vksH8=
 github.com/sercand/kuberesolver v2.4.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/cmd/tempo-serverless/lambda/go.mod
+++ b/cmd/tempo-serverless/lambda/go.mod
@@ -100,7 +100,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rs/xid v1.2.1 // indirect
 	github.com/segmentio/encoding v0.3.5 // indirect
-	github.com/segmentio/parquet-go v0.0.0-20221103170249-ef6062d06d9f // indirect
+	github.com/segmentio/parquet-go v0.0.0-20221205175245-39e02a5ed102 // indirect
 	github.com/sercand/kuberesolver v2.4.0+incompatible // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/sony/gobreaker v0.4.1 // indirect

--- a/cmd/tempo-serverless/lambda/go.sum
+++ b/cmd/tempo-serverless/lambda/go.sum
@@ -463,8 +463,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/encoding v0.3.5 h1:UZEiaZ55nlXGDL92scoVuw00RmiRCazIEmvPSbSvt8Y=
 github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
-github.com/segmentio/parquet-go v0.0.0-20221103170249-ef6062d06d9f h1:qqBLtgUF0WfUCxFuFey1ko665UfvjyFTJ/UIfJXKiao=
-github.com/segmentio/parquet-go v0.0.0-20221103170249-ef6062d06d9f/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
+github.com/segmentio/parquet-go v0.0.0-20221205175245-39e02a5ed102 h1:l8FsX3vlG/KMWi/PrJZyjKfV5ytjte6KL8kRL+ekaFE=
+github.com/segmentio/parquet-go v0.0.0-20221205175245-39e02a5ed102/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/sercand/kuberesolver v2.4.0+incompatible h1:WE2OlRf6wjLxHwNkkFLQGaZcVLEXjMjBPjjEU5vksH8=
 github.com/sercand/kuberesolver v2.4.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/prometheus/prometheus v1.8.2-0.20221021121301-51a44e6657c3
 	github.com/prometheus/statsd_exporter v0.21.0 // indirect
 	github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e
-	github.com/segmentio/parquet-go v0.0.0-20221103170249-ef6062d06d9f
+	github.com/segmentio/parquet-go v0.0.0-20221205175245-39e02a5ed102
 	github.com/sirupsen/logrus v1.8.1
 	github.com/sony/gobreaker v0.4.1
 	github.com/spf13/viper v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -901,6 +901,8 @@ github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e h1:uO75wNGioszj
 github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e/go.mod h1:tm/wZFQ8e24NYaBGIlnO2WGCAi67re4HHuOm0sftE/M=
 github.com/segmentio/parquet-go v0.0.0-20221103170249-ef6062d06d9f h1:qqBLtgUF0WfUCxFuFey1ko665UfvjyFTJ/UIfJXKiao=
 github.com/segmentio/parquet-go v0.0.0-20221103170249-ef6062d06d9f/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
+github.com/segmentio/parquet-go v0.0.0-20221205175245-39e02a5ed102 h1:l8FsX3vlG/KMWi/PrJZyjKfV5ytjte6KL8kRL+ekaFE=
+github.com/segmentio/parquet-go v0.0.0-20221205175245-39e02a5ed102/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/sercand/kuberesolver v2.4.0+incompatible h1:WE2OlRf6wjLxHwNkkFLQGaZcVLEXjMjBPjjEU5vksH8=
 github.com/sercand/kuberesolver v2.4.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=
 github.com/shirou/gopsutil/v3 v3.22.6 h1:FnHOFOh+cYAM0C30P+zysPISzlknLC5Z1G4EAElznfQ=

--- a/go.sum
+++ b/go.sum
@@ -899,8 +899,6 @@ github.com/segmentio/encoding v0.3.5 h1:UZEiaZ55nlXGDL92scoVuw00RmiRCazIEmvPSbSv
 github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
 github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e h1:uO75wNGioszjmIzcY/tvdDYKRLVvzggtAmmJkn9j4GQ=
 github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e/go.mod h1:tm/wZFQ8e24NYaBGIlnO2WGCAi67re4HHuOm0sftE/M=
-github.com/segmentio/parquet-go v0.0.0-20221103170249-ef6062d06d9f h1:qqBLtgUF0WfUCxFuFey1ko665UfvjyFTJ/UIfJXKiao=
-github.com/segmentio/parquet-go v0.0.0-20221103170249-ef6062d06d9f/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/segmentio/parquet-go v0.0.0-20221205175245-39e02a5ed102 h1:l8FsX3vlG/KMWi/PrJZyjKfV5ytjte6KL8kRL+ekaFE=
 github.com/segmentio/parquet-go v0.0.0-20221205175245-39e02a5ed102/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/sercand/kuberesolver v2.4.0+incompatible h1:WE2OlRf6wjLxHwNkkFLQGaZcVLEXjMjBPjjEU5vksH8=

--- a/vendor/github.com/segmentio/parquet-go/README.md
+++ b/vendor/github.com/segmentio/parquet-go/README.md
@@ -1,4 +1,4 @@
-# segmentio/parquet-go [![build status](https://github.com/segmentio/parquet-go/actions/workflows/test.yml/badge.svg)](https://github.com/segmentio/parquet-go/actions) [![Go Report Card](https://goreportcard.com/badge/github.com/segmentio/parquet-go)](https://goreportcard.com/report/github.com/segmentio/parquet-go) [![Go Reference](https://pkg.go.dev/badge/github.com/segmentio/parquet-go.svg)](https://pkg.go.dev/github.com/segmentio/parquet-go)
+# segmentio/parquet-go [![build status](https://github.com/segmentio/parquet-go/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/segmentio/parquet-go/actions) [![Go Report Card](https://goreportcard.com/badge/github.com/segmentio/parquet-go)](https://goreportcard.com/report/github.com/segmentio/parquet-go) [![Go Reference](https://pkg.go.dev/badge/github.com/segmentio/parquet-go.svg)](https://pkg.go.dev/github.com/segmentio/parquet-go)
 
 High-performance Go library to manipulate parquet files.
 

--- a/vendor/github.com/segmentio/parquet-go/bloom.go
+++ b/vendor/github.com/segmentio/parquet-go/bloom.go
@@ -44,15 +44,13 @@ func (f *bloomFilter) Check(v Value) (bool, error) {
 func (v Value) hash(h bloom.Hash) uint64 {
 	switch v.Kind() {
 	case Boolean:
-		return h.Sum64Uint8(uint8(v.u64))
+		return h.Sum64Uint8(v.byte())
 	case Int32, Float:
-		return h.Sum64Uint32(uint32(v.u64))
+		return h.Sum64Uint32(v.uint32())
 	case Int64, Double:
-		return h.Sum64Uint64(v.u64)
-	case Int96:
-		return h.Sum64(v.Bytes())
-	default:
-		return h.Sum64(v.ByteArray())
+		return h.Sum64Uint64(v.uint64())
+	default: // Int96, ByteArray, FixedLenByteArray, or null
+		return h.Sum64(v.byteArray())
 	}
 }
 

--- a/vendor/github.com/segmentio/parquet-go/bloom/filter.go
+++ b/vendor/github.com/segmentio/parquet-go/bloom/filter.go
@@ -12,16 +12,6 @@ type Filter interface {
 	Check(uint64) bool
 }
 
-// MutableFilter is an extension of the Filter interface which supports
-// inserting keys to the filter.
-type MutableFilter interface {
-	Filter
-	Reset()
-	Insert(uint64)
-	InsertBulk([]uint64)
-	Bytes() []byte
-}
-
 // SplitBlockFilter is an in-memory implementation of the parquet bloom filters.
 //
 // This type is useful to construct bloom filters that are later serialized
@@ -90,8 +80,6 @@ func CheckSplitBlock(r io.ReaderAt, n int64, x uint64) (bool, error) {
 }
 
 var (
-	_ MutableFilter = (SplitBlockFilter)(nil)
-
 	blockPool sync.Pool
 )
 

--- a/vendor/github.com/segmentio/parquet-go/buffer.go
+++ b/vendor/github.com/segmentio/parquet-go/buffer.go
@@ -256,7 +256,7 @@ func (buf *Buffer) WriteRowGroup(rowGroup RowGroup) (int64, error) {
 //
 // The buffer and the returned reader share memory. Mutating the buffer
 // concurrently to reading rows may result in non-deterministic behavior.
-func (buf *Buffer) Rows() Rows { return &rowGroupRows{rowGroup: buf} }
+func (buf *Buffer) Rows() Rows { return newRowGroupRows(buf, ReadModeSync) }
 
 // bufferWriter is an adapter for Buffer which implements both RowWriter and
 // PageWriter to enable optimizations in CopyRows for types that support writing

--- a/vendor/github.com/segmentio/parquet-go/column_buffer.go
+++ b/vendor/github.com/segmentio/parquet-go/column_buffer.go
@@ -1602,7 +1602,7 @@ func (col *fixedLenByteArrayColumnBuffer) WriteFixedLenByteArrays(values []byte)
 
 func (col *fixedLenByteArrayColumnBuffer) WriteValues(values []Value) (int, error) {
 	for _, v := range values {
-		col.data = append(col.data, v.ByteArray()...)
+		col.data = append(col.data, v.byteArray()...)
 	}
 	return len(values), nil
 }
@@ -1893,7 +1893,7 @@ func (col *be128ColumnBuffer) WriteValues(values []Value) (int, error) {
 	col.values = col.values[:n+len(values)]
 	newValues := col.values[n:]
 	for i, v := range values {
-		copy(newValues[i][:], v.ByteArray())
+		copy(newValues[i][:], v.byteArray())
 	}
 	return len(values), nil
 }

--- a/vendor/github.com/segmentio/parquet-go/column_index.go
+++ b/vendor/github.com/segmentio/parquet-go/column_index.go
@@ -315,8 +315,8 @@ func (i *booleanColumnIndexer) Reset() {
 
 func (i *booleanColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value) {
 	i.observe(numValues, numNulls)
-	i.minValues = append(i.minValues, min.Boolean())
-	i.maxValues = append(i.maxValues, max.Boolean())
+	i.minValues = append(i.minValues, min.boolean())
+	i.maxValues = append(i.maxValues, max.boolean())
 }
 
 func (i *booleanColumnIndexer) ColumnIndex() format.ColumnIndex {
@@ -346,8 +346,8 @@ func (i *int32ColumnIndexer) Reset() {
 
 func (i *int32ColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value) {
 	i.observe(numValues, numNulls)
-	i.minValues = append(i.minValues, min.Int32())
-	i.maxValues = append(i.maxValues, max.Int32())
+	i.minValues = append(i.minValues, min.int32())
+	i.maxValues = append(i.maxValues, max.int32())
 }
 
 func (i *int32ColumnIndexer) ColumnIndex() format.ColumnIndex {
@@ -377,8 +377,8 @@ func (i *int64ColumnIndexer) Reset() {
 
 func (i *int64ColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value) {
 	i.observe(numValues, numNulls)
-	i.minValues = append(i.minValues, min.Int64())
-	i.maxValues = append(i.maxValues, max.Int64())
+	i.minValues = append(i.minValues, min.int64())
+	i.maxValues = append(i.maxValues, max.int64())
 }
 
 func (i *int64ColumnIndexer) ColumnIndex() format.ColumnIndex {
@@ -439,8 +439,8 @@ func (i *floatColumnIndexer) Reset() {
 
 func (i *floatColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value) {
 	i.observe(numValues, numNulls)
-	i.minValues = append(i.minValues, min.Float())
-	i.maxValues = append(i.maxValues, max.Float())
+	i.minValues = append(i.minValues, min.float())
+	i.maxValues = append(i.maxValues, max.float())
 }
 
 func (i *floatColumnIndexer) ColumnIndex() format.ColumnIndex {
@@ -470,8 +470,8 @@ func (i *doubleColumnIndexer) Reset() {
 
 func (i *doubleColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value) {
 	i.observe(numValues, numNulls)
-	i.minValues = append(i.minValues, min.Double())
-	i.maxValues = append(i.maxValues, max.Double())
+	i.minValues = append(i.minValues, min.double())
+	i.maxValues = append(i.maxValues, max.double())
 }
 
 func (i *doubleColumnIndexer) ColumnIndex() format.ColumnIndex {
@@ -502,8 +502,8 @@ func (i *byteArrayColumnIndexer) Reset() {
 
 func (i *byteArrayColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value) {
 	i.observe(numValues, numNulls)
-	minValue := min.ByteArray()
-	maxValue := max.ByteArray()
+	minValue := min.byteArray()
+	maxValue := max.byteArray()
 	if i.sizeLimit > 0 {
 		minValue = truncateLargeMinByteArrayValue(minValue, i.sizeLimit)
 		maxValue = truncateLargeMaxByteArrayValue(maxValue, i.sizeLimit)
@@ -546,8 +546,8 @@ func (i *fixedLenByteArrayColumnIndexer) Reset() {
 
 func (i *fixedLenByteArrayColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value) {
 	i.observe(numValues, numNulls)
-	i.minValues = append(i.minValues, min.ByteArray()...)
-	i.maxValues = append(i.maxValues, max.ByteArray()...)
+	i.minValues = append(i.minValues, min.byteArray()...)
+	i.maxValues = append(i.maxValues, max.byteArray()...)
 }
 
 func (i *fixedLenByteArrayColumnIndexer) ColumnIndex() format.ColumnIndex {
@@ -587,8 +587,8 @@ func (i *uint32ColumnIndexer) Reset() {
 
 func (i *uint32ColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value) {
 	i.observe(numValues, numNulls)
-	i.minValues = append(i.minValues, min.Uint32())
-	i.maxValues = append(i.maxValues, max.Uint32())
+	i.minValues = append(i.minValues, min.uint32())
+	i.maxValues = append(i.maxValues, max.uint32())
 }
 
 func (i *uint32ColumnIndexer) ColumnIndex() format.ColumnIndex {
@@ -618,8 +618,8 @@ func (i *uint64ColumnIndexer) Reset() {
 
 func (i *uint64ColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value) {
 	i.observe(numValues, numNulls)
-	i.minValues = append(i.minValues, min.Uint64())
-	i.maxValues = append(i.maxValues, max.Uint64())
+	i.minValues = append(i.minValues, min.uint64())
+	i.maxValues = append(i.maxValues, max.uint64())
 }
 
 func (i *uint64ColumnIndexer) ColumnIndex() format.ColumnIndex {
@@ -650,10 +650,10 @@ func (i *be128ColumnIndexer) Reset() {
 func (i *be128ColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value) {
 	i.observe(numValues, numNulls)
 	if !min.IsNull() {
-		i.minValues = append(i.minValues, *(*[16]byte)(min.ByteArray()))
+		i.minValues = append(i.minValues, *(*[16]byte)(min.byteArray()))
 	}
 	if !max.IsNull() {
-		i.maxValues = append(i.maxValues, *(*[16]byte)(max.ByteArray()))
+		i.maxValues = append(i.maxValues, *(*[16]byte)(max.byteArray()))
 	}
 }
 

--- a/vendor/github.com/segmentio/parquet-go/compare.go
+++ b/vendor/github.com/segmentio/parquet-go/compare.go
@@ -6,6 +6,54 @@ import (
 	"github.com/segmentio/parquet-go/deprecated"
 )
 
+// CompareDescending constructs a comparison function which inverses the order
+// of values.
+//
+//go:noinline
+func CompareDescending(cmp func(Value, Value) int) func(Value, Value) int {
+	return func(a, b Value) int { return -cmp(a, b) }
+}
+
+// CompareNullsFirst constructs a comparison function which assumes that null
+// values are smaller than all other values.
+//
+//go:noinline
+func CompareNullsFirst(cmp func(Value, Value) int) func(Value, Value) int {
+	return func(a, b Value) int {
+		switch {
+		case a.IsNull():
+			if b.IsNull() {
+				return 0
+			}
+			return -1
+		case b.IsNull():
+			return +1
+		default:
+			return cmp(a, b)
+		}
+	}
+}
+
+// CompareNullsLast constructs a comparison function which assumes that null
+// values are greater than all other values.
+//
+//go:noinline
+func CompareNullsLast(cmp func(Value, Value) int) func(Value, Value) int {
+	return func(a, b Value) int {
+		switch {
+		case a.IsNull():
+			if b.IsNull() {
+				return 0
+			}
+			return +1
+		case b.IsNull():
+			return -1
+		default:
+			return cmp(a, b)
+		}
+	}
+}
+
 func compareBool(v1, v2 bool) int {
 	switch {
 	case !v1 && v2:
@@ -127,4 +175,136 @@ func lessBE128(v1, v2 *[16]byte) bool {
 	x = binary.BigEndian.Uint64(v1[8:])
 	y = binary.BigEndian.Uint64(v2[8:])
 	return x < y
+}
+
+func compareRowsFuncOf(schema *Schema, sortingColumns []SortingColumn) func(Row, Row) int {
+	compareFuncs := make([]func(Row, Row) int, 0, len(sortingColumns))
+	direct := true
+
+	for _, column := range schema.Columns() {
+		leaf, _ := schema.Lookup(column...)
+		if leaf.MaxRepetitionLevel > 0 {
+			direct = false
+		}
+
+		for _, sortingColumn := range sortingColumns {
+			path1 := columnPath(column)
+			path2 := columnPath(sortingColumn.Path())
+
+			if path1.equal(path2) {
+				descending := sortingColumn.Descending()
+				optional := leaf.MaxDefinitionLevel > 0
+				sortFunc := (func(Row, Row) int)(nil)
+
+				if direct && !optional {
+					// This is an optimization for the common case where rows
+					// are sorted by non-optional, non-repeated columns.
+					//
+					// The sort function can make the assumption that it will
+					// find the column value at the current column index, and
+					// does not need to scan the rows looking for values with
+					// a matching column index.
+					//
+					// A second optimization consists in passing the column type
+					// directly to the sort function instead of an intermediary
+					// closure, which removes an indirection layer and improves
+					// throughput by ~20% in BenchmarkSortRowBuffer.
+					typ := leaf.Node.Type()
+					if descending {
+						sortFunc = compareRowsFuncOfIndexDescending(leaf.ColumnIndex, typ)
+					} else {
+						sortFunc = compareRowsFuncOfIndexAscending(leaf.ColumnIndex, typ)
+					}
+				} else {
+					compare := leaf.Node.Type().Compare
+
+					if descending {
+						compare = CompareDescending(compare)
+					}
+
+					if optional {
+						if sortingColumn.NullsFirst() {
+							compare = CompareNullsFirst(compare)
+						} else {
+							compare = CompareNullsLast(compare)
+						}
+					}
+
+					sortFunc = compareRowsFuncOfScan(leaf.ColumnIndex, compare)
+				}
+
+				compareFuncs = append(compareFuncs, sortFunc)
+			}
+		}
+	}
+
+	// For the common case where rows are sorted by a single column, we can skip
+	// looping over the list of sort functions.
+	switch len(compareFuncs) {
+	case 0:
+		return compareRowsUnordered
+	case 1:
+		return compareFuncs[0]
+	default:
+		return compareRowsFuncOfColumns(compareFuncs)
+	}
+}
+
+func compareRowsUnordered(Row, Row) int { return 0 }
+
+//go:noinline
+func compareRowsFuncOfColumns(compareFuncs []func(Row, Row) int) func(Row, Row) int {
+	return func(row1, row2 Row) int {
+		for _, compare := range compareFuncs {
+			if cmp := compare(row1, row2); cmp != 0 {
+				return cmp
+			}
+		}
+		return 0
+	}
+}
+
+//go:noinline
+func compareRowsFuncOfIndexAscending(columnIndex int, typ Type) func(Row, Row) int {
+	return func(row1, row2 Row) int { return typ.Compare(row1[columnIndex], row2[columnIndex]) }
+}
+
+//go:noinline
+func compareRowsFuncOfIndexDescending(columnIndex int, typ Type) func(Row, Row) int {
+	return func(row1, row2 Row) int { return -typ.Compare(row1[columnIndex], row2[columnIndex]) }
+}
+
+//go:noinline
+func compareRowsFuncOfScan(columnIndex int, compare func(Value, Value) int) func(Row, Row) int {
+	columnIndexOfValues := ^int16(columnIndex)
+	return func(row1, row2 Row) int {
+		i1 := 0
+		i2 := 0
+
+		for {
+			for i1 < len(row1) && row1[i1].columnIndex != columnIndexOfValues {
+				i1++
+			}
+
+			for i2 < len(row2) && row2[i2].columnIndex != columnIndexOfValues {
+				i2++
+			}
+
+			end1 := i1 == len(row1)
+			end2 := i2 == len(row2)
+
+			if end1 && end2 {
+				return 0
+			} else if end1 {
+				return -1
+			} else if end2 {
+				return +1
+			} else if cmp := compare(row1[i1], row2[i2]); cmp != 0 {
+				return cmp
+			}
+
+			i1++
+			i2++
+		}
+	}
 }

--- a/vendor/github.com/segmentio/parquet-go/format/parquet.go
+++ b/vendor/github.com/segmentio/parquet-go/format/parquet.go
@@ -134,7 +134,8 @@ type DecimalType struct {
 }
 
 func (t *DecimalType) String() string {
-	return fmt.Sprintf("DECIMAL(%d,%d)", t.Scale, t.Precision)
+	// Matching parquet-cli's decimal string format: https://github.com/apache/parquet-mr/blob/d057b39d93014fe40f5067ee4a33621e65c91552/parquet-column/src/test/java/org/apache/parquet/parser/TestParquetParser.java#L249-L265
+	return fmt.Sprintf("DECIMAL(%d,%d)", t.Precision, t.Scale)
 }
 
 // Time units for logical types.

--- a/vendor/github.com/segmentio/parquet-go/internal/unsafecast/unsafecast_go17.go
+++ b/vendor/github.com/segmentio/parquet-go/internal/unsafecast/unsafecast_go17.go
@@ -134,3 +134,7 @@ func BytesToFloat64(data []byte) []float64 {
 func BytesToString(data []byte) string {
 	return *(*string)(unsafe.Pointer(&data))
 }
+
+func Bytes(data *byte, size int) []byte {
+	return unsafe.Slice(data, size)
+}

--- a/vendor/github.com/segmentio/parquet-go/internal/unsafecast/unsafecast_go18.go
+++ b/vendor/github.com/segmentio/parquet-go/internal/unsafecast/unsafecast_go18.go
@@ -81,6 +81,16 @@ func Slice[To, From any](data []From) []To {
 	return *(*[]To)(unsafe.Pointer(s))
 }
 
+// Bytes constructs a byte slice. The pointer to the first element of the slice
+// is set to data, the length and capacity are set to size.
+func Bytes(data *byte, size int) []byte {
+	return *(*[]byte)(unsafe.Pointer(&slice{
+		ptr: unsafe.Pointer(data),
+		len: size,
+		cap: size,
+	}))
+}
+
 // BytesToString converts a byte slice to a string value. The returned string
 // shares the backing array of the byte slice.
 //

--- a/vendor/github.com/segmentio/parquet-go/node.go
+++ b/vendor/github.com/segmentio/parquet-go/node.go
@@ -447,7 +447,9 @@ func nodesAreEqual(node1, node2 Node) bool {
 }
 
 func typesAreEqual(node1, node2 Node) bool {
-	return node1.Type().Kind() == node2.Type().Kind()
+	return node1.Type().Kind() == node2.Type().Kind() &&
+		node1.Type().Length() == node2.Type().Length() &&
+		reflect.DeepEqual(node1.Type().LogicalType(), node2.Type().LogicalType())
 }
 
 func repetitionsAreEqual(node1, node2 Node) bool {

--- a/vendor/github.com/segmentio/parquet-go/page.go
+++ b/vendor/github.com/segmentio/parquet-go/page.go
@@ -238,11 +238,6 @@ func readPages(pages Pages, read chan<- asyncPage, seek <-chan int64, done <-cha
 	}
 }
 
-func copyPagesAndClose(w PageWriter, r Pages) (int64, error) {
-	defer r.Close()
-	return CopyPages(w, r)
-}
-
 type singlePage struct {
 	page    Page
 	seek    int64
@@ -299,34 +294,6 @@ func CopyPages(dst PageWriter, src PageReader) (numValues int64, err error) {
 			return numValues, err
 		}
 	}
-}
-
-func forEachPageSlice(page Page, wantSize int64, do func(Page) error) error {
-	numRows := page.NumRows()
-	if numRows == 0 {
-		return nil
-	}
-
-	pageSize := page.Size()
-	numPages := (pageSize + (wantSize - 1)) / wantSize
-	rowIndex := int64(0)
-	if numPages < 2 {
-		return do(page)
-	}
-
-	for numPages > 0 {
-		lastRowIndex := rowIndex + ((numRows - rowIndex) / numPages)
-		pageSlice := page.Slice(rowIndex, lastRowIndex)
-		err := do(pageSlice)
-		Release(pageSlice)
-		if err != nil {
-			return err
-		}
-		rowIndex = lastRowIndex
-		numPages--
-	}
-
-	return nil
 }
 
 // errorPage is an implementation of the Page interface which always errors when

--- a/vendor/github.com/segmentio/parquet-go/row_group.go
+++ b/vendor/github.com/segmentio/parquet-go/row_group.go
@@ -245,20 +245,21 @@ func (r *rowGroup) NumRows() int64                  { return r.numRows }
 func (r *rowGroup) ColumnChunks() []ColumnChunk     { return r.columns }
 func (r *rowGroup) SortingColumns() []SortingColumn { return r.sorting }
 func (r *rowGroup) Schema() *Schema                 { return r.schema }
-func (r *rowGroup) Rows() Rows                      { return &rowGroupRows{rowGroup: r} }
+func (r *rowGroup) Rows() Rows                      { return newRowGroupRows(r, ReadModeSync) }
 
 func NewRowGroupRowReader(rowGroup RowGroup) Rows {
-	return &rowGroupRows{rowGroup: rowGroup}
+	return newRowGroupRows(rowGroup, ReadModeSync)
 }
 
 type rowGroupRows struct {
-	rowGroup RowGroup
-	buffers  []Value
-	readers  []asyncPages
-	columns  []columnChunkRows
-	inited   bool
-	closed   bool
-	done     chan<- struct{}
+	rowGroup     RowGroup
+	buffers      []Value
+	readers      []Pages
+	columns      []columnChunkRows
+	inited       bool
+	closed       bool
+	done         chan<- struct{}
+	pageReadMode ReadMode
 }
 
 type columnChunkRows struct {
@@ -277,18 +278,35 @@ func (r *rowGroupRows) buffer(i int) []Value {
 	return r.buffers[j:k:k]
 }
 
+func newRowGroupRows(rowGroup RowGroup, pageReadMode ReadMode) *rowGroupRows {
+	return &rowGroupRows{
+		rowGroup:     rowGroup,
+		pageReadMode: pageReadMode,
+	}
+}
+
 func (r *rowGroupRows) init() {
 	columns := r.rowGroup.ColumnChunks()
 
 	r.buffers = make([]Value, len(columns)*columnBufferSize)
-	r.readers = make([]asyncPages, len(columns))
+	r.readers = make([]Pages, len(columns))
 	r.columns = make([]columnChunkRows, len(columns))
 
-	done := make(chan struct{})
-	r.done = done
-
-	for i, column := range columns {
-		r.readers[i].init(column.Pages(), done)
+	switch r.pageReadMode {
+	case ReadModeAsync:
+		done := make(chan struct{})
+		r.done = done
+		readers := make([]asyncPages, len(columns))
+		for i, column := range columns {
+			readers[i].init(column.Pages(), done)
+			r.readers[i] = &readers[i]
+		}
+	case ReadModeSync:
+		for i, column := range columns {
+			r.readers[i] = column.Pages()
+		}
+	default:
+		panic(fmt.Sprintf("parquet: invalid page read mode: %d", r.pageReadMode))
 	}
 
 	r.inited = true

--- a/vendor/github.com/segmentio/parquet-go/search.go
+++ b/vendor/github.com/segmentio/parquet-go/search.go
@@ -1,41 +1,5 @@
 package parquet
 
-// CompareNullsFirst constructs a comparison function which assumes that null
-// values are smaller than all other values.
-func CompareNullsFirst(cmp func(Value, Value) int) func(Value, Value) int {
-	return func(a, b Value) int {
-		switch {
-		case a.IsNull():
-			if b.IsNull() {
-				return 0
-			}
-			return -1
-		case b.IsNull():
-			return +1
-		default:
-			return cmp(a, b)
-		}
-	}
-}
-
-// CompareNullsLast constructs a comparison function which assumes that null
-// values are greater than all other values.
-func CompareNullsLast(cmp func(Value, Value) int) func(Value, Value) int {
-	return func(a, b Value) int {
-		switch {
-		case a.IsNull():
-			if b.IsNull() {
-				return 0
-			}
-			return +1
-		case b.IsNull():
-			return -1
-		default:
-			return cmp(a, b)
-		}
-	}
-}
-
 // Search is like Find, but uses the default ordering of the given type. Search
 // and Find are scoped to a given ColumnChunk and find the pages within a
 // ColumnChunk which might contain the result.  See Find for more details.

--- a/vendor/github.com/segmentio/parquet-go/sparse/array.go
+++ b/vendor/github.com/segmentio/parquet-go/sparse/array.go
@@ -1,6 +1,9 @@
 package sparse
 
-import "unsafe"
+import (
+	"time"
+	"unsafe"
+)
 
 type Array struct{ array }
 
@@ -25,6 +28,7 @@ func (a Array) Uint32Array() Uint32Array   { return Uint32Array{a.array} }
 func (a Array) Uint64Array() Uint64Array   { return Uint64Array{a.array} }
 func (a Array) Uint128Array() Uint128Array { return Uint128Array{a.array} }
 func (a Array) StringArray() StringArray   { return StringArray{a.array} }
+func (a Array) TimeArray() TimeArray       { return TimeArray{a.array} }
 
 type array struct {
 	ptr unsafe.Pointer
@@ -290,3 +294,19 @@ func (a StringArray) Len() int                   { return int(a.len) }
 func (a StringArray) Index(i int) string         { return *(*string)(a.index(i)) }
 func (a StringArray) Slice(i, j int) StringArray { return StringArray{a.slice(i, j)} }
 func (a StringArray) UnsafeArray() Array         { return Array{a.array} }
+
+type TimeArray struct{ array }
+
+func MakeTimeArray(values []time.Time) TimeArray {
+	const sizeOfTime = unsafe.Sizeof(time.Time{})
+	return TimeArray{makeArray(*(*unsafe.Pointer)(unsafe.Pointer(&values)), uintptr(len(values)), sizeOfTime)}
+}
+
+func UnsafeTimeArray(base unsafe.Pointer, length int, offset uintptr) TimeArray {
+	return TimeArray{makeArray(base, uintptr(length), offset)}
+}
+
+func (a TimeArray) Len() int                 { return int(a.len) }
+func (a TimeArray) Index(i int) time.Time    { return *(*time.Time)(a.index(i)) }
+func (a TimeArray) Slice(i, j int) TimeArray { return TimeArray{a.slice(i, j)} }
+func (a TimeArray) UnsafeArray() Array       { return Array{a.array} }

--- a/vendor/github.com/segmentio/parquet-go/value.go
+++ b/vendor/github.com/segmentio/parquet-go/value.go
@@ -8,10 +8,12 @@ import (
 	"math"
 	"reflect"
 	"strconv"
+	"time"
 	"unsafe"
 
 	"github.com/google/uuid"
 	"github.com/segmentio/parquet-go/deprecated"
+	"github.com/segmentio/parquet-go/format"
 	"github.com/segmentio/parquet-go/internal/unsafecast"
 )
 
@@ -158,6 +160,9 @@ func copyValues(dst ValueWriter, src ValueReader, buf []Value) (written int64, e
 //
 // The function panics if the Go value cannot be represented in parquet.
 func ValueOf(v interface{}) Value {
+	k := Kind(-1)
+	t := reflect.TypeOf(v)
+
 	switch value := v.(type) {
 	case nil:
 		return Value{}
@@ -165,10 +170,9 @@ func ValueOf(v interface{}) Value {
 		return makeValueBytes(FixedLenByteArray, value[:])
 	case deprecated.Int96:
 		return makeValueInt96(value)
+	case time.Time:
+		k = Int64
 	}
-
-	k := Kind(-1)
-	t := reflect.TypeOf(v)
 
 	switch t.Kind() {
 	case reflect.Bool:
@@ -197,10 +201,62 @@ func ValueOf(v interface{}) Value {
 		panic("cannot create parquet value from go value of type " + t.String())
 	}
 
-	return makeValue(k, reflect.ValueOf(v))
+	return makeValue(k, nil, reflect.ValueOf(v))
 }
 
-func makeValue(k Kind, v reflect.Value) Value {
+// BooleanValue constructs a BOOLEAN parquet value from the bool passed as
+// argument.
+func BooleanValue(value bool) Value { return makeValueBoolean(value) }
+
+// Int32Value constructs a INT32 parquet value from the int32 passed as
+// argument.
+func Int32Value(value int32) Value { return makeValueInt32(value) }
+
+// Int64Value constructs a INT64 parquet value from the int64 passed as
+// argument.
+func Int64Value(value int64) Value { return makeValueInt64(value) }
+
+// Int96Value constructs a INT96 parquet value from the deprecated.Int96 passed
+// as argument.
+func Int96Value(value deprecated.Int96) Value { return makeValueInt96(value) }
+
+// FloatValue constructs a FLOAT parquet value from the float32 passed as
+// argument.
+func FloatValue(value float32) Value { return makeValueFloat(value) }
+
+// DoubleValue constructs a DOUBLE parquet value from the float64 passed as
+// argument.
+func DoubleValue(value float64) Value { return makeValueDouble(value) }
+
+// ByteArrayValue constructs a BYTE_ARRAY parquet value from the byte slice
+// passed as argument.
+func ByteArrayValue(value []byte) Value { return makeValueBytes(ByteArray, value) }
+
+// FixedLenByteArrayValue constructs a BYTE_ARRAY parquet value from the byte
+// slice passed as argument.
+func FixedLenByteArrayValue(value []byte) Value { return makeValueBytes(FixedLenByteArray, value) }
+
+func makeValue(k Kind, lt *format.LogicalType, v reflect.Value) Value {
+	switch v.Type() {
+	case reflect.TypeOf(time.Time{}):
+		unit := Nanosecond.TimeUnit()
+		if lt != nil && lt.Timestamp != nil {
+			unit = lt.Timestamp.Unit
+		}
+
+		t := v.Interface().(time.Time)
+		var val int64
+		switch {
+		case unit.Millis != nil:
+			val = t.UnixMilli()
+		case unit.Micros != nil:
+			val = t.UnixMicro()
+		default:
+			val = t.UnixNano()
+		}
+		return makeValueInt64(val)
+	}
+
 	switch k {
 	case Boolean:
 		return makeValueBoolean(v.Bool())
@@ -364,52 +420,69 @@ func makeValueByteArray(kind Kind, data *byte, size int) Value {
 	}
 }
 
+// These methods are internal versions of methods exported by the Value type,
+// they are usually inlined by the compiler and intended to be used inside the
+// parquet-go package because they tend to generate better code than their
+// exported counter part, which requires making a copy of the receiver.
+func (v *Value) isNull() bool            { return v.kind == 0 }
+func (v *Value) byte() byte              { return byte(v.u64) }
+func (v *Value) boolean() bool           { return v.u64 != 0 }
+func (v *Value) int32() int32            { return int32(v.u64) }
+func (v *Value) int64() int64            { return int64(v.u64) }
+func (v *Value) int96() deprecated.Int96 { return makeInt96(v.byteArray()) }
+func (v *Value) float() float32          { return math.Float32frombits(uint32(v.u64)) }
+func (v *Value) double() float64         { return math.Float64frombits(uint64(v.u64)) }
+func (v *Value) uint32() uint32          { return uint32(v.u64) }
+func (v *Value) uint64() uint64          { return v.u64 }
+func (v *Value) byteArray() []byte       { return unsafecast.Bytes(v.ptr, int(v.u64)) }
+func (v *Value) be128() *[16]byte        { return (*[16]byte)(unsafe.Pointer(v.ptr)) }
+func (v *Value) column() int             { return int(^v.columnIndex) }
+
 // Kind returns the kind of v, which represents its parquet physical type.
 func (v Value) Kind() Kind { return ^Kind(v.kind) }
 
 // IsNull returns true if v is the null value.
-func (v Value) IsNull() bool { return v.kind == 0 }
+func (v Value) IsNull() bool { return v.isNull() }
 
 // Byte returns v as a byte, which may truncate the underlying byte.
-func (v Value) Byte() byte { return byte(v.u64) }
+func (v Value) Byte() byte { return v.byte() }
 
 // Boolean returns v as a bool, assuming the underlying type is BOOLEAN.
-func (v Value) Boolean() bool { return v.u64 != 0 }
+func (v Value) Boolean() bool { return v.boolean() }
 
 // Int32 returns v as a int32, assuming the underlying type is INT32.
-func (v Value) Int32() int32 { return int32(v.u64) }
+func (v Value) Int32() int32 { return v.int32() }
 
 // Int64 returns v as a int64, assuming the underlying type is INT64.
-func (v Value) Int64() int64 { return int64(v.u64) }
+func (v Value) Int64() int64 { return v.int64() }
 
 // Int96 returns v as a int96, assuming the underlying type is INT96.
 func (v Value) Int96() deprecated.Int96 {
 	var val deprecated.Int96
-	if !v.IsNull() {
-		val = makeInt96(v.ByteArray())
+	if !v.isNull() {
+		val = v.int96()
 	}
-
 	return val
 }
 
 // Float returns v as a float32, assuming the underlying type is FLOAT.
-func (v Value) Float() float32 { return math.Float32frombits(uint32(v.u64)) }
+func (v Value) Float() float32 { return v.float() }
 
 // Double returns v as a float64, assuming the underlying type is DOUBLE.
-func (v Value) Double() float64 { return math.Float64frombits(v.u64) }
+func (v Value) Double() float64 { return v.double() }
 
 // Uint32 returns v as a uint32, assuming the underlying type is INT32.
-func (v Value) Uint32() uint32 { return uint32(v.u64) }
+func (v Value) Uint32() uint32 { return v.uint32() }
 
 // Uint64 returns v as a uint64, assuming the underlying type is INT64.
-func (v Value) Uint64() uint64 { return v.u64 }
+func (v Value) Uint64() uint64 { return v.uint64() }
 
 // ByteArray returns v as a []byte, assuming the underlying type is either
 // BYTE_ARRAY or FIXED_LEN_BYTE_ARRAY.
 //
 // The application must treat the returned byte slice as a read-only value,
 // mutating the content will result in undefined behaviors.
-func (v Value) ByteArray() []byte { return unsafe.Slice(v.ptr, int(v.u64)) }
+func (v Value) ByteArray() []byte { return v.byteArray() }
 
 // RepetitionLevel returns the repetition level of v.
 func (v Value) RepetitionLevel() int { return int(v.repetitionLevel) }
@@ -420,7 +493,7 @@ func (v Value) DefinitionLevel() int { return int(v.definitionLevel) }
 // Column returns the column index within the row that v was created from.
 //
 // Returns -1 if the value does not carry a column index.
-func (v Value) Column() int { return int(^v.columnIndex) }
+func (v Value) Column() int { return v.column() }
 
 // Bytes returns the binary representation of v.
 //
@@ -434,16 +507,16 @@ func (v Value) AppendBytes(b []byte) []byte {
 	buf := [8]byte{}
 	switch v.Kind() {
 	case Boolean:
-		binary.LittleEndian.PutUint32(buf[:4], uint32(v.u64))
+		binary.LittleEndian.PutUint32(buf[:4], v.uint32())
 		return append(b, buf[0])
 	case Int32, Float:
-		binary.LittleEndian.PutUint32(buf[:4], uint32(v.u64))
+		binary.LittleEndian.PutUint32(buf[:4], v.uint32())
 		return append(b, buf[:4]...)
 	case Int64, Double:
-		binary.LittleEndian.PutUint64(buf[:8], v.u64)
+		binary.LittleEndian.PutUint64(buf[:8], v.uint64())
 		return append(b, buf[:8]...)
 	case ByteArray, FixedLenByteArray, Int96:
-		return append(b, v.ByteArray()...)
+		return append(b, v.byteArray()...)
 	default:
 		return b
 	}
@@ -475,19 +548,19 @@ func (v Value) Format(w fmt.State, r rune) {
 		if w.Flag('+') {
 			io.WriteString(w, "C:")
 		}
-		fmt.Fprint(w, v.Column())
+		fmt.Fprint(w, v.column())
 
 	case 'd':
 		if w.Flag('+') {
 			io.WriteString(w, "D:")
 		}
-		fmt.Fprint(w, v.DefinitionLevel())
+		fmt.Fprint(w, v.definitionLevel)
 
 	case 'r':
 		if w.Flag('+') {
 			io.WriteString(w, "R:")
 		}
-		fmt.Fprint(w, v.RepetitionLevel())
+		fmt.Fprint(w, v.repetitionLevel)
 
 	case 'q':
 		if w.Flag('+') {
@@ -495,7 +568,7 @@ func (v Value) Format(w fmt.State, r rune) {
 		}
 		switch v.Kind() {
 		case ByteArray, FixedLenByteArray:
-			fmt.Fprintf(w, "%q", v.ByteArray())
+			fmt.Fprintf(w, "%q", v.byteArray())
 		default:
 			fmt.Fprintf(w, `"%s"`, v)
 		}
@@ -506,19 +579,19 @@ func (v Value) Format(w fmt.State, r rune) {
 		}
 		switch v.Kind() {
 		case Boolean:
-			fmt.Fprint(w, v.Boolean())
+			fmt.Fprint(w, v.boolean())
 		case Int32:
-			fmt.Fprint(w, v.Int32())
+			fmt.Fprint(w, v.int32())
 		case Int64:
-			fmt.Fprint(w, v.Int64())
+			fmt.Fprint(w, v.int64())
 		case Int96:
-			fmt.Fprint(w, v.Int96())
+			fmt.Fprint(w, v.int96())
 		case Float:
-			fmt.Fprint(w, v.Float())
+			fmt.Fprint(w, v.float())
 		case Double:
-			fmt.Fprint(w, v.Double())
+			fmt.Fprint(w, v.double())
 		case ByteArray, FixedLenByteArray:
-			w.Write(v.ByteArray())
+			w.Write(v.byteArray())
 		default:
 			io.WriteString(w, "<null>")
 		}
@@ -539,33 +612,31 @@ func (v Value) Format(w fmt.State, r rune) {
 func (v Value) String() string {
 	switch v.Kind() {
 	case Boolean:
-		return strconv.FormatBool(v.Boolean())
+		return strconv.FormatBool(v.boolean())
 	case Int32:
-		return strconv.FormatInt(int64(v.Int32()), 10)
+		return strconv.FormatInt(int64(v.int32()), 10)
 	case Int64:
-		return strconv.FormatInt(v.Int64(), 10)
+		return strconv.FormatInt(v.int64(), 10)
 	case Int96:
 		return v.Int96().String()
 	case Float:
-		return strconv.FormatFloat(float64(v.Float()), 'g', -1, 32)
+		return strconv.FormatFloat(float64(v.float()), 'g', -1, 32)
 	case Double:
-		return strconv.FormatFloat(v.Double(), 'g', -1, 32)
+		return strconv.FormatFloat(v.double(), 'g', -1, 32)
 	case ByteArray, FixedLenByteArray:
 		// As an optimizations for the common case of using String on UTF8
 		// columns we convert the byte array to a string without copying the
 		// underlying data to a new memory location. This is safe as long as the
 		// application respects the requirement to not mutate the byte slices
 		// returned when calling ByteArray.
-		return unsafecast.BytesToString(v.ByteArray())
+		return unsafecast.BytesToString(v.byteArray())
 	default:
 		return "<null>"
 	}
 }
 
 // GoString returns a Go value string representation of v.
-func (v Value) GoString() string {
-	return fmt.Sprintf("%#v", v)
-}
+func (v Value) GoString() string { return fmt.Sprintf("%#v", v) }
 
 // Level returns v with the repetition level, definition level, and column index
 // set to the values passed as arguments.
@@ -582,8 +653,7 @@ func (v Value) Level(repetitionLevel, definitionLevel, columnIndex int) Value {
 func (v Value) Clone() Value {
 	switch k := v.Kind(); k {
 	case ByteArray, FixedLenByteArray:
-		b := copyBytes(v.ByteArray())
-		v.ptr = unsafecast.AddressOfBytes(b)
+		v.ptr = unsafecast.AddressOfBytes(copyBytes(v.byteArray()))
 	}
 	return v
 }
@@ -625,7 +695,7 @@ func parseValue(kind Kind, data []byte) (val Value, err error) {
 	case ByteArray, FixedLenByteArray:
 		val = makeValueBytes(kind, data)
 	}
-	if val.IsNull() {
+	if val.isNull() {
 		err = fmt.Errorf("cannot decode %s value from input of length %d", kind, len(data))
 	}
 	return val, err
@@ -649,21 +719,21 @@ func Equal(v1, v2 Value) bool {
 	if v1.kind != v2.kind {
 		return false
 	}
-	switch v1.Kind() {
+	switch ^Kind(v1.kind) {
 	case Boolean:
-		return v1.Boolean() == v2.Boolean()
+		return v1.boolean() == v2.boolean()
 	case Int32:
-		return v1.Int32() == v2.Int32()
+		return v1.int32() == v2.int32()
 	case Int64:
-		return v1.Int64() == v2.Int64()
+		return v1.int64() == v2.int64()
 	case Int96:
-		return v1.Int96() == v2.Int96()
+		return v1.int96() == v2.int96()
 	case Float:
-		return v1.Float() == v2.Float()
+		return v1.float() == v2.float()
 	case Double:
-		return v1.Double() == v2.Double()
+		return v1.double() == v2.double()
 	case ByteArray, FixedLenByteArray:
-		return bytes.Equal(v1.ByteArray(), v2.ByteArray())
+		return bytes.Equal(v1.byteArray(), v2.byteArray())
 	case -1: // null
 		return true
 	default:

--- a/vendor/github.com/segmentio/parquet-go/writer_go18.go
+++ b/vendor/github.com/segmentio/parquet-go/writer_go18.go
@@ -176,6 +176,19 @@ func (w *GenericWriter[T]) WriteRowGroup(rowGroup RowGroup) (int64, error) {
 	return w.base.WriteRowGroup(rowGroup)
 }
 
+// SetKeyValueMetadata sets a key/value pair in the Parquet file metadata.
+//
+// Keys are assumed to be unique, if the same key is repeated multiple times the
+// last value is retained. While the parquet format does not require unique keys,
+// this design decision was made to optimize for the most common use case where
+// applications leverage this extension mechanism to associate single values to
+// keys. This may create incompatibilities with other parquet libraries, or may
+// cause some key/value pairs to be lost when open parquet files written with
+// repeated keys. We can revisit this decision if it ever becomes a blocker.
+func (w *GenericWriter[T]) SetKeyValueMetadata(key, value string) {
+	w.base.SetKeyValueMetadata(key, value)
+}
+
 func (w *GenericWriter[T]) ReadRowsFrom(rows RowReader) (int64, error) {
 	return w.base.ReadRowsFrom(rows)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -899,7 +899,7 @@ github.com/segmentio/encoding/thrift
 # github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e
 ## explicit
 github.com/segmentio/fasthash/fnv1a
-# github.com/segmentio/parquet-go v0.0.0-20221103170249-ef6062d06d9f
+# github.com/segmentio/parquet-go v0.0.0-20221205175245-39e02a5ed102
 ## explicit; go 1.19
 github.com/segmentio/parquet-go
 github.com/segmentio/parquet-go/bloom


### PR DESCRIPTION
**What this PR does**:
Upgrades parquet-go to the latest which will default our parquet read mode to Synchronous from Async. This will likely have a mild positive impact on ingester/compactor memory usage.