### PR TITLE
Refactor: Rename AdditionalData for clarity

### DIFF
--- a/modules/frontend/combiner/common.go
+++ b/modules/frontend/combiner/common.go
@@ -20,7 +20,7 @@ type TResponse interface {
 
 type PipelineResponse interface {
 	HTTPResponse() *http.Response
-	AdditionalData() any
+	RequestData() any
 }
 
 type genericCombiner[T TResponse] struct {

--- a/modules/frontend/combiner/common_test.go
+++ b/modules/frontend/combiner/common_test.go
@@ -220,7 +220,7 @@ func (p *testPipelineResponse) HTTPResponse() *http.Response {
 	return p.r
 }
 
-func (p *testPipelineResponse) AdditionalData() any {
+func (p *testPipelineResponse) RequestData() any {
 	return nil
 }
 

--- a/modules/frontend/combiner/metrics_query_range.go
+++ b/modules/frontend/combiner/metrics_query_range.go
@@ -31,7 +31,7 @@ func NewQueryRange(req *tempopb.QueryRangeRequest, trackDiffs bool) (Combiner, e
 				}
 			}
 
-			samplingRate := resp.AdditionalData()
+			samplingRate := resp.RequestData()
 			if samplingRate != nil {
 				fRate := samplingRate.(float64)
 

--- a/modules/frontend/combiner/search_test.go
+++ b/modules/frontend/combiner/search_test.go
@@ -394,7 +394,7 @@ func (p *pipelineResponse) HTTPResponse() *http.Response {
 	return p.r
 }
 
-func (p *pipelineResponse) AdditionalData() any {
+func (p *pipelineResponse) RequestData() any {
 	return nil
 }
 

--- a/modules/frontend/metrics_query_range_sharder.go
+++ b/modules/frontend/metrics_query_range_sharder.go
@@ -290,7 +290,7 @@ func (s *queryRangeSharder) buildShardedBackendRequests(ctx context.Context, ten
 				// Set final sampling rate after integer rounding
 				samplingRate = float64(shards) / float64(shardR.ShardCount)
 
-				httpReq = pipeline.ContextAddAdditionalData(samplingRate, httpReq)
+				httpReq = pipeline.ContextAddResponseDataForResponse(samplingRate, httpReq)
 			}
 
 			select {

--- a/modules/frontend/pipeline/context.go
+++ b/modules/frontend/pipeline/context.go
@@ -16,8 +16,9 @@ func ContextAddCacheKey(key string, req *http.Request) *http.Request {
 
 // contextEchoData is used to echo request specific data through the pipeline. It stores any value.
 // see usage for samplingRate in modules/frontend/metrics_query_range_sharder.go
-var contextEchoAdditionalData = struct{}{}
+var contextRequestDataForResponse = struct{}{}
 
-func ContextAddAdditionalData(val any, req *http.Request) *http.Request {
-	return req.WithContext(context.WithValue(req.Context(), contextEchoAdditionalData, val))
+// ContextAddResponseDataForResponse adds a value to the request context that will be echoed back in the response.
+func ContextAddResponseDataForResponse(val any, req *http.Request) *http.Request {
+	return req.WithContext(context.WithValue(req.Context(), contextRequestDataForResponse, val))
 }

--- a/modules/frontend/pipeline/pipeline.go
+++ b/modules/frontend/pipeline/pipeline.go
@@ -98,11 +98,9 @@ func (b *pipelineBridge) RoundTrip(req *http.Request) (Responses[combiner.Pipeli
 		return nil, err
 	}
 
-	// check for additional data in the context and echo it back if it exists
-	// todo: this idea is good, but needs to be fleshed out. Currently only supports one
-	// strangely communicated piece of data
-	if val := req.Context().Value(contextEchoAdditionalData); val != nil {
-		return NewHTTPToAsyncResponseWithAdditionalData(r, val), nil
+	// check for request data in the context and echo it back if it exists
+	if val := req.Context().Value(contextRequestDataForResponse); val != nil {
+		return NewHTTPToAsyncResponseWithRequestData(r, val), nil
 	}
 
 	return NewHTTPToAsyncResponse(r), nil

--- a/modules/frontend/pipeline/responses.go
+++ b/modules/frontend/pipeline/responses.go
@@ -18,16 +18,16 @@ type Responses[T any] interface {
 var _ Responses[combiner.PipelineResponse] = syncResponse{}
 
 type pipelineResponse struct {
-	r              *http.Response
-	additionalData any
+	r           *http.Response
+	requestData any
 }
 
 func (p pipelineResponse) HTTPResponse() *http.Response {
 	return p.r
 }
 
-func (p pipelineResponse) AdditionalData() any {
-	return p.additionalData
+func (p pipelineResponse) RequestData() any {
+	return p.requestData
 }
 
 // syncResponse is a single http.Response that implements the Responses[*http.Response] interface.
@@ -39,17 +39,17 @@ type syncResponse struct {
 func NewHTTPToAsyncResponse(r *http.Response) Responses[combiner.PipelineResponse] {
 	return syncResponse{
 		r: pipelineResponse{
-			r:              r,
-			additionalData: nil,
+			r:           r,
+			requestData: nil,
 		},
 	}
 }
 
-func NewHTTPToAsyncResponseWithAdditionalData(r *http.Response, additionalData any) Responses[combiner.PipelineResponse] {
+func NewHTTPToAsyncResponseWithRequestData(r *http.Response, requestData any) Responses[combiner.PipelineResponse] {
 	return syncResponse{
 		r: pipelineResponse{
-			r:              r,
-			additionalData: additionalData,
+			r:           r,
+			requestData: requestData,
 		},
 	}
 }


### PR DESCRIPTION
A simple refactor PR that renames the "additional data" concept to more clearly indicate what it's for. This feature is meant as a way to attach a specific piece of data to a request that is returned in the response.