### PR TITLE
Add a note/warning about cases in which cross tenant queries perform unexpectedly 

### DIFF
--- a/docs/sources/tempo/operations/cross_tenant_query.md
+++ b/docs/sources/tempo/operations/cross_tenant_query.md
@@ -10,7 +10,7 @@ aliases:
 
 # Cross-tenant query federation
 
-{{% admonition type=note" %}}
+{{% admonition type="note" %}}
 You need to enable `multitenancy_enabled: true` in the cluster for multi-tenant querying to work.
 see [enable multi-tenancy]({{< relref "./multitenancy" >}}) for more details and implications of `multitenancy_enabled: true`.
 {{% /admonition %}}
@@ -28,3 +28,10 @@ query_frontend:
 
 Queries performed using the cross-tenant configured data source, in either **Explore** or inside of dashboards, 
 are performed across all the tenants that you specified in the **X-Scope-OrgID** header. 
+
+TraceQL queries that compare multiple spansets may not correctly return all traces in a cross-tenant query. For instance,
+```
+{ span.attr1 = "bar" } && { span.attr2 = "foo" }
+```
+TraceQL evaluates a contiguously stored trace. If these two conditions are satisfied in separate tenants, then Tempo 
+will not correctly return it.

--- a/docs/sources/tempo/operations/cross_tenant_query.md
+++ b/docs/sources/tempo/operations/cross_tenant_query.md
@@ -25,6 +25,7 @@ By default, Cross-tenant query is enabled and can be controlled using `multi_ten
 query_frontend:
    multi_tenant_queries_enabled: true
 ```
+## TraceQL queries
 
 Queries performed using the cross-tenant configured data source, in either **Explore** or inside of dashboards, 
 are performed across all the tenants that you specified in the **X-Scope-OrgID** header. 


### PR DESCRIPTION
**What this PR does**:
Adds a note about the case where multiple spansets with conditions satisfied in different tenants will not be returned correctly.

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`