### PR TITLE
Disbale metrics collection action on forks

### DIFF
--- a/.github/workflows/metrics-collector.yml
+++ b/.github/workflows/metrics-collector.yml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   main:
+    # this action keeps failing in all forks, only run in grafana/tempo.
+    # stats collection action is only useful in main repo.
+    if: github.repository == 'grafana/tempo'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions


### PR DESCRIPTION
**What this PR does**:

Metrics collection actions cron runs on forks and fails, this PR adds a condition to only run this action on `grafana/tempo` repo.

docs on if condition: https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution#example-only-run-job-for-specific-repository

**Which issue(s) this PR fixes**:
Fixes #<issue number>

this action has [10,555 failed workflow runs](https://github.com/ie-pham/tempo/actions/workflows/metrics-collector.yml) in @ie-pham's fork and [176 failed workflow runs](https://github.com/electron0zero/tempo/actions/workflows/metrics-collector.yml) in my fork.

each failed workflow run sends an email to fork owner, so this will remove that spam as well.


**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`