### PR TITLE
Add trace quality metrics

### DIFF
--- a/pkg/dataquality/warnings.go
+++ b/pkg/dataquality/warnings.go
@@ -5,7 +5,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-const reasonOutsideIngestionSlack = "outside_ingestion_time_slack"
+const (
+	reasonOutsideIngestionSlack = "outside_ingestion_time_slack"
+	reasonDisconnectedTrace     = "disconnected_trace"
+
+	PhaseTraceFlushedToWal     = "_flushed_to_wal"
+	PhaseTraceWalToComplete    = "_wal_to_complete"
+	PhaseTraceCompactorCombine = "_compactor_combine"
+)
 
 var metric = promauto.NewCounterVec(prometheus.CounterOpts{
 	Namespace: "tempo",
@@ -15,4 +22,8 @@ var metric = promauto.NewCounterVec(prometheus.CounterOpts{
 
 func WarnOutsideIngestionSlack(tenant string) {
 	metric.WithLabelValues(tenant, reasonOutsideIngestionSlack).Inc()
+}
+
+func WarnDisconnectedTrace(tenant string, phase string) {
+	metric.WithLabelValues(tenant, reasonDisconnectedTrace+phase).Inc()
 }

--- a/pkg/dataquality/warnings.go
+++ b/pkg/dataquality/warnings.go
@@ -24,6 +24,7 @@ func WarnOutsideIngestionSlack(tenant string) {
 	metric.WithLabelValues(tenant, reasonOutsideIngestionSlack).Inc()
 }
 
+// jpe - make own metric, remove _wal_to_complete
 func WarnDisconnectedTrace(tenant string, phase string) {
 	metric.WithLabelValues(tenant, reasonDisconnectedTrace+phase).Inc()
 }

--- a/pkg/dataquality/warnings.go
+++ b/pkg/dataquality/warnings.go
@@ -24,7 +24,6 @@ func WarnOutsideIngestionSlack(tenant string) {
 	metric.WithLabelValues(tenant, reasonOutsideIngestionSlack).Inc()
 }
 
-// jpe - make own metric, remove _wal_to_complete
 func WarnDisconnectedTrace(tenant string, phase string) {
 	metric.WithLabelValues(tenant, reasonDisconnectedTrace+phase).Inc()
 }

--- a/pkg/dataquality/warnings.go
+++ b/pkg/dataquality/warnings.go
@@ -1,14 +1,18 @@
-package warnings
+package dataquality
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-const ReasonOutsideIngestionSlack = "outside_ingestion_time_slack"
+const reasonOutsideIngestionSlack = "outside_ingestion_time_slack"
 
-var Metric = promauto.NewCounterVec(prometheus.CounterOpts{
+var metric = promauto.NewCounterVec(prometheus.CounterOpts{
 	Namespace: "tempo",
 	Name:      "warnings_total",
 	Help:      "The total number of warnings per tenant with reason.",
 }, []string{"tenant", "reason"})
+
+func WarnOutsideIngestionSlack(tenant string) {
+	metric.WithLabelValues(tenant, reasonOutsideIngestionSlack).Inc()
+}

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log/level"
+	"github.com/grafana/tempo/pkg/dataquality"
 	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding"
@@ -224,6 +225,9 @@ func (rw *readerWriter) compact(ctx context.Context, blockMetas []*backend.Block
 		},
 		SpansDiscarded: func(traceId string, spans int) {
 			rw.compactorSharder.RecordDiscardedSpans(spans, tenantID, traceId)
+		},
+		DisconnectedTrace: func() {
+			dataquality.WarnDisconnectedTrace(tenantID, dataquality.PhaseTraceCompactorCombine)
 		},
 	}
 

--- a/tempodb/encoding/common/interfaces.go
+++ b/tempodb/encoding/common/interfaces.go
@@ -72,10 +72,11 @@ type CompactionOptions struct {
 	BlockConfig        BlockConfig
 	Combiner           model.ObjectCombiner
 
-	ObjectsCombined func(compactionLevel, objects int)
-	ObjectsWritten  func(compactionLevel, objects int)
-	BytesWritten    func(compactionLevel, bytes int)
-	SpansDiscarded  func(traceID string, spans int)
+	ObjectsCombined   func(compactionLevel, objects int)
+	ObjectsWritten    func(compactionLevel, objects int)
+	BytesWritten      func(compactionLevel, bytes int)
+	SpansDiscarded    func(traceID string, spans int)
+	DisconnectedTrace func()
 }
 
 type Iterator interface {

--- a/tempodb/encoding/v2/wal_block.go
+++ b/tempodb/encoding/v2/wal_block.go
@@ -15,11 +15,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/opentracing/opentracing-go"
 
+	"github.com/grafana/tempo/pkg/dataquality"
 	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/pkg/model/decoder"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/traceql"
-	"github.com/grafana/tempo/pkg/warnings"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
@@ -364,7 +364,7 @@ func (a *walBlock) adjustTimeRangeForSlack(start uint32, end uint32, additionalS
 	}
 
 	if warn {
-		warnings.Metric.WithLabelValues(a.meta.TenantID, warnings.ReasonOutsideIngestionSlack).Inc()
+		dataquality.WarnOutsideIngestionSlack(a.meta.TenantID)
 	}
 
 	return start, end

--- a/tempodb/encoding/vparquet/wal_block.go
+++ b/tempodb/encoding/vparquet/wal_block.go
@@ -14,12 +14,12 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/grafana/dskit/multierror"
+	"github.com/grafana/tempo/pkg/dataquality"
 	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/parquetquery"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/traceql"
-	"github.com/grafana/tempo/pkg/warnings"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 	"github.com/parquet-go/parquet-go"
@@ -354,7 +354,7 @@ func (b *walBlock) adjustTimeRangeForSlack(start, end uint32, additionalStartSla
 	}
 
 	if warn {
-		warnings.Metric.WithLabelValues(b.meta.TenantID, warnings.ReasonOutsideIngestionSlack).Inc()
+		dataquality.WarnOutsideIngestionSlack(b.meta.TenantID)
 	}
 
 	return start, end

--- a/tempodb/encoding/vparquet2/wal_block.go
+++ b/tempodb/encoding/vparquet2/wal_block.go
@@ -14,12 +14,12 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/grafana/dskit/multierror"
+	"github.com/grafana/tempo/pkg/dataquality"
 	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/parquetquery"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/traceql"
-	"github.com/grafana/tempo/pkg/warnings"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 	"github.com/parquet-go/parquet-go"
@@ -354,7 +354,7 @@ func (b *walBlock) adjustTimeRangeForSlack(start, end uint32, additionalStartSla
 	}
 
 	if warn {
-		warnings.Metric.WithLabelValues(b.meta.TenantID, warnings.ReasonOutsideIngestionSlack).Inc()
+		dataquality.WarnOutsideIngestionSlack(b.meta.TenantID)
 	}
 
 	return start, end

--- a/tempodb/encoding/vparquet3/block_search_test.go
+++ b/tempodb/encoding/vparquet3/block_search_test.go
@@ -98,7 +98,7 @@ func TestBackendBlockSearch(t *testing.T) {
 
 		id := test.ValidTraceID(nil)
 		pbTrace := test.MakeTrace(10, id)
-		pqTrace := traceToParquet(&backend.BlockMeta{}, id, pbTrace, nil)
+		pqTrace, _ := traceToParquet(&backend.BlockMeta{}, id, pbTrace, nil)
 		allTraces = append(allTraces, pqTrace)
 	}
 

--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -57,7 +57,7 @@ func TestBackendBlockSearchTraceQL(t *testing.T) {
 		}
 
 		id := test.ValidTraceID(nil)
-		tr := traceToParquet(&backend.BlockMeta{}, id, test.MakeTrace(1, id), nil)
+		tr, _ := traceToParquet(&backend.BlockMeta{}, id, test.MakeTrace(1, id), nil)
 		traces = append(traces, tr)
 	}
 

--- a/tempodb/encoding/vparquet3/combiner.go
+++ b/tempodb/encoding/vparquet3/combiner.go
@@ -126,7 +126,7 @@ func (c *Combiner) ConsumeWithFinal(tr *Trace, final bool) (spanCount int) {
 	return
 }
 
-// Result returns the final trace and span count.
+// Result returns the final trace, its span count, and a bool indicating whether the trace is a connected graph.
 func (c *Combiner) Result() (*Trace, int, bool) {
 	spanCount := -1
 

--- a/tempodb/encoding/vparquet3/combiner_test.go
+++ b/tempodb/encoding/vparquet3/combiner_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 func TestCombiner(t *testing.T) {
-	methods := []func(a, b *Trace) (*Trace, int){
-		func(a, b *Trace) (*Trace, int) {
+	methods := []func(a, b *Trace) (*Trace, int, bool){
+		func(a, b *Trace) (*Trace, int, bool) {
 			c := NewCombiner()
 			c.Consume(a)
 			c.Consume(b)
@@ -222,7 +222,7 @@ func TestCombiner(t *testing.T) {
 
 	for _, tt := range tests {
 		for _, m := range methods {
-			actualTrace, actualTotal := m(tt.traceA, tt.traceB)
+			actualTrace, actualTotal, _ := m(tt.traceA, tt.traceB)
 			assert.Equal(t, tt.expectedTotal, actualTotal)
 			if tt.expectedTrace != nil {
 				assert.Equal(t, tt.expectedTrace, actualTrace)
@@ -240,10 +240,10 @@ func BenchmarkCombine(b *testing.B) {
 	for _, spanCount := range spanCounts {
 		b.Run("SpanCount:"+humanize.SI(float64(batchCount*spanCount), ""), func(b *testing.B) {
 			id1 := test.ValidTraceID(nil)
-			tr1 := traceToParquet(&backend.BlockMeta{}, id1, test.MakeTraceWithSpanCount(batchCount, spanCount, id1), nil)
+			tr1, _ := traceToParquet(&backend.BlockMeta{}, id1, test.MakeTraceWithSpanCount(batchCount, spanCount, id1), nil)
 
 			id2 := test.ValidTraceID(nil)
-			tr2 := traceToParquet(&backend.BlockMeta{}, id2, test.MakeTraceWithSpanCount(batchCount, spanCount, id2), nil)
+			tr2, _ := traceToParquet(&backend.BlockMeta{}, id2, test.MakeTraceWithSpanCount(batchCount, spanCount, id2), nil)
 
 			b.ResetTimer()
 
@@ -266,7 +266,7 @@ func BenchmarkSortTrace(b *testing.B) {
 	for _, spanCount := range spanCounts {
 		b.Run("SpanCount:"+humanize.SI(float64(batchCount*spanCount), ""), func(b *testing.B) {
 			id := test.ValidTraceID(nil)
-			tr := traceToParquet(&backend.BlockMeta{}, id, test.MakeTraceWithSpanCount(batchCount, spanCount, id), nil)
+			tr, _ := traceToParquet(&backend.BlockMeta{}, id, test.MakeTraceWithSpanCount(batchCount, spanCount, id), nil)
 
 			b.ResetTimer()
 

--- a/tempodb/encoding/vparquet3/compactor.go
+++ b/tempodb/encoding/vparquet3/compactor.go
@@ -120,7 +120,10 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 			cmb.ConsumeWithFinal(tr, i == len(rows)-1)
 			pool.Put(row)
 		}
-		tr, _ := cmb.Result()
+		tr, _, connected := cmb.Result()
+		if !connected {
+			c.opts.DisconnectedTrace()
+		}
 
 		c.opts.ObjectsCombined(int(compactionLevel), 1)
 		return sch.Deconstruct(pool.Get(), tr), nil

--- a/tempodb/encoding/vparquet3/compactor_test.go
+++ b/tempodb/encoding/vparquet3/compactor_test.go
@@ -127,7 +127,8 @@ func createTestBlock(t testing.TB, ctx context.Context, cfg *common.BlockConfig,
 		require.NoError(t, err)
 
 		tr := test.AddDedicatedAttributes(test.MakeTraceWithSpanCount(batchCount, spanCount, id))
-		trp := traceToParquet(inMeta, id, tr, nil)
+		trp, connected := traceToParquet(inMeta, id, tr, nil)
+		require.False(t, connected)
 
 		require.NoError(t, sb.Add(trp, 0, 0))
 		if sb.EstimatedBufferedBytes() > 20_000_000 {
@@ -158,7 +159,8 @@ func TestCountSpans(t *testing.T) {
 
 	// make Trace and convert to parquet.Row
 	tr := test.MakeTraceWithSpanCount(batchSize, spansEach, traceID)
-	trp := traceToParquet(&backend.BlockMeta{}, traceID, tr, nil)
+	trp, connected := traceToParquet(&backend.BlockMeta{}, traceID, tr, nil)
+	require.False(t, connected)
 	row := sch.Deconstruct(nil, trp)
 
 	// count spans for generated rows.

--- a/tempodb/encoding/vparquet3/create.go
+++ b/tempodb/encoding/vparquet3/create.go
@@ -54,7 +54,7 @@ func CreateBlock(ctx context.Context, cfg *common.BlockConfig, meta *backend.Blo
 			// Copy ID to allow it to escape the iterator.
 			id = append([]byte(nil), id...)
 
-			trp = traceToParquet(meta, id, tr, trp)
+			trp, _ = traceToParquet(meta, id, tr, trp) // this logic only executes when we are transitioning from one block version to another. just ignore connected here
 
 			row := sch.Deconstruct(completeBlockRowPool.Get(), trp)
 

--- a/tempodb/encoding/vparquet3/nested_set_model_test.go
+++ b/tempodb/encoding/vparquet3/nested_set_model_test.go
@@ -172,7 +172,7 @@ func TestAssignNestedSetModelBounds(t *testing.T) {
 					{SpanID: []byte("bbbbbbbb"), ParentSpanID: []byte("aaaaaaaa"), NestedSetLeft: 2, NestedSetRight: 3, ParentID: 1},
 				},
 			},
-			expectedConnected: true, // jpe ?
+			expectedConnected: true,
 		},
 		{
 			name: "non unique IDs",

--- a/tempodb/encoding/vparquet3/nested_set_model_test.go
+++ b/tempodb/encoding/vparquet3/nested_set_model_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
-
 	"github.com/grafana/tempo/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,9 +11,10 @@ import (
 
 func TestAssignNestedSetModelBounds(t *testing.T) {
 	tests := []struct {
-		name     string
-		trace    [][]Span
-		expected [][]Span
+		name              string
+		trace             [][]Span
+		expected          [][]Span
+		expectedConnected bool
 	}{
 		{
 			name: "single span",
@@ -28,6 +28,7 @@ func TestAssignNestedSetModelBounds(t *testing.T) {
 					{SpanID: []byte("aaaaaaaa"), NestedSetLeft: 1, NestedSetRight: 2},
 				},
 			},
+			expectedConnected: true,
 		},
 		{
 			name: "linear trace",
@@ -45,6 +46,7 @@ func TestAssignNestedSetModelBounds(t *testing.T) {
 					{SpanID: []byte("cccccccc"), ParentSpanID: []byte("bbbbbbbb"), NestedSetLeft: 3, NestedSetRight: 4, ParentID: 2},
 				},
 			},
+			expectedConnected: true,
 		},
 		{
 			name: "branched trace",
@@ -68,6 +70,7 @@ func TestAssignNestedSetModelBounds(t *testing.T) {
 					{SpanID: []byte("ffffffff"), ParentSpanID: []byte("dddddddd"), NestedSetLeft: 8, NestedSetRight: 9, ParentID: 5},
 				},
 			},
+			expectedConnected: true,
 		},
 		{
 			name: "multiple scope spans",
@@ -95,6 +98,7 @@ func TestAssignNestedSetModelBounds(t *testing.T) {
 					{SpanID: []byte("ffffffff"), ParentSpanID: []byte("dddddddd"), NestedSetLeft: 8, NestedSetRight: 9, ParentID: 5},
 				},
 			},
+			expectedConnected: true,
 		},
 		{
 			name: "multiple roots",
@@ -126,6 +130,7 @@ func TestAssignNestedSetModelBounds(t *testing.T) {
 					{SpanID: []byte("iiiiiiii"), ParentSpanID: []byte("hhhhhhhh"), NestedSetLeft: 15, NestedSetRight: 16, ParentID: 14},
 				},
 			},
+			expectedConnected: true,
 		},
 		{
 			name: "interrupted",
@@ -151,6 +156,7 @@ func TestAssignNestedSetModelBounds(t *testing.T) {
 					{SpanID: []byte("ffffffff"), ParentSpanID: []byte("eeeeeeee")},
 				},
 			},
+			expectedConnected: false,
 		},
 		{
 			name: "partially assigned",
@@ -166,6 +172,7 @@ func TestAssignNestedSetModelBounds(t *testing.T) {
 					{SpanID: []byte("bbbbbbbb"), ParentSpanID: []byte("aaaaaaaa"), NestedSetLeft: 2, NestedSetRight: 3, ParentID: 1},
 				},
 			},
+			expectedConnected: true, // jpe ?
 		},
 		{
 			name: "non unique IDs",
@@ -187,6 +194,7 @@ func TestAssignNestedSetModelBounds(t *testing.T) {
 					{SpanID: []byte("dddddddd"), ParentSpanID: []byte("bbbbbbbb"), NestedSetLeft: 6, NestedSetRight: 7, ParentID: 3},
 				},
 			},
+			expectedConnected: true,
 		},
 		{
 			name: "non unique IDs 2x",
@@ -208,6 +216,43 @@ func TestAssignNestedSetModelBounds(t *testing.T) {
 					{SpanID: []byte("cccccccc"), ParentSpanID: []byte("cccccccc"), Kind: int(v1.Span_SPAN_KIND_SERVER), NestedSetLeft: 5, NestedSetRight: 6, ParentID: 4},
 				},
 			},
+			expectedConnected: true,
+		},
+		{
+			name: "3x IDs - invalid trace",
+			trace: [][]Span{
+				{
+					{SpanID: []byte("aaaaaaaa")},
+					{SpanID: []byte("bbbbbbbb"), ParentSpanID: []byte("bbbbbbbb")},
+					{SpanID: []byte("bbbbbbbb"), ParentSpanID: []byte("bbbbbbbb")},
+					{SpanID: []byte("bbbbbbbb"), ParentSpanID: []byte("bbbbbbbb")},
+				},
+			},
+			expected: [][]Span{
+				{
+					{SpanID: []byte("aaaaaaaa")},
+					{SpanID: []byte("bbbbbbbb"), ParentSpanID: []byte("bbbbbbbb")},
+					{SpanID: []byte("bbbbbbbb"), ParentSpanID: []byte("bbbbbbbb")},
+					{SpanID: []byte("bbbbbbbb"), ParentSpanID: []byte("bbbbbbbb")},
+				},
+			},
+			expectedConnected: false,
+		},
+		{
+			name: "no roots",
+			trace: [][]Span{
+				{
+					{SpanID: []byte("cccccccc"), ParentSpanID: []byte("bbbbbbbb")},
+					{SpanID: []byte("bbbbbbbb"), ParentSpanID: []byte("aaaaaaaa")},
+				},
+			},
+			expected: [][]Span{
+				{
+					{SpanID: []byte("cccccccc"), ParentSpanID: []byte("bbbbbbbb")},
+					{SpanID: []byte("bbbbbbbb"), ParentSpanID: []byte("aaaaaaaa")},
+				},
+			},
+			expectedConnected: false,
 		},
 	}
 
@@ -224,8 +269,9 @@ func TestAssignNestedSetModelBounds(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			trace := makeTrace(tt.trace)
 			expected := makeTrace(tt.expected)
-			assignNestedSetModelBounds(trace)
+			connected := assignNestedSetModelBounds(trace)
 			assertEqualNestedSetModelBounds(t, trace, expected)
+			assert.Equal(t, tt.expectedConnected, connected)
 		})
 	}
 }

--- a/tempodb/encoding/vparquet3/schema.go
+++ b/tempodb/encoding/vparquet3/schema.go
@@ -259,7 +259,9 @@ func attrToParquet(a *v1.KeyValue, p *Attribute) {
 	}
 }
 
-func traceToParquet(meta *backend.BlockMeta, id common.ID, tr *tempopb.Trace, ot *Trace) *Trace {
+// traceToParquet converts a tempopb.Trace to this schema's object model. Returns the new object and
+// a bool indicating if it's a connected trace or not
+func traceToParquet(meta *backend.BlockMeta, id common.ID, tr *tempopb.Trace, ot *Trace) (*Trace, bool) {
 	if ot == nil {
 		ot = &Trace{}
 	}
@@ -471,9 +473,7 @@ func traceToParquet(meta *backend.BlockMeta, id common.ID, tr *tempopb.Trace, ot
 		}
 	}
 
-	assignNestedSetModelBounds(ot)
-
-	return ot
+	return ot, assignNestedSetModelBounds(ot)
 }
 
 func eventToParquet(e *v1_trace.Span_Event, ee *Event) {

--- a/tempodb/encoding/vparquet3/wal_block.go
+++ b/tempodb/encoding/vparquet3/wal_block.go
@@ -14,12 +14,12 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/grafana/dskit/multierror"
+	"github.com/grafana/tempo/pkg/dataquality"
 	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/parquetquery"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/traceql"
-	"github.com/grafana/tempo/pkg/warnings"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 	"github.com/parquet-go/parquet-go"
@@ -355,7 +355,7 @@ func (b *walBlock) adjustTimeRangeForSlack(start, end uint32, additionalStartSla
 	}
 
 	if warn {
-		warnings.Metric.WithLabelValues(b.meta.TenantID, warnings.ReasonOutsideIngestionSlack).Inc()
+		dataquality.WarnOutsideIngestionSlack(b.meta.TenantID)
 	}
 
 	return start, end


### PR DESCRIPTION
**What this PR does**:
Counts disconnected traces in two "phases" of a trace's lifetime. The first is when the trace is cut from live traces to the head block. The second is when the trace is combined in the compactor. These counters should be combined with other metrics to get a percentage of traces disconnected:

```
rate(tempo_warnings_total{reason="disconnected_trace_flushed_to_wal"}[1m]) /
rate(tempo_ingester_traces_created_total{}[1m])
```
```
rate(tempo_warnings_total{reason="disconnected_trace_compactor_combine"}[1m]) /
rate(tempodb_compaction_objects_combined_total{}[1m])
```

*Thoughts*
- The first metric percentage above isn't exact. "Traces created" is counted when a live trace is created. The warning is counted when a live trace is flushed to the wal.
- There is an opportunity to also record this metric when we flush from wal -> complete block. See comments in code for why it is quite difficult to count in this case.
- This is implemented only on vParquet3 for simplicity. This should soon be our default block version.
- Found and fixed a small issue in `assignNestedSetModelBounds`. Added tests.

cc @stoewer This touches the `assignNestedSetModelBounds` function. If you have a chance to review, it would be appreciated.

**Which issue(s) this PR fixes**:
Fixes #2749 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`