### PR TITLE
[DOC] Remove  blog link from 2.5 release notes

### DIFF
--- a/docs/sources/tempo/release-notes/v2-5.md
+++ b/docs/sources/tempo/release-notes/v2-5.md
@@ -17,11 +17,11 @@ This release gives you:
 
 As part of this release, we’ve updated ownership for `/var/tempo` from `root:root` to a new `tempo:tempo` user with a UUID of `10001`. Learn about this breaking change in Upgrade considerations.
 
-Read the [Tempo 2.5 blog post](https://grafana.com/blog/2024/05/28/grafana-tempo-2.5-release-vparquet4-streaming-endpoints-and-more-metrics/) for more examples and details about these improvements.
+<!--Read the [Tempo 2.5 blog post](https://grafana.com/blog/2024/05/28/grafana-tempo-2.5-release-vparquet4-streaming-endpoints-and-more-metrics/) for more examples and details about these improvements. -->
 
 These release notes highlight the most important features and bugfixes. For a complete list, refer to the [Tempo changelog](https://github.com/grafana/tempo/releases).
 
-{{< youtube id="c4gW9fwkLhc" >}}
+<!-- {{< youtube id="c4gW9fwkLhc" >}} -->
 
 ## Features and enhancements
 

--- a/docs/sources/tempo/traceql/architecture.md
+++ b/docs/sources/tempo/traceql/architecture.md
@@ -31,7 +31,7 @@ For examples of query syntax, refer to [Construct a TraceQL query]({{< relref ".
 
 TraceQL will be implemented in phases. The initial iteration of the TraceQL engine includes spanset selection and pipelines.
 
-For more information about TraceQL’s design, refer to the [TraceQL Concepts design proposal](https://github.com/grafana/tempo/blob/main/docs/design-proposals/2022-04%20TraceQL%20Concepts.md).
+For more information about TraceQL’s design, refer to the [TraceQL extensions](https://github.com/grafana/tempo/blob/main/docs/design-proposals/2023-11%20TraceQL%20Extensions.md) abd [TraceQL Concepts](https://github.com/grafana/tempo/blob/main/docs/design-proposals/2022-04%20TraceQL%20Concepts.md) design proposals.
 
 ### Future work
 


### PR DESCRIPTION

**What this PR does**:
Removes the blog post link from the release notes. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`