### PR TITLE
Ignore gh token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ integration/e2e/e2e_integration_test[0-9]*
 integration/e2e/deployments/e2e_integration_test[0-9]*
 .tempo.yaml
 /tmp
+gh-token.txt


### PR DESCRIPTION
Frontports https://github.com/grafana/tempo/pull/4221 from the release-2.6 branch so releases will work in the future.