### PR TITLE
A more complete handling of tenant deletion

### DIFF
--- a/tempodb/backend/azure/v1/v1.go
+++ b/tempodb/backend/azure/v1/v1.go
@@ -160,7 +160,7 @@ func (rw *V1) List(ctx context.Context, keypath backend.KeyPath) ([]string, erro
 }
 
 // Find implements backend.Reader
-func (rw *V1) Find(ctx context.Context, keypath backend.KeyPath, f backend.FindFunc, _ string) (keys []string, err error) {
+func (rw *V1) Find(ctx context.Context, keypath backend.KeyPath, f backend.FindFunc) (keys []string, err error) {
 	keypath = backend.KeyPathWithPrefix(keypath, rw.cfg.Prefix)
 
 	marker := blob.Marker{}
@@ -178,7 +178,7 @@ func (rw *V1) Find(ctx context.Context, keypath backend.KeyPath, f backend.FindF
 			Details: blob.BlobListingDetails{},
 		})
 		if listErr != nil {
-			return objects, errors.Wrap(listErr, "iterating objects")
+			return objects, fmt.Errorf("iterating objects: %w", err)
 		}
 		marker = list.NextMarker
 
@@ -189,7 +189,7 @@ func (rw *V1) Find(ctx context.Context, keypath backend.KeyPath, f backend.FindF
 				Modified: blob.Properties.LastModified,
 			}
 			matched, e := f(opts)
-			if e == backend.ErrDone {
+			if errors.Is(e, backend.ErrDone) {
 				return
 			}
 			if !matched {

--- a/tempodb/backend/azure/v2/v2.go
+++ b/tempodb/backend/azure/v2/v2.go
@@ -164,6 +164,53 @@ func (rw *V2) List(ctx context.Context, keypath backend.KeyPath) ([]string, erro
 	return objects, nil
 }
 
+// Find implements backend.Reader
+func (rw *V2) Find(ctx context.Context, keypath backend.KeyPath, f backend.FindFunc) (keys []string, err error) {
+	keypath = backend.KeyPathWithPrefix(keypath, rw.cfg.Prefix)
+
+	prefix := path.Join(keypath...)
+
+	if len(prefix) > 0 {
+		prefix = prefix + dir
+	}
+
+	pager := rw.containerClient.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{
+		Prefix: &prefix,
+	})
+
+	objects := make([]string, 0)
+
+	var o string
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return objects, fmt.Errorf("iterating objects: %w", err)
+		}
+
+		for _, b := range page.Segment.BlobItems {
+			if b == nil || b.Name == nil {
+				continue
+			}
+			o = strings.TrimPrefix(strings.TrimSuffix(*b.Name, dir), prefix)
+			opts := backend.FindOpts{
+				Key:      o,
+				Modified: *b.Properties.LastModified,
+			}
+			matched, e := f(opts)
+			if errors.Is(e, backend.ErrDone) {
+				return objects, nil
+			}
+			if !matched {
+				continue
+			}
+			keys = append(keys, o)
+		}
+
+	}
+
+	return
+}
+
 // Read implements backend.Reader
 func (rw *V2) Read(ctx context.Context, name string, keypath backend.KeyPath, _ bool) (io.ReadCloser, int64, error) {
 	keypath = backend.KeyPathWithPrefix(keypath, rw.cfg.Prefix)

--- a/tempodb/backend/backend.go
+++ b/tempodb/backend/backend.go
@@ -39,6 +39,8 @@ type Writer interface {
 	CloseAppend(ctx context.Context, tracker AppendTracker) error
 	// WriteTenantIndex writes the two meta slices as a tenant index
 	WriteTenantIndex(ctx context.Context, tenantID string, meta []*BlockMeta, compactedMeta []*CompactedBlockMeta) error
+	// Delete deletes an object.
+	Delete(ctx context.Context, name string, keypath KeyPath) error
 }
 
 // Reader is a collection of methods to read data from tempodb backends

--- a/tempodb/backend/backend.go
+++ b/tempodb/backend/backend.go
@@ -59,6 +59,8 @@ type Reader interface {
 	BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*BlockMeta, error)
 	// TenantIndex returns lists of all metas given a tenant
 	TenantIndex(ctx context.Context, tenantID string) (*TenantIndex, error)
+	// Find returns the names of all objects for which the provided FindFunc is true.
+	Find(ctx context.Context, keypath KeyPath, f FindFunc) ([]string, error)
 	// Shutdown shuts...down?
 	Shutdown()
 }

--- a/tempodb/backend/cache/cache.go
+++ b/tempodb/backend/cache/cache.go
@@ -35,8 +35,8 @@ func (r *readerWriter) List(ctx context.Context, keypath backend.KeyPath) ([]str
 }
 
 // Find implements backend.Reader
-func (r *readerWriter) Find(ctx context.Context, keypath backend.KeyPath, f backend.FindFunc, start string) (keys []string, err error) {
-	return r.nextReader.Find(ctx, keypath, f, start)
+func (r *readerWriter) Find(ctx context.Context, keypath backend.KeyPath, f backend.FindFunc) (keys []string, err error) {
+	return r.nextReader.Find(ctx, keypath, f)
 }
 
 // Read implements backend.RawReader

--- a/tempodb/backend/cache/cache.go
+++ b/tempodb/backend/cache/cache.go
@@ -34,6 +34,11 @@ func (r *readerWriter) List(ctx context.Context, keypath backend.KeyPath) ([]str
 	return r.nextReader.List(ctx, keypath)
 }
 
+// Find implements backend.Reader
+func (r *readerWriter) Find(ctx context.Context, keypath backend.KeyPath, f backend.FindFunc, start string) (keys []string, err error) {
+	return r.nextReader.Find(ctx, keypath, f, start)
+}
+
 // Read implements backend.RawReader
 func (r *readerWriter) Read(ctx context.Context, name string, keypath backend.KeyPath, shouldCache bool) (io.ReadCloser, int64, error) {
 	var k string

--- a/tempodb/backend/gcs/gcs.go
+++ b/tempodb/backend/gcs/gcs.go
@@ -187,7 +187,7 @@ func (rw *readerWriter) List(ctx context.Context, keypath backend.KeyPath) ([]st
 }
 
 // Find implements backend.Reader
-func (rw *readerWriter) Find(ctx context.Context, keypath backend.KeyPath, f backend.FindFunc, start string) (keys []string, err error) {
+func (rw *readerWriter) Find(ctx context.Context, keypath backend.KeyPath, f backend.FindFunc) (keys []string, err error) {
 	keypath = backend.KeyPathWithPrefix(keypath, rw.cfg.Prefix)
 	prefix := path.Join(keypath...)
 	if len(prefix) > 0 {
@@ -195,10 +195,9 @@ func (rw *readerWriter) Find(ctx context.Context, keypath backend.KeyPath, f bac
 	}
 
 	iter := rw.bucket.Objects(ctx, &storage.Query{
-		Delimiter:   "",
-		Prefix:      prefix,
-		StartOffset: start,
-		Versions:    false,
+		Delimiter: "",
+		Prefix:    prefix,
+		Versions:  false,
 	})
 
 	for {
@@ -207,7 +206,7 @@ func (rw *readerWriter) Find(ctx context.Context, keypath backend.KeyPath, f bac
 			break
 		}
 		if iterErr != nil {
-			return nil, errors.Wrap(err, "iterating objects")
+			return nil, fmt.Errorf("iterating objects: %w", err)
 		}
 
 		obj := strings.TrimPrefix(attrs.Prefix, prefix)

--- a/tempodb/backend/gcs/gcs.go
+++ b/tempodb/backend/gcs/gcs.go
@@ -186,6 +186,50 @@ func (rw *readerWriter) List(ctx context.Context, keypath backend.KeyPath) ([]st
 	return objects, nil
 }
 
+// Find implements backend.Reader
+func (rw *readerWriter) Find(ctx context.Context, keypath backend.KeyPath, f backend.FindFunc, start string) (keys []string, err error) {
+	keypath = backend.KeyPathWithPrefix(keypath, rw.cfg.Prefix)
+	prefix := path.Join(keypath...)
+	if len(prefix) > 0 {
+		prefix = prefix + "/"
+	}
+
+	iter := rw.bucket.Objects(ctx, &storage.Query{
+		Delimiter:   "",
+		Prefix:      prefix,
+		StartOffset: start,
+		Versions:    false,
+	})
+
+	for {
+		attrs, iterErr := iter.Next()
+		if iterErr == iterator.Done {
+			break
+		}
+		if iterErr != nil {
+			return nil, errors.Wrap(err, "iterating objects")
+		}
+
+		obj := strings.TrimPrefix(attrs.Prefix, prefix)
+
+		opts := backend.FindOpts{
+			Key:      obj,
+			Modified: attrs.Updated,
+		}
+		matched, e := f(opts)
+		if e == backend.ErrDone {
+			return
+		}
+		if !matched {
+			continue
+		}
+
+		keys = append(keys, obj)
+	}
+
+	return
+}
+
 // Read implements backend.Reader
 func (rw *readerWriter) Read(ctx context.Context, name string, keypath backend.KeyPath, _ bool) (io.ReadCloser, int64, error) {
 	keypath = backend.KeyPathWithPrefix(keypath, rw.cfg.Prefix)

--- a/tempodb/backend/local/local.go
+++ b/tempodb/backend/local/local.go
@@ -130,7 +130,7 @@ func (rw *Backend) List(_ context.Context, keypath backend.KeyPath) ([]string, e
 }
 
 // Find implements backend.Reader
-func (rw *Backend) Find(_ context.Context, keypath backend.KeyPath, f backend.FindFunc, _ string) (keys []string, err error) {
+func (rw *Backend) Find(_ context.Context, keypath backend.KeyPath, f backend.FindFunc) (keys []string, err error) {
 	path := rw.rootPath(keypath)
 	fff := os.DirFS(path)
 	err = fs.WalkDir(fff, ".", func(path string, d fs.DirEntry, err error) error {

--- a/tempodb/backend/mocks.go
+++ b/tempodb/backend/mocks.go
@@ -21,11 +21,12 @@ var (
 
 // MockRawReader
 type MockRawReader struct {
-	L      []string
-	ListFn func(ctx context.Context, keypath KeyPath) ([]string, error)
-	R      []byte // read
-	Range  []byte // ReadRange
-	ReadFn func(ctx context.Context, name string, keypath KeyPath, shouldCache bool) (io.ReadCloser, int64, error)
+	L          []string
+	ListFn     func(ctx context.Context, keypath KeyPath) ([]string, error)
+	R          []byte // read
+	Range      []byte // ReadRange
+	ReadFn     func(ctx context.Context, name string, keypath KeyPath, shouldCache bool) (io.ReadCloser, int64, error)
+	FindResult []string
 }
 
 func (m *MockRawReader) List(ctx context.Context, keypath KeyPath) ([]string, error) {
@@ -34,6 +35,10 @@ func (m *MockRawReader) List(ctx context.Context, keypath KeyPath) ([]string, er
 	}
 
 	return m.L, nil
+}
+
+func (m *MockRawReader) Find(_ context.Context, _ KeyPath, _ FindFunc, _ string) ([]string, error) {
+	return m.FindResult, nil
 }
 
 func (m *MockRawReader) Read(ctx context.Context, name string, keypath KeyPath, shouldCache bool) (io.ReadCloser, int64, error) {

--- a/tempodb/backend/mocks.go
+++ b/tempodb/backend/mocks.go
@@ -37,7 +37,7 @@ func (m *MockRawReader) List(ctx context.Context, keypath KeyPath) ([]string, er
 	return m.L, nil
 }
 
-func (m *MockRawReader) Find(_ context.Context, _ KeyPath, _ FindFunc, _ string) ([]string, error) {
+func (m *MockRawReader) Find(_ context.Context, _ KeyPath, _ FindFunc) ([]string, error) {
 	return m.FindResult, nil
 }
 
@@ -126,6 +126,11 @@ type MockReader struct {
 	R             []byte // read
 	Range         []byte // ReadRange
 	ReadFn        func(name string, blockID uuid.UUID, tenantID string) ([]byte, error)
+	FindResult    []string
+}
+
+func (m *MockReader) Find(_ context.Context, _ KeyPath, _ FindFunc) ([]string, error) {
+	return m.FindResult, nil
 }
 
 func (m *MockReader) Tenants(context.Context) ([]string, error) {

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -130,6 +130,10 @@ func (w *writer) WriteTenantIndex(ctx context.Context, tenantID string, meta []*
 	return nil
 }
 
+func (w *writer) Delete(ctx context.Context, name string, keypath KeyPath) error {
+	return w.w.Delete(ctx, name, keypath, false)
+}
+
 type reader struct {
 	r RawReader
 }

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cristalhq/hedgedhttp"
 	gkLog "github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/minio/minio-go/v7"
+	minio "github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/opentracing/opentracing-go"
 
@@ -274,6 +274,62 @@ func (rw *readerWriter) List(_ context.Context, keypath backend.KeyPath) ([]stri
 	}
 
 	return objects, nil
+}
+
+// Find implements backend.Reader
+func (rw *readerWriter) Find(ctx context.Context, keypath backend.KeyPath, f backend.FindFunc, start string) (keys []string, err error) {
+	keypath = backend.KeyPathWithPrefix(keypath, rw.cfg.Prefix)
+	prefix := path.Join(keypath...)
+
+	if len(prefix) > 0 {
+		prefix = prefix + "/"
+	}
+
+	if len(start) > 0 {
+		start = prefix + start
+	}
+
+	nextToken := ""
+	isTruncated := true
+	var res minio.ListBucketV2Result
+
+	for isTruncated {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			res, err = rw.core.ListObjectsV2(rw.cfg.Bucket, prefix, start, nextToken, "", 0)
+			if err != nil {
+				return nil, errors.Wrapf(err, "error finding objects in s3 bucket, bucket: %s", rw.cfg.Bucket)
+			}
+
+			isTruncated = res.IsTruncated
+			nextToken = res.NextContinuationToken
+
+			if len(res.Contents) > 0 {
+				for _, c := range res.Contents {
+					opts := backend.FindOpts{
+						Key:      c.Key,
+						Modified: c.LastModified,
+					}
+
+					matched, e := f(opts)
+					if e == backend.ErrDone {
+						return
+					}
+					if !matched {
+						continue
+					}
+
+					keys = append(keys, c.Key)
+				}
+			}
+		}
+	}
+
+	level.Debug(rw.logger).Log("msg", "find complete", "keys", len(keys))
+
+	return
 }
 
 // Read implements backend.Reader

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -221,6 +221,12 @@ func (p *Poller) pollTenantAndCreateIndex(ctx context.Context, tenantID string) 
 		metricTenantIndexErrors.WithLabelValues(tenantID).Inc()
 		level.Error(p.logger).Log("msg", "failed to write tenant index", "tenant", tenantID, "err", err)
 	}
+
+	// TODO: if the tenant has no blocks remove all tenant objects
+	// v, err := p.reader.Find(ctx, []string{tenantID}, func(opts backend.FindOpts) (bool, error) {
+	// 	return false, nil
+	// })
+
 	metricTenantIndexAgeSeconds.WithLabelValues(tenantID).Set(0)
 
 	return blocklist, compactedBlocklist, nil


### PR DESCRIPTION
Here is a proposal for how we might handle deleting a tenant entirely when they contain no blocks but objects are left in the backend for the tenant, thus keeping the tenant in the tenant list.

**What this PR does**:

* Implements a generic `FindFunc` to allow simple approaches of finding all objects in the backend at a particular path matching specific conditions.
* Updates the poller so that in cases where there are no blocks or compacted blocks, Find all objects with a modified time older than 1 hour and remove them from the backend.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`