### PR TITLE
Fix VERSION in Drone Builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Version number
-VERSION=$(shell ./tools/image-tag | cut -d, -f 1)
+VERSION := $(shell ./tools/image-tag | cut -d, -f 1)
 
 GIT_REVISION := $(shell git rev-parse --short HEAD)
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
**What this PR does**:
Attempts to fix VERSION in Drone image builds.

VERSION is empty when we are building binaries in Drone `GO111MODULE=on CGO_ENABLED=0 go build -mod vendor -ldflags "-X main.Branch=main -X main.Revision=dc670f461 -X main.Version=" -o ./bin/linux/tempo-arm64  ./cmd/tempo`, but it works fine when tesing locally.

Drone is not evalulating and setting VERSION, so this PR makes it VERSION assignment same as GIT_REVISION, and GIT_BRANCH, which are working in Drone

I have not way to test it locally and have to build it on Drone to test it out. I tested it locally and it works fine with and without this change.



**Which issue(s) this PR fixes**:
Maybe #2283 & #1908

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`