### PR TITLE
Refactor poller into new module and adjust tempodb.New everywhere

### DIFF
--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -38,10 +38,13 @@ import (
 	"github.com/grafana/tempo/pkg/usagestats"
 	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/pkg/util/log"
+	"github.com/grafana/tempo/tempodb"
 )
 
-const metricsNamespace = "tempo"
-const apiDocs = "https://grafana.com/docs/tempo/latest/api_docs/"
+const (
+	metricsNamespace = "tempo"
+	apiDocs          = "https://grafana.com/docs/tempo/latest/api_docs/"
+)
 
 var (
 	metricConfigFeatDesc = prometheus.NewDesc(
@@ -71,6 +74,7 @@ type App struct {
 	ingester       *ingester.Ingester
 	generator      *generator.Generator
 	store          storage.Store
+	poller         tempodb.Poller
 	usageReport    *usagestats.Reporter
 	MemberlistKV   *memberlist.KVInitService
 

--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -33,12 +33,12 @@ import (
 	"github.com/grafana/tempo/modules/generator"
 	"github.com/grafana/tempo/modules/ingester"
 	"github.com/grafana/tempo/modules/overrides"
+	"github.com/grafana/tempo/modules/poller"
 	"github.com/grafana/tempo/modules/querier"
 	"github.com/grafana/tempo/modules/storage"
 	"github.com/grafana/tempo/pkg/usagestats"
 	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/pkg/util/log"
-	"github.com/grafana/tempo/tempodb"
 )
 
 const (
@@ -74,7 +74,7 @@ type App struct {
 	ingester       *ingester.Ingester
 	generator      *generator.Generator
 	store          storage.Store
-	poller         tempodb.Poller
+	poller         *poller.Poller
 	usageReport    *usagestats.Reporter
 	MemberlistKV   *memberlist.KVInitService
 

--- a/cmd/tempo/app/config.go
+++ b/cmd/tempo/app/config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/tempo/modules/ingester"
 	ingester_client "github.com/grafana/tempo/modules/ingester/client"
 	"github.com/grafana/tempo/modules/overrides"
+	"github.com/grafana/tempo/modules/poller"
 	"github.com/grafana/tempo/modules/querier"
 	"github.com/grafana/tempo/modules/storage"
 	internalserver "github.com/grafana/tempo/pkg/server"
@@ -49,6 +50,7 @@ type Config struct {
 	Ingester        ingester.Config         `yaml:"ingester,omitempty"`
 	Generator       generator.Config        `yaml:"metrics_generator,omitempty"`
 	StorageConfig   storage.Config          `yaml:"storage,omitempty"`
+	PollerConfig    poller.Config           `yaml:"poller,omitempty"`
 	LimitsConfig    overrides.Limits        `yaml:"overrides,omitempty"`
 	MemberlistKV    memberlist.KVConfig     `yaml:"memberlist,omitempty"`
 	UsageReport     usagestats.Config       `yaml:"usage_report,omitempty"`
@@ -126,6 +128,7 @@ func (c *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 	c.Frontend.RegisterFlagsAndApplyDefaults(util.PrefixConfig(prefix, "frontend"), f)
 	c.Compactor.RegisterFlagsAndApplyDefaults(util.PrefixConfig(prefix, "compactor"), f)
 	c.StorageConfig.RegisterFlagsAndApplyDefaults(util.PrefixConfig(prefix, "storage"), f)
+	c.PollerConfig.RegisterFlagsAndApplyDefaults(util.PrefixConfig(prefix, "poller"), f)
 	c.UsageReport.RegisterFlagsAndApplyDefaults(util.PrefixConfig(prefix, "reporting"), f)
 }
 
@@ -198,7 +201,6 @@ func (c *Config) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (c *Config) Collect(ch chan<- prometheus.Metric) {
-
 	features := map[string]int{
 		"search_external_endpoints": 0,
 	}

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -28,6 +28,7 @@ import (
 	"github.com/grafana/tempo/modules/ingester"
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/modules/overrides/userconfigurableapi"
+	"github.com/grafana/tempo/modules/poller"
 	"github.com/grafana/tempo/modules/querier"
 	tempo_storage "github.com/grafana/tempo/modules/storage"
 	"github.com/grafana/tempo/pkg/api"
@@ -411,8 +412,13 @@ func (t *App) initCompactor() (services.Service, error) {
 }
 
 func (t *App) initPoller() (services.Service, error) {
-	t.poller = t.store
-	return nil, nil
+	poller, err := poller.New(t.cfg.PollerConfig, t.store)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create poller %w", err)
+	}
+	t.poller = poller
+
+	return t.poller, nil
 }
 
 func (t *App) initStore() (services.Service, error) {

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -36,7 +36,6 @@ import (
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/usagestats"
 	"github.com/grafana/tempo/pkg/util/log"
-	util_log "github.com/grafana/tempo/pkg/util/log"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/azure"
 	"github.com/grafana/tempo/tempodb/backend/gcs"
@@ -494,9 +493,9 @@ func (t *App) initUsageReport() (services.Service, error) {
 		return nil, fmt.Errorf("failed to initialize usage report: %w", err)
 	}
 
-	ur, err := usagestats.NewReporter(t.cfg.UsageReport, t.cfg.Ingester.LifecyclerConfig.RingConfig.KVStore, reader, writer, util_log.Logger, prometheus.DefaultRegisterer)
+	ur, err := usagestats.NewReporter(t.cfg.UsageReport, t.cfg.Ingester.LifecyclerConfig.RingConfig.KVStore, reader, writer, log.Logger, prometheus.DefaultRegisterer)
 	if err != nil {
-		level.Info(util_log.Logger).Log("msg", "failed to initialize usage report", "err", err)
+		level.Info(log.Logger).Log("msg", "failed to initialize usage report", "err", err)
 		return nil, nil
 	}
 	t.usageReport = ur

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -398,7 +398,7 @@ func (t *App) initCompactor() (services.Service, error) {
 		t.cfg.Compactor.ShardingRing.KVStore.Store = "memberlist"
 	}
 
-	compactor, err := compactor.New(t.cfg.Compactor, t.store, t.Overrides, prometheus.DefaultRegisterer)
+	compactor, err := compactor.New(t.cfg.Compactor, t.store, t.poller, t.Overrides, prometheus.DefaultRegisterer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create compactor %w", err)
 	}
@@ -552,7 +552,7 @@ func (t *App) setupModuleManager() error {
 		Ingester:         {Common, Store, MemberlistKV},
 		MetricsGenerator: {Common, MemberlistKV},
 		Querier:          {Common, Store, Poller, IngesterRing, MetricsGeneratorRing, SecondaryIngesterRing},
-		Compactor:        {Common, Store, MemberlistKV},
+		Compactor:        {Common, Store, Poller, MemberlistKV},
 		// composite targets
 		SingleBinary:         {Compactor, QueryFrontend, Querier, Ingester, Distributor, MetricsGenerator},
 		ScalableSingleBinary: {SingleBinary},

--- a/modules/compactor/compactor.go
+++ b/modules/compactor/compactor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/tempo/pkg/model"
 	tempoUtil "github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/pkg/util/log"
+	"github.com/grafana/tempo/tempodb"
 )
 
 const (
@@ -41,6 +42,7 @@ type Compactor struct {
 
 	cfg       *Config
 	store     storage.Store
+	poller    tempodb.Poller
 	overrides overrides.Interface
 
 	// Ring used for sharding compactions.
@@ -52,11 +54,12 @@ type Compactor struct {
 }
 
 // New makes a new Compactor.
-func New(cfg Config, store storage.Store, overrides overrides.Interface, reg prometheus.Registerer) (*Compactor, error) {
+func New(cfg Config, store storage.Store, poller tempodb.Poller, overrides overrides.Interface, reg prometheus.Registerer) (*Compactor, error) {
 	c := &Compactor{
 		cfg:       &cfg,
 		store:     store,
 		overrides: overrides,
+		poller:    poller,
 	}
 
 	if c.isSharded() {
@@ -150,7 +153,7 @@ func (c *Compactor) starting(ctx context.Context) (err error) {
 	}
 
 	// this will block until one poll cycle is complete
-	c.store.EnablePolling(ctx, c)
+	c.poller.EnablePolling(ctx, c)
 
 	return nil
 }

--- a/modules/compactor/compactor.go
+++ b/modules/compactor/compactor.go
@@ -34,9 +34,7 @@ const (
 	reasonCompactorDiscardedSpans = "trace_too_large_to_compact"
 )
 
-var (
-	ringOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, nil)
-)
+var ringOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, nil)
 
 type Compactor struct {
 	services.Service
@@ -152,7 +150,7 @@ func (c *Compactor) starting(ctx context.Context) (err error) {
 	}
 
 	// this will block until one poll cycle is complete
-	c.store.EnablePolling(c)
+	c.store.EnablePolling(ctx, c)
 
 	return nil
 }

--- a/modules/frontend/config.go
+++ b/modules/frontend/config.go
@@ -86,13 +86,7 @@ func (CortexNoQuerierLimits) MaxQueriersPerUser(string) int { return 0 }
 // Returned RoundTripper can be wrapped in more round-tripper middlewares, and then eventually registered
 // into HTTP server using the Handler from this package. Returned RoundTripper is always non-nil
 // (if there are no errors), and it uses the returned frontend (if any).
-func InitFrontend(
-	cfg v1.Config,
-	limits v1.Limits,
-	log log.Logger,
-	reg prometheus.Registerer,
-	poller tempodb.Poller,
-) (http.RoundTripper, *v1.Frontend, error) {
+func InitFrontend(cfg v1.Config, limits v1.Limits, log log.Logger, reg prometheus.Registerer, poller tempodb.Poller) (http.RoundTripper, *v1.Frontend, error) {
 	statVersion.Set("v1")
 	// No scheduler = use original frontend.
 	fr, err := v1.New(cfg, limits, log, reg, poller)

--- a/modules/frontend/searchsharding_test.go
+++ b/modules/frontend/searchsharding_test.go
@@ -60,8 +60,8 @@ func (m *mockReader) Fetch(context.Context, *backend.BlockMeta, traceql.FetchSpa
 	return traceql.FetchSpansResponse{}, nil
 }
 
-func (m *mockReader) EnablePolling(blocklist.JobSharder) {}
-func (m *mockReader) Shutdown()                          {}
+func (m *mockReader) EnablePolling(context.Context, blocklist.JobSharder) {}
+func (m *mockReader) Shutdown()                                           {}
 
 func TestBuildBackendRequests(t *testing.T) {
 	tests := []struct {

--- a/modules/poller/config.go
+++ b/modules/poller/config.go
@@ -1,0 +1,15 @@
+package poller
+
+import (
+	"flag"
+)
+
+// Config is the Tempo storage configuration
+type Config struct {
+	// Trace tempodb.Config `yaml:"trace"`
+}
+
+// RegisterFlagsAndApplyDefaults registers the flags.
+func (cfg *Config) RegisterFlagsAndApplyDefaults(_ string, _ *flag.FlagSet) {
+	// cfg.Trace.RegisterFlagsAndApplyDefaults(prefix, f)
+}

--- a/modules/poller/poller.go
+++ b/modules/poller/poller.go
@@ -1,0 +1,36 @@
+package poller
+
+import (
+	"context"
+
+	"github.com/grafana/dskit/services"
+
+	"github.com/grafana/tempo/tempodb"
+)
+
+type Poller struct {
+	services.Service
+
+	cfg Config
+
+	tempodb.Poller
+}
+
+// NewStore creates a new Tempo Store using configuration supplied.
+func New(cfg Config, poller tempodb.Poller) (*Poller, error) {
+	p := &Poller{
+		cfg:    cfg,
+		Poller: poller,
+	}
+
+	p.Service = services.NewIdleService(p.starting, p.stopping)
+	return p, nil
+}
+
+func (p *Poller) starting(_ context.Context) error {
+	return nil
+}
+
+func (p *Poller) stopping(_ error) error {
+	return nil
+}

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -43,6 +43,7 @@ import (
 	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/pkg/util/log"
 	"github.com/grafana/tempo/pkg/validation"
+	"github.com/grafana/tempo/tempodb"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
@@ -88,6 +89,7 @@ type Querier struct {
 	engine *traceql.Engine
 	store  storage.Store
 	limits overrides.Interface
+	poller tempodb.Poller
 
 	searchClient     *http.Client
 	searchPreferSelf *semaphore.Weighted
@@ -148,6 +150,7 @@ func New(
 			log.Logger),
 		engine:           traceql.NewEngine(),
 		store:            store,
+		poller:           store,
 		limits:           limits,
 		searchPreferSelf: semaphore.NewWeighted(int64(cfg.Search.PreferSelf)),
 		searchClient:     http.DefaultClient,
@@ -205,6 +208,8 @@ func (q *Querier) RegisterSubservices(s ...services.Service) error {
 }
 
 func (q *Querier) starting(ctx context.Context) error {
+	q.poller.EnablePolling(ctx, nil)
+
 	if q.subservices != nil {
 		err := services.StartManagerAndAwaitHealthy(ctx, q.subservices)
 		if err != nil {
@@ -237,7 +242,12 @@ func (q *Querier) stopping(_ error) error {
 }
 
 // FindTraceByID implements tempopb.Querier.
-func (q *Querier) FindTraceByID(ctx context.Context, req *tempopb.TraceByIDRequest, timeStart int64, timeEnd int64) (*tempopb.TraceByIDResponse, error) {
+func (q *Querier) FindTraceByID(
+	ctx context.Context,
+	req *tempopb.TraceByIDRequest,
+	timeStart int64,
+	timeEnd int64,
+) (*tempopb.TraceByIDResponse, error) {
 	if !validation.ValidTraceID(req.TraceID) {
 		return nil, fmt.Errorf("invalid trace id")
 	}
@@ -265,9 +275,13 @@ func (q *Querier) FindTraceByID(ctx context.Context, req *tempopb.TraceByIDReque
 
 		// get responses from all ingesters in parallel
 		span.LogFields(ot_log.String("msg", "searching ingesters"))
-		responses, err := q.forIngesterRings(ctx, getRSFn, func(funcCtx context.Context, client tempopb.QuerierClient) (interface{}, error) {
-			return client.FindTraceByID(funcCtx, req)
-		})
+		responses, err := q.forIngesterRings(
+			ctx,
+			getRSFn,
+			func(funcCtx context.Context, client tempopb.QuerierClient) (interface{}, error) {
+				return client.FindTraceByID(funcCtx, req)
+			},
+		)
 		if err != nil {
 			return nil, errors.Wrap(err, "error querying ingesters in Querier.FindTraceByID")
 		}
@@ -292,7 +306,15 @@ func (q *Querier) FindTraceByID(ctx context.Context, req *tempopb.TraceByIDReque
 		span.LogFields(ot_log.String("msg", "searching store"))
 		span.LogFields(ot_log.String("timeStart", fmt.Sprint(timeStart)))
 		span.LogFields(ot_log.String("timeEnd", fmt.Sprint(timeEnd)))
-		partialTraces, blockErrs, err := q.store.Find(ctx, userID, req.TraceID, req.BlockStart, req.BlockEnd, timeStart, timeEnd)
+		partialTraces, blockErrs, err := q.store.Find(
+			ctx,
+			userID,
+			req.TraceID,
+			req.BlockStart,
+			req.BlockEnd,
+			timeStart,
+			timeEnd,
+		)
 		if err != nil {
 			retErr := errors.Wrap(err, "error querying store in Querier.FindTraceByID")
 			ot_log.Error(retErr)
@@ -320,11 +342,17 @@ func (q *Querier) FindTraceByID(ctx context.Context, req *tempopb.TraceByIDReque
 	}, nil
 }
 
-type forEachFn func(ctx context.Context, client tempopb.QuerierClient) (interface{}, error)
-type replicationSetFn func(r ring.ReadRing) (ring.ReplicationSet, error)
+type (
+	forEachFn        func(ctx context.Context, client tempopb.QuerierClient) (interface{}, error)
+	replicationSetFn func(r ring.ReadRing) (ring.ReplicationSet, error)
+)
 
 // forIngesterRings runs f, in parallel, for given ingesters
-func (q *Querier) forIngesterRings(ctx context.Context, getReplicationSet replicationSetFn, f forEachFn) ([]responseFromIngesters, error) {
+func (q *Querier) forIngesterRings(
+	ctx context.Context,
+	getReplicationSet replicationSetFn,
+	f forEachFn,
+) ([]responseFromIngesters, error) {
 	if ctx.Err() != nil {
 		_ = level.Debug(log.Logger).Log("forIngesterRings context error", "ctx.Err()", ctx.Err().Error())
 		return nil, ctx.Err()
@@ -379,7 +407,13 @@ func (q *Querier) forIngesterRings(ctx context.Context, getReplicationSet replic
 	return responses, nil
 }
 
-func forOneIngesterRing(ctx context.Context, replicationSet ring.ReplicationSet, f forEachFn, pool *ring_client.Pool, extraQueryDelay time.Duration) ([]interface{}, error) {
+func forOneIngesterRing(
+	ctx context.Context,
+	replicationSet ring.ReplicationSet,
+	f forEachFn,
+	pool *ring_client.Pool,
+	extraQueryDelay time.Duration,
+) ([]interface{}, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "Querier.forOneIngester")
 	defer span.Finish()
 
@@ -457,9 +491,13 @@ func (q *Querier) SearchRecent(ctx context.Context, req *tempopb.SearchRequest) 
 		return nil, errors.Wrap(err, "error extracting org id in Querier.Search")
 	}
 
-	responses, err := q.forIngesterRings(ctx, nil, func(ctx context.Context, client tempopb.QuerierClient) (interface{}, error) {
-		return client.SearchRecent(ctx, req)
-	})
+	responses, err := q.forIngesterRings(
+		ctx,
+		nil,
+		func(ctx context.Context, client tempopb.QuerierClient) (interface{}, error) {
+			return client.SearchRecent(ctx, req)
+		},
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "error querying ingesters in Querier.Search")
 	}
@@ -476,9 +514,13 @@ func (q *Querier) SearchTags(ctx context.Context, req *tempopb.SearchTagsRequest
 	limit := q.limits.MaxBytesPerTagValuesQuery(userID)
 	distinctValues := util.NewDistinctStringCollector(limit)
 
-	lookupResults, err := q.forIngesterRings(ctx, nil, func(ctx context.Context, client tempopb.QuerierClient) (interface{}, error) {
-		return client.SearchTags(ctx, req)
-	})
+	lookupResults, err := q.forIngesterRings(
+		ctx,
+		nil,
+		func(ctx context.Context, client tempopb.QuerierClient) (interface{}, error) {
+			return client.SearchTags(ctx, req)
+		},
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "error querying ingesters in Querier.SearchTags")
 	}
@@ -489,7 +531,8 @@ func (q *Querier) SearchTags(ctx context.Context, req *tempopb.SearchTagsRequest
 	}
 
 	if distinctValues.Exceeded() {
-		level.Warn(log.Logger).Log("msg", "size of tags in instance exceeded limit, reduce cardinality or size of tags", "userID", userID, "limit", limit, "total", distinctValues.TotalDataSize())
+		level.Warn(log.Logger).
+			Log("msg", "size of tags in instance exceeded limit, reduce cardinality or size of tags", "userID", userID, "limit", limit, "total", distinctValues.TotalDataSize())
 	}
 
 	resp := &tempopb.SearchTagsResponse{
@@ -506,9 +549,13 @@ func (q *Querier) SearchTagsV2(ctx context.Context, req *tempopb.SearchTagsReque
 	}
 
 	// Get results from all ingesters
-	lookupResults, err := q.forIngesterRings(ctx, nil, func(ctx context.Context, client tempopb.QuerierClient) (interface{}, error) {
-		return client.SearchTagsV2(ctx, req)
-	})
+	lookupResults, err := q.forIngesterRings(
+		ctx,
+		nil,
+		func(ctx context.Context, client tempopb.QuerierClient) (interface{}, error) {
+			return client.SearchTagsV2(ctx, req)
+		},
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "error querying ingesters in Querier.SearchTags")
 	}
@@ -532,7 +579,8 @@ func (q *Querier) SearchTagsV2(ctx context.Context, req *tempopb.SearchTagsReque
 
 	for scope, dvc := range distinctValues {
 		if dvc.Exceeded() {
-			level.Warn(log.Logger).Log("msg", "size of tags in instance exceeded limit, reduce cardinality or size of tags", "userID", userID, "limit", limit, "scope", scope, "total", dvc.TotalDataSize())
+			level.Warn(log.Logger).
+				Log("msg", "size of tags in instance exceeded limit, reduce cardinality or size of tags", "userID", userID, "limit", limit, "scope", scope, "total", dvc.TotalDataSize())
 		}
 	}
 
@@ -547,7 +595,10 @@ func (q *Querier) SearchTagsV2(ctx context.Context, req *tempopb.SearchTagsReque
 	return resp, nil
 }
 
-func (q *Querier) SearchTagValues(ctx context.Context, req *tempopb.SearchTagValuesRequest) (*tempopb.SearchTagValuesResponse, error) {
+func (q *Querier) SearchTagValues(
+	ctx context.Context,
+	req *tempopb.SearchTagValuesRequest,
+) (*tempopb.SearchTagValuesResponse, error) {
 	userID, err := user.ExtractOrgID(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "error extracting org id in Querier.SearchTagValues")
@@ -561,9 +612,13 @@ func (q *Querier) SearchTagValues(ctx context.Context, req *tempopb.SearchTagVal
 		distinctValues.Collect(v)
 	}
 
-	lookupResults, err := q.forIngesterRings(ctx, nil, func(ctx context.Context, client tempopb.QuerierClient) (interface{}, error) {
-		return client.SearchTagValues(ctx, req)
-	})
+	lookupResults, err := q.forIngesterRings(
+		ctx,
+		nil,
+		func(ctx context.Context, client tempopb.QuerierClient) (interface{}, error) {
+			return client.SearchTagValues(ctx, req)
+		},
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "error querying ingesters in Querier.SearchTagValues")
 	}
@@ -574,7 +629,8 @@ func (q *Querier) SearchTagValues(ctx context.Context, req *tempopb.SearchTagVal
 	}
 
 	if distinctValues.Exceeded() {
-		level.Warn(log.Logger).Log("msg", "size of tag values in instance exceeded limit, reduce cardinality or size of tags", "tag", req.TagName, "userID", userID, "limit", limit, "total", distinctValues.TotalDataSize())
+		level.Warn(log.Logger).
+			Log("msg", "size of tag values in instance exceeded limit, reduce cardinality or size of tags", "tag", req.TagName, "userID", userID, "limit", limit, "total", distinctValues.TotalDataSize())
 	}
 
 	resp := &tempopb.SearchTagValuesResponse{
@@ -584,7 +640,10 @@ func (q *Querier) SearchTagValues(ctx context.Context, req *tempopb.SearchTagVal
 	return resp, nil
 }
 
-func (q *Querier) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTagValuesRequest) (*tempopb.SearchTagValuesV2Response, error) {
+func (q *Querier) SearchTagValuesV2(
+	ctx context.Context,
+	req *tempopb.SearchTagValuesRequest,
+) (*tempopb.SearchTagValuesV2Response, error) {
 	userID, err := user.ExtractOrgID(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "error extracting org id in Querier.SearchTagValues")
@@ -606,9 +665,13 @@ func (q *Querier) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTagV
 	}
 
 	// Get results from all ingesters
-	lookupResults, err := q.forIngesterRings(ctx, nil, func(ctx context.Context, client tempopb.QuerierClient) (interface{}, error) {
-		return client.SearchTagValuesV2(ctx, req)
-	})
+	lookupResults, err := q.forIngesterRings(
+		ctx,
+		nil,
+		func(ctx context.Context, client tempopb.QuerierClient) (interface{}, error) {
+			return client.SearchTagValuesV2(ctx, req)
+		},
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "error querying ingesters in Querier.SearchTagValues")
 	}
@@ -619,7 +682,8 @@ func (q *Querier) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTagV
 	}
 
 	if distinctValues.Exceeded() {
-		level.Warn(log.Logger).Log("msg", "size of tag values in instance exceeded limit, reduce cardinality or size of tags", "tag", req.TagName, "userID", userID, "limit", limit, "total", distinctValues.TotalDataSize())
+		level.Warn(log.Logger).
+			Log("msg", "size of tag values in instance exceeded limit, reduce cardinality or size of tags", "tag", req.TagName, "userID", userID, "limit", limit, "total", distinctValues.TotalDataSize())
 	}
 
 	return valuesToV2Response(distinctValues), nil
@@ -783,9 +847,11 @@ func (q *Querier) internalSearchBlock(ctx context.Context, req *tempopb.SearchBl
 	opts.MaxBytes = q.limits.MaxBytesPerTrace(tenantID)
 
 	if api.IsTraceQLQuery(req.SearchReq) {
-		fetcher := traceql.NewSpansetFetcherWrapper(func(ctx context.Context, req traceql.FetchSpansRequest) (traceql.FetchSpansResponse, error) {
-			return q.store.Fetch(ctx, meta, req, opts)
-		})
+		fetcher := traceql.NewSpansetFetcherWrapper(
+			func(ctx context.Context, req traceql.FetchSpansRequest) (traceql.FetchSpansResponse, error) {
+				return q.store.Fetch(ctx, meta, req, opts)
+			},
+		)
 
 		return q.engine.ExecuteSearch(ctx, req.SearchReq, fetcher)
 	}
@@ -793,7 +859,10 @@ func (q *Querier) internalSearchBlock(ctx context.Context, req *tempopb.SearchBl
 	return q.store.Search(ctx, meta, req.SearchReq, opts)
 }
 
-func (q *Querier) postProcessIngesterSearchResults(req *tempopb.SearchRequest, rr []responseFromIngesters) *tempopb.SearchResponse {
+func (q *Querier) postProcessIngesterSearchResults(
+	req *tempopb.SearchRequest,
+	rr []responseFromIngesters,
+) *tempopb.SearchResponse {
 	response := &tempopb.SearchResponse{
 		Metrics: &tempopb.SearchMetrics{},
 	}
@@ -832,7 +901,12 @@ func (q *Querier) postProcessIngesterSearchResults(req *tempopb.SearchRequest, r
 	return response
 }
 
-func (q *Querier) searchExternalEndpoint(ctx context.Context, externalEndpoint string, maxBytes int, searchReq *tempopb.SearchBlockRequest) (*tempopb.SearchResponse, error) {
+func (q *Querier) searchExternalEndpoint(
+	ctx context.Context,
+	externalEndpoint string,
+	maxBytes int,
+	searchReq *tempopb.SearchBlockRequest,
+) (*tempopb.SearchResponse, error) {
 	req, err := http.NewRequest(http.MethodGet, externalEndpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("external endpoint failed to make new request: %w", err)

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -123,6 +123,9 @@ func NewPoller(cfg *PollerConfig, sharder JobSharder, reader backend.Reader, com
 
 // Do does the doing of getting a blocklist
 func (p *Poller) Do(ctx context.Context) (PerTenant, PerTenantCompacted, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Poller.Do")
+	defer span.Finish()
+
 	start := time.Now()
 	defer func() {
 		diff := time.Since(start).Seconds()

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -108,7 +108,14 @@ type Poller struct {
 }
 
 // NewPoller creates the Poller
-func NewPoller(cfg *PollerConfig, sharder JobSharder, reader backend.Reader, compactor backend.Compactor, writer backend.Writer, logger log.Logger) *Poller {
+func NewPoller(
+	cfg *PollerConfig,
+	sharder JobSharder,
+	reader backend.Reader,
+	compactor backend.Compactor,
+	writer backend.Writer,
+	logger log.Logger,
+) *Poller {
 	return &Poller{
 		reader:    reader,
 		compactor: compactor,
@@ -121,7 +128,7 @@ func NewPoller(cfg *PollerConfig, sharder JobSharder, reader backend.Reader, com
 }
 
 // Do does the doing of getting a blocklist
-func (p *Poller) Do() (PerTenant, PerTenantCompacted, error) {
+func (p *Poller) Do(ctx context.Context) (PerTenant, PerTenantCompacted, error) {
 	start := time.Now()
 	defer func() {
 		diff := time.Since(start).Seconds()
@@ -129,7 +136,6 @@ func (p *Poller) Do() (PerTenant, PerTenantCompacted, error) {
 		level.Info(p.logger).Log("msg", "blocklist poll complete", "seconds", diff)
 	}()
 
-	ctx := context.Background()
 	tenants, err := p.reader.Tenants(ctx)
 	if err != nil {
 		metricBlocklistErrors.WithLabelValues("").Inc()
@@ -147,7 +153,8 @@ func (p *Poller) Do() (PerTenant, PerTenantCompacted, error) {
 			level.Error(p.logger).Log("msg", "failed to poll or create index for tenant", "tenant", tenantID, "err", err)
 			consecutiveErrors++
 			if consecutiveErrors > p.cfg.TolerateConsecutiveErrors {
-				level.Error(p.logger).Log("msg", "exiting polling loop early because too many errors", "errCount", consecutiveErrors)
+				level.Error(p.logger).
+					Log("msg", "exiting polling loop early because too many errors", "errCount", consecutiveErrors)
 				return nil, nil, err
 			}
 			continue
@@ -160,16 +167,22 @@ func (p *Poller) Do() (PerTenant, PerTenantCompacted, error) {
 		compactedBlocklist[tenantID] = newCompactedBlockList
 
 		backendMetaMetrics := sumTotalBackendMetaMetrics(newBlockList, newCompactedBlockList)
-		metricBackendObjects.WithLabelValues(tenantID, blockStatusLiveLabel).Set(float64(backendMetaMetrics.blockMetaTotalObjects))
-		metricBackendObjects.WithLabelValues(tenantID, blockStatusCompactedLabel).Set(float64(backendMetaMetrics.compactedBlockMetaTotalObjects))
+		metricBackendObjects.WithLabelValues(tenantID, blockStatusLiveLabel).
+			Set(float64(backendMetaMetrics.blockMetaTotalObjects))
+		metricBackendObjects.WithLabelValues(tenantID, blockStatusCompactedLabel).
+			Set(float64(backendMetaMetrics.compactedBlockMetaTotalObjects))
 		metricBackendBytes.WithLabelValues(tenantID, blockStatusLiveLabel).Set(float64(backendMetaMetrics.blockMetaTotalBytes))
-		metricBackendBytes.WithLabelValues(tenantID, blockStatusCompactedLabel).Set(float64(backendMetaMetrics.compactedBlockMetaTotalBytes))
+		metricBackendBytes.WithLabelValues(tenantID, blockStatusCompactedLabel).
+			Set(float64(backendMetaMetrics.compactedBlockMetaTotalBytes))
 	}
 
 	return blocklist, compactedBlocklist, nil
 }
 
-func (p *Poller) pollTenantAndCreateIndex(ctx context.Context, tenantID string) ([]*backend.BlockMeta, []*backend.CompactedBlockMeta, error) {
+func (p *Poller) pollTenantAndCreateIndex(
+	ctx context.Context,
+	tenantID string,
+) ([]*backend.BlockMeta, []*backend.CompactedBlockMeta, error) {
 	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "poll tenant index")
 	defer span.Finish()
 
@@ -182,7 +195,8 @@ func (p *Poller) pollTenantAndCreateIndex(ctx context.Context, tenantID string) 
 		if err == nil {
 			// success! return the retrieved index
 			metricTenantIndexAgeSeconds.WithLabelValues(tenantID).Set(float64(time.Since(i.CreatedAt) / time.Second))
-			level.Info(p.logger).Log("msg", "successfully pulled tenant index", "tenant", tenantID, "createdAt", i.CreatedAt, "metas", len(i.Meta), "compactedMetas", len(i.CompactedMeta))
+			level.Info(p.logger).
+				Log("msg", "successfully pulled tenant index", "tenant", tenantID, "createdAt", i.CreatedAt, "metas", len(i.Meta), "compactedMetas", len(i.CompactedMeta))
 			return i.Meta, i.CompactedMeta, nil
 		}
 
@@ -194,7 +208,8 @@ func (p *Poller) pollTenantAndCreateIndex(ctx context.Context, tenantID string) 
 		}
 
 		// polling fallback is true, log the error and continue in this method to completely poll the backend
-		level.Error(p.logger).Log("msg", "failed to pull bucket index for tenant. falling back to polling", "tenant", tenantID, "err", err)
+		level.Error(p.logger).
+			Log("msg", "failed to pull bucket index for tenant. falling back to polling", "tenant", tenantID, "err", err)
 	}
 
 	// if we're here then we have been configured to be a tenant index builder OR there was a failure to pull
@@ -206,7 +221,8 @@ func (p *Poller) pollTenantAndCreateIndex(ctx context.Context, tenantID string) 
 	}
 
 	// everything is happy, write this tenant index
-	level.Info(p.logger).Log("msg", "writing tenant index", "tenant", tenantID, "metas", len(blocklist), "compactedMetas", len(compactedBlocklist))
+	level.Info(p.logger).
+		Log("msg", "writing tenant index", "tenant", tenantID, "metas", len(blocklist), "compactedMetas", len(compactedBlocklist))
 	err = p.writer.WriteTenantIndex(derivedCtx, tenantID, blocklist, compactedBlocklist)
 	if err != nil {
 		metricTenantIndexErrors.WithLabelValues(tenantID).Inc()
@@ -217,7 +233,10 @@ func (p *Poller) pollTenantAndCreateIndex(ctx context.Context, tenantID string) 
 	return blocklist, compactedBlocklist, nil
 }
 
-func (p *Poller) pollTenantBlocks(ctx context.Context, tenantID string) ([]*backend.BlockMeta, []*backend.CompactedBlockMeta, error) {
+func (p *Poller) pollTenantBlocks(
+	ctx context.Context,
+	tenantID string,
+) ([]*backend.BlockMeta, []*backend.CompactedBlockMeta, error) {
 	blockIDs, err := p.reader.Blocks(ctx, tenantID)
 	if err != nil {
 		metricBlocklistErrors.WithLabelValues(tenantID).Inc()
@@ -277,7 +296,11 @@ func (p *Poller) pollTenantBlocks(ctx context.Context, tenantID string) ([]*back
 	return newBlockList, newCompactedBlocklist, nil
 }
 
-func (p *Poller) pollBlock(ctx context.Context, tenantID string, blockID uuid.UUID) (*backend.BlockMeta, *backend.CompactedBlockMeta, error) {
+func (p *Poller) pollBlock(
+	ctx context.Context,
+	tenantID string,
+	blockID uuid.UUID,
+) (*backend.BlockMeta, *backend.CompactedBlockMeta, error) {
 	var compactedBlockMeta *backend.CompactedBlockMeta
 	blockMeta, err := p.reader.BlockMeta(ctx, blockID, tenantID)
 	// if the normal meta doesn't exist maybe it's compacted.
@@ -329,7 +352,10 @@ type backendMetaMetrics struct {
 	compactedBlockMetaTotalBytes   uint64
 }
 
-func sumTotalBackendMetaMetrics(blockMeta []*backend.BlockMeta, compactedBlockMeta []*backend.CompactedBlockMeta) backendMetaMetrics {
+func sumTotalBackendMetaMetrics(
+	blockMeta []*backend.BlockMeta,
+	compactedBlockMeta []*backend.CompactedBlockMeta,
+) backendMetaMetrics {
 	var sumTotalObjectsBM int
 	var sumTotalObjectsCBM int
 	var sumTotalBytesBM uint64

--- a/tempodb/blocklist/poller_test.go
+++ b/tempodb/blocklist/poller_test.go
@@ -9,8 +9,9 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/google/uuid"
-	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/tempo/tempodb/backend"
 )
 
 var (
@@ -239,14 +240,12 @@ func TestTenantIndexFallback(t *testing.T) {
 			}, nil, false)
 			w := &backend.MockWriter{}
 
-			r.(*backend.MockReader).TenantIndexFn = func(ctx context.Context, tenantID string) (*backend.TenantIndex, error) {
+			r.(*backend.MockReader).TenantIndexFn = func(_ context.Context, _ string) (*backend.TenantIndex, error) {
 				if tc.errorOnCreateTenantIndex {
 					return nil, errors.New("err")
 				}
 				return &backend.TenantIndex{
-					CreatedAt: time.Now().
-						Add(-5 * time.Minute),
-					// always make the tenant index 5 minutes old so the above tests can use that for fallback testing
+					CreatedAt: time.Now().Add(-5 * time.Minute), // always make the tenant index 5 minutes old so the above tests can use that for fallback testing
 				}, nil
 			}
 
@@ -531,15 +530,9 @@ func TestPollTolerateConsecutiveErrors(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			name:     "too many errors",
-			tolerate: 2,
-			tenantErrors: []error{
-				nil,
-				errors.New("tenant 1 err"),
-				errors.New("tenant 2 err"),
-				errors.New("tenant 3 err"),
-				nil,
-			},
+			name:          "too many errors",
+			tolerate:      2,
+			tenantErrors:  []error{nil, errors.New("tenant 1 err"), errors.New("tenant 2 err"), errors.New("tenant 3 err"), nil},
 			expectedError: errors.New("tenant 3 err"),
 		},
 	}

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -61,7 +61,7 @@ var (
 	}, []string{"tenant"})
 )
 
-func (db *tempoDB) compactionLoop(ctx context.Context) {
+func (db *TempoDB) compactionLoop(ctx context.Context) {
 	compactionCycle := DefaultCompactionCycle
 	if db.compactorCfg.CompactionCycle > 0 {
 		compactionCycle = db.compactorCfg.CompactionCycle
@@ -86,7 +86,7 @@ func (db *tempoDB) compactionLoop(ctx context.Context) {
 }
 
 // doCompaction runs a compaction cycle every 30s
-func (db *tempoDB) doCompaction(ctx context.Context) {
+func (db *TempoDB) doCompaction(ctx context.Context) {
 	// List of all tenants in the block list
 	// The block list is updated by constant polling the storage for tenant indexes and/or tenant blocks (and building the index)
 	tenants := db.blocklist.Tenants()
@@ -160,7 +160,7 @@ func (db *tempoDB) doCompaction(ctx context.Context) {
 	}
 }
 
-func (db *tempoDB) compact(ctx context.Context, blockMetas []*backend.BlockMeta, tenantID string) error {
+func (db *TempoDB) compact(ctx context.Context, blockMetas []*backend.BlockMeta, tenantID string) error {
 	level.Debug(db.logger).Log("msg", "beginning compaction", "num blocks compacting", len(blockMetas))
 
 	// todo - add timeout?
@@ -256,7 +256,7 @@ func (db *tempoDB) compact(ctx context.Context, blockMetas []*backend.BlockMeta,
 	return nil
 }
 
-func markCompacted(db *tempoDB, tenantID string, oldBlocks []*backend.BlockMeta, newBlocks []*backend.BlockMeta) error {
+func markCompacted(db *TempoDB, tenantID string, oldBlocks []*backend.BlockMeta, newBlocks []*backend.BlockMeta) error {
 	// Check if we have any errors, but continue marking the blocks as compacted
 	var errCount int
 	for _, meta := range oldBlocks {

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -685,7 +685,7 @@ func cutTestBlockWithTraces(t testing.TB, w Writer, tenantID string, data []test
 func cutTestBlocks(
 	ctx context.Context,
 	t testing.TB,
-	w *tempoDB,
+	w *TempoDB,
 	tenantID string,
 	blockCount int,
 	recordCount int,

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -148,14 +148,7 @@ func testCompactionRoundtrip(t *testing.T, targetBlockVersion string) {
 	rw.pollBlocklist(ctx)
 
 	blocklist := rw.blocklist.Metas(testTenantID)
-	blockSelector := newTimeWindowBlockSelector(
-		blocklist,
-		rw.compactorCfg.MaxCompactionRange,
-		10000,
-		1024*1024*1024,
-		defaultMinInputBlocks,
-		2,
-	)
+	blockSelector := newTimeWindowBlockSelector(blocklist, rw.compactorCfg.MaxCompactionRange, 10000, 1024*1024*1024, defaultMinInputBlocks, 2)
 
 	expectedCompactions := len(blocklist) / inputBlocks
 	compactions := 0
@@ -321,14 +314,7 @@ func testSameIDCompaction(t *testing.T, targetBlockVersion string) {
 
 	var blocks []*backend.BlockMeta
 	list := rw.blocklist.Metas(testTenantID)
-	blockSelector := newTimeWindowBlockSelector(
-		list,
-		rw.compactorCfg.MaxCompactionRange,
-		10000,
-		1024*1024*1024,
-		defaultMinInputBlocks,
-		blockCount,
-	)
+	blockSelector := newTimeWindowBlockSelector(list, rw.compactorCfg.MaxCompactionRange, 10000, 1024*1024*1024, defaultMinInputBlocks, blockCount)
 	blocks, _ = blockSelector.BlocksToCompact()
 	require.Len(t, blocks, blockCount)
 
@@ -513,11 +499,7 @@ func TestCompactionMetrics(t *testing.T) {
 
 	bytesEnd, err := test.GetCounterVecValue(metricCompactionBytesWritten, "0")
 	assert.NoError(t, err)
-	assert.Greater(
-		t,
-		bytesEnd,
-		bytesStart,
-	) // calculating the exact bytes requires knowledge of the bytes as written in the blocks.  just make sure it goes up
+	assert.Greater(t, bytesEnd, bytesStart) // calculating the exact bytes requires knowledge of the bytes as written in the blocks.  just make sure it goes up
 }
 
 func TestCompactionIteratesThroughTenants(t *testing.T) {
@@ -682,14 +664,7 @@ func cutTestBlockWithTraces(t testing.TB, w Writer, tenantID string, data []test
 	return b
 }
 
-func cutTestBlocks(
-	ctx context.Context,
-	t testing.TB,
-	w *TempoDB,
-	tenantID string,
-	blockCount int,
-	recordCount int,
-) []common.BackendBlock {
+func cutTestBlocks(ctx context.Context, t testing.TB, w *TempoDB, tenantID string, blockCount int, recordCount int) []common.BackendBlock {
 	blocks := make([]common.BackendBlock, 0)
 	dec := model.MustNewSegmentDecoder(model.CurrentEncoding)
 

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -412,7 +412,7 @@ func TestCompactionUpdatesBlocklist(t *testing.T) {
 	// Cut x blocks with y records each
 	blockCount := 5
 	recordCount := 1
-	cutTestBlocks(t, ctx, db, testTenantID, blockCount, recordCount)
+	cutTestBlocks(ctx, t, db, testTenantID, blockCount, recordCount)
 
 	rw := db
 	db.pollBlocklist(ctx)
@@ -483,7 +483,7 @@ func TestCompactionMetrics(t *testing.T) {
 	// Cut x blocks with y records each
 	blockCount := 5
 	recordCount := 10
-	cutTestBlocks(t, ctx, db, testTenantID, blockCount, recordCount)
+	cutTestBlocks(ctx, t, db, testTenantID, blockCount, recordCount)
 
 	rw := db
 	db.pollBlocklist(ctx)
@@ -561,8 +561,8 @@ func TestCompactionIteratesThroughTenants(t *testing.T) {
 	db.EnablePolling(ctx, &mockJobSharder{})
 
 	// Cut blocks for multiple tenants
-	cutTestBlocks(t, ctx, db, testTenantID, 2, 2)
-	cutTestBlocks(t, ctx, db, testTenantID2, 2, 2)
+	cutTestBlocks(ctx, t, db, testTenantID, 2, 2)
+	cutTestBlocks(ctx, t, db, testTenantID2, 2, 2)
 
 	rw := db
 	db.pollBlocklist(ctx)
@@ -682,7 +682,14 @@ func cutTestBlockWithTraces(t testing.TB, w Writer, tenantID string, data []test
 	return b
 }
 
-func cutTestBlocks(t testing.TB, ctx context.Context, w *tempoDB, tenantID string, blockCount int, recordCount int) []common.BackendBlock {
+func cutTestBlocks(
+	ctx context.Context,
+	t testing.TB,
+	w *tempoDB,
+	tenantID string,
+	blockCount int,
+	recordCount int,
+) []common.BackendBlock {
 	blocks := make([]common.BackendBlock, 0)
 	dec := model.MustNewSegmentDecoder(model.CurrentEncoding)
 
@@ -764,7 +771,7 @@ func benchmarkCompaction(b *testing.B, targetBlockVersion string) {
 	blockCount := 8
 
 	// Cut input blocks
-	blocks := cutTestBlocks(b, ctx, db, testTenantID, blockCount, traceCount)
+	blocks := cutTestBlocks(ctx, b, db, testTenantID, blockCount, traceCount)
 	metas := make([]*backend.BlockMeta, 0)
 	for _, b := range blocks {
 		metas = append(metas, b.BlockMeta())

--- a/tempodb/config.go
+++ b/tempodb/config.go
@@ -65,6 +65,13 @@ type Config struct {
 	Redis                   *redis.Config           `yaml:"redis"`
 }
 
+func (c *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {
+	c.BlocklistPollFallback = true
+	c.BlocklistPollConcurrency = DefaultBlocklistPollConcurrency
+	c.BlocklistPollTenantIndexBuilders = DefaultTenantIndexBuilders
+	c.BlocklistPollTolerateConsecutiveErrors = DefaultTolerateConsecutiveErrors
+}
+
 type SearchConfig struct {
 	// v2 blocks
 	ChunkSizeBytes     uint32 `yaml:"chunk_size_bytes"`

--- a/tempodb/retention.go
+++ b/tempodb/retention.go
@@ -11,7 +11,7 @@ import (
 )
 
 // retentionLoop watches a timer to clean up blocks that are past retention.
-func (db *tempoDB) retentionLoop(ctx context.Context) {
+func (db *TempoDB) retentionLoop(ctx context.Context) {
 	ticker := time.NewTicker(db.cfg.BlocklistPoll)
 	for {
 		select {
@@ -29,7 +29,7 @@ func (db *tempoDB) retentionLoop(ctx context.Context) {
 	}
 }
 
-func (db *tempoDB) doRetention(ctx context.Context) {
+func (db *TempoDB) doRetention(ctx context.Context) {
 	tenants := db.blocklist.Tenants()
 
 	bg := boundedwaitgroup.New(db.compactorCfg.RetentionConcurrency)
@@ -45,7 +45,7 @@ func (db *tempoDB) doRetention(ctx context.Context) {
 	bg.Wait()
 }
 
-func (db *tempoDB) retainTenant(ctx context.Context, tenantID string) {
+func (db *TempoDB) retainTenant(ctx context.Context, tenantID string) {
 	start := time.Now()
 	defer func() { metricRetentionDuration.Observe(time.Since(start).Seconds()) }()
 

--- a/tempodb/retention.go
+++ b/tempodb/retention.go
@@ -11,8 +11,8 @@ import (
 )
 
 // retentionLoop watches a timer to clean up blocks that are past retention.
-func (rw *readerWriter) retentionLoop(ctx context.Context) {
-	ticker := time.NewTicker(rw.cfg.BlocklistPoll)
+func (db *tempoDB) retentionLoop(ctx context.Context) {
+	ticker := time.NewTicker(db.cfg.BlocklistPoll)
 	for {
 		select {
 		case <-ctx.Done():
@@ -22,58 +22,58 @@ func (rw *readerWriter) retentionLoop(ctx context.Context) {
 
 		select {
 		case <-ticker.C:
-			rw.doRetention(ctx)
+			db.doRetention(ctx)
 		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-func (rw *readerWriter) doRetention(ctx context.Context) {
-	tenants := rw.blocklist.Tenants()
+func (db *tempoDB) doRetention(ctx context.Context) {
+	tenants := db.blocklist.Tenants()
 
-	bg := boundedwaitgroup.New(rw.compactorCfg.RetentionConcurrency)
+	bg := boundedwaitgroup.New(db.compactorCfg.RetentionConcurrency)
 
 	for _, tenantID := range tenants {
 		bg.Add(1)
 		go func(t string) {
 			defer bg.Done()
-			rw.retainTenant(ctx, t)
+			db.retainTenant(ctx, t)
 		}(tenantID)
 	}
 
 	bg.Wait()
 }
 
-func (rw *readerWriter) retainTenant(ctx context.Context, tenantID string) {
+func (db *tempoDB) retainTenant(ctx context.Context, tenantID string) {
 	start := time.Now()
 	defer func() { metricRetentionDuration.Observe(time.Since(start).Seconds()) }()
 
 	// Check for overrides
-	retention := rw.compactorCfg.BlockRetention // Default
-	if r := rw.compactorOverrides.BlockRetentionForTenant(tenantID); r != 0 {
+	retention := db.compactorCfg.BlockRetention // Default
+	if r := db.compactorOverrides.BlockRetentionForTenant(tenantID); r != 0 {
 		retention = r
 	}
-	level.Debug(rw.logger).Log("msg", "Performing block retention", "tenantID", tenantID, "retention", retention)
+	level.Debug(db.logger).Log("msg", "Performing block retention", "tenantID", tenantID, "retention", retention)
 
 	// iterate through block list.  make compacted anything that is past retention.
 	cutoff := time.Now().Add(-retention)
-	blocklist := rw.blocklist.Metas(tenantID)
+	blocklist := db.blocklist.Metas(tenantID)
 	for _, b := range blocklist {
 		select {
 		case <-ctx.Done():
 			return
 		default:
-			if b.EndTime.Before(cutoff) && rw.compactorSharder.Owns(b.BlockID.String()) {
-				level.Info(rw.logger).Log("msg", "marking block for deletion", "blockID", b.BlockID, "tenantID", tenantID)
-				err := rw.c.MarkBlockCompacted(b.BlockID, tenantID)
+			if b.EndTime.Before(cutoff) && db.compactorSharder.Owns(b.BlockID.String()) {
+				level.Info(db.logger).Log("msg", "marking block for deletion", "blockID", b.BlockID, "tenantID", tenantID)
+				err := db.c.MarkBlockCompacted(b.BlockID, tenantID)
 				if err != nil {
-					level.Error(rw.logger).Log("msg", "failed to mark block compacted during retention", "blockID", b.BlockID, "tenantID", tenantID, "err", err)
+					level.Error(db.logger).Log("msg", "failed to mark block compacted during retention", "blockID", b.BlockID, "tenantID", tenantID, "err", err)
 					metricRetentionErrors.Inc()
 				} else {
 					metricMarkedForDeletion.Inc()
 
-					rw.blocklist.Update(tenantID, nil, []*backend.BlockMeta{b}, []*backend.CompactedBlockMeta{
+					db.blocklist.Update(tenantID, nil, []*backend.BlockMeta{b}, []*backend.CompactedBlockMeta{
 						{
 							BlockMeta:     *b,
 							CompactedTime: time.Now(),
@@ -85,24 +85,24 @@ func (rw *readerWriter) retainTenant(ctx context.Context, tenantID string) {
 	}
 
 	// iterate through compacted list looking for blocks ready to be cleared
-	cutoff = time.Now().Add(-rw.compactorCfg.CompactedBlockRetention)
-	compactedBlocklist := rw.blocklist.CompactedMetas(tenantID)
+	cutoff = time.Now().Add(-db.compactorCfg.CompactedBlockRetention)
+	compactedBlocklist := db.blocklist.CompactedMetas(tenantID)
 	for _, b := range compactedBlocklist {
 		select {
 		case <-ctx.Done():
 			return
 		default:
-			level.Debug(rw.logger).Log("owns", rw.compactorSharder.Owns(b.BlockID.String()), "blockID", b.BlockID, "tenantID", tenantID)
-			if b.CompactedTime.Before(cutoff) && rw.compactorSharder.Owns(b.BlockID.String()) {
-				level.Info(rw.logger).Log("msg", "deleting block", "blockID", b.BlockID, "tenantID", tenantID)
-				err := rw.c.ClearBlock(b.BlockID, tenantID)
+			level.Debug(db.logger).Log("owns", db.compactorSharder.Owns(b.BlockID.String()), "blockID", b.BlockID, "tenantID", tenantID)
+			if b.CompactedTime.Before(cutoff) && db.compactorSharder.Owns(b.BlockID.String()) {
+				level.Info(db.logger).Log("msg", "deleting block", "blockID", b.BlockID, "tenantID", tenantID)
+				err := db.c.ClearBlock(b.BlockID, tenantID)
 				if err != nil {
-					level.Error(rw.logger).Log("msg", "failed to clear compacted block during retention", "blockID", b.BlockID, "tenantID", tenantID, "err", err)
+					level.Error(db.logger).Log("msg", "failed to clear compacted block during retention", "blockID", b.BlockID, "tenantID", tenantID, "err", err)
 					metricRetentionErrors.Inc()
 				} else {
 					metricDeleted.Inc()
 
-					rw.blocklist.Update(tenantID, nil, nil, nil, []*backend.CompactedBlockMeta{b})
+					db.blocklist.Update(tenantID, nil, nil, nil, []*backend.CompactedBlockMeta{b})
 				}
 			}
 		}

--- a/tempodb/retention_test.go
+++ b/tempodb/retention_test.go
@@ -185,7 +185,7 @@ func TestBlockRetentionOverride(t *testing.T) {
 
 	db.EnablePolling(ctx, &mockJobSharder{})
 
-	cutTestBlocks(t, ctx, db, testTenantID, 10, 10)
+	cutTestBlocks(ctx, t, db, testTenantID, 10, 10)
 
 	// The test spans are all 1 second long, so we have to sleep to put all the
 	// data in the past

--- a/tempodb/retention_test.go
+++ b/tempodb/retention_test.go
@@ -22,7 +22,7 @@ import (
 func TestRetention(t *testing.T) {
 	tempDir := t.TempDir()
 
-	r, w, c, err := New(&Config{
+	db, err := New(&Config{
 		Backend: backend.Local,
 		Local: &local.Config{
 			Path: path.Join(tempDir, "traces"),
@@ -43,7 +43,7 @@ func TestRetention(t *testing.T) {
 	assert.NoError(t, err)
 
 	ctx := context.Background()
-	err = c.EnableCompaction(ctx, &CompactorConfig{
+	err = db.EnableCompaction(ctx, &CompactorConfig{
 		ChunkSizeBytes:          10,
 		MaxCompactionRange:      time.Hour,
 		BlockRetention:          0,
@@ -51,31 +51,30 @@ func TestRetention(t *testing.T) {
 	}, &mockSharder{}, &mockOverrides{})
 	require.NoError(t, err)
 
-	r.EnablePolling(&mockJobSharder{})
+	db.EnablePolling(ctx, &mockJobSharder{})
 
 	blockID := uuid.New()
 
-	wal := w.WAL()
+	wal := db.WAL()
 	assert.NoError(t, err)
 
 	head, err := wal.NewBlock(blockID, testTenantID, model.CurrentEncoding)
 	assert.NoError(t, err)
 
-	complete, err := w.CompleteBlock(context.Background(), head)
+	complete, err := db.CompleteBlock(ctx, head)
 	assert.NoError(t, err)
 	blockID = complete.BlockMeta().BlockID
 
-	rw := r.(*readerWriter)
 	// poll
-	checkBlocklists(t, blockID, 1, 0, rw)
+	checkBlocklists(t, blockID, 1, 0, db)
 
 	// retention should mark it compacted
-	r.(*readerWriter).doRetention(ctx)
-	checkBlocklists(t, blockID, 0, 1, rw)
+	db.doRetention(ctx)
+	checkBlocklists(t, blockID, 0, 1, db)
 
 	// retention again should clear it
-	r.(*readerWriter).doRetention(ctx)
-	checkBlocklists(t, blockID, 0, 0, rw)
+	db.doRetention(ctx)
+	checkBlocklists(t, blockID, 0, 0, db)
 }
 
 func TestRetentionUpdatesBlocklistImmediately(t *testing.T) {
@@ -85,7 +84,7 @@ func TestRetentionUpdatesBlocklistImmediately(t *testing.T) {
 
 	tempDir := t.TempDir()
 
-	r, w, c, err := New(&Config{
+	db, err := New(&Config{
 		Backend: backend.Local,
 		Local: &local.Config{
 			Path: path.Join(tempDir, "traces"),
@@ -105,9 +104,10 @@ func TestRetentionUpdatesBlocklistImmediately(t *testing.T) {
 	}, log.NewNopLogger())
 	assert.NoError(t, err)
 
-	r.EnablePolling(&mockJobSharder{})
+	ctx := context.Background()
+	db.EnablePolling(ctx, &mockJobSharder{})
 
-	err = c.EnableCompaction(context.Background(), &CompactorConfig{
+	err = db.EnableCompaction(ctx, &CompactorConfig{
 		ChunkSizeBytes:          10,
 		MaxCompactionRange:      time.Hour,
 		BlockRetention:          0,
@@ -115,7 +115,7 @@ func TestRetentionUpdatesBlocklistImmediately(t *testing.T) {
 	}, &mockSharder{}, &mockOverrides{})
 	require.NoError(t, err)
 
-	wal := w.WAL()
+	wal := db.WAL()
 	assert.NoError(t, err)
 
 	blockID := uuid.New()
@@ -123,38 +123,36 @@ func TestRetentionUpdatesBlocklistImmediately(t *testing.T) {
 	head, err := wal.NewBlock(blockID, testTenantID, model.CurrentEncoding)
 	assert.NoError(t, err)
 
-	ctx := context.Background()
-	complete, err := w.CompleteBlock(ctx, head)
+	complete, err := db.CompleteBlock(ctx, head)
 	assert.NoError(t, err)
 	blockID = complete.BlockMeta().BlockID
 
 	// We have a block
-	rw := r.(*readerWriter)
-	rw.pollBlocklist()
-	require.Equal(t, blockID, rw.blocklist.Metas(testTenantID)[0].BlockID)
+	db.pollBlocklist(ctx)
+	require.Equal(t, blockID, db.blocklist.Metas(testTenantID)[0].BlockID)
 
 	// Mark it compacted
-	r.(*readerWriter).compactorCfg.BlockRetention = 0 // Immediately delete
-	r.(*readerWriter).compactorCfg.CompactedBlockRetention = time.Hour
-	r.(*readerWriter).doRetention(ctx)
+	db.compactorCfg.BlockRetention = 0 // Immediately delete
+	db.compactorCfg.CompactedBlockRetention = time.Hour
+	db.doRetention(ctx)
 
 	// Immediately compacted
-	require.Empty(t, rw.blocklist.Metas(testTenantID))
-	require.Equal(t, blockID, rw.blocklist.CompactedMetas(testTenantID)[0].BlockID)
+	require.Empty(t, db.blocklist.Metas(testTenantID))
+	require.Equal(t, blockID, db.blocklist.CompactedMetas(testTenantID)[0].BlockID)
 
 	// Now delete it permanently
-	r.(*readerWriter).compactorCfg.BlockRetention = time.Hour
-	r.(*readerWriter).compactorCfg.CompactedBlockRetention = 0 // Immediately delete
-	r.(*readerWriter).doRetention(ctx)
+	db.compactorCfg.BlockRetention = time.Hour
+	db.compactorCfg.CompactedBlockRetention = 0 // Immediately delete
+	db.doRetention(ctx)
 
-	require.Empty(t, rw.blocklist.Metas(testTenantID))
-	require.Empty(t, rw.blocklist.CompactedMetas(testTenantID))
+	require.Empty(t, db.blocklist.Metas(testTenantID))
+	require.Empty(t, db.blocklist.CompactedMetas(testTenantID))
 }
 
 func TestBlockRetentionOverride(t *testing.T) {
 	tempDir := t.TempDir()
 
-	r, w, c, err := New(&Config{
+	db, err := New(&Config{
 		Backend: backend.Local,
 		Local: &local.Config{
 			Path: path.Join(tempDir, "traces"),
@@ -177,7 +175,7 @@ func TestBlockRetentionOverride(t *testing.T) {
 	overrides := &mockOverrides{}
 
 	ctx := context.Background()
-	err = c.EnableCompaction(ctx, &CompactorConfig{
+	err = db.EnableCompaction(ctx, &CompactorConfig{
 		ChunkSizeBytes:          10,
 		MaxCompactionRange:      time.Hour,
 		BlockRetention:          time.Hour,
@@ -185,33 +183,34 @@ func TestBlockRetentionOverride(t *testing.T) {
 	}, &mockSharder{}, overrides)
 	require.NoError(t, err)
 
-	r.EnablePolling(&mockJobSharder{})
+	db.EnablePolling(ctx, &mockJobSharder{})
 
-	cutTestBlocks(t, w, testTenantID, 10, 10)
+	cutTestBlocks(t, ctx, db, testTenantID, 10, 10)
 
 	// The test spans are all 1 second long, so we have to sleep to put all the
 	// data in the past
 	time.Sleep(time.Second)
 
-	rw := r.(*readerWriter)
-	rw.pollBlocklist()
-	require.Equal(t, 10, len(rw.blocklist.Metas(testTenantID)))
+	t.Logf("blocklist: %+v", db.blocklist)
+
+	db.pollBlocklist(ctx)
+	require.Equal(t, 10, len(db.blocklist.Metas(testTenantID)))
 
 	// Retention = 1 hour, does nothing
 	overrides.blockRetention = time.Hour
-	r.(*readerWriter).doRetention(ctx)
-	rw.pollBlocklist()
-	require.Equal(t, 10, len(rw.blocklist.Metas(testTenantID)))
+	db.doRetention(ctx)
+	db.pollBlocklist(ctx)
+	require.Equal(t, 10, len(db.blocklist.Metas(testTenantID)))
 
 	// Retention = 1 minute, still does nothing
 	overrides.blockRetention = time.Minute
-	r.(*readerWriter).doRetention(ctx)
-	rw.pollBlocklist()
-	require.Equal(t, 10, len(rw.blocklist.Metas(testTenantID)))
+	db.doRetention(ctx)
+	db.pollBlocklist(ctx)
+	require.Equal(t, 10, len(db.blocklist.Metas(testTenantID)))
 
 	// Retention = 1ns, deletes everything
 	overrides.blockRetention = time.Nanosecond
-	r.(*readerWriter).doRetention(ctx)
-	rw.pollBlocklist()
-	require.Equal(t, 0, len(rw.blocklist.Metas(testTenantID)))
+	db.doRetention(ctx)
+	db.pollBlocklist(ctx)
+	require.Equal(t, 0, len(db.blocklist.Metas(testTenantID)))
 }

--- a/tempodb/tempodb_test.go
+++ b/tempodb/tempodb_test.go
@@ -33,12 +33,7 @@ const (
 
 type testConfigOption func(*Config)
 
-func testConfig(
-	t *testing.T,
-	enc backend.Encoding,
-	blocklistPoll time.Duration,
-	opts ...testConfigOption,
-) (*TempoDB, string) {
+func testConfig(t *testing.T, enc backend.Encoding, blocklistPoll time.Duration, opts ...testConfigOption) (*TempoDB, string) {
 	tempDir := t.TempDir()
 
 	cfg := &Config{
@@ -758,23 +753,12 @@ func TestShouldCache(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(
-				t,
-				tt.cache,
-				db.shouldCache(&backend.BlockMeta{CompactionLevel: tt.compactionLevel, StartTime: tt.startTime}, time.Now()),
-			)
+			assert.Equal(t, tt.cache, db.shouldCache(&backend.BlockMeta{CompactionLevel: tt.compactionLevel, StartTime: tt.startTime}, time.Now()))
 		})
 	}
 }
 
-func writeTraceToWal(
-	t require.TestingT,
-	b common.WALBlock,
-	dec model.SegmentDecoder,
-	id common.ID,
-	tr *tempopb.Trace,
-	start, end uint32,
-) {
+func writeTraceToWal(t require.TestingT, b common.WALBlock, dec model.SegmentDecoder, id common.ID, tr *tempopb.Trace, start, end uint32) {
 	b1, err := dec.PrepareForWrite(tr, 0, 0)
 	require.NoError(t, err)
 

--- a/tempodb/tempodb_test.go
+++ b/tempodb/tempodb_test.go
@@ -38,7 +38,7 @@ func testConfig(
 	enc backend.Encoding,
 	blocklistPoll time.Duration,
 	opts ...testConfigOption,
-) (*tempoDB, string) {
+) (*TempoDB, string) {
 	tempDir := t.TempDir()
 
 	cfg := &Config{
@@ -224,7 +224,7 @@ func TestBlockCleanup(t *testing.T) {
 	assert.Equal(t, 0, len(m))
 }
 
-func checkBlocklists(t *testing.T, expectedID uuid.UUID, expectedB int, expectedCB int, db *tempoDB) {
+func checkBlocklists(t *testing.T, expectedID uuid.UUID, expectedB int, expectedCB int, db *TempoDB) {
 	db.pollBlocklist(context.Background())
 
 	blocklist := db.blocklist.Metas(testTenantID)


### PR DESCRIPTION
**What this PR does**:

The poller has write operations which, if not canceled, have unknown behavior.  In order to pass the service context into the poller, this change proposes moving the poller itself into a module that can be used as a dependency and allow for more control over the termination of the write operations to the backend.

Also included here is a rename of the instance variables as well as the instance type of tempoDB.  I believe this is more clear as to the intention.

Structurally, the `tempodb.New` now returns the `tempoDB` instance. This allows the caller to use the returned instance as whatever interface is desired. Adjustments for this contract have been updated everywhere.

Additional formatting changes for `gofumpt` taking over my editor.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`