### PR TITLE
GRPC Streaming: Send diff instead of full response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [CHANGE] **BREAKING CHANGE** The dynamic injection of X-Scope-OrgID header for metrics generator remote-writes is changed. If the header is aleady set in per-tenant overrides or global tempo configuration, then it is honored and not overwritten. [#4021](https://github.com/grafana/tempo/pull/4021) (@mdisibio)
 * [CHANGE] **BREAKING CHANGE** Migrate from OpenTracing to OpenTelemetry instrumentation. Removed the `use_otel_tracer` configuration option. Use the OpenTelemetry environment variables to configure the span exporter [#3646](https://github.com/grafana/tempo/pull/3646) (@andreasgerstmayr)
   To continue using the Jaeger exporter, use the following environment variable: `OTEL_TRACES_EXPORTER=jaeger`.
+* [CHANGE] No longer send the final diff in GRPC streaming. Instead we rely on the streamed intermediate results. [#4062](https://github.com/grafana/tempo/pull/4062) (@joe-elliott)
 * [FEATURE] Discarded span logging `log_discarded_spans` [#3957](https://github.com/grafana/tempo/issues/3957) (@dastrobu)
 * [FEATURE] TraceQL support for instrumentation scope [#3967](https://github.com/grafana/tempo/pull/3967) (@ie-pham)
 * [ENHANCEMENT] TraceQL: Attribute iterators collect matched array values [#3867](https://github.com/grafana/tempo/pull/3867) (@electron0zero, @stoewer)

--- a/modules/frontend/pipeline/collector_grpc.go
+++ b/modules/frontend/pipeline/collector_grpc.go
@@ -63,8 +63,8 @@ func (c GRPCCollector[T]) RoundTrip(req *http.Request) error {
 		return grpcError(err)
 	}
 
-	// send a final, complete response
-	resp, err := c.combiner.GRPCFinal()
+	// send the final diff if there is anything left
+	resp, err := c.combiner.GRPCDiff()
 	if err != nil {
 		return grpcError(err)
 	}


### PR DESCRIPTION
**What this PR does**:
This change impacts all streaming endpoints. Instead of returning a complete final message this has the query frontend send only a final diff. For searches with very large limits and span limits we were seeing enormous final messages returned to Grafana which [tripped a limit in their websocket implementation](https://github.com/grafana/grafana/pull/93033).

The initial intention of sending the final message was to make sure the frontend got a complete response in case one of the intermediate messages was lost due to a bug. This seems to be unlikely and the rare case it does happen is not worth the cost of always sending the full response all the time.

cc @adrapereira 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`