### PR TITLE
feat: reduce GC by not passing the whole struct to compile and process TraceQL metrics

### DIFF
--- a/modules/frontend/combiner/metrics_query_range.go
+++ b/modules/frontend/combiner/metrics_query_range.go
@@ -11,8 +11,8 @@ import (
 var _ GRPCCombiner[*tempopb.QueryRangeResponse] = (*genericCombiner[*tempopb.QueryRangeResponse])(nil)
 
 // NewQueryRange returns a query range combiner.
-func NewQueryRange(req *tempopb.QueryRangeRequest, trackDiffs bool) (Combiner, error) {
-	combiner, err := traceql.QueryRangeCombinerFor(req, traceql.AggregateModeFinal, trackDiffs)
+func NewQueryRange(start, end, step uint64, query string, trackDiffs bool) (Combiner, error) {
+	combiner, err := traceql.QueryRangeCombinerFor(start, end, step, query, traceql.AggregateModeFinal, trackDiffs)
 	if err != nil {
 		return nil, err
 	}
@@ -21,7 +21,7 @@ func NewQueryRange(req *tempopb.QueryRangeRequest, trackDiffs bool) (Combiner, e
 		httpStatusCode: 200,
 		new:            func() *tempopb.QueryRangeResponse { return &tempopb.QueryRangeResponse{} },
 		current:        &tempopb.QueryRangeResponse{Metrics: &tempopb.SearchMetrics{}},
-		combine: func(partial *tempopb.QueryRangeResponse, _ *tempopb.QueryRangeResponse, resp PipelineResponse) error {
+		combine: func(partial *tempopb.QueryRangeResponse, _ *tempopb.QueryRangeResponse, _ PipelineResponse) error {
 			if partial.Metrics != nil {
 				// this is a coordination between the sharder and combiner. the sharder returns one response with summary metrics
 				// only. the combiner correctly takes and accumulates that job. however, if the response has no jobs this is
@@ -54,8 +54,8 @@ func NewQueryRange(req *tempopb.QueryRangeRequest, trackDiffs bool) (Combiner, e
 	}, nil
 }
 
-func NewTypedQueryRange(req *tempopb.QueryRangeRequest, trackDiffs bool) (GRPCCombiner[*tempopb.QueryRangeResponse], error) {
-	c, err := NewQueryRange(req, trackDiffs)
+func NewTypedQueryRange(start, end, step uint64, query string, trackDiffs bool) (GRPCCombiner[*tempopb.QueryRangeResponse], error) {
+	c, err := NewQueryRange(start, end, step, query, trackDiffs)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/frontend/metrics_query_handler.go
+++ b/modules/frontend/metrics_query_handler.go
@@ -49,7 +49,7 @@ func newQueryInstantStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTri
 		httpReq = httpReq.Clone(ctx)
 
 		var finalResponse *tempopb.QueryInstantResponse
-		c, err := combiner.NewTypedQueryRange(qr, true)
+		c, err := combiner.NewTypedQueryRange(qr.Start, qr.End, qr.Step, qr.Query, true)
 		if err != nil {
 			return err
 		}
@@ -112,7 +112,7 @@ func newMetricsQueryInstantHTTPHandler(cfg Config, next pipeline.AsyncRoundTripp
 		req.URL.Path = strings.ReplaceAll(req.URL.Path, api.PathMetricsQueryInstant, api.PathMetricsQueryRange)
 		req = api.BuildQueryRangeRequest(req, qr)
 
-		combiner, err := combiner.NewTypedQueryRange(qr, false)
+		combiner, err := combiner.NewTypedQueryRange(qr.Start, qr.End, qr.Step, qr.Query, false)
 		if err != nil {
 			level.Error(logger).Log("msg", "query instant: query range combiner failed", "err", err)
 			return &http.Response{

--- a/modules/frontend/metrics_query_range_handler.go
+++ b/modules/frontend/metrics_query_range_handler.go
@@ -37,7 +37,7 @@ func newQueryRangeStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripp
 		start := time.Now()
 
 		var finalResponse *tempopb.QueryRangeResponse
-		c, err := combiner.NewTypedQueryRange(req, true)
+		c, err := combiner.NewTypedQueryRange(req.Start, req.End, req.Step, req.Query, true)
 		if err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ func newMetricsQueryRangeHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper
 		logQueryRangeRequest(logger, tenant, queryRangeReq)
 
 		// build and use roundtripper
-		combiner, err := combiner.NewTypedQueryRange(queryRangeReq, false)
+		combiner, err := combiner.NewTypedQueryRange(queryRangeReq.Start, queryRangeReq.End, queryRangeReq.Step, queryRangeReq.Query, false)
 		if err != nil {
 			level.Error(logger).Log("msg", "query range: query range combiner failed", "err", err)
 			return &http.Response{

--- a/modules/generator/instance.go
+++ b/modules/generator/instance.go
@@ -408,7 +408,7 @@ func (i *instance) QueryRange(ctx context.Context, req *tempopb.QueryRangeReques
 				return resp, err
 			}
 
-			rr := r.ToProto(req)
+			rr := r.ToProto(req.Start, req.End, req.Step)
 			return &tempopb.QueryRangeResponse{
 				Series: rr,
 			}, nil

--- a/modules/querier/querier_query_range.go
+++ b/modules/querier/querier_query_range.go
@@ -44,7 +44,7 @@ func (q *Querier) queryRangeRecent(ctx context.Context, req *tempopb.QueryRangeR
 		return nil, fmt.Errorf("error querying generators in Querier.queryRangeRecent: %w", err)
 	}
 
-	c, err := traceql.QueryRangeCombinerFor(req, traceql.AggregateModeSum, false)
+	c, err := traceql.QueryRangeCombinerFor(req.Start, req.End, req.Step, req.Query, traceql.AggregateModeSum, false)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (q *Querier) queryBlock(ctx context.Context, req *tempopb.QueryRangeRequest
 		timeOverlapCutoff = v
 	}
 
-	eval, err := traceql.NewEngine().CompileMetricsQueryRange(req, int(req.Exemplars), timeOverlapCutoff, unsafe)
+	eval, err := traceql.NewEngine().CompileMetricsQueryRange(req.Start, req.End, req.Step, req.Query, int(req.Exemplars), timeOverlapCutoff, unsafe)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/traceql/combine.go
+++ b/pkg/traceql/combine.go
@@ -172,7 +172,7 @@ func QueryRangeCombinerFor(start, end, step uint64, query string, mode Aggregate
 	return &QueryRangeCombiner{
 		start:         start,
 		end:           end,
-		step:          end,
+		step:          step,
 		eval:          eval,
 		metrics:       &tempopb.SearchMetrics{},
 		seriesUpdated: seriesUpdated,
@@ -203,7 +203,7 @@ func (q *QueryRangeCombiner) Combine(resp *tempopb.QueryRangeResponse) {
 
 func (q *QueryRangeCombiner) Response() *tempopb.QueryRangeResponse {
 	return &tempopb.QueryRangeResponse{
-		Series:  q.eval.Results().ToProto(q.start, q.end, q.start),
+		Series:  q.eval.Results().ToProto(q.start, q.end, q.step),
 		Metrics: q.metrics,
 	}
 }
@@ -220,7 +220,7 @@ func (q *QueryRangeCombiner) Diff() *tempopb.QueryRangeResponse {
 
 	// filter out series that haven't change
 	resp := &tempopb.QueryRangeResponse{
-		Series:  q.eval.Results().ToProtoDiff(q.start, q.end, q.start, seriesRangeFn),
+		Series:  q.eval.Results().ToProtoDiff(q.start, q.end, q.step, seriesRangeFn),
 		Metrics: q.metrics,
 	}
 

--- a/pkg/traceql/combine_test.go
+++ b/pkg/traceql/combine_test.go
@@ -359,13 +359,9 @@ func TestQueryRangeCombinerDiffs(t *testing.T) {
 		},
 	}
 
-	req := &tempopb.QueryRangeRequest{
-		Start: start,
-		End:   end,
-		Step:  step,
-		Query: "{} | rate()", // simple aggregate
-	}
-	combiner, err := QueryRangeCombinerFor(req, AggregateModeFinal, true)
+	query := "{} | rate()" // simple aggregate
+
+	combiner, err := QueryRangeCombinerFor(start, end, step, query, AggregateModeFinal, true)
 	require.NoError(t, err)
 
 	for i, tc := range tcs {

--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -221,24 +221,24 @@ func (set SeriesSet) ToProtoDiff(start, end, step uint64, rangeForLabels func(st
 				},
 			)
 		}
-
+		intervalStart, intervalEnd := start, end
 		include := true
 		if rangeForLabels != nil {
-			start, end, include = rangeForLabels(promLabels)
+			intervalStart, intervalEnd, include = rangeForLabels(promLabels)
 		}
 
 		if !include {
 			continue
 		}
 
-		intervals := IntervalCount(start, end, step)
+		intervals := IntervalCount(intervalStart, intervalEnd, step)
 		samples := make([]tempopb.Sample, 0, intervals)
 		for i, value := range s.Values {
 			ts := TimestampOf(uint64(i), start, step)
 
 			// todo: this loop should be able to be restructured to directly pass over
 			// the desired intervals
-			if ts < start || ts > end {
+			if ts < intervalStart || ts > intervalEnd {
 				continue
 			}
 

--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -96,56 +96,52 @@ func TrimToOverlap(start1, end1, step, start2, end2 uint64) (uint64, uint64, uin
 
 // TrimToBefore shortens the query window to only include before the given time.
 // Request must be in unix nanoseconds already.
-func TrimToBefore(req *tempopb.QueryRangeRequest, before time.Time) {
-	wasInstant := IsInstant(*req)
+func TrimToBefore(start, end, step uint64, before time.Time) (newStart, newEnd uint64) {
 	beforeNs := uint64(before.UnixNano())
+	newStart = min(start, beforeNs)
+	newEnd = min(end, beforeNs)
 
-	req.Start = min(req.Start, beforeNs)
-	req.End = min(req.End, beforeNs)
-
-	if wasInstant {
-		// Maintain instant nature of the request
-		req.Step = req.End - req.Start
-	} else {
-		// Realign after trimming
-		AlignRequest(req)
+	if IsInstant(start, end, step) {
+		return newStart, newEnd
 	}
+
+	// Realign after trimming
+	return AlignRequest(newStart, newEnd, step)
 }
 
 // TrimToAfter shortens the query window to only include after the given time.
 // Request must be in unix nanoseconds already.
-func TrimToAfter(req *tempopb.QueryRangeRequest, before time.Time) {
-	wasInstant := IsInstant(*req)
+func TrimToAfter(start, end, step uint64, before time.Time) (newStart, newEnd uint64) {
 	beforeNs := uint64(before.UnixNano())
+	newStart = max(start, beforeNs)
+	newEnd = max(end, beforeNs)
 
-	req.Start = max(req.Start, beforeNs)
-	req.End = max(req.End, beforeNs)
-
-	if wasInstant {
-		// Maintain instant nature of the request
-		req.Step = req.End - req.Start
-	} else {
-		// Realign after trimming
-		AlignRequest(req)
+	if IsInstant(start, end, step) {
+		return newStart, newEnd
 	}
+
+	// Realign after trimming
+	return AlignRequest(newStart, newEnd, step)
 }
 
-func IsInstant(req tempopb.QueryRangeRequest) bool {
-	return req.End-req.Start == req.Step
+func IsInstant(start, end, step uint64) bool {
+	return step == end-start
 }
 
 // AlignRequest shifts the start and end times of the request to align with the step
 // interval.  This gives more consistent results across refreshes of queries like "last 1 hour".
 // Without alignment each refresh is shifted by seconds or even milliseconds and the time series
 // calculations are sublty different each time. It's not wrong, but less preferred behavior.
-func AlignRequest(req *tempopb.QueryRangeRequest) {
-	if IsInstant(*req) {
-		return
+func AlignRequest(start, end, step uint64) (newStart, newEnd uint64) {
+	if IsInstant(start, end, step) {
+		return start, end
 	}
 
 	// It doesn't really matter but the request fields are expected to be in nanoseconds.
-	req.Start = req.Start / req.Step * req.Step
-	req.End = req.End / req.Step * req.Step
+	newStart = start / step * step
+	newEnd = end / step * step
+
+	return newStart, newEnd
 }
 
 type Label struct {

--- a/pkg/traceql/engine_metrics_test.go
+++ b/pkg/traceql/engine_metrics_test.go
@@ -146,6 +146,68 @@ func TestTrimToOverlap(t *testing.T) {
 	}
 }
 
+func TestTrimToBefore(t *testing.T) {
+	tc := []struct {
+		start, end, step           uint64
+		before                     time.Time
+		expectedStart, expectedEnd uint64
+	}{
+		// instant query
+		{
+			1, 2, 1,
+			time.Now(),
+			1, 2,
+		},
+		// non instant query
+		{
+			1, 3, 1,
+			time.Now(),
+			1, 3,
+		},
+		// shorten query
+		{
+			2000000000, 4000000000, 1,
+			time.Unix(1, 0),
+			1000000000, 1000000000,
+		},
+	}
+
+	for _, c := range tc {
+		actualStart, actualEnd := TrimToBefore(c.start, c.end, c.step, c.before)
+
+		require.Equal(t, c.expectedStart, actualStart)
+		require.Equal(t, c.expectedEnd, actualEnd)
+	}
+}
+
+func TestTrimToAfter(t *testing.T) {
+	tc := []struct {
+		start, end, step           uint64
+		before                     time.Time
+		expectedStart, expectedEnd uint64
+	}{
+		// instant query
+		{
+			1, 2, 1,
+			time.Unix(1, 0),
+			1000000000, 1000000000,
+		},
+		// non instant query
+		{
+			2000000000, 4000000000, 1,
+			time.Unix(1, 0),
+			2000000000, 4000000000,
+		},
+	}
+
+	for _, c := range tc {
+		actualStart, actualEnd := TrimToAfter(c.start, c.end, c.step, c.before)
+
+		require.Equal(t, c.expectedStart, actualStart)
+		require.Equal(t, c.expectedEnd, actualEnd)
+	}
+}
+
 func TestTimeRangeOverlap(t *testing.T) {
 	tc := []struct {
 		reqStart, reqEnd, dataStart, dataEnd uint64

--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -752,14 +752,7 @@ func BenchmarkBackendBlockQueryRange(b *testing.B) {
 						return
 					}
 
-					req := &tempopb.QueryRangeRequest{
-						Query: tc,
-						Step:  uint64(time.Minute),
-						Start: uint64(st.UnixNano()),
-						End:   uint64(end.UnixNano()),
-					}
-
-					eval, err := e.CompileMetricsQueryRange(req, 4, 0, false)
+					eval, err := e.CompileMetricsQueryRange(uint64(st.UnixNano()), uint64(end.UnixNano()), uint64(time.Minute), tc, 4, 0, false)
 					require.NoError(b, err)
 
 					b.ResetTimer()

--- a/tempodb/encoding/vparquet4/block_traceql_test.go
+++ b/tempodb/encoding/vparquet4/block_traceql_test.go
@@ -1100,14 +1100,7 @@ func BenchmarkBackendBlockQueryRange(b *testing.B) {
 						return
 					}
 
-					req := &tempopb.QueryRangeRequest{
-						Query: tc,
-						Step:  uint64(time.Minute),
-						Start: uint64(st.UnixNano()),
-						End:   uint64(end.UnixNano()),
-					}
-
-					eval, err := e.CompileMetricsQueryRange(req, 2, 0, false)
+					eval, err := e.CompileMetricsQueryRange(uint64(st.UnixNano()), uint64(end.UnixNano()), uint64(time.Minute), tc, 2, 0, false)
 					require.NoError(b, err)
 
 					b.ResetTimer()
@@ -1187,14 +1180,9 @@ func TestBackendBlockQueryRange(t *testing.T) {
 				return
 			}
 
-			req := &tempopb.QueryRangeRequest{
-				Query: fmt.Sprintf("%s %s", tc, queryHint),
-				Step:  uint64(time.Minute),
-				Start: uint64(st.UnixNano()),
-				End:   uint64(end.UnixNano()),
-			}
+			query := fmt.Sprintf("%s %s", tc, queryHint)
 
-			eval, err := e.CompileMetricsQueryRange(req, 1, 0, false)
+			eval, err := e.CompileMetricsQueryRange(uint64(st.UnixNano()), uint64(end.UnixNano()), uint64(time.Minute), query, 1, 0, false)
 			require.NoError(t, err)
 
 			require.NoError(t, eval.Do(ctx, f, uint64(block.meta.StartTime.UnixNano()), uint64(block.meta.EndTime.UnixNano())))


### PR DESCRIPTION
**What this PR does**:
It aims to marginally reduce allocations by not passing the whole struct to compile and process TraceQL metrics.
It also makes the code simpler to understand by not wrapping the start, end, and step, especially for those methods where the request values were being mutated in unclear ways



<details>
  <summary>Query range benchmark results</summary>

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/tempo/tempodb/encoding/vparquet4
                                                                             │   old.txt   │              new.txt               │
                                                                             │   sec/op    │   sec/op     vs base               │
BackendBlockQueryRange/{}_|_rate()/5-11                                         1.284 ± 4%    1.260 ± 3%       ~ (p=0.190 n=10)
BackendBlockQueryRange/{}_|_rate()/7-11                                         1.302 ± 3%    1.293 ± 2%       ~ (p=0.436 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)/5-11                               2.388 ± 7%    2.361 ± 6%       ~ (p=0.393 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)/7-11                               2.665 ± 1%    2.635 ± 1%  -1.12% (p=0.043 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/5-11              1.774 ± 8%    1.677 ± 6%       ~ (p=0.075 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/7-11              2.110 ± 6%    1.971 ± 1%  -6.60% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/5-11                      2.853 ± 2%    2.836 ± 1%       ~ (p=0.481 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/7-11                      2.989 ± 1%    2.991 ± 3%       ~ (p=0.971 n=10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/5-11   204.8m ± 0%   204.8m ± 0%       ~ (p=0.481 n=10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/7-11   205.2m ± 0%   205.9m ± 2%  +0.31% (p=0.004 n=10)
BackendBlockQueryRange/{status=error}_|_rate()/5-11                            183.9m ± 0%   184.2m ± 1%  +0.16% (p=0.009 n=10)
BackendBlockQueryRange/{status=error}_|_rate()/7-11                            184.0m ± 0%   184.4m ± 0%       ~ (p=0.075 n=10)
geomean                                                                        941.2m        927.8m       -1.43%

                                                                             │  old.txt   │               new.txt               │
                                                                             │  MB_IO/op  │  MB_IO/op   vs base                 │
BackendBlockQueryRange/{}_|_rate()/5-11                                        33.74 ± 0%   33.74 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()/7-11                                        33.74 ± 0%   33.74 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(name)/5-11                              42.24 ± 0%   42.24 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(name)/7-11                              42.24 ± 0%   42.24 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/5-11             34.27 ± 0%   34.27 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/7-11             34.27 ± 0%   34.27 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/5-11                     37.19 ± 0%   37.19 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/7-11                     37.19 ± 0%   37.19 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/5-11   34.22 ± 0%   34.22 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/7-11   34.22 ± 0%   34.22 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{status=error}_|_rate()/5-11                            35.39 ± 0%   35.39 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{status=error}_|_rate()/7-11                            35.39 ± 0%   35.39 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                                        36.06        36.06       +0.00%
¹ all samples are equal

                                                                             │   old.txt   │               new.txt                │
                                                                             │  spans/op   │  spans/op    vs base                 │
BackendBlockQueryRange/{}_|_rate()/5-11                                        5.650M ± 0%   5.650M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()/7-11                                        9.068M ± 0%   9.068M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(name)/5-11                              5.650M ± 0%   5.650M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(name)/7-11                              9.068M ± 0%   9.068M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/5-11             5.650M ± 0%   5.650M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/7-11             9.068M ± 0%   9.068M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/5-11                     5.650M ± 0%   5.650M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/7-11                     9.068M ± 0%   9.068M ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/5-11   197.1k ± 0%   197.1k ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/7-11   300.6k ± 0%   300.6k ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{status=error}_|_rate()/5-11                            44.67k ± 0%   44.67k ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockQueryRange/{status=error}_|_rate()/7-11                            65.03k ± 0%   65.03k ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                                        1.804M        1.804M       +0.00%
¹ all samples are equal

                                                                             │   old.txt   │              new.txt               │
                                                                             │   spans/s   │   spans/s    vs base               │
BackendBlockQueryRange/{}_|_rate()/5-11                                        4.400M ± 4%   4.485M ± 2%       ~ (p=0.190 n=10)
BackendBlockQueryRange/{}_|_rate()/7-11                                        6.965M ± 2%   7.013M ± 2%       ~ (p=0.436 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)/5-11                              2.366M ± 8%   2.393M ± 6%       ~ (p=0.393 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)/7-11                              3.403M ± 1%   3.441M ± 1%  +1.13% (p=0.043 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/5-11             3.186M ± 9%   3.370M ± 6%       ~ (p=0.075 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/7-11             4.297M ± 6%   4.600M ± 1%  +7.06% (p=0.000 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/5-11                     1.980M ± 2%   1.992M ± 1%       ~ (p=0.481 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/7-11                     3.034M ± 1%   3.032M ± 3%       ~ (p=0.971 n=10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/5-11   962.3k ± 0%   962.6k ± 0%       ~ (p=0.481 n=10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/7-11   1.465M ± 0%   1.460M ± 2%  -0.31% (p=0.004 n=10)
BackendBlockQueryRange/{status=error}_|_rate()/5-11                            242.9k ± 0%   242.5k ± 1%  -0.16% (p=0.009 n=10)
BackendBlockQueryRange/{status=error}_|_rate()/7-11                            353.4k ± 0%   352.7k ± 0%       ~ (p=0.075 n=10)
geomean                                                                        1.917M        1.944M       +1.45%

                                                                             │    old.txt    │               new.txt                │
                                                                             │     B/op      │     B/op       vs base               │
BackendBlockQueryRange/{}_|_rate()/5-11                                        51.52Mi ± 47%   39.72Mi ± 53%       ~ (p=0.105 n=10)
BackendBlockQueryRange/{}_|_rate()/7-11                                        47.10Mi ± 27%   49.27Mi ± 31%       ~ (p=0.529 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)/5-11                              45.54Mi ± 56%   49.58Mi ± 52%       ~ (p=0.247 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)/7-11                              46.64Mi ± 22%   37.34Mi ± 71%       ~ (p=0.247 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/5-11             43.04Mi ± 42%   46.34Mi ± 72%       ~ (p=0.280 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/7-11             39.78Mi ± 24%   37.87Mi ± 51%       ~ (p=0.353 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/5-11                     436.0Mi ±  2%   427.3Mi ±  6%       ~ (p=0.393 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/7-11                     486.4Mi ±  2%   479.8Mi ±  4%       ~ (p=0.123 n=10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/5-11   65.25Mi ±  2%   65.33Mi ±  1%       ~ (p=0.971 n=10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/7-11   65.09Mi ±  2%   65.63Mi ±  1%       ~ (p=0.105 n=10)
BackendBlockQueryRange/{status=error}_|_rate()/5-11                            5.052Mi ± 23%   5.052Mi ± 11%       ~ (p=0.853 n=10)
BackendBlockQueryRange/{status=error}_|_rate()/7-11                            5.102Mi ± 21%   4.939Mi ± 20%       ~ (p=0.853 n=10)
geomean                                                                        49.28Mi         47.72Mi        -3.15%

                                                                             │   old.txt    │               new.txt                │
                                                                             │  allocs/op   │   allocs/op    vs base               │
BackendBlockQueryRange/{}_|_rate()/5-11                                        55.32k ± 87%   45.39k ±  43%       ~ (p=0.101 n=10)
BackendBlockQueryRange/{}_|_rate()/7-11                                        45.46k ± 99%   45.48k ± 127%       ~ (p=0.780 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)/5-11                              60.62k ±  0%   60.67k ± 191%       ~ (p=0.447 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(name)/7-11                              63.83k ±  0%   63.76k ±   0%       ~ (p=0.172 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/5-11             47.54k ±  0%   47.59k ± 444%       ~ (p=0.393 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/7-11             47.84k ±  0%   47.83k ±   0%       ~ (p=0.529 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/5-11                     1.072M ±  6%   1.071M ±   7%       ~ (p=0.684 n=10)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/7-11                     1.217M ±  1%   1.222M ±   2%       ~ (p=0.481 n=10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/5-11   346.6k ±  0%   346.6k ±   0%       ~ (p=0.542 n=10)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/7-11   346.6k ±  0%   346.7k ±   0%       ~ (p=0.085 n=10)
BackendBlockQueryRange/{status=error}_|_rate()/5-11                            60.30k ±  0%   60.31k ±   2%       ~ (p=0.468 n=10)
BackendBlockQueryRange/{status=error}_|_rate()/7-11                            60.30k ±  0%   60.29k ±   0%       ~ (p=0.926 n=10)
geomean                                                                        123.5k         121.5k         -1.60%
```

</details>


**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`