### PR TITLE
Continue polling remaining tenants on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [CHANGE] Prefix service graph extra dimensions labels with `server_` and `client_` if `enable_client_server_prefix` is enabled [#2335](https://github.com/grafana/tempo/pull/2335) (@domasx2)
 * [ENHANCEMENT] log client ip to help identify which client is no org id [#2436](https://github.com/grafana/tempo/pull/2436)
 * [ENHANCEMENT] Add `spss` parameter to `/api/search/tags`[#2308] to configure the spans per span set in response
+* [ENHANCEMENT] Continue polling tenants on error with configurable threshold [#2540](https://github.com/grafana/tempo/pull/2540) (@mdisibio)
 * [BUGFIX] Fix Search SLO by routing tags to a new handler. [#2468](https://github.com/grafana/tempo/issues/2468) (@electron0zero)
 * [CHANGE] Change log level of two compactor messages from `debug` to `info`. [#2443](https://github.com/grafana/tempo/pull/2443) (@dylanguedes)
 * [CHANGE] Remove `tenant_header_key` option from `tempo-query` config [#2414](https://github.com/grafana/tempo/pull/2414) (@kousikmitra)

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -841,6 +841,12 @@ storage:
         # Default 0 (disabled)
         [blocklist_poll_jitter_ms: <int>]
 
+        # Polling will tolerate this many consecutive errors before failing and exiting early for the
+        # current repoll. Can be set to 0 which means a single error is sufficient to fail and exit early
+        # (matches the original polling behavior).
+        # Default 1
+        [blocklist_poll_tolerate_consecutive_errors: <int>]
+
         # Cache type to use. Should be one of "redis", "memcached"
         # Example: "cache: memcached"
         [cache: <string>]

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -563,6 +563,7 @@ storage:
         blocklist_poll_tenant_index_builders: 2
         blocklist_poll_stale_tenant_index: 0s
         blocklist_poll_jitter_ms: 0
+        blocklist_poll_tolerate_consecutive_errors: 1
         backend: local
         local:
             path: /tmp/tempo/traces

--- a/modules/storage/config.go
+++ b/modules/storage/config.go
@@ -29,6 +29,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.Trace.BlocklistPollFallback = true
 	cfg.Trace.BlocklistPollConcurrency = tempodb.DefaultBlocklistPollConcurrency
 	cfg.Trace.BlocklistPollTenantIndexBuilders = tempodb.DefaultTenantIndexBuilders
+	cfg.Trace.BlocklistPollTolerateConsecutiveErrors = tempodb.DefaultTolerateConsecutiveErrors
 
 	f.StringVar(&cfg.Trace.Backend, util.PrefixConfig(prefix, "trace.backend"), "", "Trace backend (s3, azure, gcs, local)")
 	f.DurationVar(&cfg.Trace.BlocklistPoll, util.PrefixConfig(prefix, "trace.blocklist_poll"), tempodb.DefaultBlocklistPoll, "Period at which to run the maintenance cycle.")

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -20,9 +20,8 @@ import (
 )
 
 const (
-	blockStatusLiveLabel       = "live"
-	blockStatusCompactedLabel  = "compacted"
-	defaultTolerablePollErrors = 10
+	blockStatusLiveLabel      = "live"
+	blockStatusCompactedLabel = "compacted"
 )
 
 var (
@@ -71,11 +70,12 @@ var (
 
 // Config is used to configure the poller
 type PollerConfig struct {
-	PollConcurrency     uint
-	PollFallback        bool
-	TenantIndexBuilders int
-	StaleTenantIndex    time.Duration
-	PollJitterMs        int
+	PollConcurrency           uint
+	PollFallback              bool
+	TenantIndexBuilders       int
+	StaleTenantIndex          time.Duration
+	PollJitterMs              int
+	TolerateConsecutiveErrors int
 }
 
 // JobSharder is used to determine if a particular job is owned by this process
@@ -139,23 +139,21 @@ func (p *Poller) Do() (PerTenant, PerTenantCompacted, error) {
 	blocklist := PerTenant{}
 	compactedBlocklist := PerTenantCompacted{}
 
-	errCount := 0
-	maxErrors := defaultTolerablePollErrors
-	if maxErrors > len(tenants) {
-		maxErrors = len(tenants)
-	}
+	consecutiveErrors := 0
 
 	for _, tenantID := range tenants {
 		newBlockList, newCompactedBlockList, err := p.pollTenantAndCreateIndex(ctx, tenantID)
 		if err != nil {
 			level.Error(p.logger).Log("msg", "failed to poll or create index for tenant", "tenant", tenantID, "err", err)
-			errCount++
-			if errCount >= maxErrors {
-				level.Error(p.logger).Log("msg", "exiting poll loop early because too many errors", "errCount", errCount)
+			consecutiveErrors++
+			if consecutiveErrors > p.cfg.TolerateConsecutiveErrors {
+				level.Error(p.logger).Log("msg", "exiting polling loop early because too many errors", "errCount", consecutiveErrors)
 				return nil, nil, err
 			}
+			continue
 		}
 
+		consecutiveErrors = 0
 		metricBlocklistLength.WithLabelValues(tenantID).Set(float64(len(newBlockList)))
 
 		blocklist[tenantID] = newBlockList

--- a/tempodb/config.go
+++ b/tempodb/config.go
@@ -20,11 +20,12 @@ import (
 )
 
 const (
-	DefaultBlocklistPoll            = 5 * time.Minute
-	DefaultMaxTimePerTenant         = 5 * time.Minute
-	DefaultBlocklistPollConcurrency = uint(50)
-	DefaultRetentionConcurrency     = uint(10)
-	DefaultTenantIndexBuilders      = 2
+	DefaultBlocklistPoll             = 5 * time.Minute
+	DefaultMaxTimePerTenant          = 5 * time.Minute
+	DefaultBlocklistPollConcurrency  = uint(50)
+	DefaultRetentionConcurrency      = uint(10)
+	DefaultTenantIndexBuilders       = 2
+	DefaultTolerateConsecutiveErrors = 1
 
 	DefaultPrefetchTraceCount   = 1000
 	DefaultSearchChunkSizeBytes = 1_000_000
@@ -40,12 +41,13 @@ type Config struct {
 	Block  *common.BlockConfig `yaml:"block"`
 	Search *SearchConfig       `yaml:"search"`
 
-	BlocklistPoll                    time.Duration `yaml:"blocklist_poll"`
-	BlocklistPollConcurrency         uint          `yaml:"blocklist_poll_concurrency"`
-	BlocklistPollFallback            bool          `yaml:"blocklist_poll_fallback"`
-	BlocklistPollTenantIndexBuilders int           `yaml:"blocklist_poll_tenant_index_builders"`
-	BlocklistPollStaleTenantIndex    time.Duration `yaml:"blocklist_poll_stale_tenant_index"`
-	BlocklistPollJitterMs            int           `yaml:"blocklist_poll_jitter_ms"`
+	BlocklistPoll                          time.Duration `yaml:"blocklist_poll"`
+	BlocklistPollConcurrency               uint          `yaml:"blocklist_poll_concurrency"`
+	BlocklistPollFallback                  bool          `yaml:"blocklist_poll_fallback"`
+	BlocklistPollTenantIndexBuilders       int           `yaml:"blocklist_poll_tenant_index_builders"`
+	BlocklistPollStaleTenantIndex          time.Duration `yaml:"blocklist_poll_stale_tenant_index"`
+	BlocklistPollJitterMs                  int           `yaml:"blocklist_poll_jitter_ms"`
+	BlocklistPollTolerateConsecutiveErrors int           `yaml:"blocklist_poll_tolerate_consecutive_errors"`
 
 	// backends
 	Backend string        `yaml:"backend"`

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -429,11 +429,12 @@ func (rw *readerWriter) EnablePolling(sharder blocklist.JobSharder) {
 	level.Info(rw.logger).Log("msg", "polling enabled", "interval", rw.cfg.BlocklistPoll, "concurrency", rw.cfg.BlocklistPollConcurrency)
 
 	blocklistPoller := blocklist.NewPoller(&blocklist.PollerConfig{
-		PollConcurrency:     rw.cfg.BlocklistPollConcurrency,
-		PollFallback:        rw.cfg.BlocklistPollFallback,
-		TenantIndexBuilders: rw.cfg.BlocklistPollTenantIndexBuilders,
-		StaleTenantIndex:    rw.cfg.BlocklistPollStaleTenantIndex,
-		PollJitterMs:        rw.cfg.BlocklistPollJitterMs,
+		PollConcurrency:           rw.cfg.BlocklistPollConcurrency,
+		PollFallback:              rw.cfg.BlocklistPollFallback,
+		TenantIndexBuilders:       rw.cfg.BlocklistPollTenantIndexBuilders,
+		StaleTenantIndex:          rw.cfg.BlocklistPollStaleTenantIndex,
+		PollJitterMs:              rw.cfg.BlocklistPollJitterMs,
+		TolerateConsecutiveErrors: rw.cfg.BlocklistPollTolerateConsecutiveErrors,
 	}, sharder, rw.r, rw.c, rw.w, rw.logger)
 
 	rw.blocklistPoller = blocklistPoller


### PR DESCRIPTION
**What this PR does**:
Currently, if flakey errors occur during polling, the entire loop exits early and doesn't restart until the next timer. This can effectively starve some tenants and cause their indexes to fall out of date both due to failure to be written and failure to be read.  This PR changes the high-level error handling to be a circuit-breaker style where it will keep going until a configurable amount of consecutive errors happen.  The idea is that flakey errors will not halt polling, but consistent errors due to misconfiguration, auth, or networking will, so that we don't keep hammering the backend.   By default it's set to tolerate 1 error only, meaning it will fail if there are 2 consecutive errors.  It can also be set to 0 to revert to the prior behavior where every error is honored.

Marked as draft because I want to get feedback on this approach or see if we want to do a different approach.  Because polling iterates tenants in order, tenants that are alphanumerically last are impacted the most.  An alternative fix would be to iterate tenants randomly or keep order across loops like compactors do. But I think the approach in this PR is more robust.

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`