### PR TITLE
Add internal hook to disable the grpc over http behavior

### DIFF
--- a/cmd/tempo/app/config.go
+++ b/cmd/tempo/app/config.go
@@ -50,6 +50,11 @@ type Config struct {
 	LimitsConfig    overrides.Limits        `yaml:"overrides,omitempty"`
 	MemberlistKV    memberlist.KVConfig     `yaml:"memberlist,omitempty"`
 	UsageReport     usagestats.Config       `yaml:"usage_report,omitempty"`
+
+	// This is used by applications hosting Tempo to disable the default behavior
+	// of routing grpc over the main http server. Specifically this is for
+	// Grafana Enterprise Traces gateway module which does its own protocol muxing.
+	DoNotRouteHTTPToGRPC bool `yaml:"-"`
 }
 
 func newDefaultConfig() *Config {

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -78,9 +78,11 @@ func (t *App) initServer() (services.Service, error) {
 
 	DisableSignalHandling(&t.cfg.Server)
 
-	// this allows us to server http and grpc over the primary http server.
-	//  to use this register services with GRPCOnHTTPServer
-	t.cfg.Server.RouteHTTPToGRPC = true
+	if !t.cfg.DoNotRouteHTTPToGRPC {
+		// this allows us to serve http and grpc over the primary http server.
+		//  to use this register services with GRPCOnHTTPServer
+		t.cfg.Server.RouteHTTPToGRPC = true
+	}
 
 	server, err := server.New(t.cfg.Server)
 	if err != nil {


### PR DESCRIPTION
**What this PR does**:
Adds an internal config hook to disable the new grpc over http behavior.  It impacted the enterprise traces gateway module because it does its own protocol mux to handle grpc and http over the same port already, and is not straight-forward to make it work again when this behavior is enabled.    I don't consider this setting user-facing so it's not exposed in the yaml.

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`