### PR TITLE
Fix upgrade go to 1.21.0

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -105,7 +105,7 @@ local image_tag_for_cd() = {
 
 local build_binaries(arch) = {
   name: 'build-tempo-binaries',
-  image: 'golang:1.20.4-alpine',
+  image: 'golang:1.21.0-alpine',
   commands: [
     'apk --update --no-cache add make git bash',
   ] + [
@@ -227,7 +227,7 @@ local deploy_to_dev() = {
     steps+: [
               {
                 name: 'build-tempo-serverless',
-                image: 'golang:1.20.4-alpine',
+                image: 'golang:1.21.0-alpine',
                 commands: [
                   'apk add make git zip bash',
                   './tools/image-tag | cut -d, -f 1 | tr A-Z a-z > .tags',  // values in .tags are used by the next step when pushing the image
@@ -324,7 +324,7 @@ local deploy_to_dev() = {
       },
       {
         name: 'write-key',
-        image: 'golang:1.20.4',
+        image: 'golang:1.21.0',
         commands: ['printf "%s" "$NFPM_SIGNING_KEY" > $NFPM_SIGNING_KEY_FILE'],
         environment: {
           NFPM_SIGNING_KEY: { from_secret: gpg_private_key.name },
@@ -333,7 +333,7 @@ local deploy_to_dev() = {
       },
       {
         name: 'test release',
-        image: 'golang:1.20.4',
+        image: 'golang:1.21.0',
         commands: ['make release-snapshot'],
         environment: {
           NFPM_DEFAULT_PASSPHRASE: { from_secret: gpg_passphrase.name },
@@ -366,7 +366,7 @@ local deploy_to_dev() = {
       },
       {
         name: 'release',
-        image: 'golang:1.20.4',
+        image: 'golang:1.21.0',
         commands: ['make release'],
         environment: {
           GITHUB_TOKEN: { from_secret: gh_token_secret.name },

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -424,3 +424,8 @@ get:
   path: infra/data/ci/packages-publish/gpg
 kind: secret
 name: gpg_passphrase
+---
+kind: signature
+hmac: eae1569a689ddcdfb6f035a65ede40722df9c374dce27af3628833e518d6ab82
+
+...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -17,7 +17,7 @@ steps:
   - COMPONENT=tempo GOARCH=amd64 make exe
   - COMPONENT=tempo-vulture GOARCH=amd64 make exe
   - COMPONENT=tempo-query GOARCH=amd64 make exe
-  image: golang:1.20.4-alpine
+  image: golang:1.21.0-alpine
   name: build-tempo-binaries
 - image: plugins/docker
   name: build-tempo-image
@@ -78,7 +78,7 @@ steps:
   - COMPONENT=tempo GOARCH=arm64 make exe
   - COMPONENT=tempo-vulture GOARCH=arm64 make exe
   - COMPONENT=tempo-query GOARCH=arm64 make exe
-  image: golang:1.20.4-alpine
+  image: golang:1.21.0-alpine
   name: build-tempo-binaries
 - image: plugins/docker
   name: build-tempo-image
@@ -238,7 +238,7 @@ steps:
   - cd ./cmd/tempo-serverless
   - make build-docker-gcr-binary
   - make build-lambda-zip
-  image: golang:1.20.4-alpine
+  image: golang:1.21.0-alpine
   name: build-tempo-serverless
 - image: plugins/gcr
   name: deploy-tempo-serverless-gcr
@@ -308,7 +308,7 @@ steps:
     NFPM_SIGNING_KEY:
       from_secret: gpg_private_key
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: golang:1.20.4
+  image: golang:1.21.0
   name: write-key
 - commands:
   - make release-snapshot
@@ -316,7 +316,7 @@ steps:
     NFPM_DEFAULT_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: golang:1.20.4
+  image: golang:1.21.0
   name: test release
 - commands:
   - ./tools/packaging/verify-deb-install.sh
@@ -342,7 +342,7 @@ steps:
     NFPM_DEFAULT_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: golang:1.20.4
+  image: golang:1.21.0
   name: release
   when:
     event:
@@ -424,8 +424,3 @@ get:
   path: infra/data/ci/packages-publish/gpg
 kind: secret
 name: gpg_passphrase
----
-kind: signature
-hmac: beb2593e403f909da214e906b27317f8df0ed24dea4d98d04ba27e985b1ea701
-
-...

--- a/cmd/tempo-serverless/lambda/Dockerfile
+++ b/cmd/tempo-serverless/lambda/Dockerfile
@@ -13,7 +13,7 @@
 #
 # build the lambda and retrive the lambda-local-proxy
 #
-FROM golang:1.20.4-buster AS build
+FROM golang:1.21.0 AS build
 
 # copy in the lambda. todo: build in container
 COPY lambda /


### PR DESCRIPTION
PR #2829 missed to update some of the Go build images which broke the [drone build](https://drone.grafana.net/grafana/tempo/2411).
This PR updates the build images to Go 1.21

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`