### PR TITLE
fix: use the builtin clear to clean the map of trace sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## main / unreleased
 
 * [ENHANCEMENT] Add bytes and spans received to usage stats [#3983](https://github.com/grafana/tempo/pull/3983) (@joe-elliott)
-
+* [BUGFIX] Use the builtin clear to clean the map of trace sizes [#3988](https://github.com/grafana/tempo/pull/3988) (@javiermolinar)
 # v2.6.0-rc.0
 
 * [CHANGE] **BREAKING CHANGE** Remove `autocomplete_filtering_enabled` feature flag [#3729](https://github.com/grafana/tempo/pull/3729) (@mapno)

--- a/modules/ingester/ingester.go
+++ b/modules/ingester/ingester.go
@@ -257,7 +257,7 @@ func (i *Ingester) PushBytesV2(ctx context.Context, req *tempopb.PushBytesReques
 		return nil, err
 	}
 
-	return instance.PushBytesRequest(ctx, req), nil
+	return instance.PushBytesRequest(req), nil
 }
 
 // FindTraceByID implements tempopb.Querier.f

--- a/modules/ingester/ingester_test.go
+++ b/modules/ingester/ingester_test.go
@@ -204,7 +204,7 @@ func TestWalDropsZeroLength(t *testing.T) {
 	}
 
 	// create new ingester. we should have no tenants b/c we all our wals should have been 0 length
-	ingester, _, _ = defaultIngesterWithPush(t, tmpDir, func(t testing.TB, i *Ingester, rs *v1.ResourceSpans, b []byte) {})
+	ingester, _, _ = defaultIngesterWithPush(t, tmpDir, func(_ testing.TB, _ *Ingester, _ *v1.ResourceSpans, _ []byte) {})
 	require.Equal(t, 0, len(ingester.instances))
 }
 
@@ -228,7 +228,7 @@ func TestSearchWAL(t *testing.T) {
 	require.NoError(t, err)
 
 	// push to instance
-	require.NoError(t, inst.PushBytes(context.Background(), id, b1))
+	require.NoError(t, inst.PushBytes(id, b1))
 
 	// Write wal
 	require.NoError(t, inst.CutCompleteTraces(0, true))
@@ -383,7 +383,7 @@ func TestDedicatedColumns(t *testing.T) {
 	require.NoError(t, err)
 
 	// push to instance
-	require.NoError(t, inst.PushBytes(context.Background(), id, b1))
+	require.NoError(t, inst.PushBytes(id, b1))
 
 	// Write wal
 	require.NoError(t, inst.CutCompleteTraces(0, true))

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -117,7 +117,7 @@ func newInstance(instanceID string, limiter *Limiter, overrides ingesterOverride
 	i := &instance{
 		traces: map[uint32]*liveTrace{},
 		// Keep tracks of the size of traces even after cutting them into the HeadBlock
-		// It is clean then the block is flushed to the backend
+		// It is cleaned then the block is flushed to the backend
 		traceSizes: map[uint32]uint32{},
 
 		instanceID:         instanceID,

--- a/modules/ingester/instance_search_test.go
+++ b/modules/ingester/instance_search_test.go
@@ -586,7 +586,7 @@ func writeTracesForSearch(t *testing.T, i *instance, spanName, tagKey, tagValue 
 		require.NoError(t, err)
 
 		// searchData will be nil if not
-		err = i.PushBytes(context.Background(), id, traceBytes)
+		err = i.PushBytes(id, traceBytes)
 		require.NoError(t, err)
 
 		assert.Equal(t, int(i.traceCount.Load()), len(i.traces))
@@ -654,7 +654,7 @@ func TestInstanceSearchDoesNotRace(t *testing.T) {
 		require.NoError(t, err)
 
 		// searchData will be nil if not
-		err = i.PushBytes(context.Background(), id, traceBytes)
+		err = i.PushBytes(id, traceBytes)
 		require.NoError(t, err)
 	})
 
@@ -743,7 +743,7 @@ func TestWALBlockDeletedDuringSearch(t *testing.T) {
 		traceBytes, err := dec.PrepareForWrite(trace, 0, 0)
 		require.NoError(t, err)
 
-		err = i.PushBytes(context.Background(), id, traceBytes)
+		err = i.PushBytes(id, traceBytes)
 		require.NoError(t, err)
 	}
 
@@ -794,7 +794,7 @@ func TestInstanceSearchMetrics(t *testing.T) {
 		traceBytes, err := dec.PrepareForWrite(trace, 0, 0)
 		require.NoError(t, err)
 
-		err = i.PushBytes(context.Background(), id, traceBytes)
+		err = i.PushBytes(id, traceBytes)
 		require.NoError(t, err)
 
 		assert.Equal(t, int(i.traceCount.Load()), len(i.traces))
@@ -869,7 +869,7 @@ func BenchmarkInstanceSearchUnderLoad(b *testing.B) {
 			require.NoError(b, err)
 
 			// searchData will be nil if not
-			err = i.PushBytes(context.Background(), id, traceBytes)
+			err = i.PushBytes(id, traceBytes)
 			require.NoError(b, err)
 
 			tracesPushed.Inc()

--- a/modules/ingester/trace.go
+++ b/modules/ingester/trace.go
@@ -1,7 +1,6 @@
 package ingester
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -31,7 +30,7 @@ func newTrace(traceID []byte, maxBytes int) *liveTrace {
 	}
 }
 
-func (t *liveTrace) Push(_ context.Context, instanceID string, trace []byte) error {
+func (t *liveTrace) Push(instanceID string, trace []byte) error {
 	t.lastAppend = time.Now()
 	if t.maxBytes != 0 {
 		reqSize := len(trace)

--- a/modules/ingester/trace_test.go
+++ b/modules/ingester/trace_test.go
@@ -1,7 +1,6 @@
 package ingester
 
 import (
-	"context"
 	"testing"
 
 	"github.com/grafana/tempo/pkg/model"
@@ -18,7 +17,7 @@ func TestTraceStartEndTime(t *testing.T) {
 	// initial push
 	buff, err := s.PrepareForWrite(&tempopb.Trace{}, 10, 20)
 	require.NoError(t, err)
-	err = tr.Push(context.Background(), "test", buff)
+	err = tr.Push("test", buff)
 	require.NoError(t, err)
 
 	assert.Equal(t, uint32(10), tr.start)
@@ -27,7 +26,7 @@ func TestTraceStartEndTime(t *testing.T) {
 	// overwrite start
 	buff, err = s.PrepareForWrite(&tempopb.Trace{}, 5, 15)
 	require.NoError(t, err)
-	err = tr.Push(context.Background(), "test", buff)
+	err = tr.Push("test", buff)
 	require.NoError(t, err)
 
 	assert.Equal(t, uint32(5), tr.start)
@@ -36,7 +35,7 @@ func TestTraceStartEndTime(t *testing.T) {
 	// overwrite end
 	buff, err = s.PrepareForWrite(&tempopb.Trace{}, 15, 25)
 	require.NoError(t, err)
-	err = tr.Push(context.Background(), "test", buff)
+	err = tr.Push("test", buff)
 	require.NoError(t, err)
 
 	assert.Equal(t, uint32(5), tr.start)


### PR DESCRIPTION
**What this PR does**:
Use the builtin clear to clean the map of trace sizes. Currently, we are allocating the current length of the map. This length therefore would continue growing.

The context was not being used so I've removed it as well.



**Checklist**
- [X] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`