### PR TITLE
Avoid panic by cheking whether entry is a span in batchCollector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [ENHANCEMENT] Add caching to query range queries [#3796](https://github.com/grafana/tempo/pull/3796) (@mapno)
 * [ENHANCEMENT] Add data quality metric to measure traces without a root [#3812](https://github.com/grafana/tempo/pull/3812) (@mapno)
 * [ENHANCEMENT] Add a new helper method to allow debugging e2e tests [#3836](https://github.com/grafana/tempo/pull/3836) (@javiermolinar)
+* [BUGFIX] Fix panic in certain metrics queries using `rate()` with `by` [#3847](https://github.com/grafana/tempo/pull/3847) (@stoewer)
 * [BUGFIX] Fix metrics queries when grouping by attributes that may not exist [#3734](https://github.com/grafana/tempo/pull/3734) (@mdisibio)
 * [BUGFIX] Fix frontend parsing error on cached responses [#3759](https://github.com/grafana/tempo/pull/3759) (@mdisibio)
 * [BUGFIX] max_global_traces_per_user: take into account ingestion.tenant_shard_size when converting to local limit [#3618](https://github.com/grafana/tempo/pull/3618) (@kvrhdn)

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -2704,7 +2704,10 @@ func (c *batchCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 	// Second pass. Update and further filter the spans
 	spans = res.OtherEntries[:0]
 	for _, e := range res.OtherEntries {
-		span := e.Value.(*span)
+		span, ok := e.Value.(*span)
+		if !ok {
+			continue
+		}
 
 		// Copy resource-level attributes to the span
 		// If the span already has an entry for this attribute it


### PR DESCRIPTION
**What this PR does**:
It was observed that queries such as `{} | rate() by (event.name)` can cause panics in the `batchCollector`. Here is a stack trace taken from the logs:

```
2024-07-04 14:01:01.425	
github.com/grafana/tempo/pkg/traceql.(*MetricsEvalulator).Do(0xc0bd65db00, {0x3305e18, 0xc08a0a7440}, {0x32e1c60?, 0xc06f4f8cd0?}, 0x0?, 0xc099578f68?)
2024-07-04 14:01:01.425	
	/drone/src/tempodb/encoding/vparquet4/block_traceql.go:1312 +0x1f
2024-07-04 14:01:01.425	
github.com/grafana/tempo/tempodb/encoding/vparquet4.(*spansetIterator).Next(0xc097d151e0?, {0x3324f20?, 0xc08e5dad20?})
2024-07-04 14:01:01.425	
	/drone/src/tempodb/encoding/vparquet4/block_traceql.go:1198 +0x11f
2024-07-04 14:01:01.425	
github.com/grafana/tempo/tempodb/encoding/vparquet4.(*rebatchIterator).Next(0xc08a0a7f50)
2024-07-04 14:01:01.425	
	/drone/src/pkg/parquetquery/iters.go:1666 +0xa5
2024-07-04 14:01:01.425	
github.com/grafana/tempo/pkg/parquetquery.(*JoinIterator).Next(0xc04e206240)
2024-07-04 14:01:01.425	
	/drone/src/pkg/parquetquery/iters.go:1741 +0x352
2024-07-04 14:01:01.425	
github.com/grafana/tempo/pkg/parquetquery.(*JoinIterator).collect(0xc04e206240, {0xc9, 0x0, 0x0, 0x0, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff})
2024-07-04 14:01:01.425	
	/drone/src/pkg/parquetquery/iters.go:1863 +0xd6
2024-07-04 14:01:01.425	
github.com/grafana/tempo/pkg/parquetquery.(*LeftJoinIterator).Next(0xc0631158c0)
2024-07-04 14:01:01.425	
	/drone/src/tempodb/encoding/vparquet4/block_traceql.go:2707 +0xcb1
2024-07-04 14:01:01.425	
github.com/grafana/tempo/tempodb/encoding/vparquet4.(*batchCollector).KeepGroup(0xc08a0a7ef0, 0xc0c47cc960)
2024-07-04 14:01:01.425	
goroutine 62344 [running]:
2024-07-04 14:01:01.425	

2024-07-04 14:01:01.425	
panic: interface conversion: interface {} is traceql.Static, not *vparquet4.span
```

I wasn't able to reproduce this locally or in tests, but given the above log the missing check when casting to `*span` looks like the most likely culprit.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`