### PR TITLE
Unroll EqualRowNumber

### DIFF
--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -65,14 +65,22 @@ func CompareRowNumbers(upToDefinitionLevel int, a, b RowNumber) int {
 
 // EqualRowNumber compares the sequences of row numbers in a and b
 // for partial equality. A little faster than CompareRowNumbers(d,a,b)==0
-// NOTE - Unrolling this loop is slower because then it can't be inlined.
 func EqualRowNumber(upToDefinitionLevel int, a, b RowNumber) bool {
-	for i := 0; i <= upToDefinitionLevel; i++ {
+	/*for i := 0; i <= upToDefinitionLevel; i++ {
 		if a[i] != b[i] {
 			return false
 		}
 	}
-	return true
+	return true*/
+
+	// This is an unrolled version of the above loop, that is still
+	// small enough to be inlined and takes advantage of instruction pipelining.
+	return (a[0] == b[0]) &&
+		(a[1] == b[1] || upToDefinitionLevel < 1) &&
+		(a[2] == b[2] || upToDefinitionLevel < 2) &&
+		(a[3] == b[3] || upToDefinitionLevel < 3) &&
+		(a[4] == b[4] || upToDefinitionLevel < 4) &&
+		(a[5] == b[5] || upToDefinitionLevel < 5)
 }
 
 func TruncateRowNumber(definitionLevelToKeep int, t RowNumber) RowNumber {

--- a/pkg/parquetquery/iters_test.go
+++ b/pkg/parquetquery/iters_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"math/rand"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/parquet-go/parquet-go"
@@ -341,4 +342,29 @@ func createFileWith[T any](t testing.TB, rows []T) *parquet.File {
 	require.NoError(t, err)
 
 	return pf
+}
+
+func TestEqualRowNumber(t *testing.T) {
+	r1 := RowNumber{1, 2, 3, 4, 5, 6}
+	r2 := RowNumber{1, 2, 3, 5, 7, 9}
+
+	require.True(t, EqualRowNumber(0, r1, r2))
+	require.True(t, EqualRowNumber(1, r1, r2))
+	require.True(t, EqualRowNumber(2, r1, r2))
+	require.False(t, EqualRowNumber(3, r1, r2))
+	require.False(t, EqualRowNumber(4, r1, r2))
+	require.False(t, EqualRowNumber(5, r1, r2))
+}
+
+func BenchmarkEqualRowNumber(b *testing.B) {
+	r1 := RowNumber{1, 2, 3, 4, 5, 6}
+	r2 := RowNumber{1, 2, 3, 5, 7, 9}
+
+	for d := 0; d <= MaxDefinitionLevel; d++ {
+		b.Run(strconv.Itoa(d), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				EqualRowNumber(3, r1, r2)
+			}
+		})
+	}
 }


### PR DESCRIPTION
**What this PR does**:
Unrolls EqualRowNumber in way that still allows inlining and is faster.  This is a small portion of overall read path, but it's enough to show up in TraceQL search benchmarks.  I expected it to have a stronger effect for metrics (which processes more spans), but it doesn't show up there at all.

<details>
<summary>BenchmarkEqualRowNumber</summary>

```
pkg: github.com/grafana/tempo/pkg/parquetquery
                    │  before.txt  │              after.txt              │
                    │    sec/op    │    sec/op     vs base               │
EqualRowNumber/0-12   2.1220n ± 2%   0.2474n ± 1%  -88.34% (p=0.002 n=6)
EqualRowNumber/1-12   2.1215n ± 0%   0.2474n ± 1%  -88.34% (p=0.002 n=6)
EqualRowNumber/2-12   2.1215n ± 0%   0.2474n ± 3%  -88.34% (p=0.002 n=6)
EqualRowNumber/3-12   2.1220n ± 3%   0.2474n ± 0%  -88.34% (p=0.002 n=6)
EqualRowNumber/4-12   2.1215n ± 0%   0.2474n ± 0%  -88.34% (p=0.002 n=6)
EqualRowNumber/5-12   2.1220n ± 0%   0.2475n ± 0%  -88.34% (p=0.002 n=6)
geomean                2.122n        0.2474n       -88.34%

                    │  before.txt  │             after.txt              │
                    │     B/op     │    B/op     vs base                │
EqualRowNumber/0-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
EqualRowNumber/1-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
EqualRowNumber/2-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
EqualRowNumber/3-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
EqualRowNumber/4-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
EqualRowNumber/5-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                          ²               +0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                    │  before.txt  │             after.txt              │
                    │  allocs/op   │ allocs/op   vs base                │
EqualRowNumber/0-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
EqualRowNumber/1-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
EqualRowNumber/2-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
EqualRowNumber/3-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
EqualRowNumber/4-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
EqualRowNumber/5-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                          ²               +0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```
</details>

<details>
<summary>BenchmarkBackendBlockTraceQL</summary>

```
pkg: github.com/grafana/tempo/tempodb/encoding/vparquet3
                                                 │ before_traceql.txt │         after_traceql.txt          │
                                                 │       sec/op       │   sec/op     vs base               │
BackendBlockTraceQL/spanAttValNoMatch-12                  1.637m ± 0%   1.623m ± 0%  -0.85% (p=0.000 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-12            1.250m ± 0%   1.240m ± 0%  -0.76% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttValNoMatch-12              1.217m ± 0%   1.212m ± 0%  -0.41% (p=0.002 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-12          12.87m ± 1%   12.57m ± 1%  -2.31% (p=0.000 n=10)
BackendBlockTraceQL/mixedValNoMatch-12                    136.5m ± 3%   130.7m ± 0%  -4.24% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd-12              1.237m ± 1%   1.231m ± 0%  -0.54% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr-12               124.6m ± 4%   123.0m ± 2%  -1.23% (p=0.005 n=10)
BackendBlockTraceQL/count-12                              190.5m ± 0%   189.2m ± 0%  -0.69% (p=0.000 n=10)
BackendBlockTraceQL/struct-12                             350.3m ± 2%   349.4m ± 2%       ~ (p=0.579 n=10)
BackendBlockTraceQL/||-12                                 113.5m ± 1%   109.5m ± 2%  -3.48% (p=0.000 n=10)
BackendBlockTraceQL/mixed-12                              21.37m ± 1%   21.16m ± 2%       ~ (p=0.063 n=10)
geomean                                                   18.89m        18.61m       -1.44%

                                                 │ before_traceql.txt │          after_traceql.txt          │
                                                 │        B/s         │     B/s       vs base               │
BackendBlockTraceQL/spanAttValNoMatch-12                 1.169Gi ± 0%   1.179Gi ± 0%  +0.85% (p=0.000 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-12           1.105Gi ± 0%   1.113Gi ± 0%  +0.76% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttValNoMatch-12             346.3Mi ± 0%   347.8Mi ± 0%  +0.41% (p=0.002 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-12         1.032Gi ± 1%   1.056Gi ± 1%  +2.36% (p=0.000 n=10)
BackendBlockTraceQL/mixedValNoMatch-12                   16.51Mi ± 3%   17.24Mi ± 0%  +4.42% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd-12             350.7Mi ± 1%   352.6Mi ± 0%  +0.54% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr-12              122.7Mi ± 4%   124.2Mi ± 2%  +1.25% (p=0.005 n=10)
BackendBlockTraceQL/count-12                             72.89Mi ± 0%   73.40Mi ± 0%  +0.70% (p=0.000 n=10)
BackendBlockTraceQL/struct-12                            8.121Mi ± 2%   8.144Mi ± 2%       ~ (p=0.567 n=10)
BackendBlockTraceQL/||-12                                125.3Mi ± 1%   129.9Mi ± 2%  +3.60% (p=0.000 n=10)
BackendBlockTraceQL/mixed-12                             654.3Mi ± 1%   660.8Mi ± 2%       ~ (p=0.063 n=10)
geomean                                                  196.7Mi        199.6Mi       +1.46%

                                                 │ before_traceql.txt │          after_traceql.txt           │
                                                 │      MB_io/op      │  MB_io/op    vs base                 │
BackendBlockTraceQL/spanAttValNoMatch-12                   2.054 ± 0%    2.054 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/spanAttIntrinsicNoMatch-12             1.483 ± 0%    1.483 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/resourceAttValNoMatch-12              442.0m ± 0%   442.0m ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/resourceAttIntrinsicMatch-12           14.25 ± 0%    14.25 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixedValNoMatch-12                     2.363 ± 0%    2.363 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixedValMixedMatchAnd-12              455.0m ± 0%   455.0m ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixedValMixedMatchOr-12                16.02 ± 0%    16.02 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/count-12                               14.56 ± 0%    14.56 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/struct-12                              2.982 ± 0%    2.982 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/||-12                                  14.91 ± 0%    14.91 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixed-12                               14.66 ± 0%    14.66 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                    3.896         3.896       +0.00%
¹ all samples are equal

                                                 │ before_traceql.txt │          after_traceql.txt           │
                                                 │        B/op        │     B/op       vs base               │
BackendBlockTraceQL/spanAttValNoMatch-12                1.632Mi ±  1%   1.637Mi ±  2%       ~ (p=0.971 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-12          1.183Mi ±  0%   1.188Mi ±  1%       ~ (p=0.436 n=10)
BackendBlockTraceQL/resourceAttValNoMatch-12            1.150Mi ±  2%   1.155Mi ±  1%       ~ (p=0.739 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-12        1.403Mi ±  6%   1.372Mi ±  4%       ~ (p=0.105 n=10)
BackendBlockTraceQL/mixedValNoMatch-12                  1.726Mi ± 21%   1.928Mi ± 16%       ~ (p=0.590 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd-12            1.152Mi ±  1%   1.157Mi ±  1%       ~ (p=0.123 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr-12             2.257Mi ± 22%   2.052Mi ± 25%       ~ (p=0.739 n=10)
BackendBlockTraceQL/count-12                            242.3Mi ±  1%   242.2Mi ±  1%       ~ (p=0.971 n=10)
BackendBlockTraceQL/struct-12                           7.519Mi ± 54%   7.521Mi ± 54%       ~ (p=0.810 n=10)
BackendBlockTraceQL/||-12                               106.3Mi ±  1%   106.2Mi ±  1%       ~ (p=0.529 n=10)
BackendBlockTraceQL/mixed-12                            1.470Mi ±  6%   1.429Mi ±  5%       ~ (p=0.481 n=10)
geomean                                                 3.981Mi         3.974Mi        -0.17%

                                                 │ before_traceql.txt │         after_traceql.txt          │
                                                 │     allocs/op      │  allocs/op   vs base               │
BackendBlockTraceQL/spanAttValNoMatch-12                  17.46k ± 0%   17.46k ± 0%       ~ (p=0.087 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-12            17.39k ± 0%   17.39k ± 0%       ~ (p=0.211 n=10)
BackendBlockTraceQL/resourceAttValNoMatch-12              17.42k ± 0%   17.42k ± 0%       ~ (p=1.000 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-12          19.12k ± 0%   19.11k ± 0%       ~ (p=0.183 n=10)
BackendBlockTraceQL/mixedValNoMatch-12                    18.25k ± 0%   18.26k ± 0%       ~ (p=0.789 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd-12              17.45k ± 0%   17.45k ± 0%       ~ (p=0.628 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr-12               24.06k ± 0%   24.05k ± 0%       ~ (p=0.420 n=10)
BackendBlockTraceQL/count-12                              1.409M ± 0%   1.409M ± 0%       ~ (p=0.987 n=10)
BackendBlockTraceQL/struct-12                             39.02k ± 0%   39.01k ± 0%       ~ (p=0.866 n=10)
BackendBlockTraceQL/||-12                                 630.4k ± 0%   630.4k ± 0%       ~ (p=0.304 n=10)
BackendBlockTraceQL/mixed-12                              20.07k ± 0%   20.07k ± 0%       ~ (p=0.609 n=10)
geomean                                                   40.92k        40.92k       -0.00%
```
</details>

<details>
<summary>BenchmarkBackendBlockQueryRange</summary>

```
pkg: github.com/grafana/tempo/tempodb/encoding/vparquet3
                                                                             │ before.txt  │             after.txt              │
                                                                             │   sec/op    │   sec/op     vs base               │
BackendBlockQueryRange/{}_|_rate()/7-12                                        353.2m ± 5%   354.1m ± 3%       ~ (p=0.579 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)/7-12                               1.009 ± 4%    1.009 ± 4%       ~ (p=0.971 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/7-12             796.8m ± 3%   793.1m ± 3%       ~ (p=0.912 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/7-12                      1.124 ± 1%    1.116 ± 1%       ~ (p=0.052 n=10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/7-12   178.1m ± 5%   178.9m ± 6%       ~ (p=0.853 n=10)
BackendBlockQueryRange/{status=error}_|_rate()/7-12                            108.8m ± 0%   108.7m ± 0%       ~ (p=0.684 n=10)
geomean                                                                        428.5m        428.0m       -0.11%

                                                                             │ before.txt │              after.txt              │
                                                                             │  MB_IO/op  │  MB_IO/op   vs base                 │
BackendBlockQueryRange/{}_|_rate()/7-12                                        24.42 ± 0%   24.42 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(name)/7-12                              30.06 ± 0%   30.06 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/7-12             24.72 ± 0%   24.72 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/7-12                     26.74 ± 0%   26.74 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/7-12   24.72 ± 0%   24.72 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{status=error}_|_rate()/7-12                            25.69 ± 0%   25.69 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                                        25.99        25.99       +0.00%
¹ all samples are equal

                                                                             │ before.txt  │              after.txt               │
                                                                             │  spans/op   │  spans/op    vs base                 │
BackendBlockQueryRange/{}_|_rate()/7-12                                        2.638M ± 0%   2.638M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(name)/7-12                              2.638M ± 0%   2.638M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/7-12             2.638M ± 0%   2.638M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/7-12                     2.638M ± 0%   2.638M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/7-12   857.7k ± 0%   857.7k ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{status=error}_|_rate()/7-12                            50.27k ± 0%   50.27k ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                                        1.131M        1.131M       +0.00%
¹ all samples are equal

                                                                             │ before.txt  │             after.txt              │
                                                                             │   spans/s   │   spans/s    vs base               │
BackendBlockQueryRange/{}_|_rate()/7-12                                        7.470M ± 5%   7.450M ± 3%       ~ (p=0.579 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)/7-12                              2.614M ± 4%   2.614M ± 4%       ~ (p=0.971 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/7-12             3.311M ± 3%   3.327M ± 3%       ~ (p=0.912 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/7-12                     2.346M ± 1%   2.364M ± 1%       ~ (p=0.052 n=10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/7-12   4.815M ± 5%   4.796M ± 6%       ~ (p=0.853 n=10)
BackendBlockQueryRange/{status=error}_|_rate()/7-12                            462.0k ± 0%   462.5k ± 0%       ~ (p=0.684 n=10)
geomean                                                                        2.638M        2.641M       +0.11%

                                                                             │   before.txt   │               after.txt                │
                                                                             │      B/op      │      B/op       vs base                │
BackendBlockQueryRange/{}_|_rate()/7-12                                        31.47Mi ±  50%   24.24Mi ±  72%        ~ (p=0.400 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)/7-12                              44.16Mi ±  82%   28.11Mi ±  93%        ~ (p=0.280 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/7-12             23.73Mi ± 127%   24.45Mi ± 230%        ~ (p=0.670 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/7-12                     207.3Mi ±  28%   183.9Mi ±  27%        ~ (p=0.529 n=10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/7-12   29.02Mi ±  23%   30.62Mi ±  28%        ~ (p=0.315 n=10)
BackendBlockQueryRange/{status=error}_|_rate()/7-12                            22.62Mi ±   8%   22.91Mi ±   2%        ~ (p=0.684 n=10)
geomean                                                                        40.62Mi          35.92Mi         -11.55%

                                                                             │  before.txt  │              after.txt              │
                                                                             │  allocs/op   │  allocs/op    vs base               │
BackendBlockQueryRange/{}_|_rate()/7-12                                        326.5k ±  5%   326.5k ±  0%       ~ (p=0.307 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)/7-12                              339.7k ±  2%   339.7k ±  2%       ~ (p=0.868 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/7-12             327.4k ±  0%   327.4k ± 58%       ~ (p=0.839 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/7-12                     899.9k ± 19%   929.0k ± 21%       ~ (p=0.796 n=10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/7-12   303.8k ±  1%   303.8k ±  0%       ~ (p=0.756 n=10)
BackendBlockQueryRange/{status=error}_|_rate()/7-12                            301.1k ±  0%   300.7k ±  0%       ~ (p=0.781 n=10)
geomean                                                                        379.5k         381.5k        +0.51%
```
</details>

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`