### PR TITLE
Queriers: Ignore context canceled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ storage:
             insecure_skip_verify: true   // renamed to tls_insecure_skip_verify
 
 ```
-* [CHANGE] Ignore context canceled errors in the queriers [#2440https://github.com/grafana/tempo/pull/2440 (@joe-elliott)
+* [CHANGE] Ignore context canceled errors in the queriers [#2440](https://github.com/grafana/tempo/pull/2440) (@joe-elliott)
 
 ## v2.1.1 / 2023-04-28
 * [BUGFIX] Fix issue where Tempo sometimes flips booleans from false->true at storage time. [#2400](https://github.com/grafana/tempo/issues/2400) (@joe-elliott)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 * [ENHANCEMENT] Add support for IPv6 [#1555](https://github.com/grafana/tempo/pull/1555) (@zalegrala)
 * [ENHANCEMENT] Add span filtering to spanmetrics processor [#2274](https://github.com/grafana/tempo/pull/2274) (@zalegrala)
 * [BUGFIX] tempodb integer divide by zero error [#2167](https://github.com/grafana/tempo/issues/2167) (@kroksys)
-* [CHANGE] **Breaking Change** Rename s3.insecure_skip_verify [#???](https://github.com/grafana/tempo/pull/???) (@zalegrala)
+* [CHANGE] **Breaking Change** Rename s3.insecure_skip_verify [#2407](https://github.com/grafana/tempo/pull/2407) (@zalegrala)
 ```yaml
 storage:
     trace:
@@ -37,6 +37,7 @@ storage:
             insecure_skip_verify: true   // renamed to tls_insecure_skip_verify
 
 ```
+* [CHANGE] Ignore context canceled errors in the queriers [#2440https://github.com/grafana/tempo/pull/2440 (@joe-elliott)
 
 ## v2.1.1 / 2023-04-28
 * [BUGFIX] Fix issue where Tempo sometimes flips booleans from false->true at storage time. [#2400](https://github.com/grafana/tempo/issues/2400) (@joe-elliott)


### PR DESCRIPTION
**What this PR does**:
Changes the querier to ignore context canceled errors and return 200s. Tempo cancels context as part of normal operation. On the trace by id path, if hedging is turned on, then context will be canceled for other the slower requests. On the search path we commonly kick off thousands of jobs most of which are canceled when the search limit is hit.

Before this change the queriers would spam the logs with "context canceled" errors and metric tons of failed requests.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`