### PR TITLE
TraceQL Perf Improvement

### DIFF
--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -1884,8 +1884,12 @@ func (c *attributeCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		}
 	}
 
+	if val.Type == traceql.TypeNil {
+		return false
+	}
+
 	res.Reset()
-	res.AppendOtherValue(key, val) // jpe added here
+	res.AppendOtherValue(key, val)
 
 	return true
 }

--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -1568,11 +1568,9 @@ func (c *spanCollector) String() string {
 func (c *spanCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 	var sp *span
 	// look for existing span first. this occurs on the second pass
-	for _, e := range res.OtherEntries {
-		if e.Key == otherEntrySpanKey {
-			sp = e.Value.(*span)
-			break
-		}
+	val := res.OtherValueFromKey(otherEntrySpanKey)
+	if val != nil {
+		sp = val.(*span)
 	}
 
 	// if not found create a new one
@@ -1667,8 +1665,7 @@ func (c *spanCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		}
 	}
 
-	res.Entries = res.Entries[:0]
-	res.OtherEntries = res.OtherEntries[:0]
+	res.Reset()
 	res.AppendOtherValue(otherEntrySpanKey, sp)
 
 	return true
@@ -1772,8 +1769,7 @@ func (c *batchCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		return false
 	}
 
-	res.Entries = res.Entries[:0]
-	res.OtherEntries = res.OtherEntries[:0]
+	res.Reset()
 	res.AppendOtherValue(otherEntrySpansetKey, sp)
 
 	return true
@@ -1849,8 +1845,7 @@ func (c *traceCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		}
 	}
 
-	res.Entries = res.Entries[:0]
-	res.OtherEntries = res.OtherEntries[:0]
+	res.Reset()
 	res.AppendOtherValue(otherEntrySpansetKey, finalSpanset)
 
 	return true
@@ -1892,9 +1887,8 @@ func (c *attributeCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		}
 	}
 
-	res.Entries = res.Entries[:0]
-	res.OtherEntries = res.OtherEntries[:0]
-	res.AppendOtherValue(key, val)
+	res.Reset()
+	res.AppendOtherValue(key, val) // jpe added here
 
 	return true
 }

--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -1884,7 +1884,8 @@ func (c *attributeCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		}
 	}
 
-	if val.Type == traceql.TypeNil {
+	// if this row didn't match up a key/value pair then just drop it
+	if val.Type == traceql.TypeNil || key == "" {
 		return false
 	}
 

--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -425,10 +425,7 @@ func (i *bridgeIterator) Next() (*parquetquery.IteratorResult, error) {
 		// if the filter removed all spansets then let's release all back to the pool
 		// no reason to try anything more nuanced than this. it will handle nearly all cases
 		if len(filteredSpansets) == 0 {
-			for _, s := range spanset.Spans {
-				putSpan(s.(*span))
-			}
-			putSpanset(spanset)
+			putSpansetAndSpans(spanset)
 		}
 
 		// flatten spans into i.currentSpans

--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -526,7 +526,7 @@ func BenchmarkBackendBlockTraceQL(b *testing.B) {
 
 	opts := common.DefaultSearchOptions()
 	opts.StartPage = 10
-	opts.TotalPages = 10
+	opts.TotalPages = 1
 
 	block := newBackendBlock(meta, rr)
 	_, _, err = block.openForSearch(ctx, opts)

--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -495,7 +495,6 @@ func BenchmarkBackendBlockTraceQL(b *testing.B) {
 		{"spanAttIntrinsicMatch", "{ name = `gcs.ReadRange` }"},
 		{"spanAttIntrinsicRegexNoMatch", "{ name =~ `asdfasdf` }"},
 		{"spanAttIntrinsicRegexMatch", "{ name =~ `gcs.ReadRange` }"},
-		{"spanAttOrs", "{ resource.host.name = `foo` || resource.host.name = `bar` || resource.host.name = `baz` }"},
 
 		// resource
 		{"resourceAttNameNoMatch", "{ resource.foo = `bar` }"},
@@ -503,6 +502,8 @@ func BenchmarkBackendBlockTraceQL(b *testing.B) {
 		{"resourceAttValMatch", "{ resource.os.type = `linux` }"},
 		{"resourceAttIntrinsicNoMatch", "{ resource.service.name = `a` }"},
 		{"resourceAttIntrinsicMatch", "{ resource.service.name = `tempo-query-frontend` }"},
+		{"resourceAttOrs", "{ resource.host.name = `foo` || resource.host.name = `bar` || resource.host.name = `baz` }"},
+		{"spansetAnd", "{ resource.host.name = `foo` } && { resource.host.name = `baz` }"},
 
 		// mixed
 		{"mixedNameNoMatch", "{ .foo = `bar` }"},

--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -490,7 +490,7 @@ func BenchmarkBackendBlockTraceQL(b *testing.B) {
 		// span
 		{"spanAttNameNoMatch", "{ span.foo = `bar` }"},
 		{"spanAttValNoMatch", "{ span.bloom = `bar` }"},
-		{"spanAttValMatch", "{ span.bloom > 0 }"},
+		{"spanAttValMatch", "{ span.blockSize > 0 }"},
 		{"spanAttIntrinsicNoMatch", "{ name = `asdfasdf` }"},
 		{"spanAttIntrinsicMatch", "{ name = `gcs.ReadRange` }"},
 		{"spanAttIntrinsicRegexNoMatch", "{ name =~ `asdfasdf` }"},

--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -495,6 +495,7 @@ func BenchmarkBackendBlockTraceQL(b *testing.B) {
 		{"spanAttIntrinsicMatch", "{ name = `gcs.ReadRange` }"},
 		{"spanAttIntrinsicRegexNoMatch", "{ name =~ `asdfasdf` }"},
 		{"spanAttIntrinsicRegexMatch", "{ name =~ `gcs.ReadRange` }"},
+		{"spanAttOrs", "{ resource.host.name = `foo` || resource.host.name = `bar` || resource.host.name = `baz` }"},
 
 		// resource
 		{"resourceAttNameNoMatch", "{ resource.foo = `bar` }"},


### PR DESCRIPTION
This PR contains a nice traceql perf improvement but also a regression along with some other cleanup.

**Minor Cleanup**
- Prefer using res.Reset() and res.OtherValueWithKey() to manually digging through the result data
- Prefer using putSpansetAndSpans() to manually doing this
- Corrected spanAttValMatch benchmark to actually match some rows
- Added two new benchmarks to show the queries we need to grow into: resourceAttOrs and spansetAnd

**Perf Improvement**
Correctly return false from attribute collector `KeepGroup` when the iterator does not match up a key and value on the same row.
```
	// if this row didn't match up a key/value pair then just drop it
	if val.Type == traceql.TypeNil || key == "" {
		return false
	}
```
Previously these were dropped here in the batch collector:
https://github.com/grafana/tempo/blob/main/tempodb/encoding/vparquet3/block_traceql.go#L1758

By pushing down the layer at which we drop these attributes we see nice performance improvements when querying common attribute values and names. Primarily this is to avoid unnecessarily calling this line:

https://github.com/grafana/tempo/blob/main/tempodb/encoding/vparquet3/block_traceql.go#L1909

This adds a traceql.Static to the iterator result but the "cast" to an empty interface causes a heap allocation which can get quite costly. A future improvement may be to use pointers here or generics to prevent the allocation.

**Benchmarks**
```
name                                                old time/op    new time/op     delta
BackendBlockTraceQL/spanAttNameNoMatch-8              6.00ms ± 4%     5.95ms ± 0%      ~     (p=0.841 n=5+5)
BackendBlockTraceQL/spanAttValNoMatch-8               6.86ms ± 1%     6.88ms ± 0%      ~     (p=0.421 n=5+5)
BackendBlockTraceQL/spanAttValMatch-8                 78.3ms ± 2%     79.0ms ± 2%      ~     (p=0.548 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8         5.99ms ± 1%     6.02ms ± 1%      ~     (p=0.548 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicMatch-8           46.7ms ± 1%     47.2ms ± 2%      ~     (p=0.222 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicRegexNoMatch-8    6.17ms ± 2%     6.14ms ± 1%      ~     (p=0.286 n=5+4)
BackendBlockTraceQL/spanAttIntrinsicRegexMatch-8      71.2ms ± 7%     73.4ms ± 1%      ~     (p=0.151 n=5+5)
BackendBlockTraceQL/resourceAttNameNoMatch-8          5.76ms ± 1%     5.82ms ± 2%      ~     (p=0.095 n=5+5)
BackendBlockTraceQL/resourceAttValNoMatch-8           12.3ms ± 2%     12.7ms ± 6%      ~     (p=0.056 n=5+5)
BackendBlockTraceQL/resourceAttValMatch-8             53.8ms ± 1%     53.7ms ± 3%      ~     (p=0.222 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicNoMatch-8     6.64ms ± 9%     6.79ms ± 1%      ~     (p=1.000 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8       28.5ms ± 1%     28.5ms ± 1%      ~     (p=1.000 n=5+5)
BackendBlockTraceQL/resourceAttOrs-8                   548ms ± 1%       78ms ± 0%   -85.85%  (p=0.016 n=5+4)
BackendBlockTraceQL/spansetAnd-8                       557ms ±13%       76ms ± 1%   -86.29%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedNameNoMatch-8                 431ms ± 6%      420ms ± 1%    -2.62%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedValNoMatch-8                  345ms ± 1%      450ms ± 1%   +30.26%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchAnd-8           6.81ms ± 0%     6.78ms ± 1%      ~     (p=0.151 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchOr-8             356ms ± 0%      357ms ± 1%      ~     (p=0.690 n=5+5)
BackendBlockTraceQL/mixedValBothMatch-8               6.79ms ± 1%     6.83ms ± 2%      ~     (p=0.548 n=5+5)

name                                                old speed      new speed       delta
BackendBlockTraceQL/spanAttNameNoMatch-8             283MB/s ± 4%    285MB/s ± 0%      ~     (p=0.841 n=5+5)
BackendBlockTraceQL/spanAttValNoMatch-8              400MB/s ± 1%    399MB/s ± 0%      ~     (p=0.421 n=5+5)
BackendBlockTraceQL/spanAttValMatch-8                243MB/s ± 2%    241MB/s ± 2%      ~     (p=0.548 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8        283MB/s ± 1%    281MB/s ± 1%      ~     (p=0.548 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicMatch-8          371MB/s ± 1%    368MB/s ± 2%      ~     (p=0.222 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicRegexNoMatch-8   274MB/s ± 2%    271MB/s ± 7%      ~     (p=0.690 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicRegexMatch-8     244MB/s ± 6%    237MB/s ± 1%      ~     (p=0.151 n=5+5)
BackendBlockTraceQL/resourceAttNameNoMatch-8         201MB/s ± 1%    199MB/s ± 2%      ~     (p=0.103 n=5+5)
BackendBlockTraceQL/resourceAttValNoMatch-8          180MB/s ± 2%    174MB/s ± 6%      ~     (p=0.056 n=5+5)
BackendBlockTraceQL/resourceAttValMatch-8            303MB/s ± 1%    304MB/s ± 3%      ~     (p=0.222 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicNoMatch-8    109MB/s ± 9%    106MB/s ± 1%      ~     (p=1.000 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8      592MB/s ± 1%    593MB/s ± 2%      ~     (p=1.000 n=5+5)
BackendBlockTraceQL/resourceAttOrs-8                5.13MB/s ± 1%  28.48MB/s ± 0%  +454.78%  (p=0.016 n=5+4)
BackendBlockTraceQL/spansetAnd-8                    5.07MB/s ±12%  28.91MB/s ± 1%  +470.26%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedNameNoMatch-8              11.4MB/s ± 6%   11.7MB/s ± 1%    +2.58%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedValNoMatch-8               14.7MB/s ± 1%   11.3MB/s ± 1%   -23.22%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchAnd-8          170MB/s ± 0%    171MB/s ± 1%      ~     (p=0.151 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchOr-8          54.8MB/s ± 0%   54.7MB/s ± 1%      ~     (p=0.690 n=5+5)
BackendBlockTraceQL/mixedValBothMatch-8              106MB/s ± 1%    106MB/s ± 2%      ~     (p=0.548 n=5+5)

name                                                old MB_io/op   new MB_io/op    delta
BackendBlockTraceQL/spanAttNameNoMatch-8                1.69 ± 0%       1.69 ± 0%      ~     (all equal)
BackendBlockTraceQL/spanAttValNoMatch-8                 2.74 ± 0%       2.74 ± 0%      ~     (all equal)
BackendBlockTraceQL/spanAttValMatch-8                   19.0 ± 0%       19.0 ± 0%      ~     (all equal)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8           1.69 ± 0%       1.69 ± 0%      ~     (all equal)
BackendBlockTraceQL/spanAttIntrinsicMatch-8             17.4 ± 0%       17.4 ± 0%      ~     (all equal)
BackendBlockTraceQL/spanAttIntrinsicRegexNoMatch-8      1.69 ± 0%       1.69 ± 0%      ~     (all equal)
BackendBlockTraceQL/spanAttIntrinsicRegexMatch-8        17.4 ± 0%       17.4 ± 0%      ~     (all equal)
BackendBlockTraceQL/resourceAttNameNoMatch-8            1.16 ± 0%       1.16 ± 0%      ~     (all equal)
BackendBlockTraceQL/resourceAttValNoMatch-8             2.21 ± 0%       2.21 ± 0%      ~     (all equal)
BackendBlockTraceQL/resourceAttValMatch-8               16.3 ± 0%       16.3 ± 0%      ~     (all equal)
BackendBlockTraceQL/resourceAttIntrinsicNoMatch-8       0.72 ± 0%       0.72 ± 0%      ~     (all equal)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8         16.9 ± 0%       16.9 ± 0%      ~     (all equal)
BackendBlockTraceQL/resourceAttOrs-8                    2.81 ± 0%       2.21 ± 0%   -21.48%  (p=0.008 n=5+5)
BackendBlockTraceQL/spansetAnd-8                        2.81 ± 0%       2.21 ± 0%   -21.48%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedNameNoMatch-8                  4.91 ± 0%       4.91 ± 0%      ~     (all equal)
BackendBlockTraceQL/mixedValNoMatch-8                   5.08 ± 0%       5.08 ± 0%      ~     (all equal)
BackendBlockTraceQL/mixedValMixedMatchAnd-8             1.16 ± 0%       1.16 ± 0%      ~     (all equal)
BackendBlockTraceQL/mixedValMixedMatchOr-8              19.5 ± 0%       19.5 ± 0%      ~     (all equal)
BackendBlockTraceQL/mixedValBothMatch-8                 0.72 ± 0%       0.72 ± 0%      ~     (all equal)

name                                                old alloc/op   new alloc/op    delta
BackendBlockTraceQL/spanAttNameNoMatch-8              2.92MB ± 1%     2.94MB ± 2%      ~     (p=0.421 n=5+5)
BackendBlockTraceQL/spanAttValNoMatch-8               3.98MB ± 2%     4.00MB ± 1%      ~     (p=0.222 n=5+5)
BackendBlockTraceQL/spanAttValMatch-8                 4.90MB ±11%     4.65MB ± 4%      ~     (p=0.310 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8         2.96MB ± 1%     2.97MB ± 2%      ~     (p=1.000 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicMatch-8           3.21MB ± 6%     3.23MB ±10%      ~     (p=1.000 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicRegexNoMatch-8    3.01MB ± 2%     3.06MB ± 1%      ~     (p=0.056 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicRegexMatch-8      3.20MB ±11%     3.31MB ±14%      ~     (p=0.841 n=5+5)
BackendBlockTraceQL/resourceAttNameNoMatch-8          2.91MB ± 2%     2.98MB ± 1%      ~     (p=0.056 n=5+5)
BackendBlockTraceQL/resourceAttValNoMatch-8           5.45MB ± 1%     5.49MB ± 2%      ~     (p=0.310 n=5+5)
BackendBlockTraceQL/resourceAttValMatch-8             5.51MB ± 5%     5.51MB ± 5%      ~     (p=0.841 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicNoMatch-8     2.94MB ± 3%     2.90MB ± 2%      ~     (p=0.310 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8       3.28MB ± 2%     3.22MB ± 6%      ~     (p=0.421 n=5+5)
BackendBlockTraceQL/resourceAttOrs-8                  28.8MB ± 4%     12.2MB ± 0%   -57.60%  (p=0.016 n=5+4)
BackendBlockTraceQL/spansetAnd-8                      28.6MB ± 5%     12.3MB ± 3%   -57.03%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedNameNoMatch-8                6.84MB ±24%     7.09MB ±14%      ~     (p=1.000 n=5+5)
BackendBlockTraceQL/mixedValNoMatch-8                 7.71MB ±10%     7.18MB ±19%      ~     (p=0.548 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchAnd-8           2.95MB ± 1%     2.97MB ± 2%      ~     (p=0.690 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchOr-8            6.35MB ±16%     6.17MB ±19%      ~     (p=0.421 n=5+5)
BackendBlockTraceQL/mixedValBothMatch-8               2.93MB ± 2%     2.95MB ± 3%      ~     (p=0.421 n=5+5)

name                                                old allocs/op  new allocs/op   delta
BackendBlockTraceQL/spanAttNameNoMatch-8               44.0k ± 0%      44.0k ± 0%      ~     (p=0.444 n=5+5)
BackendBlockTraceQL/spanAttValNoMatch-8                44.1k ± 0%      44.1k ± 0%      ~     (p=0.365 n=5+5)
BackendBlockTraceQL/spanAttValMatch-8                  53.4k ± 0%      53.4k ± 0%      ~     (p=0.270 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8          44.0k ± 0%      44.0k ± 0%      ~     (p=0.968 n=4+5)
BackendBlockTraceQL/spanAttIntrinsicMatch-8            45.3k ± 0%      45.3k ± 0%      ~     (p=0.897 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicRegexNoMatch-8     44.4k ± 0%      44.4k ± 0%      ~     (p=1.000 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicRegexMatch-8       45.9k ± 0%      45.9k ± 0%      ~     (p=0.881 n=5+5)
BackendBlockTraceQL/resourceAttNameNoMatch-8           44.0k ± 0%      44.0k ± 0%    +0.00%  (p=0.016 n=5+4)
BackendBlockTraceQL/resourceAttValNoMatch-8            44.2k ± 0%      44.2k ± 0%      ~     (p=0.992 n=5+5)
BackendBlockTraceQL/resourceAttValMatch-8              45.5k ± 0%      45.5k ± 0%      ~     (p=0.738 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicNoMatch-8      44.0k ± 0%      44.0k ± 0%      ~     (p=1.000 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8        45.4k ± 0%      45.4k ± 0%      ~     (p=0.913 n=5+5)
BackendBlockTraceQL/resourceAttOrs-8                    624k ± 0%       431k ± 0%   -31.02%  (p=0.008 n=5+5)
BackendBlockTraceQL/spansetAnd-8                        624k ± 0%       431k ± 0%   -31.02%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedNameNoMatch-8                 44.6k ± 0%      44.6k ± 0%      ~     (p=0.833 n=5+5)
BackendBlockTraceQL/mixedValNoMatch-8                  48.4k ± 1%      47.1k ± 0%    -2.65%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchAnd-8            44.0k ± 0%      44.0k ± 0%      ~     (p=1.000 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchOr-8             45.8k ± 0%      45.8k ± 0%      ~     (p=0.444 n=5+5)
BackendBlockTraceQL/mixedValBothMatch-8                44.0k ± 0%      44.0k ± 0%      ~     (p=0.079 n=5+4)
```

