### PR TITLE
[DRAFT] [DOC] Add more doc for streaming endpoint

### DIFF
--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -255,7 +255,7 @@ $ curl -G -s http://localhost:3200/api/search --data-urlencode 'tags=service.nam
 Ingester configuration `complete_block_timeout` affects how long tags are available for search.
 
 This endpoint retrieves all discovered tag names that can be used in search.  The endpoint is available in the query frontend service in
-a microservices deployment, or the Tempo endpoint in a monolithic mode deployment. The tags endpoint takes a scope that controls the kinds 
+a microservices deployment, or the Tempo endpoint in a monolithic mode deployment. The tags endpoint takes a scope that controls the kinds
 of tags or attributes returned. If nothing is provided, the endpoint will return all resource and span tags.
 
 ```
@@ -294,7 +294,7 @@ $ curl -G -s http://localhost:3200/api/search/tags?scope=span  | jq
 Ingester configuration `complete_block_timeout` affects how long tags are available for search.
 
 This endpoint retrieves all discovered tag names that can be used in search.  The endpoint is available in the query frontend service in
-a microservices deployment, or the Tempo endpoint in a monolithic mode deployment. The tags endpoint takes a scope that controls the kinds 
+a microservices deployment, or the Tempo endpoint in a monolithic mode deployment. The tags endpoint takes a scope that controls the kinds
 of tags or attributes returned. If nothing is provided, the endpoint will return all resource and span tags.
 
 ```
@@ -371,7 +371,7 @@ $ curl -G -s http://localhost:3200/api/search/tag/service.name/values  | jq
 ### Search tag values V2
 
 This endpoint retrieves all discovered values and their data types for the given TraceQL identifier.
-The endpoint is available in the query frontend service in a microservices deployment, or the Tempo endpoint in a monolithic mode deployment. This endpoint is similar to `/api/search/tag/<tag>/values` but operates on TraceQL identifiers and types. 
+The endpoint is available in the query frontend service in a microservices deployment, or the Tempo endpoint in a monolithic mode deployment. This endpoint is similar to `/api/search/tag/<tag>/values` but operates on TraceQL identifiers and types.
 See [TraceQL]({{< relref "../traceql" >}}) documentation for more information.
 
 #### Example
@@ -409,9 +409,9 @@ $ curl http://localhost:3200/api/v2/search/tag/.service.name/values | jq .
 #### Filtered tag values
 If you set Tempo's `autocomplete_filtering_enabled` configuration parameter to `true` (default value is `false`), you can provide an optional URL query parameter, `q` to your request.
 The `q` parameter is a URL-encoded [TraceQL query]({{< relref "../traceql" >}}).
-If provided, the tag values returned by the API are filtered to only return values seen on spans matching your filter parameters. 
+If provided, the tag values returned by the API are filtered to only return values seen on spans matching your filter parameters.
 
-Queries can be incomplete: for example, `{ .cluster = }`. Tempo extracts only the valid matchers and build a valid query. 
+Queries can be incomplete: for example, `{ .cluster = }`. Tempo extracts only the valid matchers and build a valid query.
 
 Only queries with a single selector `{}` and AND `&&` operators are supported.
   - Example supported: `{ .cluster = "us-east-1" && .service = "frontend" }`
@@ -423,7 +423,7 @@ The following request returns all discovered service names on spans with `span.h
 GET /api/v2/search/tag/.service.name/values?q="{span.http.method='GET'}"
 ```
 
-If a particular service name (for example, `shopping-cart`) is only present on spans with `span.http.method=POST`, it would not be included in the list of values returned. 
+If a particular service name (for example, `shopping-cart`) is only present on spans with `span.http.method=POST`, it would not be included in the list of values returned.
 
 ### Query Echo Endpoint
 
@@ -573,11 +573,12 @@ Exposes the build information in a JSON object. The fields are `version`, `revis
 
 ## Tempo GRPC API
 
-Tempo uses GRPC to internally communicate with itself, but only has one externally supported client. The query-frontend component implements
-the streaming querier interface defined below. [See here](https://github.com/grafana/tempo/blob/main/pkg/tempopb/) for the complete proto definition and generated code.
+Tempo uses GRPC to internally communicate with itself, but only has one externally supported client.
+The query-frontend component implements the streaming querier interface defined below.
+[See here](https://github.com/grafana/tempo/blob/main/pkg/tempopb/) for the complete proto definition and generated code.
 
-By default this service is only offered over the GRPC port. However, one can offer this streaming service over the HTTP port as well (which Grafana expects).
-To enable the streaming service over the http port for use with Grafana set the following. 
+By default, this service is only offered over the GRPC port. However, this streaming service can be offered over the HTTP port as well (which Grafana expects).
+Set the following to enable the streaming service over the HTTP port for use with Grafana:
 
 > **Note**: Enabling this setting is incompatible with TLS.
 
@@ -585,8 +586,8 @@ To enable the streaming service over the http port for use with Grafana set the 
 stream_over_http_enabled: true
 ```
 
-The below `rpc` call returns only traces that are new or have updated each time `SearchResponse` is returned except for the last response. The
-final response sent is guaranteed to have the entire resultset.
+The below `rpc` call returns only traces that are new or have updated each time `SearchResponse` is returned, except for the last response.
+The final response sent is guaranteed to have the entire resultset.
 
 
 ```protobuf

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -19,6 +19,7 @@ This document explains the configuration options for Tempo as well as the detail
   - [Metrics-generator](#metrics-generator)
   - [Query-frontend](#query-frontend)
   - [Querier](#querier)
+  - [GRPC streaming](#grpc-streaming)
   - [Compactor](#compactor)
   - [Storage](#storage)
     - [Local storage recommendations](#local-storage-recommendations)
@@ -555,6 +556,17 @@ querier:
 
 It also queries compacted blocks that fall within the (2 * BlocklistPoll) range where the value of Blocklist poll duration
 is defined in the storage section below.
+
+## GRPC streaming
+
+Tempo has a [GRPC streaming](https://grpc.io/docs/what-is-grpc/core-concepts/#bidirectional-streaming-rpc) endpoint in Tempo’s query frontend that allows a client to stream search results from Tempo.
+The Tempo CLI also uses this new streaming endpoint.
+
+{{% admonition type="note" %}}
+As of version 10.1, Grafana supports GRPC streaming by enabling the `traceQLStreaming` feature toggle.
+{{% /admonition %}}
+
+For configuration instructions and more information, refer to the [Tempo GRPC API documentation]({{< relref "../api_docs#tempo-grpc-api" >}}).
 
 ## Compactor
 
@@ -1241,7 +1253,7 @@ overrides:
 
   # Global ingestion limits configurations
   defaults:
-    
+
     # Ingestion related overrides
     ingestion:
 
@@ -1269,11 +1281,11 @@ overrides:
       #    per-user traces limit (local: 10000 global: 0 actual local: 1) exceeded
       # This override limit is used by the ingester.
       [max_traces_per_user: <int> | default = 10000]
-      
+
       # Maximum number of active traces per user, across the cluster.
       # A value of 0 disables the check.
       [max_global_traces_per_user: <int> | default = 0]
-      
+
     # Read related overrides
     read:
       # Maximum size in bytes of a tag-values query. Tag-values query is used mainly
@@ -1293,13 +1305,13 @@ overrides:
       # Per-user max search duration. If this value is set to 0 (default), then max_duration
       #  in the front-end configuration is used.
       [max_search_duration: <duration> | default = 0s]
-    
+
     # Compaction related overrides
     compaction:
       # Per-user block retention. If this value is set to 0 (default),
       # then block_retention in the compactor configuration is used.
       [block_retention: <duration> | default = 0s]
-      
+
     # Metrics-generator related overrides
     metrics_generator:
 
@@ -1352,10 +1364,10 @@ overrides:
         # The length of the queue and the amount of workers pulling from the queue can be configured.
         [queue_size: <int> | default = 100]
         [workers: <int> | default = 2]
-      
+
       # Per processor configuration
       processor:
-        
+
         # Configuration for the service-graphs processor
         service_graphs:
           [histogram_buckets: <list of float>]
@@ -1371,7 +1383,7 @@ overrides:
           [intrinsic_dimensions: <map string to bool>]
           [filter_policies: [
             [
-              include/exclude: 
+              include/exclude:
                 match_type: <string> # options: strict, regexp
                 attributes:
                   - key: <string>
@@ -1392,13 +1404,13 @@ overrides:
           [flush_check_period: <duration>]
           [trace_idle_period: <duration>]
           [complete_block_timeout: <duration>]
-      
+
     # Generic forwarding configuration
 
     # Per-user configuration of generic forwarder feature. Each forwarder in the list
     # must refer by name to a forwarder defined in the distributor.forwarders configuration.
     forwarders: <list of string>
-      
+
     # Global enforced overrides
     global:
       # Maximum size of a single trace in bytes.  A value of 0 disables the size

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -18,8 +18,8 @@ This document explains the configuration options for Tempo as well as the detail
   - [Ingester](#ingester)
   - [Metrics-generator](#metrics-generator)
   - [Query-frontend](#query-frontend)
+    - [GRPC streaming](#grpc-streaming)
   - [Querier](#querier)
-  - [GRPC streaming](#grpc-streaming)
   - [Compactor](#compactor)
   - [Storage](#storage)
     - [Local storage recommendations](#local-storage-recommendations)
@@ -480,6 +480,13 @@ query_frontend:
         [duration_slo: <duration> | default = 0s ]
 ```
 
+### GRPC streaming
+
+Tempo has a [GRPC streaming](https://grpc.io/docs/what-is-grpc/core-concepts/#bidirectional-streaming-rpc) endpoint in Tempo’s query frontend that allows a client to stream search results from Tempo.
+The Tempo CLI also uses this new streaming endpoint.
+
+For configuration instructions, refer to the [Tempo GRPC API documentation]({{< relref "../api_docs#tempo-grpc-api" >}}).
+
 ## Querier
 
 For more information on configuration options, see [here](https://github.com/grafana/tempo/blob/main/modules/querier/config.go).
@@ -556,17 +563,6 @@ querier:
 
 It also queries compacted blocks that fall within the (2 * BlocklistPoll) range where the value of Blocklist poll duration
 is defined in the storage section below.
-
-## GRPC streaming
-
-Tempo has a [GRPC streaming](https://grpc.io/docs/what-is-grpc/core-concepts/#bidirectional-streaming-rpc) endpoint in Tempo’s query frontend that allows a client to stream search results from Tempo.
-The Tempo CLI also uses this new streaming endpoint.
-
-{{% admonition type="note" %}}
-As of version 10.1, Grafana supports GRPC streaming by enabling the `traceQLStreaming` feature toggle.
-{{% /admonition %}}
-
-For configuration instructions and more information, refer to the [Tempo GRPC API documentation]({{< relref "../api_docs#tempo-grpc-api" >}}).
 
 ## Compactor
 

--- a/docs/sources/tempo/getting-started/tempo-in-grafana.md
+++ b/docs/sources/tempo/getting-started/tempo-in-grafana.md
@@ -22,6 +22,17 @@ For details about how queries are constructed, read the [TraceQL documentation](
 
 <p align="center"><img src="../../traceql/assets/query-editor-results-span.png" alt="Query editor showing span results" /></p>
 
+
+### Stream search results while a query is executing
+
+Tempo's GPRC streaming endpoint provides faster TraceQL results.
+Added to Tempo's query frontend, this endpoint allows a client to stream search results from Tempo.
+
+By streaming results to the client, you can start to look at traces matching your query before the entire query completes.
+This is particularly helpful for long-running queries; while the total time to complete the query is the same, you can start looking at your first matches before the full set of matched traces is returned.
+
+Grafana 10.1 and later support this streaming endpoint by [enabling the `traceQLStreaming` feature toggle](/docs/grafana/latest/setup-grafana/configure-grafana#feature_toggles).
+
 ## View trace by ID
 
 The most basic functionality is to visualize a trace using its ID.  Select the Trace ID tab and enter the ID to view it. This functionality is enabled by default and is available in all versions of Grafana.


### PR DESCRIPTION
**What this PR does**:

Adds pointers to the streaming endpoint documentation in the configuration and Tempo in Grafana documentation. 

Anyone reviewing: 
* Please verify that the information in the configuration section is correct. 
* Anyone have a great screenshot we could include? 

Update the content in this PR to address the websocket work - https://github.com/grafana/tempo/issues/2917 

FYI: @stoewer 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`