### PR TITLE
[Metrics-generator] Add section about exporting metrics

### DIFF
--- a/docs/sources/tempo/metrics-generator/_index.md
+++ b/docs/sources/tempo/metrics-generator/_index.md
@@ -53,4 +53,4 @@ The metrics-generator runs a Prometheus Agent that periodically sends metrics to
 The `remote_write` endpoint is configurable and can be any [Prometheus-compatible endpoint](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write).
 To learn more about the endpoint configuration, refer to the [Metrics-generator]({{< relref "../configuration/#metrics-generator" >}}) section of the Tempo Configuration documentation. 
 
-To support multi-tenancy, the metrics-generator forwards the `X-Scope-OrgID` header to the remote_write endpoint.
+When multi-tenancy is enabled, the metrics-generator forwards the `X-Scope-OrgID` header of the original request to the remote_write endpoint.

--- a/docs/sources/tempo/metrics-generator/_index.md
+++ b/docs/sources/tempo/metrics-generator/_index.md
@@ -49,6 +49,8 @@ To learn more about this processor, read the [documentation]({{< relref "span_me
 
 ### Exporting metrics
 
-The metrics-generator runs a Prometheus Agent that periodically sends metrics to a remote_write endpoint.
-The remote_write endpoint is configurable and can be any Prometheus-compatible endpoint.
-In order to support multi-tenancy, the metrics-generator forwards the `X-Scope-OrgID` header to the remote_write endpoint.
+The metrics-generator runs a Prometheus Agent that periodically sends metrics to a `remote_write` endpoint.
+The `remote_write` endpoint is configurable and can be any [Prometheus-compatible endpoint](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write).
+To learn more about the endpoint configuration, refer to the [Metrics-generator]({{< relref "../configuration/#metrics-generator" >}}) section of the Tempo Configuration documentation. 
+
+To support multi-tenancy, the metrics-generator forwards the `X-Scope-OrgID` header to the remote_write endpoint.

--- a/docs/sources/tempo/metrics-generator/_index.md
+++ b/docs/sources/tempo/metrics-generator/_index.md
@@ -51,6 +51,7 @@ To learn more about this processor, read the [documentation]({{< relref "span_me
 
 The metrics-generator runs a Prometheus Agent that periodically sends metrics to a `remote_write` endpoint.
 The `remote_write` endpoint is configurable and can be any [Prometheus-compatible endpoint](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write).
-To learn more about the endpoint configuration, refer to the [Metrics-generator]({{< relref "../configuration/#metrics-generator" >}}) section of the Tempo Configuration documentation. 
+To learn more about the endpoint configuration, refer to the [Metrics-generator]({{< relref "../configuration/#metrics-generator" >}}) section of the Tempo Configuration documentation.
+Writing interval can be controlled via `metrics_generator.registry.collection_interval`.
 
 When multi-tenancy is enabled, the metrics-generator forwards the `X-Scope-OrgID` header of the original request to the remote_write endpoint.

--- a/docs/sources/tempo/metrics-generator/_index.md
+++ b/docs/sources/tempo/metrics-generator/_index.md
@@ -46,3 +46,9 @@ Dimensions can be the service name, the operation, the span kind, the status cod
 The more dimensions are enabled, the higher the cardinality of the generated metrics.
 
 To learn more about this processor, read the [documentation]({{< relref "span_metrics/" >}}).
+
+### Exporting metrics
+
+The metrics-generator runs a Prometheus Agent that periodically sends metrics to a remote_write endpoint.
+The remote_write endpoint is configurable and can be any Prometheus-compatible endpoint.
+In order to support multi-tenancy, the metrics-generator forwards the `X-Scope-OrgID` header to the remote_write endpoint.

--- a/docs/sources/tempo/metrics-generator/_index.md
+++ b/docs/sources/tempo/metrics-generator/_index.md
@@ -47,7 +47,7 @@ The more dimensions are enabled, the higher the cardinality of the generated met
 
 To learn more about this processor, read the [documentation]({{< relref "span_metrics/" >}}).
 
-### Exporting metrics
+### Remote writing metrics
 
 The metrics-generator runs a Prometheus Agent that periodically sends metrics to a `remote_write` endpoint.
 The `remote_write` endpoint is configurable and can be any [Prometheus-compatible endpoint](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write).


### PR DESCRIPTION
**What this PR does**:

Briefly explains how metrics are exported from the metrics-generator to the metrics backend.
