### PR TITLE
[release-v2.3] [DOC] Update Tail based sampling doc for Grafana Agent

### DIFF
--- a/docs/sources/tempo/configuration/grafana-agent/_index.md
+++ b/docs/sources/tempo/configuration/grafana-agent/_index.md
@@ -23,13 +23,24 @@ On top of receiving and exporting traces, the Grafana Agent contains many
 features that make your distributed tracing system more robust, and
 leverages all the data that is processed in the pipeline.
 
+## Agent modes
+
+Grafana Agent is available in two different variants:
+
+* [Static mode](/docs/agent/latest/static): The original Grafana Agent.
+* [Flow mode](/docs/agent/latest/flow): The new, component-based Grafana Agent.
+
+Grafana Agent Flow configuration files are [written in River](/docs/agent/latest/flow/config-language/). Static configuraiton files are [written in YAML](/docs/agent/latest/static/configuration/).
+Examples in this document are for Flow mode.
+
+For more information, refer to the [Introduction to Grafana Agent](/docs/agent/latest/about/).
+
 ## Architecture
 
 The Grafana Agent can be configured to run a set of tracing pipelines to collect data from your applications and write it to Tempo.
 Pipelines are built using OpenTelemetry,
 and consist of `receivers`, `processors` and `exporters`. The architecture mirrors that of the OTel Collector's [design](https://github.com/open-telemetry/opentelemetry-collector/blob/846b971758c92b833a9efaf742ec5b3e2fbd0c89/docs/design.md).
-See the [configuration reference](/docs/agent/latest/configuration/traces-config) for all available configuration options.
-For a quick start, refer to this [blog post](/blog/2020/11/17/tracing-with-the-grafana-cloud-agent-and-grafana-tempo/).
+See the [configuration reference](/agent/latest/static/configuration/traces-config/) for all available configuration options.
 
 <p align="center"><img src="https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector/846b971758c92b833a9efaf742ec5b3e2fbd0c89/docs/images/design-pipelines.png" alt="Tracing pipeline architecture"></p>
 
@@ -105,6 +116,8 @@ The Agent implements tail-based sampling for distributed tracing systems and mul
 With this feature, sampling decisions can be made based on data from a trace, rather than exclusively with probabilistic methods.
 
 For a detailed description, go to [Tail-based sampling]({{< relref "./tail-based-sampling" >}}).
+
+For additional information, refer to the blog post, [An introduction to trace sampling with Grafana Tempo and Grafana Agent](/blog/2022/05/11/an-introduction-to-trace-sampling-with-grafana-tempo-and-grafana-agent)
 
 #### Generating metrics from spans
 

--- a/docs/sources/tempo/configuration/grafana-agent/tail-based-sampling.md
+++ b/docs/sources/tempo/configuration/grafana-agent/tail-based-sampling.md
@@ -10,23 +10,30 @@ aliases:
 # Tail-based sampling
 
 Tempo aims to provide an inexpensive solution that makes 100% sampling possible.
-However, sometimes constraints will make a lower sampling percentage necessary or desirable,
+However, sometimes constraints make a lower sampling percentage necessary or desirable,
 such as runtime or egress traffic related costs.
 Probabilistic sampling strategies are easy to implement,
 but also run the risk of discarding relevant data that you'll later want.
 
+Tail-based sampling works with Grafana Agent in Flow or static modes.
+Flow mode configuration files are [written in River](/docs/agent/latest/flow/config-language).
+Static mode configuration files are [written in YAML](/docs/agent/latest/static/configuration).
+Examples in this document are for Flow mode. You can also use the [Static mode Kubernetes operator](/docs/agent/latest/operator).
+
+## How tail-based sampling works
+
 In tail-based sampling, sampling decisions are made at the end of the workflow allowing for a more accurate sampling decision.
-The Grafana Agent groups span by trace ID and check its data to see
-if it meets one of the defined policies (for example, latency or status_code).
+The Grafana Agent groups spans by trace ID and checks its data to see
+if it meets one of the defined policies (for example, `latency` or `status_code`).
 For instance, a policy can check if a trace contains an error or if it took
 longer than a certain duration.
 
-A trace will be sampled if it meets at least one policy.
+A trace is sampled if it meets at least one policy.
 
 To group spans by trace ID, the Agent buffers spans for a configurable amount of time,
-after which it will consider the trace complete.
-Longer running traces will be split into more than one.
-However, waiting longer times will increase the memory overhead of buffering.
+after which it considers the trace complete.
+Longer running traces are split into more than one.
+However, waiting longer times increases the memory overhead of buffering.
 
 One particular challenge of grouping trace data is for multi-instance Agent deployments,
 where spans that belong to the same trace can arrive to different Agents.
@@ -35,11 +42,11 @@ by exporting spans belonging to the same trace to the same instance.
 
 This is achieved by redistributing spans by trace ID once they arrive from the application.
 The Agent must be able to discover and connect to other Agent instances where spans for the same trace can arrive.
-For kubernetes users, that can be done with a [headless service](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services).
+Kubernetes users should use a [headless service](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services).
 
 Redistributing spans by trace ID means that spans are sent and received twice,
 which can cause a significant increase in CPU usage.
-This overhead will increase with the number of Agent instances that share the same traces.
+This overhead increases with the number of Agent instances that share the same traces.
 
 <p align="center"><img src="../tail-based-sampling.png" alt="Tail-based sampling overview"></p>
 
@@ -50,194 +57,145 @@ If you're using a multi-instance deployment of the agent,
 add load balancing and specify the resolving mechanism to find other Agents in the setup.
 To see all the available configuration options, refer to the [configuration reference](/docs/agent/latest/configuration/traces-config/).
 
-```yaml
-traces:
-  configs:
-    - name: default
-      ...
-      tail_sampling:
-        policies:
-          # sample traces that have a total duration longer than 100ms
-          - latency:
-              threshold_ms: 100
-          # sample traces that contain at least one span with status code ERROR
-          - status_code:
-              status_codes:
-                - "ERROR"
-      load_balancing:
-        resolver:
-          dns:
-            hostname: host.namespace.svc.cluster.local
+## Example for Grafana Agent Flow
+
+[Grafana Agent Flow](/docs/agent/latest/flow/) is a component-based revision of Grafana Agent with a focus on ease-of-use, debuggability, and ability to adapt to the needs of power users.
+Flow configuration files are written in River instead of YAML.
+
+Grafana Agent Flow uses the [`otelcol.processor.tail_sampling component`](/docs/agent/latest/flow/reference/components/otelcol.processor.tail_sampling/)` for tail-based sampling.
+
+```river
+otelcol.receiver.otlp "otlp_receiver" {
+    grpc {
+        endpoint = "0.0.0.0:4317"
+    }
+
+    output {
+        traces = [
+            otelcol.processor.tail_sampling.policies.input,
+        ]
+    }
+}
+
+otelcol.exporter.otlp "tempo" {
+    client {
+        endpoint = "tempo:4317"
+    }
+}
+
+// The Tail Sampling processor will use a set of policies to determine which received
+// traces to keep and send to Tempo.
+otelcol.processor.tail_sampling "policies" {
+    // Total wait time from the start of a trace before making a sampling decision.
+    // Note that smaller time periods can potentially cause a decision to be made
+    // before the end of a trace has occurred.
+    decision_wait = "30s"
+
+    // The following policies follow a logical OR pattern, meaning that if any of the
+    // policies match, the trace will be kept. For logical AND, you can use the `and`
+    // policy. Every span of a trace is examined by each policy in turn. A match will
+    // cause a short-circuit.
+
+    // This policy defines that traces that contain errors should be kept.
+    policy {
+        // The name of the policy can be used for logging purposes.
+        name = "sample-erroring-traces"
+        // The type must match the type of policy to be used, in this case examining
+        // the status code of every span in the trace.
+        type = "status_code"
+        // This block determines the error codes that should match in order to keep
+        // the trace, in this case the OpenTelemetry 'ERROR' code.
+        status_code {
+            status_codes = [ "ERROR" ]
+        }
+    }
+
+    // This policy defines that only traces that are longer than 200ms in total
+    // should be kept.
+    policy {
+        // The name of the policy can be used for logging purposes.
+        name = "sample-long-traces"
+        // The type must match the policy to be used, in this case the total latency
+        // of the trace.
+        type = "latency"
+        // This block determines the total length of the trace in milliseconds.
+        latency {
+            threshold_ms = 200
+        }
+    }
+
+    // The output block forwards the kept traces onto the batch processor, which
+    // will marshall them for exporting to Tempo.
+    output {
+        traces = [otelcol.exporter.otlp.tempo.input]
+    }
+}
+
 ```
 
-## Examples
+## Examples for Grafana Agent static mode
 
-Sampling logic can be summarized into two rules:
+For additional information, refer to the blog post, [An introduction to trace sampling with Grafana Tempo and Grafana Agent](/blog/2022/05/11/an-introduction-to-trace-sampling-with-grafana-tempo-and-grafana-agent).
 
-1. If a policy is met, the trace is sampled. Even if other policies are not met.
-2. If any of the spans of the trace meet the policy requirements, the trace is sampled.
+### Status code tail sampling policy
 
-Next, there are a couple of examples of `tail_sampling` configurations,
-with descriptions of the policies and the expected behavior.
-
-### Sampling by latency and status
-
-Sampling traces that have a total duration longer than 100ms and traces that contain at least one span with status code `ERROR`.
-Total duration is determined by looking at the earliest start time and latest end time.
-
-```yaml
-traces:
-  configs:
-    - name: default
-      ...
-      tail_sampling:
-        policies:
-          - type: latency
-            latency:
-              threshold_ms: 100
-          - type: status_code
-            status_code:
-              status_codes:
-                - "ERROR"
-```
-
-### Sampling by attributes
-
-Sampling traces that do not contain the attribute `http.endpoint` equal to `/status` and `/metrics`.
-
-```yaml
-traces:
-  configs:
-    - name: default
-      ...
-      tail_sampling:
-        policies:
-        - attributes:
-          - name: http.endpoint
-            values:
-              - /status
-              - /metrics
-            invert_match: true
-```
-
-### Sampling with `and` policy
-
-Sampling traces that have an attribute `http.endpoint` that matches `/api/v1/*`
-and that have a total duration longer than 100ms.
-
-```yaml
-traces:
-  configs:
-    - name: default
-      ...
-      tail_sampling:
-      policies:
-      - type: and
-        and:
-          and_sub_policy:
-            - type: string_attribute
-              string_attribute:
-              - name: http.endpoint
-                value: /api/v1/*
-                enabled_regex_matching: true
-                cache_max_size: 10
-            - type: latency
-              latency:
-                threshold_ms: 100
-```
-
-### Multi-requirement sampling
-
-Sampling requirements are the following:
-
-- Service A: latency> 3s
-- Service B: only error spans or latency> 5s
-- Service C: all spans
-
-```yaml
-traces:
-  configs:
-    - name: default
-      ...
-      tail_sampling:
-        policies:
-        # Service A: latency> 3s
-        - type: and
-          and:
-            and_sub_policy:
-              - type: latency
-                name: latency
-                latency:
-                  threshold_ms: 3000
-              - type: string_attribute
-                name: service-name
-                string_attribute:
-                  name: service.name
-                  values:
-                    - serviceA
-        # Service B requires two and policies
-        # 1. spans with status code ERROR
-        - type: and
-          and:
-            and_sub_policy:
-              - type: status_code
-                name: status_code
-                status_code:
-                  status_codes:
-                    - "ERROR"
-              - type: string_attribute
-                name: service-name
-                string_attribute:
-                  name: service.name
-                  values:
-                    - serviceB
-        # 2. latency> 5s
-        - type: and
-          and:
-            and_sub_policy:
-              - type: latency
-                name: latency
-                latency:
-                  threshold_ms: 5000
-              - type: string_attribute
-                name: service name
-                string_attribute:
-                  name: service.name
-                  values:
-                    - serviceB
-        # Service C: all spans
-        - type: string_attribute
-          string_attribute:
-            name: service.name
-            values:
-              - serviceC
-```
-
-## Sampling based on k8s metadata
-
-In this example, the Agent will sample traces that come from pods from the namespace `default`.
-Via `scrape_configs`, spans are relabeled with kubernetes metadata,
-in this case injecting the namespace attribute.
+The following policy only samples traces where at least one span contains an OpenTelemetry Error status code.
 
 ```yaml
 traces:
   configs:
     - name: default
     ...
-    scrape_configs:
-      - job_name: kubernetes-pods
-        kubernetes_sd_configs:
-          - role: pod
-        relabel_configs:
-          - action: replace
-            source_labels:
-              - __meta_kubernetes_namespace
-            target_label: namespace
     tail_sampling:
       policies:
-      - type: string_attribute
-        string_attribute:
-          name: namespace
-          values:
-          - default
+        - type: status_code
+          status_code:
+            status_codes:
+              - ERROR
+```
+
+### Span attribute tail sampling policy
+
+The following policy only samples traces where the span attribute `http.target` does *not* contain the value `/healthcheck` or is prefixed with `/metrics/`.
+
+```yaml
+traces:
+   configs:
+   - name: default
+    tail_sampling:
+      policies:
+        - type: string_attribute
+          string_attribute:
+            key: http.target
+            values:
+              - ^\/(?:metrics\/.*|healthcheck)$
+            enabled_regex_matching: true
+            invert_match: true
+```
+
+### And compound tail sampling policy
+
+The following policy will only sample traces where all of the conditions for the sub-policies are met. In this case, it takes the prior two policies and will only sample traces where the span attribute `http.target` does *not* contain the value `/healthcheck` or is prefixed with `/metrics/` *and* at least one of the spans of the trace contains an OpenTelemetry Error status code.
+
+```yaml
+traces:
+   configs:
+   - name: default
+    tail_sampling:
+      policies:
+       - type: and
+            and_sub_policy:
+            - name: and_tag_policy
+              type: string_attribute
+              string_attribute:
+                key: http.target
+                values:
+                    - ^\/(?:metrics\/.*|healthcheck)$
+                enabled_regex_matching: true
+                invert_match: true
+            - name: and_error_policy
+              type: status_code
+              status_code:
+                status_codes:
+                  - ERROR
 ```


### PR DESCRIPTION
Backport 865383b0be7a9bd03ac8f02429ca0dca42ef37e8 from #3167

--- Backport info 

**What this PR does**:

We've updated the tail-based sampling doc to include a River configuration file example for Agent Flow mode. 

**Which issue(s) this PR fixes**:
Fixes #2455

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
