### PR TITLE
Possibly reduce cost of tempodb tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ test-with-cover-pkg: tools
 # tests in tempodb (excluding tempodb/wal)
 .PHONY: test-with-cover-tempodb
 test-with-cover-tempodb: tools
-	$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) $(shell go list $(sort $(dir $(shell find . -name '*.go'  -not -path './tempodb/wal*/*' -path './tempodb*/*' -type f | sort))))
+	GOMEMLIMIT=6GiB $(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) $(shell go list $(sort $(dir $(shell find . -name '*.go'  -not -path './tempodb/wal*/*' -path './tempodb*/*' -type f | sort))))
 
 # tests in tempodb/wal
 .PHONY: test-with-cover-tempodb-wal


### PR DESCRIPTION
Previously we created 4 vParquet and 4 vParquet2 block. one for each of the different search tests and then ran the tests.

This PR flips things around and creates 1 vParquet and vParquet2 block and runs all 4 tests on each.