### PR TITLE
Stop counting client cancels as errors for the SLO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [BUGFIX] Add spss and limit to the frontend cache key to prevent the return of incorrect results. [#3557](https://github.com/grafana/tempo/pull/3557) (@joe-elliott)
 * [BUGFIX] Use os path separator to split blocks path. [#3552](https://github.com/grafana/tempo/issues/3552) (@teyyubismayil)
 * [BUGFIX] Correctly parse traceql queries with > 1024 character attribute names or static values. [#3571](https://github.com/grafana/tempo/issues/3571) (@joe-elliott)
+* [BUGFIX] Correctly count context cancels as non-errors for SLO calculations. [#3591](https://github.com/grafana/tempo/pull/3591) (@mapno)
 
 ## v2.4.1
 

--- a/modules/frontend/slos.go
+++ b/modules/frontend/slos.go
@@ -72,11 +72,10 @@ func sloHook(allByTenantCounter, withinSLOByTenantCounter *prometheus.CounterVec
 
 		// most errors are SLO violations
 		if err != nil {
-			switch {
 			// However, if this is a grpc resource exhausted error (429)
 			// or a client context.Cancel then we are within SLO
-			case status.Code(err) == codes.ResourceExhausted,
-				errors.Is(err, context.Canceled):
+			if status.Code(err) == codes.ResourceExhausted ||
+				errors.Is(err, context.Canceled) {
 				withinSLOByTenantCounter.WithLabelValues(tenant).Inc()
 			}
 			return


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Makes `context.Cancel` errors count as successes for the SLO.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`