### PR TITLE
Introduce constants for the backend types

### DIFF
--- a/cmd/tempo-cli/main.go
+++ b/cmd/tempo-cli/main.go
@@ -85,7 +85,7 @@ func main() {
 	ctx := kong.Parse(&cli,
 		kong.UsageOnError(),
 		kong.ConfigureHelp(kong.HelpOptions{
-			//Compact: true,
+			// Compact: true,
 		}),
 	)
 	err := ctx.Run(&cli.globalOptions)
@@ -132,13 +132,13 @@ func loadBackend(b *backendOptions, g *globalOptions) (backend.Reader, backend.W
 	var c backend.Compactor
 
 	switch cfg.StorageConfig.Trace.Backend {
-	case "local":
+	case backend.Local:
 		r, w, c, err = local.New(cfg.StorageConfig.Trace.Local)
-	case "gcs":
+	case backend.GCS:
 		r, w, c, err = gcs.New(cfg.StorageConfig.Trace.GCS)
-	case "s3":
+	case backend.S3:
 		r, w, c, err = s3.New(cfg.StorageConfig.Trace.S3)
-	case "azure":
+	case backend.Azure:
 		r, w, c, err = azure.New(cfg.StorageConfig.Trace.Azure)
 	default:
 		err = fmt.Errorf("unknown backend %s", cfg.StorageConfig.Trace.Backend)

--- a/cmd/tempo-serverless/handler.go
+++ b/cmd/tempo-serverless/handler.go
@@ -146,13 +146,13 @@ func loadBackend() (backend.Reader, *tempodb.Config, error) {
 		// standard Tempo components to fail during startup. If permissions are not correct this Lambda
 		// will fail instantly anyway and in a heavy query environment the extra calls will start to add up.
 		switch cfg.Backend {
-		case "local":
+		case backend.Local:
 			err = fmt.Errorf("local backend not supported for serverless functions")
-		case "gcs":
+		case backend.GCS:
 			r, _, _, err = gcs.NewNoConfirm(cfg.GCS)
-		case "s3":
+		case backend.S3:
 			r, _, _, err = s3.NewNoConfirm(cfg.S3)
-		case "azure":
+		case backend.Azure:
 			r, _, _, err = azure.NewNoConfirm(cfg.Azure)
 		default:
 			err = fmt.Errorf("unknown backend %s", cfg.Backend)

--- a/cmd/tempo-serverless/handler_test.go
+++ b/cmd/tempo-serverless/handler_test.go
@@ -4,13 +4,15 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/grafana/tempo/tempodb/backend"
 )
 
 func TestLoadConfig(t *testing.T) {
 	os.Setenv("TEMPO_GCS_BUCKET_NAME", "some-random-gcs-bucket")
 	os.Setenv("TEMPO_GCS_CHUNK_BUFFER_SIZE", "10")
 	os.Setenv("TEMPO_GCS_HEDGE_REQUESTS_AT", "400ms")
-	os.Setenv("TEMPO_BACKEND", "gcs")
+	os.Setenv("TEMPO_BACKEND", backend.GCS)
 
 	// purposefully not using testfiy to reduce dependencies and keep the serverless packages small
 	cfg, err := loadConfig()
@@ -18,7 +20,7 @@ func TestLoadConfig(t *testing.T) {
 		t.Error("failed to load config:", err)
 		return
 	}
-	if cfg.Backend != "gcs" {
+	if cfg.Backend != backend.GCS {
 		t.Error("backend should be gcs", cfg.Backend)
 	}
 	if cfg.GCS.BucketName != "some-random-gcs-bucket" {
@@ -35,7 +37,7 @@ func TestLoadConfig(t *testing.T) {
 func TestLoadConfigS3(t *testing.T) {
 	os.Setenv("TEMPO_S3_BUCKET", "tempo")
 	os.Setenv("TEMPO_S3_ENDPOINT", "glerg")
-	os.Setenv("TEMPO_BACKEND", "s3")
+	os.Setenv("TEMPO_BACKEND", backend.S3)
 	os.Setenv("TEMPO_S3_ACCESS_KEY", "access")
 	os.Setenv("TEMPO_S3_SECRET_KEY", "secret")
 
@@ -44,7 +46,7 @@ func TestLoadConfigS3(t *testing.T) {
 		t.Error("failed to load config", err)
 		return
 	}
-	if cfg.Backend != "s3" {
+	if cfg.Backend != backend.S3 {
 		t.Error("backend should be s3", cfg.Backend)
 	}
 	if cfg.S3.Bucket != "tempo" {
@@ -62,7 +64,7 @@ func TestLoadConfigS3(t *testing.T) {
 }
 
 func TestLoadConfigAzure(t *testing.T) {
-	os.Setenv("TEMPO_BACKEND", "azure")
+	os.Setenv("TEMPO_BACKEND", backend.Azure)
 	os.Setenv("TEMPO_AZURE_MAX_BUFFERS", "3")
 
 	cfg, err := loadConfig()
@@ -70,7 +72,7 @@ func TestLoadConfigAzure(t *testing.T) {
 		t.Error("failed to load config", err)
 		return
 	}
-	if cfg.Backend != "azure" {
+	if cfg.Backend != backend.Azure {
 		t.Error("backend should be azure", cfg.Backend)
 	}
 	if cfg.Azure.MaxBuffers != 3 {

--- a/cmd/tempo/app/config.go
+++ b/cmd/tempo/app/config.go
@@ -7,6 +7,9 @@ import (
 
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/kv/memberlist"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/weaveworks/common/server"
+
 	"github.com/grafana/tempo/modules/compactor"
 	"github.com/grafana/tempo/modules/distributor"
 	"github.com/grafana/tempo/modules/frontend"
@@ -21,9 +24,8 @@ import (
 	"github.com/grafana/tempo/pkg/usagestats"
 	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/tempodb"
+	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/weaveworks/common/server"
 )
 
 // Config is the root config for App.
@@ -147,7 +149,7 @@ func (c *Config) CheckConfig() []ConfigWarning {
 		warnings = append(warnings, warnRetentionConcurrency)
 	}
 
-	if c.StorageConfig.Trace.Backend == "s3" && c.Compactor.Compactor.FlushSizeBytes < 5242880 {
+	if c.StorageConfig.Trace.Backend == backend.S3 && c.Compactor.Compactor.FlushSizeBytes < 5242880 {
 		warnings = append(warnings, warnStorageTraceBackendS3)
 	}
 
@@ -159,7 +161,7 @@ func (c *Config) CheckConfig() []ConfigWarning {
 		warnings = append(warnings, warnLogReceivedTraces)
 	}
 
-	if c.StorageConfig.Trace.Backend == "local" && c.Target != SingleBinary {
+	if c.StorageConfig.Trace.Backend == backend.Local && c.Target != SingleBinary {
 		warnings = append(warnings, warnStorageTraceBackendLocal)
 	}
 

--- a/cmd/tempo/app/config_test.go
+++ b/cmd/tempo/app/config_test.go
@@ -4,13 +4,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/grafana/tempo/modules/distributor"
 	"github.com/grafana/tempo/modules/storage"
 	"github.com/grafana/tempo/tempodb"
+	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 	v2 "github.com/grafana/tempo/tempodb/encoding/v2"
 	"github.com/grafana/tempo/tempodb/encoding/vparquet2"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestConfig_CheckConfig(t *testing.T) {
@@ -30,7 +32,7 @@ func TestConfig_CheckConfig(t *testing.T) {
 				Target: MetricsGenerator,
 				StorageConfig: storage.Config{
 					Trace: tempodb.Config{
-						Backend:       "s3",
+						Backend:       backend.S3,
 						BlocklistPoll: time.Minute,
 						Block: &common.BlockConfig{
 							Version: "v2",
@@ -55,7 +57,7 @@ func TestConfig_CheckConfig(t *testing.T) {
 			config: func() *Config {
 				cfg := newDefaultConfig()
 				cfg.StorageConfig.Trace = tempodb.Config{
-					Backend:                  "local",
+					Backend:                  backend.Local,
 					BlocklistPollConcurrency: 1,
 					Block: &common.BlockConfig{
 						Version: "v2",

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -451,13 +451,13 @@ func (t *App) initUsageReport() (services.Service, error) {
 	var writer backend.RawWriter
 
 	switch t.cfg.StorageConfig.Trace.Backend {
-	case "local":
+	case backend.Local:
 		reader, writer, _, err = local.New(t.cfg.StorageConfig.Trace.Local)
-	case "gcs":
+	case backend.GCS:
 		reader, writer, _, err = gcs.New(t.cfg.StorageConfig.Trace.GCS)
-	case "s3":
+	case backend.S3:
 		reader, writer, _, err = s3.New(t.cfg.StorageConfig.Trace.S3)
-	case "azure":
+	case backend.Azure:
 		reader, writer, _, err = azure.New(t.cfg.StorageConfig.Trace.Azure)
 	default:
 		err = fmt.Errorf("unknown backend %s", t.cfg.StorageConfig.Trace.Backend)

--- a/integration/e2e/backend/backend.go
+++ b/integration/e2e/backend/backend.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/grafana/tempo/cmd/tempo/app"
 	util "github.com/grafana/tempo/integration"
+	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/azure"
 )
 
@@ -32,7 +33,7 @@ func parsePort(endpoint string) (int, error) {
 func New(scenario *e2e.Scenario, cfg app.Config) (*e2e.HTTPService, error) {
 	var backendService *e2e.HTTPService
 	switch cfg.StorageConfig.Trace.Backend {
-	case "s3":
+	case backend.S3:
 		port, err := parsePort(cfg.StorageConfig.Trace.S3.Endpoint)
 		if err != nil {
 			return nil, err
@@ -45,7 +46,7 @@ func New(scenario *e2e.Scenario, cfg app.Config) (*e2e.HTTPService, error) {
 		if err != nil {
 			return nil, err
 		}
-	case "azure":
+	case backend.Azure:
 		port, err := parsePort(cfg.StorageConfig.Trace.Azure.Endpoint)
 		if err != nil {
 			return nil, err
@@ -60,7 +61,7 @@ func New(scenario *e2e.Scenario, cfg app.Config) (*e2e.HTTPService, error) {
 		if err != nil {
 			return nil, err
 		}
-	case "gcs":
+	case backend.GCS:
 		port, err := parsePort(cfg.StorageConfig.Trace.GCS.Endpoint)
 		if err != nil {
 			return nil, err
@@ -83,7 +84,7 @@ func NewAzurite(port int) *e2e.HTTPService {
 		"azurite",
 		azuriteImage, // Create the the azurite container
 		e2e.NewCommandWithoutEntrypoint("sh", "-c", "azurite -l /data --blobHost 0.0.0.0"),
-		e2e.NewHTTPReadinessProbe(port, "/devstoreaccount1?comp=list", 403, 403), //If we get 403 the Azurite is ready
+		e2e.NewHTTPReadinessProbe(port, "/devstoreaccount1?comp=list", 403, 403), // If we get 403 the Azurite is ready
 		port, // blob storage port
 	)
 

--- a/integration/e2e/serverless/serverless_test.go
+++ b/integration/e2e/serverless/serverless_test.go
@@ -13,6 +13,7 @@ import (
 	util "github.com/grafana/tempo/integration"
 	"github.com/grafana/tempo/pkg/httpclient"
 	tempoUtil "github.com/grafana/tempo/pkg/util"
+	"github.com/grafana/tempo/tempodb/backend"
 )
 
 const (
@@ -139,7 +140,7 @@ func newTempoServerlessGCR() *e2e.HTTPService {
 		"TEMPO_S3_ACCESS_KEY": e2e_db.MinioAccessKey,
 		"TEMPO_S3_SECRET_KEY": e2e_db.MinioSecretKey,
 		"TEMPO_S3_INSECURE":   "true",
-		"TEMPO_BACKEND":       "s3",
+		"TEMPO_BACKEND":       backend.S3,
 	})
 
 	s.SetBackoff(util.TempoBackoff())
@@ -162,7 +163,7 @@ func newTempoServerlessLambda() *e2e.HTTPService {
 		"TEMPO_S3_ACCESS_KEY": e2e_db.MinioAccessKey,
 		"TEMPO_S3_SECRET_KEY": e2e_db.MinioSecretKey,
 		"TEMPO_S3_INSECURE":   "true",
-		"TEMPO_BACKEND":       "s3",
+		"TEMPO_BACKEND":       backend.S3,
 	})
 
 	s.SetBackoff(util.TempoBackoff())

--- a/modules/ingester/ingester_test.go
+++ b/modules/ingester/ingester_test.go
@@ -346,7 +346,7 @@ func defaultIngesterModule(t testing.TB, tmpDir string) *Ingester {
 
 	s, err := storage.NewStore(storage.Config{
 		Trace: tempodb.Config{
-			Backend: "local",
+			Backend: backend.Local,
 			Local: &local.Config{
 				Path: tmpDir,
 			},

--- a/tempodb/backend/backend.go
+++ b/tempodb/backend/backend.go
@@ -8,6 +8,13 @@ import (
 	"github.com/google/uuid"
 )
 
+const (
+	Local = "local"
+	GCS   = "gcs"
+	S3    = "s3"
+	Azure = "azure"
+)
+
 var (
 	ErrDoesNotExist  = fmt.Errorf("does not exist")
 	ErrEmptyTenantID = fmt.Errorf("empty tenant id")

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -72,7 +72,7 @@ func testCompactionRoundtrip(t *testing.T, targetBlockVersion string) {
 	tempDir := t.TempDir()
 
 	r, w, c, err := New(&Config{
-		Backend: "local",
+		Backend: backend.Local,
 		Pool: &pool.Config{
 			MaxWorkers: 10,
 			QueueDepth: 100,
@@ -218,7 +218,7 @@ func testSameIDCompaction(t *testing.T, targetBlockVersion string) {
 	tempDir := t.TempDir()
 
 	r, w, c, err := New(&Config{
-		Backend: "local",
+		Backend: backend.Local,
 		Pool: &pool.Config{
 			MaxWorkers: 10,
 			QueueDepth: 100,
@@ -362,7 +362,7 @@ func TestCompactionUpdatesBlocklist(t *testing.T) {
 	tempDir := t.TempDir()
 
 	r, w, c, err := New(&Config{
-		Backend: "local",
+		Backend: backend.Local,
 		Pool: &pool.Config{
 			MaxWorkers: 10,
 			QueueDepth: 100,
@@ -433,7 +433,7 @@ func TestCompactionMetrics(t *testing.T) {
 	tempDir := t.TempDir()
 
 	r, w, c, err := New(&Config{
-		Backend: "local",
+		Backend: backend.Local,
 		Pool: &pool.Config{
 			MaxWorkers: 10,
 			QueueDepth: 100,
@@ -507,7 +507,7 @@ func TestCompactionIteratesThroughTenants(t *testing.T) {
 	tempDir := t.TempDir()
 
 	r, w, c, err := New(&Config{
-		Backend: "local",
+		Backend: backend.Local,
 		Pool: &pool.Config{
 			MaxWorkers: 10,
 			QueueDepth: 100,
@@ -578,7 +578,7 @@ func testCompactionHonorsBlockStartEndTimes(t *testing.T, targetBlockVersion str
 	tempDir := t.TempDir()
 
 	r, w, c, err := New(&Config{
-		Backend: "local",
+		Backend: backend.Local,
 		Pool: &pool.Config{
 			MaxWorkers: 10,
 			QueueDepth: 100,
@@ -709,7 +709,7 @@ func benchmarkCompaction(b *testing.B, targetBlockVersion string) {
 	tempDir := b.TempDir()
 
 	_, w, c, err := New(&Config{
-		Backend: "local",
+		Backend: backend.Local,
 		Pool: &pool.Config{
 			MaxWorkers: 10,
 			QueueDepth: 100,

--- a/tempodb/retention_test.go
+++ b/tempodb/retention_test.go
@@ -23,7 +23,7 @@ func TestRetention(t *testing.T) {
 	tempDir := t.TempDir()
 
 	r, w, c, err := New(&Config{
-		Backend: "local",
+		Backend: backend.Local,
 		Local: &local.Config{
 			Path: path.Join(tempDir, "traces"),
 		},
@@ -86,7 +86,7 @@ func TestRetentionUpdatesBlocklistImmediately(t *testing.T) {
 	tempDir := t.TempDir()
 
 	r, w, c, err := New(&Config{
-		Backend: "local",
+		Backend: backend.Local,
 		Local: &local.Config{
 			Path: path.Join(tempDir, "traces"),
 		},
@@ -155,7 +155,7 @@ func TestBlockRetentionOverride(t *testing.T) {
 	tempDir := t.TempDir()
 
 	r, w, c, err := New(&Config{
-		Backend: "local",
+		Backend: backend.Local,
 		Local: &local.Config{
 			Path: path.Join(tempDir, "traces"),
 		},

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -139,13 +139,13 @@ func New(cfg *Config, logger gkLog.Logger) (Reader, Writer, Compactor, error) {
 	}
 
 	switch cfg.Backend {
-	case "local":
+	case backend.Local:
 		rawR, rawW, c, err = local.New(cfg.Local)
-	case "gcs":
+	case backend.GCS:
 		rawR, rawW, c, err = gcs.New(cfg.GCS)
-	case "s3":
+	case backend.S3:
 		rawR, rawW, c, err = s3.New(cfg.S3)
-	case "azure":
+	case backend.Azure:
 		rawR, rawW, c, err = azure.New(cfg.Azure)
 	default:
 		err = fmt.Errorf("unknown backend %s", cfg.Backend)

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempopb"
@@ -29,7 +31,6 @@ import (
 	"github.com/grafana/tempo/tempodb/encoding/common"
 	v2 "github.com/grafana/tempo/tempodb/encoding/v2"
 	"github.com/grafana/tempo/tempodb/wal"
-	"github.com/stretchr/testify/require"
 )
 
 type runnerFn func(*testing.T, *tempopb.Trace, *tempopb.TraceSearchMetadata, []*tempopb.SearchRequest, []*tempopb.SearchRequest, *backend.BlockMeta, Reader)
@@ -641,7 +642,7 @@ func runCompleteBlockSearchTest(t *testing.T, blockVersion string, runners ...ru
 	tempDir := t.TempDir()
 
 	r, w, c, err := New(&Config{
-		Backend: "local",
+		Backend: backend.Local,
 		Local: &local.Config{
 			Path: path.Join(tempDir, "traces"),
 		},
@@ -1023,7 +1024,7 @@ func TestWALBlockGetMetrics(t *testing.T) {
 	)
 
 	r, w, c, err := New(&Config{
-		Backend: "local",
+		Backend: backend.Local,
 		Local: &local.Config{
 			Path: path.Join(tempDir, "traces"),
 		},

--- a/tempodb/tempodb_test.go
+++ b/tempodb/tempodb_test.go
@@ -37,7 +37,7 @@ func testConfig(t *testing.T, enc backend.Encoding, blocklistPoll time.Duration,
 	tempDir := t.TempDir()
 
 	cfg := &Config{
-		Backend: "local",
+		Backend: backend.Local,
 		Local: &local.Config{
 			Path: path.Join(tempDir, "traces"),
 		},
@@ -227,7 +227,7 @@ func checkBlocklists(t *testing.T, expectedID uuid.UUID, expectedB int, expected
 		assert.Equal(t, expectedID, blocklist[0].BlockID)
 	}
 
-	//confirm blocklists are in starttime ascending order
+	// confirm blocklists are in starttime ascending order
 	lastTime := time.Time{}
 	for _, b := range blocklist {
 		assert.True(t, lastTime.Before(b.StartTime) || lastTime.Equal(b.StartTime))
@@ -653,7 +653,7 @@ func testCompleteBlockHonorsStartStopTimes(t *testing.T, targetBlockVersion stri
 	tempDir := t.TempDir()
 
 	_, w, _, err := New(&Config{
-		Backend: "local",
+		Backend: backend.Local,
 		Local: &local.Config{
 			Path: path.Join(tempDir, "traces"),
 		},
@@ -701,7 +701,7 @@ func TestShouldCache(t *testing.T) {
 	tempDir := t.TempDir()
 
 	r, _, _, err := New(&Config{
-		Backend: "local",
+		Backend: backend.Local,
 		Local: &local.Config{
 			Path: path.Join(tempDir, "traces"),
 		},
@@ -789,7 +789,7 @@ func benchmarkCompleteBlock(b *testing.B, e encoding.VersionedEncoding) {
 
 	tempDir := b.TempDir()
 	_, w, _, err := New(&Config{
-		Backend: "local",
+		Backend: backend.Local,
 		Local: &local.Config{
 			Path: path.Join(tempDir, "traces"),
 		},


### PR DESCRIPTION
**What this PR does**:
The linter is complaining we have too many copies of `"local"` and `"gcs"`. This introduces constants in the backend package that we can use in other places.

It satisfies the linter but we end up introducing more dependencies on the backend package.

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [x] Tests updated
- [ ] ~~Documentation added~~
- [ ] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~