### PR TITLE
Fix intrinsics in v2 tag value search

### DIFF
--- a/pkg/traceql/engine.go
+++ b/pkg/traceql/engine.go
@@ -382,7 +382,7 @@ func (s Static) asAnyValue() *common_v1.AnyValue {
 // a number with an optional time unit (such as "ns", "ms", "s", "m", or "h"),
 // a plain number, or the boolean values "true" or "false".
 // Example: "http.status_code = 200" from the query "{ .http.status_code = 200 && .http.method = }"
-var matchersRegexp = regexp.MustCompile(`[a-zA-Z._]+\s*[=|<=|>=|=~|!=|>|<|!~]\s*(?:"[a-zA-Z./_0-9-]+"|[0-9smh]+|true|false|)`)
+var matchersRegexp = regexp.MustCompile(`[a-zA-Z._]+\s*[=|<=|>=|=~|!=|>|<|!~]\s*(?:"[a-zA-Z./_0-9-]+"|[0-9smh]+|true|false)`)
 
 // TODO: Merge into a single regular expression
 

--- a/pkg/traceql/engine.go
+++ b/pkg/traceql/engine.go
@@ -165,14 +165,27 @@ func (e *Engine) ExecuteTagValues(
 			}
 			return false
 		}
-	case AttributeScopeNone: // If tag is unscoped, let's check all scopes manually
+	case AttributeScopeNone:
+		// If tag is unscoped, it can either be an intrinsic (eg. `name`) or an unscoped attribute (eg. `.namespace`)
+		//
+		// If the tag is intrinsic Attribute.Intrinsic is set to the Intrinsic it corresponds,
+		// so we can check against `!= IntrinsicNone` and use wantAttr directly.
+		//
+		// If the tag is unscoped, we need to check resource and span scoped manually by building a new Attribute with each scope.
 		collectAttributeValue = func(s Span) bool {
-			for _, scope := range []AttributeScope{AttributeScopeResource, AttributeScopeSpan} {
-				scopedAttr := Attribute{Scope: scope, Parent: wantAttr.Parent, Name: wantAttr.Name, Intrinsic: wantAttr.Intrinsic}
-				if v, ok := s.Attributes()[scopedAttr]; ok {
+			if wantAttr.Intrinsic != IntrinsicNone { // it's intrinsic
+				if v, ok := s.Attributes()[wantAttr]; ok {
 					return cb(v)
 				}
+			} else { // it's unscoped
+				for _, scope := range []AttributeScope{AttributeScopeResource, AttributeScopeSpan} {
+					scopedAttr := Attribute{Scope: scope, Parent: wantAttr.Parent, Name: wantAttr.Name}
+					if v, ok := s.Attributes()[scopedAttr]; ok {
+						return cb(v)
+					}
+				}
 			}
+
 			return false
 		}
 	default:
@@ -369,7 +382,7 @@ func (s Static) asAnyValue() *common_v1.AnyValue {
 // a number with an optional time unit (such as "ns", "ms", "s", "m", or "h"),
 // a plain number, or the boolean values "true" or "false".
 // Example: "http.status_code = 200" from the query "{ .http.status_code = 200 && .http.method = }"
-var matchersRegexp = regexp.MustCompile(`[a-zA-Z._]+\s*[=|<=|>=|=~|!=|>|<|!~]\s*(?:"[a-zA-Z._-]+"|[0-9smh]+|true|false)`)
+var matchersRegexp = regexp.MustCompile(`[a-zA-Z._]+\s*[=|<=|>=|=~|!=|>|<|!~]\s*(?:"[a-zA-Z./_0-9-]+"|[0-9smh]+|true|false|)`)
 
 // TODO: Merge into a single regular expression
 
@@ -384,7 +397,7 @@ var matchersRegexp = regexp.MustCompile(`[a-zA-Z._]+\s*[=|<=|>=|=~|!=|>|<|!~]\s*
 // { .bar = "foo" || .foo = "bar" }          |   No
 // { .bar = "foo" } && { .foo = "bar" }      |   No
 // { .bar = "foo" } || { .foo = "bar" }      |   No
-var singleFilterRegexp = regexp.MustCompile(`^{[a-zA-Z._\s\-()&=<>~!0-9"]*}$`)
+var singleFilterRegexp = regexp.MustCompile(`^{[a-zA-Z._\s\-()/&=<>~!0-9"]*}$`)
 
 // extractMatchers extracts matchers from a query string and returns a string that can be parsed by the storage layer.
 func extractMatchers(query string) string {

--- a/pkg/traceql/engine_test.go
+++ b/pkg/traceql/engine_test.go
@@ -83,11 +83,9 @@ func TestEngine_Execute(t *testing.T) {
 
 	expectedTraceSearchMetadata := []*tempopb.TraceSearchMetadata{
 		{
-			TraceID:           "1",
-			RootServiceName:   "my-service",
-			RootTraceName:     "HTTP GET",
-			StartTimeUnixNano: 0,
-			DurationMs:        0,
+			TraceID:         "1",
+			RootServiceName: "my-service",
+			RootTraceName:   "HTTP GET",
 			SpanSet: &tempopb.SpanSet{
 				Spans: []*tempopb.Span{
 					{
@@ -287,23 +285,25 @@ type MockSpanSetIterator struct {
 	filter  FilterSpans
 }
 
-func (m *MockSpanSetIterator) Next(ctx context.Context) (*Spanset, error) {
-	if len(m.results) == 0 {
-		return nil, nil
-	}
-	r := m.results[0]
-	m.results = m.results[1:]
+func (m *MockSpanSetIterator) Next(context.Context) (*Spanset, error) {
+	for {
+		if len(m.results) == 0 {
+			return nil, nil
+		}
+		r := m.results[0]
+		m.results = m.results[1:]
 
-	ss, err := m.filter(r)
-	if err != nil {
-		return nil, err
-	}
-	if len(ss) == 0 {
-		return &Spanset{}, nil
-	}
+		ss, err := m.filter(r)
+		if err != nil {
+			return nil, err
+		}
+		if len(ss) == 0 {
+			continue
+		}
 
-	r.Spans = r.Spans[len(ss):]
-	return r, nil
+		r.Spans = r.Spans[len(ss):]
+		return r, nil
+	}
 }
 
 func (m *MockSpanSetIterator) Close() {}
@@ -469,7 +469,7 @@ func TestExecuteTagValues(t *testing.T) {
 			},
 			expectedValues: []tempopb.TagValue{
 				{Type: "String", Value: "HTTP GET /status"},
-				{Type: "String", Value: "HTTP POST"},
+				{Type: "String", Value: "HTTP POST /api/v1/users"},
 				{Type: "String", Value: "redis call"},
 			},
 		},


### PR DESCRIPTION
**What this PR does**:

Correctly handles intrinsic attributes in `/api/v2/search/<tag>/values`

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`