### PR TITLE
Add ability to disable histogram in servicegraphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ storage:
 * [CHANGE] Start flush queue worker after wal replay and block rediscovery [#2456](https://github.com/grafana/tempo/pull/2456) (@ie-pham)
 * [CHANGE] Update Go to 1.20.4 to match GET [#2486](https://github.com/grafana/tempo/pull/2486) (@ie-pham)
 * [BUGFIX] Fix issue where metrics-generator was setting wrong labels for traces_target_info [#2546](https://github.com/grafana/tempo/pull/2546) (@ie-pham)
+* [ENHANCEMENT] Add option to reduce servicegraph metrics cardinality [#](https://github.com/grafana/tempo/pull/) (@mapno)
 
 ## v2.1.1 / 2023-04-28
 * [BUGFIX] Fix issue where Tempo sometimes flips booleans from false->true at storage time. [#2400](https://github.com/grafana/tempo/issues/2400) (@joe-elliott)

--- a/modules/generator/processor/servicegraphs/config.go
+++ b/modules/generator/processor/servicegraphs/config.go
@@ -39,6 +39,9 @@ type Config struct {
 
 	// If enabled attribute value will be used for metric calculation
 	SpanMultiplierKey string `yaml:"span_multiplier_key"`
+
+	// UseHistograms
+	UseHistograms bool `yaml:"use_histograms"`
 }
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {
@@ -47,6 +50,8 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {
 	cfg.Workers = 10
 	// TODO: Revisit this default value.
 	cfg.HistogramBuckets = prometheus.ExponentialBuckets(0.1, 2, 8)
+
+	cfg.UseHistograms = true
 
 	peerAttr := make([]string, 0, len(defaultPeerAttributes))
 	for _, attr := range defaultPeerAttributes {

--- a/modules/generator/registry/test.go
+++ b/modules/generator/registry/test.go
@@ -82,6 +82,8 @@ func (t *TestRegistry) String() string {
 	return strings.Join(metrics, "\n")
 }
 
+func (t *TestRegistry) Cardinality() int { return len(t.metrics) }
+
 type testCounter struct {
 	name     string
 	registry *TestRegistry


### PR DESCRIPTION
**What this PR does**:

Add config param `use_histograms` to control cardinality in servicegraph metrics. If set to false, it'll use a counter to measure latency instead of histograms. This saves a lot of active series

**Which issue(s) this PR fixes**:


**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`