### PR TITLE
[TraceQL Metrics] More changes to 8-byte trace ID sharding

### DIFF
--- a/pkg/util/traceidboundary/traceidboundary_test.go
+++ b/pkg/util/traceidboundary/traceidboundary_test.go
@@ -10,79 +10,71 @@ import (
 func TestPairs(t *testing.T) {
 	testCases := []struct {
 		shard, of     uint32
-		bits          int
 		expectedPairs []Boundary
 		expectedUpper bool
 	}{
 		//---------------------------------------------
-		// Simplest case, no sub-sharding,
-		// 4 shards all at the top level.
+		// Simplest case, 2 shards
 		//---------------------------------------------
-		{
-			1, 4, 0, []Boundary{
-				{
-					[]byte{0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-					[]byte{0x40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-				},
-			}, false,
-		},
-		{
-			2, 4, 0, []Boundary{
-				{
-					[]byte{0x40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-					[]byte{0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-				},
-			}, false,
-		},
-		{
-			3, 4, 0, []Boundary{
-				{
-					[]byte{0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-					[]byte{0xC0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-				},
-			}, false,
-		},
-		{
-			4, 4, 0, []Boundary{
-				{
-					[]byte{0xC0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-					[]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
-				},
-			}, true,
-		},
-
-		//---------------------------------------------
-		// Sub-sharding of 1 bit down into 64-bit IDs.
-		//---------------------------------------------
-		{
-			1, 2, 1, []Boundary{
-				{
-					[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},    // Min value overall is always zero
-					[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0}, // Half of 64-bit space (exlusive)
-				},
-				{
-					[]byte{0, 0, 0, 0, 0, 0, 0, 0x01, 0, 0, 0, 0, 0, 0, 0, 0}, // Min 65-bit value (not overlapping with max 64-bit value)
-					[]byte{0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // Half of 128-bit space (exlusive)
-				},
-			}, false,
-		},
-		{
-			2, 2, 1, []Boundary{
-				{
-					[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0},                      // Half of 64-bit space
-					[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, // Max 64-bit space (inclusive)
-				},
-				{
-					[]byte{0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},                                              // Half of 128-bit space (not overlapping with max 64-bit value)
-					[]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, // Max 128-bit value (inclusive)
-				},
-			}, true,
-		},
+		{1, 2, []Boundary{
+			{
+				// First half of upper-byte = 0 (between 0x0000 and 0x00FF)
+				[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0x80, 0, 0, 0, 0, 0, 0},
+			},
+			{
+				// First half of upper-nibble = 0 (between 0x01 and 0x0F)
+				[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0x01, 0, 0, 0, 0, 0, 0, 0},
+				[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0x08, 0x80, 0, 0, 0, 0, 0, 0},
+			},
+			{
+				// First half of upper-bit = 0 (between 0x10 and 0x7F)
+				[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0x10, 0, 0, 0, 0, 0, 0, 0},
+				[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0x48, 0, 0, 0, 0, 0, 0, 0},
+			},
+			{
+				// First half of full 8-byte ids (between 0x80 and 0xFF)
+				[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0x80, 0, 0, 0, 0, 0, 0, 0},
+				[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0},
+			},
+			{
+				// First half of full 16-byte ids (between 0x00 and 0x80)
+				[]byte{0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0},
+				[]byte{0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			},
+		}, false},
+		{2, 2, []Boundary{
+			{
+				// Second half of upper-byte = 0 (between 0x0000 and 0x00FF)
+				[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0x80, 0, 0, 0, 0, 0, 0},
+				[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
+			},
+			{
+				// Second half of upper-nibble = 0 (between 0x01 and 0x0F)
+				[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0x08, 0x80, 0, 0, 0, 0, 0, 0},
+				[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0x0F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
+			},
+			{
+				// Second half of upper-bit = 0 (between 0x10 and 0x7F)
+				[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0x48, 0, 0, 0, 0, 0, 0, 0},
+				[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
+			},
+			{
+				// Second half of full 8-byte ids (between 0x80 and 0xFF)
+				[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0},
+				[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
+			},
+			{
+				// Second half of full 16-byte ids (between 0x80 and 0xFF)
+				[]byte{0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				[]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
+			},
+		}, true},
 	}
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%d of %d", tc.shard, tc.of), func(t *testing.T) {
-			pairs, upper := PairsWithBitSharding(tc.shard, tc.of, tc.bits)
+			pairs, upper := Pairs(tc.shard, tc.of)
 			require.Equal(t, tc.expectedPairs, pairs)
 			require.Equal(t, tc.expectedUpper, upper)
 		})


### PR DESCRIPTION
**What this PR does**:
This PR is more changes to the sharding of 8-byte trace IDs for metrics.  Previously I did #3399 but it ended up with a regression on large blocks.  It accomplished making the job sizes more even, but inadvertently inspected a lot more row groups per job (because the traces responsible by the shard were "too" spread out).  This reverts things more closely to the original, but with more hand-picked regions.  It reduces row groups a lot while losing only a little bit of job uniformity.

traces per shard:
```
Before:
Shards:10   Traces: Min:232157 Max:333721 Total:2571975 Avg:257197.5  Quality:69.6 %
Shards:100  Traces: Min:22932  Max:61940  Total:2571975 Avg:25719.8   Quality:37.0 %
Shards:1000 Traces: Min:2202   Max:16181  Total:2571975 Avg:2572.0    Quality:13.6 %

After:
Shards:10   Traces: Min:220590  Max:395612  Total:2571975  Avg: 257197.5  Quality:55.8 %
Shards:100  Traces: Min:21827   Max:69869   Total:2571975  Avg: 25719.8   Quality:31.2 %
Shards:1000 Traces: Min:2070    Max:7241    Total:2571975  Avg: 2572.0    Quality:28.6 %
```

Row groups per shard.  Less than half the number of row groups at 100+ shards
```
Shards:10   RowGroups: Min:31  Max:42  Total:356   Avg:35.6 Quality:73.8 %
Shards:100  RowGroups: Min:13  Max:18  Total:1481  Avg:14.8 Quality:72.2 %
Shards:1000 RowGroups: Min:12  Max:16  Total:12731 Avg:12.7 Quality:75.0 %

Shards:10   RowGroups: Min:22  Max:58  Total:279  Avg: 27.9 Quality:37.9 %
Shards:100  RowGroups: Min:5   Max:12  Total:709  Avg: 7.1 Quality:41.7 %
Shards:1000 RowGroups: Min:4   Max:8   Total:5010 Avg: 5.0 Quality:50.0 %
```

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`