### PR TITLE
Fix: pass-through to runtime overrides for FilterPolicies and TargetInfoExcludedDimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## main / unreleased
+* [BUGFIX] Fix check for zero length attributes correctly in user configurable overrides [#3012](https://github.com/grafana/tempo/pull/3012) (@electron0zero)
 * [ENHANCEMENT] Unescape tag names [#2894](https://github.com/grafana/tempo/pull/2894) (@fabrizio-grafana)
 * [FEATURE] New TraceQL structural operators ancestor (<<), parent (<) [#2877](https://github.com/grafana/tempo/pull/2877) (@kousikmitra)
 * [ENHANCEMENT] Add support for searching by span status message using  `statusMessage` keyword [#2848](https://github.com/grafana/tempo/pull/2848) (@kousikmitra)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## main / unreleased
-* [BUGFIX] Fix check for zero length attributes correctly in user configurable overrides [#3012](https://github.com/grafana/tempo/pull/3012) (@electron0zero)
+* [BUGFIX] Fix pass-through to runtime overrides for FilterPolicies and TargetInfoExcludedDimensions [#3012](https://github.com/grafana/tempo/pull/3012) (@electron0zero)
 * [ENHANCEMENT] Unescape tag names [#2894](https://github.com/grafana/tempo/pull/2894) (@fabrizio-grafana)
 * [FEATURE] New TraceQL structural operators ancestor (<<), parent (<) [#2877](https://github.com/grafana/tempo/pull/2877) (@kousikmitra)
 * [ENHANCEMENT] Add support for searching by span status message using  `statusMessage` keyword [#2848](https://github.com/grafana/tempo/pull/2848) (@kousikmitra)

--- a/modules/overrides/user_configurable_overrides.go
+++ b/modules/overrides/user_configurable_overrides.go
@@ -195,7 +195,8 @@ func (o *userConfigurableOverridesManager) setTenantLimit(userID string, limits 
 }
 
 func (o *userConfigurableOverridesManager) Forwarders(userID string) []string {
-	if forwarders, ok := o.getTenantLimits(userID).GetForwarders(); ok {
+	forwarders, ok := o.getTenantLimits(userID).GetForwarders()
+	if ok && len(forwarders) > 0 {
 		return forwarders
 	}
 	return o.Interface.Forwarders(userID)
@@ -223,7 +224,8 @@ func (o *userConfigurableOverridesManager) MetricsGeneratorCollectionInterval(us
 }
 
 func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorServiceGraphsDimensions(userID string) []string {
-	if dimensions, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetServiceGraphs().GetDimensions(); ok {
+	dimensions, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetServiceGraphs().GetDimensions()
+	if ok && len(dimensions) > 0 {
 		return dimensions
 	}
 	return o.Interface.MetricsGeneratorProcessorServiceGraphsDimensions(userID)
@@ -237,21 +239,24 @@ func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorServiceGraph
 }
 
 func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorServiceGraphsPeerAttributes(userID string) []string {
-	if peerAttribtues, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetServiceGraphs().GetPeerAttributes(); ok {
-		return peerAttribtues
+	peerAttributes, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetServiceGraphs().GetPeerAttributes()
+	if ok && len(peerAttributes) > 0 {
+		return peerAttributes
 	}
 	return o.Interface.MetricsGeneratorProcessorServiceGraphsPeerAttributes(userID)
 }
 
 func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorServiceGraphsHistogramBuckets(userID string) []float64 {
-	if histogramBuckets, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetServiceGraphs().GetHistogramBuckets(); ok {
+	histogramBuckets, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetServiceGraphs().GetHistogramBuckets()
+	if ok && len(histogramBuckets) > 0 {
 		return histogramBuckets
 	}
 	return o.Interface.MetricsGeneratorProcessorServiceGraphsHistogramBuckets(userID)
 }
 
 func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorSpanMetricsDimensions(userID string) []string {
-	if dimensions, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetSpanMetrics().GetDimensions(); ok {
+	dimensions, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetSpanMetrics().GetDimensions()
+	if ok && len(dimensions) > 0 {
 		return dimensions
 	}
 	return o.Interface.MetricsGeneratorProcessorSpanMetricsDimensions(userID)
@@ -265,21 +270,26 @@ func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorSpanMetricsE
 }
 
 func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorSpanMetricsFilterPolicies(userID string) []filterconfig.FilterPolicy {
-	if filterPolicies, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetSpanMetrics().GetFilterPolicies(); ok {
+	filterPolicies, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetSpanMetrics().GetFilterPolicies()
+	if ok && len(filterPolicies) > 0 {
+		// only return when filterPolicies are NOT empty
 		return filterPolicies
 	}
 	return o.Interface.MetricsGeneratorProcessorSpanMetricsFilterPolicies(userID)
 }
 
 func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorSpanMetricsHistogramBuckets(userID string) []float64 {
-	if histogramBuckets, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetSpanMetrics().GetHistogramBuckets(); ok {
+	histogramBuckets, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetSpanMetrics().GetHistogramBuckets()
+	if ok && len(histogramBuckets) > 0 {
 		return histogramBuckets
 	}
 	return o.Interface.MetricsGeneratorProcessorSpanMetricsHistogramBuckets(userID)
 }
 
 func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(userID string) []string {
-	if targetInfoExcludedDimensions, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetSpanMetrics().GetTargetInfoExcludedDimensions(); ok {
+	targetInfoExcludedDimensions, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetSpanMetrics().GetTargetInfoExcludedDimensions()
+	if ok && len(targetInfoExcludedDimensions) > 0 {
+		// only return when filterPolicies are NOT empty
 		return targetInfoExcludedDimensions
 	}
 	return o.Interface.MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(userID)

--- a/modules/overrides/user_configurable_overrides.go
+++ b/modules/overrides/user_configurable_overrides.go
@@ -195,8 +195,7 @@ func (o *userConfigurableOverridesManager) setTenantLimit(userID string, limits 
 }
 
 func (o *userConfigurableOverridesManager) Forwarders(userID string) []string {
-	forwarders, ok := o.getTenantLimits(userID).GetForwarders()
-	if ok && len(forwarders) > 0 {
+	if forwarders, ok := o.getTenantLimits(userID).GetForwarders(); ok {
 		return forwarders
 	}
 	return o.Interface.Forwarders(userID)
@@ -224,8 +223,7 @@ func (o *userConfigurableOverridesManager) MetricsGeneratorCollectionInterval(us
 }
 
 func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorServiceGraphsDimensions(userID string) []string {
-	dimensions, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetServiceGraphs().GetDimensions()
-	if ok && len(dimensions) > 0 {
+	if dimensions, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetServiceGraphs().GetDimensions(); ok {
 		return dimensions
 	}
 	return o.Interface.MetricsGeneratorProcessorServiceGraphsDimensions(userID)
@@ -239,24 +237,21 @@ func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorServiceGraph
 }
 
 func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorServiceGraphsPeerAttributes(userID string) []string {
-	peerAttributes, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetServiceGraphs().GetPeerAttributes()
-	if ok && len(peerAttributes) > 0 {
+	if peerAttributes, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetServiceGraphs().GetPeerAttributes(); ok {
 		return peerAttributes
 	}
 	return o.Interface.MetricsGeneratorProcessorServiceGraphsPeerAttributes(userID)
 }
 
 func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorServiceGraphsHistogramBuckets(userID string) []float64 {
-	histogramBuckets, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetServiceGraphs().GetHistogramBuckets()
-	if ok && len(histogramBuckets) > 0 {
+	if histogramBuckets, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetServiceGraphs().GetHistogramBuckets(); ok {
 		return histogramBuckets
 	}
 	return o.Interface.MetricsGeneratorProcessorServiceGraphsHistogramBuckets(userID)
 }
 
 func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorSpanMetricsDimensions(userID string) []string {
-	dimensions, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetSpanMetrics().GetDimensions()
-	if ok && len(dimensions) > 0 {
+	if dimensions, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetSpanMetrics().GetDimensions(); ok {
 		return dimensions
 	}
 	return o.Interface.MetricsGeneratorProcessorSpanMetricsDimensions(userID)
@@ -270,26 +265,21 @@ func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorSpanMetricsE
 }
 
 func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorSpanMetricsFilterPolicies(userID string) []filterconfig.FilterPolicy {
-	filterPolicies, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetSpanMetrics().GetFilterPolicies()
-	if ok && len(filterPolicies) > 0 {
-		// only return when filterPolicies are NOT empty
+	if filterPolicies, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetSpanMetrics().GetFilterPolicies(); ok {
 		return filterPolicies
 	}
 	return o.Interface.MetricsGeneratorProcessorSpanMetricsFilterPolicies(userID)
 }
 
 func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorSpanMetricsHistogramBuckets(userID string) []float64 {
-	histogramBuckets, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetSpanMetrics().GetHistogramBuckets()
-	if ok && len(histogramBuckets) > 0 {
+	if histogramBuckets, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetSpanMetrics().GetHistogramBuckets(); ok {
 		return histogramBuckets
 	}
 	return o.Interface.MetricsGeneratorProcessorSpanMetricsHistogramBuckets(userID)
 }
 
 func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(userID string) []string {
-	targetInfoExcludedDimensions, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetSpanMetrics().GetTargetInfoExcludedDimensions()
-	if ok && len(targetInfoExcludedDimensions) > 0 {
-		// only return when filterPolicies are NOT empty
+	if targetInfoExcludedDimensions, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetSpanMetrics().GetTargetInfoExcludedDimensions(); ok {
 		return targetInfoExcludedDimensions
 	}
 	return o.Interface.MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(userID)

--- a/modules/overrides/user_configurable_overrides_test.go
+++ b/modules/overrides/user_configurable_overrides_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/tempo/pkg/util/listtomap"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/local"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -289,6 +290,8 @@ func localUserConfigOverrides(t *testing.T, baseLimits Overrides, PerTenantOverr
 	baseOverrides, err := NewOverrides(baseCfg)
 	assert.NoError(t, err)
 
+	// have to overwrite the registry or test panics with multiple metric reg
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
 	configurableOverrides, err := newUserConfigOverrides(cfg, baseOverrides)
 	assert.NoError(t, err)
 

--- a/modules/overrides/userconfigurable/client/limits.go
+++ b/modules/overrides/userconfigurable/client/limits.go
@@ -143,7 +143,7 @@ func (l *LimitsMetricsGeneratorProcessorSpanMetrics) GetFilterPolicies() ([]filt
 	if l != nil && l.FilterPolicies != nil {
 		return *l.FilterPolicies, true
 	}
-	return nil, true
+	return nil, false
 }
 
 func (l *LimitsMetricsGeneratorProcessorSpanMetrics) GetHistogramBuckets() ([]float64, bool) {
@@ -157,5 +157,5 @@ func (l *LimitsMetricsGeneratorProcessorSpanMetrics) GetTargetInfoExcludedDimens
 	if l != nil && l.TargetInfoExcludedDimensions != nil {
 		return *l.TargetInfoExcludedDimensions, true
 	}
-	return nil, true
+	return nil, false
 }


### PR DESCRIPTION
**What this PR does**:

When userconfigurableoverrides are enabled, we were returning metrics_generator `filter_policies` as empty even when it's set in per tenant runtime overrides.

This is a bug, we should return per tenant runtime overides when filter_policies are not set at userconfigurableoverrides.

this PR added a len > 0 check to fix this for multiple attribuets, and adds a test for all overrides when userconfigurableoverrides is enabled.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`