### PR TITLE
fix: enable cache for Set up Go action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,6 @@ jobs:
             test-e2e,
             test-integration-poller,
             test-e2e-deployments,
-            test-e2e-deployments,
             test-e2e-serverless,
           ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
+          cache-dependency-path: "**/go.sum"
+          cache: true
           go-version: '>=1.22.4'
 
       - name: Check out code
@@ -48,6 +50,8 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
+          cache-dependency-path: "**/go.sum"
+          cache: true
           go-version: '>=1.22.4'
 
       - name: Check out code
@@ -78,6 +82,8 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
+          cache-dependency-path: "**/go.sum"
+          cache: true
           go-version: '>=1.22.4'
 
       - name: Check out code
@@ -93,6 +99,8 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
+          cache-dependency-path: "**/go.sum"
+          cache: true
           go-version: '>=1.22.4'
 
       - name: Check out code
@@ -108,6 +116,8 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
+          cache-dependency-path: "**/go.sum"
+          cache: true
           go-version: '>=1.22.4'
 
       - name: Check out code
@@ -123,6 +133,8 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
+          cache-dependency-path: "**/go.sum"
+          cache: true
           go-version: '>=1.22.4'
 
       - name: Check out code
@@ -138,6 +150,8 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
+          cache-dependency-path: "**/go.sum"
+          cache: true
           go-version: '>=1.22.4'
 
       - name: Check out code
@@ -153,6 +167,8 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
+          cache-dependency-path: "**/go.sum"
+          cache: true
           go-version: '>=1.22.4'
 
       - name: Check out code
@@ -168,6 +184,8 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
+          cache-dependency-path: "**/go.sum"
+          cache: true
           go-version: '>=1.22.4'
 
       - name: Check out code
@@ -192,6 +210,8 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
+          cache-dependency-path: "**/go.sum"
+          cache: true
           go-version: '>=1.22.4'
 
       - name: Check out code
@@ -207,6 +227,8 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
+          cache-dependency-path: "**/go.sum"
+          cache: true
           go-version: '>=1.22.4'
 
       - name: Check out code
@@ -227,6 +249,8 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
+          cache-dependency-path: "**/go.sum"
+          cache: true
           go-version: '>=1.22.4'
 
       - name: Check out code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  setup:
-    name: Set up
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -29,21 +29,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-          cache-dependency-path: "**/go.sum"
-      - name: Upload code as artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: code
-          path: .
-  lint:
-    name: Lint
-    needs: setup
-    runs-on: ubuntu-latest
-      - name: Download code artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: code
-          path: .
       - name: check-fmt
         run: make check-fmt
 
@@ -53,223 +38,209 @@ jobs:
       - name: lint
         run: make lint base=origin/${{github.base_ref}}
 
-  # unit-tests-pkg:
-  #   name: Test packages - pkg
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set up Go 1.22
-  #       uses: actions/setup-go@v5
-  #       with:
-  #         cache-dependency-path: "**/go.sum"
-  #         go-version: '>=1.22.4'
+  unit-tests-pkg:
+    name: Test packages - pkg
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+      - name: Set up Go 1.22
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: Test
+        run: make test-with-cover-pkg
 
-  #     - name: Test
-  #       run: make test-with-cover-pkg
+  unit-tests-tempodb:
+    name: Test packages - tempodb
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  # unit-tests-tempodb:
-  #   name: Test packages - tempodb
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set up Go 1.22
-  #       uses: actions/setup-go@v5
-  #       with:
-  #         go-version: '>=1.22.4'
+      - name: Set up Go 1.22
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          
+      - name: Test
+        run: make test-with-cover-tempodb
 
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+  unit-tests-tempodb-wal:
+    name: Test packages - tempodb/wal
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  #     - name: Test
-  #       run: make test-with-cover-tempodb
+      - name: Set up Go 1.22
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
 
-  # unit-tests-tempodb-wal:
-  #   name: Test packages - tempodb/wal
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set up Go 1.22
-  #       uses: actions/setup-go@v5
-  #       with:
-  #         cache-dependency-path: "**/go.sum"
-  #         go-version: '>=1.22.4'
+      - name: Test
+        run: make test-with-cover-tempodb-wal
 
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+  unit-tests-others:
+    name: Test packages - others
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  #     - name: Test
-  #       run: make test-with-cover-tempodb-wal
+      - name: Set up Go 1.22
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
 
-  # unit-tests-others:
-  #   name: Test packages - others
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set up Go 1.22
-  #       uses: actions/setup-go@v5
-  #       with:
-  #         cache-dependency-path: "**/go.sum"
-  #         go-version: '>=1.22.4'
+      - name: Test
+        run: make test-with-cover-others
 
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+  integration-tests:
+    name: Test integration e2e suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Go 1.22
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: Test
+        run: make test-e2e
 
-  #     - name: Test
-  #       run: make test-with-cover-others
+  integration-tests-poller:
+    name: Test integration e2e suite - poller
+    runs-on: ubuntu-latest
+    steps:
 
-  # integration-tests:
-  #   name: Test integration e2e suite
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set up Go 1.22
-  #       uses: actions/setup-go@v5
-  #       with:
-  #         cache-dependency-path: "**/go.sum"
-  #         go-version: '>=1.22.4'
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+      - name: Set up Go 1.22
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
 
-  #     - name: Test
-  #       run: make test-e2e
+      - name: Poller
+        run: make test-integration-poller
 
-  # integration-tests-poller:
-  #   name: Test integration e2e suite - poller
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set up Go 1.22
-  #       uses: actions/setup-go@v5
-  #       with:
-  #         cache-dependency-path: "**/go.sum"
-  #         go-version: '>=1.22.4'
+  integration-tests-deployment-modes:
+    name: Test integration e2e suite - deployment modes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+      - name: Set up Go 1.22
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
 
-  #     - name: Poller
-  #       run: make test-integration-poller
+      - name: Deployment modes
+        run: make test-e2e-deployments
 
-  # integration-tests-deployment-modes:
-  #   name: Test integration e2e suite - deployment modes
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set up Go 1.22
-  #       uses: actions/setup-go@v5
-  #       with:
-  #         cache-dependency-path: "**/go.sum"
-  #         go-version: '>=1.22.4'
+  integration-tests-serverless:
+    name: Test integration e2e suite - serverless
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+      - name: Set up Go 1.22
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
 
-  #     - name: Deployment modes
-  #       run: make test-e2e-deployments
+      - name: Test
+        run: make test-e2e-serverless
 
-  # integration-tests-serverless:
-  #   name: Test integration e2e suite - serverless
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set up Go 1.22
-  #       uses: actions/setup-go@v5
-  #       with:
-  #         cache-dependency-path: "**/go.sum"
-  #         go-version: '>=1.22.4'
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+      - name: Set up Go 1.22
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
 
-  #     - name: Test
-  #       run: make test-e2e-serverless
+      - name: Build Tempo
+        run: make tempo
 
-  # build:
-  #   name: Build
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set up Go 1.22
-  #       uses: actions/setup-go@v5
-  #       with:
-  #         cache-dependency-path: "**/go.sum"
-  #         cache: true
-  #         go-version: '>=1.22.4'
+      - name: Build tempo-query
+        run: make tempo-query
 
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+      - name: Build vulture
+        run: make tempo-vulture
 
-  #     - name: Build Tempo
-  #       run: make tempo
+      - name: Build tempo-cli
+        run: make tempo-cli
 
-  #     - name: Build tempo-query
-  #       run: make tempo-query
+  benchmark:
+    name: Benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  #     - name: Build vulture
-  #       run: make tempo-vulture
+      - name: Set up Go 1.22
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
 
-  #     - name: Build tempo-cli
-  #       run: make tempo-cli
+      - name: Bench
+        run: make test-bench
 
-  # benchmark:
-  #   name: Benchmark
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set up Go 1.22
-  #       uses: actions/setup-go@v5
-  #       with:
-  #         cache-dependency-path: "**/go.sum"
-  #         go-version: '>=1.22.4'
+  vendor-check:
+    name: Vendor check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+      - name: Set up Go 1.22
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
 
-  #     - name: Bench
-  #       run: make test-bench
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-  # vendor-check:
-  #   name: Vendor check
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set up Go 1.22
-  #       uses: actions/setup-go@v5
-  #       with:
-  #         cache-dependency-path: "**/go.sum"
-  #         go-version: '>=1.22.4'
+      - name: Check vendor
+        run: make vendor-check
 
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+  tempo-jsonnet:
+    name: Check jsonnet & tempo-mixin
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  #     - name: Install Protoc
-  #       uses: arduino/setup-protoc@v3
-  #       with:
-  #         repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Go 1.22
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
 
-  #     - name: Check vendor
-  #       run: make vendor-check
+      - name: Check jsonnet
+        run: make jsonnet-check
 
-  # tempo-jsonnet:
-  #   name: Check jsonnet & tempo-mixin
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set up Go 1.22
-  #       uses: actions/setup-go@v5
-  #       with:
-  #         cache-dependency-path: "**/go.sum"
-  #         go-version: '>=1.22.4'
+      - name: Check tempo-mixin
+        run: make tempo-mixin-check
 
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+      - name: Test jsonnet
+        run: make jsonnet-test
 
-  #     - name: Check jsonnet
-  #       run: make jsonnet-check
-
-  #     - name: Check tempo-mixin
-  #       run: make tempo-mixin-check
-
-  #     - name: Test jsonnet
-  #       run: make jsonnet-test
-
-  # build-technical-documentation:
-  #   name: Build technical documentation
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
-  #     - name: Build Website
-  #       run: docker run -v ${PWD}/docs/sources:/hugo/content/docs/tempo/latest --rm grafana/docs-base:latest make prod
+  build-technical-documentation:
+    name: Build technical documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Build Website
+        run: docker run -v ${PWD}/docs/sources:/hugo/content/docs/tempo/latest --rm grafana/docs-base:latest make prod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version: '>=1.22.4'
 
       - name: check-fmt
         run: make check-fmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
-  lint:
-    name: Lint
+  setup:
+    name: Set up
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -32,6 +31,12 @@ jobs:
           go-version-file: 'go.mod'
           cache-dependency-path: "**/go.sum"
 
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
       - name: check-fmt
         run: make check-fmt
 
@@ -41,21 +46,22 @@ jobs:
       - name: lint
         run: make lint base=origin/${{github.base_ref}}
 
-  # unit-tests-pkg:
-  #   name: Test packages - pkg
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set up Go 1.22
-  #       uses: actions/setup-go@v5
-  #       with:
-  #         cache-dependency-path: "**/go.sum"
-  #         go-version: '>=1.22.4'
+  unit-tests-pkg:
+    name: Test packages - pkg
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - name: Set up Go 1.22
+        uses: actions/setup-go@v5
+        with:
+          cache-dependency-path: "**/go.sum"
+          go-version: '>=1.22.4'
 
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  #     - name: Test
-  #       run: make test-with-cover-pkg
+      - name: Test
+        run: make test-with-cover-pkg
 
   # unit-tests-tempodb:
   #   name: Test packages - tempodb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.22.4'
+          go-version-file: 'go.mod'
+          cache-dependency-path: "**/go.sum"
 
       - name: check-fmt
         run: make check-fmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          fetch-depth: '0'
+          fetch-depth: "0"
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
       - name: check-fmt
         run: make check-fmt
 
@@ -43,10 +43,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        test-target: [test-with-cover-pkg,
-          test-with-cover-tempodb, 
-          test-with-cover-tempodb-wal, 
-          test-with-cover-others]
+        test-target:
+          [
+            test-with-cover-pkg,
+            test-with-cover-tempodb,
+            test-with-cover-tempodb-wal,
+            test-with-cover-others,
+          ]
 
     steps:
       - name: Check out code
@@ -55,17 +58,24 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
 
       - name: Run Tests
         run: make ${{ matrix.test-target }}
-  
+
   integration-tests:
     name: Run integration tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        test-target: [test-e2e, test-integration-poller, test-e2e-deployments, test-e2e-deployments,test-e2e-serverless]
+        test-target:
+          [
+            test-e2e,
+            test-integration-poller,
+            test-e2e-deployments,
+            test-e2e-deployments,
+            test-e2e-serverless,
+          ]
 
     steps:
       - name: Check out code
@@ -73,7 +83,7 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
       - name: Run Tests
         run: make ${{ matrix.test-target }}
 
@@ -87,7 +97,7 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
 
       - name: Build Tempo
         run: make tempo
@@ -111,7 +121,7 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
 
       - name: Bench
         run: make test-bench
@@ -126,7 +136,7 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
@@ -146,7 +156,7 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
 
       - name: Check jsonnet
         run: make jsonnet-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: lint
         run: make lint base=origin/${{github.base_ref}}
 
-   unit-tests:
+  unit-tests:
     name: Run Unit Tests
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,68 +56,14 @@ jobs:
 
       - name: Run Tests
         run: make ${{ matrix.test-target }}
-  # unit-tests-pkg:
-  #   name: Test packages - pkg
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
-
-  #     - name: Set up Go 1.22
-  #       uses: actions/setup-go@v5
-  #       with:
-  #         go-version-file: 'go.mod'
-  #     - name: Test
-  #       run: make test-with-cover-pkg
-
-  # unit-tests-tempodb:
-  #   name: Test packages - tempodb
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
-
-  #     - name: Set up Go 1.22
-  #       uses: actions/setup-go@v5
-  #       with:
-  #         go-version-file: 'go.mod'
-
-  #     - name: Test
-  #       run: make test-with-cover-tempodb
-
-  # unit-tests-tempodb-wal:
-  #   name: Test packages - tempodb/wal
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
-
-  #     - name: Set up Go 1.22
-  #       uses: actions/setup-go@v5
-  #       with:
-  #         go-version-file: 'go.mod'
-
-  #     - name: Test
-  #       run: make test-with-cover-tempodb-wal
-
-  # unit-tests-others:
-  #   name: Test packages - others
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
-
-  #     - name: Set up Go 1.22
-  #       uses: actions/setup-go@v5
-  #       with:
-  #         go-version-file: 'go.mod'
-
-  #     - name: Test
-  #       run: make test-with-cover-others
-
+  
   integration-tests:
-    name: Test integration e2e suite
+    name: Run integration tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        test-target: [test-e2e, test-integration-poller, test-e2e-deployments, test-e2e-deployments,test-e2e-serverless]
+
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -125,54 +71,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      - name: Test
-        run: make test-e2e
-
-  integration-tests-poller:
-    name: Test integration e2e suite - poller
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Set up Go 1.22
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-
-      - name: Poller
-        run: make test-integration-poller
-
-  integration-tests-deployment-modes:
-    name: Test integration e2e suite - deployment modes
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Set up Go 1.22
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-
-      - name: Deployment modes
-        run: make test-e2e-deployments
-
-  integration-tests-serverless:
-    name: Test integration e2e suite - serverless
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Set up Go 1.22
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-
-      - name: Test
-        run: make test-e2e-serverless
+      - name: Run Tests
+        run: make ${{ matrix.test-target }}
 
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        test-target: [pkg, tempodb, tempodb-wal, others]
+        test-target: [test-with-cover-pkg,
+          test-with-cover-tempodb, 
+          test-with-cover-tempodb-wal, 
+          test-with-cover-others]
 
     steps:
       - name: Check out code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,17 +22,14 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.22
-        uses: actions/setup-go@v5
-        with:
-          cache-dependency-path: "**/go.sum"
-          cache: true
-          go-version: '>=1.22.4'
-
       - name: Check out code
         uses: actions/checkout@v4
         with:
           fetch-depth: '0'
+      - name: Set up Go 1.22
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: '**/go.mod'
 
       - name: check-fmt
         run: make check-fmt
@@ -43,233 +40,223 @@ jobs:
       - name: lint
         run: make lint base=origin/${{github.base_ref}}
 
-  unit-tests-pkg:
-    name: Test packages - pkg
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.22
-        uses: actions/setup-go@v5
-        with:
-          cache-dependency-path: "**/go.sum"
-          cache: true
-          go-version: '>=1.22.4'
+  # unit-tests-pkg:
+  #   name: Test packages - pkg
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set up Go 1.22
+  #       uses: actions/setup-go@v5
+  #       with:
+  #         cache-dependency-path: "**/go.sum"
+  #         go-version: '>=1.22.4'
 
-      - name: Check out code
-        uses: actions/checkout@v4
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
 
-      - name: Test
-        run: make test-with-cover-pkg
+  #     - name: Test
+  #       run: make test-with-cover-pkg
 
-  unit-tests-tempodb:
-    name: Test packages - tempodb
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.22
-        uses: actions/setup-go@v5
-        with:
-          go-version: '>=1.22.4'
+  # unit-tests-tempodb:
+  #   name: Test packages - tempodb
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set up Go 1.22
+  #       uses: actions/setup-go@v5
+  #       with:
+  #         go-version: '>=1.22.4'
 
-      - name: Check out code
-        uses: actions/checkout@v4
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
 
-      - name: Test
-        run: make test-with-cover-tempodb
+  #     - name: Test
+  #       run: make test-with-cover-tempodb
 
-  unit-tests-tempodb-wal:
-    name: Test packages - tempodb/wal
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.22
-        uses: actions/setup-go@v5
-        with:
-          cache-dependency-path: "**/go.sum"
-          cache: true
-          go-version: '>=1.22.4'
+  # unit-tests-tempodb-wal:
+  #   name: Test packages - tempodb/wal
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set up Go 1.22
+  #       uses: actions/setup-go@v5
+  #       with:
+  #         cache-dependency-path: "**/go.sum"
+  #         go-version: '>=1.22.4'
 
-      - name: Check out code
-        uses: actions/checkout@v4
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
 
-      - name: Test
-        run: make test-with-cover-tempodb-wal
+  #     - name: Test
+  #       run: make test-with-cover-tempodb-wal
 
-  unit-tests-others:
-    name: Test packages - others
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.22
-        uses: actions/setup-go@v5
-        with:
-          cache-dependency-path: "**/go.sum"
-          cache: true
-          go-version: '>=1.22.4'
+  # unit-tests-others:
+  #   name: Test packages - others
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set up Go 1.22
+  #       uses: actions/setup-go@v5
+  #       with:
+  #         cache-dependency-path: "**/go.sum"
+  #         go-version: '>=1.22.4'
 
-      - name: Check out code
-        uses: actions/checkout@v4
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
 
-      - name: Test
-        run: make test-with-cover-others
+  #     - name: Test
+  #       run: make test-with-cover-others
 
-  integration-tests:
-    name: Test integration e2e suite
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.22
-        uses: actions/setup-go@v5
-        with:
-          cache-dependency-path: "**/go.sum"
-          cache: true
-          go-version: '>=1.22.4'
+  # integration-tests:
+  #   name: Test integration e2e suite
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set up Go 1.22
+  #       uses: actions/setup-go@v5
+  #       with:
+  #         cache-dependency-path: "**/go.sum"
+  #         go-version: '>=1.22.4'
 
-      - name: Check out code
-        uses: actions/checkout@v4
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
 
-      - name: Test
-        run: make test-e2e
+  #     - name: Test
+  #       run: make test-e2e
 
-  integration-tests-poller:
-    name: Test integration e2e suite - poller
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.22
-        uses: actions/setup-go@v5
-        with:
-          cache-dependency-path: "**/go.sum"
-          cache: true
-          go-version: '>=1.22.4'
+  # integration-tests-poller:
+  #   name: Test integration e2e suite - poller
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set up Go 1.22
+  #       uses: actions/setup-go@v5
+  #       with:
+  #         cache-dependency-path: "**/go.sum"
+  #         go-version: '>=1.22.4'
 
-      - name: Check out code
-        uses: actions/checkout@v4
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
 
-      - name: Poller
-        run: make test-integration-poller
+  #     - name: Poller
+  #       run: make test-integration-poller
 
-  integration-tests-deployment-modes:
-    name: Test integration e2e suite - deployment modes
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.22
-        uses: actions/setup-go@v5
-        with:
-          cache-dependency-path: "**/go.sum"
-          cache: true
-          go-version: '>=1.22.4'
+  # integration-tests-deployment-modes:
+  #   name: Test integration e2e suite - deployment modes
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set up Go 1.22
+  #       uses: actions/setup-go@v5
+  #       with:
+  #         cache-dependency-path: "**/go.sum"
+  #         go-version: '>=1.22.4'
 
-      - name: Check out code
-        uses: actions/checkout@v4
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
 
-      - name: Deployment modes
-        run: make test-e2e-deployments
+  #     - name: Deployment modes
+  #       run: make test-e2e-deployments
 
-  integration-tests-serverless:
-    name: Test integration e2e suite - serverless
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.22
-        uses: actions/setup-go@v5
-        with:
-          cache-dependency-path: "**/go.sum"
-          cache: true
-          go-version: '>=1.22.4'
+  # integration-tests-serverless:
+  #   name: Test integration e2e suite - serverless
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set up Go 1.22
+  #       uses: actions/setup-go@v5
+  #       with:
+  #         cache-dependency-path: "**/go.sum"
+  #         go-version: '>=1.22.4'
 
-      - name: Check out code
-        uses: actions/checkout@v4
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
 
-      - name: Test
-        run: make test-e2e-serverless
+  #     - name: Test
+  #       run: make test-e2e-serverless
 
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.22
-        uses: actions/setup-go@v5
-        with:
-          cache-dependency-path: "**/go.sum"
-          cache: true
-          go-version: '>=1.22.4'
+  # build:
+  #   name: Build
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set up Go 1.22
+  #       uses: actions/setup-go@v5
+  #       with:
+  #         cache-dependency-path: "**/go.sum"
+  #         cache: true
+  #         go-version: '>=1.22.4'
 
-      - name: Check out code
-        uses: actions/checkout@v4
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
 
-      - name: Build Tempo
-        run: make tempo
+  #     - name: Build Tempo
+  #       run: make tempo
 
-      - name: Build tempo-query
-        run: make tempo-query
+  #     - name: Build tempo-query
+  #       run: make tempo-query
 
-      - name: Build vulture
-        run: make tempo-vulture
+  #     - name: Build vulture
+  #       run: make tempo-vulture
 
-      - name: Build tempo-cli
-        run: make tempo-cli
+  #     - name: Build tempo-cli
+  #       run: make tempo-cli
 
-  benchmark:
-    name: Benchmark
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.22
-        uses: actions/setup-go@v5
-        with:
-          cache-dependency-path: "**/go.sum"
-          cache: true
-          go-version: '>=1.22.4'
+  # benchmark:
+  #   name: Benchmark
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set up Go 1.22
+  #       uses: actions/setup-go@v5
+  #       with:
+  #         cache-dependency-path: "**/go.sum"
+  #         go-version: '>=1.22.4'
 
-      - name: Check out code
-        uses: actions/checkout@v4
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
 
-      - name: Bench
-        run: make test-bench
+  #     - name: Bench
+  #       run: make test-bench
 
-  vendor-check:
-    name: Vendor check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.22
-        uses: actions/setup-go@v5
-        with:
-          cache-dependency-path: "**/go.sum"
-          cache: true
-          go-version: '>=1.22.4'
+  # vendor-check:
+  #   name: Vendor check
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set up Go 1.22
+  #       uses: actions/setup-go@v5
+  #       with:
+  #         cache-dependency-path: "**/go.sum"
+  #         go-version: '>=1.22.4'
 
-      - name: Check out code
-        uses: actions/checkout@v4
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Install Protoc
+  #       uses: arduino/setup-protoc@v3
+  #       with:
+  #         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check vendor
-        run: make vendor-check
+  #     - name: Check vendor
+  #       run: make vendor-check
 
-  tempo-jsonnet:
-    name: Check jsonnet & tempo-mixin
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.22
-        uses: actions/setup-go@v5
-        with:
-          cache-dependency-path: "**/go.sum"
-          cache: true
-          go-version: '>=1.22.4'
+  # tempo-jsonnet:
+  #   name: Check jsonnet & tempo-mixin
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set up Go 1.22
+  #       uses: actions/setup-go@v5
+  #       with:
+  #         cache-dependency-path: "**/go.sum"
+  #         go-version: '>=1.22.4'
 
-      - name: Check out code
-        uses: actions/checkout@v4
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
 
-      - name: Check jsonnet
-        run: make jsonnet-check
+  #     - name: Check jsonnet
+  #       run: make jsonnet-check
 
-      - name: Check tempo-mixin
-        run: make tempo-mixin-check
+  #     - name: Check tempo-mixin
+  #       run: make tempo-mixin-check
 
-      - name: Test jsonnet
-        run: make jsonnet-test
+  #     - name: Test jsonnet
+  #       run: make jsonnet-test
 
-  build-technical-documentation:
-    name: Build technical documentation
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Build Website
-        run: docker run -v ${PWD}/docs/sources:/hugo/content/docs/tempo/latest --rm grafana/docs-base:latest make prod
+  # build-technical-documentation:
+  #   name: Build technical documentation
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
+  #     - name: Build Website
+  #       run: docker run -v ${PWD}/docs/sources:/hugo/content/docs/tempo/latest --rm grafana/docs-base:latest make prod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,20 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache-dependency-path: "**/go.sum"
-
-
+      - name: Upload code as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: code
+          path: .
   lint:
     name: Lint
-    runs-on: ubuntu-latest
     needs: setup
-    steps:
+    runs-on: ubuntu-latest
+      - name: Download code artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: code
+          path: .
       - name: check-fmt
         run: make check-fmt
 
@@ -46,22 +53,21 @@ jobs:
       - name: lint
         run: make lint base=origin/${{github.base_ref}}
 
-  unit-tests-pkg:
-    name: Test packages - pkg
-    runs-on: ubuntu-latest
-    needs: setup
-    steps:
-      - name: Set up Go 1.22
-        uses: actions/setup-go@v5
-        with:
-          cache-dependency-path: "**/go.sum"
-          go-version: '>=1.22.4'
+  # unit-tests-pkg:
+  #   name: Test packages - pkg
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set up Go 1.22
+  #       uses: actions/setup-go@v5
+  #       with:
+  #         cache-dependency-path: "**/go.sum"
+  #         go-version: '>=1.22.4'
 
-      - name: Check out code
-        uses: actions/checkout@v4
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
 
-      - name: Test
-        run: make test-with-cover-pkg
+  #     - name: Test
+  #       run: make test-with-cover-pkg
 
   # unit-tests-tempodb:
   #   name: Test packages - tempodb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version-file: '**/go.mod'
+          go-version-file: 'go.mod'
 
       - name: check-fmt
         run: make check-fmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,38 +38,13 @@ jobs:
       - name: lint
         run: make lint base=origin/${{github.base_ref}}
 
-  unit-tests-pkg:
-    name: Test packages - pkg
+   unit-tests:
+    name: Run Unit Tests
     runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+    strategy:
+      matrix:
+        test-target: [pkg, tempodb, tempodb-wal, others]
 
-      - name: Set up Go 1.22
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-      - name: Test
-        run: make test-with-cover-pkg
-
-  unit-tests-tempodb:
-    name: Test packages - tempodb
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Set up Go 1.22
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          
-      - name: Test
-        run: make test-with-cover-tempodb
-
-  unit-tests-tempodb-wal:
-    name: Test packages - tempodb/wal
-    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -79,23 +54,66 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Test
-        run: make test-with-cover-tempodb-wal
+      - name: Run Tests
+        run: make ${{ matrix.test-target }}
+  # unit-tests-pkg:
+  #   name: Test packages - pkg
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
 
-  unit-tests-others:
-    name: Test packages - others
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+  #     - name: Set up Go 1.22
+  #       uses: actions/setup-go@v5
+  #       with:
+  #         go-version-file: 'go.mod'
+  #     - name: Test
+  #       run: make test-with-cover-pkg
 
-      - name: Set up Go 1.22
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
+  # unit-tests-tempodb:
+  #   name: Test packages - tempodb
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
 
-      - name: Test
-        run: make test-with-cover-others
+  #     - name: Set up Go 1.22
+  #       uses: actions/setup-go@v5
+  #       with:
+  #         go-version-file: 'go.mod'
+
+  #     - name: Test
+  #       run: make test-with-cover-tempodb
+
+  # unit-tests-tempodb-wal:
+  #   name: Test packages - tempodb/wal
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
+
+  #     - name: Set up Go 1.22
+  #       uses: actions/setup-go@v5
+  #       with:
+  #         go-version-file: 'go.mod'
+
+  #     - name: Test
+  #       run: make test-with-cover-tempodb-wal
+
+  # unit-tests-others:
+  #   name: Test packages - others
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
+
+  #     - name: Set up Go 1.22
+  #       uses: actions/setup-go@v5
+  #       with:
+  #         go-version-file: 'go.mod'
+
+  #     - name: Test
+  #       run: make test-with-cover-others
 
   integration-tests:
     name: Test integration e2e suite


### PR DESCRIPTION
**What this PR does**:
It fixes an error with the actions/setup-go@v5 cache: https://github.com/actions/setup-go/issues/427
It takes the Go version from the `go.mod` file
It also uses a matrix strategy to remove boilerplate


**Checklist**
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`