### PR TITLE
[DOC] fix typo in setup/operator/monolithic.md

### DIFF
--- a/docs/sources/tempo/setup/operator/monolithic.md
+++ b/docs/sources/tempo/setup/operator/monolithic.md
@@ -9,7 +9,7 @@ aliases:
 
 # Monolithic deployment
 
-The `TempoMonolithic` Custom Resource (CR) creates a Tempo deployment in [Monolithic mode](https:grafana.com/docs/tempo/<TEMPO_VERSION>/setup/deployment/#monolithic-mode).
+The `TempoMonolithic` Custom Resource (CR) creates a Tempo deployment in [Monolithic mode](https://grafana.com/docs/tempo/<TEMPO_VERSION>/setup/deployment/#monolithic-mode).
 In this mode, all components of the Tempo deployment (compactor, distributor, ingester, querier and query-frontend) are contained in a single container.
 
 This type of deployment is ideal for small deployments, demo and test setups, and supports storing traces in memory, in a Persistent Volume and in object storage.


### PR DESCRIPTION
**What this PR does**:
fixes a typo in setup/operator/monolithic.md

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`