### PR TITLE
Removing N for example generating timestamp

### DIFF
--- a/docs/sources/tempo/api_docs/pushing-spans-with-http.md
+++ b/docs/sources/tempo/api_docs/pushing-spans-with-http.md
@@ -57,7 +57,7 @@ curl -X POST http://localhost:9411 -H 'Content-Type: application/json' -d '[{
 }]'
 ```
 
-Note that the `timestamp` field is in microseconds and was obtained by running `date +%s%6N`.  The `duration` field is also in microseconds and so 100000 is 100 milliseconds.
+Note that the `timestamp` field is in microseconds and was obtained by running `date +%s%6`.  The `duration` field is also in microseconds and so 100000 is 100 milliseconds.
 
 ## Retrieve traces
 


### PR DESCRIPTION
**What this PR does**:

Generating the date with the command instructed in the docs resulted in `invalid character 'N' after object key:value pair` on MacOS arm64. Removing it works

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`