### PR TITLE
[docs] use proper default value for grpc server message size

### DIFF
--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -114,11 +114,11 @@ server:
 
     # Max gRPC message size that can be received
     # This value may need to be increased if you have large traces
-    [grpc_server_max_recv_msg_size: <int> | default = 4194304]
+    [grpc_server_max_recv_msg_size: <int> | default = 16777216]
 
     # Max gRPC message size that can be sent
     # This value may need to be increased if you have large traces
-    [grpc_server_max_send_msg_size: <int> | default = 4194304]
+    [grpc_server_max_send_msg_size: <int> | default = 16777216]
 ```
 
 ## Distributor


### PR DESCRIPTION
**What this PR does**:

It updates the documentation to reflect the real default value for the grpc server message size, which is forced to 16MB here: https://github.com/grafana/tempo/blob/109f8d0b2bf64d83b97242af9d793425652eaa2a/cmd/tempo/app/config.go#L90

**Checklist**

- [x] Documentation added
