### PR TITLE
parquetquery iterator less pooling

### DIFF
--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -970,6 +970,11 @@ func (c *SyncIterator) closeCurrRowGroup() {
 func (c *SyncIterator) makeResult(t RowNumber, v *pq.Value) *IteratorResult {
 	// Use same static result instead of pooling
 	c.at.RowNumber = t
+
+	// The length of the Entries slice indicates if we should return the
+	// value or just the row number. This has already been checked during
+	// creation. SyncIterator reads a single column so the slice will
+	// always have length 0 or 1.
 	if len(c.at.Entries) == 1 {
 		if c.intern {
 			c.at.Entries[0].Value = c.interner.UnsafeClone(v)

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -345,13 +345,6 @@ type IteratorResult struct {
 		Key   string
 		Value interface{}
 	}
-	ReleaseFn func(*IteratorResult)
-}
-
-func (r *IteratorResult) Release() {
-	if r != nil && r.ReleaseFn != nil {
-		r.ReleaseFn(r)
-	}
 }
 
 func (r *IteratorResult) Reset() {
@@ -491,14 +484,14 @@ type LeftJoinIteratorOption interface {
 }
 
 type PoolOption struct {
-	pool PoolFn
+	pool *ResultPool
 }
 
 // WithPool allows setting a custom result pool for this iterator. Custom pooling
 // can be useful to keep similar sized results together or to isolate data. By
 // default all iterators use a shared pool.
 func WithPool(p *ResultPool) PoolOption {
-	return PoolOption{p.Get}
+	return PoolOption{p}
 }
 
 func (o PoolOption) applyToJoinIterator(j *JoinIterator) {
@@ -1328,7 +1321,8 @@ type JoinIterator struct {
 	lowestIters     []int
 	peeks           []*IteratorResult
 	pred            GroupPredicate
-	pool            PoolFn
+	pool            *ResultPool
+	at              *IteratorResult
 }
 
 var _ Iterator = (*JoinIterator)(nil)
@@ -1340,12 +1334,15 @@ func NewJoinIterator(definitionLevel int, iters []Iterator, pred GroupPredicate,
 		lowestIters:     make([]int, len(iters)),
 		peeks:           make([]*IteratorResult, len(iters)),
 		pred:            pred,
-		pool:            DefaultPool.Get,
+		pool:            DefaultPool,
 	}
 
 	for _, opt := range opts {
 		opt.applyToJoinIterator(j)
 	}
+
+	j.at = j.pool.Get()
+
 	return j
 }
 
@@ -1413,9 +1410,6 @@ func (j *JoinIterator) Next() (*IteratorResult, error) {
 				// Yes
 				return result, nil
 			}
-
-			// Result discarded
-			result.Release()
 		}
 
 		// Skip all iterators to the highest row seen, it's impossible
@@ -1440,7 +1434,6 @@ func (j *JoinIterator) seekAll(t RowNumber, d int) error {
 	t = TruncateRowNumber(d, t)
 	for iterNum, iter := range j.iters {
 		if j.peeks[iterNum] == nil || CompareRowNumbers(d, j.peeks[iterNum].RowNumber, t) == -1 {
-			j.peeks[iterNum].Release()
 			j.peeks[iterNum], err = iter.SeekTo(t, d)
 			if err != nil {
 				return err
@@ -1467,16 +1460,13 @@ func (j *JoinIterator) peek(iterNum int) (*IteratorResult, error) {
 func (j *JoinIterator) collect(rowNumber RowNumber) (*IteratorResult, error) {
 	var err error
 
-	result := j.pool()
+	result := j.at
+	result.Reset()
 	result.RowNumber = rowNumber
 
 	for i := range j.iters {
 		for j.peeks[i] != nil && EqualRowNumber(j.definitionLevel, j.peeks[i].RowNumber, rowNumber) {
-
 			result.Append(j.peeks[i])
-
-			j.peeks[i].Release()
-
 			j.peeks[i], err = j.iters[i].Next()
 			if err != nil {
 				return nil, err
@@ -1490,6 +1480,7 @@ func (j *JoinIterator) Close() {
 	for _, i := range j.iters {
 		i.Close()
 	}
+	j.pool.Release(j.at)
 }
 
 // LeftJoinIterator joins two or more iterators for matches at the given definition level.
@@ -1502,7 +1493,8 @@ type LeftJoinIterator struct {
 	lowestIters                  []int
 	peeksRequired, peeksOptional []*IteratorResult
 	pred                         GroupPredicate
-	pool                         PoolFn
+	pool                         *ResultPool
+	at                           *IteratorResult
 }
 
 var _ Iterator = (*LeftJoinIterator)(nil)
@@ -1523,12 +1515,14 @@ func NewLeftJoinIterator(definitionLevel int, required, optional []Iterator, pre
 		peeksRequired:   make([]*IteratorResult, len(required)),
 		peeksOptional:   make([]*IteratorResult, len(optional)),
 		pred:            pred,
-		pool:            DefaultPool.Get,
+		pool:            DefaultPool,
 	}
 
 	for _, opt := range opts {
 		opt.applyToLeftJoinIterator(j)
 	}
+
+	j.at = j.pool.Get()
 
 	return j, nil
 }
@@ -1601,9 +1595,6 @@ func (j *LeftJoinIterator) Next() (*IteratorResult, error) {
 				// Yes
 				return result, nil
 			}
-
-			// Result discarded
-			result.Release()
 		}
 
 		// Skip all iterators to the highest row seen, it's impossible
@@ -1628,7 +1619,6 @@ func (j *LeftJoinIterator) seekAll(t RowNumber, d int) (err error) {
 	t = TruncateRowNumber(d, t)
 	for iterNum, iter := range j.required {
 		if j.peeksRequired[iterNum] == nil || CompareRowNumbers(d, j.peeksRequired[iterNum].RowNumber, t) == -1 {
-			j.peeksRequired[iterNum].Release()
 			j.peeksRequired[iterNum], err = iter.SeekTo(t, d)
 			if err != nil {
 				return
@@ -1637,7 +1627,6 @@ func (j *LeftJoinIterator) seekAll(t RowNumber, d int) (err error) {
 	}
 	for iterNum, iter := range j.optional {
 		if j.peeksOptional[iterNum] == nil || CompareRowNumbers(d, j.peeksOptional[iterNum].RowNumber, t) == -1 {
-			j.peeksOptional[iterNum].Release()
 			j.peeksOptional[iterNum], err = iter.SeekTo(t, d)
 			if err != nil {
 				return
@@ -1663,7 +1652,9 @@ func (j *LeftJoinIterator) peek(iterNum int) (*IteratorResult, error) {
 // or are exhausted.
 func (j *LeftJoinIterator) collect(rowNumber RowNumber) (*IteratorResult, error) {
 	var err error
-	result := j.pool()
+
+	result := j.at
+	result.Reset()
 	result.RowNumber = rowNumber
 
 	collect := func(iters []Iterator, peeks []*IteratorResult) {
@@ -1671,7 +1662,7 @@ func (j *LeftJoinIterator) collect(rowNumber RowNumber) (*IteratorResult, error)
 			// Collect matches
 			for peeks[i] != nil && EqualRowNumber(j.definitionLevel, peeks[i].RowNumber, rowNumber) {
 				result.Append(peeks[i])
-				peeks[i].Release()
+				// peeks[i].Release()
 				peeks[i], err = iters[i].Next()
 				if err != nil {
 					return
@@ -1705,6 +1696,7 @@ func (j *LeftJoinIterator) Close() {
 	for _, i := range j.optional {
 		i.Close()
 	}
+	j.pool.Release(j.at)
 }
 
 // UnionIterator produces all results for all given iterators.  When iterators
@@ -1716,6 +1708,7 @@ type UnionIterator struct {
 	lowestIters     []int
 	peeks           []*IteratorResult
 	pred            GroupPredicate
+	at              IteratorResult
 }
 
 var _ Iterator = (*UnionIterator)(nil)
@@ -1783,7 +1776,6 @@ func (u *UnionIterator) Next() (*IteratorResult, error) {
 		// from at least one iterator, or all are exhausted
 		if len(u.lowestIters) > 0 {
 			if u.pred != nil && !u.pred.KeepGroup(result) {
-				result.Release()
 				continue
 			}
 
@@ -1826,13 +1818,13 @@ func (u *UnionIterator) peek(iterNum int) (*IteratorResult, error) {
 func (u *UnionIterator) collect(iterNums []int, rowNumber RowNumber) (*IteratorResult, error) {
 	var err error
 
-	result := DefaultPool.Get()
+	result := &u.at
+	result.Reset()
 	result.RowNumber = rowNumber
 
 	for _, iterNum := range iterNums {
 		for u.peeks[iterNum] != nil && EqualRowNumber(u.definitionLevel, u.peeks[iterNum].RowNumber, rowNumber) {
 			result.Append(u.peeks[iterNum])
-			u.peeks[iterNum].Release()
 			u.peeks[iterNum], err = u.iters[iterNum].Next()
 			if err != nil {
 				return nil, err

--- a/pkg/parquetquery/pool.go
+++ b/pkg/parquetquery/pool.go
@@ -8,11 +8,6 @@ import (
 
 var DefaultPool = NewResultPool(10)
 
-type (
-	PoolFn    func() *IteratorResult
-	ReleaseFn func(*IteratorResult)
-)
-
 type ResultPool struct {
 	pool *sync.Pool
 	cap  int
@@ -42,7 +37,6 @@ func (p *ResultPool) Get() *IteratorResult {
 			Key   string
 			Value any
 		}, 0, p.cap),
-		ReleaseFn: p.Release,
 	}
 }
 

--- a/tempodb/encoding/vparquet2/block_traceql.go
+++ b/tempodb/encoding/vparquet2/block_traceql.go
@@ -572,8 +572,6 @@ func (i *bridgeIterator) Next() (*parquetquery.IteratorResult, error) {
 			}
 		}
 
-		res.Release()
-
 		sort.Slice(i.nextSpans, func(j, k int) bool {
 			return parquetquery.CompareRowNumbers(DefinitionLevelResourceSpansILSSpan, i.nextSpans[j].rowNum, i.nextSpans[k].rowNum) == -1
 		})
@@ -694,7 +692,6 @@ func (i *rebatchIterator) Next() (*parquetquery.IteratorResult, error) {
 			i.nextSpans = append(i.nextSpans, sp)
 		}
 
-		res.Release()
 		putSpanset(ss) // Repool the spanset but not the spans which have been moved to nextSpans as needed.
 
 		res = i.resultFromNextSpans()
@@ -750,8 +747,6 @@ func (i *spansetIterator) Next(context.Context) (*traceql.Spanset, error) {
 	if res == nil {
 		return nil, nil
 	}
-
-	defer res.Release()
 
 	// The spanset is in the OtherEntries
 	iface := res.OtherValueFromKey(otherEntrySpansetKey)

--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -702,8 +702,6 @@ func (i *bridgeIterator) Next() (*parquetquery.IteratorResult, error) {
 			}
 		}
 
-		res.Release()
-
 		sort.Slice(i.nextSpans, func(j, k int) bool {
 			return parquetquery.CompareRowNumbers(DefinitionLevelResourceSpansILSSpan, i.nextSpans[j].rowNum, i.nextSpans[k].rowNum) == -1
 		})
@@ -824,7 +822,6 @@ func (i *rebatchIterator) Next() (*parquetquery.IteratorResult, error) {
 			i.nextSpans = append(i.nextSpans, sp)
 		}
 
-		res.Release()
 		putSpanset(ss) // Repool the spanset but not the spans which have been moved to nextSpans as needed.
 
 		res = i.resultFromNextSpans()
@@ -880,8 +877,6 @@ func (i *spansetIterator) Next(context.Context) (*traceql.Spanset, error) {
 	if res == nil {
 		return nil, nil
 	}
-
-	defer res.Release()
 
 	// The spanset is in the OtherEntries
 	iface := res.OtherValueFromKey(otherEntrySpansetKey)

--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -701,10 +701,10 @@ func BenchmarkBackendBlockQueryRange(b *testing.B) {
 		opts     = common.DefaultSearchOptions()
 		tenantID = "1"
 		// blockID  = uuid.MustParse("06ebd383-8d4e-4289-b0e9-cf2197d611d5")
-		blockID = uuid.MustParse("0008e57d-069d-4510-a001-b9433b2da08c")
-		// blockID = uuid.MustParse("18364616-f80d-45a6-b2a3-cb63e203edff")
-		// path = "/Users/marty/src/tmp/"
-		path = "/Users/mapno/workspace/testblock"
+		// blockID = uuid.MustParse("0008e57d-069d-4510-a001-b9433b2da08c")
+		blockID = uuid.MustParse("18364616-f80d-45a6-b2a3-cb63e203edff")
+		path    = "/Users/marty/src/tmp/"
+		// path = "/Users/mapno/workspace/testblock"
 	)
 
 	r, _, _, err := local.New(&local.Config{
@@ -727,7 +727,7 @@ func BenchmarkBackendBlockQueryRange(b *testing.B) {
 
 	for _, tc := range testCases {
 		b.Run(tc, func(b *testing.B) {
-			for _, minutes := range []int{1, 2, 3, 4, 5, 6, 7, 8, 9} {
+			for _, minutes := range []int{5, 7} {
 				b.Run(strconv.Itoa(minutes), func(b *testing.B) {
 					st := meta.StartTime
 					end := st.Add(time.Duration(minutes) * time.Minute)


### PR DESCRIPTION
**What this PR does**:
This removes pooling from the parquetquery iterator hot paths.  Instead of getting/putting an IteratorResult every iteration, get one at creation time and reuse it.  `Next()/SeekTo()` still return a `*IteratorResult` but it's the same one each time and only valid until the next call.  

Although I really wanted to eliminate pooling altogether, it's still needed to keep memory down.  Pooling lets results be used across entire jobs, which clearly shows in benchmarks and in practice will help a busy querier. And we still need to keep pool items organized by size (i.e. spansets (large) vs attrs (small)).

For metrics it looks like memory usage is higher in some cases, but I think that's GC noise.  The single-run memory usage is the same before and after.  I.e. if we fetch a spanset with 100K spans, the minimum size of the slice to contain them all is the same.  

Rebatch/Bridge iterators were also updated to do the same.

<details>
<summary>Search benchmarks</summary>

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/tempo/tempodb/encoding/vparquet3
                                              │ before_traceql.txt │          after_traceql.txt           │
                                              │       sec/op       │    sec/op     vs base                │
BackendBlockTraceQL/spanAttValNoMatch                  1.884m ± 1%   1.884m ± 11%        ~ (p=0.481 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch            1.458m ± 1%   1.459m ±  3%        ~ (p=0.436 n=10)
BackendBlockTraceQL/resourceAttValNoMatch              1.418m ± 1%   1.410m ±  1%        ~ (p=0.305 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch          12.91m ± 2%   12.89m ±  1%        ~ (p=0.739 n=10)
BackendBlockTraceQL/mixedValNoMatch                    148.3m ± 0%   133.4m ±  1%  -10.06% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd              1.435m ± 0%   1.430m ±  1%        ~ (p=0.075 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr               141.4m ± 1%   125.3m ±  1%  -11.38% (p=0.000 n=10)
BackendBlockTraceQL/count                              270.1m ± 1%   237.3m ±  1%  -12.17% (p=0.000 n=10)
BackendBlockTraceQL/struct                             383.1m ± 2%   352.2m ±  2%   -8.06% (p=0.000 n=10)
BackendBlockTraceQL/||                                 140.3m ± 1%   132.2m ±  0%   -5.79% (p=0.000 n=10)
BackendBlockTraceQL/mixed                              21.00m ± 1%   20.97m ±  1%        ~ (p=0.796 n=10)
geomean                                                21.53m        20.55m         -4.54%

                                              │ before_traceql.txt │           after_traceql.txt           │
                                              │        B/s         │      B/s       vs base                │
BackendBlockTraceQL/spanAttValNoMatch                 1.015Gi ± 1%   1.015Gi ± 10%        ~ (p=0.481 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch           970.0Mi ± 1%   969.0Mi ±  3%        ~ (p=0.436 n=10)
BackendBlockTraceQL/resourceAttValNoMatch             297.3Mi ± 1%   299.0Mi ±  1%        ~ (p=0.305 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch         1.028Gi ± 2%   1.030Gi ±  1%        ~ (p=0.739 n=10)
BackendBlockTraceQL/mixedValNoMatch                   15.19Mi ± 0%   16.89Mi ±  1%  +11.21% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd             302.5Mi ± 0%   303.5Mi ±  1%        ~ (p=0.075 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr              108.1Mi ± 1%   121.9Mi ±  1%  +12.84% (p=0.000 n=10)
BackendBlockTraceQL/count                             51.40Mi ± 1%   58.53Mi ±  1%  +13.86% (p=0.000 n=10)
BackendBlockTraceQL/struct                            7.424Mi ± 3%   8.078Mi ±  2%   +8.80% (p=0.000 n=10)
BackendBlockTraceQL/||                                101.4Mi ± 1%   107.6Mi ±  0%   +6.14% (p=0.000 n=10)
BackendBlockTraceQL/mixed                             665.9Mi ± 1%   666.8Mi ±  1%        ~ (p=0.796 n=10)
geomean                                               172.6Mi        180.8Mi         +4.76%

                                              │ before_traceql.txt │          after_traceql.txt           │
                                              │      MB_io/op      │  MB_io/op    vs base                 │
BackendBlockTraceQL/spanAttValNoMatch                   2.054 ± 0%    2.054 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/spanAttIntrinsicNoMatch             1.483 ± 0%    1.483 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/resourceAttValNoMatch              442.0m ± 0%   442.0m ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/resourceAttIntrinsicMatch           14.25 ± 0%    14.25 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixedValNoMatch                     2.363 ± 0%    2.363 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixedValMixedMatchAnd              455.0m ± 0%   455.0m ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixedValMixedMatchOr                16.02 ± 0%    16.02 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/count                               14.56 ± 0%    14.56 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/struct                              2.982 ± 0%    2.982 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/||                                  14.91 ± 0%    14.91 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixed                               14.66 ± 0%    14.66 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                 3.896         3.896       +0.00%
¹ all samples are equal

                                              │ before_traceql.txt │          after_traceql.txt          │
                                              │        B/op        │     B/op      vs base               │
BackendBlockTraceQL/spanAttValNoMatch                 1.558Mi ± 0%   1.554Mi ± 0%  -0.25% (p=0.000 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch           1.115Mi ± 0%   1.112Mi ± 0%  -0.29% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttValNoMatch             1.090Mi ± 0%   1.087Mi ± 0%  -0.29% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch         1.292Mi ± 0%   1.285Mi ± 0%  -0.51% (p=0.000 n=10)
BackendBlockTraceQL/mixedValNoMatch                   1.606Mi ± 0%   1.605Mi ± 0%  -0.04% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd             1.093Mi ± 0%   1.090Mi ± 0%  -0.28% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr              1.974Mi ± 4%   2.031Mi ± 3%       ~ (p=0.529 n=10)
BackendBlockTraceQL/count                             238.9Mi ± 0%   240.6Mi ± 0%  +0.73% (p=0.000 n=10)
BackendBlockTraceQL/struct                            7.514Mi ± 0%   7.511Mi ± 0%  -0.04% (p=0.011 n=10)
BackendBlockTraceQL/||                                102.8Mi ± 0%   104.7Mi ± 0%  +1.83% (p=0.000 n=10)
BackendBlockTraceQL/mixed                             1.334Mi ± 0%   1.331Mi ± 0%  -0.26% (p=0.000 n=10)
geomean                                               3.754Mi        3.766Mi       +0.31%

                                              │ before_traceql.txt │         after_traceql.txt          │
                                              │     allocs/op      │  allocs/op   vs base               │
BackendBlockTraceQL/spanAttValNoMatch                  17.51k ± 0%   17.48k ± 0%  -0.15% (p=0.000 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch            17.40k ± 0%   17.38k ± 0%  -0.13% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttValNoMatch              17.44k ± 0%   17.41k ± 0%  -0.13% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch          19.16k ± 0%   19.11k ± 0%  -0.23% (p=0.000 n=10)
BackendBlockTraceQL/mixedValNoMatch                    18.29k ± 0%   18.27k ± 0%  -0.09% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd              17.52k ± 0%   17.50k ± 0%  -0.13% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr               24.13k ± 0%   24.10k ± 0%  -0.11% (p=0.000 n=10)
BackendBlockTraceQL/count                              1.408M ± 0%   1.408M ± 0%  +0.00% (p=0.000 n=10)
BackendBlockTraceQL/struct                             39.02k ± 0%   39.00k ± 0%  -0.05% (p=0.010 n=10)
BackendBlockTraceQL/||                                 630.4k ± 0%   630.3k ± 0%  -0.01% (p=0.000 n=10)
BackendBlockTraceQL/mixed                              20.16k ± 0%   20.11k ± 0%  -0.20% (p=0.000 n=10)
geomean                                                40.99k        40.95k       -0.11%
```
</details>

<details>
<summary>Metrics benchmarks</summary>

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/tempo/tempodb/encoding/vparquet3
                                                                          │ before.txt  │              after.txt               │
                                                                          │   sec/op    │    sec/op     vs base                │
BackendBlockQueryRange/{}_|_rate()/5                                        531.8m ± 1%   460.2m ±  1%  -13.47% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()/7                                        542.6m ± 1%   472.2m ±  1%  -12.96% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)/5                               1.218 ± 5%    1.103 ±  3%   -9.40% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)/7                               1.436 ± 6%    1.332 ±  3%   -7.26% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/5             952.0m ± 4%   885.6m ±  5%   -6.98% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/7              1.175 ± 1%    1.127 ± 10%        ~ (p=0.143 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/5                      1.453 ± 5%    1.355 ±  3%   -6.70% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/7                      1.607 ± 1%    1.524 ±  2%   -5.16% (p=0.000 n=10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/5   257.6m ± 4%   246.8m ±  6%   -4.18% (p=0.001 n=10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/7   272.7m ± 1%   253.3m ±  1%   -7.10% (p=0.000 n=10)
BackendBlockQueryRange/{status=error}_|_rate()/5                            156.7m ± 1%   155.3m ±  0%   -0.85% (p=0.000 n=10)
BackendBlockQueryRange/{status=error}_|_rate()/7                            157.1m ± 1%   155.9m ±  0%   -0.76% (p=0.000 n=10)
geomean                                                                     602.2m        562.2m         -6.65%

                                                                          │ before.txt │              after.txt              │
                                                                          │  MB_IO/op  │  MB_IO/op   vs base                 │
BackendBlockQueryRange/{}_|_rate()/5                                        43.45 ± 0%   43.45 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()/7                                        43.45 ± 0%   43.45 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(name)/5                              57.75 ± 0%   57.75 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(name)/7                              57.75 ± 0%   57.75 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/5             44.23 ± 0%   44.23 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/7             44.23 ± 0%   44.23 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/5                     48.69 ± 0%   48.69 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/7                     48.69 ± 0%   48.69 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/5   44.23 ± 0%   44.23 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/7   44.23 ± 0%   44.23 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{status=error}_|_rate()/5                            46.66 ± 0%   46.66 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{status=error}_|_rate()/7                            46.66 ± 0%   46.66 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                                     47.27        47.27       +0.00%
¹ all samples are equal

                                                                          │ before.txt  │              after.txt               │
                                                                          │  spans/op   │  spans/op    vs base                 │
BackendBlockQueryRange/{}_|_rate()/5                                        2.266M ± 0%   2.266M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()/7                                        3.325M ± 0%   3.325M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(name)/5                              2.266M ± 0%   2.266M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(name)/7                              3.325M ± 0%   3.325M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/5             2.266M ± 0%   2.266M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/7             3.325M ± 0%   3.325M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/5                     2.266M ± 0%   2.266M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/7                     3.325M ± 0%   3.325M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/5   676.8k ± 0%   676.8k ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/7   995.9k ± 0%   995.9k ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{status=error}_|_rate()/5                            38.82k ± 0%   38.82k ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{status=error}_|_rate()/7                            58.29k ± 0%   58.29k ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                                     1.142M        1.142M       +0.00%
¹ all samples are equal

                                                                          │ before.txt  │              after.txt              │
                                                                          │   spans/s   │   spans/s    vs base                │
BackendBlockQueryRange/{}_|_rate()/5                                        4.261M ± 1%   4.924M ± 1%  +15.56% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()/7                                        6.128M ± 1%   7.040M ± 1%  +14.89% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)/5                              1.861M ± 5%   2.054M ± 3%  +10.38% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)/7                              2.316M ± 6%   2.497M ± 2%   +7.83% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/5             2.380M ± 5%   2.559M ± 5%   +7.51% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/7             2.830M ± 1%   2.950M ± 9%        ~ (p=0.143 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/5                     1.561M ± 5%   1.672M ± 3%   +7.15% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/7                     2.069M ± 1%   2.182M ± 2%   +5.44% (p=0.000 n=10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/5   2.628M ± 4%   2.742M ± 7%   +4.36% (p=0.001 n=10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/7   3.652M ± 1%   3.931M ± 1%   +7.64% (p=0.000 n=10)
BackendBlockQueryRange/{status=error}_|_rate()/5                            247.8k ± 1%   249.9k ± 0%   +0.86% (p=0.000 n=10)
BackendBlockQueryRange/{status=error}_|_rate()/7                            371.2k ± 1%   374.0k ± 0%   +0.76% (p=0.000 n=10)
geomean                                                                     1.896M        2.031M        +7.13%

                                                                          │  before.txt   │               after.txt               │
                                                                          │     B/op      │     B/op       vs base                │
BackendBlockQueryRange/{}_|_rate()/5                                        25.07Mi ±  8%   38.93Mi ± 37%  +55.29% (p=0.001 n=10)
BackendBlockQueryRange/{}_|_rate()/7                                        23.07Mi ±  0%   38.93Mi ± 37%  +68.77% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)/5                              28.41Mi ±  8%   28.38Mi ±  8%        ~ (p=0.063 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)/7                              28.50Mi ±  0%   28.46Mi ±  0%   -0.11% (p=0.001 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/5             23.21Mi ±  0%   23.18Mi ±  0%   -0.14% (p=0.001 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/7             27.27Mi ±  0%   27.24Mi ±  0%   -0.12% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/5                     181.8Mi ± 18%   200.5Mi ± 19%        ~ (p=0.579 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/7                     162.1Mi ±  0%   166.8Mi ± 16%   +2.87% (p=0.000 n=10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/5   24.07Mi ±  0%   24.04Mi ±  0%   -0.11% (p=0.000 n=10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/7   24.07Mi ±  0%   24.04Mi ±  0%   -0.14% (p=0.000 n=10)
BackendBlockQueryRange/{status=error}_|_rate()/5                            21.78Mi ±  0%   21.74Mi ±  0%   -0.17% (p=0.004 n=10)
BackendBlockQueryRange/{status=error}_|_rate()/7                            21.76Mi ±  0%   21.78Mi ±  0%        ~ (p=0.617 n=10)
geomean                                                                     34.01Mi         37.22Mi         +9.43%

                                                                          │  before.txt  │              after.txt               │
                                                                          │  allocs/op   │  allocs/op    vs base                │
BackendBlockQueryRange/{}_|_rate()/5                                        331.0k ±  0%   393.9k ± 16%  +19.01% (p=0.018 n=10)
BackendBlockQueryRange/{}_|_rate()/7                                        330.9k ±  0%   393.9k ± 16%  +19.02% (p=0.011 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)/5                              342.7k ±  0%   342.7k ±  0%   -0.01% (p=0.001 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)/7                              345.2k ±  0%   345.1k ±  0%   -0.01% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/5             332.3k ±  0%   332.3k ±  0%   -0.01% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/7             332.9k ±  0%   332.9k ±  0%   -0.01% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/5                     786.8k ± 15%   899.2k ± 21%        ~ (p=0.165 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/7                     774.3k ±  0%   791.8k ± 16%   +2.25% (p=0.000 n=10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/5   308.2k ±  0%   308.1k ±  0%   -0.01% (p=0.000 n=10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/7   308.2k ±  0%   308.1k ±  0%   -0.01% (p=0.000 n=10)
BackendBlockQueryRange/{status=error}_|_rate()/5                            306.2k ±  0%   306.2k ±  0%   -0.01% (p=0.000 n=10)
BackendBlockQueryRange/{status=error}_|_rate()/7                            306.2k ±  0%   306.2k ±  0%   -0.01% (p=0.000 n=10)
geomean                                                                     375.2k         391.2k         +4.28%
```
</details>

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`