### PR TITLE
Fix typo in service graph metric name

### DIFF
--- a/docs/sources/tempo/metrics-generator/service-graph-view.md
+++ b/docs/sources/tempo/metrics-generator/service-graph-view.md
@@ -105,7 +105,7 @@ The grid layout changes the service graph to a series of rows and columns.
 If you are using the metrics-generator, then it processes traces and generates service graphs in the form of time series metrics like:
 
 ```yaml
-tempo_service_graph_request_total{client="app", server="db"} 20
+traces_service_graph_request_total{client="app", server="db"} 20
 ```
 
 For information about service graphs and how they are calculated, refer to the [Service Graphs documentation]({{< relref "../metrics-generator/service_graphs" >}}).

--- a/docs/sources/tempo/metrics-generator/service_graphs/_index.md
+++ b/docs/sources/tempo/metrics-generator/service_graphs/_index.md
@@ -41,7 +41,7 @@ When either of these conditions are reached, the request is recorded and removed
 Each emitted metrics series have the `client` and `server` label corresponding with the service doing the request and the service receiving the request.
 
 ```
-  tempo_service_graph_request_total{client="app", server="db", connection_type="database"} 20
+  traces_service_graph_request_total{client="app", server="db", connection_type="database"} 20
 ```
 
 ### Virtual nodes


### PR DESCRIPTION
Seems like we updated the metric names from tempo_ to traces_ in the section below, but not in this specific example.