### PR TITLE
metrics-generator counter: reset length of pre-allocated slice

### DIFF
--- a/modules/generator/registry/counter.go
+++ b/modules/generator/registry/counter.go
@@ -127,7 +127,7 @@ func (c *counter) collectMetrics(appender storage.Appender, timeMs int64, extern
 	}
 
 	// base labels
-	baseLabels := make(labels.Labels, 1+len(externalLabels)+labelsCount)
+	baseLabels := make(labels.Labels, 0, 1+len(externalLabels)+labelsCount)
 
 	// add external labels
 	for name, value := range externalLabels {


### PR DESCRIPTION
**What this PR does**:

Fix misuse of a preallocated slice in `counter.collectMetrics`: we prepare a slice `baseLabels` with the static labels (metric name and externals labels) + room for the series specific labels. We didn't reset the length though, so when we append the static labels this just increases the capacity further 🙃

Noticed it will debugging another feature:

![Screenshot 2024-05-01 at 20 47 59](https://github.com/grafana/tempo/assets/7748404/4edcf27c-88bc-4193-a75a-9b6e5939e54c)

As you can see we nicely allocate 3 places (metric name + 2x external label) and then just append them anyways.

With the fix we don't get the empty labels

![Screenshot 2024-05-01 at 20 48 55](https://github.com/grafana/tempo/assets/7748404/f1f48a3d-3fbe-4096-9a13-b4148daabfd8)

This wasn't harmful since `Appender` has code to remove empty labels.

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`