### PR TITLE
Implement tenant deletion for empty tenants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [CHANGE] Clean Metrics Generator's Prometheus wal before creating instance [#3548](https://github.com/grafana/tempo/pull/3548) (@ie-pham)
 * [CHANGE] Update docker examples for permissions, deprecations, and clean-up [#3603](https://github.com/grafana/tempo/pull/3603) (@zalegrala)
 * [FEATURE] Add messaging-system latency histogram to service-graph [#3453](https://github.com/grafana/tempo/pull/3453) (@adirmatzkin)
+* [CHANGE] Delete any remaining objects for empty tenants after a configurable duration, requires config enable [#3611](https://github.com/grafana/tempo/pull/3611) (@zalegrala)
 * [ENHANCEMENT] Add string interning to TraceQL queries [#3411](https://github.com/grafana/tempo/pull/3411) (@mapno)
 * [ENHANCEMENT] Add new (unsafe) query hints for metrics queries [#3396](https://github.com/grafana/tempo/pull/3396) (@mdisibio)
 * [ENHANCEMENT] Add nestedSetLeft/Right/Parent instrinsics to TraceQL. [#3497](https://github.com/grafana/tempo/pull/3497) (@joe-elliott)

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -982,12 +982,18 @@ storage:
         # Default 1
         [blocklist_poll_tolerate_consecutive_errors: <int>]
 
-        # Polling will delete the index for a tenant if no blocks are found to
-        # exist.  The empty_tenant_deletion_age configuration is used to tune how
-        # quickly the poller will also delete any remaining backend objects found in the
-        # tenant path.
+        # Used to tune how quickly the poller will delete any remaining backend
+        # objects found in the tenant path.  This functionality requires enabling
+        # below.
         # Default: 12h
         [empty_tenant_deletion_age: <duration>]
+
+        # Polling will delete the index for a tenant if no blocks are found to
+        # exist.  If this setting is enabled, the poller will also delete any
+        # remaining backend objects found in the tenant path.  This is used to
+        # clean up partial blocks which may have not been cleaned up by the
+        # retention.
+        [empty_tenant_deletion_enabled: <bool> | default = false]
 
         # Cache type to use. Should be one of "redis", "memcached"
         # Example: "cache: memcached"

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -982,6 +982,13 @@ storage:
         # Default 1
         [blocklist_poll_tolerate_consecutive_errors: <int>]
 
+        # Polling will delete the index for a tenant if no blocks are found to
+        exist.  The empty_tenant_deletion_age configuration is used to tune how
+        quickly the poller will also delete any remaining backend objects found in the
+        tenant path.
+        # Default: 20m; four times the blocklist_poll configuration above.
+        [empty_tenant_deletion_age: <duration>]
+
         # Cache type to use. Should be one of "redis", "memcached"
         # Example: "cache: memcached"
         # Deprecated. See [cache](#cache) section below.

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -983,9 +983,9 @@ storage:
         [blocklist_poll_tolerate_consecutive_errors: <int>]
 
         # Polling will delete the index for a tenant if no blocks are found to
-        exist.  The empty_tenant_deletion_age configuration is used to tune how
-        quickly the poller will also delete any remaining backend objects found in the
-        tenant path.
+        # exist.  The empty_tenant_deletion_age configuration is used to tune how
+        # quickly the poller will also delete any remaining backend objects found in the
+        # tenant path.
         # Default: 20m; four times the blocklist_poll configuration above.
         [empty_tenant_deletion_age: <duration>]
 

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -986,7 +986,7 @@ storage:
         # exist.  The empty_tenant_deletion_age configuration is used to tune how
         # quickly the poller will also delete any remaining backend objects found in the
         # tenant path.
-        # Default: 20m; four times the blocklist_poll configuration above.
+        # Default: 12h
         [empty_tenant_deletion_age: <duration>]
 
         # Cache type to use. Should be one of "redis", "memcached"

--- a/integration/poller/poller_test.go
+++ b/integration/poller/poller_test.go
@@ -220,7 +220,6 @@ func TestPollerOwnership(t *testing.T) {
 }
 
 func TestTenantDeletion(t *testing.T) {
-	// FIXME: add test structure for prefix handling as above in the listblocks
 	testCompactorOwnershipBackends := []struct {
 		name       string
 		configFile string
@@ -239,99 +238,125 @@ func TestTenantDeletion(t *testing.T) {
 		},
 	}
 
+	storageBackendTestPermutations := []struct {
+		name   string
+		prefix string
+	}{
+		{
+			name:   "empty-string-prefix",
+			prefix: "",
+		},
+		{
+			name: "no-prefix",
+		},
+		{
+			name:   "prefix",
+			prefix: "a/b/c/",
+		},
+		{
+			name:   "prefix-no-trailing-slash",
+			prefix: "a/b/c",
+		},
+	}
+
 	logger := log.NewLogfmtLogger(os.Stdout)
 	var hhh *e2e.HTTPService
 	t.Parallel()
 	for _, tc := range testCompactorOwnershipBackends {
-		t.Run(tc.name, func(t *testing.T) {
-			s, err := e2e.NewScenario("tempo-poller-integration")
-			require.NoError(t, err)
-			defer s.Close()
+		for _, pc := range storageBackendTestPermutations {
+			t.Run(tc.name+"-"+pc.name, func(t *testing.T) {
+				s, err := e2e.NewScenario("tempo-poller-integration")
+				require.NoError(t, err)
+				defer s.Close()
 
-			// set up the backend
-			cfg := app.Config{}
-			buff, err := os.ReadFile(tc.configFile)
-			require.NoError(t, err)
-			err = yaml.UnmarshalStrict(buff, &cfg)
-			require.NoError(t, err)
-			hhh, err = e2eBackend.New(s, cfg)
-			require.NoError(t, err)
+				// set up the backend
+				cfg := app.Config{}
+				buff, err := os.ReadFile(tc.configFile)
+				require.NoError(t, err)
+				err = yaml.UnmarshalStrict(buff, &cfg)
+				require.NoError(t, err)
+				hhh, err = e2eBackend.New(s, cfg)
+				require.NoError(t, err)
 
-			err = hhh.WaitReady()
-			require.NoError(t, err)
+				err = hhh.WaitReady()
+				require.NoError(t, err)
 
-			err = hhh.Ready()
-			require.NoError(t, err)
+				err = hhh.Ready()
+				require.NoError(t, err)
 
-			// Give some time for startup
-			time.Sleep(1 * time.Second)
+				// Give some time for startup
+				time.Sleep(1 * time.Second)
 
-			t.Logf("backend: %s", hhh.Endpoint(hhh.HTTPPort()))
+				t.Logf("backend: %s", hhh.Endpoint(hhh.HTTPPort()))
 
-			require.NoError(t, util.CopyFileToSharedDir(s, tc.configFile, "config.yaml"))
+				require.NoError(t, util.CopyFileToSharedDir(s, tc.configFile, "config.yaml"))
 
-			var rr backend.RawReader
-			var ww backend.RawWriter
-			var cc backend.Compactor
+				var rr backend.RawReader
+				var ww backend.RawWriter
+				var cc backend.Compactor
 
-			concurrency := 3
-			ctx := context.Background()
+				concurrency := 3
+				ctx := context.Background()
 
-			e := hhh.Endpoint(hhh.HTTPPort())
-			switch tc.name {
-			case "s3":
-				cfg.StorageConfig.Trace.S3.ListBlocksConcurrency = concurrency
-				cfg.StorageConfig.Trace.S3.Endpoint = e
-				cfg.Overrides.UserConfigurableOverridesConfig.Client.S3.Endpoint = e
-				rr, ww, cc, err = s3.New(cfg.StorageConfig.Trace.S3)
-			case "gcs":
-				cfg.StorageConfig.Trace.GCS.ListBlocksConcurrency = concurrency
-				cfg.StorageConfig.Trace.GCS.Endpoint = e
-				cfg.Overrides.UserConfigurableOverridesConfig.Client.GCS.Endpoint = e
-				rr, ww, cc, err = gcs.New(cfg.StorageConfig.Trace.GCS)
-			case "azure":
-				cfg.StorageConfig.Trace.Azure.Endpoint = e
-				cfg.Overrides.UserConfigurableOverridesConfig.Client.Azure.Endpoint = e
-				rr, ww, cc, err = azure.New(cfg.StorageConfig.Trace.Azure)
-			}
-			require.NoError(t, err)
+				e := hhh.Endpoint(hhh.HTTPPort())
+				switch tc.name {
+				case "s3":
+					cfg.StorageConfig.Trace.S3.Endpoint = e
+					cfg.StorageConfig.Trace.S3.ListBlocksConcurrency = concurrency
+					cfg.StorageConfig.Trace.S3.Prefix = pc.prefix
+					cfg.Overrides.UserConfigurableOverridesConfig.Client.S3.Endpoint = e
+					rr, ww, cc, err = s3.New(cfg.StorageConfig.Trace.S3)
+				case "gcs":
+					cfg.Overrides.UserConfigurableOverridesConfig.Client.GCS.Endpoint = e
+					cfg.StorageConfig.Trace.GCS.Endpoint = e
+					cfg.StorageConfig.Trace.GCS.ListBlocksConcurrency = concurrency
+					cfg.StorageConfig.Trace.GCS.Prefix = pc.prefix
+					rr, ww, cc, err = gcs.New(cfg.StorageConfig.Trace.GCS)
+				case "azure":
+					cfg.Overrides.UserConfigurableOverridesConfig.Client.Azure.Endpoint = e
+					cfg.StorageConfig.Trace.Azure.Endpoint = e
+					cfg.StorageConfig.Trace.Azure.Prefix = pc.prefix
+					rr, ww, cc, err = azure.New(cfg.StorageConfig.Trace.Azure)
+				}
+				require.NoError(t, err)
 
-			r := backend.NewReader(rr)
-			w := backend.NewWriter(ww)
+				r := backend.NewReader(rr)
+				w := backend.NewWriter(ww)
 
-			blocklistPoller := blocklist.NewPoller(&blocklist.PollerConfig{
-				PollConcurrency:        3,
-				TenantIndexBuilders:    1,
-				EmptyTenantDeletionAge: 100 * time.Millisecond,
-			}, OwnsEverythingSharder, r, cc, w, logger)
+				blocklistPoller := blocklist.NewPoller(&blocklist.PollerConfig{
+					PollConcurrency:        3,
+					TenantIndexBuilders:    1,
+					EmptyTenantDeletionAge: 100 * time.Millisecond,
+				}, OwnsEverythingSharder, r, cc, w, logger)
 
-			l := blocklist.New()
-			mm, cm, err := blocklistPoller.Do(l)
-			require.NoError(t, err)
-			t.Logf("mm: %v", mm)
-			t.Logf("cm: %v", cm)
+				l := blocklist.New()
+				mm, cm, err := blocklistPoller.Do(l)
+				require.NoError(t, err)
+				t.Logf("mm: %v", mm)
+				t.Logf("cm: %v", cm)
 
-			tennants, err := r.Tenants(ctx)
-			require.NoError(t, err)
-			require.Equal(t, 0, len(tennants))
+				tennants, err := r.Tenants(ctx)
+				require.NoError(t, err)
+				require.Equal(t, 0, len(tennants))
 
-			writeBadBlockFiles(t, ww, rr, tenant)
+				writeBadBlockFiles(t, ww, rr, tenant)
 
-			// Now we should have a tenant
-			tennants, err = r.Tenants(ctx)
-			require.NoError(t, err)
-			require.Equal(t, 1, len(tennants))
+				// Now we should have a tenant
+				tennants, err = r.Tenants(ctx)
+				require.NoError(t, err)
+				require.Equal(t, 1, len(tennants))
 
-			time.Sleep(500 * time.Millisecond)
+				time.Sleep(500 * time.Millisecond)
 
-			_, _, err = blocklistPoller.Do(l)
-			require.NoError(t, err)
+				_, _, err = blocklistPoller.Do(l)
+				require.NoError(t, err)
 
-			tennants, err = r.Tenants(ctx)
-			t.Logf("tennants: %v", tennants)
-			require.NoError(t, err)
-			require.Equal(t, 0, len(tennants))
-		})
+				tennants, err = r.Tenants(ctx)
+				t.Logf("tennants: %v", tennants)
+				require.NoError(t, err)
+				require.Equal(t, 0, len(tennants))
+			})
+		}
 	}
 }
 

--- a/integration/poller/poller_test.go
+++ b/integration/poller/poller_test.go
@@ -428,7 +428,7 @@ func writeBadBlockFiles(t *testing.T, ww backend.RawWriter, rr backend.RawReader
 	t.Logf("items: %v", items)
 
 	var found []string
-	f := func(opts backend.FindOpts) {
+	f := func(opts backend.FindMatch) {
 		found = append(found, opts.Key)
 	}
 

--- a/integration/poller/poller_test.go
+++ b/integration/poller/poller_test.go
@@ -1,7 +1,9 @@
 package poller
 
 import (
+	"bytes"
 	"context"
+	"crypto/rand"
 	"os"
 	"sort"
 	"testing"
@@ -23,6 +25,7 @@ import (
 	"github.com/grafana/tempo/tempodb/backend/gcs"
 	"github.com/grafana/tempo/tempodb/backend/s3"
 	"github.com/grafana/tempo/tempodb/blocklist"
+	"github.com/grafana/tempo/tempodb/encoding/vparquet3"
 )
 
 const (
@@ -216,6 +219,122 @@ func TestPollerOwnership(t *testing.T) {
 	}
 }
 
+func TestTenantDeletion(t *testing.T) {
+	// FIXME: add test structure for prefix handling as above in the listblocks
+	testCompactorOwnershipBackends := []struct {
+		name       string
+		configFile string
+	}{
+		{
+			name:       "s3",
+			configFile: configS3,
+		},
+		{
+			name:       "azure",
+			configFile: configAzurite,
+		},
+		{
+			name:       "gcs",
+			configFile: configGCS,
+		},
+	}
+
+	logger := log.NewLogfmtLogger(os.Stdout)
+	var hhh *e2e.HTTPService
+	t.Parallel()
+	for _, tc := range testCompactorOwnershipBackends {
+		t.Run(tc.name, func(t *testing.T) {
+			s, err := e2e.NewScenario("tempo-poller-integration")
+			require.NoError(t, err)
+			defer s.Close()
+
+			// set up the backend
+			cfg := app.Config{}
+			buff, err := os.ReadFile(tc.configFile)
+			require.NoError(t, err)
+			err = yaml.UnmarshalStrict(buff, &cfg)
+			require.NoError(t, err)
+			hhh, err = e2eBackend.New(s, cfg)
+			require.NoError(t, err)
+
+			err = hhh.WaitReady()
+			require.NoError(t, err)
+
+			err = hhh.Ready()
+			require.NoError(t, err)
+
+			// Give some time for startup
+			time.Sleep(1 * time.Second)
+
+			t.Logf("backend: %s", hhh.Endpoint(hhh.HTTPPort()))
+
+			require.NoError(t, util.CopyFileToSharedDir(s, tc.configFile, "config.yaml"))
+
+			var rr backend.RawReader
+			var ww backend.RawWriter
+			var cc backend.Compactor
+
+			concurrency := 3
+			ctx := context.Background()
+
+			e := hhh.Endpoint(hhh.HTTPPort())
+			switch tc.name {
+			case "s3":
+				cfg.StorageConfig.Trace.S3.ListBlocksConcurrency = concurrency
+				cfg.StorageConfig.Trace.S3.Endpoint = e
+				cfg.Overrides.UserConfigurableOverridesConfig.Client.S3.Endpoint = e
+				rr, ww, cc, err = s3.New(cfg.StorageConfig.Trace.S3)
+			case "gcs":
+				cfg.StorageConfig.Trace.GCS.ListBlocksConcurrency = concurrency
+				cfg.StorageConfig.Trace.GCS.Endpoint = e
+				cfg.Overrides.UserConfigurableOverridesConfig.Client.GCS.Endpoint = e
+				rr, ww, cc, err = gcs.New(cfg.StorageConfig.Trace.GCS)
+			case "azure":
+				cfg.StorageConfig.Trace.Azure.Endpoint = e
+				cfg.Overrides.UserConfigurableOverridesConfig.Client.Azure.Endpoint = e
+				rr, ww, cc, err = azure.New(cfg.StorageConfig.Trace.Azure)
+			}
+			require.NoError(t, err)
+
+			r := backend.NewReader(rr)
+			w := backend.NewWriter(ww)
+
+			blocklistPoller := blocklist.NewPoller(&blocklist.PollerConfig{
+				PollConcurrency:        3,
+				TenantIndexBuilders:    1,
+				EmptyTenantDeletionAge: 100 * time.Millisecond,
+			}, OwnsEverythingSharder, r, cc, w, logger)
+
+			l := blocklist.New()
+			mm, cm, err := blocklistPoller.Do(l)
+			require.NoError(t, err)
+			t.Logf("mm: %v", mm)
+			t.Logf("cm: %v", cm)
+
+			tennants, err := r.Tenants(ctx)
+			require.NoError(t, err)
+			require.Equal(t, 0, len(tennants))
+
+			writeBadBlockFiles(t, ww, rr, tenant)
+
+			// Now we should have a tenant
+			tennants, err = r.Tenants(ctx)
+			require.NoError(t, err)
+			require.Equal(t, 1, len(tennants))
+
+			time.Sleep(500 * time.Millisecond)
+
+			_, _, err = blocklistPoller.Do(l)
+			require.NoError(t, err)
+
+			tennants, err = r.Tenants(ctx)
+			t.Logf("tennants: %v", tennants)
+			require.NoError(t, err)
+			require.Equal(t, 0, len(tennants))
+		})
+	}
+}
+
 func found(id uuid.UUID, blockMetas []*backend.BlockMeta) bool {
 	for _, b := range blockMetas {
 		if b.BlockID == id {
@@ -259,4 +378,36 @@ func incrementUUIDBytes(uuidBytes []byte) {
 
 		uuidBytes[i] = 0 // Wrap around if the byte is 255
 	}
+}
+
+func writeBadBlockFiles(t *testing.T, ww backend.RawWriter, rr backend.RawReader, tenant string) {
+	t.Logf("writing bad block files")
+
+	ctx := context.Background()
+
+	token := make([]byte, 32)
+	_, err := rand.Read(token)
+	require.NoError(t, err)
+
+	err = ww.Write(
+		ctx,
+		vparquet3.DataFileName,
+		backend.KeyPath([]string{tenant, uuid.New().String()}),
+		bytes.NewReader(token),
+		int64(len(token)), nil)
+
+	require.NoError(t, err)
+
+	items, err := rr.List(context.Background(), backend.KeyPath([]string{tenant}))
+	require.NoError(t, err)
+	t.Logf("items: %v", items)
+
+	var found []string
+	f := func(opts backend.FindOpts) {
+		found = append(found, opts.Key)
+	}
+
+	err = rr.Find(ctx, backend.KeyPath{}, f)
+	require.NoError(t, err)
+	t.Logf("items: %v", found)
 }

--- a/integration/poller/poller_test.go
+++ b/integration/poller/poller_test.go
@@ -149,8 +149,9 @@ func TestPollerOwnership(t *testing.T) {
 				w := backend.NewWriter(ww)
 
 				blocklistPoller := blocklist.NewPoller(&blocklist.PollerConfig{
-					PollConcurrency:     3,
-					TenantIndexBuilders: 1,
+					PollConcurrency:        3,
+					TenantIndexBuilders:    1,
+					EmptyTenantDeletionAge: 10 * time.Minute,
 				}, OwnsEverythingSharder, r, cc, w, logger)
 
 				// Use the block boundaries in the GCS and S3 implementation

--- a/tempodb/backend/azure/v1/v1.go
+++ b/tempodb/backend/azure/v1/v1.go
@@ -261,7 +261,7 @@ func (rw *V1) Find(ctx context.Context, keypath backend.KeyPath, f backend.FindF
 
 			level.Info(log.Logger).Log("msg", "find", "blob", blob.Name, "obj", obj, "prefix", prefix, "name", blob.Name, "lastModified", blob.Properties.LastModified)
 
-			opts := backend.FindOpts{
+			opts := backend.FindMatch{
 				Key:      blob.Name,
 				Modified: blob.Properties.LastModified,
 			}

--- a/tempodb/backend/azure/v1/v1.go
+++ b/tempodb/backend/azure/v1/v1.go
@@ -52,7 +52,7 @@ type appendTracker struct {
 func New(cfg *config.Config, confirm bool) (*V1, error) {
 	ctx := context.Background()
 	loglevel := &dskitlog.Level{}
-	loglevel.Set("debug")
+	_ = loglevel.Set("debug")
 	log.InitLogger(&server.Config{LogLevel: *loglevel})
 
 	container, err := GetContainer(ctx, cfg, false)

--- a/tempodb/backend/azure/v2/v2.go
+++ b/tempodb/backend/azure/v2/v2.go
@@ -227,6 +227,44 @@ func (rw *V2) ListBlocks(ctx context.Context, tenant string) ([]uuid.UUID, []uui
 	return blockIDs, compactedBlockIDs, nil
 }
 
+// Find implements backend.Reader
+func (rw *V2) Find(ctx context.Context, keypath backend.KeyPath, f backend.FindFunc) (err error) {
+	keypath = backend.KeyPathWithPrefix(keypath, rw.cfg.Prefix)
+
+	prefix := path.Join(keypath...)
+
+	if len(prefix) > 0 {
+		prefix = prefix + dir
+	}
+
+	pager := rw.containerClient.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{
+		Prefix: &prefix,
+	})
+
+	var o string
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return fmt.Errorf("iterating objects: %w", err)
+		}
+
+		for _, b := range page.Segment.BlobItems {
+			if b == nil || b.Name == nil {
+				continue
+			}
+			o = strings.TrimPrefix(strings.TrimSuffix(*b.Name, dir), prefix)
+			opts := backend.FindOpts{
+				Key:      o,
+				Modified: *b.Properties.LastModified,
+			}
+			f(opts)
+		}
+
+	}
+
+	return
+}
+
 // Read implements backend.Reader
 func (rw *V2) Read(ctx context.Context, name string, keypath backend.KeyPath, _ *backend.CacheInfo) (io.ReadCloser, int64, error) {
 	keypath = backend.KeyPathWithPrefix(keypath, rw.cfg.Prefix)

--- a/tempodb/backend/azure/v2/v2.go
+++ b/tempodb/backend/azure/v2/v2.go
@@ -253,7 +253,7 @@ func (rw *V2) Find(ctx context.Context, keypath backend.KeyPath, f backend.FindF
 				continue
 			}
 			o = strings.TrimPrefix(strings.TrimSuffix(*b.Name, dir), prefix)
-			opts := backend.FindOpts{
+			opts := backend.FindMatch{
 				Key:      o,
 				Modified: *b.Properties.LastModified,
 			}

--- a/tempodb/backend/backend.go
+++ b/tempodb/backend/backend.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/google/uuid"
+
 	"github.com/grafana/tempo/pkg/cache"
 )
 
@@ -65,6 +66,8 @@ type Reader interface {
 	BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID string) (*BlockMeta, error)
 	// TenantIndex returns lists of all metas given a tenant
 	TenantIndex(ctx context.Context, tenantID string) (*TenantIndex, error)
+	// Find executes f for each object in the backend that matches the keypath.
+	Find(ctx context.Context, keypath KeyPath, f FindFunc) error
 	// Shutdown shuts...down?
 	Shutdown()
 }

--- a/tempodb/backend/backend.go
+++ b/tempodb/backend/backend.go
@@ -48,6 +48,8 @@ type Writer interface {
 	CloseAppend(ctx context.Context, tracker AppendTracker) error
 	// WriteTenantIndex writes the two meta slices as a tenant index
 	WriteTenantIndex(ctx context.Context, tenantID string, meta []*BlockMeta, compactedMeta []*CompactedBlockMeta) error
+	// Delete deletes an object.
+	Delete(ctx context.Context, name string, keypath KeyPath) error
 }
 
 // Reader is a collection of methods to read data from tempodb backends

--- a/tempodb/backend/cache/cache.go
+++ b/tempodb/backend/cache/cache.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/google/uuid"
+
 	"github.com/grafana/tempo/pkg/cache"
 
 	tempo_io "github.com/grafana/tempo/pkg/io"
@@ -70,6 +71,11 @@ func (r *readerWriter) List(ctx context.Context, keypath backend.KeyPath) ([]str
 
 func (r *readerWriter) ListBlocks(ctx context.Context, tenant string) (blockIDs []uuid.UUID, compactedBlockIDs []uuid.UUID, err error) {
 	return r.nextReader.ListBlocks(ctx, tenant)
+}
+
+// Find implements backend.Reader
+func (r *readerWriter) Find(ctx context.Context, keypath backend.KeyPath, f backend.FindFunc) (err error) {
+	return r.nextReader.Find(ctx, keypath, f)
 }
 
 // Read implements backend.RawReader

--- a/tempodb/backend/gcs/gcs.go
+++ b/tempodb/backend/gcs/gcs.go
@@ -81,7 +81,7 @@ func NewVersionedReaderWriter(cfg *Config, confirmVersioning bool) (backend.Vers
 
 func internalNew(cfg *Config, confirm bool) (*readerWriter, error) {
 	loglevel := &dskitlog.Level{}
-	loglevel.Set("debug")
+	_ = loglevel.Set("debug")
 	log.InitLogger(&server.Config{LogLevel: *loglevel})
 	ctx := context.Background()
 

--- a/tempodb/backend/gcs/gcs.go
+++ b/tempodb/backend/gcs/gcs.go
@@ -13,9 +13,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/go-kit/log/level"
 	"github.com/google/uuid"
-	dskitlog "github.com/grafana/dskit/log"
 
 	"github.com/grafana/tempo/tempodb/backend/instrumentation"
 
@@ -26,11 +24,8 @@ import (
 	"google.golang.org/api/option"
 	google_http "google.golang.org/api/transport/http"
 
-	"github.com/grafana/dskit/server"
-
 	"github.com/grafana/tempo/pkg/blockboundary"
 	tempo_io "github.com/grafana/tempo/pkg/io"
-	"github.com/grafana/tempo/pkg/util/log"
 	"github.com/grafana/tempo/tempodb/backend"
 )
 
@@ -80,9 +75,6 @@ func NewVersionedReaderWriter(cfg *Config, confirmVersioning bool) (backend.Vers
 }
 
 func internalNew(cfg *Config, confirm bool) (*readerWriter, error) {
-	loglevel := &dskitlog.Level{}
-	_ = loglevel.Set("debug")
-	log.InitLogger(&server.Config{LogLevel: *loglevel})
 	ctx := context.Background()
 
 	bucket, err := createBucket(ctx, cfg, false)
@@ -323,7 +315,6 @@ func (rw *readerWriter) Find(ctx context.Context, keypath backend.KeyPath, f bac
 	if len(prefix) > 0 {
 		prefix = prefix + "/"
 	}
-	level.Info(log.Logger).Log("msg", "finding objects", "prefix", prefix, "keypath", fmt.Sprintf("%+v", keypath))
 
 	iter := rw.bucket.Objects(ctx, &storage.Query{
 		Delimiter: "",
@@ -332,7 +323,6 @@ func (rw *readerWriter) Find(ctx context.Context, keypath backend.KeyPath, f bac
 	})
 
 	for {
-		level.Info(log.Logger).Log("msg", "iterating objects", "prefix", prefix)
 		attrs, iterErr := iter.Next()
 		if errors.Is(iterErr, iterator.Done) {
 			break

--- a/tempodb/backend/gcs/gcs.go
+++ b/tempodb/backend/gcs/gcs.go
@@ -341,11 +341,6 @@ func (rw *readerWriter) Find(ctx context.Context, keypath backend.KeyPath, f bac
 			return fmt.Errorf("iterating objects: %w", err)
 		}
 
-		// TODO: hmm, all the other methods in this backend are using attrs other than name.  Except the listBlocks.  Why?
-		/* obj := strings.TrimSuffix(strings.TrimPrefix(attrs.Name, prefix), "/") */
-		/* obj := strings.TrimPrefix(attrs.Name, prefix) */
-		/* level.Info(log.Logger).Log("msg", "find", "blob", attrs.Name, "obj", obj, "attrs", fmt.Sprintf("%+v", attrs)) */
-
 		opts := backend.FindOpts{
 			Key:      attrs.Name,
 			Modified: attrs.Updated,

--- a/tempodb/backend/gcs/gcs.go
+++ b/tempodb/backend/gcs/gcs.go
@@ -341,7 +341,7 @@ func (rw *readerWriter) Find(ctx context.Context, keypath backend.KeyPath, f bac
 			return fmt.Errorf("iterating objects: %w", err)
 		}
 
-		opts := backend.FindOpts{
+		opts := backend.FindMatch{
 			Key:      attrs.Name,
 			Modified: attrs.Updated,
 		}

--- a/tempodb/backend/local/local.go
+++ b/tempodb/backend/local/local.go
@@ -209,7 +209,7 @@ func (rw *Backend) Find(_ context.Context, keypath backend.KeyPath, f backend.Fi
 		}
 
 		tenantFilePath := filepath.Join(filepath.Join(keypath...), path)
-		opts := backend.FindOpts{
+		opts := backend.FindMatch{
 			Key:      tenantFilePath,
 			Modified: info.ModTime(),
 		}

--- a/tempodb/backend/local/local.go
+++ b/tempodb/backend/local/local.go
@@ -199,6 +199,10 @@ func (rw *Backend) Find(_ context.Context, keypath backend.KeyPath, f backend.Fi
 			return err
 		}
 
+		if d.IsDir() {
+			return nil
+		}
+
 		info, err := d.Info()
 		if err != nil {
 			return err

--- a/tempodb/backend/local/local.go
+++ b/tempodb/backend/local/local.go
@@ -190,6 +190,34 @@ func (rw *Backend) ListBlocks(_ context.Context, tenant string) (metas []uuid.UU
 	return
 }
 
+// Find implements backend.Reader
+func (rw *Backend) Find(_ context.Context, keypath backend.KeyPath, f backend.FindFunc) (err error) {
+	path := rw.rootPath(keypath)
+	fff := os.DirFS(path)
+	err = fs.WalkDir(fff, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		tenantFilePath := filepath.Join(filepath.Join(keypath...), path)
+		opts := backend.FindOpts{
+			Key:      tenantFilePath,
+			Modified: info.ModTime(),
+		}
+
+		f(opts)
+
+		return nil
+	})
+
+	return
+}
+
 // Read implements backend.Reader
 func (rw *Backend) Read(ctx context.Context, name string, keypath backend.KeyPath, _ *backend.CacheInfo) (io.ReadCloser, int64, error) {
 	if err := ctx.Err(); err != nil {

--- a/tempodb/backend/mocks.go
+++ b/tempodb/backend/mocks.go
@@ -28,10 +28,10 @@ type MockRawReader struct {
 	R            []byte // read
 	Range        []byte // ReadRange
 	ReadFn       func(ctx context.Context, name string, keypath KeyPath, cacheInfo *CacheInfo) (io.ReadCloser, int64, error)
+	DeleteResult []string
 
 	BlockIDs          []uuid.UUID
 	CompactedBlockIDs []uuid.UUID
-	FindResult        []string
 }
 
 func (m *MockRawReader) List(ctx context.Context, keypath KeyPath) ([]string, error) {
@@ -48,6 +48,10 @@ func (m *MockRawReader) ListBlocks(ctx context.Context, tenant string) ([]uuid.U
 	}
 
 	return m.BlockIDs, m.CompactedBlockIDs, nil
+}
+
+func (m *MockRawReader) Find(_ context.Context, _ KeyPath, _ FindFunc) error {
+	return nil
 }
 
 func (m *MockRawReader) Read(ctx context.Context, name string, keypath KeyPath, cacheInfo *CacheInfo) (io.ReadCloser, int64, error) {
@@ -155,6 +159,10 @@ type MockReader struct {
 	CompactedBlockIDs []uuid.UUID // blocks
 }
 
+func (m *MockReader) Find(_ context.Context, _ KeyPath, _ FindFunc) error {
+	return nil
+}
+
 func (m *MockReader) Tenants(context.Context) ([]string, error) {
 	return m.T, nil
 }
@@ -239,6 +247,10 @@ func (m *MockWriter) Append(context.Context, string, uuid.UUID, string, AppendTr
 }
 
 func (m *MockWriter) CloseAppend(context.Context, AppendTracker) error {
+	return nil
+}
+
+func (m *MockWriter) Delete(context.Context, string, KeyPath) error {
 	return nil
 }
 

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"path"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -25,7 +26,15 @@ const (
 // from the backend
 type KeyPath []string
 
-type Feature int
+// FundFunc is executed for each object in the backend.  The provided FindOpts
+// are used to determine how to handle the object.  Any collection of these
+// objects is the callers responsibility.
+type FindFunc func(FindOpts)
+
+type FindOpts struct {
+	Modified time.Time
+	Key      string
+}
 
 // RawWriter is a collection of methods to write data to tempodb backends
 type RawWriter interface {
@@ -45,6 +54,8 @@ type RawReader interface {
 	List(ctx context.Context, keypath KeyPath) ([]string, error)
 	// ListBlocks returns all blockIDs and compactedBlockIDs for a tenant.
 	ListBlocks(ctx context.Context, tenant string) (blockIDs []uuid.UUID, compactedBlockIDs []uuid.UUID, err error)
+	// Find executes the FindFunc for each object in the backend starting at the specified keypath.  Collection of these objects is the callers responsibility.
+	Find(ctx context.Context, keypath KeyPath, f FindFunc) error
 	// Read is for streaming entire objects from the backend.  There will be an attempt to retrieve this from cache if shouldCache is true.
 	Read(ctx context.Context, name string, keyPath KeyPath, cacheInfo *CacheInfo) (io.ReadCloser, int64, error)
 	// ReadRange is for reading parts of large objects from the backend.
@@ -225,6 +236,11 @@ func (r *reader) TenantIndex(ctx context.Context, tenantID string) (*TenantIndex
 	}
 
 	return i, nil
+}
+
+// Find implements backend.Reader
+func (r *reader) Find(ctx context.Context, keypath KeyPath, f FindFunc) error {
+	return r.r.Find(ctx, keypath, f)
 }
 
 // Shutdown implements backend.Reader

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -26,7 +26,7 @@ const (
 // from the backend
 type KeyPath []string
 
-// FundFunc is executed for each object in the backend.  The provided FindOpts
+// FundFunc is executed for each object in the backend.  The provided FindMatch
 // are used to determine how to handle the object.  Any collection of these
 // objects is the callers responsibility.
 type FindFunc func(FindMatch)

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -29,9 +29,9 @@ type KeyPath []string
 // FundFunc is executed for each object in the backend.  The provided FindOpts
 // are used to determine how to handle the object.  Any collection of these
 // objects is the callers responsibility.
-type FindFunc func(FindOpts)
+type FindFunc func(FindMatch)
 
-type FindOpts struct {
+type FindMatch struct {
 	Modified time.Time
 	Key      string
 }

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -142,6 +142,11 @@ func (w *writer) WriteTenantIndex(ctx context.Context, tenantID string, meta []*
 	return nil
 }
 
+// Delete implements backend.Writer
+func (w *writer) Delete(ctx context.Context, name string, keypath KeyPath) error {
+	return w.w.Delete(ctx, name, keypath, nil)
+}
+
 type reader struct {
 	r RawReader
 }

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -396,8 +396,6 @@ func (rw *readerWriter) Find(ctx context.Context, keypath backend.KeyPath, f bac
 	keypath = backend.KeyPathWithPrefix(keypath, rw.cfg.Prefix)
 	prefix := path.Join(keypath...)
 
-	// TODO, verify prefix handling.
-
 	if len(prefix) > 0 {
 		prefix = prefix + "/"
 	}

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -419,7 +419,7 @@ func (rw *readerWriter) Find(ctx context.Context, keypath backend.KeyPath, f bac
 
 			if len(res.Contents) > 0 {
 				for _, c := range res.Contents {
-					opts := backend.FindOpts{
+					opts := backend.FindMatch{
 						Key:      c.Key,
 						Modified: c.LastModified,
 					}

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -497,6 +497,7 @@ func (p *Poller) deleteTenant(ctx context.Context, tenantID string) error {
 
 	for _, object := range foundObjects {
 		dir, name := path.Split(object)
+		level.Info(p.logger).Log("msg", "deleting", "tenant", tenantID, "object", object)
 		err = p.writer.Delete(ctx, name, backend.KeyPath{dir})
 		if err != nil {
 			return err

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"path"
 	"sort"
 	"strconv"
 	"sync"
@@ -232,7 +233,7 @@ func (p *Poller) pollTenantAndCreateIndex(
 	metricTenantIndexBuilder.WithLabelValues(tenantID).Set(1)
 	blocklist, compactedBlocklist, err := p.pollTenantBlocks(derivedCtx, tenantID, previous)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to poll tenant blocks: %w", err)
 	}
 
 	// everything is happy, write this tenant index
@@ -242,6 +243,14 @@ func (p *Poller) pollTenantAndCreateIndex(
 		metricTenantIndexErrors.WithLabelValues(tenantID).Inc()
 		level.Error(p.logger).Log("msg", "failed to write tenant index", "tenant", tenantID, "err", err)
 	}
+
+	if len(blocklist) == 0 && len(compactedBlocklist) == 0 {
+		err := p.deleteTenant(ctx, tenantID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to delete tenant: %w", err)
+		}
+	}
+
 	metricTenantIndexAgeSeconds.WithLabelValues(tenantID).Set(0)
 
 	return blocklist, compactedBlocklist, nil
@@ -452,6 +461,46 @@ func (p *Poller) tenantIndexPollError(idx *backend.TenantIndex, err error) error
 
 	if p.cfg.StaleTenantIndex != 0 && time.Since(idx.CreatedAt) > p.cfg.StaleTenantIndex {
 		return fmt.Errorf("tenant index created at %s is stale", idx.CreatedAt)
+	}
+
+	return nil
+}
+
+// deleteTenant will delete all of a tenant's objects if there is not a tenant index present.
+func (p *Poller) deleteTenant(ctx context.Context, tenantID string) error {
+	level.Info(p.logger).Log("msg", "deleting tenant", "tenant", tenantID)
+
+	if p.cfg.EmptyTenantDeletionAge == 0 {
+		return fmt.Errorf("empty tenant deletion age must be greater than 0")
+	}
+
+	var foundObjects []string
+	err := p.reader.Find(ctx, backend.KeyPath{tenantID}, func(opts backend.FindOpts) {
+		level.Info(p.logger).Log("msg", "checking object for deletion", "object", opts.Key, "modified", opts.Modified)
+
+		if time.Since(opts.Modified) > p.cfg.EmptyTenantDeletionAge {
+			foundObjects = append(foundObjects, opts.Key)
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	// do nothing if the tenant index has appeared.
+	_, err = p.reader.TenantIndex(ctx, tenantID)
+	// If we have any error other than that which indicates that the tenant index
+	// call was made successfuly, and that it does not exist, do nothing.  Only
+	// proceed if we know that the index does not exist.
+	if err != backend.ErrDoesNotExist {
+		return nil
+	}
+
+	for _, object := range foundObjects {
+		dir, name := path.Split(object)
+		err = p.writer.Delete(ctx, name, backend.KeyPath{dir})
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -75,13 +75,14 @@ var (
 
 // Config is used to configure the poller
 type PollerConfig struct {
-	PollConcurrency           uint
-	PollFallback              bool
-	TenantIndexBuilders       int
-	StaleTenantIndex          time.Duration
-	PollJitterMs              int
-	TolerateConsecutiveErrors int
-	EmptyTenantDeletionAge    time.Duration
+	PollConcurrency            uint
+	PollFallback               bool
+	TenantIndexBuilders        int
+	StaleTenantIndex           time.Duration
+	PollJitterMs               int
+	TolerateConsecutiveErrors  int
+	EmptyTenantDeletionAge     time.Duration
+	EmptyTenantDeletionEnabled bool
 }
 
 // JobSharder is used to determine if a particular job is owned by this process
@@ -468,6 +469,11 @@ func (p *Poller) tenantIndexPollError(idx *backend.TenantIndex, err error) error
 
 // deleteTenant will delete all of a tenant's objects if there is not a tenant index present.
 func (p *Poller) deleteTenant(ctx context.Context, tenantID string) error {
+	// If we have not enabled empty tenant deletion, do nothing.
+	if !p.cfg.EmptyTenantDeletionEnabled {
+		return nil
+	}
+
 	level.Info(p.logger).Log("msg", "deleting tenant", "tenant", tenantID)
 
 	if p.cfg.EmptyTenantDeletionAge == 0 {

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -80,6 +80,7 @@ type PollerConfig struct {
 	StaleTenantIndex          time.Duration
 	PollJitterMs              int
 	TolerateConsecutiveErrors int
+	EmptyTenantDeletionAge    time.Duration
 }
 
 // JobSharder is used to determine if a particular job is owned by this process

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -489,9 +489,9 @@ func (p *Poller) deleteTenant(ctx context.Context, tenantID string) error {
 	// do nothing if the tenant index has appeared.
 	_, err = p.reader.TenantIndex(ctx, tenantID)
 	// If we have any error other than that which indicates that the tenant index
-	// call was made successfuly, and that it does not exist, do nothing.  Only
+	// call was made successfully, and that it does not exist, do nothing.  Only
 	// proceed if we know that the index does not exist.
-	if err != backend.ErrDoesNotExist {
+	if !errors.Is(err, backend.ErrDoesNotExist) {
 		return nil
 	}
 

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -475,7 +475,7 @@ func (p *Poller) deleteTenant(ctx context.Context, tenantID string) error {
 	}
 
 	var foundObjects []string
-	err := p.reader.Find(ctx, backend.KeyPath{tenantID}, func(opts backend.FindOpts) {
+	err := p.reader.Find(ctx, backend.KeyPath{tenantID}, func(opts backend.FindMatch) {
 		level.Info(p.logger).Log("msg", "checking object for deletion", "object", opts.Key, "modified", opts.Modified)
 
 		if time.Since(opts.Modified) > p.cfg.EmptyTenantDeletionAge {

--- a/tempodb/blocklist/poller_test.go
+++ b/tempodb/blocklist/poller_test.go
@@ -21,9 +21,10 @@ import (
 )
 
 var (
-	testPollConcurrency = uint(10)
-	testPollFallback    = true
-	testBuilders        = 1
+	testPollConcurrency     = uint(10)
+	testPollFallback        = true
+	testBuilders            = 1
+	testEmptyTenantIndexAge = 1 * time.Minute
 )
 
 type mockJobSharder struct {
@@ -260,10 +261,11 @@ func TestTenantIndexFallback(t *testing.T) {
 			}
 
 			poller := NewPoller(&PollerConfig{
-				PollConcurrency:     testPollConcurrency,
-				PollFallback:        tc.pollFallback,
-				TenantIndexBuilders: testBuilders,
-				StaleTenantIndex:    tc.staleTenantIndex,
+				PollConcurrency:        testPollConcurrency,
+				PollFallback:           tc.pollFallback,
+				TenantIndexBuilders:    testBuilders,
+				StaleTenantIndex:       tc.staleTenantIndex,
+				EmptyTenantDeletionAge: testEmptyTenantIndexAge,
 			}, &mockJobSharder{
 				owns: tc.isTenantIndexBuilder,
 			}, r, c, w, log.NewNopLogger())
@@ -573,6 +575,7 @@ func TestPollTolerateConsecutiveErrors(t *testing.T) {
 				PollFallback:              testPollFallback,
 				TenantIndexBuilders:       testBuilders,
 				TolerateConsecutiveErrors: tc.tolerate,
+				EmptyTenantDeletionAge:    testEmptyTenantIndexAge,
 			}, s, r, c, w, log.NewNopLogger())
 
 			_, _, err := poller.Do(b)

--- a/tempodb/config.go
+++ b/tempodb/config.go
@@ -29,6 +29,8 @@ const (
 	DefaultTenantIndexBuilders       = 2
 	DefaultTolerateConsecutiveErrors = 1
 
+	DefaultEmptyTenantDeletionAge = 12 * time.Hour
+
 	DefaultPrefetchTraceCount   = 1000
 	DefaultSearchChunkSizeBytes = 1_000_000
 	DefaultReadBufferCount      = 32

--- a/tempodb/config.go
+++ b/tempodb/config.go
@@ -53,7 +53,8 @@ type Config struct {
 	BlocklistPollJitterMs                  int           `yaml:"blocklist_poll_jitter_ms"`
 	BlocklistPollTolerateConsecutiveErrors int           `yaml:"blocklist_poll_tolerate_consecutive_errors"`
 
-	EmptyTenantDeletionAge time.Duration `yaml:"empty_tenant_deletion_age"`
+	EmptyTenantDeletionEnabled bool          `yaml:"empty_tenant_deletion_enabled"`
+	EmptyTenantDeletionAge     time.Duration `yaml:"empty_tenant_deletion_age"`
 
 	// backends
 	Backend string        `yaml:"backend"`

--- a/tempodb/config.go
+++ b/tempodb/config.go
@@ -51,6 +51,8 @@ type Config struct {
 	BlocklistPollJitterMs                  int           `yaml:"blocklist_poll_jitter_ms"`
 	BlocklistPollTolerateConsecutiveErrors int           `yaml:"blocklist_poll_tolerate_consecutive_errors"`
 
+	EmptyTenantDeletionAge time.Duration `yaml:"empty_tenant_deletion_age"`
+
 	// backends
 	Backend string        `yaml:"backend"`
 	Local   *local.Config `yaml:"local"`

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -13,6 +13,10 @@ import (
 	gkLog "github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/google/uuid"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/grafana/tempo/modules/cache/memcached"
 	"github.com/grafana/tempo/modules/cache/redis"
 	"github.com/grafana/tempo/pkg/cache"
@@ -30,9 +34,6 @@ import (
 	"github.com/grafana/tempo/tempodb/encoding/common"
 	"github.com/grafana/tempo/tempodb/pool"
 	"github.com/grafana/tempo/tempodb/wal"
-	"github.com/opentracing/opentracing-go"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 const (
@@ -501,6 +502,10 @@ func (rw *readerWriter) EnablePolling(ctx context.Context, sharder blocklist.Job
 		rw.cfg.BlocklistPollTenantIndexBuilders = DefaultTenantIndexBuilders
 	}
 
+	if rw.cfg.EmptyTenantDeletionAge <= 0 {
+		rw.cfg.EmptyTenantDeletionAge = 4 * rw.cfg.BlocklistPoll
+	}
+
 	level.Info(rw.logger).Log("msg", "polling enabled", "interval", rw.cfg.BlocklistPoll, "blocklist_concurrency", rw.cfg.BlocklistPollConcurrency)
 
 	blocklistPoller := blocklist.NewPoller(&blocklist.PollerConfig{
@@ -510,6 +515,7 @@ func (rw *readerWriter) EnablePolling(ctx context.Context, sharder blocklist.Job
 		StaleTenantIndex:          rw.cfg.BlocklistPollStaleTenantIndex,
 		PollJitterMs:              rw.cfg.BlocklistPollJitterMs,
 		TolerateConsecutiveErrors: rw.cfg.BlocklistPollTolerateConsecutiveErrors,
+		EmptyTenantDeletionAge:    rw.cfg.EmptyTenantDeletionAge,
 	}, sharder, rw.r, rw.c, rw.w, rw.logger)
 
 	rw.blocklistPoller = blocklistPoller

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -503,7 +503,7 @@ func (rw *readerWriter) EnablePolling(ctx context.Context, sharder blocklist.Job
 	}
 
 	if rw.cfg.EmptyTenantDeletionAge <= 0 {
-		rw.cfg.EmptyTenantDeletionAge = 4 * rw.cfg.BlocklistPoll
+		rw.cfg.EmptyTenantDeletionAge = DefaultEmptyTenantDeletionAge
 	}
 
 	level.Info(rw.logger).Log("msg", "polling enabled", "interval", rw.cfg.BlocklistPoll, "blocklist_concurrency", rw.cfg.BlocklistPollConcurrency)

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -509,13 +509,14 @@ func (rw *readerWriter) EnablePolling(ctx context.Context, sharder blocklist.Job
 	level.Info(rw.logger).Log("msg", "polling enabled", "interval", rw.cfg.BlocklistPoll, "blocklist_concurrency", rw.cfg.BlocklistPollConcurrency)
 
 	blocklistPoller := blocklist.NewPoller(&blocklist.PollerConfig{
-		PollConcurrency:           rw.cfg.BlocklistPollConcurrency,
-		PollFallback:              rw.cfg.BlocklistPollFallback,
-		TenantIndexBuilders:       rw.cfg.BlocklistPollTenantIndexBuilders,
-		StaleTenantIndex:          rw.cfg.BlocklistPollStaleTenantIndex,
-		PollJitterMs:              rw.cfg.BlocklistPollJitterMs,
-		TolerateConsecutiveErrors: rw.cfg.BlocklistPollTolerateConsecutiveErrors,
-		EmptyTenantDeletionAge:    rw.cfg.EmptyTenantDeletionAge,
+		PollConcurrency:            rw.cfg.BlocklistPollConcurrency,
+		PollFallback:               rw.cfg.BlocklistPollFallback,
+		TenantIndexBuilders:        rw.cfg.BlocklistPollTenantIndexBuilders,
+		StaleTenantIndex:           rw.cfg.BlocklistPollStaleTenantIndex,
+		PollJitterMs:               rw.cfg.BlocklistPollJitterMs,
+		TolerateConsecutiveErrors:  rw.cfg.BlocklistPollTolerateConsecutiveErrors,
+		EmptyTenantDeletionAge:     rw.cfg.EmptyTenantDeletionAge,
+		EmptyTenantDeletionEnabled: rw.cfg.EmptyTenantDeletionEnabled,
 	}, sharder, rw.r, rw.c, rw.w, rw.logger)
 
 	rw.blocklistPoller = blocklistPoller


### PR DESCRIPTION
**What this PR does**:

In previous attempts to delete the tenant index, it was possible that undiscoverable objects remained in the backend as a partial blocks, which lead to unintended behavior for the poller, whereby the poller would discover a tenant, determine there were no blocks, and delete the index.  However, the partial blocks kept the tenant in the list and so would repeat this forever, or until bucket retention policies removed the objects.

Here we take a more complete approach to tenant deletion.  Upon deletion of a tenant index, we search the backend for objects on a given tenant, and then delete them after a configurable amount of time has expired since the object was last modified.

* Implement Find() on backend readers
* Implement Delete() on backend writers
* Add configuration for `EmptyTenantDeletionAge`, default to 4x the polling cycle, which will delete objects from empty tenants after this time has expired.

**Background Summary:**

* A partial block is written to a tenant and then stops sending spans.
* Retention eventually removes all known blocks.
* The partial block remains for the tenant because it is not known.
    * i.e: `<tenant>/<blockID>/data.parquet` exists
    * No `meta.json` nor `meta.compacted.json` exist for this block.
* A poller owning this tenant calls [Tenants()](https://github.com/zalegrala/tempo/blob/9e77d6f6bba2f06b53acbd70097d9dc7df86282b/tempodb/blocklist/poller.go#L142) to know on which tenants to build an index.
    * This call is simply a [list](https://github.com/zalegrala/tempo/blob/9e77d6f6bba2f06b53acbd70097d9dc7df86282b/tempodb/backend/raw.go#L167) at `/` to determine all the tenant “directory” names.
* For the given tenant, no blocks are found, and so the tenant performs a [WriteTenantIndex()](https://github.com/zalegrala/tempo/blob/9e77d6f6bba2f06b53acbd70097d9dc7df86282b/tempodb/blocklist/poller.go#L239)
    * If we are writing an index with no blocks, the tenant index is instead [deleted](https://github.com/zalegrala/tempo/blob/9e77d6f6bba2f06b53acbd70097d9dc7df86282b/tempodb/backend/raw.go#L112).
* A poller that does not own the tenant performs the above, with a subtle but important difference.
    * First attempt to read the index with a [TenantIndex()](https://github.com/zalegrala/tempo/blob/9e77d6f6bba2f06b53acbd70097d9dc7df86282b/tempodb/blocklist/poller.go#L202) call
    * The call will fail because the owning poller has deleted the index.
    * The failing index metric used to alert is [incremented](https://github.com/zalegrala/tempo/blob/9e77d6f6bba2f06b53acbd70097d9dc7df86282b/tempodb/blocklist/poller.go#L214).
    * The poller will fallback to [full polling]() as described above.
    

**Which issue(s) this PR fixes**:
Related #2678
Related #2754
Related #2781
Fixes #2878


**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`