### PR TITLE
Add flush_to_storage config doc

### DIFF
--- a/docs/sources/tempo/operations/traceql-metrics.md
+++ b/docs/sources/tempo/operations/traceql-metrics.md
@@ -80,6 +80,8 @@ metrics_generator:
       flush_to_storage: true
 ```
 
+Setting `flush_to_storage` to `true` ensures that metrics blocks are flushed to storage so TraceQL metrics queries against historical data.
+
 For more information about overrides, refer to [Standard overrides](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#standard-overrides).
 
 ## Evaluate query timeouts

--- a/docs/sources/tempo/traceql/metrics-queries.md
+++ b/docs/sources/tempo/traceql/metrics-queries.md
@@ -15,7 +15,7 @@ keywords:
 TraceQL metrics is an experimental feature in Grafana Tempo that creates metrics from traces.
 
 Metric queries extend trace queries by applying a function to trace query results.
-This powerful feature allows for adhoc aggregation of any existing TraceQL query by any dimension available in your traces, much in the same way that LogQL metric queries create metrics from logs.
+This powerful feature allows for ad hoc aggregation of any existing TraceQL query by any dimension available in your traces, much in the same way that LogQL metric queries create metrics from logs.
 
 Traces are a unique observability signal that contain causal relationships between the components in your system.
 Do you want to know how many database calls across all systems are downstream of your application?


### PR DESCRIPTION
**What this PR does**:

Add docs for flush_to_storage for the TraceQL metrics configuration.  

**Which issue(s) this PR fixes**:
Part of https://github.com/grafana/tempo/issues/4064

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`