### PR TITLE
fix: bring back content-type header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [ENHANCEMENT] Add disk caching in ingester SearchTagValuesV2 for completed blocks [#4069](https://github.com/grafana/tempo/pull/4069) (@electron0zero)
 * [BUGFIX] Replace hedged requests roundtrips total with a counter. [#4063](https://github.com/grafana/tempo/pull/4063) [#4078](https://github.com/grafana/tempo/pull/4078) (@galalen)
 * [BUGFIX] Metrics generators: Correctly drop from the ring before stopping ingestion to reduce drops during a rollout. [#4101](https://github.com/grafana/tempo/pull/4101) (@joe-elliott)
+* [BUGFIX] Bring back application-json content-type header. [#4121](https://github.com/grafana/tempo/pull/4121) (@javiermolinar)
 * [CHANGE] TraceByID: don't allow concurrent_shards greater than query_shards. [#4074](https://github.com/grafana/tempo/pull/4074) (@electron0zero)
 * **BREAKING CHANGE** tempo-query is no longer a jaeger instance with grpcPlugin. Its now a standalone server. Serving a grpc api for jaeger on `0.0.0.0:7777` by default. [#3840](https://github.com/grafana/tempo/issues/3840) (@frzifus)
 * [CHANGE] **BREAKING CHANGE** The dynamic injection of X-Scope-OrgID header for metrics generator remote-writes is changed. If the header is aleady set in per-tenant overrides or global tempo configuration, then it is honored and not overwritten. [#4021](https://github.com/grafana/tempo/pull/4021) (@mdisibio)

--- a/modules/frontend/combiner/metrics_query_range.go
+++ b/modules/frontend/combiner/metrics_query_range.go
@@ -18,7 +18,7 @@ func NewQueryRange(req *tempopb.QueryRangeRequest, trackDiffs bool) (Combiner, e
 		return nil, err
 	}
 
-	return &genericCombiner[*tempopb.QueryRangeResponse]{
+	c := &genericCombiner[*tempopb.QueryRangeResponse]{
 		httpStatusCode: 200,
 		new:            func() *tempopb.QueryRangeResponse { return &tempopb.QueryRangeResponse{} },
 		current:        &tempopb.QueryRangeResponse{Metrics: &tempopb.SearchMetrics{}},
@@ -52,7 +52,11 @@ func NewQueryRange(req *tempopb.QueryRangeRequest, trackDiffs bool) (Combiner, e
 			sortResponse(resp)
 			return resp, nil
 		},
-	}, nil
+	}
+
+	initHTTPCombiner(c, api.HeaderAcceptJSON)
+
+	return c, nil
 }
 
 func NewTypedQueryRange(req *tempopb.QueryRangeRequest, trackDiffs bool) (GRPCCombiner[*tempopb.QueryRangeResponse], error) {
@@ -60,8 +64,6 @@ func NewTypedQueryRange(req *tempopb.QueryRangeRequest, trackDiffs bool) (GRPCCo
 	if err != nil {
 		return nil, err
 	}
-
-	initHTTPCombiner(c.(*genericCombiner[*tempopb.QueryRangeResponse]), api.HeaderAcceptJSON)
 	return c.(GRPCCombiner[*tempopb.QueryRangeResponse]), nil
 }
 

--- a/modules/frontend/combiner/metrics_query_range.go
+++ b/modules/frontend/combiner/metrics_query_range.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/traceql"
 )
@@ -21,7 +22,7 @@ func NewQueryRange(req *tempopb.QueryRangeRequest, trackDiffs bool) (Combiner, e
 		httpStatusCode: 200,
 		new:            func() *tempopb.QueryRangeResponse { return &tempopb.QueryRangeResponse{} },
 		current:        &tempopb.QueryRangeResponse{Metrics: &tempopb.SearchMetrics{}},
-		combine: func(partial *tempopb.QueryRangeResponse, _ *tempopb.QueryRangeResponse, resp PipelineResponse) error {
+		combine: func(partial *tempopb.QueryRangeResponse, _ *tempopb.QueryRangeResponse, _ PipelineResponse) error {
 			if partial.Metrics != nil {
 				// this is a coordination between the sharder and combiner. the sharder returns one response with summary metrics
 				// only. the combiner correctly takes and accumulates that job. however, if the response has no jobs this is
@@ -60,6 +61,7 @@ func NewTypedQueryRange(req *tempopb.QueryRangeRequest, trackDiffs bool) (GRPCCo
 		return nil, err
 	}
 
+	initHTTPCombiner(c.(*genericCombiner[*tempopb.QueryRangeResponse]), api.HeaderAcceptJSON)
 	return c.(GRPCCombiner[*tempopb.QueryRangeResponse]), nil
 }
 

--- a/modules/frontend/combiner/search.go
+++ b/modules/frontend/combiner/search.go
@@ -16,7 +16,7 @@ func NewSearch(limit int) Combiner {
 	metadataCombiner := traceql.NewMetadataCombiner()
 	diffTraces := map[string]struct{}{}
 
-	return &genericCombiner[*tempopb.SearchResponse]{
+	c := &genericCombiner[*tempopb.SearchResponse]{
 		httpStatusCode: 200,
 		new:            func() *tempopb.SearchResponse { return &tempopb.SearchResponse{} },
 		current:        &tempopb.SearchResponse{Metrics: &tempopb.SearchMetrics{}},
@@ -97,6 +97,8 @@ func NewSearch(limit int) Combiner {
 			return metadataCombiner.Count() >= limit
 		},
 	}
+	initHTTPCombiner(c, api.HeaderAcceptJSON)
+	return c
 }
 
 func addRootSpanNotReceivedText(results []*tempopb.TraceSearchMetadata) {
@@ -108,7 +110,5 @@ func addRootSpanNotReceivedText(results []*tempopb.TraceSearchMetadata) {
 }
 
 func NewTypedSearch(limit int) GRPCCombiner[*tempopb.SearchResponse] {
-	c := NewSearch(limit).(GRPCCombiner[*tempopb.SearchResponse])
-	initHTTPCombiner(c.(*genericCombiner[*tempopb.SearchResponse]), api.HeaderAcceptJSON)
-	return c
+	return NewSearch(limit).(GRPCCombiner[*tempopb.SearchResponse])
 }

--- a/modules/frontend/combiner/search.go
+++ b/modules/frontend/combiner/search.go
@@ -3,6 +3,7 @@ package combiner
 import (
 	"sort"
 
+	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/search"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/traceql"
@@ -107,5 +108,7 @@ func addRootSpanNotReceivedText(results []*tempopb.TraceSearchMetadata) {
 }
 
 func NewTypedSearch(limit int) GRPCCombiner[*tempopb.SearchResponse] {
-	return NewSearch(limit).(GRPCCombiner[*tempopb.SearchResponse])
+	c := NewSearch(limit).(GRPCCombiner[*tempopb.SearchResponse])
+	initHTTPCombiner(c.(*genericCombiner[*tempopb.SearchResponse]), api.HeaderAcceptJSON)
+	return c
 }

--- a/modules/frontend/combiner/search_tag_values.go
+++ b/modules/frontend/combiner/search_tag_values.go
@@ -42,9 +42,7 @@ func NewSearchTagValues(limitBytes int) Combiner {
 }
 
 func NewTypedSearchTagValues(limitBytes int) GRPCCombiner[*tempopb.SearchTagValuesResponse] {
-	c := NewSearchTagValues(limitBytes).(GRPCCombiner[*tempopb.SearchTagValuesResponse])
-	initHTTPCombiner(c.(*genericCombiner[*tempopb.SearchTagValuesResponse]), api.HeaderAcceptJSON)
-	return c
+	return NewSearchTagValues(limitBytes).(GRPCCombiner[*tempopb.SearchTagValuesResponse])
 }
 
 func NewSearchTagValuesV2(limitBytes int) Combiner {
@@ -88,7 +86,5 @@ func NewSearchTagValuesV2(limitBytes int) Combiner {
 }
 
 func NewTypedSearchTagValuesV2(limitBytes int) GRPCCombiner[*tempopb.SearchTagValuesV2Response] {
-	c := NewSearchTagValuesV2(limitBytes).(GRPCCombiner[*tempopb.SearchTagValuesV2Response])
-	initHTTPCombiner(c.(*genericCombiner[*tempopb.SearchTagValuesV2Response]), api.HeaderAcceptJSON)
-	return c
+	return NewSearchTagValuesV2(limitBytes).(GRPCCombiner[*tempopb.SearchTagValuesV2Response])
 }

--- a/modules/frontend/combiner/search_tag_values.go
+++ b/modules/frontend/combiner/search_tag_values.go
@@ -1,6 +1,7 @@
 package combiner
 
 import (
+	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/collector"
 	"github.com/grafana/tempo/pkg/tempopb"
 )
@@ -14,7 +15,7 @@ func NewSearchTagValues(limitBytes int) Combiner {
 	// Distinct collector with no limit
 	d := collector.NewDistinctString(limitBytes)
 
-	return &genericCombiner[*tempopb.SearchTagValuesResponse]{
+	c := &genericCombiner[*tempopb.SearchTagValuesResponse]{
 		httpStatusCode: 200,
 		new:            func() *tempopb.SearchTagValuesResponse { return &tempopb.SearchTagValuesResponse{} },
 		current:        &tempopb.SearchTagValuesResponse{TagValues: make([]string, 0)},
@@ -36,17 +37,21 @@ func NewSearchTagValues(limitBytes int) Combiner {
 			return response, nil
 		},
 	}
+	initHTTPCombiner(c, api.HeaderAcceptJSON)
+	return c
 }
 
 func NewTypedSearchTagValues(limitBytes int) GRPCCombiner[*tempopb.SearchTagValuesResponse] {
-	return NewSearchTagValues(limitBytes).(GRPCCombiner[*tempopb.SearchTagValuesResponse])
+	c := NewSearchTagValues(limitBytes).(GRPCCombiner[*tempopb.SearchTagValuesResponse])
+	initHTTPCombiner(c.(*genericCombiner[*tempopb.SearchTagValuesResponse]), api.HeaderAcceptJSON)
+	return c
 }
 
 func NewSearchTagValuesV2(limitBytes int) Combiner {
 	// Distinct collector with no limit and diff enabled
 	d := collector.NewDistinctValueWithDiff(limitBytes, func(tv tempopb.TagValue) int { return len(tv.Type) + len(tv.Value) })
 
-	return &genericCombiner[*tempopb.SearchTagValuesV2Response]{
+	c := &genericCombiner[*tempopb.SearchTagValuesV2Response]{
 		httpStatusCode: 200,
 		current:        &tempopb.SearchTagValuesV2Response{TagValues: []*tempopb.TagValue{}},
 		new:            func() *tempopb.SearchTagValuesV2Response { return &tempopb.SearchTagValuesV2Response{} },
@@ -78,8 +83,12 @@ func NewSearchTagValuesV2(limitBytes int) Combiner {
 			return response, nil
 		},
 	}
+	initHTTPCombiner(c, api.HeaderAcceptJSON)
+	return c
 }
 
 func NewTypedSearchTagValuesV2(limitBytes int) GRPCCombiner[*tempopb.SearchTagValuesV2Response] {
-	return NewSearchTagValuesV2(limitBytes).(GRPCCombiner[*tempopb.SearchTagValuesV2Response])
+	c := NewSearchTagValuesV2(limitBytes).(GRPCCombiner[*tempopb.SearchTagValuesV2Response])
+	initHTTPCombiner(c.(*genericCombiner[*tempopb.SearchTagValuesV2Response]), api.HeaderAcceptJSON)
+	return c
 }

--- a/modules/frontend/combiner/search_tags.go
+++ b/modules/frontend/combiner/search_tags.go
@@ -1,6 +1,7 @@
 package combiner
 
 import (
+	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/collector"
 	"github.com/grafana/tempo/pkg/tempopb"
 )
@@ -13,7 +14,7 @@ var (
 func NewSearchTags(limitBytes int) Combiner {
 	d := collector.NewDistinctString(limitBytes)
 
-	return &genericCombiner[*tempopb.SearchTagsResponse]{
+	c := &genericCombiner[*tempopb.SearchTagsResponse]{
 		httpStatusCode: 200,
 		new:            func() *tempopb.SearchTagsResponse { return &tempopb.SearchTagsResponse{} },
 		current:        &tempopb.SearchTagsResponse{TagNames: make([]string, 0)},
@@ -35,10 +36,14 @@ func NewSearchTags(limitBytes int) Combiner {
 			return response, nil
 		},
 	}
+	initHTTPCombiner(c, api.HeaderAcceptJSON)
+	return c
 }
 
 func NewTypedSearchTags(limitBytes int) GRPCCombiner[*tempopb.SearchTagsResponse] {
-	return NewSearchTags(limitBytes).(GRPCCombiner[*tempopb.SearchTagsResponse])
+	c := NewSearchTags(limitBytes).(GRPCCombiner[*tempopb.SearchTagsResponse])
+	initHTTPCombiner(c.(*genericCombiner[*tempopb.SearchTagsResponse]), api.HeaderAcceptJSON)
+	return c
 }
 
 func NewSearchTagsV2(limitBytes int) Combiner {
@@ -89,5 +94,7 @@ func NewSearchTagsV2(limitBytes int) Combiner {
 }
 
 func NewTypedSearchTagsV2(limitBytes int) GRPCCombiner[*tempopb.SearchTagsV2Response] {
-	return NewSearchTagsV2(limitBytes).(GRPCCombiner[*tempopb.SearchTagsV2Response])
+	c := NewSearchTagsV2(limitBytes).(GRPCCombiner[*tempopb.SearchTagsV2Response])
+	initHTTPCombiner(c.(*genericCombiner[*tempopb.SearchTagsV2Response]), api.HeaderAcceptJSON)
+	return c
 }

--- a/modules/frontend/combiner/search_tags.go
+++ b/modules/frontend/combiner/search_tags.go
@@ -41,16 +41,14 @@ func NewSearchTags(limitBytes int) Combiner {
 }
 
 func NewTypedSearchTags(limitBytes int) GRPCCombiner[*tempopb.SearchTagsResponse] {
-	c := NewSearchTags(limitBytes).(GRPCCombiner[*tempopb.SearchTagsResponse])
-	initHTTPCombiner(c.(*genericCombiner[*tempopb.SearchTagsResponse]), api.HeaderAcceptJSON)
-	return c
+	return NewSearchTags(limitBytes).(GRPCCombiner[*tempopb.SearchTagsResponse])
 }
 
 func NewSearchTagsV2(limitBytes int) Combiner {
 	// Distinct collector map to collect scopes and scope values
 	distinctValues := collector.NewScopedDistinctString(limitBytes)
 
-	return &genericCombiner[*tempopb.SearchTagsV2Response]{
+	c := &genericCombiner[*tempopb.SearchTagsV2Response]{
 		httpStatusCode: 200,
 		new:            func() *tempopb.SearchTagsV2Response { return &tempopb.SearchTagsV2Response{} },
 		current:        &tempopb.SearchTagsV2Response{Scopes: make([]*tempopb.SearchTagsV2Scope, 0)},
@@ -91,10 +89,10 @@ func NewSearchTagsV2(limitBytes int) Combiner {
 			return response, nil
 		},
 	}
+	initHTTPCombiner(c, api.HeaderAcceptJSON)
+	return c
 }
 
 func NewTypedSearchTagsV2(limitBytes int) GRPCCombiner[*tempopb.SearchTagsV2Response] {
-	c := NewSearchTagsV2(limitBytes).(GRPCCombiner[*tempopb.SearchTagsV2Response])
-	initHTTPCombiner(c.(*genericCombiner[*tempopb.SearchTagsV2Response]), api.HeaderAcceptJSON)
-	return c
+	return NewSearchTagsV2(limitBytes).(GRPCCombiner[*tempopb.SearchTagsV2Response])
 }


### PR DESCRIPTION
**What this PR does**:
This pr brings back the `application-json ` content-type header.
Previously the common combiner harcoded the header to application json. Now we need to initialize the combiner with default values


**Which issue(s) this PR fixes**:
Fixes #4121

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`