### PR TITLE
Use canonical centering an image example

### DIFF
--- a/docs/sources/tempo/_index.md
+++ b/docs/sources/tempo/_index.md
@@ -44,7 +44,8 @@ Distributed tracing visualizes the lifecycle of a request as it passes through a
 Tempo is cost-efficient and only requires an object storage to operate.
 Tempo is deeply integrated with Grafana, Mimir, Prometheus, and Loki.
 You can use Tempo with open source tracing protocols, including Jaeger, Zipkin, or OpenTelemetry.
-<p align="center"><img src="getting-started/assets/trace_custom_metrics_dash.png" alt="Trace visualization in Grafana "></p>
+
+{{< figure src="getting-started/assets/trace_custom_metrics_dash.png" alt="Trace visualization in Grafana" class="w-100p" link-class="w-fit mx-auto d-flex flex-direction-column" >}}
 
 Tempo integrates well with a number of open source tools:
 
@@ -55,5 +56,3 @@ Tempo integrates well with a number of open source tools:
 ## Explore
 
 {{< card-grid key="cards" type="simple" >}}
-
-<p align="center"><img src="/static/img/search/tempo.svg"  alt="Tempo Logo"></p>


### PR DESCRIPTION
https://grafana.com/docs/writers-toolkit/write/shortcodes/#center-an-image-example

Also removes rogue image at the end of the page.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`