### PR TITLE
Make vParquet2 the default block format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [CHANGE] Make vParquet2 the default block format [#2526](https://github.com/grafana/tempo/pull/2526) (@stoewer)
 * [CHANGE] Disable tempo-query by default in Jsonnet libs. [#2462](https://github.com/grafana/tempo/pull/2462) (@electron0zero)
 * [ENHANCEMENT] Fill parent ID column and nested set columns [#2487](https://github.com/grafana/tempo/pull/2487) (@stoewer)
 * [ENHANCEMENT] log client ip to help identify which client is no org id [#2436](https://github.com/grafana/tempo/pull/2436)

--- a/cmd/tempo/app/config_test.go
+++ b/cmd/tempo/app/config_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/grafana/tempo/tempodb"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 	v2 "github.com/grafana/tempo/tempodb/encoding/v2"
-	"github.com/grafana/tempo/tempodb/encoding/vparquet"
+	"github.com/grafana/tempo/tempodb/encoding/vparquet2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -70,7 +70,7 @@ func TestConfig_CheckConfig(t *testing.T) {
 			name: "warnings for v2 settings when they drift from default",
 			config: func() *Config {
 				cfg := newDefaultConfig()
-				cfg.StorageConfig.Trace.Block.Version = vparquet.VersionString
+				cfg.StorageConfig.Trace.Block.Version = vparquet2.VersionString
 				cfg.StorageConfig.Trace.Block.IndexDownsampleBytes = 1
 				cfg.StorageConfig.Trace.Block.IndexPageSizeBytes = 1
 				cfg.Compactor.Compactor.ChunkSizeBytes = 1

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -1039,7 +1039,7 @@ storage:
         # block configuration
         block:
             # block format version. options: v2, vParquet, vParquet2
-            [version: <string> | default = vParquet]
+            [version: <string> | default = vParquet2]
 
             # bloom filter false positive rate.  lower values create larger filters but fewer false positives
             [bloom_filter_false_positive: <float> | default = 0.01]

--- a/docs/sources/tempo/configuration/parquet.md
+++ b/docs/sources/tempo/configuration/parquet.md
@@ -7,7 +7,7 @@ weight: 75
 # Apache Parquet block format
 
 
-Tempo has a default columnar block format based on Apache Parquet. Parquet is required for tags-based search as well as [TraceQL]({{< relref "../traceql" >}}), the query language for traces. The columnar block format results in improved search performance and also enables a large ecosystem of tools to access the underlying trace data.
+Tempo has a default columnar block format based on Apache Parquet. This format is required for tags-based search as well as [TraceQL]({{< relref "../traceql" >}}), the query language for traces. The columnar block format improves search performance and enables a large ecosystem of tools to access the underlying trace data.
 
 For more information, refer to the [Parquet schema]({{< relref "../operations/schema" >}}) and the [Parquet design document](https://github.com/mdisibio/tempo/blob/design-proposal-parquet/docs/design-proposals/2022-04%20Parquet.md).
 
@@ -21,7 +21,7 @@ Block formats based on Parquet require more CPU and memory resources than the pr
 
 ## Choose a different block format
 
-The default block format is `vParquet2` which is the latest iteration of Tempo's Parquet based block format. It is still possible to use the previous format `vParquet`. To enable it, set the block version option to `vParquet` in the Storage section of the configuration file.
+The default block format is `vParquet2` which is the latest iteration of Tempo's Parquet based columnar block format. It is still possible to use the previous format `vParquet`. To enable it, set the block version option to `vParquet` in the Storage section of the configuration file.
 
 ```yaml
 # block format version. options: v2, vParquet, vParquet2
@@ -35,7 +35,7 @@ It is possible to disable Parquet and use the previous `v2` block format. This d
 [version: v2]
 ```
 
-To re-enable the default Parquet format, remove block version option from the Storage section of the configuration file.
+To re-enable the default `vParquet2` format, remove the block version option from the Storage section of the configuration file or set the option to `vParquet2`.
 
 ## Parquet configuration parameters
 

--- a/docs/sources/tempo/configuration/parquet.md
+++ b/docs/sources/tempo/configuration/parquet.md
@@ -7,9 +7,7 @@ weight: 75
 # Apache Parquet block format
 
 
-Tempo has a default columnar block format based on Apache Parquet. Parquet is required for tags-based search as well as [TraceQL]({{< relref "../traceql" >}}), the query language for traces.
-
-A columnar block format may result in improved search performance and also enables a large ecosystem of tools access to the underlying trace data.
+Tempo has a default columnar block format based on Apache Parquet. Parquet is required for tags-based search as well as [TraceQL]({{< relref "../traceql" >}}), the query language for traces. The columnar block format results in improved search performance and also enables a large ecosystem of tools to access the underlying trace data.
 
 For more information, refer to the [Parquet schema]({{< relref "../operations/schema" >}}) and the [Parquet design document](https://github.com/mdisibio/tempo/blob/design-proposal-parquet/docs/design-proposals/2022-04%20Parquet.md).
 
@@ -23,6 +21,13 @@ Block formats based on Parquet require more CPU and memory resources than the pr
 
 ## Choose a different block format
 
+The default block format is `vParquet2` which is the latest iteration of Tempo's Parquet based block format. It is still possible to use the previous format `vParquet`. To enable it, set the block version option to `vParquet` in the Storage section of the configuration file.
+
+```yaml
+# block format version. options: v2, vParquet, vParquet2
+[version: vParquet]
+```
+
 It is possible to disable Parquet and use the previous `v2` block format. This disables all forms of search, but also reduces resource consumption, and may be desired for a high-throughput cluster that does not need these capabilities. Set the block version option to `v2` in the Storage section of the configuration file.
 
 ```yaml
@@ -30,19 +35,7 @@ It is possible to disable Parquet and use the previous `v2` block format. This d
 [version: v2]
 ```
 
-There is also a revised version of the Parquet base block format `vParquet2`. This version improves the interoperability with other tools based on Parquet. `vParquet2` is still experimental and not enabled by default yet. To enable it, set the block format version to `vParquet2` in the Storage section of the configuration file.
-
-```yaml
-# block format version. options: v2, vParquet, vParquet2
-[version: vParquet2]
-```
-
-To re-enable Parquet, set the block version option to `vParquet` in the Storage section of the configuration file.
-
-```yaml
-# block format version. options: v2, vParquet, vParquet2
-[version: vParquet]
-```
+To re-enable the default Parquet format, remove block version option from the Storage section of the configuration file.
 
 ## Parquet configuration parameters
 

--- a/docs/sources/tempo/operations/schema.md
+++ b/docs/sources/tempo/operations/schema.md
@@ -17,7 +17,7 @@ This document describes the schema used with the Parquet block format.
 
 There are two overall approaches to a columnar schema: fully nested or span-oriented.
 Span-oriented means a flattened schema where traces are destructured into rows of spans.
-A fully nested schema means the current trace structures such as Resource/InstrumentationLibrary/Spans/Events are preserved (nested data is natively supported in Parquet).
+A fully nested schema means the current trace structures such as Resource/Scope/Spans/Events are preserved (nested data is natively supported in Parquet).
 In both cases, individual leaf values such as span name and duration are individual columns.
 
 We chose the nested schema for several reasons:
@@ -47,8 +47,8 @@ The adopted Parquet schema is mostly a direct translation of OTLP but with some 
 
 The table below uses these abbreviations:
 
-- `rs` = resource spans
-- `ils` - InstrumentLibrarySpans
+- `rs` - resource spans
+- `ss` - scope spans
 
 | | | |
 |:----|:----|:----|
@@ -57,10 +57,10 @@ The table below uses these abbreviations:
 |TraceIDText|string|The trace ID in hexadecimal text form.|
 |StartTimeUnixNano|int64|Start time of the first span in the trace, in nanoseconds since unix epoch.|
 |EndTimeUnixNano|int64|End time of the last span in the trace, in nanoseconds since unix epoch.|
-|DurationNanos|int64|Total trace duration in nanoseconds, computed as difference between EndTimeUnixNano and StartTimeUnixNano.|
+|DurationNano|int64|Total trace duration in nanoseconds, computed as difference between EndTimeUnixNano and StartTimeUnixNano.|
 |RootServiceName|string|The resource-level `service.name` attribute (rs.Resource.ServiceName) from the root span of the trace if one exists, else null.|
-|RootSpanName|string|The name (rs.ils.Spans.Name) of the root span if one exists, else null.|
-|rs| |Short-hand for "ResourceSpans"|
+|RootSpanName|string|The name (rs.ss.Spans.Name) of the root span if one exists, else null.|
+|rs| |Short-hand for ResourceSpans|
 |rs.Resource.ServiceName|string|A dedicated column for the resource-level `service.name` attribute if present. https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/#service|
 |rs.Resource.Cluster|string|A dedicated column for the resource-level `cluster` attribute if present and of string type. Values of other types will be stored in the generic attribute columns.|
 |rs.Resource.Namespace|string|A dedicated column for the resource-level `namespace` attribute if present and of string type. Values of other types will be stored in the generic attribute columns.|
@@ -77,120 +77,152 @@ The table below uses these abbreviations:
 |rs.Resource.Attrs.ValueBool|bool|The attribute value if boolean type, else null.|
 |rs.Resource.Attrs.ValueArray|byte array|The attribute value if nested array type, else null. Protocol buffer encoded binary data.|
 |rs.Resource.Attrs.ValueKVList|byte array|The attribute value if nested key/value map type, else null. Protocol buffer encoded binary data.|
-|rs.ils| |Shorthand for "ResourceSpans.InstrumentationLibrarySpans"|
-|rs.ils.il| |Shorthand for ResourceSpans.InstrumentationLibrarySpans.InstrumentationLibrary|
-|rs.ils.il.Name|string|InstrumentationLibrary name if present, else empty string. https://opentelemetry.io/docs/reference/specification/glossary/#instrumentation-library|
-|rs.ils.il.Version|string|The InstrumentationLibrary version if present, else empty string. https://opentelemetry.io/docs/reference/specification/glossary/#instrumentation-library|
-|rs.ils.Spans.ID|byte array|Span unique ID|
-|rs.ils.Spans.Name|string|Span name|
-|rs.ils.Spans.ParentSpanID|byte array|The unique ID of the span's parent. For root spans without a parent this is null.|
-|rs.ils.Spans.StartUnixNanos|int64|Start time the span in nanoseconds since unix epoch.|
-|rs.ils.Spans.EndUnixNanos|int64|End time the span in nanoseconds since unix epoch.|
-|rs.ils.Spans.Kind|int|The span's kind. Defined values: 0. Unset; 1. Internal; 2. Server; 3. Client; 4. Producer; 5. Consumer; https://opentelemetry.io/docs/reference/specification/trace/api/#spankind|
-|rs.ils.Spans.StatusCode|int|The span status. Defined values: 0: Unset; 1: OK; 2: Error. https://opentelemetry.io/docs/reference/specification/trace/api/#set-status|
-|rs.ils.Spans.StatusMessage|string|Optional message to accompany Error status.|
-|rs.ils.Spans.HttpMethod|string|A dedicated column for the span-level `http.method` attribute if present and of string type, else null. Values of other types will be stored in the generic attribute columns. https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/http/#common-attributes|
-|rs.ils.Spans.HttpStatusCode|int|A dedicated column for the span-level `http.status_code` attribute if present and of integer type, else null. Values of other types will be stored in the generic attribute columns. https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/http/#common-attributes|
-|rs.ils.Spans.HttpUrl|string|A dedicated column for the span-level `http.url` attribute if present and of string type, else null. Values of other types will be stored in the generic attribute columns. https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/http/#http-client|
-|rs.ils.Spans.DroppedAttributesCount|int|Number of attributes that were dropped|
-|rs.ils.Spans.Attrs.Key|string|All span attributes that do not have a dedicated column are stored as a key value pair in these columns. The Key column stores the name, and then one of the Value columns is populated according to the attribute's data type. The other value columns will contain null.|
-|rs.ils.Spans.Attrs.Value|string|The attribute value if string type, else null.|
-|rs.ils.Spans.Attrs.ValueInt|int|The attribute value if integer type, else null.|
-|rs.ils.Spans.Attrs.ValueDouble|float|The attribute value if float type, else null.|
-|rs.ils.Spans.Attrs.ValueBool|bool|The attribute value if boolean type, else null.|
-|rs.ils.Spans.Attrs.ValueArray|byte array|The attribute value if nested array type, else null. Protocol buffer encoded binary data.|
-|rs.ils.Spans.Attrs.ValueKVList|byte array|The attribute value if nested key/value map type, else null. Protocol buffer encoded binary data.|
-|rs.ils.Spans.DroppedEventsCount|int|The number of events that were dropped|
-|rs.ils.Spans.Events.TimeUnixNano|int64|The timestamp of the event, as nanoseconds since unix epoch.|
-|rs.ils.Spans.Events.Name|string|The event name or message.|
-|rs.ils.Spans.Events.DroppedAttributesCount|int|The number of event attributes that were dropped.|
-|rs.ils.Spans.Events.Attrs.Key|string|All event attributes are stored as a key value pair in these columns. The Key column stores the name.|
-|rs.ils.Spans.Events.Attrs.Value|byte array|The attribute value, Protocol buffer encoded binary data.|
-|rs.ils.Spans.DroppedLinksCount|int|The number of links that were dropped.|
-|rs.ils.Spans.Links|byte array|Protocol-buffer encoded span links if present, else null.|
-|rs.ils.Spans.TraceState|string|The span's TraceState value if present, else empty string.https://opentelemetry.io/docs/reference/specification/trace/api/#tracestate|
+|rs.ss| |Shorthand for ResourceSpans.ScopeSpans|
+|rs.ss.Scope| |Shorthand for ResourceSpans.ScopeSpans.Scope|
+|rs.ss.Scope.Name|string|Scope name if present, else empty string. https://opentelemetry.io/docs/specs/otel/glossary/#instrumentation-scope|
+|rs.ss.Scope.Version|string|The Scope version if present, else empty string. https://opentelemetry.io/docs/specs/otel/glossary/#instrumentation-scope|
+|rs.ss.Spans.SpanID|byte array|Span unique ID.|
+|rs.ss.Spans.ParentSpanID|byte array|The unique ID of the span's parent. For root spans without a parent this is null.|
+|rs.ss.Spans.ParentID|int32|Trace local numeric parent ID.|
+|rs.ss.Spans.NestedSetLeft|int32|Left bound of the nested set model. Also used as a trace local numeric span ID.|
+|rs.ss.Spans.NestedSetRight|int32|Right bound of the nested set model.|
+|rs.ss.Spans.Name|string|Span name.|
+|rs.ss.Spans.StartTimeUnixNano|int64|Start time the span in nanoseconds since unix epoch.|
+|rs.ss.Spans.DurationNano|int64|Span duration in nanoseconds.|
+|rs.ss.Spans.Kind|int|The span's kind. Defined values: 0. Unset; 1. Internal; 2. Server; 3. Client; 4. Producer; 5. Consumer; https://opentelemetry.io/docs/reference/specification/trace/api/#spankind|
+|rs.ss.Spans.StatusCode|int|The span status. Defined values: 0: Unset; 1: OK; 2: Error. https://opentelemetry.io/docs/reference/specification/trace/api/#set-status|
+|rs.ss.Spans.StatusMessage|string|Optional message to accompany Error status.|
+|rs.ss.Spans.HttpMethod|string|A dedicated column for the span-level `http.method` attribute if present and of string type, else null. Values of other types will be stored in the generic attribute columns. https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/http/#common-attributes|
+|rs.ss.Spans.HttpStatusCode|int|A dedicated column for the span-level `http.status_code` attribute if present and of integer type, else null. Values of other types will be stored in the generic attribute columns. https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/http/#common-attributes|
+|rs.ss.Spans.HttpUrl|string|A dedicated column for the span-level `http.url` attribute if present and of string type, else null. Values of other types will be stored in the generic attribute columns. https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/http/#http-client|
+|rs.ss.Spans.DroppedAttributesCount|int|Number of attributes that were dropped|
+|rs.ss.Spans.Attrs.Key|string|All span attributes that do not have a dedicated column are stored as a key value pair in these columns. The Key column stores the name, and then one of the Value columns is populated according to the attribute's data type. The other value columns will contain null.|
+|rs.ss.Spans.Attrs.Value|string|The attribute value if string type, else null.|
+|rs.ss.Spans.Attrs.ValueInt|int|The attribute value if integer type, else null.|
+|rs.ss.Spans.Attrs.ValueDouble|float|The attribute value if float type, else null.|
+|rs.ss.Spans.Attrs.ValueBool|bool|The attribute value if boolean type, else null.|
+|rs.ss.Spans.Attrs.ValueArray|byte array|The attribute value if nested array type, else null. Protocol buffer encoded binary data.|
+|rs.ss.Spans.Attrs.ValueKVList|byte array|The attribute value if nested key/value map type, else null. Protocol buffer encoded binary data.|
+|rs.ss.Spans.DroppedEventsCount|int|The number of events that were dropped|
+|rs.ss.Spans.Events.TimeUnixNano|int64|The timestamp of the event, as nanoseconds since unix epoch.|
+|rs.ss.Spans.Events.Name|string|The event name or message.|
+|rs.ss.Spans.Events.DroppedAttributesCount|int|The number of event attributes that were dropped.|
+|rs.ss.Spans.Events.Attrs.Key|string|All event attributes are stored as a key value pair in these columns. The Key column stores the name.|
+|rs.ss.Spans.Events.Attrs.Value|byte array|The attribute value, Protocol buffer encoded binary data.|
+|rs.ss.Spans.DroppedLinksCount|int|The number of links that were dropped.|
+|rs.ss.Spans.Links|byte array|Protocol-buffer encoded span links if present, else null.|
+|rs.ss.Spans.TraceState|string|The span's TraceState value if present, else empty string.https://opentelemetry.io/docs/reference/specification/trace/api/#tracestate|
 
+To increase the readability table omits the groups `list.element` that are added for nested list types in Parquet.
 
 ### Block Schema display in Parquet Message format
 
-```yaml
+```
 message Trace {
   required binary TraceID;
-  required binary TraceIDText (STRING);
-  required int64 StartTimeUnixNano (INTEGER(64,false));
-  required int64 EndTimeUnixNano (INTEGER(64,false));
-  required int64 DurationNanos (INTEGER(64,false));
-  required binary RootServiceName (STRING);
-  required binary RootSpanName (STRING);
-
-  repeated group rs { // Resource spans
-    required group Resource {
-      repeated group Attrs {
-        required binary Key (STRING);
-        optional binary Value (STRING);
-        optional int64 ValueInt (INTEGER(64,true));
-        optional double ValueDouble;
-        optional boolean ValueBool;
-        optional binary ValueKVList (STRING);
-        optional binary ValueArray (STRING);
-      }
-
-      required binary ServiceName (STRING);
-      optional binary Cluster (STRING);
-      optional binary Namespace (STRING);
-      optional binary Pod (STRING);
-      optional binary Container (STRING);
-      optional binary K8sClusterName (STRING);
-      optional binary K8sNamespaceName (STRING);
-      optional binary K8sPodName (STRING);
-      optional binary K8sContainerName (STRING);
-      optional binary Test (STRING);
-    }
-    repeated group ils { // InstrumentationLibrarySpans
-      required group il { // InstrumentationLibrary
-        required binary Name (STRING);
-        required binary Version (STRING);
-      }
-      repeated group Spans {
-        required binary ID;
-        required binary Name (STRING);
-        required int64 Kind (INTEGER(64,true));
-        required binary ParentSpanID;
-        required binary TraceState (STRING);
-        required int64 StartUnixNanos (INTEGER(64,false));
-        required int64 EndUnixNanos (INTEGER(64,false));
-        required int64 StatusCode (INTEGER(64,true));
-        required binary StatusMessage (STRING);
-        repeated group Attrs {
-          required binary Key (STRING);
-          optional binary Value (STRING);
-          optional int64 ValueInt (INTEGER(64,true));
-          optional double ValueDouble;
-          optional boolean ValueBool;
-          optional binary ValueKVList (STRING);
-          optional binary ValueArray (STRING);
-        }
-        required int32 DroppedAttributesCount (INTEGER(32,true));
-        repeated group Events {
-          required int64 TimeUnixNano (INTEGER(64,false));
-          required binary Name (STRING);
-          repeated group Attrs {
-            required binary Key (STRING);
-            required binary Value;
+  required group rs (LIST) {
+    repeated group list {
+      required group element {
+        required group Resource {
+          required group Attrs (LIST) {
+            repeated group list {
+              required group element {
+                required binary Key (STRING);
+                optional binary Value (STRING);
+                optional int64 ValueInt (INTEGER(64,true));
+                optional double ValueDouble;
+                optional boolean ValueBool;
+                optional binary ValueKVList (STRING);
+                optional binary ValueArray (STRING);
+              }
+            }
           }
-          required int32 DroppedAttributesCount (INTEGER(32,true));
+          required binary ServiceName (STRING);
+          optional binary Cluster (STRING);
+          optional binary Namespace (STRING);
+          optional binary Pod (STRING);
+          optional binary Container (STRING);
+          optional binary K8sClusterName (STRING);
+          optional binary K8sNamespaceName (STRING);
+          optional binary K8sPodName (STRING);
+          optional binary K8sContainerName (STRING);
           optional binary Test (STRING);
         }
-        required int32 DroppedEventsCount (INTEGER(32,true));
-        required binary Links;
-        required int32 DroppedLinksCount (INTEGER(32,true));
-
-        optional binary HttpMethod (STRING);
-        optional binary HttpUrl (STRING);
-        optional int64 HttpStatusCode (INTEGER(64,true));
+        required group ss (LIST) {
+          repeated group list {
+            required group element {
+              required group Scope {
+                required binary Name (STRING);
+                required binary Version (STRING);
+              }
+              required group Spans (LIST) {
+                repeated group list {
+                  required group element {
+                    required binary SpanID;
+                    required binary ParentSpanID;
+                    required int32 ParentID (INTEGER(32,true));
+                    required int32 NestedSetLeft (INTEGER(32,true));
+                    required int32 NestedSetRight (INTEGER(32,true));
+                    required binary Name (STRING);
+                    required int64 Kind (INTEGER(64,true));
+                    required binary TraceState (STRING);
+                    required int64 StartTimeUnixNano (INTEGER(64,false));
+                    required int64 DurationNano (INTEGER(64,false));
+                    required int64 StatusCode (INTEGER(64,true));
+                    required binary StatusMessage (STRING);
+                    required group Attrs (LIST) {
+                      repeated group list {
+                        required group element {
+                          required binary Key (STRING);
+                          optional binary Value (STRING);
+                          optional int64 ValueInt (INTEGER(64,true));
+                          optional double ValueDouble;
+                          optional boolean ValueBool;
+                          optional binary ValueKVList (STRING);
+                          optional binary ValueArray (STRING);
+                        }
+                      }
+                    }
+                    required int32 DroppedAttributesCount (INTEGER(32,true));
+                    required group Events (LIST) {
+                      repeated group list {
+                        required group element {
+                          required int64 TimeUnixNano (INTEGER(64,false));
+                          required binary Name (STRING);
+                          required group Attrs (LIST) {
+                            repeated group list {
+                              required group element {
+                                required binary Key (STRING);
+                                required binary Value;
+                              }
+                            }
+                          }
+                          required int32 DroppedAttributesCount (INTEGER(32,true));
+                          optional binary Test (STRING);
+                        }
+                      }
+                    }
+                    required int32 DroppedEventsCount (INTEGER(32,true));
+                    required binary Links;
+                    required int32 DroppedLinksCount (INTEGER(32,true));
+                    optional binary HttpMethod (STRING);
+                    optional binary HttpUrl (STRING);
+                    optional int64 HttpStatusCode (INTEGER(64,true));
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
   }
+  required binary TraceIDText (STRING);
+  required int64 StartTimeUnixNano (INTEGER(64,false));
+  required int64 EndTimeUnixNano (INTEGER(64,false));
+  required int64 DurationNano (INTEGER(64,false));
+  required binary RootServiceName (STRING);
+  required binary RootSpanName (STRING);
 }
 ```
 ## Trace-level attributes

--- a/tempodb/encoding/versioned.go
+++ b/tempodb/encoding/versioned.go
@@ -70,7 +70,7 @@ func FromVersion(v string) (VersionedEncoding, error) {
 
 // DefaultEncoding for newly written blocks.
 func DefaultEncoding() VersionedEncoding {
-	return vparquet.Encoding{}
+	return vparquet2.Encoding{}
 }
 
 // AllEncodings returns all encodings


### PR DESCRIPTION
**What this PR does**:

The new block format `vParquet2` has been tested extensively over the past weeks. This PR makes it the new default. 

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`