### PR TITLE
[DOCS] Add Parquet doc, fix page weights

### DIFF
--- a/docs/sources/configuration/parquet.md
+++ b/docs/sources/configuration/parquet.md
@@ -21,11 +21,6 @@ The new Parquet block is enabled by default in Tempo 2.0. No data conversion or 
 
 The new Parquet block format requires more CPU and memory resources than the previous v2 format but provides faster search and the new TraceQL.
 
-## Convert to Parquet
-
-You can use `tempo-cli` to convert a Parquet file from its existing schema to the one used in Tempo.
-For instructions, refer to the [Parquet convert command documentation]({{< relref "../operations/tempo_cli#parquet-convert-command" >}}).
-
 ## Disable Parquet
 
 It is possible to disable Parquet and use the previous v2 block format. This disables TraceQL and will result in reduced search performance, but also reduces resource consumption, and may be desired for a high-throughput cluster that does not need these capabilities. Set the block format option to v2 in the Storage section of the configuration file.
@@ -65,3 +60,9 @@ The `cache_control` section contains the follow parameters for Parquet metadata 
 | <code>[footer: <bool> \| default = false]</code> | `false` | Specifies if the footer should be cached |
 | `[column_index: <bool> \| default = false]` | `false` | Specifies if the column index should be cached |
 | `[offset_index: <bool> \| default = false]` | `false` | Specifies if the offset index should be cached |
+
+## Convert to Parquet
+
+If you have used an earlier version of the Parquet format, you can use `tempo-cli` to convert a Parquet file from its existing schema to the one used in Tempo 2.0.
+
+For instructions, refer to the [Parquet convert command documentation]({{< relref "../operations/tempo_cli#parquet-convert-command" >}}).

--- a/docs/sources/getting-started/tempo-in-grafana.md
+++ b/docs/sources/getting-started/tempo-in-grafana.md
@@ -94,7 +94,7 @@ These metrics exist in your Hosted Metrics instance and can also be easily used 
 
 <p align="center"><img src="../assets/trace_custom_metrics_dash.png" alt="Trace custom metrics dashboard"></p>
 
-The metrics generator automatically generates exemplars as well which allows easy metrics to trace linking. [Exemplars]({{< relref "exemplars" >}}) are GA in Grafana Cloud so you can also push your own.
+The metrics generator automatically generates exemplars as well which allows easy metrics to trace linking. [Exemplars](https://grafana.com/docs/grafana-cloud/data-configuration/traces/exemplars/) are GA in Grafana Cloud so you can also push your own.
 
 <p align="center"><img src="../assets/trace_exemplars.png" alt="Trace exemplars"></p>
 

--- a/docs/sources/operations/architecture.md
+++ b/docs/sources/operations/architecture.md
@@ -3,7 +3,7 @@ title: Architecture
 aliases:
  - /docs/tempo/latest/architecture/architecture
  - /docs/tempo/latest/architecture
-weight: 1
+weight: 10
 ---
 
 A collection of documents that detail Tempo architectural decisions and operational implications.

--- a/docs/sources/operations/backend_search.md
+++ b/docs/sources/operations/backend_search.md
@@ -1,11 +1,11 @@
 ---
 title: Backend search
-weight: 9
+weight: 90
 ---
 
 # Backend search
 
-Regardless of whether or not you are using TraceQL or the original search api Tempo will search all of the blocks 
+Regardless of whether or not you are using TraceQL or the original search api Tempo will search all of the blocks
 in the specified time range. Depending on your volume this may result in quite slow queries. This document contains
 some suggestions for tuning your backend to improve performance.
 

--- a/docs/sources/operations/caching.md
+++ b/docs/sources/operations/caching.md
@@ -1,6 +1,6 @@
 ---
 title: Caching
-weight: 6
+weight: 60
 ---
 
 # Caching
@@ -8,7 +8,7 @@ weight: 6
 Caching is mainly used to improve query performance by storing bloom filters of all backend blocks which are accessed on every query.
 
 Tempo uses an external cache to improve query performance.
-The supported implementations are [Memcached](https://memcached.org/) and [Redis](https://redis.io/). 
+The supported implementations are [Memcached](https://memcached.org/) and [Redis](https://redis.io/).
 
 ## Memcached
 
@@ -45,7 +45,7 @@ accept4(): No file descriptors available
 Too many open connections
 ```
 
-When using the [memcached_exporter](https://github.com/prometheus/memcached_exporter), the number of open connections can be observed at `memcached_current_connections`. 
+When using the [memcached_exporter](https://github.com/prometheus/memcached_exporter), the number of open connections can be observed at `memcached_current_connections`.
 
 ## Cache size control
 

--- a/docs/sources/operations/consistent_hash_ring.md
+++ b/docs/sources/operations/consistent_hash_ring.md
@@ -1,6 +1,6 @@
 ---
 title: Consistent Hash Ring
-weight: 2
+weight: 20
 ---
 
 ## Consistent Hash Ring
@@ -10,7 +10,7 @@ Tempo uses the [Consistent Hash Ring](https://cortexmetrics.io/docs/architecture
 There are four consistent hash rings: distributor, ingester, metrics-generator, and compactor. Each exists for a distinct reason.
 
 ### Distributor
-**Participants:** Distributors  
+**Participants:** Distributors
 **Used by:** Distributors
 
 Unless you are running with limits this ring does not impact Tempo operation.
@@ -18,19 +18,19 @@ Unless you are running with limits this ring does not impact Tempo operation.
 This ring is only used when "global" rate limits are used. The distributors use it to count the other active distributors. Incoming traffic is assumed to be evenly spread across all distributors and (global_rate_limit / # of distributors) is used to rate limit locally.
 
 ### Ingester
-**Participants:** Ingesters  
+**Participants:** Ingesters
 **Used by:** Distributors,Queriers
 
 This ring is used by the distributors to load balance traffic into the ingesters. When spans are received the trace id is hashed and they are sent to the appropriate ingesters based on token ownership in the ring. Queriers also use this ring to find the ingesters for querying recent traces.
 
 ### Metrics-generator
-**Participants:** Metrics-generators  
+**Participants:** Metrics-generators
 **Used by:** Distributors
 
 This ring is used by distributors to load balance traffic to the metrics-generators. When spans are received, the trace ID is hashed, and the traces are sent to the appropriate metrics-generators based on token ownership in the ring.
 
 ### Compactor
-**Participants:** Compactors  
+**Participants:** Compactors
 **Used by:** Compactors
 
 This ring is used by the compactors to shard compaction jobs. Jobs are hashed into the ring and the owning compactor is the only one allowed to compact a specific set of blocks to prevent race conditions on compaction.
@@ -41,25 +41,25 @@ Web pages are available at the following endpoints. They show every ring member,
 ring member leaves the ring without properly shutting down (and therefore leaves its tokens in the ring).
 
 ### Distributor
-**Available on:** Distributors  
+**Available on:** Distributors
 **Path:** `/distributor/ring`
 
 Unhealthy distributors have little impact but should be forgotten to reduce cost of maintaining the ring .
 
 ### Ingester
-**Available on:** Distributors  
+**Available on:** Distributors
 **Path:** `/ingester/ring`
 
 Unhealthy ingesters will cause writes to fail. If the ingester is really gone, forget it immediately.
 
 ### Metrics-generators
-**Available on:** Distributors  
+**Available on:** Distributors
 **Path:** `/metrics-generator/ring`
 
 Unhealthy metrics-generators will cause writes to fail. If the metrics-generator is really gone, forget it immediately.
 
 ### Compactor
-**Available on:** Compactors  
+**Available on:** Compactors
 **Path:** `/compactor/ring`
 
 Unhealthy compactors will allow the blocklist to grow significantly. If the compactor is really gone, forget it immediately.

--- a/docs/sources/operations/deployment.md
+++ b/docs/sources/operations/deployment.md
@@ -3,7 +3,7 @@ title: Deploying Tempo
 aliases:
   - /docs/tempo/latest/deployment
   - /docs/tempo/latest/deployment/deployment
-weight: 3
+weight: 30
 ---
 
 # Deploying Tempo
@@ -48,7 +48,7 @@ Which mode is deployed is determined by the runtime configuration `target`, or
 by using the `-target` flag on the command line. The default target is `all`,
 which is the monolithic deployment mode.
 
-> **Note:** _Monolithic mode_ was previously called _single binary mode_. Similarly _scalable monolithic mode_ was previously called _scalable single binary mode_. While the documentation has been updated to reflect this change, some URL names and deployment tooling (e.g. Helm charts) do not yet reflect this change. 
+> **Note:** _Monolithic mode_ was previously called _single binary mode_. Similarly _scalable monolithic mode_ was previously called _scalable single binary mode_. While the documentation has been updated to reflect this change, some URL names and deployment tooling (e.g. Helm charts) do not yet reflect this change.
 
 ### Monolithic
 
@@ -69,7 +69,7 @@ Find docker-compose deployment examples at:
 
 Scalable monolithic mode is similar to the monolithic mode in
 that all components are run within one process. Horizontal scale out is
-achieved by instantiating more than one process, with each having `-target` set to `scalable-single-binary`. 
+achieved by instantiating more than one process, with each having `-target` set to `scalable-single-binary`.
 
 This mode offers some
 flexibility of scaling without the configuration complexity of the full

--- a/docs/sources/operations/generic_forwarding.md
+++ b/docs/sources/operations/generic_forwarding.md
@@ -1,16 +1,19 @@
 ---
 title: Generic forwarding
-weight: 13
+weight: 130
 ---
 
 # Generic forwarding
 
-Generic forwarding allows asynchronous replication of ingested traces. The distributor writes received spans to both the ingester and defined endpoints, if enabled. This feature works in a "best-effort" manner, meaning that no retries happen if an error occurs during replication. 
+Generic forwarding allows asynchronous replication of ingested traces. The distributor writes received spans to both the ingester and defined endpoints, if enabled. This feature works in a "best-effort" manner, meaning that no retries happen if an error occurs during replication.
 
 >**Warning:** Generic forwarding does not work retroactively. Once enabled, the distributor only replicates freshly ingested spans.
 
 ## Configuration
 
-Enabling generic forwarding requires the configuration of two sections. First, define a list of forwarders in the `distributor` section. Each forwarder must specify a unique `name`, supported `backend`, and backend-specific configuration. Second, reference these forwarders in the `overrides` section. This allows for fine-grained control over forwarding and makes it possible to enable this feature globally or on a per-tenant basis.
+Enabling generic forwarding requires the configuration of two sections.
 
-For a detailed view of all the config options for the generic forwarding feature, please refer to [distributor]({{< relref "../configuration/#distributor" >}}) and [overrides]({{< relref "../configuration/#overrides" >}}) config pages.
+1. First, define a list of forwarders in the `distributor` section. Each forwarder must specify a unique `name`, supported `backend`, and backend-specific configuration.
+1. Second, reference these forwarders in the `overrides` section. This allows for fine-grained control over forwarding and makes it possible to enable this feature globally or on a per-tenant basis.
+
+For a detailed view of all the config options for the generic forwarding feature, please refer to [distributor]({{< relref "../configuration/#distributor" >}}) and [overrides]({{< relref "../configuration/#overrides" >}}) configuration pages.

--- a/docs/sources/operations/ingester_pvcs.md
+++ b/docs/sources/operations/ingester_pvcs.md
@@ -1,15 +1,15 @@
 ---
 title: Ingester PVCs
-weight: 5
+weight: 50
 ---
 
 # Ingester persistent volume operations
 
 Tempo ingesters make heavy use of local disks to store write-ahead logs and blocks before being flushed to the backend (GCS, S3, etc.).  It is important to monitor the free volume space as full disks can lead to data loss and other errors. The amount of disk space available affects how much volume a Tempo ingester can process and the length of time an outage to the backend can be tolerated.
 
-Therefore it may be necessary to increase the disk space for ingesters as usage increases. 
+Therefore it may be necessary to increase the disk space for ingesters as usage increases.
 
-## Deploying 
+## Deploying
 
 When deployed as a StatefulSet with Persistent Volume Claims (PVC), some manual steps are required. The following configuration has worked successfully on GKE with GCS:
 

--- a/docs/sources/operations/monitoring.md
+++ b/docs/sources/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring Tempo
-weight: 4
+weight: 40
 ---
 
 # Monitoring Tempo

--- a/docs/sources/operations/parquet/_index.md
+++ b/docs/sources/operations/parquet/_index.md
@@ -1,0 +1,79 @@
+---
+title: Query and inspect Apache Parquet
+menuTitle: Query Parquet
+weight: 75
+---
+
+# Query and inspect Apache Parquet data
+
+Apache Parquet is a column-oriented format and is the default block format for Tempo 2.0.
+Refer to the [Parquet configuration options]({{< relref "../../configuration/parquet.md" >}}) for more information.
+
+You can use `parquet-tools` to query and inspect Parquet files. There are multiple distributions of parquet-tools available. Most of the examples on this page should work with different distributions.
+
+
+
+## Examples
+
+Examples of working with Tempo parquet blocks and popular parquet tooling.
+
+
+This command shows the schema of a Tempo parquet block using the parquet-tools command:
+
+```bash
+$ parquet-tools schema data.parquet
+message Trace {
+  required binary TraceID;
+  repeated group rs {
+    required group Resource {
+      repeated group Attrs {
+        required binary Key (STRING);
+        optional binary Value (STRING);
+        .
+        .
+        .
+```
+
+This command dumps all column sizes for a Tempo block using the `parquet-tools` command:
+
+```bash
+$ parquet-tools column-size data.parquet | sort
+DurationNanos-> Size In Bytes: 799849 Size In Ratio: 0.0011075386
+EndTimeUnixNano-> Size In Bytes: 952660 Size In Ratio: 0.0013191337
+RootServiceName-> Size In Bytes: 108145 Size In Ratio: 1.4974672E-4
+RootSpanName-> Size In Bytes: 212444 Size In Ratio: 2.9416793E-4
+StartTimeUnixNano-> Size In Bytes: 953946 Size In Ratio: 0.0013209144
+TraceID-> Size In Bytes: 3076838 Size In Ratio: 0.00426045
+TraceIDText-> Size In Bytes: 2979464 Size In Ratio: 0.004125618
+rs.Resource.Attrs.Key-> Size In Bytes: 5404392 Size In Ratio: 0.0074833785
+rs.Resource.Attrs.Value-> Size In Bytes: 20337501 Size In Ratio: 0.028161023
+rs.Resource.Attrs.ValueArray-> Size In Bytes: 1838177 Size In Ratio: 0.0025452955
+.
+.
+.
+```
+
+Dump all service names containing "tempo" from the block:
+
+```bash
+$ parquet-tools dump -c rs.Resource.ServiceName data.parquet | grep tempo
+value 60:     R:0 D:1 V:tempo-compactor
+value 6343:   R:0 D:1 V:tempo-ingester
+value 10773:  R:0 D:1 V:tempo-compactor
+value 14397:  R:0 D:1 V:tempo-compactor
+value 16824:  R:0 D:1 V:tempo-ingester
+value 17842:  R:0 D:1 V:tempo-query-frontend
+value 22749:  R:0 D:1 V:tempo-gateway
+value 25311:  R:0 D:1 V:tempo-compactor
+value 30070:  R:0 D:1 V:tempo-compactor
+value 30451:  R:0 D:1 V:tempo-query-frontend
+value 32755:  R:1 D:1 V:tempo-gateway
+value 32866:  R:0 D:1 V:tempo-compactor
+value 34998:  R:0 D:1 V:tempo-querier
+value 37242:  R:0 D:1 V:tempo-querier
+value 40643:  R:0 D:1 V:tempo-compactor
+value 42229:  R:0 D:1 V:tempo-compactor
+value 42241:  R:0 D:1 V:tempo-gateway
+value 43234:  R:0 D:1 V:tempo-gateway
+value 43244:  R:0 D:1 V:tempo-compactor
+```

--- a/docs/sources/operations/parquet/schema.md
+++ b/docs/sources/operations/parquet/schema.md
@@ -1,0 +1,274 @@
+---
+title: Parquet schema
+menuTitle: Parquet schema
+weight: 75
+---
+
+# Apache Parquet schema
+
+Tempo 2.0 uses Apache Parquet as the default column-formatted block format.
+Refer to the [Parquet configuration options]({{< relref "../../configuration/parquet.md" >}}) for more information.
+
+This document describes the schema used with the Parquet block format.
+
+
+## Fully nested versus span-oriented schema
+
+There are two overall approaches to a columnar schema: fully nested or span-oriented.
+Span-oriented means a flattened schema where traces are destructured into rows of spans.
+A fully nested schema means the current trace structures such as Resource/InstrumentationLibrary/Spans/Events are preserved (nested data is natively supported in Parquet).
+In both cases, individual leaf values such as span name and duration are individual columns.
+
+We chose the nested schema for several reasons:
+
+- The block size is much smaller for the nested schema. This is due to the high data duplication incurred when flattening resource-level attributes such as `service.name` to each individual span.
+- A flat schema is not truly "flat" because each span still contains nested data such as attributes and events.
+- Nested schema is much faster to search for resource-level attributes because the resource-level columns are very small (1 row for each batch).
+- Translation to and from the OpenTelemetry Protocol Specification (OTLP) is straightforward.
+- Easily add computed columns (for example, trace duration) at multiple levels such as per-trace, per-batch, etc.
+
+## Static vs dynamic columns
+
+Dynamic vs static columns add another layer to the schema.
+A dynamic schema stores each attribute such as `service.name` and `http.status_code` as its own column and the columns in each parquet file can be different.
+A static schema is unresponsive to the shape of the data, and all attributes are stored in generic key/value containers.
+
+The dynamic schema is the ultimate dream for a columnar format but it is too complex for a first release.
+However, the benefits of that approach are also too good to pass up, so we propose a hybrid approach.
+It is primarily a static schema but with some dynamic columns extracted from trace data based on some heuristics of frequently queried attributes.
+We plan to continue investing in this direction to implement a fully dynamic schema where trace attributes are blown out into independent Parquet columns at runtime.
+
+For more information, refer to the [Parquet design document](https://github.com/mdisibio/tempo/blob/design-proposal-parquet/docs/design-proposals/2022-04%20Parquet.md).
+
+## Schema details
+
+The adopted Parquet schema is mostly a direct translation of OTLP but with some key differences.
+
+The table below uses these abbreviations:
+
+- `rs` = resource spans
+- `ils` - InstrumentLibrarySpans
+
+| | | |
+|:----|:----|:----|
+|Name|Type|Description|
+|TraceID|byte array|The trace ID in 16-byte binary form.|
+|TraceIDText|string|The trace ID in hexadecimal text form.|
+|StartTimeUnixNano|int64|Start time of the first span in the trace, in nanoseconds since unix epoch.|
+|EndTimeUnixNano|int64|End time of the last span in the trace, in nanoseconds since unix epoch.|
+|DurationNanos|int64|Total trace duration in nanoseconds, computed as difference between EndTimeUnixNano and StartTimeUnixNano.|
+|RootServiceName|string|The resource-level `service.name` attribute (rs.Resource.ServiceName) from the root span of the trace if one exists, else null.|
+|RootSpanName|string|The name (rs.ils.Spans.Name) of the root span if one exists, else null.|
+|rs| |Short-hand for "ResourceSpans"|
+|rs.Resource.ServiceName|string|A dedicated column for the resource-level `service.name` attribute if present. https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/#service|
+|rs.Resource.Cluster|string|A dedicated column for the resource-level `cluster` attribute if present and of string type. Values of other types will be stored in the generic attribute columns.|
+|rs.Resource.Namespace|string|A dedicated column for the resource-level `namespace` attribute if present and of string type. Values of other types will be stored in the generic attribute columns.|
+|rs.Resource.Pod|string|A dedicated column for the resource-level `pod` attribute if present and of string type. Values of other types will be stored in the generic attribute columns.|
+|rs.Resource.Container|string|A dedicated column for the resource-level `container` attribute if present and of string type. Values of other types will be stored in the generic attribute columns.|
+|rs.Resource.K8sClusterName| |A dedicated column for the resource-level `k8s.cluster.name` attribute if present and of string type. Values of other types will be stored in the generic attribute columns. https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/k8s/#cluster|
+|rs.Resource.K8sNamespaceName|string|A dedicated column for the resource-level `k8s.namespace.name` attribute if present and of string type. Values of other types will be stored in the generic attribute columns. https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/k8s/#namespace|
+|rs.Resource.K8sPodName|string|A dedicated column for the resource-level `k8s.pod.name` attribute if present and of string type. Values of other types will be stored in the generic attribute columns. https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/k8s/#pod|
+|rs.Resource.K8sContainerName|string|A dedicated column for the resource-level `k8s.container.name` attribute if present and of string type. Values of other types will be stored in the generic attribute columns. https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/k8s/#container|
+|rs.Resource.Attrs.Key|string|All resource attributes that do not have a dedicated column are stored as a key value pair in these columns. The Key column stores the name, and then one of the Value columns is populated according to the attribute's data type. The other value columns will contain null.|
+|rs.Resource.Attrs.Value|string|The attribute value if string type, else null.|
+|rs.Resource.Attrs.ValueInt|int|The attribute value if integer type, else null.|
+|rs.Resource.Attrs.ValueDouble|float|The attribute value if float type, else null.|
+|rs.Resource.Attrs.ValueBool|bool|The attribute value if boolean type, else null.|
+|rs.Resource.Attrs.ValueArray|byte array|The attribute value if nested array type, else null. Protocol buffer encoded binary data.|
+|rs.Resource.Attrs.ValueKVList|byte array|The attribute value if nested key/value map type, else null. Protocol buffer encoded binary data.|
+|rs.ils| |Shorthand for "ResourceSpans.InstrumentationLibrarySpans"|
+|rs.ils.il| |Shorthand for ResourceSpans.InstrumentationLibrarySpans.InstrumentationLibrary|
+|rs.ils.il.Name|string|InstrumentationLibrary name if present, else empty string. https://opentelemetry.io/docs/reference/specification/glossary/#instrumentation-library|
+|rs.ils.il.Version|string|The InstrumentationLibrary version if present, else empty string. https://opentelemetry.io/docs/reference/specification/glossary/#instrumentation-library|
+|rs.ils.Spans.ID|byte array|Span unique ID|
+|rs.ils.Spans.Name|string|Span name|
+|rs.ils.Spans.ParentSpanID|byte array|The unique ID of the span's parent. For root spans without a parent this is null.|
+|rs.ils.Spans.StartUnixNanos|int64|Start time the span in nanoseconds since unix epoch.|
+|rs.ils.Spans.EndUnixNanos|int64|End time the span in nanoseconds since unix epoch.|
+|rs.ils.Spans.Kind|int|The span's kind. Defined values: 0. Unset; 1. Internal; 2. Server; 3. Client; 4. Producer; 5. Consumer; https://opentelemetry.io/docs/reference/specification/trace/api/#spankind|
+|rs.ils.Spans.StatusCode|int|The span status. Defined values: 0: Unset; 1: OK; 2: Error. https://opentelemetry.io/docs/reference/specification/trace/api/#set-status|
+|rs.ils.Spans.StatusMessage|string|Optional message to accompany Error status.|
+|rs.ils.Spans.HttpMethod|string|A dedicated column for the span-level `http.method` attribute if present and of string type, else null. Values of other types will be stored in the generic attribute columns. https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/http/#common-attributes|
+|rs.ils.Spans.HttpStatusCode|int|A dedicated column for the span-level `http.status_code` attribute if present and of integer type, else null. Values of other types will be stored in the generic attribute columns. https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/http/#common-attributes|
+|rs.ils.Spans.HttpUrl|string|A dedicated column for the span-level `http.url` attribute if present and of string type, else null. Values of other types will be stored in the generic attribute columns. https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/http/#http-client|
+|rs.ils.Spans.DroppedAttributesCount|int|Number of attributes that were dropped|
+|rs.ils.Spans.Attrs.Key|string|All span attributes that do not have a dedicated column are stored as a key value pair in these columns. The Key column stores the name, and then one of the Value columns is populated according to the attribute's data type. The other value columns will contain null.|
+|rs.ils.Spans.Attrs.Value|string|The attribute value if string type, else null.|
+|rs.ils.Spans.Attrs.ValueInt|int|The attribute value if integer type, else null.|
+|rs.ils.Spans.Attrs.ValueDouble|float|The attribute value if float type, else null.|
+|rs.ils.Spans.Attrs.ValueBool|bool|The attribute value if boolean type, else null.|
+|rs.ils.Spans.Attrs.ValueArray|byte array|The attribute value if nested array type, else null. Protocol buffer encoded binary data.|
+|rs.ils.Spans.Attrs.ValueKVList|byte array|The attribute value if nested key/value map type, else null. Protocol buffer encoded binary data.|
+|rs.ils.Spans.DroppedEventsCount|int|The number of events that were dropped|
+|rs.ils.Spans.Events.TimeUnixNano|int64|The timestamp of the event, as nanoseconds since unix epoch.|
+|rs.ils.Spans.Events.Name|string|The event name or message.|
+|rs.ils.Spans.Events.DroppedAttributesCount|int|The number of event attributes that were dropped.|
+|rs.ils.Spans.Events.Attrs.Key|string|All event attributes are stored as a key value pair in these columns. The Key column stores the name.|
+|rs.ils.Spans.Events.Attrs.Value|byte array|The attribute value, Protocol buffer encoded binary data.|
+|rs.ils.Spans.DroppedLinksCount|int|The number of links that were dropped.|
+|rs.ils.Spans.Links|byte array|Protocol-buffer encoded span links if present, else null.|
+|rs.ils.Spans.TraceState|string|The span's TraceState value if present, else empty string.https://opentelemetry.io/docs/reference/specification/trace/api/#tracestate|
+
+
+### Block Schema display in Parquet Message format
+
+```yaml
+message Trace {
+  required binary TraceID;
+  required binary TraceIDText (STRING);
+  required int64 StartTimeUnixNano (INTEGER(64,false));
+  required int64 EndTimeUnixNano (INTEGER(64,false));
+  required int64 DurationNanos (INTEGER(64,false));
+  required binary RootServiceName (STRING);
+  required binary RootSpanName (STRING);
+
+  repeated group rs { // Resource spans
+    required group Resource {
+      repeated group Attrs {
+        required binary Key (STRING);
+        optional binary Value (STRING);
+        optional int64 ValueInt (INTEGER(64,true));
+        optional double ValueDouble;
+        optional boolean ValueBool;
+        optional binary ValueKVList (STRING);
+        optional binary ValueArray (STRING);
+      }
+
+      required binary ServiceName (STRING);
+      optional binary Cluster (STRING);
+      optional binary Namespace (STRING);
+      optional binary Pod (STRING);
+      optional binary Container (STRING);
+      optional binary K8sClusterName (STRING);
+      optional binary K8sNamespaceName (STRING);
+      optional binary K8sPodName (STRING);
+      optional binary K8sContainerName (STRING);
+      optional binary Test (STRING);
+    }
+    repeated group ils { // InstrumentationLibrarySpans
+      required group il { // InstrumentationLibrary
+        required binary Name (STRING);
+        required binary Version (STRING);
+      }
+      repeated group Spans {
+        required binary ID;
+        required binary Name (STRING);
+        required int64 Kind (INTEGER(64,true));
+        required binary ParentSpanID;
+        required binary TraceState (STRING);
+        required int64 StartUnixNanos (INTEGER(64,false));
+        required int64 EndUnixNanos (INTEGER(64,false));
+        required int64 StatusCode (INTEGER(64,true));
+        required binary StatusMessage (STRING);
+        repeated group Attrs {
+          required binary Key (STRING);
+          optional binary Value (STRING);
+          optional int64 ValueInt (INTEGER(64,true));
+          optional double ValueDouble;
+          optional boolean ValueBool;
+          optional binary ValueKVList (STRING);
+          optional binary ValueArray (STRING);
+        }
+        required int32 DroppedAttributesCount (INTEGER(32,true));
+        repeated group Events {
+          required int64 TimeUnixNano (INTEGER(64,false));
+          required binary Name (STRING);
+          repeated group Attrs {
+            required binary Key (STRING);
+            required binary Value;
+          }
+          required int32 DroppedAttributesCount (INTEGER(32,true));
+          optional binary Test (STRING);
+        }
+        required int32 DroppedEventsCount (INTEGER(32,true));
+        required binary Links;
+        required int32 DroppedLinksCount (INTEGER(32,true));
+
+        optional binary HttpMethod (STRING);
+        optional binary HttpUrl (STRING);
+        optional int64 HttpStatusCode (INTEGER(64,true));
+      }
+    }
+  }
+}
+```
+## Trace-level attributes
+For speed and ease-of-use, we are projecting several values to columns at the trace-level:
+* Trace ID - Don't store on each span.
+* Root service/span names/StartTimeUnixNano - These are selected properties of the root span in each trace (if there is one). These are used for displaying results in the Grafana UI. These properties are computed at ingest time and stored once for efficiency, so we don't have to find the root span.
+* `DurationNanos` - The total trace duration, computed at ingest time. This powers the min/max duration filtering in the current Tempo search and is more efficient than scanning the spans duration column. However, it may go away with TraceQL or we could decide to change it to span-level duration filtering too.
+
+## Dedicated columns
+
+Projecting attributes to their own columns has benefits for speed and size.
+Therefore we are taking an opinionated approach and projecting some common attributes to their own columns.
+All other attributes are stored in the generic key/value maps and are still searchable, but not as quickly.
+We chose these attributes based on what we commonly use ourselves (scratching our own itch), but we think they will be useful to most workloads.
+
+Resource-level attributes include the following:
+
+* `service.name`
+* `cluster` and `k8s.cluster.name`
+* `namespace` and `k8s.namespace.name`
+* `pod` and `k8s.pod.name`
+* `container` and `k8s.container.name`
+
+Span-level attributes include the following:
+
+* `http.method`
+* `http.url`
+* `http.status_code` (int)
+
+## "Any"-type Attributes
+
+OTLP attributes have variable data types, which is easy to accomplish in formats like protocol-buffers, but does not translate directly to Parquet.
+Each column must have a concrete type.
+There are several possibilities here but we chose to have optional values for each concrete type.
+`Array` and `KeyValueList` types are stored as protocol-buffer-encoded byte arrays.
+
+```yaml
+repeated group Attrs {
+    required binary  Key (STRING);
+
+    # Only one of these will be set
+    optional binary  Value (STRING);
+    optional boolean ValueBool;
+    optional double  ValueDouble;
+    optional int64   ValueInt (INT(64,true));
+    optional binary  ValueArray (STRING);
+    optional binary  ValueKVList (STRING);
+}
+```
+
+Pros:
+
+* Preserves the functionality of parquet column min/max statistics which can be leveraged during search
+* Native data types should be more efficient to store and process
+
+Cons:
+
+* Many nulls - as each attribute only populates 1 column, the other 5 are guaranteed to be null. This has a non-trivial impact on storage size.
+
+## Event attributes
+
+Span event attributes are stored as JSON-encoded strings in a generic key/value map. This is by far the most space-efficient encoding and the trade-off of decreased searchability seems worthwhile. Storing event attributes this way reduces the block size ~16% for our dataset, which is huge. There are currently no use cases to search event attributes, but we can revisit this in the future if needed.
+
+```yaml
+repeated group Attrs {
+    required binary Key (STRING);
+    required binary Value (STRING);
+}
+```
+
+## Compression and encoding
+
+Parquet has robust support for many compression algorithms and data encodings. We have found excellent combinations of storage size and performance with the following:
+
+1. Snappy Compression - Enable on all columns
+1. Dictionary encoding - Enable on all string columns (including byte array ParentSpanID). Most strings are very repetitive so this works well to optimize storage size. However we can greatly speed up search by inspecting the dictionary first and eliminating pages with no matches.
+1. Time and duration unix nanos - Delta encoding
+1. Rarely used columns such as `DroppedAttributesCount` - These columns are usually all zeroes, RLE works well.
+
+### Bloom filters
+
+Parquet has native support for bloom filters. However, Tempo does not use them at this time. Tempo already has sophisticated support for sharding and caching bloom filters.

--- a/docs/sources/operations/parquet/schema.md
+++ b/docs/sources/operations/parquet/schema.md
@@ -240,18 +240,9 @@ repeated group Attrs {
 }
 ```
 
-Pros:
-
-* Preserves the functionality of parquet column min/max statistics which can be leveraged during search
-* Native data types should be more efficient to store and process
-
-Cons:
-
-* Many nulls - as each attribute only populates 1 column, the other 5 are guaranteed to be null. This has a non-trivial impact on storage size.
-
 ## Event attributes
 
-Span event attributes are stored as JSON-encoded strings in a generic key/value map. This is by far the most space-efficient encoding and the trade-off of decreased searchability seems worthwhile. Storing event attributes this way reduces the block size ~16% for our dataset, which is huge. There are currently no use cases to search event attributes, but we can revisit this in the future if needed.
+Event attributes are stored as protocol-buffer encoded.
 
 ```yaml
 repeated group Attrs {

--- a/docs/sources/operations/polling.md
+++ b/docs/sources/operations/polling.md
@@ -1,30 +1,30 @@
 ---
 title: Polling and monitoring
-weight: 8
+weight: 80
 ---
 
-# Polling 
+# Polling
 
 Tempo maintains knowledge of the state of the backend by polling it on regular intervals. There are currently
 only two components that need this knowledge and, consequently, only two that poll the backend: compactors
-and queriers. 
+and queriers.
 
-To reduce calls to the backend, only a small subset of compactors actually list all blocks and build 
+To reduce calls to the backend, only a small subset of compactors actually list all blocks and build
 what's called a tenant index. The tenant index is a gzip'ed json file located at `/<tenant>/index.json.gz` containing
 an entry for every block and compacted block for that tenant. This is done once every `blocklist_poll` duration.
 
-All other compactors and all queriers then rely on downloading this file, unzipping it and using the contained list. 
+All other compactors and all queriers then rely on downloading this file, unzipping it and using the contained list.
 Again, this is done once every `blocklist_poll` duration.
 
 Due to this behavior, a given compactor or querier will often have an out of date blocklist.
-During normal operation, it will stale by at most 2x the configured `blocklist_poll`. 
+During normal operation, it will stale by at most 2x the configured `blocklist_poll`.
 
 >**Note**: For details about configuring polling, see [polling configuration]({{< relref "../configuration/polling" >}}).
 
 ## Monitoring
 
 See our Jsonnet for example [alerts](https://github.com/grafana/tempo/blob/main/operations/tempo-mixin/alerts.libsonnet) and [runbook entries](https://github.com/grafana/tempo/blob/main/operations/tempo-mixin/runbook.md)
-related to polling. 
+related to polling.
 
 If you are building your own dashboards/alerts here are a few relevant metrics:
 

--- a/docs/sources/operations/server_side_metrics.md
+++ b/docs/sources/operations/server_side_metrics.md
@@ -1,6 +1,6 @@
 ---
 title: Server-side metrics
-weight: 12
+weight: 110
 ---
 
 # Server-side metrics

--- a/docs/sources/operations/serverless_aws.md
+++ b/docs/sources/operations/serverless_aws.md
@@ -1,9 +1,9 @@
 ---
 title: Backend search - serverless AWS setup
-alias: 
+alias:
 - /docs/tempo/latest/operations/backend_search/serverless_aws/
 - /docs/tempo/latest/operations/serverless_aws/
-weight: 11
+weight: 95
 ---
 
 # AWS Lambda for serverless backend search
@@ -17,7 +17,7 @@ For more guidance on configuration options for full backend search [check here](
     cd ./cmd/tempo-serverless && make build-lambda-zip
     ```
 
-    This will create a ZIP file containing the binary required for 
+    This will create a ZIP file containing the binary required for
     the function. The file name will be of the form: `./lambda/tempo-<branch name>-<commit hash>.zip`.
     Here is an example of that name:
 
@@ -74,7 +74,7 @@ For more guidance on configuration options for full backend search [check here](
         }
     }
     ```
-    
+
 5. Add the hostname of the newly-created ALB to the querier config:
 
     ```

--- a/docs/sources/operations/serverless_gcp.md
+++ b/docs/sources/operations/serverless_gcp.md
@@ -1,6 +1,6 @@
 ---
 title: Backend search - serverless GCP setup
-weight: 10
+weight: 93
 alias:
 - /docs/tempo/latest/operations/backend_search/serverless_gcp/
 - /docs/tempo/latest/operations/serverless_gcp/
@@ -37,7 +37,7 @@ For more guidance on configuration options for full backend search [check here](
       // this can be increased if you would like to use multiple functions
       count = 1
     }
-    
+
     resource "google_cloud_run_service" "run" {
       count = local.count
 

--- a/docs/sources/operations/tempo_cli.md
+++ b/docs/sources/operations/tempo_cli.md
@@ -2,7 +2,7 @@
 title: Tempo CLI
 description: Guide to using tempo-cli
 keywords: ["tempo", "cli", "tempo-cli", "command line interface"]
-weight: 7
+weight: 70
 ---
 
 # Tempo CLI
@@ -25,6 +25,7 @@ tempo-cli command [subcommand] -h
 ```
 
 ## Running Tempo CLI
+
 Tempo CLI is currently available as source code. A working Go installation is required to build it. It can be compiled to a native binary and executed normally, or it can be executed using the `go run` command.
 
 **Example:**

--- a/docs/sources/setup/linux.md
+++ b/docs/sources/setup/linux.md
@@ -75,14 +75,14 @@ Refer to the [Tempo configuration documentation]({{< relref "../configuration" >
 
 In the following configuration, Tempo options are altered to only listen to the OTLP gRPC and HTTP protocols.
 By default, Tempo listens for all compatible protocols.
-The [extended instructions for installing the TNS application]({{< relref "../linux" >}}) and Grafana Agent to verify that Tempo is receiving traces, relies on the default Jaeger port being available. If Tempo were also attempting to listen on the same port as the Grafana Agent for Jaeger, then Tempo would not start due a port conflict, hence we disable listening on that port in Tempo for a single Linux node.
+The [extended instructions for installing the TNS application]({{< relref "set-up-test-app" >}}) and Grafana Agent to verify that Tempo is receiving traces, relies on the default Jaeger port being available. If Tempo were also attempting to listen on the same port as the Grafana Agent for Jaeger, then Tempo would not start due a port conflict, hence we disable listening on that port in Tempo for a single Linux node.
 
 ```yaml
 server:
   http_listen_port: 3200
 
 distributor:
-  receivers:                   
+  receivers:
       otlp:
         protocols:
           http:


### PR DESCRIPTION
**What this PR does**:
Adds draft Parquet documentation for configuration, schema, and examples. Also: 
* Fixes page weights for the Deployment files
* Fixes broken links in two files

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`