### PR TITLE
docs: mark serverless as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## main / unreleased
+* [CHANGE] **BREAKING CHANGE** The Tempo serverless is now deprecated and will be removed in an upcoming release [#4017](https://github.com/grafana/tempo/pull/4017/) @electron0zero
 * [CHANGE] **BREAKING CHANGE** Change the AWS Lambda serverless build tooling output from "main" to "bootstrap". Refer to https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/ for migration steps [#3852](https://github.com/grafana/tempo/pull/3852) (@zatlodan)
 * [CHANGE] Add throughput and SLO metrics in the tags and tag values endpoints [#4148](https://github.com/grafana/tempo/pull/4148) (@electron0zero)
 * [CHANGE] tempo-cli: add support for /api/v2/traces endpoint [#4127](https://github.com/grafana/tempo/pull/4127) (@electron0zero)

--- a/cmd/tempo-serverless/readme.md
+++ b/cmd/tempo-serverless/readme.md
@@ -1,5 +1,7 @@
 # tempo-serverless
 
+## NOTE: The Tempo serverless is now deprecated and will be removed in an upcoming release.
+
 This folder is intended to wrap a simple handler for searching backend storage for traces. Subfolders 
 `./cloud-run` and `./lambda` contain specific code necessary to run this handler in the respective
 environments.

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -739,6 +739,7 @@ querier:
         # Timeout for search requests
         [query_timeout: <duration> | default = 30s]
 
+        # NOTE: The Tempo serverless feature is now deprecated and will be removed in an upcoming release.
         # A list of external endpoints that the querier will use to offload backend search requests. They must
         # take and return the same value as /api/search endpoint on the querier. This is intended to be
         # used with serverless technologies for massive parallelization of the search path.

--- a/docs/sources/tempo/operations/backend_search.md
+++ b/docs/sources/tempo/operations/backend_search.md
@@ -113,6 +113,10 @@ querier:
 
 With serverless technologies:
 
+{{< admonition type="caution" >}}
+The Tempo serverless feature is now deprecated and will be removed in an upcoming release.
+{{< /admonition >}}
+
 {{< admonition type="note" >}}
 Serverless can be a nice way to reduce cost by using it as spare query capacity.
 However, serverless tends to have higher variance then simply allowing the queriers to perform the searches themselves.
@@ -171,6 +175,10 @@ query_frontend:
 ```
 
 ### Serverless environment
+
+{{< admonition type="caution" >}}
+The Tempo serverless feature is now deprecated and will be removed in an upcoming release.
+{{< /admonition >}}
 
 Serverless isn't required, but with larger loads, serverless can be used to reduce costs.
 Tempo has support for Google Cloud Run and AWS Lambda.

--- a/docs/sources/tempo/operations/serverless_aws.md
+++ b/docs/sources/tempo/operations/serverless_aws.md
@@ -9,6 +9,10 @@ weight: 95
 
 # Search with AWS Lambda
 
+{{< admonition type="caution" >}}
+The Tempo serverless feature is now deprecated and will be removed in an upcoming release.
+{{< /admonition >}}
+
 This document explains how to set up AWS Lambda for serverless backend search.
 Read [improve search performance]({{< relref "./backend_search" >}}) for more guidance on configuration options for backend search.
 

--- a/docs/sources/tempo/operations/serverless_gcp.md
+++ b/docs/sources/tempo/operations/serverless_gcp.md
@@ -9,6 +9,10 @@ alias:
 
 # Search with Google Cloud Run
 
+{{< admonition type="caution" >}}
+The Tempo serverless feature is now deprecated and will be removed in an upcoming release.
+{{< /admonition >}}
+
 This document walks you through setting up a Google Cloud Run for serverless backend search.
 For more guidance on configuration options for full backend search [check here]({{< relref "./backend_search" >}}).
 


### PR DESCRIPTION
**What this PR does**:
we are deprecating serverless, so mark it as deprecated in the tempo docs

**Which issue(s) this PR fixes**:
we are discussing it in https://github.com/grafana/tempo/issues/4014

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`