### PR TITLE
Bring back localblocks filtering with config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * [CHANGE] Make vParquet3 the default block encoding [#2526](https://github.com/grafana/tempo/pull/3134) (@stoewer)
 * [CHANGE] Set `autocomplete_filtering_enabled` to `true` by default [#3178](https://github.com/grafana/tempo/pull/3178) (@mapno)
 * [CHANGE] Update Alpine image version to 3.19 [#3289](https://github.com/grafana/tempo/pull/3289) (@zalegrala)
-* [CHANGE] Introduce localblocks process config option to select only server spans [#???](https://github.com/grafana/tempo/pull/???) (@zalegrala)
+* [CHANGE] Introduce localblocks process config option to select only server spans 3303https://github.com/grafana/tempo/pull/3303 (@zalegrala)
 * [CHANGE] Major cache refactor to allow multiple role based caches to be configured [#3166](https://github.com/grafana/tempo/pull/3166).
   **BREAKING CHANGE** Deprecate the following fields. These have all been migrated to a top level "cache:" field.
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [CHANGE] Make vParquet3 the default block encoding [#2526](https://github.com/grafana/tempo/pull/3134) (@stoewer)
 * [CHANGE] Set `autocomplete_filtering_enabled` to `true` by default [#3178](https://github.com/grafana/tempo/pull/3178) (@mapno)
 * [CHANGE] Update Alpine image version to 3.19 [#3289](https://github.com/grafana/tempo/pull/3289) (@zalegrala)
+* [CHANGE] Introduce localblocks process config option to select only server spans [#???](https://github.com/grafana/tempo/pull/???) (@zalegrala)
 * [CHANGE] Major cache refactor to allow multiple role based caches to be configured [#3166](https://github.com/grafana/tempo/pull/3166).
   **BREAKING CHANGE** Deprecate the following fields. These have all been migrated to a top level "cache:" field.
   ```

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -1335,6 +1335,7 @@ overrides:
           [trace_idle_period: <duration>]
           [complete_block_timeout: <duration>]
           [concurrent_blocks: <duration>]
+          [filter_server_spans: <bool>]
 
     # Generic forwarding configuration
 

--- a/modules/generator/processor/localblocks/config.go
+++ b/modules/generator/processor/localblocks/config.go
@@ -40,4 +40,5 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.MaxBlockBytes = 500_000_000
 	cfg.CompleteBlockTimeout = time.Hour
 	cfg.ConcurrentBlocks = 10
+	cfg.FilterServerSpans = true
 }

--- a/modules/generator/processor/localblocks/config.go
+++ b/modules/generator/processor/localblocks/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	CompleteBlockTimeout time.Duration         `yaml:"complete_block_timeout"`
 	MaxLiveTraces        uint64                `yaml:"max_live_traces"`
 	ConcurrentBlocks     uint                  `yaml:"concurrent_blocks"`
+	FilterServerSpans    bool                  `yaml:"filter_server_spans"`
 }
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {


### PR DESCRIPTION
**What this PR does**:

Here we bring back the localblocks processor filtering for kind==server, but with a config option to modify the code path.

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`