### PR TITLE
[DOC] Clarify Parquet requirements in 2.6

### DIFF
--- a/.github/workflows/add-to-docs-project.yml
+++ b/.github/workflows/add-to-docs-project.yml
@@ -6,7 +6,7 @@ on:
     types: [labeled]
 jobs:
   main:
-    if: ${{ github.event.label.name == 'type/docs' }}
+    if: ${{ github.event.label.name == 'type/docs' }} && { github.repository == 'grafana/tempo' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/add-to-docs-project.yml
+++ b/.github/workflows/add-to-docs-project.yml
@@ -6,7 +6,7 @@ on:
     types: [labeled]
 jobs:
   main:
-    if: ${{ github.event.label.name == 'type/docs' }} && { github.repository == 'grafana/tempo' }}
+    if: ${{ github.event.label.name == 'type/docs' && github.repository == 'grafana/tempo' }}
     permissions:
       contents: read
       id-token: write

--- a/docs/sources/tempo/release-notes/v2-6.md
+++ b/docs/sources/tempo/release-notes/v2-6.md
@@ -168,7 +168,12 @@ vParquet4 format is now the default block format.
 It's production ready and we highly recommend switching to it for improved query performance. [PR [3810](https://github.com/grafana/tempo/pull/3810)]
 
 Upgrading to Tempo 2.6 modifies the Parquet block format.
-Although you can use Tempo 2.6 with vParquet2 or vParquet3, you can only use Tempo 2.6 with vParquet3.
+You don't need to do anything with Parquet to go from 2.5 to 2.6.
+If you used vParquet2 or vParquet3, all of your old blocks remain and can be read by Tempo 2.6.
+Tempo 2.6 creates vParquet4 blocks by default, which enables the new TraceQL features.
+
+Although you can use Tempo 2.6 with vParquet2 or vParquet3, you can only use vParquet4 with Tempo 2.5 and later.
+If you are using 2.5 with vParquet4, you'll need to upgrade to Tempo 2.6 to use the new TraceQL features.
 
 You can also use the `tempo-cli analyse blocks` command to query vParquet4 blocks. [PR 3868](https://github.com/grafana/tempo/pull/3868)].
 Refer to the [Tempo CLI ](https://grafana.com/docs/tempo/next/operations/tempo_cli/#analyse-blocks)documentation for more information.

--- a/docs/sources/tempo/setup/upgrade.md
+++ b/docs/sources/tempo/setup/upgrade.md
@@ -84,7 +84,12 @@ vParquet4 format is now the default block format.
 It's production ready and we highly recommend switching to it for improved query performance. [PR [3810](https://github.com/grafana/tempo/pull/3810)]
 
 Upgrading to Tempo 2.6 modifies the Parquet block format.
-Although you can use Tempo 2.6 with vParquet2 or vParquet3, you can only use Tempo 2.6 with vParquet3.
+You don't need to do anything with Parquet to go from 2.5 to 2.6.
+If you used vParquet2 or vParquet3, all of your old blocks remain and can be read by Tempo 2.6.
+Tempo 2.6 creates vParquet4 blocks by default, which enables the new TraceQL features.
+
+Although you can use Tempo 2.6 with vParquet2 or vParquet3, you can only use vParquet4 with Tempo 2.5 and later.
+If you are using 2.5 with vParquet4, you'll need to upgrade to Tempo 2.6 to use the new TraceQL features.
 
 You can also use the `tempo-cli analyse blocks` command to query vParquet4 blocks. [PR 3868](https://github.com/grafana/tempo/pull/3868)].
 Refer to the [Tempo CLI ](https://grafana.com/docs/tempo/next/operations/tempo_cli/#analyse-blocks)documentation for more information.


### PR DESCRIPTION
**What this PR does**:

Clarifies the vParquet4 requirements in the release notes and upgrade docs. 

Redo of https://github.com/grafana/tempo/pull/4107

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`