### PR TITLE
[Traceql Metrics] Variety of performance improvements

### DIFF
--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -729,7 +729,8 @@ func BenchmarkBackendBlockQueryRange(b *testing.B) {
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				eval.Do(ctx, f)
+				err := eval.Do(ctx, f)
+				require.NoError(b, err)
 			}
 		})
 	}

--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -584,12 +584,12 @@ func BenchmarkBackendBlockTraceQL(b *testing.B) {
 
 	ctx := context.TODO()
 	tenantID := "1"
-	blockID := uuid.MustParse("00000c2f-8133-4a60-a62a-7748bd146938")
-	// blockID := uuid.MustParse("06ebd383-8d4e-4289-b0e9-cf2197d611d5")
+	// blockID := uuid.MustParse("00000c2f-8133-4a60-a62a-7748bd146938")
+	blockID := uuid.MustParse("06ebd383-8d4e-4289-b0e9-cf2197d611d5")
 
 	r, _, _, err := local.New(&local.Config{
-		Path: path.Join("/home/joe/testblock/"),
-		// Path: path.Join("/Users/marty/src/tmp"),
+		// Path: path.Join("/home/joe/testblock/"),
+		Path: path.Join("/Users/marty/src/tmp"),
 	})
 	require.NoError(b, err)
 
@@ -674,6 +674,62 @@ func BenchmarkBackendBlockGetMetrics(b *testing.B) {
 
 				require.NoError(b, err)
 				require.NotNil(b, r)
+			}
+		})
+	}
+}
+
+func BenchmarkBackendBlockQueryRange(b *testing.B) {
+	testCases := []string{
+		"{} | rate()",
+		"{} | rate() by (name)",
+		"{} | rate() by (resource.service.name)",
+		"{resource.service.name=`tempo-gateway`} | rate()",
+		"{status=error} | rate()",
+	}
+
+	var (
+		ctx      = context.TODO()
+		e        = traceql.NewEngine()
+		opts     = common.DefaultSearchOptions()
+		tenantID = "1"
+		blockID  = uuid.MustParse("06ebd383-8d4e-4289-b0e9-cf2197d611d5")
+		path     = "/Users/marty/src/tmp/"
+	)
+
+	r, _, _, err := local.New(&local.Config{
+		Path: path,
+	})
+	require.NoError(b, err)
+
+	rr := backend.NewReader(r)
+	meta, err := rr.BlockMeta(ctx, blockID, tenantID)
+	require.NoError(b, err)
+	require.Equal(b, VersionString, meta.Version)
+
+	block := newBackendBlock(meta, rr)
+	_, _, err = block.openForSearch(ctx, opts)
+	require.NoError(b, err)
+
+	f := traceql.NewSpansetFetcherWrapper(func(ctx context.Context, req traceql.FetchSpansRequest) (traceql.FetchSpansResponse, error) {
+		return block.Fetch(ctx, req, opts)
+	})
+
+	for _, tc := range testCases {
+		b.Run(tc, func(b *testing.B) {
+			req := &tempopb.QueryRangeRequest{
+				Query: tc,
+				Step:  uint64(time.Minute),
+				Start: uint64(meta.StartTime.UnixNano()),
+				End:   uint64(meta.EndTime.UnixNano()),
+			}
+
+			eval, err := e.CompileMetricsQueryRange(req, false)
+			require.NoError(b, err)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				eval.Do(ctx, f)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This contains some query optimizations for TraceQL metrics queries, and some low-level tweaks in parquetquery.  **Update** I removed the more aggressive string clone cache.  The memory benefit for metrics queries was very good, but there was a slight regression in searches.  This is because a metrics query will exhaust every value of some string intrinsic/attribute whereas a search will exit early after finding enough matches.  Will need to revisit this area after some more thought.

Metrics:
```
                                                                           │ before_queryrange.txt │        after_queryrange2.txt        │
                                                                           │        sec/op         │   sec/op     vs base                │
BackendBlockQueryRange/{}_|_rate()-12                                                   1.557 ± 1%    1.553 ± 1%        ~ (p=0.684 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)-12                                         5.967 ± 3%    4.409 ± 3%  -26.11% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)-12                        5.080 ± 2%    3.677 ± 3%  -27.62% (p=0.000 n=10)
BackendBlockQueryRange/{resource.service.name=`tempo-gateway`}_|_rate()-12             57.53m ± 1%   56.95m ± 1%        ~ (p=0.063 n=10)
BackendBlockQueryRange/{status=error}_|_rate()-12                                     7877.3m ± 1%   389.1m ± 1%  -95.06% (p=0.000 n=10)
geomean                                                                                 1.845        889.8m       -51.78%

                                                                           │ before_queryrange.txt │         after_queryrange2.txt          │
                                                                           │         B/op          │      B/op       vs base                │
BackendBlockQueryRange/{}_|_rate()-12                                                40.97Mi ± 77%   42.08Mi ±  78%        ~ (p=0.954 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)-12                                      767.9Mi ±  8%   385.8Mi ±  13%  -49.75% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)-12                    387.04Mi ± 12%   40.48Mi ± 156%  -89.54% (p=0.000 n=10)
BackendBlockQueryRange/{resource.service.name=`tempo-gateway`}_|_rate()-12           2.023Mi ± 34%   2.346Mi ±  16%        ~ (p=0.143 n=10)
BackendBlockQueryRange/{status=error}_|_rate()-12                                   39.641Mi ±  7%   5.057Mi ±  77%  -87.24% (p=0.000 n=10)
geomean                                                                              62.80Mi         23.90Mi         -61.94%

                                                                           │ before_queryrange.txt │        after_queryrange2.txt        │
                                                                           │       allocs/op       │  allocs/op   vs base                │
BackendBlockQueryRange/{}_|_rate()-12                                                 22.80k ±  0%   22.80k ± 0%        ~ (p=0.923 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)-12                                       13.04M ±  0%   11.78M ± 4%   -9.66% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)-12                      3.311M ± 14%   2.051M ± 0%  -38.05% (p=0.000 n=10)
BackendBlockQueryRange/{resource.service.name=`tempo-gateway`}_|_rate()-12            30.36k ±  0%   30.35k ± 0%        ~ (p=0.402 n=10)
BackendBlockQueryRange/{status=error}_|_rate()-12                                    594.25k ±  1%   36.64k ± 0%  -93.83% (p=0.000 n=10)
geomean                                                                               446.6k         227.7k       -49.00%
```


Searches:
```
                                                 │ before_traceql.txt │         after_traceql2.txt         │
                                                 │       sec/op       │   sec/op     vs base               │
BackendBlockTraceQL/spanAttValNoMatch-12                 1.686m ±  5%   1.695m ± 1%       ~ (p=0.684 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-12           1.307m ±  1%   1.301m ± 1%  -0.42% (p=0.015 n=10)
BackendBlockTraceQL/resourceAttValNoMatch-12             1.273m ±  8%   1.264m ± 1%       ~ (p=0.075 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-12         12.79m ±  1%   12.98m ± 1%  +1.46% (p=0.000 n=10)
BackendBlockTraceQL/mixedValNoMatch-12                   150.7m ±  3%   147.6m ± 0%  -2.05% (p=0.001 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd-12             1.301m ±  3%   1.285m ± 1%       ~ (p=0.075 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr-12              138.2m ±  5%   138.7m ± 0%       ~ (p=0.280 n=10)
BackendBlockTraceQL/count-12                             209.2m ±  0%   209.4m ± 0%       ~ (p=0.190 n=10)
BackendBlockTraceQL/struct-12                            379.3m ± 10%   384.0m ± 2%       ~ (p=0.481 n=10)
BackendBlockTraceQL/||-12                                126.2m ±  4%   117.1m ± 0%  -7.23% (p=0.000 n=10)
BackendBlockTraceQL/mixed-12                             20.97m ±  5%   21.13m ± 1%       ~ (p=0.165 n=10)
geomean                                                  19.99m         19.86m       -0.68%

                                                 │ before_traceql.txt │         after_traceql2.txt          │
                                                 │        B/s         │     B/s       vs base               │
BackendBlockTraceQL/spanAttValNoMatch-12                 1.135Gi ± 4%   1.129Gi ± 1%       ~ (p=0.684 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-12           1.057Gi ± 1%   1.061Gi ± 1%  +0.42% (p=0.015 n=10)
BackendBlockTraceQL/resourceAttValNoMatch-12             331.2Mi ± 7%   333.5Mi ± 1%       ~ (p=0.075 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-12         1.038Gi ± 1%   1.023Gi ± 1%  -1.43% (p=0.000 n=10)
BackendBlockTraceQL/mixedValNoMatch-12                   14.95Mi ± 3%   15.27Mi ± 0%  +2.10% (p=0.001 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd-12             333.5Mi ± 3%   337.6Mi ± 1%       ~ (p=0.075 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr-12              110.6Mi ± 4%   110.2Mi ± 0%       ~ (p=0.305 n=10)
BackendBlockTraceQL/count-12                             66.38Mi ± 0%   66.30Mi ± 0%       ~ (p=0.198 n=10)
BackendBlockTraceQL/struct-12                            7.496Mi ± 9%   7.410Mi ± 2%       ~ (p=0.516 n=10)
BackendBlockTraceQL/||-12                                112.7Mi ± 4%   121.4Mi ± 0%  +7.78% (p=0.000 n=10)
BackendBlockTraceQL/mixed-12                             666.8Mi ± 4%   661.8Mi ± 1%       ~ (p=0.165 n=10)
geomean                                                  185.8Mi        187.1Mi       +0.69%

                                                 │ before_traceql.txt │          after_traceql2.txt          │
                                                 │      MB_io/op      │  MB_io/op    vs base                 │
BackendBlockTraceQL/spanAttValNoMatch-12                   2.054 ± 0%    2.054 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/spanAttIntrinsicNoMatch-12             1.483 ± 0%    1.483 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/resourceAttValNoMatch-12              442.0m ± 0%   442.0m ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/resourceAttIntrinsicMatch-12           14.25 ± 0%    14.25 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixedValNoMatch-12                     2.363 ± 0%    2.363 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixedValMixedMatchAnd-12              455.0m ± 0%   455.0m ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixedValMixedMatchOr-12                16.02 ± 0%    16.02 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/count-12                               14.56 ± 0%    14.56 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/struct-12                              2.982 ± 0%    2.982 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/||-12                                  14.91 ± 0%    14.91 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixed-12                               14.66 ± 0%    14.66 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                    3.896         3.896       +0.00%
¹ all samples are equal

                                                 │ before_traceql.txt │          after_traceql2.txt          │
                                                 │        B/op        │     B/op       vs base               │
BackendBlockTraceQL/spanAttValNoMatch-12                1.745Mi ±  1%   1.752Mi ±  1%       ~ (p=0.105 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-12          1.293Mi ±  2%   1.290Mi ±  1%       ~ (p=0.853 n=10)
BackendBlockTraceQL/resourceAttValNoMatch-12            1.260Mi ±  2%   1.270Mi ±  1%       ~ (p=0.143 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-12        1.498Mi ±  5%   1.509Mi ±  7%       ~ (p=0.684 n=10)
BackendBlockTraceQL/mixedValNoMatch-12                  2.464Mi ± 29%   2.108Mi ± 17%       ~ (p=0.971 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd-12            1.273Mi ±  1%   1.275Mi ±  1%       ~ (p=0.912 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr-12             2.460Mi ± 20%   2.269Mi ± 30%       ~ (p=0.353 n=10)
BackendBlockTraceQL/count-12                            247.5Mi ±  1%   246.7Mi ±  1%       ~ (p=0.353 n=10)
BackendBlockTraceQL/struct-12                           18.47Mi ± 10%   19.11Mi ±  8%       ~ (p=0.853 n=10)
BackendBlockTraceQL/||-12                               115.2Mi ±  0%   115.3Mi ±  0%       ~ (p=0.971 n=10)
BackendBlockTraceQL/mixed-12                            1.536Mi ±  5%   1.565Mi ±  7%       ~ (p=0.393 n=10)
geomean                                                 4.731Mi         4.659Mi        -1.51%

                                                 │ before_traceql.txt │          after_traceql2.txt          │
                                                 │     allocs/op      │  allocs/op   vs base                 │
BackendBlockTraceQL/spanAttValNoMatch-12                  18.66k ± 0%   18.67k ± 0%       ~ (p=0.650 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-12            18.57k ± 0%   18.57k ± 0%       ~ (p=1.000 n=10)
BackendBlockTraceQL/resourceAttValNoMatch-12              18.60k ± 0%   18.60k ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/resourceAttIntrinsicMatch-12          20.34k ± 0%   20.34k ± 0%       ~ (p=0.706 n=10)
BackendBlockTraceQL/mixedValNoMatch-12                    19.66k ± 0%   19.66k ± 0%       ~ (p=0.749 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd-12              18.68k ± 0%   18.68k ± 0%       ~ (p=1.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr-12               26.98k ± 0%   26.97k ± 0%       ~ (p=0.360 n=10)
BackendBlockTraceQL/count-12                              1.426M ± 0%   1.426M ± 0%       ~ (p=0.239 n=10)
BackendBlockTraceQL/struct-12                             179.7k ± 0%   179.7k ± 0%       ~ (p=0.564 n=10)
BackendBlockTraceQL/||-12                                 667.0k ± 0%   666.3k ± 0%  -0.09% (p=0.000 n=10)
BackendBlockTraceQL/mixed-12                              21.84k ± 0%   21.84k ± 0%       ~ (p=0.453 n=10)
geomean                                                   49.97k        49.97k       -0.01%
```


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`