### PR TITLE
Docs: Fix duplicated key on example YAML

### DIFF
--- a/docs/sources/tempo/setup/tanka.md
+++ b/docs/sources/tempo/setup/tanka.md
@@ -314,12 +314,6 @@ Install the `k.libsonnet`, Jsonnet, and Memcachd libraries.
          },
        },
 
-       tempo_ingester_container+:: {
-         securityContext+: {
-           runAsUser: 0,
-         },
-       },
-
        local statefulSet = $.apps.v1.statefulSet,
        tempo_ingester_statefulset+:
            statefulSet.mixin.spec.withPodManagementPolicy('Parallel'),


### PR DESCRIPTION
**What this PR does**:
Fix tanka docs by removing duplicating key from example.