### PR TITLE
Implement prometheus datasource health check

### DIFF
--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -519,7 +519,7 @@ func (t *App) writeStatusEndpoints(w io.Writer) error {
 }
 
 func (t *App) buildinfoHandler() http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		err := json.NewEncoder(w).Encode(build.GetVersion())
 
@@ -529,5 +529,13 @@ func (t *App) buildinfoHandler() http.HandlerFunc {
 		} else {
 			w.WriteHeader(http.StatusOK)
 		}
+	}
+}
+
+func (t *App) twoHundredHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, "{}")
+		w.WriteHeader(http.StatusOK)
 	}
 }

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -399,6 +399,10 @@ func (t *App) initQueryFrontend() (services.Service, error) {
 	t.Server.HTTP.Handle(addHTTPAPIPrefix(&t.cfg, api.PathMetricsQueryRange), base.Wrap(queryFrontend.QueryRangeHandler))
 	t.Server.HTTP.Handle(addHTTPAPIPrefix(&t.cfg, api.PathPromQueryRange), base.Wrap(queryFrontend.QueryRangeHandler))
 
+	// prometheus datasource health check
+	t.Server.HTTP.Handle(addHTTPAPIPrefix(&t.cfg, api.PathPromStatusBuildInfo), base.Wrap(t.buildinfoHandler()))
+	t.Server.HTTP.Handle(addHTTPAPIPrefix(&t.cfg, api.PathPromQuery), base.Wrap(t.twoHundredHandler()))
+
 	// the query frontend needs to have knowledge of the blocks so it can shard search jobs
 	t.store.EnablePolling(context.Background(), nil)
 

--- a/pkg/api/http.go
+++ b/pkg/api/http.go
@@ -84,7 +84,9 @@ const (
 	PathSpanMetricsSummary = "/api/metrics/summary"
 	PathMetricsQueryRange  = "/api/metrics/query_range"
 
-	PathPromQueryRange = "/prom/api/v1/query_range"
+	PathPromStatusBuildInfo = "/prom/api/v1/status/buildinfo"
+	PathPromQueryRange      = "/prom/api/v1/query_range"
+	PathPromQuery           = "/prom/api/v1/query"
 
 	// PathOverrides user configurable overrides
 	PathOverrides = "/api/overrides"


### PR DESCRIPTION
**What this PR does**:
Here we implement the two endpoints necessary to pass the "test" check when Tempo is used as a Prometheus data source.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`