### PR TITLE
Don't increment overrides reload failed counter when request was cancelled

### DIFF
--- a/modules/overrides/user_configurable_overrides.go
+++ b/modules/overrides/user_configurable_overrides.go
@@ -117,7 +117,7 @@ func (o *userConfigurableOverridesManager) running(ctx context.Context) error {
 
 		case <-ticker.C:
 			err := o.reloadAllTenantLimits(ctx)
-			if err != nil {
+			if err != nil && !errors.Is(err, context.Canceled) {
 				metricUserConfigurableOverridesReloadFailed.Inc()
 				level.Error(o.logger).Log("msg", "failed to refresh user-configurable config", "err", err)
 			}


### PR DESCRIPTION
**What this PR does**:

If reloading failed due to a context cancelled error, don't increment the error counter. If the request is being cancelled it probably is because the pod is being shutdown.

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`