### PR TITLE
Update Documentation for IPv6 Configuration in Grafana Tempo Ingester

### DIFF
--- a/docs/sources/tempo/configuration/network/ipv6.md
+++ b/docs/sources/tempo/configuration/network/ipv6.md
@@ -36,7 +36,6 @@ metrics_generator:
 
 ingester:
   lifecycler:
-    address: '::'
     enable_inet6: true
 
 server:


### PR DESCRIPTION
**What this PR does**: Removed address: '::' from ingester config.

**Which issue(s) this PR fixes**: The inclusion of the address: '::' parameter caused an issue where the expected addresses did not appear, and the curl command failed to work as intended.
Fixes #3981

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`