### PR TITLE
Local blocks processor honor per-tenant max trace size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [CHANGE] Set `autocomplete_filtering_enabled` to `true` by default [#3178](https://github.com/grafana/tempo/pull/3178) (@mapno)
 * [CHANGE] Update Alpine image version to 3.19 [#3289](https://github.com/grafana/tempo/pull/3289) (@zalegrala)
 * [CHANGE] Introduce localblocks process config option to select only server spans 3303https://github.com/grafana/tempo/pull/3303 (@zalegrala)
+* [CHANGE] Localblocks processor honor tenant max trace size limit [3305](https://github.com/grafana/tempo/pull/3305) (@mdisibio)
 * [CHANGE] Major cache refactor to allow multiple role based caches to be configured [#3166](https://github.com/grafana/tempo/pull/3166).
   **BREAKING CHANGE** Deprecate the following fields. These have all been migrated to a top level "cache:" field.
   ```

--- a/modules/generator/overrides.go
+++ b/modules/generator/overrides.go
@@ -33,6 +33,7 @@ type metricsGeneratorOverrides interface {
 	MetricsGeneratorProcessorServiceGraphsEnableClientServerPrefix(userID string) bool
 	MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(userID string) []string
 	DedicatedColumns(userID string) backend.DedicatedColumns
+	MaxBytesPerTrace(userID string) int
 }
 
 var _ metricsGeneratorOverrides = (overrides.Interface)(nil)

--- a/modules/generator/overrides_test.go
+++ b/modules/generator/overrides_test.go
@@ -28,6 +28,7 @@ type mockOverrides struct {
 	localBlocksTraceIdlePeriod              time.Duration
 	localBlocksCompleteBlockTimeout         time.Duration
 	dedicatedColumns                        backend.DedicatedColumns
+	maxBytesPerTrace                        int
 }
 
 var _ metricsGeneratorOverrides = (*mockOverrides)(nil)
@@ -128,4 +129,8 @@ func (m *mockOverrides) MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDi
 
 func (m *mockOverrides) DedicatedColumns(string) backend.DedicatedColumns {
 	return m.dedicatedColumns
+}
+
+func (m *mockOverrides) MaxBytesPerTrace(string) int {
+	return m.maxBytesPerTrace
 }

--- a/modules/generator/processor/localblocks/livetraces.go
+++ b/modules/generator/processor/localblocks/livetraces.go
@@ -1,15 +1,12 @@
 package localblocks
 
 import (
-	"errors"
 	"hash"
 	"hash/fnv"
 	"time"
 
 	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 )
-
-var errMaxExceeded = errors.New("asdf")
 
 type liveTrace struct {
 	id        []byte

--- a/modules/generator/processor/localblocks/livetraces.go
+++ b/modules/generator/processor/localblocks/livetraces.go
@@ -22,7 +22,7 @@ type liveTraces struct {
 func newLiveTraces() *liveTraces {
 	return &liveTraces{
 		hash:   fnv.New64(),
-		traces: map[uint64]*liveTrace{},
+		traces: make(map[uint64]*liveTrace),
 	}
 }
 
@@ -36,7 +36,7 @@ func (l *liveTraces) Len() uint64 {
 	return uint64(len(l.traces))
 }
 
-func (l *liveTraces) Push(traceID []byte, batches []*v1.ResourceSpans, maxTraces uint64) bool {
+func (l *liveTraces) Push(traceID []byte, batch *v1.ResourceSpans, max uint64) bool {
 	token := l.token(traceID)
 
 	tr := l.traces[token]
@@ -44,7 +44,7 @@ func (l *liveTraces) Push(traceID []byte, batches []*v1.ResourceSpans, maxTraces
 
 		// Before adding this check against max
 		// Zero means no limit
-		if maxTraces > 0 && uint64(len(l.traces)) >= maxTraces {
+		if max > 0 && uint64(len(l.traces)) >= max {
 			return false
 		}
 
@@ -54,7 +54,7 @@ func (l *liveTraces) Push(traceID []byte, batches []*v1.ResourceSpans, maxTraces
 		l.traces[token] = tr
 	}
 
-	tr.Batches = append(tr.Batches, batches...)
+	tr.Batches = append(tr.Batches, batch)
 	tr.timestamp = time.Now()
 	return true
 }

--- a/modules/generator/processor/localblocks/metrics.go
+++ b/modules/generator/processor/localblocks/metrics.go
@@ -10,6 +10,7 @@ const (
 	subsystem = "metrics_generator_processor_local_blocks"
 
 	reasonLiveTracesExceeded = "live_traces_exceeded"
+	reasonTraceSizeExceeded  = "trace_too_large"
 )
 
 var (
@@ -25,6 +26,12 @@ var (
 		Name:      "spans_total",
 		Help:      "Total number of spans after filtering",
 	}, []string{"tenant"})
+	metricDroppedSpans = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: subsystem,
+		Name:      "spans_dropped_total",
+		Help:      "Number of spans dropped",
+	}, []string{"tenant", "reason"})
 	metricLiveTraces = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: namespace,
 		Subsystem: subsystem,

--- a/modules/generator/processor/localblocks/processor_test.go
+++ b/modules/generator/processor/localblocks/processor_test.go
@@ -25,6 +25,10 @@ func (m *mockOverrides) DedicatedColumns(string) backend.DedicatedColumns {
 	return nil
 }
 
+func (m *mockOverrides) MaxBytesPerTrace(string) int {
+	return 0
+}
+
 func TestProcessorDoesNotRace(t *testing.T) {
 	wal, err := wal.New(&wal.Config{
 		Filepath: t.TempDir(),

--- a/modules/generator/processor/localblocks/traceSizes.go
+++ b/modules/generator/processor/localblocks/traceSizes.go
@@ -21,7 +21,7 @@ type traceSize struct {
 func newTraceSizes() *traceSizes {
 	return &traceSizes{
 		hash:  fnv.New64(),
-		sizes: map[uint64]*traceSize{},
+		sizes: make(map[uint64]*traceSize),
 	}
 }
 

--- a/modules/generator/processor/localblocks/traceSizes.go
+++ b/modules/generator/processor/localblocks/traceSizes.go
@@ -31,9 +31,9 @@ func (s *traceSizes) token(traceID []byte) uint64 {
 	return s.hash.Sum64()
 }
 
-// Allow returns true if the total previously received plus incoming sizes are less than
-// or equal to the max.  The incoming data size is added to the historical total even
-// if not allowed, so that when the max limit changes it still evalulates as expected.
+// Allow returns true if the historical total plus incoming size is less than
+// or equal to the max.  The historical total is kept alive and incremented even
+// if not allowed, so that long-running traces are cutoff as expected.
 func (s *traceSizes) Allow(traceID []byte, sz, max int) bool {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
@@ -46,6 +46,7 @@ func (s *traceSizes) Allow(traceID []byte, sz, max int) bool {
 		}
 		s.sizes[token] = tr
 	}
+
 	tr.timestamp = time.Now()
 	tr.size += sz
 

--- a/modules/generator/processor/localblocks/traceSizes.go
+++ b/modules/generator/processor/localblocks/traceSizes.go
@@ -1,0 +1,64 @@
+package localblocks
+
+import (
+	"hash"
+	"hash/fnv"
+	"sync"
+	"time"
+)
+
+type traceSizes struct {
+	mtx   sync.Mutex
+	hash  hash.Hash64
+	sizes map[uint64]*traceSize
+}
+
+type traceSize struct {
+	size      int
+	timestamp time.Time
+}
+
+func newTraceSizes() *traceSizes {
+	return &traceSizes{
+		hash:  fnv.New64(),
+		sizes: map[uint64]*traceSize{},
+	}
+}
+
+func (s *traceSizes) token(traceID []byte) uint64 {
+	s.hash.Reset()
+	s.hash.Write(traceID)
+	return s.hash.Sum64()
+}
+
+// Allow returns true if the total previously received plus incoming sizes are less than
+// or equal to the max.  The incoming data size is added to the historical total even
+// if not allowed, so that when the max limit changes it still evalulates as expected.
+func (s *traceSizes) Allow(traceID []byte, sz, max int) bool {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	token := s.token(traceID)
+	tr := s.sizes[token]
+	if tr == nil {
+		tr = &traceSize{
+			size: sz,
+		}
+		s.sizes[token] = tr
+	}
+	tr.timestamp = time.Now()
+	tr.size += sz
+
+	return tr.size <= max
+}
+
+func (s *traceSizes) ClearIdle(idleSince time.Time) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	for token, tr := range s.sizes {
+		if tr.timestamp.Before(idleSince) {
+			delete(s.sizes, token)
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does**:
Updates the local-blocks processor to honor the per-tenant override `max_trace_bytes`.  The generators already make use of the per-tenant overrides but this field.  This goes one step further than the trace size limits in the ingesters.  The ingesters keep track of the historical trace size only for the lifetime of the headblock, and that means long-running traces can eventually append more data.  This goes one step further and maintains the historical trace size for as long as the trace is active (continues to send spans).

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`