### PR TITLE
Fix Distributor Forwarder flaky test

### DIFF
--- a/modules/distributor/forwarder/otlpgrpc/forwarder_test.go
+++ b/modules/distributor/forwarder/otlpgrpc/forwarder_test.go
@@ -208,10 +208,15 @@ func Test_Forwarder_Dial_ReturnsErrorWithCancelledContext(t *testing.T) {
 	l := newListener(t, nil)
 	d := newContextDialer(l)
 	ctx, cancel := context.WithCancel(context.Background())
+
+	// Ensure the server is ready
+	err := f.Dial(ctx, grpc.WithContextDialer(d), grpc.WithBlock(), grpc.FailOnNonTempDialError(true))
+	require.NoError(t, err)
+
 	cancel()
 
 	// When
-	err := f.Dial(ctx, grpc.WithContextDialer(d), grpc.WithBlock(), grpc.FailOnNonTempDialError(true))
+	err = f.Dial(ctx, grpc.WithContextDialer(d), grpc.WithBlock(), grpc.FailOnNonTempDialError(true))
 
 	// Then
 	require.Error(t, err)


### PR DESCRIPTION
**What this PR does**:  Avoid that `Test_Forwarder_Dial_ReturnsErrorWithCancelledContext` randomly fails, ensuring the server is ready before canceling the context. To verify that the test is not flaky anymore, this can be run:

```
go test -v -run Test_Forwarder_Dial_ReturnsErrorWithCancelledContext  ./modules/distributor/forwarder/otlpgrpc/ -count 10000  
```

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

cc @Blinkuu 