### PR TITLE
Ensure 429 internal status is passed back to the caller

### DIFF
--- a/modules/frontend/searchsharding_test.go
+++ b/modules/frontend/searchsharding_test.go
@@ -552,6 +552,13 @@ func TestSearchSharderRoundTrip(t *testing.T) {
 			expectedStatus: 500,
 		},
 		{
+			name:           "200+429",
+			status1:        200,
+			response1:      &tempopb.SearchResponse{Metrics: &tempopb.SearchMetrics{}},
+			status2:        429,
+			expectedStatus: 429,
+		},
+		{
 			name:           "500+404",
 			status1:        500,
 			status2:        404,

--- a/modules/frontend/tracebyidsharding_test.go
+++ b/modules/frontend/tracebyidsharding_test.go
@@ -120,6 +120,13 @@ func TestShardingWareDoRequest(t *testing.T) {
 			expectedStatus: 500,
 		},
 		{
+			name:           "200+429",
+			status1:        200,
+			trace1:         trace1,
+			status2:        429,
+			expectedStatus: 429,
+		},
+		{
 			name:           "503+200",
 			status1:        503,
 			status2:        200,


### PR DESCRIPTION
**What this PR does**:

Here we ensure that 429 on the search and tracebyid paths are returned to the caller instead of a 500.

**Which issue(s) this PR fixes**:
Fixes #2843

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`