### PR TITLE
[release-v2.6] tempo-query: separate tls settings for server and client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 ## main / unreleased
 
+* [ENHANCEMENT] tempo-query: separate tls settings for server and client [#4177](https://github.com/grafana/tempo/pull/4177) (@frzifus)
+* [ENHANCEMENT] Pushdown collection of results from generators in the querier [#4119](https://github.com/grafana/tempo/pull/4119) (@electron0zero)
+* [ENHANCEMENT] Send semver version in api/stattus/buildinfo for cloud deployments [#4110](https://github.com/grafana/tempo/pull/4110) [@Aki0x137]
+* [ENHANCEMENT] Speedup tempo-query trace search by allowing parallel queries [#4159](https://github.com/grafana/tempo/pull/4159) (@pavolloffay)
+* [ENHANCEMENT] Speedup DistinctString and ScopedDistinctString collectors [#4109](https://github.com/grafana/tempo/pull/4109) (@electron0zero)
+* [CHANGE] tempo-cli: add support for /api/v2/traces endpoint [#4127](https://github.com/grafana/tempo/pull/4127) (@electron0zero)
+  **BREAKING CHANGE** The `tempo-cli` now uses the `/api/v2/traces` endpoint by default, 
+  please use `--v1` flag to use `/api/traces` endpoint, which was the default in previous versions.
+* [ENHANCEMENT] Speedup collection of results from ingesters in the querier [#4100](https://github.com/grafana/tempo/pull/4100) (@electron0zero)
+* [ENHANCEMENT] Speedup DistinctValue collector and exit early for ingesters [#4104](https://github.com/grafana/tempo/pull/4104) (@electron0zero)
+* [ENHANCEMENT] Add disk caching in ingester SearchTagValuesV2 for completed blocks [#4069](https://github.com/grafana/tempo/pull/4069) (@electron0zero)
+* [BUGFIX] Replace hedged requests roundtrips total with a counter. [#4063](https://github.com/grafana/tempo/pull/4063) [#4078](https://github.com/grafana/tempo/pull/4078) (@galalen)
+* [BUGFIX] Metrics generators: Correctly drop from the ring before stopping ingestion to reduce drops during a rollout. [#4101](https://github.com/grafana/tempo/pull/4101) (@joe-elliott)
+* [BUGFIX] Bring back application-json content-type header. [#4121](https://github.com/grafana/tempo/pull/4121) (@javiermolinar)
+* [BUGFIX] Correctly handle 400 Bad Request and 404 Not Found in gRPC streaming [#4144](https://github.com/grafana/tempo/pull/4144) (@mapno)
+* [BUGFIX] Pushes a 0 to classic histogram's counter when the series is new to allow Prometheus to start from a non-null value. [#4140](https://github.com/grafana/tempo/pull/4140) (@mapno)
+* [CHANGE] TraceByID: don't allow concurrent_shards greater than query_shards. [#4074](https://github.com/grafana/tempo/pull/4074) (@electron0zero)
+* **BREAKING CHANGE** tempo-query is no longer a jaeger instance with grpcPlugin. Its now a standalone server. Serving a grpc api for jaeger on `0.0.0.0:7777` by default. [#3840](https://github.com/grafana/tempo/issues/3840) (@frzifus)
+* [CHANGE] **BREAKING CHANGE** The dynamic injection of X-Scope-OrgID header for metrics generator remote-writes is changed. If the header is aleady set in per-tenant overrides or global tempo configuration, then it is honored and not overwritten. [#4021](https://github.com/grafana/tempo/pull/4021) (@mdisibio)
+* [CHANGE] **BREAKING CHANGE** Migrate from OpenTracing to OpenTelemetry instrumentation. Removed the `use_otel_tracer` configuration option. Use the OpenTelemetry environment variables to configure the span exporter [#3646](https://github.com/grafana/tempo/pull/3646) (@andreasgerstmayr)
+  To continue using the Jaeger exporter, use the following environment variable: `OTEL_TRACES_EXPORTER=jaeger`.
+* [CHANGE] No longer send the final diff in GRPC streaming. Instead we rely on the streamed intermediate results. [#4062](https://github.com/grafana/tempo/pull/4062) (@joe-elliott)
+* [CHANGE] Update Go to 1.23.1 [#4146](https://github.com/grafana/tempo/pull/4146) [#4147](https://github.com/grafana/tempo/pull/4147) (@javiermolinar)
+* [FEATURE] Discarded span logging `log_discarded_spans` [#3957](https://github.com/grafana/tempo/issues/3957) (@dastrobu)
 * [FEATURE] TraceQL support for instrumentation scope [#3967](https://github.com/grafana/tempo/pull/3967) (@ie-pham)
 * [ENHANCEMENT] Add bytes and spans received to usage stats [#3983](https://github.com/grafana/tempo/pull/3983) (@joe-elliott)
 

--- a/cmd/tempo-query/main.go
+++ b/cmd/tempo-query/main.go
@@ -57,7 +57,7 @@ func main() {
 		google_grpc.StreamInterceptor(otgrpc.OpenTracingStreamServerInterceptor(opentracing.GlobalTracer())),
 	}
 
-	if cfg.TLSEnabled {
+	if cfg.TLSServerEnabeld {
 		creds, err := credentials.NewClientTLSFromFile(cfg.TLS.CertPath, cfg.TLS.ServerName)
 		if err != nil {
 			logger.Error("failed to load TLS credentials", zap.Error(err))

--- a/cmd/tempo-query/tempo/config.go
+++ b/cmd/tempo-query/tempo/config.go
@@ -8,9 +8,12 @@ import (
 
 // Config holds the configuration for redbull.
 type Config struct {
-	Address               string           `yaml:"address"`
-	Backend               string           `yaml:"backend"`
-	TLSEnabled            bool             `yaml:"tls_enabled" category:"advanced"`
+	Address string `yaml:"address"`
+	Backend string `yaml:"backend"`
+	// TLSEnabled enables tls outgoing requests from tempo-query to tempo.
+	TLSEnabled bool `yaml:"tls_enabled" category:"advanced"`
+	// TLSServerEnabeld enables tls for incoming requests to the tempo-query API.
+	TLSServerEnabeld      bool             `yaml:"tls_server_enabled" category:"advanced"`
 	TLS                   tls.ClientConfig `yaml:",inline"`
 	TenantHeaderKey       string           `yaml:"tenant_header_key"`
 	QueryServicesDuration string           `yaml:"services_query_duration"`
@@ -27,6 +30,7 @@ func (c *Config) InitFromViper(v *viper.Viper) {
 	c.Address = address
 	c.Backend = v.GetString("backend")
 	c.TLSEnabled = v.GetBool("tls_enabled")
+	c.TLSServerEnabeld = v.GetBool("tls_server_enabled")
 	c.TLS.CertPath = v.GetString("tls_cert_path")
 	c.TLS.KeyPath = v.GetString("tls_key_path")
 	c.TLS.CAPath = v.GetString("tls_ca_path")


### PR DESCRIPTION
Backport a2f70c975850ac4ad31c8d92a11f85bf74a945e4 from #4177

---

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This PR extends tempo-query with the possibility to configure tls for server and client individually.

cc @pavolloffay 

**Which issue(s) this PR fixes**:


**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
