### PR TITLE
TraceQL Tests

### DIFF
--- a/tempodb/encoding/v2/backend_block.go
+++ b/tempodb/encoding/v2/backend_block.go
@@ -3,7 +3,6 @@ package v2
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 
@@ -249,5 +248,5 @@ func search(decoder model.ObjectDecoder, maxBytes int, id common.ID, obj []byte,
 }
 
 func (b *BackendBlock) Fetch(context.Context, traceql.FetchSpansRequest, common.SearchOptions) (traceql.FetchSpansResponse, error) {
-	return traceql.FetchSpansResponse{}, errors.New("Unsupported")
+	return traceql.FetchSpansResponse{}, common.ErrUnsupported
 }


### PR DESCRIPTION
**What this PR does**:
Adds some basic traceql testing at the tempodb level and rewrites the current search tests to be more broadly applicable. This still needs a lot of work but I think this is a good first step. After old search is removed we can get back into this.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`