### PR TITLE
Delete the index for empty tenants

### DIFF
--- a/modules/querier/external/client_test.go
+++ b/modules/querier/external/client_test.go
@@ -93,6 +93,7 @@ func (t *stubbedProvider) getToken(_ context.Context, _ string) (*oauth2.Token, 
 		AccessToken: t.dummyToken,
 	}, nil
 }
+
 func getStubbedTokenProvider(dummyToken string) tokenProvider {
 	return &stubbedProvider{dummyToken: dummyToken}
 }

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -89,6 +89,11 @@ func (w *writer) CloseAppend(ctx context.Context, tracker AppendTracker) error {
 }
 
 func (w *writer) WriteTenantIndex(ctx context.Context, tenantID string, meta []*BlockMeta, compactedMeta []*CompactedBlockMeta) error {
+	// If meta and compactedMeta are empty, call delete the tenant index.
+	if len(meta) == 0 && len(compactedMeta) == 0 {
+		return w.w.Delete(ctx, TenantIndexName, KeyPath([]string{tenantID}))
+	}
+
 	b := newTenantIndex(meta, compactedMeta)
 
 	indexBytes, err := b.marshal()

--- a/tempodb/backend/raw_test.go
+++ b/tempodb/backend/raw_test.go
@@ -50,6 +50,15 @@ func TestWriter(t *testing.T) {
 
 	assert.True(t, cmp.Equal([]*BlockMeta{meta}, idx.Meta))                  // using cmp.Equal to compare json datetimes
 	assert.True(t, cmp.Equal([]*CompactedBlockMeta(nil), idx.CompactedMeta)) // using cmp.Equal to compare json datetimes
+
+	// When there are no blocks, the tenant index should be deleted
+	assert.Equal(t, map[string]map[string]int(nil), w.(*writer).w.(*MockRawWriter).deleteCalls)
+
+	err = w.WriteTenantIndex(ctx, "test", nil, nil)
+	assert.NoError(t, err)
+
+	expectedDeletMap := map[string]map[string]int{TenantIndexName: {"test": 1}}
+	assert.Equal(t, expectedDeletMap, w.(*writer).w.(*MockRawWriter).deleteCalls)
 }
 
 func TestReader(t *testing.T) {

--- a/tempodb/backend/raw_test.go
+++ b/tempodb/backend/raw_test.go
@@ -57,8 +57,8 @@ func TestWriter(t *testing.T) {
 	err = w.WriteTenantIndex(ctx, "test", nil, nil)
 	assert.NoError(t, err)
 
-	expectedDeletMap := map[string]map[string]int{TenantIndexName: {"test": 1}}
-	assert.Equal(t, expectedDeletMap, w.(*writer).w.(*MockRawWriter).deleteCalls)
+	expectedDeleteMap := map[string]map[string]int{TenantIndexName: {"test": 1}}
+	assert.Equal(t, expectedDeleteMap, w.(*writer).w.(*MockRawWriter).deleteCalls)
 }
 
 func TestReader(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:

When a tenant stops writing to tempo, the blocks eventually get cleaned up by the retention, but the tenant index is still left and so the tenant is still left in the list when the poller determines which indexes to pull.  This can create additional load for no benefit long term if the tenant doesn't return with traffic.

Here we call the recently implemented `Delete` on the `RawWriter` to remove the tenant indexes from the backend to complete the deletion of all tenant objects when no blocks or compacted blocks have been found to exist.

**Which issue(s) this PR fixes**:
Fixes #2520

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`