### PR TITLE
feat: added new helper function to allow debugging e2e tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,13 @@
 * [ENHANCEMENT] Added a boolean flag to enable or disable dualstack mode on Storage block config for S3 [#3721](https://github.com/grafana/tempo/pull/3721) (@sid-jar, @mapno)
 * [ENHANCEMENT] Add caching to query range queries [#3796](https://github.com/grafana/tempo/pull/3796) (@mapno)
 * [ENHANCEMENT] Add data quality metric to measure traces without a root [#3812](https://github.com/grafana/tempo/pull/3812) (@mapno)
+* [ENHANCEMENT] Add a new helper method to allow debugging e2e tests
 * [BUGFIX] Fix metrics queries when grouping by attributes that may not exist [#3734](https://github.com/grafana/tempo/pull/3734) (@mdisibio)
 * [BUGFIX] Fix frontend parsing error on cached responses [#3759](https://github.com/grafana/tempo/pull/3759) (@mdisibio)
 * [BUGFIX] max_global_traces_per_user: take into account ingestion.tenant_shard_size when converting to local limit [#3618](https://github.com/grafana/tempo/pull/3618) (@kvrhdn)
 * [BUGFIX] Fix http connection reuse on GCP and AWS by reading io.EOF through the http body. [#3760](https://github.com/grafana/tempo/pull/3760) (@bmteller)
 * [BUGFIX] Improved handling of complete blocks in localblocks processor after enabling flusing [#3805](https://github.com/grafana/tempo/pull/3805) (@mapno)
-* [ENHANCEMENT] Add a new helper method to allow debugging e2e tests
+
 
 ## v2.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * [ENHANCEMENT] Added a boolean flag to enable or disable dualstack mode on Storage block config for S3 [#3721](https://github.com/grafana/tempo/pull/3721) (@sid-jar, @mapno)
 * [ENHANCEMENT] Add caching to query range queries [#3796](https://github.com/grafana/tempo/pull/3796) (@mapno)
 * [ENHANCEMENT] Add data quality metric to measure traces without a root [#3812](https://github.com/grafana/tempo/pull/3812) (@mapno)
-* [ENHANCEMENT] Add a new helper method to allow debugging e2e tests
+* [ENHANCEMENT] Add a new helper method to allow debugging e2e tests [#3836](https://github.com/grafana/tempo/pull/3836) (@javiermolinar)
 * [BUGFIX] Fix metrics queries when grouping by attributes that may not exist [#3734](https://github.com/grafana/tempo/pull/3734) (@mdisibio)
 * [BUGFIX] Fix frontend parsing error on cached responses [#3759](https://github.com/grafana/tempo/pull/3759) (@mdisibio)
 * [BUGFIX] max_global_traces_per_user: take into account ingestion.tenant_shard_size when converting to local limit [#3618](https://github.com/grafana/tempo/pull/3618) (@kvrhdn)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [BUGFIX] max_global_traces_per_user: take into account ingestion.tenant_shard_size when converting to local limit [#3618](https://github.com/grafana/tempo/pull/3618) (@kvrhdn)
 * [BUGFIX] Fix http connection reuse on GCP and AWS by reading io.EOF through the http body. [#3760](https://github.com/grafana/tempo/pull/3760) (@bmteller)
 * [BUGFIX] Improved handling of complete blocks in localblocks processor after enabling flusing [#3805](https://github.com/grafana/tempo/pull/3805) (@mapno)
+* [ENHANCEMENT] Add a new helper method to allow debugging e2e tests
 
 ## v2.5.0
 

--- a/integration/e2e/README.md
+++ b/integration/e2e/README.md
@@ -1,9 +1,9 @@
-To run the integration tests, use the following commands
+**Running the integration tests**
 
 
 `-count=1` is passed to disable cache during test runs.
 
-```
+```sh
 # build latest image
 make docker-tempo
 make docker-tempo-query
@@ -23,3 +23,20 @@ go test -timeout 3m -count=1 -v ./integration/e2e/... -run ^TestMultiTenantSearc
 # follow and watch logs while tests are running (assuming e2e test container is named tempo_e2e-tempo)
 docker logs $(docker container ls -f name=tempo_e2e-tempo -q) -f
 ```
+
+**How to debug Tempo while running an integration test**
+
+1. Build latest debug image
+```sh
+    make docker-tempo-debug
+```
+2. Use the function ``NewTempoAllInOneDebug`` in your test to spin a Tempo instance with debug capabilities
+3. Set a breakpoint after ``require.NoError(t, s.StartAndWaitReady(tempo))`` and before the action you want debug
+4. Get the port of Delve debugger inside the container
+```sh
+    docker ps --format '{{.Ports}}'  
+    # 0.0.0.0:53467->2345
+```
+5. Run the debugger against that port as is specified [here](https://github.com/grafana/tempo/tree/main/example/docker-compose/debug)
+ 
+

--- a/integration/util.go
+++ b/integration/util.go
@@ -69,7 +69,7 @@ func NewTempoAllInOne(extraArgs ...string) *e2e.HTTPService {
 	return NewTempoAllInOneWithReadinessProbe(e2e.NewHTTPReadinessProbe(3200, "/ready", 200, 299), extraArgs...)
 }
 
-func NewTempoAllInOnDebug(extraArgs ...string) *e2e.HTTPService {
+func NewTempoAllInOneDebug(extraArgs ...string) *e2e.HTTPService {
 	rp := e2e.NewHTTPReadinessProbe(3200, "/ready", 200, 299)
 	args := []string{"-config.file=" + filepath.Join(e2e.ContainerSharedDir, "config.yaml")}
 	args = buildArgsWithExtra(args, extraArgs)

--- a/integration/util.go
+++ b/integration/util.go
@@ -39,6 +39,7 @@ import (
 
 const (
 	image      = "tempo:latest"
+	debugImage = "tempo-debug:latest"
 	queryImage = "tempo-query:latest"
 )
 
@@ -66,6 +67,34 @@ func buildArgsWithExtra(args, extraArgs []string) []string {
 
 func NewTempoAllInOne(extraArgs ...string) *e2e.HTTPService {
 	return NewTempoAllInOneWithReadinessProbe(e2e.NewHTTPReadinessProbe(3200, "/ready", 200, 299), extraArgs...)
+}
+
+func NewTempoAllInOnDebug(extraArgs ...string) *e2e.HTTPService {
+	rp := e2e.NewHTTPReadinessProbe(3200, "/ready", 200, 299)
+	args := []string{"-config.file=" + filepath.Join(e2e.ContainerSharedDir, "config.yaml")}
+	args = buildArgsWithExtra(args, extraArgs)
+
+	s := e2e.NewHTTPService(
+		"tempo",
+		debugImage,
+		e2e.NewCommand("", args...),
+		rp,
+		3200,  // http all things
+		3201,  // http all things
+		9095,  // grpc tempo
+		14250, // jaeger grpc ingest
+		9411,  // zipkin ingest (used by load)
+		4317,  // otlp grpc
+		4318,  // OTLP HTTP
+		2345,  // delve port
+	)
+	env := map[string]string{
+		"DEBUG_BLOCK": "0",
+	}
+	s.SetEnvVars(env)
+
+	s.SetBackoff(TempoBackoff())
+	return s
 }
 
 func NewTempoAllInOneWithReadinessProbe(rp e2e.ReadinessProbe, extraArgs ...string) *e2e.HTTPService {


### PR DESCRIPTION
**What this PR does**:

It can be handy to debug Tempo code when running an e2e test. This can be done in different ways. This PR aims to ease this task by providing a new function to spin a Tempo docker container based on the tempo-debug image, without modifying any aspect of the test so it can be run in the same way either locally or in the CI.

**Limitations**:
I haven't found a way to expose the docker host port locally ie: -p 2345:2345. 
This could be enhanced to allow that:

https://github.com/grafana/e2e/blob/db90b84177fccb4f023ea9f71ec0e8dcd2d3bdad/service.go#L328


**How to use it**:
The debug process is a bit cumbersome right now:
1. In our e2e test use the new function ``NewTempoAllInOnDebug`` to spin the debug container 
2. Set a breakpoint before the action we want to test
3. Start debugging the tests and wait till the breakpoint 
4. Get the docker container endpoint, this can be done by running this:
```
docker ps --format '{{.Ports}}'  
0.0.0.0:53467->2345
```
5. From a different instance of the IDE or directly from the console
```
 dlv connect localhost:53467
```

**Checklist**
- [X ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`