### PR TITLE
SearchTagValuesV2 use protobuf internally instead of json to reduce latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [FEATURE] TraceQL support for event scope and event:name intrinsic [#3708](https://github.com/grafana/tempo/pull/3708) (@stoewer)
 * [FEATURE] Flush blocks to storage from the metrics-generator [#3628](https://github.com/grafana/tempo/pull/3628) [#3691](https://github.com/grafana/tempo/pull/3691) (@mapno)
+* [ENHANCEMENT] Tag value lookup use protobuf internally for improved latency [#3731](https://github.com/grafana/tempo/pull/3731) (@mdisibio)
 * [ENHANCEMENT] Improve use of OTEL semantic conventions on the service graph [#3711](https://github.com/grafana/tempo/pull/3711) (@zalegrala)
 
 ## v2.5.0-rc.1

--- a/modules/frontend/combiner/common.go
+++ b/modules/frontend/combiner/common.go
@@ -70,8 +70,20 @@ func (c *genericCombiner[T]) AddResponse(r PipelineResponse) error {
 	}
 
 	partial := c.new() // instantiating directly requires additional type constraints. this seemed cleaner: https://stackoverflow.com/questions/69573113/how-can-i-instantiate-a-non-nil-pointer-of-type-argument-with-generic-go
-	if err := jsonpb.Unmarshal(res.Body, partial); err != nil {
-		return fmt.Errorf("error unmarshalling response body: %w", err)
+
+	switch res.Header.Get(api.HeaderContentType) {
+	case api.HeaderAcceptJSON:
+		if err := jsonpb.Unmarshal(res.Body, partial); err != nil {
+			return fmt.Errorf("error unmarshalling response body: %w", err)
+		}
+	case api.HeaderAcceptProtobuf:
+		b, err := io.ReadAll(res.Body)
+		if err != nil {
+			return fmt.Errorf("error reading response body")
+		}
+		if err := proto.Unmarshal(b, partial); err != nil {
+			return fmt.Errorf("error unmarshalling proto response body: %w", err)
+		}
 	}
 
 	if err := c.combine(partial, c.current, r); err != nil {

--- a/modules/frontend/combiner/common.go
+++ b/modules/frontend/combiner/common.go
@@ -72,10 +72,6 @@ func (c *genericCombiner[T]) AddResponse(r PipelineResponse) error {
 	partial := c.new() // instantiating directly requires additional type constraints. this seemed cleaner: https://stackoverflow.com/questions/69573113/how-can-i-instantiate-a-non-nil-pointer-of-type-argument-with-generic-go
 
 	switch res.Header.Get(api.HeaderContentType) {
-	case api.HeaderAcceptJSON:
-		if err := jsonpb.Unmarshal(res.Body, partial); err != nil {
-			return fmt.Errorf("error unmarshalling response body: %w", err)
-		}
 	case api.HeaderAcceptProtobuf:
 		b, err := io.ReadAll(res.Body)
 		if err != nil {
@@ -83,6 +79,11 @@ func (c *genericCombiner[T]) AddResponse(r PipelineResponse) error {
 		}
 		if err := proto.Unmarshal(b, partial); err != nil {
 			return fmt.Errorf("error unmarshalling proto response body: %w", err)
+		}
+	default:
+		// Assume json
+		if err := jsonpb.Unmarshal(res.Body, partial); err != nil {
+			return fmt.Errorf("error unmarshalling response body: %w", err)
 		}
 	}
 

--- a/modules/frontend/tag_sharder.go
+++ b/modules/frontend/tag_sharder.go
@@ -299,6 +299,7 @@ func (s searchTagSharder) buildBackendRequests(ctx context.Context, tenantID str
 				errFn(err)
 				return
 			}
+			subR.Header.Set(api.HeaderAccept, api.HeaderAcceptProtobuf)
 			prepareRequestForQueriers(subR, tenantID, parent.URL.Path, subR.URL.Query())
 
 			key := cacheKey(keyPrefix, tenantID, hash, int64(searchReq.start()), int64(searchReq.end()), m, startPage, pages)
@@ -356,7 +357,7 @@ func (s searchTagSharder) buildIngesterRequest(ctx context.Context, tenantID str
 	if err != nil {
 		return nil, err
 	}
-
+	subR.Header.Set(api.HeaderAccept, api.HeaderAcceptProtobuf)
 	prepareRequestForQueriers(subR, tenantID, subR.URL.Path, subR.URL.Query())
 	return subR, nil
 }

--- a/modules/querier/http.go
+++ b/modules/querier/http.go
@@ -481,20 +481,20 @@ func writeFormattedContentForRequest(w http.ResponseWriter, req *http.Request, m
 			return
 		}
 
+		w.Header().Set(api.HeaderContentType, api.HeaderAcceptProtobuf)
 		_, err = w.Write(b)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
-		w.Header().Set(api.HeaderContentType, api.HeaderAcceptProtobuf)
 	default:
-		marshaller := &jsonpb.Marshaler{}
-		err := marshaller.Marshal(w, m)
+		w.Header().Set(api.HeaderContentType, api.HeaderAcceptJSON)
+		err := new(jsonpb.Marshaler).Marshal(w, m)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		w.Header().Set(api.HeaderContentType, api.HeaderAcceptJSON)
+
 	}
 }


### PR DESCRIPTION
**What this PR does**:
The frontend communicates with the queriers using json, and this is becomes a bottleneck for large autocomplete lookups.  This PR switches /api/v2/search/tag/.../values to use http/protobuf instead.  Testing locally and in a larger cell on a large lookup, the savings are around 30% user-facing latency to Grafana. Timings:  15s -> 10s, 5s -> 3s.   We like graphs, so here is one showing the second set:

<img width="1882" alt="image" src="https://github.com/grafana/tempo/assets/13524475/e2092847-9665-42d9-8334-4e516f7d4b0e">


The encoding is implemented optionally where the querier will reply with proto only if the request header is `Accept: application/protobuf`.  Else it defaults to json.  This helps with compatibility during rollouts of old/new pods, and also curl-ability. 

A couple future steps:

(1) It might be worth swapping over the remaining apis with large payloads like search/tags and metrics.  But didn't want to expand scope.

(2) Even better would be preserve the protobuf all the way to Grafana like we do for trace lookup, but there is work needed to connect the response/request through the new async pipeline in the frontend, so the final response can be built with the appropriate encoding.

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`