### PR TITLE
microservices: use DNS lookup for memberlist.join_members by default

### DIFF
--- a/operations/jsonnet-compiled/ConfigMap-tempo-compactor.yaml
+++ b/operations/jsonnet-compiled/ConfigMap-tempo-compactor.yaml
@@ -18,7 +18,7 @@ data:
         abort_if_cluster_join_fails: false
         bind_port: 7946
         join_members:
-            - gossip-ring.tracing.svc.cluster.local.:7946
+            - dns+gossip-ring.tracing.svc.cluster.local.:7946
     overrides:
         per_tenant_override_config: /overrides/overrides.yaml
     server:

--- a/operations/jsonnet-compiled/ConfigMap-tempo-distributor.yaml
+++ b/operations/jsonnet-compiled/ConfigMap-tempo-distributor.yaml
@@ -21,7 +21,7 @@ data:
         abort_if_cluster_join_fails: false
         bind_port: 7946
         join_members:
-            - gossip-ring.tracing.svc.cluster.local.:7946
+            - dns+gossip-ring.tracing.svc.cluster.local.:7946
     overrides:
         per_tenant_override_config: /overrides/overrides.yaml
     server:

--- a/operations/jsonnet-compiled/ConfigMap-tempo-ingester.yaml
+++ b/operations/jsonnet-compiled/ConfigMap-tempo-ingester.yaml
@@ -12,7 +12,7 @@ data:
         abort_if_cluster_join_fails: false
         bind_port: 7946
         join_members:
-            - gossip-ring.tracing.svc.cluster.local.:7946
+            - dns+gossip-ring.tracing.svc.cluster.local.:7946
     overrides:
         per_tenant_override_config: /overrides/overrides.yaml
     server:

--- a/operations/jsonnet-compiled/ConfigMap-tempo-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/ConfigMap-tempo-metrics-generator.yaml
@@ -12,7 +12,7 @@ data:
         abort_if_cluster_join_fails: false
         bind_port: 7946
         join_members:
-            - gossip-ring.tracing.svc.cluster.local.:7946
+            - dns+gossip-ring.tracing.svc.cluster.local.:7946
     metrics_generator:
         storage:
             path: /var/tempo/generator_wal

--- a/operations/jsonnet-compiled/ConfigMap-tempo-querier.yaml
+++ b/operations/jsonnet-compiled/ConfigMap-tempo-querier.yaml
@@ -12,7 +12,7 @@ data:
         abort_if_cluster_join_fails: false
         bind_port: 7946
         join_members:
-            - gossip-ring.tracing.svc.cluster.local.:7946
+            - dns+gossip-ring.tracing.svc.cluster.local.:7946
     overrides:
         per_tenant_override_config: /overrides/overrides.yaml
     querier:

--- a/operations/jsonnet-compiled/ConfigMap-tempo-query-frontend.yaml
+++ b/operations/jsonnet-compiled/ConfigMap-tempo-query-frontend.yaml
@@ -12,7 +12,7 @@ data:
         abort_if_cluster_join_fails: false
         bind_port: 7946
         join_members:
-            - gossip-ring.tracing.svc.cluster.local.:7946
+            - dns+gossip-ring.tracing.svc.cluster.local.:7946
     overrides:
         per_tenant_override_config: /overrides/overrides.yaml
     server:

--- a/operations/jsonnet-compiled/Deployment-compactor.yaml
+++ b/operations/jsonnet-compiled/Deployment-compactor.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        config_hash: 6eb438b3ed5c9d479d974627acab1417
+        config_hash: 004e7f005ba26495e1943b7948696f5c
       labels:
         app: compactor
         name: compactor

--- a/operations/jsonnet-compiled/Deployment-distributor.yaml
+++ b/operations/jsonnet-compiled/Deployment-distributor.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        config_hash: cdd8a088be55b9c2b79b94526df424f2
+        config_hash: 028b09123416ff106e411d57dafeadd8
       labels:
         app: distributor
         name: distributor

--- a/operations/jsonnet-compiled/Deployment-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/Deployment-metrics-generator.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        config_hash: 5067569ac65e5c3c0d79d48abd17c511
+        config_hash: 1c46db8f00d0094a1d213fb87e3fd4ba
       labels:
         app: metrics-generator
         name: metrics-generator

--- a/operations/jsonnet-compiled/Deployment-querier.yaml
+++ b/operations/jsonnet-compiled/Deployment-querier.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        config_hash: 357ab43462d0d51270bccb556f352c05
+        config_hash: 89dfae41b12d998719ac3ae0090cfe4f
       labels:
         app: querier
         name: querier

--- a/operations/jsonnet-compiled/Deployment-query-frontend.yaml
+++ b/operations/jsonnet-compiled/Deployment-query-frontend.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        config_hash: b9f7e4635447322231244804b290b00f
+        config_hash: 46188d18f0d8adfa8586e9dbeb744db2
       labels:
         app: query-frontend
         name: query-frontend

--- a/operations/jsonnet-compiled/StatefulSet-ingester.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-ingester.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        config_hash: b9f7e4635447322231244804b290b00f
+        config_hash: 46188d18f0d8adfa8586e9dbeb744db2
       labels:
         app: ingester
         name: ingester

--- a/operations/jsonnet-compiled/StatefulSet-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-metrics-generator.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        config_hash: 5067569ac65e5c3c0d79d48abd17c511
+        config_hash: 1c46db8f00d0094a1d213fb87e3fd4ba
       labels:
         app: metrics-generator
         name: metrics-generator

--- a/operations/jsonnet-compiled/util/jsonnetfile.lock.json
+++ b/operations/jsonnet-compiled/util/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "5580b3b3d93515fefc9676b9b51dea421591d507",
+      "version": "739af9025e8e2ddbba02547bf956c2c360366ba0",
       "sum": "0y3AFX9LQSpfWTxWKSwoLgbt0Wc9nnCwhMH2szKzHv0="
     },
     {
@@ -18,7 +18,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "5580b3b3d93515fefc9676b9b51dea421591d507",
+      "version": "739af9025e8e2ddbba02547bf956c2c360366ba0",
       "sum": "Cc715Y3rgTuimgDFIw+FaKzXSJGRYwt1pFTMbdrNBD8="
     },
     {

--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -52,7 +52,7 @@
     memberlist: {
       abort_if_cluster_join_fails: false,
       bind_port: $._config.gossip_ring_port,
-      join_members: ['gossip-ring.%s.svc.cluster.local.:%d' % [$._config.namespace, $._config.gossip_ring_port]],
+      join_members: ['dns+gossip-ring.%s.svc.cluster.local.:%d' % [$._config.namespace, $._config.gossip_ring_port]],
     },
   },
 


### PR DESCRIPTION
**What this PR does**:

Related: https://github.com/grafana/loki/pull/9723

The current default configuration will result in a connection to each member returned by a DNS entry and result in more connections than is necessary.  In large clusters, this can become a problem.

Here we include the fix that Loki has for using a `dns+` lookup feature of memberlist to ensure that only a few members of the DNS entry are added.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`