### PR TITLE
Avoid using "b/c" in official documentation

### DIFF
--- a/docs/sources/tempo/traceql/_index.md
+++ b/docs/sources/tempo/traceql/_index.md
@@ -272,8 +272,7 @@ or anything else that comes to mind.
 
 ## Selection
 
-TraceQL can select arbitrary fields from spans. This is particularly performant b/c
-the selected fields are not retrieved until all other criteria is met.
+TraceQL can select arbitrary fields from spans. This is particularly performant because the selected fields are not retrieved until all other criteria is met.
 ```
 { status=error } | select(span.http.status_code, span.http.url)
 ```


### PR DESCRIPTION
Small proposal to remove "b/c" from the [Query with TraceQL](https://grafana.com/docs/tempo/latest/traceql/#query-with-traceql) documentation page, more precisely in the [Selection](https://grafana.com/docs/tempo/latest/traceql/#selection) section:
<img width="780" alt="image" src="https://github.com/grafana/tempo/assets/135109076/517b53da-8b10-456c-8501-7560a090ede4">