### PR TITLE
Add PAT to checkout step for dependabot

### DIFF
--- a/.github/workflows/dependabot_serverless_gomod.yml
+++ b/.github/workflows/dependabot_serverless_gomod.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
+          token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
           ref: ${{ github.head_ref }}
 
       - name: Update serverless gomod


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: The checkout action automatically sets the gh.token in the header. This prevents dependabot's commit from triggering the workflow. This PR adds the PAT to the checkout action instead.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`