### PR TITLE
Run TestCountSpans with predictable batch and span size

### DIFF
--- a/tempodb/encoding/vparquet/compactor_test.go
+++ b/tempodb/encoding/vparquet/compactor_test.go
@@ -147,8 +147,8 @@ func TestValueAlloc(t *testing.T) {
 }
 
 func TestCountSpans(t *testing.T) {
-	batchSize := rand.Intn(1000) + 1
-	spansEach := rand.Intn(1000) + 1
+	batchSize := 300 + rand.Intn(25)
+	spansEach := 250 + rand.Intn(25)
 
 	sch := parquet.SchemaOf(new(Trace))
 	traceID := make([]byte, 16)

--- a/tempodb/encoding/vparquet/compactor_test.go
+++ b/tempodb/encoding/vparquet/compactor_test.go
@@ -147,6 +147,7 @@ func TestValueAlloc(t *testing.T) {
 }
 
 func TestCountSpans(t *testing.T) {
+	// It causes high mem usage when batchSize and spansEach are too big (> 500)
 	batchSize := 300 + rand.Intn(25)
 	spansEach := 250 + rand.Intn(25)
 

--- a/tempodb/encoding/vparquet2/compactor_test.go
+++ b/tempodb/encoding/vparquet2/compactor_test.go
@@ -147,8 +147,8 @@ func TestValueAlloc(t *testing.T) {
 }
 
 func TestCountSpans(t *testing.T) {
-	batchSize := rand.Intn(1000) + 1
-	spansEach := rand.Intn(1000) + 1
+	batchSize := 300 + rand.Intn(25)
+	spansEach := 250 + rand.Intn(25)
 
 	sch := parquet.SchemaOf(new(Trace))
 	traceID := make([]byte, 16)

--- a/tempodb/encoding/vparquet2/compactor_test.go
+++ b/tempodb/encoding/vparquet2/compactor_test.go
@@ -147,6 +147,7 @@ func TestValueAlloc(t *testing.T) {
 }
 
 func TestCountSpans(t *testing.T) {
+	// It causes high mem usage when batchSize and spansEach are too big (> 500)
 	batchSize := 300 + rand.Intn(25)
 	spansEach := 250 + rand.Intn(25)
 


### PR DESCRIPTION
**What this PR does**:

`TestCountSpans` randomly selects a batch and span size to run the tests with. When high numbers are chosen for both values, the tests will allocate > 10 GB memory. This PR makes the 
batch and span size more predictable in order to avoid excess memory allocation.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`