### PR TITLE
Unescape query strings in lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [BUGFIX] Error more gracefully while reading some blocks written by an interim commit between 1.5 and 2.0 [#2055](https://github.com/grafana/tempo/pull/2055) (@mdisibio)
 * [BUGFIX] Apply `rate()` to bytes/s panel in tenant's dashboard. [#2081](https://github.com/grafana/tempo/pull/2081) (@mapno)
 * [BUGFIX] Correctly coalesce trace level data when combining Parquet traces. [#2095](https://github.com/grafana/tempo/pull/2095) (@joe-elliott)
+* [BUGFIX] Unescape query parameters in AWS Lambda to allow TraceQL queries to work. [#2114](https://github.com/grafana/tempo/issues/2114) (@joe-elliott)
 * [CHANGE] Update Go to 1.20 [#2079](https://github.com/grafana/tempo/pull/2079) (@scalalang2)
 
 ## v2.0.0 / 2023-01-31

--- a/cmd/tempo-serverless/lambda/go.mod
+++ b/cmd/tempo-serverless/lambda/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-lambda-go v1.28.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/grafana/tempo v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.8.1
 )
 
 require (
@@ -112,7 +113,6 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.12.0 // indirect
-	github.com/stretchr/testify v1.8.1 // indirect
 	github.com/subosito/gotenv v1.3.0 // indirect
 	github.com/uber-go/atomic v1.4.0 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect

--- a/cmd/tempo-serverless/lambda/main_test.go
+++ b/cmd/tempo-serverless/lambda/main_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/stretchr/testify/require"
+)
+
+// Test that httpRequest() works as expected
+func Test_httpRequest(t *testing.T) {
+	tests := []struct {
+		event   events.ALBTargetGroupRequest
+		want    *http.Request
+		wantErr string
+	}{
+		// empty
+		{
+			event: events.ALBTargetGroupRequest{},
+			want: &http.Request{
+				Method:     "GET",
+				RequestURI: "/",
+				URL:        &url.URL{},
+				Header:     map[string][]string{},
+			},
+		},
+		// rando
+		{
+			event: events.ALBTargetGroupRequest{
+				HTTPMethod: "GET",
+				Path:       "/",
+				Headers: map[string]string{
+					"Content-Type": "application/json",
+				},
+				QueryStringParameters: map[string]string{
+					"query": "test",
+				},
+				Body: "test",
+			},
+			want: &http.Request{
+				Method:     "GET",
+				RequestURI: "/?query=test",
+				URL: &url.URL{
+					Path:     "/",
+					RawQuery: "query=test",
+				},
+				Header: map[string][]string{
+					"Content-Type": {"application/json"},
+				},
+			},
+		},
+		// unescape params
+		{
+			event: events.ALBTargetGroupRequest{
+				QueryStringParameters: map[string]string{
+					"q": "%7B%20.foo%20%3D%20bar%20%7D",
+				},
+			},
+			want: &http.Request{
+				Method:     "GET",
+				RequestURI: "/?q=%7B+.foo+%3D+bar+%7D",
+				URL: &url.URL{
+					RawQuery: "q=%7B+.foo+%3D+bar+%7D",
+				},
+				Header: map[string][]string{},
+			},
+		},
+		// unescape multivalue params
+		{
+			event: events.ALBTargetGroupRequest{
+				MultiValueQueryStringParameters: map[string][]string{
+					"q2": {"%7B%20.foo%20%3D%20bar%20%7D", "%7B%20.foo%20%3D%20bar%20%7D"},
+				},
+			},
+			want: &http.Request{
+				Method:     "GET",
+				RequestURI: "/?q2=%7B+.foo+%3D+bar+%7D&q2=%7B+.foo+%3D+bar+%7D",
+				URL: &url.URL{
+					RawQuery: "q2=%7B+.foo+%3D+bar+%7D&q2=%7B+.foo+%3D+bar+%7D",
+				},
+				Header: map[string][]string{},
+			},
+		},
+		// unescape error
+		{
+			event: events.ALBTargetGroupRequest{
+				QueryStringParameters: map[string]string{
+					"q": "%7B%20.foo%20%3D%20bar%20%7D%ZZ",
+				},
+			},
+			wantErr: "failed to unescape query string parameter q: %7B%20.foo%20%3D%20bar%20%7D%ZZ: invalid URL escape \"%ZZ\"",
+		},
+	}
+
+	for _, tt := range tests {
+		got, err := httpRequest(tt.event)
+		if len(tt.wantErr) > 0 {
+			require.EqualError(t, err, tt.wantErr)
+			continue
+		} else {
+			require.NoError(t, err)
+		}
+
+		require.Equal(t, tt.want.Method, got.Method)
+		require.Equal(t, tt.want.RequestURI, got.RequestURI)
+		require.Equal(t, tt.want.URL, got.URL)
+		require.Equal(t, tt.want.Header, got.Header)
+	}
+}


### PR DESCRIPTION
**What this PR does**:
Correctly unescapes parameter values in AWS Lambda

**Which issue(s) this PR fixes**:
Fixes #2114 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`