### PR TITLE
Unescape (decode) tag names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## main / unreleased
+* [ENHANCEMENT] Unescape tag names [#2894](https://github.com/grafana/tempo/pull/2894) (@fabrizio-grafana)
 * [FEATURE] New TraceQL structural operators ancestor (<<), parent (<) [#2877](https://github.com/grafana/tempo/pull/2877) (@kousikmitra)
 * [ENHANCEMENT] Add support for searching by span status message using  `statusMessage` keyword [#2848](https://github.com/grafana/tempo/pull/2848) (@kousikmitra)
 * [FEATURE] Add the `/api/status/buildinfo` endpoint [#2702](https://github.com/grafana/tempo/pull/2702) (@fabrizio-grafana)

--- a/pkg/api/search_tags_test.go
+++ b/pkg/api/search_tags_test.go
@@ -12,9 +12,10 @@ import (
 // TestParseSearchTagValues tests the SearchTagValues function
 func TestParseSearchTagValuesRequest(t *testing.T) {
 	tcs := []struct {
-		tagName, query string
-		enforceTraceQL bool
-		expectError    bool
+		tagName, query  string
+		enforceTraceQL  bool
+		expectError     bool
+		expectedTagName string
 	}{
 		{
 			expectError: true,
@@ -41,6 +42,14 @@ func TestParseSearchTagValuesRequest(t *testing.T) {
 			query:          `{"foo":"bar"}`,
 			enforceTraceQL: true,
 		},
+		{
+			tagName:         "span.encoded%2FtagName",
+			expectedTagName: "span.encoded/tagName",
+		},
+		{
+			tagName:         "span.encoded%2DtagName",
+			expectedTagName: "span.encoded-tagName",
+		},
 	}
 
 	for _, tc := range tcs {
@@ -57,7 +66,12 @@ func TestParseSearchTagValuesRequest(t *testing.T) {
 			require.Error(t, err)
 			continue
 		}
-		require.Equal(t, tc.tagName, req.TagName)
+
+		expectedTagName := tc.expectedTagName
+		if expectedTagName == "" {
+			expectedTagName = tc.tagName
+		}
+		require.Equal(t, expectedTagName, req.TagName)
 	}
 }
 


### PR DESCRIPTION
**What this PR does**:

Tag names are currently not escaped (encoded) by Grafana when using them in URLs, such as for the `/api/v2/search/tag/<tag>/values` endpoint. We have a [PR in Grafana](https://github.com/grafana/grafana/pull/74437) to fix this issue by escaping tag names, but we need Tempo to unescape (decode) them.

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`