### PR TITLE
[release-v2.2] Avoid index errors for deleted tenants

### DIFF
--- a/tempodb/backend/azure/azure.go
+++ b/tempodb/backend/azure/azure.go
@@ -120,7 +120,7 @@ func (rw *readerWriter) Delete(ctx context.Context, name string, keypath backend
 	}
 
 	if _, err = blobURL.Delete(ctx, blob.DeleteSnapshotsOptionInclude, blob.BlobAccessConditions{}); err != nil {
-		return errors.Wrapf(err, "error deleting blob, name: %s", name)
+		return readError(err)
 	}
 	return nil
 }

--- a/tempodb/backend/gcs/gcs.go
+++ b/tempodb/backend/gcs/gcs.go
@@ -123,8 +123,7 @@ func (rw *readerWriter) CloseAppend(_ context.Context, tracker backend.AppendTra
 }
 
 func (rw *readerWriter) Delete(ctx context.Context, name string, keypath backend.KeyPath, _ bool) error {
-	handle := rw.bucket.Object(backend.ObjectFileName(keypath, name))
-	return handle.Delete(ctx)
+	return readError(rw.bucket.Object(backend.ObjectFileName(keypath, name)).Delete(ctx))
 }
 
 // List implements backend.Reader

--- a/tempodb/backend/mocks.go
+++ b/tempodb/backend/mocks.go
@@ -57,6 +57,7 @@ type MockRawWriter struct {
 	appendBuffer      []byte
 	closeAppendCalled bool
 	deleteCalls       map[string]map[string]int
+	err               error
 }
 
 func (m *MockRawWriter) Write(_ context.Context, _ string, _ KeyPath, data io.Reader, size int64, _ bool) error {
@@ -89,7 +90,7 @@ func (m *MockRawWriter) Delete(_ context.Context, name string, keypath KeyPath, 
 	}
 
 	m.deleteCalls[name][strings.Join(keypath, "/")]++
-	return nil
+	return m.err
 }
 
 // MockCompactor

--- a/tempodb/backend/raw_test.go
+++ b/tempodb/backend/raw_test.go
@@ -59,6 +59,12 @@ func TestWriter(t *testing.T) {
 
 	expectedDeleteMap := map[string]map[string]int{TenantIndexName: {"test": 1}}
 	assert.Equal(t, expectedDeleteMap, w.(*writer).w.(*MockRawWriter).deleteCalls)
+
+	// When a backend returns ErrDoesNotExist, the tenant index should be deleted, but no error should be returned if the tenant index does not exist
+	m = &MockRawWriter{err: ErrDoesNotExist}
+	w = NewWriter(m)
+	err = w.WriteTenantIndex(ctx, "test", nil, nil)
+	assert.NoError(t, err)
 }
 
 func TestReader(t *testing.T) {


### PR DESCRIPTION
Backport e960fd03a8ee4a1208dbf4fe449a7700e61ed225 from #2781

---

**What this PR does**:

Here we ensure that when Tempo tries to delete a tenant index that has already been deleted, that this is not an error condition, and doesn't not log or count against the metrics.  This can happen when an index was deleted because no blocks have been found, but for block paths that still contain spurious objects.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
