### PR TITLE
Update helm microservices example for Kubernetes v1.22 deprecations

### DIFF
--- a/example/helm/microservices-extras.yaml
+++ b/example/helm/microservices-extras.yaml
@@ -1,3 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    ingress.kubernetes.io/ssl-redirect: 'false'
+  name: ingress
+  namespace: default
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              service:
+                name: grafana
+                port:
+                  number: 80
+            path: /
+            pathType: Exact
 ---
 apiVersion: v1
 data:
@@ -659,7 +677,7 @@ spec:
       containers:
         - env:
             - name: JAEGER_COLLECTOR_URL
-              value: http://tempo-distributor:14268
+              value: http://tempo-tempo-distributed-distributor:14268
             - name: TOPOLOGY_FILE
               value: /conf/load-generator.json
           image: omnition/synthetic-load-generator:1.0.25
@@ -672,3 +690,52 @@ spec:
         - configMap:
             name: synthetic-load-generator
           name: conf
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: minio
+  name: minio
+  namespace: default
+spec:
+  ports:
+    - port: 9000
+      targetPort: 9000
+  selector:
+    app: minio
+    name: minio
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+      name: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+        name: minio
+    spec:
+      containers:
+        - env:
+            - name: MINIO_ACCESS_KEY
+              value: tempo
+            - name: MINIO_SECRET_KEY
+              value: supersecret
+          image: minio/minio:latest
+          imagePullPolicy: IfNotPresent
+          name: minio
+          command: ['sh']
+          args:
+            [
+              '-euc',
+              "mkdir -p /data/tempo && /opt/bin/minio server /data --console-address ':9001'",
+            ]


### PR DESCRIPTION
**What this PR does**:

Using later versions of k3d bundles newer kubernetes, which includes some deprecations.  This change updates the mentioned resources to allow the `kubectl create` call to succeed in the `microservices` example

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`