### PR TITLE
feat: improve trace id lookup by defining a time range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 * [ENHANCEMENT] Added a Tempo CLI command to drop traces by id by rewriting blocks. [#3856](https://github.com/grafana/tempo/pull/3856)  (@joe-elliott)
 * [ENHANCEMENT] Mixin, make recording rule range interval configurable and increase range interval in alert to support scrape interval of 1 minute [#3851](https://github.com/grafana/tempo/pull/3851)  (@jmichalek132)
 * [ENHANCEMENT] Add vParquet4 support to the tempo-cli analyse blocks command [#3868](https://github.com/grafana/tempo/pull/3868) (@stoewer)
-* [ENHANCEMENT] Improve trace id lookup from Tempo Vulture by selecting a date range (@javiermolinar)
+* [ENHANCEMENT] Improve trace id lookup from Tempo Vulture by selecting a date range [#3874](https://github.com/grafana/tempo/pull/3874) (@javiermolinar)
 * [BUGFIX] Fix panic in certain metrics queries using `rate()` with `by` [#3847](https://github.com/grafana/tempo/pull/3847) (@stoewer)
 * [BUGFIX] Fix metrics queries when grouping by attributes that may not exist [#3734](https://github.com/grafana/tempo/pull/3734) (@mdisibio)
 * [BUGFIX] Fix frontend parsing error on cached responses [#3759](https://github.com/grafana/tempo/pull/3759) (@mdisibio)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [ENHANCEMENT] Added a Tempo CLI command to drop traces by id by rewriting blocks. [#3856](https://github.com/grafana/tempo/pull/3856)  (@joe-elliott)
 * [ENHANCEMENT] Mixin, make recording rule range interval configurable and increase range interval in alert to support scrape interval of 1 minute [#3851](https://github.com/grafana/tempo/pull/3851)  (@jmichalek132)
 * [ENHANCEMENT] Add vParquet4 support to the tempo-cli analyse blocks command [#3868](https://github.com/grafana/tempo/pull/3868) (@stoewer)
+* [ENHANCEMENT] Improve trace id lookup from Tempo Vulture by selecting a date range (@javiermolinar)
 * [BUGFIX] Fix panic in certain metrics queries using `rate()` with `by` [#3847](https://github.com/grafana/tempo/pull/3847) (@stoewer)
 * [BUGFIX] Fix metrics queries when grouping by attributes that may not exist [#3734](https://github.com/grafana/tempo/pull/3734) (@mdisibio)
 * [BUGFIX] Fix frontend parsing error on cached responses [#3759](https://github.com/grafana/tempo/pull/3759) (@mdisibio)

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -235,7 +235,7 @@ func queueFutureBatches(client util.JaegerClient, info *util.TraceInfo, config v
 	}()
 }
 
-func doRead(httpClient httpclient.HTTPClient, tickerRead *time.Ticker, startTime time.Time, interval time.Duration, r *rand.Rand, config vultureConfiguration, l *zap.Logger) {
+func doRead(httpClient httpclient.TempoHTTPClient, tickerRead *time.Ticker, startTime time.Time, interval time.Duration, r *rand.Rand, config vultureConfiguration, l *zap.Logger) {
 	if tickerRead != nil {
 		go func() {
 			for now := range tickerRead.C {
@@ -269,7 +269,7 @@ func doRead(httpClient httpclient.HTTPClient, tickerRead *time.Ticker, startTime
 	}
 }
 
-func doSearch(httpClient httpclient.HTTPClient, tickerSearch *time.Ticker, startTime time.Time, interval time.Duration, r *rand.Rand, config vultureConfiguration, l *zap.Logger) {
+func doSearch(httpClient httpclient.TempoHTTPClient, tickerSearch *time.Ticker, startTime time.Time, interval time.Duration, r *rand.Rand, config vultureConfiguration, l *zap.Logger) {
 	if tickerSearch != nil {
 		go func() {
 			for now := range tickerSearch.C {
@@ -394,7 +394,7 @@ func traceInTraces(traceID string, traces []*tempopb.TraceSearchMetadata) bool {
 	return false
 }
 
-func searchTag(client httpclient.HTTPClient, seed time.Time, config vultureConfiguration, l *zap.Logger) (traceMetrics, error) {
+func searchTag(client httpclient.TempoHTTPClient, seed time.Time, config vultureConfiguration, l *zap.Logger) (traceMetrics, error) {
 	tm := traceMetrics{
 		requested: 1,
 	}
@@ -443,7 +443,7 @@ func searchTag(client httpclient.HTTPClient, seed time.Time, config vultureConfi
 	return tm, nil
 }
 
-func searchTraceql(client httpclient.HTTPClient, seed time.Time, config vultureConfiguration, l *zap.Logger) (traceMetrics, error) {
+func searchTraceql(client httpclient.TempoHTTPClient, seed time.Time, config vultureConfiguration, l *zap.Logger) (traceMetrics, error) {
 	tm := traceMetrics{
 		requested: 1,
 	}
@@ -490,7 +490,7 @@ func searchTraceql(client httpclient.HTTPClient, seed time.Time, config vultureC
 	return tm, nil
 }
 
-func queryTrace(client httpclient.HTTPClient, info *util.TraceInfo, l *zap.Logger) (traceMetrics, error) {
+func queryTrace(client httpclient.TempoHTTPClient, info *util.TraceInfo, l *zap.Logger) (traceMetrics, error) {
 	tm := traceMetrics{
 		requested: 1,
 	}

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -496,15 +496,18 @@ func queryTrace(client httpclient.TempoHTTPClient, info *util.TraceInfo, l *zap.
 	}
 
 	hexID := info.HexID()
+	start := info.Timestamp().Add(-30 * time.Minute).Unix()
+	end := info.Timestamp().Add(30 * time.Minute).Unix()
 
 	logger := l.With(
 		zap.Int64("seed", info.Timestamp().Unix()),
 		zap.String("hexID", hexID),
 		zap.Duration("ago", time.Since(info.Timestamp())),
 	)
-	logger.Info("querying Tempo")
+	logger.Info("querying Tempo trace")
 
-	trace, err := client.QueryTrace(hexID)
+	// We want to define a time range to reduce the number of lookups
+	trace, err := client.QueryTraceWithRange(hexID, start, end)
 	if err != nil {
 		if errors.Is(err, util.ErrTraceNotFound) {
 			tm.notFoundByID++

--- a/cmd/tempo-vulture/mocks.go
+++ b/cmd/tempo-vulture/mocks.go
@@ -86,6 +86,17 @@ func (m *MockHTTPClient) QueryTrace(id string) (*tempopb.Trace, error) {
 	return m.traceResp, m.err
 }
 
+//nolint:all
+func (m *MockHTTPClient) QueryTraceWithRange(id string, start int64, end int64) (*tempopb.Trace, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	m.m.Lock()
+	defer m.m.Unlock()
+	m.requestsCount++
+	return m.traceResp, m.err
+}
+
 func (m *MockHTTPClient) GetRequestsCount() int {
 	m.m.Lock()
 	defer m.m.Unlock()

--- a/pkg/httpclient/client_test.go
+++ b/pkg/httpclient/client_test.go
@@ -86,7 +86,7 @@ func TestQueryTraceWithRance(t *testing.T) {
 	})
 
 	t.Run("returns a trace with range not found error on 404", func(t *testing.T) {
-		mockTransport := MockRoundTripper(func(req *http.Request) *http.Response {
+		mockTransport := MockRoundTripper(func(_ *http.Request) *http.Response {
 			return &http.Response{
 				StatusCode: 404,
 				Body:       nil,

--- a/pkg/httpclient/client_test.go
+++ b/pkg/httpclient/client_test.go
@@ -1,0 +1,103 @@
+package httpclient
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/stretchr/testify/assert"
+)
+
+type MockRoundTripper func(r *http.Request) *http.Response
+
+func (f MockRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r), nil
+}
+
+func TestQueryTrace(t *testing.T) {
+	trace := &tempopb.Trace{}
+	t.Run("returns a trace when is found", func(t *testing.T) {
+		mockTransport := MockRoundTripper(func(req *http.Request) *http.Response {
+			assert.Equal(t, "www.tempo.com/api/traces/100", req.URL.Path)
+			assert.Equal(t, "application/protobuf", req.Header.Get("Accept"))
+			response, _ := proto.Marshal(trace)
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader(response)),
+			}
+		})
+
+		client := New("www.tempo.com", "1000")
+		client.WithTransport(mockTransport)
+		response, err := client.QueryTrace("100")
+
+		assert.NoError(t, err)
+		assert.True(t, proto.Equal(trace, response))
+	})
+
+	t.Run("returns a trace not found error on 404", func(t *testing.T) {
+		mockTransport := MockRoundTripper(func(_ *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 404,
+				Body:       nil,
+			}
+		})
+
+		client := New("www.tempo.com", "1000")
+		client.WithTransport(mockTransport)
+		response, err := client.QueryTrace("notfound")
+
+		assert.Error(t, err)
+		assert.Nil(t, response)
+	})
+}
+
+func TestQueryTraceWithRance(t *testing.T) {
+	trace := &tempopb.Trace{}
+	t.Run("returns an error if start time is greater than end time", func(t *testing.T) {
+		client := New("www.tempo.com", "1000")
+		response, err := client.QueryTraceWithRange("notfound", 3000, 2000)
+
+		assert.Error(t, err)
+		assert.Nil(t, response)
+	})
+
+	t.Run("returns a trace with range when is found", func(t *testing.T) {
+		mockTransport := MockRoundTripper(func(req *http.Request) *http.Response {
+			assert.Equal(t, "www.tempo.com/api/traces/100?end=2000&start=1000", fmt.Sprint(req.URL))
+			assert.Equal(t, "application/protobuf", req.Header.Get("Accept"))
+			response, _ := proto.Marshal(trace)
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader(response)),
+			}
+		})
+
+		client := New("www.tempo.com", "1000")
+		client.WithTransport(mockTransport)
+		response, err := client.QueryTraceWithRange("100", 1000, 2000)
+
+		assert.NoError(t, err)
+		assert.True(t, proto.Equal(trace, response))
+	})
+
+	t.Run("returns a trace with range not found error on 404", func(t *testing.T) {
+		mockTransport := MockRoundTripper(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 404,
+				Body:       nil,
+			}
+		})
+
+		client := New("www.tempo.com", "1000")
+		client.WithTransport(mockTransport)
+		response, err := client.QueryTraceWithRange("notfound", 1000, 2000)
+
+		assert.Error(t, err)
+		assert.Nil(t, response)
+	})
+}


### PR DESCRIPTION
**What this PR does**:
It enables trace ID lookup for a selected time range from Tempo Vulture. This will reduce the number of blocks that Tempo has to scan to find the trace

**Which issue(s) this PR fixes**:
Fixes #3700

**Checklist**
- [ X] Tests updated
- [ X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`