### PR TITLE
Frontend cleanup and perf improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [ENHANCEMENT] TraceQL: Attribute iterators collect matched array values [#3867](https://github.com/grafana/tempo/pull/3867) (@electron0zero, @stoewer)
 * [ENHANCEMENT] Add bytes and spans received to usage stats [#3983](https://github.com/grafana/tempo/pull/3983) (@joe-elliott)
 * [ENHANCEMENT] Prevent massive allocations in the frontend if there is not sufficient pressure from the query pipeline. [#3996](https://github.com/grafana/tempo/pull/3996) (@joe-elliott)
+  **BREAKING CHANGE** Removed `querier_forget_delay` setting from the frontend. This configuration option did nothing.
 
 # v2.6.0-rc.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [ENHANCEMENT] TraceQL: Attribute iterators collect matched array values [#3867](https://github.com/grafana/tempo/pull/3867) (@electron0zero, @stoewer)
 * [ENHANCEMENT] Add bytes and spans received to usage stats [#3983](https://github.com/grafana/tempo/pull/3983) (@joe-elliott)
+* [ENHANCEMENT] Prevent massive allocations in the frontend if there is not sufficient pressure from the query pipeline. [#3996](https://github.com/grafana/tempo/pull/3996) (@joe-elliott)
 
 # v2.6.0-rc.0
 

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -364,7 +364,7 @@ func (t *App) initQuerier() (services.Service, error) {
 func (t *App) initQueryFrontend() (services.Service, error) {
 	// cortexTripper is a bridge between http and httpgrpc.
 	// It does the job of passing data to the cortex frontend code.
-	cortexTripper, v1, err := frontend.InitFrontend(t.cfg.Frontend.Config, frontend.CortexNoQuerierLimits{}, log.Logger, prometheus.DefaultRegisterer)
+	cortexTripper, v1, err := frontend.InitFrontend(t.cfg.Frontend.Config, log.Logger, prometheus.DefaultRegisterer)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -294,7 +294,6 @@ querier:
     query_relevant_ingesters: false
 query_frontend:
     max_outstanding_per_tenant: 2000
-    querier_forget_delay: 0s
     max_batch_size: 5
     log_query_request_headers: ""
     max_retries: 2

--- a/modules/frontend/config.go
+++ b/modules/frontend/config.go
@@ -103,19 +103,15 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {
 
 type CortexNoQuerierLimits struct{}
 
-var _ v1.Limits = (*CortexNoQuerierLimits)(nil)
-
-func (CortexNoQuerierLimits) MaxQueriersPerUser(string) int { return 0 }
-
 // InitFrontend initializes V1 frontend
 //
 // Returned RoundTripper can be wrapped in more round-tripper middlewares, and then eventually registered
 // into HTTP server using the Handler from this package. Returned RoundTripper is always non-nil
 // (if there are no errors), and it uses the returned frontend (if any).
-func InitFrontend(cfg v1.Config, limits v1.Limits, log log.Logger, reg prometheus.Registerer) (http.RoundTripper, *v1.Frontend, error) {
+func InitFrontend(cfg v1.Config, log log.Logger, reg prometheus.Registerer) (http.RoundTripper, *v1.Frontend, error) {
 	statVersion.Set("v1")
 	// No scheduler = use original frontend.
-	fr, err := v1.New(cfg, limits, log, reg)
+	fr, err := v1.New(cfg, log, reg)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/modules/frontend/queue/queue_test.go
+++ b/modules/frontend/queue/queue_test.go
@@ -37,7 +37,7 @@ func TestGetNextForQuerierOneUser(t *testing.T) {
 	close(start)
 
 	for j := 0; j < messages; j++ {
-		err := q.EnqueueRequest("test", &mockRequest{}, 0)
+		err := q.EnqueueRequest("test", &mockRequest{})
 		require.NoError(t, err)
 	}
 
@@ -65,7 +65,7 @@ func TestGetNextForQuerierRandomUsers(t *testing.T) {
 	close(start)
 
 	for j := 0; j < messages; j++ {
-		err := q.EnqueueRequest(test.RandomString(), &mockRequest{}, 0)
+		err := q.EnqueueRequest(test.RandomString(), &mockRequest{})
 		require.NoError(t, err)
 	}
 
@@ -93,7 +93,7 @@ func TestGetNextBatches(t *testing.T) {
 	close(start)
 
 	for j := 0; j < messages; j++ {
-		err := q.EnqueueRequest("user", &mockRequest{}, 0)
+		err := q.EnqueueRequest("user", &mockRequest{})
 		require.NoError(t, err)
 	}
 
@@ -136,7 +136,7 @@ func benchmarkGetNextForQuerier(b *testing.B, listeners int, messages int) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < messages; j++ {
-			err := q.EnqueueRequest(user, req, 0)
+			err := q.EnqueueRequest(user, req)
 			if err != nil {
 				panic(err)
 			}
@@ -160,7 +160,7 @@ func queueWithListeners(ctx context.Context, listeners int, batchSize int, liste
 		Name: "test_discarded",
 	}, []string{"user"})
 
-	q := NewRequestQueue(100_000, 0, g, c)
+	q := NewRequestQueue(100_000, g, c)
 	start := make(chan struct{})
 
 	for i := 0; i < listeners; i++ {
@@ -184,49 +184,12 @@ func queueWithListeners(ctx context.Context, listeners int, batchSize int, liste
 		}()
 	}
 
+	err := services.StartAndAwaitRunning(context.Background(), q)
+	if err != nil {
+		panic(err)
+	}
+
 	return q, start
-}
-
-func TestRequestQueue_GetNextRequestForQuerier_ShouldGetRequestAfterReshardingBecauseQuerierHasBeenForgotten(t *testing.T) {
-	const forgetDelay = 3 * time.Second
-
-	queue := NewRequestQueue(1, forgetDelay,
-		prometheus.NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
-		prometheus.NewCounterVec(prometheus.CounterOpts{}, []string{"user"}))
-
-	// Start the queue service.
-	ctx := context.Background()
-	require.NoError(t, services.StartAndAwaitRunning(ctx, queue))
-	t.Cleanup(func() {
-		require.NoError(t, services.StopAndAwaitTerminated(ctx, queue))
-	})
-
-	// Two queriers connect.
-	queue.RegisterQuerierConnection("querier-1")
-	queue.RegisterQuerierConnection("querier-2")
-
-	// Querier-2 waits for a new request.
-	querier2wg := sync.WaitGroup{}
-	querier2wg.Add(1)
-	go func() {
-		defer querier2wg.Done()
-		_, _, err := queue.GetNextRequestForQuerier(ctx, FirstUser(), "querier-2", make([]Request, 1))
-		require.NoError(t, err)
-	}()
-
-	// Querier-1 crashes (no graceful shutdown notification).
-	queue.UnregisterQuerierConnection("querier-1")
-
-	// Enqueue a request from an user which would be assigned to querier-1.
-	// NOTE: "user-1" hash falls in the querier-1 shard.
-	require.NoError(t, queue.EnqueueRequest("user-1", "request", 1))
-
-	startTime := time.Now()
-	querier2wg.Wait()
-	waitTime := time.Since(startTime)
-
-	// We expect that querier-2 got the request only after querier-1 forget delay is passed.
-	assert.GreaterOrEqual(t, waitTime.Milliseconds(), forgetDelay.Milliseconds())
 }
 
 func TestContextCond(t *testing.T) {

--- a/modules/frontend/queue/queue_test.go
+++ b/modules/frontend/queue/queue_test.go
@@ -173,7 +173,7 @@ func queueWithListeners(ctx context.Context, listeners int, batchSize int, liste
 
 			batchBuffer := make([]Request, batchSize)
 			for {
-				r, last, err = q.GetNextRequestForQuerier(ctx, last, "", batchBuffer)
+				r, last, err = q.GetNextRequestForQuerier(ctx, last, batchBuffer)
 				if err != nil {
 					return
 				}

--- a/modules/frontend/queue/user_queues.go
+++ b/modules/frontend/queue/user_queues.go
@@ -1,25 +1,5 @@
 package queue
 
-import (
-	"math/rand"
-	"sort"
-	"time"
-
-	"github.com/grafana/dskit/ring/shard"
-)
-
-// querier holds information about a querier registered in the queue.
-type querier struct {
-	// Number of active connections.
-	connections int
-
-	// True if the querier notified it's gracefully shutting down.
-	shuttingDown bool
-
-	// When the last connection has been unregistered.
-	disconnectedAt time.Time
-}
-
 // This struct holds user queues for pending requests. It also keeps track of connected queriers,
 // and mapping between users and queriers.
 type queues struct {
@@ -31,42 +11,20 @@ type queues struct {
 	users []string
 
 	maxUserQueueSize int
-
-	// How long to wait before removing a querier which has got disconnected
-	// but hasn't notified about a graceful shutdown.
-	forgetDelay time.Duration
-
-	// Tracks queriers registered to the queue.
-	queriers map[string]*querier
-
-	// Sorted list of querier names, used when creating per-user shard.
-	sortedQueriers []string
 }
 
 type userQueue struct {
 	ch chan Request
 
-	// If not nil, only these queriers can handle user requests. If nil, all queriers can.
-	// We set this to nil if number of available queriers <= maxQueriers.
-	queriers    map[string]struct{}
-	maxQueriers int
-
-	// Seed for shuffle sharding of queriers. This seed is based on userID only and is therefore consistent
-	// between different frontends.
-	seed int64
-
 	// Points back to 'users' field in queues. Enables quick cleanup.
 	index int
 }
 
-func newUserQueues(maxUserQueueSize int, forgetDelay time.Duration) *queues {
+func newUserQueues(maxUserQueueSize int) *queues {
 	return &queues{
 		userQueues:       map[string]*userQueue{},
 		users:            nil,
 		maxUserQueueSize: maxUserQueueSize,
-		forgetDelay:      forgetDelay,
-		queriers:         map[string]*querier{},
-		sortedQueriers:   nil,
 	}
 }
 
@@ -93,14 +51,10 @@ func (q *queues) deleteQueue(userID string) {
 // MaxQueriers is used to compute which queriers should handle requests for this user.
 // If maxQueriers is <= 0, all queriers can handle this user's requests.
 // If maxQueriers has changed since the last call, queriers for this are recomputed.
-func (q *queues) getOrAddQueue(userID string, maxQueriers int) chan Request {
+func (q *queues) getOrAddQueue(userID string) chan Request {
 	// Empty user is not allowed, as that would break our users list ("" is used for free spot).
 	if userID == "" {
 		return nil
-	}
-
-	if maxQueriers < 0 {
-		maxQueriers = 0
 	}
 
 	uq := q.userQueues[userID]
@@ -108,7 +62,6 @@ func (q *queues) getOrAddQueue(userID string, maxQueriers int) chan Request {
 	if uq == nil {
 		uq = &userQueue{
 			ch:    make(chan Request, q.maxUserQueueSize),
-			seed:  shard.ShuffleShardSeed(userID, ""),
 			index: -1,
 		}
 		q.userQueues[userID] = uq
@@ -127,11 +80,6 @@ func (q *queues) getOrAddQueue(userID string, maxQueriers int) chan Request {
 			uq.index = len(q.users)
 			q.users = append(q.users, userID)
 		}
-	}
-
-	if uq.maxQueriers != maxQueriers {
-		uq.maxQueriers = maxQueriers
-		uq.queriers = shuffleQueriersForUser(uq.seed, maxQueriers, q.sortedQueriers, nil)
 	}
 
 	return uq.ch
@@ -159,13 +107,6 @@ func (q *queues) getNextQueueForQuerier(lastUserIndex int, querierID string) (ch
 
 		q := q.userQueues[u]
 
-		if q.queriers != nil {
-			if _, ok := q.queriers[querierID]; !ok {
-				// This querier is not handling the user.
-				continue
-			}
-		}
-
 		if len(q.ch) == 0 {
 			continue
 		}
@@ -173,137 +114,4 @@ func (q *queues) getNextQueueForQuerier(lastUserIndex int, querierID string) (ch
 		return q.ch, u, uid
 	}
 	return nil, "", uid
-}
-
-func (q *queues) addQuerierConnection(querierID string) {
-	info := q.queriers[querierID]
-	if info != nil {
-		info.connections++
-
-		// Reset in case the querier re-connected while it was in the forget waiting period.
-		info.shuttingDown = false
-		info.disconnectedAt = time.Time{}
-
-		return
-	}
-
-	// First connection from this querier.
-	q.queriers[querierID] = &querier{connections: 1}
-	q.sortedQueriers = append(q.sortedQueriers, querierID)
-	sort.Strings(q.sortedQueriers)
-
-	q.recomputeUserQueriers()
-}
-
-func (q *queues) removeQuerierConnection(querierID string, now time.Time) {
-	info := q.queriers[querierID]
-	if info == nil || info.connections <= 0 {
-		panic("unexpected number of connections for querier")
-	}
-
-	// Decrease the number of active connections.
-	info.connections--
-	if info.connections > 0 {
-		return
-	}
-
-	// There no more active connections. If the forget delay is configured then
-	// we can remove it only if querier has announced a graceful shutdown.
-	if info.shuttingDown || q.forgetDelay == 0 {
-		q.removeQuerier(querierID)
-		return
-	}
-
-	// No graceful shutdown has been notified yet, so we should track the current time
-	// so that we'll remove the querier as soon as we receive the graceful shutdown
-	// notification (if any) or once the threshold expires.
-	info.disconnectedAt = now
-}
-
-func (q *queues) removeQuerier(querierID string) {
-	delete(q.queriers, querierID)
-
-	ix := sort.SearchStrings(q.sortedQueriers, querierID)
-	if ix >= len(q.sortedQueriers) || q.sortedQueriers[ix] != querierID {
-		panic("incorrect state of sorted queriers")
-	}
-
-	q.sortedQueriers = append(q.sortedQueriers[:ix], q.sortedQueriers[ix+1:]...)
-
-	q.recomputeUserQueriers()
-}
-
-// notifyQuerierShutdown records that a querier has sent notification about a graceful shutdown.
-func (q *queues) notifyQuerierShutdown(querierID string) {
-	info := q.queriers[querierID]
-	if info == nil {
-		// The querier may have already been removed, so we just ignore it.
-		return
-	}
-
-	// If there are no more connections, we should remove the querier.
-	if info.connections == 0 {
-		q.removeQuerier(querierID)
-		return
-	}
-
-	// Otherwise we should annotate we received a graceful shutdown notification
-	// and the querier will be removed once all connections are unregistered.
-	info.shuttingDown = true
-}
-
-// forgetDisconnectedQueriers removes all disconnected queriers that have gone since at least
-// the forget delay. Returns the number of forgotten queriers.
-func (q *queues) forgetDisconnectedQueriers(now time.Time) int {
-	// Nothing to do if the forget delay is disabled.
-	if q.forgetDelay == 0 {
-		return 0
-	}
-
-	// Remove all queriers with no connections that have gone since at least the forget delay.
-	threshold := now.Add(-q.forgetDelay)
-	forgotten := 0
-
-	for querierID := range q.queriers {
-		if info := q.queriers[querierID]; info.connections == 0 && info.disconnectedAt.Before(threshold) {
-			q.removeQuerier(querierID)
-			forgotten++
-		}
-	}
-
-	return forgotten
-}
-
-func (q *queues) recomputeUserQueriers() {
-	scratchpad := make([]string, 0, len(q.sortedQueriers))
-
-	for _, uq := range q.userQueues {
-		uq.queriers = shuffleQueriersForUser(uq.seed, uq.maxQueriers, q.sortedQueriers, scratchpad)
-	}
-}
-
-// shuffleQueriersForUser returns nil if queriersToSelect is 0 or there are not enough queriers to select from.
-// In that case *all* queriers should be used.
-// Scratchpad is used for shuffling, to avoid new allocations. If nil, new slice is allocated.
-func shuffleQueriersForUser(userSeed int64, queriersToSelect int, allSortedQueriers []string, scratchpad []string) map[string]struct{} {
-	if queriersToSelect == 0 || len(allSortedQueriers) <= queriersToSelect {
-		return nil
-	}
-
-	result := make(map[string]struct{}, queriersToSelect)
-	rnd := rand.New(rand.NewSource(userSeed))
-
-	scratchpad = scratchpad[:0]
-	scratchpad = append(scratchpad, allSortedQueriers...)
-
-	last := len(scratchpad) - 1
-	for i := 0; i < queriersToSelect; i++ {
-		r := rnd.Intn(last + 1)
-		result[scratchpad[r]] = struct{}{}
-		// move selected item to the end, it won't be selected anymore.
-		scratchpad[r], scratchpad[last] = scratchpad[last], scratchpad[r]
-		last--
-	}
-
-	return result
 }

--- a/modules/frontend/queue/user_queues.go
+++ b/modules/frontend/queue/user_queues.go
@@ -166,6 +166,10 @@ func (q *queues) getNextQueueForQuerier(lastUserIndex int, querierID string) (ch
 			}
 		}
 
+		if len(q.ch) == 0 {
+			continue
+		}
+
 		return q.ch, u, uid
 	}
 	return nil, "", uid


### PR DESCRIPTION
**What this PR does**:
This PR cleans up unused code that Tempo inherited that allows the configuration of the max number of queriers a tenant has access to. This code is complicating attempts to improve this element of the frontend. It is currently unused and not even usable.

Additionally, I've moved the clean up of user queues to a timer. This prevents "flapping" of user queue creation/deletion. Currently, we delete the queue if we [notice it has 0 jobs](https://github.com/grafana/tempo/blob/8a0b0e72a0db8374152333b1a7401d184face9e0/modules/frontend/queue/queue.go#L182-L185). This requires us to over provision go routines to shove jobs into the queue to prevent it from being constantly recreated. This PR should allow us to reduce the number of goroutines used to put pressure on the [user queues lock](https://github.com/grafana/tempo/blob/8a0b0e72a0db8374152333b1a7401d184face9e0/modules/frontend/queue/queue.go#L148-L157) and achieve the same query performance. 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`