### PR TITLE
Add spss and limit to search request hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [BUGFIX] Add support for dashes, quotes and spaces in attribute names in autocomplete [#3458](https://github.com/grafana/tempo/pull/3458) (@mapno)
 * [BUGFIX] Correctly handle 429s in GRPC search streaming. [#3469](https://github.com/grafana/tempo/pull/3469) (@joe-ellitot)
 * [BUGFIX] Correctly cancel GRPC and HTTP contexts in the frontend to prevent having to rely on http write timeout. [#3443](https://github.com/grafana/tempo/pull/3443) (@joe-elliott)
+* [BUGFIX] Add spss and limit to the frontend cache key to prevent the return of incorrect results. [#3557](https://github.com/grafana/tempo/pull/3557) (@joe-elliott)
 
 ## v2.4.1
 

--- a/modules/frontend/search_handlers_test.go
+++ b/modules/frontend/search_handlers_test.go
@@ -548,7 +548,7 @@ func TestSearchAccessesCache(t *testing.T) {
 
 	// setup query
 	query := "{}"
-	hash := hashForTraceQLQuery(query)
+	hash := hashForSearchRequest(&tempopb.SearchRequest{Query: query, Limit: 3, SpansPerSpanSet: 2})
 	start := uint32(10)
 	end := uint32(20)
 	cacheKey := searchJobCacheKey(tenant, hash, int64(start), int64(end), meta, 0, 1)
@@ -558,7 +558,7 @@ func TestSearchAccessesCache(t *testing.T) {
 	require.Equal(t, 0, len(bufs))
 
 	// execute query
-	path := fmt.Sprintf("/?start=%d&end=%d&q=%s", start, end, query) // encapsulates block above
+	path := fmt.Sprintf("/?start=%d&end=%d&q=%s&limit=3&spss=2", start, end, query) // encapsulates block above
 	req := httptest.NewRequest("GET", path, nil)
 	ctx := req.Context()
 	ctx = user.InjectOrgID(ctx, tenant)

--- a/modules/frontend/search_sharder_test.go
+++ b/modules/frontend/search_sharder_test.go
@@ -700,28 +700,38 @@ func TestMaxDuration(t *testing.T) {
 
 func TestHashTraceQLQuery(t *testing.T) {
 	// exact same queries should have the same hash
-	h1 := hashForTraceQLQuery("{ span.foo = `bar` }")
-	h2 := hashForTraceQLQuery("{ span.foo = `bar` }")
+	h1 := hashForSearchRequest(&tempopb.SearchRequest{Query: "{ span.foo = `bar` }"})
+	h2 := hashForSearchRequest(&tempopb.SearchRequest{Query: "{ span.foo = `bar` }"})
 	require.Equal(t, h1, h2)
 
 	// equivalent queries should have the same hash
-	h1 = hashForTraceQLQuery("{ span.foo = `bar`     }")
-	h2 = hashForTraceQLQuery("{ span.foo = `bar` }")
+	h1 = hashForSearchRequest(&tempopb.SearchRequest{Query: "{ span.foo = `bar`     }"})
+	h2 = hashForSearchRequest(&tempopb.SearchRequest{Query: "{ span.foo = `bar` }"})
 	require.Equal(t, h1, h2)
 
-	h1 = hashForTraceQLQuery("{ (span.foo = `bar`) || (span.bar = `foo`) }")
-	h2 = hashForTraceQLQuery("{ span.foo = `bar` || span.bar = `foo` }")
+	h1 = hashForSearchRequest(&tempopb.SearchRequest{Query: "{ (span.foo = `bar`) || (span.bar = `foo`) }"})
+	h2 = hashForSearchRequest(&tempopb.SearchRequest{Query: "{ span.foo = `bar` || span.bar = `foo` }"})
 	require.Equal(t, h1, h2)
 
 	// different queries should have different hashes
-	h1 = hashForTraceQLQuery("{ span.foo = `bar` }")
-	h2 = hashForTraceQLQuery("{ span.foo = `baz` }")
+	h1 = hashForSearchRequest(&tempopb.SearchRequest{Query: "{ span.foo = `bar` }"})
+	h2 = hashForSearchRequest(&tempopb.SearchRequest{Query: "{ span.foo = `baz` }"})
 	require.NotEqual(t, h1, h2)
 
 	// invalid queries should return 0
-	h1 = hashForTraceQLQuery("{ span.foo = `bar` ")
+	h1 = hashForSearchRequest(&tempopb.SearchRequest{Query: "{ span.foo = `bar` "})
 	require.Equal(t, uint64(0), h1)
 
-	h1 = hashForTraceQLQuery("")
+	h1 = hashForSearchRequest(&tempopb.SearchRequest{Query: ""})
 	require.Equal(t, uint64(0), h1)
+
+	// same queries with different spss and limit should have the different hash
+	h1 = hashForSearchRequest(&tempopb.SearchRequest{Query: "{ span.foo = `bar` }", Limit: 1})
+	h2 = hashForSearchRequest(&tempopb.SearchRequest{Query: "{ span.foo = `bar` }", Limit: 2})
+	require.NotEqual(t, h1, h2)
+
+	h1 = hashForSearchRequest(&tempopb.SearchRequest{Query: "{ span.foo = `bar` }", SpansPerSpanSet: 1})
+	h2 = hashForSearchRequest(&tempopb.SearchRequest{Query: "{ span.foo = `bar` }", SpansPerSpanSet: 2})
+	require.NotEqual(t, h1, h2)
+
 }

--- a/modules/frontend/search_sharder_test.go
+++ b/modules/frontend/search_sharder_test.go
@@ -733,5 +733,4 @@ func TestHashTraceQLQuery(t *testing.T) {
 	h1 = hashForSearchRequest(&tempopb.SearchRequest{Query: "{ span.foo = `bar` }", SpansPerSpanSet: 1})
 	h2 = hashForSearchRequest(&tempopb.SearchRequest{Query: "{ span.foo = `bar` }", SpansPerSpanSet: 2})
 	require.NotEqual(t, h1, h2)
-
 }


### PR DESCRIPTION
**What this PR does**:
Currently if you repeat a search with different limits and spans per spanset values it will potentially grab incorrect results from cache. This PR adds limit and spss to the cache key to make the job goes through to the backend in this case.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`