### PR TITLE
fix: update block start and end date on block creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ check-jsonnetfmt: jsonnetfmt
 	@git diff --exit-code -- $(FILES_TO_JSONNETFMT)
 
 .PHONY: lint
-lint: # linting
+lint: ##  linting
 ifneq ($(base),)
 	$(TOOLS_CMD) $(LINT) run --config .golangci.yml --new-from-rev=$(base)
 else

--- a/modules/ingester/ingester.go
+++ b/modules/ingester/ingester.go
@@ -56,8 +56,10 @@ type Ingester struct {
 	cfg Config
 
 	instancesMtx sync.RWMutex
-	instances    map[string]*instance
-	pushErr      atomic.Error
+
+	// Handle all the ingestion lifecycle. One instance per tenant
+	instances map[string]*instance
+	pushErr   atomic.Error
 
 	lifecycler   *ring.Lifecycler
 	store        storage.Store

--- a/modules/ingester/ingester_test.go
+++ b/modules/ingester/ingester_test.go
@@ -439,7 +439,8 @@ func defaultIngesterStore(t testing.TB, tmpDir string) storage.Store {
 				IndexPageSizeBytes:   1000,
 			},
 			WAL: &wal.Config{
-				Filepath: tmpDir,
+				Filepath:       tmpDir,
+				IngestionSlack: 2 * time.Minute,
 			},
 		},
 	}, nil, log.NewNopLogger())

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -176,7 +176,7 @@ func (i *instance) addTraceError(errorsByTrace []tempopb.PushErrorReason, pushEr
 		errorsByTrace = append(errorsByTrace, tempopb.PushErrorReason_UNKNOWN_ERROR)
 		return errorsByTrace
 
-	} else if pushError == nil && len(errorsByTrace) > 0 {
+	} else if len(errorsByTrace) > 0 {
 		errorsByTrace = append(errorsByTrace, tempopb.PushErrorReason_NO_ERROR)
 	}
 

--- a/modules/ingester/instance_search_test.go
+++ b/modules/ingester/instance_search_test.go
@@ -177,15 +177,15 @@ func TestInstanceSearchWithStartAndEnd(t *testing.T) {
 	tagValue := bar
 	ids, _, _, _ := writeTracesForSearch(t, i, "", tagKey, tagValue, false, false)
 
-	search := func(req *tempopb.SearchRequest, start, end uint32) *tempopb.SearchResponse {
-		req.Start = start
-		req.End = end
-		sr, err := i.Search(context.Background(), req)
-		assert.NoError(t, err)
-		return sr
-	}
-
 	searchAndAssert := func(req *tempopb.SearchRequest, inspectedTraces uint32) {
+		search := func(req *tempopb.SearchRequest, start, end uint32) *tempopb.SearchResponse {
+			req.Start = start
+			req.End = end
+			sr, err := i.Search(context.Background(), req)
+			assert.NoError(t, err)
+			return sr
+		}
+
 		sr := search(req, 0, 0)
 		assert.Len(t, sr.Traces, len(ids))
 		assert.Equal(t, sr.Metrics.InspectedTraces, inspectedTraces)
@@ -224,6 +224,7 @@ func TestInstanceSearchWithStartAndEnd(t *testing.T) {
 	// Test after completing a block
 	err = i.CompleteBlock(blockID)
 	require.NoError(t, err)
+	// It should inspect 200 traces because the completingBlocks (the wal) has not been cleaned yet
 	searchAndAssert(req, uint32(200))
 
 	err = ingester.stopping(nil)

--- a/tempodb/backend/block_meta.go
+++ b/tempodb/backend/block_meta.go
@@ -199,21 +199,10 @@ func NewBlockMetaWithDedicatedColumns(tenantID string, blockID uuid.UUID, versio
 }
 
 // ObjectAdded updates the block meta appropriately based on information about an added record
-// start/end are unix epoch seconds
-func (b *BlockMeta) ObjectAdded(id []byte, start, end uint32) {
-	if start > 0 {
-		startTime := time.Unix(int64(start), 0)
-		if b.StartTime.IsZero() || startTime.Before(b.StartTime) {
-			b.StartTime = startTime
-		}
-	}
-
-	if end > 0 {
-		endTime := time.Unix(int64(end), 0)
-		if b.EndTime.IsZero() || endTime.After(b.EndTime) {
-			b.EndTime = endTime
-		}
-	}
+// start/end are unix epoch seconds, 0 means that the block start or end time won't be updated
+func (b *BlockMeta) ObjectAdded(id []byte, startTime, endTime uint32) {
+	b.updateStartTime(startTime)
+	b.updateEndTime(endTime)
 
 	if len(b.MinID) == 0 || bytes.Compare(id, b.MinID) == -1 {
 		b.MinID = id
@@ -223,6 +212,26 @@ func (b *BlockMeta) ObjectAdded(id []byte, start, end uint32) {
 	}
 
 	b.TotalObjects++
+}
+
+func (b *BlockMeta) updateStartTime(newStartTime uint32) {
+	if newStartTime == 0 {
+		return
+	}
+	start := time.Unix(int64(newStartTime), 0)
+	if b.StartTime.IsZero() || start.Before(b.StartTime) {
+		b.StartTime = start
+	}
+}
+
+func (b *BlockMeta) updateEndTime(newEndTime uint32) {
+	if newEndTime == 0 {
+		return
+	}
+	end := time.Unix(int64(newEndTime), 0)
+	if b.EndTime.IsZero() || end.Before(b.EndTime) {
+		b.EndTime = end
+	}
 }
 
 func (b *BlockMeta) DedicatedColumnsHash() uint64 {

--- a/tempodb/backend/block_meta.go
+++ b/tempodb/backend/block_meta.go
@@ -229,7 +229,7 @@ func (b *BlockMeta) updateEndTime(newEndTime uint32) {
 		return
 	}
 	end := time.Unix(int64(newEndTime), 0)
-	if b.EndTime.IsZero() || end.Before(b.EndTime) {
+	if b.EndTime.IsZero() || end.After(b.EndTime) {
 		b.EndTime = end
 	}
 }

--- a/tempodb/encoding/v2/wal_block_test.go
+++ b/tempodb/encoding/v2/wal_block_test.go
@@ -9,7 +9,6 @@ import (
 	"math/rand"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/uuid"
@@ -127,45 +126,6 @@ func TestFullFilename(t *testing.T) {
 			assert.Equal(t, tc.expected, actual)
 		})
 	}
-}
-
-func TestAdjustTimeRangeForSlack(t *testing.T) {
-	a := &walBlock{
-		meta: &backend.BlockMeta{
-			TenantID: "test",
-		},
-		ingestionSlack: 2 * time.Minute,
-	}
-
-	// test happy path
-	start := uint32(time.Now().Unix())
-	end := uint32(time.Now().Unix())
-	actualStart, actualEnd := a.adjustTimeRangeForSlack(start, end, 0)
-	assert.Equal(t, start, actualStart)
-	assert.Equal(t, end, actualEnd)
-
-	// test start out of range
-	now := uint32(time.Now().Unix())
-	start = uint32(time.Now().Add(-time.Hour).Unix())
-	end = uint32(time.Now().Unix())
-	actualStart, actualEnd = a.adjustTimeRangeForSlack(start, end, 0)
-	assert.Equal(t, now, actualStart)
-	assert.Equal(t, end, actualEnd)
-
-	// test end out of range
-	now = uint32(time.Now().Unix())
-	start = uint32(time.Now().Unix())
-	end = uint32(time.Now().Add(time.Hour).Unix())
-	actualStart, actualEnd = a.adjustTimeRangeForSlack(start, end, 0)
-	assert.Equal(t, start, actualStart)
-	assert.Equal(t, now, actualEnd)
-
-	// test additional start slack honored
-	start = uint32(time.Now().Add(-time.Hour).Unix())
-	end = uint32(time.Now().Unix())
-	actualStart, actualEnd = a.adjustTimeRangeForSlack(start, end, time.Hour)
-	assert.Equal(t, start, actualStart)
-	assert.Equal(t, end, actualEnd)
 }
 
 func TestPartialBlock(t *testing.T) {

--- a/tempodb/encoding/vparquet3/wal_block.go
+++ b/tempodb/encoding/vparquet3/wal_block.go
@@ -150,6 +150,7 @@ func openWALBlock(filename, path string, ingestionSlack, _ time.Duration) (commo
 
 // createWALBlock creates a new appendable block
 func createWALBlock(meta *backend.BlockMeta, filepath, dataEncoding string, ingestionSlack time.Duration) (*walBlock, error) {
+	now := time.Now()
 	b := &walBlock{
 		meta: &backend.BlockMeta{
 			Version:           VersionString,
@@ -157,6 +158,8 @@ func createWALBlock(meta *backend.BlockMeta, filepath, dataEncoding string, inge
 			TenantID:          meta.TenantID,
 			DedicatedColumns:  meta.DedicatedColumns,
 			ReplicationFactor: meta.ReplicationFactor,
+			StartTime:         now.Add(-ingestionSlack),
+			EndTime:           now.Add(ingestionSlack),
 		},
 		path:           filepath,
 		ids:            common.NewIDMap[int64](),

--- a/tempodb/encoding/vparquet3/wal_block.go
+++ b/tempodb/encoding/vparquet3/wal_block.go
@@ -344,8 +344,8 @@ func (b *walBlock) AppendTrace(id common.ID, trace *tempopb.Trace, startTime, en
 	if err != nil {
 		return fmt.Errorf("error writing row: %w", err)
 	}
-
-	b.meta.ObjectAdded(id, b.getStartTimeForSlack(startTime), b.getEndTimeForSlack(endTime))
+	start, end := b.getTimeForSlack(startTime, endTime)
+	b.meta.ObjectAdded(id, start, end)
 	b.ids.Set(id, int64(b.ids.Len())) // Next row number
 
 	b.unflushedSize += int64(estimateMarshalledSizeFromTrace(b.buffer))
@@ -353,26 +353,23 @@ func (b *walBlock) AppendTrace(id common.ID, trace *tempopb.Trace, startTime, en
 	return nil
 }
 
-// It corrects traces start time outside the ingestion slack
-func (b *walBlock) getStartTimeForSlack(start uint32) uint32 {
+// It corrects traces where the start or end time outside the ingestion slack
+func (b *walBlock) getTimeForSlack(start, end uint32) (uint32, uint32) {
 	startTime := time.Unix(int64(start), 0)
+	endTime := time.Unix(int64(end), 0)
 	now := time.Now()
+
 	if startTime.Before(now.Add(-b.ingestionSlack)) {
 		dataquality.WarnOutsideIngestionSlack(b.meta.TenantID)
 		startTime = now
 	}
-	return uint32(startTime.Unix())
-}
 
-// It corrects traces end time outside the ingestion slack
-func (b *walBlock) getEndTimeForSlack(end uint32) uint32 {
-	endTime := time.Unix(int64(end), 0)
-	now := time.Now()
-	if endTime.After(now.Add(b.ingestionSlack)) {
+	if endTime.After(now.Add(b.ingestionSlack)) || endTime.Before(startTime) {
 		dataquality.WarnOutsideIngestionSlack(b.meta.TenantID)
 		endTime = now
 	}
-	return uint32(endTime.Unix())
+
+	return uint32(startTime.Unix()), uint32(endTime.Unix())
 }
 
 func (b *walBlock) filepathOf(page int) string {

--- a/tempodb/encoding/vparquet4/wal_block.go
+++ b/tempodb/encoding/vparquet4/wal_block.go
@@ -347,8 +347,9 @@ func (b *walBlock) AppendTrace(id common.ID, trace *tempopb.Trace, startTime, en
 	if err != nil {
 		return fmt.Errorf("error writing row: %w", err)
 	}
+	start, end := b.getTimeForSlack(startTime, endTime)
 
-	b.meta.ObjectAdded(id, b.getStartTimeForSlack(startTime), b.getEndTimeForSlack(endTime))
+	b.meta.ObjectAdded(id, start, end)
 	b.ids.Set(id, int64(b.ids.Len())) // Next row number
 
 	b.unflushedSize += int64(estimateMarshalledSizeFromTrace(b.buffer))
@@ -356,26 +357,23 @@ func (b *walBlock) AppendTrace(id common.ID, trace *tempopb.Trace, startTime, en
 	return nil
 }
 
-// It corrects traces start time outside the ingestion slack
-func (b *walBlock) getStartTimeForSlack(start uint32) uint32 {
+// It corrects traces where the start or end time outside the ingestion slack
+func (b *walBlock) getTimeForSlack(start, end uint32) (uint32, uint32) {
 	startTime := time.Unix(int64(start), 0)
+	endTime := time.Unix(int64(end), 0)
 	now := time.Now()
+
 	if startTime.Before(now.Add(-b.ingestionSlack)) {
 		dataquality.WarnOutsideIngestionSlack(b.meta.TenantID)
 		startTime = now
 	}
-	return uint32(startTime.Unix())
-}
 
-// It corrects traces end time outside the ingestion slack
-func (b *walBlock) getEndTimeForSlack(end uint32) uint32 {
-	endTime := time.Unix(int64(end), 0)
-	now := time.Now()
-	if endTime.After(now.Add(b.ingestionSlack)) {
+	if endTime.After(now.Add(b.ingestionSlack)) || endTime.Before(startTime) {
 		dataquality.WarnOutsideIngestionSlack(b.meta.TenantID)
 		endTime = now
 	}
-	return uint32(endTime.Unix())
+
+	return uint32(startTime.Unix()), uint32(endTime.Unix())
 }
 
 func (b *walBlock) filepathOf(page int) string {

--- a/tempodb/encoding/vparquet4/wal_block.go
+++ b/tempodb/encoding/vparquet4/wal_block.go
@@ -150,6 +150,7 @@ func openWALBlock(filename, path string, ingestionSlack, _ time.Duration) (commo
 
 // createWALBlock creates a new appendable block
 func createWALBlock(meta *backend.BlockMeta, filepath, dataEncoding string, ingestionSlack time.Duration) (*walBlock, error) {
+	now := time.Now()
 	b := &walBlock{
 		meta: &backend.BlockMeta{
 			Version:           VersionString,
@@ -157,6 +158,8 @@ func createWALBlock(meta *backend.BlockMeta, filepath, dataEncoding string, inge
 			TenantID:          meta.TenantID,
 			DedicatedColumns:  meta.DedicatedColumns,
 			ReplicationFactor: meta.ReplicationFactor,
+			StartTime:         now.Add(-ingestionSlack),
+			EndTime:           now.Add(ingestionSlack),
 		},
 		path:           filepath,
 		ids:            common.NewIDMap[int64](),
@@ -315,7 +318,7 @@ func (b *walBlock) BlockMeta() *backend.BlockMeta {
 	return b.meta
 }
 
-func (b *walBlock) Append(id common.ID, buff []byte, start, end uint32) error {
+func (b *walBlock) Append(id common.ID, buff []byte, startTime, endTime uint32) error {
 	// if decoder = nil we were created with OpenWALBlock and will not accept writes
 	if b.decoder == nil {
 		return nil
@@ -326,10 +329,10 @@ func (b *walBlock) Append(id common.ID, buff []byte, start, end uint32) error {
 		return fmt.Errorf("error preparing trace for read: %w", err)
 	}
 
-	return b.AppendTrace(id, trace, start, end)
+	return b.AppendTrace(id, trace, startTime, endTime)
 }
 
-func (b *walBlock) AppendTrace(id common.ID, trace *tempopb.Trace, start, end uint32) error {
+func (b *walBlock) AppendTrace(id common.ID, trace *tempopb.Trace, startTime, endTime uint32) error {
 	var connected bool
 	b.buffer, connected = traceToParquet(b.meta, id, trace, b.buffer)
 	if !connected {
@@ -339,15 +342,13 @@ func (b *walBlock) AppendTrace(id common.ID, trace *tempopb.Trace, start, end ui
 		dataquality.WarnRootlessTrace(b.meta.TenantID, dataquality.PhaseTraceFlushedToWal)
 	}
 
-	start, end = b.adjustTimeRangeForSlack(start, end, 0)
-
 	// add to current
 	_, err := b.writer.Write([]*Trace{b.buffer})
 	if err != nil {
 		return fmt.Errorf("error writing row: %w", err)
 	}
 
-	b.meta.ObjectAdded(id, start, end)
+	b.meta.ObjectAdded(id, b.getStartTimeForSlack(startTime), b.getEndTimeForSlack(endTime))
 	b.ids.Set(id, int64(b.ids.Len())) // Next row number
 
 	b.unflushedSize += int64(estimateMarshalledSizeFromTrace(b.buffer))
@@ -355,26 +356,26 @@ func (b *walBlock) AppendTrace(id common.ID, trace *tempopb.Trace, start, end ui
 	return nil
 }
 
-func (b *walBlock) adjustTimeRangeForSlack(start, end uint32, additionalStartSlack time.Duration) (uint32, uint32) {
+// It corrects traces start time outside the ingestion slack
+func (b *walBlock) getStartTimeForSlack(start uint32) uint32 {
+	startTime := time.Unix(int64(start), 0)
 	now := time.Now()
-	startOfRange := uint32(now.Add(-b.ingestionSlack).Add(-additionalStartSlack).Unix())
-	endOfRange := uint32(now.Add(b.ingestionSlack).Unix())
-
-	warn := false
-	if start < startOfRange {
-		warn = true
-		start = uint32(now.Unix())
-	}
-	if end > endOfRange {
-		warn = true
-		end = uint32(now.Unix())
-	}
-
-	if warn {
+	if startTime.Before(now.Add(-b.ingestionSlack)) {
 		dataquality.WarnOutsideIngestionSlack(b.meta.TenantID)
+		startTime = now
 	}
+	return uint32(startTime.Unix())
+}
 
-	return start, end
+// It corrects traces end time outside the ingestion slack
+func (b *walBlock) getEndTimeForSlack(end uint32) uint32 {
+	endTime := time.Unix(int64(end), 0)
+	now := time.Now()
+	if endTime.After(now.Add(b.ingestionSlack)) {
+		dataquality.WarnOutsideIngestionSlack(b.meta.TenantID)
+		endTime = now
+	}
+	return uint32(endTime.Unix())
 }
 
 func (b *walBlock) filepathOf(page int) string {

--- a/tempodb/tempodb_test.go
+++ b/tempodb/tempodb_test.go
@@ -683,7 +683,7 @@ func testCompleteBlockHonorsStartStopTimes(t *testing.T, targetBlockVersion stri
 			IndexPageSizeBytes:   1000,
 		},
 		WAL: &wal.Config{
-			IngestionSlack: time.Minute,
+			IngestionSlack: 0,
 			Filepath:       path.Join(tempDir, "wal"),
 		},
 		BlocklistPoll: 0,
@@ -713,8 +713,8 @@ func testCompleteBlockHonorsStartStopTimes(t *testing.T, targetBlockVersion stri
 
 	// Verify the block time was constrained to the slack time.
 	// Accept a couple seconds of slack time to ensure test reliability.
-	require.Less(t, complete.BlockMeta().StartTime.Sub(now).Seconds(), 2.0)
-	require.Less(t, complete.BlockMeta().EndTime.Sub(now).Seconds(), 2.0)
+	require.Less(t, complete.BlockMeta().StartTime.Sub(now).Seconds(), 1.0)
+	require.Less(t, complete.BlockMeta().EndTime.Sub(now).Seconds(), 1.0)
 }
 
 func writeTraceToWal(t require.TestingT, b common.WALBlock, dec model.SegmentDecoder, id common.ID, tr *tempopb.Trace, start, end uint32) {


### PR DESCRIPTION
**What this PR does**:
This PR addresses a bug where traces older than the ingestion slack are ingested. When that happened, the block start time exceeded the block end time. This led the compactor to remove those blocks, and the inability to search them by id.

**Example of the current error**
Trace data:

```json
{
          "traceId": "5B8EFFF798038103D269B633813FC703",
          "spanId": "EEE19B7EC3C1B100",
          "name": "I am a span!",
          "startTimeUnixNano": 1689969302000000000,
          "endTimeUnixNano": 1689970000000000000,
          "kind": 2,
          "status": {
            "code": "STATUS_CODE_OK"
          },
          "attributes": [
          {
              "key": "my.span.attr",
              "value": {
                  "stringValue": "some value"
              }
}
```
The start and date are from 2023

Resulting block:
```
window: 2023-07-21T20:00:00Z
start: 2024-08-07T17:21:44+02:00
end: 2023-07-21T22:06:40+02:00
duration:  -9187h15m4s
age: 9203h48m32s
```

The start date is being set as now() whereas the end date is left as it is in the span data.


The proposed change sets the start and end date to the current date time plus the slack duration when the block is created. Later on, the time window will be adjusted as before. When appending new traces to a block, we control that date range boundaries.

**Example after the PR changes**
```json
{"format":"vParquet4","blockID":"be564c9d-f76d-49ee-9668-24b6cc024eed","minID":"W47/95gDgQPSabYzgT/HAw==","maxID":"W47/95gDgQPSabYzgT/HAw==","tenantID":"single-tenant","startTime":"2024-08-09T15:45:16.837762+02:00","endTime":"2024-08-09T15:47:18+02:00","totalObjects":2,"size":0,"compactionLevel":0,"encoding":"none","indexPageSize":0,"totalRecords":0,"dataEncoding":"","bloomShards":0,"footerSize":0}
```
Now, in the wall block, the start and end times are set to now() and there are no inconsistencies.

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`