### PR TITLE
[TraceQL] Reduce work performed for structural operators due to a bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [CHANGE] TraceQL/Structural operators performance improvement. [#3088](https://github.com/grafana/tempo/pull/3088) (@joe-elliott)
 * [BUGFIX] Include statusMessage intrinsic attribute in tag search. [#3084](https://github.com/grafana/tempo/pull/3084) (@rcrowe)
 
 ## v2.3.0-rc.0 / 2023-10-20

--- a/pkg/traceql/ast_execute.go
+++ b/pkg/traceql/ast_execute.go
@@ -469,7 +469,10 @@ func (a Attribute) execute(span Span) (Static, error) {
 		return static, nil
 	}
 
-	if a.Scope == AttributeScopeNone {
+	// if the requested attribute has a scope none then we will check first for span attributes matching
+	// then any attributes matching. we don't need to both if this is an intrinsic b/c those will always
+	// be caught above if they exist
+	if a.Scope == AttributeScopeNone && a.Intrinsic == IntrinsicNone {
 		for attribute, static := range atts {
 			if a.Name == attribute.Name && attribute.Scope == AttributeScopeSpan {
 				return static, nil

--- a/tempodb/encoding/vparquet2/block_traceql.go
+++ b/tempodb/encoding/vparquet2/block_traceql.go
@@ -1036,13 +1036,16 @@ func createSpanIterator(makeIter makeIterFn, primaryIter parquetquery.Iterator, 
 		case traceql.IntrinsicStructuralDescendant:
 			selectColumnIfNotAlready(columnPathSpanNestedSetLeft)
 			selectColumnIfNotAlready(columnPathSpanNestedSetRight)
+			continue
 
 		case traceql.IntrinsicStructuralChild:
 			selectColumnIfNotAlready(columnPathSpanNestedSetLeft)
 			selectColumnIfNotAlready(columnPathSpanParentID)
+			continue
 
 		case traceql.IntrinsicStructuralSibling:
 			selectColumnIfNotAlready(columnPathSpanParentID)
+			continue
 		}
 
 		// Well-known attribute?

--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -1037,13 +1037,16 @@ func createSpanIterator(makeIter makeIterFn, primaryIter parquetquery.Iterator, 
 		case traceql.IntrinsicStructuralDescendant:
 			selectColumnIfNotAlready(columnPathSpanNestedSetLeft)
 			selectColumnIfNotAlready(columnPathSpanNestedSetRight)
+			continue
 
 		case traceql.IntrinsicStructuralChild:
 			selectColumnIfNotAlready(columnPathSpanNestedSetLeft)
 			selectColumnIfNotAlready(columnPathSpanParentID)
+			continue
 
 		case traceql.IntrinsicStructuralSibling:
 			selectColumnIfNotAlready(columnPathSpanParentID)
+			continue
 		}
 
 		// Well-known attribute?


### PR DESCRIPTION
**What this PR does**:
Prevents additional columns from being added as iterators when doing structural queries. For the query `{ resource.service.name = "loki-querier" } >> { resource.service.name = "loki-querier" }`, the following iterators were generated.

Before:
```
rebatchIterator: 
	JoinIterator: 0: traceCollector()	
		LeftJoinIterator: 1: batchCollector(true, 0)
		required: 
			LeftJoinIterator: 3: spanCollector(0)
			required: 
				SyncIterator: rs.list.element.ss.list.element.Spans.list.element.Kind : InstrumentedPredicate{2, nil}
			optional: 
				LeftJoinIterator: 4: attributeCollector{}
				required: 
					SyncIterator: rs.list.element.ss.list.element.Spans.list.element.Attrs.list.element.Key : InstrumentedPredicate{0, StringInPredicate{intrinsic(11), }}
				optional: 
					SyncIterator: rs.list.element.ss.list.element.Spans.list.element.Attrs.list.element.Value : InstrumentedPredicate{8, nil}
					SyncIterator: rs.list.element.ss.list.element.Spans.list.element.Attrs.list.element.ValueInt : InstrumentedPredicate{8, nil}
					SyncIterator: rs.list.element.ss.list.element.Spans.list.element.Attrs.list.element.ValueDouble : InstrumentedPredicate{8, nil}
					SyncIterator: rs.list.element.ss.list.element.Spans.list.element.Attrs.list.element.ValueBool : InstrumentedPredicate{8, nil}
				SyncIterator: rs.list.element.ss.list.element.Spans.list.element.NestedSetLeft : InstrumentedPredicate{2, nil}
				SyncIterator: rs.list.element.ss.list.element.Spans.list.element.NestedSetRight : InstrumentedPredicate{2, nil}
		optional: 
			SyncIterator: rs.list.element.Resource.ServiceName : InstrumentedPredicate{0, StringInPredicate{loki-querier, }}
			SyncIterator: rs.list.element.Resource.ServiceName : InstrumentedPredicate{0, StringInPredicate{loki-querier, }}
		SyncIterator: StartTimeUnixNano : InstrumentedPredicate{0, IntBetweenPredicate{0,1001000000000}}
		SyncIterator: EndTimeUnixNano : InstrumentedPredicate{0, IntBetweenPredicate{1000000000000,9223372036854775807}})
```

After:
```
rebatchIterator: 
	JoinIterator: 0: traceCollector()	
		LeftJoinIterator: 1: batchCollector(true, 0)
		required: 
			LeftJoinIterator: 3: spanCollector(0)
			required: 
				SyncIterator: rs.list.element.ss.list.element.Spans.list.element.Kind : InstrumentedPredicate{2, nil}
			optional: 
				SyncIterator: rs.list.element.ss.list.element.Spans.list.element.NestedSetLeft : InstrumentedPredicate{2, nil}
				SyncIterator: rs.list.element.ss.list.element.Spans.list.element.NestedSetRight : InstrumentedPredicate{2, nil}
		optional: 
			SyncIterator: rs.list.element.Resource.ServiceName : InstrumentedPredicate{0, StringInPredicate{loki-querier, }}
			SyncIterator: rs.list.element.Resource.ServiceName : InstrumentedPredicate{0, StringInPredicate{loki-querier, }}
		SyncIterator: StartTimeUnixNano : InstrumentedPredicate{0, IntBetweenPredicate{0,1001000000000}}
		SyncIterator: EndTimeUnixNano : InstrumentedPredicate{0, IntBetweenPredicate{1000000000000,9223372036854775807}})
```

Also finds a minor performance improvement for situations where a span has a nil intrinsic. This happens regularly for queries like `{ status = error }` where most entries in the StatusCode column are nil.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`