### PR TITLE
Put span-level iters before span attr-level iters

### DIFF
--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -992,6 +992,10 @@ func createSpanIterator(makeIter makeIterFn, primaryIter parquetquery.Iterator, 
 		genericConditions = append(genericConditions, cond)
 	}
 
+	for columnPath, predicates := range columnPredicates {
+		iters = append(iters, makeIter(columnPath, parquetquery.NewOrPredicate(predicates...), columnSelectAs[columnPath]))
+	}
+
 	attrIter, err := createAttributeIterator(makeIter, genericConditions, DefinitionLevelResourceSpansILSSpanAttrs,
 		columnPathSpanAttrKey, columnPathSpanAttrString, columnPathSpanAttrInt, columnPathSpanAttrDouble, columnPathSpanAttrBool, allConditions)
 	if err != nil {
@@ -999,10 +1003,6 @@ func createSpanIterator(makeIter makeIterFn, primaryIter parquetquery.Iterator, 
 	}
 	if attrIter != nil {
 		iters = append(iters, attrIter)
-	}
-
-	for columnPath, predicates := range columnPredicates {
-		iters = append(iters, makeIter(columnPath, parquetquery.NewOrPredicate(predicates...), columnSelectAs[columnPath]))
 	}
 
 	var required []parquetquery.Iterator

--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -519,11 +519,13 @@ func BenchmarkBackendBlockTraceQL(b *testing.B) {
 	ctx := context.TODO()
 	tenantID := "1"
 	// blockID := uuid.MustParse("000d37d0-1e66-4f4e-bbd4-f85c1deb6e5e")
-	blockID := uuid.MustParse("06ebd383-8d4e-4289-b0e9-cf2197d611d5")
+	//blockID := uuid.MustParse("06ebd383-8d4e-4289-b0e9-cf2197d611d5")
+	blockID := uuid.MustParse("0008e57d-069d-4510-a001-b9433b2da08c")
 
 	r, _, _, err := local.New(&local.Config{
 		// Path: path.Join("/home/joe/testblock/"),
-		Path: path.Join("/Users/marty/src/tmp"),
+		//Path: path.Join("/Users/marty/src/tmp"),
+		Path: path.Join("/Users/mapno/workspace/testblock"),
 	})
 	require.NoError(b, err)
 

--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -519,12 +519,12 @@ func BenchmarkBackendBlockTraceQL(b *testing.B) {
 	ctx := context.TODO()
 	tenantID := "1"
 	// blockID := uuid.MustParse("000d37d0-1e66-4f4e-bbd4-f85c1deb6e5e")
-	//blockID := uuid.MustParse("06ebd383-8d4e-4289-b0e9-cf2197d611d5")
+	// blockID := uuid.MustParse("06ebd383-8d4e-4289-b0e9-cf2197d611d5")
 	blockID := uuid.MustParse("0008e57d-069d-4510-a001-b9433b2da08c")
 
 	r, _, _, err := local.New(&local.Config{
 		// Path: path.Join("/home/joe/testblock/"),
-		//Path: path.Join("/Users/marty/src/tmp"),
+		// Path: path.Join("/Users/marty/src/tmp"),
 		Path: path.Join("/Users/mapno/workspace/testblock"),
 	})
 	require.NoError(b, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Matches span-level conditions before span attribute-level conditions, which are cheaper to read.


```
                                                    │   old.txt    │               new.txt                │
                                                    │    sec/op    │    sec/op     vs base                │
BackendBlockTraceQL/spanAttNameNoMatch-12             26.35m ±  0%   26.24m ±  0%   -0.41% (p=0.005 n=10)
BackendBlockTraceQL/spanAttValNoMatch-12              30.13m ±  0%   30.07m ±  0%        ~ (p=0.315 n=10)
BackendBlockTraceQL/spanAttValMatch-12                294.9m ±  0%   294.7m ±  3%        ~ (p=0.123 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-12        26.31m ±  0%   26.36m ±  0%   +0.19% (p=0.003 n=10)
BackendBlockTraceQL/spanAttIntrinsicMatch-12          166.0m ± 14%   142.7m ± 16%  -14.02% (p=0.043 n=10)
BackendBlockTraceQL/spanAttIntrinsicRegexNoMatch-12   26.70m ±  0%   26.74m ±  0%        ~ (p=0.105 n=10)
BackendBlockTraceQL/spanAttIntrinsicRegexMatch-12     195.9m ±  0%   196.1m ±  0%        ~ (p=0.912 n=10)
BackendBlockTraceQL/resourceAttNameNoMatch-12         25.76m ±  0%   25.80m ±  0%        ~ (p=0.315 n=10)
BackendBlockTraceQL/resourceAttValNoMatch-12          25.70m ±  0%   25.72m ±  0%        ~ (p=0.436 n=10)
BackendBlockTraceQL/resourceAttValMatch-12            49.18m ±  0%   49.26m ±  0%        ~ (p=0.315 n=10)
BackendBlockTraceQL/resourceAttIntrinsicNoMatch-12    25.50m ±  0%   25.56m ±  0%   +0.24% (p=0.029 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-12      107.7m ±  0%   107.7m ±  0%        ~ (p=0.393 n=10)
BackendBlockTraceQL/mixedNameNoMatch-12                1.981 ±  0%    1.985 ±  0%   +0.18% (p=0.009 n=10)
BackendBlockTraceQL/mixedValNoMatch-12                 1.587 ±  0%    1.581 ±  0%   -0.35% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd-12          25.78m ±  0%   25.77m ±  0%        ~ (p=0.481 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr-12            1.629 ±  0%    1.572 ±  4%   -3.53% (p=0.003 n=10)
BackendBlockTraceQL/mixedValBothMatch-12              25.50m ±  0%   25.51m ±  0%        ~ (p=0.796 n=10)
BackendBlockTraceQL/count-12                           3.310 ±  0%    3.310 ±  0%        ~ (p=0.684 n=10)
BackendBlockTraceQL/desc-12                            4.743 ±  0%    4.662 ±  2%        ~ (p=0.075 n=10)
geomean                                               133.8m         132.4m         -1.06%

                                                    │    old.txt    │                new.txt                │
                                                    │      B/s      │      B/s       vs base                │
BackendBlockTraceQL/spanAttNameNoMatch-12             416.5Mi ±  0%   418.2Mi ±  0%   +0.41% (p=0.006 n=10)
BackendBlockTraceQL/spanAttValNoMatch-12              425.0Mi ±  0%   425.8Mi ±  0%        ~ (p=0.315 n=10)
BackendBlockTraceQL/spanAttValMatch-12                54.61Mi ±  0%   54.66Mi ±  3%        ~ (p=0.127 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-12        499.0Mi ±  0%   498.1Mi ±  0%   -0.18% (p=0.003 n=10)
BackendBlockTraceQL/spanAttIntrinsicMatch-12          368.4Mi ± 16%   428.5Mi ± 14%  +16.31% (p=0.043 n=10)
BackendBlockTraceQL/spanAttIntrinsicRegexNoMatch-12   491.6Mi ±  0%   491.0Mi ±  0%        ~ (p=0.105 n=10)
BackendBlockTraceQL/spanAttIntrinsicRegexMatch-12     312.1Mi ±  0%   311.9Mi ±  0%        ~ (p=0.912 n=10)
BackendBlockTraceQL/resourceAttNameNoMatch-12         165.5Mi ±  0%   165.3Mi ±  0%        ~ (p=0.315 n=10)
BackendBlockTraceQL/resourceAttValNoMatch-12          161.8Mi ±  0%   161.7Mi ±  0%        ~ (p=0.403 n=10)
BackendBlockTraceQL/resourceAttValMatch-12            435.4Mi ±  0%   434.7Mi ±  0%        ~ (p=0.315 n=10)
BackendBlockTraceQL/resourceAttIntrinsicNoMatch-12    190.4Mi ±  0%   189.9Mi ±  0%   -0.24% (p=0.022 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-12      647.9Mi ±  0%   647.6Mi ±  0%        ~ (p=0.393 n=10)
BackendBlockTraceQL/mixedNameNoMatch-12               12.32Mi ±  0%   12.29Mi ±  0%   -0.23% (p=0.010 n=10)
BackendBlockTraceQL/mixedValNoMatch-12                15.37Mi ±  0%   15.43Mi ±  0%   +0.34% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd-12          165.4Mi ±  0%   165.5Mi ±  0%        ~ (p=0.469 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr-12           40.77Mi ±  0%   42.26Mi ±  3%   +3.65% (p=0.002 n=10)
BackendBlockTraceQL/mixedValBothMatch-12              190.4Mi ±  0%   190.3Mi ±  0%        ~ (p=0.781 n=10)
BackendBlockTraceQL/count-12                          41.12Mi ±  0%   41.13Mi ±  0%        ~ (p=0.617 n=10)
BackendBlockTraceQL/desc-12                           33.04Mi ±  0%   33.63Mi ±  2%        ~ (p=0.065 n=10)
geomean                                               145.8Mi         147.4Mi         +1.07%
```