### PR TITLE
Change toolchain from go 1.22 => go 1.22.0

### DIFF
--- a/cmd/tempo-serverless/cloud-run/go.mod
+++ b/cmd/tempo-serverless/cloud-run/go.mod
@@ -1,8 +1,6 @@
 module github.com/grafana/tempo/cmd/tempo-serverless/cloud-run
 
-go 1.22
-
-toolchain go1.22.0
+go 1.22.0
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/cmd/tempo-serverless/lambda/go.mod
+++ b/cmd/tempo-serverless/lambda/go.mod
@@ -1,8 +1,6 @@
 module github.com/grafana/tempo/cmd/tempo-serverless/lambda
 
-go 1.22
-
-toolchain go1.22.0
+go 1.22.0
 
 require (
 	github.com/aws/aws-lambda-go v1.28.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/tempo
 
-go 1.22
+go 1.22.0
 
 require (
 	cloud.google.com/go/storage v1.36.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/tempo/tools
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/golangci/golangci-lint v1.57.2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: Change toolchain from go 1.22 => go 1.22.0 in `go.mod`. [Toolchain requires a specific version.](https://github.com/golang/go/issues/62278#issuecomment-1693538776) .

```
% make docker-tempo
go: downloading go1.22 (darwin/amd64)
go: download go1.22 for darwin/amd64: toolchain not available
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`