### PR TITLE
fix: correct end time when a trace is outside the ingestion slack range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 * [BUGFIX] Fix prefix handling in Azure backend Find() call [#3875](https://github.com/grafana/tempo/pull/3875) (@zalegrala)
 * [BUGFIX] **BREAKING CHANGE** Remove unused properties from the WAL configuration [#3911](https://github.com/grafana/tempo/pull/3911) (@javiermolinar)
 * [BUGFIX] Bring back OTEL receiver metrics [#3917](https://github.com/grafana/tempo/pull/3917) (@javiermolinar)
+* [BUGFIX] Correct block end time when the ingested traces are outside the ingestion slack [#3954](https://github.com/grafana/tempo/pull/3954) (@javiermolinar)
 
 ## v2.5.0
 

--- a/tempodb/backend/block_meta.go
+++ b/tempodb/backend/block_meta.go
@@ -210,8 +210,8 @@ func NewBlockMetaWithDedicatedColumns(tenantID string, blockID uuid.UUID, versio
 }
 
 // ObjectAdded updates the block meta appropriately based on information about an added record
-// start/end are unix epoch seconds
-func (b *BlockMeta) ObjectAdded(id []byte, start, end uint32) {
+// start/end are unix epoch seconds, when 0 the start and the end are not applied.
+func (b *BlockMeta) ObjectAdded(start, end uint32) {
 	if start > 0 {
 		startTime := time.Unix(int64(start), 0)
 		if b.StartTime.IsZero() || startTime.Before(b.StartTime) {

--- a/tempodb/backend/block_meta_test.go
+++ b/tempodb/backend/block_meta_test.go
@@ -81,7 +81,7 @@ func TestBlockMetaObjectAdded(t *testing.T) {
 		b := &BlockMeta{}
 
 		for i := 0; i < len(tc.ids); i++ {
-			b.ObjectAdded(tc.ids[i], tc.starts[i], tc.ends[i])
+			b.ObjectAdded(tc.starts[i], tc.ends[i])
 		}
 
 		assert.Equal(t, tc.expectedStart, b.StartTime)

--- a/tempodb/encoding/v2/streaming_block.go
+++ b/tempodb/encoding/v2/streaming_block.go
@@ -78,7 +78,7 @@ func (c *StreamingBlock) AddObject(id common.ID, object []byte) error {
 		return err
 	}
 	c.bufferedObjects++
-	c.meta.ObjectAdded(id, 0, 0) // streaming block handles start/end time by combining BlockMetas. See .BlockMeta()
+	c.meta.ObjectAdded(0, 0) // streaming block handles start/end time by combining BlockMetas. See .BlockMeta()
 	c.bloom.Add(id)
 	return nil
 }

--- a/tempodb/encoding/v2/wal_block.go
+++ b/tempodb/encoding/v2/wal_block.go
@@ -162,7 +162,7 @@ func (a *walBlock) Append(id common.ID, b []byte, start, end uint32) error {
 		return err
 	}
 	start, end = a.adjustTimeRangeForSlack(start, end, 0)
-	a.meta.ObjectAdded(id, start, end)
+	a.meta.ObjectAdded(start, end)
 	return nil
 }
 

--- a/tempodb/encoding/v2/wal_block.go
+++ b/tempodb/encoding/v2/wal_block.go
@@ -368,7 +368,7 @@ func (a *walBlock) adjustTimeRangeForSlack(start, end uint32, additionalStartSla
 		warn = true
 		start = uint32(now.Unix())
 	}
-	if end > endOfRange {
+	if end > endOfRange || end < start {
 		warn = true
 		end = uint32(now.Unix())
 	}

--- a/tempodb/encoding/v2/wal_block_test.go
+++ b/tempodb/encoding/v2/wal_block_test.go
@@ -166,6 +166,14 @@ func TestAdjustTimeRangeForSlack(t *testing.T) {
 	actualStart, actualEnd = a.adjustTimeRangeForSlack(start, end, time.Hour)
 	assert.Equal(t, start, actualStart)
 	assert.Equal(t, end, actualEnd)
+
+	// test start and end out of range
+	now = uint32(time.Now().Unix())
+	start = uint32(time.Now().Add(5 * -time.Hour).Unix())
+	end = uint32(time.Now().Add(4 * -time.Hour).Unix())
+	actualStart, actualEnd = a.adjustTimeRangeForSlack(start, end, 0)
+	assert.Equal(t, now, actualStart)
+	assert.Equal(t, now, actualEnd)
 }
 
 func TestPartialBlock(t *testing.T) {

--- a/tempodb/encoding/vparquet2/create.go
+++ b/tempodb/encoding/vparquet2/create.go
@@ -141,7 +141,7 @@ func (b *streamingBlock) Add(tr *Trace, start, end uint32) error {
 
 	b.index.Add(id)
 	b.bloom.Add(id)
-	b.meta.ObjectAdded(id, start, end)
+	b.meta.ObjectAdded(start, end)
 	b.currentBufferedTraces++
 	b.currentBufferedBytes += estimateMarshalledSizeFromTrace(tr)
 
@@ -156,7 +156,7 @@ func (b *streamingBlock) AddRaw(id []byte, row parquet.Row, start, end uint32) e
 
 	b.index.Add(id)
 	b.bloom.Add(id)
-	b.meta.ObjectAdded(id, start, end)
+	b.meta.ObjectAdded(start, end)
 	b.currentBufferedTraces++
 	b.currentBufferedBytes += estimateMarshalledSizeFromParquetRow(row)
 

--- a/tempodb/encoding/vparquet2/wal_block.go
+++ b/tempodb/encoding/vparquet2/wal_block.go
@@ -138,7 +138,7 @@ func openWALBlock(filename, path string, ingestionSlack, _ time.Duration) (commo
 				switch e.Key {
 				case columnPathTraceID:
 					traceID := e.Value.ByteArray()
-					b.meta.ObjectAdded(traceID, 0, 0)
+					b.meta.ObjectAdded(0, 0)
 					page.ids.Set(traceID, int64(match.RowNumber[0])) // Save rownumber for the trace ID
 				}
 			}
@@ -336,7 +336,7 @@ func (b *walBlock) AppendTrace(id common.ID, trace *tempopb.Trace, start, end ui
 		return fmt.Errorf("error writing row: %w", err)
 	}
 
-	b.meta.ObjectAdded(id, start, end)
+	b.meta.ObjectAdded(start, end)
 	b.ids.Set(id, int64(b.ids.Len())) // Next row number
 
 	b.unflushedSize += int64(estimateMarshalledSizeFromTrace(b.buffer))

--- a/tempodb/encoding/vparquet2/wal_block.go
+++ b/tempodb/encoding/vparquet2/wal_block.go
@@ -328,7 +328,7 @@ func (b *walBlock) Append(id common.ID, buff []byte, start, end uint32) error {
 func (b *walBlock) AppendTrace(id common.ID, trace *tempopb.Trace, start, end uint32) error {
 	b.buffer = traceToParquet(id, trace, b.buffer)
 
-	start, end = b.adjustTimeRangeForSlack(start, end, 0)
+	start, end = b.adjustTimeRangeForSlack(start, end)
 
 	// add to current
 	_, err := b.writer.Write([]*Trace{b.buffer})
@@ -344,9 +344,9 @@ func (b *walBlock) AppendTrace(id common.ID, trace *tempopb.Trace, start, end ui
 	return nil
 }
 
-func (b *walBlock) adjustTimeRangeForSlack(start, end uint32, additionalStartSlack time.Duration) (uint32, uint32) {
+func (b *walBlock) adjustTimeRangeForSlack(start, end uint32) (uint32, uint32) {
 	now := time.Now()
-	startOfRange := uint32(now.Add(-b.ingestionSlack).Add(-additionalStartSlack).Unix())
+	startOfRange := uint32(now.Add(-b.ingestionSlack).Unix())
 	endOfRange := uint32(now.Add(b.ingestionSlack).Unix())
 
 	warn := false
@@ -354,7 +354,7 @@ func (b *walBlock) adjustTimeRangeForSlack(start, end uint32, additionalStartSla
 		warn = true
 		start = uint32(now.Unix())
 	}
-	if end > endOfRange {
+	if end > endOfRange || end < start {
 		warn = true
 		end = uint32(now.Unix())
 	}

--- a/tempodb/encoding/vparquet3/create.go
+++ b/tempodb/encoding/vparquet3/create.go
@@ -142,7 +142,7 @@ func (b *streamingBlock) Add(tr *Trace, start, end uint32) error {
 
 	b.index.Add(id)
 	b.bloom.Add(id)
-	b.meta.ObjectAdded(id, start, end)
+	b.meta.ObjectAdded(start, end)
 	b.currentBufferedTraces++
 	b.currentBufferedBytes += estimateMarshalledSizeFromTrace(tr)
 
@@ -157,7 +157,7 @@ func (b *streamingBlock) AddRaw(id []byte, row parquet.Row, start, end uint32) e
 
 	b.index.Add(id)
 	b.bloom.Add(id)
-	b.meta.ObjectAdded(id, start, end)
+	b.meta.ObjectAdded(start, end)
 	b.currentBufferedTraces++
 	b.currentBufferedBytes += estimateMarshalledSizeFromParquetRow(row)
 

--- a/tempodb/encoding/vparquet3/wal_block.go
+++ b/tempodb/encoding/vparquet3/wal_block.go
@@ -135,7 +135,7 @@ func openWALBlock(filename, path string, ingestionSlack, _ time.Duration) (commo
 				switch e.Key {
 				case columnPathTraceID:
 					traceID := e.Value.ByteArray()
-					b.meta.ObjectAdded(traceID, 0, 0)
+					b.meta.ObjectAdded(0, 0)
 					page.ids.Set(traceID, int64(match.RowNumber[0])) // Save rownumber for the trace ID
 				}
 			}
@@ -347,7 +347,7 @@ func (b *walBlock) AppendTrace(id common.ID, trace *tempopb.Trace, start, end ui
 		return fmt.Errorf("error writing row: %w", err)
 	}
 
-	b.meta.ObjectAdded(id, start, end)
+	b.meta.ObjectAdded(start, end)
 	b.ids.Set(id, int64(b.ids.Len())) // Next row number
 
 	b.unflushedSize += int64(estimateMarshalledSizeFromTrace(b.buffer))

--- a/tempodb/encoding/vparquet3/wal_block.go
+++ b/tempodb/encoding/vparquet3/wal_block.go
@@ -339,7 +339,7 @@ func (b *walBlock) AppendTrace(id common.ID, trace *tempopb.Trace, start, end ui
 		dataquality.WarnRootlessTrace(b.meta.TenantID, dataquality.PhaseTraceFlushedToWal)
 	}
 
-	start, end = b.adjustTimeRangeForSlack(start, end, 0)
+	start, end = b.adjustTimeRangeForSlack(start, end)
 
 	// add to current
 	_, err := b.writer.Write([]*Trace{b.buffer})
@@ -355,9 +355,9 @@ func (b *walBlock) AppendTrace(id common.ID, trace *tempopb.Trace, start, end ui
 	return nil
 }
 
-func (b *walBlock) adjustTimeRangeForSlack(start, end uint32, additionalStartSlack time.Duration) (uint32, uint32) {
+func (b *walBlock) adjustTimeRangeForSlack(start, end uint32) (uint32, uint32) {
 	now := time.Now()
-	startOfRange := uint32(now.Add(-b.ingestionSlack).Add(-additionalStartSlack).Unix())
+	startOfRange := uint32(now.Add(-b.ingestionSlack).Unix())
 	endOfRange := uint32(now.Add(b.ingestionSlack).Unix())
 
 	warn := false
@@ -365,7 +365,7 @@ func (b *walBlock) adjustTimeRangeForSlack(start, end uint32, additionalStartSla
 		warn = true
 		start = uint32(now.Unix())
 	}
-	if end > endOfRange {
+	if end > endOfRange || end < start {
 		warn = true
 		end = uint32(now.Unix())
 	}

--- a/tempodb/encoding/vparquet4/create.go
+++ b/tempodb/encoding/vparquet4/create.go
@@ -142,7 +142,7 @@ func (b *streamingBlock) Add(tr *Trace, start, end uint32) error {
 
 	b.index.Add(id)
 	b.bloom.Add(id)
-	b.meta.ObjectAdded(id, start, end)
+	b.meta.ObjectAdded(start, end)
 	b.currentBufferedTraces++
 	b.currentBufferedBytes += estimateMarshalledSizeFromTrace(tr)
 
@@ -157,7 +157,7 @@ func (b *streamingBlock) AddRaw(id []byte, row parquet.Row, start, end uint32) e
 
 	b.index.Add(id)
 	b.bloom.Add(id)
-	b.meta.ObjectAdded(id, start, end)
+	b.meta.ObjectAdded(start, end)
 	b.currentBufferedTraces++
 	b.currentBufferedBytes += estimateMarshalledSizeFromParquetRow(row)
 

--- a/tempodb/encoding/vparquet4/wal_block.go
+++ b/tempodb/encoding/vparquet4/wal_block.go
@@ -347,7 +347,7 @@ func (b *walBlock) AppendTrace(id common.ID, trace *tempopb.Trace, start, end ui
 		return fmt.Errorf("error writing row: %w", err)
 	}
 
-	b.meta.ObjectAdded(id, start, end)
+	b.meta.ObjectAdded(start, end)
 	b.ids.Set(id, int64(b.ids.Len())) // Next row number
 
 	b.unflushedSize += int64(estimateMarshalledSizeFromTrace(b.buffer))

--- a/tempodb/encoding/vparquet4/wal_block.go
+++ b/tempodb/encoding/vparquet4/wal_block.go
@@ -135,7 +135,7 @@ func openWALBlock(filename, path string, ingestionSlack, _ time.Duration) (commo
 				switch e.Key {
 				case columnPathTraceID:
 					traceID := e.Value.ByteArray()
-					b.meta.ObjectAdded(traceID, 0, 0)
+					b.meta.ObjectAdded(0, 0)
 					page.ids.Set(traceID, int64(match.RowNumber[0])) // Save rownumber for the trace ID
 				}
 			}
@@ -339,7 +339,7 @@ func (b *walBlock) AppendTrace(id common.ID, trace *tempopb.Trace, start, end ui
 		dataquality.WarnRootlessTrace(b.meta.TenantID, dataquality.PhaseTraceFlushedToWal)
 	}
 
-	start, end = b.adjustTimeRangeForSlack(start, end, 0)
+	start, end = b.adjustTimeRangeForSlack(start, end)
 
 	// add to current
 	_, err := b.writer.Write([]*Trace{b.buffer})
@@ -355,9 +355,10 @@ func (b *walBlock) AppendTrace(id common.ID, trace *tempopb.Trace, start, end ui
 	return nil
 }
 
-func (b *walBlock) adjustTimeRangeForSlack(start, end uint32, additionalStartSlack time.Duration) (uint32, uint32) {
+// It controls the block start/end date as a sliding window.
+func (b *walBlock) adjustTimeRangeForSlack(start, end uint32) (uint32, uint32) {
 	now := time.Now()
-	startOfRange := uint32(now.Add(-b.ingestionSlack).Add(-additionalStartSlack).Unix())
+	startOfRange := uint32(now.Add(-b.ingestionSlack).Unix())
 	endOfRange := uint32(now.Add(b.ingestionSlack).Unix())
 
 	warn := false
@@ -365,7 +366,7 @@ func (b *walBlock) adjustTimeRangeForSlack(start, end uint32, additionalStartSla
 		warn = true
 		start = uint32(now.Unix())
 	}
-	if end > endOfRange {
+	if end > endOfRange || end < start {
 		warn = true
 		end = uint32(now.Unix())
 	}

--- a/tempodb/wal/wal_test.go
+++ b/tempodb/wal/wal_test.go
@@ -133,7 +133,7 @@ func testIngestionSlack(t *testing.T, e encoding.VersionedEncoding) {
 	blockEnd := uint32(block.BlockMeta().EndTime.Unix())
 
 	require.Equal(t, uint32(appendTime.Unix()), blockStart)
-	require.Equal(t, traceEnd, blockEnd)
+	require.Equal(t, uint32(appendTime.Unix()), blockEnd)
 }
 
 func TestFindByTraceID(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:
This PR addresses a bug where traces older than the ingestion slack are ingested. When that happened, the block start time exceeded the block end time. This led the compactor to remove those blocks, and the inability to search them by id.

**Example of the current error**
Trace data:

```json
{
          "traceId": "5B8EFFF798038103D269B633813FC703",
          "spanId": "EEE19B7EC3C1B100",
          "name": "I am a span!",
          "startTimeUnixNano": 1689969302000000000,
          "endTimeUnixNano": 1689970000000000000,
          "kind": 2,
          "status": {
            "code": "STATUS_CODE_OK"
          },
          "attributes": [
          {
              "key": "my.span.attr",
              "value": {
                  "stringValue": "some value"
              }
}
```
The start and date are from 2023

Resulting block:
```
window: 2023-07-21T20:00:00Z
start: 2024-08-07T17:21:44+02:00
end: 2023-07-21T22:06:40+02:00
duration:  -9187h15m4s
age: 9203h48m32s
```

The start date is being set as now() whereas the end date is left as it is in the span data.


**Example after the PR changes**
```json
{"format":"vParquet4","blockID":"be564c9d-f76d-49ee-9668-24b6cc024eed","minID":"W47/95gDgQPSabYzgT/HAw==","maxID":"W47/95gDgQPSabYzgT/HAw==","tenantID":"single-tenant","startTime":"2024-08-09T15:45:16.837762+02:00","endTime":"2024-08-09T15:47:18+02:00","totalObjects":2,"size":0,"compactionLevel":0,"encoding":"none","indexPageSize":0,"totalRecords":0,"dataEncoding":"","bloomShards":0,"footerSize":0}
```
Now, in the wall block, the start and end times are set to now() and there are no inconsistencies.

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`