### PR TITLE
feat: improve trace id lookup by setting a date range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [ENHANCEMENT] Self document makefile [#3844](https://github.com/grafana/tempo/pull/3844)  (@javiermolinar)
 * [ENHANCEMENT] Added a Tempo CLI command to drop traces by id by rewriting blocks. [#3856](https://github.com/grafana/tempo/pull/3856)  (@joe-elliott)
 * [ENHANCEMENT] Mixin, make recording rule range interval configurable and increase range interval in alert to support scrape interval of 1 minute [#3851](https://github.com/grafana/tempo/pull/3851)  (@jmichalek132)
+* [ENHANCEMENT] Improve trace id lookup from Tempo Vulture by selecting a date range (@javiermolinar)
 * [BUGFIX] Fix panic in certain metrics queries using `rate()` with `by` [#3847](https://github.com/grafana/tempo/pull/3847) (@stoewer)
 * [BUGFIX] Fix metrics queries when grouping by attributes that may not exist [#3734](https://github.com/grafana/tempo/pull/3734) (@mdisibio)
 * [BUGFIX] Fix frontend parsing error on cached responses [#3759](https://github.com/grafana/tempo/pull/3759) (@mdisibio)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 * [ENHANCEMENT] Self document makefile [#3844](https://github.com/grafana/tempo/pull/3844)  (@javiermolinar)
 * [ENHANCEMENT] Added a Tempo CLI command to drop traces by id by rewriting blocks. [#3856](https://github.com/grafana/tempo/pull/3856)  (@joe-elliott)
 * [ENHANCEMENT] Mixin, make recording rule range interval configurable and increase range interval in alert to support scrape interval of 1 minute [#3851](https://github.com/grafana/tempo/pull/3851)  (@jmichalek132)
-* [ENHANCEMENT] Improve trace id lookup from Tempo Vulture by selecting a date range (@javiermolinar)
+* [ENHANCEMENT] Add vParquet4 support to the tempo-cli analyse blocks command [#3868](https://github.com/grafana/tempo/pull/3868) (@stoewer)
 * [BUGFIX] Fix panic in certain metrics queries using `rate()` with `by` [#3847](https://github.com/grafana/tempo/pull/3847) (@stoewer)
 * [BUGFIX] Fix metrics queries when grouping by attributes that may not exist [#3734](https://github.com/grafana/tempo/pull/3734) (@mdisibio)
 * [BUGFIX] Fix frontend parsing error on cached responses [#3759](https://github.com/grafana/tempo/pull/3759) (@mdisibio)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [ENHANCEMENT] Added a Tempo CLI command to drop traces by id by rewriting blocks. [#3856](https://github.com/grafana/tempo/pull/3856)  (@joe-elliott)
 * [ENHANCEMENT] Mixin, make recording rule range interval configurable and increase range interval in alert to support scrape interval of 1 minute [#3851](https://github.com/grafana/tempo/pull/3851)  (@jmichalek132)
 * [ENHANCEMENT] Add vParquet4 support to the tempo-cli analyse blocks command [#3868](https://github.com/grafana/tempo/pull/3868) (@stoewer)
+* [ENHANCEMENT] Improve trace id lookup from Tempo Vulture by selecting a date range (@javiermolinar)
 * [BUGFIX] Fix panic in certain metrics queries using `rate()` with `by` [#3847](https://github.com/grafana/tempo/pull/3847) (@stoewer)
 * [BUGFIX] Fix metrics queries when grouping by attributes that may not exist [#3734](https://github.com/grafana/tempo/pull/3734) (@mdisibio)
 * [BUGFIX] Fix frontend parsing error on cached responses [#3759](https://github.com/grafana/tempo/pull/3759) (@mdisibio)

--- a/cmd/tempo-cli/cmd-analyse-block.go
+++ b/cmd/tempo-cli/cmd-analyse-block.go
@@ -11,18 +11,17 @@ import (
 	"text/tabwriter"
 	"time"
 
-	tempo_io "github.com/grafana/tempo/pkg/io"
-	"github.com/parquet-go/parquet-go"
-
-	pq "github.com/grafana/tempo/pkg/parquetquery"
-	"github.com/stoewer/parquet-cli/pkg/inspect"
-
-	"github.com/grafana/tempo/tempodb/encoding/vparquet2"
-	"github.com/grafana/tempo/tempodb/encoding/vparquet3"
-
 	"github.com/dustin/go-humanize"
 	"github.com/google/uuid"
+	"github.com/parquet-go/parquet-go"
+	"github.com/stoewer/parquet-cli/pkg/inspect"
+
+	tempo_io "github.com/grafana/tempo/pkg/io"
+	pq "github.com/grafana/tempo/pkg/parquetquery"
 	"github.com/grafana/tempo/tempodb/backend"
+	"github.com/grafana/tempo/tempodb/encoding/vparquet2"
+	"github.com/grafana/tempo/tempodb/encoding/vparquet3"
+	"github.com/grafana/tempo/tempodb/encoding/vparquet4"
 )
 
 var (
@@ -38,6 +37,12 @@ var (
 	vparquet3ResourceAttrs = []string{
 		vparquet3.FieldResourceAttrVal,
 	}
+	vparquet4SpanAttrs = []string{
+		vparquet4.FieldSpanAttrVal,
+	}
+	vparquet4ResourceAttrs = []string{
+		vparquet4.FieldResourceAttrVal,
+	}
 )
 
 func spanPathsForVersion(v string) (string, []string) {
@@ -46,6 +51,8 @@ func spanPathsForVersion(v string) (string, []string) {
 		return vparquet2.FieldSpanAttrKey, vparquet2SpanAttrs
 	case vparquet3.VersionString:
 		return vparquet3.FieldSpanAttrKey, vparquet3SpanAttrs
+	case vparquet4.VersionString:
+		return vparquet4.FieldSpanAttrKey, vparquet4SpanAttrs
 	}
 	return "", nil
 }
@@ -56,6 +63,8 @@ func resourcePathsForVersion(v string) (string, []string) {
 		return vparquet2.FieldResourceAttrKey, vparquet2ResourceAttrs
 	case vparquet3.VersionString:
 		return vparquet3.FieldResourceAttrKey, vparquet3ResourceAttrs
+	case vparquet4.VersionString:
+		return vparquet4.FieldResourceAttrKey, vparquet4ResourceAttrs
 	}
 	return "", nil
 }
@@ -64,6 +73,8 @@ func dedicatedColPathForVersion(i int, scope backend.DedicatedColumnScope, v str
 	switch v {
 	case vparquet3.VersionString:
 		return vparquet3.DedicatedResourceColumnPaths[scope][backend.DedicatedColumnTypeString][i]
+	case vparquet4.VersionString:
+		return vparquet4.DedicatedResourceColumnPaths[scope][backend.DedicatedColumnTypeString][i]
 	}
 	return ""
 }
@@ -123,6 +134,8 @@ func processBlock(r backend.Reader, tenantID, blockID string, maxStartTime, minS
 		reader = vparquet2.NewBackendReaderAt(context.Background(), r, vparquet2.DataFileName, meta)
 	case vparquet3.VersionString:
 		reader = vparquet3.NewBackendReaderAt(context.Background(), r, vparquet3.DataFileName, meta)
+	case vparquet4.VersionString:
+		reader = vparquet4.NewBackendReaderAt(context.Background(), r, vparquet4.DataFileName, meta)
 	default:
 		fmt.Println("Unsupported block version:", meta.Version)
 		return nil, nil

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -235,7 +235,7 @@ func queueFutureBatches(client util.JaegerClient, info *util.TraceInfo, config v
 	}()
 }
 
-func doRead(httpClient httpclient.HTTPClient, tickerRead *time.Ticker, startTime time.Time, interval time.Duration, r *rand.Rand, config vultureConfiguration, l *zap.Logger) {
+func doRead(httpClient httpclient.TempoHTTPClient, tickerRead *time.Ticker, startTime time.Time, interval time.Duration, r *rand.Rand, config vultureConfiguration, l *zap.Logger) {
 	if tickerRead != nil {
 		go func() {
 			for now := range tickerRead.C {
@@ -269,7 +269,7 @@ func doRead(httpClient httpclient.HTTPClient, tickerRead *time.Ticker, startTime
 	}
 }
 
-func doSearch(httpClient httpclient.HTTPClient, tickerSearch *time.Ticker, startTime time.Time, interval time.Duration, r *rand.Rand, config vultureConfiguration, l *zap.Logger) {
+func doSearch(httpClient httpclient.TempoHTTPClient, tickerSearch *time.Ticker, startTime time.Time, interval time.Duration, r *rand.Rand, config vultureConfiguration, l *zap.Logger) {
 	if tickerSearch != nil {
 		go func() {
 			for now := range tickerSearch.C {
@@ -394,7 +394,7 @@ func traceInTraces(traceID string, traces []*tempopb.TraceSearchMetadata) bool {
 	return false
 }
 
-func searchTag(client httpclient.HTTPClient, seed time.Time, config vultureConfiguration, l *zap.Logger) (traceMetrics, error) {
+func searchTag(client httpclient.TempoHTTPClient, seed time.Time, config vultureConfiguration, l *zap.Logger) (traceMetrics, error) {
 	tm := traceMetrics{
 		requested: 1,
 	}
@@ -443,7 +443,7 @@ func searchTag(client httpclient.HTTPClient, seed time.Time, config vultureConfi
 	return tm, nil
 }
 
-func searchTraceql(client httpclient.HTTPClient, seed time.Time, config vultureConfiguration, l *zap.Logger) (traceMetrics, error) {
+func searchTraceql(client httpclient.TempoHTTPClient, seed time.Time, config vultureConfiguration, l *zap.Logger) (traceMetrics, error) {
 	tm := traceMetrics{
 		requested: 1,
 	}
@@ -490,7 +490,7 @@ func searchTraceql(client httpclient.HTTPClient, seed time.Time, config vultureC
 	return tm, nil
 }
 
-func queryTrace(client httpclient.HTTPClient, info *util.TraceInfo, l *zap.Logger) (traceMetrics, error) {
+func queryTrace(client httpclient.TempoHTTPClient, info *util.TraceInfo, l *zap.Logger) (traceMetrics, error) {
 	tm := traceMetrics{
 		requested: 1,
 	}

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -504,7 +504,11 @@ func queryTrace(client httpclient.TempoHTTPClient, info *util.TraceInfo, l *zap.
 	)
 	logger.Info("querying Tempo")
 
-	trace, err := client.QueryTrace(hexID)
+	start := info.Timestamp().Add(-30 * time.Minute).Unix()
+	end := info.Timestamp().Add(30 * time.Minute).Unix()
+
+	// We want to define a time range to reduce the number of lookups
+	trace, err := client.QueryTraceWithRange(hexID, start, end)
 	if err != nil {
 		if errors.Is(err, util.ErrTraceNotFound) {
 			tm.notFoundByID++

--- a/cmd/tempo-vulture/mocks.go
+++ b/cmd/tempo-vulture/mocks.go
@@ -86,6 +86,17 @@ func (m *MockHTTPClient) QueryTrace(id string) (*tempopb.Trace, error) {
 	return m.traceResp, m.err
 }
 
+//nolint:all
+func (m *MockHTTPClient) QueryTraceWithRange(id string, start int64, end int64) (*tempopb.Trace, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	m.m.Lock()
+	defer m.m.Unlock()
+	m.requestsCount++
+	return m.traceResp, m.err
+}
+
 func (m *MockHTTPClient) GetRequestsCount() int {
 	m.m.Lock()
 	defer m.m.Unlock()

--- a/modules/frontend/combiner/common.go
+++ b/modules/frontend/combiner/common.go
@@ -20,7 +20,7 @@ type TResponse interface {
 
 type PipelineResponse interface {
 	HTTPResponse() *http.Response
-	AdditionalData() any
+	RequestData() any
 }
 
 type genericCombiner[T TResponse] struct {

--- a/modules/frontend/combiner/common_test.go
+++ b/modules/frontend/combiner/common_test.go
@@ -220,7 +220,7 @@ func (p *testPipelineResponse) HTTPResponse() *http.Response {
 	return p.r
 }
 
-func (p *testPipelineResponse) AdditionalData() any {
+func (p *testPipelineResponse) RequestData() any {
 	return nil
 }
 

--- a/modules/frontend/combiner/metrics_query_range.go
+++ b/modules/frontend/combiner/metrics_query_range.go
@@ -31,7 +31,7 @@ func NewQueryRange(req *tempopb.QueryRangeRequest, trackDiffs bool) (Combiner, e
 				}
 			}
 
-			samplingRate := resp.AdditionalData()
+			samplingRate := resp.RequestData()
 			if samplingRate != nil {
 				fRate := samplingRate.(float64)
 

--- a/modules/frontend/combiner/search_test.go
+++ b/modules/frontend/combiner/search_test.go
@@ -394,7 +394,7 @@ func (p *pipelineResponse) HTTPResponse() *http.Response {
 	return p.r
 }
 
-func (p *pipelineResponse) AdditionalData() any {
+func (p *pipelineResponse) RequestData() any {
 	return nil
 }
 

--- a/modules/frontend/metrics_query_range_sharder.go
+++ b/modules/frontend/metrics_query_range_sharder.go
@@ -290,7 +290,7 @@ func (s *queryRangeSharder) buildShardedBackendRequests(ctx context.Context, ten
 				// Set final sampling rate after integer rounding
 				samplingRate = float64(shards) / float64(shardR.ShardCount)
 
-				httpReq = pipeline.ContextAddAdditionalData(samplingRate, httpReq)
+				httpReq = pipeline.ContextAddResponseDataForResponse(samplingRate, httpReq)
 			}
 
 			select {

--- a/modules/frontend/pipeline/context.go
+++ b/modules/frontend/pipeline/context.go
@@ -16,8 +16,9 @@ func ContextAddCacheKey(key string, req *http.Request) *http.Request {
 
 // contextEchoData is used to echo request specific data through the pipeline. It stores any value.
 // see usage for samplingRate in modules/frontend/metrics_query_range_sharder.go
-var contextEchoAdditionalData = struct{}{}
+var contextRequestDataForResponse = struct{}{}
 
-func ContextAddAdditionalData(val any, req *http.Request) *http.Request {
-	return req.WithContext(context.WithValue(req.Context(), contextEchoAdditionalData, val))
+// ContextAddResponseDataForResponse adds a value to the request context that will be echoed back in the response.
+func ContextAddResponseDataForResponse(val any, req *http.Request) *http.Request {
+	return req.WithContext(context.WithValue(req.Context(), contextRequestDataForResponse, val))
 }

--- a/modules/frontend/pipeline/pipeline.go
+++ b/modules/frontend/pipeline/pipeline.go
@@ -98,11 +98,9 @@ func (b *pipelineBridge) RoundTrip(req *http.Request) (Responses[combiner.Pipeli
 		return nil, err
 	}
 
-	// check for additional data in the context and echo it back if it exists
-	// todo: this idea is good, but needs to be fleshed out. Currently only supports one
-	// strangely communicated piece of data
-	if val := req.Context().Value(contextEchoAdditionalData); val != nil {
-		return NewHTTPToAsyncResponseWithAdditionalData(r, val), nil
+	// check for request data in the context and echo it back if it exists
+	if val := req.Context().Value(contextRequestDataForResponse); val != nil {
+		return NewHTTPToAsyncResponseWithRequestData(r, val), nil
 	}
 
 	return NewHTTPToAsyncResponse(r), nil

--- a/modules/frontend/pipeline/responses.go
+++ b/modules/frontend/pipeline/responses.go
@@ -18,16 +18,16 @@ type Responses[T any] interface {
 var _ Responses[combiner.PipelineResponse] = syncResponse{}
 
 type pipelineResponse struct {
-	r              *http.Response
-	additionalData any
+	r           *http.Response
+	requestData any
 }
 
 func (p pipelineResponse) HTTPResponse() *http.Response {
 	return p.r
 }
 
-func (p pipelineResponse) AdditionalData() any {
-	return p.additionalData
+func (p pipelineResponse) RequestData() any {
+	return p.requestData
 }
 
 // syncResponse is a single http.Response that implements the Responses[*http.Response] interface.
@@ -39,17 +39,17 @@ type syncResponse struct {
 func NewHTTPToAsyncResponse(r *http.Response) Responses[combiner.PipelineResponse] {
 	return syncResponse{
 		r: pipelineResponse{
-			r:              r,
-			additionalData: nil,
+			r:           r,
+			requestData: nil,
 		},
 	}
 }
 
-func NewHTTPToAsyncResponseWithAdditionalData(r *http.Response, additionalData any) Responses[combiner.PipelineResponse] {
+func NewHTTPToAsyncResponseWithRequestData(r *http.Response, requestData any) Responses[combiner.PipelineResponse] {
 	return syncResponse{
 		r: pipelineResponse{
-			r:              r,
-			additionalData: additionalData,
+			r:           r,
+			requestData: requestData,
 		},
 	}
 }

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -46,6 +46,7 @@ type TempoHTTPClient interface {
 	Search(tags string) (*tempopb.SearchResponse, error)
 	SearchWithRange(tags string, start int64, end int64) (*tempopb.SearchResponse, error)
 	QueryTrace(id string) (*tempopb.Trace, error)
+	QueryTraceWithRange(id string, start int64, end int64) (*tempopb.Trace, error)
 	SearchTraceQL(query string) (*tempopb.SearchResponse, error)
 	SearchTraceQLWithRange(query string, start int64, end int64) (*tempopb.SearchResponse, error)
 	MetricsSummary(query string, groupBy string, start int64, end int64) (*tempopb.SpanMetricsSummaryResponse, error)

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -112,8 +112,7 @@ func (c *Client) getFor(url string, m proto.Message) (*http.Response, error) {
 		if err = jsonpb.UnmarshalString(string(body), m); err != nil {
 			return resp, fmt.Errorf("error decoding %T json, err: %v body: %s", m, err, string(body))
 		}
-	case applicationProtobuf:
-
+	default:
 		if err = proto.Unmarshal(body, m); err != nil {
 			return nil, fmt.Errorf("error decoding %T proto, err: %w body: %s", m, err, string(body))
 		}

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -33,7 +33,7 @@ const (
 	applicationJSON     = "application/json"
 )
 
-type HTTPClient interface {
+type TempoHTTPClient interface {
 	WithTransport(t http.RoundTripper)
 	Do(req *http.Request) (*http.Response, error)
 	SearchTags() (*tempopb.SearchTagsResponse, error)

--- a/pkg/httpclient/client_test.go
+++ b/pkg/httpclient/client_test.go
@@ -1,0 +1,56 @@
+package httpclient
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/stretchr/testify/assert"
+)
+
+type MockRoundTripper func(r *http.Request) *http.Response
+
+func (f MockRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r), nil
+}
+
+func TestQueryTrace(t *testing.T) {
+	trace := &tempopb.Trace{}
+	t.Run("returns a trace when is found", func(t *testing.T) {
+		mockTransport := MockRoundTripper(func(req *http.Request) *http.Response {
+			assert.Equal(t, "www.tempo.com/api/traces/100", req.URL.Path)
+			assert.Equal(t, "application/protobuf", req.Header.Get("Accept"))
+			response, _ := proto.Marshal(trace)
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader(response)),
+			}
+		})
+
+		client := New("www.tempo.com", "1000")
+		client.WithTransport(mockTransport)
+		response, err := client.QueryTrace("100")
+
+		assert.NoError(t, err)
+		assert.True(t, proto.Equal(trace, response))
+	})
+
+	t.Run("returns a trace not found error on 404", func(t *testing.T) {
+		mockTransport := MockRoundTripper(func(_ *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 404,
+				Body:       nil,
+			}
+		})
+
+		client := New("www.tempo.com", "1000")
+		client.WithTransport(mockTransport)
+		response, err := client.QueryTrace("notfound")
+
+		assert.Error(t, err)
+		assert.Nil(t, response)
+	})
+}

--- a/pkg/httpclient/client_test.go
+++ b/pkg/httpclient/client_test.go
@@ -2,6 +2,7 @@ package httpclient
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 	"testing"
@@ -49,6 +50,52 @@ func TestQueryTrace(t *testing.T) {
 		client := New("www.tempo.com", "1000")
 		client.WithTransport(mockTransport)
 		response, err := client.QueryTrace("notfound")
+
+		assert.Error(t, err)
+		assert.Nil(t, response)
+	})
+}
+
+func TestQueryTraceWithRance(t *testing.T) {
+	trace := &tempopb.Trace{}
+	t.Run("returns an error if start time is greater than end time", func(t *testing.T) {
+		client := New("www.tempo.com", "1000")
+		response, err := client.QueryTraceWithRange("notfound", 3000, 2000)
+
+		assert.Error(t, err)
+		assert.Nil(t, response)
+	})
+
+	t.Run("returns a trace with range when is found", func(t *testing.T) {
+		mockTransport := MockRoundTripper(func(req *http.Request) *http.Response {
+			assert.Equal(t, "www.tempo.com/api/traces/100?end=2000&start=1000", fmt.Sprint(req.URL))
+			assert.Equal(t, "application/protobuf", req.Header.Get("Accept"))
+			response, _ := proto.Marshal(trace)
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader(response)),
+			}
+		})
+
+		client := New("www.tempo.com", "1000")
+		client.WithTransport(mockTransport)
+		response, err := client.QueryTraceWithRange("100", 1000, 2000)
+
+		assert.NoError(t, err)
+		assert.True(t, proto.Equal(trace, response))
+	})
+
+	t.Run("returns a trace with range not found error on 404", func(t *testing.T) {
+		mockTransport := MockRoundTripper(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 404,
+				Body:       nil,
+			}
+		})
+
+		client := New("www.tempo.com", "1000")
+		client.WithTransport(mockTransport)
+		response, err := client.QueryTraceWithRange("notfound", 1000, 2000)
 
 		assert.Error(t, err)
 		assert.Nil(t, response)


### PR DESCRIPTION
**WIP**

**What this PR does**:
It enables trace ID lookup for a selected time range from Tempo Vulture. This will reduce the number of blocks that Tempo has to scan to find the trace

**Which issue(s) this PR fixes**:
Fixes #3700

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`