### PR TITLE
Allow no changes when syncing release documentation

### DIFF
--- a/.github/workflows/website-versioned.yml
+++ b/.github/workflows/website-versioned.yml
@@ -91,7 +91,8 @@ jobs:
           source_folder: docs/sources/tempo
           # target is v1.2.x
           target_folder: content/docs/tempo/${{ steps.target.outputs.target }}.x
-      
+          allow_no_changes: true
+
       - shell: bash
         run: |
           test -n "${{ steps.publish.outputs.commit_hash }}"


### PR DESCRIPTION
It is already present when syncing "next" documentation.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
