### PR TITLE
Disable tempo-query by default in Jsonnet libs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [CHANGE] Disable tempo-query by default in Jsonnet libs. [#2462](https://github.com/grafana/tempo/pull/2462) (@electron0zero)
 * [ENHANCEMENT] log client ip to help identify which client is no org id [#2436](https://github.com/grafana/tempo/pull/2436)
 * [ENHANCEMENT] Add `spss` parameter to `/api/search/tags`[#2308] to configure the spans per span set in response
 * [BUGFIX] Fix Search SLO by routing tags to a new handler. [#2468](https://github.com/grafana/tempo/issues/2468) (@electron0zero)

--- a/operations/jsonnet-compiled/ConfigMap-tempo-query.yaml
+++ b/operations/jsonnet-compiled/ConfigMap-tempo-query.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-data:
-  tempo-query.yaml: |
-    backend: localhost:3200
-kind: ConfigMap
-metadata:
-  name: tempo-query
-  namespace: tracing

--- a/operations/jsonnet-compiled/Deployment-query-frontend.yaml
+++ b/operations/jsonnet-compiled/Deployment-query-frontend.yaml
@@ -52,25 +52,7 @@ spec:
           name: tempo-conf
         - mountPath: /overrides
           name: overrides
-      - args:
-        - --query.base-path=/tempo
-        - --grpc-storage-plugin.configuration-file=/conf/tempo-query.yaml
-        - --query.bearer-token-propagation=true
-        image: grafana/tempo-query:latest
-        imagePullPolicy: IfNotPresent
-        name: tempo-query
-        ports:
-        - containerPort: 16686
-          name: jaeger-ui
-        - containerPort: 16687
-          name: jaeger-metrics
-        volumeMounts:
-        - mountPath: /conf
-          name: tempo-query-conf
       volumes:
-      - configMap:
-          name: tempo-query
-        name: tempo-query-conf
       - configMap:
           name: tempo-query-frontend
         name: tempo-conf

--- a/operations/jsonnet-compiled/Service-query-frontend-discovery.yaml
+++ b/operations/jsonnet-compiled/Service-query-frontend-discovery.yaml
@@ -11,12 +11,6 @@ spec:
   - name: query-frontend-prom-metrics
     port: 3200
     targetPort: 3200
-  - name: tempo-query-jaeger-ui
-    port: 16686
-    targetPort: 16686
-  - name: tempo-query-jaeger-metrics
-    port: 16687
-    targetPort: 16687
   - name: grpc
     port: 9095
     targetPort: 9095

--- a/operations/jsonnet-compiled/Service-query-frontend.yaml
+++ b/operations/jsonnet-compiled/Service-query-frontend.yaml
@@ -10,12 +10,6 @@ spec:
   - name: query-frontend-prom-metrics
     port: 3200
     targetPort: 3200
-  - name: tempo-query-jaeger-ui
-    port: 16686
-    targetPort: 16686
-  - name: tempo-query-jaeger-metrics
-    port: 16687
-    targetPort: 16687
   - name: http
     port: 80
     targetPort: 3200

--- a/operations/jsonnet-compiled/util/Makefile
+++ b/operations/jsonnet-compiled/util/Makefile
@@ -4,6 +4,7 @@ gen:
 	jb update
 	tk export out/ example --format "{{.kind}}-{{or .metadata.name .metadata.generateName}}"
 
+	rm -r ../*.yaml
 	cp out/*.yaml ../
 	rm -r out/
 

--- a/operations/jsonnet-compiled/util/example/main.jsonnet
+++ b/operations/jsonnet-compiled/util/example/main.jsonnet
@@ -5,10 +5,10 @@ local tempo = import 'microservices/tempo.libsonnet';
 tempo {
   _images+:: {
     tempo: 'grafana/tempo:latest',
-    tempo_query: 'grafana/tempo-query:latest',
     tempo_vulture: 'grafana/tempo-vulture:latest',
   },
 
+  // generate with `tempo_query: true` to include tempo-query manifests
   _config+:: {
     namespace: 'tracing',
     compactor+: {

--- a/operations/jsonnet-compiled/util/example/main.jsonnet
+++ b/operations/jsonnet-compiled/util/example/main.jsonnet
@@ -6,9 +6,10 @@ tempo {
   _images+:: {
     tempo: 'grafana/tempo:latest',
     tempo_vulture: 'grafana/tempo-vulture:latest',
+    tempo_query: 'grafana/tempo-query:latest',
   },
 
-  // generate with `tempo_query: true` to include tempo-query manifests
+  // generate with `tempo_query.enabled: true` to include tempo-query manifests
   _config+:: {
     namespace: 'tracing',
     compactor+: {

--- a/operations/jsonnet-compiled/util/jsonnetfile.lock.json
+++ b/operations/jsonnet-compiled/util/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "d303b2031264728728dd1e1c05f74f67027139f6",
+      "version": "3b08e7d37511dfd39af6027d07788a5ca8ec71b1",
       "sum": "0y3AFX9LQSpfWTxWKSwoLgbt0Wc9nnCwhMH2szKzHv0="
     },
     {
@@ -18,7 +18,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "d303b2031264728728dd1e1c05f74f67027139f6",
+      "version": "3b08e7d37511dfd39af6027d07788a5ca8ec71b1",
       "sum": "SWywAq4U0MRPMbASU0Ez8O9ArRNeoZzb75sEuReueow="
     },
     {

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -44,6 +44,8 @@
         },
       },
     },
+    // disable tempo-query by default
+    tempo_query: false,
     querier: {
       replicas: 2,
       resources: {

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -18,6 +18,9 @@
     node_selector: null,
     ingester_allow_multiple_replicas_on_same_node: false,
 
+    // disable tempo-query by default
+    tempo_query: false,
+
     compactor: {
       replicas: 1,
       resources: {
@@ -44,8 +47,6 @@
         },
       },
     },
-    // disable tempo-query by default
-    tempo_query: false,
     querier: {
       replicas: 2,
       resources: {

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -19,8 +19,9 @@
     ingester_allow_multiple_replicas_on_same_node: false,
 
     // disable tempo-query by default
-    tempo_query: false,
-
+    tempo_query: {
+      enabled: false,
+    },
     compactor: {
       replicas: 1,
       resources: {

--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -157,7 +157,7 @@
       'tempo.yaml': $.util.manifestYaml($.tempo_query_frontend_config),
     }),
 
-  tempo_query_configmap:
+  tempo_query_configmap: if !$._config.tempo_query then null else
     configMap.new('tempo-query') +
     configMap.withData({
       'tempo-query.yaml': $.util.manifestYaml({

--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -157,7 +157,7 @@
       'tempo.yaml': $.util.manifestYaml($.tempo_query_frontend_config),
     }),
 
-  tempo_query_configmap: if !$._config.tempo_query then null else
+  tempo_query_configmap: if $._config.tempo_query.enabled then
     configMap.new('tempo-query') +
     configMap.withData({
       'tempo-query.yaml': $.util.manifestYaml({

--- a/operations/jsonnet/microservices/frontend.libsonnet
+++ b/operations/jsonnet/microservices/frontend.libsonnet
@@ -34,7 +34,7 @@
     $.util.readinessProbe +
     (if $._config.variables_expansion then container.withArgsMixin(['-config.expand-env=true']) else {}),
 
-  tempo_query_container::
+  tempo_query_container:: if !$._config.tempo_query then null else
     container.new('tempo-query', $._images.tempo_query) +
     container.withPorts([
       containerPort.new('jaeger-ui', 16686),
@@ -53,7 +53,8 @@
     deployment.new(
       target_name,
       $._config.query_frontend.replicas,
-      [$.tempo_query_frontend_container, $.tempo_query_container],
+      [$.tempo_query_frontend_container,
+      if !$._config.tempo_query then null else $.tempo_query_container],
       {
         app: target_name,
       }
@@ -64,7 +65,7 @@
       config_hash: std.md5(std.toString($.tempo_query_frontend_configmap.data['tempo.yaml'])),
     }) +
     deployment.mixin.spec.template.spec.withVolumes([
-      volume.fromConfigMap(tempo_query_config_volume, $.tempo_query_configmap.metadata.name),
+      if !$._config.tempo_query then null else volume.fromConfigMap(tempo_query_config_volume, $.tempo_query_configmap.metadata.name),
       volume.fromConfigMap(tempo_config_volume, $.tempo_query_frontend_configmap.metadata.name),
       volume.fromConfigMap(tempo_overrides_config_volume, $._config.overrides_configmap_name),
     ]),

--- a/operations/jsonnet/microservices/frontend.libsonnet
+++ b/operations/jsonnet/microservices/frontend.libsonnet
@@ -53,8 +53,8 @@
     deployment.new(
       target_name,
       $._config.query_frontend.replicas,
-      [$.tempo_query_frontend_container,
-      if !$._config.tempo_query then null else $.tempo_query_container],
+      std.prune([$.tempo_query_frontend_container,
+      if $._config.tempo_query then $.tempo_query_container]),
       {
         app: target_name,
       }
@@ -64,11 +64,11 @@
     deployment.mixin.spec.template.metadata.withAnnotations({
       config_hash: std.md5(std.toString($.tempo_query_frontend_configmap.data['tempo.yaml'])),
     }) +
-    deployment.mixin.spec.template.spec.withVolumes([
-      if !$._config.tempo_query then null else volume.fromConfigMap(tempo_query_config_volume, $.tempo_query_configmap.metadata.name),
+    deployment.mixin.spec.template.spec.withVolumes(std.prune([
+      if $._config.tempo_query then volume.fromConfigMap(tempo_query_config_volume, $.tempo_query_configmap.metadata.name),
       volume.fromConfigMap(tempo_config_volume, $.tempo_query_frontend_configmap.metadata.name),
       volume.fromConfigMap(tempo_overrides_config_volume, $._config.overrides_configmap_name),
-    ]),
+    ])),
 
   tempo_query_frontend_service:
     k.util.serviceFor($.tempo_query_frontend_deployment)

--- a/operations/jsonnet/microservices/frontend.libsonnet
+++ b/operations/jsonnet/microservices/frontend.libsonnet
@@ -34,7 +34,7 @@
     $.util.readinessProbe +
     (if $._config.variables_expansion then container.withArgsMixin(['-config.expand-env=true']) else {}),
 
-  tempo_query_container:: if !$._config.tempo_query then null else
+  tempo_query_container::
     container.new('tempo-query', $._images.tempo_query) +
     container.withPorts([
       containerPort.new('jaeger-ui', 16686),
@@ -55,7 +55,7 @@
       $._config.query_frontend.replicas,
       std.prune([
         $.tempo_query_frontend_container,
-        if $._config.tempo_query then $.tempo_query_container,
+        if $._config.tempo_query.enabled then $.tempo_query_container,
       ]),
       {
         app: target_name,
@@ -67,7 +67,7 @@
       config_hash: std.md5(std.toString($.tempo_query_frontend_configmap.data['tempo.yaml'])),
     }) +
     deployment.mixin.spec.template.spec.withVolumes(std.prune([
-      if $._config.tempo_query then volume.fromConfigMap(tempo_query_config_volume, $.tempo_query_configmap.metadata.name),
+      if $._config.tempo_query.enabled then volume.fromConfigMap(tempo_query_config_volume, $.tempo_query_configmap.metadata.name),
       volume.fromConfigMap(tempo_config_volume, $.tempo_query_frontend_configmap.metadata.name),
       volume.fromConfigMap(tempo_overrides_config_volume, $._config.overrides_configmap_name),
     ])),

--- a/operations/jsonnet/microservices/frontend.libsonnet
+++ b/operations/jsonnet/microservices/frontend.libsonnet
@@ -53,8 +53,10 @@
     deployment.new(
       target_name,
       $._config.query_frontend.replicas,
-      std.prune([$.tempo_query_frontend_container,
-      if $._config.tempo_query then $.tempo_query_container]),
+      std.prune([
+        $.tempo_query_frontend_container,
+        if $._config.tempo_query then $.tempo_query_container,
+      ]),
       {
         app: target_name,
       }

--- a/operations/jsonnet/single-binary/config.libsonnet
+++ b/operations/jsonnet/single-binary/config.libsonnet
@@ -11,6 +11,8 @@
       replicas: 1,
       headless_service_name: 'tempo-members',
     },
+    // disable tempo-query by default
+    tempo_query: false,
     pvc_size: error 'Must specify a pvc size',
     pvc_storage_class: error 'Must specify a pvc storage class',
     receivers: error 'Must specify receivers',

--- a/operations/jsonnet/single-binary/config.libsonnet
+++ b/operations/jsonnet/single-binary/config.libsonnet
@@ -12,7 +12,9 @@
       headless_service_name: 'tempo-members',
     },
     // disable tempo-query by default
-    tempo_query: false,
+    tempo_query: {
+      enabled: false,
+    },
     pvc_size: error 'Must specify a pvc size',
     pvc_storage_class: error 'Must specify a pvc storage class',
     receivers: error 'Must specify receivers',

--- a/operations/jsonnet/single-binary/configmap.libsonnet
+++ b/operations/jsonnet/single-binary/configmap.libsonnet
@@ -52,7 +52,7 @@
       |||,
     }),
 
-  tempo_query_configmap:
+  tempo_query_configmap: if $._config.tempo_query.enabled then
     configMap.new('tempo-query') +
     configMap.withData({
       'tempo-query.yaml': k.util.manifestYaml({

--- a/operations/jsonnet/single-binary/tempo.libsonnet
+++ b/operations/jsonnet/single-binary/tempo.libsonnet
@@ -72,7 +72,7 @@
                     $._config.tempo.replicas,
                     std.prune([
                       $.tempo_container,
-                      if $._config.tempo_query then $.tempo_query_container,
+                      if $._config.tempo_query.enabled then $.tempo_query_container,
                     ]),
                     self.tempo_pvc,
                     { app: 'tempo' }) +
@@ -84,7 +84,7 @@
     statefulset.mixin.spec.selector.withMatchLabels({ name: 'tempo' }) +
     statefulset.mixin.spec.template.metadata.withLabels({ name: 'tempo', app: $._config.tempo.headless_service_name }) +
     statefulset.mixin.spec.template.spec.withVolumes(std.prune([
-      if $._config.tempo_query then volume.fromConfigMap(tempo_query_config_volume, $.tempo_query_configmap.metadata.name),
+      if $._config.tempo_query.enabled then volume.fromConfigMap(tempo_query_config_volume, $.tempo_query_configmap.metadata.name),
       volume.fromConfigMap(tempo_config_volume, $.tempo_configmap.metadata.name),
     ])),
 

--- a/operations/jsonnet/single-binary/tempo.libsonnet
+++ b/operations/jsonnet/single-binary/tempo.libsonnet
@@ -70,10 +70,8 @@
   tempo_statefulset:
     statefulset.new('tempo',
                     $._config.tempo.replicas,
-                    [
-                      $.tempo_container,
-                      $.tempo_query_container,
-                    ],
+                    std.prune([$.tempo_container,
+                    if $._config.tempo_query then $.tempo_query_container]),
                     self.tempo_pvc,
                     { app: 'tempo' }) +
     statefulset.mixin.spec.withServiceName('tempo') +
@@ -83,10 +81,10 @@
     statefulset.mixin.metadata.withLabels({ app: $._config.tempo.headless_service_name, name: 'tempo' }) +
     statefulset.mixin.spec.selector.withMatchLabels({ name: 'tempo' }) +
     statefulset.mixin.spec.template.metadata.withLabels({ name: 'tempo', app: $._config.tempo.headless_service_name }) +
-    statefulset.mixin.spec.template.spec.withVolumes([
-      volume.fromConfigMap(tempo_query_config_volume, $.tempo_query_configmap.metadata.name),
+    statefulset.mixin.spec.template.spec.withVolumes(std.prune([
+     if $._config.tempo_query then volume.fromConfigMap(tempo_query_config_volume, $.tempo_query_configmap.metadata.name),
       volume.fromConfigMap(tempo_config_volume, $.tempo_configmap.metadata.name),
-    ]),
+    ])),
 
   tempo_service:
     k.util.serviceFor($.tempo_statefulset),

--- a/operations/jsonnet/single-binary/tempo.libsonnet
+++ b/operations/jsonnet/single-binary/tempo.libsonnet
@@ -70,8 +70,10 @@
   tempo_statefulset:
     statefulset.new('tempo',
                     $._config.tempo.replicas,
-                    std.prune([$.tempo_container,
-                    if $._config.tempo_query then $.tempo_query_container]),
+                    std.prune([
+                      $.tempo_container,
+                      if $._config.tempo_query then $.tempo_query_container,
+                    ]),
                     self.tempo_pvc,
                     { app: 'tempo' }) +
     statefulset.mixin.spec.withServiceName('tempo') +
@@ -82,7 +84,7 @@
     statefulset.mixin.spec.selector.withMatchLabels({ name: 'tempo' }) +
     statefulset.mixin.spec.template.metadata.withLabels({ name: 'tempo', app: $._config.tempo.headless_service_name }) +
     statefulset.mixin.spec.template.spec.withVolumes(std.prune([
-     if $._config.tempo_query then volume.fromConfigMap(tempo_query_config_volume, $.tempo_query_configmap.metadata.name),
+      if $._config.tempo_query then volume.fromConfigMap(tempo_query_config_volume, $.tempo_query_configmap.metadata.name),
       volume.fromConfigMap(tempo_config_volume, $.tempo_configmap.metadata.name),
     ])),
 


### PR DESCRIPTION
**What this PR does**:
tempo-query was required for Grafana version <7.5 for compatibility with jaeger-ui. grafana version <7.5 didn't have Tempo datasource, and we used jaeger datasource to query tempo via tempo-query.

Grafana 7.5 was released on Mar 25, 2021, which was 2+ year ago.

It is already disabled by default in helm-chart: https://github.com/grafana/helm-charts/pull/2387

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`