### PR TITLE
SearchTagValuesV2 perf improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [ENHANCEMENT] Add support for sharded ingester queries  [#3574](https://github.com/grafana/tempo/pull/3574) (@zalegrala)
 * [ENHANCEMENT] TraceQL - Add support for scoped intrinsics using `:` [#3629](https://github.com/grafana/tempo/pull/3629) (@ie-pham)
   available scoped intrinsics: trace:duration, trace:rootName, trace:rootService, span:duration, span:kind, span:name, span:status, span:statusMessage
+* [ENHANCEMENT] Performance improvements on SearchTagValuesV2. [#3650](https://github.com/grafana/tempo/pull/3650) (@joe-elliott)
 * [BUGFIX] Fix metrics query results when filtering and rating on the same attribute [#3428](https://github.com/grafana/tempo/issues/3428) (@mdisibio)
 * [BUGFIX] Fix metrics query results when series contain empty strings or nil values [#3429](https://github.com/grafana/tempo/issues/3429) (@mdisibio)
 * [BUGFIX] Fix metrics query duration check, add per-tenant override for max metrics query duration [#3479](https://github.com/grafana/tempo/issues/3479) (@mdisibio)

--- a/tempodb/encoding/vparquet3/block_autocomplete.go
+++ b/tempodb/encoding/vparquet3/block_autocomplete.go
@@ -606,8 +606,12 @@ func (d *distinctAttrCollector) KeepGroup(result *parquetquery.IteratorResult) b
 		}
 	}
 
-	attr := traceql.NewScopedAttribute(d.scope, false, key)
-	result.AppendOtherValue(attr.String(), val) // jpe remove attr.String()
+	var empty traceql.Static
+	if val != empty {
+		attr := traceql.NewScopedAttribute(d.scope, false, key)
+		result.AppendOtherValue(attr.String(), val) // jpe remove attr.String()
+
+	}
 
 	result.Entries = result.Entries[:0]
 
@@ -628,6 +632,10 @@ func (d distinctSpanCollector) String() string { return "distinctSpanCollector" 
 
 func (d distinctSpanCollector) KeepGroup(result *parquetquery.IteratorResult) bool {
 	for _, e := range result.Entries {
+		if e.Value.IsNull() {
+			continue
+		}
+
 		attr, static := mapSpanAttr(e)                 // jpe static only
 		result.AppendOtherValue(attr.String(), static) // jpe remove attr.String()
 	}
@@ -710,6 +718,10 @@ func (d *distinctBatchCollector) String() string {
 func (d *distinctBatchCollector) KeepGroup(result *parquetquery.IteratorResult) bool {
 	// Gather Attributes from dedicated resource-level columns
 	for _, e := range result.Entries {
+		if e.Value.IsNull() {
+			continue
+		}
+
 		attr, static := mapResourceAttr(e)
 		result.AppendOtherValue(attr.String(), static)
 	}
@@ -743,6 +755,10 @@ func (d *distinctTraceCollector) String() string {
 
 func (d *distinctTraceCollector) KeepGroup(result *parquetquery.IteratorResult) bool {
 	for _, e := range result.Entries {
+		if e.Value.IsNull() { // jpe why are these null?
+			continue
+		}
+
 		attr, static := mapTraceAttr(e)
 		result.AppendOtherValue(attr.String(), static)
 	}

--- a/tempodb/encoding/vparquet3/block_autocomplete_test.go
+++ b/tempodb/encoding/vparquet3/block_autocomplete_test.go
@@ -309,15 +309,11 @@ func BenchmarkFetchTagValues(b *testing.B) {
 		query string
 	}{
 		{
-			tag:   "span.http.url",
-			query: "{}",
+			tag:   "span.http.url", // well known column
+			query: `{resource.namespace="tempo-ops"}`,
 		},
 		{
-			tag:   "resource.namespace",
-			query: `{}`,
-		},
-		{
-			tag:   "span.http.url",
+			tag:   "span.component", // normal column
 			query: `{resource.namespace="tempo-ops"}`,
 		},
 		{
@@ -333,11 +329,11 @@ func BenchmarkFetchTagValues(b *testing.B) {
 	ctx := context.TODO()
 	tenantID := "1"
 	// blockID := uuid.MustParse("3685ee3d-cbbf-4f36-bf28-93447a19dea6")
-	blockID := uuid.MustParse("0008e57d-069d-4510-a001-b9433b2da08c")
+	blockID := uuid.MustParse("00145f38-6058-4e57-b1ba-334db8edce23")
 
 	r, _, _, err := local.New(&local.Config{
 		// Path: path.Join("/Users/marty/src/tmp/"),
-		Path: path.Join("/Users/mapno/workspace/testblock"),
+		Path: path.Join("/Users/joe/testblock"),
 	})
 	require.NoError(b, err)
 
@@ -357,6 +353,12 @@ func BenchmarkFetchTagValues(b *testing.B) {
 			tag, err := traceql.ParseIdentifier(tc.tag)
 			require.NoError(b, err)
 
+			// FetchTagValues expects the tag to be in the conditions with OpNone otherwise it will
+			// fall back to the old tag search
+			req.Conditions = append(req.Conditions, traceql.Condition{
+				Attribute: tag,
+			})
+
 			autocompleteReq := traceql.AutocompleteRequest{
 				Conditions: req.Conditions,
 				TagName:    tag,
@@ -365,7 +367,6 @@ func BenchmarkFetchTagValues(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				err := block.FetchTagValues(ctx, autocompleteReq, traceql.MakeCollectTagValueFunc(distinctValues.Collect), opts)
-				// err := block.SearchTagValuesV2(ctx, tag, traceql.MakeCollectTagValueFunc(distinctValues.Collect), opts)
 				require.NoError(b, err)
 			}
 		})

--- a/tempodb/encoding/vparquet3/wal_block.go
+++ b/tempodb/encoding/vparquet3/wal_block.go
@@ -723,12 +723,10 @@ func (b *walBlock) FetchTagValues(ctx context.Context, req traceql.AutocompleteR
 			}
 
 			for _, oe := range res.OtherEntries {
-				if oe.Key == req.TagName.String() {
-					v := oe.Value.(traceql.Static)
-					if cb(v) {
-						iter.Close()
-						return nil // We have enough values
-					}
+				v := oe.Value.(traceql.Static)
+				if cb(v) {
+					iter.Close()
+					return nil // We have enough values
 				}
 			}
 		}

--- a/tempodb/encoding/vparquet4/block_autocomplete.go
+++ b/tempodb/encoding/vparquet4/block_autocomplete.go
@@ -51,11 +51,9 @@ func (b *backendBlock) FetchTagValues(ctx context.Context, req traceql.Autocompl
 			break
 		}
 		for _, oe := range res.OtherEntries {
-			if oe.Key == req.TagName.String() {
-				v := oe.Value.(traceql.Static)
-				if cb(v) {
-					return nil // We have enough values
-				}
+			v := oe.Value.(traceql.Static)
+			if cb(v) {
+				return nil // We have enough values
 			}
 		}
 	}
@@ -90,27 +88,24 @@ func createDistinctIterator(
 	rgs := rowGroupsFromFile(pf, opts)
 	makeIter := makeIterFunc(ctx, rgs, pf)
 
-	// Safeguard. Shouldn't be needed since we only use collect the tag we want.
-	keep := func(attr traceql.Attribute) bool { return tag == attr }
-
 	var currentIter parquetquery.Iterator
 
 	if len(spanConditions) > 0 {
-		currentIter, err = createDistinctSpanIterator(makeIter, keep, tag, currentIter, spanConditions, dc)
+		currentIter, err = createDistinctSpanIterator(makeIter, tag, currentIter, spanConditions, dc)
 		if err != nil {
 			return nil, errors.Wrap(err, "creating span iterator")
 		}
 	}
 
 	if len(resourceConditions) > 0 {
-		currentIter, err = createDistinctResourceIterator(makeIter, keep, tag, currentIter, resourceConditions, dc)
+		currentIter, err = createDistinctResourceIterator(makeIter, tag, currentIter, resourceConditions, dc)
 		if err != nil {
 			return nil, errors.Wrap(err, "creating resource iterator")
 		}
 	}
 
 	if len(traceConditions) > 0 {
-		currentIter, err = createDistinctTraceIterator(makeIter, keep, currentIter, traceConditions)
+		currentIter, err = createDistinctTraceIterator(makeIter, currentIter, traceConditions)
 		if err != nil {
 			return nil, errors.Wrap(err, "creating trace iterator")
 		}
@@ -123,7 +118,6 @@ func createDistinctIterator(
 // one span each.  Spans are returned that match any of the given conditions.
 func createDistinctSpanIterator(
 	makeIter makeIterFn,
-	keep keepFn,
 	tag traceql.Attribute,
 	primaryIter parquetquery.Iterator,
 	conditions []traceql.Condition,
@@ -139,7 +133,7 @@ func createDistinctSpanIterator(
 
 	// TODO: Potentially problematic when wanted attribute is also part of a condition
 	//     e.g. { span.foo =~ ".*" && span.foo = }
-	addSelectAs := func(attr traceql.Attribute, columnPath, selectAs string) {
+	addSelectAs := func(attr traceql.Attribute, columnPath string, selectAs string) {
 		if attr == tag {
 			columnSelectAs[columnPath] = selectAs
 		} else {
@@ -266,7 +260,7 @@ func createDistinctSpanIterator(
 		iters = append(iters, makeIter(columnPath, orIfNeeded(predicates), columnSelectAs[columnPath]))
 	}
 
-	attrIter, err := createDistinctAttributeIterator(makeIter, keep, tag, genericConditions, DefinitionLevelResourceSpansILSSpanAttrs,
+	attrIter, err := createDistinctAttributeIterator(makeIter, tag, genericConditions, DefinitionLevelResourceSpansILSSpanAttrs,
 		columnPathSpanAttrKey, columnPathSpanAttrString, columnPathSpanAttrInt, columnPathSpanAttrDouble, columnPathSpanAttrBool)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating span attribute iterator")
@@ -285,7 +279,7 @@ func createDistinctSpanIterator(
 		return attrIter, nil
 	}
 
-	spanCol := &distinctSpanCollector{keep: keep}
+	spanCol := newDistinctValueCollector(mapSpanAttr)
 
 	// Left join here means the span id/start/end iterators + 1 are required,
 	// and all other conditions are optional. Whatever matches is returned.
@@ -294,7 +288,6 @@ func createDistinctSpanIterator(
 
 func createDistinctAttributeIterator(
 	makeIter makeIterFn,
-	keep keepFn,
 	tag traceql.Attribute,
 	conditions []traceql.Condition,
 	definitionLevel int,
@@ -393,10 +386,7 @@ func createDistinctAttributeIterator(
 				definitionLevel,
 				[]parquetquery.Iterator{makeIter(keyPath, parquetquery.NewStringInPredicate(attrKeys), "key")},
 				valueIters,
-				&distinctAttrCollector{
-					scope: scopeFromDefinitionLevel(definitionLevel),
-					keep:  keep,
-				},
+				newDistinctAttrCollector(scopeFromDefinitionLevel(definitionLevel)),
 			)
 			if err != nil {
 				return nil, fmt.Errorf("creating left join iterator: %w", err)
@@ -425,7 +415,6 @@ func oneLevelUp(definitionLevel int) int {
 
 func createDistinctResourceIterator(
 	makeIter makeIterFn,
-	keep keepFn,
 	tag traceql.Attribute,
 	spanIterator parquetquery.Iterator,
 	conditions []traceql.Condition,
@@ -443,7 +432,7 @@ func createDistinctResourceIterator(
 		columnPredicates[columnPath] = append(columnPredicates[columnPath], p)
 	}
 
-	addSelectAs := func(attr traceql.Attribute, columnPath, selectAs string) {
+	addSelectAs := func(attr traceql.Attribute, columnPath string, selectAs string) {
 		if attr == tag {
 			columnSelectAs[columnPath] = selectAs
 		} else {
@@ -504,7 +493,7 @@ func createDistinctResourceIterator(
 		iters = append(iters, makeIter(columnPath, orIfNeeded(predicates), columnSelectAs[columnPath]))
 	}
 
-	attrIter, err := createDistinctAttributeIterator(makeIter, keep, tag, genericConditions, DefinitionLevelResourceAttrs,
+	attrIter, err := createDistinctAttributeIterator(makeIter, tag, genericConditions, DefinitionLevelResourceAttrs,
 		columnPathResourceAttrKey, columnPathResourceAttrString, columnPathResourceAttrInt, columnPathResourceAttrDouble, columnPathResourceAttrBool)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating span attribute iterator")
@@ -513,7 +502,7 @@ func createDistinctResourceIterator(
 		iters = append(iters, attrIter)
 	}
 
-	batchCol := &distinctBatchCollector{keep: keep}
+	batchCol := newDistinctValueCollector(mapResourceAttr)
 
 	// Put span iterator last, so it is only read when
 	// the resource conditions are met.
@@ -526,7 +515,6 @@ func createDistinctResourceIterator(
 
 func createDistinctTraceIterator(
 	makeIter makeIterFn,
-	keep keepFn,
 	resourceIter parquetquery.Iterator,
 	conds []traceql.Condition,
 ) (parquetquery.Iterator, error) {
@@ -576,18 +564,22 @@ func createDistinctTraceIterator(
 	// Final trace iterator
 	// Join iterator means it requires matching resources to have been found
 	// TraceCollor adds trace-level data to the spansets
-	return parquetquery.NewJoinIterator(DefinitionLevelTrace, traceIters, &distinctTraceCollector{
-		keep: keep,
-	}), nil
+	return parquetquery.NewJoinIterator(DefinitionLevelTrace, traceIters, newDistinctValueCollector(mapTraceAttr)), nil
 }
-
-type keepFn func(attr traceql.Attribute) bool
 
 var _ parquetquery.GroupPredicate = (*distinctAttrCollector)(nil)
 
 type distinctAttrCollector struct {
 	scope traceql.AttributeScope
-	keep  keepFn
+
+	sentVals map[traceql.Static]struct{}
+}
+
+func newDistinctAttrCollector(scope traceql.AttributeScope) *distinctAttrCollector {
+	return &distinctAttrCollector{
+		scope:    scope,
+		sentVals: make(map[traceql.Static]struct{}),
+	}
 }
 
 func (d *distinctAttrCollector) String() string {
@@ -595,7 +587,6 @@ func (d *distinctAttrCollector) String() string {
 }
 
 func (d *distinctAttrCollector) KeepGroup(result *parquetquery.IteratorResult) bool {
-	var key string
 	var val traceql.Static
 
 	for _, e := range result.Entries {
@@ -606,8 +597,6 @@ func (d *distinctAttrCollector) KeepGroup(result *parquetquery.IteratorResult) b
 		}
 
 		switch e.Key {
-		case "key":
-			key = e.Value.String()
 		case "string":
 			val = traceql.NewStaticString(e.Value.String())
 		case "int":
@@ -619,9 +608,12 @@ func (d *distinctAttrCollector) KeepGroup(result *parquetquery.IteratorResult) b
 		}
 	}
 
-	attr := traceql.NewScopedAttribute(d.scope, false, key)
-	if d.keep(attr) {
-		result.AppendOtherValue(attr.String(), val)
+	var empty traceql.Static
+	if val != empty {
+		if _, ok := d.sentVals[val]; !ok {
+			result.AppendOtherValue("", val)
+			d.sentVals[val] = struct{}{}
+		}
 	}
 
 	result.Entries = result.Entries[:0]
@@ -634,25 +626,39 @@ type entry struct {
 	Value parquet.Value
 }
 
-var _ parquetquery.GroupPredicate = (*distinctSpanCollector)(nil)
+var _ parquetquery.GroupPredicate = (*distinctValueCollector)(nil)
 
-type distinctSpanCollector struct {
-	keep keepFn
+type distinctValueCollector struct {
+	mapToStatic func(entry) traceql.Static
+	sentVals    map[traceql.Static]struct{}
 }
 
-func (d distinctSpanCollector) String() string { return "distinctSpanCollector" }
+func newDistinctValueCollector(mapToStatic func(entry) traceql.Static) *distinctValueCollector {
+	return &distinctValueCollector{
+		mapToStatic: mapToStatic,
+		sentVals:    make(map[traceql.Static]struct{}),
+	}
+}
 
-func (d distinctSpanCollector) KeepGroup(result *parquetquery.IteratorResult) bool {
+func (d distinctValueCollector) String() string { return "distinctValueCollector" }
+
+func (d distinctValueCollector) KeepGroup(result *parquetquery.IteratorResult) bool {
 	for _, e := range result.Entries {
-		if attr, static := mapSpanAttr(e); d.keep(attr) {
-			result.AppendOtherValue(attr.String(), static)
+		if e.Value.IsNull() {
+			continue
+		}
+		static := d.mapToStatic(e)
+
+		if _, ok := d.sentVals[static]; !ok {
+			result.AppendOtherValue("", static)
+			d.sentVals[static] = struct{}{}
 		}
 	}
 	result.Entries = result.Entries[:0]
 	return true
 }
 
-func mapSpanAttr(e entry) (traceql.Attribute, traceql.Static) {
+func mapSpanAttr(e entry) traceql.Static {
 	switch e.Key {
 	case columnPathSpanID,
 		columnPathSpanParentID,
@@ -660,9 +666,9 @@ func mapSpanAttr(e entry) (traceql.Attribute, traceql.Static) {
 		columnPathSpanNestedSetRight,
 		columnPathSpanStartTime:
 	case columnPathSpanDuration:
-		return traceql.IntrinsicDurationAttribute, traceql.NewStaticDuration(time.Duration(e.Value.Int64()))
+		return traceql.NewStaticDuration(time.Duration(e.Value.Int64()))
 	case columnPathSpanName:
-		return traceql.IntrinsicNameAttribute, traceql.NewStaticString(e.Value.String())
+		return traceql.NewStaticString(e.Value.String())
 	case columnPathSpanStatusCode:
 		// Map OTLP status code back to TraceQL enum.
 		// For other values, use the raw integer.
@@ -677,9 +683,9 @@ func mapSpanAttr(e entry) (traceql.Attribute, traceql.Static) {
 		default:
 			status = traceql.Status(e.Value.Uint64())
 		}
-		return traceql.IntrinsicStatusAttribute, traceql.NewStaticStatus(status)
+		return traceql.NewStaticStatus(status)
 	case columnPathSpanStatusMessage:
-		return traceql.IntrinsicStatusMessageAttribute, traceql.NewStaticString(e.Value.String())
+		return traceql.NewStaticString(e.Value.String())
 	case columnPathSpanKind:
 		var kind traceql.Kind
 		switch e.Value.Uint64() {
@@ -698,90 +704,49 @@ func mapSpanAttr(e entry) (traceql.Attribute, traceql.Static) {
 		default:
 			kind = traceql.Kind(e.Value.Uint64())
 		}
-		return traceql.IntrinsicKindAttribute, traceql.NewStaticKind(kind)
+		return traceql.NewStaticKind(kind)
 	default:
 		// This exists for span-level dedicated columns like http.status_code
 		switch e.Value.Kind() {
 		case parquet.Boolean:
-			return newSpanAttr(e.Key), traceql.NewStaticBool(e.Value.Boolean())
+			return traceql.NewStaticBool(e.Value.Boolean())
 		case parquet.Int32, parquet.Int64:
-			return newSpanAttr(e.Key), traceql.NewStaticInt(int(e.Value.Int64()))
+			return traceql.NewStaticInt(int(e.Value.Int64()))
 		case parquet.Float:
-			return newSpanAttr(e.Key), traceql.NewStaticFloat(e.Value.Double())
+			return traceql.NewStaticFloat(e.Value.Double())
 		case parquet.ByteArray, parquet.FixedLenByteArray:
-			return newSpanAttr(e.Key), traceql.NewStaticString(e.Value.String())
+			return traceql.NewStaticString(e.Value.String())
 		}
 	}
-	return traceql.Attribute{}, traceql.Static{}
+	return traceql.Static{}
 }
 
-var _ parquetquery.GroupPredicate = (*distinctBatchCollector)(nil)
-
-type distinctBatchCollector struct {
-	keep keepFn
-}
-
-func (d *distinctBatchCollector) String() string {
-	return "distinctBatchCollector"
-}
-
-func (d *distinctBatchCollector) KeepGroup(result *parquetquery.IteratorResult) bool {
-	// Gather Attributes from dedicated resource-level columns
-	for _, e := range result.Entries {
-		if attr, static := mapResourceAttr(e); d.keep(attr) {
-			result.AppendOtherValue(attr.String(), static)
-		}
-	}
-	result.Entries = result.Entries[:0]
-	return true
-}
-
-func mapResourceAttr(e entry) (traceql.Attribute, traceql.Static) {
+func mapResourceAttr(e entry) traceql.Static {
 	switch e.Value.Kind() {
 	case parquet.Boolean:
-		return newResAttr(e.Key), traceql.NewStaticBool(e.Value.Boolean())
+		return traceql.NewStaticBool(e.Value.Boolean())
 	case parquet.Int32, parquet.Int64:
-		return newResAttr(e.Key), traceql.NewStaticInt(int(e.Value.Int64()))
+		return traceql.NewStaticInt(int(e.Value.Int64()))
 	case parquet.Float:
-		return newResAttr(e.Key), traceql.NewStaticFloat(e.Value.Double())
+		return traceql.NewStaticFloat(e.Value.Double())
 	case parquet.ByteArray, parquet.FixedLenByteArray:
-		return newResAttr(e.Key), traceql.NewStaticString(e.Value.String())
+		return traceql.NewStaticString(e.Value.String())
 	default:
-		return traceql.Attribute{}, traceql.Static{}
+		return traceql.Static{}
 	}
 }
 
-var _ parquetquery.GroupPredicate = (*distinctTraceCollector)(nil)
-
-type distinctTraceCollector struct {
-	keep keepFn
-}
-
-func (d *distinctTraceCollector) String() string {
-	return "distinctTraceCollector"
-}
-
-func (d *distinctTraceCollector) KeepGroup(result *parquetquery.IteratorResult) bool {
-	for _, e := range result.Entries {
-		if attr, static := mapTraceAttr(e); d.keep(attr) {
-			result.AppendOtherValue(attr.String(), static)
-		}
-	}
-	result.Entries = result.Entries[:0]
-	return true
-}
-
-func mapTraceAttr(e entry) (traceql.Attribute, traceql.Static) {
+func mapTraceAttr(e entry) traceql.Static {
 	switch e.Key {
 	case columnPathTraceID, columnPathEndTimeUnixNano, columnPathStartTimeUnixNano: // No TraceQL intrinsics for these
 	case columnPathDurationNanos:
-		return traceql.IntrinsicTraceDurationAttribute, traceql.NewStaticDuration(time.Duration(e.Value.Int64()))
+		return traceql.NewStaticDuration(time.Duration(e.Value.Int64()))
 	case columnPathRootSpanName:
-		return traceql.IntrinsicTraceRootSpanAttribute, traceql.NewStaticString(e.Value.String())
+		return traceql.NewStaticString(e.Value.String())
 	case columnPathRootServiceName:
-		return traceql.IntrinsicTraceRootServiceAttribute, traceql.NewStaticString(e.Value.String())
+		return traceql.NewStaticString(e.Value.String())
 	}
-	return traceql.Attribute{}, traceql.Static{}
+	return traceql.Static{}
 }
 
 func scopeFromDefinitionLevel(lvl int) traceql.AttributeScope {

--- a/tempodb/encoding/vparquet4/block_autocomplete_test.go
+++ b/tempodb/encoding/vparquet4/block_autocomplete_test.go
@@ -309,15 +309,11 @@ func BenchmarkFetchTagValues(b *testing.B) {
 		query string
 	}{
 		{
-			tag:   "span.http.url",
-			query: "{}",
+			tag:   "span.http.url", // well known column
+			query: `{resource.namespace="tempo-ops"}`,
 		},
 		{
-			tag:   "resource.namespace",
-			query: `{}`,
-		},
-		{
-			tag:   "span.http.url",
+			tag:   "span.component", // normal column
 			query: `{resource.namespace="tempo-ops"}`,
 		},
 		{
@@ -333,11 +329,11 @@ func BenchmarkFetchTagValues(b *testing.B) {
 	ctx := context.TODO()
 	tenantID := "1"
 	// blockID := uuid.MustParse("3685ee3d-cbbf-4f36-bf28-93447a19dea6")
-	blockID := uuid.MustParse("0008e57d-069d-4510-a001-b9433b2da08c")
+	blockID := uuid.MustParse("00145f38-6058-4e57-b1ba-334db8edce23")
 
 	r, _, _, err := local.New(&local.Config{
 		// Path: path.Join("/Users/marty/src/tmp/"),
-		Path: path.Join("/Users/mapno/workspace/testblock"),
+		Path: path.Join("/Users/joe/testblock"),
 	})
 	require.NoError(b, err)
 
@@ -357,6 +353,12 @@ func BenchmarkFetchTagValues(b *testing.B) {
 			tag, err := traceql.ParseIdentifier(tc.tag)
 			require.NoError(b, err)
 
+			// FetchTagValues expects the tag to be in the conditions with OpNone otherwise it will
+			// fall back to the old tag search
+			req.Conditions = append(req.Conditions, traceql.Condition{
+				Attribute: tag,
+			})
+
 			autocompleteReq := traceql.AutocompleteRequest{
 				Conditions: req.Conditions,
 				TagName:    tag,
@@ -365,7 +367,6 @@ func BenchmarkFetchTagValues(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				err := block.FetchTagValues(ctx, autocompleteReq, traceql.MakeCollectTagValueFunc(distinctValues.Collect), opts)
-				// err := block.SearchTagValuesV2(ctx, tag, traceql.MakeCollectTagValueFunc(distinctValues.Collect), opts)
 				require.NoError(b, err)
 			}
 		})

--- a/tempodb/encoding/vparquet4/wal_block.go
+++ b/tempodb/encoding/vparquet4/wal_block.go
@@ -723,12 +723,10 @@ func (b *walBlock) FetchTagValues(ctx context.Context, req traceql.AutocompleteR
 			}
 
 			for _, oe := range res.OtherEntries {
-				if oe.Key == req.TagName.String() {
-					v := oe.Value.(traceql.Static)
-					if cb(v) {
-						iter.Close()
-						return nil // We have enough values
-					}
+				v := oe.Value.(traceql.Static)
+				if cb(v) {
+					iter.Close()
+					return nil // We have enough values
 				}
 			}
 		}


### PR DESCRIPTION
**What this PR does**:
Improves the performance of SearchTagsV2 and fixes the benchmark to actually test SearchTagsV2. 

**Changes:**
- Don't unnecessarily pass null values up through the iterator OtherEntries
- Stop repeatedly building attribute name strings to double check the iterators
- Don't send the same value twice (Skips the cost of repeated allocations to and from `interface{}`)
- Consolidate the 3 samey distinct value collectors into one

**Benches:**
```
goos: darwin
goarch: arm64
pkg: github.com/grafana/tempo/tempodb/encoding/vparquet3
                                                                                                           │ before.txt  │           dontsend2x.txt            │
                                                                                                           │   sec/op    │   sec/op     vs base                │
FetchTagValues/tag:_span.http.url,_query:_{resource.namespace="tempo-ops"}-11                                252.7m ± 1%   251.9m ± 1%        ~ (p=0.218 n=10)
FetchTagValues/tag:_span.component,_query:_{resource.namespace="tempo-ops"}-11                               233.6m ± 1%   232.4m ± 1%   -0.51% (p=0.029 n=10)
FetchTagValues/tag:_span.http.url,_query:_{resource.namespace="tempo-ops"_&&_span.http.status_code=200}-11   384.8m ± 1%   388.7m ± 1%   +1.02% (p=0.000 n=10)
FetchTagValues/tag:_resource.namespace,_query:_{span.http.status_code=200}-11                                 2.548 ± 1%    2.141 ± 0%  -15.97% (p=0.000 n=10)
geomean                                                                                                      490.5m        469.8m        -4.21%

                                                                                                           │  before.txt   │            dontsend2x.txt             │
                                                                                                           │     B/op      │     B/op       vs base                │
FetchTagValues/tag:_span.http.url,_query:_{resource.namespace="tempo-ops"}-11                                 99.49Mi ± 2%   102.23Mi ± 2%   +2.75% (p=0.035 n=10)
FetchTagValues/tag:_span.component,_query:_{resource.namespace="tempo-ops"}-11                               11.013Mi ± 4%    9.212Mi ± 5%  -16.35% (p=0.000 n=10)
FetchTagValues/tag:_span.http.url,_query:_{resource.namespace="tempo-ops"_&&_span.http.status_code=200}-11    105.9Mi ± 4%    102.4Mi ± 3%   -3.31% (p=0.004 n=10)
FetchTagValues/tag:_resource.namespace,_query:_{span.http.status_code=200}-11                                417.81Mi ± 0%    48.90Mi ± 1%  -88.30% (p=0.000 n=10)
geomean                                                                                                       83.44Mi         46.60Mi       -44.15%

                                                                                                           │  before.txt  │           dontsend2x.txt            │
                                                                                                           │  allocs/op   │  allocs/op   vs base                │
FetchTagValues/tag:_span.http.url,_query:_{resource.namespace="tempo-ops"}-11                                 194.9k ± 0%   142.9k ± 0%  -26.66% (p=0.000 n=10)
FetchTagValues/tag:_span.component,_query:_{resource.namespace="tempo-ops"}-11                                204.1k ± 0%   139.6k ± 0%  -31.59% (p=0.000 n=10)
FetchTagValues/tag:_span.http.url,_query:_{resource.namespace="tempo-ops"_&&_span.http.status_code=200}-11    220.7k ± 0%   161.6k ± 0%  -26.75% (p=0.000 n=10)
FetchTagValues/tag:_resource.namespace,_query:_{span.http.status_code=200}-11                                14.220M ± 0%   2.474M ± 0%  -82.60% (p=0.000 n=10)
geomean                                                                                                       594.4k        298.9k       -49.71%
```

**Other Thoughts:**

For our worst case scenario in the benchmarks there is a massive, but harder to realize perf improvement. 

```
tag: resource.namespace
conditions: span.http.status_code = 200
```

Currently the span level iterator will find all matching spans where http.status_code = 200 and pass them up to the resource level iterator which will then add resource.namespace to the returned values. If we could short circuit the iterator as soon as a single match were found it would be a massive improvement.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`