### PR TITLE
Example of adding grpc keepalive configuration to Distributor

### DIFF
--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -130,6 +130,14 @@ distributor:
         otlp:
             protocols:
                 grpc:
+                  endpoint: 0.0.0.0:4317
+                  keepalive:
+                    server_parameters:
+                      max_connection_idle: 60s
+                      max_connection_age: 300s
+                      max_connection_age_grace: 30s
+                      time: 10s
+                      timeout: 10s
                 http:
         jaeger:
             protocols:

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -137,7 +137,7 @@ distributor:
                       max_connection_age: 300s
                       max_connection_age_grace: 30s
                       time: 10s
-                      timeout: 10s
+                      timeout: 20s
                 http:
         jaeger:
             protocols:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

- grpc server support ServerParameters  https://pkg.go.dev/google.golang.org/grpc/keepalive
- but grafana tempo doc don't write keepalive configuration example for distributor receiver grpc server
- This sample configuration is useful for anyone who wants to customise their keepalive configuration.


**Which issue(s) this PR fixes**:

- when you use distributor collector trace data in kubernetes, you can deploy two or more pods make its HA
- If You don't change any configuration, only one container will always receive the request
- because grafana Agent use grpc protocol to transmite data and Unfortunately grpc's default TCP disconnect time is infinity
- so， when rollout update distributors pod , all connection and request just connect only one pod
- use those config , you can custom your grpc parameters and fix this issue


**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`