### PR TITLE
Move ingester_traces_created_total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [FEATURE] Add cli command to print out summary of large traces [#2775](https://github.com/grafana/tempo/pull/2775) (@ie-pham)
 * [CHANGE] Update Go to 1.21 [#2486](https://github.com/grafana/tempo/pull/2829) (@zalegrala)
 * [CHANGE] Make metrics-generator ingestion slack per tenant [#2589](https://github.com/grafana/tempo/pull/2589) (@ie-pham)
+* [CHANGE] Moved the tempo_ingester_traces_created_total metric to be incremented when a trace is cut to the wal [#2884](https://github.com/grafana/tempo/pull/2884) (@joe-elliott)
 * [ENHANCEMENT] Add block indexes to vParquet2 and vParquet3 to improve trace by ID lookup [#2697](https://github.com/grafana/tempo/pull/2697) (@mdisibio)
 * [ENHANCEMENT] Assert ingestion rate limits as early as possible [#2640](https://github.com/grafana/tempo/pull/2703) (@mghildiy)
 * [ENHANCEMENT] Add several metrics-generator fields to user-configurable overrides [#2711](https://github.com/grafana/tempo/pull/2711) (@kvrhdn)

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -465,7 +465,6 @@ func (i *instance) getOrCreateTrace(traceID []byte, fp uint32, maxBytes int) *li
 
 	trace = newTrace(traceID, maxBytes)
 	i.traces[fp] = trace
-	i.tracesCreatedTotal.Inc()
 	i.traceCount.Inc()
 
 	return trace
@@ -536,6 +535,7 @@ func (i *instance) writeTraceToHeadBlock(id common.ID, b []byte, start, end uint
 	i.headBlockMtx.Lock()
 	defer i.headBlockMtx.Unlock()
 
+	i.tracesCreatedTotal.Inc()
 	err := i.headBlock.Append(id, b, start, end)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does**:
Moves the location we are calculating `tempo_ingester_traces_created_total` to the point at which a trace is appended to the wal block. This will allow for better alignment with `tempodb_warnings_total{reason="disconnected_trace_flushed_to_wal"}` which improves the accuracy of the formulas recommended here:

https://github.com/grafana/tempo/pull/2790

Preferring this to adding a new multitenant metric. This change doesn't really lower the value of `tempo_ingester_traces_created_total` it just subtly changes it's meaning. Given that it still broadly metrics traces created total this feels fine to me, but willing to be disagreed with.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`