### PR TITLE
Use os path separator to split blocks path

### DIFF
--- a/tempodb/backend/local/local.go
+++ b/tempodb/backend/local/local.go
@@ -19,9 +19,10 @@ type Backend struct {
 }
 
 var (
-	_ backend.RawReader = (*Backend)(nil)
-	_ backend.RawWriter = (*Backend)(nil)
-	_ backend.Compactor = (*Backend)(nil)
+	_                backend.RawReader = (*Backend)(nil)
+	_                backend.RawWriter = (*Backend)(nil)
+	_                backend.Compactor = (*Backend)(nil)
+	pathSeparatorStr                   = string(os.PathSeparator)
 )
 
 func NewBackend(cfg *Config) (*Backend, error) {
@@ -161,7 +162,7 @@ func (rw *Backend) ListBlocks(_ context.Context, tenant string) (metas []uuid.UU
 
 		tenantFilePath := filepath.Join(tenant, path)
 
-		parts := strings.Split(tenantFilePath, "/")
+		parts := strings.Split(tenantFilePath, pathSeparatorStr)
 		// i.e: <tenantID/<blockID>/meta
 		if len(parts) != 3 {
 			return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Use os path separator to split blocks path so local backend also works for Windows

**Which issue(s) this PR fixes**:
Fixes #3552

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`