### PR TITLE
Create Maintainer Emeritus title

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,15 +11,15 @@
 # In each subsection folders are ordered first by depth, then alphabetically.
 # This should make it easy to add new rules without breaking existing ones.
 
-* @joe-elliott @annanay25 @mdisibio @mapno @kvrhdn @zalegrala @electron0zero @ie-pham @stoewer @javiermolinar
+* @joe-elliott @mdisibio @mapno @kvrhdn @zalegrala @electron0zero @ie-pham @stoewer @javiermolinar
 
-/docs/ @knylander-grafana @joe-elliott @annanay25 @mdisibio @mapno @kvrhdn @zalegrala @electron0zero @ie-pham @stoewer
+/docs/ @knylander-grafana @joe-elliott @mdisibio @mapno @kvrhdn @zalegrala @electron0zero @ie-pham @stoewer
 
-/.github/backport.yml           @jdbaldry @joe-elliott @annanay25 @mdisibio @mapno @kvrhdn @zalegrala @electron0zero @ie-pham @stoewer
-/.github/update-make-docs.yml   @jdbaldry @joe-elliott @annanay25 @mdisibio @mapno @kvrhdn @zalegrala @electron0zero @ie-pham @stoewer
-/.github/website-next.yml       @jdbaldry @joe-elliott @annanay25 @mdisibio @mapno @kvrhdn @zalegrala @electron0zero @ie-pham @stoewer
-/.github/website-versioned.yml  @jdbaldry @joe-elliott @annanay25 @mdisibio @mapno @kvrhdn @zalegrala @electron0zero @ie-pham @stoewer
-/docs/docs.mk                   @jdbaldry @knylander-grafana @joe-elliott @annanay25 @mdisibio @mapno @kvrhdn @zalegrala @electron0zero @ie-pham @stoewer
-/docs/make-docs                 @jdbaldry @knylander-grafana @joe-elliott @annanay25 @mdisibio @mapno @kvrhdn @zalegrala @electron0zero @ie-pham @stoewer
-/docs/Makefile                  @jdbaldry @knylander-grafana @joe-elliott @annanay25 @mdisibio @mapno @kvrhdn @zalegrala @electron0zero @ie-pham @stoewer
-/docs/variables.mk              @jdbaldry @knylander-grafana @joe-elliott @annanay25 @mdisibio @mapno @kvrhdn @zalegrala @electron0zero @ie-pham @stoewer
+/.github/backport.yml           @jdbaldry @joe-elliott @mdisibio @mapno @kvrhdn @zalegrala @electron0zero @ie-pham @stoewer
+/.github/update-make-docs.yml   @jdbaldry @joe-elliott @mdisibio @mapno @kvrhdn @zalegrala @electron0zero @ie-pham @stoewer
+/.github/website-next.yml       @jdbaldry @joe-elliott @mdisibio @mapno @kvrhdn @zalegrala @electron0zero @ie-pham @stoewer
+/.github/website-versioned.yml  @jdbaldry @joe-elliott @mdisibio @mapno @kvrhdn @zalegrala @electron0zero @ie-pham @stoewer
+/docs/docs.mk                   @jdbaldry @knylander-grafana @joe-elliott @mdisibio @mapno @kvrhdn @zalegrala @electron0zero @ie-pham @stoewer
+/docs/make-docs                 @jdbaldry @knylander-grafana @joe-elliott @mdisibio @mapno @kvrhdn @zalegrala @electron0zero @ie-pham @stoewer
+/docs/Makefile                  @jdbaldry @knylander-grafana @joe-elliott @mdisibio @mapno @kvrhdn @zalegrala @electron0zero @ie-pham @stoewer
+/docs/variables.mk              @jdbaldry @knylander-grafana @joe-elliott @mdisibio @mapno @kvrhdn @zalegrala @electron0zero @ie-pham @stoewer

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -46,7 +46,6 @@ In case a member leaves, the [offboarding](#offboarding) procedure is applied.
 
 The current team members are:
 
-- Annanay Agarwal - [annanay25](https://github.com/annanay25) ([Grafana Labs](https://grafana.com/))
 - Suraj Nath - [electron0zero](https://github.com/electron0zero) ([Grafana Labs](https://grafana.com/))
 - Jennie Pham - [ie-pham](https://github.com/ie-pham) ([Grafana Labs](https://grafana.com/))
 - Javi Molina - [javiermolinar](https://github.com/javiermolinar) ([Grafana Labs](https://grafana.com/))
@@ -69,6 +68,10 @@ Maintainers are granted commit rights to all projects covered by this governance
 A maintainer or committer may resign by notifying the [team mailing list][team]. A maintainer with no project activity for a year is considered to have resigned. Maintainers that wish to resign are encouraged to propose another team member to take over the project.
 
 A project may have multiple maintainers, as long as the responsibilities are clearly agreed upon between them. This includes coordinating who handles which issues and pull requests.
+
+### Emeritus Maintainers
+
+Emeritus maintainers are former maintainers who no longer work directly on Tempo on a regular basis. We respect their former contributions by giving them the Emeritus Maintainer title. This is honorary only and confers no responsibilities or rights regarding the Tempo project.
 
 ### Technical decisions
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,4 +1,3 @@
-* @annanay25
 * @electron0zero
 * @ie-pham
 * @javiermolinar
@@ -9,3 +8,8 @@
 * @mdisibio
 * @stoewer
 * @zalegrala
+
+Emeritus Maintainers
+
+* @annanay25
+* @dgzlopes


### PR DESCRIPTION
This PR creates the definition of Maintainer Emeritus for the Tempo projects and moves two former, inactive maintainers into this category.

Thank you for your contributions @annanay25 and @dgzlopes!