### PR TITLE
Change compaction cycle complete log line to Debug level

### DIFF
--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -131,7 +131,7 @@ func (rw *readerWriter) doCompaction(ctx context.Context) {
 			if len(toBeCompacted) == 0 {
 				measureOutstandingBlocks(tenantID, blockSelector, rw.compactorSharder.Owns)
 
-				level.Info(rw.logger).Log("msg", "compaction cycle complete. No more blocks to compact", "tenantID", tenantID)
+				level.Debug(rw.logger).Log("msg", "compaction cycle complete. No more blocks to compact", "tenantID", tenantID)
 				return
 			}
 			if !rw.compactorSharder.Owns(hashString) {


### PR DESCRIPTION
We will flood compactor logs with `compaction cycle complete. No more blocks to compact` in clusters with agreesive `compaction_cycle` and multiple tenants. this will contribute to extra log volume as well, so tone it down from Info to debug level.