### PR TITLE
fix: complete writing batch even if some spans refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [ENHANCEMENT] Add synchronous read mode to vParquet and vParquet2 optionally enabled by env vars  [#2165](https://github.com/grafana/tempo/pull/2165) (@mdisibio)
 * [ENHANCEMENT] Add option to override metrics-generator ring port  [#2399](https://github.com/grafana/tempo/pull/2399) (@mdisibio)
 * [BUGFIX] tempodb integer divide by zero error [#2167](https://github.com/grafana/tempo/issues/2167) (@kroksys)
+* [BUGFIX] Complete writing a batch even if some spans refused. [#1962](https://github.com/grafana/tempo/pull/1962)
 
 ## v2.1.1 / 2023-04-28
 * [BUGFIX] Fix issue where Tempo sometimes flips booleans from false->true at storage time. [#2400](https://github.com/grafana/tempo/issues/2400) (@joe-elliott)

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -146,8 +146,7 @@ func newInstance(instanceID string, limiter *Limiter, writer tempodb.Writer, l *
 func (i *instance) PushBytesRequest(ctx context.Context, req *tempopb.PushBytesRequest) error {
 	var errs []error
 	for j := range req.Traces {
-		err := i.PushBytes(ctx, req.Ids[j].Slice, req.Traces[j].Slice)
-		if err != nil {
+		if err := i.PushBytes(ctx, req.Ids[j].Slice, req.Traces[j].Slice); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/modules/ingester/instance_test.go
+++ b/modules/ingester/instance_test.go
@@ -561,10 +561,7 @@ func TestInstanceThrowsPartialErrorsForLargeTraces(t *testing.T) {
 
 	// large trace request 1
 	reqLargeTrace1 := makeRequestWithByteLimit(largeTraceSize, traceId)
-	reqLargeTrace1Size := 0
-	for _, b := range reqLargeTrace1.Traces {
-		reqLargeTrace1Size += len(b.Slice)
-	}
+	reqLargeTrace1Size := getPushBytesRequestSize(reqLargeTrace1)
 
 	// Fill up so that large traces can no longer be added
 	err = i.PushBytesRequest(ctx, reqLargeTrace1)
@@ -576,17 +573,11 @@ func TestInstanceThrowsPartialErrorsForLargeTraces(t *testing.T) {
 
 	// large trace request 2
 	reqLargeTrace2 := makeRequestWithByteLimit(largeTraceSize, traceId)
-	reqLargeTrace2Size := 0
-	for _, b := range reqLargeTrace2.Traces {
-		reqLargeTrace2Size += len(b.Slice)
-	}
+	reqLargeTrace2Size := getPushBytesRequestSize(reqLargeTrace2)
 
 	// smaller trace
 	reqSmallTrace := makeRequestWithByteLimit(smallTraceSize, traceId)
-	smallTraceReqSize := 0
-	for _, b := range reqSmallTrace.Traces {
-		smallTraceReqSize += len(b.Slice)
-	}
+	smallTraceReqSize := getPushBytesRequestSize(reqSmallTrace)
 
 	mergedRequest := mergePushBytesRequest([]tempopb.PushBytesRequest{*reqLargeTrace1, *reqLargeTrace2, *reqSmallTrace})
 
@@ -779,6 +770,16 @@ func makePushBytesRequest(traceID []byte, batch *v1_trace.ResourceSpans) *tempop
 			Slice: buffer,
 		}},
 	}
+}
+
+func getPushBytesRequestSize(request *tempopb.PushBytesRequest) int {
+	size := 0
+	if request != nil {
+		for _, b := range request.Traces {
+			size += len(b.Slice)
+		}
+	}
+	return size
 }
 
 func mergePushBytesRequest(requests []tempopb.PushBytesRequest) *tempopb.PushBytesRequest {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
* Currently if an ingester refuses traces b/c a trace is too large it will stop writing the current batch and return an error. The end result is that the first part of the batch was written but everything after the "trace too large" error is dropped.
* This tries to ingest all spans. Incase of failures, errors are collected, and returned at end after processing entire batch.

**Which issue(s) this PR fixes**:
Fixes #1957 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`