### PR TITLE
Remove hardcoded sleep in shutdown for distributor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [ENHANCEMENT] Remove hardcoded delay in distributor shutdown [#3687](https://github.com/grafana/tempo/pull/3687) (@chodges15)
 * [ENHANCEMENT] Update OTLP and add attributes to instrumentation scope in vParquet4 [#3649](https://github.com/grafana/tempo/pull/3649) (@stoewer)
   **Breaking Change** The update to OTLP 1.3.0 removes the deprecated `InstrumentationLibrary`
   and `InstrumentationLibrarySpan` from the OTLP receivers

--- a/modules/distributor/receiver/shim.go
+++ b/modules/distributor/receiver/shim.go
@@ -305,12 +305,6 @@ func (r *receiversShim) starting(ctx context.Context) error {
 
 // Called after distributor is asked to stop via StopAsync.
 func (r *receiversShim) stopping(_ error) error {
-	// when shutdown is called on the receiver it immediately shuts down its connection
-	// which drops requests on the floor. at this point in the shutdown process
-	// the readiness handler is already down so we are not receiving any more requests.
-	// sleep for 30 seconds to here to all pending requests to finish.
-	time.Sleep(30 * time.Second)
-
 	ctx, cancelFn := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelFn()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This sleep is being removed in favor of using the configuration item `shutdown_delay` for generic server shutdown across all Tempo components introduced in #3395.

**Which issue(s) this PR fixes**:
Fixes #2353 

**Checklist**
- [ ] Tests updated **[N/A, existing coverage]**
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`