### PR TITLE
[DOC] Add blog link to release notes

### DIFF
--- a/docs/sources/tempo/release-notes/v2-2.md
+++ b/docs/sources/tempo/release-notes/v2-2.md
@@ -17,7 +17,7 @@ This release gives you:
 
 Tempo 2.2 makes vParquet2, a Parquet version designed to be more compatible with other Parquet implementations, the default block format. This block format is required for using structural operators and improves query performance relative to previous formats.
 
-Read the [Tempo 2.2 blog post](/blog/NEED BLOG LINK) for more examples and details about these improvements.
+Read the [Tempo 2.2 blog post](/blog/2023/08/02/grafana-tempo-2.2-release-traceql-structural-operators-are-here/) for more examples and details about these improvements.
 
 {{% admonition type ="note" %}}
 For a complete list of changes, enhancements, and bug fixes refer to the [Tempo 2.2 changelog](https://github.com/grafana/tempo/releases/tag/v2.2.0).
@@ -37,7 +37,7 @@ TraceQL now offers:
 * A `by()` operation that groups span sets within a trace by an attribute of your choosing. This operation is not supported in the Grafana UI yet; you can only use `by()` when querying Tempo’s search API directly. ([documentation]({{< relref "../traceql#grouping" >}})  [PR  [2490](https://github.com/grafana/tempo/pull/2490)]
 * New intrinsic attributes for use in TraceQL queries: `traceDuration`, `rootName`, and `rootServiceName` ([documentation]({{< relref "../traceql" >}})) [PR [#2503](https://github.com/grafana/tempo/pull/2503)]
 
-Read the [Tempo 2.2 blog post](/blog/need/link) for examples of how to use these new language additions. 
+Read the [Tempo 2.2 blog post](/blog/2023/08/02/grafana-tempo-2.2-release-traceql-structural-operators-are-here/) for examples of how to use these new language additions.
 
 To learn more about the TraceQL syntax, see the [TraceQL documentation]({{< relref "../traceql" >}}).
 For information on planned future extensions to the TraceQL language, see [future work]({{< relref "../traceql/architecture" >}}).

--- a/docs/sources/tempo/traceql/_index.md
+++ b/docs/sources/tempo/traceql/_index.md
@@ -25,6 +25,8 @@ Read the blog post, "[Get to know TraceQL](/blog/2023/02/07/get-to-know-traceql-
 For information on where the language is headed, see [future work]({{< relref "./architecture" >}}).
 The TraceQL language uses similar syntax and semantics as [PromQL](/blog/2020/02/04/introduction-to-promql-the-prometheus-query-language/) and [LogQL](/docs/loki/latest/logql/), where possible.
 
+Check the [release notes]({{< relref "../release-notes" >}}) for the latest updates to TraceQL.
+
 TraceQL requires Tempo’s Parquet columnar format to be enabled. For information on enabling Parquet, refer to the [Apache Parquet backend]({{< relref "..//configuration/parquet" >}}) Tempo documentation.
 
 ## TraceQL query editor


### PR DESCRIPTION

**What this PR does**:
Add the link to the blog post for the 2.2 release: [Tempo 2.2 blog post](/blog/2023/08/02/grafana-tempo-2.2-release-traceql-structural-operators-are-here/) 


**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`