### PR TITLE
Search tags refactor

### DIFF
--- a/integration/e2e/multi_tenant_test.go
+++ b/integration/e2e/multi_tenant_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grafana/dskit/user"
 	"github.com/grafana/e2e"
+	"github.com/grafana/tempo/pkg/collector"
 	"github.com/grafana/tempo/pkg/httpclient"
 	"github.com/grafana/tempo/pkg/tempopb"
 	tempoUtil "github.com/grafana/tempo/pkg/util"
@@ -222,9 +223,9 @@ func assertRequestCountMetric(t *testing.T, s *e2e.HTTPService, route string, re
 
 // getAttrsAndSpanNames returns trace attrs and span names
 func getAttrsAndSpanNames(trace *tempopb.Trace) traceStringsMap {
-	rAttrsKeys := tempoUtil.NewDistinctStringCollector(0)
-	rAttrsValues := tempoUtil.NewDistinctStringCollector(0)
-	spanNames := tempoUtil.NewDistinctStringCollector(0)
+	rAttrsKeys := collector.NewDistinctString(0)
+	rAttrsValues := collector.NewDistinctString(0)
+	spanNames := collector.NewDistinctString(0)
 
 	for _, b := range trace.Batches {
 		for _, ss := range b.ScopeSpans {

--- a/modules/frontend/combiner/search_tag_values.go
+++ b/modules/frontend/combiner/search_tag_values.go
@@ -1,8 +1,8 @@
 package combiner
 
 import (
+	"github.com/grafana/tempo/pkg/collector"
 	"github.com/grafana/tempo/pkg/tempopb"
-	"github.com/grafana/tempo/pkg/util"
 )
 
 var (
@@ -12,7 +12,7 @@ var (
 
 func NewSearchTagValues(limitBytes int) Combiner {
 	// Distinct collector with no limit
-	d := util.NewDistinctStringCollector(limitBytes)
+	d := collector.NewDistinctString(limitBytes)
 
 	return &genericCombiner[*tempopb.SearchTagValuesResponse]{
 		httpStatusCode: 200,
@@ -44,7 +44,7 @@ func NewTypedSearchTagValues(limitBytes int) GRPCCombiner[*tempopb.SearchTagValu
 
 func NewSearchTagValuesV2(limitBytes int) Combiner {
 	// Distinct collector with no limit
-	d := util.NewDistinctValueCollector(limitBytes, func(tv tempopb.TagValue) int { return len(tv.Type) + len(tv.Value) })
+	d := collector.NewDistinctValue(limitBytes, func(tv tempopb.TagValue) int { return len(tv.Type) + len(tv.Value) })
 
 	return &genericCombiner[*tempopb.SearchTagValuesV2Response]{
 		httpStatusCode: 200,

--- a/modules/frontend/combiner/search_tags.go
+++ b/modules/frontend/combiner/search_tags.go
@@ -43,7 +43,7 @@ func NewTypedSearchTags(limitBytes int) GRPCCombiner[*tempopb.SearchTagsResponse
 
 func NewSearchTagsV2(limitBytes int) Combiner {
 	// Distinct collector map to collect scopes and scope values
-	distinctValues := map[string]*collector.DistinctString{}
+	distinctValues := map[string]*collector.DistinctString{} // jpe - scoped collector
 
 	return &genericCombiner[*tempopb.SearchTagsV2Response]{
 		httpStatusCode: 200,

--- a/modules/frontend/combiner/search_tags.go
+++ b/modules/frontend/combiner/search_tags.go
@@ -1,8 +1,8 @@
 package combiner
 
 import (
+	"github.com/grafana/tempo/pkg/collector"
 	"github.com/grafana/tempo/pkg/tempopb"
-	"github.com/grafana/tempo/pkg/util"
 )
 
 var (
@@ -11,7 +11,7 @@ var (
 )
 
 func NewSearchTags(limitBytes int) Combiner {
-	d := util.NewDistinctStringCollector(limitBytes)
+	d := collector.NewDistinctString(limitBytes)
 
 	return &genericCombiner[*tempopb.SearchTagsResponse]{
 		httpStatusCode: 200,
@@ -43,7 +43,7 @@ func NewTypedSearchTags(limitBytes int) GRPCCombiner[*tempopb.SearchTagsResponse
 
 func NewSearchTagsV2(limitBytes int) Combiner {
 	// Distinct collector map to collect scopes and scope values
-	distinctValues := map[string]*util.DistinctStringCollector{}
+	distinctValues := map[string]*collector.DistinctString{}
 
 	return &genericCombiner[*tempopb.SearchTagsV2Response]{
 		httpStatusCode: 200,
@@ -53,7 +53,7 @@ func NewSearchTagsV2(limitBytes int) Combiner {
 			for _, res := range partial.GetScopes() {
 				dvc := distinctValues[res.Name]
 				if dvc == nil {
-					dvc = util.NewDistinctStringCollector(limitBytes)
+					dvc = collector.NewDistinctString(limitBytes)
 					distinctValues[res.Name] = dvc
 				}
 				for _, tag := range res.Tags {

--- a/modules/frontend/search_sharder_test.go
+++ b/modules/frontend/search_sharder_test.go
@@ -42,15 +42,11 @@ type mockReader struct {
 	metas []*backend.BlockMeta
 }
 
-func (m *mockReader) SearchTags(context.Context, *backend.BlockMeta, string, common.SearchOptions) (*tempopb.SearchTagsResponse, error) {
+func (m *mockReader) SearchTags(context.Context, *backend.BlockMeta, string, common.SearchOptions) (*tempopb.SearchTagsV2Response, error) {
 	return nil, nil
 }
 
 func (m *mockReader) SearchTagValues(context.Context, *backend.BlockMeta, string, common.SearchOptions) ([]string, error) {
-	return nil, nil
-}
-
-func (m *mockReader) SearchTagsV2(context.Context, *backend.BlockMeta, []string, common.SearchOptions) (*tempopb.SearchTagsV2Response, error) {
 	return nil, nil
 }
 

--- a/modules/generator/processor/localblocks/processor_test.go
+++ b/modules/generator/processor/localblocks/processor_test.go
@@ -336,15 +336,15 @@ func (m *mockBlock) Search(context.Context, *tempopb.SearchRequest, common.Searc
 	return nil, nil
 }
 
-func (m *mockBlock) SearchTags(context.Context, traceql.AttributeScope, common.TagCallback, common.SearchOptions) error {
+func (m *mockBlock) SearchTags(context.Context, traceql.AttributeScope, common.TagsCallback, common.SearchOptions) error {
 	return nil
 }
 
-func (m *mockBlock) SearchTagValues(context.Context, string, common.TagCallback, common.SearchOptions) error {
+func (m *mockBlock) SearchTagValues(context.Context, string, common.TagValuesCallback, common.SearchOptions) error {
 	return nil
 }
 
-func (m *mockBlock) SearchTagValuesV2(context.Context, traceql.Attribute, common.TagCallbackV2, common.SearchOptions) error {
+func (m *mockBlock) SearchTagValuesV2(context.Context, traceql.Attribute, common.TagValuesCallbackV2, common.SearchOptions) error {
 	return nil
 }
 

--- a/modules/ingester/instance_search.go
+++ b/modules/ingester/instance_search.go
@@ -175,73 +175,23 @@ func (i *instance) Search(ctx context.Context, req *tempopb.SearchRequest) (*tem
 }
 
 func (i *instance) SearchTags(ctx context.Context, scope string) (*tempopb.SearchTagsResponse, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "instance.SearchTags")
-	defer span.Finish()
-
-	userID, err := user.ExtractOrgID(ctx)
+	v2Response, err := i.SearchTagsV2(ctx, scope)
 	if err != nil {
 		return nil, err
 	}
 
-	// check if it's the special intrinsic scope
-	if scope == api.ParamScopeIntrinsic {
-		return &tempopb.SearchTagsResponse{
-			TagNames: search.GetVirtualIntrinsicValues(),
-		}, nil
-	}
+	distinctValues := util.NewDistinctStringCollector(0) // search tags v2 enforces the limit
 
-	// parse for normal scopes
-	attributeScope := traceql.AttributeScopeFromString(scope)
-	if attributeScope == traceql.AttributeScopeUnknown {
-		return nil, fmt.Errorf("unknown scope: %s", scope)
-	}
-
-	limit := i.limiter.limits.MaxBytesPerTagValuesQuery(userID)
-	distinctValues := util.NewDistinctStringCollector(limit)
-
-	search := func(ctx context.Context, s common.Searcher, dv *util.DistinctStringCollector, spanName string) error {
-		span, ctx := opentracing.StartSpanFromContext(ctx, "instance.SearchTags."+spanName)
-		defer span.Finish()
-
-		if s == nil {
-			return nil
-		}
-		if dv.Exceeded() {
-			return nil
-		}
-		err = s.SearchTags(ctx, attributeScope, dv.Collect, common.DefaultSearchOptions())
-		if err != nil && !errors.Is(err, common.ErrUnsupported) {
-			return fmt.Errorf("unexpected error searching tags: %w", err)
+	// flatten v2 response
+	for _, s := range v2Response.Scopes {
+		// SearchTags does not include intrinsics on an empty scope, but v2 does.
+		if scope == "" && s.Name == api.ParamScopeIntrinsic {
+			continue
 		}
 
-		return nil
-	}
-
-	i.headBlockMtx.RLock()
-	span.LogFields(ot_log.String("msg", "acquired headblock mtx"))
-	err = search(ctx, i.headBlock, distinctValues, "headBlock")
-	i.headBlockMtx.RUnlock()
-	if err != nil {
-		return nil, fmt.Errorf("unexpected error searching head block (%s): %w", i.headBlock.BlockMeta().BlockID, err)
-	}
-
-	i.blocksMtx.RLock()
-	defer i.blocksMtx.RUnlock()
-	span.LogFields(ot_log.String("msg", "acquired blocks mtx"))
-
-	for _, b := range i.completingBlocks {
-		if err = search(ctx, b, distinctValues, "completingBlock"); err != nil {
-			return nil, fmt.Errorf("unexpected error searching completing block (%s): %w", b.BlockMeta().BlockID, err)
+		for _, t := range s.Tags {
+			distinctValues.Collect(t)
 		}
-	}
-	for _, b := range i.completeBlocks {
-		if err = search(ctx, b, distinctValues, "completeBlock"); err != nil {
-			return nil, fmt.Errorf("unexpected error searching complete block (%s): %w", b.BlockMeta().BlockID, err)
-		}
-	}
-
-	if distinctValues.Exceeded() {
-		level.Warn(log.Logger).Log("msg", "size of tags in instance exceeded limit, reduce cardinality or size of tags", "userID", userID, "limit", limit, "total", distinctValues.TotalDataSize())
 	}
 
 	return &tempopb.SearchTagsResponse{
@@ -254,50 +204,98 @@ func (i *instance) SearchTagsV2(ctx context.Context, scope string) (*tempopb.Sea
 	span, ctx := opentracing.StartSpanFromContext(ctx, "instance.SearchTagsV2")
 	defer span.Finish()
 
-	scopes := []string{scope}
-	if scope == "" {
-		// start with intrinsic scope and all traceql attribute scopes
-		atts := traceql.AllAttributeScopes()
-		scopes = make([]string, 0, len(atts)+1) // +1 for intrinsic
-
-		scopes = append(scopes, api.ParamScopeIntrinsic)
-		for _, att := range atts {
-			scopes = append(scopes, att.String())
-		}
-	}
-	resps := make([]*tempopb.SearchTagsResponse, len(scopes))
-
-	overallError := atomic.NewError(nil)
-	wg := sync.WaitGroup{}
-	for idx := range scopes {
-		resps[idx] = &tempopb.SearchTagsResponse{}
-
-		wg.Add(1)
-		go func(scope string, ret **tempopb.SearchTagsResponse) {
-			defer wg.Done()
-
-			resp, err := i.SearchTags(ctx, scope)
-			if err != nil {
-				overallError.Store(fmt.Errorf("error searching tags: %s: %w", scope, err))
-				return
-			}
-
-			*ret = resp
-		}(scopes[idx], &resps[idx])
-	}
-	wg.Wait()
-
-	err := overallError.Load()
+	userID, err := user.ExtractOrgID(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// build response
+	// check if it's the special intrinsic scope
+	if scope == api.ParamScopeIntrinsic {
+		return &tempopb.SearchTagsV2Response{
+			Scopes: []*tempopb.SearchTagsV2Scope{
+				{
+					Name: api.ParamScopeIntrinsic,
+					Tags: search.GetVirtualIntrinsicValues(),
+				},
+			},
+		}, nil
+	}
+
+	// parse for normal scopes
+	attributeScope := traceql.AttributeScopeFromString(scope)
+	if attributeScope == traceql.AttributeScopeUnknown {
+		return nil, fmt.Errorf("unknown scope: %s", scope)
+	}
+
+	limit := i.limiter.limits.MaxBytesPerTagValuesQuery(userID)
+	collectors := map[traceql.AttributeScope]*util.DistinctStringCollector{}
+
+	searchBlock := func(ctx context.Context, s common.Searcher, spanName string) error {
+		span, ctx := opentracing.StartSpanFromContext(ctx, "instance.SearchTags."+spanName)
+		defer span.Finish()
+
+		if s == nil {
+			return nil
+		}
+		// if dv.Exceeded() { jpe - restore with scoped collector
+		// 	return nil
+		// }
+		err = s.SearchTags(ctx, attributeScope, func(t string, scope traceql.AttributeScope) {
+			dv, ok := collectors[scope]
+			if !ok {
+				dv = util.NewDistinctStringCollector(limit)
+				collectors[scope] = dv
+			}
+			dv.Collect(t)
+
+		}, common.DefaultSearchOptions()) // jpe - add scoped collector?
+		if err != nil && !errors.Is(err, common.ErrUnsupported) {
+			return fmt.Errorf("unexpected error searching tags: %w", err)
+		}
+
+		return nil
+	}
+
+	i.headBlockMtx.RLock()
+	span.LogFields(ot_log.String("msg", "acquired headblock mtx"))
+	err = searchBlock(ctx, i.headBlock, "headBlock")
+	i.headBlockMtx.RUnlock()
+	if err != nil {
+		return nil, fmt.Errorf("unexpected error searching head block (%s): %w", i.headBlock.BlockMeta().BlockID, err)
+	}
+
+	i.blocksMtx.RLock()
+	defer i.blocksMtx.RUnlock()
+	span.LogFields(ot_log.String("msg", "acquired blocks mtx"))
+
+	for _, b := range i.completingBlocks {
+		if err = searchBlock(ctx, b, "completingBlock"); err != nil {
+			return nil, fmt.Errorf("unexpected error searching completing block (%s): %w", b.BlockMeta().BlockID, err)
+		}
+	}
+	for _, b := range i.completeBlocks {
+		if err = searchBlock(ctx, b, "completeBlock"); err != nil {
+			return nil, fmt.Errorf("unexpected error searching complete block (%s): %w", b.BlockMeta().BlockID, err)
+		}
+	}
+
+	// if distinctValues.Exceeded() { // jpe - restore with scoped collector
+	// 	level.Warn(log.Logger).Log("msg", "size of tags in instance exceeded limit, reduce cardinality or size of tags", "userID", userID, "limit", limit, "total", distinctValues.TotalDataSize())
+	// }
+
 	resp := &tempopb.SearchTagsV2Response{}
-	for idx := range resps {
+	for scope, collector := range collectors {
 		resp.Scopes = append(resp.Scopes, &tempopb.SearchTagsV2Scope{
-			Name: scopes[idx],
-			Tags: resps[idx].TagNames,
+			Name: scope.String(),
+			Tags: collector.Strings(),
+		})
+	}
+
+	// add intrinsic tags if scope is none
+	if attributeScope == traceql.AttributeScopeNone {
+		resp.Scopes = append(resp.Scopes, &tempopb.SearchTagsV2Scope{
+			Name: api.ParamScopeIntrinsic,
+			Tags: search.GetVirtualIntrinsicValues(),
 		})
 	}
 

--- a/modules/ingester/instance_search_test.go
+++ b/modules/ingester/instance_search_test.go
@@ -378,7 +378,7 @@ func TestInstanceSearchTagsSpecialCases(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(
 		t,
-		[]string{"duration", "kind", "name", "status", "statusMessage", "traceDuration", "rootServiceName", "rootName"},
+		[]string{"duration", "kind", "name", "rootName", "rootServiceName", "status", "statusMessage", "traceDuration"},
 		resp.TagNames,
 	)
 }

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -827,6 +827,7 @@ func (q *Querier) internalSearchBlock(ctx context.Context, req *tempopb.SearchBl
 
 func (q *Querier) internalTagsSearchBlock(ctx context.Context, req *tempopb.SearchTagsBlockRequest) (*tempopb.SearchTagsResponse, error) {
 	// check if it's the special intrinsic scope
+	// todo: note that we are passing this up for every block search. we could add it in the frontend instead
 	if req.SearchReq.Scope == api.ParamScopeIntrinsic {
 		return &tempopb.SearchTagsResponse{
 			TagNames: search.GetVirtualIntrinsicValues(),

--- a/pkg/collector/distinct_string_collector_test.go
+++ b/pkg/collector/distinct_string_collector_test.go
@@ -1,4 +1,4 @@
-package util
+package collector
 
 import (
 	"testing"
@@ -7,7 +7,7 @@ import (
 )
 
 func TestDistinctStringCollector(t *testing.T) {
-	d := NewDistinctStringCollector(10)
+	d := NewDistinctString(10)
 
 	d.Collect("123")
 	d.Collect("4567")
@@ -19,7 +19,7 @@ func TestDistinctStringCollector(t *testing.T) {
 }
 
 func TestDistinctStringCollectorDiff(t *testing.T) {
-	d := NewDistinctStringCollector(0)
+	d := NewDistinctString(0)
 
 	d.Collect("123")
 	d.Collect("4567")

--- a/pkg/collector/distinct_value_collector_test.go
+++ b/pkg/collector/distinct_value_collector_test.go
@@ -1,4 +1,4 @@
-package util
+package collector
 
 import (
 	"sort"
@@ -8,7 +8,7 @@ import (
 )
 
 func TestDistinctValueCollectorDiff(t *testing.T) {
-	d := NewDistinctValueCollector[string](0, func(s string) int { return len(s) })
+	d := NewDistinctValue[string](0, func(s string) int { return len(s) })
 
 	d.Collect("123")
 	d.Collect("4567")

--- a/pkg/collector/scoped_distinct_string.go
+++ b/pkg/collector/scoped_distinct_string.go
@@ -1,0 +1,65 @@
+package collector
+
+type ScopedDistinctString struct {
+	cols     map[string]*DistinctString
+	maxLen   int
+	curLen   int
+	exceeded bool
+}
+
+func NewScoped(sz int) *ScopedDistinctString {
+	return &ScopedDistinctString{
+		cols: map[string]*DistinctString{},
+	}
+}
+
+func (d *ScopedDistinctString) Collect(scope string, val string) {
+	// can it fit?
+	if d.maxLen > 0 && d.curLen+len(val) > d.maxLen {
+		d.exceeded = true
+		// No
+		return
+	}
+
+	// get or create collector
+	col, ok := d.cols[scope]
+	if ok {
+		col = NewDistinctString(0)
+		d.cols[scope] = col
+	}
+
+	added := col.Collect(val)
+	if added {
+		d.curLen += len(val)
+	}
+}
+
+// Strings returns the final list of distinct values collected and sorted.
+func (d *ScopedDistinctString) Strings() map[string][]string {
+	ss := map[string][]string{}
+
+	for k, v := range d.cols {
+		ss[k] = v.Strings()
+	}
+
+	return ss
+}
+
+// Exceeded indicates if some values were lost because the maximum size limit was met.
+func (d *ScopedDistinctString) Exceeded() bool {
+	return d.exceeded
+}
+
+// Diff returns all new strings collected since the last time diff was called
+func (d *ScopedDistinctString) Diff() map[string][]string {
+	ss := map[string][]string{}
+
+	for k, v := range d.cols {
+		diff := v.Diff()
+		if len(diff) > 0 {
+			ss[k] = diff
+		}
+	}
+
+	return ss
+}

--- a/pkg/collector/scoped_distinct_string.go
+++ b/pkg/collector/scoped_distinct_string.go
@@ -7,9 +7,10 @@ type ScopedDistinctString struct {
 	exceeded bool
 }
 
-func NewScoped(sz int) *ScopedDistinctString {
+func NewScopedDistinctString(sz int) *ScopedDistinctString {
 	return &ScopedDistinctString{
-		cols: map[string]*DistinctString{},
+		cols:   map[string]*DistinctString{},
+		maxLen: sz,
 	}
 }
 
@@ -23,7 +24,7 @@ func (d *ScopedDistinctString) Collect(scope string, val string) {
 
 	// get or create collector
 	col, ok := d.cols[scope]
-	if ok {
+	if !ok {
 		col = NewDistinctString(0)
 		d.cols[scope] = col
 	}

--- a/pkg/collector/scoped_distinct_string_test.go
+++ b/pkg/collector/scoped_distinct_string_test.go
@@ -1,0 +1,79 @@
+package collector
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScopedDistinct(t *testing.T) {
+	tcs := []struct {
+		in       map[string][]string
+		expected map[string][]string
+		limit    int
+		exceeded bool
+	}{
+		{
+			in: map[string][]string{
+				"scope1": {"val1", "val2"},
+				"scope2": {"val1", "val2"},
+			},
+			expected: map[string][]string{
+				"scope1": {"val1", "val2"},
+				"scope2": {"val1", "val2"},
+			},
+		},
+		{
+			in: map[string][]string{
+				"scope1": {"val1", "val2", "val1"},
+				"scope2": {"val1", "val2", "val2"},
+			},
+			expected: map[string][]string{
+				"scope1": {"val1", "val2"},
+				"scope2": {"val1", "val2"},
+			},
+		},
+		{
+			in: map[string][]string{
+				"scope1": {"val1", "val2"},
+				"scope2": {"val1", "val2"},
+			},
+			expected: map[string][]string{
+				"scope1": {"val1", "val2"},
+				"scope2": {"val1"},
+			},
+			limit:    13,
+			exceeded: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		c := NewScopedDistinctString(tc.limit)
+
+		// get and sort keys so we can deterministically add values
+		keys := []string{}
+		for k := range tc.in {
+			keys = append(keys, k)
+		}
+		slices.Sort(keys)
+
+		for _, k := range keys {
+			v := tc.in[k]
+			for _, val := range v {
+				c.Collect(k, val)
+			}
+		}
+
+		require.Equal(t, tc.exceeded, c.Exceeded())
+
+		actual := c.Strings()
+		require.Equal(t, len(tc.expected), len(actual))
+
+		for k, v := range tc.expected {
+			require.Equal(t, v, actual[k])
+		}
+	}
+}
+
+// test diff

--- a/pkg/traceql/engine_test.go
+++ b/pkg/traceql/engine_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 
+	"github.com/grafana/tempo/pkg/collector"
 	"github.com/grafana/tempo/pkg/tempopb"
 	v1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
 	"github.com/grafana/tempo/pkg/util"
@@ -644,7 +645,7 @@ func TestExecuteTagValues(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			distinctValues := util.NewDistinctValueCollector[tempopb.TagValue](100_000, func(v tempopb.TagValue) int { return len(v.Type) + len(v.Value) })
+			distinctValues := collector.NewDistinctValue[tempopb.TagValue](100_000, func(v tempopb.TagValue) int { return len(v.Type) + len(v.Value) })
 
 			// Ugly hack to make the mock fetcher work with a bad query
 			fetcherQuery := tc.query

--- a/tempodb/encoding/common/interfaces.go
+++ b/tempodb/encoding/common/interfaces.go
@@ -15,15 +15,15 @@ type Finder interface {
 	FindTraceByID(ctx context.Context, id ID, opts SearchOptions) (*tempopb.Trace, error)
 }
 
-type TagCallback func(t string)
-
-type TagCallbackV2 func(traceql.Static) (stop bool)
+type TagsCallback func(t string, scope traceql.AttributeScope)
+type TagValuesCallback func(t string)
+type TagValuesCallbackV2 func(traceql.Static) (stop bool)
 
 type Searcher interface {
 	Search(ctx context.Context, req *tempopb.SearchRequest, opts SearchOptions) (*tempopb.SearchResponse, error)
-	SearchTags(ctx context.Context, scope traceql.AttributeScope, cb TagCallback, opts SearchOptions) error
-	SearchTagValues(ctx context.Context, tag string, cb TagCallback, opts SearchOptions) error
-	SearchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb TagCallbackV2, opts SearchOptions) error
+	SearchTags(ctx context.Context, scope traceql.AttributeScope, cb TagsCallback, opts SearchOptions) error
+	SearchTagValues(ctx context.Context, tag string, cb TagValuesCallback, opts SearchOptions) error
+	SearchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb TagValuesCallbackV2, opts SearchOptions) error
 
 	Fetch(context.Context, traceql.FetchSpansRequest, SearchOptions) (traceql.FetchSpansResponse, error)
 	FetchTagValues(context.Context, traceql.FetchTagValuesRequest, traceql.FetchTagValuesCallback, SearchOptions) error

--- a/tempodb/encoding/common/interfaces.go
+++ b/tempodb/encoding/common/interfaces.go
@@ -16,7 +16,7 @@ type Finder interface {
 }
 
 type TagsCallback func(t string, scope traceql.AttributeScope)
-type TagValuesCallback func(t string)
+type TagValuesCallback func(t string) bool
 type TagValuesCallbackV2 func(traceql.Static) (stop bool)
 
 type Searcher interface {

--- a/tempodb/encoding/v2/backend_block.go
+++ b/tempodb/encoding/v2/backend_block.go
@@ -149,15 +149,15 @@ func (b *BackendBlock) Search(context.Context, *tempopb.SearchRequest, common.Se
 	return nil, common.ErrUnsupported
 }
 
-func (b *BackendBlock) SearchTags(context.Context, traceql.AttributeScope, common.TagCallback, common.SearchOptions) error {
+func (b *BackendBlock) SearchTags(context.Context, traceql.AttributeScope, common.TagsCallback, common.SearchOptions) error {
 	return common.ErrUnsupported
 }
 
-func (b *BackendBlock) SearchTagValues(context.Context, string, common.TagCallback, common.SearchOptions) error {
+func (b *BackendBlock) SearchTagValues(context.Context, string, common.TagValuesCallback, common.SearchOptions) error {
 	return common.ErrUnsupported
 }
 
-func (b *BackendBlock) SearchTagValuesV2(context.Context, traceql.Attribute, common.TagCallbackV2, common.SearchOptions) error {
+func (b *BackendBlock) SearchTagValuesV2(context.Context, traceql.Attribute, common.TagValuesCallbackV2, common.SearchOptions) error {
 	return common.ErrUnsupported
 }
 

--- a/tempodb/encoding/v2/wal_block.go
+++ b/tempodb/encoding/v2/wal_block.go
@@ -288,16 +288,16 @@ func (a *walBlock) Search(context.Context, *tempopb.SearchRequest, common.Search
 }
 
 // Search implements common.Searcher
-func (a *walBlock) SearchTags(context.Context, traceql.AttributeScope, common.TagCallback, common.SearchOptions) error {
+func (a *walBlock) SearchTags(context.Context, traceql.AttributeScope, common.TagsCallback, common.SearchOptions) error {
 	return common.ErrUnsupported
 }
 
 // SearchTagValues implements common.Searcher
-func (a *walBlock) SearchTagValues(context.Context, string, common.TagCallback, common.SearchOptions) error {
+func (a *walBlock) SearchTagValues(context.Context, string, common.TagValuesCallback, common.SearchOptions) error {
 	return common.ErrUnsupported
 }
 
-func (a *walBlock) SearchTagValuesV2(context.Context, traceql.Attribute, common.TagCallbackV2, common.SearchOptions) error {
+func (a *walBlock) SearchTagValuesV2(context.Context, traceql.Attribute, common.TagValuesCallbackV2, common.SearchOptions) error {
 	return common.ErrUnsupported
 }
 

--- a/tempodb/encoding/vparquet2/block_search.go
+++ b/tempodb/encoding/vparquet2/block_search.go
@@ -408,10 +408,10 @@ func (r *rowNumberIterator) Close() {}
 
 // reportValuesPredicate is a "fake" predicate that uses existing iterator logic to find all values in a given column
 type reportValuesPredicate struct {
-	cb common.TagCallbackV2
+	cb common.TagValuesCallbackV2
 }
 
-func newReportValuesPredicate(cb common.TagCallbackV2) *reportValuesPredicate {
+func newReportValuesPredicate(cb common.TagValuesCallbackV2) *reportValuesPredicate {
 	return &reportValuesPredicate{cb: cb}
 }
 
@@ -453,7 +453,7 @@ func (r *reportValuesPredicate) KeepValue(v parquet.Value) bool {
 	return false
 }
 
-func callback(cb common.TagCallbackV2, v parquet.Value) (stop bool) {
+func callback(cb common.TagValuesCallbackV2, v parquet.Value) (stop bool) {
 	switch v.Kind() {
 
 	case parquet.Boolean:

--- a/tempodb/encoding/vparquet2/block_search_tags.go
+++ b/tempodb/encoding/vparquet2/block_search_tags.go
@@ -42,7 +42,7 @@ var nonTraceQLAttributes = map[string]string{
 	LabelRootSpanName:    columnPathRootSpanName,
 }
 
-func (b *backendBlock) SearchTags(ctx context.Context, scope traceql.AttributeScope, cb common.TagCallback, opts common.SearchOptions) error {
+func (b *backendBlock) SearchTags(ctx context.Context, scope traceql.AttributeScope, cb common.TagsCallback, opts common.SearchOptions) error {
 	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "parquet.backendBlock.SearchTags",
 		opentracing.Tags{
 			"blockID":   b.meta.BlockID,
@@ -60,17 +60,15 @@ func (b *backendBlock) SearchTags(ctx context.Context, scope traceql.AttributeSc
 	return searchTags(derivedCtx, scope, cb, pf)
 }
 
-func searchTags(_ context.Context, scope traceql.AttributeScope, cb common.TagCallback, pf *parquet.File) error {
-	standardAttrIdxs := make([]int, 0, 2) // the most we can have is 2, resource and span indexes depending on scope passed
-	specialAttrIdxs := map[int]string{}
+func searchTags(_ context.Context, scope traceql.AttributeScope, cb common.TagsCallback, pf *parquet.File) error {
+	scanColumns := func(standardKeyPath string, specialMappings map[string]string, cb common.TagsCallback, scope traceql.AttributeScope) error {
+		specialAttrIdxs := map[int]string{}
 
-	addToIndexes := func(standardKeyPath string, specialMappings map[string]string) error {
 		// standard resource attributes
 		resourceKeyIdx, _ := pq.GetColumnIndexByPath(pf, standardKeyPath)
 		if resourceKeyIdx == -1 {
 			return fmt.Errorf("resource attributes col not found (%d)", resourceKeyIdx)
 		}
-		standardAttrIdxs = append(standardAttrIdxs, resourceKeyIdx)
 
 		// special resource attributes
 		for lbl, col := range specialMappings {
@@ -81,68 +79,50 @@ func searchTags(_ context.Context, scope traceql.AttributeScope, cb common.TagCa
 
 			specialAttrIdxs[idx] = lbl
 		}
-		return nil
-	}
 
-	// resource
-	if scope == traceql.AttributeScopeNone || scope == traceql.AttributeScopeResource {
-		err := addToIndexes(FieldResourceAttrKey, traceqlResourceLabelMappings)
-		if err != nil {
-			return err
-		}
-	}
-	// span
-	if scope == traceql.AttributeScopeNone || scope == traceql.AttributeScopeSpan {
-		err := addToIndexes(FieldSpanAttrKey, traceqlSpanLabelMappings)
-		if err != nil {
-			return err
-		}
-	}
-
-	// now search all row groups
-	var err error
-	rgs := pf.RowGroups()
-	for _, rg := range rgs {
-		// search all special attributes
-		for idx, lbl := range specialAttrIdxs {
-			cc := rg.ColumnChunks()[idx]
-			err = func() error {
-				pgs := cc.Pages()
-				defer pgs.Close()
-				for {
-					pg, err := pgs.ReadPage()
-					if errors.Is(err, io.EOF) || pg == nil {
-						break
-					}
-					if err != nil {
-						return err
-					}
-
-					stop := func(page parquet.Page) bool {
-						defer parquet.Release(page)
-
-						// if a special attribute has any non-null values, include it
-						if page.NumNulls() < page.NumValues() {
-							cb(lbl)
-							delete(specialAttrIdxs, idx) // remove from map so we won't search again
-							return true
+		// now search all row groups
+		var err error
+		rgs := pf.RowGroups()
+		for _, rg := range rgs {
+			// search all special attributes
+			for idx, lbl := range specialAttrIdxs {
+				cc := rg.ColumnChunks()[idx]
+				err = func() error {
+					pgs := cc.Pages()
+					defer pgs.Close()
+					for {
+						pg, err := pgs.ReadPage()
+						if errors.Is(err, io.EOF) || pg == nil {
+							break
 						}
-						return false
-					}(pg)
-					if stop {
-						break
-					}
-				}
-				return nil
-			}()
-			if err != nil {
-				return err
-			}
-		}
+						if err != nil {
+							return err
+						}
 
-		// search other attributes
-		for _, idx := range standardAttrIdxs {
-			cc := rg.ColumnChunks()[idx]
+						stop := func(page parquet.Page) bool {
+							defer parquet.Release(page)
+
+							// if a special attribute has any non-null values, include it
+							if page.NumNulls() < page.NumValues() {
+								cb(lbl, scope)
+								delete(specialAttrIdxs, idx) // remove from map so we won't search again
+								return true
+							}
+							return false
+						}(pg)
+						if stop {
+							break
+						}
+					}
+					return nil
+				}()
+				if err != nil {
+					return err
+				}
+			}
+
+			// search other attributes
+			cc := rg.ColumnChunks()[resourceKeyIdx]
 			err = func() error {
 				pgs := cc.Pages()
 				defer pgs.Close()
@@ -168,7 +148,7 @@ func searchTags(_ context.Context, scope traceql.AttributeScope, cb common.TagCa
 
 					for i := 0; i < dict.Len(); i++ {
 						s := dict.Index(int32(i)).String()
-						cb(s)
+						cb(s, scope)
 					}
 				}(pg)
 
@@ -178,12 +158,29 @@ func searchTags(_ context.Context, scope traceql.AttributeScope, cb common.TagCa
 				return err
 			}
 		}
+
+		return nil
+	}
+
+	// resource
+	if scope == traceql.AttributeScopeNone || scope == traceql.AttributeScopeResource {
+		err := scanColumns(FieldResourceAttrKey, traceqlResourceLabelMappings, cb, traceql.AttributeScopeResource)
+		if err != nil {
+			return err
+		}
+	}
+	// span
+	if scope == traceql.AttributeScopeNone || scope == traceql.AttributeScopeSpan {
+		err := scanColumns(FieldSpanAttrKey, traceqlSpanLabelMappings, cb, traceql.AttributeScopeSpan)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func (b *backendBlock) SearchTagValues(ctx context.Context, tag string, cb common.TagCallback, opts common.SearchOptions) error {
+func (b *backendBlock) SearchTagValues(ctx context.Context, tag string, cb common.TagValuesCallback, opts common.SearchOptions) error {
 	att, ok := translateTagToAttribute[tag]
 	if !ok {
 		att = traceql.NewAttribute(tag)
@@ -198,7 +195,7 @@ func (b *backendBlock) SearchTagValues(ctx context.Context, tag string, cb commo
 	return b.SearchTagValuesV2(ctx, att, cb2, opts)
 }
 
-func (b *backendBlock) SearchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb common.TagCallbackV2, opts common.SearchOptions) error {
+func (b *backendBlock) SearchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb common.TagValuesCallbackV2, opts common.SearchOptions) error {
 	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "parquet.backendBlock.SearchTagValuesV2",
 		opentracing.Tags{
 			"blockID":   b.meta.BlockID,
@@ -216,7 +213,7 @@ func (b *backendBlock) SearchTagValuesV2(ctx context.Context, tag traceql.Attrib
 	return searchTagValues(derivedCtx, tag, cb, pf)
 }
 
-func searchTagValues(ctx context.Context, tag traceql.Attribute, cb common.TagCallbackV2, pf *parquet.File) error {
+func searchTagValues(ctx context.Context, tag traceql.Attribute, cb common.TagValuesCallbackV2, pf *parquet.File) error {
 	// Special handling for intrinsics
 	if tag.Intrinsic != traceql.IntrinsicNone {
 		lookup := intrinsicColumnLookups[tag.Intrinsic]
@@ -258,7 +255,7 @@ func searchTagValues(ctx context.Context, tag traceql.Attribute, cb common.TagCa
 
 // searchStandardTagValues searches a parquet file for "standard" tags. i.e. tags that don't have unique
 // columns and are contained in labelMappings
-func searchStandardTagValues(ctx context.Context, tag traceql.Attribute, pf *parquet.File, cb common.TagCallbackV2) error {
+func searchStandardTagValues(ctx context.Context, tag traceql.Attribute, pf *parquet.File, cb common.TagValuesCallbackV2) error {
 	rgs := pf.RowGroups()
 	makeIter := makeIterFunc(ctx, rgs, pf)
 
@@ -293,7 +290,7 @@ func searchStandardTagValues(ctx context.Context, tag traceql.Attribute, pf *par
 	return nil
 }
 
-func searchKeyValues(definitionLevel int, keyPath, stringPath, intPath, floatPath, boolPath string, makeIter makeIterFn, keyPred pq.Predicate, cb common.TagCallbackV2) error {
+func searchKeyValues(definitionLevel int, keyPath, stringPath, intPath, floatPath, boolPath string, makeIter makeIterFn, keyPred pq.Predicate, cb common.TagValuesCallbackV2) error {
 	skipNils := pq.NewSkipNilsPredicate()
 
 	iter, err := pq.NewLeftJoinIterator(definitionLevel,
@@ -332,7 +329,7 @@ func searchKeyValues(definitionLevel int, keyPath, stringPath, intPath, floatPat
 
 // searchSpecialTagValues searches a parquet file for all values for the provided column. It first attempts
 // to only pull all values from the column's dictionary. If this fails it falls back to scanning the entire path.
-func searchSpecialTagValues(ctx context.Context, column string, pf *parquet.File, cb common.TagCallbackV2) error {
+func searchSpecialTagValues(ctx context.Context, column string, pf *parquet.File, cb common.TagValuesCallbackV2) error {
 	pred := newReportValuesPredicate(cb)
 	rgs := pf.RowGroups()
 

--- a/tempodb/encoding/vparquet2/block_search_tags_test.go
+++ b/tempodb/encoding/vparquet2/block_search_tags_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/grafana/tempo/pkg/collector"
 	"github.com/grafana/tempo/pkg/traceql"
-	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/local"
 	"github.com/grafana/tempo/tempodb/encoding/common"
@@ -66,9 +66,10 @@ func TestBackendBlockSearchTagValues(t *testing.T) {
 	ctx := context.Background()
 	for tag, val := range attrs {
 		wasCalled := false
-		cb := func(s string) {
+		cb := func(s string) bool {
 			wasCalled = true
 			assert.Equal(t, val, s, tag)
+			return true
 		}
 
 		err := block.SearchTagValues(ctx, tag, cb, common.DefaultSearchOptions())
@@ -167,7 +168,7 @@ func BenchmarkBackendBlockSearchTags(b *testing.B) {
 
 	block := newBackendBlock(meta, rr)
 	opts := common.DefaultSearchOptions()
-	d := util.NewDistinctStringCollector(1_000_000)
+	d := collector.NewDistinctString(1_000_000)
 
 	b.ResetTimer()
 
@@ -201,7 +202,7 @@ func BenchmarkBackendBlockSearchTagValues(b *testing.B) {
 
 	for _, tc := range testCases {
 		b.Run(tc, func(b *testing.B) {
-			d := util.NewDistinctStringCollector(1_000_000)
+			d := collector.NewDistinctString(1_000_000)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				err := block.SearchTagValues(ctx, tc, d.Collect, opts)

--- a/tempodb/encoding/vparquet2/block_search_tags_test.go
+++ b/tempodb/encoding/vparquet2/block_search_tags_test.go
@@ -21,7 +21,7 @@ func TestBackendBlockSearchTags(t *testing.T) {
 
 	testVals := func(scope traceql.AttributeScope, attrs map[string]string) {
 		foundAttrs := map[string]struct{}{}
-		cb := func(s string) {
+		cb := func(s string, _ traceql.AttributeScope) {
 			foundAttrs[s] = struct{}{}
 		}
 
@@ -172,7 +172,7 @@ func BenchmarkBackendBlockSearchTags(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		err := block.SearchTags(ctx, traceql.AttributeScopeNone, d.Collect, opts)
+		err := block.SearchTags(ctx, traceql.AttributeScopeNone, func(s string, _ traceql.AttributeScope) { d.Collect(s) }, opts)
 		require.NoError(b, err)
 	}
 }

--- a/tempodb/encoding/vparquet2/wal_block.go
+++ b/tempodb/encoding/vparquet2/wal_block.go
@@ -573,7 +573,7 @@ func (b *walBlock) Search(ctx context.Context, req *tempopb.SearchRequest, _ com
 	return results, nil
 }
 
-func (b *walBlock) SearchTags(ctx context.Context, scope traceql.AttributeScope, cb common.TagCallback, _ common.SearchOptions) error {
+func (b *walBlock) SearchTags(ctx context.Context, scope traceql.AttributeScope, cb common.TagsCallback, _ common.SearchOptions) error {
 	for i, blockFlush := range b.readFlushes() {
 		file, err := blockFlush.file(ctx)
 		if err != nil {
@@ -592,7 +592,7 @@ func (b *walBlock) SearchTags(ctx context.Context, scope traceql.AttributeScope,
 	return nil
 }
 
-func (b *walBlock) SearchTagValues(ctx context.Context, tag string, cb common.TagCallback, opts common.SearchOptions) error {
+func (b *walBlock) SearchTagValues(ctx context.Context, tag string, cb common.TagValuesCallback, opts common.SearchOptions) error {
 	att, ok := translateTagToAttribute[tag]
 	if !ok {
 		att = traceql.NewAttribute(tag)
@@ -607,7 +607,7 @@ func (b *walBlock) SearchTagValues(ctx context.Context, tag string, cb common.Ta
 	return b.SearchTagValuesV2(ctx, att, cb2, opts)
 }
 
-func (b *walBlock) SearchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb common.TagCallbackV2, _ common.SearchOptions) error {
+func (b *walBlock) SearchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb common.TagValuesCallbackV2, _ common.SearchOptions) error {
 	for i, blockFlush := range b.readFlushes() {
 		file, err := blockFlush.file(ctx)
 		if err != nil {

--- a/tempodb/encoding/vparquet2/wal_block_test.go
+++ b/tempodb/encoding/vparquet2/wal_block_test.go
@@ -369,7 +369,8 @@ func BenchmarkWalSearchTagValues(b *testing.B) {
 	require.NoError(b, err)
 	require.NoError(b, warn)
 
-	cb := func(v string) {
+	cb := func(v string) bool {
+		return true
 	}
 
 	for _, t := range tags {

--- a/tempodb/encoding/vparquet3/block_autocomplete.go
+++ b/tempodb/encoding/vparquet3/block_autocomplete.go
@@ -27,7 +27,7 @@ func (b *backendBlock) FetchTagValues(ctx context.Context, req traceql.FetchTagV
 
 	// Last check. No conditions, use old path. It's much faster.
 	if len(req.Conditions) <= 1 || mingledConditions { // <= 1 because we always have a "OpNone" condition for the tag name
-		return b.SearchTagValuesV2(ctx, req.TagName, common.TagCallbackV2(cb), common.DefaultSearchOptions())
+		return b.SearchTagValuesV2(ctx, req.TagName, common.TagValuesCallbackV2(cb), common.DefaultSearchOptions())
 	}
 
 	pf, _, err := b.openForSearch(ctx, opts)

--- a/tempodb/encoding/vparquet3/block_autocomplete_test.go
+++ b/tempodb/encoding/vparquet3/block_autocomplete_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/grafana/tempo/pkg/collector"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/traceql"
-	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/local"
 	"github.com/grafana/tempo/tempodb/encoding/common"
@@ -265,7 +265,7 @@ func TestFetchTagValues(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("tag: %s, query: %s", tc.tag, tc.query), func(t *testing.T) {
-			distinctValues := util.NewDistinctValueCollector[tempopb.TagValue](1_000_000, func(v tempopb.TagValue) int { return len(v.Type) + len(v.Value) })
+			distinctValues := collector.NewDistinctValue[tempopb.TagValue](1_000_000, func(v tempopb.TagValue) int { return len(v.Type) + len(v.Value) })
 			req, err := traceql.ExtractFetchSpansRequest(tc.query)
 			require.NoError(t, err)
 
@@ -346,7 +346,7 @@ func BenchmarkFetchTagValues(b *testing.B) {
 
 	for _, tc := range testCases {
 		b.Run(fmt.Sprintf("tag: %s, query: %s", tc.tag, tc.query), func(b *testing.B) {
-			distinctValues := util.NewDistinctValueCollector[tempopb.TagValue](1_000_000, func(v tempopb.TagValue) int { return len(v.Type) + len(v.Value) })
+			distinctValues := collector.NewDistinctValue[tempopb.TagValue](1_000_000, func(v tempopb.TagValue) int { return len(v.Type) + len(v.Value) })
 			req, err := traceql.ExtractFetchSpansRequest(tc.query)
 			require.NoError(b, err)
 

--- a/tempodb/encoding/vparquet3/block_search.go
+++ b/tempodb/encoding/vparquet3/block_search.go
@@ -406,10 +406,10 @@ func (r *rowNumberIterator) Close() {}
 
 // reportValuesPredicate is a "fake" predicate that uses existing iterator logic to find all values in a given column
 type reportValuesPredicate struct {
-	cb common.TagCallbackV2
+	cb common.TagValuesCallbackV2
 }
 
-func newReportValuesPredicate(cb common.TagCallbackV2) *reportValuesPredicate {
+func newReportValuesPredicate(cb common.TagValuesCallbackV2) *reportValuesPredicate {
 	return &reportValuesPredicate{cb: cb}
 }
 
@@ -451,7 +451,7 @@ func (r *reportValuesPredicate) KeepValue(v parquet.Value) bool {
 	return false
 }
 
-func callback(cb common.TagCallbackV2, v parquet.Value) (stop bool) {
+func callback(cb common.TagValuesCallbackV2, v parquet.Value) (stop bool) {
 	switch v.Kind() {
 
 	case parquet.Boolean:

--- a/tempodb/encoding/vparquet3/block_search_tags.go
+++ b/tempodb/encoding/vparquet3/block_search_tags.go
@@ -43,7 +43,7 @@ var nonTraceQLAttributes = map[string]string{
 	LabelRootSpanName:    columnPathRootSpanName,
 }
 
-func (b *backendBlock) SearchTags(ctx context.Context, scope traceql.AttributeScope, cb common.TagCallback, opts common.SearchOptions) error {
+func (b *backendBlock) SearchTags(ctx context.Context, scope traceql.AttributeScope, cb common.TagsCallback, opts common.SearchOptions) error {
 	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "parquet.backendBlock.SearchTags",
 		opentracing.Tags{
 			"blockID":   b.meta.BlockID,
@@ -61,17 +61,12 @@ func (b *backendBlock) SearchTags(ctx context.Context, scope traceql.AttributeSc
 	return searchTags(derivedCtx, scope, cb, pf, b.meta.DedicatedColumns)
 }
 
-func searchTags(_ context.Context, scope traceql.AttributeScope, cb common.TagCallback, pf *parquet.File, dc backend.DedicatedColumns) error {
-	standardAttrIdxs := make([]int, 0, 2) // the most we can have is 2, resource and span indexes depending on scope passed
-	specialAttrIdxs := map[int]string{}
+func searchTags(_ context.Context, scope traceql.AttributeScope, cb common.TagsCallback, pf *parquet.File, dc backend.DedicatedColumns) error {
+	scanColumns := func(standardKeyPath string, specialMappings map[string]string, columnMapping dedicatedColumnMapping, cb common.TagsCallback, scope traceql.AttributeScope) error {
+		specialAttrIdxs := map[int]string{}
 
-	addToIndexes := func(standardKeyPath string, specialMappings map[string]string, columnMapping dedicatedColumnMapping) error {
 		// standard attributes
 		resourceKeyIdx, _ := pq.GetColumnIndexByPath(pf, standardKeyPath)
-		if resourceKeyIdx == -1 {
-			return fmt.Errorf("resource attributes col not found (%d)", resourceKeyIdx)
-		}
-		standardAttrIdxs = append(standardAttrIdxs, resourceKeyIdx)
 
 		// special attributes
 		for lbl, col := range specialMappings {
@@ -93,70 +88,48 @@ func searchTags(_ context.Context, scope traceql.AttributeScope, cb common.TagCa
 			specialAttrIdxs[idx] = lbl
 		})
 
-		return nil
-	}
-
-	// resource
-	if scope == traceql.AttributeScopeNone || scope == traceql.AttributeScopeResource {
-		columnMapping := dedicatedColumnsToColumnMapping(dc, backend.DedicatedColumnScopeResource)
-		err := addToIndexes(FieldResourceAttrKey, traceqlResourceLabelMappings, columnMapping)
-		if err != nil {
-			return err
-		}
-	}
-	// span
-	if scope == traceql.AttributeScopeNone || scope == traceql.AttributeScopeSpan {
-		columnMapping := dedicatedColumnsToColumnMapping(dc, backend.DedicatedColumnScopeSpan)
-		err := addToIndexes(FieldSpanAttrKey, traceqlSpanLabelMappings, columnMapping)
-		if err != nil {
-			return err
-		}
-	}
-
-	// now search all row groups
-	var err error
-	rgs := pf.RowGroups()
-	for _, rg := range rgs {
-		// search all special attributes
-		for idx, lbl := range specialAttrIdxs {
-			cc := rg.ColumnChunks()[idx]
-			err = func() error {
-				pgs := cc.Pages()
-				defer pgs.Close()
-				for {
-					pg, err := pgs.ReadPage()
-					if errors.Is(err, io.EOF) || pg == nil {
-						break
-					}
-					if err != nil {
-						return err
-					}
-
-					stop := func(page parquet.Page) bool {
-						defer parquet.Release(page)
-
-						// if a special attribute has any non-null values, include it
-						if page.NumNulls() < page.NumValues() {
-							cb(lbl)
-							delete(specialAttrIdxs, idx) // remove from map so we won't search again
-							return true
+		// now search all row groups
+		var err error
+		rgs := pf.RowGroups()
+		for _, rg := range rgs {
+			// search all special attributes
+			for idx, lbl := range specialAttrIdxs {
+				cc := rg.ColumnChunks()[idx]
+				err = func() error {
+					pgs := cc.Pages()
+					defer pgs.Close()
+					for {
+						pg, err := pgs.ReadPage()
+						if errors.Is(err, io.EOF) || pg == nil {
+							break
 						}
-						return false
-					}(pg)
-					if stop {
-						break
-					}
-				}
-				return nil
-			}()
-			if err != nil {
-				return err
-			}
-		}
+						if err != nil {
+							return err
+						}
 
-		// search other attributes
-		for _, idx := range standardAttrIdxs {
-			cc := rg.ColumnChunks()[idx]
+						stop := func(page parquet.Page) bool {
+							defer parquet.Release(page)
+
+							// if a special attribute has any non-null values, include it
+							if page.NumNulls() < page.NumValues() {
+								cb(lbl, scope)
+								delete(specialAttrIdxs, idx) // remove from map so we won't search again
+								return true
+							}
+							return false
+						}(pg)
+						if stop {
+							break
+						}
+					}
+					return nil
+				}()
+				if err != nil {
+					return err
+				}
+			}
+
+			cc := rg.ColumnChunks()[resourceKeyIdx]
 			err = func() error {
 				pgs := cc.Pages()
 				defer pgs.Close()
@@ -182,7 +155,7 @@ func searchTags(_ context.Context, scope traceql.AttributeScope, cb common.TagCa
 
 					for i := 0; i < dict.Len(); i++ {
 						s := dict.Index(int32(i)).String()
-						cb(s)
+						cb(s, scope)
 					}
 				}(pg)
 
@@ -192,12 +165,31 @@ func searchTags(_ context.Context, scope traceql.AttributeScope, cb common.TagCa
 				return err
 			}
 		}
+
+		return nil
+	}
+
+	// resource
+	if scope == traceql.AttributeScopeNone || scope == traceql.AttributeScopeResource {
+		columnMapping := dedicatedColumnsToColumnMapping(dc, backend.DedicatedColumnScopeResource)
+		err := scanColumns(FieldResourceAttrKey, traceqlResourceLabelMappings, columnMapping, cb, traceql.AttributeScopeResource)
+		if err != nil {
+			return err
+		}
+	}
+	// span
+	if scope == traceql.AttributeScopeNone || scope == traceql.AttributeScopeSpan {
+		columnMapping := dedicatedColumnsToColumnMapping(dc, backend.DedicatedColumnScopeSpan)
+		err := scanColumns(FieldSpanAttrKey, traceqlSpanLabelMappings, columnMapping, cb, traceql.AttributeScopeSpan)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func (b *backendBlock) SearchTagValues(ctx context.Context, tag string, cb common.TagCallback, opts common.SearchOptions) error {
+func (b *backendBlock) SearchTagValues(ctx context.Context, tag string, cb common.TagValuesCallback, opts common.SearchOptions) error {
 	att, ok := translateTagToAttribute[tag]
 	if !ok {
 		att = traceql.NewAttribute(tag)
@@ -212,7 +204,7 @@ func (b *backendBlock) SearchTagValues(ctx context.Context, tag string, cb commo
 	return b.SearchTagValuesV2(ctx, att, cb2, opts)
 }
 
-func (b *backendBlock) SearchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb common.TagCallbackV2, opts common.SearchOptions) error {
+func (b *backendBlock) SearchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb common.TagValuesCallbackV2, opts common.SearchOptions) error {
 	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "parquet.backendBlock.SearchTagValuesV2",
 		opentracing.Tags{
 			"blockID":   b.meta.BlockID,
@@ -230,7 +222,7 @@ func (b *backendBlock) SearchTagValuesV2(ctx context.Context, tag traceql.Attrib
 	return searchTagValues(derivedCtx, tag, cb, pf, b.meta.DedicatedColumns)
 }
 
-func searchTagValues(ctx context.Context, tag traceql.Attribute, cb common.TagCallbackV2, pf *parquet.File, dc backend.DedicatedColumns) error {
+func searchTagValues(ctx context.Context, tag traceql.Attribute, cb common.TagValuesCallbackV2, pf *parquet.File, dc backend.DedicatedColumns) error {
 	// Special handling for intrinsics
 	if tag.Intrinsic != traceql.IntrinsicNone {
 		lookup := intrinsicColumnLookups[tag.Intrinsic]
@@ -292,7 +284,7 @@ func searchTagValues(ctx context.Context, tag traceql.Attribute, cb common.TagCa
 
 // searchStandardTagValues searches a parquet file for "standard" tags. i.e. tags that don't have unique
 // columns and are contained in labelMappings
-func searchStandardTagValues(ctx context.Context, tag traceql.Attribute, pf *parquet.File, cb common.TagCallbackV2) error {
+func searchStandardTagValues(ctx context.Context, tag traceql.Attribute, pf *parquet.File, cb common.TagValuesCallbackV2) error {
 	rgs := pf.RowGroups()
 	makeIter := makeIterFunc(ctx, rgs, pf)
 
@@ -327,7 +319,7 @@ func searchStandardTagValues(ctx context.Context, tag traceql.Attribute, pf *par
 	return nil
 }
 
-func searchKeyValues(definitionLevel int, keyPath, stringPath, intPath, floatPath, boolPath string, makeIter makeIterFn, keyPred pq.Predicate, cb common.TagCallbackV2) error {
+func searchKeyValues(definitionLevel int, keyPath, stringPath, intPath, floatPath, boolPath string, makeIter makeIterFn, keyPred pq.Predicate, cb common.TagValuesCallbackV2) error {
 	skipNils := pq.NewSkipNilsPredicate()
 
 	iter, err := pq.NewLeftJoinIterator(definitionLevel,
@@ -366,7 +358,7 @@ func searchKeyValues(definitionLevel int, keyPath, stringPath, intPath, floatPat
 
 // searchSpecialTagValues searches a parquet file for all values for the provided column. It first attempts
 // to only pull all values from the column's dictionary. If this fails it falls back to scanning the entire path.
-func searchSpecialTagValues(ctx context.Context, column string, pf *parquet.File, cb common.TagCallbackV2) error {
+func searchSpecialTagValues(ctx context.Context, column string, pf *parquet.File, cb common.TagValuesCallbackV2) error {
 	pred := newReportValuesPredicate(cb)
 	rgs := pf.RowGroups()
 

--- a/tempodb/encoding/vparquet3/block_search_tags_test.go
+++ b/tempodb/encoding/vparquet3/block_search_tags_test.go
@@ -21,7 +21,7 @@ func TestBackendBlockSearchTags(t *testing.T) {
 
 	testVals := func(scope traceql.AttributeScope, attrs map[string]string) {
 		foundAttrs := map[string]struct{}{}
-		cb := func(s string) {
+		cb := func(s string, _ traceql.AttributeScope) {
 			foundAttrs[s] = struct{}{}
 		}
 
@@ -198,7 +198,7 @@ func BenchmarkBackendBlockSearchTags(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		err := block.SearchTags(ctx, traceql.AttributeScopeNone, d.Collect, opts)
+		err := block.SearchTags(ctx, traceql.AttributeScopeNone, func(s string, _ traceql.AttributeScope) { d.Collect(s) }, opts)
 		require.NoError(b, err)
 	}
 }

--- a/tempodb/encoding/vparquet3/block_search_tags_test.go
+++ b/tempodb/encoding/vparquet3/block_search_tags_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/grafana/tempo/pkg/collector"
 	"github.com/grafana/tempo/pkg/traceql"
-	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/local"
 	"github.com/grafana/tempo/tempodb/encoding/common"
@@ -66,9 +66,10 @@ func TestBackendBlockSearchTagValues(t *testing.T) {
 	ctx := context.Background()
 	for tag, val := range attrs {
 		wasCalled := false
-		cb := func(s string) {
+		cb := func(s string) bool {
 			wasCalled = true
 			assert.Equal(t, val, s, tag)
+			return true
 		}
 
 		err := block.SearchTagValues(ctx, tag, cb, common.DefaultSearchOptions())
@@ -193,7 +194,7 @@ func BenchmarkBackendBlockSearchTags(b *testing.B) {
 
 	block := newBackendBlock(meta, rr)
 	opts := common.DefaultSearchOptions()
-	d := util.NewDistinctStringCollector(1_000_000)
+	d := collector.NewDistinctString(1_000_000)
 
 	b.ResetTimer()
 
@@ -227,7 +228,7 @@ func BenchmarkBackendBlockSearchTagValues(b *testing.B) {
 
 	for _, tc := range testCases {
 		b.Run(tc, func(b *testing.B) {
-			d := util.NewDistinctStringCollector(1_000_000)
+			d := collector.NewDistinctString(1_000_000)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				err := block.SearchTagValues(ctx, tc, d.Collect, opts)

--- a/tempodb/encoding/vparquet3/wal_block.go
+++ b/tempodb/encoding/vparquet3/wal_block.go
@@ -584,7 +584,7 @@ func (b *walBlock) Search(ctx context.Context, req *tempopb.SearchRequest, _ com
 	return results, nil
 }
 
-func (b *walBlock) SearchTags(ctx context.Context, scope traceql.AttributeScope, cb common.TagCallback, _ common.SearchOptions) error {
+func (b *walBlock) SearchTags(ctx context.Context, scope traceql.AttributeScope, cb common.TagsCallback, _ common.SearchOptions) error {
 	for i, blockFlush := range b.readFlushes() {
 		file, err := blockFlush.file(ctx)
 		if err != nil {
@@ -603,7 +603,7 @@ func (b *walBlock) SearchTags(ctx context.Context, scope traceql.AttributeScope,
 	return nil
 }
 
-func (b *walBlock) SearchTagValues(ctx context.Context, tag string, cb common.TagCallback, opts common.SearchOptions) error {
+func (b *walBlock) SearchTagValues(ctx context.Context, tag string, cb common.TagValuesCallback, opts common.SearchOptions) error {
 	att, ok := translateTagToAttribute[tag]
 	if !ok {
 		att = traceql.NewAttribute(tag)
@@ -618,7 +618,7 @@ func (b *walBlock) SearchTagValues(ctx context.Context, tag string, cb common.Ta
 	return b.SearchTagValuesV2(ctx, att, cb2, opts)
 }
 
-func (b *walBlock) SearchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb common.TagCallbackV2, _ common.SearchOptions) error {
+func (b *walBlock) SearchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb common.TagValuesCallbackV2, _ common.SearchOptions) error {
 	for i, blockFlush := range b.readFlushes() {
 		file, err := blockFlush.file(ctx)
 		if err != nil {
@@ -694,7 +694,7 @@ func (b *walBlock) FetchTagValues(ctx context.Context, req traceql.FetchTagValue
 	}
 
 	if len(req.Conditions) <= 1 || mingledConditions { // Last check. No conditions, use old path. It's much faster.
-		return b.SearchTagValuesV2(ctx, req.TagName, common.TagCallbackV2(cb), common.DefaultSearchOptions())
+		return b.SearchTagValuesV2(ctx, req.TagName, common.TagValuesCallbackV2(cb), common.DefaultSearchOptions())
 	}
 
 	blockFlushes := b.readFlushes()

--- a/tempodb/encoding/vparquet3/wal_block_test.go
+++ b/tempodb/encoding/vparquet3/wal_block_test.go
@@ -369,7 +369,8 @@ func BenchmarkWalSearchTagValues(b *testing.B) {
 	require.NoError(b, err)
 	require.NoError(b, warn)
 
-	cb := func(v string) {
+	cb := func(v string) bool {
+		return true
 	}
 
 	for _, t := range tags {

--- a/tempodb/encoding/vparquet4/block_autocomplete.go
+++ b/tempodb/encoding/vparquet4/block_autocomplete.go
@@ -27,7 +27,7 @@ func (b *backendBlock) FetchTagValues(ctx context.Context, req traceql.FetchTagV
 
 	// Last check. No conditions, use old path. It's much faster.
 	if len(req.Conditions) <= 1 || mingledConditions { // <= 1 because we always have a "OpNone" condition for the tag name
-		return b.SearchTagValuesV2(ctx, req.TagName, common.TagCallbackV2(cb), common.DefaultSearchOptions())
+		return b.SearchTagValuesV2(ctx, req.TagName, common.TagValuesCallbackV2(cb), common.DefaultSearchOptions())
 	}
 
 	pf, _, err := b.openForSearch(ctx, opts)

--- a/tempodb/encoding/vparquet4/block_autocomplete_test.go
+++ b/tempodb/encoding/vparquet4/block_autocomplete_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/grafana/tempo/pkg/collector"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/traceql"
-	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/local"
 	"github.com/grafana/tempo/tempodb/encoding/common"
@@ -265,7 +265,7 @@ func TestFetchTagValues(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("tag: %s, query: %s", tc.tag, tc.query), func(t *testing.T) {
-			distinctValues := util.NewDistinctValueCollector[tempopb.TagValue](1_000_000, func(v tempopb.TagValue) int { return len(v.Type) + len(v.Value) })
+			distinctValues := collector.NewDistinctValue[tempopb.TagValue](1_000_000, func(v tempopb.TagValue) int { return len(v.Type) + len(v.Value) })
 			req, err := traceql.ExtractFetchSpansRequest(tc.query)
 			require.NoError(t, err)
 
@@ -346,7 +346,7 @@ func BenchmarkFetchTagValues(b *testing.B) {
 
 	for _, tc := range testCases {
 		b.Run(fmt.Sprintf("tag: %s, query: %s", tc.tag, tc.query), func(b *testing.B) {
-			distinctValues := util.NewDistinctValueCollector[tempopb.TagValue](1_000_000, func(v tempopb.TagValue) int { return len(v.Type) + len(v.Value) })
+			distinctValues := collector.NewDistinctValue[tempopb.TagValue](1_000_000, func(v tempopb.TagValue) int { return len(v.Type) + len(v.Value) })
 			req, err := traceql.ExtractFetchSpansRequest(tc.query)
 			require.NoError(b, err)
 

--- a/tempodb/encoding/vparquet4/block_search.go
+++ b/tempodb/encoding/vparquet4/block_search.go
@@ -406,10 +406,10 @@ func (r *rowNumberIterator) Close() {}
 
 // reportValuesPredicate is a "fake" predicate that uses existing iterator logic to find all values in a given column
 type reportValuesPredicate struct {
-	cb common.TagCallbackV2
+	cb common.TagValuesCallbackV2
 }
 
-func newReportValuesPredicate(cb common.TagCallbackV2) *reportValuesPredicate {
+func newReportValuesPredicate(cb common.TagValuesCallbackV2) *reportValuesPredicate {
 	return &reportValuesPredicate{cb: cb}
 }
 
@@ -451,7 +451,7 @@ func (r *reportValuesPredicate) KeepValue(v parquet.Value) bool {
 	return false
 }
 
-func callback(cb common.TagCallbackV2, v parquet.Value) (stop bool) {
+func callback(cb common.TagValuesCallbackV2, v parquet.Value) (stop bool) {
 	switch v.Kind() {
 
 	case parquet.Boolean:

--- a/tempodb/encoding/vparquet4/block_search_tags.go
+++ b/tempodb/encoding/vparquet4/block_search_tags.go
@@ -43,7 +43,7 @@ var nonTraceQLAttributes = map[string]string{
 	LabelRootSpanName:    columnPathRootSpanName,
 }
 
-func (b *backendBlock) SearchTags(ctx context.Context, scope traceql.AttributeScope, cb common.TagCallback, opts common.SearchOptions) error {
+func (b *backendBlock) SearchTags(ctx context.Context, scope traceql.AttributeScope, cb common.TagsCallback, opts common.SearchOptions) error {
 	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "parquet.backendBlock.SearchTags",
 		opentracing.Tags{
 			"blockID":   b.meta.BlockID,
@@ -61,17 +61,12 @@ func (b *backendBlock) SearchTags(ctx context.Context, scope traceql.AttributeSc
 	return searchTags(derivedCtx, scope, cb, pf, b.meta.DedicatedColumns)
 }
 
-func searchTags(_ context.Context, scope traceql.AttributeScope, cb common.TagCallback, pf *parquet.File, dc backend.DedicatedColumns) error {
-	standardAttrIdxs := make([]int, 0, 2) // the most we can have is 2, resource and span indexes depending on scope passed
-	specialAttrIdxs := map[int]string{}
+func searchTags(_ context.Context, scope traceql.AttributeScope, cb common.TagsCallback, pf *parquet.File, dc backend.DedicatedColumns) error {
+	scanColumns := func(standardKeyPath string, specialMappings map[string]string, columnMapping dedicatedColumnMapping, cb common.TagsCallback, scope traceql.AttributeScope) error {
+		specialAttrIdxs := map[int]string{}
 
-	addToIndexes := func(standardKeyPath string, specialMappings map[string]string, columnMapping dedicatedColumnMapping) error {
 		// standard attributes
 		resourceKeyIdx, _ := pq.GetColumnIndexByPath(pf, standardKeyPath)
-		if resourceKeyIdx == -1 {
-			return fmt.Errorf("resource attributes col not found (%d)", resourceKeyIdx)
-		}
-		standardAttrIdxs = append(standardAttrIdxs, resourceKeyIdx)
 
 		// special attributes
 		for lbl, col := range specialMappings {
@@ -93,70 +88,48 @@ func searchTags(_ context.Context, scope traceql.AttributeScope, cb common.TagCa
 			specialAttrIdxs[idx] = lbl
 		})
 
-		return nil
-	}
-
-	// resource
-	if scope == traceql.AttributeScopeNone || scope == traceql.AttributeScopeResource {
-		columnMapping := dedicatedColumnsToColumnMapping(dc, backend.DedicatedColumnScopeResource)
-		err := addToIndexes(FieldResourceAttrKey, traceqlResourceLabelMappings, columnMapping)
-		if err != nil {
-			return err
-		}
-	}
-	// span
-	if scope == traceql.AttributeScopeNone || scope == traceql.AttributeScopeSpan {
-		columnMapping := dedicatedColumnsToColumnMapping(dc, backend.DedicatedColumnScopeSpan)
-		err := addToIndexes(FieldSpanAttrKey, traceqlSpanLabelMappings, columnMapping)
-		if err != nil {
-			return err
-		}
-	}
-
-	// now search all row groups
-	var err error
-	rgs := pf.RowGroups()
-	for _, rg := range rgs {
-		// search all special attributes
-		for idx, lbl := range specialAttrIdxs {
-			cc := rg.ColumnChunks()[idx]
-			err = func() error {
-				pgs := cc.Pages()
-				defer pgs.Close()
-				for {
-					pg, err := pgs.ReadPage()
-					if errors.Is(err, io.EOF) || pg == nil {
-						break
-					}
-					if err != nil {
-						return err
-					}
-
-					stop := func(page parquet.Page) bool {
-						defer parquet.Release(page)
-
-						// if a special attribute has any non-null values, include it
-						if page.NumNulls() < page.NumValues() {
-							cb(lbl)
-							delete(specialAttrIdxs, idx) // remove from map so we won't search again
-							return true
+		// now search all row groups
+		var err error
+		rgs := pf.RowGroups()
+		for _, rg := range rgs {
+			// search all special attributes
+			for idx, lbl := range specialAttrIdxs {
+				cc := rg.ColumnChunks()[idx]
+				err = func() error {
+					pgs := cc.Pages()
+					defer pgs.Close()
+					for {
+						pg, err := pgs.ReadPage()
+						if errors.Is(err, io.EOF) || pg == nil {
+							break
 						}
-						return false
-					}(pg)
-					if stop {
-						break
-					}
-				}
-				return nil
-			}()
-			if err != nil {
-				return err
-			}
-		}
+						if err != nil {
+							return err
+						}
 
-		// search other attributes
-		for _, idx := range standardAttrIdxs {
-			cc := rg.ColumnChunks()[idx]
+						stop := func(page parquet.Page) bool {
+							defer parquet.Release(page)
+
+							// if a special attribute has any non-null values, include it
+							if page.NumNulls() < page.NumValues() {
+								cb(lbl, scope)
+								delete(specialAttrIdxs, idx) // remove from map so we won't search again
+								return true
+							}
+							return false
+						}(pg)
+						if stop {
+							break
+						}
+					}
+					return nil
+				}()
+				if err != nil {
+					return err
+				}
+			}
+
+			cc := rg.ColumnChunks()[resourceKeyIdx]
 			err = func() error {
 				pgs := cc.Pages()
 				defer pgs.Close()
@@ -182,7 +155,7 @@ func searchTags(_ context.Context, scope traceql.AttributeScope, cb common.TagCa
 
 					for i := 0; i < dict.Len(); i++ {
 						s := dict.Index(int32(i)).String()
-						cb(s)
+						cb(s, scope)
 					}
 				}(pg)
 
@@ -192,12 +165,31 @@ func searchTags(_ context.Context, scope traceql.AttributeScope, cb common.TagCa
 				return err
 			}
 		}
+
+		return nil
+	}
+
+	// resource
+	if scope == traceql.AttributeScopeNone || scope == traceql.AttributeScopeResource {
+		columnMapping := dedicatedColumnsToColumnMapping(dc, backend.DedicatedColumnScopeResource)
+		err := scanColumns(FieldResourceAttrKey, traceqlResourceLabelMappings, columnMapping, cb, traceql.AttributeScopeResource)
+		if err != nil {
+			return err
+		}
+	}
+	// span
+	if scope == traceql.AttributeScopeNone || scope == traceql.AttributeScopeSpan {
+		columnMapping := dedicatedColumnsToColumnMapping(dc, backend.DedicatedColumnScopeSpan)
+		err := scanColumns(FieldSpanAttrKey, traceqlSpanLabelMappings, columnMapping, cb, traceql.AttributeScopeSpan)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func (b *backendBlock) SearchTagValues(ctx context.Context, tag string, cb common.TagCallback, opts common.SearchOptions) error {
+func (b *backendBlock) SearchTagValues(ctx context.Context, tag string, cb common.TagValuesCallback, opts common.SearchOptions) error {
 	att, ok := translateTagToAttribute[tag]
 	if !ok {
 		att = traceql.NewAttribute(tag)
@@ -212,7 +204,7 @@ func (b *backendBlock) SearchTagValues(ctx context.Context, tag string, cb commo
 	return b.SearchTagValuesV2(ctx, att, cb2, opts)
 }
 
-func (b *backendBlock) SearchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb common.TagCallbackV2, opts common.SearchOptions) error {
+func (b *backendBlock) SearchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb common.TagValuesCallbackV2, opts common.SearchOptions) error {
 	span, derivedCtx := opentracing.StartSpanFromContext(ctx, "parquet.backendBlock.SearchTagValuesV2",
 		opentracing.Tags{
 			"blockID":   b.meta.BlockID,
@@ -230,7 +222,7 @@ func (b *backendBlock) SearchTagValuesV2(ctx context.Context, tag traceql.Attrib
 	return searchTagValues(derivedCtx, tag, cb, pf, b.meta.DedicatedColumns)
 }
 
-func searchTagValues(ctx context.Context, tag traceql.Attribute, cb common.TagCallbackV2, pf *parquet.File, dc backend.DedicatedColumns) error {
+func searchTagValues(ctx context.Context, tag traceql.Attribute, cb common.TagValuesCallbackV2, pf *parquet.File, dc backend.DedicatedColumns) error {
 	// Special handling for intrinsics
 	if tag.Intrinsic != traceql.IntrinsicNone {
 		lookup := intrinsicColumnLookups[tag.Intrinsic]
@@ -292,7 +284,7 @@ func searchTagValues(ctx context.Context, tag traceql.Attribute, cb common.TagCa
 
 // searchStandardTagValues searches a parquet file for "standard" tags. i.e. tags that don't have unique
 // columns and are contained in labelMappings
-func searchStandardTagValues(ctx context.Context, tag traceql.Attribute, pf *parquet.File, cb common.TagCallbackV2) error {
+func searchStandardTagValues(ctx context.Context, tag traceql.Attribute, pf *parquet.File, cb common.TagValuesCallbackV2) error {
 	rgs := pf.RowGroups()
 	makeIter := makeIterFunc(ctx, rgs, pf)
 
@@ -327,7 +319,7 @@ func searchStandardTagValues(ctx context.Context, tag traceql.Attribute, pf *par
 	return nil
 }
 
-func searchKeyValues(definitionLevel int, keyPath, stringPath, intPath, floatPath, boolPath string, makeIter makeIterFn, keyPred pq.Predicate, cb common.TagCallbackV2) error {
+func searchKeyValues(definitionLevel int, keyPath, stringPath, intPath, floatPath, boolPath string, makeIter makeIterFn, keyPred pq.Predicate, cb common.TagValuesCallbackV2) error {
 	skipNils := pq.NewSkipNilsPredicate()
 
 	iter, err := pq.NewLeftJoinIterator(definitionLevel,
@@ -366,7 +358,7 @@ func searchKeyValues(definitionLevel int, keyPath, stringPath, intPath, floatPat
 
 // searchSpecialTagValues searches a parquet file for all values for the provided column. It first attempts
 // to only pull all values from the column's dictionary. If this fails it falls back to scanning the entire path.
-func searchSpecialTagValues(ctx context.Context, column string, pf *parquet.File, cb common.TagCallbackV2) error {
+func searchSpecialTagValues(ctx context.Context, column string, pf *parquet.File, cb common.TagValuesCallbackV2) error {
 	pred := newReportValuesPredicate(cb)
 	rgs := pf.RowGroups()
 

--- a/tempodb/encoding/vparquet4/block_search_tags_test.go
+++ b/tempodb/encoding/vparquet4/block_search_tags_test.go
@@ -21,7 +21,7 @@ func TestBackendBlockSearchTags(t *testing.T) {
 
 	testVals := func(scope traceql.AttributeScope, attrs map[string]string) {
 		foundAttrs := map[string]struct{}{}
-		cb := func(s string) {
+		cb := func(s string, _ traceql.AttributeScope) {
 			foundAttrs[s] = struct{}{}
 		}
 
@@ -198,7 +198,7 @@ func BenchmarkBackendBlockSearchTags(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		err := block.SearchTags(ctx, traceql.AttributeScopeNone, d.Collect, opts)
+		err := block.SearchTags(ctx, traceql.AttributeScopeNone, func(s string, _ traceql.AttributeScope) { d.Collect(s) }, opts)
 		require.NoError(b, err)
 	}
 }

--- a/tempodb/encoding/vparquet4/block_search_tags_test.go
+++ b/tempodb/encoding/vparquet4/block_search_tags_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/grafana/tempo/pkg/collector"
 	"github.com/grafana/tempo/pkg/traceql"
-	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/local"
 	"github.com/grafana/tempo/tempodb/encoding/common"
@@ -66,9 +66,10 @@ func TestBackendBlockSearchTagValues(t *testing.T) {
 	ctx := context.Background()
 	for tag, val := range attrs {
 		wasCalled := false
-		cb := func(s string) {
+		cb := func(s string) bool {
 			wasCalled = true
 			assert.Equal(t, val, s, tag)
+			return true
 		}
 
 		err := block.SearchTagValues(ctx, tag, cb, common.DefaultSearchOptions())
@@ -193,7 +194,7 @@ func BenchmarkBackendBlockSearchTags(b *testing.B) {
 
 	block := newBackendBlock(meta, rr)
 	opts := common.DefaultSearchOptions()
-	d := util.NewDistinctStringCollector(1_000_000)
+	d := collector.NewDistinctString(1_000_000)
 
 	b.ResetTimer()
 
@@ -227,7 +228,7 @@ func BenchmarkBackendBlockSearchTagValues(b *testing.B) {
 
 	for _, tc := range testCases {
 		b.Run(tc, func(b *testing.B) {
-			d := util.NewDistinctStringCollector(1_000_000)
+			d := collector.NewDistinctString(1_000_000)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				err := block.SearchTagValues(ctx, tc, d.Collect, opts)

--- a/tempodb/encoding/vparquet4/wal_block.go
+++ b/tempodb/encoding/vparquet4/wal_block.go
@@ -584,7 +584,7 @@ func (b *walBlock) Search(ctx context.Context, req *tempopb.SearchRequest, _ com
 	return results, nil
 }
 
-func (b *walBlock) SearchTags(ctx context.Context, scope traceql.AttributeScope, cb common.TagCallback, _ common.SearchOptions) error {
+func (b *walBlock) SearchTags(ctx context.Context, scope traceql.AttributeScope, cb common.TagsCallback, _ common.SearchOptions) error {
 	for i, blockFlush := range b.readFlushes() {
 		file, err := blockFlush.file(ctx)
 		if err != nil {
@@ -603,7 +603,7 @@ func (b *walBlock) SearchTags(ctx context.Context, scope traceql.AttributeScope,
 	return nil
 }
 
-func (b *walBlock) SearchTagValues(ctx context.Context, tag string, cb common.TagCallback, opts common.SearchOptions) error {
+func (b *walBlock) SearchTagValues(ctx context.Context, tag string, cb common.TagValuesCallback, opts common.SearchOptions) error {
 	att, ok := translateTagToAttribute[tag]
 	if !ok {
 		att = traceql.NewAttribute(tag)
@@ -618,7 +618,7 @@ func (b *walBlock) SearchTagValues(ctx context.Context, tag string, cb common.Ta
 	return b.SearchTagValuesV2(ctx, att, cb2, opts)
 }
 
-func (b *walBlock) SearchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb common.TagCallbackV2, _ common.SearchOptions) error {
+func (b *walBlock) SearchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb common.TagValuesCallbackV2, _ common.SearchOptions) error {
 	for i, blockFlush := range b.readFlushes() {
 		file, err := blockFlush.file(ctx)
 		if err != nil {
@@ -694,7 +694,7 @@ func (b *walBlock) FetchTagValues(ctx context.Context, req traceql.FetchTagValue
 	}
 
 	if len(req.Conditions) <= 1 || mingledConditions { // Last check. No conditions, use old path. It's much faster.
-		return b.SearchTagValuesV2(ctx, req.TagName, common.TagCallbackV2(cb), common.DefaultSearchOptions())
+		return b.SearchTagValuesV2(ctx, req.TagName, common.TagValuesCallbackV2(cb), common.DefaultSearchOptions())
 	}
 
 	blockFlushes := b.readFlushes()

--- a/tempodb/encoding/vparquet4/wal_block_test.go
+++ b/tempodb/encoding/vparquet4/wal_block_test.go
@@ -369,7 +369,8 @@ func BenchmarkWalSearchTagValues(b *testing.B) {
 	require.NoError(b, err)
 	require.NoError(b, warn)
 
-	cb := func(v string) {
+	cb := func(v string) bool {
+		return true
 	}
 
 	for _, t := range tags {

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -375,7 +375,7 @@ func (rw *readerWriter) SearchTags(ctx context.Context, meta *backend.BlockMeta,
 		return nil, err
 	}
 
-	collectors := map[string]*util.DistinctStringCollector{}
+	collectors := map[string]*util.DistinctStringCollector{} // jpe - scoped collector
 
 	rw.cfg.Search.ApplyToOptions(&opts)
 	err = block.SearchTags(ctx, attributeScope, func(s string, scope traceql.AttributeScope) {

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -2037,12 +2037,16 @@ func TestSearchForTagsAndTagValues(t *testing.T) {
 	block, err := w.CompleteBlock(context.Background(), head)
 	require.NoError(t, err)
 
-	tags, err := r.SearchTags(context.Background(), block.BlockMeta(), "", common.DefaultSearchOptions())
+	resp, err := r.SearchTags(context.Background(), block.BlockMeta(), "", common.DefaultSearchOptions())
 	require.NoError(t, err)
 	expectedTags := []string{"stringTag", "intTag", "service.name", "other"}
+	var actualTags []string
+	for _, scopeTags := range resp.Scopes {
+		actualTags = append(actualTags, scopeTags.Tags...)
+	}
 	sort.Strings(expectedTags)
-	sort.Strings(tags.TagNames)
-	assert.Equal(t, expectedTags, tags.TagNames)
+	sort.Strings(actualTags)
+	assert.Equal(t, expectedTags, actualTags)
 
 	values, err := r.SearchTagValues(context.Background(), block.BlockMeta(), "service.name", common.DefaultSearchOptions())
 	require.NoError(t, err)

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/tempo/pkg/collector"
 	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempopb"
@@ -1379,7 +1380,7 @@ func autoComplete(t *testing.T, _ *tempopb.Trace, _ *tempopb.TraceSearchMetadata
 				return bb.FetchTagValues(ctx, req, cb, common.DefaultSearchOptions())
 			})
 
-			valueCollector := util.NewDistinctValueCollector[tempopb.TagValue](0, func(v tempopb.TagValue) int { return 0 })
+			valueCollector := collector.NewDistinctValue[tempopb.TagValue](0, func(v tempopb.TagValue) int { return 0 })
 			err := e.ExecuteTagValues(ctx, tc.tag, tc.query, traceql.MakeCollectTagValueFunc(valueCollector.Collect), fetcher)
 			if errors.Is(err, common.ErrUnsupported) {
 				return
@@ -2113,7 +2114,7 @@ func TestSearchForTagsAndTagValues(t *testing.T) {
 	})
 	assert.Equal(t, expected, tagValues.TagValues)
 
-	valueCollector := util.NewDistinctValueCollector[tempopb.TagValue](0, func(value tempopb.TagValue) int { return 0 })
+	valueCollector := collector.NewDistinctValue[tempopb.TagValue](0, func(value tempopb.TagValue) int { return 0 })
 	f := traceql.NewTagValuesFetcherWrapper(func(ctx context.Context, req traceql.FetchTagValuesRequest, cb traceql.FetchTagValuesCallback) error {
 		return r.FetchTagValues(ctx, block.BlockMeta(), req, cb, common.DefaultSearchOptions())
 	})


### PR DESCRIPTION
**What this PR does**:
Refactors tags search to better support tag name filtering and for performance.

- Moved all "distinct collectors" to a new package `./pkg/collector` and added `ScopedDistinctString` collector for use with tags v2.
- Fixed a bug where tag names limits were only applied per scope. Now they are applied across all scopes.
- Made SearchTags dependent on SearchTagsV2 (instead of the reverse). Previously SearchTagsV2 called SearchTags once for each scope which is much less efficient than calling it once for all scopes. Now SearchTagsV2 asks the block directly for the desired scopes.
- Added an explicit `TagsCallback` that returns both scope and tag name. Previously the block only returned tag name. Calling code was required to call the block once for each scope to know how to build the response. This is the required change that drove the refactor.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`