### PR TITLE
Fix Counter Test

### DIFF
--- a/modules/generator/registry/counter_test.go
+++ b/modules/generator/registry/counter_test.go
@@ -40,13 +40,14 @@ func Test_counter(t *testing.T) {
 	assert.Equal(t, 3, seriesAdded)
 
 	collectionTimeMs = time.Now().UnixMilli()
+	offsetCollectionTimeMs = time.UnixMilli(collectionTimeMs).Add(insertOffsetDuration).UnixMilli()
 	expectedSamples = []sample{
 		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_counter", "label": "value-2"}, collectionTimeMs, 4),
 		newSample(map[string]string{"__name__": "my_counter", "label": "value-3"}, collectionTimeMs, 0),
 		newSample(map[string]string{"__name__": "my_counter", "label": "value-3"}, offsetCollectionTimeMs, 3),
 	}
-	// TODO: this test flakes here, need to find root cause and fix :)
+
 	collectMetricAndAssert(t, c, collectionTimeMs, nil, 3, expectedSamples, nil)
 }
 


### PR DESCRIPTION
**What this PR does**:
Fixes the commonly flaking test:

```
=== RUN   Test_counter
    counter_test.go:249: 
        	Error Trace:	/home/joe/dev/joe-elliott/tempo/modules/generator/registry/counter_test.go:249
        	            				/home/joe/dev/joe-elliott/tempo/modules/generator/registry/counter_test.go:53
        	Error:      	elements differ
        	            	
        	            	extra elements in list A:
        	            	([]interface {}) (len=1) {
        	            	 (registry.sample) {
        	            	  l: (labels.Labels) (len=2) {
...
```

The test recalculated `collectionTimeMs`, but failed to recalculate `offsetCollectionTimeMs` based on the new value. If the current ms happened to tick over between lines 27 and 42 the test would fail.

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`