### PR TITLE
Prevent `LeftJoinIterator`s with no required conditions from being built

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [ENHANCEMENT] Improve TraceQL regex performance in certain queries. [#3139](https://github.com/grafana/tempo/pull/3139) (@joe-elliott)
 * [ENHANCEMENT] Improve TraceQL performance in complex queries. [#3113](https://github.com/grafana/tempo/pull/3113) (@joe-elliott)
 * [BUGFIX] Fix compactor ignore configured S3 headers [#3149](https://github.com/grafana/tempo/pull/3154) (@Batkilin) 
+* [BUGFIX] Prevent building parquet iterators that would loop forever. [#](https://github.com/grafana/tempo/pull/) (@mapno)
 
 ## v2.3.0 / 2023-10-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * [ENHANCEMENT] Improve TraceQL regex performance in certain queries. [#3139](https://github.com/grafana/tempo/pull/3139) (@joe-elliott)
 * [ENHANCEMENT] Improve TraceQL performance in complex queries. [#3113](https://github.com/grafana/tempo/pull/3113) (@joe-elliott)
 * [BUGFIX] Fix compactor ignore configured S3 headers [#3149](https://github.com/grafana/tempo/pull/3154) (@Batkilin) 
-* [BUGFIX] Prevent building parquet iterators that would loop forever. [#](https://github.com/grafana/tempo/pull/) (@mapno)
+* [BUGFIX] Prevent building parquet iterators that would loop forever. [#3159](https://github.com/grafana/tempo/pull/3159) (@mapno)
 
 ## v2.3.0 / 2023-10-30
 

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -1356,12 +1356,12 @@ type LeftJoinIterator struct {
 
 var _ Iterator = (*LeftJoinIterator)(nil)
 
-func NewLeftJoinIterator(definitionLevel int, required, optional []Iterator, pred GroupPredicate) *LeftJoinIterator {
+func NewLeftJoinIterator(definitionLevel int, required, optional []Iterator, pred GroupPredicate) (*LeftJoinIterator, error) {
 	// No query should ever result in a left-join with no required iterators.
 	// If this happens, it's a bug in the iter building code.
 	// LeftJoinIterator is not designed to handle this case and will loop forever.
 	if len(required) == 0 {
-		panic("required iterators must be provided")
+		return nil, fmt.Errorf("left join iterator requires at least one required iterator")
 	}
 
 	j := LeftJoinIterator{
@@ -1373,7 +1373,7 @@ func NewLeftJoinIterator(definitionLevel int, required, optional []Iterator, pre
 		peeksOptional:   make([]*IteratorResult, len(optional)),
 		pred:            pred,
 	}
-	return &j
+	return &j, nil
 }
 
 func (j *LeftJoinIterator) String() string {

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -1357,6 +1357,13 @@ type LeftJoinIterator struct {
 var _ Iterator = (*LeftJoinIterator)(nil)
 
 func NewLeftJoinIterator(definitionLevel int, required, optional []Iterator, pred GroupPredicate) *LeftJoinIterator {
+	// No query should ever result in a left-join with no required iterators.
+	// If this happens, it's a bug in the iter building code.
+	// LeftJoinIterator is not designed to handle this case and will loop forever.
+	if len(required) == 0 {
+		panic("required iterators must be provided")
+	}
+
 	j := LeftJoinIterator{
 		definitionLevel: definitionLevel,
 		required:        required,

--- a/tempodb/encoding/vparquet/block_search_tags.go
+++ b/tempodb/encoding/vparquet/block_search_tags.go
@@ -294,7 +294,7 @@ func searchStandardTagValues(ctx context.Context, tag traceql.Attribute, pf *par
 func searchKeyValues(definitionLevel int, keyPath, stringPath, intPath, floatPath, boolPath string, makeIter makeIterFn, keyPred pq.Predicate, cb common.TagCallbackV2) error {
 	skipNils := pq.NewSkipNilsPredicate()
 
-	iter := pq.NewLeftJoinIterator(definitionLevel,
+	iter, err := pq.NewLeftJoinIterator(definitionLevel,
 		// This is required
 		[]pq.Iterator{makeIter(keyPath, keyPred, "")},
 		[]pq.Iterator{
@@ -304,6 +304,9 @@ func searchKeyValues(definitionLevel int, keyPath, stringPath, intPath, floatPat
 			makeIter(floatPath, skipNils, "float"),
 			makeIter(boolPath, skipNils, "bool"),
 		}, nil)
+	if err != nil {
+		return fmt.Errorf("pq.NewLeftJoinIterator failed: %w", err)
+	}
 	defer iter.Close()
 
 	for {

--- a/tempodb/encoding/vparquet/block_traceql.go
+++ b/tempodb/encoding/vparquet/block_traceql.go
@@ -977,7 +977,7 @@ func createSpanIterator(makeIter makeIterFn, primaryIter parquetquery.Iterator, 
 
 	// Left join here means the span id/start/end iterators + 1 are required,
 	// and all other conditions are optional. Whatever matches is returned.
-	return parquetquery.NewLeftJoinIterator(DefinitionLevelResourceSpansILSSpan, required, iters, spanCol), nil
+	return parquetquery.NewLeftJoinIterator(DefinitionLevelResourceSpansILSSpan, required, iters, spanCol)
 }
 
 // createResourceIterator iterates through all resourcespans-level (batch-level) columns, groups them into rows representing
@@ -1076,7 +1076,7 @@ func createResourceIterator(makeIter makeIterFn, spanIterator parquetquery.Itera
 	// and all other resource conditions are optional. Whatever matches
 	// is returned.
 	return parquetquery.NewLeftJoinIterator(DefinitionLevelResourceSpans,
-		required, iters, batchCol), nil
+		required, iters, batchCol)
 }
 
 func createTraceIterator(makeIter makeIterFn, resourceIter parquetquery.Iterator, conds []traceql.Condition, start, end uint64) parquetquery.Iterator {
@@ -1427,7 +1427,7 @@ func createAttributeIterator(makeIter makeIterFn, conditions []traceql.Condition
 		return parquetquery.NewLeftJoinIterator(definitionLevel,
 			[]parquetquery.Iterator{makeIter(keyPath, parquetquery.NewStringInPredicate(attrKeys), "key")},
 			valueIters,
-			&attributeCollector{}), nil
+			&attributeCollector{})
 	}
 
 	return nil, nil

--- a/tempodb/encoding/vparquet2/block_search_tags.go
+++ b/tempodb/encoding/vparquet2/block_search_tags.go
@@ -294,7 +294,7 @@ func searchStandardTagValues(ctx context.Context, tag traceql.Attribute, pf *par
 func searchKeyValues(definitionLevel int, keyPath, stringPath, intPath, floatPath, boolPath string, makeIter makeIterFn, keyPred pq.Predicate, cb common.TagCallbackV2) error {
 	skipNils := pq.NewSkipNilsPredicate()
 
-	iter := pq.NewLeftJoinIterator(definitionLevel,
+	iter, err := pq.NewLeftJoinIterator(definitionLevel,
 		// This is required
 		[]pq.Iterator{makeIter(keyPath, keyPred, "")},
 		[]pq.Iterator{
@@ -304,6 +304,9 @@ func searchKeyValues(definitionLevel int, keyPath, stringPath, intPath, floatPat
 			makeIter(floatPath, skipNils, "float"),
 			makeIter(boolPath, skipNils, "bool"),
 		}, nil)
+	if err != nil {
+		return fmt.Errorf("pq.NewLeftJoinIterator failed: %w", err)
+	}
 	defer iter.Close()
 
 	for {

--- a/tempodb/encoding/vparquet2/block_traceql.go
+++ b/tempodb/encoding/vparquet2/block_traceql.go
@@ -1163,7 +1163,7 @@ func createSpanIterator(makeIter makeIterFn, primaryIter parquetquery.Iterator, 
 
 	// Left join here means the span id/start/end iterators + 1 are required,
 	// and all other conditions are optional. Whatever matches is returned.
-	return parquetquery.NewLeftJoinIterator(DefinitionLevelResourceSpansILSSpan, required, iters, spanCol), nil
+	return parquetquery.NewLeftJoinIterator(DefinitionLevelResourceSpansILSSpan, required, iters, spanCol)
 }
 
 // createResourceIterator iterates through all resourcespans-level (batch-level) columns, groups them into rows representing
@@ -1259,7 +1259,7 @@ func createResourceIterator(makeIter makeIterFn, spanIterator parquetquery.Itera
 	// and all other resource conditions are optional. Whatever matches
 	// is returned.
 	return parquetquery.NewLeftJoinIterator(DefinitionLevelResourceSpans,
-		required, iters, batchCol), nil
+		required, iters, batchCol)
 }
 
 func createTraceIterator(makeIter makeIterFn, resourceIter parquetquery.Iterator, conds []traceql.Condition, start, end uint64, allConditions bool) (parquetquery.Iterator, error) {
@@ -1639,7 +1639,7 @@ func createAttributeIterator(makeIter makeIterFn, conditions []traceql.Condition
 		return parquetquery.NewLeftJoinIterator(definitionLevel,
 			[]parquetquery.Iterator{makeIter(keyPath, parquetquery.NewStringInPredicate(attrKeys), "key")},
 			valueIters,
-			&attributeCollector{}), nil
+			&attributeCollector{})
 	}
 
 	return nil, nil

--- a/tempodb/encoding/vparquet3/block_search_tags.go
+++ b/tempodb/encoding/vparquet3/block_search_tags.go
@@ -328,7 +328,7 @@ func searchStandardTagValues(ctx context.Context, tag traceql.Attribute, pf *par
 func searchKeyValues(definitionLevel int, keyPath, stringPath, intPath, floatPath, boolPath string, makeIter makeIterFn, keyPred pq.Predicate, cb common.TagCallbackV2) error {
 	skipNils := pq.NewSkipNilsPredicate()
 
-	iter := pq.NewLeftJoinIterator(definitionLevel,
+	iter, err := pq.NewLeftJoinIterator(definitionLevel,
 		// This is required
 		[]pq.Iterator{makeIter(keyPath, keyPred, "")},
 		[]pq.Iterator{
@@ -338,6 +338,9 @@ func searchKeyValues(definitionLevel int, keyPath, stringPath, intPath, floatPat
 			makeIter(floatPath, skipNils, "float"),
 			makeIter(boolPath, skipNils, "bool"),
 		}, nil)
+	if err != nil {
+		return fmt.Errorf("pq.NewLeftJoinIterator failed: %w", err)
+	}
 	defer iter.Close()
 
 	for {

--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -1297,7 +1297,7 @@ func createSpanIterator(makeIter makeIterFn, primaryIter parquetquery.Iterator, 
 
 	// Left join here means the span id/start/end iterators + 1 are required,
 	// and all other conditions are optional. Whatever matches is returned.
-	return parquetquery.NewLeftJoinIterator(DefinitionLevelResourceSpansILSSpan, required, iters, spanCol), nil
+	return parquetquery.NewLeftJoinIterator(DefinitionLevelResourceSpansILSSpan, required, iters, spanCol)
 }
 
 // createResourceIterator iterates through all resourcespans-level (batch-level) columns, groups them into rows representing
@@ -1415,7 +1415,7 @@ func createResourceIterator(makeIter makeIterFn, spanIterator parquetquery.Itera
 	// and all other resource conditions are optional. Whatever matches
 	// is returned.
 	return parquetquery.NewLeftJoinIterator(DefinitionLevelResourceSpans,
-		required, iters, batchCol), nil
+		required, iters, batchCol)
 }
 
 func createTraceIterator(makeIter makeIterFn, resourceIter parquetquery.Iterator, conds []traceql.Condition, start, end uint64, allConditions bool) (parquetquery.Iterator, error) {
@@ -1795,7 +1795,7 @@ func createAttributeIterator(makeIter makeIterFn, conditions []traceql.Condition
 		return parquetquery.NewLeftJoinIterator(definitionLevel,
 			[]parquetquery.Iterator{makeIter(keyPath, parquetquery.NewStringInPredicate(attrKeys), "key")},
 			valueIters,
-			&attributeCollector{}), nil
+			&attributeCollector{})
 	}
 
 	return nil, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

No query should ever result in a left-join with no required iterators. If that happens, it's a bug in the iter building code, so it returns an error.

`LeftJoinIterator` is not designed to handle this case and will loop forever.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`