### PR TITLE
Clone the diff in GRPC streaming to prevent panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 * [BUGFIX] **BREAKING CHANGE** Remove unused properties from the WAL configuration [#3911](https://github.com/grafana/tempo/pull/3911) (@javiermolinar)
 * [BUGFIX] Bring back OTEL receiver metrics [#3917](https://github.com/grafana/tempo/pull/3917) (@javiermolinar)
 * [BUGFIX] Correct block end time when the ingested traces are outside the ingestion slack [#3954](https://github.com/grafana/tempo/pull/3954) (@javiermolinar)
+* [BUGFIX] Fix race condition where a streaming response could be marshalled while being modified in the combiner resulting in a panic. [#3961](https://github.com/grafana/tempo/pull/3961) (@joe-elliott)
 
 ## v2.5.0
 

--- a/modules/frontend/combiner/common.go
+++ b/modules/frontend/combiner/common.go
@@ -176,7 +176,9 @@ func (c *genericCombiner[T]) GRPCFinal() (T, error) {
 		return empty, err
 	}
 
-	return final, nil
+	// clone the final response to prevent race conditions with marshalling this data
+	finalClone := proto.Clone(final).(T)
+	return finalClone, nil
 }
 
 func (c *genericCombiner[T]) GRPCDiff() (T, error) {
@@ -196,7 +198,6 @@ func (c *genericCombiner[T]) GRPCDiff() (T, error) {
 
 	// clone the diff to prevent race conditions with marshalling this data
 	diffClone := proto.Clone(diff)
-
 	return diffClone.(T), nil
 }
 

--- a/modules/frontend/combiner/common.go
+++ b/modules/frontend/combiner/common.go
@@ -194,7 +194,10 @@ func (c *genericCombiner[T]) GRPCDiff() (T, error) {
 		return empty, err
 	}
 
-	return diff, nil
+	// clone the diff to prevent race conditions with marshalling this data
+	diffClone := proto.Clone(diff)
+
+	return diffClone.(T), nil
 }
 
 func (c *genericCombiner[T]) erroredResponse() (*http.Response, error) {


### PR DESCRIPTION
**What this PR does**:
Clones the diff in GRPC streaming to prevent panics


**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`