### PR TITLE
Fix really long static vals

### DIFF
--- a/pkg/traceql/lexer.go
+++ b/pkg/traceql/lexer.go
@@ -274,8 +274,12 @@ func tryScopeAttribute(l *scanner.Scanner, currentScope int) (int, bool) {
 	s := *l
 	str := ""
 	for s.Peek() != scanner.EOF {
-		if s.Peek() == '.' {
+		r := s.Peek()
+		if r == '.' {
 			str += string(s.Next())
+			break
+		}
+		if !isAttributeRune(r) {
 			break
 		}
 		str += string(s.Next())

--- a/pkg/traceql/parse_test.go
+++ b/pkg/traceql/parse_test.go
@@ -1,6 +1,7 @@
 package traceql
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -1164,5 +1165,18 @@ func TestHints(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, actual)
 		})
+	}
+}
+
+func TestReallyLongQuery(t *testing.T) {
+	for i := 1000; i < 1050; i++ {
+		static := strings.Repeat("a", i)
+		query := fmt.Sprintf("{ .a = `%s` }", static)
+		expected := newBinaryOperation(OpEqual, NewAttribute("a"), NewStaticString(static))
+
+		actual, err := Parse(query)
+
+		require.NoError(t, err, "i=%d", i)
+		require.Equal(t, newRootExpr(newPipeline(newSpansetFilter(expected))), actual, "i=%d", i)
 	}
 }


### PR DESCRIPTION
**What this PR does**:
Currently scope parsing goes all the way to the end of the query. This PR makes the routine bail out early if any "non attribute" rune is found.

**Which issue(s) this PR fixes**:
Fixes #3513

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`