### PR TITLE
[DOC] Fix wrong date command in push HTTP API doc

### DIFF
--- a/docs/sources/tempo/api_docs/pushing-spans-with-http.md
+++ b/docs/sources/tempo/api_docs/pushing-spans-with-http.md
@@ -72,7 +72,7 @@ curl -X POST -H 'Content-Type: application/json' http://localhost:4318/v1/traces
 }'
 ```
 
-Note that the `startTimeUnixNano` field is in nanoseconds and can be obtained by any tool that provides the epoch date in nanoseconds (for example, under Linux, `date +%s%8N`). The `endTimeUnixNano` field is also in nanoseconds, where 100000000 nanoseconds is 100 milliseconds.
+Note that the `startTimeUnixNano` field is in nanoseconds and can be obtained by any tool that provides the epoch date in nanoseconds (for example, under Linux, `date +%s%N`). The `endTimeUnixNano` field is also in nanoseconds, where 100000000 nanoseconds is 100 milliseconds.
 
 1. Copy and paste the curl command into a text editor.
 


### PR DESCRIPTION
**What this PR does**:

Corrects a typo in date calculation command in the push HTTP doc. There was an extra 8 that needed to be removed. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/support-escalations/issues/12401

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`