### PR TITLE
tempo-mixin: disable auto refresh every 10 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main / unreleased
 
-* [CHANGE] Update tempo-mixin to show request in Resources dashboard [#2281](https://github.com/grafana/tempo/pull/2008) (@electron0zero)
+* [CHANGE] tempo-mixin: disable auto refresh every 10 seconds [#2290](https://github.com/grafana/tempo/pull/2290) (@electron0zero)
+* [CHANGE] Update tempo-mixin to show request in Resources dashboard [#2281](https://github.com/grafana/tempo/pull/2281) (@electron0zero)
 * [FEATURE] Add support for Azure Workload Identity authentication [#2195](https://github.com/grafana/tempo/pull/2195) (@LambArchie)
 * [ENHANCEMENT] Add Throughput and SLO Metrics with SLOConfig in Query Frontend [#2008](https://github.com/grafana/tempo/pull/2008) (@electron0zero)
   - **BREAKING CHANGE** `query_frontend_result_metrics_inspected_bytes` metric removed in favour of `query_frontend_bytes_processed_per_second`

--- a/operations/tempo-mixin-compiled/dashboards/tempo-reads.json
+++ b/operations/tempo-mixin-compiled/dashboards/tempo-reads.json
@@ -22,7 +22,7 @@
    "type": "dashboards"
   }
  ],
- "refresh": "10s",
+ "refresh": "",
  "rows": [
   {
    "collapse": false,

--- a/operations/tempo-mixin-compiled/dashboards/tempo-resources.json
+++ b/operations/tempo-mixin-compiled/dashboards/tempo-resources.json
@@ -22,7 +22,7 @@
    "type": "dashboards"
   }
  ],
- "refresh": "10s",
+ "refresh": "",
  "rows": [
   {
    "collapse": false,

--- a/operations/tempo-mixin-compiled/dashboards/tempo-rollout-progress.json
+++ b/operations/tempo-mixin-compiled/dashboards/tempo-rollout-progress.json
@@ -1440,7 +1440,7 @@
    ]
   }
  ],
- "refresh": "10s",
+ "refresh": "",
  "rows": null,
  "schemaVersion": 27,
  "style": "dark",

--- a/operations/tempo-mixin-compiled/dashboards/tempo-tenants.json
+++ b/operations/tempo-mixin-compiled/dashboards/tempo-tenants.json
@@ -22,7 +22,7 @@
    "type": "dashboards"
   }
  ],
- "refresh": "10s",
+ "refresh": "",
  "rows": [
   {
    "collapse": false,

--- a/operations/tempo-mixin-compiled/dashboards/tempo-writes.json
+++ b/operations/tempo-mixin-compiled/dashboards/tempo-writes.json
@@ -22,7 +22,7 @@
    "type": "dashboards"
   }
  ],
- "refresh": "10s",
+ "refresh": "",
  "rows": [
   {
    "collapse": false,

--- a/operations/tempo-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/tempo-mixin/dashboards/dashboard-utils.libsonnet
@@ -5,10 +5,12 @@ grafana {
   // Override the dashboard constructor to add:
   // - default tags,
   // - some links that propagate the selected cluster.
+  // - disable auto refresh every 10 seconds
   dashboard(title)::
     super.dashboard(title) + {
       addClusterSelectorTemplates()::
         local d = self {
+          refresh: '',
           tags: ['tempo'],
           links: [
             {


### PR DESCRIPTION
**What this PR does**:

by default all dashboard in tempo-mixin have auto refresh enabled to refresh the dashboard every 10 seconds, this change disables that.

**why disable:**
- most users have scrape internval of 15 seconds or higher so 10 refresh is too aggresive
- auto refresh will keep refreshing dashboard in backgroud, and put extra load on datasource
- users can still enable auto-refresh when looking at dashboard, this will just turn it off by default.
- auto refresh eats up resources in your browser when you have many dashboard open.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`