### PR TITLE
Break up CI tests into pkg, tempodb, tempodb/wal and others

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           version: v1.51.0
 
-  unit-tests:
+  unit-tests-pkg:
     name: Test packages - pkg
     runs-on: ubuntu-latest
     steps:
@@ -63,7 +63,7 @@ jobs:
       - name: Test
         run: make test-with-cover-pkg
 
-  unit-tests:
+  unit-tests-tempodb:
     name: Test packages - tempodb
     runs-on: ubuntu-latest
     steps:
@@ -78,7 +78,7 @@ jobs:
       - name: Test
         run: make test-with-cover-tempodb
 
-  unit-tests:
+  unit-tests-others:
     name: Test packages - others
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         run: make test-with-cover-pkg
 
   unit-tests-tempodb:
-    name: Test packages - tempodb (excluding tempodb/wal)
+    name: Test packages - tempodb
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,21 @@ jobs:
       - name: Test
         run: make test-with-cover-tempodb
 
+  unit-tests-tempodb-wal:
+    name: Test packages - tempodb/wal
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.20
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.20.x
+
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Test
+        run: make test-with-cover-tempodb-wal
+
   unit-tests-others:
     name: Test packages - others
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         run: make test-with-cover-pkg
 
   unit-tests-tempodb:
-    name: Test packages - tempodb
+    name: Test packages - tempodb (excluding tempodb/wal)
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,8 @@ jobs:
         with:
           version: v1.51.0
 
-
   unit-tests:
-    name: Test packages
+    name: Test packages - pkg
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.20
@@ -62,7 +61,37 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Test
-        run: make test-with-cover
+        run: make test-with-cover-pkg
+
+  unit-tests:
+    name: Test packages - tempodb
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.20
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.20.x
+
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Test
+        run: make test-with-cover-tempodb
+
+  unit-tests:
+    name: Test packages - others
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.20
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.20.x
+
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Test
+        run: make test-with-cover-others
 
   integration-tests:
     name: Test integration e2e suite

--- a/Makefile
+++ b/Makefile
@@ -98,15 +98,15 @@ test-with-cover: test-serverless
 	$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) $(ALL_PKGS)
 
 .PHONY: test-with-cover-pkg
-test-with-cover:
+test-with-cover-pkg:
 	$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) $(shell go list $(sort $(dir $(shell find . -name '*.go' -path './pkg*/*' -type f | sort))))
 
 .PHONY: test-with-cover-tempodb
-test-with-cover:
+test-with-cover-tempodb:
 	$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) $(shell go list $(sort $(dir $(shell find . -name '*.go' -path './tempodb*/*' -type f | sort))))
 
 .PHONY: test-with-cover-others
-test-with-cover: test-serverless
+test-with-cover-others: test-serverless
 	$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) $(shell go list $(sort $(dir $(OTHERS_SRC))))
 
 # runs e2e tests in the top level integration/e2e directory

--- a/Makefile
+++ b/Makefile
@@ -92,19 +92,27 @@ test:
 benchmark:
 	$(GOTEST) -bench=. -run=notests $(ALL_PKGS)
 
-# Not using it in CI, tests are split in pkg, tempodb and others
+# Not used in CI, tests are split in pkg, tempodb, tempodb-wal and others in CI jobs
 .PHONY: test-with-cover
 test-with-cover: test-serverless
 	$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) $(ALL_PKGS)
 
+# tests in pkg
 .PHONY: test-with-cover-pkg
 test-with-cover-pkg:
 	$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) $(shell go list $(sort $(dir $(shell find . -name '*.go' -path './pkg*/*' -type f | sort))))
 
+# tests in tempodb (excluding tempodb/wal)
 .PHONY: test-with-cover-tempodb
 test-with-cover-tempodb:
-	$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) $(shell go list $(sort $(dir $(shell find . -name '*.go' -path './tempodb*/*' -type f | sort))))
+	$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) $(shell go list $(sort $(dir $(shell find . -name '*.go'  -not -path './tempodb/wal*/*' -path './tempodb*/*' -type f | sort))))
 
+# tests in tempodb/wal
+.PHONY: test-with-cover-tempodb-wal
+test-with-cover-tempodb-wal:
+	$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) $(shell go list $(sort $(dir $(shell find . -name '*.go' -path './tempodb/wal*/*' -type f | sort))))
+
+# all other tests (excluding pkg & tempodb)
 .PHONY: test-with-cover-others
 test-with-cover-others: test-serverless
 	$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) $(shell go list $(sort $(dir $(OTHERS_SRC))))

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ ifeq ($(BUILD_DEBUG), 1)
 	GO_OPT+= -gcflags="all=-N -l"
 endif
 
-GOTEST_OPT?= -race -timeout 30m -count=1 -v
+GOTEST_OPT?= -race -timeout 20m -count=1 -v
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -cover
 GOTEST=go test
 LINT=golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,15 @@ ALL_SRC := $(shell find . -name '*.go' \
 								-not -path './cmd/tempo-serverless/*' \
                                 -type f | sort)
 
+# ALL_SRC but without pkg and tempodb packages
+OTHERS_SRC := $(shell find . -name '*.go' \
+								-not -path './vendor*/*' \
+								-not -path './integration/*' \
+								-not -path './cmd/tempo-serverless/*' \
+								-not -path './pkg*/*' \
+								-not -path './tempodb*/*' \
+                                -type f | sort)
+
 # All source code and documents. Used in spell check.
 ALL_DOC := $(shell find . \( -name "*.md" -o -name "*.yaml" \) \
                                 -type f | sort)
@@ -83,9 +92,22 @@ test:
 benchmark:
 	$(GOTEST) -bench=. -run=notests $(ALL_PKGS)
 
+# Not using it in CI, tests are split in pkg, tempodb and others
 .PHONY: test-with-cover
 test-with-cover: test-serverless
 	$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) $(ALL_PKGS)
+
+.PHONY: test-with-cover-pkg
+test-with-cover:
+	$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) $(shell go list $(sort $(dir $(shell find . -name '*.go' -path './pkg*/*' -type f | sort))))
+
+.PHONY: test-with-cover-tempodb
+test-with-cover:
+	$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) $(shell go list $(sort $(dir $(shell find . -name '*.go' -path './tempodb*/*' -type f | sort))))
+
+.PHONY: test-with-cover-others
+test-with-cover: test-serverless
+	$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) $(shell go list $(sort $(dir $(OTHERS_SRC))))
 
 # runs e2e tests in the top level integration/e2e directory
 .PHONY: test-e2e

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ ifeq ($(BUILD_DEBUG), 1)
 	GO_OPT+= -gcflags="all=-N -l"
 endif
 
-GOTEST_OPT?= -race -timeout 30m -count=1
+GOTEST_OPT?= -race -timeout 30m -count=1 -v
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -cover
 GOTEST=go test
 LINT=golangci-lint


### PR DESCRIPTION
**What this PR does**:

Splits Single CI Test Job into 4 differrent CI Jobs (pkg, tempodb, tempodb/wal, and others) to make CI more stable and parallelize the test run.

Tempo grew and we added more tests, and test run time kept going up because we added more and more tests, this breaks CI test run into 4 different jobs to make it more managable and less flaky ✨ 

- changed `go test` to run with `-v` to print out test logs and more details like time take in each test case
- reduced `go test` `-timeout` to `20m`, now tests are split we should timeout early

**Timings:**

**before split:**
all - 22m23s

**after split into pkg, tempodb, and others:**
pkg - **3m23s**, with go test -v **2m39s**
tempodb - killed (SIGTERM) after 14m11s in first run, **20m15s** in second run, with go test -v **16m40s**
others - **9m13s**, with go test -v **7m45s**

**after split into pkg, tempodb, tempodb-wal, and others:**
pkg - with go test -v **2m58s**, **2m46s**
tempodb (without wal) - with go test -v **19m34s**, **16m4s**
tempodb-wal - with go test -v **10m7s**, **9m2s**
others - with go test -v failed after **8m3s** and **7m50**, and **8m2s** , and finally passed in **8m2s** after rerun
_- NOTE: it fails because of flaky `Test_counter` test_


 
**Which issue(s) this PR fixes**:
Issues of Tests taking too long and CI

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`