### PR TITLE
Search streaming: fix race condition

### DIFF
--- a/modules/frontend/search_progress.go
+++ b/modules/frontend/search_progress.go
@@ -50,7 +50,9 @@ type searchProgress struct {
 }
 
 func newSearchProgress() *searchProgress {
-	return &searchProgress{}
+	return &searchProgress{
+		resultsMetrics: &tempopb.SearchMetrics{},
+	}
 }
 
 func (r *searchProgress) init(ctx context.Context, limit, totalJobs, totalBlocks, totalBlockBytes int) {


### PR DESCRIPTION
**What this PR does**:
Fixes a nil pointer exception race condition in search streaming. If `.results()` was called before `.init()` then the frontend would panic trying to deference a nil resultsMetrics. This happens sometimes in search streaming.