### PR TITLE
Metrics Generator - local blocks dedicated columns

### DIFF
--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -434,8 +434,9 @@ func (d *Distributor) sendToGenerators(ctx context.Context, userID string, keys 
 		metricGeneratorPushes.WithLabelValues(generator.Addr).Inc()
 		if err != nil {
 			metricGeneratorPushesFailures.WithLabelValues(generator.Addr).Inc()
+			return fmt.Errorf("failed to push spans to generator: %w", err)
 		}
-		return fmt.Errorf("failed to push spans to generator: %w", err)
+		return nil
 	}, func() {})
 
 	return err

--- a/modules/generator/instance.go
+++ b/modules/generator/instance.go
@@ -294,7 +294,7 @@ func (i *instance) addProcessor(processorName string, cfg ProcessorConfig) error
 	case servicegraphs.Name:
 		newProcessor = servicegraphs.New(cfg.ServiceGraphs, i.instanceID, i.registry, i.logger)
 	case localblocks.Name:
-		p, err := localblocks.New(cfg.LocalBlocks, i.instanceID, i.traceWAL)
+		p, err := localblocks.New(cfg.LocalBlocks, i.instanceID, i.traceWAL, i.overrides)
 		if err != nil {
 			return err
 		}

--- a/modules/generator/overrides.go
+++ b/modules/generator/overrides.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/pkg/sharedconfig"
 	filterconfig "github.com/grafana/tempo/pkg/spanfilter/config"
+	"github.com/grafana/tempo/tempodb/backend"
 )
 
 type metricsGeneratorOverrides interface {
@@ -31,6 +32,7 @@ type metricsGeneratorOverrides interface {
 	MetricsGeneratorProcessorSpanMetricsEnableTargetInfo(userID string) bool
 	MetricsGeneratorProcessorServiceGraphsEnableClientServerPrefix(userID string) bool
 	MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(userID string) []string
+	DedicatedColumns(userID string) backend.DedicatedColumns
 }
 
 var _ metricsGeneratorOverrides = (overrides.Interface)(nil)

--- a/modules/generator/overrides_test.go
+++ b/modules/generator/overrides_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/tempo/pkg/sharedconfig"
 	filterconfig "github.com/grafana/tempo/pkg/spanfilter/config"
+	"github.com/grafana/tempo/tempodb/backend"
 )
 
 type mockOverrides struct {
@@ -26,6 +27,7 @@ type mockOverrides struct {
 	localBlocksFlushCheckPeriod             time.Duration
 	localBlocksTraceIdlePeriod              time.Duration
 	localBlocksCompleteBlockTimeout         time.Duration
+	dedicatedColumns                        backend.DedicatedColumns
 }
 
 var _ metricsGeneratorOverrides = (*mockOverrides)(nil)
@@ -118,4 +120,8 @@ func (m *mockOverrides) MetricsGeneratorProcessorServiceGraphsEnableClientServer
 
 func (m *mockOverrides) MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(string) []string {
 	return m.spanMetricsTargetInfoExcludedDimensions
+}
+
+func (m *mockOverrides) DedicatedColumns(string) backend.DedicatedColumns {
+	return m.dedicatedColumns
 }


### PR DESCRIPTION
**What this PR does**:
Adds the necessary plumbing so that the generator local blocks processor (and the metrics summary api) honors any per-tenant parquet dedicated columns in the overrides.  Also fixed the local blocks processor to honor the block version setting (instead of always using DefaultEncoding())

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`