### PR TITLE
Bump go version to 1.20

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -104,7 +104,7 @@ local image_tag_for_cd() = {
 
 local build_binaries(arch) = {
   name: 'build-tempo-binaries',
-  image: 'golang:1.19-alpine',
+  image: 'golang:1.20-alpine',
   commands: [
     'apk add make git',
   ] + [
@@ -226,7 +226,7 @@ local deploy_to_dev() = {
     steps+: [
               {
                 name: 'build-tempo-serverless',
-                image: 'golang:1.19-alpine',
+                image: 'golang:1.20-alpine',
                 commands: [
                   'apk add make git zip bash',
                   './tools/image-tag | cut -d, -f 1 | tr A-Z a-z > .tags',  // values in .tags are used by the next step when pushing the image
@@ -323,7 +323,7 @@ local deploy_to_dev() = {
       },
       {
         name: 'write-key',
-        image: 'golang:1.19',
+        image: 'golang:1.20',
         commands: ['printf "%s" "$NFPM_SIGNING_KEY" > $NFPM_SIGNING_KEY_FILE'],
         environment: {
           NFPM_SIGNING_KEY: { from_secret: gpg_private_key.name },
@@ -332,7 +332,7 @@ local deploy_to_dev() = {
       },
       {
         name: 'test release',
-        image: 'golang:1.19',
+        image: 'golang:1.20',
         commands: ['make release-snapshot'],
         environment: {
           NFPM_DEFAULT_PASSPHRASE: { from_secret: gpg_passphrase.name },
@@ -365,7 +365,7 @@ local deploy_to_dev() = {
       },
       {
         name: 'release',
-        image: 'golang:1.19',
+        image: 'golang:1.20',
         commands: ['make release'],
         environment: {
           GITHUB_TOKEN: { from_secret: gh_token_secret.name },

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -17,7 +17,7 @@ steps:
   - COMPONENT=tempo GOARCH=amd64 make exe
   - COMPONENT=tempo-vulture GOARCH=amd64 make exe
   - COMPONENT=tempo-query GOARCH=amd64 make exe
-  image: golang:1.19-alpine
+  image: golang:1.20-alpine
   name: build-tempo-binaries
 - image: plugins/docker
   name: build-tempo-image
@@ -77,7 +77,7 @@ steps:
   - COMPONENT=tempo GOARCH=arm64 make exe
   - COMPONENT=tempo-vulture GOARCH=arm64 make exe
   - COMPONENT=tempo-query GOARCH=arm64 make exe
-  image: golang:1.19-alpine
+  image: golang:1.20-alpine
   name: build-tempo-binaries
 - image: plugins/docker
   name: build-tempo-image
@@ -235,7 +235,7 @@ steps:
   - cd ./cmd/tempo-serverless
   - make build-docker-gcr-binary
   - make build-lambda-zip
-  image: golang:1.19-alpine
+  image: golang:1.20-alpine
   name: build-tempo-serverless
 - image: plugins/gcr
   name: deploy-tempo-serverless-gcr
@@ -304,7 +304,7 @@ steps:
     NFPM_SIGNING_KEY:
       from_secret: gpg_private_key
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: golang:1.19
+  image: golang:1.20
   name: write-key
 - commands:
   - make release-snapshot
@@ -312,7 +312,7 @@ steps:
     NFPM_DEFAULT_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: golang:1.19
+  image: golang:1.20
   name: test release
 - commands:
   - ./tools/packaging/verify-deb-install.sh
@@ -338,7 +338,7 @@ steps:
     NFPM_DEFAULT_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: golang:1.19
+  image: golang:1.20
   name: release
   when:
     event:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.20
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20.x
 
       - name: Install jsonnetfmt and goimports
         run: |
@@ -46,17 +46,17 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.49.0
+          version: v1.51.0
 
 
   unit-tests:
     name: Test packages
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.20
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20.x
 
       - name: Check out code
         uses: actions/checkout@v3
@@ -68,10 +68,10 @@ jobs:
     name: Test integration e2e suite
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.20
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20.x
 
       - name: Check out code
         uses: actions/checkout@v3
@@ -83,10 +83,10 @@ jobs:
     name: Test serverless integration e2e suite
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.20
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20.x
 
       - name: Check out code
         uses: actions/checkout@v3
@@ -98,10 +98,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.20
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20.x
 
       - name: Check out code
         uses: actions/checkout@v3
@@ -122,10 +122,10 @@ jobs:
     name: Benchmark
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.20
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20.x
 
       - name: Check out code
         uses: actions/checkout@v3
@@ -137,10 +137,10 @@ jobs:
     name: Vendor check
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.20
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20.x
 
       - name: Check out code
         uses: actions/checkout@v3
@@ -158,10 +158,10 @@ jobs:
     name: Check jsonnet & tempo-mixin
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.20
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20.x
 
       - name: Install jsonnet, jsonnet-bundler & tanka
         run: |

--- a/.github/workflows/dependabot_serverless_gomod.yml
+++ b/.github/workflows/dependabot_serverless_gomod.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.20
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20.x
 
       - name: Check out code
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [BUGFIX] Error more gracefully while reading some blocks written by an interim commit between 1.5 and 2.0 [#2055](https://github.com/grafana/tempo/pull/2055) (@mdisibio)
 * [BUGFIX] Apply `rate()` to bytes/s panel in tenant's dashboard. [#2081](https://github.com/grafana/tempo/pull/2081) (@mapno)
 * [BUGFIX] Correctly coalesce trace level data when combining Parquet traces. [#2095](https://github.com/grafana/tempo/pull/2095) (@joe-elliott)
+* [CHANGE] Update Go to 1.20 [#2079](https://github.com/grafana/tempo/pull/2079) (@scalalang2)
 
 ## v2.0.0 / 2023-01-31
 

--- a/cmd/tempo-cli/cmd-list-block.go
+++ b/cmd/tempo-cli/cmd-list-block.go
@@ -119,7 +119,7 @@ func dumpBlock(r tempodb_backend.Reader, c tempodb_backend.Compactor, tenantID s
 		}
 
 		// Print stats on ctrl+c
-		c := make(chan os.Signal)
+		c := make(chan os.Signal, 1)
 		// nolint:govet
 		signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 		go func() {

--- a/cmd/tempo-serverless/cloud-run/go.mod
+++ b/cmd/tempo-serverless/cloud-run/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/tempo/cmd/tempo-serverless/cloud-run
 
-go 1.19
+go 1.20
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/cmd/tempo-serverless/lambda/Dockerfile
+++ b/cmd/tempo-serverless/lambda/Dockerfile
@@ -13,7 +13,7 @@
 #
 # build the lambda and retrive the lambda-local-proxy
 #
-FROM golang:1.19-buster AS build
+FROM golang:1.20-buster AS build
 
 # copy in the lambda. todo: build in container
 COPY lambda /

--- a/cmd/tempo-serverless/lambda/go.mod
+++ b/cmd/tempo-serverless/lambda/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/tempo/cmd/tempo-serverless/lambda
 
-go 1.19
+go 1.20
 
 require (
 	github.com/aws/aws-lambda-go v1.28.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/tempo
 
-go 1.19
+go 1.20
 
 require (
 	cloud.google.com/go/storage v1.27.0

--- a/integration/e2e/receivers_test.go
+++ b/integration/e2e/receivers_test.go
@@ -2,7 +2,7 @@ package e2e
 
 import (
 	"context"
-	"math/rand"
+	crand "crypto/rand"
 	"testing"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter"
@@ -121,7 +121,7 @@ func TestReceivers(t *testing.T) {
 
 			// make request
 			traceID := make([]byte, 16)
-			_, err = rand.Read(traceID)
+			_, err = crand.Read(traceID)
 			require.NoError(t, err)
 			req := test.MakeTrace(20, traceID)
 

--- a/modules/ingester/ingester_test.go
+++ b/modules/ingester/ingester_test.go
@@ -2,7 +2,7 @@ package ingester
 
 import (
 	"context"
-	"math/rand"
+	"crypto/rand"
 	"os"
 	"testing"
 	"time"

--- a/modules/ingester/instance_search_test.go
+++ b/modules/ingester/instance_search_test.go
@@ -3,8 +3,8 @@ package ingester
 import (
 	"bytes"
 	"context"
+	crand "crypto/rand"
 	"fmt"
-	"math/rand"
 	"sort"
 	"strconv"
 	"testing"
@@ -275,7 +275,8 @@ func writeTracesWithSearchData(t *testing.T, i *instance, tagKey string, tagValu
 
 	for j := 0; j < numTraces; j++ {
 		id := make([]byte, 16)
-		rand.Read(id)
+		_, err := crand.Read(id)
+		require.NoError(t, err)
 
 		tv := tagValue
 		if postFixValue {
@@ -350,7 +351,8 @@ func TestInstanceSearchDoesNotRace(t *testing.T) {
 
 	go concurrent(func() {
 		id := make([]byte, 16)
-		rand.Read(id)
+		_, err := crand.Read(id)
+		require.NoError(t, err)
 
 		trace := test.MakeTrace(10, id)
 		traceBytes, err := dec.PrepareForWrite(trace, 0, 0)
@@ -445,7 +447,8 @@ func TestWALBlockDeletedDuringSearch(t *testing.T) {
 
 	for j := 0; j < 500; j++ {
 		id := make([]byte, 16)
-		rand.Read(id)
+		_, err := crand.Read(id)
+		require.NoError(t, err)
 
 		trace := test.MakeTrace(10, id)
 		traceBytes, err := dec.PrepareForWrite(trace, 0, 0)

--- a/modules/ingester/instance_test.go
+++ b/modules/ingester/instance_test.go
@@ -2,6 +2,7 @@ package ingester
 
 import (
 	"context"
+	crand "crypto/rand"
 	"encoding/binary"
 	"math/rand"
 	"testing"
@@ -127,7 +128,8 @@ func pushTracesToInstance(t *testing.T, i *instance, numTraces int) ([]*tempopb.
 
 	for j := 0; j < numTraces; j++ {
 		id := make([]byte, 16)
-		rand.Read(id)
+		_, err := crand.Read(id)
+		require.NoError(t, err)
 
 		testTrace := test.MakeTrace(10, id)
 		trace.SortTrace(testTrace)
@@ -307,14 +309,18 @@ func TestInstanceLimits(t *testing.T) {
 
 func TestInstanceCutCompleteTraces(t *testing.T) {
 	id := make([]byte, 16)
-	rand.Read(id)
+	_, err := crand.Read(id)
+	require.NoError(t, err)
+
 	pastTrace := &liveTrace{
 		traceID:    id,
 		lastAppend: time.Now().Add(-time.Hour),
 	}
 
 	id = make([]byte, 16)
-	rand.Read(id)
+	_, err = crand.Read(id)
+	require.NoError(t, err)
+
 	nowTrace := &liveTrace{
 		traceID:    id,
 		lastAppend: time.Now().Add(time.Hour),
@@ -543,7 +549,7 @@ func TestSortByteSlices(t *testing.T) {
 	}
 	for i := range traceBytes.Traces {
 		traceBytes.Traces[i] = make([]byte, rand.Intn(10))
-		_, err := rand.Read(traceBytes.Traces[i])
+		_, err := crand.Read(traceBytes.Traces[i])
 		require.NoError(t, err)
 	}
 

--- a/pkg/cache/background_test.go
+++ b/pkg/cache/background_test.go
@@ -2,6 +2,7 @@ package cache_test
 
 import (
 	"context"
+	crand "crypto/rand"
 	"math/rand"
 	"strconv"
 	"testing"
@@ -32,7 +33,10 @@ func fillCache(cache cache.Cache) ([]string, [][]byte) {
 	for i := 0; i < 111; i++ {
 
 		buf := make([]byte, rand.Intn(100))
-		rand.Read(buf)
+		_, err := crand.Read(buf)
+		if err != nil {
+			panic(err)
+		}
 
 		keys = append(keys, strconv.Itoa(i))
 		bufs = append(bufs, buf)

--- a/pkg/io/read_test.go
+++ b/pkg/io/read_test.go
@@ -2,7 +2,7 @@ package io
 
 import (
 	"bytes"
-	"math/rand"
+	"crypto/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/pkg/model/trace/combine_test.go
+++ b/pkg/model/trace/combine_test.go
@@ -2,8 +2,8 @@ package trace
 
 import (
 	"bytes"
+	crand "crypto/rand"
 	"fmt"
-	"math/rand"
 	"sort"
 	"strconv"
 	"testing"
@@ -74,7 +74,7 @@ func TestTokenForIDCollision(t *testing.T) {
 
 	spanID := make([]byte, 8)
 	for i := 0; i < n; i++ {
-		_, err := rand.Read(spanID)
+		_, err := crand.Read(spanID)
 		require.NoError(t, err)
 
 		copy := append([]byte(nil), spanID...)

--- a/pkg/tempopb/prealloc_test.go
+++ b/pkg/tempopb/prealloc_test.go
@@ -1,18 +1,20 @@
 package tempopb
 
 import (
-	"math/rand"
+	crand "crypto/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUnmarshal(t *testing.T) {
 	var dummyData = make([]byte, 10)
-	rand.Read(dummyData)
+	_, err := crand.Read(dummyData)
+	require.NoError(t, err)
 
 	preallocReq := &PreallocBytes{}
-	err := preallocReq.Unmarshal(dummyData)
+	err = preallocReq.Unmarshal(dummyData)
 	assert.NoError(t, err)
 
 	assert.Equal(t, dummyData, preallocReq.Slice)
@@ -22,10 +24,11 @@ func TestMarshal(t *testing.T) {
 	preallocReq := &PreallocBytes{
 		Slice: make([]byte, 10),
 	}
-	rand.Read(preallocReq.Slice)
+	_, err := crand.Read(preallocReq.Slice)
+	require.NoError(t, err)
 
 	var dummyData = make([]byte, 10)
-	_, err := preallocReq.MarshalTo(dummyData)
+	_, err = preallocReq.MarshalTo(dummyData)
 	assert.NoError(t, err)
 
 	assert.Equal(t, preallocReq.Slice, dummyData)

--- a/pkg/util/test/req.go
+++ b/pkg/util/test/req.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	crand "crypto/rand"
 	"encoding/json"
 	"math/rand"
 	"testing"
@@ -44,7 +45,10 @@ func MakeSpanWithAttributeCount(traceID []byte, count int) *v1_trace.Span {
 		DroppedLinksCount:      rand.Uint32(),
 		DroppedAttributesCount: rand.Uint32(),
 	}
-	rand.Read(s.SpanId)
+	_, err := crand.Read(s.SpanId)
+	if err != nil {
+		panic(err)
+	}
 
 	// add link
 	if rand.Intn(5) == 0 {
@@ -186,7 +190,10 @@ func MakeTraceWithSpanCount(requests int, spansEach int, traceID []byte) *tempop
 func ValidTraceID(traceID []byte) []byte {
 	if len(traceID) == 0 {
 		traceID = make([]byte, 16)
-		rand.Read(traceID)
+		_, err := crand.Read(traceID)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	for len(traceID) < 16 {

--- a/tempodb/backend/local/local_test.go
+++ b/tempodb/backend/local/local_test.go
@@ -3,6 +3,7 @@ package local
 import (
 	"bytes"
 	"context"
+	crand "crypto/rand"
 	"fmt"
 	"math/rand"
 	"os"
@@ -42,7 +43,7 @@ func TestReadWrite(t *testing.T) {
 
 	fakeObject := make([]byte, 20)
 
-	_, err = rand.Read(fakeObject)
+	_, err = crand.Read(fakeObject)
 	assert.NoError(t, err, "unexpected error creating fakeObject")
 
 	ctx := context.Background()

--- a/tempodb/encoding/common/bloom_test.go
+++ b/tempodb/encoding/common/bloom_test.go
@@ -2,7 +2,7 @@ package common
 
 import (
 	"bytes"
-	"math/rand"
+	crand "crypto/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,7 +16,7 @@ func TestShardedBloom(t *testing.T) {
 	traceIDs := make([][]byte, 0)
 	for i := 0; i < numTraces; i++ {
 		id := make([]byte, 16)
-		_, err = rand.Read(id)
+		_, err = crand.Read(id)
 		assert.NoError(t, err)
 		traceIDs = append(traceIDs, id)
 	}

--- a/tempodb/encoding/v2/appender_test.go
+++ b/tempodb/encoding/v2/appender_test.go
@@ -1,7 +1,7 @@
 package v2
 
 import (
-	"math/rand"
+	crand "crypto/rand"
 	"testing"
 
 	"github.com/grafana/tempo/tempodb/encoding/common"
@@ -39,7 +39,7 @@ func benchmarkAppender(b *testing.B, appendRecords int) {
 
 		for j := 0; j < appendRecords; j++ {
 			id := make([]byte, 16)
-			_, err := rand.Read(id)
+			_, err := crand.Read(id)
 			require.NoError(b, err)
 
 			err = appender.Append(id, nil)

--- a/tempodb/encoding/v2/data_reader_writer_test.go
+++ b/tempodb/encoding/v2/data_reader_writer_test.go
@@ -3,8 +3,8 @@ package v2
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"io"
-	"math/rand"
 	"testing"
 
 	"github.com/grafana/tempo/tempodb/backend"

--- a/tempodb/encoding/v2/index_test.go
+++ b/tempodb/encoding/v2/index_test.go
@@ -3,6 +3,7 @@ package v2
 import (
 	"bytes"
 	"context"
+	crand "crypto/rand"
 	"math/rand"
 	"testing"
 
@@ -70,7 +71,7 @@ func randomOrderedRecords(t *testing.T, num int) []Record {
 
 	for i := 0; i < num; i++ {
 		id := make([]byte, 16)
-		_, err := rand.Read(id)
+		_, err := crand.Read(id)
 		require.NoError(t, err)
 
 		rec := Record{

--- a/tempodb/encoding/v2/iterator_paged_test.go
+++ b/tempodb/encoding/v2/iterator_paged_test.go
@@ -3,9 +3,9 @@ package v2
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"fmt"
 	"io"
-	"math/rand"
 	"strconv"
 	"testing"
 

--- a/tempodb/encoding/v2/object_test.go
+++ b/tempodb/encoding/v2/object_test.go
@@ -2,7 +2,7 @@ package v2
 
 import (
 	"bytes"
-	"math/rand"
+	"crypto/rand"
 	"testing"
 
 	"github.com/golang/protobuf/proto" //nolint:all //ProtoReflect
@@ -37,7 +37,8 @@ func TestMarshalUnmarshal(t *testing.T) {
 func TestMarshalUnmarshalFromBuffer(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	id := make([]byte, 16)
-	rand.Read(id)
+	_, err := rand.Read(id)
+	assert.NoError(t, err)
 
 	o := object{}
 	var reqs []*tempopb.Trace

--- a/tempodb/encoding/v2/record_test.go
+++ b/tempodb/encoding/v2/record_test.go
@@ -2,7 +2,7 @@ package v2
 
 import (
 	"bytes"
-	"math/rand"
+	crand "crypto/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,7 +56,7 @@ func makeRecord(t *testing.T) (Record, error) {
 		Length: 0,
 	}
 
-	_, err := rand.Read(r.ID)
+	_, err := crand.Read(r.ID)
 	if err != nil {
 		return Record{}, err
 	}

--- a/tempodb/encoding/v2/streaming_block_test.go
+++ b/tempodb/encoding/v2/streaming_block_test.go
@@ -27,6 +27,8 @@ const (
 	testTenantID = "fake"
 )
 
+var rng = rand.New(rand.NewSource(time.Now().UnixNano()))
+
 func TestStreamingBlockError(t *testing.T) {
 	// no block metas
 	_, err := NewStreamingBlock(nil, uuid.New(), "", nil, 0)
@@ -54,7 +56,7 @@ func TestStreamingBlockAddObject(t *testing.T) {
 		},
 	}
 
-	numObjects := (rand.Int() % 20) + 1
+	numObjects := (rng.Int() % 20) + 1
 	cb, err := NewStreamingBlock(&common.BlockConfig{
 		BloomFP:              0.01,
 		BloomShardSizeBytes:  100,
@@ -72,11 +74,11 @@ func TestStreamingBlockAddObject(t *testing.T) {
 	ids := make([][]byte, 0)
 	for i := 0; i < numObjects; i++ {
 		id := make([]byte, 16)
-		_, err = rand.Read(id)
+		_, err = rng.Read(id)
 		assert.NoError(t, err)
 
-		object := make([]byte, rand.Int()%1024)
-		_, err = rand.Read(object)
+		object := make([]byte, rng.Int()%1024)
+		_, err = rng.Read(object)
 		assert.NoError(t, err)
 
 		ids = append(ids, id)
@@ -130,10 +132,10 @@ func TestStreamingBlockAddObject(t *testing.T) {
 
 func TestStreamingBlockAll(t *testing.T) {
 	for i := 0; i < 10; i++ {
-		indexDownsampleBytes := rand.Intn(5000) + 1000
-		bloomFP := float64(rand.Intn(99)+1) / 100.0
-		bloomShardSize := rand.Intn(10_000) + 10_000
-		indexPageSize := rand.Intn(5000) + 1000
+		indexDownsampleBytes := rng.Intn(5000) + 1000
+		bloomFP := float64(rng.Intn(99)+1) / 100.0
+		bloomShardSize := rng.Intn(10_000) + 10_000
+		indexPageSize := rng.Intn(5000) + 1000
 
 		for _, enc := range backend.SupportedEncoding {
 			t.Run(enc.String(), func(t *testing.T) {
@@ -205,8 +207,6 @@ func testStreamingBlockToBackendBlock(t *testing.T, cfg *common.BlockConfig) {
 }
 
 func streamingBlock(t *testing.T, cfg *common.BlockConfig, w backend.Writer) (*StreamingBlock, [][]byte, [][]byte) {
-	rand.Seed(time.Now().Unix())
-
 	buffer := &bytes.Buffer{}
 	writer := bufio.NewWriter(buffer)
 	dataWriter, err := NewDataWriter(writer, backend.EncNone)
@@ -219,10 +219,10 @@ func streamingBlock(t *testing.T, cfg *common.BlockConfig, w backend.Writer) (*S
 	var maxID, minID []byte
 	for i := 0; i < numMsgs; i++ {
 		id := make([]byte, 16)
-		rand.Read(id)
+		rng.Read(id)
 		ids = append(ids, id)
-		req := make([]byte, rand.Intn(100)+1)
-		rand.Read(req)
+		req := make([]byte, rng.Intn(100)+1)
+		rng.Read(req)
 		reqs = append(reqs, req)
 
 		err = appender.Append(id, req)

--- a/tempodb/encoding/v2/wal_block_test.go
+++ b/tempodb/encoding/v2/wal_block_test.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"context"
+	crand "crypto/rand"
 	"encoding/binary"
 	"io"
 	"math/rand"
@@ -196,7 +197,7 @@ func TestPartialBlock(t *testing.T) {
 	// append garbage data
 	v2Block := block.(*walBlock)
 	garbo := make([]byte, 100)
-	_, err = rand.Read(garbo)
+	_, err = crand.Read(garbo)
 	require.NoError(t, err)
 
 	appendFile, err := os.OpenFile(v2Block.fullFilename(), os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)

--- a/tempodb/wal/wal_test.go
+++ b/tempodb/wal/wal_test.go
@@ -3,6 +3,7 @@ package wal
 import (
 	"bytes"
 	"context"
+	crand "crypto/rand"
 	"fmt"
 	"io"
 	"math/rand"
@@ -86,7 +87,8 @@ func testAppendBlockStartEnd(t *testing.T, e encoding.VersionedEncoding) {
 
 	for i := 0; i < 10; i++ {
 		id := make([]byte, 16)
-		rand.Read(id)
+		_, err := crand.Read(id)
+		require.NoError(t, err)
 		obj := test.MakeTrace(rand.Int()%10+1, id)
 
 		b1, err := enc.PrepareForWrite(obj, blockStart, blockEnd)
@@ -146,7 +148,8 @@ func testIngestionSlack(t *testing.T, e encoding.VersionedEncoding) {
 
 	// Append a trace
 	id := make([]byte, 16)
-	rand.Read(id)
+	_, err = crand.Read(id)
+	require.NoError(t, err)
 	obj := test.MakeTrace(rand.Int()%10+1, id)
 
 	b1, err := enc.PrepareForWrite(obj, traceStart, traceEnd)
@@ -332,7 +335,8 @@ func TestInvalidFilesAndFoldersAreHandled(t *testing.T) {
 		require.NoError(t, err)
 
 		id := make([]byte, 16)
-		rand.Read(id)
+		_, err = crand.Read(id)
+		require.NoError(t, err)
 		tr := test.MakeTrace(10, id)
 		b1, err := model.MustNewSegmentDecoder(model.CurrentEncoding).PrepareForWrite(tr, 0, 0)
 		require.NoError(t, err)
@@ -387,7 +391,8 @@ func runWALTest(t testing.TB, encoding string, runner func([][]byte, []*tempopb.
 	ids := make([][]byte, 0, objects)
 	for i := 0; i < objects; i++ {
 		id := make([]byte, 16)
-		rand.Read(id)
+		_, err = crand.Read(id)
+		require.NoError(t, err)
 		obj := test.MakeTrace(rand.Int()%10+1, id)
 
 		trace.SortTrace(obj)
@@ -533,7 +538,8 @@ func runWALBenchmark(b *testing.B, encoding string, flushCount int, runner func(
 	ids := make([][]byte, 0, objects)
 	for i := 0; i < objects; i++ {
 		id := make([]byte, 16)
-		rand.Read(id)
+		_, err = crand.Read(id)
+		require.NoError(b, err)
 		obj := test.MakeTrace(rand.Int()%10+1, id)
 
 		trace.SortTrace(obj)


### PR DESCRIPTION
**What this PR does**:
[Go 1.20 officially released recently](https://tip.golang.org/doc/go1.20)

There's improvements on the garbage collector. It informs that overall performance improves by up to 2% and reduces memory overheads.

Migrating to v1.20 will provides improved performance, bug fixes, security enhancements and several new features in the languages.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`