### PR TITLE
Add Throughput and SLO Metrics with SLOConfig in Query Frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@
 /cmd/tempo-serverless/vendor/
 /pkg/traceql/y.output
 private-key.key
-image.sh

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /cmd/tempo-serverless/vendor/
 /pkg/traceql/y.output
 private-key.key
+image.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main / unreleased
 
 * [FEATURE] Add support for Azure Workload Identity authentication [#2195](https://github.com/grafana/tempo/pull/2195) (@LambArchie)
+* [ENHANCEMENT] Add Throughput and SLO Metrics with SLOConfig in Query Frontend [#2008](https://github.com/grafana/tempo/pull/2008) (@electron0zero)
 * [FEATURE] Add flag to check configuration [#2131](https://github.com/grafana/tempo/issues/2131) (@robertscherbarth @agrib-01)
 * [FEATURE] Add flag to optionally enable all available Go runtime metrics [#2005](https://github.com/grafana/tempo/pull/2005) (@andreasgerstmayr)
 * [FEATURE] Add support for span `kind` to TraceQL [#2217](https://github.com/grafana/tempo/pull/2217) (@joe-elliott)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [FEATURE] Add support for Azure Workload Identity authentication [#2195](https://github.com/grafana/tempo/pull/2195) (@LambArchie)
 * [ENHANCEMENT] Add Throughput and SLO Metrics with SLOConfig in Query Frontend [#2008](https://github.com/grafana/tempo/pull/2008) (@electron0zero)
+  - **BREAKING CHANGE** `query_frontend_result_metrics_inspected_bytes` metric removed in favour of `query_frontend_bytes_processed_per_seconds`
 * [FEATURE] Add flag to check configuration [#2131](https://github.com/grafana/tempo/issues/2131) (@robertscherbarth @agrib-01)
 * [FEATURE] Add flag to optionally enable all available Go runtime metrics [#2005](https://github.com/grafana/tempo/pull/2005) (@andreasgerstmayr)
 * [FEATURE] Add support for span `kind` to TraceQL [#2217](https://github.com/grafana/tempo/pull/2217) (@joe-elliott)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * [FEATURE] Add support for Azure Workload Identity authentication [#2195](https://github.com/grafana/tempo/pull/2195) (@LambArchie)
 * [ENHANCEMENT] Add Throughput and SLO Metrics with SLOConfig in Query Frontend [#2008](https://github.com/grafana/tempo/pull/2008) (@electron0zero)
-  - **BREAKING CHANGE** `query_frontend_result_metrics_inspected_bytes` metric removed in favour of `query_frontend_bytes_processed_per_seconds`
+  - **BREAKING CHANGE** `query_frontend_result_metrics_inspected_bytes` metric removed in favour of `query_frontend_bytes_processed_per_second`
 * [FEATURE] Add flag to check configuration [#2131](https://github.com/grafana/tempo/issues/2131) (@robertscherbarth @agrib-01)
 * [FEATURE] Add flag to optionally enable all available Go runtime metrics [#2005](https://github.com/grafana/tempo/pull/2005) (@andreasgerstmayr)
 * [FEATURE] Add support for span `kind` to TraceQL [#2217](https://github.com/grafana/tempo/pull/2217) (@joe-elliott)

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -402,11 +402,12 @@ query_frontend:
 
         # If set to a non-zero value, it's value will be used to decide if query is within SLO or not.
         # Query is within SLO if it returned 200 within duration_slo seconds OR processed throughput_slo bytes/s data.
+        # NOTE: `duration_slo` and `throughput_bytes_slo` both must be configured for it to work
         [duration_slo: <duration> | default = 0s ]
 
         # If set to a non-zero value, it's value will be used to decide if query is within SLO or not.
         # Query is within SLO if it returned 200 within duration_slo seconds OR processed throughput_slo bytes/s data.
-        [throughput_slo: <float> | default = 0 ]
+        [throughput_bytes_slo: <float> | default = 0 ]
 
 
     # Trace by ID lookup configuration

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -400,6 +400,21 @@ query_frontend:
         # (default: 30m)
         [query_ingesters_until: <duration>]
 
+        # If set to a non-zero value, it's value will be used to decide if query is within SLO or not
+        # tempo_query_frontend_search_queries_within_slo_total is incremented if query 
+        # completes in duration less than value of duration_slo
+        # This works in boolean OR with throughput_slo config,
+        # Query is within SLO if it returned within duration_slo seconds OR processed throughput_slo bytes/s data
+        [duration_slo: <duration> | default = 5s ]
+
+        # If set to a non-zero value, it's value will be used to decide if query is within SLO or not
+        # tempo_query_frontend_search_queries_within_slo_total is incremented if query 
+        # throughput (data processed per second) more than value of throughput_slo
+        # This works in boolean OR with throughput_slo config,
+        # Query is within SLO if it returned within duration_slo seconds OR processed throughput_slo bytes/s data
+        [throughput_slo: <float> | default = 104857600 ]
+
+
     # Trace by ID lookup configuration
     trace_by_id:
         # The number of shards to split a trace by id query into.
@@ -413,6 +428,12 @@ query_frontend:
         # The maximum number of requests to execute when hedging.
         # Requires hedge_requests_at to be set. Must be greater than 0.
         [hedge_requests_up_to: <int> | default = 2 ]
+
+        # If set to a non-zero value, it's value will be used to decide if query is within SLO or not
+        # tempo_query_frontend_tracebyid_queries_within_slo_total is incremented if query 
+        # completes in duration less than value of duration_slo
+        # Query is within SLO if it returned within duration_slo seconds
+        [duration_slo: <duration> | default = 5s ]
 ```
 
 ## Querier

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -400,18 +400,18 @@ query_frontend:
         # (default: 30m)
         [query_ingesters_until: <duration>]
 
-        # If set to a non-zero value, it's value will be used to decide if query is within SLO or not
+        # If set to a non-zero value, it's value will be used to decide if query is within SLO or not.
         # tempo_query_frontend_search_queries_within_slo_total is incremented if query 
-        # completes in duration less than value of duration_slo
+        # completes in duration less than value of duration_slo.
         # This works in boolean OR with throughput_slo config,
-        # Query is within SLO if it returned within duration_slo seconds OR processed throughput_slo bytes/s data
+        # Query is within SLO if it returned within duration_slo seconds OR processed throughput_slo bytes/s data.
         [duration_slo: <duration> | default = 5s ]
 
-        # If set to a non-zero value, it's value will be used to decide if query is within SLO or not
+        # If set to a non-zero value, it's value will be used to decide if query is within SLO or not.
         # tempo_query_frontend_search_queries_within_slo_total is incremented if query 
-        # throughput (data processed per second) more than value of throughput_slo
+        # throughput (data processed per second) more than value of throughput_slo.
         # This works in boolean OR with throughput_slo config,
-        # Query is within SLO if it returned within duration_slo seconds OR processed throughput_slo bytes/s data
+        # Query is within SLO if it returned within duration_slo seconds OR processed throughput_slo bytes/s data.
         [throughput_slo: <float> | default = 104857600 ]
 
 
@@ -429,10 +429,10 @@ query_frontend:
         # Requires hedge_requests_at to be set. Must be greater than 0.
         [hedge_requests_up_to: <int> | default = 2 ]
 
-        # If set to a non-zero value, it's value will be used to decide if query is within SLO or not
+        # If set to a non-zero value, it's value will be used to decide if query is within SLO or not.
         # tempo_query_frontend_tracebyid_queries_within_slo_total is incremented if query 
-        # completes in duration less than value of duration_slo
-        # Query is within SLO if it returned within duration_slo seconds
+        # completes in duration less than value of duration_slo.
+        # Query is within SLO if it returned within duration_slo seconds.
         [duration_slo: <duration> | default = 5s ]
 ```
 

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -401,18 +401,12 @@ query_frontend:
         [query_ingesters_until: <duration>]
 
         # If set to a non-zero value, it's value will be used to decide if query is within SLO or not.
-        # tempo_query_frontend_search_queries_within_slo_total is incremented if query 
-        # completes in duration less than value of duration_slo.
-        # This works in boolean OR with throughput_slo config,
-        # Query is within SLO if it returned within duration_slo seconds OR processed throughput_slo bytes/s data.
-        [duration_slo: <duration> | default = 5s ]
+        # Query is within SLO if it returned 200 within duration_slo seconds OR processed throughput_slo bytes/s data.
+        [duration_slo: <duration> | default = 0s ]
 
         # If set to a non-zero value, it's value will be used to decide if query is within SLO or not.
-        # tempo_query_frontend_search_queries_within_slo_total is incremented if query 
-        # throughput (data processed per second) more than value of throughput_slo.
-        # This works in boolean OR with throughput_slo config,
-        # Query is within SLO if it returned within duration_slo seconds OR processed throughput_slo bytes/s data.
-        [throughput_slo: <float> | default = 104857600 ]
+        # Query is within SLO if it returned 200 within duration_slo seconds OR processed throughput_slo bytes/s data.
+        [throughput_slo: <float> | default = 0 ]
 
 
     # Trace by ID lookup configuration
@@ -430,10 +424,8 @@ query_frontend:
         [hedge_requests_up_to: <int> | default = 2 ]
 
         # If set to a non-zero value, it's value will be used to decide if query is within SLO or not.
-        # tempo_query_frontend_tracebyid_queries_within_slo_total is incremented if query 
-        # completes in duration less than value of duration_slo.
-        # Query is within SLO if it returned within duration_slo seconds.
-        [duration_slo: <duration> | default = 5s ]
+        # Query is within SLO if it returned 200 within duration_slo seconds.
+        [duration_slo: <duration> | default = 0s ]
 ```
 
 ## Querier

--- a/modules/frontend/config.go
+++ b/modules/frontend/config.go
@@ -42,14 +42,14 @@ type HedgingConfig struct {
 }
 
 type SLOConfig struct {
-	DurationSLO   time.Duration `yaml:"duration_slo,omitempty"`
-	ThroughputSLO float64       `yaml:"throughput_slo,omitempty"`
+	DurationSLO        time.Duration `yaml:"duration_slo,omitempty"`
+	ThroughputBytesSLO float64       `yaml:"throughput_bytes_slo,omitempty"`
 }
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {
 	slo := SLOConfig{
-		DurationSLO:   0,
-		ThroughputSLO: 0,
+		DurationSLO:        0,
+		ThroughputBytesSLO: 0,
 	}
 
 	cfg.Config.MaxOutstandingPerTenant = 2000

--- a/modules/frontend/config.go
+++ b/modules/frontend/config.go
@@ -48,8 +48,8 @@ type SLOConfig struct {
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {
 	slo := SLOConfig{
-		DurationSLO:   5 * time.Second,
-		ThroughputSLO: 100 * 1024 * 1024, // 100 MB
+		DurationSLO:   0,
+		ThroughputSLO: 0,
 	}
 
 	cfg.Config.MaxOutstandingPerTenant = 2000

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -79,6 +79,7 @@ func New(cfg Config, next http.RoundTripper, o *overrides.Overrides, store stora
 
 	traces := traceByIDMiddleware.Wrap(next)
 	search := searchMiddleware.Wrap(next)
+	// TODO: pass the prom metric here??
 	return &QueryFrontend{
 		TraceByID:        newHandler(traces, traceByIDCounter, logger),
 		Search:           newHandler(search, searchCounter, logger),

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -76,17 +76,6 @@ func New(cfg Config, next http.RoundTripper, o *overrides.Overrides, store stora
 		"op": searchOp,
 	})
 
-	// add a within slo label?? and then get per tenant SLO
-	// add a config for SLO on throughput and duration.
-	// fast OR processed enough data (more than x/gb/per seconds)
-	// TODO: pass metric the handlers
-	// query_frontend config blocks....
-	// default SLO: query that returned within 2.5 seconds or processed 1GB/s
-	// is within SLO, you can override this by config....
-	// query_within_slo counter...
-	// Add only for search path for now....
-	// we can have PerTenant slo with Tenant label??
-
 	traces := traceByIDMiddleware.Wrap(next)
 	search := searchMiddleware.Wrap(next)
 	return &QueryFrontend{

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -77,9 +77,19 @@ func New(cfg Config, next http.RoundTripper, o *overrides.Overrides, store stora
 		"op": searchOp,
 	})
 
+	// add a within slo label?? and then get per tenant SLO
+	// add a config for SLO on throughput and duration.
+	// fast OR processed enough data (more than x/gb/per seconds)
+	// TODO: pass metric the handlers
+	// query_frontend config blocks....
+	// default SLO: query that returned within 2.5 seconds or processed 1GB/s
+	// is within SLO, you can override this by config....
+	// query_within_slo counter...
+	// Add only for search path for now....
+	// we can have PerTenant slo with Tenant label??
+
 	traces := traceByIDMiddleware.Wrap(next)
 	search := searchMiddleware.Wrap(next)
-	// TODO: pass the prom metric here??
 	return &QueryFrontend{
 		TraceByID:        newHandler(traces, traceByIDCounter, logger),
 		Search:           newHandler(search, searchCounter, logger),

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -34,7 +34,6 @@ const (
 type QueryFrontend struct {
 	TraceByID, Search http.Handler
 	logger            log.Logger
-	queriesPerTenant  *prometheus.CounterVec
 	store             storage.Store
 }
 
@@ -91,11 +90,10 @@ func New(cfg Config, next http.RoundTripper, o *overrides.Overrides, store stora
 	traces := traceByIDMiddleware.Wrap(next)
 	search := searchMiddleware.Wrap(next)
 	return &QueryFrontend{
-		TraceByID:        newHandler(traces, traceByIDCounter, logger),
-		Search:           newHandler(search, searchCounter, logger),
-		logger:           logger,
-		queriesPerTenant: queriesPerTenant,
-		store:            store,
+		TraceByID: newHandler(traces, traceByIDCounter, logger),
+		Search:    newHandler(search, searchCounter, logger),
+		logger:    logger,
+		store:     store,
 	}, nil
 }
 

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -53,8 +53,8 @@ func New(cfg Config, next http.RoundTripper, o *overrides.Overrides, store stora
 		return nil, fmt.Errorf("frontend search target bytes per request should be greater than 0")
 	}
 
-	if cfg.Search.SLO.ThroughputSLO <= 0 && cfg.TraceByID.SLO.ThroughputSLO <= 0 {
-		return nil, fmt.Errorf("frontend search and trace by id throughput slo should be greater than 0")
+	if cfg.Search.SLO.ThroughputSLO <= 0 || cfg.TraceByID.SLO.ThroughputSLO <= 0 {
+		return nil, fmt.Errorf("frontend search or trace by id throughput slo should be greater than 0")
 	}
 
 	if cfg.Search.Sharder.QueryIngestersUntil < cfg.Search.Sharder.QueryBackendAfter {

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -53,10 +53,6 @@ func New(cfg Config, next http.RoundTripper, o *overrides.Overrides, store stora
 		return nil, fmt.Errorf("frontend search target bytes per request should be greater than 0")
 	}
 
-	if cfg.Search.SLO.ThroughputSLO <= 0 || cfg.TraceByID.SLO.ThroughputSLO <= 0 {
-		return nil, fmt.Errorf("frontend search or trace by id throughput slo should be greater than 0")
-	}
-
 	if cfg.Search.Sharder.QueryIngestersUntil < cfg.Search.Sharder.QueryBackendAfter {
 		return nil, fmt.Errorf("query backend after should be less than or equal to query ingester until")
 	}

--- a/modules/frontend/frontend_test.go
+++ b/modules/frontend/frontend_test.go
@@ -15,11 +15,6 @@ import (
 
 type mockNextTripperware struct{}
 
-var sloCfg = SLOConfig{
-	DurationSLO:   5 * time.Second,
-	ThroughputSLO: 1 * 1024 * 1024,
-}
-
 func (s *mockNextTripperware) RoundTrip(_ *http.Request) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: 200,
@@ -32,14 +27,14 @@ func TestFrontendRoundTripsSearch(t *testing.T) {
 	f, err := New(Config{
 		TraceByID: TraceByIDConfig{
 			QueryShards: minQueryShards,
-			SLO:         sloCfg,
+			SLO:         defaultSLOcfg,
 		},
 		Search: SearchConfig{
 			Sharder: SearchSharderConfig{
 				ConcurrentRequests:    defaultConcurrentRequests,
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			},
-			SLO: sloCfg,
+			SLO: defaultSLOcfg,
 		},
 	}, next, nil, nil, log.NewNopLogger(), nil)
 	require.NoError(t, err)
@@ -62,7 +57,7 @@ func TestFrontendBadConfigFails(t *testing.T) {
 				ConcurrentRequests:    defaultConcurrentRequests,
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			},
-			SLO: sloCfg,
+			SLO: defaultSLOcfg,
 		},
 	}, nil, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "frontend query shards should be between 2 and 256 (both inclusive)")
@@ -71,14 +66,14 @@ func TestFrontendBadConfigFails(t *testing.T) {
 	f, err = New(Config{
 		TraceByID: TraceByIDConfig{
 			QueryShards: maxQueryShards + 1,
-			SLO:         sloCfg,
+			SLO:         defaultSLOcfg,
 		},
 		Search: SearchConfig{
 			Sharder: SearchSharderConfig{
 				ConcurrentRequests:    defaultConcurrentRequests,
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			},
-			SLO: sloCfg,
+			SLO: defaultSLOcfg,
 		},
 	}, nil, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "frontend query shards should be between 2 and 256 (both inclusive)")
@@ -87,14 +82,14 @@ func TestFrontendBadConfigFails(t *testing.T) {
 	f, err = New(Config{
 		TraceByID: TraceByIDConfig{
 			QueryShards: maxQueryShards,
-			SLO:         sloCfg,
+			SLO:         defaultSLOcfg,
 		},
 		Search: SearchConfig{
 			Sharder: SearchSharderConfig{
 				ConcurrentRequests:    0,
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			},
-			SLO: sloCfg,
+			SLO: defaultSLOcfg,
 		},
 	}, nil, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "frontend search concurrent requests should be greater than 0")
@@ -103,14 +98,14 @@ func TestFrontendBadConfigFails(t *testing.T) {
 	f, err = New(Config{
 		TraceByID: TraceByIDConfig{
 			QueryShards: maxQueryShards,
-			SLO:         sloCfg,
+			SLO:         defaultSLOcfg,
 		},
 		Search: SearchConfig{
 			Sharder: SearchSharderConfig{
 				ConcurrentRequests:    defaultConcurrentRequests,
 				TargetBytesPerRequest: 0,
 			},
-			SLO: sloCfg,
+			SLO: defaultSLOcfg,
 		},
 	}, nil, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "frontend search target bytes per request should be greater than 0")
@@ -119,7 +114,7 @@ func TestFrontendBadConfigFails(t *testing.T) {
 	f, err = New(Config{
 		TraceByID: TraceByIDConfig{
 			QueryShards: maxQueryShards,
-			SLO:         sloCfg,
+			SLO:         defaultSLOcfg,
 		},
 		Search: SearchConfig{
 			Sharder: SearchSharderConfig{
@@ -128,7 +123,7 @@ func TestFrontendBadConfigFails(t *testing.T) {
 				QueryIngestersUntil:   time.Minute,
 				QueryBackendAfter:     time.Hour,
 			},
-			SLO: sloCfg,
+			SLO: defaultSLOcfg,
 		},
 	}, nil, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "query backend after should be less than or equal to query ingester until")

--- a/modules/frontend/frontend_test.go
+++ b/modules/frontend/frontend_test.go
@@ -133,42 +133,4 @@ func TestFrontendBadConfigFails(t *testing.T) {
 	}, nil, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "query backend after should be less than or equal to query ingester until")
 	assert.Nil(t, f)
-
-	f, err = New(Config{
-		TraceByID: TraceByIDConfig{
-			QueryShards: maxQueryShards,
-			SLO: SLOConfig{
-				ThroughputSLO: -1,
-				DurationSLO:   1 * time.Second,
-			},
-		},
-		Search: SearchConfig{
-			Sharder: SearchSharderConfig{
-				ConcurrentRequests:    defaultConcurrentRequests,
-				TargetBytesPerRequest: defaultTargetBytesPerRequest,
-			},
-			SLO: sloCfg,
-		},
-	}, nil, nil, nil, log.NewNopLogger(), nil)
-	assert.EqualError(t, err, "frontend search or trace by id throughput slo should be greater than 0")
-	assert.Nil(t, f)
-
-	f, err = New(Config{
-		TraceByID: TraceByIDConfig{
-			QueryShards: maxQueryShards,
-			SLO:         sloCfg,
-		},
-		Search: SearchConfig{
-			Sharder: SearchSharderConfig{
-				ConcurrentRequests:    defaultConcurrentRequests,
-				TargetBytesPerRequest: defaultTargetBytesPerRequest,
-			},
-			SLO: SLOConfig{
-				ThroughputSLO: -1,
-				DurationSLO:   1 * time.Second,
-			},
-		},
-	}, nil, nil, nil, log.NewNopLogger(), nil)
-	assert.EqualError(t, err, "frontend search or trace by id throughput slo should be greater than 0")
-	assert.Nil(t, f)
 }

--- a/modules/frontend/frontend_test.go
+++ b/modules/frontend/frontend_test.go
@@ -15,6 +15,11 @@ import (
 
 type mockNextTripperware struct{}
 
+var sloCfg = SLOConfig{
+	DurationSLO:   5 * time.Second,
+	ThroughputSLO: 1 * 1024 * 1024,
+}
+
 func (s *mockNextTripperware) RoundTrip(_ *http.Request) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: 200,
@@ -27,12 +32,14 @@ func TestFrontendRoundTripsSearch(t *testing.T) {
 	f, err := New(Config{
 		TraceByID: TraceByIDConfig{
 			QueryShards: minQueryShards,
+			SLO:         sloCfg,
 		},
 		Search: SearchConfig{
 			Sharder: SearchSharderConfig{
 				ConcurrentRequests:    defaultConcurrentRequests,
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			},
+			SLO: sloCfg,
 		},
 	}, next, nil, nil, log.NewNopLogger(), nil)
 	require.NoError(t, err)
@@ -55,6 +62,7 @@ func TestFrontendBadConfigFails(t *testing.T) {
 				ConcurrentRequests:    defaultConcurrentRequests,
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			},
+			SLO: sloCfg,
 		},
 	}, nil, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "frontend query shards should be between 2 and 256 (both inclusive)")
@@ -63,12 +71,14 @@ func TestFrontendBadConfigFails(t *testing.T) {
 	f, err = New(Config{
 		TraceByID: TraceByIDConfig{
 			QueryShards: maxQueryShards + 1,
+			SLO:         sloCfg,
 		},
 		Search: SearchConfig{
 			Sharder: SearchSharderConfig{
 				ConcurrentRequests:    defaultConcurrentRequests,
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			},
+			SLO: sloCfg,
 		},
 	}, nil, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "frontend query shards should be between 2 and 256 (both inclusive)")
@@ -77,12 +87,14 @@ func TestFrontendBadConfigFails(t *testing.T) {
 	f, err = New(Config{
 		TraceByID: TraceByIDConfig{
 			QueryShards: maxQueryShards,
+			SLO:         sloCfg,
 		},
 		Search: SearchConfig{
 			Sharder: SearchSharderConfig{
 				ConcurrentRequests:    0,
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			},
+			SLO: sloCfg,
 		},
 	}, nil, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "frontend search concurrent requests should be greater than 0")
@@ -91,12 +103,14 @@ func TestFrontendBadConfigFails(t *testing.T) {
 	f, err = New(Config{
 		TraceByID: TraceByIDConfig{
 			QueryShards: maxQueryShards,
+			SLO:         sloCfg,
 		},
 		Search: SearchConfig{
 			Sharder: SearchSharderConfig{
 				ConcurrentRequests:    defaultConcurrentRequests,
 				TargetBytesPerRequest: 0,
 			},
+			SLO: sloCfg,
 		},
 	}, nil, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "frontend search target bytes per request should be greater than 0")
@@ -105,6 +119,7 @@ func TestFrontendBadConfigFails(t *testing.T) {
 	f, err = New(Config{
 		TraceByID: TraceByIDConfig{
 			QueryShards: maxQueryShards,
+			SLO:         sloCfg,
 		},
 		Search: SearchConfig{
 			Sharder: SearchSharderConfig{
@@ -113,8 +128,47 @@ func TestFrontendBadConfigFails(t *testing.T) {
 				QueryIngestersUntil:   time.Minute,
 				QueryBackendAfter:     time.Hour,
 			},
+			SLO: sloCfg,
 		},
 	}, nil, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "query backend after should be less than or equal to query ingester until")
+	assert.Nil(t, f)
+
+	f, err = New(Config{
+		TraceByID: TraceByIDConfig{
+			QueryShards: maxQueryShards,
+			SLO: SLOConfig{
+				ThroughputSLO: -1,
+				DurationSLO:   1 * time.Second,
+			},
+		},
+		Search: SearchConfig{
+			Sharder: SearchSharderConfig{
+				ConcurrentRequests:    defaultConcurrentRequests,
+				TargetBytesPerRequest: defaultTargetBytesPerRequest,
+			},
+			SLO: sloCfg,
+		},
+	}, nil, nil, nil, log.NewNopLogger(), nil)
+	assert.EqualError(t, err, "frontend search or trace by id throughput slo should be greater than 0")
+	assert.Nil(t, f)
+
+	f, err = New(Config{
+		TraceByID: TraceByIDConfig{
+			QueryShards: maxQueryShards,
+			SLO:         sloCfg,
+		},
+		Search: SearchConfig{
+			Sharder: SearchSharderConfig{
+				ConcurrentRequests:    defaultConcurrentRequests,
+				TargetBytesPerRequest: defaultTargetBytesPerRequest,
+			},
+			SLO: SLOConfig{
+				ThroughputSLO: -1,
+				DurationSLO:   1 * time.Second,
+			},
+		},
+	}, nil, nil, nil, log.NewNopLogger(), nil)
+	assert.EqualError(t, err, "frontend search or trace by id throughput slo should be greater than 0")
 	assert.Nil(t, f)
 }

--- a/modules/frontend/frontend_test.go
+++ b/modules/frontend/frontend_test.go
@@ -27,14 +27,14 @@ func TestFrontendRoundTripsSearch(t *testing.T) {
 	f, err := New(Config{
 		TraceByID: TraceByIDConfig{
 			QueryShards: minQueryShards,
-			SLO:         defaultSLOcfg,
+			SLO:         testSLOcfg,
 		},
 		Search: SearchConfig{
 			Sharder: SearchSharderConfig{
 				ConcurrentRequests:    defaultConcurrentRequests,
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			},
-			SLO: defaultSLOcfg,
+			SLO: testSLOcfg,
 		},
 	}, next, nil, nil, log.NewNopLogger(), nil)
 	require.NoError(t, err)
@@ -57,7 +57,7 @@ func TestFrontendBadConfigFails(t *testing.T) {
 				ConcurrentRequests:    defaultConcurrentRequests,
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			},
-			SLO: defaultSLOcfg,
+			SLO: testSLOcfg,
 		},
 	}, nil, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "frontend query shards should be between 2 and 256 (both inclusive)")
@@ -66,14 +66,14 @@ func TestFrontendBadConfigFails(t *testing.T) {
 	f, err = New(Config{
 		TraceByID: TraceByIDConfig{
 			QueryShards: maxQueryShards + 1,
-			SLO:         defaultSLOcfg,
+			SLO:         testSLOcfg,
 		},
 		Search: SearchConfig{
 			Sharder: SearchSharderConfig{
 				ConcurrentRequests:    defaultConcurrentRequests,
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			},
-			SLO: defaultSLOcfg,
+			SLO: testSLOcfg,
 		},
 	}, nil, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "frontend query shards should be between 2 and 256 (both inclusive)")
@@ -82,14 +82,14 @@ func TestFrontendBadConfigFails(t *testing.T) {
 	f, err = New(Config{
 		TraceByID: TraceByIDConfig{
 			QueryShards: maxQueryShards,
-			SLO:         defaultSLOcfg,
+			SLO:         testSLOcfg,
 		},
 		Search: SearchConfig{
 			Sharder: SearchSharderConfig{
 				ConcurrentRequests:    0,
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			},
-			SLO: defaultSLOcfg,
+			SLO: testSLOcfg,
 		},
 	}, nil, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "frontend search concurrent requests should be greater than 0")
@@ -98,14 +98,14 @@ func TestFrontendBadConfigFails(t *testing.T) {
 	f, err = New(Config{
 		TraceByID: TraceByIDConfig{
 			QueryShards: maxQueryShards,
-			SLO:         defaultSLOcfg,
+			SLO:         testSLOcfg,
 		},
 		Search: SearchConfig{
 			Sharder: SearchSharderConfig{
 				ConcurrentRequests:    defaultConcurrentRequests,
 				TargetBytesPerRequest: 0,
 			},
-			SLO: defaultSLOcfg,
+			SLO: testSLOcfg,
 		},
 	}, nil, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "frontend search target bytes per request should be greater than 0")
@@ -114,7 +114,7 @@ func TestFrontendBadConfigFails(t *testing.T) {
 	f, err = New(Config{
 		TraceByID: TraceByIDConfig{
 			QueryShards: maxQueryShards,
-			SLO:         defaultSLOcfg,
+			SLO:         testSLOcfg,
 		},
 		Search: SearchConfig{
 			Sharder: SearchSharderConfig{
@@ -123,7 +123,7 @@ func TestFrontendBadConfigFails(t *testing.T) {
 				QueryIngestersUntil:   time.Minute,
 				QueryBackendAfter:     time.Hour,
 			},
-			SLO: defaultSLOcfg,
+			SLO: testSLOcfg,
 		},
 	}, nil, nil, nil, log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "query backend after should be less than or equal to query ingester until")

--- a/modules/frontend/searchsharding.go
+++ b/modules/frontend/searchsharding.go
@@ -267,9 +267,10 @@ func (s searchSharder) RoundTrip(r *http.Request) (*http.Response, error) {
 		// translate all non-200s into 500s. if, for instance, we get a 400 back from an internal component
 		// it means that we created a bad request. 400 should not be propagated back to the user b/c
 		// the bad request was due to a bug on our side, so return 500 instead.
-		s.recordMetrics(tenantID, overallResponse.statusCode, throughput, reqTime)
+		statusCode = http.StatusInternalServerError
+		s.recordMetrics(tenantID, statusCode, throughput, reqTime)
 		return &http.Response{
-			StatusCode: overallResponse.statusCode,
+			StatusCode: statusCode,
 			Header:     http.Header{},
 			Body:       io.NopCloser(strings.NewReader(overallResponse.statusMsg)),
 		}, nil

--- a/modules/frontend/searchsharding.go
+++ b/modules/frontend/searchsharding.go
@@ -114,7 +114,7 @@ func (s searchSharder) RoundTrip(r *http.Request) (*http.Response, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "frontend.ShardSearch")
 	defer span.Finish()
 
-	reqStart := time.Now() // time search request
+	reqStart := time.Now()
 	// sub context to cancel in-progress sub requests
 	subCtx, subCancel := context.WithCancel(ctx)
 	defer subCancel()
@@ -287,7 +287,8 @@ func (s searchSharder) RoundTrip(r *http.Request) (*http.Response, error) {
 	// only record metric when it's enabled and within slo
 	if s.sloCfg.DurationSLO != 0 && s.sloCfg.ThroughputSLO != 0 {
 		if reqTime < s.sloCfg.DurationSLO || throughput > s.sloCfg.ThroughputSLO {
-			// query is within SLO if query returned 200 within DurationSLO seconds OR processed ThroughputSLO bytes/s data
+			// query is within SLO if query returned 200 within DurationSLO seconds OR
+			// processed ThroughputSLO bytes/s data
 			sloSearchCounter.WithLabelValues(tenantID).Inc()
 		}
 	}

--- a/modules/frontend/searchsharding.go
+++ b/modules/frontend/searchsharding.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -30,18 +31,18 @@ const (
 )
 
 var (
-	metricRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	searchThroughput = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "tempo",
-		Name:      "query_frontend_request_duration_seconds",
-		Help:      "Time taken to process the search query",
-		Buckets:   prometheus.ExponentialBuckets(1, 2, 10),
-	}, []string{"status_code"})
-	queryThroughput = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "tempo",
-		Name:      "query_frontend_request_bytes_processed_per_seconds",
+		Name:      "query_frontend_search_bytes_processed_per_seconds",
 		Help:      "Bytes processed per second in the search query",
 		Buckets:   prometheus.ExponentialBuckets(1024*1024, 2, 10), // from 1MB up to 1GB
-	}, []string{"status_code"})
+	}, []string{"status"})
+
+	sloPerTenant = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "tempo",
+		Name:      "query_frontend_search_queries_within_slo_total",
+		Help:      "Total search queries within SLO per tenant",
+	}, []string{"status"})
 )
 
 type searchSharder struct {
@@ -221,8 +222,21 @@ func (s searchSharder) RoundTrip(r *http.Request) (*http.Response, error) {
 
 	// print out request metrics
 	cancelledReqs := startedReqs - overallResponse.finishedRequests
-	reqTime := time.Since(reqStart).Seconds()
-	throughput := float64(overallResponse.resultsMetrics.InspectedBytes) / reqTime
+	reqTime := time.Since(reqStart)
+	throughput := float64(overallResponse.resultsMetrics.InspectedBytes) / reqTime.Seconds()
+
+	statusCode := http.StatusInternalServerError    // by default, return 500 on errors
+	defer func(status int, reqTime time.Duration) { // record throughput metrics
+		s := strconv.Itoa(status)
+		// orgID, _ := user.ExtractOrgID(ctx)
+		searchThroughput.WithLabelValues(s).Observe(throughput)
+		b := reqTime < (1 * time.Second) // hardcode it for now
+		t := throughput > 1*1024*1024    // 1MB/s throughput
+		if b || t {
+			// we are within SLO if query returned within x seconds or processed y bytes/s data
+			sloPerTenant.WithLabelValues(s).Inc()
+		}
+	}(statusCode, reqTime)
 
 	level.Info(s.logger).Log(
 		"msg", "sharded search query request stats",
@@ -253,18 +267,15 @@ func (s searchSharder) RoundTrip(r *http.Request) (*http.Response, error) {
 		"totalBlockBytes", overallResponse.resultsMetrics.TotalBlockBytes)
 
 	if overallResponse.err != nil {
-		recordMetrics(http.StatusInternalServerError, reqTime, throughput)
-		// TODO: what happens when there is an error in round trip??
 		return nil, overallResponse.err
 	}
 
 	if overallResponse.statusCode != http.StatusOK {
-		recordMetrics(http.StatusInternalServerError, reqTime, throughput)
 		// translate all non-200s into 500s. if, for instance, we get a 400 back from an internal component
 		// it means that we created a bad request. 400 should not be propagated back to the user b/c
 		// the bad request was due to a bug on our side, so return 500 instead.
 		return &http.Response{
-			StatusCode: http.StatusInternalServerError,
+			StatusCode: statusCode,
 			Header:     http.Header{},
 			Body:       io.NopCloser(strings.NewReader(overallResponse.statusMsg)),
 		}, nil
@@ -273,12 +284,10 @@ func (s searchSharder) RoundTrip(r *http.Request) (*http.Response, error) {
 	m := &jsonpb.Marshaler{}
 	bodyString, err := m.MarshalToString(overallResponse.result())
 	if err != nil {
-		recordMetrics(http.StatusInternalServerError, reqTime, throughput)
 		return nil, err
 	}
 
-	statusCode := http.StatusOK
-	recordMetrics(statusCode, reqTime, throughput)
+	statusCode = http.StatusOK
 	return &http.Response{
 		StatusCode: statusCode,
 		Header: http.Header{
@@ -287,13 +296,6 @@ func (s searchSharder) RoundTrip(r *http.Request) (*http.Response, error) {
 		Body:          io.NopCloser(strings.NewReader(bodyString)),
 		ContentLength: int64(len([]byte(bodyString))),
 	}, nil
-}
-
-func recordMetrics(statusCode int, reqTime, throughput float64) {
-	// sc := string(statusCode)
-	sc := fmt.Sprint(statusCode)
-	metricRequestDuration.WithLabelValues(sc).Observe(reqTime)
-	queryThroughput.WithLabelValues(sc).Observe(throughput)
 }
 
 // blockMetas returns all relevant blockMetas given a start/end

--- a/modules/frontend/searchsharding.go
+++ b/modules/frontend/searchsharding.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -229,9 +230,11 @@ func (s searchSharder) RoundTrip(r *http.Request) (*http.Response, error) {
 	throughput := float64(overallResponse.resultsMetrics.InspectedBytes) / reqTime.Seconds()
 	var statusCode int
 
+	query, _ := url.PathUnescape(r.URL.RawQuery)
+	span.SetTag("query", query)
 	level.Info(s.logger).Log(
 		"msg", "sharded search query request stats",
-		"raw_query", r.URL.RawQuery,
+		"query", query,
 		"duration_seconds", reqTime,
 		"request_throughput", throughput,
 		"total_requests", len(reqs),
@@ -249,7 +252,7 @@ func (s searchSharder) RoundTrip(r *http.Request) (*http.Response, error) {
 
 	level.Info(s.logger).Log(
 		"msg", "sharded search query SearchMetrics",
-		"raw_query", r.URL.RawQuery,
+		"query", query,
 		"inspectedBlocks", overallResponse.resultsMetrics.InspectedBlocks,
 		"skippedBlocks", overallResponse.resultsMetrics.SkippedBlocks,
 		"inspectedBytes", overallResponse.resultsMetrics.InspectedBytes,

--- a/modules/frontend/searchsharding.go
+++ b/modules/frontend/searchsharding.go
@@ -41,7 +41,7 @@ var (
 var (
 	metricInspectedBytes = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: "tempo",
-		Name:      "frontend_query_results_metrics_inspected_bytes",
+		Name:      "query_frontend_result_metrics_inspected_bytes",
 		Help:      "Inspected Bytes in a search query",
 		Buckets:   prometheus.ExponentialBuckets(1024*1024, 2, 10), // from 1MB up to 1GB
 	})

--- a/modules/frontend/searchsharding.go
+++ b/modules/frontend/searchsharding.go
@@ -38,6 +38,15 @@ var (
 	})
 )
 
+var (
+	metricInspectedBytes = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "tempo",
+		Name:      "frontend_query_results_metrics_inspected_bytes",
+		Help:      "Inspected Bytes in a search query",
+		Buckets:   prometheus.ExponentialBuckets(1024*1024, 2, 10), // from 1MB up to 1GB
+	})
+)
+
 type searchSharder struct {
 	next      http.RoundTripper
 	reader    tempodb.Reader

--- a/modules/frontend/searchsharding.go
+++ b/modules/frontend/searchsharding.go
@@ -285,10 +285,10 @@ func (s searchSharder) RoundTrip(r *http.Request) (*http.Response, error) {
 	}
 
 	// only record metric when it's enabled and within slo
-	if s.sloCfg.DurationSLO != 0 && s.sloCfg.ThroughputSLO != 0 {
-		if reqTime < s.sloCfg.DurationSLO || throughput > s.sloCfg.ThroughputSLO {
+	if s.sloCfg.DurationSLO != 0 && s.sloCfg.ThroughputBytesSLO != 0 {
+		if reqTime < s.sloCfg.DurationSLO || throughput > s.sloCfg.ThroughputBytesSLO {
 			// query is within SLO if query returned 200 within DurationSLO seconds OR
-			// processed ThroughputSLO bytes/s data
+			// processed ThroughputBytesSLO bytes/s data
 			sloSearchCounter.WithLabelValues(tenantID).Inc()
 		}
 	}

--- a/modules/frontend/searchsharding.go
+++ b/modules/frontend/searchsharding.go
@@ -223,7 +223,7 @@ func (s searchSharder) RoundTrip(r *http.Request) (*http.Response, error) {
 	// print out request metrics
 	cancelledReqs := startedReqs - overallResponse.finishedRequests
 	reqTime := time.Since(reqStart)
-	// FIXME: resultsMetrics and throughput is 0 in case TraceQL
+	// FIXME: InspectedBytes is 0 for TraceQL Search, SLO and throughput will be incorrect
 	throughput := float64(overallResponse.resultsMetrics.InspectedBytes) / reqTime.Seconds()
 	var statusCode int
 
@@ -265,10 +265,9 @@ func (s searchSharder) RoundTrip(r *http.Request) (*http.Response, error) {
 		// translate all non-200s into 500s. if, for instance, we get a 400 back from an internal component
 		// it means that we created a bad request. 400 should not be propagated back to the user b/c
 		// the bad request was due to a bug on our side, so return 500 instead.
-		statusCode = overallResponse.statusCode
-		recordSearchMetrics(tenantID, statusCode, throughput, reqTime)
+		recordSearchMetrics(tenantID, overallResponse.statusCode, throughput, reqTime)
 		return &http.Response{
-			StatusCode: statusCode,
+			StatusCode: overallResponse.statusCode,
 			Header:     http.Header{},
 			Body:       io.NopCloser(strings.NewReader(overallResponse.statusMsg)),
 		}, nil

--- a/modules/frontend/searchsharding_test.go
+++ b/modules/frontend/searchsharding_test.go
@@ -29,6 +29,11 @@ import (
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
+var defaultSLOcfg = SLOConfig{
+	ThroughputSLO: 0,
+	DurationSLO:   0,
+}
+
 // implements tempodb.Reader interface
 type mockReader struct {
 	metas []*backend.BlockMeta
@@ -551,11 +556,7 @@ func TestSearchSharderRoundTrip(t *testing.T) {
 			}, o, SearchSharderConfig{
 				ConcurrentRequests:    1, // 1 concurrent request to force order
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
-			},
-				SLOConfig{
-					DurationSLO:   1 * time.Second,
-					ThroughputSLO: 10 * 1024,
-				}, log.NewNopLogger())
+			}, defaultSLOcfg, log.NewNopLogger())
 			testRT := NewRoundTripper(next, sharder)
 
 			req := httptest.NewRequest("GET", "/?start=1000&end=1500", nil)
@@ -601,10 +602,7 @@ func TestSearchSharderRoundTripBadRequest(t *testing.T) {
 		ConcurrentRequests:    defaultConcurrentRequests,
 		TargetBytesPerRequest: defaultTargetBytesPerRequest,
 		MaxDuration:           5 * time.Minute,
-	}, SLOConfig{
-		DurationSLO:   1 * time.Second,
-		ThroughputSLO: 10 * 1024,
-	}, log.NewNopLogger())
+	}, defaultSLOcfg, log.NewNopLogger())
 	testRT := NewRoundTripper(next, sharder)
 
 	// no org id
@@ -633,10 +631,7 @@ func TestSearchSharderRoundTripBadRequest(t *testing.T) {
 		ConcurrentRequests:    defaultConcurrentRequests,
 		TargetBytesPerRequest: defaultTargetBytesPerRequest,
 		MaxDuration:           5 * time.Minute,
-	}, SLOConfig{
-		DurationSLO:   1 * time.Second,
-		ThroughputSLO: 10 * 1024,
-	}, log.NewNopLogger())
+	}, defaultSLOcfg, log.NewNopLogger())
 	testRT = NewRoundTripper(next, sharder)
 
 	req = httptest.NewRequest("GET", "/?start=1000&end=1500", nil)

--- a/modules/frontend/searchsharding_test.go
+++ b/modules/frontend/searchsharding_test.go
@@ -30,8 +30,8 @@ import (
 )
 
 var testSLOcfg = SLOConfig{
-	ThroughputSLO: 0,
-	DurationSLO:   0,
+	ThroughputBytesSLO: 0,
+	DurationSLO:        0,
 }
 
 // implements tempodb.Reader interface

--- a/modules/frontend/searchsharding_test.go
+++ b/modules/frontend/searchsharding_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
-var defaultSLOcfg = SLOConfig{
+var testSLOcfg = SLOConfig{
 	ThroughputSLO: 0,
 	DurationSLO:   0,
 }
@@ -556,7 +556,7 @@ func TestSearchSharderRoundTrip(t *testing.T) {
 			}, o, SearchSharderConfig{
 				ConcurrentRequests:    1, // 1 concurrent request to force order
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
-			}, defaultSLOcfg, log.NewNopLogger())
+			}, testSLOcfg, log.NewNopLogger())
 			testRT := NewRoundTripper(next, sharder)
 
 			req := httptest.NewRequest("GET", "/?start=1000&end=1500", nil)
@@ -602,7 +602,7 @@ func TestSearchSharderRoundTripBadRequest(t *testing.T) {
 		ConcurrentRequests:    defaultConcurrentRequests,
 		TargetBytesPerRequest: defaultTargetBytesPerRequest,
 		MaxDuration:           5 * time.Minute,
-	}, defaultSLOcfg, log.NewNopLogger())
+	}, testSLOcfg, log.NewNopLogger())
 	testRT := NewRoundTripper(next, sharder)
 
 	// no org id
@@ -631,7 +631,7 @@ func TestSearchSharderRoundTripBadRequest(t *testing.T) {
 		ConcurrentRequests:    defaultConcurrentRequests,
 		TargetBytesPerRequest: defaultTargetBytesPerRequest,
 		MaxDuration:           5 * time.Minute,
-	}, defaultSLOcfg, log.NewNopLogger())
+	}, testSLOcfg, log.NewNopLogger())
 	testRT = NewRoundTripper(next, sharder)
 
 	req = httptest.NewRequest("GET", "/?start=1000&end=1500", nil)

--- a/modules/frontend/searchsharding_test.go
+++ b/modules/frontend/searchsharding_test.go
@@ -551,7 +551,11 @@ func TestSearchSharderRoundTrip(t *testing.T) {
 			}, o, SearchSharderConfig{
 				ConcurrentRequests:    1, // 1 concurrent request to force order
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
-			}, log.NewNopLogger())
+			},
+				SLOConfig{
+					DurationSLO:   1 * time.Second,
+					ThroughputSLO: 10 * 1024,
+				}, log.NewNopLogger())
 			testRT := NewRoundTripper(next, sharder)
 
 			req := httptest.NewRequest("GET", "/?start=1000&end=1500", nil)
@@ -597,6 +601,9 @@ func TestSearchSharderRoundTripBadRequest(t *testing.T) {
 		ConcurrentRequests:    defaultConcurrentRequests,
 		TargetBytesPerRequest: defaultTargetBytesPerRequest,
 		MaxDuration:           5 * time.Minute,
+	}, SLOConfig{
+		DurationSLO:   1 * time.Second,
+		ThroughputSLO: 10 * 1024,
 	}, log.NewNopLogger())
 	testRT := NewRoundTripper(next, sharder)
 
@@ -626,6 +633,9 @@ func TestSearchSharderRoundTripBadRequest(t *testing.T) {
 		ConcurrentRequests:    defaultConcurrentRequests,
 		TargetBytesPerRequest: defaultTargetBytesPerRequest,
 		MaxDuration:           5 * time.Minute,
+	}, SLOConfig{
+		DurationSLO:   1 * time.Second,
+		ThroughputSLO: 10 * 1024,
 	}, log.NewNopLogger())
 	testRT = NewRoundTripper(next, sharder)
 

--- a/modules/frontend/tracebyidsharding.go
+++ b/modules/frontend/tracebyidsharding.go
@@ -64,7 +64,7 @@ func (s shardQuery) RoundTrip(r *http.Request) (*http.Response, error) {
 		}, nil
 	}
 
-	reqStart := time.Now() // time request
+	reqStart := time.Now()
 
 	// context propagation
 	r = r.WithContext(ctx)
@@ -159,10 +159,9 @@ func (s shardQuery) RoundTrip(r *http.Request) (*http.Response, error) {
 	}
 	wg.Wait()
 
-	reqTime := time.Since(reqStart) // time request
+	reqTime := time.Since(reqStart)
 
 	if overallError != nil {
-		// s.recordMetrics(tenantID, statusCode, reqTime)
 		return nil, overallError
 	}
 
@@ -178,7 +177,6 @@ func (s shardQuery) RoundTrip(r *http.Request) (*http.Response, error) {
 		if statusCode != http.StatusNotFound {
 			statusCode = 500
 		}
-		// s.recordMetrics(tenantID, statusCode, reqTime)
 
 		return &http.Response{
 			StatusCode: statusCode,
@@ -195,7 +193,6 @@ func (s shardQuery) RoundTrip(r *http.Request) (*http.Response, error) {
 	})
 	if err != nil {
 		_ = level.Error(s.logger).Log("msg", "error marshalling response to proto", "err", err)
-		// s.recordMetrics(tenantID, statusCode, reqTime)
 		return nil, err
 	}
 

--- a/modules/frontend/tracebyidsharding_test.go
+++ b/modules/frontend/tracebyidsharding_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/go-kit/log"
 	"github.com/gogo/protobuf/proto"
@@ -265,10 +264,7 @@ func TestShardingWareDoRequest(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			sharder := newTraceByIDSharder(2, 2, SLOConfig{
-				DurationSLO:   1 * time.Second,
-				ThroughputSLO: 10 * 1024,
-			}, log.NewNopLogger())
+			sharder := newTraceByIDSharder(2, 2, testSLOcfg, log.NewNopLogger())
 
 			next := RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 				var testTrace *tempopb.Trace

--- a/modules/frontend/tracebyidsharding_test.go
+++ b/modules/frontend/tracebyidsharding_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/gogo/protobuf/proto"
@@ -264,7 +265,10 @@ func TestShardingWareDoRequest(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			sharder := newTraceByIDSharder(2, 2, log.NewNopLogger())
+			sharder := newTraceByIDSharder(2, 2, SLOConfig{
+				DurationSLO:   1 * time.Second,
+				ThroughputSLO: 10 * 1024,
+			}, log.NewNopLogger())
 
 			next := RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 				var testTrace *tempopb.Trace

--- a/pkg/traceql/engine.go
+++ b/pkg/traceql/engine.go
@@ -74,7 +74,7 @@ func (e *Engine) Execute(ctx context.Context, searchReq *tempopb.SearchRequest, 
 
 	res := &tempopb.SearchResponse{
 		Traces: nil,
-		// TODO capture and update metrics
+		// TODO: capture and update metrics, need InspectedBytes for throughput and SLO metrics
 		Metrics: &tempopb.SearchMetrics{},
 	}
 	for {

--- a/pkg/traceql/engine.go
+++ b/pkg/traceql/engine.go
@@ -74,7 +74,7 @@ func (e *Engine) Execute(ctx context.Context, searchReq *tempopb.SearchRequest, 
 
 	res := &tempopb.SearchResponse{
 		Traces: nil,
-		// TODO: capture and update metrics, need InspectedBytes for throughput and SLO metrics
+		// TODO capture and update metrics
 		Metrics: &tempopb.SearchMetrics{},
 	}
 	for {


### PR DESCRIPTION
**What this PR does**:
Expose Throughput (for search only) and SLO Metrics, and add config in Query Frontend to configure SLOs

Note: this doesn't work with TraceQL yet because we are not sending SearchMetrics from TraceQL query execution, it will work after we start returning SearchMetrics from TraceQL query execution

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`