### PR TITLE
Fix frontend metric names to not collide with GET

### DIFF
--- a/integration/e2e/multi_tenant_test.go
+++ b/integration/e2e/multi_tenant_test.go
@@ -174,7 +174,7 @@ func TestMultiTenantSearch(t *testing.T) {
 					require.NoError(t, err)
 					// we should have 8 requests for each tenant
 					err = tempo.WaitSumMetricsWithOptions(e2e.Equals(8),
-						[]string{"tempo_tenant_federation_success_total"},
+						[]string{"tempo_query_frontend_multitenant_success_total"},
 						e2e.WithLabelMatchers(matcher),
 					)
 					require.NoError(t, err)

--- a/modules/frontend/tenant.go
+++ b/modules/frontend/tenant.go
@@ -28,16 +28,16 @@ var ErrMultiTenantUnsupported = errors.New("multi-tenant query unsupported")
 var (
 	tenantSuccessTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: "tempo",
-			Name:      "tenant_federation_success_total",
+			Namespace: "tempo_query_frontend",
+			Name:      "multitenant_success_total",
 			Help:      "Total number of successful fetches of a trace per tenant.",
 		},
 		[]string{tenantLabel})
 
 	tenantFailureTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: "tempo",
-			Name:      "tenant_federation_failures_total",
+			Namespace: "tempo_query_frontend",
+			Name:      "multitenant_failures_total",
 			Help:      "Total number of failing fetches of a trace per tenant.",
 		},
 		[]string{tenantLabel, statusCodeLabel})


### PR DESCRIPTION
**What this PR does**:
Recently added metrics collided with names in GET. This PR changes the names to reflect the fact that they are frontend multitenant metrics and also to avoid the collision.

cc @electron0zero 
