### PR TITLE
Use os path separator to split blocks path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [BUGFIX] Use os path separator to split blocks path. [#3552](https://github.com/grafana/tempo/issues/3552) (@teyyubismayil)
 * [ENHANCEMENT] Add querier metrics for requests executed [#3524](https://github.com/grafana/tempo/pull/3524) (@electron0zero)
 * [FEATURE] Added gRPC streaming endpoints for all tag queries. [#3460](https://github.com/grafana/tempo/pull/3460) (@joe-elliott)
 * [CHANGE] Align metrics query time ranges to the step parameter [#3490](https://github.com/grafana/tempo/pull/3490) (@mdisibio)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## main / unreleased
 
-* [BUGFIX] Use os path separator to split blocks path. [#3552](https://github.com/grafana/tempo/issues/3552) (@teyyubismayil)
 * [ENHANCEMENT] Add querier metrics for requests executed [#3524](https://github.com/grafana/tempo/pull/3524) (@electron0zero)
 * [FEATURE] Added gRPC streaming endpoints for all tag queries. [#3460](https://github.com/grafana/tempo/pull/3460) (@joe-elliott)
 * [CHANGE] Align metrics query time ranges to the step parameter [#3490](https://github.com/grafana/tempo/pull/3490) (@mdisibio)
@@ -23,6 +22,7 @@
 * [BUGFIX] Correctly handle 429s in GRPC search streaming. [#3469](https://github.com/grafana/tempo/pull/3469) (@joe-ellitot)
 * [BUGFIX] Correctly cancel GRPC and HTTP contexts in the frontend to prevent having to rely on http write timeout. [#3443](https://github.com/grafana/tempo/pull/3443) (@joe-elliott)
 * [BUGFIX] Add spss and limit to the frontend cache key to prevent the return of incorrect results. [#3557](https://github.com/grafana/tempo/pull/3557) (@joe-elliott)
+* [BUGFIX] Use os path separator to split blocks path. [#3552](https://github.com/grafana/tempo/issues/3552) (@teyyubismayil)
 
 ## v2.4.1
 

--- a/tempodb/backend/local/local.go
+++ b/tempodb/backend/local/local.go
@@ -19,9 +19,10 @@ type Backend struct {
 }
 
 var (
-	_ backend.RawReader = (*Backend)(nil)
-	_ backend.RawWriter = (*Backend)(nil)
-	_ backend.Compactor = (*Backend)(nil)
+	_                backend.RawReader = (*Backend)(nil)
+	_                backend.RawWriter = (*Backend)(nil)
+	_                backend.Compactor = (*Backend)(nil)
+	pathSeparatorStr                   = string(os.PathSeparator)
 )
 
 func NewBackend(cfg *Config) (*Backend, error) {
@@ -161,7 +162,7 @@ func (rw *Backend) ListBlocks(_ context.Context, tenant string) (metas []uuid.UU
 
 		tenantFilePath := filepath.Join(tenant, path)
 
-		parts := strings.Split(tenantFilePath, "/")
+		parts := strings.Split(tenantFilePath, pathSeparatorStr)
 		// i.e: <tenantID/<blockID>/meta
 		if len(parts) != 3 {
 			return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Use os path separator to split blocks path so local backend works also on Windows

**Which issue(s) this PR fixes**:
Fixes #3552

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`