### PR TITLE
Avoid panic in cachedWriter

### DIFF
--- a/modules/overrides/userconfigurableapi/client.go
+++ b/modules/overrides/userconfigurableapi/client.go
@@ -158,5 +158,5 @@ func (o *userConfigOverridesClient) Delete(ctx context.Context, userID string) e
 	defer span.Finish()
 	span.SetTag("tenant", userID)
 
-	return o.w.Delete(ctx, OverridesFileName, []string{OverridesKeyPath, userID})
+	return o.w.Delete(ctx, OverridesFileName, []string{OverridesKeyPath, userID}, false)
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -13,7 +13,7 @@ import (
 // when they returned an error.
 type Cache interface {
 	Store(ctx context.Context, key []string, buf [][]byte)
-	// TODO: ?
+	// TODO: both cached backend clients support deletion. Should we implement?
 	// Remove(ctx context.Context, key []string)
 	Fetch(ctx context.Context, keys []string) (found []string, bufs [][]byte, missing []string)
 	Stop()

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -13,6 +13,8 @@ import (
 // when they returned an error.
 type Cache interface {
 	Store(ctx context.Context, key []string, buf [][]byte)
+	// TODO: ?
+	// Remove(ctx context.Context, key []string)
 	Fetch(ctx context.Context, keys []string) (found []string, bufs [][]byte, missing []string)
 	Stop()
 }

--- a/tempodb/backend/azure/azure.go
+++ b/tempodb/backend/azure/azure.go
@@ -113,7 +113,7 @@ func (rw *readerWriter) CloseAppend(context.Context, backend.AppendTracker) erro
 	return nil
 }
 
-func (rw *readerWriter) Delete(ctx context.Context, name string, keypath backend.KeyPath) error {
+func (rw *readerWriter) Delete(ctx context.Context, name string, keypath backend.KeyPath, _ bool) error {
 	blobURL, err := GetBlobURL(ctx, rw.cfg, backend.ObjectFileName(keypath, name))
 	if err != nil {
 		return errors.Wrapf(err, "cannot get Azure blob URL, name: %s", backend.ObjectFileName(keypath, name))

--- a/tempodb/backend/cache/cache.go
+++ b/tempodb/backend/cache/cache.go
@@ -110,8 +110,11 @@ func (r *readerWriter) CloseAppend(ctx context.Context, tracker backend.AppendTr
 	return r.nextWriter.CloseAppend(ctx, tracker)
 }
 
-func (r *readerWriter) Delete(ctx context.Context, name string, keypath backend.KeyPath) error {
-	return r.nextWriter.Delete(ctx, name, keypath)
+func (r *readerWriter) Delete(ctx context.Context, name string, keypath backend.KeyPath, shouldCache bool) error {
+	if shouldCache {
+		panic("delete is not supported for cache.Cache backend")
+	}
+	return r.nextWriter.Delete(ctx, name, keypath, shouldCache)
 }
 
 func key(keypath backend.KeyPath, name string) string {

--- a/tempodb/backend/cache/cache.go
+++ b/tempodb/backend/cache/cache.go
@@ -110,8 +110,8 @@ func (r *readerWriter) CloseAppend(ctx context.Context, tracker backend.AppendTr
 	return r.nextWriter.CloseAppend(ctx, tracker)
 }
 
-func (r *readerWriter) Delete(context.Context, string, backend.KeyPath) error {
-	panic("delete is not supported for cache.Cache backend")
+func (r *readerWriter) Delete(ctx context.Context, name string, keypath backend.KeyPath) error {
+	return r.nextWriter.Delete(ctx, name, keypath)
 }
 
 func key(keypath backend.KeyPath, name string) string {

--- a/tempodb/backend/gcs/gcs.go
+++ b/tempodb/backend/gcs/gcs.go
@@ -122,7 +122,7 @@ func (rw *readerWriter) CloseAppend(_ context.Context, tracker backend.AppendTra
 	return w.Close()
 }
 
-func (rw *readerWriter) Delete(ctx context.Context, name string, keypath backend.KeyPath) error {
+func (rw *readerWriter) Delete(ctx context.Context, name string, keypath backend.KeyPath, _ bool) error {
 	handle := rw.bucket.Object(backend.ObjectFileName(keypath, name))
 	return handle.Delete(ctx)
 }

--- a/tempodb/backend/local/local.go
+++ b/tempodb/backend/local/local.go
@@ -104,7 +104,7 @@ func (rw *Backend) CloseAppend(_ context.Context, tracker backend.AppendTracker)
 	return dst.Close()
 }
 
-func (rw *Backend) Delete(_ context.Context, name string, keypath backend.KeyPath) error {
+func (rw *Backend) Delete(_ context.Context, name string, keypath backend.KeyPath, _ bool) error {
 	path := rw.rootPath(append(keypath, name))
 	return os.RemoveAll(path)
 }

--- a/tempodb/backend/mocks.go
+++ b/tempodb/backend/mocks.go
@@ -75,7 +75,7 @@ func (m *MockRawWriter) CloseAppend(context.Context, AppendTracker) error {
 	return nil
 }
 
-func (m *MockRawWriter) Delete(_ context.Context, name string, keypath KeyPath) error {
+func (m *MockRawWriter) Delete(_ context.Context, name string, keypath KeyPath, _ bool) error {
 	if m.deleteCalls == nil {
 		m.deleteCalls = make(map[string]map[string]int)
 	}

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -33,7 +33,7 @@ type RawWriter interface {
 	// CloseAppend closes any resources associated with the AppendTracker.
 	CloseAppend(ctx context.Context, tracker AppendTracker) error
 	// Delete deletes a file.
-	Delete(ctx context.Context, name string, keypath KeyPath) error
+	Delete(ctx context.Context, name string, keypath KeyPath, shouldCache bool) error
 }
 
 // RawReader is a collection of methods to read data from tempodb backends

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -91,7 +91,7 @@ func (w *writer) CloseAppend(ctx context.Context, tracker AppendTracker) error {
 func (w *writer) WriteTenantIndex(ctx context.Context, tenantID string, meta []*BlockMeta, compactedMeta []*CompactedBlockMeta) error {
 	// If meta and compactedMeta are empty, call delete the tenant index.
 	if len(meta) == 0 && len(compactedMeta) == 0 {
-		return w.w.Delete(ctx, TenantIndexName, KeyPath([]string{tenantID}))
+		return w.w.Delete(ctx, TenantIndexName, KeyPath([]string{tenantID}), false)
 	}
 
 	b := newTenantIndex(meta, compactedMeta)

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -224,7 +224,7 @@ func (rw *readerWriter) CloseAppend(ctx context.Context, tracker backend.AppendT
 	return nil
 }
 
-func (rw *readerWriter) Delete(ctx context.Context, name string, keypath backend.KeyPath) error {
+func (rw *readerWriter) Delete(ctx context.Context, name string, keypath backend.KeyPath, _ bool) error {
 	filename := backend.ObjectFileName(keypath, name)
 	return rw.core.RemoveObject(ctx, rw.cfg.Bucket, filename, minio.RemoveObjectOptions{})
 }


### PR DESCRIPTION
Here we pass the cache.Delete() call on to the nextWriter instead of panic in cases where we do not want to cache.  Cache deletion is still not supported and will panic.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`