### PR TITLE
Increase default worker count and queue size in Forwarder component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [CHANGE] Increase default size and workers count of the queue used in Forwarder component [#3234](https://github.com/grafana/tempo/pull/3234) (@Blinkuu)
 * [FEATURE] Add support for multi-tenant queries. [#3087](https://github.com/grafana/tempo/pull/3087) (@electron0zero)
 * [BUGFIX] Change exit code if config is successfully verified [#3174](https://github.com/grafana/tempo/pull/3174) (@am3o @agrib-01)
 * [BUGFIX] The tempo-cli analyse blocks command no longer fails on compacted blocks [#3183](https://github.com/grafana/tempo/pull/3183) (@stoewer)

--- a/modules/distributor/forwarder/manager.go
+++ b/modules/distributor/forwarder/manager.go
@@ -18,8 +18,8 @@ import (
 )
 
 const (
-	defaultWorkerCount = 2
-	defaultQueueSize   = 100
+	defaultWorkerCount = 5
+	defaultQueueSize   = 1000
 )
 
 type Overrides interface {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Increases the default size and number of workers of the queue used for k6 x Tempo purposes.

**Which issue(s) this PR fixes**:
This change should give more headroom for larger k6 x Tempo tests.

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`