### PR TITLE
[DOC] Fix distributor.log_received_spans.enabled in unable-to-see-trace.md

### DIFF
--- a/docs/sources/tempo/troubleshooting/unable-to-see-trace.md
+++ b/docs/sources/tempo/troubleshooting/unable-to-see-trace.md
@@ -18,7 +18,7 @@ The two main causes of missing traces are:
 
 The first step is to check whether the application spans are actually reaching Tempo.
 
-Add the following flag to the distributor container - [`distributor.log-received-spans.enabled`](https://github.com/grafana/tempo/blob/57da4f3fd5d2966e13a39d27dbed4342af6a857a/modules/distributor/config.go#L55).
+Add the following flag to the distributor container - [`distributor.log_received_spans.enabled`](https://github.com/grafana/tempo/blob/57da4f3fd5d2966e13a39d27dbed4342af6a857a/modules/distributor/config.go#L55).
 
 This flag enables debug logging of all the traces received by the distributor. These logs can help check if Tempo is receiving any traces at all.
 


### PR DESCRIPTION
Applying a fix from [another PR](https://github.com/grafana/tempo/pull/3767).

CTA remains unsigned from the other PR, but it's a fix that we need. 

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`