### PR TITLE
Improve Iterator String() output

### DIFF
--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -552,9 +552,9 @@ func NewSyncIterator(ctx context.Context, rgs []pq.RowGroup, column int, columnN
 func (c *SyncIterator) String() string {
 	filter := "nil"
 	if c.filter != nil {
-		filter = util.TabOut(c.filter)
+		filter = c.filter.String()
 	}
-	return fmt.Sprintf("SyncIterator: %s \n\t%s", c.columnName, filter)
+	return fmt.Sprintf("SyncIterator: %s : %s", c.columnName, filter)
 }
 
 func (c *SyncIterator) Next() (*IteratorResult, error) {
@@ -1204,7 +1204,7 @@ func (j *JoinIterator) String() string {
 	for _, iter := range j.iters {
 		iters += "\n\t" + util.TabOut(iter)
 	}
-	return fmt.Sprintf("JoinIterator: %d\t%s\n%s)", j.definitionLevel, iters, j.pred)
+	return fmt.Sprintf("JoinIterator: %d: %s\t%s)", j.definitionLevel, j.pred, iters)
 }
 
 func (j *JoinIterator) Next() (*IteratorResult, error) {
@@ -1372,13 +1372,13 @@ func NewLeftJoinIterator(definitionLevel int, required, optional []Iterator, pre
 func (j *LeftJoinIterator) String() string {
 	srequired := "required: "
 	for _, r := range j.required {
-		srequired += "\n\t\t" + util.TabOut(r)
+		srequired += "\n\t" + util.TabOut(r)
 	}
 	soptional := "optional: "
 	for _, o := range j.optional {
-		soptional += "\n\t\t" + util.TabOut(o)
+		soptional += "\n\t" + util.TabOut(o)
 	}
-	return fmt.Sprintf("LeftJoinIterator: %d\n\t%s\n\t%s\n\t%s", j.definitionLevel, srequired, soptional, j.pred)
+	return fmt.Sprintf("LeftJoinIterator: %d: %s\n%s\n%s", j.definitionLevel, j.pred, srequired, soptional)
 }
 
 func (j *LeftJoinIterator) Next() (*IteratorResult, error) {
@@ -1567,12 +1567,13 @@ func NewUnionIterator(definitionLevel int, iters []Iterator, pred GroupPredicate
 	return &j
 }
 
+// jpe
 func (u *UnionIterator) String() string {
 	var iters string
 	for _, iter := range u.iters {
-		iters += iter.String() + ", "
+		iters += "\n\t" + util.TabOut(iter)
 	}
-	return fmt.Sprintf("UnionIterator(%s)", iters)
+	return fmt.Sprintf("UnionIterator: %d: %s\t%s)", u.definitionLevel, u.pred, iters)
 }
 
 func (u *UnionIterator) Next() (*IteratorResult, error) {

--- a/pkg/parquetquery/predicates.go
+++ b/pkg/parquetquery/predicates.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"regexp"
+	"strings"
 
 	pq "github.com/parquet-go/parquet-go"
 )
@@ -402,15 +403,15 @@ func NewOrPredicate(preds ...Predicate) *OrPredicate {
 }
 
 func (p *OrPredicate) String() string {
-	var preds string
+	var preds []string
 	for _, pred := range p.preds {
 		if pred != nil {
-			preds += pred.String() + ","
+			preds = append(preds, pred.String())
 		} else {
-			preds += "nil,"
+			preds = append(preds, "nil")
 		}
 	}
-	return fmt.Sprintf("OrPredicate{%s}", preds)
+	return fmt.Sprintf("OrPredicate{%s}", strings.Join(preds, ","))
 }
 
 func (p *OrPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {

--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -1688,7 +1688,7 @@ type batchCollector struct {
 var _ parquetquery.GroupPredicate = (*batchCollector)(nil)
 
 func (c *batchCollector) String() string {
-	return fmt.Sprintf("batchCollector{%v, %d}", c.requireAtLeastOneMatchOverall, c.minAttributes)
+	return fmt.Sprintf("batchCollector(%v, %d)", c.requireAtLeastOneMatchOverall, c.minAttributes)
 }
 
 func (c *batchCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
@@ -1790,7 +1790,7 @@ type traceCollector struct {
 var _ parquetquery.GroupPredicate = (*traceCollector)(nil)
 
 func (c *traceCollector) String() string {
-	return "traceCollector{}"
+	return "traceCollector()"
 }
 
 func (c *traceCollector) KeepGroup(res *parquetquery.IteratorResult) bool {

--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -27,7 +27,7 @@ func TestOne(t *testing.T) {
 	wantTr := fullyPopulatedTestTrace(nil)
 	b := makeBackendBlockWithTraces(t, []*Trace{wantTr})
 	ctx := context.Background()
-	req := traceql.MustExtractFetchSpansRequestWithMetadata(`{ span.foo = "bar" || duration > 1s }`)
+	req := traceql.MustExtractFetchSpansRequestWithMetadata(`{ traceDuration > 1s }`)
 
 	req.StartTimeUnixNanos = uint64(1000 * time.Second)
 	req.EndTimeUnixNanos = uint64(1001 * time.Second)


### PR DESCRIPTION
Cleans up/tightens up the Iterator.String() output.

Before:
```
rebatchIterator: 
	JoinIterator: 0	
		SyncIterator: RootServiceName 
			InstrumentedPredicate{1, nil}
		SyncIterator: RootSpanName 
			InstrumentedPredicate{1, nil}
		SyncIterator: DurationNano 
			InstrumentedPredicate{1, nil}
		SyncIterator: TraceID 
			InstrumentedPredicate{1, nil}
		SyncIterator: StartTimeUnixNano 
			InstrumentedPredicate{1, nil}
		LeftJoinIterator: 1
			required: 
				LeftJoinIterator: 3
				required: 
					bridgeIterator: 
					rebatchIterator: 
						JoinIterator: 0	
							LeftJoinIterator: 1
								required: 
									LeftJoinIterator: 3
									required: 
										UnionIterator(LeftJoinIterator: 4
										required: 
											SyncIterator: rs.list.element.ss.list.element.Spans.list.element.Attrs.list.element.Key 
											InstrumentedPredicate{8, StringInPredicate{foo, }}
										optional: 
											SyncIterator: rs.list.element.ss.list.element.Spans.list.element.Attrs.list.element.Value 
											InstrumentedPredicate{0, OrPredicate{StringInPredicate{bar, },}}
										attributeCollector{}, SyncIterator: rs.list.element.ss.list.element.Spans.list.element.DurationNano 
										InstrumentedPredicate{2, OrPredicate{GenericPredicate{},}}, )
									optional: 
									spanCollector(1)
								optional: 
								batchCollector{true, 0}
							SyncIterator: StartTimeUnixNano 
								InstrumentedPredicate{1, IntBetweenPredicate{0,1001000000000}}
							SyncIterator: EndTimeUnixNano 
								InstrumentedPredicate{1, IntBetweenPredicate{1000000000000,9223372036854775807}}
						traceCollector{})
				optional: 
					SyncIterator: rs.list.element.ss.list.element.Spans.list.element.SpanID 
					InstrumentedPredicate{2, OrPredicate{nil,}}
					SyncIterator: rs.list.element.ss.list.element.Spans.list.element.StartTimeUnixNano 
					InstrumentedPredicate{2, OrPredicate{nil,}}
					SyncIterator: rs.list.element.ss.list.element.Spans.list.element.DurationNano 
					InstrumentedPredicate{2, OrPredicate{nil,}}
				spanCollector(0)
			optional: 
			batchCollector{false, 0}
	traceCollector{})
```

After:
```
rebatchIterator: 
	JoinIterator: 0: traceCollector()	
		SyncIterator: RootServiceName : InstrumentedPredicate{1, nil}
		SyncIterator: RootSpanName : InstrumentedPredicate{1, nil}
		SyncIterator: DurationNano : InstrumentedPredicate{1, nil}
		SyncIterator: TraceID : InstrumentedPredicate{1, nil}
		SyncIterator: StartTimeUnixNano : InstrumentedPredicate{1, nil}
		LeftJoinIterator: 1: batchCollector(false, 0)
		required: 
			LeftJoinIterator: 3: spanCollector(0)
			required: 
				bridgeIterator: 
					rebatchIterator: 
						JoinIterator: 0: traceCollector()	
							LeftJoinIterator: 1: batchCollector(true, 0)
							required: 
								LeftJoinIterator: 3: spanCollector(1)
								required: 
									UnionIterator: 3: %!s(<nil>)	
										LeftJoinIterator: 4: attributeCollector{}
										required: 
											SyncIterator: rs.list.element.ss.list.element.Spans.list.element.Attrs.list.element.Key : InstrumentedPredicate{8, StringInPredicate{foo, }}
										optional: 
											SyncIterator: rs.list.element.ss.list.element.Spans.list.element.Attrs.list.element.Value : InstrumentedPredicate{0, OrPredicate{StringInPredicate{bar, }}}
										SyncIterator: rs.list.element.ss.list.element.Spans.list.element.DurationNano : InstrumentedPredicate{2, OrPredicate{GenericPredicate{}}})
								optional: 
							optional: 
							SyncIterator: StartTimeUnixNano : InstrumentedPredicate{1, IntBetweenPredicate{0,1001000000000}}
							SyncIterator: EndTimeUnixNano : InstrumentedPredicate{1, IntBetweenPredicate{1000000000000,9223372036854775807}})
			optional: 
				SyncIterator: rs.list.element.ss.list.element.Spans.list.element.SpanID : InstrumentedPredicate{2, OrPredicate{nil}}
				SyncIterator: rs.list.element.ss.list.element.Spans.list.element.StartTimeUnixNano : InstrumentedPredicate{2, OrPredicate{nil}}
				SyncIterator: rs.list.element.ss.list.element.Spans.list.element.DurationNano : InstrumentedPredicate{2, OrPredicate{nil}}
		optional: )
```