### PR TITLE
[DOC] Add deprecation for metrics summary

### DIFF
--- a/docs/sources/tempo/api_docs/metrics-summary.md
+++ b/docs/sources/tempo/api_docs/metrics-summary.md
@@ -10,7 +10,7 @@ weight: 600
 # Metrics summary API
 
 {{< admonition type="warning" >}}
-The metrics summary API is deprecated in Tempo 2.7. Features powered by the metrics summary API, like the Aggregate by table, are also deprecated in Grafana Cloud and Grafana 11.3 and later.
+The metrics summary API is deprecated as of Tempo 2.7. Features powered by the metrics summary API, like the Aggregate by table, are also deprecated in Grafana Cloud and Grafana 11.3 and later.
 It will be removed in a future release.
 {{% /admonition %}}
 
@@ -21,7 +21,7 @@ This API returns RED metrics (span count, erroring span count, and latency infor
 
 ## Activate metrics summary
 
-To enable the experimental metrics summary API, you must turn on the local blocks processor in the metrics generator.
+To enable the (deprecated) metrics summary API, you must turn on the local blocks processor in the metrics generator.
 Be aware that the generator uses considerably more resources, including disk space, if it's enabled:
 
 ```yaml
@@ -31,7 +31,7 @@ overrides:
       processors: [..., 'local-blocks']
 ```
 
-In Grafana and Grafana Cloudl, the Metrics summary API is an [experimental feature](https://grafana.com/docs/release-life-cycle/) that is disabled by default.
+In Grafana and Grafana Cloud, the Metrics summary API is disabled by default.
 To enable it in Grafana Cloud, contact Grafana Support.
 
 ## Request

--- a/docs/sources/tempo/api_docs/metrics-summary.md
+++ b/docs/sources/tempo/api_docs/metrics-summary.md
@@ -10,7 +10,7 @@ weight: 600
 # Metrics summary API
 
 {{< admonition type="warning" >}}
-Metrics summary API is deprecated in Grafana Cloud and Grafana 11.3 and later.
+The metrics summary API is deprecated in Tempo 2.7. Features powered by the metrics summary API, like the Aggregate by table, are also deprecated in Grafana Cloud and Grafana 11.3 and later.
 It will be removed in a future release.
 {{% /admonition %}}
 

--- a/docs/sources/tempo/api_docs/metrics-summary.md
+++ b/docs/sources/tempo/api_docs/metrics-summary.md
@@ -10,7 +10,8 @@ weight: 600
 # Metrics summary API
 
 {{< admonition type="warning" >}}
-The Metrics summary API is an [experimental feature](/docs/release-life-cycle) that is disabled by default. To enable it, adjust your configuration as suggested below.
+Metrics summary API is deprecated in Grafana Cloud and Grafana 11.3 and later.
+It will be removed in a future release.
 {{% /admonition %}}
 
 This document explains how to use the metrics summary API in Tempo.
@@ -18,7 +19,7 @@ This API returns RED metrics (span count, erroring span count, and latency infor
 
 {{< youtube id="g97CjKOZqT4" >}}
 
-## Configuration
+## Activate metrics summary
 
 To enable the experimental metrics summary API, you must turn on the local blocks processor in the metrics generator.
 Be aware that the generator uses considerably more resources, including disk space, if it's enabled:
@@ -29,6 +30,9 @@ overrides:
     metrics_generator:
       processors: [..., 'local-blocks']
 ```
+
+In Grafana and Grafana Cloudl, the Metrics summary API is an [experimental feature]({{< relref "/docs/release-life-cycle" >}}) that is disabled by default.
+To enable it in Grafana Cloud, contact Grafana Support.
 
 ## Request
 

--- a/docs/sources/tempo/api_docs/metrics-summary.md
+++ b/docs/sources/tempo/api_docs/metrics-summary.md
@@ -31,7 +31,7 @@ overrides:
       processors: [..., 'local-blocks']
 ```
 
-In Grafana and Grafana Cloudl, the Metrics summary API is an [experimental feature]({{< relref "/docs/release-life-cycle" >}}) that is disabled by default.
+In Grafana and Grafana Cloudl, the Metrics summary API is an [experimental feature](https://grafana.com/docs/release-life-cycle/) that is disabled by default.
 To enable it in Grafana Cloud, contact Grafana Support.
 
 ## Request


### PR DESCRIPTION
**What this PR does**:

Adds a deprecation note for metrics summary API. Aggregate by is already marked as deprecated in Grafana Cloud.

Part of https://github.com/grafana/website/pull/22148 and https://github.com/grafana/tempo-squad/issues/438


**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`