### PR TITLE
[DOC] Clarify resources and spans in doc

### DIFF
--- a/docs/sources/traceql/_index.md
+++ b/docs/sources/traceql/_index.md
@@ -67,11 +67,14 @@ Intrinsic fields are fundamental to spans. These fields can be referenced when s
 
 Attribute fields are derived from the span and can be customized. Process and span attribute types are [defined by the attribute itself](https://github.com/open-telemetry/opentelemetry-proto/blob/b43e9b18b76abf3ee040164b55b9c355217151f3/opentelemetry/proto/common/v1/common.proto#L30-L38), whereas intrinsic fields have a built-in type. You can refer to dynamic attributes (also known as tags) on the span or the span's resource.
 
-Attributes in a query start with a span or resource scope depending on what exactly you want to query. This provides significant performance benefits because it allows Tempo to only scan the data you are interested in. To find traces with the `GET HTTP` method, your query could look like this:
+Attributes in a query start with a span or resource scope depending on what exactly you want to query. This provides significant performance benefits because it allows Tempo to only scan the data you are interested in.
+
+To find traces with the `GET HTTP` method, your query could look like this:
 
 ```
 { span.http.method = "GET" }
 ```
+There are two types of attributes, span attributes and resource attributes. By expanding a span in the Grafana UI, you can see both its span attributes (1 in the screenshot) and resource attributes (2 in the screenshot).
 
 <p align="center"><img src="assets/span-resource-attributes.png" alt="Example of span resources and attributes" /></p>
 

--- a/docs/sources/traceql/_index.md
+++ b/docs/sources/traceql/_index.md
@@ -79,6 +79,7 @@ There are two types of attributes: span attributes and resource attributes. By e
 
 <p align="center"><img src="assets/span-resource-attributes.png" alt="Example of span and resource  attributes." /></p>
 
+For more information about attributes and resources, refer to the [OpenTelemetry Resource SDK](https://opentelemetry.io/docs/reference/specification/resource/sdk/).
 #### Examples
 
 Find traces that passed through the `prod` namespace:

--- a/docs/sources/traceql/_index.md
+++ b/docs/sources/traceql/_index.md
@@ -74,7 +74,8 @@ To find traces with the `GET HTTP` method, your query could look like this:
 ```
 { span.http.method = "GET" }
 ```
-There are two types of attributes, span attributes and resource attributes. By expanding a span in the Grafana UI, you can see both its span attributes (1 in the screenshot) and resource attributes (2 in the screenshot).
+
+There are two types of attributes: span attributes and resource attributes. By expanding a span in the Grafana UI, you can see both its span attributes (1 in the screenshot) and resource attributes (2 in the screenshot).
 
 <p align="center"><img src="assets/span-resource-attributes.png" alt="Example of span resources and attributes" /></p>
 

--- a/docs/sources/traceql/_index.md
+++ b/docs/sources/traceql/_index.md
@@ -65,19 +65,19 @@ Intrinsic fields are fundamental to spans. These fields can be referenced when s
 
 ### Attribute fields
 
+There are two types of attributes: span attributes and resource attributes. By expanding a span in the Grafana UI, you can see both its span attributes (1 in the screenshot) and resource attributes (2 in the screenshot).
+
+<p align="center"><img src="assets/span-resource-attributes.png" alt="Example of span and resource  attributes." /></p>
+
 Attribute fields are derived from the span and can be customized. Process and span attribute types are [defined by the attribute itself](https://github.com/open-telemetry/opentelemetry-proto/blob/b43e9b18b76abf3ee040164b55b9c355217151f3/opentelemetry/proto/common/v1/common.proto#L30-L38), whereas intrinsic fields have a built-in type. You can refer to dynamic attributes (also known as tags) on the span or the span's resource.
 
-Attributes in a query start with a span or resource scope depending on what exactly you want to query. This provides significant performance benefits because it allows Tempo to only scan the data you are interested in.
+Attributes in a query start with a span scope (for example, `span.http`) or resource scope (for example, `resource.namespace`)  depending on what you want to query. This provides significant performance benefits because it allows Tempo to only scan the data you are interested in.
 
 To find traces with the `GET HTTP` method, your query could look like this:
 
 ```
 { span.http.method = "GET" }
 ```
-
-There are two types of attributes: span attributes and resource attributes. By expanding a span in the Grafana UI, you can see both its span attributes (1 in the screenshot) and resource attributes (2 in the screenshot).
-
-<p align="center"><img src="assets/span-resource-attributes.png" alt="Example of span and resource  attributes." /></p>
 
 For more information about attributes and resources, refer to the [OpenTelemetry Resource SDK](https://opentelemetry.io/docs/reference/specification/resource/sdk/).
 #### Examples

--- a/docs/sources/traceql/_index.md
+++ b/docs/sources/traceql/_index.md
@@ -77,7 +77,7 @@ To find traces with the `GET HTTP` method, your query could look like this:
 
 There are two types of attributes: span attributes and resource attributes. By expanding a span in the Grafana UI, you can see both its span attributes (1 in the screenshot) and resource attributes (2 in the screenshot).
 
-<p align="center"><img src="assets/span-resource-attributes.png" alt="Example of span resources and attributes" /></p>
+<p align="center"><img src="assets/span-resource-attributes.png" alt="Example of span and resource  attributes." /></p>
 
 #### Examples
 


### PR DESCRIPTION
**What this PR does**:
Adds a sentence clarifying resources and spans to link them to the screenshot in the TraceQL documentation. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`