### PR TITLE
tempo-cli: add support for /api/v2/traces endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [ENHANCEMENT] tempo-cli: add support for /api/v2/traces endpoint [#4127](https://github.com/grafana/tempo/pull/4127) (@electron0zero)
 * [ENHANCEMENT] Speedup collection of results from ingesters in the querier [#4100](https://github.com/grafana/tempo/pull/4100) (@electron0zero)
 * [ENHANCEMENT] Speedup DistinctValue collector and exit early for ingesters [#4104](https://github.com/grafana/tempo/pull/4104) (@electron0zero)
 * [ENHANCEMENT] Add disk caching in ingester SearchTagValuesV2 for completed blocks [#4069](https://github.com/grafana/tempo/pull/4069) (@electron0zero)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## main / unreleased
 
-* [ENHANCEMENT] tempo-cli: add support for /api/v2/traces endpoint [#4127](https://github.com/grafana/tempo/pull/4127) (@electron0zero)
+* [CHANGE] tempo-cli: add support for /api/v2/traces endpoint [#4127](https://github.com/grafana/tempo/pull/4127) (@electron0zero)
+  **BREAKING CHANGE** The `tempo-cli` now uses the `/api/v2/traces` endpoint by default, 
+  please use `--v1` flag to use `/api/traces` endpoint, which was the default in previous versions.
 * [ENHANCEMENT] Speedup collection of results from ingesters in the querier [#4100](https://github.com/grafana/tempo/pull/4100) (@electron0zero)
 * [ENHANCEMENT] Speedup DistinctValue collector and exit early for ingesters [#4104](https://github.com/grafana/tempo/pull/4104) (@electron0zero)
 * [ENHANCEMENT] Add disk caching in ingester SearchTagValuesV2 for completed blocks [#4069](https://github.com/grafana/tempo/pull/4069) (@electron0zero)

--- a/cmd/tempo-cli/cmd-query-trace-id.go
+++ b/cmd/tempo-cli/cmd-query-trace-id.go
@@ -27,9 +27,9 @@ func (cmd *queryTraceIDCmd) Run(_ *globalOptions) error {
 		}
 		// log the Message and trace field
 		if traceResp.Message != "" {
-			// print error message to stderr if there is one.
-			// this allows use to get a clean trace on the stdout that can be piped to a file or another commands.
-			fmt.Fprintf(os.Stderr, "status: %s , message: %s\n", traceResp.Status, traceResp.Message)
+			// print message and status to stderr if there is one.
+			// allows users to get a clean trace on the stdout, and pipe it to a file or another commands.
+			_, _ = fmt.Fprintf(os.Stderr, "status: %s , message: %s\n", traceResp.Status, traceResp.Message)
 		}
 		// only print the trace field
 		return printAsJSON(traceResp.Trace)

--- a/cmd/tempo-cli/cmd-query-trace-id.go
+++ b/cmd/tempo-cli/cmd-query-trace-id.go
@@ -11,7 +11,7 @@ type queryTraceIDCmd struct {
 	APIEndpoint string `arg:"" help:"tempo api endpoint"`
 	TraceID     string `arg:"" help:"trace ID to retrieve"`
 
-	V2    bool   `name:"v2" help:"use v2 API"`
+	V1    bool   `name:"v1" help:"Use v1 API /api/traces endpoint"`
 	OrgID string `help:"optional orgID"`
 }
 
@@ -19,25 +19,26 @@ func (cmd *queryTraceIDCmd) Run(_ *globalOptions) error {
 	client := httpclient.New(cmd.APIEndpoint, cmd.OrgID)
 	// util.QueryTrace will only add orgID header if len(orgID) > 0
 
-	// use v2 API if specified
-	if cmd.V2 {
-		traceResp, err := client.QueryTraceV2(cmd.TraceID)
+	// use v1 API if specified, we default to v2
+	if cmd.V1 {
+		trace, err := client.QueryTrace(cmd.TraceID)
 		if err != nil {
 			return err
 		}
-		// log the Message and trace field
-		if traceResp.Message != "" {
-			// print message and status to stderr if there is one.
-			// allows users to get a clean trace on the stdout, and pipe it to a file or another commands.
-			_, _ = fmt.Fprintf(os.Stderr, "status: %s , message: %s\n", traceResp.Status, traceResp.Message)
-		}
-		// only print the trace field
-		return printAsJSON(traceResp.Trace)
+		return printAsJSON(trace)
 	}
 
-	trace, err := client.QueryTrace(cmd.TraceID)
+	traceResp, err := client.QueryTraceV2(cmd.TraceID)
 	if err != nil {
 		return err
 	}
-	return printAsJSON(trace)
+	// log the Message and trace field
+	if traceResp.Message != "" {
+		// print message and status to stderr if there is one.
+		// allows users to get a clean trace on the stdout, and pipe it to a file or another commands.
+		_, _ = fmt.Fprintf(os.Stderr, "status: %s , message: %s\n", traceResp.Status, traceResp.Message)
+	}
+	// only print the trace field
+	return printAsJSON(traceResp.Trace)
+
 }

--- a/cmd/tempo-cli/cmd-query-trace-id.go
+++ b/cmd/tempo-cli/cmd-query-trace-id.go
@@ -40,5 +40,4 @@ func (cmd *queryTraceIDCmd) Run(_ *globalOptions) error {
 	}
 	// only print the trace field
 	return printAsJSON(traceResp.Trace)
-
 }

--- a/cmd/tempo-cli/main.go
+++ b/cmd/tempo-cli/main.go
@@ -94,7 +94,7 @@ func main() {
 	ctx := kong.Parse(&cli,
 		kong.UsageOnError(),
 		kong.ConfigureHelp(kong.HelpOptions{
-			// Compact: true,
+			Compact: true,
 		}),
 	)
 	err := ctx.Run(&cli.globalOptions)

--- a/cmd/tempo-cli/shared.go
+++ b/cmd/tempo-cli/shared.go
@@ -125,7 +125,7 @@ func loadBlock(r backend.Reader, c backend.Compactor, tenantID string, id uuid.U
 	}, nil
 }
 
-func printAsJSON(value interface{}) error {
+func printAsJSON[T any](value T) error {
 	traceJSON, err := json.Marshal(value)
 	if err != nil {
 		return err

--- a/docs/sources/tempo/operations/tempo_cli.md
+++ b/docs/sources/tempo/operations/tempo_cli.md
@@ -70,7 +70,7 @@ Arguments:
 
 Options:
 - `--org-id <value>` Organization ID (for use in multi-tenant setup).
-- `--v2` use v2 API (for using TraceByID V2 endpoint to fetch traces).
+- `--v2` use v2 API (for using /api/v2/traces endpoint to fetch traces).
 
 **Example:**
 ```bash

--- a/docs/sources/tempo/operations/tempo_cli.md
+++ b/docs/sources/tempo/operations/tempo_cli.md
@@ -70,6 +70,7 @@ Arguments:
 
 Options:
 - `--org-id <value>` Organization ID (for use in multi-tenant setup).
+- `--v2` use v2 API (for using TraceByID V2 endpoint to fetch traces).
 
 **Example:**
 ```bash

--- a/docs/sources/tempo/operations/tempo_cli.md
+++ b/docs/sources/tempo/operations/tempo_cli.md
@@ -70,7 +70,7 @@ Arguments:
 
 Options:
 - `--org-id <value>` Organization ID (for use in multi-tenant setup).
-- `--v2` use v2 API (for using /api/v2/traces endpoint to fetch traces).
+- `--v1` use v1 API (use /api/traces endpoint to fetch traces, default: /api/v2/traces).
 
 **Example:**
 ```bash

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -96,11 +96,11 @@ func (c *Client) getFor(url string, m proto.Message) (*http.Response, error) {
 	}
 
 	marshallingFormat := applicationJSON
-	if strings.Contains(url, QueryTraceEndpoint) {
+	if strings.Contains(url, QueryTraceEndpoint) || strings.Contains(url, QueryTraceV2Endpoint) {
 		marshallingFormat = applicationProtobuf
 	}
 	// Set 'Accept' header to 'application/protobuf'.
-	// This is required for the /api/traces endpoint to return a protobuf response.
+	// This is required for the /api/traces and /api/v2/traces endpoint to return a protobuf response.
 	// JSON lost backwards compatibility with the upgrade to `opentelemetry-proto` v0.18.0.
 	req.Header.Set(acceptHeader, marshallingFormat)
 

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -26,7 +26,8 @@ import (
 const (
 	orgIDHeader = "X-Scope-OrgID"
 
-	QueryTraceEndpoint = "/api/traces"
+	QueryTraceEndpoint   = "/api/traces"
+	QueryTraceV2Endpoint = "/api/v2/traces"
 
 	acceptHeader        = "Accept"
 	applicationProtobuf = "application/protobuf"
@@ -253,7 +254,18 @@ func (c *Client) QueryTrace(id string) (*tempopb.Trace, error) {
 		}
 		return nil, err
 	}
+	return m, nil
+}
 
+func (c *Client) QueryTraceV2(id string) (*tempopb.TraceByIDResponse, error) {
+	m := &tempopb.TraceByIDResponse{}
+	resp, err := c.getFor(c.BaseURL+QueryTraceV2Endpoint+"/"+id, m)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return nil, util.ErrTraceNotFound
+		}
+		return nil, err
+	}
 	return m, nil
 }
 


### PR DESCRIPTION
**What this PR does**:
Use `/api/v2/traces` by default to query trace by id and get partial traces for bigger traces, also add `--v1` flag in `tempo-cli query api trace-id` command to query `/api/traces` endpoint.

see https://github.com/grafana/tempo/pull/3941 for more details on  `/api/v2/traces`.

example usage: `tempo-cli query api trace-id http://tempo:3200 fd9b20c52c74f67de6a69279bfba3936 --v1 > trace.json`

there is a change in default behaviour and you need to use `--v1` if you are on a older version of tempo that doesn't support `/api/v2/traces` or want to use `/api/traces`, because of that, this change is marked as **BREAKING CHANGE**

---

This PR also includes a small change in the way we Marshal the trace.

`encoding/json` package can't handle +Inf, -Inf, NaN values and will fail to Marshal the response from tracebyid endpoints if response has keys with values of +Inf, -Inf or NaN.

`gogo/protobuf/jsonpb` package correctly handles these values so use that to Marshal and print the response to stdout

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`