### PR TITLE
Fix 429s tripping SLOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [BUGFIX] Fix metrics query results when filtering and rating on the same attribute [#3428](https://github.com/grafana/tempo/issues/3428) (@mdisibio)
 * [BUGFIX] Fix metrics query results when series contain empty strings or nil values [#3429](https://github.com/grafana/tempo/issues/3429) (@mdisibio)
 * [BUGFIX] Return unfiltered results when a bad TraceQL query is provided in autocomplete. [#3426](https://github.com/grafana/tempo/pull/3426) (@mapno)
+* [BUGFIX] Correctly handle 429s in GRPC search streaming. [#3469](https://github.com/grafana/tempo/pull/3469) (@joe-ellitot)
 
 ## v2.4.0
 

--- a/modules/frontend/combiner/common.go
+++ b/modules/frontend/combiner/common.go
@@ -152,6 +152,8 @@ func (c *genericCombiner[T]) erroredResponse() (*http.Response, error) {
 	var grpcErr error
 	if c.httpStatusCode/100 == 5 {
 		grpcErr = status.Error(codes.Internal, c.httpRespBody)
+	} else if c.httpStatusCode == http.StatusTooManyRequests {
+		grpcErr = status.Error(codes.ResourceExhausted, c.httpRespBody)
 	} else {
 		grpcErr = status.Error(codes.InvalidArgument, c.httpRespBody)
 	}

--- a/modules/frontend/combiner/search_test.go
+++ b/modules/frontend/combiner/search_test.go
@@ -167,7 +167,7 @@ func TestSearchResponseCombiner(t *testing.T) {
 			response1:         toHTTPResponse(t, &tempopb.SearchResponse{Metrics: &tempopb.SearchMetrics{}}, 200),
 			response2:         toHTTPResponse(t, nil, 429),
 			expectedStatus:    429,
-			expectedGRPCError: status.Error(codes.InvalidArgument, ""),
+			expectedGRPCError: status.Error(codes.ResourceExhausted, ""),
 		},
 		{
 			name:              "500+404",

--- a/modules/frontend/search_handlers_test.go
+++ b/modules/frontend/search_handlers_test.go
@@ -448,7 +448,7 @@ func TestSearchFailurePropagatesFromQueriers(t *testing.T) {
 			querierMessage:  "too fast!",
 			expectedCode:    429,
 			expectedMessage: "too fast!",
-			expectedErr:     status.Error(codes.InvalidArgument, "too fast!"),
+			expectedErr:     status.Error(codes.ResourceExhausted, "too fast!"),
 		},
 	}
 

--- a/modules/frontend/slos_test.go
+++ b/modules/frontend/slos_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/grafana/tempo/pkg/util/test"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestSLOHook(t *testing.T) {
@@ -29,6 +31,11 @@ func TestSLOHook(t *testing.T) {
 		{
 			name: "no slo fails : error",
 			err:  errors.New("foo"),
+		},
+		{
+			name:            "no slo passes : resource exhausted grpc error",
+			err:             status.Error(codes.ResourceExhausted, "foo"),
+			expectedWithSLO: 1.0,
 		},
 		{
 			name:           "no slo fails : 5XX status code",

--- a/modules/frontend/v1/frontend.go
+++ b/modules/frontend/v1/frontend.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/grafana/dskit/flagext"
@@ -25,8 +24,6 @@ import (
 	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/pkg/validation"
 )
-
-var errTooManyRequest = httpgrpc.Errorf(http.StatusTooManyRequests, "too many outstanding requests")
 
 // Config for a Frontend.
 type Config struct {
@@ -377,11 +374,7 @@ func (f *Frontend) queueRequest(ctx context.Context, req *request) error {
 	joinedTenantID := tenant.JoinTenantIDs(tenantIDs)
 	f.activeUsers.UpdateUserTimestamp(joinedTenantID, now)
 
-	err = f.requestQueue.EnqueueRequest(joinedTenantID, req, maxQueriers)
-	if errors.Is(err, queue.ErrTooManyRequests) {
-		return errTooManyRequest
-	}
-	return err
+	return f.requestQueue.EnqueueRequest(joinedTenantID, req, maxQueriers)
 }
 
 // CheckReady determines if the query frontend is ready.  Function parameters/return


### PR DESCRIPTION
**What this PR does**
- Correctly translates "queue full" into a 429 for the http pipeline
- Correctly propagates ResourceExhausted gRPC error instead of InvalidArgument
- Correctly prevents 429s from counting against SLOs

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`