### PR TITLE
Add tempo-cli sub command to convert from vParquet3 to vParquet4

### DIFF
--- a/cmd/tempo-cli/cmd-convert-parquet-3to4.go
+++ b/cmd/tempo-cli/cmd-convert-parquet-3to4.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/parquet-go/parquet-go"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/grafana/tempo/pkg/traceql"
+	"github.com/grafana/tempo/tempodb/backend"
+	"github.com/grafana/tempo/tempodb/backend/local"
+	"github.com/grafana/tempo/tempodb/encoding/common"
+	"github.com/grafana/tempo/tempodb/encoding/vparquet3"
+	"github.com/grafana/tempo/tempodb/encoding/vparquet4"
+)
+
+type convertParquet3to4 struct {
+	In               string   `arg:"" help:"The input parquet block to read from."`
+	Out              string   `arg:"" help:"The output folder to write block to." default:"./out" optional:""`
+	DedicatedColumns []string `arg:"" help:"List of dedicated columns to convert. Overwrites existing dedicated columns" optional:""`
+}
+
+func (cmd *convertParquet3to4) Run() error {
+	cmd.In = getPathToBlockDir(cmd.In)
+
+	// open the input parquet file
+	in, pf, err := openParquetFile(cmd.In)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	// open the input metadata file
+	meta, err := readBlockMeta(cmd.In)
+	if err != nil {
+		return err
+	}
+
+	// create output block
+	outR, outW, _, err := local.New(&local.Config{
+		Path: cmd.Out,
+	})
+	if err != nil {
+		return err
+	}
+
+	// calculate dedicated columns
+	var dedicatedCols backend.DedicatedColumns
+
+	if len(cmd.DedicatedColumns) > 0 {
+		dedicatedCols = make(backend.DedicatedColumns, 0, len(cmd.DedicatedColumns))
+
+		for _, col := range cmd.DedicatedColumns {
+			att, err := traceql.ParseIdentifier(col)
+			if err != nil {
+				return err
+			}
+
+			scope := backend.DedicatedColumnScopeSpan
+			if att.Scope == traceql.AttributeScopeResource {
+				scope = backend.DedicatedColumnScopeResource
+			}
+
+			fmt.Printf("add dedicated column scope=%s name=%s\n", scope, att.Name)
+
+			dedicatedCols = append(dedicatedCols, backend.DedicatedColumn{
+				Scope: scope,
+				Name:  att.Name,
+				Type:  backend.DedicatedColumnTypeString,
+			})
+		}
+	} else {
+		dedicatedCols = meta.DedicatedColumns
+	}
+
+	// copy block
+	blockCfg := &common.BlockConfig{
+		BloomFP:             0.99,
+		BloomShardSizeBytes: 1024 * 1024,
+		Version:             vparquet4.VersionString,
+		RowGroupSizeBytes:   100 * 1024 * 1024,
+	}
+
+	newMeta := *meta
+	newMeta.Version = vparquet4.VersionString
+	newMeta.DedicatedColumns = dedicatedCols
+
+	// create iterator over in file
+	iter := &parquetIterator3{
+		r: parquet.NewGenericReader[*vparquet3.Trace](pf),
+		m: meta,
+	}
+
+	fmt.Printf("Creating vParquet4 block in %s\n", filepath.Join(cmd.Out, meta.TenantID, newMeta.BlockID.String()))
+	fmt.Printf("Converting rows 0 to %d\n", pf.NumRows())
+	outMeta, err := vparquet4.CreateBlock(context.Background(), blockCfg, &newMeta, iter, backend.NewReader(outR), backend.NewWriter(outW))
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Successfully created block with size=%d and footerSize=%d\n", outMeta.Size, outMeta.FooterSize)
+	return nil
+}
+
+func getPathToBlockDir(path string) string {
+	if filepath.Base(path) == "data.parquet" {
+		return filepath.Dir(path)
+	}
+	return path
+}
+
+func openParquetFile(blockPath string) (*os.File, *parquet.File, error) {
+	inFile := filepath.Join(blockPath, "data.parquet")
+	in, err := os.Open(inFile)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	inStat, err := in.Stat()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pf, err := parquet.OpenFile(in, inStat.Size())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return in, pf, nil
+}
+
+func readBlockMeta(blockPath string) (*backend.BlockMeta, error) {
+	metaFile := filepath.Join(blockPath, "meta.json")
+	inMeta, err := os.Open(metaFile)
+	if err != nil {
+		return nil, err
+	}
+	defer inMeta.Close()
+
+	var meta backend.BlockMeta
+	err = json.NewDecoder(inMeta).Decode(&meta)
+	if err != nil {
+		return nil, err
+	}
+
+	return &meta, nil
+}
+
+type parquetIterator3 struct {
+	r *parquet.GenericReader[*vparquet3.Trace]
+	m *backend.BlockMeta
+	i int
+}
+
+func (i *parquetIterator3) Next(_ context.Context) (common.ID, *tempopb.Trace, error) {
+	traces := []*vparquet3.Trace{{}}
+
+	i.i++
+	if i.i%1000 == 0 {
+		fmt.Println(i.i)
+	}
+
+	_, err := i.r.Read(traces)
+	if errors.Is(err, io.EOF) {
+		return nil, nil, io.EOF
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pqTrace := traces[0]
+	pbTrace := vparquet3.ParquetTraceToTempopbTrace(i.m, pqTrace)
+	return pqTrace.TraceID, pbTrace, nil
+}
+
+func (i *parquetIterator3) Close() {
+	_ = i.r.Close()
+}

--- a/cmd/tempo-cli/main.go
+++ b/cmd/tempo-cli/main.go
@@ -82,6 +82,7 @@ var cli struct {
 		Convert     convertParquet     `cmd:"" help:"convert from an existing file to tempodb parquet schema"`
 		Convert1to2 convertParquet1to2 `cmd:"" help:"convert an existing vParquet file to vParquet2 schema"`
 		Convert2to3 convertParquet2to3 `cmd:"" help:"convert an existing vParquet2 file to vParquet3 block"`
+		Convert3to4 convertParquet3to4 `cmd:"" help:"convert an existing vParquet3 file to vParquet4 block"`
 	} `cmd:""`
 
 	Migrate struct {

--- a/tempodb/encoding/vparquet3/block_findtracebyid.go
+++ b/tempodb/encoding/vparquet3/block_findtracebyid.go
@@ -271,7 +271,7 @@ func findTraceByID(ctx context.Context, traceID common.ID, maxTraceSizeBytes int
 	}
 
 	// convert to proto trace and return
-	return parquetTraceToTempopbTrace(meta, tr), nil
+	return ParquetTraceToTempopbTrace(meta, tr), nil
 }
 
 // binarySearch that finds exact matching entry. Returns non-zero index when found, or -1 when not found

--- a/tempodb/encoding/vparquet3/block_findtracebyid_test.go
+++ b/tempodb/encoding/vparquet3/block_findtracebyid_test.go
@@ -95,7 +95,7 @@ func TestBackendBlockFindTraceByID(t *testing.T) {
 
 	// Now find and verify all test traces
 	for _, tr := range traces {
-		wantProto := parquetTraceToTempopbTrace(meta, tr)
+		wantProto := ParquetTraceToTempopbTrace(meta, tr)
 
 		gotProto, err := b.FindTraceByID(ctx, tr.TraceID, common.DefaultSearchOptions())
 		require.NoError(t, err)

--- a/tempodb/encoding/vparquet3/schema.go
+++ b/tempodb/encoding/vparquet3/schema.go
@@ -571,7 +571,7 @@ func parquetToProtoEvents(parquetEvents []Event) []*v1_trace.Span_Event {
 	return protoEvents
 }
 
-func parquetTraceToTempopbTrace(meta *backend.BlockMeta, parquetTrace *Trace) *tempopb.Trace {
+func ParquetTraceToTempopbTrace(meta *backend.BlockMeta, parquetTrace *Trace) *tempopb.Trace {
 	protoTrace := &tempopb.Trace{}
 	protoTrace.Batches = make([]*v1_trace.ResourceSpans, 0, len(parquetTrace.ResourceSpans))
 

--- a/tempodb/encoding/vparquet3/schema_test.go
+++ b/tempodb/encoding/vparquet3/schema_test.go
@@ -30,11 +30,11 @@ func TestProtoParquetRoundTrip(t *testing.T) {
 	}
 	traceIDA := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}
 
-	expectedTrace := parquetTraceToTempopbTrace(&meta, fullyPopulatedTestTrace(traceIDA))
+	expectedTrace := ParquetTraceToTempopbTrace(&meta, fullyPopulatedTestTrace(traceIDA))
 
 	parquetTrace, connected := traceToParquet(&meta, traceIDA, expectedTrace, nil)
 	require.True(t, connected)
-	actualTrace := parquetTraceToTempopbTrace(&meta, parquetTrace)
+	actualTrace := ParquetTraceToTempopbTrace(&meta, parquetTrace)
 	assert.Equal(t, expectedTrace, actualTrace)
 }
 
@@ -57,7 +57,7 @@ func TestProtoParquetRando(t *testing.T) {
 		expectedTrace := test.AddDedicatedAttributes(test.MakeTrace(batches, id))
 
 		parqTr, _ := traceToParquet(&backend.BlockMeta{}, id, expectedTrace, trp)
-		actualTrace := parquetTraceToTempopbTrace(&backend.BlockMeta{}, parqTr)
+		actualTrace := ParquetTraceToTempopbTrace(&backend.BlockMeta{}, parqTr)
 		require.Equal(t, expectedTrace, actualTrace)
 	}
 }
@@ -68,7 +68,7 @@ func TestFieldsAreCleared(t *testing.T) {
 	}
 
 	traceID := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}
-	complexTrace := parquetTraceToTempopbTrace(&meta, fullyPopulatedTestTrace(traceID))
+	complexTrace := ParquetTraceToTempopbTrace(&meta, fullyPopulatedTestTrace(traceID))
 	simpleTrace := &tempopb.Trace{
 		Batches: []*v1_trace.ResourceSpans{
 			{
@@ -115,7 +115,7 @@ func TestFieldsAreCleared(t *testing.T) {
 	_, _ = traceToParquet(&meta, traceID, complexTrace, tr)
 
 	parqTr, _ := traceToParquet(&meta, traceID, simpleTrace, tr)
-	actualTrace := parquetTraceToTempopbTrace(&meta, parqTr)
+	actualTrace := ParquetTraceToTempopbTrace(&meta, parqTr)
 	require.Equal(t, simpleTrace, actualTrace)
 }
 

--- a/tempodb/encoding/vparquet3/wal_block.go
+++ b/tempodb/encoding/vparquet3/wal_block.go
@@ -535,7 +535,7 @@ func (b *walBlock) FindTraceByID(ctx context.Context, id common.ID, opts common.
 				return nil, fmt.Errorf("error reading row from backend: %w", err)
 			}
 
-			trp := parquetTraceToTempopbTrace(b.meta, tr)
+			trp := ParquetTraceToTempopbTrace(b.meta, tr)
 
 			trs = append(trs, trp)
 		}
@@ -870,7 +870,7 @@ func (i *commonIterator) Next(ctx context.Context) (common.ID, *tempopb.Trace, e
 		return nil, nil, err
 	}
 
-	tr := parquetTraceToTempopbTrace(i.meta, t)
+	tr := ParquetTraceToTempopbTrace(i.meta, t)
 	return id, tr, nil
 }
 


### PR DESCRIPTION
**What this PR does**:
Add sub command `tempo-cli parquet convert-3-to-4` that converts vParquet3 blocks to vParquet4

**Which issue(s) this PR fixes**:
Contribute to grafana/tempo-squad#299

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`