### PR TITLE
Add example of finding a trace by its ID

### DIFF
--- a/docs/sources/tempo/traceql/_index.md
+++ b/docs/sources/tempo/traceql/_index.md
@@ -283,6 +283,14 @@ It's a convenient request to identify misconfigurations and leaks across product
 { resource.deployment.environment = "production" } && { resource.deployment.environment = "staging" }
 ```
 
+### Find traces by trace ID
+
+Find any trace with trace ID `1a2b3c4e5f678901`:
+
+```
+1a2b3c4e5f678901
+```
+
 ### Other examples
 
 Find any trace with a `deployment.environment` attribute set to `production` and `http.status_code` attribute set to `200`:


### PR DESCRIPTION
**What this PR does**:

It wasn't immediately clear to me by looking at [the TraceQL docs](https://grafana.com/docs/tempo/latest/traceql/) how I can search for a trace by its ID, so this PR adds an example of how to do that.

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [n/a] Tests updated
- [x] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`