### PR TITLE
[tempo-cli] Add flags to print simple summary vs full summary

### DIFF
--- a/cmd/tempo-cli/cmd-analyse-blocks.go
+++ b/cmd/tempo-cli/cmd-analyse-blocks.go
@@ -14,6 +14,8 @@ type analyseBlocksCmd struct {
 	backendOptions
 
 	Jsonnet            bool   `help:"output Jsonnet necessary for overrides"`
+	SimpleSummary      bool   `help:"Print only single line of top attributes" default:"false"`
+	PrintFullSummary   bool   `help:"Print full summary of the analysed block" default:"true"`
 	TenantID           string `arg:"" help:"tenant-id within the bucket"`
 	MinCompactionLevel int    `help:"Min compaction level to analyse" default:"3"`
 	MaxBlocks          int    `help:"Max number of blocks to analyse" default:"10"`
@@ -101,5 +103,5 @@ func (cmd *analyseBlocksCmd) Run(ctx *globalOptions) error {
 			totalBytes: totalResourceBytes,
 			attributes: topResourceAttrs,
 		},
-	}).print(cmd.NumAttr, cmd.Jsonnet)
+	}).print(cmd.NumAttr, cmd.Jsonnet, cmd.SimpleSummary, cmd.PrintFullSummary)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: Add `print-full-summary` flag to allow user to omit the summary and `simple-summary` to only print only the names of the top attributes. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`