### PR TITLE
[TraceQL] Multiple &&ed or ||ed should return unique spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [BUGFIX] Fix not closing WAL block file before attempting to delete the folder. [#2139](https://github.com/grafana/tempo/pull/2152) (@kostya9)
 * [BUGFIX] Stop searching for virtual tags if there are any hits.
   This prevents invalid values from showing up for intrinsics like `status` [#2219](https://github.com/grafana/tempo/pull/2152) (@joe-elliott)
+* [BUGFIX] Correctly return unique spans when &&ing and ||ing spansets. [#2254](https://github.com/grafana/tempo/pull/2254) (@joe-elliott)
 
 ## v2.0.1 / 2023-03-03
 

--- a/pkg/traceql/ast_execute_test.go
+++ b/pkg/traceql/ast_execute_test.go
@@ -214,7 +214,6 @@ func TestSpansetOperationEvaluate(t *testing.T) {
 			"{ true } && { true } && { true }",
 			[]*Spanset{
 				{Spans: []Span{
-					// This spanset will be kept because it satisfies both conditions
 					&mockSpan{id: []byte{1}, attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticString("a")}},
 				}},
 			},
@@ -228,7 +227,6 @@ func TestSpansetOperationEvaluate(t *testing.T) {
 			"{ true } || { true } || { true }",
 			[]*Spanset{
 				{Spans: []Span{
-					// This spanset will be kept because it satisfies both conditions
 					&mockSpan{id: []byte{1}, attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticString("a")}},
 				}},
 			},

--- a/pkg/traceql/ast_execute_test.go
+++ b/pkg/traceql/ast_execute_test.go
@@ -1,6 +1,7 @@
 package traceql
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -181,8 +182,8 @@ func TestSpansetOperationEvaluate(t *testing.T) {
 			},
 			[]*Spanset{
 				{Spans: []Span{
-					&mockSpan{id: []byte{1}, attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticString("a")}},
 					&mockSpan{id: []byte{2}, attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticString("b")}},
+					&mockSpan{id: []byte{1}, attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticString("a")}},
 				}},
 			},
 		},
@@ -201,11 +202,39 @@ func TestSpansetOperationEvaluate(t *testing.T) {
 			},
 			[]*Spanset{
 				{Spans: []Span{
-					&mockSpan{id: []byte{1}, attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticString("a")}},
 					&mockSpan{id: []byte{2}, attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticString("b")}},
+					&mockSpan{id: []byte{1}, attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticString("a")}},
 				}},
 				{Spans: []Span{
 					&mockSpan{id: []byte{3}, attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticString("b")}},
+				}},
+			},
+		},
+		{
+			"{ true } && { true } && { true }",
+			[]*Spanset{
+				{Spans: []Span{
+					// This spanset will be kept because it satisfies both conditions
+					&mockSpan{id: []byte{1}, attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticString("a")}},
+				}},
+			},
+			[]*Spanset{
+				{Spans: []Span{
+					&mockSpan{id: []byte{1}, attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticString("a")}},
+				}},
+			},
+		},
+		{
+			"{ true } || { true } || { true }",
+			[]*Spanset{
+				{Spans: []Span{
+					// This spanset will be kept because it satisfies both conditions
+					&mockSpan{id: []byte{1}, attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticString("a")}},
+				}},
+			},
+			[]*Spanset{
+				{Spans: []Span{
+					&mockSpan{id: []byte{1}, attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticString("a")}},
 				}},
 			},
 		},
@@ -674,5 +703,31 @@ func BenchmarkBinOp(b *testing.B) {
 				_, _ = o.op.execute(&mockSpan{})
 			}
 		})
+	}
+}
+
+// BenchmarkUniquespans benchmarks the performance of the uniqueSpans function using
+// different numbers of spansets and spans.
+func BenchmarkUniqueSpans(b *testing.B) {
+	sizes := []int{1, 10, 100, 1000, 10000}
+
+	for _, lhs := range sizes {
+		for i := len(sizes) - 1; i >= 0; i-- {
+			rhs := sizes[i]
+			b.Run(fmt.Sprintf("%d|%d", rhs, lhs), func(b *testing.B) {
+				lhsSpansets := []*Spanset{{Spans: make([]Span, lhs)}}
+				rhsSpansets := []*Spanset{{Spans: make([]Span, rhs)}}
+				for j := 0; j < lhs; j++ {
+					lhsSpansets[0].Spans[j] = &mockSpan{id: []byte{byte(j)}}
+				}
+				for j := 0; j < rhs; j++ {
+					rhsSpansets[0].Spans[j] = &mockSpan{id: []byte{byte(j)}}
+				}
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					uniqueSpans(lhsSpansets, rhsSpansets)
+				}
+			})
+		}
 	}
 }

--- a/tempodb/encoding/vparquet/block_traceql.go
+++ b/tempodb/encoding/vparquet/block_traceql.go
@@ -295,6 +295,8 @@ func (i *spansetIterator) Next() (*span, error) {
 			}
 		}
 
+		// jpe, need to sort spansets in row order
+
 		// found something!
 		if len(i.currentSpans) > 0 {
 			ret := i.currentSpans[0]

--- a/tempodb/encoding/vparquet/block_traceql.go
+++ b/tempodb/encoding/vparquet/block_traceql.go
@@ -299,7 +299,7 @@ func (i *spansetIterator) Next() (*span, error) {
 		// spans returned from the filter are not guaranteed to be in file order
 		// we need them to be so that the meta iterators work correctly. sort here
 		sort.Slice(i.currentSpans, func(j, k int) bool {
-			return parquetquery.CompareRowNumbers(DefinitionLevelResourceSpans, i.currentSpans[k].rowNum, i.currentSpans[j].rowNum) == 1
+			return parquetquery.CompareRowNumbers(DefinitionLevelResourceSpans, i.currentSpans[j].rowNum, i.currentSpans[k].rowNum) == -1
 		})
 
 		// found something!

--- a/tempodb/encoding/vparquet/block_traceql.go
+++ b/tempodb/encoding/vparquet/block_traceql.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"sort"
 	"sync"
 	"time"
 
@@ -295,7 +296,11 @@ func (i *spansetIterator) Next() (*span, error) {
 			}
 		}
 
-		// jpe, need to sort spansets in row order
+		// spans returned from the filter are not guaranteed to be in file order
+		// we need them to be so that the meta iterators work correctly. sort here
+		sort.Slice(i.currentSpans, func(j, k int) bool {
+			return parquetquery.CompareRowNumbers(DefinitionLevelResourceSpans, i.currentSpans[k].rowNum, i.currentSpans[j].rowNum) == 1
+		})
 
 		// found something!
 		if len(i.currentSpans) > 0 {

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -175,6 +175,8 @@ func testAdvancedTraceQLCompleteBlock(t *testing.T, blockVersion string) {
 			{Query: fmt.Sprintf("{} | count() != %d", totalSpans+1)},
 			{Query: fmt.Sprintf("{} | count() <= %d", totalSpans)},
 			{Query: fmt.Sprintf("{} | count() >= %d", totalSpans)},
+			{Query: fmt.Sprintf("{ true } && { true } | count() = %d", totalSpans)},
+			{Query: fmt.Sprintf("{ true } || { true } | count() = %d", totalSpans)},
 			// avgs
 			{Query: "{ } | avg(duration) > 0"}, // todo: make this better
 		}


### PR DESCRIPTION
**What this PR does**:
Forces the spanset operations && and || to always return a unique spanset. Before they would return the cross product of all spansets. For instance this query `{ true } && { true }` would return a spanset that was double the input trace. Now it will return a spanset that is equal to the input trace.

**Which issue(s) this PR fixes**:
Fixes #2246 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`