### PR TITLE
[DOC] Clarify linux setup insecure setting

### DIFF
--- a/docs/sources/tempo/setup/linux.md
+++ b/docs/sources/tempo/setup/linux.md
@@ -109,7 +109,7 @@ storage:
       endpoint: s3.us-east-1.amazonaws.com
       bucket: grafana-traces-data
       forcepathstyle: true
-      # set to false if endpoint is https
+      # set insecure to false if endpoint is https; use true if endpoint is http
       insecure: true
       access_key: # TODO - Add S3 access key
       secret_key: # TODO - Add S3 secret key


### PR DESCRIPTION
**What this PR does**:

We had a request for clarification on the Linux set up doc in the docs mailing list. We've added some clarification to make sure it's clear `insecure:true` is used for http and `insecure:false` is used for https in the S3 storage configuration block. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`