### PR TITLE
[release-v1.5] Update publishing workflows to use organization secret (#2080)

### DIFF
--- a/.github/workflows/website-next.yml
+++ b/.github/workflows/website-next.yml
@@ -22,9 +22,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: "Clone website-sync Action"
-        # WEBSITE_SYNC_TEMPO is a fine-grained GitHub Personal Access Token that expires.
-        # It must be updated in the grafanabot GitHub account.
-        run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_TEMPO }}@github.com/grafana/website-sync ./.github/actions/website-sync"
+        # WEBSITE_SYNC_TOKEN is a fine-grained GitHub Personal Access Token that expires.
+        # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
+        # GitHub administrator to update the organization secret.
+        # The IT helpdesk can update the organization secret.
+        run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync"
+
       - name: publish-to-git
         uses: ./.github/actions/website-sync
         id: publish
@@ -32,9 +35,11 @@ jobs:
           repository: grafana/website
           branch: master
           host: github.com
-          # PUBLISH_TO_WEBSITE_TEMPO is a fine-grained GitHub Personal Access Token that expires.
-          # It must be updated in the grafanabot GitHub account.
-          github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_TEMPO }}"
+          # PUBLISH_TO_WEBSITE_TOKEN is a fine-grained GitHub Personal Access Token that expires.
+          # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
+          # GitHub administrator to update the organization secret.
+          # The IT helpdesk can update the organization secret.
+          github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_TOKEN }}"
           source_folder: docs/tempo/website
           target_folder: content/docs/tempo/next
       - shell: bash

--- a/.github/workflows/website-versioned.yml
+++ b/.github/workflows/website-versioned.yml
@@ -57,10 +57,12 @@ jobs:
       # Clone and run the website sync action
       # ----------------------------------------
       - if: steps.has-tag.outputs.bool == 'true'
-        # WEBSITE_SYNC_TEMPO is a fine-grained GitHub Personal Access Token that expires.
-        # It must be updated in the grafanabot GitHub account.
-        run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_TEMPO }}@github.com/grafana/website-sync ./.github/actions/website-sync"
-      
+        # WEBSITE_SYNC_TOKEN is a fine-grained GitHub Personal Access Token that expires.
+        # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
+        # GitHub administrator to update the organization secret.
+        # The IT helpdesk can update the organization secret.
+        run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync"
+
       - if: steps.has-tag.outputs.bool == 'true'
         name: publish-to-git
         uses: ./.github/actions/website-sync
@@ -69,9 +71,11 @@ jobs:
           repository: grafana/website
           branch: master
           host: github.com
-          # PUBLISH_TO_WEBSITE_TEMPO is a fine-grained GitHub Personal Access Token that expires.
-          # It must be updated in the grafanabot GitHub account.
-          github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_TEMPO }}"
+          # PUBLISH_TO_WEBSITE_TOKEN is a fine-grained GitHub Personal Access Token that expires.
+          # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
+          # GitHub administrator to update the organization secret.
+          # The IT helpdesk can update the organization secret.
+          github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_TOKEN }}"
           source_folder: docs/tempo/website
           # target is v1.2.x
           target_folder: content/docs/tempo/${{ steps.target.outputs.target }}.x


### PR DESCRIPTION
The new tokens are managed centrally and have a longer expiry. Administrators of the grafanabot account will be
notified of the pending expiry and the secret can be rotated centrally without the need for a repository administrator to update their secrets.

The existing repository secrets can safely be removed. The tokens for those secrets will be removed by the end of this week.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
(cherry picked from commit dfc7848f24572dbc04510080a9f91a910e294593)
