### PR TITLE
Return more consistent search results by combining partial traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,7 @@ Internal types are updated to use `scope` instead of `instrumentation_library`. 
 * [BUGFIX] Don't persist tenants without blocks in the ingester[#1947](https://github.com/grafana/tempo/pull/1947) (@joe-elliott)
 * [BUGFIX] TraceQL: span scope not working with ranges [#1948](https://github.com/grafana/tempo/issues/1948) (@mdisibio)
 * [BUGFIX] TraceQL: skip live traces search [#1997](https://github.com/grafana/tempo/pull/1997) (@mapno)
+* [BUGFIX] Return more consistent search results by combining partial traces [#](https://github.com/tempo/pull/) (@mapno)
 
 ## v1.5.0 / 2022-08-17
 

--- a/modules/frontend/search_response.go
+++ b/modules/frontend/search_response.go
@@ -150,4 +150,5 @@ func coalesce(a, b *tempopb.TraceSearchMetadata) {
 	if a.DurationMs < b.DurationMs {
 		a.DurationMs = b.DurationMs
 	}
+	// TODO: Merge spansets?
 }

--- a/modules/frontend/search_response_test.go
+++ b/modules/frontend/search_response_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/stretchr/testify/assert"
@@ -48,7 +49,7 @@ func TestSearchResponseShouldQuit(t *testing.T) {
 	sr.addResponse(&tempopb.SearchResponse{
 		Traces: []*tempopb.TraceSearchMetadata{
 			{
-				TraceID: "samething",
+				TraceID: "something",
 			},
 		},
 		Metrics: &tempopb.SearchMetrics{},
@@ -57,10 +58,10 @@ func TestSearchResponseShouldQuit(t *testing.T) {
 	sr.addResponse(&tempopb.SearchResponse{
 		Traces: []*tempopb.TraceSearchMetadata{
 			{
-				TraceID: "samething",
+				TraceID: "something",
 			},
 			{
-				TraceID: "samething",
+				TraceID: "something",
 			},
 		},
 		Metrics: &tempopb.SearchMetrics{},
@@ -128,7 +129,7 @@ func TestCancelFuncEvents(t *testing.T) {
 	sr.addResponse(&tempopb.SearchResponse{
 		Traces: []*tempopb.TraceSearchMetadata{
 			{
-				TraceID: "samething",
+				TraceID: "something",
 			},
 		},
 		Metrics: &tempopb.SearchMetrics{},
@@ -142,7 +143,7 @@ func TestCancelFuncEvents(t *testing.T) {
 	sr.addResponse(&tempopb.SearchResponse{
 		Traces: []*tempopb.TraceSearchMetadata{
 			{
-				TraceID: "samething",
+				TraceID: "something",
 			},
 		},
 		Metrics: &tempopb.SearchMetrics{},
@@ -153,11 +154,48 @@ func TestCancelFuncEvents(t *testing.T) {
 	sr.addResponse(&tempopb.SearchResponse{
 		Traces: []*tempopb.TraceSearchMetadata{
 			{
-				TraceID: "samething else", // needs unique traceID to hit limits
+				TraceID: "something else", // needs unique traceID to hit limits
 			},
 		},
 		Metrics: &tempopb.SearchMetrics{},
 	})
 	assert.True(t, sr.internalShouldQuit()) // internalShouldQuit should return true
 	assert.True(t, called)                  // addResponse calls cancelFunc (without calling shouldQuit)
+}
+
+func TestSearchResponseCoalesce(t *testing.T) {
+	start := time.Date(1, 2, 3, 4, 5, 6, 7, time.UTC)
+	traceID := "traceID"
+
+	sr := newSearchResponse(context.Background(), 10, func() {})
+	sr.addResponse(&tempopb.SearchResponse{
+		Traces: []*tempopb.TraceSearchMetadata{
+			{
+				TraceID:           traceID,
+				StartTimeUnixNano: uint64(start.Add(time.Second).UnixNano()),
+				DurationMs:        uint32(time.Second.Milliseconds()),
+			}, // 1 second after start and shorter duration
+			{
+				TraceID:           traceID,
+				StartTimeUnixNano: uint64(start.UnixNano()),
+				DurationMs:        uint32(time.Hour.Milliseconds()),
+			}, // earliest start time and longer duration
+			{
+				TraceID:           traceID,
+				StartTimeUnixNano: uint64(start.Add(time.Hour).UnixNano()),
+				DurationMs:        uint32(time.Millisecond.Milliseconds()),
+			}, // 1 hour after start and shorter duration
+		},
+		Metrics: &tempopb.SearchMetrics{},
+	})
+
+	expected := &tempopb.SearchResponse{
+		Traces: []*tempopb.TraceSearchMetadata{
+			{TraceID: traceID, StartTimeUnixNano: uint64(start.UnixNano()), DurationMs: uint32(time.Hour.Milliseconds())},
+		},
+		Metrics: &tempopb.SearchMetrics{},
+	}
+
+	assert.Equal(t, expected, sr.result())
+
 }

--- a/modules/frontend/search_response_test.go
+++ b/modules/frontend/search_response_test.go
@@ -163,7 +163,7 @@ func TestCancelFuncEvents(t *testing.T) {
 	assert.True(t, called)                  // addResponse calls cancelFunc (without calling shouldQuit)
 }
 
-func TestSearchResponseCoalesce(t *testing.T) {
+func TestSearchResponseCombineResults(t *testing.T) {
 	start := time.Date(1, 2, 3, 4, 5, 6, 7, time.UTC)
 	traceID := "traceID"
 

--- a/tempodb/search/util.go
+++ b/tempodb/search/util.go
@@ -49,7 +49,7 @@ func GetSearchResultFromData(s *tempofb.SearchEntry) *tempopb.TraceSearchMetadat
 	}
 }
 
-// CombineResults overlays the incoming search result with the existing result. This is required
+// CombineSearchResults overlays the incoming search result with the existing result. This is required
 // for the following reason:  a trace may be present in multiple blocks, or in partial segments
 // in live traces.  The results should reflect elements of all segments.
 func CombineSearchResults(existing *tempopb.TraceSearchMetadata, incoming *tempopb.TraceSearchMetadata) {


### PR DESCRIPTION
**What this PR does**:

Makes search results by combining partial results and taking the earliest start time and longest duration.

**Which issue(s) this PR fixes**:
Fixes #2001

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`