### PR TITLE
[Docs] s3:ListObjects does not exist

### DIFF
--- a/docs/sources/tempo/configuration/s3.md
+++ b/docs/sources/tempo/configuration/s3.md
@@ -29,7 +29,6 @@ The following IAM policy shows minimal permissions required by Tempo, where the 
                 "s3:PutObject",
                 "s3:GetObject",
                 "s3:ListBucket",
-                "s3:ListObjects",
                 "s3:DeleteObject",
                 "s3:GetObjectTagging",
                 "s3:PutObjectTagging"


### PR DESCRIPTION
According to this thread the `s3:ListObjects` permission does not actually exist. Removing!

https://github.com/grafana/tempo/issues/2489

cc @knylander-grafana 