### PR TITLE
Ignore gh-token.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 private-key.key
 integration/e2e/e2e_integration_test[0-9]*
 .tempo.yaml
+gh-token.txt


### PR DESCRIPTION
drone is failing with:

```
/go/bin/goreleaser release --rm-dist 
Flag --rm-dist has been deprecated, please use --clean instead
  • starting release...
  • loading                                          path=.goreleaser.yml
  • DEPRECATED: --rm-dist was deprecated in favor of --clean, check https://goreleaser.com/deprecations#-rm-dist for more details
  • loading environment variables
    • using token from  $GITHUB_TOKEN 
  • getting and validating git state
    • git state                                      commit=c4fad424e0f0b7e32187edb88b29a59b38198478 branch=HEAD current_tag=v2.6.1 previous_tag=v2.6.0 dirty=true
  ⨯ release failed after 0s                  error=git is in a dirty state
Please check in your pipeline what can be changing the following files:
?? gh-token.txt
```