### PR TITLE
[Doc] use proper default value for grpc server message size

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,13 +15,6 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - name: Get app token
-        uses: actions/create-github-app-token@v1
-        id: get-github-app-token
-        with:
-          app-id: ${{secrets.APP_ID}}
-          private-key: ${{secrets.APP_PRIVATE_KEY}}
-          owner: ${{ github.repository_owner }}
       - name: Checkout Actions
         uses: actions/checkout@v4
         with:
@@ -35,6 +28,6 @@ jobs:
       - name: Run backport
         uses: ./actions/backport
         with:
-          token: ${{ steps.get-github-app-token.outputs.token }}
+          token: ${{secrets.GITHUB_TOKEN}}
           labelsToAdd: "backport"
           title: "[{{base}}] {{originalTitle}}"

--- a/.github/workflows/dependabot_serverless_gomod.yml
+++ b/.github/workflows/dependabot_serverless_gomod.yml
@@ -15,7 +15,7 @@ jobs:
   dependabot:
     name: Serverless gomod update
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'tempo-gh-bot[bot]' }}
     steps:
       - name: Set up Go 1.22
         uses: actions/setup-go@v5

--- a/.github/workflows/doc-validator.yml
+++ b/.github/workflows/doc-validator.yml
@@ -9,13 +9,6 @@ jobs:
     container:
       image: "grafana/doc-validator:v5.2.0"
     steps:
-      - name: Get app token
-        uses: actions/create-github-app-token@v1
-        id: get-github-app-token
-        with:
-          app-id: ${{secrets.APP_ID}}
-          private-key: ${{secrets.APP_PRIVATE_KEY}}
-          owner: ${{ github.repository_owner }}
       - name: "Checkout code"
         uses: "actions/checkout@v4"
       - name: "Run doc-validator"
@@ -37,5 +30,3 @@ jobs:
               --filter-mode=nofilter \
               --name=doc-validator \
               --reporter=github-pr-review
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: "${{ steps.get-github-app-token.outputs.token }}"

--- a/.github/workflows/doc-validator.yml
+++ b/.github/workflows/doc-validator.yml
@@ -30,3 +30,5 @@ jobs:
               --filter-mode=nofilter \
               --name=doc-validator \
               --reporter=github-pr-review
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -114,11 +114,11 @@ server:
 
     # Max gRPC message size that can be received
     # This value may need to be increased if you have large traces
-    [grpc_server_max_recv_msg_size: <int> | default = 4194304]
+    [grpc_server_max_recv_msg_size: <int> | default = 16777216]
 
     # Max gRPC message size that can be sent
     # This value may need to be increased if you have large traces
-    [grpc_server_max_send_msg_size: <int> | default = 4194304]
+    [grpc_server_max_send_msg_size: <int> | default = 16777216]
 ```
 
 ## Distributor


### PR DESCRIPTION
**What this PR does**:

It updates the documentation to reflect the real default value for the grpc server message size, which is forced to 16MB here: https://github.com/grafana/tempo/blob/109f8d0b2bf64d83b97242af9d793425652eaa2a/cmd/tempo/app/config.go#L90

**Checklist**

- [x] Documentation added
