### PR TITLE
Ipv6 docs

### DIFF
--- a/docs/sources/tempo/configuration/ipv6.md
+++ b/docs/sources/tempo/configuration/ipv6.md
@@ -14,7 +14,7 @@ Tempo can be configured to communicate between the components using Internet Pro
 
 This sample listen configuration will allow the gRPC and HTTP servers to listen on IPv6, and configure the various memberlist components to enable IPv6.
 
-NOTE: If using the Helm chart, set `http_listen_port: 3100` as the pod ports are hard-coded to 3100.
+NOTE: If using the Helm chart, set `http_listen_port: 3100` as the pod ports are hard-coded to 3100. The Jsonnet files are configured to use 3200 by default.
 
 ```yaml
 memberlist:

--- a/docs/sources/tempo/configuration/ipv6.md
+++ b/docs/sources/tempo/configuration/ipv6.md
@@ -14,8 +14,6 @@ Tempo can be configured to communicate between the components using Internet Pro
 
 This sample listen configuration will allow the gRPC and HTTP servers to listen on IPv6, and configure the various memberlist components to enable IPv6.
 
-NOTE: If using the Helm chart, set `http_listen_port: 3100` as the pod ports are hard-coded to 3100. The Jsonnet files are configured to use 3200 by default.
-
 ```yaml
 memberlist:
   bind_addr:
@@ -34,14 +32,11 @@ metrics_generator:
 
 ingester:
   lifecycler:
-    address: '::'
     enable_inet6: true
 
 server:
   grpc_listen_address: '[::0]'
-  grpc_listen_port: 9095
   http_listen_address: '[::0]'
-  http_listen_port: 3200
 ```
 
 ## Kubernetes service configuration

--- a/docs/sources/tempo/configuration/ipv6.md
+++ b/docs/sources/tempo/configuration/ipv6.md
@@ -14,6 +14,8 @@ Tempo can be configured to communicate between the components using Internet Pro
 
 This sample listen configuration will allow the gRPC and HTTP servers to listen on IPv6, and configure the various memberlist components to enable IPv6.
 
+NOTE: If using the Helm chart, set `http_listen_port: 3100` as the pod ports are hard-coded to 3100.
+
 ```yaml
 memberlist:
   bind_addr:


### PR DESCRIPTION
**What this PR does**:

Addresses a missing note in the IPv6 docs to use port 3100 as the http_listen_port when using the Helm chart to deploy Tempo.

**Which issue(s) this PR fixes**:
Fixes #2586 

**Checklist**
- [x] Documentation added