### PR TITLE
Fix malformed link in Tempo docs

### DIFF
--- a/docs/sources/tempo/operations/architecture.md
+++ b/docs/sources/tempo/operations/architecture.md
@@ -27,7 +27,7 @@ the [Grafana Agent](https://github.com/grafana/agent) uses the otlp exporter/rec
 
 ## Ingester
 
-The [Ingester]{{{< relref "../configuration#ingester" >}}} batches trace into blocks, creates bloom filters and indexes, and then flushes it all to the backend.
+The [Ingester]({{< relref "../configuration#ingester" >}}) batches trace into blocks, creates bloom filters and indexes, and then flushes it all to the backend.
 Blocks in the backend are generated in the following layout:
 
 ```


### PR DESCRIPTION
This link wasn't rendering nicely in the docs[1]

[1] https://grafana.com/docs/tempo/latest/operations/architecture/

**Checklist**
- [ ] Tests updated (N/A: no code changes)
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]` (N/A: just a small docs change)