### PR TITLE
Avoid returning 500 for TRACE_TOO_LARGE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [CHANGE] No longer send the final diff in GRPC streaming. Instead we rely on the streamed intermediate results. [#4062](https://github.com/grafana/tempo/pull/4062) (@joe-elliott)
 * [CHANGE] Update Go to 1.23.1 [#4146](https://github.com/grafana/tempo/pull/4146) [#4147](https://github.com/grafana/tempo/pull/4147) (@javiermolinar)
 * [CHANGE] TraceQL: Add range condition for byte predicates [#4198](https://github.com/grafana/tempo/pull/4198) (@ie-pham)
+* [CHANGE] Return 422 for TRACE_TOO_LARGE queries [#4160](https://github.com/grafana/tempo/pull/4160) (@zalegrala)
 * [FEATURE] Discarded span logging `log_discarded_spans` [#3957](https://github.com/grafana/tempo/issues/3957) (@dastrobu)
 * [FEATURE] TraceQL support for instrumentation scope [#3967](https://github.com/grafana/tempo/pull/3967) (@ie-pham)
 * [ENHANCEMENT] TraceQL: Attribute iterators collect matched array values [#3867](https://github.com/grafana/tempo/pull/3867) (@electron0zero, @stoewer)

--- a/integration/e2e/limits_test.go
+++ b/integration/e2e/limits_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/grafana/tempo/integration/util"
 	"github.com/grafana/tempo/pkg/httpclient"
+	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempopb"
 	tempoUtil "github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/pkg/util/test"
@@ -233,21 +234,21 @@ func TestQueryLimits(t *testing.T) {
 	querierClient := httpclient.New("http://"+tempo.Endpoint(3200)+"/querier", tempoUtil.FakeTenantID)
 
 	_, err = client.QueryTrace(tempoUtil.TraceIDToHexString(traceID[:]))
-	require.ErrorContains(t, err, "trace exceeds max size")
+	require.ErrorContains(t, err, trace.ErrTraceTooLarge.Error())
 	require.ErrorContains(t, err, "failed with response: 413") // confirm frontend returns 413
 
 	_, err = querierClient.QueryTrace(tempoUtil.TraceIDToHexString(traceID[:]))
-	require.ErrorContains(t, err, "trace exceeds max size")
+	require.ErrorContains(t, err, trace.ErrTraceTooLarge.Error())
 	require.ErrorContains(t, err, "failed with response: 413")
 
 	// complete block timeout  is 10 seconds
 	time.Sleep(15 * time.Second)
 	_, err = client.QueryTrace(tempoUtil.TraceIDToHexString(traceID[:]))
-	require.ErrorContains(t, err, "trace exceeds max size")
+	require.ErrorContains(t, err, trace.ErrTraceTooLarge.Error())
 	require.ErrorContains(t, err, "failed with response: 413") // confirm frontend returns 500
 
 	_, err = querierClient.QueryTrace(tempoUtil.TraceIDToHexString(traceID[:]))
-	require.ErrorContains(t, err, "trace exceeds max size")
+	require.ErrorContains(t, err, trace.ErrTraceTooLarge.Error())
 	require.ErrorContains(t, err, "failed with response: 413") // confirm querier returns 400
 }
 

--- a/integration/e2e/limits_test.go
+++ b/integration/e2e/limits_test.go
@@ -234,11 +234,11 @@ func TestQueryLimits(t *testing.T) {
 
 	_, err = client.QueryTrace(tempoUtil.TraceIDToHexString(traceID[:]))
 	require.ErrorContains(t, err, "trace exceeds max size")
-	require.ErrorContains(t, err, "failed with response: 500") // confirm frontend returns 500
+	require.ErrorContains(t, err, "failed with response: 413") // confirm frontend returns 413
 
 	_, err = querierClient.QueryTrace(tempoUtil.TraceIDToHexString(traceID[:]))
 	require.ErrorContains(t, err, "trace exceeds max size")
-	require.ErrorContains(t, err, "failed with response: 500") // todo: this should return 400 ideally so the frontend does not retry, but does not currently
+	require.ErrorContains(t, err, "failed with response: 413")
 
 	// complete block timeout  is 10 seconds
 	time.Sleep(15 * time.Second)
@@ -248,7 +248,7 @@ func TestQueryLimits(t *testing.T) {
 
 	_, err = querierClient.QueryTrace(tempoUtil.TraceIDToHexString(traceID[:]))
 	require.ErrorContains(t, err, "trace exceeds max size")
-	require.ErrorContains(t, err, "failed with response: 400") // confirm querier returns 400
+	require.ErrorContains(t, err, "failed with response: 413") // confirm querier returns 400
 }
 
 func TestLimitsPartialSuccess(t *testing.T) {

--- a/integration/e2e/limits_test.go
+++ b/integration/e2e/limits_test.go
@@ -244,7 +244,7 @@ func TestQueryLimits(t *testing.T) {
 	time.Sleep(15 * time.Second)
 	_, err = client.QueryTrace(tempoUtil.TraceIDToHexString(traceID[:]))
 	require.ErrorContains(t, err, "trace exceeds max size")
-	require.ErrorContains(t, err, "failed with response: 500") // confirm frontend returns 500
+	require.ErrorContains(t, err, "failed with response: 413") // confirm frontend returns 500
 
 	_, err = querierClient.QueryTrace(tempoUtil.TraceIDToHexString(traceID[:]))
 	require.ErrorContains(t, err, "trace exceeds max size")

--- a/integration/e2e/limits_test.go
+++ b/integration/e2e/limits_test.go
@@ -235,21 +235,21 @@ func TestQueryLimits(t *testing.T) {
 
 	_, err = client.QueryTrace(tempoUtil.TraceIDToHexString(traceID[:]))
 	require.ErrorContains(t, err, trace.ErrTraceTooLarge.Error())
-	require.ErrorContains(t, err, "failed with response: 413") // confirm frontend returns 413
+	require.ErrorContains(t, err, "failed with response: 422") // confirm frontend returns 422
 
 	_, err = querierClient.QueryTrace(tempoUtil.TraceIDToHexString(traceID[:]))
 	require.ErrorContains(t, err, trace.ErrTraceTooLarge.Error())
-	require.ErrorContains(t, err, "failed with response: 413")
+	require.ErrorContains(t, err, "failed with response: 422")
 
 	// complete block timeout  is 10 seconds
 	time.Sleep(15 * time.Second)
 	_, err = client.QueryTrace(tempoUtil.TraceIDToHexString(traceID[:]))
 	require.ErrorContains(t, err, trace.ErrTraceTooLarge.Error())
-	require.ErrorContains(t, err, "failed with response: 413") // confirm frontend returns 500
+	require.ErrorContains(t, err, "failed with response: 422") // confirm frontend returns 422
 
 	_, err = querierClient.QueryTrace(tempoUtil.TraceIDToHexString(traceID[:]))
 	require.ErrorContains(t, err, trace.ErrTraceTooLarge.Error())
-	require.ErrorContains(t, err, "failed with response: 413") // confirm querier returns 400
+	require.ErrorContains(t, err, "failed with response: 422") // confirm querier returns 422
 }
 
 func TestLimitsPartialSuccess(t *testing.T) {

--- a/modules/frontend/combiner/trace_by_id.go
+++ b/modules/frontend/combiner/trace_by_id.go
@@ -87,7 +87,7 @@ func (c *traceByIDCombiner) AddResponse(r PipelineResponse) error {
 
 	if errors.Is(err, trace.ErrTraceTooLarge) {
 		c.code = http.StatusUnprocessableEntity
-		c.statusMessage = trace.ErrTraceTooLarge.Error()
+		c.statusMessage =  fmt.Sprint(err)
 		return nil
 	}
 

--- a/modules/frontend/combiner/trace_by_id.go
+++ b/modules/frontend/combiner/trace_by_id.go
@@ -86,7 +86,7 @@ func (c *traceByIDCombiner) AddResponse(r PipelineResponse) error {
 	_, err = c.c.Consume(resp.Trace)
 
 	if errors.Is(err, trace.ErrTraceTooLarge) {
-		c.code = http.StatusRequestEntityTooLarge
+		c.code = http.StatusUnprocessableEntity
 		c.statusMessage = trace.ErrTraceTooLarge.Error()
 		return nil
 	}
@@ -164,8 +164,8 @@ func (c *traceByIDCombiner) shouldQuit() bool {
 		return false
 	}
 
-	// test special case for 413
-	if c.code == http.StatusRequestEntityTooLarge {
+	// test special case for 422
+	if c.code == http.StatusUnprocessableEntity {
 		return true
 	}
 

--- a/modules/frontend/combiner/trace_by_id.go
+++ b/modules/frontend/combiner/trace_by_id.go
@@ -87,7 +87,7 @@ func (c *traceByIDCombiner) AddResponse(r PipelineResponse) error {
 
 	if errors.Is(err, trace.ErrTraceTooLarge) {
 		c.code = http.StatusUnprocessableEntity
-		c.statusMessage =  fmt.Sprint(err)
+		c.statusMessage = fmt.Sprint(err)
 		return nil
 	}
 

--- a/modules/frontend/combiner/trace_by_id.go
+++ b/modules/frontend/combiner/trace_by_id.go
@@ -88,6 +88,7 @@ func (c *traceByIDCombiner) AddResponse(r PipelineResponse) error {
 	if errors.Is(err, trace.ErrTraceTooLarge) {
 		c.code = http.StatusRequestEntityTooLarge
 		c.statusMessage = trace.ErrTraceTooLarge.Error()
+		return nil
 	}
 
 	return err
@@ -165,7 +166,7 @@ func (c *traceByIDCombiner) shouldQuit() bool {
 
 	// test special case for 413
 	if c.code == http.StatusRequestEntityTooLarge {
-		return false
+		return true
 	}
 
 	// bail on other 400s

--- a/modules/frontend/combiner/trace_by_id_test.go
+++ b/modules/frontend/combiner/trace_by_id_test.go
@@ -48,15 +48,15 @@ func TestTraceByIDShouldQuit(t *testing.T) {
 	should = c.ShouldQuit()
 	require.False(t, should)
 
-	// trace too large, should not quit but should return an error
+	// trace too large, should quit and should not return an error
 	c = NewTraceByID(1, api.HeaderAcceptJSON)
 	err = c.AddResponse(toHTTPProtoResponse(t, &tempopb.TraceByIDResponse{
 		Trace:   test.MakeTrace(1, nil),
 		Metrics: &tempopb.TraceByIDMetrics{},
 	}, 200))
-	require.Error(t, err)
+	require.NoError(t, err)
 	should = c.ShouldQuit()
-	require.False(t, should)
+	require.True(t, should)
 }
 
 func TestTraceByIDHonorsContentType(t *testing.T) {

--- a/modules/frontend/handler.go
+++ b/modules/frontend/handler.go
@@ -32,6 +32,7 @@ var (
 	errCanceled              = httpgrpc.Errorf(StatusClientClosedRequest, context.Canceled.Error())
 	errDeadlineExceeded      = httpgrpc.Errorf(http.StatusGatewayTimeout, context.DeadlineExceeded.Error())
 	errRequestEntityTooLarge = httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "http: request body too large")
+	errTraceTooLarge         = httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "body: trace too large")
 )
 
 // handler exists to wrap a roundtripper with an HTTP handler. It wraps all
@@ -163,6 +164,8 @@ func writeError(w http.ResponseWriter, err error) error {
 		err = errDeadlineExceeded
 	} else if isRequestBodyTooLarge(err) {
 		err = errRequestEntityTooLarge
+	} else if isTraceTooLarge(err) {
+		err = errTraceTooLarge
 	}
 	httpgrpc.WriteError(w, err)
 	return err
@@ -171,4 +174,8 @@ func writeError(w http.ResponseWriter, err error) error {
 // isRequestBodyTooLarge returns true if the error is "http: request body too large".
 func isRequestBodyTooLarge(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "http: request body too large")
+}
+
+func isTraceTooLarge(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "body: trace exceeds max size")
 }

--- a/modules/frontend/handler.go
+++ b/modules/frontend/handler.go
@@ -32,7 +32,6 @@ var (
 	errCanceled              = httpgrpc.Errorf(StatusClientClosedRequest, context.Canceled.Error())
 	errDeadlineExceeded      = httpgrpc.Errorf(http.StatusGatewayTimeout, context.DeadlineExceeded.Error())
 	errRequestEntityTooLarge = httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "http: request body too large")
-	errTraceTooLarge         = httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "http: trace exceeds max size")
 )
 
 // handler exists to wrap a roundtripper with an HTTP handler. It wraps all
@@ -164,8 +163,6 @@ func writeError(w http.ResponseWriter, err error) error {
 		err = errDeadlineExceeded
 	} else if isRequestBodyTooLarge(err) {
 		err = errRequestEntityTooLarge
-	} else if isTraceTooLarge(err) {
-		err = errTraceTooLarge
 	}
 	httpgrpc.WriteError(w, err)
 	return err
@@ -174,8 +171,4 @@ func writeError(w http.ResponseWriter, err error) error {
 // isRequestBodyTooLarge returns true if the error is "http: request body too large".
 func isRequestBodyTooLarge(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "http: request body too large")
-}
-
-func isTraceTooLarge(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "trace exceeds max size")
 }

--- a/modules/frontend/handler.go
+++ b/modules/frontend/handler.go
@@ -32,7 +32,7 @@ var (
 	errCanceled              = httpgrpc.Errorf(StatusClientClosedRequest, context.Canceled.Error())
 	errDeadlineExceeded      = httpgrpc.Errorf(http.StatusGatewayTimeout, context.DeadlineExceeded.Error())
 	errRequestEntityTooLarge = httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "http: request body too large")
-	errTraceTooLarge         = httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "body: trace too large")
+	errTraceTooLarge         = httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "http: trace exceeds max size")
 )
 
 // handler exists to wrap a roundtripper with an HTTP handler. It wraps all
@@ -177,5 +177,5 @@ func isRequestBodyTooLarge(err error) bool {
 }
 
 func isTraceTooLarge(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "body: trace exceeds max size")
+	return err != nil && strings.Contains(err.Error(), "trace exceeds max size")
 }

--- a/modules/frontend/pipeline/sync_handler_adjust_response_code.go
+++ b/modules/frontend/pipeline/sync_handler_adjust_response_code.go
@@ -44,9 +44,9 @@ func (c statusCodeAdjustWare) RoundTrip(req Request) (*http.Response, error) {
 	// if the frontend issues a bad request then externally we need to represent that as an
 	// internal error
 	// exceptions
-	//   413 - request entity too large
+	//   422 - unprocessable entity
 	//   429 - too many requests
-	if resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != 429 && resp.StatusCode != 413 {
+	if resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != 429 && resp.StatusCode != 422 {
 		resp.StatusCode = http.StatusInternalServerError
 		resp.Status = http.StatusText(http.StatusInternalServerError)
 		// leave the body alone. it will preserve the original error message

--- a/modules/frontend/pipeline/sync_handler_adjust_response_code.go
+++ b/modules/frontend/pipeline/sync_handler_adjust_response_code.go
@@ -44,8 +44,9 @@ func (c statusCodeAdjustWare) RoundTrip(req Request) (*http.Response, error) {
 	// if the frontend issues a bad request then externally we need to represent that as an
 	// internal error
 	// exceptions
+	//   413 - request entity too large
 	//   429 - too many requests
-	if resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != 429 {
+	if resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != 429 && resp.StatusCode != 413 {
 		resp.StatusCode = http.StatusInternalServerError
 		resp.Status = http.StatusText(http.StatusInternalServerError)
 		// leave the body alone. it will preserve the original error message

--- a/modules/querier/http.go
+++ b/modules/querier/http.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/golang/protobuf/jsonpb" //nolint:all //deprecated
@@ -425,8 +426,9 @@ func handleError(w http.ResponseWriter, err error) {
 		return
 	}
 
-	// todo: better understand all errors returned from queriers and categorize more as 4XX
-	if errors.Is(err, trace.ErrTraceTooLarge) {
+	// TODO: better understand all errors returned from queriers and categorize more as 4XX
+	// NOTE: we receive a GRPC error from the ingesters, and so we need to check the string content of error as well.
+	if errors.Is(err, trace.ErrTraceTooLarge) || strings.Contains(err.Error(), trace.ErrTraceTooLarge.Error()) {
 		http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
 		return
 	}

--- a/modules/querier/http.go
+++ b/modules/querier/http.go
@@ -429,7 +429,7 @@ func handleError(w http.ResponseWriter, err error) {
 	// TODO: better understand all errors returned from queriers and categorize more as 4XX
 	// NOTE: we receive a GRPC error from the ingesters, and so we need to check the string content of error as well.
 	if errors.Is(err, trace.ErrTraceTooLarge) || strings.Contains(err.Error(), trace.ErrTraceTooLarge.Error()) {
-		http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
 		return
 	}
 

--- a/modules/querier/http.go
+++ b/modules/querier/http.go
@@ -427,7 +427,7 @@ func handleError(w http.ResponseWriter, err error) {
 
 	// todo: better understand all errors returned from queriers and categorize more as 4XX
 	if errors.Is(err, trace.ErrTraceTooLarge) {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
 		return
 	}
 


### PR DESCRIPTION
**What this PR does**:

Here we make an adjustment to the return value at the querier and query-frontend for the case where a trace is larger than the max configured size.  Previously this was reported as a 500 status code and has now been changed to a 422.  This will allow these conditions to be excluded from SLO failures, which is more appropriate since this is based on a configured max trace size.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`