### PR TITLE
Update add-to-docs-project.yml

### DIFF
--- a/.github/workflows/add-to-docs-project.yml
+++ b/.github/workflows/add-to-docs-project.yml
@@ -6,7 +6,9 @@ on:
     types: [labeled]
 jobs:
   main:
-    if: ${{ github.event.label.name == 'type/docs' }}
+    if: 
+      ${{ github.event.label.name == 'type/docs' 
+      github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Please check this! I'm trying to add a fix to the GitHub add for PRs to let them work with forks. This is my first time editing a GitHub action. 

@jdbaldry posted this fix: "If you want to stop the errors on forks, you can add github.event.pull_request.head.repo.full_name == github.repository to the if expression that limits job execution."

**What this PR does**:
Attempts to fix a build error using a suggestion Jack B. 

Example error: https://github.com/grafana/tempo/actions/runs/11079160979/job/30787709474?pr=4135 

![image](https://github.com/user-attachments/assets/9e866f1c-feb7-48d8-afbf-0a12477b87a3)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`