### PR TITLE
Fix poller to maintain previous blocklist results on tenant error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 * [BUGFIX] Fix http connection reuse on GCP and AWS by reading io.EOF through the http body. [#3760](https://github.com/grafana/tempo/pull/3760) (@bmteller)
 * [BUGFIX] Improved handling of complete blocks in localblocks processor after enabling flusing [#3805](https://github.com/grafana/tempo/pull/3805) (@mapno)
 * [BUGFIX] Handle out of boundaries spans kinds [#3861](https://github.com/grafana/tempo/pull/3861) (@javiermolinar)
+* [BUGFIX] Maintain previous tenant blocklist on tenant errors [#3860](https://github.com/grafana/tempo/pull/3860) (@zalegrala)
+
 
 ## v2.5.0
 

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -162,6 +162,9 @@ func (p *Poller) Do(previous *List) (PerTenant, PerTenantCompacted, error) {
 				level.Error(p.logger).Log("msg", "exiting polling loop early because too many errors", "errCount", consecutiveErrors)
 				return nil, nil, err
 			}
+
+			blocklist[tenantID] = previous.Metas(tenantID)
+			compactedBlocklist[tenantID] = previous.CompactedMetas(tenantID)
 			continue
 		}
 


### PR DESCRIPTION
**What this PR does**:

Here we fix a bug where a single tenant experiences an error during polling,
which is not enough to trip the max error threshold.  In this case, the tenant
which experienced the error would be removed from the blocklist, and would not
be re-added until the next time the poller runs.  Inconsistent results in the
blocklist can cause issues on the query path for this tenant.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`