### PR TITLE
Docs: indent code block to allow proper list numbers

### DIFF
--- a/docs/sources/tempo/api_docs/pushing-spans-with-http.md
+++ b/docs/sources/tempo/api_docs/pushing-spans-with-http.md
@@ -100,11 +100,11 @@ The easiest way to get the trace is to execute a simple curl command to Tempo.  
 
 1. Replace the trace ID in the `curl` command with the trace ID that was generated from the push. This information is is in the data that's sent with the `curl`. You could use Grafana’s Explorer page to find this, as shown in the previous section.
 
-```bash
-curl http://localhost:3200/api/traces/5b8efff798038103d269b633813fc700
+	```bash
+	curl http://localhost:3200/api/traces/5b8efff798038103d269b633813fc700
 
-{"batches":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"my.service"}}]},"scopeSpans":[{"scope":{"name":"my.library","version":"1.0.0"},"spans":[{"traceId":"W47/95gDgQPSabYzgT/HAA==","spanId":"7uGbfsPBsQA=","name":"I am a span!","kind":"SPAN_KIND_SERVER","startTimeUnixNano":"1689969302000000000","endTimeUnixNano":"1689970000000000000","attributes":[{"key":"my.span.attr","value":{"stringValue":"some value"}}],"status":{}}]}]}]}
-```
+	{"batches":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"my.service"}}]},"scopeSpans":[{"scope":{"name":"my.library","version":"1.0.0"},"spans":[{"traceId":"W47/95gDgQPSabYzgT/HAA==","spanId":"7uGbfsPBsQA=","name":"I am a span!","kind":"SPAN_KIND_SERVER","startTimeUnixNano":"1689969302000000000","endTimeUnixNano":"1689970000000000000","attributes":[{"key":"my.span.attr","value":{"stringValue":"some value"}}],"status":{}}]}]}]}
+	```
 
 1. Copy and paste the updated `curl` command into a terminal window.
 


### PR DESCRIPTION
A code block breaks the numbering of list items:
<img width="825" alt="image" src="https://github.com/grafana/tempo/assets/135109076/454e020c-4581-4885-8375-4e0fb59b95ca">

Indenting it, as done in the preceding list, should fix the issue:
<img width="474" alt="image" src="https://github.com/grafana/tempo/assets/135109076/ee43c954-e182-45e5-8314-ea1213e50e6c">
