### PR TITLE
Local blocks processor query all blocks

### DIFF
--- a/modules/generator/processor/localblocks/config.go
+++ b/modules/generator/processor/localblocks/config.go
@@ -32,9 +32,9 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.Search = &tempodb.SearchConfig{}
 	cfg.Search.RegisterFlagsAndApplyDefaults(prefix, f)
 
-	cfg.FlushCheckPeriod = 5 * time.Second
-	cfg.TraceIdlePeriod = 5 * time.Second
+	cfg.FlushCheckPeriod = 10 * time.Second
+	cfg.TraceIdlePeriod = 10 * time.Second
 	cfg.MaxBlockDuration = 1 * time.Minute
 	cfg.MaxBlockBytes = 500_000_000
-	cfg.CompleteBlockTimeout = 5 * time.Minute
+	cfg.CompleteBlockTimeout = time.Hour
 }

--- a/modules/generator/processor/localblocks/processor.go
+++ b/modules/generator/processor/localblocks/processor.go
@@ -205,20 +205,20 @@ func (p *Processor) metricLoop() {
 
 func (p *Processor) completeBlock() error {
 
-	// Get a wal block and lock it.
+	// Get a wal block
 	var firstWalBlock common.WALBlock
-	p.blocksMtx.Lock()
+	p.blocksMtx.RLock()
 	for _, e := range p.walBlocks {
 		firstWalBlock = e
 		break
 	}
-	p.blocksMtx.Unlock()
+	p.blocksMtx.RUnlock()
 
 	if firstWalBlock == nil {
 		return nil
 	}
 
-	// Now create a new block just under read-lock
+	// Now create a new block
 
 	var (
 		ctx    = context.Background()
@@ -245,7 +245,7 @@ func (p *Processor) completeBlock() error {
 		return err
 	}
 
-	// Exchange read-lock for write lock
+	// Add new block and delete old block
 	p.blocksMtx.Lock()
 	defer p.blocksMtx.Unlock()
 

--- a/modules/generator/processor/localblocks/processor.go
+++ b/modules/generator/processor/localblocks/processor.go
@@ -31,7 +31,7 @@ type Processor struct {
 	wal      *wal.WAL
 	closeCh  chan struct{}
 	wg       sync.WaitGroup
-	cacheMtx sync.Mutex
+	cacheMtx sync.RWMutex
 	cache    *lru.Cache
 
 	blocksMtx      sync.RWMutex
@@ -343,8 +343,8 @@ func (p *Processor) GetMetrics(ctx context.Context, req *tempopb.SpanMetricsRequ
 }
 
 func (p *Processor) metricsCacheGet(key string) *traceqlmetrics.MetricsResults {
-	p.cacheMtx.Lock()
-	defer p.cacheMtx.Unlock()
+	p.cacheMtx.RLock()
+	defer p.cacheMtx.RUnlock()
 
 	if r, ok := p.cache.Get(key); ok {
 		return r.(*traceqlmetrics.MetricsResults)

--- a/modules/generator/processor/localblocks/processor_test.go
+++ b/modules/generator/processor/localblocks/processor_test.go
@@ -1,0 +1,119 @@
+package localblocks
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	"github.com/grafana/tempo/pkg/util/test"
+	"github.com/grafana/tempo/tempodb/encoding"
+	"github.com/grafana/tempo/tempodb/encoding/common"
+	"github.com/grafana/tempo/tempodb/wal"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessorDoesNotRace(t *testing.T) {
+	wal, err := wal.New(&wal.Config{
+		Filepath: t.TempDir(),
+		Version:  encoding.DefaultEncoding().Version(),
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	tenant := "fake"
+	cfg := Config{
+		FlushCheckPeriod:     10 * time.Millisecond,
+		TraceIdlePeriod:      time.Second,
+		CompleteBlockTimeout: time.Minute,
+		Block: &common.BlockConfig{
+			BloomShardSizeBytes: 100_000,
+			BloomFP:             0.05,
+			Version:             encoding.DefaultEncoding().Version(),
+		},
+	}
+
+	p, err := New(cfg, tenant, wal)
+	require.NoError(t, err)
+
+	end := make(chan struct{})
+
+	wg := sync.WaitGroup{}
+
+	concurrent := func(f func()) {
+		wg.Add(1)
+		defer wg.Done()
+
+		for {
+			select {
+			case <-end:
+				return
+			default:
+				f()
+			}
+		}
+	}
+
+	go concurrent(func() {
+		tr := test.MakeTrace(10, nil)
+		for _, b := range tr.Batches {
+			for _, ss := range b.ScopeSpans {
+				for _, s := range ss.Spans {
+					s.Kind = v1.Span_SPAN_KIND_SERVER
+				}
+			}
+		}
+
+		req := &tempopb.PushSpansRequest{
+			Batches: tr.Batches,
+		}
+		p.PushSpans(ctx, req)
+	})
+
+	go concurrent(func() {
+		err := p.cutIdleTraces(true)
+		require.NoError(t, err, "cutting idle traces")
+	})
+
+	go concurrent(func() {
+		err := p.cutBlocks(true)
+		require.NoError(t, err, "cutting blocks")
+	})
+
+	go concurrent(func() {
+		err := p.completeBlock()
+		require.NoError(t, err, "completing block")
+	})
+
+	go concurrent(func() {
+		err := p.deleteOldBlocks()
+		require.NoError(t, err, "deleting old blocks")
+	})
+
+	// Run multiple queries
+	go concurrent(func() {
+		_, err := p.GetMetrics(ctx, &tempopb.SpanMetricsRequest{
+			Query:   "{}",
+			GroupBy: "status",
+		})
+		require.NoError(t, err)
+	})
+
+	go concurrent(func() {
+		_, err := p.GetMetrics(ctx, &tempopb.SpanMetricsRequest{
+			Query:   "{}",
+			GroupBy: "status",
+		})
+		require.NoError(t, err)
+	})
+
+	// Run for a bit
+	time.Sleep(200 * time.Millisecond)
+
+	// Cleanup
+	close(end)
+	wg.Wait()
+	p.Shutdown(ctx)
+}


### PR DESCRIPTION
**What this PR does**:
This PR is part of a wider initiative to perform on-demand metrics calculations.  Updates the `/generator/api/metrics` API to query all blocks.  Includes some basic caching with simplelru that definitely needs to be replaced with something more robust.  Finally added a test but it's a good one 😬 

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`