### PR TITLE
vParquet4: Fix typo in event name encoding

### DIFF
--- a/tempodb/encoding/vparquet3/schema.go
+++ b/tempodb/encoding/vparquet3/schema.go
@@ -152,7 +152,7 @@ type DedicatedAttributes struct {
 
 type Event struct {
 	TimeSinceStartNano     uint64      `parquet:",delta"`
-	Name                   string      `parquet:",snappy,dic"`
+	Name                   string      `parquet:",snappy,dict"`
 	Attrs                  []Attribute `parquet:",list"`
 	DroppedAttributesCount int32       `parquet:",snappy,delta"`
 }


### PR DESCRIPTION
**What this PR does**:

Fix a small typo

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`