### PR TITLE
Set GRAFANA_VERSION used throughout shared lookups

### DIFF
--- a/docs/sources/tempo/_index.md
+++ b/docs/sources/tempo/_index.md
@@ -3,6 +3,8 @@ title: Tempo documentation
 description: Grafana Tempo is an open source distributed tracing backend.
 aliases:
   - /docs/tempo/
+cascade:
+  GRAFANA_VERSION: next
 ---
 
 # Tempo documentation

--- a/docs/sources/tempo/traceql/query-editor/traceql-editor.md
+++ b/docs/sources/tempo/traceql/query-editor/traceql-editor.md
@@ -11,7 +11,7 @@ title: Write TraceQL queries with the editor
 
 # Write TraceQL queries with the editor
 
-[//]: # 'Shared content for the TraceQL query editor'
-[//]: # 'This content is located in /docs/sources/shared/datasources/tempo-editor-traceql.md'
+[//]: # "Shared content for the TraceQL query editor"
+[//]: # "This content is located in /docs/sources/shared/datasources/tempo-editor-traceql.md"
 
-{{< docs/shared source="grafana" lookup="datasources/tempo-editor-traceql.md" version="<GRAFANA VERSION>" >}}
+{{< docs/shared source="grafana" lookup="datasources/tempo-editor-traceql.md" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/tempo/traceql/query-editor/traceql-search.md
+++ b/docs/sources/tempo/traceql/query-editor/traceql-search.md
@@ -27,6 +27,6 @@ This feature is automatically available in Grafana 10 (and newer) and Grafana Cl
 
 To enable the TraceQL query builder in self-hosted Grafana through version 10.1, [enable the `traceqlSearch` feature toggle](/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/).
 
-[//]: # 'Shared content for the Search - TraceQL query builder'
+[//]: # "Shared content for the Search - TraceQL query builder"
 
-{{< docs/shared source="grafana" lookup="datasources/tempo-search-traceql.md" leveloffset="+1" version="<GRAFANA VERSION>" >}}
+{{< docs/shared source="grafana" lookup="datasources/tempo-search-traceql.md" leveloffset="+1" version="<GRAFANA_VERSION>" >}}


### PR DESCRIPTION
It was working in "next" because the fallback behavior is to use the page's version for any "SOMETHING_VERSION" lookup.
Therefore, the `docs/shared` lookup coincidentally targeted "next" which exists in the Grafana documentation.

Now that we have cut a new release with these docs, the released version is being used which is causing errors because `v2.3.x` is not a valid Grafana version.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
