### PR TITLE
Replace `encoding/json` with `json-iterator/go` in backend

### DIFF
--- a/modules/generator/processor/localblocks/processor.go
+++ b/modules/generator/processor/localblocks/processor.go
@@ -3,10 +3,10 @@ package localblocks
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -742,8 +742,7 @@ func (p *Processor) reloadBlocks() error {
 
 		var clearBlock bool
 		if err != nil {
-			var vv *json.SyntaxError
-			if errors.Is(err, backend.ErrDoesNotExist) || errors.As(err, &vv) {
+			if errors.Is(err, backend.ErrDoesNotExist) || strings.Contains(err.Error(), "error found in") {
 				clearBlock = true
 			}
 		}

--- a/tempodb/backend/block_meta.go
+++ b/tempodb/backend/block_meta.go
@@ -1,7 +1,6 @@
 package backend
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -108,13 +107,13 @@ func (dc *DedicatedColumn) MarshalJSON() ([]byte, error) {
 	if cpy.Type == DefaultDedicatedColumnType {
 		cpy.Type = ""
 	}
-	return json.Marshal(&cpy)
+	return jsonCompat.Marshal(&cpy)
 }
 
 func (dc *DedicatedColumn) UnmarshalJSON(b []byte) error {
 	type dcAlias DedicatedColumn // alias required to avoid recursive calls of UnmarshalJSON
 
-	err := json.Unmarshal(b, (*dcAlias)(dc))
+	err := jsonCompat.Unmarshal(b, (*dcAlias)(dc))
 	if err != nil {
 		return err
 	}
@@ -139,7 +138,7 @@ func (dcs *DedicatedColumns) UnmarshalJSON(b []byte) error {
 	}
 
 	type dcsAlias DedicatedColumns // alias required to avoid recursive calls of UnmarshalJSON
-	err := json.Unmarshal(b, (*dcsAlias)(dcs))
+	err := jsonCompat.Unmarshal(b, (*dcsAlias)(dcs))
 	if err != nil {
 		return err
 	}
@@ -310,7 +309,7 @@ func (dcs DedicatedColumns) Marshal() ([]byte, error) {
 	}
 
 	// NOTE: The json bytes interned in a map to avoid re-unmarshalling the same byte slice.
-	return json.Marshal(dcs)
+	return jsonCompat.Marshal(dcs)
 }
 
 func (dcs DedicatedColumns) MarshalTo(data []byte) (n int, err error) {
@@ -329,12 +328,12 @@ func (dcs *DedicatedColumns) Unmarshal(data []byte) error {
 	}
 
 	// NOTE: The json bytes interned in a map to avoid re-unmarshalling the same byte slice.
-	return json.Unmarshal(data, &dcs)
+	return jsonCompat.Unmarshal(data, &dcs)
 }
 
 func (b *CompactedBlockMeta) UnmarshalJSON(data []byte) error {
 	var msg interface{}
-	err := json.Unmarshal(data, &msg)
+	err := jsonCompat.Unmarshal(data, &msg)
 	if err != nil {
 		return err
 	}
@@ -347,7 +346,7 @@ func (b *CompactedBlockMeta) UnmarshalJSON(data []byte) error {
 		}
 	}
 
-	if err := json.Unmarshal(data, &b.BlockMeta); err != nil {
+	if err := jsonCompat.Unmarshal(data, &b.BlockMeta); err != nil {
 		return fmt.Errorf("failed at unmarshal for dedicated columns: %w", err)
 	}
 

--- a/tempodb/backend/encoding.go
+++ b/tempodb/backend/encoding.go
@@ -2,7 +2,6 @@ package backend
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -86,7 +85,7 @@ func (e Encoding) MarshalYAML() (interface{}, error) {
 // UnmarshalJSON implements the Unmarshaler interface of the json pkg.
 func (e *Encoding) UnmarshalJSON(b []byte) error {
 	var encString string
-	err := json.Unmarshal(b, &encString)
+	err := jsonCompat.Unmarshal(b, &encString)
 	if err != nil {
 		return err
 	}

--- a/tempodb/backend/json.go
+++ b/tempodb/backend/json.go
@@ -1,10 +1,15 @@
 package backend
 
-import "sync"
+import (
+	"sync"
+
+	jsoniter "github.com/json-iterator/go"
+)
 
 var (
 	dedicatedColumnsKeeper = map[string]*DedicatedColumns{}
 	dedicatedColumnsMtx    = sync.Mutex{}
+	jsonCompat             = jsoniter.ConfigCompatibleWithStandardLibrary
 )
 
 func getDedicatedColumns(b string) *DedicatedColumns {

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -3,7 +3,6 @@ package backend
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -105,7 +104,7 @@ func (w *writer) WriteBlockMeta(ctx context.Context, meta *BlockMeta) error {
 		tenantID = meta.TenantID
 	)
 
-	bMeta, err := json.Marshal(meta)
+	bMeta, err := jsonCompat.Marshal(meta)
 	if err != nil {
 		return err
 	}
@@ -233,7 +232,7 @@ func (r *reader) BlockMeta(ctx context.Context, blockID uuid.UUID, tenantID stri
 	}
 
 	out := &BlockMeta{}
-	err = json.Unmarshal(bytes, out)
+	err = jsonCompat.Unmarshal(bytes, out)
 	if err != nil {
 		return nil, err
 	}

--- a/tempodb/backend/tenantindex.go
+++ b/tempodb/backend/tenantindex.go
@@ -2,7 +2,6 @@ package backend
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -32,7 +31,7 @@ func (b *TenantIndex) marshal() ([]byte, error) {
 	gzip := gzip.NewWriter(buffer)
 	gzip.Name = internalFilename
 
-	jsonBytes, err := json.Marshal(b)
+	jsonBytes, err := jsonCompat.Marshal(b)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +57,7 @@ func (b *TenantIndex) unmarshal(buffer []byte) error {
 	}
 	defer gzipReader.Close()
 
-	d := json.NewDecoder(gzipReader)
+	d := jsonCompat.NewDecoder(gzipReader)
 	return d.Decode(b)
 }
 

--- a/tempodb/backend/uuid.go
+++ b/tempodb/backend/uuid.go
@@ -59,12 +59,12 @@ func (u *UUID) Size() int {
 }
 
 func (u UUID) MarshalJSON() ([]byte, error) {
-	return json.Marshal(((google_uuid.UUID)(u)).String())
+	return jsonCompat.Marshal(((google_uuid.UUID)(u)).String())
 }
 
 func (u *UUID) UnmarshalJSON(data []byte) error {
 	var s string
-	err := json.Unmarshal(data, &s)
+	err := jsonCompat.Unmarshal(data, &s)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does**:

To improve the performance of json marshaling/unmarshaling of the tenant index and the block metas, swap out the library in use.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`