### PR TITLE
Add shutdown delay and e2e test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * [ENHANCEMENT] Update memcached default image in jsonnet for multiple CVE [#3310](https://github.com/grafana/tempo/pull/3310) (@zalegrala)
 * [ENHANCEMENT] Add HTML pages /status/overrides and /status/overrides/{tenant} [#3244](https://github.com/grafana/tempo/pull/3244) [#3332](https://github.com/grafana/tempo/pull/3332) (@kvrhdn)
 * [ENHANCEMENT] Precalculate and reuse the vParquet3 schema before opening blocks [#3367](https://github.com/grafana/tempo/pull/3367) (@stoewer)
+* [ENHANCEMENT] Add `--shutdown-delay` to allow Tempo to cleanly drain connections. [#???](https://github.com/grafana/tempo/pull/???) (@joe-elliott)
 * [BUGFIX] Prevent building parquet iterators that would loop forever. [#3159](https://github.com/grafana/tempo/pull/3159) (@mapno)
 * [BUGFIX] Sanitize name in mapped dimensions in span-metrics processor [#3171](https://github.com/grafana/tempo/pull/3171) (@mapno)
 * [BUGFIX] Fixed an issue where cached footers were requested then ignored. [#3196](https://github.com/grafana/tempo/pull/3196) (@joe-elliott)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@
 * [ENHANCEMENT] Update memcached default image in jsonnet for multiple CVE [#3310](https://github.com/grafana/tempo/pull/3310) (@zalegrala)
 * [ENHANCEMENT] Add HTML pages /status/overrides and /status/overrides/{tenant} [#3244](https://github.com/grafana/tempo/pull/3244) [#3332](https://github.com/grafana/tempo/pull/3332) (@kvrhdn)
 * [ENHANCEMENT] Precalculate and reuse the vParquet3 schema before opening blocks [#3367](https://github.com/grafana/tempo/pull/3367) (@stoewer)
-* [ENHANCEMENT] Add `--shutdown-delay` to allow Tempo to cleanly drain connections. [#???](https://github.com/grafana/tempo/pull/???) (@joe-elliott)
+* [ENHANCEMENT] Add `--shutdown-delay` to allow Tempo to cleanly drain connections. [#3395](https://github.com/grafana/tempo/pull/3395) (@joe-elliott)
 * [BUGFIX] Prevent building parquet iterators that would loop forever. [#3159](https://github.com/grafana/tempo/pull/3159) (@mapno)
 * [BUGFIX] Sanitize name in mapped dimensions in span-metrics processor [#3171](https://github.com/grafana/tempo/pull/3171) (@mapno)
 * [BUGFIX] Fixed an issue where cached footers were requested then ignored. [#3196](https://github.com/grafana/tempo/pull/3196) (@joe-elliott)

--- a/cmd/tempo/app/config.go
+++ b/cmd/tempo/app/config.go
@@ -31,14 +31,15 @@ import (
 
 // Config is the root config for App.
 type Config struct {
-	Target                       string `yaml:"target,omitempty"`
-	AuthEnabled                  bool   `yaml:"auth_enabled,omitempty"`
-	MultitenancyEnabled          bool   `yaml:"multitenancy_enabled,omitempty"`
-	StreamOverHTTPEnabled        bool   `yaml:"stream_over_http_enabled,omitempty"`
-	HTTPAPIPrefix                string `yaml:"http_api_prefix"`
-	UseOTelTracer                bool   `yaml:"use_otel_tracer,omitempty"`
-	EnableGoRuntimeMetrics       bool   `yaml:"enable_go_runtime_metrics,omitempty"`
-	AutocompleteFilteringEnabled bool   `yaml:"autocomplete_filtering_enabled,omitempty"`
+	Target                       string        `yaml:"target,omitempty"`
+	AuthEnabled                  bool          `yaml:"auth_enabled,omitempty"`
+	MultitenancyEnabled          bool          `yaml:"multitenancy_enabled,omitempty"`
+	ShutdownDelay                time.Duration `yaml:"shutdown_delay,omitempty"`
+	StreamOverHTTPEnabled        bool          `yaml:"stream_over_http_enabled,omitempty"`
+	HTTPAPIPrefix                string        `yaml:"http_api_prefix"`
+	UseOTelTracer                bool          `yaml:"use_otel_tracer,omitempty"`
+	EnableGoRuntimeMetrics       bool          `yaml:"enable_go_runtime_metrics,omitempty"`
+	AutocompleteFilteringEnabled bool          `yaml:"autocomplete_filtering_enabled,omitempty"`
 
 	Server          server.Config           `yaml:"server,omitempty"`
 	InternalServer  internalserver.Config   `yaml:"internal_server,omitempty"`
@@ -76,6 +77,7 @@ func (c *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 	f.BoolVar(&c.UseOTelTracer, "use-otel-tracer", false, "Set to true to replace the OpenTracing tracer with the OpenTelemetry tracer")
 	f.BoolVar(&c.EnableGoRuntimeMetrics, "enable-go-runtime-metrics", false, "Set to true to enable all Go runtime metrics")
 	f.BoolVar(&c.AutocompleteFilteringEnabled, "autocomplete-filtering.enabled", true, "Set to false to disable autocomplete filtering")
+	f.DurationVar(&c.ShutdownDelay, "shutdown-delay", 0, "How long to wait between SIGTERM and shutdown. After receiving SIGTERM, Tempo will report not-ready status via /ready endpoint.")
 
 	// Server settings
 	flagext.DefaultValues(&c.Server)

--- a/cmd/tempo/app/server_service.go
+++ b/cmd/tempo/app/server_service.go
@@ -25,6 +25,7 @@ type TempoServer interface {
 	GRPC() *grpc.Server
 	Log() log.Logger
 	EnableHTTP2()
+	SetKeepAlivesEnabled(enabled bool)
 
 	StartAndReturnService(cfg server.Config, supportGRPCOnHTTP bool, servicesToWaitFor func() []services.Service) (services.Service, error)
 }
@@ -60,6 +61,10 @@ func (s *tempoServer) EnableHTTP2() {
 	s.enableHTTP2Once.Do(func() {
 		s.externalServer.HTTPServer.Handler = h2c.NewHandler(s.externalServer.HTTPServer.Handler, &http2.Server{})
 	})
+}
+
+func (s *tempoServer) SetKeepAlivesEnabled(enabled bool) {
+	s.externalServer.HTTPServer.SetKeepAlivesEnabled(enabled)
 }
 
 func (s *tempoServer) StartAndReturnService(cfg server.Config, supportGRPCOnHTTP bool, servicesToWaitFor func() []services.Service) (services.Service, error) {


### PR DESCRIPTION
**What this PR does**:
Adds a shutdown delay configurable parameter modeled after mimir:

https://github.com/grafana/mimir/pull/3298

After receiving SIGTERM Tempo will drop its readiness handler and wait the configured seconds. In a k8s environment this will allow Tempo to cleanly roll its frontend without dropping queries.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`