### PR TITLE
Use all encodings in WAL tests

### DIFF
--- a/tempodb/wal/wal_test.go
+++ b/tempodb/wal/wal_test.go
@@ -26,8 +26,6 @@ import (
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/grafana/tempo/tempodb/encoding/common"
-	v2 "github.com/grafana/tempo/tempodb/encoding/v2"
-	"github.com/grafana/tempo/tempodb/encoding/vparquet"
 )
 
 const (
@@ -55,11 +53,7 @@ func TestCompletedDirIsRemoved(t *testing.T) {
 }
 
 func TestAppendBlockStartEnd(t *testing.T) {
-	encodings := []encoding.VersionedEncoding{
-		v2.Encoding{},
-		vparquet.Encoding{},
-	}
-	for _, e := range encodings {
+	for _, e := range encoding.AllEncodings() {
 		t.Run(e.Version(), func(t *testing.T) {
 			testAppendBlockStartEnd(t, e)
 		})
@@ -116,11 +110,7 @@ func testAppendBlockStartEnd(t *testing.T, e encoding.VersionedEncoding) {
 }
 
 func TestIngestionSlack(t *testing.T) {
-	encodings := []encoding.VersionedEncoding{
-		v2.Encoding{},
-		vparquet.Encoding{},
-	}
-	for _, e := range encodings {
+	for _, e := range encoding.AllEncodings() {
 		t.Run(e.Version(), func(t *testing.T) {
 			testIngestionSlack(t, e)
 		})


### PR DESCRIPTION
**What this PR does**:

The WAL tests only run with the block encodings `v2` and `vParquet`. This change makes sure that the tests use all available block encodings.

**Which issue(s) this PR fixes**:

None

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`