### PR TITLE
Disable parquet trace index by default

### DIFF
--- a/tempodb/encoding/vparquet2/block_findtracebyid.go
+++ b/tempodb/encoding/vparquet2/block_findtracebyid.go
@@ -27,8 +27,8 @@ const (
 
 	TraceIDColumnName = "TraceID"
 
-	EnvVarIndexName          = "VPARQUET_INDEX"
-	EnvVarIndexDisabledValue = "0"
+	EnvVarIndexName         = "VPARQUET_INDEX"
+	EnvVarIndexEnabledValue = "1"
 )
 
 func (b *backendBlock) checkBloom(ctx context.Context, id common.ID) (found bool, err error) {
@@ -58,7 +58,7 @@ func (b *backendBlock) checkBloom(ctx context.Context, id common.ID) (found bool
 }
 
 func (b *backendBlock) checkIndex(ctx context.Context, id common.ID) (bool, int, error) {
-	if os.Getenv(EnvVarIndexName) == EnvVarIndexDisabledValue {
+	if os.Getenv(EnvVarIndexName) != EnvVarIndexEnabledValue {
 		// Index lookup disabled
 		return true, -1, nil
 	}

--- a/tempodb/encoding/vparquet3/block_findtracebyid.go
+++ b/tempodb/encoding/vparquet3/block_findtracebyid.go
@@ -27,8 +27,8 @@ const (
 
 	TraceIDColumnName = "TraceID"
 
-	EnvVarIndexName          = "VPARQUET_INDEX"
-	EnvVarIndexDisabledValue = "0"
+	EnvVarIndexName         = "VPARQUET_INDEX"
+	EnvVarIndexEnabledValue = "1"
 )
 
 func (b *backendBlock) checkBloom(ctx context.Context, id common.ID) (found bool, err error) {
@@ -58,7 +58,7 @@ func (b *backendBlock) checkBloom(ctx context.Context, id common.ID) (found bool
 }
 
 func (b *backendBlock) checkIndex(ctx context.Context, id common.ID) (bool, int, error) {
-	if os.Getenv(EnvVarIndexName) == EnvVarIndexDisabledValue {
+	if os.Getenv(EnvVarIndexName) != EnvVarIndexEnabledValue {
 		// Index lookup disabled
 		return true, -1, nil
 	}

--- a/tempodb/encoding/vparquet3/block_findtracebyid_test.go
+++ b/tempodb/encoding/vparquet3/block_findtracebyid_test.go
@@ -193,7 +193,7 @@ func BenchmarkFindTraceByID(b *testing.B) {
 	// index := genIndex(b, block)
 	// writeBlockMeta(ctx, ww, meta, &common.ShardedBloomFilter{}, index)
 
-	for _, tc := range []string{EnvVarIndexDisabledValue, "1"} {
+	for _, tc := range []string{"0", EnvVarIndexEnabledValue} {
 		b.Run(EnvVarIndexName+"="+tc, func(b *testing.B) {
 			os.Setenv(EnvVarIndexName, tc)
 			b.ResetTimer()


### PR DESCRIPTION
**What this PR does**:
Since there ended up being issues in the index due to #2867, we decided to disable it by default in the next release.  

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`