### PR TITLE
Fix Race Condition on Inspected Blocks

### DIFF
--- a/modules/ingester/instance_search.go
+++ b/modules/ingester/instance_search.go
@@ -439,11 +439,10 @@ func (i *instance) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTag
 			return nil // Early exit if any error has occurred
 		}
 
-		if maxBlocks > 0 && inspectedBlocks.Load() >= maxBlocks {
+		if maxBlocks > 0 && inspectedBlocks.Inc() > maxBlocks {
 			return nil
 		}
 
-		inspectedBlocks.Inc()
 		fetcher := traceql.NewSpansetFetcherWrapper(func(ctx context.Context, req traceql.FetchSpansRequest) (traceql.FetchSpansResponse, error) {
 			return s.Fetch(ctx, req, common.DefaultSearchOptions())
 		})


### PR DESCRIPTION
**What this PR does**:
In practice this race condition simply meant that occasionally we searched more blocks then was set up in the limit. However this was regularly breaking tests. This PR corrects the race condition.

While making this fix it occurs to me that the way this is written the blocks we search are non deterministic. I think an improvement here would be to guarantee that the same blocks are always searched.

cc @mapno 

