### PR TITLE
Add support for multi-tenant queries in streaming search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@
 /tempodb/encoding/benchmark_block
 private-key.key
 integration/e2e/e2e_integration_test[0-9]*
-integration/e2e/metrics_*_dump.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [FEATURE] Add support for multi-tenant queries in streaming search [#3262](https://github.com/grafana/tempo/pull/3262) (@electron0zero)
 * [FEATURE] TraceQL metrics queries [#3227](https://github.com/grafana/tempo/pull/3227) [#3252](https://github.com/grafana/tempo/pull/3252) [#3258](https://github.com/grafana/tempo/pull/3258) (@mdisibio @zalegrala)
 * [FEATURE] Add support for multi-tenant queries. [#3087](https://github.com/grafana/tempo/pull/3087) (@electron0zero)
 * [BUGFIX] Fix parsing of span.resource.xyz attributes in TraceQL. [#3284](https://github.com/grafana/tempo/pull/3284) (@mghildiy)

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ lint:
 
 .PHONY: docker-component # Not intended to be used directly
 docker-component: check-component exe
-	docker build -t grafana/$(COMPONENT) --load --build-arg=TARGETARCH=$(GOARCH) -f ./cmd/$(COMPONENT)/Dockerfile .
+	docker build -t grafana/$(COMPONENT) --build-arg=TARGETARCH=$(GOARCH) -f ./cmd/$(COMPONENT)/Dockerfile .
 	docker tag grafana/$(COMPONENT) $(COMPONENT)
 
 .PHONY: docker-component-debug

--- a/example/docker-compose/multi-tenant/docker-compose.yaml
+++ b/example/docker-compose/multi-tenant/docker-compose.yaml
@@ -1,0 +1,48 @@
+version: "3"
+services:
+  tempo:
+    image: grafana/tempo:latest
+    environment:
+      - GRPC_TRACE=api
+    command: [ "-config.file=/etc/tempo.yaml" ]
+    volumes:
+      - ./tempo.yaml:/etc/tempo.yaml
+      - ./tempo-data:/tmp/tempo
+    ports:
+      - "14268:14268"  # jaeger ingest
+      - "3200:3200"   # tempo
+      - "9095:9095" # tempo grpc
+      - "4317:4317"  # otlp grpc
+      - "4318:4318"  # otlp http
+      - "9411:9411"   # zipkin
+
+  k6-tracing:
+    image: ghcr.io/grafana/xk6-client-tracing:latest
+    environment:
+      - ENDPOINT=tempo:4317
+      - TEMPO_X_SCOPE_ORGID=test
+    restart: always
+    depends_on:
+      - tempo
+
+  k6-tracing-2:
+    image: ghcr.io/grafana/xk6-client-tracing:latest
+    environment:
+      - ENDPOINT=tempo:4317
+      - TEMPO_X_SCOPE_ORGID=test2
+    restart: always
+    depends_on:
+      - tempo
+
+  grafana:
+    image: grafana/grafana:main
+    volumes:
+      - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+    environment:
+      - GF_DEFAULT_APP_MODE=development
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor traceQLStreaming metricsSummary
+    ports:
+      - "3000:3000"

--- a/example/docker-compose/multi-tenant/grafana-datasources.yaml
+++ b/example/docker-compose/multi-tenant/grafana-datasources.yaml
@@ -1,0 +1,33 @@
+apiVersion: 1
+
+datasources:
+- name: Prometheus
+  type: prometheus
+  uid: prometheus
+  access: proxy
+  orgId: 1
+  url: http://prometheus:9090
+  basicAuth: false
+  isDefault: false
+  version: 1
+  editable: false
+  jsonData:
+    httpMethod: GET
+- name: Tempo
+  type: tempo
+  access: proxy
+  orgId: 1
+  url: http://tempo:3200
+  basicAuth: false
+  isDefault: true
+  version: 1
+  editable: false
+  apiVersion: 1
+  uid: tempo
+  jsonData:
+    httpMethod: GET
+    serviceMap:
+      datasourceUid: prometheus
+    httpHeaderName1: 'X-Scope-Orgid'
+  secureJsonData:
+    httpHeaderValue1: 'test|test2'

--- a/example/docker-compose/multi-tenant/readme.md
+++ b/example/docker-compose/multi-tenant/readme.md
@@ -59,10 +59,7 @@ You can use Grafana or tempo-cli to make a query.
 **grpc streaming query using tempo-cli**
 - `$ tempo-cli query api search "0.0.0.0:3200" --use-grpc --limit 10000 "{}" "2023-12-05T08:11:18Z" "2023-12-05T08:12:18Z" --org-id="test"`
 
-**websocket streaming query using tempo-cli**
-- `$ tempo-cli query api search "0.0.0.0:3200" --use-ws --limit 10000 "{}" "2023-12-05T08:11:18Z" "2023-12-05T08:12:18Z" --org-id="test"`
-
 **multi-tenant streaming queries using tempo-cli**
-- Just pass multiple tenant ids with `|` like this `--org-id="test|test2"`
+- pass multiple tenant ids with `|` like this `--org-id="test|test2"`
 
 example: `$ ./bin/linux/tempo-cli-amd64 query api search "0.0.0.0:3200" --use-grpc --limit 10000 "{ true } >> { true }" "2024-01-15T11:00:00Z" "2024-01-19T12:30:00Z" --org-id="test|test2"`

--- a/example/docker-compose/multi-tenant/readme.md
+++ b/example/docker-compose/multi-tenant/readme.md
@@ -1,0 +1,68 @@
+## Local Storage
+In this example all data is stored locally in the `tempo-data` folder. Local storage is fine for experimenting with Tempo
+or when using the single binary, but does not work in a distributed/microservices scenario.
+
+1. First start up the local stack.
+
+```console
+$ docker-compose up -d
+Starting multi-tenant_grafana_1    ... done
+Starting multi-tenant_tempo_1      ... done
+Starting multi-tenant_k6-tracing-2_1 ... done
+Starting multi-tenant_k6-tracing_1   ... done
+```
+
+At this point, the following containers should be spun up -
+
+```console
+$ docker-compose ps
+           Name                          Command               State                                                                     Ports                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+multi-tenant_grafana_1        /run.sh                          Up      0.0.0.0:3000->3000/tcp,:::3000->3000/tcp
+multi-tenant_k6-tracing-2_1   /k6-tracing run /example-s ...   Up
+multi-tenant_k6-tracing_1     /k6-tracing run /example-s ...   Up
+multi-tenant_tempo_1          /tempo -config.file=/etc/t ...   Up      0.0.0.0:14268->14268/tcp,:::14268->14268/tcp, 0.0.0.0:3200->3200/tcp,:::3200->3200/tcp, 0.0.0.0:4317->4317/tcp,:::4317->4317/tcp,
+                                                                       0.0.0.0:4318->4318/tcp,:::4318->4318/tcp, 0.0.0.0:9095->9095/tcp,:::9095->9095/tcp, 0.0.0.0:9411->9411/tcp,:::9411->9411/tcp
+
+
+```
+
+2. If you're interested you can see the wal/blocks as they are being created.
+
+```console
+$ ls tempo-data/
+```
+
+3. Navigate to [Grafana](http://localhost:3000/explore) select the Tempo data source and use the "Search"
+tab to find traces. Also notice that you can query Tempo metrics from the Prometheus data source setup in
+Grafana.
+
+4. Tail logs of a container (eg: tempo)
+```bash
+$ docker logs multi-tenant_tempo_1 -f
+```
+
+5. To stop the setup use -
+
+```console
+docker-compose down -v
+```
+
+## streaming and multi-tenant search
+
+- needs `traceQLStreaming` feature flag set in Grafana, see `docker-compose.yaml`
+- needs `stream_over_http_enabled: true`, `multitenancy_enabled: true`,
+and `query_frontend.multi_tenant_queries_enabled: true` in the tempo config file, see `tempo.yaml`
+
+You can use Grafana or tempo-cli to make a query.
+
+**grpc streaming query using tempo-cli**
+- `$ tempo-cli query api search "0.0.0.0:3200" --use-grpc --limit 10000 "{}" "2023-12-05T08:11:18Z" "2023-12-05T08:12:18Z" --org-id="test"`
+
+**websocket streaming query using tempo-cli**
+- `$ tempo-cli query api search "0.0.0.0:3200" --use-ws --limit 10000 "{}" "2023-12-05T08:11:18Z" "2023-12-05T08:12:18Z" --org-id="test"`
+
+**multi-tenant streaming queries using tempo-cli**
+- Just pass multiple tenant ids with `|` like this `--org-id="test|test2"`
+
+example: `$ ./bin/linux/tempo-cli-amd64 query api search "0.0.0.0:3200" --use-grpc --limit 10000 "{ true } >> { true }" "2024-01-15T11:00:00Z" "2024-01-19T12:30:00Z" --org-id="test|test2"`

--- a/example/docker-compose/multi-tenant/tempo.yaml
+++ b/example/docker-compose/multi-tenant/tempo.yaml
@@ -1,0 +1,50 @@
+target: all
+multitenancy_enabled: true
+stream_over_http_enabled: true
+server:
+  http_listen_port: 3200
+  log_level: info
+
+query_frontend:
+  multi_tenant_queries_enabled: true
+  search:
+    duration_slo: 5s
+    throughput_bytes_slo: 1.073741824e+09
+  trace_by_id:
+    duration_slo: 5s
+
+distributor:
+  receivers:                           # this configuration will listen on all ports and protocols that tempo is capable of.
+    jaeger:                            # the receives all come from the OpenTelemetry collector.  more configuration information can
+      protocols:                       # be found there: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver
+        thrift_http:                   #
+        grpc:                          # for a production deployment you should only enable the receivers you need!
+        thrift_binary:
+        thrift_compact:
+    zipkin:
+    otlp:
+      protocols:
+        http:
+        grpc:
+    opencensus:
+
+ingester:
+  max_block_duration: 5m               # cut the headblock when this much time passes. this is being set for demo purposes and should probably be left alone normally
+
+compactor:
+  compaction:
+    block_retention: 1h                # overall Tempo trace retention. set for demo purposes
+
+metrics_generator:
+
+storage:
+  trace:
+    backend: local                     # backend configuration to use
+    wal:
+      path: /tmp/tempo/wal             # where to store the the wal locally
+    local:
+      path: /tmp/tempo/blocks
+
+overrides:
+  defaults:
+    metrics_generator:

--- a/integration/e2e/config-multi-tenant-local.yaml
+++ b/integration/e2e/config-multi-tenant-local.yaml
@@ -54,6 +54,7 @@ metrics_generator:
 
 storage:
   trace:
+    blocklist_poll: 1s
     backend: local
     local:
       path: /var/tempo

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -131,7 +131,7 @@ func TestAllInOne(t *testing.T) {
 			grpcClient, err := util.NewSearchGRPCClient(context.Background(), tempo.Endpoint(3200))
 			require.NoError(t, err)
 
-			util.SearchStreamAndAssertTrace(t, grpcClient, info, now.Add(-20*time.Minute).Unix(), now.Unix())
+			util.SearchStreamAndAssertTrace(t, context.Background(), grpcClient, info, now.Add(-20*time.Minute).Unix(), now.Unix())
 		})
 	}
 }

--- a/integration/e2e/encodings_test.go
+++ b/integration/e2e/encodings_test.go
@@ -121,7 +121,7 @@ func TestEncodings(t *testing.T) {
 				// search the backend. this works b/c we're passing a start/end AND setting query ingesters within min/max to 0
 				integration.SearchAndAssertTraceBackend(t, apiClient, info, now.Add(-20*time.Minute).Unix(), now.Unix())
 				// find the trace with streaming. using the http server b/c that's what Grafana will do
-				integration.SearchStreamAndAssertTrace(t, grpcClient, info, now.Add(-20*time.Minute).Unix(), now.Unix())
+				integration.SearchStreamAndAssertTrace(t, context.Background(), grpcClient, info, now.Add(-20*time.Minute).Unix(), now.Unix())
 			}
 		})
 	}

--- a/integration/e2e/https_test.go
+++ b/integration/e2e/https_test.go
@@ -82,5 +82,5 @@ func TestHTTPS(t *testing.T) {
 	require.NoError(t, err)
 
 	now := time.Now()
-	util.SearchStreamAndAssertTrace(t, grpcClient, info, now.Add(-time.Hour).Unix(), now.Add(time.Hour).Unix())
+	util.SearchStreamAndAssertTrace(t, context.Background(), grpcClient, info, now.Add(-time.Hour).Unix(), now.Add(time.Hour).Unix())
 }

--- a/integration/e2e/multi_tenant_test.go
+++ b/integration/e2e/multi_tenant_test.go
@@ -220,24 +220,9 @@ func TestMultiTenantSearch(t *testing.T) {
 				Query: "{}", Start: uint32(now.Add(-20 * time.Minute).Unix()), End: uint32(now.Unix()),
 			})
 			require.NoError(t, err)
-			// actual error comes in resp, need to call Recv to get it.
+			// actual error comes in response, need to call Recv to get it.
 			_, grpcErr := grpcResp.Recv()
-			// fmt.Printf("==== grpcResp.Recv() grpcErr: %s\n", grpcErr)
-			// fmt.Printf("==== grpcResp.Recv() grpcSearchResp: %s\n", grpcSearchResp)
-
-			// drain the stream until everything is returned
-			// for {
-			// 	_, grpcErr = grpcResp.Recv()
-			// 	if errors.Is(err, io.EOF) {
-			// 		break
-			// 	}
-			// 	require.NoError(t, err)
-			// }
-
-			// find the trace with streaming. using the http server b/c that's what Grafana will do
-			// FIXME: info is for the last tenant so it's gonna fail, assert streaming in it's own test?? and only check for no error here
-			// rpc error: code = Unknown desc = no org id
-			// util.SearchStreamAndAssertTrace(t, grpcClient, info, now.Add(-20*time.Minute).Unix(), now.Unix())
+			assertRequestCountMetric(t, tempo, "/tempopb.StreamingQuerier/Search", 1)
 
 			if tc.tenantSize > 1 {
 				// error for multi-tenant request for unsupported endpoints

--- a/integration/e2e/multi_tenant_test.go
+++ b/integration/e2e/multi_tenant_test.go
@@ -222,11 +222,28 @@ func TestMultiTenantSearch(t *testing.T) {
 			require.NoError(t, err)
 			// actual error comes in resp, need to call Recv to get it.
 			_, grpcErr := grpcResp.Recv()
+			// fmt.Printf("==== grpcResp.Recv() grpcErr: %s\n", grpcErr)
+			// fmt.Printf("==== grpcResp.Recv() grpcSearchResp: %s\n", grpcSearchResp)
+
+			// drain the stream until everything is returned
+			// for {
+			// 	_, grpcErr = grpcResp.Recv()
+			// 	if errors.Is(err, io.EOF) {
+			// 		break
+			// 	}
+			// 	require.NoError(t, err)
+			// }
+
+			// find the trace with streaming. using the http server b/c that's what Grafana will do
+			// FIXME: info is for the last tenant so it's gonna fail, assert streaming in it's own test?? and only check for no error here
+			// rpc error: code = Unknown desc = no org id
+			// util.SearchStreamAndAssertTrace(t, grpcClient, info, now.Add(-20*time.Minute).Unix(), now.Unix())
 
 			if tc.tenantSize > 1 {
-				// we expect error in case of multi-tenant request for unsupported endpoints
+				// error for multi-tenant request for unsupported endpoints
 				require.Error(t, msErr)
-				require.Error(t, grpcErr)
+				// no error for multi-tenant streaming search
+				require.NoError(t, grpcErr)
 			} else {
 				require.NoError(t, msErr)
 				require.NoError(t, grpcErr)

--- a/integration/e2e/multi_tenant_test.go
+++ b/integration/e2e/multi_tenant_test.go
@@ -205,10 +205,6 @@ func TestMultiTenantSearch(t *testing.T) {
 				assertRequestCountMetric(t, tempo, rt.route, rt.reqCount)
 			}
 
-			// test all the unsupported endpoints
-			now := time.Now()
-			_, msErr := apiClient.MetricsSummary("{}", "name", 0, 0)
-
 			// test streaming search over grpc
 			grpcCtx := user.InjectOrgID(context.Background(), tc.tenant)
 			grpcCtx, err = user.InjectIntoGRPCRequest(grpcCtx)
@@ -216,22 +212,19 @@ func TestMultiTenantSearch(t *testing.T) {
 
 			grpcClient, err := util.NewSearchGRPCClient(grpcCtx, tempo.Endpoint(3200))
 			require.NoError(t, err)
-			grpcResp, err := grpcClient.Search(grpcCtx, &tempopb.SearchRequest{
-				Query: "{}", Start: uint32(now.Add(-20 * time.Minute).Unix()), End: uint32(now.Unix()),
-			})
-			require.NoError(t, err)
-			// actual error comes in response, need to call Recv to get it.
-			_, grpcErr := grpcResp.Recv()
+
+			time.Sleep(2 * time.Second) // ensure that blocklist poller has built the blocklist
+			now := time.Now()
+			util.SearchStreamAndAssertTrace(t, grpcCtx, grpcClient, info, now.Add(-5*time.Minute).Unix(), now.Add(5*time.Minute).Unix())
 			assertRequestCountMetric(t, tempo, "/tempopb.StreamingQuerier/Search", 1)
 
+			// test unsupported endpoint
+			_, msErr := apiClient.MetricsSummary("{}", "name", 0, 0)
 			if tc.tenantSize > 1 {
 				// error for multi-tenant request for unsupported endpoints
 				require.Error(t, msErr)
-				// no error for multi-tenant streaming search
-				require.NoError(t, grpcErr)
 			} else {
 				require.NoError(t, msErr)
-				require.NoError(t, grpcErr)
 			}
 		})
 	}

--- a/integration/util.go
+++ b/integration/util.go
@@ -365,14 +365,14 @@ func SearchTraceQLAndAssertTrace(t *testing.T, client *httpclient.Client, info *
 	require.True(t, traceIDInResults(t, info.HexID(), resp))
 }
 
-func SearchStreamAndAssertTrace(t *testing.T, client tempopb.StreamingQuerierClient, info *tempoUtil.TraceInfo, start, end int64) {
+func SearchStreamAndAssertTrace(t *testing.T, ctx context.Context, client tempopb.StreamingQuerierClient, info *tempoUtil.TraceInfo, start, end int64) {
 	expected, err := info.ConstructTraceFromEpoch()
 	require.NoError(t, err)
 
 	attr := tempoUtil.RandomAttrFromTrace(expected)
 	query := fmt.Sprintf(`{ .%s = "%s"}`, attr.GetKey(), attr.GetValue().GetStringValue())
 
-	resp, err := client.Search(context.Background(), &tempopb.SearchRequest{
+	resp, err := client.Search(ctx, &tempopb.SearchRequest{
 		Query: query,
 		Start: uint32(start),
 		End:   uint32(end),

--- a/integration/util.go
+++ b/integration/util.go
@@ -365,6 +365,8 @@ func SearchTraceQLAndAssertTrace(t *testing.T, client *httpclient.Client, info *
 	require.True(t, traceIDInResults(t, info.HexID(), resp))
 }
 
+// SearchStreamAndAssertTrace will search and assert that the trace is present in the streamed results.
+// nolint: revive
 func SearchStreamAndAssertTrace(t *testing.T, ctx context.Context, client tempopb.StreamingQuerierClient, info *tempoUtil.TraceInfo, start, end int64) {
 	expected, err := info.ConstructTraceFromEpoch()
 	require.NoError(t, err)

--- a/modules/frontend/combiner/noop.go
+++ b/modules/frontend/combiner/noop.go
@@ -1,0 +1,27 @@
+package combiner
+
+import (
+	"io"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+)
+
+var _ Combiner = (*genericCombiner[*tempopb.SearchResponse])(nil)
+
+// NewNoOp returns a combiner that doesn't is a no op, and doesn't combine.
+// It is used in search streaming, in search streaming keeps trek of search progress
+// and combines result on its own from the multi-tenant search.
+func NewNoOp() Combiner {
+	return &genericCombiner[*tempopb.SearchResponse]{
+		code:  200,
+		final: &tempopb.SearchResponse{Metrics: &tempopb.SearchMetrics{}},
+		combine: func(body io.ReadCloser, final *tempopb.SearchResponse) error {
+			// no op
+			return nil
+		},
+		result: func(response *tempopb.SearchResponse) (string, error) {
+			// no op
+			return "", nil
+		},
+	}
+}

--- a/modules/frontend/search_progress.go
+++ b/modules/frontend/search_progress.go
@@ -23,7 +23,7 @@ type shardedSearchProgress interface {
 	addResponse(res *tempopb.SearchResponse)
 	shouldQuit() bool
 	result() *shardedSearchResults
-	metrics() *tempopb.SearchMetrics
+	metrics() tempopb.SearchMetrics
 }
 
 // shardedSearchResults is the overall response from the shardedSearchProgress
@@ -193,11 +193,21 @@ func (r *searchProgress) result() *shardedSearchResults {
 	return res
 }
 
-func (r *searchProgress) metrics() *tempopb.SearchMetrics {
+// metrics return a copy of resultsMetrics, copy can be costly so only recommended for infrequent access
+func (r *searchProgress) metrics() tempopb.SearchMetrics {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
 
-	return r.resultsMetrics
+	// return a copy of metrics, instead of a copy.
+	metricsCopy := tempopb.SearchMetrics{
+		InspectedTraces: r.resultsMetrics.InspectedTraces,
+		InspectedBytes:  r.resultsMetrics.InspectedBytes,
+		TotalBlocks:     r.resultsMetrics.TotalBlocks,
+		CompletedJobs:   r.resultsMetrics.CompletedJobs,
+		TotalJobs:       r.resultsMetrics.TotalJobs,
+		TotalBlockBytes: r.resultsMetrics.TotalBlockBytes,
+	}
+	return metricsCopy
 }
 
 func copySpanset(ss *tempopb.SpanSet) *tempopb.SpanSet {

--- a/modules/frontend/search_streaming.go
+++ b/modules/frontend/search_streaming.go
@@ -87,7 +87,7 @@ func (p *diffSearchProgress) result() *shardedSearchResults {
 	return res
 }
 
-func (p *diffSearchProgress) metrics() *tempopb.SearchMetrics {
+func (p *diffSearchProgress) metrics() tempopb.SearchMetrics {
 	return p.progress.metrics()
 }
 
@@ -117,7 +117,7 @@ func (mp *multiProgress) Add(p *diffSearchProgress) {
 	mp.progress = append(mp.progress, p)
 
 	// combine metrics
-	m := *p.metrics()
+	m := p.metrics()
 	// only set the metrics we set in progress constructor, other metrics are set by the sharder
 	mp.combinedMetrics.TotalBlocks += m.TotalBlocks
 	mp.combinedMetrics.TotalBlockBytes += m.TotalBlockBytes
@@ -136,7 +136,7 @@ func (mp *multiProgress) results(ctx context.Context) *shardedSearchResults {
 
 	comb := newSearchProgress(ctx, 0, mp.combinedMetrics.TotalJobs, mp.combinedMetrics.TotalBlocks, mp.combinedMetrics.TotalBlockBytes)
 	for _, progress := range mp.progress {
-		r := *progress.result() // only get new results from each progress object
+		r := progress.result() // only get new results from each progress object
 		comb.addResponse(r.response)
 		// set the error and status code, if any
 		if r.err != nil || r.statusCode != http.StatusOK {
@@ -161,7 +161,7 @@ func (mp *multiProgress) finalResults(ctx context.Context) *shardedSearchResults
 	// init the progress object with combinedMetrics to report accurate metrics
 	comb := newSearchProgress(ctx, 0, mp.combinedMetrics.TotalJobs, mp.combinedMetrics.TotalBlocks, mp.combinedMetrics.TotalBlockBytes)
 	for _, progress := range mp.progress {
-		r := *progress.finalResult()
+		r := progress.finalResult()
 		comb.addResponse(r.response)
 		// set the error and status code, if any
 		if r.err != nil || r.statusCode != http.StatusOK {

--- a/modules/frontend/search_streaming.go
+++ b/modules/frontend/search_streaming.go
@@ -13,10 +13,8 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
-	//nolint:all //deprecated
+	"github.com/go-kit/log/level" //nolint:all //deprecated
 	"github.com/grafana/tempo/modules/frontend/combiner"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/dskit/user"
 	"github.com/grafana/tempo/modules/overrides"
@@ -184,8 +182,8 @@ func newSearchStreamingGRPCHandler(cfg Config, o overrides.Interface, downstream
 		o:           o,
 		searchCache: searchCache,
 		cfg:         &cfg,
-		// pass NoOp combiner because we combine results ourselves, and don't use
-		// combined results from middleware
+		// pass NoOp combiner because we combine results ourselves.
+		// we don't use combiner's combined result for streaming search.
 		preMiddleware: newMultiTenantMiddleware(cfg, combiner.NewNoOp, logger),
 	}
 
@@ -257,7 +255,7 @@ func (s *streamingSearcher) handle(r *http.Request, forwardResults func(*tempopb
 
 	// initiate http pipeline
 	go func() {
-		// blocking, and query is done when this returns.
+		// query is finished when RoundTrip returns.
 		resp, err := rt.RoundTrip(r)
 		resultChan <- roundTripResult{resp, err}
 		close(resultChan)
@@ -281,7 +279,7 @@ func (s *streamingSearcher) handle(r *http.Request, forwardResults func(*tempopb
 				return fmt.Errorf("search streaming send failed: %w", err)
 			}
 
-		// final result is available, request is done
+		// final result is available, pipeline is done
 		case roundTripRes := <-resultChan:
 			// check for errors in the http response
 			if roundTripRes.err != nil {

--- a/modules/frontend/search_streaming.go
+++ b/modules/frontend/search_streaming.go
@@ -167,15 +167,6 @@ func newSearchStreamingGRPCHandler(cfg Config, o overrides.Interface, downstream
 
 	downstreamPath := path.Join(apiPrefix, api.PathSearch)
 	return func(req *tempopb.SearchRequest, srv tempopb.StreamingQuerier_SearchServer) error {
-		// FIXME: do we need this?? check if we need this?? this was commented out before?
-		tenant, _, err := user.ExtractFromGRPCRequest(srv.Context())
-		if err != nil {
-			level.Error(logger).Log("msg", "search streaming: extract org id failed", "err", err)
-			return fmt.Errorf("extract org id failed: %w", err)
-		}
-
-		level.Debug(logger).Log("msg", "in search streaming", "tenant", tenant)
-
 		httpReq, err := api.BuildSearchRequest(&http.Request{
 			URL: &url.URL{
 				Path: downstreamPath,

--- a/modules/frontend/search_streaming_test.go
+++ b/modules/frontend/search_streaming_test.go
@@ -45,9 +45,9 @@ func (m *mockStreamingServer) SendMsg(interface{}) error    { return nil }
 func (m *mockStreamingServer) RecvMsg(interface{}) error    { return nil }
 func (m *mockStreamingServer) SetTrailer(metadata.MD)       {}
 
-func newMockStreamingServer(orgId string, cb func(int, *tempopb.SearchResponse)) *mockStreamingServer {
+func newMockStreamingServer(orgID string, cb func(int, *tempopb.SearchResponse)) *mockStreamingServer {
 	return &mockStreamingServer{
-		ctx: user.InjectOrgID(context.Background(), orgId),
+		ctx: user.InjectOrgID(context.Background(), orgID),
 		cb:  cb,
 	}
 }

--- a/modules/frontend/search_streaming_test.go
+++ b/modules/frontend/search_streaming_test.go
@@ -45,165 +45,261 @@ func (m *mockStreamingServer) SendMsg(interface{}) error    { return nil }
 func (m *mockStreamingServer) RecvMsg(interface{}) error    { return nil }
 func (m *mockStreamingServer) SetTrailer(metadata.MD)       {}
 
-func newMockStreamingServer(cb func(int, *tempopb.SearchResponse)) *mockStreamingServer {
+func newMockStreamingServer(orgId string, cb func(int, *tempopb.SearchResponse)) *mockStreamingServer {
 	return &mockStreamingServer{
-		ctx: user.InjectOrgID(context.Background(), "fake-tenant"),
+		ctx: user.InjectOrgID(context.Background(), orgId),
 		cb:  cb,
 	}
 }
 
 func TestStreamingSearchHandlerSucceeds(t *testing.T) {
-	traceResp := []*tempopb.TraceSearchMetadata{
+	tests := []struct {
+		name       string
+		tenants    string
+		tenantSize uint32
+	}{
 		{
-			TraceID:         "1234",
-			RootServiceName: "root",
+			name:       "single tenant",
+			tenants:    "single-tenant",
+			tenantSize: 1,
+		},
+		{
+			name:       "multiple tenants",
+			tenants:    "tenant-1|tenant-2|tenant-3",
+			tenantSize: 3,
 		},
 	}
 
-	next := RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
-		response := &tempopb.SearchResponse{
-			Traces:  traceResp,
-			Metrics: &tempopb.SearchMetrics{},
-		}
-		resString, err := (&jsonpb.Marshaler{}).MarshalToString(response)
-		require.NoError(t, err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			traceResp := []*tempopb.TraceSearchMetadata{
+				{
+					TraceID:         "1234",
+					RootServiceName: "root",
+				},
+			}
 
-		return &http.Response{
-			Body:       io.NopCloser(strings.NewReader(resString)),
-			StatusCode: 200,
-		}, nil
-	})
+			next := RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				response := &tempopb.SearchResponse{
+					Traces:  traceResp,
+					Metrics: &tempopb.SearchMetrics{},
+				}
+				resString, err := (&jsonpb.Marshaler{}).MarshalToString(response)
+				require.NoError(t, err)
 
-	srv := newMockStreamingServer(nil)
-	handler := testHandler(t, next)
-	err := handler(&tempopb.SearchRequest{
-		Start: 1000,
-		End:   1500,
-		Query: "{}",
-	}, srv)
-	require.NoError(t, err)
-	// confirm final result is expected
-	require.Equal(t,
-		*srv.lastResponse.Load(),
-		&tempopb.SearchResponse{
-			Traces: traceResp,
-			Metrics: &tempopb.SearchMetrics{
-				TotalBlocks:     1,
-				CompletedJobs:   2,
-				TotalJobs:       2,
-				TotalBlockBytes: 209715200,
-			},
-		},
-	)
+				return &http.Response{
+					Body:       io.NopCloser(strings.NewReader(resString)),
+					StatusCode: 200,
+				}, nil
+			})
+
+			srv := newMockStreamingServer(tc.tenants, nil)
+			handler := testHandler(t, next)
+			err := handler(&tempopb.SearchRequest{
+				Start: 1000,
+				End:   1500,
+				Query: "{}",
+			}, srv)
+			require.NoError(t, err)
+
+			// confirm final result is expected and metrics are merged
+			lastResp := *srv.lastResponse.Load()
+			expectedLastResp := &tempopb.SearchResponse{
+				Traces: traceResp,
+				Metrics: &tempopb.SearchMetrics{
+					TotalBlocks:     tc.tenantSize,
+					CompletedJobs:   2 * tc.tenantSize,
+					TotalJobs:       2 * tc.tenantSize,
+					TotalBlockBytes: uint64(209715200 * tc.tenantSize),
+				},
+			}
+
+			require.Equal(t, expectedLastResp, lastResp)
+		})
+	}
 }
 
 func TestStreamingSearchHandlerStreams(t *testing.T) {
-	traceResp := []*tempopb.TraceSearchMetadata{
+	tests := []struct {
+		name       string
+		tenants    string
+		tenantSize uint32
+	}{
 		{
-			TraceID:         "1234",
-			RootServiceName: "root",
+			name:       "single tenant",
+			tenants:    "single-tenant",
+			tenantSize: 1,
+		},
+		{
+			name:       "multiple tenants",
+			tenants:    "tenant-1|tenant-2|tenant-3",
+			tenantSize: 3,
 		},
 	}
 
-	next := RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
-		time.Sleep(1 * time.Second) // forces the streaming responses to work
-
-		response := &tempopb.SearchResponse{
-			Traces:  traceResp,
-			Metrics: &tempopb.SearchMetrics{},
-		}
-		resString, err := (&jsonpb.Marshaler{}).MarshalToString(response)
-		require.NoError(t, err)
-
-		return &http.Response{
-			Body:       io.NopCloser(strings.NewReader(resString)),
-			StatusCode: 200,
-		}, nil
-	})
-
-	srv := newMockStreamingServer(
-		func(n int, r *tempopb.SearchResponse) {
-			if len(r.Traces) > 0 {
-				// if we have some traces confirm it's what is expected
-				require.Equal(t, r,
-					&tempopb.SearchResponse{
-						Traces: traceResp,
-						Metrics: &tempopb.SearchMetrics{
-							TotalBlocks:     1,
-							CompletedJobs:   r.Metrics.CompletedJobs,
-							TotalJobs:       2,
-							TotalBlockBytes: 209715200,
-						},
-					},
-				)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			traceResp := []*tempopb.TraceSearchMetadata{
+				{
+					TraceID:         "1234",
+					RootServiceName: "root",
+				},
 			}
-		},
-	)
-	handler := testHandler(t, next)
-	err := handler(&tempopb.SearchRequest{
-		Start: 1000,
-		End:   1500,
-		Query: "{}",
-	}, srv)
-	require.NoError(t, err)
-	require.GreaterOrEqual(t, srv.responses.Load(), int32(3)) // confirm that our server got 3 or more sends
+
+			next := RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				time.Sleep(1 * time.Second) // forces the streaming responses to work
+
+				response := &tempopb.SearchResponse{
+					Traces:  traceResp,
+					Metrics: &tempopb.SearchMetrics{},
+				}
+				resString, err := (&jsonpb.Marshaler{}).MarshalToString(response)
+				require.NoError(t, err)
+
+				return &http.Response{
+					Body:       io.NopCloser(strings.NewReader(resString)),
+					StatusCode: 200,
+				}, nil
+			})
+
+			srv := newMockStreamingServer(tc.tenants,
+				func(n int, r *tempopb.SearchResponse) {
+					if len(r.Traces) > 0 {
+						// if we have some traces confirm it's what is expected
+						require.Equal(t, r,
+							&tempopb.SearchResponse{
+								Traces: traceResp,
+								Metrics: &tempopb.SearchMetrics{
+									TotalBlocks:     tc.tenantSize,
+									CompletedJobs:   r.Metrics.CompletedJobs,
+									TotalJobs:       2 * tc.tenantSize,
+									TotalBlockBytes: uint64(209715200 * tc.tenantSize),
+								},
+							},
+						)
+					}
+				},
+			)
+			handler := testHandler(t, next)
+			err := handler(&tempopb.SearchRequest{
+				Start: 1000,
+				End:   1500,
+				Query: "{}",
+			}, srv)
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, srv.responses.Load(), int32(3)) // confirm that our server got 3 or more sends
+		})
+	}
 }
 
 func TestStreamingSearchHandlerCancels(t *testing.T) {
-	next := RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
-		time.Sleep(24 * time.Hour) // will break any test time limits
-		return nil, nil
-	})
+	tests := []struct {
+		name    string
+		tenants string
+	}{
+		{
+			name:    "single tenant",
+			tenants: "single-tenant",
+		},
+		{
+			name:    "multiple tenants",
+			tenants: "tenant-1|tenant-2|tenant-3",
+		},
+	}
 
-	var cancel context.CancelFunc
-	srv := newMockStreamingServer(nil)
-	srv.ctx, cancel = context.WithCancel(srv.ctx)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			next := RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				time.Sleep(24 * time.Hour) // will break any test time limits
+				return nil, nil
+			})
 
-	go func() {
-		time.Sleep(500 * time.Millisecond)
-		cancel()
-	}()
+			var cancel context.CancelFunc
+			srv := newMockStreamingServer(tc.tenants, nil)
+			srv.ctx, cancel = context.WithCancel(srv.ctx)
 
-	handler := testHandler(t, next)
-	err := handler(&tempopb.SearchRequest{
-		Start: 1000,
-		End:   1500,
-		Query: "{}",
-	}, srv)
-	require.Equal(t, context.Canceled, err)
+			go func() {
+				time.Sleep(500 * time.Millisecond)
+				cancel()
+			}()
+
+			handler := testHandler(t, next)
+			err := handler(&tempopb.SearchRequest{
+				Start: 1000,
+				End:   1500,
+				Query: "{}",
+			}, srv)
+			require.Equal(t, context.Canceled, err)
+		})
+	}
 }
 
 func TestStreamingSearchHandlerFailsDueToStatusCode(t *testing.T) {
-	next := RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
-		return &http.Response{
-			Body:       io.NopCloser(strings.NewReader("error")),
-			StatusCode: 500,
-		}, nil
-	})
+	tests := []struct {
+		name    string
+		tenants string
+	}{
+		{
+			name:    "single tenant",
+			tenants: "single-tenant",
+		},
+		{
+			name:    "multiple tenants",
+			tenants: "tenant-1|tenant-2|tenant-3",
+		},
+	}
 
-	srv := newMockStreamingServer(nil)
-	handler := testHandler(t, next)
-	err := handler(&tempopb.SearchRequest{
-		Start: 1000,
-		End:   1500,
-		Query: "{}",
-	}, srv)
-	require.Error(t, err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			next := RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				return &http.Response{
+					Body:       io.NopCloser(strings.NewReader("error")),
+					StatusCode: 500,
+				}, nil
+			})
+			srv := newMockStreamingServer(tc.tenants, nil)
+			handler := testHandler(t, next)
+			err := handler(&tempopb.SearchRequest{
+				Start: 1000,
+				End:   1500,
+				Query: "{}",
+			}, srv)
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestStreamingSearchHandlerFailsDueToError(t *testing.T) {
-	next := RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
-		return nil, errors.New("error")
-	})
+	tests := []struct {
+		name    string
+		tenants string
+	}{
+		{
+			name:    "single tenant",
+			tenants: "single-tenant",
+		},
+		{
+			name:    "multiple tenants",
+			tenants: "tenant-1|tenant-2|tenant-3",
+		},
+	}
 
-	srv := newMockStreamingServer(nil)
-	handler := testHandler(t, next)
-	err := handler(&tempopb.SearchRequest{
-		Start: 1000,
-		End:   1500,
-		Query: "{}",
-	}, srv)
-	require.Error(t, err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			next := RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				return nil, errors.New("error")
+			})
+
+			srv := newMockStreamingServer(tc.tenants, nil)
+			handler := testHandler(t, next)
+			err := handler(&tempopb.SearchRequest{
+				Start: 1000,
+				End:   1500,
+				Query: "{}",
+			}, srv)
+			require.Error(t, err)
+		})
+	}
 }
 
 func testHandler(t *testing.T, next http.RoundTripper) streamingSearchHandler {
@@ -219,6 +315,7 @@ func testHandler(t *testing.T, next http.RoundTripper) streamingSearchHandler {
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			},
 		},
+		MultiTenantQueriesEnabled: true, // to test multi-tenant
 	}, o, next, &mockReader{
 		metas: []*backend.BlockMeta{ // one block with 2 records that are each the target bytes per request will force 2 sub queries
 			{
@@ -357,9 +454,7 @@ func TestMultiProgress(t *testing.T) {
 	ctx := context.Background()
 
 	diffProgress := newDiffSearchProgress(ctx, 0, 0, 0, 0)
-	p1 := atomic.NewPointer[*diffSearchProgress](nil)
-	p1.Store(&diffProgress)
-	mp.Add(p1)
+	mp.Add(diffProgress)
 
 	// first request should be empty
 	require.Equal(t, &tempopb.SearchResponse{
@@ -415,9 +510,7 @@ func TestMultiProgress(t *testing.T) {
 
 	// now let's add another diffProgress
 	diffProgress2 := newDiffSearchProgress(ctx, 0, 0, 0, 0)
-	p2 := atomic.NewPointer[*diffSearchProgress](nil)
-	p2.Store(&diffProgress2)
-	mp.Add(p2)
+	mp.Add(diffProgress2)
 
 	// second diffProgress is empty, so results should be same
 	require.Equal(t, &tempopb.SearchResponse{
@@ -474,7 +567,7 @@ func TestMultiProgress(t *testing.T) {
 				StartTimeUnixNano: 1, // forces order
 			},
 		},
-		Metrics: &tempopb.SearchMetrics{
+		Metrics: &tempopb.SearchMetrics{ // metrics should be summed
 			CompletedJobs:   2,
 			InspectedTraces: 2,
 			InspectedBytes:  4,

--- a/modules/frontend/searchsharding.go
+++ b/modules/frontend/searchsharding.go
@@ -151,7 +151,7 @@ func (s searchSharder) RoundTrip(r *http.Request) (*http.Response, error) {
 
 	// execute requests
 	wg := boundedwaitgroup.New(uint(s.cfg.ConcurrentRequests))
-	progress := s.progress(ctx, int(searchReq.Limit), totalJobs, totalBlocks, totalBlockBytes)
+	progress := s.progress(ctx, int(searchReq.Limit), uint32(totalJobs), uint32(totalBlocks), totalBlockBytes)
 
 	startedReqs := 0
 	for req := range reqCh {


### PR DESCRIPTION
**What this PR does**:

Add multi-tenant query support in streaming search endpoints.

follow up on https://github.com/grafana/tempo/pull/3087

**Which issue(s) this PR fixes**:
Fixes #1858

```[tasklist]
### Tasks
- [x] multi-tenant streaming Search works
- [x] test for multiProgress
- [x] fix metrics in streamed results
- [x] test that streaming actually streams
```

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`