### PR TITLE
Tempo-query: improve performance of FindTraces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [ENHANCEMENT] Speedup tempo-query trace search by allowing parallel queries [#4159](https://github.com/grafana/tempo/pull/4159) (@pavolloffay)
 * [CHANGE] tempo-cli: add support for /api/v2/traces endpoint [#4127](https://github.com/grafana/tempo/pull/4127) (@electron0zero)
   **BREAKING CHANGE** The `tempo-cli` now uses the `/api/v2/traces` endpoint by default, 
   please use `--v1` flag to use `/api/traces` endpoint, which was the default in previous versions.

--- a/cmd/tempo-query/main.go
+++ b/cmd/tempo-query/main.go
@@ -3,14 +3,16 @@ package main
 import (
 	"flag"
 	"net"
+	"os"
 	"strings"
 
-	"github.com/hashicorp/go-hclog"
-	hcplugin "github.com/hashicorp/go-plugin"
 	"github.com/jaegertracing/jaeger/proto-gen/storage_v1"
+	zaplogfmt "github.com/jsternberg/zap-logfmt"
 	otgrpc "github.com/opentracing-contrib/go-grpc"
 	"github.com/opentracing/opentracing-go"
 	"github.com/spf13/viper"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	google_grpc "google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
@@ -18,11 +20,12 @@ import (
 )
 
 func main() {
-	logger := hclog.New(&hclog.LoggerOptions{
-		Name:       "jaeger-tempo",
-		Level:      hclog.Error,
-		JSONFormat: true,
-	})
+	config := zap.NewProductionEncoderConfig()
+	logger := zap.New(zapcore.NewCore(
+		zaplogfmt.NewEncoder(config),
+		os.Stdout,
+		zapcore.InfoLevel,
+	))
 
 	var configPath string
 	flag.StringVar(&configPath, "config", "", "A path to the plugin's configuration file")
@@ -37,16 +40,16 @@ func main() {
 
 		err := v.ReadInConfig()
 		if err != nil {
-			logger.Error("failed to parse configuration file", "error", err)
+			logger.Error("failed to parse configuration file", zap.Error(err))
 		}
 	}
 
 	cfg := &tempo.Config{}
 	cfg.InitFromViper(v)
 
-	backend, err := tempo.New(cfg)
+	backend, err := tempo.New(logger, cfg)
 	if err != nil {
-		logger.Error("failed to init tracer backend", "error", err)
+		logger.Error("failed to init tracer backend", zap.Error(err))
 	}
 
 	grpcOpts := []google_grpc.ServerOption{
@@ -57,13 +60,13 @@ func main() {
 	if cfg.TLSEnabled {
 		creds, err := credentials.NewClientTLSFromFile(cfg.TLS.CertPath, cfg.TLS.ServerName)
 		if err != nil {
-			logger.Error("failed to load TLS credentials", "error", err)
+			logger.Error("failed to load TLS credentials", zap.Error(err))
 		} else {
 			grpcOpts = append(grpcOpts, google_grpc.Creds(creds))
 		}
 	}
 
-	srv := hcplugin.DefaultGRPCServer(grpcOpts)
+	srv := google_grpc.NewServer(grpcOpts...)
 
 	storage_v1.RegisterSpanReaderPluginServer(srv, backend)
 	storage_v1.RegisterDependenciesReaderPluginServer(srv, backend)
@@ -71,11 +74,11 @@ func main() {
 
 	lis, err := net.Listen("tcp", cfg.Address)
 	if err != nil {
-		logger.Error("failed to listen", "error", err)
+		logger.Error("failed to listen", zap.Error(err))
 	}
 
-	logger.Info("Server starts serving", "address", cfg.Address)
+	logger.Info("Server starts serving", zap.String("address", cfg.Address))
 	if err := srv.Serve(lis); err != nil {
-		logger.Error("failed to serve", "error", err)
+		logger.Error("failed to serve", zap.Error(err))
 	}
 }

--- a/cmd/tempo-query/tempo/config.go
+++ b/cmd/tempo-query/tempo/config.go
@@ -14,6 +14,8 @@ type Config struct {
 	TLS                   tls.ClientConfig `yaml:",inline"`
 	TenantHeaderKey       string           `yaml:"tenant_header_key"`
 	QueryServicesDuration string           `yaml:"services_query_duration"`
+	// FindTracesConcurrentRequests defines how many concurrent requests trace search submits to get a trace.
+	FindTracesConcurrentRequests int `yaml:"find_traces_concurrent_requests"`
 }
 
 // InitFromViper initializes the options struct with values from Viper
@@ -33,7 +35,11 @@ func (c *Config) InitFromViper(v *viper.Viper) {
 	c.TLS.CipherSuites = v.GetString("tls_cipher_suites")
 	c.TLS.MinVersion = v.GetString("tls_min_version")
 	c.QueryServicesDuration = v.GetString("services_query_duration")
+	c.FindTracesConcurrentRequests = v.GetInt("find_traces_concurrent_requests")
 
+	if c.FindTracesConcurrentRequests == 0 {
+		c.FindTracesConcurrentRequests = 1
+	}
 	tenantHeader := v.GetString("tenant_header_key")
 	if tenantHeader == "" {
 		tenantHeader = shared.BearerTokenKey

--- a/cmd/tempo-query/tempo/plugin.go
+++ b/cmd/tempo-query/tempo/plugin.go
@@ -374,10 +374,10 @@ func (b *Backend) FindTraces(req *storage_v1.FindTracesRequest, stream storage_v
 	// Collecting results
 	for i := 0; i < len(resp.TraceIDs); i++ {
 		result := <-results
-		//// TODO this seems to be an internal inconsistency error, ignore so we can still show the rest
-		span.AddEvent(fmt.Sprintf("could not get trace for traceID %v", result.traceID))
-		span.RecordError(err)
 		if result.err != nil {
+			//// TODO this seems to be an internal inconsistency error, ignore so we can still show the rest
+			span.AddEvent(fmt.Sprintf("could not get trace for traceID %v", result.traceID))
+			span.RecordError(err)
 			failedTraces = append(failedTraces, result)
 		} else {
 			jaegerTraces = append(jaegerTraces, result.trace)

--- a/cmd/tempo-query/tempo/plugin.go
+++ b/cmd/tempo-query/tempo/plugin.go
@@ -326,9 +326,6 @@ type jobResult struct {
 func worker(b *Backend, jobs <-chan job, results chan<- jobResult) {
 	for job := range jobs {
 		jaegerTrace, err := b.getTrace(job.ctx, job.traceID)
-		if err != nil {
-			b.logger.Info("failed trace", zap.Error(err), zap.String("traceid", job.traceID.String()))
-		}
 		results <- jobResult{
 			traceID: job.traceID,
 			trace:   jaegerTrace,
@@ -376,6 +373,7 @@ func (b *Backend) FindTraces(req *storage_v1.FindTracesRequest, stream storage_v
 		result := <-results
 		if result.err != nil {
 			//// TODO this seems to be an internal inconsistency error, ignore so we can still show the rest
+			b.logger.Info("failed to get a trace", zap.Error(err), zap.String("traceid", result.traceID.String()))
 			span.AddEvent(fmt.Sprintf("could not get trace for traceID %v", result.traceID))
 			span.RecordError(err)
 			failedTraces = append(failedTraces, result)

--- a/go.mod
+++ b/go.mod
@@ -27,8 +27,8 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/grafana/dskit v0.0.0-20240801171758-736c44c85382
 	github.com/grafana/e2e v0.1.1
-	github.com/hashicorp/go-hclog v1.6.3
-	github.com/hashicorp/go-plugin v1.6.0
+	github.com/hashicorp/go-hclog v1.6.3 // indirect
+	github.com/hashicorp/go-plugin v1.6.0 // indirect
 	github.com/jaegertracing/jaeger v1.57.0
 	github.com/jedib0t/go-pretty/v6 v6.2.4
 	github.com/json-iterator/go v1.1.12


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Improves performance for tempo query for searching traces. There is a new configuration option to submit multiple gettracebyid requests from a search. 

Uses can scale up queriers and get faster queries. A single querier can process 20 queries https://grafana.com/docs/tempo/latest/operations/backend_search/#querier-and-query-frontend-configuration 


Tested with TempoStack on OCP. Image `pavolloffay/tempo-query:concurrency-main-15`

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`