### PR TITLE
Speedup DistinctString and ScopedDistinctString collectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .idea
 .vscode
 *.test
+*.pprof
 /bin
 /cmd/tempo-cli/tempo-cli
 /cmd/tempo-query/tempo-query

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [ENHANCEMENT] Send semver version in api/stattus/buildinfo for cloud deployments [#4110](https://github.com/grafana/tempo/pull/4110) [@Aki0x137]
 * [ENHANCEMENT] Speedup tempo-query trace search by allowing parallel queries [#4159](https://github.com/grafana/tempo/pull/4159) (@pavolloffay)
+* [ENHANCEMENT] Speedup DistinctString and ScopedDistinctString collectors [#4109](https://github.com/grafana/tempo/pull/4109) (@electron0zero)
 * [CHANGE] tempo-cli: add support for /api/v2/traces endpoint [#4127](https://github.com/grafana/tempo/pull/4127) (@electron0zero)
   **BREAKING CHANGE** The `tempo-cli` now uses the `/api/v2/traces` endpoint by default, 
   please use `--v1` flag to use `/api/traces` endpoint, which was the default in previous versions.

--- a/modules/frontend/combiner/search_tag_values.go
+++ b/modules/frontend/combiner/search_tag_values.go
@@ -33,7 +33,11 @@ func NewSearchTagValues(limitBytes int) Combiner {
 			return d.Exceeded()
 		},
 		diff: func(response *tempopb.SearchTagValuesResponse) (*tempopb.SearchTagValuesResponse, error) {
-			response.TagValues = d.Diff()
+			resp, err := d.Diff()
+			if err != nil {
+				return nil, err
+			}
+			response.TagValues = resp
 			return response, nil
 		},
 	}
@@ -72,7 +76,10 @@ func NewSearchTagValuesV2(limitBytes int) Combiner {
 			return d.Exceeded()
 		},
 		diff: func(response *tempopb.SearchTagValuesV2Response) (*tempopb.SearchTagValuesV2Response, error) {
-			diff := d.Diff()
+			diff, err := d.Diff()
+			if err != nil {
+				return nil, err
+			}
 			response.TagValues = make([]*tempopb.TagValue, 0, len(diff))
 			for _, v := range diff {
 				v2 := v

--- a/modules/frontend/combiner/search_tag_values.go
+++ b/modules/frontend/combiner/search_tag_values.go
@@ -13,7 +13,7 @@ var (
 
 func NewSearchTagValues(limitBytes int) Combiner {
 	// Distinct collector with no limit
-	d := collector.NewDistinctString(limitBytes)
+	d := collector.NewDistinctStringWithDiff(limitBytes)
 
 	c := &genericCombiner[*tempopb.SearchTagValuesResponse]{
 		httpStatusCode: 200,

--- a/modules/frontend/combiner/search_tags.go
+++ b/modules/frontend/combiner/search_tags.go
@@ -12,7 +12,7 @@ var (
 )
 
 func NewSearchTags(limitBytes int) Combiner {
-	d := collector.NewDistinctString(limitBytes)
+	d := collector.NewDistinctStringWithDiff(limitBytes)
 
 	c := &genericCombiner[*tempopb.SearchTagsResponse]{
 		httpStatusCode: 200,
@@ -46,7 +46,7 @@ func NewTypedSearchTags(limitBytes int) GRPCCombiner[*tempopb.SearchTagsResponse
 
 func NewSearchTagsV2(limitBytes int) Combiner {
 	// Distinct collector map to collect scopes and scope values
-	distinctValues := collector.NewScopedDistinctString(limitBytes)
+	distinctValues := collector.NewScopedDistinctStringWithDiff(limitBytes)
 
 	c := &genericCombiner[*tempopb.SearchTagsV2Response]{
 		httpStatusCode: 200,

--- a/modules/frontend/combiner/search_tags.go
+++ b/modules/frontend/combiner/search_tags.go
@@ -32,7 +32,12 @@ func NewSearchTags(limitBytes int) Combiner {
 			return d.Exceeded()
 		},
 		diff: func(response *tempopb.SearchTagsResponse) (*tempopb.SearchTagsResponse, error) {
-			response.TagNames = d.Diff()
+			resp, err := d.Diff()
+			if err != nil {
+				return nil, err
+			}
+
+			response.TagNames = resp
 			return response, nil
 		},
 	}
@@ -76,7 +81,10 @@ func NewSearchTagsV2(limitBytes int) Combiner {
 			return distinctValues.Exceeded()
 		},
 		diff: func(response *tempopb.SearchTagsV2Response) (*tempopb.SearchTagsV2Response, error) {
-			collected := distinctValues.Diff()
+			collected, err := distinctValues.Diff()
+			if err != nil {
+				return nil, err
+			}
 			response.Scopes = make([]*tempopb.SearchTagsV2Scope, 0, len(collected))
 
 			for scope, vals := range collected {

--- a/modules/ingester/instance_search.go
+++ b/modules/ingester/instance_search.go
@@ -376,7 +376,7 @@ func (i *instance) SearchTagValues(ctx context.Context, tagName string) (*tempop
 	}
 
 	if distinctValues.Exceeded() {
-		level.Warn(log.Logger).Log("msg", "size of tag values in instance exceeded limit, reduce cardinality or size of tags", "tag", tagName, "userID", userID, "limit", limit, "total", distinctValues.TotalDataSize())
+		level.Warn(log.Logger).Log("msg", "size of tag values in instance exceeded limit, reduce cardinality or size of tags", "tag", tagName, "userID", userID, "limit", limit, "size", distinctValues.Size())
 	}
 
 	return &tempopb.SearchTagValuesResponse{

--- a/modules/ingester/instance_search.go
+++ b/modules/ingester/instance_search.go
@@ -265,8 +265,7 @@ func (i *instance) SearchTagsV2(ctx context.Context, req *tempopb.SearchTagsRequ
 		})
 
 		return engine.ExecuteTagNames(ctx, attributeScope, query, func(tag string, scope traceql.AttributeScope) bool {
-			distinctValues.Collect(scope.String(), tag)
-			return distinctValues.Exceeded()
+			return distinctValues.Collect(scope.String(), tag)
 		}, fetcher)
 	}
 

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -564,7 +564,7 @@ func (q *Querier) SearchTags(ctx context.Context, req *tempopb.SearchTagsRequest
 	}
 
 	if distinctValues.Exceeded() {
-		level.Warn(log.Logger).Log("msg", "size of tags in instance exceeded limit, reduce cardinality or size of tags", "userID", userID, "limit", limit, "total", distinctValues.TotalDataSize())
+		level.Warn(log.Logger).Log("msg", "size of tags in instance exceeded limit, reduce cardinality or size of tags", "userID", userID, "limit", limit, "size", distinctValues.Size())
 	}
 
 	resp := &tempopb.SearchTagsResponse{
@@ -659,7 +659,7 @@ func (q *Querier) SearchTagValues(ctx context.Context, req *tempopb.SearchTagVal
 	}
 
 	if distinctValues.Exceeded() {
-		level.Warn(log.Logger).Log("msg", "size of tag values in instance exceeded limit, reduce cardinality or size of tags", "tag", req.TagName, "userID", userID, "limit", limit, "total", distinctValues.TotalDataSize())
+		level.Warn(log.Logger).Log("msg", "size of tag values in instance exceeded limit, reduce cardinality or size of tags", "tag", req.TagName, "userID", userID, "limit", limit, "size", distinctValues.Size())
 	}
 
 	resp := &tempopb.SearchTagValuesResponse{

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -591,8 +591,7 @@ func (q *Querier) SearchTagsV2(ctx context.Context, req *tempopb.SearchTagsReque
 		}
 		for _, res := range resp.Scopes {
 			for _, tag := range res.Tags {
-				distinctValues.Collect(res.Name, tag)
-				if distinctValues.Exceeded() {
+				if distinctValues.Collect(res.Name, tag) {
 					return nil
 				}
 			}
@@ -970,8 +969,7 @@ func (q *Querier) internalTagsSearchBlockV2(ctx context.Context, req *tempopb.Se
 
 	valueCollector := collector.NewScopedDistinctString(q.limits.MaxBytesPerTagValuesQuery(tenantID))
 	err = q.engine.ExecuteTagNames(ctx, scope, query, func(tag string, scope traceql.AttributeScope) bool {
-		valueCollector.Collect(scope.String(), tag)
-		return valueCollector.Exceeded()
+		return valueCollector.Collect(scope.String(), tag)
 	}, fetcher)
 	if err != nil {
 		return nil, err

--- a/pkg/collector/distinct_string_collector.go
+++ b/pkg/collector/distinct_string_collector.go
@@ -38,11 +38,13 @@ func NewDistinctStringWithDiff(maxDataSize int) *DistinctString {
 	}
 }
 
-// FIXME: also add a benchmark for this to show it goes faster without diff support
-
 // Collect adds a new value to the distinct string collector.
-// return indicates if the value was added or not.
-// FIXME: return an exceeded flag to stop early
+// returns a bool to indicate if the value was added or not.
+// you need to call Exceeded to check if the limit was reached
+//
+// Note: Collect doesn't return exceeded bool like other collectors,
+// changing it to be consistent with other collectors requires changes in Searcher interface.
+// callbacks because Collect is used in Searcher interface callbacks.
 func (d *DistinctString) Collect(s string) bool {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()

--- a/pkg/collector/distinct_string_collector.go
+++ b/pkg/collector/distinct_string_collector.go
@@ -22,7 +22,6 @@ type DistinctString struct {
 func NewDistinctString(maxDataSize int) *DistinctString {
 	return &DistinctString{
 		values:      make(map[string]struct{}),
-		new:         make(map[string]struct{}),
 		maxLen:      maxDataSize,
 		diffEnabled: false, // disable diff to make it faster
 	}

--- a/pkg/collector/distinct_string_collector.go
+++ b/pkg/collector/distinct_string_collector.go
@@ -108,13 +108,12 @@ func (d *DistinctString) Size() int {
 }
 
 // Diff returns all new strings collected since the last time diff was called
-func (d *DistinctString) Diff() []string {
+func (d *DistinctString) Diff() ([]string, error) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 
-	// TODO: return error if Diff is called on diffEnabled=false collector
 	if !d.diffEnabled {
-		return nil
+		return nil, errDiffNotEnabled
 	}
 
 	ss := make([]string, 0, len(d.new))
@@ -125,5 +124,5 @@ func (d *DistinctString) Diff() []string {
 
 	clear(d.new)
 	sort.Strings(ss)
-	return ss
+	return ss, nil
 }

--- a/pkg/collector/distinct_string_collector.go
+++ b/pkg/collector/distinct_string_collector.go
@@ -42,6 +42,7 @@ func NewDistinctStringWithDiff(maxDataSize int) *DistinctString {
 
 // Collect adds a new value to the distinct string collector.
 // return indicates if the value was added or not.
+// FIXME: return an exceeded flag to stop early
 func (d *DistinctString) Collect(s string) bool {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()

--- a/pkg/collector/distinct_string_collector.go
+++ b/pkg/collector/distinct_string_collector.go
@@ -37,14 +37,10 @@ func NewDistinctStringWithDiff(maxDataSize int) *DistinctString {
 	}
 }
 
-// Collect adds a new value to the distinct string collector.
-// returns a bool to indicate if the value was added or not.
-// you need to call Exceeded to check if the limit was reached
-//
-// Note: Collect doesn't return exceeded bool like other collectors,
-// changing it to be consistent with other collectors requires changes in Searcher interface.
-// callbacks because Collect is used in Searcher interface callbacks.
-func (d *DistinctString) Collect(s string) bool {
+// Collect adds a new value to the distinct string collector
+// and returns a boolean indicating whether the value was successfully added or not.
+// To check if the limit has been reached, you must call the Exceeded method separately.
+func (d *DistinctString) Collect(s string) (added bool) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 

--- a/pkg/collector/distinct_string_collector.go
+++ b/pkg/collector/distinct_string_collector.go
@@ -39,7 +39,6 @@ func NewDistinctStringWithDiff(maxDataSize int) *DistinctString {
 }
 
 // FIXME: also add a benchmark for this to show it goes faster without diff support
-// FIXME: replaces the places where Diff is used with NewDistinctStringWithDiff
 
 // Collect adds a new value to the distinct string collector.
 // return indicates if the value was added or not.

--- a/pkg/collector/distinct_string_collector.go
+++ b/pkg/collector/distinct_string_collector.go
@@ -106,12 +106,13 @@ func (d *DistinctString) Size() int {
 
 // Diff returns all new strings collected since the last time diff was called
 func (d *DistinctString) Diff() ([]string, error) {
-	d.mtx.Lock()
-	defer d.mtx.Unlock()
-
+	// can check diffEnabled without lock because it is not modified after creation
 	if !d.diffEnabled {
 		return nil, errDiffNotEnabled
 	}
+
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
 	ss := make([]string, 0, len(d.new))
 

--- a/pkg/collector/distinct_string_collector_test.go
+++ b/pkg/collector/distinct_string_collector_test.go
@@ -18,7 +18,7 @@ func TestDistinctStringCollector(t *testing.T) {
 	d.Collect("11")
 
 	require.True(t, d.Exceeded())
-	require.Equal(t, []string{"123", "4567", "890"}, d.Strings())
+	stringsSlicesEqual(t, []string{"123", "4567", "890"}, d.Strings())
 
 	// diff fails when diff is not enabled
 	res, err := d.Diff()
@@ -32,14 +32,14 @@ func TestDistinctStringCollectorDiff(t *testing.T) {
 	d.Collect("123")
 	d.Collect("4567")
 
-	require.Equal(t, []string{"123", "4567"}, readDistinctStringDiff(t, d))
-	require.Equal(t, []string{}, readDistinctStringDiff(t, d))
+	stringsSlicesEqual(t, []string{"123", "4567"}, readDistinctStringDiff(t, d))
+	stringsSlicesEqual(t, []string{}, readDistinctStringDiff(t, d))
 
 	d.Collect("123")
 	d.Collect("890")
 
-	require.Equal(t, []string{"890"}, readDistinctStringDiff(t, d))
-	require.Equal(t, []string{}, readDistinctStringDiff(t, d))
+	stringsSlicesEqual(t, []string{"890"}, readDistinctStringDiff(t, d))
+	stringsSlicesEqual(t, []string{}, readDistinctStringDiff(t, d))
 }
 
 func readDistinctStringDiff(t *testing.T, d *DistinctString) []string {

--- a/pkg/collector/distinct_string_collector_test.go
+++ b/pkg/collector/distinct_string_collector_test.go
@@ -21,7 +21,7 @@ func TestDistinctStringCollector(t *testing.T) {
 }
 
 func TestDistinctStringCollectorDiff(t *testing.T) {
-	d := NewDistinctString(0)
+	d := NewDistinctStringWithDiff(0)
 
 	d.Collect("123")
 	d.Collect("4567")

--- a/pkg/collector/distinct_string_collector_test.go
+++ b/pkg/collector/distinct_string_collector_test.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"fmt"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -52,4 +53,55 @@ func TestDistinctStringCollectorIsSafe(t *testing.T) {
 
 	require.Equal(t, len(d.Strings()), 10*100)
 	require.False(t, d.Exceeded())
+}
+
+func BenchmarkDistinctStringCollect(b *testing.B) {
+	// simulate 100 ingesters, each returning 10_000 tag values
+	numIngesters := 100
+	numTagValuesPerIngester := 10_000
+	ingesterStrings := make([][]string, numIngesters)
+	for i := 0; i < numIngesters; i++ {
+		strings := make([]string, numTagValuesPerIngester)
+		for j := 0; j < numTagValuesPerIngester; j++ {
+			strings[j] = fmt.Sprintf("string_%d_%d", i, j)
+		}
+		ingesterStrings[i] = strings
+	}
+
+	limits := []int{
+		0,          // no limit
+		100_000,    // 100KB
+		1_000_000,  // 1MB
+		10_000_000, // 10MB
+	}
+
+	b.ResetTimer() // to exclude the setup time for generating tag values
+	for _, lim := range limits {
+		b.Run("uniques_limit:"+strconv.Itoa(lim), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				distinctStrings := NewDistinctString(lim)
+				for _, values := range ingesterStrings {
+					for _, v := range values {
+						if distinctStrings.Collect(v) {
+							break // stop early if limit is reached
+						}
+					}
+				}
+			}
+		})
+
+		b.Run("duplicates_limit:"+strconv.Itoa(lim), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				distinctStrings := NewDistinctString(lim)
+				for i := 0; i < numIngesters; i++ {
+					for j := 0; j < numTagValuesPerIngester; j++ {
+						// collect first item to simulate duplicates
+						if distinctStrings.Collect(ingesterStrings[i][0]) {
+							break // stop early if limit is reached
+						}
+					}
+				}
+			}
+		})
+	}
 }

--- a/pkg/collector/distinct_string_collector_test.go
+++ b/pkg/collector/distinct_string_collector_test.go
@@ -19,6 +19,11 @@ func TestDistinctStringCollector(t *testing.T) {
 
 	require.True(t, d.Exceeded())
 	require.Equal(t, []string{"123", "4567", "890"}, d.Strings())
+
+	// diff fails when diff is not enabled
+	res, err := d.Diff()
+	require.Nil(t, res)
+	require.Error(t, err, errDiffNotEnabled)
 }
 
 func TestDistinctStringCollectorDiff(t *testing.T) {
@@ -27,14 +32,20 @@ func TestDistinctStringCollectorDiff(t *testing.T) {
 	d.Collect("123")
 	d.Collect("4567")
 
-	require.Equal(t, []string{"123", "4567"}, d.Diff())
-	require.Equal(t, []string{}, d.Diff())
+	require.Equal(t, []string{"123", "4567"}, readDistinctStringDiff(t, d))
+	require.Equal(t, []string{}, readDistinctStringDiff(t, d))
 
 	d.Collect("123")
 	d.Collect("890")
 
-	require.Equal(t, []string{"890"}, d.Diff())
-	require.Equal(t, []string{}, d.Diff())
+	require.Equal(t, []string{"890"}, readDistinctStringDiff(t, d))
+	require.Equal(t, []string{}, readDistinctStringDiff(t, d))
+}
+
+func readDistinctStringDiff(t *testing.T, d *DistinctString) []string {
+	res, err := d.Diff()
+	require.NoError(t, err)
+	return res
 }
 
 func TestDistinctStringCollectorIsSafe(t *testing.T) {

--- a/pkg/collector/distinct_value_collector.go
+++ b/pkg/collector/distinct_value_collector.go
@@ -25,7 +25,6 @@ type DistinctValue[T comparable] struct {
 func NewDistinctValue[T comparable](maxDataSize int, len func(T) int) *DistinctValue[T] {
 	return &DistinctValue[T]{
 		values:      make(map[T]struct{}),
-		new:         make(map[T]struct{}),
 		maxLen:      maxDataSize,
 		diffEnabled: false, // disable diff to make it faster
 		len:         len,

--- a/pkg/collector/distinct_value_collector.go
+++ b/pkg/collector/distinct_value_collector.go
@@ -111,12 +111,13 @@ func (d *DistinctValue[T]) Size() int {
 // Diff returns all new strings collected since the last time diff was called
 // returns nil if diff is not enabled
 func (d *DistinctValue[T]) Diff() ([]T, error) {
-	d.mtx.Lock()
-	defer d.mtx.Unlock()
-
+	// can check diffEnabled without lock because it is not modified after creation
 	if !d.diffEnabled {
 		return nil, errDiffNotEnabled
 	}
+
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
 	ss := make([]T, 0, len(d.new))
 	for k := range d.new {

--- a/pkg/collector/distinct_value_collector.go
+++ b/pkg/collector/distinct_value_collector.go
@@ -1,8 +1,11 @@
 package collector
 
 import (
+	"errors"
 	"sync"
 )
+
+var errDiffNotEnabled = errors.New("diff not enabled")
 
 type DistinctValue[T comparable] struct {
 	values      map[T]struct{}
@@ -108,13 +111,12 @@ func (d *DistinctValue[T]) Size() int {
 
 // Diff returns all new strings collected since the last time diff was called
 // returns nil if diff is not enabled
-func (d *DistinctValue[T]) Diff() []T {
+func (d *DistinctValue[T]) Diff() ([]T, error) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 
-	// TODO: return error if Diff is called on diffEnabled=false collector
 	if !d.diffEnabled {
-		return nil
+		return nil, errDiffNotEnabled
 	}
 
 	ss := make([]T, 0, len(d.new))
@@ -123,5 +125,5 @@ func (d *DistinctValue[T]) Diff() []T {
 	}
 
 	clear(d.new)
-	return ss
+	return ss, nil
 }

--- a/pkg/collector/distinct_value_collector.go
+++ b/pkg/collector/distinct_value_collector.go
@@ -112,6 +112,7 @@ func (d *DistinctValue[T]) Diff() []T {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 
+	// TODO: return error if Diff is called on diffEnabled=false collector
 	if !d.diffEnabled {
 		return nil
 	}

--- a/pkg/collector/distinct_value_collector_test.go
+++ b/pkg/collector/distinct_value_collector_test.go
@@ -13,11 +13,16 @@ import (
 func TestDistinctValueCollector(t *testing.T) {
 	d := NewDistinctValue[string](10, func(s string) int { return len(s) })
 
-	d.Collect("123")
-	d.Collect("4567")
-	d.Collect("890")
+	var stop bool
+	stop = d.Collect("123")
+	require.False(t, stop)
+	stop = d.Collect("4567")
+	require.False(t, stop)
+	stop = d.Collect("890")
+	require.True(t, stop)
 
 	require.True(t, d.Exceeded())
+	require.Equal(t, stop, d.Exceeded()) // final stop should be same as Exceeded
 	require.Equal(t, []string{"123", "4567"}, d.Values())
 
 	// diff fails when diff is not enabled

--- a/pkg/collector/distinct_value_collector_test.go
+++ b/pkg/collector/distinct_value_collector_test.go
@@ -23,7 +23,7 @@ func TestDistinctValueCollector(t *testing.T) {
 
 	require.True(t, d.Exceeded())
 	require.Equal(t, stop, d.Exceeded()) // final stop should be same as Exceeded
-	require.Equal(t, []string{"123", "4567"}, d.Values())
+	stringsSlicesEqual(t, []string{"123", "4567"}, d.Values())
 
 	// diff fails when diff is not enabled
 	res, err := d.Diff()

--- a/pkg/collector/scoped_distinct_string.go
+++ b/pkg/collector/scoped_distinct_string.go
@@ -1,6 +1,8 @@
 package collector
 
-import "sync"
+import (
+	"sync"
+)
 
 type ScopedDistinctString struct {
 	cols        map[string]*DistinctString

--- a/pkg/collector/scoped_distinct_string.go
+++ b/pkg/collector/scoped_distinct_string.go
@@ -88,23 +88,26 @@ func (d *ScopedDistinctString) Exceeded() bool {
 }
 
 // Diff returns all new strings collected since the last time Diff was called
-func (d *ScopedDistinctString) Diff() map[string][]string {
+func (d *ScopedDistinctString) Diff() (map[string][]string, error) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 
-	// TODO: return error if Diff is called on diffEnabled=false collector
 	if !d.diffEnabled {
-		return nil
+		return nil, errDiffNotEnabled
 	}
 
 	ss := map[string][]string{}
 
 	for k, v := range d.cols {
-		diff := v.Diff()
+		diff, err := v.Diff()
+		if err != nil {
+			return nil, err
+		}
+
 		if len(diff) > 0 {
 			ss[k] = diff
 		}
 	}
 
-	return ss
+	return ss, nil
 }

--- a/pkg/collector/scoped_distinct_string.go
+++ b/pkg/collector/scoped_distinct_string.go
@@ -89,12 +89,12 @@ func (d *ScopedDistinctString) Exceeded() bool {
 
 // Diff returns all new strings collected since the last time Diff was called
 func (d *ScopedDistinctString) Diff() (map[string][]string, error) {
-	d.mtx.Lock()
-	defer d.mtx.Unlock()
-
 	if !d.diffEnabled {
 		return nil, errDiffNotEnabled
 	}
+
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 
 	ss := map[string][]string{}
 

--- a/pkg/collector/scoped_distinct_string.go
+++ b/pkg/collector/scoped_distinct_string.go
@@ -33,6 +33,7 @@ func NewScopedDistinctStringWithDiff(maxDataSize int) *ScopedDistinctString {
 // FIXME: also add a benchmark for this to show it goes faster without diff support
 
 // Collect adds a new value to the distinct string collector.
+// FIXME: return an exceeded flag to stop early
 func (d *ScopedDistinctString) Collect(scope string, val string) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()

--- a/pkg/collector/scoped_distinct_string_test.go
+++ b/pkg/collector/scoped_distinct_string_test.go
@@ -75,7 +75,7 @@ func TestScopedDistinct(t *testing.T) {
 }
 
 func TestScopedDistinctDiff(t *testing.T) {
-	c := NewScopedDistinctString(0)
+	c := NewScopedDistinctStringWithDiff(0)
 
 	c.Collect("scope1", "val1")
 	expected := map[string][]string{

--- a/pkg/collector/scoped_distinct_string_test.go
+++ b/pkg/collector/scoped_distinct_string_test.go
@@ -82,29 +82,29 @@ func TestScopedDistinctDiff(t *testing.T) {
 	expected := map[string][]string{
 		"scope1": {"val1"},
 	}
-	assertMaps(t, expected, c.Diff())
+	assertMaps(t, expected, readScopedDistinctStringDiff(t, c))
 
 	// no diff
 	c.Collect("scope1", "val1")
 	expected = map[string][]string{}
-	assertMaps(t, expected, c.Diff())
-	assertMaps(t, map[string][]string{}, c.Diff())
+	assertMaps(t, expected, readScopedDistinctStringDiff(t, c))
+	assertMaps(t, map[string][]string{}, readScopedDistinctStringDiff(t, c))
 
 	// new value
 	c.Collect("scope1", "val2")
 	expected = map[string][]string{
 		"scope1": {"val2"},
 	}
-	assertMaps(t, expected, c.Diff())
-	assertMaps(t, map[string][]string{}, c.Diff())
+	assertMaps(t, expected, readScopedDistinctStringDiff(t, c))
+	assertMaps(t, map[string][]string{}, readScopedDistinctStringDiff(t, c))
 
 	// new scope
 	c.Collect("scope2", "val1")
 	expected = map[string][]string{
 		"scope2": {"val1"},
 	}
-	assertMaps(t, expected, c.Diff())
-	assertMaps(t, map[string][]string{}, c.Diff())
+	assertMaps(t, expected, readScopedDistinctStringDiff(t, c))
+	assertMaps(t, map[string][]string{}, readScopedDistinctStringDiff(t, c))
 
 	// all
 	c.Collect("scope2", "val1")
@@ -114,8 +114,21 @@ func TestScopedDistinctDiff(t *testing.T) {
 		"scope1": {"val3"},
 		"scope2": {"val2"},
 	}
-	assertMaps(t, expected, c.Diff())
-	assertMaps(t, map[string][]string{}, c.Diff())
+	assertMaps(t, expected, readScopedDistinctStringDiff(t, c))
+	assertMaps(t, map[string][]string{}, readScopedDistinctStringDiff(t, c))
+
+	// diff should error when diff is not enabled
+	col := NewScopedDistinctString(0)
+	col.Collect("scope1", "val1")
+	res, err := col.Diff()
+	require.Nil(t, res)
+	require.Error(t, err, errDiffNotEnabled)
+}
+
+func readScopedDistinctStringDiff(t *testing.T, d *ScopedDistinctString) map[string][]string {
+	res, err := d.Diff()
+	require.NoError(t, err)
+	return res
 }
 
 func assertMaps(t *testing.T, expected, actual map[string][]string) {

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -1457,8 +1457,7 @@ func tagNamesRunner(t *testing.T, _ *tempopb.Trace, _ *tempopb.TraceSearchMetada
 
 			valueCollector := collector.NewScopedDistinctString(0)
 			err := e.ExecuteTagNames(ctx, traceql.AttributeScopeFromString(tc.scope), tc.query, func(tag string, scope traceql.AttributeScope) bool {
-				valueCollector.Collect(scope.String(), tag)
-				return valueCollector.Exceeded()
+				return valueCollector.Collect(scope.String(), tag)
 			}, fetcher)
 			if errors.Is(err, common.ErrUnsupported) {
 				return


### PR DESCRIPTION
**What this PR does**:

This PR makes the DistinctString and ScopedDistinctString collectors go faster by not tracking diff in cases where we don't use the diff

We made similar performance improvements in DistinctValue collector in https://github.com/grafana/tempo/pull/4104, and now making the similar performance improvements in the DistinctString and ScopedDistinctString collectors in this PR.

how fast?
- DistinctString collector is around 54.93% faster with 43% improvements in mem. usage.
- ScopedDistinctString collector is from 27% to 49% faster with 45% improvements in mem. usage.

**Benchmarks:**

<details>
<summary>DistinctString collector</summary>

```text
goos: darwin
goarch: amd64
pkg: github.com/grafana/tempo/pkg/collector
cpu: VirtualApple @ 2.50GHz
                                                │ BenchmarkDistinctStringCollect_main.txt │ BenchmarkDistinctStringCollect_fast.txt │
                                                │                 sec/op                  │     sec/op       vs base                │
DistinctStringCollect/uniques_limit:0                                         29.57µ ± 1%       13.23µ ± 0%  -55.25% (p=0.000 n=10)
DistinctStringCollect/duplicates_limit:0                                      29.86µ ± 0%       13.45µ ± 0%  -54.94% (p=0.000 n=10)
DistinctStringCollect/uniques_limit:100000                                    29.48µ ± 0%       13.29µ ± 0%  -54.93% (p=0.000 n=10)
DistinctStringCollect/duplicates_limit:100000                                 29.85µ ± 0%       13.45µ ± 1%  -54.94% (p=0.000 n=10)
DistinctStringCollect/uniques_limit:1000000                                   29.48µ ± 0%       13.40µ ± 0%  -54.53% (p=0.000 n=10)
DistinctStringCollect/duplicates_limit:1000000                                29.85µ ± 0%       13.55µ ± 0%  -54.60% (p=0.000 n=10)
DistinctStringCollect/uniques_limit:10000000                                  29.50µ ± 0%       13.39µ ± 0%  -54.61% (p=0.000 n=10)
DistinctStringCollect/duplicates_limit:10000000                               29.85µ ± 1%       13.45µ ± 0%  -54.92% (p=0.000 n=10)
geomean                                                                       29.68µ            13.40µ       -54.84%

                                                │ BenchmarkDistinctStringCollect_main.txt │ BenchmarkDistinctStringCollect_fast.txt │
                                                │                  B/op                   │      B/op        vs base                │
DistinctStringCollect/uniques_limit:0                                       12.563Ki ± 0%      7.133Ki ± 0%  -43.23% (p=0.000 n=10)
DistinctStringCollect/duplicates_limit:0                                    12.562Ki ± 0%      7.133Ki ± 0%  -43.22% (p=0.000 n=10)
DistinctStringCollect/uniques_limit:100000                                  12.563Ki ± 0%      7.133Ki ± 0%  -43.23% (p=0.000 n=10)
DistinctStringCollect/duplicates_limit:100000                               12.563Ki ± 0%      7.133Ki ± 0%  -43.23% (p=0.000 n=10)
DistinctStringCollect/uniques_limit:1000000                                 12.563Ki ± 0%      7.133Ki ± 0%  -43.23% (p=0.000 n=10)
DistinctStringCollect/duplicates_limit:1000000                              12.563Ki ± 0%      7.133Ki ± 0%  -43.23% (p=0.000 n=10)
DistinctStringCollect/uniques_limit:10000000                                12.562Ki ± 0%      7.133Ki ± 0%  -43.22% (p=0.000 n=10)
DistinctStringCollect/duplicates_limit:10000000                             12.562Ki ± 0%      7.133Ki ± 0%  -43.22% (p=0.000 n=10)
geomean                                                                      12.56Ki           7.133Ki       -43.22%

                                                │ BenchmarkDistinctStringCollect_main.txt │ BenchmarkDistinctStringCollect_fast.txt │
                                                │                allocs/op                │    allocs/op      vs base               │
DistinctStringCollect/uniques_limit:0                                          121.0 ± 0%         112.0 ± 0%  -7.44% (p=0.000 n=10)
DistinctStringCollect/duplicates_limit:0                                       121.0 ± 0%         112.0 ± 0%  -7.44% (p=0.000 n=10)
DistinctStringCollect/uniques_limit:100000                                     121.0 ± 0%         112.0 ± 0%  -7.44% (p=0.000 n=10)
DistinctStringCollect/duplicates_limit:100000                                  121.0 ± 0%         112.0 ± 0%  -7.44% (p=0.000 n=10)
DistinctStringCollect/uniques_limit:1000000                                    121.0 ± 0%         112.0 ± 0%  -7.44% (p=0.000 n=10)
DistinctStringCollect/duplicates_limit:1000000                                 121.0 ± 0%         112.0 ± 0%  -7.44% (p=0.000 n=10)
DistinctStringCollect/uniques_limit:10000000                                   121.0 ± 0%         112.0 ± 0%  -7.44% (p=0.000 n=10)
DistinctStringCollect/duplicates_limit:10000000                                121.0 ± 0%         112.0 ± 0%  -7.44% (p=0.000 n=10)
geomean                                                                        121.0              112.0       -7.44%

```

</details>

<details>
<summary>ScopedDistinctString collector</summary>

```text
goos: darwin
goarch: amd64
pkg: github.com/grafana/tempo/pkg/collector
cpu: VirtualApple @ 2.50GHz
                                                         │ BenchmarkScopedDistinctStringCollect_main.txt │ BenchmarkScopedDistinctStringCollect_fast.txt │
                                                         │                    sec/op                     │        sec/op          vs base                │
ScopedDistinctStringCollect/uniques_limit:0-11                                               707.2m ± 2%             357.7m ± 2%  -49.42% (p=0.000 n=10)
ScopedDistinctStringCollect/duplicates_limit:0-11                                           110.45µ ± 0%             80.61µ ± 0%  -27.02% (p=0.000 n=10)
ScopedDistinctStringCollect/uniques_limit:100000-11                                          2.574m ± 0%             1.724m ± 0%  -33.01% (p=0.000 n=10)
ScopedDistinctStringCollect/duplicates_limit:100000-11                                      110.26µ ± 1%             80.52µ ± 0%  -26.97% (p=0.000 n=10)
ScopedDistinctStringCollect/uniques_limit:1000000-11                                         26.13m ± 1%             17.13m ± 0%  -34.45% (p=0.000 n=10)
ScopedDistinctStringCollect/duplicates_limit:1000000-11                                     109.42µ ± 0%             80.06µ ± 1%  -26.84% (p=0.000 n=10)
ScopedDistinctStringCollect/uniques_limit:10000000-11                                        642.3m ± 2%             323.8m ± 1%  -49.59% (p=0.000 n=10)
ScopedDistinctStringCollect/duplicates_limit:10000000-11                                    109.49µ ± 0%             79.93µ ± 0%  -27.00% (p=0.000 n=10)
geomean                                                                                      2.859m                  1.858m       -35.00%

                                                         │ BenchmarkScopedDistinctStringCollect_main.txt │ BenchmarkScopedDistinctStringCollect_fast.txt │
                                                         │                     B/op                      │         B/op           vs base                │
ScopedDistinctStringCollect/uniques_limit:0-11                                             178.78Mi ± 0%            97.02Mi ± 0%  -45.73% (p=0.000 n=10)
ScopedDistinctStringCollect/duplicates_limit:0-11                                           47.43Ki ± 0%            25.71Ki ± 0%  -45.80% (p=0.000 n=10)
ScopedDistinctStringCollect/uniques_limit:100000-11                                        1495.6Ki ± 0%            826.9Ki ± 0%  -44.71% (p=0.000 n=10)
ScopedDistinctStringCollect/duplicates_limit:100000-11                                      47.43Ki ± 0%            25.71Ki ± 0%  -45.80% (p=0.000 n=10)
ScopedDistinctStringCollect/uniques_limit:1000000-11                                       12.247Mi ± 0%            6.891Mi ± 0%  -43.73% (p=0.000 n=10)
ScopedDistinctStringCollect/duplicates_limit:1000000-11                                     47.43Ki ± 0%            25.70Ki ± 0%  -45.80% (p=0.000 n=10)
ScopedDistinctStringCollect/uniques_limit:10000000-11                                      177.69Mi ± 0%            95.91Mi ± 0%  -46.02% (p=0.000 n=10)
ScopedDistinctStringCollect/duplicates_limit:10000000-11                                    47.43Ki ± 0%            25.71Ki ± 0%  -45.80% (p=0.000 n=10)
geomean                                                                                     1.128Mi                 630.1Ki       -45.43%

                                                         │ BenchmarkScopedDistinctStringCollect_main.txt │ BenchmarkScopedDistinctStringCollect_fast.txt │
                                                         │                   allocs/op                   │       allocs/op         vs base               │
ScopedDistinctStringCollect/uniques_limit:0-11                                               1.075M ± 0%              1.038M ± 0%  -3.50% (p=0.000 n=10)
ScopedDistinctStringCollect/duplicates_limit:0-11                                             490.0 ± 0%               452.0 ± 0%  -7.76% (p=0.000 n=10)
ScopedDistinctStringCollect/uniques_limit:100000-11                                          10.63k ± 0%              10.38k ± 0%  -2.29% (p=0.000 n=10)
ScopedDistinctStringCollect/duplicates_limit:100000-11                                        490.0 ± 0%               452.0 ± 0%  -7.76% (p=0.000 n=10)
ScopedDistinctStringCollect/uniques_limit:1000000-11                                         108.2k ± 0%              104.6k ± 0%  -3.28% (p=0.000 n=10)
ScopedDistinctStringCollect/duplicates_limit:1000000-11                                       490.0 ± 0%               452.0 ± 0%  -7.76% (p=0.000 n=10)
ScopedDistinctStringCollect/uniques_limit:10000000-11                                       1003.2k ± 0%              965.4k ± 0%  -3.77% (p=0.000 n=10)
ScopedDistinctStringCollect/duplicates_limit:10000000-11                                      490.0 ± 0%               452.0 ± 0%  -7.76% (p=0.000 n=10)
geomean                                                                                      9.589k                   9.061k       -5.51%

```

</details>


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`