### PR TITLE
Detect body format after reading from cache and restore content-type header

### DIFF
--- a/modules/frontend/pipeline/sync_handler_cache.go
+++ b/modules/frontend/pipeline/sync_handler_cache.go
@@ -52,6 +52,8 @@ func (c cachingWare) RoundTrip(req *http.Request) (*http.Response, error) {
 			// TODO - Cache should capture all of the relevant parts of the
 			// original response including both content-type and content-length headers, possibly more.
 			// But upgrading the cache format requires migration/detection of previous format either way.
+			// It's tempting to use https://pkg.go.dev/net/http#DetectContentType but it doesn't detect
+			// json or proto.
 			if body[0] == '{' {
 				resp.Header.Add(api.HeaderContentType, api.HeaderAcceptJSON)
 			} else {


### PR DESCRIPTION
**What this PR does**:
This fixes a bug introduced in #3731 and caching the new protobuf responses.   Cache loses the Content-Type header and therefore it falls back to json parsing which fails with an error like `error unmarshalling response body: invalid character '\x17' looking for beginning of value`.  This is a quick work-around to readd the Content-Type by detecting the format.  I wish we could use https://pkg.go.dev/net/http#DetectContentType but it doesn't seem to detect either json or proto, and yields either `text/plain` or `application/octet-stream`.

Long-term cache needs to be updated to store the http response more comprehensively, likely including all headers.  And add more structure around upgrading/migration cache content.  Changing the cache key (`stv:v1` -> `stv:v2`) isn't sufficient in this case because the cache key is determined by the frontend, and the response format by the querier, so there is a disconnect.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`