### PR TITLE
Merge the processors overrides set through runtime overrides and user-configurable overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main / unreleased
 
 * [CHANGE] TraceQL/Structural operators performance improvement. [#3088](https://github.com/grafana/tempo/pull/3088) (@joe-elliott)
+* [CHANGE] Merge the processors overrides set through runtime overrides and user-configurable overrides [#3125](https://github.com/grafana/tempo/pull/3125) (@kvrhdn)
 * [FEATURE] Introduce list_blocks_concurrency on GCS and S3 backends to control backend load and performance. [#2652](https://github.com/grafana/tempo/pull/2652) (@zalegrala)
 * [BUGFIX] Include statusMessage intrinsic attribute in tag search. [#3084](https://github.com/grafana/tempo/pull/3084) (@rcrowe)
 * [ENHANCEMENT] Update poller to make use of previous results and reduce backend load. [#2652](https://github.com/grafana/tempo/pull/2652) (@zalegrala)

--- a/modules/overrides/user_configurable_overrides_test.go
+++ b/modules/overrides/user_configurable_overrides_test.go
@@ -11,6 +11,12 @@ import (
 	"time"
 
 	"github.com/grafana/dskit/services"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+
 	userconfigurableoverrides "github.com/grafana/tempo/modules/overrides/userconfigurable/client"
 	tempo_api "github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/sharedconfig"
@@ -18,11 +24,6 @@ import (
 	"github.com/grafana/tempo/pkg/util/listtomap"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/local"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/model"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -371,15 +372,24 @@ func TestUserConfigOverridesManager_MergeRuntimeConfig(t *testing.T) {
 	// Set Forwarders in UserConfigOverrides limits
 	mgr.tenantLimits[tenantID] = &userconfigurableoverrides.Limits{
 		Forwarders: &[]string{"my-other-forwarder"},
+		MetricsGenerator: &userconfigurableoverrides.LimitsMetricsGenerator{
+			Processors: map[string]struct{}{"local-blocks": {}},
+		},
 	}
 
-	// test all override methods
+	// Test all override methods
+
+	// Forwarders are set in user-configurable overrides and will override runtime overrides
+	assert.NotEqual(t, mgr.Forwarders(tenantID), baseMgr.Forwarders(tenantID))
+
+	// Processors will be the merged result between runtime and user-configurable overrides
+	assert.Equal(t, mgr.MetricsGeneratorProcessors(tenantID), map[string]struct{}{"local-blocks": {}, "service-graphs": {}, "span-metrics": {}})
+
+	// For the remaining settings runtime overrides will bubble up
 	assert.Equal(t, mgr.IngestionRateStrategy(), baseMgr.IngestionRateStrategy())
 	assert.Equal(t, mgr.MaxLocalTracesPerUser(tenantID), baseMgr.MaxLocalTracesPerUser(tenantID))
 	assert.Equal(t, mgr.MaxGlobalTracesPerUser(tenantID), baseMgr.MaxGlobalTracesPerUser(tenantID))
 	assert.Equal(t, mgr.MaxBytesPerTrace(tenantID), baseMgr.MaxBytesPerTrace(tenantID))
-	// Forwarders are set in userconfigurableoverrides so not same as runtime overrides
-	assert.NotEqual(t, mgr.Forwarders(tenantID), baseMgr.Forwarders(tenantID))
 	assert.Equal(t, mgr.Forwarders(tenantID), []string{"my-other-forwarder"})
 	assert.Equal(t, baseMgr.Forwarders(tenantID), []string{"fwd", "fwd-2"})
 
@@ -389,7 +399,6 @@ func TestUserConfigOverridesManager_MergeRuntimeConfig(t *testing.T) {
 	assert.Equal(t, mgr.IngestionBurstSizeBytes(tenantID), baseMgr.IngestionBurstSizeBytes(tenantID))
 	assert.Equal(t, mgr.MetricsGeneratorIngestionSlack(tenantID), baseMgr.MetricsGeneratorIngestionSlack(tenantID))
 	assert.Equal(t, mgr.MetricsGeneratorRingSize(tenantID), baseMgr.MetricsGeneratorRingSize(tenantID))
-	assert.Equal(t, mgr.MetricsGeneratorProcessors(tenantID), baseMgr.MetricsGeneratorProcessors(tenantID))
 	assert.Equal(t, mgr.MetricsGeneratorMaxActiveSeries(tenantID), baseMgr.MetricsGeneratorMaxActiveSeries(tenantID))
 	assert.Equal(t, mgr.MetricsGeneratorCollectionInterval(tenantID), baseMgr.MetricsGeneratorCollectionInterval(tenantID))
 	assert.Equal(t, mgr.MetricsGeneratorDisableCollection(tenantID), baseMgr.MetricsGeneratorDisableCollection(tenantID))

--- a/pkg/util/listtomap/list_to_map.go
+++ b/pkg/util/listtomap/list_to_map.go
@@ -77,10 +77,10 @@ func (l *ListToMap) GetMap() map[string]struct{} {
 
 func Merge(m1, m2 ListToMap) ListToMap {
 	merged := make(ListToMap)
-	for k, _ := range m1 {
+	for k := range m1 {
 		merged[k] = struct{}{}
 	}
-	for k, _ := range m2 {
+	for k := range m2 {
 		merged[k] = struct{}{}
 	}
 	return merged

--- a/pkg/util/listtomap/list_to_map.go
+++ b/pkg/util/listtomap/list_to_map.go
@@ -74,3 +74,14 @@ func (l *ListToMap) GetMap() map[string]struct{} {
 	}
 	return *l
 }
+
+func Merge(m1, m2 ListToMap) ListToMap {
+	merged := make(ListToMap)
+	for k, _ := range m1 {
+		merged[k] = struct{}{}
+	}
+	for k, _ := range m2 {
+		merged[k] = struct{}{}
+	}
+	return merged
+}

--- a/pkg/util/listtomap/list_to_map_test.go
+++ b/pkg/util/listtomap/list_to_map_test.go
@@ -93,3 +93,34 @@ func TestListToMapMarshalOperationsJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestMerge(t *testing.T) {
+	testCases := []struct {
+		name           string
+		m1, m2, merged ListToMap
+	}{
+		{
+			"merge keys from both maps",
+			map[string]struct{}{"key1": {}, "key3": {}},
+			map[string]struct{}{"key2": {}, "key3": {}},
+			map[string]struct{}{"key1": {}, "key2": {}, "key3": {}},
+		},
+		{
+			"nil map",
+			nil,
+			map[string]struct{}{"key1": {}},
+			map[string]struct{}{"key1": {}},
+		},
+		{
+			"both nil",
+			nil,
+			nil,
+			map[string]struct{}{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.merged, Merge(tc.m1, tc.m2))
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does**:

By default overrides set through user-configurable overrides take precedence over runtime overrides. For `processors` however it makes more sense to merge both layers with an OR logic.

This makes it possible to enable processors for all tenants through the runtime overrides, regardless of the setting the user-configurable overrides.
As a downside it will not be possible to disable processors set in the runtime overrides.

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [x] Tests updated
- [ ] ~~Documentation added~~
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`