### PR TITLE
make vparquet4 the default block encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [CHANGE] Bump opentelemetry-collector to 0.102.1 [#3784](https://github.com/grafana/tempo/pull/3784) (@debasishbsws)
 * [CHANGE] Bump Jaeger query docker image to 1.57.0 [#3652](https://github.com/grafana/tempo/issues/3652) (@iblancasa)
 * [CHANGE] Update Go to 1.22.4 [#3757](https://github.com/grafana/tempo/pull/3757) [#3793](https://github.com/grafana/tempo/pull/3793) (@joe-elliott, @mapno)
+* [CHANGE] Make vParquet4 the default block encoding [#3810](https://github.com/grafana/tempo/pull/3810) (@ie-pham)
 * [FEATURE] TraceQL support for link scope and link:traceID and link:spanID [#3741](https://github.com/grafana/tempo/pull/3741) (@stoewer)
 * [FEATURE] TraceQL support for event scope and event:name intrinsic [#3708](https://github.com/grafana/tempo/pull/3708) (@stoewer)
 * [FEATURE] Flush and query RF1 blocks for TraceQL metric queries [#3628](https://github.com/grafana/tempo/pull/3628) [#3691](https://github.com/grafana/tempo/pull/3691) [#3723](https://github.com/grafana/tempo/pull/3723) (@mapno)

--- a/cmd/tempo/app/config_test.go
+++ b/cmd/tempo/app/config_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 	v2 "github.com/grafana/tempo/tempodb/encoding/v2"
-	"github.com/grafana/tempo/tempodb/encoding/vparquet3"
+	"github.com/grafana/tempo/tempodb/encoding/vparquet4"
 )
 
 func TestConfig_CheckConfig(t *testing.T) {
@@ -81,7 +81,7 @@ func TestConfig_CheckConfig(t *testing.T) {
 			name: "warnings for v2 settings when they drift from default",
 			config: func() *Config {
 				cfg := newDefaultConfig()
-				cfg.StorageConfig.Trace.Block.Version = vparquet3.VersionString
+				cfg.StorageConfig.Trace.Block.Version = vparquet4.VersionString
 				cfg.StorageConfig.Trace.Block.IndexDownsampleBytes = 1
 				cfg.StorageConfig.Trace.Block.IndexPageSizeBytes = 1
 				cfg.Compactor.Compactor.ChunkSizeBytes = 1

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -1119,7 +1119,7 @@ storage:
         # block configuration
         block:
             # block format version. options: v2, vParquet2, vParquet3, vParquet4
-            [version: <string> | default = vParquet3]
+            [version: <string> | default = vParquet4]
 
             # bloom filter false positive rate. lower values create larger filters but fewer false positives
             [bloom_filter_false_positive: <float> | default = 0.01]

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -535,7 +535,7 @@ metrics_generator:
             block:
                 bloom_filter_false_positive: 0.01
                 bloom_filter_shard_size_bytes: 102400
-                version: vParquet3
+                version: vParquet4
                 search_encoding: snappy
                 search_page_size_bytes: 1048576
                 v2_index_downsample_bytes: 1048576
@@ -586,7 +586,7 @@ metrics_generator:
         v2_encoding: none
         search_encoding: none
         ingestion_time_range_slack: 0s
-        version: vParquet3
+        version: vParquet4
     metrics_ingestion_time_range_slack: 30s
     query_timeout: 30s
     override_ring_key: metrics-generator
@@ -602,11 +602,11 @@ storage:
             v2_encoding: snappy
             search_encoding: none
             ingestion_time_range_slack: 2m0s
-            version: vParquet3
+            version: vParquet4
         block:
             bloom_filter_false_positive: 0.01
             bloom_filter_shard_size_bytes: 102400
-            version: vParquet3
+            version: vParquet4
             search_encoding: snappy
             search_page_size_bytes: 1048576
             v2_index_downsample_bytes: 1048576

--- a/docs/sources/tempo/configuration/parquet.md
+++ b/docs/sources/tempo/configuration/parquet.md
@@ -23,13 +23,13 @@ Block formats based on Parquet require more CPU and memory resources than the pr
 
 ## Choose a different block format
 
-The default block format is `vParquet3`, which is the latest iteration of the Parquet-based columnar block format in Tempo.
+The default block format is `vParquet4`, which is the latest iteration of the Parquet-based columnar block format in Tempo.
 It introduces dedicated attribute columns, which improve query performance by storing attributes in own columns,
 rather than in the generic attribute key-value list.
 For more information, see [Dedicated attribute columns]({{< relref "../operations/tempo_cli" >}}).
 
-You can also use the latest more experimental version `vParquet4`.
-To enable it, set the block version option to `vParquet4` in the Storage section of the configuration file.
+You can still use the previous format `vParquet3`.
+To enable it, set the block version option to `vParquet3` in the Storage section of the configuration file.
 
 ```yaml
 # block format version. options: v2, vParquet2, vParquet3, vParquet4

--- a/tempodb/config_test.go
+++ b/tempodb/config_test.go
@@ -145,7 +145,7 @@ func TestDeprecatedVersions(t *testing.T) {
 					IndexPageSizeBytes:   1,
 					BloomFP:              0.01,
 					BloomShardSizeBytes:  1,
-					Version:              "vParquet3",
+					Version:              "vParquet4",
 				},
 			},
 			expectedConfig: &Config{
@@ -157,7 +157,7 @@ func TestDeprecatedVersions(t *testing.T) {
 					IndexPageSizeBytes:   1,
 					BloomFP:              0.01,
 					BloomShardSizeBytes:  1,
-					Version:              "vParquet3",
+					Version:              "vParquet4",
 				},
 			},
 		},

--- a/tempodb/encoding/versioned.go
+++ b/tempodb/encoding/versioned.go
@@ -79,7 +79,7 @@ func FromVersion(v string) (VersionedEncoding, error) {
 
 // DefaultEncoding for newly written blocks.
 func DefaultEncoding() VersionedEncoding {
-	return vparquet3.Encoding{}
+	return vparquet4.Encoding{}
 }
 
 // LatestEncoding returns the most recent encoding.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: Make vParquet4 the default block encoding

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`