### PR TITLE
fix: handle out of boundaries spans kinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 * [BUGFIX] max_global_traces_per_user: take into account ingestion.tenant_shard_size when converting to local limit [#3618](https://github.com/grafana/tempo/pull/3618) (@kvrhdn)
 * [BUGFIX] Fix http connection reuse on GCP and AWS by reading io.EOF through the http body. [#3760](https://github.com/grafana/tempo/pull/3760) (@bmteller)
 * [BUGFIX] Improved handling of complete blocks in localblocks processor after enabling flusing [#3805](https://github.com/grafana/tempo/pull/3805) (@mapno)
-
+* [BUGFIX] Handle out of boundaries spans kinds [#3861](https://github.com/grafana/tempo/pull/3861) (@javiermolinar)
 
 ## v2.5.0
 

--- a/pkg/util/traceid.go
+++ b/pkg/util/traceid.go
@@ -60,6 +60,9 @@ var spanKindFNVHashes = [...]uint64{
 // that it has a low collision probability. In zipkin traces the span id is not guaranteed to be unique as it
 // is shared between client and server spans. Therefore, it is sometimes required to take the span kind into account.
 func SpanIDAndKindToToken(id []byte, kind int) uint64 {
+	if kind < 0 || kind >= len(spanKindFNVHashes) {
+		kind = 0
+	}
 	return SpanIDToUint64(id) ^ spanKindFNVHashes[kind]
 }
 

--- a/pkg/util/traceid_test.go
+++ b/pkg/util/traceid_test.go
@@ -191,6 +191,14 @@ func TestSpanIDAndKindToToken(t *testing.T) {
 			tokensForKind[token] = struct{}{}
 		}
 	}
+
+	t.Run("when kind is outside the boundaries", func(t *testing.T) {
+		spanID := []byte{0x60}
+		t1 := SpanIDAndKindToToken(spanID, 1000)
+		t2 := SpanIDAndKindToToken(spanID, -2)
+
+		assert.Equal(t, t1, t2)
+	})
 }
 
 var tokenToPreventOptimization uint64


### PR DESCRIPTION
**What this PR does**:
Control unbounded spans kinds

**Checklist**
- [X] Tests updated
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`