### PR TITLE
Improve TruncateRowNumber

### DIFF
--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -62,12 +62,10 @@ func CompareRowNumbers(upToDefinitionLevel int, a, b RowNumber) int {
 	return 0
 }
 
-func TruncateRowNumber(definitionLevelToKeep int, t RowNumber) RowNumber {
-	n := EmptyRowNumber()
-	for i := 0; i <= definitionLevelToKeep; i++ {
-		n[i] = t[i]
+func TruncateRowNumber(definitionLevelToKeep int, t RowNumber) {
+	for i := definitionLevelToKeep + 1; i < len(t); i++ {
+		t[i] = -1
 	}
-	return n
 }
 
 func (t *RowNumber) Valid() bool {
@@ -1287,7 +1285,7 @@ func (j *JoinIterator) SeekTo(t RowNumber, d int) (*IteratorResult, error) {
 
 func (j *JoinIterator) seekAll(t RowNumber, d int) error {
 	var err error
-	t = TruncateRowNumber(d, t)
+	TruncateRowNumber(d, t)
 	for iterNum, iter := range j.iters {
 		if j.peeks[iterNum] == nil || CompareRowNumbers(d, j.peeks[iterNum].RowNumber, t) == -1 {
 			ReleaseResult(j.peeks[iterNum])
@@ -1461,7 +1459,7 @@ func (j *LeftJoinIterator) SeekTo(t RowNumber, d int) (*IteratorResult, error) {
 }
 
 func (j *LeftJoinIterator) seekAll(t RowNumber, d int) (err error) {
-	t = TruncateRowNumber(d, t)
+	TruncateRowNumber(d, t)
 	for iterNum, iter := range j.required {
 		if j.peeksRequired[iterNum] == nil || CompareRowNumbers(d, j.peeksRequired[iterNum].RowNumber, t) == -1 {
 			ReleaseResult(j.peeksRequired[iterNum])
@@ -1633,7 +1631,7 @@ func (u *UnionIterator) Next() (*IteratorResult, error) {
 
 func (u *UnionIterator) SeekTo(t RowNumber, d int) (*IteratorResult, error) {
 	var err error
-	t = TruncateRowNumber(d, t)
+	TruncateRowNumber(d, t)
 	for iterNum, iter := range u.iters {
 		if p := u.peeks[iterNum]; p == nil || CompareRowNumbers(d, p.RowNumber, t) == -1 {
 			u.peeks[iterNum], err = iter.SeekTo(t, d)


### PR DESCRIPTION
Perf improvement found doing some idle profiling of traceql. 

Bench:
```
name                                                old time/op    new time/op     delta
BackendBlockTraceQL/spanAttNameNoMatch-8              7.69ms ± 2%     7.62ms ± 0%     ~     (p=0.548 n=5+5)
BackendBlockTraceQL/spanAttValNoMatch-8               13.5ms ± 2%     13.4ms ± 1%     ~     (p=0.222 n=5+5)
BackendBlockTraceQL/spanAttValMatch-8                  440ms ± 3%      450ms ± 3%     ~     (p=0.095 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8         7.59ms ± 1%     7.60ms ± 2%     ~     (p=1.000 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicMatch-8            370ms ± 1%      376ms ± 3%     ~     (p=0.310 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicRegexNoMatch-8    8.28ms ± 2%     8.21ms ± 1%     ~     (p=0.556 n=5+4)
BackendBlockTraceQL/spanAttIntrinsicRegexMatch-8       562ms ± 2%      579ms ± 3%   +2.99%  (p=0.008 n=5+5)
BackendBlockTraceQL/resourceAttNameNoMatch-8          6.53ms ± 1%     6.43ms ± 1%   -1.50%  (p=0.032 n=5+5)
BackendBlockTraceQL/resourceAttValNoMatch-8           27.3ms ± 0%     27.4ms ± 1%     ~     (p=0.421 n=5+5)
BackendBlockTraceQL/resourceAttValMatch-8              595ms ± 6%      572ms ± 3%     ~     (p=0.056 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicNoMatch-8     6.81ms ± 9%     6.47ms ± 2%   -4.91%  (p=0.032 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8        232ms ± 5%      201ms ± 2%  -13.53%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedNameNoMatch-8                 4.52s ±15%      3.62s ± 3%  -19.83%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedValNoMatch-8                  3.46s ± 4%      2.99s ± 2%  -13.53%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchAnd-8           7.73ms ± 2%     7.05ms ±10%   -8.75%  (p=0.032 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchOr-8             3.47s ± 2%      3.15s ± 1%   -9.36%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedValBothMatch-8               8.30ms ±18%     7.25ms ± 1%  -12.71%  (p=0.008 n=5+5)

name                                                old speed      new speed       delta
BackendBlockTraceQL/spanAttNameNoMatch-8            1.45GB/s ± 2%   1.46GB/s ± 0%     ~     (p=0.548 n=5+5)
BackendBlockTraceQL/spanAttValNoMatch-8              901MB/s ± 2%    911MB/s ± 1%     ~     (p=0.222 n=5+5)
BackendBlockTraceQL/spanAttValMatch-8               44.5MB/s ± 3%   43.5MB/s ± 3%     ~     (p=0.095 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8       1.47GB/s ± 1%   1.46GB/s ± 2%     ~     (p=1.000 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicMatch-8          385MB/s ± 1%    379MB/s ± 3%     ~     (p=0.310 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicRegexNoMatch-8  1.35GB/s ± 2%   1.32GB/s ±10%     ~     (p=1.000 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicRegexMatch-8     254MB/s ± 2%    246MB/s ± 3%   -2.89%  (p=0.008 n=5+5)
BackendBlockTraceQL/resourceAttNameNoMatch-8         922MB/s ± 1%    936MB/s ± 1%   +1.52%  (p=0.032 n=5+5)
BackendBlockTraceQL/resourceAttValNoMatch-8          426MB/s ± 0%    425MB/s ± 1%     ~     (p=0.421 n=5+5)
BackendBlockTraceQL/resourceAttValMatch-8            317MB/s ± 6%    329MB/s ± 3%     ~     (p=0.056 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicNoMatch-8    206MB/s ± 8%    216MB/s ± 2%   +4.95%  (p=0.032 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8      633MB/s ± 4%    731MB/s ± 2%  +15.56%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedNameNoMatch-8              9.70MB/s ±13%  12.02MB/s ± 3%  +23.97%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedValNoMatch-8               13.2MB/s ± 4%   15.3MB/s ± 2%  +15.57%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchAnd-8          778MB/s ± 2%    857MB/s ±10%  +10.14%  (p=0.032 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchOr-8          47.3MB/s ± 2%   52.2MB/s ± 1%  +10.32%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedValBothMatch-8              169MB/s ±16%    193MB/s ± 1%  +13.74%  (p=0.008 n=5+5)

name                                                old MB_io/op   new MB_io/op    delta
BackendBlockTraceQL/spanAttNameNoMatch-8                11.1 ± 0%       11.1 ± 0%     ~     (all equal)
BackendBlockTraceQL/spanAttValNoMatch-8                 12.2 ± 0%       12.2 ± 0%     ~     (all equal)
BackendBlockTraceQL/spanAttValMatch-8                   19.6 ± 0%       19.6 ± 0%     ~     (all equal)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8           11.1 ± 0%       11.1 ± 0%     ~     (all equal)
BackendBlockTraceQL/spanAttIntrinsicMatch-8              142 ± 0%        142 ± 0%     ~     (all equal)
BackendBlockTraceQL/spanAttIntrinsicRegexNoMatch-8      11.1 ± 0%       11.1 ± 0%     ~     (all equal)
BackendBlockTraceQL/spanAttIntrinsicRegexMatch-8         142 ± 0%        142 ± 0%     ~     (all equal)
BackendBlockTraceQL/resourceAttNameNoMatch-8            6.01 ± 0%       6.01 ± 0%     ~     (all equal)
BackendBlockTraceQL/resourceAttValNoMatch-8             11.7 ± 0%       11.7 ± 0%     ~     (all equal)
BackendBlockTraceQL/resourceAttValMatch-8                188 ± 0%        188 ± 0%     ~     (all equal)
BackendBlockTraceQL/resourceAttIntrinsicNoMatch-8       1.40 ± 0%       1.40 ± 0%     ~     (all equal)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8          147 ± 0%        147 ± 0%     ~     (all equal)
BackendBlockTraceQL/mixedNameNoMatch-8                  43.5 ± 0%       43.5 ± 0%     ~     (all equal)
BackendBlockTraceQL/mixedValNoMatch-8                   45.7 ± 0%       45.7 ± 0%     ~     (all equal)
BackendBlockTraceQL/mixedValMixedMatchAnd-8             6.01 ± 0%       6.01 ± 0%     ~     (all equal)
BackendBlockTraceQL/mixedValMixedMatchOr-8               164 ± 0%        164 ± 0%     ~     (all equal)
BackendBlockTraceQL/mixedValBothMatch-8                 1.40 ± 0%       1.40 ± 0%     ~     (all equal)

name                                                old alloc/op   new alloc/op    delta
BackendBlockTraceQL/spanAttNameNoMatch-8              3.13MB ± 0%     3.09MB ± 2%     ~     (p=0.190 n=4+5)
BackendBlockTraceQL/spanAttValNoMatch-8               14.6MB ± 1%     14.7MB ± 1%     ~     (p=0.690 n=5+5)
BackendBlockTraceQL/spanAttValMatch-8                 3.79MB ±16%     3.57MB ±20%     ~     (p=0.587 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8         3.55MB ± 3%     3.54MB ± 1%     ~     (p=0.421 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicMatch-8           6.11MB ± 4%     7.19MB ±19%     ~     (p=0.056 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicRegexNoMatch-8    3.93MB ± 0%     3.93MB ± 1%     ~     (p=0.548 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicRegexMatch-8      9.63MB ± 2%    10.57MB ±10%     ~     (p=0.190 n=4+5)
BackendBlockTraceQL/resourceAttNameNoMatch-8          3.01MB ± 1%     2.98MB ± 2%     ~     (p=0.421 n=5+5)
BackendBlockTraceQL/resourceAttValNoMatch-8           28.7MB ± 1%     28.6MB ± 1%     ~     (p=0.841 n=5+5)
BackendBlockTraceQL/resourceAttValMatch-8             31.7MB ± 4%     33.8MB ± 4%   +6.37%  (p=0.008 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicNoMatch-8     2.97MB ± 2%     3.00MB ± 2%     ~     (p=0.421 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8       6.35MB ±12%     6.11MB ±11%     ~     (p=0.548 n=5+5)
BackendBlockTraceQL/mixedNameNoMatch-8                43.9MB ± 6%     44.0MB ± 5%     ~     (p=0.841 n=5+5)
BackendBlockTraceQL/mixedValNoMatch-8                 48.2MB ± 7%     47.8MB ± 4%     ~     (p=1.000 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchAnd-8           3.00MB ± 1%     2.99MB ± 1%     ~     (p=0.841 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchOr-8            40.3MB ±13%     38.7MB ± 7%     ~     (p=0.548 n=5+5)
BackendBlockTraceQL/mixedValBothMatch-8               3.05MB ± 2%     2.98MB ± 2%   -2.12%  (p=0.016 n=5+5)

name                                                old allocs/op  new allocs/op   delta
BackendBlockTraceQL/spanAttNameNoMatch-8               44.4k ± 0%      44.4k ± 0%     ~     (p=0.492 n=5+5)
BackendBlockTraceQL/spanAttValNoMatch-8                44.7k ± 0%      44.7k ± 0%     ~     (p=0.619 n=5+5)
BackendBlockTraceQL/spanAttValMatch-8                  62.4k ± 0%      62.4k ± 0%     ~     (p=0.643 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8          44.4k ± 0%      44.4k ± 0%     ~     (p=0.968 n=5+4)
BackendBlockTraceQL/spanAttIntrinsicMatch-8            62.6k ± 0%      62.5k ± 0%     ~     (p=0.952 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicRegexNoMatch-8     48.8k ± 0%      48.8k ± 0%     ~     (p=0.444 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicRegexMatch-8        100k ± 0%       100k ± 0%     ~     (p=0.286 n=4+5)
BackendBlockTraceQL/resourceAttNameNoMatch-8           44.3k ± 0%      44.3k ± 0%     ~     (p=0.413 n=4+5)
BackendBlockTraceQL/resourceAttValNoMatch-8            44.9k ± 0%      44.9k ± 0%     ~     (p=1.000 n=5+5)
BackendBlockTraceQL/resourceAttValMatch-8              65.3k ± 0%      65.3k ± 0%     ~     (p=0.056 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicNoMatch-8      44.4k ± 0%      44.4k ± 0%     ~     (p=0.238 n=4+5)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8        61.3k ± 0%      61.3k ± 0%     ~     (p=0.500 n=5+5)
BackendBlockTraceQL/mixedNameNoMatch-8                 50.8k ± 0%      50.8k ± 0%     ~     (p=0.841 n=5+4)
BackendBlockTraceQL/mixedValNoMatch-8                   100k ± 0%       100k ± 0%     ~     (p=0.222 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchAnd-8            44.4k ± 0%      44.4k ± 0%     ~     (p=1.000 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchOr-8             69.2k ± 0%      69.2k ± 0%     ~     (p=0.794 n=5+5)
BackendBlockTraceQL/mixedValBothMatch-8                44.4k ± 0%      44.4k ± 0%     ~     (p=0.159 n=5+5)
```