### PR TITLE
[TraceQL] Add support to directly compare floats and ints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@
 * [BUGFIX] Correctly coalesce trace level data when combining Parquet traces. [#2095](https://github.com/grafana/tempo/pull/2095) (@joe-elliott)
 * [BUGFIX] Unescape query parameters in AWS Lambda to allow TraceQL queries to work. [#2114](https://github.com/grafana/tempo/issues/2114) (@joe-elliott)
 * [BUGFIX] Fix float/int comparisons in TraceQL. [#2139](https://github.com/grafana/tempo/issues/2139) (@joe-elliott)
-* [CHANGE] Update Go to 1.20 [#2079](https://github.com/grafana/tempo/pull/2079) (@scalalang2)
-* [CHANGE] Removing leading zeroes in span id [#2062](https://github.com/grafana/tempo/pull/2062) (@ie-pham)
 
 ## v2.0.0 / 2023-01-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [BUGFIX] Apply `rate()` to bytes/s panel in tenant's dashboard. [#2081](https://github.com/grafana/tempo/pull/2081) (@mapno)
 * [BUGFIX] Correctly coalesce trace level data when combining Parquet traces. [#2095](https://github.com/grafana/tempo/pull/2095) (@joe-elliott)
 * [BUGFIX] Unescape query parameters in AWS Lambda to allow TraceQL queries to work. [#2114](https://github.com/grafana/tempo/issues/2114) (@joe-elliott)
+* [BUGFIX] Fix float/int comparisons in TraceQL. [#2139](https://github.com/grafana/tempo/issues/2139) (@joe-elliott)
 * [CHANGE] Update Go to 1.20 [#2079](https://github.com/grafana/tempo/pull/2079) (@scalalang2)
 * [CHANGE] Removing leading zeroes in span id [#2062](https://github.com/grafana/tempo/pull/2062) (@ie-pham)
 

--- a/pkg/traceql/ast.go
+++ b/pkg/traceql/ast.go
@@ -421,20 +421,23 @@ func (s Static) impliedType() StaticType {
 }
 
 func (s Static) Equals(other Static) bool {
-	// if either is a number compare as floats
-	bothAreTypeNumber := (s.Type == TypeInt || s.Type == TypeFloat) && (other.Type == TypeInt || other.Type == TypeFloat)
-	if bothAreTypeNumber {
+	// if they are different number types. compare them as floats. otherwise just fall through to the normal comparison
+	// which should be more efficient
+	differentNumberTypes := (s.Type == TypeInt && other.Type == TypeFloat) || (other.Type == TypeInt && s.Type == TypeFloat)
+	if differentNumberTypes {
 		return s.asFloat() == other.asFloat()
 	}
 
 	eitherIsTypeStatus := (s.Type == TypeStatus && other.Type == TypeInt) || (other.Type == TypeStatus && s.Type == TypeInt)
-	if !eitherIsTypeStatus {
-		return s == other
+	if eitherIsTypeStatus {
+		if s.Type == TypeStatus {
+			return s.Status == Status(other.N)
+		}
+		return Status(s.N) == other.Status
 	}
-	if s.Type == TypeStatus {
-		return s.Status == Status(other.N)
-	}
-	return Status(s.N) == other.Status
+
+	// no special cases, just compare directly
+	return s == other
 }
 
 func (s Static) asFloat() float64 {

--- a/pkg/traceql/ast.go
+++ b/pkg/traceql/ast.go
@@ -421,6 +421,12 @@ func (s Static) impliedType() StaticType {
 }
 
 func (s Static) Equals(other Static) bool {
+	// if either is a number compare as floats
+	bothAreTypeNumber := (s.Type == TypeInt || s.Type == TypeFloat) && (other.Type == TypeInt || other.Type == TypeFloat)
+	if bothAreTypeNumber {
+		return s.asFloat() == other.asFloat()
+	}
+
 	eitherIsTypeStatus := (s.Type == TypeStatus && other.Type == TypeInt) || (other.Type == TypeStatus && s.Type == TypeInt)
 	if !eitherIsTypeStatus {
 		return s == other

--- a/pkg/traceql/ast_execute_test.go
+++ b/pkg/traceql/ast_execute_test.go
@@ -298,3 +298,179 @@ func TestScalarFilterEvaluate(t *testing.T) {
 		})
 	}
 }
+
+func TestBinaryOperationWorksWithFloatsAndInts(t *testing.T) {
+	testCases := []struct {
+		query  string
+		input  []Spanset
+		output []Spanset
+	}{
+		// binops work int -> float
+		{
+			"{ .foo > 0 }",
+			[]Spanset{
+				{Spans: []Span{
+					{ID: []byte{1}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1)}},
+					{ID: []byte{2}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticFloat(1)}},
+				}},
+			},
+			[]Spanset{
+				{
+					Spans: []Span{
+						{ID: []byte{1}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1)}},
+						{ID: []byte{2}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticFloat(1)}},
+					},
+				},
+			},
+		},
+		{
+			"{ .foo < 2 }",
+			[]Spanset{
+				{Spans: []Span{
+					{ID: []byte{1}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1)}},
+					{ID: []byte{2}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticFloat(1)}},
+				}},
+			},
+			[]Spanset{
+				{
+					Spans: []Span{
+						{ID: []byte{1}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1)}},
+						{ID: []byte{2}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticFloat(1)}},
+					},
+				},
+			},
+		},
+		{
+			"{ .foo = 1 }",
+			[]Spanset{
+				{Spans: []Span{
+					{ID: []byte{1}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1)}},
+					{ID: []byte{2}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticFloat(1)}},
+				}},
+			},
+			[]Spanset{
+				{
+					Spans: []Span{
+						{ID: []byte{1}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1)}},
+						{ID: []byte{2}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticFloat(1)}},
+					},
+				},
+			},
+		},
+		// binops work float -> int
+		{
+			"{ .foo > 0. }",
+			[]Spanset{
+				{Spans: []Span{
+					{ID: []byte{1}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1)}},
+					{ID: []byte{2}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticFloat(1)}},
+				}},
+			},
+			[]Spanset{
+				{
+					Spans: []Span{
+						{ID: []byte{1}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1)}},
+						{ID: []byte{2}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticFloat(1)}},
+					},
+				},
+			},
+		},
+		{
+			"{ .foo < 2. }",
+			[]Spanset{
+				{Spans: []Span{
+					{ID: []byte{1}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1)}},
+					{ID: []byte{2}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticFloat(1)}},
+				}},
+			},
+			[]Spanset{
+				{
+					Spans: []Span{
+						{ID: []byte{1}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1)}},
+						{ID: []byte{2}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticFloat(1)}},
+					},
+				},
+			},
+		},
+		{
+			"{ .foo = 1. }",
+			[]Spanset{
+				{Spans: []Span{
+					{ID: []byte{1}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1)}},
+					{ID: []byte{2}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticFloat(1)}},
+				}},
+			},
+			[]Spanset{
+				{
+					Spans: []Span{
+						{ID: []byte{1}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1)}},
+						{ID: []byte{2}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticFloat(1)}},
+					},
+				},
+			},
+		},
+		// binops work with statics
+		{
+			"{ 1 > 0. }",
+			[]Spanset{
+				{Spans: []Span{
+					{ID: []byte{1}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1)}},
+					{ID: []byte{2}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticFloat(1)}},
+				}},
+			},
+			[]Spanset{
+				{
+					Spans: []Span{
+						{ID: []byte{1}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1)}},
+						{ID: []byte{2}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticFloat(1)}},
+					},
+				},
+			},
+		},
+		{
+			"{ 0 < 2. }",
+			[]Spanset{
+				{Spans: []Span{
+					{ID: []byte{1}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1)}},
+					{ID: []byte{2}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticFloat(1)}},
+				}},
+			},
+			[]Spanset{
+				{
+					Spans: []Span{
+						{ID: []byte{1}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1)}},
+						{ID: []byte{2}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticFloat(1)}},
+					},
+				},
+			},
+		},
+		{
+			"{ 1 = 1. }",
+			[]Spanset{
+				{Spans: []Span{
+					{ID: []byte{1}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1)}},
+					{ID: []byte{2}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticFloat(1)}},
+				}},
+			},
+			[]Spanset{
+				{
+					Spans: []Span{
+						{ID: []byte{1}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1)}},
+						{ID: []byte{2}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticFloat(1)}},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.query, func(t *testing.T) {
+			ast, err := Parse(tc.query)
+			require.NoError(t, err)
+
+			actual, err := ast.Pipeline.evaluate(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.output, actual)
+		})
+	}
+}

--- a/pkg/traceql/ast_execute_test.go
+++ b/pkg/traceql/ast_execute_test.go
@@ -461,6 +461,49 @@ func TestBinaryOperationWorksWithFloatsAndInts(t *testing.T) {
 				},
 			},
 		},
+		// binops work with attributes
+		{
+			"{ .foo < .bar }",
+			[]Spanset{
+				{Spans: []Span{
+					{ID: []byte{1}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1), NewAttribute("bar"): NewStaticFloat(2)}},
+					{ID: []byte{2}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(2), NewAttribute("bar"): NewStaticFloat(1)}},
+				}},
+			},
+			[]Spanset{
+				{Spans: []Span{
+					{ID: []byte{1}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1), NewAttribute("bar"): NewStaticFloat(2)}},
+				}},
+			},
+		},
+		{
+			"{ .bar > .foo }",
+			[]Spanset{
+				{Spans: []Span{
+					{ID: []byte{1}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1), NewAttribute("bar"): NewStaticFloat(2)}},
+					{ID: []byte{2}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(2), NewAttribute("bar"): NewStaticFloat(1)}},
+				}},
+			},
+			[]Spanset{
+				{Spans: []Span{
+					{ID: []byte{1}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1), NewAttribute("bar"): NewStaticFloat(2)}},
+				}},
+			},
+		},
+		{
+			"{ .foo = .bar }",
+			[]Spanset{
+				{Spans: []Span{
+					{ID: []byte{1}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1), NewAttribute("bar"): NewStaticFloat(1)}},
+					{ID: []byte{2}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(2), NewAttribute("bar"): NewStaticFloat(1)}},
+				}},
+			},
+			[]Spanset{
+				{Spans: []Span{
+					{ID: []byte{1}, Attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1), NewAttribute("bar"): NewStaticFloat(1)}},
+				}},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/traceql/ast_test.go
+++ b/pkg/traceql/ast_test.go
@@ -15,6 +15,7 @@ func TestStatic_Equals(t *testing.T) {
 	}{
 		{NewStaticInt(1), NewStaticInt(1)},
 		{NewStaticFloat(1.5), NewStaticFloat(1.5)},
+		{NewStaticInt(1), NewStaticFloat(1)},
 		{NewStaticString("foo"), NewStaticString("foo")},
 		{NewStaticBool(true), NewStaticBool(true)},
 		{NewStaticDuration(1 * time.Second), NewStaticDuration(1000 * time.Millisecond)},
@@ -28,10 +29,9 @@ func TestStatic_Equals(t *testing.T) {
 		lhs, rhs Static
 	}{
 		{NewStaticInt(1), NewStaticInt(2)},
-		{NewStaticInt(1), NewStaticFloat(1)},
 		{NewStaticBool(true), NewStaticInt(1)},
 		{NewStaticString("foo"), NewStaticString("bar")},
-		{NewStaticDuration(0), NewStaticInt(0)},
+		{NewStaticDuration(0), NewStaticInt(0)}, // should these be equal?
 		{NewStaticStatus(StatusError), NewStaticStatus(StatusOk)},
 		{NewStaticStatus(StatusOk), NewStaticInt(0)},
 		{NewStaticStatus(StatusError), NewStaticFloat(0)},


### PR DESCRIPTION
**What this PR does**:
Previously the following traceql query would always return nothing b/c floats and ints were not comparable via equality:
```
{ 1 = 1. }
```
This PR makes it so that both static and attribute comparisons will work for all number types.

**Which issue(s) this PR fixes**:
Fixes #2010 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`