### PR TITLE
Move ExtractTraceID from util to util/tracing

### DIFF
--- a/modules/frontend/handler.go
+++ b/modules/frontend/handler.go
@@ -12,9 +12,10 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/httpgrpc/server"
-	"github.com/grafana/dskit/tracing"
 	"github.com/grafana/dskit/user"
 	"github.com/opentracing/opentracing-go"
+
+	"github.com/grafana/tempo/pkg/util/tracing"
 )
 
 const (

--- a/modules/overrides/user_configurable_overrides.go
+++ b/modules/overrides/user_configurable_overrides.go
@@ -13,7 +13,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/services"
-	"github.com/grafana/dskit/tracing"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -23,6 +22,7 @@ import (
 	userconfigurableoverrides "github.com/grafana/tempo/modules/overrides/userconfigurable/client"
 	filterconfig "github.com/grafana/tempo/pkg/spanfilter/config"
 	tempo_log "github.com/grafana/tempo/pkg/util/log"
+	"github.com/grafana/tempo/pkg/util/tracing"
 	"github.com/grafana/tempo/tempodb/backend"
 )
 

--- a/modules/overrides/userconfigurable/api/api.go
+++ b/modules/overrides/userconfigurable/api/api.go
@@ -11,13 +11,13 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/services"
-	"github.com/grafana/dskit/tracing"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/opentracing/opentracing-go"
 
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/modules/overrides/userconfigurable/client"
 	tempo_log "github.com/grafana/tempo/pkg/util/log"
+	"github.com/grafana/tempo/pkg/util/tracing"
 	"github.com/grafana/tempo/tempodb/backend"
 )
 

--- a/modules/overrides/userconfigurable/api/http.go
+++ b/modules/overrides/userconfigurable/api/http.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 
 	"github.com/go-kit/log/level"
-	"github.com/grafana/dskit/tracing"
 	"github.com/grafana/dskit/user"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/opentracing/opentracing-go"
@@ -19,6 +18,7 @@ import (
 	"github.com/grafana/tempo/modules/overrides/userconfigurable/client"
 	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/spanfilter/config"
+	"github.com/grafana/tempo/pkg/util/tracing"
 	"github.com/grafana/tempo/tempodb/backend"
 )
 

--- a/pkg/util/tracing/tracing.go
+++ b/pkg/util/tracing/tracing.go
@@ -1,4 +1,4 @@
-package util
+package tracing
 
 import (
 	"context"

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -14,7 +14,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/grafana/tempo/pkg/dataquality"
-	"github.com/grafana/tempo/pkg/util"
+	"github.com/grafana/tempo/pkg/util/tracing"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/grafana/tempo/tempodb/encoding/common"
@@ -170,7 +170,7 @@ func (rw *readerWriter) compact(ctx context.Context, blockMetas []*backend.Block
 	span, ctx := opentracing.StartSpanFromContext(ctx, "rw.compact")
 	defer span.Finish()
 
-	traceID, _ := util.ExtractTraceID(ctx)
+	traceID, _ := tracing.ExtractTraceID(ctx)
 	if traceID != "" {
 		level.Info(rw.logger).Log("msg", "beginning compaction", "traceID", traceID)
 	}


### PR DESCRIPTION
**What this PR does**:

Small refactor in preparation for a bigger change to our tracing SDK setup.

Changes:
- move `ExtractTraceID` to its own package, from `pkg/util` to `pkg/util/tracing`
- in some places we were calling `dskit/tracing.ExtractTraceID` directly instead of our helper, for consistency all calls will now go through our own `ExtractTraceID` (which calls dskit's version) 

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [ ] ~~Tests updated~~
- [ ] ~~Documentation added~~
- [ ] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~