### PR TITLE
Fix a few bugs in vParquet2 structural operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * [CHANGE] Make vParquet2 the default block format [#2526](https://github.com/grafana/tempo/pull/2526) (@stoewer)
 * [CHANGE] Disable tempo-query by default in Jsonnet libs. [#2462](https://github.com/grafana/tempo/pull/2462) (@electron0zero)
 * [FEATURE] New experimental API to derive on-demand RED metrics grouped by any attribute, and new metrics generator processor [#2368](https://github.com/grafana/tempo/pull/2368) [#2418](https://github.com/grafana/tempo/pull/2418) [#2424](https://github.com/grafana/tempo/pull/2424) [#2442](https://github.com/grafana/tempo/pull/2442) [#2480](https://github.com/grafana/tempo/pull/2480) [#2481](https://github.com/grafana/tempo/pull/2481) [#2501](https://github.com/grafana/tempo/pull/2501) [#2579](https://github.com/grafana/tempo/pull/2579) [#2582](https://github.com/grafana/tempo/pull/2582) (@mdisibio @zalegrala)
-* [FEATURE] New TraceQL structural operators descendant (>>), child (>), and sibling (~) [#2625](https://github.com/grafana/tempo/pull/2625) (@mdisibio)
+* [FEATURE] New TraceQL structural operators descendant (>>), child (>), and sibling (~) [#2625](https://github.com/grafana/tempo/pull/2625) [#2660](https://github.com/grafana/tempo/pull/2660) (@mdisibio)
 * [ENHANCEMENT] Add capability to flush all remaining traces to backend when ingester is stopped [#2538](https://github.com/grafana/tempo/pull/2538)
 * [ENHANCEMENT] Fill parent ID column and nested set columns [#2487](https://github.com/grafana/tempo/pull/2487) (@stoewer)
 * [ENHANCEMENT] Add metrics generator config option to allow customizable ring port [#2399](https://github.com/grafana/tempo/pull/2399) (@mdisibio)

--- a/pkg/util/math/math.go
+++ b/pkg/util/math/math.go
@@ -16,18 +16,38 @@ func Min(a, b int) int {
 	return b
 }
 
-// Max64 returns the maximum of two int64s
-func Max64(a, b int64) int64 {
-	if a > b {
-		return a
+// Max64 returns the maximum uint64s
+func Max64(values ...uint64) uint64 {
+	if len(values) == 0 {
+		return 0
 	}
-	return b
+	if len(values) == 1 {
+		return values[0]
+	}
+
+	x := values[0]
+	for i := 1; i < len(values); i++ {
+		if values[i] > x {
+			x = values[i]
+		}
+	}
+	return x
 }
 
-// Min64 returns the minimum of two int64s
-func Min64(a, b int64) int64 {
-	if a < b {
-		return a
+// Min64 returns the minimum of uint64s
+func Min64(values ...uint64) uint64 {
+	if len(values) == 0 {
+		return 0
 	}
-	return b
+	if len(values) == 1 {
+		return values[0]
+	}
+
+	x := values[0]
+	for i := 1; i < len(values); i++ {
+		if values[i] < x {
+			x = values[i]
+		}
+	}
+	return x
 }

--- a/tempodb/encoding/vparquet2/block_traceql.go
+++ b/tempodb/encoding/vparquet2/block_traceql.go
@@ -74,7 +74,12 @@ func (s *span) SiblingOf(x traceql.Span) bool {
 			ss.nestedSetParent == 0 {
 			return false
 		}
-		return ss.nestedSetParent == s.nestedSetParent
+		// Same parent but not ourself
+		// Checking pointers here means we don't have to load
+		// an additional column of nestedSetLeft but assumes the span
+		// object. This is true because all TraceQL executions are
+		// currently single-pass.
+		return ss.nestedSetParent == s.nestedSetParent && s != ss
 	}
 	return false
 }

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -541,6 +541,7 @@ func traceQLStructural(t *testing.T, _ *tempopb.Trace, wantMeta *tempopb.TraceSe
 		{Query: "{ .child } >> { .parent }"},
 		{Query: "{ .child } > { .parent }"},
 		{Query: "{ .child } ~ { .parent }"},
+		{Query: "{ .child } ~ { .child }"},
 		{Query: "{ .broken} >> {}"},
 		{Query: "{ .broken} > {}"},
 		{Query: "{ .broken} ~ {}"},

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -179,26 +179,30 @@ func advancedTraceQLRunner(t *testing.T, wantTr *tempopb.Trace, wantMeta *tempop
 		// that always match multiple spans. The only way to keep these tests from being brittle
 		// is to ensure that all spans are selected.  It's ok if a span still shows up in multiple
 		// filters (because of traceDuration > 0 for example) because the && operator ensures final uniqueness.
-		{Query: fmt.Sprintf("{ %s && %s } && { %s && %s } && { %s && %s } | avg(duration) = %dns",
+		{Query: fmt.Sprintf("{ %s && %s } && { %s && %s } && { %s && %s } && { %s && %s } | avg(duration) = %dns",
 			rando(trueConditionsBySpan[0]), rando(trueConditionsBySpan[0]),
 			rando(trueConditionsBySpan[1]), rando(trueConditionsBySpan[1]),
 			rando(trueConditionsBySpan[2]), rando(trueConditionsBySpan[2]),
-			(durationBySpan[0]+durationBySpan[1]+durationBySpan[2])/3)},
-		{Query: fmt.Sprintf("{ %s && %s } && { %s && %s } && { %s && %s } | min(duration) = %dns",
+			rando(trueConditionsBySpan[3]), rando(trueConditionsBySpan[3]),
+			(durationBySpan[0]+durationBySpan[1]+durationBySpan[2]+durationBySpan[3])/4)},
+		{Query: fmt.Sprintf("{ %s && %s } && { %s && %s } && { %s && %s } && { %s && %s } | min(duration) = %dns",
 			rando(trueConditionsBySpan[0]), rando(trueConditionsBySpan[0]),
 			rando(trueConditionsBySpan[1]), rando(trueConditionsBySpan[1]),
 			rando(trueConditionsBySpan[2]), rando(trueConditionsBySpan[2]),
-			math.Min64(math.Min64(int64(durationBySpan[0]), int64(durationBySpan[1])), int64(durationBySpan[2])))},
-		{Query: fmt.Sprintf("{ %s && %s } && { %s && %s }  && { %s && %s } | max(duration) = %dns",
+			rando(trueConditionsBySpan[3]), rando(trueConditionsBySpan[3]),
+			math.Min64(durationBySpan[0], durationBySpan[1], durationBySpan[2], durationBySpan[3]))},
+		{Query: fmt.Sprintf("{ %s && %s } && { %s && %s }  && { %s && %s } && { %s && %s } | max(duration) = %dns",
 			rando(trueConditionsBySpan[0]), rando(trueConditionsBySpan[0]),
 			rando(trueConditionsBySpan[1]), rando(trueConditionsBySpan[1]),
 			rando(trueConditionsBySpan[2]), rando(trueConditionsBySpan[2]),
-			math.Max64(math.Max64(int64(durationBySpan[0]), int64(durationBySpan[1])), int64(durationBySpan[2])))},
-		{Query: fmt.Sprintf("{ %s && %s } && { %s && %s } && { %s && %s } | sum(duration) = %dns",
+			rando(trueConditionsBySpan[3]), rando(trueConditionsBySpan[3]),
+			math.Max64(durationBySpan[0], durationBySpan[1], durationBySpan[2], durationBySpan[3]))},
+		{Query: fmt.Sprintf("{ %s && %s } && { %s && %s } && { %s && %s }  && { %s && %s }| sum(duration) = %dns",
 			rando(trueConditionsBySpan[0]), rando(trueConditionsBySpan[0]),
 			rando(trueConditionsBySpan[1]), rando(trueConditionsBySpan[1]),
 			rando(trueConditionsBySpan[2]), rando(trueConditionsBySpan[2]),
-			durationBySpan[0]+durationBySpan[1]+durationBySpan[2])},
+			rando(trueConditionsBySpan[3]), rando(trueConditionsBySpan[3]),
+			durationBySpan[0]+durationBySpan[1]+durationBySpan[2]+durationBySpan[3])},
 		// groupin' (.foo is a known attribute that is the same on both spans)
 		{Query: "{} | by(span.foo) | count() = 2"},
 		{Query: "{} | by(resource.service.name) | count() = 1"},
@@ -365,6 +369,24 @@ func groupTraceQLRunner(t *testing.T, _ *tempopb.Trace, wantMeta *tempopb.TraceS
 								{Key: "count()", Value: &v1_common.AnyValue{Value: &v1_common.AnyValue_IntValue{IntValue: 1}}},
 							},
 						},
+						{
+							Spans: []*tempopb.Span{
+								{
+									SpanID:            "0000000000000000",
+									StartTimeUnixNano: 1000000000000,
+									DurationNanos:     1000000000,
+									Name:              "",
+									Attributes: []*v1_common.KeyValue{
+										{Key: "service.name", Value: &v1_common.AnyValue{Value: &v1_common.AnyValue_StringValue{StringValue: "BrokenService"}}},
+									},
+								},
+							},
+							Matched: 1,
+							Attributes: []*v1_common.KeyValue{
+								{Key: "by(resource.service.name)", Value: &v1_common.AnyValue{Value: &v1_common.AnyValue_StringValue{StringValue: "BrokenService"}}},
+								{Key: "count()", Value: &v1_common.AnyValue{Value: &v1_common.AnyValue_IntValue{IntValue: 1}}},
+							},
+						},
 					},
 				},
 			},
@@ -519,6 +541,12 @@ func traceQLStructural(t *testing.T, _ *tempopb.Trace, wantMeta *tempopb.TraceSe
 		{Query: "{ .child } >> { .parent }"},
 		{Query: "{ .child } > { .parent }"},
 		{Query: "{ .child } ~ { .parent }"},
+		{Query: "{ .broken} >> {}"},
+		{Query: "{ .broken} > {}"},
+		{Query: "{ .broken} ~ {}"},
+		{Query: "{} >> {.broken}"},
+		{Query: "{} > {.broken}"},
+		{Query: "{} ~ {.broken}"},
 	}
 
 	for _, tc := range searchesThatMatch {
@@ -898,6 +926,31 @@ func searchTestSuite() (
 								Status:            &v1.Status{Code: v1.Status_STATUS_CODE_OK},
 								Attributes: []*v1_common.KeyValue{
 									boolKV("child2", true),
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Resource: &v1_resource.Resource{
+					Attributes: []*v1_common.KeyValue{
+						stringKV("service.name", "BrokenService"),
+					},
+				},
+				ScopeSpans: []*v1.ScopeSpans{
+					{
+						Spans: []*v1.Span{
+							{
+								Name:              "BrokenSpan",
+								TraceId:           id,
+								SpanId:            []byte{0, 0, 0},
+								ParentSpanId:      []byte{0, 0, 0},
+								StartTimeUnixNano: uint64(1000 * time.Second),
+								EndTimeUnixNano:   uint64(1001 * time.Second),
+								Status:            &v1.Status{Code: v1.Status_STATUS_CODE_OK},
+								Attributes: []*v1_common.KeyValue{
+									boolKV("broken", true),
 								},
 							},
 						},

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -761,10 +761,10 @@ func intKV(k string, v int) *v1_common.KeyValue {
 	}
 }
 
-func boolKV(k string, v bool) *v1_common.KeyValue {
+func boolKV(k string) *v1_common.KeyValue {
 	return &v1_common.KeyValue{
 		Key:   k,
-		Value: &v1_common.AnyValue{Value: &v1_common.AnyValue_BoolValue{BoolValue: v}},
+		Value: &v1_common.AnyValue{Value: &v1_common.AnyValue_BoolValue{BoolValue: true}},
 	}
 }
 
@@ -875,7 +875,7 @@ func searchTestSuite() (
 									stringKV("http.url", "url/Hello/World"),
 									intKV("http.status_code", 500),
 									stringKV("foo", "Bar"),
-									boolKV("child", true),
+									boolKV("child"),
 								},
 							},
 						},
@@ -901,7 +901,7 @@ func searchTestSuite() (
 								Kind:              v1.Span_SPAN_KIND_CLIENT,
 								Attributes: []*v1_common.KeyValue{
 									stringKV("foo", "Bar"),
-									boolKV("parent", true),
+									boolKV("parent"),
 								},
 							},
 						},
@@ -926,7 +926,7 @@ func searchTestSuite() (
 								Kind:              v1.Span_SPAN_KIND_PRODUCER,
 								Status:            &v1.Status{Code: v1.Status_STATUS_CODE_OK},
 								Attributes: []*v1_common.KeyValue{
-									boolKV("child2", true),
+									boolKV("child2"),
 								},
 							},
 						},
@@ -951,7 +951,7 @@ func searchTestSuite() (
 								EndTimeUnixNano:   uint64(1001 * time.Second),
 								Status:            &v1.Status{Code: v1.Status_STATUS_CODE_OK},
 								Attributes: []*v1_common.KeyValue{
-									boolKV("broken", true),
+									boolKV("broken"),
 								},
 							},
 						},


### PR DESCRIPTION
**What this PR does**:
A few fixes in the structural operators:
1. Need to skip over spans with broken nesting. This is detected as any value of either span == 0.  Without this it was falsely identifying matches on partial traces where the spans had broken nesting
2. Sibling operator would falsely identify a span as its own sibling if it was present in multiple spansets.  I.e. `{ .foo} ~ {.foo}` because each input technically had the same parent.  There are two ways to fix this, and I chose the more efficient one.  Theoretically we could loading both Parent and Left and ensure Lefts are different (not same spans).  However instead I am just checking struct pointers to ensure not the same `*span`.  This works until the TraceQL engine starts making multiple passes over a file (which is not the plan and may be never). 
3. There was also a small typo in DescendantOf that could have led to more false positives.  I never saw this in the wild.

**Which issue(s) this PR fixes**:
Fixes #2658 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`