### PR TITLE
Undo remove of TEMPO_EXTRA_ARGS in e2e tests

### DIFF
--- a/integration/util.go
+++ b/integration/util.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,9 +30,23 @@ const (
 	image = "tempo:latest"
 )
 
+// GetExtraArgs returns the extra args to pass to the Docker command used to run Tempo.
+func GetExtraArgs() []string {
+	// Get extra args from the TEMPO_EXTRA_ARGS env variable
+	// falling back to an empty list
+	if os.Getenv("TEMPO_EXTRA_ARGS") != "" {
+		return strings.Fields(os.Getenv("TEMPO_EXTRA_ARGS"))
+	}
+
+	return nil
+}
+
 func buildArgsWithExtra(args, extraArgs []string) []string {
 	if len(extraArgs) > 0 {
-		return append(extraArgs, args...)
+		args = append(extraArgs, args...)
+	}
+	if envExtraArgs := GetExtraArgs(); len(envExtraArgs) > 0 {
+		args = append(envExtraArgs, args...)
 	}
 
 	return args

--- a/integration/util.go
+++ b/integration/util.go
@@ -43,10 +43,10 @@ func GetExtraArgs() []string {
 
 func buildArgsWithExtra(args, extraArgs []string) []string {
 	if len(extraArgs) > 0 {
-		args = append(extraArgs, args...)
+		args = append(args, extraArgs...)
 	}
 	if envExtraArgs := GetExtraArgs(); len(envExtraArgs) > 0 {
-		args = append(envExtraArgs, args...)
+		args = append(args, envExtraArgs...)
 	}
 
 	return args


### PR DESCRIPTION
I removed it in https://github.com/grafana/tempo/pull/2433/files#diff-a7eacfbc9abb400eb8d6a88999ad08771790b3c85eba0a1e5ce2366ce8544443L33-L45, thinking it wasn't being used. But it's being used in internal CIs.