### PR TITLE
Support quoted attribute in traceql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## main / unreleased
-* [ENHANCEMENT] Support quoted attribute name in traceql [#3004](https://github.com/grafana/tempo/pull/3004) (@kousikmitra)
+* [ENHANCEMENT] Support quoted attribute name in TraceQL [#3004](https://github.com/grafana/tempo/pull/3004) (@kousikmitra)
 * [BUGFIX] Fix pass-through to runtime overrides for FilterPolicies and TargetInfoExcludedDimensions [#3012](https://github.com/grafana/tempo/pull/3012) (@electron0zero)
 * [ENHANCEMENT] Unescape tag names [#2894](https://github.com/grafana/tempo/pull/2894) (@fabrizio-grafana)
 * [FEATURE] New TraceQL structural operators ancestor (<<), parent (<) [#2877](https://github.com/grafana/tempo/pull/2877) (@kousikmitra)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## main / unreleased
+* [ENHANCEMENT] Support quoted attribute name in traceql [#3004](https://github.com/grafana/tempo/pull/3004) (@kousikmitra)
 * [BUGFIX] Fix pass-through to runtime overrides for FilterPolicies and TargetInfoExcludedDimensions [#3012](https://github.com/grafana/tempo/pull/3012) (@electron0zero)
 * [ENHANCEMENT] Unescape tag names [#2894](https://github.com/grafana/tempo/pull/2894) (@fabrizio-grafana)
 * [FEATURE] New TraceQL structural operators ancestor (<<), parent (<) [#2877](https://github.com/grafana/tempo/pull/2877) (@kousikmitra)

--- a/docs/sources/tempo/traceql/_index.md
+++ b/docs/sources/tempo/traceql/_index.md
@@ -119,6 +119,25 @@ For example, to find traces with an attribute of `sla` set to `critical`:
 { .sla = "critical" }
 ```
 
+### Quoted attribute names
+
+It's possible that attributes name can contain terminal characters, to search span attributes with terminal character you can use quoted attribute syntax. A quoted attirbute should be enclosed inside double quote and all characters between the quotes will be considered part of the attribute name.
+
+For example, to find span with attribute name `attribute name with space` one can use the following query
+```
+{ ."attribute name with space" = "value" }
+```
+
+Also, you can use quoted attributes syntax with non-quoted attribute syntax as well.
+
+Fox example, below syntax is a valid traceql query.
+```
+{ span.attribute."attribute name with space" = "value" }
+```
+
+Note: Only `\"` and `\\` escape sequence are supported as of now.
+
+
 ### Comparison operators
 
 Comparison operators are used to test values within an expression.

--- a/docs/sources/tempo/traceql/_index.md
+++ b/docs/sources/tempo/traceql/_index.md
@@ -121,22 +121,27 @@ For example, to find traces with an attribute of `sla` set to `critical`:
 
 ### Quoted attribute names
 
-Attribute names can contain terminal characters, such as a period (`.`). To search span attributes with terminal characters, you can use quoted attribute syntax. A quoted attribute should be enclosed inside double quotes, for example, `"example one"`. All characters between the quotes are considered part of the attribute name.
+Attribute names can contain terminal characters, such as a period (`.`).
+To search span attributes with terminal characters, you can use quoted attribute syntax.
+A quoted attribute should be enclosed inside double quotes, for example, `"example one"`.
+All characters between the quotes are considered part of the attribute name.
 
-For example, to find span with attribute name `attribute name with space`, you can use the following query:
+#### Examples
+
+To find a span with the attribute name `attribute name with space`, use the following query:
+
 ```
 { ."attribute name with space" = "value" }
 ```
 
-You can use quoted attributes syntax with non-quoted attribute syntax.
+You can use quoted attributes syntax with non-quoted attribute syntax, the following is a valid TraceQL query:
 
-For example, the syntax below is a valid TraceQL query.
 ```
 { span.attribute."attribute name with space" = "value" }
 ```
 
 {{% admonition type="note" %}}
-Currently, only `\"` and `\\` escape sequence are supported.
+Currently, only the `\"` and `\\` escape sequences are supported.
 {{% /admonition %}}
 
 ### Comparison operators

--- a/docs/sources/tempo/traceql/_index.md
+++ b/docs/sources/tempo/traceql/_index.md
@@ -121,22 +121,23 @@ For example, to find traces with an attribute of `sla` set to `critical`:
 
 ### Quoted attribute names
 
-It's possible that attributes name can contain terminal characters, to search span attributes with terminal character you can use quoted attribute syntax. A quoted attirbute should be enclosed inside double quote and all characters between the quotes will be considered part of the attribute name.
+Attribute names can contain terminal characters, such as a period (`.`). To search span attributes with terminal characters, you can use quoted attribute syntax. A quoted attribute should be enclosed inside double quotes, for example, `"example one"`. All characters between the quotes are considered part of the attribute name.
 
-For example, to find span with attribute name `attribute name with space` one can use the following query
+For example, to find span with attribute name `attribute name with space`, you can use the following query:
 ```
 { ."attribute name with space" = "value" }
 ```
 
-Also, you can use quoted attributes syntax with non-quoted attribute syntax as well.
+You can use quoted attributes syntax with non-quoted attribute syntax.
 
-Fox example, below syntax is a valid traceql query.
+For example, the syntax below is a valid TraceQL query.
 ```
 { span.attribute."attribute name with space" = "value" }
 ```
 
-Note: Only `\"` and `\\` escape sequence are supported as of now.
-
+{{% admonition type="note" %}}
+Currently, only `\"` and `\\` escape sequence are supported.
+{{% /admonition %}}
 
 ### Comparison operators
 

--- a/pkg/traceql/lexer.go
+++ b/pkg/traceql/lexer.go
@@ -100,7 +100,7 @@ func (l *lexer) Lex(lval *yySymType) int {
 
 	if l.parsingAttribute {
 		// parse out any scopes here
-		scopeToken, ok := tryScopeAtribute(&l.Scanner)
+		scopeToken, ok := tryScopeAttribute(&l.Scanner)
 		if ok {
 			return scopeToken
 		}
@@ -258,7 +258,7 @@ func parseQuotedAtrribute(s *scanner.Scanner) (string, error) {
 	return sb.String(), nil
 }
 
-func tryScopeAtribute(l *scanner.Scanner) (int, bool) {
+func tryScopeAttribute(l *scanner.Scanner) (int, bool) {
 	// copy the scanner to avoid advancing if it's not a scope.
 	s := *l
 	str := ""

--- a/pkg/traceql/lexer_test.go
+++ b/pkg/traceql/lexer_test.go
@@ -18,6 +18,10 @@ func TestLexerAttributes(t *testing.T) {
 	testLexer(t, ([]lexerTestCase{
 		// attributes
 		{`.foo`, []int{DOT, IDENTIFIER, END_ATTRIBUTE}},
+		{`."foo".baz."bar"`, []int{DOT, IDENTIFIER, END_ATTRIBUTE}},
+		{`.foo."bar \" baz"."bar"`, []int{DOT, IDENTIFIER, END_ATTRIBUTE}},
+		{`.foo."baz \\".bar`, []int{DOT, IDENTIFIER, END_ATTRIBUTE}},
+		{`."foo.bar"`, []int{DOT, IDENTIFIER, END_ATTRIBUTE}},
 		{`.count`, []int{DOT, IDENTIFIER, END_ATTRIBUTE}},
 		{`.foo3`, []int{DOT, IDENTIFIER, END_ATTRIBUTE}},
 		{`.foo+bar`, []int{DOT, IDENTIFIER, END_ATTRIBUTE}},

--- a/pkg/traceql/parse_test.go
+++ b/pkg/traceql/parse_test.go
@@ -882,6 +882,7 @@ func TestAttributeNameErrors(t *testing.T) {
 		{in: "{ .foo .bar }", err: newParseError("syntax error: unexpected .", 1, 8)},
 		{in: "{ parent. }", err: newParseError("syntax error: unexpected END_ATTRIBUTE, expecting IDENTIFIER or resource. or span.", 0, 3)},
 		{in: ".3foo", err: newParseError("syntax error: unexpected IDENTIFIER", 1, 3)},
+		{in: `{ ."foo }`, err: newParseError(`unexpected EOF, expecting "`, 0, 3)},
 	}
 
 	for _, tc := range tests {

--- a/pkg/traceql/parse_test.go
+++ b/pkg/traceql/parse_test.go
@@ -878,6 +878,7 @@ func TestAttributeNameErrors(t *testing.T) {
 		err error
 	}{
 		{in: "{ . foo }", err: newParseError("syntax error: unexpected END_ATTRIBUTE, expecting IDENTIFIER", 1, 3)},
+		{in: `{ . "foo" }`, err: newParseError("syntax error: unexpected END_ATTRIBUTE, expecting IDENTIFIER", 1, 3)},
 		{in: "{ .foo .bar }", err: newParseError("syntax error: unexpected .", 1, 8)},
 		{in: "{ parent. }", err: newParseError("syntax error: unexpected END_ATTRIBUTE, expecting IDENTIFIER or resource. or span.", 0, 3)},
 		{in: ".3foo", err: newParseError("syntax error: unexpected IDENTIFIER", 1, 3)},
@@ -920,6 +921,16 @@ func TestAttributes(t *testing.T) {
 		{in: "parent.span.foo", expected: NewScopedAttribute(AttributeScopeSpan, true, "foo")},
 		{in: "parent.resource.foo.bar.baz", expected: NewScopedAttribute(AttributeScopeResource, true, "foo.bar.baz")},
 		{in: "parent.span.foo.bar", expected: NewScopedAttribute(AttributeScopeSpan, true, "foo.bar")},
+		{in: `."bar z".foo`, expected: NewAttribute("bar z.foo")},
+		{in: `span."bar z".foo`, expected: NewScopedAttribute(AttributeScopeSpan, false, "bar z.foo")},
+		{in: `."bar z".foo."bar"`, expected: NewAttribute("bar z.foo.bar")},
+		{in: `.foo."bar baz"`, expected: NewAttribute("foo.bar baz")},
+		{in: `.foo."bar baz".bar`, expected: NewAttribute("foo.bar baz.bar")},
+		{in: `.foo."bar \" baz"`, expected: NewAttribute(`foo.bar " baz`)},
+		{in: `.foo."bar \\ baz"`, expected: NewAttribute(`foo.bar \ baz`)},
+		{in: `.foo."bar \\"." baz"`, expected: NewAttribute(`foo.bar \. baz`)},
+		{in: `."foo.bar"`, expected: NewAttribute(`foo.bar`)},
+		{in: `."🤘"`, expected: NewAttribute(`🤘`)},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This PR extends the traceql lexer to lex quoted attribute names (ex: `span."foo bar"`) this will help searching tempo with span attributes containing breaking characters like `=, "` etc. 

**Which issue(s) this PR fixes**:
Fixes #2805

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`