### PR TITLE
[DOC] Fix typo in metrics-summary API

### DIFF
--- a/docs/sources/tempo/api_docs/metrics-summary.md
+++ b/docs/sources/tempo/api_docs/metrics-summary.md
@@ -18,7 +18,8 @@ This API returns RED metrics (span count, erroring span count, and latency infor
 
 ## Configuration
 
-To enable the experimental metrics summary API you must turn on the local blocks processor in the metrics generator. Be aware that the generator will use considerably more resources including disk space if this is enabled:
+To enable the experimental metrics summary API, you must turn on the local blocks processor in the metrics generator.
+Be aware that the generator will use considerably more resources, including disk space, if this is enabled:
 
 ```yaml
 overrides:
@@ -29,7 +30,7 @@ overrides:
 
 ## Request
 
-To make a request to this API, use the following endoint on the query-frontend:
+To make a request to this API, use the following endpoint on the query-frontend:
 
 ```
 GET http://<tempo>/api/metrics/summary


### PR DESCRIPTION
**What this PR does**:

Fixes a typo and missing comma in the metrics-summary API doc. 

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`