### PR TITLE
Parquet WAL Improvements: Multitenant envs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ ALL_DOC := $(shell find . \( -name "*.md" -o -name "*.yaml" \) \
 ALL_PKGS := $(shell go list $(sort $(dir $(ALL_SRC))))
 
 GO_OPT= -mod vendor -ldflags "-X main.Branch=$(GIT_BRANCH) -X main.Revision=$(GIT_REVISION) -X main.Version=$(VERSION)"
-GOTEST_OPT?= -race -timeout 16m -count=1
+GOTEST_OPT?= -race -timeout 20m -count=1
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -cover
 GOTEST=go test
 LINT=golangci-lint

--- a/cmd/tempo-serverless/cloud-run/go.mod
+++ b/cmd/tempo-serverless/cloud-run/go.mod
@@ -99,7 +99,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rs/xid v1.2.1 // indirect
 	github.com/segmentio/encoding v0.3.5 // indirect
-	github.com/segmentio/parquet-go v0.0.0-20221209072905-710d87d50dd1 // indirect
+	github.com/segmentio/parquet-go v0.0.0-20221212205011-52de454c1d86 // indirect
 	github.com/sercand/kuberesolver v2.4.0+incompatible // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/sony/gobreaker v0.4.1 // indirect

--- a/cmd/tempo-serverless/cloud-run/go.sum
+++ b/cmd/tempo-serverless/cloud-run/go.sum
@@ -458,8 +458,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/encoding v0.3.5 h1:UZEiaZ55nlXGDL92scoVuw00RmiRCazIEmvPSbSvt8Y=
 github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
-github.com/segmentio/parquet-go v0.0.0-20221209072905-710d87d50dd1 h1:dSPoc3EY9Bj65BJNbv6vI1S/aXRuzXh+p6wIj2POIpE=
-github.com/segmentio/parquet-go v0.0.0-20221209072905-710d87d50dd1/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
+github.com/segmentio/parquet-go v0.0.0-20221212205011-52de454c1d86 h1:GmmJJXVsNenHHsKn6Ncu+rn1aNYS5DnIyc9+xJL5q3s=
+github.com/segmentio/parquet-go v0.0.0-20221212205011-52de454c1d86/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/sercand/kuberesolver v2.4.0+incompatible h1:WE2OlRf6wjLxHwNkkFLQGaZcVLEXjMjBPjjEU5vksH8=
 github.com/sercand/kuberesolver v2.4.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/cmd/tempo-serverless/lambda/go.mod
+++ b/cmd/tempo-serverless/lambda/go.mod
@@ -100,7 +100,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rs/xid v1.2.1 // indirect
 	github.com/segmentio/encoding v0.3.5 // indirect
-	github.com/segmentio/parquet-go v0.0.0-20221209072905-710d87d50dd1 // indirect
+	github.com/segmentio/parquet-go v0.0.0-20221212205011-52de454c1d86 // indirect
 	github.com/sercand/kuberesolver v2.4.0+incompatible // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/sony/gobreaker v0.4.1 // indirect

--- a/cmd/tempo-serverless/lambda/go.sum
+++ b/cmd/tempo-serverless/lambda/go.sum
@@ -463,8 +463,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/encoding v0.3.5 h1:UZEiaZ55nlXGDL92scoVuw00RmiRCazIEmvPSbSvt8Y=
 github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
-github.com/segmentio/parquet-go v0.0.0-20221209072905-710d87d50dd1 h1:dSPoc3EY9Bj65BJNbv6vI1S/aXRuzXh+p6wIj2POIpE=
-github.com/segmentio/parquet-go v0.0.0-20221209072905-710d87d50dd1/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
+github.com/segmentio/parquet-go v0.0.0-20221212205011-52de454c1d86 h1:GmmJJXVsNenHHsKn6Ncu+rn1aNYS5DnIyc9+xJL5q3s=
+github.com/segmentio/parquet-go v0.0.0-20221212205011-52de454c1d86/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/sercand/kuberesolver v2.4.0+incompatible h1:WE2OlRf6wjLxHwNkkFLQGaZcVLEXjMjBPjjEU5vksH8=
 github.com/sercand/kuberesolver v2.4.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/prometheus/prometheus v1.8.2-0.20221021121301-51a44e6657c3
 	github.com/prometheus/statsd_exporter v0.21.0 // indirect
 	github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e
-	github.com/segmentio/parquet-go v0.0.0-20221209072905-710d87d50dd1
+	github.com/segmentio/parquet-go v0.0.0-20221212205011-52de454c1d86
 	github.com/sirupsen/logrus v1.8.1
 	github.com/sony/gobreaker v0.4.1
 	github.com/spf13/viper v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -899,8 +899,8 @@ github.com/segmentio/encoding v0.3.5 h1:UZEiaZ55nlXGDL92scoVuw00RmiRCazIEmvPSbSv
 github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
 github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e h1:uO75wNGioszjmIzcY/tvdDYKRLVvzggtAmmJkn9j4GQ=
 github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e/go.mod h1:tm/wZFQ8e24NYaBGIlnO2WGCAi67re4HHuOm0sftE/M=
-github.com/segmentio/parquet-go v0.0.0-20221209072905-710d87d50dd1 h1:dSPoc3EY9Bj65BJNbv6vI1S/aXRuzXh+p6wIj2POIpE=
-github.com/segmentio/parquet-go v0.0.0-20221209072905-710d87d50dd1/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
+github.com/segmentio/parquet-go v0.0.0-20221212205011-52de454c1d86 h1:GmmJJXVsNenHHsKn6Ncu+rn1aNYS5DnIyc9+xJL5q3s=
+github.com/segmentio/parquet-go v0.0.0-20221212205011-52de454c1d86/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/sercand/kuberesolver v2.4.0+incompatible h1:WE2OlRf6wjLxHwNkkFLQGaZcVLEXjMjBPjjEU5vksH8=
 github.com/sercand/kuberesolver v2.4.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=
 github.com/shirou/gopsutil/v3 v3.22.6 h1:FnHOFOh+cYAM0C30P+zysPISzlknLC5Z1G4EAElznfQ=

--- a/pkg/parquetquery/predicates.go
+++ b/pkg/parquetquery/predicates.go
@@ -48,7 +48,6 @@ func (p *StringInPredicate) KeepColumnChunk(cc pq.ColumnChunk) bool {
 		}
 		return false
 	}
-
 	return true
 }
 
@@ -63,11 +62,14 @@ func (p *StringInPredicate) KeepValue(v pq.Value) bool {
 }
 
 func (p *StringInPredicate) KeepPage(page pq.Page) bool {
+	//
+
 	// todo: check bounds
 
 	// If a dictionary column then ensure at least one matching
 	// value exists in the dictionary
 	dict := page.Dictionary()
+
 	if dict != nil && dict.Len() > 0 {
 		len := dict.Len()
 

--- a/tempodb/encoding/vparquet/wal_block.go
+++ b/tempodb/encoding/vparquet/wal_block.go
@@ -691,7 +691,7 @@ func openLocalParquetFile(filename string) (*parquet.File, error) {
 		return nil, fmt.Errorf("error getting file info: %w", err)
 	}
 	sz := info.Size()
-	pf, err := parquet.OpenFile(file, sz, parquet.SkipBloomFilters(true), parquet.SkipPageIndex(true))
+	pf, err := parquet.OpenFile(file, sz, parquet.SkipBloomFilters(true), parquet.SkipPageIndex(true), parquet.FileSchema(walSchema))
 	if err != nil {
 		return nil, fmt.Errorf("error opening parquet file: %w", err)
 	}

--- a/tempodb/encoding/vparquet/wal_block.go
+++ b/tempodb/encoding/vparquet/wal_block.go
@@ -289,12 +289,13 @@ func (b *walBlock) openWriter() (err error) {
 
 	if b.writer == nil {
 		b.writer = parquet.NewGenericWriter[*Trace](b.file, &parquet.WriterConfig{
-			Schema: walSchema,
+			Schema:         walSchema,
+			PageBufferSize: 1024,
 		})
 		// ,parquet.WriteBufferSize(0) -> bufio.NewWriterSize - 32k default - 32k per file - minor memory savings - possible cpu improvement?
 		// ColumnPageBuffers -> allows for on disk buffer pool?
-		// ColumnIndexSizeLimit -> 256KB default
-		// PageBufferSize -> 16 default
+		// ColumnIndexSizeLimit -> 16 default
+		// PageBufferSize -> 256KB default
 		// Schema -> default nil - minor savings to create one and share between all writers
 		// BloomFilters -> ability to add custom bloom filters? ignore for now
 		// Compression -> default nil

--- a/tempodb/encoding/vparquet/wal_block.go
+++ b/tempodb/encoding/vparquet/wal_block.go
@@ -201,11 +201,11 @@ func newWalBlockFlush(path string, ids *common.IDMap[int64]) *walBlockFlush {
 
 func (w *walBlockFlush) File() (*parquet.File, error) {
 	if w.pf == nil {
-		pf, err := openLocalParquetFile(w.path)
-		if err != nil {
-			return nil, err
-		}
-		w.pf = pf
+		return openLocalParquetFile(w.path)
+		// if err != nil {
+		// 	return nil, err
+		// }
+		// w.pf = pf
 	}
 
 	return w.pf, nil

--- a/tempodb/encoding/vparquet/wal_block.go
+++ b/tempodb/encoding/vparquet/wal_block.go
@@ -201,7 +201,11 @@ func newWalBlockFlush(path string, ids *common.IDMap[int64]) *walBlockFlush {
 
 func (w *walBlockFlush) File() (*parquet.File, error) {
 	if w.pf == nil {
-		return openLocalParquetFile(w.path)
+		pf, err := openLocalParquetFile(w.path)
+		if err != nil {
+			return nil, err
+		}
+		w.pf = pf
 	}
 
 	return w.pf, nil

--- a/tempodb/encoding/vparquet/wal_block.go
+++ b/tempodb/encoding/vparquet/wal_block.go
@@ -315,8 +315,11 @@ func (b *walBlock) openWriter() (err error) {
 
 	if b.writer == nil {
 		b.writer = parquet.NewGenericWriter[*Trace](b.file, &parquet.WriterConfig{
-			Schema:         walSchema,
-			PageBufferSize: 1024,
+			Schema: walSchema,
+			// there is tension between this value and search speeds. 250KB is the default, but leaving this default causes the wal to hold onto
+			// a large amount of memory in multitenant installs. Reducing this value causes parquet to cut pages more aggressively which slows down search
+			// this setting does not impact the blocks shipped to the backend, only the wal.
+			PageBufferSize: 10 * 1024,
 		})
 	} else {
 		b.writer.Reset(b.file)

--- a/tempodb/encoding/vparquet/wal_block.go
+++ b/tempodb/encoding/vparquet/wal_block.go
@@ -650,7 +650,7 @@ func openLocalParquetFile(filename string) (*parquet.File, int64, error) {
 		return nil, 0, fmt.Errorf("error getting file info: %w", err)
 	}
 	sz := info.Size()
-	pf, err := parquet.OpenFile(file, sz)
+	pf, err := parquet.OpenFile(file, sz, parquet.SkipBloomFilters(true), parquet.SkipPageIndex(true))
 	if err != nil {
 		return nil, 0, fmt.Errorf("error opening parquet file: %w", err)
 	}

--- a/tempodb/encoding/vparquet/wal_block.go
+++ b/tempodb/encoding/vparquet/wal_block.go
@@ -325,11 +325,9 @@ func (b *walBlock) openWriter() (err error) {
 	if b.writer == nil {
 		b.writer = parquet.NewGenericWriter[*Trace](b.file, &parquet.WriterConfig{
 			Schema: walSchema,
-			// there is tension between this value and search speeds. 250KB is the default, but leaving this default causes the wal to hold onto
-			// a large amount of memory in multitenant installs. Reducing this value causes parquet to cut pages more aggressively which slows down search
-			// this setting does not impact the blocks shipped to the backend, only the wal.
-			// todo: slowdown due to excessive pages is in parquetquery.StringInPredicate.KeepPage. review and improve this method
-			PageBufferSize: 10 * 1024,
+			// setting this value low massively reduces the amount of static memory we hold onto in highly multi-tenant environments at the cost of
+			// cutting pages more aggressively when writing column chunks
+			PageBufferSize: 1024,
 		})
 	} else {
 		b.writer.Reset(b.file)

--- a/tempodb/encoding/vparquet/wal_block.go
+++ b/tempodb/encoding/vparquet/wal_block.go
@@ -314,13 +314,6 @@ func (b *walBlock) openWriter() (err error) {
 			Schema:         walSchema,
 			PageBufferSize: 1024,
 		})
-		// ,parquet.WriteBufferSize(0) -> bufio.NewWriterSize - 32k default - 32k per file - minor memory savings - possible cpu improvement?
-		// ColumnPageBuffers -> allows for on disk buffer pool?
-		// ColumnIndexSizeLimit -> 16 default
-		// PageBufferSize -> 256KB default
-		// Schema -> default nil - minor savings to create one and share between all writers
-		// BloomFilters -> ability to add custom bloom filters? ignore for now
-		// Compression -> default nil
 	} else {
 		b.writer.Reset(b.file)
 	}

--- a/tempodb/encoding/vparquet/wal_block.go
+++ b/tempodb/encoding/vparquet/wal_block.go
@@ -49,7 +49,7 @@ var walSchema = parquet.SchemaOf(&Trace{})
 // not assigning a decoder.
 //
 // there's an interesting bug here that does not come into play due to the fact that we do not append to a wal created with this method.
-// if there are 2 wal files and the second is loaded succesfully, but the first fails then b.flushed will contain one entry. then when
+// if there are 2 wal files and the second is loaded successfully, but the first fails then b.flushed will contain one entry. then when
 // calling b.openWriter() it will attempt to create a new file as path/folder/00002 which will overwrite the first file. as long as we never
 // append to this file it should be ok.
 func openWALBlock(filename string, path string, ingestionSlack time.Duration, _ time.Duration) (common.WALBlock, error, error) {

--- a/tempodb/encoding/vparquet/wal_block_test.go
+++ b/tempodb/encoding/vparquet/wal_block_test.go
@@ -262,7 +262,8 @@ func TestWalBlockIterator(t *testing.T) {
 func TestRowIterator(t *testing.T) {
 	testWalBlock(t, func(w *walBlock, _ []common.ID, _ []*tempopb.Trace) {
 		for _, f := range w.flushed {
-			ri := f.rowIterator()
+			ri, err := f.rowIterator()
+			require.NoError(t, err)
 
 			var lastID []byte
 			for {

--- a/vendor/github.com/segmentio/parquet-go/README.md
+++ b/vendor/github.com/segmentio/parquet-go/README.md
@@ -405,7 +405,9 @@ mechanisms to read column values:
 
 ```go
 pages := column.Pages()
-defer checkErr(pages.Close())
+defer func() {
+    checkErr(pages.Close())
+}()
 
 for {
     p, err := pages.ReadPage()

--- a/vendor/github.com/segmentio/parquet-go/config.go
+++ b/vendor/github.com/segmentio/parquet-go/config.go
@@ -93,6 +93,7 @@ type FileConfig struct {
 	SkipBloomFilters bool
 	ReadBufferSize   int
 	ReadMode         ReadMode
+	Schema           *Schema
 }
 
 // DefaultFileConfig returns a new FileConfig value initialized with the
@@ -103,6 +104,7 @@ func DefaultFileConfig() *FileConfig {
 		SkipBloomFilters: DefaultSkipBloomFilters,
 		ReadBufferSize:   defaultReadBufferSize,
 		ReadMode:         DefaultReadMode,
+		Schema:           nil,
 	}
 }
 
@@ -131,6 +133,7 @@ func (c *FileConfig) ConfigureFile(config *FileConfig) {
 		SkipBloomFilters: c.SkipBloomFilters,
 		ReadBufferSize:   coalesceInt(c.ReadBufferSize, config.ReadBufferSize),
 		ReadMode:         ReadMode(coalesceInt(int(c.ReadMode), int(config.ReadMode))),
+		Schema:           coalesceSchema(c.Schema, config.Schema),
 	}
 }
 
@@ -467,6 +470,15 @@ func FileReadMode(mode ReadMode) FileOption {
 // Defaults to 4096.
 func ReadBufferSize(size int) FileOption {
 	return fileOption(func(config *FileConfig) { config.ReadBufferSize = size })
+}
+
+// FileSchema is used to pass a known schema in while opening a Parquet file.
+// This optimization is only useful if your application is currently opening
+// an extremely large number of parquet files with the same, known schema.
+//
+// Defaults to nil.
+func FileSchema(schema *Schema) FileOption {
+	return fileOption(func(config *FileConfig) { config.Schema = schema })
 }
 
 // PageBufferSize configures the size of column page buffers on parquet writers.

--- a/vendor/github.com/segmentio/parquet-go/file.go
+++ b/vendor/github.com/segmentio/parquet-go/file.go
@@ -91,7 +91,12 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 		return nil, fmt.Errorf("opening columns of parquet file: %w", err)
 	}
 
-	schema := NewSchema(f.root.Name(), f.root)
+	var schema *Schema
+	if c.Schema != nil {
+		schema = c.Schema
+	} else {
+		schema = NewSchema(f.root.Name(), f.root)
+	}
 	columns := make([]*Column, 0, numLeafColumnsOf(f.root))
 	f.schema = schema
 	f.root.forEachLeaf(func(c *Column) { columns = append(columns, c) })

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -899,7 +899,7 @@ github.com/segmentio/encoding/thrift
 # github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e
 ## explicit
 github.com/segmentio/fasthash/fnv1a
-# github.com/segmentio/parquet-go v0.0.0-20221209072905-710d87d50dd1
+# github.com/segmentio/parquet-go v0.0.0-20221212205011-52de454c1d86
 ## explicit; go 1.19
 github.com/segmentio/parquet-go
 github.com/segmentio/parquet-go/bloom


### PR DESCRIPTION
**What this PR does**:
A number of performance improvements for the Parquet wal that are particularly impactful in a highly multitenant environment:

- shared writer schema
- 1KB page buffer size for writers
- don't load page index or bloom filters when opening a wal "page" file
- lazy load wal "page" files

The real winners here were the 1k page buffer size and the lazy loading of the wal page files (instead of loading them immediately after flushing).

By default the page buffer size is 256KB. This page buffer is applied to every column of every tenant which adds up fast. Ideally there would be a way to specify per column page buffers, but this does not exist. The 1KB size does slow down tests. It doubles the length of time to run the tests in the `/tempodb/wal` folder for me, but in practice it seemed to have negligible impact on flush times in real environments.