### PR TITLE
Query-frontend: allow unknown fields

### DIFF
--- a/modules/frontend/searchsharding.go
+++ b/modules/frontend/searchsharding.go
@@ -218,7 +218,7 @@ func (s searchSharder) RoundTrip(r *http.Request) (*http.Response, error) {
 
 			// successful query, read the body
 			results := &tempopb.SearchResponse{}
-			err = jsonpb.Unmarshal(resp.Body, results)
+			err = (&jsonpb.Unmarshaler{AllowUnknownFields: true}).Unmarshal(resp.Body, results)
 			if err != nil {
 				_ = level.Error(s.logger).Log("msg", "error reading response body status == ok", "url", innerR.RequestURI, "err", err)
 				s.progress.setError(err)


### PR DESCRIPTION
**What this PR does**:
Currently if there is a mismatch between the json sent by the querier and the one expected by the query-frontend it will fail to parse. This was recently revealed with the rename of `inspectedBlocks` -> `totalBlocks`.

This PR allows the frontend to leniently parse the response from the querier which prevent this issue and simplifies rollouts.