### PR TITLE
TraceQL: Collapse statics

### DIFF
--- a/pkg/traceql/ast.go
+++ b/pkg/traceql/ast.go
@@ -402,12 +402,20 @@ type BinaryOperation struct {
 	compiledExpression *regexp.Regexp
 }
 
-func newBinaryOperation(op Operator, lhs, rhs FieldExpression) *BinaryOperation {
-	return &BinaryOperation{
+func newBinaryOperation(op Operator, lhs, rhs FieldExpression) FieldExpression {
+	binop := &BinaryOperation{
 		Op:  op,
 		LHS: lhs,
 		RHS: rhs,
 	}
+
+	if !binop.referencesSpan() && binop.validate() == nil {
+		if simplified, err := binop.execute(nil); err == nil {
+			return simplified
+		}
+	}
+
+	return binop
 }
 
 // nolint: revive
@@ -437,11 +445,19 @@ type UnaryOperation struct {
 	Expression FieldExpression
 }
 
-func newUnaryOperation(op Operator, e FieldExpression) UnaryOperation {
-	return UnaryOperation{
+func newUnaryOperation(op Operator, e FieldExpression) FieldExpression {
+	unop := UnaryOperation{
 		Op:         op,
 		Expression: e,
 	}
+
+	if !unop.referencesSpan() && unop.validate() == nil {
+		if simplified, err := unop.execute(nil); err == nil {
+			return simplified
+		}
+	}
+
+	return unop
 }
 
 // nolint: revive

--- a/pkg/traceql/ast_execute.go
+++ b/pkg/traceql/ast_execute.go
@@ -360,6 +360,33 @@ func (o *BinaryOperation) execute(span Span) (Static, error) {
 		}
 	}
 
+	// if both sides are integers then do integer math, otherwise we can drop to the
+	// catch all below
+	if lhsT == TypeInt && rhsT == TypeInt {
+		switch o.Op {
+		case OpAdd:
+			return NewStaticInt(lhs.N + rhs.N), nil
+		case OpSub:
+			return NewStaticInt(lhs.N - rhs.N), nil
+		case OpDiv:
+			return NewStaticInt(lhs.N / rhs.N), nil
+		case OpMod:
+			return NewStaticInt(lhs.N % rhs.N), nil
+		case OpMult:
+			return NewStaticInt(lhs.N * rhs.N), nil
+		case OpGreater:
+			return NewStaticBool(lhs.N > rhs.N), nil
+		case OpGreaterEqual:
+			return NewStaticBool(lhs.N >= rhs.N), nil
+		case OpLess:
+			return NewStaticBool(lhs.N < rhs.N), nil
+		case OpLessEqual:
+			return NewStaticBool(lhs.N <= rhs.N), nil
+		case OpPower:
+			return NewStaticInt(intPow(rhs.N, lhs.N)), nil
+		}
+	}
+
 	switch o.Op {
 	case OpAdd:
 		return NewStaticFloat(lhs.asFloat() + rhs.asFloat()), nil
@@ -528,4 +555,12 @@ func uniqueSpans(ss1 []*Spanset, ss2 []*Spanset) []Span {
 	}
 
 	return output
+}
+
+func intPow(m, n int) int {
+	result := 1
+	for i := 0; i < n; i++ {
+		result *= m
+	}
+	return result
 }

--- a/pkg/traceql/ast_execute_test.go
+++ b/pkg/traceql/ast_execute_test.go
@@ -1011,7 +1011,12 @@ func TestArithmetic(t *testing.T) {
 			[]*Spanset{{Spans: []Span{&mockSpan{id: []byte{1}, attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1), NewAttribute("bar"): NewStaticFloat(1)}}}}},
 		},
 		{
-			"{ 1 / 10 = .1 }",
+			"{ 1 / 10. = .1 }",
+			[]*Spanset{{Spans: []Span{&mockSpan{id: []byte{1}, attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1), NewAttribute("bar"): NewStaticFloat(1)}}}}},
+			[]*Spanset{{Spans: []Span{&mockSpan{id: []byte{1}, attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1), NewAttribute("bar"): NewStaticFloat(1)}}}}},
+		},
+		{
+			"{ 1 / 10 = 0 }", // integer division
 			[]*Spanset{{Spans: []Span{&mockSpan{id: []byte{1}, attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1), NewAttribute("bar"): NewStaticFloat(1)}}}}},
 			[]*Spanset{{Spans: []Span{&mockSpan{id: []byte{1}, attributes: map[Attribute]Static{NewAttribute("foo"): NewStaticInt(1), NewAttribute("bar"): NewStaticFloat(1)}}}}},
 		},

--- a/pkg/traceql/parse_test.go
+++ b/pkg/traceql/parse_test.go
@@ -979,6 +979,8 @@ func TestBinaryAndUnaryOperationsCollapseToStatics(t *testing.T) {
 		{in: "{ `foo` = `bar` }", expected: NewStaticBool(false)},
 		{in: "{ 1 = 1. }", expected: NewStaticBool(true)}, // this is an interesting case, it returns true even though { span.foo = 1 } would be false if span.foo had the float value 1.0
 		{in: "{ .1 + 1 }", expected: NewStaticFloat(1.1)},
+		{in: "{ 1 * -1 = -1 }", expected: NewStaticBool(true)},
+		{in: "{ .foo * -1. = -1 }", expected: newBinaryOperation(OpEqual, newBinaryOperation(OpMult, NewAttribute("foo"), NewStaticFloat(-1)), NewStaticInt(-1))},
 	}
 
 	test := func(q string, expected FieldExpression) {

--- a/pkg/traceql/parse_test.go
+++ b/pkg/traceql/parse_test.go
@@ -983,7 +983,7 @@ func TestBinaryAndUnaryOperationsCollapseToStatics(t *testing.T) {
 		{in: "{ .foo * -1. = -1 }", expected: newBinaryOperation(OpEqual, newBinaryOperation(OpMult, NewAttribute("foo"), NewStaticFloat(-1)), NewStaticInt(-1))},
 	}
 
-	test := func(q string, expected FieldExpression) {
+	test := func(t *testing.T, q string, expected FieldExpression) {
 		actual, err := Parse(q)
 		require.NoError(t, err, q)
 		require.Equal(t, newRootExpr(newPipeline(newSpansetFilter(expected))), actual, q)
@@ -991,7 +991,7 @@ func TestBinaryAndUnaryOperationsCollapseToStatics(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.in, func(t *testing.T) {
-			test(tc.in, tc.expected)
+			test(t, tc.in, tc.expected)
 		})
 	}
 }

--- a/pkg/traceql/parse_test.go
+++ b/pkg/traceql/parse_test.go
@@ -966,6 +966,34 @@ func TestAttributeNameErrors(t *testing.T) {
 	}
 }
 
+// TestBinaryAndUnaryOperationsCollapseToStatics tests code in the newBinaryOperation and newUnaryOperation functions
+// that attempts to simplify combinations of static values where possible.
+func TestBinaryAndUnaryOperationsCollapseToStatics(t *testing.T) {
+	tests := []struct {
+		in       string
+		expected FieldExpression
+	}{
+		{in: "{ duration > 1 + 2}", expected: newBinaryOperation(OpGreater, NewIntrinsic(IntrinsicDuration), NewStaticInt(3))},
+		{in: "{ -1 }", expected: NewStaticInt(-1)},
+		{in: "{ 1 + 1 > 1 }", expected: NewStaticBool(true)},
+		{in: "{ `foo` = `bar` }", expected: NewStaticBool(false)},
+		{in: "{ 1 = 1. }", expected: NewStaticBool(true)}, // this is an interesting case, it returns true even though { span.foo = 1 } would be false if span.foo had the float value 1.0
+		{in: "{ .1 + 1 }", expected: NewStaticFloat(1.1)},
+	}
+
+	test := func(q string, expected FieldExpression) {
+		actual, err := Parse(q)
+		require.NoError(t, err, q)
+		require.Equal(t, newRootExpr(newPipeline(newSpansetFilter(expected))), actual, q)
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			test(tc.in, tc.expected)
+		})
+	}
+}
+
 func TestAttributes(t *testing.T) {
 	tests := []struct {
 		in       string

--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -571,27 +571,8 @@ func BenchmarkBackendBlockTraceQL(b *testing.B) {
 		query string
 	}{
 		// span
-		{"spanAttValMatch", "{ span.component = `net/http` }"},
-		{"spanAttValNoMatch", "{ span.bloom = `does-not-exit-6c2408325a45` }"},
-		{"spanAttIntrinsicMatch", "{ name = `/cortex.Ingester/Push` }"},
-		{"spanAttIntrinsicNoMatch", "{ name = `does-not-exit-6c2408325a45` }"},
-
-		// resource
-		{"resourceAttValMatch", "{ resource.opencensus.exporterversion = `Jaeger-Go-2.30.0` }"},
-		{"resourceAttValNoMatch", "{ resource.module.path = `does-not-exit-6c2408325a45` }"},
-		{"resourceAttIntrinsicMatch", "{ resource.service.name = `tempo-gateway` }"},
-		{"resourceAttIntrinsicMatch", "{ resource.service.name = `does-not-exit-6c2408325a45` }"},
-
-		// mixed
-		{"mixedValNoMatch", "{ .bloom = `does-not-exit-6c2408325a45` }"},
-		{"mixedValMixedMatchAnd", "{ resource.foo = `bar` && name = `gcs.ReadRange` }"},
-		{"mixedValMixedMatchOr", "{ resource.foo = `bar` || name = `gcs.ReadRange` }"},
-
-		{"count", "{ } | count() > 1"},
-		{"struct", "{ resource.service.name != `loki-querier` } >> { resource.service.name = `loki-gateway` && status = error }"},
-		{"||", "{ resource.service.name = `loki-querier` } || { resource.service.name = `loki-gateway` }"},
-		{"mixed", `{resource.namespace!="" && resource.service.name="cortex-gateway" && duration>50ms && resource.cluster=~"prod.*"}`},
-		{"complex", `{resource.cluster=~"prod.*" && resource.namespace = "tempo-prod" && resource.container="query-frontend" && name = "HTTP GET - tempo_api_v2_search_tags" && span.http.status_code = 200 && duration > 1s}`},
+		{"foo", "{ nestedSetParent = -1 }"},
+		{"bar", "{ nestedSetParent < 0 }"},
 	}
 
 	ctx := context.TODO()

--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -571,8 +571,27 @@ func BenchmarkBackendBlockTraceQL(b *testing.B) {
 		query string
 	}{
 		// span
-		{"foo", "{ nestedSetParent = -1 }"},
-		{"bar", "{ nestedSetParent < 0 }"},
+		{"spanAttValMatch", "{ span.component = `net/http` }"},
+		{"spanAttValNoMatch", "{ span.bloom = `does-not-exit-6c2408325a45` }"},
+		{"spanAttIntrinsicMatch", "{ name = `/cortex.Ingester/Push` }"},
+		{"spanAttIntrinsicNoMatch", "{ name = `does-not-exit-6c2408325a45` }"},
+
+		// resource
+		{"resourceAttValMatch", "{ resource.opencensus.exporterversion = `Jaeger-Go-2.30.0` }"},
+		{"resourceAttValNoMatch", "{ resource.module.path = `does-not-exit-6c2408325a45` }"},
+		{"resourceAttIntrinsicMatch", "{ resource.service.name = `tempo-gateway` }"},
+		{"resourceAttIntrinsicMatch", "{ resource.service.name = `does-not-exit-6c2408325a45` }"},
+
+		// mixed
+		{"mixedValNoMatch", "{ .bloom = `does-not-exit-6c2408325a45` }"},
+		{"mixedValMixedMatchAnd", "{ resource.foo = `bar` && name = `gcs.ReadRange` }"},
+		{"mixedValMixedMatchOr", "{ resource.foo = `bar` || name = `gcs.ReadRange` }"},
+
+		{"count", "{ } | count() > 1"},
+		{"struct", "{ resource.service.name != `loki-querier` } >> { resource.service.name = `loki-gateway` && status = error }"},
+		{"||", "{ resource.service.name = `loki-querier` } || { resource.service.name = `loki-gateway` }"},
+		{"mixed", `{resource.namespace!="" && resource.service.name="cortex-gateway" && duration>50ms && resource.cluster=~"prod.*"}`},
+		{"complex", `{resource.cluster=~"prod.*" && resource.namespace = "tempo-prod" && resource.container="query-frontend" && name = "HTTP GET - tempo_api_v2_search_tags" && span.http.status_code = 200 && duration > 1s}`},
 	}
 
 	ctx := context.TODO()

--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -20,7 +20,6 @@ import (
 	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	"github.com/grafana/tempo/pkg/traceql"
 	"github.com/grafana/tempo/pkg/traceqlmetrics"
-	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/pkg/util/test"
 	"github.com/grafana/tempo/pkg/util/traceidboundary"
 	"github.com/grafana/tempo/tempodb/backend"
@@ -70,7 +69,6 @@ func TestBackendBlockSearchTraceQL(t *testing.T) {
 
 	b := makeBackendBlockWithTraces(t, traces)
 	ctx := context.Background()
-	traceIDText := util.TraceIDToHexString(wantTraceID)
 
 	searchesThatMatch := []struct {
 		name string
@@ -109,7 +107,6 @@ func TestBackendBlockSearchTraceQL(t *testing.T) {
 		{"Intrinsic: status = 2", traceql.MustExtractFetchSpansRequestWithMetadata(`{` + LabelStatus + ` = 2}`)},
 		{"Intrinsic: statusMessage = STATUS_CODE_ERROR", traceql.MustExtractFetchSpansRequestWithMetadata(`{` + "statusMessage" + ` = "STATUS_CODE_ERROR"}`)},
 		{"Intrinsic: kind = client", traceql.MustExtractFetchSpansRequestWithMetadata(`{` + LabelKind + ` = client }`)},
-		{"Intrinsic: trace:id", traceql.MustExtractFetchSpansRequestWithMetadata(`{ trace:id = "` + traceIDText + `" }`)},
 		// Resource well-known attributes
 		{".service.name", traceql.MustExtractFetchSpansRequestWithMetadata(`{.` + LabelServiceName + ` = "spanservicename"}`)}, // Overridden at span},
 		{".cluster", traceql.MustExtractFetchSpansRequestWithMetadata(`{.` + LabelCluster + ` = "cluster"}`)},


### PR DESCRIPTION
**What this PR does**:
On creation of binary and unary operations this PR attempts to collapse values down to a single static where possible. This allows the fetch layer to directly apply predicates for conditions like `{ span.foo = 1 + 1 }` b/c they turn into `{ span.foo = 2 }`.

In order to make this PR work I needed to split out integer math from float. Currently the engine processes all values as floats. However, it's important not to change the type when collapsing or it breaks the fetch layer. `{ span.foo = 1 + 1 }` needs to collapse to `{ span.foo = 2 }` and not `{ span.foo = 2. }`

This has interesting consequences. Note the changed test. This used to be true `{ 1 / 10 = .1 }` but, due to integer division it is not. These two statements are now true: `{ 1 / 10. = .1 }` and `{ 1 / 10 = 0 }`. Overall I don't mind this. Generally TraceQL is quite strict about datatypes and this was an exception.

**Other options**

This whole exercise started when I noticed how bad performance was on `{ nestedSetParent = -1 }` which I realized was due to an `OpNone` condition being passed to the fetch layer instead of `OpEqual` and -1. In main -1 is parsed as an `UnaryOperation` with `OpSub` and 1.

We could just subtly change the parser by adding lines like these to fieldExpression:

```
  | fieldExpression AND fieldExpression      { $$ = newBinaryOperation(OpAnd, $1, $3) }
  | fieldExpression OR fieldExpression       { $$ = newBinaryOperation(OpOr, $1, $3) }
+ | SUB INTEGER                      { $$ = newStaticInt(-$2) }
+ | SUB FLOAT                      { $$ = newStaticFloat(-$2) }
  | SUB fieldExpression                      { $$ = newUnaryOperation(OpSub, $2) }
  | NOT fieldExpression                      { $$ = newUnaryOperation(OpNot, $2) }
  | static                                   { $$ = $1 }
```

This solves the -N case, but nothing else. It also introduces a lot of conflicts in the language, but testing suggests this is fine. Perhaps we prefer this b/c it imposes no other changes on TraceQL? Overall I prefer my proposed solution but am game to try the simpler thing.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`