### PR TITLE
Generators: Drop out of the ring before stopping ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [ENHANCEMENT] Add disk caching in ingester SearchTagValuesV2 for completed blocks [#4069](https://github.com/grafana/tempo/pull/4069) (@electron0zero)
 * [BUGFIX] Replace hedged requests roundtrips total with a counter. [#4063](https://github.com/grafana/tempo/pull/4063) [#4078](https://github.com/grafana/tempo/pull/4078) (@galalen)
+* [BUGFIX] Metrics generators: Correctly drop from the ring before stopping ingestion to reduce drops during a rollout. [#4101](https://github.com/grafana/tempo/pull/4101) (@joe-elliott)
 * [CHANGE] TraceByID: don't allow concurrent_shards greater than query_shards. [#4074](https://github.com/grafana/tempo/pull/4074) (@electron0zero)
 * **BREAKING CHANGE** tempo-query is no longer a jaeger instance with grpcPlugin. Its now a standalone server. Serving a grpc api for jaeger on `0.0.0.0:7777` by default. [#3840](https://github.com/grafana/tempo/issues/3840) (@frzifus)
 * [CHANGE] **BREAKING CHANGE** The dynamic injection of X-Scope-OrgID header for metrics generator remote-writes is changed. If the header is aleady set in per-tenant overrides or global tempo configuration, then it is honored and not overwritten. [#4021](https://github.com/grafana/tempo/pull/4021) (@mdisibio)

--- a/modules/generator/generator.go
+++ b/modules/generator/generator.go
@@ -162,15 +162,15 @@ func (g *Generator) running(ctx context.Context) error {
 }
 
 func (g *Generator) stopping(_ error) error {
-	// Mark as read-only
-	g.stopIncomingRequests()
-
 	if g.subservices != nil {
 		err := services.StopManagerAndAwaitStopped(context.Background(), g.subservices)
 		if err != nil {
 			level.Error(g.logger).Log("msg", "failed to stop metrics-generator dependencies", "err", err)
 		}
 	}
+
+	// Mark as read-only after we have removed ourselves from the ring
+	g.stopIncomingRequests()
 
 	var wg sync.WaitGroup
 	wg.Add(len(g.instances))

--- a/modules/generator/generator.go
+++ b/modules/generator/generator.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"sync"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -168,6 +169,8 @@ func (g *Generator) stopping(_ error) error {
 			level.Error(g.logger).Log("msg", "failed to stop metrics-generator dependencies", "err", err)
 		}
 	}
+
+	time.Sleep(5 * time.Second) // let the ring propagate the shutdown
 
 	// Mark as read-only after we have removed ourselves from the ring
 	g.stopIncomingRequests()


### PR DESCRIPTION
**What this PR does**:
Currently on shutdown the generators set a flag to stop receiving traffic and then remove themselves from the ring. This causes distributors to continue to send to a generator that is refusing traffic for a few seconds.

This PR:
1) Correctly drops out of the ring first and then sets the flag to stop ingestion
2) Adds a sleep in between these steps. Tempo by default uses memberlist for ring propagation which often requires a few seconds to propagate state from one component to another. Without this sleep the change was ineffective. I do not like the sleep but I'm not sure there's a better solution.

To the left of the red line is what a generator rollout looks like today. To the right is what this change looks like. Note that there are still a few drops but it's significantly reduced.

![image](https://github.com/user-attachments/assets/36be42c6-0eee-46d6-a907-f866d81f0ea6)

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`