### PR TITLE
Use tools image for lint in CI and allow passing base ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,8 @@ jobs:
       - name: check-jsonnetfmt
         run: make check-jsonnetfmt
 
-      - name: Lint
-        uses: golangci/golangci-lint-action@v4
-        with:
-          version: v1.55.2
-          only-new-issues: true
+      - name: lint
+        run: make lint base=${{github.base_ref}}
 
   unit-tests-pkg:
     name: Test packages - pkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
 
       - name: check-fmt
         run: make check-fmt
@@ -37,7 +39,7 @@ jobs:
         run: make check-jsonnetfmt
 
       - name: lint
-        run: make lint base=${{github.base_ref}}
+        run: make lint base=origin/${{github.base_ref}}
 
   unit-tests-pkg:
     name: Test packages - pkg

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,11 @@ check-jsonnetfmt: jsonnetfmt
 
 .PHONY: lint
 lint:
+ifneq ($(base),)
+	$(TOOLS_CMD) $(LINT) run --config .golangci.yml --new-from-rev=$(base)
+else
 	$(TOOLS_CMD) $(LINT) run --config .golangci.yml
+endif
 
 ### Docker Images
 


### PR DESCRIPTION
**What this PR does**:
As a follow up to #3610, here we update CI to use the `make lint` target.  This will mean the local and CI version of golangci-lint will match.

**Checklist**
- [x] CI updated
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`