### PR TITLE
[DOC] Remove duplicate link from instrumentation

### DIFF
--- a/docs/sources/tempo/getting-started/_index.md
+++ b/docs/sources/tempo/getting-started/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Get started
-menuTitle: Get started with Grafana Tempo
+menuTitle: Get started
 weight: 200
 aliases:
 - /docs/tempo/getting-started

--- a/docs/sources/tempo/getting-started/instrumentation.md
+++ b/docs/sources/tempo/getting-started/instrumentation.md
@@ -25,10 +25,6 @@ You should pick one according to your application needs.
 * [Zipkin](https://zipkin.io/pages/tracers_instrumentation)
 * [OpenTelemetry](https://opentelemetry.io/docs/concepts/instrumenting/)
 
-
-> **Note**: Check out the [instrumentation references]({{< relref "./instrumentation" >}}) to learn how to instrument your
-> favorite language for distributed tracing.
-
 ### OpenTelemetry auto-instrumentation
 
 Some languages have support for auto-instrumentation. These libraries capture telemetry


### PR DESCRIPTION
**What this PR does**:
Remove a note with a link to the instrumentation page that is on the instrumentation page. 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`