### PR TITLE
Incorrect flag name for new version

### DIFF
--- a/docs/sources/tempo/troubleshooting/unable-to-see-trace.md
+++ b/docs/sources/tempo/troubleshooting/unable-to-see-trace.md
@@ -17,7 +17,7 @@ The two main causes of missing traces are:
 
 The first step is to check whether the application spans are actually reaching Tempo.
 
-Add the following flag to the distributor container - [`distributor.log-received-traces`](https://github.com/grafana/tempo/blob/57da4f3fd5d2966e13a39d27dbed4342af6a857a/modules/distributor/config.go#L55).
+Add the following flag to the distributor container - [`distributor.log-received-spans.enabled`](https://github.com/grafana/tempo/blob/57da4f3fd5d2966e13a39d27dbed4342af6a857a/modules/distributor/config.go#L55).
 
 This flag enables debug logging of all the traces received by the distributor. These logs can help check if Tempo is receiving any traces at all.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Fixes an outdated flag from `tempo` which is now `-distributor.log-received-spans.enabled`

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`