### PR TITLE
Context.canceled handling changes for slo and receiver shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [BUGFIX] Add support for dashes, quotes and spaces in attribute names in autocomplete [#3458](https://github.com/grafana/tempo/pull/3458) (@mapno)
 * [BUGFIX] Correctly handle 429s in GRPC search streaming. [#3469](https://github.com/grafana/tempo/pull/3469) (@joe-ellitot)
 * [BUGFIX] Correctly cancel GRPC and HTTP contexts in the frontend to prevent having to rely on http write timeout. [#3443](https://github.com/grafana/tempo/pull/3443) (@joe-elliott)
+* [BUGFIX] Fix client disconnect errors to not count against SLOs or be returned to the client [#3505](https://github.com/grafana/tempo/pull/3505) (@mdisibio) 
 * [BUGFIX] Fix compaction/retention in AWS S3 and GCS when a prefix is configured. [#3465](https://github.com/grafana/tempo/issues/3465) (@bpfoster)
 
 ## v2.4.0

--- a/modules/distributor/receiver/shim.go
+++ b/modules/distributor/receiver/shim.go
@@ -2,6 +2,7 @@ package receiver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -342,6 +343,12 @@ func (r *receiversShim) ConsumeTraces(ctx context.Context, td ptrace.Traces) err
 	metricPushDuration.Observe(time.Since(start).Seconds())
 	if err != nil {
 		r.logger.Log("msg", "pusher failed to consume trace data", "err", err)
+
+		// Client disconnects are logged but not propogated back.
+		if errors.Is(err, context.Canceled) {
+			return nil
+		}
+
 		err = wrapErrorIfRetryable(err, r.retryDelay)
 	}
 

--- a/modules/frontend/slos_test.go
+++ b/modules/frontend/slos_test.go
@@ -1,6 +1,7 @@
 package frontend
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"testing"
@@ -31,6 +32,11 @@ func TestSLOHook(t *testing.T) {
 		{
 			name: "no slo fails : error",
 			err:  errors.New("foo"),
+		},
+		{
+			name:            "client disconnect (context canceled) passes",
+			err:             context.Canceled,
+			expectedWithSLO: 1.0,
 		},
 		{
 			name:            "no slo passes : resource exhausted grpc error",


### PR DESCRIPTION
**What this PR does**:

Addresses two places where a client disconnect could cause unexpected behavior and false alarms:
* SLO calculation - if a client disconnects while calling an API, now it's considered within SLO
* Pushing traces - if a client disconnects while pushing traces, now we ignore and don't propagate a 5xx upstream. The error is still logged to help troubleshooting   

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`