### PR TITLE
Adjust exceeds max trace size message to remove trace size

### DIFF
--- a/pkg/model/trace/combine.go
+++ b/pkg/model/trace/combine.go
@@ -138,7 +138,7 @@ func (c *Combiner) sizeError() error {
 	}
 
 	if c.result.Size() > c.maxSizeBytes {
-		return fmt.Errorf("%w (%d bytes)", ErrTraceTooLarge, c.maxSizeBytes)
+		return fmt.Errorf("%w (max bytes: %d)", ErrTraceTooLarge, c.maxSizeBytes)
 	}
 
 	return nil

--- a/pkg/model/trace/combine.go
+++ b/pkg/model/trace/combine.go
@@ -138,7 +138,7 @@ func (c *Combiner) sizeError() error {
 	}
 
 	if c.result.Size() > c.maxSizeBytes {
-		return fmt.Errorf("%w (%d > %d)", ErrTraceTooLarge, c.result.Size(), c.maxSizeBytes)
+		return fmt.Errorf("%w (%d bytes)", ErrTraceTooLarge, c.maxSizeBytes)
 	}
 
 	return nil

--- a/tempodb/encoding/vparquet3/block_findtracebyid.go
+++ b/tempodb/encoding/vparquet3/block_findtracebyid.go
@@ -254,7 +254,7 @@ func findTraceByID(ctx context.Context, traceID common.ID, maxTraceSizeBytes int
 	if maxTraceSizeBytes > 0 {
 		estimatedSize := estimateMarshalledSizeFromTrace(tr)
 		if estimatedSize > maxTraceSizeBytes {
-			return nil, errors.Errorf("trace exceeds max size in the block. size: %d, max: %d", estimatedSize, maxTraceSizeBytes)
+			return nil, errors.Errorf("trace exceeds max size in the block. (%d bytes)", maxTraceSizeBytes)
 		}
 	}
 

--- a/tempodb/encoding/vparquet3/block_findtracebyid.go
+++ b/tempodb/encoding/vparquet3/block_findtracebyid.go
@@ -254,7 +254,7 @@ func findTraceByID(ctx context.Context, traceID common.ID, maxTraceSizeBytes int
 	if maxTraceSizeBytes > 0 {
 		estimatedSize := estimateMarshalledSizeFromTrace(tr)
 		if estimatedSize > maxTraceSizeBytes {
-			return nil, errors.Errorf("trace exceeds max size in the block. (%d bytes)", maxTraceSizeBytes)
+			return nil, errors.Errorf("trace exceeds max size in the block. (max bytes: %d)", maxTraceSizeBytes)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does**:

Removes the trace size from the max trace size message. This value is misleading b/c it's not the actual full trace size. It will lead users to think that their traces are just barely over the limit (b/c we test on every combine) when they may be significantly larger.