### PR TITLE
[DOC] Restructure Configure section

### DIFF
--- a/docs/sources/helm-charts/tempo-distributed/get-started-helm-charts/_index.md
+++ b/docs/sources/helm-charts/tempo-distributed/get-started-helm-charts/_index.md
@@ -325,11 +325,11 @@ minio:
 
 Update the `storage` configuration options based upon your requirements:
 
-- [Amazon S3 configuration documentation]({{< relref "/docs/tempo/latest/configuration/s3" >}}). The Amazon S3 example is identical to the MinIO configuration. The two last options, `endpoint` and `insecure`, are dropped.
+- [Amazon S3 configuration documentation]({{< relref "/docs/tempo/latest/configuration/hosted-storage/s3" >}}). The Amazon S3 example is identical to the MinIO configuration. The two last options, `endpoint` and `insecure`, are dropped.
 
-- [Azure Blob Storage configuration documentation]({{< relref "/docs/tempo/latest/configuration/azure" >}})
+- [Azure Blob Storage configuration documentation]({{< relref "/docs/tempo/latest/configuration/hosted-storage/azure" >}})
 
-- [Google Cloud Storage configuration documentation]({{< relref "/docs/tempo/latest/configuration/gcs" >}})
+- [Google Cloud Storage configuration documentation]({{< relref "/docs/tempo/latest/configuration/hosted-storage/gcs" >}})
 
 ### Set traces receivers
 

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -38,7 +38,7 @@ The Tempo configuration options include:
   - [Usage-report](#usage-report)
   - [Cache](#cache)
 
-Additionally, you can review [TLS]({{< relref "./tls" >}}) to configure the cluster components to communicate over TLS, or receive traces over TLS.
+Additionally, you can review [TLS]({{< relref "./network/tls" >}}) to configure the cluster components to communicate over TLS, or receive traces over TLS.
 
 ## Use environment variables in the configuration
 
@@ -666,9 +666,9 @@ You can not use both local and object storage in the same Tempo deployment.
 The storage block is used to configure TempoDB.
 The following example shows common options. For further platform-specific information, refer to the following:
 
-* [GCS]({{< relref "./gcs" >}})
-* [S3]({{< relref "./s3" >}})
-* [Azure]({{< relref "./azure" >}})
+* [GCS]({{< relref "./hosted-storage/gcs" >}})
+* [S3]({{< relref "./hosted-storage/s3" >}})
+* [Azure]({{< relref "./hosted-storage/azure" >}})
 * [Parquet]({{< relref "./parquet" >}})
 
 ```yaml

--- a/docs/sources/tempo/configuration/compression.md
+++ b/docs/sources/tempo/configuration/compression.md
@@ -1,7 +1,7 @@
 ---
 title: Compression and encoding
 description: Learn about compression and encoding options available for Tempo.
-weight: 50
+weight: 200
 ---
 
 <!-- Page needs to be updated. -->

--- a/docs/sources/tempo/configuration/hosted-storage/_index.md
+++ b/docs/sources/tempo/configuration/hosted-storage/_index.md
@@ -1,0 +1,16 @@
+---
+title: Hosted storage
+menuTitle: Hosted storage
+description: Learn about Tempo's available hosted storage options and how to configure them.
+weight: 400
+aliases:
+- /docs/tempo/latest/configuration/
+---
+
+# Hosted storage
+
+Tempo provides additional hosted storage configuration options discussed on the pages below. These options relate to providers such as Google Cloud, AWS S3, and Azure.
+
+For additional details about storage configuration, refer to the [Storage configuration]({{< relref "../../configuration#storage" >}}).
+
+{{< section withDescriptions="true">}}

--- a/docs/sources/tempo/configuration/hosted-storage/azure.md
+++ b/docs/sources/tempo/configuration/hosted-storage/azure.md
@@ -2,7 +2,8 @@
 title: Azure blob storage permissions and management
 menuTitle: Azure blob storage
 description: Azure blog storage permissions and configuration options for Tempo.
-weight: 30
+aliases:
+  - ../../configuration/azure/ # /docs/tempo/<TEMPO_VERSION>/configuration/azure/
 ---
 
 # Azure blob storage permissions and management
@@ -20,6 +21,7 @@ Tempo requires the following configuration to authenticate to and access Azure b
 ## Sample configuration (for Tempo Monolithic Mode)
 
 ### Access key
+
 This sample configuration shows how to set up Azure blob storage using Helm charts and an access key from Kubernetes secrets.
 
 ```yaml
@@ -43,7 +45,7 @@ tempo:
 ```
 
 ### Azure Workload Identity
-Here is an example config for using Azure Workload Identity. 
+Here is an example config for using Azure Workload Identity.
 ```yaml
 tempo:
   storage:

--- a/docs/sources/tempo/configuration/hosted-storage/gcs.md
+++ b/docs/sources/tempo/configuration/hosted-storage/gcs.md
@@ -1,12 +1,13 @@
 ---
-title: Google Cloud Storage permissions
+title: Google Cloud Storage
 description: Learn about Google Cloud Storage permissions for Tempo.
-weight: 10
+aliases:
+  - ../../configuration/gcs/ # /docs/tempo/<TEMPO_VERSION>/configuration/gcs/
 ---
 
-# Google Cloud Storage permissions
+# Google Cloud Storage
 
-For configuration options, check the storage section on the [configuration]({{< relref "../configuration#storage" >}}) page.
+For configuration options, check the storage section on the [configuration]({{< relref "../../configuration#storage" >}}) page.
 
 ## Permissions
 

--- a/docs/sources/tempo/configuration/hosted-storage/s3.md
+++ b/docs/sources/tempo/configuration/hosted-storage/s3.md
@@ -1,11 +1,14 @@
 ---
 title: Amazon S3 permissions
+menuTitle: Amazon S3
 description: Set Amazon S3 permissions for Tempo.
-weight: 20
+aliases:
+  - ../../configuration/s3/ # /docs/tempo/<TEMPO_VERSION>/configuration/s3/
 ---
+
 # Amazon S3 permissions
 
-For configuration options, refer to the storage section on the [configuration]({{< relref "../configuration#storage" >}}) page.
+For configuration options, refer to the storage section on the [configuration]({{< relref "../../configuration#storage" >}}) page.
 
 The following authentication methods are supported:
 - AWS environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -1,7 +1,7 @@
 ---
 title: Manifest
 description: This manifest lists of all Tempo options and their defaults.
-weight: 70
+weight: 110
 ---
 
 # Manifest

--- a/docs/sources/tempo/configuration/network/_index.md
+++ b/docs/sources/tempo/configuration/network/_index.md
@@ -1,0 +1,13 @@
+---
+title: Network options
+menuTitle: Network options
+description: Learn about Tempo's available network options and how to configure them.
+weight: 500
+---
+
+# Network options
+
+
+Tempo provides additional network configuration options discussed on the pages below.
+
+{{< section withDescriptions="true" >}}

--- a/docs/sources/tempo/configuration/network/ipv6.md
+++ b/docs/sources/tempo/configuration/network/ipv6.md
@@ -1,14 +1,18 @@
 ---
 title: Configure IPv6
 description: Learn how to configure IPv6 for Tempo.
-weight: 37
+menuTitle: Configure IPv6
+aliases:
+  - ../../configuration/ipv6/ # /docs/tempo/<TEMPO_VERSION>/configuration/ipv6/
 ---
 
 # Configure IPv6
 
 Tempo can be configured to communicate between the components using Internet Protocol Version 6, or IPv6.
 
-> Note: In order to support this support this configuration, the underlying infrastructure must support this address family. This configuration may be used in a single-stack IPv6 environment, or in a dual-stack environment where both IPv6 and IPv4 are present. In a dual-stack scenario, only one address family may be configured at a time, and all components must be configured for that address family.
+{{% admonition type="note" %}}
+To support this support this configuration, the underlying infrastructure must support this address family. This configuration may be used in a single-stack IPv6 environment, or in a dual-stack environment where both IPv6 and IPv4 are present. In a dual-stack scenario, only one address family may be configured at a time, and all components must be configured for that address family.
+{{% /admonition %}}
 
 ## Protocol configuration
 

--- a/docs/sources/tempo/configuration/network/sidecar-proxy.md
+++ b/docs/sources/tempo/configuration/network/sidecar-proxy.md
@@ -1,13 +1,15 @@
 ---
-title: Run Tempo Distributed with sidecar proxies
+title: Run Tempo distributed with sidecar proxies
 menuTitle: Configure sidecar proxies
-description: Configure Tempo Distributed to run with sidecar proxies
-weight: 36
+description: Configure Tempo distributed to run with sidecar proxies
+aliases:
+  - ../../configuration/sidecar-proxy/ # /docs/tempo/<TEMPO_VERSION>/configuration/sidecar-proxy/
 ---
 
-# Run Tempo Distributed with sidecar proxies
+# Run Tempo distributed with sidecar proxies
 
-You can route inter-pod gRPC traffic run through a sidecar proxy to meet requirements such as custom security, routing, or logging.  Common examples include Envoy, Nginx, Traefik, or service meshes like Istio and Linkerd. 
+You can route inter-pod gRPC traffic run through a sidecar proxy to meet requirements such as custom security, routing, or logging.
+Common examples include Envoy, Nginx, Traefik, or service meshes like Istio and Linkerd.
 
 ## How Tempo pods communicate
 

--- a/docs/sources/tempo/configuration/network/tls.md
+++ b/docs/sources/tempo/configuration/network/tls.md
@@ -2,7 +2,8 @@
 title: Configure TLS communication
 menuTitle: Configure TLS
 description: Configure Tempo components to communicate using TLS.
-weight: 35
+aliases:
+  - ../../configuration/tls/ # /docs/tempo/<TEMPO_VERSION>/configuration/tls/
 ---
 
 # Configure TLS communication

--- a/docs/sources/tempo/configuration/parquet.md
+++ b/docs/sources/tempo/configuration/parquet.md
@@ -2,7 +2,7 @@
 title: Apache Parquet block format
 menuTitle: Apache Parquet
 description: Learn about Tempo's Parquet block format.
-weight: 75
+weight: 300
 ---
 
 # Apache Parquet block format

--- a/docs/sources/tempo/configuration/polling.md
+++ b/docs/sources/tempo/configuration/polling.md
@@ -1,7 +1,7 @@
 ---
 title: Polling
 description: Learn about Tempo's polling cycle configuration options.
-weight: 80
+weight: 700
 aliases:
 - /docs/tempo/configuration/polling
 ---

--- a/docs/sources/tempo/configuration/querying.md
+++ b/docs/sources/tempo/configuration/querying.md
@@ -1,19 +1,17 @@
 ---
-title: Query Tempo with Grafana
-menuTitle: Query Tempo with Grafana
+title: Use Tempo with Grafana
+menuTitle: Use Tempo with Grafana
 description: Learn how to configure and query Tempo with Grafana.
-weight: 40
+weight: 900
 ---
 
 <!-- Page is being deprecated because it describes versions of Grafana that are no longer supported. -->
 
-# Query Tempo with Grafana
+# Use Tempo with Grafana
 
-Grafana can query Tempo directly. This feature has been enabled since Grafana 7.5.x.
+You can use Tempo as a data source in Grafana to Tempo can query Grafana directly. Grafana Cloud comes pre-configured with a Tempo data source.
 
-Grafana Cloud comes pre-configured with a Tempo data source.
-
-If you are using Grafana on-prem, you need to [set up the Tempo data source](/docs/grafana/latest/datasources/tempo).
+If you are using Grafana on-prem, you need to [set up the Tempo data source](/docs/grafana/<GRAFANA_VERSION>/datasources/tempo).
 
 {{% admonition type="tip" %}}
 If you want to see what you can do with tracing data in Grafana, try the [Intro to Metrics, Logs, Traces, and Profiling example]({{< relref "../getting-started/docker-example" >}}).
@@ -25,12 +23,17 @@ This video explains how to add data sources, including Loki, Tempo, and Mimir, t
 
 ## Configure the data source
 
-To query Tempo with Grafana:
+For detailed instructions on the Tempo dta source in Grafana, refer to [Tempo data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/).
+
+To configure Tempo with Grafana:
 
 1. Point the Grafana data source at your Tempo query frontend (or monolithic mode Tempo).
 1. Enter the URL: `http://<tempo hostname>:<http port number>`. For most of [the Tempo examples](https://github.com/grafana/tempo/tree/main/example/docker-compose) the following works.
 
 The port of 3200 is a common port used in our examples. Tempo default HTTP port is 80.
 
-Prior to Grafana 7.5.x, Grafana was not able to query Tempo directly and required an intermediary, Tempoo-Query.
-This [the Grafana 7.4.x example](https://github.com/grafana/tempo/tree/main/example/docker-compose/grafana7.4) to explains  configuration. The URL entered is `http://<tempo-query hostname>:16686/`.
+## Query the data source
+
+Refer to [Tempo in Grafana]({{< relref "../getting-started/tempo-in-grafana" >}}) for an overview about how tracing data can be viewed and used in Grafana.
+
+For information on querying the Tempo data source, refer to [Tempo query editor](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/query-editor/).


### PR DESCRIPTION
**What this PR does**:
Restructures the table of contents for the Configure section of the docs by adding two new directories (Network and Hosted storage). No major content changes in this PR, only page movement (including link and alias updates, and two new summary pages added. 

New structure: 
![image](https://github.com/grafana/tempo/assets/104772500/ce8a1d35-bead-47ce-b4a5-cd1d3c88c33b)

Old structure: 
![image](https://github.com/grafana/tempo/assets/104772500/9981cd88-47ec-497d-9225-9e7b90321dbb)


**Which issue(s) this PR fixes**:
Fixes #https://github.com/grafana/tempo-squad/issues/396

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`