### PR TITLE
Add range condition to bytes predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   To continue using the Jaeger exporter, use the following environment variable: `OTEL_TRACES_EXPORTER=jaeger`.
 * [CHANGE] No longer send the final diff in GRPC streaming. Instead we rely on the streamed intermediate results. [#4062](https://github.com/grafana/tempo/pull/4062) (@joe-elliott)
 * [CHANGE] Update Go to 1.23.1 [#4146](https://github.com/grafana/tempo/pull/4146) [#4147](https://github.com/grafana/tempo/pull/4147) (@javiermolinar)
+* [CHANGE] TraceQL: Add range condition for byte predicates [#4198](https://github.com/grafana/tempo/pull/4198) (@ie-pham)
 * [FEATURE] Discarded span logging `log_discarded_spans` [#3957](https://github.com/grafana/tempo/issues/3957) (@dastrobu)
 * [FEATURE] TraceQL support for instrumentation scope [#3967](https://github.com/grafana/tempo/pull/3967) (@ie-pham)
 * [ENHANCEMENT] TraceQL: Attribute iterators collect matched array values [#3867](https://github.com/grafana/tempo/pull/3867) (@electron0zero, @stoewer)

--- a/pkg/parquetquerygen/predicates.go
+++ b/pkg/parquetquerygen/predicates.go
@@ -252,7 +252,7 @@ func (p {{ $structName }}) KeepValue(v pq.Value) bool {
 				{
 					Op:          "Equal",
 					CompareCond: `bytes.Equal(bytes.TrimLeft(vv, "\x00"), p.value)`,
-					RangeCond:   "", // benchmarks are generally better w/o a range condition? "bytes.Compare(p.value, min) >= 0 && bytes.Compare(p.value, max) <= 0",
+					RangeCond:   "bytes.Compare(p.value, min) >= 0 && bytes.Compare(p.value, max) <= 0",
 				},
 				{
 					Op:          "NotEqual",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: Remove earlier comment to add range condition to byte predicates. 

```
                                                                     │ before-onlyid.txt │           after-onlyid.txt           │
                                                                     │      sec/op       │    sec/op     vs base                │
BackendBlockTraceQL/trace:id_=_`xxx`-16        17.421m ± 3%   9.895m ± 13%  -43.20% (p=0.000 n=20)

                                                                     │ before-onlyid.txt │           after-onlyid.txt            │
                                                                     │        B/s        │      B/s       vs base                │
BackendBlockTraceQL/trace:id_=_`xxx`-16        540.3Mi ± 3%   837.7Mi ± 11%  +55.03% (p=0.000 n=20)

                                                                     │ before-onlyid.txt │          after-onlyid.txt          │
                                                                     │     MB_io/op      │  MB_io/op   vs base                │
BackendBlockTraceQL/trace:id_=_`xxx`-16          9.870 ± 0%   8.691 ± 0%  -11.95% (p=0.000 n=20)
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`