### PR TITLE
Fix Search - Cross pollination

### DIFF
--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -180,7 +180,7 @@ func newTraceByIDMiddleware(cfg Config, logger log.Logger) Middleware {
 func newSearchMiddleware(cfg Config, o *overrides.Overrides, reader tempodb.Reader, logger log.Logger) Middleware {
 	return MiddlewareFunc(func(next http.RoundTripper) http.RoundTripper {
 		ingesterSearchRT := next
-		backendSearchRT := NewRoundTripper(next, newSearchSharder(reader, o, cfg.Search.Sharder, cfg.Search.SLO, newSearchProgress(), logger))
+		backendSearchRT := NewRoundTripper(next, newSearchSharder(reader, o, cfg.Search.Sharder, cfg.Search.SLO, newSearchProgress, logger))
 
 		return RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 			// backend search queries require sharding so we pass through a special roundtripper

--- a/modules/frontend/search_progress_test.go
+++ b/modules/frontend/search_progress_test.go
@@ -14,43 +14,36 @@ func TestSearchProgressShouldQuit(t *testing.T) {
 	ctx := context.Background()
 
 	// brand-new response should not quit
-	sr := newSearchProgress()
-	sr.init(ctx, 10, 0, 0, 0)
+	sr := newSearchProgress(ctx, 10, 0, 0, 0)
 	assert.False(t, sr.shouldQuit())
 
 	// errored response should quit
-	sr = newSearchProgress()
-	sr.init(ctx, 10, 0, 0, 0)
+	sr = newSearchProgress(ctx, 10, 0, 0, 0)
 	sr.setError(errors.New("blerg"))
 	assert.True(t, sr.shouldQuit())
 
 	// happy status code should not quit
-	sr = newSearchProgress()
-	sr.init(ctx, 10, 0, 0, 0)
+	sr = newSearchProgress(ctx, 10, 0, 0, 0)
 	sr.setStatus(200, "")
 	assert.False(t, sr.shouldQuit())
 
 	// sad status code should quit
-	sr = newSearchProgress()
-	sr.init(ctx, 10, 0, 0, 0)
+	sr = newSearchProgress(ctx, 10, 0, 0, 0)
 	sr.setStatus(400, "")
 	assert.True(t, sr.shouldQuit())
 
-	sr = newSearchProgress()
-	sr.init(ctx, 10, 0, 0, 0)
+	sr = newSearchProgress(ctx, 10, 0, 0, 0)
 	sr.setStatus(500, "")
 	assert.True(t, sr.shouldQuit())
 
 	// cancelled context should quit
 	cancellableContext, cancel := context.WithCancel(ctx)
-	sr = newSearchProgress()
-	sr.init(cancellableContext, 10, 0, 0, 0)
+	sr = newSearchProgress(cancellableContext, 10, 0, 0, 0)
 	cancel()
 	assert.True(t, sr.shouldQuit())
 
 	// limit reached should quit
-	sr = newSearchProgress()
-	sr.init(ctx, 2, 0, 0, 0)
+	sr = newSearchProgress(ctx, 2, 0, 0, 0)
 	sr.addResponse(&tempopb.SearchResponse{
 		Traces: []*tempopb.TraceSearchMetadata{
 			{
@@ -90,8 +83,7 @@ func TestSearchProgressCombineResults(t *testing.T) {
 	start := time.Date(1, 2, 3, 4, 5, 6, 7, time.UTC)
 	traceID := "traceID"
 
-	sr := newSearchProgress()
-	sr.init(context.Background(), 10, 0, 0, 0)
+	sr := newSearchProgress(context.Background(), 10, 0, 0, 0)
 	sr.addResponse(&tempopb.SearchResponse{
 		Traces: []*tempopb.TraceSearchMetadata{
 			{

--- a/modules/frontend/search_streaming.go
+++ b/modules/frontend/search_streaming.go
@@ -147,12 +147,12 @@ func newSearchStreamingHandler(cfg Config, o *overrides.Overrides, downstream ht
 				return ctx.Err()
 			// stream results as they come in
 			case <-time.After(500 * time.Millisecond):
-				p := *progress.Load()
+				p := progress.Load()
 				if p == nil {
 					continue
 				}
 
-				result := p.result()
+				result := (*p).result()
 				if result.err != nil || result.statusCode != http.StatusOK { // ignore errors here, we'll get them in the resultChan
 					continue
 				}
@@ -164,7 +164,6 @@ func newSearchStreamingHandler(cfg Config, o *overrides.Overrides, downstream ht
 				}
 			// final result is available
 			case roundTripRes := <-resultChan:
-				p := *progress.Load()
 				// check for errors in the http response
 				if roundTripRes.err != nil {
 					return roundTripRes.err
@@ -177,6 +176,7 @@ func newSearchStreamingHandler(cfg Config, o *overrides.Overrides, downstream ht
 				}
 
 				// overall pipeline returned successfully, now grab the final results and send them
+				p := *progress.Load()
 				result := p.finalResult()
 				if result.err != nil || result.statusCode != http.StatusOK {
 					level.Error(logger).Log("msg", "search streaming: result status != 200", "err", result.err, "status", result.statusCode, "body", result.statusMsg)

--- a/modules/frontend/search_streaming_test.go
+++ b/modules/frontend/search_streaming_test.go
@@ -235,9 +235,8 @@ func testHandler(t *testing.T, next http.RoundTripper) streamingSearchHandler {
 }
 
 func TestDiffSearchProgress(t *testing.T) {
-	diffProgress := newDiffSearchProgress()
 	ctx := context.Background()
-	diffProgress.init(ctx, 0, 0, 0, 0)
+	diffProgress := newDiffSearchProgress(ctx, 0, 0, 0, 0)
 
 	// first request should be empty
 	require.Equal(t, &tempopb.SearchResponse{

--- a/modules/frontend/searchsharding_test.go
+++ b/modules/frontend/searchsharding_test.go
@@ -558,7 +558,7 @@ func TestSearchSharderRoundTrip(t *testing.T) {
 			}, o, SearchSharderConfig{
 				ConcurrentRequests:    1, // 1 concurrent request to force order
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
-			}, testSLOcfg, newSearchProgress(), log.NewNopLogger())
+			}, testSLOcfg, newSearchProgress, log.NewNopLogger())
 			testRT := NewRoundTripper(next, sharder)
 
 			req := httptest.NewRequest("GET", "/?start=1000&end=1500", nil)
@@ -604,7 +604,7 @@ func TestSearchSharderRoundTripBadRequest(t *testing.T) {
 		ConcurrentRequests:    defaultConcurrentRequests,
 		TargetBytesPerRequest: defaultTargetBytesPerRequest,
 		MaxDuration:           5 * time.Minute,
-	}, testSLOcfg, newSearchProgress(), log.NewNopLogger())
+	}, testSLOcfg, newSearchProgress, log.NewNopLogger())
 	testRT := NewRoundTripper(next, sharder)
 
 	// no org id
@@ -633,7 +633,7 @@ func TestSearchSharderRoundTripBadRequest(t *testing.T) {
 		ConcurrentRequests:    defaultConcurrentRequests,
 		TargetBytesPerRequest: defaultTargetBytesPerRequest,
 		MaxDuration:           5 * time.Minute,
-	}, testSLOcfg, newSearchProgress(), log.NewNopLogger())
+	}, testSLOcfg, newSearchProgress, log.NewNopLogger())
 	testRT = NewRoundTripper(next, sharder)
 
 	req = httptest.NewRequest("GET", "/?start=1000&end=1500", nil)
@@ -758,7 +758,7 @@ func TestSubRequestsCancelled(t *testing.T) {
 		ConcurrentRequests:    10,
 		TargetBytesPerRequest: defaultTargetBytesPerRequest,
 		DefaultLimit:          2,
-	}, testSLOcfg, newSearchProgress(), log.NewNopLogger())
+	}, testSLOcfg, newSearchProgress, log.NewNopLogger())
 
 	// return some things and assert the right subrequests are cancelled
 	// 500, err, limit


### PR DESCRIPTION
The query frontend currently has an issue introduced in https://github.com/grafana/tempo/pull/2366 where it will cross pollinate search results if two were initiated at roughly the same time.

This was due to reuse of the same "shardedSearchProgress" object for every query. This PR fixes it by using a factory function instead of a single instance to have a unique instance per search.