### PR TITLE
only register metric for new frontendProcessor

### DIFF
--- a/modules/querier/worker/frontend_processor_test.go
+++ b/modules/querier/worker/frontend_processor_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/grpcclient"
 	"github.com/grafana/dskit/httpgrpc"
+	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 )
@@ -32,6 +33,8 @@ func TestRunRequests(t *testing.T) {
 
 	inf := newFrontendProcessor(Config{GRPCClientConfig: grpcclient.Config{MaxSendMsgSize: 10}}, RequestHandlerFunc(handler), log.NewNopLogger())
 	fp := inf.(*frontendProcessor)
+	// unregister metric in test avoid panic due to registering it twice in tests
+	defer prometheus.Unregister(fp.metricRequestsTotal)
 
 	totalRequests := byte(10)
 	reqs := []*httpgrpc.HTTPRequest{}
@@ -58,6 +61,8 @@ func TestRunRequests(t *testing.T) {
 func TestHandleSendError(t *testing.T) {
 	inf := newFrontendProcessor(Config{}, nil, log.NewNopLogger())
 	fp := inf.(*frontendProcessor)
+	// unregister metric in test avoid panic due to registering it twice in tests
+	defer prometheus.Unregister(fp.metricRequestsTotal)
 
 	err := fp.handleSendError(nil)
 	require.NoError(t, err)

--- a/modules/querier/worker/frontend_processor_test.go
+++ b/modules/querier/worker/frontend_processor_test.go
@@ -50,7 +50,7 @@ func TestRunRequests(t *testing.T) {
 
 	// check that counter metric is working
 	m := &dto.Metric{}
-	err := metricWorkerRequests.Write(m)
+	err := fp.metricRequestsTotal.Write(m)
 	require.NoError(t, err)
 	require.Equal(t, float64(totalRequests), m.Counter.GetValue())
 }


### PR DESCRIPTION
only register `tempo_querier_worker_request_executed_total` when we create a new frontend processor...before this change it was registerd in all tempo componentns.

it would add `tempo_querier_worker_request_executed_total` with 0 in all tempo components like query_frontend, compactor, and increase the cardinality of metric...

![image](https://github.com/grafana/tempo/assets/9503187/37c611f7-a13f-49a5-808a-ff333c3b6a46)


follow up fix for https://github.com/grafana/tempo/pull/3524.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`