### PR TITLE
Fix Exit code for -config.verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## main / unreleased
 
-+ [BUGFIX] Change exit code if config is successfully verified (...) (@am3o @agrib-01)
++ [BUGFIX] Change exit code if config is successfully verified [#3174](https://github.com/grafana/tempo/pull/3174) (@am3o @agrib-01)
 * [ENHANCEMENT] Introduced `AttributePolicyMatch` & `IntrinsicPolicyMatch` structures to match span attributes based on strongly typed values & precompiled regexp [#3025](https://github.com/grafana/tempo/pull/3025) (@andriusluk)
 * [CHANGE] TraceQL/Structural operators performance improvement. [#3088](https://github.com/grafana/tempo/pull/3088) (@joe-elliott)
 * [CHANGE] Merge the processors overrides set through runtime overrides and user-configurable overrides [#3125](https://github.com/grafana/tempo/pull/3125) (@kvrhdn)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
++ [BUGFIX] Change exit code if config is successfully verified (...) (@am3o @agrib-01)
 * [ENHANCEMENT] Introduced `AttributePolicyMatch` & `IntrinsicPolicyMatch` structures to match span attributes based on strongly typed values & precompiled regexp [#3025](https://github.com/grafana/tempo/pull/3025) (@andriusluk)
 * [CHANGE] TraceQL/Structural operators performance improvement. [#3088](https://github.com/grafana/tempo/pull/3088) (@joe-elliott)
 * [CHANGE] Merge the processors overrides set through runtime overrides and user-configurable overrides [#3125](https://github.com/grafana/tempo/pull/3125) (@kvrhdn)

--- a/cmd/tempo/main.go
+++ b/cmd/tempo/main.go
@@ -82,7 +82,7 @@ func main() {
 
 	// Exit if config.verify flag is true
 	if configVerify {
-		if isValid {
+		if !isValid {
 			os.Exit(1)
 		}
 		os.Exit(0)


### PR DESCRIPTION
**What this PR does**:
This PR corrects the exit status behavior in Tempo. Now, when -config.verify=true is used and the configuration is valid, the application will exit with status 0.

**Which issue(s) this PR fixes**:
Fixes #3172

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`