### PR TITLE
Refactor caching to support multiple independent caches

### DIFF
--- a/cmd/tempo-cli/cmd-analyse-block.go
+++ b/cmd/tempo-cli/cmd-analyse-block.go
@@ -134,11 +134,11 @@ func processBlock(r backend.Reader, _ backend.Compactor, tenantID, blockID strin
 	var reader io.ReaderAt
 	switch meta.Version {
 	case vparquet.VersionString:
-		reader = vparquet.NewBackendReaderAt(context.Background(), r, vparquet.DataFileName, meta.BlockID, meta.TenantID)
+		reader = vparquet.NewBackendReaderAt(context.Background(), r, vparquet.DataFileName, meta)
 	case vparquet2.VersionString:
-		reader = vparquet2.NewBackendReaderAt(context.Background(), r, vparquet2.DataFileName, meta.BlockID, meta.TenantID)
+		reader = vparquet2.NewBackendReaderAt(context.Background(), r, vparquet2.DataFileName, meta)
 	case vparquet3.VersionString:
-		reader = vparquet3.NewBackendReaderAt(context.Background(), r, vparquet3.DataFileName, meta.BlockID, meta.TenantID)
+		reader = vparquet3.NewBackendReaderAt(context.Background(), r, vparquet3.DataFileName, meta)
 	default:
 		fmt.Println("Unsupported block version:", meta.Version)
 		return nil, nil

--- a/cmd/tempo-cli/cmd-gen-bloom.go
+++ b/cmd/tempo-cli/cmd-gen-bloom.go
@@ -120,7 +120,7 @@ func (cmd *bloomCmd) Run(ctx *globalOptions) error {
 	}
 
 	for i := 0; i < len(bloomBytes); i++ {
-		err = w.Write(context.TODO(), bloomFilePrefix+strconv.Itoa(i), blockID, cmd.TenantID, bloomBytes[i], false)
+		err = w.Write(context.TODO(), bloomFilePrefix+strconv.Itoa(i), blockID, cmd.TenantID, bloomBytes[i], nil)
 		if err != nil {
 			fmt.Println("error writing bloom filter to backend", err)
 			return err
@@ -132,7 +132,7 @@ func (cmd *bloomCmd) Run(ctx *globalOptions) error {
 	// verify generated bloom
 	shardedBloomFilter := make([]*willf_bloom.BloomFilter, meta.BloomShardCount)
 	for i := 0; i < int(meta.BloomShardCount); i++ {
-		bloomBytes, err := r.Read(context.TODO(), bloomFilePrefix+strconv.Itoa(i), blockID, cmd.TenantID, false)
+		bloomBytes, err := r.Read(context.TODO(), bloomFilePrefix+strconv.Itoa(i), blockID, cmd.TenantID, nil)
 		if err != nil {
 			fmt.Println("error reading bloom from backend")
 			return nil

--- a/cmd/tempo-cli/cmd-gen-index.go
+++ b/cmd/tempo-cli/cmd-gen-index.go
@@ -140,7 +140,7 @@ func (cmd *indexCmd) Run(ctx *globalOptions) error {
 	}
 
 	// write to the local backend
-	err = w.Write(context.TODO(), "index", blockID, cmd.TenantID, indexBytes, false)
+	err = w.Write(context.TODO(), "index", blockID, cmd.TenantID, indexBytes, nil)
 	if err != nil {
 		fmt.Println("error writing index to backend", err)
 		return err

--- a/cmd/tempo-cli/cmd-list-column.go
+++ b/cmd/tempo-cli/cmd-list-column.go
@@ -32,7 +32,7 @@ func (cmd *listColumnCmd) Run(ctx *globalOptions) error {
 		return err
 	}
 
-	rr := vparquet.NewBackendReaderAt(context.Background(), r, vparquet.DataFileName, meta.BlockID, meta.TenantID)
+	rr := vparquet.NewBackendReaderAt(context.Background(), r, vparquet.DataFileName, meta)
 	pf, err := parquet.OpenFile(rr, int64(meta.Size))
 	if err != nil {
 		return err

--- a/cmd/tempo-cli/cmd-view-pq-schema.go
+++ b/cmd/tempo-cli/cmd-view-pq-schema.go
@@ -36,7 +36,7 @@ func (cmd *viewSchemaCmd) Run(ctx *globalOptions) error {
 	fmt.Printf("\n***************     block meta    *********************\n\n\n")
 	fmt.Printf("%+v\n", meta)
 
-	rr := vparquet.NewBackendReaderAt(context.Background(), r, vparquet.DataFileName, meta.BlockID, meta.TenantID)
+	rr := vparquet.NewBackendReaderAt(context.Background(), r, vparquet.DataFileName, meta)
 	pf, err := parquet.OpenFile(rr, int64(meta.Size))
 	if err != nil {
 		return err

--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -38,6 +38,7 @@ import (
 	"github.com/grafana/tempo/modules/querier"
 	"github.com/grafana/tempo/modules/storage"
 	"github.com/grafana/tempo/pkg/api"
+	"github.com/grafana/tempo/pkg/cache"
 	"github.com/grafana/tempo/pkg/usagestats"
 	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/pkg/util/log"
@@ -77,6 +78,7 @@ type App struct {
 	generator      *generator.Generator
 	store          storage.Store
 	usageReport    *usagestats.Reporter
+	cacheProvider  cache.Provider
 	MemberlistKV   *memberlist.KVInitService
 
 	HTTPAuthMiddleware       middleware.Interface

--- a/cmd/tempo/app/config.go
+++ b/cmd/tempo/app/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/dskit/server"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/grafana/tempo/modules/cache"
 	"github.com/grafana/tempo/modules/compactor"
 	"github.com/grafana/tempo/modules/distributor"
 	"github.com/grafana/tempo/modules/frontend"
@@ -53,6 +54,7 @@ type Config struct {
 	Overrides       overrides.Config        `yaml:"overrides,omitempty"`
 	MemberlistKV    memberlist.KVConfig     `yaml:"memberlist,omitempty"`
 	UsageReport     usagestats.Config       `yaml:"usage_report,omitempty"`
+	CacheProvider   cache.Config            `yaml:"cache,omitempty"`
 }
 
 func newDefaultConfig() *Config {

--- a/integration/microservices/tempo.yaml
+++ b/integration/microservices/tempo.yaml
@@ -41,3 +41,4 @@ storage:
         queue_depth: 2000
     wal:
         path: /var/tempo/wal
+

--- a/modules/cache/cache.go
+++ b/modules/cache/cache.go
@@ -1,0 +1,92 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/dskit/services"
+	"github.com/grafana/tempo/modules/cache/memcached"
+	"github.com/grafana/tempo/modules/cache/redis"
+	"github.com/grafana/tempo/pkg/cache"
+	"github.com/grafana/tempo/pkg/usagestats"
+	"github.com/prometheus/statsd_exporter/pkg/level"
+
+	"github.com/go-kit/log"
+)
+
+var (
+	statMemcached = usagestats.NewInt("cache_memcached")
+	statRedis     = usagestats.NewInt("cache_redis")
+)
+
+type provider struct {
+	services.Service
+
+	caches map[cache.Role]cache.Cache
+}
+
+func NewProvider(cfg *Config, logger log.Logger) (cache.Provider, error) {
+	p := &provider{
+		caches: map[cache.Role]cache.Cache{},
+	}
+
+	err := cfg.Validate()
+	if err != nil {
+		return nil, fmt.Errorf("invalid cache config: %w", err)
+	}
+
+	statMemcached.Set(0)
+	statRedis.Set(0)
+
+	for _, cacheCfg := range cfg.Caches {
+		var c cache.Cache
+
+		if cacheCfg.MemcachedConfig != nil {
+			level.Info(logger).Log("msg", "configuring memcached client", "roles", cacheCfg.Name())
+
+			statMemcached.Add(1)
+			c = memcached.NewClient(cacheCfg.MemcachedConfig, cfg.Background, cacheCfg.Name(), logger)
+		}
+
+		if cacheCfg.RedisConfig != nil {
+			level.Info(logger).Log("msg", "configuring redis client", "roles", cacheCfg.Name())
+
+			statRedis.Add(1)
+			c = redis.NewClient(cacheCfg.RedisConfig, cfg.Background, cacheCfg.Name(), logger)
+		}
+
+		// add this cache for all claimed roles
+		for _, role := range cacheCfg.Role {
+			p.caches[role] = c
+		}
+	}
+
+	p.Service = services.NewIdleService(p.starting, p.stopping)
+	return p, nil
+}
+
+func (p *provider) CacheFor(role cache.Role) cache.Cache {
+	return p.caches[role]
+}
+
+func (p *provider) AddCache(role cache.Role, c cache.Cache) error {
+	if _, ok := p.caches[role]; ok {
+		return fmt.Errorf("cache for role %s already exists", role)
+	}
+
+	p.caches[role] = c
+
+	return nil
+}
+
+func (p *provider) starting(_ context.Context) error {
+	return nil
+}
+
+func (p *provider) stopping(_ error) error {
+	for _, c := range p.caches {
+		c.Stop()
+	}
+
+	return nil
+}

--- a/modules/cache/config.go
+++ b/modules/cache/config.go
@@ -1,0 +1,84 @@
+package cache
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/grafana/tempo/modules/cache/memcached"
+	"github.com/grafana/tempo/modules/cache/redis"
+	"github.com/grafana/tempo/pkg/cache"
+)
+
+// role must be pipe based and valid
+type Config struct {
+	Background *cache.BackgroundConfig `yaml:"background"`
+	Caches     []CacheConfig           `yaml:"caches"`
+}
+
+type CacheConfig struct {
+	Role            []cache.Role      `yaml:"roles"`
+	MemcachedConfig *memcached.Config `yaml:"memcached"`
+	RedisConfig     *redis.Config     `yaml:"redis"`
+}
+
+// Validate validates the config.
+func (cfg *Config) Validate() error {
+	claimedRoles := map[cache.Role]struct{}{}
+	allRoles := allRoles()
+
+	for _, cacheCfg := range cfg.Caches {
+		if cacheCfg.MemcachedConfig != nil && cacheCfg.RedisConfig != nil {
+			return fmt.Errorf("cache config for role %s has both memcached and redis configs", cacheCfg.Role)
+		}
+
+		if cacheCfg.MemcachedConfig == nil && cacheCfg.RedisConfig == nil {
+			return fmt.Errorf("cache config for role %s has neither memcached nor redis configs", cacheCfg.Role)
+		}
+
+		if len(cacheCfg.Role) == 0 {
+			return errors.New("configured caches require a valid role")
+		}
+
+		// check that all roles are unique
+		for _, role := range cacheCfg.Role {
+			if _, ok := allRoles[role]; !ok {
+				return fmt.Errorf("role %s is not a valid role", role)
+			}
+
+			if _, ok := claimedRoles[role]; ok {
+				return fmt.Errorf("role %s is claimed by more than one cache", role)
+			}
+
+			claimedRoles[role] = struct{}{}
+		}
+	}
+
+	return nil
+}
+
+// Name returns a string representation of the roles claimed by this cache.
+func (cfg *CacheConfig) Name() string {
+	stringRoles := make([]string, len(cfg.Role))
+	for i, role := range cfg.Role {
+		stringRoles[i] = string(role)
+	}
+	return strings.Join(stringRoles, "|")
+}
+
+func allRoles() map[cache.Role]struct{} {
+	all := []cache.Role{
+		cache.RoleBloom,
+		cache.RoleParquetFooter,
+		cache.RoleParquetColumnIdx,
+		cache.RoleParquetOffsetIdx,
+		cache.RoleTraceIDIdx,
+	}
+
+	roles := map[cache.Role]struct{}{}
+	for _, role := range all {
+		roles[role] = struct{}{}
+	}
+
+	return roles
+}

--- a/modules/cache/config_test.go
+++ b/modules/cache/config_test.go
@@ -1,0 +1,138 @@
+package cache
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/grafana/tempo/modules/cache/memcached"
+	"github.com/grafana/tempo/modules/cache/redis"
+	"github.com/grafana/tempo/pkg/cache"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigValidation(t *testing.T) {
+	tcs := []struct {
+		name     string
+		cfg      *Config
+		expected error
+	}{
+		{
+			name: "no caching is valid",
+			cfg:  &Config{},
+		},
+		{
+			name: "valid config",
+			cfg: &Config{
+				Caches: []CacheConfig{
+					{
+						Role:            []cache.Role{cache.RoleBloom},
+						MemcachedConfig: &memcached.Config{},
+					},
+					{
+						Role:        []cache.Role{cache.RoleParquetColumnIdx},
+						RedisConfig: &redis.Config{},
+					},
+				},
+			},
+		},
+		{
+			name: "invalid - duplicate roles",
+			cfg: &Config{
+				Caches: []CacheConfig{
+					{
+						Role:            []cache.Role{cache.RoleBloom},
+						MemcachedConfig: &memcached.Config{},
+					},
+					{
+						Role:        []cache.Role{cache.RoleBloom},
+						RedisConfig: &redis.Config{},
+					},
+				},
+			},
+			expected: errors.New("role bloom is claimed by more than one cache"),
+		},
+		{
+			name: "invalid - no roles",
+			cfg: &Config{
+				Caches: []CacheConfig{
+					{
+						MemcachedConfig: &memcached.Config{},
+					},
+				},
+			},
+			expected: errors.New("configured caches require a valid role"),
+		},
+		{
+			name: "invalid - both caches configged",
+			cfg: &Config{
+				Caches: []CacheConfig{
+					{
+						Role:            []cache.Role{cache.RoleBloom},
+						MemcachedConfig: &memcached.Config{},
+						RedisConfig:     &redis.Config{},
+					},
+				},
+			},
+			expected: errors.New("cache config for role [bloom] has both memcached and redis configs"),
+		},
+		{
+			name: "invalid - no caches configged",
+			cfg: &Config{
+				Caches: []CacheConfig{
+					{
+						Role: []cache.Role{cache.RoleBloom},
+					},
+				},
+			},
+			expected: errors.New("cache config for role [bloom] has neither memcached nor redis configs"),
+		},
+		{
+			name: "invalid - non-existent role",
+			cfg: &Config{
+				Caches: []CacheConfig{
+					{
+						Role:            []cache.Role{cache.Role("foo")},
+						MemcachedConfig: &memcached.Config{},
+					},
+				},
+			},
+			expected: errors.New("role foo is not a valid role"),
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			require.Equal(t, tc.expected, err)
+		})
+	}
+}
+
+func TestCacheConfigName(t *testing.T) {
+	tcs := []struct {
+		cfg      *CacheConfig
+		expected string
+	}{
+		{
+			cfg: &CacheConfig{
+				Role: []cache.Role{cache.RoleBloom},
+			},
+			expected: "bloom",
+		},
+		{
+			cfg: &CacheConfig{
+				Role: []cache.Role{cache.RoleBloom, cache.RoleParquetColumnIdx},
+			},
+			expected: "bloom|parquet-column-idx",
+		},
+		{
+			cfg:      &CacheConfig{},
+			expected: "",
+		},
+	}
+
+	for _, tc := range tcs {
+		actual := tc.cfg.Name()
+		require.Equal(t, tc.expected, actual)
+	}
+}

--- a/modules/cache/memcached/memcached.go
+++ b/modules/cache/memcached/memcached.go
@@ -15,7 +15,7 @@ type Config struct {
 	TTL time.Duration `yaml:"ttl"`
 }
 
-func NewClient(cfg *Config, cfgBackground *cache.BackgroundConfig, logger log.Logger) cache.Cache {
+func NewClient(cfg *Config, cfgBackground *cache.BackgroundConfig, name string, logger log.Logger) cache.Cache {
 	if cfg.ClientConfig.MaxIdleConns == 0 {
 		cfg.ClientConfig.MaxIdleConns = 16
 	}
@@ -26,13 +26,13 @@ func NewClient(cfg *Config, cfgBackground *cache.BackgroundConfig, logger log.Lo
 		cfg.ClientConfig.UpdateInterval = time.Minute
 	}
 
-	client := cache.NewMemcachedClient(cfg.ClientConfig, "tempo", prometheus.DefaultRegisterer, logger)
+	client := cache.NewMemcachedClient(cfg.ClientConfig, name, prometheus.DefaultRegisterer, logger)
 	memcachedCfg := cache.MemcachedConfig{
 		Expiration:  cfg.TTL,
 		BatchSize:   0, // we are currently only requesting one key at a time, which is bad.  we could restructure Find() to batch request all blooms at once
 		Parallelism: 0,
 	}
-	c := cache.NewMemcached(memcachedCfg, client, "tempo", prometheus.DefaultRegisterer, logger)
+	c := cache.NewMemcached(memcachedCfg, client, name, prometheus.DefaultRegisterer, logger)
 
-	return cache.NewBackground("tempo", *cfgBackground, c, prometheus.DefaultRegisterer)
+	return cache.NewBackground(name, *cfgBackground, c, prometheus.DefaultRegisterer)
 }

--- a/modules/cache/redis/redis.go
+++ b/modules/cache/redis/redis.go
@@ -15,7 +15,7 @@ type Config struct {
 	TTL time.Duration `yaml:"ttl"`
 }
 
-func NewClient(cfg *Config, cfgBackground *cache.BackgroundConfig, logger log.Logger) cache.Cache {
+func NewClient(cfg *Config, cfgBackground *cache.BackgroundConfig, name string, logger log.Logger) cache.Cache {
 	if cfg.ClientConfig.Timeout == 0 {
 		cfg.ClientConfig.Timeout = 100 * time.Millisecond
 	}
@@ -24,7 +24,7 @@ func NewClient(cfg *Config, cfgBackground *cache.BackgroundConfig, logger log.Lo
 	}
 
 	client := cache.NewRedisClient(&cfg.ClientConfig)
-	c := cache.NewRedisCache("tempo", client, prometheus.DefaultRegisterer, logger)
+	c := cache.NewRedisCache(name, client, prometheus.DefaultRegisterer, logger)
 
-	return cache.NewBackground("tempo", *cfgBackground, c, prometheus.DefaultRegisterer)
+	return cache.NewBackground(name, *cfgBackground, c, prometheus.DefaultRegisterer)
 }

--- a/modules/ingester/ingester_test.go
+++ b/modules/ingester/ingester_test.go
@@ -428,7 +428,7 @@ func defaultIngesterWithOverrides(t testing.TB, tmpDir string, o overrides.Confi
 				Filepath: tmpDir,
 			},
 		},
-	}, log.NewNopLogger())
+	}, nil, log.NewNopLogger())
 	require.NoError(t, err, "unexpected error store")
 
 	ingester, err := New(ingesterConfig, s, limits, prometheus.NewPedanticRegistry())

--- a/modules/ingester/local_block.go
+++ b/modules/ingester/local_block.go
@@ -37,7 +37,7 @@ func newLocalBlock(ctx context.Context, existingBlock common.BackendBlock, l *lo
 		writer:       backend.NewWriter(l),
 	}
 
-	flushedBytes, err := c.reader.Read(ctx, nameFlushed, c.BlockMeta().BlockID, c.BlockMeta().TenantID, false)
+	flushedBytes, err := c.reader.Read(ctx, nameFlushed, c.BlockMeta().BlockID, c.BlockMeta().TenantID, nil)
 	if err == nil {
 		flushedTime := time.Time{}
 		err = flushedTime.UnmarshalText(flushedBytes)
@@ -73,7 +73,7 @@ func (c *localBlock) SetFlushed(ctx context.Context) error {
 		return fmt.Errorf("error marshalling flush time to text: %w", err)
 	}
 
-	err = c.writer.Write(ctx, nameFlushed, c.BlockMeta().BlockID, c.BlockMeta().TenantID, flushedBytes, false)
+	err = c.writer.Write(ctx, nameFlushed, c.BlockMeta().BlockID, c.BlockMeta().TenantID, flushedBytes, nil)
 	if err != nil {
 		return fmt.Errorf("error writing ingester block flushed file: %w", err)
 	}

--- a/modules/storage/store.go
+++ b/modules/storage/store.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/services"
 
+	"github.com/grafana/tempo/pkg/cache"
 	"github.com/grafana/tempo/pkg/usagestats"
 	"github.com/grafana/tempo/tempodb"
 )
@@ -39,7 +40,7 @@ type store struct {
 }
 
 // NewStore creates a new Tempo Store using configuration supplied.
-func NewStore(cfg Config, logger log.Logger) (Store, error) {
+func NewStore(cfg Config, cacheProvider cache.Provider, logger log.Logger) (Store, error) {
 	statCache.Set(cfg.Trace.Cache)
 	statBackend.Set(cfg.Trace.Backend)
 	statWalEncoding.Set(cfg.Trace.WAL.Encoding.String())
@@ -47,7 +48,7 @@ func NewStore(cfg Config, logger log.Logger) (Store, error) {
 	statBlockEncoding.Set(cfg.Trace.Block.Encoding.String())
 	statBlockSearchEncoding.Set(cfg.Trace.Block.SearchEncoding.String())
 
-	r, w, c, err := tempodb.New(&cfg.Trace, logger)
+	r, w, c, err := tempodb.New(&cfg.Trace, cacheProvider, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -2,7 +2,28 @@ package cache
 
 import (
 	"context"
+
+	"github.com/grafana/dskit/services"
 )
+
+type Role string
+
+const (
+	// individual roles
+	RoleBloom            Role = "bloom"
+	RoleTraceIDIdx       Role = "trace-id-index"
+	RoleParquetFooter    Role = "parquet-footer"
+	RoleParquetColumnIdx Role = "parquet-column-idx"
+	RoleParquetOffsetIdx Role = "parquet-offset-idx"
+)
+
+// Provider is an object that can return a cache for a requested role
+type Provider interface {
+	services.Service
+
+	CacheFor(role Role) Cache
+	AddCache(role Role, c Cache) error
+}
 
 // Cache byte arrays by key.
 //

--- a/pkg/usagestats/reporter.go
+++ b/pkg/usagestats/reporter.go
@@ -200,7 +200,7 @@ func (rep *Reporter) fetchSeed(ctx context.Context, continueFn func(err error) b
 
 // readSeedFile reads the cluster seed file from the object store.
 func (rep *Reporter) readSeedFile(ctx context.Context) (*ClusterSeed, error) {
-	reader, _, err := rep.reader.Read(ctx, backend.ClusterSeedFileName, backend.KeyPath{}, false)
+	reader, _, err := rep.reader.Read(ctx, backend.ClusterSeedFileName, backend.KeyPath{}, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +226,7 @@ func (rep *Reporter) writeSeedFile(ctx context.Context, seed ClusterSeed) error 
 	if err != nil {
 		return err
 	}
-	return rep.writer.Write(ctx, backend.ClusterSeedFileName, []string{}, bytes.NewReader(data), -1, false)
+	return rep.writer.Write(ctx, backend.ClusterSeedFileName, []string{}, bytes.NewReader(data), -1, nil)
 }
 
 // running inits the reporter seed and start sending report for every interval

--- a/pkg/usagestats/reporter_test.go
+++ b/pkg/usagestats/reporter_test.go
@@ -81,7 +81,7 @@ func Test_LeaderElectionWithBrokenSeedFile(t *testing.T) {
 	// Ensure that leader election succeeds even when the seed file has been
 	// corrupted.  This means that we don't need to extend the interface of the
 	// backend in order to delete a corrupted seed file.
-	err = objectClient.Write(context.Background(), backend.ClusterSeedFileName, []string{}, bytes.NewReader([]byte("{")), -1, false)
+	err = objectClient.Write(context.Background(), backend.ClusterSeedFileName, []string{}, bytes.NewReader([]byte("{")), -1, nil)
 	require.NoError(t, err)
 
 	for i := 0; i < 3; i++ {

--- a/tempodb/backend/azure/azure_test.go
+++ b/tempodb/backend/azure/azure_test.go
@@ -90,12 +90,12 @@ func TestHedge(t *testing.T) {
 
 					// the first call on each client initiates an extra http request
 					// clearing that here
-					_, _, _ = r.Read(ctx, "object", backend.KeyPathForBlock(uuid.New(), "tenant"), false)
+					_, _, _ = r.Read(ctx, "object", backend.KeyPathForBlock(uuid.New(), "tenant"), nil)
 					time.Sleep(tc.returnIn)
 					atomic.StoreInt32(&count, 0)
 
 					// calls that should hedge
-					_, _, _ = r.Read(ctx, "object", backend.KeyPathForBlock(uuid.New(), "tenant"), false)
+					_, _, _ = r.Read(ctx, "object", backend.KeyPathForBlock(uuid.New(), "tenant"), nil)
 					time.Sleep(tc.returnIn)
 					assert.Equal(t, tc.expectedHedgedRequests*2, atomic.LoadInt32(&count)) // *2 b/c reads execute a HEAD and GET
 					atomic.StoreInt32(&count, 0)
@@ -111,10 +111,10 @@ func TestHedge(t *testing.T) {
 					assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 					atomic.StoreInt32(&count, 0)
 
-					_ = w.Write(ctx, "object", backend.KeyPathForBlock(uuid.New(), "tenant"), bytes.NewReader(make([]byte, 10)), 10, false)
+					_ = w.Write(ctx, "object", backend.KeyPathForBlock(uuid.New(), "tenant"), bytes.NewReader(make([]byte, 10)), 10, nil)
 					// Write consists of two operations:
 					// - Put Block operation
-					//   https://docs.microsoft.com/en-us/rest/api/storageservices/put-block
+					//   https://docs.microso).com/en-us/rest/api/storageservices/put-block
 					// - Put Block List operation
 					//   https://docs.microsoft.com/en-us/rest/api/storageservices/put-block-list
 					if useV2 {
@@ -130,7 +130,7 @@ func TestHedge(t *testing.T) {
 						// blockSize := 2000000
 						// u, err := uuid.Parse("f97223f3-d60c-4923-b255-bb7b8140b389")
 						// require.NoError(t, err)
-						// _ = w.Write(ctx, "object", backend.KeyPathForBlock(u, "tenant"), bytes.NewReader(make([]byte, blockSize)), 10, false)
+						// _ = w.Write(ctx, "object", backend.KeyPathForBlock(u, "tenant"), bytes.NewReader(make([]byte, blockSize)), 10, nil)
 					} else {
 						assert.Equal(t, int32(2), atomic.LoadInt32(&count))
 					}
@@ -246,7 +246,7 @@ func TestObjectWithPrefix(t *testing.T) {
 			require.NoError(t, err)
 
 			ctx := context.Background()
-			err = w.Write(ctx, tc.objectName, tc.keyPath, bytes.NewReader([]byte{}), 0, false)
+			err = w.Write(ctx, tc.objectName, tc.keyPath, bytes.NewReader([]byte{}), 0, nil)
 			assert.NoError(t, err)
 		})
 	}

--- a/tempodb/backend/azure/v2/compactor.go
+++ b/tempodb/backend/azure/v2/compactor.go
@@ -45,7 +45,7 @@ func (rw *V2) MarkBlockCompacted(blockID uuid.UUID, tenantID string) error {
 	}
 
 	// delete the old file
-	return rw.Delete(ctx, metaFilename, []string{}, false)
+	return rw.Delete(ctx, metaFilename, []string{}, nil)
 }
 
 func (rw *V2) ClearBlock(blockID uuid.UUID, tenantID string) error {
@@ -78,7 +78,7 @@ func (rw *V2) ClearBlock(blockID uuid.UUID, tenantID string) error {
 				return fmt.Errorf("unexpected empty blob name when listing %s: %w", prefix, err)
 			}
 
-			err = rw.Delete(ctx, *b.Name, []string{}, false)
+			err = rw.Delete(ctx, *b.Name, []string{}, nil)
 			if err != nil {
 				warning = err
 				continue

--- a/tempodb/backend/cache/cache.go
+++ b/tempodb/backend/cache/cache.go
@@ -6,7 +6,10 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/pkg/cache"
 
@@ -14,18 +17,45 @@ import (
 	"github.com/grafana/tempo/tempodb/backend"
 )
 
-type readerWriter struct {
-	nextReader backend.RawReader
-	nextWriter backend.RawWriter
-	cache      cache.Cache
+type BloomConfig struct {
+	CacheMinCompactionLevel uint8         `yaml:"cache_min_compaction_level"`
+	CacheMaxBlockAge        time.Duration `yaml:"cache_max_block_age"`
 }
 
-func NewCache(nextReader backend.RawReader, nextWriter backend.RawWriter, cache cache.Cache) (backend.RawReader, backend.RawWriter, error) {
+type readerWriter struct {
+	cfgBloom *BloomConfig
+
+	nextReader backend.RawReader
+	nextWriter backend.RawWriter
+
+	footerCache     cache.Cache
+	bloomCache      cache.Cache
+	columnIdxCache  cache.Cache
+	offsetIdxCache  cache.Cache
+	traceIDIdxCache cache.Cache
+}
+
+func NewCache(cfgBloom *BloomConfig, nextReader backend.RawReader, nextWriter backend.RawWriter, cacheProvider cache.Provider, logger log.Logger) (backend.RawReader, backend.RawWriter, error) {
 	rw := &readerWriter{
-		cache:      cache,
+		cfgBloom: cfgBloom,
+
+		footerCache:     cacheProvider.CacheFor(cache.RoleParquetFooter),
+		bloomCache:      cacheProvider.CacheFor(cache.RoleBloom),
+		offsetIdxCache:  cacheProvider.CacheFor(cache.RoleParquetOffsetIdx),
+		columnIdxCache:  cacheProvider.CacheFor(cache.RoleParquetColumnIdx),
+		traceIDIdxCache: cacheProvider.CacheFor(cache.RoleTraceIDIdx),
+
 		nextReader: nextReader,
 		nextWriter: nextWriter,
 	}
+
+	level.Info(logger).Log("msg", "caches available to storage backend",
+		"footer", rw.footerCache != nil,
+		"bloom", rw.bloomCache != nil,
+		"offset_idx", rw.offsetIdxCache != nil,
+		"column_idx", rw.columnIdxCache != nil,
+		"trace_id_idx", rw.traceIDIdxCache != nil,
+	)
 
 	return rw, rw, nil
 }
@@ -40,47 +70,53 @@ func (r *readerWriter) ListBlocks(ctx context.Context, tenant string) (blockIDs 
 }
 
 // Read implements backend.RawReader
-func (r *readerWriter) Read(ctx context.Context, name string, keypath backend.KeyPath, shouldCache bool) (io.ReadCloser, int64, error) {
+func (r *readerWriter) Read(ctx context.Context, name string, keypath backend.KeyPath, cacheInfo *backend.CacheInfo) (io.ReadCloser, int64, error) {
 	var k string
-	if shouldCache {
+	cache := r.cacheFor(cacheInfo)
+	if cache != nil {
 		k = key(keypath, name)
-		found, vals, _ := r.cache.Fetch(ctx, []string{k})
+		found, vals, _ := cache.Fetch(ctx, []string{k})
 		if len(found) > 0 {
 			return io.NopCloser(bytes.NewReader(vals[0])), int64(len(vals[0])), nil
 		}
 	}
 
-	object, size, err := r.nextReader.Read(ctx, name, keypath, false)
+	// previous implemenation always passed false forward for "shouldCache" so we are matching that behavior by passing nil for cacheInfo
+	// todo: reevaluate. should we pass the cacheInfo forward?
+	object, size, err := r.nextReader.Read(ctx, name, keypath, nil)
 	if err != nil {
 		return nil, 0, err
 	}
 	defer object.Close()
 
 	b, err := tempo_io.ReadAllWithEstimate(object, size)
-	if err == nil && shouldCache {
-		r.cache.Store(ctx, []string{k}, [][]byte{b})
+	if err == nil && cache != nil {
+		cache.Store(ctx, []string{k}, [][]byte{b})
 	}
 
 	return io.NopCloser(bytes.NewReader(b)), size, err
 }
 
 // ReadRange implements backend.RawReader
-func (r *readerWriter) ReadRange(ctx context.Context, name string, keypath backend.KeyPath, offset uint64, buffer []byte, shouldCache bool) error {
+func (r *readerWriter) ReadRange(ctx context.Context, name string, keypath backend.KeyPath, offset uint64, buffer []byte, cacheInfo *backend.CacheInfo) error {
 	var k string
-	if shouldCache {
+	cache := r.cacheFor(cacheInfo)
+	if cache != nil {
 		// cache key is tenantID:blockID:offset:length - file name is not needed in key
 		keyGen := keypath
 		keyGen = append(keyGen, strconv.Itoa(int(offset)), strconv.Itoa(len(buffer)))
 		k = strings.Join(keyGen, ":")
-		found, vals, _ := r.cache.Fetch(ctx, []string{k})
+		found, vals, _ := cache.Fetch(ctx, []string{k})
 		if len(found) > 0 {
 			copy(buffer, vals[0])
 		}
 	}
 
-	err := r.nextReader.ReadRange(ctx, name, keypath, offset, buffer, false)
-	if err == nil && shouldCache {
-		r.cache.Store(ctx, []string{k}, [][]byte{buffer})
+	// previous implemenation always passed false forward for "shouldCache" so we are matching that behavior by passing nil for cacheInfo
+	// todo: reevaluate. should we pass the cacheInfo forward?
+	err := r.nextReader.ReadRange(ctx, name, keypath, offset, buffer, nil)
+	if err == nil && cache != nil {
+		cache.Store(ctx, []string{k}, [][]byte{buffer})
 	}
 
 	return err
@@ -89,20 +125,34 @@ func (r *readerWriter) ReadRange(ctx context.Context, name string, keypath backe
 // Shutdown implements backend.RawReader
 func (r *readerWriter) Shutdown() {
 	r.nextReader.Shutdown()
-	r.cache.Stop()
+
+	stopCache := func(c cache.Cache) {
+		if c != nil {
+			c.Stop()
+		}
+	}
+
+	stopCache(r.footerCache)
+	stopCache(r.bloomCache)
+	stopCache(r.offsetIdxCache)
+	stopCache(r.columnIdxCache)
+	stopCache(r.traceIDIdxCache)
 }
 
 // Write implements backend.Writer
-func (r *readerWriter) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, size int64, shouldCache bool) error {
+func (r *readerWriter) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, size int64, cacheInfo *backend.CacheInfo) error {
 	b, err := tempo_io.ReadAllWithEstimate(data, size)
 	if err != nil {
 		return err
 	}
 
-	if shouldCache {
-		r.cache.Store(ctx, []string{key(keypath, name)}, [][]byte{b})
+	if cache := r.cacheFor(cacheInfo); cache != nil {
+		cache.Store(ctx, []string{key(keypath, name)}, [][]byte{b})
 	}
-	return r.nextWriter.Write(ctx, name, keypath, bytes.NewReader(b), int64(len(b)), false)
+
+	// previous implemenation always passed false forward for "shouldCache" so we are matching that behavior by passing nil for cacheInfo
+	// todo: reevaluate. should we pass the cacheInfo forward?
+	return r.nextWriter.Write(ctx, name, keypath, bytes.NewReader(b), int64(len(b)), nil)
 }
 
 // Append implements backend.Writer
@@ -115,13 +165,55 @@ func (r *readerWriter) CloseAppend(ctx context.Context, tracker backend.AppendTr
 	return r.nextWriter.CloseAppend(ctx, tracker)
 }
 
-func (r *readerWriter) Delete(ctx context.Context, name string, keypath backend.KeyPath, shouldCache bool) error {
-	if shouldCache {
+func (r *readerWriter) Delete(ctx context.Context, name string, keypath backend.KeyPath, cacheInfo *backend.CacheInfo) error {
+	if cacheInfo != nil {
 		panic("delete is not supported for cache.Cache backend")
 	}
-	return r.nextWriter.Delete(ctx, name, keypath, shouldCache)
+	return r.nextWriter.Delete(ctx, name, keypath, nil)
 }
 
 func key(keypath backend.KeyPath, name string) string {
 	return strings.Join(keypath, ":") + ":" + name
+}
+
+// cacheFor evaluates the cacheInfo and returns the appropriate cache.
+func (r *readerWriter) cacheFor(cacheInfo *backend.CacheInfo) cache.Cache {
+	if cacheInfo == nil {
+		return nil
+	}
+
+	switch cacheInfo.Role {
+	case cache.RoleParquetFooter:
+		return r.footerCache
+	case cache.RoleParquetColumnIdx:
+		return r.columnIdxCache
+	case cache.RoleParquetOffsetIdx:
+		return r.offsetIdxCache
+	case cache.RoleTraceIDIdx:
+		return r.traceIDIdxCache
+	case cache.RoleBloom:
+		// if there is no bloom cfg then there are no restrictions on bloom filter caching
+		if r.cfgBloom == nil {
+			return r.bloomCache
+		}
+
+		if cacheInfo.Meta == nil {
+			return nil
+		}
+
+		// compaction level is _atleast_ CacheMinCompactionLevel
+		if r.cfgBloom.CacheMinCompactionLevel > 0 && cacheInfo.Meta.CompactionLevel > r.cfgBloom.CacheMinCompactionLevel {
+			return nil
+		}
+
+		curTime := time.Now()
+		// block is not older than CacheMaxBlockAge
+		if r.cfgBloom.CacheMaxBlockAge > 0 && curTime.Sub(cacheInfo.Meta.StartTime) > r.cfgBloom.CacheMaxBlockAge {
+			return nil
+		}
+
+		return r.bloomCache
+	}
+
+	return nil
 }

--- a/tempodb/backend/cache/cache_test.go
+++ b/tempodb/backend/cache/cache_test.go
@@ -5,11 +5,15 @@ import (
 	"context"
 	"io"
 	"testing"
+	"time"
 
+	"github.com/go-kit/log"
 	"github.com/google/uuid"
+	"github.com/grafana/dskit/services"
 	"github.com/grafana/tempo/pkg/cache"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockClient struct {
@@ -41,6 +45,166 @@ func NewMockClient() cache.Cache {
 	}
 }
 
+func newMockProvider() *mockProvider {
+	return &mockProvider{
+		c: NewMockClient(),
+	}
+}
+
+type mockProvider struct {
+	services.Service
+
+	c cache.Cache
+}
+
+func (p *mockProvider) CacheFor(r cache.Role) cache.Cache {
+	return p.c
+}
+
+func (p *mockProvider) AddCache(_ cache.Role, c cache.Cache) error {
+	return nil
+}
+
+func TestCacheFor(t *testing.T) {
+	reader, _, err := NewCache(&BloomConfig{
+		CacheMaxBlockAge:        time.Hour,
+		CacheMinCompactionLevel: 1,
+	}, nil, nil, newMockProvider(), log.NewNopLogger())
+	require.NoError(t, err)
+
+	rw := reader.(*readerWriter)
+
+	testCases := []struct {
+		name          string
+		cacheInfo     *backend.CacheInfo
+		expectedCache cache.Cache
+	}{
+		// first three caches are unconditionally returned
+		{
+			name:          "footer is always returned",
+			cacheInfo:     &backend.CacheInfo{Role: cache.RoleParquetFooter},
+			expectedCache: rw.footerCache,
+		},
+		{
+			name:          "col idx is always returned",
+			cacheInfo:     &backend.CacheInfo{Role: cache.RoleParquetColumnIdx},
+			expectedCache: rw.columnIdxCache,
+		},
+		{
+			name:          "offset idx is always returned",
+			cacheInfo:     &backend.CacheInfo{Role: cache.RoleParquetOffsetIdx},
+			expectedCache: rw.offsetIdxCache,
+		},
+		{
+			name:          "trace id idx is always returned",
+			cacheInfo:     &backend.CacheInfo{Role: cache.RoleTraceIDIdx},
+			expectedCache: rw.traceIDIdxCache,
+		},
+		// bloom cache is returned if the meta is valid given the bloom config
+		{
+			name: "bloom - no meta means no cache",
+			cacheInfo: &backend.CacheInfo{
+				Role: cache.RoleBloom,
+			},
+		},
+		{
+			name: "bloom - compaction lvl and start time valid",
+			cacheInfo: &backend.CacheInfo{
+				Role: cache.RoleBloom,
+				Meta: &backend.BlockMeta{CompactionLevel: 1, StartTime: time.Now()},
+			},
+			expectedCache: rw.bloomCache,
+		},
+		{
+			name: "bloom - start time invalid",
+			cacheInfo: &backend.CacheInfo{
+				Role: cache.RoleBloom,
+				Meta: &backend.BlockMeta{CompactionLevel: 1, StartTime: time.Now().Add(-2 * time.Hour)},
+			},
+		},
+		{
+			name: "bloom - compaction lvl invalid",
+			cacheInfo: &backend.CacheInfo{
+				Role: cache.RoleBloom,
+				Meta: &backend.BlockMeta{CompactionLevel: 2, StartTime: time.Now()},
+			},
+		},
+		{
+			name: "bloom - both invalid",
+			cacheInfo: &backend.CacheInfo{
+				Role: cache.RoleBloom,
+				Meta: &backend.BlockMeta{CompactionLevel: 2, StartTime: time.Now().Add(-2 * time.Hour)},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expectedCache, rw.cacheFor(tt.cacheInfo))
+		})
+	}
+}
+
+func TestCacheForReturnsBloomWithNoConfig(t *testing.T) {
+	reader, _, err := NewCache(nil, nil, nil, newMockProvider(), log.NewNopLogger())
+	require.NoError(t, err)
+
+	rw := reader.(*readerWriter)
+
+	testCases := []struct {
+		name          string
+		cacheInfo     *backend.CacheInfo
+		expectedCache cache.Cache
+	}{
+		// bloom cache is returned if the meta is valid given the bloom config
+		{
+			name: "bloom - no meta means no cache",
+			cacheInfo: &backend.CacheInfo{
+				Role: cache.RoleBloom,
+			},
+			expectedCache: rw.bloomCache,
+		},
+		{
+			name: "bloom - compaction lvl and start time valid",
+			cacheInfo: &backend.CacheInfo{
+				Role: cache.RoleBloom,
+				Meta: &backend.BlockMeta{CompactionLevel: 1, StartTime: time.Now()},
+			},
+			expectedCache: rw.bloomCache,
+		},
+		{
+			name: "bloom - start time invalid",
+			cacheInfo: &backend.CacheInfo{
+				Role: cache.RoleBloom,
+				Meta: &backend.BlockMeta{CompactionLevel: 1, StartTime: time.Now().Add(-2 * time.Hour)},
+			},
+			expectedCache: rw.bloomCache,
+		},
+		{
+			name: "bloom - compaction lvl invalid",
+			cacheInfo: &backend.CacheInfo{
+				Role: cache.RoleBloom,
+				Meta: &backend.BlockMeta{CompactionLevel: 2, StartTime: time.Now()},
+			},
+			expectedCache: rw.bloomCache,
+		},
+		{
+			name: "bloom - both invalid",
+			cacheInfo: &backend.CacheInfo{
+				Role: cache.RoleBloom,
+				Meta: &backend.BlockMeta{CompactionLevel: 2, StartTime: time.Now().Add(-2 * time.Hour)},
+			},
+			expectedCache: rw.bloomCache,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expectedCache, rw.cacheFor(tt.cacheInfo))
+		})
+	}
+}
+
 func TestReadWrite(t *testing.T) {
 	tenantID := "test"
 	blockID := uuid.New()
@@ -49,7 +213,7 @@ func TestReadWrite(t *testing.T) {
 		name          string
 		readerRead    []byte
 		readerName    string
-		shouldCache   bool
+		cacheInfo     *backend.CacheInfo
 		expectedRead  []byte
 		expectedCache []byte
 	}{
@@ -57,14 +221,14 @@ func TestReadWrite(t *testing.T) {
 			name:          "should cache",
 			readerName:    "foo",
 			readerRead:    []byte{0x02},
-			shouldCache:   true,
+			cacheInfo:     &backend.CacheInfo{Role: cache.RoleParquetFooter},
 			expectedRead:  []byte{0x02},
 			expectedCache: []byte{0x02},
 		},
 		{
 			name:         "should not cache",
 			readerName:   "bar",
-			shouldCache:  false,
+			cacheInfo:    &backend.CacheInfo{Role: cache.Role("foo")}, // fake role name will not find a matching cache
 			readerRead:   []byte{0x02},
 			expectedRead: []byte{0x02},
 		},
@@ -78,24 +242,27 @@ func TestReadWrite(t *testing.T) {
 			mockW := &backend.MockRawWriter{}
 
 			// READ
-			r, _, _ := NewCache(mockR, mockW, NewMockClient())
+			r, _, err := NewCache(nil, mockR, mockW, newMockProvider(), log.NewNopLogger())
+			require.NoError(t, err)
 
 			ctx := context.Background()
-			reader, _, _ := r.Read(ctx, tt.readerName, backend.KeyPathForBlock(blockID, tenantID), tt.shouldCache)
+			reader, _, _ := r.Read(ctx, tt.readerName, backend.KeyPathForBlock(blockID, tenantID), tt.cacheInfo)
 			read, _ := io.ReadAll(reader)
 			assert.Equal(t, tt.expectedRead, read)
 
 			// clear reader and re-request
 			mockR.R = nil
 
-			reader, _, _ = r.Read(ctx, tt.readerName, backend.KeyPathForBlock(blockID, tenantID), tt.shouldCache)
+			reader, _, _ = r.Read(ctx, tt.readerName, backend.KeyPathForBlock(blockID, tenantID), tt.cacheInfo)
 			read, _ = io.ReadAll(reader)
 			assert.Equal(t, len(tt.expectedCache), len(read))
 
 			// WRITE
-			_, w, _ := NewCache(mockR, mockW, NewMockClient())
-			_ = w.Write(ctx, tt.readerName, backend.KeyPathForBlock(blockID, tenantID), bytes.NewReader(tt.readerRead), int64(len(tt.readerRead)), tt.shouldCache)
-			reader, _, _ = r.Read(ctx, tt.readerName, backend.KeyPathForBlock(blockID, tenantID), tt.shouldCache)
+			_, w, err := NewCache(nil, mockR, mockW, newMockProvider(), log.NewNopLogger())
+			require.NoError(t, err)
+
+			_ = w.Write(ctx, tt.readerName, backend.KeyPathForBlock(blockID, tenantID), bytes.NewReader(tt.readerRead), int64(len(tt.readerRead)), tt.cacheInfo)
+			reader, _, _ = r.Read(ctx, tt.readerName, backend.KeyPathForBlock(blockID, tenantID), tt.cacheInfo)
 			read, _ = io.ReadAll(reader)
 			assert.Equal(t, len(tt.expectedCache), len(read))
 		})
@@ -127,7 +294,7 @@ func TestList(t *testing.T) {
 			}
 			mockW := &backend.MockRawWriter{}
 
-			rw, _, _ := NewCache(mockR, mockW, NewMockClient())
+			rw, _, _ := NewCache(nil, mockR, mockW, newMockProvider(), log.NewNopLogger())
 
 			ctx := context.Background()
 			list, _ := rw.List(ctx, backend.KeyPathForBlock(blockID, tenantID))

--- a/tempodb/backend/gcs/gcs.go
+++ b/tempodb/backend/gcs/gcs.go
@@ -104,7 +104,7 @@ func internalNew(cfg *Config, confirm bool) (*readerWriter, error) {
 }
 
 // Write implements backend.Writer
-func (rw *readerWriter) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, _ int64, _ bool) error {
+func (rw *readerWriter) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, _ int64, _ *backend.CacheInfo) error {
 	keypath = backend.KeyPathWithPrefix(keypath, rw.cfg.Prefix)
 	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "gcs.Write")
 	defer span.Finish()
@@ -156,7 +156,7 @@ func (rw *readerWriter) CloseAppend(_ context.Context, tracker backend.AppendTra
 	return w.Close()
 }
 
-func (rw *readerWriter) Delete(ctx context.Context, name string, keypath backend.KeyPath, _ bool) error {
+func (rw *readerWriter) Delete(ctx context.Context, name string, keypath backend.KeyPath, _ *backend.CacheInfo) error {
 	return readError(rw.bucket.Object(backend.ObjectFileName(keypath, name)).Delete(ctx))
 }
 
@@ -309,7 +309,7 @@ func (rw *readerWriter) ListBlocks(ctx context.Context, tenant string) ([]uuid.U
 }
 
 // Read implements backend.Reader
-func (rw *readerWriter) Read(ctx context.Context, name string, keypath backend.KeyPath, _ bool) (io.ReadCloser, int64, error) {
+func (rw *readerWriter) Read(ctx context.Context, name string, keypath backend.KeyPath, _ *backend.CacheInfo) (io.ReadCloser, int64, error) {
 	keypath = backend.KeyPathWithPrefix(keypath, rw.cfg.Prefix)
 	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "gcs.Read")
 	defer span.Finish()
@@ -324,7 +324,7 @@ func (rw *readerWriter) Read(ctx context.Context, name string, keypath backend.K
 }
 
 // ReadRange implements backend.Reader
-func (rw *readerWriter) ReadRange(ctx context.Context, name string, keypath backend.KeyPath, offset uint64, buffer []byte, _ bool) error {
+func (rw *readerWriter) ReadRange(ctx context.Context, name string, keypath backend.KeyPath, offset uint64, buffer []byte, _ *backend.CacheInfo) error {
 	keypath = backend.KeyPathWithPrefix(keypath, rw.cfg.Prefix)
 	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "gcs.ReadRange", opentracing.Tags{
 		"len":    len(buffer),

--- a/tempodb/backend/gcs/gcs_test.go
+++ b/tempodb/backend/gcs/gcs_test.go
@@ -67,17 +67,17 @@ func TestHedge(t *testing.T) {
 
 			// the first call on each client initiates an extra http request
 			// clearing that here
-			_, _, _ = r.Read(ctx, "object", []string{"test"}, false)
+			_, _, _ = r.Read(ctx, "object", []string{"test"}, nil)
 			time.Sleep(tc.returnIn)
 			atomic.StoreInt32(&count, 0)
 
 			// calls that should hedge
-			_, _, _ = r.Read(ctx, "object", []string{"test"}, false)
+			_, _, _ = r.Read(ctx, "object", []string{"test"}, nil)
 			time.Sleep(tc.returnIn)
 			assert.Equal(t, tc.expectedHedgedRequests, atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 
-			_ = r.ReadRange(ctx, "object", []string{"test"}, 10, []byte{}, false)
+			_ = r.ReadRange(ctx, "object", []string{"test"}, 10, []byte{}, nil)
 			time.Sleep(tc.returnIn)
 			assert.Equal(t, tc.expectedHedgedRequests, atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
@@ -87,7 +87,7 @@ func TestHedge(t *testing.T) {
 			assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 
-			_ = w.Write(ctx, "object", []string{"test"}, bytes.NewReader([]byte{}), 0, false)
+			_ = w.Write(ctx, "object", []string{"test"}, bytes.NewReader([]byte{}), 0, nil)
 			assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 		})
@@ -139,7 +139,7 @@ func TestObjectConfigAttributes(t *testing.T) {
 
 			ctx := context.Background()
 
-			_ = w.Write(ctx, "object", []string{"test"}, bytes.NewReader([]byte{}), 0, false)
+			_ = w.Write(ctx, "object", []string{"test"}, bytes.NewReader([]byte{}), 0, nil)
 			assert.Equal(t, tc.expectedObject, rawObject)
 		})
 	}
@@ -293,7 +293,7 @@ func TestObjectWithPrefix(t *testing.T) {
 			require.NoError(t, err)
 
 			ctx := context.Background()
-			err = w.Write(ctx, tc.objectName, tc.keyPath, bytes.NewReader([]byte{}), 0, false)
+			err = w.Write(ctx, tc.objectName, tc.keyPath, bytes.NewReader([]byte{}), 0, nil)
 			assert.NoError(t, err)
 		})
 	}

--- a/tempodb/backend/local/local.go
+++ b/tempodb/backend/local/local.go
@@ -43,7 +43,7 @@ func New(cfg *Config) (backend.RawReader, backend.RawWriter, backend.Compactor, 
 }
 
 // Write implements backend.Writer
-func (rw *Backend) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, _ int64, _ bool) error {
+func (rw *Backend) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, _ int64, _ *backend.CacheInfo) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func (rw *Backend) CloseAppend(ctx context.Context, tracker backend.AppendTracke
 	return dst.Close()
 }
 
-func (rw *Backend) Delete(ctx context.Context, name string, keypath backend.KeyPath, _ bool) error {
+func (rw *Backend) Delete(ctx context.Context, name string, keypath backend.KeyPath, _ *backend.CacheInfo) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -190,7 +190,7 @@ func (rw *Backend) ListBlocks(_ context.Context, tenant string) (metas []uuid.UU
 }
 
 // Read implements backend.Reader
-func (rw *Backend) Read(ctx context.Context, name string, keypath backend.KeyPath, _ bool) (io.ReadCloser, int64, error) {
+func (rw *Backend) Read(ctx context.Context, name string, keypath backend.KeyPath, _ *backend.CacheInfo) (io.ReadCloser, int64, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, -1, err
 	}
@@ -212,7 +212,7 @@ func (rw *Backend) Read(ctx context.Context, name string, keypath backend.KeyPat
 }
 
 // ReadRange implements backend.Reader
-func (rw *Backend) ReadRange(ctx context.Context, name string, keypath backend.KeyPath, offset uint64, buffer []byte, _ bool) error {
+func (rw *Backend) ReadRange(ctx context.Context, name string, keypath backend.KeyPath, offset uint64, buffer []byte, _ *backend.CacheInfo) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}

--- a/tempodb/backend/local/local_test.go
+++ b/tempodb/backend/local/local_test.go
@@ -49,23 +49,23 @@ func TestReadWrite(t *testing.T) {
 	ctx := context.Background()
 	for _, id := range tenantIDs {
 		fakeMeta.TenantID = id
-		err = w.Write(ctx, objectName, backend.KeyPathForBlock(fakeMeta.BlockID, id), bytes.NewReader(fakeObject), int64(len(fakeObject)), false)
+		err = w.Write(ctx, objectName, backend.KeyPathForBlock(fakeMeta.BlockID, id), bytes.NewReader(fakeObject), int64(len(fakeObject)), nil)
 		assert.NoError(t, err, "unexpected error writing")
 
-		err = w.Write(ctx, backend.MetaName, backend.KeyPathForBlock(fakeMeta.BlockID, id), bytes.NewReader(fakeObject), int64(len(fakeObject)), false)
+		err = w.Write(ctx, backend.MetaName, backend.KeyPathForBlock(fakeMeta.BlockID, id), bytes.NewReader(fakeObject), int64(len(fakeObject)), nil)
 		assert.NoError(t, err, "unexpected error meta.json")
-		err = w.Write(ctx, backend.CompactedMetaName, backend.KeyPathForBlock(fakeMeta.BlockID, id), bytes.NewReader(fakeObject), int64(len(fakeObject)), false)
+		err = w.Write(ctx, backend.CompactedMetaName, backend.KeyPathForBlock(fakeMeta.BlockID, id), bytes.NewReader(fakeObject), int64(len(fakeObject)), nil)
 		assert.NoError(t, err, "unexpected error meta.compacted.json")
 	}
 
-	actualObject, size, err := r.Read(ctx, objectName, backend.KeyPathForBlock(blockID, tenantIDs[0]), false)
+	actualObject, size, err := r.Read(ctx, objectName, backend.KeyPathForBlock(blockID, tenantIDs[0]), nil)
 	assert.NoError(t, err, "unexpected error reading")
 	actualObjectBytes, err := io.ReadAllWithEstimate(actualObject, size)
 	assert.NoError(t, err, "unexpected error reading")
 	assert.Equal(t, fakeObject, actualObjectBytes)
 
 	actualReadRange := make([]byte, 5)
-	err = r.ReadRange(ctx, objectName, backend.KeyPathForBlock(blockID, tenantIDs[0]), 5, actualReadRange, false)
+	err = r.ReadRange(ctx, objectName, backend.KeyPathForBlock(blockID, tenantIDs[0]), 5, actualReadRange, nil)
 	assert.NoError(t, err, "unexpected error range")
 	assert.Equal(t, fakeObject[5:10], actualReadRange)
 
@@ -92,7 +92,7 @@ func TestShutdownLeavesTenantsWithBlocks(t *testing.T) {
 	tenant := "fake"
 
 	// write a "block"
-	err = w.Write(ctx, "test", backend.KeyPathForBlock(blockID, tenant), contents, contents.Size(), false)
+	err = w.Write(ctx, "test", backend.KeyPathForBlock(blockID, tenant), contents, contents.Size(), nil)
 	require.NoError(t, err)
 
 	tenantExists(t, tenant, r)
@@ -117,7 +117,7 @@ func TestShutdownRemovesTenantsWithoutBlocks(t *testing.T) {
 	tenant := "tenant"
 
 	// write a "block"
-	err = w.Write(ctx, "test", backend.KeyPathForBlock(blockID, tenant), contents, contents.Size(), false)
+	err = w.Write(ctx, "test", backend.KeyPathForBlock(blockID, tenant), contents, contents.Size(), nil)
 	require.NoError(t, err)
 
 	tenantExists(t, tenant, r)

--- a/tempodb/backend/raw_test.go
+++ b/tempodb/backend/raw_test.go
@@ -23,7 +23,7 @@ func TestWriter(t *testing.T) {
 
 	expected := []byte{0x01, 0x02, 0x03, 0x04}
 
-	err := w.Write(ctx, "test", uuid.New(), "test", expected, false)
+	err := w.Write(ctx, "test", uuid.New(), "test", expected, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, m.writeBuffer)
 
@@ -74,12 +74,12 @@ func TestReader(t *testing.T) {
 
 	expected := []byte{0x01, 0x02, 0x03, 0x04}
 	m.R = expected
-	actual, err := r.Read(ctx, "test", uuid.New(), "test", false)
+	actual, err := r.Read(ctx, "test", uuid.New(), "test", nil)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 
 	m.Range = expected
-	err = r.ReadRange(ctx, "test", uuid.New(), "test", 10, actual, false)
+	err = r.ReadRange(ctx, "test", uuid.New(), "test", 10, actual, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 

--- a/tempodb/backend/readerat.go
+++ b/tempodb/backend/readerat.go
@@ -19,31 +19,29 @@ type ContextReader interface {
 
 // backendReader is a shim that allows a backend.Reader to be used as a ContextReader
 type backendReader struct {
-	meta        *BlockMeta
-	name        string
-	r           Reader
-	shouldCache bool
+	meta *BlockMeta
+	name string
+	r    Reader
 }
 
 // NewContextReader creates a ReaderAt for the given BlockMeta
-func NewContextReader(meta *BlockMeta, name string, r Reader, shouldCache bool) ContextReader {
+func NewContextReader(meta *BlockMeta, name string, r Reader) ContextReader {
 	return &backendReader{
-		meta:        meta,
-		name:        name,
-		r:           r,
-		shouldCache: shouldCache,
+		meta: meta,
+		name: name,
+		r:    r,
 	}
 }
 
 // ReadAt implements ContextReader
 func (b *backendReader) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
-	err := b.r.ReadRange(ctx, b.name, b.meta.BlockID, b.meta.TenantID, uint64(off), p, false)
+	err := b.r.ReadRange(ctx, b.name, b.meta.BlockID, b.meta.TenantID, uint64(off), p, nil)
 	return len(p), err
 }
 
 // ReadAll implements ContextReader
 func (b *backendReader) ReadAll(ctx context.Context) ([]byte, error) {
-	return b.r.Read(ctx, b.name, b.meta.BlockID, b.meta.TenantID, b.shouldCache)
+	return b.r.Read(ctx, b.name, b.meta.BlockID, b.meta.TenantID, nil)
 }
 
 // Reader implements ContextReader

--- a/tempodb/backend/s3/s3_test.go
+++ b/tempodb/backend/s3/s3_test.go
@@ -249,17 +249,17 @@ func TestHedge(t *testing.T) {
 
 			// the first call on each client initiates an extra http request
 			// clearing that here
-			_, _, _ = r.Read(ctx, "object", backend.KeyPath{"test"}, false)
+			_, _, _ = r.Read(ctx, "object", backend.KeyPath{"test"}, nil)
 			time.Sleep(tc.returnIn)
 			atomic.StoreInt32(&count, 0)
 
 			// calls that should hedge
-			_, _, _ = r.Read(ctx, "object", backend.KeyPath{"test"}, false)
+			_, _, _ = r.Read(ctx, "object", backend.KeyPath{"test"}, nil)
 			time.Sleep(tc.returnIn)
 			assert.Equal(t, tc.expectedHedgedRequests, atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 
-			_ = r.ReadRange(ctx, "object", backend.KeyPath{"test"}, 10, []byte{}, false)
+			_ = r.ReadRange(ctx, "object", backend.KeyPath{"test"}, 10, []byte{}, nil)
 			time.Sleep(tc.returnIn)
 			assert.Equal(t, tc.expectedHedgedRequests, atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
@@ -269,7 +269,7 @@ func TestHedge(t *testing.T) {
 			assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 
-			_ = w.Write(ctx, "object", backend.KeyPath{"test"}, bytes.NewReader([]byte{}), 0, false)
+			_ = w.Write(ctx, "object", backend.KeyPath{"test"}, bytes.NewReader([]byte{}), 0, nil)
 			assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 		})
@@ -367,7 +367,7 @@ func TestObjectBlockTags(t *testing.T) {
 			require.NoError(t, err)
 
 			ctx := context.Background()
-			_ = w.Write(ctx, "object", backend.KeyPath{"test"}, bytes.NewReader([]byte{}), 0, false)
+			_ = w.Write(ctx, "object", backend.KeyPath{"test"}, bytes.NewReader([]byte{}), 0, nil)
 
 			for k, v := range tc.tags {
 				vv := obj.Get(k)
@@ -443,7 +443,7 @@ func TestObjectWithPrefix(t *testing.T) {
 			require.NoError(t, err)
 
 			ctx := context.Background()
-			err = w.Write(ctx, tc.objectName, tc.keyPath, bytes.NewReader([]byte{}), 0, false)
+			err = w.Write(ctx, tc.objectName, tc.keyPath, bytes.NewReader([]byte{}), 0, nil)
 			assert.NoError(t, err)
 		})
 	}
@@ -478,7 +478,7 @@ func TestObjectStorageClass(t *testing.T) {
 			require.NoError(t, err)
 
 			ctx := context.Background()
-			_ = w.Write(ctx, "object", backend.KeyPath{"test"}, bytes.NewReader([]byte{}), 0, false)
+			_ = w.Write(ctx, "object", backend.KeyPath{"test"}, bytes.NewReader([]byte{}), 0, nil)
 			require.Equal(t, obj.Has(tc.StorageClass), true)
 		})
 	}

--- a/tempodb/backend/versioned.go
+++ b/tempodb/backend/versioned.go
@@ -49,15 +49,15 @@ func NewFakeVersionedReaderWriter(r RawReader, w RawWriter) *FakeVersionedReader
 }
 
 func (f *FakeVersionedReaderWriter) WriteVersioned(ctx context.Context, name string, keypath KeyPath, data io.Reader, _ Version) (Version, error) {
-	err := f.Write(ctx, name, keypath, data, -1, false)
+	err := f.Write(ctx, name, keypath, data, -1, nil)
 	return VersionNew, err
 }
 
 func (f *FakeVersionedReaderWriter) ReadVersioned(ctx context.Context, name string, keypath KeyPath) (io.ReadCloser, Version, error) {
-	readCloser, _, err := f.Read(ctx, name, keypath, false)
+	readCloser, _, err := f.Read(ctx, name, keypath, nil)
 	return readCloser, VersionNew, err
 }
 
 func (f *FakeVersionedReaderWriter) DeleteVersioned(ctx context.Context, name string, keypath KeyPath, _ Version) error {
-	return f.Delete(ctx, name, keypath, false)
+	return f.Delete(ctx, name, keypath, nil)
 }

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -241,7 +241,7 @@ func (rw *readerWriter) compact(ctx context.Context, blockMetas []*backend.Block
 	compactor := enc.NewCompactor(opts)
 
 	// Compact selected blocks into a larger one
-	newCompactedBlocks, err := compactor.Compact(ctx, rw.logger, rw.r, rw.getWriterForBlock, blockMetas)
+	newCompactedBlocks, err := compactor.Compact(ctx, rw.logger, rw.r, rw.w, blockMetas)
 	if err != nil {
 		return err
 	}

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -98,7 +98,7 @@ func testCompactionRoundtrip(t *testing.T, targetBlockVersion string) {
 			Filepath: path.Join(tempDir, "wal"),
 		},
 		BlocklistPoll: 0,
-	}, log.NewNopLogger())
+	}, nil, log.NewNopLogger())
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -245,7 +245,7 @@ func testSameIDCompaction(t *testing.T, targetBlockVersion string) {
 			Filepath: path.Join(tempDir, "wal"),
 		},
 		BlocklistPoll: 0,
-	}, log.NewNopLogger())
+	}, nil, log.NewNopLogger())
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -389,7 +389,7 @@ func TestCompactionUpdatesBlocklist(t *testing.T) {
 			Filepath: path.Join(tempDir, "wal"),
 		},
 		BlocklistPoll: 0,
-	}, log.NewNopLogger())
+	}, nil, log.NewNopLogger())
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -460,7 +460,7 @@ func TestCompactionMetrics(t *testing.T) {
 			Filepath: path.Join(tempDir, "wal"),
 		},
 		BlocklistPoll: 0,
-	}, log.NewNopLogger())
+	}, nil, log.NewNopLogger())
 	assert.NoError(t, err)
 
 	ctx := context.Background()
@@ -534,7 +534,7 @@ func TestCompactionIteratesThroughTenants(t *testing.T) {
 			Filepath: path.Join(tempDir, "wal"),
 		},
 		BlocklistPoll: 0,
-	}, log.NewNopLogger())
+	}, nil, log.NewNopLogger())
 	assert.NoError(t, err)
 
 	ctx := context.Background()
@@ -607,7 +607,7 @@ func testCompactionHonorsBlockStartEndTimes(t *testing.T, targetBlockVersion str
 			IngestionSlack: time.Since(time.Unix(0, 0)), // Let us use obvious start/end times below
 		},
 		BlocklistPoll: 0,
-	}, log.NewNopLogger())
+	}, nil, log.NewNopLogger())
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -737,7 +737,7 @@ func benchmarkCompaction(b *testing.B, targetBlockVersion string) {
 			Filepath: path.Join(tempDir, "wal"),
 		},
 		BlocklistPoll: 0,
-	}, log.NewNopLogger())
+	}, nil, log.NewNopLogger())
 	require.NoError(b, err)
 
 	rw := c.(*readerWriter)

--- a/tempodb/encoding/common/interfaces.go
+++ b/tempodb/encoding/common/interfaces.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"context"
-	"time"
 
 	"github.com/go-kit/log"
 
@@ -29,12 +28,6 @@ type Searcher interface {
 	Fetch(context.Context, traceql.FetchSpansRequest, SearchOptions) (traceql.FetchSpansResponse, error)
 }
 
-type CacheControl struct {
-	Footer      bool
-	ColumnIndex bool
-	OffsetIndex bool
-}
-
 type SearchOptions struct {
 	ChunkSizeBytes     uint32 // Buffer size to read from backend storage.
 	StartPage          int    // Controls searching only a subset of the block. Which page to begin searching at.
@@ -43,7 +36,6 @@ type SearchOptions struct {
 	PrefetchTraceCount int    // How many traces to prefetch async.
 	ReadBufferCount    int
 	ReadBufferSize     int
-	CacheControl       CacheControl
 }
 
 // DefaultSearchOptions() is used in a lot of places such as local ingester searches. It is important
@@ -69,7 +61,7 @@ func DefaultSearchOptionsWithMaxBytes(maxBytes int) SearchOptions {
 }
 
 type Compactor interface {
-	Compact(ctx context.Context, l log.Logger, r backend.Reader, writerCallback func(*backend.BlockMeta, time.Time) backend.Writer, inputs []*backend.BlockMeta) ([]*backend.BlockMeta, error)
+	Compact(ctx context.Context, l log.Logger, r backend.Reader, w backend.Writer, inputs []*backend.BlockMeta) ([]*backend.BlockMeta, error)
 }
 
 type CompactionOptions struct {

--- a/tempodb/encoding/vparquet/block_findtracebyid.go
+++ b/tempodb/encoding/vparquet/block_findtracebyid.go
@@ -11,6 +11,7 @@ import (
 	"github.com/parquet-go/parquet-go"
 	"github.com/willf/bloom"
 
+	"github.com/grafana/tempo/pkg/cache"
 	"github.com/grafana/tempo/pkg/parquetquery"
 	pq "github.com/grafana/tempo/pkg/parquetquery"
 	"github.com/grafana/tempo/pkg/tempopb"
@@ -39,7 +40,10 @@ func (b *backendBlock) checkBloom(ctx context.Context, id common.ID) (found bool
 	nameBloom := common.BloomName(shardKey)
 	span.SetTag("bloom", nameBloom)
 
-	bloomBytes, err := b.r.Read(derivedCtx, nameBloom, b.meta.BlockID, b.meta.TenantID, true)
+	bloomBytes, err := b.r.Read(derivedCtx, nameBloom, b.meta.BlockID, b.meta.TenantID, &backend.CacheInfo{
+		Meta: b.meta,
+		Role: cache.RoleBloom,
+	})
 	if err != nil {
 		return false, fmt.Errorf("error retrieving bloom %s (%s, %s): %w", nameBloom, b.meta.TenantID, b.meta.BlockID, err)
 	}

--- a/tempodb/encoding/vparquet/block_iterator.go
+++ b/tempodb/encoding/vparquet/block_iterator.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (b *backendBlock) open(ctx context.Context) (*parquet.File, *parquet.Reader, error) { //nolint:all //deprecated
-	rr := NewBackendReaderAt(ctx, b.r, DataFileName, b.meta.BlockID, b.meta.TenantID)
+	rr := NewBackendReaderAt(ctx, b.r, DataFileName, b.meta)
 
 	// 128 MB memory buffering
 	br := tempo_io.NewBufferedReaderAt(rr, int64(b.meta.Size), 2*1024*1024, 64)

--- a/tempodb/encoding/vparquet/block_search.go
+++ b/tempodb/encoding/vparquet/block_search.go
@@ -63,7 +63,7 @@ func (b *backendBlock) openForSearch(ctx context.Context, opts common.SearchOpti
 	defer b.openMtx.Unlock()
 
 	// TODO: ctx is also cached when we cache backendReaderAt, not ideal but leaving it as is for now
-	backendReaderAt := NewBackendReaderAt(ctx, b.r, DataFileName, b.meta.BlockID, b.meta.TenantID)
+	backendReaderAt := NewBackendReaderAt(ctx, b.r, DataFileName, b.meta)
 
 	// no searches currently require bloom filters or the page index. so just add them statically
 	o := []parquet.FileOption{
@@ -90,9 +90,7 @@ func (b *backendBlock) openForSearch(ctx context.Context, opts common.SearchOpti
 	readerAt = newParquetOptimizedReaderAt(readerAt, int64(b.meta.Size), b.meta.FooterSize)
 
 	// cached reader
-	if opts.CacheControl.ColumnIndex || opts.CacheControl.Footer || opts.CacheControl.OffsetIndex {
-		readerAt = newCachedReaderAt(readerAt, backendReaderAt, opts.CacheControl)
-	}
+	readerAt = newCachedReaderAt(readerAt, backendReaderAt)
 
 	span, _ := opentracing.StartSpanFromContext(ctx, "parquet.OpenFile")
 	defer span.Finish()

--- a/tempodb/encoding/vparquet/compactor.go
+++ b/tempodb/encoding/vparquet/compactor.go
@@ -29,7 +29,7 @@ type Compactor struct {
 	opts common.CompactionOptions
 }
 
-func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader, writerCallback func(*backend.BlockMeta, time.Time) backend.Writer, inputs []*backend.BlockMeta) (newCompactedBlocks []*backend.BlockMeta, err error) {
+func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader, w backend.Writer, inputs []*backend.BlockMeta) (newCompactedBlocks []*backend.BlockMeta, err error) {
 	var (
 		compactionLevel uint8
 		totalRecords    int
@@ -152,7 +152,6 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 				CompactionLevel: nextCompactionLevel,
 				TotalObjects:    recordsPerBlock, // Just an estimate
 			}
-			w := writerCallback(newMeta, time.Now())
 
 			currentBlock = newStreamingBlock(ctx, &c.opts.BlockConfig, newMeta, r, w, tempo_io.NewBufferedWriter)
 			currentBlock.meta.CompactionLevel = nextCompactionLevel

--- a/tempodb/encoding/vparquet/compactor_test.go
+++ b/tempodb/encoding/vparquet/compactor_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/go-kit/log"
 	"github.com/google/uuid"
@@ -64,7 +63,7 @@ func benchmarkCompactor(b *testing.B, traceCount, batchCount, spanCount int) {
 			MaxBytesPerTrace: 50_000_000,
 		})
 
-		_, err = c.Compact(ctx, l, r, func(*backend.BlockMeta, time.Time) backend.Writer { return w }, inputs)
+		_, err = c.Compact(ctx, l, r, w, inputs)
 		require.NoError(b, err)
 	}
 }
@@ -102,7 +101,7 @@ func BenchmarkCompactorDupes(b *testing.B) {
 			SpansDiscarded:   func(traceID, rootSpanName string, rootServiceName string, spans int) {},
 		})
 
-		_, err = c.Compact(ctx, l, r, func(*backend.BlockMeta, time.Time) backend.Writer { return w }, inputs)
+		_, err = c.Compact(ctx, l, r, w, inputs)
 		require.NoError(b, err)
 	}
 }

--- a/tempodb/encoding/vparquet/create.go
+++ b/tempodb/encoding/vparquet/create.go
@@ -218,7 +218,7 @@ func (b *streamingBlock) Complete() (int, error) {
 
 	// Read the footer size out of the parquet footer
 	buf := make([]byte, 8)
-	err = b.r.ReadRange(b.ctx, DataFileName, b.meta.BlockID, b.meta.TenantID, b.meta.Size-8, buf, false)
+	err = b.r.ReadRange(b.ctx, DataFileName, b.meta.BlockID, b.meta.TenantID, b.meta.Size-8, buf, nil)
 	if err != nil {
 		return 0, fmt.Errorf("error reading parquet file footer: %w", err)
 	}

--- a/tempodb/encoding/vparquet/readers_test.go
+++ b/tempodb/encoding/vparquet/readers_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/local"
-	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
 var tenantID = "single-tenant"
@@ -48,7 +47,7 @@ func TestParquetGoSetsMetadataSections(t *testing.T) {
 	meta, err := r.BlockMeta(ctx, blocks[0], tenantID)
 	require.NoError(t, err)
 
-	br := NewBackendReaderAt(ctx, r, DataFileName, meta.BlockID, tenantID)
+	br := NewBackendReaderAt(ctx, r, DataFileName, meta)
 	dr := &dummyReader{r: br}
 	_, err = parquet.OpenFile(dr, int64(meta.Size))
 	require.NoError(t, err)
@@ -104,10 +103,10 @@ func TestCachingReaderAt(t *testing.T) {
 	meta, err := r.BlockMeta(ctx, blocks[0], tenantID)
 	require.NoError(t, err)
 
-	br := NewBackendReaderAt(ctx, r, DataFileName, meta.BlockID, tenantID)
+	br := NewBackendReaderAt(ctx, r, DataFileName, meta)
 	rr := &recordingReaderAt{}
 
-	cr := newCachedReaderAt(rr, br, common.CacheControl{Footer: true, ColumnIndex: true, OffsetIndex: true})
+	cr := newCachedReaderAt(rr, br)
 
 	// cached items should not hit rr
 	cr.SetColumnIndexSection(1, 34)

--- a/tempodb/encoding/vparquet2/block_iterator.go
+++ b/tempodb/encoding/vparquet2/block_iterator.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (b *backendBlock) open(ctx context.Context) (*parquet.File, *parquet.Reader, error) { //nolint:all //deprecated
-	rr := NewBackendReaderAt(ctx, b.r, DataFileName, b.meta.BlockID, b.meta.TenantID)
+	rr := NewBackendReaderAt(ctx, b.r, DataFileName, b.meta)
 
 	// 128 MB memory buffering
 	br := tempo_io.NewBufferedReaderAt(rr, int64(b.meta.Size), 2*1024*1024, 64)

--- a/tempodb/encoding/vparquet2/block_search.go
+++ b/tempodb/encoding/vparquet2/block_search.go
@@ -63,7 +63,7 @@ func (b *backendBlock) openForSearch(ctx context.Context, opts common.SearchOpti
 	defer b.openMtx.Unlock()
 
 	// TODO: ctx is also cached when we cache backendReaderAt, not ideal but leaving it as is for now
-	backendReaderAt := NewBackendReaderAt(ctx, b.r, DataFileName, b.meta.BlockID, b.meta.TenantID)
+	backendReaderAt := NewBackendReaderAt(ctx, b.r, DataFileName, b.meta)
 
 	// no searches currently require bloom filters or the page index. so just add them statically
 	o := []parquet.FileOption{
@@ -90,9 +90,7 @@ func (b *backendBlock) openForSearch(ctx context.Context, opts common.SearchOpti
 	readerAt = newParquetOptimizedReaderAt(readerAt, int64(b.meta.Size), b.meta.FooterSize)
 
 	// cached reader
-	if opts.CacheControl.ColumnIndex || opts.CacheControl.Footer || opts.CacheControl.OffsetIndex {
-		readerAt = newCachedReaderAt(readerAt, backendReaderAt, opts.CacheControl)
-	}
+	readerAt = newCachedReaderAt(readerAt, backendReaderAt)
 
 	span, _ := opentracing.StartSpanFromContext(ctx, "parquet.OpenFile")
 	defer span.Finish()

--- a/tempodb/encoding/vparquet2/compactor.go
+++ b/tempodb/encoding/vparquet2/compactor.go
@@ -29,7 +29,7 @@ type Compactor struct {
 	opts common.CompactionOptions
 }
 
-func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader, writerCallback func(*backend.BlockMeta, time.Time) backend.Writer, inputs []*backend.BlockMeta) (newCompactedBlocks []*backend.BlockMeta, err error) {
+func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader, w backend.Writer, inputs []*backend.BlockMeta) (newCompactedBlocks []*backend.BlockMeta, err error) {
 	var (
 		compactionLevel uint8
 		totalRecords    int
@@ -152,7 +152,6 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 				CompactionLevel: nextCompactionLevel,
 				TotalObjects:    recordsPerBlock, // Just an estimate
 			}
-			w := writerCallback(newMeta, time.Now())
 
 			currentBlock = newStreamingBlock(ctx, &c.opts.BlockConfig, newMeta, r, w, tempo_io.NewBufferedWriter)
 			currentBlock.meta.CompactionLevel = nextCompactionLevel

--- a/tempodb/encoding/vparquet2/compactor_test.go
+++ b/tempodb/encoding/vparquet2/compactor_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/go-kit/log"
 	"github.com/google/uuid"
@@ -64,7 +63,7 @@ func benchmarkCompactor(b *testing.B, traceCount, batchCount, spanCount int) {
 			MaxBytesPerTrace: 50_000_000,
 		})
 
-		_, err = c.Compact(ctx, l, r, func(*backend.BlockMeta, time.Time) backend.Writer { return w }, inputs)
+		_, err = c.Compact(ctx, l, r, w, inputs)
 		require.NoError(b, err)
 	}
 }
@@ -102,7 +101,7 @@ func BenchmarkCompactorDupes(b *testing.B) {
 			SpansDiscarded:   func(traceID, rootSpanName string, rootServiceName string, spans int) {},
 		})
 
-		_, err = c.Compact(ctx, l, r, func(*backend.BlockMeta, time.Time) backend.Writer { return w }, inputs)
+		_, err = c.Compact(ctx, l, r, w, inputs)
 		require.NoError(b, err)
 	}
 }

--- a/tempodb/encoding/vparquet2/copy.go
+++ b/tempodb/encoding/vparquet2/copy.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/grafana/tempo/pkg/cache"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
@@ -22,13 +23,15 @@ func CopyBlock(ctx context.Context, fromMeta, toMeta *backend.BlockMeta, from ba
 	}
 
 	// Read entire object and attempt to cache
-	cpy := func(name string) error {
-		b, err := from.Read(ctx, name, fromMeta.BlockID, fromMeta.TenantID, true)
+	cpy := func(name string, cacheInfo *backend.CacheInfo) error {
+		cacheInfo.Meta = fromMeta
+		b, err := from.Read(ctx, name, fromMeta.BlockID, fromMeta.TenantID, cacheInfo)
 		if err != nil {
 			return fmt.Errorf("error reading %s: %w", name, err)
 		}
 
-		return to.Write(ctx, name, toMeta.BlockID, toMeta.TenantID, b, true)
+		cacheInfo.Meta = toMeta
+		return to.Write(ctx, name, toMeta.BlockID, toMeta.TenantID, b, cacheInfo)
 	}
 
 	// Data
@@ -39,14 +42,14 @@ func CopyBlock(ctx context.Context, fromMeta, toMeta *backend.BlockMeta, from ba
 
 	// Bloom
 	for i := 0; i < common.ValidateShardCount(int(fromMeta.BloomShardCount)); i++ {
-		err = cpy(common.BloomName(i))
+		err = cpy(common.BloomName(i), &backend.CacheInfo{Role: cache.RoleBloom})
 		if err != nil {
 			return err
 		}
 	}
 
 	// Index (may not exist)
-	err = cpy(common.NameIndex)
+	err = cpy(common.NameIndex, &backend.CacheInfo{Role: cache.RoleTraceIDIdx})
 	if err != nil && !errors.Is(err, backend.ErrDoesNotExist) {
 		return err
 	}
@@ -62,9 +65,14 @@ func writeBlockMeta(ctx context.Context, w backend.Writer, meta *backend.BlockMe
 	if err != nil {
 		return err
 	}
+
+	cacheInfo := &backend.CacheInfo{
+		Meta: meta,
+		Role: cache.RoleBloom,
+	}
 	for i, bloom := range blooms {
 		nameBloom := common.BloomName(i)
-		err := w.Write(ctx, nameBloom, meta.BlockID, meta.TenantID, bloom, true)
+		err := w.Write(ctx, nameBloom, meta.BlockID, meta.TenantID, bloom, cacheInfo)
 		if err != nil {
 			return fmt.Errorf("unexpected error writing bloom-%d: %w", i, err)
 		}
@@ -75,7 +83,10 @@ func writeBlockMeta(ctx context.Context, w backend.Writer, meta *backend.BlockMe
 	if err != nil {
 		return err
 	}
-	err = w.Write(ctx, common.NameIndex, meta.BlockID, meta.TenantID, i, true)
+	err = w.Write(ctx, common.NameIndex, meta.BlockID, meta.TenantID, i, &backend.CacheInfo{
+		Meta: meta,
+		Role: cache.RoleTraceIDIdx,
+	})
 	if err != nil {
 		return err
 	}

--- a/tempodb/encoding/vparquet2/create.go
+++ b/tempodb/encoding/vparquet2/create.go
@@ -224,7 +224,7 @@ func (b *streamingBlock) Complete() (int, error) {
 
 	// Read the footer size out of the parquet footer
 	buf := make([]byte, 8)
-	err = b.r.ReadRange(b.ctx, DataFileName, b.meta.BlockID, b.meta.TenantID, b.meta.Size-8, buf, false)
+	err = b.r.ReadRange(b.ctx, DataFileName, b.meta.BlockID, b.meta.TenantID, b.meta.Size-8, buf, nil)
 	if err != nil {
 		return 0, fmt.Errorf("error reading parquet file footer: %w", err)
 	}

--- a/tempodb/encoding/vparquet2/readers_test.go
+++ b/tempodb/encoding/vparquet2/readers_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/local"
-	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
 var tenantID = "single-tenant"
@@ -48,7 +47,7 @@ func TestParquetGoSetsMetadataSections(t *testing.T) {
 	meta, err := r.BlockMeta(ctx, blocks[0], tenantID)
 	require.NoError(t, err)
 
-	br := NewBackendReaderAt(ctx, r, DataFileName, meta.BlockID, tenantID)
+	br := NewBackendReaderAt(ctx, r, DataFileName, meta)
 	dr := &dummyReader{r: br}
 	_, err = parquet.OpenFile(dr, int64(meta.Size))
 	require.NoError(t, err)
@@ -104,10 +103,10 @@ func TestCachingReaderAt(t *testing.T) {
 	meta, err := r.BlockMeta(ctx, blocks[0], tenantID)
 	require.NoError(t, err)
 
-	br := NewBackendReaderAt(ctx, r, DataFileName, meta.BlockID, tenantID)
+	br := NewBackendReaderAt(ctx, r, DataFileName, meta)
 	rr := &recordingReaderAt{}
 
-	cr := newCachedReaderAt(rr, br, common.CacheControl{Footer: true, ColumnIndex: true, OffsetIndex: true})
+	cr := newCachedReaderAt(rr, br)
 
 	// cached items should not hit rr
 	cr.SetColumnIndexSection(1, 34)

--- a/tempodb/encoding/vparquet3/block_iterator.go
+++ b/tempodb/encoding/vparquet3/block_iterator.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (b *backendBlock) open(ctx context.Context) (*parquet.File, *parquet.Reader, error) { //nolint:all //deprecated
-	rr := NewBackendReaderAt(ctx, b.r, DataFileName, b.meta.BlockID, b.meta.TenantID)
+	rr := NewBackendReaderAt(ctx, b.r, DataFileName, b.meta)
 
 	// 128 MB memory buffering
 	br := tempo_io.NewBufferedReaderAt(rr, int64(b.meta.Size), 2*1024*1024, 64)

--- a/tempodb/encoding/vparquet3/block_search.go
+++ b/tempodb/encoding/vparquet3/block_search.go
@@ -64,7 +64,7 @@ func (b *backendBlock) openForSearch(ctx context.Context, opts common.SearchOpti
 	defer b.openMtx.Unlock()
 
 	// TODO: ctx is also cached when we cache backendReaderAt, not ideal but leaving it as is for now
-	backendReaderAt := NewBackendReaderAt(ctx, b.r, DataFileName, b.meta.BlockID, b.meta.TenantID)
+	backendReaderAt := NewBackendReaderAt(ctx, b.r, DataFileName, b.meta)
 
 	// no searches currently require bloom filters or the page index. so just add them statically
 	o := []parquet.FileOption{
@@ -91,9 +91,7 @@ func (b *backendBlock) openForSearch(ctx context.Context, opts common.SearchOpti
 	readerAt = newParquetOptimizedReaderAt(readerAt, int64(b.meta.Size), b.meta.FooterSize)
 
 	// cached reader
-	if opts.CacheControl.ColumnIndex || opts.CacheControl.Footer || opts.CacheControl.OffsetIndex {
-		readerAt = newCachedReaderAt(readerAt, backendReaderAt, opts.CacheControl)
-	}
+	readerAt = newCachedReaderAt(readerAt, backendReaderAt)
 
 	span, _ := opentracing.StartSpanFromContext(ctx, "parquet.OpenFile")
 	defer span.Finish()

--- a/tempodb/encoding/vparquet3/compactor.go
+++ b/tempodb/encoding/vparquet3/compactor.go
@@ -29,7 +29,7 @@ type Compactor struct {
 	opts common.CompactionOptions
 }
 
-func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader, writerCallback func(*backend.BlockMeta, time.Time) backend.Writer, inputs []*backend.BlockMeta) (newCompactedBlocks []*backend.BlockMeta, err error) {
+func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader, w backend.Writer, inputs []*backend.BlockMeta) (newCompactedBlocks []*backend.BlockMeta, err error) {
 	var (
 		compactionLevel uint8
 		totalRecords    int
@@ -156,7 +156,6 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 				TotalObjects:     recordsPerBlock, // Just an estimate
 				DedicatedColumns: inputs[0].DedicatedColumns,
 			}
-			w := writerCallback(newMeta, time.Now())
 
 			currentBlock = newStreamingBlock(ctx, &c.opts.BlockConfig, newMeta, r, w, tempo_io.NewBufferedWriter)
 			currentBlock.meta.CompactionLevel = nextCompactionLevel

--- a/tempodb/encoding/vparquet3/compactor_test.go
+++ b/tempodb/encoding/vparquet3/compactor_test.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/go-kit/log"
 	"github.com/google/uuid"
@@ -64,7 +63,7 @@ func benchmarkCompactor(b *testing.B, traceCount, batchCount, spanCount int) {
 			MaxBytesPerTrace: 50_000_000,
 		})
 
-		_, err = c.Compact(ctx, l, r, func(*backend.BlockMeta, time.Time) backend.Writer { return w }, inputs)
+		_, err = c.Compact(ctx, l, r, w, inputs)
 		require.NoError(b, err)
 	}
 }
@@ -102,7 +101,7 @@ func BenchmarkCompactorDupes(b *testing.B) {
 			SpansDiscarded:   func(traceID, rootSpanName string, rootServiceName string, spans int) {},
 		})
 
-		_, err = c.Compact(ctx, l, r, func(*backend.BlockMeta, time.Time) backend.Writer { return w }, inputs)
+		_, err = c.Compact(ctx, l, r, w, inputs)
 		require.NoError(b, err)
 	}
 }
@@ -207,7 +206,7 @@ func TestCompact(t *testing.T) {
 
 	inputs := []*backend.BlockMeta{meta1, meta2}
 
-	newMeta, err := c.Compact(context.Background(), log.NewNopLogger(), r, func(*backend.BlockMeta, time.Time) backend.Writer { return w }, inputs)
+	newMeta, err := c.Compact(context.Background(), log.NewNopLogger(), r, w, inputs)
 	require.NoError(t, err)
 	require.Len(t, newMeta, 1)
 	require.Equal(t, 20, newMeta[0].TotalObjects)

--- a/tempodb/encoding/vparquet3/create.go
+++ b/tempodb/encoding/vparquet3/create.go
@@ -224,7 +224,7 @@ func (b *streamingBlock) Complete() (int, error) {
 
 	// Read the footer size out of the parquet footer
 	buf := make([]byte, 8)
-	err = b.r.ReadRange(b.ctx, DataFileName, b.meta.BlockID, b.meta.TenantID, b.meta.Size-8, buf, false)
+	err = b.r.ReadRange(b.ctx, DataFileName, b.meta.BlockID, b.meta.TenantID, b.meta.Size-8, buf, nil)
 	if err != nil {
 		return 0, fmt.Errorf("error reading parquet file footer: %w", err)
 	}

--- a/tempodb/encoding/vparquet3/readers_test.go
+++ b/tempodb/encoding/vparquet3/readers_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/local"
-	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
 var tenantID = "single-tenant"
@@ -48,7 +47,7 @@ func TestParquetGoSetsMetadataSections(t *testing.T) {
 	meta, err := r.BlockMeta(ctx, blocks[0], tenantID)
 	require.NoError(t, err)
 
-	br := NewBackendReaderAt(ctx, r, DataFileName, meta.BlockID, tenantID)
+	br := NewBackendReaderAt(ctx, r, DataFileName, meta)
 	dr := &dummyReader{r: br}
 	_, err = parquet.OpenFile(dr, int64(meta.Size))
 	require.NoError(t, err)
@@ -104,10 +103,10 @@ func TestCachingReaderAt(t *testing.T) {
 	meta, err := r.BlockMeta(ctx, blocks[0], tenantID)
 	require.NoError(t, err)
 
-	br := NewBackendReaderAt(ctx, r, DataFileName, meta.BlockID, tenantID)
+	br := NewBackendReaderAt(ctx, r, DataFileName, meta)
 	rr := &recordingReaderAt{}
 
-	cr := newCachedReaderAt(rr, br, common.CacheControl{Footer: true, ColumnIndex: true, OffsetIndex: true})
+	cr := newCachedReaderAt(rr, br)
 
 	// cached items should not hit rr
 	cr.SetColumnIndexSection(1, 34)

--- a/tempodb/retention_test.go
+++ b/tempodb/retention_test.go
@@ -39,7 +39,7 @@ func TestRetention(t *testing.T) {
 			Filepath: path.Join(tempDir, "wal"),
 		},
 		BlocklistPoll: 0,
-	}, log.NewNopLogger())
+	}, nil, log.NewNopLogger())
 	assert.NoError(t, err)
 
 	ctx := context.Background()
@@ -102,7 +102,7 @@ func TestRetentionUpdatesBlocklistImmediately(t *testing.T) {
 			Filepath: path.Join(tempDir, "wal"),
 		},
 		BlocklistPoll: 0,
-	}, log.NewNopLogger())
+	}, nil, log.NewNopLogger())
 	assert.NoError(t, err)
 
 	ctx := context.Background()
@@ -171,7 +171,7 @@ func TestBlockRetentionOverride(t *testing.T) {
 			Filepath: path.Join(tempDir, "wal"),
 		},
 		BlocklistPoll: 0,
-	}, log.NewNopLogger())
+	}, nil, log.NewNopLogger())
 	require.NoError(t, err)
 
 	overrides := &mockOverrides{}

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -1021,7 +1021,7 @@ func runCompleteBlockSearchTest(t *testing.T, blockVersion string, runners ...ru
 			ReadBufferCount: 8, ReadBufferSizeBytes: 4 * 1024 * 1024,
 		},
 		BlocklistPoll: 0,
-	}, log.NewNopLogger())
+	}, nil, log.NewNopLogger())
 	require.NoError(t, err)
 
 	err = c.EnableCompaction(context.Background(), &CompactorConfig{
@@ -1451,7 +1451,7 @@ func TestWALBlockGetMetrics(t *testing.T) {
 			ReadBufferCount: 8, ReadBufferSizeBytes: 4 * 1024 * 1024,
 		},
 		BlocklistPoll: 0,
-	}, log.NewNopLogger())
+	}, nil, log.NewNopLogger())
 	require.NoError(t, err)
 
 	err = c.EnableCompaction(context.Background(), &CompactorConfig{

--- a/tempodb/tempodb_test.go
+++ b/tempodb/tempodb_test.go
@@ -2,6 +2,7 @@ package tempodb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -12,9 +13,13 @@ import (
 	"github.com/go-kit/log"
 	"github.com/golang/protobuf/proto" //nolint:all
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/tempo/modules/cache/memcached"
+	"github.com/grafana/tempo/modules/cache/redis"
+	"github.com/grafana/tempo/pkg/cache"
 	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempopb"
@@ -59,7 +64,7 @@ func testConfig(t *testing.T, enc backend.Encoding, blocklistPoll time.Duration,
 		opt(cfg)
 	}
 
-	r, w, c, err := New(cfg, log.NewNopLogger())
+	r, w, c, err := New(cfg, nil, log.NewNopLogger())
 	require.NoError(t, err)
 	return r, w, c, tempDir
 }
@@ -668,7 +673,7 @@ func testCompleteBlockHonorsStartStopTimes(t *testing.T, targetBlockVersion stri
 			Filepath:       path.Join(tempDir, "wal"),
 		},
 		BlocklistPoll: 0,
-	}, log.NewNopLogger())
+	}, nil, log.NewNopLogger())
 	require.NoError(t, err)
 
 	dec := model.MustNewSegmentDecoder(model.CurrentEncoding)
@@ -694,72 +699,6 @@ func testCompleteBlockHonorsStartStopTimes(t *testing.T, targetBlockVersion stri
 	// Verify the block time was constrained to the slack time.
 	require.Equal(t, now.Unix(), complete.BlockMeta().StartTime.Unix())
 	require.Equal(t, now.Unix(), complete.BlockMeta().EndTime.Unix())
-}
-
-func TestShouldCache(t *testing.T) {
-	tempDir := t.TempDir()
-
-	r, _, _, err := New(&Config{
-		Backend: backend.Local,
-		Local: &local.Config{
-			Path: path.Join(tempDir, "traces"),
-		},
-		Block: &common.BlockConfig{
-			IndexDownsampleBytes: 17,
-			BloomFP:              .01,
-			BloomShardSizeBytes:  100_000,
-			Version:              encoding.DefaultEncoding().Version(),
-			Encoding:             backend.EncLZ4_256k,
-			IndexPageSizeBytes:   1000,
-		},
-		WAL: &wal.Config{
-			Filepath: path.Join(tempDir, "wal"),
-		},
-		BlocklistPoll:           0,
-		CacheMaxBlockAge:        time.Hour,
-		CacheMinCompactionLevel: 1,
-	}, log.NewNopLogger())
-	require.NoError(t, err)
-
-	rw := r.(*readerWriter)
-
-	testCases := []struct {
-		name            string
-		compactionLevel uint8
-		startTime       time.Time
-		cache           bool
-	}{
-		{
-			name:            "both pass",
-			compactionLevel: 1,
-			startTime:       time.Now(),
-			cache:           true,
-		},
-		{
-			name:            "startTime fail",
-			compactionLevel: 2,
-			startTime:       time.Now().Add(-2 * time.Hour),
-			cache:           false,
-		},
-		{
-			name:            "compactionLevel fail",
-			compactionLevel: 0,
-			startTime:       time.Now(),
-			cache:           false,
-		},
-		{
-			name:            "both fail",
-			compactionLevel: 0,
-			startTime:       time.Now(),
-			cache:           false,
-		},
-	}
-
-	for _, tt := range testCases {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.cache, rw.shouldCache(&backend.BlockMeta{CompactionLevel: tt.compactionLevel, StartTime: tt.startTime}, time.Now()))
-		})
-	}
 }
 
 func writeTraceToWal(t require.TestingT, b common.WALBlock, dec model.SegmentDecoder, id common.ID, tr *tempopb.Trace, start, end uint32) {
@@ -806,7 +745,7 @@ func benchmarkCompleteBlock(b *testing.B, e encoding.VersionedEncoding) {
 			Filepath:       path.Join(tempDir, "wal"),
 		},
 		BlocklistPoll: 0,
-	}, log.NewNopLogger())
+	}, nil, log.NewNopLogger())
 	require.NoError(b, err)
 
 	dec := model.MustNewSegmentDecoder(model.CurrentEncoding)
@@ -834,4 +773,83 @@ func benchmarkCompleteBlock(b *testing.B, e encoding.VersionedEncoding) {
 		_, err := w.CompleteBlock(context.Background(), blk)
 		require.NoError(b, err)
 	}
+}
+
+func TestCreateLegacyCache(t *testing.T) {
+	tcs := []struct {
+		name          string
+		cfg           *Config
+		expectedErr   error
+		expectedRoles []cache.Role
+		expectedCache bool
+	}{
+		{
+			name: "no caches",
+			cfg:  &Config{},
+		},
+		{
+			name: "redis",
+			cfg: &Config{
+				Cache:           "redis",
+				Redis:           &redis.Config{},
+				BackgroundCache: &cache.BackgroundConfig{},
+			},
+			expectedRoles: []cache.Role{cache.RoleBloom, cache.RoleTraceIDIdx},
+			expectedCache: true,
+		},
+		{
+			name: "memcached",
+			cfg: &Config{
+				Cache:           "memcached",
+				Memcached:       &memcached.Config{},
+				BackgroundCache: &cache.BackgroundConfig{},
+			},
+			expectedRoles: []cache.Role{cache.RoleBloom, cache.RoleTraceIDIdx},
+			expectedCache: true,
+		},
+		{
+			name: "no cache but cache control",
+			cfg: &Config{
+				Search: &SearchConfig{
+					CacheControl: CacheControlConfig{
+						Footer: true,
+					},
+				},
+			},
+			expectedErr: errors.New("no legacy cache configured, but cache_control is enabled. Please use the new top level cache configuration."),
+		},
+		{
+			name: "memcached + cache control",
+			cfg: &Config{
+				Cache:           "memcached",
+				Memcached:       &memcached.Config{},
+				BackgroundCache: &cache.BackgroundConfig{},
+				Search: &SearchConfig{
+					CacheControl: CacheControlConfig{
+						Footer:      true,
+						ColumnIndex: true,
+						OffsetIndex: true,
+					},
+				},
+			},
+			expectedRoles: []cache.Role{cache.RoleBloom, cache.RoleTraceIDIdx, cache.RoleParquetColumnIdx, cache.RoleParquetFooter, cache.RoleParquetOffsetIdx},
+			expectedCache: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			prometheus.DefaultRegisterer = prometheus.NewRegistry() // prevent duplicate registration
+
+			cache, actualRoles, actualErr := createLegacyCache(tc.cfg, log.NewNopLogger())
+			require.Equal(t, tc.expectedErr, actualErr)
+			require.Equal(t, tc.expectedRoles, actualRoles)
+			if tc.expectedCache {
+				require.NotNil(t, cache)
+			} else {
+				require.Nil(t, cache)
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
**What this PR does**:
This PR refactors caches to allow for multiple independent caches that can be assigned to various roles. It lays the ground work for adding additional caches for things like parquet pages or frontend search jobs. This PR is completely backwards compatible, but does deprecate all the existing cache configuration fields in the `store:` config block.

- Replaces "shouldCache" on the backend calls with a "cacheInfo" struct that allows the cache layer to make its own decisions.
- Create a new top level "cacheProvider" module and config block (see below for an example). Different components can now request caches that fulfill different roles from the provider.
- Came with some nice cleanup that helped validate the refactor.
  - removing `writerCallback func(*backend.BlockMeta, time.Time)` from compaction
  - removing CacheControl from SearchOptions
  - deprecating CacheControl and replacing it with the idea of roles
  
**Open Questions**
- `cache_min_compaction_level` and `cache_max_block_age` were the only caching settings that were left alone. These are policy settings and I decided to leave them under `storage.trace` in the config block. Should we leave "policy" style settings in the normal config blocks? and only put caching settings in the cache provider? This is the approach I preferred but I thought it was worth discussing.

- Roles are currently configured as a yaml list, but I'm tempted to make them a pipe delimited list of roles. I think it would read better, but seems strange when yaml supports lists directly.

**New example config**
```yaml
cache:
  background_cache:
    writeback_goroutines: 5
  caches:
  - roles:
    - parquet-footer
    - parquet-column-idx
    - parquet-offset-idx
    memcached:
      host: memcached-instance
  - roles:
    - bloom
    redis:
      endpoint: redis-instance
```

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`