### PR TITLE
fix(traceql): fix extract matcher regexes to work with regexp-type matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [BUGFIX] Fix handling of regex matchers in autocomplete endpoints [#3641](https://github.com/grafana/tempo/pull/3641) (@sd2k)
 * [ENHANCEMENT] Surface new labels for uninstrumented services and systems [#3543](https://github.com/grafana/tempo/pull/3543) (@t00mas)
 * [FEATURE] Add TLS support for Memcached Client [#3585](https://github.com/grafana/tempo/pull/3585) (@sonisr)
 * [FEATURE] TraceQL metrics queries: add quantile_over_time [#3605](https://github.com/grafana/tempo/pull/3605) [#3633](https://github.com/grafana/tempo/pull/3633) (@mdisibio) 

--- a/pkg/traceql/extractmatcher.go
+++ b/pkg/traceql/extractmatcher.go
@@ -18,7 +18,7 @@ import (
 //  3. The boolean values "true" or "false".
 //
 // Example: "http.status_code = 200" from the query "{ .http.status_code = 200 && .http.method = }"
-var matchersRegexp = regexp.MustCompile(`[\p{L}\p{N}._\-" ]+\s*[=|<=|>=|=~|!=|>|<|!~]\s*(?:"[\p{L}\p{N}\p{P}\p{M}\p{S}]+"|true|false|[a-z]+|[0-9smh]+)`)
+var matchersRegexp = regexp.MustCompile(`[\p{L}\p{N}._\-" ]+\s*(=|<=|>=|=~|!=|>|<|!~)\s*(?:"[\p{L}\p{N}\p{P}\p{M}\p{S}]+"|true|false|[a-z]+|[0-9smh]+)`)
 
 // TODO: Merge into a single regular expression
 
@@ -29,11 +29,12 @@ var matchersRegexp = regexp.MustCompile(`[\p{L}\p{N}._\-" ]+\s*[=|<=|>=|=~|!=|>|
 //	Query                                    |  Match
 //
 // { .bar = "foo" }                          |   Yes
+// { .bar =~ "foo|bar" }                     |   Yes
 // { .bar = "foo" && .foo = "bar" }          |   Yes
 // { .bar = "foo" || .foo = "bar" }          |   No
 // { .bar = "foo" } && { .foo = "bar" }      |   No
 // { .bar = "foo" } || { .foo = "bar" }      |   No
-var singleFilterRegexp = regexp.MustCompile(`^\{[^|{}]*[^|{}]}?$`)
+var singleFilterRegexp = regexp.MustCompile(`^(\{[^|{}]*[^|{}]}?|\{[^|{}]*=~[^{}]*})$`)
 
 const emptyQuery = "{}"
 

--- a/pkg/traceql/extractmatcher_test.go
+++ b/pkg/traceql/extractmatcher_test.go
@@ -110,6 +110,16 @@ func TestExtractMatchers(t *testing.T) {
 			query:    `{ .foo =~ "(a|b)" }`,
 			expected: `{.foo =~ "(a|b)"}`,
 		},
+		{
+			name:     "query with multiple regex matchers",
+			query:    `{ .foo =~ "(a|b)" && .bar =~ "(c|d)" }`,
+			expected: `{.foo =~ "(a|b)" && .bar =~ "(c|d)"}`,
+		},
+		{
+			name:     "query with mixed equal and regex matchers",
+			query:    `{ .foo = "a" && .bar =~ "(c|d)" }`,
+			expected: `{.foo = "a" && .bar =~ "(c|d)"}`,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/traceql/extractmatcher_test.go
+++ b/pkg/traceql/extractmatcher_test.go
@@ -100,6 +100,16 @@ func TestExtractMatchers(t *testing.T) {
 			query:    `{ span."foo bar" = "baz" }`,
 			expected: `{span."foo bar" = "baz"}`,
 		},
+		{
+			name:     "query with trivial regex matcher",
+			query:    `{ .foo =~ "a" }`,
+			expected: `{.foo =~ "a"}`,
+		},
+		{
+			name:     "query with regex matcher",
+			query:    `{ .foo =~ "(a|b)" }`,
+			expected: `{.foo =~ "(a|b)"}`,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This improves the regexes used by autocomplete (and I think the search tags v2 endpoint?) so that they work with queries like `{ resource.service.name = "app" && resource.k8s.cluster.name=~"prod-.+" }`.

Fixes #3635.
