### PR TITLE
Change trace-level iterators to push predicates down for all queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [ENHANCEMENT] Add local disk caching of metrics queries in local-blocks processor [#3799](https://github.com/grafana/tempo/pull/3799) (@mdisibio)
 * [ENHANCEMENT] Improve use of OTEL semantic conventions on the service graph [#3711](https://github.com/grafana/tempo/pull/3711) (@zalegrala)
 * [ENHANCEMENT] Performance improvement for `rate() by ()` queries [#3719](https://github.com/grafana/tempo/pull/3719) (@mapno)
+* [ENHANCEMENT] Performance improvement for queries using trace-level intrinsics [#3920](https://github.com/grafana/tempo/pull/3920) (@mdisibio)
 * [ENHANCEMENT] Use multiple goroutines to unmarshal responses in parallel in the query frontend. [#3713](https://github.com/grafana/tempo/pull/3713) (@joe-elliott)
 * [ENHANCEMENT] Protect ingesters from panics by adding defer/recover to all read path methods. [#3790](https://github.com/grafana/tempo/pull/3790) (@joe-elliott)
 * [ENHANCEMENT] Added a boolean flag to enable or disable dualstack mode on Storage block config for S3 [#3721](https://github.com/grafana/tempo/pull/3721) (@sid-jar, @mapno)

--- a/pkg/traceql/engine.go
+++ b/pkg/traceql/engine.go
@@ -60,11 +60,11 @@ func (e *Engine) ExecuteSearch(ctx context.Context, searchReq *tempopb.SearchReq
 	span.SetTag("fetchSpansRequest", fetchSpansRequest)
 
 	// calculate search meta conditions.
-	metaConditions := SearchMetaConditionsWithout(fetchSpansRequest.Conditions)
+	meta := SearchMetaConditionsWithout(fetchSpansRequest.Conditions, fetchSpansRequest.AllConditions)
+	fetchSpansRequest.SecondPassConditions = append(fetchSpansRequest.SecondPassConditions, meta...)
 
 	spansetsEvaluated := 0
 	// set up the expression evaluation as a filter to reduce data pulled
-	fetchSpansRequest.SecondPassConditions = append(fetchSpansRequest.SecondPassConditions, metaConditions...)
 	fetchSpansRequest.SecondPass = func(inSS *Spanset) ([]*Spanset, error) {
 		if len(inSS.Spans) == 0 {
 			return nil, nil

--- a/pkg/traceql/storage.go
+++ b/pkg/traceql/storage.go
@@ -26,16 +26,23 @@ func SearchMetaConditions() []Condition {
 	}
 }
 
-func SearchMetaConditionsWithout(remove []Condition) []Condition {
+func SearchMetaConditionsWithout(remove []Condition, allConditions bool) []Condition {
 	metaConds := SearchMetaConditions()
 	retConds := make([]Condition, 0, len(metaConds))
 	for _, c := range metaConds {
 		// if we can't find c in the remove conditions then add it to retConds
 		found := false
-		for _, e := range remove {
-			if e.Attribute == c.Attribute {
-				found = true
-				break
+		for _, r := range remove {
+			if r.Attribute == c.Attribute {
+				// We can reuse the existing condition of a metadata field in two cases:
+				// (1) OpNone, since it has no filtering it will always return a value, there is no need to read it again.
+				// (2) AllConditions - No matter the operation, it will return a value for all results.
+				// If neither of those apply then we have to select
+				// the metadata field again without filtering.
+				if r.Op == OpNone || allConditions {
+					found = true
+					break
+				}
 			}
 		}
 		if !found {

--- a/pkg/traceql/storage_test.go
+++ b/pkg/traceql/storage_test.go
@@ -48,23 +48,31 @@ func TestSpansetClone(t *testing.T) {
 }
 
 func TestMetaConditionsWithout(t *testing.T) {
-	conditionsFor := func(q string) []Condition {
-		req, err := ExtractFetchSpansRequest(q)
-		require.NoError(t, err)
-
-		return req.Conditions
-	}
-
 	tcs := []struct {
-		remove []Condition
+		query  string
 		expect []Condition
 	}{
 		{
-			remove: []Condition{},
+			// No meta fields present in query, all are selected.
+			query:  "{ status=error}",
 			expect: SearchMetaConditions(),
 		},
 		{
-			remove: conditionsFor("{ duration > 1s}"),
+			// Service name, span name are able to be reused
+			query: "{ rootServiceName = `foo` && rootName = `bar`}",
+			expect: []Condition{
+				{NewIntrinsic(IntrinsicTraceDuration), OpNone, nil},
+				{NewIntrinsic(IntrinsicTraceID), OpNone, nil},
+				{NewIntrinsic(IntrinsicTraceStartTime), OpNone, nil},
+				{NewIntrinsic(IntrinsicSpanID), OpNone, nil},
+				{NewIntrinsic(IntrinsicSpanStartTime), OpNone, nil},
+				{NewIntrinsic(IntrinsicDuration), OpNone, nil},
+				{NewIntrinsic(IntrinsicServiceStats), OpNone, nil},
+			},
+		},
+		{
+			// Duration is the only one able to be reused because it has no filtering
+			query: "{ rootServiceName = `foo` && rootName = `bar`} | avg(duration) > 1s",
 			expect: []Condition{
 				{NewIntrinsic(IntrinsicTraceRootService), OpNone, nil},
 				{NewIntrinsic(IntrinsicTraceRootSpan), OpNone, nil},
@@ -77,19 +85,14 @@ func TestMetaConditionsWithout(t *testing.T) {
 			},
 		},
 		{
-			remove: conditionsFor("{ rootServiceName = `foo` && rootName = `bar`} | avg(duration) > 1s"),
-			expect: []Condition{
-				{NewIntrinsic(IntrinsicTraceDuration), OpNone, nil},
-				{NewIntrinsic(IntrinsicTraceID), OpNone, nil},
-				{NewIntrinsic(IntrinsicTraceStartTime), OpNone, nil},
-				{NewIntrinsic(IntrinsicSpanID), OpNone, nil},
-				{NewIntrinsic(IntrinsicSpanStartTime), OpNone, nil},
-				{NewIntrinsic(IntrinsicServiceStats), OpNone, nil},
-			},
+			// None are reused because the values are filtered and allConditions=false
+			query:  "{ rootServiceName = `foo` || rootName = `bar`}",
+			expect: SearchMetaConditions(),
 		},
 	}
 
 	for _, tc := range tcs {
-		require.Equal(t, tc.expect, SearchMetaConditionsWithout(tc.remove))
+		req, _ := ExtractFetchSpansRequest(tc.query)
+		require.Equal(t, tc.expect, SearchMetaConditionsWithout(req.Conditions, req.AllConditions))
 	}
 }

--- a/tempodb/encoding/vparquet2/block_traceql.go
+++ b/tempodb/encoding/vparquet2/block_traceql.go
@@ -1561,9 +1561,7 @@ func createResourceIterator(makeIter makeIterFn, spanIterator parquetquery.Itera
 }
 
 func createTraceIterator(makeIter makeIterFn, resourceIter parquetquery.Iterator, conds []traceql.Condition, start, end uint64, shardID, shardCount uint32, allConditions bool) (parquetquery.Iterator, error) {
-	traceIters := make([]parquetquery.Iterator, 0, 3)
-
-	var err error
+	iters := make([]parquetquery.Iterator, 0, 3)
 
 	// add conditional iterators first. this way if someone searches for { traceDuration > 1s && span.foo = "bar"} the query will
 	// be sped up by searching for traceDuration first. note that we can only set the predicates if all conditions is true.
@@ -1571,51 +1569,48 @@ func createTraceIterator(makeIter makeIterFn, resourceIter parquetquery.Iterator
 	for _, cond := range conds {
 		switch cond.Attribute.Intrinsic {
 		case traceql.IntrinsicTraceID:
-			var pred parquetquery.Predicate
-			if allConditions {
-				pred, err = createBytesPredicate(cond.Op, cond.Operands, false)
-				if err != nil {
-					return nil, err
-				}
+			pred, err := createBytesPredicate(cond.Op, cond.Operands, false)
+			if err != nil {
+				return nil, err
 			}
-			traceIters = append(traceIters, makeIter(columnPathTraceID, pred, columnPathTraceID))
+			iters = append(iters, makeIter(columnPathTraceID, pred, columnPathTraceID))
 		case traceql.IntrinsicTraceDuration:
-			var pred parquetquery.Predicate
-			if allConditions {
-				pred, err = createIntPredicate(cond.Op, cond.Operands)
-				if err != nil {
-					return nil, err
-				}
+			pred, err := createIntPredicate(cond.Op, cond.Operands)
+			if err != nil {
+				return nil, err
 			}
-			traceIters = append(traceIters, makeIter(columnPathDurationNanos, pred, columnPathDurationNanos))
+			iters = append(iters, makeIter(columnPathDurationNanos, pred, columnPathDurationNanos))
 		case traceql.IntrinsicTraceStartTime:
 			if start == 0 && end == 0 {
-				traceIters = append(traceIters, makeIter(columnPathStartTimeUnixNano, nil, columnPathStartTimeUnixNano))
+				iters = append(iters, makeIter(columnPathStartTimeUnixNano, nil, columnPathStartTimeUnixNano))
 			}
 		case traceql.IntrinsicTraceRootSpan:
-			var pred parquetquery.Predicate
-			if allConditions {
-				pred, err = createStringPredicate(cond.Op, cond.Operands)
-				if err != nil {
-					return nil, err
-				}
+			pred, err := createStringPredicate(cond.Op, cond.Operands)
+			if err != nil {
+				return nil, err
 			}
-			traceIters = append(traceIters, makeIter(columnPathRootSpanName, pred, columnPathRootSpanName))
+			iters = append(iters, makeIter(columnPathRootSpanName, pred, columnPathRootSpanName))
 		case traceql.IntrinsicTraceRootService:
-			var pred parquetquery.Predicate
-			if allConditions {
-				pred, err = createStringPredicate(cond.Op, cond.Operands)
-				if err != nil {
-					return nil, err
-				}
+			pred, err := createStringPredicate(cond.Op, cond.Operands)
+			if err != nil {
+				return nil, err
 			}
-			traceIters = append(traceIters, makeIter(columnPathRootServiceName, pred, columnPathRootServiceName))
+			iters = append(iters, makeIter(columnPathRootServiceName, pred, columnPathRootServiceName))
 		}
+	}
+
+	var required []parquetquery.Iterator
+
+	// This is an optimization for when all of the conditions must be met.
+	// We simply move all iterators into the required list.
+	if allConditions {
+		required = append(required, iters...)
+		iters = nil
 	}
 
 	// order is interesting here. would it be more efficient to grab the span/resource conditions first
 	// or the time range filtering first?
-	traceIters = append(traceIters, resourceIter)
+	required = append(required, resourceIter)
 
 	// evaluate time range
 	// Time range filtering?
@@ -1627,14 +1622,13 @@ func createTraceIterator(makeIter makeIterFn, resourceIter parquetquery.Iterator
 		startFilter = parquetquery.NewIntBetweenPredicate(0, int64(end))
 		endFilter = parquetquery.NewIntBetweenPredicate(int64(start), math.MaxInt64)
 
-		traceIters = append(traceIters, makeIter(columnPathStartTimeUnixNano, startFilter, columnPathStartTimeUnixNano))
-		traceIters = append(traceIters, makeIter(columnPathEndTimeUnixNano, endFilter, columnPathEndTimeUnixNano))
+		required = append(required, makeIter(columnPathStartTimeUnixNano, startFilter, columnPathStartTimeUnixNano))
+		required = append(required, makeIter(columnPathEndTimeUnixNano, endFilter, columnPathEndTimeUnixNano))
 	}
 
 	// Final trace iterator
-	// Join iterator means it requires matching resources to have been found
 	// TraceCollor adds trace-level data to the spansets
-	return parquetquery.NewJoinIterator(DefinitionLevelTrace, traceIters, newTraceCollector()), nil
+	return parquetquery.NewLeftJoinIterator(DefinitionLevelTrace, required, iters, newTraceCollector())
 }
 
 func createPredicate(op traceql.Operator, operands traceql.Operands) (parquetquery.Predicate, error) {

--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -1859,9 +1859,7 @@ func createResourceIterator(makeIter makeIterFn, spanIterator parquetquery.Itera
 }
 
 func createTraceIterator(makeIter makeIterFn, resourceIter parquetquery.Iterator, conds []traceql.Condition, start, end uint64, _, _ uint32, allConditions bool, selectAll bool) (parquetquery.Iterator, error) {
-	traceIters := make([]parquetquery.Iterator, 0, 3)
-
-	var err error
+	iters := make([]parquetquery.Iterator, 0, 3)
 
 	// add conditional iterators first. this way if someone searches for { traceDuration > 1s && span.foo = "bar"} the query will
 	// be sped up by searching for traceDuration first. note that we can only set the predicates if all conditions is true.
@@ -1869,45 +1867,33 @@ func createTraceIterator(makeIter makeIterFn, resourceIter parquetquery.Iterator
 	for _, cond := range conds {
 		switch cond.Attribute.Intrinsic {
 		case traceql.IntrinsicTraceID:
-			var pred parquetquery.Predicate
-			if allConditions {
-				pred, err = createBytesPredicate(cond.Op, cond.Operands, false)
-				if err != nil {
-					return nil, err
-				}
+			pred, err := createBytesPredicate(cond.Op, cond.Operands, false)
+			if err != nil {
+				return nil, err
 			}
-			traceIters = append(traceIters, makeIter(columnPathTraceID, pred, columnPathTraceID))
+			iters = append(iters, makeIter(columnPathTraceID, pred, columnPathTraceID))
 		case traceql.IntrinsicTraceDuration:
-			var pred parquetquery.Predicate
-			if allConditions {
-				pred, err = createIntPredicate(cond.Op, cond.Operands)
-				if err != nil {
-					return nil, err
-				}
+			pred, err := createIntPredicate(cond.Op, cond.Operands)
+			if err != nil {
+				return nil, err
 			}
-			traceIters = append(traceIters, makeIter(columnPathDurationNanos, pred, columnPathDurationNanos))
+			iters = append(iters, makeIter(columnPathDurationNanos, pred, columnPathDurationNanos))
 		case traceql.IntrinsicTraceStartTime:
 			if start == 0 && end == 0 {
-				traceIters = append(traceIters, makeIter(columnPathStartTimeUnixNano, nil, columnPathStartTimeUnixNano))
+				iters = append(iters, makeIter(columnPathStartTimeUnixNano, nil, columnPathStartTimeUnixNano))
 			}
 		case traceql.IntrinsicTraceRootSpan:
-			var pred parquetquery.Predicate
-			if allConditions {
-				pred, err = createStringPredicate(cond.Op, cond.Operands)
-				if err != nil {
-					return nil, err
-				}
+			pred, err := createStringPredicate(cond.Op, cond.Operands)
+			if err != nil {
+				return nil, err
 			}
-			traceIters = append(traceIters, makeIter(columnPathRootSpanName, pred, columnPathRootSpanName))
+			iters = append(iters, makeIter(columnPathRootSpanName, pred, columnPathRootSpanName))
 		case traceql.IntrinsicTraceRootService:
-			var pred parquetquery.Predicate
-			if allConditions {
-				pred, err = createStringPredicate(cond.Op, cond.Operands)
-				if err != nil {
-					return nil, err
-				}
+			pred, err := createStringPredicate(cond.Op, cond.Operands)
+			if err != nil {
+				return nil, err
 			}
-			traceIters = append(traceIters, makeIter(columnPathRootServiceName, pred, columnPathRootServiceName))
+			iters = append(iters, makeIter(columnPathRootServiceName, pred, columnPathRootServiceName))
 		}
 	}
 
@@ -1922,13 +1908,22 @@ func createTraceIterator(makeIter makeIterFn, resourceIter parquetquery.Iterator
 				traceql.IntrinsicServiceStats:
 				continue
 			}
-			traceIters = append(traceIters, makeIter(entry.columnPath, nil, entry.columnPath))
+			iters = append(iters, makeIter(entry.columnPath, nil, entry.columnPath))
 		}
+	}
+
+	var required []parquetquery.Iterator
+
+	// This is an optimization for when all of the conditions must be met.
+	// We simply move all iterators into the required list.
+	if allConditions {
+		required = append(required, iters...)
+		iters = nil
 	}
 
 	// order is interesting here. would it be more efficient to grab the span/resource conditions first
 	// or the time range filtering first?
-	traceIters = append(traceIters, resourceIter)
+	required = append(required, resourceIter)
 
 	// evaluate time range
 	// Time range filtering?
@@ -1940,14 +1935,14 @@ func createTraceIterator(makeIter makeIterFn, resourceIter parquetquery.Iterator
 		startFilter = parquetquery.NewIntBetweenPredicate(0, int64(end))
 		endFilter = parquetquery.NewIntBetweenPredicate(int64(start), math.MaxInt64)
 
-		traceIters = append(traceIters, makeIter(columnPathStartTimeUnixNano, startFilter, columnPathStartTimeUnixNano))
-		traceIters = append(traceIters, makeIter(columnPathEndTimeUnixNano, endFilter, columnPathEndTimeUnixNano))
+		required = append(required, makeIter(columnPathStartTimeUnixNano, startFilter, columnPathStartTimeUnixNano))
+		required = append(required, makeIter(columnPathEndTimeUnixNano, endFilter, columnPathEndTimeUnixNano))
 	}
 
 	// Final trace iterator
 	// Join iterator means it requires matching resources to have been found
 	// TraceCollor adds trace-level data to the spansets
-	return parquetquery.NewJoinIterator(DefinitionLevelTrace, traceIters, newTraceCollector(), parquetquery.WithPool(pqTracePool)), nil
+	return parquetquery.NewLeftJoinIterator(DefinitionLevelTrace, required, iters, newTraceCollector(), parquetquery.WithPool(pqTracePool))
 }
 
 func createPredicate(op traceql.Operator, operands traceql.Operands) (parquetquery.Predicate, error) {

--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -581,6 +581,10 @@ func BenchmarkBackendBlockTraceQL(b *testing.B) {
 		{"resourceAttIntrinsicMatch", "{ resource.service.name = `tempo-gateway` }"},
 		{"resourceAttIntrinsicMatch", "{ resource.service.name = `does-not-exit-6c2408325a45` }"},
 
+		// trace
+		{"traceOrMatch", "{ rootServiceName = `tempo-gateway` && (status = error || span.http.status_code = 500)}"},
+		{"traceOrNoMatch", "{ rootServiceName = `doesntexist` && (status = error || span.http.status_code = 500)}"},
+
 		// mixed
 		{"mixedValNoMatch", "{ .bloom = `does-not-exit-6c2408325a45` }"},
 		{"mixedValMixedMatchAnd", "{ resource.foo = `bar` && name = `gcs.ReadRange` }"},

--- a/tempodb/encoding/vparquet4/block_traceql_test.go
+++ b/tempodb/encoding/vparquet4/block_traceql_test.go
@@ -903,6 +903,10 @@ func BenchmarkBackendBlockTraceQL(b *testing.B) {
 		{"resourceAttIntrinsicMatch", "{ resource.service.name = `tempo-gateway` }"},
 		{"resourceAttIntrinsicMatch", "{ resource.service.name = `does-not-exit-6c2408325a45` }"},
 
+		// trace
+		{"traceOrMatch", "{ rootServiceName = `tempo-gateway` && (status = error || span.http.status_code = 500)}"},
+		{"traceOrNoMatch", "{ rootServiceName = `doesntexist` && (status = error || span.http.status_code = 500)}"},
+
 		// mixed
 		{"mixedValNoMatch", "{ .bloom = `does-not-exit-6c2408325a45` }"},
 		{"mixedValMixedMatchAnd", "{ resource.foo = `bar` && name = `gcs.ReadRange` }"},


### PR DESCRIPTION
**What this PR does**:
This PR updates the trace-level iterators to push down predicates for all queries, even where AllConditions=false.   An example query is `{ rootServiceName = "tempo-gateway" && (status = error || span.http.status_code = 500)}`. This wasn't actually filtering for "tempo-gateway" at the fetch layer.

The reason this wasn't done before was interaction with metadata on search responses.  If the query was already using a metadata column (i.e root service name), we didn't want to read it again.  But this meant that queries like above had to be reverted to do no filtering in the fetch layer, and pass everything up to the engine.

By updating the metadata second pass to be a bit more precise and splitting it out better, we can let those predicates be pushed down, and then read the column a second time (only for the search hits).  This gains a lot of cpu/mem improvement, for a little bit more i/o.  I think it's a worthwhile tradeoff.

This PR has a little improvement for other query types too, because the join in `createTraceIterator` was changed. Previously it was pulling the first page of each column before checking for hits on the inner iterator, because it was a Join and not a LeftJoin.

Query_range is unaffected in the current benchmarks because none of them have a metadata column in the second pass. But this will be important for #3824 

<details>

<summary>BenchmarkTraceQL</summary>

```
                                                 │ before.txt  │              after.txt              │
                                                 │   sec/op    │   sec/op     vs base                │
BackendBlockTraceQL/spanAttValMatch                78.04m ± 1%   77.35m ± 1%   -0.88% (p=0.011 n=10)
BackendBlockTraceQL/spanAttValNoMatch              1.955m ± 0%   1.833m ± 0%   -6.26% (p=0.000 n=10)
BackendBlockTraceQL/spanAttIntrinsicMatch          42.60m ± 1%   42.13m ± 1%        ~ (p=0.105 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch        1.547m ± 0%   1.444m ± 1%   -6.63% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttValMatch            330.0m ± 1%   328.8m ± 1%        ~ (p=0.075 n=10)
BackendBlockTraceQL/resourceAttValNoMatch          1.604m ± 0%   1.455m ± 0%   -9.28% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch      11.91m ± 1%   11.92m ± 0%        ~ (p=0.912 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01   1.582m ± 1%   1.433m ± 0%   -9.40% (p=0.000 n=10)
BackendBlockTraceQL/traceOrMatch                   314.7m ± 0%   228.6m ± 1%  -27.34% (p=0.000 n=10)
BackendBlockTraceQL/traceOrNoMatch                 302.3m ± 2%   222.5m ± 1%  -26.39% (p=0.000 n=10)
BackendBlockTraceQL/mixedValNoMatch                100.9m ± 0%   100.5m ± 0%   -0.42% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd          1.644m ± 0%   1.609m ± 1%   -2.14% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr           100.5m ± 0%   100.3m ± 2%        ~ (p=0.143 n=10)
BackendBlockTraceQL/count                          277.4m ± 1%   276.4m ± 2%        ~ (p=0.739 n=10)
BackendBlockTraceQL/struct                         383.9m ± 1%   384.5m ± 1%        ~ (p=0.971 n=10)
BackendBlockTraceQL/||                             115.1m ± 1%   114.3m ± 1%        ~ (p=0.353 n=10)
BackendBlockTraceQL/mixed                          33.54m ± 1%   33.54m ± 1%        ~ (p=0.912 n=10)
BackendBlockTraceQL/complex                        2.016m ± 1%   1.912m ± 0%   -5.13% (p=0.000 n=10)
geomean                                            28.26m        26.63m        -5.76%

                                                 │  before.txt   │              after.txt               │
                                                 │      B/s      │     B/s       vs base                │
BackendBlockTraceQL/spanAttValMatch                 183.9Mi ± 1%   185.6Mi ± 1%   +0.89% (p=0.011 n=10)
BackendBlockTraceQL/spanAttValNoMatch              1001.9Mi ± 0%   933.0Mi ± 0%   -6.88% (p=0.000 n=10)
BackendBlockTraceQL/spanAttIntrinsicMatch           351.8Mi ± 1%   355.8Mi ± 1%        ~ (p=0.105 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch         914.2Mi ± 0%   806.6Mi ± 1%  -11.77% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttValMatch             42.89Mi ± 1%   43.04Mi ± 1%        ~ (p=0.078 n=10)
BackendBlockTraceQL/resourceAttValNoMatch           262.9Mi ± 0%   118.6Mi ± 0%  -54.89% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch       1.032Gi ± 1%   1.032Gi ± 0%        ~ (p=0.912 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01    288.3Mi ± 1%   144.5Mi ± 0%  -49.90% (p=0.000 n=10)
BackendBlockTraceQL/traceOrMatch                    41.29Mi ± 0%   56.87Mi ± 1%  +37.73% (p=0.000 n=10)
BackendBlockTraceQL/traceOrNoMatch                  3.667Mi ± 2%   3.901Mi ± 1%   +6.37% (p=0.000 n=10)
BackendBlockTraceQL/mixedValNoMatch                 22.10Mi ± 0%   19.71Mi ± 0%  -10.79% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd           264.0Mi ± 0%   115.0Mi ± 1%  -56.46% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr            151.8Mi ± 0%   152.1Mi ± 2%        ~ (p=0.138 n=10)
BackendBlockTraceQL/count                           50.95Mi ± 1%   51.15Mi ± 2%        ~ (p=0.739 n=10)
BackendBlockTraceQL/struct                          41.08Mi ± 1%   41.02Mi ± 1%        ~ (p=0.987 n=10)
BackendBlockTraceQL/||                              123.6Mi ± 1%   124.4Mi ± 1%        ~ (p=0.353 n=10)
BackendBlockTraceQL/mixed                           417.0Mi ± 1%   416.9Mi ± 1%        ~ (p=0.912 n=10)
BackendBlockTraceQL/complex                         884.0Mi ± 1%   806.1Mi ± 1%   -8.82% (p=0.000 n=10)
geomean                                             154.8Mi        136.2Mi       -12.02%

                                                 │  before.txt  │               after.txt               │
                                                 │   MB_io/op   │  MB_io/op    vs base                  │
BackendBlockTraceQL/spanAttValMatch                  15.05 ± 0%    15.05 ± 0%        ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/spanAttValNoMatch                2.054 ± 0%    1.793 ± 0%  -12.71% (p=0.000 n=10)
BackendBlockTraceQL/spanAttIntrinsicMatch            15.72 ± 0%    15.72 ± 0%        ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/spanAttIntrinsicNoMatch          1.483 ± 0%    1.221 ± 0%  -17.67% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttValMatch              14.84 ± 0%    14.84 ± 0%        ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/resourceAttValNoMatch           442.0m ± 0%   180.9m ± 0%  -59.07% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch        13.21 ± 0%    13.21 ± 0%        ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/resourceAttIntrinsicMatch#01    478.2m ± 0%   217.1m ± 0%  -54.60% (p=0.000 n=10)
BackendBlockTraceQL/traceOrMatch                     13.63 ± 0%    13.63 ± 0%        ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/traceOrNoMatch                 1162.0m ± 0%   909.1m ± 0%  -21.76% (p=0.000 n=10)
BackendBlockTraceQL/mixedValNoMatch                  2.339 ± 0%    2.078 ± 0%  -11.16% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd           455.0m ± 0%   193.9m ± 0%  -57.38% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr             16.00 ± 0%    16.00 ± 0%        ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/count                            14.82 ± 0%    14.82 ± 0%        ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/struct                           16.54 ± 0%    16.54 ± 0%        ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/||                               14.91 ± 0%    14.91 ± 0%        ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixed                            14.66 ± 0%    14.66 ± 0%        ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/complex                          1.866 ± 1%    1.617 ± 2%  -13.32% (p=0.000 n=10)
geomean                                              4.586         3.802       -17.09%
¹ all samples are equal

                                                 │  before.txt   │              after.txt               │
                                                 │     B/op      │     B/op      vs base                │
BackendBlockTraceQL/spanAttValMatch                 29.74Mi ± 0%   29.77Mi ± 1%        ~ (p=0.739 n=10)
BackendBlockTraceQL/spanAttValNoMatch               1.554Mi ± 0%   1.538Mi ± 0%   -1.05% (p=0.000 n=10)
BackendBlockTraceQL/spanAttIntrinsicMatch           14.81Mi ± 1%   14.81Mi ± 0%        ~ (p=0.971 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch         1.112Mi ± 0%   1.095Mi ± 0%   -1.48% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttValMatch             316.8Mi ± 0%   317.3Mi ± 0%        ~ (p=0.052 n=10)
BackendBlockTraceQL/resourceAttValNoMatch           1.087Mi ± 0%   1.070Mi ± 0%   -1.53% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch       1.210Mi ± 0%   1.322Mi ± 0%   +9.21% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01    1.089Mi ± 0%   1.072Mi ± 0%   -1.52% (p=0.000 n=10)
BackendBlockTraceQL/traceOrMatch                   128.48Mi ± 1%   17.54Mi ± 0%  -86.35% (p=0.000 n=10)
BackendBlockTraceQL/traceOrNoMatch                 125.42Mi ± 1%   16.14Mi ± 1%  -87.13% (p=0.000 n=10)
BackendBlockTraceQL/mixedValNoMatch                 1.596Mi ± 0%   1.579Mi ± 0%   -1.04% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd           1.089Mi ± 0%   1.073Mi ± 0%   -1.53% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr            2.020Mi ± 3%   2.100Mi ± 1%   +3.95% (p=0.000 n=10)
BackendBlockTraceQL/count                           231.3Mi ± 0%   231.4Mi ± 0%        ~ (p=1.000 n=10)
BackendBlockTraceQL/struct                          127.2Mi ± 3%   130.4Mi ± 3%   +2.52% (p=0.005 n=10)
BackendBlockTraceQL/||                              16.41Mi ± 0%   16.42Mi ± 0%        ~ (p=0.739 n=10)
BackendBlockTraceQL/mixed                           4.186Mi ± 0%   4.201Mi ± 0%   +0.34% (p=0.000 n=10)
BackendBlockTraceQL/complex                         1.148Mi ± 0%   1.132Mi ± 0%   -1.47% (p=0.000 n=10)
geomean                                             8.421Mi        6.751Mi       -19.84%

                                                 │  before.txt  │              after.txt              │
                                                 │  allocs/op   │  allocs/op   vs base                │
BackendBlockTraceQL/spanAttValMatch                 313.6k ± 0%   313.6k ± 0%        ~ (p=0.361 n=10)
BackendBlockTraceQL/spanAttValNoMatch               17.44k ± 0%   17.29k ± 0%   -0.85% (p=0.000 n=10)
BackendBlockTraceQL/spanAttIntrinsicMatch           118.5k ± 0%   118.5k ± 0%   +0.00% (p=0.001 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch         17.37k ± 0%   17.22k ± 0%   -0.86% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttValMatch             2.293M ± 0%   2.293M ± 0%        ~ (p=0.084 n=10)
BackendBlockTraceQL/resourceAttValNoMatch           17.40k ± 0%   17.25k ± 0%   -0.87% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch       18.57k ± 0%   18.57k ± 0%        ~ (p=1.000 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01    17.40k ± 0%   17.25k ± 0%   -0.87% (p=0.000 n=10)
BackendBlockTraceQL/traceOrMatch                   1107.9k ± 1%   162.1k ± 0%  -85.37% (p=0.000 n=10)
BackendBlockTraceQL/traceOrNoMatch                 1117.4k ± 1%   153.5k ± 0%  -86.26% (p=0.000 n=10)
BackendBlockTraceQL/mixedValNoMatch                 18.18k ± 0%   18.03k ± 0%   -0.83% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd           17.43k ± 0%   17.28k ± 0%   -0.87% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr            24.19k ± 0%   24.19k ± 0%        ~ (p=0.636 n=10)
BackendBlockTraceQL/count                           1.476M ± 0%   1.476M ± 0%        ~ (p=0.753 n=10)
BackendBlockTraceQL/struct                          1.009M ± 1%   1.006M ± 1%        ~ (p=0.393 n=10)
BackendBlockTraceQL/||                              141.7k ± 0%   141.7k ± 0%   -0.00% (p=0.016 n=10)
BackendBlockTraceQL/mixed                           47.45k ± 0%   47.45k ± 0%   +0.00% (p=0.000 n=10)
BackendBlockTraceQL/complex                         17.78k ± 0%   17.63k ± 0%   -0.84% (p=0.000 n=10)
geomean                                             92.48k        74.18k       -19.79%
```

</details>

<details>

<summary>BenchmarkQueryRange</summary>

```
                                                                          │ before_range.txt │          after_range.txt           │
                                                                          │      sec/op      │   sec/op     vs base               │
BackendBlockQueryRange/{}_|_rate()/3                                             410.4m ± 1%   406.8m ± 1%       ~ (p=0.063 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)/3                                   815.7m ± 3%   809.1m ± 4%       ~ (p=0.315 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/3                  556.1m ± 4%   554.8m ± 5%       ~ (p=0.529 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/3                           1.028 ± 2%    1.020 ± 2%       ~ (p=0.393 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.foo)/3                               950.0m ± 1%   968.1m ± 3%       ~ (p=0.143 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.foo)/3                           875.0m ± 3%   868.6m ± 1%       ~ (p=0.436 n=10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/3        132.8m ± 3%   132.1m ± 2%       ~ (p=0.529 n=10)
BackendBlockQueryRange/{status=error}_|_rate()/3                                 105.2m ± 1%   105.5m ± 0%       ~ (p=0.481 n=10)
geomean                                                                          466.0m        464.9m       -0.24%

                                                                          │ before_range.txt │           after_range.txt           │
                                                                          │     MB_IO/op     │  MB_IO/op   vs base                 │
BackendBlockQueryRange/{}_|_rate()/3                                              14.64 ± 0%   14.64 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(name)/3                                    18.61 ± 0%   18.61 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/3                   14.95 ± 0%   14.95 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/3                           16.95 ± 0%   16.95 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(span.foo)/3                                17.45 ± 0%   17.45 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(resource.foo)/3                            15.20 ± 0%   15.20 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/3         14.95 ± 0%   14.95 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{status=error}_|_rate()/3                                  15.65 ± 0%   15.65 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                                           16.00        16.00       +0.00%
¹ all samples are equal

                                                                          │ before_range.txt │           after_range.txt            │
                                                                          │     spans/op     │  spans/op    vs base                 │
BackendBlockQueryRange/{}_|_rate()/3                                             2.553M ± 0%   2.553M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(name)/3                                   2.553M ± 0%   2.553M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/3                  2.553M ± 0%   2.553M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/3                          2.553M ± 0%   2.553M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(span.foo)/3                               2.553M ± 0%   2.553M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(resource.foo)/3                           2.553M ± 0%   2.553M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/3        503.7k ± 0%   503.7k ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{status=error}_|_rate()/3                                 93.82k ± 0%   93.82k ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                                          1.379M        1.379M       +0.00%
¹ all samples are equal

                                                                          │ before_range.txt │          after_range.txt           │
                                                                          │     spans/s      │   spans/s    vs base               │
BackendBlockQueryRange/{}_|_rate()/3                                             6.220M ± 1%   6.275M ± 1%       ~ (p=0.063 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)/3                                   3.130M ± 3%   3.155M ± 4%       ~ (p=0.315 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/3                  4.590M ± 5%   4.601M ± 6%       ~ (p=0.529 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/3                          2.482M ± 3%   2.502M ± 2%       ~ (p=0.393 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.foo)/3                               2.687M ± 1%   2.637M ± 3%       ~ (p=0.143 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.foo)/3                           2.918M ± 3%   2.939M ± 1%       ~ (p=0.436 n=10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/3        3.793M ± 3%   3.814M ± 2%       ~ (p=0.529 n=10)
BackendBlockQueryRange/{status=error}_|_rate()/3                                 891.5k ± 1%   889.7k ± 0%       ~ (p=0.481 n=10)
geomean                                                                          2.959M        2.966M       +0.24%

                                                                          │ before_range.txt │           after_range.txt            │
                                                                          │       B/op       │     B/op       vs base               │
BackendBlockQueryRange/{}_|_rate()/3                                           7.460Mi ±  0%   7.460Mi ±  0%  +0.00% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)/3                                 8.843Mi ±  2%   8.842Mi ±  0%       ~ (p=0.172 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/3                8.188Mi ±  0%   8.188Mi ±  0%       ~ (p=0.305 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/3                        158.8Mi ± 14%   170.4Mi ± 10%       ~ (p=0.280 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.foo)/3                             106.3Mi ±  5%   105.8Mi ±  6%       ~ (p=0.566 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.foo)/3                         105.6Mi ±  5%   105.6Mi ±  7%       ~ (p=0.668 n=10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/3      5.951Mi ±  0%   5.951Mi ±  0%  +0.00% (p=0.001 n=10)
BackendBlockQueryRange/{status=error}_|_rate()/3                               1.674Mi ±  0%   1.669Mi ±  0%       ~ (p=0.462 n=10)
geomean                                                                        17.69Mi         17.83Mi        +0.80%

                                                                          │ before_range.txt │          after_range.txt           │
                                                                          │    allocs/op     │  allocs/op   vs base               │
BackendBlockQueryRange/{}_|_rate()/3                                            237.2k ±  0%   237.2k ± 0%  +0.00% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)/3                                  242.3k ±  0%   242.3k ± 0%       ~ (p=0.642 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/3                 237.9k ±  0%   237.9k ± 0%  +0.00% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/3                         1.238M ± 11%   1.288M ± 4%       ~ (p=0.105 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.foo)/3                              983.2k ±  3%   983.2k ± 4%       ~ (p=0.343 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.foo)/3                          983.2k ±  2%   983.2k ± 3%       ~ (p=0.302 n=10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/3       63.38k ±  0%   63.38k ± 0%  +0.00% (p=0.000 n=10)
BackendBlockQueryRange/{status=error}_|_rate()/3                                37.84k ±  0%   37.84k ± 0%  +0.01% (p=0.000 n=10)
geomean                                                                         281.3k         282.7k       +0.50%
```

</details>

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`