### PR TITLE
Plumb s3 dial context options into the config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [ENHANCEMENT] Add override to limit number of blocks inspected in tag value search [#2358](https://github.com/grafana/tempo/pull/2358) (@mapno)
 * [ENHANCEMENT] Add synchronous read mode to vParquet and vParquet2 optionally enabled by env vars  [#2165](https://github.com/grafana/tempo/pull/2165) (@mdisibio)
 * [ENHANCEMENT] Add option to override metrics-generator ring port  [#2399](https://github.com/grafana/tempo/pull/2399) (@mdisibio)
+* [ENHANCEMENT] Add configuration for S3 dial timeout [#2349](https://github.com/grafana/tempo/pull/2349) (@zalegrala)
 * [BUGFIX] tempodb integer divide by zero error [#2167](https://github.com/grafana/tempo/issues/2167) (@kroksys)
 * [BUGFIX] Fix issue where Tempo sometimes flips booleans from false->true at storage time. [#2400](https://github.com/grafana/tempo/issues/2400) (@joe-elliott)
 

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -716,6 +716,17 @@ storage:
             # See the [S3 documentation on object tagging](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html) for more detail.
             [tags: <map[string]string>]
 
+            # Optional
+            # Example: "dial_timeout: 30s"
+            # The HTTP transport configuration for dial timeout.  Timeout is the maximum amount of time a dial will wait for a connection to complete.
+            [dial_timeout: <duration>]
+
+            # Optional
+            # Example: "dial_keepalive: 30s"
+            # The HTTP transport configuration for dial keepalive.  Keepaliave specifies the interval between keep-aliave probes for an active network connection.
+            [dial_keepalive: <duration>]
+
+
         # azure configuration. Will be used only if value of backend is "azure"
         # EXPERIMENTAL
         azure:

--- a/modules/storage/config.go
+++ b/modules/storage/config.go
@@ -81,6 +81,8 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	f.Var(&cfg.Trace.S3.SecretKey, util.PrefixConfig(prefix, "trace.s3.secret_key"), "s3 secret key.")
 	f.Var(&cfg.Trace.S3.SessionToken, util.PrefixConfig(prefix, "trace.s3.session_token"), "s3 session token.")
 	cfg.Trace.S3.HedgeRequestsUpTo = 2
+	f.DurationVar(&cfg.Trace.S3.DialTimeout, util.PrefixConfig(prefix, "trace.s3.dial_timeout"), 30*time.Second, "s3 dial timeout.")
+	f.DurationVar(&cfg.Trace.S3.DialKeepAlive, util.PrefixConfig(prefix, "trace.s3.dial_keepalive"), 30*time.Second, "s3 dial keepalive.")
 
 	cfg.Trace.GCS = &gcs.Config{}
 	f.StringVar(&cfg.Trace.GCS.BucketName, util.PrefixConfig(prefix, "trace.gcs.bucket"), "", "gcs bucket to store traces in.")

--- a/tempodb/backend/s3/config.go
+++ b/tempodb/backend/s3/config.go
@@ -26,7 +26,6 @@ type Config struct {
 	Tags             map[string]string `yaml:"tags"`
 	StorageClass     string            `yaml:"storage_class"`
 	Metadata         map[string]string `yaml:"metadata"`
-
-	DialTimeout   time.Duration `yaml:"dial_timeout"`
-	DialKeepAlive time.Duration `yaml:"dial_keepalive"`
+	DialTimeout      time.Duration     `yaml:"dial_timeout"`
+	DialKeepAlive    time.Duration     `yaml:"dial_keepalive"`
 }

--- a/tempodb/backend/s3/config.go
+++ b/tempodb/backend/s3/config.go
@@ -26,4 +26,7 @@ type Config struct {
 	Tags             map[string]string `yaml:"tags"`
 	StorageClass     string            `yaml:"storage_class"`
 	Metadata         map[string]string `yaml:"metadata"`
+
+	DialTimeout   time.Duration `yaml:"dial_timeout"`
+	DialKeepAlive time.Duration `yaml:"dial_keepalive"`
 }

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"path"
 	"strings"
@@ -375,6 +376,11 @@ func createCore(cfg *Config, hedge bool) (*minio.Core, error) {
 	if cfg.InsecureSkipVerify {
 		customTransport.TLSClientConfig.InsecureSkipVerify = true
 	}
+
+	customTransport.DialContext = (&net.Dialer{
+		Timeout:   cfg.DialTimeout,
+		KeepAlive: cfg.DialKeepAlive,
+	}).DialContext
 
 	// add instrumentation
 	transport := instrumentation.NewTransport(customTransport)


### PR DESCRIPTION
**What this PR does**:

Here we allow the dial context of the HTTPTransport for S3 to be modified.  Default values here were taken from the Minio client default transport.

**Which issue(s) this PR fixes**:
Fixes #2346

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`