### PR TITLE
Fix TLS documentation for configuring Jaeger receviers

### DIFF
--- a/docs/sources/configuration/tls.md
+++ b/docs/sources/configuration/tls.md
@@ -89,5 +89,5 @@ The above structure can be set on the following receiver configurations:
 - `distributor.receivers.otlp.protocols.grpc.tls`
 - `distributor.receivers.otlp.protocols.http.tls`
 - `distributor.receivers.zipkin.tls`
-- `distributor.receivers.jaeger.grpc.tls`
-- `distributor.receivers.jaeger.thrift_http.tls`
+- `distributor.receivers.jaeger.protocols.grpc.tls`
+- `distributor.receivers.jaeger.protocols.thrift_http.tls`


### PR DESCRIPTION
**What this PR does**:

Fix the path we hang the Jaeger TLS block in our documentation.

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`