### PR TITLE
Fix spanmetrics latency underflow, prevent partial histogram scrape

### DIFF
--- a/modules/generator/processor/spanmetrics/spanmetrics.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics.go
@@ -138,7 +138,11 @@ func (p *Processor) aggregateMetrics(resourceSpans []*v1_trace.ResourceSpans) {
 }
 
 func (p *Processor) aggregateMetricsForSpan(svcName string, jobName string, instanceID string, rs *v1.Resource, span *v1_trace.Span, resourceLabels []string, resourceValues []string) {
-	latencySeconds := float64(span.GetEndTimeUnixNano()-span.GetStartTimeUnixNano()) / float64(time.Second.Nanoseconds())
+	// Spans with negative latency are treated as zero.
+	latencySeconds := 0.0
+	if start, end := span.GetStartTimeUnixNano(), span.GetEndTimeUnixNano(); start < end {
+		latencySeconds = float64(end-start) / float64(time.Second.Nanoseconds())
+	}
 
 	labelValues := make([]string, 0, 4+len(p.Cfg.Dimensions))
 	targetInfoLabelValues := make([]string, len(resourceLabels))


### PR DESCRIPTION
**What this PR does**:
Fixes 2 small bugs in the span metrics processor.

1. Latency underflow

As mentioned in #3338 the latency calculation will be incorrect if span End is < Start.  However it doesn't lead to a negative float64.  Because start and end are uint64 the calculation underflows to a very large uint64 before float64 conversion, for example float64(uint64(-1)) is `1.8446744073709552e+19`.  I'm not sure of the side effects from this all the way to the metrics backend, but in addition to the bad value the counter also stops increasing.  It no longer has enough precision to capture increments of +1.0.

Rather than ignore these spans, they are treated as zero latency. This ensures that _count and le buckets are still incremented.

2. Partial histogram scrape

The histograms counters are updated outside of lock. Therefore it's possible for a histogram to be scraped with inconsistent values.  For example if the histogram is scraped after incrementing `_count` but before incrementing `le="+Inf"`.  In all cases these metrics should be identical.   I addressed this by doing `updateSeries` under lock and reverting to `sync.Mutex` instead of `RWMutex`.  This has performance implications, but not sure of the degree in practice.  If we really need to avoid the lock, then we could make it more "failsafe" by changing the order of increments in `updateSeries`.  I.e. update the buckets in reverse order so `+Inf` is always highest even in a partial scrape.  Happy to discuss more.

**Which issue(s) this PR fixes**:
Relates to #3338   I don't think it fixes it

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`