### PR TITLE
[Traceql metrics] Better trace ID sharding

### DIFF
--- a/pkg/util/traceidboundary/traceidboundary.go
+++ b/pkg/util/traceidboundary/traceidboundary.go
@@ -2,9 +2,12 @@ package traceidboundary
 
 import (
 	"bytes"
+	"encoding/binary"
 
 	"github.com/grafana/tempo/pkg/blockboundary"
 )
+
+const defaultBitSharding = 12
 
 type Boundary struct {
 	Min, Max []byte
@@ -20,32 +23,69 @@ type Boundary struct {
 //   - Trace IDs can be 16 or 8 bytes.  If we naively sharded only in 16-byte space it would
 //     be unbalanced because all 8-byte IDs would land in the first shard. Therefore we
 //     divide in both 16- and 8-byte spaces and a single shard covers a range in each.
-//   - Technically 8-byte IDs are only 63 bits, so we account for this
 //   - The boundaries are inclusive/exclusive: [min, max), except the max of the last shard
 //     is the valid ID FFFFF... and inclusive/inclusive.
+//   - There are various regimes of 64-bit trace IDs and they are not uniformly distributed
+//     Therefore we sub-shard **many** bits further down than 64-bits. Default is 12 bits.
 func Pairs(shard, of uint32) (boundaries []Boundary, upperInclusive bool) {
-	// First pair is 63-bit IDs left-padded with zeroes to make 16-byte divisions
-	// that matches the 16-byte layout in the block.
-	// To create 63-bit boundaries we create twice as many as needed,
-	// then only use the first half.  i.e. shaving off the top-most bit.
-	int63bounds := blockboundary.CreateBlockBoundaries(int(of * 2))
+	// Internal testing showed that sharding to 12 bits is 95+% optimal.
+	return PairsWithBitSharding(shard, of, defaultBitSharding)
+}
 
-	// Adjust last boundary to be inclusive so it matches the other pair.
-	int63bounds[of] = []byte{0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}
+// PairsWithBitSharding allows choosing a specific level of sub-sharding.
+func PairsWithBitSharding(shard, of uint32, bits int) (boundaries []Boundary, upperInclusive bool) {
+	// This function takes a list of trace ID boundaries and subdivides them down to the
+	// same space for the given number of bits.  This seems like overkill but has a big upside:
+	// it means that the fairness of every shard is greatly increased, but also *invariant*
+	// across workloads, no matter if your instrumentation is generating 8-byte or
+	// or 16-byte trace IDs.
+	// For example shard 2 of 4 has the boundary:
+	//		0x40	b0100
+	//		0x80	b1000
+	// Shifting by 1 bit gives shard 2 of 4 in 64-bit-only space:
+	//				 |
+	//				 v
+	//		0xA0	b1010
+	//		0xC0	b1100
+	// Shifting by 2 bits gives shard 2 of 4 in 63-bit-only space:
+	//				  |
+	// 				  v
+	//      0x50	b0101
+	//      0x60	b0110
+	// ... and so on
+	cloneRotateAndSet := func(v []byte, right int) []byte {
+		v2 := binary.BigEndian.Uint64(v)
+		v2 >>= right
+		v2 |= 0x01 << (64 - right)
 
-	boundaries = append(boundaries, Boundary{
-		Min: append([]byte{0, 0, 0, 0, 0, 0, 0, 0}, int63bounds[shard-1][0:8]...),
-		Max: append([]byte{0, 0, 0, 0, 0, 0, 0, 0}, int63bounds[shard][0:8]...),
-	})
+		copy := make([]byte, 8)
+		binary.BigEndian.PutUint64(copy, v2)
+		return copy
+	}
 
-	// Second pair is normal full precision 16-byte IDs.
 	int128bounds := blockboundary.CreateBlockBoundaries(int(of))
 
-	// However there is one caveat - We adjust the very first boundary to ensure it doesn't
-	// overlap with the 63-bit precision ones. I.e. a minimum of 0x0000.... would
-	// unintentionally include all 63-bit IDs.
-	// The first 64-bit ID starts here:
-	int128bounds[0] = []byte{0, 0, 0, 0, 0, 0, 0, 0, 0x80, 0, 0, 0, 0, 0, 0, 0}
+	for i := bits; i >= 1; i-- {
+		min := cloneRotateAndSet(int128bounds[shard-1], i)
+		max := cloneRotateAndSet(int128bounds[shard], i)
+
+		if i == bits && shard == 1 {
+			// We don't shard below this, so its minimum is absolute zero.
+			clear(min)
+		}
+		boundaries = append(boundaries, Boundary{
+			Min: append([]byte{0, 0, 0, 0, 0, 0, 0, 0}, min[0:8]...),
+			Max: append([]byte{0, 0, 0, 0, 0, 0, 0, 0}, max[0:8]...),
+		})
+	}
+
+	// Final pair is the normal full precision 16-byte IDs.
+	if bits > 0 {
+		// Avoid overlap with the 64-bit precision ones. I.e. a minimum of 0x0000.... would
+		// unintentionally include all 64-bit IDs.
+		// The first 65-bit ID starts here:
+		int128bounds[0] = []byte{0, 0, 0, 0, 0, 0, 0, 0x01, 0, 0, 0, 0, 0, 0, 0, 0}
+	}
 
 	boundaries = append(boundaries, Boundary{
 		Min: int128bounds[shard-1],
@@ -60,7 +100,12 @@ func Pairs(shard, of uint32) (boundaries []Boundary, upperInclusive bool) {
 
 // Funcs returns helper functions that match trace IDs in the given shard.
 func Funcs(shard, of uint32) (testSingle func([]byte) bool, testRange func([]byte, []byte) bool) {
-	pairs, upperInclusive := Pairs(shard, of)
+	return FuncsWithBitSharding(shard, of, defaultBitSharding)
+}
+
+// FuncsWithBitSharding is like Funcs but allows choosing a specific level of sub-sharding.
+func FuncsWithBitSharding(shard, of uint32, bits int) (testSingle func([]byte) bool, testRange func([]byte, []byte) bool) {
+	pairs, upperInclusive := PairsWithBitSharding(shard, of, bits)
 
 	upper := -1
 	if upperInclusive {
@@ -70,11 +115,9 @@ func Funcs(shard, of uint32) (testSingle func([]byte) bool, testRange func([]byt
 	isMatch := func(id []byte) bool {
 		for _, p := range pairs {
 			if bytes.Compare(p.Min, id) <= 0 && bytes.Compare(id, p.Max) <= upper {
-				// fmt.Printf("TraceID: %16X true\n", id)
 				return true
 			}
 		}
-		// fmt.Printf("TraceID: %16X false\n", id)
 		return false
 	}
 

--- a/pkg/util/traceidboundary/traceidboundary_test.go
+++ b/pkg/util/traceidboundary/traceidboundary_test.go
@@ -10,31 +10,70 @@ import (
 func TestPairs(t *testing.T) {
 	testCases := []struct {
 		shard, of     uint32
+		bits          int
 		expectedPairs []Boundary
 		expectedUpper bool
 	}{
+		//---------------------------------------------
+		// Simplest case, no sub-sharding,
+		// 4 shards all at the top level.
+		//---------------------------------------------
 		{
-			1, 2,
-			[]Boundary{
+			1, 4, 0, []Boundary{
 				{
-					[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},    // Min 63-bit value
-					[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0x40, 0, 0, 0, 0, 0, 0, 0}, // Half of 63-bit space (exlusive)
+					[]byte{0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+					[]byte{0x40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 				},
-				{
-					[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0x80, 0, 0, 0, 0, 0, 0, 0}, // Min 64-bit value (not overlapping with max 63-bit value)
-					[]byte{0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // Half of 128-bit space (exlusive)
-				},
-			},
-			false,
+			}, false,
 		},
 		{
-			2, 2, []Boundary{
+			2, 4, 0, []Boundary{
 				{
-					[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0x40, 0, 0, 0, 0, 0, 0, 0},                      // Half of 63-bit space
-					[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, // Max 63-bit space (inclusive)
+					[]byte{0x40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+					[]byte{0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				},
+			}, false,
+		},
+		{
+			3, 4, 0, []Boundary{
+				{
+					[]byte{0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+					[]byte{0xC0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				},
+			}, false,
+		},
+		{
+			4, 4, 0, []Boundary{
+				{
+					[]byte{0xC0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+					[]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
+				},
+			}, true,
+		},
+
+		//---------------------------------------------
+		// Sub-sharding of 1 bit down into 64-bit IDs.
+		//---------------------------------------------
+		{
+			1, 2, 1, []Boundary{
+				{
+					[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},    // Min value overall is always zero
+					[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0}, // Half of 64-bit space (exlusive)
 				},
 				{
-					[]byte{0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},                                              // Half of 128-bit space (not overlapping with max 63-bit value)
+					[]byte{0, 0, 0, 0, 0, 0, 0, 0x01, 0, 0, 0, 0, 0, 0, 0, 0}, // Min 65-bit value (not overlapping with max 64-bit value)
+					[]byte{0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // Half of 128-bit space (exlusive)
+				},
+			}, false,
+		},
+		{
+			2, 2, 1, []Boundary{
+				{
+					[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0},                      // Half of 64-bit space
+					[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, // Max 64-bit space (inclusive)
+				},
+				{
+					[]byte{0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},                                              // Half of 128-bit space (not overlapping with max 64-bit value)
 					[]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, // Max 128-bit value (inclusive)
 				},
 			}, true,
@@ -43,7 +82,7 @@ func TestPairs(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%d of %d", tc.shard, tc.of), func(t *testing.T) {
-			pairs, upper := Pairs(tc.shard, tc.of)
+			pairs, upper := PairsWithBitSharding(tc.shard, tc.of, tc.bits)
 			require.Equal(t, tc.expectedPairs, pairs)
 			require.Equal(t, tc.expectedUpper, upper)
 		})

--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -800,8 +800,8 @@ func TestTraceIDShardingQuality(t *testing.T) {
 		return block.Fetch(ctx, req, opts)
 	})
 
-	shardsToTest := []int{2, 5, 10, 100, 500, 1000, 2000}
-	bitsToTest := []int{ /*4, 8, 12, 16 20,*/ 24 /*28, 32*/}
+	shardsToTest := []int{2, 5, 10 /*, 100, 500, 1000, 2000*/}
+	bitsToTest := []int{4, 8, 12 /*16, 20, 24 /*28, 32*/}
 
 	for _, shards := range shardsToTest {
 		t.Run(strconv.Itoa(shards), func(t *testing.T) {

--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"math/rand"
+	"os"
 	"path"
 	"strconv"
 	"testing"
@@ -19,6 +21,7 @@ import (
 	"github.com/grafana/tempo/pkg/traceql"
 	"github.com/grafana/tempo/pkg/traceqlmetrics"
 	"github.com/grafana/tempo/pkg/util/test"
+	"github.com/grafana/tempo/pkg/util/traceidboundary"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/local"
 	"github.com/grafana/tempo/tempodb/encoding/common"
@@ -751,6 +754,110 @@ func BenchmarkBackendBlockQueryRange(b *testing.B) {
 					b.ReportMetric(float64(bytes)/float64(b.N)/1024.0/1024.0, "MB_IO/op")
 					b.ReportMetric(float64(spansTotal)/float64(b.N), "spans/op")
 					b.ReportMetric(float64(spansTotal)/b.Elapsed().Seconds(), "spans/s")
+				})
+			}
+		})
+	}
+}
+
+func TestTraceIDShardingQuality(t *testing.T) {
+	// Use debug=1 go test -v -run=TestTraceIDShardingQuality
+	if os.Getenv("debug") != "1" {
+		t.Skip()
+	}
+
+	var (
+		ctx      = context.TODO()
+		opts     = common.DefaultSearchOptions()
+		tenantID = "1"
+		// blockID  = uuid.MustParse("06ebd383-8d4e-4289-b0e9-cf2197d611d5")
+		blockID = uuid.MustParse("18364616-f80d-45a6-b2a3-cb63e203edff")
+		path    = "/Users/marty/src/tmp/"
+	)
+
+	r, _, _, err := local.New(&local.Config{
+		Path: path,
+	})
+	require.NoError(t, err)
+
+	rr := backend.NewReader(r)
+	meta, err := rr.BlockMeta(ctx, blockID, tenantID)
+	require.NoError(t, err)
+	require.Equal(t, VersionString, meta.Version)
+
+	block := newBackendBlock(meta, rr)
+	_, _, err = block.openForSearch(ctx, opts)
+	require.NoError(t, err)
+
+	fetchReq := traceql.FetchSpansRequest{
+		AllConditions: true,
+		Conditions: []traceql.Condition{
+			{Attribute: traceql.IntrinsicTraceIDAttribute},
+		},
+	}
+
+	f := traceql.NewSpansetFetcherWrapper(func(ctx context.Context, req traceql.FetchSpansRequest) (traceql.FetchSpansResponse, error) {
+		return block.Fetch(ctx, req, opts)
+	})
+
+	shardsToTest := []int{2, 5, 10, 100, 500, 1000, 2000}
+	bitsToTest := []int{ /*4, 8, 12, 16 20,*/ 24 /*28, 32*/}
+
+	for _, shards := range shardsToTest {
+		t.Run(strconv.Itoa(shards), func(t *testing.T) {
+			for _, bits := range bitsToTest {
+				t.Run(strconv.Itoa(bits), func(t *testing.T) {
+					// Create all shard-ownership functions
+					counts := make([]int, shards)
+					funcs := make([]func([]byte) bool, shards)
+					for s := 1; s <= shards; s++ {
+						funcs[s-1], _ = traceidboundary.FuncsWithBitSharding(uint32(s), uint32(shards), bits)
+					}
+
+					resp, err := f.Fetch(ctx, fetchReq)
+					require.NoError(t, err)
+					defer resp.Results.Close()
+
+					for {
+						ss, err := resp.Results.Next(ctx)
+						require.NoError(t, err)
+
+						if ss == nil {
+							break
+						}
+
+						// Match the trace ID against every shard
+						matches := 0
+						for i := 0; i < shards; i++ {
+							if funcs[i](ss.TraceID) {
+								counts[i]++
+								matches++
+								// fmt.Println("TraceID:", ss.TraceID, "is bucket", i)
+							}
+						}
+
+						if matches > 1 {
+							fmt.Println("TraceID matched mutiple shards:", ss.TraceID)
+							panic("trace matched multiple shards")
+						} else if matches == 0 {
+							fmt.Println("TraceID not matched by any shard:", ss.TraceID)
+							panic("trace id not matched by any shard")
+						}
+
+						ss.Release()
+					}
+
+					fmt.Println(counts)
+
+					sum := 0
+					minv := math.MaxInt
+					maxv := math.MinInt
+					for _, v := range counts {
+						sum += v
+						minv = min(minv, v)
+						maxv = max(maxv, v)
+					}
+					fmt.Printf("Shards:%d Bits:%d Total:%d spans Min:%d Max:%d Quality:%.1f %%\n", shards, bits, sum, minv, maxv, float64(minv)/float64(maxv)*100.0)
 				})
 			}
 		})


### PR DESCRIPTION
**What this PR does**:
Extends trace ID sharding further into the lower bit ranges.  This improves fairness of work on 8-byte trace IDs, which are unevenly weighted towards lower values (0x00...). This is a result of implementation details for various instrumentation libraries, languages, and pipelines.  From what I've seen so far this is not an issue for 16-byte trace IDs as they are distributed much more uniformly.

Added a test to help measure the quality of trace ID sharding, by going through a real block and counting the matches per shard.  Results for a randomly selected 13GB block from an internal cluster are below.   The ideal scenario is that counts across shards are even no matter how many.  Quality is the difference between the highest and lowest shards (Min and Max).   This improves the situation, but still a lot of room for more.  I didn't collect numbers from the previous behavior but it's worse than `Bits:4` (would be equivalent to `Bits:2`).

Default is 12 bits which gets most of the improvement at lower shard counts (<=100).  At higher shard counts it looks like we need to go higher (20+ bits), but I'd rather re-evaluate this whole approach after seeing this operate more at scale.

```
Shards:2 Bits:4  Total:2571975 spans Min:1122731 Max:1449244 Quality:77.5 %
Shards:2 Bits:8  Total:2571975 spans Min:1212589 Max:1359386 Quality:89.2 %
Shards:2 Bits:12 Total:2571975 spans Min:1245736 Max:1326239 Quality:93.9 %
Shards:2 Bits:16 Total:2571975 spans Min:1249382 Max:1322593 Quality:94.5 %
Shards:2 Bits:20 Total:2571975 spans Min:1250462 Max:1321513 Quality:94.6 %
Shards:2 Bits:24 Total:2571975 spans Min:1250540 Max:1321435 Quality:94.6 %

Shards:5 Bits:4  Total:2571975 spans Min:418131 Max:801432 Quality:52.2 %
Shards:5 Bits:8  Total:2571975 spans Min:451318 Max:638512 Quality:70.7 %
Shards:5 Bits:12 Total:2571975 spans Min:464477 Max:585527 Quality:79.3 %
Shards:5 Bits:16 Total:2571975 spans Min:465742 Max:578838 Quality:80.5 %
Shards:5 Bits:20 Total:2571975 spans Min:466142 Max:577178 Quality:80.8 %
Shards:5 Bits:24 Total:2571975 spans Min:466174 Max:577060 Quality:80.8 %

Shards:10 Bits:4  Total:2571975 spans Min:208969 Max:584477 Quality:35.8 %
Shards:10 Bits:8  Total:2571975 spans Min:225620 Max:393259 Quality:57.4 %
Shards:10 Bits:12 Total:2571975 spans Min:232157 Max:333721 Quality:69.6 %
Shards:10 Bits:16 Total:2571975 spans Min:232793 Max:326000 Quality:71.4 %
Shards:10 Bits:20 Total:2571975 spans Min:232997 Max:324122 Quality:71.9 %
Shards:10 Bits:24 Total:2571975 spans Min:233017 Max:323989 Quality:71.9 %

Shards:100 Bits:4  Total:2571975 spans Min:20644 Max:344153 Quality:6.0 %
Shards:100 Bits:8  Total:2571975 spans Min:22305 Max:127513 Quality:17.5 %
Shards:100 Bits:12 Total:2571975 spans Min:22932 Max:61940  Quality:37.0 %
Shards:100 Bits:16 Total:2571975 spans Min:23006 Max:53330  Quality:43.1 %
Shards:100 Bits:20 Total:2571975 spans Min:23034 Max:51245  Quality:44.9 %
Shards:100 Bits:24 Total:2571975 spans Min:23034 Max:51096  Quality:45.1 %

Shards:500 Bits:4  Total:2571975 spans Min:4047 Max:306322 Quality:1.3 %
Shards:500 Bits:8  Total:2571975 spans Min:4361 Max:87316  Quality:5.0 %
Shards:500 Bits:12 Total:2571975 spans Min:4490 Max:21212  Quality:21.2 %
Shards:500 Bits:16 Total:2571975 spans Min:4500 Max:12537  Quality:35.9 %
Shards:500 Bits:20 Total:2571975 spans Min:4503 Max:10436  Quality:43.1 %
Shards:500 Bits:24 Total:2571975 spans Min:4503 Max:10367  Quality:43.4 %

Shards:1000 Bits:4  Total:2571975 spans Min:1969 Max:301624 Quality:0.7 %
Shards:1000 Bits:8  Total:2571975 spans Min:2139 Max:82350  Quality:2.6 %
Shards:1000 Bits:12 Total:2571975 spans Min:2202 Max:16181  Quality:13.6 %
Shards:1000 Bits:16 Total:2571975 spans Min:2207 Max:7495   Quality:29.4 %
Shards:1000 Bits:20 Total:2571975 spans Min:2209 Max:5392   Quality:41.0 %
Shards:1000 Bits:24 Total:2571975 spans Min:2209 Max:5351   Quality:41.3 %
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`