### PR TITLE
TraceQL Metrics: skip blocks with no overlap

### DIFF
--- a/modules/frontend/metrics_query_range_sharder.go
+++ b/modules/frontend/metrics_query_range_sharder.go
@@ -378,7 +378,7 @@ func (s *queryRangeSharder) buildBackendRequests(ctx context.Context, tenantID s
 			// size savings but the main thing is that the response is reuseable for any overlapping query.
 			start, end, step := traceql.TrimToOverlap(searchReq.Start, searchReq.End, searchReq.Step, uint64(m.StartTime.UnixNano()), uint64(m.EndTime.UnixNano()))
 			if start == end || step == 0 {
-				level.Warn(s.logger).Log("invalid start/step end. skipping", "start", start, "end", end, "step", step, "blockStart", m.StartTime.UnixNano(), "blockEnd", m.EndTime.UnixNano())
+				level.Warn(s.logger).Log("msg", "invalid start/step end. skipping", "start", start, "end", end, "step", step, "blockStart", m.StartTime.UnixNano(), "blockEnd", m.EndTime.UnixNano())
 				continue
 			}
 


### PR DESCRIPTION
**What this PR does**:
Given an unknown set of conditions the query frontend can issue commands to the queriers on blocks where start = end and the step is 0s. This materializes in the frontend with the error:

```
end must be greater than start
```

This has been most commonly observed when the duration is the last 15m and query_backend_after is also set to 15m.

Example query-frontend query:
```
GET /tempo/api/metrics/query_range?query=%7BnestedSetParent%3C0%26%26resource.cluster%3D%22dev-us-central-0%22%7D%20%7C%20histogram_over_time(duration)&start=1721402456&end=1721403356&step=37s (500) 173.192079ms Response: \"end must be greater than start\\n\
```

gets translated to the following. note that start = end and step = 0
```
GET /querier/tempo/api/metrics/query_range?blockID=948dc707-4945-45bb-be66-cc5c7af273a1&dc=%5B%7B%22name%22%3A%22db.statement%22%7D%2C%7B%22name%22%3A%22component%22%7D%2C%7B%22name%22%3A%22http.user_agent%22%7D%2C%7B%22name%22%3A%22otel.library.name%22%7D%2C%7B%22name%22%3A%22db.connection_string%22%7D%2C%7B%22name%22%3A%22organization%22%7D%2C%7B%22name%22%3A%22peer.address%22%7D%2C%7B%22name%22%3A%22net.peer.name%22%7D%2C%7B%22name%22%3A%22blockID%22%7D%2C%7B%22name%22%3A%22db.name%22%7D%2C%7B%22scope%22%3A1%2C%22name%22%3A%22host.name%22%7D%2C%7B%22scope%22%3A1%2C%22name%22%3A%22opencensus.exporterversion%22%7D%2C%7B%22scope%22%3A1%2C%22name%22%3A%22client-uuid%22%7D%2C%7B%22scope%22%3A1%2C%22name%22%3A%22ip%22%7D%2C%7B%22scope%22%3A1%2C%22name%22%3A%22database%22%7D%2C%7B%22scope%22%3A1%2C%22name%22%3A%22os.description%22%7D%2C%7B%22scope%22%3A1%2C%22name%22%3A%22process.runtime.description%22%7D%2C%7B%22scope%22%3A1%2C%22name%22%3A%22container.id%22%7D%2C%7B%22scope%22%3A1%2C%22name%22%3A%22slug%22%7D%2C%7B%22scope%22%3A1%2C%22name%22%3A%22module.path%22%7D%5D&encoding=none&end=1721402467000000000&footerSize=21122&mode=&pagesToSearch=3&q=%7BnestedSetParent%3C0%26%26resource.cluster%3D%22dev-us-central-0%22%7D+%7C+histogram_over_time%28duration%29&query=%7BnestedSetParent%3C0%26%26resource.cluster%3D%22dev-us-central-0%22%7D+%7C+histogram_over_time%28duration%29&shard=0&shardCount=0&size=27962060&start=1721402467000000000&startPage=0&step=0s&version=vParquet4 (500) 498.912µs Response: \"end must be greater than start\\n\
```