### PR TITLE
Metrics Summary:  fix panic edge case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [FEATURE] New encoding vParquet3 with support for dedicated attribute columns (@mapno, @stoewer) [#2649](https://github.com/grafana/tempo/pull/2649)
 * [ENHANCEMENT] Assert ingestion rate limits as early as possible [#2640](https://github.com/grafana/tempo/pull/2703) (@mghildiy)
 * [ENHANCEMENT] Add several metrics-generator fields to user-configurable overrides [#2711](https://github.com/grafana/tempo/pull/2711) (@kvrhdn)
+* [BUGFIX] Fix panic in metrics summary api [#2738](https://github.com/grafana/tempo/pull/2738) (@mdisibio)
 
 ## v2.2.0 / 2023-07-31
 

--- a/pkg/traceqlmetrics/metrics.go
+++ b/pkg/traceqlmetrics/metrics.go
@@ -12,11 +12,13 @@ import (
 	"github.com/pkg/errors"
 )
 
+const maxBuckets = 64
+
 type LatencyHistogram struct {
-	buckets [64]int // Exponential buckets, powers of 2
+	buckets [maxBuckets]int // Exponential buckets, powers of 2
 }
 
-func New(buckets [64]int) *LatencyHistogram {
+func New(buckets [maxBuckets]int) *LatencyHistogram {
 	return &LatencyHistogram{buckets: buckets}
 }
 
@@ -26,6 +28,10 @@ func (m *LatencyHistogram) Record(durationNanos uint64) {
 	if durationNanos >= 2 {
 		bucket = int(math.Ceil(math.Log2(float64(durationNanos))))
 	}
+	if bucket >= maxBuckets {
+		bucket = maxBuckets - 1
+	}
+
 	m.buckets[bucket]++
 }
 

--- a/pkg/traceqlmetrics/metrics_test.go
+++ b/pkg/traceqlmetrics/metrics_test.go
@@ -2,6 +2,7 @@ package traceqlmetrics
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/grafana/tempo/pkg/traceql"
@@ -38,6 +39,12 @@ func TestPercentile(t *testing.T) {
 			durations: []uint64{1},
 			p:         1.0,
 			value:     uint64(1),
+		},
+		{
+			name:      "edge case max bucket",
+			durations: []uint64{math.MaxUint64},
+			p:         1.0,
+			value:     uint64(1 << (maxBuckets - 1)),
 		},
 		{
 			name:      "edge case empty",


### PR DESCRIPTION
**What this PR does**:
Fixes a panic for very large uint64s.  This was seen in the wild and my best guess is its from calculating `duration = endTime - startTime` when endTime is less than startTime (leading to unsigned wrap-around).  So this doesn't address the root cause, per se, but prevents the panic and bad data will be visible.

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`