### PR TITLE
[DOC] Doc restructure: introduction and get-started

### DIFF
--- a/docs/sources/tempo/_index.md
+++ b/docs/sources/tempo/_index.md
@@ -10,7 +10,7 @@ aliases:
 
 Grafana Tempo is an open source, easy-to-use, and high-volume distributed tracing backend. Tempo is cost-efficient, and only requires an object storage to operate. Tempo is deeply integrated with Grafana, Mimir, Prometheus, and Loki. You can use Tempo with open-source tracing protocols, including Jaeger, Zipkin, or OpenTelemetry.
 
-Tempo integrates well with a number of existing open source tools: 
+Tempo integrates well with a number of existing open source tools:
 
 - **Grafana** ships with native support for Tempo using the built-in [Tempo data source](https://grafana.com/docs/grafana/latest/datasources/tempo/).
 - **Grafana Loki**, with its powerful query language [LogQL v2](https://grafana.com/blog/2020/10/28/loki-2.0-released-transform-logs-as-youre-querying-them-and-set-up-alerts-within-loki/) allows you to filter requests that you care about, and jump to traces using the [Derived fields support in Grafana](https://grafana.com/docs/grafana/latest/datasources/loki/#derived-fields).
@@ -18,7 +18,7 @@ Tempo integrates well with a number of existing open source tools:
 
 <p align="center"><img src="getting-started/assets/trace_custom_metrics_dash.png" alt="Trace visualization in Grafana "></p>
 
-Grafana Tempo builds an index from the high-cardinality trace-id field. Because Tempo uses an object store as a backend, Tempo can query many blocks simultaneously, so queries are highly parallelized. 
+Grafana Tempo builds an index from the high-cardinality trace-id field. Because Tempo uses an object store as a backend, Tempo can query many blocks simultaneously, so queries are highly parallelized.
 For more information, see [Architecture](https://grafana.com/docs/tempo/latest/operations/architecture/).
 
 ## Learn more about Tempo

--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -2,7 +2,7 @@
 title: Tempo API
 description: Grafana Tempo exposes an API for pushing and querying traces, and operating the cluster itself.
 menuTitle: Tempo API
-weight: 500
+weight: 700
 ---
 
 # Tempo API
@@ -11,6 +11,7 @@ Tempo exposes an API for pushing and querying traces, and operating the cluster 
 
 For the sake of clarity, API endpoints are grouped by service.
 These endpoints are exposed both when running Tempo in microservices and monolithic mode:
+
 - **microservices**: each service exposes its own endpoints
 - **monolithic**: the Tempo process exposes all API endpoints for the services running internally
 

--- a/docs/sources/tempo/community/_index.md
+++ b/docs/sources/tempo/community/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Community
-weight: 700
+weight: 800
 ---
 
 ## Communicate

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-weight: 200
+weight: 400
 alias:
 - /docs/tempo/latest/configuration/
 ---

--- a/docs/sources/tempo/configuration/polling.md
+++ b/docs/sources/tempo/configuration/polling.md
@@ -1,6 +1,8 @@
 ---
 title: Polling
 weight: 80
+aliases:
+- /docs/tempo/configuration/polling
 ---
 
 # Polling
@@ -11,7 +13,7 @@ The polling cycle is controlled by a number of configuration options detailed he
 storage:
     trace:
         # How often to repoll the backend for new blocks. Default is 5m
-        [blocklist_poll: <duration>] 
+        [blocklist_poll: <duration>]
 
         # Number of blocks to process in parallel during polling. Default is 50.
         [blocklist_poll_concurrency: <int>]
@@ -20,7 +22,7 @@ storage:
         # fallback to scanning the entire bucket. Set to false to disable this behavior. Default is true.
         [blocklist_poll_fallback: <bool>]
 
-        # Maximum number of compactors that should build the tenant index. All other components will download 
+        # Maximum number of compactors that should build the tenant index. All other components will download
         # the index.  Default 2.
         [blocklist_poll_tenant_index_builders: <int>]
 
@@ -33,7 +35,7 @@ storage:
 ```
 
 Due to the mechanics of the [tenant index]({{< relref "../operations/polling" >}}), the blocklist will be stale by
-at most 2 times the configured `blocklist_poll` duration. There are two configuration options that need to be balanced 
+at most 2 times the configured `blocklist_poll` duration. There are two configuration options that need to be balanced
 against the `blockist_poll` to handle this:
 
 The ingester `complete_block_timeout` is used to hold a block in the ingester for a given period of time after
@@ -47,7 +49,7 @@ ingester:
 
 The compactor `compacted_block_retention` is used to keep a block in the backend for a given period of time
 after it has been compacted and the data is no longer needed. This allows queriers with a stale blocklist to access
-these blocks successfully until they complete their polling cycles and have up to date blocklists. Like the 
+these blocks successfully until they complete their polling cycles and have up to date blocklists. Like the
 `complete_block_timeout`, this should be at a minimum 2x the configured `blocklist_poll` duration.
 
 ```
@@ -57,6 +59,6 @@ compactor:
     [compacted_block_retention: <duration>]
 ```
 
-Additionally, the querier `blocklist_poll` duration needs to be greater than or equal to the compactor 
-`blocklist_poll` duration. Otherwise, a querier may not correctly check all assigned blocks and incorrectly return 404. 
+Additionally, the querier `blocklist_poll` duration needs to be greater than or equal to the compactor
+`blocklist_poll` duration. Otherwise, a querier may not correctly check all assigned blocks and incorrectly return 404.
 It is recommended to simply set both components to use the same poll duration.

--- a/docs/sources/tempo/getting-started/_index.md
+++ b/docs/sources/tempo/getting-started/_index.md
@@ -1,13 +1,15 @@
 ---
 title: Get started
 menuTitle: Get started with Grafana Tempo
-weight: 150
+weight: 200
+aliases:
+- /docs/tempo/getting-started
 ---
 
 # Get started with Grafana Tempo
 
 Distributed tracing visualizes the lifecycle of a request as it passes through a set of applications.
-For more information about traces, refer to [What are traces?]({{< relref "traces" >}}).
+For more information about traces, refer to [What are traces?]({{< relref "../traces" >}}).
 
 Grafana Tempo is an open-source, easy-to-use, and high-scale distributed tracing backend. Tempo lets you search for traces, generate metrics from spans, and link your tracing data with logs and metrics.
 
@@ -24,24 +26,7 @@ Client instrumentation (1 in the diagram) is the first building block to a funct
 Client instrumentation is the process of adding instrumentation points in the application that
 create and offload spans.
 
-Most of the popular client instrumentation frameworks
-have SDKs in the most commonly used programming languages.
-You should pick one according to your application needs.
-
-* [OpenTracing/Jaeger](https://www.jaegertracing.io/docs/latest/client-libraries/)
-* [Zipkin](https://zipkin.io/pages/tracers_instrumentation)
-* [OpenTelemetry](https://opentelemetry.io/docs/concepts/instrumenting/)
-
-### OpenTelemetry auto-instrumentation
-
-Some languages have support for auto-instrumentation. These libraries capture telemetry
-information from a client application with minimal manual instrumentation of the codebase.
-
-* [OpenTelemetry Java auto-instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation)
-* [OpenTelemetry .NET auto-instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation)
-* [OpenTelemetry Python auto-instrumentation](https://github.com/open-telemetry/opentelemetry-python-contrib)
-
-> **Note**: Check out the [instrumentation references]({{< relref "./instrumentation" >}}) to learn how to instrument your
+> **Note**: To learn more about instrumentation, read [instrumentation references]({{< relref "./instrumentation" >}}) to learn how to instrument your
 > favorite language for distributed tracing.
 
 ## Pipeline (Grafana Agent)

--- a/docs/sources/tempo/getting-started/instrumentation.md
+++ b/docs/sources/tempo/getting-started/instrumentation.md
@@ -1,25 +1,51 @@
 ---
-title: Instrumentation references
-menuTitle: Instrumentation references
+title: Instrument for tracing
+menuTitle: Instrument for tracing
 aliases:
 - /docs/tempo/latest/guides/instrumentation/
 weight: 200
 ---
 
 
-# Instrumentation references
+# Instrument for distributed tracing
+
+Client instrumentation is the first building block to a functioning distributed tracing visualization pipeline.
+Client instrumentation is the process of adding instrumentation points in the application that create and offload spans.
 
 Check out these resources for help instrumenting tracing with your favorite languages.
 Most of these guides include complete end-to-end examples with Grafana, Loki, and Tempo.
 
+### Instrumentaiton frameworks
+
+Most of the popular client instrumentation frameworks
+have SDKs in the most commonly used programming languages.
+You should pick one according to your application needs.
+
+* [OpenTracing/Jaeger](https://www.jaegertracing.io/docs/latest/client-libraries/)
+* [Zipkin](https://zipkin.io/pages/tracers_instrumentation)
+* [OpenTelemetry](https://opentelemetry.io/docs/concepts/instrumenting/)
+
+
+> **Note**: Check out the [instrumentation references]({{< relref "./instrumentation" >}}) to learn how to instrument your
+> favorite language for distributed tracing.
+
+### OpenTelemetry auto-instrumentation
+
+Some languages have support for auto-instrumentation. These libraries capture telemetry
+information from a client application with minimal manual instrumentation of the codebase.
+
+* [OpenTelemetry Java auto-instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation)
+* [OpenTelemetry .NET auto-instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation)
+* [OpenTelemetry Python auto-instrumentation](https://github.com/open-telemetry/opentelemetry-python-contrib)
+
 ## OpenTelemetry
 
-- [OpenTelemetry Language Specific Instrumentation](https://opentelemetry.io/docs/)
+- [OpenTelemetry Language Specific Instrumentation](https://opentelemetry.io/docs/instrumentation/)
 
-## Jaeger 
+## Jaeger
 - [Jaeger Language Specific Instrumentation](https://www.jaegertracing.io/docs/latest/client-libraries/)
 
-## Zipkin 
+## Zipkin
 - [Zipkin Language Specific Instrumentation](https://zipkin.io/pages/tracers_instrumentation.html)
 
 ## Grafana Blog

--- a/docs/sources/tempo/getting-started/tempo-in-grafana.md
+++ b/docs/sources/tempo/getting-started/tempo-in-grafana.md
@@ -7,18 +7,6 @@ weight: 400
 
 Grafana has a built-in Tempo datasource that can be used to query Tempo and visualize traces.  This page describes the high-level features and their availability.  Use the latest versions for best compatibility and stability.
 
-## View trace by ID
-
-The most basic functionality is to visualize a trace using its ID.  Select the Trace ID tab and enter the ID to view it. This functionality is enabled by default and is available in all versions of Grafana.
-<p align="center"><img src="../assets/grafana-query.png" alt="View trace by ID"></p>
-
-## Log search
-
-Traces can be discovered by searching logs for entries containing trace IDs.  This is most useful when your application also logs relevant information about the trace that can also be searched, such as HTTP status code, customer ID, etc.  This feature requires Grafana 7.5 or later, with a linked Loki data source, and a [traceID derived field](https://grafana.com/docs/grafana/latest/datasources/loki/#derived-fields).
-
-<p align="center"><img src="../assets/log-search.png" alt="Log Search"></p>
-
-
 ## Use TraceQL to dig deep into trace data
 
 Inspired by PromQL and LogQL, TraceQL is a query language designed for selecting traces in Tempo.
@@ -28,6 +16,16 @@ The default Tempo search reviews the whole trace. TraceQL provides a method for 
 You can run a TraceQL query either by issuing it to Tempo’s `q` parameter of the [`search` API endpoint]({{< relref "../api_docs/#search" >}}), or, for those using Tempo in conjunction with Grafana, by using Grafana’s [TraceQL query editor]({{< relref "../traceql/query-editor" >}}).
 
 For details about how queries are constructed, read the [TraceQL documentation]({{< relref "../traceql" >}}).
+
+<p align="center"><img src="../../traceql/assets/query-editor-results-span.png" alt="Query editor showing span results" /></p>
+
+## View trace by ID
+
+The most basic functionality is to visualize a trace using its ID.  Select the Trace ID tab and enter the ID to view it. This functionality is enabled by default and is available in all versions of Grafana.
+
+## Log search
+
+Traces can be discovered by searching logs for entries containing trace IDs.  This is most useful when your application also logs relevant information about the trace that can also be searched, such as HTTP status code, customer ID, etc.  This feature requires Grafana 7.5 or later, with a linked Loki data source, and a [traceID derived field](https://grafana.com/docs/grafana/latest/datasources/loki/#derived-fields).
 
 ## Find traces using Tempo tags search
 

--- a/docs/sources/tempo/grafana-agent/_index.md
+++ b/docs/sources/tempo/grafana-agent/_index.md
@@ -1,23 +1,26 @@
 ---
 title: Grafana Agent
 weight: 600
+aliases:
+- /docs/tempo/grafana-agent
+- /docs/tempo/configuration/grafana-agent
 ---
 
 # Grafana Agent
 
-The [Grafana Agent](https://github.com/grafana/agent) is a telemetry 
-collector for sending metrics, logs, and trace data to the opinionated 
+The [Grafana Agent](https://github.com/grafana/agent) is a telemetry
+collector for sending metrics, logs, and trace data to the opinionated
 Grafana observability stack.
 
-It is commonly used as a tracing pipeline, offloading traces from the 
+It is commonly used as a tracing pipeline, offloading traces from the
 application and forwarding them to a storage backend.
 The Grafana Agent tracing stack is built using OpenTelemetry.
 
 The Grafana Agent supports receiving traces in multiple formats:
 OTLP (OpenTelemetry), Jaeger, Zipkin and OpenCensus.
 
-On top of receiving and exporting traces, the Grafana Agent contains many 
-features that make your distributed tracing system more robust, and 
+On top of receiving and exporting traces, the Grafana Agent contains many
+features that make your distributed tracing system more robust, and
 leverages all the data that is processed in the pipeline.
 
 ## Architecture
@@ -25,18 +28,18 @@ leverages all the data that is processed in the pipeline.
 The Grafana Agent can be configured to run a set of tracing pipelines to collect data from your applications and write it to Tempo.
 Pipelines are built using OpenTelemetry,
 and consist of `receivers`, `processors` and `exporters`. The architecture mirrors that of the OTel Collector's [design](https://github.com/open-telemetry/opentelemetry-collector/blob/846b971758c92b833a9efaf742ec5b3e2fbd0c89/docs/design.md).
-See the [configuration reference](https://grafana.com/docs/agent/latest/configuration/traces-config/) for all available config options. 
+See the [configuration reference](https://grafana.com/docs/agent/latest/configuration/traces-config/) for all available config options.
 For a quick start, refer to this [blog post](https://grafana.com/blog/2020/11/17/tracing-with-the-grafana-agent-and-grafana-tempo/).
 
 <p align="center"><img src="https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector/846b971758c92b833a9efaf742ec5b3e2fbd0c89/docs/images/design-pipelines.png" alt="Tracing pipeline architecture"></p>
 
 This allows you to configure multiple distinct tracing
-pipelines, each of which collects separate spans and sends them to different 
+pipelines, each of which collects separate spans and sends them to different
 backends.
 
 ### Receiving traces
 
-The Grafana Agent supports multiple ingestion receivers: 
+The Grafana Agent supports multiple ingestion receivers:
 OTLP (OpenTelemetry), Jaeger, Zipkin, OpenCensus and Kafka.
 
 Each tracing pipeline can be configured to receive traces in all these formats.

--- a/docs/sources/tempo/metrics-generator/_index.md
+++ b/docs/sources/tempo/metrics-generator/_index.md
@@ -3,7 +3,7 @@ aliases:
 - /docs/tempo/latest/server_side_metrics/
 - /docs/tempo/latest/metrics-generator/
 title: Metrics-generator
-weight: 400
+weight: 500
 ---
 
 # Metrics-generator

--- a/docs/sources/tempo/operations/_index.md
+++ b/docs/sources/tempo/operations/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Deployment and operations
-weight: 300
+weight: 600
 ---
 
 # Deployment and operations

--- a/docs/sources/tempo/operations/ingester_pvcs.md
+++ b/docs/sources/tempo/operations/ingester_pvcs.md
@@ -9,7 +9,11 @@ Tempo ingesters make heavy use of local disks to store write-ahead logs and bloc
 
 Therefore it may be necessary to increase the disk space for ingesters as usage increases.
 
-## Deploying
+We recommend using SSDs for local storage.
+
+<!-- Wr>
+
+## Increase VCC size
 
 When deployed as a StatefulSet with Persistent Volume Claims (PVC), some manual steps are required. The following configuration has worked successfully on GKE with GCS:
 

--- a/docs/sources/tempo/operations/parquet/_index.md
+++ b/docs/sources/tempo/operations/parquet/_index.md
@@ -1,17 +1,15 @@
 ---
-title: Query and inspect Apache Parquet
-menuTitle: Query Parquet
+title: Inspect Apache Parquet
+menuTitle: Inspect Parquet
 weight: 75
 ---
 
-# Query and inspect Apache Parquet data
+# Inspect Apache Parquet data
 
 Apache Parquet is a column-oriented format and is the default block format for Tempo 2.0.
 Refer to the [Parquet configuration options]({{< relref "../../configuration/parquet.md" >}}) for more information.
 
 You can use `parquet-tools` to query and inspect Parquet files. There are multiple distributions of parquet-tools available. Most of the examples on this page should work with different distributions.
-
-
 
 ## Examples
 

--- a/docs/sources/tempo/operations/polling.md
+++ b/docs/sources/tempo/operations/polling.md
@@ -1,5 +1,5 @@
 ---
-title: Polling and monitoring
+title: Polling
 weight: 80
 ---
 

--- a/docs/sources/tempo/setup/_index.md
+++ b/docs/sources/tempo/setup/_index.md
@@ -2,7 +2,9 @@
 title: Set up a Tempo server or cluster
 menuTitle: Set up a Tempo server or cluster
 description: Learn how to set up a Tempo server or cluster and visualize data
-weight: 150
+aliases:
+- /docs/tempo/setup
+weight: 300
 ---
 
 # Set up a Tempo server or cluster

--- a/docs/sources/tempo/traces.md
+++ b/docs/sources/tempo/traces.md
@@ -1,6 +1,7 @@
 ---
 aliases:
 - /docs/tempo/getting-started/traces
+- /docs/tempo/traces
 description: "What are traces?"
 keywords:
 - Grafana


### PR DESCRIPTION
**What this PR does**:
Restructures the Tempo documentation: introduction (what are traces) and get started sections. 

**Which issue(s) this PR fixes**:
Addressed  part of issue #2223 

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`