### PR TITLE
Surface new labels for uninstrumented services and systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [ENHANCEMENT] Surface new labels for uninstrumented services and systems [#3543](https://github.com/grafana/tempo/pull/3543) (@t00mas)
 * [FEATURE] Add TLS support for Memcached Client [#3585](https://github.com/grafana/tempo/pull/3585) (@sonisr)
 * [ENHANCEMENT] Add querier metrics for requests executed [#3524](https://github.com/grafana/tempo/pull/3524) (@electron0zero)
 * [FEATURE] Added gRPC streaming endpoints for Tempo APIs.

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -324,6 +324,9 @@ metrics_generator:
             # Attribute Key to multiply span metrics
             [span_multiplier_key: <string> | default = ""]
 
+            # Enables additional labels for services and virtual nodes.
+            [enable_extra_uninstrumented_services_labels: <bool> | default = false]
+
         span_metrics:
 
             # Buckets for the latency histogram in seconds.

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -325,7 +325,7 @@ metrics_generator:
             [span_multiplier_key: <string> | default = ""]
 
             # Enables additional labels for services and virtual nodes.
-            [enable_extra_uninstrumented_services_labels: <bool> | default = false]
+            [enable_virtual_node_label: <bool> | default = false]
 
         span_metrics:
 

--- a/docs/sources/tempo/metrics-generator/service_graphs/_index.md
+++ b/docs/sources/tempo/metrics-generator/service_graphs/_index.md
@@ -73,13 +73,13 @@ Duration is measured both from the client and the server sides.
 
 Possible values for `connection_type`: unset, `virtual_node`, `messaging_system`, or `database`.
 
-Additional labels can be included using the `dimensions` configuration option, or the `enable_extra_uninstrumented_services_label` option.
+Additional labels can be included using the `dimensions` configuration option, or the `enable_virtual_node_label` option.
 
 Since the service graph processor has to process both sides of an edge,
 it needs to process all spans of a trace to function properly.
 If spans of a trace are spread out over multiple instances, spans are not paired up reliably.
 
-#### Activate `enable_extra_uninstrumented_services_label`
+#### Activate `enable_virtual_node_label`
 
 Activating this feature adds the following label and corresponding values:
 

--- a/docs/sources/tempo/metrics-generator/service_graphs/_index.md
+++ b/docs/sources/tempo/metrics-generator/service_graphs/_index.md
@@ -73,20 +73,16 @@ Duration is measured both from the client and the server sides.
 
 Possible values for `connection_type`: unset, `virtual_node`, `messaging_system`, or `database`.
 
-Additional labels can be included using the `dimensions` configuration option, or the `enable_extra_uninstrumented_services_labels` option.
+Additional labels can be included using the `dimensions` configuration option, or the `enable_extra_uninstrumented_services_label` option.
 
 Since the service graph processor has to process both sides of an edge,
 it needs to process all spans of a trace to function properly.
 If spans of a trace are spread out over multiple instances, spans are not paired up reliably.
 
-#### Activating enable_extra_uninstrumented_services_labels
+#### Activating enable_extra_uninstrumented_services_label
 
-The following labels, with the corresponding values, will be added if this feature is enabled:
+The following label, with the corresponding values, will be added if this feature is enabled:
 
 | Label                   | Possible Values             | Description                                                              |
 |-------------------------|-----------------------------|--------------------------------------------------------------------------|
 | virtual_node            | `unset`, `client`, `server` | Explicitly indicates the side that is uninstrumented                     |
-| client_db_system        | `unset`,  `<string>`        | Surfaces the `db.system` resource attribute of the client, if any        |
-| server_db_system        | `unset`,  `<string>`        | Surfaces the `db.system` resource attribute of the server, if any        |
-| client_messaging_system | `unset`,  `<string>`        | Surfaces the `messaging.system` resource attribute of the client, if any |
-| server_messaging_system | `unset`,  `<string>`        | Surfaces the `messaging.system` resource attribute of the server, if any |

--- a/docs/sources/tempo/metrics-generator/service_graphs/_index.md
+++ b/docs/sources/tempo/metrics-generator/service_graphs/_index.md
@@ -79,9 +79,9 @@ Since the service graph processor has to process both sides of an edge,
 it needs to process all spans of a trace to function properly.
 If spans of a trace are spread out over multiple instances, spans are not paired up reliably.
 
-#### Activating enable_extra_uninstrumented_services_label
+#### Activate `enable_extra_uninstrumented_services_label`
 
-The following label, with the corresponding values, will be added if this feature is enabled:
+Activating this feature adds the following label and corresponding values:
 
 | Label                   | Possible Values             | Description                                                              |
 |-------------------------|-----------------------------|--------------------------------------------------------------------------|

--- a/docs/sources/tempo/metrics-generator/service_graphs/_index.md
+++ b/docs/sources/tempo/metrics-generator/service_graphs/_index.md
@@ -71,10 +71,22 @@ The following metrics are exported:
 
 Duration is measured both from the client and the server sides.
 
-Possible values for `connection_type`: unset, `messaging_system`, or `database`.
+Possible values for `connection_type`: unset, `virtual_node`, `messaging_system`, or `database`.
 
-Additional labels can be included using the `dimensions` configuration option.
+Additional labels can be included using the `dimensions` configuration option, or the `enable_extra_uninstrumented_services_labels` option.
 
 Since the service graph processor has to process both sides of an edge,
 it needs to process all spans of a trace to function properly.
 If spans of a trace are spread out over multiple instances, spans are not paired up reliably.
+
+#### Activating enable_extra_uninstrumented_services_labels
+
+The following labels, with the corresponding values, will be added if this feature is enabled:
+
+| Label                   | Possible Values             | Description                                                              |
+|-------------------------|-----------------------------|--------------------------------------------------------------------------|
+| virtual_node            | `unset`, `client`, `server` | Explicitly indicates the side that is uninstrumented                     |
+| client_db_system        | `unset`,  `<string>`        | Surfaces the `db.system` resource attribute of the client, if any        |
+| server_db_system        | `unset`,  `<string>`        | Surfaces the `db.system` resource attribute of the server, if any        |
+| client_messaging_system | `unset`,  `<string>`        | Surfaces the `messaging.system` resource attribute of the client, if any |
+| server_messaging_system | `unset`,  `<string>`        | Surfaces the `messaging.system` resource attribute of the server, if any |

--- a/modules/generator/config.go
+++ b/modules/generator/config.go
@@ -123,5 +123,7 @@ func (cfg *ProcessorConfig) copyWithOverrides(o metricsGeneratorOverrides, userI
 
 	copyCfg.ServiceGraphs.EnableClientServerPrefix = o.MetricsGeneratorProcessorServiceGraphsEnableClientServerPrefix(userID)
 
+	copyCfg.ServiceGraphs.EnableVirtualNodeLabel = o.MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel(userID)
+
 	return copyCfg, nil
 }

--- a/modules/generator/overrides.go
+++ b/modules/generator/overrides.go
@@ -33,6 +33,7 @@ type metricsGeneratorOverrides interface {
 	MetricsGeneratorProcessorSpanMetricsDimensionMappings(userID string) []sharedconfig.DimensionMappings
 	MetricsGeneratorProcessorSpanMetricsEnableTargetInfo(userID string) bool
 	MetricsGeneratorProcessorServiceGraphsEnableClientServerPrefix(userID string) bool
+	MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel(userID string) bool
 	MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(userID string) []string
 	DedicatedColumns(userID string) backend.DedicatedColumns
 	MaxBytesPerTrace(userID string) int

--- a/modules/generator/overrides_test.go
+++ b/modules/generator/overrides_test.go
@@ -14,6 +14,7 @@ type mockOverrides struct {
 	serviceGraphsDimensions                 []string
 	serviceGraphsPeerAttributes             []string
 	serviceGraphsEnableClientServerPrefix   bool
+	serviceGraphsEnableVirtualNodeLabel     bool
 	spanMetricsHistogramBuckets             []float64
 	spanMetricsDimensions                   []string
 	spanMetricsIntrinsicDimensions          map[string]bool
@@ -126,6 +127,10 @@ func (m *mockOverrides) MetricsGeneratorProcessorSpanMetricsEnableTargetInfo(str
 
 func (m *mockOverrides) MetricsGeneratorProcessorServiceGraphsEnableClientServerPrefix(string) bool {
 	return m.serviceGraphsEnableClientServerPrefix
+}
+
+func (m *mockOverrides) MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel(string) bool {
+	return m.serviceGraphsEnableVirtualNodeLabel
 }
 
 func (m *mockOverrides) MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(string) []string {

--- a/modules/generator/processor/servicegraphs/config.go
+++ b/modules/generator/processor/servicegraphs/config.go
@@ -41,7 +41,7 @@ type Config struct {
 	SpanMultiplierKey string `yaml:"span_multiplier_key"`
 
 	// EnableExtraUninstrumentedServicesLabels enables additional labels for uninstrumented services
-	EnableExtraUninstrumentedServicesLabels bool `yaml:"enable_extra_uninstrumented_services_labels"`
+	EnableVirtualNodeLabel bool `yaml:"enable_virtual_node_label"`
 }
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {

--- a/modules/generator/processor/servicegraphs/config.go
+++ b/modules/generator/processor/servicegraphs/config.go
@@ -40,7 +40,7 @@ type Config struct {
 	// If enabled attribute value will be used for metric calculation
 	SpanMultiplierKey string `yaml:"span_multiplier_key"`
 
-	// EnableExtraUninstrumentedServicesLabels enables additional labels for uninstrumented services
+	// EnableVirtualNodeLabel enables additional labels for uninstrumented services
 	EnableVirtualNodeLabel bool `yaml:"enable_virtual_node_label"`
 }
 

--- a/modules/generator/processor/servicegraphs/config.go
+++ b/modules/generator/processor/servicegraphs/config.go
@@ -39,6 +39,9 @@ type Config struct {
 
 	// If enabled attribute value will be used for metric calculation
 	SpanMultiplierKey string `yaml:"span_multiplier_key"`
+
+	// EnableExtraUninstrumentedServicesLabels enables additional labels for uninstrumented services
+	EnableExtraUninstrumentedServicesLabels bool `yaml:"enable_extra_uninstrumented_services_labels"`
 }
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -275,7 +275,7 @@ func (p *Processor) Shutdown(_ context.Context) {
 func (p *Processor) onComplete(e *store.Edge) {
 	numLabels := 3 + len(p.Cfg.Dimensions)
 	if p.Cfg.EnableClientServerPrefix {
-		numLabels += 1
+		numLabels++
 	}
 	labelValues := make([]string, 0, numLabels-1)
 	labelValues = append(labelValues, e.ClientService, e.ServerService, string(e.ConnectionType))

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -52,7 +52,7 @@ const (
 	metricRequestClientSeconds = "traces_service_graph_request_client_seconds"
 )
 
-const virtualNodeLabel = "__virtual_node"
+const virtualNodeLabel = "virtual_node"
 
 var defaultPeerAttributes = []attribute.Key{
 	semconv.PeerServiceKey, semconv.DBNameKey, semconv.DBSystemKey,

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -307,6 +307,8 @@ func (p *Processor) onComplete(e *store.Edge) {
 
 	p.serviceGraphRequestServerSecondsHistogram.ObserveWithExemplar(registryLabelValues, e.ServerLatencySec, e.TraceID, e.SpanMultiplier)
 	p.serviceGraphRequestClientSecondsHistogram.ObserveWithExemplar(registryLabelValues, e.ClientLatencySec, e.TraceID, e.SpanMultiplier)
+
+	p.store.ReturnEdge(e)
 }
 
 func (p *Processor) onExpire(e *store.Edge) {

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -87,13 +87,13 @@ type Processor struct {
 func New(cfg Config, tenant string, registry registry.Registry, logger log.Logger) gen.Processor {
 	labels := []string{"client", "server", "connection_type"}
 
-	if cfg.EnableExtraUninstrumentedServicesLabels {
+	if cfg.EnableVirtualNodeLabel {
 		cfg.Dimensions = append(cfg.Dimensions, "virtual_node")
 	}
 
 	for _, d := range cfg.Dimensions {
 		if cfg.EnableClientServerPrefix {
-			if cfg.EnableExtraUninstrumentedServicesLabels {
+			if cfg.EnableVirtualNodeLabel {
 				// leave the extra label for this feature as-is
 				if d == "virtual_node" {
 					labels = append(labels, strutil.SanitizeLabelName(d))
@@ -283,7 +283,7 @@ func (p *Processor) onComplete(e *store.Edge) {
 
 	for _, dimension := range p.Cfg.Dimensions {
 		if p.Cfg.EnableClientServerPrefix {
-			if p.Cfg.EnableExtraUninstrumentedServicesLabels {
+			if p.Cfg.EnableVirtualNodeLabel {
 				// leave the extra label for this feature as-is
 				if dimension == "virtual_node" {
 					labelValues = append(labelValues, e.Dimensions[dimension])
@@ -323,7 +323,7 @@ func (p *Processor) onExpire(e *store.Edge) {
 		if _, parentSpan := parseKey(e.Key()); len(parentSpan) == 0 {
 			e.ClientService = "user"
 
-			if p.Cfg.EnableExtraUninstrumentedServicesLabels {
+			if p.Cfg.EnableVirtualNodeLabel {
 				e.Dimensions["virtual_node"] = "client"
 			}
 
@@ -334,7 +334,7 @@ func (p *Processor) onExpire(e *store.Edge) {
 		// we make the assumption that a call was made to an external service, for which Tempo won't receive spans.
 		e.ServerService = e.PeerNode
 
-		if p.Cfg.EnableExtraUninstrumentedServicesLabels {
+		if p.Cfg.EnableVirtualNodeLabel {
 			e.Dimensions["virtual_node"] = "server"
 		}
 

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -227,7 +227,7 @@ func TestServiceGraphs_virtualNodesExtraLabelsForUninstrumentedServices(t *testi
 	cfg := Config{}
 	cfg.RegisterFlagsAndApplyDefaults("", nil)
 
-	cfg.EnableExtraUninstrumentedServicesLabels = true
+	cfg.EnableVirtualNodeLabel = true
 	cfg.Wait = time.Nanosecond
 
 	p := New(cfg, "test", testRegistry, log.NewNopLogger())
@@ -271,7 +271,7 @@ func TestServiceGraphs_prefixDimensionsAndEnableExtraLabels(t *testing.T) {
 	cfg.HistogramBuckets = []float64{0.04}
 	cfg.Dimensions = []string{"db.system", "messaging.system"}
 	cfg.EnableClientServerPrefix = true
-	cfg.EnableExtraUninstrumentedServicesLabels = true
+	cfg.EnableVirtualNodeLabel = true
 
 	p := New(cfg, "test", testRegistry, log.NewNopLogger())
 	defer p.Shutdown(context.Background())

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -299,8 +299,6 @@ func TestServiceGraphs_enableExtraLabelsForUninstrumentedServicesWithQueueAndDat
 		"server_messaging_system": "rabbitmq",
 	})
 
-	fmt.Println(testRegistry)
-
 	// counters
 	assert.Equal(t, 1.0, testRegistry.Query(`traces_service_graph_request_total`, serverDbSystemLabels))
 	assert.Equal(t, 0.0, testRegistry.Query(`traces_service_graph_request_failed_total`, serverDbSystemLabels))

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -244,14 +244,14 @@ func TestServiceGraphs_virtualNodesExtraLabelsForUninstrumentedServices(t *testi
 		"client":          "user",
 		"server":          "mythical-server",
 		"connection_type": "virtual_node",
-		"virtual_node":    "client",
+		virtualNodeLabel:  "client",
 	})
 
 	clientToVirtualPeerLabels := labels.FromMap(map[string]string{
 		"client":          "mythical-requester",
 		"server":          "external-payments-platform",
 		"connection_type": "virtual_node",
-		"virtual_node":    "server",
+		virtualNodeLabel:  "server",
 	})
 
 	// counters
@@ -289,7 +289,7 @@ func TestServiceGraphs_prefixDimensionsAndEnableExtraLabels(t *testing.T) {
 		"server_db_system":        "",
 		"server_messaging_system": "rabbitmq",
 		"server":                  "mythical-recorder",
-		"virtual_node":            "",
+		virtualNodeLabel:          "",
 	})
 
 	dbSystemSystemLabels := labels.FromMap(map[string]string{
@@ -300,7 +300,7 @@ func TestServiceGraphs_prefixDimensionsAndEnableExtraLabels(t *testing.T) {
 		"server_db_system":        "",
 		"server_messaging_system": "",
 		"server":                  "postgres",
-		"virtual_node":            "",
+		virtualNodeLabel:          "",
 	})
 
 	// counters

--- a/modules/generator/processor/servicegraphs/store/edge.go
+++ b/modules/generator/processor/servicegraphs/store/edge.go
@@ -37,12 +37,22 @@ type Edge struct {
 	SpanMultiplier float64
 }
 
-func newEdge(key string, ttl time.Duration) *Edge {
-	return &Edge{
-		key:        key,
-		Dimensions: make(map[string]string),
-		expiration: time.Now().Add(ttl).Unix(),
+// zeroStateEdge resets the Edge to its zero state.
+// Useful for reusing an Edge without allocating a new one.
+func zeroStateEdge(e *Edge) {
+	e.TraceID = ""
+	e.ConnectionType = Unknown
+	e.ServerService = ""
+	e.ClientService = ""
+	e.ServerLatencySec = 0
+	e.ClientLatencySec = 0
+	e.Failed = false
+	for k := range e.Dimensions {
+		// saves 30ns/op, 50 B/op, 1 allocs/op
+		delete(e.Dimensions, k)
 	}
+	e.PeerNode = ""
+	e.SpanMultiplier = 1
 }
 
 // isComplete returns true if the corresponding client and server

--- a/modules/generator/processor/servicegraphs/store/edge.go
+++ b/modules/generator/processor/servicegraphs/store/edge.go
@@ -47,10 +47,7 @@ func zeroStateEdge(e *Edge) {
 	e.ServerLatencySec = 0
 	e.ClientLatencySec = 0
 	e.Failed = false
-	for k := range e.Dimensions {
-		// saves 30ns/op, 50 B/op, 1 allocs/op
-		delete(e.Dimensions, k)
-	}
+	clear(e.Dimensions)
 	e.PeerNode = ""
 	e.SpanMultiplier = 1
 }

--- a/modules/generator/processor/servicegraphs/store/edge.go
+++ b/modules/generator/processor/servicegraphs/store/edge.go
@@ -27,11 +27,6 @@ type Edge struct {
 	// Additional dimension to add to the metrics
 	Dimensions map[string]string
 
-	// Additional labels for uninstrumented services
-	VirtualNode                           string // Indicates which service is the virtual node (client or server)
-	ClientDbSystem, ClientMessagingSystem string // If the client is a virtual node, indicates the client's db or messaging system
-	ServerDbSystem, ServerMessagingSystem string // If the server is a virtual node, indicates the server's db or messaging system
-
 	// PeerNode is the attribute that will be used to create a peer edge
 	PeerNode string
 

--- a/modules/generator/processor/servicegraphs/store/edge.go
+++ b/modules/generator/processor/servicegraphs/store/edge.go
@@ -27,6 +27,11 @@ type Edge struct {
 	// Additional dimension to add to the metrics
 	Dimensions map[string]string
 
+	// Additional labels for uninstrumented services
+	VirtualNode                           string // Indicates which service is the virtual node (client or server)
+	ClientDbSystem, ClientMessagingSystem string // If the client is a virtual node, indicates the client's db or messaging system
+	ServerDbSystem, ServerMessagingSystem string // If the server is a virtual node, indicates the server's db or messaging system
+
 	// PeerNode is the attribute that will be used to create a peer edge
 	PeerNode string
 

--- a/modules/generator/processor/servicegraphs/store/edge.go
+++ b/modules/generator/processor/servicegraphs/store/edge.go
@@ -37,9 +37,9 @@ type Edge struct {
 	SpanMultiplier float64
 }
 
-// zeroStateEdge resets the Edge to its zero state.
+// resetEdge resets the Edge to its zero state.
 // Useful for reusing an Edge without allocating a new one.
-func zeroStateEdge(e *Edge) {
+func resetEdge(e *Edge) {
 	e.TraceID = ""
 	e.ConnectionType = Unknown
 	e.ServerService = ""

--- a/modules/generator/processor/servicegraphs/store/interface.go
+++ b/modules/generator/processor/servicegraphs/store/interface.go
@@ -8,8 +8,4 @@ type Store interface {
 	UpsertEdge(key string, update Callback) (isNew bool, err error)
 	// Expire evicts expired edges from the store.
 	Expire()
-	// GrabEdge returns an edge from the store, creating a new one if it doesn't exist.
-	GrabEdge(key string) *Edge
-	// ReturnEdge returns an edge to the store.
-	ReturnEdge(e *Edge)
 }

--- a/modules/generator/processor/servicegraphs/store/interface.go
+++ b/modules/generator/processor/servicegraphs/store/interface.go
@@ -8,4 +8,8 @@ type Store interface {
 	UpsertEdge(key string, update Callback) (isNew bool, err error)
 	// Expire evicts expired edges from the store.
 	Expire()
+	// GrabEdge returns an edge from the store, creating a new one if it doesn't exist.
+	GrabEdge(key string) *Edge
+	// ReturnEdge returns an edge to the store.
+	ReturnEdge(e *Edge)
 }

--- a/modules/generator/processor/servicegraphs/store/store.go
+++ b/modules/generator/processor/servicegraphs/store/store.go
@@ -34,7 +34,7 @@ var edgePool = sync.Pool{
 // GrabEdge returns a new Edge from the pool, clearing its state and setting the key and expiration.
 func (s *store) GrabEdge(key string) *Edge {
 	edge := edgePool.Get().(*Edge)
-	zeroStateEdge(edge)
+	resetEdge(edge)
 	edge.key = key
 	edge.expiration = time.Now().Add(s.ttl).Unix()
 	return edge

--- a/modules/generator/processor/servicegraphs/store/store.go
+++ b/modules/generator/processor/servicegraphs/store/store.go
@@ -61,7 +61,6 @@ func (s *store) tryEvictHead() bool {
 
 	headEdge := head.Value.(*Edge)
 	if !headEdge.isExpired() {
-		s.returnEdge(headEdge)
 		return false
 	}
 

--- a/modules/generator/processor/servicegraphs/store/store_test.go
+++ b/modules/generator/processor/servicegraphs/store/store_test.go
@@ -166,6 +166,20 @@ func TestStore_concurrency(t *testing.T) {
 	close(end)
 }
 
+func BenchmarkStoreUpsertEdge(b *testing.B) {
+	// Benchmark the performance of UpsertEdge with edge pooling enabled
+	s := NewStore(10*time.Millisecond, 1e10, noopCallback, noopCallback)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		key := fmt.Sprintf("key-%d", i)
+		_, err := s.UpsertEdge(key, func(e *Edge) {
+			e.ClientService = clientService
+		})
+		require.NoError(b, err)
+	}
+}
+
 func noopCallback(_ *Edge) {
 }
 

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -81,6 +81,7 @@ type ServiceGraphsOverrides struct {
 	Dimensions               []string  `yaml:"dimensions,omitempty" json:"dimensions,omitempty"`
 	PeerAttributes           []string  `yaml:"peer_attributes,omitempty" json:"peer_attributes,omitempty"`
 	EnableClientServerPrefix bool      `yaml:"enable_client_server_prefix,omitempty" json:"enable_client_server_prefix,omitempty"`
+	EnableVirtualNodeLabel   bool      `yaml:"enable_virtual_node_label,omitempty" json:"enable_virtual_node_label,omitempty"`
 }
 
 type SpanMetricsOverrides struct {

--- a/modules/overrides/config_legacy.go
+++ b/modules/overrides/config_legacy.go
@@ -36,6 +36,7 @@ func (c *Overrides) toLegacy() LegacyOverrides {
 		MetricsGeneratorProcessorServiceGraphsDimensions:                 c.MetricsGenerator.Processor.ServiceGraphs.Dimensions,
 		MetricsGeneratorProcessorServiceGraphsPeerAttributes:             c.MetricsGenerator.Processor.ServiceGraphs.PeerAttributes,
 		MetricsGeneratorProcessorServiceGraphsEnableClientServerPrefix:   c.MetricsGenerator.Processor.ServiceGraphs.EnableClientServerPrefix,
+		MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel:     c.MetricsGenerator.Processor.ServiceGraphs.EnableVirtualNodeLabel,
 		MetricsGeneratorProcessorSpanMetricsHistogramBuckets:             c.MetricsGenerator.Processor.SpanMetrics.HistogramBuckets,
 		MetricsGeneratorProcessorSpanMetricsDimensions:                   c.MetricsGenerator.Processor.SpanMetrics.Dimensions,
 		MetricsGeneratorProcessorSpanMetricsIntrinsicDimensions:          c.MetricsGenerator.Processor.SpanMetrics.IntrinsicDimensions,
@@ -95,6 +96,7 @@ type LegacyOverrides struct {
 	MetricsGeneratorProcessorServiceGraphsDimensions                 []string                         `yaml:"metrics_generator_processor_service_graphs_dimensions" json:"metrics_generator_processor_service_graphs_dimensions"`
 	MetricsGeneratorProcessorServiceGraphsPeerAttributes             []string                         `yaml:"metrics_generator_processor_service_graphs_peer_attributes" json:"metrics_generator_processor_service_graphs_peer_attributes"`
 	MetricsGeneratorProcessorServiceGraphsEnableClientServerPrefix   bool                             `yaml:"metrics_generator_processor_service_graphs_enable_client_server_prefix" json:"metrics_generator_processor_service_graphs_enable_client_server_prefix"`
+	MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel     bool                             `yaml:"metrics_generator_processor_service_graphs_enable_virtual_node_label" json:"metrics_generator_processor_service_graphs_enable_virtual_node_label"`
 	MetricsGeneratorProcessorSpanMetricsHistogramBuckets             []float64                        `yaml:"metrics_generator_processor_span_metrics_histogram_buckets" json:"metrics_generator_processor_span_metrics_histogram_buckets"`
 	MetricsGeneratorProcessorSpanMetricsDimensions                   []string                         `yaml:"metrics_generator_processor_span_metrics_dimensions" json:"metrics_generator_processor_span_metrics_dimensions"`
 	MetricsGeneratorProcessorSpanMetricsIntrinsicDimensions          map[string]bool                  `yaml:"metrics_generator_processor_span_metrics_intrinsic_dimensions" json:"metrics_generator_processor_span_metrics_intrinsic_dimensions"`
@@ -171,6 +173,7 @@ func (l *LegacyOverrides) toNewLimits() Overrides {
 					Dimensions:               l.MetricsGeneratorProcessorServiceGraphsDimensions,
 					PeerAttributes:           l.MetricsGeneratorProcessorServiceGraphsPeerAttributes,
 					EnableClientServerPrefix: l.MetricsGeneratorProcessorServiceGraphsEnableClientServerPrefix,
+					EnableVirtualNodeLabel:   l.MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel,
 				},
 				SpanMetrics: SpanMetricsOverrides{
 					HistogramBuckets:             l.MetricsGeneratorProcessorSpanMetricsHistogramBuckets,

--- a/modules/overrides/interface.go
+++ b/modules/overrides/interface.go
@@ -66,6 +66,7 @@ type Interface interface {
 	MetricsGeneratorProcessorSpanMetricsDimensionMappings(userID string) []sharedconfig.DimensionMappings
 	MetricsGeneratorProcessorSpanMetricsEnableTargetInfo(userID string) bool
 	MetricsGeneratorProcessorServiceGraphsEnableClientServerPrefix(userID string) bool
+	MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel(userID string) bool
 	MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(userID string) []string
 	BlockRetention(userID string) time.Duration
 	MaxSearchDuration(userID string) time.Duration

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -435,6 +435,11 @@ func (o *runtimeConfigOverridesManager) MetricsGeneratorProcessorServiceGraphsEn
 	return o.getOverridesForUser(userID).MetricsGenerator.Processor.ServiceGraphs.EnableClientServerPrefix
 }
 
+// MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel adds the "virtual_node" label
+func (o *runtimeConfigOverridesManager) MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel(userID string) bool {
+	return o.getOverridesForUser(userID).MetricsGenerator.Processor.ServiceGraphs.EnableVirtualNodeLabel
+}
+
 // MetricsGeneratorProcessorSpanMetricsHistogramBuckets controls the histogram buckets to be used
 // by the span metrics processor.
 func (o *runtimeConfigOverridesManager) MetricsGeneratorProcessorSpanMetricsHistogramBuckets(userID string) []float64 {

--- a/modules/overrides/user_configurable_overrides.go
+++ b/modules/overrides/user_configurable_overrides.go
@@ -259,6 +259,13 @@ func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorServiceGraph
 	return o.Interface.MetricsGeneratorProcessorServiceGraphsEnableClientServerPrefix(userID)
 }
 
+func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel(userID string) bool {
+	if enableVirtualNodeLabel, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetServiceGraphs().GetEnableVirtualNodeLabel(); ok {
+		return enableVirtualNodeLabel
+	}
+	return o.Interface.MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel(userID)
+}
+
 func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorServiceGraphsPeerAttributes(userID string) []string {
 	if peerAttributes, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetServiceGraphs().GetPeerAttributes(); ok {
 		return peerAttributes

--- a/modules/overrides/user_configurable_overrides_test.go
+++ b/modules/overrides/user_configurable_overrides_test.go
@@ -147,6 +147,7 @@ func TestUserConfigOverridesManager_allFields(t *testing.T) {
 	assert.Equal(t, []string{"sg-dimension"}, mgr.MetricsGeneratorProcessorServiceGraphsDimensions(tenant1))
 	assert.Equal(t, 60*time.Second, mgr.MetricsGeneratorCollectionInterval(tenant1))
 	assert.Equal(t, true, mgr.MetricsGeneratorProcessorServiceGraphsEnableClientServerPrefix(tenant1))
+	assert.Equal(t, true, mgr.MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel(tenant1))
 	assert.Equal(t, []string{"attribute"}, mgr.MetricsGeneratorProcessorServiceGraphsPeerAttributes(tenant1))
 	assert.Equal(t, []float64{1, 2, 3, 4, 5}, mgr.MetricsGeneratorProcessorServiceGraphsHistogramBuckets(tenant1))
 	assert.Equal(t, []string{"sm-dimension"}, mgr.MetricsGeneratorProcessorSpanMetricsDimensions(tenant1))

--- a/modules/overrides/user_configurable_overrides_test.go
+++ b/modules/overrides/user_configurable_overrides_test.go
@@ -104,6 +104,7 @@ func TestUserConfigOverridesManager_allFields(t *testing.T) {
 				ServiceGraphs: userconfigurableoverrides.LimitsMetricsGeneratorProcessorServiceGraphs{
 					Dimensions:               &[]string{"sg-dimension"},
 					EnableClientServerPrefix: boolPtr(true),
+					EnableVirtualNodeLabel:   boolPtr(true),
 					PeerAttributes:           &[]string{"attribute"},
 					HistogramBuckets:         &[]float64{1, 2, 3, 4, 5},
 				},

--- a/modules/overrides/userconfigurable/client/limits.go
+++ b/modules/overrides/userconfigurable/client/limits.go
@@ -85,6 +85,7 @@ func (l *LimitsMetricsGeneratorProcessor) GetSpanMetrics() *LimitsMetricsGenerat
 type LimitsMetricsGeneratorProcessorServiceGraphs struct {
 	Dimensions               *[]string  `yaml:"dimensions,omitempty" json:"dimensions,omitempty"`
 	EnableClientServerPrefix *bool      `yaml:"enable_client_server_prefix,omitempty" json:"enable_client_server_prefix,omitempty"`
+	EnableVirtualNodeLabel   *bool      `yaml:"enable_virtual_node_label,omitempty" json:"enable_virtual_node_label,omitempty"`
 	PeerAttributes           *[]string  `yaml:"peer_attributes,omitempty" json:"peer_attributes,omitempty"`
 	HistogramBuckets         *[]float64 `yaml:"histogram_buckets,omitempty" json:"histogram_buckets,omitempty"`
 }
@@ -99,6 +100,13 @@ func (l *LimitsMetricsGeneratorProcessorServiceGraphs) GetDimensions() ([]string
 func (l *LimitsMetricsGeneratorProcessorServiceGraphs) GetEnableClientServerPrefix() (bool, bool) {
 	if l != nil && l.EnableClientServerPrefix != nil {
 		return *l.EnableClientServerPrefix, true
+	}
+	return false, false
+}
+
+func (l *LimitsMetricsGeneratorProcessorServiceGraphs) GetEnableVirtualNodeLabel() (bool, bool) {
+	if l != nil && l.EnableVirtualNodeLabel != nil {
+		return *l.EnableVirtualNodeLabel, true
 	}
 	return false, false
 }


### PR DESCRIPTION
**What this PR does**:

For the servicegraphs processor:
- Gates this feature behind the EnableExtraUninstrumentedServicesLabels flag in the Config
- If enabled, adds new labels to `traces_service_graph_request_*`:
  - `virtual_node` with a value of `client` or `server`, so the un-instrumented service's node can be identified.
  - `client|server_db|messaging_system` with the corresponding resource attribute value, to surface and identify the service and the node.

**Which issue(s) this PR fixes**:
Fixes #3461 

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`