### PR TITLE
Disable log message in http timeout middleware

### DIFF
--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"path"
 
+	kitlog "github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/dns"
 	"github.com/grafana/dskit/kv/codec"
@@ -382,7 +383,7 @@ func (t *App) initQueryFrontend() (services.Service, error) {
 	// use the api timeout for http requests if set. note that this is set in initServer() for
 	// grpc requests
 	if t.cfg.Frontend.APITimeout > 0 {
-		httpAPIMiddleware = append(httpAPIMiddleware, middleware.NewTimeoutMiddleware(t.cfg.Frontend.APITimeout, "unable to process request in the configured timeout", t.Server.Log()))
+		httpAPIMiddleware = append(httpAPIMiddleware, middleware.NewTimeoutMiddleware(t.cfg.Frontend.APITimeout, "unable to process request in the configured timeout", kitlog.NewNopLogger()))
 	}
 
 	// wrap handlers with auth


### PR DESCRIPTION
**What this PR does**:

Here we disable a log message which fires far too often and provides very little value. 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`