### PR TITLE
Remove multi-tenancy config in docker-compose examples

### DIFF
--- a/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
+++ b/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
@@ -50,6 +50,6 @@ services:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_DISABLE_LOGIN_FORM=true
-      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor
+      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor traceQLStreaming metricsSummary
     ports:
       - "3000:3000"

--- a/example/docker-compose/shared/tempo.yaml
+++ b/example/docker-compose/shared/tempo.yaml
@@ -1,4 +1,3 @@
-multitenancy_enabled: true
 stream_over_http_enabled: true
 server:
   http_listen_port: 3200


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Removes `multitenancy_enabled: true` in non-multi-tenant` docker-compose examples

**Which issue(s) this PR fixes**:
Fixes #3260 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`