### PR TITLE
Doc update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ Tempo documentation is located in the `docs` directory. The `docs` directory has
 Once you know what you would like to write, use the [Writer's Toolkit](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-documentation/) for information on creating good documentation.
 The toolkit also provides [document templates](https://github.com/grafana/writers-toolkit/tree/main/docs/static/templates) to help get started.
 
-When you create a PR for documentation, add the `types/doc` label to identify the PR as contributing documentation.
+When you create a PR for documentation, add the `type/doc` label to identify the PR as contributing documentation.
 
 If your content needs to be added to a previous release, use the `backport` label for the version. When your PR is merged, the backport label triggers an automatic process to create an additional PR to merge the content into the version's branch. Check the PR for content that might not be appropriate for the version. For example, if you fix a broken link on a page and then backport to Tempo 1.5, you would not want any TraceQL information to appear.
 

--- a/docs/sources/tempo/getting-started/example-demo-app.md
+++ b/docs/sources/tempo/getting-started/example-demo-app.md
@@ -48,4 +48,4 @@ To learn how to set up a Tempo cluster, see [Deploy on Kubernetes with Tanka]({{
 
 The [Introduction to Metrics, Logs and Traces in Grafana](https://github.com/grafana/intro-to-mlt) provides a self-contained environment for learning about Mimir, Loki, Tempo, and Grafana. It includes detailed explanations of each compononent, annotated configurations for each component.
 
-The README.md file has full details on how to quickly download and [start the environment](https://github.com/grafana/intro-to-mlt#running-the-demonstration-environment). Additionally, you can use the [`ctl.sh`](https://github.com/grafana/intro-to-mlt#grafana-cloud) script to alter the environment to send metrics, logs, and traces to Grafana Cloud.
+The README.md file has full details on how to quickly download and [start the environment](https://github.com/grafana/intro-to-mlt#running-the-demonstration-environment), including instructions for using Grafana Cloud and the OpenTelemetry Agent.


### PR DESCRIPTION
**What this PR does**:

Removes a reference to ctl.sh which was [removed from mltp](https://github.com/grafana/intro-to-mltp/commit/13354c1919a8153a02b62cea986ad2f575da9d1b).

Additionally, I noticed when doing a PR for the first fix that all the labels on the project are singular, so I went with what is live in the repo and (presumably) corrected the markdown.