### PR TITLE
SearchRecent ignore start and end parameters

### DIFF
--- a/pkg/api/http.go
+++ b/pkg/api/http.go
@@ -171,7 +171,7 @@ func ParseSearchRequest(r *http.Request) (*tempopb.SearchRequest, error) {
 		// As Grafana gets updated and/or versions using this get old we can remove this section.
 		for k, v := range r.URL.Query() {
 			// Skip reserved keywords
-			if k == urlParamQuery || k == urlParamTags || k == urlParamMinDuration || k == urlParamMaxDuration || k == urlParamLimit || k == urlParamSpansPerSpanSet {
+			if k == urlParamQuery || k == urlParamTags || k == urlParamMinDuration || k == urlParamMaxDuration || k == urlParamLimit || k == urlParamSpansPerSpanSet || k == urlParamStart || k == urlParamEnd {
 				continue
 			}
 

--- a/pkg/api/http_test.go
+++ b/pkg/api/http_test.go
@@ -37,6 +37,15 @@ func TestQuerierParseSearchRequest(t *testing.T) {
 			},
 		},
 		{
+			name:     "zero ranges",
+			urlQuery: "start=0&end=0",
+			expected: &tempopb.SearchRequest{
+				Tags:            map[string]string{},
+				Limit:           defaultLimit,
+				SpansPerSpanSet: defaultSpansPerSpanSet,
+			},
+		},
+		{
 			name:     "limit set",
 			urlQuery: "limit=10",
 			expected: &tempopb.SearchRequest{


### PR DESCRIPTION
**What this PR does**:
This PR fixes an issue introduced in https://github.com/grafana/tempo/pull/2468  where calling `/api/search` with no parameters would turn into an ingester search for the tags `start="0"` and `end="0"`  The root cause is the new [ingesterRequest function](https://github.com/grafana/tempo/pull/2468/files#diff-37a55d5d14039ce02a2185b21f3180c569bc546cfedbbe4bf8ede63408f68892R382).  Previously it always filled in the start/end request time range, but now it preserves the case where start/end=0, and they get interpreted as tag conditions.   This fix unfortunately prevents actually searching against the tags "start" and "end".  I'm not sure if that's why they were originally left out of the if statement, but since this is all very deprecated, I think this makes the most sense. 

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`