### PR TITLE
Add config param for autocomplete filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
       concurrent_shards: 3
   ```
 * [FEATURE] Add support for `q` query param in `/api/v2/search/<tag.name>/values` to filter results based on a TraceQL query [#2253](https://github.com/grafana/tempo/pull/2253) (@mapno)
+To make use of filtering, configure `autocomplete_filtering_enabled`.
 * [FEATURE] Add a GRPC streaming endpoint for traceql search [#2366](https://github.com/grafana/tempo/pull/2366) (@joe-elliott)
 * [ENHANCEMENT] Add `scope` parameter to `/api/search/tags` [#2282](https://github.com/grafana/tempo/pull/2282) (@joe-elliott)
   Create new endpoint `/api/v2/search/tags` that returns all tags organized by scope.

--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -51,8 +51,9 @@ var (
 		nil,
 	)
 
-	statFeatureEnabledAuth         = usagestats.NewInt("feature_enabled_auth_stats")
-	statFeatureEnabledMultitenancy = usagestats.NewInt("feature_enabled_multitenancy")
+	statFeatureEnabledAuth                  = usagestats.NewInt("feature_enabled_auth_stats")
+	statFeatureEnabledMultitenancy          = usagestats.NewInt("feature_enabled_multitenancy")
+	statFeatureAutocompleteFilteringEnabled = usagestats.NewInt("feature_enabled_autocomplete_filtering")
 )
 
 // App is the root datastructure.
@@ -98,6 +99,11 @@ func New(cfg Config) (*App, error) {
 	statFeatureEnabledMultitenancy.Set(0)
 	if cfg.MultitenancyEnabled {
 		statFeatureEnabledMultitenancy.Set(1)
+	}
+
+	statFeatureAutocompleteFilteringEnabled.Set(0)
+	if cfg.AutocompleteFilteringEnabled {
+		statFeatureAutocompleteFilteringEnabled.Set(1)
 	}
 
 	app.setupAuthMiddleware()

--- a/cmd/tempo/app/config.go
+++ b/cmd/tempo/app/config.go
@@ -27,12 +27,13 @@ import (
 
 // Config is the root config for App.
 type Config struct {
-	Target                 string `yaml:"target,omitempty"`
-	AuthEnabled            bool   `yaml:"auth_enabled,omitempty"`
-	MultitenancyEnabled    bool   `yaml:"multitenancy_enabled,omitempty"`
-	HTTPAPIPrefix          string `yaml:"http_api_prefix"`
-	UseOTelTracer          bool   `yaml:"use_otel_tracer,omitempty"`
-	EnableGoRuntimeMetrics bool   `yaml:"enable_go_runtime_metrics,omitempty"`
+	Target                       string `yaml:"target,omitempty"`
+	AuthEnabled                  bool   `yaml:"auth_enabled,omitempty"`
+	MultitenancyEnabled          bool   `yaml:"multitenancy_enabled,omitempty"`
+	HTTPAPIPrefix                string `yaml:"http_api_prefix"`
+	UseOTelTracer                bool   `yaml:"use_otel_tracer,omitempty"`
+	EnableGoRuntimeMetrics       bool   `yaml:"enable_go_runtime_metrics,omitempty"`
+	AutocompleteFilteringEnabled bool   `yaml:"autocomplete_filtering_enabled"`
 
 	Server          server.Config           `yaml:"server,omitempty"`
 	InternalServer  internalserver.Config   `yaml:"internal_server,omitempty"`
@@ -67,6 +68,7 @@ func (c *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 	f.StringVar(&c.HTTPAPIPrefix, "http-api-prefix", "", "String prefix for all http api endpoints.")
 	f.BoolVar(&c.UseOTelTracer, "use-otel-tracer", false, "Set to true to replace the OpenTracing tracer with the OpenTelemetry tracer")
 	f.BoolVar(&c.EnableGoRuntimeMetrics, "enable-go-runtime-metrics", false, "Set to true to enable all Go runtime metrics")
+	f.BoolVar(&c.AutocompleteFilteringEnabled, "autocomplete-filtering.enabled", false, "Set to true to enable autocomplete filtering")
 
 	// Server settings
 	flagext.DefaultValues(&c.Server)

--- a/cmd/tempo/app/config.go
+++ b/cmd/tempo/app/config.go
@@ -33,7 +33,7 @@ type Config struct {
 	HTTPAPIPrefix                string `yaml:"http_api_prefix"`
 	UseOTelTracer                bool   `yaml:"use_otel_tracer,omitempty"`
 	EnableGoRuntimeMetrics       bool   `yaml:"enable_go_runtime_metrics,omitempty"`
-	AutocompleteFilteringEnabled bool   `yaml:"autocomplete_filtering_enabled"`
+	AutocompleteFilteringEnabled bool   `yaml:"autocomplete_filtering_enabled,omitempty"`
 
 	Server          server.Config           `yaml:"server,omitempty"`
 	InternalServer  internalserver.Config   `yaml:"internal_server,omitempty"`

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -186,6 +186,7 @@ func (t *App) initDistributor() (services.Service, error) {
 
 func (t *App) initIngester() (services.Service, error) {
 	t.cfg.Ingester.LifecyclerConfig.ListenPort = t.cfg.Server.GRPCListenPort
+	t.cfg.Ingester.AutocompleteFilteringEnabled = t.cfg.AutocompleteFilteringEnabled
 	ingester, err := ingester.New(t.cfg.Ingester, t.store, t.overrides, prometheus.DefaultRegisterer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ingester: %w", err)

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -64,6 +64,9 @@ Tempo uses the Weaveworks/common server. For more information on configuration o
 ```yaml
 # Optional. Setting to true enables multitenancy and requires X-Scope-OrgID header on all requests.
 [multitenancy_enabled: <bool> | default = false]
+  
+# Optional. Setting to true enables query filtering in tag value search API `/api/v2/search/<tag>/values`.
+[autocomplete_filtering_enabled: <bool> | default = false]
 
 # Optional. String prefix for all http api endpoints. Must include beginning slash.
 [http_api_prefix: <string>]

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -66,6 +66,8 @@ Tempo uses the Weaveworks/common server. For more information on configuration o
 [multitenancy_enabled: <bool> | default = false]
   
 # Optional. Setting to true enables query filtering in tag value search API `/api/v2/search/<tag>/values`.
+# If filtering is enabled, the API accepts a query parameter `q` containing a TraceQL query,
+# and returns only tag values that match the query.
 [autocomplete_filtering_enabled: <bool> | default = false]
 
 # Optional. String prefix for all http api endpoints. Must include beginning slash.

--- a/go.mod
+++ b/go.mod
@@ -102,6 +102,7 @@ require (
 	github.com/Azure/go-autorest/autorest v0.11.28
 	github.com/googleapis/gax-go/v2 v2.7.0
 	github.com/grafana/gomemcache v0.0.0-20230316202710-a081dae0aba9
+	github.com/grafana/regexp v0.0.0-20221123153739-15dc172cd2db
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	go.opentelemetry.io/collector/exporter v0.74.0
 	go.opentelemetry.io/collector/receiver v0.74.0
@@ -161,7 +162,6 @@ require (
 	github.com/google/btree v1.0.1 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/gorilla/handlers v1.5.1 // indirect
-	github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2 // indirect
 	github.com/hashicorp/consul/api v1.15.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,6 @@ require (
 	github.com/Azure/go-autorest/autorest v0.11.28
 	github.com/googleapis/gax-go/v2 v2.7.0
 	github.com/grafana/gomemcache v0.0.0-20230316202710-a081dae0aba9
-	github.com/grafana/regexp v0.0.0-20221123153739-15dc172cd2db
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	go.opentelemetry.io/collector/exporter v0.74.0
 	go.opentelemetry.io/collector/receiver v0.74.0
@@ -162,6 +161,7 @@ require (
 	github.com/google/btree v1.0.1 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/gorilla/handlers v1.5.1 // indirect
+	github.com/grafana/regexp v0.0.0-20221123153739-15dc172cd2db // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2 // indirect
 	github.com/hashicorp/consul/api v1.15.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -488,8 +488,8 @@ github.com/grafana/gomemcache v0.0.0-20230316202710-a081dae0aba9 h1:WB3bGH2f1UN6
 github.com/grafana/gomemcache v0.0.0-20230316202710-a081dae0aba9/go.mod h1:PGk3RjYHpxMM8HFPhKKo+vve3DdlPUELZLSDEFehPuU=
 github.com/grafana/memberlist v0.3.1-0.20220708130638-bd88e10a3d91 h1:/NipyHnOmvRsVzj81j2qE0VxsvsqhOB0f4vJIhk2qCQ=
 github.com/grafana/memberlist v0.3.1-0.20220708130638-bd88e10a3d91/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6 h1:A3dhViTeFDSQcGOXuUi6ukCQSMyDtDISBp2z6OOo2YM=
-github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
+github.com/grafana/regexp v0.0.0-20221123153739-15dc172cd2db h1:7aN5cccjIqCLTzedH7MZzRZt5/lsAHch6Z3L2ZGn5FA=
+github.com/grafana/regexp v0.0.0-20221123153739-15dc172cd2db/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=

--- a/integration/e2e/api_test.go
+++ b/integration/e2e/api_test.go
@@ -22,7 +22,7 @@ func TestSearchTagValuesV2(t *testing.T) {
 	defer s.Close()
 
 	require.NoError(t, util.CopyFileToSharedDir(s, configAllInOneLocal, "config.yaml"))
-	tempo := util.NewTempoAllInOne()
+	tempo := util.NewTempoAllInOne("-autocomplete-filtering.enabled=true")
 	require.NoError(t, s.StartAndWaitReady(tempo))
 
 	jaegerClient, err := util.NewJaegerGRPCClient(tempo.Endpoint(14250))

--- a/integration/util.go
+++ b/integration/util.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -30,19 +29,7 @@ const (
 	image = "tempo:latest"
 )
 
-// GetExtraArgs returns the extra args to pass to the Docker command used to run Tempo.
-func GetExtraArgs() []string {
-	// Get extra args from the TEMPO_EXTRA_ARGS env variable
-	// falling back to an empty list
-	if os.Getenv("TEMPO_EXTRA_ARGS") != "" {
-		return strings.Fields(os.Getenv("TEMPO_EXTRA_ARGS"))
-	}
-
-	return nil
-}
-
-func buildArgsWithExtra(args []string) []string {
-	extraArgs := GetExtraArgs()
+func buildArgsWithExtra(args, extraArgs []string) []string {
 	if len(extraArgs) > 0 {
 		return append(extraArgs, args...)
 	}
@@ -50,9 +37,9 @@ func buildArgsWithExtra(args []string) []string {
 	return args
 }
 
-func NewTempoAllInOne() *e2e.HTTPService {
+func NewTempoAllInOne(extraArgs ...string) *e2e.HTTPService {
 	args := []string{"-config.file=" + filepath.Join(e2e.ContainerSharedDir, "config.yaml")}
-	args = buildArgsWithExtra(args)
+	args = buildArgsWithExtra(args, extraArgs)
 
 	s := e2e.NewHTTPService(
 		"tempo",

--- a/integration/util.go
+++ b/integration/util.go
@@ -58,9 +58,9 @@ func NewTempoAllInOne(extraArgs ...string) *e2e.HTTPService {
 	return s
 }
 
-func NewTempoDistributor() *e2e.HTTPService {
+func NewTempoDistributor(extraArgs ...string) *e2e.HTTPService {
 	args := []string{"-config.file=" + filepath.Join(e2e.ContainerSharedDir, "config.yaml"), "-target=distributor"}
-	args = buildArgsWithExtra(args)
+	args = buildArgsWithExtra(args, extraArgs)
 
 	s := e2e.NewHTTPService(
 		"distributor",
@@ -76,9 +76,9 @@ func NewTempoDistributor() *e2e.HTTPService {
 	return s
 }
 
-func NewTempoIngester(replica int) *e2e.HTTPService {
+func NewTempoIngester(replica int, extraArgs ...string) *e2e.HTTPService {
 	args := []string{"-config.file=" + filepath.Join(e2e.ContainerSharedDir, "config.yaml"), "-target=ingester"}
-	args = buildArgsWithExtra(args)
+	args = buildArgsWithExtra(args, extraArgs)
 
 	s := e2e.NewHTTPService(
 		"ingester-"+strconv.Itoa(replica),
@@ -93,9 +93,9 @@ func NewTempoIngester(replica int) *e2e.HTTPService {
 	return s
 }
 
-func NewTempoMetricsGenerator() *e2e.HTTPService {
+func NewTempoMetricsGenerator(extraArgs ...string) *e2e.HTTPService {
 	args := []string{"-config.file=" + filepath.Join(e2e.ContainerSharedDir, "config.yaml"), "-target=metrics-generator"}
-	args = buildArgsWithExtra(args)
+	args = buildArgsWithExtra(args, extraArgs)
 
 	s := e2e.NewHTTPService(
 		"metrics-generator",
@@ -110,9 +110,9 @@ func NewTempoMetricsGenerator() *e2e.HTTPService {
 	return s
 }
 
-func NewTempoQueryFrontend() *e2e.HTTPService {
+func NewTempoQueryFrontend(extraArgs ...string) *e2e.HTTPService {
 	args := []string{"-config.file=" + filepath.Join(e2e.ContainerSharedDir, "config.yaml"), "-target=query-frontend"}
-	args = buildArgsWithExtra(args)
+	args = buildArgsWithExtra(args, extraArgs)
 
 	s := e2e.NewHTTPService(
 		"query-frontend",
@@ -127,9 +127,9 @@ func NewTempoQueryFrontend() *e2e.HTTPService {
 	return s
 }
 
-func NewTempoQuerier() *e2e.HTTPService {
+func NewTempoQuerier(extraArgs ...string) *e2e.HTTPService {
 	args := []string{"-config.file=" + filepath.Join(e2e.ContainerSharedDir, "config.yaml"), "-target=querier"}
-	args = buildArgsWithExtra(args)
+	args = buildArgsWithExtra(args, extraArgs)
 
 	s := e2e.NewHTTPService(
 		"querier",
@@ -144,9 +144,9 @@ func NewTempoQuerier() *e2e.HTTPService {
 	return s
 }
 
-func NewTempoScalableSingleBinary(replica int) *e2e.HTTPService {
+func NewTempoScalableSingleBinary(replica int, extraArgs ...string) *e2e.HTTPService {
 	args := []string{"-config.file=" + filepath.Join(e2e.ContainerSharedDir, "config.yaml"), "-target=scalable-single-binary", "-querier.frontend-address=tempo-" + strconv.Itoa(replica) + ":9095"}
-	args = buildArgsWithExtra(args)
+	args = buildArgsWithExtra(args, extraArgs)
 
 	s := e2e.NewHTTPService(
 		"tempo-"+strconv.Itoa(replica),

--- a/modules/ingester/config.go
+++ b/modules/ingester/config.go
@@ -25,6 +25,8 @@ type Config struct {
 	MaxBlockBytes        uint64        `yaml:"max_block_bytes"`
 	CompleteBlockTimeout time.Duration `yaml:"complete_block_timeout"`
 	OverrideRingKey      string        `yaml:"override_ring_key"`
+
+	AutocompleteFilteringEnabled bool `yaml:"-"`
 }
 
 // RegisterFlagsAndApplyDefaults registers the flags.

--- a/modules/ingester/ingester.go
+++ b/modules/ingester/ingester.go
@@ -282,7 +282,7 @@ func (i *Ingester) getOrCreateInstance(instanceID string) (*instance, error) {
 	inst, ok = i.instances[instanceID]
 	if !ok {
 		var err error
-		inst, err = newInstance(instanceID, i.limiter, i.store, i.local)
+		inst, err = newInstance(instanceID, i.limiter, i.store, i.local, i.cfg.AutocompleteFilteringEnabled)
 		if err != nil {
 			return nil, err
 		}

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -116,9 +116,11 @@ type instance struct {
 	localWriter backend.Writer
 
 	hash hash.Hash32
+
+	autocompleteFilteringEnabled bool
 }
 
-func newInstance(instanceID string, limiter *Limiter, writer tempodb.Writer, l *local.Backend) (*instance, error) {
+func newInstance(instanceID string, limiter *Limiter, writer tempodb.Writer, l *local.Backend, autocompleteFiltering bool) (*instance, error) {
 	i := &instance{
 		traces:     map[uint32]*liveTrace{},
 		traceSizes: map[uint32]uint32{},
@@ -134,6 +136,8 @@ func newInstance(instanceID string, limiter *Limiter, writer tempodb.Writer, l *
 		localWriter: backend.NewWriter(l),
 
 		hash: fnv.New32(),
+
+		autocompleteFilteringEnabled: autocompleteFiltering,
 	}
 	err := i.resetHeadBlock()
 	if err != nil {

--- a/modules/ingester/instance_search.go
+++ b/modules/ingester/instance_search.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/grafana/regexp"
+	"regexp"
 
 	"github.com/go-kit/log/level"
 	"github.com/grafana/tempo/pkg/api"

--- a/modules/ingester/instance_search.go
+++ b/modules/ingester/instance_search.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
+
+	"github.com/grafana/regexp"
 
 	"github.com/go-kit/log/level"
 	"github.com/grafana/tempo/pkg/api"
@@ -432,19 +435,42 @@ func (i *instance) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTag
 		maxBlocks = int32(limit)
 	}
 
-	searchBlock := func(s common.Searcher) error {
-		if anyErr.Load() != nil {
-			return nil // Early exit if any error has occurred
-		}
+	tag, err := traceql.ParseIdentifier(req.TagName)
+	if err != nil {
+		return nil, err
+	}
 
-		if maxBlocks > 0 && inspectedBlocks.Inc() > maxBlocks {
-			return nil
-		}
+	query := extractMatchers(req.Query)
 
-		fetcher := traceql.NewSpansetFetcherWrapper(func(ctx context.Context, req traceql.FetchSpansRequest) (traceql.FetchSpansResponse, error) {
-			return s.Fetch(ctx, req, common.DefaultSearchOptions())
-		})
-		return engine.ExecuteTagValues(ctx, req, cb, fetcher)
+	var searchBlock func(common.Searcher) error
+	if i.autocompleteFilteringEnabled && len(query) > 0 {
+		searchBlock = func(s common.Searcher) error {
+			if anyErr.Load() != nil {
+				return nil // Early exit if any error has occurred
+			}
+
+			if maxBlocks > 0 && inspectedBlocks.Inc() > maxBlocks {
+				return nil
+			}
+
+			fetcher := traceql.NewSpansetFetcherWrapper(func(ctx context.Context, req traceql.FetchSpansRequest) (traceql.FetchSpansResponse, error) {
+				return s.Fetch(ctx, req, common.DefaultSearchOptions())
+			})
+
+			return engine.ExecuteTagValues(ctx, tag, query, cb, fetcher)
+		}
+	} else {
+		searchBlock = func(s common.Searcher) error {
+			if anyErr.Load() != nil {
+				return nil // Early exit if any error has occurred
+			}
+
+			if maxBlocks > 0 && inspectedBlocks.Inc() > maxBlocks {
+				return nil
+			}
+
+			return s.SearchTagValuesV2(ctx, tag, cb, common.DefaultSearchOptions())
+		}
 	}
 
 	i.blocksMtx.RLock()
@@ -501,4 +527,57 @@ func (i *instance) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTag
 	}
 
 	return resp, nil
+}
+
+// Regex to extract matchers from a query string
+// This regular expression matches a string that contains three groups separated by operators.
+// The first group is a string of alphabetical characters, dots, and underscores.
+// The second group is a comparison operator, which can be one of several possibilities, including =, >, <, and !=.
+// The third group is one of several possible values: a string enclosed in double quotes,
+// a number with an optional time unit (such as "ns", "ms", "s", "m", or "h"),
+// a plain number, or the boolean values "true" or "false".
+// Example: "http.status_code = 200" from the query "{ .http.status_code = 200 && .http.method = }"
+var matchersRegexp = regexp.MustCompile(`[a-zA-Z._]+\s*[=|<=|>=|=~|!=|>|<|!~]\s*(?:"[a-zA-Z./_0-9-]+"|[0-9smh]+|true|false)`)
+
+// TODO: Merge into a single regular expression
+
+// Regex to extract selectors from a query string
+// This regular expression matches a string that contains a single spanset filter and no OR `||` conditions.
+// Examples
+//
+//	Query                        |  Match
+//
+// { .bar = "foo" }                          |   Yes
+// { .bar = "foo" && .foo = "bar" }          |   Yes
+// { .bar = "foo" || .foo = "bar" }          |   No
+// { .bar = "foo" } && { .foo = "bar" }      |   No
+// { .bar = "foo" } || { .foo = "bar" }      |   No
+var singleFilterRegexp = regexp.MustCompile(`^{[a-zA-Z._\s\-()/&=<>~!0-9"]*}$`)
+
+// extractMatchers extracts matchers from a query string and returns a string that can be parsed by the storage layer.
+func extractMatchers(query string) string {
+	query = strings.TrimSpace(query)
+
+	if len(query) == 0 {
+		return "{}"
+	}
+
+	selector := singleFilterRegexp.FindString(query)
+	if len(selector) == 0 {
+		return "{}"
+	}
+
+	matchers := matchersRegexp.FindAllString(query, -1)
+
+	var q strings.Builder
+	q.WriteString("{")
+	for i, m := range matchers {
+		if i > 0 {
+			q.WriteString(" && ")
+		}
+		q.WriteString(m)
+	}
+	q.WriteString("}")
+
+	return q.String()
 }

--- a/modules/ingester/instance_search_test.go
+++ b/modules/ingester/instance_search_test.go
@@ -227,6 +227,7 @@ func testSearchTagsAndValues(t *testing.T, ctx context.Context, i *instance, tag
 
 func TestInstanceSearchTagAndValuesV2(t *testing.T) {
 	i, _ := defaultInstance(t)
+	i.autocompleteFilteringEnabled = true
 
 	// add dummy search data
 	var (

--- a/modules/ingester/instance_search_test.go
+++ b/modules/ingester/instance_search_test.go
@@ -749,3 +749,90 @@ func BenchmarkInstanceSearchUnderLoad(b *testing.B) {
 	// exiting and cleaning up
 	time.Sleep(1 * time.Second)
 }
+
+func TestExtractMatchers(t *testing.T) {
+	testCases := []struct {
+		name, query, expected string
+	}{
+		{
+			name:     "empty query",
+			query:    "",
+			expected: "{}",
+		},
+		{
+			name:     "empty query with spaces",
+			query:    " { } ",
+			expected: "{}",
+		},
+		{
+			name:     "simple query",
+			query:    `{.service_name = "foo"}`,
+			expected: `{.service_name = "foo"}`,
+		},
+		{
+			name:     "incomplete query",
+			query:    `{ .http.status_code = 200 && .http.method = }`,
+			expected: "{.http.status_code = 200}",
+		},
+		{
+			name:     "invalid query",
+			query:    "{ 2 = .b ",
+			expected: "{}",
+		},
+		{
+			name:     "long query",
+			query:    `{.service_name = "foo" && .http.status_code = 200 && .http.method = "GET" && .cluster = }`,
+			expected: `{.service_name = "foo" && .http.status_code = 200 && .http.method = "GET"}`,
+		},
+		{
+			name:     "query with duration a boolean",
+			query:    `{ duration > 5s && .success = true && .cluster = }`,
+			expected: `{duration > 5s && .success = true}`,
+		},
+		{
+			name:     "query with three selectors with AND",
+			query:    `{ .foo = "bar" && .baz = "qux" } && { duration > 1s } || { .foo = "bar" && .baz = "qux" }`,
+			expected: "{}",
+		},
+		{
+			name:     "query with OR conditions",
+			query:    `{ (.foo = "bar" || .baz = "qux") && duration > 1s }`,
+			expected: "{}",
+		},
+		{
+			name:     "query with multiple selectors and pipelines",
+			query:    `{ .foo = "bar" && .baz = "qux" } && { duration > 1s } || { .foo = "bar" && .baz = "qux" } | count() > 4`,
+			expected: "{}",
+		},
+		{
+			name:     "query with slash in value",
+			query:    `{ span.http.target = "/api/v1/users" }`,
+			expected: `{span.http.target = "/api/v1/users"}`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, extractMatchers(tc.query))
+		})
+	}
+}
+
+func BenchmarkExtractMatchers(b *testing.B) {
+	queries := []string{
+		`{.service_name = "foo"}`,
+		`{.service_name = "foo" && .http.status_code = 200}`,
+		`{.service_name = "foo" && .http.status_code = 200 && .http.method = "GET"}`,
+		`{.service_name = "foo" && .http.status_code = 200 && .http.method = "GET" && .http.url = "/foo"}`,
+		`{.service_name = "foo" && .cluster = }`,
+		`{.service_name = "foo" && .http.status_code = 200 && .cluster = }`,
+		`{.service_name = "foo" && .http.status_code = 200 && .http.method = "GET" && .cluster = }`,
+		`{.service_name = "foo" && .http.status_code = 200 && .http.method = "GET" && .http.url = "/foo" && .cluster = }`,
+	}
+	for _, query := range queries {
+		b.Run(query, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = extractMatchers(query)
+			}
+		})
+	}
+}

--- a/pkg/traceql/engine.go
+++ b/pkg/traceql/engine.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"regexp"
-	"strings"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
@@ -124,16 +122,14 @@ func (e *Engine) ExecuteSearch(ctx context.Context, searchReq *tempopb.SearchReq
 
 func (e *Engine) ExecuteTagValues(
 	ctx context.Context,
-	req *tempopb.SearchTagValuesRequest,
+	tag Attribute,
+	query string,
 	cb func(v Static) bool,
 	fetcher SpansetFetcher,
 ) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "traceql.Engine.ExecuteTagValues")
 	defer span.Finish()
 
-	query := extractMatchers(req.Query)
-
-	span.SetTag("query", req.Query)
 	span.SetTag("sanitized query", query)
 
 	rootExpr, err := Parse(query)
@@ -149,11 +145,6 @@ func (e *Engine) ExecuteTagValues(
 		End:   math.MaxUint32,
 	}
 
-	wantAttr, err := ParseIdentifier(req.TagName)
-	if err != nil {
-		return err
-	}
-
 	fetchSpansRequest := e.createFetchSpansRequest(searchReq, rootExpr.Pipeline)
 	// TODO: remove other conditions for the wantAttr we're searching for
 	// for _, cond := range fetchSpansRequest.Conditions {
@@ -162,7 +153,7 @@ func (e *Engine) ExecuteTagValues(
 	// 	}
 	// }
 	fetchSpansRequest.Conditions = append(fetchSpansRequest.Conditions, Condition{
-		Attribute: wantAttr,
+		Attribute: tag,
 		Op:        OpNone,
 	})
 
@@ -170,11 +161,11 @@ func (e *Engine) ExecuteTagValues(
 	span.SetTag("fetchSpansRequest", fetchSpansRequest)
 
 	var collectAttributeValue func(s Span) bool
-	switch wantAttr.Scope {
+	switch tag.Scope {
 	case AttributeScopeResource,
 		AttributeScopeSpan: // If tag is scoped, we can check the map directly
 		collectAttributeValue = func(s Span) bool {
-			if v, ok := s.Attributes()[wantAttr]; ok {
+			if v, ok := s.Attributes()[tag]; ok {
 				return cb(v)
 			}
 			return false
@@ -183,17 +174,17 @@ func (e *Engine) ExecuteTagValues(
 		// If tag is unscoped, it can either be an intrinsic (eg. `name`) or an unscoped attribute (eg. `.namespace`)
 		//
 		// If the tag is intrinsic Attribute.Intrinsic is set to the Intrinsic it corresponds,
-		// so we can check against `!= IntrinsicNone` and use wantAttr directly.
+		// so we can check against `!= IntrinsicNone` and use tag directly.
 		//
 		// If the tag is unscoped, we need to check resource and span scoped manually by building a new Attribute with each scope.
 		collectAttributeValue = func(s Span) bool {
-			if wantAttr.Intrinsic != IntrinsicNone { // it's intrinsic
-				if v, ok := s.Attributes()[wantAttr]; ok {
+			if tag.Intrinsic != IntrinsicNone { // it's intrinsic
+				if v, ok := s.Attributes()[tag]; ok {
 					return cb(v)
 				}
 			} else { // it's unscoped
 				for _, scope := range []AttributeScope{AttributeScopeResource, AttributeScopeSpan} {
-					scopedAttr := Attribute{Scope: scope, Parent: wantAttr.Parent, Name: wantAttr.Name}
+					scopedAttr := Attribute{Scope: scope, Parent: tag.Parent, Name: tag.Name}
 					if v, ok := s.Attributes()[scopedAttr]; ok {
 						return cb(v)
 					}
@@ -203,7 +194,7 @@ func (e *Engine) ExecuteTagValues(
 			return false
 		}
 	default:
-		return fmt.Errorf("unknown attribute scope: %s", wantAttr)
+		return fmt.Errorf("unknown attribute scope: %s", tag)
 	}
 
 	// set up the expression evaluation as a filter to reduce data pulled
@@ -386,57 +377,4 @@ func (s Static) asAnyValue() *common_v1.AnyValue {
 			StringValue: fmt.Sprintf("error formatting val: static has unexpected type %v", s.Type),
 		},
 	}
-}
-
-// Regex to extract matchers from a query string
-// This regular expression matches a string that contains three groups separated by operators.
-// The first group is a string of alphabetical characters, dots, and underscores.
-// The second group is a comparison operator, which can be one of several possibilities, including =, >, <, and !=.
-// The third group is one of several possible values: a string enclosed in double quotes,
-// a number with an optional time unit (such as "ns", "ms", "s", "m", or "h"),
-// a plain number, or the boolean values "true" or "false".
-// Example: "http.status_code = 200" from the query "{ .http.status_code = 200 && .http.method = }"
-var matchersRegexp = regexp.MustCompile(`[a-zA-Z._]+\s*[=|<=|>=|=~|!=|>|<|!~]\s*(?:"[a-zA-Z./_0-9-]+"|[0-9smh]+|true|false)`)
-
-// TODO: Merge into a single regular expression
-
-// Regex to extract selectors from a query string
-// This regular expression matches a string that contains a single spanset filter and no OR `||` conditions.
-// Examples
-//
-//	Query                        |  Match
-//
-// { .bar = "foo" }                          |   Yes
-// { .bar = "foo" && .foo = "bar" }          |   Yes
-// { .bar = "foo" || .foo = "bar" }          |   No
-// { .bar = "foo" } && { .foo = "bar" }      |   No
-// { .bar = "foo" } || { .foo = "bar" }      |   No
-var singleFilterRegexp = regexp.MustCompile(`^{[a-zA-Z._\s\-()/&=<>~!0-9"]*}$`)
-
-// extractMatchers extracts matchers from a query string and returns a string that can be parsed by the storage layer.
-func extractMatchers(query string) string {
-	query = strings.TrimSpace(query)
-
-	if len(query) == 0 {
-		return "{}"
-	}
-
-	selector := singleFilterRegexp.FindString(query)
-	if len(selector) == 0 {
-		return "{}"
-	}
-
-	matchers := matchersRegexp.FindAllString(query, -1)
-
-	var q strings.Builder
-	q.WriteString("{")
-	for i, m := range matchers {
-		if i > 0 {
-			q.WriteString(" && ")
-		}
-		q.WriteString(m)
-	}
-	q.WriteString("}")
-
-	return q.String()
 }

--- a/tempodb/encoding/common/interfaces.go
+++ b/tempodb/encoding/common/interfaces.go
@@ -24,6 +24,7 @@ type Searcher interface {
 	Search(ctx context.Context, req *tempopb.SearchRequest, opts SearchOptions) (*tempopb.SearchResponse, error)
 	SearchTags(ctx context.Context, scope traceql.AttributeScope, cb TagCallback, opts SearchOptions) error
 	SearchTagValues(ctx context.Context, tag string, cb TagCallback, opts SearchOptions) error
+	SearchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb TagCallbackV2, opts SearchOptions) error
 
 	Fetch(context.Context, traceql.FetchSpansRequest, SearchOptions) (traceql.FetchSpansResponse, error)
 }

--- a/tempodb/encoding/v2/backend_block.go
+++ b/tempodb/encoding/v2/backend_block.go
@@ -153,6 +153,10 @@ func (b *BackendBlock) SearchTagValues(ctx context.Context, tag string, cb commo
 	return common.ErrUnsupported
 }
 
+func (b *BackendBlock) SearchTagValuesV2(context.Context, traceql.Attribute, common.TagCallbackV2, common.SearchOptions) error {
+	return common.ErrUnsupported
+}
+
 func (b *BackendBlock) Fetch(context.Context, traceql.FetchSpansRequest, common.SearchOptions) (traceql.FetchSpansResponse, error) {
 	return traceql.FetchSpansResponse{}, common.ErrUnsupported
 }

--- a/tempodb/encoding/v2/wal_block.go
+++ b/tempodb/encoding/v2/wal_block.go
@@ -276,6 +276,10 @@ func (a *walBlock) SearchTagValues(ctx context.Context, tag string, cb common.Ta
 	return common.ErrUnsupported
 }
 
+func (a *walBlock) SearchTagValuesV2(context.Context, traceql.Attribute, common.TagCallbackV2, common.SearchOptions) error {
+	return common.ErrUnsupported
+}
+
 // Fetch implements traceql.SpansetFetcher
 func (a *walBlock) Fetch(context.Context, traceql.FetchSpansRequest, common.SearchOptions) (traceql.FetchSpansResponse, error) {
 	return traceql.FetchSpansResponse{}, common.ErrUnsupported

--- a/tempodb/encoding/vparquet/block_search_tags.go
+++ b/tempodb/encoding/vparquet/block_search_tags.go
@@ -192,11 +192,11 @@ func (b *backendBlock) SearchTagValues(ctx context.Context, tag string, cb commo
 		return false
 	}
 
-	return b.searchTagValuesV2(ctx, att, cb2, opts)
+	return b.SearchTagValuesV2(ctx, att, cb2, opts)
 }
 
-func (b *backendBlock) searchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb common.TagCallbackV2, opts common.SearchOptions) error {
-	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "parquet.backendBlock.searchTagValuesV2",
+func (b *backendBlock) SearchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb common.TagCallbackV2, opts common.SearchOptions) error {
+	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "parquet.backendBlock.SearchTagValuesV2",
 		opentracing.Tags{
 			"blockID":   b.meta.BlockID,
 			"tenantID":  b.meta.TenantID,

--- a/tempodb/encoding/vparquet/block_search_tags_test.go
+++ b/tempodb/encoding/vparquet/block_search_tags_test.go
@@ -139,7 +139,7 @@ func TestBackendBlockSearchTagValuesV2(t *testing.T) {
 			return false
 		}
 
-		err := block.searchTagValuesV2(ctx, tc.tag, cb, common.DefaultSearchOptions())
+		err := block.SearchTagValuesV2(ctx, tc.tag, cb, common.DefaultSearchOptions())
 		require.NoError(t, err, tc.tag)
 		require.Equal(t, tc.vals, got, "tag=%v", tc.tag)
 	}

--- a/tempodb/encoding/vparquet/wal_block.go
+++ b/tempodb/encoding/vparquet/wal_block.go
@@ -595,10 +595,10 @@ func (b *walBlock) SearchTagValues(ctx context.Context, tag string, cb common.Ta
 		return false
 	}
 
-	return b.searchTagValuesV2(ctx, att, cb2, opts)
+	return b.SearchTagValuesV2(ctx, att, cb2, opts)
 }
 
-func (b *walBlock) searchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb common.TagCallbackV2, _ common.SearchOptions) error {
+func (b *walBlock) SearchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb common.TagCallbackV2, _ common.SearchOptions) error {
 	for i, blockFlush := range b.readFlushes() {
 		file, err := blockFlush.file()
 		if err != nil {

--- a/tempodb/encoding/vparquet2/block_search_tags.go
+++ b/tempodb/encoding/vparquet2/block_search_tags.go
@@ -192,11 +192,11 @@ func (b *backendBlock) SearchTagValues(ctx context.Context, tag string, cb commo
 		return false
 	}
 
-	return b.searchTagValuesV2(ctx, att, cb2, opts)
+	return b.SearchTagValuesV2(ctx, att, cb2, opts)
 }
 
-func (b *backendBlock) searchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb common.TagCallbackV2, opts common.SearchOptions) error {
-	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "parquet.backendBlock.searchTagValuesV2",
+func (b *backendBlock) SearchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb common.TagCallbackV2, opts common.SearchOptions) error {
+	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "parquet.backendBlock.SearchTagValuesV2",
 		opentracing.Tags{
 			"blockID":   b.meta.BlockID,
 			"tenantID":  b.meta.TenantID,

--- a/tempodb/encoding/vparquet2/block_search_tags_test.go
+++ b/tempodb/encoding/vparquet2/block_search_tags_test.go
@@ -139,7 +139,7 @@ func TestBackendBlockSearchTagValuesV2(t *testing.T) {
 			return false
 		}
 
-		err := block.searchTagValuesV2(ctx, tc.tag, cb, common.DefaultSearchOptions())
+		err := block.SearchTagValuesV2(ctx, tc.tag, cb, common.DefaultSearchOptions())
 		require.NoError(t, err, tc.tag)
 		require.Equal(t, tc.vals, got, "tag=%v", tc.tag)
 	}

--- a/tempodb/encoding/vparquet2/wal_block.go
+++ b/tempodb/encoding/vparquet2/wal_block.go
@@ -595,10 +595,10 @@ func (b *walBlock) SearchTagValues(ctx context.Context, tag string, cb common.Ta
 		return false
 	}
 
-	return b.searchTagValuesV2(ctx, att, cb2, opts)
+	return b.SearchTagValuesV2(ctx, att, cb2, opts)
 }
 
-func (b *walBlock) searchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb common.TagCallbackV2, _ common.SearchOptions) error {
+func (b *walBlock) SearchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb common.TagCallbackV2, _ common.SearchOptions) error {
 	for i, blockFlush := range b.readFlushes() {
 		file, err := blockFlush.file()
 		if err != nil {

--- a/vendor/github.com/grafana/regexp/exec.go
+++ b/vendor/github.com/grafana/regexp/exec.go
@@ -441,7 +441,6 @@ func (re *Regexp) doOnePass(ir io.RuneReader, ib []byte, is string, pos, ncap in
 	} else {
 		flag = i.context(pos)
 	}
-	// If there is a simple literal prefix, skip over it.
 	if r != endOfText {
 		r1, width1 = i.step(pos + width)
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -389,7 +389,7 @@ github.com/grafana/e2e/images
 # github.com/grafana/gomemcache v0.0.0-20230316202710-a081dae0aba9
 ## explicit; go 1.18
 github.com/grafana/gomemcache/memcache
-# github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6
+# github.com/grafana/regexp v0.0.0-20221123153739-15dc172cd2db
 ## explicit; go 1.17
 github.com/grafana/regexp
 github.com/grafana/regexp/syntax


### PR DESCRIPTION
**What this PR does**:

Add new param `autocomplete_filtering_enabled` to configure filtering results in tag value search `/api/v2/search/<tag>/values`. If disabled, no filtering is done.

It also fallbacks to no filtering if there is no query or it's invalid. It's much faster.

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`