### PR TITLE
Include securityContext.fsGroup on jsonnet statefulset

### DIFF
--- a/operations/jsonnet-compiled/StatefulSet-ingester.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-ingester.yaml
@@ -58,6 +58,8 @@ spec:
           name: ingester-data
         - mountPath: /overrides
           name: overrides
+      securityContext:
+        fsGroup: 10001
       terminationGracePeriodSeconds: 1200
       volumes:
       - configMap:

--- a/operations/jsonnet-compiled/StatefulSet-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-metrics-generator.yaml
@@ -60,6 +60,8 @@ spec:
           name: metrics-generator-data
         - mountPath: /overrides
           name: overrides
+      securityContext:
+        fsGroup: 10001
       volumes:
       - configMap:
           name: tempo-metrics-generator

--- a/operations/jsonnet-compiled/util/jsonnetfile.lock.json
+++ b/operations/jsonnet-compiled/util/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "5f8a166911d56d0402fd52cbbce47cadfee0e466",
+      "version": "0ed0fe46fea3c7f47cc5859103f81684f59a85bc",
       "sum": "0y3AFX9LQSpfWTxWKSwoLgbt0Wc9nnCwhMH2szKzHv0="
     },
     {
@@ -18,7 +18,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "5f8a166911d56d0402fd52cbbce47cadfee0e466",
+      "version": "0ed0fe46fea3c7f47cc5859103f81684f59a85bc",
       "sum": "Cc715Y3rgTuimgDFIw+FaKzXSJGRYwt1pFTMbdrNBD8="
     },
     {

--- a/operations/jsonnet/microservices/generator.libsonnet
+++ b/operations/jsonnet/microservices/generator.libsonnet
@@ -92,7 +92,10 @@
     $.util.podPriority('high') +
     (if with_anti_affinity then $.util.antiAffinity else {}),
 
-  tempo_metrics_generator_statefulset: $.newGeneratorStatefulSet(target_name, self.tempo_metrics_generator_container) + statefulset.mixin.spec.withReplicas($._config.metrics_generator.replicas),
+  tempo_metrics_generator_statefulset:
+    $.newGeneratorStatefulSet(target_name, self.tempo_metrics_generator_container)
+    + statefulset.spec.template.spec.securityContext.withFsGroup(10001)  // 10001 is the UID of the tempo user
+    + statefulset.mixin.spec.withReplicas($._config.metrics_generator.replicas),
 
   tempo_metrics_generator_service:
     kausal.util.serviceFor($.tempo_metrics_generator_deployment),

--- a/operations/jsonnet/microservices/ingester.libsonnet
+++ b/operations/jsonnet/microservices/ingester.libsonnet
@@ -70,7 +70,10 @@
     (if with_anti_affinity then $.util.antiAffinity else {})
   ,
 
-  tempo_ingester_statefulset: $.newIngesterStatefulSet(target_name, self.tempo_ingester_container) + statefulset.mixin.spec.withReplicas($._config.ingester.replicas),
+  tempo_ingester_statefulset:
+    $.newIngesterStatefulSet(target_name, self.tempo_ingester_container)
+    + statefulset.spec.template.spec.securityContext.withFsGroup(10001)  // 10001 is the UID of the tempo user
+    + statefulset.mixin.spec.withReplicas($._config.ingester.replicas),
 
   tempo_ingester_service:
     kausal.util.serviceFor($.tempo_ingester_statefulset),


### PR DESCRIPTION
**What this PR does**:

New PVCs may get exposed to the container with root permissions despite the UID of the container.  Here we set the `securityContext.fsGroup` of the statefulset which run the tempo container.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`