### PR TITLE
add additional required permissions & auth-method

### DIFF
--- a/docs/tempo/website/configuration/gcs.md
+++ b/docs/tempo/website/configuration/gcs.md
@@ -10,6 +10,7 @@ For configuration options, check the storage section on the [configuration]({{< 
 ## Permissions
 The following authentication methods are supported:
 - GCP environment variable `GOOGLE_APPLICATION_CREDENTIALS`
+- GCP Workload Identity
 
 The `(service-)account` that will communicate towards GCS should be assigned to the bucket which will receive the traces and should have the following IAM polices within the bucket:
 
@@ -17,3 +18,4 @@ The `(service-)account` that will communicate towards GCS should be assigned to 
 - `storage.objects.delete`
 - `storage.objects.get`
 - `storage.buckets.get`
+- `storage.objects.list`


### PR DESCRIPTION
Add `storage.objects.list` as required policy
Mention Workload Identity as another valid authentication method

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
DOCS: Add missing required permissions for GCP Storage Bucket and mention possible use of GCP's Workload Identity as an alternative to `GOOGLE_APPLICATION_CREDENTIALS`

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`