### PR TITLE
[DOC] Added feature flag info for trace view

### DIFF
--- a/docs/sources/configuration/parquet.md
+++ b/docs/sources/configuration/parquet.md
@@ -11,7 +11,7 @@ Tempo has a default columnar block format based on Apache Parquet. [TraceQL]({{<
 
 A columnar block format may result in improved search performance and also enables a large ecosystem of tools access to the underlying trace data. For example, you can use `parquet-tools` to [query Parquet data]({{< relref "../operations/parquet" >}}).
 
-For more information, refer to the [Parquet schema]({{< relref "../operations/parquet/schema" >}}), the [Parquet design document](https://github.com/mdisibio/tempo/blob/design-proposal-parquet/docs/design-proposals/2022-04%20Parquet.md), and [Issue 1480](https://github.com/grafana/tempo/issues/1480).
+For more information, refer to the [Parquet schema]({{< relref "../operations/parquet/schema" >}}) and the [Parquet design document](https://github.com/mdisibio/tempo/blob/design-proposal-parquet/docs/design-proposals/2022-04%20Parquet.md).
 
 If you install using the new Helm charts, then Parquet is enabled by default.
 

--- a/docs/sources/configuration/parquet.md
+++ b/docs/sources/configuration/parquet.md
@@ -9,9 +9,9 @@ weight: 75
 
 Tempo has a default columnar block format based on Apache Parquet. [TraceQL]({{< relref "../traceql" >}}), the query language for traces, requires Parquet. In a future release, Parquet will be required to use traces search.
 
-A columnar block format may result in improved search performance and also enables a large ecosystem of tools access to the underlying trace data.
+A columnar block format may result in improved search performance and also enables a large ecosystem of tools access to the underlying trace data. For example, you can use `parquet-tools` to [query Parquet data]({{< relref "../operations/parquet" >}}).
 
-For more information, refer to the [Parquet design document](https://github.com/mdisibio/tempo/blob/design-proposal-parquet/docs/design-proposals/2022-04%20Parquet.md) and [Issue 1480](https://github.com/grafana/tempo/issues/1480).
+For more information, refer to the [Parquet schema]({{< relref "../operations/parquet/schema" >}}), the [Parquet design document](https://github.com/mdisibio/tempo/blob/design-proposal-parquet/docs/design-proposals/2022-04%20Parquet.md), and [Issue 1480](https://github.com/grafana/tempo/issues/1480).
 
 If you install using the new Helm charts, then Parquet is enabled by default.
 

--- a/docs/sources/getting-started/tempo-in-grafana.md
+++ b/docs/sources/getting-started/tempo-in-grafana.md
@@ -19,6 +19,17 @@ Traces can be discovered by searching logs for entries containing trace IDs.  Th
 <p align="center"><img src="../assets/log-search.png" alt="Log Search"></p>
 
 
+## Use TraceQL to dig deep into trace data
+
+Inspired by PromQL and LogQL, TraceQL is a query language designed for selecting traces in Tempo.
+
+The default Tempo search reviews the whole trace. TraceQL provides a method for formulating precise queries so you can zoom in to the data you need. Query results are returned faster because the queries limit what is searched.
+These queries also make it possible for you to understand the broad context for an event sequence.
+
+You can run a TraceQL query either by issuing it to Tempo’s `q` parameter of the [`search` API endpoint]({{< relref "../api_docs/#search" >}}), or, for those using Tempo in conjunction with Grafana, by using Grafana’s [TraceQL query editor]({{< relref "../traceql/query-editor" >}}).
+
+For details about how queries are constructed, read the [TraceQL documentation]({{< relref "../traceql" >}}).
+
 ## Find traces using Tempo search
 
 Search for traces using common dimensions such as time range, duration, span tags, service names, and more. Use the trace view to quickly diagnose errors and high-latency events in your system.

--- a/docs/sources/getting-started/tempo-in-grafana.md
+++ b/docs/sources/getting-started/tempo-in-grafana.md
@@ -23,8 +23,7 @@ Traces can be discovered by searching logs for entries containing trace IDs.  Th
 
 Inspired by PromQL and LogQL, TraceQL is a query language designed for selecting traces in Tempo.
 
-The default Tempo search reviews the whole trace. TraceQL provides a method for formulating precise queries so you can zoom in to the data you need. Query results are returned faster because the queries limit what is searched.
-These queries also make it possible for you to understand the broad context for an event sequence.
+The default Tempo search reviews the whole trace. TraceQL provides a method for formulating precise queries so you can quickly identify the traces and spans that you need. Query results are returned faster because the queries limit what is searched.
 
 You can run a TraceQL query either by issuing it to Tempo’s `q` parameter of the [`search` API endpoint]({{< relref "../api_docs/#search" >}}), or, for those using Tempo in conjunction with Grafana, by using Grafana’s [TraceQL query editor]({{< relref "../traceql/query-editor" >}}).
 

--- a/docs/sources/traceql/query-editor.md
+++ b/docs/sources/traceql/query-editor.md
@@ -13,7 +13,9 @@ keywords:
 
 # TraceQL query editor
 
-With Tempo 2.0, you can use the TraceQL query editor in the Tempo data source to build queries and drill-down into result sets. The editor is available in Grafana’s Explore interface.
+With Tempo 2.0, you can use the TraceQL viewer and query editor in the Tempo data source to build queries and drill-down into result sets. The editor is available in Grafana’s Explore interface.
+
+>**NOTE**: To use the TraceQL query editor, you need to enable the `traceqlEditor` feature flag. This feature is available starting in Grafana 9.3.2.
 
 
 <p align="center"><img src="../assets/query-editor-http-method.png" alt="Query editor showing request for http.method" /></p>


### PR DESCRIPTION
**What this PR does**:
Adds feature flag for enabling trace view to TraceQL docs and links between Parquet docs.

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`