### PR TITLE
Regex tweak

### DIFF
--- a/pkg/parquetquery/predicates.go
+++ b/pkg/parquetquery/predicates.go
@@ -133,20 +133,23 @@ func (p *regexPredicate) keep(v *pq.Value) bool {
 		return false
 	}
 
-	s := v.String()
-	if matched, ok := p.matches[s]; ok {
+	// Check uses zero alloc optimization of map[string([]byte)]
+	b := v.ByteArray()
+	if matched, ok := p.matches[string(b)]; ok {
 		return matched
 	}
 
 	matched := false
 	for _, r := range p.regs {
-		if r.MatchString(s) == p.shouldMatch {
+		if r.Match(b) == p.shouldMatch {
 			matched = true
 			break
 		}
 	}
 
-	p.matches[s] = matched
+	// Only alloc the string when updating the map
+	p.matches[v.String()] = matched
+
 	return matched
 }
 

--- a/tempodb/encoding/vparquet2/block_traceql_test.go
+++ b/tempodb/encoding/vparquet2/block_traceql_test.go
@@ -456,6 +456,8 @@ func BenchmarkBackendBlockTraceQL(b *testing.B) {
 		{"spanAttValMatch", traceql.MustExtractFetchSpansRequest("{ span.bloom > 0 }")},
 		{"spanAttIntrinsicNoMatch", traceql.MustExtractFetchSpansRequest("{ name = `asdfasdf` }")},
 		{"spanAttIntrinsicMatch", traceql.MustExtractFetchSpansRequest("{ name = `gcs.ReadRange` }")},
+		{"spanAttIntrinsicRegexNoMatch", traceql.MustExtractFetchSpansRequest("{ name =~ `asdfasdf` }")},
+		{"spanAttIntrinsicRegexMatch", traceql.MustExtractFetchSpansRequest("{ name =~ `gcs.ReadRange` }")},
 
 		// resource
 		{"resourceAttNameNoMatch", traceql.MustExtractFetchSpansRequest("{ resource.foo = `bar` }")},
@@ -474,10 +476,10 @@ func BenchmarkBackendBlockTraceQL(b *testing.B) {
 
 	ctx := context.TODO()
 	tenantID := "1"
-	blockID := uuid.MustParse("149e41d2-cc4d-4f71-b355-3377eabc94c8")
+	blockID := uuid.MustParse("2968a567-5873-4e4c-b3cb-21c106c6714b")
 
 	r, _, _, err := local.New(&local.Config{
-		Path: path.Join("/home/joe/testblock/"),
+		Path: path.Join("/Users/marty/src/tmp/"),
 	})
 	require.NoError(b, err)
 


### PR DESCRIPTION
**What this PR does**:
Makes regex predicate faster.  Particularly the case where there are found matches because of all the map access.

Tweak originally discussed https://github.com/grafana/tempo/pull/2410#discussion_r1181532807

```
name                                                 old time/op    new time/op    delta
BackendBlockTraceQL/spanAttIntrinsicRegexNoMatch-12    2.51ms ± 2%    2.45ms ± 0%   -2.52%  (p=0.000 n=9+8)
BackendBlockTraceQL/spanAttIntrinsicRegexMatch-12      72.1ms ± 2%    49.5ms ± 2%  -31.36%  (p=0.000 n=9+10)

name                                                 old speed      new speed      delta
BackendBlockTraceQL/spanAttIntrinsicRegexNoMatch-12   385MB/s ± 2%   395MB/s ± 0%   +2.58%  (p=0.000 n=9+8)
BackendBlockTraceQL/spanAttIntrinsicRegexMatch-12     186MB/s ± 2%   271MB/s ± 2%  +45.69%  (p=0.000 n=9+10)

name                                                 old MB_io/op   new MB_io/op   delta
BackendBlockTraceQL/spanAttIntrinsicRegexNoMatch-12      0.97 ± 0%      0.97 ± 0%     ~     (all equal)
BackendBlockTraceQL/spanAttIntrinsicRegexMatch-12        13.4 ± 0%      13.4 ± 0%     ~     (all equal)

name                                                 old alloc/op   new alloc/op   delta
BackendBlockTraceQL/spanAttIntrinsicRegexNoMatch-12    1.10MB ± 4%    1.07MB ± 4%   -2.71%  (p=0.017 n=10+9)
BackendBlockTraceQL/spanAttIntrinsicRegexMatch-12      33.4MB ± 1%    12.5MB ± 0%  -62.73%  (p=0.000 n=10+7)

name                                                 old allocs/op  new allocs/op  delta
BackendBlockTraceQL/spanAttIntrinsicRegexNoMatch-12     12.9k ± 0%     12.8k ± 0%   -0.18%  (p=0.000 n=10+7)
BackendBlockTraceQL/spanAttIntrinsicRegexMatch-12        786k ± 0%       14k ± 0%  -98.22%  (p=0.000 n=10+10)
```

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`