### PR TITLE
Add a generator troubleshooting page

### DIFF
--- a/docs/sources/tempo/operations/troubleshooting/_index.md
+++ b/docs/sources/tempo/operations/troubleshooting/_index.md
@@ -27,3 +27,7 @@ In addition, the [Tempo runbook](https://github.com/grafana/tempo/blob/main/oper
 - [Queries fail with 500 and "error using pageFinder"]({{< relref "./bad-blocks" >}})
 - [I can search traces, but there are no service name or span name values available]({{< relref "./search-tag" >}})
 - [Error message `response larger than the max (<number> vs <limit>)`]({{< relref "./response-too-large" >}})
+
+## Metrics Generator
+
+- [Metrics or service graphs seem incomplete]({{< relref "./metrics-generator" >}})

--- a/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
+++ b/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
@@ -1,6 +1,6 @@
 ---
-title: Troubleshoot Metrics Generator
-menuTitle: Metrics Generator
+title: Troubleshoot metrics-generator
+menuTitle: Metrics-generator
 description: Gain an understanding of how to debug metrics quality issues.
 weight: 500
 ---

--- a/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
+++ b/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
@@ -114,7 +114,7 @@ of edges it will track at once. To determine if edges are being dropped due to t
 sum(rate(tempo_metrics_generator_processor_service_graphs_dropped_spans{}[1m]))
 ```
 
-To adjust the maximum amount of edges it will track use:
+Use `max_items` to adjust the maximum amount of edges tracked:
 
 ```
 metrics_generator:

--- a/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
+++ b/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
@@ -18,7 +18,7 @@ If everything seems ok from these two perspectives, consider the following topic
 
 ### Dropped spans in the distributor
 
-The distributor has a queue of outgoing spans to the metrics generators. If that queue is full then the distributor
+The distributor has a queue of outgoing spans to the metrics-generators. If that queue is full then the distributor
 will drop spans before they reach the generator. Use the following metric to determine if that is happening:
 
 ```

--- a/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
+++ b/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
@@ -12,7 +12,7 @@ If you are concerned with data quality issues in the metrics-generator, we'd fir
 - Reviewing your telemetry pipeline to determine the number of dropped spans. We are only looking for major issues here.
 - Reviewing the [service graph documentation]({{< relref "../../metrics-generator/service_graphs" >}}) to understand how they are built.
 
-If everything seems ok from these two perspectives consider the following.
+If everything seems ok from these two perspectives, consider the following topics to help resolve general issues with all metrics and span metrics specifically.
 
 ## All metrics
 

--- a/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
+++ b/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
@@ -107,8 +107,8 @@ metrics_generator:
 
 ### Service graph max items
 
-In order to limit the total amount of memory that the service graph processor uses there is a maximum number
-of edges it will track at once. To determine if edges are being dropped due to this limit check:
+The service graph processor has a maximum number of edges it will track at once to limit the total amount of memory the processor uses.
+To determine if edges are being dropped due to this limit, check:
 
 ```
 sum(rate(tempo_metrics_generator_processor_service_graphs_dropped_spans{}[1m]))

--- a/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
+++ b/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
@@ -53,8 +53,8 @@ metrics_generator:
 
 ### Max active series
 
-The generator protects itself and your remote write target by having a maximum number of series it will produce. To 
-determine if series are being dropped due to this limit check:
+The generator protects itself and your remote-write target by having a maximum number of series the generator produces.  
+Use the `sum` below to determine if series are being dropped due to this limit:
 
 ```
 sum(rate(tempo_metrics_generator_registry_series_limited_total{}[1m]))

--- a/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
+++ b/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
@@ -69,7 +69,7 @@ overrides:
 
 ### Remote write failures
 
-For any number of reasons the generator may fail a write to the remote write target. Use the following metrics to
+For any number of reasons, the generator may fail a write to the remote write target. Use the following metrics to
 determine if that is happening:
 
 ```

--- a/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
+++ b/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
@@ -43,7 +43,7 @@ configurable filters. You can see the number of spans rejected by reason using t
 sum(rate(tempo_metrics_generator_spans_discarded_total{}[1m])) by (reason)
 ```
 
-If you are dropping a lot of spans due to your filters, you will need to adjust them. If you are dropping a lot of spans
+If a lot of spans are dropped in the metrics-generator due to your filters, you will need to adjust them. If spans are dropped
 due to the ingestion slack time, consider adjusting this setting:
 
 ```

--- a/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
+++ b/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
@@ -5,7 +5,9 @@ description: Gain an understanding of how to debug metrics quality issues.
 weight: 500
 ---
 
-If you are concerned with data quality issues in the metrics generator, we'd first recommend:
+# Troubleshoot metrics-generator
+
+If you are concerned with data quality issues in the metrics-generator, we'd first recommend:
 
 - Reviewing your telemetry pipeline to determine the number of dropped spans. We are only looking for major issues here.
 - Reviewing the [service graph documentation]({{< relref "../../metrics-generator/service_graphs" >}}) to understand how they are built.

--- a/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
+++ b/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
@@ -22,7 +22,7 @@ sum(rate(tempo_metrics_generator_spans_discarded_total{}[1m])) by (reason)
 ```
 
 If you are dropping a lot of spans due to your filters, you will need to adjust them. If you are dropping a lot of spans
-due to the ingestion slack time consider adjusting this setting:
+due to the ingestion slack time, consider adjusting this setting:
 
 ```
 metrics_generator:

--- a/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
+++ b/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
@@ -36,7 +36,7 @@ sum(rate(tempo_distributor_metrics_generator_pushes_failures_total{}[1m]))
 
 ### Discarded spans in the generator
 
-Spans are rejected from being considered by the metrics generator by a configurable slack time as well as due to user
+Spans are rejected from being considered by the metrics-generator by a configurable slack time as well as due to user
 configurable filters. You can see the number of spans rejected by reason using this metric:
 
 ```

--- a/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
+++ b/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
@@ -51,6 +51,10 @@ metrics_generator:
   metrics_ingestion_time_range_slack: 30s
 ```
 
+If spans are regularly exceeding this value you may want to consider reviewing your tracing pipeline to see if you have excessive buffering. 
+Note that increasing this value allows the generator to consume more spans, but does reduce the accuracy of metrics because spans farther
+away from "now" are included.
+
 ### Max active series
 
 The generator protects itself and your remote-write target by having a maximum number of series the generator produces.  
@@ -67,6 +71,8 @@ overrides:
   metrics_generator_max_active_series: 0
 ```
 
+Note that this value is per metrics generator. The actual max series remote written will be `<# of metrics generators> * <metrics_generator_max_active_series>`.
+
 ### Remote write failures
 
 For any number of reasons, the generator may fail a write to the remote write target. Use the following metrics to
@@ -75,6 +81,8 @@ determine if that is happening:
 ```
 sum(rate(prometheus_remote_storage_samples_failed_total{}[1m]))
 sum(rate(prometheus_remote_storage_samples_dropped_total{}[1m]))
+sum(rate(prometheus_remote_storage_exemplars_failed_total{}[1m]))
+sum(rate(prometheus_remote_storage_exemplars_dropped_total{}[1m]))
 ```
 
 ## Service graph metrics

--- a/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
+++ b/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
@@ -27,7 +27,7 @@ sum(rate(tempo_distributor_queue_pushes_failures_total{}[1m]))
 
 ### Failed pushes to the generator
 
-For any number of reasons the distributor can fail a push to the generators. Use the following metric to
+For any number of reasons, the distributor can fail a push to the generators. Use the following metric to
 determine if that is happening:
 
 ```

--- a/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
+++ b/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
@@ -44,7 +44,7 @@ Rate of all edges:
 sum(rate(tempo_metrics_generator_processor_service_graphs_edges{}[1m]))
 ```
 
-If you are seeing a large number of edges expire without a match consider adjusting the following setting. This
+If you are seeing a large number of edges expire without a match, consider adjusting the `wait` setting. This
 controls how long the metrics generator waits to find a match before it gives up.
 
 ```

--- a/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
+++ b/docs/sources/tempo/operations/troubleshooting/metrics-generator.md
@@ -1,0 +1,55 @@
+---
+title: Troubleshoot Metrics Generator
+menuTitle: Metrics Generator
+description: Gain an understanding of how to debug metrics quality issues.
+weight: 500
+---
+
+If you are concerned with data quality issues in the metrics generator, we'd first recommend:
+
+- Reviewing your telemetry pipeline to determine the number of dropped spans. We are only looking for major issues here.
+- Reviewing the [service graph documentation]({{< relref "../../metrics-generator/service_graphs" >}}) to understand how they are built.
+
+If everything seems ok from these two perspectives consider the following.
+
+## All metrics
+
+Spans are rejected from being considered by the metrics generator by a configurable slack time as well as due to user
+configurable filters. You can see the number of spans rejected by reason using this metric:
+
+```
+sum(rate(tempo_metrics_generator_spans_discarded_total{}[1m])) by (reason)
+```
+
+If you are dropping a lot of spans due to your filters, you will need to adjust them. If you are dropping a lot of spans
+due to the ingestion slack time consider adjusting this setting:
+
+```
+metrics_generator:
+  metrics_ingestion_time_range_slack: 30s
+```
+
+## Service graphs
+
+Service graphs have additional configuration which can impact the quality of the output metrics. The following metrics
+can be used to determine how many edges are failing to find a match.
+
+Rate of edges that have expired without a match:
+```
+sum(rate(tempo_metrics_generator_processor_service_graphs_expired_edges{}[1m]))
+```
+
+Rate of all edges:
+```
+sum(rate(tempo_metrics_generator_processor_service_graphs_edges{}[1m]))
+```
+
+If you are seeing a large number of edges expire without a match consider adjusting the following setting. This
+controls how long the metrics generator waits to find a match before it gives up.
+
+```
+metrics_generator:
+  processor:
+    service_graphs:
+      wait: 10s
+```


### PR DESCRIPTION
Adds a trouble shooting page for metrics generator. There have been a lot of questions like

https://github.com/grafana/tempo/issues/2771

and I feel like this is a gap in the docs.