### PR TITLE
Fix panic when scanning blocks with missing files (#2063)

### DIFF
--- a/cmd/tempo-cli/cmd-list-block.go
+++ b/cmd/tempo-cli/cmd-list-block.go
@@ -81,8 +81,8 @@ func dumpBlock(r tempodb_backend.Reader, c tempodb_backend.Compactor, tenantID s
 	fmt.Println("Age           : ", fmt.Sprint(time.Since(unifiedMeta.EndTime).Round(time.Second)))
 
 	if scan {
-		if meta.Version != v2.VersionString {
-			return fmt.Errorf("cannot scan block contents. unsupported block version: %s", meta.Version)
+		if unifiedMeta.Version != v2.VersionString {
+			return fmt.Errorf("cannot scan block contents. unsupported block version: %s", unifiedMeta.Version)
 		}
 
 		fmt.Println("Scanning block contents.  Press CRTL+C to quit ...")
@@ -154,7 +154,7 @@ func dumpBlock(r tempodb_backend.Reader, c tempodb_backend.Compactor, tenantID s
 
 			copy(prevID, objID)
 
-			trace, err := model.MustNewObjectDecoder(meta.DataEncoding).PrepareForRead(obj)
+			trace, err := model.MustNewObjectDecoder(unifiedMeta.DataEncoding).PrepareForRead(obj)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Prevents `tempo-cli` from `panic`ing when a compacted block *only* includes a `meta.compacted.json` file (no `index`, ...).

**Which issue(s) this PR fixes**:
Fixes #2063

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`