### PR TITLE
feat: update distributed docker compose example to serve TraceQL metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [ENHANCEMENT] Add bytes and spans received to usage stats [#3983](https://github.com/grafana/tempo/pull/3983) (@joe-elliott)
 * [ENHANCEMENT] Prevent massive allocations in the frontend if there is not sufficient pressure from the query pipeline. [#3996](https://github.com/grafana/tempo/pull/3996) (@joe-elliott)
   **BREAKING CHANGE** Removed `querier_forget_delay` setting from the frontend. This configuration option did nothing.
+* [ENHANCEMENT] Update metrics-generator config in Tempo distributed docker compose example to serve TraceQL metrics [#4003](https://github.com/grafana/tempo/pull/4003) (@javiermolinar)
 
 # v2.6.0-rc.0
 

--- a/example/docker-compose/distributed/tempo-distributed.yaml
+++ b/example/docker-compose/distributed/tempo-distributed.yaml
@@ -45,6 +45,8 @@ metrics_generator:
     remote_write:
       - url: http://prometheus:9090/api/v1/write
         send_exemplars: true
+  traces_storage:
+    path: /var/tempo/generator/traces
 
 storage:
   trace:
@@ -63,4 +65,5 @@ storage:
 overrides:
   defaults:
     metrics_generator:
-      processors: ['service-graphs', 'span-metrics']
+      processors: ['service-graphs', 'span-metrics', 'local-blocks']
+      generate_native_histograms: both


### PR DESCRIPTION
**What this PR does**:
It updates Tempo metrics-generator configuration in the distributed example to serves TraceQL metrics

**Checklist**
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`