### PR TITLE
[DOC] Update statement for metrics-generator for Cloud

### DIFF
--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -287,6 +287,10 @@ For more information on the metrics-generator, refer to the [Metrics-generator d
 
 Metrics-generator processors are disabled by default. To enable it for a specific tenant, set `metrics_generator.processors` in the [overrides](#overrides) section.
 
+{{< admonition type="note" >}}
+If you want to enable metrics-generator for your Grafana Cloud account, refer to the [Metrics-generator in Grafana Cloud](https://grafana.com/docs/grafana-cloud/send-data/traces/metrics-generator/) documentation.
+{{< /admonition >}}
+
 You can limit spans with end times that occur within a configured duration to be considered in metrics generation using `metrics_ingestion_time_range_slack`.
 In Grafana Cloud, this value defaults to 30 seconds so all spans sent to the metrics-generation more than 30 seconds in the past are discarded or rejected.
 

--- a/docs/sources/tempo/metrics-generator/_index.md
+++ b/docs/sources/tempo/metrics-generator/_index.md
@@ -10,12 +10,8 @@ weight: 500
 # Metrics-generator
 
 Metrics-generator is an optional Tempo component that derives metrics from ingested traces.
-If present, the distributor will write received spans to both the ingester and the metrics-generator.
+If present, the distributors write received spans to both the ingester and the metrics-generator.
 The metrics-generator processes spans and writes metrics to a Prometheus data source using the Prometheus remote write protocol.
-
-{{< admonition type="note" >}}
-Enabling metrics generation and remote writing them to Grafana Cloud Metrics produces extra active series that could impact your billing. For more information on billing, refer to [Billing and usage](/docs/grafana-cloud/billing-and-usage/).
-{{% /admonition %}}
 
 ## Architecture
 
@@ -76,3 +72,10 @@ high-resolution data. Users must [update the receiving endpoint](https://grafana
 histograms, and [update histogram queries](https://grafana.com/docs/mimir/<MIMIR_VERSION>/visualize/native-histograms/) in their dashboards.
 
 To learn more about the configuration, refer to the [Metrics-generator]({{< relref "../configuration#metrics-generator" >}}) section of the Tempo Configuration documentation.
+
+## Use metrics-generator in Grafana Cloud
+
+If you want to enable metrics-generator for your Grafana Cloud account, refer to the [Metrics-generator in Grafana Cloud](https://grafana.com/docs/grafana-cloud/send-data/traces/metrics-generator/) documentation.
+
+Enabling metrics generation and remote writing them to Grafana Cloud Metrics produces extra active series that could impact your billing.
+For more information on billing, refer to [Billing and usage](/docs/grafana-cloud/billing-and-usage/).

--- a/docs/sources/tempo/metrics-generator/service_graphs/_index.md
+++ b/docs/sources/tempo/metrics-generator/service_graphs/_index.md
@@ -8,9 +8,6 @@ weight: 300
 
 # Service graphs
 
-{{< docs/alias from="/docs/tempo/latest/server_side_metrics/service_graphs/" to="/docs/tempo/latest/metrics-generator/service_graphs/" >}}
-
-
 A service graph is a visual representation of the interrelationships between various services.
 Service graphs help you to understand the structure of a distributed system,
 and the connections and dependencies between its components:

--- a/docs/sources/tempo/metrics-generator/span_metrics.md
+++ b/docs/sources/tempo/metrics-generator/span_metrics.md
@@ -1,7 +1,6 @@
 ---
 aliases:
-  - /docs/tempo/latest/server_side_metrics/span_metrics/
-  - /docs/tempo/latest/metrics-generator/span_metrics/
+  - ../server_side_metrics/span_metrics/ # /docs/tempo/latest/server_side_metrics/span_metrics/
 title: Span metrics
 description: The span metrics processor generates metrics from ingested tracing data, including request, error, and duration (RED) metrics.
 weight: 200
@@ -20,10 +19,6 @@ Span metrics are of particular interest if your system is not monitored with met
 but it has distributed tracing implemented.
 You get out-of-the-box metrics from your tracing pipeline.
 
-{{< admonition type="note" >}}
-Metrics generation is disabled by default. Contact Grafana Support to enable metrics generation in your organization.
-{{% /admonition %}}
-
 Even if you already have metrics, span metrics can provide in-depth monitoring of your system.
 The generated metrics will show application level insight into your monitoring,
 as far as tracing gets propagated through your applications.
@@ -35,7 +30,10 @@ exemplars can be automatically added, providing additional value to these metric
 
 ## How to run
 
-To enable span metrics in Tempo/GET, enable the metrics generator and add an overrides section which enables the `span-metrics` generator. See [here for configuration details]({{< relref "../configuration#metrics-generator" >}}).
+To enable span metrics in Tempo or Grafana Enterprise Traces, enable the metrics generator and add an overrides section which enables the `span-metrics` generator.
+Refer to [the configuration details]({{< relref "../configuration#metrics-generator" >}}).
+
+If you want to enable metrics-generator for your Grafana Cloud account, refer to the [Metrics-generator in Grafana Cloud](https://grafana.com/docs/grafana-cloud/send-data/traces/metrics-generator/) documentation.
 
 ## How it works
 

--- a/docs/sources/tempo/metrics-generator/span_metrics.md
+++ b/docs/sources/tempo/metrics-generator/span_metrics.md
@@ -30,7 +30,7 @@ exemplars can be automatically added, providing additional value to these metric
 
 ## How to run
 
-To enable span metrics in Tempo or Grafana Enterprise Traces, enable the metrics generator and add an overrides section which enables the `span-metrics` generator.
+To enable span metrics in Tempo or Grafana Enterprise Traces, enable the metrics generator and add an overrides section which enables the `span-metrics` processor.
 Refer to [the configuration details]({{< relref "../configuration#metrics-generator" >}}).
 
 If you want to enable metrics-generator for your Grafana Cloud account, refer to the [Metrics-generator in Grafana Cloud](https://grafana.com/docs/grafana-cloud/send-data/traces/metrics-generator/) documentation.


### PR DESCRIPTION
**What this PR does**:

Addresses a customer issue that it wasn't clear that you can enable Metrics Generator for Grafana Cloud in Application Observability. 

Original PR update: https://github.com/grafana/tempo/pull/4141

This PR: 
* Cleans up the copied-from-cloud admonition notes
* Removes references to Cloud metrics-generator vs OSS in the Tempo docs
* Instead, points readers to the Grafana Cloud Traces documentation for metrics-generator

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/support-escalations/issues/12501

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`