### PR TITLE
Re-enable test cases for structural operators

### DIFF
--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -537,19 +537,18 @@ func traceQLStructural(t *testing.T, _ *tempopb.Trace, wantMeta *tempopb.TraceSe
 			},
 		},
 	}
-	// TODO re-enable commented searches after fixing structural operator bugs in vParquet3
-	//      https://github.com/grafana/tempo/issues/2674
+
 	searchesThatDontMatch := []*tempopb.SearchRequest{
 		{Query: "{ .child } >> { .parent }"},
 		{Query: "{ .child } > { .parent }"},
 		{Query: "{ .child } ~ { .parent }"},
-		// {Query: "{ .child } ~ { .child }"},
+		{Query: "{ .child } ~ { .child }"},
 		{Query: "{ .broken} >> {}"},
-		// {Query: "{ .broken} > {}"},
-		// {Query: "{ .broken} ~ {}"},
+		{Query: "{ .broken} > {}"},
+		{Query: "{ .broken} ~ {}"},
 		{Query: "{} >> {.broken}"},
-		// {Query: "{} > {.broken}"},
-		// {Query: "{} ~ {.broken}"},
+		{Query: "{} > {.broken}"},
+		{Query: "{} ~ {.broken}"},
 	}
 
 	for _, tc := range searchesThatMatch {


### PR DESCRIPTION
**What this PR does**:
Now that the structural operator bugs are fixed in vParquet3, the disabled test cases can be re-enabled

**Which issue(s) this PR fixes**:
Is related to #2674

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`