### PR TITLE
Improve Parquet Dictionary Handling

### DIFF
--- a/pkg/parquetquery/predicate_test.go
+++ b/pkg/parquetquery/predicate_test.go
@@ -66,30 +66,6 @@ func TestSubstringPredicate(t *testing.T) {
 			require.NoError(t, w.Write(&dictString{"abc"}))
 		},
 	})
-
-	// If the dictionary cardinality is too high we just read the page anyway
-	testPredicate(t, predicateTestCase{
-		predicate:  NewSubstringPredicate("x"), // Not present in any values
-		keptChunks: 1,
-		keptPages:  1,
-		keptValues: 0,
-		writeData: func(w *parquet.Writer) { //nolint:all
-			type dictString struct {
-				S string `parquet:",dict"`
-			}
-			require.NoError(t, w.Write(&dictString{"abc"}))
-			require.NoError(t, w.Write(&dictString{"bcd"}))
-			require.NoError(t, w.Write(&dictString{"cde"}))
-			require.NoError(t, w.Write(&dictString{"def"}))
-			require.NoError(t, w.Write(&dictString{"efg"}))
-			require.NoError(t, w.Write(&dictString{"fgh"}))
-			require.NoError(t, w.Write(&dictString{"ghi"}))
-			require.NoError(t, w.Write(&dictString{"ijk"}))
-			require.NoError(t, w.Write(&dictString{"jkl"}))
-			require.NoError(t, w.Write(&dictString{"klm"}))
-			require.NoError(t, w.Write(&dictString{"lmn"}))
-		},
-	})
 }
 
 // TestOrPredicateCallsKeepColumnChunk ensures that the OrPredicate calls

--- a/pkg/parquetquery/predicate_test.go
+++ b/pkg/parquetquery/predicate_test.go
@@ -39,8 +39,28 @@ func TestSubstringPredicate(t *testing.T) {
 				S string `parquet:",dict"`
 			}
 			require.NoError(t, w.Write(&dictString{"abc"}))
+			require.NoError(t, w.Write(&dictString{"abc"}))
+			require.NoError(t, w.Write(&dictString{"abc"}))
+			require.NoError(t, w.Write(&dictString{"abc"}))
+			require.NoError(t, w.Write(&dictString{"abc"}))
+		},
+	})
+
+	// If the dictionary cardinality is too high we just read the page anyway
+	testPredicate(t, predicateTestCase{
+		predicate:  NewSubstringPredicate("x"), // Not present in any values
+		keptChunks: 1,
+		keptPages:  1,
+		keptValues: 0,
+		writeData: func(w *parquet.Writer) { //nolint:all
+			type dictString struct {
+				S string `parquet:",dict"`
+			}
+			require.NoError(t, w.Write(&dictString{"abc"}))
 			require.NoError(t, w.Write(&dictString{"bcd"}))
 			require.NoError(t, w.Write(&dictString{"cde"}))
+			require.NoError(t, w.Write(&dictString{"def"}))
+			require.NoError(t, w.Write(&dictString{"efg"}))
 		},
 	})
 }

--- a/pkg/parquetquery/predicates.go
+++ b/pkg/parquetquery/predicates.go
@@ -20,6 +20,8 @@ type Predicate interface {
 // Case sensitive exact byte matching
 type StringInPredicate struct {
 	ss [][]byte
+
+	helper DictionaryPredicateHelper
 }
 
 var _ Predicate = (*StringInPredicate)(nil)
@@ -35,6 +37,8 @@ func NewStringInPredicate(ss []string) Predicate {
 }
 
 func (p *StringInPredicate) KeepColumnChunk(cc pq.ColumnChunk) bool {
+	p.helper.setNewRowGroup()
+
 	if ci := cc.ColumnIndex(); ci != nil {
 
 		for _, subs := range p.ss {
@@ -65,26 +69,28 @@ func (p *StringInPredicate) KeepValue(v pq.Value) bool {
 func (p *StringInPredicate) KeepPage(page pq.Page) bool {
 	// todo: check bounds
 
-	// If a dictionary column then ensure at least one matching
-	// value exists in the dictionary
-	dict := page.Dictionary()
-	if dict != nil && dict.Len() > 0 {
-		len := dict.Len()
+	return p.helper.keepPage(func() bool {
+		// If a dictionary column then ensure at least one matching
+		// value exists in the dictionary
+		dict := page.Dictionary()
+		if dict != nil && dict.Len() > 0 {
+			len := dict.Len()
 
-		for i := 0; i < len; i++ {
-			dictionaryEntry := dict.Index(int32(i)).ByteArray()
-			for _, subs := range p.ss {
-				if bytes.Equal(dictionaryEntry, subs) {
-					// At least 1 string present in this page
-					return true
+			for i := 0; i < len; i++ {
+				dictionaryEntry := dict.Index(int32(i)).ByteArray()
+				for _, subs := range p.ss {
+					if bytes.Equal(dictionaryEntry, subs) {
+						// At least 1 string present in this page
+						return true
+					}
 				}
 			}
+
+			return false
 		}
 
-		return false
-	}
-
-	return true
+		return true
+	})
 }
 
 // RegexInPredicate checks for match against any of the given regexs.
@@ -92,6 +98,8 @@ func (p *StringInPredicate) KeepPage(page pq.Page) bool {
 type RegexInPredicate struct {
 	regs    []*regexp.Regexp
 	matches map[string]bool
+
+	helper DictionaryPredicateHelper
 }
 
 var _ Predicate = (*RegexInPredicate)(nil)
@@ -135,6 +143,8 @@ func (p *RegexInPredicate) keep(v *pq.Value) bool {
 }
 
 func (p *RegexInPredicate) KeepColumnChunk(cc pq.ColumnChunk) bool {
+	p.helper.setNewRowGroup()
+
 	// Reset match cache on each row group change
 	p.matches = make(map[string]bool, len(p.matches))
 
@@ -148,29 +158,33 @@ func (p *RegexInPredicate) KeepValue(v pq.Value) bool {
 
 func (p *RegexInPredicate) KeepPage(page pq.Page) bool {
 
-	// If a dictionary column then ensure at least one matching
-	// value exists in the dictionary
-	dict := page.Dictionary()
-	if dict != nil && dict.Len() > 0 {
-		len := dict.Len()
+	return p.helper.keepPage(func() bool {
+		// If a dictionary column then ensure at least one matching
+		// value exists in the dictionary
+		dict := page.Dictionary()
+		if dict != nil && dict.Len() > 0 {
+			len := dict.Len()
 
-		for i := 0; i < len; i++ {
-			dictionaryEntry := dict.Index(int32(i))
-			if p.keep(&dictionaryEntry) {
-				// At least 1 dictionary entry matches
-				return true
+			for i := 0; i < len; i++ {
+				dictionaryEntry := dict.Index(int32(i))
+				if p.keep(&dictionaryEntry) {
+					// At least 1 dictionary entry matches
+					return true
+				}
 			}
+
+			return false
 		}
 
-		return false
-	}
-
-	return true
+		return true
+	})
 }
 
 type SubstringPredicate struct {
 	substring string
 	matches   map[string]bool
+
+	helper DictionaryPredicateHelper
 }
 
 var _ Predicate = (*SubstringPredicate)(nil)
@@ -204,22 +218,23 @@ func (p *SubstringPredicate) KeepValue(v pq.Value) bool {
 }
 
 func (p *SubstringPredicate) KeepPage(page pq.Page) bool {
-
-	// If a dictionary column then ensure at least one matching
-	// value exists in the dictionary
-	dict := page.Dictionary()
-	if dict != nil && dict.Len() > 0 {
-		len := dict.Len()
-		for i := 0; i < len; i++ {
-			if p.KeepValue(dict.Index(int32(i))) {
-				return true
+	return p.helper.keepPage(func() bool {
+		// If a dictionary column then ensure at least one matching
+		// value exists in the dictionary
+		dict := page.Dictionary()
+		if dict != nil && dict.Len() > 0 {
+			len := dict.Len()
+			for i := 0; i < len; i++ {
+				if p.KeepValue(dict.Index(int32(i))) {
+					return true
+				}
 			}
+
+			return false
 		}
 
-		return false
-	}
-
-	return true
+		return true
+	})
 }
 
 // IntBetweenPredicate checks for int between the bounds [min,max] inclusive
@@ -270,15 +285,19 @@ type GenericPredicate[T any] struct {
 	Fn      func(T) bool
 	RangeFn func(min, max T) bool
 	Extract func(pq.Value) T
+
+	helper DictionaryPredicateHelper
 }
 
 var _ Predicate = (*GenericPredicate[int64])(nil)
 
 func NewGenericPredicate[T any](fn func(T) bool, rangeFn func(T, T) bool, extract func(pq.Value) T) *GenericPredicate[T] {
-	return &GenericPredicate[T]{fn, rangeFn, extract}
+	return &GenericPredicate[T]{Fn: fn, RangeFn: rangeFn, Extract: extract}
 }
 
 func (p *GenericPredicate[T]) KeepColumnChunk(c pq.ColumnChunk) bool {
+	p.helper.setNewRowGroup()
+
 	if p.RangeFn == nil {
 		return true
 	}
@@ -305,22 +324,24 @@ func (p *GenericPredicate[T]) KeepPage(page pq.Page) bool {
 		}
 	}
 
-	// If a dictionary column then ensure at least one matching
-	// value exists in the dictionary
-	dict := page.Dictionary()
-	if dict != nil && dict.Len() > 0 {
-		len := dict.Len()
-		for i := 0; i < len; i++ {
-			if p.KeepValue(dict.Index(int32(i))) {
-				return true
+	return p.helper.keepPage(func() bool {
+		// If a dictionary column then ensure at least one matching
+		// value exists in the dictionary
+		dict := page.Dictionary()
+		if dict != nil && dict.Len() > 0 {
+			len := dict.Len()
+			for i := 0; i < len; i++ {
+				if p.KeepValue(dict.Index(int32(i))) {
+					return true
+				}
 			}
+
+			// No values matched
+			return false
 		}
 
-		// No values matched
-		return false
-	}
-
-	return true
+		return true
+	})
 }
 
 func (p *GenericPredicate[T]) KeepValue(v pq.Value) bool {
@@ -484,4 +505,29 @@ func (p *InstrumentedPredicate) KeepValue(v pq.Value) bool {
 	}
 
 	return false
+}
+
+// DictionaryPredicateHelper is a helper for a predicate that uses a dictionary
+// for filtering. it implements the Predicate interface and can be used
+// to simply dictionary handling.
+//
+// There is one dictionary per ColumnChunk/RowGroup, but it is not accessible in
+// KeepColumnChunk. This predicate saves the result of KeepPage and uses it for
+// all pages in the row group
+type DictionaryPredicateHelper struct {
+	newRowGroup         bool
+	keepPagesInRowGroup bool
+}
+
+func (d *DictionaryPredicateHelper) setNewRowGroup() {
+	d.newRowGroup = true
+}
+
+func (d *DictionaryPredicateHelper) keepPage(fn func() bool) bool {
+	if !d.newRowGroup {
+		return d.keepPagesInRowGroup
+	}
+
+	d.keepPagesInRowGroup = fn()
+	return d.keepPagesInRowGroup
 }

--- a/pkg/parquetquery/predicates.go
+++ b/pkg/parquetquery/predicates.go
@@ -359,7 +359,7 @@ func (p *OrPredicate) KeepColumnChunk(c pq.ColumnChunk) bool {
 		}
 	}
 
-	return true
+	return ret
 }
 
 func (p *OrPredicate) KeepPage(page pq.Page) bool {

--- a/pkg/parquetquery/predicates.go
+++ b/pkg/parquetquery/predicates.go
@@ -347,17 +347,18 @@ func NewOrPredicate(preds ...Predicate) *OrPredicate {
 }
 
 func (p *OrPredicate) KeepColumnChunk(c pq.ColumnChunk) bool {
+	ret := false
 	for _, p := range p.preds {
 		if p == nil {
 			// Nil means all values are returned
-			return true
+			ret = ret || true
 		}
 		if p.KeepColumnChunk(c) {
-			return true
+			ret = ret || true
 		}
 	}
 
-	return false
+	return true
 }
 
 func (p *OrPredicate) KeepPage(page pq.Page) bool {

--- a/pkg/parquetquery/predicates.go
+++ b/pkg/parquetquery/predicates.go
@@ -352,6 +352,7 @@ func (p *OrPredicate) KeepColumnChunk(c pq.ColumnChunk) bool {
 		if p == nil {
 			// Nil means all values are returned
 			ret = ret || true
+			continue
 		}
 		if p.KeepColumnChunk(c) {
 			ret = ret || true
@@ -449,7 +450,7 @@ type DictionaryPredicateHelper struct {
 
 func (d *DictionaryPredicateHelper) setNewRowGroup(cc pq.ColumnChunk) {
 	// if our length is a significant portion of the total values, then using the dictionary is worse. 1.2 is a guess. todo: tune this value
-	d.fullScanThreshold = int64(float32(cc.NumValues()) / 1.2) // jpe remove?
+	d.fullScanThreshold = int64(float32(cc.NumValues()) / 1.2)
 	d.newRowGroup = true
 }
 
@@ -469,9 +470,9 @@ func (d *DictionaryPredicateHelper) keepPage(page pq.Page, keepValue func(pq.Val
 	}
 
 	l := dict.Len()
-	// if d.fullScanThreshold > 0 && int64(l) > d.fullScanThreshold { jpe remove?
-	// 	return d.keepPagesInRowGroup
-	// }
+	if d.fullScanThreshold > 0 && int64(l) > d.fullScanThreshold {
+		return d.keepPagesInRowGroup
+	}
 
 	d.keepPagesInRowGroup = false
 	for i := 0; i < l; i++ {

--- a/pkg/parquetquery/predicates.go
+++ b/pkg/parquetquery/predicates.go
@@ -434,12 +434,12 @@ func (p *InstrumentedPredicate) KeepValue(v pq.Value) bool {
 }
 
 // DictionaryPredicateHelper is a helper for a predicate that uses a dictionary
-// for filtering. it implements the Predicate interface and can be used
-// to simply dictionary handling.
+// for filtering.
 //
 // There is one dictionary per ColumnChunk/RowGroup, but it is not accessible in
-// KeepColumnChunk. This predicate saves the result of KeepPage and uses it for
-// all pages in the row group
+// KeepColumnChunk. This helper saves the result of KeepPage and uses it for
+// all pages in the row group. It also has a basic heuristic for choosing not
+// to check the dictionary at all if the cardinality is too high.
 type DictionaryPredicateHelper struct {
 	numValues           int64
 	newRowGroup         bool

--- a/pkg/parquetquery/predicates.go
+++ b/pkg/parquetquery/predicates.go
@@ -37,7 +37,7 @@ func NewStringInPredicate(ss []string) Predicate {
 }
 
 func (p *StringInPredicate) KeepColumnChunk(cc pq.ColumnChunk) bool {
-	p.helper.setNewRowGroup(cc)
+	p.helper.setNewRowGroup()
 
 	if ci := cc.ColumnIndex(); ci != nil {
 		for _, subs := range p.ss {
@@ -120,7 +120,7 @@ func (p *RegexInPredicate) keep(v *pq.Value) bool {
 }
 
 func (p *RegexInPredicate) KeepColumnChunk(cc pq.ColumnChunk) bool {
-	p.helper.setNewRowGroup(cc)
+	p.helper.setNewRowGroup()
 
 	// Reset match cache on each row group change
 	p.matches = make(map[string]bool, len(p.matches))
@@ -154,7 +154,7 @@ func NewSubstringPredicate(substring string) *SubstringPredicate {
 }
 
 func (p *SubstringPredicate) KeepColumnChunk(cc pq.ColumnChunk) bool {
-	p.helper.setNewRowGroup(cc)
+	p.helper.setNewRowGroup()
 
 	// Reset match cache on each row group change
 	p.matches = make(map[string]bool, len(p.matches))
@@ -239,7 +239,7 @@ func NewGenericPredicate[T any](fn func(T) bool, rangeFn func(T, T) bool, extrac
 }
 
 func (p *GenericPredicate[T]) KeepColumnChunk(c pq.ColumnChunk) bool {
-	p.helper.setNewRowGroup(c)
+	p.helper.setNewRowGroup()
 
 	if p.RangeFn == nil {
 		return true
@@ -447,7 +447,7 @@ type DictionaryPredicateHelper struct {
 	keepPagesInRowGroup bool
 }
 
-func (d *DictionaryPredicateHelper) setNewRowGroup(cc pq.ColumnChunk) {
+func (d *DictionaryPredicateHelper) setNewRowGroup() {
 	d.newRowGroup = true
 }
 

--- a/tempodb/encoding/vparquet/block_search.go
+++ b/tempodb/encoding/vparquet/block_search.go
@@ -220,29 +220,32 @@ func searchTags(_ context.Context, cb common.TagCallback, pf *parquet.File) erro
 			err = func() error {
 				pgs := cc.Pages()
 				defer pgs.Close()
-				for {
-					pg, err := pgs.ReadPage()
-					if err == io.EOF || pg == nil {
-						break
-					}
-					if err != nil {
-						return err
-					}
 
-					func(page parquet.Page) {
-						defer parquet.Release(page)
-
-						dict := page.Dictionary()
-						if dict == nil {
-							return
-						}
-
-						for i := 0; i < dict.Len(); i++ {
-							s := dict.Index(int32(i)).String()
-							cb(s)
-						}
-					}(pg)
+				// normally we'd loop here calling read page for every page in the column chunk, but
+				// there is only one dictionary per column chunk, so just read it from the first page
+				// and be done.
+				pg, err := pgs.ReadPage()
+				if err == io.EOF || pg == nil {
+					return nil
 				}
+				if err != nil {
+					return err
+				}
+
+				func(page parquet.Page) {
+					defer parquet.Release(page)
+
+					dict := page.Dictionary()
+					if dict == nil {
+						return
+					}
+
+					for i := 0; i < dict.Len(); i++ {
+						s := dict.Index(int32(i)).String()
+						cb(s)
+					}
+				}(pg)
+
 				return nil
 			}()
 			if err != nil {


### PR DESCRIPTION
**What this PR does**:
Improves parquet-query's handling of dictionaries in predicates. Currently we test the dictionary for every page. However, the dictionary is per row group and not per page. Therefore, for row groups that contained multiple pages, we were repeatedly and unnecessarily checking the dictionary.

~~There is also a cardinality question. If every value in the row group is unique then testing the dictionary isn't worth it. We will test n/2 values in the dictionary until we get to the one that suggests we should keep the column and then go back and test n values for whatever the initial condition was. In this case, especially since we've already paid the cost of pulling everything from object storage, it would likely be faster to simply test the values directly.~~
Although this feels very true, benchmarks are showing otherwise. See below.

**Checklist**[
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`