### PR TITLE
Expose s3 bucket lookup type config

### DIFF
--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -659,6 +659,14 @@ storage:
             # enable to use path-style requests.
             [forcepathstyle: <bool>]
 
+            # Optional. Default is 0
+            # Example: "bucket_lookup_type: 0"
+            # options: 0: BucketLookupAuto, 1: BucketLookupDNS, 2: BucketLookupPath
+            # See the [S3 documentation on virtual-hosted–style and path-style](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#path-style-access) for more detail.
+            # See the [Minio-API documentation on opts.BucketLookup](https://github.com/minio/minio-go/blob/master/docs/API.md#newendpoint-string-opts-options-client-error)] for more detail.
+            # Notice: ignore this option if `forcepathstyle` is set true, this option allow expose minio's sdk configure.
+            [bucket_lookup_type: <int> | default = 0]
+
             # Optional. Default is 0 (disabled)
             # Example: "hedge_requests_at: 500ms"
             # If set to a non-zero value a second request will be issued at the provided duration. Recommended to

--- a/tempodb/backend/s3/config.go
+++ b/tempodb/backend/s3/config.go
@@ -19,9 +19,10 @@ type Config struct {
 	HedgeRequestsAt    time.Duration  `yaml:"hedge_requests_at"`
 	HedgeRequestsUpTo  int            `yaml:"hedge_requests_up_to"`
 	// SignatureV2 configures the object storage to use V2 signing instead of V4
-	SignatureV2    bool              `yaml:"signature_v2"`
-	ForcePathStyle bool              `yaml:"forcepathstyle"`
-	Tags           map[string]string `yaml:"tags"`
-	StorageClass   string            `yaml:"storage_class"`
-	Metadata       map[string]string `yaml:"metadata"`
+	SignatureV2      bool              `yaml:"signature_v2"`
+	ForcePathStyle   bool              `yaml:"forcepathstyle"`
+	BucketLookupType int               `yaml:"bucket_lookup_type"`
+	Tags             map[string]string `yaml:"tags"`
+	StorageClass     string            `yaml:"storage_class"`
+	Metadata         map[string]string `yaml:"metadata"`
 }

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -386,6 +386,8 @@ func createCore(cfg *Config, hedge bool) (*minio.Core, error) {
 
 	if cfg.ForcePathStyle {
 		opts.BucketLookup = minio.BucketLookupPath
+	} else {
+		opts.BucketLookup = minio.BucketLookupType(cfg.BucketLookupType)
 	}
 
 	return minio.NewCore(cfg.Endpoint, opts)


### PR DESCRIPTION
**What this PR does**:

Minio Sdk supports it，So we need to expose the configuration. For examples: The Volcano Engine product TOS S3 protocol request style only supports virtual host（https://www.volcengine.com/docs/6349/147050）

**Which issue(s) this PR fixes**:
Fixes #2109 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] [ENHANCEMENT] expose minio's BucketLookupType to tempo's S3 config