### PR TITLE
Tempo: add dedicated columns to block analyze

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ lint:
 
 .PHONY: docker-component # Not intended to be used directly
 docker-component: check-component exe
-	docker build -t grafana/$(COMPONENT) --build-arg=TARGETARCH=$(GOARCH) -f ./cmd/$(COMPONENT)/Dockerfile .
+	docker build -t grafana/$(COMPONENT) --load --build-arg=TARGETARCH=$(GOARCH) -f ./cmd/$(COMPONENT)/Dockerfile .
 	docker tag grafana/$(COMPONENT) $(COMPONENT)
 
 .PHONY: docker-component-debug

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ lint:
 
 .PHONY: docker-component # Not intended to be used directly
 docker-component: check-component exe
-	docker build -t grafana/$(COMPONENT) --load --build-arg=TARGETARCH=$(GOARCH) -f ./cmd/$(COMPONENT)/Dockerfile .
+	docker build -t grafana/$(COMPONENT) --build-arg=TARGETARCH=$(GOARCH) -f ./cmd/$(COMPONENT)/Dockerfile .
 	docker tag grafana/$(COMPONENT) $(COMPONENT)
 
 .PHONY: docker-component-debug

--- a/cmd/tempo-cli/cmd-analyse-block.go
+++ b/cmd/tempo-cli/cmd-analyse-block.go
@@ -79,6 +79,14 @@ func resourcePathsForVersion(v string) (string, []string) {
 	return "", nil
 }
 
+func dedicatedColPathForVersion(i int, scope backend.DedicatedColumnScope, v string) string {
+	switch v {
+	case vparquet3.VersionString:
+		return vparquet3.DedicatedResourceColumnPaths[scope][backend.DedicatedColumnTypeString][i]
+	}
+	return ""
+}
+
 type analyseBlockCmd struct {
 	backendOptions
 
@@ -151,12 +159,34 @@ func processBlock(r backend.Reader, _ backend.Compactor, tenantID, blockID strin
 		return nil, err
 	}
 
+	// add up dedicated span attribute columns
+	spanDedicatedSummary, err := aggregateDedicatedColumns(pf, backend.DedicatedColumnScopeSpan, meta)
+	if err != nil {
+		return nil, err
+	}
+	// merge dedicated with span attributes
+	for k, v := range spanDedicatedSummary.attributes {
+		spanAttrsSummary.attributes[k] = v
+	}
+	spanAttrsSummary.totalBytes += spanDedicatedSummary.totalBytes
+
 	// Aggregate resource attributes
 	resourceKey, resourceVals := resourcePathsForVersion(meta.Version)
 	resourceAttrsSummary, err := aggregateAttributes(pf, resourceKey, resourceVals)
 	if err != nil {
 		return nil, err
 	}
+
+	// add up dedicated resource attribute columns
+	resourceDedicatedSummary, err := aggregateDedicatedColumns(pf, backend.DedicatedColumnScopeResource, meta)
+	if err != nil {
+		return nil, err
+	}
+	// merge dedicated with span attributes
+	for k, v := range resourceDedicatedSummary.attributes {
+		resourceAttrsSummary.attributes[k] = v
+	}
+	resourceAttrsSummary.totalBytes += spanDedicatedSummary.totalBytes
 
 	return &blockSummary{
 		spanSummary:     spanAttrsSummary,
@@ -226,6 +256,61 @@ func aggregateAttributes(pf *parquet.File, keyPath string, valuePaths []string) 
 		totalBytes: totalBytes,
 		attributes: attrMap,
 	}, nil
+}
+
+func aggregateDedicatedColumns(pf *parquet.File, scope backend.DedicatedColumnScope, meta *backend.BlockMeta) (genericAttrSummary, error) {
+	attrMap := make(map[string]uint64)
+	totalBytes := uint64(0)
+
+	i := 0
+	for _, dedColumn := range meta.DedicatedColumns {
+		if dedColumn.Scope != scope {
+			continue
+		}
+
+		path := dedicatedColPathForVersion(i, scope, meta.Version)
+		sz, err := aggregateColumn(pf, path)
+		if err != nil {
+			return genericAttrSummary{}, err
+		}
+		i++
+
+		attrMap["dedicated: "+dedColumn.Name] = sz
+		totalBytes += sz
+	}
+
+	return genericAttrSummary{
+		totalBytes: totalBytes,
+		attributes: attrMap,
+	}, nil
+}
+
+func aggregateColumn(pf *parquet.File, colName string) (uint64, error) {
+	idx, _ := pq.GetColumnIndexByPath(pf, colName)
+	calc, err := inspect.NewRowStatCalculator(pf, inspect.RowStatOptions{
+		Columns: []int{idx},
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	totalBytes := uint64(0)
+	for {
+		row, err := calc.NextRow()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return 0, err
+		}
+
+		cells := row.Cells()
+
+		bytes := uint64(cells[1].(int))
+		totalBytes += bytes
+	}
+
+	return uint64(totalBytes), nil
 }
 
 func printSummary(scope string, max int, summary genericAttrSummary) error {

--- a/cmd/tempo-cli/cmd-analyse-block.go
+++ b/cmd/tempo-cli/cmd-analyse-block.go
@@ -310,7 +310,7 @@ func aggregateColumn(pf *parquet.File, colName string) (uint64, error) {
 		totalBytes += bytes
 	}
 
-	return uint64(totalBytes), nil
+	return totalBytes, nil
 }
 
 func printSummary(scope string, max int, summary genericAttrSummary) error {

--- a/tempodb/encoding/vparquet3/dedicated_columns.go
+++ b/tempodb/encoding/vparquet3/dedicated_columns.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Column paths for spare dedicated attribute columns
-var dedicatedResourceColumnPaths = map[backend.DedicatedColumnScope]map[backend.DedicatedColumnType][]string{
+var DedicatedResourceColumnPaths = map[backend.DedicatedColumnScope]map[backend.DedicatedColumnType][]string{
 	backend.DedicatedColumnScopeResource: {
 		backend.DedicatedColumnTypeString: {
 			"rs.list.element.Resource.DedicatedAttributes.String01",
@@ -157,7 +157,7 @@ func dedicatedColumnsToColumnMapping(dedicatedColumns backend.DedicatedColumns, 
 	mapping := newDedicatedColumnMapping(len(dedicatedColumns))
 
 	for _, scope := range scopes {
-		spareColumnsByType, ok := dedicatedResourceColumnPaths[scope]
+		spareColumnsByType, ok := DedicatedResourceColumnPaths[scope]
 		if !ok {
 			continue
 		}


### PR DESCRIPTION
**What this PR does**:
Adds support for dedicated columns to the `analyze block(s)` cli command.

Now when calculating total column size the commands will include dedicated columns if they exist.