### PR TITLE
Fix error returns that didn't check `err != nil`

### DIFF
--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -434,8 +434,9 @@ func (d *Distributor) sendToGenerators(ctx context.Context, userID string, keys 
 		metricGeneratorPushes.WithLabelValues(generator.Addr).Inc()
 		if err != nil {
 			metricGeneratorPushesFailures.WithLabelValues(generator.Addr).Inc()
+			return fmt.Errorf("failed to push spans to generator: %w", err)
 		}
-		return fmt.Errorf("failed to push spans to generator: %w", err)
+		return nil
 	}, func() {})
 
 	return err

--- a/tempodb/backend/azure/azure.go
+++ b/tempodb/backend/azure/azure.go
@@ -55,5 +55,8 @@ func readError(err error) error {
 		return backend.ErrDoesNotExist
 	}
 
-	return fmt.Errorf("reading Azure blob container: %w", err)
+	if err != nil {
+		return fmt.Errorf("reading Azure blob container: %w", err)
+	}
+	return nil
 }

--- a/tempodb/backend/azure/v1/v1.go
+++ b/tempodb/backend/azure/v1/v1.go
@@ -392,5 +392,9 @@ func readError(err error) error {
 	if storageError.ServiceCode() == blob.ServiceCodeBlobNotFound {
 		return backend.ErrDoesNotExist
 	}
-	return fmt.Errorf("reading Azure blob container: %w", storageError)
+
+	if err != nil {
+		return fmt.Errorf("reading Azure blob container: %w", storageError)
+	}
+	return nil
 }

--- a/tempodb/backend/azure/v2/v2.go
+++ b/tempodb/backend/azure/v2/v2.go
@@ -403,5 +403,8 @@ func readError(err error) error {
 		return backend.ErrDoesNotExist
 	}
 
-	return fmt.Errorf("reading Azure blob container: %w", err)
+	if err != nil {
+		return fmt.Errorf("reading Azure blob container: %w", err)
+	}
+	return nil
 }

--- a/tempodb/encoding/vparquet/block_iterator.go
+++ b/tempodb/encoding/vparquet/block_iterator.go
@@ -72,7 +72,10 @@ func (i *rawIterator) Next(context.Context) (common.ID, parquet.Row, error) {
 		return nil, nil, nil
 	}
 
-	return nil, nil, fmt.Errorf("error iterating through block %s: %w", i.blockID, err)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error iterating through block %s: %w", i.blockID, err)
+	}
+	return nil, nil, nil
 }
 
 func (i *rawIterator) peekNextID(context.Context) (common.ID, error) { // nolint:unused // this is required to satisfy the bookmarkIterator interface

--- a/tempodb/encoding/vparquet2/block_iterator.go
+++ b/tempodb/encoding/vparquet2/block_iterator.go
@@ -72,7 +72,10 @@ func (i *rawIterator) Next(context.Context) (common.ID, parquet.Row, error) {
 		return nil, nil, nil
 	}
 
-	return nil, nil, fmt.Errorf("error iterating through block %s: %w", i.blockID, err)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error iterating through block %s: %w", i.blockID, err)
+	}
+	return nil, nil, nil
 }
 
 func (i *rawIterator) peekNextID(context.Context) (common.ID, error) { // nolint:unused // this is required to satisfy the bookmarkIterator interface

--- a/tempodb/encoding/vparquet3/block_iterator.go
+++ b/tempodb/encoding/vparquet3/block_iterator.go
@@ -72,7 +72,10 @@ func (i *rawIterator) Next(context.Context) (common.ID, parquet.Row, error) {
 		return nil, nil, nil
 	}
 
-	return nil, nil, fmt.Errorf("error iterating through block %s: %w", i.blockID, err)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error iterating through block %s: %w", i.blockID, err)
+	}
+	return nil, nil, nil
 }
 
 func (i *rawIterator) peekNextID(context.Context) (common.ID, error) { // nolint:unused // this is required to satisfy the bookmarkIterator interface


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

In https://github.com/grafana/tempo/pull/2955 tempo replaced usage of github.com/pkg/errors
with errors package from the standard library.

In that process errors.Wrap calls were replaced with fmt.Errorf,
and there a difference in the way both work with `nil` error.

e.g: `errors.Wrap(nil, "test")` is `<nil>`, but `fmt.Errorf("test", nil)` is `test%!(EXTRA <nil>)`

so we need to guard fmt.Errorf calls to avoid returning errors when `err` is `nil`.