### PR TITLE
[TraceQL Metrics] Add local disk caching for generator completed blocks

### DIFF
--- a/modules/frontend/metrics_query_range_sharder.go
+++ b/modules/frontend/metrics_query_range_sharder.go
@@ -111,7 +111,7 @@ func (s queryRangeSharder) RoundTrip(r *http.Request) (pipeline.Responses[combin
 		return pipeline.NewBadRequest(errors.New("invalid interval specified: 0")), nil
 	}
 
-	generatorReq := s.generatorRequest(*req, r, tenantID, now, samplingRate)
+	generatorReq := s.generatorRequest(*req, r, tenantID, now)
 	reqCh := make(chan *http.Request, 2) // buffer of 2 allows us to insert generatorReq and metrics
 
 	if generatorReq != nil {
@@ -418,7 +418,7 @@ func (s *queryRangeSharder) backendRange(now time.Time, start, end uint64, query
 	return start, end
 }
 
-func (s *queryRangeSharder) generatorRequest(searchReq tempopb.QueryRangeRequest, parent *http.Request, tenantID string, now time.Time, samplingRate float64) *http.Request {
+func (s *queryRangeSharder) generatorRequest(searchReq tempopb.QueryRangeRequest, parent *http.Request, tenantID string, now time.Time) *http.Request {
 	cutoff := uint64(now.Add(-s.cfg.QueryBackendAfter).UnixNano())
 
 	// if there's no overlap between the query and ingester range just return nil

--- a/modules/generator/config.go
+++ b/modules/generator/config.go
@@ -43,6 +43,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.Registry.RegisterFlagsAndApplyDefaults(prefix, f)
 	cfg.Storage.RegisterFlagsAndApplyDefaults(prefix, f)
 	cfg.TracesWAL.Version = encoding.DefaultEncoding().Version()
+	cfg.TracesWAL.IngestionSlack = 2 * time.Minute
 
 	// setting default for max span age before discarding to 30s
 	cfg.MetricsIngestionSlack = 30 * time.Second

--- a/modules/generator/processor/localblocks/processor.go
+++ b/modules/generator/processor/localblocks/processor.go
@@ -17,11 +17,8 @@ import (
 	"github.com/grafana/tempo/modules/ingester"
 	"github.com/grafana/tempo/pkg/flushqueues"
 	"github.com/grafana/tempo/tempodb"
-	"github.com/opentracing/opentracing-go"
-	"go.uber.org/atomic"
 
 	gen "github.com/grafana/tempo/modules/generator/processor"
-	"github.com/grafana/tempo/pkg/boundedwaitgroup"
 	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/pkg/tempopb"
 	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
@@ -48,6 +45,8 @@ type Processor struct {
 	logger    kitlog.Logger
 	Cfg       Config
 	wal       *wal.WAL
+	walR      backend.Reader
+	walW      backend.Writer
 	closeCh   chan struct{}
 	wg        sync.WaitGroup
 	cacheMtx  sync.RWMutex
@@ -90,6 +89,8 @@ func New(cfg Config, tenant string, wal *wal.WAL, writer tempodb.Writer, overrid
 		logger:         log.WithUserID(tenant, log.Logger),
 		Cfg:            cfg,
 		wal:            wal,
+		walR:           backend.NewReader(wal.LocalBackend()),
+		walW:           backend.NewWriter(wal.LocalBackend()),
 		overrides:      overrides,
 		enc:            enc,
 		walBlocks:      map[uuid.UUID]common.WALBlock{},
@@ -492,108 +493,6 @@ func (p *Processor) GetMetrics(ctx context.Context, req *tempopb.SpanMetricsRequ
 	}
 
 	return resp, nil
-}
-
-// QueryRange returns metrics.
-func (p *Processor) QueryRange(ctx context.Context, req *tempopb.QueryRangeRequest) (traceql.SeriesSet, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	p.blocksMtx.RLock()
-	defer p.blocksMtx.RUnlock()
-
-	cutoff := time.Now().Add(-p.Cfg.CompleteBlockTimeout).Add(-timeBuffer)
-	if req.Start < uint64(cutoff.UnixNano()) {
-		return nil, fmt.Errorf("time range must be within last %v", p.Cfg.CompleteBlockTimeout)
-	}
-
-	// Blocks to check
-	blocks := make([]common.BackendBlock, 0, 1+len(p.walBlocks)+len(p.completeBlocks))
-	if p.headBlock != nil {
-		blocks = append(blocks, p.headBlock)
-	}
-	for _, b := range p.walBlocks {
-		blocks = append(blocks, b)
-	}
-	for _, b := range p.completeBlocks {
-		blocks = append(blocks, b)
-	}
-	if len(blocks) == 0 {
-		return nil, nil
-	}
-
-	expr, err := traceql.Parse(req.Query)
-	if err != nil {
-		return nil, fmt.Errorf("compiling query: %w", err)
-	}
-
-	unsafe := p.overrides.UnsafeQueryHints(p.tenant)
-
-	timeOverlapCutoff := p.Cfg.Metrics.TimeOverlapCutoff
-	if v, ok := expr.Hints.GetFloat(traceql.HintTimeOverlapCutoff, unsafe); ok && v >= 0 && v <= 1.0 {
-		timeOverlapCutoff = v
-	}
-
-	concurrency := p.Cfg.Metrics.ConcurrentBlocks
-	if v, ok := expr.Hints.GetInt(traceql.HintConcurrentBlocks, unsafe); ok && v > 0 && v < 100 {
-		concurrency = uint(v)
-	}
-
-	// Compile the sharded version of the query
-	eval, err := traceql.NewEngine().CompileMetricsQueryRange(req, false, timeOverlapCutoff, unsafe)
-	if err != nil {
-		return nil, err
-	}
-
-	var (
-		wg     = boundedwaitgroup.New(concurrency)
-		jobErr = atomic.Error{}
-	)
-
-	for _, b := range blocks {
-		// If a job errored then quit immediately.
-		if err := jobErr.Load(); err != nil {
-			return nil, err
-		}
-
-		start := uint64(b.BlockMeta().StartTime.UnixNano())
-		end := uint64(b.BlockMeta().EndTime.UnixNano())
-		if start > req.End || end < req.Start {
-			// Out of time range
-			continue
-		}
-
-		wg.Add(1)
-		go func(b common.BackendBlock) {
-			defer wg.Done()
-
-			m := b.BlockMeta()
-
-			span, ctx := opentracing.StartSpanFromContext(ctx, "Processor.QueryRange.Block", opentracing.Tags{
-				"block":     m.BlockID,
-				"blockSize": m.Size,
-			})
-			defer span.Finish()
-
-			// TODO - caching
-			f := traceql.NewSpansetFetcherWrapper(func(ctx context.Context, req traceql.FetchSpansRequest) (traceql.FetchSpansResponse, error) {
-				return b.Fetch(ctx, req, common.DefaultSearchOptions())
-			})
-
-			err := eval.Do(ctx, f, uint64(m.StartTime.UnixNano()), uint64(m.EndTime.UnixNano()))
-			if err != nil {
-				jobErr.Store(err)
-			}
-		}(b)
-	}
-
-	wg.Wait()
-
-	if err := jobErr.Load(); err != nil {
-		return nil, err
-	}
-
-	return eval.Results(), nil
 }
 
 func (p *Processor) metricsCacheGet(key string) *traceqlmetrics.MetricsResults {

--- a/modules/generator/processor/localblocks/query_range.go
+++ b/modules/generator/processor/localblocks/query_range.go
@@ -1,0 +1,285 @@
+package localblocks
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"sync"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/grafana/tempo/modules/ingester"
+	"github.com/grafana/tempo/pkg/boundedwaitgroup"
+	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/grafana/tempo/pkg/traceql"
+	"github.com/grafana/tempo/tempodb/backend"
+	"github.com/grafana/tempo/tempodb/encoding/common"
+	"github.com/opentracing/opentracing-go"
+	"go.uber.org/atomic"
+)
+
+// QueryRange returns metrics.
+func (p *Processor) QueryRange(ctx context.Context, req *tempopb.QueryRangeRequest) (traceql.SeriesSet, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	p.blocksMtx.RLock()
+	defer p.blocksMtx.RUnlock()
+
+	cutoff := time.Now().Add(-p.Cfg.CompleteBlockTimeout).Add(-timeBuffer)
+	if req.Start < uint64(cutoff.UnixNano()) {
+		return nil, fmt.Errorf("time range must be within last %v", p.Cfg.CompleteBlockTimeout)
+	}
+
+	expr, err := traceql.Parse(req.Query)
+	if err != nil {
+		return nil, fmt.Errorf("compiling query: %w", err)
+	}
+
+	unsafe := p.overrides.UnsafeQueryHints(p.tenant)
+
+	timeOverlapCutoff := p.Cfg.Metrics.TimeOverlapCutoff
+	if v, ok := expr.Hints.GetFloat(traceql.HintTimeOverlapCutoff, unsafe); ok && v >= 0 && v <= 1.0 {
+		timeOverlapCutoff = v
+	}
+
+	concurrency := p.Cfg.Metrics.ConcurrentBlocks
+	if v, ok := expr.Hints.GetInt(traceql.HintConcurrentBlocks, unsafe); ok && v > 0 && v < 100 {
+		concurrency = uint(v)
+	}
+
+	e := traceql.NewEngine()
+
+	// Compile the raw version of the query for wal blocks
+	// These aren't cached and we put them all into the same evaluator
+	// for efficiency.
+	eval, err := e.CompileMetricsQueryRange(req, false, timeOverlapCutoff, unsafe)
+	if err != nil {
+		return nil, err
+	}
+
+	// This is a summation version of the query for complete blocks
+	// which can be cached. But we need their results separately so they are
+	// computed separately.
+	overallEvalMtx := sync.Mutex{}
+	overallEval, err := traceql.NewEngine().CompileMetricsQueryRangeNonRaw(req, traceql.AggregateModeSum)
+	if err != nil {
+		return nil, err
+	}
+
+	withinRange := func(m *backend.BlockMeta) bool {
+		start := uint64(m.StartTime.UnixNano())
+		end := uint64(m.EndTime.UnixNano())
+		return req.Start < end && req.End > start
+	}
+
+	var (
+		wg     = boundedwaitgroup.New(concurrency)
+		jobErr = atomic.Error{}
+	)
+
+	if p.headBlock != nil && withinRange(p.headBlock.BlockMeta()) {
+		wg.Add(1)
+		go func(w common.WALBlock) {
+			defer wg.Done()
+			err := p.queryRangeWALBlock(ctx, w, eval)
+			if err != nil {
+				jobErr.Store(err)
+			}
+		}(p.headBlock)
+	}
+
+	for _, w := range p.walBlocks {
+		if jobErr.Load() != nil {
+			break
+		}
+
+		if !withinRange(w.BlockMeta()) {
+			continue
+		}
+
+		wg.Add(1)
+		go func(w common.WALBlock) {
+			defer wg.Done()
+			err := p.queryRangeWALBlock(ctx, w, eval)
+			if err != nil {
+				jobErr.Store(err)
+			}
+		}(w)
+	}
+
+	for _, b := range p.completeBlocks {
+		if jobErr.Load() != nil {
+			break
+		}
+
+		if !withinRange(b.BlockMeta()) {
+			continue
+		}
+
+		wg.Add(1)
+		go func(b *ingester.LocalBlock) {
+			defer wg.Done()
+			resp, err := p.queryRangeCompleteBlock(ctx, b, *req, timeOverlapCutoff, unsafe)
+			if err != nil {
+				jobErr.Store(err)
+				return
+			}
+
+			overallEvalMtx.Lock()
+			defer overallEvalMtx.Unlock()
+			overallEval.ObserveSeries(resp)
+		}(b)
+	}
+
+	wg.Wait()
+
+	if err := jobErr.Load(); err != nil {
+		return nil, err
+	}
+
+	// Combine the uncacheable results into the overall results
+	walResults := eval.Results().ToProto(req)
+	overallEval.ObserveSeries(walResults)
+
+	return overallEval.Results(), nil
+}
+
+func (p *Processor) queryRangeWALBlock(ctx context.Context, b common.WALBlock, eval *traceql.MetricsEvalulator) error {
+	m := b.BlockMeta()
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Processor.QueryRange.WALBlock", opentracing.Tags{
+		"block":     m.BlockID,
+		"blockSize": m.Size,
+	})
+	defer span.Finish()
+
+	fetcher := traceql.NewSpansetFetcherWrapper(func(ctx context.Context, req traceql.FetchSpansRequest) (traceql.FetchSpansResponse, error) {
+		return b.Fetch(ctx, req, common.DefaultSearchOptions())
+	})
+
+	return eval.Do(ctx, fetcher, uint64(m.StartTime.UnixNano()), uint64(m.EndTime.UnixNano()))
+}
+
+func (p *Processor) queryRangeCompleteBlock(ctx context.Context, b *ingester.LocalBlock, req tempopb.QueryRangeRequest, timeOverlapCutoff float64, unsafe bool) ([]*tempopb.TimeSeries, error) {
+	m := b.BlockMeta()
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Processor.QueryRange.CompleteBlock", opentracing.Tags{
+		"block":     m.BlockID,
+		"blockSize": m.Size,
+	})
+	defer span.Finish()
+
+	fmt.Println("Before:", m.BlockID, time.Unix(0, int64(req.Start)), time.Unix(0, int64(req.End)))
+	fmt.Println("Block:", m.BlockID, m.StartTime, m.EndTime)
+
+	// Trim and align the request for this block. I.e. if the request is "Last Hour" we don't want to
+	// cache the response for that, we want only the few minutes time range for this block. This has
+	// size savings but the main thing is that the response is reuseable for any overlapping query.
+	// TODO - This buffer time is needed to close gaps between block meta time and actual
+	// span contents
+	blockStart := m.StartTime.Add(-time.Minute)
+	blockEnd := m.EndTime.Add(time.Minute)
+
+	req.Start = max(uint64(blockStart.UnixNano()), req.Start)
+	req.End = min(uint64(blockEnd.UnixNano()), req.End)
+	req.Start = (req.Start / req.Step) * req.Step
+	req.End = (req.End/req.Step)*req.Step + req.Step
+
+	fmt.Println("After:", m.BlockID, time.Unix(0, int64(req.Start)), time.Unix(0, int64(req.End)))
+
+	cached, name, err := p.queryRangeCacheGet(ctx, m, req)
+	if err != nil {
+		return nil, err
+	}
+
+	span.SetTag("cached", cached != nil)
+
+	if cached != nil {
+		return cached.Series, nil
+	}
+
+	// Not in cache or not cacheable, so execute
+	eval, err := traceql.NewEngine().CompileMetricsQueryRange(&req, false, timeOverlapCutoff, unsafe)
+	if err != nil {
+		return nil, err
+	}
+	f := traceql.NewSpansetFetcherWrapper(func(ctx context.Context, req traceql.FetchSpansRequest) (traceql.FetchSpansResponse, error) {
+		return b.Fetch(ctx, req, common.DefaultSearchOptions())
+	})
+	err = eval.Do(ctx, f, uint64(m.StartTime.UnixNano()), uint64(m.EndTime.UnixNano()))
+	if err != nil {
+		return nil, err
+	}
+
+	results := eval.Results().ToProto(&req)
+
+	if name != "" {
+		err = p.queryRangeCacheSet(ctx, m, name, &tempopb.QueryRangeResponse{
+			Series: results,
+		})
+	}
+
+	return results, nil
+}
+
+func (p *Processor) queryRangeCacheGet(ctx context.Context, m *backend.BlockMeta, req tempopb.QueryRangeRequest) (*tempopb.QueryRangeResponse, string, error) {
+	cacheable := req.Start <= uint64(m.StartTime.UnixNano()) && req.End >= uint64(m.EndTime.UnixNano())
+	if !cacheable {
+		return nil, "", nil
+	}
+
+	hash := queryRangeHashForBlock(req)
+
+	name := fmt.Sprintf("cache_query_range_%v.buf", hash)
+
+	data, err := p.walR.Read(ctx, name, m.BlockID, m.TenantID, nil)
+	if err != nil {
+		if errors.Is(err, backend.ErrDoesNotExist) {
+			// Not cached, but return the name/keypath so it can be set after
+			return nil, name, nil
+		}
+		return nil, "", err
+	}
+
+	resp := &tempopb.QueryRangeResponse{}
+	err = proto.Unmarshal(data, resp)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return resp, name, nil
+}
+
+func (p *Processor) queryRangeCacheSet(ctx context.Context, m *backend.BlockMeta, name string, resp *tempopb.QueryRangeResponse) error {
+	data, err := proto.Marshal(resp)
+	if err != nil {
+		return err
+	}
+
+	return p.walW.Write(ctx, name, m.BlockID, m.TenantID, data, nil)
+}
+
+func queryRangeHashForBlock(req tempopb.QueryRangeRequest) uint64 {
+	h := fnv.New64a()
+	buf := make([]byte, 8)
+
+	h.Write([]byte(req.Query))
+
+	binary.BigEndian.PutUint64(buf, req.Step)
+	h.Write(buf)
+
+	binary.BigEndian.PutUint64(buf, req.Start)
+	h.Write(buf)
+
+	binary.BigEndian.PutUint64(buf, req.End)
+	h.Write(buf)
+
+	// TODO - caching for WAL blocks
+	// Including trace count means we can safely cache results
+	// for wal blocks which might receive new data
+	// binary.BigEndian.PutUint64(buf, uint64(m.TotalObjects))
+	// h.Write(buf)
+
+	return h.Sum64()
+}

--- a/modules/generator/processor/localblocks/query_range.go
+++ b/modules/generator/processor/localblocks/query_range.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/gogo/protobuf/proto"
 	"github.com/grafana/tempo/modules/ingester"
 	"github.com/grafana/tempo/pkg/boundedwaitgroup"
 	"github.com/grafana/tempo/pkg/tempopb"
@@ -210,6 +210,9 @@ func (p *Processor) queryRangeCompleteBlock(ctx context.Context, b *ingester.Loc
 		err = p.queryRangeCacheSet(ctx, m, name, &tempopb.QueryRangeResponse{
 			Series: results,
 		})
+		if err != nil {
+			return nil, fmt.Errorf("writing local query cache: %w", err)
+		}
 	}
 
 	return results, nil

--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -70,6 +70,15 @@ func IntervalOfMs(tsmills int64, start, end, step uint64) int {
 	return IntervalOf(ts, start, end, step)
 }
 
+// TrimToOverlap returns the aligned overlap between the two given time ranges.
+func TrimToOverlap(start1, end1, step, start2, end2 uint64) (uint64, uint64) {
+	start1 = max(start1, start2)
+	end1 = min(end1, end2)
+	start1 = (start1 / step) * step
+	end1 = (end1/step)*step + step
+	return start1, end1
+}
+
 type Label struct {
 	Name  string
 	Value Static


### PR DESCRIPTION
**What this PR does**:
Generators service metrics queries against recent data, which is done frequently and sensitive to user-facing performance. This adds a cache of query responses for local completed blocks which is typically the last 5-20 minutes.

The generators already have a similar cache for the metrics summary api, but this takes a different approach. Whereas the summary api cache is in-memory, this is disk-based and writes new caching files to the block folder. These files are unique to each request (query + params), and exist for the lifetime of the block.  They aren't flushed to object storage, and they get automatically cleaned up when the block is deleted.  (Note - this has precedent in the `flushed` file that is written to block folders to track their flushed status) Reasons to avoid the in-memory cache is that generators are already usually memory-intensive, and the cache is often inadequate as-is. Example block contents:

```
pwd = /tempo/generator/traces/single-tenant/blocks/single-tenant/
  65beeff3-d9c5-49c1-b69e-8c7b022024f3/bloom-0
  65beeff3-d9c5-49c1-b69e-8c7b022024f3/cache_query_range_14197044629227963207.buf
  65beeff3-d9c5-49c1-b69e-8c7b022024f3/cache_query_range_18089096181261108941.buf
  65beeff3-d9c5-49c1-b69e-8c7b022024f3/cache_query_range_433499706678913880.buf
  65beeff3-d9c5-49c1-b69e-8c7b022024f3/cache_query_range_4989462974766826143.buf
  65beeff3-d9c5-49c1-b69e-8c7b022024f3/data.parquet
  65beeff3-d9c5-49c1-b69e-8c7b022024f3/flushed
  65beeff3-d9c5-49c1-b69e-8c7b022024f3/index
  65beeff3-d9c5-49c1-b69e-8c7b022024f3/meta.json
```

There are additional changes in this PR which proved necessary:

* Generator RF1 block meta times weren't right. They always flushed traces with the timestamp of "now" so the metas were off by roughly trace_idle_period + trace_flush_period. This fixes it to flush proper times.
* As part of that, it also requires that the generator traces WAL has a real ingestion_slack time. This fixes the default to match ingesters of 2 minutes. NOTE - This is different than the slack time for metrics.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`