### PR TITLE
Fix typo

### DIFF
--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -872,7 +872,7 @@ storage:
 
             # Optional. Default is false.
             # Example: "insecure: true"
-            # Set to true to enable authentication and certificate checks on gcs requests
+            # Set to true to disable authentication and certificate checks on gcs requests
             [insecure: <bool>]
 
             # The number of list calls to make in parallel to the backend per instance.


### PR DESCRIPTION
If insecure is set to "true", the authentication and certificate checks for gcs are disabled rather than enabled.