### PR TITLE
Unmarshal identical dedicatedColumns fields less often

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * [CHANGE] Make vParquet4 the default block encoding [#3810](https://github.com/grafana/tempo/pull/3810) (@ie-pham)
 * [CHANGE] Azure v2 backend becomes the only and primary Azure backend [#3875](https://github.com/grafana/tempo/pull/3875) (@zalegrala)
   **BREAKING CHANGE** The `use_v2_sdk` configuration option has been removed.
-* [CHANGE] BlockMeta improvements to reduce the size [#3950](https://github.com/grafana/tempo/pull/3950) [#3951](https://github.com/grafana/tempo/pull/3951) (@zalegrala)
+* [CHANGE] BlockMeta improvements to reduce the size [#3950](https://github.com/grafana/tempo/pull/3950) [#3951](https://github.com/grafana/tempo/pull/3951) [#3952](https://github.com/grafana/tempo/pull/3952)(@zalegrala)
 * [FEATURE] TraceQL support for link scope and link:traceID and link:spanID [#3741](https://github.com/grafana/tempo/pull/3741) (@stoewer)
 * [FEATURE] TraceQL support for link attribute querying [#3814](https://github.com/grafana/tempo/pull/3814) (@ie-pham)
 * [FEATURE] TraceQL support for event scope and event:name intrinsic [#3708](https://github.com/grafana/tempo/pull/3708) (@stoewer)

--- a/tempodb/backend/json.go
+++ b/tempodb/backend/json.go
@@ -23,3 +23,10 @@ func putDedicatedColumns(b string, d *DedicatedColumns) {
 
 	dedicatedColumnsKeeper[b] = d
 }
+
+func ClearDedicatedColumns() {
+	dedicatedColumnsMtx.Lock()
+	defer dedicatedColumnsMtx.Unlock()
+
+	clear(dedicatedColumnsKeeper)
+}

--- a/tempodb/backend/json.go
+++ b/tempodb/backend/json.go
@@ -1,0 +1,25 @@
+package backend
+
+import "sync"
+
+var (
+	dedicatedColumnsKeeper = map[string]*DedicatedColumns{}
+	dedicatedColumnsMtx    = sync.Mutex{}
+)
+
+func getDedicatedColumns(b string) *DedicatedColumns {
+	dedicatedColumnsMtx.Lock()
+	defer dedicatedColumnsMtx.Unlock()
+
+	if v, ok := dedicatedColumnsKeeper[b]; ok {
+		return v
+	}
+	return nil
+}
+
+func putDedicatedColumns(b string, d *DedicatedColumns) {
+	dedicatedColumnsMtx.Lock()
+	defer dedicatedColumnsMtx.Unlock()
+
+	dedicatedColumnsKeeper[b] = d
+}

--- a/tempodb/backend/json_test.go
+++ b/tempodb/backend/json_test.go
@@ -1,0 +1,56 @@
+package backend
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_getDedicatedColumns(t *testing.T) {
+	tests := []struct {
+		name     string
+		jsonStr  string
+		expected *DedicatedColumns
+	}{
+		{
+			name:    "case1",
+			jsonStr: `[ {"s": "resource", "n": "namespace"}, {"n": "http.method"}, {"n": "namespace"} ]`,
+			expected: &DedicatedColumns{
+				{Scope: "resource", Name: "namespace", Type: "string"},
+				{Scope: "span", Name: "http.method", Type: "string"},
+				{Scope: "span", Name: "namespace", Type: "string"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// clear the map so we start with a clean slate
+			clear(dedicatedColumnsKeeper)
+
+			v := getDedicatedColumns(tc.jsonStr)
+			require.Nil(t, v)
+
+			dcs := &DedicatedColumns{}
+			err := json.Unmarshal([]byte(tc.jsonStr), dcs)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, dcs)
+
+			v = getDedicatedColumns(tc.jsonStr)
+			require.Equal(t, dcs, v)
+
+			p1 := fmt.Sprintf("%p", dcs)
+			p2 := fmt.Sprintf("%p", v)
+			require.Equal(t, p1, p2)
+
+			dcs2 := &DedicatedColumns{}
+			err = json.Unmarshal([]byte(tc.jsonStr), dcs2)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, dcs)
+
+			require.Equal(t, dcs, dcs2)
+		})
+	}
+}

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -140,6 +140,7 @@ func (p *Poller) Do(previous *List) (PerTenant, PerTenantCompacted, error) {
 		diff := time.Since(start).Seconds()
 		metricBlocklistPollDuration.Observe(diff)
 		level.Info(p.logger).Log("msg", "blocklist poll complete", "seconds", diff)
+		backend.ClearDedicatedColumns()
 	}()
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
**What this PR does**:

Here we cache the unmarshaled DedicatedColumns in a package level map variable which is keyed by the bytes that were used to unmarshal.

* This works because we are not dealing with maps, which are unordered.  Otherwise the json should be in a consistent order.
* This has the potential to grow unbounded, but there are not an unbounded set of dedicated columns, so this is probably fine.
* The string of the json is used as the map key, which could be large.

A reasonable follow up might be to do the same kind of caching, but for each dedicated column.  This would mean that we use the cached set of columns first, and if that isn't available, then use the cache for a single column.  

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`