### PR TITLE
Drop unnecessary concurrency check in metrics-generator histogram

### DIFF
--- a/modules/generator/registry/histogram.go
+++ b/modules/generator/registry/histogram.go
@@ -101,13 +101,7 @@ func (h *histogram) ObserveWithExemplar(labelValueCombo *LabelValueCombo, value 
 		return
 	}
 
-	newSeries := h.newSeries(labelValueCombo, value, traceID, multiplier)
-	s, ok = h.series[hash]
-	if ok {
-		h.updateSeries(s, value, traceID, multiplier)
-		return
-	}
-	h.series[hash] = newSeries
+	h.series[hash] = h.newSeries(labelValueCombo, value, traceID, multiplier)
 }
 
 func (h *histogram) newSeries(labelValueCombo *LabelValueCombo, value float64, traceID string, multiplier float64) *histogramSeries {


### PR DESCRIPTION
**What this PR does**:
Simplify the `histogram.ObserveWithExemplar` a tad. Since we lock a `Mutex` for the entire method, we don't have to check whether the map was updated in the meantime. This code was added when we still used a `RWMutex` which was removed by #3412.

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [ ] ~~Tests updated~~
- [ ] ~~Documentation added~~
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`