### PR TITLE
Fix incorrectly reported vulture errors

### DIFF
--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -317,7 +317,7 @@ func newJaegerGRPCClient(endpoint string) (*jaeger_grpc.Reporter, error) {
 	return jaeger_grpc.NewReporter(conn, nil, logger), err
 }
 
-func generateRandomInt(min int64, max int64, r *rand.Rand) int64 {
+func generateRandomInt(min, max int64, r *rand.Rand) int64 {
 	min++
 	number := min + r.Int63n(max-min)
 	return number
@@ -436,7 +436,7 @@ func searchTraceql(client *httpclient.Client, seed time.Time) (traceMetrics, err
 
 	start := seed.Add(-30 * time.Minute).Unix()
 	end := seed.Add(30 * time.Minute).Unix()
-	resp, err := client.SearchTraceQLWithRange(fmt.Sprintf(`{span.%s = "%s"}`, attr.Key, util.StringifyAnyValue(attr.Value)), start, end)
+	resp, err := client.SearchTraceQLWithRange(fmt.Sprintf(`{.%s = "%s"}`, attr.Key, util.StringifyAnyValue(attr.Value)), start, end)
 	if err != nil {
 		logger.Error(fmt.Sprintf("failed to search traces with traceql %s: %s", attr.Key, err.Error()))
 		tm.requestFailed++
@@ -513,8 +513,8 @@ func queryTrace(client *httpclient.Client, info *util.TraceInfo) (traceMetrics, 
 }
 
 func equalTraces(a, b *tempopb.Trace) bool {
-	trace.SortTrace(a)
-	trace.SortTrace(b)
+	trace.SortTraceAndAttributes(a)
+	trace.SortTraceAndAttributes(b)
 
 	return reflect.DeepEqual(a, b)
 }

--- a/pkg/util/trace_info.go
+++ b/pkg/util/trace_info.go
@@ -265,7 +265,7 @@ func RandomAttrFromTrace(t *tempopb.Trace) *v1common.KeyValue {
 
 	// maybe choose resource attribute
 	res := batch.Resource
-	if len(res.Attributes) > 0 && rand.Int()%2 == 1 {
+	if len(res.Attributes) > 0 && r.Int()%2 == 1 {
 		return randFrom(r, res.Attributes)
 	}
 

--- a/pkg/util/trace_info.go
+++ b/pkg/util/trace_info.go
@@ -266,7 +266,12 @@ func RandomAttrFromTrace(t *tempopb.Trace) *v1common.KeyValue {
 	// maybe choose resource attribute
 	res := batch.Resource
 	if len(res.Attributes) > 0 && r.Int()%2 == 1 {
-		return randFrom(r, res.Attributes)
+		attr := randFrom(r, res.Attributes)
+		// skip service.name because service names have low cardinality and produce queries with
+		// too many results in tempo-vulture
+		if attr.Key != "service.name" {
+			return attr
+		}
 	}
 
 	if len(batch.ScopeSpans) == 0 {


### PR DESCRIPTION
Fix vulture problems:
* Since #2649 the function `RandomAttrFromTrace()` may return attributes with resource scope. This caused several problems in vulture:
  * When searching for `service.name` the matching traces can exceed the limit and the relevant trace could be missing from the result
    *Solution: skip the `service.name` attribute when selecting random attributes*
  * Vulture's `searchTraceql()` function was only searching through span attributes
    *Solution: change query template from `span.%s="%s"` to `.%s="%s"`*
  
* The order of attributes in generated data can differ from the order of attributes in traces retrieved from the API.
  *Solution: sort attributes before testing traces for equality*

**Which issue(s) this PR fixes**:
Fixes #2792

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`