### PR TITLE
Update docker-compose.yaml to get Minio up

### DIFF
--- a/example/docker-compose/scalable-single-binary/docker-compose.yaml
+++ b/example/docker-compose/scalable-single-binary/docker-compose.yaml
@@ -74,12 +74,9 @@ services:
   minio:
     image: minio/minio:latest
     environment:
-      - MINIO_ACCESS_KEY=tempo
-      - MINIO_SECRET_KEY=supersecret
-    entrypoint:
-      - sh
-      - -euc
-      - mkdir -p /data/tempo && /opt/bin/minio server /data --console-address ':9001'
+      - MINIO_ROOT_USER=tempo
+      - MINIO_ROOT_PASSWORD=supersecret
+    entrypoint: /bin/sh -c "mc mb --ignore-existing /data/tempo ; minio server /data --console-address ':9001'"
     ports:
       - 9001:9001
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: Due to changes in Minio Docker image, [Tempo's Scaling monolithic mode example](https://grafana.com/docs/tempo/latest/setup/deployment/#scaling-monolithic-mode) didn't work. Now the Docker Compose file works again.

**Which issue(s) this PR fixes**:
Fixes #3893 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`