### PR TITLE
Fix tools image

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -122,6 +122,7 @@ local docker_build(arch, app, dockerfile='') = {
     repo: 'grafana/%s' % app,
     username: { from_secret: docker_username_secret.name },
     password: { from_secret: docker_password_secret.name },
+    platform: '%s/%s' % ['linux', arch],
     build_args: [
       'TARGETARCH=' + arch,
     ],

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -27,6 +27,7 @@ steps:
     dockerfile: cmd/tempo/Dockerfile
     password:
       from_secret: docker_password
+    platform: linux/amd64
     repo: grafana/tempo
     username:
       from_secret: docker_username
@@ -38,6 +39,7 @@ steps:
     dockerfile: cmd/tempo-vulture/Dockerfile
     password:
       from_secret: docker_password
+    platform: linux/amd64
     repo: grafana/tempo-vulture
     username:
       from_secret: docker_username
@@ -49,6 +51,7 @@ steps:
     dockerfile: cmd/tempo-query/Dockerfile
     password:
       from_secret: docker_password
+    platform: linux/amd64
     repo: grafana/tempo-query
     username:
       from_secret: docker_username
@@ -88,6 +91,7 @@ steps:
     dockerfile: cmd/tempo/Dockerfile
     password:
       from_secret: docker_password
+    platform: linux/arm64
     repo: grafana/tempo
     username:
       from_secret: docker_username
@@ -99,6 +103,7 @@ steps:
     dockerfile: cmd/tempo-vulture/Dockerfile
     password:
       from_secret: docker_password
+    platform: linux/arm64
     repo: grafana/tempo-vulture
     username:
       from_secret: docker_username
@@ -110,6 +115,7 @@ steps:
     dockerfile: cmd/tempo-query/Dockerfile
     password:
       from_secret: docker_password
+    platform: linux/arm64
     repo: grafana/tempo-query
     username:
       from_secret: docker_username
@@ -192,6 +198,7 @@ steps:
     dockerfile: tools/Dockerfile
     password:
       from_secret: docker_password
+    platform: linux/amd64
     repo: grafana/tempo-ci-tools
     username:
       from_secret: docker_username
@@ -224,6 +231,7 @@ steps:
     dockerfile: tools/Dockerfile
     password:
       from_secret: docker_password
+    platform: linux/arm64
     repo: grafana/tempo-ci-tools
     username:
       from_secret: docker_username
@@ -522,6 +530,6 @@ kind: secret
 name: gpg_passphrase
 ---
 kind: signature
-hmac: 01adf0a8a3952d45aca5575e624a63a088167173e18c07b3dfe1950dcb3e069b
+hmac: fd0d2fe13ee75cfc3a721fee180a293121c8aad04419e22e47e16793b45a2e33
 
 ...

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM golang:alpine
+FROM golang:alpine
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
**What this PR does**:

Each drone builder is running on the native platform, and so there is no TARGETPLATFORM passed here, and so we can drop it from the tools image. Here we make the adjustment that was required to get r143 to build.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`