### PR TITLE
Keep blocks for longer in e2e test

### DIFF
--- a/integration/e2e/config-all-in-one-local.yaml
+++ b/integration/e2e/config-all-in-one-local.yaml
@@ -32,7 +32,7 @@ ingester:
   trace_idle_period: 1s
   max_block_bytes: 1
   max_block_duration: 2s
-  complete_block_timeout: 1s
+  complete_block_timeout: 20s
   flush_check_period: 1s
 
 storage:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Increases `ingester.complete_block_timeout` in e2e test config to reduce probability of race condition.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`