### PR TITLE
Fix memcache host for local tempo setup

### DIFF
--- a/example/docker-compose/local/tempo.yaml
+++ b/example/docker-compose/local/tempo.yaml
@@ -11,7 +11,7 @@ cache:
   - roles:
     - frontend-search  
     memcached: 
-      host: localhost:11211
+      host: memcached:11211
 
 query_frontend:
   search:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Fixes mamcache host path issue for local tempo example which was introduced in https://github.com/grafana/tempo/pull/4032

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`