### PR TITLE
[DOC] Add 2.3.1 releaes notes

### DIFF
--- a/docs/sources/tempo/_index.md
+++ b/docs/sources/tempo/_index.md
@@ -13,6 +13,8 @@ cascade:
 
 Grafana Tempo is an open source, easy-to-use, and high-volume distributed tracing backend. Tempo is cost-efficient, and only requires an object storage to operate. Tempo is deeply integrated with Grafana, Mimir, Prometheus, and Loki. You can use Tempo with open-source tracing protocols, including Jaeger, Zipkin, or OpenTelemetry.
 
+Tempo implements [TraceQL](/docs/tempo/latest/traceql), a traces-first query language inspired by LogQL and PromQL. This query language allows users to very precisely and easily select spans and jump directly to the spans fulfilling the specified conditions.
+
 Tempo integrates well with a number of existing open source tools:
 
 - **Grafana** ships with native support for Tempo using the built-in [Tempo data source](/docs/grafana/latest/datasources/tempo/).

--- a/docs/sources/tempo/release-notes/v2-3.md
+++ b/docs/sources/tempo/release-notes/v2-3.md
@@ -183,6 +183,14 @@ The following vulnerabilities have been addressed:
 
 For a complete list, refer to the [Tempo changelog](https://github.com/grafana/tempo/releases).
 
+### 2.3.1
+
+* Include statusMessage intrinsic attribute in tag search. [PR 3084](https://github.com/grafana/tempo/pull/3084)
+* Fix compactor ignore configured S3 headers. [PR 3149](https://github.com/grafana/tempo/pull/3154)
+* Readd session token to s3 credentials. [PR 3144](https://github.com/grafana/tempo/pull/3144)
+
+### 2.3
+
 * Loaded defaults for the internal server [PR 3041](https://github.com/grafana/tempo/pull/3041)
 * Fixed  pass-through to runtime overrides for FilterPolicies and TargetInfoExcludedDimensions [PR 3012](https://github.com/grafana/tempo/pull/3012)
 * Fixed a panic in metrics-summary API PR [#2738](https://github.com/grafana/tempo/pull/2738)


### PR DESCRIPTION
**What this PR does**:
Add release notes for v2.3.1

Adds an opening paragraph about TraceQL to the main index page. 

@joe-elliott FYI

**Which issue(s) this PR fixes**:
Fixes: https://github.com/grafana/tempo/issues/3187

Related to: https://github.com/grafana/tempo/pull/3186
**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`