### PR TITLE
Update link to docs instead of outdated blog post

### DIFF
--- a/docs/sources/tempo/getting-started/_index.md
+++ b/docs/sources/tempo/getting-started/_index.md
@@ -43,7 +43,7 @@ a storage backend.
 The Grafana Agent also abstracts features like trace batching to a remote trace backend store, including retries on write failures.
 
 To learn more about the Grafana Agent and how to set it up for tracing with Tempo,
-refer to [this blog post](https://grafana.com/blog/2020/11/17/tracing-with-the-grafana-cloud-agent-and-grafana-tempo/).
+refer to [the Grafana Agent traces config docs](/docs/agent/latest/static/configuration/traces-config/).
 
 > **Note**: The [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector) / [Jaeger Agent](https://www.jaegertracing.io/docs/latest/deployment/) can also be used at the agent layer.
 > Refer to [this blog post](https://grafana.com/blog/2021/04/13/how-to-send-traces-to-grafana-clouds-tempo-service-with-opentelemetry-collector/)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
There's a link in the docs that refers to an outdated blog post. Linking the corresponding config page instead.

**Which issue(s) this PR fixes**:
Fixes #<issue number>
