### PR TITLE
Improve http connection reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [ENHANCEMENT] Use multiple goroutines to unmarshal responses in parallel in the query frontend. [#3713](https://github.com/grafana/tempo/pull/3713) (@joe-elliott)
 * [BUGFIX] Fix metrics queries when grouping by attributes that may not exist [#3734](https://github.com/grafana/tempo/pull/3734) (@mdisibio)
 * [BUGFIX] max_global_traces_per_user: take into account ingestion.tenant_shard_size when converting to local limit [#3618](https://github.com/grafana/tempo/pull/3618) (@kvrhdn)
+* [BUGFIX] Fix http connection reuse on GCP and AWS by reading io.EOF through the http body. [#3760](https://github.com/grafana/tempo/pull/3760) (@bmteller)
 
 ## v2.5.0
 

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -623,6 +623,10 @@ func createCore(cfg *Config, hedge bool) (*minio.Core, error) {
 		return nil, fmt.Errorf("create minio.DefaultTransport: %w", err)
 	}
 
+	/* minio sets MaxIdleConns to 100 but we should also increase per host to 100 */
+	customTransport.MaxIdleConnsPerHost = 100
+	customTransport.MaxIdleConns = 100
+
 	tlsConfig, err := cfg.GetTLSConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create TLS config: %w", err)


### PR DESCRIPTION
**What this PR does**: 
Fixes connection reuse for S3 range requests and increases the number of MaxIdleConnsPerHost for the S3 backend to 100 to match the azure settings. Also, assumes GCP has the same connection reuse problem for range requests and performs the same fix. Note: I have tested the fix for S3 range requests and verified it is a problem and the change fixes the problem but I have not verified that it is a problem for GCP or that it fixes the problem for GCP. The GCP HTTP google storage code does look like it effectively returns the body reader so it does look like GCP would have a similar issue.

**Which issue(s) this PR fixes**:
Fixes #3750

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`