### PR TITLE
[r160] Clone the diff in GRPC streaming to prevent panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@
 * [BUGFIX] Fix prefix handling in Azure backend Find() call [#3875](https://github.com/grafana/tempo/pull/3875) (@zalegrala)
 * [BUGFIX] **BREAKING CHANGE** Remove unused properties from the WAL configuration [#3911](https://github.com/grafana/tempo/pull/3911) (@javiermolinar)
 * [BUGFIX] Bring back OTEL receiver metrics [#3917](https://github.com/grafana/tempo/pull/3917) (@javiermolinar)
+* [BUGFIX] Correct block end time when the ingested traces are outside the ingestion slack [#3954](https://github.com/grafana/tempo/pull/3954) (@javiermolinar)
+* [BUGFIX] Fix race condition where a streaming response could be marshalled while being modified in the combiner resulting in a panic. [#3961](https://github.com/grafana/tempo/pull/3961) (@joe-elliott)
 
 ## v2.5.0
 

--- a/modules/frontend/combiner/common.go
+++ b/modules/frontend/combiner/common.go
@@ -176,7 +176,9 @@ func (c *genericCombiner[T]) GRPCFinal() (T, error) {
 		return empty, err
 	}
 
-	return final, nil
+	// clone the final response to prevent race conditions with marshalling this data
+	finalClone := proto.Clone(final).(T)
+	return finalClone, nil
 }
 
 func (c *genericCombiner[T]) GRPCDiff() (T, error) {
@@ -194,7 +196,9 @@ func (c *genericCombiner[T]) GRPCDiff() (T, error) {
 		return empty, err
 	}
 
-	return diff, nil
+	// clone the diff to prevent race conditions with marshalling this data
+	diffClone := proto.Clone(diff)
+	return diffClone.(T), nil
 }
 
 func (c *genericCombiner[T]) erroredResponse() (*http.Response, error) {


### PR DESCRIPTION
Backport 89b8d7d783e7e4c8b2955bd3b39c9e084f75ca4c from #3961

---

**What this PR does**:
Clones the diff in GRPC streaming to prevent panics


**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
