### PR TITLE
Add querier metrics for requests executed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## main / unreleased
 
-* [ENHANCEMENT] Add querier metrics for concurrency and requests executed [#3524](https://github.com/grafana/tempo/pull/3524) (@electron0zero)
+* [ENHANCEMENT] Add querier metrics for requests executed [#3524](https://github.com/grafana/tempo/pull/3524) (@electron0zero)
 * [FEATURE] Added gRPC streaming endpoints for all tag queries. [#3460](https://github.com/grafana/tempo/pull/3460) (@joe-elliott)
 * [CHANGE] Align metrics query time ranges to the step parameter [#3490](https://github.com/grafana/tempo/pull/3490) (@mdisibio)
 * [ENHANCEMENT] Add string interning to TraceQL queries [#3411](https://github.com/grafana/tempo/pull/3411) (@mapno)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [ENHANCEMENT] Add querier metrics for concurrency and requests executed [#3524](https://github.com/grafana/tempo/pull/3524) (@electron0zero)
 * [FEATURE] Added gRPC streaming endpoints for all tag queries. [#3460](https://github.com/grafana/tempo/pull/3460) (@joe-elliott)
 * [CHANGE] Align metrics query time ranges to the step parameter [#3490](https://github.com/grafana/tempo/pull/3490) (@mdisibio)
 * [ENHANCEMENT] Add string interning to TraceQL queries [#3411](https://github.com/grafana/tempo/pull/3411) (@mapno)

--- a/modules/querier/worker/frontend_processor_test.go
+++ b/modules/querier/worker/frontend_processor_test.go
@@ -49,7 +49,7 @@ func TestRunRequests(t *testing.T) {
 	}
 
 	// check that counter metric is working
-	var m = &dto.Metric{}
+	m := &dto.Metric{}
 	err := metricWorkerRequests.Write(m)
 	require.NoError(t, err)
 	require.Equal(t, float64(totalRequests), m.Counter.GetValue())

--- a/modules/querier/worker/frontend_processor_test.go
+++ b/modules/querier/worker/frontend_processor_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/grpcclient"
 	"github.com/grafana/dskit/httpgrpc"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,6 +47,12 @@ func TestRunRequests(t *testing.T) {
 	for i, resp := range resps {
 		require.Equal(t, []byte{byte(i)}, resp.Body)
 	}
+
+	// check that counter metric is working
+	var m = &dto.Metric{}
+	err := metricWorkerRequests.Write(m)
+	require.NoError(t, err)
+	require.Equal(t, float64(totalRequests), m.Counter.GetValue())
 }
 
 func TestHandleSendError(t *testing.T) {

--- a/modules/querier/worker/worker.go
+++ b/modules/querier/worker/worker.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"google.golang.org/grpc"
 
 	"github.com/grafana/tempo/pkg/util"
@@ -32,6 +33,12 @@ type Config struct {
 
 	GRPCClientConfig grpcclient.Config `yaml:"grpc_client_config"`
 }
+
+var metricConcurrency = promauto.NewGauge(prometheus.GaugeOpts{
+	Namespace: "tempo",
+	Name:      "querier_actual_concurrency",
+	Help:      "The actual value of concurrency.",
+})
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.FrontendAddress, "querier.frontend-address", "", "Address of query frontend service, in host:port format. If -querier.scheduler-address is set as well, querier will use scheduler instead. Only one of -querier.frontend-address or -querier.scheduler-address can be set. If neither is set, queries are only received via HTTP endpoint.")
@@ -242,6 +249,9 @@ func (w *querierWorker) resetConcurrency() {
 	if totalConcurrency > w.cfg.MaxConcurrentRequests {
 		level.Warn(w.log).Log("msg", "total worker concurrency is greater than promql max concurrency. Queries may be queued in the querier which reduces QOS")
 	}
+
+	// capture the current concurrency metric
+	metricConcurrency.Set(float64(totalConcurrency))
 }
 
 func (w *querierWorker) connect(ctx context.Context, address string) (*grpc.ClientConn, error) {


### PR DESCRIPTION
**What this PR does**:

Adds two metrics to provide observability into read path and query processing

1. `tempo_querier_worker_request_executed_total` is a counter, measuring the requests executed by the querier
2. log the concurrency of a querier

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`