### PR TITLE
Updated metrics generator note

### DIFF
--- a/docs/sources/tempo/metrics-generator/span_metrics.md
+++ b/docs/sources/tempo/metrics-generator/span_metrics.md
@@ -21,7 +21,7 @@ but it has distributed tracing implemented.
 You get out-of-the-box metrics from your tracing pipeline.
 
 {{< admonition type="note" >}}
-Metrics generation is disabled by default. Contact Grafana Support to enable metrics generation in your organization.
+Metrics generation is disabled by default. You can enable it for use with Application Observability defaults in Application Observability, or contact Grafana Support to enable metrics-generation for your organization with custom settings.
 {{% /admonition %}}
 
 Even if you already have metrics, span metrics can provide in-depth monitoring of your system.


### PR DESCRIPTION
Added a note that Metrics Generator can be enabled via Application  Observability or to contact support for custom Metrics Generator configs. Mirrors the note found on this page for Metrics Generator https://grafana.com/docs/grafana-cloud/send-data/traces/metrics-generator/

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/support-escalations/issues/12501

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`