### PR TITLE
Fix Small Typo in Documentation

### DIFF
--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -178,7 +178,7 @@ distributor:
           tls:
 
             # Optional.
-            # Disables TSL if set to true.
+            # Disables TLS if set to true.
             [insecure: <boolean> | default = false]
 
             # Optional.


### PR DESCRIPTION
This PR fixes a typo in the docs. `TSL` => `TLS`.