### PR TITLE
TraceQL Performance: Drop Clone

### DIFF
--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -843,7 +843,7 @@ func (c *SyncIterator) makeResult(t RowNumber, v *pq.Value) *IteratorResult {
 	r := GetResult()
 	r.RowNumber = t
 	if c.selectAs != "" {
-		r.AppendValue(c.selectAs, v.Clone())
+		r.AppendValue(c.selectAs, *v)
 	}
 	return r
 }


### PR DESCRIPTION
**What this PR does**:
Drops a call to clone in the iterator to reduce memory consumption. This change gives a small %age gain on most queries and larger gains on some. This query
```
{ resource.service.name != `loki-ingester` } >> { resource.service.name = `loki-ingester` }
```
has these benchmarks:
```
name                                    old time/op    new time/op    delta
BackendBlockTraceQL/mixedNameNoMatch-8     2.18s ± 6%     2.14s ± 3%     ~     (p=1.000 n=5+5)

name                                    old speed      new speed      delta
BackendBlockTraceQL/mixedNameNoMatch-8   864kB/s ± 6%   872kB/s ± 3%     ~     (p=0.770 n=5+5)

name                                    old MB_io/op   new MB_io/op   delta
BackendBlockTraceQL/mixedNameNoMatch-8      1.87 ± 0%      1.87 ± 0%     ~     (all equal)

name                                    old alloc/op   new alloc/op   delta
BackendBlockTraceQL/mixedNameNoMatch-8    33.4MB ±10%    51.6MB ±94%     ~     (p=0.730 n=4+5)

name                                    old allocs/op  new allocs/op  delta
BackendBlockTraceQL/mixedNameNoMatch-8      636k ± 0%      488k ±18%  -23.29%  (p=0.016 n=4+5)
```
I believe this is safe because lines like these in the fetch layer cause a clone of the underlying data:

https://github.com/grafana/tempo/blob/main/tempodb/encoding/vparquet3/block_traceql.go#L1713