### PR TITLE
Allow grpc dial config for querier worker

### DIFF
--- a/modules/querier/worker/worker.go
+++ b/modules/querier/worker/worker.go
@@ -251,6 +251,11 @@ func (w *querierWorker) connect(ctx context.Context, address string) (*grpc.Clie
 		return nil, err
 	}
 
+	opts = append(opts, grpc.WithDefaultCallOptions(
+		grpc.MaxCallRecvMsgSize(w.cfg.GRPCClientConfig.MaxRecvMsgSize),
+		grpc.MaxCallSendMsgSize(w.cfg.GRPCClientConfig.MaxSendMsgSize),
+	))
+
 	conn, err := grpc.DialContext(ctx, address, opts...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does**:

Without this change, the querier worker does not honor the send/recv max message size.

**Which issue(s) this PR fixes**:
Fixes #1596

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`