### PR TITLE
Restore tempo_request_duration_seconds metrics for querier_api_* requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [BUGFIX] Move waitgroup handling for poller error condition [#3224](https://github.com/grafana/tempo/pull/3224) (@zalegrala)
 * [BUGFIX] Fix head block excessive locking in ingester search [#3328](https://github.com/grafana/tempo/pull/3328) (@mdisibio)
 * [BUGFIX] Fix issue with ingester failed to cut traces no such file or directory [#3346](https://github.com/grafana/tempo/issues/3346) (@mdisibio)
+* [BUGFIX] Restore `tempo_request_duration_seconds` metrics for `querier_api_*` requests [#3403](https://github.com/grafana/tempo/pull/3403) (@kvrhdn)
 * [ENHANCEMENT] Introduced `AttributePolicyMatch` & `IntrinsicPolicyMatch` structures to match span attributes based on strongly typed values & precompiled regexp [#3025](https://github.com/grafana/tempo/pull/3025) (@andriusluk)
 * [CHANGE] TraceQL/Structural operators performance improvement. [#3088](https://github.com/grafana/tempo/pull/3088) (@joe-elliott)
 * [CHANGE] Merge the processors overrides set through runtime overrides and user-configurable overrides [#3125](https://github.com/grafana/tempo/pull/3125) (@kvrhdn)

--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -199,11 +199,11 @@ func (t *App) Run() error {
 		t.InternalServer.HTTP.Path("/ready").Methods("GET").Handler(t.readyHandler(sm, shutdownRequested))
 	}
 
-	t.Server.HTTP().Path(addHTTPAPIPrefix(&t.cfg, api.PathBuildInfo)).Handler(t.buildinfoHandler()).Methods("GET")
+	t.Server.HTTPRouter().Path(addHTTPAPIPrefix(&t.cfg, api.PathBuildInfo)).Handler(t.buildinfoHandler()).Methods("GET")
 
-	t.Server.HTTP().Path("/ready").Handler(t.readyHandler(sm, shutdownRequested))
-	t.Server.HTTP().Path("/status").Handler(t.statusHandler()).Methods("GET")
-	t.Server.HTTP().Path("/status/{endpoint}").Handler(t.statusHandler()).Methods("GET")
+	t.Server.HTTPRouter().Path("/ready").Handler(t.readyHandler(sm, shutdownRequested))
+	t.Server.HTTPRouter().Path("/status").Handler(t.statusHandler()).Methods("GET")
+	t.Server.HTTPRouter().Path("/status/{endpoint}").Handler(t.statusHandler()).Methods("GET")
 	grpc_health_v1.RegisterHealthServer(t.Server.GRPC(),
 		grpcutil.NewHealthCheckFrom(
 			grpcutil.WithShutdownRequested(shutdownRequested),
@@ -497,7 +497,7 @@ func (t *App) writeStatusEndpoints(w io.Writer) error {
 
 	endpoints := []endpoint{}
 
-	err := t.Server.HTTP().Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+	err := t.Server.HTTPRouter().Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
 		e := endpoint{}
 
 		pathTemplate, err := route.GetPathTemplate()

--- a/cmd/tempo/app/server_service.go
+++ b/cmd/tempo/app/server_service.go
@@ -21,7 +21,8 @@ import (
 )
 
 type TempoServer interface {
-	HTTP() *mux.Router
+	HTTPRouter() *mux.Router
+	HTTPHandler() http.Handler
 	GRPC() *grpc.Server
 	Log() log.Logger
 	EnableHTTP2()
@@ -32,7 +33,8 @@ type TempoServer interface {
 
 // todo: evaluate whether the internal server should be included as part of this
 type tempoServer struct {
-	mux *mux.Router // all tempo http routes are added here
+	mux     *mux.Router  // all tempo http routes are added here
+	handler http.Handler // the final handler which includes the router and any middleware
 
 	externalServer  *server.Server // the standard server that all HTTP/GRPC requests are served on
 	enableHTTP2Once sync.Once
@@ -45,8 +47,12 @@ func newTempoServer() *tempoServer {
 	}
 }
 
-func (s *tempoServer) HTTP() *mux.Router {
+func (s *tempoServer) HTTPRouter() *mux.Router {
 	return s.mux
+}
+
+func (s *tempoServer) HTTPHandler() http.Handler {
+	return s.handler
 }
 
 func (s *tempoServer) GRPC() *grpc.Server {
@@ -71,22 +77,28 @@ func (s *tempoServer) StartAndReturnService(cfg server.Config, supportGRPCOnHTTP
 	var err error
 
 	metrics := server.NewServerMetrics(cfg)
-	// use tempo's mux unless we are doing grpc over http, then we will let the library instantiate its own
-	// router and piggy back on it to route grpc requests
-	cfg.Router = s.mux
-	if supportGRPCOnHTTP {
+	DisableSignalHandling(&cfg)
+
+	if !supportGRPCOnHTTP {
+		// We don't do any GRPC handling, let the library handle all routing for us
+		cfg.Router = s.mux
+
+		s.externalServer, err = server.NewWithMetrics(cfg, metrics)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create server: %w", err)
+		}
+		s.handler = s.externalServer.HTTPServer.Handler
+	} else {
+		// We want to route both GRPC and HTTP requests on the same endpoint
 		cfg.Router = nil
 		cfg.DoNotAddDefaultHTTPMiddleware = true // we don't want instrumentation on the "root" router, we want it on our mux. it will be added below.
-	}
 
-	DisableSignalHandling(&cfg)
-	s.externalServer, err = server.NewWithMetrics(cfg, metrics)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create server: %w", err)
-	}
+		s.externalServer, err = server.NewWithMetrics(cfg, metrics)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create server: %w", err)
+		}
 
-	// now that we have created the server and service let's setup our grpc/http router if necessary
-	if supportGRPCOnHTTP {
+		// now that we have created the server and service let's setup our grpc/http router if necessary
 		// for grpc to work we must enable h2c on the external server
 		s.EnableHTTP2()
 
@@ -96,7 +108,8 @@ func (s *tempoServer) StartAndReturnService(cfg server.Config, supportGRPCOnHTTP
 		if err != nil {
 			return nil, fmt.Errorf("failed to create http middleware: %w", err)
 		}
-		router := middleware.Merge(httpMiddleware...).Wrap(s.mux)
+
+		s.handler = middleware.Merge(httpMiddleware...).Wrap(s.mux)
 		s.externalServer.HTTP.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			// route to GRPC server if it's a GRPC request
 			if req.ProtoMajor == 2 && strings.Contains(req.Header.Get("Content-Type"), "application/grpc") {
@@ -105,7 +118,7 @@ func (s *tempoServer) StartAndReturnService(cfg server.Config, supportGRPCOnHTTP
 			}
 
 			// default to standard http server
-			router.ServeHTTP(w, req)
+			s.handler.ServeHTTP(w, req)
 		})
 	}
 


### PR DESCRIPTION
**What this PR does**:

Recent changes (I suspect https://github.com/grafana/tempo/pull/3300) broke middleware on our querier requests. We have HTTP middleware that provides tracing and metrics. Requests sent to the querier are routed slightly differently and due to this change we didn't get metrics anymore for the HTTP routes.

__Issue__
So `tempo_request_duration_seconds` does not show up for routes like `querier_api_search_tags` and `querier_api_traces_traceid`. GRPC routes were still instrumented correctly (`/tempopb.Querier/FindTraceByID` and `/tempopb.Querier/SearchTags`).

__How it works__
Normal middleware flow:

```
http.Handler.Serve --> middleware (tracing, metrics) --> mux.Router (calls the correct http.Handler for each path)
```

When we set `stream_over_http_enabled: false` this will be

```
http.Handler.Serve --> dskit.Server (with instrumentation middleware) --> Tempo's mux.Router
```

When we set `stream_over_http_enabled: true` we switch up the order a bit:

```
http.Handler.Server --> GRPC interceptor --> instrumentation middleware --> Tempo's Router
                        (1)                                                 (2)
```

The bug: requests from query-frontend to querier are handled differently, they are _pulled_ by the frontend worker process.
The frontend worker will pull a request from the frontend, unpack the GRPC requests and then push the HTTP request to the regular HTTP handler. This handler was the router (marked `(2)`), since this handler is after instrumentation we didn't get any metrics for it. By instead passing the start of the middleware chain (`(1)`) we fix this.

Adding `HTTPRouter` and `HTTPHandler` to `TempoServer` should make this more explicit.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`