### PR TITLE
Update IPv6 jsonnet and docs after dskit update

### DIFF
--- a/docs/sources/tempo/configuration/ipv6.md
+++ b/docs/sources/tempo/configuration/ipv6.md
@@ -36,9 +36,9 @@ ingester:
     enable_inet6: true
 
 server:
-  grpc_listen_address: '[::0]'
+  grpc_listen_address: '::0'
   grpc_listen_port: 9095
-  http_listen_address: '[::0]'
+  http_listen_address: '::0'
   http_listen_port: 3200
 ```
 

--- a/operations/jsonnet/microservices/common.libsonnet
+++ b/operations/jsonnet/microservices/common.libsonnet
@@ -39,8 +39,8 @@
       },
       tempo_config+:: {
         server+: {
-          http_listen_address: '[::0]',
-          grpc_listen_address: '[::0]',
+          http_listen_address: '::0',
+          grpc_listen_address: '::0',
         },
         ingester+: {
           lifecycler+: {


### PR DESCRIPTION
**What this PR does**:

Update the listen address on the server after https://github.com/grafana/dskit/commit/5729ba4790f2c6ef0cf735f030d47885abcc6285 introduced a subtle breaking change for IPv6 specification.



**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`