### PR TITLE
QueryRange use protobuf internally instead of json to reduce latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [FEATURE] TraceQL support for event scope and event:name intrinsic [#3708](https://github.com/grafana/tempo/pull/3708) (@stoewer)
 * [FEATURE] Flush and query RF1 blocks for TraceQL metric queries [#3628](https://github.com/grafana/tempo/pull/3628) [#3691](https://github.com/grafana/tempo/pull/3691) [#3723](https://github.com/grafana/tempo/pull/3723) (@mapno)
 * [ENHANCEMENT] Tag value lookup use protobuf internally for improved latency [#3731](https://github.com/grafana/tempo/pull/3731) (@mdisibio)
+* [ENHANCEMENT] TraceQL metrics queries use protobuf internally for improved latency [#3745](https://github.com/grafana/tempo/pull/3745) (@mdisibio)
 * [ENHANCEMENT] Improve use of OTEL semantic conventions on the service graph [#3711](https://github.com/grafana/tempo/pull/3711) (@zalegrala)
 * [ENHANCEMENT] Performance improvement for `rate() by ()` queries [#3719](https://github.com/grafana/tempo/pull/3719) (@mapno)
 * [BUGFIX] Fix metrics queries when grouping by attributes that may not exist [#3734](https://github.com/grafana/tempo/pull/3734) (@mdisibio)

--- a/modules/frontend/metrics_query_range_sharder.go
+++ b/modules/frontend/metrics_query_range_sharder.go
@@ -389,6 +389,7 @@ func (s *queryRangeSharder) buildBackendRequests(ctx context.Context, tenantID s
 			queryRangeReq.End += queryRangeReq.Step
 
 			subR = api.BuildQueryRangeRequest(subR, queryRangeReq)
+			subR.Header.Set(api.HeaderAccept, api.HeaderAcceptProtobuf)
 
 			prepareRequestForQueriers(subR, tenantID, subR.URL.Path, subR.URL.Query())
 			// TODO: Handle sampling rate
@@ -438,7 +439,10 @@ func (s *queryRangeSharder) generatorRequest(searchReq tempopb.QueryRangeRequest
 
 	searchReq.QueryMode = querier.QueryModeRecent
 
-	return s.toUpstreamRequest(parent.Context(), searchReq, parent, tenantID)
+	req := s.toUpstreamRequest(parent.Context(), searchReq, parent, tenantID)
+	req.Header.Set(api.HeaderAccept, api.HeaderAcceptProtobuf)
+
+	return req
 }
 
 func (s *queryRangeSharder) toUpstreamRequest(ctx context.Context, req tempopb.QueryRangeRequest, parent *http.Request, tenantID string) *http.Request {

--- a/modules/querier/http.go
+++ b/modules/querier/http.go
@@ -409,22 +409,7 @@ func (q *Querier) QueryRangeHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		m := jsonpb.Marshaler{}
-		jsBytes, funcErr := m.MarshalToString(resp)
-		if funcErr != nil {
-			errHandler(ctx, span, funcErr)
-			http.Error(w, funcErr.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		_, funcErr = w.Write([]byte(jsBytes))
-		if funcErr != nil {
-			errHandler(ctx, span, funcErr)
-			http.Error(w, funcErr.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		w.Header().Set(api.HeaderContentType, api.HeaderAcceptJSON)
+		writeFormattedContentForRequest(w, r, resp)
 	}()
 
 	req, err := api.ParseQueryRangeRequest(r)


### PR DESCRIPTION
**What this PR does**:
Similar to #3731 but for query_range.  For high cardinality metrics queriers on larger clusters, the marshaling/unmarshaling of json was becoming the bottleneck in the query-frontend.   Metrics queries have larger and more numerous jobs than autocomplete, so the improvement is even better.   I was thinking about why this was just now being noticed, since autocomplete and query_range have existed for some time and the request/response formats haven't changed.  I believe it is due to the recently added asynchronous frontend pipeline.  Two changes (1) It is more efficient at issuing jobs, so the bottleneck in the frontend from unmarshaling is now readily apparent (2) the unmarshaling was moved to a single goroutine, which will be restored in #3713 however this PR is more impactful because it greatly reduces the overall amount of work done by the frontend (versus spreading it out among more cpu cores).

Here is another graph showing the improvement for the query `{ } | rate() by (resource.service.name)` of 3h time range, from ~80s to 20s (all cluster and request parameters the same).

![image](https://github.com/grafana/tempo/assets/13524475/3dfc4af8-46eb-4a1c-9251-6d6aa2bf03bd)


NOTE - I only did this for the rf1 read path.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`