### PR TITLE
Add specific configuration for Tempo Distributed Mode

### DIFF
--- a/docs/sources/tempo/configuration/azure.md
+++ b/docs/sources/tempo/configuration/azure.md
@@ -17,7 +17,7 @@ Tempo requires the following configuration to authenticate to and access Azure b
       - For a user-assigned managed identity, you'll need to set `user_assigned_id` to the client ID for the managed identity in the configuration file.
   - Via Azure Workload Identity. To use Azure Workload Identity, you'll need to enable Azure Workload Identity on your cluster, add the required label and annotation to the service account and the required pod label.
 
-## Sample configuration
+## Sample configuration (for Tempo Monolithic Mode)
 
 This sample configuration shows how to set up Azure blob storage using Helm charts and an access key from Kubernetes secrets.
 
@@ -39,6 +39,76 @@ tempo:
         secretKeyRef:
           name: secret-name
           key: STORAGE_ACCOUNT_ACCESS_KEY
+```
+
+## Sample configuration (for Tempo Distributed Mode)
+
+In Distributed mode the `trace` configuration needs to be applied against the `storage` object, which resides at the root of the Values object. Additionally, the `extraArgs` and `extraEnv` configuration need to be applied to each of the following services:
+ - distributor
+ - compactor
+ - ingester
+ - querier
+ - queryFrontend
+
+```
+storage:
+  trace:
+    backend: azure
+    azure:
+      container_name: tempo-traces
+      storage_account_name: stgappgeneraluks
+      storage_account_key: ${STORAGE_ACCOUNT_ACCESS_KEY}
+
+
+distributor:
+  extraArgs:
+  - "-config.expand-env=true"
+  extraEnv:
+  - name: STORAGE_ACCOUNT_ACCESS_KEY
+    valueFrom:
+      secretKeyRef:
+        name: tempo-traces-stg-key
+        key: tempo-traces-key
+
+compactor:
+  extraArgs:
+  - "-config.expand-env=true"
+  extraEnv:
+  - name: STORAGE_ACCOUNT_ACCESS_KEY
+    valueFrom:
+      secretKeyRef:
+        name: tempo-traces-stg-key
+        key: tempo-traces-key
+
+ingester:
+  extraArgs:
+  - "-config.expand-env=true"
+  extraEnv:
+  - name: STORAGE_ACCOUNT_ACCESS_KEY
+    valueFrom:
+      secretKeyRef:
+        name: tempo-traces-stg-key
+        key: tempo-traces-key
+
+querier:
+  extraArgs:
+  - "-config.expand-env=true"
+  extraEnv:
+  - name: STORAGE_ACCOUNT_ACCESS_KEY
+    valueFrom:
+      secretKeyRef:
+        name: tempo-traces-stg-key
+        key: tempo-traces-key
+
+queryFrontend:
+  extraArgs:
+  - "-config.expand-env=true"
+  extraEnv:
+  - name: STORAGE_ACCOUNT_ACCESS_KEY
+    valueFrom:
+      secretKeyRef:
+        name: tempo-traces-stg-key
+        key: tempo-traces-key
 ```
 
 ## Azure blocklist polling


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

I am proposing this update to the Tempo configuration for Azure Storage in the light of issues I encountered when trying to run Tempo in Distributed Mode.

I found that, when using the existing documentation the trace specification did not get successfully applied to the storage object - it was still pointing to 'local' as its backend.

I also found that the extraArgs and etraEnv configuration did not seem to cascade down to any of the relevant services - so they were unable to retrieve the Storage Account key. This meant that the services threw errors during initialization and were unable to start up.

It seems to me that Tempo Monolithic and Tempo Distributed have different architectures so they each need their own distinct configuration for Azure Storage.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`