### PR TITLE
Fix broken link in TraceQL doc

### DIFF
--- a/docs/sources/traceql/_index.md
+++ b/docs/sources/traceql/_index.md
@@ -25,7 +25,7 @@ TraceQL requires Tempo’s Parquet columnar format to be enabled. For informatio
 
 ## TraceQL query editor
 
-With Tempo 2.0, you can use the TraceQL query editor in the Tempo data source to build queries and drill-down into result sets. The editor is available in Grafana’s Explore interface. For more information, refer to [TraceQL query editor](query-editor.md).
+With Tempo 2.0, you can use the TraceQL query editor in the Tempo data source to build queries and drill-down into result sets. The editor is available in Grafana’s Explore interface. For more information, refer to [TraceQL query editor]({{< relref "query-editor" >}}).
 
 <p align="center"><img src="assets/query-editor-http-method.png" alt="Query editor showing request for http.method" /></p>
 


### PR DESCRIPTION
Fix a broken link to the query editor from the TraceQL doc. 