### PR TITLE
Undocument cache options

### DIFF
--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -1516,8 +1516,6 @@ cache:
         # Allowed values:
         #   bloom              - Bloom filters for trace id lookup.
         #   parquet-footer     - Parquet footer values. Useful for search and trace by id lookup.
-        #   parquet-column-idx - Parquet column index values. Useful for search and trace by id lookup.
-        #   parquet-offset-idx - Parquet offset index values. Useful for search and trace by id lookup.
         #   parquet-page       - Parquet "pages". WARNING: This will attempt to cache most reads from parquet and, as a result, is very high volume.
         #   frontend-search    - Frontend search job results.
 


### PR DESCRIPTION
Removes documentation on two caching options that we don't use. I also believe these cache options are not even correctly used by Tempo.