### PR TITLE
feat: refactor Tempo vulture to reduce code complexity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,10 @@
 .idea
 .vscode
 *.test
+*.out
 /bin
 /cmd/tempo-cli/tempo-cli
+/cmd/tempo-vulture/tempo-vulture
 /cmd/tempo-serverless/vendor/
 /dist
 /example/docker-compose/**/gcs-data/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [ENHANCEMENT] Add caching to query range queries [#3796](https://github.com/grafana/tempo/pull/3796) (@mapno)
 * [ENHANCEMENT] Add data quality metric to measure traces without a root [#3812](https://github.com/grafana/tempo/pull/3812) (@mapno)
 * [ENHANCEMENT] Add a new helper method to allow debugging e2e tests [#3836](https://github.com/grafana/tempo/pull/3836) (@javiermolinar)
+* [ENHANCEMENT] Refactor Tempo Vulture [#3849](https://github.com/grafana/tempo/pull/3849) (@javiermolinar)
 * [BUGFIX] Fix panic in certain metrics queries using `rate()` with `by` [#3847](https://github.com/grafana/tempo/pull/3847) (@stoewer)
 * [BUGFIX] Fix metrics queries when grouping by attributes that may not exist [#3734](https://github.com/grafana/tempo/pull/3734) (@mdisibio)
 * [BUGFIX] Fix frontend parsing error on cached responses [#3759](https://github.com/grafana/tempo/pull/3759) (@mdisibio)

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -340,7 +340,7 @@ func newJaegerGRPCClient(endpoint string) (*jaeger_grpc.Reporter, error) {
 	}
 
 	// new jaeger grpc exporter
-	conn, err := grpc.Dial(u.Host+":14250", dialOpts...)
+	conn, err := grpc.NewClient(u.Host+":14250", dialOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -418,12 +418,12 @@ func searchTag(client httpclient.IClient, seed time.Time) (traceMetrics, error) 
 	return tm, nil
 }
 
-func searchTraceql(client httpclient.IClient, seed time.Time, tempoOrgId string) (traceMetrics, error) {
+func searchTraceql(client httpclient.IClient, seed time.Time, tempoOrgID string) (traceMetrics, error) {
 	tm := traceMetrics{
 		requested: 1,
 	}
 
-	info := util.NewTraceInfo(seed, tempoOrgId)
+	info := util.NewTraceInfo(seed, tempoOrgID)
 	hexID := info.HexID()
 
 	// Get the expected

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -131,10 +131,8 @@ func main() {
 	if tickerSearch != nil {
 		doSearchs(httpClient, tickerSearch, startTime, interval, r, vultureConfig, logger)
 	}
-
 	http.Handle(prometheusPath, promhttp.Handler())
 	log.Fatal(http.ListenAndServe(prometheusListenAddress, nil))
-
 }
 
 func initTickers(tempoWriteBackoffDuration time.Duration, tempoReadBackoffDuration time.Duration, tempoSearchBackoffDuration time.Duration) (tickerWrite *time.Ticker, tickerRead *time.Ticker, tickerSearch *time.Ticker, err error) {
@@ -226,7 +224,6 @@ func doReads(client httpclient.IClient, tickerRead *time.Ticker, startTime time.
 // expect the write loop to have fired yet.  Double the duration here to
 // avoid a race.
 func traceIsReady(info *util.TraceInfo, now time.Time, startTime time.Time, config vultureConfiguration) bool {
-
 	if info.Timestamp().Before(startTime.Add(2 * config.tempoWriteBackoffDuration)) {
 		return false
 	}

--- a/cmd/tempo-vulture/main_test.go
+++ b/cmd/tempo-vulture/main_test.go
@@ -189,5 +189,5 @@ func TestDoWrite(t *testing.T) {
 	time.Sleep(time.Second)
 	ticker.Stop()
 
-	require.Greater(t, len(mockJaegerClient.batches_emitted), 0)
+	require.Greater(t, len(mockJaegerClient.batchesEmitted), 0)
 }

--- a/cmd/tempo-vulture/main_test.go
+++ b/cmd/tempo-vulture/main_test.go
@@ -189,5 +189,5 @@ func TestDoWrite(t *testing.T) {
 	time.Sleep(time.Second)
 	ticker.Stop()
 
-	require.Greater(t, len(mockJaegerClient.batches_emited), 0)
+	require.Greater(t, len(mockJaegerClient.batches_emitted), 0)
 }

--- a/cmd/tempo-vulture/mocks.go
+++ b/cmd/tempo-vulture/mocks.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"net/http"
+
+	//nolint:all
+	userconfigurableoverrides "github.com/grafana/tempo/modules/overrides/userconfigurable/client"
+	"github.com/grafana/tempo/pkg/tempopb"
+	thrift "github.com/jaegertracing/jaeger/thrift-gen/jaeger"
+	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
+)
+
+type MockReporter struct {
+	err            error
+	batches_emited []*thrift.Batch
+}
+
+func (r MockReporter) EmitZipkinBatch(_ context.Context, _ []*zipkincore.Span) error {
+	return r.err
+}
+
+func (r *MockReporter) EmitBatch(_ context.Context, b *thrift.Batch) error {
+	r.batches_emited = append(r.batches_emited, b)
+	return r.err
+}
+
+type MockHttpClient struct {
+	err  error
+	resp http.Response
+}
+
+// DeleteOverrides implements httpclient.IClient.
+func (m MockHttpClient) DeleteOverrides(version string) error {
+	panic("unimplemented")
+}
+
+// Do implements httpclient.IClient.
+func (m MockHttpClient) Do(req *http.Request) (*http.Response, error) {
+	return &m.resp, m.err
+}
+
+// GetOverrides implements httpclient.IClient.
+func (m MockHttpClient) GetOverrides() (*userconfigurableoverrides.Limits, string, error) {
+	panic("unimplemented")
+}
+
+// MetricsSummary implements httpclient.IClient.
+func (m MockHttpClient) MetricsSummary(query string, groupBy string, start int64, end int64) (*tempopb.SpanMetricsSummaryResponse, error) {
+	panic("unimplemented")
+}
+
+// PatchOverrides implements httpclient.IClient.
+func (m MockHttpClient) PatchOverrides(limits *userconfigurableoverrides.Limits) (*userconfigurableoverrides.Limits, string, error) {
+	panic("unimplemented")
+}
+
+// QueryTrace implements httpclient.IClient.
+func (m MockHttpClient) QueryTrace(id string) (*tempopb.Trace, error) {
+	panic("unimplemented")
+}
+
+// Search implements httpclient.IClient.
+func (m MockHttpClient) Search(tags string) (*tempopb.SearchResponse, error) {
+	panic("unimplemented")
+}
+
+// SearchTagValues implements httpclient.IClient.
+func (m MockHttpClient) SearchTagValues(key string) (*tempopb.SearchTagValuesResponse, error) {
+	panic("unimplemented")
+}
+
+// SearchTagValuesV2 implements httpclient.IClient.
+func (m MockHttpClient) SearchTagValuesV2(key string, query string) (*tempopb.SearchTagValuesV2Response, error) {
+	panic("unimplemented")
+}
+
+// SearchTagValuesV2WithRange implements httpclient.IClient.
+func (m MockHttpClient) SearchTagValuesV2WithRange(tag string, start int64, end int64) (*tempopb.SearchTagValuesV2Response, error) {
+	panic("unimplemented")
+}
+
+// SearchTags implements httpclient.IClient.
+func (m MockHttpClient) SearchTags() (*tempopb.SearchTagsResponse, error) {
+	panic("unimplemented")
+}
+
+// SearchTagsV2 implements httpclient.IClient.
+func (m MockHttpClient) SearchTagsV2() (*tempopb.SearchTagsV2Response, error) {
+	panic("unimplemented")
+}
+
+// SearchTagsV2WithRange implements httpclient.IClient.
+func (m MockHttpClient) SearchTagsV2WithRange(start int64, end int64) (*tempopb.SearchTagsV2Response, error) {
+	panic("unimplemented")
+}
+
+// SearchTagsWithRange implements httpclient.IClient.
+func (m MockHttpClient) SearchTagsWithRange(start int64, end int64) (*tempopb.SearchTagsResponse, error) {
+	panic("unimplemented")
+}
+
+// SearchTraceQL implements httpclient.IClient.
+func (m MockHttpClient) SearchTraceQL(query string) (*tempopb.SearchResponse, error) {
+	panic("unimplemented")
+}
+
+// SearchTraceQLWithRange implements httpclient.IClient.
+func (m MockHttpClient) SearchTraceQLWithRange(query string, start int64, end int64) (*tempopb.SearchResponse, error) {
+	panic("unimplemented")
+}
+
+// SearchWithRange implements httpclient.IClient.
+func (m MockHttpClient) SearchWithRange(tags string, start int64, end int64) (*tempopb.SearchResponse, error) {
+	panic("unimplemented")
+}
+
+// SetOverrides implements httpclient.IClient.
+func (m MockHttpClient) SetOverrides(limits *userconfigurableoverrides.Limits, version string) (string, error) {
+	panic("unimplemented")
+}
+
+// WithTransport implements httpclient.IClient.
+func (m MockHttpClient) WithTransport(t http.RoundTripper) {
+	panic("unimplemented")
+}

--- a/cmd/tempo-vulture/mocks.go
+++ b/cmd/tempo-vulture/mocks.go
@@ -12,8 +12,8 @@ import (
 )
 
 type MockReporter struct {
-	err             error
-	batches_emitted []*thrift.Batch
+	err            error
+	batchesEmitted []*thrift.Batch
 }
 
 func (r MockReporter) EmitZipkinBatch(_ context.Context, _ []*zipkincore.Span) error {
@@ -21,7 +21,7 @@ func (r MockReporter) EmitZipkinBatch(_ context.Context, _ []*zipkincore.Span) e
 }
 
 func (r *MockReporter) EmitBatch(_ context.Context, b *thrift.Batch) error {
-	r.batches_emitted = append(r.batches_emitted, b)
+	r.batchesEmitted = append(r.batchesEmitted, b)
 	return r.err
 }
 
@@ -30,78 +30,97 @@ type MockHTTPClient struct {
 	resp http.Response
 }
 
+//nolint:all
 func (m MockHTTPClient) DeleteOverrides(version string) error {
 	panic("unimplemented")
 }
 
+//nolint:all
 func (m MockHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	return &m.resp, m.err
 }
 
+//nolint:all
 func (m MockHTTPClient) GetOverrides() (*userconfigurableoverrides.Limits, string, error) {
 	panic("unimplemented")
 }
 
+//nolint:all
 func (m MockHTTPClient) MetricsSummary(query string, groupBy string, start int64, end int64) (*tempopb.SpanMetricsSummaryResponse, error) {
 	panic("unimplemented")
 }
 
+//nolint:all
 func (m MockHTTPClient) PatchOverrides(limits *userconfigurableoverrides.Limits) (*userconfigurableoverrides.Limits, string, error) {
 	panic("unimplemented")
 }
 
+//nolint:all
 func (m MockHTTPClient) QueryTrace(id string) (*tempopb.Trace, error) {
 	panic("unimplemented")
 }
 
+//nolint:all
 func (m MockHTTPClient) Search(tags string) (*tempopb.SearchResponse, error) {
 	panic("unimplemented")
 }
 
+//nolint:all
 func (m MockHTTPClient) SearchTagValues(key string) (*tempopb.SearchTagValuesResponse, error) {
 	panic("unimplemented")
 }
 
+//nolint:all
 func (m MockHTTPClient) SearchTagValuesV2(key string, query string) (*tempopb.SearchTagValuesV2Response, error) {
 	panic("unimplemented")
 }
 
+//nolint:all
 func (m MockHTTPClient) SearchTagValuesV2WithRange(tag string, start int64, end int64) (*tempopb.SearchTagValuesV2Response, error) {
 	panic("unimplemented")
 }
 
+//nolint:all
 func (m MockHTTPClient) SearchTags() (*tempopb.SearchTagsResponse, error) {
 	panic("unimplemented")
 }
 
+//nolint:all
 func (m MockHTTPClient) SearchTagsV2() (*tempopb.SearchTagsV2Response, error) {
 	panic("unimplemented")
 }
 
+//nolint:all
 func (m MockHTTPClient) SearchTagsV2WithRange(start int64, end int64) (*tempopb.SearchTagsV2Response, error) {
 	panic("unimplemented")
 }
 
+//nolint:all
 func (m MockHTTPClient) SearchTagsWithRange(start int64, end int64) (*tempopb.SearchTagsResponse, error) {
 	panic("unimplemented")
 }
 
+//nolint:all
 func (m MockHTTPClient) SearchTraceQL(query string) (*tempopb.SearchResponse, error) {
 	panic("unimplemented")
 }
 
+//nolint:all
 func (m MockHTTPClient) SearchTraceQLWithRange(query string, start int64, end int64) (*tempopb.SearchResponse, error) {
 	panic("unimplemented")
 }
 
+//nolint:all
 func (m MockHTTPClient) SearchWithRange(tags string, start int64, end int64) (*tempopb.SearchResponse, error) {
 	panic("unimplemented")
 }
 
+//nolint:all
 func (m MockHTTPClient) SetOverrides(limits *userconfigurableoverrides.Limits, version string) (string, error) {
 	panic("unimplemented")
 }
 
+//nolint:all
 func (m MockHTTPClient) WithTransport(t http.RoundTripper) {
 	panic("unimplemented")
 }

--- a/cmd/tempo-vulture/mocks.go
+++ b/cmd/tempo-vulture/mocks.go
@@ -12,8 +12,8 @@ import (
 )
 
 type MockReporter struct {
-	err            error
-	batches_emited []*thrift.Batch
+	err             error
+	batches_emitted []*thrift.Batch
 }
 
 func (r MockReporter) EmitZipkinBatch(_ context.Context, _ []*zipkincore.Span) error {
@@ -21,106 +21,87 @@ func (r MockReporter) EmitZipkinBatch(_ context.Context, _ []*zipkincore.Span) e
 }
 
 func (r *MockReporter) EmitBatch(_ context.Context, b *thrift.Batch) error {
-	r.batches_emited = append(r.batches_emited, b)
+	r.batches_emitted = append(r.batches_emitted, b)
 	return r.err
 }
 
-type MockHttpClient struct {
+type MockHTTPClient struct {
 	err  error
 	resp http.Response
 }
 
-// DeleteOverrides implements httpclient.IClient.
-func (m MockHttpClient) DeleteOverrides(version string) error {
+func (m MockHTTPClient) DeleteOverrides(version string) error {
 	panic("unimplemented")
 }
 
-// Do implements httpclient.IClient.
-func (m MockHttpClient) Do(req *http.Request) (*http.Response, error) {
+func (m MockHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	return &m.resp, m.err
 }
 
-// GetOverrides implements httpclient.IClient.
-func (m MockHttpClient) GetOverrides() (*userconfigurableoverrides.Limits, string, error) {
+func (m MockHTTPClient) GetOverrides() (*userconfigurableoverrides.Limits, string, error) {
 	panic("unimplemented")
 }
 
-// MetricsSummary implements httpclient.IClient.
-func (m MockHttpClient) MetricsSummary(query string, groupBy string, start int64, end int64) (*tempopb.SpanMetricsSummaryResponse, error) {
+func (m MockHTTPClient) MetricsSummary(query string, groupBy string, start int64, end int64) (*tempopb.SpanMetricsSummaryResponse, error) {
 	panic("unimplemented")
 }
 
-// PatchOverrides implements httpclient.IClient.
-func (m MockHttpClient) PatchOverrides(limits *userconfigurableoverrides.Limits) (*userconfigurableoverrides.Limits, string, error) {
+func (m MockHTTPClient) PatchOverrides(limits *userconfigurableoverrides.Limits) (*userconfigurableoverrides.Limits, string, error) {
 	panic("unimplemented")
 }
 
-// QueryTrace implements httpclient.IClient.
-func (m MockHttpClient) QueryTrace(id string) (*tempopb.Trace, error) {
+func (m MockHTTPClient) QueryTrace(id string) (*tempopb.Trace, error) {
 	panic("unimplemented")
 }
 
-// Search implements httpclient.IClient.
-func (m MockHttpClient) Search(tags string) (*tempopb.SearchResponse, error) {
+func (m MockHTTPClient) Search(tags string) (*tempopb.SearchResponse, error) {
 	panic("unimplemented")
 }
 
-// SearchTagValues implements httpclient.IClient.
-func (m MockHttpClient) SearchTagValues(key string) (*tempopb.SearchTagValuesResponse, error) {
+func (m MockHTTPClient) SearchTagValues(key string) (*tempopb.SearchTagValuesResponse, error) {
 	panic("unimplemented")
 }
 
-// SearchTagValuesV2 implements httpclient.IClient.
-func (m MockHttpClient) SearchTagValuesV2(key string, query string) (*tempopb.SearchTagValuesV2Response, error) {
+func (m MockHTTPClient) SearchTagValuesV2(key string, query string) (*tempopb.SearchTagValuesV2Response, error) {
 	panic("unimplemented")
 }
 
-// SearchTagValuesV2WithRange implements httpclient.IClient.
-func (m MockHttpClient) SearchTagValuesV2WithRange(tag string, start int64, end int64) (*tempopb.SearchTagValuesV2Response, error) {
+func (m MockHTTPClient) SearchTagValuesV2WithRange(tag string, start int64, end int64) (*tempopb.SearchTagValuesV2Response, error) {
 	panic("unimplemented")
 }
 
-// SearchTags implements httpclient.IClient.
-func (m MockHttpClient) SearchTags() (*tempopb.SearchTagsResponse, error) {
+func (m MockHTTPClient) SearchTags() (*tempopb.SearchTagsResponse, error) {
 	panic("unimplemented")
 }
 
-// SearchTagsV2 implements httpclient.IClient.
-func (m MockHttpClient) SearchTagsV2() (*tempopb.SearchTagsV2Response, error) {
+func (m MockHTTPClient) SearchTagsV2() (*tempopb.SearchTagsV2Response, error) {
 	panic("unimplemented")
 }
 
-// SearchTagsV2WithRange implements httpclient.IClient.
-func (m MockHttpClient) SearchTagsV2WithRange(start int64, end int64) (*tempopb.SearchTagsV2Response, error) {
+func (m MockHTTPClient) SearchTagsV2WithRange(start int64, end int64) (*tempopb.SearchTagsV2Response, error) {
 	panic("unimplemented")
 }
 
-// SearchTagsWithRange implements httpclient.IClient.
-func (m MockHttpClient) SearchTagsWithRange(start int64, end int64) (*tempopb.SearchTagsResponse, error) {
+func (m MockHTTPClient) SearchTagsWithRange(start int64, end int64) (*tempopb.SearchTagsResponse, error) {
 	panic("unimplemented")
 }
 
-// SearchTraceQL implements httpclient.IClient.
-func (m MockHttpClient) SearchTraceQL(query string) (*tempopb.SearchResponse, error) {
+func (m MockHTTPClient) SearchTraceQL(query string) (*tempopb.SearchResponse, error) {
 	panic("unimplemented")
 }
 
-// SearchTraceQLWithRange implements httpclient.IClient.
-func (m MockHttpClient) SearchTraceQLWithRange(query string, start int64, end int64) (*tempopb.SearchResponse, error) {
+func (m MockHTTPClient) SearchTraceQLWithRange(query string, start int64, end int64) (*tempopb.SearchResponse, error) {
 	panic("unimplemented")
 }
 
-// SearchWithRange implements httpclient.IClient.
-func (m MockHttpClient) SearchWithRange(tags string, start int64, end int64) (*tempopb.SearchResponse, error) {
+func (m MockHTTPClient) SearchWithRange(tags string, start int64, end int64) (*tempopb.SearchResponse, error) {
 	panic("unimplemented")
 }
 
-// SetOverrides implements httpclient.IClient.
-func (m MockHttpClient) SetOverrides(limits *userconfigurableoverrides.Limits, version string) (string, error) {
+func (m MockHTTPClient) SetOverrides(limits *userconfigurableoverrides.Limits, version string) (string, error) {
 	panic("unimplemented")
 }
 
-// WithTransport implements httpclient.IClient.
-func (m MockHttpClient) WithTransport(t http.RoundTripper) {
+func (m MockHTTPClient) WithTransport(t http.RoundTripper) {
 	panic("unimplemented")
 }

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -35,6 +35,28 @@ const (
 
 var ErrNotFound = errors.New("resource not found")
 
+type IClient interface {
+	WithTransport(t http.RoundTripper)
+	Do(req *http.Request) (*http.Response, error)
+	SearchTags() (*tempopb.SearchTagsResponse, error)
+	SearchTagsV2() (*tempopb.SearchTagsV2Response, error)
+	SearchTagsWithRange(start int64, end int64) (*tempopb.SearchTagsResponse, error)
+	SearchTagsV2WithRange(start int64, end int64) (*tempopb.SearchTagsV2Response, error)
+	SearchTagValues(key string) (*tempopb.SearchTagValuesResponse, error)
+	SearchTagValuesV2(key, query string) (*tempopb.SearchTagValuesV2Response, error)
+	SearchTagValuesV2WithRange(tag string, start int64, end int64) (*tempopb.SearchTagValuesV2Response, error)
+	Search(tags string) (*tempopb.SearchResponse, error)
+	SearchWithRange(tags string, start int64, end int64) (*tempopb.SearchResponse, error)
+	QueryTrace(id string) (*tempopb.Trace, error)
+	SearchTraceQL(query string) (*tempopb.SearchResponse, error)
+	SearchTraceQLWithRange(query string, start int64, end int64) (*tempopb.SearchResponse, error)
+	MetricsSummary(query string, groupBy string, start int64, end int64) (*tempopb.SpanMetricsSummaryResponse, error)
+	GetOverrides() (*userconfigurableoverrides.Limits, string, error)
+	SetOverrides(limits *userconfigurableoverrides.Limits, version string) (string, error)
+	PatchOverrides(limits *userconfigurableoverrides.Limits) (*userconfigurableoverrides.Limits, string, error)
+	DeleteOverrides(version string) error
+}
+
 // Client is client to the Tempo API.
 type Client struct {
 	BaseURL string


### PR DESCRIPTION
**What this PR does**:
This PR aims to reduce the complexity of Vulture by refactoring the code into different functions. New tests have been added to provide a ground base for future changes.
Since this is a refactor, **the behavior is unaltered**. Some of the changes included:

- No references to global variables
- External dependencies are now interfaces
- Deduplicate function traceIsReady 
- Consistent use of the logger

Although the code coverage is not a goal itself it has been increased from 12% to 82%. Only the main method is not covered.

**Checklist**
- [ X] Tests updated
- [ ] Documentation added
- [ X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`