### PR TITLE
Fix Tags v2 API

### DIFF
--- a/modules/ingester/instance_search.go
+++ b/modules/ingester/instance_search.go
@@ -253,6 +253,8 @@ func (i *instance) SearchTagsV2(ctx context.Context, req *tempopb.SearchTagsRequ
 			if err != nil && !errors.Is(err, common.ErrUnsupported) {
 				return fmt.Errorf("unexpected error searching tags: %w", err)
 			}
+
+			return nil
 		}
 
 		// otherwise use the filtered search


### PR DESCRIPTION
A previous PR:

https://github.com/grafana/tempo/pull/3822

accidentally caused Tempo to search for tags using both the old and the new search paths. This correctly returns early if we can do the unfiltered/faster search.