### PR TITLE
Fix cli analyse block dedicated text output

### DIFF
--- a/cmd/tempo-cli/cmd-analyse-block.go
+++ b/cmd/tempo-cli/cmd-analyse-block.go
@@ -184,6 +184,7 @@ func processBlock(r backend.Reader, tenantID, blockID string, maxStartTime, minS
 	// merge dedicated with span attributes
 	for k, v := range resourceDedicatedSummary.attributes {
 		resourceAttrsSummary.attributes[k] = v
+		resourceAttrsSummary.dedicated[k] = struct{}{}
 	}
 	resourceAttrsSummary.totalBytes += spanDedicatedSummary.totalBytes
 
@@ -336,7 +337,7 @@ func printSummary(scope string, max int, summary genericAttrSummary) error {
 	for _, a := range attrList {
 
 		name := a.name
-		if _, ok := summary.dedicated[a.name]; !ok {
+		if _, ok := summary.dedicated[a.name]; ok {
 			name = a.name + " (dedicated)"
 		}
 


### PR DESCRIPTION
**What this PR does**:

Invert the logic to know which columns are currently dedicated.  Includes resource attributes in dedicated column tracking.

**Which issue(s) this PR fixes**:
Related #4012

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`