### PR TITLE
Remove tenant when last block is removed from local backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ Internal types are updated to use `scope` instead of `instrumentation_library`. 
 * [ENHANCEMENT] New tenant dashboard [#1901](https://github.com/grafana/tempo/pull/1901) (@mapno)
 * [BUGFIX] Fix docker-compose examples not running on Apple M1 hardware [#1920](https://github.com/grafana/tempo/pull/1920) (@stoewer)
 * [BUGFIX] Fix traceql parsing of most binary operations to not require spacing [#1939](https://github.com/grafana/tempo/pull/1941) (@mdisibio)
+* [BUGFIX] Don't persist tenants without blocks in the ingester[#1947](https://github.com/grafana/tempo/pull/1947) (@joe-elliott)
 
 ## v1.5.0 / 2022-08-17
 

--- a/modules/ingester/ingester.go
+++ b/modules/ingester/ingester.go
@@ -421,6 +421,11 @@ func (i *Ingester) rediscoverLocalBlocks() error {
 			return errors.Wrapf(err, "getting local blocks for tenant %v", t)
 		}
 
+		// don't persist a tenant if it doesn't have blocks
+		if len(newBlocks) == 0 {
+			delete(i.instances, t)
+		}
+
 		// Requeue needed flushes
 		for _, b := range newBlocks {
 			if b.FlushedTime().IsZero() {

--- a/modules/ingester/ingester.go
+++ b/modules/ingester/ingester.go
@@ -155,6 +155,8 @@ func (i *Ingester) stopping(_ error) error {
 		i.flushQueuesDone.Wait()
 	}
 
+	i.local.Shutdown()
+
 	return nil
 }
 

--- a/modules/ingester/instance_search_test.go
+++ b/modules/ingester/instance_search_test.go
@@ -82,7 +82,7 @@ func TestInstanceSearch(t *testing.T) {
 			ingester, _, _ = defaultIngester(t, tempDir)
 
 			i, ok := ingester.getInstanceByID("fake")
-			assert.True(t, ok)
+			require.True(t, ok)
 
 			sr, err = i.Search(context.Background(), req)
 			assert.NoError(t, err)

--- a/tempodb/backend/local/compactor.go
+++ b/tempodb/backend/local/compactor.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -20,14 +21,34 @@ func (rw *Backend) MarkBlockCompacted(blockID uuid.UUID, tenantID string) error 
 
 func (rw *Backend) ClearBlock(blockID uuid.UUID, tenantID string) error {
 	if len(tenantID) == 0 {
-		return fmt.Errorf("empty tenant id")
+		return errors.New("empty tenant id")
 	}
 
 	if blockID == uuid.Nil {
-		return fmt.Errorf("empty block id")
+		return errors.New("empty block id")
 	}
 
-	return os.RemoveAll(rw.rootPath(backend.KeyPathForBlock(blockID, tenantID)))
+	path := rw.rootPath(backend.KeyPathForBlock(blockID, tenantID))
+	err := os.RemoveAll(path)
+	if err != nil {
+		return fmt.Errorf("failed to remove keypath for block %s: %w", path, err)
+	}
+
+	// if there are no more blocks in this tenant, clear the tenant
+	path = rw.rootPath(backend.KeyPath{tenantID})
+	folders, err := os.ReadDir(path)
+	if err != nil {
+		return fmt.Errorf("failed to list keypath for tenant %s: %w", path, err)
+	}
+
+	if len(folders) == 0 {
+		err = os.RemoveAll(path)
+		if err != nil {
+			return fmt.Errorf("failed to remove keypath for tenant %s: %w", path, err)
+		}
+	}
+
+	return nil
 }
 
 func (rw *Backend) CompactedBlockMeta(blockID uuid.UUID, tenantID string) (*backend.CompactedBlockMeta, error) {

--- a/tempodb/backend/local/compactor.go
+++ b/tempodb/backend/local/compactor.go
@@ -37,6 +37,9 @@ func (rw *Backend) ClearBlock(blockID uuid.UUID, tenantID string) error {
 	// if there are no more blocks in this tenant, clear the tenant
 	path = rw.rootPath(backend.KeyPath{tenantID})
 	folders, err := os.ReadDir(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("failed to list keypath for tenant %s: %w", path, err)
 	}

--- a/tempodb/backend/local/compactor.go
+++ b/tempodb/backend/local/compactor.go
@@ -34,23 +34,6 @@ func (rw *Backend) ClearBlock(blockID uuid.UUID, tenantID string) error {
 		return fmt.Errorf("failed to remove keypath for block %s: %w", path, err)
 	}
 
-	// if there are no more blocks in this tenant, clear the tenant
-	path = rw.rootPath(backend.KeyPath{tenantID})
-	folders, err := os.ReadDir(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("failed to list keypath for tenant %s: %w", path, err)
-	}
-
-	if len(folders) == 0 {
-		err = os.RemoveAll(path)
-		if err != nil {
-			return fmt.Errorf("failed to remove keypath for tenant %s: %w", path, err)
-		}
-	}
-
 	return nil
 }
 

--- a/tempodb/backend/local/local.go
+++ b/tempodb/backend/local/local.go
@@ -161,9 +161,27 @@ func (rw *Backend) ReadRange(ctx context.Context, name string, keypath backend.K
 	return nil
 }
 
-// Shutdown implements backend.Reader
+// Shutdown implements backend.Reader. It attempts to clear all tenants
+// that do not have blocks.
 func (rw *Backend) Shutdown() {
-	// clean up local storage jpe
+	ctx := context.Background()
+
+	// Shutdown() doesn't return error so this is best effort
+	tenants, err := rw.List(ctx, backend.KeyPath{})
+	if err != nil {
+		return
+	}
+
+	for _, tenant := range tenants {
+		blocks, err := rw.List(ctx, backend.KeyPath{tenant})
+		if err != nil {
+			continue
+		}
+
+		if len(blocks) == 0 {
+			_ = os.RemoveAll(rw.rootPath(backend.KeyPath{tenant}))
+		}
+	}
 }
 
 func (rw *Backend) objectFileName(keypath backend.KeyPath, name string) string {

--- a/tempodb/backend/local/local.go
+++ b/tempodb/backend/local/local.go
@@ -163,7 +163,7 @@ func (rw *Backend) ReadRange(ctx context.Context, name string, keypath backend.K
 
 // Shutdown implements backend.Reader
 func (rw *Backend) Shutdown() {
-
+	// clean up local storage jpe
 }
 
 func (rw *Backend) objectFileName(keypath backend.KeyPath, name string) string {

--- a/tempodb/backend/local/local_test.go
+++ b/tempodb/backend/local/local_test.go
@@ -78,7 +78,7 @@ func TestShutdownLeavesTenantsWithBlocks(t *testing.T) {
 	ctx := context.Background()
 	blockID := uuid.New()
 	contents := bytes.NewReader([]byte("test"))
-	tenant := "tenant"
+	tenant := "fake"
 
 	// write a "block"
 	err = w.Write(ctx, "test", backend.KeyPathForBlock(blockID, tenant), contents, contents.Size(), false)

--- a/tempodb/backend/local/local_test.go
+++ b/tempodb/backend/local/local_test.go
@@ -67,3 +67,7 @@ func TestReadWrite(t *testing.T) {
 	assert.Len(t, list, 1)
 	assert.Equal(t, blockID.String(), list[0])
 }
+
+func TestShutdownCleansupTenants(t *testing.T) {
+	// jpe
+}

--- a/tempodb/backend/local/local_test.go
+++ b/tempodb/backend/local/local_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/tempo/tempodb/backend"
 )
@@ -68,6 +69,71 @@ func TestReadWrite(t *testing.T) {
 	assert.Equal(t, blockID.String(), list[0])
 }
 
-func TestShutdownCleansupTenants(t *testing.T) {
-	// jpe
+func TestShutdownLeavesTenantsWithBlocks(t *testing.T) {
+	r, w, _, err := New(&Config{
+		Path: t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	blockID := uuid.New()
+	contents := bytes.NewReader([]byte("test"))
+	tenant := "tenant"
+
+	// write a "block"
+	err = w.Write(ctx, "test", backend.KeyPathForBlock(blockID, tenant), contents, contents.Size(), false)
+	require.NoError(t, err)
+
+	// shutdown the backend
+	r.Shutdown()
+
+	tenantExists(t, tenant, r)
+	blockExists(t, blockID, tenant, r)
+}
+
+func TestShutdownRemovesTenantsWithoutBlocks(t *testing.T) {
+	r, w, c, err := New(&Config{
+		Path: t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	blockID := uuid.New()
+	contents := bytes.NewReader([]byte("test"))
+	tenant := "tenant"
+
+	// write a "block"
+	err = w.Write(ctx, "test", backend.KeyPathForBlock(blockID, tenant), contents, contents.Size(), false)
+	require.NoError(t, err)
+
+	tenantExists(t, tenant, r)
+	blockExists(t, blockID, tenant, r)
+
+	// clear the block
+	err = c.ClearBlock(blockID, tenant)
+	require.NoError(t, err)
+
+	tenantExists(t, tenant, r)
+
+	// shutdown the backend
+	r.Shutdown()
+
+	// tenant should not exist
+	tenants, err := r.List(ctx, backend.KeyPath{})
+	require.NoError(t, err)
+	require.Len(t, tenants, 0)
+}
+
+func tenantExists(t *testing.T, tenant string, r backend.RawReader) {
+	tenants, err := r.List(context.Background(), backend.KeyPath{})
+	require.NoError(t, err)
+	require.Len(t, tenants, 1)
+	require.Equal(t, tenant, tenants[0])
+}
+
+func blockExists(t *testing.T, blockID uuid.UUID, tenant string, r backend.RawReader) {
+	blocks, err := r.List(context.Background(), backend.KeyPath{tenant})
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	require.Equal(t, blockID.String(), blocks[0])
 }

--- a/tempodb/backend/local/local_test.go
+++ b/tempodb/backend/local/local_test.go
@@ -84,6 +84,9 @@ func TestShutdownLeavesTenantsWithBlocks(t *testing.T) {
 	err = w.Write(ctx, "test", backend.KeyPathForBlock(blockID, tenant), contents, contents.Size(), false)
 	require.NoError(t, err)
 
+	tenantExists(t, tenant, r)
+	blockExists(t, blockID, tenant, r)
+
 	// shutdown the backend
 	r.Shutdown()
 
@@ -114,6 +117,11 @@ func TestShutdownRemovesTenantsWithoutBlocks(t *testing.T) {
 	require.NoError(t, err)
 
 	tenantExists(t, tenant, r)
+
+	// block should not exist
+	blocks, err := r.List(ctx, backend.KeyPath{tenant})
+	require.NoError(t, err)
+	require.Len(t, blocks, 0)
 
 	// shutdown the backend
 	r.Shutdown()


### PR DESCRIPTION
**What this PR does**:
This fixes a long running issue where tenants were persisted even if they had a zero length wal. The issue was that when rediscovering local blocks a tenant was still found even if there were no blocks. This PR fixes the issue with two changes:

- When rediscovering local blocks don't include tenants without blocks
- When clearing a block in the local backend remove the tenant as well

Technically only the first of the two is needed and would be a safer change. Having the second is nice because it will clear up folders in our ingester local backends. Should we remove the second change and err towards safety? Especially with the 2.0 release coming up?

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`