### PR TITLE
[release-v2-2][DOC] Backport 2798 to release v2.2

### DIFF
--- a/docs/sources/tempo/troubleshooting/_index.md
+++ b/docs/sources/tempo/troubleshooting/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Troubleshoot Tempo
-menuTitle: Troubleshoot Tempo
+menuTitle: Troubleshoot
 description: Learn how to troubleshoot operational issues for Grafana Tempo.
-weight: 200
+weight: 700
 aliases:
-- /docs/tempo/troubleshooting/
+  - ../operations/troubleshooting/
 ---
 
 # Troubleshoot Tempo
@@ -26,3 +26,7 @@ In addition, the [Tempo runbook](https://github.com/grafana/tempo/blob/main/oper
 - [Queries fail with 500 and "error using pageFinder"]({{< relref "./bad-blocks" >}})
 - [I can search traces, but there are no service name or span name values available]({{< relref "./search-tag" >}})
 - [Error message `response larger than the max (<number> vs <limit>)`]({{< relref "./response-too-large" >}})
+
+## Metrics Generator
+
+- [Metrics or service graphs seem incomplete]({{< relref "./metrics-generator" >}})

--- a/docs/sources/tempo/troubleshooting/agent.md
+++ b/docs/sources/tempo/troubleshooting/agent.md
@@ -4,7 +4,7 @@ menuTitle: Grafana Agent
 description: Gain visibility on how many traces are being pushed to the Agent and if they are making it to the Tempo backend.
 weight: 472
 aliases:
-- /docs/tempo/troubleshooting/agent
+- ../operations/troubleshooting/agent/
 ---
 
 # Troubleshoot Grafana Agent
@@ -30,7 +30,7 @@ traces_exporter_send_failed_spans
 
 ## Automatic logging
 
-If metrics and logs are looking good, but you are still unable to find traces in Grafana Cloud, you can turn on [Automatic Logging]({{< relref "../../configuration/grafana-agent/automatic-logging" >}}). A recommend debug setup is:
+If metrics and logs are looking good, but you are still unable to find traces in Grafana Cloud, you can turn on [Automatic Logging]({{< relref "../configuration/grafana-agent/automatic-logging" >}}). A recommend debug setup is:
 
 ```yaml
 traces:

--- a/docs/sources/tempo/troubleshooting/bad-blocks.md
+++ b/docs/sources/tempo/troubleshooting/bad-blocks.md
@@ -3,7 +3,7 @@ title: Bad blocks
 description: Troubleshoot queries failing with an error message indicating bad blocks.
 weight: 475
 aliases:
-- /docs/tempo/troubleshooting/bad-blocks
+- ../operations/troubleshooting/bad-blocks/
 ---
 
 # Bad blocks
@@ -26,7 +26,7 @@ To fix such a block, first download it onto a machine where you can run the `tem
 
 Next run the `tempo-cli`'s `gen index` / `gen bloom` commands depending on which file is corrupt/deleted.
 The command will create a fresh index/bloom-filter from the data file at the required location (in the block folder).
-To view all of the options for this command, see the [cli docs]({{< relref "../../operations/tempo_cli" >}}).
+To view all of the options for this command, see the [cli docs]({{< relref "../operations/tempo_cli" >}}).
 
 Finally, upload the generated index or bloom-filter onto the object store backend under the folder for the block.
 

--- a/docs/sources/tempo/troubleshooting/max-trace-limit-reached.md
+++ b/docs/sources/tempo/troubleshooting/max-trace-limit-reached.md
@@ -3,7 +3,7 @@ title: Distributor refusing spans
 description: Troubleshoot distributor refusing spans
 weight: 471
 aliases:
-- /docs/tempo/troubleshooting/max-trace-limit-reached
+- ../operations/troubleshooting/max-trace-limit-reached/
 ---
 
 # Distributor refusing spans
@@ -12,14 +12,14 @@ The two most likely causes of refused spans are unhealthy ingesters or trace lim
 
 ## Unhealthy ingesters
 
-Unhealthy ingesters can be caused by failing OOMs, or scale down events. If you have unhealthy ingesters your log line will
-look something like:
+Unhealthy ingesters can be caused by failing OOMs, or scale down events.
+If you have unhealthy ingesters, your log line will look something like this:
 
 ```
 msg="pusher failed to consume trace data" err="at least 2 live replicas required, could only find 1"
 ```
 
-In this case you may need to visit the ingester [ring page]({{< relref "../../operations/consistent_hash_ring" >}}) at `/ingester/ring` on the Distributors
+In this case you may need to visit the ingester [ring page]({{< relref "../operations/consistent_hash_ring" >}}) at `/ingester/ring` on the Distributors
 and "Forget" the unhealthy ingesters. This will work in the short term, but the long term fix is to stabilize your ingesters.
 
 ## Trace limits reached
@@ -39,4 +39,4 @@ You will also see the following metric incremented. The `reason` label on this m
 tempo_discarded_spans_total
 ```
 
-In this case use available configuration options to [increase limits]({{< relref "../../configuration#ingestion-limits" >}}).
+In this case use available configuration options to [increase limits]({{< relref "../configuration#ingestion-limits" >}}).

--- a/docs/sources/tempo/troubleshooting/metrics-generator.md
+++ b/docs/sources/tempo/troubleshooting/metrics-generator.md
@@ -1,0 +1,134 @@
+---
+title: Troubleshoot metrics-generator
+menuTitle: Metrics-generator
+description: Gain an understanding of how to debug metrics quality issues.
+weight: 500
+aliases:
+- ../operations/troubleshooting/metrics-generator/
+---
+
+# Troubleshoot metrics-generator
+
+If you are concerned with data quality issues in the metrics-generator, we'd first recommend:
+
+- Reviewing your telemetry pipeline to determine the number of dropped spans. We are only looking for major issues here.
+- Reviewing the [service graph documentation]({{< relref "../metrics-generator/service_graphs" >}}) to understand how they are built.
+
+If everything seems ok from these two perspectives, consider the following topics to help resolve general issues with all metrics and span metrics specifically.
+
+## All metrics
+
+### Dropped spans in the distributor
+
+The distributor has a queue of outgoing spans to the metrics-generators. If that queue is full then the distributor
+will drop spans before they reach the generator. Use the following metric to determine if that is happening:
+
+```
+sum(rate(tempo_distributor_queue_pushes_failures_total{}[1m]))
+```
+
+### Failed pushes to the generator
+
+For any number of reasons, the distributor can fail a push to the generators. Use the following metric to
+determine if that is happening:
+
+```
+sum(rate(tempo_distributor_metrics_generator_pushes_failures_total{}[1m]))
+```
+
+### Discarded spans in the generator
+
+Spans are rejected from being considered by the metrics-generator by a configurable slack time as well as due to user
+configurable filters. You can see the number of spans rejected by reason using this metric:
+
+```
+sum(rate(tempo_metrics_generator_spans_discarded_total{}[1m])) by (reason)
+```
+
+If a lot of spans are dropped in the metrics-generator due to your filters, you will need to adjust them. If spans are dropped
+due to the ingestion slack time, consider adjusting this setting:
+
+```
+metrics_generator:
+  metrics_ingestion_time_range_slack: 30s
+```
+
+If spans are regularly exceeding this value you may want to consider reviewing your tracing pipeline to see if you have excessive buffering.
+Note that increasing this value allows the generator to consume more spans, but does reduce the accuracy of metrics because spans farther
+away from "now" are included.
+
+### Max active series
+
+The generator protects itself and your remote-write target by having a maximum number of series the generator produces.
+Use the `sum` below to determine if series are being dropped due to this limit:
+
+```
+sum(rate(tempo_metrics_generator_registry_series_limited_total{}[1m]))
+```
+
+Use the following setting to update the limit:
+
+```
+overrides:
+  metrics_generator_max_active_series: 0
+```
+
+Note that this value is per metrics generator. The actual max series remote written will be `<# of metrics generators> * <metrics_generator_max_active_series>`.
+
+### Remote write failures
+
+For any number of reasons, the generator may fail a write to the remote write target. Use the following metrics to
+determine if that is happening:
+
+```
+sum(rate(prometheus_remote_storage_samples_failed_total{}[1m]))
+sum(rate(prometheus_remote_storage_samples_dropped_total{}[1m]))
+sum(rate(prometheus_remote_storage_exemplars_failed_total{}[1m]))
+sum(rate(prometheus_remote_storage_exemplars_dropped_total{}[1m]))
+```
+
+## Service graph metrics
+
+Service graphs have additional configuration which can impact the quality of the output metrics.
+
+### Expired edges
+
+The following metrics can be used to determine how many edges are failing to find a match.
+
+Rate of edges that have expired without a match:
+```
+sum(rate(tempo_metrics_generator_processor_service_graphs_expired_edges{}[1m]))
+```
+
+Rate of all edges:
+```
+sum(rate(tempo_metrics_generator_processor_service_graphs_edges{}[1m]))
+```
+
+If you are seeing a large number of edges expire without a match, consider adjusting the `wait` setting. This
+controls how long the metrics generator waits to find a match before it gives up.
+
+```
+metrics_generator:
+  processor:
+    service_graphs:
+      wait: 10s
+```
+
+### Service graph max items
+
+The service graph processor has a maximum number of edges it will track at once to limit the total amount of memory the processor uses.
+To determine if edges are being dropped due to this limit, check:
+
+```
+sum(rate(tempo_metrics_generator_processor_service_graphs_dropped_spans{}[1m]))
+```
+
+Use `max_items` to adjust the maximum amount of edges tracked:
+
+```
+metrics_generator:
+  processor:
+    service_graphs:
+      max_items: 10000
+```

--- a/docs/sources/tempo/troubleshooting/response-too-large.md
+++ b/docs/sources/tempo/troubleshooting/response-too-large.md
@@ -3,7 +3,7 @@ title: Response larger than the max
 description: Troubleshoot response larger than the max error message
 weight: 477
 aliases:
-- /docs/tempo/troubleshooting/response-too-large
+- ../operations/troubleshooting/response-too-large/
 ---
 
 # Response larger than the max

--- a/docs/sources/tempo/troubleshooting/search-tag.md
+++ b/docs/sources/tempo/troubleshooting/search-tag.md
@@ -3,7 +3,7 @@ title: Tag search
 description: Troubleshoot No options found in Grafana tag search
 weight: 476
 aliases:
-- /docs/tempo/troubleshooting/search-tag
+- ../operations/troubleshooting/search-tag/
 ---
 
 # Tag search
@@ -25,4 +25,4 @@ when a query exceeds the configured value.
 There are two main solutions to this issue:
 
 * Reduce the cardinality of tags pushed to Tempo. Reducing the number of unique tag values will reduce the size returned by a tag search query.
-* Increase the `max_bytes_per_tag_values_query` parameter in the [overrides]({{< relref "../../configuration#overrides" >}}) block of your Tempo configuration to a value as high as 50MB.
+* Increase the `max_bytes_per_tag_values_query` parameter in the [overrides]({{< relref "../configuration#overrides" >}}) block of your Tempo configuration to a value as high as 50MB.

--- a/docs/sources/tempo/troubleshooting/too-many-jobs-in-queue.md
+++ b/docs/sources/tempo/troubleshooting/too-many-jobs-in-queue.md
@@ -1,9 +1,9 @@
 ---
 title: Too many jobs in the queue
-description: Troublehsoot too many jobs in the queue
+description: Troubleshoot too many jobs in the queue
 weight: 474
 aliases:
-- /docs/tempo/troubleshooting/too-many-jobs-in-queue
+- ../operations/troubleshooting/too-many-jobs-in-queue/
 ---
 
 # Too many jobs in the queue

--- a/docs/sources/tempo/troubleshooting/unable-to-see-trace.md
+++ b/docs/sources/tempo/troubleshooting/unable-to-see-trace.md
@@ -3,8 +3,8 @@ title: Unable to find traces
 description: Troubleshoot missing traces
 weight: 473
 aliases:
-- /docs/tempo/troubleshooting/missing-trace
-- /docs/tempo/troubleshooting/unable-to-see-trace
+- ../operations/troubleshooting/missing-trace/
+- ../operations/troubleshooting/unable-to-see-trace/
 ---
 
 # Unable to find traces
@@ -101,7 +101,7 @@ If the pipeline is not reporting any dropped spans, check whether application sp
 - If more ingestion volume is needed, increase the configuration for the rate limiting, by adding this CLI flag to Tempo at startup - https://github.com/grafana/tempo/blob/78f3554ca30bd5a4dec01629b8b7b2b0b2b489be/modules/overrides/limits.go#L42
 
 {{% admonition type="note" %}}
-Check the [ingestion limits page]({{< relref "../../configuration#ingestion-limits" >}}) for further information on limits.
+Check the [ingestion limits page]({{< relref "../configuration#ingestion-limits" >}}) for further information on limits.
 {{% /admonition %}}
 
 ## Section 3: Diagnose and fix issues with querying traces
@@ -130,7 +130,7 @@ Possible reasons for the above errors are:
 
 ### Solutions
 
-To fix connection issues
+To fix connection issues:
   - If the queriers are not connected to the Query Frontend, check the following section in Querier configuration and make sure the address of the Query Frontend is correct
     ```yaml
     querier:


### PR DESCRIPTION
**What this PR does**:

Backports changes from https://github.com/grafana/tempo/pull/2798 to make the troubleshooting directory top-level. 



**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`