### PR TITLE
Avoid deleting tenants

### DIFF
--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"path"
 
@@ -106,16 +105,6 @@ func (w *writer) CloseAppend(ctx context.Context, tracker AppendTracker) error {
 
 // Write implements backend.Writer
 func (w *writer) WriteTenantIndex(ctx context.Context, tenantID string, meta []*BlockMeta, compactedMeta []*CompactedBlockMeta) error {
-	// If meta and compactedMeta are empty, call delete the tenant index.
-	if len(meta) == 0 && len(compactedMeta) == 0 {
-		// Skip returning an error when the object is already deleted.
-		err := w.w.Delete(ctx, TenantIndexName, []string{tenantID}, nil)
-		if err != nil && !errors.Is(err, ErrDoesNotExist) {
-			return err
-		}
-		return nil
-	}
-
 	b := newTenantIndex(meta, compactedMeta)
 
 	indexBytes, err := b.marshal()

--- a/tempodb/backend/raw_test.go
+++ b/tempodb/backend/raw_test.go
@@ -57,9 +57,6 @@ func TestWriter(t *testing.T) {
 	err = w.WriteTenantIndex(ctx, "test", nil, nil)
 	assert.NoError(t, err)
 
-	expectedDeleteMap := map[string]map[string]int{TenantIndexName: {"test": 1}}
-	assert.Equal(t, expectedDeleteMap, w.(*writer).w.(*MockRawWriter).deleteCalls)
-
 	// When a backend returns ErrDoesNotExist, the tenant index should be deleted, but no error should be returned if the tenant index does not exist
 	m = &MockRawWriter{err: ErrDoesNotExist}
 	w = NewWriter(m)


### PR DESCRIPTION
**What this PR does**:

The tenant index deletion was originally put in as TCO win, but did not have the desired effect and surfaced other issues in the system.

Related grafana/tempo#2678
Related grafana/tempo#2754
Related grafana/tempo#2781
Related grafana/tempo#2878
Related grafana/tempo#3115
Related grafana/tempo#3223

Due to the number of issues here, and causing considerable noise on the pager, perhaps the right thing to do is back out the tenant deletion.

Raising here for discussion.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`