### PR TITLE
Unroll RowNumber Next()

### DIFF
--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -92,17 +92,7 @@ func (t *RowNumber) Valid() bool {
 func (t *RowNumber) Next(repetitionLevel, definitionLevel int) {
 	t[repetitionLevel]++
 
-	// the following is these loops unrolled:
-	// New children up through the definition level
-	// for i := repetitionLevel + 1; i <= definitionLevel; i++ {
-	// 	t[i] = 0
-	// }
-
-	// // Children past the definition level are undefined
-	// for i := definitionLevel + 1; i < len(t); i++ {
-	// 	t[i] = -1
-	// }
-
+	// the following is nextSlow() unrolled
 	switch repetitionLevel {
 	case 0:
 		switch definitionLevel {
@@ -282,6 +272,22 @@ func (t *RowNumber) Next(repetitionLevel, definitionLevel int) {
 		case 4:
 			t[5] = -1
 		}
+	}
+}
+
+// nextSlow is the original implementation of next. it is kept to test against
+// the unrolled version above
+func (t *RowNumber) nextSlow(repetitionLevel, definitionLevel int) {
+	t[repetitionLevel]++
+
+	// New children up through the definition level
+	for i := repetitionLevel + 1; i <= definitionLevel; i++ {
+		t[i] = 0
+	}
+
+	// // Children past the definition level are undefined
+	for i := definitionLevel + 1; i < len(t); i++ {
+		t[i] = -1
 	}
 }
 

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -90,17 +90,198 @@ func (t *RowNumber) Valid() bool {
 // gb     | 1 | 3 | {  0,  2,  0,  0 }
 // null   | 0 | 1 | {  1,  0, -1, -1 }
 func (t *RowNumber) Next(repetitionLevel, definitionLevel int) {
-	// Next row at this level
 	t[repetitionLevel]++
 
+	// the following is these loops unrolled:
 	// New children up through the definition level
-	for i := repetitionLevel + 1; i <= definitionLevel; i++ {
-		t[i] = 0
-	}
+	// for i := repetitionLevel + 1; i <= definitionLevel; i++ {
+	// 	t[i] = 0
+	// }
 
-	// Children past the definition level are undefined
-	for i := definitionLevel + 1; i < len(t); i++ {
-		t[i] = -1
+	// // Children past the definition level are undefined
+	// for i := definitionLevel + 1; i < len(t); i++ {
+	// 	t[i] = -1
+	// }
+
+	switch repetitionLevel {
+	case 0:
+		switch definitionLevel {
+		case 0:
+			t[1] = -1
+			t[2] = -1
+			t[3] = -1
+			t[4] = -1
+			t[5] = -1
+		case 1:
+			t[1] = 0
+			t[2] = -1
+			t[3] = -1
+			t[4] = -1
+			t[5] = -1
+		case 2:
+			t[1] = 0
+			t[2] = 0
+			t[3] = -1
+			t[4] = -1
+			t[5] = -1
+		case 3:
+			t[1] = 0
+			t[2] = 0
+			t[3] = 0
+			t[4] = -1
+			t[5] = -1
+		case 4:
+			t[1] = 0
+			t[2] = 0
+			t[3] = 0
+			t[4] = 0
+			t[5] = -1
+		case 5:
+			t[1] = 0
+			t[2] = 0
+			t[3] = 0
+			t[4] = 0
+			t[5] = 0
+		}
+	case 1:
+		switch definitionLevel {
+		case 0:
+			t[1] = -1
+			t[2] = -1
+			t[3] = -1
+			t[4] = -1
+			t[5] = -1
+		case 1:
+			t[2] = -1
+			t[3] = -1
+			t[4] = -1
+			t[5] = -1
+		case 2:
+			t[2] = 0
+			t[3] = -1
+			t[4] = -1
+			t[5] = -1
+		case 3:
+			t[2] = 0
+			t[3] = 0
+			t[4] = -1
+			t[5] = -1
+		case 4:
+			t[2] = 0
+			t[3] = 0
+			t[4] = 0
+			t[5] = -1
+		case 5:
+			t[2] = 0
+			t[3] = 0
+			t[4] = 0
+			t[5] = 0
+		}
+	case 2:
+		switch definitionLevel {
+		case 0:
+			t[1] = -1
+			t[2] = -1
+			t[3] = -1
+			t[4] = -1
+			t[5] = -1
+		case 1:
+			t[2] = -1
+			t[3] = -1
+			t[4] = -1
+			t[5] = -1
+		case 2:
+			t[3] = -1
+			t[4] = -1
+			t[5] = -1
+		case 3:
+			t[3] = 0
+			t[4] = -1
+			t[5] = -1
+		case 4:
+			t[3] = 0
+			t[4] = 0
+			t[5] = -1
+		case 5:
+			t[3] = 0
+			t[4] = 0
+			t[5] = 0
+		}
+	case 3:
+		switch definitionLevel {
+		case 0:
+			t[1] = -1
+			t[2] = -1
+			t[3] = -1
+			t[4] = -1
+			t[5] = -1
+		case 1:
+			t[2] = -1
+			t[3] = -1
+			t[4] = -1
+			t[5] = -1
+		case 2:
+			t[3] = -1
+			t[4] = -1
+			t[5] = -1
+		case 3:
+			t[4] = -1
+			t[5] = -1
+		case 4:
+			t[4] = 0
+			t[5] = -1
+		case 5:
+			t[4] = 0
+			t[5] = 0
+		}
+	case 4:
+		switch definitionLevel {
+		case 0:
+			t[1] = -1
+			t[2] = -1
+			t[3] = -1
+			t[4] = -1
+			t[5] = -1
+		case 1:
+			t[2] = -1
+			t[3] = -1
+			t[4] = -1
+			t[5] = -1
+		case 2:
+			t[3] = -1
+			t[4] = -1
+			t[5] = -1
+		case 3:
+			t[4] = -1
+			t[5] = -1
+		case 4:
+			t[5] = -1
+		case 5:
+			t[5] = 0
+		}
+	case 5:
+		switch definitionLevel {
+		case 0:
+			t[1] = -1
+			t[2] = -1
+			t[3] = -1
+			t[4] = -1
+			t[5] = -1
+		case 1:
+			t[2] = -1
+			t[3] = -1
+			t[4] = -1
+			t[5] = -1
+		case 2:
+			t[3] = -1
+			t[4] = -1
+			t[5] = -1
+		case 3:
+			t[4] = -1
+			t[5] = -1
+		case 4:
+			t[5] = -1
+		}
 	}
 }
 

--- a/pkg/parquetquery/iters_test.go
+++ b/pkg/parquetquery/iters_test.go
@@ -3,6 +3,7 @@ package parquetquery
 import (
 	"context"
 	"math"
+	"math/rand"
 	"os"
 	"testing"
 
@@ -22,6 +23,23 @@ var iterTestCases = []struct {
 	{"sync", func(pf *parquet.File, idx int, filter Predicate, selectAs string) Iterator {
 		return NewSyncIterator(context.TODO(), pf.RowGroups(), idx, selectAs, 1000, filter, selectAs)
 	}},
+}
+
+// TestNext compares the unrolled Next() with the original nextSlow() to
+// prevent drift
+func TestNext(t *testing.T) {
+	rn1 := RowNumber{0, 0, 0, 0, 0, 0}
+	rn2 := RowNumber{0, 0, 0, 0, 0, 0}
+
+	for i := 0; i < 1000; i++ {
+		r := rand.Intn(6)
+		d := rand.Intn(6)
+
+		rn1.Next(r, d)
+		rn2.nextSlow(r, d)
+
+		require.Equal(t, rn1, rn2)
+	}
 }
 
 func TestRowNumber(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:
When executing large fetches the `Next()` function is called continuously. This PR unrolls `Next()` for better performance.

Next Benchmarks:
```
name    old time/op  new time/op  delta
Next-8  83.8ns ± 1%  66.6ns ± 2%  -20.44%  (p=0.000 n=10+10)
```

Fetch benchmarks:
```
name                                               old time/op    new time/op    delta
BackendBlockTraceQL/spanAttNameNoMatch-8             27.2ms ± 5%    27.0ms ± 1%     ~     (p=1.000 n=5+5)
BackendBlockTraceQL/spanAttValNoMatch-8              36.6ms ±12%    33.9ms ± 2%   -7.25%  (p=0.032 n=5+5)
BackendBlockTraceQL/spanAttValMatch-8                 414ms ± 2%     401ms ± 2%   -3.23%  (p=0.016 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8        26.1ms ± 2%    25.2ms ± 3%   -3.69%  (p=0.008 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicMatch-8           353ms ± 2%     355ms ± 2%     ~     (p=1.000 n=5+5)
BackendBlockTraceQL/resourceAttNameNoMatch-8         12.8ms ± 4%    12.3ms ± 2%     ~     (p=0.056 n=5+5)
BackendBlockTraceQL/resourceAttValNoMatch-8          45.5ms ± 5%    45.2ms ± 5%     ~     (p=0.548 n=5+5)
BackendBlockTraceQL/resourceAttValMatch-8             346ms ± 2%     338ms ± 3%     ~     (p=0.095 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicNoMatch-8    11.1ms ± 4%    10.9ms ± 4%     ~     (p=0.222 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8       266ms ± 2%     263ms ± 2%     ~     (p=0.421 n=5+5)
BackendBlockTraceQL/mixedNameNoMatch-8                5.99s ± 5%     5.78s ± 2%   -3.62%  (p=0.032 n=5+5)
BackendBlockTraceQL/mixedValNoMatch-8                 4.05s ± 1%     3.55s ± 2%  -12.54%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchAnd-8          13.4ms ± 9%    11.9ms ± 3%  -11.29%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchOr-8            3.78s ± 4%     3.39s ± 6%  -10.25%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedValBothMatch-8              12.0ms ± 4%    11.9ms ± 4%     ~     (p=0.548 n=5+5)

name                                               old speed      new speed      delta
BackendBlockTraceQL/spanAttNameNoMatch-8            488MB/s ± 4%   492MB/s ± 1%     ~     (p=1.000 n=5+5)
BackendBlockTraceQL/spanAttValNoMatch-8             548MB/s ±11%   588MB/s ± 2%   +7.40%  (p=0.032 n=5+5)
BackendBlockTraceQL/spanAttValMatch-8              43.4MB/s ± 2%  44.8MB/s ± 3%   +3.34%  (p=0.016 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8       514MB/s ± 2%   534MB/s ± 3%   +3.85%  (p=0.008 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicMatch-8         454MB/s ± 2%   452MB/s ± 2%     ~     (p=1.000 n=5+5)
BackendBlockTraceQL/resourceAttNameNoMatch-8        403MB/s ± 4%   419MB/s ± 2%     ~     (p=0.056 n=5+5)
BackendBlockTraceQL/resourceAttValNoMatch-8         424MB/s ± 5%   427MB/s ± 5%     ~     (p=0.548 n=5+5)
BackendBlockTraceQL/resourceAttValMatch-8           609MB/s ± 2%   624MB/s ± 3%     ~     (p=0.095 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicNoMatch-8  76.8MB/s ± 4%  78.0MB/s ± 4%     ~     (p=0.222 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8     696MB/s ± 2%   702MB/s ± 2%     ~     (p=0.421 n=5+5)
BackendBlockTraceQL/mixedNameNoMatch-8             10.3MB/s ± 5%  10.7MB/s ± 2%   +3.68%  (p=0.032 n=5+5)
BackendBlockTraceQL/mixedValNoMatch-8              15.2MB/s ± 1%  17.4MB/s ± 2%  +14.36%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchAnd-8         384MB/s ± 9%   432MB/s ± 3%  +12.52%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchOr-8         50.3MB/s ± 4%  56.1MB/s ± 6%  +11.51%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedValBothMatch-8            70.9MB/s ± 4%  72.1MB/s ± 4%     ~     (p=0.548 n=5+5)

name                                               old MB_io/op   new MB_io/op   delta
BackendBlockTraceQL/spanAttNameNoMatch-8               13.3 ± 0%      13.3 ± 0%     ~     (all equal)
BackendBlockTraceQL/spanAttValNoMatch-8                20.0 ± 0%      20.0 ± 0%     ~     (all equal)
BackendBlockTraceQL/spanAttValMatch-8                  18.0 ± 0%      18.0 ± 0%     ~     (all equal)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8          13.4 ± 0%      13.4 ± 0%     ~     (all equal)
BackendBlockTraceQL/spanAttIntrinsicMatch-8             160 ± 0%       160 ± 0%     ~     (all equal)
BackendBlockTraceQL/resourceAttNameNoMatch-8           5.14 ± 0%      5.14 ± 0%     ~     (all equal)
BackendBlockTraceQL/resourceAttValNoMatch-8            19.3 ± 0%      19.3 ± 0%     ~     (all equal)
BackendBlockTraceQL/resourceAttValMatch-8               211 ± 0%       211 ± 0%     ~     (all equal)
BackendBlockTraceQL/resourceAttIntrinsicNoMatch-8      0.85 ± 0%      0.85 ± 0%     ~     (all equal)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8         185 ± 0%       185 ± 0%     ~     (all equal)
BackendBlockTraceQL/mixedNameNoMatch-8                 61.6 ± 0%      61.6 ± 0%     ~     (all equal)
BackendBlockTraceQL/mixedValNoMatch-8                  61.6 ± 0%      61.6 ± 0%     ~     (all equal)
BackendBlockTraceQL/mixedValMixedMatchAnd-8            5.14 ± 0%      5.14 ± 0%     ~     (all equal)
BackendBlockTraceQL/mixedValMixedMatchOr-8              190 ± 0%       190 ± 0%     ~     (all equal)
BackendBlockTraceQL/mixedValBothMatch-8                0.85 ± 0%      0.85 ± 0%     ~     (all equal)
```
