### PR TITLE
Fix tools package listing on Go 1.21

### DIFF
--- a/build/tools.mk
+++ b/build/tools.mk
@@ -11,7 +11,7 @@ GO_MOD_OUTDATED  ?= go-mod-outdated
 TOOL_DIR     ?= tools
 TOOL_CONFIG  ?= $(TOOL_DIR)/tools.go
 
-GOTOOLS ?= $(shell cd $(TOOL_DIR) && go list -f '{{ .Imports }}' -tags tools |tr -d '[]')
+GOTOOLS ?= $(shell cd $(TOOL_DIR) && go list -e -f '{{ .Imports }}' -tags tools |tr -d '[]')
 
 tools:
 	@echo "=== [ tools            ]: Installing tools required by the project..."


### PR DESCRIPTION
**What this PR does**:

Without this change, the `go list` used to track with tools are required by the project is broken in Go 1.21, resulting in the following error.

```
tools.go:6:2: import "github.com/psampaz/go-mod-outdated" is a program, not an importable package
```

Here we add `-e` to the `go list` to allow the list to complete and handle the tool management as before.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`