### PR TITLE
tempo-query: remove binary from source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.test
 /bin
 /cmd/tempo-cli/tempo-cli
+/cmd/tempo-query/tempo-query
 /cmd/tempo-serverless/vendor/
 /dist
 /example/docker-compose/**/gcs-data/


### PR DESCRIPTION
**What this PR does**:

Remove tempo-query binary from source and add `cmd/tempo-query/tempo-query` to `.gitignore`.

Originally introduced in: 0448492dc317f3e2a5fc9e071639552abf40dddc

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

I assume we can skip the changelog?