### PR TITLE
[jsonnet-microservices] support k8s v1.25

### DIFF
--- a/operations/jsonnet-compiled/PodDisruptionBudget-ingester.yaml
+++ b/operations/jsonnet-compiled/PodDisruptionBudget-ingester.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/operations/jsonnet-compiled/StatefulSet-ingester.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-ingester.yaml
@@ -34,7 +34,6 @@ spec:
         - -mem-ballast-size-mbs=1024
         - -target=ingester
         image: grafana/tempo:latest
-        imagePullPolicy: IfNotPresent
         name: ingester
         ports:
         - containerPort: 3200
@@ -67,8 +66,6 @@ spec:
       - configMap:
           name: tempo-overrides
         name: overrides
-  updateStrategy:
-    type: RollingUpdate
   volumeClaimTemplates:
   - apiVersion: v1
     kind: PersistentVolumeClaim

--- a/operations/jsonnet-compiled/StatefulSet-memcached.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-memcached.yaml
@@ -50,4 +50,3 @@ spec:
           name: http-metrics
   updateStrategy:
     type: RollingUpdate
-  volumeClaimTemplates: []

--- a/operations/jsonnet-compiled/util/jsonnetfile.json
+++ b/operations/jsonnet-compiled/util/jsonnetfile.json
@@ -12,13 +12,6 @@
     },
     {
       "source": {
-        "local": {
-          "directory": "../../jsonnet/microservices"
-        }
-      }
-    },
-    {
-      "source": {
         "git": {
           "remote": "https://github.com/grafana/jsonnet-libs.git",
           "subdir": "memcached"
@@ -29,11 +22,28 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/jsonnet-libs/k8s-libsonnet.git",
+          "subdir": "1.21"
+        }
+      },
+      "version": "main"
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/ksonnet/ksonnet-lib.git",
           "subdir": "ksonnet.beta.4"
         }
       },
       "version": "master"
+    },
+    {
+      "source": {
+        "local": {
+          "directory": "../../jsonnet/microservices"
+        }
+      },
+      "version": ""
     }
   ],
   "legacyImports": true

--- a/operations/jsonnet-compiled/util/jsonnetfile.lock.json
+++ b/operations/jsonnet-compiled/util/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "a924ab1b5fd4e6eacd7235a20978d050a27bdb65",
-      "sum": "/pkNOLhRqvQoPA0yYdUuJvpPHqhkCLauAUMD2ZHMIkE="
+      "version": "8bfe11e93d844b24420c513780d51dcbe254f284",
+      "sum": "0y3AFX9LQSpfWTxWKSwoLgbt0Wc9nnCwhMH2szKzHv0="
     },
     {
       "source": {
@@ -18,8 +18,18 @@
           "subdir": "memcached"
         }
       },
-      "version": "a924ab1b5fd4e6eacd7235a20978d050a27bdb65",
+      "version": "8bfe11e93d844b24420c513780d51dcbe254f284",
       "sum": "SWywAq4U0MRPMbASU0Ez8O9ArRNeoZzb75sEuReueow="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/k8s-libsonnet.git",
+          "subdir": "1.21"
+        }
+      },
+      "version": "8ecd8500e820a5ef4e0394f64e383b0edb768137",
+      "sum": "b8GtKWztbpnnMojHt8A9sfkEgs+2t2rtvZcpDteuLFo="
     },
     {
       "source": {

--- a/operations/jsonnet-compiled/util/lib/k.libsonnet
+++ b/operations/jsonnet-compiled/util/lib/k.libsonnet
@@ -1,1 +1,1 @@
-import "ksonnet.beta.4/k.libsonnet"
+import 'github.com/jsonnet-libs/k8s-libsonnet/1.21/main.libsonnet'

--- a/operations/jsonnet-compiled/util/vendor/github.com/grafana/jsonnet-libs/ksonnet-util/util.libsonnet
+++ b/operations/jsonnet-compiled/util/vendor/github.com/grafana/jsonnet-libs/ksonnet-util/util.libsonnet
@@ -226,7 +226,9 @@ local util(k) = {
 
   manifestYaml(value):: (
     local f = std.native('manifestYamlFromJson');
-    f(std.toString(value))
+    if f != null
+    then f(std.toString(value))
+    else std.manifestYamlDoc(value)
   ),
 
   resourcesRequests(cpu, memory)::

--- a/operations/jsonnet/microservices/ingester.libsonnet
+++ b/operations/jsonnet/microservices/ingester.libsonnet
@@ -74,7 +74,7 @@
   tempo_ingester_service:
     kausal.util.serviceFor($.tempo_ingester_statefulset),
 
-  local podDisruptionBudget = k.policy.v1beta1.podDisruptionBudget,
+  local podDisruptionBudget = k.policy.v1.podDisruptionBudget,
   ingester_pdb:
     podDisruptionBudget.new(target_name) +
     podDisruptionBudget.mixin.metadata.withLabels({ name: target_name }) +


### PR DESCRIPTION
**What this PR does**:

* Rely more heavily on the lib version of `k` and use `kausal` only when needed.
* Update PodDisruptionBudget to policy/v1, which has had [support since v1.21](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125)

**Which issue(s) this PR fixes**:
Fixes #2186

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`