### PR TITLE
Bump jaeger-query image to 1.46.0

### DIFF
--- a/cmd/tempo-query/Dockerfile
+++ b/cmd/tempo-query/Dockerfile
@@ -1,4 +1,4 @@
-FROM jaegertracing/jaeger-query:1.43.0
+FROM jaegertracing/jaeger-query:1.46.0
 
 ENV SPAN_STORAGE_TYPE=grpc-plugin \
     GRPC_STORAGE_PLUGIN_BINARY=/tmp/tempo-query


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Backport of github.com/grafana/tempo/pull/2557 to 2.1 branch. 

Will be tempo-query docker image published once this is merged? 


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`