### PR TITLE
Parquet: Fix Combiner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 * [CHANGE] Add support for s3 session token in static config [#2093](https://github.com/grafana/tempo/pull/2093) (@farodin91)
 * [BUGFIX] Suppress logspam in single binary mode when metrics generator is disabled. [#2058](https://github.com/grafana/tempo/pull/2058) (@joe-elliott)
 * [BUGFIX] Error more gracefully while reading some blocks written by an interim commit between 1.5 and 2.0 [#2055](https://github.com/grafana/tempo/pull/2055) (@mdisibio)
-* [BUGFIX] Apply `rate()` to bytes/s panel in tenant's dashboard. [#](https://github.com/grafana/tempo/pull/) (@mapno)
+* [BUGFIX] Apply `rate()` to bytes/s panel in tenant's dashboard. [#2081](https://github.com/grafana/tempo/pull/2081) (@mapno)
+* [BUGFIX] Correctly coalesce trace level data when combining Parquet traces. [#2095](https://github.com/grafana/tempo/pull/2095) (@joe-elliott)
 
 ## v2.0.0 / 2023-01-31
 

--- a/tempodb/encoding/vparquet/combiner.go
+++ b/tempodb/encoding/vparquet/combiner.go
@@ -99,7 +99,7 @@ func (c *Combiner) ConsumeWithFinal(tr *Trace, final bool) (spanCount int) {
 		return
 	}
 
-	// coalese root level information
+	// coalesce root level information
 	if tr.EndTimeUnixNano > c.result.EndTimeUnixNano {
 		c.result.EndTimeUnixNano = tr.EndTimeUnixNano
 	}

--- a/tempodb/encoding/vparquet/combiner.go
+++ b/tempodb/encoding/vparquet/combiner.go
@@ -99,6 +99,21 @@ func (c *Combiner) ConsumeWithFinal(tr *Trace, final bool) (spanCount int) {
 		return
 	}
 
+	// coalese root level information
+	if tr.EndTimeUnixNano > c.result.EndTimeUnixNano || c.result.EndTimeUnixNano == 0 {
+		c.result.EndTimeUnixNano = tr.EndTimeUnixNano
+	}
+	if tr.StartTimeUnixNano < c.result.StartTimeUnixNano || c.result.StartTimeUnixNano == 0 {
+		c.result.StartTimeUnixNano = tr.StartTimeUnixNano
+	}
+	if c.result.RootServiceName == "" {
+		c.result.RootServiceName = tr.RootServiceName
+	}
+	if c.result.RootSpanName == "" {
+		c.result.RootSpanName = tr.RootSpanName
+	}
+	c.result.DurationNanos = c.result.EndTimeUnixNano - c.result.StartTimeUnixNano
+
 	// loop through every span and copy spans in B that don't exist to A
 	for _, b := range tr.ResourceSpans {
 		notFoundILS := b.ScopeSpans[:0]

--- a/tempodb/encoding/vparquet/combiner.go
+++ b/tempodb/encoding/vparquet/combiner.go
@@ -100,7 +100,7 @@ func (c *Combiner) ConsumeWithFinal(tr *Trace, final bool) (spanCount int) {
 	}
 
 	// coalese root level information
-	if tr.EndTimeUnixNano > c.result.EndTimeUnixNano || c.result.EndTimeUnixNano == 0 {
+	if tr.EndTimeUnixNano > c.result.EndTimeUnixNano {
 		c.result.EndTimeUnixNano = tr.EndTimeUnixNano
 	}
 	if tr.StartTimeUnixNano < c.result.StartTimeUnixNano || c.result.StartTimeUnixNano == 0 {

--- a/tempodb/encoding/vparquet/combiner_test.go
+++ b/tempodb/encoding/vparquet/combiner_test.go
@@ -40,6 +40,88 @@ func TestCombiner(t *testing.T) {
 			traceB:        &Trace{},
 			expectedTotal: 0,
 		},
+		// root meta from second overrides empty first
+		{
+			traceA: &Trace{
+				TraceID: []byte{0x00, 0x01},
+			},
+			traceB: &Trace{
+				TraceID:           []byte{0x00, 0x01},
+				RootServiceName:   "serviceNameB",
+				RootSpanName:      "spanNameB",
+				StartTimeUnixNano: 10,
+				EndTimeUnixNano:   20,
+				DurationNanos:     10,
+			},
+			expectedTrace: &Trace{
+				TraceID:           []byte{0x00, 0x01},
+				RootServiceName:   "serviceNameB",
+				RootSpanName:      "spanNameB",
+				StartTimeUnixNano: 10,
+				EndTimeUnixNano:   20,
+				DurationNanos:     10,
+			},
+		},
+		// if both set first root name wins
+		{
+			traceA: &Trace{
+				TraceID:         []byte{0x00, 0x01},
+				RootServiceName: "serviceNameA",
+				RootSpanName:    "spanNameA",
+			},
+			traceB: &Trace{
+				TraceID:         []byte{0x00, 0x01},
+				RootServiceName: "serviceNameB",
+				RootSpanName:    "spanNameB",
+			},
+			expectedTrace: &Trace{
+				TraceID:         []byte{0x00, 0x01},
+				RootServiceName: "serviceNameA",
+				RootSpanName:    "spanNameA",
+			},
+		},
+		// second trace start/end override
+		{
+			traceA: &Trace{
+				TraceID:           []byte{0x00, 0x01},
+				StartTimeUnixNano: 10,
+				EndTimeUnixNano:   20,
+				DurationNanos:     10,
+			},
+			traceB: &Trace{
+				TraceID:           []byte{0x00, 0x01},
+				StartTimeUnixNano: 5,
+				EndTimeUnixNano:   25,
+				DurationNanos:     20,
+			},
+			expectedTrace: &Trace{
+				TraceID:           []byte{0x00, 0x01},
+				StartTimeUnixNano: 5,
+				EndTimeUnixNano:   25,
+				DurationNanos:     20,
+			},
+		},
+		// second trace start/end ignored
+		{
+			traceA: &Trace{
+				TraceID:           []byte{0x00, 0x01},
+				StartTimeUnixNano: 10,
+				EndTimeUnixNano:   20,
+				DurationNanos:     10,
+			},
+			traceB: &Trace{
+				TraceID:           []byte{0x00, 0x01},
+				StartTimeUnixNano: 12,
+				EndTimeUnixNano:   18,
+				DurationNanos:     6,
+			},
+			expectedTrace: &Trace{
+				TraceID:           []byte{0x00, 0x01},
+				StartTimeUnixNano: 10,
+				EndTimeUnixNano:   20,
+				DurationNanos:     10,
+			},
+		},
 		{
 			traceA: &Trace{
 				TraceID:         []byte{0x00, 0x01},


### PR DESCRIPTION
**What this PR does**:
The Parquet combiner used during compaction and when combining multiple traces on query does not correctly coalesce root level trace data. This fixes it.

**Which issue(s) this PR fixes**:
Likely this fixes #2057. At  least it would certainly contribute to it.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`