### PR TITLE
New metrics generator processor to store a local copy of traces

### DIFF
--- a/cmd/tempo/app/config.go
+++ b/cmd/tempo/app/config.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/tempo/pkg/usagestats"
 	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/tempodb"
+	"github.com/grafana/tempo/tempodb/encoding/common"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weaveworks/common/server"
 )
@@ -156,11 +157,11 @@ func (c *Config) CheckConfig() []ConfigWarning {
 	}
 
 	// check v2 specific settings
-	if c.StorageConfig.Trace.Block.Version != "v2" && c.StorageConfig.Trace.Block.IndexDownsampleBytes != storage.DefaultIndexDownSampleBytes {
+	if c.StorageConfig.Trace.Block.Version != "v2" && c.StorageConfig.Trace.Block.IndexDownsampleBytes != common.DefaultIndexDownSampleBytes {
 		warnings = append(warnings, newV2Warning("v2_index_downsample_bytes"))
 	}
 
-	if c.StorageConfig.Trace.Block.Version != "v2" && c.StorageConfig.Trace.Block.IndexPageSizeBytes != storage.DefaultIndexPageSizeBytes {
+	if c.StorageConfig.Trace.Block.Version != "v2" && c.StorageConfig.Trace.Block.IndexPageSizeBytes != common.DefaultIndexPageSizeBytes {
 		warnings = append(warnings, newV2Warning("v2_index_page_size_bytes"))
 	}
 

--- a/modules/generator/config.go
+++ b/modules/generator/config.go
@@ -11,6 +11,8 @@ import (
 	"github.com/grafana/tempo/modules/generator/processor/spanmetrics"
 	"github.com/grafana/tempo/modules/generator/registry"
 	"github.com/grafana/tempo/modules/generator/storage"
+	"github.com/grafana/tempo/tempodb/encoding"
+	"github.com/grafana/tempo/tempodb/wal"
 )
 
 const (
@@ -27,6 +29,7 @@ type Config struct {
 	Processor ProcessorConfig `yaml:"processor"`
 	Registry  registry.Config `yaml:"registry"`
 	Storage   storage.Config  `yaml:"storage"`
+	TracesWAL wal.Config      `yaml:"traces_storage"`
 	// MetricsIngestionSlack is the max amount of time passed since a span's start time
 	// for the span to be considered in metrics generation
 	MetricsIngestionSlack time.Duration `yaml:"metrics_ingestion_time_range_slack"`
@@ -38,6 +41,8 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.Processor.RegisterFlagsAndApplyDefaults(prefix, f)
 	cfg.Registry.RegisterFlagsAndApplyDefaults(prefix, f)
 	cfg.Storage.RegisterFlagsAndApplyDefaults(prefix, f)
+	cfg.TracesWAL.Version = encoding.DefaultEncoding().Version()
+
 	// setting default for max span age before discarding to 30s
 	cfg.MetricsIngestionSlack = 30 * time.Second
 }

--- a/modules/generator/config.go
+++ b/modules/generator/config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/grafana/tempo/modules/generator/processor/localblocks"
 	"github.com/grafana/tempo/modules/generator/processor/servicegraphs"
 	"github.com/grafana/tempo/modules/generator/processor/spanmetrics"
 	"github.com/grafana/tempo/modules/generator/registry"
@@ -44,11 +45,13 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 type ProcessorConfig struct {
 	ServiceGraphs servicegraphs.Config `yaml:"service_graphs"`
 	SpanMetrics   spanmetrics.Config   `yaml:"span_metrics"`
+	LocalBlocks   localblocks.Config   `yaml:"local_blocks"`
 }
 
 func (cfg *ProcessorConfig) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 	cfg.ServiceGraphs.RegisterFlagsAndApplyDefaults(prefix, f)
 	cfg.SpanMetrics.RegisterFlagsAndApplyDefaults(prefix, f)
+	cfg.LocalBlocks.RegisterFlagsAndApplyDefaults(prefix, f)
 }
 
 // copyWithOverrides creates a copy of the config using values set in the overrides.

--- a/modules/generator/generator.go
+++ b/modules/generator/generator.go
@@ -275,7 +275,11 @@ func (g *Generator) createInstance(id string) (*instance, error) {
 		return nil, err
 	}
 
-	g.reg.Register(reg)
+	err = g.reg.Register(reg)
+	if err != nil {
+		wal.Close()
+		return nil, err
+	}
 
 	return inst, nil
 }

--- a/modules/generator/instance_test.go
+++ b/modules/generator/instance_test.go
@@ -26,7 +26,7 @@ import (
 
 func Test_instance_concurrency(t *testing.T) {
 	overrides := &mockOverrides{}
-	instance, err := newInstance(&Config{}, "test", overrides, &noopStorage{}, prometheus.DefaultRegisterer, log.NewNopLogger())
+	instance, err := newInstance(&Config{}, "test", overrides, &noopStorage{}, prometheus.DefaultRegisterer, log.NewNopLogger(), nil)
 	assert.NoError(t, err)
 
 	end := make(chan struct{})
@@ -76,7 +76,7 @@ func Test_instance_updateProcessors(t *testing.T) {
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
 	overrides := mockOverrides{}
 
-	instance, err := newInstance(&cfg, "test", &overrides, &noopStorage{}, prometheus.DefaultRegisterer, logger)
+	instance, err := newInstance(&cfg, "test", &overrides, &noopStorage{}, prometheus.DefaultRegisterer, logger, nil)
 	assert.NoError(t, err)
 
 	// stop the update goroutine

--- a/modules/generator/processor/localblocks/config.go
+++ b/modules/generator/processor/localblocks/config.go
@@ -23,7 +23,7 @@ type Config struct {
 func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 	cfg.FlushCheckPeriod = 5 * time.Second
 	cfg.MaxTraceIdle = 5 * time.Second
-	cfg.MaxBlockDuration = 15 * time.Minute
+	cfg.MaxBlockDuration = 1 * time.Minute
 	cfg.MaxBlockBytes = 500_000_000
-	cfg.CompleteBlockTimeout = time.Hour
+	cfg.CompleteBlockTimeout = 5 * time.Minute
 }

--- a/modules/generator/processor/localblocks/config.go
+++ b/modules/generator/processor/localblocks/config.go
@@ -17,7 +17,7 @@ type Config struct {
 	Block                *common.BlockConfig   `yaml:"block"`
 	Search               *tempodb.SearchConfig `yaml:"search"`
 	FlushCheckPeriod     time.Duration         `yaml:"flush_check_period"`
-	MaxTraceIdle         time.Duration         `yaml:"trace_idle_period"`
+	TraceIdlePeriod      time.Duration         `yaml:"trace_idle_period"`
 	MaxBlockDuration     time.Duration         `yaml:"max_block_duration"`
 	MaxBlockBytes        uint64                `yaml:"max_block_bytes"`
 	CompleteBlockTimeout time.Duration         `yaml:"complete_block_timeout"`
@@ -32,7 +32,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.Search.RegisterFlagsAndApplyDefaults(prefix, f)
 
 	cfg.FlushCheckPeriod = 5 * time.Second
-	cfg.MaxTraceIdle = 5 * time.Second
+	cfg.TraceIdlePeriod = 5 * time.Second
 	cfg.MaxBlockDuration = 1 * time.Minute
 	cfg.MaxBlockBytes = 500_000_000
 	cfg.CompleteBlockTimeout = 5 * time.Minute

--- a/modules/generator/processor/localblocks/config.go
+++ b/modules/generator/processor/localblocks/config.go
@@ -1,0 +1,29 @@
+package localblocks
+
+import (
+	"flag"
+	"time"
+
+	"github.com/grafana/tempo/tempodb/wal"
+)
+
+const (
+	Name = "local-blocks"
+)
+
+type Config struct {
+	WAL                  *wal.Config   `yaml:"wal"`
+	FlushCheckPeriod     time.Duration `yaml:"flush_check_period"`
+	MaxTraceIdle         time.Duration `yaml:"trace_idle_period"`
+	MaxBlockDuration     time.Duration `yaml:"max_block_duration"`
+	MaxBlockBytes        uint64        `yaml:"max_block_bytes"`
+	CompleteBlockTimeout time.Duration `yaml:"complete_block_timeout"`
+}
+
+func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
+	cfg.FlushCheckPeriod = 5 * time.Second
+	cfg.MaxTraceIdle = 5 * time.Second
+	cfg.MaxBlockDuration = 15 * time.Minute
+	cfg.MaxBlockBytes = 500_000_000
+	cfg.CompleteBlockTimeout = time.Hour
+}

--- a/modules/generator/processor/localblocks/config.go
+++ b/modules/generator/processor/localblocks/config.go
@@ -4,7 +4,9 @@ import (
 	"flag"
 	"time"
 
-	"github.com/grafana/tempo/tempodb/wal"
+	"github.com/grafana/tempo/tempodb"
+	"github.com/grafana/tempo/tempodb/encoding"
+	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
 const (
@@ -12,15 +14,23 @@ const (
 )
 
 type Config struct {
-	WAL                  *wal.Config   `yaml:"wal"`
-	FlushCheckPeriod     time.Duration `yaml:"flush_check_period"`
-	MaxTraceIdle         time.Duration `yaml:"trace_idle_period"`
-	MaxBlockDuration     time.Duration `yaml:"max_block_duration"`
-	MaxBlockBytes        uint64        `yaml:"max_block_bytes"`
-	CompleteBlockTimeout time.Duration `yaml:"complete_block_timeout"`
+	Block                *common.BlockConfig   `yaml:"block"`
+	Search               *tempodb.SearchConfig `yaml:"search"`
+	FlushCheckPeriod     time.Duration         `yaml:"flush_check_period"`
+	MaxTraceIdle         time.Duration         `yaml:"trace_idle_period"`
+	MaxBlockDuration     time.Duration         `yaml:"max_block_duration"`
+	MaxBlockBytes        uint64                `yaml:"max_block_bytes"`
+	CompleteBlockTimeout time.Duration         `yaml:"complete_block_timeout"`
 }
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
+	cfg.Block = &common.BlockConfig{}
+	cfg.Block.Version = encoding.DefaultEncoding().Version()
+	cfg.Block.RegisterFlagsAndApplyDefaults(prefix, f)
+
+	cfg.Search = &tempodb.SearchConfig{}
+	cfg.Search.RegisterFlagsAndApplyDefaults(prefix, f)
+
 	cfg.FlushCheckPeriod = 5 * time.Second
 	cfg.MaxTraceIdle = 5 * time.Second
 	cfg.MaxBlockDuration = 1 * time.Minute

--- a/modules/generator/processor/localblocks/livetraces.go
+++ b/modules/generator/processor/localblocks/livetraces.go
@@ -1,0 +1,62 @@
+package localblocks
+
+import (
+	"hash"
+	"hash/fnv"
+	"time"
+
+	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+)
+
+type liveTrace struct {
+	id        []byte
+	timestamp time.Time
+	Batches   []*v1.ResourceSpans
+}
+
+type liveTraces struct {
+	hash   hash.Hash64
+	traces map[uint64]*liveTrace
+}
+
+func NewLiveTraces() *liveTraces {
+	return &liveTraces{
+		hash:   fnv.New64(),
+		traces: map[uint64]*liveTrace{},
+	}
+}
+
+func (l *liveTraces) token(traceID []byte) uint64 {
+	l.hash.Reset()
+	l.hash.Write(traceID)
+	return l.hash.Sum64()
+}
+
+func (l *liveTraces) Push(batch *v1.ResourceSpans) {
+	traceID := batch.ScopeSpans[0].Spans[0].TraceId
+	token := l.token(traceID)
+
+	tr := l.traces[token]
+	if tr == nil {
+		tr = &liveTrace{
+			id: traceID,
+		}
+		l.traces[token] = tr
+	}
+
+	tr.Batches = append(tr.Batches, batch)
+	tr.timestamp = time.Now()
+}
+
+func (l *liveTraces) CutIdle(idleSince time.Time) []*liveTrace {
+	res := []*liveTrace{}
+
+	for k, tr := range l.traces {
+		if tr.timestamp.Before(idleSince) {
+			res = append(res, tr)
+			delete(l.traces, k)
+		}
+	}
+
+	return res
+}

--- a/modules/generator/processor/localblocks/livetraces.go
+++ b/modules/generator/processor/localblocks/livetraces.go
@@ -19,7 +19,7 @@ type liveTraces struct {
 	traces map[uint64]*liveTrace
 }
 
-func NewLiveTraces() *liveTraces {
+func newLiveTraces() *liveTraces {
 	return &liveTraces{
 		hash:   fnv.New64(),
 		traces: map[uint64]*liveTrace{},

--- a/modules/generator/processor/localblocks/livetraces.go
+++ b/modules/generator/processor/localblocks/livetraces.go
@@ -33,6 +33,10 @@ func (l *liveTraces) token(traceID []byte) uint64 {
 }
 
 func (l *liveTraces) Push(batch *v1.ResourceSpans) {
+	if len(batch.ScopeSpans) == 0 || len(batch.ScopeSpans[0].Spans) == 0 {
+		return
+	}
+
 	traceID := batch.ScopeSpans[0].Spans[0].TraceId
 	token := l.token(traceID)
 

--- a/modules/generator/processor/localblocks/processor.go
+++ b/modules/generator/processor/localblocks/processor.go
@@ -51,7 +51,7 @@ func New(cfg Config, tenant string, wal *wal.WAL) (*Processor, error) {
 		wal:            wal,
 		walBlocks:      map[uuid.UUID]common.WALBlock{},
 		completeBlocks: map[uuid.UUID]common.BackendBlock{},
-		liveTraces:     NewLiveTraces(),
+		liveTraces:     newLiveTraces(),
 		closeCh:        make(chan struct{}),
 	}
 

--- a/modules/generator/processor/localblocks/processor.go
+++ b/modules/generator/processor/localblocks/processor.go
@@ -1,0 +1,219 @@
+package localblocks
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log/level"
+	"github.com/google/uuid"
+	gen "github.com/grafana/tempo/modules/generator/processor"
+	"github.com/grafana/tempo/pkg/model"
+	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/grafana/tempo/pkg/util/log"
+	"github.com/grafana/tempo/tempodb/encoding/common"
+	"github.com/grafana/tempo/tempodb/wal"
+	"github.com/pkg/errors"
+)
+
+type Processor struct {
+	tenant  string
+	Cfg     Config
+	wal     *wal.WAL
+	closeCh chan struct{}
+
+	blocksMtx   sync.Mutex
+	headBlock   common.WALBlock
+	walBlocks   []common.WALBlock
+	lastCutTime time.Time
+
+	liveTracesMtx sync.Mutex
+	liveTraces    *liveTraces
+}
+
+var _ gen.Processor = (*Processor)(nil)
+
+func New(cfg Config, tenant string) (*Processor, error) {
+	if cfg.WAL == nil {
+		return nil, errors.New("wal config cannot be nil")
+	}
+
+	// Copy the wal config. This is because it contains runtime properties
+	// that are set after creation like CompletedFilePath that break the
+	// automatic configuration drift detection higher up in the metrics
+	// generator module.
+	walCfg := *cfg.WAL
+	wal, err := wal.New(&walCfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating local blocks processor wal")
+	}
+
+	p := &Processor{
+		Cfg:        cfg,
+		tenant:     tenant,
+		wal:        wal,
+		liveTraces: NewLiveTraces(),
+		closeCh:    make(chan struct{}),
+	}
+
+	go p.loop()
+
+	return p, nil
+}
+
+func (*Processor) Name() string {
+	return "LocalBlocksProcessor"
+}
+
+func (p *Processor) PushSpans(ctx context.Context, req *tempopb.PushSpansRequest) {
+
+	p.liveTracesMtx.Lock()
+	defer p.liveTracesMtx.Unlock()
+
+	for _, batch := range req.Batches {
+		p.liveTraces.Push(batch)
+	}
+}
+
+func (p *Processor) Shutdown(ctx context.Context) {
+	close(p.closeCh)
+}
+
+func (p *Processor) loop() {
+	flushTicker := time.NewTicker(p.Cfg.FlushCheckPeriod)
+	defer flushTicker.Stop()
+
+	for {
+		select {
+		case <-flushTicker.C:
+			err := p.cutIdleTraces(false)
+			if err != nil {
+				level.Error(log.WithUserID(p.tenant, log.Logger)).Log("msg", "local blocks processor failed to cut idle traces", "err", err)
+			}
+
+			err = p.cutBlocks()
+			if err != nil {
+				level.Error(log.WithUserID(p.tenant, log.Logger)).Log("msg", "local blocks processor failed to cut idle traces", "err", err)
+			}
+
+		case <-p.closeCh:
+			// Immediately cut all traces from memory
+			err := p.cutIdleTraces(true)
+			if err != nil {
+				level.Error(log.WithUserID(p.tenant, log.Logger)).Log("msg", "local blocks processor failed to cut idle traces", "err", err)
+			}
+			return
+		}
+	}
+}
+
+func (p *Processor) cutIdleTraces(immediate bool) error {
+	p.liveTracesMtx.Lock()
+	defer p.liveTracesMtx.Unlock()
+
+	since := time.Now().Add(-p.Cfg.MaxTraceIdle)
+	if immediate {
+		since = time.Time{}
+	}
+
+	tracesToCut := p.liveTraces.CutIdle(since)
+
+	if len(tracesToCut) == 0 {
+		return nil
+	}
+
+	segmentDecoder := model.MustNewSegmentDecoder(model.CurrentEncoding)
+
+	// Sort by ID
+	sort.Slice(tracesToCut, func(i, j int) bool {
+		return bytes.Compare(tracesToCut[i].id, tracesToCut[j].id) == -1
+	})
+
+	for _, t := range tracesToCut {
+
+		// TODO - This is dumb because the wal block will immediately
+		// unmarshal the bytes, fix this.
+
+		buf, err := segmentDecoder.PrepareForWrite(&tempopb.Trace{
+			Batches: t.Batches,
+		}, 0, 0)
+		if err != nil {
+			return err
+		}
+
+		out, err := segmentDecoder.ToObject([][]byte{buf})
+		if err != nil {
+			return err
+		}
+
+		err = p.writeHeadBlock(t.id, out)
+		if err != nil {
+			return err
+		}
+
+	}
+
+	p.blocksMtx.Lock()
+	defer p.blocksMtx.Unlock()
+	return p.headBlock.Flush()
+}
+
+func (p *Processor) writeHeadBlock(id common.ID, b []byte) error {
+	p.blocksMtx.Lock()
+	defer p.blocksMtx.Unlock()
+
+	if p.headBlock == nil {
+		err := p.resetHeadBlock()
+		if err != nil {
+			return err
+		}
+	}
+
+	err := p.headBlock.Append(id, b, 0, 0)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *Processor) resetHeadBlock() error {
+	block, err := p.wal.NewBlock(uuid.New(), p.tenant, model.CurrentEncoding)
+	if err != nil {
+		return err
+	}
+	p.headBlock = block
+	p.lastCutTime = time.Now()
+	return nil
+}
+
+func (p *Processor) cutBlocks() error {
+	p.blocksMtx.Lock()
+	defer p.blocksMtx.Unlock()
+
+	if p.headBlock == nil {
+		return nil
+	}
+
+	if time.Since(p.lastCutTime) < p.Cfg.MaxBlockDuration || p.headBlock.DataLength() < p.Cfg.MaxBlockBytes {
+		return nil
+	}
+
+	// Final flush
+	err := p.headBlock.Flush()
+	if err != nil {
+		return fmt.Errorf("failed to flush head block: %w", err)
+	}
+
+	p.walBlocks = append(p.walBlocks, p.headBlock)
+
+	err = p.resetHeadBlock()
+	if err != nil {
+		return fmt.Errorf("failed to resetHeadBlock: %w", err)
+	}
+
+	return nil
+}

--- a/modules/generator/processor/localblocks/processor.go
+++ b/modules/generator/processor/localblocks/processor.go
@@ -246,7 +246,7 @@ func (p *Processor) cutIdleTraces(immediate bool) error {
 	p.liveTracesMtx.Lock()
 	defer p.liveTracesMtx.Unlock()
 
-	since := time.Now().Add(-p.Cfg.MaxTraceIdle)
+	since := time.Now().Add(-p.Cfg.TraceIdlePeriod)
 	if immediate {
 		since = time.Time{}
 	}

--- a/modules/storage/config.go
+++ b/modules/storage/config.go
@@ -19,13 +19,6 @@ import (
 	"github.com/grafana/tempo/tempodb/wal"
 )
 
-const (
-	DefaultBloomFP              = .01
-	DefaultBloomShardSizeBytes  = 100 * 1024
-	DefaultIndexDownSampleBytes = 1024 * 1024
-	DefaultIndexPageSizeBytes   = 250 * 1024
-)
-
 // Config is the Tempo storage configuration
 type Config struct {
 	Trace tempodb.Config `yaml:"trace"`
@@ -48,21 +41,11 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.Trace.WAL.IngestionSlack = 2 * time.Minute
 
 	cfg.Trace.Search = &tempodb.SearchConfig{}
-	cfg.Trace.Search.ChunkSizeBytes = tempodb.DefaultSearchChunkSizeBytes
-	cfg.Trace.Search.PrefetchTraceCount = tempodb.DefaultPrefetchTraceCount
-	cfg.Trace.Search.ReadBufferCount = tempodb.DefaultReadBufferCount
-	cfg.Trace.Search.ReadBufferSizeBytes = tempodb.DefaultReadBufferSize
+	cfg.Trace.Search.RegisterFlagsAndApplyDefaults(prefix, f)
 
 	cfg.Trace.Block = &common.BlockConfig{}
-	f.Float64Var(&cfg.Trace.Block.BloomFP, util.PrefixConfig(prefix, "trace.block.v2-bloom-filter-false-positive"), DefaultBloomFP, "Bloom Filter False Positive.")
-	f.IntVar(&cfg.Trace.Block.BloomShardSizeBytes, util.PrefixConfig(prefix, "trace.block.v2-bloom-filter-shard-size-bytes"), DefaultBloomShardSizeBytes, "Bloom Filter Shard Size in bytes.")
-	f.IntVar(&cfg.Trace.Block.IndexDownsampleBytes, util.PrefixConfig(prefix, "trace.block.v2-index-downsample-bytes"), DefaultIndexDownSampleBytes, "Number of bytes (before compression) per index record.")
-	f.IntVar(&cfg.Trace.Block.IndexPageSizeBytes, util.PrefixConfig(prefix, "trace.block.v2-index-page-size-bytes"), DefaultIndexPageSizeBytes, "Number of bytes per index page.")
 	cfg.Trace.Block.Version = encoding.DefaultEncoding().Version()
-	cfg.Trace.Block.Encoding = backend.EncZstd
-	cfg.Trace.Block.SearchEncoding = backend.EncSnappy
-	cfg.Trace.Block.SearchPageSizeBytes = 1024 * 1024 // 1 MB
-	cfg.Trace.Block.RowGroupSizeBytes = 100_000_000   // 100 MB
+	cfg.Trace.Block.RegisterFlagsAndApplyDefaults(prefix, f)
 
 	cfg.Trace.Azure = &azure.Config{}
 	f.StringVar(&cfg.Trace.Azure.StorageAccountName, util.PrefixConfig(prefix, "trace.azure.storage_account_name"), "", "Azure storage account name.")

--- a/tempodb/config.go
+++ b/tempodb/config.go
@@ -78,11 +78,11 @@ type SearchConfig struct {
 	} `yaml:"cache_control"`
 }
 
-func (cfg *SearchConfig) RegisterFlagsAndApplyDefaults(_ string, f *flag.FlagSet) {
-	cfg.ChunkSizeBytes = DefaultSearchChunkSizeBytes
-	cfg.PrefetchTraceCount = DefaultPrefetchTraceCount
-	cfg.ReadBufferCount = DefaultReadBufferCount
-	cfg.ReadBufferSizeBytes = DefaultReadBufferSize
+func (c *SearchConfig) RegisterFlagsAndApplyDefaults(_ string, f *flag.FlagSet) {
+	c.ChunkSizeBytes = DefaultSearchChunkSizeBytes
+	c.PrefetchTraceCount = DefaultPrefetchTraceCount
+	c.ReadBufferCount = DefaultReadBufferCount
+	c.ReadBufferSizeBytes = DefaultReadBufferSize
 }
 
 func (c SearchConfig) ApplyToOptions(o *common.SearchOptions) {

--- a/tempodb/config.go
+++ b/tempodb/config.go
@@ -2,6 +2,7 @@ package tempodb
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"time"
 
@@ -75,6 +76,13 @@ type SearchConfig struct {
 		ColumnIndex bool `yaml:"column_index"`
 		OffsetIndex bool `yaml:"offset_index"`
 	} `yaml:"cache_control"`
+}
+
+func (cfg *SearchConfig) RegisterFlagsAndApplyDefaults(_ string, f *flag.FlagSet) {
+	cfg.ChunkSizeBytes = DefaultSearchChunkSizeBytes
+	cfg.PrefetchTraceCount = DefaultPrefetchTraceCount
+	cfg.ReadBufferCount = DefaultReadBufferCount
+	cfg.ReadBufferSizeBytes = DefaultReadBufferSize
 }
 
 func (c SearchConfig) ApplyToOptions(o *common.SearchOptions) {


### PR DESCRIPTION
**What this PR does**:
This PR is part of a wider initiative to perform on-demand metrics calculations.  It adds a new processor `local-blocks` that stores a copy of all received traces on disk.  It works almost identically to an ingester with a live traces map, wal, local blocks, retention period, and with similar configuration.  Currently this serves **no purpose** but more functionality will be added in later PRs.

The metrics generator config looks like:
```yaml
metrics-generator:
  processor:
    local_blocks:
       block: (tempodb block config, optional)
       flush_check_period: (duration, optional)
       trace_idle_period: (duration, optional)
       max_block_duration: (duration, optional)
       max_block_bytes: (optional)
       complete_block_timeout: (optional)

  traces_storage:
    path: /tmp/tempo/generator/traces (required) # the only required field
    version: (optional)

overrides:
  metrics_generator_processors: [local-blocks]  # Enable the processor
```

Notes:

1. This forks a lot of code from the ingester for live traces, flushing, deleting, etc.  I originally hoped to call the ingester module but it's not prepared for that and would need a combination of updates (exporting symbols, making parts like flushing to object storage disable-able). So forking was not only more straightforward but also a chance to simplify the code.
2. Flushing/completing/deleting is done via goroutines per instance. The real ingester has a shared set of workers and work queue across all instances.  That approach should be adopted here but unsure yet how to make it work with the processors, since they can be dynamically configured, enabled, and disabled.
3. This tries to reuse config structs and defaults where possible, but counter-intuitively it doesn't reuse actual same settings as the rest of Tempo. There are a few reasons:  they are separate modules and probably should have separate config.  This processor's storage has to be distinct from the main storage area since the data is a little different.  Real storage will be RF3 (if configured), but the metrics-generator traffic is best-effort and only RF1.  

Additional changes:
1. I think this should fix the "duplication registration" bug that sometimes happens in metrics generator. 
2. Relocates some config defaults to be callable by the generator module.

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`