### PR TITLE
vParquet4: handle unsupported / dropped attributes

### DIFF
--- a/tempodb/encoding/vparquet3/block_findtracebyid.go
+++ b/tempodb/encoding/vparquet3/block_findtracebyid.go
@@ -259,7 +259,7 @@ func findTraceByID(ctx context.Context, traceID common.ID, maxTraceSizeBytes int
 	}
 
 	// convert to proto trace and return
-	return parquetTraceToTempopbTrace(meta, tr), nil
+	return parquetTraceToTempopbTrace(meta, tr, false), nil
 }
 
 // binarySearch that finds exact matching entry. Returns non-zero index when found, or -1 when not found

--- a/tempodb/encoding/vparquet3/block_findtracebyid_test.go
+++ b/tempodb/encoding/vparquet3/block_findtracebyid_test.go
@@ -95,7 +95,7 @@ func TestBackendBlockFindTraceByID(t *testing.T) {
 
 	// Now find and verify all test traces
 	for _, tr := range traces {
-		wantProto := parquetTraceToTempopbTrace(meta, tr)
+		wantProto := parquetTraceToTempopbTrace(meta, tr, false)
 
 		gotProto, err := b.FindTraceByID(ctx, tr.TraceID, common.DefaultSearchOptions())
 		require.NoError(t, err)

--- a/tempodb/encoding/vparquet3/schema.go
+++ b/tempodb/encoding/vparquet3/schema.go
@@ -107,7 +107,7 @@ var (
 
 // droppedAttrCounter represents an entity that can count dropped attributes
 type droppedAttrCounter interface {
-	droppedAttrAdd(n int32)
+	addDroppedAttr(n int32)
 }
 
 type Attribute struct {
@@ -180,7 +180,7 @@ type Span struct {
 	DedicatedAttributes DedicatedAttributes `parquet:""`
 }
 
-func (s *Span) droppedAttrAdd(n int32) {
+func (s *Span) addDroppedAttr(n int32) {
 	s.DroppedAttributesCount += n
 }
 
@@ -217,7 +217,7 @@ type Resource struct {
 	DedicatedAttributes DedicatedAttributes `parquet:""`
 }
 
-func (r *Resource) droppedAttrAdd(n int32) {
+func (r *Resource) addDroppedAttr(n int32) {
 	r.DroppedAttributesCount += n
 }
 
@@ -264,7 +264,7 @@ func attrToParquet(a *v1.KeyValue, p *Attribute, counter droppedAttrCounter) {
 		jsonBytes := &bytes.Buffer{}
 		_ = jsonMarshaler.Marshal(jsonBytes, a.Value) // deliberately marshalling a.Value because of AnyValue logic
 		p.ValueDropped = jsonBytes.String()
-		counter.droppedAttrAdd(1)
+		counter.addDroppedAttr(1)
 	}
 }
 
@@ -525,7 +525,7 @@ func parquetToProtoAttrs(parquetAttrs []Attribute, counter droppedAttrCounter, i
 			}
 		} else if attr.ValueDropped != "" && includeDroppedAttr {
 			_ = jsonpb.Unmarshal(bytes.NewBufferString(attr.ValueDropped), protoVal)
-			counter.droppedAttrAdd(-1)
+			counter.addDroppedAttr(-1)
 		}
 
 		protoAttrs = append(protoAttrs, &v1.KeyValue{

--- a/tempodb/encoding/vparquet3/schema_test.go
+++ b/tempodb/encoding/vparquet3/schema_test.go
@@ -30,11 +30,11 @@ func TestProtoParquetRoundTrip(t *testing.T) {
 	}
 	traceIDA := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}
 
-	expectedTrace := parquetTraceToTempopbTrace(&meta, fullyPopulatedTestTrace(traceIDA))
+	expectedTrace := parquetTraceToTempopbTrace(&meta, fullyPopulatedTestTrace(traceIDA), true)
 
 	parquetTrace, connected := traceToParquet(&meta, traceIDA, expectedTrace, nil)
 	require.True(t, connected)
-	actualTrace := parquetTraceToTempopbTrace(&meta, parquetTrace)
+	actualTrace := parquetTraceToTempopbTrace(&meta, parquetTrace, true)
 	assert.Equal(t, expectedTrace, actualTrace)
 }
 
@@ -57,7 +57,7 @@ func TestProtoParquetRando(t *testing.T) {
 		expectedTrace := test.AddDedicatedAttributes(test.MakeTrace(batches, id))
 
 		parqTr, _ := traceToParquet(&backend.BlockMeta{}, id, expectedTrace, trp)
-		actualTrace := parquetTraceToTempopbTrace(&backend.BlockMeta{}, parqTr)
+		actualTrace := parquetTraceToTempopbTrace(&backend.BlockMeta{}, parqTr, true)
 		require.Equal(t, expectedTrace, actualTrace)
 	}
 }
@@ -68,7 +68,7 @@ func TestFieldsAreCleared(t *testing.T) {
 	}
 
 	traceID := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}
-	complexTrace := parquetTraceToTempopbTrace(&meta, fullyPopulatedTestTrace(traceID))
+	complexTrace := parquetTraceToTempopbTrace(&meta, fullyPopulatedTestTrace(traceID), false)
 	simpleTrace := &tempopb.Trace{
 		Batches: []*v1_trace.ResourceSpans{
 			{
@@ -76,6 +76,7 @@ func TestFieldsAreCleared(t *testing.T) {
 					Attributes: []*v1.KeyValue{
 						{Key: "i", Value: &v1.AnyValue{Value: &v1.AnyValue_IntValue{IntValue: 123}}},
 					},
+					DroppedAttributesCount: 10,
 				},
 				ScopeSpans: []*v1_trace.ScopeSpans{
 					{
@@ -115,7 +116,7 @@ func TestFieldsAreCleared(t *testing.T) {
 	_, _ = traceToParquet(&meta, traceID, complexTrace, tr)
 
 	parqTr, _ := traceToParquet(&meta, traceID, simpleTrace, tr)
-	actualTrace := parquetTraceToTempopbTrace(&meta, parqTr)
+	actualTrace := parquetTraceToTempopbTrace(&meta, parqTr, false)
 	require.Equal(t, simpleTrace, actualTrace)
 }
 

--- a/tempodb/encoding/vparquet3/wal_block.go
+++ b/tempodb/encoding/vparquet3/wal_block.go
@@ -532,7 +532,7 @@ func (b *walBlock) FindTraceByID(ctx context.Context, id common.ID, opts common.
 				return nil, fmt.Errorf("error reading row from backend: %w", err)
 			}
 
-			trp := parquetTraceToTempopbTrace(b.meta, tr)
+			trp := parquetTraceToTempopbTrace(b.meta, tr, false)
 
 			trs = append(trs, trp)
 		}
@@ -809,7 +809,7 @@ func (i *commonIterator) Next(ctx context.Context) (common.ID, *tempopb.Trace, e
 		return nil, nil, err
 	}
 
-	tr := parquetTraceToTempopbTrace(i.meta, t)
+	tr := parquetTraceToTempopbTrace(i.meta, t, true)
 	return id, tr, nil
 }
 


### PR DESCRIPTION
**What this PR does**:
* Drop unsupported attribute values and increment dropped attribute count
* Remove support for array and kv-list attribute values

**Which issue(s) this PR fixes**:
Fixes grafana/tempo-squad#346

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`