### PR TITLE
Parquet Update + Fetch Spans Cleanup

### DIFF
--- a/cmd/tempo-serverless/cloud-run/go.mod
+++ b/cmd/tempo-serverless/cloud-run/go.mod
@@ -100,7 +100,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rs/xid v1.2.1 // indirect
 	github.com/segmentio/encoding v0.3.5 // indirect
-	github.com/segmentio/parquet-go v0.0.0-20230201213121-e1109e2f6a20 // indirect
+	github.com/segmentio/parquet-go v0.0.0-20230309140036-b6d0a6236da6 // indirect
 	github.com/sercand/kuberesolver v2.4.0+incompatible // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/sony/gobreaker v0.4.1 // indirect

--- a/cmd/tempo-serverless/cloud-run/go.sum
+++ b/cmd/tempo-serverless/cloud-run/go.sum
@@ -469,8 +469,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/encoding v0.3.5 h1:UZEiaZ55nlXGDL92scoVuw00RmiRCazIEmvPSbSvt8Y=
 github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
-github.com/segmentio/parquet-go v0.0.0-20230201213121-e1109e2f6a20 h1:4BzlTkAqAj8HsgqXBDiFppY7AHWaeeZmBSdQtwXk/qg=
-github.com/segmentio/parquet-go v0.0.0-20230201213121-e1109e2f6a20/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
+github.com/segmentio/parquet-go v0.0.0-20230309140036-b6d0a6236da6 h1:XH/DKem9en9377KZvez9O/QwkXsFJGfuDzjM4c/NX4Y=
+github.com/segmentio/parquet-go v0.0.0-20230309140036-b6d0a6236da6/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/sercand/kuberesolver v2.4.0+incompatible h1:WE2OlRf6wjLxHwNkkFLQGaZcVLEXjMjBPjjEU5vksH8=
 github.com/sercand/kuberesolver v2.4.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/cmd/tempo-serverless/lambda/go.mod
+++ b/cmd/tempo-serverless/lambda/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rs/xid v1.2.1 // indirect
 	github.com/segmentio/encoding v0.3.5 // indirect
-	github.com/segmentio/parquet-go v0.0.0-20230201213121-e1109e2f6a20 // indirect
+	github.com/segmentio/parquet-go v0.0.0-20230309140036-b6d0a6236da6 // indirect
 	github.com/sercand/kuberesolver v2.4.0+incompatible // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/sony/gobreaker v0.4.1 // indirect

--- a/cmd/tempo-serverless/lambda/go.sum
+++ b/cmd/tempo-serverless/lambda/go.sum
@@ -474,8 +474,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/encoding v0.3.5 h1:UZEiaZ55nlXGDL92scoVuw00RmiRCazIEmvPSbSvt8Y=
 github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
-github.com/segmentio/parquet-go v0.0.0-20230201213121-e1109e2f6a20 h1:4BzlTkAqAj8HsgqXBDiFppY7AHWaeeZmBSdQtwXk/qg=
-github.com/segmentio/parquet-go v0.0.0-20230201213121-e1109e2f6a20/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
+github.com/segmentio/parquet-go v0.0.0-20230309140036-b6d0a6236da6 h1:XH/DKem9en9377KZvez9O/QwkXsFJGfuDzjM4c/NX4Y=
+github.com/segmentio/parquet-go v0.0.0-20230309140036-b6d0a6236da6/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/sercand/kuberesolver v2.4.0+incompatible h1:WE2OlRf6wjLxHwNkkFLQGaZcVLEXjMjBPjjEU5vksH8=
 github.com/sercand/kuberesolver v2.4.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/prometheus/prometheus v1.8.2-0.20221021121301-51a44e6657c3
 	github.com/prometheus/statsd_exporter v0.21.0 // indirect
 	github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e
-	github.com/segmentio/parquet-go v0.0.0-20230201213121-e1109e2f6a20
+	github.com/segmentio/parquet-go v0.0.0-20230309140036-b6d0a6236da6
 	github.com/sirupsen/logrus v1.8.1
 	github.com/sony/gobreaker v0.4.1
 	github.com/spf13/viper v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -907,8 +907,8 @@ github.com/segmentio/encoding v0.3.5 h1:UZEiaZ55nlXGDL92scoVuw00RmiRCazIEmvPSbSv
 github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
 github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e h1:uO75wNGioszjmIzcY/tvdDYKRLVvzggtAmmJkn9j4GQ=
 github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e/go.mod h1:tm/wZFQ8e24NYaBGIlnO2WGCAi67re4HHuOm0sftE/M=
-github.com/segmentio/parquet-go v0.0.0-20230201213121-e1109e2f6a20 h1:4BzlTkAqAj8HsgqXBDiFppY7AHWaeeZmBSdQtwXk/qg=
-github.com/segmentio/parquet-go v0.0.0-20230201213121-e1109e2f6a20/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
+github.com/segmentio/parquet-go v0.0.0-20230309140036-b6d0a6236da6 h1:XH/DKem9en9377KZvez9O/QwkXsFJGfuDzjM4c/NX4Y=
+github.com/segmentio/parquet-go v0.0.0-20230309140036-b6d0a6236da6/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/sercand/kuberesolver v2.4.0+incompatible h1:WE2OlRf6wjLxHwNkkFLQGaZcVLEXjMjBPjjEU5vksH8=
 github.com/sercand/kuberesolver v2.4.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=
 github.com/shirou/gopsutil/v3 v3.22.6 h1:FnHOFOh+cYAM0C30P+zysPISzlknLC5Z1G4EAElznfQ=

--- a/pkg/traceql/ast_test.go
+++ b/pkg/traceql/ast_test.go
@@ -236,8 +236,6 @@ type mockSpan struct {
 	startTimeUnixNanos uint64
 	endTimeUnixNanos   uint64
 	attributes         map[Attribute]Static
-
-	wasReleased bool
 }
 
 func (m *mockSpan) Attributes() map[Attribute]Static {
@@ -251,7 +249,4 @@ func (m *mockSpan) StartTimeUnixNanos() uint64 {
 }
 func (m *mockSpan) EndtimeUnixNanos() uint64 {
 	return m.endTimeUnixNanos
-}
-func (m *mockSpan) Release() {
-	m.wasReleased = true
 }

--- a/pkg/traceql/engine.go
+++ b/pkg/traceql/engine.go
@@ -52,12 +52,6 @@ func (e *Engine) Execute(ctx context.Context, searchReq *tempopb.SearchRequest, 
 
 		spansetsEvaluated++
 		if len(evalSS) == 0 {
-			// this is an easy place to release. the engine rejected every single span. just release
-			// them all back to the fetch layer
-			for _, s := range inSS.Spans {
-				s.Release()
-			}
-
 			return nil, nil
 		}
 

--- a/pkg/traceql/engine_test.go
+++ b/pkg/traceql/engine_test.go
@@ -136,38 +136,6 @@ func TestEngine_Execute(t *testing.T) {
 	assert.Equal(t, expectedTraceSearchMetadata, response.Traces)
 }
 
-func TestEngine_ReleasesOnDrop(t *testing.T) {
-	e := Engine{}
-
-	req := &tempopb.SearchRequest{
-		Query: `{ false }`,
-	}
-	span := &mockSpan{}
-	spanSetFetcher := MockSpanSetFetcher{
-		iterator: &MockSpanSetIterator{
-			results: []*Spanset{
-				{
-					Spans: []Span{span},
-				},
-			},
-		},
-	}
-
-	// should release because all spans dropped
-	_, err := e.Execute(context.Background(), req, &spanSetFetcher)
-	require.NoError(t, err)
-	require.True(t, span.wasReleased)
-
-	// reset
-	req.Query = `{ true }`
-	span.wasReleased = false
-
-	// should keep because some spans kept
-	_, err = e.Execute(context.Background(), req, &spanSetFetcher)
-	require.NoError(t, err)
-	require.False(t, span.wasReleased)
-}
-
 func TestEngine_asTraceSearchMetadata(t *testing.T) {
 	now := time.Now()
 

--- a/pkg/traceql/storage.go
+++ b/pkg/traceql/storage.go
@@ -54,8 +54,6 @@ type Span interface {
 	ID() []byte
 	StartTimeUnixNanos() uint64
 	EndtimeUnixNanos() uint64
-
-	Release()
 }
 
 type Spanset struct {

--- a/tempodb/encoding/vparquet/block_traceql.go
+++ b/tempodb/encoding/vparquet/block_traceql.go
@@ -279,6 +279,13 @@ func (i *spansetIterator) Next() (*span, error) {
 			if err != nil {
 				return nil, err
 			}
+			// if the filter removed all spansets then let's release all back to the pool
+			// no reason to try anything more nuanced than this. it will handle nearly all cases
+			if len(filteredSpansets) == 0 {
+				for _, s := range spanset.Spans {
+					putSpan(s.(*span))
+				}
+			}
 		} else {
 			filteredSpansets = []*traceql.Spanset{spanset}
 		}

--- a/vendor/github.com/segmentio/parquet-go/buffer.go
+++ b/vendor/github.com/segmentio/parquet-go/buffer.go
@@ -81,6 +81,11 @@ func (buf *Buffer) configure(schema *Schema) {
 			columnType = dictionary.Type()
 		}
 
+		sortingIndex := searchSortingColumn(sortingColumns, leaf.path)
+		if sortingIndex < len(sortingColumns) && sortingColumns[sortingIndex].NullsFirst() {
+			nullOrdering = nullsGoFirst
+		}
+
 		column := columnType.NewColumnBuffer(columnIndex, bufferCap)
 		switch {
 		case leaf.maxRepetitionLevel > 0:
@@ -90,12 +95,9 @@ func (buf *Buffer) configure(schema *Schema) {
 		}
 		buf.columns = append(buf.columns, column)
 
-		if sortingIndex := searchSortingColumn(sortingColumns, leaf.path); sortingIndex < len(sortingColumns) {
+		if sortingIndex < len(sortingColumns) {
 			if sortingColumns[sortingIndex].Descending() {
 				column = &reversedColumnBuffer{column}
-			}
-			if sortingColumns[sortingIndex].NullsFirst() {
-				nullOrdering = nullsGoFirst
 			}
 			buf.sorted[sortingIndex] = column
 		}

--- a/vendor/github.com/segmentio/parquet-go/config.go
+++ b/vendor/github.com/segmentio/parquet-go/config.go
@@ -14,7 +14,7 @@ import (
 type ReadMode int
 
 const (
-	ReadModeSync  ReadMode = iota // ReadModeSync reads pages synchronously on demand.
+	ReadModeSync  ReadMode = iota // ReadModeSync reads pages synchronously on demand (Default).
 	ReadModeAsync                 // ReadModeAsync reads pages asynchronously in the background.
 )
 
@@ -87,6 +87,7 @@ func formatCreatedBy(application, version, build string) string {
 //	f, err := parquet.OpenFile(reader, size, &parquet.FileConfig{
 //		SkipPageIndex:    true,
 //		SkipBloomFilters: true,
+//		ReadMode:         ReadModeAsync,
 //	})
 type FileConfig struct {
 	SkipPageIndex    bool
@@ -454,18 +455,21 @@ func SkipBloomFilters(skip bool) FileOption {
 }
 
 // FileReadMode is a file configuration option which controls the way pages
-// are read. Currently the only two options are PageReadModeAsync and PageReadModeSync
-// which control whether or not pages are loaded asynchronously.
+// are read. Currently the only two options are ReadModeAsync and ReadModeSync
+// which control whether or not pages are loaded asynchronously. It can be
+// advantageous to use ReadModeAsync if your reader is backed by network
+// storage.
 //
-// Defaults to ReadModeAsync.
+// Defaults to ReadModeSync.
 func FileReadMode(mode ReadMode) FileOption {
 	return fileOption(func(config *FileConfig) { config.ReadMode = mode })
 }
 
 // ReadBufferSize is a file configuration option which controls the default
 // buffer sizes for reads made to the provided io.Reader. The default of 4096
-// is appropriate for disk based access but if your reader is backed by something
-// like network storage it can be advantageous to increase this value.
+// is appropriate for disk based access but if your reader is backed by network
+// storage it can be advantageous to increase this value to something more like
+// 4 MiB.
 //
 // Defaults to 4096.
 func ReadBufferSize(size int) FileOption {

--- a/vendor/github.com/segmentio/parquet-go/row.go
+++ b/vendor/github.com/segmentio/parquet-go/row.go
@@ -126,8 +126,10 @@ type RowSeeker interface {
 
 // RowReader reads a sequence of parquet rows.
 type RowReader interface {
-	// Read rows from the reader, returning the number of rows read into the
-	// buffer, and any error that occurred.
+	// ReadRows reads rows from the reader, returning the number of rows read
+	// into the buffer, and any error that occurred. Note that the rows read
+	// into the buffer are not safe for reuse after a subsequent call to
+	// ReadRows. Callers that want to reuse rows must copy the rows using Clone.
 	//
 	// When all rows have been read, the reader returns io.EOF to indicate the
 	// end of the sequence. It is valid for the reader to return both a non-zero

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -901,7 +901,7 @@ github.com/segmentio/encoding/thrift
 # github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e
 ## explicit
 github.com/segmentio/fasthash/fnv1a
-# github.com/segmentio/parquet-go v0.0.0-20230201213121-e1109e2f6a20
+# github.com/segmentio/parquet-go v0.0.0-20230309140036-b6d0a6236da6
 ## explicit; go 1.19
 github.com/segmentio/parquet-go
 github.com/segmentio/parquet-go/bloom


### PR DESCRIPTION
**What this PR does**:
Something of a cheat PR. Includes a Parquet update to catch https://github.com/segmentio/parquet-go/pull/484 and slightly rewrites #2183.

#2183 was rewritten to not overcomplicate the Span interface. Technically this was achievable entirely at the fetch layer.

Memory benchmarks for the parquet update. Seeing some improvement but not the same levels as the original PR. Perhaps due to file differences?
```
name                                               old alloc/op   new alloc/op   delta
BackendBlockTraceQL/spanAttNameNoMatch-8             4.70MB ±10%    4.40MB ± 5%     ~     (p=0.056 n=5+5)
BackendBlockTraceQL/spanAttValNoMatch-8              13.1MB ± 5%    12.9MB ± 3%     ~     (p=0.222 n=5+5)
BackendBlockTraceQL/spanAttValMatch-8                8.91MB ± 6%    8.18MB ±13%     ~     (p=0.222 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8        4.98MB ± 1%    5.02MB ± 0%     ~     (p=0.095 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicMatch-8          29.9MB ± 4%    29.8MB ± 5%     ~     (p=0.841 n=5+5)
BackendBlockTraceQL/resourceAttNameNoMatch-8         3.85MB ± 0%    3.83MB ± 0%   -0.50%  (p=0.032 n=5+5)
BackendBlockTraceQL/resourceAttValNoMatch-8          36.4MB ± 0%    36.3MB ± 1%     ~     (p=1.000 n=5+5)
BackendBlockTraceQL/resourceAttValMatch-8            60.2MB ± 3%    60.8MB ± 4%     ~     (p=0.690 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicNoMatch-8    3.80MB ± 0%    3.81MB ± 0%     ~     (p=0.222 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8      30.9MB ± 8%    31.8MB ± 4%     ~     (p=0.421 n=5+5)
BackendBlockTraceQL/mixedNameNoMatch-8               45.8MB ± 6%    45.2MB ± 5%     ~     (p=0.548 n=5+5)
BackendBlockTraceQL/mixedValNoMatch-8                48.6MB ± 7%    49.3MB ± 9%     ~     (p=0.841 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchAnd-8          3.85MB ± 0%    3.83MB ± 1%   -0.49%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchOr-8           69.5MB ±11%    68.3MB ±14%     ~     (p=0.421 n=5+5)
BackendBlockTraceQL/mixedValBothMatch-8              3.80MB ± 0%    3.79MB ± 0%     ~     (p=0.095 n=5+5)

name                                               old allocs/op  new allocs/op  delta
BackendBlockTraceQL/spanAttNameNoMatch-8              49.3k ± 0%     48.4k ± 0%   -1.75%  (p=0.008 n=5+5)
BackendBlockTraceQL/spanAttValNoMatch-8               49.6k ± 0%     48.7k ± 0%   -1.78%  (p=0.008 n=5+5)
BackendBlockTraceQL/spanAttValMatch-8                 58.2k ± 0%     57.0k ± 0%   -2.07%  (p=0.008 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8         49.3k ± 0%     48.5k ± 0%   -1.74%  (p=0.000 n=4+5)
BackendBlockTraceQL/spanAttIntrinsicMatch-8            718k ± 0%      714k ± 0%   -0.61%  (p=0.016 n=4+5)
BackendBlockTraceQL/resourceAttNameNoMatch-8          48.3k ± 0%     47.8k ± 0%   -1.12%  (p=0.008 n=5+5)
BackendBlockTraceQL/resourceAttValNoMatch-8           49.0k ± 0%     48.5k ± 0%   -1.19%  (p=0.008 n=5+5)
BackendBlockTraceQL/resourceAttValMatch-8              748k ± 0%      741k ± 0%   -0.89%  (p=0.008 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicNoMatch-8     47.5k ± 0%     47.3k ± 0%   -0.36%  (p=0.029 n=4+4)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8        770k ± 0%      765k ± 0%   -0.71%  (p=0.016 n=5+4)
BackendBlockTraceQL/mixedNameNoMatch-8                59.4k ± 0%     55.3k ± 0%   -6.95%  (p=0.029 n=4+4)
BackendBlockTraceQL/mixedValNoMatch-8                 81.9k ± 0%     77.8k ± 0%   -5.04%  (p=0.029 n=4+4)
BackendBlockTraceQL/mixedValMixedMatchAnd-8           48.3k ± 0%     47.8k ± 0%   -1.12%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchOr-8             725k ± 0%      719k ± 0%   -0.91%  (p=0.016 n=5+4)
BackendBlockTraceQL/mixedValBothMatch-8               47.5k ± 0%     47.3k ± 0%   -0.37%  (p=0.008 n=5+5)
```
