### PR TITLE
FIX1958: Error code 400 when input trace is too large(WIP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [BUGFIX] Return status code 400 when input trace is too large error [#2612](https://github.com/grafana/tempo/pull/2612)
 * [CHANGE] Make vParquet2 the default block format [#2526](https://github.com/grafana/tempo/pull/2526) (@stoewer)
 * [CHANGE] Disable tempo-query by default in Jsonnet libs. [#2462](https://github.com/grafana/tempo/pull/2462) (@electron0zero)
 * [FEATURE] New experimental API to derive on-demand RED metrics grouped by any attribute, and new metrics generator processor [#2368](https://github.com/grafana/tempo/pull/2368) [#2418](https://github.com/grafana/tempo/pull/2418) [#2424](https://github.com/grafana/tempo/pull/2424) [#2442](https://github.com/grafana/tempo/pull/2442) [#2480](https://github.com/grafana/tempo/pull/2480) [#2481](https://github.com/grafana/tempo/pull/2481) [#2501](https://github.com/grafana/tempo/pull/2501) [#2579](https://github.com/grafana/tempo/pull/2579) (@mdisibio @zalegrala)

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -186,7 +186,7 @@ func (i *instance) push(ctx context.Context, id, traceBytes []byte) error {
 		prevSize := int(i.traceSizes[tkn])
 		reqSize := len(traceBytes)
 		if prevSize+reqSize > maxBytes {
-			return status.Errorf(codes.FailedPrecondition, (newTraceTooLargeError(id, i.instanceID, maxBytes, reqSize).Error()))
+			return status.Errorf(codes.InvalidArgument, (newTraceTooLargeError(id, i.instanceID, maxBytes, reqSize).Error()))
 		}
 	}
 
@@ -195,7 +195,7 @@ func (i *instance) push(ctx context.Context, id, traceBytes []byte) error {
 	err := trace.Push(ctx, i.instanceID, traceBytes)
 	if err != nil {
 		if e, ok := err.(*traceTooLargeError); ok {
-			return status.Errorf(codes.FailedPrecondition, e.Error())
+			return status.Errorf(codes.InvalidArgument, e.Error())
 		}
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**Return status code 400 when input trace is too large**:

**Currently, status code returned for traces larger than permissible size is 500, which makes client to retry. To avoid this, return status code 400 instead.**:
Fixes #1958

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`