### PR TITLE
Fix range calculation on recent searches

### DIFF
--- a/modules/frontend/searchsharding.go
+++ b/modules/frontend/searchsharding.go
@@ -318,8 +318,6 @@ func (s *searchSharder) backendRequests(ctx context.Context, tenantID string, pa
 		return
 	}
 
-	fmt.Println("req", searchReq.Query, "tenant", tenantID, "start", start, time.Unix(int64(start), 0), "end", end, time.Unix(int64(end), 0))
-
 	// get block metadata of blocks in start, end duration
 	blocks = s.blockMetas(int64(start), int64(end), tenantID)
 

--- a/modules/frontend/searchsharding.go
+++ b/modules/frontend/searchsharding.go
@@ -135,7 +135,7 @@ func (s searchSharder) RoundTrip(r *http.Request) (*http.Response, error) {
 
 	// build request to search ingester based on query_ingesters_until config and time range
 	// pass subCtx in requests so we can cancel and exit early
-	ingesterReq, err := s.ingesterRequest(subCtx, tenantID, r, searchReq)
+	ingesterReq, err := s.ingesterRequest(subCtx, tenantID, r, *searchReq)
 	if err != nil {
 		return nil, err
 	}
@@ -435,10 +435,10 @@ func pagesPerRequest(m *backend.BlockMeta, bytesPerRequest int) int {
 // that covers the ingesters. If nil is returned for the http.Request then there is no ingesters query.
 // since this function modifies searchReq.Start and End we are taking a value instead of a pointer to prevent it from
 // unexpectedly changing the passed searchReq.
-func (s *searchSharder) ingesterRequest(ctx context.Context, tenantID string, parent *http.Request, searchReq *tempopb.SearchRequest) (*http.Request, error) {
+func (s *searchSharder) ingesterRequest(ctx context.Context, tenantID string, parent *http.Request, searchReq tempopb.SearchRequest) (*http.Request, error) {
 	// request without start or end, search only in ingester
 	if searchReq.Start == 0 || searchReq.End == 0 {
-		return buildIngesterRequest(ctx, tenantID, parent, searchReq)
+		return buildIngesterRequest(ctx, tenantID, parent, &searchReq)
 	}
 
 	now := time.Now()
@@ -465,7 +465,7 @@ func (s *searchSharder) ingesterRequest(ctx context.Context, tenantID string, pa
 	searchReq.Start = ingesterStart
 	searchReq.End = ingesterEnd
 
-	return buildIngesterRequest(ctx, tenantID, parent, searchReq)
+	return buildIngesterRequest(ctx, tenantID, parent, &searchReq)
 }
 
 func buildIngesterRequest(ctx context.Context, tenantID string, parent *http.Request, searchReq *tempopb.SearchRequest) (*http.Request, error) {

--- a/modules/frontend/searchsharding.go
+++ b/modules/frontend/searchsharding.go
@@ -318,6 +318,8 @@ func (s *searchSharder) backendRequests(ctx context.Context, tenantID string, pa
 		return
 	}
 
+	fmt.Println("start", start, "end", end)
+
 	// get block metadata of blocks in start, end duration
 	blocks = s.blockMetas(int64(start), int64(end), tenantID)
 

--- a/modules/frontend/searchsharding.go
+++ b/modules/frontend/searchsharding.go
@@ -318,7 +318,7 @@ func (s *searchSharder) backendRequests(ctx context.Context, tenantID string, pa
 		return
 	}
 
-	fmt.Println("start", start, "end", end)
+	fmt.Println("req", searchReq.Query, "tenant", tenantID, "start", start, time.Unix(int64(start), 0), "end", end, time.Unix(int64(end), 0))
 
 	// get block metadata of blocks in start, end duration
 	blocks = s.blockMetas(int64(start), int64(end), tenantID)

--- a/modules/frontend/searchsharding_test.go
+++ b/modules/frontend/searchsharding_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -388,7 +389,8 @@ func TestIngesterRequest(t *testing.T) {
 		searchReq, err := api.ParseSearchRequest(req)
 		require.NoError(t, err)
 
-		actualReq, err := s.ingesterRequest(context.Background(), "test", req, searchReq)
+		copyReq := searchReq
+		actualReq, err := s.ingesterRequest(context.Background(), "test", req, *searchReq)
 		if tc.expectedError != nil {
 			assert.Equal(t, tc.expectedError, err)
 			continue
@@ -399,6 +401,10 @@ func TestIngesterRequest(t *testing.T) {
 		} else {
 			assert.Equal(t, tc.expectedURI, actualReq.RequestURI)
 		}
+
+		// it may seem odd to test that the searchReq is not modified, but this is to prevent an issue that
+		// occurs if the ingesterRequest method is changed to take a searchReq pointer
+		require.True(t, reflect.DeepEqual(copyReq, searchReq))
 	}
 }
 


### PR DESCRIPTION
**What this PR does**:
A bug [was introduced](https://github.com/grafana/tempo/pull/2530) by changing the `searchReq` param on `ingesterRequest` from a value type to a pointer. The pointer allowed the struct to be modified by the calling code which broke request ranges that included ingester requests.

**Which issue(s) this PR fixes**:
Fixes #2577 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`