### PR TITLE
Wal blocks AppendTrace method

### DIFF
--- a/tempodb/encoding/common/interfaces.go
+++ b/tempodb/encoding/common/interfaces.go
@@ -96,6 +96,8 @@ type WALBlock interface {
 	// Append the given trace to the block. Must be safe for concurrent use with read operations.
 	Append(id ID, b []byte, start, end uint32) error
 
+	AppendTrace(id ID, tr *tempopb.Trace, start, end uint32) error
+
 	// Flush any unbuffered data to disk.  Must be safe for concurrent use with read operations.
 	Flush() error
 

--- a/tempodb/encoding/vparquet/wal_block.go
+++ b/tempodb/encoding/vparquet/wal_block.go
@@ -316,12 +316,16 @@ func (b *walBlock) Append(id common.ID, buff []byte, start, end uint32) error {
 		return fmt.Errorf("error preparing trace for read: %w", err)
 	}
 
+	return b.AppendTrace(id, trace, start, end)
+}
+
+func (b *walBlock) AppendTrace(id common.ID, trace *tempopb.Trace, start, end uint32) error {
 	b.buffer = traceToParquet(id, trace, b.buffer)
 
 	start, end = b.adjustTimeRangeForSlack(start, end, 0)
 
 	// add to current
-	_, err = b.writer.Write([]*Trace{b.buffer})
+	_, err := b.writer.Write([]*Trace{b.buffer})
 	if err != nil {
 		return fmt.Errorf("error writing row: %w", err)
 	}
@@ -329,9 +333,7 @@ func (b *walBlock) Append(id common.ID, buff []byte, start, end uint32) error {
 	b.meta.ObjectAdded(id, start, end)
 	b.ids.Set(id, int64(b.ids.Len())) // Next row number
 
-	// This is actually the protobuf size but close enough
-	// for this purpose and only temporary until next flush.
-	b.unflushedSize += int64(len(buff))
+	b.unflushedSize += int64(estimateMarshalledSizeFromTrace(b.buffer))
 
 	return nil
 }

--- a/tempodb/encoding/vparquet2/wal_block.go
+++ b/tempodb/encoding/vparquet2/wal_block.go
@@ -316,12 +316,16 @@ func (b *walBlock) Append(id common.ID, buff []byte, start, end uint32) error {
 		return fmt.Errorf("error preparing trace for read: %w", err)
 	}
 
+	return b.AppendTrace(id, trace, start, end)
+}
+
+func (b *walBlock) AppendTrace(id common.ID, trace *tempopb.Trace, start, end uint32) error {
 	b.buffer = traceToParquet(id, trace, b.buffer)
 
 	start, end = b.adjustTimeRangeForSlack(start, end, 0)
 
 	// add to current
-	_, err = b.writer.Write([]*Trace{b.buffer})
+	_, err := b.writer.Write([]*Trace{b.buffer})
 	if err != nil {
 		return fmt.Errorf("error writing row: %w", err)
 	}
@@ -329,9 +333,7 @@ func (b *walBlock) Append(id common.ID, buff []byte, start, end uint32) error {
 	b.meta.ObjectAdded(id, start, end)
 	b.ids.Set(id, int64(b.ids.Len())) // Next row number
 
-	// This is actually the protobuf size but close enough
-	// for this purpose and only temporary until next flush.
-	b.unflushedSize += int64(len(buff))
+	b.unflushedSize += int64(estimateMarshalledSizeFromTrace(b.buffer))
 
 	return nil
 }


### PR DESCRIPTION
**What this PR does**:
This PR is part of a wider initiative to perform on-demand metrics calculations.  Adds a new WAL write path `AppendTrace` which takes a `tempopb.Trace` instead of encoded bytes, which allows the LocalBlocks processor to write more efficiently since it already has the traces in `tempopb.Trace` form.  No change made to ingester write path, except there will be a small difference in flushing going from `len(proto)` to `estimateMarshalledSizeFromTrace()` in the parquet encodings.

Updated just the one test `tempodb/wal/TestFindByTraceID` to cover both write paths.

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`