### PR TITLE
Support per-tenant limits in metrics generator local blocks processor

### DIFF
--- a/modules/generator/config.go
+++ b/modules/generator/config.go
@@ -84,8 +84,29 @@ func (cfg *ProcessorConfig) copyWithOverrides(o metricsGeneratorOverrides, userI
 	if filterPolicies := o.MetricsGeneratorProcessorSpanMetricsFilterPolicies(userID); filterPolicies != nil {
 		copyCfg.SpanMetrics.FilterPolicies = filterPolicies
 	}
+
 	if max := o.MetricsGeneratorProcessorLocalBlocksMaxLiveTraces(userID); max > 0 {
 		copyCfg.LocalBlocks.MaxLiveTraces = max
+	}
+
+	if max := o.MetricsGeneratorProcessorLocalBlocksMaxBlockDuration(userID); max > 0 {
+		copyCfg.LocalBlocks.MaxBlockDuration = max
+	}
+
+	if max := o.MetricsGeneratorProcessorLocalBlocksMaxBlockBytes(userID); max > 0 {
+		copyCfg.LocalBlocks.MaxBlockBytes = max
+	}
+
+	if period := o.MetricsGeneratorProcessorLocalBlocksFlushCheckPeriod(userID); period > 0 {
+		copyCfg.LocalBlocks.FlushCheckPeriod = period
+	}
+
+	if period := o.MetricsGeneratorProcessorLocalBlocksTraceIdlePeriod(userID); period > 0 {
+		copyCfg.LocalBlocks.TraceIdlePeriod = period
+	}
+
+	if timeout := o.MetricsGeneratorProcessorLocalBlocksCompleteBlockTimeout(userID); timeout > 0 {
+		copyCfg.LocalBlocks.CompleteBlockTimeout = timeout
 	}
 
 	return copyCfg, nil

--- a/modules/generator/config.go
+++ b/modules/generator/config.go
@@ -84,6 +84,9 @@ func (cfg *ProcessorConfig) copyWithOverrides(o metricsGeneratorOverrides, userI
 	if filterPolicies := o.MetricsGeneratorProcessorSpanMetricsFilterPolicies(userID); filterPolicies != nil {
 		copyCfg.SpanMetrics.FilterPolicies = filterPolicies
 	}
+	if max := o.MetricsGeneratorProcessorLocalBlocksMaxLiveTraces(userID); max > 0 {
+		copyCfg.LocalBlocks.MaxLiveTraces = max
+	}
 
 	return copyCfg, nil
 }

--- a/modules/generator/overrides.go
+++ b/modules/generator/overrides.go
@@ -16,6 +16,7 @@ type metricsGeneratorOverrides interface {
 	MetricsGeneratorProcessorSpanMetricsDimensions(userID string) []string
 	MetricsGeneratorProcessorSpanMetricsIntrinsicDimensions(userID string) map[string]bool
 	MetricsGeneratorProcessorSpanMetricsFilterPolicies(userID string) []filterconfig.FilterPolicy
+	MetricsGeneratorProcessorLocalBlocksMaxLiveTraces(userID string) uint64
 }
 
 var _ metricsGeneratorOverrides = (*overrides.Overrides)(nil)

--- a/modules/generator/overrides.go
+++ b/modules/generator/overrides.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	"time"
+
 	"github.com/grafana/tempo/modules/generator/registry"
 	"github.com/grafana/tempo/modules/overrides"
 	filterconfig "github.com/grafana/tempo/pkg/spanfilter/config"
@@ -17,6 +19,11 @@ type metricsGeneratorOverrides interface {
 	MetricsGeneratorProcessorSpanMetricsIntrinsicDimensions(userID string) map[string]bool
 	MetricsGeneratorProcessorSpanMetricsFilterPolicies(userID string) []filterconfig.FilterPolicy
 	MetricsGeneratorProcessorLocalBlocksMaxLiveTraces(userID string) uint64
+	MetricsGeneratorProcessorLocalBlocksMaxBlockDuration(userID string) time.Duration
+	MetricsGeneratorProcessorLocalBlocksMaxBlockBytes(userID string) uint64
+	MetricsGeneratorProcessorLocalBlocksTraceIdlePeriod(userID string) time.Duration
+	MetricsGeneratorProcessorLocalBlocksFlushCheckPeriod(userID string) time.Duration
+	MetricsGeneratorProcessorLocalBlocksCompleteBlockTimeout(userID string) time.Duration
 }
 
 var _ metricsGeneratorOverrides = (*overrides.Overrides)(nil)

--- a/modules/generator/overrides_test.go
+++ b/modules/generator/overrides_test.go
@@ -14,6 +14,7 @@ type mockOverrides struct {
 	spanMetricsDimensions          []string
 	spanMetricsIntrinsicDimensions map[string]bool
 	spanMetricsFilterPolicies      []filterconfig.FilterPolicy
+	localBlocksMaxLiveTraces       uint64
 }
 
 var _ metricsGeneratorOverrides = (*mockOverrides)(nil)
@@ -56,4 +57,8 @@ func (m *mockOverrides) MetricsGeneratorProcessorSpanMetricsIntrinsicDimensions(
 
 func (m *mockOverrides) MetricsGeneratorProcessorSpanMetricsFilterPolicies(userID string) []filterconfig.FilterPolicy {
 	return m.spanMetricsFilterPolicies
+}
+
+func (m *mockOverrides) MetricsGeneratorProcessorLocalBlocksMaxLiveTraces(userID string) uint64 {
+	return m.localBlocksMaxLiveTraces
 }

--- a/modules/generator/overrides_test.go
+++ b/modules/generator/overrides_test.go
@@ -7,19 +7,19 @@ import (
 )
 
 type mockOverrides struct {
-	processors                     map[string]struct{}
-	serviceGraphsHistogramBuckets  []float64
-	serviceGraphsDimensions        []string
-	spanMetricsHistogramBuckets    []float64
-	spanMetricsDimensions          []string
-	spanMetricsIntrinsicDimensions map[string]bool
-	spanMetricsFilterPolicies      []filterconfig.FilterPolicy
-	localBlocksMaxLiveTraces       uint64
-	maxBlockDuration               time.Duration
-	maxBlockBytes                  uint64
-	flushCheckPeriod               time.Duration
-	traceIdlePeriod                time.Duration
-	completeBlockTimeout           time.Duration
+	processors                      map[string]struct{}
+	serviceGraphsHistogramBuckets   []float64
+	serviceGraphsDimensions         []string
+	spanMetricsHistogramBuckets     []float64
+	spanMetricsDimensions           []string
+	spanMetricsIntrinsicDimensions  map[string]bool
+	spanMetricsFilterPolicies       []filterconfig.FilterPolicy
+	localBlocksMaxLiveTraces        uint64
+	localBlocksMaxBlockDuration     time.Duration
+	localBlocksMaxBlockBytes        uint64
+	localBlocksFlushCheckPeriod     time.Duration
+	localBlocksTraceIdlePeriod      time.Duration
+	localBlocksCompleteBlockTimeout time.Duration
 }
 
 var _ metricsGeneratorOverrides = (*mockOverrides)(nil)
@@ -69,21 +69,21 @@ func (m *mockOverrides) MetricsGeneratorProcessorLocalBlocksMaxLiveTraces(userID
 }
 
 func (m *mockOverrides) MetricsGeneratorProcessorLocalBlocksMaxBlockDuration(userID string) time.Duration {
-	return m.maxBlockDuration
+	return m.localBlocksMaxBlockDuration
 }
 
 func (m *mockOverrides) MetricsGeneratorProcessorLocalBlocksMaxBlockBytes(userID string) uint64 {
-	return m.maxBlockBytes
+	return m.localBlocksMaxBlockBytes
 }
 
 func (m *mockOverrides) MetricsGeneratorProcessorLocalBlocksTraceIdlePeriod(userID string) time.Duration {
-	return m.traceIdlePeriod
+	return m.localBlocksTraceIdlePeriod
 }
 
 func (m *mockOverrides) MetricsGeneratorProcessorLocalBlocksFlushCheckPeriod(userID string) time.Duration {
-	return m.flushCheckPeriod
+	return m.localBlocksFlushCheckPeriod
 }
 
 func (m *mockOverrides) MetricsGeneratorProcessorLocalBlocksCompleteBlockTimeout(userID string) time.Duration {
-	return m.completeBlockTimeout
+	return m.localBlocksCompleteBlockTimeout
 }

--- a/modules/generator/overrides_test.go
+++ b/modules/generator/overrides_test.go
@@ -15,6 +15,11 @@ type mockOverrides struct {
 	spanMetricsIntrinsicDimensions map[string]bool
 	spanMetricsFilterPolicies      []filterconfig.FilterPolicy
 	localBlocksMaxLiveTraces       uint64
+	maxBlockDuration               time.Duration
+	maxBlockBytes                  uint64
+	flushCheckPeriod               time.Duration
+	traceIdlePeriod                time.Duration
+	completeBlockTimeout           time.Duration
 }
 
 var _ metricsGeneratorOverrides = (*mockOverrides)(nil)
@@ -61,4 +66,24 @@ func (m *mockOverrides) MetricsGeneratorProcessorSpanMetricsFilterPolicies(userI
 
 func (m *mockOverrides) MetricsGeneratorProcessorLocalBlocksMaxLiveTraces(userID string) uint64 {
 	return m.localBlocksMaxLiveTraces
+}
+
+func (m *mockOverrides) MetricsGeneratorProcessorLocalBlocksMaxBlockDuration(userID string) time.Duration {
+	return m.maxBlockDuration
+}
+
+func (m *mockOverrides) MetricsGeneratorProcessorLocalBlocksMaxBlockBytes(userID string) uint64 {
+	return m.maxBlockBytes
+}
+
+func (m *mockOverrides) MetricsGeneratorProcessorLocalBlocksTraceIdlePeriod(userID string) time.Duration {
+	return m.traceIdlePeriod
+}
+
+func (m *mockOverrides) MetricsGeneratorProcessorLocalBlocksFlushCheckPeriod(userID string) time.Duration {
+	return m.flushCheckPeriod
+}
+
+func (m *mockOverrides) MetricsGeneratorProcessorLocalBlocksCompleteBlockTimeout(userID string) time.Duration {
+	return m.completeBlockTimeout
 }

--- a/modules/generator/processor/localblocks/config.go
+++ b/modules/generator/processor/localblocks/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	MaxBlockDuration     time.Duration         `yaml:"max_block_duration"`
 	MaxBlockBytes        uint64                `yaml:"max_block_bytes"`
 	CompleteBlockTimeout time.Duration         `yaml:"complete_block_timeout"`
+	MaxLiveTraces        uint64                `yaml:"max_live_traces"`
 }
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {

--- a/modules/generator/processor/localblocks/metrics.go
+++ b/modules/generator/processor/localblocks/metrics.go
@@ -1,0 +1,40 @@
+package localblocks
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	namespace = "tempo"
+	subsystem = "metrics_generator_processor_local_blocks"
+
+	reasonLiveTracesExceeded = "live_traces_exceeded"
+)
+
+var (
+	metricTotalTraces = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: subsystem,
+		Name:      "traces_total",
+		Help:      "Total number of traces created",
+	}, []string{"tenant"})
+	metricLiveTraces = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: subsystem,
+		Name:      "live_traces",
+		Help:      "Number of live traces",
+	}, []string{"tenant"})
+	metricDroppedTraces = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: subsystem,
+		Name:      "traces_dropped_total",
+		Help:      "Number of traces dropped",
+	}, []string{"tenant", "reason"})
+	metricBlockSize = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: subsystem,
+		Name:      "bytes",
+		Help:      "Total size of local blocks",
+	}, []string{"tenant"})
+)

--- a/modules/generator/processor/localblocks/processor.go
+++ b/modules/generator/processor/localblocks/processor.go
@@ -460,15 +460,12 @@ func (p *Processor) recordBlockBytes() {
 
 	if p.headBlock != nil {
 		sum += p.headBlock.DataLength()
-		fmt.Println("head block: ", p.headBlock.BlockMeta().BlockID, p.headBlock.DataLength())
 	}
 	for _, b := range p.walBlocks {
 		sum += b.DataLength()
-		fmt.Println("wal block: ", b.BlockMeta().BlockID, b.DataLength())
 	}
 	for _, b := range p.completeBlocks {
 		sum += b.BlockMeta().Size
-		fmt.Println("complete block: ", b.BlockMeta().BlockID, b.BlockMeta().Size)
 	}
 
 	metricBlockSize.WithLabelValues(p.tenant).Set(float64(sum))

--- a/modules/overrides/limits.go
+++ b/modules/overrides/limits.go
@@ -72,6 +72,7 @@ type Limits struct {
 	MetricsGeneratorProcessorSpanMetricsDimensions          []string                    `yaml:"metrics_generator_processor_span_metrics_dimensions" json:"metrics_generator_processor_span_metrics_dimensions"`
 	MetricsGeneratorProcessorSpanMetricsIntrinsicDimensions map[string]bool             `yaml:"metrics_generator_processor_span_metrics_intrinsic_dimensions" json:"metrics_generator_processor_span_metrics_intrinsic_dimensions"`
 	MetricsGeneratorProcessorSpanMetricsFilterPolicies      []filterconfig.FilterPolicy `yaml:"metrics_generator_processor_span_metrics_filter_policies" json:"metrics_generator_processor_span_metrics_filter_policies"`
+	MetricsGeneratorProcessorLocalBlocksMaxLiveTraces       uint64                      `yaml:"metrics_generator_processor_local_blocks_max_live_traces" json:"metrics_generator_processor_local_blocks_max_live_traces"`
 
 	// Compactor enforced limits.
 	BlockRetention model.Duration `yaml:"block_retention" json:"block_retention"`

--- a/modules/overrides/limits.go
+++ b/modules/overrides/limits.go
@@ -59,20 +59,25 @@ type Limits struct {
 	Forwarders []string `yaml:"forwarders" json:"forwarders"`
 
 	// Metrics-generator config
-	MetricsGeneratorRingSize                                int                         `yaml:"metrics_generator_ring_size" json:"metrics_generator_ring_size"`
-	MetricsGeneratorProcessors                              ListToMap                   `yaml:"metrics_generator_processors" json:"metrics_generator_processors"`
-	MetricsGeneratorMaxActiveSeries                         uint32                      `yaml:"metrics_generator_max_active_series" json:"metrics_generator_max_active_series"`
-	MetricsGeneratorCollectionInterval                      time.Duration               `yaml:"metrics_generator_collection_interval" json:"metrics_generator_collection_interval"`
-	MetricsGeneratorDisableCollection                       bool                        `yaml:"metrics_generator_disable_collection" json:"metrics_generator_disable_collection"`
-	MetricsGeneratorForwarderQueueSize                      int                         `yaml:"metrics_generator_forwarder_queue_size" json:"metrics_generator_forwarder_queue_size"`
-	MetricsGeneratorForwarderWorkers                        int                         `yaml:"metrics_generator_forwarder_workers" json:"metrics_generator_forwarder_workers"`
-	MetricsGeneratorProcessorServiceGraphsHistogramBuckets  []float64                   `yaml:"metrics_generator_processor_service_graphs_histogram_buckets" json:"metrics_generator_processor_service_graphs_histogram_buckets"`
-	MetricsGeneratorProcessorServiceGraphsDimensions        []string                    `yaml:"metrics_generator_processor_service_graphs_dimensions" json:"metrics_generator_processor_service_graphs_dimensions"`
-	MetricsGeneratorProcessorSpanMetricsHistogramBuckets    []float64                   `yaml:"metrics_generator_processor_span_metrics_histogram_buckets" json:"metrics_generator_processor_span_metrics_histogram_buckets"`
-	MetricsGeneratorProcessorSpanMetricsDimensions          []string                    `yaml:"metrics_generator_processor_span_metrics_dimensions" json:"metrics_generator_processor_span_metrics_dimensions"`
-	MetricsGeneratorProcessorSpanMetricsIntrinsicDimensions map[string]bool             `yaml:"metrics_generator_processor_span_metrics_intrinsic_dimensions" json:"metrics_generator_processor_span_metrics_intrinsic_dimensions"`
-	MetricsGeneratorProcessorSpanMetricsFilterPolicies      []filterconfig.FilterPolicy `yaml:"metrics_generator_processor_span_metrics_filter_policies" json:"metrics_generator_processor_span_metrics_filter_policies"`
-	MetricsGeneratorProcessorLocalBlocksMaxLiveTraces       uint64                      `yaml:"metrics_generator_processor_local_blocks_max_live_traces" json:"metrics_generator_processor_local_blocks_max_live_traces"`
+	MetricsGeneratorRingSize                                 int                         `yaml:"metrics_generator_ring_size" json:"metrics_generator_ring_size"`
+	MetricsGeneratorProcessors                               ListToMap                   `yaml:"metrics_generator_processors" json:"metrics_generator_processors"`
+	MetricsGeneratorMaxActiveSeries                          uint32                      `yaml:"metrics_generator_max_active_series" json:"metrics_generator_max_active_series"`
+	MetricsGeneratorCollectionInterval                       time.Duration               `yaml:"metrics_generator_collection_interval" json:"metrics_generator_collection_interval"`
+	MetricsGeneratorDisableCollection                        bool                        `yaml:"metrics_generator_disable_collection" json:"metrics_generator_disable_collection"`
+	MetricsGeneratorForwarderQueueSize                       int                         `yaml:"metrics_generator_forwarder_queue_size" json:"metrics_generator_forwarder_queue_size"`
+	MetricsGeneratorForwarderWorkers                         int                         `yaml:"metrics_generator_forwarder_workers" json:"metrics_generator_forwarder_workers"`
+	MetricsGeneratorProcessorServiceGraphsHistogramBuckets   []float64                   `yaml:"metrics_generator_processor_service_graphs_histogram_buckets" json:"metrics_generator_processor_service_graphs_histogram_buckets"`
+	MetricsGeneratorProcessorServiceGraphsDimensions         []string                    `yaml:"metrics_generator_processor_service_graphs_dimensions" json:"metrics_generator_processor_service_graphs_dimensions"`
+	MetricsGeneratorProcessorSpanMetricsHistogramBuckets     []float64                   `yaml:"metrics_generator_processor_span_metrics_histogram_buckets" json:"metrics_generator_processor_span_metrics_histogram_buckets"`
+	MetricsGeneratorProcessorSpanMetricsDimensions           []string                    `yaml:"metrics_generator_processor_span_metrics_dimensions" json:"metrics_generator_processor_span_metrics_dimensions"`
+	MetricsGeneratorProcessorSpanMetricsIntrinsicDimensions  map[string]bool             `yaml:"metrics_generator_processor_span_metrics_intrinsic_dimensions" json:"metrics_generator_processor_span_metrics_intrinsic_dimensions"`
+	MetricsGeneratorProcessorSpanMetricsFilterPolicies       []filterconfig.FilterPolicy `yaml:"metrics_generator_processor_span_metrics_filter_policies" json:"metrics_generator_processor_span_metrics_filter_policies"`
+	MetricsGeneratorProcessorLocalBlocksMaxLiveTraces        uint64                      `yaml:"metrics_generator_processor_local_blocks_max_live_traces" json:"metrics_generator_processor_local_blocks_max_live_traces"`
+	MetricsGeneratorProcessorLocalBlocksMaxBlockDuration     time.Duration               `yaml:"metrics_generator_processor_local_blocks_max_block_duration" json:"metrics_generator_processor_local_blocks_max_block_duration"`
+	MetricsGeneratorProcessorLocalBlocksMaxBlockBytes        uint64                      `yaml:"metrics_generator_processor_local_blocks_max_block_bytes" json:"metrics_generator_processor_local_blocks_max_block_bytes"`
+	MetricsGeneratorProcessorLocalBlocksFlushCheckPeriod     time.Duration               `yaml:"metrics_generator_processor_local_blocks_flush_check_period" json:"metrics_generator_processor_local_blocks_flush_check_period"`
+	MetricsGeneratorProcessorLocalBlocksTraceIdlePeriod      time.Duration               `yaml:"metrics_generator_processor_local_blocks_trace_idle_period" json:"metrics_generator_processor_local_blocks_trace_idle_period"`
+	MetricsGeneratorProcessorLocalBlocksCompleteBlockTimeout time.Duration               `yaml:"metrics_generator_processor_local_blocks_complete_block_timeout" json:"metrics_generator_processor_local_blocks_complete_block_timeout"`
 
 	// Compactor enforced limits.
 	BlockRetention model.Duration `yaml:"block_retention" json:"block_retention"`

--- a/modules/overrides/overrides.go
+++ b/modules/overrides/overrides.go
@@ -352,6 +352,10 @@ func (o *Overrides) MetricsGeneratorProcessorSpanMetricsFilterPolicies(userID st
 	return o.getOverridesForUser(userID).MetricsGeneratorProcessorSpanMetricsFilterPolicies
 }
 
+func (o *Overrides) MetricsGeneratorProcessorLocalBlocksMaxLiveTraces(userID string) uint64 {
+	return o.getOverridesForUser(userID).MetricsGeneratorProcessorLocalBlocksMaxLiveTraces
+}
+
 // BlockRetention is the duration of the block retention for this tenant.
 func (o *Overrides) BlockRetention(userID string) time.Duration {
 	return time.Duration(o.getOverridesForUser(userID).BlockRetention)

--- a/modules/overrides/overrides.go
+++ b/modules/overrides/overrides.go
@@ -356,6 +356,26 @@ func (o *Overrides) MetricsGeneratorProcessorLocalBlocksMaxLiveTraces(userID str
 	return o.getOverridesForUser(userID).MetricsGeneratorProcessorLocalBlocksMaxLiveTraces
 }
 
+func (o *Overrides) MetricsGeneratorProcessorLocalBlocksMaxBlockDuration(userID string) time.Duration {
+	return o.getOverridesForUser(userID).MetricsGeneratorProcessorLocalBlocksMaxBlockDuration
+}
+
+func (o *Overrides) MetricsGeneratorProcessorLocalBlocksMaxBlockBytes(userID string) uint64 {
+	return o.getOverridesForUser(userID).MetricsGeneratorProcessorLocalBlocksMaxBlockBytes
+}
+
+func (o *Overrides) MetricsGeneratorProcessorLocalBlocksTraceIdlePeriod(userID string) time.Duration {
+	return o.getOverridesForUser(userID).MetricsGeneratorProcessorLocalBlocksTraceIdlePeriod
+}
+
+func (o *Overrides) MetricsGeneratorProcessorLocalBlocksFlushCheckPeriod(userID string) time.Duration {
+	return o.getOverridesForUser(userID).MetricsGeneratorProcessorLocalBlocksFlushCheckPeriod
+}
+
+func (o *Overrides) MetricsGeneratorProcessorLocalBlocksCompleteBlockTimeout(userID string) time.Duration {
+	return o.getOverridesForUser(userID).MetricsGeneratorProcessorLocalBlocksCompleteBlockTimeout
+}
+
 // BlockRetention is the duration of the block retention for this tenant.
 func (o *Overrides) BlockRetention(userID string) time.Duration {
 	return time.Duration(o.getOverridesForUser(userID).BlockRetention)


### PR DESCRIPTION
**What this PR does**:
This PR is part of a wider initiative to perform on-demand metrics calculations. Add per-tenant overrides and limits for settings related to flushing/retaining local blocks, and a few metrics similar to those in the ingester.  

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`