### PR TITLE
substitute empty root span in query frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ defaults:
   metrics_generator:
     processors: [service-graphs, span-metrics]
 ```  
+* [BUGFIX] Moved empty root span substitution from `querier` to `query-frontend`. [#2671](https://github.com/grafana/tempo/issues/2671) (@galalen)
 
 # v2.2.2 / 2023-08-30
 

--- a/modules/frontend/search_progress.go
+++ b/modules/frontend/search_progress.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/grafana/tempo/pkg/search"
 	"github.com/grafana/tempo/pkg/tempopb"
 	v1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
 	"github.com/grafana/tempo/pkg/traceql"
@@ -156,6 +157,11 @@ func (r *searchProgress) result() *shardedSearchResults {
 			for _, ss := range m.SpanSets {
 				mCopy.SpanSets = append(mCopy.SpanSets, copySpanset(ss))
 			}
+		}
+
+		// substitute empty root span
+		if mCopy.RootServiceName == "" {
+			mCopy.RootServiceName = search.RootSpanNotYetReceivedText
 		}
 
 		mdCopy = append(mdCopy, mCopy)

--- a/modules/frontend/search_progress_test.go
+++ b/modules/frontend/search_progress_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/tempo/pkg/search"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/traceql"
 	"github.com/stretchr/testify/assert"
@@ -107,7 +108,12 @@ func TestSearchProgressCombineResults(t *testing.T) {
 	expected := &shardedSearchResults{
 		response: &tempopb.SearchResponse{
 			Traces: []*tempopb.TraceSearchMetadata{
-				{TraceID: traceID, StartTimeUnixNano: uint64(start.UnixNano()), DurationMs: uint32(time.Hour.Milliseconds())},
+				{
+					TraceID:           traceID,
+					StartTimeUnixNano: uint64(start.UnixNano()),
+					DurationMs:        uint32(time.Hour.Milliseconds()),
+					RootServiceName:   search.RootSpanNotYetReceivedText,
+				},
 			},
 			Metrics: &tempopb.SearchMetrics{
 				CompletedJobs: 1,

--- a/modules/frontend/searchsharding_test.go
+++ b/modules/frontend/searchsharding_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/pkg/api"
+	"github.com/grafana/tempo/pkg/search"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/traceql"
 	"github.com/grafana/tempo/pkg/util/test"
@@ -608,10 +609,12 @@ func TestSearchSharderRoundTrip(t *testing.T) {
 					{
 						TraceID:           "1234",
 						StartTimeUnixNano: 1,
+						RootServiceName:   search.RootSpanNotYetReceivedText,
 					},
 					{
 						TraceID:           "5678",
 						StartTimeUnixNano: 0,
+						RootServiceName:   search.RootSpanNotYetReceivedText,
 					},
 				},
 				Metrics: &tempopb.SearchMetrics{

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -805,9 +805,6 @@ func (q *Querier) postProcessIngesterSearchResults(req *tempopb.SearchRequest, r
 	}
 
 	for _, t := range traces {
-		if t.RootServiceName == "" {
-			t.RootServiceName = search.RootSpanNotYetReceivedText
-		}
 		response.Traces = append(response.Traces, t)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This PR moved the substitution of empty root span to the query frontend, to be applied on results coming from backend blocks.
**Which issue(s) this PR fixes**:
Fixes [#2671](https://github.com/grafana/tempo/issues/2671)

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`