### PR TITLE
Update parquet-go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main / unreleased
 
 * [FEATURE] Add flag to optionally enable all available Go runtime metrics [#2005](https://github.com/grafana/tempo/pull/2005) (@andreasgerstmayr)
+* [BUGFIX] Error more gracefully while reading some blocks written by an interim commit between 1.5 and 2.0 [#2055](https://github.com/grafana/tempo/pull/2055) (@mdisibio)
 
 ## v2.0.0 / 2023-01-31
 

--- a/cmd/tempo-serverless/cloud-run/go.mod
+++ b/cmd/tempo-serverless/cloud-run/go.mod
@@ -99,7 +99,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rs/xid v1.2.1 // indirect
 	github.com/segmentio/encoding v0.3.5 // indirect
-	github.com/segmentio/parquet-go v0.0.0-20230120165150-63d6a781234f // indirect
+	github.com/segmentio/parquet-go v0.0.0-20230201213121-e1109e2f6a20 // indirect
 	github.com/sercand/kuberesolver v2.4.0+incompatible // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/sony/gobreaker v0.4.1 // indirect

--- a/cmd/tempo-serverless/cloud-run/go.sum
+++ b/cmd/tempo-serverless/cloud-run/go.sum
@@ -458,8 +458,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/encoding v0.3.5 h1:UZEiaZ55nlXGDL92scoVuw00RmiRCazIEmvPSbSvt8Y=
 github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
-github.com/segmentio/parquet-go v0.0.0-20230120165150-63d6a781234f h1:hJ2eADPXuqfCWPeiDEnney9EfSzGipRDA6igKHYMILg=
-github.com/segmentio/parquet-go v0.0.0-20230120165150-63d6a781234f/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
+github.com/segmentio/parquet-go v0.0.0-20230201213121-e1109e2f6a20 h1:4BzlTkAqAj8HsgqXBDiFppY7AHWaeeZmBSdQtwXk/qg=
+github.com/segmentio/parquet-go v0.0.0-20230201213121-e1109e2f6a20/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/sercand/kuberesolver v2.4.0+incompatible h1:WE2OlRf6wjLxHwNkkFLQGaZcVLEXjMjBPjjEU5vksH8=
 github.com/sercand/kuberesolver v2.4.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/cmd/tempo-serverless/lambda/go.mod
+++ b/cmd/tempo-serverless/lambda/go.mod
@@ -100,7 +100,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rs/xid v1.2.1 // indirect
 	github.com/segmentio/encoding v0.3.5 // indirect
-	github.com/segmentio/parquet-go v0.0.0-20230120165150-63d6a781234f // indirect
+	github.com/segmentio/parquet-go v0.0.0-20230201213121-e1109e2f6a20 // indirect
 	github.com/sercand/kuberesolver v2.4.0+incompatible // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/sony/gobreaker v0.4.1 // indirect

--- a/cmd/tempo-serverless/lambda/go.sum
+++ b/cmd/tempo-serverless/lambda/go.sum
@@ -463,8 +463,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/encoding v0.3.5 h1:UZEiaZ55nlXGDL92scoVuw00RmiRCazIEmvPSbSvt8Y=
 github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
-github.com/segmentio/parquet-go v0.0.0-20230120165150-63d6a781234f h1:hJ2eADPXuqfCWPeiDEnney9EfSzGipRDA6igKHYMILg=
-github.com/segmentio/parquet-go v0.0.0-20230120165150-63d6a781234f/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
+github.com/segmentio/parquet-go v0.0.0-20230201213121-e1109e2f6a20 h1:4BzlTkAqAj8HsgqXBDiFppY7AHWaeeZmBSdQtwXk/qg=
+github.com/segmentio/parquet-go v0.0.0-20230201213121-e1109e2f6a20/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/sercand/kuberesolver v2.4.0+incompatible h1:WE2OlRf6wjLxHwNkkFLQGaZcVLEXjMjBPjjEU5vksH8=
 github.com/sercand/kuberesolver v2.4.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/prometheus/prometheus v1.8.2-0.20221021121301-51a44e6657c3
 	github.com/prometheus/statsd_exporter v0.21.0 // indirect
 	github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e
-	github.com/segmentio/parquet-go v0.0.0-20230120165150-63d6a781234f
+	github.com/segmentio/parquet-go v0.0.0-20230201213121-e1109e2f6a20
 	github.com/sirupsen/logrus v1.8.1
 	github.com/sony/gobreaker v0.4.1
 	github.com/spf13/viper v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -899,8 +899,8 @@ github.com/segmentio/encoding v0.3.5 h1:UZEiaZ55nlXGDL92scoVuw00RmiRCazIEmvPSbSv
 github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
 github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e h1:uO75wNGioszjmIzcY/tvdDYKRLVvzggtAmmJkn9j4GQ=
 github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e/go.mod h1:tm/wZFQ8e24NYaBGIlnO2WGCAi67re4HHuOm0sftE/M=
-github.com/segmentio/parquet-go v0.0.0-20230120165150-63d6a781234f h1:hJ2eADPXuqfCWPeiDEnney9EfSzGipRDA6igKHYMILg=
-github.com/segmentio/parquet-go v0.0.0-20230120165150-63d6a781234f/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
+github.com/segmentio/parquet-go v0.0.0-20230201213121-e1109e2f6a20 h1:4BzlTkAqAj8HsgqXBDiFppY7AHWaeeZmBSdQtwXk/qg=
+github.com/segmentio/parquet-go v0.0.0-20230201213121-e1109e2f6a20/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/sercand/kuberesolver v2.4.0+incompatible h1:WE2OlRf6wjLxHwNkkFLQGaZcVLEXjMjBPjjEU5vksH8=
 github.com/sercand/kuberesolver v2.4.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=
 github.com/shirou/gopsutil/v3 v3.22.6 h1:FnHOFOh+cYAM0C30P+zysPISzlknLC5Z1G4EAElznfQ=

--- a/vendor/github.com/segmentio/parquet-go/row.go
+++ b/vendor/github.com/segmentio/parquet-go/row.go
@@ -635,8 +635,11 @@ func reconstructFuncOfRepeated(columnIndex int16, node Node) (int16, reconstruct
 		for i := 0; i < n; i++ {
 			for j, column := range values {
 				column = column[:cap(column)]
-				k := 1
+				if len(column) == 0 {
+					continue
+				}
 
+				k := 1
 				for k < len(column) && column[k].repetitionLevel > levels.repetitionDepth {
 					k++
 				}

--- a/vendor/github.com/segmentio/parquet-go/row_builder.go
+++ b/vendor/github.com/segmentio/parquet-go/row_builder.go
@@ -1,0 +1,202 @@
+package parquet
+
+// RowBuilder is a type which helps build parquet rows incrementally by adding
+// values to columns.
+type RowBuilder struct {
+	columns [][]Value
+	models  []Value
+	levels  []columnLevel
+	groups  []*columnGroup
+}
+
+type columnLevel struct {
+	repetitionDepth byte
+	repetitionLevel byte
+	definitionLevel byte
+}
+
+type columnGroup struct {
+	baseColumn      []Value
+	members         []int16
+	startIndex      int16
+	endIndex        int16
+	repetitionLevel byte
+	definitionLevel byte
+}
+
+// NewRowBuilder constructs a RowBuilder which builds rows for the parquet
+// schema passed as argument.
+func NewRowBuilder(schema Node) *RowBuilder {
+	if schema.Leaf() {
+		panic("schema of row builder must be a group")
+	}
+	n := numLeafColumnsOf(schema)
+	b := &RowBuilder{
+		columns: make([][]Value, n),
+		models:  make([]Value, n),
+		levels:  make([]columnLevel, n),
+	}
+	buffers := make([]Value, len(b.columns))
+	for i := range b.columns {
+		b.columns[i] = buffers[i : i : i+1]
+	}
+	topGroup := &columnGroup{baseColumn: []Value{{}}}
+	endIndex := b.configure(schema, 0, columnLevel{}, topGroup)
+	topGroup.endIndex = endIndex
+	b.groups = append(b.groups, topGroup)
+	return b
+}
+
+func (b *RowBuilder) configure(node Node, columnIndex int16, level columnLevel, group *columnGroup) (endIndex int16) {
+	switch {
+	case node.Optional():
+		level.definitionLevel++
+		endIndex = b.configure(Required(node), columnIndex, level, group)
+
+		for i := columnIndex; i < endIndex; i++ {
+			b.models[i].kind = 0 // null if not set
+			b.models[i].ptr = nil
+			b.models[i].u64 = 0
+		}
+
+	case node.Repeated():
+		level.definitionLevel++
+
+		group = &columnGroup{
+			startIndex:      columnIndex,
+			repetitionLevel: level.repetitionDepth,
+			definitionLevel: level.definitionLevel,
+		}
+
+		level.repetitionDepth++
+		endIndex = b.configure(Required(node), columnIndex, level, group)
+
+		for i := columnIndex; i < endIndex; i++ {
+			b.models[i].kind = 0 // null if not set
+			b.models[i].ptr = nil
+			b.models[i].u64 = 0
+		}
+
+		group.endIndex = endIndex
+		b.groups = append(b.groups, group)
+
+	case node.Leaf():
+		typ := node.Type()
+		kind := typ.Kind()
+		model := makeValueKind(kind)
+		model.repetitionLevel = level.repetitionLevel
+		model.definitionLevel = level.definitionLevel
+		// FIXED_LEN_BYTE_ARRAY is the only type which needs to be given a
+		// non-nil zero-value if the field is required.
+		if kind == FixedLenByteArray {
+			zero := make([]byte, typ.Length())
+			model.ptr = &zero[0]
+			model.u64 = uint64(len(zero))
+		}
+		group.members = append(group.members, columnIndex)
+		b.models[columnIndex] = model
+		b.levels[columnIndex] = level
+		endIndex = columnIndex + 1
+
+	default:
+		endIndex = columnIndex
+
+		for _, field := range node.Fields() {
+			endIndex = b.configure(field, endIndex, level, group)
+		}
+	}
+	return endIndex
+}
+
+// Add adds columnValue to the column at columnIndex.
+func (b *RowBuilder) Add(columnIndex int, columnValue Value) {
+	level := &b.levels[columnIndex]
+	columnValue.repetitionLevel = level.repetitionLevel
+	columnValue.definitionLevel = level.definitionLevel
+	columnValue.columnIndex = ^int16(columnIndex)
+	level.repetitionLevel = level.repetitionDepth
+	b.columns[columnIndex] = append(b.columns[columnIndex], columnValue)
+}
+
+// Next must be called to indicate the start of a new repeated record for the
+// column at the given index.
+//
+// If the column index is part of a repeated group, the builder automatically
+// starts a new record for all adjacent columns, the application does not need
+// to call this method for each column of the repeated group.
+//
+// Next must be called after adding a sequence of records.
+func (b *RowBuilder) Next(columnIndex int) {
+	for _, group := range b.groups {
+		if group.startIndex <= int16(columnIndex) && int16(columnIndex) < group.endIndex {
+			for i := group.startIndex; i < group.endIndex; i++ {
+				if level := &b.levels[i]; level.repetitionLevel != 0 {
+					level.repetitionLevel = group.repetitionLevel
+				}
+			}
+			break
+		}
+	}
+}
+
+// Reset clears the internal state of b, making it possible to reuse while
+// retaining the internal buffers.
+func (b *RowBuilder) Reset() {
+	for i, column := range b.columns {
+		clearValues(column)
+		b.columns[i] = column[:0]
+	}
+	for i := range b.levels {
+		b.levels[i].repetitionLevel = 0
+	}
+}
+
+// Row materializes the current state of b into a parquet row.
+func (b *RowBuilder) Row() Row {
+	numValues := 0
+	for _, column := range b.columns {
+		numValues += len(column)
+	}
+	return b.AppendRow(make(Row, 0, numValues))
+}
+
+// AppendRow appends the current state of b to row and returns it.
+func (b *RowBuilder) AppendRow(row Row) Row {
+	for _, group := range b.groups {
+		maxColumn := group.baseColumn
+
+		for _, columnIndex := range group.members {
+			if column := b.columns[columnIndex]; len(column) > len(maxColumn) {
+				maxColumn = column
+			}
+		}
+
+		if len(maxColumn) != 0 {
+			columns := b.columns[group.startIndex:group.endIndex]
+
+			for i, column := range columns {
+				if len(column) < len(maxColumn) {
+					n := len(column)
+					column = append(column, maxColumn[n:]...)
+
+					columnIndex := group.startIndex + int16(i)
+					model := b.models[columnIndex]
+
+					for n < len(column) {
+						v := &column[n]
+						v.kind = model.kind
+						v.ptr = model.ptr
+						v.u64 = model.u64
+						v.definitionLevel = group.definitionLevel
+						v.columnIndex = ^columnIndex
+						n++
+					}
+
+					columns[i] = column
+				}
+			}
+		}
+	}
+
+	return appendRow(row, b.columns)
+}

--- a/vendor/github.com/segmentio/parquet-go/transform.go
+++ b/vendor/github.com/segmentio/parquet-go/transform.go
@@ -1,0 +1,143 @@
+package parquet
+
+// TransformRowReader constructs a RowReader which applies the given transform
+// to each row rad from reader.
+//
+// The transformation function appends the transformed src row to dst, returning
+// dst and any error that occurred during the transformation. If dst is returned
+// unchanged, the row is skipped.
+func TransformRowReader(reader RowReader, transform func(dst, src Row) (Row, error)) RowReader {
+	return &transformRowReader{reader: reader, transform: transform}
+}
+
+type transformRowReader struct {
+	reader    RowReader
+	transform func(Row, Row) (Row, error)
+	rows      []Row
+	offset    int
+	length    int
+}
+
+func (t *transformRowReader) ReadRows(rows []Row) (n int, err error) {
+	if len(t.rows) == 0 {
+		t.rows = makeRows(len(rows))
+	}
+
+	for {
+		for n < len(rows) && t.offset < t.length {
+			dst := rows[n][:0]
+			src := t.rows[t.offset]
+			rows[n], err = t.transform(dst, src)
+			if err != nil {
+				return n, err
+			}
+			clearValues(src)
+			t.rows[t.offset] = src[:0]
+			t.offset++
+			n++
+		}
+
+		if n == len(rows) {
+			return n, nil
+		}
+
+		r, err := t.reader.ReadRows(t.rows)
+		if r == 0 && err != nil {
+			return n, err
+		}
+		t.offset = 0
+		t.length = r
+	}
+}
+
+type transformRowBuffer struct {
+	buffer []Row
+	offset int32
+	length int32
+}
+
+func (b *transformRowBuffer) init(n int) {
+	b.buffer = makeRows(n)
+	b.offset = 0
+	b.length = 0
+}
+
+func (b *transformRowBuffer) discard() {
+	row := b.buffer[b.offset]
+	clearValues(row)
+	b.buffer[b.offset] = row[:0]
+
+	if b.offset++; b.offset == b.length {
+		b.reset(0)
+	}
+}
+
+func (b *transformRowBuffer) reset(n int) {
+	b.offset = 0
+	b.length = int32(n)
+}
+
+func (b *transformRowBuffer) rows() []Row {
+	return b.buffer[b.offset:b.length]
+}
+
+func (b *transformRowBuffer) cap() int {
+	return len(b.buffer)
+}
+
+func (b *transformRowBuffer) len() int {
+	return int(b.length - b.offset)
+}
+
+// TransformRowWriter constructs a RowWriter which applies the given transform
+// to each row writter to writer.
+//
+// The transformation function appends the transformed src row to dst, returning
+// dst and any error that occurred during the transformation. If dst is returned
+// unchanged, the row is skipped.
+func TransformRowWriter(writer RowWriter, transform func(dst, src Row) (Row, error)) RowWriter {
+	return &transformRowWriter{writer: writer, transform: transform}
+}
+
+type transformRowWriter struct {
+	writer    RowWriter
+	transform func(Row, Row) (Row, error)
+	rows      []Row
+}
+
+func (t *transformRowWriter) WriteRows(rows []Row) (n int, err error) {
+	if len(t.rows) == 0 {
+		t.rows = makeRows(len(rows))
+	}
+
+	for n < len(rows) {
+		numRows := len(rows) - n
+		if numRows > len(t.rows) {
+			numRows = len(t.rows)
+		}
+		if err := t.writeRows(rows[n : n+numRows]); err != nil {
+			return n, err
+		}
+		n += numRows
+	}
+
+	return n, nil
+}
+
+func (t *transformRowWriter) writeRows(rows []Row) (err error) {
+	numRows := 0
+	defer func() { clearRows(t.rows[:numRows]) }()
+
+	for _, row := range rows {
+		t.rows[numRows], err = t.transform(t.rows[numRows][:0], row)
+		if err != nil {
+			return err
+		}
+		if len(t.rows[numRows]) != 0 {
+			numRows++
+		}
+	}
+
+	_, err = t.writer.WriteRows(t.rows[:numRows])
+	return err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -900,7 +900,7 @@ github.com/segmentio/encoding/thrift
 # github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e
 ## explicit
 github.com/segmentio/fasthash/fnv1a
-# github.com/segmentio/parquet-go v0.0.0-20230120165150-63d6a781234f
+# github.com/segmentio/parquet-go v0.0.0-20230201213121-e1109e2f6a20
 ## explicit; go 1.19
 github.com/segmentio/parquet-go
 github.com/segmentio/parquet-go/bloom


### PR DESCRIPTION
**What this PR does**:
Update parquet-go to catch https://github.com/segmentio/parquet-go/issues/460.  This change converts the panic `panic: runtime error: slice bounds out of range [:1] with capacity 0` to an error `rs → ils → Spans → Links → no values found in parquet row for column 44`.   This error has been observed while reading or compacting a subset of traces in blocks written by an interim commit between 1.5 and 2.0.  This change doesn't resolve the issue, just fail more gracefully, which will help system stability until those blocks fall out of retention for those installations experiencing the error.

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`