### PR TITLE
Ingester Search honor ctx errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ defaults:
 ```  
 * [BUGFIX] Moved empty root span substitution from `querier` to `query-frontend`. [#2671](https://github.com/grafana/tempo/issues/2671) (@galalen)
 * [BUGFIX] Correctly propagate ingester errors on the query path [#2935](https://github.com/grafana/tempo/issues/2935) (@joe-elliott)
+* [BUGFIX] Fix issue where ingester doesn't stop query after timeout [#3031](https://github.com/grafana/tempo/pull/3031) (@mdisibio) 
 * [BUGFIX] Fix cases where empty filter {} wouldn't return expected results [#2498](https://github.com/grafana/tempo/issues/2498) (@mdisibio)
 
 # v2.2.3 / 2023-09-13

--- a/modules/ingester/ingester_test.go
+++ b/modules/ingester/ingester_test.go
@@ -483,6 +483,7 @@ func defaultIngesterTestConfig() Config {
 		nil,
 	)
 
+	cfg.FlushOpTimeout = 99999 * time.Hour
 	cfg.FlushCheckPeriod = 99999 * time.Hour
 	cfg.MaxTraceIdle = 99999 * time.Hour
 	cfg.ConcurrentFlushes = 1

--- a/modules/ingester/instance_search.go
+++ b/modules/ingester/instance_search.go
@@ -75,19 +75,14 @@ func (i *instance) Search(ctx context.Context, req *tempopb.SearchRequest) (*tem
 	// collect results from all the goroutines via sr.Results channel.
 	// range loop will exit when sr.Results channel is closed.
 	for result := range sr.Results() {
-		// exit early and Propagate error upstream
-		if sr.Error() != nil {
-			return nil, sr.Error()
+		if combiner.Count() >= maxResults {
+			sr.Close() // signal pending workers to exit
+			continue
 		}
 
 		combiner.AddMetadata(result)
-		if combiner.Count() >= maxResults {
-			sr.Close() // signal pending workers to exit
-			break
-		}
 	}
 
-	// can happen when we have only error, and no results
 	if sr.Error() != nil {
 		return nil, sr.Error()
 	}
@@ -139,6 +134,10 @@ func (i *instance) searchBlock(ctx context.Context, req *tempopb.SearchRequest, 
 			}))
 		} else {
 			resp, err = e.Search(ctx, req, opts)
+		}
+
+		if err != nil {
+			fmt.Println("!!!!!! searchBlock bailing", blockID, err)
 		}
 
 		if errors.Is(err, common.ErrUnsupported) {

--- a/modules/ingester/instance_search.go
+++ b/modules/ingester/instance_search.go
@@ -136,10 +136,6 @@ func (i *instance) searchBlock(ctx context.Context, req *tempopb.SearchRequest, 
 			resp, err = e.Search(ctx, req, opts)
 		}
 
-		if err != nil {
-			fmt.Println("!!!!!! searchBlock bailing", blockID, err)
-		}
-
 		if errors.Is(err, common.ErrUnsupported) {
 			level.Warn(log.Logger).Log("msg", "block does not support search", "blockID", blockID)
 			return

--- a/pkg/search/results.go
+++ b/pkg/search/results.go
@@ -61,6 +61,7 @@ func (sr *Results) AddResult(ctx context.Context, r *tempopb.TraceSearchMetadata
 func (sr *Results) SetError(err error) {
 	if !errors.Is(err, common.ErrUnsupported) { // ignore common.Unsupported
 		sr.error.Store(err)
+		sr.Close()
 	}
 }
 

--- a/tempodb/backend/local/local.go
+++ b/tempodb/backend/local/local.go
@@ -150,6 +150,10 @@ func (rw *Backend) List(ctx context.Context, keypath backend.KeyPath) ([]string,
 
 // Read implements backend.Reader
 func (rw *Backend) Read(ctx context.Context, name string, keypath backend.KeyPath, _ bool) (io.ReadCloser, int64, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, -1, err
+	}
+
 	filename := rw.objectFileName(keypath, name)
 
 	f, err := os.OpenFile(filename, os.O_RDONLY, 0o644)

--- a/tempodb/encoding/vparquet3/wal_block.go
+++ b/tempodb/encoding/vparquet3/wal_block.go
@@ -112,7 +112,7 @@ func openWALBlock(filename, path string, ingestionSlack, _ time.Duration) (commo
 		path := filepath.Join(dir, f.Name())
 		page := newWalBlockFlush(path, common.NewIDMap[int64]())
 
-		file, err := page.file()
+		file, err := page.file(context.Background())
 		if err != nil {
 			warning = fmt.Errorf("error opening file info: %s: %w", page.path, err)
 			continue
@@ -209,8 +209,13 @@ func newWalBlockFlush(path string, ids *common.IDMap[int64]) *walBlockFlush {
 }
 
 // file() opens the parquet file and returns it. previously this method cached the file on first open
-// but the memory cost of this was quite high. so instead we open it fresh every time
-func (w *walBlockFlush) file() (*pageFile, error) {
+// but the memory cost of this was quite high. so instead we open it fresh every time.  This
+// also allows it to take the context for the caller.
+func (w *walBlockFlush) file(ctx context.Context) (*pageFile, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	file, err := os.OpenFile(w.path, os.O_RDONLY, 0o644)
 	if err != nil {
 		return nil, fmt.Errorf("error opening file: %w", err)
@@ -221,7 +226,7 @@ func (w *walBlockFlush) file() (*pageFile, error) {
 	}
 	size := info.Size()
 
-	wr := newWalReaderAt(file)
+	wr := newWalReaderAt(ctx, file)
 	pf, err := parquet.OpenFile(wr, size, parquet.SkipBloomFilters(true), parquet.SkipPageIndex(true), parquet.FileSchema(walSchema))
 	if err != nil {
 		return nil, fmt.Errorf("error opening parquet file: %w", err)
@@ -233,7 +238,7 @@ func (w *walBlockFlush) file() (*pageFile, error) {
 }
 
 func (w *walBlockFlush) rowIterator() (*rowIterator, error) {
-	file, err := w.file()
+	file, err := w.file(context.Background())
 	if err != nil {
 		return nil, err
 	}
@@ -500,12 +505,12 @@ func (b *walBlock) Clear() error {
 	return errs.Err()
 }
 
-func (b *walBlock) FindTraceByID(_ context.Context, id common.ID, opts common.SearchOptions) (*tempopb.Trace, error) {
+func (b *walBlock) FindTraceByID(ctx context.Context, id common.ID, opts common.SearchOptions) (*tempopb.Trace, error) {
 	trs := make([]*tempopb.Trace, 0)
 
 	for _, page := range b.flushed {
 		if rowNumber, ok := page.ids.Get(id); ok {
-			file, err := page.file()
+			file, err := page.file(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("error opening file %s: %w", page.path, err)
 			}
@@ -551,7 +556,7 @@ func (b *walBlock) Search(ctx context.Context, req *tempopb.SearchRequest, _ com
 	}
 
 	for i, blockFlush := range b.readFlushes() {
-		file, err := blockFlush.file()
+		file, err := blockFlush.file(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("error opening file %s: %w", blockFlush.path, err)
 		}
@@ -577,7 +582,7 @@ func (b *walBlock) Search(ctx context.Context, req *tempopb.SearchRequest, _ com
 
 func (b *walBlock) SearchTags(ctx context.Context, scope traceql.AttributeScope, cb common.TagCallback, _ common.SearchOptions) error {
 	for i, blockFlush := range b.readFlushes() {
-		file, err := blockFlush.file()
+		file, err := blockFlush.file(ctx)
 		if err != nil {
 			return fmt.Errorf("error opening file %s: %w", blockFlush.path, err)
 		}
@@ -611,7 +616,7 @@ func (b *walBlock) SearchTagValues(ctx context.Context, tag string, cb common.Ta
 
 func (b *walBlock) SearchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb common.TagCallbackV2, _ common.SearchOptions) error {
 	for i, blockFlush := range b.readFlushes() {
-		file, err := blockFlush.file()
+		file, err := blockFlush.file(ctx)
 		if err != nil {
 			return fmt.Errorf("error opening file %s: %w", blockFlush.path, err)
 		}
@@ -640,7 +645,7 @@ func (b *walBlock) Fetch(ctx context.Context, req traceql.FetchSpansRequest, opt
 	readers := make([]*walReaderAt, 0, len(blockFlushes))
 	iters := make([]traceql.SpansetIterator, 0, len(blockFlushes))
 	for _, page := range blockFlushes {
-		file, err := page.file()
+		file, err := page.file(ctx)
 		if err != nil {
 			return traceql.FetchSpansResponse{}, fmt.Errorf("error opening file %s: %w", page.path, err)
 		}


### PR DESCRIPTION
**What this PR does**:
Big queries sent to Ingester.SearchRecent may keep running after a context timeout.  The root cause is the Local backend wraps local file i/o which is not context aware.  This fixes the Local backend to check errors, but also addresses some handling in instance.Search to properly wait for all goroutines to complete before releasing the lock.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`