### PR TITLE
[tempo-mixin] add new alert to identify block list growth

### DIFF
--- a/operations/tempo-mixin-compiled/alerts.yaml
+++ b/operations/tempo-mixin-compiled/alerts.yaml
@@ -96,6 +96,15 @@
     "for": "5m"
     "labels":
       "severity": "critical"
+  - "alert": "TempoBlockListRisingQuickly"
+    "annotations":
+      "message": "Tempo block list length is up 40 percent over the last 7 days.  Consider scaling compactors."
+      "runbook_url": "https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoBlockListRisingQuickly"
+    "expr": |
+      avg(tempodb_blocklist_length{namespace=".*"}) / avg(tempodb_blocklist_length{namespace=".*", job=~"$namespace/$component"} offset 7d) > 1.4
+    "for": "15m"
+    "labels":
+      "severity": "critical"
   - "alert": "TempoBadOverrides"
     "annotations":
       "message": "{{ $labels.job }} failed to reload overrides."

--- a/operations/tempo-mixin/alerts.libsonnet
+++ b/operations/tempo-mixin/alerts.libsonnet
@@ -153,6 +153,20 @@
             },
           },
           {
+            alert: 'TempoBlockListRisingQuickly',
+            expr: |||
+              avg(tempodb_blocklist_length{namespace="%(namespace)s"}) / avg(tempodb_blocklist_length{namespace="%(namespace)s", job=~"$namespace/$component"} offset 7d) > 1.4
+            ||| % { namespace: $._config.namespace },
+            'for': '15m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              message: 'Tempo block list length is up 40 percent over the last 7 days.  Consider scaling compactors.',
+              runbook_url: 'https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoBlockListRisingQuickly',
+            },
+          },
+          {
             alert: 'TempoBadOverrides',
             expr: |||
               sum(tempo_runtime_config_last_reload_successful{namespace=~"%s"} == 0) by (%s)

--- a/operations/tempo-mixin/runbook.md
+++ b/operations/tempo-mixin/runbook.md
@@ -230,6 +230,11 @@ to pull is to simply delete stale tenant indexes as all components will fallback
 /<tenant>/index.json.gz
 ```
 
+## TempoBlockListRisingQuickly
+
+The block list needs to remain under control to keep query performance acceptable.  If the block list is rising too quickly, this might indicate the compactors are under scaled.  Add more compactors until the block list is back under control and holding mostly steady.
+
+
 ### TempoBadOverrides
 
 Fix the overrides!  Overrides are loaded by the distributors so hopefully there is


### PR DESCRIPTION
**What this PR does**:

Here we include a new mixin alert to notify when the block list growth is over 40% over the last 7 days.  This may indicates an under-scaled compactor deployment.


**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`