### PR TITLE
A collection of TraceQL improvements

### DIFF
--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -1538,6 +1538,7 @@ func (j *LeftJoinIterator) SeekTo(t RowNumber, d int) (*IteratorResult, error) {
 
 	return j.Next()
 }
+
 func (j *LeftJoinIterator) seekAll(t RowNumber, d int) (err error) {
 	if EqualRowNumbers(d, t, j.lastSeekAll) {
 		return nil

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -1538,19 +1538,11 @@ func (j *LeftJoinIterator) SeekTo(t RowNumber, d int) (*IteratorResult, error) {
 
 	return j.Next()
 }
-
-var A = map[int]int{}
-
 func (j *LeftJoinIterator) seekAll(t RowNumber, d int) (err error) {
 	if EqualRowNumbers(d, t, j.lastSeekAll) {
 		return nil
 	}
 	j.lastSeekAll = t
-
-	// A[j.definitionLevel]++
-	// if j.definitionLevel == 4 {
-	// 	fmt.Println(t, j.definitionLevel, d)
-	// }
 
 	t = TruncateRowNumber(d, t)
 	for iterNum, iter := range j.required {

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -63,6 +63,35 @@ func CompareRowNumbers(upToDefinitionLevel int, a, b RowNumber) int {
 }
 
 func TruncateRowNumber(definitionLevelToKeep int, t RowNumber) RowNumber {
+	if definitionLevelToKeep < 3 {
+		n := EmptyRowNumber()
+		switch definitionLevelToKeep {
+		case 0:
+			n[0] = t[0]
+		case 1:
+			n[0] = t[0]
+			n[1] = t[1]
+		case 2:
+			n[0] = t[0]
+			n[1] = t[1]
+			n[2] = t[2]
+		}
+		return n
+	}
+
+	switch definitionLevelToKeep {
+	case 3:
+		t[4] = -1
+		t[5] = -1
+	case 4:
+		t[5] = -1
+	case 5:
+	}
+
+	return t
+}
+
+func truncateRowNumberSlow(definitionLevelToKeep int, t RowNumber) RowNumber {
 	n := EmptyRowNumber()
 	for i := 0; i <= definitionLevelToKeep; i++ {
 		n[i] = t[i]

--- a/pkg/parquetquery/iters_test.go
+++ b/pkg/parquetquery/iters_test.go
@@ -32,13 +32,32 @@ func TestNext(t *testing.T) {
 	rn2 := RowNumber{0, 0, 0, 0, 0, 0}
 
 	for i := 0; i < 1000; i++ {
-		r := rand.Intn(6)
-		d := rand.Intn(6)
+		r := rand.Intn(MaxDefinitionLevel + 1)
+		d := rand.Intn(MaxDefinitionLevel + 1)
 
 		rn1.Next(r, d)
 		rn2.nextSlow(r, d)
 
 		require.Equal(t, rn1, rn2)
+	}
+}
+
+func TestTruncateRowNumber(t *testing.T) {
+	rn1 := RowNumber{0, 0, 0, 0, 0, 0}
+	rn2 := RowNumber{0, 0, 0, 0, 0, 0}
+
+	for i := 0; i < 1000; i++ {
+		for j := 0; j <= MaxDefinitionLevel; j++ {
+			rando := int64(rand.Intn(100))
+			rn1[j] = rando
+			rn2[j] = rando
+		}
+		upto := rand.Intn(MaxDefinitionLevel + 1)
+
+		rn1 = TruncateRowNumber(upto, rn1)
+		rn2 = truncateRowNumberSlow(upto, rn2)
+
+		require.Equal(t, rn2, rn1, "upto=%d", upto)
 	}
 }
 
@@ -271,6 +290,15 @@ func TestColumnIteratorExitEarly(t *testing.T) {
 		require.NoError(t, err)
 		require.Less(t, readSize+res2, count)
 	})
+}
+
+func BenchmarkTruncateRowNumber(b *testing.B) {
+	rn := EmptyRowNumber()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j <= MaxDefinitionLevel; j++ {
+			rn = TruncateRowNumber(j, rn)
+		}
+	}
 }
 
 func BenchmarkColumnIterator(b *testing.B) {

--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -1896,8 +1896,13 @@ func (c *attributeCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		}
 	}
 
+	// if this row didn't match up a key/value pair then just drop it
+	if val.Type == traceql.TypeNil || key == "" {
+		return false
+	}
+
 	res.Reset()
-	res.AppendOtherValue(key, val) // jpe added here
+	res.AppendOtherValue(key, val)
 
 	return true
 }

--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -504,6 +504,8 @@ func BenchmarkBackendBlockTraceQL(b *testing.B) {
 		{"resourceAttValMatch", "{ resource.os.type = `linux` }"},
 		{"resourceAttIntrinsicNoMatch", "{ resource.service.name = `a` }"},
 		{"resourceAttIntrinsicMatch", "{ resource.service.name = `tempo-query-frontend` }"},
+		{"resourceAttOrs", "{ resource.host.name = `foo` || resource.host.name = `bar` || resource.host.name = `baz` }"},
+		{"spansetAnd", "{ resource.host.name = `foo` } && { resource.host.name = `baz` }"},
 
 		// mixed
 		{"mixedNameNoMatch", "{ .foo = `bar` }"},

--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -492,7 +492,7 @@ func BenchmarkBackendBlockTraceQL(b *testing.B) {
 		// span
 		{"spanAttNameNoMatch", "{ span.foo = `bar` }"},
 		{"spanAttValNoMatch", "{ span.bloom = `bar` }"},
-		{"spanAttValMatch", "{ span.bloom > 0 }"},
+		{"spanAttValMatch", "{ span.blockSize > 0 }"},
 		{"spanAttIntrinsicNoMatch", "{ name = `asdfasdf` }"},
 		{"spanAttIntrinsicMatch", "{ name = `gcs.ReadRange` }"},
 		{"spanAttIntrinsicRegexNoMatch", "{ name =~ `asdfasdf` }"},
@@ -528,7 +528,7 @@ func BenchmarkBackendBlockTraceQL(b *testing.B) {
 
 	opts := common.DefaultSearchOptions()
 	opts.StartPage = 10
-	opts.TotalPages = 10
+	opts.TotalPages = 1
 
 	block := newBackendBlock(meta, rr)
 	_, _, err = block.openForSearch(ctx, opts)


### PR DESCRIPTION
**What this PR does**:
This PR contains a collection of TraceQL perf improvements that primarily look for opportunities at the iterator level. It also does some mild cleanup in block_traceql and extends the Benchmark to contain two new tests that nicely show some of the improvements:
```
{ resource.host.name = `foo` || resource.host.name = `bar` || resource.host.name = `baz` }
{ resource.host.name = `foo` } && { resource.host.name = `baz` }
```

Improvements:
- [Drop groups at the attribute level early](https://github.com/grafana/tempo/pull/2897/commits/259e6702265cfe95ebacfc04781122a9ce8106e3)
- [Unroll TruncateRowNumber](https://github.com/grafana/tempo/pull/2897/commits/bf4cf440d50321f67ad25c451cf2449b2f79230d)
- [Reduce unnecessary iteration. Set a "never iterated marker" so nil always means "iteration complete"](https://github.com/grafana/tempo/pull/2897/commits/bf4cf440d50321f67ad25c451cf2449b2f79230d)
- [Prevent double seeks](https://github.com/grafana/tempo/pull/2897/commits/ae818b228d6eb691ac490c592639ce3a83ef90e1)
  - This is the one I'm most concerned about. It was added to prevent a double seek to the same row numbers that occurs in the JoinIterators between `collect` and a `seekAll` [here](https://github.com/grafana/tempo/blob/main/pkg/parquetquery/iters.go#L1256-L1273). I'm wondering if I need store the definition level as well as the "lastRowNumber". I could also move the improvement to specifically guard against the double seek highlighted in the link.
- [Create and unroll EqualRowNumbers](https://github.com/grafana/tempo/pull/2897/commits/1280d11425b621cff8dab3270486709f86baa992)