### PR TITLE
add support for custom internal server

### DIFF
--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -59,19 +59,20 @@ var (
 type App struct {
 	cfg Config
 
-	Server        *server.Server
-	ring          *ring.Ring
-	generatorRing *ring.Ring
-	overrides     *overrides.Overrides
-	distributor   *distributor.Distributor
-	querier       *querier.Querier
-	frontend      *frontend_v1.Frontend
-	compactor     *compactor.Compactor
-	ingester      *ingester.Ingester
-	generator     *generator.Generator
-	store         storage.Store
-	usageReport   *usagestats.Reporter
-	MemberlistKV  *memberlist.KVInitService
+	Server         *server.Server
+	InternalServer *server.Server
+	ring           *ring.Ring
+	generatorRing  *ring.Ring
+	overrides      *overrides.Overrides
+	distributor    *distributor.Distributor
+	querier        *querier.Querier
+	frontend       *frontend_v1.Frontend
+	compactor      *compactor.Compactor
+	ingester       *ingester.Ingester
+	generator      *generator.Generator
+	store          storage.Store
+	usageReport    *usagestats.Reporter
+	MemberlistKV   *memberlist.KVInitService
 
 	HTTPAuthMiddleware       middleware.Interface
 	TracesConsumerMiddleware receiver.Middleware
@@ -174,6 +175,10 @@ func (t *App) Run() error {
 	}
 
 	// before starting servers, register /ready handler and gRPC health check service.
+	if t.cfg.InternalServer.Enable {
+		t.InternalServer.HTTP.Path("/ready").Methods("GET").Handler(t.readyHandler(sm))
+	}
+
 	t.Server.HTTP.Path("/ready").Handler(t.readyHandler(sm))
 	t.Server.HTTP.Path("/status").Handler(t.statusHandler()).Methods("GET")
 	t.Server.HTTP.Path("/status/{endpoint}").Handler(t.statusHandler()).Methods("GET")

--- a/cmd/tempo/app/config.go
+++ b/cmd/tempo/app/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/modules/querier"
 	"github.com/grafana/tempo/modules/storage"
+	internalserver "github.com/grafana/tempo/pkg/server"
 	"github.com/grafana/tempo/pkg/usagestats"
 	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/tempodb"
@@ -34,6 +35,7 @@ type Config struct {
 	EnableGoRuntimeMetrics bool   `yaml:"enable_go_runtime_metrics,omitempty"`
 
 	Server          server.Config           `yaml:"server,omitempty"`
+	InternalServer  internalserver.Config   `yaml:"internal_server,omitempty"`
 	Distributor     distributor.Config      `yaml:"distributor,omitempty"`
 	IngesterClient  ingester_client.Config  `yaml:"ingester_client,omitempty"`
 	GeneratorClient generator_client.Config `yaml:"metrics_generator_client,omitempty"`
@@ -69,6 +71,9 @@ func (c *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 	// Server settings
 	flagext.DefaultValues(&c.Server)
 	c.Server.LogLevel.RegisterFlags(f)
+
+	// Internal server settings
+	flagext.DefaultValues(&c.InternalServer)
 
 	// Increase max message size to 16MB
 	c.Server.GPRCServerMaxRecvMsgSize = 16 * 1024 * 1024

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -420,9 +420,7 @@ func (t *App) setupModuleManager() error {
 	mm := modules.NewManager(log.Logger)
 
 	mm.RegisterModule(Server, t.initServer, modules.UserInvisibleModule)
-	if t.cfg.InternalServer.Enable {
-		mm.RegisterModule(InternalServer, t.initInternalServer, modules.UserInvisibleModule)
-	}
+	mm.RegisterModule(InternalServer, t.initInternalServer, modules.UserInvisibleModule)
 	mm.RegisterModule(MemberlistKV, t.initMemberlistKV, modules.UserInvisibleModule)
 	mm.RegisterModule(Ring, t.initRing, modules.UserInvisibleModule)
 	mm.RegisterModule(MetricsGeneratorRing, t.initGeneratorRing, modules.UserInvisibleModule)

--- a/pkg/server/internal_server.go
+++ b/pkg/server/internal_server.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"flag"
+	"time"
+
+	serverww "github.com/weaveworks/common/server"
+)
+
+// Config extends weaveworks server config
+type Config struct {
+	serverww.Config `yaml:",inline"`
+	Enable          bool `yaml:"enable"`
+}
+
+// RegisterFlags add internal server flags to flagset
+func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
+	f.StringVar(&cfg.Config.HTTPListenAddress, "internal-server.http-listen-address", "localhost", "HTTP internal server listen address.")
+	f.StringVar(&cfg.Config.HTTPListenNetwork, "internal-server.http-listen-network", serverww.DefaultNetwork, "HTTP internal server listen network, default tcp")
+	f.StringVar(&cfg.Config.HTTPTLSConfig.TLSCertPath, "internal-server.http-tls-cert-path", "", "HTTP internal server cert path.")
+	f.StringVar(&cfg.Config.HTTPTLSConfig.TLSKeyPath, "internal-server.http-tls-key-path", "", "HTTP internal server key path.")
+	f.StringVar(&cfg.Config.HTTPTLSConfig.ClientAuth, "internal-server.http-tls-client-auth", "", "HTTP TLS Client Auth type.")
+	f.StringVar(&cfg.Config.HTTPTLSConfig.ClientCAs, "internal-server.http-tls-ca-path", "", "HTTP TLS Client CA path.")
+	f.StringVar(&cfg.Config.CipherSuites, "internal-server.http-tls-cipher-suites", "", "HTTP TLS Cipher Suites.")
+	f.StringVar(&cfg.Config.MinVersion, "internal-server.http-tls-min-version", "", "HTTP TLS Min Version.")
+	f.IntVar(&cfg.Config.HTTPListenPort, "internal-server.http-listen-port", 3101, "HTTP internal server listen port.")
+	f.IntVar(&cfg.Config.HTTPConnLimit, "internal-server.http-conn-limit", 0, "Maximum number of simultaneous http connections, <=0 to disable")
+	f.DurationVar(&cfg.Config.ServerGracefulShutdownTimeout, "internal-server.graceful-shutdown-timeout", 30*time.Second, "Timeout for graceful shutdowns")
+	f.DurationVar(&cfg.Config.HTTPServerReadTimeout, "internal-server.http-read-timeout", 30*time.Second, "Read timeout for HTTP server")
+	f.DurationVar(&cfg.Config.HTTPServerWriteTimeout, "internal-server.http-write-timeout", 30*time.Second, "Write timeout for HTTP server")
+	f.DurationVar(&cfg.Config.HTTPServerIdleTimeout, "internal-server.http-idle-timeout", 120*time.Second, "Idle timeout for HTTP server")
+	f.BoolVar(&cfg.Enable, "internal-server.enable", false, "Disable the internal http server.")
+}


### PR DESCRIPTION
Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>

**What this PR does**:
The following PR adds support for a custom internal server listener dedicated for the start to serve the ready handler on a separate port and optionally TLS configuration. The key purpose for this one is to serve the Tempo HTTP API via mTLS while serving the readiness endpoints without (i.e. kubernetes readiness/liveness probes do not support authentication)

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/tempo/issues/2044


This is based on https://github.com/grafana/loki/pull/7069
**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`