### PR TITLE
metrics-generator disable x-scope-orgid header append

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [ENHANCEMENT] Add `target_info_excluded_dimensions` to user-config api [#2945](https://github.com/grafana/tempo/pull/2945) (@ie-pham)
 * [ENHANCEMENT] User-configurable overrides: add scope query parameter to return merged overrides for tenant [#2915](https://github.com/grafana/tempo/pull/2915) (@kvrhdn)
 * [ENHANCEMENT] Add histogram buckets to metrics-generator config in user-configurable overrides [#2928](https://github.com/grafana/tempo/pull/2928) (@mar4uk)
+* [ENHANCEMENT] metrics-generator disable x-scope-orgid header append [#2974](https://github.com/grafana/tempo/pull/2974) (@vineetjp)
 * [BUGFIX] Fix panic in metrics summary api [#2738](https://github.com/grafana/tempo/pull/2738) (@mdisibio)
 * [BUGFIX] Fix rare deadlock when uploading blocks to Azure Blob Storage [#2129](https://github.com/grafana/tempo/issues/2129) (@LasseHels)
 * [BUGFIX] Only search ingester blocks that fall within the request time range. [#2783](https://github.com/grafana/tempo/pull/2783) (@joe-elliott)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 * [ENHANCEMENT] Add `target_info_excluded_dimensions` to user-config api [#2945](https://github.com/grafana/tempo/pull/2945) (@ie-pham)
 * [ENHANCEMENT] User-configurable overrides: add scope query parameter to return merged overrides for tenant [#2915](https://github.com/grafana/tempo/pull/2915) (@kvrhdn)
 * [ENHANCEMENT] Add histogram buckets to metrics-generator config in user-configurable overrides [#2928](https://github.com/grafana/tempo/pull/2928) (@mar4uk)
-* [ENHANCEMENT] metrics-generator disable x-scope-orgid header append [#2974](https://github.com/grafana/tempo/pull/2974) (@vineetjp)
+* [ENHANCEMENT] added a metrics generator config option to enable/disable X-Scope-OrgID headers on remote write. [#2974](https://github.com/grafana/tempo/pull/2974) (@vineetjp)
 * [BUGFIX] Fix panic in metrics summary api [#2738](https://github.com/grafana/tempo/pull/2738) (@mdisibio)
 * [BUGFIX] Fix rare deadlock when uploading blocks to Azure Blob Storage [#2129](https://github.com/grafana/tempo/issues/2129) (@LasseHels)
 * [BUGFIX] Only search ingester blocks that fall within the request time range. [#2783](https://github.com/grafana/tempo/pull/2783) (@joe-elliott)

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -376,6 +376,9 @@ metrics_generator:
         # How long to wait when flushing samples on shutdown
         [remote_write_flush_deadline: <duration> | default = 1m]
 
+        # Whether to remove X-Scope-OrgID header in remote write requests
+        [remote_write_remove_org_id_header: <bool> | default = false]
+
         # A list of remote write endpoints.
         # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
         remote_write:

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -376,8 +376,8 @@ metrics_generator:
         # How long to wait when flushing samples on shutdown
         [remote_write_flush_deadline: <duration> | default = 1m]
 
-        # Whether to remove X-Scope-OrgID header in remote write requests
-        [remote_write_remove_org_id_header: <bool> | default = false]
+        # Whether to add X-Scope-OrgID header in remote write requests
+        [remote_write_add_org_id_header: <bool> | default = true]
 
         # A list of remote write endpoints.
         # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write

--- a/docs/sources/tempo/metrics-generator/_index.md
+++ b/docs/sources/tempo/metrics-generator/_index.md
@@ -57,4 +57,4 @@ The `remote_write` endpoint is configurable and can be any [Prometheus-compatibl
 To learn more about the endpoint configuration, refer to the [Metrics-generator]({{< relref "../configuration#metrics-generator" >}}) section of the Tempo Configuration documentation.
 Writing interval can be controlled via `metrics_generator.registry.collection_interval`.
 
-When multi-tenancy is enabled, the metrics-generator forwards the `X-Scope-OrgID` header of the original request to the `remote_write` endpoint.
+When multi-tenancy is enabled, the metrics-generator forwards the `X-Scope-OrgID` header of the original request to the `remote_write` endpoint. This feature can be disabled by setting `remote_write_add_org_id_header` to false.

--- a/modules/generator/storage/config.go
+++ b/modules/generator/storage/config.go
@@ -17,6 +17,9 @@ type Config struct {
 	// How long to wait when flushing sample on shutdown
 	RemoteWriteFlushDeadline time.Duration `yaml:"remote_write_flush_deadline"`
 
+	// Add X-Scope-OrgID header in remote write requests
+	RemoteWriteRemoveOrgIDHeader bool `yaml:"remote_write_remove_org_id_header,omitempty"`
+
 	// Prometheus remote write config
 	// https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
 	RemoteWrite []prometheus_config.RemoteWriteConfig `yaml:"remote_write,omitempty"`

--- a/modules/generator/storage/config.go
+++ b/modules/generator/storage/config.go
@@ -18,7 +18,7 @@ type Config struct {
 	RemoteWriteFlushDeadline time.Duration `yaml:"remote_write_flush_deadline"`
 
 	// Add X-Scope-OrgID header in remote write requests
-	RemoteWriteAddOrgIDHeader *bool `yaml:"remote_write_add_org_id_header,omitempty"`
+	RemoteWriteAddOrgIDHeader bool `yaml:"remote_write_add_org_id_header,omitempty"`
 
 	// Prometheus remote write config
 	// https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
@@ -29,6 +29,8 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {
 	cfg.Wal = agentDefaultOptions()
 
 	cfg.RemoteWriteFlushDeadline = time.Minute
+
+	cfg.RemoteWriteAddOrgIDHeader = true
 }
 
 // agentOptions is a copy of agent.Options but with yaml struct tags. Refer to agent.Options for

--- a/modules/generator/storage/config.go
+++ b/modules/generator/storage/config.go
@@ -18,7 +18,7 @@ type Config struct {
 	RemoteWriteFlushDeadline time.Duration `yaml:"remote_write_flush_deadline"`
 
 	// Add X-Scope-OrgID header in remote write requests
-	RemoteWriteRemoveOrgIDHeader bool `yaml:"remote_write_remove_org_id_header,omitempty"`
+	RemoteWriteAddOrgIDHeader *bool `yaml:"remote_write_add_org_id_header,omitempty"`
 
 	// Prometheus remote write config
 	// https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write

--- a/modules/generator/storage/config_test.go
+++ b/modules/generator/storage/config_test.go
@@ -41,9 +41,10 @@ remote_write:
 	}
 
 	expectedCfg := Config{
-		Path:                     "/var/wal/tempo",
-		Wal:                      walCfg,
-		RemoteWriteFlushDeadline: 5 * time.Minute,
+		Path:                      "/var/wal/tempo",
+		Wal:                       walCfg,
+		RemoteWriteFlushDeadline:  5 * time.Minute,
+		RemoteWriteAddOrgIDHeader: true,
 		RemoteWrite: []prometheus_config.RemoteWriteConfig{
 			remoteWriteConfig,
 		},

--- a/modules/generator/storage/config_util.go
+++ b/modules/generator/storage/config_util.go
@@ -21,7 +21,7 @@ func generateTenantRemoteWriteConfigs(originalCfgs []prometheus_config.RemoteWri
 		*cloneCfg = originalCfg
 
 		// Inject/overwrite X-Scope-OrgID header in multi-tenant setups
-		if tenant != util.FakeTenantID {
+		if tenant != util.FakeTenantID && addOrgIDHeader {
 			// Copy headers so we can modify them
 			cloneCfg.Headers = copyMap(cloneCfg.Headers)
 
@@ -33,9 +33,7 @@ func generateTenantRemoteWriteConfigs(originalCfgs []prometheus_config.RemoteWri
 				}
 			}
 
-			if addOrgIDHeader {
-				cloneCfg.Headers[user.OrgIDHeaderName] = tenant
-			}
+			cloneCfg.Headers[user.OrgIDHeaderName] = tenant
 		}
 
 		cloneCfgs = append(cloneCfgs, cloneCfg)

--- a/modules/generator/storage/config_util.go
+++ b/modules/generator/storage/config_util.go
@@ -12,8 +12,8 @@ import (
 )
 
 // generateTenantRemoteWriteConfigs creates a copy of the remote write configurations with the
-// X-Scope-OrgID header present for the given tenant, unless Tempo is run in single tenant mode.
-func generateTenantRemoteWriteConfigs(originalCfgs []prometheus_config.RemoteWriteConfig, tenant string, logger log.Logger) []*prometheus_config.RemoteWriteConfig {
+// X-Scope-OrgID header present for the given tenant, unless Tempo is run in single tenant mode or instructed to remove X-Scope-OrgID header.
+func generateTenantRemoteWriteConfigs(originalCfgs []prometheus_config.RemoteWriteConfig, tenant string, removeOrgIDHeader bool, logger log.Logger) []*prometheus_config.RemoteWriteConfig {
 	var cloneCfgs []*prometheus_config.RemoteWriteConfig
 
 	for _, originalCfg := range originalCfgs {
@@ -34,6 +34,15 @@ func generateTenantRemoteWriteConfigs(originalCfgs []prometheus_config.RemoteWri
 			}
 
 			cloneCfg.Headers[user.OrgIDHeaderName] = tenant
+		}
+
+		if removeOrgIDHeader {
+			for k, v := range cloneCfg.Headers {
+				if strings.EqualFold(user.OrgIDHeaderName, strings.TrimSpace(k)) {
+					level.Warn(logger).Log("msg", "Removing X-Scope-OrgId header", "key", k, "value", v)
+					delete(cloneCfg.Headers, k)
+				}
+			}
 		}
 
 		cloneCfgs = append(cloneCfgs, cloneCfg)

--- a/modules/generator/storage/config_util.go
+++ b/modules/generator/storage/config_util.go
@@ -13,13 +13,8 @@ import (
 
 // generateTenantRemoteWriteConfigs creates a copy of the remote write configurations with the
 // X-Scope-OrgID header present for the given tenant, unless Tempo is run in single tenant mode or instructed not to add X-Scope-OrgID header.
-func generateTenantRemoteWriteConfigs(originalCfgs []prometheus_config.RemoteWriteConfig, tenant string, addOrgIDHeader *bool, logger log.Logger) []*prometheus_config.RemoteWriteConfig {
+func generateTenantRemoteWriteConfigs(originalCfgs []prometheus_config.RemoteWriteConfig, tenant string, addOrgIDHeader bool, logger log.Logger) []*prometheus_config.RemoteWriteConfig {
 	var cloneCfgs []*prometheus_config.RemoteWriteConfig
-
-	if addOrgIDHeader == nil {
-		addHeader := true
-		addOrgIDHeader = &addHeader
-	}
 
 	for _, originalCfg := range originalCfgs {
 		cloneCfg := &prometheus_config.RemoteWriteConfig{}
@@ -38,7 +33,7 @@ func generateTenantRemoteWriteConfigs(originalCfgs []prometheus_config.RemoteWri
 				}
 			}
 
-			if *addOrgIDHeader {
+			if addOrgIDHeader {
 				cloneCfg.Headers[user.OrgIDHeaderName] = tenant
 			}
 		}

--- a/modules/generator/storage/config_util_test.go
+++ b/modules/generator/storage/config_util_test.go
@@ -15,7 +15,6 @@ import (
 
 func Test_generateTenantRemoteWriteConfigs(t *testing.T) {
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
-	removeOrgID := false
 
 	original := []prometheus_config.RemoteWriteConfig{
 		{
@@ -31,7 +30,7 @@ func Test_generateTenantRemoteWriteConfigs(t *testing.T) {
 		},
 	}
 
-	result := generateTenantRemoteWriteConfigs(original, "my-tenant", removeOrgID, logger)
+	result := generateTenantRemoteWriteConfigs(original, "my-tenant", nil, logger)
 
 	assert.Equal(t, original[0].URL, result[0].URL)
 	assert.Equal(t, map[string]string{}, original[0].Headers, "Original headers have been modified")
@@ -44,7 +43,6 @@ func Test_generateTenantRemoteWriteConfigs(t *testing.T) {
 
 func Test_generateTenantRemoteWriteConfigs_singleTenant(t *testing.T) {
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
-	removeOrgID := false
 
 	original := []prometheus_config.RemoteWriteConfig{
 		{
@@ -59,7 +57,7 @@ func Test_generateTenantRemoteWriteConfigs_singleTenant(t *testing.T) {
 		},
 	}
 
-	result := generateTenantRemoteWriteConfigs(original, util.FakeTenantID, removeOrgID, logger)
+	result := generateTenantRemoteWriteConfigs(original, util.FakeTenantID, nil, logger)
 
 	assert.Equal(t, original[0].URL, result[0].URL)
 
@@ -74,9 +72,9 @@ func Test_generateTenantRemoteWriteConfigs_singleTenant(t *testing.T) {
 	assert.Equal(t, map[string]string{"x-scope-orgid": "my-custom-tenant-id"}, result[1].Headers)
 }
 
-func Test_generateTenantRemoteWriteConfigs_removeOrgIDHeader(t *testing.T) {
+func Test_generateTenantRemoteWriteConfigs_addOrgIDHeader(t *testing.T) {
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
-	removeOrgID := true
+	addOrgID := false
 
 	original := []prometheus_config.RemoteWriteConfig{
 		{
@@ -92,10 +90,10 @@ func Test_generateTenantRemoteWriteConfigs_removeOrgIDHeader(t *testing.T) {
 		},
 	}
 
-	result := generateTenantRemoteWriteConfigs(original, "my-tenant", removeOrgID, logger)
+	result := generateTenantRemoteWriteConfigs(original, "my-tenant", &addOrgID, logger)
 
 	assert.Equal(t, original[0].URL, result[0].URL)
-	assert.Empty(t, original[0].Headers, "X-Scope-OrgID header have been dropped")
+	assert.Empty(t, original[0].Headers, "X-Scope-OrgID header is not added")
 
 	assert.Equal(t, original[1].URL, result[1].URL)
 	assert.Equal(t, map[string]string{"foo": "bar"}, result[1].Headers, "Original headers have been modified")

--- a/modules/generator/storage/config_util_test.go
+++ b/modules/generator/storage/config_util_test.go
@@ -30,7 +30,9 @@ func Test_generateTenantRemoteWriteConfigs(t *testing.T) {
 		},
 	}
 
-	result := generateTenantRemoteWriteConfigs(original, "my-tenant", nil, logger)
+	addOrgIDHeader := true
+
+	result := generateTenantRemoteWriteConfigs(original, "my-tenant", addOrgIDHeader, logger)
 
 	assert.Equal(t, original[0].URL, result[0].URL)
 	assert.Equal(t, map[string]string{}, original[0].Headers, "Original headers have been modified")
@@ -57,7 +59,9 @@ func Test_generateTenantRemoteWriteConfigs_singleTenant(t *testing.T) {
 		},
 	}
 
-	result := generateTenantRemoteWriteConfigs(original, util.FakeTenantID, nil, logger)
+	addOrgIDHeader := true
+
+	result := generateTenantRemoteWriteConfigs(original, util.FakeTenantID, addOrgIDHeader, logger)
 
 	assert.Equal(t, original[0].URL, result[0].URL)
 
@@ -74,7 +78,6 @@ func Test_generateTenantRemoteWriteConfigs_singleTenant(t *testing.T) {
 
 func Test_generateTenantRemoteWriteConfigs_addOrgIDHeader(t *testing.T) {
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
-	addOrgID := false
 
 	original := []prometheus_config.RemoteWriteConfig{
 		{
@@ -90,7 +93,9 @@ func Test_generateTenantRemoteWriteConfigs_addOrgIDHeader(t *testing.T) {
 		},
 	}
 
-	result := generateTenantRemoteWriteConfigs(original, "my-tenant", &addOrgID, logger)
+	addOrgIDHeader := false
+
+	result := generateTenantRemoteWriteConfigs(original, "my-tenant", addOrgIDHeader, logger)
 
 	assert.Equal(t, original[0].URL, result[0].URL)
 	assert.Empty(t, original[0].Headers, "X-Scope-OrgID header is not added")

--- a/modules/generator/storage/config_util_test.go
+++ b/modules/generator/storage/config_util_test.go
@@ -101,7 +101,7 @@ func Test_generateTenantRemoteWriteConfigs_addOrgIDHeader(t *testing.T) {
 	assert.Empty(t, original[0].Headers, "X-Scope-OrgID header is not added")
 
 	assert.Equal(t, original[1].URL, result[1].URL)
-	assert.Equal(t, map[string]string{"foo": "bar"}, result[1].Headers, "Original headers have been modified")
+	assert.Equal(t, map[string]string{"foo": "bar", "x-scope-orgid": "fake-tenant"}, result[1].Headers, "Original headers not modified")
 }
 
 func Test_copyMap(t *testing.T) {

--- a/modules/generator/storage/instance.go
+++ b/modules/generator/storage/instance.go
@@ -59,7 +59,7 @@ func New(cfg *Config, tenant string, reg prometheus.Registerer, logger log.Logge
 	remoteStorage := remote.NewStorage(log.With(logger, "component", "remote"), reg, startTimeCallback, walDir, cfg.RemoteWriteFlushDeadline, &noopScrapeManager{})
 
 	remoteStorageConfig := &prometheus_config.Config{
-		RemoteWriteConfigs: generateTenantRemoteWriteConfigs(cfg.RemoteWrite, tenant, cfg.RemoteWriteRemoveOrgIDHeader, logger),
+		RemoteWriteConfigs: generateTenantRemoteWriteConfigs(cfg.RemoteWrite, tenant, cfg.RemoteWriteAddOrgIDHeader, logger),
 	}
 
 	err = remoteStorage.ApplyConfig(remoteStorageConfig)

--- a/modules/generator/storage/instance.go
+++ b/modules/generator/storage/instance.go
@@ -59,7 +59,7 @@ func New(cfg *Config, tenant string, reg prometheus.Registerer, logger log.Logge
 	remoteStorage := remote.NewStorage(log.With(logger, "component", "remote"), reg, startTimeCallback, walDir, cfg.RemoteWriteFlushDeadline, &noopScrapeManager{})
 
 	remoteStorageConfig := &prometheus_config.Config{
-		RemoteWriteConfigs: generateTenantRemoteWriteConfigs(cfg.RemoteWrite, tenant, logger),
+		RemoteWriteConfigs: generateTenantRemoteWriteConfigs(cfg.RemoteWrite, tenant, cfg.RemoteWriteRemoveOrgIDHeader, logger),
 	}
 
 	err = remoteStorage.ApplyConfig(remoteStorageConfig)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds option to disable addition of X-Scope-OrgID header in metrics generator with remote writing
**Which issue(s) this PR fixes**:
Fixes #1554

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`