### PR TITLE
[DOC] Update instrumentation doc to focus on OTel

### DIFF
--- a/docs/sources/tempo/getting-started/instrumentation.md
+++ b/docs/sources/tempo/getting-started/instrumentation.md
@@ -7,52 +7,71 @@ aliases:
 weight: 200
 ---
 
-
 # Instrument for distributed tracing
 
 Client instrumentation is the first building block to a functioning distributed tracing visualization pipeline.
 Client instrumentation is the process of adding instrumentation points in the application that create and offload spans.
 
 Check out these resources for help instrumenting tracing with your favorite languages.
-Most of these guides include complete end-to-end examples with Grafana, Loki, and Tempo.
+Most of these guides include complete end-to-end examples with Grafana, Loki, Mimir, and Tempo.
 
-### Instrumentation frameworks
+## Instrumentation frameworks
 
-Most of the popular client instrumentation frameworks
-have SDKs in the most commonly used programming languages.
+Most of the popular client instrumentation frameworks have SDKs in the most commonly used programming languages.
 You should pick one according to your application needs.
 
+* [OpenTelemetry](https://opentelemetry.io/docs/concepts/instrumenting/)
 * [OpenTracing/Jaeger](https://www.jaegertracing.io/docs/latest/client-libraries/)
 * [Zipkin](https://zipkin.io/pages/tracers_instrumentation)
-* [OpenTelemetry](https://opentelemetry.io/docs/concepts/instrumenting/)
 
-### OpenTelemetry auto-instrumentation
-
-Some languages have support for auto-instrumentation. These libraries capture telemetry
-information from a client application with minimal manual instrumentation of the codebase.
-
-* [OpenTelemetry Java auto-instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation)
-* [OpenTelemetry .NET auto-instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation)
-* [OpenTelemetry Python auto-instrumentation](https://github.com/open-telemetry/opentelemetry-python-contrib)
 
 ## OpenTelemetry
 
+A collection of tools, APIs, and SDKs, [OpenTelemetry](https://grafana.com/docs/opentelemetry/) helps engineers instrument, generate, collect, and export telemetry data such as metrics, logs, and traces, to analyze software performance and behavior.
+
+### Auto-instrumentation frameworks
+
+OpenTelemetry provides auto-instrumentation agents and libraries of Java, .Net, Python, Go, and JavaScript applications, among others.
+For more information, refer for the [OpenTelemetry Instrumentation documentation](https://opentelemetry.io/docs/instrumentation/).
+
+These libraries capture telemetry
+information from a client application with minimal manual instrumentation of the codebase.
+
+* [OpenTelemetry Java auto-instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation) and [documentation](/docs/opentelemetry/instrumentation/java/)
+    - [Java auto-instrumentation with Java and OTel Java Agent](/docs/opentelemetry/instrumentation/java/javaagent/)
+    - [Automatic instrumentation of Spring Boot 3.x applications with Grafana OpenTelemetry Starter](/docs/opentelemetry/instrumentation/java/spring-starter/)
+* [OpenTelemetry .NET auto-instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation)
+* [OpenTelemetry Python auto-instrumentation](https://github.com/open-telemetry/opentelemetry-python-contrib)
+* [OpenTelemetry Go auto-instrumentation](https://github.com/open-telemetry/opentelemetry-go-instrumentation) and [documentation](https://opentelemetry.io/docs/instrumentation/go/getting-started/)
+
+
+### Additional OTel resources
+
+- [Java HTTP Metrics from OpenTelemetry Traces](/docs/opentelemetry/instrumentation/java/metrics-from-traces/)
+- [OpenTelemetry documentation at Grafana](h/docs/opentelemetry)
+- [OpenTelemetry Go instrumentation examples](https://github.com/open-telemetry/opentelemetry-go/tree/main/example)
 - [OpenTelemetry Language Specific Instrumentation](https://opentelemetry.io/docs/instrumentation/)
 
-## Jaeger
+## Other instrumentation resources
+
+### Jaeger
+
 - [Jaeger Language Specific Instrumentation](https://www.jaegertracing.io/docs/latest/client-libraries/)
 
-## Zipkin
+### Zipkin
+
 - [Zipkin Language Specific Instrumentation](https://zipkin.io/pages/tracers_instrumentation.html)
 
 ## Grafana Blog
+
+The Grafana blot periodically features instrumentation posts.
 
 - [Java Spring Boot Auto-Instrumentation](/blog/2021/02/03/auto-instrumenting-a-java-spring-boot-application-for-traces-and-logs-using-opentelemetry-and-grafana-tempo/)
 - [Go + OpenMetrics Exemplars](/blog/2020/11/09/trace-discovery-in-grafana-tempo-using-prometheus-exemplars-loki-2.0-queries-and-more/)
 - [.NET](/blog/2021/02/11/instrumenting-a-.net-web-api-using-opentelemetry-tempo-and-grafana-cloud/)
 - [Python](/blog/2021/05/04/get-started-with-distributed-tracing-and-grafana-tempo-using-foobar-a-demo-written-in-python/)
 
-## Community Resources
+## Community resources
 
 - [NodeJS](https://github.com/mnadeem/nodejs-opentelemetry-tempo)
 - [Java Spring Boot](https://github.com/mnadeem/boot-opentelemetry-tempo)

--- a/docs/sources/tempo/getting-started/instrumentation.md
+++ b/docs/sources/tempo/getting-started/instrumentation.md
@@ -27,7 +27,7 @@ You should pick one according to your application needs.
 
 ## OpenTelemetry
 
-A collection of tools, APIs, and SDKs, [OpenTelemetry](https://grafana.com/docs/opentelemetry/) helps engineers instrument, generate, collect, and export telemetry data such as metrics, logs, and traces, to analyze software performance and behavior.
+A collection of tools, APIs, and SDKs, [OpenTelemetry](/docs/opentelemetry) helps engineers instrument, generate, collect, and export telemetry data such as metrics, logs, and traces, to analyze software performance and behavior.
 
 ### Auto-instrumentation frameworks
 

--- a/docs/sources/tempo/getting-started/instrumentation.md
+++ b/docs/sources/tempo/getting-started/instrumentation.md
@@ -48,7 +48,7 @@ information from a client application with minimal manual instrumentation of the
 ### Additional OTel resources
 
 - [Java HTTP Metrics from OpenTelemetry Traces](/docs/opentelemetry/instrumentation/java/metrics-from-traces/)
-- [OpenTelemetry documentation at Grafana](h/docs/opentelemetry)
+- [OpenTelemetry documentation at Grafana](/docs/opentelemetry)
 - [OpenTelemetry Go instrumentation examples](https://github.com/open-telemetry/opentelemetry-go/tree/main/example)
 - [OpenTelemetry Language Specific Instrumentation](https://opentelemetry.io/docs/instrumentation/)
 


### PR DESCRIPTION
Updates the structure of the instrumentation page to restructure to focus on OTel and add links from the Grafana OTel documentation.

Which issue(s) this PR fixes:
Fixes https://github.com/grafana/tempo-squad/issues/211

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`