### PR TITLE
Implement polling tenants concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@
 * [ENHANCEMENT] Reduce log level verbosity for e2e tests[#3900](https://github.com/grafana/tempo/pull/3900) (@javiermolinar)
 * [ENHANCEMENT] Added new Traces api V2[#3912](https://github.com/grafana/tempo/pull/3912) (@javiermolinar)
 * [ENHANCEMENT] Update to the latest dskit [#3915](https://github.com/grafana/tempo/pull/3915) (@andreasgerstmayr)
-
+* [ENHANCEMENT] Implement polling tenants concurrently [#3647](https://github.com/grafana/tempo/pull/3647) (@zalegrala)
 * [BUGFIX] Fix panic in certain metrics queries using `rate()` with `by` [#3847](https://github.com/grafana/tempo/pull/3847) (@stoewer)
 * [BUGFIX] Fix double appending the primary iterator on second pass with event iterator [#3903](https://github.com/grafana/tempo/pull/3903) (@ie-pham)
 * [BUGFIX] Fix metrics queries when grouping by attributes that may not exist [#3734](https://github.com/grafana/tempo/pull/3734) (@mdisibio)

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -1084,11 +1084,19 @@ storage:
         # Default 0 (disabled)
         [blocklist_poll_jitter_ms: <int>]
 
-        # Polling will tolerate this many consecutive errors before failing and exiting early for the
-        # current repoll. Can be set to 0 which means a single error is sufficient to fail and exit early
-        # (matches the original polling behavior).
+        # Polling will tolerate this many consecutive errors during the poll of
+        # a single tenant before marking the tenant as failed.
+        # This can be set to 0 which means a single error is sufficient to mark the tenant failed
+        # and exit early.  Any previous results for the failing tenant will be kept.
+        # See also `blocklist_poll_tolerate_tenant_failures` below.
         # Default 1
         [blocklist_poll_tolerate_consecutive_errors: <int>]
+
+        # Polling will tolerate this number of tenants which have failed to poll.
+        # This can be set to 0 which means a single tenant failure  sufficient to fail and exit
+        # early.
+        # Default 1
+        [blocklist_poll_tolerate_tenant_failures: <int>]
 
         # Used to tune how quickly the poller will delete any remaining backend
         # objects found in the tenant path.  This functionality requires enabling

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -1071,6 +1071,9 @@ storage:
         # the index. Default 2.
         [blocklist_poll_tenant_index_builders: <int>]
 
+        # Number of tenants to poll concurrently. Default is 1.
+        [blocklist_poll_tenant_concurrency: <int>]
+
         # The oldest allowable tenant index. If an index is pulled that is older than this duration,
         # the polling will consider this an error. Note that `blocklist_poll_fallback` applies here.
         # If fallback is true and a tenant index exceeds this duration, it will fall back to listing

--- a/integration/poller/poller_test.go
+++ b/integration/poller/poller_test.go
@@ -171,8 +171,6 @@ func TestPollerOwnership(t *testing.T) {
 					mmResults, cmResults, err := rr.ListBlocks(context.Background(), testTenant)
 					require.NoError(t, err)
 					sort.Slice(mmResults, func(i, j int) bool { return mmResults[i].String() < mmResults[j].String() })
-					// t.Logf("mmResults: %s", mmResults)
-					// t.Logf("cmResults: %s", cmResults)
 
 					require.Equal(t, tenantExpected[testTenant], mmResults)
 					require.Equal(t, len(tenantExpected[testTenant]), len(mmResults))

--- a/integration/poller/poller_test.go
+++ b/integration/poller/poller_test.go
@@ -451,6 +451,7 @@ func pushBlocksToTenant(t *testing.T, tenant string, bb [][]byte, w backend.Writ
 	r := mathrand.Intn(len(bb))
 
 	base := bb[r]
+	t.Logf("base: %v", base)
 	expected := []uuid.UUID{}
 
 	// Include the min and max in each tenant for testing

--- a/integration/poller/poller_test.go
+++ b/integration/poller/poller_test.go
@@ -353,6 +353,7 @@ func TestTenantDeletion(t *testing.T) {
 					TenantIndexBuilders:        1,
 					EmptyTenantDeletionAge:     100 * time.Millisecond,
 					EmptyTenantDeletionEnabled: true,
+					TenantPollConcurrency:      3,
 				}, OwnsEverythingSharder, r, cc, w, logger)
 
 				// Again

--- a/integration/poller/poller_test.go
+++ b/integration/poller/poller_test.go
@@ -160,7 +160,7 @@ func TestPollerOwnership(t *testing.T) {
 				// Use the block boundaries in the GCS and S3 implementation
 				bb := blockboundary.CreateBlockBoundaries(listBlockConcurrency)
 
-				tenantCount := 1000
+				tenantCount := 250
 				tenantExpected := map[string][]uuid.UUID{}
 
 				// Push some data to a few tenants
@@ -180,8 +180,8 @@ func TestPollerOwnership(t *testing.T) {
 				l := blocklist.New()
 				mm, cm, err := blocklistPoller.Do(l)
 				require.NoError(t, err)
-				t.Logf("mm: %v", mm)
-				t.Logf("cm: %v", cm)
+				// t.Logf("mm: %v", mm)
+				// t.Logf("cm: %v", cm)
 
 				l.ApplyPollResults(mm, cm)
 
@@ -197,7 +197,7 @@ func TestPollerOwnership(t *testing.T) {
 
 					assert.Equal(t, expected, actual)
 					assert.Equal(t, len(expected), len(metas))
-					t.Logf("actual: %v", actual)
+					// t.Logf("actual: %v", actual)
 
 					for _, e := range expected {
 						assert.True(t, found(e, metas))
@@ -361,7 +361,7 @@ func TestTenantDeletion(t *testing.T) {
 				require.NoError(t, err)
 
 				tennants, err = r.Tenants(ctx)
-				t.Logf("tennants: %v", tennants)
+				// t.Logf("tennants: %v", tennants)
 				require.NoError(t, err)
 				require.Equal(t, 0, len(tennants))
 			})

--- a/integration/poller/poller_test.go
+++ b/integration/poller/poller_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
-	mathrand "math/rand"
+	mathrand "math/rand/v2"
 	"os"
 	"sort"
 	"strconv"
@@ -448,7 +448,7 @@ func writeBadBlockFiles(t *testing.T, ww backend.RawWriter, rr backend.RawReader
 
 func pushBlocksToTenant(t *testing.T, tenant string, bb [][]byte, w backend.Writer) []uuid.UUID {
 	// Randomly pick a block boundary
-	r := mathrand.Intn(len(bb))
+	r := mathrand.IntN(len(bb))
 
 	base := bb[r]
 	t.Logf("base: %v", base)

--- a/integration/poller/poller_test.go
+++ b/integration/poller/poller_test.go
@@ -150,6 +150,7 @@ func TestPollerOwnership(t *testing.T) {
 
 				blocklistPoller := blocklist.NewPoller(&blocklist.PollerConfig{
 					PollConcurrency:        3,
+					TenantPollConcurrency:  2,
 					TenantIndexBuilders:    1,
 					EmptyTenantDeletionAge: 10 * time.Minute,
 				}, OwnsEverythingSharder, r, cc, w, logger)

--- a/modules/storage/config.go
+++ b/modules/storage/config.go
@@ -29,6 +29,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.Trace.BlocklistPollConcurrency = tempodb.DefaultBlocklistPollConcurrency
 	cfg.Trace.BlocklistPollTenantIndexBuilders = tempodb.DefaultTenantIndexBuilders
 	cfg.Trace.BlocklistPollTolerateConsecutiveErrors = tempodb.DefaultTolerateConsecutiveErrors
+	cfg.Trace.BlocklistPollTolerateTenantFailures = tempodb.DefaultTolerateTenantFailures
 
 	f.StringVar(&cfg.Trace.Backend, util.PrefixConfig(prefix, "trace.backend"), "", "Trace backend (s3, azure, gcs, local)")
 	f.DurationVar(&cfg.Trace.BlocklistPoll, util.PrefixConfig(prefix, "trace.blocklist_poll"), tempodb.DefaultBlocklistPoll, "Period at which to run the maintenance cycle.")

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -161,10 +161,8 @@ func (p *Poller) Do(previous *List) (PerTenant, PerTenantCompacted, error) {
 		blocklist          = PerTenant{}
 		compactedBlocklist = PerTenantCompacted{}
 
-		tenantFailuresRemaining atomic.Int32
+		tenantFailuresRemaining = atomic.NewInt32(int32(p.cfg.TolerateTenantFailures))
 	)
-
-	tenantFailuresRemaining.Store(int32(p.cfg.TolerateTenantFailures))
 
 	for _, tenantID := range tenants {
 		// Exit early if we have exceeded our tolerance for number of failing tenants.

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -193,7 +193,6 @@ func (p *Poller) Do(previous *List) (PerTenant, PerTenantCompacted, error) {
 					break
 				}
 
-				tenantFailures.Inc()
 				consecutiveErrorsRemaining--
 			}
 
@@ -205,6 +204,7 @@ func (p *Poller) Do(previous *List) (PerTenant, PerTenantCompacted, error) {
 				blocklist[tenantID] = previous.Metas(tenantID)
 				compactedBlocklist[tenantID] = previous.CompactedMetas(tenantID)
 
+				tenantFailures.Inc()
 				tenantFailuresRemaining--
 				finalErr.Store(err)
 

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -165,6 +165,7 @@ func (p *Poller) Do(previous *List) (PerTenant, PerTenantCompacted, error) {
 	)
 
 	for _, tenantID := range tenants {
+		// The finalErr is only stored when the number of consecutive errors exceeds the tolerance.  If present, return it.
 		if err := finalErr.Load(); err != nil {
 			level.Error(p.logger).Log("msg", "exiting polling loop early because too many errors", "errCount", consecutiveErrors)
 			return nil, nil, err
@@ -212,6 +213,7 @@ func (p *Poller) Do(previous *List) (PerTenant, PerTenantCompacted, error) {
 
 	wg.Wait()
 
+	// Load the finalErr in case the error was on the last itteration of the tenant loop.
 	if err := finalErr.Load(); err != nil {
 		return nil, nil, err
 	}

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -165,9 +165,9 @@ func (p *Poller) Do(previous *List) (PerTenant, PerTenantCompacted, error) {
 	)
 
 	for _, tenantID := range tenants {
-		if consecutiveErrors > p.cfg.TolerateConsecutiveErrors {
+		if err := finalErr.Load(); err != nil {
 			level.Error(p.logger).Log("msg", "exiting polling loop early because too many errors", "errCount", consecutiveErrors)
-			return nil, nil, finalErr.Load()
+			return nil, nil, err
 		}
 
 		wg.Add(1)

--- a/tempodb/blocklist/poller_test.go
+++ b/tempodb/blocklist/poller_test.go
@@ -581,8 +581,13 @@ func TestPollTolerateConsecutiveErrors(t *testing.T) {
 					errors.New("tenant three error"),
 					errors.New("tenant three error"),
 				},
+				"four": {
+					errors.New("tenant four error"),
+					errors.New("tenant four error"),
+					errors.New("tenant four error"),
+				},
 			},
-			expectedError: errors.New("tenant three err"),
+			expectedError: errors.New("tenant four err"),
 		},
 	}
 

--- a/tempodb/blocklist/poller_test.go
+++ b/tempodb/blocklist/poller_test.go
@@ -252,7 +252,7 @@ func TestTenantIndexFallback(t *testing.T) {
 			w := &backend.MockWriter{}
 			b := newBlocklist(PerTenant{}, PerTenantCompacted{})
 
-			r.(*backend.MockReader).TenantIndexFn = func(_ context.Context, tenantID string) (*backend.TenantIndex, error) {
+			r.(*backend.MockReader).TenantIndexFn = func(_ context.Context, _ string) (*backend.TenantIndex, error) {
 				if tc.errorOnCreateTenantIndex {
 					return nil, errors.New("err")
 				}

--- a/tempodb/blocklist/poller_test.go
+++ b/tempodb/blocklist/poller_test.go
@@ -541,7 +541,7 @@ func TestPollTolerateConsecutiveErrors(t *testing.T) {
 			tolerate:                0,
 			tollerateTenantFailures: 0,
 			tenantErrors:            map[string][]error{"one": {errors.New("tenant one error")}},
-			expectedError:           errors.New("tenant one err"),
+			expectedError:           errors.New("too many tenant failures; abandoning polling cycle"),
 		},
 		{
 			name:                    "tolerated errors",
@@ -577,17 +577,17 @@ func TestPollTolerateConsecutiveErrors(t *testing.T) {
 					nil,
 				},
 				"three": {
-					errors.New("tenant x error"),
-					errors.New("tenant x error"),
-					errors.New("tenant x error"),
+					errors.New("tenant three error"),
+					errors.New("tenant three error"),
+					errors.New("tenant three error"),
 				},
 				"four": {
-					errors.New("tenant x error"),
-					errors.New("tenant x error"),
-					errors.New("tenant x error"),
+					errors.New("tenant four error"),
+					errors.New("tenant four error"),
+					errors.New("tenant four error"),
 				},
 			},
-			expectedError: errors.New("tenant x err"), // test for tenant x err to avoid needing to care which of the last two tenants were caught
+			expectedError: errors.New("too many tenant failures; abandoning polling cycle"), // test for tenant x err to avoid needing to care which of the last two tenants were caught
 		},
 	}
 

--- a/tempodb/blocklist/poller_test.go
+++ b/tempodb/blocklist/poller_test.go
@@ -577,17 +577,17 @@ func TestPollTolerateConsecutiveErrors(t *testing.T) {
 					nil,
 				},
 				"three": {
-					errors.New("tenant three error"),
-					errors.New("tenant three error"),
-					errors.New("tenant three error"),
+					errors.New("tenant x error"),
+					errors.New("tenant x error"),
+					errors.New("tenant x error"),
 				},
 				"four": {
-					errors.New("tenant four error"),
-					errors.New("tenant four error"),
-					errors.New("tenant four error"),
+					errors.New("tenant x error"),
+					errors.New("tenant x error"),
+					errors.New("tenant x error"),
 				},
 			},
-			expectedError: errors.New("tenant four err"),
+			expectedError: errors.New("tenant x err"), // test for tenant x err to avoid needing to care which of the last two tenants were caught
 		},
 	}
 

--- a/tempodb/blocklist/poller_test.go
+++ b/tempodb/blocklist/poller_test.go
@@ -21,10 +21,11 @@ import (
 )
 
 var (
-	testPollConcurrency     = uint(10)
-	testPollFallback        = true
-	testBuilders            = 1
-	testEmptyTenantIndexAge = 1 * time.Minute
+	testPollConcurrency       = uint(10)
+	testTenantPollConcurrency = uint(2)
+	testPollFallback          = true
+	testBuilders              = 1
+	testEmptyTenantIndexAge   = 1 * time.Minute
 )
 
 type mockJobSharder struct {
@@ -158,9 +159,10 @@ func TestTenantIndexBuilder(t *testing.T) {
 			b := newBlocklist(PerTenant{}, PerTenantCompacted{})
 
 			poller := NewPoller(&PollerConfig{
-				PollConcurrency:     testPollConcurrency,
-				PollFallback:        testPollFallback,
-				TenantIndexBuilders: testBuilders,
+				PollConcurrency:       testPollConcurrency,
+				TenantPollConcurrency: testTenantPollConcurrency,
+				PollFallback:          testPollFallback,
+				TenantIndexBuilders:   testBuilders,
 			}, &mockJobSharder{
 				owns: true,
 			}, r, c, w, log.NewNopLogger())
@@ -262,6 +264,7 @@ func TestTenantIndexFallback(t *testing.T) {
 
 			poller := NewPoller(&PollerConfig{
 				PollConcurrency:        testPollConcurrency,
+				TenantPollConcurrency:  testTenantPollConcurrency,
 				PollFallback:           tc.pollFallback,
 				TenantIndexBuilders:    testBuilders,
 				StaleTenantIndex:       tc.staleTenantIndex,
@@ -352,9 +355,10 @@ func TestPollBlock(t *testing.T) {
 			w := &backend.MockWriter{}
 
 			poller := NewPoller(&PollerConfig{
-				PollConcurrency:     testPollConcurrency,
-				PollFallback:        testPollFallback,
-				TenantIndexBuilders: testBuilders,
+				PollConcurrency:       testPollConcurrency,
+				TenantPollConcurrency: testTenantPollConcurrency,
+				PollFallback:          testPollFallback,
+				TenantIndexBuilders:   testBuilders,
 			}, &mockJobSharder{}, r, c, w, log.NewNopLogger())
 			actualMeta, actualCompactedMeta, err := poller.pollBlock(context.Background(), tc.pollTenantID, tc.pollBlockID, false)
 
@@ -572,6 +576,7 @@ func TestPollTolerateConsecutiveErrors(t *testing.T) {
 
 			poller := NewPoller(&PollerConfig{
 				PollConcurrency:           testPollConcurrency,
+				TenantPollConcurrency:     testTenantPollConcurrency,
 				PollFallback:              testPollFallback,
 				TenantIndexBuilders:       testBuilders,
 				TolerateConsecutiveErrors: tc.tolerate,
@@ -813,6 +818,7 @@ func TestPollComparePreviousResults(t *testing.T) {
 				PollConcurrency:           testPollConcurrency,
 				PollFallback:              testPollFallback,
 				TenantIndexBuilders:       testBuilders,
+				TenantPollConcurrency:     testTenantPollConcurrency,
 				TolerateConsecutiveErrors: tc.tollerateErrors,
 			}, s, r, c, w, log.NewNopLogger())
 
@@ -898,9 +904,10 @@ func BenchmarkPoller10k(b *testing.B) {
 
 		// This mock reader returns error or nil based on the tenant ID
 		poller := NewPoller(&PollerConfig{
-			PollConcurrency:     testPollConcurrency,
-			PollFallback:        testPollFallback,
-			TenantIndexBuilders: testBuilders,
+			PollConcurrency:       testPollConcurrency,
+			TenantPollConcurrency: testTenantPollConcurrency,
+			PollFallback:          testPollFallback,
+			TenantIndexBuilders:   testBuilders,
 		}, s, r, c, w, log.NewNopLogger())
 
 		runName := fmt.Sprintf("%d-%d", tc.tenantCount, tc.blocksPerTenant)

--- a/tempodb/config.go
+++ b/tempodb/config.go
@@ -22,12 +22,13 @@ import (
 )
 
 const (
-	DefaultBlocklistPoll             = 5 * time.Minute
-	DefaultMaxTimePerTenant          = 5 * time.Minute
-	DefaultBlocklistPollConcurrency  = uint(50)
-	DefaultRetentionConcurrency      = uint(10)
-	DefaultTenantIndexBuilders       = 2
-	DefaultTolerateConsecutiveErrors = 1
+	DefaultBlocklistPoll                  = 5 * time.Minute
+	DefaultMaxTimePerTenant               = 5 * time.Minute
+	DefaultBlocklistPollConcurrency       = uint(50)
+	DefaultBlocklistPollTenantConcurrency = uint(1)
+	DefaultRetentionConcurrency           = uint(10)
+	DefaultTenantIndexBuilders            = 2
+	DefaultTolerateConsecutiveErrors      = 1
 
 	DefaultEmptyTenantDeletionAge = 12 * time.Hour
 
@@ -47,6 +48,7 @@ type Config struct {
 
 	BlocklistPoll                          time.Duration `yaml:"blocklist_poll"`
 	BlocklistPollConcurrency               uint          `yaml:"blocklist_poll_concurrency"`
+	BlocklistPollTenantConcurrency         uint          `yaml:"blocklist_poll_tenant_concurrency"`
 	BlocklistPollFallback                  bool          `yaml:"blocklist_poll_fallback"`
 	BlocklistPollTenantIndexBuilders       int           `yaml:"blocklist_poll_tenant_index_builders"`
 	BlocklistPollStaleTenantIndex          time.Duration `yaml:"blocklist_poll_stale_tenant_index"`

--- a/tempodb/config.go
+++ b/tempodb/config.go
@@ -29,6 +29,7 @@ const (
 	DefaultRetentionConcurrency           = uint(10)
 	DefaultTenantIndexBuilders            = 2
 	DefaultTolerateConsecutiveErrors      = 1
+	DefaultTolerateTenantFailures         = 1
 
 	DefaultEmptyTenantDeletionAge = 12 * time.Hour
 
@@ -54,6 +55,7 @@ type Config struct {
 	BlocklistPollStaleTenantIndex          time.Duration `yaml:"blocklist_poll_stale_tenant_index"`
 	BlocklistPollJitterMs                  int           `yaml:"blocklist_poll_jitter_ms"`
 	BlocklistPollTolerateConsecutiveErrors int           `yaml:"blocklist_poll_tolerate_consecutive_errors"`
+	BlocklistPollTolerateTenantFailures    int           `yaml:"blocklist_poll_tolerate_tenant_failures"`
 
 	EmptyTenantDeletionEnabled bool          `yaml:"empty_tenant_deletion_enabled"`
 	EmptyTenantDeletionAge     time.Duration `yaml:"empty_tenant_deletion_age"`

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -549,6 +549,7 @@ func (rw *readerWriter) EnablePolling(ctx context.Context, sharder blocklist.Job
 		StaleTenantIndex:           rw.cfg.BlocklistPollStaleTenantIndex,
 		PollJitterMs:               rw.cfg.BlocklistPollJitterMs,
 		TolerateConsecutiveErrors:  rw.cfg.BlocklistPollTolerateConsecutiveErrors,
+		TenantPollConcurrency:      rw.cfg.BlocklistPollTenantConcurrency,
 		EmptyTenantDeletionAge:     rw.cfg.EmptyTenantDeletionAge,
 		EmptyTenantDeletionEnabled: rw.cfg.EmptyTenantDeletionEnabled,
 	}, sharder, rw.r, rw.c, rw.w, rw.logger)

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -549,6 +549,7 @@ func (rw *readerWriter) EnablePolling(ctx context.Context, sharder blocklist.Job
 		StaleTenantIndex:           rw.cfg.BlocklistPollStaleTenantIndex,
 		PollJitterMs:               rw.cfg.BlocklistPollJitterMs,
 		TolerateConsecutiveErrors:  rw.cfg.BlocklistPollTolerateConsecutiveErrors,
+		TolerateTenantFailures:     rw.cfg.BlocklistPollTolerateTenantFailures,
 		TenantPollConcurrency:      rw.cfg.BlocklistPollTenantConcurrency,
 		EmptyTenantDeletionAge:     rw.cfg.EmptyTenantDeletionAge,
 		EmptyTenantDeletionEnabled: rw.cfg.EmptyTenantDeletionEnabled,

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -528,6 +528,10 @@ func (rw *readerWriter) EnablePolling(ctx context.Context, sharder blocklist.Job
 		rw.cfg.BlocklistPollConcurrency = DefaultBlocklistPollConcurrency
 	}
 
+	if rw.cfg.BlocklistPollTenantConcurrency == 0 {
+		rw.cfg.BlocklistPollTenantConcurrency = DefaultBlocklistPollTenantConcurrency
+	}
+
 	if rw.cfg.BlocklistPollTenantIndexBuilders <= 0 {
 		rw.cfg.BlocklistPollTenantIndexBuilders = DefaultTenantIndexBuilders
 	}


### PR DESCRIPTION
**What this PR does**:

Here we implement basic polling for tenants concurrently.  This is another step
towards making the polling more efficient.  The next step will be to implement
a weighted polling strategy to poll tenants by some priority.  For now, I think
this is a reasonable start and should stand on its own.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`