### PR TITLE
Improve poller missing index error condition

### DIFF
--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -211,10 +211,12 @@ func TestMicroservicesWithKVStores(t *testing.T) {
 			tempoIngester2 := util.NewTempoIngester(2)
 			tempoIngester3 := util.NewTempoIngester(3)
 
+			tempoCompactor := util.NewTempoCompactor()
+
 			tempoDistributor := util.NewTempoDistributor()
 			tempoQueryFrontend := util.NewTempoQueryFrontend()
 			tempoQuerier := util.NewTempoQuerier()
-			require.NoError(t, s.StartAndWaitReady(tempoIngester1, tempoIngester2, tempoIngester3, tempoDistributor, tempoQueryFrontend, tempoQuerier))
+			require.NoError(t, s.StartAndWaitReady(tempoIngester1, tempoIngester2, tempoIngester3, tempoDistributor, tempoQueryFrontend, tempoQuerier, tempoCompactor))
 
 			// wait for active ingesters
 			time.Sleep(1 * time.Second)

--- a/integration/e2e/serverless/serverless_test.go
+++ b/integration/e2e/serverless/serverless_test.go
@@ -56,8 +56,9 @@ func TestServerless(t *testing.T) {
 			tempoDistributor := util.NewTempoDistributor()
 			tempoQueryFrontend := util.NewTempoQueryFrontend()
 			tempoQuerier := util.NewTempoQuerier()
+			tempoCompactor := util.NewTempoCompactor()
 			tempoServerless := tc.serverless
-			require.NoError(t, s.StartAndWaitReady(tempoIngester1, tempoIngester2, tempoIngester3, tempoDistributor, tempoQueryFrontend, tempoQuerier, tempoServerless))
+			require.NoError(t, s.StartAndWaitReady(tempoIngester1, tempoIngester2, tempoIngester3, tempoDistributor, tempoQueryFrontend, tempoQuerier, tempoServerless, tempoCompactor))
 
 			// wait for 2 active ingesters
 			time.Sleep(1 * time.Second)

--- a/integration/poller/poller_test.go
+++ b/integration/poller/poller_test.go
@@ -216,7 +216,7 @@ func TestPollerNonOwnership(t *testing.T) {
 	t.Parallel()
 	for _, tc := range testCompactorOwnershipBackends {
 		t.Run(tc.name, func(t *testing.T) {
-			s, err := e2e.NewScenario("tempo-integration")
+			s, err := e2e.NewScenario("tempo-integration-poller-non-ownership")
 			require.NoError(t, err)
 			defer s.Close()
 

--- a/integration/util.go
+++ b/integration/util.go
@@ -186,6 +186,27 @@ func NewNamedTempoQuerier(name string, extraArgs ...string) *e2e.HTTPService {
 	return s
 }
 
+func NewTempoCompactor(extraArgs ...string) *e2e.HTTPService {
+	return NewNamedTempoComponent("compactor", extraArgs...)
+}
+
+func NewNamedTempoComponent(name string, extraArgs ...string) *e2e.HTTPService {
+	args := []string{"-config.file=" + filepath.Join(e2e.ContainerSharedDir, "config.yaml"), "-target=" + name}
+	args = buildArgsWithExtra(args, extraArgs)
+
+	s := e2e.NewHTTPService(
+		name,
+		image,
+		e2e.NewCommandWithoutEntrypoint("/tempo", args...),
+		e2e.NewHTTPReadinessProbe(3200, "/ready", 200, 299),
+		3200,
+	)
+
+	s.SetBackoff(TempoBackoff())
+
+	return s
+}
+
 func NewTempoScalableSingleBinary(replica int, extraArgs ...string) *e2e.HTTPService {
 	args := []string{"-config.file=" + filepath.Join(e2e.ContainerSharedDir, "config.yaml"), "-target=scalable-single-binary", "-querier.frontend-address=tempo-" + strconv.Itoa(replica) + ":9095"}
 	args = buildArgsWithExtra(args, extraArgs)

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -201,6 +201,7 @@ func (p *Poller) pollTenantAndCreateIndex(
 	// are we a tenant index builder?
 	builder := p.tenantIndexBuilder(tenantID)
 	span.SetTag("tenant_index_builder", builder)
+
 	if !builder {
 		metricTenantIndexBuilder.WithLabelValues(tenantID).Set(0)
 

--- a/tempodb/blocklist/poller_test.go
+++ b/tempodb/blocklist/poller_test.go
@@ -552,6 +552,22 @@ func TestPollTolerateConsecutiveErrors(t *testing.T) {
 			},
 			expectedError: errors.New("tenant 3 err"),
 		},
+		{
+			name:     "index not found",
+			tolerate: 2,
+			tenantErrors: []error{
+				nil,
+				backend.ErrDoesNotExist,
+				errors.New("tenant 1 err"),
+				backend.ErrDoesNotExist,
+				errors.New("tenant 2 err"),
+				backend.ErrDoesNotExist,
+				errors.New("tenant 3 err"),
+				backend.ErrDoesNotExist,
+				nil,
+			},
+			expectedError: errors.New("tenant 3 err"),
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
**What this PR does**:

Here we handle an error condition for a missing tenant index on non-index-builder pollers.  This avoids unnecessary work when a tenant has been deleted, but remains in the tenant list due to the behavior described in #2754.

For non-index-builders:
* a missing index will skip the tenant
* a corrupted index will poll the tenant if fallback is enabled
* a corrupted index will not poll the tenant if fallback is disabled

This change resulted in the compactor being required as part of some tests.  Previously, if the index was not available, all pollers would attempt to build and write the index.

**Which issue(s) this PR fixes**:
Related #2754

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`