### PR TITLE
Experiment with string interning on BlockMeta

### DIFF
--- a/pkg/intern/intern.go
+++ b/pkg/intern/intern.go
@@ -4,16 +4,16 @@ import "sync"
 
 // A Value pointer is the handle to an underlying comparable value.
 type Value struct {
-	cmpVal interface{}
+	cmpVal string
 }
 
 // Get returns the comparable value passed to the Get func that returned v.
-func (v *Value) Get() interface{} { return v.cmpVal }
+func (v *Value) Get() string { return v.cmpVal }
 
 // Our pool of interned values and a lock to serialize access.
 var (
 	mu  sync.Mutex
-	val = map[interface{}]*Value{}
+	val = map[string]*Value{}
 )
 
 // Get returns a pointer representing the comparable value cmpVal.
@@ -24,7 +24,7 @@ var (
 // Note that Get returns a *Value so we only return one word of data
 // to the caller, despite potentially storing a large amount of data
 // within the Value itself.
-func Get(cmpVal interface{}) *Value {
+func Get(cmpVal string) *Value {
 	mu.Lock()
 	defer mu.Unlock()
 

--- a/pkg/intern/intern.go
+++ b/pkg/intern/intern.go
@@ -1,0 +1,41 @@
+package intern
+
+import "sync"
+
+// A Value pointer is the handle to an underlying comparable value.
+type Value struct {
+	cmpVal interface{}
+}
+
+// Get returns the comparable value passed to the Get func that returned v.
+func (v *Value) Get() interface{} { return v.cmpVal }
+
+// Our pool of interned values and a lock to serialize access.
+var (
+	mu  sync.Mutex
+	val = map[interface{}]*Value{}
+)
+
+// Get returns a pointer representing the comparable value cmpVal.
+//
+// The returned pointer will be the same for Get(v) and Get(v2)
+// if and only if v == v2, and can be used as a map key.
+//
+// Note that Get returns a *Value so we only return one word of data
+// to the caller, despite potentially storing a large amount of data
+// within the Value itself.
+func Get(cmpVal interface{}) *Value {
+	mu.Lock()
+	defer mu.Unlock()
+
+	v := val[cmpVal]
+	if v != nil {
+		// Value is already interned in the pool.
+		return v
+	}
+
+	// Value must be created now and then interned.
+	v = &Value{cmpVal: cmpVal}
+	val[cmpVal] = v
+	return v
+}

--- a/pkg/intern/intern_test.go
+++ b/pkg/intern/intern_test.go
@@ -1,0 +1,35 @@
+package intern
+
+import (
+	"fmt"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBasics(t *testing.T) {
+	x := Get("abc123")
+	y := Get("abc123")
+
+	if x.Get() != y.Get() {
+		t.Error("abc123 values differ")
+	}
+	if x.Get() != "abc123" {
+		t.Error("x.Get not abc123")
+	}
+	if x != y {
+		t.Error("abc123 pointers differ")
+	}
+
+	a1 := x.Get()
+	a2 := y.Get()
+
+	p1 := fmt.Sprintf("%08x\n", stringAddr(a1.(string)))
+	p2 := fmt.Sprintf("%08x\n", stringAddr(a2.(string)))
+	require.Equal(t, p1, p2)
+}
+
+func stringAddr(s string) uintptr {
+	return uintptr(unsafe.Pointer(unsafe.StringData(s)))
+}

--- a/pkg/intern/intern_test.go
+++ b/pkg/intern/intern_test.go
@@ -25,8 +25,8 @@ func TestBasics(t *testing.T) {
 	a1 := x.Get()
 	a2 := y.Get()
 
-	p1 := fmt.Sprintf("%08x\n", stringAddr(a1.(string)))
-	p2 := fmt.Sprintf("%08x\n", stringAddr(a2.(string)))
+	p1 := fmt.Sprintf("%08x\n", stringAddr(a1))
+	p2 := fmt.Sprintf("%08x\n", stringAddr(a2))
 	require.Equal(t, p1, p2)
 }
 

--- a/tempodb/backend/block_meta.go
+++ b/tempodb/backend/block_meta.go
@@ -91,6 +91,28 @@ type CompactedBlockMeta struct {
 	CompactedTime time.Time `json:"compactedTime"`
 }
 
+func (b *CompactedBlockMeta) UnmarshalJSON(data []byte) error {
+	if err := json.Unmarshal(data, &b.BlockMeta); err != nil {
+		return fmt.Errorf("failed at unmarshal for dedicated columns: %w", err)
+	}
+
+	var msg interface{}
+	err := json.Unmarshal(data, &msg)
+	if err != nil {
+		return err
+	}
+	msgMap := msg.(map[string]interface{})
+
+	if v, ok := msgMap["compactedTime"]; ok {
+		b.CompactedTime, err = time.Parse(time.RFC3339, v.(string))
+		if err != nil {
+			return fmt.Errorf("failed to parse time at compactedTime: %w", err)
+		}
+	}
+
+	return nil
+}
+
 const (
 	DefaultReplicationFactor          = 0 // Replication factor for blocks from the ingester. This is the default value to indicate RF3.
 	MetricsGeneratorReplicationFactor = 1

--- a/tempodb/backend/block_meta.go
+++ b/tempodb/backend/block_meta.go
@@ -166,8 +166,8 @@ func (b *BlockMeta) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	b.Version = intern.Get(b.Version).Get().(string)
-	b.TenantID = intern.Get(b.TenantID).Get().(string)
+	b.Version = intern.Get(b.Version).Get()
+	b.TenantID = intern.Get(b.TenantID).Get()
 
 	return nil
 }

--- a/tempodb/backend/block_meta.go
+++ b/tempodb/backend/block_meta.go
@@ -158,16 +158,20 @@ func (b *BlockMeta) UnmarshalJSON(data []byte) error {
 	}
 
 	if v, ok := msgMap["minID"]; ok {
-		b.MinID, err = base64.StdEncoding.DecodeString(v.(string))
-		if err != nil {
-			return fmt.Errorf("failed decode at minID: %w", err)
+		if v != nil {
+			b.MinID, err = base64.StdEncoding.DecodeString(v.(string))
+			if err != nil {
+				return fmt.Errorf("failed decode at minID: %w", err)
+			}
 		}
 	}
 
 	if v, ok := msgMap["maxID"]; ok {
-		b.MaxID, err = base64.StdEncoding.DecodeString(v.(string))
-		if err != nil {
-			return fmt.Errorf("failed decode at maxID: %w", err)
+		if v != nil {
+			b.MaxID, err = base64.StdEncoding.DecodeString(v.(string))
+			if err != nil {
+				return fmt.Errorf("failed decode at maxID: %w", err)
+			}
 		}
 	}
 

--- a/tempodb/backend/block_meta.go
+++ b/tempodb/backend/block_meta.go
@@ -209,6 +209,11 @@ func (dc *DedicatedColumn) UnmarshalJSON(b []byte) error {
 	if dc.Type == "" {
 		dc.Type = DefaultDedicatedColumnType
 	}
+
+	dc.Scope = DedicatedColumnScope(intern.Get(string(dc.Scope)).Get())
+	dc.Type = DedicatedColumnType(intern.Get(string(dc.Type)).Get())
+	dc.Name = intern.Get(dc.Name).Get()
+
 	return nil
 }
 

--- a/tempodb/backend/block_meta.go
+++ b/tempodb/backend/block_meta.go
@@ -2,7 +2,6 @@ package backend
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -161,113 +160,14 @@ type BlockMeta struct {
 }
 
 func (b *BlockMeta) UnmarshalJSON(data []byte) error {
-	var msg interface{}
-	err := json.Unmarshal(data, &msg)
+	type metaAlias BlockMeta
+
+	err := json.Unmarshal(data, (*metaAlias)(b))
 	if err != nil {
 		return err
 	}
-	msgMap := msg.(map[string]interface{})
-
-	if v, ok := msgMap["format"]; ok {
-		b.Version = intern.Get(v.(string)).Get().(string)
-	}
-
-	if v, ok := msgMap["blockID"]; ok {
-		b.BlockID, err = uuid.Parse(v.(string))
-		if err != nil {
-			return err
-		}
-	}
-
-	if v, ok := msgMap["minID"]; ok {
-		if v != nil {
-			b.MinID, err = base64.StdEncoding.DecodeString(v.(string))
-			if err != nil {
-				return fmt.Errorf("failed decode at minID: %w", err)
-			}
-		}
-	}
-
-	if v, ok := msgMap["maxID"]; ok {
-		if v != nil {
-			b.MaxID, err = base64.StdEncoding.DecodeString(v.(string))
-			if err != nil {
-				return fmt.Errorf("failed decode at maxID: %w", err)
-			}
-		}
-	}
-
-	if v, ok := msgMap["tenantID"]; ok {
-		b.TenantID = intern.Get(v.(string)).Get().(string)
-	}
-
-	if v, ok := msgMap["startTime"]; ok {
-		b.StartTime, err = time.Parse(time.RFC3339, v.(string))
-		if err != nil {
-			return fmt.Errorf("failed to parse time at startTime: %w", err)
-		}
-	}
-
-	if v, ok := msgMap["endTime"]; ok {
-		b.EndTime, err = time.Parse(time.RFC3339, v.(string))
-		if err != nil {
-			return fmt.Errorf("failed to parse time at startTime: %w", err)
-		}
-	}
-
-	if v, ok := msgMap["totalObjects"]; ok {
-		b.TotalObjects = int(v.(float64))
-	}
-
-	if v, ok := msgMap["size"]; ok {
-		b.Size = uint64(v.(float64))
-	}
-
-	if v, ok := msgMap["compactionLevel"]; ok {
-		b.CompactionLevel = uint8(v.(float64))
-	}
-
-	if v, ok := msgMap["encoding"]; ok {
-		b.Encoding, err = ParseEncoding(v.(string))
-		if err != nil {
-			return fmt.Errorf("failed unmarshal at encoding: %w", err)
-		}
-	}
-
-	if v, ok := msgMap["indexPageSize"]; ok {
-		b.IndexPageSize = uint32((v.(float64)))
-	}
-
-	if v, ok := msgMap["totalRecords"]; ok {
-		b.TotalRecords = uint32((v.(float64)))
-	}
-
-	if v, ok := msgMap["dataEncoding"]; ok {
-		b.DataEncoding = v.(string)
-	}
-
-	if v, ok := msgMap["bloomShards"]; ok {
-		b.BloomShardCount = uint16((v.(float64)))
-	}
-
-	if v, ok := msgMap["footerSize"]; ok {
-		b.FooterSize = uint32((v.(float64)))
-	}
-
-	if v, ok := msgMap["dedicatedColumns"]; ok {
-		jsonStr, err := json.Marshal(v)
-		if err != nil {
-			fmt.Println(err)
-		}
-
-		if err := json.Unmarshal(jsonStr, &b.DedicatedColumns); err != nil {
-			return fmt.Errorf("failed at unmarshal for dedicated columns: %w", err)
-		}
-	}
-
-	if v, ok := msgMap["replicationFactor"]; ok {
-		b.ReplicationFactor = uint32((v.(float64)))
-	}
+	b.Version = intern.Get(b.Version).Get().(string)
+	b.TenantID = intern.Get(b.TenantID).Get().(string)
 
 	return nil
 }

--- a/tempodb/backend/block_meta_test.go
+++ b/tempodb/backend/block_meta_test.go
@@ -173,7 +173,6 @@ func TestBlockMetaParsing(t *testing.T) {
 
 	assert.Exactly(t, metaRoundtrip.Version, metaRoundtrip2.Version)
 	assert.Exactly(t, metaRoundtrip.TenantID, metaRoundtrip2.TenantID)
-	t.Error("f")
 }
 
 func TestDedicatedColumnsFromTempopb(t *testing.T) {

--- a/tempodb/backend/block_meta_test.go
+++ b/tempodb/backend/block_meta_test.go
@@ -111,7 +111,7 @@ func TestBlockMetaParsing(t *testing.T) {
 
 	meta := BlockMeta{
 		Version:         "vParquet3",
-		BlockID:         uuid.MustParse("00000000-0000-0000-0000-000000000000"),
+		BlockID:         uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 		MinID:           minID,
 		MaxID:           maxID,
 		TenantID:        "single-tenant",
@@ -135,7 +135,7 @@ func TestBlockMetaParsing(t *testing.T) {
 
 	expectedJSON := `{
     	"format": "vParquet3",
-    	"blockID": "00000000-0000-0000-0000-000000000000",
+    	"blockID": "00000000-0000-0000-0000-000000000001",
     	"minID": "ACA/8tpRKjtPqxHXJDrBzA==",
     	"maxID": "8St6GtMRX/IHc0+rDQqyNQ==",
     	"tenantID": "single-tenant",
@@ -165,6 +165,15 @@ func TestBlockMetaParsing(t *testing.T) {
 	err = json.Unmarshal(metaJSON, &metaRoundtrip)
 	require.NoError(t, err)
 	assert.Equal(t, meta, metaRoundtrip)
+
+	var metaRoundtrip2 BlockMeta
+	err = json.Unmarshal(metaJSON, &metaRoundtrip2)
+	require.NoError(t, err)
+	assert.Equal(t, meta, metaRoundtrip2)
+
+	assert.Exactly(t, metaRoundtrip.Version, metaRoundtrip2.Version)
+	assert.Exactly(t, metaRoundtrip.TenantID, metaRoundtrip2.TenantID)
+	t.Error("f")
 }
 
 func TestDedicatedColumnsFromTempopb(t *testing.T) {

--- a/tempodb/backend/tenantindex_test.go
+++ b/tempodb/backend/tenantindex_test.go
@@ -111,6 +111,14 @@ func BenchmarkIndexMarshal(b *testing.B) {
 		},
 	}
 
+	for i := range idx.Meta {
+		idx.Meta[i].DedicatedColumns = DedicatedColumns{
+			{Scope: "resource", Name: "namespace", Type: "string"},
+			{Scope: "span", Name: "http.method", Type: "string"},
+			{Scope: "span", Name: "namespace", Type: "string"},
+		}
+	}
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, _ = idx.marshal()
@@ -138,6 +146,14 @@ func BenchmarkIndexUnmarshal(b *testing.B) {
 				CompactedTime: time.Now(),
 			},
 		},
+	}
+
+	for i := range idx.Meta {
+		idx.Meta[i].DedicatedColumns = DedicatedColumns{
+			{Scope: "resource", Name: "namespace", Type: "string"},
+			{Scope: "span", Name: "http.method", Type: "string"},
+			{Scope: "span", Name: "namespace", Type: "string"},
+		}
 	}
 
 	buf, err := idx.marshal()

--- a/tempodb/backend/tenantindex_test.go
+++ b/tempodb/backend/tenantindex_test.go
@@ -87,3 +87,65 @@ func TestIndexUnmarshalErrors(t *testing.T) {
 	err := test.unmarshal([]byte("bad data"))
 	assert.Error(t, err)
 }
+
+func BenchmarkIndexMarshal(b *testing.B) {
+	idx := &TenantIndex{
+		Meta: []*BlockMeta{
+			NewBlockMeta("test", uuid.New(), "v1", EncGZIP, "adsf"),
+			NewBlockMeta("test", uuid.New(), "v2", EncNone, "adsf"),
+			NewBlockMeta("test", uuid.New(), "v3", EncLZ4_4M, "adsf"),
+		},
+		CompactedMeta: []*CompactedBlockMeta{
+			{
+				BlockMeta:     *NewBlockMeta("test", uuid.New(), "v1", EncGZIP, "adsf"),
+				CompactedTime: time.Now(),
+			},
+			{
+				BlockMeta:     *NewBlockMeta("test", uuid.New(), "v1", EncZstd, "adsf"),
+				CompactedTime: time.Now(),
+			},
+			{
+				BlockMeta:     *NewBlockMeta("test", uuid.New(), "v1", EncSnappy, "adsf"),
+				CompactedTime: time.Now(),
+			},
+		},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = idx.marshal()
+	}
+}
+
+func BenchmarkIndexUnmarshal(b *testing.B) {
+	idx := &TenantIndex{
+		Meta: []*BlockMeta{
+			NewBlockMeta("test", uuid.New(), "v1", EncGZIP, "adsf"),
+			NewBlockMeta("test", uuid.New(), "v2", EncNone, "adsf"),
+			NewBlockMeta("test", uuid.New(), "v3", EncLZ4_4M, "adsf"),
+		},
+		CompactedMeta: []*CompactedBlockMeta{
+			{
+				BlockMeta:     *NewBlockMeta("test", uuid.New(), "v1", EncGZIP, "adsf"),
+				CompactedTime: time.Now(),
+			},
+			{
+				BlockMeta:     *NewBlockMeta("test", uuid.New(), "v1", EncZstd, "adsf"),
+				CompactedTime: time.Now(),
+			},
+			{
+				BlockMeta:     *NewBlockMeta("test", uuid.New(), "v1", EncSnappy, "adsf"),
+				CompactedTime: time.Now(),
+			},
+		},
+	}
+
+	buf, err := idx.marshal()
+	require.NoError(b, err)
+
+	unIdx := &TenantIndex{}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = unIdx.unmarshal(buf)
+	}
+}


### PR DESCRIPTION
**What this PR does**:

Here is a bit of experiment to see if we can reduce the size of memory that the poller consumes.

* New `intern` package which will intern a string
* Add `UnmarshalJson` on `BlockMeta` and `CompactedBlockMeta`

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`