### PR TITLE
Fix TraceQL failures on boolean operations with statics and attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## main / unreleased
 
+* [BUGFIX] Fix TraceQL queries involving non boolean operations between statics and attributes. [#3698](https://github.com/grafana/tempo/pull/3698) (@joe-elliott)
+
 ## v2.5.0-rc.0
 
 * [CHANGE] Align metrics query time ranges to the step parameter [#3490](https://github.com/grafana/tempo/pull/3490) (@mdisibio)
@@ -64,7 +66,6 @@
 * [BUGFIX] Correctly parse traceql queries with > 1024 character attribute names or static values. [#3571](https://github.com/grafana/tempo/issues/3571) (@joe-elliott)
 * [BUGFIX] Fix span-metrics' subprocessors bug that applied wrong configs when running multiple tenants. [#3612](https://github.com/grafana/tempo/pull/3612) (@mapno)
 * [BUGFIX] Fix panic in query-frontend when combining results [#3683](https://github.com/grafana/tempo/pull/3683) (@mapno)
-* [BUGFIX] Fix TraceQL queries involving non boolean operations between statics and attributes. [#3698](https://github.com/grafana/tempo/pull/3698) (@joe-elliott)
 
 ## v2.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 * [BUGFIX] Correctly parse traceql queries with > 1024 character attribute names or static values. [#3571](https://github.com/grafana/tempo/issues/3571) (@joe-elliott)
 * [BUGFIX] Fix span-metrics' subprocessors bug that applied wrong configs when running multiple tenants. [#3612](https://github.com/grafana/tempo/pull/3612) (@mapno)
 * [BUGFIX] Fix panic in query-frontend when combining results [#3683](https://github.com/grafana/tempo/pull/3683) (@mapno)
+* [BUGFIX] Fix TraceQL queries involving non boolean operations between statics and attributes. [#3698](https://github.com/grafana/tempo/pull/3698) (@joe-elliott)
 
 ## v2.4.2
 

--- a/pkg/traceql/ast_conditions.go
+++ b/pkg/traceql/ast_conditions.go
@@ -44,7 +44,7 @@ func (o *BinaryOperation) extractConditions(request *FetchSpansRequest) {
 	case Attribute:
 		switch o.RHS.(type) {
 		case Static:
-			if o.RHS.(Static).Type == TypeNil && o.Op == OpNotEqual {
+			if o.RHS.(Static).Type == TypeNil && o.Op == OpNotEqual || !o.Op.isBoolean() { // the fetch layer can't build predicates on operators that are not boolean
 				request.appendCondition(Condition{
 					Attribute: o.LHS.(Attribute),
 					Op:        OpNone,
@@ -84,7 +84,7 @@ func (o *BinaryOperation) extractConditions(request *FetchSpansRequest) {
 			// 2 statics, don't need to send any conditions
 			return
 		case Attribute:
-			if o.LHS.(Static).Type == TypeNil && o.Op == OpNotEqual {
+			if o.LHS.(Static).Type == TypeNil && o.Op == OpNotEqual || !o.Op.isBoolean() { // the fetch layer can't build predicates on operators that are not boolean
 				request.appendCondition(Condition{
 					Attribute: o.RHS.(Attribute),
 					Op:        OpNone,

--- a/pkg/traceql/ast_conditions.go
+++ b/pkg/traceql/ast_conditions.go
@@ -44,7 +44,7 @@ func (o *BinaryOperation) extractConditions(request *FetchSpansRequest) {
 	case Attribute:
 		switch o.RHS.(type) {
 		case Static:
-			if o.RHS.(Static).Type == TypeNil && o.Op == OpNotEqual || !o.Op.isBoolean() { // the fetch layer can't build predicates on operators that are not boolean
+			if (o.RHS.(Static).Type == TypeNil && o.Op == OpNotEqual) || !o.Op.isBoolean() { // the fetch layer can't build predicates on operators that are not boolean
 				request.appendCondition(Condition{
 					Attribute: o.LHS.(Attribute),
 					Op:        OpNone,
@@ -84,7 +84,7 @@ func (o *BinaryOperation) extractConditions(request *FetchSpansRequest) {
 			// 2 statics, don't need to send any conditions
 			return
 		case Attribute:
-			if o.LHS.(Static).Type == TypeNil && o.Op == OpNotEqual || !o.Op.isBoolean() { // the fetch layer can't build predicates on operators that are not boolean
+			if (o.LHS.(Static).Type == TypeNil && o.Op == OpNotEqual) || !o.Op.isBoolean() { // the fetch layer can't build predicates on operators that are not boolean
 				request.appendCondition(Condition{
 					Attribute: o.RHS.(Attribute),
 					Op:        OpNone,

--- a/pkg/traceql/ast_conditions_test.go
+++ b/pkg/traceql/ast_conditions_test.go
@@ -97,6 +97,14 @@ func TestSpansetFilter_extractConditions(t *testing.T) {
 			},
 			allConditions: true,
 		},
+		{
+			query: `{ (.foo = 2) && (.bar / 1 > 3) }`,
+			conditions: []Condition{
+				newCondition(NewAttribute("foo"), OpEqual, NewStaticInt(2)),
+				newCondition(NewAttribute("bar"), OpNone),
+			},
+			allConditions: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.query, func(t *testing.T) {

--- a/pkg/traceql/ast_conditions_test.go
+++ b/pkg/traceql/ast_conditions_test.go
@@ -89,6 +89,14 @@ func TestSpansetFilter_extractConditions(t *testing.T) {
 			},
 			allConditions: true,
 		},
+		{
+			query: `{ .foo = .bar + 1 }`,
+			conditions: []Condition{
+				newCondition(NewAttribute("foo"), OpNone),
+				newCondition(NewAttribute("bar"), OpNone),
+			},
+			allConditions: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.query, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:
Fixes an issue where TraceQL will pass a bad condition to the fetch layer when you use add a static and attribute such as:
```
{ span.http.status_code > span.http.status_code + 1 }
```

Currently this returns an error:

![image](https://github.com/grafana/tempo/assets/2272392/31a6d1de-9d6f-4707-bb75-00b1edbbee34)


**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`