### PR TITLE
Extract configuration out of overrides.Limits into dedicated a Config struct

### DIFF
--- a/cmd/tempo/app/config.go
+++ b/cmd/tempo/app/config.go
@@ -7,6 +7,9 @@ import (
 
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/kv/memberlist"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/weaveworks/common/server"
+
 	"github.com/grafana/tempo/modules/compactor"
 	"github.com/grafana/tempo/modules/distributor"
 	"github.com/grafana/tempo/modules/frontend"
@@ -22,8 +25,6 @@ import (
 	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/tempodb"
 	"github.com/grafana/tempo/tempodb/encoding/common"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/weaveworks/common/server"
 )
 
 // Config is the root config for App.
@@ -47,7 +48,7 @@ type Config struct {
 	Ingester        ingester.Config         `yaml:"ingester,omitempty"`
 	Generator       generator.Config        `yaml:"metrics_generator,omitempty"`
 	StorageConfig   storage.Config          `yaml:"storage,omitempty"`
-	LimitsConfig    overrides.Limits        `yaml:"overrides,omitempty"`
+	OverridesConfig overrides.Config        `yaml:"overrides,omitempty"`
 	MemberlistKV    memberlist.KVConfig     `yaml:"memberlist,omitempty"`
 	UsageReport     usagestats.Config       `yaml:"usage_report,omitempty"`
 
@@ -115,7 +116,7 @@ func (c *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 	c.IngesterClient.GRPCClientConfig.GRPCCompression = "snappy"
 	flagext.DefaultValues(&c.GeneratorClient)
 	c.GeneratorClient.GRPCClientConfig.GRPCCompression = "snappy"
-	flagext.DefaultValues(&c.LimitsConfig)
+	flagext.DefaultValues(&c.OverridesConfig)
 
 	c.Distributor.RegisterFlagsAndApplyDefaults(util.PrefixConfig(prefix, "distributor"), f)
 	c.Ingester.RegisterFlagsAndApplyDefaults(util.PrefixConfig(prefix, "ingester"), f)

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -179,15 +179,15 @@ func (t *App) initReadRing(cfg ring.Config, name, key string) (*ring.Ring, error
 }
 
 func (t *App) initOverrides() (services.Service, error) {
-	overrides, err := overrides.NewOverrides(t.cfg.LimitsConfig)
+	overrides, err := overrides.NewOverrides(t.cfg.OverridesConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create overrides %w", err)
 	}
 	t.Overrides = overrides
 
-	prometheus.MustRegister(&t.cfg.LimitsConfig)
+	prometheus.MustRegister(&t.cfg.OverridesConfig.DefaultLimits)
 
-	if t.cfg.LimitsConfig.PerTenantOverrideConfig != "" {
+	if t.cfg.OverridesConfig.PerTenantOverrideConfig != "" {
 		prometheus.MustRegister(t.Overrides)
 	}
 

--- a/modules/compactor/compactor_test.go
+++ b/modules/compactor/compactor_test.go
@@ -4,19 +4,22 @@ import (
 	"math"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempopb"
 	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	"github.com/grafana/tempo/pkg/util/test"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCombineLimitsNotHit(t *testing.T) {
-	o, err := overrides.NewOverrides(overrides.Limits{
-		MaxBytesPerTrace: math.MaxInt,
+	o, err := overrides.NewOverrides(overrides.Config{
+		DefaultLimits: overrides.Limits{
+			MaxBytesPerTrace: math.MaxInt,
+		},
 	})
 	require.NoError(t, err)
 
@@ -45,8 +48,10 @@ func TestCombineLimitsNotHit(t *testing.T) {
 }
 
 func TestCombineLimitsHit(t *testing.T) {
-	o, err := overrides.NewOverrides(overrides.Limits{
-		MaxBytesPerTrace: 1,
+	o, err := overrides.NewOverrides(overrides.Config{
+		DefaultLimits: overrides.Limits{
+			MaxBytesPerTrace: 1,
+		},
 	})
 	require.NoError(t, err)
 
@@ -75,8 +80,10 @@ func TestCombineLimitsHit(t *testing.T) {
 }
 
 func TestCombineDoesntEnforceZero(t *testing.T) {
-	o, err := overrides.NewOverrides(overrides.Limits{
-		MaxBytesPerTrace: 0,
+	o, err := overrides.NewOverrides(overrides.Config{
+		DefaultLimits: overrides.Limits{
+			MaxBytesPerTrace: 0,
+		},
 	})
 	require.NoError(t, err)
 

--- a/modules/distributor/distributor_test.go
+++ b/modules/distributor/distributor_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -666,7 +667,7 @@ func TestDistributor(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("[%d](samples=%v)", i, tc.lines), func(t *testing.T) {
 			limits := overrides.Limits{}
-			flagext.DefaultValues(limits)
+			limits.RegisterFlags(&flag.FlagSet{})
 
 			// todo:  test limits
 			d := prepare(t, limits, nil, nil)

--- a/modules/distributor/distributor_test.go
+++ b/modules/distributor/distributor_test.go
@@ -864,8 +864,8 @@ func TestLogSpans(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("[%d] TestLogSpans LogReceivedTraces=%v LogReceivedSpansEnabled=%v filterByStatusError=%v includeAllAttributes=%v", i, tc.LogReceivedTraces, tc.LogReceivedSpansEnabled, tc.filterByStatusError, tc.includeAllAttributes), func(t *testing.T) {
-			limits := &overrides.Limits{}
-			flagext.DefaultValues(limits)
+			limits := overrides.Limits{}
+			flagext.DefaultValues(&limits)
 
 			buf := &bytes.Buffer{}
 			logger := kitlog.NewJSONLogger(kitlog.NewSyncWriter(buf))
@@ -977,7 +977,7 @@ func makeResourceSpans(serviceName string, ils []*v1.ScopeSpans, attributes ...*
 	return rs
 }
 
-func prepare(t *testing.T, limits *overrides.Limits, kvStore kv.Client, logger log.Logger) *Distributor {
+func prepare(t *testing.T, limits overrides.Limits, kvStore kv.Client, logger log.Logger) *Distributor {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
@@ -988,7 +988,7 @@ func prepare(t *testing.T, limits *overrides.Limits, kvStore kv.Client, logger l
 	)
 	flagext.DefaultValues(&clientConfig)
 
-	overrides, err := overrides.NewOverrides(*limits)
+	overrides, err := overrides.NewOverrides(overrides.Config{DefaultLimits: limits})
 	require.NoError(t, err)
 
 	// Mock the ingesters ring

--- a/modules/distributor/distributor_test.go
+++ b/modules/distributor/distributor_test.go
@@ -665,7 +665,7 @@ func TestDistributor(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("[%d](samples=%v)", i, tc.lines), func(t *testing.T) {
-			limits := &overrides.Limits{}
+			limits := overrides.Limits{}
 			flagext.DefaultValues(limits)
 
 			// todo:  test limits

--- a/modules/distributor/forwarder_test.go
+++ b/modules/distributor/forwarder_test.go
@@ -20,7 +20,7 @@ import (
 const tenantID = "tenant-id"
 
 func TestForwarder(t *testing.T) {
-	oCfg := overrides.Limits{}
+	oCfg := overrides.Config{}
 	oCfg.RegisterFlags(&flag.FlagSet{})
 
 	id, err := util.HexStringToTraceID("1234567890abcdef")
@@ -60,9 +60,9 @@ func TestForwarder(t *testing.T) {
 }
 
 func TestForwarder_shutdown(t *testing.T) {
-	oCfg := overrides.Limits{}
+	oCfg := overrides.Config{}
 	oCfg.RegisterFlags(&flag.FlagSet{})
-	oCfg.MetricsGeneratorForwarderQueueSize = 200
+	oCfg.DefaultLimits.MetricsGeneratorForwarderQueueSize = 200
 
 	id, err := util.HexStringToTraceID("1234567890abcdef")
 	require.NoError(t, err)

--- a/modules/distributor/ingestion_rate_strategy_test.go
+++ b/modules/distributor/ingestion_rate_strategy_test.go
@@ -51,7 +51,9 @@ func TestIngestionRateStrategy(t *testing.T) {
 			var strategy limiter.RateLimiterStrategy
 
 			// Init limits overrides
-			o, err := overrides.NewOverrides(testData.limits)
+			o, err := overrides.NewOverrides(overrides.Config{
+				DefaultLimits: testData.limits,
+			})
 			require.NoError(t, err)
 
 			// Instance the strategy

--- a/modules/frontend/search_streaming_test.go
+++ b/modules/frontend/search_streaming_test.go
@@ -11,14 +11,15 @@ import (
 	"github.com/go-kit/log"
 	"github.com/golang/protobuf/jsonpb" //nolint:all //deprecated
 	"github.com/google/uuid"
-	"github.com/grafana/tempo/modules/overrides"
-	"github.com/grafana/tempo/pkg/tempopb"
-	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/user"
 	"go.uber.org/atomic"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/grafana/tempo/modules/overrides"
+	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/grafana/tempo/tempodb/backend"
 )
 
 type mockStreamingServer struct {
@@ -208,7 +209,7 @@ func TestStreamingSearchHandlerFailsDueToError(t *testing.T) {
 func testHandler(t *testing.T, next http.RoundTripper) streamingSearchHandler {
 	t.Helper()
 
-	o, err := overrides.NewOverrides(overrides.Limits{})
+	o, err := overrides.NewOverrides(overrides.Config{})
 	require.NoError(t, err)
 
 	handler := newSearchStreamingHandler(Config{

--- a/modules/frontend/searchsharding_test.go
+++ b/modules/frontend/searchsharding_test.go
@@ -670,7 +670,7 @@ func TestSearchSharderRoundTrip(t *testing.T) {
 				}, nil
 			})
 
-			o, err := overrides.NewOverrides(overrides.Limits{})
+			o, err := overrides.NewOverrides(overrides.Config{})
 			require.NoError(t, err)
 
 			sharder := newSearchSharder(&mockReader{
@@ -733,7 +733,7 @@ func TestTotalJobsIncludesIngester(t *testing.T) {
 		}, nil
 	})
 
-	o, err := overrides.NewOverrides(overrides.Limits{})
+	o, err := overrides.NewOverrides(overrides.Config{})
 	require.NoError(t, err)
 
 	now := time.Now().Add(-10 * time.Minute).Unix()
@@ -780,7 +780,7 @@ func TestSearchSharderRoundTripBadRequest(t *testing.T) {
 		return nil, nil
 	})
 
-	o, err := overrides.NewOverrides(overrides.Limits{})
+	o, err := overrides.NewOverrides(overrides.Config{})
 	require.NoError(t, err)
 
 	sharder := newSearchSharder(&mockReader{}, o, SearchSharderConfig{
@@ -807,8 +807,10 @@ func TestSearchSharderRoundTripBadRequest(t *testing.T) {
 	testBadRequest(t, resp, err, "invalid start: strconv.ParseInt: parsing \"asdf\": invalid syntax")
 
 	// test max duration error with overrides
-	o, err = overrides.NewOverrides(overrides.Limits{
-		MaxSearchDuration: model.Duration(time.Minute),
+	o, err = overrides.NewOverrides(overrides.Config{
+		DefaultLimits: overrides.Limits{
+			MaxSearchDuration: model.Duration(time.Minute),
+		},
 	})
 	require.NoError(t, err)
 
@@ -842,7 +844,7 @@ func TestAdjustLimit(t *testing.T) {
 
 func TestMaxDuration(t *testing.T) {
 	//
-	o, err := overrides.NewOverrides(overrides.Limits{})
+	o, err := overrides.NewOverrides(overrides.Config{})
 	require.NoError(t, err)
 	sharder := searchSharder{
 		cfg: SearchSharderConfig{
@@ -853,8 +855,10 @@ func TestMaxDuration(t *testing.T) {
 	actual := sharder.maxDuration("test")
 	assert.Equal(t, 5*time.Minute, actual)
 
-	o, err = overrides.NewOverrides(overrides.Limits{
-		MaxSearchDuration: model.Duration(10 * time.Minute),
+	o, err = overrides.NewOverrides(overrides.Config{
+		DefaultLimits: overrides.Limits{
+			MaxSearchDuration: model.Duration(10 * time.Minute),
+		},
 	})
 	require.NoError(t, err)
 	sharder = searchSharder{
@@ -924,7 +928,7 @@ func TestSubRequestsCancelled(t *testing.T) {
 		return httptest.NewRecorder().Result(), nil
 	})
 
-	o, err := overrides.NewOverrides(overrides.Limits{})
+	o, err := overrides.NewOverrides(overrides.Config{})
 	require.NoError(t, err)
 
 	sharder := newSearchSharder(&mockReader{
@@ -1026,7 +1030,7 @@ func benchmarkSearchSharderRoundTrip(b *testing.B, s int32) {
 		}, nil
 	})
 
-	o, err := overrides.NewOverrides(overrides.Limits{})
+	o, err := overrides.NewOverrides(overrides.Config{})
 	require.NoError(b, err)
 
 	totalMetas := 10000

--- a/modules/ingester/ingester_test.go
+++ b/modules/ingester/ingester_test.go
@@ -341,7 +341,7 @@ func TestFlush(t *testing.T) {
 
 func defaultIngesterModule(t testing.TB, tmpDir string) *Ingester {
 	ingesterConfig := defaultIngesterTestConfig()
-	limits, err := overrides.NewOverrides(defaultLimitsTestConfig())
+	limits, err := overrides.NewOverrides(defaultOverridesConfig())
 	require.NoError(t, err, "unexpected error creating overrides")
 
 	s, err := storage.NewStore(storage.Config{
@@ -430,10 +430,10 @@ func defaultIngesterTestConfig() Config {
 	return cfg
 }
 
-func defaultLimitsTestConfig() overrides.Limits {
-	limits := overrides.Limits{}
-	flagext.DefaultValues(&limits)
-	return limits
+func defaultOverridesConfig() overrides.Config {
+	config := overrides.Config{}
+	flagext.DefaultValues(&config)
+	return config
 }
 
 func pushBatchV2(t testing.TB, i *Ingester, batch *v1.ResourceSpans, id []byte) {

--- a/modules/ingester/instance_search_test.go
+++ b/modules/ingester/instance_search_test.go
@@ -360,8 +360,10 @@ func TestInstanceSearchTagsSpecialCases(t *testing.T) {
 // TestInstanceSearchMaxBytesPerTagValuesQueryReturnsPartial confirms that SearchTagValues returns
 // partial results if the bytes of the found tag value exceeds the MaxBytesPerTagValuesQuery limit
 func TestInstanceSearchMaxBytesPerTagValuesQueryReturnsPartial(t *testing.T) {
-	limits, err := overrides.NewOverrides(overrides.Limits{
-		MaxBytesPerTagValuesQuery: 10,
+	limits, err := overrides.NewOverrides(overrides.Config{
+		DefaultLimits: overrides.Limits{
+			MaxBytesPerTagValuesQuery: 10,
+		},
 	})
 	assert.NoError(t, err, "unexpected error creating limits")
 	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
@@ -387,8 +389,10 @@ func TestInstanceSearchMaxBytesPerTagValuesQueryReturnsPartial(t *testing.T) {
 // TestInstanceSearchMaxBytesPerTagValuesQueryReturnsPartial confirms that SearchTagValues returns
 // partial results if the bytes of the found tag value exceeds the MaxBytesPerTagValuesQuery limit
 func TestInstanceSearchMaxBlocksPerTagValuesQueryReturnsPartial(t *testing.T) {
-	limits, err := overrides.NewOverrides(overrides.Limits{
-		MaxBlocksPerTagValuesQuery: 1,
+	limits, err := overrides.NewOverrides(overrides.Config{
+		DefaultLimits: overrides.Limits{
+			MaxBlocksPerTagValuesQuery: 1,
+		},
 	})
 	assert.NoError(t, err, "unexpected error creating limits")
 	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
@@ -423,7 +427,7 @@ func TestInstanceSearchMaxBlocksPerTagValuesQueryReturnsPartial(t *testing.T) {
 	assert.Equal(t, 100, len(respV2.TagValues))
 
 	// Now test with unlimited blocks
-	limits, err = overrides.NewOverrides(overrides.Limits{})
+	limits, err = overrides.NewOverrides(overrides.Config{})
 	assert.NoError(t, err, "unexpected error creating limits")
 
 	i.limiter = NewLimiter(limits, &ringCountMock{count: 1}, 1)

--- a/modules/ingester/instance_test.go
+++ b/modules/ingester/instance_test.go
@@ -210,9 +210,11 @@ func TestInstanceDoesNotRace(t *testing.T) {
 }
 
 func TestInstanceLimits(t *testing.T) {
-	limits, err := overrides.NewOverrides(overrides.Limits{
-		MaxBytesPerTrace:      1000,
-		MaxLocalTracesPerUser: 4,
+	limits, err := overrides.NewOverrides(overrides.Config{
+		DefaultLimits: overrides.Limits{
+			MaxBytesPerTrace:      1000,
+			MaxLocalTracesPerUser: 4,
+		},
 	})
 	require.NoError(t, err, "unexpected error creating limits")
 	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
@@ -503,8 +505,10 @@ func TestInstanceFailsLargeTracesEvenAfterFlushing(t *testing.T) {
 	maxTraceBytes := 1000
 	id := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 
-	limits, err := overrides.NewOverrides(overrides.Limits{
-		MaxBytesPerTrace: maxTraceBytes,
+	limits, err := overrides.NewOverrides(overrides.Config{
+		DefaultLimits: overrides.Limits{
+			MaxBytesPerTrace: maxTraceBytes,
+		},
 	})
 	require.NoError(t, err)
 	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -1,0 +1,23 @@
+package overrides
+
+import (
+	"flag"
+
+	"github.com/prometheus/common/model"
+)
+
+type Config struct {
+	DefaultLimits Limits `yaml:",inline" json:",inline"`
+
+	PerTenantOverrideConfig string         `yaml:"per_tenant_override_config" json:"per_tenant_override_config"`
+	PerTenantOverridePeriod model.Duration `yaml:"per_tenant_override_period" json:"per_tenant_override_period"`
+}
+
+// RegisterFlags adds the flags required to config this to the given FlagSet
+func (c *Config) RegisterFlags(f *flag.FlagSet) {
+	c.DefaultLimits.RegisterFlags(f)
+
+	f.StringVar(&c.PerTenantOverrideConfig, "config.per-user-override-config", "", "File name of per-user overrides.")
+	_ = c.PerTenantOverridePeriod.Set("10s")
+	f.Var(&c.PerTenantOverridePeriod, "config.per-user-override-period", "Period with this to reload the overrides.")
+}

--- a/modules/overrides/config_test.go
+++ b/modules/overrides/config_test.go
@@ -17,7 +17,33 @@ per_tenant_override_config: /overrides/overrides.yaml
 `
 
 	cfg := Config{}
-	assert.NoError(t, yaml.Unmarshal([]byte(rawYaml), &cfg))
+	assert.NoError(t, yaml.UnmarshalStrict([]byte(rawYaml), &cfg))
+
+	expected := Config{
+		DefaultLimits: Limits{
+			MaxBytesPerTrace:        100,
+			MaxLocalTracesPerUser:   1,
+			IngestionRateLimitBytes: 500,
+			IngestionBurstSizeBytes: 500,
+		},
+		PerTenantOverrideConfig: "/overrides/overrides.yaml",
+		PerTenantOverridePeriod: 0,
+	}
+	assert.Equal(t, expected, cfg)
+}
+
+func TestConfig_defaultLimits(t *testing.T) {
+	rawYaml := `
+default_limits:
+  max_bytes_per_trace: 100
+  max_traces_per_user: 1
+  ingestion_rate_limit_bytes: 500
+  ingestion_burst_size_bytes: 500
+per_tenant_override_config: /overrides/overrides.yaml
+`
+
+	cfg := Config{}
+	assert.NoError(t, yaml.UnmarshalStrict([]byte(rawYaml), &cfg))
 
 	expected := Config{
 		DefaultLimits: Limits{

--- a/modules/overrides/config_test.go
+++ b/modules/overrides/config_test.go
@@ -1,0 +1,33 @@
+package overrides
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+)
+
+func TestConfig_inlineLimits(t *testing.T) {
+	rawYaml := `
+max_bytes_per_trace: 100
+max_traces_per_user: 1
+ingestion_rate_limit_bytes: 500
+ingestion_burst_size_bytes: 500
+per_tenant_override_config: /overrides/overrides.yaml
+`
+
+	cfg := Config{}
+	assert.NoError(t, yaml.Unmarshal([]byte(rawYaml), &cfg))
+
+	expected := Config{
+		DefaultLimits: Limits{
+			MaxBytesPerTrace:        100,
+			MaxLocalTracesPerUser:   1,
+			IngestionRateLimitBytes: 500,
+			IngestionBurstSizeBytes: 500,
+		},
+		PerTenantOverrideConfig: "/overrides/overrides.yaml",
+		PerTenantOverridePeriod: 0,
+	}
+	assert.Equal(t, expected, cfg)
+}

--- a/modules/overrides/limits.go
+++ b/modules/overrides/limits.go
@@ -4,10 +4,11 @@ import (
 	"flag"
 	"time"
 
-	"github.com/grafana/tempo/pkg/sharedconfig"
-	filterconfig "github.com/grafana/tempo/pkg/spanfilter/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/tempo/pkg/sharedconfig"
+	filterconfig "github.com/grafana/tempo/pkg/spanfilter/config"
 )
 
 const (
@@ -97,10 +98,6 @@ type Limits struct {
 	// MaxBytesPerTrace is enforced in the Ingester, Compactor, Querier (Search) and Serverless (Search). It
 	//  is not used when doing a trace by id lookup.
 	MaxBytesPerTrace int `yaml:"max_bytes_per_trace" json:"max_bytes_per_trace"`
-
-	// Configuration for overrides, convenient if it goes here.
-	PerTenantOverrideConfig string         `yaml:"per_tenant_override_config" json:"per_tenant_override_config"`
-	PerTenantOverridePeriod model.Duration `yaml:"per_tenant_override_period" json:"per_tenant_override_period"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -118,10 +115,6 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	// Querier limits
 	f.IntVar(&l.MaxBytesPerTagValuesQuery, "querier.max-bytes-per-tag-values-query", 50e5, "Maximum size of response for a tag-values query. Used mainly to limit large the number of values associated with a particular tag")
 	f.IntVar(&l.MaxBlocksPerTagValuesQuery, "querier.max-blocks-per-tag-values-query", 0, "Maximum number of blocks to query for a tag-values query. 0 to disable.")
-
-	f.StringVar(&l.PerTenantOverrideConfig, "limits.per-user-override-config", "", "File name of per-user overrides.")
-	_ = l.PerTenantOverridePeriod.Set("10s")
-	f.Var(&l.PerTenantOverridePeriod, "limits.per-user-override-period", "Period with this to reload the overrides.")
 }
 
 func (l *Limits) Describe(ch chan<- *prometheus.Desc) {

--- a/modules/querier/querier_test.go
+++ b/modules/querier/querier_test.go
@@ -8,13 +8,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/atomic"
+	"github.com/weaveworks/common/user"
+
 	generator_client "github.com/grafana/tempo/modules/generator/client"
 	ingester_client "github.com/grafana/tempo/modules/ingester/client"
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/pkg/tempopb"
-	"github.com/stretchr/testify/require"
-	"github.com/uber-go/atomic"
-	"github.com/weaveworks/common/user"
 )
 
 func TestQuerierUsesSearchExternalEndpoint(t *testing.T) {
@@ -65,7 +66,7 @@ func TestQuerierUsesSearchExternalEndpoint(t *testing.T) {
 	for _, tc := range tests {
 		numExternalRequests.Store(0)
 
-		o, err := overrides.NewOverrides(overrides.Limits{})
+		o, err := overrides.NewOverrides(overrides.Config{})
 		require.NoError(t, err)
 
 		q, err := New(tc.cfg, ingester_client.Config{}, nil, generator_client.Config{}, nil, nil, o)
@@ -82,7 +83,7 @@ func TestQuerierUsesSearchExternalEndpoint(t *testing.T) {
 }
 
 func TestVirtualTagsDoesntHitBackend(t *testing.T) {
-	o, err := overrides.NewOverrides(overrides.Limits{})
+	o, err := overrides.NewOverrides(overrides.Config{})
 	require.NoError(t, err)
 
 	q, err := New(Config{}, ingester_client.Config{}, nil, generator_client.Config{}, nil, nil, o)


### PR DESCRIPTION
**What this PR does**:
While working on https://github.com/grafana/tempo/pull/2543 we noticed the `Limits` struct has a mixed responsibility:
- it contains all the limits (we have more than 30 now!)
- it contains configuration for the overrides module itself

When it is used in the top-level `App` struct it contains default values for the limits and configuration for per-tenant overrides. But when `Limits` is used by the runtime config manager it contains per tenant values of the limits.

The dual purpose of `Limits` is awkward and confusing.

This PR addresses this by creating a `Config` struct that is explicitly intended to configure the overrides module, ensuring the `Limits` struct can focus on holding limits only.

Currently default limits are configured as follows:

```yaml
overrides:
  max_bytes_per_trace: 100
  max_traces_per_user: 1
  ingestion_rate_limit_bytes: 500
  ingestion_burst_size_bytes: 500
  per_tenant_override_config: /overrides/overrides.yaml
```

This remains valid.

From now on you can also specify limits under the `default_limits` key which is more explicit:

```yaml
overrides:
  default_limits:
    max_bytes_per_trace: 100
    max_traces_per_user: 1
    ingestion_rate_limit_bytes: 500
    ingestion_burst_size_bytes: 500
  per_tenant_override_config: /overrides/overrides.yaml
  user_configurable_overrides:
    enabled: false
```

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`