### PR TITLE
Limit GitHub workflows to only grafana/tempo repo

### DIFF
--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -4,6 +4,8 @@ on:
     types: [labeled]
 jobs:
   main:
+    # only run in grafana/tempo.
+    if: github.repository == 'grafana/tempo'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions

--- a/.github/workflows/milestoned_to_project.yml
+++ b/.github/workflows/milestoned_to_project.yml
@@ -7,6 +7,8 @@ on:
     
 jobs:
   build:
+    # only run in grafana/tempo.
+    if: github.repository == 'grafana/tempo'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -9,6 +9,8 @@ on:
  workflow_dispatch:
 
 jobs:
+  # only run in grafana/tempo.
+  if: github.repository == 'grafana/tempo'
   snyk-scan-ci:
     uses: 'grafana/security-github-actions/.github/workflows/snyk_monitor.yml@main'
     secrets:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,6 +8,8 @@ permissions:
   pull-requests: write
 jobs:
   stale:
+    # only run in grafana/tempo.
+    if: github.repository == 'grafana/tempo'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v6.0.1

--- a/.github/workflows/website-next.yml
+++ b/.github/workflows/website-next.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   test:
+    # only run in grafana/tempo.
+    if: github.repository == 'grafana/tempo'
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -25,6 +27,8 @@ jobs:
                 /bin/bash -c 'make hugo'
 
   sync:
+    # only run in grafana/tempo.
+    if: github.repository == 'grafana/tempo'
     runs-on: ubuntu-latest
     needs: test
     steps:

--- a/.github/workflows/website-versioned.yml
+++ b/.github/workflows/website-versioned.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   test:
+    # only run in grafana/tempo.
+    if: github.repository == 'grafana/tempo'
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -19,6 +21,8 @@ jobs:
       - name: Build Website
         run: docker run -v ${PWD}/docs/sources/tempo:/hugo/content/docs/tempo/latest --rm grafana/docs-base:latest make prod
   sync:
+    # only run in grafana/tempo.
+    if: github.repository == 'grafana/tempo'
     runs-on: ubuntu-latest
     needs: test
     steps:


### PR DESCRIPTION
**What this PR does**:

follow up on https://github.com/grafana/tempo/pull/2284, after https://github.com/grafana/tempo/pull/2284, I noticed that few other workflows are also running in my fork.

This PR limits grafana specific workflow actions to `grafana/tempo` repo.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`