### PR TITLE
Pin the goreleaser version for Go version support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,7 @@ update-mod:
 
 ### Release (intended to be used in the .github/workflows/release.yml)
 $(GORELEASER):
-	go install github.com/goreleaser/goreleaser@latest
+	go install github.com/goreleaser/goreleaser@v1.25.1
 
 .PHONY: release
 release: $(GORELEASER)

--- a/build/tools.mk
+++ b/build/tools.mk
@@ -12,10 +12,11 @@ TOOL_DIR     ?= tools
 TOOL_CONFIG  ?= $(TOOL_DIR)/tools.go
 
 TOOLS_IMAGE ?= grafana/tempo-ci-tools
+TOOLS_IMAGE_TAG ?= main-d8c69d4
 
 GOTOOLS ?= $(shell cd $(TOOL_DIR) && go list -e -f '{{ .Imports }}' -tags tools |tr -d '[]')
 
-TOOLS_CMD = docker run --rm -t -v ${PWD}:/tools $(TOOLS_IMAGE)
+TOOLS_CMD = docker run --rm -t -v ${PWD}:/tools $(TOOLS_IMAGE):$(TOOLS_IMAGE_TAG)
 
 .PHONY: tools-image-build
 tools-image-build:


### PR DESCRIPTION
**What this PR does**:

Without this change, goreleaser@latest requires a newer version of Go than is currently supported by the project.  Here we pin the version.

**Checklist**
- [x] CI update
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`