### PR TITLE
Fix correctness of block min/max IDs

### DIFF
--- a/tempodb/encoding/vparquet/block_iterator.go
+++ b/tempodb/encoding/vparquet/block_iterator.go
@@ -54,7 +54,8 @@ var _ RawIterator = (*rawIterator)(nil)
 func (i *rawIterator) getTraceID(r parquet.Row) common.ID {
 	for _, v := range r {
 		if v.Column() == i.traceIDIndex {
-			return v.ByteArray()
+			// Important - clone to get a detached copy that lives outside the pool.
+			return v.Clone().ByteArray()
 		}
 	}
 	return nil

--- a/tempodb/encoding/vparquet2/block_findtracebyid.go
+++ b/tempodb/encoding/vparquet2/block_findtracebyid.go
@@ -109,7 +109,7 @@ func (b *backendBlock) FindTraceByID(ctx context.Context, traceID common.ID, opt
 		return nil, nil
 	}
 
-	ok, rowGroup, err := b.checkIndex(ctx, traceID)
+	ok, rowGroup, err := b.checkIndex(derivedCtx, traceID)
 	if err != nil {
 		return nil, err
 	}

--- a/tempodb/encoding/vparquet2/block_iterator.go
+++ b/tempodb/encoding/vparquet2/block_iterator.go
@@ -54,7 +54,8 @@ var _ RawIterator = (*rawIterator)(nil)
 func (i *rawIterator) getTraceID(r parquet.Row) common.ID {
 	for _, v := range r {
 		if v.Column() == i.traceIDIndex {
-			return v.ByteArray()
+			// Important - clone to get a detached copy that lives outside the pool.
+			return v.Clone().ByteArray()
 		}
 	}
 	return nil

--- a/tempodb/encoding/vparquet3/block_findtracebyid.go
+++ b/tempodb/encoding/vparquet3/block_findtracebyid.go
@@ -109,7 +109,7 @@ func (b *backendBlock) FindTraceByID(ctx context.Context, traceID common.ID, opt
 		return nil, nil
 	}
 
-	ok, rowGroup, err := b.checkIndex(ctx, traceID)
+	ok, rowGroup, err := b.checkIndex(derivedCtx, traceID)
 	if err != nil {
 		return nil, err
 	}

--- a/tempodb/encoding/vparquet3/block_iterator.go
+++ b/tempodb/encoding/vparquet3/block_iterator.go
@@ -54,7 +54,8 @@ var _ RawIterator = (*rawIterator)(nil)
 func (i *rawIterator) getTraceID(r parquet.Row) common.ID {
 	for _, v := range r {
 		if v.Column() == i.traceIDIndex {
-			return v.ByteArray()
+			// Important - clone to get a detached copy that lives outside the pool.
+			return v.Clone().ByteArray()
 		}
 	}
 	return nil


### PR DESCRIPTION
**What this PR does**:
Tempo has had a long-standing bug where the min/max trace IDs in meta.json were wrong.  These fields were no longer read in https://github.com/grafana/tempo/pull/1904 and then this issue surfaced again in https://github.com/grafana/tempo/pull/2697.  I think this PR fixes it and the root issue is that the byte slice returned by the raw iterator is still attached to the underlying parquet row which gets reused through pooling.   Try as I might, I wasn't able to reproduce this with a test or running locally, only by trying it out in a medium-sized staging cluster.    Marked as draft for now because I would really like to cover it with a test.

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`