### PR TITLE
Docs: Fix invalid query

### DIFF
--- a/docs/sources/tempo/traceql/_index.md
+++ b/docs/sources/tempo/traceql/_index.md
@@ -144,7 +144,7 @@ For example, to find all traces where an `http.status_code` attribute in a span 
 This works for `http.status_code` values that are strings as well using lexographic ordering:
 
 ```
-{ span.http.status_code >= "400"}
+{ span.http.status_code >= "400" }
 ```
 
 Find all traces where the `http.method` attribute is either `GET` or `DELETE`:


### PR DESCRIPTION
**What this PR does**:
Query `{ error = true } | by(resource.service.name) | count() > 1`, reported in the [online documentation](https://grafana.com/docs/tempo/latest/traceql/#selecting-spans), seems to be invalid:
<img width="1434" alt="Screenshot 2023-08-28 at 15 50 02" src="https://github.com/grafana/tempo/assets/135109076/ffa4be92-7ccd-4a89-8eef-8210a5f26d6e">

This PR proposes to replace it with `{ status = error } | by(resource.service.name) | count() > 1`, which instead seems correct:
<img width="1419" alt="Screenshot 2023-08-28 at 15 49 51" src="https://github.com/grafana/tempo/assets/135109076/12e2eb9b-c04a-444c-a9e6-da9bb4e31d2d">

In addition, this PR also fixes a small typo (missing whitespace before a `}`).

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`