### PR TITLE
Improve servicegraph handling of newer OTEL semantic conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [FEATURE] TraceQL support for event scope and event:name intrinsic [#3708](https://github.com/grafana/tempo/pull/3708) (@stoewer)
 * [FEATURE] Flush blocks to storage from the metrics-generator [#3628](https://github.com/grafana/tempo/pull/3628) [#3691](https://github.com/grafana/tempo/pull/3691) (@mapno)
+* [ENHANCEMENT] Improve use of OTEL semantic conventions on the service graph [#3711](https://github.com/grafana/tempo/pull/3711) (@zalegrala)
 
 ## v2.5.0-rc.1
 
@@ -58,7 +59,6 @@
 * [ENHANCEMENT] TraceQL - Add support for scoped intrinsics using `:` [#3629](https://github.com/grafana/tempo/pull/3629) (@ie-pham)
   available scoped intrinsics: trace:duration, trace:rootName, trace:rootService, span:duration, span:kind, span:name, span:status, span:statusMessage
 * [ENHANCEMENT] Performance improvements on TraceQL and tag value search. [#3650](https://github.com/grafana/tempo/pull/3650),[#3667](https://github.com/grafana/tempo/pull/3667) (@joe-elliott)
-* [ENHANCEMENT] Improve use of OTEL semantic conventions on the service graph [#3711](https://github.com/grafana/tempo/pull/3711) (@zalegrala)
 * [BUGFIX] Fix handling of regex matchers in autocomplete endpoints [#3641](https://github.com/grafana/tempo/pull/3641) (@sd2k)
 * [BUGFIX] Update golang.org/x/net package to 0.24.0 to fix CVE-2023-45288 [#3613](https://github.com/grafana/tempo/pull/3613) (@pavolloffay)
 * [BUGFIX] Fix metrics query results when filtering and rating on the same attribute [#3428](https://github.com/grafana/tempo/issues/3428) (@mdisibio)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * [ENHANCEMENT] TraceQL - Add support for scoped intrinsics using `:` [#3629](https://github.com/grafana/tempo/pull/3629) (@ie-pham)
   available scoped intrinsics: trace:duration, trace:rootName, trace:rootService, span:duration, span:kind, span:name, span:status, span:statusMessage
 * [ENHANCEMENT] Performance improvements on TraceQL and tag value search. [#3650](https://github.com/grafana/tempo/pull/3650),[#3667](https://github.com/grafana/tempo/pull/3667) (@joe-elliott)
+* [ENHANCEMENT] Improve use of OTEL semantic conventions on the service graph [#3711](https://github.com/grafana/tempo/pull/3711) (@zalegrala)
 * [BUGFIX] Fix handling of regex matchers in autocomplete endpoints [#3641](https://github.com/grafana/tempo/pull/3641) (@sd2k)
 * [BUGFIX] Update golang.org/x/net package to 0.24.0 to fix CVE-2023-45288 [#3613](https://github.com/grafana/tempo/pull/3613) (@pavolloffay)
 * [BUGFIX] Fix metrics query results when filtering and rating on the same attribute [#3428](https://github.com/grafana/tempo/issues/3428) (@mdisibio)

--- a/docs/sources/tempo/metrics-generator/service_graphs/_index.md
+++ b/docs/sources/tempo/metrics-generator/service_graphs/_index.md
@@ -58,7 +58,7 @@ Virtual nodes can be detected in two different ways:
 
 A database node is identified by the span having at least `db.name` or `db.system` attribute.
 
-The name of a database node is determined using the following span attributes in order of precedence: `peer.service`, `server.address`, `db.name`.
+The name of a database node is determined using the following span attributes in order of precedence: `peer.service`, `server.address`, `network.peer.address:network.peer.port`, `db.name`.
 
 ### Metrics
 

--- a/docs/sources/tempo/metrics-generator/service_graphs/_index.md
+++ b/docs/sources/tempo/metrics-generator/service_graphs/_index.md
@@ -33,7 +33,7 @@ The processor uses the [OpenTelemetry semantic conventions](https://github.com/o
 It currently supports the following requests:
 - A direct request between two services where the outgoing and the incoming span must have [`span.kind`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#spankind), `client`, and `server`, respectively.
 - A request across a messaging system where the outgoing and the incoming span must have `span.kind`, `producer`, and `consumer` respectively.
-- A database request; in this case the processor looks for spans containing attributes `span.kind`=`client` as well as `db.name`.
+- A database request; in this case the processor looks for spans containing attributes `span.kind`=`client` as well as one of `db.name` or `db.system`.  See below for how the name of the node is determined for a database request.
 
 Every span that can be paired up to form a request is kept in an in-memory store, until its corresponding pair span is received or the maximum waiting time has passed.
 When either of these conditions are reached, the request is recorded and removed from the local store.
@@ -55,6 +55,10 @@ Virtual nodes can be detected in two different ways:
 - A `client` span does not have its matching `server` span, but has a peer attribute present. In this case, we make the assumption that a call was made to an external service, for which Tempo won't receive spans.
    - The default peer attributes are `peer.service`, `db.name` and `db.system`.
    - The order of the attributes is important, as the first one that is present will be used as the virtual node name.
+
+A database node is identified by the span having at least `db.name` or `db.system` attribute.
+
+The name of a database node is determined using the following span attributes in order of precedence: `peer.service`, `server.address`, `db.name`.
 
 ### Metrics
 

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -323,6 +323,16 @@ func (p *Processor) upsertDatabaseRequest(e *store.Edge, resourceAttr []*v1_comm
 		return
 	}
 
+	// Check for network.peer.address and network.peer.port.  Use port if it is present.
+	if host, ok := processor_util.FindAttributeValue(string(semconv.NetworkPeerAddressKey), resourceAttr, span.Attributes); ok {
+		if port, ok := processor_util.FindAttributeValue(string(semconv.NetworkPeerPortKey), resourceAttr, span.Attributes); ok {
+			e.ServerService = fmt.Sprintf("%s:%s", host, port)
+			return
+		}
+		e.ServerService = host
+		return
+	}
+
 	// Fallback to db.name
 	if dbName != "" {
 		e.ServerService = dbName

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -280,6 +280,7 @@ func (p *Processor) upsertPeerNode(e *store.Edge, spanAttr []*v1_common.KeyValue
 //
 //	if we have a peer.service, use it as the database ServerService
 //	if we have a server.address, use it as the database ServerService
+//	if we have a network.peer.address, use it as the database ServerService.  Include :port if network.peer.port is present
 //	if we have a db.name, use it as the database ServerService, which is the backwards-compatible behavior
 func (p *Processor) upsertDatabaseRequest(e *store.Edge, resourceAttr []*v1_common.KeyValue, span *v1_trace.Span) {
 	var (

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/grafana/tempo/pkg/tempopb"
 )
 
-// This is a way to know if the contents of the semconv package have changed.
+// NOTE: This is a way to know if the contents of the semconv package have changed.
 // Since we rely on the key contents in the span attributes, we want to know if
 // there is ever a change to the ones we rely on.  This is not a complete test,
 // but just a quick way to know about changes upstream.
@@ -28,6 +28,9 @@ func TestSemconvKeys(t *testing.T) {
 	require.Equal(t, string(semconv.DBNameKey), "db.name")
 	require.Equal(t, string(semconv.DBSystemKey), "db.system")
 	require.Equal(t, string(semconv.PeerServiceKey), "peer.service")
+	require.Equal(t, string(semconv.NetworkPeerAddressKey), "network.peer.address")
+	require.Equal(t, string(semconv.NetworkPeerPortKey), "network.peer.port")
+	require.Equal(t, string(semconv.ServerAddressKey), "server.address")
 }
 
 func TestServiceGraphs(t *testing.T) {
@@ -307,6 +310,96 @@ func TestServiceGraphs_virtualNodesExtraLabelsForUninstrumentedServices(t *testi
 
 	assert.Equal(t, 1.0, testRegistry.Query(`traces_service_graph_request_total`, clientToVirtualPeerLabels))
 	assert.Equal(t, 0.0, testRegistry.Query(`traces_service_graph_request_failed_total`, clientToVirtualPeerLabels))
+}
+
+func TestServiceGraphs_databaseVirtualNodes(t *testing.T) {
+	cases := []struct {
+		name           string
+		fixturePath    string
+		databaseLabels labels.Labels
+		total          float64
+		errors         float64
+	}{
+		{
+			name:        "virtualNodesWithoutDatabase",
+			fixturePath: "testdata/trace-with-virtual-nodes.json",
+			databaseLabels: labels.FromMap(map[string]string{
+				"client":          "mythical-server",
+				"server":          "mythical-database",
+				"connection_type": "database",
+			}),
+			total:  0.0,
+			errors: 0.0,
+		},
+		{
+			name:        "semconv118",
+			fixturePath: "testdata/trace-with-queue-database.json",
+			databaseLabels: labels.FromMap(map[string]string{
+				"client":          "mythical-server",
+				"server":          "postgres",
+				"connection_type": "database",
+			}),
+			total:  1.0,
+			errors: 0.0,
+		},
+		{
+			name:        "semconv125",
+			fixturePath: "testdata/trace-with-queue-database2.json",
+			databaseLabels: labels.FromMap(map[string]string{
+				"client":          "mythical-server",
+				"server":          "mythical-database",
+				"connection_type": "database",
+			}),
+			total:  1.0,
+			errors: 0.0,
+		},
+		{
+			name:        "semconv125PeerService",
+			fixturePath: "testdata/trace-with-queue-database3.json",
+			databaseLabels: labels.FromMap(map[string]string{
+				"client":          "mythical-server",
+				"server":          "mythical-database",
+				"connection_type": "database",
+			}),
+			total:  1.0,
+			errors: 0.0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			testRegistry := registry.NewTestRegistry()
+
+			cfg := Config{}
+			cfg.RegisterFlagsAndApplyDefaults("", nil)
+
+			cfg.HistogramBuckets = []float64{0.04}
+			cfg.EnableMessagingSystemLatencyHistogram = true
+
+			p := New(cfg, "test", testRegistry, log.NewNopLogger())
+			defer p.Shutdown(context.Background())
+
+			request, err := loadTestData(tc.fixturePath)
+			require.NoError(t, err)
+
+			p.PushSpans(context.Background(), request)
+
+			// counters
+			assert.Equal(t, tc.total, testRegistry.Query(`traces_service_graph_request_total`, tc.databaseLabels))
+			assert.Equal(t, tc.errors, testRegistry.Query(`traces_service_graph_request_failed_total`, tc.databaseLabels))
+
+			// histograms
+			assert.Equal(t, tc.total, testRegistry.Query(`traces_service_graph_request_client_seconds_bucket`, withLe(tc.databaseLabels, 0.04)))
+			assert.Equal(t, tc.total, testRegistry.Query(`traces_service_graph_request_client_seconds_bucket`, withLe(tc.databaseLabels, math.Inf(1))))
+			assert.Equal(t, tc.total, testRegistry.Query(`traces_service_graph_request_client_seconds_count`, tc.databaseLabels))
+			// assert.InDelta(t, 0.023, testRegistry.Query(`traces_service_graph_request_client_seconds_sum`, tc.databaseLabels), 0.001)
+
+			assert.Equal(t, tc.total, testRegistry.Query(`traces_service_graph_request_server_seconds_bucket`, withLe(tc.databaseLabels, 0.04)))
+			assert.Equal(t, tc.total, testRegistry.Query(`traces_service_graph_request_server_seconds_bucket`, withLe(tc.databaseLabels, math.Inf(1))))
+			assert.Equal(t, tc.total, testRegistry.Query(`traces_service_graph_request_server_seconds_count`, tc.databaseLabels))
+			// assert.InDelta(t, 0.023, testRegistry.Query(`traces_service_graph_request_server_seconds_sum`, tc.databaseLabels), 0.001)
+		})
+	}
 }
 
 func TestServiceGraphs_prefixDimensionsAndEnableExtraLabels(t *testing.T) {

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -332,6 +332,17 @@ func TestServiceGraphs_databaseVirtualNodes(t *testing.T) {
 			errors: 0.0,
 		},
 		{
+			name:        "withoutDatabaseName",
+			fixturePath: "testdata/trace-without-database-name.json",
+			databaseLabels: labels.FromMap(map[string]string{
+				"client":          "mythical-server",
+				"server":          "mythical-database",
+				"connection_type": "database",
+			}),
+			total:  1.0,
+			errors: 0.0,
+		},
+		{
 			name:        "semconv118",
 			fixturePath: "testdata/trace-with-queue-database.json",
 			databaseLabels: labels.FromMap(map[string]string{
@@ -365,11 +376,22 @@ func TestServiceGraphs_databaseVirtualNodes(t *testing.T) {
 			errors: 0.0,
 		},
 		{
-			name:        "semconv125NetworkPeer",
+			name:        "semconv125NetworkPeerWithPort",
 			fixturePath: "testdata/trace-with-queue-database4.json",
 			databaseLabels: labels.FromMap(map[string]string{
 				"client":          "mythical-server",
 				"server":          "mythical-database:5432",
+				"connection_type": "database",
+			}),
+			total:  1.0,
+			errors: 0.0,
+		},
+		{
+			name:        "semconv125NetworkPeerWithoutPort",
+			fixturePath: "testdata/trace-with-queue-database5.json",
+			databaseLabels: labels.FromMap(map[string]string{
+				"client":          "mythical-server",
+				"server":          "mythical-database",
 				"connection_type": "database",
 			}),
 			total:  1.0,

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -364,6 +364,17 @@ func TestServiceGraphs_databaseVirtualNodes(t *testing.T) {
 			total:  1.0,
 			errors: 0.0,
 		},
+		{
+			name:        "semconv125NetworkPeer",
+			fixturePath: "testdata/trace-with-queue-database4.json",
+			databaseLabels: labels.FromMap(map[string]string{
+				"client":          "mythical-server",
+				"server":          "mythical-database:5432",
+				"connection_type": "database",
+			}),
+			total:  1.0,
+			errors: 0.0,
+		},
 	}
 
 	for _, tc := range cases {

--- a/modules/generator/processor/servicegraphs/testdata/trace-with-queue-database2.json
+++ b/modules/generator/processor/servicegraphs/testdata/trace-with-queue-database2.json
@@ -1,0 +1,1662 @@
+{
+  "batches": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "1gZXnld4dYc=",
+              "name": "requester",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854877522688",
+              "endTimeUnixNano": "1658320854923357184",
+              "attributes": [
+                {
+                  "key": "beast",
+                  "value": {
+                    "stringValue": "manticore"
+                  }
+                },
+                {
+                  "key": "god",
+                  "value": {
+                    "stringValue": "ares"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "U/Mym4Y9qV0=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854877839616",
+              "endTimeUnixNano": "1658320854878545408",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-server"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "4000"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "46950"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-http",
+            "version": "0.27.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "mZKWiJfzyEY=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "GET /:endpoint",
+              "kind": "SPAN_KIND_SERVER",
+              "startTimeUnixNano": "1658320854878927360",
+              "endTimeUnixNano": "1658320854908913408",
+              "attributes": [
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://mythical-server:4000/manticore"
+                  }
+                },
+                {
+                  "key": "http.host",
+                  "value": {
+                    "stringValue": "mythical-server:4000"
+                  }
+                },
+                {
+                  "key": "net.host.name",
+                  "value": {
+                    "stringValue": "mythical-server"
+                  }
+                },
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "http.target",
+                  "value": {
+                    "stringValue": "/manticore"
+                  }
+                },
+                {
+                  "key": "http.flavor",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                },
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "god",
+                  "value": {
+                    "stringValue": "zeus"
+                  }
+                },
+                {
+                  "key": "beast",
+                  "value": {
+                    "stringValue": "manticore"
+                  }
+                },
+                {
+                  "key": "span.kind",
+                  "value": {
+                    "intValue": "2"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "::ffff:172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "4000"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "::ffff:172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "46950"
+                  }
+                },
+                {
+                  "key": "http.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                },
+                {
+                  "key": "http.status_text",
+                  "value": {
+                    "stringValue": "OK"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "A38EGjeny0Y=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - query",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879122688",
+              "endTimeUnixNano": "1658320854879143680",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "query"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "7eLzskA9GzQ=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - expressInit",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879322624",
+              "endTimeUnixNano": "1658320854879355136",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "expressInit"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "I+ErHCWWzIw=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - jsonParser",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879422208",
+              "endTimeUnixNano": "1658320854879444480",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "jsonParser"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "w4/Ni3Fq4S4=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "request handler - /:endpoint",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879524608",
+              "endTimeUnixNano": "1658320854879526400",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "request_handler"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-pg",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "JT4hL+I0IWw=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "pg.query:SELECT",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854879610624",
+              "endTimeUnixNano": "1658320854903392000",
+              "attributes": [
+                {
+                  "key": "db.name",
+                  "value": {
+                    "stringValue": "postgres"
+                  }
+                },
+                {
+                  "key": "db.system",
+                  "value": {
+                    "stringValue": "postgresql"
+                  }
+                },
+                {
+                  "key": "db.connection_string",
+                  "value": {
+                    "stringValue": "jdbc:postgresql://mythical-database:5432/postgres"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "mythical-database"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "5432"
+                  }
+                },
+                {
+                  "key": "db.user",
+                  "value": {
+                    "stringValue": "postgres"
+                  }
+                },
+                {
+                  "key": "db.statement",
+                  "value": {
+                    "stringValue": "SELECT name from manticore"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-http",
+            "version": "0.27.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "Iq8HyyCGMcA=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "HTTP POST",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854909347584",
+              "endTimeUnixNano": "1658320854913202688",
+              "attributes": [
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://loki:3100/loki/api/v1/push"
+                  }
+                },
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "POST"
+                  }
+                },
+                {
+                  "key": "http.target",
+                  "value": {
+                    "stringValue": "/loki/api/v1/push"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "3100"
+                  }
+                },
+                {
+                  "key": "http.host",
+                  "value": {
+                    "stringValue": "loki:3100"
+                  }
+                },
+                {
+                  "key": "http.status_code",
+                  "value": {
+                    "intValue": "204"
+                  }
+                },
+                {
+                  "key": "http.status_text",
+                  "value": {
+                    "stringValue": "NO CONTENT"
+                  }
+                },
+                {
+                  "key": "http.flavor",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                },
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "5xenytYWGCM=",
+              "parentSpanId": "Iq8HyyCGMcA=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854909465856",
+              "endTimeUnixNano": "1658320854911322112",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "51090"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-dns",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "G1lOVPULKHA=",
+              "parentSpanId": "Iq8HyyCGMcA=",
+              "name": "dns.lookup",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854909490688",
+              "endTimeUnixNano": "1658320854910292992",
+              "attributes": [
+                {
+                  "key": "peer.ipv4",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "oMg46pqD9yY=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "publish_to_queue",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854915519232",
+              "endTimeUnixNano": "1658320854916681216",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-amqplib",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "CbyBh8ln9LQ=",
+              "parentSpanId": "oMg46pqD9yY=",
+              "name": "<default> -> messages send",
+              "kind": "SPAN_KIND_PRODUCER",
+              "startTimeUnixNano": "1658320854915559936",
+              "endTimeUnixNano": "1658320854915628800",
+              "attributes": [
+                {
+                  "key": "messaging.protocol_version",
+                  "value": {
+                    "stringValue": "0.9.1"
+                  }
+                },
+                {
+                  "key": "messaging.url",
+                  "value": {
+                    "stringValue": "amqp://mythical-queue"
+                  }
+                },
+                {
+                  "key": "messaging.protocol",
+                  "value": {
+                    "stringValue": "AMQP"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-queue"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "5672"
+                  }
+                },
+                {
+                  "key": "messaging.system",
+                  "value": {
+                    "stringValue": "rabbitmq"
+                  }
+                },
+                {
+                  "key": "messaging.destination",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "messaging.destination_kind",
+                  "value": {
+                    "stringValue": "topic"
+                  }
+                },
+                {
+                  "key": "messaging.rabbitmq.routing_key",
+                  "value": {
+                    "stringValue": "messages"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "HZ43ugub274=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "log_to_loki",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854916730624",
+              "endTimeUnixNano": "1658320854930536704",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "ByBJTXxe2aI=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "log_to_loki",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854923263232",
+              "endTimeUnixNano": "1658320854929491200",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "ivrh44gllP0=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854923789312",
+              "endTimeUnixNano": "1658320854925569280",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "41594"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "o/mJQtsdDeE=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854924354560",
+              "endTimeUnixNano": "1658320854925760768",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "41596"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-recorder"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-amqplib",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "qMP7VjNGIK8=",
+              "parentSpanId": "CbyBh8ln9LQ=",
+              "name": "messages process",
+              "kind": "SPAN_KIND_CONSUMER",
+              "startTimeUnixNano": "1658320854925510400",
+              "endTimeUnixNano": "1658320854926209792",
+              "attributes": [
+                {
+                  "key": "messaging.protocol_version",
+                  "value": {
+                    "stringValue": "0.9.1"
+                  }
+                },
+                {
+                  "key": "messaging.url",
+                  "value": {
+                    "stringValue": "amqp://mythical-queue"
+                  }
+                },
+                {
+                  "key": "messaging.protocol",
+                  "value": {
+                    "stringValue": "AMQP"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-queue"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "5672"
+                  }
+                },
+                {
+                  "key": "messaging.system",
+                  "value": {
+                    "stringValue": "rabbitmq"
+                  }
+                },
+                {
+                  "key": "messaging.destination",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "messaging.destination_kind",
+                  "value": {
+                    "stringValue": "topic"
+                  }
+                },
+                {
+                  "key": "messaging.rabbitmq.routing_key",
+                  "value": {
+                    "stringValue": "messages"
+                  }
+                },
+                {
+                  "key": "messaging.operation",
+                  "value": {
+                    "stringValue": "process"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-recorder"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-recorder"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "j9WiKB5PGKw=",
+              "parentSpanId": "qMP7VjNGIK8=",
+              "name": "process_message",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854925532928",
+              "endTimeUnixNano": "1658320854963292160",
+              "status": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/modules/generator/processor/servicegraphs/testdata/trace-with-queue-database3.json
+++ b/modules/generator/processor/servicegraphs/testdata/trace-with-queue-database3.json
@@ -1,0 +1,1662 @@
+{
+  "batches": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "1gZXnld4dYc=",
+              "name": "requester",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854877522688",
+              "endTimeUnixNano": "1658320854923357184",
+              "attributes": [
+                {
+                  "key": "beast",
+                  "value": {
+                    "stringValue": "manticore"
+                  }
+                },
+                {
+                  "key": "god",
+                  "value": {
+                    "stringValue": "ares"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "U/Mym4Y9qV0=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854877839616",
+              "endTimeUnixNano": "1658320854878545408",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-server"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "4000"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "46950"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-http",
+            "version": "0.27.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "mZKWiJfzyEY=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "GET /:endpoint",
+              "kind": "SPAN_KIND_SERVER",
+              "startTimeUnixNano": "1658320854878927360",
+              "endTimeUnixNano": "1658320854908913408",
+              "attributes": [
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://mythical-server:4000/manticore"
+                  }
+                },
+                {
+                  "key": "http.host",
+                  "value": {
+                    "stringValue": "mythical-server:4000"
+                  }
+                },
+                {
+                  "key": "net.host.name",
+                  "value": {
+                    "stringValue": "mythical-server"
+                  }
+                },
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "http.target",
+                  "value": {
+                    "stringValue": "/manticore"
+                  }
+                },
+                {
+                  "key": "http.flavor",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                },
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "god",
+                  "value": {
+                    "stringValue": "zeus"
+                  }
+                },
+                {
+                  "key": "beast",
+                  "value": {
+                    "stringValue": "manticore"
+                  }
+                },
+                {
+                  "key": "span.kind",
+                  "value": {
+                    "intValue": "2"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "::ffff:172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "4000"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "::ffff:172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "46950"
+                  }
+                },
+                {
+                  "key": "http.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                },
+                {
+                  "key": "http.status_text",
+                  "value": {
+                    "stringValue": "OK"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "A38EGjeny0Y=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - query",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879122688",
+              "endTimeUnixNano": "1658320854879143680",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "query"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "7eLzskA9GzQ=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - expressInit",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879322624",
+              "endTimeUnixNano": "1658320854879355136",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "expressInit"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "I+ErHCWWzIw=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - jsonParser",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879422208",
+              "endTimeUnixNano": "1658320854879444480",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "jsonParser"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "w4/Ni3Fq4S4=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "request handler - /:endpoint",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879524608",
+              "endTimeUnixNano": "1658320854879526400",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "request_handler"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-pg",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "JT4hL+I0IWw=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "pg.query:SELECT",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854879610624",
+              "endTimeUnixNano": "1658320854903392000",
+              "attributes": [
+                {
+                  "key": "db.name",
+                  "value": {
+                    "stringValue": "postgres"
+                  }
+                },
+                {
+                  "key": "db.system",
+                  "value": {
+                    "stringValue": "postgresql"
+                  }
+                },
+                {
+                  "key": "db.connection_string",
+                  "value": {
+                    "stringValue": "jdbc:postgresql://mythical-database:5432/postgres"
+                  }
+                },
+                {
+                  "key": "peer.service",
+                  "value": {
+                    "stringValue": "mythical-database"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "5432"
+                  }
+                },
+                {
+                  "key": "db.user",
+                  "value": {
+                    "stringValue": "postgres"
+                  }
+                },
+                {
+                  "key": "db.statement",
+                  "value": {
+                    "stringValue": "SELECT name from manticore"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-http",
+            "version": "0.27.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "Iq8HyyCGMcA=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "HTTP POST",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854909347584",
+              "endTimeUnixNano": "1658320854913202688",
+              "attributes": [
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://loki:3100/loki/api/v1/push"
+                  }
+                },
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "POST"
+                  }
+                },
+                {
+                  "key": "http.target",
+                  "value": {
+                    "stringValue": "/loki/api/v1/push"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "3100"
+                  }
+                },
+                {
+                  "key": "http.host",
+                  "value": {
+                    "stringValue": "loki:3100"
+                  }
+                },
+                {
+                  "key": "http.status_code",
+                  "value": {
+                    "intValue": "204"
+                  }
+                },
+                {
+                  "key": "http.status_text",
+                  "value": {
+                    "stringValue": "NO CONTENT"
+                  }
+                },
+                {
+                  "key": "http.flavor",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                },
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "5xenytYWGCM=",
+              "parentSpanId": "Iq8HyyCGMcA=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854909465856",
+              "endTimeUnixNano": "1658320854911322112",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "51090"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-dns",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "G1lOVPULKHA=",
+              "parentSpanId": "Iq8HyyCGMcA=",
+              "name": "dns.lookup",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854909490688",
+              "endTimeUnixNano": "1658320854910292992",
+              "attributes": [
+                {
+                  "key": "peer.ipv4",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "oMg46pqD9yY=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "publish_to_queue",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854915519232",
+              "endTimeUnixNano": "1658320854916681216",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-amqplib",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "CbyBh8ln9LQ=",
+              "parentSpanId": "oMg46pqD9yY=",
+              "name": "<default> -> messages send",
+              "kind": "SPAN_KIND_PRODUCER",
+              "startTimeUnixNano": "1658320854915559936",
+              "endTimeUnixNano": "1658320854915628800",
+              "attributes": [
+                {
+                  "key": "messaging.protocol_version",
+                  "value": {
+                    "stringValue": "0.9.1"
+                  }
+                },
+                {
+                  "key": "messaging.url",
+                  "value": {
+                    "stringValue": "amqp://mythical-queue"
+                  }
+                },
+                {
+                  "key": "messaging.protocol",
+                  "value": {
+                    "stringValue": "AMQP"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-queue"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "5672"
+                  }
+                },
+                {
+                  "key": "messaging.system",
+                  "value": {
+                    "stringValue": "rabbitmq"
+                  }
+                },
+                {
+                  "key": "messaging.destination",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "messaging.destination_kind",
+                  "value": {
+                    "stringValue": "topic"
+                  }
+                },
+                {
+                  "key": "messaging.rabbitmq.routing_key",
+                  "value": {
+                    "stringValue": "messages"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "HZ43ugub274=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "log_to_loki",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854916730624",
+              "endTimeUnixNano": "1658320854930536704",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "ByBJTXxe2aI=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "log_to_loki",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854923263232",
+              "endTimeUnixNano": "1658320854929491200",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "ivrh44gllP0=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854923789312",
+              "endTimeUnixNano": "1658320854925569280",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "41594"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "o/mJQtsdDeE=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854924354560",
+              "endTimeUnixNano": "1658320854925760768",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "41596"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-recorder"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-amqplib",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "qMP7VjNGIK8=",
+              "parentSpanId": "CbyBh8ln9LQ=",
+              "name": "messages process",
+              "kind": "SPAN_KIND_CONSUMER",
+              "startTimeUnixNano": "1658320854925510400",
+              "endTimeUnixNano": "1658320854926209792",
+              "attributes": [
+                {
+                  "key": "messaging.protocol_version",
+                  "value": {
+                    "stringValue": "0.9.1"
+                  }
+                },
+                {
+                  "key": "messaging.url",
+                  "value": {
+                    "stringValue": "amqp://mythical-queue"
+                  }
+                },
+                {
+                  "key": "messaging.protocol",
+                  "value": {
+                    "stringValue": "AMQP"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-queue"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "5672"
+                  }
+                },
+                {
+                  "key": "messaging.system",
+                  "value": {
+                    "stringValue": "rabbitmq"
+                  }
+                },
+                {
+                  "key": "messaging.destination",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "messaging.destination_kind",
+                  "value": {
+                    "stringValue": "topic"
+                  }
+                },
+                {
+                  "key": "messaging.rabbitmq.routing_key",
+                  "value": {
+                    "stringValue": "messages"
+                  }
+                },
+                {
+                  "key": "messaging.operation",
+                  "value": {
+                    "stringValue": "process"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-recorder"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-recorder"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "j9WiKB5PGKw=",
+              "parentSpanId": "qMP7VjNGIK8=",
+              "name": "process_message",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854925532928",
+              "endTimeUnixNano": "1658320854963292160",
+              "status": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/modules/generator/processor/servicegraphs/testdata/trace-with-queue-database4.json
+++ b/modules/generator/processor/servicegraphs/testdata/trace-with-queue-database4.json
@@ -1,0 +1,1662 @@
+{
+  "batches": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "1gZXnld4dYc=",
+              "name": "requester",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854877522688",
+              "endTimeUnixNano": "1658320854923357184",
+              "attributes": [
+                {
+                  "key": "beast",
+                  "value": {
+                    "stringValue": "manticore"
+                  }
+                },
+                {
+                  "key": "god",
+                  "value": {
+                    "stringValue": "ares"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "U/Mym4Y9qV0=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854877839616",
+              "endTimeUnixNano": "1658320854878545408",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-server"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "4000"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "46950"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-http",
+            "version": "0.27.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "mZKWiJfzyEY=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "GET /:endpoint",
+              "kind": "SPAN_KIND_SERVER",
+              "startTimeUnixNano": "1658320854878927360",
+              "endTimeUnixNano": "1658320854908913408",
+              "attributes": [
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://mythical-server:4000/manticore"
+                  }
+                },
+                {
+                  "key": "http.host",
+                  "value": {
+                    "stringValue": "mythical-server:4000"
+                  }
+                },
+                {
+                  "key": "net.host.name",
+                  "value": {
+                    "stringValue": "mythical-server"
+                  }
+                },
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "http.target",
+                  "value": {
+                    "stringValue": "/manticore"
+                  }
+                },
+                {
+                  "key": "http.flavor",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                },
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "god",
+                  "value": {
+                    "stringValue": "zeus"
+                  }
+                },
+                {
+                  "key": "beast",
+                  "value": {
+                    "stringValue": "manticore"
+                  }
+                },
+                {
+                  "key": "span.kind",
+                  "value": {
+                    "intValue": "2"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "::ffff:172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "4000"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "::ffff:172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "46950"
+                  }
+                },
+                {
+                  "key": "http.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                },
+                {
+                  "key": "http.status_text",
+                  "value": {
+                    "stringValue": "OK"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "A38EGjeny0Y=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - query",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879122688",
+              "endTimeUnixNano": "1658320854879143680",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "query"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "7eLzskA9GzQ=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - expressInit",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879322624",
+              "endTimeUnixNano": "1658320854879355136",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "expressInit"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "I+ErHCWWzIw=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - jsonParser",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879422208",
+              "endTimeUnixNano": "1658320854879444480",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "jsonParser"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "w4/Ni3Fq4S4=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "request handler - /:endpoint",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879524608",
+              "endTimeUnixNano": "1658320854879526400",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "request_handler"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-pg",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "JT4hL+I0IWw=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "pg.query:SELECT",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854879610624",
+              "endTimeUnixNano": "1658320854903392000",
+              "attributes": [
+                {
+                  "key": "db.name",
+                  "value": {
+                    "stringValue": "postgres"
+                  }
+                },
+                {
+                  "key": "db.system",
+                  "value": {
+                    "stringValue": "postgresql"
+                  }
+                },
+                {
+                  "key": "db.connection_string",
+                  "value": {
+                    "stringValue": "jdbc:postgresql://mythical-database:5432/postgres"
+                  }
+                },
+                {
+                  "key": "network.peer.address",
+                  "value": {
+                    "stringValue": "mythical-database"
+                  }
+                },
+                {
+                  "key": "network.peer.port",
+                  "value": {
+                    "intValue": "5432"
+                  }
+                },
+                {
+                  "key": "db.user",
+                  "value": {
+                    "stringValue": "postgres"
+                  }
+                },
+                {
+                  "key": "db.statement",
+                  "value": {
+                    "stringValue": "SELECT name from manticore"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-http",
+            "version": "0.27.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "Iq8HyyCGMcA=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "HTTP POST",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854909347584",
+              "endTimeUnixNano": "1658320854913202688",
+              "attributes": [
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://loki:3100/loki/api/v1/push"
+                  }
+                },
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "POST"
+                  }
+                },
+                {
+                  "key": "http.target",
+                  "value": {
+                    "stringValue": "/loki/api/v1/push"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "3100"
+                  }
+                },
+                {
+                  "key": "http.host",
+                  "value": {
+                    "stringValue": "loki:3100"
+                  }
+                },
+                {
+                  "key": "http.status_code",
+                  "value": {
+                    "intValue": "204"
+                  }
+                },
+                {
+                  "key": "http.status_text",
+                  "value": {
+                    "stringValue": "NO CONTENT"
+                  }
+                },
+                {
+                  "key": "http.flavor",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                },
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "5xenytYWGCM=",
+              "parentSpanId": "Iq8HyyCGMcA=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854909465856",
+              "endTimeUnixNano": "1658320854911322112",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "51090"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-dns",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "G1lOVPULKHA=",
+              "parentSpanId": "Iq8HyyCGMcA=",
+              "name": "dns.lookup",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854909490688",
+              "endTimeUnixNano": "1658320854910292992",
+              "attributes": [
+                {
+                  "key": "peer.ipv4",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "oMg46pqD9yY=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "publish_to_queue",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854915519232",
+              "endTimeUnixNano": "1658320854916681216",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-amqplib",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "CbyBh8ln9LQ=",
+              "parentSpanId": "oMg46pqD9yY=",
+              "name": "<default> -> messages send",
+              "kind": "SPAN_KIND_PRODUCER",
+              "startTimeUnixNano": "1658320854915559936",
+              "endTimeUnixNano": "1658320854915628800",
+              "attributes": [
+                {
+                  "key": "messaging.protocol_version",
+                  "value": {
+                    "stringValue": "0.9.1"
+                  }
+                },
+                {
+                  "key": "messaging.url",
+                  "value": {
+                    "stringValue": "amqp://mythical-queue"
+                  }
+                },
+                {
+                  "key": "messaging.protocol",
+                  "value": {
+                    "stringValue": "AMQP"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-queue"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "5672"
+                  }
+                },
+                {
+                  "key": "messaging.system",
+                  "value": {
+                    "stringValue": "rabbitmq"
+                  }
+                },
+                {
+                  "key": "messaging.destination",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "messaging.destination_kind",
+                  "value": {
+                    "stringValue": "topic"
+                  }
+                },
+                {
+                  "key": "messaging.rabbitmq.routing_key",
+                  "value": {
+                    "stringValue": "messages"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "HZ43ugub274=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "log_to_loki",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854916730624",
+              "endTimeUnixNano": "1658320854930536704",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "ByBJTXxe2aI=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "log_to_loki",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854923263232",
+              "endTimeUnixNano": "1658320854929491200",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "ivrh44gllP0=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854923789312",
+              "endTimeUnixNano": "1658320854925569280",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "41594"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "o/mJQtsdDeE=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854924354560",
+              "endTimeUnixNano": "1658320854925760768",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "41596"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-recorder"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-amqplib",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "qMP7VjNGIK8=",
+              "parentSpanId": "CbyBh8ln9LQ=",
+              "name": "messages process",
+              "kind": "SPAN_KIND_CONSUMER",
+              "startTimeUnixNano": "1658320854925510400",
+              "endTimeUnixNano": "1658320854926209792",
+              "attributes": [
+                {
+                  "key": "messaging.protocol_version",
+                  "value": {
+                    "stringValue": "0.9.1"
+                  }
+                },
+                {
+                  "key": "messaging.url",
+                  "value": {
+                    "stringValue": "amqp://mythical-queue"
+                  }
+                },
+                {
+                  "key": "messaging.protocol",
+                  "value": {
+                    "stringValue": "AMQP"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-queue"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "5672"
+                  }
+                },
+                {
+                  "key": "messaging.system",
+                  "value": {
+                    "stringValue": "rabbitmq"
+                  }
+                },
+                {
+                  "key": "messaging.destination",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "messaging.destination_kind",
+                  "value": {
+                    "stringValue": "topic"
+                  }
+                },
+                {
+                  "key": "messaging.rabbitmq.routing_key",
+                  "value": {
+                    "stringValue": "messages"
+                  }
+                },
+                {
+                  "key": "messaging.operation",
+                  "value": {
+                    "stringValue": "process"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-recorder"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-recorder"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "j9WiKB5PGKw=",
+              "parentSpanId": "qMP7VjNGIK8=",
+              "name": "process_message",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854925532928",
+              "endTimeUnixNano": "1658320854963292160",
+              "status": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/modules/generator/processor/servicegraphs/testdata/trace-with-queue-database5.json
+++ b/modules/generator/processor/servicegraphs/testdata/trace-with-queue-database5.json
@@ -1,0 +1,1656 @@
+{
+  "batches": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "1gZXnld4dYc=",
+              "name": "requester",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854877522688",
+              "endTimeUnixNano": "1658320854923357184",
+              "attributes": [
+                {
+                  "key": "beast",
+                  "value": {
+                    "stringValue": "manticore"
+                  }
+                },
+                {
+                  "key": "god",
+                  "value": {
+                    "stringValue": "ares"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "U/Mym4Y9qV0=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854877839616",
+              "endTimeUnixNano": "1658320854878545408",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-server"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "4000"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "46950"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-http",
+            "version": "0.27.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "mZKWiJfzyEY=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "GET /:endpoint",
+              "kind": "SPAN_KIND_SERVER",
+              "startTimeUnixNano": "1658320854878927360",
+              "endTimeUnixNano": "1658320854908913408",
+              "attributes": [
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://mythical-server:4000/manticore"
+                  }
+                },
+                {
+                  "key": "http.host",
+                  "value": {
+                    "stringValue": "mythical-server:4000"
+                  }
+                },
+                {
+                  "key": "net.host.name",
+                  "value": {
+                    "stringValue": "mythical-server"
+                  }
+                },
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "http.target",
+                  "value": {
+                    "stringValue": "/manticore"
+                  }
+                },
+                {
+                  "key": "http.flavor",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                },
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "god",
+                  "value": {
+                    "stringValue": "zeus"
+                  }
+                },
+                {
+                  "key": "beast",
+                  "value": {
+                    "stringValue": "manticore"
+                  }
+                },
+                {
+                  "key": "span.kind",
+                  "value": {
+                    "intValue": "2"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "::ffff:172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "4000"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "::ffff:172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "46950"
+                  }
+                },
+                {
+                  "key": "http.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                },
+                {
+                  "key": "http.status_text",
+                  "value": {
+                    "stringValue": "OK"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "A38EGjeny0Y=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - query",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879122688",
+              "endTimeUnixNano": "1658320854879143680",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "query"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "7eLzskA9GzQ=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - expressInit",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879322624",
+              "endTimeUnixNano": "1658320854879355136",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "expressInit"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "I+ErHCWWzIw=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - jsonParser",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879422208",
+              "endTimeUnixNano": "1658320854879444480",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "jsonParser"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "w4/Ni3Fq4S4=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "request handler - /:endpoint",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879524608",
+              "endTimeUnixNano": "1658320854879526400",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "request_handler"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-pg",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "JT4hL+I0IWw=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "pg.query:SELECT",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854879610624",
+              "endTimeUnixNano": "1658320854903392000",
+              "attributes": [
+                {
+                  "key": "db.name",
+                  "value": {
+                    "stringValue": "postgres"
+                  }
+                },
+                {
+                  "key": "db.system",
+                  "value": {
+                    "stringValue": "postgresql"
+                  }
+                },
+                {
+                  "key": "db.connection_string",
+                  "value": {
+                    "stringValue": "jdbc:postgresql://mythical-database:5432/postgres"
+                  }
+                },
+                {
+                  "key": "network.peer.address",
+                  "value": {
+                    "stringValue": "mythical-database"
+                  }
+                },
+                {
+                  "key": "db.user",
+                  "value": {
+                    "stringValue": "postgres"
+                  }
+                },
+                {
+                  "key": "db.statement",
+                  "value": {
+                    "stringValue": "SELECT name from manticore"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-http",
+            "version": "0.27.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "Iq8HyyCGMcA=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "HTTP POST",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854909347584",
+              "endTimeUnixNano": "1658320854913202688",
+              "attributes": [
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://loki:3100/loki/api/v1/push"
+                  }
+                },
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "POST"
+                  }
+                },
+                {
+                  "key": "http.target",
+                  "value": {
+                    "stringValue": "/loki/api/v1/push"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "3100"
+                  }
+                },
+                {
+                  "key": "http.host",
+                  "value": {
+                    "stringValue": "loki:3100"
+                  }
+                },
+                {
+                  "key": "http.status_code",
+                  "value": {
+                    "intValue": "204"
+                  }
+                },
+                {
+                  "key": "http.status_text",
+                  "value": {
+                    "stringValue": "NO CONTENT"
+                  }
+                },
+                {
+                  "key": "http.flavor",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                },
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "5xenytYWGCM=",
+              "parentSpanId": "Iq8HyyCGMcA=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854909465856",
+              "endTimeUnixNano": "1658320854911322112",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "51090"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-dns",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "G1lOVPULKHA=",
+              "parentSpanId": "Iq8HyyCGMcA=",
+              "name": "dns.lookup",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854909490688",
+              "endTimeUnixNano": "1658320854910292992",
+              "attributes": [
+                {
+                  "key": "peer.ipv4",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "oMg46pqD9yY=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "publish_to_queue",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854915519232",
+              "endTimeUnixNano": "1658320854916681216",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-amqplib",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "CbyBh8ln9LQ=",
+              "parentSpanId": "oMg46pqD9yY=",
+              "name": "<default> -> messages send",
+              "kind": "SPAN_KIND_PRODUCER",
+              "startTimeUnixNano": "1658320854915559936",
+              "endTimeUnixNano": "1658320854915628800",
+              "attributes": [
+                {
+                  "key": "messaging.protocol_version",
+                  "value": {
+                    "stringValue": "0.9.1"
+                  }
+                },
+                {
+                  "key": "messaging.url",
+                  "value": {
+                    "stringValue": "amqp://mythical-queue"
+                  }
+                },
+                {
+                  "key": "messaging.protocol",
+                  "value": {
+                    "stringValue": "AMQP"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-queue"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "5672"
+                  }
+                },
+                {
+                  "key": "messaging.system",
+                  "value": {
+                    "stringValue": "rabbitmq"
+                  }
+                },
+                {
+                  "key": "messaging.destination",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "messaging.destination_kind",
+                  "value": {
+                    "stringValue": "topic"
+                  }
+                },
+                {
+                  "key": "messaging.rabbitmq.routing_key",
+                  "value": {
+                    "stringValue": "messages"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "HZ43ugub274=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "log_to_loki",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854916730624",
+              "endTimeUnixNano": "1658320854930536704",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "ByBJTXxe2aI=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "log_to_loki",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854923263232",
+              "endTimeUnixNano": "1658320854929491200",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "ivrh44gllP0=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854923789312",
+              "endTimeUnixNano": "1658320854925569280",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "41594"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "o/mJQtsdDeE=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854924354560",
+              "endTimeUnixNano": "1658320854925760768",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "41596"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-recorder"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-amqplib",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "qMP7VjNGIK8=",
+              "parentSpanId": "CbyBh8ln9LQ=",
+              "name": "messages process",
+              "kind": "SPAN_KIND_CONSUMER",
+              "startTimeUnixNano": "1658320854925510400",
+              "endTimeUnixNano": "1658320854926209792",
+              "attributes": [
+                {
+                  "key": "messaging.protocol_version",
+                  "value": {
+                    "stringValue": "0.9.1"
+                  }
+                },
+                {
+                  "key": "messaging.url",
+                  "value": {
+                    "stringValue": "amqp://mythical-queue"
+                  }
+                },
+                {
+                  "key": "messaging.protocol",
+                  "value": {
+                    "stringValue": "AMQP"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-queue"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "5672"
+                  }
+                },
+                {
+                  "key": "messaging.system",
+                  "value": {
+                    "stringValue": "rabbitmq"
+                  }
+                },
+                {
+                  "key": "messaging.destination",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "messaging.destination_kind",
+                  "value": {
+                    "stringValue": "topic"
+                  }
+                },
+                {
+                  "key": "messaging.rabbitmq.routing_key",
+                  "value": {
+                    "stringValue": "messages"
+                  }
+                },
+                {
+                  "key": "messaging.operation",
+                  "value": {
+                    "stringValue": "process"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-recorder"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-recorder"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "j9WiKB5PGKw=",
+              "parentSpanId": "qMP7VjNGIK8=",
+              "name": "process_message",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854925532928",
+              "endTimeUnixNano": "1658320854963292160",
+              "status": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/modules/generator/processor/servicegraphs/testdata/trace-without-database-name.json
+++ b/modules/generator/processor/servicegraphs/testdata/trace-without-database-name.json
@@ -1,0 +1,1656 @@
+{
+  "batches": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "1gZXnld4dYc=",
+              "name": "requester",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854877522688",
+              "endTimeUnixNano": "1658320854923357184",
+              "attributes": [
+                {
+                  "key": "beast",
+                  "value": {
+                    "stringValue": "manticore"
+                  }
+                },
+                {
+                  "key": "god",
+                  "value": {
+                    "stringValue": "ares"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "U/Mym4Y9qV0=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854877839616",
+              "endTimeUnixNano": "1658320854878545408",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-server"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "4000"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "46950"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-http",
+            "version": "0.27.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "mZKWiJfzyEY=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "GET /:endpoint",
+              "kind": "SPAN_KIND_SERVER",
+              "startTimeUnixNano": "1658320854878927360",
+              "endTimeUnixNano": "1658320854908913408",
+              "attributes": [
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://mythical-server:4000/manticore"
+                  }
+                },
+                {
+                  "key": "http.host",
+                  "value": {
+                    "stringValue": "mythical-server:4000"
+                  }
+                },
+                {
+                  "key": "net.host.name",
+                  "value": {
+                    "stringValue": "mythical-server"
+                  }
+                },
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "http.target",
+                  "value": {
+                    "stringValue": "/manticore"
+                  }
+                },
+                {
+                  "key": "http.flavor",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                },
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "god",
+                  "value": {
+                    "stringValue": "zeus"
+                  }
+                },
+                {
+                  "key": "beast",
+                  "value": {
+                    "stringValue": "manticore"
+                  }
+                },
+                {
+                  "key": "span.kind",
+                  "value": {
+                    "intValue": "2"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "::ffff:172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "4000"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "::ffff:172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "46950"
+                  }
+                },
+                {
+                  "key": "http.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                },
+                {
+                  "key": "http.status_text",
+                  "value": {
+                    "stringValue": "OK"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "A38EGjeny0Y=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - query",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879122688",
+              "endTimeUnixNano": "1658320854879143680",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "query"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "7eLzskA9GzQ=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - expressInit",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879322624",
+              "endTimeUnixNano": "1658320854879355136",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "expressInit"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "I+ErHCWWzIw=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - jsonParser",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879422208",
+              "endTimeUnixNano": "1658320854879444480",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "jsonParser"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "w4/Ni3Fq4S4=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "request handler - /:endpoint",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879524608",
+              "endTimeUnixNano": "1658320854879526400",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "request_handler"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-pg",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "JT4hL+I0IWw=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "pg.query:SELECT",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854879610624",
+              "endTimeUnixNano": "1658320854903392000",
+              "attributes": [
+                {
+                  "key": "db.system",
+                  "value": {
+                    "stringValue": "postgresql"
+                  }
+                },
+                {
+                  "key": "db.connection_string",
+                  "value": {
+                    "stringValue": "jdbc:postgresql://mythical-database:5432/postgres"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "mythical-database"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "5432"
+                  }
+                },
+                {
+                  "key": "db.user",
+                  "value": {
+                    "stringValue": "postgres"
+                  }
+                },
+                {
+                  "key": "db.statement",
+                  "value": {
+                    "stringValue": "SELECT name from manticore"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-http",
+            "version": "0.27.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "Iq8HyyCGMcA=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "HTTP POST",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854909347584",
+              "endTimeUnixNano": "1658320854913202688",
+              "attributes": [
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://loki:3100/loki/api/v1/push"
+                  }
+                },
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "POST"
+                  }
+                },
+                {
+                  "key": "http.target",
+                  "value": {
+                    "stringValue": "/loki/api/v1/push"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "3100"
+                  }
+                },
+                {
+                  "key": "http.host",
+                  "value": {
+                    "stringValue": "loki:3100"
+                  }
+                },
+                {
+                  "key": "http.status_code",
+                  "value": {
+                    "intValue": "204"
+                  }
+                },
+                {
+                  "key": "http.status_text",
+                  "value": {
+                    "stringValue": "NO CONTENT"
+                  }
+                },
+                {
+                  "key": "http.flavor",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                },
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "5xenytYWGCM=",
+              "parentSpanId": "Iq8HyyCGMcA=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854909465856",
+              "endTimeUnixNano": "1658320854911322112",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "51090"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-dns",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "G1lOVPULKHA=",
+              "parentSpanId": "Iq8HyyCGMcA=",
+              "name": "dns.lookup",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854909490688",
+              "endTimeUnixNano": "1658320854910292992",
+              "attributes": [
+                {
+                  "key": "peer.ipv4",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "oMg46pqD9yY=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "publish_to_queue",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854915519232",
+              "endTimeUnixNano": "1658320854916681216",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-amqplib",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "CbyBh8ln9LQ=",
+              "parentSpanId": "oMg46pqD9yY=",
+              "name": "<default> -> messages send",
+              "kind": "SPAN_KIND_PRODUCER",
+              "startTimeUnixNano": "1658320854915559936",
+              "endTimeUnixNano": "1658320854915628800",
+              "attributes": [
+                {
+                  "key": "messaging.protocol_version",
+                  "value": {
+                    "stringValue": "0.9.1"
+                  }
+                },
+                {
+                  "key": "messaging.url",
+                  "value": {
+                    "stringValue": "amqp://mythical-queue"
+                  }
+                },
+                {
+                  "key": "messaging.protocol",
+                  "value": {
+                    "stringValue": "AMQP"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-queue"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "5672"
+                  }
+                },
+                {
+                  "key": "messaging.system",
+                  "value": {
+                    "stringValue": "rabbitmq"
+                  }
+                },
+                {
+                  "key": "messaging.destination",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "messaging.destination_kind",
+                  "value": {
+                    "stringValue": "topic"
+                  }
+                },
+                {
+                  "key": "messaging.rabbitmq.routing_key",
+                  "value": {
+                    "stringValue": "messages"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "HZ43ugub274=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "log_to_loki",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854916730624",
+              "endTimeUnixNano": "1658320854930536704",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "ByBJTXxe2aI=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "log_to_loki",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854923263232",
+              "endTimeUnixNano": "1658320854929491200",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "ivrh44gllP0=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854923789312",
+              "endTimeUnixNano": "1658320854925569280",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "41594"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "o/mJQtsdDeE=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854924354560",
+              "endTimeUnixNano": "1658320854925760768",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "41596"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-recorder"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-amqplib",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "qMP7VjNGIK8=",
+              "parentSpanId": "CbyBh8ln9LQ=",
+              "name": "messages process",
+              "kind": "SPAN_KIND_CONSUMER",
+              "startTimeUnixNano": "1658320854925510400",
+              "endTimeUnixNano": "1658320854926209792",
+              "attributes": [
+                {
+                  "key": "messaging.protocol_version",
+                  "value": {
+                    "stringValue": "0.9.1"
+                  }
+                },
+                {
+                  "key": "messaging.url",
+                  "value": {
+                    "stringValue": "amqp://mythical-queue"
+                  }
+                },
+                {
+                  "key": "messaging.protocol",
+                  "value": {
+                    "stringValue": "AMQP"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-queue"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "5672"
+                  }
+                },
+                {
+                  "key": "messaging.system",
+                  "value": {
+                    "stringValue": "rabbitmq"
+                  }
+                },
+                {
+                  "key": "messaging.destination",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "messaging.destination_kind",
+                  "value": {
+                    "stringValue": "topic"
+                  }
+                },
+                {
+                  "key": "messaging.rabbitmq.routing_key",
+                  "value": {
+                    "stringValue": "messages"
+                  }
+                },
+                {
+                  "key": "messaging.operation",
+                  "value": {
+                    "stringValue": "process"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-recorder"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-recorder"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "j9WiKB5PGKw=",
+              "parentSpanId": "qMP7VjNGIK8=",
+              "name": "process_message",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854925532928",
+              "endTimeUnixNano": "1658320854963292160",
+              "status": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**What this PR does**:

Currently, the `db.name` attribute is used as the node identity on the service graph.  This leads to situations where the name of the database may be reused between services, leading to a single node on the graph where more than one actual service is in use.

This PR changes the node identity when newer OTEL semantic conventions are available as attributes on the span.  The following attributes are considered in order:
- `peer.service`
- `server.address`
- `network.peer.address` -- additionally `network.peer.port` will be used if available
- fall back to `db.name`

**Which issue(s) this PR fixes**:
Fixes #3010

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`