### PR TITLE
Parquet: Restore async read mode

### DIFF
--- a/tempodb/encoding/vparquet/block_search.go
+++ b/tempodb/encoding/vparquet/block_search.go
@@ -56,6 +56,7 @@ func (b *backendBlock) openForSearch(ctx context.Context, opts common.SearchOpti
 	o := []parquet.FileOption{
 		parquet.SkipBloomFilters(true),
 		parquet.SkipPageIndex(true),
+		parquet.FileReadMode(parquet.ReadModeAsync),
 	}
 
 	// backend reader


### PR DESCRIPTION
When upgrading the Parquet dependency we caught [this change](https://github.com/segmentio/parquet-go/pull/417) which defaulted page reads to be synchronous. There is likely some nuance for best performance on when to enable this or not, but trace by id search on the backend was heavily (negatively) impacted by this change. 

This should restore the old behavior. 

With this change the wal remains synchronous, which is preferred given the smaller files and increased number of files.

