### PR TITLE
[TraceQL] SyncIterator seekWithinPage for improved performance

### DIFF
--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -753,7 +753,10 @@ func (c *SyncIterator) seekWithinPage(to RowNumber, definitionLevel int) {
 
 	// skips are calculated off the start of the page
 	rowSkip := to[0] - c.currPageMin[0]
-	if rowSkip <= 2 { // skipping 1 or 2 row causes test to fail? jpe
+	if rowSkip < 1 {
+		return
+	}
+	if rowSkip > c.currPage.NumRows() {
 		return
 	}
 
@@ -761,7 +764,7 @@ func (c *SyncIterator) seekWithinPage(to RowNumber, definitionLevel int) {
 	pg := c.currPage.Slice(rowSkip-1, c.currPage.NumRows())
 
 	// remove all detail below the row number
-	c.curr = TruncateRowNumber(1, to)
+	c.curr = TruncateRowNumber(0, to)
 	c.curr = c.curr.Preceding()
 
 	// reset buffers and other vars

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -716,7 +716,7 @@ func (c *SyncIterator) seekPages(seekTo RowNumber, definitionLevel int) (done bo
 
 func (c *SyncIterator) seekWithinPage(to RowNumber, definitionLevel int) {
 	rowSkipRelative := int(to[0] - c.curr[0])
-	magicThreshold := 50
+	magicThreshold := 1000 // jpe change this to 5 so tests fail and fix.
 	shouldSkip := false
 
 	if definitionLevel == 0 {
@@ -729,7 +729,7 @@ func (c *SyncIterator) seekWithinPage(to RowNumber, definitionLevel int) {
 		replvls := c.currPage.RepetitionLevels()
 		nextsRequired := 0
 
-		for i := c.currRepLvl + 1; i < len(replvls); i++ {
+		for i := c.currRepLvl; i < len(replvls); i++ {
 			nextsRequired++
 
 			if nextsRequired > magicThreshold {

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -586,37 +586,7 @@ func (c *SyncIterator) SeekTo(to RowNumber, definitionLevel int) (*IteratorResul
 		return nil, nil
 	}
 
-	// if c.columnName == "rs.list.element.Resource.Attrs.list.element.Key" && to[0] == 1 {
-	// 	fmt.Println("?") // this is when bad things happen
-	// } else if c.columnName == "rs.list.element.Resource.Attrs.list.element.Key" {
-	// 	fmt.Println("!")
-	// }
-
-	// only skip if to is ahead of curr
-	if CompareRowNumbers(definitionLevel, to, c.curr) > 0 {
-		// skips are calculated off the start of the page
-		rowSkip := to[0] - c.currPageMin[0]
-		if rowSkip > 1 {
-			// reslice the page to jump directly to the desired row number
-			pg := c.currPage.Slice(rowSkip-1, c.currPage.NumRows())
-			pq.Release(c.currPage) //- can i release here? i think the internal buffers are  are preserved, so no
-
-			// set curr to what it will be now that we've resliced
-			c.curr = to
-			// remove all detail below the row number
-			for i := 1; i < 5; i++ {
-				c.curr[i] = -1
-			}
-			c.curr = c.curr.Preceding()
-
-			// reset buffers and other vars
-			c.currPage = pg
-			c.currPageMin = c.curr
-			c.currValues = pg.Values()
-			syncIteratorPoolPut(c.currBuf)
-			c.currBuf = nil
-		}
-	}
+	c.seekRows(to, definitionLevel)
 
 	// The row group and page have been selected to where this value is possibly
 	// located. Now scan through the page and look for it.
@@ -743,6 +713,34 @@ func (c *SyncIterator) seekPages(seekTo RowNumber, definitionLevel int) (done bo
 	}
 
 	return false, nil
+}
+
+func (c *SyncIterator) seekRows(to RowNumber, definitionLevel int) {
+	// only skip if to is ahead of curr
+	if CompareRowNumbers(definitionLevel, to, c.curr) > 0 {
+		// skips are calculated off the start of the page
+		rowSkip := to[0] - c.currPageMin[0]
+		if rowSkip > 5 { // made up threshold worth skipping
+			// reslice the page to jump directly to the desired row number
+			pg := c.currPage.Slice(rowSkip-1, c.currPage.NumRows())
+			pq.Release(c.currPage) //- can i release here? i think the internal buffers are  are preserved, so no
+
+			// set curr to what it will be now that we've resliced
+			c.curr = to
+			// remove all detail below the row number
+			for i := 1; i < 5; i++ {
+				c.curr[i] = -1
+			}
+			c.curr = c.curr.Preceding()
+
+			// reset buffers and other vars
+			c.currPage = pg
+			c.currPageMin = c.curr
+			c.currValues = pg.Values()
+			syncIteratorPoolPut(c.currBuf)
+			c.currBuf = nil
+		}
+	}
 }
 
 // next is the core functionality of this iterator and returns the next matching result. This

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -721,9 +721,16 @@ func (c *SyncIterator) seekWithinPage(to RowNumber, definitionLevel int) {
 		return
 	}
 
+	// constantly skipping can be more expensive than just nexting
+	// this requires at least skipping 1 row to pass. something of a made up threshold
+	rowSkipRelative := to[0] - c.curr[0]
+	if rowSkipRelative <= 1 {
+		return
+	}
+
 	// skips are calculated off the start of the page
 	rowSkip := to[0] - c.currPageMin[0]
-	if rowSkip <= 5 { // made up threshold worth skipping
+	if rowSkip <= 1 {
 		return
 	}
 

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -576,6 +576,8 @@ func (c *SyncIterator) SeekTo(to RowNumber, definitionLevel int) (*IteratorResul
 		return nil, nil
 	}
 
+	// fmt.Println("seeking to", to, c.columnName)
+
 	done, err := c.seekPages(to, definitionLevel)
 	if err != nil {
 		return nil, err
@@ -584,12 +586,24 @@ func (c *SyncIterator) SeekTo(to RowNumber, definitionLevel int) (*IteratorResul
 		return nil, nil
 	}
 
+	// if c.columnName == "rs.list.element.Resource.Attrs.list.element.Key" && to[0] == 1 {
+	// 	fmt.Println("?")  // this is when bad things happen
+	// } else if c.columnName == "rs.list.element.Resource.Attrs.list.element.Key" {
+	// 	fmt.Println("!")
+	// }
+
 	// reslice the page to jump directly to the desired row number
 	row := to[0] - c.currPageMin[0]
 	if row > 1 {
-		fmt.Println(row)
+		//fmt.Println(row)
 		pg := c.currPage.Slice(row-1, c.currPage.NumRows())
-		pq.Release(c.currPage)
+		// pq.Release(c.currPage) - can i release here? i think the internal buffers are  are preserved, so no
+		to[1] = -1
+		to[2] = -1
+		to[3] = -1
+		to[4] = -1
+		to[5] = -1 // works slightly better? still fails sometimes
+
 		c.curr = to.Preceding() // we need to cut off to to a certain def lvl for safety
 		c.currPage = pg
 		c.currPageMin = c.curr // set c.currPageMin below? is it safer?

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -732,7 +732,6 @@ func (c *SyncIterator) seekWithinPage(to RowNumber, definitionLevel int) {
 
 	// reslice the page to jump directly to the desired row number
 	pg := c.currPage.Slice(rowSkip-1, c.currPage.NumRows())
-	pq.Release(c.currPage) //- can i release here? i think the internal buffers are  are preserved, so no
 
 	// remove all detail below the row number
 	c.curr = TruncateRowNumber(1, to)

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -714,17 +714,20 @@ func (c *SyncIterator) seekPages(seekTo RowNumber, definitionLevel int) (done bo
 	return false, nil
 }
 
+// seekWithinPage decides if it should reslice the current page to jump directly to the desired row number
+// or allow the iterator to call Next() until it finds the desired row number. it uses the magicThreshold
+// as its balance point. if the number of Next()s to skip is less than the magicThreshold, it will not reslice
 func (c *SyncIterator) seekWithinPage(to RowNumber, definitionLevel int) {
 	rowSkipRelative := int(to[0] - c.curr[0])
-	magicThreshold := 1000
+	const magicThreshold = 1000
 	shouldSkip := false
 
 	if definitionLevel == 0 {
-		// if definition level is 0 there is always a 1:1 ratio between nexts and rows. it's only deeper
+		// if definition level is 0 there is always a 1:1 ratio between Next()s and rows. it's only deeper
 		// levels of nesting we have to manually count
 		shouldSkip = rowSkipRelative > magicThreshold
 	} else {
-		// this is a nested iterator, let's count the nexts required to get to the desired row number
+		// this is a nested iterator, let's count the Next()s required to get to the desired row number
 		// and decide if we should skip or not
 		replvls := c.currPage.RepetitionLevels()
 		nextsRequired := 0

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -716,7 +716,7 @@ func (c *SyncIterator) seekPages(seekTo RowNumber, definitionLevel int) (done bo
 
 func (c *SyncIterator) seekWithinPage(to RowNumber, definitionLevel int) {
 	rowSkipRelative := int(to[0] - c.curr[0])
-	magicThreshold := 1000 // jpe change this to 5 so tests fail and fix.
+	magicThreshold := 1000
 	shouldSkip := false
 
 	if definitionLevel == 0 {
@@ -753,7 +753,7 @@ func (c *SyncIterator) seekWithinPage(to RowNumber, definitionLevel int) {
 
 	// skips are calculated off the start of the page
 	rowSkip := to[0] - c.currPageMin[0]
-	if rowSkip <= 1 { // sanity check. if you tried to skip from row 0 to 0 the below would panic. this should never happen
+	if rowSkip <= 2 { // skipping 1 or 2 row causes test to fail? jpe
 		return
 	}
 

--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -584,7 +584,7 @@ func BenchmarkBackendBlockTraceQL(b *testing.B) {
 
 	ctx := context.TODO()
 	tenantID := "1"
-	blockID := uuid.MustParse("000d37d0-1e66-4f4e-bbd4-f85c1deb6e5e")
+	blockID := uuid.MustParse("00000c2f-8133-4a60-a62a-7748bd146938")
 	// blockID := uuid.MustParse("06ebd383-8d4e-4289-b0e9-cf2197d611d5")
 
 	r, _, _, err := local.New(&local.Config{


### PR DESCRIPTION
**What this PR does**:
Adds a seekRows method to the sync iterator to skip rows (traces). This has nice performance improvements for queries that seek a lot and is break even for others. There was a small increase in cpu in one benchmark.

Note this line:
```
		if rowSkip > 5 { // made up threshold worth skipping
```
This threshold is impossible to tune (and very easy to overtune). The issue is that we are skipping rows at the trace level but often iterating at the span level or even deeper. A single row skip may avoid 100k nexts or 1 next and I don't think it's possible to know that at the row level, but I'd love to hear otherwise.

Another consideration is that perhaps the rowSkip threshold should be based on the definition level? The deeper the level the more likely we can avoid a large number of nexting.

I would love to see others repro these benches:

```
name                                             old time/op    new time/op    delta
BackendBlockTraceQL/spanAttValNoMatch-8            8.84ms ± 1%    8.88ms ± 1%     ~     (p=0.105 n=10+10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8      8.41ms ± 1%    8.39ms ± 0%     ~     (p=0.780 n=9+10)
BackendBlockTraceQL/resourceAttValNoMatch-8        8.23ms ± 1%    8.24ms ± 1%     ~     (p=0.247 n=10+10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8    28.6ms ± 2%    22.2ms ± 1%  -22.42%  (p=0.000 n=10+10)
BackendBlockTraceQL/mixedValNoMatch-8               259ms ± 2%     263ms ± 4%     ~     (p=0.156 n=9+10)
BackendBlockTraceQL/mixedValMixedMatchAnd-8        8.30ms ± 1%    8.33ms ± 2%     ~     (p=0.393 n=10+10)
BackendBlockTraceQL/mixedValMixedMatchOr-8          274ms ± 3%     273ms ± 4%     ~     (p=0.853 n=10+10)
BackendBlockTraceQL/count-8                         470ms ± 3%     484ms ± 8%   +3.07%  (p=0.028 n=10+9)
BackendBlockTraceQL/struct-8                        781ms ± 4%     767ms ± 3%     ~     (p=0.052 n=10+10)
BackendBlockTraceQL/||-8                            182ms ± 2%     166ms ± 1%   -8.85%  (p=0.000 n=10+10)
BackendBlockTraceQL/mixed-8                        40.5ms ± 1%    28.7ms ± 1%  -29.00%  (p=0.000 n=9+10)

name                                             old speed      new speed      delta
BackendBlockTraceQL/spanAttValNoMatch-8           184MB/s ± 1%   183MB/s ± 1%     ~     (p=0.109 n=10+10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8     223MB/s ± 1%   223MB/s ± 0%     ~     (p=0.705 n=9+10)
BackendBlockTraceQL/resourceAttValNoMatch-8       101MB/s ± 1%   101MB/s ± 1%     ~     (p=0.288 n=10+10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8   514MB/s ± 2%   663MB/s ± 1%  +28.90%  (p=0.000 n=10+10)
BackendBlockTraceQL/mixedValNoMatch-8            7.22MB/s ± 2%  7.12MB/s ± 3%     ~     (p=0.149 n=9+10)
BackendBlockTraceQL/mixedValMixedMatchAnd-8       101MB/s ± 1%   101MB/s ± 2%     ~     (p=0.393 n=10+10)
BackendBlockTraceQL/mixedValMixedMatchOr-8       58.0MB/s ± 3%  58.3MB/s ± 4%     ~     (p=0.853 n=10+10)
BackendBlockTraceQL/count-8                      33.7MB/s ± 3%  32.8MB/s ± 8%   -2.91%  (p=0.023 n=10+9)
BackendBlockTraceQL/struct-8                     5.61MB/s ± 4%  5.71MB/s ± 3%   +1.82%  (p=0.045 n=10+10)
BackendBlockTraceQL/||-8                         88.9MB/s ± 2%  97.6MB/s ± 1%   +9.71%  (p=0.000 n=10+10)
BackendBlockTraceQL/mixed-8                       361MB/s ± 1%   509MB/s ± 1%  +40.85%  (p=0.000 n=9+10)

name                                             old MB_io/op   new MB_io/op   delta
BackendBlockTraceQL/spanAttValNoMatch-8              1.63 ± 0%      1.63 ± 0%     ~     (all equal)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8        1.88 ± 0%      1.88 ± 0%     ~     (all equal)
BackendBlockTraceQL/resourceAttValNoMatch-8          0.83 ± 0%      0.83 ± 0%     ~     (all equal)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8      14.7 ± 0%      14.7 ± 0%     ~     (all equal)
BackendBlockTraceQL/mixedValNoMatch-8                1.87 ± 0%      1.87 ± 0%     ~     (all equal)
BackendBlockTraceQL/mixedValMixedMatchAnd-8          0.84 ± 0%      0.84 ± 0%     ~     (all equal)
BackendBlockTraceQL/mixedValMixedMatchOr-8           15.9 ± 0%      15.9 ± 0%     ~     (all equal)
BackendBlockTraceQL/count-8                          15.8 ± 0%      15.8 ± 0%     ~     (all equal)
BackendBlockTraceQL/struct-8                         4.38 ± 0%      4.38 ± 0%     ~     (all equal)
BackendBlockTraceQL/||-8                             16.2 ± 0%      16.2 ± 0%     ~     (all equal)
BackendBlockTraceQL/mixed-8                          14.6 ± 0%      14.6 ± 0%     ~     (all equal)

name                                             old alloc/op   new alloc/op   delta
BackendBlockTraceQL/spanAttValNoMatch-8            5.03MB ± 2%    5.07MB ± 2%     ~     (p=0.218 n=10+10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8      4.49MB ± 2%    4.46MB ± 2%     ~     (p=0.247 n=10+10)
BackendBlockTraceQL/resourceAttValNoMatch-8        4.43MB ± 2%    4.43MB ± 2%     ~     (p=0.912 n=10+10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8    5.56MB ± 4%    5.42MB ± 4%     ~     (p=0.123 n=10+10)
BackendBlockTraceQL/mixedValNoMatch-8              5.72MB ±28%    5.96MB ±29%     ~     (p=0.305 n=10+10)
BackendBlockTraceQL/mixedValMixedMatchAnd-8        4.39MB ± 2%    4.41MB ± 1%     ~     (p=0.315 n=10+10)
BackendBlockTraceQL/mixedValMixedMatchOr-8         5.16MB ±46%    5.60MB ±36%   +8.50%  (p=0.022 n=10+10)
BackendBlockTraceQL/count-8                         281MB ± 3%     287MB ± 3%   +2.05%  (p=0.022 n=10+9)
BackendBlockTraceQL/struct-8                       58.2MB ± 5%    58.5MB ± 5%     ~     (p=0.739 n=10+10)
BackendBlockTraceQL/||-8                           83.9MB ± 1%    84.5MB ± 1%   +0.69%  (p=0.043 n=9+10)
BackendBlockTraceQL/mixed-8                        5.18MB ±16%    5.22MB ± 8%     ~     (p=0.739 n=10+10)

name                                             old allocs/op  new allocs/op  delta
BackendBlockTraceQL/spanAttValNoMatch-8             64.1k ± 0%     64.1k ± 0%     ~     (p=0.248 n=10+9)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-8       64.0k ± 0%     64.0k ± 0%     ~     (p=0.573 n=10+10)
BackendBlockTraceQL/resourceAttValNoMatch-8         64.0k ± 0%     64.0k ± 0%     ~     (p=0.984 n=10+10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-8     67.7k ± 0%     67.9k ± 0%   +0.39%  (p=0.000 n=10+10)
BackendBlockTraceQL/mixedValNoMatch-8               65.7k ± 0%     65.7k ± 0%     ~     (p=0.540 n=10+10)
BackendBlockTraceQL/mixedValMixedMatchAnd-8         64.0k ± 0%     64.1k ± 0%     ~     (p=0.155 n=10+10)
BackendBlockTraceQL/mixedValMixedMatchOr-8          65.6k ± 0%     65.7k ± 0%   +0.15%  (p=0.000 n=10+10)
BackendBlockTraceQL/count-8                         1.29M ± 0%     1.31M ± 0%   +1.01%  (p=0.000 n=10+10)
BackendBlockTraceQL/struct-8                         211k ± 1%      211k ± 1%     ~     (p=0.382 n=10+10)
BackendBlockTraceQL/||-8                             447k ± 0%      463k ± 0%   +3.61%  (p=0.000 n=9+10)
BackendBlockTraceQL/mixed-8                         65.5k ± 0%     66.1k ± 0%   +0.87%  (p=0.000 n=9+10)
```