### PR TITLE
Fix autocomplete returning erroneous values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * [BUGFIX] Fix panic in autocomplete when query condition had wrong type [#3277](https://github.com/grafana/tempo/pull/3277) (@mapno)
 * [BUGFIX] Fix TLS when GRPC is enabled on HTTP [#3300](https://github.com/grafana/tempo/pull/3300) (@joe-elliott)
 * [BUGFIX] Correctly return 400 when max limit is requested on search. [#3340](https://github.com/grafana/tempo/pull/3340) (@joe-elliott)
+* [BUGFIX] Fix autocomplete filters sometimes returning erroneous results. [#3339](https://github.com/grafana/tempo/pull/3339) (@joe-elliott)
 
 ## v2.3.1 / 2023-11-28
 

--- a/tempodb/encoding/vparquet3/block_autocomplete.go
+++ b/tempodb/encoding/vparquet3/block_autocomplete.go
@@ -65,7 +65,7 @@ func (b *backendBlock) FetchTagValues(ctx context.Context, req traceql.Autocompl
 
 // autocompleteIter creates an iterator that will collect values for a given attribute/tag.
 func autocompleteIter(ctx context.Context, req traceql.AutocompleteRequest, pf *parquet.File, opts common.SearchOptions, dc backend.DedicatedColumns) (parquetquery.Iterator, error) {
-	iter, err := createDistinctIterator(ctx, nil, req.Conditions, req.TagName, pf, opts, dc)
+	iter, err := createDistinctIterator(ctx, req.Conditions, req.TagName, pf, opts, dc)
 	if err != nil {
 		return nil, fmt.Errorf("error creating iterator: %w", err)
 	}
@@ -75,7 +75,6 @@ func autocompleteIter(ctx context.Context, req traceql.AutocompleteRequest, pf *
 
 func createDistinctIterator(
 	ctx context.Context,
-	primaryIter parquetquery.Iterator, // jpe - remove me
 	conds []traceql.Condition,
 	tag traceql.Attribute,
 	pf *parquet.File,
@@ -97,7 +96,7 @@ func createDistinctIterator(
 	var currentIter parquetquery.Iterator
 
 	if len(spanConditions) > 0 {
-		currentIter, err = createDistinctSpanIterator(makeIter, keep, tag, primaryIter, spanConditions, dc)
+		currentIter, err = createDistinctSpanIterator(makeIter, keep, tag, currentIter, spanConditions, dc)
 		if err != nil {
 			return nil, errors.Wrap(err, "creating span iterator")
 		}

--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -27,7 +27,7 @@ func TestOne(t *testing.T) {
 	wantTr := fullyPopulatedTestTrace(nil)
 	b := makeBackendBlockWithTraces(t, []*Trace{wantTr})
 	ctx := context.Background()
-	q := `{ traceDuration > 1s }`
+	q := `{ resource.region != nil && resource.service.name = "bar" }`
 	req := traceql.MustExtractFetchSpansRequestWithMetadata(q)
 
 	req.StartTimeUnixNanos = uint64(1000 * time.Second)

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -979,20 +979,23 @@ func autoComplete(t *testing.T, _ *tempopb.Trace, _ *tempopb.TraceSearchMetadata
 			},
 		},
 		{
-			name:  "resource filtered by unscoped",
-			tag:   traceql.NewScopedAttribute(traceql.AttributeScopeResource, false, "service.name"),
-			query: "{ .foo = `Bar` }",
+			name:  "multiple conditions",
+			tag:   traceql.NewScopedAttribute(traceql.AttributeScopeResource, false, "res-dedicated.01"),
+			query: "{ resource.res-dedicated.02 = `res-2a` && span.http.status_code = 500 }",
 			expected: []tempopb.TagValue{
-				{Type: "string", Value: "MyService"},
-				{Type: "string", Value: "RootService"},
+				{Type: "string", Value: "res-1a"},
 			},
 		},
 		{
-			name:  "span filtered by unscoped",
-			tag:   traceql.NewScopedAttribute(traceql.AttributeScopeSpan, false, "span-dedicated.01"),
-			query: "{ .service.name = `RootService` }",
+			name:  "unscoped not supported", // todo: add support for unscoped. currently it falls back to old logic and returns everything
+			tag:   traceql.NewScopedAttribute(traceql.AttributeScopeResource, false, "service.name"),
+			query: "{ .foo = `Bar` }",
 			expected: []tempopb.TagValue{
-				{Type: "string", Value: "span-1b"},
+				{Type: "string", Value: "RootService"},
+				{Type: "string", Value: "Service3"},
+				{Type: "string", Value: "BrokenService"},
+				{Type: "string", Value: "MyService"},
+				{Type: "string", Value: "test-service"},
 			},
 		},
 	}

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -987,6 +987,14 @@ func autoComplete(t *testing.T, _ *tempopb.Trace, _ *tempopb.TraceSearchMetadata
 				{Type: "string", Value: "RootService"},
 			},
 		},
+		{
+			name:  "span filtered by unscoped",
+			tag:   traceql.NewScopedAttribute(traceql.AttributeScopeSpan, false, "span-dedicated.01"),
+			query: "{ .service.name = `RootService` }",
+			expected: []tempopb.TagValue{
+				{Type: "string", Value: "span-1b"},
+			},
+		},
 	}
 
 	for _, tc := range tcs {

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -916,10 +916,9 @@ func traceQLExistence(t *testing.T, _ *tempopb.Trace, _ *tempopb.TraceSearchMeta
 }
 
 // autoComplete!
-func autoComplete(t *testing.T, _ *tempopb.Trace, _ *tempopb.TraceSearchMetadata, _, _ []*tempopb.SearchRequest, meta *backend.BlockMeta, _ Reader, bb common.BackendBlock) {
+func autoComplete(t *testing.T, _ *tempopb.Trace, _ *tempopb.TraceSearchMetadata, _, _ []*tempopb.SearchRequest, _ *backend.BlockMeta, _ Reader, bb common.BackendBlock) {
 	ctx := context.Background()
 	e := traceql.NewEngine()
-	const intrinsicName = "name"
 
 	tcs := []struct {
 		name     string


### PR DESCRIPTION
**What this PR does**:
In certain circumstances filtered autocomplete would return incorrect results due to an incorrect iterator scope. The actual fix is [this line](https://github.com/grafana/tempo/pull/3339/files#diff-75a709e18d228f16dc762d46a5b3d80e86ac0c8c632d12d6618f72052f26c58aR503)

- removed an unused param in `createDistinctAttributeOperator`
- added integration tests for filtered autocomplete

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`