### PR TITLE
Fix autocomplete panic when condition has wrong type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 * [BUGFIX] Prevent building parquet iterators that would loop forever. [#3159](https://github.com/grafana/tempo/pull/3159) (@mapno)
 * [BUGFIX] Sanitize name in mapped dimensions in span-metrics processor [#3171](https://github.com/grafana/tempo/pull/3171) (@mapno)
 * [BUGFIX] Fixed an issue where cached footers were requested then ignored. [#3196](https://github.com/grafana/tempo/pull/3196) (@joe-elliott)
-* [BUGFIX] Fix panic in autocomplete when query condition had wrong type [#](https://github.com/grafana/tempo/pull/) (@mapno)
+* [BUGFIX] Fix panic in autocomplete when query condition had wrong type [#3277](https://github.com/grafana/tempo/pull/3277) (@mapno)
 
 ## v2.3.1 / 2023-11-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [BUGFIX] Prevent building parquet iterators that would loop forever. [#3159](https://github.com/grafana/tempo/pull/3159) (@mapno)
 * [BUGFIX] Sanitize name in mapped dimensions in span-metrics processor [#3171](https://github.com/grafana/tempo/pull/3171) (@mapno)
 * [BUGFIX] Fixed an issue where cached footers were requested then ignored. [#3196](https://github.com/grafana/tempo/pull/3196) (@joe-elliott)
+* [BUGFIX] Fix panic in autocomplete when query condition had wrong type [#](https://github.com/grafana/tempo/pull/) (@mapno)
 
 ## v2.3.1 / 2023-11-28
 

--- a/tempodb/encoding/vparquet3/block_autocomplete.go
+++ b/tempodb/encoding/vparquet3/block_autocomplete.go
@@ -359,6 +359,10 @@ func createDistinctAttributeIterator(
 			keyIter = makeIter(keyPath, parquetquery.NewStringInPredicate([]string{cond.Attribute.Name}), selectAs("key", cond.Attribute))
 			valIter = makeIter(boolPath, pred, selectAs("bool", cond.Attribute))
 		default:
+			// Generic attributes don't support special types (e.g. duration, status, kind)
+			// If we get here, it means we're trying to search for a special type in a generic attribute
+			// e.g. { span.foo = 1s }
+			// This is not supported. Condition will be ignored.
 			continue
 		}
 

--- a/tempodb/encoding/vparquet3/block_autocomplete.go
+++ b/tempodb/encoding/vparquet3/block_autocomplete.go
@@ -358,6 +358,8 @@ func createDistinctAttributeIterator(
 			}
 			keyIter = makeIter(keyPath, parquetquery.NewStringInPredicate([]string{cond.Attribute.Name}), selectAs("key", cond.Attribute))
 			valIter = makeIter(boolPath, pred, selectAs("bool", cond.Attribute))
+		default:
+			continue
 		}
 
 		iters = append(iters, parquetquery.NewJoinIterator(definitionLevel, []parquetquery.Iterator{keyIter, valIter}, nil))
@@ -378,7 +380,6 @@ func createDistinctAttributeIterator(
 	}
 
 	if len(valueIters) > 0 || len(iters) > 0 {
-
 		if len(valueIters) > 0 {
 			tagIter, err := parquetquery.NewLeftJoinIterator(
 				definitionLevel,

--- a/tempodb/encoding/vparquet3/block_autocomplete_test.go
+++ b/tempodb/encoding/vparquet3/block_autocomplete_test.go
@@ -248,6 +248,14 @@ func TestFetchTagValues(t *testing.T) {
 			query:          `{ .namespace="namespace"}`,
 			expectedValues: []tempopb.TagValue{intTagValue(123), intTagValue(1234), stringTagValue("myservice"), stringTagValue("service2"), stringTagValue("spanservicename"), stringTagValue("spanservicename2")},
 		},
+		{
+			name:  "query with wrong op types - conditions are ignored",
+			tag:   "status",
+			query: `{resource.service.name="myservice" && span.http.status_code=server && resource.namespace=server}`,
+			expectedValues: []tempopb.TagValue{
+				{Type: "keyword", Value: "error"},
+			},
+		},
 	}
 
 	ctx := context.TODO()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

It prevents a panic when a filtering query is passed to `/search/tag/<tag>/values` with a attribute condition (`.a=b`) where `b` is a special type (`server/client`, `ok/error/unset`) but `.a` is of a different type (`string`, `int`). For example, `span.http.status_code=server`. This would create iterators with nil predicates and panics when it called `iter.Next()`.

Now, such conditions are ignored and iterators are not built for them.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`