### PR TITLE
Keep replicationFactor in meta file after compaction

### DIFF
--- a/tempodb/encoding/vparquet3/compactor.go
+++ b/tempodb/encoding/vparquet3/compactor.go
@@ -150,11 +150,12 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 		if currentBlock == nil {
 			// Start with a copy and then customize
 			newMeta := &backend.BlockMeta{
-				BlockID:          uuid.New(),
-				TenantID:         inputs[0].TenantID,
-				CompactionLevel:  nextCompactionLevel,
-				TotalObjects:     recordsPerBlock, // Just an estimate
-				DedicatedColumns: inputs[0].DedicatedColumns,
+				BlockID:           uuid.New(),
+				TenantID:          inputs[0].TenantID,
+				CompactionLevel:   nextCompactionLevel,
+				TotalObjects:      recordsPerBlock, // Just an estimate
+				ReplicationFactor: inputs[0].ReplicationFactor,
+				DedicatedColumns:  inputs[0].DedicatedColumns,
 			}
 
 			currentBlock = newStreamingBlock(ctx, &c.opts.BlockConfig, newMeta, r, w, tempo_io.NewBufferedWriter)

--- a/tempodb/encoding/vparquet4/compactor.go
+++ b/tempodb/encoding/vparquet4/compactor.go
@@ -150,11 +150,12 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 		if currentBlock == nil {
 			// Start with a copy and then customize
 			newMeta := &backend.BlockMeta{
-				BlockID:          uuid.New(),
-				TenantID:         inputs[0].TenantID,
-				CompactionLevel:  nextCompactionLevel,
-				TotalObjects:     recordsPerBlock, // Just an estimate
-				DedicatedColumns: inputs[0].DedicatedColumns,
+				BlockID:           uuid.New(),
+				TenantID:          inputs[0].TenantID,
+				CompactionLevel:   nextCompactionLevel,
+				TotalObjects:      recordsPerBlock, // Just an estimate
+				ReplicationFactor: inputs[0].ReplicationFactor,
+				DedicatedColumns:  inputs[0].DedicatedColumns,
 			}
 
 			currentBlock = newStreamingBlock(ctx, &c.opts.BlockConfig, newMeta, r, w, tempo_io.NewBufferedWriter)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Follow up to https://github.com/grafana/tempo/pull/3628. `ReplicationFactor` was not being set during compaction.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`