### PR TITLE
[TraceQL] Quit tag values search if virtual tags returns anything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 * [BUGFIX] Fix float/int comparisons in TraceQL. [#2139](https://github.com/grafana/tempo/issues/2139) (@joe-elliott)
 * [BUGFIX] Improve locking and search head block in SearchTagValuesV2 [#2164](https://github.com/grafana/tempo/pull/2164) (@mapno)
 * [BUGFIX] Fix not closing WAL block file before attempting to delete the folder. [#2139](https://github.com/grafana/tempo/pull/2152) (@kostya9)
+* [BUGFIX] Stop searching for virtual tags if there are any hits.
+  This prevents invalid values from showing up for intrinsics like `status` [#2219](https://github.com/grafana/tempo/pull/2152) (@joe-elliott)
 
 ## v2.0.1 / 2023-03-03
 


### PR DESCRIPTION
**What this PR does**:
Halts v2 tag values search if any virtual tags are found.

![image](https://user-images.githubusercontent.com/2272392/225646558-64b39d5d-17f4-4695-bf5a-1e2c4d54b5cc.png)

cc @mapno since you're working in this area
cc @mdisibio since you had recently changed the behavior of v1/v2 tag values search w/r to `status`

**Which issue(s) this PR fixes**:
Fixes #2200 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`