### PR TITLE
Upgrade grafana and xk6-client-tracing in examples

### DIFF
--- a/example/docker-compose/agent/docker-compose.yaml
+++ b/example/docker-compose/agent/docker-compose.yaml
@@ -57,7 +57,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:10.4.2
+    image: grafana/grafana:11.0.0
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/agent/docker-compose.yaml
+++ b/example/docker-compose/agent/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
 
   # Generate fake traces...
   k6-tracing:
-    image: ghcr.io/grafana/xk6-client-tracing:v0.0.2
+    image: ghcr.io/grafana/xk6-client-tracing:v0.0.5
     environment:
       - ENDPOINT=agent:4317
     restart: always

--- a/example/docker-compose/cross-cluster/docker-compose.yaml
+++ b/example/docker-compose/cross-cluster/docker-compose.yaml
@@ -151,7 +151,7 @@ services:
       - mkdir -p /data/tempo && minio server /data --console-address ':9001'
 
   k6-tracing:
-    image: ghcr.io/grafana/xk6-client-tracing:v0.0.2
+    image: ghcr.io/grafana/xk6-client-tracing:v0.0.5
     environment:
       - ENDPOINT=distributor-a:4317
     restart: always

--- a/example/docker-compose/cross-cluster/docker-compose.yaml
+++ b/example/docker-compose/cross-cluster/docker-compose.yaml
@@ -170,7 +170,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:10.4.2
+    image: grafana/grafana:11.0.0
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/debug/docker-compose.yaml
+++ b/example/docker-compose/debug/docker-compose.yaml
@@ -50,7 +50,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:10.4.2
+    image: grafana/grafana:11.0.0
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/debug/docker-compose.yaml
+++ b/example/docker-compose/debug/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
       - init
 
   k6-tracing:
-    image: ghcr.io/grafana/xk6-client-tracing:v0.0.2
+    image: ghcr.io/grafana/xk6-client-tracing:v0.0.5
     environment:
       - ENDPOINT=tempo:4317
     restart: always

--- a/example/docker-compose/distributed/docker-compose.yaml
+++ b/example/docker-compose/distributed/docker-compose.yaml
@@ -125,7 +125,7 @@ services:
       - mkdir -p /data/tempo && minio server /data --console-address ':9001'
 
   k6-tracing:
-    image: ghcr.io/grafana/xk6-client-tracing:latest
+    image: ghcr.io/grafana/xk6-client-tracing:v0.0.5
     environment:
       - ENDPOINT=distributor:4317
     restart: always

--- a/example/docker-compose/distributed/docker-compose.yaml
+++ b/example/docker-compose/distributed/docker-compose.yaml
@@ -146,7 +146,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:10.4.2
+    image: grafana/grafana:11.0.0
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/local/docker-compose.yaml
+++ b/example/docker-compose/local/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
       - init
 
   k6-tracing:
-    image: ghcr.io/grafana/xk6-client-tracing:latest
+    image: ghcr.io/grafana/xk6-client-tracing:v0.0.5
     environment:
       - ENDPOINT=tempo:4317
     restart: always

--- a/example/docker-compose/local/docker-compose.yaml
+++ b/example/docker-compose/local/docker-compose.yaml
@@ -48,7 +48,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:10.4.2
+    image: grafana/grafana:11.0.0
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/multi-tenant/docker-compose.yaml
+++ b/example/docker-compose/multi-tenant/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
       - init
 
   k6-tracing:
-    image: ghcr.io/grafana/xk6-client-tracing:latest
+    image: ghcr.io/grafana/xk6-client-tracing:v0.0.5
     environment:
       - ENDPOINT=tempo:4317
       - TEMPO_X_SCOPE_ORGID=test
@@ -40,7 +40,7 @@ services:
       - tempo
 
   k6-tracing-2:
-    image: ghcr.io/grafana/xk6-client-tracing:latest
+    image: ghcr.io/grafana/xk6-client-tracing:v0.0.5
     environment:
       - ENDPOINT=tempo:4317
       - TEMPO_X_SCOPE_ORGID=test2

--- a/example/docker-compose/multi-tenant/docker-compose.yaml
+++ b/example/docker-compose/multi-tenant/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
       - tempo
 
   grafana:
-    image: grafana/grafana:10.4.2
+    image: grafana/grafana:11.0.0
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
+++ b/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
@@ -55,7 +55,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:10.4.2
+    image: grafana/grafana:11.0.0
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
+++ b/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
 
   # Generate fake traces...
   k6-tracing:
-    image: ghcr.io/grafana/xk6-client-tracing:v0.0.2
+    image: ghcr.io/grafana/xk6-client-tracing:v0.0.5
     environment:
       - ENDPOINT=otel-collector:4317
     restart: always

--- a/example/docker-compose/otel-collector/docker-compose.yaml
+++ b/example/docker-compose/otel-collector/docker-compose.yaml
@@ -55,7 +55,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:10.4.2
+    image: grafana/grafana:11.0.0
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/docker-compose/otel-collector/docker-compose.yaml
+++ b/example/docker-compose/otel-collector/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
 
   # Generate fake traces...
   k6-tracing:
-    image: ghcr.io/grafana/xk6-client-tracing:v0.0.2
+    image: ghcr.io/grafana/xk6-client-tracing:v0.0.5
     environment:
       - ENDPOINT=otel-collector:4317
     restart: always

--- a/example/docker-compose/scalable-single-binary/docker-compose.yaml
+++ b/example/docker-compose/scalable-single-binary/docker-compose.yaml
@@ -83,7 +83,7 @@ services:
       - 9001:9001
 
   k6-tracing:
-    image: ghcr.io/grafana/xk6-client-tracing:v0.0.2
+    image: ghcr.io/grafana/xk6-client-tracing:v0.0.5
     environment:
       - ENDPOINT=tempo1:4317
     restart: always

--- a/example/docker-compose/scalable-single-binary/docker-compose.yaml
+++ b/example/docker-compose/scalable-single-binary/docker-compose.yaml
@@ -59,7 +59,7 @@ services:
       - ./prometheus.yaml:/etc/prometheus.yaml
 
   grafana:
-    image: grafana/grafana:10.4.2
+    image: grafana/grafana:11.0.0
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/example/helm/microservices-extras.yaml
+++ b/example/helm/microservices-extras.yaml
@@ -40,6 +40,6 @@ spec:
       - env:
         - name: ENDPOINT
           value: tempo-distributor:4317
-        image: ghcr.io/grafana/xk6-client-tracing:v0.0.2
+        image: ghcr.io/grafana/xk6-client-tracing:v0.0.5
         imagePullPolicy: IfNotPresent
         name: xk6-tracing

--- a/example/helm/single-binary-extras.yaml
+++ b/example/helm/single-binary-extras.yaml
@@ -40,6 +40,6 @@ spec:
       - env:
         - name: ENDPOINT
           value: tempo:4317
-        image: ghcr.io/grafana/xk6-client-tracing:v0.0.2
+        image: ghcr.io/grafana/xk6-client-tracing:v0.0.5
         imagePullPolicy: IfNotPresent
         name: xk6-tracing


### PR DESCRIPTION
**What this PR does**:

Use the latest release of grafana and xk6-client-tracing in Tempo's docker-compose examples. This improves support for event and links in the examples.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`