### PR TITLE
Query-frontend: Parrallelize unmarshalling of responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [ENHANCEMENT] Tag value lookup use protobuf internally for improved latency [#3731](https://github.com/grafana/tempo/pull/3731) (@mdisibio)
 * [ENHANCEMENT] Improve use of OTEL semantic conventions on the service graph [#3711](https://github.com/grafana/tempo/pull/3711) (@zalegrala)
 * [ENHANCEMENT] Performance improvement for `rate() by ()` queries [#3719](https://github.com/grafana/tempo/pull/3719) (@mapno)
+* [ENHANCEMENT] Use multiple goroutines to unmarshal responses in parallel in the query frontend. [#3713](https://github.com/grafana/tempo/pull/3713) (@joe-elliott)
 * [BUGFIX] Fix metrics queries when grouping by attributes that may not exist [#3734](https://github.com/grafana/tempo/pull/3734) (@mdisibio)
 * [BUGFIX] max_global_traces_per_user: take into account ingestion.tenant_shard_size when converting to local limit [#3618](https://github.com/grafana/tempo/pull/3618) (@kvrhdn)
 

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -433,6 +433,11 @@ query_frontend:
     # (default: 2)
     [max_retries: <int>]
 
+    # The number of goroutines dedicated to consuming, unmarshalling and recombining responses per request. This
+    # same parameter is used for all endpoints. 
+    # (default: 10)
+    [response_consumers: <int>]
+
     # Maximum number of outstanding requests per tenant per frontend; requests beyond this error with HTTP 429.
     # (default: 2000)
     [max_outstanding_per_tenant: <int>]

--- a/integration/e2e/limits_test.go
+++ b/integration/e2e/limits_test.go
@@ -375,7 +375,13 @@ func TestQueryRateLimits(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = resp.Recv()
+	// loop until we get io.EOF or an error
+	for {
+		_, err = resp.Recv()
+		if err != nil {
+			break
+		}
+	}
 	require.ErrorContains(t, err, "job queue full")
 	require.ErrorContains(t, err, "code = ResourceExhausted")
 }

--- a/modules/frontend/combiner/common.go
+++ b/modules/frontend/combiner/common.go
@@ -99,6 +99,11 @@ func (c *genericCombiner[T]) AddResponse(r PipelineResponse) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	// test again for should quit. it's possible that another response came in while we were unmarshalling that would make us quit.
+	if c.shouldQuit() {
+		return nil
+	}
+
 	c.httpStatusCode = res.StatusCode
 	if err := c.combine(partial, c.current, r); err != nil {
 		c.httpRespBody = internalErrorMsg

--- a/modules/frontend/combiner/common_test.go
+++ b/modules/frontend/combiner/common_test.go
@@ -124,15 +124,13 @@ func TestGenericCombinerDoesntRace(t *testing.T) {
 		}
 	}
 	go concurrent(func() {
-		err := combiner.AddResponse(newTestResponse(t))
-		require.NoError(t, err)
+		_ = combiner.AddResponse(newTestResponse(t))
 	})
 
 	go concurrent(func() {
 		// this test is going to add a failed response which cuts off certain code paths. just wait a bit to test the other paths
 		time.Sleep(10 * time.Millisecond)
-		err := combiner.AddResponse(newFailedTestResponse())
-		require.NoError(t, err)
+		_ = combiner.AddResponse(newFailedTestResponse())
 	})
 
 	go concurrent(func() {
@@ -144,18 +142,15 @@ func TestGenericCombinerDoesntRace(t *testing.T) {
 	})
 
 	go concurrent(func() {
-		_, err := combiner.HTTPFinal()
-		require.NoError(t, err)
+		_, _ = combiner.HTTPFinal()
 	})
 
 	go concurrent(func() {
-		_, err := combiner.GRPCFinal()
-		require.NoError(t, err)
+		_, _ = combiner.GRPCFinal()
 	})
 
 	go concurrent(func() {
-		_, err := combiner.GRPCDiff()
-		require.NoError(t, err)
+		_, _ = combiner.GRPCDiff()
 	})
 
 	time.Sleep(100 * time.Millisecond)

--- a/modules/frontend/combiner/search_tag_values.go
+++ b/modules/frontend/combiner/search_tag_values.go
@@ -47,8 +47,9 @@ func NewSearchTagValuesV2(limitBytes int) Combiner {
 	d := util.NewDistinctValueCollector(limitBytes, func(tv tempopb.TagValue) int { return len(tv.Type) + len(tv.Value) })
 
 	return &genericCombiner[*tempopb.SearchTagValuesV2Response]{
-		current: &tempopb.SearchTagValuesV2Response{TagValues: []*tempopb.TagValue{}},
-		new:     func() *tempopb.SearchTagValuesV2Response { return &tempopb.SearchTagValuesV2Response{} },
+		httpStatusCode: 200,
+		current:        &tempopb.SearchTagValuesV2Response{TagValues: []*tempopb.TagValue{}},
+		new:            func() *tempopb.SearchTagValuesV2Response { return &tempopb.SearchTagValuesV2Response{} },
 		combine: func(partial, final *tempopb.SearchTagValuesV2Response, _ PipelineResponse) error {
 			for _, v := range partial.TagValues {
 				d.Collect(*v)

--- a/modules/frontend/config.go
+++ b/modules/frontend/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	TraceByID                 TraceByIDConfig `yaml:"trace_by_id"`
 	Metrics                   MetricsConfig   `yaml:"metrics"`
 	MultiTenantQueriesEnabled bool            `yaml:"multi_tenant_queries_enabled"`
+	ResponseConsumers         int             `yaml:"response_consumers"`
 
 	// the maximum time limit that tempo will work on an api request. this includes both
 	// grpc and http requests and applies to all "api" frontend query endpoints such as
@@ -61,6 +62,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {
 	cfg.Config.MaxOutstandingPerTenant = 2000
 	cfg.Config.MaxBatchSize = 5
 	cfg.MaxRetries = 2
+	cfg.ResponseConsumers = 10
 	cfg.Search = SearchConfig{
 		Sharder: SearchSharderConfig{
 			QueryBackendAfter:     15 * time.Minute,

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -135,10 +135,10 @@ func New(cfg Config, next http.RoundTripper, o overrides.Interface, reader tempo
 
 	traces := newTraceIDHandler(cfg, o, tracePipeline, logger)
 	search := newSearchHTTPHandler(cfg, searchPipeline, logger)
-	searchTags := newTagHTTPHandler(searchTagsPipeline, o, combiner.NewSearchTags, logger)
-	searchTagsV2 := newTagHTTPHandler(searchTagsPipeline, o, combiner.NewSearchTagsV2, logger)
-	searchTagValues := newTagHTTPHandler(searchTagValuesPipeline, o, combiner.NewSearchTagValues, logger)
-	searchTagValuesV2 := newTagHTTPHandler(searchTagValuesPipeline, o, combiner.NewSearchTagValuesV2, logger)
+	searchTags := newTagHTTPHandler(cfg, searchTagsPipeline, o, combiner.NewSearchTags, logger)
+	searchTagsV2 := newTagHTTPHandler(cfg, searchTagsPipeline, o, combiner.NewSearchTagsV2, logger)
+	searchTagValues := newTagHTTPHandler(cfg, searchTagValuesPipeline, o, combiner.NewSearchTagValues, logger)
+	searchTagValuesV2 := newTagHTTPHandler(cfg, searchTagValuesPipeline, o, combiner.NewSearchTagValuesV2, logger)
 	metrics := newMetricsSummaryHandler(metricsPipeline, logger)
 	queryrange := newMetricsQueryRangeHTTPHandler(cfg, queryRangePipeline, logger)
 
@@ -155,10 +155,10 @@ func New(cfg Config, next http.RoundTripper, o overrides.Interface, reader tempo
 
 		// grpc/streaming
 		streamingSearch:      newSearchStreamingGRPCHandler(cfg, searchPipeline, apiPrefix, logger),
-		streamingTags:        newTagStreamingGRPCHandler(searchTagsPipeline, apiPrefix, o, logger),
-		streamingTagsV2:      newTagV2StreamingGRPCHandler(searchTagsPipeline, apiPrefix, o, logger),
-		streamingTagValues:   newTagValuesStreamingGRPCHandler(searchTagValuesPipeline, apiPrefix, o, logger),
-		streamingTagValuesV2: newTagValuesV2StreamingGRPCHandler(searchTagValuesPipeline, apiPrefix, o, logger),
+		streamingTags:        newTagStreamingGRPCHandler(cfg, searchTagsPipeline, apiPrefix, o, logger),
+		streamingTagsV2:      newTagV2StreamingGRPCHandler(cfg, searchTagsPipeline, apiPrefix, o, logger),
+		streamingTagValues:   newTagValuesStreamingGRPCHandler(cfg, searchTagValuesPipeline, apiPrefix, o, logger),
+		streamingTagValuesV2: newTagValuesV2StreamingGRPCHandler(cfg, searchTagValuesPipeline, apiPrefix, o, logger),
 		streamingQueryRange:  newQueryRangeStreamingGRPCHandler(cfg, queryRangePipeline, apiPrefix, logger),
 
 		cacheProvider: cacheProvider,

--- a/modules/frontend/metrics_query_range_handler.go
+++ b/modules/frontend/metrics_query_range_handler.go
@@ -42,7 +42,7 @@ func newQueryRangeStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripp
 			return err
 		}
 
-		collector := pipeline.NewGRPCCollector(next, c, func(qrr *tempopb.QueryRangeResponse) error {
+		collector := pipeline.NewGRPCCollector(next, cfg.ResponseConsumers, c, func(qrr *tempopb.QueryRangeResponse) error {
 			finalResponse = qrr // sadly we can't pass srv.Send directly into the collector. we need bytesProcessed for the SLO calculations
 			return srv.Send(qrr)
 		})
@@ -92,7 +92,7 @@ func newMetricsQueryRangeHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper
 				Body:       io.NopCloser(strings.NewReader(err.Error())),
 			}, nil
 		}
-		rt := pipeline.NewHTTPCollector(next, combiner)
+		rt := pipeline.NewHTTPCollector(next, cfg.ResponseConsumers, combiner)
 
 		resp, err := rt.RoundTrip(req)
 

--- a/modules/frontend/pipeline/collector_grpc.go
+++ b/modules/frontend/pipeline/collector_grpc.go
@@ -37,36 +37,9 @@ func (c GRPCCollector[T]) RoundTrip(req *http.Request) error {
 		return grpcError(err)
 	}
 
-	// stores any error that occurs during the streaming
-	//  the wg protects the store from concurrent writes/reads
-	var overallErr error
 	lastUpdate := time.Now()
 
-	for {
-		resp, done, err := resps.Next(ctx)
-		if err != nil {
-			overallErr = err
-			break
-		}
-
-		if resp != nil {
-			err = c.combiner.AddResponse(resp)
-			if err != nil {
-				overallErr = err
-				break
-			}
-		}
-
-		// limit reached or http errors
-		if c.combiner.ShouldQuit() {
-			break
-		}
-
-		// pipeline exhausted
-		if done {
-			break
-		}
-
+	err = addNextAsync(ctx, resps, c.next, c.combiner, func() error {
 		// check if we should send an update
 		if time.Since(lastUpdate) > 500*time.Millisecond {
 			lastUpdate = time.Now()
@@ -74,20 +47,18 @@ func (c GRPCCollector[T]) RoundTrip(req *http.Request) error {
 			// send a diff only during streaming
 			resp, err := c.combiner.GRPCDiff()
 			if err != nil {
-				overallErr = err
-				break
+				return err
 			}
 			err = c.send(resp)
 			if err != nil {
-				overallErr = err
-				break
+				return err
 			}
 		}
-	}
 
-	// if we have an error then no need to send a final message
-	if overallErr != nil {
-		return grpcError(overallErr)
+		return nil
+	})
+	if err != nil {
+		return grpcError(err)
 	}
 
 	// send a final, complete response
@@ -112,16 +83,3 @@ func grpcError(err error) error {
 
 	return status.Error(codes.Internal, err.Error())
 }
-
-// func contextDone(ctx context.Context) (bool, error) {
-// 	select {
-// 	case <-ctx.Done():
-// 		err := ctx.Err()
-// 		if err != nil && !errors.Is(err, context.Canceled) {
-// 			return true, err
-// 		}
-// 		return true, nil
-// 	default:
-// 		return false, nil
-// 	}
-// }

--- a/modules/frontend/pipeline/collector_grpc.go
+++ b/modules/frontend/pipeline/collector_grpc.go
@@ -11,17 +11,19 @@ import (
 )
 
 type GRPCCollector[T combiner.TResponse] struct {
-	next     AsyncRoundTripper[combiner.PipelineResponse]
-	combiner combiner.GRPCCombiner[T]
+	next      AsyncRoundTripper[combiner.PipelineResponse]
+	combiner  combiner.GRPCCombiner[T]
+	consumers int
 
 	send func(T) error
 }
 
-func NewGRPCCollector[T combiner.TResponse](next AsyncRoundTripper[combiner.PipelineResponse], combiner combiner.GRPCCombiner[T], send func(T) error) *GRPCCollector[T] {
+func NewGRPCCollector[T combiner.TResponse](next AsyncRoundTripper[combiner.PipelineResponse], consumers int, combiner combiner.GRPCCombiner[T], send func(T) error) *GRPCCollector[T] {
 	return &GRPCCollector[T]{
-		next:     next,
-		combiner: combiner,
-		send:     send,
+		next:      next,
+		combiner:  combiner,
+		consumers: consumers,
+		send:      send,
 	}
 }
 
@@ -39,7 +41,7 @@ func (c GRPCCollector[T]) RoundTrip(req *http.Request) error {
 
 	lastUpdate := time.Now()
 
-	err = addNextAsync(ctx, resps, c.next, c.combiner, func() error {
+	err = addNextAsync(ctx, c.consumers, resps, c.next, c.combiner, func() error {
 		// check if we should send an update
 		if time.Since(lastUpdate) > 500*time.Millisecond {
 			lastUpdate = time.Now()

--- a/modules/frontend/pipeline/collector_grpc.go
+++ b/modules/frontend/pipeline/collector_grpc.go
@@ -41,7 +41,7 @@ func (c GRPCCollector[T]) RoundTrip(req *http.Request) error {
 
 	lastUpdate := time.Now()
 
-	err = addNextAsync(ctx, c.consumers, resps, c.combiner, func() error {
+	err = consumeAndCombineResponses(ctx, c.consumers, resps, c.combiner, func() error {
 		// check if we should send an update
 		if time.Since(lastUpdate) > 500*time.Millisecond {
 			lastUpdate = time.Now()

--- a/modules/frontend/pipeline/collector_grpc.go
+++ b/modules/frontend/pipeline/collector_grpc.go
@@ -41,7 +41,7 @@ func (c GRPCCollector[T]) RoundTrip(req *http.Request) error {
 
 	lastUpdate := time.Now()
 
-	err = addNextAsync(ctx, c.consumers, resps, c.next, c.combiner, func() error {
+	err = addNextAsync(ctx, c.consumers, resps, c.combiner, func() error {
 		// check if we should send an update
 		if time.Since(lastUpdate) > 500*time.Millisecond {
 			lastUpdate = time.Now()

--- a/modules/frontend/pipeline/collector_http.go
+++ b/modules/frontend/pipeline/collector_http.go
@@ -39,7 +39,7 @@ func (r httpCollector) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 
-	err = addNextAsync(ctx, r.consumers, resps, r.combiner, nil)
+	err = consumeAndCombineResponses(ctx, r.consumers, resps, r.combiner, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func (r httpCollector) RoundTrip(req *http.Request) (*http.Response, error) {
 	return r.combiner.HTTPFinal()
 }
 
-func addNextAsync(ctx context.Context, consumers int, resps Responses[combiner.PipelineResponse], c combiner.Combiner, callback func() error) error {
+func consumeAndCombineResponses(ctx context.Context, consumers int, resps Responses[combiner.PipelineResponse], c combiner.Combiner, callback func() error) error {
 	respChan := make(chan combiner.PipelineResponse)
 	overallErr := atomic.Error{}
 	wg := sync.WaitGroup{}

--- a/modules/frontend/pipeline/collector_http.go
+++ b/modules/frontend/pipeline/collector_http.go
@@ -39,7 +39,7 @@ func (r httpCollector) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 
-	err = addNextAsync(ctx, r.consumers, resps, r.next, r.combiner, nil)
+	err = addNextAsync(ctx, r.consumers, resps, r.combiner, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func (r httpCollector) RoundTrip(req *http.Request) (*http.Response, error) {
 	return r.combiner.HTTPFinal()
 }
 
-func addNextAsync(ctx context.Context, consumers int, resps Responses[combiner.PipelineResponse], next AsyncRoundTripper[combiner.PipelineResponse], c combiner.Combiner, callback func() error) error {
+func addNextAsync(ctx context.Context, consumers int, resps Responses[combiner.PipelineResponse], c combiner.Combiner, callback func() error) error {
 	respChan := make(chan combiner.PipelineResponse)
 	overallErr := atomic.Error{}
 	wg := sync.WaitGroup{}

--- a/modules/frontend/pipeline/responses_test.go
+++ b/modules/frontend/pipeline/responses_test.go
@@ -326,7 +326,7 @@ func TestAsyncResponsesDoesNotLeak(t *testing.T) {
 				bridge := &pipelineBridge{
 					next: tc.finalRT(cancel),
 				}
-				grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](sharder{next: bridge}, 0, combiner.NewTypedSearch(0), func(sr *tempopb.SearchResponse) error { return nil })
+				grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](sharder{next: bridge}, 0, combiner.NewTypedSearch(0), func(_ *tempopb.SearchResponse) error { return nil })
 
 				_ = grpcCollector.RoundTrip(req)
 
@@ -350,7 +350,7 @@ func TestAsyncResponsesDoesNotLeak(t *testing.T) {
 				}
 
 				s := sharder{next: sharder{next: bridge}, funcSharder: true}
-				grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](s, 0, combiner.NewTypedSearch(0), func(sr *tempopb.SearchResponse) error { return nil })
+				grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](s, 0, combiner.NewTypedSearch(0), func(_ *tempopb.SearchResponse) error { return nil })
 
 				_ = grpcCollector.RoundTrip(req)
 
@@ -373,7 +373,7 @@ func TestAsyncResponsesDoesNotLeak(t *testing.T) {
 				}
 
 				s := sharder{next: sharder{next: bridge, funcSharder: true}}
-				grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](s, 0, combiner.NewTypedSearch(0), func(sr *tempopb.SearchResponse) error { return nil })
+				grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](s, 0, combiner.NewTypedSearch(0), func(_ *tempopb.SearchResponse) error { return nil })
 
 				_ = grpcCollector.RoundTrip(req)
 

--- a/modules/frontend/pipeline/responses_test.go
+++ b/modules/frontend/pipeline/responses_test.go
@@ -304,7 +304,7 @@ func TestAsyncResponsesDoesNotLeak(t *testing.T) {
 				bridge := &pipelineBridge{
 					next: tc.finalRT(cancel),
 				}
-				httpCollector := NewHTTPCollector(sharder{next: bridge}, combiner.NewSearch(0))
+				httpCollector := NewHTTPCollector(sharder{next: bridge}, 0, combiner.NewSearch(0))
 
 				_, _ = httpCollector.RoundTrip(req)
 
@@ -326,7 +326,7 @@ func TestAsyncResponsesDoesNotLeak(t *testing.T) {
 				bridge := &pipelineBridge{
 					next: tc.finalRT(cancel),
 				}
-				grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](sharder{next: bridge}, combiner.NewTypedSearch(0), func(sr *tempopb.SearchResponse) error { return nil })
+				grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](sharder{next: bridge}, 0, combiner.NewTypedSearch(0), func(sr *tempopb.SearchResponse) error { return nil })
 
 				_ = grpcCollector.RoundTrip(req)
 
@@ -350,7 +350,7 @@ func TestAsyncResponsesDoesNotLeak(t *testing.T) {
 				}
 
 				s := sharder{next: sharder{next: bridge}, funcSharder: true}
-				grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](s, combiner.NewTypedSearch(0), func(sr *tempopb.SearchResponse) error { return nil })
+				grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](s, 0, combiner.NewTypedSearch(0), func(sr *tempopb.SearchResponse) error { return nil })
 
 				_ = grpcCollector.RoundTrip(req)
 
@@ -373,7 +373,7 @@ func TestAsyncResponsesDoesNotLeak(t *testing.T) {
 				}
 
 				s := sharder{next: sharder{next: bridge, funcSharder: true}}
-				grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](s, combiner.NewTypedSearch(0), func(sr *tempopb.SearchResponse) error { return nil })
+				grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](s, 0, combiner.NewTypedSearch(0), func(sr *tempopb.SearchResponse) error { return nil })
 
 				_ = grpcCollector.RoundTrip(req)
 

--- a/modules/frontend/search_handlers.go
+++ b/modules/frontend/search_handlers.go
@@ -65,7 +65,7 @@ func newSearchStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[c
 			bytesProcessed = finalResponse.Metrics.InspectedBytes
 		}
 		postSLOHook(nil, tenant, bytesProcessed, duration, err)
-		logResult(logger, tenant, duration.Seconds(), req, finalResponse, err)
+		logResult(logger, tenant, duration.Seconds(), req, finalResponse, nil, err)
 		return err
 	}
 }
@@ -117,7 +117,7 @@ func newSearchHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.P
 
 		duration := time.Since(start)
 		postSLOHook(resp, tenant, bytesProcessed, duration, err)
-		logResult(logger, tenant, duration.Seconds(), searchReq, searchResp, err)
+		logResult(logger, tenant, duration.Seconds(), searchReq, searchResp, resp, err)
 		return resp, err
 	})
 }
@@ -135,12 +135,18 @@ func adjustLimit(limit, defaultLimit, maxLimit uint32) (uint32, error) {
 	return limit, nil
 }
 
-func logResult(logger log.Logger, tenantID string, durationSeconds float64, req *tempopb.SearchRequest, resp *tempopb.SearchResponse, err error) {
+func logResult(logger log.Logger, tenantID string, durationSeconds float64, req *tempopb.SearchRequest, resp *tempopb.SearchResponse, httpResp *http.Response, err error) {
+	statusCode := -1
+	if httpResp != nil {
+		statusCode = httpResp.StatusCode
+	}
+
 	if resp == nil {
 		level.Info(logger).Log(
 			"msg", "search results - no resp",
 			"tenant", tenantID,
 			"duration_seconds", durationSeconds,
+			"status_code", statusCode,
 			"error", err)
 
 		return
@@ -153,6 +159,7 @@ func logResult(logger log.Logger, tenantID string, durationSeconds float64, req 
 			"query", req.Query,
 			"range_seconds", req.End-req.Start,
 			"duration_seconds", durationSeconds,
+			"status_code", statusCode,
 			"error", err)
 		return
 	}
@@ -171,6 +178,7 @@ func logResult(logger log.Logger, tenantID string, durationSeconds float64, req 
 		"inspected_bytes", resp.Metrics.InspectedBytes,
 		"inspected_traces", resp.Metrics.InspectedTraces,
 		"inspected_spans", resp.Metrics.InspectedSpans,
+		"status_code", statusCode,
 		"error", err)
 }
 

--- a/modules/frontend/search_handlers.go
+++ b/modules/frontend/search_handlers.go
@@ -51,7 +51,7 @@ func newSearchStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[c
 
 		var finalResponse *tempopb.SearchResponse
 		c := combiner.NewTypedSearch(int(limit))
-		collector := pipeline.NewGRPCCollector[*tempopb.SearchResponse](next, c, func(sr *tempopb.SearchResponse) error {
+		collector := pipeline.NewGRPCCollector[*tempopb.SearchResponse](next, cfg.ResponseConsumers, c, func(sr *tempopb.SearchResponse) error {
 			finalResponse = sr // sadly we can't srv.Send directly into the collector. we need bytesProcessed for the SLO calculations
 			return srv.Send(sr)
 		})
@@ -104,7 +104,7 @@ func newSearchHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.P
 
 		// build and use roundtripper
 		combiner := combiner.NewTypedSearch(int(limit))
-		rt := pipeline.NewHTTPCollector(next, combiner)
+		rt := pipeline.NewHTTPCollector(next, cfg.ResponseConsumers, combiner)
 
 		resp, err := rt.RoundTrip(req)
 

--- a/modules/frontend/tag_handlers_test.go
+++ b/modules/frontend/tag_handlers_test.go
@@ -340,7 +340,7 @@ func TestSearchTagValuesV2FailurePropagatesFromQueriers(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			//queriers will return one errr
+			// queriers will return one err
 			f := frontendWithSettings(t, &mockRoundTripper{
 				statusCode:    tc.querierCode,
 				statusMessage: tc.querierMessage,

--- a/modules/frontend/tag_handlers_test.go
+++ b/modules/frontend/tag_handlers_test.go
@@ -339,90 +339,92 @@ func TestSearchTagValuesV2FailurePropagatesFromQueriers(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		// queriers will return one errr
-		f := frontendWithSettings(t, &mockRoundTripper{
-			statusCode:    tc.querierCode,
-			statusMessage: tc.querierMessage,
-			err:           tc.querierErr,
-			responseFn: func() proto.Message {
-				return &tempopb.SearchTagsResponse{}
-			},
-		}, nil, &Config{
-			MultiTenantQueriesEnabled: true,
-			MaxRetries:                0, // disable retries or it will try twice and get success. the querier response is designed to fail exactly once
-			TraceByID: TraceByIDConfig{
-				QueryShards: minQueryShards,
-				SLO:         testSLOcfg,
-			},
-			Search: SearchConfig{
-				Sharder: SearchSharderConfig{
-					ConcurrentRequests:    defaultConcurrentRequests,
-					TargetBytesPerRequest: defaultTargetBytesPerRequest,
+		t.Run(tc.name, func(t *testing.T) {
+			//queriers will return one errr
+			f := frontendWithSettings(t, &mockRoundTripper{
+				statusCode:    tc.querierCode,
+				statusMessage: tc.querierMessage,
+				err:           tc.querierErr,
+				responseFn: func() proto.Message {
+					return &tempopb.SearchTagsResponse{}
 				},
-				SLO: testSLOcfg,
-			},
-			Metrics: MetricsConfig{
-				Sharder: QueryRangeSharderConfig{
-					ConcurrentRequests:    defaultConcurrentRequests,
-					TargetBytesPerRequest: defaultTargetBytesPerRequest,
-					Interval:              1 * time.Second,
+			}, nil, &Config{
+				MultiTenantQueriesEnabled: true,
+				MaxRetries:                0, // disable retries or it will try twice and get success. the querier response is designed to fail exactly once
+				TraceByID: TraceByIDConfig{
+					QueryShards: minQueryShards,
+					SLO:         testSLOcfg,
 				},
-				SLO: testSLOcfg,
-			},
-		}, nil)
-
-		httpReq := httptest.NewRequest("GET", "/api/v2/search/tags?start=1&end=10000", nil)
-		httpResp := httptest.NewRecorder()
-
-		ctx := user.InjectOrgID(httpReq.Context(), "foo")
-		httpReq = httpReq.WithContext(ctx)
-
-		f.SearchHandler.ServeHTTP(httpResp, httpReq)
-		require.Equal(t, tc.expectedMessage, httpResp.Body.String())
-		require.Equal(t, tc.expectedCode, httpResp.Code)
-
-		// have to recreate the frontend to reset the querier response
-		f = frontendWithSettings(t, &mockRoundTripper{
-			statusCode:    tc.querierCode,
-			statusMessage: tc.querierMessage,
-			err:           tc.querierErr,
-			responseFn: func() proto.Message {
-				return &tempopb.SearchResponse{
-					Traces:  []*tempopb.TraceSearchMetadata{},
-					Metrics: &tempopb.SearchMetrics{},
-				}
-			},
-		}, nil, &Config{
-			MultiTenantQueriesEnabled: true,
-			MaxRetries:                0, // disable retries or it will try twice and get success
-			TraceByID: TraceByIDConfig{
-				QueryShards: minQueryShards,
-				SLO:         testSLOcfg,
-			},
-			Search: SearchConfig{
-				Sharder: SearchSharderConfig{
-					ConcurrentRequests:    defaultConcurrentRequests,
-					TargetBytesPerRequest: defaultTargetBytesPerRequest,
+				Search: SearchConfig{
+					Sharder: SearchSharderConfig{
+						ConcurrentRequests:    defaultConcurrentRequests,
+						TargetBytesPerRequest: defaultTargetBytesPerRequest,
+					},
+					SLO: testSLOcfg,
 				},
-				SLO: testSLOcfg,
-			},
-			Metrics: MetricsConfig{
-				Sharder: QueryRangeSharderConfig{
-					ConcurrentRequests:    defaultConcurrentRequests,
-					TargetBytesPerRequest: defaultTargetBytesPerRequest,
-					Interval:              1 * time.Second,
+				Metrics: MetricsConfig{
+					Sharder: QueryRangeSharderConfig{
+						ConcurrentRequests:    defaultConcurrentRequests,
+						TargetBytesPerRequest: defaultTargetBytesPerRequest,
+						Interval:              1 * time.Second,
+					},
+					SLO: testSLOcfg,
 				},
-				SLO: testSLOcfg,
-			},
-		}, nil)
+			}, nil)
 
-		// grpc
-		srv := newMockStreamingServer[*tempopb.SearchTagValuesV2Response]("bar", nil)
-		grpcReq := &tempopb.SearchTagValuesRequest{
-			TagName: "foo",
-		}
-		err := f.streamingTagValuesV2(grpcReq, srv)
-		require.Equal(t, tc.expectedErr, err)
+			httpReq := httptest.NewRequest("GET", "/api/v2/search/tags?start=1&end=10000", nil)
+			httpResp := httptest.NewRecorder()
+
+			ctx := user.InjectOrgID(httpReq.Context(), "foo")
+			httpReq = httpReq.WithContext(ctx)
+
+			f.SearchHandler.ServeHTTP(httpResp, httpReq)
+			require.Equal(t, tc.expectedMessage, httpResp.Body.String())
+			require.Equal(t, tc.expectedCode, httpResp.Code)
+
+			// have to recreate the frontend to reset the querier response
+			f = frontendWithSettings(t, &mockRoundTripper{
+				statusCode:    tc.querierCode,
+				statusMessage: tc.querierMessage,
+				err:           tc.querierErr,
+				responseFn: func() proto.Message {
+					return &tempopb.SearchResponse{
+						Traces:  []*tempopb.TraceSearchMetadata{},
+						Metrics: &tempopb.SearchMetrics{},
+					}
+				},
+			}, nil, &Config{
+				MultiTenantQueriesEnabled: true,
+				MaxRetries:                0, // disable retries or it will try twice and get success
+				TraceByID: TraceByIDConfig{
+					QueryShards: minQueryShards,
+					SLO:         testSLOcfg,
+				},
+				Search: SearchConfig{
+					Sharder: SearchSharderConfig{
+						ConcurrentRequests:    defaultConcurrentRequests,
+						TargetBytesPerRequest: defaultTargetBytesPerRequest,
+					},
+					SLO: testSLOcfg,
+				},
+				Metrics: MetricsConfig{
+					Sharder: QueryRangeSharderConfig{
+						ConcurrentRequests:    defaultConcurrentRequests,
+						TargetBytesPerRequest: defaultTargetBytesPerRequest,
+						Interval:              1 * time.Second,
+					},
+					SLO: testSLOcfg,
+				},
+			}, nil)
+
+			// grpc
+			srv := newMockStreamingServer[*tempopb.SearchTagValuesV2Response]("bar", nil)
+			grpcReq := &tempopb.SearchTagValuesRequest{
+				TagName: "foo",
+			}
+			err := f.streamingTagValuesV2(grpcReq, srv)
+			require.Equal(t, tc.expectedErr, err)
+		})
 	}
 }
 

--- a/modules/frontend/traceid_handlers.go
+++ b/modules/frontend/traceid_handlers.go
@@ -66,7 +66,7 @@ func newTraceIDHandler(cfg Config, o overrides.Interface, next pipeline.AsyncRou
 			"path", req.URL.Path)
 
 		combiner := combiner.NewTraceByID(o.MaxBytesPerTrace(tenant), marshallingFormat)
-		rt := pipeline.NewHTTPCollector(next, combiner)
+		rt := pipeline.NewHTTPCollector(next, cfg.ResponseConsumers, combiner)
 
 		start := time.Now()
 		resp, err := rt.RoundTrip(req)


### PR DESCRIPTION
**What this PR does**:

Adds a configurable number of dedicated goroutines per request to consume the responses and add them to the combiner. The combiner was also adjusted to move the unmarshalling steps outside of the locking logic so we could do multiple unmarshals in parrallel.

- Added a parameter to configure the number of goroutines. Default: 10
- Added tests to confirm the combiner doesn't race with the new changes
- Found and fixed an issue where tag values v2 was not initializing its status code to 200 which caused it to fail if GRPCDiff was called before a response was received.

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`