### PR TITLE
[vParquet3] Write path

### DIFF
--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -192,6 +192,7 @@ func (t *App) initDistributor() (services.Service, error) {
 func (t *App) initIngester() (services.Service, error) {
 	t.cfg.Ingester.LifecyclerConfig.ListenPort = t.cfg.Server.GRPCListenPort
 	t.cfg.Ingester.AutocompleteFilteringEnabled = t.cfg.AutocompleteFilteringEnabled
+	t.cfg.Ingester.DedicatedColumns = t.cfg.StorageConfig.Trace.Block.DedicatedColumns
 	ingester, err := ingester.New(t.cfg.Ingester, t.store, t.Overrides, prometheus.DefaultRegisterer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ingester: %w", err)

--- a/modules/ingester/config.go
+++ b/modules/ingester/config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/grafana/tempo/pkg/util/log"
 	"github.com/grafana/tempo/tempodb"
+	"github.com/grafana/tempo/tempodb/backend"
 )
 
 // Config for an ingester.
@@ -27,7 +28,8 @@ type Config struct {
 	OverrideRingKey      string        `yaml:"override_ring_key"`
 	FlushAllOnShutdown   bool          `yaml:"flush_all_on_shutdown"`
 
-	AutocompleteFilteringEnabled bool `yaml:"-"`
+	DedicatedColumns             []backend.DedicatedColumn `yaml:"-"`
+	AutocompleteFilteringEnabled bool                      `yaml:"-"`
 }
 
 // RegisterFlagsAndApplyDefaults registers the flags.

--- a/modules/ingester/ingester.go
+++ b/modules/ingester/ingester.go
@@ -303,7 +303,7 @@ func (i *Ingester) getOrCreateInstance(instanceID string) (*instance, error) {
 	inst, ok = i.instances[instanceID]
 	if !ok {
 		var err error
-		inst, err = newInstance(instanceID, i.limiter, i.overrides, i.store, i.local, i.cfg.AutocompleteFilteringEnabled)
+		inst, err = newInstance(instanceID, i.limiter, i.overrides, i.store, i.local, i.cfg.AutocompleteFilteringEnabled, i.cfg.DedicatedColumns)
 		if err != nil {
 			return nil, err
 		}

--- a/modules/ingester/ingester.go
+++ b/modules/ingester/ingester.go
@@ -66,17 +66,20 @@ type Ingester struct {
 
 	limiter *Limiter
 
+	overrides ingesterOverrides
+
 	subservicesWatcher *services.FailureWatcher
 }
 
 // New makes a new Ingester.
-func New(cfg Config, store storage.Store, limits overrides.Interface, reg prometheus.Registerer) (*Ingester, error) {
+func New(cfg Config, store storage.Store, overrides overrides.Interface, reg prometheus.Registerer) (*Ingester, error) {
 	i := &Ingester{
 		cfg:          cfg,
 		instances:    map[string]*instance{},
 		store:        store,
 		flushQueues:  flushqueues.New(cfg.ConcurrentFlushes, metricFlushQueueLength),
 		replayJitter: true,
+		overrides:    overrides,
 	}
 
 	i.local = store.WAL().LocalBackend()
@@ -89,7 +92,7 @@ func New(cfg Config, store storage.Store, limits overrides.Interface, reg promet
 
 	// Now that the lifecycler has been created, we can create the limiter
 	// which depends on it.
-	i.limiter = NewLimiter(limits, i.lifecycler, cfg.LifecyclerConfig.RingConfig.ReplicationFactor)
+	i.limiter = NewLimiter(overrides, i.lifecycler, cfg.LifecyclerConfig.RingConfig.ReplicationFactor)
 
 	i.subservicesWatcher = services.NewFailureWatcher()
 	i.subservicesWatcher.WatchService(i.lifecycler)
@@ -300,7 +303,7 @@ func (i *Ingester) getOrCreateInstance(instanceID string) (*instance, error) {
 	inst, ok = i.instances[instanceID]
 	if !ok {
 		var err error
-		inst, err = newInstance(instanceID, i.limiter, i.store, i.local, i.cfg.AutocompleteFilteringEnabled)
+		inst, err = newInstance(instanceID, i.limiter, i.overrides, i.store, i.local, i.cfg.AutocompleteFilteringEnabled)
 		if err != nil {
 			return nil, err
 		}

--- a/modules/ingester/ingester_test.go
+++ b/modules/ingester/ingester_test.go
@@ -344,7 +344,7 @@ func TestFlush(t *testing.T) {
 func TestDedicatedColumns(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("/tmp", "")
 	require.NoError(t, err, "unexpected error getting tempdir")
-	defer os.RemoveAll(tmpDir)
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
 
 	limits := overrides.Limits{}
 	flagext.DefaultValues(&limits)
@@ -402,7 +402,7 @@ func TestDedicatedColumns(t *testing.T) {
 }
 
 func defaultIngesterModule(t testing.TB, tmpDir string) *Ingester {
-	return defaultIngesterWithOverrides(t, tmpDir, defaultLimitsTestConfig())
+	return defaultIngesterWithOverrides(t, tmpDir, defaultOverrides())
 }
 
 func defaultIngesterWithOverrides(t testing.TB, tmpDir string, o overrides.Limits) *Ingester {
@@ -496,7 +496,7 @@ func defaultIngesterTestConfig() Config {
 	return cfg
 }
 
-func defaultLimitsTestConfig() overrides.Limits {
+func defaultOverrides() overrides.Limits {
 	limits := overrides.Limits{}
 	flagext.DefaultValues(&limits)
 	return limits

--- a/modules/ingester/ingester_test.go
+++ b/modules/ingester/ingester_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/go-kit/log"
 	"github.com/gogo/protobuf/proto"
 	"github.com/grafana/dskit/flagext"
@@ -339,9 +341,47 @@ func TestFlush(t *testing.T) {
 	}
 }
 
+func TestDedicatedColumns(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("/tmp", "")
+	require.NoError(t, err, "unexpected error getting tempdir")
+	defer os.RemoveAll(tmpDir)
+
+	limits := overrides.Limits{}
+	flagext.DefaultValues(&limits)
+	limits.DedicatedColumns = []backend.DedicatedColumn{{Scope: "span", Name: "foo", Type: "string"}}
+
+	i := defaultIngesterWithOverrides(t, tmpDir, limits)
+	inst, _ := i.getOrCreateInstance("test")
+	require.NotNil(t, inst)
+
+	dec := model.MustNewSegmentDecoder(model.CurrentEncoding)
+
+	// create some search data
+	id := make([]byte, 16)
+	_, err = rand.Read(id)
+	require.NoError(t, err)
+	trace := test.MakeTrace(10, id)
+	b1, err := dec.PrepareForWrite(trace, 0, 0)
+	require.NoError(t, err)
+
+	// push to instance
+	require.NoError(t, inst.PushBytes(context.Background(), id, b1))
+
+	// Write wal
+	require.NoError(t, inst.CutCompleteTraces(0, true))
+
+	assert.Equal(t, limits.DedicatedColumns, inst.headBlock.BlockMeta().DedicatedColumns)
+
+	// TODO: Search the ingested trace when the read path is supported
+}
+
 func defaultIngesterModule(t testing.TB, tmpDir string) *Ingester {
+	return defaultIngesterWithOverrides(t, tmpDir, defaultLimitsTestConfig())
+}
+
+func defaultIngesterWithOverrides(t testing.TB, tmpDir string, o overrides.Limits) *Ingester {
 	ingesterConfig := defaultIngesterTestConfig()
-	limits, err := overrides.NewOverrides(defaultLimitsTestConfig())
+	limits, err := overrides.NewOverrides(o)
 	require.NoError(t, err, "unexpected error creating overrides")
 
 	s, err := storage.NewStore(storage.Config{

--- a/modules/ingester/ingester_test.go
+++ b/modules/ingester/ingester_test.go
@@ -382,9 +382,23 @@ func TestDedicatedColumns(t *testing.T) {
 	blockID, err := inst.CutBlockIfReady(0, 0, true)
 	require.NoError(t, err)
 
+	// TODO: This check should be included as part of the read path
+	inst.blocksMtx.RLock()
+	for _, b := range inst.completingBlocks {
+		assert.Equal(t, limits.DedicatedColumns, b.BlockMeta().DedicatedColumns)
+	}
+	inst.blocksMtx.RUnlock()
+
 	// Complete block
 	err = inst.CompleteBlock(blockID)
 	require.NoError(t, err)
+
+	// TODO: This check should be included as part of the read path
+	inst.blocksMtx.RLock()
+	for _, b := range inst.completeBlocks {
+		assert.Equal(t, limits.DedicatedColumns, b.BlockMeta().DedicatedColumns)
+	}
+	inst.blocksMtx.RUnlock()
 }
 
 func defaultIngesterModule(t testing.TB, tmpDir string) *Ingester {

--- a/modules/ingester/ingester_test.go
+++ b/modules/ingester/ingester_test.go
@@ -372,7 +372,19 @@ func TestDedicatedColumns(t *testing.T) {
 
 	assert.Equal(t, limits.DedicatedColumns, inst.headBlock.BlockMeta().DedicatedColumns)
 
-	// TODO: Search the ingested trace when the read path is supported
+	// TODO: This search should find a match once the read path is supported
+	ctx := user.InjectOrgID(context.Background(), "test")
+	searchReq := &tempopb.SearchRequest{Query: "{span.foo=\"bar\"}"}
+	results, err := inst.Search(ctx, searchReq)
+	require.NoError(t, err)
+	assert.Len(t, results.Traces, 0)
+
+	blockID, err := inst.CutBlockIfReady(0, 0, true)
+	require.NoError(t, err)
+
+	// Complete block
+	err = inst.CompleteBlock(blockID)
+	require.NoError(t, err)
 }
 
 func defaultIngesterModule(t testing.TB, tmpDir string) *Ingester {

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -500,7 +500,7 @@ func (i *instance) resetHeadBlock() error {
 }
 
 func (i *instance) getDedicatedColumns() []backend.DedicatedColumn {
-	if cols := i.overrides.DedicatedColumns(i.instanceID); len(cols) > 0 {
+	if cols := i.overrides.DedicatedColumns(i.instanceID); cols != nil {
 		return cols
 	}
 	return i.dedicatedColumns

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -488,7 +488,7 @@ func (i *instance) resetHeadBlock() error {
 
 	dedicatedColumns := i.getDedicatedColumns()
 
-	newHeadBlock, err := i.writer.WAL().NewBlock(uuid.New(), i.instanceID, model.CurrentEncoding, dedicatedColumns...)
+	newHeadBlock, err := i.writer.WAL().NewBlockWithDedicatedColumns(uuid.New(), i.instanceID, model.CurrentEncoding, dedicatedColumns)
 	if err != nil {
 		return err
 	}

--- a/modules/ingester/overrides.go
+++ b/modules/ingester/overrides.go
@@ -1,0 +1,15 @@
+package ingester
+
+import (
+	"github.com/grafana/tempo/modules/generator/registry"
+	"github.com/grafana/tempo/modules/overrides"
+	"github.com/grafana/tempo/tempodb/backend"
+)
+
+type ingesterOverrides interface {
+	registry.Overrides
+
+	DedicatedColumns(userID string) []backend.DedicatedColumn
+}
+
+var _ ingesterOverrides = (overrides.Interface)(nil)

--- a/modules/overrides/overrides.go
+++ b/modules/overrides/overrides.go
@@ -397,8 +397,7 @@ func (o *overrides) MaxSearchDuration(userID string) time.Duration {
 }
 
 func (o *overrides) DedicatedColumns(userID string) []backend.DedicatedColumn {
-	dc := o.getOverridesForUser(userID).DedicatedColumns
-	return dc
+	return o.getOverridesForUser(userID).DedicatedColumns
 }
 
 func (o *overrides) getOverridesForUser(userID string) *Limits {

--- a/modules/overrides/overrides.go
+++ b/modules/overrides/overrides.go
@@ -397,7 +397,8 @@ func (o *overrides) MaxSearchDuration(userID string) time.Duration {
 }
 
 func (o *overrides) DedicatedColumns(userID string) []backend.DedicatedColumn {
-	return o.getOverridesForUser(userID).DedicatedColumns
+	dc := o.getOverridesForUser(userID).DedicatedColumns
+	return dc
 }
 
 func (o *overrides) getOverridesForUser(userID string) *Limits {

--- a/pkg/util/test/req.go
+++ b/pkg/util/test/req.go
@@ -22,17 +22,13 @@ func MakeSpan(traceID []byte) *v1_trace.Span {
 }
 
 func MakeSpanWithAttributeCount(traceID []byte, count int) *v1_trace.Span {
-	attributes := make([]*v1_common.KeyValue, 0, count+1)
+	attributes := make([]*v1_common.KeyValue, 0, count)
 	for i := 0; i < count; i++ {
 		attributes = append(attributes, &v1_common.KeyValue{
 			Key:   RandomString(),
 			Value: &v1_common.AnyValue{Value: &v1_common.AnyValue_StringValue{StringValue: RandomString()}},
 		})
 	}
-	attributes = append(attributes, &v1_common.KeyValue{
-		Key:   "foo",
-		Value: &v1_common.AnyValue{Value: &v1_common.AnyValue_StringValue{StringValue: "bar"}},
-	})
 
 	now := time.Now()
 	s := &v1_trace.Span{

--- a/pkg/util/test/req.go
+++ b/pkg/util/test/req.go
@@ -22,13 +22,17 @@ func MakeSpan(traceID []byte) *v1_trace.Span {
 }
 
 func MakeSpanWithAttributeCount(traceID []byte, count int) *v1_trace.Span {
-	attributes := make([]*v1_common.KeyValue, 0, count)
+	attributes := make([]*v1_common.KeyValue, 0, count+1)
 	for i := 0; i < count; i++ {
 		attributes = append(attributes, &v1_common.KeyValue{
 			Key:   RandomString(),
 			Value: &v1_common.AnyValue{Value: &v1_common.AnyValue_StringValue{StringValue: RandomString()}},
 		})
 	}
+	attributes = append(attributes, &v1_common.KeyValue{
+		Key:   "foo",
+		Value: &v1_common.AnyValue{Value: &v1_common.AnyValue_StringValue{StringValue: "bar"}},
+	})
 
 	now := time.Now()
 	s := &v1_trace.Span{
@@ -154,27 +158,6 @@ func MakeTrace(requests int, traceID []byte) *tempopb.Trace {
 	}
 
 	return trace
-}
-
-func MakeTraceBytes(requests int, traceID []byte) *tempopb.TraceBytes {
-	trace := &tempopb.Trace{
-		Batches: make([]*v1_trace.ResourceSpans, 0),
-	}
-
-	for i := 0; i < requests; i++ {
-		trace.Batches = append(trace.Batches, MakeBatch(rand.Int()%20+1, traceID))
-	}
-
-	bytes, err := proto.Marshal(trace)
-	if err != nil {
-		panic(err)
-	}
-
-	traceBytes := &tempopb.TraceBytes{
-		Traces: [][]byte{bytes},
-	}
-
-	return traceBytes
 }
 
 func MakeTraceWithSpanCount(requests int, spansEach int, traceID []byte) *tempopb.Trace {

--- a/tempodb/backend/block_meta.go
+++ b/tempodb/backend/block_meta.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"time"
 
+	"github.com/cespare/xxhash/v2"
+
 	"github.com/google/uuid"
 )
 
@@ -49,7 +51,7 @@ type BlockMeta struct {
 	// FooterSize contains the size of the footer in bytes (used by parquet)
 	FooterSize uint32 `json:"footerSize"`
 	// DedicatedColumns configuration for attributes (used by parquet)
-	DedicatedColumns []DedicatedColumn `json:"dedicatedColumns,omitempty"`
+	DedicatedColumns DedicatedColumns `json:"dedicatedColumns,omitempty"`
 }
 
 // DedicatedColumn contains the configuration for a single attribute with the given name that should
@@ -63,15 +65,35 @@ type DedicatedColumn struct {
 	Type string `yaml:"type" json:"type"`
 }
 
-func NewBlockMeta(tenantID string, blockID uuid.UUID, version string, encoding Encoding, dataEncoding string) *BlockMeta {
+type DedicatedColumns []DedicatedColumn
+
+// separatorByte is a byte that cannot occur in valid UTF-8 sequences
+var separatorByte = []byte{255}
+
+func (cs *DedicatedColumns) Hash() uint64 {
+	h := xxhash.New()
+
+	for _, c := range *cs {
+		_, _ = h.WriteString(c.Scope)
+		_, _ = h.Write(separatorByte)
+		_, _ = h.WriteString(c.Name)
+		_, _ = h.Write(separatorByte)
+		_, _ = h.WriteString(c.Type)
+	}
+
+	return h.Sum64()
+}
+
+func NewBlockMeta(tenantID string, blockID uuid.UUID, version string, encoding Encoding, dataEncoding string, dedicatedColumns ...DedicatedColumn) *BlockMeta {
 	b := &BlockMeta{
-		Version:      version,
-		BlockID:      blockID,
-		MinID:        []byte{},
-		MaxID:        []byte{},
-		TenantID:     tenantID,
-		Encoding:     encoding,
-		DataEncoding: dataEncoding,
+		Version:          version,
+		BlockID:          blockID,
+		MinID:            []byte{},
+		MaxID:            []byte{},
+		TenantID:         tenantID,
+		Encoding:         encoding,
+		DataEncoding:     dataEncoding,
+		DedicatedColumns: dedicatedColumns,
 	}
 
 	return b

--- a/tempodb/backend/block_meta.go
+++ b/tempodb/backend/block_meta.go
@@ -65,7 +65,11 @@ type DedicatedColumn struct {
 	Type string `yaml:"type" json:"type"`
 }
 
-func NewBlockMeta(tenantID string, blockID uuid.UUID, version string, encoding Encoding, dataEncoding string, dedicatedColumns ...DedicatedColumn) *BlockMeta {
+func NewBlockMeta(tenantID string, blockID uuid.UUID, version string, encoding Encoding, dataEncoding string) *BlockMeta {
+	return NewBlockMetaWithDedicatedColumns(tenantID, blockID, version, encoding, dataEncoding, nil)
+}
+
+func NewBlockMetaWithDedicatedColumns(tenantID string, blockID uuid.UUID, version string, encoding Encoding, dataEncoding string, dedicatedColumns []DedicatedColumn) *BlockMeta {
 	b := &BlockMeta{
 		Version:          version,
 		BlockID:          blockID,

--- a/tempodb/encoding/common/config.go
+++ b/tempodb/encoding/common/config.go
@@ -30,6 +30,9 @@ type BlockConfig struct {
 
 	// parquet fields
 	RowGroupSizeBytes int `yaml:"parquet_row_group_size_bytes"`
+
+	// vParquet3 fields
+	DedicatedColumns []backend.DedicatedColumn `yaml:"dedicated_columns"`
 }
 
 func (cfg *BlockConfig) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {

--- a/tempodb/encoding/v2/encoding.go
+++ b/tempodb/encoding/v2/encoding.go
@@ -47,7 +47,7 @@ func (v Encoding) OpenWALBlock(filename string, path string, ingestionSlack time
 }
 
 // CreateWALBlock creates a new appendable block
-func (v Encoding) CreateWALBlock(id uuid.UUID, tenantID string, filepath string, e backend.Encoding, dataEncoding string, ingestionSlack time.Duration) (common.WALBlock, error) {
+func (v Encoding) CreateWALBlock(id uuid.UUID, tenantID string, filepath string, e backend.Encoding, dataEncoding string, ingestionSlack time.Duration, dedicatedColumns ...backend.DedicatedColumn) (common.WALBlock, error) {
 	// Default data encoding if needed
 	if dataEncoding == "" {
 		dataEncoding = model.CurrentEncoding

--- a/tempodb/encoding/v2/encoding.go
+++ b/tempodb/encoding/v2/encoding.go
@@ -47,7 +47,7 @@ func (v Encoding) OpenWALBlock(filename string, path string, ingestionSlack time
 }
 
 // CreateWALBlock creates a new appendable block
-func (v Encoding) CreateWALBlock(id uuid.UUID, tenantID string, filepath string, e backend.Encoding, dataEncoding string, ingestionSlack time.Duration, dedicatedColumns ...backend.DedicatedColumn) (common.WALBlock, error) {
+func (v Encoding) CreateWALBlock(id uuid.UUID, tenantID string, filepath string, e backend.Encoding, dataEncoding string, ingestionSlack time.Duration, _ []backend.DedicatedColumn) (common.WALBlock, error) {
 	// Default data encoding if needed
 	if dataEncoding == "" {
 		dataEncoding = model.CurrentEncoding

--- a/tempodb/encoding/v2/streaming_block.go
+++ b/tempodb/encoding/v2/streaming_block.go
@@ -28,14 +28,13 @@ func NewStreamingBlock(cfg *common.BlockConfig, id uuid.UUID, tenantID string, m
 		return nil, fmt.Errorf("empty block meta list")
 	}
 
-	dataEncoding := metas[0].DataEncoding
-	dedicatedColumns := metas[0].DedicatedColumns
-	columnsHash := dedicatedColumns.Hash()
+	dataEncoding, dedicatedColumns := metas[0].DataEncoding, metas[0].DedicatedColumns
+	columnsHash := metas[0].DedicatedColumnsHash()
 	for _, meta := range metas {
 		if meta.DataEncoding != dataEncoding {
 			return nil, fmt.Errorf("two blocks of different data encodings can not be streamed together: %s: %s", dataEncoding, meta.DataEncoding)
 		}
-		if meta.DedicatedColumns.Hash() != columnsHash {
+		if meta.DedicatedColumnsHash() != columnsHash {
 			return nil, fmt.Errorf("two blocks of different dedicated columns can not be streamed together: %s: %s", dedicatedColumns, meta.DedicatedColumns)
 		}
 	}

--- a/tempodb/encoding/v2/streaming_block.go
+++ b/tempodb/encoding/v2/streaming_block.go
@@ -40,7 +40,7 @@ func NewStreamingBlock(cfg *common.BlockConfig, id uuid.UUID, tenantID string, m
 	}
 
 	// Start with times from input metas.
-	newMeta := backend.NewBlockMeta(tenantID, id, VersionString, cfg.Encoding, dataEncoding, dedicatedColumns...)
+	newMeta := backend.NewBlockMetaWithDedicatedColumns(tenantID, id, VersionString, cfg.Encoding, dataEncoding, dedicatedColumns)
 	newMeta.StartTime = metas[0].StartTime
 	newMeta.EndTime = metas[0].EndTime
 	for _, m := range metas[1:] {

--- a/tempodb/encoding/v2/streaming_block.go
+++ b/tempodb/encoding/v2/streaming_block.go
@@ -29,14 +29,19 @@ func NewStreamingBlock(cfg *common.BlockConfig, id uuid.UUID, tenantID string, m
 	}
 
 	dataEncoding := metas[0].DataEncoding
+	dedicatedColumns := metas[0].DedicatedColumns
+	columnsHash := dedicatedColumns.Hash()
 	for _, meta := range metas {
 		if meta.DataEncoding != dataEncoding {
 			return nil, fmt.Errorf("two blocks of different data encodings can not be streamed together: %s: %s", dataEncoding, meta.DataEncoding)
 		}
+		if meta.DedicatedColumns.Hash() != columnsHash {
+			return nil, fmt.Errorf("two blocks of different dedicated columns can not be streamed together: %s: %s", dedicatedColumns, meta.DedicatedColumns)
+		}
 	}
 
 	// Start with times from input metas.
-	newMeta := backend.NewBlockMeta(tenantID, id, VersionString, cfg.Encoding, dataEncoding)
+	newMeta := backend.NewBlockMeta(tenantID, id, VersionString, cfg.Encoding, dataEncoding, dedicatedColumns...)
 	newMeta.StartTime = metas[0].StartTime
 	newMeta.EndTime = metas[0].EndTime
 	for _, m := range metas[1:] {

--- a/tempodb/encoding/versioned.go
+++ b/tempodb/encoding/versioned.go
@@ -48,7 +48,7 @@ type VersionedEncoding interface {
 	OpenWALBlock(filename string, path string, ingestionSlack time.Duration, additionalStartSlack time.Duration) (common.WALBlock, error, error)
 
 	// CreateWALBlock creates a new appendable block for the WAL
-	CreateWALBlock(id uuid.UUID, tenantID string, filepath string, e backend.Encoding, dataEncoding string, ingestionSlack time.Duration) (common.WALBlock, error)
+	CreateWALBlock(id uuid.UUID, tenantID string, filepath string, e backend.Encoding, dataEncoding string, ingestionSlack time.Duration, dedicatedColumns ...backend.DedicatedColumn) (common.WALBlock, error)
 
 	// OwnsWALBlock indicates if this encoding owns the WAL block
 	OwnsWALBlock(entry fs.DirEntry) bool

--- a/tempodb/encoding/versioned.go
+++ b/tempodb/encoding/versioned.go
@@ -48,7 +48,7 @@ type VersionedEncoding interface {
 	OpenWALBlock(filename string, path string, ingestionSlack time.Duration, additionalStartSlack time.Duration) (common.WALBlock, error, error)
 
 	// CreateWALBlock creates a new appendable block for the WAL
-	CreateWALBlock(id uuid.UUID, tenantID string, filepath string, e backend.Encoding, dataEncoding string, ingestionSlack time.Duration, dedicatedColumns ...backend.DedicatedColumn) (common.WALBlock, error)
+	CreateWALBlock(id uuid.UUID, tenantID string, filepath string, e backend.Encoding, dataEncoding string, ingestionSlack time.Duration, dedicatedColumns []backend.DedicatedColumn) (common.WALBlock, error)
 
 	// OwnsWALBlock indicates if this encoding owns the WAL block
 	OwnsWALBlock(entry fs.DirEntry) bool

--- a/tempodb/encoding/vparquet/encoding.go
+++ b/tempodb/encoding/vparquet/encoding.go
@@ -45,7 +45,7 @@ func (v Encoding) OpenWALBlock(filename string, path string, ingestionSlack time
 }
 
 // CreateWALBlock creates a new appendable block
-func (v Encoding) CreateWALBlock(id uuid.UUID, tenantID string, filepath string, e backend.Encoding, dataEncoding string, ingestionSlack time.Duration) (common.WALBlock, error) {
+func (v Encoding) CreateWALBlock(id uuid.UUID, tenantID string, filepath string, e backend.Encoding, dataEncoding string, ingestionSlack time.Duration, dedicatedColumns ...backend.DedicatedColumn) (common.WALBlock, error) {
 	return createWALBlock(id, tenantID, filepath, e, dataEncoding, ingestionSlack)
 }
 

--- a/tempodb/encoding/vparquet/encoding.go
+++ b/tempodb/encoding/vparquet/encoding.go
@@ -45,7 +45,7 @@ func (v Encoding) OpenWALBlock(filename string, path string, ingestionSlack time
 }
 
 // CreateWALBlock creates a new appendable block
-func (v Encoding) CreateWALBlock(id uuid.UUID, tenantID string, filepath string, e backend.Encoding, dataEncoding string, ingestionSlack time.Duration, dedicatedColumns ...backend.DedicatedColumn) (common.WALBlock, error) {
+func (v Encoding) CreateWALBlock(id uuid.UUID, tenantID string, filepath string, e backend.Encoding, dataEncoding string, ingestionSlack time.Duration, _ []backend.DedicatedColumn) (common.WALBlock, error) {
 	return createWALBlock(id, tenantID, filepath, e, dataEncoding, ingestionSlack)
 }
 

--- a/tempodb/encoding/vparquet2/create.go
+++ b/tempodb/encoding/vparquet2/create.go
@@ -105,7 +105,7 @@ type streamingBlock struct {
 }
 
 func newStreamingBlock(ctx context.Context, cfg *common.BlockConfig, meta *backend.BlockMeta, r backend.Reader, to backend.Writer, createBufferedWriter func(w io.Writer) tempo_io.BufferedWriteFlusher) *streamingBlock {
-	newMeta := backend.NewBlockMeta(meta.TenantID, meta.BlockID, VersionString, backend.EncNone, "", meta.DedicatedColumns...)
+	newMeta := backend.NewBlockMetaWithDedicatedColumns(meta.TenantID, meta.BlockID, VersionString, backend.EncNone, "", meta.DedicatedColumns)
 	newMeta.StartTime = meta.StartTime
 	newMeta.EndTime = meta.EndTime
 

--- a/tempodb/encoding/vparquet2/create.go
+++ b/tempodb/encoding/vparquet2/create.go
@@ -105,7 +105,7 @@ type streamingBlock struct {
 }
 
 func newStreamingBlock(ctx context.Context, cfg *common.BlockConfig, meta *backend.BlockMeta, r backend.Reader, to backend.Writer, createBufferedWriter func(w io.Writer) tempo_io.BufferedWriteFlusher) *streamingBlock {
-	newMeta := backend.NewBlockMeta(meta.TenantID, meta.BlockID, VersionString, backend.EncNone, "")
+	newMeta := backend.NewBlockMeta(meta.TenantID, meta.BlockID, VersionString, backend.EncNone, "", meta.DedicatedColumns...)
 	newMeta.StartTime = meta.StartTime
 	newMeta.EndTime = meta.EndTime
 

--- a/tempodb/encoding/vparquet2/encoding.go
+++ b/tempodb/encoding/vparquet2/encoding.go
@@ -45,8 +45,8 @@ func (v Encoding) OpenWALBlock(filename string, path string, ingestionSlack time
 }
 
 // CreateWALBlock creates a new appendable block
-func (v Encoding) CreateWALBlock(id uuid.UUID, tenantID string, filepath string, e backend.Encoding, dataEncoding string, ingestionSlack time.Duration) (common.WALBlock, error) {
-	return createWALBlock(id, tenantID, filepath, e, dataEncoding, ingestionSlack)
+func (v Encoding) CreateWALBlock(id uuid.UUID, tenantID string, filepath string, e backend.Encoding, dataEncoding string, ingestionSlack time.Duration, dedicatedColumns ...backend.DedicatedColumn) (common.WALBlock, error) {
+	return createWALBlock(id, tenantID, filepath, e, dataEncoding, ingestionSlack, dedicatedColumns...)
 }
 
 func (v Encoding) OwnsWALBlock(entry fs.DirEntry) bool {

--- a/tempodb/encoding/vparquet2/encoding.go
+++ b/tempodb/encoding/vparquet2/encoding.go
@@ -45,8 +45,8 @@ func (v Encoding) OpenWALBlock(filename string, path string, ingestionSlack time
 }
 
 // CreateWALBlock creates a new appendable block
-func (v Encoding) CreateWALBlock(id uuid.UUID, tenantID string, filepath string, e backend.Encoding, dataEncoding string, ingestionSlack time.Duration, dedicatedColumns ...backend.DedicatedColumn) (common.WALBlock, error) {
-	return createWALBlock(id, tenantID, filepath, e, dataEncoding, ingestionSlack, dedicatedColumns...)
+func (v Encoding) CreateWALBlock(id uuid.UUID, tenantID string, filepath string, e backend.Encoding, dataEncoding string, ingestionSlack time.Duration, dedicatedColumns []backend.DedicatedColumn) (common.WALBlock, error) {
+	return createWALBlock(id, tenantID, filepath, e, dataEncoding, ingestionSlack, dedicatedColumns)
 }
 
 func (v Encoding) OwnsWALBlock(entry fs.DirEntry) bool {

--- a/tempodb/encoding/vparquet2/wal_block.go
+++ b/tempodb/encoding/vparquet2/wal_block.go
@@ -152,7 +152,7 @@ func openWALBlock(filename string, path string, ingestionSlack time.Duration, _ 
 }
 
 // createWALBlock creates a new appendable block
-func createWALBlock(id uuid.UUID, tenantID string, filepath string, _ backend.Encoding, dataEncoding string, ingestionSlack time.Duration, dedicatedColumns ...backend.DedicatedColumn) (*walBlock, error) {
+func createWALBlock(id uuid.UUID, tenantID string, filepath string, _ backend.Encoding, dataEncoding string, ingestionSlack time.Duration, dedicatedColumns []backend.DedicatedColumn) (*walBlock, error) {
 	b := &walBlock{
 		meta: &backend.BlockMeta{
 			Version:          VersionString,

--- a/tempodb/encoding/vparquet2/wal_block.go
+++ b/tempodb/encoding/vparquet2/wal_block.go
@@ -152,12 +152,13 @@ func openWALBlock(filename string, path string, ingestionSlack time.Duration, _ 
 }
 
 // createWALBlock creates a new appendable block
-func createWALBlock(id uuid.UUID, tenantID string, filepath string, _ backend.Encoding, dataEncoding string, ingestionSlack time.Duration) (*walBlock, error) {
+func createWALBlock(id uuid.UUID, tenantID string, filepath string, _ backend.Encoding, dataEncoding string, ingestionSlack time.Duration, dedicatedColumns ...backend.DedicatedColumn) (*walBlock, error) {
 	b := &walBlock{
 		meta: &backend.BlockMeta{
-			Version:  VersionString,
-			BlockID:  id,
-			TenantID: tenantID,
+			Version:          VersionString,
+			BlockID:          id,
+			TenantID:         tenantID,
+			DedicatedColumns: dedicatedColumns,
 		},
 		path:           filepath,
 		ids:            common.NewIDMap[int64](),

--- a/tempodb/encoding/vparquet2/wal_block_test.go
+++ b/tempodb/encoding/vparquet2/wal_block_test.go
@@ -64,7 +64,7 @@ func TestPartialReplay(t *testing.T) {
 	blockID := uuid.New()
 	basePath := t.TempDir()
 
-	w, err := createWALBlock(blockID, "fake", basePath, backend.EncNone, model.CurrentEncoding, 0)
+	w, err := createWALBlock(blockID, "fake", basePath, backend.EncNone, model.CurrentEncoding, 0, nil)
 	require.NoError(t, err)
 
 	// Flush a set of traces across 2 pages
@@ -292,7 +292,7 @@ func TestRowIterator(t *testing.T) {
 }
 
 func testWalBlock(t *testing.T, f func(w *walBlock, ids []common.ID, trs []*tempopb.Trace)) {
-	w, err := createWALBlock(uuid.New(), "fake", t.TempDir(), backend.EncNone, model.CurrentEncoding, 0)
+	w, err := createWALBlock(uuid.New(), "fake", t.TempDir(), backend.EncNone, model.CurrentEncoding, 0, nil)
 	require.NoError(t, err)
 
 	decoder := model.MustNewSegmentDecoder(model.CurrentEncoding)

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -232,16 +232,16 @@ func (rw *readerWriter) CompleteBlockWithBackend(ctx context.Context, block comm
 
 	inMeta := &backend.BlockMeta{
 		// From the wal block
-		TenantID:     walMeta.TenantID,
-		BlockID:      walMeta.BlockID,
-		TotalObjects: walMeta.TotalObjects,
-		StartTime:    walMeta.StartTime,
-		EndTime:      walMeta.EndTime,
-		DataEncoding: walMeta.DataEncoding,
+		TenantID:         walMeta.TenantID,
+		BlockID:          walMeta.BlockID,
+		TotalObjects:     walMeta.TotalObjects,
+		StartTime:        walMeta.StartTime,
+		EndTime:          walMeta.EndTime,
+		DataEncoding:     walMeta.DataEncoding,
+		DedicatedColumns: walMeta.DedicatedColumns,
 
 		// Other
-		Encoding:         rw.cfg.Block.Encoding,
-		DedicatedColumns: walMeta.DedicatedColumns,
+		Encoding: rw.cfg.Block.Encoding,
 	}
 
 	newMeta, err := vers.CreateBlock(ctx, rw.cfg.Block, inMeta, iter, r, w)

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -240,7 +240,8 @@ func (rw *readerWriter) CompleteBlockWithBackend(ctx context.Context, block comm
 		DataEncoding: walMeta.DataEncoding,
 
 		// Other
-		Encoding: rw.cfg.Block.Encoding,
+		Encoding:         rw.cfg.Block.Encoding,
+		DedicatedColumns: walMeta.DedicatedColumns,
 	}
 
 	newMeta, err := vers.CreateBlock(ctx, rw.cfg.Block, inMeta, iter, r, w)

--- a/tempodb/wal/wal.go
+++ b/tempodb/wal/wal.go
@@ -154,16 +154,16 @@ func (w *WAL) RescanBlocks(additionalStartSlack time.Duration, log log.Logger) (
 	return blocks, nil
 }
 
-func (w *WAL) NewBlock(id uuid.UUID, tenantID string, dataEncoding string) (common.WALBlock, error) {
-	return w.newBlock(id, tenantID, dataEncoding, w.c.Version)
+func (w *WAL) NewBlock(id uuid.UUID, tenantID, dataEncoding string, dedicatedColumns ...backend.DedicatedColumn) (common.WALBlock, error) {
+	return w.newBlock(id, tenantID, dataEncoding, w.c.Version, dedicatedColumns...)
 }
 
-func (w *WAL) newBlock(id uuid.UUID, tenantID string, dataEncoding string, blockVersion string) (common.WALBlock, error) {
+func (w *WAL) newBlock(id uuid.UUID, tenantID string, dataEncoding string, blockVersion string, dedicatedColumns ...backend.DedicatedColumn) (common.WALBlock, error) {
 	v, err := encoding.FromVersion(blockVersion)
 	if err != nil {
 		return nil, err
 	}
-	return v.CreateWALBlock(id, tenantID, w.c.Filepath, w.c.Encoding, dataEncoding, w.c.IngestionSlack)
+	return v.CreateWALBlock(id, tenantID, w.c.Filepath, w.c.Encoding, dataEncoding, w.c.IngestionSlack, dedicatedColumns...)
 }
 
 func (w *WAL) GetFilepath() string {

--- a/tempodb/wal/wal.go
+++ b/tempodb/wal/wal.go
@@ -154,16 +154,20 @@ func (w *WAL) RescanBlocks(additionalStartSlack time.Duration, log log.Logger) (
 	return blocks, nil
 }
 
-func (w *WAL) NewBlock(id uuid.UUID, tenantID, dataEncoding string, dedicatedColumns ...backend.DedicatedColumn) (common.WALBlock, error) {
-	return w.newBlock(id, tenantID, dataEncoding, w.c.Version, dedicatedColumns...)
+func (w *WAL) NewBlock(id uuid.UUID, tenantID, dataEncoding string) (common.WALBlock, error) {
+	return w.NewBlockWithDedicatedColumns(id, tenantID, dataEncoding, nil)
 }
 
-func (w *WAL) newBlock(id uuid.UUID, tenantID string, dataEncoding string, blockVersion string, dedicatedColumns ...backend.DedicatedColumn) (common.WALBlock, error) {
+func (w *WAL) NewBlockWithDedicatedColumns(id uuid.UUID, tenantID, dataEncoding string, dedicatedColumns []backend.DedicatedColumn) (common.WALBlock, error) {
+	return w.newBlock(id, tenantID, dataEncoding, w.c.Version, dedicatedColumns)
+}
+
+func (w *WAL) newBlock(id uuid.UUID, tenantID string, dataEncoding string, blockVersion string, dedicatedColumns []backend.DedicatedColumn) (common.WALBlock, error) {
 	v, err := encoding.FromVersion(blockVersion)
 	if err != nil {
 		return nil, err
 	}
-	return v.CreateWALBlock(id, tenantID, w.c.Filepath, w.c.Encoding, dataEncoding, w.c.IngestionSlack, dedicatedColumns...)
+	return v.CreateWALBlock(id, tenantID, w.c.Filepath, w.c.Encoding, dataEncoding, w.c.IngestionSlack, dedicatedColumns)
 }
 
 func (w *WAL) GetFilepath() string {

--- a/tempodb/wal/wal.go
+++ b/tempodb/wal/wal.go
@@ -158,6 +158,14 @@ func (w *WAL) NewBlock(id uuid.UUID, tenantID, dataEncoding string) (common.WALB
 	return w.NewBlockWithDedicatedColumns(id, tenantID, dataEncoding, nil)
 }
 
+// TODO(mapno): NewBlock and NewBlockWithDedicatedColumns should be consolidated into a single method
+//  They're currently separate because the dedicated columns feature is vParquet3-only,
+//  and we prefer to avoid leaking vParquet3-specific code where possible.
+//  There are a couple of ways to do this:
+//  1. Add a dedicatedColumns parameter to NewBlock, and have it default to nil.
+//  2. Have encoding-specific config be part of the encoding itself
+//  3. Pass the meta file path to the WAL constructor
+
 func (w *WAL) NewBlockWithDedicatedColumns(id uuid.UUID, tenantID, dataEncoding string, dedicatedColumns []backend.DedicatedColumn) (common.WALBlock, error) {
 	return w.newBlock(id, tenantID, dataEncoding, w.c.Version, dedicatedColumns)
 }

--- a/tempodb/wal/wal_test.go
+++ b/tempodb/wal/wal_test.go
@@ -70,7 +70,7 @@ func testAppendBlockStartEnd(t *testing.T, e encoding.VersionedEncoding) {
 	require.NoError(t, err, "unexpected error creating temp wal")
 
 	blockID := uuid.New()
-	block, err := wal.newBlock(blockID, testTenantID, model.CurrentEncoding, e.Version())
+	block, err := wal.newBlock(blockID, testTenantID, model.CurrentEncoding, e.Version(), nil)
 	require.NoError(t, err, "unexpected error creating block")
 
 	enc := model.MustNewSegmentDecoder(model.CurrentEncoding)
@@ -128,7 +128,7 @@ func testIngestionSlack(t *testing.T, e encoding.VersionedEncoding) {
 	require.NoError(t, err, "unexpected error creating temp wal")
 
 	blockID := uuid.New()
-	block, err := wal.newBlock(blockID, testTenantID, model.CurrentEncoding, e.Version())
+	block, err := wal.newBlock(blockID, testTenantID, model.CurrentEncoding, e.Version(), nil)
 	require.NoError(t, err, "unexpected error creating block")
 
 	enc := model.MustNewSegmentDecoder(model.CurrentEncoding)
@@ -341,7 +341,7 @@ func TestInvalidFilesAndFoldersAreHandled(t *testing.T) {
 
 	// create all valid blocks
 	for _, e := range encoding.AllEncodings() {
-		block, err := wal.newBlock(uuid.New(), testTenantID, model.CurrentEncoding, e.Version())
+		block, err := wal.newBlock(uuid.New(), testTenantID, model.CurrentEncoding, e.Version(), nil)
 		require.NoError(t, err)
 
 		id := make([]byte, 16)
@@ -395,7 +395,7 @@ func runWALTestWithAppendMode(t testing.TB, encoding string, appendTrace bool, r
 
 	blockID := uuid.New()
 
-	block, err := wal.newBlock(blockID, testTenantID, model.CurrentEncoding, encoding)
+	block, err := wal.newBlock(blockID, testTenantID, model.CurrentEncoding, encoding, nil)
 	require.NoError(t, err, "unexpected error creating block")
 
 	enc := model.MustNewSegmentDecoder(model.CurrentEncoding)
@@ -543,7 +543,7 @@ func runWALBenchmarkWithAppendMode(b *testing.B, encoding string, flushCount int
 
 	blockID := uuid.New()
 
-	block, err := wal.newBlock(blockID, testTenantID, model.CurrentEncoding, encoding)
+	block, err := wal.newBlock(blockID, testTenantID, model.CurrentEncoding, encoding, nil)
 	require.NoError(b, err, "unexpected error creating block")
 
 	dec := model.MustNewSegmentDecoder(model.CurrentEncoding)


### PR DESCRIPTION
**What this PR does**:
Propagates dynamic columns configuration to the write path. Ingesters now are able to create and write to blocks with dedicated columns.

**Which issue(s) this PR fixes**:
Fixes #2552

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`