### PR TITLE
Upgrade otel/build-protobuf image for apple silicon compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GOPATH := $(shell go env GOPATH)
 GORELEASER := $(GOPATH)/bin/goreleaser
 
 # Build Images
-DOCKER_PROTOBUF_IMAGE ?= otel/build-protobuf:0.14.0
+DOCKER_PROTOBUF_IMAGE ?= otel/build-protobuf:0.23.0
 LOKI_BUILD_IMAGE ?= grafana/loki-build-image:0.21.0
 DOCS_IMAGE ?= grafana/docs-base:latest
 


### PR DESCRIPTION
**What this PR does**:
This fixes compatibility issues with Apple silicon (m1/2/3) and `make gen-proto`.  Previously it would fail with the error: 
```
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
--gogofaster_out: protoc-gen-gogofaster: Plugin killed by signal 11.
```

**Note** I didn't pin down the exact change that fixed it. Any version 0.18+ works, so it was likely in [this diff](https://github.com/open-telemetry/build-tools/commit/312c7ff0a2faa52cb0d6d363c8968316e1b94c1c#diff-a8bde4bfc923aab18efd4967f7b92bf5eb95095043616a52e2b49b151a1f1a02) but I'm not sure it's as simple as the TARGETARCH changes.  I am using `DOCKER_DEFAULT_PLATFORM=linux/amd64` to force running non-arm images already.  And confirm this with:

```
$ docker inspect otel/build-protobuf:0.23.0
......
        "Architecture": "amd64",
        "Os": "linux",
```

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`