### PR TITLE
Native histograms processor replacement enum

### DIFF
--- a/cmd/tempo/app/overrides_validation.go
+++ b/cmd/tempo/app/overrides_validation.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/grafana/tempo/modules/generator"
+	"github.com/grafana/tempo/modules/generator/registry"
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/modules/overrides/userconfigurable/api"
 	"github.com/grafana/tempo/modules/overrides/userconfigurable/client"
@@ -33,11 +34,10 @@ func (r *runtimeConfigValidator) Validate(config *overrides.Overrides) error {
 		}
 	}
 
-	if config.MetricsGenerator.GenerateNativeHistograms != overrides.HistogramMethodClassic &&
-		config.MetricsGenerator.GenerateNativeHistograms != overrides.HistogramMethodNative &&
-		config.MetricsGenerator.GenerateNativeHistograms != overrides.HistogramMethodBoth &&
-		config.MetricsGenerator.GenerateNativeHistograms != "" {
-		return fmt.Errorf("metrics_generator.generate_native_histograms \"%s\" is not a valid value, valid values: classic, native, both", config.MetricsGenerator.GenerateNativeHistograms)
+	if v, ok := registry.HistogramModeToValue[string(config.MetricsGenerator.GenerateNativeHistograms)]; !ok {
+		if string(v) != "" {
+			return fmt.Errorf("metrics_generator.generate_native_histograms \"%s\" is not a valid value, valid values: classic, native, both", config.MetricsGenerator.GenerateNativeHistograms)
+		}
 	}
 
 	return nil

--- a/cmd/tempo/app/overrides_validation.go
+++ b/cmd/tempo/app/overrides_validation.go
@@ -33,9 +33,9 @@ func (r *runtimeConfigValidator) Validate(config *overrides.Overrides) error {
 		}
 	}
 
-	if config.MetricsGenerator.GenerateNativeHistograms != "classic" &&
-		config.MetricsGenerator.GenerateNativeHistograms != "native" &&
-		config.MetricsGenerator.GenerateNativeHistograms != "both" &&
+	if config.MetricsGenerator.GenerateNativeHistograms != overrides.HistogramMethodClassic &&
+		config.MetricsGenerator.GenerateNativeHistograms != overrides.HistogramMethodNative &&
+		config.MetricsGenerator.GenerateNativeHistograms != overrides.HistogramMethodBoth &&
 		config.MetricsGenerator.GenerateNativeHistograms != "" {
 		return fmt.Errorf("metrics_generator.generate_native_histograms \"%s\" is not a valid value, valid values: classic, native, both", config.MetricsGenerator.GenerateNativeHistograms)
 	}

--- a/cmd/tempo/app/overrides_validation.go
+++ b/cmd/tempo/app/overrides_validation.go
@@ -34,8 +34,8 @@ func (r *runtimeConfigValidator) Validate(config *overrides.Overrides) error {
 		}
 	}
 
-	if v, ok := registry.HistogramModeToValue[string(config.MetricsGenerator.GenerateNativeHistograms)]; !ok {
-		if string(v) != "" {
+	if _, ok := registry.HistogramModeToValue[string(config.MetricsGenerator.GenerateNativeHistograms)]; !ok {
+		if config.MetricsGenerator.GenerateNativeHistograms != "" {
 			return fmt.Errorf("metrics_generator.generate_native_histograms \"%s\" is not a valid value, valid values: classic, native, both", config.MetricsGenerator.GenerateNativeHistograms)
 		}
 	}

--- a/modules/generator/config.go
+++ b/modules/generator/config.go
@@ -117,8 +117,8 @@ func (cfg *ProcessorConfig) copyWithOverrides(o metricsGeneratorOverrides, userI
 	}
 
 	if histograms := o.MetricsGeneratorGenerateNativeHistograms(userID); histograms != "" {
-		copyCfg.ServiceGraphs.HistogramOverride = histograms
-		copyCfg.SpanMetrics.HistogramOverride = histograms
+		copyCfg.ServiceGraphs.HistogramOverride = registry.HistogramModeToValue[string(histograms)]
+		copyCfg.SpanMetrics.HistogramOverride = registry.HistogramModeToValue[string(histograms)]
 	}
 
 	copyCfg.SpanMetrics.DimensionMappings = o.MetricsGeneratorProcessorSpanMetricsDimensionMappings(userID)

--- a/modules/generator/instance.go
+++ b/modules/generator/instance.go
@@ -295,7 +295,10 @@ func (i *instance) addProcessor(processorName string, cfg ProcessorConfig) error
 			return err
 		}
 	case servicegraphs.Name:
-		newProcessor = servicegraphs.New(cfg.ServiceGraphs, i.instanceID, i.registry, i.logger)
+		newProcessor, err = servicegraphs.New(cfg.ServiceGraphs, i.instanceID, i.registry, i.logger)
+		if err != nil {
+			return err
+		}
 	case localblocks.Name:
 		p, err := localblocks.New(cfg.LocalBlocks, i.instanceID, i.traceWAL, i.writer, i.overrides)
 		if err != nil {

--- a/modules/generator/instance.go
+++ b/modules/generator/instance.go
@@ -295,10 +295,7 @@ func (i *instance) addProcessor(processorName string, cfg ProcessorConfig) error
 			return err
 		}
 	case servicegraphs.Name:
-		newProcessor, err = servicegraphs.New(cfg.ServiceGraphs, i.instanceID, i.registry, i.logger)
-		if err != nil {
-			return err
-		}
+		newProcessor = servicegraphs.New(cfg.ServiceGraphs, i.instanceID, i.registry, i.logger)
 	case localblocks.Name:
 		p, err := localblocks.New(cfg.LocalBlocks, i.instanceID, i.traceWAL, i.writer, i.overrides)
 		if err != nil {

--- a/modules/generator/overrides.go
+++ b/modules/generator/overrides.go
@@ -15,7 +15,7 @@ type metricsGeneratorOverrides interface {
 	registry.Overrides
 	storage.Overrides
 
-	MetricsGeneratorGenerateNativeHistograms(userID string) string
+	MetricsGeneratorGenerateNativeHistograms(userID string) overrides.HistogramMethod
 	MetricsGeneratorIngestionSlack(userID string) time.Duration
 	MetricsGeneratorProcessors(userID string) map[string]struct{}
 	MetricsGeneratorProcessorServiceGraphsHistogramBuckets(userID string) []float64

--- a/modules/generator/overrides_test.go
+++ b/modules/generator/overrides_test.go
@@ -3,6 +3,7 @@ package generator
 import (
 	"time"
 
+	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/pkg/sharedconfig"
 	filterconfig "github.com/grafana/tempo/pkg/spanfilter/config"
 	"github.com/grafana/tempo/tempodb/backend"
@@ -32,7 +33,7 @@ type mockOverrides struct {
 	dedicatedColumns                                   backend.DedicatedColumns
 	maxBytesPerTrace                                   int
 	unsafeQueryHints                                   bool
-	nativeHistograms                                   string
+	nativeHistograms                                   overrides.HistogramMethod
 }
 
 var _ metricsGeneratorOverrides = (*mockOverrides)(nil)
@@ -57,7 +58,7 @@ func (m *mockOverrides) MetricsGeneratorDisableCollection(string) bool {
 	return false
 }
 
-func (m *mockOverrides) MetricsGeneratorGenerateNativeHistograms(string) string {
+func (m *mockOverrides) MetricsGeneratorGenerateNativeHistograms(string) overrides.HistogramMethod {
 	return m.nativeHistograms
 }
 

--- a/modules/generator/processor/servicegraphs/config.go
+++ b/modules/generator/processor/servicegraphs/config.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"time"
 
+	"github.com/grafana/tempo/modules/generator/registry"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -23,8 +24,8 @@ type Config struct {
 	// Buckets for latency histogram in seconds.
 	HistogramBuckets []float64 `yaml:"histogram_buckets"`
 
-	// The histogram implementation to select.
-	HistogramOverride string `yaml:"-"`
+	// The histogram mode to select.
+	HistogramOverride registry.HistogramMode `yaml:"-"`
 
 	// Additional dimensions (labels) to be added to the metric along with the default ones.
 	// If client and server spans have the same attribute and EnableClientServerPrefix is not enabled,
@@ -56,6 +57,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {
 	cfg.Workers = 10
 	// TODO: Revisit this default value.
 	cfg.HistogramBuckets = prometheus.ExponentialBuckets(0.1, 2, 8)
+	cfg.HistogramOverride = registry.HistogramModeClassic
 
 	peerAttr := make([]string, 0, len(defaultPeerAttributes))
 	for _, attr := range defaultPeerAttributes {

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -88,7 +88,7 @@ type Processor struct {
 	logger             log.Logger
 }
 
-func New(cfg Config, tenant string, reg registry.Registry, logger log.Logger) (gen.Processor, error) {
+func New(cfg Config, tenant string, reg registry.Registry, logger log.Logger) gen.Processor {
 	labels := []string{"client", "server", "connection_type"}
 
 	if cfg.EnableVirtualNodeLabel {
@@ -146,7 +146,7 @@ func New(cfg Config, tenant string, reg registry.Registry, logger log.Logger) (g
 		}()
 	}
 
-	return p, nil
+	return p
 }
 
 func (p *Processor) Name() string {

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -88,7 +88,7 @@ type Processor struct {
 	logger             log.Logger
 }
 
-func New(cfg Config, tenant string, registry registry.Registry, logger log.Logger) gen.Processor {
+func New(cfg Config, tenant string, reg registry.Registry, logger log.Logger) (gen.Processor, error) {
 	labels := []string{"client", "server", "connection_type"}
 
 	if cfg.EnableVirtualNodeLabel {
@@ -112,15 +112,15 @@ func New(cfg Config, tenant string, registry registry.Registry, logger log.Logge
 
 	p := &Processor{
 		Cfg:      cfg,
-		registry: registry,
+		registry: reg,
 		labels:   labels,
 		closeCh:  make(chan struct{}, 1),
 
-		serviceGraphRequestTotal:                           registry.NewCounter(metricRequestTotal),
-		serviceGraphRequestFailedTotal:                     registry.NewCounter(metricRequestFailedTotal),
-		serviceGraphRequestServerSecondsHistogram:          registry.NewHistogram(metricRequestServerSeconds, cfg.HistogramBuckets, cfg.HistogramOverride),
-		serviceGraphRequestClientSecondsHistogram:          registry.NewHistogram(metricRequestClientSeconds, cfg.HistogramBuckets, cfg.HistogramOverride),
-		serviceGraphRequestMessagingSystemSecondsHistogram: registry.NewHistogram(metricRequestMessagingSystemSeconds, cfg.HistogramBuckets, cfg.HistogramOverride),
+		serviceGraphRequestTotal:                           reg.NewCounter(metricRequestTotal),
+		serviceGraphRequestFailedTotal:                     reg.NewCounter(metricRequestFailedTotal),
+		serviceGraphRequestServerSecondsHistogram:          reg.NewHistogram(metricRequestServerSeconds, cfg.HistogramBuckets, cfg.HistogramOverride),
+		serviceGraphRequestClientSecondsHistogram:          reg.NewHistogram(metricRequestClientSeconds, cfg.HistogramBuckets, cfg.HistogramOverride),
+		serviceGraphRequestMessagingSystemSecondsHistogram: reg.NewHistogram(metricRequestMessagingSystemSeconds, cfg.HistogramBuckets, cfg.HistogramOverride),
 
 		metricDroppedSpans: metricDroppedSpans.WithLabelValues(tenant),
 		metricTotalEdges:   metricTotalEdges.WithLabelValues(tenant),
@@ -146,7 +146,7 @@ func New(cfg Config, tenant string, registry registry.Registry, logger log.Logge
 		}()
 	}
 
-	return p
+	return p, nil
 }
 
 func (p *Processor) Name() string {

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -43,7 +43,8 @@ func TestServiceGraphs(t *testing.T) {
 	cfg.Dimensions = []string{"beast", "god"}
 	cfg.EnableMessagingSystemLatencyHistogram = true
 
-	p := New(cfg, "test", testRegistry, log.NewNopLogger())
+	p, err := New(cfg, "test", testRegistry, log.NewNopLogger())
+	require.NoError(t, err)
 	defer p.Shutdown(context.Background())
 
 	request, err := loadTestData("testdata/trace-with-queue-database.json")
@@ -130,7 +131,8 @@ func TestServiceGraphs_prefixDimensions(t *testing.T) {
 	cfg.Dimensions = []string{"beast", "god"}
 	cfg.EnableClientServerPrefix = true
 
-	p := New(cfg, "test", testRegistry, log.NewNopLogger())
+	p, err := New(cfg, "test", testRegistry, log.NewNopLogger())
+	require.NoError(t, err)
 	defer p.Shutdown(context.Background())
 
 	request, err := loadTestData("testdata/trace-with-queue-database.json")
@@ -162,7 +164,8 @@ func TestServiceGraphs_MessagingSystemLatencyHistogram(t *testing.T) {
 	cfg.Dimensions = []string{"beast", "god"}
 	cfg.EnableMessagingSystemLatencyHistogram = true
 
-	p := New(cfg, "test", testRegistry, log.NewNopLogger())
+	p, err := New(cfg, "test", testRegistry, log.NewNopLogger())
+	require.NoError(t, err)
 	defer p.Shutdown(context.Background())
 
 	request, err := loadTestData("testdata/trace-with-queue-database.json")
@@ -188,7 +191,8 @@ func TestServiceGraphs_failedRequests(t *testing.T) {
 	cfg := Config{}
 	cfg.RegisterFlagsAndApplyDefaults("", nil)
 
-	p := New(cfg, "test", testRegistry, log.NewNopLogger())
+	p, err := New(cfg, "test", testRegistry, log.NewNopLogger())
+	require.NoError(t, err)
 	defer p.Shutdown(context.Background())
 
 	request, err := loadTestData("testdata/trace-with-failed-requests.json")
@@ -221,7 +225,8 @@ func TestServiceGraphs_tooManySpansErr(t *testing.T) {
 	cfg := Config{}
 	cfg.RegisterFlagsAndApplyDefaults("", nil)
 	cfg.MaxItems = 1
-	p := New(cfg, "test", &testRegistry, log.NewNopLogger())
+	p, err := New(cfg, "test", &testRegistry, log.NewNopLogger())
+	require.NoError(t, err)
 	defer p.Shutdown(context.Background())
 
 	request, err := loadTestData("testdata/trace-with-queue-database.json")
@@ -241,7 +246,8 @@ func TestServiceGraphs_virtualNodes(t *testing.T) {
 	cfg.HistogramBuckets = []float64{0.04}
 	cfg.Wait = time.Nanosecond
 
-	p := New(cfg, "test", testRegistry, log.NewNopLogger())
+	p, err := New(cfg, "test", testRegistry, log.NewNopLogger())
+	require.NoError(t, err)
 	defer p.Shutdown(context.Background())
 
 	request, err := loadTestData("testdata/trace-with-virtual-nodes.json")
@@ -280,7 +286,8 @@ func TestServiceGraphs_virtualNodesExtraLabelsForUninstrumentedServices(t *testi
 	cfg.EnableVirtualNodeLabel = true
 	cfg.Wait = time.Nanosecond
 
-	p := New(cfg, "test", testRegistry, log.NewNopLogger())
+	p, err := New(cfg, "test", testRegistry, log.NewNopLogger())
+	require.NoError(t, err)
 	defer p.Shutdown(context.Background())
 
 	request, err := loadTestData("testdata/trace-with-virtual-nodes.json")
@@ -409,7 +416,8 @@ func TestServiceGraphs_databaseVirtualNodes(t *testing.T) {
 			cfg.HistogramBuckets = []float64{0.04}
 			cfg.EnableMessagingSystemLatencyHistogram = true
 
-			p := New(cfg, "test", testRegistry, log.NewNopLogger())
+			p, err := New(cfg, "test", testRegistry, log.NewNopLogger())
+			require.NoError(t, err)
 			defer p.Shutdown(context.Background())
 
 			request, err := loadTestData(tc.fixturePath)
@@ -446,7 +454,8 @@ func TestServiceGraphs_prefixDimensionsAndEnableExtraLabels(t *testing.T) {
 	cfg.EnableClientServerPrefix = true
 	cfg.EnableVirtualNodeLabel = true
 
-	p := New(cfg, "test", testRegistry, log.NewNopLogger())
+	p, err := New(cfg, "test", testRegistry, log.NewNopLogger())
+	require.NoError(t, err)
 	defer p.Shutdown(context.Background())
 
 	request, err := loadTestData("testdata/trace-with-queue-database.json")
@@ -493,7 +502,8 @@ func BenchmarkServiceGraphs(b *testing.B) {
 	cfg.HistogramBuckets = []float64{0.04}
 	cfg.Dimensions = []string{"beast", "god"}
 
-	p := New(cfg, "test", testRegistry, log.NewNopLogger())
+	p, err := New(cfg, "test", testRegistry, log.NewNopLogger())
+	require.NoError(b, err)
 	defer p.Shutdown(context.Background())
 
 	request, err := loadTestData("testdata/trace-with-queue-database.json")

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -43,8 +43,7 @@ func TestServiceGraphs(t *testing.T) {
 	cfg.Dimensions = []string{"beast", "god"}
 	cfg.EnableMessagingSystemLatencyHistogram = true
 
-	p, err := New(cfg, "test", testRegistry, log.NewNopLogger())
-	require.NoError(t, err)
+	p := New(cfg, "test", testRegistry, log.NewNopLogger())
 	defer p.Shutdown(context.Background())
 
 	request, err := loadTestData("testdata/trace-with-queue-database.json")
@@ -131,8 +130,7 @@ func TestServiceGraphs_prefixDimensions(t *testing.T) {
 	cfg.Dimensions = []string{"beast", "god"}
 	cfg.EnableClientServerPrefix = true
 
-	p, err := New(cfg, "test", testRegistry, log.NewNopLogger())
-	require.NoError(t, err)
+	p := New(cfg, "test", testRegistry, log.NewNopLogger())
 	defer p.Shutdown(context.Background())
 
 	request, err := loadTestData("testdata/trace-with-queue-database.json")
@@ -164,8 +162,7 @@ func TestServiceGraphs_MessagingSystemLatencyHistogram(t *testing.T) {
 	cfg.Dimensions = []string{"beast", "god"}
 	cfg.EnableMessagingSystemLatencyHistogram = true
 
-	p, err := New(cfg, "test", testRegistry, log.NewNopLogger())
-	require.NoError(t, err)
+	p := New(cfg, "test", testRegistry, log.NewNopLogger())
 	defer p.Shutdown(context.Background())
 
 	request, err := loadTestData("testdata/trace-with-queue-database.json")
@@ -191,8 +188,7 @@ func TestServiceGraphs_failedRequests(t *testing.T) {
 	cfg := Config{}
 	cfg.RegisterFlagsAndApplyDefaults("", nil)
 
-	p, err := New(cfg, "test", testRegistry, log.NewNopLogger())
-	require.NoError(t, err)
+	p := New(cfg, "test", testRegistry, log.NewNopLogger())
 	defer p.Shutdown(context.Background())
 
 	request, err := loadTestData("testdata/trace-with-failed-requests.json")
@@ -225,8 +221,7 @@ func TestServiceGraphs_tooManySpansErr(t *testing.T) {
 	cfg := Config{}
 	cfg.RegisterFlagsAndApplyDefaults("", nil)
 	cfg.MaxItems = 1
-	p, err := New(cfg, "test", &testRegistry, log.NewNopLogger())
-	require.NoError(t, err)
+	p := New(cfg, "test", &testRegistry, log.NewNopLogger())
 	defer p.Shutdown(context.Background())
 
 	request, err := loadTestData("testdata/trace-with-queue-database.json")
@@ -246,8 +241,7 @@ func TestServiceGraphs_virtualNodes(t *testing.T) {
 	cfg.HistogramBuckets = []float64{0.04}
 	cfg.Wait = time.Nanosecond
 
-	p, err := New(cfg, "test", testRegistry, log.NewNopLogger())
-	require.NoError(t, err)
+	p := New(cfg, "test", testRegistry, log.NewNopLogger())
 	defer p.Shutdown(context.Background())
 
 	request, err := loadTestData("testdata/trace-with-virtual-nodes.json")
@@ -286,8 +280,7 @@ func TestServiceGraphs_virtualNodesExtraLabelsForUninstrumentedServices(t *testi
 	cfg.EnableVirtualNodeLabel = true
 	cfg.Wait = time.Nanosecond
 
-	p, err := New(cfg, "test", testRegistry, log.NewNopLogger())
-	require.NoError(t, err)
+	p := New(cfg, "test", testRegistry, log.NewNopLogger())
 	defer p.Shutdown(context.Background())
 
 	request, err := loadTestData("testdata/trace-with-virtual-nodes.json")
@@ -416,8 +409,7 @@ func TestServiceGraphs_databaseVirtualNodes(t *testing.T) {
 			cfg.HistogramBuckets = []float64{0.04}
 			cfg.EnableMessagingSystemLatencyHistogram = true
 
-			p, err := New(cfg, "test", testRegistry, log.NewNopLogger())
-			require.NoError(t, err)
+			p := New(cfg, "test", testRegistry, log.NewNopLogger())
 			defer p.Shutdown(context.Background())
 
 			request, err := loadTestData(tc.fixturePath)
@@ -454,8 +446,7 @@ func TestServiceGraphs_prefixDimensionsAndEnableExtraLabels(t *testing.T) {
 	cfg.EnableClientServerPrefix = true
 	cfg.EnableVirtualNodeLabel = true
 
-	p, err := New(cfg, "test", testRegistry, log.NewNopLogger())
-	require.NoError(t, err)
+	p := New(cfg, "test", testRegistry, log.NewNopLogger())
 	defer p.Shutdown(context.Background())
 
 	request, err := loadTestData("testdata/trace-with-queue-database.json")
@@ -502,8 +493,7 @@ func BenchmarkServiceGraphs(b *testing.B) {
 	cfg.HistogramBuckets = []float64{0.04}
 	cfg.Dimensions = []string{"beast", "god"}
 
-	p, err := New(cfg, "test", testRegistry, log.NewNopLogger())
-	require.NoError(b, err)
+	p := New(cfg, "test", testRegistry, log.NewNopLogger())
 	defer p.Shutdown(context.Background())
 
 	request, err := loadTestData("testdata/trace-with-queue-database.json")

--- a/modules/generator/processor/spanmetrics/config.go
+++ b/modules/generator/processor/spanmetrics/config.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 
+	"github.com/grafana/tempo/modules/generator/registry"
 	"github.com/grafana/tempo/pkg/sharedconfig"
 	filterconfig "github.com/grafana/tempo/pkg/spanfilter/config"
 	"github.com/prometheus/client_golang/prometheus"
@@ -25,8 +26,8 @@ type Config struct {
 	// Buckets for latency histogram in seconds.
 	HistogramBuckets []float64 `yaml:"histogram_buckets"`
 
-	// The histogram implementation to select.
-	HistogramOverride string `yaml:"-"`
+	// The histogram mode to select.
+	HistogramOverride registry.HistogramMode `yaml:"-"`
 
 	// Intrinsic dimensions (labels) added to the metric, that are generated from fixed span
 	// data. The dimensions service, span_name, span_kind, status_code, job and instance are enabled by
@@ -59,6 +60,7 @@ type Config struct {
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {
 	cfg.HistogramBuckets = prometheus.ExponentialBuckets(0.002, 2, 14)
+	cfg.HistogramOverride = registry.HistogramModeClassic
 	cfg.IntrinsicDimensions.Service = true
 	cfg.IntrinsicDimensions.SpanName = true
 	cfg.IntrinsicDimensions.SpanKind = true

--- a/modules/generator/processor/spanmetrics/spanmetrics.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics.go
@@ -43,7 +43,7 @@ type Processor struct {
 	now func() time.Time
 }
 
-func New(cfg Config, registry registry.Registry, spanDiscardCounter prometheus.Counter) (gen.Processor, error) {
+func New(cfg Config, reg registry.Registry, spanDiscardCounter prometheus.Counter) (gen.Processor, error) {
 	labels := make([]string, 0, 4+len(cfg.Dimensions))
 
 	if cfg.IntrinsicDimensions.Service {
@@ -72,21 +72,21 @@ func New(cfg Config, registry registry.Registry, spanDiscardCounter prometheus.C
 
 	p := &Processor{
 		Cfg:                   cfg,
-		registry:              registry,
-		spanMetricsTargetInfo: registry.NewGauge(targetInfo),
+		registry:              reg,
+		spanMetricsTargetInfo: reg.NewGauge(targetInfo),
 		now:                   time.Now,
 		labels:                labels,
 		filteredSpansCounter:  spanDiscardCounter,
 	}
 
 	if cfg.Subprocessors[Latency] {
-		p.spanMetricsDurationSeconds = registry.NewHistogram(metricDurationSeconds, cfg.HistogramBuckets, cfg.HistogramOverride)
+		p.spanMetricsDurationSeconds = reg.NewHistogram(metricDurationSeconds, cfg.HistogramBuckets, cfg.HistogramOverride)
 	}
 	if cfg.Subprocessors[Count] {
-		p.spanMetricsCallsTotal = registry.NewCounter(metricCallsTotal)
+		p.spanMetricsCallsTotal = reg.NewCounter(metricCallsTotal)
 	}
 	if cfg.Subprocessors[Size] {
-		p.spanMetricsSizeTotal = registry.NewCounter(metricSizeTotal)
+		p.spanMetricsSizeTotal = reg.NewCounter(metricSizeTotal)
 	}
 
 	filter, err := spanfilter.NewSpanFilter(cfg.FilterPolicies)

--- a/modules/generator/registry/interface.go
+++ b/modules/generator/registry/interface.go
@@ -4,7 +4,7 @@ package registry
 type Registry interface {
 	NewLabelValueCombo(labels []string, values []string) *LabelValueCombo
 	NewCounter(name string) Counter
-	NewHistogram(name string, buckets []float64, histogramOverride string) Histogram
+	NewHistogram(name string, buckets []float64, histogramOverride HistogramMode) Histogram
 	NewGauge(name string) Gauge
 }
 
@@ -35,6 +35,26 @@ type Gauge interface {
 	Set(labelValueCombo *LabelValueCombo, value float64)
 	Inc(labelValueCombo *LabelValueCombo, value float64)
 	SetForTargetInfo(labelValueCombo *LabelValueCombo, value float64)
+}
+
+type HistogramMode int
+
+const (
+	HistogramModeClassic HistogramMode = iota
+	HistogramModeNative
+	HistogramModeBoth
+)
+
+var HistogramModeToString = map[HistogramMode]string{
+	HistogramModeClassic: "classic",
+	HistogramModeNative:  "native",
+	HistogramModeBoth:    "both",
+}
+
+var HistogramModeToValue = map[string]HistogramMode{
+	"classic": HistogramModeClassic,
+	"native":  HistogramModeNative,
+	"both":    HistogramModeBoth,
 }
 
 // LabelValueCombo is a wrapper around a slice of label values. It has the ability to cache the hash of

--- a/modules/generator/registry/native_histogram_test.go
+++ b/modules/generator/registry/native_histogram_test.go
@@ -20,7 +20,7 @@ func Test_ObserveWithExemplar_duplicate(t *testing.T) {
 		return true
 	}
 
-	h := newNativeHistogram("my_histogram", []float64{0.1, 0.2}, onAdd, nil, "trace_id", "both")
+	h := newNativeHistogram("my_histogram", []float64{0.1, 0.2}, onAdd, nil, "trace_id", HistogramModeBoth)
 
 	lv := newLabelValueCombo([]string{"label"}, []string{"value-1"})
 
@@ -460,7 +460,7 @@ func Test_Histograms(t *testing.T) {
 					return true
 				}
 
-				h := newNativeHistogram("test_histogram", tc.buckets, onAdd, nil, "trace_id", "both")
+				h := newNativeHistogram("test_histogram", tc.buckets, onAdd, nil, "trace_id", HistogramModeBoth)
 				testHistogram(t, h, tc.collections)
 			})
 		})

--- a/modules/generator/registry/overrides.go
+++ b/modules/generator/registry/overrides.go
@@ -10,7 +10,7 @@ type Overrides interface {
 	MetricsGeneratorMaxActiveSeries(userID string) uint32
 	MetricsGeneratorCollectionInterval(userID string) time.Duration
 	MetricsGeneratorDisableCollection(userID string) bool
-	MetricsGeneratorGenerateNativeHistograms(userID string) string
+	MetricsGeneratorGenerateNativeHistograms(userID string) overrides.HistogramMethod
 	MetricsGenerationTraceIDLabelName(userID string) string
 }
 

--- a/modules/generator/registry/registry.go
+++ b/modules/generator/registry/registry.go
@@ -14,7 +14,6 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"go.uber.org/atomic"
 
-	"github.com/grafana/tempo/modules/overrides"
 	tempo_log "github.com/grafana/tempo/pkg/util/log"
 )
 
@@ -148,12 +147,13 @@ func (r *ManagedRegistry) NewCounter(name string) Counter {
 	return c
 }
 
-func (r *ManagedRegistry) NewHistogram(name string, buckets []float64, histogramOverride string) (h Histogram) {
+func (r *ManagedRegistry) NewHistogram(name string, buckets []float64, histogramOverride HistogramMode) (h Histogram) {
 	traceIDLabelName := r.overrides.MetricsGenerationTraceIDLabelName(r.tenant)
 
 	// TODO: Temporary switch: use the old implementation when native histograms
 	// are disabled, eventually the new implementation can handle all cases
-	if overrides.HasNativeHistograms(histogramOverride) {
+
+	if hasNativeHistograms(histogramOverride) {
 		h = newNativeHistogram(name, buckets, r.onAddMetricSeries, r.onRemoveMetricSeries, traceIDLabelName, histogramOverride)
 	} else {
 		h = newHistogram(name, buckets, r.onAddMetricSeries, r.onRemoveMetricSeries, traceIDLabelName)
@@ -277,4 +277,12 @@ func (r *ManagedRegistry) removeStaleSeries(_ context.Context) {
 func (r *ManagedRegistry) Close() {
 	level.Info(r.logger).Log("msg", "closing registry")
 	r.onShutdown()
+}
+
+func hasNativeHistograms(s HistogramMode) bool {
+	return s == HistogramModeNative || s == HistogramModeBoth
+}
+
+func hasClassicHistograms(s HistogramMode) bool {
+	return s == HistogramModeClassic || s == HistogramModeBoth
 }

--- a/modules/generator/registry/registry_test.go
+++ b/modules/generator/registry/registry_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/tempo/modules/overrides"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -79,7 +80,7 @@ func TestManagedRegistry_histogram(t *testing.T) {
 	registry := New(&Config{}, &mockOverrides{}, "test", appender, log.NewNopLogger())
 	defer registry.Close()
 
-	histogram := registry.NewHistogram("histogram", []float64{1.0, 2.0}, "classic")
+	histogram := registry.NewHistogram("histogram", []float64{1.0, 2.0}, HistogramModeClassic)
 
 	histogram.ObserveWithExemplar(newLabelValueCombo([]string{"label"}, []string{"value-1"}), 1.0, "", 1.0)
 
@@ -228,7 +229,7 @@ func TestManagedRegistry_maxLabelNameLength(t *testing.T) {
 	defer registry.Close()
 
 	counter := registry.NewCounter("counter")
-	histogram := registry.NewHistogram("histogram", []float64{1.0}, "classic")
+	histogram := registry.NewHistogram("histogram", []float64{1.0}, HistogramModeClassic)
 
 	counter.Inc(registry.NewLabelValueCombo([]string{"very_lengthy_label"}, []string{"very_length_value"}), 1.0)
 	histogram.ObserveWithExemplar(registry.NewLabelValueCombo([]string{"another_very_lengthy_label"}, []string{"another_very_lengthy_value"}), 1.0, "", 1.0)
@@ -258,32 +259,22 @@ func TestValidLabelValueCombo(t *testing.T) {
 func TestHistogramOverridesConfig(t *testing.T) {
 	cases := []struct {
 		name                string
-		nativeHistogramMode string
+		nativeHistogramMode HistogramMode
 		typeOfHistogram     interface{}
 	}{
 		{
-			"empty",
-			"",
-			&histogram{},
-		},
-		{
-			"bad",
-			"invalid",
-			&histogram{},
-		},
-		{
 			"classic",
-			"classic",
+			HistogramModeClassic,
 			&histogram{},
 		},
 		{
 			"native",
-			"native",
+			HistogramModeNative,
 			&nativeHistogram{},
 		},
 		{
 			"both",
-			"both",
+			HistogramModeBoth,
 			&nativeHistogram{},
 		},
 	}
@@ -291,14 +282,7 @@ func TestHistogramOverridesConfig(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			appender := &capturingAppender{}
-			overrides := &mockOverrides{
-
-				// TODO: Review this test.  Since we no longer switch on the overrides,
-				// this is only testing the New call returns the correct implementation
-				// based on the received string.  We might have coverage elsewhere.
-
-				// generateNativeHistograms: c.nativeHistogramMode,
-			}
+			overrides := &mockOverrides{}
 			registry := New(&Config{}, overrides, "test", appender, log.NewNopLogger())
 			defer registry.Close()
 
@@ -353,7 +337,7 @@ func collectRegistryMetricsAndAssert(t *testing.T, r *ManagedRegistry, appender 
 type mockOverrides struct {
 	maxActiveSeries          uint32
 	disableCollection        bool
-	generateNativeHistograms string
+	generateNativeHistograms overrides.HistogramMethod
 }
 
 var _ Overrides = (*mockOverrides)(nil)
@@ -370,7 +354,7 @@ func (m *mockOverrides) MetricsGeneratorDisableCollection(string) bool {
 	return m.disableCollection
 }
 
-func (m *mockOverrides) MetricsGeneratorGenerateNativeHistograms(_ string) string {
+func (m *mockOverrides) MetricsGeneratorGenerateNativeHistograms(_ string) overrides.HistogramMethod {
 	return m.generateNativeHistograms
 }
 

--- a/modules/generator/registry/test.go
+++ b/modules/generator/registry/test.go
@@ -42,7 +42,7 @@ func (t *TestRegistry) NewLabelValueCombo(labels []string, values []string) *Lab
 	return newLabelValueCombo(labels, values)
 }
 
-func (t *TestRegistry) NewHistogram(name string, buckets []float64, histogramOverrides string) Histogram {
+func (t *TestRegistry) NewHistogram(name string, buckets []float64, histogramOverrides HistogramMode) Histogram {
 	return &testHistogram{
 		nameSum:            name + "_sum",
 		nameCount:          name + "_count",
@@ -170,7 +170,7 @@ type testHistogram struct {
 	nameBucket         string
 	buckets            []float64
 	registry           *TestRegistry
-	histogramOverrides string
+	histogramOverrides HistogramMode
 }
 
 var (

--- a/modules/generator/registry/test_test.go
+++ b/modules/generator/registry/test_test.go
@@ -28,7 +28,7 @@ func TestTestRegistry_counter(t *testing.T) {
 func TestTestRegistry_histogram(t *testing.T) {
 	testRegistry := NewTestRegistry()
 
-	histogram := testRegistry.NewHistogram("histogram", []float64{1.0, 2.0}, "classic")
+	histogram := testRegistry.NewHistogram("histogram", []float64{1.0, 2.0}, HistogramModeClassic)
 
 	labelValues := newLabelValueCombo([]string{"foo", "bar"}, []string{"foo-value", "bar-value"})
 	histogram.ObserveWithExemplar(labelValues, 1.0, "", 1.0)

--- a/modules/generator/storage/instance_test.go
+++ b/modules/generator/storage/instance_test.go
@@ -206,7 +206,7 @@ func TestInstance_remoteWriteHeaders(t *testing.T) {
 
 	headers := map[string]string{user.OrgIDHeaderName: "my-other-tenant"}
 
-	instance, err := New(&cfg, &mockOverrides{headers, string(overrides.HistogramMethodClassic)}, "test-tenant", &noopRegisterer{}, logger)
+	instance, err := New(&cfg, &mockOverrides{headers, overrides.HistogramMethodClassic}, "test-tenant", &noopRegisterer{}, logger)
 	require.NoError(t, err)
 
 	// Refuse requests - the WAL should buffer data until requests succeed

--- a/modules/generator/storage/instance_test.go
+++ b/modules/generator/storage/instance_test.go
@@ -368,14 +368,14 @@ var _ Overrides = (*mockOverrides)(nil)
 
 type mockOverrides struct {
 	headers          map[string]string
-	nativeHistograms string
+	nativeHistograms overrides.HistogramMethod
 }
 
 func (m *mockOverrides) MetricsGeneratorRemoteWriteHeaders(string) map[string]string {
 	return m.headers
 }
 
-func (m *mockOverrides) MetricsGeneratorGenerateNativeHistograms(string) string {
+func (m *mockOverrides) MetricsGeneratorGenerateNativeHistograms(string) overrides.HistogramMethod {
 	return m.nativeHistograms
 }
 

--- a/modules/generator/storage/overrides.go
+++ b/modules/generator/storage/overrides.go
@@ -1,6 +1,10 @@
 package storage
 
+import "github.com/grafana/tempo/modules/overrides"
+
 type Overrides interface {
 	MetricsGeneratorRemoteWriteHeaders(userID string) map[string]string
-	MetricsGeneratorGenerateNativeHistograms(userID string) string
+	MetricsGeneratorGenerateNativeHistograms(userID string) overrides.HistogramMethod
 }
+
+var _ Overrides = (overrides.Interface)(nil)

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -250,6 +250,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // RegisterFlagsAndApplyDefaults adds the flags required to config this to the given FlagSet
 func (c *Config) RegisterFlagsAndApplyDefaults(f *flag.FlagSet) {
+	// Generator
+	c.Defaults.MetricsGenerator.GenerateNativeHistograms = HistogramMethodClassic
+
 	// Distributor LegacyOverrides
 	f.StringVar(&c.Defaults.Ingestion.RateStrategy, "distributor.rate-limit-strategy", "local", "Whether the various ingestion rate limits should be applied individually to each distributor instance (local), or evenly shared across the cluster (global).")
 	f.IntVar(&c.Defaults.Ingestion.RateLimitBytes, "distributor.ingestion-rate-limit-bytes", 15e6, "Per-user ingestion rate limit in bytes per second.")

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -290,7 +290,3 @@ func (c *Config) Collect(ch chan<- prometheus.Metric) {
 func HasNativeHistograms(s HistogramMethod) bool {
 	return s == HistogramMethodNative || s == HistogramMethodBoth
 }
-
-func HasClassicHistograms(s HistogramMethod) bool {
-	return s == HistogramMethodClassic || s == HistogramMethodBoth
-}

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -140,7 +140,7 @@ type MetricsGeneratorOverrides struct {
 	MaxActiveSeries          uint32              `yaml:"max_active_series,omitempty" json:"max_active_series,omitempty"`
 	CollectionInterval       time.Duration       `yaml:"collection_interval,omitempty" json:"collection_interval,omitempty"`
 	DisableCollection        bool                `yaml:"disable_collection,omitempty" json:"disable_collection,omitempty"`
-	GenerateNativeHistograms string              `yaml:"generate_native_histograms" json:"generate_native_histograms,omitempty"`
+	GenerateNativeHistograms HistogramMethod     `yaml:"generate_native_histograms" json:"generate_native_histograms,omitempty"`
 	TraceIDLabelName         string              `yaml:"trace_id_label_name,omitempty" json:"trace_id_label_name,omitempty"`
 
 	RemoteWriteHeaders RemoteWriteHeaders `yaml:"remote_write_headers,omitempty" json:"remote_write_headers,omitempty"`
@@ -287,10 +287,10 @@ func (c *Config) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(metricLimitsDesc, prometheus.GaugeValue, float64(c.Defaults.MetricsGenerator.MaxActiveSeries), MetricMetricsGeneratorMaxActiveSeries)
 }
 
-func HasNativeHistograms(s string) bool {
-	return s == string(HistogramMethodNative) || s == string(HistogramMethodBoth)
+func HasNativeHistograms(s HistogramMethod) bool {
+	return s == HistogramMethodNative || s == HistogramMethodBoth
 }
 
-func HasClassicHistograms(s string) bool {
-	return s == string(HistogramMethodClassic) || s == string(HistogramMethodBoth)
+func HasClassicHistograms(s HistogramMethod) bool {
+	return s == HistogramMethodClassic || s == HistogramMethodBoth
 }

--- a/modules/overrides/config_legacy.go
+++ b/modules/overrides/config_legacy.go
@@ -90,7 +90,7 @@ type LegacyOverrides struct {
 	MetricsGeneratorMaxActiveSeries                                             uint32                           `yaml:"metrics_generator_max_active_series" json:"metrics_generator_max_active_series"`
 	MetricsGeneratorCollectionInterval                                          time.Duration                    `yaml:"metrics_generator_collection_interval" json:"metrics_generator_collection_interval"`
 	MetricsGeneratorDisableCollection                                           bool                             `yaml:"metrics_generator_disable_collection" json:"metrics_generator_disable_collection"`
-	MetricsGeneratorGenerateNativeHistograms                                    string                           `yaml:"metrics_generator_generate_native_histograms" json:"metrics_generator_generate_native_histograms"`
+	MetricsGeneratorGenerateNativeHistograms                                    HistogramMethod                  `yaml:"metrics_generator_generate_native_histograms" json:"metrics_generator_generate_native_histograms"`
 	MetricsGeneratorTraceIDLabelName                                            string                           `yaml:"metrics_generator_trace_id_label_name" json:"metrics_generator_trace_id_label_name"`
 	MetricsGeneratorForwarderQueueSize                                          int                              `yaml:"metrics_generator_forwarder_queue_size" json:"metrics_generator_forwarder_queue_size"`
 	MetricsGeneratorForwarderWorkers                                            int                              `yaml:"metrics_generator_forwarder_workers" json:"metrics_generator_forwarder_workers"`

--- a/modules/overrides/interface.go
+++ b/modules/overrides/interface.go
@@ -46,7 +46,7 @@ type Interface interface {
 	MetricsGeneratorMaxActiveSeries(userID string) uint32
 	MetricsGeneratorCollectionInterval(userID string) time.Duration
 	MetricsGeneratorDisableCollection(userID string) bool
-	MetricsGeneratorGenerateNativeHistograms(userID string) string
+	MetricsGeneratorGenerateNativeHistograms(userID string) HistogramMethod
 	MetricsGenerationTraceIDLabelName(userID string) string
 	MetricsGeneratorRemoteWriteHeaders(userID string) map[string]string
 	MetricsGeneratorForwarderQueueSize(userID string) int

--- a/modules/overrides/overrides.go
+++ b/modules/overrides/overrides.go
@@ -18,15 +18,15 @@ var metricOverridesLimitsDesc = prometheus.NewDesc(
 // are defaulted to those values.  As such, the last call to NewOverrides will
 // become the new global defaults.
 func NewOverrides(cfg Config, validator Validator, registerer prometheus.Registerer) (Service, error) {
-	overrides, err := newRuntimeConfigOverrides(cfg, validator, registerer)
+	o, err := newRuntimeConfigOverrides(cfg, validator, registerer)
 	if err != nil {
 		return nil, err
 	}
 
 	if cfg.UserConfigurableOverridesConfig.Enabled {
 		// Wrap runtime config with user-config overrides module
-		overrides, err = newUserConfigOverrides(&cfg.UserConfigurableOverridesConfig, overrides)
+		o, err = newUserConfigOverrides(&cfg.UserConfigurableOverridesConfig, o)
 	}
 
-	return overrides, err
+	return o, err
 }

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -396,7 +396,7 @@ func (o *runtimeConfigOverridesManager) MetricsGeneratorDisableCollection(userID
 	return o.getOverridesForUser(userID).MetricsGenerator.DisableCollection
 }
 
-func (o *runtimeConfigOverridesManager) MetricsGeneratorGenerateNativeHistograms(userID string) string {
+func (o *runtimeConfigOverridesManager) MetricsGeneratorGenerateNativeHistograms(userID string) HistogramMethod {
 	return o.getOverridesForUser(userID).MetricsGenerator.GenerateNativeHistograms
 }
 


### PR DESCRIPTION
**What this PR does**:

Plumb an enum into the native histograms and update overrides.

As a follow up to https://github.com/grafana/tempo/pull/3923

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`