### PR TITLE
[DOC] [TraceQL] Remove early access message

### DIFF
--- a/docs/sources/tempo/traceql/architecture.md
+++ b/docs/sources/tempo/traceql/architecture.md
@@ -39,7 +39,3 @@ For more information about TraceQL’s design, refer to the [TraceQL Concepts de
 - Structural Queries
 - Metrics
 - Pipeline comparisons
-
-### Request access
-
-Once TraceQL is available in Grafana Cloud as an experimental feature, you can open a ticket with Grafana Support to request access.

--- a/docs/sources/tempo/traceql/query-editor.md
+++ b/docs/sources/tempo/traceql/query-editor.md
@@ -15,7 +15,9 @@ keywords:
 
 You can use the TraceQL viewer and query editor in the Tempo data source to build queries and drill-down into result sets. The editor is available in Grafana’s Explore interface.
 
->**NOTE**: To use the TraceQL query editor in Grafana, you need to enable the `traceqlEditor` feature flag. This feature is available starting in Grafana 9.3.2. The query editory is available automatically in Grafana Cloud. 
+{{% admonition type="note" %}}
+To use the TraceQL query editor in Grafana, you need to enable the `traceqlEditor` feature flag. This feature is available starting in Grafana 9.3.2. The query editory is available automatically in Grafana Cloud.
+{{% /admonition %}}
 
 ![Query editor showing request for http.method](/static/img/docs/tempo/query-editor-http-method.png)
 


### PR DESCRIPTION
**What this PR does**:
Removes the early access warning from the TraceQL architecture page. 

**Checklist**
- [X] Documentation added
