### PR TITLE
Configure S3's credential chain based on config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
   sum(rate(tempo_query_frontend_queries_total{}[1m])) by (op)
   ```
   **BREAKING CHANGE** Removed: tempo_query_frontend_queries_total{op="searchtags|metrics"}. 
+* [BUGFIX] Fix S3 credentials providers configuration [#2889](https://github.com/grafana/tempo/pull/2889) (@mapno)
 * [CHANGE] Overrides module refactor [#2688](https://github.com/grafana/tempo/pull/2688) (@mapno)
     Added new `defaults` block to the overrides' module. Overrides change to indented syntax.
     Old config:

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -805,6 +805,10 @@ storage:
             # See the [S3 documentation on object tagging](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html) for more detail.
             [tags: <map[string]string>]
 
+            # If enabled, it will use the default authentication methods of
+            # the AWS SDK for go based on known environment variables and known AWS config files.
+            [native_aws_auth_enabled: <boolean> | default = false]
+
         # azure configuration. Will be used only if value of backend is "azure"
         # EXPERIMENTAL
         azure:

--- a/tempodb/backend/s3/config.go
+++ b/tempodb/backend/s3/config.go
@@ -25,12 +25,13 @@ type Config struct {
 	HedgeRequestsAt   time.Duration  `yaml:"hedge_requests_at"`
 	HedgeRequestsUpTo int            `yaml:"hedge_requests_up_to"`
 	// SignatureV2 configures the object storage to use V2 signing instead of V4
-	SignatureV2      bool              `yaml:"signature_v2"`
-	ForcePathStyle   bool              `yaml:"forcepathstyle"`
-	BucketLookupType int               `yaml:"bucket_lookup_type"`
-	Tags             map[string]string `yaml:"tags"`
-	StorageClass     string            `yaml:"storage_class"`
-	Metadata         map[string]string `yaml:"metadata"`
+	SignatureV2          bool              `yaml:"signature_v2"`
+	ForcePathStyle       bool              `yaml:"forcepathstyle"`
+	BucketLookupType     int               `yaml:"bucket_lookup_type"`
+	Tags                 map[string]string `yaml:"tags"`
+	StorageClass         string            `yaml:"storage_class"`
+	Metadata             map[string]string `yaml:"metadata"`
+	NativeAWSAuthEnabled bool              `yaml:"native_aws_auth_enabled"`
 }
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -15,9 +15,9 @@ import (
 	"github.com/cristalhq/hedgedhttp"
 	gkLog "github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	minio "github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
 	tempo_io "github.com/grafana/tempo/pkg/io"
@@ -429,25 +429,35 @@ func createCore(cfg *Config, hedge bool) (*minio.Core, error) {
 		return p
 	}
 
-	creds := credentials.NewChainCredentials([]credentials.Provider{
-		wrapCredentialsProvider(NewAWSSDKAuth(cfg.Region)),
-		wrapCredentialsProvider(&credentials.EnvAWS{}),
-		wrapCredentialsProvider(&credentials.Static{
-			Value: credentials.Value{
-				AccessKeyID:     cfg.AccessKey,
-				SecretAccessKey: cfg.SecretKey.String(),
-				SessionToken:    cfg.SessionToken.String(),
-			},
-		}),
-		wrapCredentialsProvider(&credentials.EnvMinio{}),
-		wrapCredentialsProvider(&credentials.FileAWSCredentials{}),
-		wrapCredentialsProvider(&credentials.FileMinioClient{}),
-		wrapCredentialsProvider(&credentials.IAM{
-			Client: &http.Client{
-				Transport: http.DefaultTransport,
-			},
-		}),
-	})
+	var chain []credentials.Provider
+
+	if cfg.NativeAWSAuthEnabled {
+		chain = []credentials.Provider{
+			wrapCredentialsProvider(NewAWSSDKAuth(cfg.Region)),
+		}
+	} else if cfg.AccessKey != "" {
+		chain = []credentials.Provider{
+			wrapCredentialsProvider(&credentials.Static{
+				Value: credentials.Value{
+					AccessKeyID:     cfg.AccessKey,
+					SecretAccessKey: cfg.SecretKey.String(),
+					SessionToken:    cfg.SessionToken.String(),
+				},
+			}),
+		}
+	} else {
+		chain = []credentials.Provider{
+			wrapCredentialsProvider(&credentials.EnvAWS{}),
+			wrapCredentialsProvider(&credentials.EnvMinio{}),
+			wrapCredentialsProvider(&credentials.FileAWSCredentials{}),
+			wrapCredentialsProvider(&credentials.FileMinioClient{}),
+			wrapCredentialsProvider(&credentials.IAM{
+				Client: &http.Client{
+					Transport: http.DefaultTransport,
+				},
+			}),
+		}
+	}
 
 	customTransport, err := minio.DefaultTransport(!cfg.Insecure)
 	if err != nil {
@@ -478,7 +488,7 @@ func createCore(cfg *Config, hedge bool) (*minio.Core, error) {
 	opts := &minio.Options{
 		Region:    cfg.Region,
 		Secure:    !cfg.Insecure,
-		Creds:     creds,
+		Creds:     credentials.NewChainCredentials(chain),
 		Transport: transport,
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Configures the S3 credentials chain based on what S3 auth method is configured.

Added a config param to S3 config `native_aws_auth_enabled`. When enabled, Tempo will use the default authentication methods of the AWS SDK for go based on known environment variables and known AWS config files.

**Which issue(s) this PR fixes**:
Fixes #2888 

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`