### PR TITLE
tempo-cli: add command to migrate a tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [FEATURE] Add flag to optionally enable all available Go runtime metrics [#2005](https://github.com/grafana/tempo/pull/2005) (@andreasgerstmayr)
 * [ENHANCEMENT] Metrics generator to make use of counters earlier [#2068](https://github.com/grafana/tempo/pull/2068) (@zalegrala)
+* [ENHANCEMENT] tempo-cli: add command to migrate a tenant [#2130](https://github.com/grafana/tempo/pull/2130) (@kvrhdn)
 * [CHANGE] Add support for s3 session token in static config [#2093](https://github.com/grafana/tempo/pull/2093) (@farodin91)
 * [BUGFIX] Suppress logspam in single binary mode when metrics generator is disabled. [#2058](https://github.com/grafana/tempo/pull/2058) (@joe-elliott)
 * [BUGFIX] Error more gracefully while reading some blocks written by an interim commit between 1.5 and 2.0 [#2055](https://github.com/grafana/tempo/pull/2055) (@mdisibio)

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,10 @@ docker-tempo:
 docker-tempo-debug:
 	COMPONENT=tempo $(MAKE) docker-component-debug
 
+.PHONY: docker-cli
+docker-tempo-cli:
+	COMPONENT=tempo-cli $(MAKE) docker-component
+
 .PHONY: docker-tempo-query
 docker-tempo-query:
 	COMPONENT=tempo-query $(MAKE) docker-component

--- a/cmd/tempo-cli/Dockerfile
+++ b/cmd/tempo-cli/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.16 as certs
+RUN apk --update add ca-certificates
+ARG TARGETARCH
+COPY bin/linux/tempo-cli-${TARGETARCH} /tempo-cli
+ENTRYPOINT ["/tempo-cli"]

--- a/cmd/tempo-cli/cmd-migrate-tenant.go
+++ b/cmd/tempo-cli/cmd-migrate-tenant.go
@@ -57,8 +57,7 @@ blocks:
 		}
 
 		// create a copy with destination tenant ID
-		var destBlockMeta backend.BlockMeta
-		destBlockMeta = *sourceBlockMeta
+		destBlockMeta := *sourceBlockMeta
 		destBlockMeta.TenantID = cmd.DestTenantID
 
 		encoder, err := encoding.FromVersion(sourceBlockMeta.Version)
@@ -71,7 +70,7 @@ blocks:
 			return errors.Wrap(err, "copying block")
 		}
 
-		copiedBlocks += 1
+		copiedBlocks++
 		copiedSize += sourceBlockMeta.Size
 	}
 

--- a/cmd/tempo-cli/cmd-migrate-tenant.go
+++ b/cmd/tempo-cli/cmd-migrate-tenant.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dustin/go-humanize"
+	"github.com/pkg/errors"
+
+	"github.com/grafana/tempo/tempodb/backend"
+	"github.com/grafana/tempo/tempodb/encoding"
+)
+
+type migrateTenantCmd struct {
+	SourceConfigFile string `type:"path" required:"" help:"Path to tempo config file for source"`
+
+	SourceTenantID string `arg:"" help:"source tenant-id"`
+	DestTenantID   string `arg:"" help:"dest tenant-id"`
+}
+
+func (cmd *migrateTenantCmd) Run(opts *globalOptions) error {
+	ctx := context.Background()
+
+	readerSource, readerDest, writerDest, err := cmd.setupBackends(opts)
+	if err != nil {
+		return errors.Wrap(err, "setting up backends")
+	}
+	defer func() {
+		readerSource.Shutdown()
+		readerDest.Shutdown()
+	}()
+
+	sourceTenantIndex, err := readerSource.TenantIndex(ctx, cmd.SourceTenantID)
+	if err != nil {
+		return errors.Wrap(err, "reading source tenant index")
+	}
+	fmt.Printf("Blocks in source: %d, compacted: %d\n", len(sourceTenantIndex.Meta), len(sourceTenantIndex.CompactedMeta))
+
+	// TODO create dest directory if it doesn't exist yet?
+
+	blocksDest, err := readerDest.Blocks(ctx, cmd.DestTenantID)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Blocks in destination: %d\n", len(blocksDest))
+
+	var copiedBlocks, copiedSize uint64
+
+blocks:
+	for _, sourceBlockMeta := range sourceTenantIndex.Meta {
+		// check for collisions
+		for _, uuidDest := range blocksDest {
+			if sourceBlockMeta.BlockID == uuidDest {
+				fmt.Printf("UUID %s exists in source and destination, skipping block\n", sourceBlockMeta.BlockID)
+				continue blocks
+			}
+		}
+
+		// create a copy with destination tenant ID
+		var destBlockMeta backend.BlockMeta
+		destBlockMeta = *sourceBlockMeta
+		destBlockMeta.TenantID = cmd.DestTenantID
+
+		encoder, err := encoding.FromVersion(sourceBlockMeta.Version)
+		if err != nil {
+			return errors.Wrap(err, "creating encoder from version")
+		}
+
+		err = encoder.MigrateBlock(ctx, sourceBlockMeta, &destBlockMeta, readerSource, writerDest)
+		if err != nil {
+			return errors.Wrap(err, "copying block")
+		}
+
+		copiedBlocks += 1
+		copiedSize += sourceBlockMeta.Size
+	}
+
+	fmt.Printf("Finished migrating data. Copied %d blocks, %s\n", copiedBlocks, humanize.Bytes(copiedSize))
+	return nil
+}
+
+func (cmd *migrateTenantCmd) setupBackends(optsDest *globalOptions) (readerSource, readerDest backend.Reader, writerDest backend.Writer, err error) {
+	emptyBackendOptions := backendOptions{}
+
+	optsSource := &globalOptions{
+		ConfigFile: cmd.SourceConfigFile,
+	}
+	readerSource, _, _, err = loadBackend(&emptyBackendOptions, optsSource)
+	if err != nil {
+		return
+	}
+
+	readerDest, writerDest, _, err = loadBackend(&emptyBackendOptions, optsDest)
+	return
+}

--- a/cmd/tempo-cli/main.go
+++ b/cmd/tempo-cli/main.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/grafana/tempo/cmd/tempo/app"
-	"github.com/grafana/tempo/tempodb/backend"
-	"github.com/grafana/tempo/tempodb/backend/local"
+	"github.com/alecthomas/kong"
 	"gopkg.in/yaml.v2"
 
-	"github.com/alecthomas/kong"
+	"github.com/grafana/tempo/cmd/tempo/app"
+	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/azure"
 	"github.com/grafana/tempo/tempodb/backend/gcs"
+	"github.com/grafana/tempo/tempodb/backend/local"
 	"github.com/grafana/tempo/tempodb/backend/s3"
 )
 
@@ -73,6 +73,10 @@ var cli struct {
 
 	Parquet struct {
 		Convert convertParquet `cmd:"" help:"convert from an existing file to tempodb parquet schema"`
+	} `cmd:""`
+
+	Migrate struct {
+		Tenant migrateTenantCmd `cmd:"" help:"migrate tenant between two backends"`
 	} `cmd:""`
 }
 

--- a/docs/sources/tempo/operations/tempo_cli.md
+++ b/docs/sources/tempo/operations/tempo_cli.md
@@ -27,11 +27,17 @@ tempo-cli command [subcommand] -h
 ## Running Tempo CLI
 
 Tempo CLI is currently available as source code. A working Go installation is required to build it. It can be compiled to a native binary and executed normally, or it can be executed using the `go run` command.
+It can be packaged as a Docker container using `make docker-tempo-cli`.
 
 **Example:**
 ```bash
 ./tempo-cli [arguments...]
 go run ./cmd/tempo-cli [arguments...]
+```
+
+```bash
+make docker-tempo-cli
+docker run docker.io/grafana/tempo-cli [arguments...]
 ```
 
 ## Backend options
@@ -266,6 +272,7 @@ attempting to determine the impact of changing compression or encoding of column
 
 ```bash
 tempo-cli parquet convert <in file> <out file>
+```
 
 Arguments:
 - `in file` Filename of an existing parquet file containing Tempo trace data
@@ -274,4 +281,25 @@ Arguments:
 **Example:**
 ```bash
 tempo-cli parquet convert data.parquet out.parquet
+```
+
+## Migrate tenant command
+Copy blocks from one backend and tenant to another. Blocks can be copied within the same backend or between two
+different backends. Data format will not be converted but tenant ID in `meta.json` will be rewritten.
+
+```bash
+tempo-cli migrate tenant <source tenant> <dest tenant>
+```
+
+Arguments:
+- `source tenant` Tenant to copy blocks from 
+- `dest tenant` Tenant to copy blocks into
+
+Options:
+- `--source-config-file <value>` Configuration file for the source backend
+- `--config-file <value>` Configuration file for the destination backend
+
+**Example:**
+```bash
+tempo-cli migrate tenant --source-config source.yaml --config-file dest.yaml my-tenant my-other-tenant
 ```

--- a/tempodb/encoding/v2/encoding.go
+++ b/tempodb/encoding/v2/encoding.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
 	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
@@ -29,7 +30,11 @@ func (v Encoding) OpenBlock(meta *backend.BlockMeta, r backend.Reader) (common.B
 }
 
 func (v Encoding) CopyBlock(ctx context.Context, meta *backend.BlockMeta, from backend.Reader, to backend.Writer) error {
-	return CopyBlock(ctx, meta, from, to)
+	return CopyBlock(ctx, meta, meta, from, to)
+}
+
+func (v Encoding) MigrateBlock(ctx context.Context, fromMeta, toMeta *backend.BlockMeta, from backend.Reader, to backend.Writer) error {
+	return CopyBlock(ctx, fromMeta, toMeta, from, to)
 }
 
 func (v Encoding) CreateBlock(ctx context.Context, cfg *common.BlockConfig, meta *backend.BlockMeta, i common.Iterator, _ backend.Reader, to backend.Writer) (*backend.BlockMeta, error) {

--- a/tempodb/encoding/versioned.go
+++ b/tempodb/encoding/versioned.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 	v2 "github.com/grafana/tempo/tempodb/encoding/v2"
@@ -38,6 +39,9 @@ type VersionedEncoding interface {
 
 	// CopyBlock from one backend to another.
 	CopyBlock(ctx context.Context, meta *backend.BlockMeta, from backend.Reader, to backend.Writer) error
+
+	// MigrateBlock from one backend and tenant to another.
+	MigrateBlock(ctx context.Context, fromMeta, toMeta *backend.BlockMeta, from backend.Reader, to backend.Writer) error
 
 	// OpenWALBlock opens an existing appendable block for the WAL
 	OpenWALBlock(filename string, path string, ingestionSlack time.Duration, additionalStartSlack time.Duration) (common.WALBlock, error, error)

--- a/tempodb/encoding/vparquet/encoding.go
+++ b/tempodb/encoding/vparquet/encoding.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
@@ -27,7 +28,11 @@ func (v Encoding) OpenBlock(meta *backend.BlockMeta, r backend.Reader) (common.B
 }
 
 func (v Encoding) CopyBlock(ctx context.Context, meta *backend.BlockMeta, from backend.Reader, to backend.Writer) error {
-	return CopyBlock(ctx, meta, from, to)
+	return CopyBlock(ctx, meta, meta, from, to)
+}
+
+func (v Encoding) MigrateBlock(ctx context.Context, fromMeta, toMeta *backend.BlockMeta, from backend.Reader, to backend.Writer) error {
+	return CopyBlock(ctx, fromMeta, toMeta, from, to)
 }
 
 func (v Encoding) CreateBlock(ctx context.Context, cfg *common.BlockConfig, meta *backend.BlockMeta, i common.Iterator, r backend.Reader, to backend.Writer) (*backend.BlockMeta, error) {


### PR DESCRIPTION
**What this PR does**:
Adds a new tempo-cli command `migrate tenant` which can copy the blocks of a tenant between two tenants and even two backends.

Usage:
```
go run ./cmd/tempo-cli migrate tenant --source-config-file source-config.yaml --config-file dest-config.yaml tenant1 tenant2
```

Note it can not change format of the block, the entire block will be streamed from source to destination without parsing.

I've also added a Dockerfile and Makefile target for tempo-cli. You can run it with `docker run docker.io/grafana/tempo-cli <args>`.

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`