### PR TITLE
Update Alpine Image to 3.18.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [CHANGE] Restructure Azure backends into versioned backends.  Introduce `use_v2_sdk` config option for switching. [#2952](https://github.com/grafana/tempo/issues/2952) (@zalegrala)
     v1: [azure-storage-blob-go](https://github.com/Azure/azure-storage-blob-go) original (now deprecated) SDK
     v2: [azure-sdk-for-go](https://github.com/Azure/azure-sdk-for-go)
+* [CHANGE] Update alpine image version to 3.18. [#](https://github.com/grafana/tempo/pull/) (@joe-elliott)
 * [ENHANCEMENT] Add block indexes to vParquet2 and vParquet3 to improve trace by ID lookup [#2697](https://github.com/grafana/tempo/pull/2697) (@mdisibio)
 * [ENHANCEMENT] Assert ingestion rate limits as early as possible [#2640](https://github.com/grafana/tempo/pull/2703) (@mghildiy)
 * [ENHANCEMENT] Add several metrics-generator fields to user-configurable overrides [#2711](https://github.com/grafana/tempo/pull/2711) (@kvrhdn)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 * [CHANGE] Restructure Azure backends into versioned backends.  Introduce `use_v2_sdk` config option for switching. [#2952](https://github.com/grafana/tempo/issues/2952) (@zalegrala)
     v1: [azure-storage-blob-go](https://github.com/Azure/azure-storage-blob-go) original (now deprecated) SDK
     v2: [azure-sdk-for-go](https://github.com/Azure/azure-sdk-for-go)
-* [CHANGE] Update alpine image version to 3.18. [#](https://github.com/grafana/tempo/pull/) (@joe-elliott)
+* [CHANGE] Update alpine image version to 3.18. [#3046](https://github.com/grafana/tempo/pull/) (@joe-elliott)
 * [ENHANCEMENT] Add block indexes to vParquet2 and vParquet3 to improve trace by ID lookup [#2697](https://github.com/grafana/tempo/pull/2697) (@mdisibio)
 * [ENHANCEMENT] Assert ingestion rate limits as early as possible [#2640](https://github.com/grafana/tempo/pull/2703) (@mghildiy)
 * [ENHANCEMENT] Add several metrics-generator fields to user-configurable overrides [#2711](https://github.com/grafana/tempo/pull/2711) (@kvrhdn)

--- a/cmd/tempo-cli/Dockerfile
+++ b/cmd/tempo-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16 as certs
+FROM alpine:3.18 as certs
 RUN apk --update add ca-certificates
 ARG TARGETARCH
 COPY bin/linux/tempo-cli-${TARGETARCH} /tempo-cli

--- a/cmd/tempo-serverless/cloud-run/Dockerfile
+++ b/cmd/tempo-serverless/cloud-run/Dockerfile
@@ -9,7 +9,7 @@
 # build the serverless container image
 #
 #  todo: FROM scratch saves ~5MB which could be meaningful in a serverless setting, but using scratch gave strange errors on query.
-FROM alpine:3.16 as certs
+FROM alpine:3.18 as certs
 RUN apk --update add ca-certificates
 COPY ./main /main
 ENTRYPOINT ["/main"]

--- a/cmd/tempo-vulture/Dockerfile
+++ b/cmd/tempo-vulture/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16 as certs
+FROM alpine:3.18 as certs
 RUN apk --update add ca-certificates
 ARG TARGETARCH
 COPY bin/linux/tempo-vulture-${TARGETARCH} /tempo-vulture

--- a/cmd/tempo/Dockerfile
+++ b/cmd/tempo/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16 as certs
+FROM alpine:3.18 as certs
 RUN apk --update add ca-certificates
 ARG TARGETARCH
 COPY bin/linux/tempo-${TARGETARCH} /tempo

--- a/cmd/tempo/Dockerfile_debug
+++ b/cmd/tempo/Dockerfile_debug
@@ -2,7 +2,7 @@ FROM golang:alpine AS build-dlv
 
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
-FROM alpine:3.16 as certs
+FROM alpine:3.18 as certs
 RUN apk --update add ca-certificates bash
 ARG TARGETARCH
 COPY bin/linux/tempo-${TARGETARCH} /tempo


### PR DESCRIPTION
**What this PR does**:
Updates our base image to 3.18.x to patch CVE-2022-48174

**Which issue(s) this PR fixes**:
Update the Alpine image to fix [3.18](https://github.com/grafana/tempo/issues/3044) for Tempo. We will need to build a new release to fix GET.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`