### PR TITLE
Correctly handle 400 Bad Request and 404 Not Found in gRPC streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [BUGFIX] Replace hedged requests roundtrips total with a counter. [#4063](https://github.com/grafana/tempo/pull/4063) [#4078](https://github.com/grafana/tempo/pull/4078) (@galalen)
 * [BUGFIX] Metrics generators: Correctly drop from the ring before stopping ingestion to reduce drops during a rollout. [#4101](https://github.com/grafana/tempo/pull/4101) (@joe-elliott)
 * [BUGFIX] Bring back application-json content-type header. [#4121](https://github.com/grafana/tempo/pull/4121) (@javiermolinar)
+* [BUGFIX] Correctly handle 400 Bad Request in gRPC streaming [#4144](https://github.com/grafana/tempo/pull/4144) (@mapno)
 * [CHANGE] TraceByID: don't allow concurrent_shards greater than query_shards. [#4074](https://github.com/grafana/tempo/pull/4074) (@electron0zero)
 * **BREAKING CHANGE** tempo-query is no longer a jaeger instance with grpcPlugin. Its now a standalone server. Serving a grpc api for jaeger on `0.0.0.0:7777` by default. [#3840](https://github.com/grafana/tempo/issues/3840) (@frzifus)
 * [CHANGE] **BREAKING CHANGE** The dynamic injection of X-Scope-OrgID header for metrics generator remote-writes is changed. If the header is aleady set in per-tenant overrides or global tempo configuration, then it is honored and not overwritten. [#4021](https://github.com/grafana/tempo/pull/4021) (@mdisibio)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * [BUGFIX] Replace hedged requests roundtrips total with a counter. [#4063](https://github.com/grafana/tempo/pull/4063) [#4078](https://github.com/grafana/tempo/pull/4078) (@galalen)
 * [BUGFIX] Metrics generators: Correctly drop from the ring before stopping ingestion to reduce drops during a rollout. [#4101](https://github.com/grafana/tempo/pull/4101) (@joe-elliott)
 * [BUGFIX] Bring back application-json content-type header. [#4121](https://github.com/grafana/tempo/pull/4121) (@javiermolinar)
-* [BUGFIX] Correctly handle 400 Bad Request in gRPC streaming [#4144](https://github.com/grafana/tempo/pull/4144) (@mapno)
+* [BUGFIX] Correctly handle 400 Bad Request and 404 Not Found in gRPC streaming [#4144](https://github.com/grafana/tempo/pull/4144) (@mapno)
 * [CHANGE] TraceByID: don't allow concurrent_shards greater than query_shards. [#4074](https://github.com/grafana/tempo/pull/4074) (@electron0zero)
 * **BREAKING CHANGE** tempo-query is no longer a jaeger instance with grpcPlugin. Its now a standalone server. Serving a grpc api for jaeger on `0.0.0.0:7777` by default. [#3840](https://github.com/grafana/tempo/issues/3840) (@frzifus)
 * [CHANGE] **BREAKING CHANGE** The dynamic injection of X-Scope-OrgID header for metrics generator remote-writes is changed. If the header is aleady set in per-tenant overrides or global tempo configuration, then it is honored and not overwritten. [#4021](https://github.com/grafana/tempo/pull/4021) (@mdisibio)

--- a/modules/frontend/combiner/common.go
+++ b/modules/frontend/combiner/common.go
@@ -212,8 +212,10 @@ func (c *genericCombiner[T]) erroredResponse() (*http.Response, error) {
 		grpcErr = status.Error(codes.Internal, c.httpRespBody)
 	} else if c.httpStatusCode == http.StatusTooManyRequests {
 		grpcErr = status.Error(codes.ResourceExhausted, c.httpRespBody)
-	} else {
+	} else if c.httpStatusCode == http.StatusBadRequest {
 		grpcErr = status.Error(codes.InvalidArgument, c.httpRespBody)
+	} else {
+		grpcErr = status.Error(codes.Unknown, c.httpRespBody)
 	}
 	httpResp := &http.Response{
 		StatusCode: c.httpStatusCode,

--- a/modules/frontend/combiner/search_test.go
+++ b/modules/frontend/combiner/search_test.go
@@ -153,7 +153,7 @@ func TestSearchResponseCombiner(t *testing.T) {
 			response1:         toHTTPResponse(t, nil, 404),
 			response2:         toHTTPResponse(t, &tempopb.SearchResponse{Metrics: &tempopb.SearchMetrics{}}, 200),
 			expectedStatus:    404,
-			expectedGRPCError: status.Error(codes.InvalidArgument, ""),
+			expectedGRPCError: status.Error(codes.NotFound, ""),
 		},
 		{
 			name:              "200+400",
@@ -181,7 +181,7 @@ func TestSearchResponseCombiner(t *testing.T) {
 			response1:         toHTTPResponse(t, nil, 404),
 			response2:         toHTTPResponse(t, nil, 500),
 			expectedStatus:    404,
-			expectedGRPCError: status.Error(codes.InvalidArgument, ""),
+			expectedGRPCError: status.Error(codes.NotFound, ""),
 		},
 		{
 			name:              "500+200",

--- a/modules/frontend/search_handlers.go
+++ b/modules/frontend/search_handlers.go
@@ -139,6 +139,8 @@ func logResult(logger log.Logger, tenantID string, durationSeconds float64, req 
 	statusCode := -1
 	if httpResp != nil {
 		statusCode = httpResp.StatusCode
+	} else if st, ok := status.FromError(err); ok {
+		statusCode = int(st.Code())
 	}
 
 	if resp == nil {

--- a/modules/frontend/slos.go
+++ b/modules/frontend/slos.go
@@ -81,8 +81,10 @@ func sloHook(allByTenantCounter, withinSLOByTenantCounter *prometheus.CounterVec
 
 		// most errors are SLO violations
 		if err != nil {
-			// however, if this is a grpc resource exhausted error (429) then we are within SLO
-			if status.Code(err) == codes.ResourceExhausted {
+			// however, if this is a grpc resource exhausted error (429) or invalid argument (400) then we are within SLO
+			switch status.Code(err) {
+			case codes.ResourceExhausted,
+				codes.InvalidArgument:
 				withinSLOByTenantCounter.WithLabelValues(tenant).Inc()
 			}
 			return

--- a/modules/frontend/slos.go
+++ b/modules/frontend/slos.go
@@ -84,7 +84,8 @@ func sloHook(allByTenantCounter, withinSLOByTenantCounter *prometheus.CounterVec
 			// however, if this is a grpc resource exhausted error (429) or invalid argument (400) then we are within SLO
 			switch status.Code(err) {
 			case codes.ResourceExhausted,
-				codes.InvalidArgument:
+				codes.InvalidArgument,
+				codes.NotFound:
 				withinSLOByTenantCounter.WithLabelValues(tenant).Inc()
 			}
 			return

--- a/modules/frontend/slos_test.go
+++ b/modules/frontend/slos_test.go
@@ -163,6 +163,6 @@ func TestBadRequest(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 1.0, actualAll)
-	require.Equal(t, 0.0, actualSLO)
+	require.Equal(t, 1.0, actualSLO)
 
 }

--- a/modules/frontend/slos_test.go
+++ b/modules/frontend/slos_test.go
@@ -164,5 +164,4 @@ func TestBadRequest(t *testing.T) {
 
 	require.Equal(t, 1.0, actualAll)
 	require.Equal(t, 1.0, actualSLO)
-
 }

--- a/modules/frontend/slos_test.go
+++ b/modules/frontend/slos_test.go
@@ -2,7 +2,9 @@ package frontend
 
 import (
 	"errors"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -135,4 +137,32 @@ func TestSLOHook(t *testing.T) {
 			require.Equal(t, tc.expectedWithSLO, actualSLO)
 		})
 	}
+}
+
+func TestBadRequest(t *testing.T) {
+	allCounter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "all"}, []string{"tenant"})
+	sloCounter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "slo"}, []string{"tenant"})
+	throughputVec := prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "throughput"}, []string{"tenant"})
+
+	hook := sloHook(allCounter, sloCounter, throughputVec, SLOConfig{
+		DurationSLO:        10 * time.Second,
+		ThroughputBytesSLO: 100,
+	})
+
+	res := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Status:     http.StatusText(http.StatusBadRequest),
+		Body:       io.NopCloser(strings.NewReader("foo")),
+	}
+
+	hook(res, "tenant", 0, 0, nil)
+
+	actualAll, err := test.GetCounterValue(allCounter.WithLabelValues("tenant"))
+	require.NoError(t, err)
+	actualSLO, err := test.GetCounterValue(sloCounter.WithLabelValues("tenant"))
+	require.NoError(t, err)
+
+	require.Equal(t, 1.0, actualAll)
+	require.Equal(t, 0.0, actualSLO)
+
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Correctly handle 400 Bad Request and 404 Not Found in gRPC streaming.

Status codes in gRPC are changed to return `InvalidArgument` for 400 and `NotFound` for 404. Other non-special HTTP status codes are `Unknown`.

This also allows fixing how 400 responses are counted towards SLO calculations.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`