### PR TITLE
Update jsonnet memcached image version for multiple CVE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * [ENHANCEMENT] Added a `frontend-search` cache role for job search caching. [#3225](https://github.com/grafana/tempo/pull/3225) (@joe-elliott)
 * [ENHANCEMENT] Added a `parquet-page` cache role for page level caching. [#3196](https://github.com/grafana/tempo/pull/3196) (@joe-elliott)
 * [ENHANCEMENT] Update opentelemetry-collector-contrib dependency to the latest version, v0.89.0 [#3148](https://github.com/grafana/tempo/pull/3148) (@gebn)
+* [ENHANCEMENT] Update memcached default image in jsonnet for multiple CVE [#3310](https://github.com/grafana/tempo/pull/3310) (@zalegrala)
 * [BUGFIX] Prevent building parquet iterators that would loop forever. [#3159](https://github.com/grafana/tempo/pull/3159) (@mapno)
 * [BUGFIX] Sanitize name in mapped dimensions in span-metrics processor [#3171](https://github.com/grafana/tempo/pull/3171) (@mapno)
 * [BUGFIX] Fixed an issue where cached footers were requested then ignored. [#3196](https://github.com/grafana/tempo/pull/3196) (@joe-elliott)

--- a/operations/jsonnet-compiled/StatefulSet-memcached.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-memcached.yaml
@@ -27,7 +27,7 @@ spec:
         - -I 5m
         - -c 4096
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.23-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/jsonnet-compiled/util/jsonnetfile.lock.json
+++ b/operations/jsonnet-compiled/util/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "f56b2115eb7789d0d0506088cd60495abfd2f656",
+      "version": "3d58bd591c278f3f342bc1e25399806c49ace104",
       "sum": "0y3AFX9LQSpfWTxWKSwoLgbt0Wc9nnCwhMH2szKzHv0="
     },
     {
@@ -18,7 +18,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "f56b2115eb7789d0d0506088cd60495abfd2f656",
+      "version": "3d58bd591c278f3f342bc1e25399806c49ace104",
       "sum": "Cc715Y3rgTuimgDFIw+FaKzXSJGRYwt1pFTMbdrNBD8="
     },
     {
@@ -28,7 +28,7 @@
           "subdir": "1.21"
         }
       },
-      "version": "44a9f3d21c089a01f62b22e25bdf553f488a74e8",
+      "version": "3e32f80d1493d1579d273d1522af1fae2cc7c97f",
       "sum": "b8GtKWztbpnnMojHt8A9sfkEgs+2t2rtvZcpDteuLFo="
     },
     {

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -4,7 +4,7 @@
     tempo_query: 'grafana/tempo-query:latest',
     tempo_vulture: 'grafana/tempo-vulture:latest',
     rollout_operator: 'grafana/rollout-operator:v0.1.1',
-    memcached: 'memcached:1.6.17-alpine',
+    memcached: 'memcached:1.6.23-alpine',
     memcachedExporter: 'prom/memcached-exporter:v0.6.0',
   },
 


### PR DESCRIPTION
**What this PR does**:

Update the default memcachced image in jsonnet to patch for multiple CVEs.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`