### PR TITLE
Fix panic with unmatched descendant selectors

### DIFF
--- a/pkg/traceql/ast_execute.go
+++ b/pkg/traceql/ast_execute.go
@@ -181,16 +181,12 @@ func (o *SpansetOperation) joinSpansAndReturnRHS(lhs, rhs []Span, eval func(l, r
 
 	o.matchingSpansBuffer = o.matchingSpansBuffer[:0]
 
-	for _, l := range lhs {
-		for i, r := range rhs {
-			if r == nil {
-				// Already matched
-				continue
-			}
+	for _, r := range rhs {
+		for _, l := range lhs {
 			if eval(l, r) {
 				// Returns RHS
 				o.matchingSpansBuffer = append(o.matchingSpansBuffer, r)
-				rhs[i] = nil // No need to check this span again
+				break
 			}
 		}
 	}

--- a/pkg/traceql/ast_execute_test.go
+++ b/pkg/traceql/ast_execute_test.go
@@ -377,15 +377,25 @@ func TestSpansetOperationEvaluate(t *testing.T) {
 			"{ .child1 } ~ { .child2 }",
 			[]*Spanset{
 				{Spans: []Span{
-					newMockSpan([]byte{1}).WithAttrBool("child1", true).WithNestedSetInfo(1, 1, 2),
-					newMockSpan([]byte{1}).WithAttrBool("child2", true).WithNestedSetInfo(1, 3, 4),
+					newMockSpan([]byte{1}).WithAttrBool("child1", true).WithNestedSetInfo(1, 2, 3),
+					newMockSpan([]byte{1}).WithAttrBool("child2", true).WithNestedSetInfo(1, 4, 5),
 				}},
 			},
 			[]*Spanset{
 				{Spans: []Span{
-					newMockSpan([]byte{1}).WithAttrBool("child2", true).WithNestedSetInfo(1, 3, 4),
+					newMockSpan([]byte{1}).WithAttrBool("child2", true).WithNestedSetInfo(1, 4, 5),
 				}},
 			},
+		},
+		{ // tests that child operators do not modify the spanset
+			"{ } > { } > { } > { }",
+			[]*Spanset{
+				{Spans: []Span{
+					newMockSpan([]byte{1}).WithAttrBool("child1", true).WithNestedSetInfo(1, 2, 3),
+					newMockSpan([]byte{1}).WithAttrBool("child2", true).WithNestedSetInfo(1, 4, 5),
+				}},
+			},
+			[]*Spanset{},
 		},
 	}
 


### PR DESCRIPTION
**What this PR does**:
Under certain circumstances the descendant operators will adjust the input slice by setting a member to nil for record keeping:

https://github.com/grafana/tempo/blob/3b618cc343ed79399985bc06a553662994a3cf9c/pkg/traceql/ast_execute.go#L193

Later when the encoding layer attempts to recover the span it panics b/c the span is nil:

https://github.com/grafana/tempo/blob/3b618cc343ed79399985bc06a553662994a3cf9c/tempodb/encoding/vparquet2/block_traceql.go#L414

This PR fixes the issue by not modifying the input slice and adds a test to check for this condition.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`