### PR TITLE
Add missing fields in overrides API merged response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 * [ENHANCEMENT] Add collection-interval to metrics-generator config in user-configurable overrides [#2899](https://github.com/grafana/tempo/pull/2899) (@rlankfo)
 * [ENHANCEMENT] Enforce max trace size on the trace by id path. [#2935](https://github.com/grafana/tempo/issues/2935) (@joe-elliott)
 * [ENHANCEMENT] Add `target_info_excluded_dimensions` to user-config api [#2945](https://github.com/grafana/tempo/pull/2945) (@ie-pham)
-* [ENHANCEMENT] User-configurable overrides: add scope query parameter to return merged overrides for tenant [#2915](https://github.com/grafana/tempo/pull/2915) (@kvrhdn)
+* [ENHANCEMENT] User-configurable overrides: add scope query parameter to return merged overrides for tenant [#2915](https://github.com/grafana/tempo/pull/2915) [#3018](https://github.com/grafana/tempo/pull/3018) (@kvrhdn)
 * [ENHANCEMENT] Add histogram buckets to metrics-generator config in user-configurable overrides [#2928](https://github.com/grafana/tempo/pull/2928) (@mar4uk)
 * [ENHANCEMENT] Adds websocket support for search streaming. [#2971](https://github.com/grafana/tempo/pull/2840) (@joe-elliott)
    **Breaking Change** Deprecated GRPC streaming

--- a/modules/overrides/userconfigurable/api/http.go
+++ b/modules/overrides/userconfigurable/api/http.go
@@ -14,10 +14,8 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	ot_log "github.com/opentracing/opentracing-go/log"
 
-	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/modules/overrides/userconfigurable/client"
 	"github.com/grafana/tempo/pkg/api"
-	"github.com/grafana/tempo/pkg/spanfilter/config"
 	"github.com/grafana/tempo/pkg/util/tracing"
 	"github.com/grafana/tempo/tempodb/backend"
 )
@@ -194,38 +192,4 @@ func (a *UserConfigOverridesAPI) logRequest(ctx context.Context, handler string,
 
 		span.Finish()
 	}
-}
-
-func limitsFromOverrides(overrides overrides.Interface, userID string) *client.Limits {
-	return &client.Limits{
-		Forwarders: strArrPtr(overrides.Forwarders(userID)),
-		MetricsGenerator: &client.LimitsMetricsGenerator{
-			Processors:        overrides.MetricsGeneratorProcessors(userID),
-			DisableCollection: boolPtr(overrides.MetricsGeneratorDisableCollection(userID)),
-			Processor: &client.LimitsMetricsGeneratorProcessor{
-				ServiceGraphs: &client.LimitsMetricsGeneratorProcessorServiceGraphs{
-					Dimensions:               strArrPtr(overrides.MetricsGeneratorProcessorServiceGraphsDimensions(userID)),
-					EnableClientServerPrefix: boolPtr(overrides.MetricsGeneratorProcessorServiceGraphsEnableClientServerPrefix(userID)),
-					PeerAttributes:           strArrPtr(overrides.MetricsGeneratorProcessorServiceGraphsPeerAttributes(userID)),
-				},
-				SpanMetrics: &client.LimitsMetricsGeneratorProcessorSpanMetrics{
-					Dimensions:       strArrPtr(overrides.MetricsGeneratorProcessorSpanMetricsDimensions(userID)),
-					EnableTargetInfo: boolPtr(overrides.MetricsGeneratorProcessorSpanMetricsEnableTargetInfo(userID)),
-					FilterPolicies:   filterPoliciesPtr(overrides.MetricsGeneratorProcessorSpanMetricsFilterPolicies(userID)),
-				},
-			},
-		},
-	}
-}
-
-func boolPtr(b bool) *bool {
-	return &b
-}
-
-func strArrPtr(s []string) *[]string {
-	return &s
-}
-
-func filterPoliciesPtr(p []config.FilterPolicy) *[]config.FilterPolicy {
-	return &p
 }

--- a/modules/overrides/userconfigurable/api/limits.go
+++ b/modules/overrides/userconfigurable/api/limits.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"time"
+
+	"github.com/grafana/tempo/modules/overrides"
+	"github.com/grafana/tempo/modules/overrides/userconfigurable/client"
+	"github.com/grafana/tempo/pkg/spanfilter/config"
+)
+
+// limitsFromOverrides will reconstruct a client.Limits from the overrides module
+func limitsFromOverrides(overrides overrides.Interface, userID string) *client.Limits {
+	return &client.Limits{
+		Forwarders: strArrPtr(overrides.Forwarders(userID)),
+		MetricsGenerator: &client.LimitsMetricsGenerator{
+			Processors:         overrides.MetricsGeneratorProcessors(userID),
+			DisableCollection:  boolPtr(overrides.MetricsGeneratorDisableCollection(userID)),
+			CollectionInterval: timePtr(overrides.MetricsGeneratorCollectionInterval(userID)),
+			Processor: &client.LimitsMetricsGeneratorProcessor{
+				ServiceGraphs: &client.LimitsMetricsGeneratorProcessorServiceGraphs{
+					Dimensions:               strArrPtr(overrides.MetricsGeneratorProcessorServiceGraphsDimensions(userID)),
+					EnableClientServerPrefix: boolPtr(overrides.MetricsGeneratorProcessorServiceGraphsEnableClientServerPrefix(userID)),
+					PeerAttributes:           strArrPtr(overrides.MetricsGeneratorProcessorServiceGraphsPeerAttributes(userID)),
+					HistogramBuckets:         floatArrPtr(overrides.MetricsGeneratorProcessorServiceGraphsHistogramBuckets(userID)),
+				},
+				SpanMetrics: &client.LimitsMetricsGeneratorProcessorSpanMetrics{
+					Dimensions:                   strArrPtr(overrides.MetricsGeneratorProcessorSpanMetricsDimensions(userID)),
+					EnableTargetInfo:             boolPtr(overrides.MetricsGeneratorProcessorSpanMetricsEnableTargetInfo(userID)),
+					FilterPolicies:               filterPoliciesPtr(overrides.MetricsGeneratorProcessorSpanMetricsFilterPolicies(userID)),
+					HistogramBuckets:             floatArrPtr(overrides.MetricsGeneratorProcessorSpanMetricsHistogramBuckets(userID)),
+					TargetInfoExcludedDimensions: strArrPtr(overrides.MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(userID)),
+				},
+			},
+		},
+	}
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func timePtr(t time.Duration) *client.Duration {
+	return &client.Duration{t}
+}
+
+func strArrPtr(s []string) *[]string {
+	return &s
+}
+
+func floatArrPtr(f []float64) *[]float64 {
+	return &f
+}
+
+func filterPoliciesPtr(p []config.FilterPolicy) *[]config.FilterPolicy {
+	return &p
+}

--- a/modules/overrides/userconfigurable/api/limits.go
+++ b/modules/overrides/userconfigurable/api/limits.go
@@ -40,7 +40,7 @@ func boolPtr(b bool) *bool {
 }
 
 func timePtr(t time.Duration) *client.Duration {
-	return &client.Duration{t}
+	return &client.Duration{Duration: t}
 }
 
 func strArrPtr(s []string) *[]string {

--- a/modules/overrides/userconfigurable/api/limits_test.go
+++ b/modules/overrides/userconfigurable/api/limits_test.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/tempo/modules/overrides"
+	filterconfig "github.com/grafana/tempo/pkg/spanfilter/config"
+)
+
+func Test_limitsFromOverrides(t *testing.T) {
+	userID := "foo"
+
+	cfg := overrides.Config{
+		Defaults: overrides.Overrides{
+			Forwarders: []string{"my-forwarder"},
+			MetricsGenerator: overrides.MetricsGeneratorOverrides{
+				Processors:         map[string]struct{}{"service-graphs": {}},
+				CollectionInterval: 15 * time.Second,
+				DisableCollection:  true,
+				Processor: overrides.ProcessorOverrides{
+					ServiceGraphs: overrides.ServiceGraphsOverrides{
+						HistogramBuckets:         []float64{0.1, 0.2, 0.5},
+						Dimensions:               []string{"my-dim1", "my-dim2"},
+						PeerAttributes:           []string{"db.name"},
+						EnableClientServerPrefix: true,
+					},
+					SpanMetrics: overrides.SpanMetricsOverrides{
+						Dimensions:       []string{"your-dim1", "your-dim2"},
+						EnableTargetInfo: true,
+						FilterPolicies: []filterconfig.FilterPolicy{
+							{
+								Exclude: &filterconfig.PolicyMatch{
+									MatchType: filterconfig.Regex,
+									Attributes: []filterconfig.MatchPolicyAttribute{
+										{
+											Key:   "resource.service.name",
+											Value: "unknown_service:myservice",
+										},
+									},
+								},
+							},
+						},
+						HistogramBuckets:             []float64{1, 2, 5},
+						TargetInfoExcludedDimensions: []string{"no"},
+					},
+				},
+			},
+		},
+	}
+	overridesInt, err := overrides.NewOverrides(cfg)
+	assert.NoError(t, err)
+
+	limits := limitsFromOverrides(overridesInt, userID)
+	limitsJson, err := json.MarshalIndent(limits, "", "  ")
+	assert.NoError(t, err)
+
+	expectedJson := `{
+  "forwarders": [
+    "my-forwarder"
+  ],
+  "metrics_generator": {
+    "processors": [
+      "service-graphs"
+    ],
+    "disable_collection": true,
+    "collection_interval": "15s",
+    "processor": {
+      "service_graphs": {
+        "dimensions": [
+          "my-dim1",
+          "my-dim2"
+        ],
+        "enable_client_server_prefix": true,
+        "peer_attributes": [
+          "db.name"
+        ],
+        "histogram_buckets": [
+          0.1,
+          0.2,
+          0.5
+        ]
+      },
+      "span_metrics": {
+        "dimensions": [
+          "your-dim1",
+          "your-dim2"
+        ],
+        "enable_target_info": true,
+        "filter_policies": [
+          {
+            "exclude": {
+              "match_type": "regex",
+              "attributes": [
+                {
+                  "key": "resource.service.name",
+                  "value": "unknown_service:myservice"
+                }
+              ]
+            }
+          }
+        ],
+        "histogram_buckets": [
+          1,
+          2,
+          5
+        ],
+        "target_info_excluded_dimensions": [
+          "no"
+        ]
+      }
+    }
+  }
+}`
+	assert.Equal(t, expectedJson, string(limitsJson))
+}

--- a/modules/overrides/userconfigurable/api/limits_test.go
+++ b/modules/overrides/userconfigurable/api/limits_test.go
@@ -55,10 +55,10 @@ func Test_limitsFromOverrides(t *testing.T) {
 	assert.NoError(t, err)
 
 	limits := limitsFromOverrides(overridesInt, userID)
-	limitsJson, err := json.MarshalIndent(limits, "", "  ")
+	limitsJSON, err := json.MarshalIndent(limits, "", "  ")
 	assert.NoError(t, err)
 
-	expectedJson := `{
+	expectedJSON := `{
   "forwarders": [
     "my-forwarder"
   ],
@@ -115,5 +115,5 @@ func Test_limitsFromOverrides(t *testing.T) {
     }
   }
 }`
-	assert.Equal(t, expectedJson, string(limitsJson))
+	assert.Equal(t, expectedJSON, string(limitsJSON))
 }


### PR DESCRIPTION
**What this PR does**:

While reviewing https://github.com/grafana/tempo/pull/3012 I noticed some fields weren't being populated correctly. This was a massive oversight on my part as the PR adding the merge logic (#2915) was merged during the same time window as PRs adding extending the limits struct (#2899, #2928, #2945, ).
When merged the code got merged without issues but the merge function wasn't updated.

Fields that weren't being populated:
- `metrics_generator.collection_interval`
- `metrics_generator.service_graphs.histogram_buckets`
- `metrics_generator.span_metrics.histogram_buckets`
- `metrics_generator.span_metrics.target_info_excluded_dimensions`

Before this change they would always be returned from the result even though a value would be set.

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`