### PR TITLE
Tempo CLI - add percentage support for query blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## main / unreleased
-
+* [ENHANCEMENT] Tempo CLI - add percentage support for query blocks #3697 [#3697](https://github.com/grafana/tempo/pull/3697) (@edgarkz)
 * [ENHANCEMENT] Update OTLP and add attributes to instrumentation scope in vParquet4 [#3649](https://github.com/grafana/tempo/pull/3649) (@stoewer)
   **Breaking Change** The update to OTLP 1.3.0 removes the deprecated `InstrumentationLibrary`
   and `InstrumentationLibrarySpan` from the OTLP receivers

--- a/cmd/tempo-cli/cmd-query-blocks.go
+++ b/cmd/tempo-cli/cmd-query-blocks.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"math/rand"
 	"fmt"
+	"math/rand"
 	"strconv"
 
 	"github.com/gogo/protobuf/jsonpb"
@@ -29,8 +29,8 @@ type queryResults struct {
 type queryBlocksCmd struct {
 	backendOptions
 
-	TraceID  string `arg:"" help:"trace ID to retrieve"`
-	TenantID string `arg:"" help:"tenant ID to search"`
+	TraceID    string  `arg:"" help:"trace ID to retrieve"`
+	TenantID   string  `arg:"" help:"tenant ID to search"`
 	Percentage float32 `help:"percentage of blocks to scan e.g..1 for 10%"`
 }
 

--- a/cmd/tempo-cli/cmd-query-blocks.go
+++ b/cmd/tempo-cli/cmd-query-blocks.go
@@ -30,8 +30,8 @@ type queryBlocksCmd struct {
 	backendOptions
 
 	TraceID  string `arg:"" help:"trace ID to retrieve"`
-	TenantID string `arg:"" help:"tenant ID to searchi"`
-    Percentage float32 `help:"percentage of blocks to scan e.g..1 for 10%"`
+	TenantID string `arg:"" help:"tenant ID to search"`
+	Percentage float32 `help:"percentage of blocks to scan e.g..1 for 10%"`
 }
 
 func (cmd *queryBlocksCmd) Run(ctx *globalOptions) error {


### PR DESCRIPTION
**What this PR does**:add tempo cli support for % of blocks to scan and dump using cli `query blocks` option.

**Which issue(s) this PR fixes**:
Fixes #3690

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`