### PR TITLE
Add missing `omitempty` struct tags to user-configurable API

### DIFF
--- a/modules/overrides/userconfigurableapi/limits.go
+++ b/modules/overrides/userconfigurableapi/limits.go
@@ -5,7 +5,7 @@ import (
 )
 
 type UserConfigurableLimits struct {
-	Forwarders *[]string `json:"forwarders"`
+	Forwarders *[]string `json:"forwarders,omitempty"`
 
 	MetricsGenerator *UserConfigurableOverridesMetricsGenerator `json:"metrics_generator,omitempty"`
 }
@@ -72,8 +72,8 @@ func (l *UserConfigurableOverridesMetricsGeneratorProcessor) GetSpanMetrics() *U
 }
 
 type UserConfigurableOverridesMetricsGeneratorProcessorServiceGraphs struct {
-	Dimensions               *[]string `json:"dimensions"`
-	EnableClientServerPrefix *bool     `json:"enable_client_server_prefix"`
+	Dimensions               *[]string `json:"dimensions,omitempty"`
+	EnableClientServerPrefix *bool     `json:"enable_client_server_prefix,omitempty"`
 	PeerAttributes           *[]string `json:"peer_attributes,omitempty"`
 }
 
@@ -99,7 +99,7 @@ func (l *UserConfigurableOverridesMetricsGeneratorProcessorServiceGraphs) GetPee
 }
 
 type UserConfigurableOverridesMetricsGeneratorProcessorSpanMetrics struct {
-	Dimensions       *[]string `json:"dimensions"`
+	Dimensions       *[]string `json:"dimensions,omitempty"`
 	EnableTargetInfo *bool     `json:"enable_target_info,omitempty"`
 }
 


### PR DESCRIPTION
**What this PR does**:

We were missing some `omitempty` struct tags on the user-configurable overrides. Setting these avoids you get potentially confusing responses like

```json
{
  "forwarders": null,
}
```

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [ ] ~~Tests updated~~
- [ ] ~~Documentation added~~
- [ ] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~