### PR TITLE
consistnent cache names in config and log line

### DIFF
--- a/tempodb/backend/cache/cache.go
+++ b/tempodb/backend/cache/cache.go
@@ -53,12 +53,12 @@ func NewCache(cfgBloom *BloomConfig, nextReader backend.RawReader, nextWriter ba
 	}
 
 	level.Info(logger).Log("msg", "caches available to storage backend",
-		"footer", rw.footerCache != nil,
-		"bloom", rw.bloomCache != nil,
-		"offset_idx", rw.offsetIdxCache != nil,
-		"column_idx", rw.columnIdxCache != nil,
-		"trace_id_idx", rw.traceIDIdxCache != nil,
-		"page", rw.pageCache != nil,
+		cache.RoleParquetFooter, rw.footerCache != nil,
+		cache.RoleBloom, rw.bloomCache != nil,
+		cache.RoleParquetOffsetIdx, rw.offsetIdxCache != nil,
+		cache.RoleParquetColumnIdx, rw.columnIdxCache != nil,
+		cache.RoleTraceIDIdx, rw.traceIDIdxCache != nil,
+		cache.RoleParquetPage, rw.pageCache != nil,
 	)
 
 	return rw, rw, nil


### PR DESCRIPTION
**What this PR does**:

use the same cache name in the log line as the cache roles in config, some users are using this log line to see if the cache config is picked up correctly and find this difference [confusing](https://github.com/grafana/tempo/discussions/3553#discussioncomment-10453202)

use the same names to avid the confusion.

old log line looked something like `"caches available to storage backend" footer=true bloom=true offset_idx=false column_idx=false trace_id_idx=false page=false`

updated log line looks like `"caches available to storage backend" parquet-footer=true bloom=true parquet-offset-idx=false parquet-column-idx=false trace-id-index=false parquet-page=false`


frontend cache is configured in frontend, and is logged correctly like `"init frontend cache" role=frontend-search enabled=true`

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`