### PR TITLE
TraceQL performance improvements

### DIFF
--- a/pkg/traceql/ast_execute.go
+++ b/pkg/traceql/ast_execute.go
@@ -330,6 +330,20 @@ func (o *BinaryOperation) execute(span Span) (Static, error) {
 		return NewStaticNil(), err
 	}
 
+	// Look for cases where we don't even need to evalulate the RHS
+	if lhsB, ok := lhs.Bool(); ok {
+		if o.Op == OpAnd && !lhsB {
+			// x && y
+			// x is false so we don't need to evalulate y
+			return StaticFalse, nil
+		}
+		if o.Op == OpOr && lhsB {
+			// x || y
+			// x is true so we don't need to evalulate y
+			return StaticTrue, nil
+		}
+	}
+
 	rhs, err := o.RHS.execute(span)
 	if err != nil {
 		return NewStaticNil(), err

--- a/pkg/traceql/ast_execute.go
+++ b/pkg/traceql/ast_execute.go
@@ -339,7 +339,7 @@ func (o *BinaryOperation) execute(span Span) (Static, error) {
 	lhsT := lhs.Type
 	rhsT := rhs.Type
 	if !lhsT.isMatchingOperand(rhsT) {
-		return NewStaticBool(false), nil
+		return StaticFalse, nil
 	}
 
 	if !o.Op.binaryTypesValid(lhsT, rhsT) {
@@ -585,7 +585,7 @@ func (a Attribute) execute(span Span) (Static, error) {
 		return static, nil
 	}
 
-	return NewStaticNil(), nil
+	return StaticNil, nil
 }
 
 func uniqueSpans(ss1 []*Spanset, ss2 []*Spanset) []Span {

--- a/pkg/traceql/enum_statics.go
+++ b/pkg/traceql/enum_statics.go
@@ -174,6 +174,7 @@ func (k Kind) String() string {
 }
 
 var (
+	StaticNil   = NewStaticNil()
 	StaticTrue  = NewStaticBool(true)
 	StaticFalse = NewStaticBool(false)
 )

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -122,6 +122,7 @@ func (s *span) AttributeFor(a traceql.Attribute) (traceql.Static, bool) {
 			if attrs[0].a == a {
 				return &attrs[0].s
 			}
+			return nil
 		}
 		if len(attrs) == 2 {
 			if attrs[0].a == a {
@@ -130,11 +131,12 @@ func (s *span) AttributeFor(a traceql.Attribute) (traceql.Static, bool) {
 			if attrs[1].a == a {
 				return &attrs[1].s
 			}
+			return nil
 		}
 
-		for _, st := range attrs {
-			if st.a == a {
-				return &st.s
+		for i := range attrs {
+			if attrs[i].a == a {
+				return &attrs[i].s
 			}
 		}
 		return nil
@@ -144,6 +146,7 @@ func (s *span) AttributeFor(a traceql.Attribute) (traceql.Static, bool) {
 			if attrs[0].a.Name == s {
 				return &attrs[0].s
 			}
+			return nil
 		}
 		if len(attrs) == 2 {
 			if attrs[0].a.Name == s {
@@ -152,47 +155,53 @@ func (s *span) AttributeFor(a traceql.Attribute) (traceql.Static, bool) {
 			if attrs[1].a.Name == s {
 				return &attrs[1].s
 			}
+			return nil
 		}
 
-		for _, st := range attrs {
-			if st.a.Name == s {
-				return &st.s
+		for i := range attrs {
+			if attrs[i].a.Name == s {
+				return &attrs[i].s
 			}
 		}
 		return nil
 	}
 
-	if a.Scope == traceql.AttributeScopeResource {
-		if attr := find(a, s.resourceAttrs); attr != nil {
-			return *attr, true
+	switch a.Scope {
+	case traceql.AttributeScopeResource:
+		if len(s.resourceAttrs) > 0 {
+			if attr := find(a, s.resourceAttrs); attr != nil {
+				return *attr, true
+			}
 		}
-		return traceql.NewStaticNil(), false
-	}
-
-	if a.Scope == traceql.AttributeScopeSpan {
-		if attr := find(a, s.spanAttrs); attr != nil {
-			return *attr, true
+		return traceql.StaticNil, false
+	case traceql.AttributeScopeSpan:
+		if len(s.spanAttrs) > 0 {
+			if attr := find(a, s.spanAttrs); attr != nil {
+				return *attr, true
+			}
 		}
-		return traceql.NewStaticNil(), false
-	}
-
-	if a.Scope == traceql.AttributeScopeEvent {
-		if attr := find(a, s.eventAttrs); attr != nil {
-			return *attr, true
+		return traceql.StaticNil, false
+	case traceql.AttributeScopeEvent:
+		if len(s.eventAttrs) > 0 {
+			if attr := find(a, s.eventAttrs); attr != nil {
+				return *attr, true
+			}
 		}
-		return traceql.NewStaticNil(), false
-	}
-	if a.Scope == traceql.AttributeScopeLink {
-		if attr := find(a, s.linkAttrs); attr != nil {
-			return *attr, true
+		return traceql.StaticNil, false
+	case traceql.AttributeScopeLink:
+		if len(s.linkAttrs) > 0 {
+			if attr := find(a, s.linkAttrs); attr != nil {
+				return *attr, true
+			}
 		}
-		return traceql.NewStaticNil(), false
-	}
-	if a.Scope == traceql.AttributeScopeInstrumentation {
-		if attr := find(a, s.instrumentationAttrs); attr != nil {
-			return *attr, true
+		return traceql.StaticNil, false
+	case traceql.AttributeScopeInstrumentation:
+		if len(s.instrumentationAttrs) > 0 {
+			if attr := find(a, s.instrumentationAttrs); attr != nil {
+				return *attr, true
+			}
 		}
-		return traceql.NewStaticNil(), false
+		return traceql.StaticNil, false
 	}
 
 	if a.Intrinsic != traceql.IntrinsicNone {
@@ -230,27 +239,37 @@ func (s *span) AttributeFor(a traceql.Attribute) (traceql.Static, bool) {
 
 	// name search in span, resource, link, and event to give precedence to span
 	// we don't need to do a name search at the trace level b/c it is intrinsics only
-	if attr := findName(a.Name, s.spanAttrs); attr != nil {
-		return *attr, true
+	if len(s.spanAttrs) > 0 {
+		if attr := findName(a.Name, s.spanAttrs); attr != nil {
+			return *attr, true
+		}
 	}
 
-	if attr := findName(a.Name, s.resourceAttrs); attr != nil {
-		return *attr, true
+	if len(s.resourceAttrs) > 0 {
+		if attr := findName(a.Name, s.resourceAttrs); attr != nil {
+			return *attr, true
+		}
 	}
 
-	if attr := findName(a.Name, s.eventAttrs); attr != nil {
-		return *attr, true
+	if len(s.eventAttrs) > 0 {
+		if attr := findName(a.Name, s.eventAttrs); attr != nil {
+			return *attr, true
+		}
 	}
 
-	if attr := findName(a.Name, s.linkAttrs); attr != nil {
-		return *attr, true
+	if len(s.linkAttrs) > 0 {
+		if attr := findName(a.Name, s.linkAttrs); attr != nil {
+			return *attr, true
+		}
 	}
 
-	if attr := findName(a.Name, s.instrumentationAttrs); attr != nil {
-		return *attr, true
+	if len(s.instrumentationAttrs) > 0 {
+		if attr := findName(a.Name, s.instrumentationAttrs); attr != nil {
+			return *attr, true
+		}
 	}
 
-	return traceql.NewStaticNil(), false
+	return traceql.StaticNil, false
 }
 
 func (s *span) ID() []byte {


### PR DESCRIPTION
**What this PR does**:
Some micro-optimizations to improve traceql engine attribute checks. Search bottleneck is usually in the storage layer, but some complex queries, particularly ones with unscoped attributes, are bottlenecked in the engine. 

The **memory** improvement primarily comes from fixing the for loop in span.AttributeFor.

This loop allocs because the address of the loop var must escape:
```go
for _, st := range attrs {
	if st.a == a {
		return &st.s
	}
}
```

But this version doesn't because we take the address of the existing slice entry, which was the intention.
```go
for i := range attrs {
	if attrs[i].a == a {
		return &attrs[i].s
	}
}
```

The **speed** improvement is from also short-circuiting binary operations more like a real compiler if statement does.  Two cases can exit early and don't need to evaluate both sides:
*  x == y && a == b   <-- when x==y is false, can skip a==b
*  x == y || a == b   <-- when x==y is true, can skip a==b

This is the main speed improvement in `traceOrMatch` and `traceOrNoMatch`

<details>
<summary>Benchmark</summary>

```
$ benchstat before.txt after_2.txt
name                                              old time/op    new time/op    delta
BackendBlockTraceQL/spanAttValMatch                  267ms ±10%     254ms ± 2%   -4.79%  (p=0.000 n=10+9)
BackendBlockTraceQL/spanAttValNoMatch               7.00ms ± 3%    6.75ms ± 3%   -3.47%  (p=0.000 n=9+10)
BackendBlockTraceQL/spanAttIntrinsicMatch            137ms ± 3%     134ms ± 1%   -2.50%  (p=0.000 n=10+8)
BackendBlockTraceQL/spanAttIntrinsicNoMatch         7.04ms ± 1%    6.81ms ± 2%   -3.31%  (p=0.000 n=10+10)
BackendBlockTraceQL/resourceAttValMatch              1.24s ± 4%     1.19s ± 2%   -3.56%  (p=0.000 n=10+9)
BackendBlockTraceQL/resourceAttValNoMatch           6.73ms ± 1%    6.55ms ± 1%   -2.65%  (p=0.000 n=10+8)
BackendBlockTraceQL/resourceAttIntrinsicMatch       62.6ms ± 2%    61.3ms ± 1%   -2.02%  (p=0.000 n=9+8)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01    6.86ms ± 1%    6.52ms ± 2%   -4.84%  (p=0.000 n=9+9)
BackendBlockTraceQL/traceOrMatch                     811ms ± 2%     517ms ± 2%  -36.24%  (p=0.000 n=10+10)
BackendBlockTraceQL/traceOrNoMatch                   815ms ± 2%     524ms ± 1%  -35.62%  (p=0.000 n=9+8)
BackendBlockTraceQL/mixedValNoMatch                  411ms ± 1%     402ms ± 2%   -2.10%  (p=0.000 n=10+10)
BackendBlockTraceQL/mixedValMixedMatchAnd           7.71ms ± 2%    7.17ms ± 4%   -6.98%  (p=0.000 n=10+9)
BackendBlockTraceQL/mixedValMixedMatchOr             350ms ± 2%     346ms ± 2%     ~     (p=0.089 n=10+10)
BackendBlockTraceQL/count                            983ms ± 2%     968ms ± 3%     ~     (p=0.053 n=9+10)
BackendBlockTraceQL/struct                           1.34s ± 4%     1.04s ± 8%  -22.93%  (p=0.000 n=10+10)
BackendBlockTraceQL/||                               391ms ± 8%     382ms ± 2%     ~     (p=0.356 n=10+9)
BackendBlockTraceQL/mixed                           52.2ms ± 3%    53.8ms ± 6%     ~     (p=0.190 n=10+10)
BackendBlockTraceQL/complex                         7.42ms ± 6%    7.35ms ± 2%     ~     (p=0.605 n=9+9)

name                                              old speed      new speed      delta
BackendBlockTraceQL/spanAttValMatch                102MB/s ±10%   107MB/s ± 2%   +4.84%  (p=0.000 n=10+9)
BackendBlockTraceQL/spanAttValNoMatch              220MB/s ± 3%   228MB/s ± 3%   +3.60%  (p=0.000 n=9+10)
BackendBlockTraceQL/spanAttIntrinsicMatch          206MB/s ± 3%   212MB/s ± 1%   +2.55%  (p=0.000 n=10+8)
BackendBlockTraceQL/spanAttIntrinsicNoMatch        330MB/s ± 1%   341MB/s ± 2%   +3.44%  (p=0.000 n=10+10)
BackendBlockTraceQL/resourceAttValMatch           21.6MB/s ± 4%  22.4MB/s ± 2%   +3.64%  (p=0.000 n=10+9)
BackendBlockTraceQL/resourceAttValNoMatch         66.1MB/s ± 1%  67.9MB/s ± 1%   +2.73%  (p=0.000 n=10+8)
BackendBlockTraceQL/resourceAttIntrinsicMatch      429MB/s ± 2%   438MB/s ± 1%   +2.06%  (p=0.000 n=9+8)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01  73.6MB/s ± 1%  77.3MB/s ± 2%   +5.09%  (p=0.000 n=9+9)
BackendBlockTraceQL/traceOrMatch                  1.74MB/s ± 2%  2.74MB/s ± 2%  +56.94%  (p=0.000 n=10+10)
BackendBlockTraceQL/traceOrNoMatch                1.73MB/s ± 5%  2.70MB/s ± 1%  +56.09%  (p=0.000 n=10+8)
BackendBlockTraceQL/mixedValNoMatch               5.63MB/s ± 1%  5.75MB/s ± 2%   +2.15%  (p=0.000 n=10+10)
BackendBlockTraceQL/mixedValMixedMatchAnd          113MB/s ± 2%   121MB/s ± 5%   +6.95%  (p=0.000 n=10+10)
BackendBlockTraceQL/mixedValMixedMatchOr          43.9MB/s ± 2%  44.4MB/s ± 2%     ~     (p=0.086 n=10+10)
BackendBlockTraceQL/count                         27.2MB/s ± 2%  27.7MB/s ± 3%     ~     (p=0.053 n=9+10)
BackendBlockTraceQL/struct                        4.73MB/s ± 4%  6.15MB/s ± 7%  +29.85%  (p=0.000 n=10+10)
BackendBlockTraceQL/||                            69.0MB/s ± 8%  70.5MB/s ± 2%     ~     (p=0.345 n=10+9)
BackendBlockTraceQL/mixed                          498MB/s ± 3%   484MB/s ± 6%     ~     (p=0.190 n=10+10)
BackendBlockTraceQL/complex                       62.0MB/s ± 6%  62.5MB/s ± 2%     ~     (p=0.605 n=9+9)

name                                              old MB_io/op   new MB_io/op   delta
BackendBlockTraceQL/spanAttValMatch                   27.3 ± 0%      27.3 ± 0%     ~     (all equal)
BackendBlockTraceQL/spanAttValNoMatch                 1.54 ± 0%      1.54 ± 0%     ~     (all equal)
BackendBlockTraceQL/spanAttIntrinsicMatch             28.3 ± 0%      28.3 ± 0%     ~     (all equal)
BackendBlockTraceQL/spanAttIntrinsicNoMatch           2.32 ± 0%      2.32 ± 0%     ~     (all equal)
BackendBlockTraceQL/resourceAttValMatch               26.8 ± 0%      26.8 ± 0%     ~     (all equal)
BackendBlockTraceQL/resourceAttValNoMatch             0.44 ± 0%      0.44 ± 0%     ~     (all equal)
BackendBlockTraceQL/resourceAttIntrinsicMatch         26.8 ± 0%      26.8 ± 0%     ~     (all equal)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01      0.50 ± 0%      0.50 ± 0%     ~     (all equal)
BackendBlockTraceQL/traceOrMatch                      1.42 ± 0%      1.42 ± 0%     ~     (all equal)
BackendBlockTraceQL/traceOrNoMatch                    1.42 ± 0%      1.42 ± 0%     ~     (all equal)
BackendBlockTraceQL/mixedValNoMatch                   2.31 ± 0%      2.31 ± 0%     ~     (all equal)
BackendBlockTraceQL/mixedValMixedMatchAnd             0.87 ± 0%      0.87 ± 0%     ~     (all equal)
BackendBlockTraceQL/mixedValMixedMatchOr              15.4 ± 0%      15.4 ± 0%     ~     (all equal)
BackendBlockTraceQL/count                             26.8 ± 0%      26.8 ± 0%     ~     (all equal)
BackendBlockTraceQL/struct                            6.36 ± 0%      6.36 ± 0%     ~     (all equal)
BackendBlockTraceQL/||                                26.9 ± 0%      26.9 ± 0%     ~     (all equal)
BackendBlockTraceQL/mixed                             26.0 ± 0%      26.0 ± 0%     ~     (all equal)
BackendBlockTraceQL/complex                           0.46 ± 0%      0.46 ± 0%     ~     (all equal)

name                                              old alloc/op   new alloc/op   delta
BackendBlockTraceQL/spanAttValMatch                 58.9MB ± 1%    58.9MB ± 1%     ~     (p=1.000 n=10+9)
BackendBlockTraceQL/spanAttValNoMatch               2.72MB ± 0%    2.72MB ± 0%     ~     (p=0.113 n=9+10)
BackendBlockTraceQL/spanAttIntrinsicMatch           31.8MB ± 1%    32.0MB ± 1%   +0.69%  (p=0.006 n=10+9)
BackendBlockTraceQL/spanAttIntrinsicNoMatch         2.74MB ± 0%    2.74MB ± 0%   -0.01%  (p=0.005 n=10+10)
BackendBlockTraceQL/resourceAttValMatch              697MB ± 0%     697MB ± 0%     ~     (p=0.370 n=8+9)
BackendBlockTraceQL/resourceAttValNoMatch           2.70MB ± 0%    2.70MB ± 0%   +0.01%  (p=0.000 n=10+10)
BackendBlockTraceQL/resourceAttIntrinsicMatch       7.42MB ± 0%    7.42MB ± 0%     ~     (p=0.211 n=9+10)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01    2.70MB ± 0%    2.70MB ± 0%   +0.01%  (p=0.000 n=10+8)
BackendBlockTraceQL/traceOrMatch                    10.2MB ± 1%     3.5MB ± 6%  -65.44%  (p=0.000 n=6+9)
BackendBlockTraceQL/traceOrNoMatch                  9.46MB ± 0%    3.43MB ± 1%  -63.77%  (p=0.000 n=10+10)
BackendBlockTraceQL/mixedValNoMatch                 2.77MB ± 0%    2.77MB ± 0%   -0.01%  (p=0.000 n=10+10)
BackendBlockTraceQL/mixedValMixedMatchAnd           2.70MB ± 0%    2.70MB ± 0%   +0.02%  (p=0.000 n=9+10)
BackendBlockTraceQL/mixedValMixedMatchOr            3.11MB ± 0%    3.11MB ± 0%   -0.04%  (p=0.000 n=9+10)
BackendBlockTraceQL/count                            506MB ± 0%     507MB ± 0%     ~     (p=0.095 n=9+10)
BackendBlockTraceQL/struct                           221MB ± 4%       8MB ± 3%  -96.32%  (p=0.000 n=10+8)
BackendBlockTraceQL/||                              28.7MB ± 2%    29.0MB ± 0%     ~     (p=0.497 n=10+9)
BackendBlockTraceQL/mixed                           4.28MB ± 0%    4.22MB ± 0%   -1.50%  (p=0.000 n=10+10)
BackendBlockTraceQL/complex                         2.72MB ± 0%    2.73MB ± 0%   +0.13%  (p=0.000 n=8+8)

name                                              old allocs/op  new allocs/op  delta
BackendBlockTraceQL/spanAttValMatch                   635k ± 0%      635k ± 0%   -0.01%  (p=0.000 n=10+9)
BackendBlockTraceQL/spanAttValNoMatch                43.3k ± 0%     43.3k ± 0%   +0.00%  (p=0.001 n=10+10)
BackendBlockTraceQL/spanAttIntrinsicMatch             228k ± 0%      228k ± 0%   -0.04%  (p=0.000 n=9+10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch          43.3k ± 0%     43.3k ± 0%   -0.01%  (p=0.000 n=10+10)
BackendBlockTraceQL/resourceAttValMatch              4.12M ± 0%     4.12M ± 0%   -0.00%  (p=0.000 n=9+9)
BackendBlockTraceQL/resourceAttValNoMatch            43.3k ± 0%     43.3k ± 0%   +0.00%  (p=0.000 n=10+10)
BackendBlockTraceQL/resourceAttIntrinsicMatch        91.7k ± 0%     91.6k ± 0%   -0.10%  (p=0.000 n=9+10)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01     43.3k ± 0%     43.3k ± 0%   +0.00%  (p=0.000 n=10+10)
BackendBlockTraceQL/traceOrMatch                      108k ± 1%       53k ± 1%  -50.80%  (p=0.000 n=8+8)
BackendBlockTraceQL/traceOrNoMatch                    106k ± 0%       53k ± 0%  -50.50%  (p=0.000 n=10+10)
BackendBlockTraceQL/mixedValNoMatch                  44.1k ± 0%     44.0k ± 0%   -0.03%  (p=0.000 n=10+10)
BackendBlockTraceQL/mixedValMixedMatchAnd            43.3k ± 0%     43.4k ± 0%   +0.03%  (p=0.000 n=9+9)
BackendBlockTraceQL/mixedValMixedMatchOr             45.3k ± 0%     45.3k ± 0%   -0.08%  (p=0.000 n=10+10)
BackendBlockTraceQL/count                            2.40M ± 0%     2.40M ± 0%   -0.00%  (p=0.000 n=9+9)
BackendBlockTraceQL/struct                           1.83M ± 2%     0.06M ± 4%  -96.53%  (p=0.000 n=10+9)
BackendBlockTraceQL/||                                210k ± 0%      210k ± 0%   -0.04%  (p=0.000 n=10+9)
BackendBlockTraceQL/mixed                            56.7k ± 0%     56.0k ± 0%   -1.11%  (p=0.000 n=10+10)
BackendBlockTraceQL/complex                          43.6k ± 0%     43.6k ± 0%   +0.14%  (p=0.000 n=10+10)
```
</details>

There is a particularly tough query run internally that was the original impetus for this change:

```
$ benchstat before_complex.txt after_complex2.txt 
name                               old time/op    new time/op     delta
BackendBlockTraceQL/complex_query     2.86s ± 2%      1.55s ± 4%  -45.82%  (p=0.000 n=9+9)

name                               old speed      new speed       delta
BackendBlockTraceQL/complex_query  7.39MB/s ± 2%  13.65MB/s ± 4%  +84.54%  (p=0.000 n=9+9)

name                               old MB_io/op   new MB_io/op    delta
BackendBlockTraceQL/complex_query      21.2 ± 0%       21.2 ± 0%     ~     (all equal)

name                               old alloc/op   new alloc/op    delta
BackendBlockTraceQL/complex_query    1.08GB ± 0%     0.03GB ± 0%  -96.95%  (p=0.000 n=9+8)

name                               old allocs/op  new allocs/op   delta
BackendBlockTraceQL/complex_query     9.88M ± 0%      0.58M ± 0%  -94.13%  (p=0.000 n=10+9)
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`