### PR TITLE
Compactor tweaks:  Fix pool leak when iter exhausted and async pages for better throughput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [ENHANCEMENT] Add new (unsafe) query hints for metrics queries [#3396](https://github.com/grafana/tempo/pull/3396) (@mdisibio)
 * [ENHANCEMENT] Add nestedSetLeft/Right/Parent instrinsics to TraceQL. [#3497](https://github.com/grafana/tempo/pull/3497) (@joe-elliott)
 * [ENHANCEMENT] Add tenant to frontend job cache key. [#3527](https://github.com/grafana/tempo/pull/3527) (@joe-elliott)
+* [ENHANCEMENT] Better compaction throughput and memory usage [#3579](https://github.com/grafana/tempo/pull/3579) (@mdisibio)
 * [BUGFIX] Fix metrics query results when filtering and rating on the same attribute [#3428](https://github.com/grafana/tempo/issues/3428) (@mdisibio)
 * [BUGFIX] Fix metrics query results when series contain empty strings or nil values [#3429](https://github.com/grafana/tempo/issues/3429) (@mdisibio)
 * [BUGFIX] Fix metrics query duration check, add per-tenant override for max metrics query duration [#3479](https://github.com/grafana/tempo/issues/3479) (@mdisibio)

--- a/tempodb/encoding/vparquet3/block_iterator.go
+++ b/tempodb/encoding/vparquet3/block_iterator.go
@@ -23,6 +23,7 @@ func (b *backendBlock) open(ctx context.Context) (*parquet.File, *parquet.Reader
 		parquet.SkipBloomFilters(true),
 		parquet.SkipPageIndex(true),
 		parquet.FileSchema(parquetSchema),
+		parquet.FileReadMode(parquet.ReadModeAsync),
 	}
 
 	pf, err := parquet.OpenFile(br, int64(b.meta.Size), o...)
@@ -75,6 +76,7 @@ func (i *rawIterator) Next(context.Context) (common.ID, parquet.Row, error) {
 	}
 
 	if errors.Is(err, io.EOF) {
+		i.pool.Put(rows[0])
 		return nil, nil, nil
 	}
 


### PR DESCRIPTION
**What this PR does**:
Two small improvements to compactors that I noticed in #3537 .  Bringing them forward since it is currently paused for a bit, and the changes are very small.

Async pages improves throughput by ~40% in our internal cluster. Below are screenshots showing total output traces and data rate.  Benchmarks don't show this since there is no latency like object storage.  (Aside, the benchmarks could use some work but skipping for now).

![image](https://github.com/grafana/tempo/assets/13524475/1d9e29ef-89b4-4648-9889-f933637946c1)

![image](https://github.com/grafana/tempo/assets/13524475/dcd53184-90bb-432d-b901-487b0a0087e2)


The pooling leak is mentioned [here](https://github.com/grafana/tempo/pull/3537#discussion_r1551637156)  It only happens when compacting blocks of different trace counts. The benchmarks are also lacking this (they compact blocks of identical counts).  Small but useful reduction in memory.

<img width="1266" alt="image" src="https://github.com/grafana/tempo/assets/13524475/66b7b2e4-33f0-4b5e-a1b4-8afc824d9c9a">
 


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`