### PR TITLE
feat: expose availability-zone as a cli flag for ingester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 * [BUGFIX] Improved handling of complete blocks in localblocks processor after enabling flusing [#3805](https://github.com/grafana/tempo/pull/3805) (@mapno)
 * [BUGFIX] Handle out of boundaries spans kinds [#3861](https://github.com/grafana/tempo/pull/3861) (@javiermolinar)
 * [BUGFIX] Maintain previous tenant blocklist on tenant errors [#3860](https://github.com/grafana/tempo/pull/3860) (@zalegrala)
-* [ENHANCEMENT] expose availability-zone as a cli flag in ingester 
+* [ENHANCEMENT] expose availability-zone as a cli flag in ingester [#3881](https://github.com/grafana/tempo/pull/3881)
 
 
 ## v2.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * [BUGFIX] Improved handling of complete blocks in localblocks processor after enabling flusing [#3805](https://github.com/grafana/tempo/pull/3805) (@mapno)
 * [BUGFIX] Handle out of boundaries spans kinds [#3861](https://github.com/grafana/tempo/pull/3861) (@javiermolinar)
 * [BUGFIX] Maintain previous tenant blocklist on tenant errors [#3860](https://github.com/grafana/tempo/pull/3860) (@zalegrala)
+* [ENHANCEMENT] expose availability-zone as a cli flag in ingester 
 
 
 ## v2.5.0

--- a/modules/ingester/config.go
+++ b/modules/ingester/config.go
@@ -48,7 +48,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	f.DurationVar(&cfg.MaxBlockDuration, prefix+".max-block-duration", 30*time.Minute, "Maximum duration which the head block can be appended to before cutting it.")
 	f.Uint64Var(&cfg.MaxBlockBytes, prefix+".max-block-bytes", 500*1024*1024, "Maximum size of the head block before cutting it.")
 	f.DurationVar(&cfg.CompleteBlockTimeout, prefix+".complete-block-timeout", 3*tempodb.DefaultBlocklistPoll, "Duration to keep blocks in the ingester after they have been flushed.")
-	f.StringVar(&cfg.LifecyclerConfig.Zone, prefix+".availability-zone", "default-zone", "Define Availability Zone in which this ingester is running in")
+	f.StringVar(&cfg.LifecyclerConfig.Zone, prefix+".availability-zone", "", "Define Availability Zone in which this ingester is running in")
 
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/modules/ingester/config.go
+++ b/modules/ingester/config.go
@@ -48,7 +48,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	f.DurationVar(&cfg.MaxBlockDuration, prefix+".max-block-duration", 30*time.Minute, "Maximum duration which the head block can be appended to before cutting it.")
 	f.Uint64Var(&cfg.MaxBlockBytes, prefix+".max-block-bytes", 500*1024*1024, "Maximum size of the head block before cutting it.")
 	f.DurationVar(&cfg.CompleteBlockTimeout, prefix+".complete-block-timeout", 3*tempodb.DefaultBlocklistPoll, "Duration to keep blocks in the ingester after they have been flushed.")
-	f.StringVar(&cfg.LifecyclerConfig.Zone, prefix+".availability-zone", "", "Define Availability Zone in which this ingester is running in")
+	f.StringVar(&cfg.LifecyclerConfig.Zone, prefix+".availability-zone", "", "Define Availability Zone in which this ingester is running.")
 
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/modules/ingester/config.go
+++ b/modules/ingester/config.go
@@ -48,6 +48,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	f.DurationVar(&cfg.MaxBlockDuration, prefix+".max-block-duration", 30*time.Minute, "Maximum duration which the head block can be appended to before cutting it.")
 	f.Uint64Var(&cfg.MaxBlockBytes, prefix+".max-block-bytes", 500*1024*1024, "Maximum size of the head block before cutting it.")
 	f.DurationVar(&cfg.CompleteBlockTimeout, prefix+".complete-block-timeout", 3*tempodb.DefaultBlocklistPoll, "Duration to keep blocks in the ingester after they have been flushed.")
+	f.StringVar(&cfg.LifecyclerConfig.Zone, prefix+"availability-zone", "default-zone", "Define Availability Zone in which this ingester is running in")
 
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/modules/ingester/config.go
+++ b/modules/ingester/config.go
@@ -48,7 +48,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	f.DurationVar(&cfg.MaxBlockDuration, prefix+".max-block-duration", 30*time.Minute, "Maximum duration which the head block can be appended to before cutting it.")
 	f.Uint64Var(&cfg.MaxBlockBytes, prefix+".max-block-bytes", 500*1024*1024, "Maximum size of the head block before cutting it.")
 	f.DurationVar(&cfg.CompleteBlockTimeout, prefix+".complete-block-timeout", 3*tempodb.DefaultBlocklistPoll, "Duration to keep blocks in the ingester after they have been flushed.")
-	f.StringVar(&cfg.LifecyclerConfig.Zone, prefix+"availability-zone", "default-zone", "Define Availability Zone in which this ingester is running in")
+	f.StringVar(&cfg.LifecyclerConfig.Zone, prefix+".availability-zone", "default-zone", "Define Availability Zone in which this ingester is running in")
 
 	hostname, err := os.Hostname()
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

expose availability-zone cli flag (needed for zone aware ingester in helm chart) 

**Which issue(s) this PR fixes**:
Fixes #3877 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`