### PR TITLE
Return rate limit error according to ingestion rate strategy

### DIFF
--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -282,9 +282,8 @@ func (d *Distributor) checkForRateLimits(tracesSize, spanCount int, userID strin
 	if !d.ingestionRateLimiter.AllowN(now, userID, tracesSize) {
 		overrides.RecordDiscardedSpans(spanCount, reasonRateLimited, userID)
 		limit := int(d.ingestionRateLimiter.Limit(now, userID))
-		if (reflect.TypeOf(*d.ingestionRateLimiter) == reflect.TypeOf(globalStrategy{})) {
-			numDistributors := d.DistributorRing.InstancesCount()
-			limit = limit * numDistributors
+		if reflect.TypeOf(*d.ingestionRateLimiter) == reflect.TypeOf(globalStrategy{}) {
+			limit = limit * d.DistributorRing.InstancesCount()
 		}
 		return status.Errorf(codes.ResourceExhausted,
 			"%s: ingestion rate limit (%d bytes) exceeded while adding %d bytes for user %s",

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -29,9 +29,6 @@ const (
 	// GlobalIngestionRateStrategy indicates that an attempt should be made to consider this limit across the entire Tempo cluster
 	GlobalIngestionRateStrategy = "global"
 
-	// IngestionRateUser since ingestion rate strategy is not per tenant config
-	IngestionRateUserVariable = "ingestion rate strategy user variable"
-
 	// ErrorPrefixLiveTracesExceeded is used to flag batches from the ingester that were rejected b/c they had too many traces
 	ErrorPrefixLiveTracesExceeded = "LIVE_TRACES_EXCEEDED"
 	// ErrorPrefixTraceTooLarge is used to flag batches from the ingester that were rejected b/c they exceeded the single trace limit

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -29,6 +29,9 @@ const (
 	// GlobalIngestionRateStrategy indicates that an attempt should be made to consider this limit across the entire Tempo cluster
 	GlobalIngestionRateStrategy = "global"
 
+	// IngestionRateUser since ingestion rate strategy is not per tenant config
+	IngestionRateUserVariable = "ingestion rate strategy user variable"
+
 	// ErrorPrefixLiveTracesExceeded is used to flag batches from the ingester that were rejected b/c they had too many traces
 	ErrorPrefixLiveTracesExceeded = "LIVE_TRACES_EXCEEDED"
 	// ErrorPrefixTraceTooLarge is used to flag batches from the ingester that were rejected b/c they exceeded the single trace limit

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -275,8 +275,8 @@ func (o *runtimeConfigOverridesManager) GetRuntimeOverridesFor(userID string) *O
 // to each distributor instance (local) or evenly shared across the cluster (global).
 func (o *runtimeConfigOverridesManager) IngestionRateStrategy() string {
 	// The ingestion rate strategy can't be overridden on a per-tenant basis,
-	// so here we just pick the value for a not-existing user ID (empty string).
-	return o.getOverridesForUser("").Ingestion.RateStrategy
+	// so here we just pass this specific variable to fetch the defaults value.
+	return o.getOverridesForUser(IngestionRateUserVariable).Ingestion.RateStrategy
 }
 
 // MaxLocalTracesPerUser returns the maximum number of traces a user is allowed to store
@@ -484,7 +484,7 @@ func (o *runtimeConfigOverridesManager) DedicatedColumns(userID string) backend.
 }
 
 func (o *runtimeConfigOverridesManager) getOverridesForUser(userID string) *Overrides {
-	if tenantOverrides := o.tenantOverrides(); tenantOverrides != nil {
+	if tenantOverrides := o.tenantOverrides(); tenantOverrides != nil && userID != IngestionRateUserVariable {
 		l := tenantOverrides.forUser(userID)
 		if l != nil {
 			return l
@@ -496,6 +496,7 @@ func (o *runtimeConfigOverridesManager) getOverridesForUser(userID string) *Over
 		}
 	}
 
+	fmt.Println("default overrides")
 	return o.defaultLimits
 }
 

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -275,8 +275,8 @@ func (o *runtimeConfigOverridesManager) GetRuntimeOverridesFor(userID string) *O
 // to each distributor instance (local) or evenly shared across the cluster (global).
 func (o *runtimeConfigOverridesManager) IngestionRateStrategy() string {
 	// The ingestion rate strategy can't be overridden on a per-tenant basis,
-	// so here we just pass this specific variable to fetch the defaults value.
-	return o.getOverridesForUser(IngestionRateUserVariable).Ingestion.RateStrategy
+	// so here we are returning the defaults overrides
+	return o.defaultLimits.Ingestion.RateStrategy
 }
 
 // MaxLocalTracesPerUser returns the maximum number of traces a user is allowed to store
@@ -484,7 +484,7 @@ func (o *runtimeConfigOverridesManager) DedicatedColumns(userID string) backend.
 }
 
 func (o *runtimeConfigOverridesManager) getOverridesForUser(userID string) *Overrides {
-	if tenantOverrides := o.tenantOverrides(); tenantOverrides != nil && userID != IngestionRateUserVariable {
+	if tenantOverrides := o.tenantOverrides(); tenantOverrides != nil {
 		l := tenantOverrides.forUser(userID)
 		if l != nil {
 			return l

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -496,7 +496,6 @@ func (o *runtimeConfigOverridesManager) getOverridesForUser(userID string) *Over
 		}
 	}
 
-	fmt.Println("default overrides")
 	return o.defaultLimits
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: Currently, for all rate_limited errors regardless of the ingestion rate strategy, Tempo returns the local strategy limit. This causes confusion for setups that use the global strategy. This PR correctly returns the limit according to the ingestion rate strategy. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`