### PR TITLE
[DOC] Updates to 2.4 rel notes

### DIFF
--- a/docs/sources/tempo/release-notes/v2-4.md
+++ b/docs/sources/tempo/release-notes/v2-4.md
@@ -139,7 +139,8 @@ For information on upgrading, refer to [Upgrade to Tempo 2.4]({{< relref "../set
   </tr>
     <tr>
    <td>
-```
+
+```yaml
 storage:
   trace:
     cache:

--- a/docs/sources/tempo/release-notes/v2-4.md
+++ b/docs/sources/tempo/release-notes/v2-4.md
@@ -17,7 +17,8 @@ This release gives you:
 
 As part of this release, vParquet3 has also been promoted to the new default storage format for traces. For more about why we’re so excited about vParquet3, refer to [Accelerate TraceQL queries at scale with dedicated attribute columns in Grafana Tempo](/blog/2024/01/22/accelerate-traceql-queries-at-scale-with-dedicated-attribute-columns-in-grafana-tempo/).
 
-Read the [Tempo 2.4 blog post](/blog/2023/11/01/grafana-tempo-2.3-release-faster-trace-queries-traceql-upgrades/) for more examples and details about these improvements.
+<!-- Need updated blog post link
+Read the [Tempo 2.4 blog post](/blog/2023/11/01/grafana-tempo-2.3-release-faster-trace-queries-traceql-upgrades/) for more examples and details about these improvements. -->
 
 These release notes highlight the most important features and bugfixes. For a complete list, refer to the [Tempo changelog](https://github.com/grafana/tempo/releases).
 

--- a/docs/sources/tempo/release-notes/v2-4.md
+++ b/docs/sources/tempo/release-notes/v2-4.md
@@ -167,7 +167,7 @@ Those issues were corrected [in PR 3300](https://github.com/grafana/tempo/pull/3
 
 ### Cache configuration refactored
 
-The major cache refactor to allow multiple role-based caches to be configured. [[PR 3166](https://github.com/grafana/tempo/pull/3166)]
+The major cache refactor allows multiple role-based caches to be configured. [[PR 3166](https://github.com/grafana/tempo/pull/3166)]
 This change resulted in the following fields being deprecated.
 These have all been migrated to a top level `cache:` field.
 


### PR DESCRIPTION

**What this PR does**:
Minor updates to the 2.4 release notes: 

* Removes the inactive blog post link for 2.4. This should be able to be live in the enxt day or two. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`