### PR TITLE
Support float as duration in traceql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
   This prevents invalid values from showing up for intrinsics like `status` [#2219](https://github.com/grafana/tempo/pull/2152) (@joe-elliott)
 * [BUGFIX] Correctly return unique spans when &&ing and ||ing spansets. [#2254](https://github.com/grafana/tempo/pull/2254) (@joe-elliott)
 * [BUGFIX] Support negative values on aggregate filters like `count() > -1`. [#2289](https://github.com/grafana/tempo/pull/2289) (@joe-elliott)
+* [BUGFIX] Support float as duration like `{duration > 1.5s}` [#2304]https://github.com/grafana/tempo/pull/2304 (@ie-pham)
 
 ## v2.0.1 / 2023-03-03
 

--- a/pkg/traceql/lexer.go
+++ b/pkg/traceql/lexer.go
@@ -142,8 +142,17 @@ func (l *lexer) Lex(lval *yySymType) int {
 		return INTEGER
 
 	case scanner.Float:
+		numberText := l.TokenText()
+
+		// first try to parse as duration
+		duration, ok := tryScanDuration(numberText, &l.Scanner)
+		if ok {
+			lval.staticDuration = duration
+			return DURATION
+		}
+		
 		var err error
-		lval.staticFloat, err = strconv.ParseFloat(l.TokenText(), 64)
+		lval.staticFloat, err = strconv.ParseFloat(numberText, 64)
 		if err != nil {
 			l.Error(err.Error())
 			return 0

--- a/pkg/traceql/lexer.go
+++ b/pkg/traceql/lexer.go
@@ -150,7 +150,7 @@ func (l *lexer) Lex(lval *yySymType) int {
 			lval.staticDuration = duration
 			return DURATION
 		}
-		
+
 		var err error
 		lval.staticFloat, err = strconv.ParseFloat(numberText, 64)
 		if err != nil {

--- a/pkg/traceql/lexer_test.go
+++ b/pkg/traceql/lexer_test.go
@@ -61,7 +61,7 @@ func TestLexerAttributes(t *testing.T) {
 		{`. foo`, []int{DOT, END_ATTRIBUTE, IDENTIFIER}},
 		// not attributes
 		{`.3`, []int{FLOAT}},
-		{`.24h`, []int{FLOAT, IDENTIFIER}},
+		{`.24h`, []int{DURATION}},
 	}))
 }
 

--- a/pkg/traceql/parse_test.go
+++ b/pkg/traceql/parse_test.go
@@ -630,6 +630,7 @@ func TestSpansetFilterStatics(t *testing.T) {
 		{in: "{ 1.234 }", expected: NewStaticFloat(1.234)},
 		{in: "{ nil }", expected: NewStaticNil()},
 		{in: "{ 3h }", expected: NewStaticDuration(3 * time.Hour)},
+		{in: "{ 1.5m }", expected: NewStaticDuration(1 * time.Minute + 30 * time.Second)},
 		{in: "{ error }", expected: NewStaticStatus(StatusError)},
 		{in: "{ ok }", expected: NewStaticStatus(StatusOk)},
 		{in: "{ unset }", expected: NewStaticStatus(StatusUnset)},

--- a/pkg/traceql/parse_test.go
+++ b/pkg/traceql/parse_test.go
@@ -630,7 +630,7 @@ func TestSpansetFilterStatics(t *testing.T) {
 		{in: "{ 1.234 }", expected: NewStaticFloat(1.234)},
 		{in: "{ nil }", expected: NewStaticNil()},
 		{in: "{ 3h }", expected: NewStaticDuration(3 * time.Hour)},
-		{in: "{ 1.5m }", expected: NewStaticDuration(1 * time.Minute + 30 * time.Second)},
+		{in: "{ 1.5m }", expected: NewStaticDuration(1*time.Minute + 30*time.Second)},
 		{in: "{ error }", expected: NewStaticStatus(StatusError)},
 		{in: "{ ok }", expected: NewStaticStatus(StatusOk)},
 		{in: "{ unset }", expected: NewStaticStatus(StatusUnset)},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: Support float as duration in traceql

**Which issue(s) this PR fixes**:
Fixes [#2180](https://github.com/grafana/tempo/issues/2180)

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`