### PR TITLE
Split metrics slo out from search slo

### DIFF
--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -541,6 +541,15 @@ query_frontend:
 
         # The target length of time for each job to handle when querying the backend.
         [interval: <duration> | default = 5m ]
+
+        # If set to a non-zero value, it's value will be used to decide if query is within SLO or not.
+        # Query is within SLO if it returned 200 within duration_slo seconds OR processed throughput_slo bytes/s data.
+        # NOTE: `duration_slo` and `throughput_bytes_slo` both must be configured for it to work
+        [duration_slo: <duration> | default = 0s ]
+
+        # If set to a non-zero value, it's value will be used to decide if query is within SLO or not.
+        # Query is within SLO if it returned 200 within duration_slo seconds OR processed throughput_slo bytes/s data.
+        [throughput_bytes_slo: <float> | default = 0 ]
 ```
 
 ## Querier

--- a/modules/frontend/config.go
+++ b/modules/frontend/config.go
@@ -44,6 +44,7 @@ type TraceByIDConfig struct {
 
 type MetricsConfig struct {
 	Sharder QueryRangeSharderConfig `yaml:",inline"`
+	SLO     SLOConfig               `yaml:",inline"`
 }
 
 type SLOConfig struct {
@@ -85,6 +86,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {
 			TargetBytesPerRequest: defaultTargetBytesPerRequest,
 			Interval:              5 * time.Minute,
 		},
+		SLO: slo,
 	}
 
 	// enable multi tenant queries by default

--- a/modules/frontend/frontend_test.go
+++ b/modules/frontend/frontend_test.go
@@ -35,6 +35,7 @@ func TestFrontendTagSearchRequiresOrgID(t *testing.T) {
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 				Interval:              time.Second,
 			},
+			SLO: testSLOcfg,
 		},
 	}, next, nil, nil, nil, "", log.NewNopLogger(), nil)
 	require.NoError(t, err)
@@ -173,6 +174,7 @@ func TestFrontendBadConfigFails(t *testing.T) {
 				ConcurrentRequests:    defaultConcurrentRequests,
 				TargetBytesPerRequest: 0,
 			},
+			SLO: testSLOcfg,
 		},
 	}, nil, nil, nil, nil, "", log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "frontend metrics target bytes per request should be greater than 0")
@@ -195,6 +197,7 @@ func TestFrontendBadConfigFails(t *testing.T) {
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 				Interval:              0,
 			},
+			SLO: testSLOcfg,
 		},
 	}, nil, nil, nil, nil, "", log.NewNopLogger(), nil)
 	assert.EqualError(t, err, "frontend metrics interval should be greater than 0")

--- a/modules/frontend/metrics_query_range_handler.go
+++ b/modules/frontend/metrics_query_range_handler.go
@@ -21,8 +21,7 @@ import (
 
 // newQueryRangeStreamingGRPCHandler returns a handler that streams results from the HTTP handler
 func newQueryRangeStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], apiPrefix string, logger log.Logger) streamingQueryRangeHandler {
-	// todo: should traceql metrics queries contribute to the search SLO or should we create a new one? as is they use the same settings and contribute to search
-	postSLOHook := searchSLOPostHook(cfg.Search.SLO)
+	postSLOHook := metricsSLOPostHook(cfg.Metrics.SLO)
 	downstreamPath := path.Join(apiPrefix, api.PathMetricsQueryRange)
 
 	return func(req *tempopb.QueryRangeRequest, srv tempopb.StreamingQuerier_MetricsQueryRangeServer) error {
@@ -64,7 +63,7 @@ func newQueryRangeStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripp
 
 // newMetricsQueryRangeHTTPHandler returns a handler that returns a single response from the HTTP handler
 func newMetricsQueryRangeHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], logger log.Logger) http.RoundTripper {
-	postSLOHook := searchSLOPostHook(cfg.Search.SLO)
+	postSLOHook := metricsSLOPostHook(cfg.Metrics.SLO)
 
 	return pipeline.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		tenant, _ := user.ExtractOrgID(req.Context())

--- a/modules/frontend/search_handlers_test.go
+++ b/modules/frontend/search_handlers_test.go
@@ -333,6 +333,7 @@ func TestSearchLimitHonored(t *testing.T) {
 				TargetBytesPerRequest: defaultTargetBytesPerRequest,
 				Interval:              time.Second,
 			},
+			SLO: testSLOcfg,
 		},
 	}, nil)
 
@@ -491,6 +492,7 @@ func TestSearchFailurePropagatesFromQueriers(t *testing.T) {
 					TargetBytesPerRequest: defaultTargetBytesPerRequest,
 					Interval:              time.Second,
 				},
+				SLO: testSLOcfg,
 			},
 		}, nil)
 
@@ -535,6 +537,7 @@ func TestSearchFailurePropagatesFromQueriers(t *testing.T) {
 					TargetBytesPerRequest: defaultTargetBytesPerRequest,
 					Interval:              time.Second,
 				},
+				SLO: testSLOcfg,
 			},
 		}, nil)
 
@@ -719,6 +722,7 @@ func frontendWithSettings(t *testing.T, next http.RoundTripper, rdr tempodb.Read
 					TargetBytesPerRequest: defaultTargetBytesPerRequest,
 					Interval:              1 * time.Second,
 				},
+				SLO: testSLOcfg,
 			},
 		}
 	}

--- a/modules/frontend/slos_test.go
+++ b/modules/frontend/slos_test.go
@@ -116,8 +116,9 @@ func TestSLOHook(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			allCounter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "all"}, []string{"tenant"})
 			sloCounter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "slo"}, []string{"tenant"})
+			throughputVec := prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "throughput"}, []string{"tenant"})
 
-			hook := sloHook(allCounter, sloCounter, tc.cfg)
+			hook := sloHook(allCounter, sloCounter, throughputVec, tc.cfg)
 
 			resp := &http.Response{
 				StatusCode: tc.httpStatusCode,

--- a/modules/frontend/tag_handlers_test.go
+++ b/modules/frontend/tag_handlers_test.go
@@ -237,6 +237,7 @@ func TestSearchTagsV2FailurePropagatesFromQueriers(t *testing.T) {
 					TargetBytesPerRequest: defaultTargetBytesPerRequest,
 					Interval:              1 * time.Second,
 				},
+				SLO: testSLOcfg,
 			},
 		}, nil)
 
@@ -281,6 +282,7 @@ func TestSearchTagsV2FailurePropagatesFromQueriers(t *testing.T) {
 					TargetBytesPerRequest: defaultTargetBytesPerRequest,
 					Interval:              1 * time.Second,
 				},
+				SLO: testSLOcfg,
 			},
 		}, nil)
 
@@ -365,6 +367,7 @@ func TestSearchTagValuesV2FailurePropagatesFromQueriers(t *testing.T) {
 					TargetBytesPerRequest: defaultTargetBytesPerRequest,
 					Interval:              1 * time.Second,
 				},
+				SLO: testSLOcfg,
 			},
 		}, nil)
 
@@ -409,6 +412,7 @@ func TestSearchTagValuesV2FailurePropagatesFromQueriers(t *testing.T) {
 					TargetBytesPerRequest: defaultTargetBytesPerRequest,
 					Interval:              1 * time.Second,
 				},
+				SLO: testSLOcfg,
 			},
 		}, nil)
 

--- a/modules/frontend/traceid_handlers_test.go
+++ b/modules/frontend/traceid_handlers_test.go
@@ -195,6 +195,7 @@ func TestTraceIDHandler(t *testing.T) {
 						TargetBytesPerRequest: defaultTargetBytesPerRequest,
 						Interval:              time.Second,
 					},
+					SLO: testSLOcfg,
 				},
 			}, nil)
 


### PR DESCRIPTION
**What this PR does**:
In https://github.com/grafana/tempo/pull/3584/ we decided to count metrics queries as part of search slo. split metrics slo out of search because metrics are still experimental and should not share the SLO with search.


**Checklist**
- [x] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`