### PR TITLE
Update deb and rpm packages to create and assign permissions for /var/tempo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [CHANGE] Return a less confusing error message to the client when refusing spans due to ingestion rates. [#3485](https://github.com/grafana/tempo/pull/3485) (@ie-pham)
 * [CHANGE] Clean Metrics Generator's Prometheus wal before creating instance [#3548](https://github.com/grafana/tempo/pull/3548) (@ie-pham)
 * [CHANGE] Update docker examples for permissions, deprecations, and clean-up [#3603](https://github.com/grafana/tempo/pull/3603) (@zalegrala)
+* [CHANGE] Update debian and rpm packages to grant required permissions to default storage path after installation [#3657](https://github.com/grafana/tempo/pull/3657) (@mdisibio)
 * [FEATURE] Add messaging-system latency histogram to service-graph [#3453](https://github.com/grafana/tempo/pull/3453) (@adirmatzkin)
 * [CHANGE] Delete any remaining objects for empty tenants after a configurable duration, requires config enable [#3611](https://github.com/grafana/tempo/pull/3611) (@zalegrala)
 * [ENHANCEMENT] Add string interning to TraceQL queries [#3411](https://github.com/grafana/tempo/pull/3411) (@mapno)

--- a/tools/packaging/tempo-postinstall.sh
+++ b/tools/packaging/tempo-postinstall.sh
@@ -17,7 +17,7 @@ cleanInstall() {
     fi
 
     # Create and assign permissions for default storage
-    mkdir /var/tempo
+    mkdir -m 0700 /var/tempo
     chown tempo /var/tempo
 
     # rhel/centos7 cannot use ExecStartPre=+ to specify the pre start should be run as root

--- a/tools/packaging/tempo-postinstall.sh
+++ b/tools/packaging/tempo-postinstall.sh
@@ -16,6 +16,10 @@ cleanInstall() {
         adduser --system --shell /bin/false "tempo"
     fi
 
+    # Create and assign permissions for default storage
+    mkdir /var/tempo
+    chown tempo /var/tempo
+
     # rhel/centos7 cannot use ExecStartPre=+ to specify the pre start should be run as root
     # even if you want your service to run as non root.
     if [ "${systemd_version}" -lt 231 ]; then

--- a/tools/packaging/verify-deb-install.sh
+++ b/tools/packaging/verify-deb-install.sh
@@ -22,6 +22,11 @@ cat <<EOF | docker exec --interactive "${image}" sh
     systemctl is-active tempo
     tail /var/log/dpkg.log
     journalctl -b
+    journalctl
+    journalctl -u tempo.service
+
+    curl -vvv http://localhost:3200/status
+    curl -vvv http://localhost:3200/ready
 
     # Wait for tempo to be ready. The script is cat-ed because it is passed to docker exec
     apt update && apt install -y curl

--- a/tools/packaging/verify-deb-install.sh
+++ b/tools/packaging/verify-deb-install.sh
@@ -18,7 +18,6 @@ cat <<EOF | docker exec --interactive "${image}" sh
     # Install tempo and check it's running
     dpkg -i ${dir}/dist/tempo*_amd64.deb
     [ "\$(systemctl is-active tempo)" = "active" ] || (echo "tempo is inactive" && exit 1)
-    
     # Wait for tempo to be ready. The script is cat-ed because it is passed to docker exec
     apt update && apt install -y curl
     $(cat ${dir}/tools/packaging/wait-for-ready.sh)

--- a/tools/packaging/verify-deb-install.sh
+++ b/tools/packaging/verify-deb-install.sh
@@ -19,16 +19,21 @@ cat <<EOF | docker exec --interactive "${image}" sh
     dpkg -i ${dir}/dist/tempo*_amd64.deb
     [ "\$(systemctl is-active tempo)" = "active" ] || (echo "tempo is inactive" && exit 1)
 
+    mkdir /var/tempo
+    chown tempo /var/tempo
+
+    systemctl restart tempo
+
     systemctl is-active tempo
     tail /var/log/dpkg.log
-    journalctl -b
     journalctl
-    journalctl -u tempo.service
+    
+    # Wait for tempo to be ready. The script is cat-ed because it is passed to docker exec
+    apt update && apt install -y curl
 
     curl -vvv http://localhost:3200/status
     curl -vvv http://localhost:3200/ready
 
-    # Wait for tempo to be ready. The script is cat-ed because it is passed to docker exec
-    apt update && apt install -y curl
+
     $(cat ${dir}/tools/packaging/wait-for-ready.sh)
 EOF

--- a/tools/packaging/verify-deb-install.sh
+++ b/tools/packaging/verify-deb-install.sh
@@ -18,22 +18,8 @@ cat <<EOF | docker exec --interactive "${image}" sh
     # Install tempo and check it's running
     dpkg -i ${dir}/dist/tempo*_amd64.deb
     [ "\$(systemctl is-active tempo)" = "active" ] || (echo "tempo is inactive" && exit 1)
-
-    mkdir /var/tempo
-    chown tempo /var/tempo
-
-    systemctl restart tempo
-
-    systemctl is-active tempo
-    tail /var/log/dpkg.log
-    journalctl
     
     # Wait for tempo to be ready. The script is cat-ed because it is passed to docker exec
     apt update && apt install -y curl
-
-    curl -vvv http://localhost:3200/status
-    curl -vvv http://localhost:3200/ready
-
-
     $(cat ${dir}/tools/packaging/wait-for-ready.sh)
 EOF

--- a/tools/packaging/verify-deb-install.sh
+++ b/tools/packaging/verify-deb-install.sh
@@ -19,6 +19,10 @@ cat <<EOF | docker exec --interactive "${image}" sh
     dpkg -i ${dir}/dist/tempo*_amd64.deb
     [ "\$(systemctl is-active tempo)" = "active" ] || (echo "tempo is inactive" && exit 1)
 
+    systemctl is-active tempo
+    tail /var/log/dpkg.log
+    journalctl -b
+
     # Wait for tempo to be ready. The script is cat-ed because it is passed to docker exec
     apt update && apt install -y curl
     $(cat ${dir}/tools/packaging/wait-for-ready.sh)

--- a/tools/packaging/verify-deb-install.sh
+++ b/tools/packaging/verify-deb-install.sh
@@ -18,6 +18,7 @@ cat <<EOF | docker exec --interactive "${image}" sh
     # Install tempo and check it's running
     dpkg -i ${dir}/dist/tempo*_amd64.deb
     [ "\$(systemctl is-active tempo)" = "active" ] || (echo "tempo is inactive" && exit 1)
+
     # Wait for tempo to be ready. The script is cat-ed because it is passed to docker exec
     apt update && apt install -y curl
     $(cat ${dir}/tools/packaging/wait-for-ready.sh)

--- a/tools/packaging/verify-rpm-install.sh
+++ b/tools/packaging/verify-rpm-install.sh
@@ -18,7 +18,7 @@ cat <<EOF | docker exec --interactive "${image}" sh
     # Import the Grafana GPG key
     rpm --import https://packages.grafana.com/gpg.key
 
-    # Install loki and check it's running
+    # Install tempo and check it's running
     rpm -i ${dir}/dist/tempo*_amd64.rpm
     [ "\$(systemctl is-active tempo)" = "active" ] || (echo "tempo is inactive" && exit 1)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
The motivation for this PR is to fix the deb and rpm Drone test process, but we decided it's also a good improvement that should be shipped in the packages.

The deb and rpm packages install Tempo as a systemd service, under a newly-created user `tempo`.  However the services can't start out of the box because the `tempo` user lacks permissions to create and write to `/var/tempo` which is the default storage path.   This updates the post install process to create and assign perms to `/var/tempo`.  Unfortunately we couldn't pin down when this became a problem or what changed.

**Note**  A tricky bit is that Drone only runs for tags and PRs of branches in the Tempo repo itself.  If you PR is from a fork, it doesn't run. This made the failures go unnoticed for some time as most PRs are from forks.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`