### PR TITLE
Enhancement: Allow configuring a prefix path for s3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [ENHANCEMENT] Add `prefix` configuration option to `storage.trace.s3` [#2362](https://github.com/grafana/tempo/pull/2362) (@kousikmitra)
 * [FEATURE] Add support for `q` query param in `/api/v2/search/<tag.name>/values` to filter results based on a TraceQL query [#2253](https://github.com/grafana/tempo/pull/2253) (@mapno)
 * [ENHANCEMENT] Add `scope` parameter to `/api/search/tags` [#2282](https://github.com/grafana/tempo/pull/2282) (@joe-elliott)
   Create new endpoint `/api/v2/search/tags` that returns all tags organized by scope.

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -651,6 +651,11 @@ storage:
             # a custom prefix to nest within a shared bucket.
             [bucket: <string>]
 
+            # Prefix name in s3
+            # Tempo has this additional option to support a custom prefix to nest all
+            # the objects withing a shared bucket.
+            [prefix: <string>]
+
             # api endpoint to connect to. use AWS S3 or any S3 compatible object storage endpoint.
             # Example: "endpoint: s3.dualstack.us-east-2.amazonaws.com"
             [endpoint: <string>]

--- a/modules/storage/config.go
+++ b/modules/storage/config.go
@@ -75,6 +75,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 
 	cfg.Trace.S3 = &s3.Config{}
 	f.StringVar(&cfg.Trace.S3.Bucket, util.PrefixConfig(prefix, "trace.s3.bucket"), "", "s3 bucket to store blocks in.")
+	f.StringVar(&cfg.Trace.S3.Prefix, util.PrefixConfig(prefix, "trace.s3.prefix"), "", "s3 root directory to store blocks in.")
 	f.StringVar(&cfg.Trace.S3.Endpoint, util.PrefixConfig(prefix, "trace.s3.endpoint"), "", "s3 endpoint to push blocks to.")
 	f.StringVar(&cfg.Trace.S3.AccessKey, util.PrefixConfig(prefix, "trace.s3.access_key"), "", "s3 access key.")
 	f.Var(&cfg.Trace.S3.SecretKey, util.PrefixConfig(prefix, "trace.s3.secret_key"), "s3 secret key.")

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -225,6 +225,15 @@ func ObjectFileName(keypath KeyPath, name string) string {
 	return path.Join(path.Join(keypath...), name)
 }
 
+// KeyPathWithPrefix returns a keypath with a prefix
+func KeyPathWithPrefix(keypath KeyPath, prefix string) KeyPath {
+	if len(prefix) == 0 {
+		return keypath
+	}
+
+	return append([]string{prefix}, keypath...)
+}
+
 // MetaFileName returns the object name for the block meta given a block id and tenantid
 func MetaFileName(blockID uuid.UUID, tenantID string) string {
 	return path.Join(RootPath(blockID, tenantID), MetaName)

--- a/tempodb/backend/s3/config.go
+++ b/tempodb/backend/s3/config.go
@@ -8,6 +8,7 @@ import (
 
 type Config struct {
 	Bucket             string         `yaml:"bucket"`
+	Prefix             string         `yaml:"prefix"`
 	Endpoint           string         `yaml:"endpoint"`
 	Region             string         `yaml:"region"`
 	AccessKey          string         `yaml:"access_key"`

--- a/tempodb/backend/s3/s3_test.go
+++ b/tempodb/backend/s3/s3_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const getMethod = "GET"
+const putMethod = "PUT"
 const tagHeader = "X-Amz-Tagging"
 const storageClassHeader = "X-Amz-Storage-Class"
 
@@ -126,7 +128,7 @@ func fakeServerWithHeader(t *testing.T, obj *url.Values, testedHeaderName string
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch method := r.Method; method {
-		case "PUT":
+		case putMethod:
 			// https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
 			switch testedHeaderValue := r.Header.Get(testedHeaderName); testedHeaderValue {
 			case "":
@@ -136,7 +138,7 @@ func fakeServerWithHeader(t *testing.T, obj *url.Values, testedHeaderName string
 				require.NoError(t, err)
 				*obj = value
 			}
-		case "GET":
+		case getMethod:
 			// return fake list response b/c it's the only call that has to succeed
 			_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
 		<ListBucketResult>
@@ -206,7 +208,7 @@ func TestObjectWithPrefix(t *testing.T) {
 			keyPath:    backend.KeyPath{"test"},
 			httpHandler: func(t *testing.T) http.HandlerFunc {
 				return func(w http.ResponseWriter, r *http.Request) {
-					if r.Method == "GET" {
+					if r.Method == getMethod {
 						assert.Equal(t, r.URL.Query().Get("prefix"), "test_storage")
 
 						_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
@@ -226,7 +228,7 @@ func TestObjectWithPrefix(t *testing.T) {
 			keyPath:    backend.KeyPath{"test"},
 			httpHandler: func(t *testing.T) http.HandlerFunc {
 				return func(w http.ResponseWriter, r *http.Request) {
-					if r.Method == "GET" {
+					if r.Method == getMethod {
 						assert.Equal(t, r.URL.Query().Get("prefix"), "")
 
 						_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>

--- a/tempodb/backend/s3/s3_test.go
+++ b/tempodb/backend/s3/s3_test.go
@@ -258,7 +258,8 @@ func TestObjectWithPrefix(t *testing.T) {
 			require.NoError(t, err)
 
 			ctx := context.Background()
-			_ = w.Write(ctx, tc.objectName, tc.keyPath, bytes.NewReader([]byte{}), 0, false)
+			err = w.Write(ctx, tc.objectName, tc.keyPath, bytes.NewReader([]byte{}), 0, false)
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/tempodb/backend/s3/s3_test.go
+++ b/tempodb/backend/s3/s3_test.go
@@ -131,6 +131,7 @@ func fakeServerWithHeader(t *testing.T, obj *url.Values, testedHeaderName string
 			switch testedHeaderValue := r.Header.Get(testedHeaderName); testedHeaderValue {
 			case "":
 			default:
+
 				value, err := url.ParseQuery(testedHeaderValue)
 				require.NoError(t, err)
 				*obj = value
@@ -189,6 +190,77 @@ func TestObjectBlockTags(t *testing.T) {
 	}
 }
 
+func TestObjectWithPrefix(t *testing.T) {
+
+	tests := []struct {
+		name        string
+		prefix      string
+		objectName  string
+		keyPath     backend.KeyPath
+		httpHandler func(t *testing.T) http.HandlerFunc
+	}{
+		{
+			name:       "with prefix",
+			prefix:     "test_storage",
+			objectName: "object",
+			keyPath:    backend.KeyPath{"test"},
+			httpHandler: func(t *testing.T) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == "GET" {
+						assert.Equal(t, r.URL.Query().Get("prefix"), "test_storage")
+
+						_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+						<ListBucketResult>
+						</ListBucketResult>`))
+						return
+					}
+
+					assert.Equal(t, r.URL.String(), "/blerg/test_storage/test/object")
+				}
+			},
+		},
+		{
+			name:       "without prefix",
+			prefix:     "",
+			objectName: "object",
+			keyPath:    backend.KeyPath{"test"},
+			httpHandler: func(t *testing.T) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == "GET" {
+						assert.Equal(t, r.URL.Query().Get("prefix"), "")
+
+						_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+						<ListBucketResult>
+						</ListBucketResult>`))
+						return
+					}
+
+					assert.Equal(t, r.URL.String(), "/blerg/test/object")
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := testServer(t, tc.httpHandler(t))
+			_, w, _, err := New(&Config{
+				Region:    "blerg",
+				AccessKey: "test",
+				SecretKey: flagext.SecretWithValue("test"),
+				Bucket:    "blerg",
+				Prefix:    tc.prefix,
+				Insecure:  true,
+				Endpoint:  server.URL[7:],
+			})
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			_ = w.Write(ctx, tc.objectName, tc.keyPath, bytes.NewReader([]byte{}), 0, false)
+		})
+	}
+}
+
 func TestObjectStorageClass(t *testing.T) {
 
 	tests := []struct {
@@ -223,4 +295,12 @@ func TestObjectStorageClass(t *testing.T) {
 			require.Equal(t, obj.Has(tc.StorageClass), true)
 		})
 	}
+}
+
+func testServer(t *testing.T, httpHandler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	assert.NotNil(t, httpHandler)
+	server := httptest.NewServer(httpHandler)
+	t.Cleanup(server.Close)
+	return server
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Enables storing blocks in shared s3 bucket with the prefix option.

<img width="692" alt="image" src="https://user-images.githubusercontent.com/15109533/234343411-0e954c81-ada5-4fd3-94e2-61f1be621d91.png">


**Which issue(s) this PR fixes**:
Fixes #2100 

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`