### PR TITLE
Fix typo in service graph docs

### DIFF
--- a/docs/sources/tempo/metrics-generator/service_graphs.md
+++ b/docs/sources/tempo/metrics-generator/service_graphs.md
@@ -109,7 +109,7 @@ An often most reliable solution is by running the metrics-generator in a dry-run
 That is generating metrics but not collecting them, thus not writing them to a metrics storage.
 The override `metrics_generator_disable_collection` is defined for this use-case.
 
-To get an estimate, run the metrics-generator normally and set the override to `false`.
+To get an estimate, run the metrics-generator normally and set the override to `true`.
 Then, check `tempo_metrics_generator_registry_active_series` to get an estimation of the active series for that set-up.
 
 ## How to run


### PR DESCRIPTION
**What this PR does**:

Just noticed a small mistake in the section explaining disabling collection. The setting `metrics_generator_disable_collection` defaults to `false` and has to be set to `true` to disable collection.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`