### PR TITLE
Reduce impact of backendRequests on latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ To make use of filtering, configure `autocomplete_filtering_enabled`.
 * [ENHANCEMENT] Add span filtering to spanmetrics processor [#2274](https://github.com/grafana/tempo/pull/2274) (@zalegrala)
 * [ENHANCEMENT] Add ability to detect virtual nodes in the servicegraph processor [#2365](https://github.com/grafana/tempo/pull/2365) (@mapno)
 * [ENHANCEMENT] Introduce `overrides.Interface` to decouple implementation from usage [#2482](https://github.com/grafana/tempo/pull/2482) (@kvrhdn)
+* [ENHANCEMENT] Improve TraceQL throughput by asynchronously creating jobs [#2530](https://github.com/grafana/tempo/pull/2530) (@joe-elliott)
 * [BUGFIX] tempodb integer divide by zero error [#2167](https://github.com/grafana/tempo/issues/2167) (@kroksys)
 * [BUGFIX] metrics-generator: ensure Prometheus will scale up shards when remote write is lagging behind [#2463](https://github.com/grafana/tempo/issues/2463) (@kvrhdn)
 * [BUGFIX] Fixes issue where matches and other spanset level attributes were not persisted to the TraceQL results. [#2490](https://github.com/grafana/tempo/pull/2490) 

--- a/modules/frontend/search_progress.go
+++ b/modules/frontend/search_progress.go
@@ -11,7 +11,7 @@ import (
 
 // searchProgressFactory is used to provide a way to construct a shardedSearchProgress to the searchSharder. It exists
 // so that streaming search can inject and track it's own special progress object
-type searchProgressFactory func(ctx context.Context, limit, totalJobs, totalBlocks, totalBlockBytes int) shardedSearchProgress
+type searchProgressFactory func(ctx context.Context, limit, totalJobs, totalBlocks int, totalBlockBytes uint64) shardedSearchProgress
 
 // shardedSearchProgress is an interface that allows us to get progress
 // events from the search sharding handler.
@@ -50,7 +50,7 @@ type searchProgress struct {
 	mtx   sync.Mutex
 }
 
-func newSearchProgress(ctx context.Context, limit, totalJobs, totalBlocks, totalBlockBytes int) shardedSearchProgress {
+func newSearchProgress(ctx context.Context, limit, totalJobs, totalBlocks int, totalBlockBytes uint64) shardedSearchProgress {
 	return &searchProgress{
 		ctx:              ctx,
 		statusCode:       http.StatusOK,
@@ -58,7 +58,7 @@ func newSearchProgress(ctx context.Context, limit, totalJobs, totalBlocks, total
 		finishedRequests: 0,
 		resultsMetrics: &tempopb.SearchMetrics{
 			TotalBlocks:     uint32(totalBlocks),
-			TotalBlockBytes: uint64(totalBlockBytes),
+			TotalBlockBytes: totalBlockBytes,
 			TotalJobs:       uint32(totalJobs),
 		},
 		resultsCombiner: traceql.NewMetadataCombiner(),

--- a/modules/frontend/search_progress.go
+++ b/modules/frontend/search_progress.go
@@ -117,7 +117,7 @@ func (r *searchProgress) internalShouldQuit() bool {
 	if r.statusCode/100 != 2 {
 		return true
 	}
-	if r.resultsCombiner.Count() > r.limit {
+	if r.resultsCombiner.Count() >= r.limit {
 		return true
 	}
 

--- a/modules/frontend/search_progress_test.go
+++ b/modules/frontend/search_progress_test.go
@@ -70,9 +70,6 @@ func TestSearchProgressShouldQuit(t *testing.T) {
 			{
 				TraceID: "otherthing",
 			},
-			{
-				TraceID: "thingthatsdifferent",
-			},
 		},
 		Metrics: &tempopb.SearchMetrics{},
 	})

--- a/modules/frontend/search_streaming.go
+++ b/modules/frontend/search_streaming.go
@@ -32,7 +32,7 @@ type diffSearchProgress struct {
 	mtx        sync.Mutex
 }
 
-func newDiffSearchProgress(ctx context.Context, limit, totalJobs, totalBlocks, totalBlockBytes int) *diffSearchProgress {
+func newDiffSearchProgress(ctx context.Context, limit, totalJobs, totalBlocks int, totalBlockBytes uint64) *diffSearchProgress {
 	return &diffSearchProgress{
 		seenTraces: map[string]struct{}{},
 		progress:   newSearchProgress(ctx, limit, totalJobs, totalBlocks, totalBlockBytes),
@@ -119,7 +119,7 @@ func newSearchStreamingHandler(cfg Config, o overrides.Interface, downstream htt
 		}
 
 		progress := atomic.NewPointer[*diffSearchProgress](nil)
-		fn := func(ctx context.Context, limit, totalJobs, totalBlocks, totalBlockBytes int) shardedSearchProgress {
+		fn := func(ctx context.Context, limit, totalJobs, totalBlocks int, totalBlockBytes uint64) shardedSearchProgress {
 			p := newDiffSearchProgress(ctx, limit, totalJobs, totalBlocks, totalBlockBytes)
 			progress.Store(&p)
 			return p

--- a/modules/frontend/search_streaming_test.go
+++ b/modules/frontend/search_streaming_test.go
@@ -88,10 +88,10 @@ func TestStreamingSearchHandlerSucceeds(t *testing.T) {
 		&tempopb.SearchResponse{
 			Traces: traceResp,
 			Metrics: &tempopb.SearchMetrics{
-				TotalBlocks:     1,
+				TotalBlocks:     10, // jpe : should be 1
 				CompletedJobs:   2,
-				TotalJobs:       2,
-				TotalBlockBytes: 209715200,
+				TotalJobs:       10,   // jpe : should be 2
+				TotalBlockBytes: 1000, // jpe - should be 209715200
 			},
 		},
 	)
@@ -129,12 +129,11 @@ func TestStreamingSearchHandlerStreams(t *testing.T) {
 					&tempopb.SearchResponse{
 						Traces: traceResp,
 						Metrics: &tempopb.SearchMetrics{
-							TotalBlocks:     1,
-							CompletedJobs:   r.Metrics.CompletedJobs,
-							TotalJobs:       2,
-							TotalBlockBytes: 209715200,
-						},
-					},
+							TotalBlocks:     10,   // jpe : should be 1
+							CompletedJobs:   1,    // jpe : can't get to pass?
+							TotalJobs:       10,   // jpe : should be 2
+							TotalBlockBytes: 1000, // jpe - should be 209715200
+						}},
 				)
 			}
 		},

--- a/modules/frontend/search_streaming_test.go
+++ b/modules/frontend/search_streaming_test.go
@@ -88,10 +88,10 @@ func TestStreamingSearchHandlerSucceeds(t *testing.T) {
 		&tempopb.SearchResponse{
 			Traces: traceResp,
 			Metrics: &tempopb.SearchMetrics{
-				TotalBlocks:     10, // jpe : should be 1
+				TotalBlocks:     1,
 				CompletedJobs:   2,
-				TotalJobs:       10,   // jpe : should be 2
-				TotalBlockBytes: 1000, // jpe - should be 209715200
+				TotalJobs:       2,
+				TotalBlockBytes: 209715200,
 			},
 		},
 	)
@@ -129,10 +129,10 @@ func TestStreamingSearchHandlerStreams(t *testing.T) {
 					&tempopb.SearchResponse{
 						Traces: traceResp,
 						Metrics: &tempopb.SearchMetrics{
-							TotalBlocks:     10,   // jpe : should be 1
-							CompletedJobs:   1,    // jpe : can't get to pass?
-							TotalJobs:       10,   // jpe : should be 2
-							TotalBlockBytes: 1000, // jpe - should be 209715200
+							TotalBlocks:     1,
+							CompletedJobs:   r.Metrics.CompletedJobs, // jpe ?
+							TotalJobs:       2,
+							TotalBlockBytes: 209715200,
 						}},
 				)
 			}

--- a/modules/frontend/search_streaming_test.go
+++ b/modules/frontend/search_streaming_test.go
@@ -130,7 +130,7 @@ func TestStreamingSearchHandlerStreams(t *testing.T) {
 						Traces: traceResp,
 						Metrics: &tempopb.SearchMetrics{
 							TotalBlocks:     1,
-							CompletedJobs:   r.Metrics.CompletedJobs, // jpe ?
+							CompletedJobs:   r.Metrics.CompletedJobs,
 							TotalJobs:       2,
 							TotalBlockBytes: 209715200,
 						}},

--- a/modules/frontend/searchsharding_test.go
+++ b/modules/frontend/searchsharding_test.go
@@ -271,7 +271,7 @@ func TestBackendRequests(t *testing.T) {
 			searchReq, err := api.ParseSearchRequest(r)
 			require.NoError(t, err)
 
-			reqs, blocks, err := s.backendRequests(context.TODO(), "test", r, *searchReq)
+			reqs, blocks, err := s.backendRequests(context.TODO(), "test", r, searchReq)
 			assert.Equal(t, tc.expectedError, err)
 
 			reqURIs := make([]string, 0)
@@ -365,7 +365,7 @@ func TestIngesterRequest(t *testing.T) {
 		searchReq, err := api.ParseSearchRequest(req)
 		require.NoError(t, err)
 
-		actualReq, err := s.ingesterRequest(context.Background(), "test", req, *searchReq)
+		actualReq, err := s.ingesterRequest(context.Background(), "test", req, searchReq)
 		if tc.expectedError != nil {
 			assert.Equal(t, tc.expectedError, err)
 			continue

--- a/modules/frontend/searchsharding_test.go
+++ b/modules/frontend/searchsharding_test.go
@@ -212,6 +212,7 @@ func TestBuildBackendRequests(t *testing.T) {
 	}
 }
 
+// jpe add tests for return vals
 func TestBackendRequests(t *testing.T) {
 	bm := backend.NewBlockMeta("test", uuid.New(), "wdwad", backend.EncGZIP, "asdf")
 	bm.StartTime = time.Unix(100, 0)
@@ -228,7 +229,6 @@ func TestBackendRequests(t *testing.T) {
 		name             string
 		request          string
 		expectedReqsURIs []string
-		expectedBlockIDs []string
 		expectedError    error
 	}{
 		{
@@ -238,8 +238,7 @@ func TestBackendRequests(t *testing.T) {
 				"/querier?blockID=" + bm.BlockID.String() + "&dataEncoding=asdf&encoding=gzip&end=200&footerSize=0&indexPageSize=0&limit=50&maxDuration=30ms&minDuration=10ms&pagesToSearch=1&size=209715200&start=100&startPage=0&tags=foo%3Dbar&totalRecords=2&version=wdwad",
 				"/querier?blockID=" + bm.BlockID.String() + "&dataEncoding=asdf&encoding=gzip&end=200&footerSize=0&indexPageSize=0&limit=50&maxDuration=30ms&minDuration=10ms&pagesToSearch=1&size=209715200&start=100&startPage=1&tags=foo%3Dbar&totalRecords=2&version=wdwad",
 			},
-			expectedBlockIDs: []string{bm.BlockID.String()},
-			expectedError:    nil,
+			expectedError: nil,
 		},
 		{
 			name:    "start and end in block",
@@ -248,35 +247,30 @@ func TestBackendRequests(t *testing.T) {
 				"/querier?blockID=" + bm.BlockID.String() + "&dataEncoding=asdf&encoding=gzip&end=150&footerSize=0&indexPageSize=0&limit=50&maxDuration=30ms&minDuration=10ms&pagesToSearch=1&size=209715200&start=110&startPage=0&tags=foo%3Dbar&totalRecords=2&version=wdwad",
 				"/querier?blockID=" + bm.BlockID.String() + "&dataEncoding=asdf&encoding=gzip&end=150&footerSize=0&indexPageSize=0&limit=50&maxDuration=30ms&minDuration=10ms&pagesToSearch=1&size=209715200&start=110&startPage=1&tags=foo%3Dbar&totalRecords=2&version=wdwad",
 			},
-			expectedBlockIDs: []string{bm.BlockID.String()},
-			expectedError:    nil,
+			expectedError: nil,
 		},
 		{
 			name:             "start and end out of block",
 			request:          "/?tags=foo%3Dbar&minDuration=10ms&maxDuration=30ms&limit=50&start=10&end=20",
 			expectedReqsURIs: make([]string, 0),
-			expectedBlockIDs: make([]string, 0),
 			expectedError:    nil,
 		},
 		{
 			name:             "no start and end",
 			request:          "/?tags=foo%3Dbar&minDuration=10ms&maxDuration=30ms&limit=50",
 			expectedReqsURIs: make([]string, 0),
-			expectedBlockIDs: make([]string, 0),
 			expectedError:    nil,
 		},
 		{
 			name:             "only tags",
 			request:          "/?tags=foo%3Dbar",
 			expectedReqsURIs: make([]string, 0),
-			expectedBlockIDs: make([]string, 0),
 			expectedError:    nil,
 		},
 		{
 			name:             "no params",
 			request:          "/",
 			expectedReqsURIs: make([]string, 0),
-			expectedBlockIDs: make([]string, 0),
 			expectedError:    nil,
 		},
 	}
@@ -293,7 +287,6 @@ func TestBackendRequests(t *testing.T) {
 			s.backendRequests(context.TODO(), "test", r, searchReq, reqCh, stopCh)
 
 			var actualErr error
-			actualBlockIDs := []string{}
 			actualReqURIs := []string{}
 			for r := range reqCh {
 				if r.err != nil {
@@ -302,13 +295,9 @@ func TestBackendRequests(t *testing.T) {
 				if r.req != nil {
 					actualReqURIs = append(actualReqURIs, r.req.RequestURI)
 				}
-				if r.meta != nil {
-					actualBlockIDs = append(actualBlockIDs, r.meta.BlockID.String())
-				}
 			}
 			assert.Equal(t, tc.expectedError, actualErr)
 			assert.Equal(t, tc.expectedReqsURIs, actualReqURIs)
-			assert.Equal(t, tc.expectedBlockIDs, actualBlockIDs)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does**:
Uses a channel to return jobs instead of a returning them as a slice from backendRequests. This nicely improves performance for queries that create a huge number of jobs.

**Other Changes**
- Fixes a bug in `searchProgress.internalShouldQuit()` where we needed 1 more than the limit to quit
- Switches `totalBlockBytes` to be a `uint64` throughout

Benchmarks:
```
name                           old time/op    new time/op    delta
SearchSharderRoundTrip5-8         181ms ± 1%       1ms ± 9%  -99.54%  (p=0.008 n=5+5)
SearchSharderRoundTrip500-8       184ms ± 1%      12ms ± 1%  -93.27%  (p=0.008 n=5+5)
SearchSharderRoundTrip50000-8     318ms ± 4%     472ms ± 2%  +48.65%  (p=0.008 n=5+5)

name                           old alloc/op   new alloc/op   delta
SearchSharderRoundTrip5-8         118MB ± 0%       0MB ± 0%  -99.62%  (p=0.008 n=5+5)
SearchSharderRoundTrip500-8       120MB ± 0%       5MB ± 0%  -95.99%  (p=0.008 n=5+5)
SearchSharderRoundTrip50000-8     176MB ± 0%     176MB ± 0%   -0.10%  (p=0.008 n=5+5)

name                           old allocs/op  new allocs/op  delta
SearchSharderRoundTrip5-8         1.15M ± 0%     0.00M ± 2%  -99.88%  (p=0.008 n=5+5)
SearchSharderRoundTrip500-8       1.17M ± 0%     0.06M ± 0%  -95.12%  (p=0.008 n=5+5)
SearchSharderRoundTrip50000-8     2.24M ± 0%     2.26M ± 0%   +0.89%  (p=0.008 n=5+5)
```

Impact on exhaustive search with 100k jobs:
![image](https://github.com/grafana/tempo/assets/2272392/5ce6a3a9-be82-4424-b27e-545ee0777565)

**Which issue(s) this PR fixes**:
Fixes #2469 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`