### PR TITLE
Replace weavework with dskit for recent merge

### DIFF
--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -59,7 +59,7 @@ You can find more about other supported syntax [here](https://github.com/drone/e
 
 ## Server
 
-Tempo uses the Weaveworks/common server. For more information on configuration options, see [here](https://github.com/weaveworks/common/blob/master/server/server.go#L54).
+Tempo uses the server from `dskit/server`. For more information on configuration options, see [here](https://github.com/grafana/dskit/blob/main/server/server.go#L66).
 
 ```yaml
 # Optional. Setting to true enables multitenancy and requires X-Scope-OrgID header on all requests.

--- a/modules/distributor/forwarder/forwarder.go
+++ b/modules/distributor/forwarder/forwarder.go
@@ -8,11 +8,11 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	dslog "github.com/grafana/dskit/log"
 	zaplogfmt "github.com/jsternberg/zap-logfmt"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor"
 	"github.com/sirupsen/logrus"
-	"github.com/weaveworks/common/logging"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/extension"
@@ -46,7 +46,7 @@ func (l List) ForwardTraces(ctx context.Context, traces ptrace.Traces) error {
 	return multierr.Combine(errs...)
 }
 
-func New(cfg Config, logger log.Logger, logLevel logging.Level) (Forwarder, error) {
+func New(cfg Config, logger log.Logger, logLevel dslog.Level) (Forwarder, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("failed to validate config: %w", err)
 	}
@@ -84,7 +84,7 @@ type FilterForwarder struct {
 	fatalErrorMu    sync.RWMutex
 }
 
-func NewFilterForwarder(cfg FilterConfig, next Forwarder, logLevel logging.Level) (*FilterForwarder, error) {
+func NewFilterForwarder(cfg FilterConfig, next Forwarder, logLevel dslog.Level) (*FilterForwarder, error) {
 	factory := filterprocessor.NewFactory()
 
 	set := processor.CreateSettings{
@@ -191,7 +191,7 @@ func (c consumerToForwarderAdapter) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 
-func newLogger(level logging.Level) *zap.Logger {
+func newLogger(level dslog.Level) *zap.Logger {
 	zapLevel := zapcore.InfoLevel
 
 	switch level.Logrus {

--- a/modules/distributor/forwarder/forwarder_test.go
+++ b/modules/distributor/forwarder/forwarder_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
+	dslog "github.com/grafana/dskit/log"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
-	"github.com/weaveworks/common/logging"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -138,7 +138,7 @@ func TestFilterForwarder_ForwardTraces_ReturnsNoErrorAndCallsForwardTracesOnUnde
 
 	f := &mockCountingForwarder{next: &mockWorkingForwarder{}, forwardTracesCount: 0}
 	cfg := FilterConfig{}
-	ff, err := NewFilterForwarder(cfg, f, logging.Level{})
+	ff, err := NewFilterForwarder(cfg, f, dslog.Level{})
 	require.NoError(t, err)
 
 	// When
@@ -165,7 +165,7 @@ func TestFilterForwarder_ForwardTraces_ReturnsNoErrorAndCallsForwardTracesOnUnde
 			SpanEventConditions: nil,
 		},
 	}
-	ff, err := NewFilterForwarder(cfg, f, logging.Level{})
+	ff, err := NewFilterForwarder(cfg, f, dslog.Level{})
 	require.NoError(t, err)
 
 	// When
@@ -196,7 +196,7 @@ func TestFilterForwarder_ForwardTraces_ReturnsNoErrorAndDoesNotCallsForwardTrace
 			SpanEventConditions: nil,
 		},
 	}
-	ff, err := NewFilterForwarder(cfg, f, logging.Level{})
+	ff, err := NewFilterForwarder(cfg, f, dslog.Level{})
 	require.NoError(t, err)
 
 	// When
@@ -218,7 +218,7 @@ func TestFilterForwarder_ForwardTraces_ReturnsErrorAndDoesNotCallForwardTracesOn
 			SpanEventConditions: nil,
 		},
 	}
-	ff, err := NewFilterForwarder(cfg, f, logging.Level{})
+	ff, err := NewFilterForwarder(cfg, f, dslog.Level{})
 	require.NoError(t, err)
 
 	ff.fatalError = fatalErr
@@ -247,7 +247,7 @@ func TestFilterForwarder_ForwardTraces_ReturnsErrorWithFailingUnderlyingForwarde
 			SpanEventConditions: nil,
 		},
 	}
-	ff, err := NewFilterForwarder(cfg, f, logging.Level{})
+	ff, err := NewFilterForwarder(cfg, f, dslog.Level{})
 	require.NoError(t, err)
 
 	// When

--- a/modules/distributor/forwarder/manager.go
+++ b/modules/distributor/forwarder/manager.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	dslog "github.com/grafana/dskit/log"
 	"github.com/grafana/dskit/services"
-	"github.com/weaveworks/common/logging"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/multierr"
 
@@ -40,7 +40,7 @@ type Manager struct {
 	tenantToQueueListMu *sync.RWMutex
 }
 
-func NewManager(cfgs ConfigList, logger log.Logger, overrides Overrides, logLevel logging.Level) (*Manager, error) {
+func NewManager(cfgs ConfigList, logger log.Logger, overrides Overrides, logLevel dslog.Level) (*Manager, error) {
 	if err := cfgs.Validate(); err != nil {
 		return nil, fmt.Errorf("failed to validate config list: %w", err)
 	}

--- a/modules/distributor/forwarder/manager_test.go
+++ b/modules/distributor/forwarder/manager_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/go-kit/log"
+	dslog "github.com/grafana/dskit/log"
 	"github.com/stretchr/testify/require"
-	"github.com/weaveworks/common/logging"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"golang.org/x/exp/slices"
 )
@@ -64,7 +64,7 @@ func (m *mockChannelledInterceptorForwarder) Shutdown(ctx context.Context) error
 func newManagerWithForwarders(t *testing.T, forwarderNameToForwarder map[string]Forwarder, logger log.Logger, o Overrides) *Manager {
 	t.Helper()
 
-	manager, err := NewManager(ConfigList{}, logger, o, logging.Level{})
+	manager, err := NewManager(ConfigList{}, logger, o, dslog.Level{})
 	require.NoError(t, err)
 	manager.forwarderNameToForwarder = forwarderNameToForwarder
 
@@ -83,7 +83,7 @@ func TestNewManager_ReturnsNoErrorAndNonNilManagerWithValidConfigList(t *testing
 	o := &mockWorkingOverrides{}
 
 	// When
-	got, err := NewManager(cfgs, logger, o, logging.Level{})
+	got, err := NewManager(cfgs, logger, o, dslog.Level{})
 
 	// Then
 	require.NoError(t, err)
@@ -99,7 +99,7 @@ func TestNewManager_ReturnsErrorAndNilManagerWithInvalidConfigList(t *testing.T)
 	o := &mockWorkingOverrides{}
 
 	// When
-	got, err := NewManager(cfgs, logger, o, logging.Level{})
+	got, err := NewManager(cfgs, logger, o, dslog.Level{})
 
 	// Then
 	require.Error(t, err)

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -236,7 +236,7 @@ func newSpanMetricsMiddleware() Middleware {
 
 // buildUpstreamRequestURI returns a uri based on the passed parameters
 // we do this because dskit/common uses the RequestURI field to translate from http.Request to httpgrpc.Request
-// https://github.com/dskit/common/blob/47e357f4e1badb7da17ad74bae63e228bdd76e8f/httpgrpc/server/server.go#L48
+// https://github.com/grafana/dskit/blob/740f56bd293423c5147773ce97264519f9fddc58/httpgrpc/server/server.go#L59
 func buildUpstreamRequestURI(originalURI string, params url.Values) string {
 	const queryDelimiter = "?"
 

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -235,8 +235,8 @@ func newSpanMetricsMiddleware() Middleware {
 }
 
 // buildUpstreamRequestURI returns a uri based on the passed parameters
-// we do this because weaveworks/common uses the RequestURI field to translate from http.Request to httpgrpc.Request
-// https://github.com/weaveworks/common/blob/47e357f4e1badb7da17ad74bae63e228bdd76e8f/httpgrpc/server/server.go#L48
+// we do this because dskit/common uses the RequestURI field to translate from http.Request to httpgrpc.Request
+// https://github.com/dskit/common/blob/47e357f4e1badb7da17ad74bae63e228bdd76e8f/httpgrpc/server/server.go#L48
 func buildUpstreamRequestURI(originalURI string, params url.Values) string {
 	const queryDelimiter = "?"
 


### PR DESCRIPTION
**What this PR does**:

Unfortunate merge timing meant that we re-introduced some weaveworks packages which we intended to drop.  Here we make the weaveworks -> dskit transition that was intended.

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`