### PR TITLE
[release-v2.3] Update parquet-go dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ defaults:
 * [BUGFIX] Fix issue where ingester doesn't stop query after timeout [#3031](https://github.com/grafana/tempo/pull/3031) (@mdisibio) 
 * [BUGFIX] Fix cases where empty filter {} wouldn't return expected results [#2498](https://github.com/grafana/tempo/issues/2498) (@mdisibio)
 * [BUGFIX] Reorder S3 credential chain and upgrade minio-go. `native_aws_auth_enabled` is deprecated [#3006](https://github.com/grafana/tempo/pull/3006) (@ekristen, @mapno)
+* [BUGFIX] Update parquet-go dependency including a bugfix that prevents corrupted blocks from being written [#3068](https://github.com/grafana/tempo/pull/3068) (@stoewer)
 
 # v2.2.3 / 2023-09-13
 

--- a/cmd/tempo-serverless/cloud-run/go.mod
+++ b/cmd/tempo-serverless/cloud-run/go.mod
@@ -94,7 +94,7 @@ require (
 	github.com/opentracing-contrib/go-grpc v0.0.0-20210225150812-73cb765af46e // indirect
 	github.com/opentracing-contrib/go-stdlib v1.0.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
-	github.com/parquet-go/parquet-go v0.18.1-0.20231002172823-4b0ea5ed3565 // indirect
+	github.com/parquet-go/parquet-go v0.18.1-0.20231023162157-1748e4b3ff04 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/pierrec/lz4/v4 v4.1.18 // indirect
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect

--- a/cmd/tempo-serverless/cloud-run/go.sum
+++ b/cmd/tempo-serverless/cloud-run/go.sum
@@ -763,8 +763,8 @@ github.com/opentracing-contrib/go-stdlib v1.0.0/go.mod h1:qtI1ogk+2JhVPIXVc6q+NH
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
-github.com/parquet-go/parquet-go v0.18.1-0.20231002172823-4b0ea5ed3565 h1:F0rZ3iHuqpF/IVbGvnMulL+H9Yy6OjB/zbvIwOCdtx8=
-github.com/parquet-go/parquet-go v0.18.1-0.20231002172823-4b0ea5ed3565/go.mod h1:6pu/Ca02WRyWyF6jbY1KceESGBZMsRMSijjLbajXaG8=
+github.com/parquet-go/parquet-go v0.18.1-0.20231023162157-1748e4b3ff04 h1:v5xe/XduDhXXcsbidemHvFrfkdDUt5gi5JzsC04lZ2w=
+github.com/parquet-go/parquet-go v0.18.1-0.20231023162157-1748e4b3ff04/go.mod h1:6pu/Ca02WRyWyF6jbY1KceESGBZMsRMSijjLbajXaG8=
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=
 github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNcZljzZR9VXg+4=
 github.com/pierrec/lz4/v4 v4.1.18 h1:xaKrnTkyoqfh1YItXl56+6KJNVYWlEEPuAQW9xsplYQ=

--- a/cmd/tempo-serverless/lambda/go.mod
+++ b/cmd/tempo-serverless/lambda/go.mod
@@ -97,7 +97,7 @@ require (
 	github.com/opentracing-contrib/go-grpc v0.0.0-20210225150812-73cb765af46e // indirect
 	github.com/opentracing-contrib/go-stdlib v1.0.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
-	github.com/parquet-go/parquet-go v0.18.1-0.20231002172823-4b0ea5ed3565 // indirect
+	github.com/parquet-go/parquet-go v0.18.1-0.20231023162157-1748e4b3ff04 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/pierrec/lz4/v4 v4.1.18 // indirect
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect

--- a/cmd/tempo-serverless/lambda/go.sum
+++ b/cmd/tempo-serverless/lambda/go.sum
@@ -767,8 +767,8 @@ github.com/opentracing-contrib/go-stdlib v1.0.0/go.mod h1:qtI1ogk+2JhVPIXVc6q+NH
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
-github.com/parquet-go/parquet-go v0.18.1-0.20231002172823-4b0ea5ed3565 h1:F0rZ3iHuqpF/IVbGvnMulL+H9Yy6OjB/zbvIwOCdtx8=
-github.com/parquet-go/parquet-go v0.18.1-0.20231002172823-4b0ea5ed3565/go.mod h1:6pu/Ca02WRyWyF6jbY1KceESGBZMsRMSijjLbajXaG8=
+github.com/parquet-go/parquet-go v0.18.1-0.20231023162157-1748e4b3ff04 h1:v5xe/XduDhXXcsbidemHvFrfkdDUt5gi5JzsC04lZ2w=
+github.com/parquet-go/parquet-go v0.18.1-0.20231023162157-1748e4b3ff04/go.mod h1:6pu/Ca02WRyWyF6jbY1KceESGBZMsRMSijjLbajXaG8=
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=
 github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNcZljzZR9VXg+4=
 github.com/pierrec/lz4/v4 v4.1.18 h1:xaKrnTkyoqfh1YItXl56+6KJNVYWlEEPuAQW9xsplYQ=

--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.74.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.74.0
-	github.com/parquet-go/parquet-go v0.18.1-0.20231002172823-4b0ea5ed3565
+	github.com/parquet-go/parquet-go v0.18.1-0.20231023162157-1748e4b3ff04
 	github.com/stoewer/parquet-cli v0.0.5
 	go.opentelemetry.io/collector/config/configgrpc v0.86.0
 	go.opentelemetry.io/collector/config/confighttp v0.86.0
@@ -121,6 +121,7 @@ require (
 	go.opentelemetry.io/collector/receiver v0.86.0
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 	golang.org/x/oauth2 v0.12.0
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230717213848-3f92550aa753
 )
 
 require (
@@ -316,7 +317,6 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230717213848-3f92550aa753 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230717213848-3f92550aa753 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20230717213848-3f92550aa753 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1593,8 +1593,8 @@ github.com/openzipkin/zipkin-go v0.4.2 h1:zjqfqHjUpPmB3c1GlCvvgsM1G4LkvqQbBDueDO
 github.com/openzipkin/zipkin-go v0.4.2/go.mod h1:ZeVkFjuuBiSy13y8vpSDCjMi9GoI3hPpCJSBx/EYFhY=
 github.com/ovh/go-ovh v1.4.1 h1:VBGa5wMyQtTP7Zb+w97zRCh9sLtM/2YKRyy+MEJmWaM=
 github.com/ovh/go-ovh v1.4.1/go.mod h1:6bL6pPyUT7tBfI0pqOegJgRjgjuO+mOo+MyXd1EEC0M=
-github.com/parquet-go/parquet-go v0.18.1-0.20231002172823-4b0ea5ed3565 h1:F0rZ3iHuqpF/IVbGvnMulL+H9Yy6OjB/zbvIwOCdtx8=
-github.com/parquet-go/parquet-go v0.18.1-0.20231002172823-4b0ea5ed3565/go.mod h1:6pu/Ca02WRyWyF6jbY1KceESGBZMsRMSijjLbajXaG8=
+github.com/parquet-go/parquet-go v0.18.1-0.20231023162157-1748e4b3ff04 h1:v5xe/XduDhXXcsbidemHvFrfkdDUt5gi5JzsC04lZ2w=
+github.com/parquet-go/parquet-go v0.18.1-0.20231023162157-1748e4b3ff04/go.mod h1:6pu/Ca02WRyWyF6jbY1KceESGBZMsRMSijjLbajXaG8=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/vendor/github.com/parquet-go/parquet-go/README.md
+++ b/vendor/github.com/parquet-go/parquet-go/README.md
@@ -39,7 +39,7 @@ dependency on and install with the following command:
 go get github.com/parquet-go/parquet-go
 ```
 
-Go 1.18 or later is required to use the package.
+Go 1.20 or later is required to use the package.
 
 ### Compatibility Guarantees
 

--- a/vendor/github.com/parquet-go/parquet-go/column.go
+++ b/vendor/github.com/parquet-go/parquet-go/column.go
@@ -76,6 +76,9 @@ func (c *Column) Path() []string { return c.path[1:] }
 // Name returns the column name.
 func (c *Column) Name() string { return c.schema.Name }
 
+// ID returns column field id
+func (c *Column) ID() int { return int(c.schema.FieldID) }
+
 // Columns returns the list of child columns.
 //
 // The method returns the same slice across multiple calls, the program must

--- a/vendor/github.com/parquet-go/parquet-go/merge.go
+++ b/vendor/github.com/parquet-go/parquet-go/merge.go
@@ -460,6 +460,10 @@ func (m *mergeBuffer) left() bool {
 func (m *mergeBuffer) read() (n int64) {
 	for n < int64(len(m.copy)) && m.Len() != 0 {
 		r := m.buffer[:m.len][0]
+		if len(r) == 0 {
+			heap.Pop(m)
+			continue
+		}
 		m.copy[n] = append(m.copy[n][:0], r[m.head[0]]...)
 		m.head[0]++
 		n++

--- a/vendor/github.com/parquet-go/parquet-go/node.go
+++ b/vendor/github.com/parquet-go/parquet-go/node.go
@@ -21,6 +21,12 @@ import (
 // Nodes are immutable values and therefore safe to use concurrently from
 // multiple goroutines.
 type Node interface {
+	// The id of this node in its parent node. Zero value is treated as id is not
+	// set. ID only needs to be unique within its parent context.
+	//
+	// This is the same as parquet field_id
+	ID() int
+
 	// Returns a human-readable representation of the parquet node.
 	String() string
 
@@ -156,6 +162,16 @@ func (opt *optionalNode) Repeated() bool       { return false }
 func (opt *optionalNode) Required() bool       { return false }
 func (opt *optionalNode) GoType() reflect.Type { return reflect.PtrTo(opt.Node.GoType()) }
 
+// FieldID wraps a node to provide node field id
+func FieldID(node Node, id int) Node { return &fieldIDNode{Node: node, id: id} }
+
+type fieldIDNode struct {
+	Node
+	id int
+}
+
+func (f *fieldIDNode) ID() int { return f.id }
+
 // Repeated wraps the given node to make it repeated.
 func Repeated(node Node) Node { return &repeatedNode{node} }
 
@@ -184,6 +200,8 @@ func Leaf(typ Type) Node {
 }
 
 type leafNode struct{ typ Type }
+
+func (n *leafNode) ID() int { return 0 }
 
 func (n *leafNode) String() string { return sprint("", n) }
 
@@ -247,6 +265,8 @@ func applyFieldRepetitionType(t format.FieldRepetitionType, repetitionLevel, def
 }
 
 type Group map[string]Node
+
+func (g Group) ID() int { return 0 }
 
 func (g Group) String() string { return sprint("", g) }
 

--- a/vendor/github.com/parquet-go/parquet-go/print.go
+++ b/vendor/github.com/parquet-go/parquet-go/print.go
@@ -94,6 +94,11 @@ func printSchemaWithIndent(w io.StringWriter, name string, node Node, indent *pr
 			w.WriteString(")")
 		}
 
+		if id := node.ID(); id != 0 {
+			w.WriteString(" = ")
+			w.WriteString(strconv.Itoa(id))
+		}
+
 		w.WriteString(";")
 	} else {
 		w.WriteString("group")
@@ -107,6 +112,11 @@ func printSchemaWithIndent(w io.StringWriter, name string, node Node, indent *pr
 			w.WriteString(" (")
 			w.WriteString(annotation)
 			w.WriteString(")")
+		}
+
+		if id := node.ID(); id != 0 {
+			w.WriteString(" = ")
+			w.WriteString(strconv.Itoa(id))
 		}
 
 		w.WriteString(" {")

--- a/vendor/github.com/parquet-go/parquet-go/writer.go
+++ b/vendor/github.com/parquet-go/parquet-go/writer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
+	"math"
 	"math/bits"
 	"reflect"
 	"sort"
@@ -16,6 +17,12 @@ import (
 	"github.com/parquet-go/parquet-go/encoding/plain"
 	"github.com/parquet-go/parquet-go/format"
 	"github.com/segmentio/encoding/thrift"
+)
+
+const (
+	// The uncompressed page size is stored as int32 and must not be larger than the
+	// maximum int32 value (see format.PageHeader).
+	maxUncompressedPageSize = math.MaxInt32
 )
 
 // GenericWriter is similar to a Writer but uses a type parameter to define the
@@ -516,7 +523,6 @@ func newWriter(output io.Writer, config *WriterConfig) *writer {
 		if node != config.Schema { // the root has no repetition type
 			repetitionType = fieldRepetitionTypePtrOf(node)
 		}
-
 		// For backward compatibility with older readers, the parquet specification
 		// recommends to set the scale and precision on schema elements when the
 		// column is of logical type decimal.
@@ -541,6 +547,7 @@ func newWriter(output io.Writer, config *WriterConfig) *writer {
 			ConvertedType:  nodeType.ConvertedType(),
 			Scale:          scale,
 			Precision:      precision,
+			FieldID:        int32(node.ID()),
 			LogicalType:    logicalType,
 		})
 	})
@@ -1363,6 +1370,9 @@ func (c *writerColumn) writeDataPage(page Page) (int64, error) {
 	}
 
 	uncompressedPageSize := buf.size()
+	if uncompressedPageSize > maxUncompressedPageSize {
+		return 0, fmt.Errorf("page size limit exceeded: %d>%d", uncompressedPageSize, maxUncompressedPageSize)
+	}
 	if c.isCompressed {
 		if err := buf.compress(c.compression); err != nil {
 			return 0, fmt.Errorf("compressing parquet data page: %w", err)
@@ -1458,6 +1468,9 @@ func (c *writerColumn) writeDictionaryPage(output io.Writer, dict Dictionary) (e
 	}
 
 	uncompressedPageSize := buf.size()
+	if uncompressedPageSize > maxUncompressedPageSize {
+		return fmt.Errorf("page size limit exceeded: %d>%d", uncompressedPageSize, maxUncompressedPageSize)
+	}
 	if isCompressed(c.compression) {
 		if err := buf.compress(c.compression); err != nil {
 			return fmt.Errorf("copmressing parquet dictionary page: %w", err)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -951,7 +951,7 @@ github.com/opentracing/opentracing-go/log
 github.com/openzipkin/zipkin-go/model
 github.com/openzipkin/zipkin-go/proto/zipkin_proto3
 github.com/openzipkin/zipkin-go/reporter
-# github.com/parquet-go/parquet-go v0.18.1-0.20231002172823-4b0ea5ed3565
+# github.com/parquet-go/parquet-go v0.18.1-0.20231023162157-1748e4b3ff04
 ## explicit; go 1.20
 github.com/parquet-go/parquet-go
 github.com/parquet-go/parquet-go/bloom


### PR DESCRIPTION
Backport 419288d49dae887d8887aae24e83f3407665f8f1 from #3068

---

**What this PR does**:

Among other changes the parquet-go update contains a fix that avoids blocks with overflows in the uncompressed page size

**Which issue(s) this PR fixes**:

Helps to mitigate #2987

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
