### PR TITLE
FIX-2605: Make span.resource.xyz attributes work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main / unreleased
 
 * [FEATURE] Add support for multi-tenant queries. [#3087](https://github.com/grafana/tempo/pull/3087) (@electron0zero)
+* [BUGFIX] Make span.resource.xyz attributes work. [#3284](https://github.com/grafana/tempo/pull/3284) (@mghildiy)
 * [BUGFIX] Change exit code if config is successfully verified [#3174](https://github.com/grafana/tempo/pull/3174) (@am3o @agrib-01)
 * [BUGFIX] The tempo-cli analyse blocks command no longer fails on compacted blocks [#3183](https://github.com/grafana/tempo/pull/3183) (@stoewer)
 * [BUGFIX] Move waitgroup handling for poller error condition [#3224](https://github.com/grafana/tempo/pull/3224) (@zalegrala)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## main / unreleased
 
 * [FEATURE] Add support for multi-tenant queries. [#3087](https://github.com/grafana/tempo/pull/3087) (@electron0zero)
-* [BUGFIX] Make span.resource.xyz attributes work. [#3284](https://github.com/grafana/tempo/pull/3284) (@mghildiy)
+* [BUGFIX] Fix parsing of span.resource.xyz attributes in TraceQL. [#3284](https://github.com/grafana/tempo/pull/3284) (@mghildiy)
 * [BUGFIX] Change exit code if config is successfully verified [#3174](https://github.com/grafana/tempo/pull/3174) (@am3o @agrib-01)
 * [BUGFIX] The tempo-cli analyse blocks command no longer fails on compacted blocks [#3183](https://github.com/grafana/tempo/pull/3183) (@stoewer)
 * [BUGFIX] Move waitgroup handling for poller error condition [#3224](https://github.com/grafana/tempo/pull/3224) (@zalegrala)

--- a/pkg/traceql/lexer.go
+++ b/pkg/traceql/lexer.go
@@ -87,6 +87,7 @@ type lexer struct {
 	errs   []*ParseError
 
 	parsingAttribute bool
+	currentScope     int
 }
 
 func (l *lexer) Lex(lval *yySymType) int {
@@ -100,8 +101,9 @@ func (l *lexer) Lex(lval *yySymType) int {
 
 	if l.parsingAttribute {
 		// parse out any scopes here
-		scopeToken, ok := tryScopeAttribute(&l.Scanner)
+		scopeToken, ok := tryScopeAttribute(&l.Scanner, l.currentScope)
 		if ok {
+			l.currentScope = scopeToken
 			return scopeToken
 		}
 
@@ -184,6 +186,10 @@ func (l *lexer) Lex(lval *yySymType) int {
 		break
 	}
 
+	if multiTok == PARENT_DOT || multiTok == SPAN_DOT || multiTok == RESOURCE_DOT {
+		l.currentScope = multiTok
+	}
+
 	// did we find a combination token?
 	if multiTok != -1 {
 		l.parsingAttribute = startsAttribute(multiTok)
@@ -258,7 +264,7 @@ func parseQuotedAtrribute(s *scanner.Scanner) (string, error) {
 	return sb.String(), nil
 }
 
-func tryScopeAttribute(l *scanner.Scanner) (int, bool) {
+func tryScopeAttribute(l *scanner.Scanner, currentScope int) (int, bool) {
 	// copy the scanner to avoid advancing if it's not a scope.
 	s := *l
 	str := ""
@@ -270,7 +276,8 @@ func tryScopeAttribute(l *scanner.Scanner) (int, bool) {
 		str += string(s.Next())
 	}
 	tok := tokens[str]
-	if tok == RESOURCE_DOT || tok == SPAN_DOT {
+
+	if (tok == SPAN_DOT || tok == RESOURCE_DOT) && currentScope == PARENT_DOT {
 		// we have found scope attribute so consume the original scanner
 		for i := 0; i < len(str); i++ {
 			l.Next()

--- a/pkg/traceql/lexer_test.go
+++ b/pkg/traceql/lexer_test.go
@@ -128,6 +128,28 @@ func TestLexerParseDuration(t *testing.T) {
 	}
 }
 
+func TestLexerScoping(t *testing.T) {
+	testLexer(t, ([]lexerTestCase{
+		{`span.foo3`, []int{SPAN_DOT, IDENTIFIER, END_ATTRIBUTE}},
+		{`span.foo+bar`, []int{SPAN_DOT, IDENTIFIER, END_ATTRIBUTE}},
+		{`span.foo-bar`, []int{SPAN_DOT, IDENTIFIER, END_ATTRIBUTE}},
+		{`span.resource.foo`, []int{SPAN_DOT, IDENTIFIER, END_ATTRIBUTE}},
+		{`parent.span.foo`, []int{PARENT_DOT, SPAN_DOT, IDENTIFIER, END_ATTRIBUTE}},
+		{`span.foo.bar`, []int{SPAN_DOT, IDENTIFIER, END_ATTRIBUTE}},
+		// resource attributes
+		{`resource.foo`, []int{RESOURCE_DOT, IDENTIFIER, END_ATTRIBUTE}},
+		{`resource.count`, []int{RESOURCE_DOT, IDENTIFIER, END_ATTRIBUTE}},
+		{`resource.foo3`, []int{RESOURCE_DOT, IDENTIFIER, END_ATTRIBUTE}},
+		{`resource.foo+bar`, []int{RESOURCE_DOT, IDENTIFIER, END_ATTRIBUTE}},
+		{`resource.foo-bar`, []int{RESOURCE_DOT, IDENTIFIER, END_ATTRIBUTE}},
+		{`resource.span.foo`, []int{RESOURCE_DOT, IDENTIFIER, END_ATTRIBUTE}},
+		// parent span attributes
+		{`parent.span.foo`, []int{PARENT_DOT, SPAN_DOT, IDENTIFIER, END_ATTRIBUTE}},
+		{`parent.span.count`, []int{PARENT_DOT, SPAN_DOT, IDENTIFIER, END_ATTRIBUTE}},
+		{`parent.span.resource.id`, []int{PARENT_DOT, SPAN_DOT, IDENTIFIER, END_ATTRIBUTE}},
+	}))
+}
+
 func testLexer(t *testing.T, tcs []lexerTestCase) {
 	for _, tc := range tcs {
 		t.Run(tc.input, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**Solves the error when searching for span attributes that start with resource.**:

**Which issue(s) this PR fixes**:
Fixes #2605

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`