### PR TITLE
Query Frontend Refactor: Fix goroutine leaks

### DIFF
--- a/modules/frontend/pipeline/async_handler_multitenant.go
+++ b/modules/frontend/pipeline/async_handler_multitenant.go
@@ -50,7 +50,7 @@ func (t *tenantRoundTripper) RoundTrip(req *http.Request) (Responses[*http.Respo
 	// join tenants for logger because list value type is unsupported.
 	_ = level.Debug(t.logger).Log("msg", "handling multi-tenant query", "tenants", strings.Join(tenants, ","))
 
-	return NewAsyncSharderFunc(0, len(tenants), func(tenantIdx int) *http.Request {
+	return NewAsyncSharderFunc(req.Context(), 0, len(tenants), func(tenantIdx int) *http.Request {
 		if tenantIdx >= len(tenants) {
 			return nil
 		}

--- a/modules/frontend/pipeline/async_sharding.go
+++ b/modules/frontend/pipeline/async_sharding.go
@@ -26,7 +26,7 @@ func NewAsyncSharderFunc(concurrentReqs, totalReqs int, reqFn func(i int) *http.
 	asyncResp := newAsyncResponse()
 
 	go func() {
-		defer asyncResp.done()
+		defer asyncResp.SendComplete()
 
 		for i := 0; i < totalReqs; i++ {
 			req := reqFn(i)
@@ -96,9 +96,8 @@ func NewAsyncSharderChan(concurrentReqs int, reqs <-chan *http.Request, resps Re
 			asyncResp.Send(resps)
 		}
 
-		// and wait for all the workers to finish
 		wg.Wait()
-		asyncResp.done()
+		asyncResp.SendComplete()
 	}()
 
 	return asyncResp

--- a/modules/frontend/pipeline/async_sharding_test.go
+++ b/modules/frontend/pipeline/async_sharding_test.go
@@ -21,7 +21,7 @@ func TestAsyncSharders(t *testing.T) {
 		{
 			name: "AsyncSharder",
 			responseFn: func(next AsyncRoundTripper[*http.Response]) *asyncResponse {
-				return NewAsyncSharderFunc(10, expectedRequestCount, func(i int) *http.Request {
+				return NewAsyncSharderFunc(context.Background(), 10, expectedRequestCount, func(i int) *http.Request {
 					if i >= expectedRequestCount {
 						return nil
 					}
@@ -32,7 +32,7 @@ func TestAsyncSharders(t *testing.T) {
 		{
 			name: "AsyncSharder - no limit",
 			responseFn: func(next AsyncRoundTripper[*http.Response]) *asyncResponse {
-				return NewAsyncSharderFunc(0, expectedRequestCount, func(i int) *http.Request {
+				return NewAsyncSharderFunc(context.Background(), 0, expectedRequestCount, func(i int) *http.Request {
 					if i >= expectedRequestCount {
 						return nil
 					}
@@ -51,7 +51,7 @@ func TestAsyncSharders(t *testing.T) {
 					close(reqChan)
 				}()
 
-				return NewAsyncSharderChan(10, reqChan, nil, next).(*asyncResponse)
+				return NewAsyncSharderChan(context.Background(), 10, reqChan, nil, next).(*asyncResponse)
 			},
 		},
 	}

--- a/modules/frontend/pipeline/collector_grpc.go
+++ b/modules/frontend/pipeline/collector_grpc.go
@@ -36,6 +36,7 @@ func (c GRPCCollector[T]) RoundTrip(req *http.Request) error {
 	if err != nil {
 		return grpcError(err)
 	}
+	defer resps.NextComplete()
 
 	// stores any error that occurs during the streaming
 	//  the wg protects the store from concurrent writes/reads
@@ -99,6 +100,7 @@ func (c GRPCCollector[T]) RoundTrip(req *http.Request) error {
 	if err != nil {
 		return grpcError(err)
 	}
+
 	return nil
 }
 

--- a/modules/frontend/pipeline/collector_grpc.go
+++ b/modules/frontend/pipeline/collector_grpc.go
@@ -36,7 +36,6 @@ func (c GRPCCollector[T]) RoundTrip(req *http.Request) error {
 	if err != nil {
 		return grpcError(err)
 	}
-	defer resps.NextComplete()
 
 	// stores any error that occurs during the streaming
 	//  the wg protects the store from concurrent writes/reads

--- a/modules/frontend/pipeline/collector_http.go
+++ b/modules/frontend/pipeline/collector_http.go
@@ -34,7 +34,6 @@ func (r httpCollector) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resps.NextComplete()
 
 	for {
 		resp, done, err := resps.Next(ctx)

--- a/modules/frontend/pipeline/collector_http.go
+++ b/modules/frontend/pipeline/collector_http.go
@@ -34,6 +34,7 @@ func (r httpCollector) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resps.NextComplete()
 
 	for {
 		resp, done, err := resps.Next(ctx)
@@ -58,5 +59,6 @@ func (r httpCollector) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	resp, err := r.combiner.HTTPFinal()
+
 	return resp, err
 }

--- a/modules/frontend/pipeline/responses.go
+++ b/modules/frontend/pipeline/responses.go
@@ -101,16 +101,18 @@ func (a *asyncResponse) SendComplete() {
 
 // NextComplete indicates the receiver is done. We drain all channels and subchannels to goroutines are orphaned
 func (a *asyncResponse) NextComplete() {
-	// drain the response channel?
-	for resps := range a.respChan {
-		if resps != nil {
-			resps.NextComplete()
+	go func() {
+		// drain the response channel?
+		for resps := range a.respChan {
+			if resps != nil {
+				resps.NextComplete()
+			}
 		}
-	}
 
-	if a.curResponses != nil {
-		a.curResponses.NextComplete()
-	}
+		if a.curResponses != nil {
+			a.curResponses.NextComplete()
+		}
+	}()
 }
 
 // Next returns the next http.Response or an error if one is available. It always prefers an error over a response.

--- a/modules/frontend/pipeline/responses.go
+++ b/modules/frontend/pipeline/responses.go
@@ -67,7 +67,6 @@ type asyncResponse struct {
 	respChan chan Responses[*http.Response]
 	errChan  chan error
 	err      *atomic.Error
-	//done     *atomic.Bool
 
 	curResponses Responses[*http.Response]
 }
@@ -77,7 +76,6 @@ func newAsyncResponse() *asyncResponse {
 		respChan: make(chan Responses[*http.Response]),
 		errChan:  make(chan error, 1),
 		err:      atomic.NewError(nil),
-		//done:     atomic.NewBool(false),
 	}
 }
 

--- a/modules/frontend/pipeline/responses_test.go
+++ b/modules/frontend/pipeline/responses_test.go
@@ -314,7 +314,7 @@ func TestAsyncResponsesDoesNotLeak(t *testing.T) {
 				goleak.VerifyNone(t, leakOpts)
 			})
 
-			//grpc
+			// grpc
 			t.Run("grpc", func(t *testing.T) {
 				leakOpts := goleak.IgnoreCurrent()
 				ctx, cancel := context.WithCancel(context.Background())
@@ -336,7 +336,7 @@ func TestAsyncResponsesDoesNotLeak(t *testing.T) {
 				goleak.VerifyNone(t, leakOpts)
 			})
 
-			//multiple sharder tiers
+			// multiple sharder tiers
 			t.Run("multiple sharder tiers", func(t *testing.T) {
 				leakOpts := goleak.IgnoreCurrent()
 				ctx, cancel := context.WithCancel(context.Background())
@@ -349,7 +349,6 @@ func TestAsyncResponsesDoesNotLeak(t *testing.T) {
 				}
 
 				s := sharder{next: sharder{next: bridge}, funcSharder: true}
-				//s := sharder{next: sharder{next: bridge, funcSharder: true}}
 				grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](s, combiner.NewNoOp().(combiner.GRPCCombiner[*tempopb.SearchResponse]), func(sr *tempopb.SearchResponse) error { return nil })
 
 				_ = grpcCollector.RoundTrip(req)

--- a/modules/frontend/pipeline/responses_test.go
+++ b/modules/frontend/pipeline/responses_test.go
@@ -382,7 +382,6 @@ func TestAsyncResponsesDoesNotLeak(t *testing.T) {
 
 				goleak.VerifyNone(t, leakOpts)
 			})
-
 		})
 	}
 }

--- a/modules/frontend/search_handlers_test.go
+++ b/modules/frontend/search_handlers_test.go
@@ -135,6 +135,7 @@ func TestFrontendSearch(t *testing.T) {
 		leakOpts := goleak.IgnoreCurrent()
 		f := frontendWithSettings(t, nil, nil, nil, nil)
 		runner(t, f)
+		time.Sleep(5 * time.Second) // give sleeping goroutines a chance to wake up
 		goleak.VerifyNone(t, leakOpts)
 	}
 }

--- a/modules/frontend/search_handlers_test.go
+++ b/modules/frontend/search_handlers_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
+	"go.uber.org/goleak"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 
@@ -131,8 +132,10 @@ func TestFrontendSearch(t *testing.T) {
 	}
 
 	for _, runner := range allRunners {
+		leakOpts := goleak.IgnoreCurrent()
 		f := frontendWithSettings(t, nil, nil, nil, nil)
 		runner(t, f)
+		goleak.VerifyNone(t, leakOpts)
 	}
 }
 

--- a/modules/frontend/search_handlers_test.go
+++ b/modules/frontend/search_handlers_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
-	"go.uber.org/goleak"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 
@@ -132,11 +131,8 @@ func TestFrontendSearch(t *testing.T) {
 	}
 
 	for _, runner := range allRunners {
-		leakOpts := goleak.IgnoreCurrent()
 		f := frontendWithSettings(t, nil, nil, nil, nil)
 		runner(t, f)
-		time.Sleep(5 * time.Second) // give sleeping goroutines a chance to wake up
-		goleak.VerifyNone(t, leakOpts)
 	}
 }
 

--- a/modules/frontend/search_sharder.go
+++ b/modules/frontend/search_sharder.go
@@ -137,7 +137,7 @@ func (s asyncSearchSharder) RoundTrip(r *http.Request) (pipeline.Responses[*http
 	}
 
 	// execute requests
-	return pipeline.NewAsyncSharderChan(s.cfg.ConcurrentRequests, reqCh, jobMetricsResponse, s.next), nil
+	return pipeline.NewAsyncSharderChan(ctx, s.cfg.ConcurrentRequests, reqCh, jobMetricsResponse, s.next), nil
 }
 
 // blockMetas returns all relevant blockMetas given a start/end


### PR DESCRIPTION
- Add Send/NextComplete methods that must be called by the producer/consumer to guarantee cleanup of resources
- Add goroutine leak tests using built pipelines and the async response