### PR TITLE
Defer recover all read endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [ENHANCEMENT] Improve use of OTEL semantic conventions on the service graph [#3711](https://github.com/grafana/tempo/pull/3711) (@zalegrala)
 * [ENHANCEMENT] Performance improvement for `rate() by ()` queries [#3719](https://github.com/grafana/tempo/pull/3719) (@mapno)
 * [ENHANCEMENT] Use multiple goroutines to unmarshal responses in parallel in the query frontend. [#3713](https://github.com/grafana/tempo/pull/3713) (@joe-elliott)
+* [ENHANCEMENT] Protect ingesters from panics by adding defer/recover to all read path methods. [#3790](https://github.com/grafana/tempo/pull/3790) (@joe-elliott)
 * [BUGFIX] Fix metrics queries when grouping by attributes that may not exist [#3734](https://github.com/grafana/tempo/pull/3734) (@mdisibio)
 * [BUGFIX] Fix frontend parsing error on cached responses [#3759](https://github.com/grafana/tempo/pull/3759) (@mdisibio)
 * [BUGFIX] max_global_traces_per_user: take into account ingestion.tenant_shard_size when converting to local limit [#3618](https://github.com/grafana/tempo/pull/3618) (@kvrhdn)

--- a/modules/ingester/ingester.go
+++ b/modules/ingester/ingester.go
@@ -27,6 +27,7 @@ import (
 	v1 "github.com/grafana/tempo/pkg/model/v1"
 	v2 "github.com/grafana/tempo/pkg/model/v2"
 	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/pkg/util/log"
 	"github.com/grafana/tempo/pkg/validation"
 	"github.com/grafana/tempo/tempodb/backend"
@@ -263,7 +264,7 @@ func (i *Ingester) PushBytesV2(ctx context.Context, req *tempopb.PushBytesReques
 func (i *Ingester) FindTraceByID(ctx context.Context, req *tempopb.TraceByIDRequest) (res *tempopb.TraceByIDResponse, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			level.Error(log.Logger).Log("msg", "recover in FindTraceByID", "stack", r, string(debug.Stack()))
+			level.Error(log.Logger).Log("msg", "recover in FindTraceByID", "id", util.TraceIDToHexString(req.TraceID), "stack", r, string(debug.Stack()))
 			err = errors.New("recovered in FindTraceByID")
 		}
 	}()

--- a/modules/ingester/ingester_search.go
+++ b/modules/ingester/ingester_search.go
@@ -14,7 +14,7 @@ import (
 func (i *Ingester) SearchRecent(ctx context.Context, req *tempopb.SearchRequest) (res *tempopb.SearchResponse, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			level.Error(log.Logger).Log("msg", "recover in SearchRecent", "stack", r, string(debug.Stack()))
+			level.Error(log.Logger).Log("msg", "recover in SearchRecent", "query", req.Query, "stack", r, string(debug.Stack()))
 			err = errors.New("recovered in SearchRecent")
 		}
 	}()
@@ -114,7 +114,7 @@ func (i *Ingester) SearchTagValues(ctx context.Context, req *tempopb.SearchTagVa
 func (i *Ingester) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTagValuesRequest) (res *tempopb.SearchTagValuesV2Response, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			level.Error(log.Logger).Log("msg", "recover in SearchTagValuesV2", "stack", r, string(debug.Stack()))
+			level.Error(log.Logger).Log("msg", "recover in SearchTagValuesV2", "tag", req.TagName, "query", req.Query, "stack", r, string(debug.Stack()))
 			err = errors.New("recovered in SearchTagValuesV2")
 		}
 	}()

--- a/modules/ingester/ingester_search.go
+++ b/modules/ingester/ingester_search.go
@@ -3,12 +3,22 @@ package ingester
 import (
 	"context"
 	"errors"
+	"runtime/debug"
 
+	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/user"
 	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/grafana/tempo/pkg/util/log"
 )
 
-func (i *Ingester) SearchRecent(ctx context.Context, req *tempopb.SearchRequest) (*tempopb.SearchResponse, error) {
+func (i *Ingester) SearchRecent(ctx context.Context, req *tempopb.SearchRequest) (res *tempopb.SearchResponse, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			level.Error(log.Logger).Log("msg", "recover in SearchRecent", "stack", r, string(debug.Stack()))
+			err = errors.New("recovered in SearchRecent")
+		}
+	}()
+
 	instanceID, err := user.ExtractOrgID(ctx)
 	if err != nil {
 		return nil, err
@@ -18,7 +28,7 @@ func (i *Ingester) SearchRecent(ctx context.Context, req *tempopb.SearchRequest)
 		return &tempopb.SearchResponse{}, nil
 	}
 
-	res, err := inst.Search(ctx, req)
+	res, err = inst.Search(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -26,7 +36,14 @@ func (i *Ingester) SearchRecent(ctx context.Context, req *tempopb.SearchRequest)
 	return res, nil
 }
 
-func (i *Ingester) SearchTags(ctx context.Context, req *tempopb.SearchTagsRequest) (*tempopb.SearchTagsResponse, error) {
+func (i *Ingester) SearchTags(ctx context.Context, req *tempopb.SearchTagsRequest) (res *tempopb.SearchTagsResponse, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			level.Error(log.Logger).Log("msg", "recover in SearchTags", "stack", r, string(debug.Stack()))
+			err = errors.New("recovered in SearchTags")
+		}
+	}()
+
 	instanceID, err := user.ExtractOrgID(ctx)
 	if err != nil {
 		return nil, err
@@ -36,7 +53,7 @@ func (i *Ingester) SearchTags(ctx context.Context, req *tempopb.SearchTagsReques
 		return &tempopb.SearchTagsResponse{}, nil
 	}
 
-	res, err := inst.SearchTags(ctx, req.Scope)
+	res, err = inst.SearchTags(ctx, req.Scope)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +61,14 @@ func (i *Ingester) SearchTags(ctx context.Context, req *tempopb.SearchTagsReques
 	return res, nil
 }
 
-func (i *Ingester) SearchTagsV2(ctx context.Context, req *tempopb.SearchTagsRequest) (*tempopb.SearchTagsV2Response, error) {
+func (i *Ingester) SearchTagsV2(ctx context.Context, req *tempopb.SearchTagsRequest) (res *tempopb.SearchTagsV2Response, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			level.Error(log.Logger).Log("msg", "recover in SearchTagsV2", "stack", r, string(debug.Stack()))
+			err = errors.New("recovered in SearchTagsV2")
+		}
+	}()
+
 	instanceID, err := user.ExtractOrgID(ctx)
 	if err != nil {
 		return nil, err
@@ -54,7 +78,7 @@ func (i *Ingester) SearchTagsV2(ctx context.Context, req *tempopb.SearchTagsRequ
 		return &tempopb.SearchTagsV2Response{}, nil
 	}
 
-	res, err := inst.SearchTagsV2(ctx, req.Scope)
+	res, err = inst.SearchTagsV2(ctx, req.Scope)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +86,14 @@ func (i *Ingester) SearchTagsV2(ctx context.Context, req *tempopb.SearchTagsRequ
 	return res, nil
 }
 
-func (i *Ingester) SearchTagValues(ctx context.Context, req *tempopb.SearchTagValuesRequest) (*tempopb.SearchTagValuesResponse, error) {
+func (i *Ingester) SearchTagValues(ctx context.Context, req *tempopb.SearchTagValuesRequest) (res *tempopb.SearchTagValuesResponse, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			level.Error(log.Logger).Log("msg", "recover in SearchTagValues", "stack", r, string(debug.Stack()))
+			err = errors.New("recovered in SearchTagValues")
+		}
+	}()
+
 	instanceID, err := user.ExtractOrgID(ctx)
 	if err != nil {
 		return nil, err
@@ -72,7 +103,7 @@ func (i *Ingester) SearchTagValues(ctx context.Context, req *tempopb.SearchTagVa
 		return &tempopb.SearchTagValuesResponse{}, nil
 	}
 
-	res, err := inst.SearchTagValues(ctx, req.TagName)
+	res, err = inst.SearchTagValues(ctx, req.TagName)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +111,14 @@ func (i *Ingester) SearchTagValues(ctx context.Context, req *tempopb.SearchTagVa
 	return res, nil
 }
 
-func (i *Ingester) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTagValuesRequest) (*tempopb.SearchTagValuesV2Response, error) {
+func (i *Ingester) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTagValuesRequest) (res *tempopb.SearchTagValuesV2Response, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			level.Error(log.Logger).Log("msg", "recover in SearchTagValuesV2", "stack", r, string(debug.Stack()))
+			err = errors.New("recovered in SearchTagValuesV2")
+		}
+	}()
+
 	instanceID, err := user.ExtractOrgID(ctx)
 	if err != nil {
 		return nil, err
@@ -90,7 +128,7 @@ func (i *Ingester) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTag
 		return &tempopb.SearchTagValuesV2Response{}, nil
 	}
 
-	res, err := inst.SearchTagValuesV2(ctx, req)
+	res, err = inst.SearchTagValuesV2(ctx, req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does**:
Adds a defer/recover to all ingester gRPC endpoints to prevent poison reads from panicing ingesters.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`