### PR TITLE
[DOC] Update query-editor.md

### DIFF
--- a/docs/sources/tempo/traceql/query-editor.md
+++ b/docs/sources/tempo/traceql/query-editor.md
@@ -13,19 +13,18 @@ keywords:
 
 # TraceQL query editor
 
-With Tempo 2.0, you can use the TraceQL viewer and query editor in the Tempo data source to build queries and drill-down into result sets. The editor is available in Grafana’s Explore interface.
+You can use the TraceQL viewer and query editor in the Tempo data source to build queries and drill-down into result sets. The editor is available in Grafana’s Explore interface.
 
->**NOTE**: To use the TraceQL query editor, you need to enable the `traceqlEditor` feature flag. This feature is available starting in Grafana 9.3.2.
+>**NOTE**: To use the TraceQL query editor in Grafana, you need to enable the `traceqlEditor` feature flag. This feature is available starting in Grafana 9.3.2. The query editory is available automatically in Grafana Cloud. 
 
-
-<p align="center"><img src="./assets/query-editor-http-method.png" alt="Query editor showing request for http.method" /></p>
+![Query editor showing request for http.method](/static/img/docs/tempo/query-editor-http-method.png)
 
 Using the query editor, you can use the editor’s autocomplete suggestions to write queries. The editor detects span sets to provide relevant autocomplete options. It uses regular expressions (regex) to detect where it is inside a spanset and provide attribute names, scopes, intrinsic names, logic operators, or attribute values from Tempo's API, depending on what is expected for the current situation.
 
-<p align="center"><img src="./assets/query-editor-auto-complete.png" alt="Query editor showing the auto-complete feature" /></p>
+![Query editor showing the auto-complete feature](/static/img/docs/tempo/query-editor-auto-complete.png)
 
 Query results are returned in a table. Selecting the Trace ID or Span ID provides more detailed information.
 
-<p align="center"><img src="./assets/query-editor-results-span.png" alt="Query editor showing span results" /></p>
+![Query editor showing span results](/static/img/docs/tempo/query-editor-results-span.png)
 
 Selecting the trace ID from the returned results will open a trace diagram. Selecting a span from the returned results opens a trace diagram and reveals the relevant span in the trace diagram (above, the highlighted blue line).


### PR DESCRIPTION
**What this PR does**:
Preparing to share the content from the query editor page to the Cloud and the Grafana docs. This update: 
* Changes the image calls from the TraceQL query editor page to use the asset storage in GCP instead of local storage
* Removes calls to specific Tempo versions
* Adds a few words about Grafana Cloud vs Grafana
