### PR TITLE
Fixes a bug where page bounds are being ignored

### DIFF
--- a/pkg/parquetquery/predicates.go
+++ b/pkg/parquetquery/predicates.go
@@ -54,7 +54,7 @@ func (p *StringInPredicate) KeepColumnChunk(cc *ColumnChunkHelper) bool {
 	}
 
 	ci, err := cc.ColumnIndex()
-	if err != nil && ci != nil {
+	if err == nil && ci != nil {
 		for _, subs := range p.ss {
 			for i := 0; i < ci.NumPages(); i++ {
 				ok := bytes.Compare(ci.MinValue(i).ByteArray(), subs) <= 0 && bytes.Compare(ci.MaxValue(i).ByteArray(), subs) >= 0
@@ -248,7 +248,7 @@ func (p *IntBetweenPredicate) String() string {
 
 func (p *IntBetweenPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
 	ci, err := c.ColumnIndex()
-	if err != nil && ci != nil {
+	if err == nil && ci != nil {
 		for i := 0; i < ci.NumPages(); i++ {
 			min := ci.MinValue(i).Int64()
 			max := ci.MaxValue(i).Int64()
@@ -305,7 +305,7 @@ func (p *GenericPredicate[T]) KeepColumnChunk(c *ColumnChunkHelper) bool {
 	}
 
 	ci, err := c.ColumnIndex()
-	if err != nil && ci != nil {
+	if err == nil && ci != nil {
 		for i := 0; i < ci.NumPages(); i++ {
 			min := p.Extract(ci.MinValue(i))
 			max := p.Extract(ci.MaxValue(i))
@@ -371,7 +371,7 @@ func (p *FloatBetweenPredicate) String() string {
 
 func (p *FloatBetweenPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
 	ci, err := c.ColumnIndex()
-	if err != nil && ci != nil {
+	if err == nil && ci != nil {
 		for i := 0; i < ci.NumPages(); i++ {
 			min := ci.MinValue(i).Double()
 			max := ci.MaxValue(i).Double()


### PR DESCRIPTION
 Fixes a small bug created in https://github.com/grafana/tempo/pull/3231.

The err condition was written incorrectly.