### PR TITLE
Introduce `overrides.Interface` to decouple implementation from usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ To make use of filtering, configure `autocomplete_filtering_enabled`.
 * [ENHANCEMENT] Add support for IPv6 [#1555](https://github.com/grafana/tempo/pull/1555) (@zalegrala)
 * [ENHANCEMENT] Add span filtering to spanmetrics processor [#2274](https://github.com/grafana/tempo/pull/2274) (@zalegrala)
 * [ENHANCEMENT] Add ability to detect virtual nodes in the servicegraph processor [#2365](https://github.com/grafana/tempo/pull/2365) (@mapno)
+* [ENHANCEMENT] Introduce `overrides.Interface` to decouple implementation from usage [#2482](https://github.com/grafana/tempo/pull/2482) (@kvrhdn)
 * [BUGFIX] tempodb integer divide by zero error [#2167](https://github.com/grafana/tempo/issues/2167) (@kroksys)
 * [BUGFIX] metrics-generator: ensure Prometheus will scale up shards when remote write is lagging behind [#2463](https://github.com/grafana/tempo/issues/2463) (@kvrhdn)
 * [CHANGE] **Breaking Change** Rename s3.insecure_skip_verify [#2407](https://github.com/grafana/tempo/pull/2407) (@zalegrala)

--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -64,7 +64,7 @@ type App struct {
 	InternalServer *server.Server
 	ring           *ring.Ring
 	generatorRing  *ring.Ring
-	overrides      *overrides.Overrides
+	Overrides      overrides.Service
 	distributor    *distributor.Distributor
 	querier        *querier.Querier
 	frontend       *frontend_v1.Frontend
@@ -338,11 +338,11 @@ func (t *App) readyHandler(sm *services.Manager) http.HandlerFunc {
 
 func (t *App) writeRuntimeConfig(w io.Writer, r *http.Request) error {
 	// Querier and query-frontend services do not run the overrides module
-	if t.overrides == nil {
+	if t.Overrides == nil {
 		_, err := w.Write([]byte(fmt.Sprintf("overrides module not loaded in %s\n", t.cfg.Target)))
 		return err
 	}
-	return t.overrides.WriteStatusRuntimeConfig(w, r)
+	return t.Overrides.WriteStatusRuntimeConfig(w, r)
 }
 
 func (t *App) statusHandler() http.HandlerFunc {

--- a/modules/compactor/compactor.go
+++ b/modules/compactor/compactor.go
@@ -10,13 +10,13 @@ import (
 	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
-	tempoUtil "github.com/grafana/tempo/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/modules/storage"
 	"github.com/grafana/tempo/pkg/model"
+	tempoUtil "github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/pkg/util/log"
 )
 
@@ -43,7 +43,7 @@ type Compactor struct {
 
 	cfg       *Config
 	store     storage.Store
-	overrides *overrides.Overrides
+	overrides overrides.Interface
 
 	// Ring used for sharding compactions.
 	ringLifecycler *ring.BasicLifecycler
@@ -54,7 +54,7 @@ type Compactor struct {
 }
 
 // New makes a new Compactor.
-func New(cfg Config, store storage.Store, overrides *overrides.Overrides, reg prometheus.Registerer) (*Compactor, error) {
+func New(cfg Config, store storage.Store, overrides overrides.Interface, reg prometheus.Registerer) (*Compactor, error) {
 	c := &Compactor{
 		cfg:       &cfg,
 		store:     store,

--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -119,7 +119,7 @@ type Distributor struct {
 	ingestersRing   ring.ReadRing
 	pool            *ring_client.Pool
 	DistributorRing *ring.Ring
-	overrides       *overrides.Overrides
+	overrides       overrides.Interface
 	traceEncoder    model.SegmentDecoder
 
 	// metrics-generator
@@ -142,7 +142,7 @@ type Distributor struct {
 }
 
 // New a distributor creates.
-func New(cfg Config, clientCfg ingester_client.Config, ingestersRing ring.ReadRing, generatorClientCfg generator_client.Config, generatorsRing ring.ReadRing, o *overrides.Overrides, middleware receiver.Middleware, logger log.Logger, loggingLevel logging.Level, reg prometheus.Registerer) (*Distributor, error) {
+func New(cfg Config, clientCfg ingester_client.Config, ingestersRing ring.ReadRing, generatorClientCfg generator_client.Config, generatorsRing ring.ReadRing, o overrides.Interface, middleware receiver.Middleware, logger log.Logger, loggingLevel logging.Level, reg prometheus.Registerer) (*Distributor, error) {
 	factory := cfg.factory
 	if factory == nil {
 		factory = func(addr string) (ring_client.PoolClient, error) {

--- a/modules/distributor/forwarder.go
+++ b/modules/distributor/forwarder.go
@@ -54,12 +54,12 @@ type generatorForwarder struct {
 
 	forwardFunc forwardFunc
 
-	o                 *overrides.Overrides
+	o                 overrides.Interface
 	overridesInterval time.Duration
 	shutdown          chan interface{}
 }
 
-func newGeneratorForwarder(logger log.Logger, fn forwardFunc, o *overrides.Overrides) *generatorForwarder {
+func newGeneratorForwarder(logger log.Logger, fn forwardFunc, o overrides.Interface) *generatorForwarder {
 	rf := &generatorForwarder{
 		logger:            logger,
 		queues:            make(map[string]*queue.Queue[*request]),

--- a/modules/distributor/forwarder/manager.go
+++ b/modules/distributor/forwarder/manager.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/multierr"
 
 	"github.com/grafana/tempo/modules/distributor/queue"
+	"github.com/grafana/tempo/modules/overrides"
 )
 
 const (
@@ -21,9 +22,10 @@ const (
 )
 
 type Overrides interface {
-	TenantIDs() []string
 	Forwarders(tenantID string) []string
 }
+
+var _ Overrides = (overrides.Interface)(nil)
 
 type Manager struct {
 	services.Service

--- a/modules/distributor/ingestion_rate_strategy.go
+++ b/modules/distributor/ingestion_rate_strategy.go
@@ -2,6 +2,7 @@ package distributor
 
 import (
 	"github.com/grafana/dskit/limiter"
+
 	"github.com/grafana/tempo/modules/overrides"
 )
 
@@ -11,10 +12,10 @@ type ReadLifecycler interface {
 }
 
 type localStrategy struct {
-	limits *overrides.Overrides
+	limits overrides.Interface
 }
 
-func newLocalIngestionRateStrategy(limits *overrides.Overrides) limiter.RateLimiterStrategy {
+func newLocalIngestionRateStrategy(limits overrides.Interface) limiter.RateLimiterStrategy {
 	return &localStrategy{
 		limits: limits,
 	}
@@ -29,11 +30,11 @@ func (s *localStrategy) Burst(userID string) int {
 }
 
 type globalStrategy struct {
-	limits *overrides.Overrides
+	limits overrides.Interface
 	ring   ReadLifecycler
 }
 
-func newGlobalIngestionRateStrategy(limits *overrides.Overrides, ring ReadLifecycler) limiter.RateLimiterStrategy {
+func newGlobalIngestionRateStrategy(limits overrides.Interface, ring ReadLifecycler) limiter.RateLimiterStrategy {
 	return &globalStrategy{
 		limits: limits,
 		ring:   ring,

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -39,7 +39,7 @@ type QueryFrontend struct {
 }
 
 // New returns a new QueryFrontend
-func New(cfg Config, next http.RoundTripper, o *overrides.Overrides, reader tempodb.Reader, apiPrefix string, logger log.Logger, registerer prometheus.Registerer) (*QueryFrontend, error) {
+func New(cfg Config, next http.RoundTripper, o overrides.Interface, reader tempodb.Reader, apiPrefix string, logger log.Logger, registerer prometheus.Registerer) (*QueryFrontend, error) {
 	level.Info(logger).Log("msg", "creating middleware in query frontend")
 
 	if cfg.TraceByID.QueryShards < minQueryShards || cfg.TraceByID.QueryShards > maxQueryShards {
@@ -177,7 +177,7 @@ func newTraceByIDMiddleware(cfg Config, logger log.Logger) Middleware {
 }
 
 // newSearchMiddleware creates a new frontend middleware to handle search and search tags requests.
-func newSearchMiddleware(cfg Config, o *overrides.Overrides, reader tempodb.Reader, logger log.Logger) Middleware {
+func newSearchMiddleware(cfg Config, o overrides.Interface, reader tempodb.Reader, logger log.Logger) Middleware {
 	return MiddlewareFunc(func(next http.RoundTripper) http.RoundTripper {
 		ingesterSearchRT := next
 		backendSearchRT := NewRoundTripper(next, newSearchSharder(reader, o, cfg.Search.Sharder, cfg.Search.SLO, newSearchProgress, logger))

--- a/modules/frontend/search_streaming.go
+++ b/modules/frontend/search_streaming.go
@@ -13,12 +13,13 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/pkg/errors"
+	"go.uber.org/atomic"
+
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/tempodb"
-	"github.com/pkg/errors"
-	"go.uber.org/atomic"
 )
 
 // diffSearchProgress only returns new and updated traces when result() is called
@@ -92,7 +93,7 @@ func (p *diffSearchProgress) finalResult() *shardedSearchResults {
 }
 
 // newSearchStreamingHandler returns a handler that streams results from the HTTP handler
-func newSearchStreamingHandler(cfg Config, o *overrides.Overrides, downstream http.RoundTripper, reader tempodb.Reader, apiPrefix string, logger log.Logger) streamingSearchHandler {
+func newSearchStreamingHandler(cfg Config, o overrides.Interface, downstream http.RoundTripper, reader tempodb.Reader, apiPrefix string, logger log.Logger) streamingSearchHandler {
 	downstreamPath := path.Join(apiPrefix, api.PathSearch)
 	return func(req *tempopb.SearchRequest, srv tempopb.StreamingQuerier_SearchServer) error {
 		// build search request and propagate context

--- a/modules/generator/registry/overrides.go
+++ b/modules/generator/registry/overrides.go
@@ -12,4 +12,4 @@ type Overrides interface {
 	MetricsGeneratorDisableCollection(userID string) bool
 }
 
-var _ Overrides = (*overrides.Overrides)(nil)
+var _ Overrides = (overrides.Interface)(nil)

--- a/modules/ingester/ingester.go
+++ b/modules/ingester/ingester.go
@@ -70,7 +70,7 @@ type Ingester struct {
 }
 
 // New makes a new Ingester.
-func New(cfg Config, store storage.Store, limits *overrides.Overrides, reg prometheus.Registerer) (*Ingester, error) {
+func New(cfg Config, store storage.Store, limits overrides.Interface, reg prometheus.Registerer) (*Ingester, error) {
 	i := &Ingester{
 		cfg:          cfg,
 		instances:    map[string]*instance{},

--- a/modules/ingester/limiter.go
+++ b/modules/ingester/limiter.go
@@ -20,13 +20,13 @@ type RingCount interface {
 // Limiter implements primitives to get the maximum number of traces
 // an ingester can handle for a specific tenant
 type Limiter struct {
-	limits            *overrides.Overrides
+	limits            overrides.Interface
 	ring              RingCount
 	replicationFactor int
 }
 
 // NewLimiter makes a new limiter
-func NewLimiter(limits *overrides.Overrides, ring RingCount, replicationFactor int) *Limiter {
+func NewLimiter(limits overrides.Interface, ring RingCount, replicationFactor int) *Limiter {
 	return &Limiter{
 		limits:            limits,
 		ring:              ring,

--- a/modules/overrides/interface.go
+++ b/modules/overrides/interface.go
@@ -1,25 +1,49 @@
-package generator
+package overrides
 
 import (
+	"io"
+	"net/http"
 	"time"
 
-	"github.com/grafana/tempo/modules/generator/registry"
-	"github.com/grafana/tempo/modules/overrides"
+	"github.com/grafana/dskit/services"
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/grafana/tempo/pkg/sharedconfig"
-	filterconfig "github.com/grafana/tempo/pkg/spanfilter/config"
+	"github.com/grafana/tempo/pkg/spanfilter/config"
 )
 
-type metricsGeneratorOverrides interface {
-	registry.Overrides
+type Service interface {
+	services.Service
+	prometheus.Collector
+	Interface
 
+	WriteStatusRuntimeConfig(w io.Writer, r *http.Request) error
+}
+
+type Interface interface {
+	IngestionRateStrategy() string
+	MaxLocalTracesPerUser(userID string) int
+	MaxGlobalTracesPerUser(userID string) int
+	MaxBytesPerTrace(userID string) int
+	Forwarders(userID string) []string
+	MaxBytesPerTagValuesQuery(userID string) int
+	MaxBlocksPerTagValuesQuery(userID string) int
+	IngestionRateLimitBytes(userID string) float64
+	IngestionBurstSizeBytes(userID string) int
+	MetricsGeneratorRingSize(userID string) int
 	MetricsGeneratorProcessors(userID string) map[string]struct{}
+	MetricsGeneratorMaxActiveSeries(userID string) uint32
+	MetricsGeneratorCollectionInterval(userID string) time.Duration
+	MetricsGeneratorDisableCollection(userID string) bool
+	MetricsGeneratorForwarderQueueSize(userID string) int
+	MetricsGeneratorForwarderWorkers(userID string) int
 	MetricsGeneratorProcessorServiceGraphsHistogramBuckets(userID string) []float64
 	MetricsGeneratorProcessorServiceGraphsDimensions(userID string) []string
 	MetricsGeneratorProcessorServiceGraphsPeerAttributes(userID string) []string
 	MetricsGeneratorProcessorSpanMetricsHistogramBuckets(userID string) []float64
 	MetricsGeneratorProcessorSpanMetricsDimensions(userID string) []string
 	MetricsGeneratorProcessorSpanMetricsIntrinsicDimensions(userID string) map[string]bool
-	MetricsGeneratorProcessorSpanMetricsFilterPolicies(userID string) []filterconfig.FilterPolicy
+	MetricsGeneratorProcessorSpanMetricsFilterPolicies(userID string) []config.FilterPolicy
 	MetricsGeneratorProcessorLocalBlocksMaxLiveTraces(userID string) uint64
 	MetricsGeneratorProcessorLocalBlocksMaxBlockDuration(userID string) time.Duration
 	MetricsGeneratorProcessorLocalBlocksMaxBlockBytes(userID string) uint64
@@ -28,6 +52,6 @@ type metricsGeneratorOverrides interface {
 	MetricsGeneratorProcessorLocalBlocksCompleteBlockTimeout(userID string) time.Duration
 	MetricsGeneratorProcessorSpanMetricsDimensionMappings(userID string) []sharedconfig.DimensionMappings
 	MetricsGeneratorProcessorSpanMetricsEnableTargetInfo(userID string) bool
+	BlockRetention(userID string) time.Duration
+	MaxSearchDuration(userID string) time.Duration
 }
-
-var _ metricsGeneratorOverrides = (overrides.Interface)(nil)

--- a/modules/overrides/overrides.go
+++ b/modules/overrides/overrides.go
@@ -63,9 +63,9 @@ type Config struct {
 	PerTenantOverrides perTenantOverrides `yaml:",inline"`
 }
 
-// Overrides periodically fetch a set of per-user overrides, and provides convenience
+// overrides periodically fetch a set of per-user overrides, and provides convenience
 // functions for fetching the correct value.
-type Overrides struct {
+type overrides struct {
 	services.Service
 
 	defaultLimits    *Limits
@@ -80,7 +80,7 @@ type Overrides struct {
 // We store the supplied limits in a global variable to ensure per-tenant limits
 // are defaulted to those values.  As such, the last call to NewOverrides will
 // become the new global defaults.
-func NewOverrides(defaults Limits) (*Overrides, error) {
+func NewOverrides(defaults Limits) (Service, error) {
 	var manager *runtimeconfig.Manager
 	subservices := []services.Service(nil)
 
@@ -98,7 +98,7 @@ func NewOverrides(defaults Limits) (*Overrides, error) {
 		subservices = append(subservices, runtimeCfgMgr)
 	}
 
-	o := &Overrides{
+	o := &overrides{
 		runtimeConfigMgr: manager,
 		defaultLimits:    &defaults,
 	}
@@ -118,7 +118,7 @@ func NewOverrides(defaults Limits) (*Overrides, error) {
 	return o, nil
 }
 
-func (o *Overrides) starting(ctx context.Context) error {
+func (o *overrides) starting(ctx context.Context) error {
 	if o.subservices != nil {
 		err := services.StartManagerAndAwaitHealthy(ctx, o.subservices)
 		if err != nil {
@@ -129,7 +129,7 @@ func (o *Overrides) starting(ctx context.Context) error {
 	return nil
 }
 
-func (o *Overrides) running(ctx context.Context) error {
+func (o *overrides) running(ctx context.Context) error {
 	if o.subservices != nil {
 		select {
 		case <-ctx.Done():
@@ -142,14 +142,14 @@ func (o *Overrides) running(ctx context.Context) error {
 	return nil
 }
 
-func (o *Overrides) stopping(_ error) error {
+func (o *overrides) stopping(_ error) error {
 	if o.subservices != nil {
 		return services.StopManagerAndAwaitStopped(context.Background(), o.subservices)
 	}
 	return nil
 }
 
-func (o *Overrides) tenantOverrides() *perTenantOverrides {
+func (o *overrides) tenantOverrides() *perTenantOverrides {
 	if o.runtimeConfigMgr == nil {
 		return nil
 	}
@@ -161,7 +161,7 @@ func (o *Overrides) tenantOverrides() *perTenantOverrides {
 	return cfg
 }
 
-func (o *Overrides) WriteStatusRuntimeConfig(w io.Writer, r *http.Request) error {
+func (o *overrides) WriteStatusRuntimeConfig(w io.Writer, r *http.Request) error {
 	var tenantOverrides perTenantOverrides
 	if o.tenantOverrides() != nil {
 		tenantOverrides = *o.tenantOverrides()
@@ -216,7 +216,7 @@ func (o *Overrides) WriteStatusRuntimeConfig(w io.Writer, r *http.Request) error
 	return nil
 }
 
-func (o *Overrides) TenantIDs() []string {
+func (o *overrides) TenantIDs() []string {
 	tenantOverrides := o.tenantOverrides()
 	if tenantOverrides == nil {
 		return nil
@@ -232,7 +232,7 @@ func (o *Overrides) TenantIDs() []string {
 
 // IngestionRateStrategy returns whether the ingestion rate limit should be individually applied
 // to each distributor instance (local) or evenly shared across the cluster (global).
-func (o *Overrides) IngestionRateStrategy() string {
+func (o *overrides) IngestionRateStrategy() string {
 	// The ingestion rate strategy can't be overridden on a per-tenant basis,
 	// so here we just pick the value for a not-existing user ID (empty string).
 	return o.getOverridesForUser("").IngestionRateStrategy
@@ -240,170 +240,170 @@ func (o *Overrides) IngestionRateStrategy() string {
 
 // MaxLocalTracesPerUser returns the maximum number of traces a user is allowed to store
 // in a single ingester.
-func (o *Overrides) MaxLocalTracesPerUser(userID string) int {
+func (o *overrides) MaxLocalTracesPerUser(userID string) int {
 	return o.getOverridesForUser(userID).MaxLocalTracesPerUser
 }
 
 // MaxGlobalTracesPerUser returns the maximum number of traces a user is allowed to store
 // across the cluster.
-func (o *Overrides) MaxGlobalTracesPerUser(userID string) int {
+func (o *overrides) MaxGlobalTracesPerUser(userID string) int {
 	return o.getOverridesForUser(userID).MaxGlobalTracesPerUser
 }
 
 // MaxBytesPerTrace returns the maximum size of a single trace in bytes allowed for a user.
-func (o *Overrides) MaxBytesPerTrace(userID string) int {
+func (o *overrides) MaxBytesPerTrace(userID string) int {
 	return o.getOverridesForUser(userID).MaxBytesPerTrace
 }
 
 // Forwarders returns the list of forwarder IDs for a user.
-func (o *Overrides) Forwarders(userID string) []string {
+func (o *overrides) Forwarders(userID string) []string {
 	return o.getOverridesForUser(userID).Forwarders
 }
 
 // MaxBytesPerTagValuesQuery returns the maximum size of a response to a tag-values query allowed for a user.
-func (o *Overrides) MaxBytesPerTagValuesQuery(userID string) int {
+func (o *overrides) MaxBytesPerTagValuesQuery(userID string) int {
 	return o.getOverridesForUser(userID).MaxBytesPerTagValuesQuery
 }
 
 // MaxBlocksPerTagValuesQuery returns the maximum number of blocks to query for a tag-values query allowed for a user.
-func (o *Overrides) MaxBlocksPerTagValuesQuery(userID string) int {
+func (o *overrides) MaxBlocksPerTagValuesQuery(userID string) int {
 	return o.getOverridesForUser(userID).MaxBlocksPerTagValuesQuery
 }
 
 // IngestionRateLimitBytes is the number of spans per second allowed for this tenant.
-func (o *Overrides) IngestionRateLimitBytes(userID string) float64 {
+func (o *overrides) IngestionRateLimitBytes(userID string) float64 {
 	return float64(o.getOverridesForUser(userID).IngestionRateLimitBytes)
 }
 
 // IngestionBurstSizeBytes is the burst size in spans allowed for this tenant.
-func (o *Overrides) IngestionBurstSizeBytes(userID string) int {
+func (o *overrides) IngestionBurstSizeBytes(userID string) int {
 	return o.getOverridesForUser(userID).IngestionBurstSizeBytes
 }
 
 // MetricsGeneratorRingSize is the desired size of the metrics-generator ring for this tenant.
 // Using shuffle sharding, a tenant can use a smaller ring than the entire ring.
-func (o *Overrides) MetricsGeneratorRingSize(userID string) int {
+func (o *overrides) MetricsGeneratorRingSize(userID string) int {
 	return o.getOverridesForUser(userID).MetricsGeneratorRingSize
 }
 
 // MetricsGeneratorProcessors returns the metrics-generator processors enabled for this tenant.
-func (o *Overrides) MetricsGeneratorProcessors(userID string) map[string]struct{} {
+func (o *overrides) MetricsGeneratorProcessors(userID string) map[string]struct{} {
 	return o.getOverridesForUser(userID).MetricsGeneratorProcessors.GetMap()
 }
 
 // MetricsGeneratorMaxActiveSeries is the maximum amount of active series in the metrics-generator
 // registry for this tenant. Note this is a local limit enforced in every instance separately.
-func (o *Overrides) MetricsGeneratorMaxActiveSeries(userID string) uint32 {
+func (o *overrides) MetricsGeneratorMaxActiveSeries(userID string) uint32 {
 	return o.getOverridesForUser(userID).MetricsGeneratorMaxActiveSeries
 }
 
 // MetricsGeneratorCollectionInterval is the collection interval of the metrics-generator registry
 // for this tenant.
-func (o *Overrides) MetricsGeneratorCollectionInterval(userID string) time.Duration {
+func (o *overrides) MetricsGeneratorCollectionInterval(userID string) time.Duration {
 	return o.getOverridesForUser(userID).MetricsGeneratorCollectionInterval
 }
 
 // MetricsGeneratorDisableCollection controls whether metrics are remote written for this tenant.
-func (o *Overrides) MetricsGeneratorDisableCollection(userID string) bool {
+func (o *overrides) MetricsGeneratorDisableCollection(userID string) bool {
 	return o.getOverridesForUser(userID).MetricsGeneratorDisableCollection
 }
 
 // MetricsGeneratorForwarderQueueSize is the size of the buffer of requests to send to the metrics-generator
 // from the distributor for this tenant.
-func (o *Overrides) MetricsGeneratorForwarderQueueSize(userID string) int {
+func (o *overrides) MetricsGeneratorForwarderQueueSize(userID string) int {
 	return o.getOverridesForUser(userID).MetricsGeneratorForwarderQueueSize
 }
 
 // MetricsGeneratorForwarderWorkers is the number of workers to send metrics to the metrics-generator
-func (o *Overrides) MetricsGeneratorForwarderWorkers(userID string) int {
+func (o *overrides) MetricsGeneratorForwarderWorkers(userID string) int {
 	return o.getOverridesForUser(userID).MetricsGeneratorForwarderWorkers
 }
 
 // MetricsGeneratorProcessorServiceGraphsHistogramBuckets controls the histogram buckets to be used
 // by the service graphs processor.
-func (o *Overrides) MetricsGeneratorProcessorServiceGraphsHistogramBuckets(userID string) []float64 {
+func (o *overrides) MetricsGeneratorProcessorServiceGraphsHistogramBuckets(userID string) []float64 {
 	return o.getOverridesForUser(userID).MetricsGeneratorProcessorServiceGraphsHistogramBuckets
 }
 
 // MetricsGeneratorProcessorServiceGraphsDimensions controls the dimensions that are added to the
 // service graphs processor.
-func (o *Overrides) MetricsGeneratorProcessorServiceGraphsDimensions(userID string) []string {
+func (o *overrides) MetricsGeneratorProcessorServiceGraphsDimensions(userID string) []string {
 	return o.getOverridesForUser(userID).MetricsGeneratorProcessorServiceGraphsDimensions
 }
 
 // MetricsGeneratorProcessorServiceGraphsPeerAttributes controls the attributes that are used to build virtual nodes
-func (o *Overrides) MetricsGeneratorProcessorServiceGraphsPeerAttributes(userID string) []string {
+func (o *overrides) MetricsGeneratorProcessorServiceGraphsPeerAttributes(userID string) []string {
 	return o.getOverridesForUser(userID).MetricsGeneratorProcessorServiceGraphsPeerAttributes
 }
 
 // MetricsGeneratorProcessorSpanMetricsHistogramBuckets controls the histogram buckets to be used
 // by the span metrics processor.
-func (o *Overrides) MetricsGeneratorProcessorSpanMetricsHistogramBuckets(userID string) []float64 {
+func (o *overrides) MetricsGeneratorProcessorSpanMetricsHistogramBuckets(userID string) []float64 {
 	return o.getOverridesForUser(userID).MetricsGeneratorProcessorSpanMetricsHistogramBuckets
 }
 
 // MetricsGeneratorProcessorSpanMetricsDimensions controls the dimensions that are added to the
 // span metrics processor.
-func (o *Overrides) MetricsGeneratorProcessorSpanMetricsDimensions(userID string) []string {
+func (o *overrides) MetricsGeneratorProcessorSpanMetricsDimensions(userID string) []string {
 	return o.getOverridesForUser(userID).MetricsGeneratorProcessorSpanMetricsDimensions
 }
 
 // MetricsGeneratorProcessorSpanMetricsIntrinsicDimensions controls the intrinsic dimensions such as service, span_kind, or
 // span_name that are activated or deactivated on the span metrics processor.
-func (o *Overrides) MetricsGeneratorProcessorSpanMetricsIntrinsicDimensions(userID string) map[string]bool {
+func (o *overrides) MetricsGeneratorProcessorSpanMetricsIntrinsicDimensions(userID string) map[string]bool {
 	return o.getOverridesForUser(userID).MetricsGeneratorProcessorSpanMetricsIntrinsicDimensions
 }
 
 // MetricsGeneratorProcessorSpanMetricsFilterPolicies controls the filter policies that are added to the spanmetrics processor.
-func (o *Overrides) MetricsGeneratorProcessorSpanMetricsFilterPolicies(userID string) []filterconfig.FilterPolicy {
+func (o *overrides) MetricsGeneratorProcessorSpanMetricsFilterPolicies(userID string) []filterconfig.FilterPolicy {
 	return o.getOverridesForUser(userID).MetricsGeneratorProcessorSpanMetricsFilterPolicies
 }
 
-func (o *Overrides) MetricsGeneratorProcessorLocalBlocksMaxLiveTraces(userID string) uint64 {
+func (o *overrides) MetricsGeneratorProcessorLocalBlocksMaxLiveTraces(userID string) uint64 {
 	return o.getOverridesForUser(userID).MetricsGeneratorProcessorLocalBlocksMaxLiveTraces
 }
 
-func (o *Overrides) MetricsGeneratorProcessorLocalBlocksMaxBlockDuration(userID string) time.Duration {
+func (o *overrides) MetricsGeneratorProcessorLocalBlocksMaxBlockDuration(userID string) time.Duration {
 	return o.getOverridesForUser(userID).MetricsGeneratorProcessorLocalBlocksMaxBlockDuration
 }
 
-func (o *Overrides) MetricsGeneratorProcessorLocalBlocksMaxBlockBytes(userID string) uint64 {
+func (o *overrides) MetricsGeneratorProcessorLocalBlocksMaxBlockBytes(userID string) uint64 {
 	return o.getOverridesForUser(userID).MetricsGeneratorProcessorLocalBlocksMaxBlockBytes
 }
 
-func (o *Overrides) MetricsGeneratorProcessorLocalBlocksTraceIdlePeriod(userID string) time.Duration {
+func (o *overrides) MetricsGeneratorProcessorLocalBlocksTraceIdlePeriod(userID string) time.Duration {
 	return o.getOverridesForUser(userID).MetricsGeneratorProcessorLocalBlocksTraceIdlePeriod
 }
 
-func (o *Overrides) MetricsGeneratorProcessorLocalBlocksFlushCheckPeriod(userID string) time.Duration {
+func (o *overrides) MetricsGeneratorProcessorLocalBlocksFlushCheckPeriod(userID string) time.Duration {
 	return o.getOverridesForUser(userID).MetricsGeneratorProcessorLocalBlocksFlushCheckPeriod
 }
 
-func (o *Overrides) MetricsGeneratorProcessorLocalBlocksCompleteBlockTimeout(userID string) time.Duration {
+func (o *overrides) MetricsGeneratorProcessorLocalBlocksCompleteBlockTimeout(userID string) time.Duration {
 	return o.getOverridesForUser(userID).MetricsGeneratorProcessorLocalBlocksCompleteBlockTimeout
 }
 
 // MetricsGeneratorProcessorSpanMetricsDimensionMappings controls custom dimension mapping
-func (o *Overrides) MetricsGeneratorProcessorSpanMetricsDimensionMappings(userID string) []sharedconfig.DimensionMappings {
+func (o *overrides) MetricsGeneratorProcessorSpanMetricsDimensionMappings(userID string) []sharedconfig.DimensionMappings {
 	return o.getOverridesForUser(userID).MetricsGeneratorProcessorSpanMetricsDimensionMappings
 }
 
 // MetricsGeneratorProcessorSpanMetricsEnableTargetInfo enables target_info metrics
-func (o *Overrides) MetricsGeneratorProcessorSpanMetricsEnableTargetInfo(userID string) bool {
+func (o *overrides) MetricsGeneratorProcessorSpanMetricsEnableTargetInfo(userID string) bool {
 	return o.getOverridesForUser(userID).MetricsGeneratorProcessorSpanMetricsEnableTargetInfo
 }
 
 // BlockRetention is the duration of the block retention for this tenant.
-func (o *Overrides) BlockRetention(userID string) time.Duration {
+func (o *overrides) BlockRetention(userID string) time.Duration {
 	return time.Duration(o.getOverridesForUser(userID).BlockRetention)
 }
 
 // MaxSearchDuration is the duration of the max search duration for this tenant.
-func (o *Overrides) MaxSearchDuration(userID string) time.Duration {
+func (o *overrides) MaxSearchDuration(userID string) time.Duration {
 	return time.Duration(o.getOverridesForUser(userID).MaxSearchDuration)
 }
 
-func (o *Overrides) getOverridesForUser(userID string) *Limits {
+func (o *overrides) getOverridesForUser(userID string) *Limits {
 	if tenantOverrides := o.tenantOverrides(); tenantOverrides != nil {
 		l := tenantOverrides.forUser(userID)
 		if l != nil {
@@ -419,11 +419,11 @@ func (o *Overrides) getOverridesForUser(userID string) *Limits {
 	return o.defaultLimits
 }
 
-func (o *Overrides) Describe(ch chan<- *prometheus.Desc) {
+func (o *overrides) Describe(ch chan<- *prometheus.Desc) {
 	ch <- metricOverridesLimitsDesc
 }
 
-func (o *Overrides) Collect(ch chan<- prometheus.Metric) {
+func (o *overrides) Collect(ch chan<- prometheus.Metric) {
 	overrides := o.tenantOverrides()
 	if overrides == nil {
 		return

--- a/modules/overrides/overrides.go
+++ b/modules/overrides/overrides.go
@@ -216,20 +216,6 @@ func (o *overrides) WriteStatusRuntimeConfig(w io.Writer, r *http.Request) error
 	return nil
 }
 
-func (o *overrides) TenantIDs() []string {
-	tenantOverrides := o.tenantOverrides()
-	if tenantOverrides == nil {
-		return nil
-	}
-
-	result := make([]string, 0, len(tenantOverrides.TenantLimits))
-	for userID := range tenantOverrides.TenantLimits {
-		result = append(result, userID)
-	}
-
-	return result
-}
-
 // IngestionRateStrategy returns whether the ingestion rate limit should be individually applied
 // to each distributor instance (local) or evenly shared across the cluster (global).
 func (o *overrides) IngestionRateStrategy() string {

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -74,7 +74,7 @@ type Querier struct {
 	pool   *ring_client.Pool
 	engine *traceql.Engine
 	store  storage.Store
-	limits *overrides.Overrides
+	limits overrides.Interface
 
 	searchClient     *http.Client
 	searchPreferSelf *semaphore.Weighted
@@ -89,7 +89,7 @@ type responseFromIngesters struct {
 }
 
 // New makes a new Querier.
-func New(cfg Config, clientCfg ingester_client.Config, ring ring.ReadRing, store storage.Store, limits *overrides.Overrides) (*Querier, error) {
+func New(cfg Config, clientCfg ingester_client.Config, ring ring.ReadRing, store storage.Store, limits overrides.Interface) (*Querier, error) {
 	// TODO should we somehow refuse traceQL queries if backend encoding is not parquet?
 
 	factory := func(addr string) (ring_client.PoolClient, error) {


### PR DESCRIPTION
**What this PR does**:

A lot of modules in Tempo rely on the overrides package for runtime config, they directly use the `overrides.Overrides` struct. This makes the coupling very tight and limits modularity.

Changes:
- extract `overrides.Interface` from the methods of `overrides.Overrides`
- use this interface in as much places as possible
- export the Overrides module from `App`

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`