### PR TITLE
Tweak traceql parsing to correctly parse binary operations without space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ Internal types are updated to use `scope` instead of `instrumentation_library`. 
 * [BUGFIX] tempo-mixin: tweak dashboards to support metrics without `cluster` label present [#1913](https://github.com/grafana/tempo/pull/1913) (@kvrhdn)
 * [ENHANCEMENT] New tenant dashboard [#1901](https://github.com/grafana/tempo/pull/1901) (@mapno)
 * [BUGFIX] Fix docker-compose examples not running on Apple M1 hardware [#1920](https://github.com/grafana/tempo/pull/1920) (@stoewer)
+* [BUGFIX] Fix traceql parsing of most binary operations to not require spacing [#1939](https://github.com/grafana/tempo/pull/1941) (@mdisibio)
 
 ## v1.5.0 / 2022-08-17
 

--- a/pkg/traceql/lexer.go
+++ b/pkg/traceql/lexer.go
@@ -224,12 +224,16 @@ func isDurationRune(r rune) bool {
 }
 
 func isAttributeRune(r rune) bool {
-	return !unicode.IsSpace(r) &&
-		r != scanner.EOF &&
-		r != '(' &&
-		r != ')' &&
-		r != '}' &&
-		r != '{'
+	if unicode.IsSpace(r) {
+		return false
+	}
+
+	switch r {
+	case scanner.EOF, '{', '}', '(', ')', '=', '~', '!', '<', '>', '&', '|', '^':
+		return false
+	default:
+		return true
+	}
 }
 
 func startsAttribute(tok int) bool {

--- a/pkg/traceql/lexer_test.go
+++ b/pkg/traceql/lexer_test.go
@@ -134,3 +134,9 @@ func testLexer(t *testing.T, tcs []lexerTestCase) {
 		})
 	}
 }
+
+func BenchmarkIsAttributeRune(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		isAttributeRune('=')
+	}
+}


### PR DESCRIPTION
**What this PR does**:
This PR changes parsing of most binary operations to work without spacing.  Example:  `{.foo="bar"}`.  Previously this wasn't handled as expected  and the entire `foo="bar"` was considered the attribute name.  This was done purposefully to accommodate searching on attribute names with syntaxy characters like `= ~ - +` etc, but the negative impact to every day usage isn't worth it.

Characters in the changed operations can no longer be included in an attribute name so querying on them is impossible.  Some operations are not changed because the likelihood of those characters in attribute names is enough to  weigh the decision the other way.

Fixed: `= != =~ != > >= < <= ^ && ||`
Unchanged: `+ - / % *`

**Overall**
Currently this isn't in a good spot because we are trading parsing flexibility for attribute name support. TraceQL needs some escape hatches to support the full range of [valid attribute names](https://opentelemetry.io/docs/reference/specification/common/attribute-naming/) which is any valid unicode sequence and could include things like newline, space, quotes, etc. There's no way to unambiguously fit this into the current language spec. 

**Which issue(s) this PR fixes**:
Fixes #1939 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`