### PR TITLE
Add disk caching in ingester SearchTagValuesV2 for completed blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 private-key.key
 integration/e2e/e2e_integration_test[0-9]*
 .tempo.yaml
+/tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [ENHANCEMENT] Add disk caching in ingester SearchTagValuesV2 for completed blocks [#4069](https://github.com/grafana/tempo/pull/4069) (@electron0zero)
 * [BUGFIX] Replace hedged requests roundtrips total with a counter. [#4063](https://github.com/grafana/tempo/pull/4063) [#4078](https://github.com/grafana/tempo/pull/4078) (@galalen)
 * [CHANGE] TraceByID: don't allow concurrent_shards greater than query_shards. [#4074](https://github.com/grafana/tempo/pull/4074) (@electron0zero)
 * **BREAKING CHANGE** tempo-query is no longer a jaeger instance with grpcPlugin. Its now a standalone server. Serving a grpc api for jaeger on `0.0.0.0:7777` by default. [#3840](https://github.com/grafana/tempo/issues/3840) (@frzifus)

--- a/modules/ingester/instance_search.go
+++ b/modules/ingester/instance_search.go
@@ -469,11 +469,10 @@ func (i *instance) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTag
 				// TODO: will this panic??
 				stop := valueCollector.Collect(*v)
 				if stop {
-					return nil
+					break
 				}
-				// return because we are done
-				return nil
 			}
+			return nil
 		}
 
 		// results not in cache, so we search and set the cache
@@ -484,6 +483,9 @@ func (i *instance) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTag
 		// if the query is empty, use the old search
 		if traceql.IsEmptyQuery(query) {
 			localErr = s.SearchTagValuesV2(ctx, tag, traceql.MakeCollectTagValueFunc(localCol.Collect), common.DefaultSearchOptions())
+			if localErr != nil {
+				return localErr
+			}
 		}
 
 		// otherwise use the filtered search

--- a/modules/ingester/instance_search.go
+++ b/modules/ingester/instance_search.go
@@ -422,6 +422,7 @@ func (i *instance) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTag
 
 	query := traceql.ExtractMatchers(req.Query)
 	// cacheKey will be same for all blocks in a request so only compute it once
+	// NOTE: cacheKey tag name and query, so if we start respecting start and end, add them to the cacheKey
 	cacheKey := searchTagValuesV2CacheKey(req, limit, "cache_search_tagvaluesv2")
 
 	// helper functions as closures, to access local variables
@@ -608,10 +609,10 @@ func searchTagValuesV2CacheKey(req *tempopb.SearchTagValuesRequest, limit int, p
 		query = ast.String()
 	}
 
+	// NOTE: we are not adding req.Start and req.End to the cache key because we don't respect the start and end
+	// please add them to cacheKey if we start respecting them
 	h := fnv1a.HashString64(req.TagName)
 	h = fnv1a.AddString64(h, query)
-	h = fnv1a.AddUint64(h, uint64(req.Start))
-	h = fnv1a.AddUint64(h, uint64(req.End))
 	h = fnv1a.AddUint64(h, uint64(limit))
 
 	return fmt.Sprintf("%s_%v.buf", prefix, h)

--- a/modules/ingester/local_block.go
+++ b/modules/ingester/local_block.go
@@ -128,18 +128,10 @@ func (c *LocalBlock) Write(ctx context.Context, w backend.Writer) error {
 }
 
 func (c *LocalBlock) SetDiskCache(ctx context.Context, cacheKey string, data []byte) error {
-	if cacheKey == "" {
-		return errors.New("cacheKey is empty")
-	}
-
 	return c.writer.Write(ctx, cacheKey, c.BlockMeta().BlockID, c.BlockMeta().TenantID, data, nil)
 }
 
 func (c *LocalBlock) GetDiskCache(ctx context.Context, cacheKey string) ([]byte, error) {
-	if cacheKey == "" {
-		return nil, errors.New("cacheKey is empty")
-	}
-
 	data, err := c.reader.Read(ctx, cacheKey, c.BlockMeta().BlockID, c.BlockMeta().TenantID, nil)
 	if errors.Is(err, backend.ErrDoesNotExist) {
 		// file doesn't exist, so it's a cache miss

--- a/modules/ingester/local_block.go
+++ b/modules/ingester/local_block.go
@@ -128,10 +128,18 @@ func (c *LocalBlock) Write(ctx context.Context, w backend.Writer) error {
 }
 
 func (c *LocalBlock) SetDiskCache(ctx context.Context, cacheKey string, data []byte) error {
+	if cacheKey == "" {
+		return errors.New("cacheKey is empty")
+	}
+
 	return c.writer.Write(ctx, cacheKey, c.BlockMeta().BlockID, c.BlockMeta().TenantID, data, nil)
 }
 
 func (c *LocalBlock) GetDiskCache(ctx context.Context, cacheKey string) ([]byte, error) {
+	if cacheKey == "" {
+		return nil, errors.New("cacheKey is empty")
+	}
+
 	data, err := c.reader.Read(ctx, cacheKey, c.BlockMeta().BlockID, c.BlockMeta().TenantID, nil)
 	if errors.Is(err, backend.ErrDoesNotExist) {
 		// file doesn't exist, so it's a cache miss

--- a/modules/ingester/local_block.go
+++ b/modules/ingester/local_block.go
@@ -28,9 +28,11 @@ type LocalBlock struct {
 	flushedTime atomic.Int64 // protecting flushedTime b/c it's accessed from the store on flush and from the ingester instance checking flush time
 }
 
-var _ common.Finder = (*LocalBlock)(nil)
-var _ common.Searcher = (*LocalBlock)(nil)
-var _ common.BlockCacher = (*LocalBlock)(nil)
+var (
+	_ common.Finder      = (*LocalBlock)(nil)
+	_ common.Searcher    = (*LocalBlock)(nil)
+	_ common.BlockCacher = (*LocalBlock)(nil)
+)
 
 // NewLocalBlock creates a local block
 func NewLocalBlock(ctx context.Context, existingBlock common.BackendBlock, l *local.Backend) *LocalBlock {

--- a/modules/ingester/local_block.go
+++ b/modules/ingester/local_block.go
@@ -29,9 +29,8 @@ type LocalBlock struct {
 }
 
 var (
-	_ common.Finder      = (*LocalBlock)(nil)
-	_ common.Searcher    = (*LocalBlock)(nil)
-	_ common.BlockCacher = (*LocalBlock)(nil)
+	_ common.Finder   = (*LocalBlock)(nil)
+	_ common.Searcher = (*LocalBlock)(nil)
 )
 
 // NewLocalBlock creates a local block

--- a/modules/ingester/local_block.go
+++ b/modules/ingester/local_block.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/grafana/tempo/pkg/traceql"
 	"go.uber.org/atomic"
 
 	"github.com/grafana/tempo/pkg/tempopb"
@@ -52,6 +53,36 @@ func (c *LocalBlock) FindTraceByID(ctx context.Context, id common.ID, opts commo
 	ctx, span := tracer.Start(ctx, "LocalBlock.FindTraceByID")
 	defer span.End()
 	return c.BackendBlock.FindTraceByID(ctx, id, opts)
+}
+
+func (c *LocalBlock) Search(ctx context.Context, req *tempopb.SearchRequest, opts common.SearchOptions) (*tempopb.SearchResponse, error) {
+	ctx, span := tracer.Start(ctx, "LocalBlock.Search")
+	defer span.End()
+	return c.BackendBlock.Search(ctx, req, opts)
+}
+
+func (c *LocalBlock) SearchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb common.TagValuesCallbackV2, opts common.SearchOptions) error {
+	ctx, span := tracer.Start(ctx, "LocalBlock.SearchTagValuesV2")
+	defer span.End()
+	return c.BackendBlock.SearchTagValuesV2(ctx, tag, cb, opts)
+}
+
+func (c *LocalBlock) Fetch(ctx context.Context, req traceql.FetchSpansRequest, opts common.SearchOptions) (traceql.FetchSpansResponse, error) {
+	ctx, span := tracer.Start(ctx, "LocalBlock.Fetch")
+	defer span.End()
+	return c.BackendBlock.Fetch(ctx, req, opts)
+}
+
+func (c *LocalBlock) FetchTagValues(ctx context.Context, req traceql.FetchTagValuesRequest, cb traceql.FetchTagValuesCallback, opts common.SearchOptions) error {
+	ctx, span := tracer.Start(ctx, "LocalBlock.FetchTagValues")
+	defer span.End()
+	return c.BackendBlock.FetchTagValues(ctx, req, cb, opts)
+}
+
+func (c *LocalBlock) FetchTagNames(ctx context.Context, req traceql.FetchTagsRequest, cb traceql.FetchTagsCallback, opts common.SearchOptions) error {
+	ctx, span := tracer.Start(ctx, "LocalBlock.FetchTagNames")
+	defer span.End()
+	return c.BackendBlock.FetchTagNames(ctx, req, cb, opts)
 }
 
 // FlushedTime returns the time the block was flushed.  Will return 0

--- a/tempodb/encoding/common/interfaces.go
+++ b/tempodb/encoding/common/interfaces.go
@@ -32,11 +32,6 @@ type Searcher interface {
 	FetchTagNames(context.Context, traceql.FetchTagsRequest, traceql.FetchTagsCallback, SearchOptions) error
 }
 
-type BlockCacher interface {
-	SetDiskCache(ctx context.Context, name string, data []byte) error
-	GetDiskCache(ctx context.Context, name string) ([]byte, error)
-}
-
 type SearchOptions struct {
 	ChunkSizeBytes         uint32 // Buffer size to read from backend storage.
 	StartPage              int    // Controls searching only a subset of the block. Which page to begin searching at.

--- a/tempodb/encoding/common/interfaces.go
+++ b/tempodb/encoding/common/interfaces.go
@@ -32,6 +32,11 @@ type Searcher interface {
 	FetchTagNames(context.Context, traceql.FetchTagsRequest, traceql.FetchTagsCallback, SearchOptions) error
 }
 
+type BlockCacher interface {
+	SetDiskCache(ctx context.Context, name string, data []byte) error
+	GetDiskCache(ctx context.Context, name string) ([]byte, error)
+}
+
 type SearchOptions struct {
 	ChunkSizeBytes         uint32 // Buffer size to read from backend storage.
 	StartPage              int    // Controls searching only a subset of the block. Which page to begin searching at.

--- a/tempodb/encoding/vparquet4/block_search_tags.go
+++ b/tempodb/encoding/vparquet4/block_search_tags.go
@@ -239,6 +239,7 @@ func (b *backendBlock) SearchTagValuesV2(ctx context.Context, tag traceql.Attrib
 	if err != nil {
 		return fmt.Errorf("unexpected error opening parquet file: %w", err)
 	}
+	// TODO(suraj): push this BytesRead to SLO middleware
 	defer func() { span.SetAttributes(attribute.Int64("inspectedBytes", int64(rr.BytesRead()))) }()
 
 	return searchTagValues(derivedCtx, tag, cb, pf, b.meta.DedicatedColumns)

--- a/tempodb/encoding/vparquet4/wal_block.go
+++ b/tempodb/encoding/vparquet4/wal_block.go
@@ -514,6 +514,9 @@ func (b *walBlock) Clear() error {
 }
 
 func (b *walBlock) FindTraceByID(ctx context.Context, id common.ID, opts common.SearchOptions) (*tempopb.Trace, error) {
+	ctx, span := tracer.Start(ctx, "walBlock.FindTraceByID")
+	defer span.End()
+
 	trs := make([]*tempopb.Trace, 0)
 
 	for _, page := range b.flushed {
@@ -559,6 +562,9 @@ func (b *walBlock) FindTraceByID(ctx context.Context, id common.ID, opts common.
 }
 
 func (b *walBlock) Search(ctx context.Context, req *tempopb.SearchRequest, _ common.SearchOptions) (*tempopb.SearchResponse, error) {
+	ctx, span := tracer.Start(ctx, "walBlock.Search")
+	defer span.End()
+
 	results := &tempopb.SearchResponse{
 		Metrics: &tempopb.SearchMetrics{},
 	}
@@ -589,6 +595,9 @@ func (b *walBlock) Search(ctx context.Context, req *tempopb.SearchRequest, _ com
 }
 
 func (b *walBlock) SearchTags(ctx context.Context, scope traceql.AttributeScope, cb common.TagsCallback, _ common.SearchOptions) error {
+	ctx, span := tracer.Start(ctx, "walBlock.SearchTags")
+	defer span.End()
+
 	for i, blockFlush := range b.readFlushes() {
 		file, err := blockFlush.file(ctx)
 		if err != nil {
@@ -608,6 +617,9 @@ func (b *walBlock) SearchTags(ctx context.Context, scope traceql.AttributeScope,
 }
 
 func (b *walBlock) SearchTagValues(ctx context.Context, tag string, cb common.TagValuesCallback, opts common.SearchOptions) error {
+	ctx, span := tracer.Start(ctx, "walBlock.SearchTags")
+	defer span.End()
+
 	att, ok := translateTagToAttribute[tag]
 	if !ok {
 		att = traceql.NewAttribute(tag)
@@ -623,6 +635,9 @@ func (b *walBlock) SearchTagValues(ctx context.Context, tag string, cb common.Ta
 }
 
 func (b *walBlock) SearchTagValuesV2(ctx context.Context, tag traceql.Attribute, cb common.TagValuesCallbackV2, _ common.SearchOptions) error {
+	ctx, span := tracer.Start(ctx, "walBlock.SearchTagsV2")
+	defer span.End()
+
 	for i, blockFlush := range b.readFlushes() {
 		file, err := blockFlush.file(ctx)
 		if err != nil {
@@ -642,6 +657,9 @@ func (b *walBlock) SearchTagValuesV2(ctx context.Context, tag traceql.Attribute,
 }
 
 func (b *walBlock) Fetch(ctx context.Context, req traceql.FetchSpansRequest, _ common.SearchOptions) (traceql.FetchSpansResponse, error) {
+	ctx, span := tracer.Start(ctx, "walBlock.Fetch")
+	defer span.End()
+
 	// todo: this same method is called in backendBlock.Fetch. is there anyway to share this?
 	err := checkConditions(req.Conditions)
 	if err != nil {
@@ -687,6 +705,9 @@ func (b *walBlock) Fetch(ctx context.Context, req traceql.FetchSpansRequest, _ c
 }
 
 func (b *walBlock) FetchTagValues(ctx context.Context, req traceql.FetchTagValuesRequest, cb traceql.FetchTagValuesCallback, opts common.SearchOptions) error {
+	ctx, span := tracer.Start(ctx, "walBlock.FetchTagValues")
+	defer span.End()
+
 	err := checkConditions(req.Conditions)
 	if err != nil {
 		return fmt.Errorf("conditions invalid: %w", err)
@@ -748,6 +769,9 @@ func (b *walBlock) FetchTagValues(ctx context.Context, req traceql.FetchTagValue
 }
 
 func (b *walBlock) FetchTagNames(ctx context.Context, req traceql.FetchTagsRequest, cb traceql.FetchTagsCallback, opts common.SearchOptions) error {
+	ctx, span := tracer.Start(ctx, "walBlock.FetchTagNames")
+	defer span.End()
+
 	err := checkConditions(req.Conditions)
 	if err != nil {
 		return fmt.Errorf("conditions invalid: %w", err)


### PR DESCRIPTION
**What this PR does**:

cache the response for TagValuesV2 requests alongside the local blocks on the ingesters, this should speedup the autocomplete queries hitting ingesters.

In our dev env, it shows sizeable difference in p90, p95 of latency and throughout for tags that has values with high cardinality.

also updated instrumentation to make the ingester search spans more closer to the code.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`