### PR TITLE
[Traceql Metrics] PR 3 - Trace ID sharding

### DIFF
--- a/tempodb/encoding/vparquet3/wal_block.go
+++ b/tempodb/encoding/vparquet3/wal_block.go
@@ -652,7 +652,7 @@ func (b *walBlock) Fetch(ctx context.Context, req traceql.FetchSpansRequest, opt
 
 		pf := file.parquetFile
 
-		iter, err := fetch(ctx, req, pf, opts, b.meta.DedicatedColumns)
+		iter, err := fetch(ctx, req, pf, pf.RowGroups(), opts, b.meta.DedicatedColumns)
 		if err != nil {
 			return traceql.FetchSpansResponse{}, fmt.Errorf("creating fetch iter: %w", err)
 		}


### PR DESCRIPTION
**What this PR does**:
This PR implements the trace-ID sharding used by metrics in the block Fetch() method.  For context:  the query-frontend divides a metrics query into jobs along 2 dimensions:   horizontally across time (i.e. a job every 5 minutes) and vertically across trace IDs (i.e. 10 shards).  This PR is the vertical scaling. For example:  shard "10 of 16" processes only traces A00.... through AFF....  This is done with a predicate against the TraceID column.  

There are some other details to be aware:
* Some tricks to shard both 8-byte and 16-byte trace IDs.
* It uses the previously-experimental trace ID index json in each block.  This eliminates quite a few reads because we can go straight to the row groups that contain the matching trace IDs instead of testing every one.  I think we fixed the issues with index, it's been working well for me.

**Notes**
This is one entry in a set of chained PRs.  The full body of work has been split into separate buckets to make reviews and updates more manageable.  
1. https://github.com/grafana/tempo/pull/3251
2. https://github.com/grafana/tempo/pull/3252
3. <this PR>

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`