### PR TITLE
Fix flaky `TestManagedRegistry_externalLabels`

### DIFF
--- a/modules/generator/registry/registry_test.go
+++ b/modules/generator/registry/registry_test.go
@@ -3,7 +3,6 @@ package registry
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"math/rand"
 	"os"
 	"sort"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestManagedRegistry_concurrency(*testing.T) {


### PR DESCRIPTION
**What this PR does**:
This pull request implements a solution to the flaky `TestManagedRegistry_externalLabels` test.

`TestManagedRegistry_externalLabels` is flaky since it relies on a specific label order which is not guaranteed. The solution is particularly tricky as neither sample order nor label order is guaranteed across the test suite, meaning `collectRegistryMetricsAndAssert` must assert agnostic of both sample _and_ label order.

**This pull request contains no functional changes to Tempo.**

**Which issue(s) this PR fixes**:
Fixes #2881.

**Checklist**
- [x] Tests updated
- [ ] ~Documentation added~
- [ ] ~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~