### PR TITLE
Metrics summary API root spans

### DIFF
--- a/modules/generator/processor/localblocks/metrics.go
+++ b/modules/generator/processor/localblocks/metrics.go
@@ -19,6 +19,12 @@ var (
 		Name:      "traces_total",
 		Help:      "Total number of traces created",
 	}, []string{"tenant"})
+	metricTotalSpans = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: subsystem,
+		Name:      "spans_total",
+		Help:      "Total number of spans after filtering",
+	}, []string{"tenant"})
 	metricLiveTraces = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: namespace,
 		Subsystem: subsystem,

--- a/modules/generator/processor/localblocks/processor.go
+++ b/modules/generator/processor/localblocks/processor.go
@@ -629,7 +629,7 @@ func filterBatch(batch *v1.ResourceSpans) *v1.ResourceSpans {
 
 		var keepSpans []*v1.Span
 		for _, s := range ss.Spans {
-			if s.Kind == v1.Span_SPAN_KIND_SERVER {
+			if s.Kind == v1.Span_SPAN_KIND_SERVER || len(s.ParentSpanId) == 0 {
 				keepSpans = append(keepSpans, s)
 			}
 		}


### PR DESCRIPTION
**What this PR does**:
Also keeps root spans in the local-blocks processor so that things like `traceDuration`, `rootServiceName` can work in the metrics summary API.  It's best effort and has the same limitations as other cross-span traceql features:  when the root span and matching span are not in the same segment (wal flush or complete block) then it doesn't work.

Also adds a metric to track spans after filtering.

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`