### PR TITLE
Fix block reload in local-blocks

### DIFF
--- a/modules/generator/processor/localblocks/processor.go
+++ b/modules/generator/processor/localblocks/processor.go
@@ -652,6 +652,7 @@ func (p *Processor) deleteOldBlocks() (err error) {
 		}
 
 		if flushedTime.Add(p.Cfg.CompleteBlockTimeout).Before(time.Now()) {
+			level.Info(p.logger).Log("msg", "deleting complete block", "block", id.String())
 			err = p.wal.LocalBackend().ClearBlock(id, p.tenant)
 			if err != nil {
 				return err

--- a/modules/generator/processor/localblocks/processor.go
+++ b/modules/generator/processor/localblocks/processor.go
@@ -652,7 +652,7 @@ func (p *Processor) deleteOldBlocks() (err error) {
 		}
 
 		if flushedTime.Add(p.Cfg.CompleteBlockTimeout).Before(time.Now()) {
-			level.Info(p.logger).Log("msg", "deleting complete block", "block", id.String())
+			level.Info(p.logger).Log("msg", "deleting flushed complete block", "block", id.String())
 			err = p.wal.LocalBackend().ClearBlock(id, p.tenant)
 			if err != nil {
 				return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Fix for bug introduced in https://github.com/grafana/tempo/pull/3691.

If `FlushToStorage` was set to `false` (default), complete blocks were not handled correctly:
* local blocks are no longer pushed to the queue to be flushed during reload (start-up)
* complete blocks can now be deleted if old (`endTime < now + completeBlockTimeout`)