### PR TITLE
Backport 2729 to release v2.2

### DIFF
--- a/cmd/tempo-query/Dockerfile
+++ b/cmd/tempo-query/Dockerfile
@@ -1,4 +1,4 @@
-FROM jaegertracing/jaeger-query:1.46.0
+FROM jaegertracing/jaeger-query:1.47.0
 
 ENV SPAN_STORAGE_TYPE=grpc-plugin \
     GRPC_STORAGE_PLUGIN_BINARY=/tempo-query

--- a/modules/overrides/userconfigurableapi/client.go
+++ b/modules/overrides/userconfigurableapi/client.go
@@ -153,5 +153,5 @@ func (o *userConfigOverridesClient) Delete(ctx context.Context, userID string) e
 	defer span.Finish()
 	span.SetTag("tenant", userID)
 
-	return o.w.Delete(ctx, OverridesFileName, []string{OverridesKeyPath, userID})
+	return o.w.Delete(ctx, OverridesFileName, []string{OverridesKeyPath, userID}, false)
 }

--- a/modules/querier/external/client.go
+++ b/modules/querier/external/client.go
@@ -17,7 +17,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/weaveworks/common/user"
-	"golang.org/x/oauth2"
 )
 
 var (
@@ -54,18 +53,11 @@ type Client struct {
 
 type CloudRunConfig struct {
 	Endpoints []string `yaml:"external_endpoints"`
+	NoAuth    bool     // For testing
 }
 
 type HTTPConfig struct {
 	Endpoints []string
-}
-
-type tokenProvider interface {
-	// Returns an oauth2 token, leveraging a cache unless the token is expired.
-	// If expired, the token is renewed and added to the cache.
-	//
-	// If this returns nil, the request will be unauthenticated.
-	getToken(ctx context.Context, endpoint string) (*oauth2.Token, error)
 }
 
 type option func(client *Client) error
@@ -90,7 +82,7 @@ func NewClient(cfg *Config) (*Client, error) {
 			hedgeRequestsUpTo: cfg.HedgeRequestsUpTo,
 		})
 	case "google_cloud_run":
-		provider, err := newGoogleProvider(ctx, cfg.CloudRunConfig.Endpoints)
+		provider, err := newGoogleProvider(ctx, cfg.CloudRunConfig.Endpoints, cfg.CloudRunConfig.NoAuth)
 		if err != nil {
 			return nil, err
 		}

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -713,7 +713,7 @@ func valuesToV2Response(distinctValues *util.DistinctValueCollector[tempopb.TagV
 // SearchBlock searches the specified subset of the block for the passed tags.
 func (q *Querier) SearchBlock(ctx context.Context, req *tempopb.SearchBlockRequest) (*tempopb.SearchResponse, error) {
 	// if we have no external configuration always search in the querier
-	if len(q.cfg.Search.ExternalEndpoints) == 0 {
+	if q.cfg.Search.ExternalBackend == "" && len(q.cfg.Search.ExternalEndpoints) == 0 {
 		return q.internalSearchBlock(ctx, req)
 	}
 

--- a/modules/querier/querier_test.go
+++ b/modules/querier/querier_test.go
@@ -11,6 +11,7 @@ import (
 	generator_client "github.com/grafana/tempo/modules/generator/client"
 	ingester_client "github.com/grafana/tempo/modules/ingester/client"
 	"github.com/grafana/tempo/modules/overrides"
+	"github.com/grafana/tempo/modules/querier/external"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/atomic"
@@ -46,6 +47,19 @@ func TestQuerierUsesSearchExternalEndpoint(t *testing.T) {
 			cfg:              Config{},
 			queriesToExecute: 3,
 			externalExpected: 0,
+		},
+		{
+			cfg: Config{
+				Search: SearchConfig{
+					ExternalBackend: "google_cloud_run",
+					CloudRun: &external.CloudRunConfig{
+						Endpoints: []string{srv.URL},
+						NoAuth:    true,
+					},
+				},
+			},
+			queriesToExecute: 1,
+			externalExpected: 1,
 		},
 		// SearchPreferSelf is respected. this test won't pass b/c SearchBlock fails instantly and so
 		//  all 3 queries are executed locally and nothing is proxied to the external endpoint.

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -13,6 +13,8 @@ import (
 // when they returned an error.
 type Cache interface {
 	Store(ctx context.Context, key []string, buf [][]byte)
+	// TODO: both cached backend clients support deletion. Should we implement?
+	// Remove(ctx context.Context, key []string)
 	Fetch(ctx context.Context, keys []string) (found []string, bufs [][]byte, missing []string)
 	Stop()
 }

--- a/tempodb/backend/azure/azure.go
+++ b/tempodb/backend/azure/azure.go
@@ -113,7 +113,7 @@ func (rw *readerWriter) CloseAppend(context.Context, backend.AppendTracker) erro
 	return nil
 }
 
-func (rw *readerWriter) Delete(ctx context.Context, name string, keypath backend.KeyPath) error {
+func (rw *readerWriter) Delete(ctx context.Context, name string, keypath backend.KeyPath, _ bool) error {
 	blobURL, err := GetBlobURL(ctx, rw.cfg, backend.ObjectFileName(keypath, name))
 	if err != nil {
 		return errors.Wrapf(err, "cannot get Azure blob URL, name: %s", backend.ObjectFileName(keypath, name))

--- a/tempodb/backend/cache/cache.go
+++ b/tempodb/backend/cache/cache.go
@@ -110,8 +110,11 @@ func (r *readerWriter) CloseAppend(ctx context.Context, tracker backend.AppendTr
 	return r.nextWriter.CloseAppend(ctx, tracker)
 }
 
-func (r *readerWriter) Delete(context.Context, string, backend.KeyPath) error {
-	panic("delete is not supported for cache.Cache backend")
+func (r *readerWriter) Delete(ctx context.Context, name string, keypath backend.KeyPath, shouldCache bool) error {
+	if shouldCache {
+		panic("delete is not supported for cache.Cache backend")
+	}
+	return r.nextWriter.Delete(ctx, name, keypath, shouldCache)
 }
 
 func key(keypath backend.KeyPath, name string) string {

--- a/tempodb/backend/gcs/gcs.go
+++ b/tempodb/backend/gcs/gcs.go
@@ -122,7 +122,7 @@ func (rw *readerWriter) CloseAppend(_ context.Context, tracker backend.AppendTra
 	return w.Close()
 }
 
-func (rw *readerWriter) Delete(ctx context.Context, name string, keypath backend.KeyPath) error {
+func (rw *readerWriter) Delete(ctx context.Context, name string, keypath backend.KeyPath, _ bool) error {
 	handle := rw.bucket.Object(backend.ObjectFileName(keypath, name))
 	return handle.Delete(ctx)
 }

--- a/tempodb/backend/local/local.go
+++ b/tempodb/backend/local/local.go
@@ -104,7 +104,7 @@ func (rw *Backend) CloseAppend(_ context.Context, tracker backend.AppendTracker)
 	return dst.Close()
 }
 
-func (rw *Backend) Delete(_ context.Context, name string, keypath backend.KeyPath) error {
+func (rw *Backend) Delete(_ context.Context, name string, keypath backend.KeyPath, _ bool) error {
 	path := rw.rootPath(append(keypath, name))
 	return os.RemoveAll(path)
 }

--- a/tempodb/backend/mocks.go
+++ b/tempodb/backend/mocks.go
@@ -75,7 +75,7 @@ func (m *MockRawWriter) CloseAppend(context.Context, AppendTracker) error {
 	return nil
 }
 
-func (m *MockRawWriter) Delete(_ context.Context, name string, keypath KeyPath) error {
+func (m *MockRawWriter) Delete(_ context.Context, name string, keypath KeyPath, _ bool) error {
 	if m.deleteCalls == nil {
 		m.deleteCalls = make(map[string]map[string]int)
 	}

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -33,7 +33,7 @@ type RawWriter interface {
 	// CloseAppend closes any resources associated with the AppendTracker.
 	CloseAppend(ctx context.Context, tracker AppendTracker) error
 	// Delete deletes a file.
-	Delete(ctx context.Context, name string, keypath KeyPath) error
+	Delete(ctx context.Context, name string, keypath KeyPath, shouldCache bool) error
 }
 
 // RawReader is a collection of methods to read data from tempodb backends
@@ -91,7 +91,7 @@ func (w *writer) CloseAppend(ctx context.Context, tracker AppendTracker) error {
 func (w *writer) WriteTenantIndex(ctx context.Context, tenantID string, meta []*BlockMeta, compactedMeta []*CompactedBlockMeta) error {
 	// If meta and compactedMeta are empty, call delete the tenant index.
 	if len(meta) == 0 && len(compactedMeta) == 0 {
-		return w.w.Delete(ctx, TenantIndexName, KeyPath([]string{tenantID}))
+		return w.w.Delete(ctx, TenantIndexName, KeyPath([]string{tenantID}), false)
 	}
 
 	b := newTenantIndex(meta, compactedMeta)

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -224,7 +224,7 @@ func (rw *readerWriter) CloseAppend(ctx context.Context, tracker backend.AppendT
 	return nil
 }
 
-func (rw *readerWriter) Delete(ctx context.Context, name string, keypath backend.KeyPath) error {
+func (rw *readerWriter) Delete(ctx context.Context, name string, keypath backend.KeyPath, _ bool) error {
 	filename := backend.ObjectFileName(keypath, name)
 	return rw.core.RemoveObject(ctx, rw.cfg.Bucket, filename, minio.RemoveObjectOptions{})
 }

--- a/tempodb/encoding/vparquet2/schema.go
+++ b/tempodb/encoding/vparquet2/schema.go
@@ -342,6 +342,12 @@ func traceToParquet(id common.ID, tr *tempopb.Trace, ot *Trace) *Trace {
 					eventToParquet(e, &ss.Events[ie])
 				}
 
+				// nested set values do not come from the proto, they are calculated
+				// later. set all to 0
+				ss.NestedSetLeft = 0
+				ss.NestedSetRight = 0
+				ss.ParentID = 0
+
 				ss.SpanID = s.SpanId
 				ss.ParentSpanID = s.ParentSpanId
 				ss.Name = s.Name


### PR DESCRIPTION
Backports the nested set fix to v2.2:

https://github.com/grafana/tempo/pull/2729