### PR TITLE
tools: update go and add goyacc and drone-cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,8 +273,8 @@ gen-proto:  ## Generate proto files
 ##@ Gen Traceql
 
 .PHONY: gen-traceql 
-gen-traceql: ## Generate traceql 
-	docker run --rm -v${PWD}:/src/loki ${LOKI_BUILD_IMAGE} gen-traceql-local
+gen-traceql: ## Generate traceql
+	$(TOOLS_CMD) $(MAKE) gen-traceql-local
 
 .PHONY: gen-traceql-local 
 gen-traceql-local: ## Generate traceq local
@@ -295,7 +295,7 @@ vendor-check: gen-proto update-mod gen-traceql gen-parquet-query ## Keep up to d
 
 
 ### Tidy dependencies for tempo and tempo-serverless modules
-.PHONY: update-mod 
+.PHONY: update-mod
 update-mod: tools-update-mod ## Update module
 	go mod vendor
 	go mod tidy -e
@@ -359,7 +359,7 @@ drone: ## Run Drone targets
 	# piggyback on Loki's build image, this image contains a newer version of drone-cli than is
 	# released currently (1.4.0). The newer version of drone-clie keeps drone.yml human-readable.
 	# This will run 'make drone-jsonnet' from within the container
-	docker run -e DRONE_SERVER -e DRONE_TOKEN --rm -v $(shell pwd):/src/loki ${LOKI_BUILD_IMAGE} drone-jsonnet drone-signature
+	docker run -e DRONE_SERVER -e DRONE_TOKEN --rm -v $(shell pwd):/tools $(TOOLS_IMAGE):$(TOOLS_IMAGE_TAG) $(MAKE) drone-jsonnet drone-signature
 
 	drone lint .drone/drone.yml --trusted
 

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,3 +1,8 @@
+FROM golang:1.23.0-bookworm AS drone
+ARG TARGETARCH
+RUN curl -L "https://github.com/drone/drone-cli/releases/download/v1.7.0/drone_linux_$TARGETARCH".tar.gz | tar zx && \
+    install -t /usr/local/bin drone
+
 FROM golang:alpine
 
 ARG TARGETOS
@@ -7,6 +12,7 @@ RUN apk --update add --no-cache make git bash
 
 WORKDIR /tools
 COPY tools /tools
+COPY --from=drone /usr/local/bin/drone /usr/bin/drone
 RUN /tools/install.sh
 COPY tools/entrypoint.sh /bin/entrypoint.sh
 ENTRYPOINT [ "/bin/entrypoint.sh" ]

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb"
 	_ "github.com/psampaz/go-mod-outdated"
 	_ "golang.org/x/tools/cmd/goimports"
+	_ "golang.org/x/tools/cmd/goyacc"
 	_ "gotest.tools/gotestsum"
 	_ "mvdan.cc/gofumpt"
 )


### PR DESCRIPTION
**What this PR does**:

update tools image to include goyaac and drone-cli, 
also update go to 1.23 in the tools image, required to update go version in tempo.

once we have new image with these tools, we can stop using loki-build-image and move these commands to use our own build image.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`