### PR TITLE
Query-frontend: Performance Improvements and Refactor

### DIFF
--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -218,7 +218,7 @@ func newMetricsSummaryHandler(next pipeline.AsyncRoundTripper[combiner.PipelineR
 			"tenant", tenant,
 			"path", req.URL.Path)
 
-		resps, err := next.RoundTrip(req)
+		resps, err := next.RoundTrip(pipeline.NewHTTPRequest(req))
 		if err != nil {
 			return nil, err
 		}

--- a/modules/frontend/metrics_query_handler.go
+++ b/modules/frontend/metrics_query_handler.go
@@ -80,7 +80,7 @@ func newQueryInstantStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTri
 func newMetricsQueryInstantHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], logger log.Logger) http.RoundTripper {
 	postSLOHook := metricsSLOPostHook(cfg.Metrics.SLO)
 
-	return pipeline.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		tenant, _ := user.ExtractOrgID(req.Context())
 		start := time.Now()
 

--- a/modules/frontend/metrics_query_range_handler.go
+++ b/modules/frontend/metrics_query_range_handler.go
@@ -65,7 +65,7 @@ func newQueryRangeStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripp
 func newMetricsQueryRangeHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], logger log.Logger) http.RoundTripper {
 	postSLOHook := metricsSLOPostHook(cfg.Metrics.SLO)
 
-	return pipeline.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		tenant, _ := user.ExtractOrgID(req.Context())
 		start := time.Now()
 

--- a/modules/frontend/metrics_query_range_sharder.go
+++ b/modules/frontend/metrics_query_range_sharder.go
@@ -64,7 +64,9 @@ func newAsyncQueryRangeSharder(reader tempodb.Reader, o overrides.Interface, cfg
 	})
 }
 
-func (s queryRangeSharder) RoundTrip(r *http.Request) (pipeline.Responses[combiner.PipelineResponse], error) {
+func (s queryRangeSharder) RoundTrip(pipelineRequest pipeline.Request) (pipeline.Responses[combiner.PipelineResponse], error) {
+	r := pipelineRequest.HTTPRequest()
+
 	span, ctx := opentracing.StartSpanFromContext(r.Context(), "frontend.QueryRangeSharder")
 	defer span.Finish()
 

--- a/modules/frontend/metrics_query_range_sharder.go
+++ b/modules/frontend/metrics_query_range_sharder.go
@@ -404,7 +404,7 @@ func (s *queryRangeSharder) buildBackendRequests(ctx context.Context, tenantID s
 			subR = api.BuildQueryRangeRequest(subR, queryRangeReq)
 			subR.Header.Set(api.HeaderAccept, api.HeaderAcceptProtobuf)
 
-			prepareRequestForQueriers(subR, tenantID, subR.URL.Path, subR.URL.Query())
+			prepareRequestForQueriers(subR, tenantID)
 			// TODO: Handle sampling rate
 			key := queryRangeCacheKey(tenantID, queryHash, int64(queryRangeReq.Start), int64(queryRangeReq.End), m, int(queryRangeReq.StartPage), int(queryRangeReq.PagesToSearch))
 			if len(key) > 0 {
@@ -440,7 +440,7 @@ func (s *queryRangeSharder) toUpstreamRequest(ctx context.Context, req tempopb.Q
 	subR := parent.Clone(ctx)
 	subR = api.BuildQueryRangeRequest(subR, &req)
 
-	prepareRequestForQueriers(subR, tenantID, parent.URL.Path, subR.URL.Query())
+	prepareRequestForQueriers(subR, tenantID)
 	return subR
 }
 

--- a/modules/frontend/pipeline/async_handler_noop.go
+++ b/modules/frontend/pipeline/async_handler_noop.go
@@ -1,15 +1,13 @@
 package pipeline
 
 import (
-	"net/http"
-
 	"github.com/grafana/tempo/modules/frontend/combiner"
 )
 
 // NewNoopMiddleware returns a middleware that is a passthrough only
 func NewNoopMiddleware() AsyncMiddleware[combiner.PipelineResponse] {
 	return AsyncMiddlewareFunc[combiner.PipelineResponse](func(next AsyncRoundTripper[combiner.PipelineResponse]) AsyncRoundTripper[combiner.PipelineResponse] {
-		return AsyncRoundTripperFunc[combiner.PipelineResponse](func(req *http.Request) (Responses[combiner.PipelineResponse], error) {
+		return AsyncRoundTripperFunc[combiner.PipelineResponse](func(req Request) (Responses[combiner.PipelineResponse], error) {
 			return next.RoundTrip(req)
 		})
 	})

--- a/modules/frontend/pipeline/async_sharding.go
+++ b/modules/frontend/pipeline/async_sharding.go
@@ -2,7 +2,6 @@ package pipeline
 
 import (
 	"context"
-	"net/http"
 	"sync"
 
 	"github.com/grafana/tempo/modules/frontend/combiner"
@@ -17,7 +16,7 @@ type waitGroup interface {
 
 // NewAsyncSharderFunc creates a new AsyncResponse that shards requests to the next AsyncRoundTripper[combiner.PipelineResponse]. It creates one
 // goroutine per concurrent request.
-func NewAsyncSharderFunc(ctx context.Context, concurrentReqs, totalReqs int, reqFn func(i int) *http.Request, next AsyncRoundTripper[combiner.PipelineResponse]) Responses[combiner.PipelineResponse] {
+func NewAsyncSharderFunc(ctx context.Context, concurrentReqs, totalReqs int, reqFn func(i int) Request, next AsyncRoundTripper[combiner.PipelineResponse]) Responses[combiner.PipelineResponse] {
 	var wg waitGroup
 	if concurrentReqs <= 0 {
 		wg = &sync.WaitGroup{}
@@ -43,10 +42,10 @@ func NewAsyncSharderFunc(ctx context.Context, concurrentReqs, totalReqs int, req
 			}
 
 			wg.Add(1)
-			go func(r *http.Request) {
+			go func(r Request) {
 				defer wg.Done()
 
-				resp, err := next.RoundTrip(NewHTTPRequest(r))
+				resp, err := next.RoundTrip(r)
 				if err != nil {
 					asyncResp.SendError(err)
 					return
@@ -63,7 +62,7 @@ func NewAsyncSharderFunc(ctx context.Context, concurrentReqs, totalReqs int, req
 }
 
 // NewAsyncSharderChan creates a new AsyncResponse that shards requests to the next AsyncRoundTripper[combiner.PipelineResponse] using a limited number of goroutines.
-func NewAsyncSharderChan(ctx context.Context, concurrentReqs int, reqs <-chan *http.Request, resps Responses[combiner.PipelineResponse], next AsyncRoundTripper[combiner.PipelineResponse]) Responses[combiner.PipelineResponse] {
+func NewAsyncSharderChan(ctx context.Context, concurrentReqs int, reqs <-chan Request, resps Responses[combiner.PipelineResponse], next AsyncRoundTripper[combiner.PipelineResponse]) Responses[combiner.PipelineResponse] {
 	if concurrentReqs == 0 {
 		panic("NewAsyncSharderChan: concurrentReqs must be greater than 0")
 	}
@@ -81,7 +80,7 @@ func NewAsyncSharderChan(ctx context.Context, concurrentReqs int, reqs <-chan *h
 					continue
 				}
 
-				resp, err := next.RoundTrip(NewHTTPRequest(req))
+				resp, err := next.RoundTrip(req)
 				if err != nil {
 					asyncResp.SendError(err)
 					continue

--- a/modules/frontend/pipeline/async_sharding.go
+++ b/modules/frontend/pipeline/async_sharding.go
@@ -46,7 +46,7 @@ func NewAsyncSharderFunc(ctx context.Context, concurrentReqs, totalReqs int, req
 			go func(r *http.Request) {
 				defer wg.Done()
 
-				resp, err := next.RoundTrip(r)
+				resp, err := next.RoundTrip(NewHTTPRequest(r))
 				if err != nil {
 					asyncResp.SendError(err)
 					return
@@ -81,7 +81,7 @@ func NewAsyncSharderChan(ctx context.Context, concurrentReqs int, reqs <-chan *h
 					continue
 				}
 
-				resp, err := next.RoundTrip(req)
+				resp, err := next.RoundTrip(NewHTTPRequest(req))
 				if err != nil {
 					asyncResp.SendError(err)
 					continue

--- a/modules/frontend/pipeline/async_sharding_test.go
+++ b/modules/frontend/pipeline/async_sharding_test.go
@@ -22,32 +22,32 @@ func TestAsyncSharders(t *testing.T) {
 		{
 			name: "AsyncSharder",
 			responseFn: func(next AsyncRoundTripper[combiner.PipelineResponse]) *asyncResponse {
-				return NewAsyncSharderFunc(context.Background(), 10, expectedRequestCount, func(i int) *http.Request {
+				return NewAsyncSharderFunc(context.Background(), 10, expectedRequestCount, func(i int) Request {
 					if i >= expectedRequestCount {
 						return nil
 					}
-					return &http.Request{}
+					return NewHTTPRequest(&http.Request{})
 				}, next).(*asyncResponse)
 			},
 		},
 		{
 			name: "AsyncSharder - no limit",
 			responseFn: func(next AsyncRoundTripper[combiner.PipelineResponse]) *asyncResponse {
-				return NewAsyncSharderFunc(context.Background(), 0, expectedRequestCount, func(i int) *http.Request {
+				return NewAsyncSharderFunc(context.Background(), 0, expectedRequestCount, func(i int) Request {
 					if i >= expectedRequestCount {
 						return nil
 					}
-					return &http.Request{}
+					return NewHTTPRequest(&http.Request{})
 				}, next).(*asyncResponse)
 			},
 		},
 		{
 			name: "AsyncSharderLimitedGoroutines",
 			responseFn: func(next AsyncRoundTripper[combiner.PipelineResponse]) *asyncResponse {
-				reqChan := make(chan *http.Request)
+				reqChan := make(chan Request)
 				go func() {
 					for i := 0; i < expectedRequestCount; i++ {
-						reqChan <- &http.Request{}
+						reqChan <- NewHTTPRequest(&http.Request{})
 					}
 					close(reqChan)
 				}()

--- a/modules/frontend/pipeline/async_sharding_test.go
+++ b/modules/frontend/pipeline/async_sharding_test.go
@@ -59,7 +59,7 @@ func TestAsyncSharders(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			next := AsyncRoundTripperFunc[combiner.PipelineResponse](func(r *http.Request) (Responses[combiner.PipelineResponse], error) {
+			next := AsyncRoundTripperFunc[combiner.PipelineResponse](func(r Request) (Responses[combiner.PipelineResponse], error) {
 				// return a generic 200
 				return NewHTTPToAsyncResponse(&http.Response{
 					Body:       io.NopCloser(strings.NewReader("")),

--- a/modules/frontend/pipeline/collector_grpc.go
+++ b/modules/frontend/pipeline/collector_grpc.go
@@ -34,7 +34,7 @@ func (c GRPCCollector[T]) RoundTrip(req *http.Request) error {
 	defer cancel()
 
 	req = req.WithContext(ctx)
-	resps, err := c.next.RoundTrip(req)
+	resps, err := c.next.RoundTrip(NewHTTPRequest(req))
 	if err != nil {
 		return grpcError(err)
 	}

--- a/modules/frontend/pipeline/collector_http.go
+++ b/modules/frontend/pipeline/collector_http.go
@@ -34,7 +34,7 @@ func (r httpCollector) RoundTrip(req *http.Request) (*http.Response, error) {
 	defer cancel()
 	req = req.WithContext(ctx)
 
-	resps, err := r.next.RoundTrip(req)
+	resps, err := r.next.RoundTrip(NewHTTPRequest(req))
 	if err != nil {
 		return nil, err
 	}

--- a/modules/frontend/pipeline/context.go
+++ b/modules/frontend/pipeline/context.go
@@ -7,13 +7,6 @@ import (
 
 // this file exists to consolidate and clearly document all context keys that are valid and recognized by the pipeline package
 
-// contextCacheKey is used by cachingWare to store the cache key in the request context. It stores a string value.
-var contextCacheKey = struct{}{}
-
-func ContextAddCacheKey(key string, req *http.Request) *http.Request {
-	return req.WithContext(context.WithValue(req.Context(), contextCacheKey, key))
-}
-
 // contextEchoData is used to echo request specific data through the pipeline. It stores any value.
 // see usage for samplingRate in modules/frontend/metrics_query_range_sharder.go
 var contextRequestDataForResponse = struct{}{}

--- a/modules/frontend/pipeline/pipeline.go
+++ b/modules/frontend/pipeline/pipeline.go
@@ -10,14 +10,19 @@ import (
 type Request interface {
 	HTTPRequest() *http.Request
 	Context() context.Context
+
+	SetCacheKey(string)
+	CacheKey() string
 }
 
 type HTTPRequest struct {
 	req *http.Request
+
+	cacheKey string
 }
 
-func NewHTTPRequest(req *http.Request) HTTPRequest {
-	return HTTPRequest{req: req}
+func NewHTTPRequest(req *http.Request) *HTTPRequest {
+	return &HTTPRequest{req: req}
 }
 
 func (r HTTPRequest) HTTPRequest() *http.Request {
@@ -30,6 +35,14 @@ func (r HTTPRequest) Context() context.Context {
 	}
 
 	return r.req.Context()
+}
+
+func (r *HTTPRequest) SetCacheKey(s string) {
+	r.cacheKey = s
+}
+
+func (r *HTTPRequest) CacheKey() string {
+	return r.cacheKey
 }
 
 //

--- a/modules/frontend/pipeline/responses_test.go
+++ b/modules/frontend/pipeline/responses_test.go
@@ -398,15 +398,15 @@ func (s sharder) RoundTrip(r Request) (Responses[combiner.PipelineResponse], err
 
 	// execute requests
 	if s.funcSharder {
-		return NewAsyncSharderFunc(r.HTTPRequest().Context(), concurrent, total, func(i int) *http.Request {
-			return r.HTTPRequest()
+		return NewAsyncSharderFunc(r.HTTPRequest().Context(), concurrent, total, func(i int) Request {
+			return r
 		}, s.next), nil
 	}
 
-	reqCh := make(chan *http.Request)
+	reqCh := make(chan Request)
 	go func() {
 		for i := 0; i < total; i++ {
-			reqCh <- r.HTTPRequest()
+			reqCh <- r
 		}
 		close(reqCh)
 	}()

--- a/modules/frontend/pipeline/responses_test.go
+++ b/modules/frontend/pipeline/responses_test.go
@@ -214,7 +214,7 @@ func TestAsyncResponsesDoesNotLeak(t *testing.T) {
 		{
 			name: "happy path",
 			finalRT: func(_ context.CancelFunc) RoundTripperFunc {
-				return RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				return RoundTripperFunc(func(r Request) (*http.Response, error) {
 					return &http.Response{
 						Body: io.NopCloser(strings.NewReader("foo")),
 					}, nil
@@ -224,7 +224,7 @@ func TestAsyncResponsesDoesNotLeak(t *testing.T) {
 		{
 			name: "error path",
 			finalRT: func(_ context.CancelFunc) RoundTripperFunc {
-				return RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				return RoundTripperFunc(func(r Request) (*http.Response, error) {
 					return nil, errors.New("foo")
 				})
 			},
@@ -234,7 +234,7 @@ func TestAsyncResponsesDoesNotLeak(t *testing.T) {
 			finalRT: func(_ context.CancelFunc) RoundTripperFunc {
 				responseCounter := atomic.Int32{}
 
-				return RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				return RoundTripperFunc(func(r Request) (*http.Response, error) {
 					counter := responseCounter.Add(1)
 					if counter == 2 {
 						return &http.Response{
@@ -257,7 +257,7 @@ func TestAsyncResponsesDoesNotLeak(t *testing.T) {
 					cancel()
 				}()
 
-				return RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				return RoundTripperFunc(func(r Request) (*http.Response, error) {
 					time.Sleep(3 * time.Second)
 
 					return &http.Response{
@@ -274,7 +274,7 @@ func TestAsyncResponsesDoesNotLeak(t *testing.T) {
 			finalRT: func(cancel context.CancelFunc) RoundTripperFunc {
 				responseCounter := atomic.Int32{}
 
-				return RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				return RoundTripperFunc(func(r Request) (*http.Response, error) {
 					counter := responseCounter.Add(1)
 					if counter == 2 {
 						cancel()

--- a/modules/frontend/pipeline/sync_handler_adjust_response_code.go
+++ b/modules/frontend/pipeline/sync_handler_adjust_response_code.go
@@ -5,7 +5,7 @@ import (
 )
 
 type statusCodeAdjustWare struct {
-	next        http.RoundTripper
+	next        RoundTripper
 	allowedCode int
 }
 
@@ -13,7 +13,7 @@ type statusCodeAdjustWare struct {
 // This is necessary because the queriers may return 4xx status codes for bad requests, but we want to represent
 // these as 500s to the rest of the pipeline. This also allows the rest of the pipeline to return 4xxs that can be trusted.
 func NewStatusCodeAdjustWare() Middleware {
-	return MiddlewareFunc(func(next http.RoundTripper) http.RoundTripper {
+	return MiddlewareFunc(func(next RoundTripper) RoundTripper {
 		return statusCodeAdjustWare{
 			next: next,
 		}
@@ -21,7 +21,7 @@ func NewStatusCodeAdjustWare() Middleware {
 }
 
 func NewStatusCodeAdjustWareWithAllowedCode(code int) Middleware {
-	return MiddlewareFunc(func(next http.RoundTripper) http.RoundTripper {
+	return MiddlewareFunc(func(next RoundTripper) RoundTripper {
 		return statusCodeAdjustWare{
 			next:        next,
 			allowedCode: code,
@@ -30,7 +30,7 @@ func NewStatusCodeAdjustWareWithAllowedCode(code int) Middleware {
 }
 
 // RoundTrip implements http.RoundTripper
-func (c statusCodeAdjustWare) RoundTrip(req *http.Request) (*http.Response, error) {
+func (c statusCodeAdjustWare) RoundTrip(req Request) (*http.Response, error) {
 	resp, err := c.next.RoundTrip(req)
 	if err != nil {
 		return resp, err

--- a/modules/frontend/pipeline/sync_handler_adjust_response_code_test.go
+++ b/modules/frontend/pipeline/sync_handler_adjust_response_code_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestAdjustsResponseCode(t *testing.T) {
-	nextFn := func(status int) http.RoundTripper {
-		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+	nextFn := func(status int) RoundTripper {
+		return RoundTripperFunc(func(req Request) (*http.Response, error) {
 			return &http.Response{StatusCode: status}, nil
 		})
 	}
@@ -30,7 +30,7 @@ func TestAdjustsResponseCode(t *testing.T) {
 		retryWare := NewStatusCodeAdjustWare()
 		handler := retryWare.Wrap(nextFn(tc.actualCode))
 		req := httptest.NewRequest("GET", "http://example.com", nil)
-		res, err := handler.RoundTrip(req)
+		res, err := handler.RoundTrip(NewHTTPRequest(req))
 
 		require.NoError(t, err)
 		require.Equal(t, res.StatusCode, tc.expectedCode)
@@ -38,8 +38,8 @@ func TestAdjustsResponseCode(t *testing.T) {
 }
 
 func TestAdjustsResponseCodeTeapotAllowed(t *testing.T) {
-	nextFn := func(status int) http.RoundTripper {
-		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+	nextFn := func(status int) RoundTripper {
+		return RoundTripperFunc(func(req Request) (*http.Response, error) {
 			return &http.Response{StatusCode: status}, nil
 		})
 	}
@@ -59,7 +59,7 @@ func TestAdjustsResponseCodeTeapotAllowed(t *testing.T) {
 		retryWare := NewStatusCodeAdjustWareWithAllowedCode(418)
 		handler := retryWare.Wrap(nextFn(tc.actualCode))
 		req := httptest.NewRequest("GET", "http://example.com", nil)
-		res, err := handler.RoundTrip(req)
+		res, err := handler.RoundTrip(NewHTTPRequest(req))
 
 		require.NoError(t, err)
 		require.Equal(t, res.StatusCode, tc.expectedCode)

--- a/modules/frontend/pipeline/sync_handler_cache.go
+++ b/modules/frontend/pipeline/sync_handler_cache.go
@@ -15,7 +15,7 @@ import (
 )
 
 func NewCachingWare(cacheProvider cache.Provider, role cache.Role, logger log.Logger) Middleware {
-	return MiddlewareFunc(func(next http.RoundTripper) http.RoundTripper {
+	return MiddlewareFunc(func(next RoundTripper) RoundTripper {
 		return cachingWare{
 			next:  next,
 			cache: newFrontendCache(cacheProvider, role, logger),
@@ -24,19 +24,19 @@ func NewCachingWare(cacheProvider cache.Provider, role cache.Role, logger log.Lo
 }
 
 type cachingWare struct {
-	next  http.RoundTripper
+	next  RoundTripper
 	cache *frontendCache
 }
 
 // RoundTrip implements http.RoundTripper
-func (c cachingWare) RoundTrip(req *http.Request) (*http.Response, error) {
+func (c cachingWare) RoundTrip(req Request) (*http.Response, error) {
 	// short circuit everything if there cache is no cache
 	if c.cache == nil {
 		return c.next.RoundTrip(req)
 	}
 
 	// extract cache key
-	key := "foo" //ok := req.Context().Value(contextCacheKey).(string)
+	key := req.CacheKey()
 	if len(key) > 0 {
 		body := c.cache.fetchBytes(key)
 		if len(body) > 0 {

--- a/modules/frontend/pipeline/sync_handler_cache.go
+++ b/modules/frontend/pipeline/sync_handler_cache.go
@@ -36,8 +36,8 @@ func (c cachingWare) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	// extract cache key
-	key, ok := req.Context().Value(contextCacheKey).(string)
-	if ok && len(key) > 0 {
+	key := "foo" //ok := req.Context().Value(contextCacheKey).(string)
+	if len(key) > 0 {
 		body := c.cache.fetchBytes(key)
 		if len(body) > 0 {
 			resp := &http.Response{

--- a/modules/frontend/search_handlers.go
+++ b/modules/frontend/search_handlers.go
@@ -74,7 +74,7 @@ func newSearchStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[c
 func newSearchHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], logger log.Logger) http.RoundTripper {
 	postSLOHook := searchSLOPostHook(cfg.Search.SLO)
 
-	return pipeline.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		tenant, _ := user.ExtractOrgID(req.Context())
 		start := time.Now()
 

--- a/modules/frontend/search_handlers_test.go
+++ b/modules/frontend/search_handlers_test.go
@@ -660,9 +660,52 @@ func cacheResponsesEqual(t *testing.T, cacheResponse *tempopb.SearchResponse, pi
 	require.Equal(t, pipelineResp, cacheResponse)
 }
 
+func BenchmarkSearchPipeline(b *testing.B) {
+	tenant := "foo"
+
+	// create 500 blocks. each is forces one job
+	totalBlocks := 500
+	rdr := &mockReader{
+		metas: make([]*backend.BlockMeta, 0, totalBlocks),
+	}
+	for i := 0; i < totalBlocks; i++ {
+		rdr.metas = append(rdr.metas, &backend.BlockMeta{
+			StartTime:    time.Unix(15, 0),
+			EndTime:      time.Unix(16, 0),
+			Size:         defaultTargetBytesPerRequest,
+			TotalRecords: 1,
+			BlockID:      uuid.MustParse(fmt.Sprintf("00000000-0000-0000-0000-%012d", i)),
+		})
+	}
+
+	f := frontendWithSettings(b, nil, rdr, nil, nil)
+
+	// setup query
+	query := "{}"
+
+	start := uint32(10)
+	end := uint32(20)
+
+	// execute query
+	path := fmt.Sprintf("/?start=%d&end=%d&q=%s&limit=3&spss=2", start, end, query) // encapsulates block above
+	req := httptest.NewRequest("GET", path, nil)
+	ctx := req.Context()
+	ctx = user.InjectOrgID(ctx, tenant)
+	req = req.WithContext(ctx)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		respWriter := httptest.NewRecorder()
+		f.SearchHandler.ServeHTTP(respWriter, req)
+
+		resp := respWriter.Result()
+		require.Equal(b, 200, resp.StatusCode)
+	}
+}
+
 // frontendWithSettings returns a new frontend with the given settings. any nil options
 // are given "happy path" defaults
-func frontendWithSettings(t *testing.T, next http.RoundTripper, rdr tempodb.Reader, cfg *Config, cacheProvider cache.Provider,
+func frontendWithSettings(t require.TestingT, next http.RoundTripper, rdr tempodb.Reader, cfg *Config, cacheProvider cache.Provider,
 	opts ...func(*Config),
 ) *QueryFrontend {
 	if next == nil {

--- a/modules/frontend/search_sharder.go
+++ b/modules/frontend/search_sharder.go
@@ -93,7 +93,7 @@ func (s asyncSearchSharder) RoundTrip(pipelineRequest pipeline.Request) (pipelin
 	}
 
 	// buffer of shards+1 allows us to insert ingestReq and metrics
-	reqCh := make(chan *http.Request, s.cfg.IngesterShards+1)
+	reqCh := make(chan pipeline.Request, s.cfg.IngesterShards+1)
 
 	// build request to search ingesters based on query_ingesters_until config and time range
 	// pass subCtx in requests so we can cancel and exit early
@@ -155,7 +155,7 @@ func (s *asyncSearchSharder) blockMetas(start, end int64, tenantID string) []*ba
 
 // backendRequest builds backend requests to search backend blocks. backendRequest takes ownership of reqCh and closes it.
 // it returns 3 int values: totalBlocks, totalBlockBytes, and estimated jobs
-func (s *asyncSearchSharder) backendRequests(ctx context.Context, tenantID string, parent *http.Request, searchReq *tempopb.SearchRequest, reqCh chan<- *http.Request, errFn func(error)) (totalJobs, totalBlocks int, totalBlockBytes uint64) {
+func (s *asyncSearchSharder) backendRequests(ctx context.Context, tenantID string, parent *http.Request, searchReq *tempopb.SearchRequest, reqCh chan<- pipeline.Request, errFn func(error)) (totalJobs, totalBlocks int, totalBlockBytes uint64) {
 	var blocks []*backend.BlockMeta
 
 	// request without start or end, search only in ingester
@@ -201,7 +201,7 @@ func (s *asyncSearchSharder) backendRequests(ctx context.Context, tenantID strin
 // that covers the ingesters. If nil is returned for the http.Request then there is no ingesters query.
 // since this function modifies searchReq.Start and End we are taking a value instead of a pointer to prevent it from
 // unexpectedly changing the passed searchReq.
-func (s *asyncSearchSharder) ingesterRequests(ctx context.Context, tenantID string, parent *http.Request, searchReq tempopb.SearchRequest, reqCh chan *http.Request) error {
+func (s *asyncSearchSharder) ingesterRequests(ctx context.Context, tenantID string, parent *http.Request, searchReq tempopb.SearchRequest, reqCh chan pipeline.Request) error {
 	// request without start or end, search only in ingester
 	if searchReq.Start == 0 || searchReq.End == 0 {
 		return buildIngesterRequest(ctx, tenantID, parent, &searchReq, reqCh)
@@ -299,7 +299,7 @@ func backendRange(start, end uint32, queryBackendAfter time.Duration) (uint32, u
 
 // buildBackendRequests returns a slice of requests that cover all blocks in the store
 // that are covered by start/end.
-func buildBackendRequests(ctx context.Context, tenantID string, parent *http.Request, searchReq *tempopb.SearchRequest, metas []*backend.BlockMeta, bytesPerRequest int, reqCh chan<- *http.Request, errFn func(error)) {
+func buildBackendRequests(ctx context.Context, tenantID string, parent *http.Request, searchReq *tempopb.SearchRequest, metas []*backend.BlockMeta, bytesPerRequest int, reqCh chan<- pipeline.Request, errFn func(error)) {
 	defer close(reqCh)
 
 	queryHash := hashForSearchRequest(searchReq)
@@ -340,12 +340,11 @@ func buildBackendRequests(ctx context.Context, tenantID string, parent *http.Req
 
 			prepareRequestForQueriers(subR, tenantID)
 			key := searchJobCacheKey(tenantID, queryHash, int64(searchReq.Start), int64(searchReq.End), m, startPage, pages)
-			if len(key) > 0 {
-				subR = pipeline.ContextAddCacheKey(key, subR)
-			}
+			pipelineR := pipeline.NewHTTPRequest(subR)
+			pipelineR.SetCacheKey(key)
 
 			select {
-			case reqCh <- subR:
+			case reqCh <- pipeline.NewHTTPRequest(subR):
 			case <-ctx.Done():
 				// ignore the error if there is one. it will be handled elsewhere
 				return
@@ -398,7 +397,7 @@ func pagesPerRequest(m *backend.BlockMeta, bytesPerRequest int) int {
 	return pagesPerQuery
 }
 
-func buildIngesterRequest(ctx context.Context, tenantID string, parent *http.Request, searchReq *tempopb.SearchRequest, reqCh chan *http.Request) error {
+func buildIngesterRequest(ctx context.Context, tenantID string, parent *http.Request, searchReq *tempopb.SearchRequest, reqCh chan pipeline.Request) error {
 	subR := parent.Clone(ctx)
 	subR, err := api.BuildSearchRequest(subR, searchReq)
 	if err != nil {
@@ -406,6 +405,6 @@ func buildIngesterRequest(ctx context.Context, tenantID string, parent *http.Req
 	}
 
 	prepareRequestForQueriers(subR, tenantID)
-	reqCh <- subR
+	reqCh <- pipeline.NewHTTPRequest(subR)
 	return nil
 }

--- a/modules/frontend/search_sharder.go
+++ b/modules/frontend/search_sharder.go
@@ -64,7 +64,9 @@ func newAsyncSearchSharder(reader tempodb.Reader, o overrides.Interface, cfg Sea
 // RoundTrip implements http.RoundTripper
 // execute up to concurrentRequests simultaneously where each request scans ~targetMBsPerRequest
 // until limit results are found
-func (s asyncSearchSharder) RoundTrip(r *http.Request) (pipeline.Responses[combiner.PipelineResponse], error) {
+func (s asyncSearchSharder) RoundTrip(pipelineRequest pipeline.Request) (pipeline.Responses[combiner.PipelineResponse], error) {
+	r := pipelineRequest.HTTPRequest()
+
 	searchReq, err := api.ParseSearchRequest(r)
 	if err != nil {
 		return pipeline.NewBadRequest(err), nil

--- a/modules/frontend/search_sharder.go
+++ b/modules/frontend/search_sharder.go
@@ -344,7 +344,7 @@ func buildBackendRequests(ctx context.Context, tenantID string, parent *http.Req
 			pipelineR.SetCacheKey(key)
 
 			select {
-			case reqCh <- pipeline.NewHTTPRequest(subR):
+			case reqCh <- pipelineR:
 			case <-ctx.Done():
 				// ignore the error if there is one. it will be handled elsewhere
 				return

--- a/modules/frontend/search_sharder.go
+++ b/modules/frontend/search_sharder.go
@@ -336,7 +336,7 @@ func buildBackendRequests(ctx context.Context, tenantID string, parent *http.Req
 				continue
 			}
 
-			prepareRequestForQueriers(subR, tenantID, subR.URL.Path, subR.URL.Query())
+			prepareRequestForQueriers(subR, tenantID)
 			key := searchJobCacheKey(tenantID, queryHash, int64(searchReq.Start), int64(searchReq.End), m, startPage, pages)
 			if len(key) > 0 {
 				subR = pipeline.ContextAddCacheKey(key, subR)
@@ -403,7 +403,7 @@ func buildIngesterRequest(ctx context.Context, tenantID string, parent *http.Req
 		return err
 	}
 
-	prepareRequestForQueriers(subR, tenantID, subR.URL.Path, subR.URL.Query())
+	prepareRequestForQueriers(subR, tenantID)
 	reqCh <- subR
 	return nil
 }

--- a/modules/frontend/search_sharder_test.go
+++ b/modules/frontend/search_sharder_test.go
@@ -224,7 +224,7 @@ func TestBuildBackendRequests(t *testing.T) {
 		require.NoError(t, err)
 
 		ctx, cancelCause := context.WithCancelCause(context.Background())
-		reqCh := make(chan *http.Request)
+		reqCh := make(chan pipeline.Request)
 
 		go func() {
 			buildBackendRequests(ctx, "test", req, searchReq, tc.metas, tc.targetBytesPerRequest, reqCh, cancelCause)
@@ -233,7 +233,7 @@ func TestBuildBackendRequests(t *testing.T) {
 		actualURIs := []string{}
 		for r := range reqCh {
 			if r != nil {
-				actualURIs = append(actualURIs, r.RequestURI)
+				actualURIs = append(actualURIs, r.HTTPRequest().RequestURI)
 			}
 		}
 
@@ -313,7 +313,7 @@ func TestBackendRequests(t *testing.T) {
 
 			stopCh := make(chan struct{})
 			defer close(stopCh)
-			reqCh := make(chan *http.Request)
+			reqCh := make(chan pipeline.Request)
 
 			ctx, cancelCause := context.WithCancelCause(context.Background())
 
@@ -325,7 +325,7 @@ func TestBackendRequests(t *testing.T) {
 			actualReqURIs := []string{}
 			for r := range reqCh {
 				if r != nil {
-					actualReqURIs = append(actualReqURIs, r.RequestURI)
+					actualReqURIs = append(actualReqURIs, r.HTTPRequest().RequestURI)
 				}
 			}
 			require.NoError(t, ctx.Err())
@@ -489,7 +489,7 @@ func TestIngesterRequests(t *testing.T) {
 		searchReq, err := api.ParseSearchRequest(req)
 		require.NoError(t, err)
 
-		reqChan := make(chan *http.Request, tc.ingesterShards)
+		reqChan := make(chan pipeline.Request, tc.ingesterShards)
 		defer close(reqChan)
 
 		copyReq := searchReq
@@ -506,7 +506,7 @@ func TestIngesterRequests(t *testing.T) {
 			req := <-reqChan
 			require.NotNil(t, req)
 
-			values := req.URL.Query()
+			values := req.HTTPRequest().URL.Query()
 			expectedQueryStringValues, err := url.ParseQuery(expectedURI)
 			require.NoError(t, err)
 

--- a/modules/frontend/tag_handlers.go
+++ b/modules/frontend/tag_handlers.go
@@ -123,7 +123,7 @@ func streamingTags[TReq proto.Message, TResp proto.Message](ctx context.Context,
 
 // newTagHTTPHandler returns a handler that returns a single response from the HTTP handler
 func newTagHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], o overrides.Interface, fnCombiner func(int) combiner.Combiner, logger log.Logger) http.RoundTripper {
-	return pipeline.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		tenant, err := user.ExtractOrgID(req.Context())
 		if err != nil {
 			level.Error(logger).Log("msg", "tags failed to extract orgid", "err", err)

--- a/modules/frontend/tag_handlers.go
+++ b/modules/frontend/tag_handlers.go
@@ -108,7 +108,7 @@ func streamingTags[TReq proto.Message, TResp proto.Message](ctx context.Context,
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	prepareRequestForQueriers(httpReq, tenant, httpReq.URL.Path, httpReq.URL.Query())
+	prepareRequestForQueriers(httpReq, tenant)
 
 	c := fnCombiner(o.MaxBytesPerTagValuesQuery(tenant))
 	collector := pipeline.NewGRPCCollector[TResp](next, cfg.ResponseConsumers, c, fnSend)

--- a/modules/frontend/tag_sharder.go
+++ b/modules/frontend/tag_sharder.go
@@ -189,7 +189,8 @@ func newAsyncTagSharder(reader tempodb.Reader, o overrides.Interface, cfg Search
 // RoundTrip implements pipeline.AsyncRoundTripper
 // execute up to concurrentRequests simultaneously where each request scans ~targetMBsPerRequest
 // until limit results are found
-func (s searchTagSharder) RoundTrip(r *http.Request) (pipeline.Responses[combiner.PipelineResponse], error) {
+func (s searchTagSharder) RoundTrip(pipelineRequest pipeline.Request) (pipeline.Responses[combiner.PipelineResponse], error) {
+	r := pipelineRequest.HTTPRequest()
 	requestCtx := r.Context()
 
 	tenantID, err := user.ExtractOrgID(requestCtx)

--- a/modules/frontend/tag_sharder.go
+++ b/modules/frontend/tag_sharder.go
@@ -300,7 +300,7 @@ func (s searchTagSharder) buildBackendRequests(ctx context.Context, tenantID str
 				return
 			}
 			subR.Header.Set(api.HeaderAccept, api.HeaderAcceptProtobuf)
-			prepareRequestForQueriers(subR, tenantID, parent.URL.Path, subR.URL.Query())
+			prepareRequestForQueriers(subR, tenantID)
 
 			key := cacheKey(keyPrefix, tenantID, hash, int64(searchReq.start()), int64(searchReq.end()), m, startPage, pages)
 			if len(key) > 0 {
@@ -358,7 +358,7 @@ func (s searchTagSharder) buildIngesterRequest(ctx context.Context, tenantID str
 		return nil, err
 	}
 	subR.Header.Set(api.HeaderAccept, api.HeaderAcceptProtobuf)
-	prepareRequestForQueriers(subR, tenantID, subR.URL.Path, subR.URL.Query())
+	prepareRequestForQueriers(subR, tenantID)
 	return subR, nil
 }
 

--- a/modules/frontend/tag_sharder_test.go
+++ b/modules/frontend/tag_sharder_test.go
@@ -154,7 +154,7 @@ func TestTagsBackendRequests(t *testing.T) {
 
 			stopCh := make(chan struct{})
 			defer close(stopCh)
-			reqCh := make(chan *http.Request)
+			reqCh := make(chan pipeline.Request)
 			req := fakeReq{}
 			if tc.params != nil {
 				req.startValue = uint32(tc.params.start)
@@ -167,7 +167,7 @@ func TestTagsBackendRequests(t *testing.T) {
 
 			actualReqURIs := []string{}
 			for r := range reqCh {
-				actualReqURIs = append(actualReqURIs, r.RequestURI)
+				actualReqURIs = append(actualReqURIs, r.HTTPRequest().RequestURI)
 			}
 			require.Equal(t, tc.expectedReqsURIs, actualReqURIs)
 		})

--- a/modules/frontend/tag_sharder_test.go
+++ b/modules/frontend/tag_sharder_test.go
@@ -283,7 +283,7 @@ func TestTagsIngesterRequest(t *testing.T) {
 }
 
 func TestTagsSearchSharderRoundTripBadRequest(t *testing.T) {
-	next := pipeline.AsyncRoundTripperFunc[combiner.PipelineResponse](func(r *http.Request) (pipeline.Responses[combiner.PipelineResponse], error) {
+	next := pipeline.AsyncRoundTripperFunc[combiner.PipelineResponse](func(_ pipeline.Request) (pipeline.Responses[combiner.PipelineResponse], error) {
 		return nil, nil
 	})
 
@@ -299,19 +299,19 @@ func TestTagsSearchSharderRoundTripBadRequest(t *testing.T) {
 
 	// no org id
 	req := httptest.NewRequest("GET", "/?start=1000&end=1100", nil)
-	resp, err := testRT.RoundTrip(req)
+	resp, err := testRT.RoundTrip(pipeline.NewHTTPRequest(req))
 	testBadRequestFromResponses(t, resp, err, "no org id")
 
 	// start/end outside of max duration
 	req = httptest.NewRequest("GET", "/?start=1000&end=1500", nil)
 	req = req.WithContext(user.InjectOrgID(req.Context(), "blerg"))
-	resp, err = testRT.RoundTrip(req)
+	resp, err = testRT.RoundTrip(pipeline.NewHTTPRequest(req))
 	testBadRequestFromResponses(t, resp, err, "range specified by start and end exceeds 5m0s. received start=1000 end=1500")
 
 	// bad request
 	req = httptest.NewRequest("GET", "/?start=asdf&end=1500", nil)
 	req = req.WithContext(user.InjectOrgID(req.Context(), "blerg"))
-	resp, err = testRT.RoundTrip(req)
+	resp, err = testRT.RoundTrip(pipeline.NewHTTPRequest(req))
 	testBadRequestFromResponses(t, resp, err, "invalid start: strconv.ParseInt: parsing \"asdf\": invalid syntax")
 
 	// test max duration error with overrides
@@ -333,6 +333,6 @@ func TestTagsSearchSharderRoundTripBadRequest(t *testing.T) {
 
 	req = httptest.NewRequest("GET", "/?start=1000&end=1500", nil)
 	req = req.WithContext(user.InjectOrgID(req.Context(), "blerg"))
-	resp, err = testRT.RoundTrip(req)
+	resp, err = testRT.RoundTrip(pipeline.NewHTTPRequest(req))
 	testBadRequestFromResponses(t, resp, err, "range specified by start and end exceeds 1m0s. received start=1000 end=1500")
 }

--- a/modules/frontend/time_range_sharder.go
+++ b/modules/frontend/time_range_sharder.go
@@ -1,0 +1,19 @@
+package frontend
+
+// sharder that takes an interface? or functions to provide a generic way to shard a given query over
+// a time range. we will execute queries in reverse time order starting from the end and progressing
+// toward the start. every time a query finishes we will check the combiner to see if the query is
+// complete. if it is then we will sort and return the results
+
+// add a local interface for a "combinersorter" to sort results
+
+// todo: jpe
+//  - change "additional data" to "request data" or "request context" - sure
+//  - execute one request for each hour working backwards
+//    - 2 simultaneous requests
+//  - combiner holds the N most recent results
+//  - after each batch check if the combiner has enough to return
+//  - adjust the sharder to be exclusive on either the front or end of the range
+//
+// This causes overscan of the blocks! (unless you pass both "real" range and sub "range" the real range is passed to the queriers and the sub range is used to select the blocks)
+//   can we just watch the jobs come in record what the closest to now "in flight" job is? and only return if the closest to now in flight job's block does not overlap w/ the oldest sorted result?

--- a/modules/frontend/traceid_handlers.go
+++ b/modules/frontend/traceid_handlers.go
@@ -19,7 +19,7 @@ import (
 func newTraceIDHandler(cfg Config, o overrides.Interface, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], logger log.Logger) http.RoundTripper {
 	postSLOHook := traceByIDSLOPostHook(cfg.TraceByID.SLO)
 
-	return pipeline.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		tenant, err := user.ExtractOrgID(req.Context())
 		if err != nil {
 			level.Error(logger).Log("msg", "trace id: failed to extract tenant id", "err", err)

--- a/modules/frontend/traceid_handlers.go
+++ b/modules/frontend/traceid_handlers.go
@@ -58,7 +58,6 @@ func newTraceIDHandler(cfg Config, o overrides.Interface, next pipeline.AsyncRou
 
 		// enforce all communication internal to Tempo to be in protobuf bytes
 		req.Header.Set(api.HeaderAccept, api.HeaderAcceptProtobuf)
-		prepareRequestForQueriers(req, tenant, req.RequestURI, nil)
 
 		level.Info(logger).Log(
 			"msg", "trace id request",

--- a/modules/frontend/traceid_handlers_test.go
+++ b/modules/frontend/traceid_handlers_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/gorilla/mux"
 	"github.com/grafana/dskit/user"
-	"github.com/grafana/tempo/modules/frontend/pipeline"
 	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/util/test"
@@ -134,7 +133,7 @@ func TestTraceIDHandler(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // copy the test case to prevent race on the loop variable
 		t.Run(tc.name, func(t *testing.T) {
-			next := pipeline.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			next := RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 				var testTrace *tempopb.Trace
 				var statusCode int
 				var err error

--- a/modules/frontend/traceid_sharder.go
+++ b/modules/frontend/traceid_sharder.go
@@ -57,8 +57,8 @@ func (s asyncTraceSharder) RoundTrip(pipelineRequest pipeline.Request) (pipeline
 		concurrentShards = uint(s.cfg.ConcurrentShards)
 	}
 
-	return pipeline.NewAsyncSharderFunc(ctx, int(concurrentShards), len(reqs), func(i int) *http.Request {
-		return reqs[i]
+	return pipeline.NewAsyncSharderFunc(ctx, int(concurrentShards), len(reqs), func(i int) pipeline.Request {
+		return pipeline.NewHTTPRequest(reqs[i])
 	}, s.next), nil
 }
 

--- a/modules/frontend/traceid_sharder.go
+++ b/modules/frontend/traceid_sharder.go
@@ -39,7 +39,9 @@ func newAsyncTraceIDSharder(cfg *TraceByIDConfig, logger log.Logger) pipeline.As
 }
 
 // RoundTrip implements http.RoundTripper
-func (s asyncTraceSharder) RoundTrip(r *http.Request) (pipeline.Responses[combiner.PipelineResponse], error) {
+func (s asyncTraceSharder) RoundTrip(pipelineRequest pipeline.Request) (pipeline.Responses[combiner.PipelineResponse], error) {
+	r := pipelineRequest.HTTPRequest()
+
 	span, ctx := opentracing.StartSpanFromContext(r.Context(), "frontend.ShardQuery")
 	defer span.Finish()
 	r = r.WithContext(ctx)

--- a/modules/frontend/traceid_sharder.go
+++ b/modules/frontend/traceid_sharder.go
@@ -83,8 +83,9 @@ func (s *asyncTraceSharder) buildShardedRequests(ctx context.Context, parent *ht
 			q.Add(querier.BlockEndKey, hex.EncodeToString(s.blockBoundaries[i]))
 			q.Add(querier.QueryModeKey, querier.QueryModeBlocks)
 		}
+		reqs[i].URL.RawQuery = q.Encode()
 
-		prepareRequestForQueriers(reqs[i], userID, reqs[i].URL.Path, q)
+		prepareRequestForQueriers(reqs[i], userID)
 	}
 
 	return reqs, nil


### PR DESCRIPTION
**What this PR does**:
Refactors the frontend to pass a `Request` interface instead of an `*http.Request`. This is progress toward supporting deterministic search. Also added a search pipeline benchmark and found a perf improvement in `prepareRequestForQueriers`.

```
> benchstat before.txt after.txt
goos: darwin
goarch: arm64
pkg: github.com/grafana/tempo/modules/frontend
                  │  before.txt  │             after.txt              │
                  │    sec/op    │    sec/op     vs base              │
SearchPipeline-11   609.4m ± ∞ ¹   604.0m ± ∞ ¹  -0.87% (p=0.008 n=5)
¹ need >= 6 samples for confidence interval at level 0.95

                  │   before.txt   │              after.txt               │
                  │      B/op      │     B/op       vs base               │
SearchPipeline-11   10.642Mi ± ∞ ¹   8.659Mi ± ∞ ¹  -18.63% (p=0.008 n=5)
¹ need >= 6 samples for confidence interval at level 0.95

                  │  before.txt  │             after.txt              │
                  │  allocs/op   │  allocs/op    vs base              │
SearchPipeline-11   163.0k ± ∞ ¹   148.3k ± ∞ ¹  -9.02% (p=0.008 n=5)
¹ need >= 6 samples for confidence interval at level 0.95
```

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`