### PR TITLE
Fix autocomplete parsing of new scoped intrinsics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [BUGFIX] Fix panic in certain metrics queries using `rate()` with `by` [#3847](https://github.com/grafana/tempo/pull/3847) (@stoewer)
 * [BUGFIX] Fix metrics queries when grouping by attributes that may not exist [#3734](https://github.com/grafana/tempo/pull/3734) (@mdisibio)
 * [BUGFIX] Fix frontend parsing error on cached responses [#3759](https://github.com/grafana/tempo/pull/3759) (@mdisibio)
+* [BUGFIX] Fix autocomplete of a query using scoped instrinsics [#3865](https://github.com/grafana/tempo/pull/3865) (@mdisibio)
 * [BUGFIX] max_global_traces_per_user: take into account ingestion.tenant_shard_size when converting to local limit [#3618](https://github.com/grafana/tempo/pull/3618) (@kvrhdn)
 * [BUGFIX] Fix http connection reuse on GCP and AWS by reading io.EOF through the http body. [#3760](https://github.com/grafana/tempo/pull/3760) (@bmteller)
 * [BUGFIX] Improved handling of complete blocks in localblocks processor after enabling flusing [#3805](https://github.com/grafana/tempo/pull/3805) (@mapno)

--- a/pkg/traceql/extractmatcher.go
+++ b/pkg/traceql/extractmatcher.go
@@ -18,7 +18,7 @@ import (
 //  3. The boolean values "true" or "false".
 //
 // Example: "http.status_code = 200" from the query "{ .http.status_code = 200 && .http.method = }"
-var matchersRegexp = regexp.MustCompile(`[\p{L}\p{N}._\-" ]+\s*(=|<=|>=|=~|!=|>|<|!~)\s*(?:"[\p{L}\p{N}\p{P}\p{M}\p{S}]+"|true|false|[a-z]+|[0-9smh]+)`)
+var matchersRegexp = regexp.MustCompile(`[\p{L}\p{N}._\-:" ]+\s*(=|<=|>=|=~|!=|>|<|!~)\s*(?:"[\p{L}\p{N}\p{P}\p{M}\p{S}]+"|true|false|[a-z]+|[0-9smh]+)`)
 
 // TODO: Merge into a single regular expression
 

--- a/pkg/traceql/extractmatcher_test.go
+++ b/pkg/traceql/extractmatcher_test.go
@@ -120,6 +120,11 @@ func TestExtractMatchers(t *testing.T) {
 			query:    `{ .foo = "a" && .bar =~ "(c|d)" }`,
 			expected: `{.foo = "a" && .bar =~ "(c|d)"}`,
 		},
+		{
+			name:     "scoped intrinsic",
+			query:    `{ event:name = "exception" }`,
+			expected: `{event:name = "exception"}`,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:
Tiny fix to autocomplete parsing of the new scoped intrinics inside the filtering query.  Ex:
`/api/v2/search/tag/resource.service.name/values?q={event:name="exception"}`   Missing colon lead to the extracted matchers dropping the scope and became `name="exception"`.

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`