### PR TITLE
Don't keep file and reader around in backendBlock

### DIFF
--- a/tempodb/encoding/vparquet/block.go
+++ b/tempodb/encoding/vparquet/block.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
-	"github.com/segmentio/parquet-go"
 )
 
 const (
@@ -16,9 +15,7 @@ type backendBlock struct {
 	meta *backend.BlockMeta
 	r    backend.Reader
 
-	openMtx  sync.Mutex
-	pf       *parquet.File
-	readerAt *BackendReaderAt
+	openMtx sync.Mutex
 }
 
 var _ common.BackendBlock = (*backendBlock)(nil)

--- a/tempodb/encoding/vparquet/block_search.go
+++ b/tempodb/encoding/vparquet/block_search.go
@@ -93,11 +93,6 @@ func (b *backendBlock) openForSearch(ctx context.Context, opts common.SearchOpti
 	defer span.Finish()
 	pf, err := parquet.OpenFile(readerAt, int64(b.meta.Size), o...)
 
-	if err == nil {
-		b.pf = pf
-		b.readerAt = backendReaderAt
-	}
-
 	return pf, backendReaderAt, err
 }
 


### PR DESCRIPTION
**What this PR does**:
We are saving file and reader in backendBlock, but are never using them. removing them to save some memory

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`