### PR TITLE
[DOC] Remove traceQLStreaming feature flag

### DIFF
--- a/docs/sources/tempo/traceql/_index.md
+++ b/docs/sources/tempo/traceql/_index.md
@@ -47,7 +47,8 @@ The [GRPC streaming API endpoint]({{< relref "../api_docs#tempo-grpc-api" >}}) i
 The `tempo-cli` also uses this streaming endpoint.
 For more information, refer to the [Tempo CLI documentation]({{< relref "../operations/tempo_cli#query-api-command" >}}).
 
-To use streaming in Grafana, you must first enable the `traceQLStreaming` feature toggle.
+To use streaming in Grafana, you must have `stream_over_http_enabled: true` enabled in Tempo.
+For information, refer to [Tempo GRPC API](https://grafana.com/docs/tempo/latest/api_docs/#tempo-grpc-api).
 
 ## Construct a TraceQL query
 

--- a/example/docker-compose/local/docker-compose.yaml
+++ b/example/docker-compose/local/docker-compose.yaml
@@ -59,13 +59,13 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:11.0.0
+    image: grafana/grafana:11.2.0
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_DISABLE_LOGIN_FORM=true
-      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor traceQLStreaming metricsSummary
+      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor metricsSummary
     ports:
       - "3000:3000"

--- a/example/docker-compose/local/readme.md
+++ b/example/docker-compose/local/readme.md
@@ -1,12 +1,12 @@
-## Local Storage
+## Local storage
 
-In this example all data is stored locally in the `tempo-data` folder. Local
+In this example, all data is stored locally in the `tempo-data` folder. Local
 storage is fine for experimenting with Tempo or when using the single binary,
-but does not work in a distributed/microservices scenario. The container runs
+but doesn't work in a distributed/microservices scenario. The container runs
 as non-root, and so the local directory needs to have the appropriate
-permissions set in order to start correctly.
+permissions set to start correctly.
 
-1.Create the storage directory with the correct permissions and start up the local stack.
+1. Create the storage directory with the correct permissions and start up the local stack.
 
 ```console
 mkdir tempo-data/
@@ -19,29 +19,30 @@ At this point, the following containers should be spun up:
 docker compose ps
 ```
 ```
-       Name                     Command               State                                   Ports                                 
+       Name                     Command               State                                   Ports
 -----------------------------------------------------------------------------------------------------------
-local_grafana_1      /run.sh                          Up      0.0.0.0:3000->3000/tcp,:::3000->3000/tcp                              
-local_k6-tracing_1   /k6-tracing run /example-s ...   Up                                                                            
-local_prometheus_1   /bin/prometheus --config.f ...   Up      0.0.0.0:9090->9090/tcp,:::9090->9090/tcp                              
-local_tempo_1        /tempo -config.file=/etc/t ...   Up      0.0.0.0:14268->14268/tcp,:::14268->14268/tcp,                         
-                                                              0.0.0.0:3200->3200/tcp,:::3200->3200/tcp,                             
-                                                              0.0.0.0:4317->4317/tcp,:::4317->4317/tcp,                             
-                                                              0.0.0.0:4318->4318/tcp,:::4318->4318/tcp,                             
-                                                              0.0.0.0:9411->9411/tcp,:::9411->9411/tcp 
+local_grafana_1      /run.sh                          Up      0.0.0.0:3000->3000/tcp,:::3000->3000/tcp
+local_k6-tracing_1   /k6-tracing run /example-s ...   Up
+local_prometheus_1   /bin/prometheus --config.f ...   Up      0.0.0.0:9090->9090/tcp,:::9090->9090/tcp
+local_tempo_1        /tempo -config.file=/etc/t ...   Up      0.0.0.0:14268->14268/tcp,:::14268->14268/tcp,
+                                                              0.0.0.0:3200->3200/tcp,:::3200->3200/tcp,
+                                                              0.0.0.0:4317->4317/tcp,:::4317->4317/tcp,
+                                                              0.0.0.0:4318->4318/tcp,:::4318->4318/tcp,
+                                                              0.0.0.0:9411->9411/tcp,:::9411->9411/tcp
 ```
 
-2. If you're interested you can see the wal/blocks as they are being created.
+2. If you're interested, you can see the wal/blocks as they are being created.
 
 ```console
 ls tempo-data/
 ```
 
-3. Navigate to [Grafana](http://localhost:3000/explore) select the Tempo data source and use the "Search"
+3. Navigate to [Grafana](http://localhost:3000/explore) select the Tempo data source and use the **Search**
 tab to find traces. Also notice that you can query Tempo metrics from the Prometheus data source setup in
 Grafana.
 
-4. Tail logs of a container (eg: tempo)
+4. Tail logs of a container (for example, tempo):
+
 ```bash
 docker logs local_tempo_1 -f
 ```
@@ -52,11 +53,12 @@ docker logs local_tempo_1 -f
 docker compose down -v
 ```
 
-## search streaming over http
+## Search streaming over HTTP
 
-- need to set `traceQLStreaming` feature flag in Grafana
-- need to enable `stream_over_http_enabled` in tempo by setting `stream_over_http_enabled: true` in the config file.
+- Need to enable `stream_over_http_enabled` in Tempo by setting `stream_over_http_enabled: true` in the configuration file.
 
-you can use Grafana or tempo-cli to make a query.
+You can use Grafana or `tempo-cli `to make a query.
 
+```console
 tempo-cli: `$ tempo-cli query api search "0.0.0.0:3200" --use-grpc "{}" "2023-12-05T08:11:18Z" "2023-12-05T08:12:18Z" --org-id="test"`
+```

--- a/example/docker-compose/multi-tenant/docker-compose.yaml
+++ b/example/docker-compose/multi-tenant/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
       - tempo
 
   grafana:
-    image: grafana/grafana:11.0.0
+    image: grafana/grafana:11.2.0
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:
@@ -57,6 +57,6 @@ services:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_DISABLE_LOGIN_FORM=true
-      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor traceQLStreaming metricsSummary
+      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor metricsSummary
     ports:
       - "3000:3000"

--- a/example/docker-compose/multi-tenant/readme.md
+++ b/example/docker-compose/multi-tenant/readme.md
@@ -1,6 +1,7 @@
 ## Local Storage
-In this example all data is stored locally in the `tempo-data` folder. Local storage is fine for experimenting with Tempo
-or when using the single binary, but does not work in a distributed/microservices scenario.
+
+In this example, all data is stored locally in the `tempo-data` folder. Local storage is fine for experimenting with Tempo
+or when using the single binary, but doesn't work in a distributed or microservices scenario.
 
 1. Start up the local stack.
 
@@ -16,7 +17,7 @@ At this point, the following containers should be spun up:
 
 ```console
 $ docker compose ps
-           Name                          Command               State                                                                     Ports                                                                  
+           Name                          Command               State                                                                     Ports
 ------------------------------------------------------------------------------------------------------------------------------------------------------------
 multi-tenant_grafana_1        /run.sh                          Up      0.0.0.0:3000->3000/tcp,:::3000->3000/tcp
 multi-tenant_k6-tracing-2_1   /k6-tracing run /example-s ...   Up
@@ -27,7 +28,7 @@ multi-tenant_tempo_1          /tempo -config.file=/etc/t ...   Up      0.0.0.0:1
 
 ```
 
-2. If you're interested you can see the wal/blocks as they are being created.
+2. If you're interested, you can see the wal/blocks as they are being created.
 
 ```console
 $ ls tempo-data/
@@ -37,29 +38,31 @@ $ ls tempo-data/
 tab to find traces. Also notice that you can query Tempo metrics from the Prometheus data source setup in
 Grafana.
 
-4. Tail logs of a container (eg: tempo)
+4. Tail logs of a container (for example, tempo):
 ```bash
 $ docker logs multi-tenant_tempo_1 -f
 ```
 
-5. To stop the setup use -
+5. To stop the setup, use the following command:
 
 ```console
 docker compose down -v
 ```
 
-## streaming and multi-tenant search
+## Streaming and multi-tenant search
 
-- needs `traceQLStreaming` feature flag set in Grafana, see `docker-compose.yaml`
-- needs `stream_over_http_enabled: true`, `multitenancy_enabled: true`,
-and `query_frontend.multi_tenant_queries_enabled: true` in the tempo config file, see `tempo.yaml`
+- Needs `stream_over_http_enabled: true`, `multitenancy_enabled: true`,
+and `query_frontend.multi_tenant_queries_enabled: true` in the Tempo configuration file, see `tempo.yaml`
 
 You can use Grafana or tempo-cli to make a query.
 
-**grpc streaming query using tempo-cli**
+**gRPC streaming query using tempo-cli**
 - `$ tempo-cli query api search "0.0.0.0:3200" --use-grpc --limit 10000 "{}" "2023-12-05T08:11:18Z" "2023-12-05T08:12:18Z" --org-id="test"`
 
-**multi-tenant streaming queries using tempo-cli**
-- pass multiple tenant ids with `|` like this `--org-id="test|test2"`
+**Multi-tenant streaming queries using tempo-cli**
+- Pass multiple tenant ids with `|` like this `--org-id="test|test2"`
 
-example: `$ ./bin/linux/tempo-cli-amd64 query api search "0.0.0.0:3200" --use-grpc --limit 10000 "{ true } >> { true }" "2024-01-15T11:00:00Z" "2024-01-19T12:30:00Z" --org-id="test|test2"`
+Example:
+```
+$ ./bin/linux/tempo-cli-amd64 query api search "0.0.0.0:3200" --use-grpc --limit 10000 "{ true } >> { true }" "2024-01-15T11:00:00Z" "2024-01-19T12:30:00Z" --org-id="test|test2"
+```

--- a/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
+++ b/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
@@ -45,7 +45,7 @@ services:
 
   prometheus:
     image: prom/prometheus:latest
-    command: 
+    command:
       - --config.file=/etc/prometheus.yaml
       - --web.enable-remote-write-receiver
       - --enable-feature=exemplar-storage
@@ -56,13 +56,13 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:11.0.0
+    image: grafana/grafana:11.2.0
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_DISABLE_LOGIN_FORM=true
-      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor traceQLStreaming metricsSummary
+      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor metricsSummary
     ports:
       - "3000:3000"

--- a/example/docker-compose/shared/grafana-datasources.yaml
+++ b/example/docker-compose/shared/grafana-datasources.yaml
@@ -28,3 +28,6 @@ datasources:
     httpMethod: GET
     serviceMap:
       datasourceUid: prometheus
+    streamingEnabled:
+      search: true
+


### PR DESCRIPTION
**What this PR does**:

Removes the traceQLStreaming feature toggle, per https://github.com/grafana/grafana/issues/94528

Also, updates the version of Grafana to 11.2 in some of the docker-compose files that reference the feature toggle. 

**Which issue(s) this PR fixes**:
Part of https://github.com/grafana/grafana/issues/94528

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`