### PR TITLE
Fetch Tag Values Refactor

### DIFF
--- a/modules/frontend/search_sharder_test.go
+++ b/modules/frontend/search_sharder_test.go
@@ -58,7 +58,7 @@ func (m *mockReader) SearchTagValuesV2(context.Context, *backend.BlockMeta, *tem
 	return nil, nil
 }
 
-func (m *mockReader) FetchTagValues(context.Context, *backend.BlockMeta, traceql.AutocompleteRequest, traceql.AutocompleteCallback, common.SearchOptions) error {
+func (m *mockReader) FetchTagValues(context.Context, *backend.BlockMeta, traceql.FetchTagValuesRequest, traceql.FetchTagValuesCallback, common.SearchOptions) error {
 	return nil
 }
 

--- a/modules/ingester/instance_search.go
+++ b/modules/ingester/instance_search.go
@@ -398,37 +398,26 @@ func (i *instance) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTag
 
 	query := traceql.ExtractMatchers(req.Query)
 
-	var searchBlock func(context.Context, common.Searcher) error
-	if !i.autocompleteFilteringEnabled || traceql.IsEmptyQuery(query) {
-		// If filtering is disabled or query is empty,
-		// we can use the more efficient SearchTagValuesV2 method.
-		searchBlock = func(ctx context.Context, s common.Searcher) error {
-			if anyErr.Load() != nil {
-				return nil // Early exit if any error has occurred
-			}
+	searchBlock := func(ctx context.Context, s common.Searcher) error {
+		if anyErr.Load() != nil {
+			return nil // Early exit if any error has occurred
+		}
 
-			if maxBlocks > 0 && inspectedBlocks.Inc() > maxBlocks {
-				return nil
-			}
+		if maxBlocks > 0 && inspectedBlocks.Inc() > maxBlocks {
+			return nil
+		}
 
+		// if the query is empty or autocomplete filtering is disabled, use the old search
+		if !i.autocompleteFilteringEnabled || traceql.IsEmptyQuery(query) {
 			return s.SearchTagValuesV2(ctx, tag, traceql.MakeCollectTagValueFunc(valueCollector.Collect), common.DefaultSearchOptions())
 		}
-	} else {
-		searchBlock = func(ctx context.Context, s common.Searcher) error {
-			if anyErr.Load() != nil {
-				return nil // Early exit if any error has occurred
-			}
 
-			if maxBlocks > 0 && inspectedBlocks.Inc() > maxBlocks {
-				return nil
-			}
+		// otherwise use the filtered search
+		fetcher := traceql.NewTagValuesFetcherWrapper(func(ctx context.Context, req traceql.FetchTagValuesRequest, cb traceql.FetchTagValuesCallback) error {
+			return s.FetchTagValues(ctx, req, cb, common.DefaultSearchOptions())
+		})
 
-			fetcher := traceql.NewAutocompleteFetcherWrapper(func(ctx context.Context, req traceql.AutocompleteRequest, cb traceql.AutocompleteCallback) error {
-				return s.FetchTagValues(ctx, req, cb, common.DefaultSearchOptions())
-			})
-
-			return engine.ExecuteTagValues(ctx, tag, query, traceql.MakeCollectTagValueFunc(valueCollector.Collect), fetcher)
-		}
+		return engine.ExecuteTagValues(ctx, tag, query, traceql.MakeCollectTagValueFunc(valueCollector.Collect), fetcher)
 	}
 
 	// head block

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -1020,7 +1020,7 @@ func (q *Querier) internalTagValuesSearchBlockV2(ctx context.Context, req *tempo
 		return nil, err
 	}
 
-	fetcher := traceql.NewAutocompleteFetcherWrapper(func(ctx context.Context, req traceql.AutocompleteRequest, cb traceql.AutocompleteCallback) error {
+	fetcher := traceql.NewTagValuesFetcherWrapper(func(ctx context.Context, req traceql.FetchTagValuesRequest, cb traceql.FetchTagValuesCallback) error {
 		return q.store.FetchTagValues(ctx, meta, req, cb, common.DefaultSearchOptions())
 	})
 

--- a/pkg/traceql/engine.go
+++ b/pkg/traceql/engine.go
@@ -144,8 +144,8 @@ func (e *Engine) ExecuteTagValues(
 	ctx context.Context,
 	tag Attribute,
 	query string,
-	cb AutocompleteCallback,
-	fetcher AutocompleteFetcher,
+	cb FetchTagValuesCallback,
+	fetcher TagValuesFetcher,
 ) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "traceql.Engine.ExecuteTagValues")
 	defer span.Finish()
@@ -195,7 +195,7 @@ func (e *Engine) createFetchSpansRequest(searchReq *tempopb.SearchRequest, pipel
 	return req
 }
 
-func (e *Engine) createAutocompleteRequest(tag Attribute, pipeline Pipeline) AutocompleteRequest {
+func (e *Engine) createAutocompleteRequest(tag Attribute, pipeline Pipeline) FetchTagValuesRequest {
 	req := FetchSpansRequest{
 		Conditions:    nil,
 		AllConditions: true,
@@ -205,7 +205,7 @@ func (e *Engine) createAutocompleteRequest(tag Attribute, pipeline Pipeline) Aut
 	//  and breaks optimizations in block_autocomplete.go.
 	//  We only want the attribute we're searching for in the conditions.
 	if pipeline.String() == "{ true }" {
-		return AutocompleteRequest{
+		return FetchTagValuesRequest{
 			Conditions: []Condition{{Attribute: tag, Op: OpNone}},
 			TagName:    tag,
 		}
@@ -224,7 +224,7 @@ func (e *Engine) createAutocompleteRequest(tag Attribute, pipeline Pipeline) Aut
 		Op:        OpNone,
 	})
 
-	autocompleteReq := AutocompleteRequest{
+	autocompleteReq := FetchTagValuesRequest{
 		Conditions: req.Conditions,
 		TagName:    tag,
 	}

--- a/pkg/traceql/engine_test.go
+++ b/pkg/traceql/engine_test.go
@@ -357,14 +357,14 @@ func TestEngine_asTraceSearchMetadata(t *testing.T) {
 	assert.Equal(t, expectedTraceSearchMetadata, traceSearchMetadata)
 }
 
-var _ AutocompleteFetcher = (*MockAutocompleteFetcher)(nil)
+var _ TagValuesFetcher = (*MockAutocompleteFetcher)(nil)
 
 type MockAutocompleteFetcher struct {
 	query    string
 	iterator SpansetIterator
 }
 
-func (m *MockAutocompleteFetcher) Fetch(ctx context.Context, req AutocompleteRequest, cb AutocompleteCallback) error {
+func (m *MockAutocompleteFetcher) Fetch(ctx context.Context, req FetchTagValuesRequest, cb FetchTagValuesCallback) error {
 	rootExpr, err := Parse(m.query)
 	if err != nil {
 		return err
@@ -546,7 +546,7 @@ func TestExecuteTagValues(t *testing.T) {
 	now := time.Now()
 	e := Engine{}
 
-	mockSpansetFetcher := func(query string) AutocompleteFetcher {
+	mockSpansetFetcher := func(query string) TagValuesFetcher {
 		return &MockAutocompleteFetcher{
 			query: query,
 			iterator: &MockSpanSetIterator{

--- a/pkg/traceql/storage.go
+++ b/pkg/traceql/storage.go
@@ -189,31 +189,31 @@ type SpansetFetcher interface {
 	Fetch(context.Context, FetchSpansRequest) (FetchSpansResponse, error)
 }
 
-// AutocompleteCallback is called to collect unique tag values.
+// FetchTagValuesCallback is called to collect unique tag values.
 // Returns true if it has exceeded the maximum number of results.
-type AutocompleteCallback func(static Static) bool
+type FetchTagValuesCallback func(static Static) bool
 
-type AutocompleteRequest struct {
+type FetchTagValuesRequest struct {
 	Conditions []Condition
 	TagName    Attribute
 	// TODO: Add start and end time?
 }
 
-type AutocompleteFetcher interface {
-	Fetch(context.Context, AutocompleteRequest, AutocompleteCallback) error
+type TagValuesFetcher interface {
+	Fetch(context.Context, FetchTagValuesRequest, FetchTagValuesCallback) error
 }
 
-type AutocompleteFetcherWrapper struct {
-	f func(context.Context, AutocompleteRequest, AutocompleteCallback) error
+type TagValuesFetcherWrapper struct {
+	f func(context.Context, FetchTagValuesRequest, FetchTagValuesCallback) error
 }
 
-var _ AutocompleteFetcher = (*AutocompleteFetcherWrapper)(nil)
+var _ TagValuesFetcher = (*TagValuesFetcherWrapper)(nil)
 
-func NewAutocompleteFetcherWrapper(f func(context.Context, AutocompleteRequest, AutocompleteCallback) error) AutocompleteFetcher {
-	return AutocompleteFetcherWrapper{f}
+func NewTagValuesFetcherWrapper(f func(context.Context, FetchTagValuesRequest, FetchTagValuesCallback) error) TagValuesFetcher {
+	return TagValuesFetcherWrapper{f}
 }
 
-func (s AutocompleteFetcherWrapper) Fetch(ctx context.Context, request AutocompleteRequest, callback AutocompleteCallback) error {
+func (s TagValuesFetcherWrapper) Fetch(ctx context.Context, request FetchTagValuesRequest, callback FetchTagValuesCallback) error {
 	return s.f(ctx, request, callback)
 }
 

--- a/tempodb/encoding/common/interfaces.go
+++ b/tempodb/encoding/common/interfaces.go
@@ -26,7 +26,7 @@ type Searcher interface {
 	SearchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb TagCallbackV2, opts SearchOptions) error
 
 	Fetch(context.Context, traceql.FetchSpansRequest, SearchOptions) (traceql.FetchSpansResponse, error)
-	FetchTagValues(context.Context, traceql.AutocompleteRequest, traceql.AutocompleteCallback, SearchOptions) error
+	FetchTagValues(context.Context, traceql.FetchTagValuesRequest, traceql.FetchTagValuesCallback, SearchOptions) error
 }
 
 type SearchOptions struct {

--- a/tempodb/encoding/v2/backend_block.go
+++ b/tempodb/encoding/v2/backend_block.go
@@ -165,6 +165,6 @@ func (b *BackendBlock) Fetch(context.Context, traceql.FetchSpansRequest, common.
 	return traceql.FetchSpansResponse{}, common.ErrUnsupported
 }
 
-func (b *BackendBlock) FetchTagValues(context.Context, traceql.AutocompleteRequest, traceql.AutocompleteCallback, common.SearchOptions) error {
+func (b *BackendBlock) FetchTagValues(context.Context, traceql.FetchTagValuesRequest, traceql.FetchTagValuesCallback, common.SearchOptions) error {
 	return common.ErrUnsupported
 }

--- a/tempodb/encoding/v2/wal_block.go
+++ b/tempodb/encoding/v2/wal_block.go
@@ -307,7 +307,7 @@ func (a *walBlock) Fetch(context.Context, traceql.FetchSpansRequest, common.Sear
 }
 
 // FetchTagValues implements traceql.Searcher
-func (a *walBlock) FetchTagValues(context.Context, traceql.AutocompleteRequest, traceql.AutocompleteCallback, common.SearchOptions) error {
+func (a *walBlock) FetchTagValues(context.Context, traceql.FetchTagValuesRequest, traceql.FetchTagValuesCallback, common.SearchOptions) error {
 	return common.ErrUnsupported
 }
 

--- a/tempodb/encoding/vparquet2/block.go
+++ b/tempodb/encoding/vparquet2/block.go
@@ -34,7 +34,7 @@ func (b *backendBlock) BlockMeta() *backend.BlockMeta {
 	return b.meta
 }
 
-func (b *backendBlock) FetchTagValues(context.Context, traceql.AutocompleteRequest, traceql.AutocompleteCallback, common.SearchOptions) error {
+func (b *backendBlock) FetchTagValues(context.Context, traceql.FetchTagValuesRequest, traceql.FetchTagValuesCallback, common.SearchOptions) error {
 	// TODO: Add support?
 	return common.ErrUnsupported
 }

--- a/tempodb/encoding/vparquet2/wal_block.go
+++ b/tempodb/encoding/vparquet2/wal_block.go
@@ -671,7 +671,7 @@ func (b *walBlock) Fetch(ctx context.Context, req traceql.FetchSpansRequest, opt
 	}, nil
 }
 
-func (b *walBlock) FetchTagValues(context.Context, traceql.AutocompleteRequest, traceql.AutocompleteCallback, common.SearchOptions) error {
+func (b *walBlock) FetchTagValues(context.Context, traceql.FetchTagValuesRequest, traceql.FetchTagValuesCallback, common.SearchOptions) error {
 	// TODO: Add support?
 	return common.ErrUnsupported
 }

--- a/tempodb/encoding/vparquet3/block_autocomplete.go
+++ b/tempodb/encoding/vparquet3/block_autocomplete.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (b *backendBlock) FetchTagValues(ctx context.Context, req traceql.AutocompleteRequest, cb traceql.AutocompleteCallback, opts common.SearchOptions) error {
+func (b *backendBlock) FetchTagValues(ctx context.Context, req traceql.FetchTagValuesRequest, cb traceql.FetchTagValuesCallback, opts common.SearchOptions) error {
 	err := checkConditions(req.Conditions)
 	if err != nil {
 		return errors.Wrap(err, "conditions invalid")
@@ -62,7 +62,7 @@ func (b *backendBlock) FetchTagValues(ctx context.Context, req traceql.Autocompl
 }
 
 // autocompleteIter creates an iterator that will collect values for a given attribute/tag.
-func autocompleteIter(ctx context.Context, req traceql.AutocompleteRequest, pf *parquet.File, opts common.SearchOptions, dc backend.DedicatedColumns) (parquetquery.Iterator, error) {
+func autocompleteIter(ctx context.Context, req traceql.FetchTagValuesRequest, pf *parquet.File, opts common.SearchOptions, dc backend.DedicatedColumns) (parquetquery.Iterator, error) {
 	iter, err := createDistinctIterator(ctx, req.Conditions, req.TagName, pf, opts, dc)
 	if err != nil {
 		return nil, fmt.Errorf("error creating iterator: %w", err)

--- a/tempodb/encoding/vparquet3/block_autocomplete_test.go
+++ b/tempodb/encoding/vparquet3/block_autocomplete_test.go
@@ -273,7 +273,7 @@ func TestFetchTagValues(t *testing.T) {
 			require.NoError(t, err)
 
 			// Build autocomplete request
-			autocompleteReq := traceql.AutocompleteRequest{
+			autocompleteReq := traceql.FetchTagValuesRequest{
 				Conditions: req.Conditions,
 				TagName:    tag,
 			}
@@ -359,7 +359,7 @@ func BenchmarkFetchTagValues(b *testing.B) {
 				Attribute: tag,
 			})
 
-			autocompleteReq := traceql.AutocompleteRequest{
+			autocompleteReq := traceql.FetchTagValuesRequest{
 				Conditions: req.Conditions,
 				TagName:    tag,
 			}

--- a/tempodb/encoding/vparquet3/wal_block.go
+++ b/tempodb/encoding/vparquet3/wal_block.go
@@ -682,7 +682,7 @@ func (b *walBlock) Fetch(ctx context.Context, req traceql.FetchSpansRequest, _ c
 	}, nil
 }
 
-func (b *walBlock) FetchTagValues(ctx context.Context, req traceql.AutocompleteRequest, cb traceql.AutocompleteCallback, opts common.SearchOptions) error {
+func (b *walBlock) FetchTagValues(ctx context.Context, req traceql.FetchTagValuesRequest, cb traceql.FetchTagValuesCallback, opts common.SearchOptions) error {
 	err := checkConditions(req.Conditions)
 	if err != nil {
 		return fmt.Errorf("conditions invalid: %w", err)

--- a/tempodb/encoding/vparquet4/block_autocomplete.go
+++ b/tempodb/encoding/vparquet4/block_autocomplete.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (b *backendBlock) FetchTagValues(ctx context.Context, req traceql.AutocompleteRequest, cb traceql.AutocompleteCallback, opts common.SearchOptions) error {
+func (b *backendBlock) FetchTagValues(ctx context.Context, req traceql.FetchTagValuesRequest, cb traceql.FetchTagValuesCallback, opts common.SearchOptions) error {
 	err := checkConditions(req.Conditions)
 	if err != nil {
 		return errors.Wrap(err, "conditions invalid")
@@ -62,7 +62,7 @@ func (b *backendBlock) FetchTagValues(ctx context.Context, req traceql.Autocompl
 }
 
 // autocompleteIter creates an iterator that will collect values for a given attribute/tag.
-func autocompleteIter(ctx context.Context, req traceql.AutocompleteRequest, pf *parquet.File, opts common.SearchOptions, dc backend.DedicatedColumns) (parquetquery.Iterator, error) {
+func autocompleteIter(ctx context.Context, req traceql.FetchTagValuesRequest, pf *parquet.File, opts common.SearchOptions, dc backend.DedicatedColumns) (parquetquery.Iterator, error) {
 	iter, err := createDistinctIterator(ctx, req.Conditions, req.TagName, pf, opts, dc)
 	if err != nil {
 		return nil, fmt.Errorf("error creating iterator: %w", err)

--- a/tempodb/encoding/vparquet4/block_autocomplete_test.go
+++ b/tempodb/encoding/vparquet4/block_autocomplete_test.go
@@ -273,7 +273,7 @@ func TestFetchTagValues(t *testing.T) {
 			require.NoError(t, err)
 
 			// Build autocomplete request
-			autocompleteReq := traceql.AutocompleteRequest{
+			autocompleteReq := traceql.FetchTagValuesRequest{
 				Conditions: req.Conditions,
 				TagName:    tag,
 			}
@@ -359,7 +359,7 @@ func BenchmarkFetchTagValues(b *testing.B) {
 				Attribute: tag,
 			})
 
-			autocompleteReq := traceql.AutocompleteRequest{
+			autocompleteReq := traceql.FetchTagValuesRequest{
 				Conditions: req.Conditions,
 				TagName:    tag,
 			}

--- a/tempodb/encoding/vparquet4/wal_block.go
+++ b/tempodb/encoding/vparquet4/wal_block.go
@@ -682,7 +682,7 @@ func (b *walBlock) Fetch(ctx context.Context, req traceql.FetchSpansRequest, _ c
 	}, nil
 }
 
-func (b *walBlock) FetchTagValues(ctx context.Context, req traceql.AutocompleteRequest, cb traceql.AutocompleteCallback, opts common.SearchOptions) error {
+func (b *walBlock) FetchTagValues(ctx context.Context, req traceql.FetchTagValuesRequest, cb traceql.FetchTagValuesCallback, opts common.SearchOptions) error {
 	err := checkConditions(req.Conditions)
 	if err != nil {
 		return fmt.Errorf("conditions invalid: %w", err)

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -84,7 +84,7 @@ type Reader interface {
 	SearchTagValuesV2(ctx context.Context, meta *backend.BlockMeta, req *tempopb.SearchTagValuesRequest, opts common.SearchOptions) (*tempopb.SearchTagValuesV2Response, error)
 
 	Fetch(ctx context.Context, meta *backend.BlockMeta, req traceql.FetchSpansRequest, opts common.SearchOptions) (traceql.FetchSpansResponse, error)
-	FetchTagValues(ctx context.Context, meta *backend.BlockMeta, req traceql.AutocompleteRequest, cb traceql.AutocompleteCallback, opts common.SearchOptions) error
+	FetchTagValues(ctx context.Context, meta *backend.BlockMeta, req traceql.FetchTagValuesRequest, cb traceql.FetchTagValuesCallback, opts common.SearchOptions) error
 
 	BlockMetas(tenantID string) []*backend.BlockMeta
 	EnablePolling(ctx context.Context, sharder blocklist.JobSharder)
@@ -435,7 +435,7 @@ func (rw *readerWriter) Fetch(ctx context.Context, meta *backend.BlockMeta, req 
 	return block.Fetch(ctx, req, opts)
 }
 
-func (rw *readerWriter) FetchTagValues(ctx context.Context, meta *backend.BlockMeta, req traceql.AutocompleteRequest, cb traceql.AutocompleteCallback, opts common.SearchOptions) error {
+func (rw *readerWriter) FetchTagValues(ctx context.Context, meta *backend.BlockMeta, req traceql.FetchTagValuesRequest, cb traceql.FetchTagValuesCallback, opts common.SearchOptions) error {
 	block, err := encoding.OpenBlock(meta, rw.r)
 	if err != nil {
 		return err

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -1375,7 +1375,7 @@ func autoComplete(t *testing.T, _ *tempopb.Trace, _ *tempopb.TraceSearchMetadata
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			fetcher := traceql.NewAutocompleteFetcherWrapper(func(ctx context.Context, req traceql.AutocompleteRequest, cb traceql.AutocompleteCallback) error {
+			fetcher := traceql.NewTagValuesFetcherWrapper(func(ctx context.Context, req traceql.FetchTagValuesRequest, cb traceql.FetchTagValuesCallback) error {
 				return bb.FetchTagValues(ctx, req, cb, common.DefaultSearchOptions())
 			})
 
@@ -2110,7 +2110,7 @@ func TestSearchForTagsAndTagValues(t *testing.T) {
 	assert.Equal(t, expected, tagValues.TagValues)
 
 	valueCollector := util.NewDistinctValueCollector[tempopb.TagValue](0, func(value tempopb.TagValue) int { return 0 })
-	f := traceql.NewAutocompleteFetcherWrapper(func(ctx context.Context, req traceql.AutocompleteRequest, cb traceql.AutocompleteCallback) error {
+	f := traceql.NewTagValuesFetcherWrapper(func(ctx context.Context, req traceql.FetchTagValuesRequest, cb traceql.FetchTagValuesCallback) error {
 		return r.FetchTagValues(ctx, block.BlockMeta(), req, cb, common.DefaultSearchOptions())
 	})
 


### PR DESCRIPTION
**What this PR does**:
Renames a few elements in Tempo from "Autocomplete" to "FetchTagValues" to better match established patterns and make room for "FetchTags" functionality.

The only change that was not a simple rename was the code in instance_search.go

https://github.com/grafana/tempo/pull/3692/files#diff-8c9aac72ec16ad39eb093753942cde7f893be0b5950578ffe10ef003d2ff5237

