### PR TITLE
[cli] add jsonnet support to analyse blocks

### DIFF
--- a/cmd/tempo-cli/cmd-analyse-block.go
+++ b/cmd/tempo-cli/cmd-analyse-block.go
@@ -165,6 +165,7 @@ func processBlock(r backend.Reader, tenantID, blockID string, maxStartTime, minS
 	// merge dedicated with span attributes
 	for k, v := range spanDedicatedSummary.attributes {
 		spanAttrsSummary.attributes[k] = v
+		spanAttrsSummary.dedicated[k] = struct{}{}
 	}
 	spanAttrsSummary.totalBytes += spanDedicatedSummary.totalBytes
 
@@ -215,6 +216,7 @@ func (s *blockSummary) print(maxAttr int, generateJsonnet bool) error {
 type genericAttrSummary struct {
 	totalBytes uint64
 	attributes map[string]uint64 // key: attribute name, value: total bytes
+	dedicated  map[string]struct{}
 }
 
 type attribute struct {
@@ -262,6 +264,7 @@ func aggregateAttributes(pf *parquet.File, keyPath string, valuePaths []string) 
 	return genericAttrSummary{
 		totalBytes: totalBytes,
 		attributes: attrMap,
+		dedicated:  make(map[string]struct{}),
 	}, nil
 }
 
@@ -282,7 +285,7 @@ func aggregateDedicatedColumns(pf *parquet.File, scope backend.DedicatedColumnSc
 		}
 		i++
 
-		attrMap["dedicated: "+dedColumn.Name] = sz
+		attrMap[dedColumn.Name] = sz
 		totalBytes += sz
 	}
 
@@ -331,8 +334,14 @@ func printSummary(scope string, max int, summary genericAttrSummary) error {
 	fmt.Printf("Top %d %s attributes by size\n", max, scope)
 	attrList := topN(max, summary.attributes)
 	for _, a := range attrList {
+
+		name := a.name
+		if _, ok := summary.dedicated[a.name]; !ok {
+			name = a.name + " (dedicated)"
+		}
+
 		percentage := float64(a.bytes) / float64(summary.totalBytes) * 100
-		_, err := fmt.Fprintf(w, "name: %s\t size: %s\t (%s%%)\n", a.name, humanize.Bytes(a.bytes), strconv.FormatFloat(percentage, 'f', 2, 64))
+		_, err := fmt.Fprintf(w, "name: %s\t size: %s\t (%s%%)\n", name, humanize.Bytes(a.bytes), strconv.FormatFloat(percentage, 'f', 2, 64))
 		if err != nil {
 			return err
 		}

--- a/cmd/tempo-cli/cmd-analyse-blocks.go
+++ b/cmd/tempo-cli/cmd-analyse-blocks.go
@@ -13,6 +13,7 @@ import (
 type analyseBlocksCmd struct {
 	backendOptions
 
+	Jsonnet            bool   `help:"output jsonnet nexessary for overrides"`
 	TenantID           string `arg:"" help:"tenant-id within the bucket"`
 	MinCompactionLevel int    `help:"Min compaction level to analyse" default:"3"`
 	MaxBlocks          int    `help:"Max number of blocks to analyse" default:"10"`
@@ -100,5 +101,5 @@ func (cmd *analyseBlocksCmd) Run(ctx *globalOptions) error {
 			totalBytes: totalResourceBytes,
 			attributes: topResourceAttrs,
 		},
-	}).print(cmd.NumAttr, false)
+	}).print(cmd.NumAttr, cmd.Jsonnet)
 }

--- a/cmd/tempo-cli/cmd-analyse-blocks.go
+++ b/cmd/tempo-cli/cmd-analyse-blocks.go
@@ -13,7 +13,7 @@ import (
 type analyseBlocksCmd struct {
 	backendOptions
 
-	Jsonnet            bool   `help:"output jsonnet nexessary for overrides"`
+	Jsonnet            bool   `help:"output Jsonnet necessary for overrides"`
 	TenantID           string `arg:"" help:"tenant-id within the bucket"`
 	MinCompactionLevel int    `help:"Min compaction level to analyse" default:"3"`
 	MaxBlocks          int    `help:"Max number of blocks to analyse" default:"10"`


### PR DESCRIPTION
**What this PR does**:

Add `--jsonnet` flag to enable writing output for `analyse blocks` with jsonnet support.  This makes for easy updates.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`