### PR TITLE
Propogate Compaction Error

### DIFF
--- a/modules/compactor/compactor.go
+++ b/modules/compactor/compactor.go
@@ -160,7 +160,10 @@ func (c *Compactor) starting(ctx context.Context) (err error) {
 func (c *Compactor) running(ctx context.Context) error {
 	if !c.cfg.Disabled {
 		level.Info(log.Logger).Log("msg", "enabling compaction")
-		c.store.EnableCompaction(ctx, &c.cfg.Compactor, c, c)
+		err := c.store.EnableCompaction(ctx, &c.cfg.Compactor, c, c)
+		if err != nil {
+			return fmt.Errorf("failed to enable compaction: %w", err)
+		}
 	}
 
 	if c.subservices != nil {

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -741,7 +741,7 @@ func benchmarkCompaction(b *testing.B, targetBlockVersion string) {
 		FlushSizeBytes:     10_000_000,
 		IteratorBufferSize: DefaultIteratorBufferSize,
 	}, &mockSharder{}, &mockOverrides{})
-	require.NoError(t, err)
+	require.NoError(b, err)
 
 	traceCount := 20_000
 	blockCount := 8

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -97,13 +97,14 @@ func testCompactionRoundtrip(t *testing.T, targetBlockVersion string) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	c.EnableCompaction(ctx, &CompactorConfig{
+	err = c.EnableCompaction(ctx, &CompactorConfig{
 		ChunkSizeBytes:          10_000_000,
 		FlushSizeBytes:          10_000_000,
 		MaxCompactionRange:      24 * time.Hour,
 		BlockRetention:          0,
 		CompactedBlockRetention: 0,
 	}, &mockSharder{}, &mockOverrides{})
+	require.NoError(t, err)
 
 	r.EnablePolling(&mockJobSharder{})
 
@@ -242,13 +243,14 @@ func testSameIDCompaction(t *testing.T, targetBlockVersion string) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	c.EnableCompaction(ctx, &CompactorConfig{
+	err = c.EnableCompaction(ctx, &CompactorConfig{
 		ChunkSizeBytes:          10_000_000,
 		MaxCompactionRange:      24 * time.Hour,
 		BlockRetention:          0,
 		CompactedBlockRetention: 0,
 		FlushSizeBytes:          10_000_000,
 	}, &mockSharder{}, &mockOverrides{})
+	require.NoError(t, err)
 
 	r.EnablePolling(&mockJobSharder{})
 
@@ -384,12 +386,13 @@ func TestCompactionUpdatesBlocklist(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	c.EnableCompaction(ctx, &CompactorConfig{
+	err = c.EnableCompaction(ctx, &CompactorConfig{
 		ChunkSizeBytes:          10,
 		MaxCompactionRange:      24 * time.Hour,
 		BlockRetention:          0,
 		CompactedBlockRetention: 0,
 	}, &mockSharder{}, &mockOverrides{})
+	require.NoError(t, err)
 
 	r.EnablePolling(&mockJobSharder{})
 
@@ -454,12 +457,13 @@ func TestCompactionMetrics(t *testing.T) {
 	assert.NoError(t, err)
 
 	ctx := context.Background()
-	c.EnableCompaction(ctx, &CompactorConfig{
+	err = c.EnableCompaction(ctx, &CompactorConfig{
 		ChunkSizeBytes:          10,
 		MaxCompactionRange:      24 * time.Hour,
 		BlockRetention:          0,
 		CompactedBlockRetention: 0,
 	}, &mockSharder{}, &mockOverrides{})
+	require.NoError(t, err)
 
 	r.EnablePolling(&mockJobSharder{})
 
@@ -527,7 +531,7 @@ func TestCompactionIteratesThroughTenants(t *testing.T) {
 	assert.NoError(t, err)
 
 	ctx := context.Background()
-	c.EnableCompaction(ctx, &CompactorConfig{
+	err = c.EnableCompaction(ctx, &CompactorConfig{
 		ChunkSizeBytes:          10,
 		MaxCompactionRange:      24 * time.Hour,
 		MaxCompactionObjects:    1000,
@@ -535,6 +539,7 @@ func TestCompactionIteratesThroughTenants(t *testing.T) {
 		BlockRetention:          0,
 		CompactedBlockRetention: 0,
 	}, &mockSharder{}, &mockOverrides{})
+	require.NoError(t, err)
 
 	r.EnablePolling(&mockJobSharder{})
 
@@ -599,13 +604,14 @@ func testCompactionHonorsBlockStartEndTimes(t *testing.T, targetBlockVersion str
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	c.EnableCompaction(ctx, &CompactorConfig{
+	err = c.EnableCompaction(ctx, &CompactorConfig{
 		ChunkSizeBytes:          10_000_000,
 		FlushSizeBytes:          10_000_000,
 		MaxCompactionRange:      24 * time.Hour,
 		BlockRetention:          0,
 		CompactedBlockRetention: 0,
 	}, &mockSharder{}, &mockOverrides{})
+	require.NoError(t, err)
 
 	r.EnablePolling(&mockJobSharder{})
 
@@ -730,11 +736,12 @@ func benchmarkCompaction(b *testing.B, targetBlockVersion string) {
 	rw := c.(*readerWriter)
 
 	ctx := context.Background()
-	c.EnableCompaction(ctx, &CompactorConfig{
+	err = c.EnableCompaction(ctx, &CompactorConfig{
 		ChunkSizeBytes:     10_000_000,
 		FlushSizeBytes:     10_000_000,
 		IteratorBufferSize: DefaultIteratorBufferSize,
 	}, &mockSharder{}, &mockOverrides{})
+	require.NoError(t, err)
 
 	traceCount := 20_000
 	blockCount := 8

--- a/tempodb/retention_test.go
+++ b/tempodb/retention_test.go
@@ -43,12 +43,13 @@ func TestRetention(t *testing.T) {
 	assert.NoError(t, err)
 
 	ctx := context.Background()
-	c.EnableCompaction(ctx, &CompactorConfig{
+	err = c.EnableCompaction(ctx, &CompactorConfig{
 		ChunkSizeBytes:          10,
 		MaxCompactionRange:      time.Hour,
 		BlockRetention:          0,
 		CompactedBlockRetention: 0,
 	}, &mockSharder{}, &mockOverrides{})
+	require.NoError(t, err)
 
 	r.EnablePolling(&mockJobSharder{})
 
@@ -106,12 +107,13 @@ func TestRetentionUpdatesBlocklistImmediately(t *testing.T) {
 
 	r.EnablePolling(&mockJobSharder{})
 
-	c.EnableCompaction(context.Background(), &CompactorConfig{
+	err = c.EnableCompaction(context.Background(), &CompactorConfig{
 		ChunkSizeBytes:          10,
 		MaxCompactionRange:      time.Hour,
 		BlockRetention:          0,
 		CompactedBlockRetention: 0,
 	}, &mockSharder{}, &mockOverrides{})
+	require.NoError(t, err)
 
 	wal := w.WAL()
 	assert.NoError(t, err)
@@ -175,12 +177,13 @@ func TestBlockRetentionOverride(t *testing.T) {
 	overrides := &mockOverrides{}
 
 	ctx := context.Background()
-	c.EnableCompaction(ctx, &CompactorConfig{
+	err = c.EnableCompaction(ctx, &CompactorConfig{
 		ChunkSizeBytes:          10,
 		MaxCompactionRange:      time.Hour,
 		BlockRetention:          time.Hour,
 		CompactedBlockRetention: 0,
 	}, &mockSharder{}, overrides)
+	require.NoError(t, err)
 
 	r.EnablePolling(&mockJobSharder{})
 

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -394,7 +394,7 @@ func (rw *readerWriter) EnableCompaction(ctx context.Context, cfg *CompactorConf
 
 	if rw.cfg.BlocklistPoll == 0 {
 		level.Info(rw.logger).Log("msg", "polling cycle unset. compaction and retention disabled")
-		return
+		return nil
 	}
 
 	if cfg != nil {
@@ -402,6 +402,8 @@ func (rw *readerWriter) EnableCompaction(ctx context.Context, cfg *CompactorConf
 		go rw.compactionLoop(ctx)
 		go rw.retentionLoop(ctx)
 	}
+
+	return nil
 }
 
 // EnablePolling activates the polling loop. Pass nil if this component

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -85,7 +85,7 @@ type Reader interface {
 }
 
 type Compactor interface {
-	EnableCompaction(ctx context.Context, cfg *CompactorConfig, sharder CompactorSharder, overrides CompactorOverrides)
+	EnableCompaction(ctx context.Context, cfg *CompactorConfig, sharder CompactorSharder, overrides CompactorOverrides) error
 }
 
 type CompactorSharder interface {
@@ -376,12 +376,11 @@ func (rw *readerWriter) Shutdown() {
 }
 
 // EnableCompaction activates the compaction/retention loops
-func (rw *readerWriter) EnableCompaction(ctx context.Context, cfg *CompactorConfig, c CompactorSharder, overrides CompactorOverrides) {
+func (rw *readerWriter) EnableCompaction(ctx context.Context, cfg *CompactorConfig, c CompactorSharder, overrides CompactorOverrides) error {
 	// If compactor configuration is not as expected, no need to go any further
 	err := cfg.validate()
 	if err != nil {
-		level.Error(log.Logger).Log(err.Error())
-		return
+		return err
 	}
 
 	// Set default if needed. This is mainly for tests.

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -330,12 +330,13 @@ func runCompleteBlockSearchTest(t testing.TB, blockVersion string, runner runner
 	}, log.NewNopLogger())
 	require.NoError(t, err)
 
-	c.EnableCompaction(context.Background(), &CompactorConfig{
+	err = c.EnableCompaction(context.Background(), &CompactorConfig{
 		ChunkSizeBytes:          10,
 		MaxCompactionRange:      time.Hour,
 		BlockRetention:          0,
 		CompactedBlockRetention: 0,
 	}, &mockSharder{}, &mockOverrides{})
+	require.NoError(t, err)
 
 	r.EnablePolling(&mockJobSharder{})
 	rw := r.(*readerWriter)

--- a/tempodb/tempodb_test.go
+++ b/tempodb/tempodb_test.go
@@ -67,12 +67,13 @@ func testConfig(t *testing.T, enc backend.Encoding, blocklistPoll time.Duration,
 func TestDB(t *testing.T) {
 	r, w, c, _ := testConfig(t, backend.EncGZIP, 0)
 
-	c.EnableCompaction(context.Background(), &CompactorConfig{
+	err := c.EnableCompaction(context.Background(), &CompactorConfig{
 		ChunkSizeBytes:          10,
 		MaxCompactionRange:      time.Hour,
 		BlockRetention:          0,
 		CompactedBlockRetention: 0,
 	}, &mockSharder{}, &mockOverrides{})
+	require.NoError(t, err)
 
 	r.EnablePolling(&mockJobSharder{})
 
@@ -113,9 +114,10 @@ func TestDB(t *testing.T) {
 func TestNoCompactionWhenCompactionRange0(t *testing.T) {
 	_, _, c, _ := testConfig(t, backend.EncGZIP, 0)
 
-	c.EnableCompaction(context.Background(), &CompactorConfig{
+	err := c.EnableCompaction(context.Background(), &CompactorConfig{
 		MaxCompactionRange: 0,
 	}, &mockSharder{}, &mockOverrides{})
+	require.NoError(t, err)
 
 	rw := c.(*readerWriter)
 
@@ -185,12 +187,13 @@ func TestNilOnUnknownTenantID(t *testing.T) {
 func TestBlockCleanup(t *testing.T) {
 	r, w, c, tempDir := testConfig(t, backend.EncLZ4_256k, 0)
 
-	c.EnableCompaction(context.Background(), &CompactorConfig{
+	err := c.EnableCompaction(context.Background(), &CompactorConfig{
 		ChunkSizeBytes:          10,
 		MaxCompactionRange:      time.Hour,
 		BlockRetention:          0,
 		CompactedBlockRetention: 0,
 	}, &mockSharder{}, &mockOverrides{})
+	require.NoError(t, err)
 
 	r.EnablePolling(&mockJobSharder{})
 
@@ -515,12 +518,13 @@ func TestIncludeCompactedBlock(t *testing.T) {
 func TestSearchCompactedBlocks(t *testing.T) {
 	r, w, c, _ := testConfig(t, backend.EncLZ4_256k, time.Hour)
 
-	c.EnableCompaction(context.Background(), &CompactorConfig{
+	err := c.EnableCompaction(context.Background(), &CompactorConfig{
 		ChunkSizeBytes:          10,
 		MaxCompactionRange:      time.Hour,
 		BlockRetention:          0,
 		CompactedBlockRetention: 0,
 	}, &mockSharder{}, &mockOverrides{})
+	require.NoError(t, err)
 
 	r.EnablePolling(&mockJobSharder{})
 

--- a/tempodb/tempodb_test.go
+++ b/tempodb/tempodb_test.go
@@ -117,12 +117,7 @@ func TestNoCompactionWhenCompactionRange0(t *testing.T) {
 	err := c.EnableCompaction(context.Background(), &CompactorConfig{
 		MaxCompactionRange: 0,
 	}, &mockSharder{}, &mockOverrides{})
-	require.NoError(t, err)
-
-	rw := c.(*readerWriter)
-
-	assert.Equal(t, 0, len(rw.blocklist.Tenants()))
-	assert.Equal(t, 0, len(rw.blocklist.Metas(testTenantID)))
+	require.Error(t, err)
 }
 
 func TestBlockSharding(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:
Correctly propagates the compaction error out to the compactor. If the compactor is misconfigured it now logs:

```
level=error ts=2023-04-17T21:03:51.787335269Z caller=app.go:202 msg="module failed" module=compactor err="invalid service state: Failed, expected: Running, failure: failed to enable compaction: Compaction window can't be 0"
```

and exits cleanly.

