### PR TITLE
Ingester readonly on startup until replay and rediscover is done to prevent broken head blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [BUGFIX] The tempo-cli analyse blocks command no longer fails on compacted blocks [#3183](https://github.com/grafana/tempo/pull/3183) (@stoewer)
 * [BUGFIX] Move waitgroup handling for poller error condition [#3224](https://github.com/grafana/tempo/pull/3224) (@zalegrala)
 * [BUGFIX] Fix head block excessive locking in ingester search [#3328](https://github.com/grafana/tempo/pull/3328) (@mdisibio)
+* [BUGFIX] Fix issue with ingester failed to cut traces no such file or directory [#3346](https://github.com/grafana/tempo/issues/3346) (@mdisibio)
 * [ENHANCEMENT] Introduced `AttributePolicyMatch` & `IntrinsicPolicyMatch` structures to match span attributes based on strongly typed values & precompiled regexp [#3025](https://github.com/grafana/tempo/pull/3025) (@andriusluk)
 * [CHANGE] TraceQL/Structural operators performance improvement. [#3088](https://github.com/grafana/tempo/pull/3088) (@joe-elliott)
 * [CHANGE] Merge the processors overrides set through runtime overrides and user-configurable overrides [#3125](https://github.com/grafana/tempo/pull/3125) (@kvrhdn)


### PR DESCRIPTION
**What this PR does**:
This is one of those bugs that makes you wonder "how did this ever work?"   This PR changes the ingester to enter a read-only state on startup (similar to shutdown) until wal replay and local blocks rediscover are complete.  This prevents pushes from creating headblocks that get tangled up in the replay process (and broken).  I really like having the startup error different than the shutting down error.  It makes it easy to check logs for `Ingester is starting` and verify the fix is working.

**Description of the Bug**
Here is a full sequence of the bug:
1. An Ingester unexpectedly terminates (OOM, panic, readinessprobe failure etc)
2. The ingester restarts and begins WAL replay
3. Because it didn't leave the ring gracefully and propagating the new state takes some time, it still appears HEALTHY to (some or all) the distributors.
4. The distributors push traffic to it while it is replaying
5. PushBytes works (unexpectedly) and creates a headblock     <--- This is where we fix it
6. The headblock gets picked up by the replay process and deleted
7. All pushes to that headblock fail and the ingester never recovers

**Steps to Reproduce**
1. Requires a distributed setup with separate distributors, ingesters, and replication factor >= 2
2. While continuously pushing traffic, quickly kill and restart a single ingester via `docker kill`/etc
3. Only kill 1 ingester, so that the distributor sees the minimum replicas and keeps pushing traffic
4. Eventually it will trigger the bug

**Which issue(s) this PR fixes**:
Fixes #3346 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`