### PR TITLE
Implement a priority queue for tenant polling

### DIFF
--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -388,7 +388,9 @@ func (t *App) initQueryFrontend() (services.Service, error) {
 	t.Server.HTTPRouter().Handle(addHTTPAPIPrefix(&t.cfg, api.PathPromQueryRange), base.Wrap(queryFrontend.QueryRangeHandler))
 
 	// the query frontend needs to have knowledge of the blocks so it can shard search jobs
-	t.store.EnablePolling(context.Background(), nil)
+	if t.cfg.Target == QueryFrontend {
+		t.store.EnablePolling(context.Background(), nil)
+	}
 
 	// http query echo endpoint
 	t.Server.HTTPRouter().Handle(addHTTPAPIPrefix(&t.cfg, api.PathEcho), echoHandler())

--- a/integration/poller/poller_test.go
+++ b/integration/poller/poller_test.go
@@ -127,6 +127,8 @@ func TestPollerOwnership(t *testing.T) {
 				TenantPollConcurrency: 3,
 			}, OwnsEverythingSharder, r, cc, w, logger, l)
 
+			blocklistPoller.Start(context.Background())
+
 			// Use the block boundaries in the GCS and S3 implementation
 			bb := blockboundary.CreateBlockBoundaries(concurrency)
 			// Pick a boundary to use for this test

--- a/integration/poller/poller_test.go
+++ b/integration/poller/poller_test.go
@@ -119,11 +119,13 @@ func TestPollerOwnership(t *testing.T) {
 
 			r := backend.NewReader(rr)
 			w := backend.NewWriter(ww)
+			l := blocklist.New()
 
 			blocklistPoller := blocklist.NewPoller(&blocklist.PollerConfig{
-				PollConcurrency:     3,
-				TenantIndexBuilders: 1,
-			}, OwnsEverythingSharder, r, cc, w, logger)
+				PollConcurrency:       3,
+				TenantIndexBuilders:   1,
+				TenantPollConcurrency: 3,
+			}, OwnsEverythingSharder, r, cc, w, logger, l)
 
 			// Use the block boundaries in the GCS and S3 implementation
 			bb := blockboundary.CreateBlockBoundaries(concurrency)
@@ -162,8 +164,7 @@ func TestPollerOwnership(t *testing.T) {
 			assert.Equal(t, len(expected), len(mmResults))
 			assert.Equal(t, 0, len(cmResults))
 
-			l := blocklist.New()
-			mm, cm, err := blocklistPoller.Do(l)
+			mm, cm, err := blocklistPoller.Do()
 			require.NoError(t, err)
 			t.Logf("mm: %v", mm)
 			t.Logf("cm: %v", cm)

--- a/integration/poller/poller_test.go
+++ b/integration/poller/poller_test.go
@@ -127,8 +127,6 @@ func TestPollerOwnership(t *testing.T) {
 				TenantPollConcurrency: 3,
 			}, OwnsEverythingSharder, r, cc, w, logger, l)
 
-			blocklistPoller.Start(context.Background())
-
 			// Use the block boundaries in the GCS and S3 implementation
 			bb := blockboundary.CreateBlockBoundaries(concurrency)
 			// Pick a boundary to use for this test

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -290,6 +290,10 @@ func (p *Poller) tenantPollLoop(ctx context.Context, j int) {
 	}()
 
 	for {
+		if ctx.Err() != nil { // context cancelled
+			return
+		}
+
 		o := p.tenantQueues.Dequeue(j)
 		if o == nil {
 			return

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -162,7 +162,7 @@ func (p *Poller) Do() (PerTenant, PerTenantCompacted, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	span, _ := opentracing.StartSpanFromContext(ctx, "Poller.Do")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Poller.Do")
 	defer span.Finish()
 
 	tenants, err := p.reader.Tenants(ctx)
@@ -219,6 +219,7 @@ func (p *Poller) Do() (PerTenant, PerTenantCompacted, error) {
 		select {
 		case <-ctx.Done():
 			if errors.Is(ctx.Err(), context.Canceled) {
+				// TODO: perhaps we should return the partial results here?  The caller doesn't know what do do with nil error and nil results.
 				return nil, nil, nil
 			}
 

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -221,16 +221,6 @@ func (p *Poller) Do() (PerTenant, PerTenantCompacted, error) {
 		case <-ticker.C:
 			if p.tenantQueues.IsEmpty() {
 
-				for tenantID := range blocklist {
-					metricBlocklistLength.WithLabelValues(tenantID).Set(float64(len(blocklist[tenantID])))
-
-					backendMetaMetrics := sumTotalBackendMetaMetrics(blocklist[tenantID], compactedBlocklist[tenantID])
-					metricBackendObjects.WithLabelValues(tenantID, blockStatusLiveLabel).Set(float64(backendMetaMetrics.blockMetaTotalObjects))
-					metricBackendObjects.WithLabelValues(tenantID, blockStatusCompactedLabel).Set(float64(backendMetaMetrics.compactedBlockMetaTotalObjects))
-					metricBackendBytes.WithLabelValues(tenantID, blockStatusLiveLabel).Set(float64(backendMetaMetrics.blockMetaTotalBytes))
-					metricBackendBytes.WithLabelValues(tenantID, blockStatusCompactedLabel).Set(float64(backendMetaMetrics.compactedBlockMetaTotalBytes))
-				}
-
 				// Ensure that even empty results in either the blocklist or compacted blocklist contain the same tenants.
 				for tenantID := range compactedBlocklist {
 					if _, ok := blocklist[tenantID]; !ok {
@@ -242,6 +232,17 @@ func (p *Poller) Do() (PerTenant, PerTenantCompacted, error) {
 					if _, ok := compactedBlocklist[tenantID]; !ok {
 						compactedBlocklist[tenantID] = []*backend.CompactedBlockMeta{}
 					}
+				}
+
+				// Metric the blocklist
+				for tenantID := range blocklist {
+					metricBlocklistLength.WithLabelValues(tenantID).Set(float64(len(blocklist[tenantID])))
+
+					backendMetaMetrics := sumTotalBackendMetaMetrics(blocklist[tenantID], compactedBlocklist[tenantID])
+					metricBackendObjects.WithLabelValues(tenantID, blockStatusLiveLabel).Set(float64(backendMetaMetrics.blockMetaTotalObjects))
+					metricBackendObjects.WithLabelValues(tenantID, blockStatusCompactedLabel).Set(float64(backendMetaMetrics.compactedBlockMetaTotalObjects))
+					metricBackendBytes.WithLabelValues(tenantID, blockStatusLiveLabel).Set(float64(backendMetaMetrics.blockMetaTotalBytes))
+					metricBackendBytes.WithLabelValues(tenantID, blockStatusCompactedLabel).Set(float64(backendMetaMetrics.compactedBlockMetaTotalBytes))
 				}
 
 				return blocklist, compactedBlocklist, nil

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -185,7 +185,7 @@ func (p *Poller) Do() (PerTenant, PerTenantCompacted, error) {
 	)
 
 	for _, tenantID := range tenants {
-		lastTenantPoll = time.Now()
+		lastTenantPoll = time.Time{}
 		if last, ok := tenantsPolled[tenantID]; ok {
 			lastTenantPoll = last
 		}

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -185,7 +185,7 @@ func (p *Poller) Do() (PerTenant, PerTenantCompacted, error) {
 		}
 
 		err = p.tenantQueues.Enqueue(&tenantOp{
-			at:       lastTenantPoll,
+			lastPoll: lastTenantPoll,
 			tenantID: tenantID,
 		})
 		if err != nil {

--- a/tempodb/blocklist/poller_test.go
+++ b/tempodb/blocklist/poller_test.go
@@ -166,7 +166,6 @@ func TestTenantIndexBuilder(t *testing.T) {
 			}, &mockJobSharder{
 				owns: true,
 			}, r, c, w, log.NewNopLogger(), b)
-			poller.Start(context.Background())
 			actualList, actualCompactedList, err := poller.Do()
 
 			// confirm return as expected
@@ -272,7 +271,6 @@ func TestTenantIndexFallback(t *testing.T) {
 			}, &mockJobSharder{
 				owns: tc.isTenantIndexBuilder,
 			}, r, c, w, log.NewNopLogger(), b)
-			poller.Start(context.Background())
 			_, _, err := poller.Do()
 
 			assert.Equal(t, tc.expectsError, err != nil)
@@ -585,7 +583,6 @@ func TestPollTolerateConsecutiveErrors(t *testing.T) {
 				TolerateConsecutiveErrors: tc.tolerate,
 				TenantPollConcurrency:     testTenantPollConcurrency,
 			}, s, r, c, w, log.NewLogfmtLogger(os.Stdout), b)
-			poller.Start(context.Background())
 
 			_, _, err := poller.Do()
 
@@ -789,7 +786,6 @@ func TestPollComparePreviousResults(t *testing.T) {
 				TenantIndexBuilders:   testBuilders,
 				TenantPollConcurrency: testTenantPollConcurrency,
 			}, s, r, c, w, log.NewNopLogger(), previous)
-			poller.Start(context.Background())
 
 			metas, compactedMetas, err := poller.Do()
 			require.Equal(t, tc.err, err)

--- a/tempodb/blocklist/tenant_op.go
+++ b/tempodb/blocklist/tenant_op.go
@@ -1,0 +1,21 @@
+package blocklist
+
+import (
+	"time"
+)
+
+type tenantOp struct {
+	at       time.Time // When to execute
+	attempts uint
+	tenantID string
+}
+
+func (o *tenantOp) Key() string {
+	return o.tenantID
+}
+
+// Priority orders entries in the queue. The larger the number the higher the priority, so inverted here to
+// prioritize entries with earliest timestamps.
+func (o *tenantOp) Priority() int64 {
+	return -o.at.Unix()
+}

--- a/tempodb/blocklist/tenant_op.go
+++ b/tempodb/blocklist/tenant_op.go
@@ -5,7 +5,7 @@ import (
 )
 
 type tenantOp struct {
-	at       time.Time // When to execute
+	lastPoll time.Time // When to execute
 	attempts uint
 	tenantID string
 }
@@ -17,5 +17,5 @@ func (o *tenantOp) Key() string {
 // Priority orders entries in the queue. The larger the number the higher the priority, so inverted here to
 // prioritize entries with earliest timestamps.
 func (o *tenantOp) Priority() int64 {
-	return -o.at.Unix()
+	return -o.lastPoll.Unix()
 }

--- a/tempodb/config.go
+++ b/tempodb/config.go
@@ -28,6 +28,7 @@ const (
 	DefaultRetentionConcurrency      = uint(10)
 	DefaultTenantIndexBuilders       = 2
 	DefaultTolerateConsecutiveErrors = 1
+	DefaultTenantPollConcurrency     = uint(4)
 
 	DefaultPrefetchTraceCount   = 1000
 	DefaultSearchChunkSizeBytes = 1_000_000
@@ -50,6 +51,8 @@ type Config struct {
 	BlocklistPollStaleTenantIndex          time.Duration `yaml:"blocklist_poll_stale_tenant_index"`
 	BlocklistPollJitterMs                  int           `yaml:"blocklist_poll_jitter_ms"`
 	BlocklistPollTolerateConsecutiveErrors int           `yaml:"blocklist_poll_tolerate_consecutive_errors"`
+
+	TenantPollConcurrency uint `yaml:"tenant_poll_concurrency"`
 
 	// backends
 	Backend string        `yaml:"backend"`

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -519,8 +519,6 @@ func (rw *readerWriter) EnablePolling(ctx context.Context, sharder blocklist.Job
 
 	rw.blocklistPoller = blocklistPoller
 
-	rw.blocklistPoller.Start(ctx)
-
 	// do the first poll cycle synchronously. this will allow the caller to know
 	// that when this method returns the block list is updated
 	rw.pollBlocklist()

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -544,7 +544,13 @@ func (rw *readerWriter) pollingLoop(ctx context.Context) {
 func (rw *readerWriter) pollBlocklist() {
 	blocklist, compactedBlocklist, err := rw.blocklistPoller.Do()
 	if err != nil {
-		level.Error(rw.logger).Log("msg", "failed to poll blocklist", "err", err)
+		switch {
+		case errors.Is(err, context.Canceled):
+		case errors.Is(err, context.DeadlineExceeded):
+		default:
+			level.Error(rw.logger).Log("msg", "failed to poll blocklist", "err", err)
+		}
+
 		return
 	}
 


### PR DESCRIPTION
**What this PR does**:

Here is an implementation of using a priority queue to poll the tenants who have been polled least recently, in combination with a modest concurrent polling.   In a small environment with 30k blocks and 10k tenants, this results in a 70% decrease in overall polling time.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`