### PR TITLE
Ensure poller only runs on the frontend for the frontend target

### DIFF
--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -404,7 +404,9 @@ func (t *App) initQueryFrontend() (services.Service, error) {
 	t.Server.HTTPRouter().Handle(addHTTPAPIPrefix(&t.cfg, api.PathPromQueryRange), base.Wrap(queryFrontend.QueryRangeHandler))
 
 	// the query frontend needs to have knowledge of the blocks so it can shard search jobs
-	t.store.EnablePolling(context.Background(), nil)
+	if t.cfg.Target == QueryFrontend {
+		t.store.EnablePolling(context.Background(), nil)
+	}
 
 	// http query echo endpoint
 	t.Server.HTTPRouter().Handle(addHTTPAPIPrefix(&t.cfg, api.PathEcho), echoHandler())


### PR DESCRIPTION
**What this PR does**:

Without this change, SSB mode will end up running multiple pollers per instance; one for the compactor, and one for the frontend.  The frontend only needs the poller when we are running it with the QueryFrontend target.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`