### PR TITLE
Release spans when nothing matches

### DIFF
--- a/pkg/traceql/ast_test.go
+++ b/pkg/traceql/ast_test.go
@@ -250,3 +250,4 @@ func (m *mockSpan) StartTimeUnixNanos() uint64 {
 func (m *mockSpan) EndtimeUnixNanos() uint64 {
 	return m.endTimeUnixNanos
 }
+func (m *mockSpan) Release() {}

--- a/pkg/traceql/ast_test.go
+++ b/pkg/traceql/ast_test.go
@@ -236,6 +236,8 @@ type mockSpan struct {
 	startTimeUnixNanos uint64
 	endTimeUnixNanos   uint64
 	attributes         map[Attribute]Static
+
+	wasReleased bool
 }
 
 func (m *mockSpan) Attributes() map[Attribute]Static {
@@ -250,4 +252,6 @@ func (m *mockSpan) StartTimeUnixNanos() uint64 {
 func (m *mockSpan) EndtimeUnixNanos() uint64 {
 	return m.endTimeUnixNanos
 }
-func (m *mockSpan) Release() {}
+func (m *mockSpan) Release() {
+	m.wasReleased = true
+}

--- a/pkg/traceql/engine.go
+++ b/pkg/traceql/engine.go
@@ -52,6 +52,12 @@ func (e *Engine) Execute(ctx context.Context, searchReq *tempopb.SearchRequest, 
 
 		spansetsEvaluated++
 		if len(evalSS) == 0 {
+			// this is an easy place to release. the engine rejected every single span. just release
+			// them all back to the fetch layer
+			for _, s := range inSS.Spans {
+				s.Release()
+			}
+
 			return nil, nil
 		}
 

--- a/pkg/traceql/engine_test.go
+++ b/pkg/traceql/engine_test.go
@@ -136,6 +136,38 @@ func TestEngine_Execute(t *testing.T) {
 	assert.Equal(t, expectedTraceSearchMetadata, response.Traces)
 }
 
+func TestEngine_ReleasesOnDrop(t *testing.T) {
+	e := Engine{}
+
+	req := &tempopb.SearchRequest{
+		Query: `{ false }`,
+	}
+	span := &mockSpan{}
+	spanSetFetcher := MockSpanSetFetcher{
+		iterator: &MockSpanSetIterator{
+			results: []*Spanset{
+				{
+					Spans: []Span{span},
+				},
+			},
+		},
+	}
+
+	// should release because all spans dropped
+	_, err := e.Execute(context.Background(), req, &spanSetFetcher)
+	require.NoError(t, err)
+	require.True(t, span.wasReleased)
+
+	// reset
+	req.Query = `{ true }`
+	span.wasReleased = false
+
+	// should keep because some spans kept
+	_, err = e.Execute(context.Background(), req, &spanSetFetcher)
+	require.NoError(t, err)
+	require.False(t, span.wasReleased)
+}
+
 func TestEngine_asTraceSearchMetadata(t *testing.T) {
 	now := time.Now()
 

--- a/pkg/traceql/storage.go
+++ b/pkg/traceql/storage.go
@@ -54,6 +54,8 @@ type Span interface {
 	ID() []byte
 	StartTimeUnixNanos() uint64
 	EndtimeUnixNanos() uint64
+
+	Release()
 }
 
 type Spanset struct {

--- a/tempodb/encoding/vparquet/block_traceql.go
+++ b/tempodb/encoding/vparquet/block_traceql.go
@@ -39,6 +39,9 @@ func (s *span) StartTimeUnixNanos() uint64 {
 func (s *span) EndtimeUnixNanos() uint64 {
 	return s.endtimeUnixNanos
 }
+func (s *span) Release() {
+	putSpan(s)
+}
 
 // todo: this sync pool currently massively reduces allocations by pooling spans for certain queries.
 // it currently catches spans discarded:


### PR DESCRIPTION
**What this PR does**:
- Adds an interface method that allows the engine to signal to the fetch layer it is dropping spans
- Use the new method to release spans back to the fetch pool when nothing matches

When doing a needle in the haystack query that is rejected by the engine, we drop millions of spans on the floor which puts a lot of pressure on the GC. This PR releases spans back to the pool when the engine rejects everything. This is the 99.99...% case when searching (b)millions of traces for just one or two.