### PR TITLE
Improves the size estimation when cutting new rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * [CHANGE] Restructure Azure backends into versioned backends.  Introduce `use_v2_sdk` config option for switching. [#2952](https://github.com/grafana/tempo/issues/2952) (@zalegrala)
     v1: [azure-storage-blob-go](https://github.com/Azure/azure-storage-blob-go) original (now deprecated) SDK
     v2: [azure-sdk-for-go](https://github.com/Azure/azure-sdk-for-go)
-* [CHANGE] Adjust trace size estimation to better honor row group size settings. [#2952](https://github.com/grafana/tempo/pull/3038) (@joe-elliott)
+* [CHANGE] Adjust trace size estimation to better honor row group size settings. [#3038](https://github.com/grafana/tempo/pull/3038) (@joe-elliott)
 * [ENHANCEMENT] Add block indexes to vParquet2 and vParquet3 to improve trace by ID lookup [#2697](https://github.com/grafana/tempo/pull/2697) (@mdisibio)
 * [ENHANCEMENT] Assert ingestion rate limits as early as possible [#2640](https://github.com/grafana/tempo/pull/2703) (@mghildiy)
 * [ENHANCEMENT] Add several metrics-generator fields to user-configurable overrides [#2711](https://github.com/grafana/tempo/pull/2711) (@kvrhdn)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [CHANGE] Restructure Azure backends into versioned backends.  Introduce `use_v2_sdk` config option for switching. [#2952](https://github.com/grafana/tempo/issues/2952) (@zalegrala)
     v1: [azure-storage-blob-go](https://github.com/Azure/azure-storage-blob-go) original (now deprecated) SDK
     v2: [azure-sdk-for-go](https://github.com/Azure/azure-sdk-for-go)
+* [CHANGE] Adjust trace size estimation to better honor row group size settings. [#2952](https://github.com/grafana/tempo/pull/3038) (@joe-elliott)
 * [ENHANCEMENT] Add block indexes to vParquet2 and vParquet3 to improve trace by ID lookup [#2697](https://github.com/grafana/tempo/pull/2697) (@mdisibio)
 * [ENHANCEMENT] Assert ingestion rate limits as early as possible [#2640](https://github.com/grafana/tempo/pull/2703) (@mghildiy)
 * [ENHANCEMENT] Add several metrics-generator fields to user-configurable overrides [#2711](https://github.com/grafana/tempo/pull/2711) (@kvrhdn)

--- a/tempodb/encoding/vparquet/compactor.go
+++ b/tempodb/encoding/vparquet/compactor.go
@@ -323,7 +323,9 @@ func estimateMarshalledSizeFromParquetRow(row parquet.Row) (size int) {
 		}
 
 		if sz > 1 {
-			sz = max(sz/25, 1) // 25 is a magic number that seems to work well
+			// for larger values, estimate 1 byte per 25 bytes. this is a very rough estimate
+			// but works well enough for our purposes.
+			sz = max(sz/25, 1) // nolint: typecheck
 		}
 
 		size += sz

--- a/tempodb/encoding/vparquet/compactor.go
+++ b/tempodb/encoding/vparquet/compactor.go
@@ -311,26 +311,7 @@ func estimateProtoSizeFromParquetRow(row parquet.Row) (size int) {
 // estimateMarshalledSizeFromParquetRow estimates the byte size as marshalled into parquet.
 // this is a very rough estimate and is generally 66%-100% of actual size.
 func estimateMarshalledSizeFromParquetRow(row parquet.Row) (size int) {
-	for _, v := range row {
-		sz := 1
-
-		switch v.Kind() {
-		case parquet.ByteArray:
-			sz = len(v.ByteArray())
-
-		case parquet.FixedLenByteArray:
-			sz = len(v.ByteArray())
-		}
-
-		if sz > 1 {
-			// for larger values, estimate 1 byte per 20 bytes. this is a very rough estimate
-			// but works well enough for our purposes. TODO: improve this calculation
-			sz = max(sz/20, 1) // nolint: typecheck
-		}
-
-		size += sz
-	}
-	return
+	return len(row)
 }
 
 // countSpans counts the number of spans in the given trace in deconstructed

--- a/tempodb/encoding/vparquet/compactor.go
+++ b/tempodb/encoding/vparquet/compactor.go
@@ -311,7 +311,24 @@ func estimateProtoSizeFromParquetRow(row parquet.Row) (size int) {
 // estimateMarshalledSizeFromParquetRow estimates the byte size as marshalled into parquet.
 // this is a very rough estimate and is generally 66%-100% of actual size.
 func estimateMarshalledSizeFromParquetRow(row parquet.Row) (size int) {
-	return len(row)
+	for _, v := range row {
+		sz := 1
+
+		switch v.Kind() {
+		case parquet.ByteArray:
+			sz = len(v.ByteArray())
+
+		case parquet.FixedLenByteArray:
+			sz = len(v.ByteArray())
+		}
+
+		if sz > 1 {
+			sz = max(sz/25, 1) // 25 is a magic number that seems to work well
+		}
+
+		size += sz
+	}
+	return
 }
 
 // countSpans counts the number of spans in the given trace in deconstructed

--- a/tempodb/encoding/vparquet/compactor.go
+++ b/tempodb/encoding/vparquet/compactor.go
@@ -323,9 +323,9 @@ func estimateMarshalledSizeFromParquetRow(row parquet.Row) (size int) {
 		}
 
 		if sz > 1 {
-			// for larger values, estimate 1 byte per 25 bytes. this is a very rough estimate
-			// but works well enough for our purposes.
-			sz = max(sz/25, 1) // nolint: typecheck
+			// for larger values, estimate 1 byte per 20 bytes. this is a very rough estimate
+			// but works well enough for our purposes. TODO: improve this calculation
+			sz = max(sz/20, 1) // nolint: typecheck
 		}
 
 		size += sz

--- a/tempodb/encoding/vparquet3/compactor.go
+++ b/tempodb/encoding/vparquet3/compactor.go
@@ -315,7 +315,26 @@ func estimateProtoSizeFromParquetRow(row parquet.Row) (size int) {
 // estimateMarshalledSizeFromParquetRow estimates the byte size as marshalled into parquet.
 // this is a very rough estimate and is generally 66%-100% of actual size.
 func estimateMarshalledSizeFromParquetRow(row parquet.Row) (size int) {
-	return len(row)
+	for _, v := range row {
+		sz := 1
+
+		switch v.Kind() {
+		case parquet.ByteArray:
+			sz = len(v.ByteArray())
+
+		case parquet.FixedLenByteArray:
+			sz = len(v.ByteArray())
+		}
+
+		if sz > 1 {
+			// for larger values, estimate 1 byte per 20 bytes. this is a very rough estimate
+			// but works well enough for our purposes. TODO: improve this calculation
+			sz = max(sz/20, 1) // nolint: typecheck
+		}
+
+		size += sz
+	}
+	return
 }
 
 // countSpans counts the number of spans in the given trace in deconstructed


### PR DESCRIPTION
**What this PR does**:
Recently we have discovered that tenants with extremely large strings in their attributes will cause Tempo to cut large row groups whose dictionary sizes can overflow an int32:

https://github.com/parquet-go/parquet-go/issues/79

This PR adjusts the size estimation to better take into account these very large strings. in an environment with a target rg size of 50MB the above change had the following impact to min/max/avg row group sizes:

https://github.com/grafana/tempo/issues/2731

**Which issue(s) this PR fixes**:
This PR, along with the fix to the parquet-go issue above, will help alleviate https://github.com/grafana/tempo/issues/2987 and https://github.com/grafana/tempo/issues/2731.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`