### PR TITLE
[Traceql] Add support for event timestamp 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [FEATURE] TraceQL support for link attribute querying [#3814](https://github.com/grafana/tempo/pull/3814) (@ie-pham)
 * [FEATURE] TraceQL support for event scope and event:name intrinsic [#3708](https://github.com/grafana/tempo/pull/3708) (@stoewer)
 * [FEATURE] TraecQL support for event attributes [#3708](https://github.com/grafana/tempo/pull/3748) (@ie-pham)
+* [FEATURE] TraceQL support for event:timeSinceStart [#3908](https://github.com/grafana/tempo/pull/3908) (@ie-pham)
 * [FEATURE] Autocomplete support for events and links [#3846](https://github.com/grafana/tempo/pull/3846) (@ie-pham)
 * [FEATURE] Flush and query RF1 blocks for TraceQL metric queries [#3628](https://github.com/grafana/tempo/pull/3628) [#3691](https://github.com/grafana/tempo/pull/3691) [#3723](https://github.com/grafana/tempo/pull/3723) (@mapno)
 * [FEATURE] Add new compare() metrics function [#3695](https://github.com/grafana/tempo/pull/3695) (@mdisibio)

--- a/docs/sources/tempo/traceql/_index.md
+++ b/docs/sources/tempo/traceql/_index.md
@@ -91,6 +91,7 @@ The following table shows the current available scoped intrinsic fields:
 | `trace:rootService`     | string      | if it exists the service name of the root span in the trace     | `{ trace:rootServiceName = "gateway" }`|
 | `trace:id`              | string      | trace id using hex string                                       | `{ trace:id = "1234567890abcde" }`     |
 | `event:name`            | string      | name of event                                                   | `{ event:name = "exception" }`         |
+| `event:timeSinceStart`  | duration    | time of event in relation to the span start time                | `{ event:timeSinceStart > 2ms}`        |
 | `link:spanID`           | string      | link span id using hex string                                   | `{ link:spanID = "0000000000000001" }` |
 | `link:traceID`          | string      | link trace id using hex string                                  | `{ link:traceID = "1234567890abcde" }` |
 

--- a/integration/e2e/api_test.go
+++ b/integration/e2e/api_test.go
@@ -596,7 +596,7 @@ func callSearchTagsV2AndAssert(t *testing.T, svc *e2e.HTTPService, scope, query 
 	if scope == "none" || scope == "" || scope == "intrinsic" {
 		expected.Scopes = append(expected.Scopes, &tempopb.SearchTagsV2Scope{
 			Name: "intrinsic",
-			Tags: []string{"duration", "event:name", "kind", "name", "rootName", "rootServiceName", "span:duration", "span:kind", "span:name", "span:status", "span:statusMessage", "status", "statusMessage", "trace:duration", "trace:rootName", "trace:rootService", "traceDuration"},
+			Tags: []string{"duration", "event:name", "event:timeSinceStart", "kind", "name", "rootName", "rootServiceName", "span:duration", "span:kind", "span:name", "span:status", "span:statusMessage", "status", "statusMessage", "trace:duration", "trace:rootName", "trace:rootService", "traceDuration"},
 		})
 	}
 	sort.Slice(expected.Scopes, func(i, j int) bool { return expected.Scopes[i].Name < expected.Scopes[j].Name })

--- a/modules/ingester/instance_search_test.go
+++ b/modules/ingester/instance_search_test.go
@@ -424,7 +424,7 @@ func TestInstanceSearchTagsSpecialCases(t *testing.T) {
 	require.Equal(
 		t,
 		[]string{
-			"duration", "event:name", "kind", "name", "rootName", "rootServiceName",
+			"duration", "event:name", "event:timeSinceStart", "kind", "name", "rootName", "rootServiceName",
 			"span:duration", "span:kind", "span:name", "span:status", "span:statusMessage", "status", "statusMessage",
 			"trace:duration", "trace:rootName", "trace:rootService", "traceDuration",
 		},

--- a/pkg/search/util.go
+++ b/pkg/search/util.go
@@ -73,6 +73,7 @@ func GetVirtualIntrinsicValues() []string {
 		traceql.ScopedIntrinsicTraceRootService.String(),
 		traceql.ScopedIntrinsicTraceDuration.String(),
 		traceql.IntrinsicEventName.String(),
+		traceql.IntrinsicEventTimeSinceStart.String(),
 		/* these are technically intrinsics that can be requested, but they are not generally of interest to a user
 		   typing a query. for simplicity and clarity we are leaving them out of autocomplete
 			IntrinsicNestedSetLeft

--- a/pkg/traceql/ast.go
+++ b/pkg/traceql/ast.go
@@ -917,6 +917,8 @@ func (a Attribute) impliedType() StaticType {
 		return TypeKind
 	case IntrinsicEventName:
 		return TypeString
+	case IntrinsicEventTimeSinceStart:
+		return TypeDuration
 	case IntrinsicLinkTraceID:
 		return TypeString
 	case IntrinsicLinkSpanID:

--- a/pkg/traceql/enum_attributes.go
+++ b/pkg/traceql/enum_attributes.go
@@ -73,6 +73,7 @@ const (
 	IntrinsicNestedSetRight
 	IntrinsicNestedSetParent
 	IntrinsicEventName
+	IntrinsicEventTimeSinceStart
 	IntrinsicLinkSpanID
 	IntrinsicLinkTraceID
 
@@ -108,23 +109,25 @@ const (
 )
 
 var (
-	IntrinsicDurationAttribute         = NewIntrinsic(IntrinsicDuration)
-	IntrinsicNameAttribute             = NewIntrinsic(IntrinsicName)
-	IntrinsicStatusAttribute           = NewIntrinsic(IntrinsicStatus)
-	IntrinsicStatusMessageAttribute    = NewIntrinsic(IntrinsicStatusMessage)
-	IntrinsicKindAttribute             = NewIntrinsic(IntrinsicKind)
-	IntrinsicSpanIDAttribute           = NewIntrinsic(IntrinsicSpanID)
-	IntrinsicChildCountAttribute       = NewIntrinsic(IntrinsicChildCount)
-	IntrinsicTraceIDAttribute          = NewIntrinsic(IntrinsicTraceID)
-	IntrinsicTraceRootServiceAttribute = NewIntrinsic(IntrinsicTraceRootService)
-	IntrinsicTraceRootSpanAttribute    = NewIntrinsic(IntrinsicTraceRootSpan)
-	IntrinsicTraceDurationAttribute    = NewIntrinsic(IntrinsicTraceDuration)
-	IntrinsicSpanStartTimeAttribute    = NewIntrinsic(IntrinsicSpanStartTime)
-	IntrinsicNestedSetLeftAttribute    = NewIntrinsic(IntrinsicNestedSetLeft)
-	IntrinsicNestedSetRightAttribute   = NewIntrinsic(IntrinsicNestedSetRight)
-	IntrinsicNestedSetParentAttribute  = NewIntrinsic(IntrinsicNestedSetParent)
-	IntrinsicLinkTraceIDAttribute      = NewIntrinsic(IntrinsicLinkTraceID)
-	IntrinsicLinkSpanIDAttribute       = NewIntrinsic(IntrinsicLinkSpanID)
+	IntrinsicDurationAttribute            = NewIntrinsic(IntrinsicDuration)
+	IntrinsicNameAttribute                = NewIntrinsic(IntrinsicName)
+	IntrinsicStatusAttribute              = NewIntrinsic(IntrinsicStatus)
+	IntrinsicStatusMessageAttribute       = NewIntrinsic(IntrinsicStatusMessage)
+	IntrinsicKindAttribute                = NewIntrinsic(IntrinsicKind)
+	IntrinsicSpanIDAttribute              = NewIntrinsic(IntrinsicSpanID)
+	IntrinsicChildCountAttribute          = NewIntrinsic(IntrinsicChildCount)
+	IntrinsicTraceIDAttribute             = NewIntrinsic(IntrinsicTraceID)
+	IntrinsicTraceRootServiceAttribute    = NewIntrinsic(IntrinsicTraceRootService)
+	IntrinsicTraceRootSpanAttribute       = NewIntrinsic(IntrinsicTraceRootSpan)
+	IntrinsicTraceDurationAttribute       = NewIntrinsic(IntrinsicTraceDuration)
+	IntrinsicSpanStartTimeAttribute       = NewIntrinsic(IntrinsicSpanStartTime)
+	IntrinsicNestedSetLeftAttribute       = NewIntrinsic(IntrinsicNestedSetLeft)
+	IntrinsicNestedSetRightAttribute      = NewIntrinsic(IntrinsicNestedSetRight)
+	IntrinsicNestedSetParentAttribute     = NewIntrinsic(IntrinsicNestedSetParent)
+	IntrinsicLinkTraceIDAttribute         = NewIntrinsic(IntrinsicLinkTraceID)
+	IntrinsicLinkSpanIDAttribute          = NewIntrinsic(IntrinsicLinkSpanID)
+	IntrinsicEventNameAttribute           = NewIntrinsic(IntrinsicEventName)
+	IntrinsicEventTimeSinceStartAttribute = NewIntrinsic(IntrinsicEventTimeSinceStart)
 )
 
 func (i Intrinsic) String() string {
@@ -145,6 +148,8 @@ func (i Intrinsic) String() string {
 		return "childCount"
 	case IntrinsicEventName:
 		return "event:name"
+	case IntrinsicEventTimeSinceStart:
+		return "event:timeSinceStart"
 	case IntrinsicLinkSpanID:
 		return "link:spanID"
 	case IntrinsicLinkTraceID:
@@ -210,6 +215,8 @@ func intrinsicFromString(s string) Intrinsic {
 		return IntrinsicChildCount
 	case "event:name":
 		return IntrinsicEventName
+	case "event:timeSinceStart":
+		return IntrinsicEventTimeSinceStart
 	case "link:spanID":
 		return IntrinsicLinkSpanID
 	case "link:traceID":

--- a/pkg/traceql/expr.y
+++ b/pkg/traceql/expr.y
@@ -93,6 +93,7 @@ import (
                         NIL TRUE FALSE STATUS_ERROR STATUS_OK STATUS_UNSET
                         KIND_UNSPECIFIED KIND_INTERNAL KIND_SERVER KIND_CLIENT KIND_PRODUCER KIND_CONSUMER
                         IDURATION CHILDCOUNT NAME STATUS STATUS_MESSAGE PARENT KIND ROOTNAME ROOTSERVICENAME 
+                        TIMESINCESTART
                         ROOTSERVICE TRACEDURATION NESTEDSETLEFT NESTEDSETRIGHT NESTEDSETPARENT ID TRACE_ID SPAN_ID
                         PARENT_DOT RESOURCE_DOT SPAN_DOT TRACE_COLON SPAN_COLON EVENT_COLON EVENT_DOT LINK_COLON LINK_DOT
                         COUNT AVG MAX MIN SUM
@@ -406,6 +407,7 @@ scopedIntrinsicField:
   | SPAN_COLON ID                { $$ = NewIntrinsic(IntrinsicSpanID)              }
 // event:
   | EVENT_COLON NAME             { $$ = NewIntrinsic(IntrinsicEventName)           }
+  | EVENT_COLON TIMESINCESTART   { $$ = NewIntrinsic(IntrinsicEventTimeSinceStart) }
 // link:
   | LINK_COLON TRACE_ID          { $$ = NewIntrinsic(IntrinsicLinkTraceID)         }
   | LINK_COLON SPAN_ID           { $$ = NewIntrinsic(IntrinsicLinkSpanID)          }

--- a/pkg/traceql/expr.y.go
+++ b/pkg/traceql/expr.y.go
@@ -87,68 +87,69 @@ const PARENT = 57374
 const KIND = 57375
 const ROOTNAME = 57376
 const ROOTSERVICENAME = 57377
-const ROOTSERVICE = 57378
-const TRACEDURATION = 57379
-const NESTEDSETLEFT = 57380
-const NESTEDSETRIGHT = 57381
-const NESTEDSETPARENT = 57382
-const ID = 57383
-const TRACE_ID = 57384
-const SPAN_ID = 57385
-const PARENT_DOT = 57386
-const RESOURCE_DOT = 57387
-const SPAN_DOT = 57388
-const TRACE_COLON = 57389
-const SPAN_COLON = 57390
-const EVENT_COLON = 57391
-const EVENT_DOT = 57392
-const LINK_COLON = 57393
-const LINK_DOT = 57394
-const COUNT = 57395
-const AVG = 57396
-const MAX = 57397
-const MIN = 57398
-const SUM = 57399
-const BY = 57400
-const COALESCE = 57401
-const SELECT = 57402
-const END_ATTRIBUTE = 57403
-const RATE = 57404
-const COUNT_OVER_TIME = 57405
-const QUANTILE_OVER_TIME = 57406
-const HISTOGRAM_OVER_TIME = 57407
-const COMPARE = 57408
-const WITH = 57409
-const PIPE = 57410
-const AND = 57411
-const OR = 57412
-const EQ = 57413
-const NEQ = 57414
-const LT = 57415
-const LTE = 57416
-const GT = 57417
-const GTE = 57418
-const NRE = 57419
-const RE = 57420
-const DESC = 57421
-const ANCE = 57422
-const SIBL = 57423
-const NOT_CHILD = 57424
-const NOT_PARENT = 57425
-const NOT_DESC = 57426
-const NOT_ANCE = 57427
-const UNION_CHILD = 57428
-const UNION_PARENT = 57429
-const UNION_DESC = 57430
-const UNION_ANCE = 57431
-const UNION_SIBL = 57432
-const ADD = 57433
-const SUB = 57434
-const NOT = 57435
-const MUL = 57436
-const DIV = 57437
-const MOD = 57438
-const POW = 57439
+const TIMESINCESTART = 57378
+const ROOTSERVICE = 57379
+const TRACEDURATION = 57380
+const NESTEDSETLEFT = 57381
+const NESTEDSETRIGHT = 57382
+const NESTEDSETPARENT = 57383
+const ID = 57384
+const TRACE_ID = 57385
+const SPAN_ID = 57386
+const PARENT_DOT = 57387
+const RESOURCE_DOT = 57388
+const SPAN_DOT = 57389
+const TRACE_COLON = 57390
+const SPAN_COLON = 57391
+const EVENT_COLON = 57392
+const EVENT_DOT = 57393
+const LINK_COLON = 57394
+const LINK_DOT = 57395
+const COUNT = 57396
+const AVG = 57397
+const MAX = 57398
+const MIN = 57399
+const SUM = 57400
+const BY = 57401
+const COALESCE = 57402
+const SELECT = 57403
+const END_ATTRIBUTE = 57404
+const RATE = 57405
+const COUNT_OVER_TIME = 57406
+const QUANTILE_OVER_TIME = 57407
+const HISTOGRAM_OVER_TIME = 57408
+const COMPARE = 57409
+const WITH = 57410
+const PIPE = 57411
+const AND = 57412
+const OR = 57413
+const EQ = 57414
+const NEQ = 57415
+const LT = 57416
+const LTE = 57417
+const GT = 57418
+const GTE = 57419
+const NRE = 57420
+const RE = 57421
+const DESC = 57422
+const ANCE = 57423
+const SIBL = 57424
+const NOT_CHILD = 57425
+const NOT_PARENT = 57426
+const NOT_DESC = 57427
+const NOT_ANCE = 57428
+const UNION_CHILD = 57429
+const UNION_PARENT = 57430
+const UNION_DESC = 57431
+const UNION_ANCE = 57432
+const UNION_SIBL = 57433
+const ADD = 57434
+const SUB = 57435
+const NOT = 57436
+const MUL = 57437
+const DIV = 57438
+const MOD = 57439
+const POW = 57440
 
 var yyToknames = [...]string{
 	"$end",
@@ -186,6 +187,7 @@ var yyToknames = [...]string{
 	"KIND",
 	"ROOTNAME",
 	"ROOTSERVICENAME",
+	"TIMESINCESTART",
 	"ROOTSERVICE",
 	"TRACEDURATION",
 	"NESTEDSETLEFT",
@@ -260,160 +262,161 @@ var yyExca = [...]int{
 	-1, 1,
 	1, -1,
 	-2, 0,
-	-1, 288,
+	-1, 289,
 	13, 86,
 	-2, 94,
 }
 
 const yyPrivate = 57344
 
-const yyLast = 959
+const yyLast = 965
 
 var yyAct = [...]int{
 
-	101, 5, 100, 6, 99, 8, 224, 7, 276, 98,
-	12, 67, 18, 13, 286, 2, 243, 90, 225, 94,
-	77, 325, 201, 70, 66, 230, 231, 30, 232, 233,
-	234, 243, 151, 29, 152, 200, 155, 200, 153, 85,
-	86, 335, 87, 88, 89, 90, 232, 233, 234, 243,
+	101, 5, 100, 6, 99, 8, 224, 7, 277, 98,
+	12, 67, 18, 13, 287, 2, 243, 90, 225, 94,
+	77, 326, 200, 70, 66, 230, 231, 201, 232, 233,
+	234, 243, 151, 30, 152, 200, 155, 29, 153, 85,
+	86, 336, 87, 88, 89, 90, 232, 233, 234, 243,
 	181, 183, 184, 185, 186, 187, 188, 189, 190, 191,
-	192, 193, 194, 195, 196, 197, 198, 322, 72, 73,
-	334, 74, 75, 76, 77, 318, 317, 321, 314, 313,
-	312, 207, 87, 88, 89, 90, 74, 75, 76, 77,
-	332, 311, 201, 228, 362, 227, 349, 226, 215, 217,
-	218, 219, 220, 221, 222, 339, 338, 268, 269, 267,
-	367, 223, 252, 370, 293, 246, 247, 248, 340, 366,
-	293, 17, 371, 244, 245, 235, 236, 237, 238, 239,
-	240, 242, 241, 244, 245, 235, 236, 237, 238, 239,
-	240, 242, 241, 68, 11, 230, 231, 341, 232, 233,
-	234, 243, 331, 253, 254, 230, 231, 327, 232, 233,
-	234, 243, 326, 283, 270, 271, 272, 273, 274, 359,
-	293, 358, 293, 356, 357, 284, 235, 236, 237, 238,
-	239, 240, 242, 241, 283, 19, 20, 21, 17, 17,
-	182, 161, 277, 354, 353, 204, 230, 231, 365, 232,
-	233, 234, 243, 151, 355, 152, 345, 155, 344, 153,
-	342, 343, 323, 324, 288, 206, 209, 210, 211, 212,
-	213, 214, 285, 290, 282, 19, 20, 21, 281, 17,
-	284, 161, 23, 26, 24, 25, 27, 14, 162, 15,
-	205, 156, 157, 158, 159, 160, 369, 205, 292, 293,
-	294, 295, 296, 297, 298, 299, 300, 301, 302, 303,
-	304, 305, 306, 307, 308, 309, 280, 279, 278, 208,
-	164, 22, 23, 26, 24, 25, 27, 14, 162, 15,
-	149, 228, 228, 227, 227, 226, 226, 148, 257, 67,
-	147, 67, 146, 330, 228, 258, 227, 259, 226, 328,
-	329, 70, 260, 70, 290, 78, 79, 80, 81, 82,
-	83, 22, 333, 145, 144, 92, 91, 364, 85, 86,
-	84, 87, 88, 89, 90, 85, 86, 350, 87, 88,
-	89, 90, 71, 336, 151, 337, 152, 316, 155, 28,
-	153, 141, 142, 143, 315, 228, 228, 227, 227, 226,
-	226, 351, 352, 361, 360, 256, 228, 255, 227, 251,
-	226, 275, 363, 348, 347, 250, 228, 249, 227, 346,
-	226, 69, 368, 102, 103, 104, 108, 131, 16, 93,
-	95, 4, 150, 107, 105, 106, 110, 109, 111, 112,
-	113, 114, 115, 116, 117, 118, 119, 120, 121, 122,
-	124, 123, 125, 126, 10, 127, 128, 129, 130, 203,
-	154, 1, 134, 132, 133, 137, 138, 139, 135, 140,
-	136, 320, 0, 102, 103, 104, 108, 131, 0, 0,
-	95, 0, 0, 107, 105, 106, 110, 109, 111, 112,
-	113, 114, 115, 116, 117, 118, 119, 120, 121, 122,
-	124, 123, 125, 126, 0, 127, 128, 129, 130, 319,
-	96, 97, 134, 132, 133, 137, 138, 139, 135, 140,
-	136, 310, 0, 0, 0, 0, 0, 244, 245, 235,
-	236, 237, 238, 239, 240, 242, 241, 72, 73, 0,
-	74, 75, 76, 77, 0, 0, 0, 0, 0, 230,
-	231, 291, 232, 233, 234, 243, 0, 0, 0, 229,
-	96, 97, 0, 0, 0, 244, 245, 235, 236, 237,
-	238, 239, 240, 242, 241, 0, 0, 244, 245, 235,
-	236, 237, 238, 239, 240, 242, 241, 230, 231, 0,
-	232, 233, 234, 243, 0, 0, 0, 0, 0, 230,
-	231, 0, 232, 233, 234, 243, 0, 244, 245, 235,
-	236, 237, 238, 239, 240, 242, 241, 244, 245, 235,
-	236, 237, 238, 239, 240, 242, 241, 202, 0, 230,
-	231, 0, 232, 233, 234, 243, 0, 0, 0, 230,
-	231, 0, 232, 233, 234, 243, 78, 79, 80, 81,
-	82, 83, 199, 78, 79, 80, 81, 82, 83, 0,
-	0, 0, 0, 0, 0, 0, 85, 86, 0, 87,
-	88, 89, 90, 72, 73, 0, 74, 75, 76, 77,
-	0, 0, 0, 48, 53, 0, 0, 50, 0, 49,
+	192, 193, 194, 195, 196, 197, 198, 323, 72, 73,
+	335, 74, 75, 76, 77, 319, 318, 322, 333, 315,
+	314, 207, 87, 88, 89, 90, 74, 75, 76, 77,
+	313, 201, 312, 228, 363, 227, 350, 226, 215, 217,
+	218, 219, 220, 221, 222, 340, 339, 267, 269, 270,
+	368, 223, 252, 341, 268, 246, 247, 248, 371, 294,
+	367, 294, 360, 294, 244, 245, 235, 236, 237, 238,
+	239, 240, 242, 241, 244, 245, 235, 236, 237, 238,
+	239, 240, 242, 241, 68, 11, 230, 231, 372, 232,
+	233, 234, 243, 342, 253, 254, 230, 231, 332, 232,
+	233, 234, 243, 284, 328, 272, 273, 274, 275, 359,
+	294, 357, 358, 355, 354, 285, 235, 236, 237, 238,
+	239, 240, 242, 241, 284, 19, 20, 21, 327, 17,
+	271, 161, 278, 343, 344, 204, 230, 231, 366, 232,
+	233, 234, 243, 151, 17, 152, 182, 155, 356, 153,
+	324, 325, 293, 294, 289, 346, 206, 209, 210, 211,
+	212, 213, 214, 291, 345, 19, 20, 21, 286, 17,
+	285, 161, 283, 23, 26, 24, 25, 27, 14, 162,
+	15, 282, 156, 157, 158, 159, 160, 205, 281, 280,
+	295, 296, 297, 298, 299, 300, 301, 302, 303, 304,
+	305, 306, 307, 308, 309, 310, 370, 279, 208, 164,
+	149, 148, 22, 23, 26, 24, 25, 27, 14, 162,
+	15, 257, 228, 228, 227, 227, 226, 226, 258, 147,
+	67, 259, 67, 146, 331, 228, 260, 227, 145, 226,
+	329, 330, 70, 17, 70, 291, 78, 79, 80, 81,
+	82, 83, 22, 334, 144, 92, 91, 365, 261, 351,
+	262, 264, 265, 317, 263, 316, 85, 86, 84, 87,
+	88, 89, 90, 266, 337, 151, 338, 152, 256, 155,
+	71, 153, 141, 142, 143, 255, 228, 228, 227, 227,
+	226, 226, 352, 353, 362, 361, 251, 228, 250, 227,
+	249, 226, 28, 364, 349, 348, 276, 228, 347, 227,
+	69, 226, 16, 369, 102, 103, 104, 108, 131, 4,
+	93, 95, 150, 10, 107, 105, 106, 110, 109, 111,
+	112, 113, 114, 115, 116, 117, 118, 119, 120, 121,
+	122, 124, 123, 125, 126, 154, 1, 127, 128, 129,
+	130, 0, 0, 0, 134, 132, 133, 137, 138, 139,
+	135, 140, 136, 321, 102, 103, 104, 108, 131, 0,
+	0, 95, 0, 0, 107, 105, 106, 110, 109, 111,
+	112, 113, 114, 115, 116, 117, 118, 119, 120, 121,
+	122, 124, 123, 125, 126, 0, 0, 127, 128, 129,
+	130, 320, 96, 97, 134, 132, 133, 137, 138, 139,
+	135, 140, 136, 311, 78, 79, 80, 81, 82, 83,
+	244, 245, 235, 236, 237, 238, 239, 240, 242, 241,
+	0, 0, 0, 0, 85, 86, 0, 87, 88, 89,
+	90, 0, 230, 231, 292, 232, 233, 234, 243, 0,
+	0, 0, 96, 97, 229, 0, 0, 0, 244, 245,
+	235, 236, 237, 238, 239, 240, 242, 241, 0, 205,
+	244, 245, 235, 236, 237, 238, 239, 240, 242, 241,
+	230, 231, 0, 232, 233, 234, 243, 0, 0, 0,
+	0, 0, 230, 231, 0, 232, 233, 234, 243, 0,
+	0, 244, 245, 235, 236, 237, 238, 239, 240, 242,
+	241, 0, 202, 244, 245, 235, 236, 237, 238, 239,
+	240, 242, 241, 230, 231, 0, 232, 233, 234, 243,
+	0, 0, 0, 0, 199, 230, 231, 0, 232, 233,
+	234, 243, 78, 79, 80, 81, 82, 83, 85, 86,
+	0, 87, 88, 89, 90, 0, 0, 0, 0, 0,
+	0, 0, 72, 73, 0, 74, 75, 76, 77, 48,
+	53, 0, 0, 50, 0, 49, 0, 57, 0, 51,
+	52, 54, 55, 56, 59, 58, 60, 61, 64, 63,
+	62, 31, 36, 0, 0, 33, 0, 32, 0, 42,
+	0, 34, 35, 37, 38, 39, 40, 41, 43, 44,
+	45, 46, 47, 48, 53, 0, 0, 50, 0, 49,
 	0, 57, 0, 51, 52, 54, 55, 56, 59, 58,
-	60, 61, 64, 63, 62, 0, 0, 0, 31, 36,
-	0, 0, 33, 0, 32, 0, 42, 0, 34, 35,
-	37, 38, 39, 40, 41, 43, 44, 45, 46, 47,
-	48, 53, 0, 0, 50, 0, 49, 0, 57, 0,
-	51, 52, 54, 55, 56, 59, 58, 60, 61, 64,
-	63, 62, 31, 36, 0, 0, 33, 0, 32, 0,
+	60, 61, 64, 63, 62, 31, 36, 0, 0, 33,
+	0, 32, 0, 42, 0, 34, 35, 37, 38, 39,
+	40, 41, 43, 44, 45, 46, 47, 19, 20, 21,
+	0, 17, 0, 290, 0, 19, 20, 21, 50, 17,
+	49, 288, 57, 0, 51, 52, 54, 55, 56, 59,
+	58, 60, 61, 64, 63, 62, 33, 0, 32, 0,
 	42, 0, 34, 35, 37, 38, 39, 40, 41, 43,
-	44, 45, 46, 47, 19, 20, 21, 0, 17, 0,
-	289, 0, 19, 20, 21, 50, 17, 49, 287, 57,
-	0, 51, 52, 54, 55, 56, 59, 58, 60, 61,
-	64, 63, 62, 33, 0, 32, 0, 42, 0, 34,
-	35, 37, 38, 39, 40, 41, 43, 44, 45, 46,
-	47, 23, 26, 24, 25, 27, 14, 0, 15, 23,
-	26, 24, 25, 27, 14, 0, 15, 19, 20, 21,
-	0, 17, 0, 9, 0, 19, 20, 21, 0, 17,
-	0, 161, 19, 20, 21, 0, 0, 0, 216, 0,
-	22, 261, 0, 262, 264, 265, 0, 263, 22, 0,
-	0, 0, 65, 3, 0, 266, 0, 0, 0, 0,
-	0, 0, 0, 0, 23, 26, 24, 25, 27, 14,
-	0, 15, 23, 26, 24, 25, 27, 0, 0, 23,
-	26, 24, 25, 27, 163, 165, 166, 167, 168, 169,
+	44, 45, 46, 47, 203, 23, 26, 24, 25, 27,
+	14, 0, 15, 23, 26, 24, 25, 27, 14, 0,
+	15, 19, 20, 21, 0, 17, 0, 9, 0, 19,
+	20, 21, 0, 17, 0, 161, 0, 0, 0, 0,
+	0, 0, 0, 0, 22, 19, 20, 21, 0, 0,
+	0, 216, 22, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 23,
+	26, 24, 25, 27, 14, 0, 15, 23, 26, 24,
+	25, 27, 0, 72, 73, 0, 74, 75, 76, 77,
+	0, 0, 0, 23, 26, 24, 25, 27, 0, 131,
+	0, 0, 0, 0, 0, 0, 0, 0, 22, 0,
+	0, 0, 65, 3, 0, 0, 22, 118, 119, 120,
+	121, 122, 124, 123, 125, 126, 0, 0, 127, 128,
+	129, 130, 22, 0, 0, 134, 132, 133, 137, 138,
+	139, 135, 140, 136, 163, 165, 166, 167, 168, 169,
 	170, 171, 172, 173, 174, 175, 176, 177, 178, 179,
-	180, 131, 0, 22, 0, 0, 0, 0, 0, 0,
-	0, 22, 0, 0, 0, 0, 0, 0, 22, 118,
-	119, 120, 121, 122, 124, 123, 125, 126, 0, 127,
-	128, 129, 130, 0, 0, 0, 134, 132, 133, 137,
-	138, 139, 135, 140, 136, 102, 103, 104, 108, 0,
-	0, 0, 208, 0, 0, 107, 105, 106, 110, 109,
-	111, 112, 113, 114, 115, 116, 117, 102, 103, 104,
-	108, 0, 0, 0, 0, 0, 0, 107, 105, 106,
-	110, 109, 111, 112, 113, 114, 115, 116, 117,
+	180, 102, 103, 104, 108, 0, 0, 0, 208, 0,
+	0, 107, 105, 106, 110, 109, 111, 112, 113, 114,
+	115, 116, 117, 102, 103, 104, 108, 0, 0, 0,
+	0, 0, 0, 107, 105, 106, 110, 109, 111, 112,
+	113, 114, 115, 116, 117,
 }
 var yyPact = [...]int{
 
-	781, -34, -41, 633, -1000, 611, -1000, -1000, -1000, 781,
-	-1000, 532, -1000, 525, 304, 303, -1000, 368, -1000, -1000,
-	-1000, -1000, 335, 302, 301, 280, 278, 275, -1000, 268,
-	179, 258, 258, 258, 258, 258, 258, 258, 258, 258,
-	258, 258, 258, 258, 258, 258, 258, 258, 178, 178,
-	178, 178, 178, 178, 178, 178, 178, 178, 178, 178,
-	178, 178, 178, 178, 178, 589, 24, 564, 396, 182,
-	234, 910, 257, 257, 257, 257, 257, 257, -1000, -1000,
-	-1000, -1000, -1000, -1000, 796, 796, 796, 796, 796, 796,
-	796, 418, 862, -1000, 498, 418, 418, 418, -1000, -1000,
+	775, -31, -36, 625, -1000, 603, -1000, -1000, -1000, 775,
+	-1000, 530, -1000, 402, 304, 303, -1000, 369, -1000, -1000,
+	-1000, -1000, 336, 302, 286, 281, 277, 259, -1000, 258,
+	179, 257, 257, 257, 257, 257, 257, 257, 257, 257,
+	257, 257, 257, 257, 257, 257, 257, 257, 194, 194,
+	194, 194, 194, 194, 194, 194, 194, 194, 194, 194,
+	194, 194, 194, 194, 194, 581, 22, 559, 751, 182,
+	234, 916, 256, 256, 256, 256, 256, 256, -1000, -1000,
+	-1000, -1000, -1000, -1000, 799, 799, 799, 799, 799, 799,
+	799, 419, 850, -1000, 503, 419, 419, 419, -1000, -1000,
 	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
 	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
 	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
-	-1000, 363, 361, 355, 108, 353, 351, 261, 784, 80,
-	65, -1000, -1000, -1000, 151, 418, 418, 418, 418, 188,
-	-1000, 611, -1000, -1000, -1000, -1000, 256, 255, 254, 216,
-	212, 789, 210, 680, 726, -1000, -1000, -1000, -1000, 680,
+	-1000, 356, 354, 352, 108, 341, 334, 254, 291, 78,
+	65, -1000, -1000, -1000, 177, 419, 419, 419, 419, 188,
+	-1000, 603, -1000, -1000, -1000, -1000, 255, 237, 236, 229,
+	220, 783, 216, 672, 719, -1000, -1000, -1000, -1000, 672,
 	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
-	-1000, 662, 178, -1000, -1000, -1000, -1000, 662, -1000, -1000,
+	-1000, 654, 194, -1000, -1000, -1000, -1000, 654, -1000, -1000,
 	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
-	-1000, 219, -1000, -1000, -1000, -1000, -23, -1000, 718, -8,
-	-8, -77, -77, -77, -77, -52, 796, -12, -12, -80,
-	-80, -80, -80, 488, 235, -1000, -1000, -1000, -1000, -1000,
-	418, 418, 418, 418, 418, 418, 418, 418, 418, 418,
-	418, 418, 418, 418, 418, 418, 458, -48, -48, 30,
-	19, 18, 17, 340, 333, 15, 14, -1000, -1000, -1000,
+	-1000, 219, -1000, -1000, -1000, -1000, -24, -1000, 711, -9,
+	-9, -78, -78, -78, -78, -53, 799, -13, -13, -81,
+	-81, -81, -81, 491, 199, -1000, -1000, -1000, -1000, -1000,
+	419, 419, 419, 419, 419, 419, 419, 419, 419, 419,
+	419, 419, 419, 419, 419, 419, 460, -49, -49, 30,
+	28, 18, 17, 321, 319, 14, 13, -1000, -1000, -1000,
 	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
-	-1000, 446, 408, 64, 54, 199, -1000, -50, 149, 144,
-	862, 862, 111, 564, 227, 139, 22, 726, -1000, 718,
-	-46, -1000, -1000, 862, -48, -48, -81, -81, -81, -66,
-	-66, -66, -66, -66, -66, -66, -66, -81, 105, 105,
-	-1000, -1000, -1000, -1000, -1000, 9, -20, -1000, -1000, -1000,
-	-1000, -1000, -1000, -1000, 188, 932, 48, 47, 104, 134,
-	197, -1000, 219, -1000, -1000, -1000, -1000, -1000, 196, 194,
-	357, 38, -1000, 321, 862, 862, 180, -1000, -1000, 192,
-	160, 158, 156, 347, 36, 862, -1000, 311, -1000, -1000,
-	-1000, -1000, 186, 106, 96, 862, -1000, 240, 100, 109,
-	-1000, -1000,
+	-1000, -1000, 448, 410, 64, 54, 197, -1000, -51, 175,
+	151, 850, 850, 293, 559, 516, 145, 9, 719, -1000,
+	711, -42, -1000, -1000, 850, -49, -49, -82, -82, -82,
+	-67, -67, -67, -67, -67, -67, -67, -67, -82, 104,
+	104, -1000, -1000, -1000, -1000, -1000, 8, -21, -1000, -1000,
+	-1000, -1000, -1000, -1000, -1000, 188, 938, 47, 46, 99,
+	140, 180, -1000, 219, -1000, -1000, -1000, -1000, -1000, 212,
+	203, 358, 37, -1000, 313, 850, 850, 160, -1000, -1000,
+	196, 158, 156, 109, 348, 35, 850, -1000, 311, -1000,
+	-1000, -1000, -1000, 186, 107, 96, 850, -1000, 260, 105,
+	135, -1000, -1000,
 }
 var yyPgo = [...]int{
 
-	0, 411, 7, 410, 5, 6, 1, 822, 404, 14,
-	10, 3, 320, 382, 381, 143, 13, 378, 371, 12,
-	19, 9, 4, 2, 0, 18, 369, 8, 361, 339,
+	0, 406, 7, 405, 5, 6, 1, 872, 383, 14,
+	10, 3, 328, 382, 379, 144, 13, 372, 370, 12,
+	19, 9, 4, 2, 0, 18, 368, 8, 366, 362,
 }
 var yyR1 = [...]int{
 
@@ -435,8 +438,8 @@ var yyR1 = [...]int{
 	21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
 	22, 22, 22, 22, 22, 22, 22, 22, 22, 22,
 	22, 22, 22, 24, 24, 24, 24, 24, 24, 24,
-	24, 24, 24, 24, 24, 24, 23, 23, 23, 23,
-	23, 23, 23, 23,
+	24, 24, 24, 24, 24, 24, 24, 23, 23, 23,
+	23, 23, 23, 23, 23,
 }
 var yyR2 = [...]int{
 
@@ -458,49 +461,49 @@ var yyR2 = [...]int{
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
 	1, 1, 1, 2, 2, 2, 2, 2, 2, 2,
-	2, 2, 2, 2, 2, 2, 3, 3, 3, 3,
-	4, 4, 3, 3,
+	2, 2, 2, 2, 2, 2, 2, 3, 3, 3,
+	3, 4, 4, 3, 3,
 }
 var yyChk = [...]int{
 
 	-1000, -1, -9, -7, -14, -6, -11, -2, -4, 12,
-	-8, -15, -10, -16, 58, 60, -17, 10, -19, 6,
-	7, 8, 92, 53, 55, 56, 54, 57, -29, 67,
-	68, 69, 75, 73, 79, 80, 70, 81, 82, 83,
-	84, 85, 77, 86, 87, 88, 89, 90, 69, 75,
-	73, 79, 80, 70, 81, 82, 83, 77, 85, 84,
-	86, 87, 90, 89, 88, -7, -9, -6, -15, -18,
-	-16, -12, 91, 92, 94, 95, 96, 97, 71, 72,
-	73, 74, 75, 76, -12, 91, 92, 94, 95, 96,
-	97, 12, 12, 11, -20, 12, 92, 93, -21, -22,
+	-8, -15, -10, -16, 59, 61, -17, 10, -19, 6,
+	7, 8, 93, 54, 56, 57, 55, 58, -29, 68,
+	69, 70, 76, 74, 80, 81, 71, 82, 83, 84,
+	85, 86, 78, 87, 88, 89, 90, 91, 70, 76,
+	74, 80, 81, 71, 82, 83, 84, 78, 86, 85,
+	87, 88, 91, 90, 89, -7, -9, -6, -15, -18,
+	-16, -12, 92, 93, 95, 96, 97, 98, 72, 73,
+	74, 75, 76, 77, -12, 92, 93, 95, 96, 97,
+	98, 12, 12, 11, -20, 12, 93, 94, -21, -22,
 	-23, -24, 5, 6, 7, 16, 17, 15, 8, 19,
 	18, 20, 21, 22, 23, 24, 25, 26, 27, 28,
-	29, 30, 31, 33, 32, 34, 35, 37, 38, 39,
-	40, 9, 45, 46, 44, 50, 52, 47, 48, 49,
-	51, 6, 7, 8, 12, 12, 12, 12, 12, 12,
-	-13, -6, -11, -2, -3, -4, 62, 63, 64, 65,
-	66, 12, 59, -7, 12, -7, -7, -7, -7, -7,
+	29, 30, 31, 33, 32, 34, 35, 38, 39, 40,
+	41, 9, 46, 47, 45, 51, 53, 48, 49, 50,
+	52, 6, 7, 8, 12, 12, 12, 12, 12, 12,
+	-13, -6, -11, -2, -3, -4, 63, 64, 65, 66,
+	67, 12, 60, -7, 12, -7, -7, -7, -7, -7,
 	-7, -7, -7, -7, -7, -7, -7, -7, -7, -7,
 	-7, -6, 12, -6, -6, -6, -6, -6, -6, -6,
 	-6, -6, -6, -6, -6, -6, -6, -6, -6, 13,
-	13, 68, 13, 13, 13, 13, -15, -21, 12, -15,
+	13, 69, 13, 13, 13, 13, -15, -21, 12, -15,
 	-15, -15, -15, -15, -15, -16, 12, -16, -16, -16,
 	-16, -16, -16, -20, -5, -25, -22, -23, -24, 11,
-	91, 92, 94, 95, 96, 71, 72, 73, 74, 75,
-	76, 78, 77, 97, 69, 70, -20, -20, -20, 4,
-	4, 4, 4, 45, 46, 4, 4, 27, 34, 36,
-	41, 27, 29, 33, 30, 31, 41, 29, 42, 43,
-	13, -20, -20, -20, -20, -28, -27, 4, 12, 12,
-	12, 12, 12, -6, -16, 12, -9, 12, -19, 12,
-	-9, 13, 13, 14, -20, -20, -20, -20, -20, -20,
+	92, 93, 95, 96, 97, 72, 73, 74, 75, 76,
+	77, 79, 78, 98, 70, 71, -20, -20, -20, 4,
+	4, 4, 4, 46, 47, 4, 4, 27, 34, 37,
+	42, 27, 29, 33, 30, 31, 42, 29, 36, 43,
+	44, 13, -20, -20, -20, -20, -28, -27, 4, 12,
+	12, 12, 12, 12, -6, -16, 12, -9, 12, -19,
+	12, -9, 13, 13, 14, -20, -20, -20, -20, -20,
 	-20, -20, -20, -20, -20, -20, -20, -20, -20, -20,
-	13, 61, 61, 61, 61, 4, 4, 61, 61, 13,
-	13, 13, 13, 13, 14, 71, 13, 13, -25, -25,
-	-10, 13, 68, -25, 61, 61, -27, -21, 58, 58,
-	14, 13, 13, 14, 12, 12, -26, 7, 6, 58,
-	6, -5, -5, 14, 13, 12, 13, 14, 13, 13,
-	7, 6, 58, -5, 6, 12, 13, 14, -5, 6,
-	13, 13,
+	-20, 13, 62, 62, 62, 62, 4, 4, 62, 62,
+	13, 13, 13, 13, 13, 14, 72, 13, 13, -25,
+	-25, -10, 13, 69, -25, 62, 62, -27, -21, 59,
+	59, 14, 13, 13, 14, 12, 12, -26, 7, 6,
+	59, 6, -5, -5, 14, 13, 12, 13, 14, 13,
+	13, 7, 6, 59, -5, 6, 12, 13, 14, -5,
+	6, 13, 13,
 }
 var yyDef = [...]int{
 
@@ -531,17 +534,17 @@ var yyDef = [...]int{
 	0, 0, 0, 0, 0, 0, 0, 138, 139, 0,
 	0, 0, 0, 0, 0, 0, 0, 173, 174, 175,
 	176, 177, 178, 179, 180, 181, 182, 183, 184, 185,
-	101, 0, 0, 0, 0, 0, 119, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, -2, 0,
-	0, 35, 37, 0, 122, 123, 124, 125, 126, 127,
-	128, 129, 130, 131, 132, 133, 134, 135, 136, 137,
-	121, 186, 187, 188, 189, 0, 0, 192, 193, 102,
-	103, 104, 105, 118, 0, 0, 106, 108, 0, 0,
-	0, 36, 0, 42, 190, 191, 120, 117, 0, 0,
-	0, 112, 114, 0, 0, 0, 0, 43, 44, 0,
-	0, 0, 0, 0, 110, 0, 115, 0, 107, 109,
-	45, 46, 0, 0, 0, 0, 113, 0, 0, 0,
-	111, 116,
+	186, 101, 0, 0, 0, 0, 0, 119, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, -2,
+	0, 0, 35, 37, 0, 122, 123, 124, 125, 126,
+	127, 128, 129, 130, 131, 132, 133, 134, 135, 136,
+	137, 121, 187, 188, 189, 190, 0, 0, 193, 194,
+	102, 103, 104, 105, 118, 0, 0, 106, 108, 0,
+	0, 0, 36, 0, 42, 191, 192, 120, 117, 0,
+	0, 0, 112, 114, 0, 0, 0, 0, 43, 44,
+	0, 0, 0, 0, 0, 110, 0, 115, 0, 107,
+	109, 45, 46, 0, 0, 0, 0, 113, 0, 0,
+	0, 111, 116,
 }
 var yyTok1 = [...]int{
 
@@ -558,7 +561,7 @@ var yyTok2 = [...]int{
 	62, 63, 64, 65, 66, 67, 68, 69, 70, 71,
 	72, 73, 74, 75, 76, 77, 78, 79, 80, 81,
 	82, 83, 84, 85, 86, 87, 88, 89, 90, 91,
-	92, 93, 94, 95, 96, 97,
+	92, 93, 94, 95, 96, 97, 98,
 }
 var yyTok3 = [...]int{
 	0,
@@ -903,1099 +906,1099 @@ yydefault:
 
 	case 1:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:118
+//line pkg/traceql/expr.y:119
 		{
 			yylex.(*lexer).expr = newRootExpr(yyDollar[1].spansetPipeline)
 		}
 	case 2:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:119
+//line pkg/traceql/expr.y:120
 		{
 			yylex.(*lexer).expr = newRootExpr(yyDollar[1].spansetPipelineExpression)
 		}
 	case 3:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:120
+//line pkg/traceql/expr.y:121
 		{
 			yylex.(*lexer).expr = newRootExpr(yyDollar[1].scalarPipelineExpressionFilter)
 		}
 	case 4:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:121
+//line pkg/traceql/expr.y:122
 		{
 			yylex.(*lexer).expr = newRootExprWithMetrics(yyDollar[1].spansetPipeline, yyDollar[3].metricsAggregation)
 		}
 	case 5:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line pkg/traceql/expr.y:122
+//line pkg/traceql/expr.y:123
 		{
 			yylex.(*lexer).expr.withHints(yyDollar[2].hints)
 		}
 	case 6:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:129
+//line pkg/traceql/expr.y:130
 		{
 			yyVAL.spansetPipelineExpression = yyDollar[2].spansetPipelineExpression
 		}
 	case 7:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:130
+//line pkg/traceql/expr.y:131
 		{
 			yyVAL.spansetPipelineExpression = newSpansetOperation(OpSpansetAnd, yyDollar[1].spansetPipelineExpression, yyDollar[3].spansetPipelineExpression)
 		}
 	case 8:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:131
+//line pkg/traceql/expr.y:132
 		{
 			yyVAL.spansetPipelineExpression = newSpansetOperation(OpSpansetChild, yyDollar[1].spansetPipelineExpression, yyDollar[3].spansetPipelineExpression)
 		}
 	case 9:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:132
+//line pkg/traceql/expr.y:133
 		{
 			yyVAL.spansetPipelineExpression = newSpansetOperation(OpSpansetParent, yyDollar[1].spansetPipelineExpression, yyDollar[3].spansetPipelineExpression)
 		}
 	case 10:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:133
+//line pkg/traceql/expr.y:134
 		{
 			yyVAL.spansetPipelineExpression = newSpansetOperation(OpSpansetDescendant, yyDollar[1].spansetPipelineExpression, yyDollar[3].spansetPipelineExpression)
 		}
 	case 11:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:134
+//line pkg/traceql/expr.y:135
 		{
 			yyVAL.spansetPipelineExpression = newSpansetOperation(OpSpansetAncestor, yyDollar[1].spansetPipelineExpression, yyDollar[3].spansetPipelineExpression)
 		}
 	case 12:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:135
+//line pkg/traceql/expr.y:136
 		{
 			yyVAL.spansetPipelineExpression = newSpansetOperation(OpSpansetUnion, yyDollar[1].spansetPipelineExpression, yyDollar[3].spansetPipelineExpression)
 		}
 	case 13:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:136
+//line pkg/traceql/expr.y:137
 		{
 			yyVAL.spansetPipelineExpression = newSpansetOperation(OpSpansetSibling, yyDollar[1].spansetPipelineExpression, yyDollar[3].spansetPipelineExpression)
 		}
 	case 14:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:137
+//line pkg/traceql/expr.y:138
 		{
 			yyVAL.spansetPipelineExpression = newSpansetOperation(OpSpansetNotChild, yyDollar[1].spansetPipelineExpression, yyDollar[3].spansetPipelineExpression)
 		}
 	case 15:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:138
+//line pkg/traceql/expr.y:139
 		{
 			yyVAL.spansetPipelineExpression = newSpansetOperation(OpSpansetNotParent, yyDollar[1].spansetPipelineExpression, yyDollar[3].spansetPipelineExpression)
 		}
 	case 16:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:139
+//line pkg/traceql/expr.y:140
 		{
 			yyVAL.spansetPipelineExpression = newSpansetOperation(OpSpansetNotDescendant, yyDollar[1].spansetPipelineExpression, yyDollar[3].spansetPipelineExpression)
 		}
 	case 17:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:140
+//line pkg/traceql/expr.y:141
 		{
 			yyVAL.spansetPipelineExpression = newSpansetOperation(OpSpansetNotAncestor, yyDollar[1].spansetPipelineExpression, yyDollar[3].spansetPipelineExpression)
 		}
 	case 18:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:141
+//line pkg/traceql/expr.y:142
 		{
 			yyVAL.spansetPipelineExpression = newSpansetOperation(OpSpansetNotSibling, yyDollar[1].spansetPipelineExpression, yyDollar[3].spansetPipelineExpression)
 		}
 	case 19:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:142
+//line pkg/traceql/expr.y:143
 		{
 			yyVAL.spansetPipelineExpression = newSpansetOperation(OpSpansetUnionChild, yyDollar[1].spansetPipelineExpression, yyDollar[3].spansetPipelineExpression)
 		}
 	case 20:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:143
+//line pkg/traceql/expr.y:144
 		{
 			yyVAL.spansetPipelineExpression = newSpansetOperation(OpSpansetUnionParent, yyDollar[1].spansetPipelineExpression, yyDollar[3].spansetPipelineExpression)
 		}
 	case 21:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:144
+//line pkg/traceql/expr.y:145
 		{
 			yyVAL.spansetPipelineExpression = newSpansetOperation(OpSpansetUnionDescendant, yyDollar[1].spansetPipelineExpression, yyDollar[3].spansetPipelineExpression)
 		}
 	case 22:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:145
+//line pkg/traceql/expr.y:146
 		{
 			yyVAL.spansetPipelineExpression = newSpansetOperation(OpSpansetUnionAncestor, yyDollar[1].spansetPipelineExpression, yyDollar[3].spansetPipelineExpression)
 		}
 	case 23:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:146
+//line pkg/traceql/expr.y:147
 		{
 			yyVAL.spansetPipelineExpression = newSpansetOperation(OpSpansetUnionSibling, yyDollar[1].spansetPipelineExpression, yyDollar[3].spansetPipelineExpression)
 		}
 	case 24:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:147
+//line pkg/traceql/expr.y:148
 		{
 			yyVAL.spansetPipelineExpression = yyDollar[1].wrappedSpansetPipeline
 		}
 	case 25:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:151
+//line pkg/traceql/expr.y:152
 		{
 			yyVAL.wrappedSpansetPipeline = yyDollar[2].spansetPipeline
 		}
 	case 26:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:154
+//line pkg/traceql/expr.y:155
 		{
 			yyVAL.spansetPipeline = newPipeline(yyDollar[1].spansetExpression)
 		}
 	case 27:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:155
+//line pkg/traceql/expr.y:156
 		{
 			yyVAL.spansetPipeline = newPipeline(yyDollar[1].scalarFilter)
 		}
 	case 28:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:156
+//line pkg/traceql/expr.y:157
 		{
 			yyVAL.spansetPipeline = newPipeline(yyDollar[1].groupOperation)
 		}
 	case 29:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:157
+//line pkg/traceql/expr.y:158
 		{
 			yyVAL.spansetPipeline = newPipeline(yyDollar[1].selectOperation)
 		}
 	case 30:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:158
+//line pkg/traceql/expr.y:159
 		{
 			yyVAL.spansetPipeline = yyDollar[1].spansetPipeline.addItem(yyDollar[3].spansetExpression)
 		}
 	case 31:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:159
+//line pkg/traceql/expr.y:160
 		{
 			yyVAL.spansetPipeline = yyDollar[1].spansetPipeline.addItem(yyDollar[3].scalarFilter)
 		}
 	case 32:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:160
+//line pkg/traceql/expr.y:161
 		{
 			yyVAL.spansetPipeline = yyDollar[1].spansetPipeline.addItem(yyDollar[3].groupOperation)
 		}
 	case 33:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:161
+//line pkg/traceql/expr.y:162
 		{
 			yyVAL.spansetPipeline = yyDollar[1].spansetPipeline.addItem(yyDollar[3].coalesceOperation)
 		}
 	case 34:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:162
+//line pkg/traceql/expr.y:163
 		{
 			yyVAL.spansetPipeline = yyDollar[1].spansetPipeline.addItem(yyDollar[3].selectOperation)
 		}
 	case 35:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line pkg/traceql/expr.y:166
+//line pkg/traceql/expr.y:167
 		{
 			yyVAL.groupOperation = newGroupOperation(yyDollar[3].fieldExpression)
 		}
 	case 36:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:170
+//line pkg/traceql/expr.y:171
 		{
 			yyVAL.coalesceOperation = newCoalesceOperation()
 		}
 	case 37:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line pkg/traceql/expr.y:174
+//line pkg/traceql/expr.y:175
 		{
 			yyVAL.selectOperation = newSelectOperation(yyDollar[3].attributeList)
 		}
 	case 38:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:178
+//line pkg/traceql/expr.y:179
 		{
 			yyVAL.attribute = yyDollar[1].intrinsicField
 		}
 	case 39:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:179
+//line pkg/traceql/expr.y:180
 		{
 			yyVAL.attribute = yyDollar[1].attributeField
 		}
 	case 40:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:180
+//line pkg/traceql/expr.y:181
 		{
 			yyVAL.attribute = yyDollar[1].scopedIntrinsicField
 		}
 	case 41:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:184
+//line pkg/traceql/expr.y:185
 		{
 			yyVAL.attributeList = []Attribute{yyDollar[1].attribute}
 		}
 	case 42:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:185
+//line pkg/traceql/expr.y:186
 		{
 			yyVAL.attributeList = append(yyDollar[1].attributeList, yyDollar[3].attribute)
 		}
 	case 43:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:190
+//line pkg/traceql/expr.y:191
 		{
 			yyVAL.numericList = []float64{yyDollar[1].staticFloat}
 		}
 	case 44:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:191
+//line pkg/traceql/expr.y:192
 		{
 			yyVAL.numericList = []float64{float64(yyDollar[1].staticInt)}
 		}
 	case 45:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:192
+//line pkg/traceql/expr.y:193
 		{
 			yyVAL.numericList = append(yyDollar[1].numericList, yyDollar[3].staticFloat)
 		}
 	case 46:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:193
+//line pkg/traceql/expr.y:194
 		{
 			yyVAL.numericList = append(yyDollar[1].numericList, float64(yyDollar[3].staticInt))
 		}
 	case 47:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:197
+//line pkg/traceql/expr.y:198
 		{
 			yyVAL.spansetExpression = yyDollar[2].spansetExpression
 		}
 	case 48:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:198
+//line pkg/traceql/expr.y:199
 		{
 			yyVAL.spansetExpression = newSpansetOperation(OpSpansetAnd, yyDollar[1].spansetExpression, yyDollar[3].spansetExpression)
 		}
 	case 49:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:199
+//line pkg/traceql/expr.y:200
 		{
 			yyVAL.spansetExpression = newSpansetOperation(OpSpansetChild, yyDollar[1].spansetExpression, yyDollar[3].spansetExpression)
 		}
 	case 50:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:200
+//line pkg/traceql/expr.y:201
 		{
 			yyVAL.spansetExpression = newSpansetOperation(OpSpansetParent, yyDollar[1].spansetExpression, yyDollar[3].spansetExpression)
 		}
 	case 51:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:201
+//line pkg/traceql/expr.y:202
 		{
 			yyVAL.spansetExpression = newSpansetOperation(OpSpansetDescendant, yyDollar[1].spansetExpression, yyDollar[3].spansetExpression)
 		}
 	case 52:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:202
+//line pkg/traceql/expr.y:203
 		{
 			yyVAL.spansetExpression = newSpansetOperation(OpSpansetAncestor, yyDollar[1].spansetExpression, yyDollar[3].spansetExpression)
 		}
 	case 53:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:203
+//line pkg/traceql/expr.y:204
 		{
 			yyVAL.spansetExpression = newSpansetOperation(OpSpansetUnion, yyDollar[1].spansetExpression, yyDollar[3].spansetExpression)
 		}
 	case 54:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:204
+//line pkg/traceql/expr.y:205
 		{
 			yyVAL.spansetExpression = newSpansetOperation(OpSpansetSibling, yyDollar[1].spansetExpression, yyDollar[3].spansetExpression)
 		}
 	case 55:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:206
+//line pkg/traceql/expr.y:207
 		{
 			yyVAL.spansetExpression = newSpansetOperation(OpSpansetNotChild, yyDollar[1].spansetExpression, yyDollar[3].spansetExpression)
 		}
 	case 56:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:207
+//line pkg/traceql/expr.y:208
 		{
 			yyVAL.spansetExpression = newSpansetOperation(OpSpansetNotParent, yyDollar[1].spansetExpression, yyDollar[3].spansetExpression)
 		}
 	case 57:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:208
+//line pkg/traceql/expr.y:209
 		{
 			yyVAL.spansetExpression = newSpansetOperation(OpSpansetNotSibling, yyDollar[1].spansetExpression, yyDollar[3].spansetExpression)
 		}
 	case 58:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:209
+//line pkg/traceql/expr.y:210
 		{
 			yyVAL.spansetExpression = newSpansetOperation(OpSpansetNotAncestor, yyDollar[1].spansetExpression, yyDollar[3].spansetExpression)
 		}
 	case 59:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:210
+//line pkg/traceql/expr.y:211
 		{
 			yyVAL.spansetExpression = newSpansetOperation(OpSpansetNotDescendant, yyDollar[1].spansetExpression, yyDollar[3].spansetExpression)
 		}
 	case 60:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:212
+//line pkg/traceql/expr.y:213
 		{
 			yyVAL.spansetExpression = newSpansetOperation(OpSpansetUnionChild, yyDollar[1].spansetExpression, yyDollar[3].spansetExpression)
 		}
 	case 61:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:213
+//line pkg/traceql/expr.y:214
 		{
 			yyVAL.spansetExpression = newSpansetOperation(OpSpansetUnionParent, yyDollar[1].spansetExpression, yyDollar[3].spansetExpression)
 		}
 	case 62:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:214
+//line pkg/traceql/expr.y:215
 		{
 			yyVAL.spansetExpression = newSpansetOperation(OpSpansetUnionSibling, yyDollar[1].spansetExpression, yyDollar[3].spansetExpression)
 		}
 	case 63:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:215
+//line pkg/traceql/expr.y:216
 		{
 			yyVAL.spansetExpression = newSpansetOperation(OpSpansetUnionAncestor, yyDollar[1].spansetExpression, yyDollar[3].spansetExpression)
 		}
 	case 64:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:216
+//line pkg/traceql/expr.y:217
 		{
 			yyVAL.spansetExpression = newSpansetOperation(OpSpansetUnionDescendant, yyDollar[1].spansetExpression, yyDollar[3].spansetExpression)
 		}
 	case 65:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:218
+//line pkg/traceql/expr.y:219
 		{
 			yyVAL.spansetExpression = yyDollar[1].spansetFilter
 		}
 	case 66:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line pkg/traceql/expr.y:222
+//line pkg/traceql/expr.y:223
 		{
 			yyVAL.spansetFilter = newSpansetFilter(NewStaticBool(true))
 		}
 	case 67:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:223
+//line pkg/traceql/expr.y:224
 		{
 			yyVAL.spansetFilter = newSpansetFilter(yyDollar[2].fieldExpression)
 		}
 	case 68:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:227
+//line pkg/traceql/expr.y:228
 		{
 			yyVAL.scalarFilter = newScalarFilter(yyDollar[2].scalarFilterOperation, yyDollar[1].scalarExpression, yyDollar[3].scalarExpression)
 		}
 	case 69:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:231
+//line pkg/traceql/expr.y:232
 		{
 			yyVAL.scalarFilterOperation = OpEqual
 		}
 	case 70:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:232
+//line pkg/traceql/expr.y:233
 		{
 			yyVAL.scalarFilterOperation = OpNotEqual
 		}
 	case 71:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:233
+//line pkg/traceql/expr.y:234
 		{
 			yyVAL.scalarFilterOperation = OpLess
 		}
 	case 72:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:234
+//line pkg/traceql/expr.y:235
 		{
 			yyVAL.scalarFilterOperation = OpLessEqual
 		}
 	case 73:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:235
+//line pkg/traceql/expr.y:236
 		{
 			yyVAL.scalarFilterOperation = OpGreater
 		}
 	case 74:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:236
+//line pkg/traceql/expr.y:237
 		{
 			yyVAL.scalarFilterOperation = OpGreaterEqual
 		}
 	case 75:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:243
+//line pkg/traceql/expr.y:244
 		{
 			yyVAL.scalarPipelineExpressionFilter = newScalarFilter(yyDollar[2].scalarFilterOperation, yyDollar[1].scalarPipelineExpression, yyDollar[3].scalarPipelineExpression)
 		}
 	case 76:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:244
+//line pkg/traceql/expr.y:245
 		{
 			yyVAL.scalarPipelineExpressionFilter = newScalarFilter(yyDollar[2].scalarFilterOperation, yyDollar[1].scalarPipelineExpression, yyDollar[3].static)
 		}
 	case 77:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:248
+//line pkg/traceql/expr.y:249
 		{
 			yyVAL.scalarPipelineExpression = yyDollar[2].scalarPipelineExpression
 		}
 	case 78:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:249
+//line pkg/traceql/expr.y:250
 		{
 			yyVAL.scalarPipelineExpression = newScalarOperation(OpAdd, yyDollar[1].scalarPipelineExpression, yyDollar[3].scalarPipelineExpression)
 		}
 	case 79:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:250
+//line pkg/traceql/expr.y:251
 		{
 			yyVAL.scalarPipelineExpression = newScalarOperation(OpSub, yyDollar[1].scalarPipelineExpression, yyDollar[3].scalarPipelineExpression)
 		}
 	case 80:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:251
+//line pkg/traceql/expr.y:252
 		{
 			yyVAL.scalarPipelineExpression = newScalarOperation(OpMult, yyDollar[1].scalarPipelineExpression, yyDollar[3].scalarPipelineExpression)
 		}
 	case 81:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:252
+//line pkg/traceql/expr.y:253
 		{
 			yyVAL.scalarPipelineExpression = newScalarOperation(OpDiv, yyDollar[1].scalarPipelineExpression, yyDollar[3].scalarPipelineExpression)
 		}
 	case 82:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:253
+//line pkg/traceql/expr.y:254
 		{
 			yyVAL.scalarPipelineExpression = newScalarOperation(OpMod, yyDollar[1].scalarPipelineExpression, yyDollar[3].scalarPipelineExpression)
 		}
 	case 83:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:254
+//line pkg/traceql/expr.y:255
 		{
 			yyVAL.scalarPipelineExpression = newScalarOperation(OpPower, yyDollar[1].scalarPipelineExpression, yyDollar[3].scalarPipelineExpression)
 		}
 	case 84:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:255
+//line pkg/traceql/expr.y:256
 		{
 			yyVAL.scalarPipelineExpression = yyDollar[1].wrappedScalarPipeline
 		}
 	case 85:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:259
+//line pkg/traceql/expr.y:260
 		{
 			yyVAL.wrappedScalarPipeline = yyDollar[2].scalarPipeline
 		}
 	case 86:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:263
+//line pkg/traceql/expr.y:264
 		{
 			yyVAL.scalarPipeline = yyDollar[1].spansetPipeline.addItem(yyDollar[3].aggregate)
 		}
 	case 87:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:267
+//line pkg/traceql/expr.y:268
 		{
 			yyVAL.scalarExpression = yyDollar[2].scalarExpression
 		}
 	case 88:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:268
+//line pkg/traceql/expr.y:269
 		{
 			yyVAL.scalarExpression = newScalarOperation(OpAdd, yyDollar[1].scalarExpression, yyDollar[3].scalarExpression)
 		}
 	case 89:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:269
+//line pkg/traceql/expr.y:270
 		{
 			yyVAL.scalarExpression = newScalarOperation(OpSub, yyDollar[1].scalarExpression, yyDollar[3].scalarExpression)
 		}
 	case 90:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:270
+//line pkg/traceql/expr.y:271
 		{
 			yyVAL.scalarExpression = newScalarOperation(OpMult, yyDollar[1].scalarExpression, yyDollar[3].scalarExpression)
 		}
 	case 91:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:271
+//line pkg/traceql/expr.y:272
 		{
 			yyVAL.scalarExpression = newScalarOperation(OpDiv, yyDollar[1].scalarExpression, yyDollar[3].scalarExpression)
 		}
 	case 92:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:272
+//line pkg/traceql/expr.y:273
 		{
 			yyVAL.scalarExpression = newScalarOperation(OpMod, yyDollar[1].scalarExpression, yyDollar[3].scalarExpression)
 		}
 	case 93:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:273
+//line pkg/traceql/expr.y:274
 		{
 			yyVAL.scalarExpression = newScalarOperation(OpPower, yyDollar[1].scalarExpression, yyDollar[3].scalarExpression)
 		}
 	case 94:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:274
+//line pkg/traceql/expr.y:275
 		{
 			yyVAL.scalarExpression = yyDollar[1].aggregate
 		}
 	case 95:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:275
+//line pkg/traceql/expr.y:276
 		{
 			yyVAL.scalarExpression = NewStaticInt(yyDollar[1].staticInt)
 		}
 	case 96:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:276
+//line pkg/traceql/expr.y:277
 		{
 			yyVAL.scalarExpression = NewStaticFloat(yyDollar[1].staticFloat)
 		}
 	case 97:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:277
+//line pkg/traceql/expr.y:278
 		{
 			yyVAL.scalarExpression = NewStaticDuration(yyDollar[1].staticDuration)
 		}
 	case 98:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line pkg/traceql/expr.y:278
+//line pkg/traceql/expr.y:279
 		{
 			yyVAL.scalarExpression = NewStaticInt(-yyDollar[2].staticInt)
 		}
 	case 99:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line pkg/traceql/expr.y:279
+//line pkg/traceql/expr.y:280
 		{
 			yyVAL.scalarExpression = NewStaticFloat(-yyDollar[2].staticFloat)
 		}
 	case 100:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line pkg/traceql/expr.y:280
+//line pkg/traceql/expr.y:281
 		{
 			yyVAL.scalarExpression = NewStaticDuration(-yyDollar[2].staticDuration)
 		}
 	case 101:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:284
+//line pkg/traceql/expr.y:285
 		{
 			yyVAL.aggregate = newAggregate(aggregateCount, nil)
 		}
 	case 102:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line pkg/traceql/expr.y:285
+//line pkg/traceql/expr.y:286
 		{
 			yyVAL.aggregate = newAggregate(aggregateMax, yyDollar[3].fieldExpression)
 		}
 	case 103:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line pkg/traceql/expr.y:286
+//line pkg/traceql/expr.y:287
 		{
 			yyVAL.aggregate = newAggregate(aggregateMin, yyDollar[3].fieldExpression)
 		}
 	case 104:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line pkg/traceql/expr.y:287
+//line pkg/traceql/expr.y:288
 		{
 			yyVAL.aggregate = newAggregate(aggregateAvg, yyDollar[3].fieldExpression)
 		}
 	case 105:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line pkg/traceql/expr.y:288
+//line pkg/traceql/expr.y:289
 		{
 			yyVAL.aggregate = newAggregate(aggregateSum, yyDollar[3].fieldExpression)
 		}
 	case 106:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:295
+//line pkg/traceql/expr.y:296
 		{
 			yyVAL.metricsAggregation = newMetricsAggregate(metricsAggregateRate, nil)
 		}
 	case 107:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line pkg/traceql/expr.y:296
+//line pkg/traceql/expr.y:297
 		{
 			yyVAL.metricsAggregation = newMetricsAggregate(metricsAggregateRate, yyDollar[6].attributeList)
 		}
 	case 108:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:297
+//line pkg/traceql/expr.y:298
 		{
 			yyVAL.metricsAggregation = newMetricsAggregate(metricsAggregateCountOverTime, nil)
 		}
 	case 109:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line pkg/traceql/expr.y:298
+//line pkg/traceql/expr.y:299
 		{
 			yyVAL.metricsAggregation = newMetricsAggregate(metricsAggregateCountOverTime, yyDollar[6].attributeList)
 		}
 	case 110:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line pkg/traceql/expr.y:299
+//line pkg/traceql/expr.y:300
 		{
 			yyVAL.metricsAggregation = newMetricsAggregateQuantileOverTime(yyDollar[3].attribute, yyDollar[5].numericList, nil)
 		}
 	case 111:
 		yyDollar = yyS[yypt-10 : yypt+1]
-//line pkg/traceql/expr.y:300
+//line pkg/traceql/expr.y:301
 		{
 			yyVAL.metricsAggregation = newMetricsAggregateQuantileOverTime(yyDollar[3].attribute, yyDollar[5].numericList, yyDollar[9].attributeList)
 		}
 	case 112:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line pkg/traceql/expr.y:301
+//line pkg/traceql/expr.y:302
 		{
 			yyVAL.metricsAggregation = newMetricsAggregateHistogramOverTime(yyDollar[3].attribute, nil)
 		}
 	case 113:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line pkg/traceql/expr.y:302
+//line pkg/traceql/expr.y:303
 		{
 			yyVAL.metricsAggregation = newMetricsAggregateHistogramOverTime(yyDollar[3].attribute, yyDollar[7].attributeList)
 		}
 	case 114:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line pkg/traceql/expr.y:303
+//line pkg/traceql/expr.y:304
 		{
 			yyVAL.metricsAggregation = newMetricsCompare(yyDollar[3].spansetFilter, 10, 0, 0)
 		}
 	case 115:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line pkg/traceql/expr.y:304
+//line pkg/traceql/expr.y:305
 		{
 			yyVAL.metricsAggregation = newMetricsCompare(yyDollar[3].spansetFilter, yyDollar[5].staticInt, 0, 0)
 		}
 	case 116:
 		yyDollar = yyS[yypt-10 : yypt+1]
-//line pkg/traceql/expr.y:305
+//line pkg/traceql/expr.y:306
 		{
 			yyVAL.metricsAggregation = newMetricsCompare(yyDollar[3].spansetFilter, yyDollar[5].staticInt, yyDollar[7].staticInt, yyDollar[9].staticInt)
 		}
 	case 117:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:312
+//line pkg/traceql/expr.y:313
 		{
 			yyVAL.hint = newHint(yyDollar[1].staticStr, yyDollar[3].static)
 		}
 	case 118:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line pkg/traceql/expr.y:316
+//line pkg/traceql/expr.y:317
 		{
 			yyVAL.hints = newHints(yyDollar[3].hintList)
 		}
 	case 119:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:320
+//line pkg/traceql/expr.y:321
 		{
 			yyVAL.hintList = []*Hint{yyDollar[1].hint}
 		}
 	case 120:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:321
+//line pkg/traceql/expr.y:322
 		{
 			yyVAL.hintList = append(yyDollar[1].hintList, yyDollar[3].hint)
 		}
 	case 121:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:329
+//line pkg/traceql/expr.y:330
 		{
 			yyVAL.fieldExpression = yyDollar[2].fieldExpression
 		}
 	case 122:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:330
+//line pkg/traceql/expr.y:331
 		{
 			yyVAL.fieldExpression = newBinaryOperation(OpAdd, yyDollar[1].fieldExpression, yyDollar[3].fieldExpression)
 		}
 	case 123:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:331
+//line pkg/traceql/expr.y:332
 		{
 			yyVAL.fieldExpression = newBinaryOperation(OpSub, yyDollar[1].fieldExpression, yyDollar[3].fieldExpression)
 		}
 	case 124:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:332
+//line pkg/traceql/expr.y:333
 		{
 			yyVAL.fieldExpression = newBinaryOperation(OpMult, yyDollar[1].fieldExpression, yyDollar[3].fieldExpression)
 		}
 	case 125:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:333
+//line pkg/traceql/expr.y:334
 		{
 			yyVAL.fieldExpression = newBinaryOperation(OpDiv, yyDollar[1].fieldExpression, yyDollar[3].fieldExpression)
 		}
 	case 126:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:334
+//line pkg/traceql/expr.y:335
 		{
 			yyVAL.fieldExpression = newBinaryOperation(OpMod, yyDollar[1].fieldExpression, yyDollar[3].fieldExpression)
 		}
 	case 127:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:335
+//line pkg/traceql/expr.y:336
 		{
 			yyVAL.fieldExpression = newBinaryOperation(OpEqual, yyDollar[1].fieldExpression, yyDollar[3].fieldExpression)
 		}
 	case 128:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:336
+//line pkg/traceql/expr.y:337
 		{
 			yyVAL.fieldExpression = newBinaryOperation(OpNotEqual, yyDollar[1].fieldExpression, yyDollar[3].fieldExpression)
 		}
 	case 129:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:337
+//line pkg/traceql/expr.y:338
 		{
 			yyVAL.fieldExpression = newBinaryOperation(OpLess, yyDollar[1].fieldExpression, yyDollar[3].fieldExpression)
 		}
 	case 130:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:338
+//line pkg/traceql/expr.y:339
 		{
 			yyVAL.fieldExpression = newBinaryOperation(OpLessEqual, yyDollar[1].fieldExpression, yyDollar[3].fieldExpression)
 		}
 	case 131:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:339
+//line pkg/traceql/expr.y:340
 		{
 			yyVAL.fieldExpression = newBinaryOperation(OpGreater, yyDollar[1].fieldExpression, yyDollar[3].fieldExpression)
 		}
 	case 132:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:340
+//line pkg/traceql/expr.y:341
 		{
 			yyVAL.fieldExpression = newBinaryOperation(OpGreaterEqual, yyDollar[1].fieldExpression, yyDollar[3].fieldExpression)
 		}
 	case 133:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:341
+//line pkg/traceql/expr.y:342
 		{
 			yyVAL.fieldExpression = newBinaryOperation(OpRegex, yyDollar[1].fieldExpression, yyDollar[3].fieldExpression)
 		}
 	case 134:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:342
+//line pkg/traceql/expr.y:343
 		{
 			yyVAL.fieldExpression = newBinaryOperation(OpNotRegex, yyDollar[1].fieldExpression, yyDollar[3].fieldExpression)
 		}
 	case 135:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:343
+//line pkg/traceql/expr.y:344
 		{
 			yyVAL.fieldExpression = newBinaryOperation(OpPower, yyDollar[1].fieldExpression, yyDollar[3].fieldExpression)
 		}
 	case 136:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:344
+//line pkg/traceql/expr.y:345
 		{
 			yyVAL.fieldExpression = newBinaryOperation(OpAnd, yyDollar[1].fieldExpression, yyDollar[3].fieldExpression)
 		}
 	case 137:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:345
+//line pkg/traceql/expr.y:346
 		{
 			yyVAL.fieldExpression = newBinaryOperation(OpOr, yyDollar[1].fieldExpression, yyDollar[3].fieldExpression)
 		}
 	case 138:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line pkg/traceql/expr.y:346
+//line pkg/traceql/expr.y:347
 		{
 			yyVAL.fieldExpression = newUnaryOperation(OpSub, yyDollar[2].fieldExpression)
 		}
 	case 139:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line pkg/traceql/expr.y:347
+//line pkg/traceql/expr.y:348
 		{
 			yyVAL.fieldExpression = newUnaryOperation(OpNot, yyDollar[2].fieldExpression)
 		}
 	case 140:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:348
+//line pkg/traceql/expr.y:349
 		{
 			yyVAL.fieldExpression = yyDollar[1].static
 		}
 	case 141:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:349
+//line pkg/traceql/expr.y:350
 		{
 			yyVAL.fieldExpression = yyDollar[1].intrinsicField
 		}
 	case 142:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:350
+//line pkg/traceql/expr.y:351
 		{
 			yyVAL.fieldExpression = yyDollar[1].attributeField
 		}
 	case 143:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:351
+//line pkg/traceql/expr.y:352
 		{
 			yyVAL.fieldExpression = yyDollar[1].scopedIntrinsicField
 		}
 	case 144:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:358
+//line pkg/traceql/expr.y:359
 		{
 			yyVAL.static = NewStaticString(yyDollar[1].staticStr)
 		}
 	case 145:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:359
+//line pkg/traceql/expr.y:360
 		{
 			yyVAL.static = NewStaticInt(yyDollar[1].staticInt)
 		}
 	case 146:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:360
+//line pkg/traceql/expr.y:361
 		{
 			yyVAL.static = NewStaticFloat(yyDollar[1].staticFloat)
 		}
 	case 147:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:361
+//line pkg/traceql/expr.y:362
 		{
 			yyVAL.static = NewStaticBool(true)
 		}
 	case 148:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:362
+//line pkg/traceql/expr.y:363
 		{
 			yyVAL.static = NewStaticBool(false)
 		}
 	case 149:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:363
+//line pkg/traceql/expr.y:364
 		{
 			yyVAL.static = NewStaticNil()
 		}
 	case 150:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:364
+//line pkg/traceql/expr.y:365
 		{
 			yyVAL.static = NewStaticDuration(yyDollar[1].staticDuration)
 		}
 	case 151:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:365
+//line pkg/traceql/expr.y:366
 		{
 			yyVAL.static = NewStaticStatus(StatusOk)
 		}
 	case 152:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:366
+//line pkg/traceql/expr.y:367
 		{
 			yyVAL.static = NewStaticStatus(StatusError)
 		}
 	case 153:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:367
+//line pkg/traceql/expr.y:368
 		{
 			yyVAL.static = NewStaticStatus(StatusUnset)
 		}
 	case 154:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:368
+//line pkg/traceql/expr.y:369
 		{
 			yyVAL.static = NewStaticKind(KindUnspecified)
 		}
 	case 155:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:369
+//line pkg/traceql/expr.y:370
 		{
 			yyVAL.static = NewStaticKind(KindInternal)
 		}
 	case 156:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:370
+//line pkg/traceql/expr.y:371
 		{
 			yyVAL.static = NewStaticKind(KindServer)
 		}
 	case 157:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:371
+//line pkg/traceql/expr.y:372
 		{
 			yyVAL.static = NewStaticKind(KindClient)
 		}
 	case 158:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:372
+//line pkg/traceql/expr.y:373
 		{
 			yyVAL.static = NewStaticKind(KindProducer)
 		}
 	case 159:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:373
+//line pkg/traceql/expr.y:374
 		{
 			yyVAL.static = NewStaticKind(KindConsumer)
 		}
 	case 160:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:379
+//line pkg/traceql/expr.y:380
 		{
 			yyVAL.intrinsicField = NewIntrinsic(IntrinsicDuration)
 		}
 	case 161:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:380
+//line pkg/traceql/expr.y:381
 		{
 			yyVAL.intrinsicField = NewIntrinsic(IntrinsicChildCount)
 		}
 	case 162:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:381
+//line pkg/traceql/expr.y:382
 		{
 			yyVAL.intrinsicField = NewIntrinsic(IntrinsicName)
 		}
 	case 163:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:382
+//line pkg/traceql/expr.y:383
 		{
 			yyVAL.intrinsicField = NewIntrinsic(IntrinsicStatus)
 		}
 	case 164:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:383
+//line pkg/traceql/expr.y:384
 		{
 			yyVAL.intrinsicField = NewIntrinsic(IntrinsicStatusMessage)
 		}
 	case 165:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:384
+//line pkg/traceql/expr.y:385
 		{
 			yyVAL.intrinsicField = NewIntrinsic(IntrinsicKind)
 		}
 	case 166:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:385
+//line pkg/traceql/expr.y:386
 		{
 			yyVAL.intrinsicField = NewIntrinsic(IntrinsicParent)
 		}
 	case 167:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:386
+//line pkg/traceql/expr.y:387
 		{
 			yyVAL.intrinsicField = NewIntrinsic(IntrinsicTraceRootSpan)
 		}
 	case 168:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:387
+//line pkg/traceql/expr.y:388
 		{
 			yyVAL.intrinsicField = NewIntrinsic(IntrinsicTraceRootService)
 		}
 	case 169:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:388
+//line pkg/traceql/expr.y:389
 		{
 			yyVAL.intrinsicField = NewIntrinsic(IntrinsicTraceDuration)
 		}
 	case 170:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:389
+//line pkg/traceql/expr.y:390
 		{
 			yyVAL.intrinsicField = NewIntrinsic(IntrinsicNestedSetLeft)
 		}
 	case 171:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:390
+//line pkg/traceql/expr.y:391
 		{
 			yyVAL.intrinsicField = NewIntrinsic(IntrinsicNestedSetRight)
 		}
 	case 172:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line pkg/traceql/expr.y:391
+//line pkg/traceql/expr.y:392
 		{
 			yyVAL.intrinsicField = NewIntrinsic(IntrinsicNestedSetParent)
 		}
 	case 173:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line pkg/traceql/expr.y:396
+//line pkg/traceql/expr.y:397
 		{
 			yyVAL.scopedIntrinsicField = NewIntrinsic(IntrinsicTraceDuration)
 		}
 	case 174:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line pkg/traceql/expr.y:397
+//line pkg/traceql/expr.y:398
 		{
 			yyVAL.scopedIntrinsicField = NewIntrinsic(IntrinsicTraceRootSpan)
 		}
 	case 175:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line pkg/traceql/expr.y:398
+//line pkg/traceql/expr.y:399
 		{
 			yyVAL.scopedIntrinsicField = NewIntrinsic(IntrinsicTraceRootService)
 		}
 	case 176:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line pkg/traceql/expr.y:399
+//line pkg/traceql/expr.y:400
 		{
 			yyVAL.scopedIntrinsicField = NewIntrinsic(IntrinsicTraceID)
 		}
 	case 177:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line pkg/traceql/expr.y:401
+//line pkg/traceql/expr.y:402
 		{
 			yyVAL.scopedIntrinsicField = NewIntrinsic(IntrinsicDuration)
 		}
 	case 178:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line pkg/traceql/expr.y:402
+//line pkg/traceql/expr.y:403
 		{
 			yyVAL.scopedIntrinsicField = NewIntrinsic(IntrinsicName)
 		}
 	case 179:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line pkg/traceql/expr.y:403
+//line pkg/traceql/expr.y:404
 		{
 			yyVAL.scopedIntrinsicField = NewIntrinsic(IntrinsicKind)
 		}
 	case 180:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line pkg/traceql/expr.y:404
+//line pkg/traceql/expr.y:405
 		{
 			yyVAL.scopedIntrinsicField = NewIntrinsic(IntrinsicStatus)
 		}
 	case 181:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line pkg/traceql/expr.y:405
+//line pkg/traceql/expr.y:406
 		{
 			yyVAL.scopedIntrinsicField = NewIntrinsic(IntrinsicStatusMessage)
 		}
 	case 182:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line pkg/traceql/expr.y:406
+//line pkg/traceql/expr.y:407
 		{
 			yyVAL.scopedIntrinsicField = NewIntrinsic(IntrinsicSpanID)
 		}
 	case 183:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line pkg/traceql/expr.y:408
+//line pkg/traceql/expr.y:409
 		{
 			yyVAL.scopedIntrinsicField = NewIntrinsic(IntrinsicEventName)
 		}
@@ -2003,59 +2006,65 @@ yydefault:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line pkg/traceql/expr.y:410
 		{
-			yyVAL.scopedIntrinsicField = NewIntrinsic(IntrinsicLinkTraceID)
+			yyVAL.scopedIntrinsicField = NewIntrinsic(IntrinsicEventTimeSinceStart)
 		}
 	case 185:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line pkg/traceql/expr.y:411
+//line pkg/traceql/expr.y:412
+		{
+			yyVAL.scopedIntrinsicField = NewIntrinsic(IntrinsicLinkTraceID)
+		}
+	case 186:
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line pkg/traceql/expr.y:413
 		{
 			yyVAL.scopedIntrinsicField = NewIntrinsic(IntrinsicLinkSpanID)
 		}
-	case 186:
-		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:415
-		{
-			yyVAL.attributeField = NewAttribute(yyDollar[2].staticStr)
-		}
 	case 187:
-		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:416
-		{
-			yyVAL.attributeField = NewScopedAttribute(AttributeScopeResource, false, yyDollar[2].staticStr)
-		}
-	case 188:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line pkg/traceql/expr.y:417
 		{
-			yyVAL.attributeField = NewScopedAttribute(AttributeScopeSpan, false, yyDollar[2].staticStr)
+			yyVAL.attributeField = NewAttribute(yyDollar[2].staticStr)
 		}
-	case 189:
+	case 188:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line pkg/traceql/expr.y:418
 		{
-			yyVAL.attributeField = NewScopedAttribute(AttributeScopeNone, true, yyDollar[2].staticStr)
+			yyVAL.attributeField = NewScopedAttribute(AttributeScopeResource, false, yyDollar[2].staticStr)
 		}
-	case 190:
-		yyDollar = yyS[yypt-4 : yypt+1]
+	case 189:
+		yyDollar = yyS[yypt-3 : yypt+1]
 //line pkg/traceql/expr.y:419
 		{
-			yyVAL.attributeField = NewScopedAttribute(AttributeScopeResource, true, yyDollar[3].staticStr)
+			yyVAL.attributeField = NewScopedAttribute(AttributeScopeSpan, false, yyDollar[2].staticStr)
+		}
+	case 190:
+		yyDollar = yyS[yypt-3 : yypt+1]
+//line pkg/traceql/expr.y:420
+		{
+			yyVAL.attributeField = NewScopedAttribute(AttributeScopeNone, true, yyDollar[2].staticStr)
 		}
 	case 191:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line pkg/traceql/expr.y:420
+//line pkg/traceql/expr.y:421
+		{
+			yyVAL.attributeField = NewScopedAttribute(AttributeScopeResource, true, yyDollar[3].staticStr)
+		}
+	case 192:
+		yyDollar = yyS[yypt-4 : yypt+1]
+//line pkg/traceql/expr.y:422
 		{
 			yyVAL.attributeField = NewScopedAttribute(AttributeScopeSpan, true, yyDollar[3].staticStr)
 		}
-	case 192:
+	case 193:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:421
+//line pkg/traceql/expr.y:423
 		{
 			yyVAL.attributeField = NewScopedAttribute(AttributeScopeEvent, false, yyDollar[2].staticStr)
 		}
-	case 193:
+	case 194:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line pkg/traceql/expr.y:422
+//line pkg/traceql/expr.y:424
 		{
 			yyVAL.attributeField = NewScopedAttribute(AttributeScopeLink, false, yyDollar[2].staticStr)
 		}

--- a/pkg/traceql/lexer.go
+++ b/pkg/traceql/lexer.go
@@ -78,6 +78,7 @@ var tokens = map[string]int{
 	"id":                  ID,
 	"traceID":             TRACE_ID,
 	"spanID":              SPAN_ID,
+	"timeSinceStart":      TIMESINCESTART,
 	"parent":              PARENT,
 	"parent.":             PARENT_DOT,
 	"resource.":           RESOURCE_DOT,

--- a/pkg/traceql/lexer_test.go
+++ b/pkg/traceql/lexer_test.go
@@ -100,6 +100,7 @@ func TestLexerScopedIntrinsic(t *testing.T) {
 		{`span:id`, []int{SPAN_COLON, ID}},
 		// event scoped intrinsics
 		{`event:name`, []int{EVENT_COLON, NAME}},
+		{`event:timeSinceStart`, []int{EVENT_COLON, TIMESINCESTART}},
 		// link scoped intrinsics
 		{`link:traceID`, []int{LINK_COLON, TRACE_ID}},
 		{`link:spanID`, []int{LINK_COLON, SPAN_ID}},

--- a/pkg/traceql/parse_test.go
+++ b/pkg/traceql/parse_test.go
@@ -1214,6 +1214,7 @@ func TestScopedIntrinsics(t *testing.T) {
 		{in: "span:statusMessage", expected: IntrinsicStatusMessage},
 		{in: "span:id", expected: IntrinsicSpanID},
 		{in: "event:name", expected: IntrinsicEventName},
+		{in: "event:timeSinceStart", expected: IntrinsicEventTimeSinceStart},
 		{in: "link:traceID", expected: IntrinsicLinkTraceID},
 		{in: "link:spanID", expected: IntrinsicLinkSpanID},
 		{in: ":duration", shouldError: true},

--- a/pkg/traceql/test_examples.yaml
+++ b/pkg/traceql/test_examples.yaml
@@ -64,6 +64,7 @@ valid:
   - '{ span:statusMessage = "status message" }'
   - '{ span:id = "61626364656667" }'
   - '{ event:name = "exception" }'
+  - '{ event:timeSinceStart > 1s }'
   - '{ link:traceID = "f1f1f1f1f1f1ff1f1f1f1f1f1f1f1f1" }'
   - '{ link:spanID = "f1f1f1f1f1f1f1f1" }'
   # binary operations

--- a/pkg/util/test/req.go
+++ b/pkg/util/test/req.go
@@ -86,7 +86,7 @@ func MakeSpanWithAttributeCount(traceID []byte, count int) *v1_trace.Span {
 	// add event
 	if rand.Intn(3) == 0 {
 		s.Events = append(s.Events, &v1_trace.Span_Event{
-			TimeUnixNano:           rand.Uint64(),
+			TimeUnixNano:           s.StartTimeUnixNano + uint64(rand.Intn(1*1000*1000)), // 1ms
 			Name:                   "event",
 			DroppedAttributesCount: rand.Uint32(),
 			Attributes: []*v1_common.KeyValue{

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -861,37 +861,38 @@ const (
 	columnPathResourceK8sPodName       = "rs.list.element.Resource.K8sPodName"
 	columnPathResourceK8sContainerName = "rs.list.element.Resource.K8sContainerName"
 
-	columnPathSpanID             = "rs.list.element.ss.list.element.Spans.list.element.SpanID"
-	columnPathSpanName           = "rs.list.element.ss.list.element.Spans.list.element.Name"
-	columnPathSpanStartTime      = "rs.list.element.ss.list.element.Spans.list.element.StartTimeUnixNano"
-	columnPathSpanDuration       = "rs.list.element.ss.list.element.Spans.list.element.DurationNano"
-	columnPathSpanKind           = "rs.list.element.ss.list.element.Spans.list.element.Kind"
-	columnPathSpanStatusCode     = "rs.list.element.ss.list.element.Spans.list.element.StatusCode"
-	columnPathSpanStatusMessage  = "rs.list.element.ss.list.element.Spans.list.element.StatusMessage"
-	columnPathSpanAttrKey        = "rs.list.element.ss.list.element.Spans.list.element.Attrs.list.element.Key"
-	columnPathSpanAttrString     = "rs.list.element.ss.list.element.Spans.list.element.Attrs.list.element.Value.list.element"
-	columnPathSpanAttrInt        = "rs.list.element.ss.list.element.Spans.list.element.Attrs.list.element.ValueInt.list.element"
-	columnPathSpanAttrDouble     = "rs.list.element.ss.list.element.Spans.list.element.Attrs.list.element.ValueDouble.list.element"
-	columnPathSpanAttrBool       = "rs.list.element.ss.list.element.Spans.list.element.Attrs.list.element.ValueBool.list.element"
-	columnPathSpanHTTPStatusCode = "rs.list.element.ss.list.element.Spans.list.element.HttpStatusCode"
-	columnPathSpanHTTPMethod     = "rs.list.element.ss.list.element.Spans.list.element.HttpMethod"
-	columnPathSpanHTTPURL        = "rs.list.element.ss.list.element.Spans.list.element.HttpUrl"
-	columnPathSpanNestedSetLeft  = "rs.list.element.ss.list.element.Spans.list.element.NestedSetLeft"
-	columnPathSpanNestedSetRight = "rs.list.element.ss.list.element.Spans.list.element.NestedSetRight"
-	columnPathSpanParentID       = "rs.list.element.ss.list.element.Spans.list.element.ParentID"
-	columnPathEventName          = "rs.list.element.ss.list.element.Spans.list.element.Events.list.element.Name"
-	columnPathLinkTraceID        = "rs.list.element.ss.list.element.Spans.list.element.Links.list.element.TraceID"
-	columnPathLinkSpanID         = "rs.list.element.ss.list.element.Spans.list.element.Links.list.element.SpanID"
-	columnPathEventAttrKey       = "rs.list.element.ss.list.element.Spans.list.element.Events.list.element.Attrs.list.element.Key"
-	columnPathEventAttrString    = "rs.list.element.ss.list.element.Spans.list.element.Events.list.element.Attrs.list.element.Value.list.element"
-	columnPathEventAttrInt       = "rs.list.element.ss.list.element.Spans.list.element.Events.list.element.Attrs.list.element.ValueInt.list.element"
-	columnPathEventAttrDouble    = "rs.list.element.ss.list.element.Spans.list.element.Events.list.element.Attrs.list.element.ValueDouble.list.element"
-	columnPathEventAttrBool      = "rs.list.element.ss.list.element.Spans.list.element.Events.list.element.Attrs.list.element.ValueBool.list.element"
-	columnPathLinkAttrKey        = "rs.list.element.ss.list.element.Spans.list.element.Links.list.element.Attrs.list.element.Key"
-	columnPathLinkAttrString     = "rs.list.element.ss.list.element.Spans.list.element.Links.list.element.Attrs.list.element.Value.list.element"
-	columnPathLinkAttrInt        = "rs.list.element.ss.list.element.Spans.list.element.Links.list.element.Attrs.list.element.ValueInt.list.element"
-	columnPathLinkAttrDouble     = "rs.list.element.ss.list.element.Spans.list.element.Links.list.element.Attrs.list.element.ValueDouble.list.element"
-	columnPathLinkAttrBool       = "rs.list.element.ss.list.element.Spans.list.element.Links.list.element.Attrs.list.element.ValueBool.list.element"
+	columnPathSpanID              = "rs.list.element.ss.list.element.Spans.list.element.SpanID"
+	columnPathSpanName            = "rs.list.element.ss.list.element.Spans.list.element.Name"
+	columnPathSpanStartTime       = "rs.list.element.ss.list.element.Spans.list.element.StartTimeUnixNano"
+	columnPathSpanDuration        = "rs.list.element.ss.list.element.Spans.list.element.DurationNano"
+	columnPathSpanKind            = "rs.list.element.ss.list.element.Spans.list.element.Kind"
+	columnPathSpanStatusCode      = "rs.list.element.ss.list.element.Spans.list.element.StatusCode"
+	columnPathSpanStatusMessage   = "rs.list.element.ss.list.element.Spans.list.element.StatusMessage"
+	columnPathSpanAttrKey         = "rs.list.element.ss.list.element.Spans.list.element.Attrs.list.element.Key"
+	columnPathSpanAttrString      = "rs.list.element.ss.list.element.Spans.list.element.Attrs.list.element.Value.list.element"
+	columnPathSpanAttrInt         = "rs.list.element.ss.list.element.Spans.list.element.Attrs.list.element.ValueInt.list.element"
+	columnPathSpanAttrDouble      = "rs.list.element.ss.list.element.Spans.list.element.Attrs.list.element.ValueDouble.list.element"
+	columnPathSpanAttrBool        = "rs.list.element.ss.list.element.Spans.list.element.Attrs.list.element.ValueBool.list.element"
+	columnPathSpanHTTPStatusCode  = "rs.list.element.ss.list.element.Spans.list.element.HttpStatusCode"
+	columnPathSpanHTTPMethod      = "rs.list.element.ss.list.element.Spans.list.element.HttpMethod"
+	columnPathSpanHTTPURL         = "rs.list.element.ss.list.element.Spans.list.element.HttpUrl"
+	columnPathSpanNestedSetLeft   = "rs.list.element.ss.list.element.Spans.list.element.NestedSetLeft"
+	columnPathSpanNestedSetRight  = "rs.list.element.ss.list.element.Spans.list.element.NestedSetRight"
+	columnPathSpanParentID        = "rs.list.element.ss.list.element.Spans.list.element.ParentID"
+	columnPathEventName           = "rs.list.element.ss.list.element.Spans.list.element.Events.list.element.Name"
+	columnPathEventTimeSinceStart = "rs.list.element.ss.list.element.Spans.list.element.Events.list.element.TimeSinceStartNano"
+	columnPathLinkTraceID         = "rs.list.element.ss.list.element.Spans.list.element.Links.list.element.TraceID"
+	columnPathLinkSpanID          = "rs.list.element.ss.list.element.Spans.list.element.Links.list.element.SpanID"
+	columnPathEventAttrKey        = "rs.list.element.ss.list.element.Spans.list.element.Events.list.element.Attrs.list.element.Key"
+	columnPathEventAttrString     = "rs.list.element.ss.list.element.Spans.list.element.Events.list.element.Attrs.list.element.Value.list.element"
+	columnPathEventAttrInt        = "rs.list.element.ss.list.element.Spans.list.element.Events.list.element.Attrs.list.element.ValueInt.list.element"
+	columnPathEventAttrDouble     = "rs.list.element.ss.list.element.Spans.list.element.Events.list.element.Attrs.list.element.ValueDouble.list.element"
+	columnPathEventAttrBool       = "rs.list.element.ss.list.element.Spans.list.element.Events.list.element.Attrs.list.element.ValueBool.list.element"
+	columnPathLinkAttrKey         = "rs.list.element.ss.list.element.Spans.list.element.Links.list.element.Attrs.list.element.Key"
+	columnPathLinkAttrString      = "rs.list.element.ss.list.element.Spans.list.element.Links.list.element.Attrs.list.element.Value.list.element"
+	columnPathLinkAttrInt         = "rs.list.element.ss.list.element.Spans.list.element.Links.list.element.Attrs.list.element.ValueInt.list.element"
+	columnPathLinkAttrDouble      = "rs.list.element.ss.list.element.Spans.list.element.Links.list.element.Attrs.list.element.ValueDouble.list.element"
+	columnPathLinkAttrBool        = "rs.list.element.ss.list.element.Spans.list.element.Links.list.element.Attrs.list.element.ValueBool.list.element"
 
 	otherEntrySpansetKey = "spanset"
 	otherEntrySpanKey    = "span"
@@ -931,9 +932,10 @@ var intrinsicColumnLookups = map[traceql.Intrinsic]struct {
 	traceql.IntrinsicTraceID:          {intrinsicScopeTrace, traceql.TypeString, columnPathTraceID},
 	traceql.IntrinsicTraceStartTime:   {intrinsicScopeTrace, traceql.TypeDuration, columnPathStartTimeUnixNano},
 
-	traceql.IntrinsicEventName:   {intrinsicScopeEvent, traceql.TypeString, columnPathEventName},
-	traceql.IntrinsicLinkTraceID: {intrinsicScopeLink, traceql.TypeString, columnPathLinkTraceID},
-	traceql.IntrinsicLinkSpanID:  {intrinsicScopeLink, traceql.TypeString, columnPathLinkSpanID},
+	traceql.IntrinsicEventName:           {intrinsicScopeEvent, traceql.TypeString, columnPathEventName},
+	traceql.IntrinsicEventTimeSinceStart: {intrinsicScopeEvent, traceql.TypeDuration, columnPathEventTimeSinceStart},
+	traceql.IntrinsicLinkTraceID:         {intrinsicScopeLink, traceql.TypeString, columnPathLinkTraceID},
+	traceql.IntrinsicLinkSpanID:          {intrinsicScopeLink, traceql.TypeString, columnPathLinkSpanID},
 
 	traceql.IntrinsicServiceStats: {intrinsicScopeTrace, traceql.TypeNil, ""}, // Not a real column, this entry is only used to assign default scope.
 }
@@ -1606,6 +1608,13 @@ func createEventIterator(makeIter makeIterFn, conditions []traceql.Condition, al
 				return nil, err
 			}
 			eventIters = append(eventIters, makeIter(columnPathEventName, pred, columnPathEventName))
+			continue
+		case traceql.IntrinsicEventTimeSinceStart:
+			pred, err := createIntPredicate(cond.Op, cond.Operands)
+			if err != nil {
+				return nil, err
+			}
+			eventIters = append(eventIters, makeIter(columnPathEventTimeSinceStart, pred, columnPathEventTimeSinceStart))
 			continue
 		}
 		genericConditions = append(genericConditions, cond)
@@ -2953,8 +2962,13 @@ func (c *eventCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		switch e.Key {
 		case columnPathEventName:
 			ev.attrs = append(ev.attrs, attrVal{
-				a: traceql.NewIntrinsic(traceql.IntrinsicEventName),
+				a: traceql.IntrinsicEventNameAttribute,
 				s: traceql.NewStaticString(unsafeToString(e.Value.Bytes())),
+			})
+		case columnPathEventTimeSinceStart:
+			ev.attrs = append(ev.attrs, attrVal{
+				a: traceql.IntrinsicEventTimeSinceStartAttribute,
+				s: traceql.NewStaticDuration(time.Duration(e.Value.Int64())),
 			})
 		}
 	}

--- a/tempodb/encoding/vparquet4/block_traceql_meta_test.go
+++ b/tempodb/encoding/vparquet4/block_traceql_meta_test.go
@@ -536,6 +536,7 @@ func TestBackendBlockSearchFetchMetaData(t *testing.T) {
 						},
 						eventAttrs: []attrVal{
 							{traceql.IntrinsicEventNameAttribute, traceql.NewStaticString("e1")},
+							{traceql.IntrinsicEventNameAttribute, traceql.NewStaticString("e1")}, // two events with the same name in the same span
 						},
 					},
 				),
@@ -544,7 +545,7 @@ func TestBackendBlockSearchFetchMetaData(t *testing.T) {
 		{
 			"Intrinsic event time since start lookup",
 			makeReq(
-				parse(t, `{event:timeSinceStart > 1ms}`), //
+				parse(t, `{event:timeSinceStart > 2ms}`), //
 			),
 			makeSpansets(
 				makeSpanset(
@@ -568,7 +569,8 @@ func TestBackendBlockSearchFetchMetaData(t *testing.T) {
 							{traceql.NewIntrinsic(traceql.IntrinsicTraceID), traceql.NewStaticString(util.TraceIDToHexString(wantTr.TraceID))},
 						},
 						eventAttrs: []attrVal{
-							{traceql.IntrinsicEventTimeSinceStartAttribute, traceql.NewStaticDuration(2 * time.Millisecond)},
+							{traceql.IntrinsicEventTimeSinceStartAttribute, traceql.NewStaticDuration(3 * time.Millisecond)},
+							{traceql.IntrinsicEventTimeSinceStartAttribute, traceql.NewStaticDuration(3 * time.Millisecond)}, // two events with same time since start in the same span
 						},
 					},
 				),
@@ -602,6 +604,7 @@ func TestBackendBlockSearchFetchMetaData(t *testing.T) {
 						},
 						eventAttrs: []attrVal{
 							{traceql.NewScopedAttribute(traceql.AttributeScopeEvent, false, "message"), traceql.NewStaticString("exception")},
+							{traceql.NewScopedAttribute(traceql.AttributeScopeEvent, false, "message"), traceql.NewStaticString("exception")}, // two events with the same message attr in the same span
 						},
 					},
 				),

--- a/tempodb/encoding/vparquet4/block_traceql_meta_test.go
+++ b/tempodb/encoding/vparquet4/block_traceql_meta_test.go
@@ -535,7 +535,40 @@ func TestBackendBlockSearchFetchMetaData(t *testing.T) {
 							{traceql.NewIntrinsic(traceql.IntrinsicTraceID), traceql.NewStaticString(util.TraceIDToHexString(wantTr.TraceID))},
 						},
 						eventAttrs: []attrVal{
-							{traceql.NewIntrinsic(traceql.IntrinsicEventName), traceql.NewStaticString("e1")},
+							{traceql.IntrinsicEventNameAttribute, traceql.NewStaticString("e1")},
+						},
+					},
+				),
+			),
+		},
+		{
+			"Intrinsic event time since start lookup",
+			makeReq(
+				parse(t, `{event:timeSinceStart > 1ms}`), //
+			),
+			makeSpansets(
+				makeSpanset(
+					wantTr.TraceID,
+					wantTr.RootSpanName,
+					wantTr.RootServiceName,
+					wantTr.StartTimeUnixNano,
+					wantTr.DurationNano,
+					&span{
+						id:                 wantTr.ResourceSpans[0].ScopeSpans[0].Spans[0].SpanID,
+						startTimeUnixNanos: wantTr.ResourceSpans[0].ScopeSpans[0].Spans[0].StartTimeUnixNano,
+						durationNanos:      wantTr.ResourceSpans[0].ScopeSpans[0].Spans[0].DurationNano,
+						spanAttrs: []attrVal{
+							{traceql.NewIntrinsic(traceql.IntrinsicDuration), traceql.NewStaticDuration(100 * time.Second)},
+							{traceql.NewIntrinsic(traceql.IntrinsicSpanID), traceql.NewStaticString(util.SpanIDToHexString(wantTr.ResourceSpans[0].ScopeSpans[0].Spans[0].SpanID))},
+						},
+						traceAttrs: []attrVal{
+							{traceql.NewIntrinsic(traceql.IntrinsicTraceRootService), traceql.NewStaticString("RootService")},
+							{traceql.NewIntrinsic(traceql.IntrinsicTraceRootSpan), traceql.NewStaticString("RootSpan")},
+							{traceql.NewIntrinsic(traceql.IntrinsicTraceDuration), traceql.NewStaticDuration(100 * time.Millisecond)},
+							{traceql.NewIntrinsic(traceql.IntrinsicTraceID), traceql.NewStaticString(util.TraceIDToHexString(wantTr.TraceID))},
+						},
+						eventAttrs: []attrVal{
+							{traceql.IntrinsicEventTimeSinceStartAttribute, traceql.NewStaticDuration(2 * time.Millisecond)},
 						},
 					},
 				),

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -1713,6 +1713,9 @@ func runEventLinkSearchTest(t *testing.T, blockVersion string) {
 			Query: "{ event:name = `event name` }",
 		},
 		{
+			Query: "{ event:timeSinceStart > 10ms }",
+		},
+		{
 			Query: "{ link.relation = `child-of` }",
 		},
 		{
@@ -1911,7 +1914,7 @@ func makeExpectedTrace() (
 								},
 								Events: []*v1.Span_Event{
 									{
-										TimeUnixNano: uint64(1000*time.Second) + 100,
+										TimeUnixNano: uint64(1000*time.Second) + uint64(500*time.Millisecond),
 										Name:         "event name",
 										Attributes: []*v1_common.KeyValue{
 											stringKV("exception.message", "random error"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: Add Traceql support for event timestamp. User will be able to query for events by how much time as elapsed since span start time to the timestamp of the event using `event:timeSinceStart`. 

Example:
`{ event:timeSinceStart > 1m }`
This query can help find spans where an event took place at least 1 minute after the span start time. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`