### PR TITLE
TraceQL: Improve regexp perf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [FEATURE] Introduce list_blocks_concurrency on GCS and S3 backends to control backend load and performance. [#2652](https://github.com/grafana/tempo/pull/2652) (@zalegrala)
 * [BUGFIX] Include statusMessage intrinsic attribute in tag search. [#3084](https://github.com/grafana/tempo/pull/3084) (@rcrowe)
 * [ENHANCEMENT] Update poller to make use of previous results and reduce backend load. [#2652](https://github.com/grafana/tempo/pull/2652) (@zalegrala)
+* [ENHANCEMENT] Improve TraceQL regex performance in certain queries. [#3139](https://github.com/grafana/tempo/pull/3139) (@joe-elliott)
 
 ## v2.3.0 / 2023-10-30
 

--- a/pkg/traceql/ast.go
+++ b/pkg/traceql/ast.go
@@ -3,6 +3,7 @@ package traceql
 import (
 	"fmt"
 	"math"
+	"regexp"
 	"time"
 )
 
@@ -368,10 +369,12 @@ type BinaryOperation struct {
 	Op  Operator
 	LHS FieldExpression
 	RHS FieldExpression
+
+	compiledExpression *regexp.Regexp
 }
 
-func newBinaryOperation(op Operator, lhs FieldExpression, rhs FieldExpression) BinaryOperation {
-	return BinaryOperation{
+func newBinaryOperation(op Operator, lhs FieldExpression, rhs FieldExpression) *BinaryOperation {
+	return &BinaryOperation{
 		Op:  op,
 		LHS: lhs,
 		RHS: rhs,
@@ -381,7 +384,7 @@ func newBinaryOperation(op Operator, lhs FieldExpression, rhs FieldExpression) B
 // nolint: revive
 func (BinaryOperation) __fieldExpression() {}
 
-func (o BinaryOperation) impliedType() StaticType {
+func (o *BinaryOperation) impliedType() StaticType {
 	if o.Op.isBoolean() {
 		return TypeBoolean
 	}
@@ -396,7 +399,7 @@ func (o BinaryOperation) impliedType() StaticType {
 	return o.RHS.impliedType()
 }
 
-func (o BinaryOperation) referencesSpan() bool {
+func (o *BinaryOperation) referencesSpan() bool {
 	return o.LHS.referencesSpan() || o.RHS.referencesSpan()
 }
 

--- a/pkg/traceql/ast_conditions.go
+++ b/pkg/traceql/ast_conditions.go
@@ -31,7 +31,7 @@ func (o SelectOperation) extractConditions(request *FetchSpansRequest) {
 	request.SecondPassConditions = append(request.SecondPassConditions, selectR.Conditions...)
 }
 
-func (o BinaryOperation) extractConditions(request *FetchSpansRequest) {
+func (o *BinaryOperation) extractConditions(request *FetchSpansRequest) {
 	// TODO we can further optimise this by attempting to execute every FieldExpression, if they only contain statics it should resolve
 	switch o.LHS.(type) {
 	case Attribute:

--- a/pkg/traceql/ast_stringer.go
+++ b/pkg/traceql/ast_stringer.go
@@ -58,7 +58,7 @@ func (f ScalarFilter) String() string {
 	return binaryOp(f.op, f.lhs, f.rhs)
 }
 
-func (o BinaryOperation) String() string {
+func (o *BinaryOperation) String() string {
 	return binaryOp(o.Op, o.LHS, o.RHS)
 }
 

--- a/pkg/traceql/ast_validate.go
+++ b/pkg/traceql/ast_validate.go
@@ -156,7 +156,7 @@ func (f ScalarFilter) validate() error {
 	return nil
 }
 
-func (o BinaryOperation) validate() error {
+func (o *BinaryOperation) validate() error {
 	if err := o.LHS.validate(); err != nil {
 		return err
 	}

--- a/pkg/traceql/ast_validate.go
+++ b/pkg/traceql/ast_validate.go
@@ -1,6 +1,9 @@
 package traceql
 
-import "fmt"
+import (
+	"fmt"
+	"regexp"
+)
 
 // unsupportedError is returned for traceql features that are not yet supported.
 type unsupportedError struct {
@@ -177,6 +180,14 @@ func (o *BinaryOperation) validate() error {
 
 	if !o.Op.binaryTypesValid(lhsT, rhsT) {
 		return fmt.Errorf("illegal operation for the given types: %s", o.String())
+	}
+
+	// if this is a regex operator confirm the RHS is a valid regex
+	if o.Op == OpRegex || o.Op == OpNotRegex {
+		_, err := regexp.Compile(o.RHS.String())
+		if err != nil {
+			return fmt.Errorf("invalid regex: %s", o.RHS.String())
+		}
 	}
 
 	// this condition may not be possible to hit since it's not parseable.

--- a/pkg/traceql/test_examples.yaml
+++ b/pkg/traceql/test_examples.yaml
@@ -205,6 +205,9 @@ validate_fails:
   - '{ traceDuration > "test" }'
   - '{ rootServiceName = 1 }'
   - '{ rootName != 3.2 }'
+  # invalid regexes
+  - '{ span.foo =~ "[" }'
+  - '{ span.foo !~ "[" }'
   # unary operators - incorrect types
   - '{ -true }'
   - '{ -"foo" = "bar" }'


### PR DESCRIPTION
**What this PR does**:
Fixes a nasty performance issue when regexp matches get to the engine layer. Currently we are calling `regexp.MatchString()` which recompiles the regex on every span.

Uses benchmarks from [this PR](https://github.com/grafana/tempo/pull/3113) against main plus one to highlight the improvement:

`{resource.namespace!=""} && {resource.service.name="loki-distributor"} && {duration>2s} && {resource.cluster=~"prod.*"}`

```
name                                             old time/op    new time/op    delta
BackendBlockTraceQL/spanAttValNoMatch-8            6.71ms ± 0%    6.73ms ± 0%     ~     (p=0.151 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8      5.80ms ± 0%    5.91ms ± 2%     ~     (p=0.056 n=5+5)
BackendBlockTraceQL/resourceAttValNoMatch-8        12.1ms ± 1%    12.1ms ± 1%     ~     (p=1.000 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8    24.4ms ± 2%    24.0ms ± 1%   -1.64%  (p=0.032 n=5+5)
BackendBlockTraceQL/mixedValNoMatch-8               327ms ± 2%     317ms ± 2%   -3.04%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchAnd-8        5.76ms ± 1%    5.76ms ± 1%     ~     (p=0.841 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchOr-8          326ms ± 3%     328ms ± 4%     ~     (p=0.841 n=5+5)
BackendBlockTraceQL/count-8                         577ms ± 3%     578ms ± 2%     ~     (p=1.000 n=5+5)
BackendBlockTraceQL/struct-8                        1.24s ± 4%     1.19s ± 5%     ~     (p=0.095 n=5+5)
BackendBlockTraceQL/||-8                            443ms ± 2%     446ms ± 2%     ~     (p=0.548 n=5+5)
BackendBlockTraceQL/mixed-8                        37.4ms ± 2%    37.6ms ± 3%     ~     (p=0.841 n=5+5)
BackendBlockTraceQL/spansets-8                      3.05s ± 1%     1.53s ± 3%  -49.90%  (p=0.008 n=5+5)

name                                             old speed      new speed      delta
BackendBlockTraceQL/spanAttValNoMatch-8           409MB/s ± 0%   408MB/s ± 0%     ~     (p=0.151 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8     292MB/s ± 0%   286MB/s ± 2%     ~     (p=0.056 n=5+5)
BackendBlockTraceQL/resourceAttValNoMatch-8       183MB/s ± 1%   183MB/s ± 1%     ~     (p=1.000 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8   679MB/s ± 2%   691MB/s ± 1%   +1.66%  (p=0.032 n=5+5)
BackendBlockTraceQL/mixedValNoMatch-8            14.7MB/s ± 2%  15.2MB/s ± 2%   +3.15%  (p=0.008 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchAnd-8       201MB/s ± 1%   201MB/s ± 1%     ~     (p=0.841 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchOr-8       59.1MB/s ± 3%  58.8MB/s ± 4%     ~     (p=0.841 n=5+5)
BackendBlockTraceQL/count-8                      29.8MB/s ± 3%  29.8MB/s ± 2%     ~     (p=1.000 n=5+5)
BackendBlockTraceQL/struct-8                     1.49MB/s ± 4%  1.56MB/s ± 5%     ~     (p=0.087 n=5+5)
BackendBlockTraceQL/||-8                         39.9MB/s ± 2%  39.7MB/s ± 2%     ~     (p=0.548 n=5+5)
BackendBlockTraceQL/mixed-8                       116MB/s ± 2%   116MB/s ± 3%     ~     (p=0.841 n=5+5)
BackendBlockTraceQL/spansets-8                   1.54MB/s ± 1%  3.07MB/s ± 3%  +99.74%  (p=0.008 n=5+5)

name                                             old MB_io/op   new MB_io/op   delta
BackendBlockTraceQL/spanAttValNoMatch-8              2.74 ± 0%      2.74 ± 0%     ~     (all equal)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8        1.69 ± 0%      1.69 ± 0%     ~     (all equal)
BackendBlockTraceQL/resourceAttValNoMatch-8          2.21 ± 0%      2.21 ± 0%     ~     (all equal)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8      16.6 ± 0%      16.6 ± 0%     ~     (all equal)
BackendBlockTraceQL/mixedValNoMatch-8                4.80 ± 0%      4.80 ± 0%     ~     (all equal)
BackendBlockTraceQL/mixedValMixedMatchAnd-8          1.16 ± 0%      1.16 ± 0%     ~     (all equal)
BackendBlockTraceQL/mixedValMixedMatchOr-8           19.2 ± 0%      19.2 ± 0%     ~     (all equal)
BackendBlockTraceQL/count-8                          17.2 ± 0%      17.2 ± 0%     ~     (all equal)
BackendBlockTraceQL/struct-8                         1.85 ± 0%      1.85 ± 0%     ~     (all equal)
BackendBlockTraceQL/||-8                             17.7 ± 0%      17.7 ± 0%     ~     (all equal)
BackendBlockTraceQL/mixed-8                          4.36 ± 0%      4.36 ± 0%     ~     (all equal)
BackendBlockTraceQL/spansets-8                       4.69 ± 0%      4.69 ± 0%     ~     (all equal)

name                                             old alloc/op   new alloc/op   delta
BackendBlockTraceQL/spanAttValNoMatch-8            3.99MB ± 1%    4.00MB ± 2%     ~     (p=0.690 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8      2.97MB ± 2%    2.96MB ± 3%     ~     (p=1.000 n=5+5)
BackendBlockTraceQL/resourceAttValNoMatch-8        5.47MB ± 2%    5.43MB ± 2%     ~     (p=0.690 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8    3.07MB ± 5%    3.18MB ± 6%     ~     (p=0.151 n=5+5)
BackendBlockTraceQL/mixedValNoMatch-8              6.70MB ± 6%    6.73MB ± 9%     ~     (p=1.000 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchAnd-8        2.93MB ± 2%    2.94MB ± 2%     ~     (p=0.690 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchOr-8         6.12MB ±12%    5.84MB ±13%     ~     (p=0.310 n=5+5)
BackendBlockTraceQL/count-8                         275MB ± 2%     275MB ± 2%     ~     (p=1.000 n=5+5)
BackendBlockTraceQL/struct-8                       21.3MB ± 0%    22.4MB ±15%     ~     (p=0.857 n=4+4)
BackendBlockTraceQL/||-8                            453MB ± 0%     452MB ± 0%     ~     (p=0.056 n=5+5)
BackendBlockTraceQL/mixed-8                        3.09MB ± 5%    3.05MB ± 8%     ~     (p=0.421 n=5+5)
BackendBlockTraceQL/spansets-8                     1.59GB ± 5%   0.04GB ±105%  -97.31%  (p=0.008 n=5+5)

name                                             old allocs/op  new allocs/op  delta
BackendBlockTraceQL/spanAttValNoMatch-8             44.1k ± 0%     44.1k ± 0%     ~     (p=0.643 n=5+5)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8       44.0k ± 0%     44.0k ± 0%     ~     (p=1.000 n=5+5)
BackendBlockTraceQL/resourceAttValNoMatch-8         44.2k ± 0%     44.2k ± 0%     ~     (p=0.905 n=5+5)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8     45.6k ± 0%     45.6k ± 0%     ~     (p=0.206 n=5+5)
BackendBlockTraceQL/mixedValNoMatch-8               47.2k ± 0%     47.2k ± 0%     ~     (p=1.000 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchAnd-8         44.1k ± 0%     44.1k ± 0%     ~     (p=0.683 n=5+5)
BackendBlockTraceQL/mixedValMixedMatchOr-8          46.0k ± 0%     46.0k ± 0%     ~     (p=0.841 n=5+5)
BackendBlockTraceQL/count-8                         2.71M ± 0%     2.71M ± 0%     ~     (p=1.000 n=5+5)
BackendBlockTraceQL/struct-8                         250k ± 0%      250k ± 0%     ~     (p=0.857 n=4+4)
BackendBlockTraceQL/||-8                            1.12M ± 0%     1.12M ± 0%     ~     (p=1.000 n=5+5)
BackendBlockTraceQL/mixed-8                         44.9k ± 0%     44.9k ± 0%     ~     (p=0.635 n=5+5)
BackendBlockTraceQL/spansets-8                      18.1M ± 1%      0.5M ±21%  -97.43%  (p=0.008 n=5+5)
```