### PR TITLE
Enable errorlint and check for plain error comparisons

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -62,7 +62,7 @@ linters-settings:
   errcheck:
     exclude: ./.errcheck-exclude.txt
   errorlint:
-    errorf: false # don't check whether fmt.Errorf uses the %w errors
+    errorf: false # don't check whether fmt.Errorf uses %w to wrap errors
 
 issues:
   exclude:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,6 +43,7 @@ output:
 linters:
   enable:
     - errcheck
+    - errorlint
     - goconst
     - gofmt
     - goimports
@@ -60,6 +61,8 @@ linters:
 linters-settings:
   errcheck:
     exclude: ./.errcheck-exclude.txt
+  errorlint:
+    errorf: false # don't check whether fmt.Errorf uses the %w errors
 
 issues:
   exclude:

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ check-jsonnetfmt: jsonnetfmt
 
 .PHONY: lint
 lint:
-	$(LINT) run
+	$(LINT) run --config .golangci.yml
 
 ### Docker Images
 

--- a/cmd/tempo-cli/cmd-convert-parquet-2to3.go
+++ b/cmd/tempo-cli/cmd-convert-parquet-2to3.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/tempo/tempodb/encoding/vparquet2"
 	"github.com/grafana/tempo/tempodb/encoding/vparquet3"
 	"github.com/parquet-go/parquet-go"
+	"github.com/pkg/errors"
 )
 
 type convertParquet2to3 struct {
@@ -117,7 +118,7 @@ func (i *parquetIterator) Next(_ context.Context) (common.ID, *tempopb.Trace, er
 	}
 
 	_, err := i.r.Read(traces)
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		return nil, nil, io.EOF
 	}
 	if err != nil {

--- a/cmd/tempo-cli/cmd-gen-bloom.go
+++ b/cmd/tempo-cli/cmd-gen-bloom.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/pkg/errors"
+
 	"github.com/google/uuid"
 	willf_bloom "github.com/willf/bloom"
 
@@ -43,7 +45,7 @@ func ReplayBlockAndDoForEachRecord(meta *backend.BlockMeta, filepath string, for
 	objectRW := v2.NewObjectReaderWriter()
 	for {
 		buffer, _, err := dataReader.NextPage(buffer)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
@@ -64,7 +66,7 @@ func ReplayBlockAndDoForEachRecord(meta *backend.BlockMeta, filepath string, for
 			}
 		}
 
-		if iterErr != io.EOF {
+		if !errors.Is(iterErr, io.EOF) {
 			return iterErr
 		}
 	}

--- a/cmd/tempo-cli/cmd-gen-index.go
+++ b/cmd/tempo-cli/cmd-gen-index.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
@@ -40,7 +41,7 @@ func ReplayBlockAndGetRecords(meta *backend.BlockMeta, filepath string) ([]v2.Re
 	currentOffset := uint64(0)
 	for {
 		buffer, pageLen, err := dataReader.NextPage(buffer)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
@@ -60,7 +61,7 @@ func ReplayBlockAndGetRecords(meta *backend.BlockMeta, filepath string) ([]v2.Re
 			lastID = id
 		}
 
-		if iterErr != io.EOF {
+		if !errors.Is(iterErr, io.EOF) {
 			replayError = iterErr
 			break
 		}

--- a/cmd/tempo-cli/cmd-list-block.go
+++ b/cmd/tempo-cli/cmd-list-block.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
 	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/util"
@@ -52,12 +54,12 @@ func dumpBlock(r tempodb_backend.Reader, c tempodb_backend.Compactor, tenantID s
 	id := uuid.MustParse(blockID)
 
 	meta, err := r.BlockMeta(context.TODO(), id, tenantID)
-	if err != nil && err != tempodb_backend.ErrDoesNotExist {
+	if err != nil && !errors.Is(err, tempodb_backend.ErrDoesNotExist) {
 		return err
 	}
 
 	compactedMeta, err := c.CompactedBlockMeta(id, tenantID)
-	if err != nil && err != tempodb_backend.ErrDoesNotExist {
+	if err != nil && !errors.Is(err, tempodb_backend.ErrDoesNotExist) {
 		return err
 	}
 
@@ -132,7 +134,7 @@ func dumpBlock(r tempodb_backend.Reader, c tempodb_backend.Compactor, tenantID s
 		prevID := make([]byte, 16)
 		for {
 			objID, obj, err := iter.NextBytes(ctx)
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			} else if err != nil {
 				return err
@@ -242,7 +244,7 @@ func addKey(kvp kvPairs, key string, count int) {
 	kvp[key] = v
 }
 
-func addVal(kvp kvPairs, key string, val string, count int) {
+func addVal(kvp kvPairs, key, val string, count int) {
 	v := kvp[key]
 	stats, ok := v.all[val]
 	if !ok {

--- a/cmd/tempo-cli/cmd-list-column.go
+++ b/cmd/tempo-cli/cmd-list-column.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/parquet-go/parquet-go"
+	"github.com/pkg/errors"
 
 	pq "github.com/grafana/tempo/pkg/parquetquery"
 	"github.com/grafana/tempo/tempodb/encoding/vparquet"
@@ -54,7 +55,7 @@ func (cmd *listColumnCmd) Run(ctx *globalOptions) error {
 		buffer := make([]parquet.Value, 10000)
 		for {
 			pg, err := pages.ReadPage()
-			if pg == nil || err == io.EOF {
+			if pg == nil || errors.Is(err, io.EOF) {
 				break
 			}
 
@@ -66,7 +67,7 @@ func (cmd *listColumnCmd) Run(ctx *globalOptions) error {
 				}
 
 				// check for EOF after processing any returned data
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					break
 				}
 				// todo: better error handling

--- a/cmd/tempo-cli/cmd-query-blocks.go
+++ b/cmd/tempo-cli/cmd-query-blocks.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
 	"github.com/grafana/tempo/pkg/boundedwaitgroup"
 	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempopb"
@@ -127,13 +129,13 @@ func queryBlock(ctx context.Context, r backend.Reader, c backend.Compactor, bloc
 	}
 
 	meta, err := r.BlockMeta(context.Background(), id, tenantID)
-	if err != nil && err != backend.ErrDoesNotExist {
+	if err != nil && !errors.Is(err, backend.ErrDoesNotExist) {
 		return nil, err
 	}
 
-	if err == backend.ErrDoesNotExist {
+	if errors.Is(err, backend.ErrDoesNotExist) {
 		compactedMeta, err := c.CompactedBlockMeta(id, tenantID)
-		if err != nil && err != backend.ErrDoesNotExist {
+		if err != nil && !errors.Is(err, backend.ErrDoesNotExist) {
 			return nil, err
 		}
 

--- a/cmd/tempo-cli/cmd-query-search.go
+++ b/cmd/tempo-cli/cmd-query-search.go
@@ -5,10 +5,12 @@ import (
 	"io"
 	"time"
 
-	"github.com/grafana/dskit/user"
-	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/grafana/dskit/user"
+	"github.com/grafana/tempo/pkg/tempopb"
 )
 
 type querySearchCmd struct {
@@ -62,7 +64,7 @@ func (cmd *querySearchCmd) Run(_ *globalOptions) error {
 				return err
 			}
 		}
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		if err != nil {

--- a/cmd/tempo-cli/cmd-search.go
+++ b/cmd/tempo-cli/cmd-search.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
 	"github.com/grafana/tempo/pkg/boundedwaitgroup"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/tempodb"
@@ -69,7 +71,7 @@ func (cmd *searchBlocksCmd) Run(opts *globalOptions) error {
 
 			// search here
 			meta, err := r.BlockMeta(ctx, id2, cmd.TenantID)
-			if err == backend.ErrDoesNotExist {
+			if errors.Is(err, backend.ErrDoesNotExist) {
 				return
 			}
 			if err != nil {

--- a/cmd/tempo-cli/shared.go
+++ b/cmd/tempo-cli/shared.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
 	"github.com/grafana/tempo/pkg/boundedwaitgroup"
 	"github.com/grafana/tempo/tempodb/backend"
 )
@@ -105,14 +107,14 @@ func loadBlock(r backend.Reader, c backend.Compactor, tenantID string, id uuid.U
 	}
 
 	meta, err := r.BlockMeta(context.Background(), id, tenantID)
-	if err == backend.ErrDoesNotExist && !includeCompacted {
+	if errors.Is(err, backend.ErrDoesNotExist) && !includeCompacted {
 		return nil, nil
-	} else if err != nil && err != backend.ErrDoesNotExist {
+	} else if err != nil && !errors.Is(err, backend.ErrDoesNotExist) {
 		return nil, err
 	}
 
 	compactedMeta, err := c.CompactedBlockMeta(id, tenantID)
-	if err != nil && err != backend.ErrDoesNotExist {
+	if err != nil && !errors.Is(err, backend.ErrDoesNotExist) {
 		return nil, err
 	}
 

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-test/deep"
 	jaeger_grpc "github.com/jaegertracing/jaeger/cmd/agent/app/reporter/grpc"
 	zaplogfmt "github.com/jsternberg/zap-logfmt"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -467,7 +468,7 @@ func queryTrace(client *httpclient.Client, info *util.TraceInfo) (traceMetrics, 
 
 	trace, err := client.QueryTrace(hexID)
 	if err != nil {
-		if err == util.ErrTraceNotFound {
+		if errors.Is(err, util.ErrTraceNotFound) {
 			tm.notFoundByID++
 		} else {
 			tm.requestFailed++

--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -207,14 +207,11 @@ func (t *App) Run() error {
 		// let's find out which module failed
 		for m, s := range serviceMap {
 			if s == service {
-				switch service.FailureCase() {
-				case modules.ErrStopProcess:
+				if errors.Is(service.FailureCase(), modules.ErrStopProcess) {
 					level.Info(log.Logger).Log("msg", "received stop signal via return error", "module", m, "err", service.FailureCase())
-				case context.Canceled:
-				default:
+				} else {
 					level.Error(log.Logger).Log("msg", "module failed", "module", m, "err", service.FailureCase())
 				}
-
 				return
 			}
 		}

--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -207,10 +207,11 @@ func (t *App) Run() error {
 		// let's find out which module failed
 		for m, s := range serviceMap {
 			if s == service {
-				if errors.Is(service.FailureCase(), modules.ErrStopProcess) {
-					level.Info(log.Logger).Log("msg", "received stop signal via return error", "module", m, "err", service.FailureCase())
-				} else {
-					level.Error(log.Logger).Log("msg", "module failed", "module", m, "err", service.FailureCase())
+				err = service.FailureCase()
+				if errors.Is(err, modules.ErrStopProcess) {
+					level.Info(log.Logger).Log("msg", "received stop signal via return error", "module", m, "err", err)
+				} else if err != nil && !errors.Is(err, context.Canceled) {
+					level.Error(log.Logger).Log("msg", "module failed", "module", m, "err", err)
 				}
 				return
 			}

--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -210,7 +210,9 @@ func (t *App) Run() error {
 				err = service.FailureCase()
 				if errors.Is(err, modules.ErrStopProcess) {
 					level.Info(log.Logger).Log("msg", "received stop signal via return error", "module", m, "err", err)
-				} else if err != nil && !errors.Is(err, context.Canceled) {
+				} else if errors.Is(err, context.Canceled) {
+					return
+				} else if err != nil {
 					level.Error(log.Logger).Log("msg", "module failed", "module", m, "err", err)
 				}
 				return

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -263,7 +263,7 @@ func (t *App) initIngester() (services.Service, error) {
 func (t *App) initGenerator() (services.Service, error) {
 	t.cfg.Generator.Ring.ListenPort = t.cfg.Server.GRPCListenPort
 	genSvc, err := generator.New(&t.cfg.Generator, t.Overrides, prometheus.DefaultRegisterer, log.Logger)
-	if err == generator.ErrUnconfigured && t.cfg.Target != MetricsGenerator { // just warn if we're not running the metrics-generator
+	if errors.Is(err, generator.ErrUnconfigured) && t.cfg.Target != MetricsGenerator { // just warn if we're not running the metrics-generator
 		level.Warn(log.Logger).Log("msg", "metrics-generator is not configured.", "err", err)
 		return services.NewIdleService(nil, nil), nil
 	}

--- a/integration/util.go
+++ b/integration/util.go
@@ -347,7 +347,7 @@ func SearchStreamAndAssertTrace(t *testing.T, client tempopb.StreamingQuerierCli
 				break
 			}
 		}
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		require.NoError(t, err)

--- a/modules/frontend/handler.go
+++ b/modules/frontend/handler.go
@@ -156,15 +156,12 @@ func copyHeader(dst, src http.Header) {
 // httpgrpc errors can bubble up to here and should be translated to http errors. It returns
 // httpgrpc error.
 func writeError(w http.ResponseWriter, err error) error {
-	switch err {
-	case context.Canceled:
+	if errors.Is(err, context.Canceled) {
 		err = errCanceled
-	case context.DeadlineExceeded:
+	} else if errors.Is(err, context.DeadlineExceeded) {
 		err = errDeadlineExceeded
-	default:
-		if isRequestBodyTooLarge(err) {
-			err = errRequestEntityTooLarge
-		}
+	} else if isRequestBodyTooLarge(err) {
+		err = errRequestEntityTooLarge
 	}
 	server.WriteError(w, err)
 	return err

--- a/modules/frontend/v1/frontend.go
+++ b/modules/frontend/v1/frontend.go
@@ -377,7 +377,7 @@ func (f *Frontend) queueRequest(ctx context.Context, req *request) error {
 	f.activeUsers.UpdateUserTimestamp(joinedTenantID, now)
 
 	err = f.requestQueue.EnqueueRequest(joinedTenantID, req, maxQueriers)
-	if err == queue.ErrTooManyRequests {
+	if errors.Is(err, queue.ErrTooManyRequests) {
 		return errTooManyRequest
 	}
 	return err

--- a/modules/generator/processor/localblocks/processor.go
+++ b/modules/generator/processor/localblocks/processor.go
@@ -89,7 +89,8 @@ func (p *Processor) PushSpans(_ context.Context, req *tempopb.PushSpansRequest) 
 
 	for _, batch := range req.Batches {
 		if batch = filterBatch(batch); batch != nil {
-			if err := p.liveTraces.Push(batch, p.Cfg.MaxLiveTraces); errors.Is(err, errMaxExceeded) {
+			err := p.liveTraces.Push(batch, p.Cfg.MaxLiveTraces)
+			if errors.Is(err, errMaxExceeded) {
 				metricDroppedTraces.WithLabelValues(p.tenant, reasonLiveTracesExceeded).Inc()
 			}
 		}

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -185,7 +185,8 @@ func TestServiceGraphs_tooManySpansErr(t *testing.T) {
 	require.NoError(t, err)
 
 	err = p.(*Processor).consume(request.Batches)
-	assert.True(t, errors.As(err, &tooManySpansError{}))
+	var tmsErr *tooManySpansError
+	assert.True(t, errors.As(err, &tmsErr))
 }
 
 func TestServiceGraphs_virtualNodes(t *testing.T) {

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -165,7 +165,7 @@ func (i *instance) PushBytesRequest(ctx context.Context, req *tempopb.PushBytesR
 }
 
 // PushBytes is used to push an unmarshalled tempopb.Trace to the instance
-func (i *instance) PushBytes(ctx context.Context, id []byte, traceBytes []byte) error {
+func (i *instance) PushBytes(ctx context.Context, id, traceBytes []byte) error {
 	i.measureReceivedBytes(traceBytes)
 
 	if !validation.ValidTraceID(id) {
@@ -575,7 +575,7 @@ func (i *instance) rediscoverLocalBlocks(ctx context.Context) ([]*localBlock, er
 		// If meta missing then block was not successfully written.
 		meta, err := i.localReader.BlockMeta(ctx, id, i.instanceID)
 		if err != nil {
-			if err == backend.ErrDoesNotExist {
+			if errors.Is(err, backend.ErrDoesNotExist) {
 				// Partial/incomplete block found, remove, it will be recreated from data in the wal.
 				level.Warn(log.Logger).Log("msg", "Unable to reload meta for local block. This indicates an incomplete block and will be deleted", "tenant", i.instanceID, "block", id.String())
 				err = i.local.ClearBlock(id, i.instanceID)

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -200,8 +200,9 @@ func (i *instance) push(ctx context.Context, id, traceBytes []byte) error {
 
 	err := trace.Push(ctx, i.instanceID, traceBytes)
 	if err != nil {
-		if e, ok := err.(*traceTooLargeError); ok {
-			return status.Errorf(codes.FailedPrecondition, e.Error())
+		var ttlErr traceTooLargeError
+		if ok := errors.As(err, &ttlErr); ok {
+			return status.Errorf(codes.FailedPrecondition, ttlErr.Error())
 		}
 		return err
 	}

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -200,9 +200,8 @@ func (i *instance) push(ctx context.Context, id, traceBytes []byte) error {
 
 	err := trace.Push(ctx, i.instanceID, traceBytes)
 	if err != nil {
-		var ttlErr traceTooLargeError
-		if ok := errors.As(err, &ttlErr); ok {
-			return status.Errorf(codes.FailedPrecondition, ttlErr.Error())
+		if ok := errors.As(err, &traceTooLargeError{}); ok {
+			return status.Errorf(codes.FailedPrecondition, err.Error())
 		}
 		return err
 	}

--- a/modules/overrides/user_configurable_overrides.go
+++ b/modules/overrides/user_configurable_overrides.go
@@ -154,7 +154,7 @@ func (o *userConfigurableOverridesManager) reloadAllTenantLimits(ctx context.Con
 	// For every tenant with user-configurable overrides, download and cache them
 	for _, tenant := range tenants {
 		limits, _, err := o.client.Get(ctx, tenant)
-		if err == backend.ErrDoesNotExist {
+		if errors.Is(err, backend.ErrDoesNotExist) {
 			o.setTenantLimit(tenant, nil)
 			continue
 		}

--- a/modules/overrides/userconfigurable/api/api.go
+++ b/modules/overrides/userconfigurable/api/api.go
@@ -102,18 +102,18 @@ func (a *UserConfigOverridesAPI) update(ctx context.Context, userID string, patc
 	traceID, _ := tracing.ExtractTraceID(ctx)
 
 	currLimits, currVersion, err := a.client.Get(ctx, userID)
-	if err != nil && err != backend.ErrDoesNotExist {
+	if err != nil && !errors.Is(err, backend.ErrDoesNotExist) {
 		return nil, "", err
 	}
 
 	level.Info(a.logger).Log("traceID", traceID, "msg", "patching user-configurable overrides", "userID", userID, "patch", patch, "currLimits", logLimits(currLimits), "currVersion", currVersion)
 
-	if err == backend.ErrDoesNotExist {
+	if errors.Is(err, backend.ErrDoesNotExist) {
 		currVersion = backend.VersionNew
 	}
 
 	patchedBytes := patch
-	if err != backend.ErrDoesNotExist {
+	if !errors.Is(err, backend.ErrDoesNotExist) {
 		currBytes, err := json.Marshal(currLimits)
 		if err != nil {
 			return nil, "", err
@@ -131,7 +131,7 @@ func (a *UserConfigOverridesAPI) update(ctx context.Context, userID string, patc
 	}
 
 	version, err := a.set(ctx, userID, patchedLimits, currVersion)
-	if err == backend.ErrVersionDoesNotMatch {
+	if errors.Is(err, backend.ErrVersionDoesNotMatch) {
 		return nil, "", errors.New("overrides have been modified during request processing, try again")
 	}
 	if err != nil {

--- a/modules/overrides/userconfigurable/api/api.go
+++ b/modules/overrides/userconfigurable/api/api.go
@@ -171,12 +171,16 @@ type validationError struct {
 	err error
 }
 
+func newValidationError(err error) *validationError {
+	return &validationError{err: err}
+}
+
 func (e *validationError) Error() string {
 	return e.err.Error()
 }
 
-func newValidationError(err error) *validationError {
-	return &validationError{err: err}
+func (e *validationError) Unwrap() error {
+	return errors.Unwrap(e.err)
 }
 
 func logLimits(limits *client.Limits) string {

--- a/modules/overrides/userconfigurable/api/api.go
+++ b/modules/overrides/userconfigurable/api/api.go
@@ -168,11 +168,15 @@ func (a *UserConfigOverridesAPI) parseLimits(body io.Reader) (*client.Limits, er
 
 // validationError is returned when the request can not be accepted because of a client error
 type validationError struct {
-	error
+	err error
 }
 
-func newValidationError(err error) validationError {
-	return validationError{err}
+func (e *validationError) Error() string {
+	return e.err.Error()
+}
+
+func newValidationError(err error) *validationError {
+	return &validationError{err: err}
 }
 
 func logLimits(limits *client.Limits) string {

--- a/modules/overrides/userconfigurable/api/http.go
+++ b/modules/overrides/userconfigurable/api/http.go
@@ -137,9 +137,8 @@ func writeError(w http.ResponseWriter, err error) {
 		http.Error(w, err.Error(), http.StatusPreconditionFailed)
 		return
 	}
-	var valErr validationError
-	if ok := errors.As(err, &valErr); ok {
-		http.Error(w, valErr.Error(), http.StatusBadRequest)
+	if ok := errors.As(err, &validationError{}); ok {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/modules/overrides/userconfigurable/api/http.go
+++ b/modules/overrides/userconfigurable/api/http.go
@@ -12,6 +12,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	ot_log "github.com/opentracing/opentracing-go/log"
+	"github.com/pkg/errors"
 
 	"github.com/grafana/tempo/modules/overrides/userconfigurable/client"
 	"github.com/grafana/tempo/pkg/api"
@@ -128,11 +129,11 @@ func (a *UserConfigOverridesAPI) DeleteHandler(w http.ResponseWriter, r *http.Re
 }
 
 func writeError(w http.ResponseWriter, err error) {
-	if err == backend.ErrDoesNotExist {
+	if errors.Is(err, backend.ErrDoesNotExist) {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
-	if err == backend.ErrVersionDoesNotMatch || err == backend.ErrVersionInvalid {
+	if errors.Is(err, backend.ErrVersionDoesNotMatch) || errors.Is(err, backend.ErrVersionInvalid) {
 		http.Error(w, err.Error(), http.StatusPreconditionFailed)
 		return
 	}
@@ -165,7 +166,7 @@ func (a *UserConfigOverridesAPI) logRequest(ctx context.Context, handler string,
 	return ctx, func(errPtr *error) {
 		err := *errPtr
 
-		if err != nil && err != backend.ErrDoesNotExist {
+		if err != nil && !errors.Is(err, backend.ErrDoesNotExist) {
 			span.LogFields(ot_log.Error(err))
 			ext.Error.Set(span, true)
 			level.Error(a.logger).Log("traceID", traceID, "method", r.Method, "url", r.URL.RequestURI(), "user-agent", r.UserAgent(), "err", err)

--- a/modules/overrides/userconfigurable/api/http.go
+++ b/modules/overrides/userconfigurable/api/http.go
@@ -137,7 +137,8 @@ func writeError(w http.ResponseWriter, err error) {
 		http.Error(w, err.Error(), http.StatusPreconditionFailed)
 		return
 	}
-	if ok := errors.As(err, &validationError{}); ok {
+	var valErr *validationError
+	if ok := errors.As(err, &valErr); ok {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/modules/overrides/userconfigurable/api/http.go
+++ b/modules/overrides/userconfigurable/api/http.go
@@ -137,8 +137,9 @@ func writeError(w http.ResponseWriter, err error) {
 		http.Error(w, err.Error(), http.StatusPreconditionFailed)
 		return
 	}
-	if err, ok := err.(validationError); ok {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+	var valErr validationError
+	if ok := errors.As(err, &valErr); ok {
+		http.Error(w, valErr.Error(), http.StatusBadRequest)
 		return
 	}
 	http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/api/http.go
+++ b/pkg/api/http.go
@@ -161,7 +161,8 @@ func ParseSearchRequest(r *http.Request) (*tempopb.SearchRequest, error) {
 		}
 
 		if err := decoder.Err(); err != nil {
-			if syntaxErr, ok := err.(*logfmt.SyntaxError); ok {
+			var syntaxErr *logfmt.SyntaxError
+			if ok := errors.As(err, &syntaxErr); ok {
 				return nil, fmt.Errorf("invalid tags: %s at pos %d", syntaxErr.Msg, syntaxErr.Pos)
 			}
 			return nil, fmt.Errorf("invalid tags: %w", err)

--- a/pkg/cache/memcached.go
+++ b/pkg/cache/memcached.go
@@ -11,6 +11,7 @@ import (
 	instr "github.com/grafana/dskit/instrument"
 	"github.com/grafana/gomemcache/memcache"
 	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
@@ -118,16 +119,16 @@ type result struct {
 
 func memcacheStatusCode(err error) string {
 	// See https://godoc.org/github.com/bradfitz/gomemcache/memcache#pkg-variables
-	switch err {
-	case nil:
-		return "200"
-	case memcache.ErrCacheMiss:
+	if errors.Is(err, memcache.ErrCacheMiss) {
 		return "404"
-	case memcache.ErrMalformedKey:
+	}
+	if errors.Is(err, memcache.ErrMalformedKey) {
 		return "400"
-	default:
+	}
+	if err != nil {
 		return "500"
 	}
+	return "200"
 }
 
 // Fetch gets keys from the cache. The keys that are found must be in the order of the keys requested.

--- a/pkg/cache/redis_client.go
+++ b/pkg/cache/redis_client.go
@@ -10,6 +10,7 @@ import (
 	"unsafe"
 
 	"github.com/go-redis/redis/v8"
+	"github.com/pkg/errors"
 
 	"github.com/grafana/dskit/flagext"
 )
@@ -134,7 +135,7 @@ func (c *RedisClient) MGet(ctx context.Context, keys []string) ([][]byte, error)
 		for i, key := range keys {
 			cmd := c.rdb.Get(ctx, key)
 			err := cmd.Err()
-			if err == redis.Nil {
+			if errors.Is(err, redis.Nil) {
 				// if key not found, response nil
 				continue
 			} else if err != nil {

--- a/pkg/io/read.go
+++ b/pkg/io/read.go
@@ -2,6 +2,8 @@ package io
 
 import (
 	"io"
+
+	"github.com/pkg/errors"
 )
 
 // ReadAllWithEstimate is a fork of https://go.googlesource.com/go/+/go1.16.3/src/io/io.go#626
@@ -20,7 +22,7 @@ func ReadAllWithEstimate(r io.Reader, estimatedBytes int64) ([]byte, error) {
 		n, err := r.Read(b[len(b):cap(b)])
 		b = b[:len(b)+n]
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				err = nil
 			}
 			return b, err
@@ -50,7 +52,7 @@ func ReadAllWithBuffer(r io.Reader, estimatedBytes int, b []byte) ([]byte, error
 		n, err := r.Read(b[len(b):cap(b)])
 		b = b[:len(b)+n]
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				err = nil
 			}
 			return b, err

--- a/pkg/model/object_decoder_test.go
+++ b/pkg/model/object_decoder_test.go
@@ -5,12 +5,14 @@ import (
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/tempo/pkg/model/decoder"
 	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/util/test"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestObjectDecoderMarshalUnmarshal(t *testing.T) {
@@ -158,7 +160,7 @@ func TestCombines(t *testing.T) {
 					assert.Equal(t, tt.expected, actual)
 
 					start, end, err := d.FastRange(actualBytes)
-					if err == decoder.ErrUnsupported {
+					if errors.Is(err, decoder.ErrUnsupported) {
 						return
 					}
 					require.NoError(t, err)

--- a/pkg/model/segment_decoder_test.go
+++ b/pkg/model/segment_decoder_test.go
@@ -5,9 +5,11 @@ import (
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/tempo/pkg/model/decoder"
 	"github.com/grafana/tempo/pkg/util/test"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSegmentDecoderToObjectDecoder(t *testing.T) {
@@ -65,7 +67,7 @@ func TestSegmentDecoderToObjectDecoderRange(t *testing.T) {
 
 			// test range
 			actualStart, actualEnd, err := objectDecoder.FastRange(object)
-			if err == decoder.ErrUnsupported {
+			if errors.Is(err, decoder.ErrUnsupported) {
 				return
 			}
 
@@ -93,7 +95,7 @@ func TestSegmentDecoderFastRange(t *testing.T) {
 
 			// test range
 			actualStart, actualEnd, err := segmentDecoder.FastRange(segment)
-			if err == decoder.ErrUnsupported {
+			if errors.Is(err, decoder.ErrUnsupported) {
 				return
 			}
 

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -679,7 +679,7 @@ func (c *SyncIterator) seekPages(seekTo RowNumber, definitionLevel int) (done bo
 			if pg == nil || err != nil {
 				// No more pages in this column chunk,
 				// cleanup and exit.
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					err = nil
 				}
 				pq.Release(pg)
@@ -734,7 +734,7 @@ func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 
 		if c.currPage == nil {
 			pg, err := c.currChunk.NextPage()
-			if pg == nil || err == io.EOF {
+			if pg == nil || errors.Is(err, io.EOF) {
 				// This row group is exhausted
 				c.closeCurrRowGroup()
 				continue
@@ -758,7 +758,7 @@ func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 		if c.currBufN >= len(c.currBuf) || len(c.currBuf) == 0 {
 			c.currBuf = c.currBuf[:cap(c.currBuf)]
 			n, err := c.currValues.ReadValues(c.currBuf)
-			if err != nil && err != io.EOF {
+			if err != nil && !errors.Is(err, io.EOF) {
 				return EmptyRowNumber(), nil, err
 			}
 			c.currBuf = c.currBuf[:n]
@@ -982,7 +982,7 @@ func (c *ColumnIterator) iterate(ctx context.Context, readSize int) {
 			}()
 			for {
 				pg, err := col.NextPage()
-				if pg == nil || err == io.EOF {
+				if pg == nil || errors.Is(err, io.EOF) {
 					break
 				}
 				if err != nil {
@@ -1053,7 +1053,7 @@ func (c *ColumnIterator) iterate(ctx context.Context, readSize int) {
 
 						// Error checks MUST occur after processing any returned data
 						// following io.Reader behavior.
-						if err == io.EOF {
+						if errors.Is(err, io.EOF) {
 							break
 						}
 						if err != nil {

--- a/pkg/search/results.go
+++ b/pkg/search/results.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"sync"
 
+	"github.com/pkg/errors"
+	"go.uber.org/atomic"
+
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/tempodb/encoding/common"
-	"go.uber.org/atomic"
 )
 
 // Results eases performing a highly parallel search by funneling all results into a single
@@ -57,7 +59,7 @@ func (sr *Results) AddResult(ctx context.Context, r *tempopb.TraceSearchMetadata
 // NOTE: this will ignore common.Unsupported errors,
 // we don't Propagate those error upstream.
 func (sr *Results) SetError(err error) {
-	if err != common.ErrUnsupported { // ignore common.Unsupported
+	if !errors.Is(err, common.ErrUnsupported) { // ignore common.Unsupported
 		sr.error.Store(err)
 	}
 }

--- a/pkg/traceql/ast_validate.go
+++ b/pkg/traceql/ast_validate.go
@@ -7,11 +7,11 @@ type unsupportedError struct {
 	feature string
 }
 
-func newUnsupportedError(feature string) unsupportedError {
-	return unsupportedError{feature: feature}
+func newUnsupportedError(feature string) *unsupportedError {
+	return &unsupportedError{feature: feature}
 }
 
-func (e unsupportedError) Error() string {
+func (e *unsupportedError) Error() string {
 	return e.feature + " not yet supported"
 }
 

--- a/pkg/traceql/ast_validate_test.go
+++ b/pkg/traceql/ast_validate_test.go
@@ -48,7 +48,8 @@ func TestExamples(t *testing.T) {
 			require.NoError(t, err)
 			err = p.validate()
 			require.Error(t, err)
-			require.False(t, errors.As(err, &unsupportedError{}))
+			var unErr *unsupportedError
+			require.False(t, errors.As(err, &unErr))
 		})
 	}
 
@@ -58,7 +59,8 @@ func TestExamples(t *testing.T) {
 			require.NoError(t, err)
 			err = p.validate()
 			require.Error(t, err)
-			require.True(t, errors.As(err, &unsupportedError{}))
+			var unErr *unsupportedError
+			require.True(t, errors.As(err, &unErr))
 		})
 	}
 

--- a/pkg/traceql/engine.go
+++ b/pkg/traceql/engine.go
@@ -7,6 +7,8 @@ import (
 	"math"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/opentracing/opentracing-go"
 
 	"github.com/grafana/tempo/pkg/tempopb"
@@ -105,7 +107,7 @@ func (e *Engine) ExecuteSearch(ctx context.Context, searchReq *tempopb.SearchReq
 	combiner := NewMetadataCombiner()
 	for {
 		spanset, err := iterator.Next(ctx)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			span.LogKV("msg", "iterator.Next", "err", err)
 			return nil, err
 		}
@@ -219,7 +221,7 @@ func (e *Engine) ExecuteTagValues(
 
 	for {
 		spanset, err := iterator.Next(ctx)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			span.LogKV("msg", "iterator.Next", "err", err)
 			return err
 		}

--- a/pkg/traceql/engine_test.go
+++ b/pkg/traceql/engine_test.go
@@ -451,7 +451,8 @@ func TestExamplesInEngine(t *testing.T) {
 				Query: q,
 			})
 			require.Error(t, err)
-			require.False(t, errors.As(err, &unsupportedError{}))
+			var unErr *unsupportedError
+			require.False(t, errors.As(err, &unErr))
 		})
 	}
 
@@ -461,7 +462,8 @@ func TestExamplesInEngine(t *testing.T) {
 				Query: q,
 			})
 			require.Error(t, err)
-			require.True(t, errors.As(err, &unsupportedError{}))
+			var unErr *unsupportedError
+			require.True(t, errors.As(err, &unErr))
 		})
 	}
 }

--- a/pkg/traceql/lexer.go
+++ b/pkg/traceql/lexer.go
@@ -77,7 +77,7 @@ type lexer struct {
 	scanner.Scanner
 	expr   *RootExpr
 	parser *yyParserImpl
-	errs   []ParseError
+	errs   []*ParseError
 
 	parsingAttribute bool
 }

--- a/pkg/traceql/parse.go
+++ b/pkg/traceql/parse.go
@@ -22,7 +22,8 @@ func Parse(s string) (expr *RootExpr, err error) {
 		if r := recover(); r != nil {
 			var ok bool
 			if err, ok = r.(error); ok {
-				if errors.Is(err, &ParseError{}) {
+				var parseErr *ParseError
+				if errors.As(err, &parseErr) {
 					return
 				}
 				err = newParseError(err.Error(), 0, 0)

--- a/pkg/traceql/parse.go
+++ b/pkg/traceql/parse.go
@@ -22,7 +22,7 @@ func Parse(s string) (expr *RootExpr, err error) {
 		if r := recover(); r != nil {
 			var ok bool
 			if err, ok = r.(error); ok {
-				if errors.Is(err, ParseError{}) {
+				if errors.Is(err, &ParseError{}) {
 					return
 				}
 				err = newParseError(err.Error(), 0, 0)
@@ -78,15 +78,15 @@ type ParseError struct {
 	line, col int
 }
 
-func (p ParseError) Error() string {
+func (p *ParseError) Error() string {
 	if p.col == 0 && p.line == 0 {
 		return fmt.Sprintf("parse error : %s", p.msg)
 	}
 	return fmt.Sprintf("parse error at line %d, col %d: %s", p.line, p.col, p.msg)
 }
 
-func newParseError(msg string, line, col int) ParseError {
-	return ParseError{
+func newParseError(msg string, line, col int) *ParseError {
+	return &ParseError{
 		msg:  msg,
 		line: line,
 		col:  col,

--- a/pkg/traceqlmetrics/metrics.go
+++ b/pkg/traceqlmetrics/metrics.go
@@ -156,7 +156,7 @@ func (m *MetricsResults) Combine(other *MetricsResults) {
 }
 
 // GetMetrics
-func GetMetrics(ctx context.Context, query string, groupBy string, spanLimit int, start, end uint64, fetcher traceql.SpansetFetcher) (*MetricsResults, error) {
+func GetMetrics(ctx context.Context, query, groupBy string, spanLimit int, start, end uint64, fetcher traceql.SpansetFetcher) (*MetricsResults, error) {
 	identifiers := strings.Split(groupBy, ",")
 
 	if len(identifiers) > maxGroupBys {
@@ -253,7 +253,7 @@ func GetMetrics(ctx context.Context, query string, groupBy string, spanLimit int
 	// callback.  No actual results will be returned from this fetch call,
 	// But we still need to call Next() at least once.
 	res, err := fetcher.Fetch(ctx, *req)
-	if err == util.ErrUnsupported {
+	if errors.Is(err, util.ErrUnsupported) {
 		return nil, nil
 	}
 	if err != nil {

--- a/pkg/usagestats/reporter.go
+++ b/pkg/usagestats/reporter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/multierror"
 	"github.com/grafana/dskit/services"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/tempo/cmd/tempo/build"
@@ -103,10 +104,10 @@ func (rep *Reporter) initLeader(ctx context.Context) *ClusterSeed {
 		remoteSeed, err := rep.fetchSeed(ctx,
 			func(err error) bool {
 				// we only want to retry if the error is not an object not found error or a bad see file error
-				return err != backend.ErrDoesNotExist && err != backend.ErrBadSeedFile
+				return !errors.Is(err, backend.ErrDoesNotExist) && !errors.Is(err, backend.ErrBadSeedFile)
 			})
 		if err != nil {
-			if err == backend.ErrDoesNotExist || err == backend.ErrBadSeedFile {
+			if errors.Is(err, backend.ErrDoesNotExist) || errors.Is(err, backend.ErrBadSeedFile) {
 				// we are the leader and we need to save the file.
 				if err := rep.writeSeedFile(ctx, seed); err != nil {
 					level.Warn(rep.logger).Log("msg", "failed to CAS cluster seed key", "err", err)
@@ -177,12 +178,12 @@ func (rep *Reporter) fetchSeed(ctx context.Context, continueFn func(err error) b
 	for backoff.Ongoing() {
 		seed, err := rep.readSeedFile(ctx)
 		if err != nil {
-			if err != backend.ErrDoesNotExist {
+			if !errors.Is(err, backend.ErrDoesNotExist) {
 				readingErr++
 			}
 			level.Debug(rep.logger).Log("msg", "failed to read cluster seed file", "err", err)
 			if readingErr > attemptNumber {
-				if err == backend.ErrBadSeedFile {
+				if errors.Is(err, backend.ErrBadSeedFile) {
 					level.Debug(rep.logger).Log("msg", "seed file corrupted")
 				}
 			}
@@ -261,12 +262,10 @@ func (rep *Reporter) running(ctx context.Context) error {
 			rep.lastReport = next
 			next = next.Add(reportInterval)
 		case <-ctx.Done():
-			switch ctx.Err() {
-			case context.Canceled:
+			if errors.Is(ctx.Err(), context.Canceled) {
 				return nil
-			default:
-				return ctx.Err()
 			}
+			return ctx.Err()
 		}
 	}
 }

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -46,7 +46,8 @@ func (es *MultiError) Add(err error) {
 	if err == nil {
 		return
 	}
-	if merr, ok := err.(MultiError); ok {
+	var merr MultiError
+	if ok := errors.As(err, &merr); ok {
 		*es = append(*es, merr...)
 	} else {
 		*es = append(*es, err)

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 
@@ -18,49 +17,6 @@ var (
 
 	ErrUnsupported = fmt.Errorf("unsupported")
 )
-
-// The MultiError type implements the error interface, and contains the
-// Errors used to construct it.
-type MultiError []error
-
-// Returns a concatenated string of the contained errors
-func (es MultiError) Error() string {
-	var buf bytes.Buffer
-
-	if len(es) > 1 {
-		_, _ = fmt.Fprintf(&buf, "%d errors: ", len(es))
-	}
-
-	for i, err := range es {
-		if i != 0 {
-			buf.WriteString("; ")
-		}
-		buf.WriteString(err.Error())
-	}
-
-	return buf.String()
-}
-
-// Add adds the error to the error list if it is not nil.
-func (es *MultiError) Add(err error) {
-	if err == nil {
-		return
-	}
-	var merr MultiError
-	if ok := errors.As(err, &merr); ok {
-		*es = append(*es, merr...)
-	} else {
-		*es = append(*es, err)
-	}
-}
-
-// Err returns the error list as an error or nil if it is empty.
-func (es MultiError) Err() error {
-	if len(es) == 0 {
-		return nil
-	}
-	return es
-}
 
 // IsConnCanceled returns true, if error is from a closed gRPC connection.
 // copied from https://github.com/etcd-io/etcd/blob/7f47de84146bdc9225d2080ec8678ca8189a2d2b/clientv3/client.go#L646

--- a/pkg/util/httpgrpcutil/carrier.go
+++ b/pkg/util/httpgrpcutil/carrier.go
@@ -1,8 +1,10 @@
 package httpgrpcutil
 
 import (
-	"github.com/grafana/dskit/httpgrpc"
 	"github.com/opentracing/opentracing-go"
+	"github.com/pkg/errors"
+
+	"github.com/grafana/dskit/httpgrpc"
 )
 
 // Used to transfer trace information from/to HTTP request.
@@ -33,7 +35,7 @@ func GetParentSpanForRequest(tracer opentracing.Tracer, req *httpgrpc.HTTPReques
 
 	carrier := (*HttpgrpcHeadersCarrier)(req)
 	extracted, err := tracer.Extract(opentracing.HTTPHeaders, carrier)
-	if err == opentracing.ErrSpanContextNotFound {
+	if errors.Is(err, opentracing.ErrSpanContextNotFound) {
 		err = nil
 	}
 	return extracted, err

--- a/tempodb/backend/azure/azure.go
+++ b/tempodb/backend/azure/azure.go
@@ -219,17 +219,17 @@ func (rw *readerWriter) Shutdown() {
 func (rw *readerWriter) WriteVersioned(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, version backend.Version) (backend.Version, error) {
 	// TODO use conditional if-match API
 	_, currentVersion, err := rw.ReadVersioned(ctx, name, keypath)
-	if err != nil && err != backend.ErrDoesNotExist {
+	if err != nil && !errors.Is(err, backend.ErrDoesNotExist) {
 		return "", err
 	}
 
 	level.Info(log.Logger).Log("msg", "WriteVersioned - fetching data", "currentVersion", currentVersion, "err", err, "version", version)
 
 	// object does not exist - supplied version must be "0"
-	if err == backend.ErrDoesNotExist && version != backend.VersionNew {
+	if errors.Is(err, backend.ErrDoesNotExist) && version != backend.VersionNew {
 		return "", backend.ErrVersionDoesNotMatch
 	}
-	if err != backend.ErrDoesNotExist && version != currentVersion {
+	if !errors.Is(err, backend.ErrDoesNotExist) && version != currentVersion {
 		return "", backend.ErrVersionDoesNotMatch
 	}
 
@@ -245,10 +245,10 @@ func (rw *readerWriter) WriteVersioned(ctx context.Context, name string, keypath
 func (rw *readerWriter) DeleteVersioned(ctx context.Context, name string, keypath backend.KeyPath, version backend.Version) error {
 	// TODO use conditional if-match API
 	_, currentVersion, err := rw.ReadVersioned(ctx, name, keypath)
-	if err != nil && err != backend.ErrDoesNotExist {
+	if err != nil && !errors.Is(err, backend.ErrDoesNotExist) {
 		return err
 	}
-	if err != backend.ErrDoesNotExist && currentVersion != version {
+	if !errors.Is(err, backend.ErrDoesNotExist) && currentVersion != version {
 		return backend.ErrVersionDoesNotMatch
 	}
 

--- a/tempodb/backend/gcs/compactor.go
+++ b/tempodb/backend/gcs/compactor.go
@@ -8,6 +8,7 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/google/uuid"
 	"github.com/googleapis/gax-go/v2"
+	"github.com/pkg/errors"
 	"google.golang.org/api/iterator"
 
 	"github.com/grafana/tempo/tempodb/backend"
@@ -50,7 +51,7 @@ func (rw *readerWriter) ClearBlock(blockID uuid.UUID, tenantID string) error {
 
 	for {
 		attrs, err := iter.Next()
-		if err == iterator.Done {
+		if errors.Is(err, iterator.Done) {
 			break
 		}
 		if err != nil {

--- a/tempodb/backend/gcs/gcs.go
+++ b/tempodb/backend/gcs/gcs.go
@@ -172,7 +172,7 @@ func (rw *readerWriter) List(ctx context.Context, keypath backend.KeyPath) ([]st
 	var objects []string
 	for {
 		attrs, err := iter.Next()
-		if err == iterator.Done {
+		if errors.Is(err, iterator.Done) {
 			break
 		}
 		if err != nil {
@@ -325,7 +325,7 @@ func (rw *readerWriter) readRange(ctx context.Context, name string, offset int64
 	totalBytes := 0
 	for {
 		byteCount, err := r.Read(buffer[totalBytes:])
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		if err != nil {
@@ -388,7 +388,7 @@ func createBucket(ctx context.Context, cfg *Config, hedge bool) (*storage.Bucket
 }
 
 func readError(err error) error {
-	if err == storage.ErrObjectNotExist {
+	if errors.Is(err, storage.ErrObjectNotExist) {
 		return backend.ErrDoesNotExist
 	}
 

--- a/tempodb/backend/gcs/gcs_test.go
+++ b/tempodb/backend/gcs/gcs_test.go
@@ -18,11 +18,11 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	raw "google.golang.org/api/storage/v1"
 
 	"github.com/grafana/tempo/tempodb/backend"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestHedge(t *testing.T) {

--- a/tempodb/backend/gcs/gcs_test.go
+++ b/tempodb/backend/gcs/gcs_test.go
@@ -17,10 +17,12 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	raw "google.golang.org/api/storage/v1"
+
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	raw "google.golang.org/api/storage/v1"
 )
 
 func TestHedge(t *testing.T) {
@@ -202,7 +204,7 @@ func fakeServerWithObjectAttributes(t *testing.T, o *raw.Object) *httptest.Serve
 
 			for {
 				part, err := reader.NextPart()
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					break
 				}
 				require.NoError(t, err)

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -9,6 +9,7 @@ import (
 	"path"
 
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 
 	tempo_io "github.com/grafana/tempo/pkg/io"
 )
@@ -92,7 +93,7 @@ func (w *writer) WriteTenantIndex(ctx context.Context, tenantID string, meta []*
 	// If meta and compactedMeta are empty, call delete the tenant index.
 	if len(meta) == 0 && len(compactedMeta) == 0 {
 		// Skip returning an error when the object is already deleted.
-		if err := w.w.Delete(ctx, TenantIndexName, KeyPath([]string{tenantID}), false); err != nil && err != ErrDoesNotExist {
+		if err := w.w.Delete(ctx, TenantIndexName, KeyPath([]string{tenantID}), false); err != nil && !errors.Is(err, ErrDoesNotExist) {
 			return err
 		}
 		return nil
@@ -246,16 +247,16 @@ func KeyPathWithPrefix(keypath KeyPath, prefix string) KeyPath {
 }
 
 // MetaFileName returns the object name for the block meta given a block id and tenantid
-func MetaFileName(blockID uuid.UUID, tenantID string, prefix string) string {
+func MetaFileName(blockID uuid.UUID, tenantID, prefix string) string {
 	return path.Join(prefix, tenantID, blockID.String(), MetaName)
 }
 
 // CompactedMetaFileName returns the object name for the compacted block meta given a block id and tenantid
-func CompactedMetaFileName(blockID uuid.UUID, tenantID string, prefix string) string {
+func CompactedMetaFileName(blockID uuid.UUID, tenantID, prefix string) string {
 	return path.Join(prefix, tenantID, blockID.String(), CompactedMetaName)
 }
 
 // RootPath returns the root path for a block given a block id and tenantid
-func RootPath(blockID uuid.UUID, tenantID string, prefix string) string {
+func RootPath(blockID uuid.UUID, tenantID, prefix string) string {
 	return path.Join(prefix, tenantID, blockID.String())
 }

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -93,7 +93,8 @@ func (w *writer) WriteTenantIndex(ctx context.Context, tenantID string, meta []*
 	// If meta and compactedMeta are empty, call delete the tenant index.
 	if len(meta) == 0 && len(compactedMeta) == 0 {
 		// Skip returning an error when the object is already deleted.
-		if err := w.w.Delete(ctx, TenantIndexName, KeyPath([]string{tenantID}), false); err != nil && !errors.Is(err, ErrDoesNotExist) {
+		err := w.w.Delete(ctx, TenantIndexName, []string{tenantID}, false)
+		if err != nil && !errors.Is(err, ErrDoesNotExist) {
 			return err
 		}
 		return nil

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/google/uuid"
 	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.uber.org/atomic"
@@ -289,14 +290,14 @@ func (p *Poller) pollBlock(ctx context.Context, tenantID string, blockID uuid.UU
 	var compactedBlockMeta *backend.CompactedBlockMeta
 	blockMeta, err := p.reader.BlockMeta(ctx, blockID, tenantID)
 	// if the normal meta doesn't exist maybe it's compacted.
-	if err == backend.ErrDoesNotExist {
+	if errors.Is(err, backend.ErrDoesNotExist) {
 		blockMeta = nil
 		compactedBlockMeta, err = p.compactor.CompactedBlockMeta(blockID, tenantID)
 	}
 
 	// blocks in intermediate states may not have a compacted or normal block meta.
 	//   this is not necessarily an error, just bail out
-	if err == backend.ErrDoesNotExist {
+	if errors.Is(err, backend.ErrDoesNotExist) {
 		return nil, nil, nil
 	}
 

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -8,14 +8,16 @@ import (
 	"time"
 
 	"github.com/go-kit/log/level"
+	"github.com/opentracing/opentracing-go"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/grafana/tempo/pkg/dataquality"
 	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/grafana/tempo/tempodb/encoding/common"
-	"github.com/opentracing/opentracing-go"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 const (
@@ -143,7 +145,7 @@ func (rw *readerWriter) doCompaction(ctx context.Context) {
 			// Compact selected blocks into a larger one
 			err := rw.compact(ctx, toBeCompacted, tenantID)
 
-			if err == backend.ErrDoesNotExist {
+			if errors.Is(err, backend.ErrDoesNotExist) {
 				level.Warn(rw.logger).Log("msg", "unable to find meta during compaction.  trying again on this block list", "err", err)
 			} else if err != nil {
 				level.Error(rw.logger).Log("msg", "error during compaction cycle", "err", err)
@@ -223,7 +225,7 @@ func (rw *readerWriter) compact(ctx context.Context, blockMetas []*backend.Block
 		ObjectsWritten: func(compactionLevel, objs int) {
 			metricCompactionObjectsWritten.WithLabelValues(strconv.Itoa(compactionLevel)).Add(float64(objs))
 		},
-		SpansDiscarded: func(traceId, rootSpanName string, rootServiceName string, spans int) {
+		SpansDiscarded: func(traceId, rootSpanName, rootServiceName string, spans int) {
 			rw.compactorSharder.RecordDiscardedSpans(spans, tenantID, traceId, rootSpanName, rootServiceName)
 		},
 		DisconnectedTrace: func() {
@@ -260,7 +262,7 @@ func (rw *readerWriter) compact(ctx context.Context, blockMetas []*backend.Block
 	return nil
 }
 
-func markCompacted(rw *readerWriter, tenantID string, oldBlocks []*backend.BlockMeta, newBlocks []*backend.BlockMeta) error {
+func markCompacted(rw *readerWriter, tenantID string, oldBlocks, newBlocks []*backend.BlockMeta) error {
 	// Check if we have any errors, but continue marking the blocks as compacted
 	var errCount int
 	for _, meta := range oldBlocks {

--- a/tempodb/encoding/v2/compactor.go
+++ b/tempodb/encoding/v2/compactor.go
@@ -80,7 +80,7 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 	for {
 
 		id, body, err := iter.NextBytes(ctx)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 

--- a/tempodb/encoding/v2/create_block.go
+++ b/tempodb/encoding/v2/create_block.go
@@ -59,7 +59,7 @@ func CreateBlock(ctx context.Context, cfg *common.BlockConfig, meta *backend.Blo
 	var tracker backend.AppendTracker
 	for {
 		id, trBytes, err := next(ctx)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return nil, errors.Wrap(err, "error iterating")
 		}
 

--- a/tempodb/encoding/v2/finder_paged.go
+++ b/tempodb/encoding/v2/finder_paged.go
@@ -96,7 +96,7 @@ func (f *PagedFinder) findOne(ctx context.Context, id common.ID, record Record) 
 
 	for {
 		foundID, b, err := iter.NextBytes(ctx)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/tempodb/encoding/v2/iterator_deduping.go
+++ b/tempodb/encoding/v2/iterator_deduping.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/pkg/errors"
+
 	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempopb"
@@ -41,7 +43,7 @@ func NewDedupingIterator(iter BytesIterator, combiner model.ObjectCombiner, data
 	}
 
 	i.currentID, i.currentObject, err = i.iter.NextBytes(context.Background())
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, err
 	}
 
@@ -112,7 +114,7 @@ func (i *dedupingIterator) next(ctx context.Context) (common.ID, [][]byte, error
 
 	for {
 		id, obj, err := i.iter.NextBytes(ctx)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return nil, nil, err
 		}
 

--- a/tempodb/encoding/v2/iterator_deduping_test.go
+++ b/tempodb/encoding/v2/iterator_deduping_test.go
@@ -6,9 +6,11 @@ import (
 	"io"
 	"testing"
 
-	"github.com/grafana/tempo/tempodb/encoding/common"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
 type mockIterator struct {
@@ -112,7 +114,7 @@ func TestDedupingIterator(t *testing.T) {
 
 		for {
 			id, obj, err := iter.NextBytes(context.Background())
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			assert.NoError(t, err)

--- a/tempodb/encoding/v2/iterator_multiblock.go
+++ b/tempodb/encoding/v2/iterator_multiblock.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/pkg/errors"
+	"github.com/uber-go/atomic"
 
 	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/tempodb/encoding/common"
-
-	"github.com/uber-go/atomic"
 )
 
 type multiblockIterator struct {
@@ -107,7 +107,7 @@ func (i *multiblockIterator) iterate(ctx context.Context) {
 		// find lowest ID of the new object
 		for _, b := range i.bookmarks {
 			currentID, currentObject, err := b.current(ctx)
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				continue
 			} else if err != nil {
 				i.err.Store(err)

--- a/tempodb/encoding/v2/iterator_multiblock_test.go
+++ b/tempodb/encoding/v2/iterator_multiblock_test.go
@@ -8,10 +8,11 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-
-	"github.com/grafana/tempo/tempodb/encoding/common"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
+
+	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
 var testLogger log.Logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
@@ -61,7 +62,7 @@ func TestBookmarkIteration(t *testing.T) {
 	i := 0
 	for {
 		id, data, err := bm.current(context.Background())
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		require.NoError(t, err)
@@ -91,7 +92,7 @@ func TestMultiblockSorts(t *testing.T) {
 	lastID := -1
 	for {
 		id, _, err := iter.NextBytes(context.TODO())
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		require.NoError(t, err)

--- a/tempodb/encoding/v2/iterator_paged_test.go
+++ b/tempodb/encoding/v2/iterator_paged_test.go
@@ -9,10 +9,12 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/grafana/tempo/tempodb/backend"
-	"github.com/grafana/tempo/tempodb/encoding/common"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/tempo/tempodb/backend"
+	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
 // TestIteratorPaged tests the iterator paging functionality
@@ -112,7 +114,7 @@ func TestIteratorPartialPaged(t *testing.T) {
 func assertIterator(t *testing.T, iter BytesIterator, ids []common.ID, objs [][]byte) {
 	for {
 		id, obj, err := iter.NextBytes(context.Background())
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		require.NoError(t, err)

--- a/tempodb/encoding/v2/iterator_prefetch.go
+++ b/tempodb/encoding/v2/iterator_prefetch.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"io"
 
-	"github.com/grafana/tempo/tempodb/encoding/common"
-
+	"github.com/pkg/errors"
 	"github.com/uber-go/atomic"
+
+	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
 type prefetchIterator struct {
@@ -71,7 +72,7 @@ func (i *prefetchIterator) iterate(ctx context.Context) {
 
 	for {
 		id, obj, err := i.iter.NextBytes(ctx)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return
 		}
 		if err != nil {

--- a/tempodb/encoding/v2/iterator_prefetch_test.go
+++ b/tempodb/encoding/v2/iterator_prefetch_test.go
@@ -56,7 +56,7 @@ func TestPrefetchIterates(t *testing.T) {
 		count := 0
 		for {
 			id, obj, err := prefetchIter.NextBytes(context.TODO())
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			if err != nil {

--- a/tempodb/encoding/v2/iterator_record.go
+++ b/tempodb/encoding/v2/iterator_record.go
@@ -33,7 +33,7 @@ func newRecordIterator(r []Record, dataR DataReader, objectRW ObjectReaderWriter
 func (i *recordIterator) NextBytes(ctx context.Context) (common.ID, []byte, error) {
 	if i.currentIterator != nil {
 		id, object, err := i.currentIterator.NextBytes(ctx)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return nil, nil, err
 		}
 		if id != nil {

--- a/tempodb/encoding/v2/streaming_block_test.go
+++ b/tempodb/encoding/v2/streaming_block_test.go
@@ -13,14 +13,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/local"
 	"github.com/grafana/tempo/tempodb/encoding/common"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -187,7 +188,7 @@ func testStreamingBlockToBackendBlock(t *testing.T, cfg *common.BlockConfig) {
 	for i, id := range ids {
 		idsToObjs[util.TokenForTraceID(id)] = reqs[i]
 	}
-	sort.Slice(ids, func(i int, j int) bool { return bytes.Compare(ids[i], ids[j]) == -1 })
+	sort.Slice(ids, func(i, j int) bool { return bytes.Compare(ids[i], ids[j]) == -1 })
 
 	iterator, err := backendBlock.Iterator(50 * 1024)
 	require.NoError(t, err, "error getting iterator")
@@ -261,7 +262,7 @@ func streamingBlock(t *testing.T, cfg *common.BlockConfig, w backend.Writer) (*S
 	ctx := context.Background()
 	for {
 		id, data, err := iter.NextBytes(ctx)
-		if err != io.EOF {
+		if !errors.Is(err, io.EOF) {
 			require.NoError(t, err)
 		}
 
@@ -394,10 +395,10 @@ func benchmarkCompressBlock(b *testing.B, encoding backend.Encoding, indexDownsa
 	ctx := context.Background()
 	for {
 		id, data, err := iter.NextBytes(ctx)
-		if err != io.EOF {
+		if !errors.Is(err, io.EOF) {
 			require.NoError(b, err)
 		}
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 
@@ -429,7 +430,7 @@ func benchmarkCompressBlock(b *testing.B, encoding backend.Encoding, indexDownsa
 	o := NewObjectReaderWriter()
 	for {
 		tempBuffer, _, err = pr.NextPage(tempBuffer)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		require.NoError(b, err)
@@ -438,7 +439,7 @@ func benchmarkCompressBlock(b *testing.B, encoding backend.Encoding, indexDownsa
 
 		for {
 			_, _, err = o.UnmarshalObjectFromReader(bufferReader)
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 		}

--- a/tempodb/encoding/v2/wal_block.go
+++ b/tempodb/encoding/v2/wal_block.go
@@ -43,7 +43,7 @@ type walBlock struct {
 	once     sync.Once
 }
 
-func createWALBlock(id uuid.UUID, tenantID string, filepath string, e backend.Encoding, dataEncoding string, ingestionSlack time.Duration) (common.WALBlock, error) {
+func createWALBlock(id uuid.UUID, tenantID, filepath string, e backend.Encoding, dataEncoding string, ingestionSlack time.Duration) (common.WALBlock, error) {
 	if strings.ContainsRune(dataEncoding, ':') || strings.ContainsRune(dataEncoding, '+') ||
 		len([]rune(dataEncoding)) > maxDataEncodingLength {
 		return nil, fmt.Errorf("dataEncoding %s is invalid", dataEncoding)
@@ -81,7 +81,7 @@ func createWALBlock(id uuid.UUID, tenantID string, filepath string, e backend.En
 
 // openWALBlock returns an AppendBlock that can not be appended to, but can
 // be completed. It can return a warning or a fatal error
-func openWALBlock(filename string, path string, ingestionSlack time.Duration, additionalStartSlack time.Duration) (common.WALBlock, error, error) {
+func openWALBlock(filename, path string, ingestionSlack, additionalStartSlack time.Duration) (common.WALBlock, error, error) {
 	var warning error
 	blockID, tenantID, version, e, dataEncoding, err := ParseFilename(filename)
 	if err != nil {
@@ -110,7 +110,7 @@ func openWALBlock(filename string, path string, ingestionSlack time.Duration, ad
 
 	records, warning, err := ReplayWALAndGetRecords(f, e, func(bytes []byte) error {
 		start, end, err := dec.FastRange(bytes)
-		if err == decoder.ErrUnsupported {
+		if errors.Is(err, decoder.ErrUnsupported) {
 			now := uint32(time.Now().Unix())
 			start = now
 			end = now
@@ -348,7 +348,7 @@ func (a *walBlock) file() (*os.File, error) {
 	return a.readFile, err
 }
 
-func (a *walBlock) adjustTimeRangeForSlack(start uint32, end uint32, additionalStartSlack time.Duration) (uint32, uint32) {
+func (a *walBlock) adjustTimeRangeForSlack(start, end uint32, additionalStartSlack time.Duration) (uint32, uint32) {
 	now := time.Now()
 	startOfRange := uint32(now.Add(-a.ingestionSlack).Add(-additionalStartSlack).Unix())
 	endOfRange := uint32(now.Add(a.ingestionSlack).Unix())

--- a/tempodb/encoding/v2/wal_block_replay.go
+++ b/tempodb/encoding/v2/wal_block_replay.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 
+	"github.com/pkg/errors"
+
 	"github.com/grafana/tempo/tempodb/backend"
 )
 
@@ -25,7 +27,7 @@ func ReplayWALAndGetRecords(file *os.File, enc backend.Encoding, handleObj func(
 	currentOffset := uint64(0)
 	for {
 		buffer, pageLen, err = dataReader.NextPage(buffer)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
@@ -41,7 +43,7 @@ func ReplayWALAndGetRecords(file *os.File, enc backend.Encoding, handleObj func(
 		}
 		// wal should only ever have one object per page, test that here
 		_, _, err = objectReader.UnmarshalObjectFromReader(reader)
-		if err != io.EOF {
+		if !errors.Is(err, io.EOF) {
 			warning = fmt.Errorf("expected EOF while replaying wal: %w", err)
 			break
 		}

--- a/tempodb/encoding/v2/wal_block_test.go
+++ b/tempodb/encoding/v2/wal_block_test.go
@@ -12,12 +12,14 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/util/test"
 	"github.com/grafana/tempo/tempodb/backend"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // Note: Standard wal block functionality (appending, searching, finding, etc.) is tested with all other wal blocks
@@ -214,7 +216,7 @@ func TestPartialBlock(t *testing.T) {
 	require.NoError(t, err)
 	for {
 		_, bytesObject, err := bytesIter.NextBytes(context.Background())
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		require.NoError(t, err)

--- a/tempodb/encoding/vparquet/block_findtracebyid.go
+++ b/tempodb/encoding/vparquet/block_findtracebyid.go
@@ -116,7 +116,7 @@ func findTraceByID(ctx context.Context, traceID common.ID, meta *backend.BlockMe
 		}
 
 		c, err := page.Values().ReadValues(buf)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return nil, err
 		}
 		if c < 1 {

--- a/tempodb/encoding/vparquet/block_iterator.go
+++ b/tempodb/encoding/vparquet/block_iterator.go
@@ -68,7 +68,7 @@ func (i *rawIterator) Next(context.Context) (common.ID, parquet.Row, error) {
 		return i.getTraceID(rows[0]), rows[0], nil
 	}
 
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		return nil, nil, nil
 	}
 

--- a/tempodb/encoding/vparquet/block_search_tags.go
+++ b/tempodb/encoding/vparquet/block_search_tags.go
@@ -109,7 +109,7 @@ func searchTags(_ context.Context, scope traceql.AttributeScope, cb common.TagCa
 				defer pgs.Close()
 				for {
 					pg, err := pgs.ReadPage()
-					if err == io.EOF || pg == nil {
+					if errors.Is(err, io.EOF) || pg == nil {
 						break
 					}
 					if err != nil {
@@ -149,7 +149,7 @@ func searchTags(_ context.Context, scope traceql.AttributeScope, cb common.TagCa
 				// there is only one dictionary per column chunk, so just read it from the first page
 				// and be done.
 				pg, err := pgs.ReadPage()
-				if err == io.EOF || pg == nil {
+				if errors.Is(err, io.EOF) || pg == nil {
 					return nil
 				}
 				if err != nil {

--- a/tempodb/encoding/vparquet/block_traceql.go
+++ b/tempodb/encoding/vparquet/block_traceql.go
@@ -331,7 +331,7 @@ func (i *bridgeIterator) Next() (*pq.IteratorResult, error) {
 		}
 
 		filteredSpansets, err := i.cb(spanset)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil, nil
 		}
 		if err != nil {

--- a/tempodb/encoding/vparquet/compactor.go
+++ b/tempodb/encoding/vparquet/compactor.go
@@ -135,7 +135,7 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 
 	for {
 		lowestID, lowestObject, err := m.Next(ctx)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 
@@ -317,7 +317,7 @@ func estimateMarshalledSizeFromParquetRow(row parquet.Row) (size int) {
 // countSpans counts the number of spans in the given trace in deconstructed
 // parquet row format and returns traceId.
 // It simply counts the number of values for span ID, which is always present.
-func countSpans(schema *parquet.Schema, row parquet.Row) (traceID string, rootSpanName string, rootServiceName string, spans int) {
+func countSpans(schema *parquet.Schema, row parquet.Row) (traceID, rootSpanName, rootServiceName string, spans int) {
 	traceIDColumn, found := schema.Lookup(TraceIDColumnName)
 	if !found {
 		return "", "", "", 0

--- a/tempodb/encoding/vparquet/create.go
+++ b/tempodb/encoding/vparquet/create.go
@@ -47,7 +47,7 @@ func CreateBlock(ctx context.Context, cfg *common.BlockConfig, meta *backend.Blo
 		sch := parquet.SchemaOf(trp)
 		next = func(context.Context) (common.ID, parquet.Row, error) {
 			id, tr, err := i.Next(ctx)
-			if err == io.EOF || tr == nil {
+			if errors.Is(err, io.EOF) || tr == nil {
 				return id, nil, err
 			}
 
@@ -64,7 +64,7 @@ func CreateBlock(ctx context.Context, cfg *common.BlockConfig, meta *backend.Blo
 
 	for {
 		id, row, err := next(ctx)
-		if err == io.EOF || row == nil {
+		if errors.Is(err, io.EOF) || row == nil {
 			break
 		}
 

--- a/tempodb/encoding/vparquet/multiblock_iterator.go
+++ b/tempodb/encoding/vparquet/multiblock_iterator.go
@@ -42,7 +42,7 @@ func (m *MultiBlockIterator[T]) Next(ctx context.Context) (common.ID, T, error) 
 	// find lowest ID of the new object
 	for _, b := range m.bookmarks {
 		id, err := b.peekID(ctx)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return nil, nil, err
 		}
 		if id == nil {
@@ -66,7 +66,7 @@ func (m *MultiBlockIterator[T]) Next(ctx context.Context) (common.ID, T, error) 
 	lowestObjects := make([]T, 0, len(lowestBookmarks))
 	for _, b := range lowestBookmarks {
 		_, obj, err := b.current(ctx)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return nil, nil, err
 		}
 		if obj == nil {
@@ -125,7 +125,7 @@ func newBookmark[T iteratable](iter bookmarkIterator[T]) *bookmark[T] {
 
 func (b *bookmark[T]) peekID(ctx context.Context) (common.ID, error) {
 	nextID, err := b.iter.peekNextID(ctx)
-	if err != common.ErrUnsupported {
+	if !errors.Is(err, common.ErrUnsupported) {
 		return nextID, err
 	}
 
@@ -148,7 +148,7 @@ func (b *bookmark[T]) current(ctx context.Context) (common.ID, T, error) {
 
 func (b *bookmark[T]) done(ctx context.Context) bool {
 	nextID, err := b.iter.peekNextID(ctx)
-	if err != common.ErrUnsupported {
+	if !errors.Is(err, common.ErrUnsupported) {
 		return nextID == nil || err != nil
 	}
 

--- a/tempodb/encoding/vparquet/multiblock_iterator_test.go
+++ b/tempodb/encoding/vparquet/multiblock_iterator_test.go
@@ -5,8 +5,10 @@ import (
 	"io"
 	"testing"
 
-	"github.com/grafana/tempo/tempodb/encoding/common"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
 type intIterator []*uint8 // making this a pointer makes the below code a little gross but allows multiblockiterator to treat all types as nillable
@@ -81,7 +83,7 @@ func TestMultiBlockIterator(t *testing.T) {
 		ctx := context.Background()
 		for {
 			id, val, err := mbi.Next(ctx)
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			require.NoError(t, err)

--- a/tempodb/encoding/vparquet/schema_test.go
+++ b/tempodb/encoding/vparquet/schema_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/parquet-go/parquet-go"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -225,7 +226,7 @@ func estimateRowSize(t *testing.T, name string) {
 	for {
 		_, err := r.Read(row)
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			require.NoError(t, err)

--- a/tempodb/encoding/vparquet/wal_block.go
+++ b/tempodb/encoding/vparquet/wal_block.go
@@ -777,11 +777,11 @@ func newCommonIterator(iter *MultiBlockIterator[parquet.Row], schema *parquet.Sc
 
 func (i *commonIterator) Next(ctx context.Context) (common.ID, *tempopb.Trace, error) {
 	id, row, err := i.iter.Next(ctx)
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, nil, err
 	}
 
-	if row == nil || err == io.EOF {
+	if row == nil || errors.Is(err, io.EOF) {
 		return nil, nil, nil
 	}
 

--- a/tempodb/encoding/vparquet2/block_findtracebyid.go
+++ b/tempodb/encoding/vparquet2/block_findtracebyid.go
@@ -71,7 +71,7 @@ func (b *backendBlock) checkIndex(ctx context.Context, id common.ID) (bool, int,
 	defer span.Finish()
 
 	indexBytes, err := b.r.Read(derivedCtx, common.NameIndex, b.meta.BlockID, b.meta.TenantID, true)
-	if err == backend.ErrDoesNotExist {
+	if errors.Is(err, backend.ErrDoesNotExist) {
 		return true, -1, nil
 	}
 	if err != nil {
@@ -168,7 +168,7 @@ func findTraceByID(ctx context.Context, traceID common.ID, meta *backend.BlockMe
 			}
 
 			c, err := page.Values().ReadValues(buf)
-			if err != nil && err != io.EOF {
+			if err != nil && !errors.Is(err, io.EOF) {
 				return nil, err
 			}
 			if c < 1 {

--- a/tempodb/encoding/vparquet2/block_iterator.go
+++ b/tempodb/encoding/vparquet2/block_iterator.go
@@ -68,7 +68,7 @@ func (i *rawIterator) Next(context.Context) (common.ID, parquet.Row, error) {
 		return i.getTraceID(rows[0]), rows[0], nil
 	}
 
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		return nil, nil, nil
 	}
 

--- a/tempodb/encoding/vparquet2/block_search_tags.go
+++ b/tempodb/encoding/vparquet2/block_search_tags.go
@@ -109,7 +109,7 @@ func searchTags(_ context.Context, scope traceql.AttributeScope, cb common.TagCa
 				defer pgs.Close()
 				for {
 					pg, err := pgs.ReadPage()
-					if err == io.EOF || pg == nil {
+					if errors.Is(err, io.EOF) || pg == nil {
 						break
 					}
 					if err != nil {
@@ -149,7 +149,7 @@ func searchTags(_ context.Context, scope traceql.AttributeScope, cb common.TagCa
 				// there is only one dictionary per column chunk, so just read it from the first page
 				// and be done.
 				pg, err := pgs.ReadPage()
-				if err == io.EOF || pg == nil {
+				if errors.Is(err, io.EOF) || pg == nil {
 					return nil
 				}
 				if err != nil {

--- a/tempodb/encoding/vparquet2/block_traceql.go
+++ b/tempodb/encoding/vparquet2/block_traceql.go
@@ -417,7 +417,7 @@ func (i *bridgeIterator) Next() (*parquetquery.IteratorResult, error) {
 		}
 
 		filteredSpansets, err := i.cb(spanset)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil, nil
 		}
 		if err != nil {

--- a/tempodb/encoding/vparquet2/compactor.go
+++ b/tempodb/encoding/vparquet2/compactor.go
@@ -135,7 +135,7 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 
 	for {
 		lowestID, lowestObject, err := m.Next(ctx)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 
@@ -317,7 +317,7 @@ func estimateMarshalledSizeFromParquetRow(row parquet.Row) (size int) {
 // countSpans counts the number of spans in the given trace in deconstructed
 // parquet row format and returns traceId.
 // It simply counts the number of values for span ID, which is always present.
-func countSpans(schema *parquet.Schema, row parquet.Row) (traceID string, rootSpanName string, rootServiceName string, spans int) {
+func countSpans(schema *parquet.Schema, row parquet.Row) (traceID, rootSpanName, rootServiceName string, spans int) {
 	traceIDColumn, found := schema.Lookup(TraceIDColumnName)
 	if !found {
 		return "", "", "", 0

--- a/tempodb/encoding/vparquet2/create.go
+++ b/tempodb/encoding/vparquet2/create.go
@@ -47,7 +47,7 @@ func CreateBlock(ctx context.Context, cfg *common.BlockConfig, meta *backend.Blo
 		sch := parquet.SchemaOf(trp)
 		next = func(context.Context) (common.ID, parquet.Row, error) {
 			id, tr, err := i.Next(ctx)
-			if err == io.EOF || tr == nil {
+			if errors.Is(err, io.EOF) || tr == nil {
 				return id, nil, err
 			}
 
@@ -64,7 +64,7 @@ func CreateBlock(ctx context.Context, cfg *common.BlockConfig, meta *backend.Blo
 
 	for {
 		id, row, err := next(ctx)
-		if err == io.EOF || row == nil {
+		if errors.Is(err, io.EOF) || row == nil {
 			break
 		}
 

--- a/tempodb/encoding/vparquet2/multiblock_iterator.go
+++ b/tempodb/encoding/vparquet2/multiblock_iterator.go
@@ -42,7 +42,7 @@ func (m *MultiBlockIterator[T]) Next(ctx context.Context) (common.ID, T, error) 
 	// find lowest ID of the new object
 	for _, b := range m.bookmarks {
 		id, err := b.peekID(ctx)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return nil, nil, err
 		}
 		if id == nil {
@@ -66,7 +66,7 @@ func (m *MultiBlockIterator[T]) Next(ctx context.Context) (common.ID, T, error) 
 	lowestObjects := make([]T, 0, len(lowestBookmarks))
 	for _, b := range lowestBookmarks {
 		_, obj, err := b.current(ctx)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return nil, nil, err
 		}
 		if obj == nil {
@@ -125,7 +125,7 @@ func newBookmark[T iteratable](iter bookmarkIterator[T]) *bookmark[T] {
 
 func (b *bookmark[T]) peekID(ctx context.Context) (common.ID, error) {
 	nextID, err := b.iter.peekNextID(ctx)
-	if err != common.ErrUnsupported {
+	if !errors.Is(err, common.ErrUnsupported) {
 		return nextID, err
 	}
 
@@ -148,7 +148,7 @@ func (b *bookmark[T]) current(ctx context.Context) (common.ID, T, error) {
 
 func (b *bookmark[T]) done(ctx context.Context) bool {
 	nextID, err := b.iter.peekNextID(ctx)
-	if err != common.ErrUnsupported {
+	if !errors.Is(err, common.ErrUnsupported) {
 		return nextID == nil || err != nil
 	}
 

--- a/tempodb/encoding/vparquet2/multiblock_iterator_test.go
+++ b/tempodb/encoding/vparquet2/multiblock_iterator_test.go
@@ -5,8 +5,10 @@ import (
 	"io"
 	"testing"
 
-	"github.com/grafana/tempo/tempodb/encoding/common"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
 type intIterator []*uint8 // making this a pointer makes the below code a little gross but allows multiblockiterator to treat all types as nillable
@@ -81,7 +83,7 @@ func TestMultiBlockIterator(t *testing.T) {
 		ctx := context.Background()
 		for {
 			id, val, err := mbi.Next(ctx)
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			require.NoError(t, err)

--- a/tempodb/encoding/vparquet2/schema_test.go
+++ b/tempodb/encoding/vparquet2/schema_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/parquet-go/parquet-go"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -408,7 +409,7 @@ func estimateRowSize(t *testing.T, name string) {
 	for {
 		_, err := r.Read(row)
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			require.NoError(t, err)

--- a/tempodb/encoding/vparquet2/wal_block.go
+++ b/tempodb/encoding/vparquet2/wal_block.go
@@ -777,11 +777,11 @@ func newCommonIterator(iter *MultiBlockIterator[parquet.Row], schema *parquet.Sc
 
 func (i *commonIterator) Next(ctx context.Context) (common.ID, *tempopb.Trace, error) {
 	id, row, err := i.iter.Next(ctx)
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, nil, err
 	}
 
-	if row == nil || err == io.EOF {
+	if row == nil || errors.Is(err, io.EOF) {
 		return nil, nil, nil
 	}
 

--- a/tempodb/encoding/vparquet3/block_findtracebyid.go
+++ b/tempodb/encoding/vparquet3/block_findtracebyid.go
@@ -71,7 +71,7 @@ func (b *backendBlock) checkIndex(ctx context.Context, id common.ID) (bool, int,
 	defer span.Finish()
 
 	indexBytes, err := b.r.Read(derivedCtx, common.NameIndex, b.meta.BlockID, b.meta.TenantID, true)
-	if err == backend.ErrDoesNotExist {
+	if errors.Is(err, backend.ErrDoesNotExist) {
 		return true, -1, nil
 	}
 	if err != nil {
@@ -168,7 +168,7 @@ func findTraceByID(ctx context.Context, traceID common.ID, meta *backend.BlockMe
 			}
 
 			c, err := page.Values().ReadValues(buf)
-			if err != nil && err != io.EOF {
+			if err != nil && !errors.Is(err, io.EOF) {
 				return nil, err
 			}
 			if c < 1 {

--- a/tempodb/encoding/vparquet3/block_iterator.go
+++ b/tempodb/encoding/vparquet3/block_iterator.go
@@ -68,7 +68,7 @@ func (i *rawIterator) Next(context.Context) (common.ID, parquet.Row, error) {
 		return i.getTraceID(rows[0]), rows[0], nil
 	}
 
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		return nil, nil, nil
 	}
 

--- a/tempodb/encoding/vparquet3/block_search_tags.go
+++ b/tempodb/encoding/vparquet3/block_search_tags.go
@@ -123,7 +123,7 @@ func searchTags(_ context.Context, scope traceql.AttributeScope, cb common.TagCa
 				defer pgs.Close()
 				for {
 					pg, err := pgs.ReadPage()
-					if err == io.EOF || pg == nil {
+					if errors.Is(err, io.EOF) || pg == nil {
 						break
 					}
 					if err != nil {
@@ -163,7 +163,7 @@ func searchTags(_ context.Context, scope traceql.AttributeScope, cb common.TagCa
 				// there is only one dictionary per column chunk, so just read it from the first page
 				// and be done.
 				pg, err := pgs.ReadPage()
-				if err == io.EOF || pg == nil {
+				if errors.Is(err, io.EOF) || pg == nil {
 					return nil
 				}
 				if err != nil {

--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -418,7 +418,7 @@ func (i *bridgeIterator) Next() (*parquetquery.IteratorResult, error) {
 		}
 
 		filteredSpansets, err := i.cb(spanset)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil, nil
 		}
 		if err != nil {

--- a/tempodb/encoding/vparquet3/compactor.go
+++ b/tempodb/encoding/vparquet3/compactor.go
@@ -138,7 +138,7 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 
 	for {
 		lowestID, lowestObject, err := m.Next(ctx)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 
@@ -321,7 +321,7 @@ func estimateMarshalledSizeFromParquetRow(row parquet.Row) (size int) {
 // countSpans counts the number of spans in the given trace in deconstructed
 // parquet row format and returns traceId.
 // It simply counts the number of values for span ID, which is always present.
-func countSpans(schema *parquet.Schema, row parquet.Row) (traceID string, rootSpanName string, rootServiceName string, spans int) {
+func countSpans(schema *parquet.Schema, row parquet.Row) (traceID, rootSpanName, rootServiceName string, spans int) {
 	traceIDColumn, found := schema.Lookup(TraceIDColumnName)
 	if !found {
 		return "", "", "", 0

--- a/tempodb/encoding/vparquet3/create.go
+++ b/tempodb/encoding/vparquet3/create.go
@@ -47,7 +47,7 @@ func CreateBlock(ctx context.Context, cfg *common.BlockConfig, meta *backend.Blo
 		sch := parquet.SchemaOf(trp)
 		next = func(context.Context) (common.ID, parquet.Row, error) {
 			id, tr, err := i.Next(ctx)
-			if err == io.EOF || tr == nil {
+			if errors.Is(err, io.EOF) || tr == nil {
 				return id, nil, err
 			}
 
@@ -64,7 +64,7 @@ func CreateBlock(ctx context.Context, cfg *common.BlockConfig, meta *backend.Blo
 
 	for {
 		id, row, err := next(ctx)
-		if err == io.EOF || row == nil {
+		if errors.Is(err, io.EOF) || row == nil {
 			break
 		}
 

--- a/tempodb/encoding/vparquet3/dedicated_columns_test.go
+++ b/tempodb/encoding/vparquet3/dedicated_columns_test.go
@@ -3,9 +3,10 @@ package vparquet3
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	v1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
 	"github.com/grafana/tempo/tempodb/backend"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDedicatedColumnsToColumnMapping(t *testing.T) {

--- a/tempodb/encoding/vparquet3/multiblock_iterator.go
+++ b/tempodb/encoding/vparquet3/multiblock_iterator.go
@@ -42,7 +42,7 @@ func (m *MultiBlockIterator[T]) Next(ctx context.Context) (common.ID, T, error) 
 	// find lowest ID of the new object
 	for _, b := range m.bookmarks {
 		id, err := b.peekID(ctx)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return nil, nil, err
 		}
 		if id == nil {
@@ -66,7 +66,7 @@ func (m *MultiBlockIterator[T]) Next(ctx context.Context) (common.ID, T, error) 
 	lowestObjects := make([]T, 0, len(lowestBookmarks))
 	for _, b := range lowestBookmarks {
 		_, obj, err := b.current(ctx)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return nil, nil, err
 		}
 		if obj == nil {
@@ -125,7 +125,7 @@ func newBookmark[T iteratable](iter bookmarkIterator[T]) *bookmark[T] {
 
 func (b *bookmark[T]) peekID(ctx context.Context) (common.ID, error) {
 	nextID, err := b.iter.peekNextID(ctx)
-	if err != common.ErrUnsupported {
+	if !errors.Is(err, common.ErrUnsupported) {
 		return nextID, err
 	}
 
@@ -148,7 +148,7 @@ func (b *bookmark[T]) current(ctx context.Context) (common.ID, T, error) {
 
 func (b *bookmark[T]) done(ctx context.Context) bool {
 	nextID, err := b.iter.peekNextID(ctx)
-	if err != common.ErrUnsupported {
+	if !errors.Is(err, common.ErrUnsupported) {
 		return nextID == nil || err != nil
 	}
 

--- a/tempodb/encoding/vparquet3/multiblock_iterator_test.go
+++ b/tempodb/encoding/vparquet3/multiblock_iterator_test.go
@@ -5,8 +5,10 @@ import (
 	"io"
 	"testing"
 
-	"github.com/grafana/tempo/tempodb/encoding/common"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
 type intIterator []*uint8 // making this a pointer makes the below code a little gross but allows multiblockiterator to treat all types as nillable
@@ -81,7 +83,7 @@ func TestMultiBlockIterator(t *testing.T) {
 		ctx := context.Background()
 		for {
 			id, val, err := mbi.Next(ctx)
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			require.NoError(t, err)

--- a/tempodb/encoding/vparquet3/schema_test.go
+++ b/tempodb/encoding/vparquet3/schema_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/parquet-go/parquet-go"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -455,7 +456,7 @@ func estimateRowSize(t *testing.T, name string) {
 	for {
 		_, err := r.Read(row)
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			require.NoError(t, err)

--- a/tempodb/encoding/vparquet3/wal_block.go
+++ b/tempodb/encoding/vparquet3/wal_block.go
@@ -787,11 +787,11 @@ func newCommonIterator(meta *backend.BlockMeta, iter *MultiBlockIterator[parquet
 
 func (i *commonIterator) Next(ctx context.Context) (common.ID, *tempopb.Trace, error) {
 	id, row, err := i.iter.Next(ctx)
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, nil, err
 	}
 
-	if row == nil || err == io.EOF {
+	if row == nil || errors.Is(err, io.EOF) {
 		return nil, nil, nil
 	}
 

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -56,7 +56,7 @@ func searchRunner(t *testing.T, _ *tempopb.Trace, wantMeta *tempopb.TraceSearchM
 
 	for _, req := range searchesThatMatch {
 		res, err := r.Search(ctx, meta, req, common.DefaultSearchOptions())
-		if err == common.ErrUnsupported {
+		if errors.Is(err, common.ErrUnsupported) {
 			return
 		}
 		require.NoError(t, err, "search request: %+v", req)

--- a/tempodb/wal/wal_test.go
+++ b/tempodb/wal/wal_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-kit/log" //nolint:all
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/tempo/pkg/model"
@@ -205,7 +206,7 @@ func testIterator(t *testing.T, e encoding.VersionedEncoding) {
 		i := 0
 		for {
 			id, obj, err := iterator.Next(ctx)
-			if err == io.EOF || id == nil {
+			if errors.Is(err, io.EOF) || id == nil {
 				break
 			}
 			require.NoError(t, err)
@@ -252,7 +253,7 @@ func testSearch(t *testing.T, e encoding.VersionedEncoding) {
 				},
 				Limit: 10,
 			}, common.DefaultSearchOptions())
-			if err == common.ErrUnsupported {
+			if errors.Is(err, common.ErrUnsupported) {
 				return
 			}
 			require.NoError(t, err)
@@ -286,7 +287,7 @@ func testFetch(t *testing.T, e encoding.VersionedEncoding) {
 			query := fmt.Sprintf("{ .%s = \"%s\" }", k, v)
 			resp, err := block.Fetch(ctx, traceql.MustExtractFetchSpansRequestWithMetadata(query), common.DefaultSearchOptions())
 			// not all blocks support fetch
-			if err == common.ErrUnsupported {
+			if errors.Is(err, common.ErrUnsupported) {
 				return
 			}
 			require.NoError(t, err)
@@ -514,7 +515,7 @@ func BenchmarkSearch(b *testing.B) {
 						},
 						Limit: 10,
 					}, common.DefaultSearchOptions())
-					if err == common.ErrUnsupported {
+					if errors.Is(err, common.ErrUnsupported) {
 						return
 					}
 					require.NoError(b, err)


### PR DESCRIPTION
**What this PR does**:

Enable the linter [`errorlint`](https://github.com/polyfloyd/go-errorlint) to and configure it to check for plain error comparisons and type assertions. Enabling this linter can help to catch errors like the one fixed by #2890.

Fix all plain comparisons and type assertions found by `errorlint`.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`