### PR TITLE
Ensure `/api/status/buildinfo` respects `http_api_prefix`

### DIFF
--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -37,6 +37,7 @@ import (
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/modules/querier"
 	"github.com/grafana/tempo/modules/storage"
+	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/usagestats"
 	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/pkg/util/log"
@@ -189,7 +190,8 @@ func (t *App) Run() error {
 		t.InternalServer.HTTP.Path("/ready").Methods("GET").Handler(t.readyHandler(sm))
 	}
 
-	t.Server.HTTP.Path("/api/status/buildinfo").Handler(t.buildinfoHandler()).Methods("GET")
+	t.Server.HTTP.Path(addHTTPAPIPrefix(&t.cfg, api.PathBuildInfo)).Handler(t.buildinfoHandler()).Methods("GET")
+
 	t.Server.HTTP.Path("/ready").Handler(t.readyHandler(sm))
 	t.Server.HTTP.Path("/status").Handler(t.statusHandler()).Methods("GET")
 	t.Server.HTTP.Path("/status/{endpoint}").Handler(t.statusHandler()).Methods("GET")

--- a/pkg/api/http.go
+++ b/pkg/api/http.go
@@ -68,6 +68,7 @@ const (
 	PathSearchTags         = "/api/search/tags"
 	PathSearchTagValues    = "/api/search/tag/{" + muxVarTagName + "}/values"
 	PathEcho               = "/api/echo"
+	PathBuildInfo          = "/api/status/buildinfo"
 	PathUsageStats         = "/status/usage-stats"
 	PathSpanMetrics        = "/api/metrics"
 	PathSpanMetricsSummary = "/api/metrics/summary"


### PR DESCRIPTION
**What this PR does**:
https://github.com/grafana/tempo/pull/2702 added a new public endpoint to Tempo to view the current version of Tempo running. Since this is part of the API now it should respect `http_api_prefix`.

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`