### PR TITLE
clear metrics generator wal on start up

### DIFF
--- a/modules/generator/generator.go
+++ b/modules/generator/generator.go
@@ -66,13 +66,7 @@ func New(cfg *Config, overrides metricsGeneratorOverrides, reg prometheus.Regist
 		return nil, ErrUnconfigured
 	}
 
-	// clean the wal before everything
-	err := os.RemoveAll(cfg.Storage.Path)
-	if err != nil {
-		level.Warn(logger).Log("msg", "failed to remove wal on start up")
-	}
-
-	err = os.MkdirAll(cfg.Storage.Path, os.ModePerm)
+	err := os.MkdirAll(cfg.Storage.Path, os.ModePerm)
 	if err != nil {
 		return nil, fmt.Errorf("failed to mkdir on %s: %w", cfg.Storage.Path, err)
 	}

--- a/modules/generator/storage/instance.go
+++ b/modules/generator/storage/instance.go
@@ -57,12 +57,19 @@ func New(cfg *Config, o Overrides, tenant string, reg prometheus.Registerer, log
 
 	walDir := filepath.Join(cfg.Path, tenant)
 
+	// clean the wal before everything
+	level.Info(logger).Log("msg", "clearing old WAL on start up", "dir", walDir)
+	err := os.RemoveAll(walDir)
+	if err != nil {
+		level.Warn(logger).Log("msg", "failed to remove wal on start up: %s", err.Error())
+	}
+
 	level.Info(logger).Log("msg", "creating WAL", "dir", walDir)
 
 	// Create WAL directory with necessary permissions
 	// This creates both <walDir>/<tenant>/ and <walDir>/<tenant>/wal/. If we don't create the wal
 	// subdirectory remote storage logs a scary error.
-	err := os.MkdirAll(filepath.Join(walDir, "wal"), 0o755)
+	err = os.MkdirAll(filepath.Join(walDir, "wal"), 0o755)
 	if err != nil {
 		return nil, fmt.Errorf("could not create directory for metrics WAL: %w", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: Set metrics generator to clear its wal on start up.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`