### PR TITLE
Log when a trace is too large to compact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,16 @@
 ## main / unreleased
 
+* [CHANGE] Add support for s3 session token in static config [#2093](https://github.com/grafana/tempo/pull/2093) (@farodin91)
+* [CHANGE] Update Go to 1.20 [#2079](https://github.com/grafana/tempo/pull/2079) (@scalalang2)
+* [CHANGE] Removing leading zeroes in span id [#2062](https://github.com/grafana/tempo/pull/2062) (@ie-pham)
 * [FEATURE] Add flag to optionally enable all available Go runtime metrics [#2005](https://github.com/grafana/tempo/pull/2005) (@andreasgerstmayr)
 * [ENHANCEMENT] Metrics generator to make use of counters earlier [#2068](https://github.com/grafana/tempo/pull/2068) (@zalegrala)
-* [CHANGE] Add support for s3 session token in static config [#2093](https://github.com/grafana/tempo/pull/2093) (@farodin91)
+* [ENHANCEMENT] Log when a trace is too large to compact [#2105](https://github.com/grafana/tempo/pull/2105) (@scalalang2)
 * [BUGFIX] Suppress logspam in single binary mode when metrics generator is disabled. [#2058](https://github.com/grafana/tempo/pull/2058) (@joe-elliott)
 * [BUGFIX] Error more gracefully while reading some blocks written by an interim commit between 1.5 and 2.0 [#2055](https://github.com/grafana/tempo/pull/2055) (@mdisibio)
 * [BUGFIX] Apply `rate()` to bytes/s panel in tenant's dashboard. [#2081](https://github.com/grafana/tempo/pull/2081) (@mapno)
 * [BUGFIX] Correctly coalesce trace level data when combining Parquet traces. [#2095](https://github.com/grafana/tempo/pull/2095) (@joe-elliott)
 * [BUGFIX] Unescape query parameters in AWS Lambda to allow TraceQL queries to work. [#2114](https://github.com/grafana/tempo/issues/2114) (@joe-elliott)
-* [CHANGE] Update Go to 1.20 [#2079](https://github.com/grafana/tempo/pull/2079) (@scalalang2)
-* [CHANGE] Removing leading zeroes in span id [#2062](https://github.com/grafana/tempo/pull/2062) (@ie-pham)
 
 ## v2.0.0 / 2023-01-31
 

--- a/modules/compactor/compactor.go
+++ b/modules/compactor/compactor.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
+	tempoUtil "github.com/grafana/tempo/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -236,12 +237,13 @@ func (c *Compactor) Combine(dataEncoding string, tenantID string, objs ...[]byte
 		return objs[0], wasCombined, nil
 	}
 
-	spansDiscarded := countSpans(dataEncoding, objs[1:]...)
-	overrides.RecordDiscardedSpans(spansDiscarded, reasonCompactorDiscardedSpans, tenantID)
+	totalDiscarded := countSpans(dataEncoding, objs[1:]...)
+	overrides.RecordDiscardedSpans(totalDiscarded, reasonCompactorDiscardedSpans, tenantID)
 	return objs[0], wasCombined, nil
 }
 
-func (c *Compactor) RecordDiscardedSpans(count int, tenantID string) {
+func (c *Compactor) RecordDiscardedSpans(count int, tenantID string, traceID string) {
+	level.Warn(log.Logger).Log("msg", "max size of trace exceeded", "tenant", tenantID, "traceId", traceID, "discarded_span_count", count)
 	overrides.RecordDiscardedSpans(count, reasonCompactorDiscardedSpans, tenantID)
 }
 
@@ -293,12 +295,12 @@ func (c *Compactor) OnRingInstanceStopping(lifecycler *ring.BasicLifecycler) {}
 func (c *Compactor) OnRingInstanceHeartbeat(lifecycler *ring.BasicLifecycler, ringDesc *ring.Desc, instanceDesc *ring.InstanceDesc) {
 }
 
-func countSpans(dataEncoding string, objs ...[]byte) int {
+func countSpans(dataEncoding string, objs ...[]byte) (total int) {
+	var traceID string
 	decoder, err := model.NewObjectDecoder(dataEncoding)
 	if err != nil {
 		return 0
 	}
-	spans := 0
 
 	for _, o := range objs {
 		t, err := decoder.PrepareForRead(o)
@@ -308,10 +310,15 @@ func countSpans(dataEncoding string, objs ...[]byte) int {
 
 		for _, b := range t.Batches {
 			for _, ilm := range b.ScopeSpans {
-				spans += len(ilm.Spans)
+				if len(ilm.Spans) > 0 && traceID == "" {
+					traceID = tempoUtil.TraceIDToHexString(ilm.Spans[0].TraceId)
+				}
+				total += len(ilm.Spans)
 			}
 		}
 	}
 
-	return spans
+	level.Debug(log.Logger).Log("msg", "max size of trace exceeded", "traceId", traceID, "discarded_span_count", total)
+
+	return
 }

--- a/modules/compactor/compactor_test.go
+++ b/modules/compactor/compactor_test.go
@@ -113,11 +113,13 @@ func TestCountSpans(t *testing.T) {
 	b1 := encode(t, t1)
 	b2 := encode(t, t2)
 
-	assert.Equal(t, t1ExpectedSpans, countSpans(model.CurrentEncoding, b1))
-	assert.Equal(t, t2ExpectedSpans, countSpans(model.CurrentEncoding, b2))
-	assert.Equal(t,
-		t1ExpectedSpans+t2ExpectedSpans,
-		countSpans(model.CurrentEncoding, b1, b2))
+	b1Total := countSpans(model.CurrentEncoding, b1)
+	b2Total := countSpans(model.CurrentEncoding, b2)
+	total := countSpans(model.CurrentEncoding, b1, b2)
+
+	assert.Equal(t, t1ExpectedSpans, b1Total)
+	assert.Equal(t, t2ExpectedSpans, b2Total)
+	assert.Equal(t, t1ExpectedSpans+t2ExpectedSpans, total)
 }
 
 func encode(t *testing.T, tr *tempopb.Trace) []byte {

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -194,8 +194,8 @@ func (rw *readerWriter) compact(blockMetas []*backend.BlockMeta, tenantID string
 		ObjectsWritten: func(compactionLevel, objs int) {
 			metricCompactionObjectsWritten.WithLabelValues(strconv.Itoa(compactionLevel)).Add(float64(objs))
 		},
-		SpansDiscarded: func(spans int) {
-			rw.compactorSharder.RecordDiscardedSpans(spans, tenantID)
+		SpansDiscarded: func(traceId string, spans int) {
+			rw.compactorSharder.RecordDiscardedSpans(spans, tenantID, traceId)
 		},
 	}
 

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -42,7 +42,7 @@ func (m *mockSharder) Combine(dataEncoding string, tenantID string, objs ...[]by
 	return model.StaticCombiner.Combine(dataEncoding, objs...)
 }
 
-func (m *mockSharder) RecordDiscardedSpans(count int, tenantID string) {}
+func (m *mockSharder) RecordDiscardedSpans(count int, tenantID string, traceID string) {}
 
 type mockJobSharder struct{}
 

--- a/tempodb/encoding/common/interfaces.go
+++ b/tempodb/encoding/common/interfaces.go
@@ -74,7 +74,7 @@ type CompactionOptions struct {
 	ObjectsCombined func(compactionLevel, objects int)
 	ObjectsWritten  func(compactionLevel, objects int)
 	BytesWritten    func(compactionLevel, bytes int)
-	SpansDiscarded  func(spans int)
+	SpansDiscarded  func(traceID string, spans int)
 }
 
 type Iterator interface {

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -93,7 +93,7 @@ type Compactor interface {
 type CompactorSharder interface {
 	Combine(dataEncoding string, tenantID string, objs ...[]byte) ([]byte, bool, error)
 	Owns(hash string) bool
-	RecordDiscardedSpans(count int, tenantID string)
+	RecordDiscardedSpans(count int, tenantID string, traceID string)
 }
 
 type CompactorOverrides interface {


### PR DESCRIPTION
**What this PR does**:
Log when a trace is too large to compact.
If the total bytes of traces exceeds maximum limit, the following messages will be logged.

```json
{
    "msg": "max size of trace exceeded",
    "tenant": "XXXXX",
    "traceId": "XXXXX",
    "discarded_span_count": 100
}
```

There will be some dicussions in this PR.
Please refer to following comments.

**Which issue(s) this PR fixes**:
Fixes #1931

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`