### PR TITLE
Copy tempo-query binary to /tempo-query

### DIFF
--- a/cmd/tempo-query/Dockerfile
+++ b/cmd/tempo-query/Dockerfile
@@ -3,7 +3,8 @@ FROM jaegertracing/jaeger-query:1.43.0
 ENV SPAN_STORAGE_TYPE=grpc-plugin \
     GRPC_STORAGE_PLUGIN_BINARY=/tmp/tempo-query
 
-# This is silly, but it's important that tempo-query gets copied into /tmp
-#  b/c it forces a /tmp dir to exist which hashicorp plugins depend on
+# This is silly, but it's important b/c it forces a /tmp dir to exist which hashicorp plugins depend on
+RUN mkdir -p /tmp
+
 ARG TARGETARCH
-COPY bin/linux/tempo-query-${TARGETARCH} /tmp/tempo-query
+COPY bin/linux/tempo-query-${TARGETARCH} /tempo-query


### PR DESCRIPTION
- previous implementation forces tempo to run with root privileges in Kubernetes because it is also writing to files in /tmp directory
- this solution is inline to how other tempo components are built and ensures /tmp dir exists with mkdir -p

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`