### PR TITLE
Return Bad Request when exceeding limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * [BUGFIX] Fixed an issue where cached footers were requested then ignored. [#3196](https://github.com/grafana/tempo/pull/3196) (@joe-elliott)
 * [BUGFIX] Fix panic in autocomplete when query condition had wrong type [#3277](https://github.com/grafana/tempo/pull/3277) (@mapno)
 * [BUGFIX] Fix TLS when GRPC is enabled on HTTP [#3300](https://github.com/grafana/tempo/pull/3300) (@joe-elliott)
+* [BUGFIX] Correctly return 400 when max limit is requested on search. [#3340](https://github.com/grafana/tempo/pull/3340) (@joe-elliott)
 
 ## v2.3.1 / 2023-11-28
 

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -452,7 +452,7 @@ query_frontend:
         [default_result_limit: <int>]
 
         # The maximum allowed value of the limit parameter on search requests. If the search request limit parameter
-        # exceeds the value configured here it will be set to the value configured here.
+        # exceeds the value configured here the frontend will return a 400.
         # The default value of 0 disables this limit.
         # (default: 0)
         [max_result_limit: <int>]

--- a/modules/frontend/searchsharding_test.go
+++ b/modules/frontend/searchsharding_test.go
@@ -996,10 +996,21 @@ func testBadRequest(t *testing.T, resp *http.Response, err error, expectedBody s
 }
 
 func TestAdjustLimit(t *testing.T) {
-	assert.Equal(t, uint32(10), adjustLimit(0, 10, 0))
-	assert.Equal(t, uint32(3), adjustLimit(3, 10, 0))
-	assert.Equal(t, uint32(3), adjustLimit(3, 10, 20))
-	assert.Equal(t, uint32(20), adjustLimit(25, 10, 20))
+	l, err := adjustLimit(0, 10, 0)
+	require.Equal(t, uint32(10), l)
+	require.NoError(t, err)
+
+	l, err = adjustLimit(3, 10, 0)
+	require.Equal(t, uint32(3), l)
+	require.NoError(t, err)
+
+	l, err = adjustLimit(3, 10, 20)
+	require.Equal(t, uint32(3), l)
+	require.NoError(t, err)
+
+	l, err = adjustLimit(25, 10, 20)
+	require.Equal(t, uint32(0), l)
+	require.EqualError(t, err, "limit 25 exceeds max limit 20")
 }
 
 func TestMaxDuration(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:
Currently if the configured max limit is exceeded Tempo will just cut off results at the max limit. Instead we should return a 400 to clearly notify the user their request is invalid.

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`