### PR TITLE
Updated Grafana image in the docker-compose examples to latest

### DIFF
--- a/example/docker-compose/agent/docker-compose.yaml
+++ b/example/docker-compose/agent/docker-compose.yaml
@@ -45,7 +45,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:10.1.1
+    image: grafana/grafana:10.4.2
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/azure/docker-compose.yaml
+++ b/example/docker-compose/azure/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:10.1.1
+    image: grafana/grafana:10.4.2
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/cross-cluster/docker-compose.yaml
+++ b/example/docker-compose/cross-cluster/docker-compose.yaml
@@ -171,7 +171,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:10.1.1
+    image: grafana/grafana:10.4.2
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/debug/docker-compose.yaml
+++ b/example/docker-compose/debug/docker-compose.yaml
@@ -37,7 +37,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:10.1.1
+    image: grafana/grafana:10.4.2
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/distributed/docker-compose.yaml
+++ b/example/docker-compose/distributed/docker-compose.yaml
@@ -147,7 +147,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:10.1.1
+    image: grafana/grafana:10.4.2
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/gcs/docker-compose.yaml
+++ b/example/docker-compose/gcs/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:10.1.1
+    image: grafana/grafana:10.4.2
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/multi-tenant/docker-compose.yaml
+++ b/example/docker-compose/multi-tenant/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
       - tempo
 
   grafana:
-    image: grafana/grafana:main
+    image: grafana/grafana:10.4.2
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
+++ b/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
@@ -43,7 +43,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:10.1.1
+    image: grafana/grafana:10.4.2
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/otel-collector/docker-compose.yaml
+++ b/example/docker-compose/otel-collector/docker-compose.yaml
@@ -43,7 +43,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:10.1.1
+    image: grafana/grafana:latest
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/otel-collector/docker-compose.yaml
+++ b/example/docker-compose/otel-collector/docker-compose.yaml
@@ -43,7 +43,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:10.4.2
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/s3/docker-compose.yaml
+++ b/example/docker-compose/s3/docker-compose.yaml
@@ -46,7 +46,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:10.1.1
+    image: grafana/grafana:10.4.2
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/scalable-single-binary/docker-compose.yaml
+++ b/example/docker-compose/scalable-single-binary/docker-compose.yaml
@@ -60,7 +60,7 @@ services:
       - ./prometheus.yaml:/etc/prometheus.yaml
 
   grafana:
-    image: grafana/grafana:10.1.1
+    image: grafana/grafana:10.4.2
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:


### PR DESCRIPTION
**What this PR does**:

The Grafana image used in the `docker-compose` examples are hardcoded to `10.1.1` which does not support the functionality of creating dashboard variables out of Tempo. I believe this is a great feature which everyone would like to be able test the moment when they run these examples.

More of such features will definitely come along with improvements in Tempo. Therefore, I would suggest to keep the Grafana images up-to-date just like the images for Prometheus and Tempo in these examples.