### PR TITLE
Delay logging config warnings until the logger has been initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ To make use of filtering, configure `autocomplete_filtering_enabled`.
 * [BUGFIX] Fixes issue where matches and other spanset level attributes were not persisted to the TraceQL results. [#2490](https://github.com/grafana/tempo/pull/2490) 
 * [BUGFIX] Fixes issue where ingester search could occasionally fail with file does not exist error [#2534](https://github.com/grafana/tempo/issues/2534) (@mdisibio)
 * [BUGFIX] Tempo failed to find meta.json path after adding prefix in S3/GCS/Azure configuration. [#2585](https://github.com/grafana/tempo/issues/2585) (@WildCatFish)
+* [BUGFIX] Delay logging config warnings until the logger has been initialized [#2645](https://github.com/grafana/tempo/pull/2645) (@kvrhdn)
 * [CHANGE] **Breaking Change** Rename s3.insecure_skip_verify [#2407](https://github.com/grafana/tempo/pull/2407) (@zalegrala)
 ```yaml
 storage:


### PR DESCRIPTION
**What this PR does**:
While adding config warnings in https://github.com/grafana/tempo/pull/2543 I noticed the warnings never got printed. Because we print the warnings while loading the configuration, we log them using the default NoopLogger...

This PR holds on to the warnings until we initialized the logger and can correctly log them. 

End result:
```
level=warn ts=2023-07-12T16:30:04.59588Z caller=main.go:78 msg="-- CONFIGURATION WARNINGS --"
level=warn ts=2023-07-12T16:30:04.595906Z caller=main.go:78 msg="c.Distributor.LogReceivedTraces is deprecated. The new flag is c.Distributor.log_received_spans.enabled"
level=warn ts=2023-07-12T16:30:04.595911Z caller=main.go:78 msg="Trace storage conflict with user-configuirable overrides storage"
level=info ts=2023-07-12T16:30:04.595916Z caller=main.go:222 msg="initialising OpenTracing tracer"
...
```

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [ ] ~~Tests updated~~
- [ ] ~~Documentation added~~
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`