### PR TITLE
Queriers: Fix external search config when using RBAC with Google Cloud Run

### DIFF
--- a/modules/querier/external/client.go
+++ b/modules/querier/external/client.go
@@ -17,7 +17,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/weaveworks/common/user"
-	"golang.org/x/oauth2"
 )
 
 var (
@@ -54,18 +53,11 @@ type Client struct {
 
 type CloudRunConfig struct {
 	Endpoints []string `yaml:"external_endpoints"`
+	NoAuth    bool     // For testing
 }
 
 type HTTPConfig struct {
 	Endpoints []string
-}
-
-type tokenProvider interface {
-	// Returns an oauth2 token, leveraging a cache unless the token is expired.
-	// If expired, the token is renewed and added to the cache.
-	//
-	// If this returns nil, the request will be unauthenticated.
-	getToken(ctx context.Context, endpoint string) (*oauth2.Token, error)
 }
 
 type option func(client *Client) error
@@ -90,7 +82,7 @@ func NewClient(cfg *Config) (*Client, error) {
 			hedgeRequestsUpTo: cfg.HedgeRequestsUpTo,
 		})
 	case "google_cloud_run":
-		provider, err := newGoogleProvider(ctx, cfg.CloudRunConfig.Endpoints)
+		provider, err := newGoogleProvider(ctx, cfg.CloudRunConfig.Endpoints, cfg.CloudRunConfig.NoAuth)
 		if err != nil {
 			return nil, err
 		}

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -713,7 +713,7 @@ func valuesToV2Response(distinctValues *util.DistinctValueCollector[tempopb.TagV
 // SearchBlock searches the specified subset of the block for the passed tags.
 func (q *Querier) SearchBlock(ctx context.Context, req *tempopb.SearchBlockRequest) (*tempopb.SearchResponse, error) {
 	// if we have no external configuration always search in the querier
-	if len(q.cfg.Search.ExternalEndpoints) == 0 {
+	if q.cfg.Search.ExternalBackend == "" && len(q.cfg.Search.ExternalEndpoints) == 0 {
 		return q.internalSearchBlock(ctx, req)
 	}
 

--- a/modules/querier/querier_test.go
+++ b/modules/querier/querier_test.go
@@ -11,6 +11,7 @@ import (
 	generator_client "github.com/grafana/tempo/modules/generator/client"
 	ingester_client "github.com/grafana/tempo/modules/ingester/client"
 	"github.com/grafana/tempo/modules/overrides"
+	"github.com/grafana/tempo/modules/querier/external"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/atomic"
@@ -46,6 +47,19 @@ func TestQuerierUsesSearchExternalEndpoint(t *testing.T) {
 			cfg:              Config{},
 			queriesToExecute: 3,
 			externalExpected: 0,
+		},
+		{
+			cfg: Config{
+				Search: SearchConfig{
+					ExternalBackend: "google_cloud_run",
+					CloudRun: &external.CloudRunConfig{
+						Endpoints: []string{srv.URL},
+						NoAuth:    true,
+					},
+				},
+			},
+			queriesToExecute: 1,
+			externalExpected: 1,
 		},
 		// SearchPreferSelf is respected. this test won't pass b/c SearchBlock fails instantly and so
 		//  all 3 queries are executed locally and nothing is proxied to the external endpoint.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

I implemented a feature enabling RBAC on Google Cloud Run endpoints, which was merged last week: https://github.com/grafana/tempo/pull/2593

But there is a bug with the configuration, as described below. This PR fixes that bug.

**Repro:**

Run Tempo with the following config:
```
querier:
  search:
    external_backend: google_cloud_run
    google_cloud_run:
      external_endpoints: ["https://my-cloud-run-endpoint.run.app"]
```

Open the Grafana Tempo explore panel, and search for traces.
We'll see traces in our results, but they should be coming from our external Cloud Run endpoint, not an internal block search.

**Expected:**

Block queries are sent to the external Cloud Run endpoint.

**Actual:**

An internal search is performed instead of an external search. This is because the `querier.search.external_endpoints` list is unset, so it defaults to an empty list, and is caught by this conditional:
https://github.com/grafana/tempo/blob/41dfbc49e640b45c6e98c92e8889692bf27c53c0/modules/querier/querier.go#L716-L718

We can work around it by defining a non-empty `querier.search.external_endpoints` list:
```
querier:
  search:
    external_endpoints: ["dummy-value"]
    external_backend: google_cloud_run
    google_cloud_run:
      external_endpoints: ["https://my-cloud-run-endpoint.run.app"]
```
but clearly that's not desirable. This PR fixes the conditional and adds a unit test to cover this code path.



**Checklist**
- [x] Tests updated
- [x] Documentation added
  - No documentation changes required
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
  - Since this is a bug on a pre-release feature, I figured it's not worth updating the changelog. Happy to update it though if requested.