### PR TITLE
Wipe nested set model fields

### DIFF
--- a/tempodb/encoding/vparquet2/schema.go
+++ b/tempodb/encoding/vparquet2/schema.go
@@ -342,6 +342,12 @@ func traceToParquet(id common.ID, tr *tempopb.Trace, ot *Trace) *Trace {
 					eventToParquet(e, &ss.Events[ie])
 				}
 
+				// nested set values do not come from the proto, they are calculated
+				// later. set all to 0
+				ss.NestedSetLeft = 0
+				ss.NestedSetRight = 0
+				ss.ParentID = 0
+
 				ss.SpanID = s.SpanId
 				ss.ParentSpanID = s.ParentSpanId
 				ss.Name = s.Name

--- a/tempodb/encoding/vparquet3/schema.go
+++ b/tempodb/encoding/vparquet3/schema.go
@@ -373,6 +373,12 @@ func traceToParquet(meta *backend.BlockMeta, id common.ID, tr *tempopb.Trace, ot
 					eventToParquet(e, &ss.Events[ie])
 				}
 
+				// nested set values do not come from the proto, they are calculated
+				// later. set all to 0
+				ss.NestedSetLeft = 0
+				ss.NestedSetRight = 0
+				ss.ParentID = 0
+
 				ss.SpanID = s.SpanId
 				ss.ParentSpanID = s.ParentSpanId
 				ss.Name = s.Name

--- a/tempodb/encoding/vparquet3/schema_test.go
+++ b/tempodb/encoding/vparquet3/schema_test.go
@@ -110,6 +110,7 @@ func TestFieldsAreCleared(t *testing.T) {
 	// a minimal trace to make sure nothing bleeds through
 	tr := &Trace{}
 	_ = traceToParquet(&meta, traceID, complexTrace, tr)
+
 	parqTr := traceToParquet(&meta, traceID, simpleTrace, tr)
 	actualTrace := parquetTraceToTempopbTrace(&meta, parqTr)
 	require.Equal(t, simpleTrace, actualTrace)


### PR DESCRIPTION
**What this PR does**:

Struggling to find a good test for this, but can confirm it fixes the issue in intro to mlt. The nested set model values were not being correctly wiped out while translating from proto -> parquet which resulted in some values bleeding through.

This needs to be backported to 2.2.

**Which issue(s) this PR fixes**:
Fixes #2725 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`