### PR TITLE
Support to filter traces using `!~`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main / unreleased
 
-* [ENHANCEMENT] Add `prefix` configuration option to `storage.trace.azure` and `storage.trace.gcs` [#2362](https://github.com/grafana/tempo/pull/2386) (@kousikmitra)
+* [ENHANCEMENT] Add support to filter using negated regex operator `!~` [#2410](https://github.com/grafana/tempo/pull/2410) (@kousikmitra)
+* [ENHANCEMENT] Add `prefix` configuration option to `storage.trace.azure` and `storage.trace.gcs` [#2386](https://github.com/grafana/tempo/pull/2386) (@kousikmitra)
 * [ENHANCEMENT] Add `prefix` configuration option to `storage.trace.s3` [#2362](https://github.com/grafana/tempo/pull/2362) (@kousikmitra)
 * [FEATURE] Add support for `q` query param in `/api/v2/search/<tag.name>/values` to filter results based on a TraceQL query [#2253](https://github.com/grafana/tempo/pull/2253) (@mapno)
 * [ENHANCEMENT] Add `scope` parameter to `/api/search/tags` [#2282](https://github.com/grafana/tempo/pull/2282) (@joe-elliott)

--- a/docs/sources/tempo/traceql/_index.md
+++ b/docs/sources/tempo/traceql/_index.md
@@ -120,6 +120,7 @@ The implemented comparison operators are:
 - `<` (less than)
 - `<=` (less than or equal to)
 - `=~` (regular expression)
+- `!~` (negated regular expression)
 
 TraceQL uses Golang regular expressions. Online regular expression testing sites like https://regex101.com/ are convenient to validate regular expressions used in TraceQL queries.
 

--- a/pkg/parquetquery/predicate_test.go
+++ b/pkg/parquetquery/predicate_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/segmentio/parquet-go"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -91,7 +90,8 @@ func TestNewRegexInPredicate(t *testing.T) {
 			testName: "all chunks/pages/values inspected",
 			predicate: func() Predicate {
 				pred, err := NewRegexInPredicate([]string{"a.*"})
-				assert.NoError(t, err)
+				require.NoError(t, err)
+
 				return pred
 			}(),
 			keptChunks: 1,
@@ -110,7 +110,8 @@ func TestNewRegexInPredicate(t *testing.T) {
 			testName: "dictionary in the page header allows for skipping a page",
 			predicate: func() Predicate {
 				pred, err := NewRegexInPredicate([]string{"x.*"})
-				assert.NoError(t, err)
+				require.NoError(t, err)
+
 				return pred
 			}(), // Not present in any values
 			keptChunks: 1,
@@ -139,7 +140,8 @@ func TestNewRegexNotInPredicate(t *testing.T) {
 			testName: "all chunks/pages/values inspected",
 			predicate: func() Predicate {
 				pred, err := NewRegexNotInPredicate([]string{"a.*"})
-				assert.NoError(t, err)
+				require.NoError(t, err)
+
 				return pred
 			}(),
 			keptChunks: 1,
@@ -159,7 +161,8 @@ func TestNewRegexNotInPredicate(t *testing.T) {
 			testName: "dictionary in the page header allows for skipping a page",
 			predicate: func() Predicate {
 				pred, err := NewRegexNotInPredicate([]string{"x.*"})
-				assert.NoError(t, err)
+				require.NoError(t, err)
+
 				return pred
 			}(), // Not present in any values
 			keptChunks: 1,

--- a/pkg/parquetquery/predicate_test.go
+++ b/pkg/parquetquery/predicate_test.go
@@ -10,14 +10,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var _ Predicate = (*mockPredicate)(nil)
-
 type mockPredicate struct {
 	ret         bool
 	valCalled   bool
 	pageCalled  bool
 	chunkCalled bool
 }
+
+type testDictString struct {
+	S string `parquet:",dict"`
+}
+
+var _ Predicate = (*mockPredicate)(nil)
 
 func newAlwaysTruePredicate() *mockPredicate {
 	return &mockPredicate{ret: true}
@@ -50,12 +54,10 @@ func TestSubstringPredicate(t *testing.T) {
 			keptPages:  1,
 			keptValues: 2,
 			writeData: func(w *parquet.Writer) { //nolint:all
-				type String struct {
-					S string `parquet:",dict"`
-				}
-				require.NoError(t, w.Write(&String{"abc"})) // kept
-				require.NoError(t, w.Write(&String{"bcd"})) // kept
-				require.NoError(t, w.Write(&String{"cde"})) // skipped
+
+				require.NoError(t, w.Write(&testDictString{"abc"})) // kept
+				require.NoError(t, w.Write(&testDictString{"bcd"})) // kept
+				require.NoError(t, w.Write(&testDictString{"cde"})) // skipped
 			},
 		},
 		{
@@ -65,14 +67,11 @@ func TestSubstringPredicate(t *testing.T) {
 			keptPages:  0,
 			keptValues: 0,
 			writeData: func(w *parquet.Writer) { //nolint:all
-				type dictString struct {
-					S string `parquet:",dict"`
-				}
-				require.NoError(t, w.Write(&dictString{"abc"}))
-				require.NoError(t, w.Write(&dictString{"abc"}))
-				require.NoError(t, w.Write(&dictString{"abc"}))
-				require.NoError(t, w.Write(&dictString{"abc"}))
-				require.NoError(t, w.Write(&dictString{"abc"}))
+				require.NoError(t, w.Write(&testDictString{"abc"}))
+				require.NoError(t, w.Write(&testDictString{"abc"}))
+				require.NoError(t, w.Write(&testDictString{"abc"}))
+				require.NoError(t, w.Write(&testDictString{"abc"}))
+				require.NoError(t, w.Write(&testDictString{"abc"}))
 			},
 		},
 	}
@@ -98,12 +97,9 @@ func TestNewRegexInPredicate(t *testing.T) {
 			keptPages:  1,
 			keptValues: 2,
 			writeData: func(w *parquet.Writer) { //nolint:all
-				type String struct {
-					S string `parquet:",dict"`
-				}
-				require.NoError(t, w.Write(&String{"abc"})) // kept
-				require.NoError(t, w.Write(&String{"acd"})) // kept
-				require.NoError(t, w.Write(&String{"cde"})) // skipped
+				require.NoError(t, w.Write(&testDictString{"abc"})) // kept
+				require.NoError(t, w.Write(&testDictString{"acd"})) // kept
+				require.NoError(t, w.Write(&testDictString{"cde"})) // skipped
 			},
 		},
 		{
@@ -118,11 +114,8 @@ func TestNewRegexInPredicate(t *testing.T) {
 			keptPages:  0,
 			keptValues: 0,
 			writeData: func(w *parquet.Writer) { //nolint:all
-				type dictString struct {
-					S string `parquet:",dict"`
-				}
-				require.NoError(t, w.Write(&dictString{"abc"}))
-				require.NoError(t, w.Write(&dictString{"abc"}))
+				require.NoError(t, w.Write(&testDictString{"abc"}))
+				require.NoError(t, w.Write(&testDictString{"abc"}))
 			},
 		},
 	}
@@ -148,13 +141,10 @@ func TestNewRegexNotInPredicate(t *testing.T) {
 			keptPages:  1,
 			keptValues: 2,
 			writeData: func(w *parquet.Writer) { //nolint:all
-				type String struct {
-					S string `parquet:",dict"`
-				}
-				require.NoError(t, w.Write(&String{"abc"})) // skipped
-				require.NoError(t, w.Write(&String{"acd"})) // skipped
-				require.NoError(t, w.Write(&String{"cde"})) // kept
-				require.NoError(t, w.Write(&String{"xde"})) // kept
+				require.NoError(t, w.Write(&testDictString{"abc"})) // skipped
+				require.NoError(t, w.Write(&testDictString{"acd"})) // skipped
+				require.NoError(t, w.Write(&testDictString{"cde"})) // kept
+				require.NoError(t, w.Write(&testDictString{"xde"})) // kept
 			},
 		},
 		{
@@ -169,11 +159,8 @@ func TestNewRegexNotInPredicate(t *testing.T) {
 			keptPages:  0,
 			keptValues: 0,
 			writeData: func(w *parquet.Writer) { //nolint:all
-				type dictString struct {
-					S string `parquet:",dict"`
-				}
-				require.NoError(t, w.Write(&dictString{"xyz"}))
-				require.NoError(t, w.Write(&dictString{"xyz"}))
+				require.NoError(t, w.Write(&testDictString{"xyz"}))
+				require.NoError(t, w.Write(&testDictString{"xyz"}))
 			},
 		},
 	}

--- a/pkg/parquetquery/predicate_test.go
+++ b/pkg/parquetquery/predicate_test.go
@@ -286,3 +286,21 @@ func BenchmarkStringInPredicate(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkRegexInPredicate(b *testing.B) {
+	p, err := NewRegexInPredicate([]string{"abc"})
+	require.NoError(b, err)
+
+	s := make([]parquet.Value, 1000)
+	for i := 0; i < 1000; i++ {
+		s[i] = parquet.ValueOf(uuid.New().String())
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for _, ss := range s {
+			p.KeepValue(ss)
+		}
+	}
+}

--- a/pkg/traceql/ast_validate.go
+++ b/pkg/traceql/ast_validate.go
@@ -178,8 +178,7 @@ func (o BinaryOperation) validate() error {
 	}
 
 	switch o.Op {
-	case OpNotRegex,
-		OpSpansetChild,
+	case OpSpansetChild,
 		OpSpansetDescendant,
 		OpSpansetSibling:
 		return newUnsupportedError(fmt.Sprintf("binary operation (%v)", o.Op))

--- a/pkg/traceql/test_examples.yaml
+++ b/pkg/traceql/test_examples.yaml
@@ -1,258 +1,257 @@
 # valid queries parse successfully and return nil when calling .validate()
 valid:
   # spanset filters
-  - '{ true }'
-  - '{ !true }'
-  - '{ true && false }'
-  - '{ true || false }'
-  - '{ 1 = 2 }'
-  - '{ 1 != 2 }'
-  - '{ 1 > 2 }'
-  - '{ 1 >= 2 }'
-  - '{ 1 < 2 }'
-  - '{ 1 <= 2 }'
-  - '{ -1 = 2 }'
+  - "{ true }"
+  - "{ !true }"
+  - "{ true && false }"
+  - "{ true || false }"
+  - "{ 1 = 2 }"
+  - "{ 1 != 2 }"
+  - "{ 1 > 2 }"
+  - "{ 1 >= 2 }"
+  - "{ 1 < 2 }"
+  - "{ 1 <= 2 }"
+  - "{ -1 = 2 }"
   - '{ "test" =~ "test" }'
+  - '{ "test" !~ "test" }'
   - '{ "test" = "test" }'
   - '{ "test" != "test" }'
-  - '{ .a }'
-  - '{ !.a }'
-  - '{ .a && false }'
-  - '{ .a || true }'
-  - '{ .a = 2 }'
-  - '{ .a != 2 }'
-  - '{ .a > 2 }'
-  - '{ .a >= 2 }'
-  - '{ .a < 2 }'
-  - '{ .a <= 2 }'
-  - '{ -.a = 2 }'
+  - "{ .a }"
+  - "{ !.a }"
+  - "{ .a && false }"
+  - "{ .a || true }"
+  - "{ .a = 2 }"
+  - "{ .a != 2 }"
+  - "{ .a > 2 }"
+  - "{ .a >= 2 }"
+  - "{ .a < 2 }"
+  - "{ .a <= 2 }"
+  - "{ -.a = 2 }"
   - '{ .a =~ "test" }'
+  - '{ .a !~ "test" }'
   - '{ .a = "test" }'
   - '{ .a != "test" }'
-  - '{ resource.a != 3 }'
-  - '{ span.a != 3 }'
+  - "{ resource.a != 3 }"
+  - "{ span.a != 3 }"
   - '{ !("test" != .c || ((true && .b) || 3 < .a)) }'
-  - '{ status = ok }'
-  - '{ status = unset }'
-  - '{ status = error }'
-  - '{ status != error }'
-  - '{ kind = internal }'
-  - '{ kind = client }'
-  - '{ kind = consumer }'
-  - '{ duration > 1s }'
-  - '{ 1 < 1h }'
-  - '{ 1 <= 1.1 }'
+  - "{ status = ok }"
+  - "{ status = unset }"
+  - "{ status = error }"
+  - "{ status != error }"
+  - "{ kind = internal }"
+  - "{ kind = client }"
+  - "{ kind = consumer }"
+  - "{ duration > 1s }"
+  - "{ 1 < 1h }"
+  - "{ 1 <= 1.1 }"
   # binary operations
-  - '{ 1 + 1 = 2 }'
-  - '{ 1 - 1 = 2 }'
-  - '{ 1 * 1 = 2 }'
-  - '{ 1 / 1 = 2 }'
-  - '{ 1 ^ 1 = 2 }'
-  - '{ .a + 1 = 2 }'
-  - '{ .a - 1 = 2 }'
-  - '{ .a * 1 = 2 }'
-  - '{ .a / 1 = 2 }'
-  - '{ .a ^ 1 = 2 }'
-  - '{ duration > 1s * 2s }' 
-  - '{ 1 * 1h = 1 }'     # combining float, int and duration can make sense, but can also be weird. we just accept it all
-  - '{ 1 / 1.1 = 1 }'
+  - "{ 1 + 1 = 2 }"
+  - "{ 1 - 1 = 2 }"
+  - "{ 1 * 1 = 2 }"
+  - "{ 1 / 1 = 2 }"
+  - "{ 1 ^ 1 = 2 }"
+  - "{ .a + 1 = 2 }"
+  - "{ .a - 1 = 2 }"
+  - "{ .a * 1 = 2 }"
+  - "{ .a / 1 = 2 }"
+  - "{ .a ^ 1 = 2 }"
+  - "{ duration > 1s * 2s }"
+  - "{ 1 * 1h = 1 }" # combining float, int and duration can make sense, but can also be weird. we just accept it all
+  - "{ 1 / 1.1 = 1 }"
   - '{ .http.status >= "200" }'
   # spanset expressions
-  - '{ true } && { true }'
-  - '{ true } || { true }'
+  - "{ true } && { true }"
+  - "{ true } || { true }"
   # scalar filters
-  - 'avg(.field) > 1'
-  - 'max(duration) >= 1s'
-  - 'max(duration) > 1'            # same note as above for int, float and duration
-  - '{ true } | max(duration) = 1h'
-  - '{ true } | min(duration) = 1h'
-  - '{ true } | sum(duration) = 1h'
-  - '{ true } | max(.a) = 1'
-  - '{ true } | max(span.a) = 1'
-  - '{ true } | max(resource.a) = 1'
-  - '{ true } | max(1 + .a) = 1'
-  - '{ true } | max((1 + .a) * 2) = 1'
-  - 'max(duration) > 3s | { status = error || .http.status = 500 }'
+  - "avg(.field) > 1"
+  - "max(duration) >= 1s"
+  - "max(duration) > 1" # same note as above for int, float and duration
+  - "{ true } | max(duration) = 1h"
+  - "{ true } | min(duration) = 1h"
+  - "{ true } | sum(duration) = 1h"
+  - "{ true } | max(.a) = 1"
+  - "{ true } | max(span.a) = 1"
+  - "{ true } | max(resource.a) = 1"
+  - "{ true } | max(1 + .a) = 1"
+  - "{ true } | max((1 + .a) * 2) = 1"
+  - "max(duration) > 3s | { status = error || .http.status = 500 }"
   # pipelines
-  - '{ true } | { .a }'
-  - '{ true } | count() = 1'
-  - '{ true } | avg(duration) = 1h'
-  - 'count() = 1 | { true }'
-  - '{ true } | count() = 1 | { true }'
+  - "{ true } | { .a }"
+  - "{ true } | count() = 1"
+  - "{ true } | avg(duration) = 1h"
+  - "count() = 1 | { true }"
+  - "{ true } | count() = 1 | { true }"
   # pipeline expressions
-  - '({ true } | count() > 1 | { false }) && ({ true } | count() > 1 | { false })'
-  - '({ true } | count() > 1 | { false }) || ({ true } | count() > 1 | { false })'
-  
+  - "({ true } | count() > 1 | { false }) && ({ true } | count() > 1 | { false })"
+  - "({ true } | count() > 1 | { false }) || ({ true } | count() > 1 | { false })"
+
 # parse_fails throw an error when parsing
 parse_fails:
-  - 'true'
-  - '[ true ]'
-  - '( true )'
+  - "true"
+  - "[ true ]"
+  - "( true )"
   # spanset filters
-  - '{ . }'
-  - '{ < }'
-  - '{ .a < }'
-  - '{ .a < 3'
-  - '{ (.a < 3 }'
-  - '{ attribute = 4 }'           # custom attribute not prefixed with ., span., resource. or parent.
-  - '{ .attribute == 4 }'         # invalid operator
-  - '{ span. }'
+  - "{ . }"
+  - "{ < }"
+  - "{ .a < }"
+  - "{ .a < 3"
+  - "{ (.a < 3 }"
+  - "{ attribute = 4 }" # custom attribute not prefixed with ., span., resource. or parent.
+  - "{ .attribute == 4 }" # invalid operator
+  - "{ span. }"
   # spanset expressions
-  - '{ true } + { true }'
-  - '{ true } - { true }'
-  - '{ true } * { true }'
-  - '{ true } / { true }'
-  - '{ true } ^ { true }'
-  - '{ true } = { true }'         # an interesting operator. possible future addition
-  - '{ true } <= { true }'
-  - '{ true } >= { true }'
-  - '{ true } < { true }'
+  - "{ true } + { true }"
+  - "{ true } - { true }"
+  - "{ true } * { true }"
+  - "{ true } / { true }"
+  - "{ true } ^ { true }"
+  - "{ true } = { true }" # an interesting operator. possible future addition
+  - "{ true } <= { true }"
+  - "{ true } >= { true }"
+  - "{ true } < { true }"
   # scalar expressions must evaluate to a number
   - 'max(name) = "foo"'
   - 'avg("foo") = "bar"'
-  - 'max(status) = ok'
-  - 'max(kind) = consumer'
-  - 'max(duration) < ok'
+  - "max(status) = ok"
+  - "max(kind) = consumer"
+  - "max(duration) < ok"
   - 'min(1) = "foo"'
-  - 'min(parent) = nil'
+  - "min(parent) = nil"
   - 'avg(childCount) > "foo"'
   # scalar filters
-  - 'avg(.field) + 1'             # scalar filters must resolve to boolean
-  - 'sum(3) - 2'
-  - 'min(childCount) && 2'
+  - "avg(.field) + 1" # scalar filters must resolve to boolean
+  - "sum(3) - 2"
+  - "min(childCount) && 2"
   # pipelines
-  - 'coalesce() | { true }'       # pipelines can't start with coalesce
-  - 'count() > 3 && { true }'     # scalar filters have to be in pipeline
-  - '{ true } | count()'          # naked scalar pipelines not allowed
-  - '{ true } | notAnAggregate() = 1'
-  - '{ true } | count = 1'
-  - '{ true } | max() = 1'
-  - '{ true } | by()'
+  - "coalesce() | { true }" # pipelines can't start with coalesce
+  - "count() > 3 && { true }" # scalar filters have to be in pipeline
+  - "{ true } | count()" # naked scalar pipelines not allowed
+  - "{ true } | notAnAggregate() = 1"
+  - "{ true } | count = 1"
+  - "{ true } | max() = 1"
+  - "{ true } | by()"
   # pipeline expressions
-  - '({ true }) + (count()) = 1'
-  - '({ true }) && (count())'
-  - '({ true } | count()) && ({ true } | count()) = 1'
-  - '({ true }) + ({ true }) = 1'
-  - '({ true } | count()) + ({ true } | count())'
+  - "({ true }) + (count()) = 1"
+  - "({ true }) && (count())"
+  - "({ true } | count()) && ({ true } | count()) = 1"
+  - "({ true }) + ({ true }) = 1"
+  - "({ true } | count()) + ({ true } | count())"
   # todo: improve the following
-  - '(by(namespace) | count()) > 2 * 2' # scalar expressions are currently not allowed in scalar pipelines
-  - '(by(namespace) | count()) * 2 > 2'
-  - '2 < (by(namespace) | count())'     # static value needs to be on the RHS to remove conflicts with scalar expressions
+  - "(by(namespace) | count()) > 2 * 2" # scalar expressions are currently not allowed in scalar pipelines
+  - "(by(namespace) | count()) * 2 > 2"
+  - "2 < (by(namespace) | count())" # static value needs to be on the RHS to remove conflicts with scalar expressions
 
 # validate_fails parse correctly and return an error **besides unsupported** when calling .validate()
 validate_fails:
   # span expressions must evaluate to a boolean
-  - '{ status }'
-  - '{ kind }'
-  - '{ ok }'
-  - '{ 1.1 }'
-  - '{ 1h }'
+  - "{ status }"
+  - "{ kind }"
+  - "{ ok }"
+  - "{ 1.1 }"
+  - "{ 1h }"
   - '{ "foo" }'
-  - '{ 1 + 1 }'       
+  - "{ 1 + 1 }"
   # binary operators - incorrect types
   - '{ 1 + "foo" = 1 }'
-  - '{ 1 - true = 1 }'
-  - '{ 1 / ok = 1 }'
-  - '{ 1 ^ name = 1 }'
+  - "{ 1 - true = 1 }"
+  - "{ 1 / ok = 1 }"
+  - "{ 1 ^ name = 1 }"
   - '{ 1 = "foo" }'
-  - '{ 1 != true }'
-  - '{ 1 > ok }'
-  - '{ 1 = name }'
-  - '{ 1 =~ 2}'
+  - "{ 1 != true }"
+  - "{ 1 > ok }"
+  - "{ 1 = name }"
+  - "{ 1 =~ 2}"
   - '{ 1 && "foo" }'
-  - '{ 1 || ok }'
-  - '{ true || 1.1 }'
-  - '{ status > ok }'
-  - '{ kind < consumer }'
+  - "{ 1 || ok }"
+  - "{ true || 1.1 }"
+  - "{ status > ok }"
+  - "{ kind < consumer }"
   # unary operators - incorrect types
-  - '{ -true }'
+  - "{ -true }"
   - '{ -"foo" = "bar" }'
-  - '{ -ok = status }'
+  - "{ -ok = status }"
   - '{ -name = "foo" }'
   - '{ !"foo" = "bar" }'
-  - '{ !ok = status }'
-  - '{ !consumer = kind }'
+  - "{ !ok = status }"
+  - "{ !consumer = kind }"
   - '{ !name = "foo" }'
-  - '{ !1 = 1 }'
-  - '{ !1h = 1 }'
-  - '{ !1.1 = 1.1 }'
+  - "{ !1 = 1 }"
+  - "{ !1h = 1 }"
+  - "{ !1.1 = 1.1 }"
   # scalar expressions must evaluate to a number
-  - 'min(1 = 3) = 1'
+  - "min(1 = 3) = 1"
   # scalar expressions must reference the span
-  - 'sum(3) = 2'
-  - 'sum(3) = min(14)'
-  - 'min(2h) < max(duration)'
-  - 'min(3) = max(duration)'
-  - 'min(1) = max(2) + 3'
-  - 'min(1.1 - 3) > 1'
-  - 'max(1h + 2h) > 1'
+  - "sum(3) = 2"
+  - "sum(3) = min(14)"
+  - "min(2h) < max(duration)"
+  - "min(3) = max(duration)"
+  - "min(1) = max(2) + 3"
+  - "min(1.1 - 3) > 1"
+  - "max(1h + 2h) > 1"
 
 # unsupported parse correctly and return an unsupported error when calling .validate()
 unsupported:
   # coalesce - will be valid when supported
-  - '{ true } | coalesce()'
-  - '{ true } | by(1 + .a) | coalesce()'
+  - "{ true } | coalesce()"
+  - "{ true } | by(1 + .a) | coalesce()"
   # by - will be valid when supported
-  - '{ true } | by(.a)'
-  - '{ true } | by(1 + .a)'
-  - 'by(.a) | { true }'
-  - '{ true } | by(name) | count() > 2'
-  - '{ true } | by(.field) | avg(.b) = 2'
+  - "{ true } | by(.a)"
+  - "{ true } | by(1 + .a)"
+  - "by(.a) | { true }"
+  - "{ true } | by(name) | count() > 2"
+  - "{ true } | by(.field) | avg(.b) = 2"
   # by - will *not* be valid when supported - group expressions must reference the span
-  - '{ true } | by(1)'
+  - "{ true } | by(1)"
   - '{ true } | by("foo")'
   # complex scalar filters - will be valid when supported
-  - 'min(.field) < max(duration)'
-  - 'sum(.field) = min(.field)'
-  - 'min(.field) + max(.field) > 1'
-  - 'min(.field) + max(childCount) > max(duration) - min(.field)'
-  - 'min(childCount) < 2 / 6'
-  - 'max(1 - (2 + .field)) < avg(3 * duration ^ 2)'
+  - "min(.field) < max(duration)"
+  - "sum(.field) = min(.field)"
+  - "min(.field) + max(.field) > 1"
+  - "min(.field) + max(childCount) > max(duration) - min(.field)"
+  - "min(childCount) < 2 / 6"
+  - "max(1 - (2 + .field)) < avg(3 * duration ^ 2)"
   # aggregates - will be valid when supported
-  - 'min(childCount) < 2'
-  - '{ true } | max(parent.a) = 1'
-  - '{ true } | by(3 * .field - 2) | max(duration) < 1s'
-  - '{ .http.status = 200 } | max(.field) - min(.field) > 3'
+  - "min(childCount) < 2"
+  - "{ true } | max(parent.a) = 1"
+  - "{ true } | by(3 * .field - 2) | max(duration) < 1s"
+  - "{ .http.status = 200 } | max(.field) - min(.field) > 3"
   # parent - will be valid when supported
-  - '{ parent.a != 3 }'
-  - '{ parent.resource.a && true }'
-  - '{ parent.span.a > 3 }'
-  - '{ parent.duration = 1h }'
-  - '{ parent = nil }'
-  - '{ (-(3 / 2) * .test - parent.blerg + .other)^3 = 2 }'
+  - "{ parent.a != 3 }"
+  - "{ parent.resource.a && true }"
+  - "{ parent.span.a > 3 }"
+  - "{ parent.duration = 1h }"
+  - "{ parent = nil }"
+  - "{ (-(3 / 2) * .test - parent.blerg + .other)^3 = 2 }"
   # parent - will not be valid when supported
-  - '{ parent }'
-  - '{ 1 % parent = 1 }'
-  - '{ 1 >= parent }'
-  - '{ -parent = nil }'
-  - '{ !parent = nil }'
+  - "{ parent }"
+  - "{ 1 % parent = 1 }"
+  - "{ 1 >= parent }"
+  - "{ -parent = nil }"
+  - "{ !parent = nil }"
   # nil - will be valid when supported
-  - '{ .foo = nil }'
-  # binary operations - will be valid when supported
-  - '{ "test" !~ "test" }'
-  - '{ .a !~ "test" }'
+  - "{ .foo = nil }"
   # childCount - will be valid when supported
-  - '{ 1 = childCount }'
+  - "{ 1 = childCount }"
   # childCount - will be invalid when supported
   - '{ "foo" = childCount }'
   # spanset operations - will be valid when supported
-  - '{ true } >> { true }'
-  - '{ true } > { true }'
-  - '{ true } ~ { true }'
-  - '({ true } | count() > 1 | { false }) >> ({ true } | count() > 1 | { false })'
-  - '({ true } | count() > 1 | { false }) > ({ true } | count() > 1 | { false })'
-  - '({ true } | count() > 1 | { false }) ~ ({ true } | count() > 1 | { false })'
+  - "{ true } >> { true }"
+  - "{ true } > { true }"
+  - "{ true } ~ { true }"
+  - "({ true } | count() > 1 | { false }) >> ({ true } | count() > 1 | { false })"
+  - "({ true } | count() > 1 | { false }) > ({ true } | count() > 1 | { false })"
+  - "({ true } | count() > 1 | { false }) ~ ({ true } | count() > 1 | { false })"
   # spanset pipelines + scalar filters - will be valid when supported
-  - '{ true } | count() + count() = 1' 
-  - '({ true } | count()) + ({ true } | count()) = 1'
-  - '({ true } | count()) - ({ true } | count()) <= 1'
-  - '({ true } | count()) / ({ true } | count()) > ({ true } | count()) / ({ true } | count())'
-  - '({ true } | count()) * ({ true } | count()) < ({ true } | count()) / ({ true } | count())'
-  - '({ .http.status = 200 } | count()) + ({ name = `foo` } | avg(duration)) = 2'
-  - '({ .a } | count()) > ({ .b } | count())'
+  - "{ true } | count() + count() = 1"
+  - "({ true } | count()) + ({ true } | count()) = 1"
+  - "({ true } | count()) - ({ true } | count()) <= 1"
+  - "({ true } | count()) / ({ true } | count()) > ({ true } | count()) / ({ true } | count())"
+  - "({ true } | count()) * ({ true } | count()) < ({ true } | count()) / ({ true } | count())"
+  - "({ .http.status = 200 } | count()) + ({ name = `foo` } | avg(duration)) = 2"
+  - "({ .a } | count()) > ({ .b } | count())"
   # other scalar filters. no idea if these should be supported
-  - '3 = 2'                       # naked scalar filter, technically allowed
-  - 'avg(.field) > 1 - 3'         # scalar expressions in scalar filters are currently not allowed. possible future addition
+  - "3 = 2" # naked scalar filter, technically allowed
+  - "avg(.field) > 1 - 3" # scalar expressions in scalar filters are currently not allowed. possible future addition
 
 # parsed and the ast is dumped to stdout. this is a debugging tool
 dump:

--- a/pkg/traceql/test_examples.yaml
+++ b/pkg/traceql/test_examples.yaml
@@ -1,257 +1,258 @@
 # valid queries parse successfully and return nil when calling .validate()
 valid:
   # spanset filters
-  - "{ true }"
-  - "{ !true }"
-  - "{ true && false }"
-  - "{ true || false }"
-  - "{ 1 = 2 }"
-  - "{ 1 != 2 }"
-  - "{ 1 > 2 }"
-  - "{ 1 >= 2 }"
-  - "{ 1 < 2 }"
-  - "{ 1 <= 2 }"
-  - "{ -1 = 2 }"
+  - '{ true }'
+  - '{ !true }'
+  - '{ true && false }'
+  - '{ true || false }'
+  - '{ 1 = 2 }'
+  - '{ 1 != 2 }'
+  - '{ 1 > 2 }'
+  - '{ 1 >= 2 }'
+  - '{ 1 < 2 }'
+  - '{ 1 <= 2 }'
+  - '{ -1 = 2 }'
   - '{ "test" =~ "test" }'
   - '{ "test" !~ "test" }'
   - '{ "test" = "test" }'
   - '{ "test" != "test" }'
-  - "{ .a }"
-  - "{ !.a }"
-  - "{ .a && false }"
-  - "{ .a || true }"
-  - "{ .a = 2 }"
-  - "{ .a != 2 }"
-  - "{ .a > 2 }"
-  - "{ .a >= 2 }"
-  - "{ .a < 2 }"
-  - "{ .a <= 2 }"
-  - "{ -.a = 2 }"
+  - '{ .a }'
+  - '{ !.a }'
+  - '{ .a && false }'
+  - '{ .a || true }'
+  - '{ .a = 2 }'
+  - '{ .a != 2 }'
+  - '{ .a > 2 }'
+  - '{ .a >= 2 }'
+  - '{ .a < 2 }'
+  - '{ .a <= 2 }'
+  - '{ -.a = 2 }'
   - '{ .a =~ "test" }'
   - '{ .a !~ "test" }'
   - '{ .a = "test" }'
   - '{ .a != "test" }'
-  - "{ resource.a != 3 }"
-  - "{ span.a != 3 }"
+  - '{ resource.a != 3 }'
+  - '{ span.a != 3 }'
   - '{ !("test" != .c || ((true && .b) || 3 < .a)) }'
-  - "{ status = ok }"
-  - "{ status = unset }"
-  - "{ status = error }"
-  - "{ status != error }"
-  - "{ kind = internal }"
-  - "{ kind = client }"
-  - "{ kind = consumer }"
-  - "{ duration > 1s }"
-  - "{ 1 < 1h }"
-  - "{ 1 <= 1.1 }"
+  - '{ status = ok }'
+  - '{ status = unset }'
+  - '{ status = error }'
+  - '{ status != error }'
+  - '{ kind = internal }'
+  - '{ kind = client }'
+  - '{ kind = consumer }'
+  - '{ duration > 1s }'
+  - '{ 1 < 1h }'
+  - '{ 1 <= 1.1 }'
   # binary operations
-  - "{ 1 + 1 = 2 }"
-  - "{ 1 - 1 = 2 }"
-  - "{ 1 * 1 = 2 }"
-  - "{ 1 / 1 = 2 }"
-  - "{ 1 ^ 1 = 2 }"
-  - "{ .a + 1 = 2 }"
-  - "{ .a - 1 = 2 }"
-  - "{ .a * 1 = 2 }"
-  - "{ .a / 1 = 2 }"
-  - "{ .a ^ 1 = 2 }"
-  - "{ duration > 1s * 2s }"
-  - "{ 1 * 1h = 1 }" # combining float, int and duration can make sense, but can also be weird. we just accept it all
-  - "{ 1 / 1.1 = 1 }"
+  - '{ 1 + 1 = 2 }'
+  - '{ 1 - 1 = 2 }'
+  - '{ 1 * 1 = 2 }'
+  - '{ 1 / 1 = 2 }'
+  - '{ 1 ^ 1 = 2 }'
+  - '{ .a + 1 = 2 }'
+  - '{ .a - 1 = 2 }'
+  - '{ .a * 1 = 2 }'
+  - '{ .a / 1 = 2 }'
+  - '{ .a ^ 1 = 2 }'
+  - '{ duration > 1s * 2s }' 
+  - '{ 1 * 1h = 1 }'     # combining float, int and duration can make sense, but can also be weird. we just accept it all
+  - '{ 1 / 1.1 = 1 }'
   - '{ .http.status >= "200" }'
   # spanset expressions
-  - "{ true } && { true }"
-  - "{ true } || { true }"
+  - '{ true } && { true }'
+  - '{ true } || { true }'
   # scalar filters
-  - "avg(.field) > 1"
-  - "max(duration) >= 1s"
-  - "max(duration) > 1" # same note as above for int, float and duration
-  - "{ true } | max(duration) = 1h"
-  - "{ true } | min(duration) = 1h"
-  - "{ true } | sum(duration) = 1h"
-  - "{ true } | max(.a) = 1"
-  - "{ true } | max(span.a) = 1"
-  - "{ true } | max(resource.a) = 1"
-  - "{ true } | max(1 + .a) = 1"
-  - "{ true } | max((1 + .a) * 2) = 1"
-  - "max(duration) > 3s | { status = error || .http.status = 500 }"
+  - 'avg(.field) > 1'
+  - 'max(duration) >= 1s'
+  - 'max(duration) > 1'            # same note as above for int, float and duration
+  - '{ true } | max(duration) = 1h'
+  - '{ true } | min(duration) = 1h'
+  - '{ true } | sum(duration) = 1h'
+  - '{ true } | max(.a) = 1'
+  - '{ true } | max(span.a) = 1'
+  - '{ true } | max(resource.a) = 1'
+  - '{ true } | max(1 + .a) = 1'
+  - '{ true } | max((1 + .a) * 2) = 1'
+  - 'max(duration) > 3s | { status = error || .http.status = 500 }'
   # pipelines
-  - "{ true } | { .a }"
-  - "{ true } | count() = 1"
-  - "{ true } | avg(duration) = 1h"
-  - "count() = 1 | { true }"
-  - "{ true } | count() = 1 | { true }"
+  - '{ true } | { .a }'
+  - '{ true } | count() = 1'
+  - '{ true } | avg(duration) = 1h'
+  - 'count() = 1 | { true }'
+  - '{ true } | count() = 1 | { true }'
   # pipeline expressions
-  - "({ true } | count() > 1 | { false }) && ({ true } | count() > 1 | { false })"
-  - "({ true } | count() > 1 | { false }) || ({ true } | count() > 1 | { false })"
-
+  - '({ true } | count() > 1 | { false }) && ({ true } | count() > 1 | { false })'
+  - '({ true } | count() > 1 | { false }) || ({ true } | count() > 1 | { false })'
+  
 # parse_fails throw an error when parsing
 parse_fails:
-  - "true"
-  - "[ true ]"
-  - "( true )"
+  - 'true'
+  - '[ true ]'
+  - '( true )'
   # spanset filters
-  - "{ . }"
-  - "{ < }"
-  - "{ .a < }"
-  - "{ .a < 3"
-  - "{ (.a < 3 }"
-  - "{ attribute = 4 }" # custom attribute not prefixed with ., span., resource. or parent.
-  - "{ .attribute == 4 }" # invalid operator
-  - "{ span. }"
+  - '{ . }'
+  - '{ < }'
+  - '{ .a < }'
+  - '{ .a < 3'
+  - '{ (.a < 3 }'
+  - '{ attribute = 4 }'           # custom attribute not prefixed with ., span., resource. or parent.
+  - '{ .attribute == 4 }'         # invalid operator
+  - '{ span. }'
   # spanset expressions
-  - "{ true } + { true }"
-  - "{ true } - { true }"
-  - "{ true } * { true }"
-  - "{ true } / { true }"
-  - "{ true } ^ { true }"
-  - "{ true } = { true }" # an interesting operator. possible future addition
-  - "{ true } <= { true }"
-  - "{ true } >= { true }"
-  - "{ true } < { true }"
+  - '{ true } + { true }'
+  - '{ true } - { true }'
+  - '{ true } * { true }'
+  - '{ true } / { true }'
+  - '{ true } ^ { true }'
+  - '{ true } = { true }'         # an interesting operator. possible future addition
+  - '{ true } <= { true }'
+  - '{ true } >= { true }'
+  - '{ true } < { true }'
   # scalar expressions must evaluate to a number
   - 'max(name) = "foo"'
   - 'avg("foo") = "bar"'
-  - "max(status) = ok"
-  - "max(kind) = consumer"
-  - "max(duration) < ok"
+  - 'max(status) = ok'
+  - 'max(kind) = consumer'
+  - 'max(duration) < ok'
   - 'min(1) = "foo"'
-  - "min(parent) = nil"
+  - 'min(parent) = nil'
   - 'avg(childCount) > "foo"'
   # scalar filters
-  - "avg(.field) + 1" # scalar filters must resolve to boolean
-  - "sum(3) - 2"
-  - "min(childCount) && 2"
+  - 'avg(.field) + 1'             # scalar filters must resolve to boolean
+  - 'sum(3) - 2'
+  - 'min(childCount) && 2'
   # pipelines
-  - "coalesce() | { true }" # pipelines can't start with coalesce
-  - "count() > 3 && { true }" # scalar filters have to be in pipeline
-  - "{ true } | count()" # naked scalar pipelines not allowed
-  - "{ true } | notAnAggregate() = 1"
-  - "{ true } | count = 1"
-  - "{ true } | max() = 1"
-  - "{ true } | by()"
+  - 'coalesce() | { true }'       # pipelines can't start with coalesce
+  - 'count() > 3 && { true }'     # scalar filters have to be in pipeline
+  - '{ true } | count()'          # naked scalar pipelines not allowed
+  - '{ true } | notAnAggregate() = 1'
+  - '{ true } | count = 1'
+  - '{ true } | max() = 1'
+  - '{ true } | by()'
   # pipeline expressions
-  - "({ true }) + (count()) = 1"
-  - "({ true }) && (count())"
-  - "({ true } | count()) && ({ true } | count()) = 1"
-  - "({ true }) + ({ true }) = 1"
-  - "({ true } | count()) + ({ true } | count())"
+  - '({ true }) + (count()) = 1'
+  - '({ true }) && (count())'
+  - '({ true } | count()) && ({ true } | count()) = 1'
+  - '({ true }) + ({ true }) = 1'
+  - '({ true } | count()) + ({ true } | count())'
   # todo: improve the following
-  - "(by(namespace) | count()) > 2 * 2" # scalar expressions are currently not allowed in scalar pipelines
-  - "(by(namespace) | count()) * 2 > 2"
-  - "2 < (by(namespace) | count())" # static value needs to be on the RHS to remove conflicts with scalar expressions
+  - '(by(namespace) | count()) > 2 * 2' # scalar expressions are currently not allowed in scalar pipelines
+  - '(by(namespace) | count()) * 2 > 2'
+  - '2 < (by(namespace) | count())'     # static value needs to be on the RHS to remove conflicts with scalar expressions
 
 # validate_fails parse correctly and return an error **besides unsupported** when calling .validate()
 validate_fails:
   # span expressions must evaluate to a boolean
-  - "{ status }"
-  - "{ kind }"
-  - "{ ok }"
-  - "{ 1.1 }"
-  - "{ 1h }"
+  - '{ status }'
+  - '{ kind }'
+  - '{ ok }'
+  - '{ 1.1 }'
+  - '{ 1h }'
   - '{ "foo" }'
-  - "{ 1 + 1 }"
+  - '{ 1 + 1 }'       
   # binary operators - incorrect types
   - '{ 1 + "foo" = 1 }'
-  - "{ 1 - true = 1 }"
-  - "{ 1 / ok = 1 }"
-  - "{ 1 ^ name = 1 }"
+  - '{ 1 - true = 1 }'
+  - '{ 1 / ok = 1 }'
+  - '{ 1 ^ name = 1 }'
   - '{ 1 = "foo" }'
-  - "{ 1 != true }"
-  - "{ 1 > ok }"
-  - "{ 1 = name }"
-  - "{ 1 =~ 2}"
+  - '{ 1 != true }'
+  - '{ 1 > ok }'
+  - '{ 1 = name }'
+  - '{ 1 =~ 2}'
+  - '{ 1 !~ 2}'
   - '{ 1 && "foo" }'
-  - "{ 1 || ok }"
-  - "{ true || 1.1 }"
-  - "{ status > ok }"
-  - "{ kind < consumer }"
+  - '{ 1 || ok }'
+  - '{ true || 1.1 }'
+  - '{ status > ok }'
+  - '{ kind < consumer }'
   # unary operators - incorrect types
-  - "{ -true }"
+  - '{ -true }'
   - '{ -"foo" = "bar" }'
-  - "{ -ok = status }"
+  - '{ -ok = status }'
   - '{ -name = "foo" }'
   - '{ !"foo" = "bar" }'
-  - "{ !ok = status }"
-  - "{ !consumer = kind }"
+  - '{ !ok = status }'
+  - '{ !consumer = kind }'
   - '{ !name = "foo" }'
-  - "{ !1 = 1 }"
-  - "{ !1h = 1 }"
-  - "{ !1.1 = 1.1 }"
+  - '{ !1 = 1 }'
+  - '{ !1h = 1 }'
+  - '{ !1.1 = 1.1 }'
   # scalar expressions must evaluate to a number
-  - "min(1 = 3) = 1"
+  - 'min(1 = 3) = 1'
   # scalar expressions must reference the span
-  - "sum(3) = 2"
-  - "sum(3) = min(14)"
-  - "min(2h) < max(duration)"
-  - "min(3) = max(duration)"
-  - "min(1) = max(2) + 3"
-  - "min(1.1 - 3) > 1"
-  - "max(1h + 2h) > 1"
+  - 'sum(3) = 2'
+  - 'sum(3) = min(14)'
+  - 'min(2h) < max(duration)'
+  - 'min(3) = max(duration)'
+  - 'min(1) = max(2) + 3'
+  - 'min(1.1 - 3) > 1'
+  - 'max(1h + 2h) > 1'
 
 # unsupported parse correctly and return an unsupported error when calling .validate()
 unsupported:
   # coalesce - will be valid when supported
-  - "{ true } | coalesce()"
-  - "{ true } | by(1 + .a) | coalesce()"
+  - '{ true } | coalesce()'
+  - '{ true } | by(1 + .a) | coalesce()'
   # by - will be valid when supported
-  - "{ true } | by(.a)"
-  - "{ true } | by(1 + .a)"
-  - "by(.a) | { true }"
-  - "{ true } | by(name) | count() > 2"
-  - "{ true } | by(.field) | avg(.b) = 2"
+  - '{ true } | by(.a)'
+  - '{ true } | by(1 + .a)'
+  - 'by(.a) | { true }'
+  - '{ true } | by(name) | count() > 2'
+  - '{ true } | by(.field) | avg(.b) = 2'
   # by - will *not* be valid when supported - group expressions must reference the span
-  - "{ true } | by(1)"
+  - '{ true } | by(1)'
   - '{ true } | by("foo")'
   # complex scalar filters - will be valid when supported
-  - "min(.field) < max(duration)"
-  - "sum(.field) = min(.field)"
-  - "min(.field) + max(.field) > 1"
-  - "min(.field) + max(childCount) > max(duration) - min(.field)"
-  - "min(childCount) < 2 / 6"
-  - "max(1 - (2 + .field)) < avg(3 * duration ^ 2)"
+  - 'min(.field) < max(duration)'
+  - 'sum(.field) = min(.field)'
+  - 'min(.field) + max(.field) > 1'
+  - 'min(.field) + max(childCount) > max(duration) - min(.field)'
+  - 'min(childCount) < 2 / 6'
+  - 'max(1 - (2 + .field)) < avg(3 * duration ^ 2)'
   # aggregates - will be valid when supported
-  - "min(childCount) < 2"
-  - "{ true } | max(parent.a) = 1"
-  - "{ true } | by(3 * .field - 2) | max(duration) < 1s"
-  - "{ .http.status = 200 } | max(.field) - min(.field) > 3"
+  - 'min(childCount) < 2'
+  - '{ true } | max(parent.a) = 1'
+  - '{ true } | by(3 * .field - 2) | max(duration) < 1s'
+  - '{ .http.status = 200 } | max(.field) - min(.field) > 3'
   # parent - will be valid when supported
-  - "{ parent.a != 3 }"
-  - "{ parent.resource.a && true }"
-  - "{ parent.span.a > 3 }"
-  - "{ parent.duration = 1h }"
-  - "{ parent = nil }"
-  - "{ (-(3 / 2) * .test - parent.blerg + .other)^3 = 2 }"
+  - '{ parent.a != 3 }'
+  - '{ parent.resource.a && true }'
+  - '{ parent.span.a > 3 }'
+  - '{ parent.duration = 1h }'
+  - '{ parent = nil }'
+  - '{ (-(3 / 2) * .test - parent.blerg + .other)^3 = 2 }'
   # parent - will not be valid when supported
-  - "{ parent }"
-  - "{ 1 % parent = 1 }"
-  - "{ 1 >= parent }"
-  - "{ -parent = nil }"
-  - "{ !parent = nil }"
+  - '{ parent }'
+  - '{ 1 % parent = 1 }'
+  - '{ 1 >= parent }'
+  - '{ -parent = nil }'
+  - '{ !parent = nil }'
   # nil - will be valid when supported
-  - "{ .foo = nil }"
+  - '{ .foo = nil }'
   # childCount - will be valid when supported
-  - "{ 1 = childCount }"
+  - '{ 1 = childCount }'
   # childCount - will be invalid when supported
   - '{ "foo" = childCount }'
   # spanset operations - will be valid when supported
-  - "{ true } >> { true }"
-  - "{ true } > { true }"
-  - "{ true } ~ { true }"
-  - "({ true } | count() > 1 | { false }) >> ({ true } | count() > 1 | { false })"
-  - "({ true } | count() > 1 | { false }) > ({ true } | count() > 1 | { false })"
-  - "({ true } | count() > 1 | { false }) ~ ({ true } | count() > 1 | { false })"
+  - '{ true } >> { true }'
+  - '{ true } > { true }'
+  - '{ true } ~ { true }'
+  - '({ true } | count() > 1 | { false }) >> ({ true } | count() > 1 | { false })'
+  - '({ true } | count() > 1 | { false }) > ({ true } | count() > 1 | { false })'
+  - '({ true } | count() > 1 | { false }) ~ ({ true } | count() > 1 | { false })'
   # spanset pipelines + scalar filters - will be valid when supported
-  - "{ true } | count() + count() = 1"
-  - "({ true } | count()) + ({ true } | count()) = 1"
-  - "({ true } | count()) - ({ true } | count()) <= 1"
-  - "({ true } | count()) / ({ true } | count()) > ({ true } | count()) / ({ true } | count())"
-  - "({ true } | count()) * ({ true } | count()) < ({ true } | count()) / ({ true } | count())"
-  - "({ .http.status = 200 } | count()) + ({ name = `foo` } | avg(duration)) = 2"
-  - "({ .a } | count()) > ({ .b } | count())"
+  - '{ true } | count() + count() = 1' 
+  - '({ true } | count()) + ({ true } | count()) = 1'
+  - '({ true } | count()) - ({ true } | count()) <= 1'
+  - '({ true } | count()) / ({ true } | count()) > ({ true } | count()) / ({ true } | count())'
+  - '({ true } | count()) * ({ true } | count()) < ({ true } | count()) / ({ true } | count())'
+  - '({ .http.status = 200 } | count()) + ({ name = `foo` } | avg(duration)) = 2'
+  - '({ .a } | count()) > ({ .b } | count())'
   # other scalar filters. no idea if these should be supported
-  - "3 = 2" # naked scalar filter, technically allowed
-  - "avg(.field) > 1 - 3" # scalar expressions in scalar filters are currently not allowed. possible future addition
+  - '3 = 2'                       # naked scalar filter, technically allowed
+  - 'avg(.field) > 1 - 3'         # scalar expressions in scalar filters are currently not allowed. possible future addition
 
 # parsed and the ast is dumped to stdout. this is a debugging tool
 dump:

--- a/tempodb/encoding/vparquet/block_traceql.go
+++ b/tempodb/encoding/vparquet/block_traceql.go
@@ -195,7 +195,7 @@ func checkConditions(conditions []traceql.Condition) error {
 		case traceql.OpEqual, traceql.OpNotEqual,
 			traceql.OpGreater, traceql.OpGreaterEqual,
 			traceql.OpLess, traceql.OpLessEqual,
-			traceql.OpRegex:
+			traceql.OpRegex, traceql.OpNotRegex:
 			if opCount != 1 {
 				return fmt.Errorf("operation %v must have exactly 1 argument. condition: %+v", cond.Op, cond)
 			}
@@ -837,6 +837,8 @@ func createStringPredicate(op traceql.Operator, operands traceql.Operands) (parq
 
 	case traceql.OpRegex:
 		return parquetquery.NewRegexInPredicate([]string{s})
+	case traceql.OpNotRegex:
+		return parquetquery.NewRegexNotInPredicate([]string{s})
 	case traceql.OpEqual:
 		return parquetquery.NewStringInPredicate([]string{s}), nil
 	case traceql.OpGreater:

--- a/tempodb/encoding/vparquet/block_traceql_test.go
+++ b/tempodb/encoding/vparquet/block_traceql_test.go
@@ -138,6 +138,7 @@ func TestBackendBlockSearchTraceQL(t *testing.T) {
 		traceql.MustExtractFetchSpansRequest(`{.foo = "def"}`),         // String ==
 		traceql.MustExtractFetchSpansRequest(`{.foo != "deg"}`),        // String !=
 		traceql.MustExtractFetchSpansRequest(`{.foo =~ "d.*"}`),        // String Regex
+		traceql.MustExtractFetchSpansRequest(`{.foo !~ "x.*"}`),        // String Not Regex
 		traceql.MustExtractFetchSpansRequest(`{resource.foo = "abc"}`), // Resource-level only
 		traceql.MustExtractFetchSpansRequest(`{span.foo = "def"}`),     // Span-level only
 		traceql.MustExtractFetchSpansRequest(`{.foo}`),                 // Projection only
@@ -222,6 +223,7 @@ func TestBackendBlockSearchTraceQL(t *testing.T) {
 		// TODO - Should the below query return data or not?  It does match the resource
 		// makeReq(parse(t, `{.foo = "abc"}`)),                           // This should not return results because the span has overridden this attribute to "def".
 		traceql.MustExtractFetchSpansRequest(`{.foo =~ "xyz.*"}`),                                     // Regex IN
+		traceql.MustExtractFetchSpansRequest(`{.foo !~ ".*"}`),                                        // Regex IN
 		traceql.MustExtractFetchSpansRequest(`{span.bool = true}`),                                    // Bool not match
 		traceql.MustExtractFetchSpansRequest(`{` + LabelDuration + ` >  100s}`),                       // Intrinsic: duration
 		traceql.MustExtractFetchSpansRequest(`{` + LabelStatus + ` = ok}`),                            // Intrinsic: status

--- a/tempodb/encoding/vparquet2/block_traceql.go
+++ b/tempodb/encoding/vparquet2/block_traceql.go
@@ -196,7 +196,7 @@ func checkConditions(conditions []traceql.Condition) error {
 		case traceql.OpEqual, traceql.OpNotEqual,
 			traceql.OpGreater, traceql.OpGreaterEqual,
 			traceql.OpLess, traceql.OpLessEqual,
-			traceql.OpRegex:
+			traceql.OpRegex, traceql.OpNotRegex:
 			if opCount != 1 {
 				return fmt.Errorf("operation %v must have exactly 1 argument. condition: %+v", cond.Op, cond)
 			}
@@ -825,6 +825,8 @@ func createStringPredicate(op traceql.Operator, operands traceql.Operands) (parq
 
 	case traceql.OpRegex:
 		return parquetquery.NewRegexInPredicate([]string{s})
+	case traceql.OpNotRegex:
+		return parquetquery.NewRegexNotInPredicate([]string{s})
 
 	case traceql.OpEqual:
 		return parquetquery.NewStringInPredicate([]string{s}), nil

--- a/tempodb/encoding/vparquet2/block_traceql_test.go
+++ b/tempodb/encoding/vparquet2/block_traceql_test.go
@@ -139,6 +139,7 @@ func TestBackendBlockSearchTraceQL(t *testing.T) {
 		traceql.MustExtractFetchSpansRequest(`{.foo = "def"}`),         // String ==
 		traceql.MustExtractFetchSpansRequest(`{.foo != "deg"}`),        // String !=
 		traceql.MustExtractFetchSpansRequest(`{.foo =~ "d.*"}`),        // String Regex
+		traceql.MustExtractFetchSpansRequest(`{.foo !~ "x.*"}`),        // String Not Regex
 		traceql.MustExtractFetchSpansRequest(`{resource.foo = "abc"}`), // Resource-level only
 		traceql.MustExtractFetchSpansRequest(`{span.foo = "def"}`),     // Span-level only
 		traceql.MustExtractFetchSpansRequest(`{.foo}`),                 // Projection only
@@ -223,6 +224,7 @@ func TestBackendBlockSearchTraceQL(t *testing.T) {
 		// TODO - Should the below query return data or not?  It does match the resource
 		// makeReq(parse(t, `{.foo = "abc"}`)),                           // This should not return results because the span has overridden this attribute to "def".
 		traceql.MustExtractFetchSpansRequest(`{.foo =~ "xyz.*"}`),                                     // Regex IN
+		traceql.MustExtractFetchSpansRequest(`{.foo !~ ".*"}`),                                        // String Not Regex
 		traceql.MustExtractFetchSpansRequest(`{span.bool = true}`),                                    // Bool not match
 		traceql.MustExtractFetchSpansRequest(`{` + LabelDuration + ` >  100s}`),                       // Intrinsic: duration
 		traceql.MustExtractFetchSpansRequest(`{` + LabelStatus + ` = ok}`),                            // Intrinsic: status


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

* Enables parsing `!~` in tracql
* Support for filtering values using negated regex pattern

**Which issue(s) this PR fixes**:
Fixes #1990

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`