### PR TITLE
operations: change query-frontend maxSurge to 0 for better rollouts

### DIFF
--- a/operations/jsonnet-compiled/Deployment-query-frontend.yaml
+++ b/operations/jsonnet-compiled/Deployment-query-frontend.yaml
@@ -13,7 +13,7 @@ spec:
       name: query-frontend
   strategy:
     rollingUpdate:
-      maxSurge: 3
+      maxSurge: 0
       maxUnavailable: 1
   template:
     metadata:

--- a/operations/jsonnet-compiled/util/jsonnetfile.lock.json
+++ b/operations/jsonnet-compiled/util/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "84e49c8549fa472c963862f233422c8b368afabe",
+      "version": "7561fd330312538d22b00e0c7caecb4ba66321ea",
       "sum": "0y3AFX9LQSpfWTxWKSwoLgbt0Wc9nnCwhMH2szKzHv0="
     },
     {
@@ -18,7 +18,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "84e49c8549fa472c963862f233422c8b368afabe",
+      "version": "7561fd330312538d22b00e0c7caecb4ba66321ea",
       "sum": "Cc715Y3rgTuimgDFIw+FaKzXSJGRYwt1pFTMbdrNBD8="
     },
     {

--- a/operations/jsonnet/microservices/frontend.libsonnet
+++ b/operations/jsonnet/microservices/frontend.libsonnet
@@ -61,7 +61,7 @@
         app: target_name,
       }
     ) +
-    deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(3) +
+    deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(0) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
     deployment.mixin.spec.template.metadata.withAnnotations({
       config_hash: std.md5(std.toString($.tempo_query_frontend_configmap.data['tempo.yaml'])),


### PR DESCRIPTION
**What this PR does**:

Modify maxSurge in query-frontend deployment to 0, this config makes the rollouts of query-frontends more stable.

During a rollout, maxSurge added extra replicas, and it would result in queriers splitting the the connections across the old and new frontends. that resulted in reduced capacity on the old query frontends, and queries getting `context cancelled` or timeout when we rolled out query frontends.

With updated config, k8s will rollout one pod at a time and that makes rollout more stable.

**Which issue(s) this PR fixes**:
Fixes #

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`