### PR TITLE
Add HTML pages to view tenants with overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 * [ENHANCEMENT] Added a `parquet-page` cache role for page level caching. [#3196](https://github.com/grafana/tempo/pull/3196) (@joe-elliott)
 * [ENHANCEMENT] Update opentelemetry-collector-contrib dependency to the latest version, v0.89.0 [#3148](https://github.com/grafana/tempo/pull/3148) (@gebn)
 * [ENHANCEMENT] Update memcached default image in jsonnet for multiple CVE [#3310](https://github.com/grafana/tempo/pull/3310) (@zalegrala)
-* [ENHANCEMENT] Add /status/overrides/{tenant} endpoint [#3244](https://github.com/grafana/tempo/pull/3244) (@kvrhdn)
+* [ENHANCEMENT] Add HTML pages /status/overrides and /status/overrides/{tenant} [#3244](https://github.com/grafana/tempo/pull/3244) [#3332](https://github.com/grafana/tempo/pull/3332) (@kvrhdn)
 * [BUGFIX] Prevent building parquet iterators that would loop forever. [#3159](https://github.com/grafana/tempo/pull/3159) (@mapno)
 * [BUGFIX] Sanitize name in mapped dimensions in span-metrics processor [#3171](https://github.com/grafana/tempo/pull/3171) (@mapno)
 * [BUGFIX] Fixed an issue where cached footers were requested then ignored. [#3196](https://github.com/grafana/tempo/pull/3196) (@joe-elliott)

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -182,6 +182,9 @@ func (t *App) initOverrides() (services.Service, error) {
 		prometheus.MustRegister(t.Overrides)
 	}
 
+	t.Server.HTTP().Path("/status/overrides").Handler(http.HandlerFunc(t.Overrides.TenantsHandler)).Methods("GET")
+	t.Server.HTTP().Path("/status/overrides/{tenant}").Handler(http.HandlerFunc(t.Overrides.TenantStatusHandler)).Methods("GET")
+
 	return t.Overrides, nil
 }
 

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -182,8 +182,8 @@ func (t *App) initOverrides() (services.Service, error) {
 		prometheus.MustRegister(t.Overrides)
 	}
 
-	t.Server.HTTP().Path("/status/overrides").HandlerFunc(t.Overrides.TenantsHandler).Methods("GET")
-	t.Server.HTTP().Path("/status/overrides/{tenant}").HandlerFunc(t.Overrides.TenantStatusHandler).Methods("GET")
+	t.Server.HTTP().Path("/status/overrides").HandlerFunc(overrides.TenantsHandler(t.Overrides)).Methods("GET")
+	t.Server.HTTP().Path("/status/overrides/{tenant}").HandlerFunc(overrides.TenantStatusHandler(t.Overrides)).Methods("GET")
 
 	return t.Overrides, nil
 }

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -182,8 +182,8 @@ func (t *App) initOverrides() (services.Service, error) {
 		prometheus.MustRegister(t.Overrides)
 	}
 
-	t.Server.HTTP().Path("/status/overrides").Handler(http.HandlerFunc(t.Overrides.TenantsHandler)).Methods("GET")
-	t.Server.HTTP().Path("/status/overrides/{tenant}").Handler(http.HandlerFunc(t.Overrides.TenantStatusHandler)).Methods("GET")
+	t.Server.HTTP().Path("/status/overrides").HandlerFunc(t.Overrides.TenantsHandler).Methods("GET")
+	t.Server.HTTP().Path("/status/overrides/{tenant}").HandlerFunc(t.Overrides.TenantStatusHandler).Methods("GET")
 
 	return t.Overrides, nil
 }

--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -560,13 +560,17 @@ Displays the override configuration.
 Query parameter:
 - `mode = (diff)`: Show the difference between defaults and overrides.
 
-Alias: `/status/overrides`
+```
+GET /status/overrides
+```
+
+Displays all tenants that have non-default overrides configured. 
 
 ```
 GET /status/overrides/{tenant}
 ```
 
-Displays the override configuration for the specified tenant.
+Displays all overrides configured for the specified tenant.
 
 ```
 GET /status/usage-stats

--- a/modules/overrides/interface.go
+++ b/modules/overrides/interface.go
@@ -71,7 +71,4 @@ type Interface interface {
 
 	// Management API
 	WriteStatusRuntimeConfig(w io.Writer, r *http.Request) error
-
-	TenantsHandler(w http.ResponseWriter, req *http.Request)
-	TenantStatusHandler(w http.ResponseWriter, req *http.Request)
 }

--- a/modules/overrides/interface.go
+++ b/modules/overrides/interface.go
@@ -21,6 +21,9 @@ type Service interface {
 type Interface interface {
 	prometheus.Collector
 
+	// GetTenantIDs returns all tenants that have non-default overrides.
+	GetTenantIDs() []string
+
 	// GetRuntimeOverridesFor returns the runtime overrides set for the given user excluding
 	// overrides from the user-configurable overrides, if enabled.
 	GetRuntimeOverridesFor(userID string) *Overrides
@@ -68,5 +71,7 @@ type Interface interface {
 
 	// Management API
 	WriteStatusRuntimeConfig(w io.Writer, r *http.Request) error
-	WriteTenantOverrides(w io.Writer, r *http.Request, tenant string) error
+
+	TenantsHandler(w http.ResponseWriter, req *http.Request)
+	TenantStatusHandler(w http.ResponseWriter, req *http.Request)
 }

--- a/modules/overrides/overrides_tenant_status_http.go
+++ b/modules/overrides/overrides_tenant_status_http.go
@@ -24,71 +24,48 @@ type tenantStatusPageContents struct {
 	UserConfigurableOverrides string    `json:"user_configurable_overrides"`
 }
 
-func (o *runtimeConfigOverridesManager) TenantStatusHandler(w http.ResponseWriter, req *http.Request) {
-	vars := mux.Vars(req)
+func TenantStatusHandler(o Interface) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		vars := mux.Vars(req)
 
-	tenantID := vars["tenant"]
-	if tenantID == "" {
-		util.WriteTextResponse(w, "Tenant ID can't be empty")
-		return
-	}
+		tenantID := vars["tenant"]
+		if tenantID == "" {
+			util.WriteTextResponse(w, "Tenant ID can't be empty")
+			return
+		}
 
-	runtimeOverrides, err := marshalRuntimeOverrides(o, tenantID)
-	if err != nil {
-		util.WriteTextResponse(w, err.Error())
-		return
-	}
-
-	util.RenderHTTPResponse(w, tenantStatusPageContents{
-		Now:                       time.Now(),
-		Tenant:                    tenantID,
-		RuntimeOverrides:          runtimeOverrides,
-		UserConfigurableOverrides: "User-configurable overrides not enabled",
-	}, tenantStatusTemplate, req)
-}
-
-func (o *userConfigurableOverridesManager) TenantStatusHandler(w http.ResponseWriter, req *http.Request) {
-	vars := mux.Vars(req)
-
-	tenantID := vars["tenant"]
-	if tenantID == "" {
-		util.WriteTextResponse(w, "Tenant ID can't be empty")
-		return
-	}
-
-	runtimeOverrides, err := marshalRuntimeOverrides(o, tenantID)
-	if err != nil {
-		util.WriteTextResponse(w, err.Error())
-		return
-	}
-
-	var userConfigurableOverrides string
-
-	overrides := o.getTenantLimits(tenantID)
-	if overrides != nil {
-		marshalledOverrides, err := yaml.Marshal(overrides)
+		// runtime overrides
+		overrides := o.GetRuntimeOverridesFor(tenantID)
+		runtimeOverrides, err := yaml.Marshal(overrides)
 		if err != nil {
 			util.WriteTextResponse(w, fmt.Sprintf("Marshalling runtime overrides failed: %s", err))
+			return
 		}
-		userConfigurableOverrides = string(marshalledOverrides)
-	} else {
-		userConfigurableOverrides = "No user-configurable overrides set"
+
+		// user-configurable overrides
+		var userConfigurableOverrides string
+
+		if userConfigOverridesManager, ok := o.(*userConfigurableOverridesManager); ok {
+			overrides := userConfigOverridesManager.getTenantLimits(tenantID)
+			if overrides != nil {
+				marshalledOverrides, err := yaml.Marshal(overrides)
+				if err != nil {
+					util.WriteTextResponse(w, fmt.Sprintf("Marshalling user-configurable overrides failed: %s", err))
+					return
+				}
+				userConfigurableOverrides = string(marshalledOverrides)
+			} else {
+				userConfigurableOverrides = "No user-configurable overrides set"
+			}
+		} else {
+			userConfigurableOverrides = "User-configurable overrides are not enabled"
+		}
+
+		util.RenderHTTPResponse(w, tenantStatusPageContents{
+			Now:                       time.Now(),
+			Tenant:                    tenantID,
+			RuntimeOverrides:          string(runtimeOverrides),
+			UserConfigurableOverrides: userConfigurableOverrides,
+		}, tenantStatusTemplate, req)
 	}
-
-	util.RenderHTTPResponse(w, tenantStatusPageContents{
-		Now:                       time.Now(),
-		Tenant:                    tenantID,
-		RuntimeOverrides:          runtimeOverrides,
-		UserConfigurableOverrides: userConfigurableOverrides,
-	}, tenantStatusTemplate, req)
-}
-
-func marshalRuntimeOverrides(o Interface, tenantID string) (string, error) {
-	overrides := o.GetRuntimeOverridesFor(tenantID)
-
-	runtimeOverrides, err := yaml.Marshal(overrides)
-	if err != nil {
-		return "", fmt.Errorf("Marshalling runtime overrides failed: %w", err)
-	}
-	return string(runtimeOverrides), nil
 }

--- a/modules/overrides/overrides_tenant_status_http.go
+++ b/modules/overrides/overrides_tenant_status_http.go
@@ -68,7 +68,7 @@ func (o *userConfigurableOverridesManager) TenantStatusHandler(w http.ResponseWr
 	if overrides != nil {
 		marshalledOverrides, err := yaml.Marshal(overrides)
 		if err != nil {
-			util.WriteTextResponse(w, fmt.Sprintf("Marshalling runtime overrides failed: %w", err))
+			util.WriteTextResponse(w, fmt.Sprintf("Marshalling runtime overrides failed: %s", err))
 		}
 		userConfigurableOverrides = string(marshalledOverrides)
 	} else {

--- a/modules/overrides/overrides_tenant_status_http.go
+++ b/modules/overrides/overrides_tenant_status_http.go
@@ -1,0 +1,94 @@
+package overrides
+
+import (
+	_ "embed" // Used to embed html templates
+	"fmt"
+	"html/template"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+	"gopkg.in/yaml.v2"
+
+	"github.com/grafana/tempo/pkg/util"
+)
+
+//go:embed tenant_status.gohtml
+var tenantStatusPageHTML string
+var tenantStatusTemplate = template.Must(template.New("webpage").Parse(tenantStatusPageHTML))
+
+type tenantStatusPageContents struct {
+	Now                       time.Time `json:"now"`
+	Tenant                    string    `json:"tenant"`
+	RuntimeOverrides          string    `json:"runtime_overrides"`
+	UserConfigurableOverrides string    `json:"user_configurable_overrides"`
+}
+
+func (o *runtimeConfigOverridesManager) TenantStatusHandler(w http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+
+	tenantID := vars["tenant"]
+	if tenantID == "" {
+		util.WriteTextResponse(w, "Tenant ID can't be empty")
+		return
+	}
+
+	runtimeOverrides, err := marshalRuntimeOverrides(o, tenantID)
+	if err != nil {
+		util.WriteTextResponse(w, err.Error())
+		return
+	}
+
+	util.RenderHTTPResponse(w, tenantStatusPageContents{
+		Now:                       time.Now(),
+		Tenant:                    tenantID,
+		RuntimeOverrides:          runtimeOverrides,
+		UserConfigurableOverrides: "User-configurable overrides not enabled",
+	}, tenantStatusTemplate, req)
+}
+
+func (o *userConfigurableOverridesManager) TenantStatusHandler(w http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+
+	tenantID := vars["tenant"]
+	if tenantID == "" {
+		util.WriteTextResponse(w, "Tenant ID can't be empty")
+		return
+	}
+
+	runtimeOverrides, err := marshalRuntimeOverrides(o, tenantID)
+	if err != nil {
+		util.WriteTextResponse(w, err.Error())
+		return
+	}
+
+	var userConfigurableOverrides string
+
+	overrides := o.getTenantLimits(tenantID)
+	if overrides != nil {
+		marshalledOverrides, err := yaml.Marshal(overrides)
+		if err != nil {
+			util.WriteTextResponse(w, fmt.Sprintf("Marshalling runtime overrides failed: %w", err))
+		}
+		userConfigurableOverrides = string(marshalledOverrides)
+	} else {
+		userConfigurableOverrides = "No user-configurable overrides set"
+	}
+
+	util.RenderHTTPResponse(w, tenantStatusPageContents{
+		Now:                       time.Now(),
+		Tenant:                    tenantID,
+		RuntimeOverrides:          runtimeOverrides,
+		UserConfigurableOverrides: userConfigurableOverrides,
+	}, tenantStatusTemplate, req)
+}
+
+func marshalRuntimeOverrides(o Interface, tenantID string) (string, error) {
+	overrides := o.GetRuntimeOverridesFor(tenantID)
+
+	runtimeOverrides, err := yaml.Marshal(overrides)
+	if err != nil {
+		return "", fmt.Errorf("Marshalling runtime overrides failed: %w", err)
+	}
+	return string(runtimeOverrides), nil
+}

--- a/modules/overrides/overrides_tenants_http.go
+++ b/modules/overrides/overrides_tenants_http.go
@@ -1,0 +1,87 @@
+package overrides
+
+import (
+	_ "embed" // Used to embed html templates
+	"html/template"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/grafana/tempo/pkg/util"
+)
+
+//go:embed tenants.gohtml
+var tenantsPageHTML string
+var tenantsTemplate = template.Must(template.New("webpage").Parse(tenantsPageHTML))
+
+type tenantsPageContents struct {
+	Now     time.Time           `json:"now"`
+	Tenants []tenantsPageTenant `json:"tenants,omitempty"`
+}
+
+type tenantsPageTenant struct {
+	Name                         string `json:"name"`
+	HasRuntimeOverrides          bool   `json:"has_runtime_overrides"`
+	HasUserConfigurableOverrides bool   `json:"has_user_configurable_overrides"`
+}
+
+func (o *runtimeConfigOverridesManager) TenantsHandler(w http.ResponseWriter, req *http.Request) {
+	var tenants []tenantsPageTenant
+	for _, tenant := range o.GetTenantIDs() {
+		tenants = append(tenants, tenantsPageTenant{
+			Name:                         tenant,
+			HasRuntimeOverrides:          true,
+			HasUserConfigurableOverrides: false,
+		})
+	}
+
+	sortTenantsPageTenant(tenants)
+
+	util.RenderHTTPResponse(w, tenantsPageContents{
+		Now:     time.Now(),
+		Tenants: tenants,
+	}, tenantsTemplate, req)
+}
+
+func (o *userConfigurableOverridesManager) TenantsHandler(w http.ResponseWriter, req *http.Request) {
+	tenants := make(map[string]tenantsPageTenant)
+
+	// runtime overrides
+	for _, tenant := range o.Interface.GetTenantIDs() {
+		tenants[tenant] = tenantsPageTenant{
+			Name:                         tenant,
+			HasRuntimeOverrides:          true,
+			HasUserConfigurableOverrides: false,
+		}
+	}
+
+	// user-configurable overrides
+	for _, tenant := range o.GetTenantIDs() {
+		_, hasRuntimeOverrides := tenants[tenant]
+
+		tenants[tenant] = tenantsPageTenant{
+			Name:                         tenant,
+			HasRuntimeOverrides:          hasRuntimeOverrides,
+			HasUserConfigurableOverrides: true,
+		}
+	}
+
+	var tenantsList []tenantsPageTenant
+	for _, tenant := range tenants {
+		tenantsList = append(tenantsList, tenant)
+	}
+
+	sortTenantsPageTenant(tenantsList)
+
+	util.RenderHTTPResponse(w, tenantsPageContents{
+		Now:     time.Now(),
+		Tenants: tenantsList,
+	}, tenantsTemplate, req)
+}
+
+func sortTenantsPageTenant(list []tenantsPageTenant) {
+	sort.Slice(list, func(i, j int) bool {
+		return strings.Compare(list[i].Name, list[j].Name) < 0
+	})
+}

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log/level"
+	"golang.org/x/exp/maps"
 
 	"github.com/grafana/dskit/runtimeconfig"
 	"github.com/grafana/dskit/services"
@@ -247,11 +248,7 @@ func (o *runtimeConfigOverridesManager) GetTenantIDs() []string {
 		return nil
 	}
 
-	var ids []string
-	for tenant := range tenantOverrides.TenantLimits {
-		ids = append(ids, tenant)
-	}
-	return ids
+	return maps.Keys(tenantOverrides.TenantLimits)
 }
 
 func (o *runtimeConfigOverridesManager) GetRuntimeOverridesFor(userID string) *Overrides {

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -241,20 +241,21 @@ func (o *runtimeConfigOverridesManager) WriteStatusRuntimeConfig(w io.Writer, r 
 	return nil
 }
 
-func (o *runtimeConfigOverridesManager) GetRuntimeOverridesFor(userID string) *Overrides {
-	return o.getOverridesForUser(userID)
-}
-
-func (o *runtimeConfigOverridesManager) WriteTenantOverrides(w io.Writer, _ *http.Request, userID string) error {
-	overrides := o.getOverridesForUser(userID)
-
-	out, err := yaml.Marshal(overrides)
-	if err != nil {
-		return err
+func (o *runtimeConfigOverridesManager) GetTenantIDs() []string {
+	tenantOverrides := o.tenantOverrides()
+	if tenantOverrides == nil {
+		return nil
 	}
 
-	_, err = w.Write(out)
-	return err
+	var ids []string
+	for tenant := range tenantOverrides.TenantLimits {
+		ids = append(ids, tenant)
+	}
+	return ids
+}
+
+func (o *runtimeConfigOverridesManager) GetRuntimeOverridesFor(userID string) *Overrides {
+	return o.getOverridesForUser(userID)
 }
 
 // IngestionRateStrategy returns whether the ingestion rate limit should be individually applied

--- a/modules/overrides/tenant_status.gohtml
+++ b/modules/overrides/tenant_status.gohtml
@@ -1,0 +1,17 @@
+{{- /*gotype: github.com/grafana/mimir/pkg/storegateway.tenantsPageContents*/ -}}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Overrides: tenant</title>
+</head>
+<body>
+<h1>Overrides: tenant</h1>
+<p>Current time: {{ .Now }}</p>
+<p>Showing overrides for tenant: <strong>{{ .Tenant }}</strong></p>
+<h3>User-configurable overrides</h3>
+<pre><code>{{ .UserConfigurableOverrides }}</code></pre>
+<h3>Runtime overrides</h3>
+<pre><code>{{ .RuntimeOverrides }}</code></pre>
+</body>
+</html>

--- a/modules/overrides/tenant_status.gohtml
+++ b/modules/overrides/tenant_status.gohtml
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/grafana/mimir/pkg/storegateway.tenantsPageContents*/ -}}
+{{- /*gotype: github.com/grafana/tempo/modules/overrides.tenantStatusPageContents*/ -}}
 <!DOCTYPE html>
 <html>
 <head>

--- a/modules/overrides/tenant_status.gohtml
+++ b/modules/overrides/tenant_status.gohtml
@@ -12,6 +12,7 @@
 <h3>User-configurable overrides</h3>
 <pre><code>{{ .UserConfigurableOverrides }}</code></pre>
 <h3>Runtime overrides</h3>
+<p>Source of runtime overrides: <strong>{{ .RuntimeOverridesSource }}</strong></p>
 <pre><code>{{ .RuntimeOverrides }}</code></pre>
 </body>
 </html>

--- a/modules/overrides/tenants.gohtml
+++ b/modules/overrides/tenants.gohtml
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/grafana/mimir/pkg/storegateway.tenantsPageContents*/ -}}
+{{- /*gotype: github.com/grafana/tempo/modules/overrides.tenantsPageContents*/ -}}
 <!DOCTYPE html>
 <html>
 <head>

--- a/modules/overrides/tenants.gohtml
+++ b/modules/overrides/tenants.gohtml
@@ -1,0 +1,30 @@
+{{- /*gotype: github.com/grafana/mimir/pkg/storegateway.tenantsPageContents*/ -}}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Overrides: tenants</title>
+</head>
+<body>
+<h1>Overrides: tenants</h1>
+<p>Current time: {{ .Now }}</p>
+<table border="1" cellpadding="5" style="border-collapse: collapse">
+    <thead>
+    <tr>
+        <th>Tenant</th>
+        <th>Runtime overrides</th>
+        <th>User-configurable overrides</th>
+    </tr>
+    </thead>
+    <tbody style="font-family: monospace;">
+    {{ range .Tenants }}
+        <tr>
+            <td><a href="overrides/{{ .Name }}">{{ .Name }}</a></td>
+            <td>{{ if .HasRuntimeOverrides }}x{{ end }}</td>
+            <td>{{ if .HasUserConfigurableOverrides }}x{{ end }}</td>
+        </tr>
+    {{ end }}
+    </tbody>
+</table>
+</body>
+</html>

--- a/modules/overrides/user_configurable_overrides.go
+++ b/modules/overrides/user_configurable_overrides.go
@@ -69,8 +69,10 @@ type userConfigurableOverridesManager struct {
 	logger log.Logger
 }
 
-var _ Service = (*userConfigurableOverridesManager)(nil)
-var _ Interface = (*userConfigurableOverridesManager)(nil)
+var (
+	_ Service   = (*userConfigurableOverridesManager)(nil)
+	_ Interface = (*userConfigurableOverridesManager)(nil)
+)
 
 // newUserConfigOverrides wraps the given overrides with user-configurable overrides.
 func newUserConfigOverrides(cfg *UserConfigurableOverridesConfig, subOverrides Service) (*userConfigurableOverridesManager, error) {

--- a/modules/overrides/user_configurable_overrides.go
+++ b/modules/overrides/user_configurable_overrides.go
@@ -16,6 +16,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v2"
 
@@ -199,11 +200,7 @@ func (o *userConfigurableOverridesManager) setTenantLimit(userID string, limits 
 }
 
 func (o *userConfigurableOverridesManager) GetTenantIDs() []string {
-	var ids []string
-	for tenant := range o.getAllTenantLimits() {
-		ids = append(ids, tenant)
-	}
-	return ids
+	return maps.Keys(o.getAllTenantLimits())
 }
 
 func (o *userConfigurableOverridesManager) Forwarders(userID string) []string {


### PR DESCRIPTION
**What this PR does**:
Changes `/status/overrides` and `/status/overrides/{tenant}` to HTML page which are nicer and easier to use.

Examples:

`/status/overrides` with user-configurable overrides disabled

> ![Screenshot 2024-01-25 at 20 13 38](https://github.com/grafana/tempo/assets/7748404/cfb8864b-3dd0-4383-b644-46bf11197158)

`/status/overrides/{tenant}` with user-configurable overrides disabled

> ![Screenshot 2024-01-25 at 20 13 54](https://github.com/grafana/tempo/assets/7748404/e5318391-26d9-4943-a1ca-e6a5b0cf402a)

`/status/overrides` with user-configurable overrides enabled

> ![Screenshot 2024-01-25 at 20 12 08](https://github.com/grafana/tempo/assets/7748404/a0fc1859-ebc0-4fb1-8540-1e6eb1ab018d)

`/status/overrides/{tenant}` with user-configurable overrides enabled

> ![Screenshot 2024-01-25 at 20 12 27](https://github.com/grafana/tempo/assets/7748404/65cf2b02-a142-4de0-88db-c352ba36029b)

> ![Screenshot 2024-01-25 at 20 12 43](https://github.com/grafana/tempo/assets/7748404/8f9bfdc3-ca6f-423b-8e98-630901545a8f)

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`