### PR TITLE
Move util.Client into httpclient.Client

### DIFF
--- a/cmd/tempo-cli/cmd-query-search-tag-values.go
+++ b/cmd/tempo-cli/cmd-query-search-tag-values.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/grafana/tempo/pkg/util"
+	"github.com/grafana/tempo/pkg/httpclient"
 )
 
 type querySearchTagValuesCmd struct {
@@ -12,7 +12,7 @@ type querySearchTagValuesCmd struct {
 }
 
 func (cmd *querySearchTagValuesCmd) Run(_ *globalOptions) error {
-	client := util.NewClient(cmd.APIEndpoint, cmd.OrgID)
+	client := httpclient.New(cmd.APIEndpoint, cmd.OrgID)
 
 	tagValues, err := client.SearchTagValues(cmd.Tag)
 	if err != nil {

--- a/cmd/tempo-cli/cmd-query-search-tags.go
+++ b/cmd/tempo-cli/cmd-query-search-tags.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/grafana/tempo/pkg/util"
+	"github.com/grafana/tempo/pkg/httpclient"
 )
 
 type querySearchTagsCmd struct {
@@ -11,7 +11,7 @@ type querySearchTagsCmd struct {
 }
 
 func (cmd *querySearchTagsCmd) Run(_ *globalOptions) error {
-	client := util.NewClient(cmd.APIEndpoint, cmd.OrgID)
+	client := httpclient.New(cmd.APIEndpoint, cmd.OrgID)
 
 	tags, err := client.SearchTags()
 	if err != nil {

--- a/cmd/tempo-cli/cmd-query-trace-id.go
+++ b/cmd/tempo-cli/cmd-query-trace-id.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/grafana/tempo/pkg/util"
+	"github.com/grafana/tempo/pkg/httpclient"
 )
 
 type queryTraceIDCmd struct {
@@ -12,7 +12,7 @@ type queryTraceIDCmd struct {
 }
 
 func (cmd *queryTraceIDCmd) Run(_ *globalOptions) error {
-	client := util.NewClient(cmd.APIEndpoint, cmd.OrgID)
+	client := httpclient.New(cmd.APIEndpoint, cmd.OrgID)
 
 	// util.QueryTrace will only add orgID header if len(orgID) > 0
 	trace, err := client.QueryTrace(cmd.TraceID)

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/grafana/tempo/pkg/httpclient"
 	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/util"
@@ -161,7 +162,7 @@ func main() {
 					continue
 				}
 
-				client := util.NewClient(tempoQueryURL, tempoOrgID)
+				client := httpclient.New(tempoQueryURL, tempoOrgID)
 
 				// query the trace
 				queryMetrics, err := queryTrace(client, info)
@@ -192,7 +193,7 @@ func main() {
 					continue
 				}
 
-				client := util.NewClient(tempoQueryURL, tempoOrgID)
+				client := httpclient.New(tempoQueryURL, tempoOrgID)
 
 				// query a tag we expect the trace to be found within
 				searchMetrics, err := searchTag(client, seed)
@@ -322,7 +323,7 @@ func generateRandomInt(min int64, max int64, r *rand.Rand) int64 {
 	return number
 }
 
-func searchTag(client *util.Client, seed time.Time) (traceMetrics, error) {
+func searchTag(client *httpclient.Client, seed time.Time) (traceMetrics, error) {
 	tm := traceMetrics{
 		requested: 1,
 	}
@@ -388,7 +389,7 @@ func searchTag(client *util.Client, seed time.Time) (traceMetrics, error) {
 	return tm, nil
 }
 
-func searchTraceql(client *util.Client, seed time.Time) (traceMetrics, error) {
+func searchTraceql(client *httpclient.Client, seed time.Time) (traceMetrics, error) {
 	tm := traceMetrics{
 		requested: 1,
 	}
@@ -452,7 +453,7 @@ func searchTraceql(client *util.Client, seed time.Time) (traceMetrics, error) {
 	return tm, nil
 }
 
-func queryTrace(client *util.Client, info *util.TraceInfo) (traceMetrics, error) {
+func queryTrace(client *httpclient.Client, info *util.TraceInfo) (traceMetrics, error) {
 	tm := traceMetrics{
 		requested: 1,
 	}

--- a/integration/e2e/compression_test.go
+++ b/integration/e2e/compression_test.go
@@ -7,10 +7,11 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/jsonpb"
+	"github.com/grafana/e2e"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/e2e"
 	util "github.com/grafana/tempo/integration"
+	"github.com/grafana/tempo/pkg/httpclient"
 	"github.com/grafana/tempo/pkg/tempopb"
 	tempoUtil "github.com/grafana/tempo/pkg/util"
 )
@@ -36,15 +37,15 @@ func TestCompression(t *testing.T) {
 	info := tempoUtil.NewTraceInfo(time.Now(), "")
 	require.NoError(t, info.EmitAllBatches(c))
 
-	apiClient := tempoUtil.NewClient("http://"+tempo.Endpoint(3200), "")
+	apiClient := httpclient.New("http://"+tempo.Endpoint(3200), "")
 
-	apiClientWithCompression := tempoUtil.NewClientWithCompression("http://"+tempo.Endpoint(3200), "")
+	apiClientWithCompression := httpclient.NewWithCompression("http://"+tempo.Endpoint(3200), "")
 
 	queryAndAssertTrace(t, apiClient, info)
 	queryAndAssertTraceCompression(t, apiClientWithCompression, info)
 }
 
-func queryAndAssertTraceCompression(t *testing.T, client *tempoUtil.Client, info *tempoUtil.TraceInfo) {
+func queryAndAssertTraceCompression(t *testing.T, client *httpclient.Client, info *tempoUtil.TraceInfo) {
 
 	// The received client will strip the header before we have a chance to inspect it, so just validate that the compressed client works as expected.
 	result, err := client.QueryTrace(info.HexID())
@@ -59,7 +60,7 @@ func queryAndAssertTraceCompression(t *testing.T, client *tempoUtil.Client, info
 	// response, to disable this behaviour you have to explicitly set the Accept-Encoding header.
 
 	// Make the call directly so we have a chance to inspect the response header and manually un-gzip it ourselves to confirm the content.
-	request, err := http.NewRequest("GET", client.BaseURL+tempoUtil.QueryTraceEndpoint+"/"+info.HexID(), nil)
+	request, err := http.NewRequest("GET", client.BaseURL+httpclient.QueryTraceEndpoint+"/"+info.HexID(), nil)
 	require.NoError(t, err)
 	request.Header.Add("Accept-Encoding", "gzip")
 

--- a/integration/e2e/cross_cluster_reads_test.go
+++ b/integration/e2e/cross_cluster_reads_test.go
@@ -6,10 +6,12 @@ import (
 
 	"github.com/grafana/e2e"
 	e2edb "github.com/grafana/e2e/db"
-	util "github.com/grafana/tempo/integration"
-	tempoUtil "github.com/grafana/tempo/pkg/util"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
+
+	util "github.com/grafana/tempo/integration"
+	"github.com/grafana/tempo/pkg/httpclient"
+	tempoUtil "github.com/grafana/tempo/pkg/util"
 )
 
 // TestCrossClusterReads uses the secondary_ingester_ring querier configuration option. it writes a trace to
@@ -45,7 +47,7 @@ func TestCrossClusterReads(t *testing.T) {
 	require.NoError(t, tempoDistributorA.WaitSumMetrics(e2e.Equals(spanCount(expected)), "tempo_distributor_spans_received_total"))
 
 	// read from cluster B
-	apiClient := tempoUtil.NewClient("http://"+tempoQueryFrontendB.Endpoint(3200), "")
+	apiClient := httpclient.New("http://"+tempoQueryFrontendB.Endpoint(3200), "")
 
 	// query an in-memory trace
 	queryAndAssertTrace(t, apiClient, info)

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grafana/tempo/cmd/tempo/app"
 	util "github.com/grafana/tempo/integration"
 	"github.com/grafana/tempo/integration/e2e/backend"
+	"github.com/grafana/tempo/pkg/httpclient"
 	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempopb"
 	tempoUtil "github.com/grafana/tempo/pkg/util"
@@ -93,7 +94,7 @@ func TestAllInOne(t *testing.T) {
 			// test echo
 			assertEcho(t, "http://"+tempo.Endpoint(3200)+"/api/echo")
 
-			apiClient := tempoUtil.NewClient("http://"+tempo.Endpoint(3200), "")
+			apiClient := httpclient.New("http://"+tempo.Endpoint(3200), "")
 
 			// query an in-memory trace
 			queryAndAssertTrace(t, apiClient, info)
@@ -250,7 +251,7 @@ func TestMicroservicesWithKVStores(t *testing.T) {
 			// test echo
 			assertEcho(t, "http://"+tempoQueryFrontend.Endpoint(3200)+"/api/echo")
 
-			apiClient := tempoUtil.NewClient("http://"+tempoQueryFrontend.Endpoint(3200), "")
+			apiClient := httpclient.New("http://"+tempoQueryFrontend.Endpoint(3200), "")
 
 			// query an in-memory trace
 			queryAndAssertTrace(t, apiClient, info)
@@ -400,7 +401,7 @@ func TestScalableSingleBinary(t *testing.T) {
 		callStatus(t, i)
 	}
 
-	apiClient1 := tempoUtil.NewClient("http://"+tempo1.Endpoint(3200), "")
+	apiClient1 := httpclient.New("http://"+tempo1.Endpoint(3200), "")
 
 	queryAndAssertTrace(t, apiClient1, info)
 
@@ -492,7 +493,7 @@ func assertEcho(t *testing.T, url string) {
 	defer res.Body.Close()
 }
 
-func queryAndAssertTrace(t *testing.T, client *tempoUtil.Client, info *tempoUtil.TraceInfo) {
+func queryAndAssertTrace(t *testing.T, client *httpclient.Client, info *tempoUtil.TraceInfo) {
 	resp, err := client.QueryTrace(info.HexID())
 	require.NoError(t, err)
 

--- a/integration/e2e/receivers_test.go
+++ b/integration/e2e/receivers_test.go
@@ -5,6 +5,7 @@ import (
 	crand "crypto/rand"
 	"testing"
 
+	"github.com/grafana/e2e"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter"
 	"github.com/stretchr/testify/assert"
@@ -22,8 +23,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
-	"github.com/grafana/e2e"
 	util "github.com/grafana/tempo/integration"
+	"github.com/grafana/tempo/pkg/httpclient"
 	tempoUtil "github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/pkg/util/test"
 )
@@ -157,7 +158,7 @@ func TestReceivers(t *testing.T) {
 			require.NoError(t, exporter.Shutdown(context.Background()))
 
 			// query for the trace
-			client := tempoUtil.NewClient("http://"+tempo.Endpoint(3200), tempoUtil.FakeTenantID)
+			client := httpclient.New("http://"+tempo.Endpoint(3200), tempoUtil.FakeTenantID)
 			trace, err := client.QueryTrace(tempoUtil.TraceIDToHexString(traceID))
 			require.NoError(t, err)
 

--- a/integration/e2e/serverless/serverless_test.go
+++ b/integration/e2e/serverless/serverless_test.go
@@ -11,6 +11,7 @@ import (
 	e2e_db "github.com/grafana/e2e/db"
 
 	util "github.com/grafana/tempo/integration"
+	"github.com/grafana/tempo/pkg/httpclient"
 	tempoUtil "github.com/grafana/tempo/pkg/util"
 )
 
@@ -96,7 +97,7 @@ func TestServerless(t *testing.T) {
 			}
 			require.NoError(t, tempoDistributor.WaitSumMetricsWithOptions(e2e.Equals(1), []string{`tempo_feature_enabled`}, e2e.WithLabelMatchers(features...), e2e.WaitMissingMetrics))
 
-			apiClient := tempoUtil.NewClient("http://"+tempoQueryFrontend.Endpoint(3200), "")
+			apiClient := httpclient.New("http://"+tempoQueryFrontend.Endpoint(3200), "")
 
 			// flush trace to backend
 			res, err := e2e.DoGet("http://" + tempoIngester1.Endpoint(3200) + "/flush")

--- a/integration/util.go
+++ b/integration/util.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/grafana/tempo/pkg/httpclient"
 	"github.com/grafana/tempo/pkg/tempopb"
 	tempoUtil "github.com/grafana/tempo/pkg/util"
 )
@@ -267,7 +268,7 @@ func NewSearchGRPCClient(endpoint string) (tempopb.StreamingQuerierClient, error
 	return tempopb.NewStreamingQuerierClient(clientConn), nil
 }
 
-func SearchAndAssertTrace(t *testing.T, client *tempoUtil.Client, info *tempoUtil.TraceInfo) {
+func SearchAndAssertTrace(t *testing.T, client *httpclient.Client, info *tempoUtil.TraceInfo) {
 	expected, err := info.ConstructTraceFromEpoch()
 	require.NoError(t, err)
 
@@ -288,7 +289,7 @@ func SearchAndAssertTrace(t *testing.T, client *tempoUtil.Client, info *tempoUti
 	require.True(t, traceIDInResults(t, info.HexID(), resp))
 }
 
-func SearchTraceQLAndAssertTrace(t *testing.T, client *tempoUtil.Client, info *tempoUtil.TraceInfo) {
+func SearchTraceQLAndAssertTrace(t *testing.T, client *httpclient.Client, info *tempoUtil.TraceInfo) {
 	expected, err := info.ConstructTraceFromEpoch()
 	require.NoError(t, err)
 
@@ -335,7 +336,7 @@ func SearchStreamAndAssertTrace(t *testing.T, client tempopb.StreamingQuerierCli
 
 // by passing a time range and using a query_ingesters_until/backend_after of 0 we can force the queriers
 // to look in the backend blocks
-func SearchAndAssertTraceBackend(t *testing.T, client *tempoUtil.Client, info *tempoUtil.TraceInfo, start int64, end int64) {
+func SearchAndAssertTraceBackend(t *testing.T, client *httpclient.Client, info *tempoUtil.TraceInfo, start int64, end int64) {
 	expected, err := info.ConstructTraceFromEpoch()
 	require.NoError(t, err)
 

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -1,4 +1,4 @@
-package util
+package httpclient
 
 import (
 	"fmt"
@@ -10,8 +10,10 @@ import (
 
 	"github.com/golang/protobuf/jsonpb" //nolint:all
 	"github.com/golang/protobuf/proto"  //nolint:all
-	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/klauspost/compress/gzhttp"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/grafana/tempo/pkg/util"
 )
 
 const (
@@ -31,7 +33,7 @@ type Client struct {
 	client  *http.Client
 }
 
-func NewClient(baseURL, orgID string) *Client {
+func New(baseURL, orgID string) *Client {
 	return &Client{
 		BaseURL: baseURL,
 		OrgID:   orgID,
@@ -39,8 +41,8 @@ func NewClient(baseURL, orgID string) *Client {
 	}
 }
 
-func NewClientWithCompression(baseURL, orgID string) *Client {
-	c := NewClient(baseURL, orgID)
+func NewWithCompression(baseURL, orgID string) *Client {
+	c := New(baseURL, orgID)
 	c.WithTransport(gzhttp.Transport(http.DefaultTransport))
 	return c
 }
@@ -154,7 +156,7 @@ func (c *Client) QueryTrace(id string) (*tempopb.Trace, error) {
 	resp, err := c.getFor(c.BaseURL+QueryTraceEndpoint+"/"+id, m)
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
-			return nil, ErrTraceNotFound
+			return nil, util.ErrTraceNotFound
 		}
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does**:
As suggested here https://github.com/grafana/tempo/pull/2543#discussion_r1256173221. Move Client out of pkg/util into its own dedicated package.

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [ ] ~~Tests updated~~
- [ ] ~~Documentation added~~
- [ ] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~