### PR TITLE
Fix hyphenation in not- structural operators

### DIFF
--- a/docs/sources/tempo/release-notes/v2-3.md
+++ b/docs/sources/tempo/release-notes/v2-3.md
@@ -15,16 +15,16 @@ This release gives you:
     * Ancestor (`<<`)
     * Parent (`<`)
     * Not-child (`!>`) (experimental)
-    * Not descendant (`!>>`) (experimental)
-    * Not ancestor (`!<<`) (experimental)
-    * Not parent (`!<`) (experimental)
-    * Not siblings (`!~`) (experimental)
+    * Not-descendant (`!>>`) (experimental)
+    * Not-ancestor (`!<<`) (experimental)
+    * Not-parent (`!<`) (experimental)
+    * Not-siblings (`!~`) (experimental)
 
 * TraceQL support for [searching quoted attributes]({{< relref "../traceql#experimental-structural" >}}) (for example, `{ span."name with spaces" = "foo" }`).
 * [Dedicated attribute columns]({{< relref "../operations/dedicated_columns" >}}) for improving query performance on your most frequently queried attributes
 
 Tempo 2.3 introduces [vParquet3]({{< relref "../configuration/parquet" >}}), a Parquet version designed to be more compatible with other Parquet implementations, available as a production-ready option.
-This block format improves query performance relative to previous formats. 
+This block format improves query performance relative to previous formats.
 
 Read the **Tempo 2.3 blog post** for more examples and details about these improvements.
 


### PR DESCRIPTION
**What this PR does**:
Hyphenates the  not structural operators to be consistent with the documentation. 

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`