### PR TITLE
Really fix VERSION in Drone Builds

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -106,7 +106,7 @@ local build_binaries(arch) = {
   name: 'build-tempo-binaries',
   image: 'golang:1.20-alpine',
   commands: [
-    'apk add make git',
+    'apk --update --no-cache add make git bash',
   ] + [
     'COMPONENT=%s GOARCH=%s make exe' % [app, arch]
     for app in apps

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -13,7 +13,7 @@ steps:
   image: alpine/git:v2.30.2
   name: image-tag
 - commands:
-  - apk add make git
+  - apk --update --no-cache add make git bash
   - COMPONENT=tempo GOARCH=amd64 make exe
   - COMPONENT=tempo-vulture GOARCH=amd64 make exe
   - COMPONENT=tempo-query GOARCH=amd64 make exe
@@ -73,7 +73,7 @@ steps:
   image: alpine/git:v2.30.2
   name: image-tag
 - commands:
-  - apk add make git
+  - apk --update --no-cache add make git bash
   - COMPONENT=tempo GOARCH=arm64 make exe
   - COMPONENT=tempo-vulture GOARCH=arm64 make exe
   - COMPONENT=tempo-query GOARCH=arm64 make exe
@@ -422,6 +422,6 @@ kind: secret
 name: gpg_passphrase
 ---
 kind: signature
-hmac: 66d14ceba8885ceea66b6ab4274103b80ee5aff0323b6c5a496a844a2ce998ae
+hmac: d92429ebb30ec062362d88387f0e22d2b3c1dc9c6ac5ae5960494f4ab4089a7c
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Version number
-VERSION := $(shell ./tools/image-tag | cut -d, -f 1)
+VERSION=$(shell ./tools/image-tag | cut -d, -f 1)
 
 GIT_REVISION := $(shell git rev-parse --short HEAD)
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
**What this PR does**:

`tools/image-tag` script needs bash and it was failing because `golang:1.20-alpine` image used in `build-tempo-binaries` step
is missing bash

due to missing bash `./tools/image-tag` was failing with `env: can't execute 'bash': No such file or directory` and
producing tempo binaries with missing version tag

Tested this locally by building tempo in `golang:1.20-alpine` with bash, and it works ✨ 

here is what I see `GO111MODULE=on CGO_ENABLED=0 go build -mod vendor -ldflags "-X main.Branch=really_fix_version -X main.Revision=53c3e6e9a -X main.Version=really_fix_version-53c3e6e-WIP" -o ./bin/linux/tempo-amd64  ./cmd/tempo` when running `COMPONENT=tempo GOARCH=amd64 make exe` in `golang:1.20-alpine` with bash

#2312 didn't work, so reverted changes made in #2312

**Which issue(s) this PR fixes**:
Maybe #2283 & #1908

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`