### PR TITLE
Add TLS support to jaeger query plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## main / unreleased
+* [FEATURE] Add TLS support to jaeger query plugin. [#1999](https://github.com/grafana/tempo/pull/1999) (@rubenvp8510)
 * [ENHANCEMENT] Add support for TraceQL in Parquet WAL and Local Blocks. [#1966](https://github.com/grafana/tempo/pull/1966) (@electron0zero)
 * [CHANGE] Collect inspectedBytes from SearchMetrics [#1975](https://github.com/grafana/tempo/pull/1975) (@electron0zero)
 * [ENHANCEMENT] Add zone awareness replication for ingesters. [#1936](https://github.com/grafana/tempo/pull/1936) (@manohar-koukuntla)

--- a/cmd/tempo-query/main.go
+++ b/cmd/tempo-query/main.go
@@ -53,7 +53,10 @@ func main() {
 	cfg := &tempo.Config{}
 	cfg.InitFromViper(v)
 
-	backend := tempo.New(cfg)
+	backend, err := tempo.New(cfg)
+	if err != nil {
+		logger.Error("failed to init tracer backend", "error", err)
+	}
 	plugin := &plugin{backend: backend}
 	grpc.ServeWithGRPCServer(&shared.PluginServices{
 		Store: plugin,

--- a/cmd/tempo-query/tempo/config.go
+++ b/cmd/tempo-query/tempo/config.go
@@ -1,15 +1,27 @@
 package tempo
 
 import (
+	"github.com/grafana/dskit/crypto/tls"
 	"github.com/spf13/viper"
 )
 
 // Config holds the configuration for redbull.
 type Config struct {
-	Backend string `yaml:"backend"`
+	Backend    string           `yaml:"backend"`
+	TLSEnabled bool             `yaml:"tls_enabled" category:"advanced"`
+	TLS        tls.ClientConfig `yaml:",inline"`
 }
 
 // InitFromViper initializes the options struct with values from Viper
 func (c *Config) InitFromViper(v *viper.Viper) {
 	c.Backend = v.GetString("backend")
+	c.TLSEnabled = v.GetBool("tls_enabled")
+	c.TLS.CertPath = v.GetString("tls_cert_path")
+	c.TLS.KeyPath = v.GetString("tls_key_path")
+	c.TLS.CAPath = v.GetString("tls_ca_path")
+	c.TLS.ServerName = v.GetString("tls_server_name")
+	c.TLS.InsecureSkipVerify = v.GetBool("tls_insecure_skip_verify")
+	c.TLS.CipherSuites = v.GetString("tls_cipher_suites")
+	c.TLS.MinVersion = v.GetString("tls_min_version")
+
 }


### PR DESCRIPTION
Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This PR adds options to HTTP client to do TLS handshake with the query-frontend tempo API.

Something similar to what other components have:

Here is an example of the tempo-query config: 
```
backend: 127.0.0.1:3100
tls_enabled: true
tls_cert_path: /var/run/tls/grpc/server/tls.crt
tls_key_path: /var/run/tls/grpc/server/tls.key
tls_ca_path: /var/run/ca/service-ca.crt
tls_insecure_skip_verify: false
```

**Which issue(s) this PR fixes**:
Fixes #1998 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`