### PR TITLE
Fix ingester locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ To make use of filtering, configure `autocomplete_filtering_enabled`.
 * [BUGFIX] tempodb integer divide by zero error [#2167](https://github.com/grafana/tempo/issues/2167) (@kroksys)
 * [BUGFIX] metrics-generator: ensure Prometheus will scale up shards when remote write is lagging behind [#2463](https://github.com/grafana/tempo/issues/2463) (@kvrhdn)
 * [BUGFIX] Fixes issue where matches and other spanset level attributes were not persisted to the TraceQL results. [#2490](https://github.com/grafana/tempo/pull/2490) 
+* [BUGFIX] Fixes issue where ingester search could occasionally fail with file does not exist error [#2534](https://github.com/grafana/tempo/issues/2534) (@mdisibio)
 * [CHANGE] **Breaking Change** Rename s3.insecure_skip_verify [#2407](https://github.com/grafana/tempo/pull/2407) (@zalegrala)
 ```yaml
 storage:

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -272,8 +272,8 @@ func (i *instance) CutBlockIfReady(maxBlockLifetime time.Duration, maxBlockBytes
 		// Now that we are adding a new block take the blocks mutex.
 		// A warning about deadlocks!!  This area does a hard-acquire of both mutexes.
 		// To avoid deadlocks this function and all others must acquire them in
-		// the ** same_order ** or else. i.e. another function can't acquire blocksMtx
-		// then headblockMtx. Even if the likelihood is low it is a statical certainly
+		// the ** same_order ** or else!!! i.e. another function can't acquire blocksMtx
+		// then headblockMtx. Even if the likelihood is low it is a statistical certainly
 		// that eventually a deadlock will occur.
 		i.blocksMtx.Lock()
 		defer i.blocksMtx.Unlock()

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -98,8 +98,10 @@ type instance struct {
 	traceSizes map[uint32]uint32
 	traceCount atomic.Int32
 
+	headBlockMtx sync.RWMutex
+	headBlock    common.WALBlock
+
 	blocksMtx        sync.RWMutex
-	headBlock        common.WALBlock
 	completingBlocks []common.WALBlock
 	completeBlocks   []*localBlock
 
@@ -241,16 +243,16 @@ func (i *instance) CutCompleteTraces(cutoff time.Duration, immediate bool) error
 		tempopb.ReuseByteSlices(t.batches)
 	}
 
-	i.blocksMtx.Lock()
-	defer i.blocksMtx.Unlock()
+	i.headBlockMtx.Lock()
+	defer i.headBlockMtx.Unlock()
 	return i.headBlock.Flush()
 }
 
 // CutBlockIfReady cuts a completingBlock from the HeadBlock if ready.
 // Returns the ID of a block if one was cut or a nil ID if one was not cut, along with the error (if any).
 func (i *instance) CutBlockIfReady(maxBlockLifetime time.Duration, maxBlockBytes uint64, immediate bool) (uuid.UUID, error) {
-	i.blocksMtx.Lock()
-	defer i.blocksMtx.Unlock()
+	i.headBlockMtx.Lock()
+	defer i.headBlockMtx.Unlock()
 
 	if i.headBlock == nil || i.headBlock.DataLength() == 0 {
 		return uuid.Nil, nil
@@ -266,6 +268,15 @@ func (i *instance) CutBlockIfReady(maxBlockLifetime time.Duration, maxBlockBytes
 		}
 
 		completingBlock := i.headBlock
+
+		// Now that we are adding a new block take the blocks mutex.
+		// A warning about deadlocks!!  This area does a hard-acquire of both mutexes.
+		// To avoid deadlocks this function and all others must acquire them in
+		// the ** same_order ** or else. i.e. another function can't acquire blocksMtx
+		// then headblockMtx. Even if the likelihood is low it is a statical certainly
+		// that eventually a deadlock will occur.
+		i.blocksMtx.Lock()
+		defer i.blocksMtx.Unlock()
 
 		i.completingBlocks = append(i.completingBlocks, completingBlock)
 
@@ -390,18 +401,20 @@ func (i *instance) FindTraceByID(ctx context.Context, id []byte) (*tempopb.Trace
 	}
 	i.tracesMtx.Unlock()
 
-	i.blocksMtx.RLock()
-	defer i.blocksMtx.RUnlock()
-
 	combiner := trace.NewCombiner()
 	combiner.Consume(completeTrace)
 
 	// headBlock
+	i.headBlockMtx.RLock()
 	tr, err := i.headBlock.FindTraceByID(ctx, id, common.DefaultSearchOptions())
+	i.headBlockMtx.RUnlock()
 	if err != nil {
 		return nil, fmt.Errorf("headBlock.FindTraceByID failed: %w", err)
 	}
 	combiner.Consume(tr)
+
+	i.blocksMtx.RLock()
+	defer i.blocksMtx.RUnlock()
 
 	// completingBlock
 	for _, c := range i.completingBlocks {
@@ -500,8 +513,8 @@ func (i *instance) tracesToCut(cutoff time.Duration, immediate bool) []*liveTrac
 }
 
 func (i *instance) writeTraceToHeadBlock(id common.ID, b []byte, start, end uint32) error {
-	i.blocksMtx.Lock()
-	defer i.blocksMtx.Unlock()
+	i.headBlockMtx.Lock()
+	defer i.headBlockMtx.Unlock()
 
 	err := i.headBlock.Append(id, b, start, end)
 	if err != nil {

--- a/modules/ingester/instance_search.go
+++ b/modules/ingester/instance_search.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 
 	"github.com/go-kit/log/level"
+	"github.com/google/uuid"
 	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/boundedwaitgroup"
 	"github.com/grafana/tempo/pkg/search"
@@ -41,13 +42,29 @@ func (i *instance) Search(ctx context.Context, req *tempopb.SearchRequest) (*tem
 	sr := search.NewResults()
 	defer sr.Close() // signal all running workers to quit
 
-	// Lock blocks mutex until all search tasks have been created. This avoids
+	// Lock headblock separately from other blocks and release it as soon as this
+	// subtask is finished.
+	// A warning about deadlocks!!  This area does a hard-acquire of both mutexes.
+	// To avoid deadlocks this function and all others must acquire them in
+	// the ** same_order ** or else. i.e. another function can't acquire blocksMtx
+	// then headblockMtx. Even if the likelihood is low it is a statical certainly
+	// that eventually a deadlock will occur.
+	i.headBlockMtx.RLock()
+	i.searchBlock(ctx, req, sr, i.headBlock.BlockMeta().BlockID, i.headBlock, i.headBlockMtx.RUnlock)
+
+	// Lock blocks mutex until all search tasks are finished and this function exists. This avoids
 	// deadlocking with other activity (ingest, flushing), caused by releasing
 	// and then attempting to retake the lock.
 	i.blocksMtx.RLock()
-	i.searchWAL(ctx, req, sr)
-	i.searchLocalBlocks(ctx, req, sr)
-	i.blocksMtx.RUnlock()
+	defer i.blocksMtx.RUnlock()
+
+	for _, b := range i.completingBlocks {
+		i.searchBlock(ctx, req, sr, b.BlockMeta().BlockID, b, nil)
+	}
+
+	for _, b := range i.completeBlocks {
+		i.searchBlock(ctx, req, sr, b.BlockMeta().BlockID, b, nil)
+	}
 
 	sr.AllWorkersStarted()
 
@@ -83,15 +100,20 @@ func (i *instance) Search(ctx context.Context, req *tempopb.SearchRequest) (*tem
 	}, nil
 }
 
-// searchWAL starts a search task for every WAL block. Must be called under lock.
-func (i *instance) searchWAL(ctx context.Context, req *tempopb.SearchRequest, sr *search.Results) {
-	searchWalBlock := func(b common.WALBlock) {
-		blockID := b.BlockMeta().BlockID.String()
-		span, ctx := opentracing.StartSpanFromContext(ctx, "instance.searchWALBlock", opentracing.Tags{
-			"blockID": blockID,
-		})
-		defer span.Finish()
+// searchLocalBlocks starts a search task for every local block. Must be called under lock.
+func (i *instance) searchBlock(ctx context.Context, req *tempopb.SearchRequest, sr *search.Results, blockID uuid.UUID, block common.Searcher, cleanup func()) {
+	sr.StartWorker()
+	go func(e common.Searcher, cleanup func()) {
+		if cleanup != nil {
+			defer cleanup()
+		}
 		defer sr.FinishWorker()
+
+		span, ctx := opentracing.StartSpanFromContext(ctx, "instance.searchLocalBlocks")
+		defer span.Finish()
+
+		span.LogFields(ot_log.Event("local block entry mtx acquired"))
+		span.SetTag("blockID", blockID)
 
 		var resp *tempopb.SearchResponse
 		var err error
@@ -101,92 +123,30 @@ func (i *instance) searchWAL(ctx context.Context, req *tempopb.SearchRequest, sr
 			// note: we are creating new engine for each wal block,
 			// and engine.ExecuteSearch is parsing the query for each block
 			resp, err = traceql.NewEngine().ExecuteSearch(ctx, req, traceql.NewSpansetFetcherWrapper(func(ctx context.Context, req traceql.FetchSpansRequest) (traceql.FetchSpansResponse, error) {
-				return b.Fetch(ctx, req, opts)
+				return e.Fetch(ctx, req, opts)
 			}))
 		} else {
-			resp, err = b.Search(ctx, req, opts)
+			resp, err = e.Search(ctx, req, opts)
 		}
 
 		if err == common.ErrUnsupported {
-			level.Warn(log.Logger).Log("msg", "wal block does not support search", "blockID", b.BlockMeta().BlockID)
+			level.Warn(log.Logger).Log("msg", "block does not support search", "blockID", blockID)
 			return
 		}
 		if err != nil {
-			level.Error(log.Logger).Log("msg", "error searching local block", "blockID", blockID, "block_version", b.BlockMeta().Version, "err", err)
+			level.Error(log.Logger).Log("msg", "error searching local block", "blockID", blockID, "err", err)
 			sr.SetError(err)
 			return
 		}
 
+		for _, t := range resp.Traces {
+			sr.AddResult(ctx, t)
+		}
 		sr.AddBlockInspected()
+
 		sr.AddBytesInspected(resp.Metrics.InspectedBytes)
 		sr.AddTraceInspected(resp.Metrics.InspectedTraces)
-		for _, r := range resp.Traces {
-			sr.AddResult(ctx, r)
-		}
-	}
-
-	// head block
-	if i.headBlock != nil {
-		sr.StartWorker()
-		go searchWalBlock(i.headBlock)
-	}
-
-	// completing blocks
-	for _, b := range i.completingBlocks {
-		sr.StartWorker()
-		go searchWalBlock(b)
-	}
-}
-
-// searchLocalBlocks starts a search task for every local block. Must be called under lock.
-func (i *instance) searchLocalBlocks(ctx context.Context, req *tempopb.SearchRequest, sr *search.Results) {
-	// next check all complete blocks to see if they were not searched, if they weren't then attempt to search them
-	for _, e := range i.completeBlocks {
-		sr.StartWorker()
-		go func(e *localBlock) {
-			defer sr.FinishWorker()
-
-			span, ctx := opentracing.StartSpanFromContext(ctx, "instance.searchLocalBlocks")
-			defer span.Finish()
-
-			blockID := e.BlockMeta().BlockID.String()
-
-			span.LogFields(ot_log.Event("local block entry mtx acquired"))
-			span.SetTag("blockID", blockID)
-
-			var resp *tempopb.SearchResponse
-			var err error
-
-			opts := common.DefaultSearchOptions()
-			if api.IsTraceQLQuery(req) {
-				// note: we are creating new engine for each wal block,
-				// and engine.ExecuteSearch is parsing the query for each block
-				resp, err = traceql.NewEngine().ExecuteSearch(ctx, req, traceql.NewSpansetFetcherWrapper(func(ctx context.Context, req traceql.FetchSpansRequest) (traceql.FetchSpansResponse, error) {
-					return e.Fetch(ctx, req, opts)
-				}))
-			} else {
-				resp, err = e.Search(ctx, req, opts)
-			}
-
-			if err == common.ErrUnsupported {
-				level.Warn(log.Logger).Log("msg", "block does not support search", "blockID", e.BlockMeta().BlockID)
-				return
-			}
-			if err != nil {
-				level.Error(log.Logger).Log("msg", "error searching local block", "blockID", blockID, "err", err)
-				sr.SetError(err)
-				return
-			}
-
-			for _, t := range resp.Traces {
-				sr.AddResult(ctx, t)
-			}
-			sr.AddBlockInspected()
-
-			sr.AddBytesInspected(resp.Metrics.InspectedBytes)
-			sr.AddTraceInspected(resp.Metrics.InspectedTraces)
-		}(e)
-	}
+	}(block, cleanup)
 }
 
 func (i *instance) SearchTags(ctx context.Context, scope string) (*tempopb.SearchTagsResponse, error) {
@@ -226,13 +186,16 @@ func (i *instance) SearchTags(ctx context.Context, scope string) (*tempopb.Searc
 		return nil
 	}
 
+	i.headBlockMtx.RLock()
+	err = search(i.headBlock, distinctValues)
+	i.headBlockMtx.RUnlock()
+	if err != nil {
+		return nil, fmt.Errorf("unexpected error searching head block (%s): %w", i.headBlock.BlockMeta().BlockID, err)
+	}
+
 	i.blocksMtx.RLock()
 	defer i.blocksMtx.RUnlock()
 
-	// search parquet wal/completing blocks/completed blocks
-	if err = search(i.headBlock, distinctValues); err != nil {
-		return nil, fmt.Errorf("unexpected error searching head block (%s): %w", i.headBlock.BlockMeta().BlockID, err)
-	}
 	for _, b := range i.completingBlocks {
 		if err = search(b, distinctValues); err != nil {
 			return nil, fmt.Errorf("unexpected error searching completing block (%s): %w", b.BlockMeta().BlockID, err)
@@ -340,13 +303,16 @@ func (i *instance) SearchTagValues(ctx context.Context, tagName string) (*tempop
 		return nil
 	}
 
+	i.headBlockMtx.RLock()
+	err = search(i.headBlock, distinctValues)
+	i.headBlockMtx.RUnlock()
+	if err != nil {
+		return nil, fmt.Errorf("unexpected error searching head block (%s): %w", i.headBlock.BlockMeta().BlockID, err)
+	}
+
 	i.blocksMtx.RLock()
 	defer i.blocksMtx.RUnlock()
 
-	// search parquet wal/completing blocks/completed blocks
-	if err = search(i.headBlock, distinctValues); err != nil {
-		return nil, fmt.Errorf("unexpected error searching head block (%s): %w", i.headBlock.BlockMeta().BlockID, err)
-	}
 	for _, b := range i.completingBlocks {
 		if err = search(b, distinctValues); err != nil {
 			return nil, fmt.Errorf("unexpected error searching completing block (%s): %w", b.BlockMeta().BlockID, err)
@@ -456,6 +422,24 @@ func (i *instance) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTag
 		}
 	}
 
+	// head block
+	// A warning about deadlocks!!  This area does a hard-acquire of both mutexes.
+	// To avoid deadlocks this function and all others must acquire them in
+	// the ** same_order ** or else. i.e. another function can't acquire blocksMtx
+	// then headblockMtx. Even if the likelihood is low it is a statical certainly
+	// that eventually a deadlock will occur.
+	i.headBlockMtx.RLock()
+	if i.headBlock != nil {
+		wg.Add(1)
+		go func() {
+			defer i.headBlockMtx.RUnlock()
+			defer wg.Done()
+			if err := searchBlock(i.headBlock); err != nil {
+				anyErr.Store(fmt.Errorf("unexpected error searching head block (%s): %w", i.headBlock.BlockMeta().BlockID, err))
+			}
+		}()
+	}
+
 	i.blocksMtx.RLock()
 	defer i.blocksMtx.RUnlock()
 
@@ -479,17 +463,6 @@ func (i *instance) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTag
 				anyErr.Store(fmt.Errorf("unexpected error searching completing block (%s): %w", b.BlockMeta().BlockID, err))
 			}
 		}(b)
-	}
-
-	// head block
-	if i.headBlock != nil {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			if err := searchBlock(i.headBlock); err != nil {
-				anyErr.Store(fmt.Errorf("unexpected error searching head block (%s): %w", i.headBlock.BlockMeta().BlockID, err))
-			}
-		}()
 	}
 
 	wg.Wait()


### PR DESCRIPTION
**What this PR does**:
Fixes #2534 by keeping the lock until the search is complete, but also splits out a separate mutex for the headblock ease contention on the core write path (live traces -> disk).   I added a new `BenchmarkInstanceContention` to help measure the effect, which is similar to the `xxxDoesNotRace` methods but prints out the op/sec of each thing.   Comparison between `main` and this branch are below. There's definitely a draw back in reads due to the increased lock time, but the write path actually looks better, since it only has to lock the headblock, and I took care to ensure that the read paths release the headblock as soon as possible.

```
name                   old time/op            new time/op            delta
InstanceContention-12             2.37s ±21%             2.69s ±29%      ~     (p=0.105 n=10+10)

name                   old blockflushes/sec   new blockflushes/sec   delta
InstanceContention-12              257 ±124%              886 ±101%  +244.84%  (p=0.000 n=10+10)

name                   old finds/sec          new finds/sec          delta
InstanceContention-12             6.84k ±20%             0.10k ±78%   -98.58%  (p=0.000 n=10+10)

name                   old pushes/sec         new pushes/sec         delta
InstanceContention-12             2.83k ±16%             2.39k ±28%   -15.51%  (p=0.009 n=10+10)

name                   old retentions/sec     new retentions/sec     delta
InstanceContention-12             1.91k ±22%             4.82k ±72%  +151.49%  (p=0.000 n=10+10)

name                   old searchTags/sec     new searchTags/sec     delta
InstanceContention-12               612 ±19%                52 ±36%   -91.51%  (p=0.000 n=10+10)

name                   old searchedBytes/sec  new searchedBytes/sec  delta
InstanceContention-12             25.2M ±13%             29.9M ±37%   +18.80%  (p=0.017 n=9+10)

name                   old searches/sec       new searches/sec       delta
InstanceContention-12               191 ±21%                34 ±20%   -82.00%  (p=0.000 n=10+9)

name                   old traceflushes/sec   new traceflushes/sec   delta
InstanceContention-12             5.43 ±126%              9.83 ±30%   +81.00%  (p=0.006 n=9+10)
```

**Note** Having the two mutexes makes it possible to introduce deadlocks if they are accessed in the wrong order. Left a couple huge comments explaining it, but the brittleness of future dev error is something to consider.

**Note2** I have been debating between this change and an alternate approach [here](https://github.com/grafana/tempo/compare/main...mdisibio:locklist).  The alternative approach is the `granular per-block locking nirvana` that I would like to see.  It reduces contention even more but it's not quite enough to balance out the increased complexity yet.  I'll keep working on it if there are no objections.

**Which issue(s) this PR fixes**:
Fixes #2534 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`