### PR TITLE
Fix a broken link in tail-based-sampling.md

### DIFF
--- a/docs/sources/tempo/configuration/grafana-agent/tail-based-sampling.md
+++ b/docs/sources/tempo/configuration/grafana-agent/tail-based-sampling.md
@@ -16,7 +16,7 @@ Probabilistic sampling strategies are easy to implement,
 but also run the risk of discarding relevant data that you'll later want.
 
 Tail-based sampling works with Grafana Agent in Flow or static modes.
-Flow mode configuration files are [written in River](/docs/agent/latest/flow/config-language).
+Flow mode configuration files are [written in River](/docs/agent/latest/flow/concepts/config-language).
 Static mode configuration files are [written in YAML](/docs/agent/latest/static/configuration).
 Examples in this document are for Flow mode. You can also use the [Static mode Kubernetes operator](/docs/agent/latest/operator).
 


### PR DESCRIPTION
the link to the "river language" was leading to a 404

**What this PR does**:

just fixes a link in the docs

**Which issue(s) this PR fixes**:

no related issue exists