### PR TITLE
Remove mentions of synthetic-load-generator from example README

### DIFF
--- a/example/docker-compose/agent/readme.md
+++ b/example/docker-compose/agent/readme.md
@@ -13,12 +13,17 @@ At this point, the following containers should be spun up -
 docker-compose ps
 ```
 ```
-                  Name                                Command               State           Ports         
-----------------------------------------------------------------------------------------------------------
-agent_agent_1                      /bin/agent -config.file=/e ...   Up                            
-agent_grafana_1                    /run.sh                          Up      0.0.0.0:3000->3000/tcp
-agent_synthetic-load-generator_1   ./start.sh                       Up                            
-agent_tempo_1                      /tempo --target=all --mult ...   Up      0.0.0.0:8081->80/tcp  
+       Name                     Command               State                                Ports                              
+-----------------------------------------------------------------------------------------------------------
+agent_agent_1        /bin/agent -config.file=/e ...   Up                                                                      
+agent_grafana_1      /run.sh                          Up      0.0.0.0:3000->3000/tcp,:::3000->3000/tcp                        
+agent_k6-tracing_1   /k6-tracing run /example-s ...   Up                                                                      
+agent_prometheus_1   /bin/prometheus --config.f ...   Up      0.0.0.0:9090->9090/tcp,:::9090->9090/tcp                        
+agent_tempo_1        /tempo -config.file=/etc/t ...   Up      0.0.0.0:32768->14268/tcp,:::32768->14268/tcp,                   
+                                                              0.0.0.0:32772->3200/tcp,:::32772->3200/tcp,                     
+                                                              0.0.0.0:32771->4317/tcp,:::32771->4317/tcp,                     
+                                                              0.0.0.0:32770->4318/tcp,:::32770->4318/tcp,                     
+                                                              0.0.0.0:32769->9411/tcp,:::32769->9411/tcp 
 ```
 
 2. If you're interested you can see the wal/blocks as they are being created.
@@ -26,29 +31,10 @@ agent_tempo_1                      /tempo --target=all --mult ...   Up      0.0.
 ls tempo-data/
 ```
 
-3. The synthetic-load-generator is now printing out trace ids it's flushing into Tempo.  To view its logs use -
+3. Navigate to [Grafana](http://localhost:3000/explore) select the Tempo data source and use the "Search"
+tab to find traces.
 
-```console
-docker-compose logs -f synthetic-load-generator
-```
-```
-synthetic-load-generator_1  | 20/10/24 08:26:55 INFO ScheduledTraceGenerator: Emitted traceId 48367daf25266daa for service frontend route /currency
-synthetic-load-generator_1  | 20/10/24 08:26:55 INFO ScheduledTraceGenerator: Emitted traceId 10e50d2aca58d5e7 for service frontend route /cart
-synthetic-load-generator_1  | 20/10/24 08:26:55 INFO ScheduledTraceGenerator: Emitted traceId 51a4ac1638ee4c63 for service frontend route /shipping
-synthetic-load-generator_1  | 20/10/24 08:26:55 INFO ScheduledTraceGenerator: Emitted traceId 1219370c6a796a6d for service frontend route /product
-```
-
-Logs are in the form
-
-```
-Emitted traceId <traceid> for service frontend route /cart
-```
-
-Copy one of these trace ids.
-
-4. Navigate to [Grafana](http://localhost:3000/explore) and paste the trace id to request it from Tempo.
-
-5. To stop the setup use -
+4. To stop the setup use -
 
 ```console
 docker-compose down -v

--- a/example/docker-compose/azure/readme.md
+++ b/example/docker-compose/azure/readme.md
@@ -13,42 +13,26 @@ At this point, the following containers should be spun up -
 docker-compose ps
 ```
 ```
-                  Name                                 Command               State                         Ports
---------------------------------------------------------------------------------------------------------------------------------------
-azure_azure-cli_1                  az storage container creat ...   Exit 0
-azure_azurite_1                    docker-entrypoint.sh azuri ...   Up       0.0.0.0:10000->10000/tcp, 10001/tcp
-azure_grafana_1                    /run.sh                          Up       0.0.0.0:3000->3000/tcp
-azure_prometheus_1                 /bin/prometheus --config.f ...   Up       0.0.0.0:9090->9090/tcp
-azure_synthetic-load-generator_1   ./start.sh                       Up
-azure_tempo_1                      /tempo -config.file=/etc/t ...   Up       0.0.0.0:32768->14268/tcp, 0.0.0.0:3200->3200/tcp
+       Name                     Command               State                                 Ports                             
+------------------------------------------------------------------------------------------------------------------------------
+azure_azure-cli_1    az storage container creat ...   Exit 0                                                                  
+azure_azurite_1      docker-entrypoint.sh azuri ...   Up       0.0.0.0:10000->10000/tcp,:::10000->10000/tcp, 10001/tcp,       
+                                                               10002/tcp                                                      
+azure_grafana_1      /run.sh                          Up       0.0.0.0:3000->3000/tcp,:::3000->3000/tcp                       
+azure_k6-tracing_1   /k6-tracing run /example-s ...   Up                                                                      
+azure_prometheus_1   /bin/prometheus --config.f ...   Up       0.0.0.0:9090->9090/tcp,:::9090->9090/tcp                       
+azure_tempo_1        /tempo -config.file=/etc/t ...   Up       0.0.0.0:32779->14268/tcp,:::32779->14268/tcp,                  
+                                                               0.0.0.0:3200->3200/tcp,:::3200->3200/tcp   
 ```
 
-2. If you're interested you can see the wal/blocks as they are being created.  Check [Azure Storage Explorer](https://azure.microsoft.com/en-us/features/storage-explorer/) and [Azurite docs](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azurite).
+2. If you're interested you can see the wal/blocks as they are being created.  Check [Azure Storage Explorer](https://azure.microsoft.com/en-us/features/storage-explorer/) 
+and [Azurite docs](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azurite).
+   
+3. Navigate to [Grafana](http://localhost:3000/explore) select the Tempo data source and use the "Search"
+tab to find traces. Also notice that you can query Tempo metrics from the Prometheus data source setup in 
+Grafana.
 
-3. The synthetic-load-generator is now printing out trace ids it's flushing into Tempo.  To view its logs use -
-
-```console
-docker-compose logs -f synthetic-load-generator
-```
-```
-synthetic-load-generator_1  | 20/10/24 08:26:55 INFO ScheduledTraceGenerator: Emitted traceId 48367daf25266daa for service frontend route /currency
-synthetic-load-generator_1  | 20/10/24 08:26:55 INFO ScheduledTraceGenerator: Emitted traceId 10e50d2aca58d5e7 for service frontend route /cart
-synthetic-load-generator_1  | 20/10/24 08:26:55 INFO ScheduledTraceGenerator: Emitted traceId 51a4ac1638ee4c63 for service frontend route /shipping
-synthetic-load-generator_1  | 20/10/24 08:26:55 INFO ScheduledTraceGenerator: Emitted traceId 1219370c6a796a6d for service frontend route /product
-```
-
-Logs are in the form
-
-```
-Emitted traceId <traceid> for service frontend route /cart
-```
-
-Copy one of these trace ids.
-
-4. Navigate to [Grafana](http://localhost:3000/explore) and paste the trace id to request it from Tempo.
-Also notice that you can query Tempo metrics from the Prometheus data source setup in Grafana.
-
-5. To stop the setup use -
+4. To stop the setup use -
 
 ```console
 docker-compose down -v

--- a/example/docker-compose/distributed/readme.md
+++ b/example/docker-compose/distributed/readme.md
@@ -16,48 +16,29 @@ At this point, the following containers should be spun up -
 docker-compose ps
 ```
 ```
-                 Name                               Command               State                         Ports                       
-------------------------------------------------------------------------------------------------------------------------------------
-distributed_compactor_1                  /tempo -target=compactor - ...   Up      0.0.0.0:49662->3200/tcp,:::49652->3200/tcp        
-distributed_distributor_1                /tempo -target=distributor ...   Up      0.0.0.0:49659->3200/tcp,:::49649->3200/tcp        
-distributed_grafana_1                    /run.sh                          Up      0.0.0.0:3000->3000/tcp,:::3000->3000/tcp          
-distributed_ingester-0_1                 /tempo -target=ingester -c ...   Up      0.0.0.0:49663->3200/tcp,:::49653->3200/tcp        
-distributed_ingester-1_1                 /tempo -target=ingester -c ...   Up      0.0.0.0:49660->3200/tcp,:::49650->3200/tcp        
-distributed_ingester-2_1                 /tempo -target=ingester -c ...   Up      0.0.0.0:49665->3200/tcp,:::49655->3200/tcp        
-distributed_minio_1                      sh -euc mkdir -p /data/tem ...   Up      9000/tcp, 0.0.0.0:9001->9001/tcp,:::9001->9001/tcp
-distributed_prometheus_1                 /bin/prometheus --config.f ...   Up      0.0.0.0:9090->9090/tcp,:::9090->9090/tcp          
-distributed_querier_1                    /tempo -target=querier -co ...   Up      0.0.0.0:49664->3200/tcp,:::49654->3200/tcp        
-distributed_query-frontend_1             /tempo -target=query-front ...   Up      0.0.0.0:49661->3200/tcp,:::49651->3200/tcp        
-distributed_synthetic-load-generator_1   ./start.sh                       Up                                                        
+             Name                            Command               State                         Ports                       
+------------------------------------------------------------------------------------------------------------------------
+distributed_compactor_1           /tempo -target=compactor - ...   Up      0.0.0.0:32785->3200/tcp,:::32785->3200/tcp        
+distributed_distributor_1         /tempo -target=distributor ...   Up      0.0.0.0:32787->3200/tcp,:::32787->3200/tcp        
+distributed_grafana_1             /run.sh                          Up      0.0.0.0:3000->3000/tcp,:::3000->3000/tcp          
+distributed_ingester-0_1          /tempo -target=ingester -c ...   Up      0.0.0.0:32789->3200/tcp,:::32789->3200/tcp        
+distributed_ingester-1_1          /tempo -target=ingester -c ...   Up      0.0.0.0:32783->3200/tcp,:::32783->3200/tcp        
+distributed_ingester-2_1          /tempo -target=ingester -c ...   Up      0.0.0.0:32784->3200/tcp,:::32784->3200/tcp        
+distributed_k6-tracing_1          /k6-tracing run /example-s ...   Up                                                        
+distributed_metrics-generator_1   /tempo -target=metrics-gen ...   Up      0.0.0.0:32790->3200/tcp,:::32790->3200/tcp        
+distributed_minio_1               sh -euc mkdir -p /data/tem ...   Up      9000/tcp, 0.0.0.0:9001->9001/tcp,:::9001->9001/tcp
+distributed_prometheus_1          /bin/prometheus --config.f ...   Up      0.0.0.0:9090->9090/tcp,:::9090->9090/tcp          
+distributed_querier_1             /tempo -target=querier -co ...   Up      0.0.0.0:32788->3200/tcp,:::32788->3200/tcp        
+distributed_query-frontend_1      /tempo -target=query-front ...   Up      0.0.0.0:3200->3200/tcp,:::3200->3200/tcp
 ```
 
 2. If you're interested you can see the wal/blocks as they are being created.  Navigate to minio at
 http://localhost:9001 and use the username/password of `tempo`/`supersecret`.
 
-3. The synthetic-load-generator is now printing out trace ids it's flushing into Tempo.  To view its logs use -
+3. Navigate to [Grafana](http://localhost:3000/explore) select the Tempo data source and use the "Search"
+tab to find traces.
 
-```console
-docker-compose logs -f synthetic-load-generator
-```
-```
-synthetic-load-generator_1  | 20/10/24 08:27:09 INFO ScheduledTraceGenerator: Emitted traceId 57aedb829f352625 for service frontend route /product
-synthetic-load-generator_1  | 20/10/24 08:27:09 INFO ScheduledTraceGenerator: Emitted traceId 25fa96b9da24b23f for service frontend route /cart
-synthetic-load-generator_1  | 20/10/24 08:27:09 INFO ScheduledTraceGenerator: Emitted traceId 15b3ad814b77b779 for service frontend route /shipping
-synthetic-load-generator_1  | 20/10/24 08:27:09 INFO ScheduledTraceGenerator: Emitted traceId 3803db7d7d848a1a for service frontend route /checkout
-```
-
-Logs are in the form
-
-```
-Emitted traceId <traceid> for service frontend route /cart
-```
-
-Copy one of these trace ids.
-
-4. Navigate to [Grafana](http://localhost:3000/explore) and paste the trace id to request it from Tempo.
-Also notice that you can query Tempo metrics from the Prometheus data source setup in Grafana.
-
-5. To stop the setup use -
+4. To stop the setup use -
 
 ```console
 docker-compose down -v

--- a/example/docker-compose/gcs/readme.md
+++ b/example/docker-compose/gcs/readme.md
@@ -13,42 +13,24 @@ At this point, the following containers should be spun up -
 docker-compose ps
 ```
 ```
-                  Name                                Command               State                        Ports
-------------------------------------------------------------------------------------------------------------------------------------
-gcs_gcs_1                        /bin/fake-gcs-server -data ...   Up      0.0.0.0:4443->4443/tcp
-gcs_grafana_1                    /run.sh                          Up      0.0.0.0:3000->3000/tcp
-gcs_prometheus_1                 /bin/prometheus --config.f ...   Up      0.0.0.0:9090->9090/tcp
-gcs_synthetic-load-generator_1   ./start.sh                       Up
-gcs_tempo_1                      /tempo -config.file=/etc/t ...   Up      0.0.0.0:59543->14268/tcp, 0.0.0.0:3200->3200/tcp
+      Name                    Command               State                                 Ports                               
+--------------------------------------------------------------------------------------------------------
+gcs_gcs_1          /bin/fake-gcs-server -data ...   Up      0.0.0.0:4443->4443/tcp,:::4443->4443/tcp                          
+gcs_grafana_1      /run.sh                          Up      0.0.0.0:3000->3000/tcp,:::3000->3000/tcp                          
+gcs_k6-tracing_1   /k6-tracing run /example-s ...   Up                                                                        
+gcs_prometheus_1   /bin/prometheus --config.f ...   Up      0.0.0.0:9090->9090/tcp,:::9090->9090/tcp                          
+gcs_tempo_1        /tempo -config.file=/etc/t ...   Up      0.0.0.0:32791->14268/tcp,:::32791->14268/tcp,                     
+                                                            0.0.0.0:3200->3200/tcp,:::3200->3200/tcp
 ```
 
 2. If you're interested you can kind of see the wal/blocks as they are being created. Navigate to https://localhost:4443/storage/v1/b/tempo/o
 to get a dump of all objects in the bucket.
 
-3. The synthetic-load-generator is now printing out trace ids it's flushing into Tempo.  To view its logs use -
+3. Navigate to [Grafana](http://localhost:3000/explore) select the Tempo data source and use the "Search"
+tab to find traces. Also notice that you can query Tempo metrics from the Prometheus data source setup in 
+Grafana.
 
-```console
-docker-compose logs -f synthetic-load-generator
-```
-```
-synthetic-load-generator_1  | 20/10/24 08:26:55 INFO ScheduledTraceGenerator: Emitted traceId 48367daf25266daa for service frontend route /currency
-synthetic-load-generator_1  | 20/10/24 08:26:55 INFO ScheduledTraceGenerator: Emitted traceId 10e50d2aca58d5e7 for service frontend route /cart
-synthetic-load-generator_1  | 20/10/24 08:26:55 INFO ScheduledTraceGenerator: Emitted traceId 51a4ac1638ee4c63 for service frontend route /shipping
-synthetic-load-generator_1  | 20/10/24 08:26:55 INFO ScheduledTraceGenerator: Emitted traceId 1219370c6a796a6d for service frontend route /product
-```
-
-Logs are in the form
-
-```
-Emitted traceId <traceid> for service frontend route /cart
-```
-
-Copy one of these trace ids.
-
-4. Navigate to [Grafana](http://localhost:3000/explore) and paste the trace id to request it from Tempo.
-Also notice that you can query Tempo metrics from the Prometheus data source setup in Grafana.
-
-5. To stop the setup use -
+4. To stop the setup use -
 
 ```console
 docker-compose down -v

--- a/example/docker-compose/local/readme.md
+++ b/example/docker-compose/local/readme.md
@@ -14,12 +14,16 @@ At this point, the following containers should be spun up -
 docker-compose ps
 ```
 ```
-                  Name                                 Command               State                         Ports
---------------------------------------------------------------------------------------------------------------------------------------
-docker-compose_grafana_1                    /run.sh                          Up      0.0.0.0:3000->3000/tcp
-docker-compose_prometheus_1                 /bin/prometheus --config.f ...   Up      0.0.0.0:9090->9090/tcp
-docker-compose_synthetic-load-generator_1   ./start.sh                       Up
-docker-compose_tempo_1                      /tempo -storage.trace.back ...   Up      0.0.0.0:32772->14268/tcp, 0.0.0.0:32773->3200/tcp
+       Name                     Command               State                                   Ports                                 
+-----------------------------------------------------------------------------------------------------------
+local_grafana_1      /run.sh                          Up      0.0.0.0:3000->3000/tcp,:::3000->3000/tcp                              
+local_k6-tracing_1   /k6-tracing run /example-s ...   Up                                                                            
+local_prometheus_1   /bin/prometheus --config.f ...   Up      0.0.0.0:9090->9090/tcp,:::9090->9090/tcp                              
+local_tempo_1        /tempo -config.file=/etc/t ...   Up      0.0.0.0:14268->14268/tcp,:::14268->14268/tcp,                         
+                                                              0.0.0.0:3200->3200/tcp,:::3200->3200/tcp,                             
+                                                              0.0.0.0:4317->4317/tcp,:::4317->4317/tcp,                             
+                                                              0.0.0.0:4318->4318/tcp,:::4318->4318/tcp,                             
+                                                              0.0.0.0:9411->9411/tcp,:::9411->9411/tcp 
 ```
 
 2. If you're interested you can see the wal/blocks as they are being created.
@@ -28,30 +32,11 @@ docker-compose_tempo_1                      /tempo -storage.trace.back ...   Up 
 ls tempo-data/
 ```
 
-3. The synthetic-load-generator is now printing out trace ids it's flushing into Tempo.  To view its logs use -
+3. Navigate to [Grafana](http://localhost:3000/explore) select the Tempo data source and use the "Search"
+tab to find traces. Also notice that you can query Tempo metrics from the Prometheus data source setup in
+Grafana.
 
-```console
-docker-compose logs -f synthetic-load-generator
-```
-```
-synthetic-load-generator_1  | 20/10/24 08:27:09 INFO ScheduledTraceGenerator: Emitted traceId 57aedb829f352625 for service frontend route /product
-synthetic-load-generator_1  | 20/10/24 08:27:09 INFO ScheduledTraceGenerator: Emitted traceId 25fa96b9da24b23f for service frontend route /cart
-synthetic-load-generator_1  | 20/10/24 08:27:09 INFO ScheduledTraceGenerator: Emitted traceId 15b3ad814b77b779 for service frontend route /shipping
-synthetic-load-generator_1  | 20/10/24 08:27:09 INFO ScheduledTraceGenerator: Emitted traceId 3803db7d7d848a1a for service frontend route /checkout
-```
-
-Logs are in the form
-
-```
-Emitted traceId <traceid> for service frontend route /cart
-```
-
-Copy one of these trace ids.
-
-4. Navigate to [Grafana](http://localhost:3000/explore) and paste the trace id to request it from Tempo.
-Also notice that you can query Tempo metrics from the Prometheus data source setup in Grafana.
-
-5. To stop the setup use -
+4. To stop the setup use -
 
 ```console
 docker-compose down -v

--- a/example/docker-compose/loki/readme.md
+++ b/example/docker-compose/loki/readme.md
@@ -29,8 +29,9 @@ loki_prometheus_1    /bin/prometheus --config.f ...   Up      0.0.0.0:9090->9090
 loki_tempo_1         /tempo -storage.trace.back ...   Up      0.0.0.0:32774->14268/tcp
 ```
 
-3. Navigate to [Grafana](http://localhost:3000/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Loki%22,%7B%7D%5D) and **query Loki a few times to generate some traces** (this setup does not use the synthetic load generator and all traces are generated from Loki).
-Something like the below works, but feel free to explore other options!
+3. Navigate to [Grafana](http://localhost:3000/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Loki%22,%7B%7D%5D) 
+and **query Loki a few times to generate some traces** (this setup does not use the xk6-client-tracing and all traces 
+are generated from Loki). Something like the below works, but feel free to explore other options!
 
 ```
 {container_name="loki_loki_1"}

--- a/example/docker-compose/otel-collector-multitenant/readme.md
+++ b/example/docker-compose/otel-collector-multitenant/readme.md
@@ -13,12 +13,17 @@ At this point, the following containers should be spun up -
 docker-compose ps
 ```
 ```
-                  Name                                Command               State           Ports         
-----------------------------------------------------------------------------------------------------------
-otel-collector-multitenant_grafana_1                    /run.sh                          Up      0.0.0.0:3000->3000/tcp
-otel-collector-multitenant_otel-collector_1             /otelcol --config=/etc/ote ...   Up      55678/tcp, 55679/tcp  
-otel-collector-multitenant_synthetic-load-generator_1   ./start.sh                       Up                            
-otel-collector-multitenant_tempo_1                      /tempo --target=all --mult ...   Up      0.0.0.0:8081->80/tcp  
+                   Name                                  Command               State                          Ports                        
+-----------------------------------------------------------------------------------------------------------------------------------
+otel-collector-multitenant_grafana_1          /run.sh                          Up      0.0.0.0:3000->3000/tcp,:::3000->3000/tcp            
+otel-collector-multitenant_k6-tracing_1       /k6-tracing run /example-s ...   Up                                                          
+otel-collector-multitenant_otel-collector_1   /otelcol --config=/etc/ote ...   Up      4317/tcp, 55678/tcp, 55679/tcp                      
+otel-collector-multitenant_prometheus_1       /bin/prometheus --config.f ...   Up      0.0.0.0:9090->9090/tcp,:::9090->9090/tcp            
+otel-collector-multitenant_tempo_1            /tempo -multitenancy.enabl ...   Up      0.0.0.0:32802->14268/tcp,:::32802->14268/tcp,       
+                                                                                       0.0.0.0:32806->3200/tcp,:::32806->3200/tcp,         
+                                                                                       0.0.0.0:32805->4317/tcp,:::32805->4317/tcp,         
+                                                                                       0.0.0.0:32804->4318/tcp,:::32804->4318/tcp,         
+                                                                                       0.0.0.0:32803->9411/tcp,:::32803->9411/tcp  
 ```
 
 2. If you're interested you can see the wal/blocks as they are being created.
@@ -26,29 +31,11 @@ otel-collector-multitenant_tempo_1                      /tempo --target=all --mu
 ls tempo-data/
 ```
 
-3. The synthetic-load-generator is now printing out trace ids it's flushing into Tempo.  To view its logs use -
+3. Navigate to [Grafana](http://localhost:3000/explore) select the Tempo data source and use the "Search"
+tab to find traces. Also notice that you can query Tempo metrics from the Prometheus data source setup in
+Grafana.
 
-```console
-docker-compose logs -f synthetic-load-generator
-```
-```
-synthetic-load-generator_1  | 20/10/24 08:26:55 INFO ScheduledTraceGenerator: Emitted traceId 48367daf25266daa for service frontend route /currency
-synthetic-load-generator_1  | 20/10/24 08:26:55 INFO ScheduledTraceGenerator: Emitted traceId 10e50d2aca58d5e7 for service frontend route /cart
-synthetic-load-generator_1  | 20/10/24 08:26:55 INFO ScheduledTraceGenerator: Emitted traceId 51a4ac1638ee4c63 for service frontend route /shipping
-synthetic-load-generator_1  | 20/10/24 08:26:55 INFO ScheduledTraceGenerator: Emitted traceId 1219370c6a796a6d for service frontend route /product
-```
-
-Logs are in the form
-
-```
-Emitted traceId <traceid> for service frontend route /cart
-```
-
-Copy one of these trace ids.
-
-4. Navigate to [Grafana](http://localhost:3000/explore) and paste the trace id to request it from Tempo. Note that you are using the "Tempo-Multitenant" datasource which includes a special header to select the tenant.
-
-5. To stop the setup use -
+4. To stop the setup use -
 
 ```console
 docker-compose down -v

--- a/example/docker-compose/otel-collector/readme.md
+++ b/example/docker-compose/otel-collector/readme.md
@@ -13,14 +13,17 @@ At this point, the following containers should be spun up -
 docker-compose ps
 ```
 ```
-                  Name                                Command               State           Ports
-----------------------------------------------------------------------------------------------------------
-otel-collector_grafana_1                    /run.sh                          Up      0.0.0.0:3000->3000/tcp
-otel-collector_otel-collector_1             /otelcol --config=/etc/ote ...   Up      55678/tcp, 55679/tcp
-otel-collector_synthetic-load-generator_1   ./start.sh                       Up
-otel-collector_tempo_1                      /tempo -config.file=/etc/t ...   Up      0.0.0.0:59538->14268/tcp, 0.0.0.0:59540->3200/tcp,
-                                                                                    0.0.0.0:59537->4317/tcp, 0.0.0.0:59536->4318/tcp,
-                                                                                    0.0.0.0:59539->9411/tcp
+             Name                            Command               State                          Ports                       
+----------------------------------------------------------------------------------------------------------------------
+otel-collector_grafana_1          /run.sh                          Up      0.0.0.0:3000->3000/tcp,:::3000->3000/tcp           
+otel-collector_k6-tracing_1       /k6-tracing run /example-s ...   Up                                                         
+otel-collector_otel-collector_1   /otelcol --config=/etc/ote ...   Up      4317/tcp, 55678/tcp, 55679/tcp                     
+otel-collector_prometheus_1       /bin/prometheus --config.f ...   Up      0.0.0.0:9090->9090/tcp,:::9090->9090/tcp           
+otel-collector_tempo_1            /tempo -config.file=/etc/t ...   Up      0.0.0.0:32792->14268/tcp,:::32792->14268/tcp,      
+                                                                           0.0.0.0:32796->3200/tcp,:::32796->3200/tcp,        
+                                                                           0.0.0.0:32795->4317/tcp,:::32795->4317/tcp,        
+                                                                           0.0.0.0:32794->4318/tcp,:::32794->4318/tcp,        
+                                                                           0.0.0.0:32793->9411/tcp,:::32793->9411/tcp 
 ```
 
 2. If you're interested you can see the wal/blocks as they are being created.
@@ -29,29 +32,11 @@ otel-collector_tempo_1                      /tempo -config.file=/etc/t ...   Up 
 ls tempo-data/
 ```
 
-3. The synthetic-load-generator is now printing out trace ids it's flushing into Tempo.  To view its logs use -
+3. Navigate to [Grafana](http://localhost:3000/explore) select the Tempo data source and use the "Search"
+tab to find traces. Also notice that you can query Tempo metrics from the Prometheus data source setup in
+Grafana.
 
-```console
-docker-compose logs -f synthetic-load-generator
-```
-```
-synthetic-load-generator_1  | 20/10/24 08:26:55 INFO ScheduledTraceGenerator: Emitted traceId 48367daf25266daa for service frontend route /currency
-synthetic-load-generator_1  | 20/10/24 08:26:55 INFO ScheduledTraceGenerator: Emitted traceId 10e50d2aca58d5e7 for service frontend route /cart
-synthetic-load-generator_1  | 20/10/24 08:26:55 INFO ScheduledTraceGenerator: Emitted traceId 51a4ac1638ee4c63 for service frontend route /shipping
-synthetic-load-generator_1  | 20/10/24 08:26:55 INFO ScheduledTraceGenerator: Emitted traceId 1219370c6a796a6d for service frontend route /product
-```
-
-Logs are in the form
-
-```
-Emitted traceId <traceid> for service frontend route /cart
-```
-
-Copy one of these trace ids.
-
-4. Navigate to [Grafana](http://localhost:3000/explore) and paste the trace id to request it from Tempo.
-
-5. To stop the setup use -
+4. To stop the setup use -
 
 ```console
 docker-compose down -v

--- a/example/docker-compose/s3/readme.md
+++ b/example/docker-compose/s3/readme.md
@@ -14,42 +14,24 @@ At this point, the following containers should be spun up -
 docker-compose ps
 ```
 ```
-                  Name                                 Command               State                        Ports
--------------------------------------------------------------------------------------------------------------------------------------
-s3_grafana_1                    /run.sh                          Up      0.0.0.0:3000->3000/tcp
-s3_minio_1                      sh -euc mkdir -p /data/tem ...   Up      0.0.0.0:9001->9001/tcp
-s3_prometheus_1                 /bin/prometheus --config.f ...   Up      0.0.0.0:9090->9090/tcp
-s3_synthetic-load-generator_1   ./start.sh                       Up
-s3_tempo_1                      /tempo -config.file=/etc/t ...   Up      0.0.0.0:32770->14268/tcp, 0.0.0.0:3200->3200/tcp
+     Name                    Command               State                                  Ports                               
+------------------------------------------------------------------------------------------------------------------------------
+s3_grafana_1      /run.sh                          Up      0.0.0.0:3000->3000/tcp,:::3000->3000/tcp                           
+s3_k6-tracing_1   /k6-tracing run /example-s ...   Up                                                                         
+s3_minio_1        sh -euc mkdir -p /data/tem ...   Up      9000/tcp, 0.0.0.0:9001->9001/tcp,:::9001->9001/tcp                 
+s3_prometheus_1   /bin/prometheus --config.f ...   Up      0.0.0.0:9090->9090/tcp,:::9090->9090/tcp                           
+s3_tempo_1        /tempo -config.file=/etc/t ...   Up      0.0.0.0:32807->14268/tcp,:::32807->14268/tcp,                      
+                                                           0.0.0.0:3200->3200/tcp,:::3200->3200/tcp 
 ```
 
 2. If you're interested you can see the wal/blocks as they are being created.  Navigate to minio at
 http://localhost:9001 and use the username/password of `tempo`/`supersecret`.
 
-3. The synthetic-load-generator is now printing out trace ids it's flushing into Tempo.  To view its logs use -
+3. Navigate to [Grafana](http://localhost:3000/explore) select the Tempo data source and use the "Search"
+tab to find traces. Also notice that you can query Tempo metrics from the Prometheus data source setup in
+Grafana.
 
-```console
-docker-compose logs -f synthetic-load-generator
-```
-```
-synthetic-load-generator_1  | 20/10/24 08:26:55 INFO ScheduledTraceGenerator: Emitted traceId 48367daf25266daa for service frontend route /currency
-synthetic-load-generator_1  | 20/10/24 08:26:55 INFO ScheduledTraceGenerator: Emitted traceId 10e50d2aca58d5e7 for service frontend route /cart
-synthetic-load-generator_1  | 20/10/24 08:26:55 INFO ScheduledTraceGenerator: Emitted traceId 51a4ac1638ee4c63 for service frontend route /shipping
-synthetic-load-generator_1  | 20/10/24 08:26:55 INFO ScheduledTraceGenerator: Emitted traceId 1219370c6a796a6d for service frontend route /product
-```
-
-Logs are in the form
-
-```
-Emitted traceId <traceid> for service frontend route /cart
-```
-
-Copy one of these trace ids.
-
-4. Navigate to [Grafana](http://localhost:3000/explore) and paste the trace id to request it from Tempo.
-Also notice that you can query Tempo metrics from the Prometheus data source setup in Grafana.
-
-5. To stop the setup use -
+4. To stop the setup use -
 
 ```console
 docker-compose down -v

--- a/example/docker-compose/scalable-single-binary/readme.md
+++ b/example/docker-compose/scalable-single-binary/readme.md
@@ -19,44 +19,27 @@ At this point, the following containers should be spun up -
 docker-compose ps
 ```
 ```
-NAME                                                COMMAND                  SERVICE                    STATUS              PORTS
-scalable-single-binary-grafana-1                    "/run.sh"                grafana                    running             3000/tcp
-scalable-single-binary-minio-1                      "sh -euc 'mkdir -p /…"   minio                      running             9000/tcp
-scalable-single-binary-prometheus-1                 "/bin/prometheus --c…"   prometheus                 running             9090/tcp
-scalable-single-binary-synthetic-load-generator-1   "./start.sh"             synthetic-load-generator   running             
-scalable-single-binary-tempo1-1                     "/tempo -target=scal…"   tempo1                     running             
-scalable-single-binary-tempo2-1                     "/tempo -target=scal…"   tempo2                     running             
-scalable-single-binary-tempo3-1                     "/tempo -target=scal…"   tempo3                     running             
-scalable-single-binary-vulture-1                    "/tempo-vulture -pro…"   vulture                    running
+               Name                              Command               State                        Ports                     
+------------------------------------------------------------------------------------------------------------------------------
+scalable-single-binary_grafana_1      /run.sh                          Up      0.0.0.0:3000->3000/tcp,:::3000->3000/tcp       
+scalable-single-binary_k6-tracing_1   /k6-tracing run /example-s ...   Up                                                     
+scalable-single-binary_minio_1        sh -euc mkdir -p /data/tem ...   Up      9000/tcp,                                      
+                                                                               0.0.0.0:9001->9001/tcp,:::9001->9001/tcp       
+scalable-single-binary_prometheus_1   /bin/prometheus --config.f ...   Up      9090/tcp                                       
+scalable-single-binary_tempo1_1       /tempo -target=scalable-si ...   Up      0.0.0.0:3200->3200/tcp,:::3200->3200/tcp       
+scalable-single-binary_tempo2_1       /tempo -target=scalable-si ...   Up                                                     
+scalable-single-binary_tempo3_1       /tempo -target=scalable-si ...   Up                                                     
+scalable-single-binary_vulture_1      /tempo-vulture -prometheus ...   Up 
 ```
 
 2. If you're interested you can see the WAL/blocks as they are being created.  Navigate to MinIO at
 http://localhost:9001 and use the username/password of `tempo`/`supersecret`.
 
-3. The synthetic-load-generator is now printing out trace IDs it's flushing into Tempo.  To view its logs use -
+3. Navigate to [Grafana](http://localhost:3000/explore) select the Tempo data source and use the "Search"
+tab to find traces. Also notice that you can query Tempo metrics from the Prometheus data source setup in
+Grafana.
 
-```console
-docker-compose logs -f synthetic-load-generator
-```
-```
-synthetic-load-generator_1  | 20/10/24 08:27:09 INFO ScheduledTraceGenerator: Emitted traceId 57aedb829f352625 for service frontend route /product
-synthetic-load-generator_1  | 20/10/24 08:27:09 INFO ScheduledTraceGenerator: Emitted traceId 25fa96b9da24b23f for service frontend route /cart
-synthetic-load-generator_1  | 20/10/24 08:27:09 INFO ScheduledTraceGenerator: Emitted traceId 15b3ad814b77b779 for service frontend route /shipping
-synthetic-load-generator_1  | 20/10/24 08:27:09 INFO ScheduledTraceGenerator: Emitted traceId 3803db7d7d848a1a for service frontend route /checkout
-```
-
-Logs are in the form
-
-```
-Emitted traceId <traceid> for service frontend route /cart
-```
-
-Copy one of these trace IDs.
-
-4. Navigate to [Grafana](http://localhost:3000/explore) and paste the trace ID to request it from Tempo.
-Also notice that you can query Tempo metrics from the Prometheus data source setup in Grafana.
-
-5. To stop the setup use:
+4. To stop the setup use -
 
 ```console
 docker-compose down -v


### PR DESCRIPTION
**What this PR does**:

Example README files still mentioned the synthetic-load-generator which is no longer used in most examples. I also regenerated the output of `docker-compose ps` as it also looks quite different now in some cases.

**Which issue(s) this PR fixes**:
None, I just noticed this while working on the debug example.

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`