### PR TITLE
[TraceQL] Fix subtly incorrect handling of second pass conditions

### DIFF
--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -1756,9 +1756,6 @@ func createResourceIterator(makeIter makeIterFn, spanIterator parquetquery.Itera
 	}
 
 	minCount := 0
-	/*if requireAtLeastOneMatch {
-		minCount = 1
-	}*/
 	if allConditions {
 		// The final number of expected attributes
 		distinct := map[string]struct{}{}
@@ -1777,15 +1774,6 @@ func createResourceIterator(makeIter makeIterFn, spanIterator parquetquery.Itera
 		required = append(required, iters...)
 		iters = nil
 	}
-
-	// This is an optimization for cases when only resource conditions are
-	// present and we require at least one of them to match.  Wrap
-	// up the individual conditions with a union and move it into the
-	// required list.
-	/*if requireAtLeastOneMatch && len(iters) > 0 {
-		required = append(required, unionIfNeeded(DefinitionLevelResourceSpans, iters, nil))
-		iters = nil
-	}*/
 
 	// Put span iterator last so it is only read when
 	// the resource conditions are met.

--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -597,12 +597,12 @@ func BenchmarkBackendBlockTraceQL(b *testing.B) {
 	ctx := context.TODO()
 	tenantID := "1"
 	// blockID := uuid.MustParse("00000c2f-8133-4a60-a62a-7748bd146938")
-	// blockID := uuid.MustParse("06ebd383-8d4e-4289-b0e9-cf2197d611d5")
-	blockID := uuid.MustParse("00145f38-6058-4e57-b1ba-334db8edce23")
+	blockID := uuid.MustParse("06ebd383-8d4e-4289-b0e9-cf2197d611d5")
+	// blockID := uuid.MustParse("00145f38-6058-4e57-b1ba-334db8edce23")
 
 	r, _, _, err := local.New(&local.Config{
-		Path: path.Join("/Users/joe/testblock/"),
-		// Path: path.Join("/Users/marty/src/tmp"),
+		// Path: path.Join("/Users/joe/testblock/"),
+		Path: path.Join("/Users/marty/src/tmp"),
 		//		Path: path.Join("/Users/mapno/workspace/testblock"),
 	})
 	require.NoError(b, err)
@@ -703,6 +703,8 @@ func BenchmarkBackendBlockQueryRange(b *testing.B) {
 		"{} | rate() by (name)",
 		"{} | rate() by (resource.service.name)",
 		"{} | rate() by (span.http.url)", // High cardinality attribute
+		"{} | rate() by (span.foo)",      // Nonexistent, all spans will be in the nil series
+		"{} | rate() by (resource.foo)",  // Nonexistent, all spans will be in the nil series
 		"{resource.service.name=`loki-ingester`} | rate()",
 		"{status=error} | rate()",
 	}
@@ -712,17 +714,16 @@ func BenchmarkBackendBlockQueryRange(b *testing.B) {
 		e        = traceql.NewEngine()
 		opts     = common.DefaultSearchOptions()
 		tenantID = "1"
-		// blockID  = uuid.MustParse("06ebd383-8d4e-4289-b0e9-cf2197d611d5")
-		blockID = uuid.MustParse("0008e57d-069d-4510-a001-b9433b2da08c")
+		blockID  = uuid.MustParse("06ebd383-8d4e-4289-b0e9-cf2197d611d5")
+		// blockID = uuid.MustParse("0008e57d-069d-4510-a001-b9433b2da08c")
 		// blockID = uuid.MustParse("00145f38-6058-4e57-b1ba-334db8edce23")
 		// path    = "/Users/joe/testblock/"
-		path = "/Users/mapno/workspace/testblock"
+		// path = "/Users/mapno/workspace/testblock"
+		path = "/Users/marty/src/tmp"
 	)
 
 	r, _, _, err := local.New(&local.Config{
 		Path: path,
-		// Path: path.Join("/Users/marty/src/tmp"),
-		//		Path: path.Join("/Users/mapno/workspace/testblock"),
 	})
 	require.NoError(b, err)
 
@@ -741,7 +742,7 @@ func BenchmarkBackendBlockQueryRange(b *testing.B) {
 
 	for _, tc := range testCases {
 		b.Run(tc, func(b *testing.B) {
-			for _, minutes := range []int{5, 7} {
+			for _, minutes := range []int{3} {
 				b.Run(strconv.Itoa(minutes), func(b *testing.B) {
 					st := meta.StartTime
 					end := st.Add(time.Duration(minutes) * time.Minute)

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -1455,19 +1455,10 @@ func createAllIterator(ctx context.Context, primaryIter parquetquery.Iterator, c
 	// matched upstream to a resource.
 	// TODO - After introducing AllConditions it seems like some of this logic overlaps.
 	//        Determine if it can be generalized or simplified.
-	var (
-		// If there are only span conditions, then don't return a span upstream
-		// unless it matches at least 1 span-level condition.
-		spanRequireAtLeastOneMatch = len(spanConditions) > 0 && len(resourceConditions) == 0 && len(traceConditions) == 0
 
-		// If there are only resource conditions, then don't return a resource upstream
-		// unless it matches at least 1 resource-level condition.
-		batchRequireAtLeastOneMatch = len(spanConditions) == 0 && len(resourceConditions) > 0 && len(traceConditions) == 0
-
-		// Don't return the final spanset upstream unless it matched at least 1 condition
-		// anywhere, except in the case of the empty query: {}
-		batchRequireAtLeastOneMatchOverall = len(conds) > 0 && len(traceConditions) == 0 && len(traceConditions) == 0
-	)
+	// Don't return the final spanset upstream unless it matched at least 1 condition
+	// anywhere, except in the case of the empty query: {}
+	batchRequireAtLeastOneMatchOverall := len(conds) > 0 && len(traceConditions) == 0 && len(traceConditions) == 0
 
 	// Optimization for queries like {resource.x... && span.y ...}
 	// Requires no mingled scopes like .foo=x, which could be satisfied
@@ -1479,12 +1470,12 @@ func createAllIterator(ctx context.Context, primaryIter parquetquery.Iterator, c
 		return nil, fmt.Errorf("creating event iterator: %w", err)
 	}
 
-	spanIter, err := createSpanIterator(makeIter, eventIter, spanConditions, spanRequireAtLeastOneMatch, allConditions, dc)
+	spanIter, err := createSpanIterator(makeIter, eventIter, spanConditions, allConditions, dc)
 	if err != nil {
 		return nil, fmt.Errorf("creating span iterator: %w", err)
 	}
 
-	resourceIter, err := createResourceIterator(makeIter, spanIter, resourceConditions, batchRequireAtLeastOneMatch, batchRequireAtLeastOneMatchOverall, allConditions, dc)
+	resourceIter, err := createResourceIterator(makeIter, spanIter, resourceConditions, batchRequireAtLeastOneMatchOverall, allConditions, dc)
 	if err != nil {
 		return nil, fmt.Errorf("creating resource iterator: %w", err)
 	}
@@ -1519,7 +1510,7 @@ func createEventIterator(makeIter makeIterFn, primaryIter parquetquery.Iterator,
 
 // createSpanIterator iterates through all span-level columns, groups them into rows representing
 // one span each.  Spans are returned that match any of the given conditions.
-func createSpanIterator(makeIter makeIterFn, primaryIter parquetquery.Iterator, conditions []traceql.Condition, requireAtLeastOneMatch, allConditions bool, dedicatedColumns backend.DedicatedColumns) (parquetquery.Iterator, error) {
+func createSpanIterator(makeIter makeIterFn, primaryIter parquetquery.Iterator, conditions []traceql.Condition, allConditions bool, dedicatedColumns backend.DedicatedColumns) (parquetquery.Iterator, error) {
 	var (
 		columnSelectAs          = map[string]string{}
 		columnPredicates        = map[string][]parquetquery.Predicate{}
@@ -1728,9 +1719,6 @@ func createSpanIterator(makeIter makeIterFn, primaryIter parquetquery.Iterator, 
 	}
 
 	minCount := 0
-	if requireAtLeastOneMatch {
-		minCount = 1
-	}
 	if allConditions {
 		// The final number of expected attributes.
 		distinct := map[string]struct{}{}
@@ -1754,16 +1742,6 @@ func createSpanIterator(makeIter makeIterFn, primaryIter parquetquery.Iterator, 
 		iters = nil
 	}
 
-	// This is an optimization for cases when allConditions is false, and
-	// only span conditions are present, and we require at least one of them to match.
-	// Wrap up the individual conditions with a union and move it into the required list.
-	// This skips over static columns like ID that are omnipresent. This is also only
-	// possible when there isn't a duration filter because it's computed from start/end.
-	if requireAtLeastOneMatch && len(iters) > 0 {
-		required = append(required, unionIfNeeded(DefinitionLevelResourceSpansILSSpan, iters, nil))
-		iters = nil
-	}
-
 	// if there are no direct conditions imposed on the span/span attributes level we are purposefully going to request the "Kind" column
 	//  b/c it is extremely cheap to retrieve. retrieving matching spans in this case will allow aggregates such as "count" to be computed
 	//  how do we know to pull duration for things like | avg(duration) > 1s? look at avg(span.http.status_code) it pushes a column request down here
@@ -1784,7 +1762,7 @@ func createSpanIterator(makeIter makeIterFn, primaryIter parquetquery.Iterator, 
 // createResourceIterator iterates through all resourcespans-level (batch-level) columns, groups them into rows representing
 // one batch each. It builds on top of the span iterator, and turns the groups of spans and resource-level values into
 // spansets. Spansets are returned that match any of the given conditions.
-func createResourceIterator(makeIter makeIterFn, spanIterator parquetquery.Iterator, conditions []traceql.Condition, requireAtLeastOneMatch, requireAtLeastOneMatchOverall, allConditions bool, dedicatedColumns backend.DedicatedColumns) (parquetquery.Iterator, error) {
+func createResourceIterator(makeIter makeIterFn, spanIterator parquetquery.Iterator, conditions []traceql.Condition, requireAtLeastOneMatchOverall, allConditions bool, dedicatedColumns backend.DedicatedColumns) (parquetquery.Iterator, error) {
 	var (
 		columnSelectAs    = map[string]string{}
 		columnPredicates  = map[string][]parquetquery.Predicate{}
@@ -1857,9 +1835,6 @@ func createResourceIterator(makeIter makeIterFn, spanIterator parquetquery.Itera
 	}
 
 	minCount := 0
-	if requireAtLeastOneMatch {
-		minCount = 1
-	}
 	if allConditions {
 		// The final number of expected attributes
 		distinct := map[string]struct{}{}
@@ -1876,15 +1851,6 @@ func createResourceIterator(makeIter makeIterFn, spanIterator parquetquery.Itera
 	// We simply move all iterators into the required list.
 	if allConditions {
 		required = append(required, iters...)
-		iters = nil
-	}
-
-	// This is an optimization for cases when only resource conditions are
-	// present and we require at least one of them to match.  Wrap
-	// up the individual conditions with a union and move it into the
-	// required list.
-	if requireAtLeastOneMatch && len(iters) > 0 {
-		required = append(required, unionIfNeeded(DefinitionLevelResourceSpans, iters, nil))
 		iters = nil
 	}
 


### PR DESCRIPTION
**What this PR does**:
I'm pretty happy about this PR.  It started off as a metrics grouping bug, but ended up with deleting very old parquet cruft that's been on our todo list for over a year. 😎 

The bug is that conditions put in the second pass could be subjected to existence checks incorrectly.  The query `{ } | rate() by(span.foo)` should plot all spans in the "nil" time-series, because the first part `{ }` matches all spans, and the second part `span.foo` doesn't exist.  However it was returning the dreaded No Data.   

![image](https://github.com/grafana/tempo/assets/13524475/902c4b95-5b0b-4309-81a2-b06ee4930601)

Adding a condition to the query fixed it.

![image](https://github.com/grafana/tempo/assets/13524475/3773be8a-340b-4036-b5d0-1d30e4a09863)

The source of the bug was the very crufty and very old "requireAtLeastOneMatch" class of optimizations.  These optimizations predate the AllConditions, and as we suspected they were redundant and could be deleted.  On the second pass we set AllConditions = false so that the second pass is considered truly optional.  However these optimizations were forcing it back into an "all-conditions-like" mode and requiring the existent of `by(span.foo)`.   Simply deleting these and relying on AllConditions led to the correct behavior.

The remaining `batchRequireAtLeastOneMatchOverall` cannot yet be deleted.

Here is a snippet from the query_range benchmarks before and after with cases added for this query.  Notice that the queries matched 0 spans before, but now they match all spans again.  (In fact because all queries have `{ }` they match the same number of spans no matter how they are grouped)

```
name                                                                       old spans/op   new spans/op     delta
BackendBlockQueryRange/{}_|_rate()/3                                          2.55M ± 0%       2.55M ± 0%        ~     (all equal)
BackendBlockQueryRange/{}_|_rate()_by_(name)/3                                2.55M ± 0%       2.55M ± 0%        ~     (all equal)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/3               2.55M ± 0%       2.55M ± 0%        ~     (all equal)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/3                       2.55M ± 0%       2.55M ± 0%        ~     (all equal)
BackendBlockQueryRange/{}_|_rate()_by_(span.foo)/3                             0.00       2552739.00 ± 0%       +Inf%  (p=0.000 n=10+10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.foo)/3                         0.00       2552739.00 ± 0%       +Inf%  (p=0.000 n=10+10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/3      504k ± 0%        504k ± 0%        ~     (all equal)
BackendBlockQueryRange/{status=error}_|_rate()/3                              93.8k ± 0%       93.8k ± 0%        ~     (all equal)
``` 

Benchmarks for search show some noise, but I don't think this actually changed performance. Because queries `{...} | select(...)` already set AllConditions to false (because of the pipeline).  TODO - This can probably be fixed now.

<details>
<summary>BenchmarkBackendBlockTraceQL</summary>

```
name                                              old time/op    new time/op    delta
BackendBlockTraceQL/spanAttValMatch                  133ms ± 8%     133ms ± 5%    ~     (p=0.853 n=10+10)
BackendBlockTraceQL/spanAttValNoMatch               3.80ms ± 2%    3.78ms ± 2%    ~     (p=0.633 n=10+8)
BackendBlockTraceQL/spanAttIntrinsicMatch           63.1ms ± 2%    64.5ms ± 1%  +2.26%  (p=0.001 n=10+8)
BackendBlockTraceQL/spanAttIntrinsicNoMatch         2.92ms ± 2%    2.94ms ± 2%    ~     (p=0.353 n=10+10)
BackendBlockTraceQL/resourceAttValMatch              602ms ±10%     591ms ± 2%    ~     (p=0.796 n=10+10)
BackendBlockTraceQL/resourceAttValNoMatch           2.97ms ± 4%    2.95ms ± 2%    ~     (p=0.631 n=10+10)
BackendBlockTraceQL/resourceAttIntrinsicMatch       14.4ms ± 2%    14.3ms ± 3%    ~     (p=0.315 n=10+10)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01    2.95ms ± 1%    2.99ms ± 3%  +1.38%  (p=0.035 n=10+10)
BackendBlockTraceQL/mixedValNoMatch                  177ms ± 2%     176ms ± 1%  -0.89%  (p=0.013 n=10+9)
BackendBlockTraceQL/mixedValMixedMatchAnd           2.99ms ± 4%    2.96ms ± 4%    ~     (p=0.393 n=10+10)
BackendBlockTraceQL/mixedValMixedMatchOr             169ms ± 2%     168ms ± 2%    ~     (p=0.436 n=10+10)
BackendBlockTraceQL/count                            424ms ± 3%     456ms ± 2%  +7.63%  (p=0.000 n=10+9)
BackendBlockTraceQL/struct                           612ms ±10%     610ms ± 9%    ~     (p=0.796 n=10+10)
BackendBlockTraceQL/||                              83.4ms ± 6%    82.2ms ± 2%    ~     (p=0.315 n=10+10)
BackendBlockTraceQL/mixed                           52.3ms ± 1%    52.1ms ± 1%    ~     (p=0.278 n=10+9)
BackendBlockTraceQL/complex                         3.82ms ± 3%    3.79ms ± 1%    ~     (p=0.101 n=10+8)

name                                              old speed      new speed      delta
BackendBlockTraceQL/spanAttValMatch                113MB/s ± 7%   113MB/s ± 5%    ~     (p=0.853 n=10+10)
BackendBlockTraceQL/spanAttValNoMatch              541MB/s ± 2%   544MB/s ± 2%    ~     (p=0.617 n=10+8)
BackendBlockTraceQL/spanAttIntrinsicMatch          249MB/s ± 2%   244MB/s ± 1%  -2.23%  (p=0.001 n=10+8)
BackendBlockTraceQL/spanAttIntrinsicNoMatch        507MB/s ± 2%   505MB/s ± 2%    ~     (p=0.353 n=10+10)
BackendBlockTraceQL/resourceAttValMatch           24.7MB/s ± 9%  25.1MB/s ± 2%    ~     (p=0.754 n=10+10)
BackendBlockTraceQL/resourceAttValNoMatch          149MB/s ± 3%   150MB/s ± 2%    ~     (p=0.631 n=10+10)
BackendBlockTraceQL/resourceAttIntrinsicMatch      920MB/s ± 2%   925MB/s ± 3%    ~     (p=0.315 n=10+10)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01   162MB/s ± 1%   160MB/s ± 3%  -1.35%  (p=0.034 n=10+10)
BackendBlockTraceQL/mixedValNoMatch               13.2MB/s ± 2%  13.3MB/s ± 1%  +0.89%  (p=0.014 n=10+9)
BackendBlockTraceQL/mixedValMixedMatchAnd          152MB/s ± 4%   154MB/s ± 4%    ~     (p=0.393 n=10+10)
BackendBlockTraceQL/mixedValMixedMatchOr          94.9MB/s ± 2%  95.2MB/s ± 2%    ~     (p=0.436 n=10+10)
BackendBlockTraceQL/count                         34.3MB/s ± 3%  32.5MB/s ± 2%  -5.41%  (p=0.000 n=10+9)
BackendBlockTraceQL/struct                        27.1MB/s ±10%  27.2MB/s ±10%    ~     (p=0.754 n=10+10)
BackendBlockTraceQL/||                             179MB/s ± 6%   181MB/s ± 2%    ~     (p=0.315 n=10+10)
BackendBlockTraceQL/mixed                          281MB/s ± 1%   282MB/s ± 1%    ~     (p=0.278 n=10+9)
BackendBlockTraceQL/complex                        488MB/s ± 1%   494MB/s ± 2%  +1.12%  (p=0.043 n=8+10)

name                                              old MB_io/op   new MB_io/op   delta
BackendBlockTraceQL/spanAttValMatch                   15.1 ± 0%      15.1 ± 0%    ~     (all equal)
BackendBlockTraceQL/spanAttValNoMatch                 2.05 ± 0%      2.05 ± 0%    ~     (all equal)
BackendBlockTraceQL/spanAttIntrinsicMatch             15.7 ± 0%      15.7 ± 0%    ~     (all equal)
BackendBlockTraceQL/spanAttIntrinsicNoMatch           1.48 ± 0%      1.48 ± 0%    ~     (all equal)
BackendBlockTraceQL/resourceAttValMatch               14.8 ± 0%      14.8 ± 0%    ~     (all equal)
BackendBlockTraceQL/resourceAttValNoMatch             0.44 ± 0%      0.44 ± 0%    ~     (all equal)
BackendBlockTraceQL/resourceAttIntrinsicMatch         13.2 ± 0%      13.2 ± 0%    ~     (all equal)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01      0.48 ± 0%      0.48 ± 0%    ~     (all equal)
BackendBlockTraceQL/mixedValNoMatch                   2.34 ± 0%      2.34 ± 0%    ~     (all equal)
BackendBlockTraceQL/mixedValMixedMatchAnd             0.46 ± 0%      0.46 ± 0%    ~     (all equal)
BackendBlockTraceQL/mixedValMixedMatchOr              16.0 ± 0%      16.0 ± 0%    ~     (all equal)
BackendBlockTraceQL/count                             14.6 ± 0%      14.8 ± 0%  +1.79%  (p=0.000 n=10+10)
BackendBlockTraceQL/struct                            16.5 ± 0%      16.5 ± 0%    ~     (all equal)
BackendBlockTraceQL/||                                14.9 ± 0%      14.9 ± 0%    ~     (all equal)
BackendBlockTraceQL/mixed                             14.7 ± 0%      14.7 ± 0%    ~     (all equal)
BackendBlockTraceQL/complex                           1.86 ± 1%      1.88 ± 3%  +1.18%  (p=0.048 n=9+9)

name                                              old alloc/op   new alloc/op   delta
BackendBlockTraceQL/spanAttValMatch                 34.0MB ± 1%    33.9MB ± 1%    ~     (p=0.436 n=10+10)
BackendBlockTraceQL/spanAttValNoMatch               1.63MB ± 0%    1.63MB ± 0%    ~     (p=0.065 n=9+10)
BackendBlockTraceQL/spanAttIntrinsicMatch           15.4MB ± 1%    15.5MB ± 0%    ~     (p=0.360 n=10+8)
BackendBlockTraceQL/spanAttIntrinsicNoMatch         1.17MB ± 0%    1.17MB ± 0%    ~     (p=0.753 n=10+10)
BackendBlockTraceQL/resourceAttValMatch              323MB ± 0%     323MB ± 0%    ~     (p=0.853 n=10+10)
BackendBlockTraceQL/resourceAttValNoMatch           1.14MB ± 0%    1.14MB ± 0%    ~     (p=0.104 n=10+9)
BackendBlockTraceQL/resourceAttIntrinsicMatch       1.27MB ± 0%    1.27MB ± 0%    ~     (p=0.883 n=10+8)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01    1.14MB ± 0%    1.14MB ± 0%    ~     (p=0.170 n=10+10)
BackendBlockTraceQL/mixedValNoMatch                 1.68MB ± 0%    1.68MB ± 0%    ~     (p=1.000 n=8+8)
BackendBlockTraceQL/mixedValMixedMatchAnd           1.14MB ± 0%    1.14MB ± 0%    ~     (p=0.323 n=10+10)
BackendBlockTraceQL/mixedValMixedMatchOr            2.08MB ± 4%    2.11MB ± 2%    ~     (p=0.929 n=10+10)
BackendBlockTraceQL/count                            231MB ± 0%     233MB ± 0%  +0.87%  (p=0.000 n=8+10)
BackendBlockTraceQL/struct                          12.4MB ± 2%    12.4MB ± 2%    ~     (p=1.000 n=9+9)
BackendBlockTraceQL/||                              17.3MB ± 0%    17.3MB ± 0%    ~     (p=0.052 n=10+10)
BackendBlockTraceQL/mixed                           4.13MB ± 0%    4.13MB ± 0%    ~     (p=0.912 n=10+10)
BackendBlockTraceQL/complex                         1.21MB ± 1%    1.20MB ± 0%    ~     (p=0.068 n=10+8)

name                                              old allocs/op  new allocs/op  delta
BackendBlockTraceQL/spanAttValMatch                   343k ± 0%      343k ± 0%    ~     (p=0.954 n=10+9)
BackendBlockTraceQL/spanAttValNoMatch                17.4k ± 0%     17.4k ± 0%    ~     (p=0.370 n=10+10)
BackendBlockTraceQL/spanAttIntrinsicMatch             122k ± 0%      122k ± 0%    ~     (p=0.769 n=10+9)
BackendBlockTraceQL/spanAttIntrinsicNoMatch          17.4k ± 0%     17.4k ± 0%    ~     (all equal)
BackendBlockTraceQL/resourceAttValMatch              2.34M ± 0%     2.34M ± 0%    ~     (p=0.956 n=10+10)
BackendBlockTraceQL/resourceAttValNoMatch            17.4k ± 0%     17.4k ± 0%    ~     (all equal)
BackendBlockTraceQL/resourceAttIntrinsicMatch        18.6k ± 0%     18.6k ± 0%    ~     (p=0.173 n=10+9)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01     17.4k ± 0%     17.4k ± 0%    ~     (all equal)
BackendBlockTraceQL/mixedValNoMatch                  18.2k ± 0%     18.2k ± 0%    ~     (all equal)
BackendBlockTraceQL/mixedValMixedMatchAnd            17.4k ± 0%     17.4k ± 0%    ~     (all equal)
BackendBlockTraceQL/mixedValMixedMatchOr             24.4k ± 0%     24.4k ± 0%    ~     (p=0.988 n=10+10)
BackendBlockTraceQL/count                            1.53M ± 0%     1.53M ± 0%  +0.03%  (p=0.000 n=10+10)
BackendBlockTraceQL/struct                           49.7k ± 1%     49.7k ± 1%    ~     (p=0.981 n=8+8)
BackendBlockTraceQL/||                                149k ± 0%      149k ± 0%    ~     (p=0.889 n=9+10)
BackendBlockTraceQL/mixed                            44.8k ± 0%     44.8k ± 0%    ~     (p=0.892 n=9+10)
BackendBlockTraceQL/complex                          17.8k ± 0%     17.8k ± 0%    ~     (p=0.187 n=9+10)
```

</details>

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`