### PR TITLE
Bugfix: Improved handling of complete blocks in localblocks processor after enabling flushing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [BUGFIX] Fix frontend parsing error on cached responses [#3759](https://github.com/grafana/tempo/pull/3759) (@mdisibio)
 * [BUGFIX] max_global_traces_per_user: take into account ingestion.tenant_shard_size when converting to local limit [#3618](https://github.com/grafana/tempo/pull/3618) (@kvrhdn)
 * [BUGFIX] Fix http connection reuse on GCP and AWS by reading io.EOF through the http body. [#3760](https://github.com/grafana/tempo/pull/3760) (@bmteller)
+* [BUGFIX] Improved handling of old blocks in localblocks processor after enabling flusing [#3805](https://github.com/grafana/tempo/pull/3805) (@mapno)
 
 ## v2.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * [BUGFIX] Fix frontend parsing error on cached responses [#3759](https://github.com/grafana/tempo/pull/3759) (@mdisibio)
 * [BUGFIX] max_global_traces_per_user: take into account ingestion.tenant_shard_size when converting to local limit [#3618](https://github.com/grafana/tempo/pull/3618) (@kvrhdn)
 * [BUGFIX] Fix http connection reuse on GCP and AWS by reading io.EOF through the http body. [#3760](https://github.com/grafana/tempo/pull/3760) (@bmteller)
-* [BUGFIX] Improved handling of old blocks in localblocks processor after enabling flusing [#3805](https://github.com/grafana/tempo/pull/3805) (@mapno)
+* [BUGFIX] Improved handling of complete blocks in localblocks processor after enabling flusing [#3805](https://github.com/grafana/tempo/pull/3805) (@mapno)
 
 ## v2.5.0
 

--- a/modules/generator/processor/localblocks/processor.go
+++ b/modules/generator/processor/localblocks/processor.go
@@ -573,17 +573,6 @@ func (p *Processor) deleteOldBlocks() (err error) {
 	return
 }
 
-func (p *Processor) deleteCompleteBlock(id uuid.UUID) error {
-	level.Info(p.logger).Log("msg", "deleting complete block", "block", id.String())
-	err := p.wal.LocalBackend().ClearBlock(id, p.tenant)
-	if err != nil {
-		return err
-	}
-
-	delete(p.completeBlocks, id)
-	return nil
-}
-
 func (p *Processor) cutIdleTraces(immediate bool) error {
 	p.liveTracesMtx.Lock()
 

--- a/modules/generator/processor/localblocks/processor.go
+++ b/modules/generator/processor/localblocks/processor.go
@@ -547,20 +547,10 @@ func (p *Processor) deleteOldBlocks() (err error) {
 
 		flushedTime := b.FlushedTime()
 		if flushedTime.IsZero() {
-
-			if b.BlockMeta().EndTime.Before(cuttoff) { // Not flushed and old
-				level.Info(p.logger).Log("msg", "deleting complete block", "block", id.String())
-				err = p.wal.LocalBackend().ClearBlock(id, p.tenant)
-				if err != nil {
-					return err
-				}
-				delete(p.completeBlocks, id)
-			}
-
 			continue
 		}
 
-		if flushedTime.Before(cuttoff) {
+		if b.BlockMeta().EndTime.Before(cuttoff) {
 			level.Info(p.logger).Log("msg", "deleting flushed complete block", "block", id.String())
 			err = p.wal.LocalBackend().ClearBlock(id, p.tenant)
 			if err != nil {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This fix addresses an issue where complete blocks were not being properly processed in the `localblocks` processor. Before, complete blocks were kept for longer than necessary. This was a problem specially when enabling flushing to storage for the first time.

The condition for deleting complete blocks has been changed to be based on block end time. If the block has been flushed and it's past it the cutoff time, it's deleted.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`