### PR TITLE
Update podDisruptionBudget policy API version [ksonnet]

### DIFF
--- a/operations/jsonnet/microservices/multi-zone.libsonnet
+++ b/operations/jsonnet/microservices/multi-zone.libsonnet
@@ -2,7 +2,7 @@
   local container = $.core.v1.container,
   local deployment = $.apps.v1.deployment,
   local statefulSet = $.apps.v1.statefulSet,
-  local podDisruptionBudget = $.policy.v1beta1.podDisruptionBudget,
+  local podDisruptionBudget = $.policy.v1.podDisruptionBudget,
   local volume = $.core.v1.volume,
   local roleBinding = $.rbac.v1.roleBinding,
   local role = $.rbac.v1.role,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Upgrade podDisruptionBudget policy API from v1beta1 to v1 as the v1beta1 deprecated in k8s 1.25.

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`