### PR TITLE
[DOC] TOC restructure for Setup content

### DIFF
--- a/docs/sources/tempo/getting-started/_index.md
+++ b/docs/sources/tempo/getting-started/_index.md
@@ -60,7 +60,7 @@ First, check out the [examples]({{< relref "example-demo-app.md" >}}) for ideas 
 
 Next, review the [Setup documentation]({{< relref "../setup/" >}}) for step-by-step instructions for setting up a Tempo cluster and creating a test application.
 
-For production workloads, refer to the [deployment]({{< relref "../operations/deployment" >}}) section.
+For production workloads, refer to the [deployment]({{< relref "../setup/deployment" >}}) section.
 
 > **Note:** The Grafana Agent is already set up to use Tempo. Refer to the [configuration](https://grafana.com/docs/agent/latest/configuration/traces-config/) and [example](https://github.com/grafana/agent/blob/main/example/docker-compose/agent/config/agent.yaml) for details.
 

--- a/docs/sources/tempo/getting-started/_index.md
+++ b/docs/sources/tempo/getting-started/_index.md
@@ -58,9 +58,9 @@ Getting started with Tempo is easy.
 
 First, check out the [examples]({{< relref "example-demo-app.md" >}}) for ideas on how to get started with Tempo.
 
-Next, review the [Setup documentation]({{< relref "../setup/" >}}) for step-by-step instructions for setting up a Tempo cluster and creating a test application.
+Next, review the [Setup documentation]({{< relref "../setup/" >}}) for step-by-step instructions for setting up Tempo and creating a test application.
 
-For production workloads, refer to the [deployment]({{< relref "../setup/deployment" >}}) section.
+Tempo offers different deployment options, depending upon your needs. Refer to the [plan your deployment]({{< relref "../setup/deployment" >}}) section for more information
 
 > **Note:** The Grafana Agent is already set up to use Tempo. Refer to the [configuration](https://grafana.com/docs/agent/latest/configuration/traces-config/) and [example](https://github.com/grafana/agent/blob/main/example/docker-compose/agent/config/agent.yaml) for details.
 

--- a/docs/sources/tempo/getting-started/example-demo-app.md
+++ b/docs/sources/tempo/getting-started/example-demo-app.md
@@ -16,6 +16,7 @@ For more information about Tempo setup and configuration, see:
 * [Tempo configuration]({{< relref "../configuration" >}})
 
 If you are interested in instrumentation, see [Tempo instrumentation]({{< relref "instrumentation" >}}).
+
 ## Docker Compose
 
 The [docker-compose examples](https://github.com/grafana/tempo/tree/main/example/docker-compose) are simpler and designed to show minimal configuration.
@@ -29,19 +30,19 @@ Some of the examples include:
 
 This is a great place to get started with Tempo and learn about various trace discovery flows.
 
-## Tanka
-
-To view an example of a complete microservice-based deployment, this [Jsonnet based example](https://github.com/grafana/tempo/tree/main/example/tk) shows a complete microservice based deployment.
-There are monolithic mode and microservices examples.
-
-To learn how to set up a Tempo cluster, see [Deploy on Kubernetes with Tanka]({{< relref "../setup/tanka" >}}).
-
 ## Helm
 
 The Helm [example](https://github.com/grafana/tempo/tree/main/example/helm) shows a complete microservice based deployment.
 There are monolithic mode and microservices examples.
 
 To install Tempo on Kubernetes, use the [Deploy on Kubernetes using Helm](/docs/helm-charts/tempo-distributed/next/) procedure.
+
+## Tanka
+
+To view an example of a complete microservice-based deployment, this [Jsonnet based example](https://github.com/grafana/tempo/tree/main/example/tk) shows a complete microservice based deployment.
+There are monolithic mode and microservices examples.
+
+To learn how to set up a Tempo cluster, see [Deploy on Kubernetes with Tanka]({{< relref "../setup/tanka" >}}).
 
 ## The New Stack demo
 

--- a/docs/sources/tempo/getting-started/example-demo-app.md
+++ b/docs/sources/tempo/getting-started/example-demo-app.md
@@ -12,7 +12,7 @@ The following examples show various deployment and configuration options using t
 
 For more information about Tempo setup and configuration, see:
 
-* [Set up a Tempo cluster]({{< relref "../setup">}})
+* [Set up Tempo]({{< relref "../setup">}})
 * [Tempo configuration]({{< relref "../configuration" >}})
 
 If you are interested in instrumentation, see [Tempo instrumentation]({{< relref "instrumentation" >}}).

--- a/docs/sources/tempo/operations/architecture.md
+++ b/docs/sources/tempo/operations/architecture.md
@@ -11,7 +11,7 @@ A collection of documents that detail Tempo architectural decisions and operatio
 # Architecture
 
 This topic provides an overview of the major components of Tempo. Refer to the [example setups]({{< relref "../getting-started/example-demo-app" >}})
-or [deployment options]({{< relref "./deployment" >}}) for help deploying.
+or [deployment options]({{< relref "../setup/deployment" >}}) for help deploying.
 
 <p align="center"><img src="../tempo_arch.png" alt="Tempo Architecture"></p>
 

--- a/docs/sources/tempo/operations/caching.md
+++ b/docs/sources/tempo/operations/caching.md
@@ -13,7 +13,7 @@ The supported implementations are [Memcached](https://memcached.org/) and [Redis
 ## Memcached
 
 Memcached is one of the cache implementations supported by Tempo.
-It is used by default in the Tanka and Helm examples, see [Deploying Tempo]({{< relref "deployment/" >}}).
+It is used by default in the Tanka and Helm examples, see [Deploying Tempo]({{< relref "../setup/deployment/" >}}).
 
 ### Connection limit
 

--- a/docs/sources/tempo/release-notes/v1-2.md
+++ b/docs/sources/tempo/release-notes/v1-2.md
@@ -9,8 +9,8 @@ The Tempo team is excited to announce the release of Tempo 1.2. This release int
 
 ## Features and enhancements
 
-* **Recent traces search** The headline feature of Tempo 1.2 is the ability to search for data that is still in the ingester component. This experimental feature must be enabled using feature flags in both Grafana and Tempo. Refer to [Tempo search](https://grafana.com/docs/tempo/latest/getting-started/tempo-in-grafana/#tempo-search) for details.
-* **Scalable monolithic deployment mode (formerly scalable single binary deployment mode)** The new [scalable monolithic](https://grafana.com/docs/tempo/latest/operations/deployment/#scalable-monolithic) deployment mode is operationally simpler, although less robust than a fully distributed deployment. We consider it a balanced operational mode that some may find attractive. 
+* **Recent traces search** The headline feature of Tempo 1.2 is the ability to search for data that is still in the ingester component. This experimental feature must be enabled using feature flags in both Grafana and Tempo. Refer to [Tempo search](/docs/tempo/v1.2.x/getting-started/tempo-in-grafana/#tempo-search) for details.
+* **Scalable monolithic deployment mode (formerly scalable single binary deployment mode)** The new [scalable monolithic](/docs/tempo/v1.2.x/operations/deployment/#scalable-monolithic) deployment mode is operationally simpler, although less robust than a fully distributed deployment. We consider it a balanced operational mode that some may find attractive.
 * **Massive performance improvements** were achieved by more efficiently batching trace data being ingested. In terms of CPU needed, Tempo v1.2 is twice as efficient as Tempo v1.1. Refer to [PR 1075](https://github.com/grafana/tempo/pull/1075) for details.
 * **API improvements** Some informational endpoints were consolidated within the [`status` endpoint](https://grafana.com/docs/tempo/latest/api_docs/#status). New endpoints were also added.
 
@@ -20,7 +20,7 @@ When upgrading to Tempo v1.2, be aware of these changes:
 
 * Support for v0 and v1 blocks were dropped as announced with Tempo v1.1. Refer to the [Tempo v1.1 changelog](https://github.com/grafana/tempo/releases/tag/v1.1.0) for details.
 * [PR 1007](https://github.com/grafana/tempo/pull/1007) altered the Querier API. When upgrading components within a deployment, there will be a read outage until all queriers and query frontends have rolled to the upgraded version.
-* API improvements consolidated informational endpoints within the [`status` endpoint](https://grafana.com/docs/tempo/latest/api_docs/#status).
+* API improvements consolidated informational endpoints within the [`status` endpoint](https://grafana.com/docs/tempo/v1.2.x/api_docs/#status).
 * Metric `ingester_bytes_metric_total` is renamed `ingester_bytes_received_total` by [PR 979](https://github.com/grafana/tempo/pull/979).
 * Metric `cortex_runtime_config_last_reload_successful` is renamed `tempo_runtime_config_last_reload_successful` by [PR 945](https://github.com/grafana/tempo/pull/945).
 * The `tempo-cli` flag `--storage.trace.maintenance-cycle` is renamed  `-storage.trace.blocklist_poll` by [PR 897](https://github.com/grafana/tempo/pull/897).
@@ -37,5 +37,5 @@ When upgrading to Tempo v1.2, be aware of these changes:
 * Fixed errors with magic numbers and other block mishandling when an ingester forcefully shuts down.  [Issue #937](https://github.com/grafana/tempo/issues/937) (@mdisibio)
 * Fixed a memory leak in the compactor component.  [PR #806](https://github.com/grafana/tempo/pull/806) (@mdisibio)
 * Set a span's tag `span.kind` to `client` in query-frontend to allow query frontend spans to be paired with querier server spans. [PR #975](https://github.com/grafana/tempo/pull/975) (@mapno)
-*  Metric `tempodb_backend_hedged_roundtrips_total` now correctly counts hedged roundtrips. [PR #1079](https://github.com/grafana/tempo/pull/1079) (@joe-elliott) 
+*  Metric `tempodb_backend_hedged_roundtrips_total` now correctly counts hedged roundtrips. [PR #1079](https://github.com/grafana/tempo/pull/1079) (@joe-elliott)
 * Updated the `go-kit` logger package to remove spurious debug logs. [PR #1094](https://github.com/grafana/tempo/pull/1094) (@bboreham)

--- a/docs/sources/tempo/setup/_index.md
+++ b/docs/sources/tempo/setup/_index.md
@@ -9,27 +9,30 @@ weight: 300
 
 # Set up Tempo
 
-Tempo can deployed in one of three modes:
+To set up Tempo, you need to:
 
-- monolithic
-- scalable monolithic
-- microservices
-
-Grafana Tempo is available as a pre-compiled binary, a Docker image, and as common OS-specific packaging.
+1. Plan your deployment
+1. Deploy Tempo
+1. Test your installation
+1. (Optional) Configure Tempo services
 
 ## Plan your deployment
 
 How you choose to deploy Tempo depends upon your tracing needs.
+Tempo has two deployment modes: monolithic or microservices.
+
 Read [Plan your deployment]({{< relref "./deployment" >}}) to determine the best method to deploy Tempo.
 
 ## Deploy Tempo
 
-Once you have decided how to deploy Tempo to best meet your needs, you can install and set up Tempo. The Plan your deployment topic links to multiple examples for installing Tempo in
+Once you have decided how to deploy Tempo, you can install and set up Tempo. For additional samples, refer to the [Example setups]({{< relref "../getting-started/example-demo-app" >}}) topic.
+
+Grafana Tempo is available as a [pre-compiled binary, OS_specific packaging](https://github.com/grafana/tempo/releases), and [Docker image](https://github.com/grafana/tempo/tree/main/example/docker-compose).
 
 The following procedures provide example Tempo deployments that you can use as a starting point:
 
-- [Deploy on Kubernetes using Helm](/docs/helm-charts/tempo-distributed/next/)
-- [Deploy on Linux]({{< relref "linux">}})
+- [Deploy on Kubernetes using Helm](/docs/helm-charts/tempo-distributed/next/) (microservices)
+- [Deploy on Linux]({{< relref "linux">}}) (monolithic)
 - [Deploy on Kubernetes using Tanka]({{< relref "tanka">}})
 
 You can also use Docker to deploy Tempo using [the Docker examples](https://github.com/grafana/tempo/tree/main/example/docker-compose).
@@ -40,3 +43,9 @@ Once Tempo is deployed, you can test Tempo by visualizing traces data:
 
 - Using a [test application for a Tempo cluster]({{< relref "set-up-test-app" >}}) for the Kubernetes with Tanka setup
 - Using a [Docker example]({{< relref "linux">}}) to test the Linux setup
+
+These visualizations test Kubernetes with Tanka and Linux procedures. They do not check optional configuration you have enabled.
+
+## (Optional) Configure Tempo services
+
+Explore Tempo's features by learning about [available features and configurations]({{< relref "../configuration" >}}).

--- a/docs/sources/tempo/setup/_index.md
+++ b/docs/sources/tempo/setup/_index.md
@@ -31,9 +31,9 @@ Grafana Tempo is available as a [pre-compiled binary, OS_specific packaging](htt
 
 The following procedures provide example Tempo deployments that you can use as a starting point:
 
-- [Deploy on Kubernetes using Helm](/docs/helm-charts/tempo-distributed/next/) (microservices)
+- [Deploy with Helm]({{< relref "helm-chart" >}}) (microservices and monolithic)
 - [Deploy on Linux]({{< relref "linux">}}) (monolithic)
-- [Deploy on Kubernetes using Tanka]({{< relref "tanka">}})
+- [Deploy on Kubernetes using Tanka]({{< relref "tanka">}}) (microservices)
 
 You can also use Docker to deploy Tempo using [the Docker examples](https://github.com/grafana/tempo/tree/main/example/docker-compose).
 

--- a/docs/sources/tempo/setup/_index.md
+++ b/docs/sources/tempo/setup/_index.md
@@ -1,25 +1,30 @@
 ---
-title: Set up a Tempo server or cluster
-menuTitle: Set up a Tempo server or cluster
-description: Learn how to set up a Tempo server or cluster and visualize data
+title: Set up Tempo
+menuTitle: Set up Tempo
+description: Learn how to set up a Tempo server or cluster and visualize data.
 aliases:
 - /docs/tempo/setup
 weight: 300
 ---
 
-# Set up a Tempo server or cluster
+# Set up
 
-Tempo is available as a pre-compiled binary, a Docker image, and as common OS-specific packaging.
+Tempo can deployed in one of three modes:
 
-This section describes how to set up Tempo on a single Linux node or as a cluster using Kubernetes and Tanka. Tempo can also be set up as a distributed set of services.
+- monolithic
+- scalable monolithic
+- microservices
 
-This page highlights these steps; more detailed instructions are available on the procedures for installing Tempo.
+Grafana Tempo is available as a pre-compiled binary, a Docker image, and as common OS-specific packaging.
 
 ## Deploy Tempo
 
-Choose a method to deploy Tempo:
+How you choose to deploy Tempo depends upon your tracing needs.
+Read [Plan your deployment]({{< relref "./deployment" >}}) to determine the best method to deploy Tempo.
 
-- [Deploy on Kubernetes using Helm](/docs/helm-charts/tempo-distributed/next/)
+THe following procedures provide example Tempo deployments that you can use as a starting point:
+
+- Microservices: [Deploy on Kubernetes using Helm](/docs/helm-charts/tempo-distributed/next/)
 - [Deploy on Linux]({{< relref "linux">}})
 - [Deploy on Kubernetes using Tanka]({{< relref "tanka">}})
 

--- a/docs/sources/tempo/setup/_index.md
+++ b/docs/sources/tempo/setup/_index.md
@@ -7,7 +7,7 @@ aliases:
 weight: 300
 ---
 
-# Set up
+# Set up Tempo
 
 Tempo can deployed in one of three modes:
 
@@ -17,14 +17,18 @@ Tempo can deployed in one of three modes:
 
 Grafana Tempo is available as a pre-compiled binary, a Docker image, and as common OS-specific packaging.
 
-## Deploy Tempo
+## Plan your deployment
 
 How you choose to deploy Tempo depends upon your tracing needs.
 Read [Plan your deployment]({{< relref "./deployment" >}}) to determine the best method to deploy Tempo.
 
-THe following procedures provide example Tempo deployments that you can use as a starting point:
+## Deploy Tempo
 
-- Microservices: [Deploy on Kubernetes using Helm](/docs/helm-charts/tempo-distributed/next/)
+Once you have decided how to deploy Tempo to best meet your needs, you can install and set up Tempo. The Plan your deployment topic links to multiple examples for installing Tempo in
+
+The following procedures provide example Tempo deployments that you can use as a starting point:
+
+- [Deploy on Kubernetes using Helm](/docs/helm-charts/tempo-distributed/next/)
 - [Deploy on Linux]({{< relref "linux">}})
 - [Deploy on Kubernetes using Tanka]({{< relref "tanka">}})
 

--- a/docs/sources/tempo/setup/deployment.md
+++ b/docs/sources/tempo/setup/deployment.md
@@ -10,35 +10,6 @@ weight: 10
 
 # Plan your Tempo deployment
 
-Tempo can be easily deployed through a number of tools as explained in this document.
-
-> **Note**: The Tanka and Helm examples are equivalent.
-> They are both provided for people who prefer different configuration mechanisms.
-
-## Tanka/Jsonnet
-
-The Jsonnet files that you need to deploy Tempo with Tanka are available here:
-
-- [monolithic mode](https://github.com/grafana/tempo/tree/main/operations/jsonnet/single-binary)
-- [microservices mode](https://github.com/grafana/tempo/tree/main/operations/jsonnet/microservices)
-
-Here are a few [examples](https://github.com/grafana/tempo/tree/main/example/tk) that use official Jsonnet files.
-They display the full range of configurations available to Tempo.
-
-## Helm
-
-Helm charts are available in the grafana/helm-charts repo:
-
-- [monolithic mode](https://github.com/grafana/helm-charts/tree/main/charts/tempo)
-- [microservices mode](https://github.com/grafana/helm-charts/tree/main/charts/tempo-distributed) and [`tempo-distributed` documentation](/docs/helm-charts/tempo-distributed/next/)
-
-## Kubernetes manifests
-
-You can find a collection of Kubernetes manifests to deploy Tempo in the
-[operations/jsonnet-compiled](https://github.com/grafana/tempo/tree/main/operations/jsonnet-compiled)
-folder.  These are generated using the Tanka / Jsonnet.
-
-## Deployment scenarios
 
 Tempo can be deployed in one of three modes:
 
@@ -101,3 +72,34 @@ instance.
 Find a docker-compose deployment example at:
 
 - [https://github.com/grafana/tempo/tree/main/example/docker-compose/distributed](https://github.com/grafana/tempo/tree/main/example/docker-compose/distributed)
+
+## Tools used to deploy Tempo
+
+Tempo can be easily deployed through a number of tools, including Helm, Tanka, Kubernetes, and Docker.
+
+> **Note**: The Tanka and Helm examples are equivalent.
+> They are both provided for people who prefer different configuration mechanisms.
+
+### Helm
+
+Helm charts are available in the grafana/helm-charts repo:
+
+- [monolithic mode](https://github.com/grafana/helm-charts/tree/main/charts/tempo)
+- [microservices mode](https://github.com/grafana/helm-charts/tree/main/charts/tempo-distributed) and [`tempo-distributed` documentation](/docs/helm-charts/tempo-distributed/next/)
+
+## Tanka/Jsonnet
+
+The Jsonnet files that you need to deploy Tempo with Tanka are available here:
+
+- [monolithic mode](https://github.com/grafana/tempo/tree/main/operations/jsonnet/single-binary)
+- [microservices mode](https://github.com/grafana/tempo/tree/main/operations/jsonnet/microservices)
+
+Here are a few [examples](https://github.com/grafana/tempo/tree/main/example/tk) that use official Jsonnet files.
+They display the full range of configurations available to Tempo.
+
+
+### Kubernetes manifests
+
+You can find a collection of Kubernetes manifests to deploy Tempo in the
+[operations/jsonnet-compiled](https://github.com/grafana/tempo/tree/main/operations/jsonnet-compiled)
+folder.  These are generated using the Tanka/Jsonnet.

--- a/docs/sources/tempo/setup/deployment.md
+++ b/docs/sources/tempo/setup/deployment.md
@@ -10,20 +10,15 @@ weight: 10
 
 # Plan your Tempo deployment
 
+Tempo can be deployed in _monolithic_ or _microservices_ modes.
 
-Tempo can be deployed in one of three modes:
-
-- monolithic
-- scalable monolithic
-- microservices
-
-Which mode is deployed is determined by the runtime configuration `target`, or
+The deployment mode is determined by the runtime configuration `target`, or
 by using the `-target` flag on the command line. The default target is `all`,
 which is the monolithic deployment mode.
 
-> **Note:** _Monolithic mode_ was previously called _single binary mode_. Similarly _scalable monolithic mode_ was previously called _scalable single binary mode_. While the documentation has been updated to reflect this change, some URL names and deployment tooling (e.g. Helm charts) do not yet reflect this change.
+> **Note:** _Monolithic mode_ was previously called _single binary mode_. Similarly _scalable monolithic mode_ was previously called _scalable single binary mode_. While the documentation has been updated to reflect this change, some URL names and deployment tooling (for example, Helm charts) do not yet reflect this change.
 
-### Monolithic
+## Monolithic mode
 
 Monolithic mode deployment runs all top-level components in a single
 process, forming an instance of Tempo.  The monolithic mode is the simplest
@@ -38,32 +33,30 @@ Find docker-compose deployment examples at:
 - [https://github.com/grafana/tempo/tree/main/example/docker-compose/local](https://github.com/grafana/tempo/tree/main/example/docker-compose/local)
 - [https://github.com/grafana/tempo/tree/main/example/docker-compose/s3](https://github.com/grafana/tempo/tree/main/example/docker-compose/s3)
 
-### Scalable monolithic
+### Scaling monolithic mode
 
-Scalable monolithic mode is similar to the monolithic mode in
-that all components are run within one process. Horizontal scale out is
-achieved by instantiating more than one process, with each having `-target` set to `scalable-single-binary`.
+Monolithic mode can be horizontally scaled out.
+This scalable monolithic mode is similar to the monolithic mode in that all components are run within one process.
+Horizontal scale out is achieved by instantiating more than one process, with each having `-target` set to `scalable-single-binary`.
 
-This mode offers some
-flexibility of scaling without the configuration complexity of the full
+This mode offers some flexibility of scaling without the configuration complexity of the full
 microservices deployment.
 
-Each of the `queriers` will perform a DNS lookup for the `frontend_address` and
-connect to the addresses found within the DNS record.
+Each of the `queriers` perform a DNS lookup for the `frontend_address` and connect to the addresses found within the DNS record.
 
 Find a docker-compose deployment example at:
 
 - [https://github.com/grafana/tempo/tree/main/example/docker-compose/scalable-single-binary](https://github.com/grafana/tempo/tree/main/example/docker-compose/scalable-single-binary)
 
-### Microservices
+## Microservices mode
 
-In microservices mode, components are deployed in distinct processes.  Scaling
-is per component, which allows for greater flexibility in scaling and more
+In microservices mode, components are deployed in distinct processes.
+Scaling is per component, which allows for greater flexibility in scaling and more
 granular failure domains. This is the preferred method for a production
 deployment, but it is also the most complex.
 
 The configuration associated with each component's deployment specifies a
-`target`.  For example, to deploy a `querier`, the configuration would contain
+`target`. For example, to deploy a `querier`, the configuration would contain
 `target: querier`.  A command-line deployment may specify the `-target=querier`
 flag. Each of the components referenced in [Architecture]({{< relref
 "../operations/architecture" >}}) must be deployed in order to get a working Tempo
@@ -82,10 +75,12 @@ Tempo can be easily deployed through a number of tools, including Helm, Tanka, K
 
 ### Helm
 
-Helm charts are available in the grafana/helm-charts repo:
+Helm charts are available in the `grafana/helm-charts` repository:
 
 - [monolithic mode](https://github.com/grafana/helm-charts/tree/main/charts/tempo)
-- [microservices mode](https://github.com/grafana/helm-charts/tree/main/charts/tempo-distributed) and [`tempo-distributed` documentation](/docs/helm-charts/tempo-distributed/next/)
+- [microservices mode](https://github.com/grafana/helm-charts/tree/main/charts/tempo-distributed) and [`tempo-distributed` chart documentation](/docs/helm-charts/tempo-distributed/next/)
+
+In addition, several Helm chart examples are available in the Tempo repository.
 
 ## Tanka/Jsonnet
 

--- a/docs/sources/tempo/setup/deployment.md
+++ b/docs/sources/tempo/setup/deployment.md
@@ -2,10 +2,10 @@
 title: Plan your Tempo deployment
 menuTitle: Plan your deployment
 aliases:
-  - /docs/tempo/latest/deployment
-  - /docs/tempo/latest/deployment/deployment
-  - /docs/tempo/latest/setup/deployment
-weight: 10
+  - /docs/tempo/deployment
+  - /docs/tempo/deployment/deployment
+  - /docs/tempo/setup/deployment
+weight: 200
 ---
 
 # Plan your Tempo deployment

--- a/docs/sources/tempo/setup/deployment.md
+++ b/docs/sources/tempo/setup/deployment.md
@@ -5,7 +5,7 @@ aliases:
   - /docs/tempo/latest/deployment
   - /docs/tempo/latest/deployment/deployment
   - /docs/tempo/latest/setup/deployment
-weight: 30
+weight: 10
 ---
 
 # Plan your Tempo deployment

--- a/docs/sources/tempo/setup/deployment.md
+++ b/docs/sources/tempo/setup/deployment.md
@@ -1,12 +1,14 @@
 ---
-title: Deploying Tempo
+title: Plan your Tempo deployment
+menuTitle: Plan your deployment
 aliases:
   - /docs/tempo/latest/deployment
   - /docs/tempo/latest/deployment/deployment
+  - /docs/tempo/latest/setup/deployment
 weight: 30
 ---
 
-# Deploying Tempo
+# Plan your Tempo deployment
 
 Tempo can be easily deployed through a number of tools as explained in this document.
 
@@ -55,7 +57,7 @@ which is the monolithic deployment mode.
 Monolithic mode deployment runs all top-level components in a single
 process, forming an instance of Tempo.  The monolithic mode is the simplest
 to deploy, but can not horizontally scale out by increasing the quantity of
-components.  Refer to [Architecture]({{< relref "./architecture" >}}) for
+components.  Refer to [Architecture]({{< relref "../operations/architecture" >}}) for
 descriptions of the components.
 
 To enable this mode, `-target=all` is used, which is the default.
@@ -87,13 +89,13 @@ Find a docker-compose deployment example at:
 In microservices mode, components are deployed in distinct processes.  Scaling
 is per component, which allows for greater flexibility in scaling and more
 granular failure domains. This is the preferred method for a production
-deployment, but it is also the most complex
+deployment, but it is also the most complex.
 
 The configuration associated with each component's deployment specifies a
 `target`.  For example, to deploy a `querier`, the configuration would contain
 `target: querier`.  A command-line deployment may specify the `-target=querier`
 flag. Each of the components referenced in [Architecture]({{< relref
-"./architecture" >}}) must be deployed in order to get a working Tempo
+"../operations/architecture" >}}) must be deployed in order to get a working Tempo
 instance.
 
 Find a docker-compose deployment example at:

--- a/docs/sources/tempo/setup/helm-chart.md
+++ b/docs/sources/tempo/setup/helm-chart.md
@@ -6,9 +6,9 @@ weight: 350
 
 # Deploy Tempo with Helm
 
-The Helm charts for for Grafana Tempo and Grafana Enterprise Traces (GET) allows you to configure, install, and upgrade Grafana Tempo or Grafana Enterprise Traces within a Kubernetes cluster.
+The Helm charts for Grafana Tempo and Grafana Enterprise Traces allows you to configure, install, and upgrade Grafana Tempo or Grafana Enterprise Traces within a Kubernetes cluster.
 
-The Helm [example](https://github.com/grafana/tempo/tree/main/example/helm) shows a complete microservice based deployment.
+The Tempo repository has an [example Helm chart](https://github.com/grafana/tempo/tree/main/example/helm) that shows a complete microservice-based deployment.
 
 Tempo has two primary charts used for deployment:
 

--- a/docs/sources/tempo/setup/helm-chart.md
+++ b/docs/sources/tempo/setup/helm-chart.md
@@ -1,0 +1,18 @@
+---
+title: Deploy Tempo with Helm
+menuTitle: Deploy with Helm
+weight: 350
+---
+
+# Deploy Tempo with Helm
+
+The Helm charts for for Grafana Tempo and Grafana Enterprise Traces (GET) allows you to configure, install, and upgrade Grafana Tempo or Grafana Enterprise Traces within a Kubernetes cluster.
+
+The Helm [example](https://github.com/grafana/tempo/tree/main/example/helm) shows a complete microservice based deployment.
+
+Tempo has two primary charts used for deployment:
+
+* [`tempo-distributed` Helm chart](https://github.com/grafana/helm-charts/tree/main/charts/tempo-distributed) deploys Tempo in microservices mode
+* [`tempo` Helm chart](https://github.com/grafana/helm-charts/tree/main/charts/tempo) deploys Tempo in monolithic (single binary) mode
+
+To deploy Tempo using the `tempo-distributed` Helm chart, read the [Get started with Grafana Tempo using Helm]({{< relref "/docs/helm-charts/tempo-distributed/next/get-started-helm-charts/" >}}).

--- a/docs/sources/tempo/setup/linux.md
+++ b/docs/sources/tempo/setup/linux.md
@@ -2,7 +2,7 @@
 title: Deploy on Linux
 menuTitle: Deploy on Linux
 description: Learn how to deploy Tempo on Linux
-weight: 25
+weight: 400
 ---
 
 # Deploy on Linux

--- a/docs/sources/tempo/setup/linux.md
+++ b/docs/sources/tempo/setup/linux.md
@@ -2,7 +2,7 @@
 title: Deploy on Linux
 menuTitle: Deploy on Linux
 description: Learn how to deploy Tempo on Linux
-weight: 100
+weight: 25
 ---
 
 # Deploy on Linux

--- a/docs/sources/tempo/setup/linux.md
+++ b/docs/sources/tempo/setup/linux.md
@@ -11,7 +11,7 @@ This guide provides a step-by-step process for installing Tempo on Linux.
 It assumes you have access to a Linux system and the permissions required to deploy a service with network and file system access.
 At the end of this guide, you will have deployed a single Tempo instance on a single node.
 
-These instructions focus on a single binary install. You can also run Tempo in distributed mode by deploying multiple binaries and using a distributed configuration.
+These instructions focus on a [monolithic installation]({{< relref "./deployment" >}}). You can also run Tempo in distributed mode by deploying multiple binaries and using a distributed configuration.
 
 ## Before you begin
 

--- a/docs/sources/tempo/setup/set-up-test-app.md
+++ b/docs/sources/tempo/setup/set-up-test-app.md
@@ -2,7 +2,7 @@
 title: Set up a test app for a Tempo cluster
 menuTitle: Set up a test application for a Tempo cluster
 description: Learn how to set up a test app for your Tempo cluster and visualize data.
-weight: 400
+weight: 50
 ---
 
 # Set up a test application for a Tempo cluster

--- a/docs/sources/tempo/setup/set-up-test-app.md
+++ b/docs/sources/tempo/setup/set-up-test-app.md
@@ -2,12 +2,14 @@
 title: Set up a test app for a Tempo cluster
 menuTitle: Set up a test application for a Tempo cluster
 description: Learn how to set up a test app for your Tempo cluster and visualize data.
-weight: 50
+weight: 600
 ---
 
 # Set up a test application for a Tempo cluster
 
 Once you've set up a Grafana Tempo cluster, you need to write some traces to it and then query the traces from within Grafana.
+This procedure uses Tempo in microservices mode.
+For example, if you [set up Tempo using the Kubernetes with Tanka procedure]({{< relref "./tanka" >}}), then you can use this procedure to test your set up.
 
 ## Before you begin
 

--- a/docs/sources/tempo/setup/tanka.md
+++ b/docs/sources/tempo/setup/tanka.md
@@ -1,6 +1,6 @@
 ---
 title: Deploy on Kubernetes with Tanka
-weight: 200
+weight: 40
 ---
 
 # Deploy on Kubernetes with Tanka

--- a/docs/sources/tempo/setup/tanka.md
+++ b/docs/sources/tempo/setup/tanka.md
@@ -1,6 +1,7 @@
 ---
 title: Deploy on Kubernetes with Tanka
-weight: 40
+menuTitle: Deploy on Kubernetes with Tanka
+weight: 500
 ---
 
 # Deploy on Kubernetes with Tanka
@@ -399,4 +400,4 @@ The Tempo instance will now accept the two configured trace protocols (OTLP gRPC
 
 You can query Tempo using the `query-frontend.tempo.svc.cluster.local` service on port `3200` for Tempo queries or port `16686` or `16687` for Jaeger type queries.
 
-Now that you've configured a Tempo cluster, you'll need to get data into it.
+Now that you've configured a Tempo cluster, you'll need to get data into it. Read the [Set up a test app]({{< relref "./set-up-test-app">}}) for instructions.

--- a/docs/sources/tempo/setup/upgrade.md
+++ b/docs/sources/tempo/setup/upgrade.md
@@ -2,7 +2,7 @@
 title: Upgrade your Tempo installation
 menuTitle: Upgrade
 description: Upgrade your Tempo installation to the latest version.
-weight: 20
+weight: 310
 ---
 
 # Upgrade Tempo

--- a/docs/sources/tempo/setup/upgrade.md
+++ b/docs/sources/tempo/setup/upgrade.md
@@ -2,7 +2,7 @@
 title: Upgrade your Tempo installation
 menuTitle: Upgrade
 description: Upgrade your Tempo installation to the latest version.
-weight: 75
+weight: 20
 ---
 
 # Upgrade Tempo
@@ -33,7 +33,7 @@ Once you upgrade to Tempo 2.0, there is no path to downgrade.
 
 ### Check Tempo installation resource allocation
 
-Parquet provides faster search and is required to enable TraceQL. However, the Tempo installation will require additional CPU and memory resources to use Parquet efficiently. Parquet is more costly due to the extra work of building the columnar blocks, and operators should expect at least 1.5x increase in required resources to run a Tempo 2.0 cluster. Most users will find these extra resources are negligible compared to the benefits that come from the additional features of TraceQL and from storing traces in an open format. 
+Parquet provides faster search and is required to enable TraceQL. However, the Tempo installation will require additional CPU and memory resources to use Parquet efficiently. Parquet is more costly due to the extra work of building the columnar blocks, and operators should expect at least 1.5x increase in required resources to run a Tempo 2.0 cluster. Most users will find these extra resources are negligible compared to the benefits that come from the additional features of TraceQL and from storing traces in an open format.
 
 You can can continue using the previous `v2` block format using the instructions provided in the [Parquet configuration documentation]({{< relref "../configuration/parquet/" >}}). Tempo will continue to support trace by id lookup on the `v2` format for the foreseeable future.
 

--- a/docs/sources/tempo/traces.md
+++ b/docs/sources/tempo/traces.md
@@ -39,7 +39,7 @@ That trace ID enables one to trace, or follow a request as it flows from node to
 
 Here's an example showing two pages in Grafana Cloud. The first, on the left (1), shows a query using the **Explore** feature. In the query results you can see a **traceID** field that was added to an application. That field contains a **Tempo** trace ID. The second page, on the right (2), uses the same Explore feature to perform a Tempo search using that **trace ID**. It then shows a set of spans as horizontal bars, each bar denoting a different part of the system.
 
-<p align="center"><img src="../assets/trace-explore-spans.png" alt="Trace example"></p>
+<p align="center"><img src="../getting-started/assets/trace-explore-spans.png" alt="Trace example"></p>
 
 The trace ID is applied to activities recorded as metrics and as logs.
 


### PR DESCRIPTION
**What this PR does**:

Restructures the Set up TOC content and moves the deployment page to the Set up folder. Also, fixes a missing image and some links. 

**Which issue(s) this PR fixes**:
Completes part of #2223 

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`