### PR TITLE
Add Azure Workload Identity authentication support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [FEATURE] Add support for Azure Workload Identity authentication [#2195](https://github.com/grafana/tempo/pull/2195) (@LambArchie)
 * [FEATURE] Add flag to check configuration [#2131](https://github.com/grafana/tempo/issues/2131) (@robertscherbarth @agrib-01)
 * [FEATURE] Add flag to optionally enable all available Go runtime metrics [#2005](https://github.com/grafana/tempo/pull/2005) (@andreasgerstmayr)
 * [CHANGE] Add support for s3 session token in static config [#2093](https://github.com/grafana/tempo/pull/2093) (@farodin91)

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -698,6 +698,12 @@ storage:
             # Azure German(blob.core.cloudapi.de), Azure US Government(blob.core.usgovcloudapi.net).
             [endpoint_suffix: <string>]
 
+            # optional.
+            # Azure Cloud environment. Supported values are: AzureGlobal,
+            # AzureChinaCloud, AzureGermanCloud, AzureUSGovernment.
+            # Used by Azure Workload Identity.
+            [environment: <string> | default = "AzureGlobal"]
+
             # Name of the azure storage account
             [storage_account_name: <string>]
 
@@ -708,6 +714,13 @@ storage:
             # optional.
             # use Azure Managed Identity to access Azure storage.
             [use_managed_identity: <bool>]
+
+            # optional.
+            # Use a Federated Token to authenticate to the Azure storage account.
+            # Enable if you want to use Azure Workload Identity. Expects AZURE_CLIENT_ID,
+            # AZURE_TENANT_ID and AZURE_FEDERATED_TOKEN_FILE envs to be present (set automatically
+            # when using Azure Workload Identity).
+            [use_federated_token: <boolean> | default = false]
 
             # optional.
             # The Client ID for the user-assigned Azure Managed Identity used to access Azure storage.

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -698,12 +698,6 @@ storage:
             # Azure German(blob.core.cloudapi.de), Azure US Government(blob.core.usgovcloudapi.net).
             [endpoint_suffix: <string>]
 
-            # optional.
-            # Azure Cloud environment. Supported values are: AzureGlobal,
-            # AzureChinaCloud, AzureGermanCloud, AzureUSGovernment.
-            # Used by Azure Workload Identity.
-            [environment: <string> | default = "AzureGlobal"]
-
             # Name of the azure storage account
             [storage_account_name: <string>]
 
@@ -718,9 +712,9 @@ storage:
             # optional.
             # Use a Federated Token to authenticate to the Azure storage account.
             # Enable if you want to use Azure Workload Identity. Expects AZURE_CLIENT_ID,
-            # AZURE_TENANT_ID and AZURE_FEDERATED_TOKEN_FILE envs to be present (set automatically
-            # when using Azure Workload Identity).
-            [use_federated_token: <boolean> | default = false]
+            # AZURE_TENANT_ID, AZURE_AUTHORITY_HOST and AZURE_FEDERATED_TOKEN_FILE envs to be present
+            # (these are set automatically when using Azure Workload Identity).
+            [use_federated_token: <bool>]
 
             # optional.
             # The Client ID for the user-assigned Azure Managed Identity used to access Azure storage.

--- a/docs/sources/tempo/configuration/azure.md
+++ b/docs/sources/tempo/configuration/azure.md
@@ -13,6 +13,7 @@ Tempo requires the following configuration to authenticate to and access Azure b
   - An Azure Managed Identity; either system or user assigned. To use Azure Managed Identities, you'll need to set `use_managed_identity` to `true` in the configuration file or set `user_assigned_id` to the client ID for the managed identity you'd like to use.  
       - For a system-assigned managed identity, no additional configuration is required.
       - For a user-assigned managed identity, you'll need to set `user_assigned_id` to the client ID for the managed identity in the configuration file.
+  - Via Azure Workload Identity. To use Azure Workload Identity, you'll need to enable Workload Identity on your AKS cluster, add the required label and annotation to the service account and the reqiured pod label. Additionally, ensure environment is set in the configuration.
 
 ## Azure blocklist polling
 

--- a/docs/sources/tempo/configuration/azure.md
+++ b/docs/sources/tempo/configuration/azure.md
@@ -13,7 +13,7 @@ Tempo requires the following configuration to authenticate to and access Azure b
   - An Azure Managed Identity; either system or user assigned. To use Azure Managed Identities, you'll need to set `use_managed_identity` to `true` in the configuration file or set `user_assigned_id` to the client ID for the managed identity you'd like to use.  
       - For a system-assigned managed identity, no additional configuration is required.
       - For a user-assigned managed identity, you'll need to set `user_assigned_id` to the client ID for the managed identity in the configuration file.
-  - Via Azure Workload Identity. To use Azure Workload Identity, you'll need to enable Workload Identity on your AKS cluster, add the required label and annotation to the service account and the reqiured pod label. Additionally, ensure environment is set in the configuration.
+  - Via Azure Workload Identity. To use Azure Workload Identity, you'll need to enable Azure Workload Identity on your cluster, add the required label and annotation to the service account and the required pod label.
 
 ## Azure blocklist polling
 

--- a/modules/storage/config.go
+++ b/modules/storage/config.go
@@ -69,6 +69,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	f.Var(&cfg.Trace.Azure.StorageAccountKey, util.PrefixConfig(prefix, "trace.azure.storage_account_key"), "Azure storage access key.")
 	f.StringVar(&cfg.Trace.Azure.ContainerName, util.PrefixConfig(prefix, "trace.azure.container_name"), "", "Azure container name to store blocks in.")
 	f.StringVar(&cfg.Trace.Azure.Endpoint, util.PrefixConfig(prefix, "trace.azure.endpoint"), "blob.core.windows.net", "Azure endpoint to push blocks to.")
+	f.StringVar(&cfg.Trace.Azure.Environment, util.PrefixConfig(prefix, "trace.azure.environment"), "AzureGlobal", "Azure Cloud environment")
 	f.IntVar(&cfg.Trace.Azure.MaxBuffers, util.PrefixConfig(prefix, "trace.azure.max_buffers"), 4, "Number of simultaneous uploads.")
 	cfg.Trace.Azure.BufferSize = 3 * 1024 * 1024
 	cfg.Trace.Azure.HedgeRequestsUpTo = 2

--- a/modules/storage/config.go
+++ b/modules/storage/config.go
@@ -69,7 +69,6 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	f.Var(&cfg.Trace.Azure.StorageAccountKey, util.PrefixConfig(prefix, "trace.azure.storage_account_key"), "Azure storage access key.")
 	f.StringVar(&cfg.Trace.Azure.ContainerName, util.PrefixConfig(prefix, "trace.azure.container_name"), "", "Azure container name to store blocks in.")
 	f.StringVar(&cfg.Trace.Azure.Endpoint, util.PrefixConfig(prefix, "trace.azure.endpoint"), "blob.core.windows.net", "Azure endpoint to push blocks to.")
-	f.StringVar(&cfg.Trace.Azure.Environment, util.PrefixConfig(prefix, "trace.azure.environment"), "AzureGlobal", "Azure Cloud environment")
 	f.IntVar(&cfg.Trace.Azure.MaxBuffers, util.PrefixConfig(prefix, "trace.azure.max_buffers"), 4, "Number of simultaneous uploads.")
 	cfg.Trace.Azure.BufferSize = 3 * 1024 * 1024
 	cfg.Trace.Azure.HedgeRequestsUpTo = 2

--- a/tempodb/backend/azure/azure_helpers_test.go
+++ b/tempodb/backend/azure/azure_helpers_test.go
@@ -14,8 +14,8 @@ import (
 const (
 	TestStorageAccountName = "foobar"
 	TestStorageAccountKey  = "abc123"
-	TestAzureClientId      = "myClientId"
-	TestAzureTenantId      = "myTenantId"
+	TestAzureClientID      = "myClientId"
+	TestAzureTenantID      = "myTenantId"
 )
 
 // TestGetStorageAccountName* explicitly broken out into
@@ -115,9 +115,9 @@ func TestGetContainerURL(t *testing.T) {
 }
 
 func TestServicePrincipalTokenFromFederatedToken(t *testing.T) {
-	os.Setenv("AZURE_CLIENT_ID", TestAzureClientId)
+	os.Setenv("AZURE_CLIENT_ID", TestAzureClientID)
 	defer os.Unsetenv("AZURE_CLIENT_ID")
-	os.Setenv("AZURE_TENANT_ID", TestAzureTenantId)
+	os.Setenv("AZURE_TENANT_ID", TestAzureTenantID)
 	defer os.Unsetenv("AZURE_TENANT_ID")
 
 	mockOAuthConfig, _ := adal.NewOAuthConfig("foo", "bar")
@@ -130,7 +130,7 @@ func TestServicePrincipalTokenFromFederatedToken(t *testing.T) {
 
 	newOAuthConfigFunc := func(activeDirectoryEndpoint, tenantID string) (*adal.OAuthConfig, error) {
 		assert.Equal(t, azure.PublicCloud.ActiveDirectoryEndpoint, activeDirectoryEndpoint)
-		assert.Equal(t, TestAzureTenantId, tenantID)
+		assert.Equal(t, TestAzureTenantID, tenantID)
 
 		_, err := adal.NewOAuthConfig(activeDirectoryEndpoint, tenantID)
 		assert.NoError(t, err)
@@ -140,7 +140,7 @@ func TestServicePrincipalTokenFromFederatedToken(t *testing.T) {
 
 	servicePrincipalTokenFromFederatedTokenFunc := func(oauthConfig adal.OAuthConfig, clientID string, jwt string, resource string, callbacks ...adal.TokenRefreshCallback) (*adal.ServicePrincipalToken, error) {
 		assert.True(t, *mockOAuthConfig == oauthConfig, "should return the mocked object")
-		assert.Equal(t, TestAzureClientId, clientID)
+		assert.Equal(t, TestAzureClientID, clientID)
 		assert.Equal(t, "myJwtToken", jwt)
 		assert.Equal(t, "https://bar.blob.core.windows.net", resource)
 		return mockedServicePrincipalToken, nil

--- a/tempodb/backend/azure/azure_helpers_test.go
+++ b/tempodb/backend/azure/azure_helpers_test.go
@@ -148,7 +148,10 @@ func TestServicePrincipalTokenFromFederatedToken(t *testing.T) {
 		return mockedServicePrincipalToken, nil
 	}
 
-	token, err := servicePrincipalTokenFromFederatedToken("https://bar.blob.core.windows.net", newOAuthConfigFunc, servicePrincipalTokenFromFederatedTokenFunc)
+	token, err := servicePrincipalTokenFromFederatedToken("https://bar.blob.core.windows.net", authFunctions{
+		newOAuthConfigFunc,
+		servicePrincipalTokenFromFederatedTokenFunc,
+	})
 
 	assert.NoError(t, err)
 	assert.True(t, mockedServicePrincipalToken == token, "should return the mocked object")

--- a/tempodb/backend/azure/config.go
+++ b/tempodb/backend/azure/config.go
@@ -10,9 +10,11 @@ type Config struct {
 	StorageAccountName string         `yaml:"storage_account_name"`
 	StorageAccountKey  flagext.Secret `yaml:"storage_account_key"`
 	UseManagedIdentity bool           `yaml:"use_managed_identity"`
+	UseFederatedToken  bool           `yaml:"use_federated_token"`
 	UserAssignedID     string         `yaml:"user_assigned_id"`
 	ContainerName      string         `yaml:"container_name"`
 	Endpoint           string         `yaml:"endpoint_suffix"`
+	Environment        string         `yaml:"environment"`
 	MaxBuffers         int            `yaml:"max_buffers"`
 	BufferSize         int            `yaml:"buffer_size"`
 	HedgeRequestsAt    time.Duration  `yaml:"hedge_requests_at"`

--- a/tempodb/backend/azure/config.go
+++ b/tempodb/backend/azure/config.go
@@ -14,7 +14,6 @@ type Config struct {
 	UserAssignedID     string         `yaml:"user_assigned_id"`
 	ContainerName      string         `yaml:"container_name"`
 	Endpoint           string         `yaml:"endpoint_suffix"`
-	Environment        string         `yaml:"environment"`
 	MaxBuffers         int            `yaml:"max_buffers"`
 	BufferSize         int            `yaml:"buffer_size"`
 	HedgeRequestsAt    time.Duration  `yaml:"hedge_requests_at"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds support for [Azure Workload Identity](https://azure.github.io/azure-workload-identity/docs/) authentication.

Partially based off the following PR https://github.com/grafana/loki/pull/7540 which implemented Azure Workload Identity into Loki.

<!-- 
**Which issue(s) this PR fixes**:
Fixes #<issue number>
-->

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

---

This is my first time writing anything in Go, so I might have made a mistake with the syntax. If I have feel free to fix it or let me know and I'll fix it myself.  
I have tested this and it seems to work so I'm hoping I haven't made a mistake but you never know.