### PR TITLE
search/utils: added missing new intrinsic names to search/tags endpoint

### DIFF
--- a/modules/ingester/instance_search_test.go
+++ b/modules/ingester/instance_search_test.go
@@ -378,7 +378,7 @@ func TestInstanceSearchTagsSpecialCases(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(
 		t,
-		[]string{"duration", "kind", "name", "status", "statusMessage", "traceDuration", "rootServiceName", "rootName", "span:status", "span:statusMessage", "span:duration", "span:name", "span:kind", "trace:rootName", "trace:rootServiceName"},
+		[]string{"duration", "kind", "name", "status", "statusMessage", "traceDuration", "rootServiceName", "rootName", "span:status", "span:statusMessage", "span:duration", "span:name", "span:kind", "trace:rootName", "trace:rootServiceName", "trace:traceDuration"},
 		resp.TagNames,
 	)
 }

--- a/modules/ingester/instance_search_test.go
+++ b/modules/ingester/instance_search_test.go
@@ -378,7 +378,7 @@ func TestInstanceSearchTagsSpecialCases(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(
 		t,
-		[]string{"duration", "kind", "name", "status", "statusMessage", "traceDuration", "rootServiceName", "rootName"},
+		[]string{"duration", "kind", "name", "status", "statusMessage", "traceDuration", "rootServiceName", "rootName", "span:status", "span:statusMessage", "span:duration", "span:name", "span:kind", "trace:rootName", "trace:rootServiceName"},
 		resp.TagNames,
 	)
 }

--- a/pkg/search/util.go
+++ b/pkg/search/util.go
@@ -71,6 +71,7 @@ func GetVirtualIntrinsicValues() []string {
 		traceql.ScopedIntrinsicSpanKind.String(),
 		traceql.ScopedIntrinsicTraceRootName.String(),
 		traceql.ScopedIntrinsicTraceRootServiceName.String(),
+		traceql.ScopedIntrinsicTraceDuration.String(),
 		/* these are technically intrinsics that can be requested, but they are not generally of interest to a user
 		   typing a query. for simplicity and clarity we are leaving them out of autocomplete
 			IntrinsicNestedSetLeft

--- a/pkg/search/util.go
+++ b/pkg/search/util.go
@@ -30,13 +30,13 @@ func GetVirtualTagValues(tagName string) []string {
 
 func GetVirtualTagValuesV2(tagName string) []tempopb.TagValue {
 	switch tagName {
-	case traceql.IntrinsicStatus.String(), traceql.IntrinsicSpanStatus.String():
+	case traceql.IntrinsicStatus.String(), traceql.ScopedIntrinsicSpanStatus.String():
 		return []tempopb.TagValue{
 			{Type: "keyword", Value: traceql.StatusOk.String()},
 			{Type: "keyword", Value: traceql.StatusError.String()},
 			{Type: "keyword", Value: traceql.StatusUnset.String()},
 		}
-	case traceql.IntrinsicKind.String(), traceql.IntrinsicSpanKind.String():
+	case traceql.IntrinsicKind.String(), traceql.ScopedIntrinsicSpanKind.String():
 		return []tempopb.TagValue{
 			{Type: "keyword", Value: traceql.KindClient.String()},
 			{Type: "keyword", Value: traceql.KindServer.String()},
@@ -45,7 +45,7 @@ func GetVirtualTagValuesV2(tagName string) []tempopb.TagValue {
 			{Type: "keyword", Value: traceql.KindInternal.String()},
 			{Type: "keyword", Value: traceql.KindUnspecified.String()},
 		}
-	case traceql.IntrinsicDuration.String(), traceql.IntrinsicSpanDuration.String():
+	case traceql.IntrinsicDuration.String(), traceql.ScopedIntrinsicSpanDuration.String():
 		return []tempopb.TagValue{}
 	case traceql.IntrinsicTraceDuration.String():
 		return []tempopb.TagValue{}
@@ -64,13 +64,13 @@ func GetVirtualIntrinsicValues() []string {
 		traceql.IntrinsicTraceDuration.String(),
 		traceql.IntrinsicTraceRootService.String(),
 		traceql.IntrinsicTraceRootSpan.String(),
-		traceql.IntrinsicSpanStatus.String(),
-		traceql.IntrinsicSpanStatusMessage.String(),
-		traceql.IntrinsicSpanDuration.String(),
-		traceql.IntrinsicSpanName.String(),
-		traceql.IntrinsicSpanKind.String(),
-		traceql.IntrinsicTraceRootName.String(),
-		traceql.IntrinsicTraceRootServiceName.String(),
+		traceql.ScopedIntrinsicSpanStatus.String(),
+		traceql.ScopedIntrinsicSpanStatusMessage.String(),
+		traceql.ScopedIntrinsicSpanDuration.String(),
+		traceql.ScopedIntrinsicSpanName.String(),
+		traceql.ScopedIntrinsicSpanKind.String(),
+		traceql.ScopedIntrinsicTraceRootName.String(),
+		traceql.ScopedIntrinsicTraceRootServiceName.String(),
 		/* these are technically intrinsics that can be requested, but they are not generally of interest to a user
 		   typing a query. for simplicity and clarity we are leaving them out of autocomplete
 			IntrinsicNestedSetLeft

--- a/pkg/search/util.go
+++ b/pkg/search/util.go
@@ -30,13 +30,13 @@ func GetVirtualTagValues(tagName string) []string {
 
 func GetVirtualTagValuesV2(tagName string) []tempopb.TagValue {
 	switch tagName {
-	case traceql.IntrinsicStatus.String():
+	case traceql.IntrinsicStatus.String(), traceql.IntrinsicSpanStatus.String():
 		return []tempopb.TagValue{
 			{Type: "keyword", Value: traceql.StatusOk.String()},
 			{Type: "keyword", Value: traceql.StatusError.String()},
 			{Type: "keyword", Value: traceql.StatusUnset.String()},
 		}
-	case traceql.IntrinsicKind.String():
+	case traceql.IntrinsicKind.String(), traceql.IntrinsicSpanKind.String():
 		return []tempopb.TagValue{
 			{Type: "keyword", Value: traceql.KindClient.String()},
 			{Type: "keyword", Value: traceql.KindServer.String()},
@@ -45,7 +45,7 @@ func GetVirtualTagValuesV2(tagName string) []tempopb.TagValue {
 			{Type: "keyword", Value: traceql.KindInternal.String()},
 			{Type: "keyword", Value: traceql.KindUnspecified.String()},
 		}
-	case traceql.IntrinsicDuration.String():
+	case traceql.IntrinsicDuration.String(), traceql.IntrinsicSpanDuration.String():
 		return []tempopb.TagValue{}
 	case traceql.IntrinsicTraceDuration.String():
 		return []tempopb.TagValue{}
@@ -64,6 +64,13 @@ func GetVirtualIntrinsicValues() []string {
 		traceql.IntrinsicTraceDuration.String(),
 		traceql.IntrinsicTraceRootService.String(),
 		traceql.IntrinsicTraceRootSpan.String(),
+		traceql.IntrinsicSpanStatus.String(),
+		traceql.IntrinsicSpanStatusMessage.String(),
+		traceql.IntrinsicSpanDuration.String(),
+		traceql.IntrinsicSpanName.String(),
+		traceql.IntrinsicSpanKind.String(),
+		traceql.IntrinsicTraceRootName.String(),
+		traceql.IntrinsicTraceRootServiceName.String(),
 		/* these are technically intrinsics that can be requested, but they are not generally of interest to a user
 		   typing a query. for simplicity and clarity we are leaving them out of autocomplete
 			IntrinsicNestedSetLeft

--- a/pkg/traceql/enum_attributes.go
+++ b/pkg/traceql/enum_attributes.go
@@ -89,13 +89,13 @@ const (
 
 	IntrinsicTraceID
 	IntrinsicSpanID
-	IntrinsicSpanStatus
-	IntrinsicSpanStatusMessage
-	IntrinsicSpanDuration
-	IntrinsicSpanName
-	IntrinsicSpanKind
-	IntrinsicTraceRootName
-	IntrinsicTraceRootServiceName
+	ScopedIntrinsicSpanStatus
+	ScopedIntrinsicSpanStatusMessage
+	ScopedIntrinsicSpanDuration
+	ScopedIntrinsicSpanName
+	ScopedIntrinsicSpanKind
+	ScopedIntrinsicTraceRootName
+	ScopedIntrinsicTraceRootServiceName
 
 	// not yet implemented in traceql and may never be. these exist so that we can retrieve
 	// these fields from the fetch layer
@@ -158,19 +158,19 @@ func (i Intrinsic) String() string {
 		return "trace:id"
 	case IntrinsicTraceStartTime:
 		return "traceStartTime"
-	case IntrinsicSpanStatus:
+	case ScopedIntrinsicSpanStatus:
 		return "span:status"
-	case IntrinsicSpanStatusMessage:
+	case ScopedIntrinsicSpanStatusMessage:
 		return "span:statusMessage"
-	case IntrinsicSpanDuration:
+	case ScopedIntrinsicSpanDuration:
 		return "span:duration"
-	case IntrinsicSpanName:
+	case ScopedIntrinsicSpanName:
 		return "span:name"
-	case IntrinsicSpanKind:
+	case ScopedIntrinsicSpanKind:
 		return "span:kind"
-	case IntrinsicTraceRootName:
+	case ScopedIntrinsicTraceRootName:
 		return "trace:rootName"
-	case IntrinsicTraceRootServiceName:
+	case ScopedIntrinsicTraceRootServiceName:
 		return "trace:rootServiceName"
 	case IntrinsicSpanID:
 		return "span:id"
@@ -223,6 +223,20 @@ func intrinsicFromString(s string) Intrinsic {
 		return IntrinsicTraceStartTime
 	case "span:id":
 		return IntrinsicSpanID
+	case "span:status":
+		return ScopedIntrinsicSpanStatus
+	case "span:statusMessage":
+		return ScopedIntrinsicSpanStatusMessage
+	case "span:duration":
+		return ScopedIntrinsicSpanDuration
+	case "span:name":
+		return ScopedIntrinsicSpanName
+	case "span:kind":
+		return ScopedIntrinsicSpanKind
+	case "trace:rootName":
+		return ScopedIntrinsicTraceRootName
+	case "trace:rootServiceName":
+		return ScopedIntrinsicTraceRootServiceName
 	// unimplemented
 	case "spanStartTime":
 		return IntrinsicSpanStartTime

--- a/pkg/traceql/enum_attributes.go
+++ b/pkg/traceql/enum_attributes.go
@@ -96,7 +96,7 @@ const (
 	ScopedIntrinsicSpanKind
 	ScopedIntrinsicTraceRootName
 	ScopedIntrinsicTraceRootServiceName
-
+	ScopedIntrinsicTraceDuration
 	// not yet implemented in traceql and may never be. these exist so that we can retrieve
 	// these fields from the fetch layer
 
@@ -172,6 +172,8 @@ func (i Intrinsic) String() string {
 		return "trace:rootName"
 	case ScopedIntrinsicTraceRootServiceName:
 		return "trace:rootServiceName"
+	case ScopedIntrinsicTraceDuration:
+		return "trace:traceDuration"
 	case IntrinsicSpanID:
 		return "span:id"
 	// below is unimplemented
@@ -237,6 +239,8 @@ func intrinsicFromString(s string) Intrinsic {
 		return ScopedIntrinsicTraceRootName
 	case "trace:rootServiceName":
 		return ScopedIntrinsicTraceRootServiceName
+	case "trace:traceDuration":
+		return ScopedIntrinsicTraceDuration
 	// unimplemented
 	case "spanStartTime":
 		return IntrinsicSpanStartTime

--- a/pkg/traceql/enum_attributes.go
+++ b/pkg/traceql/enum_attributes.go
@@ -89,6 +89,13 @@ const (
 
 	IntrinsicTraceID
 	IntrinsicSpanID
+	IntrinsicSpanStatus
+	IntrinsicSpanStatusMessage
+	IntrinsicSpanDuration
+	IntrinsicSpanName
+	IntrinsicSpanKind
+	IntrinsicTraceRootName
+	IntrinsicTraceRootServiceName
 
 	// not yet implemented in traceql and may never be. these exist so that we can retrieve
 	// these fields from the fetch layer
@@ -151,6 +158,20 @@ func (i Intrinsic) String() string {
 		return "trace:id"
 	case IntrinsicTraceStartTime:
 		return "traceStartTime"
+	case IntrinsicSpanStatus:
+		return "span:status"
+	case IntrinsicSpanStatusMessage:
+		return "span:statusMessage"
+	case IntrinsicSpanDuration:
+		return "span:duration"
+	case IntrinsicSpanName:
+		return "span:name"
+	case IntrinsicSpanKind:
+		return "span:kind"
+	case IntrinsicTraceRootName:
+		return "trace:rootName"
+	case IntrinsicTraceRootServiceName:
+		return "trace:rootServiceName"
 	case IntrinsicSpanID:
 		return "span:id"
 	// below is unimplemented


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This PR adds new intrinsic names to the response of `/v2/search/tags` endpoint.

The response now looks like, 
```
{"scopes":[{"name":"intrinsic","tags":["duration","kind","name","rootName","rootServiceName","span:duration","span:kind","span:name","span:status","span:statusMessage","status","statusMessage","trace:rootName","trace:rootServiceName","traceDuration"]}]}
```

It is missing `trace:traceDuration`. I wasn't sure what to call it in the code ?

**Which issue(s) this PR fixes**:
Fixes #3714

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`