### PR TITLE
Return first unmarshal error when parsing overrides config

### DIFF
--- a/modules/overrides/config_test.go
+++ b/modules/overrides/config_test.go
@@ -248,3 +248,14 @@ func rvCountFields(rv reflect.Value) int {
 	}
 	return n
 }
+
+func TestConfigParsingError(t *testing.T) {
+	rawYaml := `
+defaults:
+  compaction:
+    block_retentionnnn: 14s
+`
+	cfg := Config{}
+	cfg.RegisterFlagsAndApplyDefaults(&flag.FlagSet{})
+	assert.ErrorContains(t, yaml.UnmarshalStrict([]byte(rawYaml), &cfg), "field block_retentionnnn not found in type overrides.CompactionOverrides")
+}


### PR DESCRIPTION
**What this PR does**:
When using the newer overrides config format, if your config has an error it will always returns something like "field defaults does not exist".
This isn't helpful, instead hold on to the original error and return that instead when unmarshalling as legacy config fails as well.

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`