### PR TITLE
[servicegraph] Simplify default peer attributes

### DIFF
--- a/docs/sources/tempo/metrics-generator/service_graphs.md
+++ b/docs/sources/tempo/metrics-generator/service_graphs.md
@@ -52,7 +52,7 @@ Virtual nodes can be detected in two different ways:
 
 - The root span has `span.kind` set to `server`. This indicates that the request has initiated by an external system that's not instrumented, like a frontend application or an engineer via `curl`.
 - A `client` span does not have its matching `server` span, but has a peer attribute present. In this case, we make the assumption that a call was made to an external service, for which Tempo won't receive spans.
-   - The default peer attributes are `peer.service`, `net.peer.name`, `net.sock.peer.name`, `rpc.service.key`, `net.sock.peer.addr`, `http.url`, `http.target`.
+   - The default peer attributes are `peer.service`, `db.name` and `db.system`.
    - The order of the attributes is important, as the first one that is present will be used as the virtual node name.
 
 ### Metrics

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -53,7 +53,7 @@ const (
 )
 
 var defaultPeerAttributes = []attribute.Key{
-	semconv.PeerServiceKey, semconv.NetPeerNameKey, semconv.NetSockPeerNameKey, semconv.RPCServiceKey, semconv.NetSockPeerAddrKey, semconv.HTTPURLKey, semconv.HTTPTargetKey,
+	semconv.PeerServiceKey, semconv.DBNameKey, semconv.DBSystemKey,
 }
 
 type tooManySpansError struct {

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -182,8 +182,6 @@ func TestServiceGraphs_virtualNodes(t *testing.T) {
 		"connection_type": "virtual_node",
 	})
 
-	fmt.Println(testRegistry)
-
 	// counters
 	assert.Equal(t, 1.0, testRegistry.Query(`traces_service_graph_request_total`, userToServerLabels))
 	assert.Equal(t, 0.0, testRegistry.Query(`traces_service_graph_request_failed_total`, userToServerLabels))

--- a/modules/generator/processor/servicegraphs/testdata/trace-with-virtual-nodes.json
+++ b/modules/generator/processor/servicegraphs/testdata/trace-with-virtual-nodes.json
@@ -68,7 +68,7 @@
               "endTimeUnixNano": "1658320854878545408",
               "attributes": [
                 {
-                  "key": "net.peer.name",
+                  "key": "peer.service",
                   "value": {
                     "stringValue": "external-payments-platform"
                   }


### PR DESCRIPTION
**What this PR does**:

Simplify default peer attributes for virtual nodes.

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`