### PR TITLE
Change spanmetrics filtering with multiple policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 * [BUGFIX] Change exit code if config is successfully verified [#3174](https://github.com/grafana/tempo/pull/3174) (@am3o @agrib-01)
 * [BUGFIX] The tempo-cli analyse blocks command no longer fails on compacted blocks [#3183](https://github.com/grafana/tempo/pull/3183) (@stoewer)
 * [BUGFIX] Move waitgroup handling for poller error condition [#3224](https://github.com/grafana/tempo/pull/3224) (@zalegrala)
-* [BUGFIX] Continue evaluating spanmetrics filter policies even if the first one doesn't match [#3308](https://github.com/grafana/tempo/pull/3308) (@zalegrala)
 * [ENHANCEMENT] Introduced `AttributePolicyMatch` & `IntrinsicPolicyMatch` structures to match span attributes based on strongly typed values & precompiled regexp [#3025](https://github.com/grafana/tempo/pull/3025) (@andriusluk)
 * [CHANGE] TraceQL/Structural operators performance improvement. [#3088](https://github.com/grafana/tempo/pull/3088) (@joe-elliott)
 * [CHANGE] Merge the processors overrides set through runtime overrides and user-configurable overrides [#3125](https://github.com/grafana/tempo/pull/3125) (@kvrhdn)
@@ -15,6 +14,74 @@
 * [CHANGE] Update Alpine image version to 3.19 [#3289](https://github.com/grafana/tempo/pull/3289) (@zalegrala)
 * [CHANGE] Introduce localblocks process config option to select only server spans 3303https://github.com/grafana/tempo/pull/3303 (@zalegrala)
 * [CHANGE] Localblocks processor honor tenant max trace size limit [3305](https://github.com/grafana/tempo/pull/3305) (@mdisibio)
+* [CHANGE] Continue evaluating spanmetrics filter policies even if not matched in one policy [#3308](https://github.com/grafana/tempo/pull/3308) (@zalegrala)
+  **BREAKING CHANGE** Exclude policies are no longer global
+
+  The documentation currently suggests the following policy to include and
+  exclude using two filter policies.
+
+  ```
+    metrics_generator:
+      processor:
+        span_metrics:
+          filter_policies:
+            - include:
+                match_type: regex
+                attributes:
+                  - key: resource.location
+                    value: eu-.*
+            - exclude:
+                match_type: regex
+                attributes:
+                  - key: resource.tier
+                    value: dev-.*
+  ```
+
+  Currently, at the first non-matching filter, the span is dropped.  The
+  breaking change here is that when an include is not matched, we continue
+  evaluating additional policies for possible matches.  In the above scenario,
+  each exclude must now be paired with the include that it wishes to further
+  filter.  The above can be re-written with the include and exclude in the same
+  policy filter.
+
+  ```
+    metrics_generator:
+      processor:
+        span_metrics:
+          filter_policies:
+            - include:
+                match_type: regex
+                attributes:
+                  - key: resource.location
+                    value: eu-.*
+              exclude:
+                match_type: regex
+                attributes:
+                  - key: resource.tier
+                    value: dev-.*
+  ```
+
+  Users are now able to write an additional filter policy that matches on the
+  same attribute (`resource.location`), where previously the first non-match
+  was used as a reason not to include the span.
+
+  ```
+    metrics_generator:
+      processor:
+        span_metrics:
+          filter_policies:
+            - include:
+                match_type: regex
+                attributes:
+                  - key: resource.location
+                    value: eu-.*
+            - include:
+                match_type: static
+                attributes:
+                  - key: resource.location
+                    value: moon
+  ```
+
 * [CHANGE] Major cache refactor to allow multiple role based caches to be configured [#3166](https://github.com/grafana/tempo/pull/3166).
   **BREAKING CHANGE** Deprecate the following fields. These have all been migrated to a top level "cache:" field.
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [BUGFIX] Change exit code if config is successfully verified [#3174](https://github.com/grafana/tempo/pull/3174) (@am3o @agrib-01)
 * [BUGFIX] The tempo-cli analyse blocks command no longer fails on compacted blocks [#3183](https://github.com/grafana/tempo/pull/3183) (@stoewer)
 * [BUGFIX] Move waitgroup handling for poller error condition [#3224](https://github.com/grafana/tempo/pull/3224) (@zalegrala)
+* [BUGFIX] Continue evaluating spanmetrics filter policies even if the first one doesn't match [#3308](https://github.com/grafana/tempo/pull/3308) (@zalegrala)
 * [ENHANCEMENT] Introduced `AttributePolicyMatch` & `IntrinsicPolicyMatch` structures to match span attributes based on strongly typed values & precompiled regexp [#3025](https://github.com/grafana/tempo/pull/3025) (@andriusluk)
 * [CHANGE] TraceQL/Structural operators performance improvement. [#3088](https://github.com/grafana/tempo/pull/3088) (@joe-elliott)
 * [CHANGE] Merge the processors overrides set through runtime overrides and user-configurable overrides [#3125](https://github.com/grafana/tempo/pull/3125) (@kvrhdn)

--- a/docs/sources/tempo/metrics-generator/span_metrics.md
+++ b/docs/sources/tempo/metrics-generator/span_metrics.md
@@ -125,8 +125,8 @@ func (ds RatioBasedSampler) Description() string {
 
 ### Filtering
 
-In some cases, you may want to reduce the number of metrics that are produced
-from the `spanmetrics` processor by using a filter. With a filter, you can
+In some cases, you may want to use a filter to reduce the number of metrics that are produced
+from the `spanmetrics` processor. With a filter, you can
 configure the processor to use an `include` statement to match criteria that
 must be present in the span in order to be included in the metrics. Following
 the include filter, you can use an `exclude` filter to reject portions of what

--- a/docs/sources/tempo/metrics-generator/span_metrics.md
+++ b/docs/sources/tempo/metrics-generator/span_metrics.md
@@ -290,7 +290,7 @@ included, but both cases also exclude spans which match
 `{resource.tier="research"}`.
 
 This example could also be written with a single regex expression, except that
-in the second policy we have an additional constraint to match against for
+in the second policy has an additional constraint to match against for
 `k8s-.*`.  If either the `resource.location` or the `resource.platform` is not
 matched in the second policy, then the span is not included.
 

--- a/docs/sources/tempo/metrics-generator/span_metrics.md
+++ b/docs/sources/tempo/metrics-generator/span_metrics.md
@@ -247,10 +247,10 @@ metrics_generator:
                 value: dev-.*
 ```
 
-In the above, we first include all spans which have a `resource.location` that
+The above example first includes all spans which have a `resource.location` that
 begins with `eu-` with the `include` statement, and then `exclude` those with
-begin with `dev-`. In this way, a flexible approach to filtering can be
-achieved to store only those metrics which are important.
+begin with `dev-`. In this way, you can create a flexible approach to filtering to store 
+only those metrics which are important.
 
 Additionally, when multiple filter policies are are used, any policy that is
 matched results in the span being included in the metric export.

--- a/docs/sources/tempo/metrics-generator/span_metrics.md
+++ b/docs/sources/tempo/metrics-generator/span_metrics.md
@@ -162,12 +162,12 @@ used to *reject* spans from the metrics.  With no filter polices applied, all
 spans are included.
 
 {{% admonition type="note" %}}
-An exclude match will take precedence over an include match within the *same*
+An exclude match takes precedence over an include match within the *same*
 policy, but not later polices.
 {{% /admonition %}}
 
 {{% admonition type="note" %}}
-A matching exclude of one policy will be ignored if a later policy `include`
+A matching exclude of one policy is ignored if a later policy `include`
 matches, and that same policy does not also have a matching `exclude` for the
 span.
 {{% /admonition %}}

--- a/docs/sources/tempo/metrics-generator/span_metrics.md
+++ b/docs/sources/tempo/metrics-generator/span_metrics.md
@@ -285,8 +285,8 @@ metrics_generator:
                 value: research
 ```
 
-In this example, spans that match a location beginning with `eu-` or `sa-` will
-be included, but in both cases we also exclude spans which match
+In this example, spans that match a location beginning with `eu-` or `sa-` are 
+included, but both cases also exclude spans which match
 `{resource.tier="research"}`.
 
 This example could also be written with a single regex expression, except that

--- a/docs/sources/tempo/metrics-generator/span_metrics.md
+++ b/docs/sources/tempo/metrics-generator/span_metrics.md
@@ -253,7 +253,7 @@ begin with `dev-`. In this way, a flexible approach to filtering can be
 achieved to store only those metrics which are important.
 
 Additionally, when multiple filter policies are are used, any policy that is
-matched will result in the span being included in the metric export.
+matched results in the span being included in the metric export.
 
 ```yaml
 ---

--- a/docs/sources/tempo/metrics-generator/span_metrics.md
+++ b/docs/sources/tempo/metrics-generator/span_metrics.md
@@ -156,10 +156,10 @@ The following intrinsic kinds are available for filtering.
 
 #### Filter policies
 
-Each filter policy is evaluated in order for every span to determine if the
-span should be included for metrics.  Both `include` and `exclude` policies are
-used to *reject* spans from the metrics.  With no filter polices applied, all
-spans are included.
+Each filter policy is evaluated for every span until an `include` policy is
+matched without a corresponding `exclude` policy match within the same filter.
+Both `include` and `exclude` policies are used to *reject* spans from the
+metrics.  With no filter polices applied, all spans are included.
 
 {{% admonition type="note" %}}
 An exclude match takes precedence over an include match within the *same*

--- a/docs/sources/tempo/metrics-generator/span_metrics.md
+++ b/docs/sources/tempo/metrics-generator/span_metrics.md
@@ -126,7 +126,7 @@ func (ds RatioBasedSampler) Description() string {
 ### Filtering
 
 In some cases, you may want to reduce the number of metrics that are produced
-from the `spanmetrics` processor by using a filter. With a filter you can
+from the `spanmetrics` processor by using a filter. With a filter, you can
 configure the processor to use an `include` statement to match criteria that
 must be present in the span in order to be included in the metrics. Following
 the include filter, you can use an `exclude` filter to reject portions of what

--- a/pkg/spanfilter/spanfilter.go
+++ b/pkg/spanfilter/spanfilter.go
@@ -56,17 +56,21 @@ func (f *SpanFilter) ApplyFilterPolicy(rs *v1.Resource, span *tracev1.Span) bool
 		return true
 	}
 
+	var policyMatch int
+
 	for _, policy := range f.filterPolicies {
 		if policy.Include != nil && !policy.Include.Match(rs, span) {
-			return false
+			continue
 		}
 
 		if policy.Exclude != nil && policy.Exclude.Match(rs, span) {
-			return false
+			continue
 		}
+
+		policyMatch++
 	}
 
-	return true
+	return policyMatch > 0
 }
 
 func getSplitPolicy(policy *config.PolicyMatch) (*splitPolicy, error) {

--- a/pkg/spanfilter/spanfilter.go
+++ b/pkg/spanfilter/spanfilter.go
@@ -49,28 +49,59 @@ func NewSpanFilter(filterPolicies []config.FilterPolicy) (*SpanFilter, error) {
 	}, nil
 }
 
-// ApplyFilterPolicy returns true if the span should be included in the metrics.
+// ApplyFilterPolicy returns true if the span should be included in the
+// metrics.  Each filter policy is evaluated in order.
 func (f *SpanFilter) ApplyFilterPolicy(rs *v1.Resource, span *tracev1.Span) bool {
 	// With no filter policies specified, all spans are included.
 	if len(f.filterPolicies) == 0 {
 		return true
 	}
 
-	var policyMatch int
+	var (
+		included bool // a policy matched and included the span
+		excluded bool // a policy matched and excluded the span
+		tries    int  // the number of attempts to exclude a span
+	)
 
 	for _, policy := range f.filterPolicies {
-		if policy.Include != nil && !policy.Include.Match(rs, span) {
-			continue
+		// if both matched, the span is excluded unless included by a later policy
+		// if neither matched, the span is included
+		// if the include policy matched, but the exclude policy did not, include the span
+		// if the exclude policy matched, but the include policy did not, exclude the span
+		// if only exclude policies are specified, and none match, include the span
+		// if only exclude policies are specified, and any match, exclude the span
+
+		if policy.Include != nil {
+			if policy.Include.Match(rs, span) {
+				included = true
+				if policy.Exclude != nil {
+					// continue to check additional policies for inclusion
+					if policy.Exclude.Match(rs, span) {
+						excluded = true
+						continue
+					}
+				}
+				return true
+			}
 		}
 
-		if policy.Exclude != nil && policy.Exclude.Match(rs, span) {
-			continue
+		if policy.Exclude != nil {
+			tries++
+			if policy.Exclude.Match(rs, span) {
+				excluded = true
+			}
 		}
-
-		policyMatch++
 	}
 
-	return policyMatch > 0
+	// attempts were made to exclude the span
+	if tries > 0 {
+		// we didn't include nor exclude the span, include it
+		if !included && !excluded {
+			return true
+		}
+	}
+
+	return false
 }
 
 func getSplitPolicy(policy *config.PolicyMatch) (*splitPolicy, error) {

--- a/pkg/spanfilter/spanfilter_test.go
+++ b/pkg/spanfilter/spanfilter_test.go
@@ -6,12 +6,13 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/tempo/pkg/spanfilter/config"
 	"github.com/grafana/tempo/pkg/tempopb"
 	commonv1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
 	v1 "github.com/grafana/tempo/pkg/tempopb/resource/v1"
 	tracev1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSpanFilter_NewSpanFilter(t *testing.T) {
@@ -448,6 +449,54 @@ func TestSpanMetrics_applyFilterPolicy(t *testing.T) {
 						Value: &commonv1.AnyValue{
 							Value: &commonv1.AnyValue_StringValue{
 								StringValue: "somethinginteresting",
+							},
+						},
+					},
+				},
+			},
+			span: &tracev1.Span{
+				Kind: tracev1.Span_SPAN_KIND_SERVER,
+				Status: &tracev1.Status{
+					Code: tracev1.Status_STATUS_CODE_OK,
+				},
+				Name: "test",
+			},
+		},
+		{
+			name:   "multiple includes with only one matching",
+			err:    nil,
+			expect: true,
+			filterPolicies: []config.FilterPolicy{
+				{
+					Include: &config.PolicyMatch{
+						MatchType: config.Regex,
+						Attributes: []config.MatchPolicyAttribute{
+							{
+								Key:   "name",
+								Value: "(test|test2)",
+							},
+						},
+					},
+				},
+				{
+					Include: &config.PolicyMatch{
+						MatchType: config.Regex,
+						Attributes: []config.MatchPolicyAttribute{
+							{
+								Key:   "name",
+								Value: "(untest|untest2)",
+							},
+						},
+					},
+				},
+			},
+			resource: &v1.Resource{
+				Attributes: []*commonv1.KeyValue{
+					{
+						Key: "name",
+						Value: &commonv1.AnyValue{
+							Value: &commonv1.AnyValue_StringValue{
+								StringValue: "untest",
 							},
 						},
 					},

--- a/pkg/spanfilter/spanfilter_test.go
+++ b/pkg/spanfilter/spanfilter_test.go
@@ -510,6 +510,274 @@ func TestSpanMetrics_applyFilterPolicy(t *testing.T) {
 				Name: "test",
 			},
 		},
+		{
+			name:   "multiple excludes with only one matching",
+			err:    nil,
+			expect: false,
+			filterPolicies: []config.FilterPolicy{
+				{
+					Exclude: &config.PolicyMatch{
+						MatchType: config.Regex,
+						Attributes: []config.MatchPolicyAttribute{
+							{
+								Key:   "name",
+								Value: "(test|test2)",
+							},
+						},
+					},
+				},
+				{
+					Exclude: &config.PolicyMatch{
+						MatchType: config.Strict,
+						Attributes: []config.MatchPolicyAttribute{
+							{
+								Key:   "name",
+								Value: "asd",
+							},
+						},
+					},
+				},
+				{
+					Exclude: &config.PolicyMatch{
+						MatchType: config.Regex,
+						Attributes: []config.MatchPolicyAttribute{
+							{
+								Key:   "name",
+								Value: "(tset|tset2)",
+							},
+						},
+					},
+				},
+			},
+			resource: &v1.Resource{
+				Attributes: []*commonv1.KeyValue{
+					{
+						Key: "name",
+						Value: &commonv1.AnyValue{
+							Value: &commonv1.AnyValue_StringValue{
+								StringValue: "untest",
+							},
+						},
+					},
+				},
+			},
+			span: &tracev1.Span{
+				Kind: tracev1.Span_SPAN_KIND_SERVER,
+				Status: &tracev1.Status{
+					Code: tracev1.Status_STATUS_CODE_OK,
+				},
+				Name: "tset2",
+			},
+		},
+		{
+			name:   "multiple excludes with none matching",
+			err:    nil,
+			expect: true,
+			filterPolicies: []config.FilterPolicy{
+				{
+					Exclude: &config.PolicyMatch{
+						MatchType: config.Regex,
+						Attributes: []config.MatchPolicyAttribute{
+							{
+								Key:   "name",
+								Value: "(test|test2)",
+							},
+						},
+					},
+				},
+				{
+					Exclude: &config.PolicyMatch{
+						MatchType: config.Strict,
+						Attributes: []config.MatchPolicyAttribute{
+							{
+								Key:   "name",
+								Value: "asd",
+							},
+						},
+					},
+				},
+				{
+					Exclude: &config.PolicyMatch{
+						MatchType: config.Regex,
+						Attributes: []config.MatchPolicyAttribute{
+							{
+								Key:   "name",
+								Value: "(tset|tset2)",
+							},
+						},
+					},
+				},
+			},
+			resource: &v1.Resource{
+				Attributes: []*commonv1.KeyValue{
+					{
+						Key: "name",
+						Value: &commonv1.AnyValue{
+							Value: &commonv1.AnyValue_StringValue{
+								StringValue: "untest",
+							},
+						},
+					},
+				},
+			},
+			span: &tracev1.Span{
+				Kind: tracev1.Span_SPAN_KIND_SERVER,
+				Status: &tracev1.Status{
+					Code: tracev1.Status_STATUS_CODE_OK,
+				},
+				Name: "blarg",
+			},
+		},
+		{
+			name:   "one matching include, but excluded for name",
+			err:    nil,
+			expect: false,
+			filterPolicies: []config.FilterPolicy{
+				{
+					Exclude: &config.PolicyMatch{
+						MatchType: config.Regex,
+						Attributes: []config.MatchPolicyAttribute{
+							{
+								Key:   "name",
+								Value: "(test|test2)",
+							},
+						},
+					},
+				},
+				{
+					Exclude: &config.PolicyMatch{
+						MatchType: config.Strict,
+						Attributes: []config.MatchPolicyAttribute{
+							{
+								Key:   "name",
+								Value: "asd",
+							},
+						},
+					},
+				},
+				{
+					Include: &config.PolicyMatch{
+						MatchType: config.Strict,
+						Attributes: []config.MatchPolicyAttribute{
+							{
+								Key:   "kind",
+								Value: "SPAN_KIND_SERVER",
+							},
+						},
+					},
+					Exclude: &config.PolicyMatch{
+						MatchType: config.Regex,
+						Attributes: []config.MatchPolicyAttribute{
+							{
+								Key:   "name",
+								Value: "(tset|tset2)",
+							},
+						},
+					},
+				},
+			},
+			span: &tracev1.Span{
+				Kind: tracev1.Span_SPAN_KIND_SERVER,
+				Status: &tracev1.Status{
+					Code: tracev1.Status_STATUS_CODE_OK,
+				},
+				Name: "tset2",
+			},
+		},
+		{
+			name:   "one matching include",
+			err:    nil,
+			expect: true,
+			filterPolicies: []config.FilterPolicy{
+				{
+					Exclude: &config.PolicyMatch{
+						MatchType: config.Regex,
+						Attributes: []config.MatchPolicyAttribute{
+							{
+								Key:   "name",
+								Value: "(test|test2)",
+							},
+						},
+					},
+				},
+				{
+					Exclude: &config.PolicyMatch{
+						MatchType: config.Strict,
+						Attributes: []config.MatchPolicyAttribute{
+							{
+								Key:   "name",
+								Value: "asd",
+							},
+						},
+					},
+				},
+				{
+					Include: &config.PolicyMatch{
+						MatchType: config.Strict,
+						Attributes: []config.MatchPolicyAttribute{
+							{
+								Key:   "kind",
+								Value: "SPAN_KIND_SERVER",
+							},
+						},
+					},
+				},
+			},
+			span: &tracev1.Span{
+				Kind: tracev1.Span_SPAN_KIND_SERVER,
+				Status: &tracev1.Status{
+					Code: tracev1.Status_STATUS_CODE_OK,
+				},
+				Name: "tset2",
+			},
+		},
+		{
+			name:   "none matching",
+			err:    nil,
+			expect: true,
+			filterPolicies: []config.FilterPolicy{
+				{
+					Exclude: &config.PolicyMatch{
+						MatchType: config.Regex,
+						Attributes: []config.MatchPolicyAttribute{
+							{
+								Key:   "name",
+								Value: "(test|test2)",
+							},
+						},
+					},
+				},
+				{
+					Exclude: &config.PolicyMatch{
+						MatchType: config.Strict,
+						Attributes: []config.MatchPolicyAttribute{
+							{
+								Key:   "name",
+								Value: "asd",
+							},
+						},
+					},
+				},
+				{
+					Include: &config.PolicyMatch{
+						MatchType: config.Strict,
+						Attributes: []config.MatchPolicyAttribute{
+							{
+								Key:   "kind",
+								Value: "SPAN_KIND_SERVER",
+							},
+						},
+					},
+				},
+			},
+			span: &tracev1.Span{
+				Kind: tracev1.Span_SPAN_KIND_CLIENT,
+				Status: &tracev1.Status{
+					Code: tracev1.Status_STATUS_CODE_OK,
+				},
+				Name: "tset2",
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
**What this PR does**:

Here is an issue that was identified when trying to use multiple include policies against the same intrinsic attribute.  Without this change, multiple policies operating on the same attributes will never match since we find the first opportunity to reject a span from being included in the metrics.  Here we make a change to continue evaluating additional filter policies even if the current one is unmatched.  This means that a filter policy uses `AND` logic internally, but multiple polices use `OR` logic to determine if the span should be included.  Any filter policy that is matched will include the metric.

  **BREAKING CHANGE** Exclude policies are no longer global

  The documentation currently suggests the following policy to include and
  exclude using two filter policies.

  ```
    metrics_generator:
      processor:
        span_metrics:
          filter_policies:
            - include:
                match_type: regex
                attributes:
                  - key: resource.location
                    value: eu-.*
            - exclude:
                match_type: regex
                attributes:
                  - key: resource.tier
                    value: dev-.*
  ```

  Currently, at the first non-matching filter, the span is dropped.  The
  breaking change here is that when an include is not matched, we continue
  evaluating additional policies for possible matches.  In the above scenario,
  each exclude must now be paired with the include that it wishes to further
  filter.  The above can be re-written with the include and exclude in the same
  policy filter.

  ```
    metrics_generator:
      processor:
        span_metrics:
          filter_policies:
            - include:
                match_type: regex
                attributes:
                  - key: resource.location
                    value: eu-.*
              exclude:
                match_type: regex
                attributes:
                  - key: resource.tier
                    value: dev-.*
  ```

  Users are now able to write an additional filter policy that matches on the
  same attribute (`resource.location`), where previously the first non-match
  was used as a reason not to include the span.

  ```
    metrics_generator:
      processor:
        span_metrics:
          filter_policies:
            - include:
                match_type: regex
                attributes:
                  - key: resource.location
                    value: eu-.*
            - include:
                match_type: static
                attributes:
                  - key: resource.location
                    value: moon
  ```


**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`