### PR TITLE
Generator remote write update handling of X-Scope-OrgID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [CHANGE] **BREAKING CHANGE** The dynamic injection of X-Scope-OrgID header for metrics generator remote-writes is changed. If the header is aleady set in per-tenant overrides or global tempo configuration, then it is honored and not overwritten. [#4021](https://github.com/grafana/tempo/pull/4021) (@mdisibio)
 * [FEATURE] Discarded span logging `log_discarded_spans` [#3957](https://github.com/grafana/tempo/issues/3957) (@dastrobu)
 * [ENHANCEMENT] TraceQL: Attribute iterators collect matched array values [#3867](https://github.com/grafana/tempo/pull/3867) (@electron0zero, @stoewer)
 * [ENHANCEMENT] Allow returning partial traces that exceed the MaxBytes limit for V2 [#3941](https://github.com/grafana/tempo/pull/3941) (@javiermolinar)

--- a/modules/generator/storage/config_util.go
+++ b/modules/generator/storage/config_util.go
@@ -32,7 +32,7 @@ func generateTenantRemoteWriteConfigs(inputs []prometheus_config.RemoteWriteConf
 		if tenant != util.FakeTenantID && addOrgIDHeader {
 			existing := ""
 			for k, v := range output.Headers {
-				if strings.EqualFold(user.OrgIDHeaderName, k) {
+				if strings.EqualFold(user.OrgIDHeaderName, strings.TrimSpace(k)) {
 					existing = v
 					break
 				}

--- a/modules/generator/storage/config_util.go
+++ b/modules/generator/storage/config_util.go
@@ -13,43 +13,51 @@ import (
 
 // generateTenantRemoteWriteConfigs creates a copy of the remote write configurations with the
 // X-Scope-OrgID header present for the given tenant, unless Tempo is run in single tenant mode or instructed not to add X-Scope-OrgID header.
-func generateTenantRemoteWriteConfigs(originalCfgs []prometheus_config.RemoteWriteConfig, tenant string, headers map[string]string, addOrgIDHeader bool, logger log.Logger, sendNativeHistograms bool) []*prometheus_config.RemoteWriteConfig {
-	var cloneCfgs []*prometheus_config.RemoteWriteConfig
+func generateTenantRemoteWriteConfigs(inputs []prometheus_config.RemoteWriteConfig, tenant string, headers map[string]string, addOrgIDHeader bool, logger log.Logger, sendNativeHistograms bool) []*prometheus_config.RemoteWriteConfig {
+	var outputs []*prometheus_config.RemoteWriteConfig
 
-	for _, originalCfg := range originalCfgs {
-		cloneCfg := &prometheus_config.RemoteWriteConfig{}
-		*cloneCfg = originalCfg
+	for _, input := range inputs {
+		output := &prometheus_config.RemoteWriteConfig{}
+		*output = input
+
+		// Copy headers so we can modify them
+		output.Headers = copyMap(output.Headers)
+
+		// Inject/overwrite custom headers from runtime overrides
+		for k, v := range headers {
+			output.Headers[k] = v
+		}
 
 		// Inject/overwrite X-Scope-OrgID header in multi-tenant setups
 		if tenant != util.FakeTenantID && addOrgIDHeader {
-			// Copy headers so we can modify them
-			cloneCfg.Headers = copyMap(cloneCfg.Headers)
-
-			// Ensure that no variation of the X-Scope-OrgId header can be added, which might trick authentication
-			for k, v := range cloneCfg.Headers {
-				if strings.EqualFold(user.OrgIDHeaderName, strings.TrimSpace(k)) {
-					level.Warn(logger).Log("msg", "discarding X-Scope-OrgId header", "key", k, "value", v)
-					delete(cloneCfg.Headers, k)
+			existing := ""
+			for k, v := range output.Headers {
+				if strings.EqualFold(user.OrgIDHeaderName, k) {
+					existing = v
+					break
 				}
 			}
 
-			cloneCfg.Headers[user.OrgIDHeaderName] = tenant
+			if existing == "" {
+				output.Headers[user.OrgIDHeaderName] = tenant
+			} else {
+				// Remote write config already contains the header, so we don't overwrite it.
+				level.Warn(logger).Log("msg", "underlying remote write already contains X-Scope-OrgId header, not applying new value",
+					"remoteWriteName", input.Name,
+					"remoteWriteURL", input.URL,
+					"existing", existing,
+					"new", tenant)
+			}
 		}
 
-		// Inject/overwrite custom headers
-		// Caution! This can overwrite the X-Scope-OrgID header
-		for k, v := range headers {
-			cloneCfg.Headers[k] = v
-		}
-
-		cloneCfg.SendNativeHistograms = sendNativeHistograms
+		output.SendNativeHistograms = sendNativeHistograms
 		// TODO: enable exemplars
 		// cloneCfg.SendExemplars = sendExemplars
 
-		cloneCfgs = append(cloneCfgs, cloneCfg)
+		outputs = append(outputs, output)
 	}
 
-	return cloneCfgs
+	return outputs
 }
 
 // copyMap creates a new map containing all values from the given map.

--- a/modules/generator/storage/config_util.go
+++ b/modules/generator/storage/config_util.go
@@ -28,7 +28,7 @@ func generateTenantRemoteWriteConfigs(inputs []prometheus_config.RemoteWriteConf
 			output.Headers[k] = v
 		}
 
-		// Inject/overwrite X-Scope-OrgID header in multi-tenant setups
+		// Inject X-Scope-OrgID header in multi-tenant setups if not set already
 		if tenant != util.FakeTenantID && addOrgIDHeader {
 			existing := ""
 			for k, v := range output.Headers {

--- a/modules/generator/storage/config_util_test.go
+++ b/modules/generator/storage/config_util_test.go
@@ -34,13 +34,16 @@ func Test_generateTenantRemoteWriteConfigs(t *testing.T) {
 
 	result := generateTenantRemoteWriteConfigs(original, "my-tenant", nil, addOrgIDHeader, logger, false)
 
+	// First case doesn't have a header, gets set.
 	assert.Equal(t, original[0].URL, result[0].URL)
 	assert.Equal(t, map[string]string{}, original[0].Headers, "Original headers have been modified")
 	assert.Equal(t, map[string]string{"X-Scope-OrgID": "my-tenant"}, result[0].Headers)
 
+	// Second case already contains header, not overwritten
+	// Also checks case-insensitivity
 	assert.Equal(t, original[1].URL, result[1].URL)
 	assert.Equal(t, map[string]string{"foo": "bar", "x-scope-orgid": "fake-tenant"}, original[1].Headers, "Original headers have been modified")
-	assert.Equal(t, map[string]string{"foo": "bar", "X-Scope-OrgID": "my-tenant"}, result[1].Headers)
+	assert.Equal(t, map[string]string{"foo": "bar", "x-scope-orgid": "fake-tenant"}, result[1].Headers, "Existing header was incorrectly overwritten")
 }
 
 func Test_generateTenantRemoteWriteConfigs_singleTenant(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:
This PR changes the header precedence in Generator remote write, so that statically configured X-Scope-OrgID is honored. This change is necessary to unlock a use case that is currently not possible.  Will do my best to explain.  The desired behavior is to have a setup like this:
* 2 remote write targets with different headers and auth:
  * remote write target A:
    * The usual setup:
    * dynamically set X-Scope-OrgID header == tenant ID
  * remote write target B:
    * statically configured X-Scope-OrgID (we want to target a fixed metrics tenant)
    * Dynamically injected metrics label with the tenant ID like `{__id__="<tenantid>"}`

Target B doesn't work currently because the logic gives highest precedence to dynamically set X-Scope-OrgID.  The statically configured header is deleted and a warning logged.

This logic was inherited and designed to protect against broken authentication, but after review it doesn't seem a compelling use case.  Remote write headers can be set in two locations:

1. In the global config:
```yaml
metrics_generator:
  storage:
    remote_write:
      - url: ...
        headers:
          X-Scope-OrgID: ...
```

2. In runtime overrides per-tenant:
```yaml
overrides:
  '*':
    metrics_generator_remote_write_headers:
      X-Scope-OrgID: ...
```

Both locations are statically configured by a Tempo operator, and it is more likely they are intentional than not.

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`