### PR TITLE
[DOC] Add blog post link to 2.4 rel notes

### DIFF
--- a/docs/sources/tempo/release-notes/v2-4.md
+++ b/docs/sources/tempo/release-notes/v2-4.md
@@ -17,10 +17,11 @@ This release gives you:
 
 As part of this release, vParquet3 has also been promoted to the new default storage format for traces. For more about why we’re so excited about vParquet3, refer to [Accelerate TraceQL queries at scale with dedicated attribute columns in Grafana Tempo](/blog/2024/01/22/accelerate-traceql-queries-at-scale-with-dedicated-attribute-columns-in-grafana-tempo/).
 
-<!-- Need updated blog post link
-Read the [Tempo 2.4 blog post](/blog/2023/11/01/grafana-tempo-2.3-release-faster-trace-queries-traceql-upgrades/) for more examples and details about these improvements. -->
+Read the [Tempo 2.4 blog post](/blog/2024/02/29/grafana-tempo-2.4-release-traceql-metrics-tiered-caching-and-tco-improvements/) for more examples and details about these improvements.
 
 These release notes highlight the most important features and bugfixes. For a complete list, refer to the [Tempo changelog](https://github.com/grafana/tempo/releases).
+
+{{< youtube id="EYUx2DkNRas" >}}
 
 ## Features and enhancements
 


### PR DESCRIPTION

**What this PR does**: 

Adds a link to the Tempo 2.4 blog post and includes the YouTube video in the release notes

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`