### PR TITLE
TraceQL: Fix bug trying to optimize queries using only && and repeated attribute name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ Internal types are updated to use `scope` instead of `instrumentation_library`. 
 * [BUGFIX] Fix docker-compose examples not running on Apple M1 hardware [#1920](https://github.com/grafana/tempo/pull/1920) (@stoewer)
 * [BUGFIX] Fix traceql parsing of most binary operations to not require spacing [#1939](https://github.com/grafana/tempo/pull/1941) (@mdisibio)
 * [BUGFIX] Don't persist tenants without blocks in the ingester[#1947](https://github.com/grafana/tempo/pull/1947) (@joe-elliott)
+* [BUGFIX] TraceQL: span scope not working with ranges [#1948](https://github.com/grafana/tempo/issues/1948) (@mdisibio)
 
 ## v1.5.0 / 2022-08-17
 

--- a/pkg/traceql/storage.go
+++ b/pkg/traceql/storage.go
@@ -74,11 +74,13 @@ func MustExtractFetchSpansRequest(query string) FetchSpansRequest {
 // ExtractFetchSpansRequest parses the given traceql query and returns
 // the storage layer conditions. Returns an error if the query fails to parse.
 func ExtractFetchSpansRequest(query string) (FetchSpansRequest, error) {
-	req := FetchSpansRequest{}
-
 	ast, err := Parse(query)
 	if err != nil {
-		return req, err
+		return FetchSpansRequest{}, err
+	}
+
+	req := FetchSpansRequest{
+		AllConditions: true,
 	}
 
 	ast.Pipeline.extractConditions(&req)

--- a/pkg/traceql/storage.go
+++ b/pkg/traceql/storage.go
@@ -61,26 +61,28 @@ type SpansetFetcher interface {
 	Fetch(context.Context, FetchSpansRequest) (FetchSpansResponse, error)
 }
 
-// MustExtractConditions parses the given traceql query and returns
+// MustExtractFetchSpansRequest parses the given traceql query and returns
 // the storage layer conditions. Panics if the query fails to parse.
-func MustExtractConditions(query string) []Condition {
-	c, err := ExtractConditions(query)
+func MustExtractFetchSpansRequest(query string) FetchSpansRequest {
+	c, err := ExtractFetchSpansRequest(query)
 	if err != nil {
 		panic(err)
 	}
 	return c
 }
 
-// ExtractConditions parses the given traceql query and returns
+// ExtractFetchSpansRequest parses the given traceql query and returns
 // the storage layer conditions. Returns an error if the query fails to parse.
-func ExtractConditions(query string) (cond []Condition, err error) {
+func ExtractFetchSpansRequest(query string) (FetchSpansRequest, error) {
+	req := FetchSpansRequest{}
+
 	ast, err := Parse(query)
 	if err != nil {
-		return cond, err
+		return req, err
 	}
-	req := &FetchSpansRequest{}
-	ast.Pipeline.extractConditions(req)
-	return req.Conditions, nil
+
+	ast.Pipeline.extractConditions(&req)
+	return req, nil
 }
 
 type SpansetFetcherWrapper struct {

--- a/tempodb/encoding/vparquet/block_traceql.go
+++ b/tempodb/encoding/vparquet/block_traceql.go
@@ -472,7 +472,12 @@ func createSpanIterator(makeIter makeIterFn, conditions []traceql.Condition, sta
 		minCount = 1
 	}
 	if allConditions {
-		minCount = len(conditions)
+		// The final number of expected attributes.
+		distinct := map[string]struct{}{}
+		for _, cond := range conditions {
+			distinct[cond.Attribute.Name] = struct{}{}
+		}
+		minCount = len(distinct)
 	}
 	spanCol := &spanCollector{
 		minCount,
@@ -562,7 +567,12 @@ func createResourceIterator(makeIter makeIterFn, spanIterator parquetquery.Itera
 		minCount = 1
 	}
 	if allConditions {
-		minCount = len(conditions)
+		// The final number of expected attributes
+		distinct := map[string]struct{}{}
+		for _, cond := range conditions {
+			distinct[cond.Attribute.Name] = struct{}{}
+		}
+		minCount = len(distinct)
 	}
 	batchCol := &batchCollector{
 		requireAtLeastOneMatchOverall,

--- a/tempodb/encoding/vparquet/block_traceql_test.go
+++ b/tempodb/encoding/vparquet/block_traceql_test.go
@@ -32,61 +32,61 @@ func TestBackendBlockSearchTraceQL(t *testing.T) {
 			EndTimeUnixNanos:   uint64(102 * time.Second),
 		},
 		// Intrinsics
-		makeReq(parse(t, `{`+LabelName+` = "hello"}`)),
-		makeReq(parse(t, `{`+LabelDuration+` =  100s}`)),
-		makeReq(parse(t, `{`+LabelDuration+` >  99s}`)),
-		makeReq(parse(t, `{`+LabelDuration+` >= 100s}`)),
-		makeReq(parse(t, `{`+LabelDuration+` <  101s}`)),
-		makeReq(parse(t, `{`+LabelDuration+` <= 100s}`)),
-		makeReq(parse(t, `{`+LabelDuration+` <= 100s}`)),
-		makeReq(parse(t, `{`+LabelStatus+` = error}`)),
-		makeReq(parse(t, `{`+LabelStatus+` = 2}`)),
+		traceql.MustExtractFetchSpansRequest(`{` + LabelName + ` = "hello"}`),
+		traceql.MustExtractFetchSpansRequest(`{` + LabelDuration + ` =  100s}`),
+		traceql.MustExtractFetchSpansRequest(`{` + LabelDuration + ` >  99s}`),
+		traceql.MustExtractFetchSpansRequest(`{` + LabelDuration + ` >= 100s}`),
+		traceql.MustExtractFetchSpansRequest(`{` + LabelDuration + ` <  101s}`),
+		traceql.MustExtractFetchSpansRequest(`{` + LabelDuration + ` <= 100s}`),
+		traceql.MustExtractFetchSpansRequest(`{` + LabelDuration + ` <= 100s}`),
+		traceql.MustExtractFetchSpansRequest(`{` + LabelStatus + ` = error}`),
+		traceql.MustExtractFetchSpansRequest(`{` + LabelStatus + ` = 2}`),
 		// Resource well-known attributes
-		makeReq(parse(t, `{.`+LabelServiceName+` = "spanservicename"}`)), // Overridden at span
-		makeReq(parse(t, `{.`+LabelCluster+` = "cluster"}`)),
-		makeReq(parse(t, `{.`+LabelNamespace+` = "namespace"}`)),
-		makeReq(parse(t, `{.`+LabelPod+` = "pod"}`)),
-		makeReq(parse(t, `{.`+LabelContainer+` = "container"}`)),
-		makeReq(parse(t, `{.`+LabelK8sNamespaceName+` = "k8snamespace"}`)),
-		makeReq(parse(t, `{.`+LabelK8sClusterName+` = "k8scluster"}`)),
-		makeReq(parse(t, `{.`+LabelK8sPodName+` = "k8spod"}`)),
-		makeReq(parse(t, `{.`+LabelK8sContainerName+` = "k8scontainer"}`)),
-		makeReq(parse(t, `{resource.`+LabelServiceName+` = "myservice"}`)),
-		makeReq(parse(t, `{resource.`+LabelCluster+` = "cluster"}`)),
-		makeReq(parse(t, `{resource.`+LabelNamespace+` = "namespace"}`)),
-		makeReq(parse(t, `{resource.`+LabelPod+` = "pod"}`)),
-		makeReq(parse(t, `{resource.`+LabelContainer+` = "container"}`)),
-		makeReq(parse(t, `{resource.`+LabelK8sNamespaceName+` = "k8snamespace"}`)),
-		makeReq(parse(t, `{resource.`+LabelK8sClusterName+` = "k8scluster"}`)),
-		makeReq(parse(t, `{resource.`+LabelK8sPodName+` = "k8spod"}`)),
-		makeReq(parse(t, `{resource.`+LabelK8sContainerName+` = "k8scontainer"}`)),
+		traceql.MustExtractFetchSpansRequest(`{.` + LabelServiceName + ` = "spanservicename"}`), // Overridden at span
+		traceql.MustExtractFetchSpansRequest(`{.` + LabelCluster + ` = "cluster"}`),
+		traceql.MustExtractFetchSpansRequest(`{.` + LabelNamespace + ` = "namespace"}`),
+		traceql.MustExtractFetchSpansRequest(`{.` + LabelPod + ` = "pod"}`),
+		traceql.MustExtractFetchSpansRequest(`{.` + LabelContainer + ` = "container"}`),
+		traceql.MustExtractFetchSpansRequest(`{.` + LabelK8sNamespaceName + ` = "k8snamespace"}`),
+		traceql.MustExtractFetchSpansRequest(`{.` + LabelK8sClusterName + ` = "k8scluster"}`),
+		traceql.MustExtractFetchSpansRequest(`{.` + LabelK8sPodName + ` = "k8spod"}`),
+		traceql.MustExtractFetchSpansRequest(`{.` + LabelK8sContainerName + ` = "k8scontainer"}`),
+		traceql.MustExtractFetchSpansRequest(`{resource.` + LabelServiceName + ` = "myservice"}`),
+		traceql.MustExtractFetchSpansRequest(`{resource.` + LabelCluster + ` = "cluster"}`),
+		traceql.MustExtractFetchSpansRequest(`{resource.` + LabelNamespace + ` = "namespace"}`),
+		traceql.MustExtractFetchSpansRequest(`{resource.` + LabelPod + ` = "pod"}`),
+		traceql.MustExtractFetchSpansRequest(`{resource.` + LabelContainer + ` = "container"}`),
+		traceql.MustExtractFetchSpansRequest(`{resource.` + LabelK8sNamespaceName + ` = "k8snamespace"}`),
+		traceql.MustExtractFetchSpansRequest(`{resource.` + LabelK8sClusterName + ` = "k8scluster"}`),
+		traceql.MustExtractFetchSpansRequest(`{resource.` + LabelK8sPodName + ` = "k8spod"}`),
+		traceql.MustExtractFetchSpansRequest(`{resource.` + LabelK8sContainerName + ` = "k8scontainer"}`),
 		// Span well-known attributes
-		makeReq(parse(t, `{.`+LabelHTTPStatusCode+` = 500}`)),
-		makeReq(parse(t, `{.`+LabelHTTPMethod+` = "get"}`)),
-		makeReq(parse(t, `{.`+LabelHTTPUrl+` = "url/hello/world"}`)),
-		makeReq(parse(t, `{span.`+LabelHTTPStatusCode+` = 500}`)),
-		makeReq(parse(t, `{span.`+LabelHTTPMethod+` = "get"}`)),
-		makeReq(parse(t, `{span.`+LabelHTTPUrl+` = "url/hello/world"}`)),
+		traceql.MustExtractFetchSpansRequest(`{.` + LabelHTTPStatusCode + ` = 500}`),
+		traceql.MustExtractFetchSpansRequest(`{.` + LabelHTTPMethod + ` = "get"}`),
+		traceql.MustExtractFetchSpansRequest(`{.` + LabelHTTPUrl + ` = "url/hello/world"}`),
+		traceql.MustExtractFetchSpansRequest(`{span.` + LabelHTTPStatusCode + ` = 500}`),
+		traceql.MustExtractFetchSpansRequest(`{span.` + LabelHTTPMethod + ` = "get"}`),
+		traceql.MustExtractFetchSpansRequest(`{span.` + LabelHTTPUrl + ` = "url/hello/world"}`),
 		// Basic data types and operations
-		makeReq(parse(t, `{.float = 456.78}`)),      // Float ==
-		makeReq(parse(t, `{.float != 456.79}`)),     // Float !=
-		makeReq(parse(t, `{.float > 456.7}`)),       // Float >
-		makeReq(parse(t, `{.float >= 456.78}`)),     // Float >=
-		makeReq(parse(t, `{.float < 456.781}`)),     // Float <
-		makeReq(parse(t, `{.bool = false}`)),        // Bool ==
-		makeReq(parse(t, `{.bool != true}`)),        // Bool !=
-		makeReq(parse(t, `{.bar = 123}`)),           // Int ==
-		makeReq(parse(t, `{.bar != 124}`)),          // Int !=
-		makeReq(parse(t, `{.bar > 122}`)),           // Int >
-		makeReq(parse(t, `{.bar >= 123}`)),          // Int >=
-		makeReq(parse(t, `{.bar < 124}`)),           // Int <
-		makeReq(parse(t, `{.bar <= 123}`)),          // Int <=
-		makeReq(parse(t, `{.foo = "def"}`)),         // String ==
-		makeReq(parse(t, `{.foo != "deg"}`)),        // String !=
-		makeReq(parse(t, `{.foo =~ "d.*"}`)),        // String Regex
-		makeReq(parse(t, `{resource.foo = "abc"}`)), // Resource-level only
-		makeReq(parse(t, `{span.foo = "def"}`)),     // Span-level only
-		makeReq(parse(t, `{.foo}`)),                 // Projection only
+		traceql.MustExtractFetchSpansRequest(`{.float = 456.78}`),      // Float ==
+		traceql.MustExtractFetchSpansRequest(`{.float != 456.79}`),     // Float !=
+		traceql.MustExtractFetchSpansRequest(`{.float > 456.7}`),       // Float >
+		traceql.MustExtractFetchSpansRequest(`{.float >= 456.78}`),     // Float >=
+		traceql.MustExtractFetchSpansRequest(`{.float < 456.781}`),     // Float <
+		traceql.MustExtractFetchSpansRequest(`{.bool = false}`),        // Bool ==
+		traceql.MustExtractFetchSpansRequest(`{.bool != true}`),        // Bool !=
+		traceql.MustExtractFetchSpansRequest(`{.bar = 123}`),           // Int ==
+		traceql.MustExtractFetchSpansRequest(`{.bar != 124}`),          // Int !=
+		traceql.MustExtractFetchSpansRequest(`{.bar > 122}`),           // Int >
+		traceql.MustExtractFetchSpansRequest(`{.bar >= 123}`),          // Int >=
+		traceql.MustExtractFetchSpansRequest(`{.bar < 124}`),           // Int <
+		traceql.MustExtractFetchSpansRequest(`{.bar <= 123}`),          // Int <=
+		traceql.MustExtractFetchSpansRequest(`{.foo = "def"}`),         // String ==
+		traceql.MustExtractFetchSpansRequest(`{.foo != "deg"}`),        // String !=
+		traceql.MustExtractFetchSpansRequest(`{.foo =~ "d.*"}`),        // String Regex
+		traceql.MustExtractFetchSpansRequest(`{resource.foo = "abc"}`), // Resource-level only
+		traceql.MustExtractFetchSpansRequest(`{span.foo = "def"}`),     // Span-level only
+		traceql.MustExtractFetchSpansRequest(`{.foo}`),                 // Projection only
 		makeReq(
 			// Matches either condition
 			parse(t, `{.foo = "baz"}`),
@@ -114,11 +114,11 @@ func TestBackendBlockSearchTraceQL(t *testing.T) {
 		),
 
 		// Edge cases
-		makeReq(parse(t, `{.name = "Bob"}`)),                             // Almost conflicts with intrinsic but still works
-		makeReq(parse(t, `{resource.`+LabelServiceName+` = 123}`)),       // service.name doesn't match type of dedicated column
-		makeReq(parse(t, `{.`+LabelServiceName+` = "spanservicename"}`)), // service.name present on span
-		makeReq(parse(t, `{.`+LabelHTTPStatusCode+` = "500ouch"}`)),      // http.status_code doesn't match type of dedicated column
-		makeReq(parse(t, `{.foo = "def"}`)),
+		traceql.MustExtractFetchSpansRequest(`{.name = "Bob"}`),                                 // Almost conflicts with intrinsic but still works
+		traceql.MustExtractFetchSpansRequest(`{resource.` + LabelServiceName + ` = 123}`),       // service.name doesn't match type of dedicated column
+		traceql.MustExtractFetchSpansRequest(`{.` + LabelServiceName + ` = "spanservicename"}`), // service.name present on span
+		traceql.MustExtractFetchSpansRequest(`{.` + LabelHTTPStatusCode + ` = "500ouch"}`),      // http.status_code doesn't match type of dedicated column
+		traceql.MustExtractFetchSpansRequest(`{.foo = "def"}`),
 		{
 			// Range at unscoped
 			AllConditions: true,
@@ -159,19 +159,15 @@ func TestBackendBlockSearchTraceQL(t *testing.T) {
 	searchesThatDontMatch := []traceql.FetchSpansRequest{
 		// TODO - Should the below query return data or not?  It does match the resource
 		// makeReq(parse(t, `{.foo = "abc"}`)),                           // This should not return results because the span has overridden this attribute to "def".
-		makeReq(parse(t, `{.foo =~ "xyz.*"}`)),                        // Regex IN
-		makeReq(parse(t, `{span.bool = true}`)),                       // Bool not match
-		makeReq(parse(t, `{`+LabelDuration+` >  100s}`)),              // Intrinsic: duration
-		makeReq(parse(t, `{`+LabelStatus+` = ok}`)),                   // Intrinsic: status
-		makeReq(parse(t, `{`+LabelName+` = "nothello"}`)),             // Intrinsic: name
-		makeReq(parse(t, `{.`+LabelServiceName+` = "notmyservice"}`)), // Well-known attribute: service.name not match
-		makeReq(parse(t, `{.`+LabelHTTPStatusCode+` = 200}`)),         // Well-known attribute: http.status_code not match
-		makeReq(parse(t, `{.`+LabelHTTPStatusCode+` > 600}`)),         // Well-known attribute: http.status_code not match
-		makeReq(
-			// Matches neither condition
-			parse(t, `{.foo = "xyz"}`),
-			parse(t, `{.`+LabelHTTPStatusCode+" = 1000}"),
-		),
+		traceql.MustExtractFetchSpansRequest(`{.foo =~ "xyz.*"}`),                                     // Regex IN
+		traceql.MustExtractFetchSpansRequest(`{span.bool = true}`),                                    // Bool not match
+		traceql.MustExtractFetchSpansRequest(`{` + LabelDuration + ` >  100s}`),                       // Intrinsic: duration
+		traceql.MustExtractFetchSpansRequest(`{` + LabelStatus + ` = ok}`),                            // Intrinsic: status
+		traceql.MustExtractFetchSpansRequest(`{` + LabelName + ` = "nothello"}`),                      // Intrinsic: name
+		traceql.MustExtractFetchSpansRequest(`{.` + LabelServiceName + ` = "notmyservice"}`),          // Well-known attribute: service.name not match
+		traceql.MustExtractFetchSpansRequest(`{.` + LabelHTTPStatusCode + ` = 200}`),                  // Well-known attribute: http.status_code not match
+		traceql.MustExtractFetchSpansRequest(`{.` + LabelHTTPStatusCode + ` > 600}`),                  // Well-known attribute: http.status_code not match
+		traceql.MustExtractFetchSpansRequest(`{.foo = "xyz" || .` + LabelHTTPStatusCode + " = 1000}"), // Matches neither condition
 		{
 			// Outside time range
 			StartTimeUnixNanos: uint64(300 * time.Second),

--- a/tempodb/wal/wal_test.go
+++ b/tempodb/wal/wal_test.go
@@ -278,9 +278,7 @@ func testFetch(t *testing.T, e encoding.VersionedEncoding) {
 			require.NotEmpty(t, v)
 
 			query := fmt.Sprintf("{ .%s = \"%s\" }", k, v)
-			resp, err := block.Fetch(ctx, traceql.FetchSpansRequest{
-				Conditions: traceql.MustExtractConditions(query),
-			}, common.DefaultSearchOptions())
+			resp, err := block.Fetch(ctx, traceql.MustExtractFetchSpansRequest(query), common.DefaultSearchOptions())
 			// not all blocks support fetch
 			if err == common.ErrUnsupported {
 				return


### PR DESCRIPTION
**What this PR does**:
Fixes an issue when trying to optimize some queries using only `&&` which turns into the `AllConditions=true` storage layer hint, and including repeated attribute names.

**Which issue(s) this PR fixes**:
Fixes #1948 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`