### PR TITLE
Remove mention to `$__tags`

### DIFF
--- a/docs/sources/tempo/getting-started/tempo-in-grafana.md
+++ b/docs/sources/tempo/getting-started/tempo-in-grafana.md
@@ -85,7 +85,4 @@ A local JSON file containing a trace can be uploaded and viewed in the Grafana U
 Grafana can correlate different signals by adding the functionality to link between traces and metrics. The [trace to metrics feature](/blog/2022/08/18/new-in-grafana-9.1-trace-to-metrics-allows-users-to-navigate-from-a-trace-span-to-a-selected-data-source/), a beta feature in Grafana 9.1, lets you quickly see trends or aggregated data related to each span.
 
 You can try it out by enabling the `traceToMetrics` feature toggle in your Grafana configuration file.
-
-For example, you can use span attributes to metric labels by using the `$__tags` keyword to convert span attributes to metrics labels.
-
 For more information, refer to the [trace to metric configuration](/docs/grafana/latest/datasources/tempo/#trace-to-metrics) documentation.


### PR DESCRIPTION
[This documentation page](https://grafana.com/docs/tempo/latest/getting-started/tempo-in-grafana/#linking-traces-and-metrics) contains a mention to the use of `$__tags`:

> For example, you can use span attributes to metric labels by using the $__tags keyword to convert span attributes to metrics labels.

[As shown in this issue](https://github.com/grafana/grafana/issues/64871), its use might be misleading when dealing with YAML files, which require to escape the literal `$` by writing `$$`. Since the documentation later suggests to [refer to this page](https://grafana.com/docs/grafana/latest/datasources/tempo/#trace-to-metrics) for more information and that page also contains a YAML example which uses `$$__tags`, I propose to simply remove the potentially misleading mention to `$__tags` and instead redirect the user to the dedicated page.

If we like the changes, I'll take care of updating also [the corresponding page for Grafana Cloud](https://grafana.com/docs/grafana-cloud/data-configuration/traces/#linking-traces-and-metrics).

Outcome after the changes:
![image](https://github.com/grafana/tempo/assets/135109076/a138d309-b5ce-40ff-8204-542951049789) 

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`