### PR TITLE
Rework SLO metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@
 * [BUGFIX] Fix panic in metrics summary api [#2738](https://github.com/grafana/tempo/pull/2738) (@mdisibio)
 * [BUGFIX] Fix node role auth IDMSv1 [#2760](https://github.com/grafana/tempo/pull/2760) (@coufalja)
 * [BUGFIX] Only search ingester blocks that fall within the request time range. [#2783](https://github.com/grafana/tempo/pull/2783) (@joe-elliott)
+* [BUGFIX] Align tempo_query_frontend_queries_total and tempo_query_frontend_queries_within_slo_total. [#2840](https://github.com/grafana/tempo/pull/2840) (@joe-elliott)
+  This query will now correctly tell you %age of requests that are within SLO:
+  ```
+  sum(rate(tempo_query_frontend_queries_within_slo_total{}[1m])) by (op) 
+  /
+  sum(rate(tempo_query_frontend_queries_total{}[1m])) by (op)
+  ```
+  **BREAKING CHANGE** Removed: tempo_query_frontend_queries_total{op="searchtags|metrics"}. 
 * [CHANGE] Overrides module refactor [#2688](https://github.com/grafana/tempo/pull/2688) (@mapno)
     Added new `defaults` block to the overrides' module. Overrides change to indented syntax.
     Old config:
@@ -38,9 +46,7 @@ defaults:
   forwarders: ['foo']
   metrics_generator:
     processors: [service-graphs, span-metrics]
-```
-* [CHANGE] Dropped status from tempo_query_frontend_queries_total to better align with the slo metric. This
-  is technically a breaking change, but since the status code was always 0 it's clear no one was using it. [#2840](https://github.com/grafana/tempo/pull/2840) (@joe-elliott)
+```  
 
 ## v2.2.1 / 2023-08-??
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ defaults:
   metrics_generator:
     processors: [service-graphs, span-metrics]
 ```
+* [CHANGE] Dropped status from tempo_query_frontend_queries_total to better align with the slo metric. This
+  is technically a breaking change, but since the status code was always 0 it's clear no one was using it. [#2840](https://github.com/grafana/tempo/pull/2840) (@joe-elliott)
 
 ## v2.2.1 / 2023-08-??
 

--- a/example/docker-compose/shared/tempo.yaml
+++ b/example/docker-compose/shared/tempo.yaml
@@ -1,6 +1,14 @@
 server:
   http_listen_port: 3200
 
+query_frontend:
+  search:
+    duration_slo: 5s
+    throughput_bytes_slo: 1.073741824e+09
+  trace_by_id:
+    duration_slo: 5s
+
+
 distributor:
   receivers:                           # this configuration will listen on all ports and protocols that tempo is capable of.
     jaeger:                            # the receives all come from the OpenTelemetry collector.  more configuration information can

--- a/example/docker-compose/shared/tempo.yaml
+++ b/example/docker-compose/shared/tempo.yaml
@@ -8,7 +8,6 @@ query_frontend:
   trace_by_id:
     duration_slo: 5s
 
-
 distributor:
   receivers:                           # this configuration will listen on all ports and protocols that tempo is capable of.
     jaeger:                            # the receives all come from the OpenTelemetry collector.  more configuration information can

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -117,7 +117,7 @@ func TestAllInOne(t *testing.T) {
 			// test metrics
 			require.NoError(t, tempo.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_blocks_flushed_total"))
 			require.NoError(t, tempo.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"tempodb_blocklist_length"}, e2e.WaitMissingMetrics))
-			require.NoError(t, tempo.WaitSumMetrics(e2e.Equals(4), "tempo_query_frontend_queries_total"))
+			require.NoError(t, tempo.WaitSumMetrics(e2e.Equals(3), "tempo_query_frontend_queries_total"))
 
 			// query trace - should fetch from backend
 			queryAndAssertTrace(t, apiClient, info)
@@ -271,7 +271,7 @@ func TestMicroservicesWithKVStores(t *testing.T) {
 				require.NoError(t, i.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_blocks_flushed_total"))
 			}
 			require.NoError(t, tempoQuerier.WaitSumMetrics(e2e.Equals(3), "tempodb_blocklist_length"))
-			require.NoError(t, tempoQueryFrontend.WaitSumMetrics(e2e.Equals(4), "tempo_query_frontend_queries_total"))
+			require.NoError(t, tempoQueryFrontend.WaitSumMetrics(e2e.Equals(3), "tempo_query_frontend_queries_total"))
 
 			// query trace - should fetch from backend
 			queryAndAssertTrace(t, apiClient, info)

--- a/integration/e2e/encodings_test.go
+++ b/integration/e2e/encodings_test.go
@@ -99,7 +99,7 @@ func TestEncodings(t *testing.T) {
 			require.NoError(t, tempo.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_blocks_flushed_total"))
 			require.NoError(t, tempo.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"tempodb_blocklist_length"}, e2e.WaitMissingMetrics))
 			if enc.Version() != v2.VersionString {
-				require.NoError(t, tempo.WaitSumMetrics(e2e.Greater(20), "tempo_query_frontend_queries_total"))
+				require.NoError(t, tempo.WaitSumMetrics(e2e.Greater(15), "tempo_query_frontend_queries_total"))
 			}
 
 			// query trace - should fetch from backend

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -64,7 +64,7 @@ func New(cfg Config, next http.RoundTripper, o overrides.Interface, reader tempo
 		Namespace: "tempo",
 		Name:      "query_frontend_queries_total",
 		Help:      "Total queries received per tenant.",
-	}, []string{"tenant", "op", "status"})
+	}, []string{"tenant", "op"})
 
 	retryWare := newRetryWare(cfg.MaxRetries, registerer)
 

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -17,19 +17,11 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/tempodb"
-)
-
-const (
-	traceByIDOp  = "traces"
-	searchOp     = "search"
-	searchTagsOp = "searchtags"
-	metricsOp    = "metrics"
 )
 
 type streamingSearchHandler func(req *tempopb.SearchRequest, srv tempopb.StreamingQuerier_SearchServer) error
@@ -60,15 +52,6 @@ func New(cfg Config, next http.RoundTripper, o overrides.Interface, reader tempo
 		return nil, fmt.Errorf("query backend after should be less than or equal to query ingester until")
 	}
 
-	// be careful about adding or removing labels from this metric. this, along with the
-	// query_frontend_queries_within_slo_total metric are used to calculate budget burns.
-	// the labels need to be aligned for accurate calculations
-	queriesPerTenant := promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
-		Namespace: "tempo",
-		Name:      "query_frontend_queries_total",
-		Help:      "Total queries received per tenant.",
-	}, []string{"tenant", "op"})
-
 	retryWare := newRetryWare(cfg.MaxRetries, registerer)
 
 	// tracebyid middleware
@@ -78,21 +61,16 @@ func New(cfg Config, next http.RoundTripper, o overrides.Interface, reader tempo
 
 	spanMetricsMiddleware := MergeMiddlewares(newSpanMetricsMiddleware(), retryWare)
 
-	traceByIDCounter := queriesPerTenant.MustCurryWith(prometheus.Labels{"op": traceByIDOp})
-	searchCounter := queriesPerTenant.MustCurryWith(prometheus.Labels{"op": searchOp})
-	searchTagsCounter := queriesPerTenant.MustCurryWith(prometheus.Labels{"op": searchTagsOp})
-	spanMetricsCounter := queriesPerTenant.MustCurryWith(prometheus.Labels{"op": metricsOp})
-
 	traces := traceByIDMiddleware.Wrap(next)
 	search := searchMiddleware.Wrap(next)
 	searchTags := searchTagsMiddleware.Wrap(next)
 	metrics := spanMetricsMiddleware.Wrap(next)
 
 	return &QueryFrontend{
-		TraceByIDHandler:          newHandler(traces, traceByIDCounter, logger),
-		SearchHandler:             newHandler(search, searchCounter, logger),
-		SearchTagsHandler:         newHandler(searchTags, searchTagsCounter, logger),
-		SpanMetricsSummaryHandler: newHandler(metrics, spanMetricsCounter, logger),
+		TraceByIDHandler:          newHandler(traces, traceByIDSLOHook(&cfg.TraceByID.SLO), logger), // jpe add secret sauce here
+		SearchHandler:             newHandler(search, searchSLOHook(&cfg.Search.SLO), logger),
+		SearchTagsHandler:         newHandler(searchTags, nil, logger),
+		SpanMetricsSummaryHandler: newHandler(metrics, nil, logger),
 		streamingSearch:           newSearchStreamingHandler(cfg, o, retryWare.Wrap(next), reader, apiPrefix, logger),
 		logger:                    logger,
 	}, nil
@@ -194,7 +172,7 @@ func newTraceByIDMiddleware(cfg Config, logger log.Logger) Middleware {
 // newSearchMiddleware creates a new frontend middleware to handle search and search tags requests.
 func newSearchMiddleware(cfg Config, o overrides.Interface, reader tempodb.Reader, logger log.Logger) Middleware {
 	return MiddlewareFunc(func(next http.RoundTripper) http.RoundTripper {
-		searchRT := NewRoundTripper(next, newSearchSharder(reader, o, cfg.Search.Sharder, cfg.Search.SLO, newSearchProgress, logger))
+		searchRT := NewRoundTripper(next, newSearchSharder(reader, o, cfg.Search.Sharder, newSearchProgress, logger))
 
 		return RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 			// backend search queries require sharding, so we pass through a special roundtripper

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -60,6 +60,9 @@ func New(cfg Config, next http.RoundTripper, o overrides.Interface, reader tempo
 		return nil, fmt.Errorf("query backend after should be less than or equal to query ingester until")
 	}
 
+	// be careful about adding or removing labels from this metric. this, along with the
+	// query_frontend_queries_within_slo_total metric are used to calculate budget burns.
+	// the labels need to be aligned for accurate calculations
 	queriesPerTenant := promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 		Namespace: "tempo",
 		Name:      "query_frontend_queries_total",

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -67,10 +67,10 @@ func New(cfg Config, next http.RoundTripper, o overrides.Interface, reader tempo
 	metrics := spanMetricsMiddleware.Wrap(next)
 
 	return &QueryFrontend{
-		TraceByIDHandler:          newHandler(traces, traceByIDSLOHook(&cfg.TraceByID.SLO), logger), // jpe add secret sauce here
-		SearchHandler:             newHandler(search, searchSLOHook(&cfg.Search.SLO), logger),
-		SearchTagsHandler:         newHandler(searchTags, nil, logger),
-		SpanMetricsSummaryHandler: newHandler(metrics, nil, logger),
+		TraceByIDHandler:          newHandler(traces, traceByIDSLOPostHook(cfg.TraceByID.SLO), nil, logger),
+		SearchHandler:             newHandler(search, searchSLOPostHook(cfg.Search.SLO), searchSLOPreHook, logger),
+		SearchTagsHandler:         newHandler(searchTags, nil, nil, logger),
+		SpanMetricsSummaryHandler: newHandler(metrics, nil, nil, logger),
 		streamingSearch:           newSearchStreamingHandler(cfg, o, retryWare.Wrap(next), reader, apiPrefix, logger),
 		logger:                    logger,
 	}, nil

--- a/modules/frontend/frontend_test.go
+++ b/modules/frontend/frontend_test.go
@@ -13,6 +13,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var testSLOcfg = SLOConfig{
+	ThroughputBytesSLO: 0,
+	DurationSLO:        0,
+}
+
 type mockNextTripperware struct{}
 
 func (s *mockNextTripperware) RoundTrip(_ *http.Request) (*http.Response, error) {

--- a/modules/frontend/handler.go
+++ b/modules/frontend/handler.go
@@ -30,8 +30,10 @@ var (
 	errRequestEntityTooLarge = httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "http: request body too large")
 )
 
-type handlerPostHook func(ctx context.Context, resp *http.Response, tenant string, latency time.Duration, err error)
-type handlerPreHook func(ctx context.Context) context.Context
+type (
+	handlerPostHook func(ctx context.Context, resp *http.Response, tenant string, latency time.Duration, err error)
+	handlerPreHook  func(ctx context.Context) context.Context
+)
 
 // handler exists to wrap a roundtripper with an HTTP handler. It wraps all
 // frontend endpoints and should only contain functionality that is common to all.

--- a/modules/frontend/handler.go
+++ b/modules/frontend/handler.go
@@ -30,22 +30,25 @@ var (
 	errRequestEntityTooLarge = httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "http: request body too large")
 )
 
-type requestHook func(ctx context.Context, resp *http.Response, tenant string, latency time.Duration, err error)
+type handlerPostHook func(ctx context.Context, resp *http.Response, tenant string, latency time.Duration, err error)
+type handlerPreHook func(ctx context.Context) context.Context
 
 // handler exists to wrap a roundtripper with an HTTP handler. It wraps all
 // frontend endpoints and should only contain functionality that is common to all.
 type handler struct {
 	roundTripper http.RoundTripper
 	logger       log.Logger
-	post         requestHook
+	post         handlerPostHook
+	pre          handlerPreHook
 }
 
 // newHandler creates a handler
-func newHandler(rt http.RoundTripper, post requestHook, logger log.Logger) http.Handler {
+func newHandler(rt http.RoundTripper, post handlerPostHook, pre handlerPreHook, logger log.Logger) http.Handler {
 	return &handler{
 		roundTripper: rt,
 		logger:       logger,
 		post:         post,
+		pre:          pre,
 	}
 }
 
@@ -66,6 +69,10 @@ func (f *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		span.SetTag("orgID", orgID)
 	}
 
+	if f.pre != nil {
+		ctx = f.pre(ctx)
+		r = r.WithContext(ctx)
+	}
 	resp, err := f.roundTripper.RoundTrip(r)
 	elapsed := time.Since(start)
 	if f.post != nil {

--- a/modules/frontend/search_streaming.go
+++ b/modules/frontend/search_streaming.go
@@ -125,7 +125,7 @@ func newSearchStreamingHandler(cfg Config, o overrides.Interface, downstream htt
 			return p
 		}
 		// build roundtripper
-		rt := NewRoundTripper(downstream, newSearchSharder(reader, o, cfg.Search.Sharder, cfg.Search.SLO, fn, logger))
+		rt := NewRoundTripper(downstream, newSearchSharder(reader, o, cfg.Search.Sharder, fn, logger))
 
 		type roundTripResult struct {
 			resp *http.Response

--- a/modules/frontend/search_streaming.go
+++ b/modules/frontend/search_streaming.go
@@ -92,6 +92,7 @@ func (p *diffSearchProgress) finalResult() *shardedSearchResults {
 	return p.progress.result()
 }
 
+// jpe slos on this?
 // newSearchStreamingHandler returns a handler that streams results from the HTTP handler
 func newSearchStreamingHandler(cfg Config, o overrides.Interface, downstream http.RoundTripper, reader tempodb.Reader, apiPrefix string, logger log.Logger) streamingSearchHandler {
 	downstreamPath := path.Join(apiPrefix, api.PathSearch)

--- a/modules/frontend/search_streaming.go
+++ b/modules/frontend/search_streaming.go
@@ -157,7 +157,6 @@ func newSearchStreamingHandler(cfg Config, o overrides.Interface, downstream htt
 			select {
 			// handles context canceled or other errors
 			case <-ctx.Done():
-				postSLOHook(ctx, nil, tenant, time.Since(start), ctx.Err())
 				return ctx.Err()
 			// stream results as they come in
 			case <-time.After(500 * time.Millisecond):

--- a/modules/frontend/searchsharding.go
+++ b/modules/frontend/searchsharding.go
@@ -41,6 +41,9 @@ var (
 
 	searchThroughput = queryThroughput.MustCurryWith(prometheus.Labels{"op": searchOp})
 
+	// be careful about adding or removing labels from this metric. this, along with the
+	// query_frontend_queries_total metric are used to calculate budget burns.
+	// the labels need to be aligned for accurate calculations
 	sloQueriesPerTenant = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "tempo",
 		Name:      "query_frontend_queries_within_slo_total",

--- a/modules/frontend/searchsharding_test.go
+++ b/modules/frontend/searchsharding_test.go
@@ -34,11 +34,6 @@ import (
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
-var testSLOcfg = SLOConfig{
-	ThroughputBytesSLO: 0,
-	DurationSLO:        0,
-}
-
 // implements tempodb.Reader interface
 type mockReader struct {
 	metas []*backend.BlockMeta
@@ -709,7 +704,7 @@ func TestSearchSharderRoundTrip(t *testing.T) {
 			}, o, SearchSharderConfig{
 				ConcurrentRequests:    1, // 1 concurrent request to force order
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
-			}, testSLOcfg, newSearchProgress, log.NewNopLogger())
+			}, newSearchProgress, log.NewNopLogger())
 			testRT := NewRoundTripper(next, sharder)
 
 			req := httptest.NewRequest("GET", "/?start=1000&end=1500", nil)
@@ -775,7 +770,7 @@ func TestTotalJobsIncludesIngester(t *testing.T) {
 		QueryIngestersUntil:   15 * time.Minute,
 		ConcurrentRequests:    1, // 1 concurrent request to force order
 		TargetBytesPerRequest: defaultTargetBytesPerRequest,
-	}, testSLOcfg, newSearchProgress, log.NewNopLogger())
+	}, newSearchProgress, log.NewNopLogger())
 	testRT := NewRoundTripper(next, sharder)
 
 	path := fmt.Sprintf("/?start=%d&end=%d", now-1, now+1)
@@ -810,7 +805,7 @@ func TestSearchSharderRoundTripBadRequest(t *testing.T) {
 		ConcurrentRequests:    defaultConcurrentRequests,
 		TargetBytesPerRequest: defaultTargetBytesPerRequest,
 		MaxDuration:           5 * time.Minute,
-	}, testSLOcfg, newSearchProgress, log.NewNopLogger())
+	}, newSearchProgress, log.NewNopLogger())
 	testRT := NewRoundTripper(next, sharder)
 
 	// no org id
@@ -843,7 +838,7 @@ func TestSearchSharderRoundTripBadRequest(t *testing.T) {
 		ConcurrentRequests:    defaultConcurrentRequests,
 		TargetBytesPerRequest: defaultTargetBytesPerRequest,
 		MaxDuration:           5 * time.Minute,
-	}, testSLOcfg, newSearchProgress, log.NewNopLogger())
+	}, newSearchProgress, log.NewNopLogger())
 	testRT = NewRoundTripper(next, sharder)
 
 	req = httptest.NewRequest("GET", "/?start=1000&end=1500", nil)
@@ -972,7 +967,7 @@ func TestSubRequestsCancelled(t *testing.T) {
 		ConcurrentRequests:    10,
 		TargetBytesPerRequest: defaultTargetBytesPerRequest,
 		DefaultLimit:          2,
-	}, testSLOcfg, newSearchProgress, log.NewNopLogger())
+	}, newSearchProgress, log.NewNopLogger())
 
 	// return some things and assert the right subrequests are cancelled
 	// 500, err, limit
@@ -1078,7 +1073,7 @@ func benchmarkSearchSharderRoundTrip(b *testing.B, s int32) {
 	}, o, SearchSharderConfig{
 		ConcurrentRequests:    100,
 		TargetBytesPerRequest: defaultTargetBytesPerRequest,
-	}, testSLOcfg, newSearchProgress, log.NewNopLogger())
+	}, newSearchProgress, log.NewNopLogger())
 	testRT := NewRoundTripper(next, sharder)
 
 	req := httptest.NewRequest("GET", "/?start=1000&end=1500&limit=1", nil) // limiting to 1 to let succeedAfter work

--- a/modules/frontend/slos.go
+++ b/modules/frontend/slos.go
@@ -1,0 +1,91 @@
+package frontend
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	traceByIDOp = "traces"
+	searchOp    = "search"
+
+	throughputKey
+)
+
+var (
+	// be careful about adding or removing labels from this metric. this, along with the
+	// query_frontend_queries_total metric are used to calculate budget burns.
+	// the labels need to be aligned for accurate calculations
+	sloQueriesPerTenant = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "tempo",
+		Name:      "query_frontend_queries_within_slo_total",
+		Help:      "Total Queries within SLO per tenant",
+	}, []string{"tenant", "op"})
+
+	sloTraceByIDCounter = sloQueriesPerTenant.MustCurryWith(prometheus.Labels{"op": traceByIDOp})
+	sloSearchCounter    = sloQueriesPerTenant.MustCurryWith(prometheus.Labels{"op": searchOp})
+
+	// be careful about adding or removing labels from this metric. this, along with the
+	// query_frontend_queries_within_slo_total metric are used to calculate budget burns.
+	// the labels need to be aligned for accurate calculations
+	queriesPerTenant = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "tempo",
+		Name:      "query_frontend_queries_total",
+		Help:      "Total queries received per tenant.",
+	}, []string{"tenant", "op"})
+
+	traceByIDCounter = queriesPerTenant.MustCurryWith(prometheus.Labels{"op": traceByIDOp})
+	searchCounter    = queriesPerTenant.MustCurryWith(prometheus.Labels{"op": searchOp})
+)
+
+func traceByIDSLOHook(cfg *SLOConfig) requestHook {
+	return sloHook(sloTraceByIDCounter, traceByIDCounter, cfg)
+}
+
+func searchSLOHook(cfg *SLOConfig) requestHook {
+	return sloHook(sloSearchCounter, searchCounter, cfg)
+}
+
+func sloHook(allByTenantCounter, withinSLOByTenantCounter *prometheus.CounterVec, cfg *SLOConfig) requestHook {
+	return func(ctx context.Context, resp *http.Response, tenant string, latency time.Duration, err error) { // jpe add tenant?
+		// first record all queries
+		allByTenantCounter.WithLabelValues(tenant).Inc()
+
+		// now check conditions to see if we should record within SLO
+		if err != nil {
+			return
+		}
+
+		// all 200s/300s/400s are success
+		if resp.StatusCode >= 500 {
+			return
+		}
+
+		passedThroughput := true
+		// final check is throughput
+		if cfg.ThroughputBytesSLO > 0 {
+			throughput, ok := ctx.Value(throughputKey).(float64)
+
+			// if we didn't find the key, but expected it, we consider throughput a failure
+			passedThroughput = !ok && throughput >= cfg.ThroughputBytesSLO
+		}
+
+		passedDuration := cfg.DurationSLO == 0 || latency < cfg.DurationSLO
+
+		// throughput and latency are evaluated simultaneously. if either pass then we're good
+		// if both fail then bail out
+		if !passedDuration && !passedThroughput {
+			return
+		}
+
+		withinSLOByTenantCounter.WithLabelValues(tenant).Inc()
+	}
+}
+
+func addThroughputToContext(ctx context.Context, throughput float64) context.Context {
+	return context.WithValue(ctx, throughputKey, throughput)
+}

--- a/modules/frontend/slos.go
+++ b/modules/frontend/slos.go
@@ -65,7 +65,7 @@ func sloHook(allByTenantCounter, withinSLOByTenantCounter *prometheus.CounterVec
 		}
 
 		// all 200s/300s/400s are success
-		if resp.StatusCode >= 500 {
+		if resp != nil && resp.StatusCode >= 500 {
 			return
 		}
 

--- a/modules/frontend/slos.go
+++ b/modules/frontend/slos.go
@@ -9,11 +9,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+type contextKey string
+
 const (
 	traceByIDOp = "traces"
 	searchOp    = "search"
 
-	throughputKey
+	throughputKey = contextKey("throughput")
 )
 
 var (

--- a/modules/frontend/slos.go
+++ b/modules/frontend/slos.go
@@ -115,5 +115,9 @@ func addThroughputToContext(ctx context.Context, throughput float64) {
 		return
 	}
 
+	if throughputPtr == nil {
+		return
+	}
+
 	*throughputPtr = throughput
 }

--- a/modules/frontend/slos.go
+++ b/modules/frontend/slos.go
@@ -43,11 +43,11 @@ var (
 )
 
 func traceByIDSLOPostHook(cfg SLOConfig) handlerPostHook {
-	return sloHook(sloTraceByIDCounter, traceByIDCounter, cfg)
+	return sloHook(traceByIDCounter, sloTraceByIDCounter, cfg)
 }
 
 func searchSLOPostHook(cfg SLOConfig) handlerPostHook {
-	return sloHook(sloSearchCounter, searchCounter, cfg)
+	return sloHook(searchCounter, sloSearchCounter, cfg)
 }
 
 func searchSLOPreHook(ctx context.Context) context.Context {

--- a/modules/frontend/slos_test.go
+++ b/modules/frontend/slos_test.go
@@ -1,0 +1,134 @@
+package frontend
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/grafana/tempo/pkg/util/test"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSLOHook(t *testing.T) {
+	tcs := []struct {
+		name            string
+		cfg             SLOConfig
+		throughputBytes float64
+		httpStatusCode  int
+		latency         time.Duration
+		err             error
+
+		expectedWithSLO float64
+	}{
+		{
+			name:            "no slo passes",
+			expectedWithSLO: 1.0,
+		},
+		{
+			name: "no slo fails : error",
+			err:  errors.New("foo"),
+		},
+		{
+			name:           "no slo fails : 5XX status code",
+			httpStatusCode: http.StatusInternalServerError,
+		},
+		{
+			name:            "no slo passes : 4XX status code",
+			httpStatusCode:  http.StatusTooManyRequests,
+			expectedWithSLO: 1.0,
+		},
+		{
+			name: "slo passes - both",
+			cfg: SLOConfig{
+				DurationSLO:        10 * time.Second,
+				ThroughputBytesSLO: 100,
+			},
+			latency:         5 * time.Second,
+			throughputBytes: 110,
+			expectedWithSLO: 1.0,
+		},
+		{
+			name: "slo passes - duration",
+			cfg: SLOConfig{
+				DurationSLO:        10 * time.Second,
+				ThroughputBytesSLO: 100,
+			},
+			latency:         5 * time.Second,
+			throughputBytes: 90,
+			expectedWithSLO: 1.0,
+		},
+		{
+			name: "slo passes - throughput",
+			cfg: SLOConfig{
+				DurationSLO:        10 * time.Second,
+				ThroughputBytesSLO: 100,
+			},
+			latency:         15 * time.Second,
+			throughputBytes: 110,
+			expectedWithSLO: 1.0,
+		},
+		{
+			name: "slo passes - no throughput configured",
+			cfg: SLOConfig{
+				DurationSLO: 10 * time.Second,
+			},
+			latency:         5 * time.Second,
+			throughputBytes: 1,
+			expectedWithSLO: 1.0,
+		},
+		{
+			name: "slo passes - no duration configured",
+			cfg: SLOConfig{
+				ThroughputBytesSLO: 100,
+			},
+			latency:         15 * time.Second,
+			throughputBytes: 110,
+			expectedWithSLO: 1.0,
+		},
+		{
+			name: "slo fails - no throughput configured",
+			cfg: SLOConfig{
+				DurationSLO: 10 * time.Second,
+			},
+			latency:         15 * time.Second,
+			throughputBytes: 1,
+		},
+		{
+			name: "slo fails - no duration configured",
+			cfg: SLOConfig{
+				ThroughputBytesSLO: 100,
+			},
+			latency:         1 * time.Second,
+			throughputBytes: 90,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			allCounter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "all"}, []string{"tenant"})
+			sloCounter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "slo"}, []string{"tenant"})
+
+			hook := sloHook(allCounter, sloCounter, tc.cfg)
+
+			ctx := searchSLOPreHook(context.Background()) // prehook adds the throughput pointer
+			addThroughputToContext(ctx, tc.throughputBytes)
+
+			resp := &http.Response{
+				StatusCode: tc.httpStatusCode,
+			}
+
+			hook(ctx, resp, "tenant", tc.latency, tc.err)
+
+			actualAll, err := test.GetCounterValue(allCounter.WithLabelValues("tenant"))
+			require.NoError(t, err)
+			actualSLO, err := test.GetCounterValue(sloCounter.WithLabelValues("tenant"))
+			require.NoError(t, err)
+
+			require.Equal(t, 1.0, actualAll)
+			require.Equal(t, tc.expectedWithSLO, actualSLO)
+		})
+	}
+}

--- a/modules/frontend/tracebyidsharding_test.go
+++ b/modules/frontend/tracebyidsharding_test.go
@@ -253,7 +253,6 @@ func TestShardingWareDoRequest(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			sharder := newTraceByIDSharder(&TraceByIDConfig{
 				QueryShards: 2,
-				SLO:         testSLOcfg,
 			}, log.NewNopLogger())
 
 			next := RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
@@ -334,7 +333,6 @@ func TestConcurrentShards(t *testing.T) {
 	sharder := newTraceByIDSharder(&TraceByIDConfig{
 		QueryShards:      20,
 		ConcurrentShards: concurrency,
-		SLO:              testSLOcfg,
 	}, log.NewNopLogger())
 
 	sawMaxConcurrncy := atomic.NewBool(false)


### PR DESCRIPTION
**What this PR does**:
This PR reworks the way our SLO metrics are recorded with these goals in mind;

- Push the calculations out to be as close the http.Server as possible
- Clearly metric both total queries and SLO queries in one spot
- Cleanup and remove unused metrics

This PR accomplishes the above with the following sharp corners:

- In order to pass the throughput up to the code that calculates the SLOs a *float was added to the context. This works, but is brittle and difficult to detect if it breaks.
- Specialized code needed to be added to the streaming endpoint

TODO
- [x] correct changelog
- [x] add tests

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`