### PR TITLE
Fix panic when &&ing or ||ing multiple spansets

### DIFF
--- a/pkg/traceql/ast_execute.go
+++ b/pkg/traceql/ast_execute.go
@@ -113,7 +113,7 @@ func (a Aggregate) evaluate(input []*Spanset) (output []*Spanset, err error) {
 	for _, ss := range input {
 		switch a.op {
 		case aggregateCount:
-			copy := ss
+			copy := ss.clone()
 			copy.Scalar = NewStaticInt(len(ss.Spans))
 			output = append(output, copy)
 
@@ -130,7 +130,7 @@ func (a Aggregate) evaluate(input []*Spanset) (output []*Spanset, err error) {
 				count++
 			}
 
-			copy := ss
+			copy := ss.clone()
 			copy.Scalar = NewStaticFloat(sum / float64(count))
 			output = append(output, copy)
 

--- a/pkg/traceql/ast_execute.go
+++ b/pkg/traceql/ast_execute.go
@@ -5,10 +5,6 @@ import (
 	"fmt"
 	"math"
 	"regexp"
-
-	"github.com/go-kit/log/level"
-
-	"github.com/grafana/tempo/pkg/util/log"
 )
 
 func appendSpans(buffer []Span, input []*Spanset) []Span {
@@ -91,19 +87,6 @@ func (f ScalarFilter) evaluate(input []*Spanset) (output []*Spanset, err error) 
 	}
 
 	return output, nil
-}
-
-func (f SpansetFilter) matches(span Span) (bool, error) {
-	static, err := f.Expression.execute(span)
-	if err != nil {
-		level.Debug(log.Logger).Log("msg", "SpanSetFilter.matches failed", "err", err)
-		return false, err
-	}
-	if static.Type != TypeBoolean {
-		level.Debug(log.Logger).Log("msg", "SpanSetFilter.matches did not return a boolean", "err", err)
-		return false, fmt.Errorf("result of SpanSetFilter (%v) is %v", f, static.Type)
-	}
-	return static.B, nil
 }
 
 func (a Aggregate) evaluate(input []*Spanset) (output []*Spanset, err error) {

--- a/pkg/traceql/ast_execute.go
+++ b/pkg/traceql/ast_execute.go
@@ -33,8 +33,6 @@ func (o SpansetOperation) evaluate(input []*Spanset) (output []*Spanset, err err
 			return nil, err
 		}
 
-		// { a } && { b } | count() = 10 - jpe issue or test
-		//   a and b potentially have the same spans
 		switch o.Op {
 		case OpSpansetAnd:
 			if len(lhs) > 0 && len(rhs) > 0 {

--- a/pkg/traceql/ast_execute.go
+++ b/pkg/traceql/ast_execute.go
@@ -33,10 +33,12 @@ func (o SpansetOperation) evaluate(input []*Spanset) (output []*Spanset, err err
 			return nil, err
 		}
 
+		// { a } && { b } | count() = 10 - jpe issue or test
+		//   a and b potentially have the same spans
 		switch o.Op {
 		case OpSpansetAnd:
 			if len(lhs) > 0 && len(rhs) > 0 {
-				matchingSpanset := input[i]
+				matchingSpanset := input[i].clone()
 				matchingSpanset.Spans = appendSpans(nil, lhs)
 				matchingSpanset.Spans = appendSpans(matchingSpanset.Spans, rhs)
 				output = append(output, matchingSpanset)
@@ -44,7 +46,7 @@ func (o SpansetOperation) evaluate(input []*Spanset) (output []*Spanset, err err
 
 		case OpSpansetUnion:
 			if len(lhs) > 0 || len(rhs) > 0 {
-				matchingSpanset := input[i]
+				matchingSpanset := input[i].clone()
 				matchingSpanset.Spans = appendSpans(nil, lhs)
 				matchingSpanset.Spans = appendSpans(matchingSpanset.Spans, rhs)
 				output = append(output, matchingSpanset)

--- a/pkg/traceql/ast_execute_test.go
+++ b/pkg/traceql/ast_execute_test.go
@@ -9,6 +9,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type evalTC struct {
+	query  string
+	input  []*Spanset
+	output []*Spanset
+}
+
+func testEvaluator(t *testing.T, tc evalTC) {
+	t.Helper()
+
+	t.Run(tc.query, func(t *testing.T) {
+		ast, err := Parse(tc.query)
+		require.NoError(t, err)
+
+		// clone input to confirm it doesn't get modified
+		cloneIn := make([]*Spanset, len(tc.input))
+		for i := range tc.input {
+			cloneIn[i] = tc.input[i].clone()
+			cloneIn[i].Spans = append([]Span(nil), tc.input[i].Spans...)
+		}
+
+		actual, err := ast.Pipeline.evaluate(tc.input)
+		require.NoError(t, err)
+		require.Equal(t, tc.output, actual)
+		require.Equal(t, cloneIn, tc.input)
+	})
+}
+
 func TestSpansetFilter_matches(t *testing.T) {
 	tests := []struct {
 		query   string
@@ -131,7 +158,6 @@ func TestSpansetFilter_matches(t *testing.T) {
 			require.NoError(t, err)
 
 			spansetFilter := expr.Pipeline.Elements[0].(SpansetFilter)
-
 			matches, err := spansetFilter.matches(tt.span)
 
 			if tt.err {
@@ -147,11 +173,7 @@ func TestSpansetFilter_matches(t *testing.T) {
 }
 
 func TestSpansetOperationEvaluate(t *testing.T) {
-	testCases := []struct {
-		query  string
-		input  []*Spanset
-		output []*Spanset
-	}{
+	testCases := []evalTC{
 		{
 			"{ .foo = `a` } && { .foo = `b` }",
 			[]*Spanset{
@@ -198,25 +220,12 @@ func TestSpansetOperationEvaluate(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.query, func(t *testing.T) {
-			ast, err := Parse(tc.query)
-			require.NoError(t, err)
-
-			filt := ast.Pipeline.Elements[0].(SpansetOperation)
-
-			actual, err := filt.evaluate(tc.input)
-			require.NoError(t, err)
-			require.Equal(t, tc.output, actual)
-		})
+		testEvaluator(t, tc)
 	}
 }
 
 func TestScalarFilterEvaluate(t *testing.T) {
-	testCases := []struct {
-		query  string
-		input  []*Spanset
-		output []*Spanset
-	}{
+	testCases := []evalTC{
 		{
 			"{ .foo = `a` } | count() > 1",
 			[]*Spanset{
@@ -288,23 +297,12 @@ func TestScalarFilterEvaluate(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.query, func(t *testing.T) {
-			ast, err := Parse(tc.query)
-			require.NoError(t, err)
-
-			actual, err := ast.Pipeline.evaluate(tc.input)
-			require.NoError(t, err)
-			require.Equal(t, tc.output, actual)
-		})
+		testEvaluator(t, tc)
 	}
 }
 
 func TestBinaryOperationsWorkAcrossNumberTypes(t *testing.T) {
-	testCases := []struct {
-		query  string
-		input  []*Spanset
-		output []*Spanset
-	}{
+	testCases := []evalTC{
 		{
 			"{ .foo > 0 }",
 			[]*Spanset{{Spans: []Span{
@@ -512,23 +510,12 @@ func TestBinaryOperationsWorkAcrossNumberTypes(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.query, func(t *testing.T) {
-			ast, err := Parse(tc.query)
-			require.NoError(t, err)
-
-			actual, err := ast.Pipeline.evaluate(tc.input)
-			require.NoError(t, err)
-			require.Equal(t, tc.output, actual)
-		})
+		testEvaluator(t, tc)
 	}
 }
 
 func TestArithmetic(t *testing.T) {
-	testCases := []struct {
-		query  string
-		input  []*Spanset
-		output []*Spanset
-	}{
+	testCases := []evalTC{
 		// static arithmetic works
 		{
 			"{ 1 + 1 = 2 }",
@@ -651,14 +638,7 @@ func TestArithmetic(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.query, func(t *testing.T) {
-			ast, err := Parse(tc.query)
-			require.NoError(t, err)
-
-			actual, err := ast.Pipeline.evaluate(tc.input)
-			require.NoError(t, err)
-			require.Equal(t, tc.output, actual)
-		})
+		testEvaluator(t, tc)
 	}
 }
 

--- a/pkg/traceql/engine.go
+++ b/pkg/traceql/engine.go
@@ -44,11 +44,25 @@ func (e *Engine) Execute(ctx context.Context, searchReq *tempopb.SearchRequest, 
 			return nil, nil
 		}
 
+		/*
+			// debug code that confirms that inSS is unmodified
+			clone := inSS.clone()
+			clone.Spans = append([]Span(nil), inSS.Spans...)
+		*/
+
 		evalSS, err := rootExpr.Pipeline.evaluate([]*Spanset{inSS})
 		if err != nil {
 			span.LogKV("msg", "pipeline.evaluate", "err", err)
 			return nil, err
 		}
+
+		/*
+			// debug code that confirms that inSS is unmodified
+			diff := deep.Equal(clone, inSS)
+			if len(diff) > 0 {
+				panic(fmt.Sprintf("inSS was modified: %v", diff))
+			}
+		*/
 
 		spansetsEvaluated++
 		if len(evalSS) == 0 {

--- a/pkg/traceql/engine.go
+++ b/pkg/traceql/engine.go
@@ -44,25 +44,11 @@ func (e *Engine) Execute(ctx context.Context, searchReq *tempopb.SearchRequest, 
 			return nil, nil
 		}
 
-		/*
-			// debug code that confirms that inSS is unmodified
-			clone := inSS.clone()
-			clone.Spans = append([]Span(nil), inSS.Spans...)
-		*/
-
 		evalSS, err := rootExpr.Pipeline.evaluate([]*Spanset{inSS})
 		if err != nil {
 			span.LogKV("msg", "pipeline.evaluate", "err", err)
 			return nil, err
 		}
-
-		/*
-			// debug code that confirms that inSS is unmodified
-			diff := deep.Equal(clone, inSS)
-			if len(diff) > 0 {
-				panic(fmt.Sprintf("inSS was modified: %v", diff))
-			}
-		*/
 
 		spansetsEvaluated++
 		if len(evalSS) == 0 {

--- a/pkg/traceql/storage.go
+++ b/pkg/traceql/storage.go
@@ -68,6 +68,17 @@ type Spanset struct {
 	DurationNanos      uint64
 }
 
+func (s *Spanset) clone() *Spanset {
+	return &Spanset{
+		TraceID:            s.TraceID,
+		Scalar:             s.Scalar,
+		RootSpanName:       s.RootSpanName,
+		RootServiceName:    s.RootServiceName,
+		StartTimeUnixNanos: s.StartTimeUnixNanos,
+		DurationNanos:      s.DurationNanos,
+	}
+}
+
 type SpansetIterator interface {
 	Next(context.Context) (*Spanset, error)
 	Close()

--- a/pkg/traceql/storage.go
+++ b/pkg/traceql/storage.go
@@ -76,6 +76,7 @@ func (s *Spanset) clone() *Spanset {
 		RootServiceName:    s.RootServiceName,
 		StartTimeUnixNanos: s.StartTimeUnixNanos,
 		DurationNanos:      s.DurationNanos,
+		Spans:              s.Spans, // we're not deep cloning into the spans themselves
 	}
 }
 

--- a/tempodb/encoding/vparquet/block_traceql.go
+++ b/tempodb/encoding/vparquet/block_traceql.go
@@ -39,9 +39,6 @@ func (s *span) StartTimeUnixNanos() uint64 {
 func (s *span) EndtimeUnixNanos() uint64 {
 	return s.endtimeUnixNanos
 }
-func (s *span) Release() {
-	putSpan(s)
-}
 
 // todo: this sync pool currently massively reduces allocations by pooling spans for certain queries.
 // it currently catches spans discarded:

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -161,6 +161,8 @@ func testAdvancedTraceQLCompleteBlock(t *testing.T, blockVersion string) {
 			// spansets
 			{Query: fmt.Sprintf("{%s} && {%s}", rando(trueConditionsBySpan[0]), rando(trueConditionsBySpan[1]))},
 			{Query: fmt.Sprintf("{%s} || {%s}", rando(trueConditionsBySpan[0]), rando(falseConditions))},
+			{Query: fmt.Sprintf("{%s} && {%s} && {%s} && {%s} && {%s}", rando(trueConditionsBySpan[0]), rando(trueConditionsBySpan[0]), rando(trueConditionsBySpan[0]), rando(trueConditionsBySpan[0]), rando(trueConditionsBySpan[0]))},
+			{Query: fmt.Sprintf("{%s} || {%s} || {%s} || {%s} || {%s}", rando(falseConditions), rando(falseConditions), rando(falseConditions), rando(trueConditionsBySpan[0]), rando(falseConditions))},
 			{Query: fmt.Sprintf("{%s && %s} || {%s}", rando(falseConditions), rando(falseConditions), rando(trueConditionsBySpan[0]))},
 			// pipelines
 			{Query: fmt.Sprintf("{%s} | {%s}", rando(trueConditionsBySpan[0]), rando(trueConditionsBySpan[0]))},


### PR DESCRIPTION
**What this PR does**:
Due to recent performance improvements specific queries can now panic the engine. When executing a query that &&'s or ||'s multiple spansets together like:
```
{} && {} && {} ...
```
The engine would modify the input slices in the "filter" step. These modifications would sometimes place duplicates of the same span in the input spanset slice. Then, when executing this code:

https://github.com/grafana/tempo/blob/70272b8221ae9456c79b8337984068ecd0a91b34/tempodb/encoding/vparquet/block_traceql.go#L285

we would place the same pointer into the span pool multiple times. This has been corrected by cloning the spanset correctly in the engine layer.

Also, removed an unused `matches()` function and rewrote our evaluate tests to confirm the input was not modified.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`