### PR TITLE
Change ReplicationFactor to uint8 in BlockMeta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * [CHANGE] Make vParquet4 the default block encoding [#3810](https://github.com/grafana/tempo/pull/3810) (@ie-pham)
 * [CHANGE] Azure v2 backend becomes the only and primary Azure backend [#3875](https://github.com/grafana/tempo/pull/3875) (@zalegrala)
   **BREAKING CHANGE** The `use_v2_sdk` configuration option has been removed.
-* [CHANGE] BlockMeta improvements to reduce the size [#3950](https://github.com/grafana/tempo/pull/3950) (@zalegrala)
+* [CHANGE] BlockMeta improvements to reduce the size [#3950](https://github.com/grafana/tempo/pull/3950) [#3951](https://github.com/grafana/tempo/pull/3951) (@zalegrala)
 * [FEATURE] TraceQL support for link scope and link:traceID and link:spanID [#3741](https://github.com/grafana/tempo/pull/3741) (@stoewer)
 * [FEATURE] TraceQL support for link attribute querying [#3814](https://github.com/grafana/tempo/pull/3814) (@ie-pham)
 * [FEATURE] TraceQL support for event scope and event:name intrinsic [#3708](https://github.com/grafana/tempo/pull/3708) (@stoewer)

--- a/modules/frontend/metrics_query_range_sharder.go
+++ b/modules/frontend/metrics_query_range_sharder.go
@@ -32,7 +32,7 @@ type queryRangeSharder struct {
 	overrides         overrides.Interface
 	cfg               QueryRangeSharderConfig
 	logger            log.Logger
-	replicationFactor uint32
+	replicationFactor uint8
 }
 
 type QueryRangeSharderConfig struct {
@@ -48,7 +48,7 @@ type QueryRangeSharderConfig struct {
 
 // newAsyncQueryRangeSharder creates a sharding middleware for search
 func newAsyncQueryRangeSharder(reader tempodb.Reader, o overrides.Interface, cfg QueryRangeSharderConfig, logger log.Logger) pipeline.AsyncMiddleware[combiner.PipelineResponse] {
-	var replicationFactor uint32
+	var replicationFactor uint8
 	if cfg.RF1ReadPath {
 		replicationFactor = 1
 	}

--- a/tempodb/backend/block_meta.go
+++ b/tempodb/backend/block_meta.go
@@ -128,7 +128,7 @@ type BlockMeta struct {
 	DedicatedColumns DedicatedColumns `json:"dedicatedColumns,omitempty"`
 	// ReplicationFactor is the number of times the data written in this block has been replicated.
 	// It's left unset if replication factor is 3. Default is 0 (RF3).
-	ReplicationFactor uint32 `json:"replicationFactor,omitempty"`
+	ReplicationFactor uint8 `json:"replicationFactor,omitempty"`
 }
 
 // DedicatedColumn contains the configuration for a single attribute with the given name that should

--- a/tempodb/encoding/vparquet3/compactor_test.go
+++ b/tempodb/encoding/vparquet3/compactor_test.go
@@ -115,7 +115,7 @@ func createTestBlock(t testing.TB, ctx context.Context, cfg *common.BlockConfig,
 		TenantID:          tenantID,
 		BlockID:           uuid.New(),
 		TotalObjects:      traceCount,
-		ReplicationFactor: uint32(replicationFactor),
+		ReplicationFactor: uint8(replicationFactor),
 		DedicatedColumns:  dc,
 	}
 
@@ -211,6 +211,6 @@ func TestCompact(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, newMeta, 1)
 	require.Equal(t, 20, newMeta[0].TotalObjects)
-	require.Equal(t, uint32(1), newMeta[0].ReplicationFactor)
+	require.Equal(t, uint8(1), newMeta[0].ReplicationFactor)
 	require.Equal(t, dedicatedColumns, newMeta[0].DedicatedColumns)
 }

--- a/tempodb/encoding/vparquet4/compactor_test.go
+++ b/tempodb/encoding/vparquet4/compactor_test.go
@@ -115,7 +115,7 @@ func createTestBlock(t testing.TB, ctx context.Context, cfg *common.BlockConfig,
 		TenantID:          tenantID,
 		BlockID:           uuid.New(),
 		TotalObjects:      traceCount,
-		ReplicationFactor: uint32(replicationFactor),
+		ReplicationFactor: uint8(replicationFactor),
 		DedicatedColumns:  dc,
 	}
 
@@ -211,6 +211,6 @@ func TestCompact(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, newMeta, 1)
 	require.Equal(t, 20, newMeta[0].TotalObjects)
-	require.Equal(t, uint32(1), newMeta[0].ReplicationFactor)
+	require.Equal(t, uint8(1), newMeta[0].ReplicationFactor)
 	require.Equal(t, dedicatedColumns, newMeta[0].DedicatedColumns)
 }

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -609,7 +609,7 @@ func includeBlock(b *backend.BlockMeta, _ common.ID, blockStart, blockEnd []byte
 		return false
 	}
 
-	return b.ReplicationFactor == uint32(replicationFactor)
+	return b.ReplicationFactor == uint8(replicationFactor)
 }
 
 // if block is compacted within lookback period, and is within shard ranges, include it in search


### PR DESCRIPTION
**What this PR does**:

Here we reduce the size of the integer representing a block replication factor.  Normal values are 1-3.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`