### PR TITLE
Manually applying dskit/server patch

### DIFF
--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -253,6 +253,29 @@ func (c *Client) SetOverrides(limits *api.UserConfigurableLimits, version string
 	return resp.Header.Get("Etag"), err
 }
 
+func (c *Client) PatchOverrides(limits *api.UserConfigurableLimits) (*api.UserConfigurableLimits, string, error) {
+	b, err := json.Marshal(limits)
+	if err != nil {
+		return nil, "", err
+	}
+
+	req, err := http.NewRequest("PATCH", c.BaseURL+tempo_api.PathOverrides, bytes.NewBuffer(b))
+	if err != nil {
+		return nil, "", err
+	}
+
+	resp, body, err := c.doRequest(req)
+	if err != nil {
+		return nil, "", err
+	}
+
+	patchedLimits := &api.UserConfigurableLimits{}
+	if err = json.Unmarshal(body, patchedLimits); err != nil {
+		return nil, "", fmt.Errorf("error decoding overrides, err: %v body: %s", err, string(body))
+	}
+	return patchedLimits, resp.Header.Get("Etag"), err
+}
+
 func (c *Client) DeleteOverrides(version string) error {
 	req, err := http.NewRequest("DELETE", c.BaseURL+tempo_api.PathOverrides, nil)
 	if err != nil {

--- a/vendor/github.com/grafana/dskit/server/server.go
+++ b/vendor/github.com/grafana/dskit/server/server.go
@@ -259,7 +259,7 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 	if cfg.RouteHTTPToGRPC {
 		grpchttpmux = cmux.New(httpListener)
 
-		httpListener = grpchttpmux.Match(cmux.HTTP1Fast())
+		httpListener = grpchttpmux.Match(cmux.HTTP1Fast("PATCH"))
 		grpcOnHTTPListener = grpchttpmux.Match(cmux.HTTP2())
 	}
 


### PR DESCRIPTION
**What this PR does**:
Manually apply the change from https://github.com/grafana/dskit/pull/347 to run it against our CI.


**Which issue(s) this PR fixes**:
Should fix https://github.com/grafana/tempo/issues/2756

**Checklist**
- [x] Tests updated
- [ ] ~~Documentation added~~
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`