### PR TITLE
[TraceQL Metrics] Fix handling of empties and nils + other fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [ENHANCEMENT] Add string interning to TraceQL queries [#3411](https://github.com/grafana/tempo/pull/3411) (@mapno)
 * [BUGFIX] Fix metrics query results when filtering and rating on the same attribute [#3428](https://github.com/grafana/tempo/issues/3428) (@mdisibio)
+* [BUGFIX] Fix metrics query results when series contain empty strings or nil values [#3429](https://github.com/grafana/tempo/issues/3429) (@mdisibio)
 * [BUGFIX] Return unfiltered results when a bad TraceQL query is provided in autocomplete. [#3426](https://github.com/grafana/tempo/pull/3426) (@mapno)
 
 ## v2.4.0

--- a/modules/generator/instance.go
+++ b/modules/generator/instance.go
@@ -427,7 +427,7 @@ func (i *instance) queryRangeTraceQLToProto(set traceql.SeriesSet, req *tempopb.
 			labels = append(labels,
 				commonv1proto.KeyValue{
 					Key:   label.Name,
-					Value: traceql.NewStaticString(label.Value).AsAnyValue(),
+					Value: label.Value.AsAnyValue(),
 				},
 			)
 		}

--- a/modules/generator/instance_test.go
+++ b/modules/generator/instance_test.go
@@ -296,9 +296,6 @@ func Test_instanceQueryRangeTraceQLToProto(t *testing.T) {
 	instance, err := newInstance(&cfg, "test", &overrides, &noopStorage{}, prometheus.DefaultRegisterer, logger, nil)
 	assert.NoError(t, err)
 
-	// k1 := traceql.Label{Key: traceql.NewAttribute("."), Value: traceql.NewStaticString("nil")}
-	ls1 := labels.FromStrings("a", "b")
-
 	req := &tempopb.QueryRangeRequest{
 		Query: "{}",
 		Start: 1700143700617413958, // 3 minute window
@@ -308,7 +305,7 @@ func Test_instanceQueryRangeTraceQLToProto(t *testing.T) {
 
 	ts := instance.queryRangeTraceQLToProto(traceql.SeriesSet{
 		"": traceql.TimeSeries{
-			Labels: ls1,
+			Labels: []traceql.Label{{Name: "a", Value: traceql.NewStaticString("b")}},
 			Values: []float64{17.566666666666666, 18.133333333333333, 17.3, 14.533333333333333, 0, 0, 0},
 		},
 	}, req)

--- a/modules/querier/querier_query_range.go
+++ b/modules/querier/querier_query_range.go
@@ -147,7 +147,7 @@ func queryRangeTraceQLToProto(set traceql.SeriesSet, req *tempopb.QueryRangeRequ
 			labels = append(labels,
 				v1.KeyValue{
 					Key:   label.Name,
-					Value: traceql.NewStaticString(label.Value).AsAnyValue(),
+					Value: label.Value.AsAnyValue(),
 				},
 			)
 		}

--- a/pkg/api/http.go
+++ b/pkg/api/http.go
@@ -344,10 +344,9 @@ func ParseQueryRangeRequest(r *http.Request) (*tempopb.QueryRangeRequest, error)
 
 	step, err := step(r, start, end)
 	if err != nil {
-		req.Step = traceql.DefaultQueryRangeStep(uint64(start.UnixNano()), uint64(end.UnixNano()))
-	} else {
-		req.Step = uint64(step)
+		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}
+	req.Step = uint64(step.Nanoseconds())
 
 	if of, err := strconv.Atoi(r.Form.Get(urlParamShardCount)); err == nil {
 		req.ShardCount = uint32(of)
@@ -458,15 +457,9 @@ func parseTimestamp(value string, def time.Time) (time.Time, error) {
 func step(r *http.Request, start, end time.Time) (time.Duration, error) {
 	value := r.Form.Get(urlParamStep)
 	if value == "" {
-		return time.Duration(defaultQueryRangeStep(start, end)) * time.Second, nil
+		return time.Duration(traceql.DefaultQueryRangeStep(uint64(start.UnixNano()), uint64(end.UnixNano()))), nil
 	}
 	return parseSecondsOrDuration(value)
-}
-
-// defaultQueryRangeStep returns the default step used in the query range API,
-// which is dynamically calculated based on the time range
-func defaultQueryRangeStep(start time.Time, end time.Time) int {
-	return int(math.Max(math.Floor(end.Sub(start).Seconds()/250), 1))
 }
 
 func parseSecondsOrDuration(value string) (time.Duration, error) {

--- a/pkg/tempopb/tempo.pb.go
+++ b/pkg/tempopb/tempo.pb.go
@@ -2878,16 +2878,13 @@ func (m *Sample) GetValue() float64 {
 	return 0
 }
 
-// https : // github.com/grafana/mimir/blob/main/pkg/mimirpb/mimir.proto#L53
 type TimeSeries struct {
-	// repeated LabelPair labels = 1 [(gogoproto.nullable) = false,
-	// (gogoproto.customtype) = "LabelAdapter"];
+	// Series labels containing name and value. Data-type aware.
 	Labels []v1.KeyValue `protobuf:"bytes,1,rep,name=labels,proto3" json:"labels"`
 	// Sorted by time, oldest sample first.
 	Samples []Sample `protobuf:"bytes,2,rep,name=samples,proto3" json:"samples"`
-	// repeated Exemplar exemplars = 3 [ (gogoproto.nullable) = false ];
-	// repeated Histogram histograms = 4 [ (gogoproto.nullable) = false ];
-	// TODO: review the LabelAdapter and migrate the use of this string
+	// prom_labels are a flattened string-only version of the typed labels.
+	// They are used internally and may differ from official prometheus conventions.
 	PromLabels string `protobuf:"bytes,3,opt,name=prom_labels,json=promLabels,proto3" json:"prom_labels,omitempty"`
 }
 

--- a/pkg/tempopb/tempo.proto
+++ b/pkg/tempopb/tempo.proto
@@ -369,15 +369,14 @@ message Sample {
   double value = 1;
 }
 
-// https : // github.com/grafana/mimir/blob/main/pkg/mimirpb/mimir.proto#L53
 message TimeSeries {
-  // repeated LabelPair labels = 1 [(gogoproto.nullable) = false,
-  // (gogoproto.customtype) = "LabelAdapter"];
+  // Series labels containing name and value. Data-type aware.
   repeated tempopb.common.v1.KeyValue labels = 1 [(gogoproto.nullable) = false];
+  
   // Sorted by time, oldest sample first.
   repeated Sample samples = 2 [(gogoproto.nullable) = false];
-  // repeated Exemplar exemplars = 3 [ (gogoproto.nullable) = false ];
-  // repeated Histogram histograms = 4 [ (gogoproto.nullable) = false ];
-  // TODO: review the LabelAdapter and migrate the use of this string
+
+  // prom_labels are a flattened string-only version of the typed labels.
+  // They are used internally and may differ from official prometheus conventions.
   string prom_labels = 3;
 }


### PR DESCRIPTION
**What this PR does**:
Basically this overhauls the handling of timeseries labels for metrics queries.  There are several fixes in here, but it also lines up behavior with: https://github.com/grafana/grafana/pull/83619

* Empty strings were previously dropped but now they are preserved. For example: `{rootName=""} | rate() by (rootName)`.  This would look like a completely empty labelset in the response and cause issues downstream.  Now it's preserved as the single label `rootName` with an empty string value.
* When all labels are nil, we were backfilling a single label with the text "<nil>" to make Grafana happy like.  This was actually premature specialization for the prometheus-compatible API, and now that we have the new dedicated Tempo-UI we can fix this.  Now nils are dropped entirely and handled in the frontend. They will become `{}` in the Tempo UI and the query name in the Prometheus UI (a fallback method).  Note:  the `EmitDefaults:true` is part of this so that Tempo always outputs an empty array in the json (and not nil).
* Fix sorting.  Previously we only sorted during the conversion to Prometheus format.  Also fix sorting to handle non-strings and multiple label values correctly.
* Fix default step calculation and error handling.

**Which issue(s) this PR fixes**:
Fixes #3429 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`