### PR TITLE
fix: counter samples being downsampled when series is new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,9 @@
 ## main / unreleased
-* [ENHANCEMENT] The span multiplier now also sources its value from the resource attributes. [#4210](https://github.com/grafana/tempo/pull/4210)
-* [ENHANCEMENT] Changed log level from INFO to DEBUG for the TempoDB Find operation using traceId to reduce excessive/unwanted logs in log search. [#4179](https://github.com/grafana/tempo/pull/4179) (@Aki0x137)
-* [ENHANCEMENT] Pushdown collection of results from generators in the querier [#4119](https://github.com/grafana/tempo/pull/4119) (@electron0zero)
+
 * [CHANGE] Add throughput and SLO metrics in the tags and tag values endpoints [#4148](https://github.com/grafana/tempo/pull/4148) (@electron0zero)
-* [ENHANCEMENT] Send semver version in api/stattus/buildinfo for cloud deployments [#4110](https://github.com/grafana/tempo/pull/4110) [@Aki0x137]
-* [ENHANCEMENT] Speedup DistinctString and ScopedDistinctString collectors [#4109](https://github.com/grafana/tempo/pull/4109) (@electron0zero)
 * [CHANGE] tempo-cli: add support for /api/v2/traces endpoint [#4127](https://github.com/grafana/tempo/pull/4127) (@electron0zero)
   **BREAKING CHANGE** The `tempo-cli` now uses the `/api/v2/traces` endpoint by default, 
   please use `--v1` flag to use `/api/traces` endpoint, which was the default in previous versions.
-* [ENHANCEMENT] Speedup collection of results from ingesters in the querier [#4100](https://github.com/grafana/tempo/pull/4100) (@electron0zero)
-* [ENHANCEMENT] Speedup DistinctValue collector and exit early for ingesters [#4104](https://github.com/grafana/tempo/pull/4104) (@electron0zero)
-* [ENHANCEMENT] Add disk caching in ingester SearchTagValuesV2 for completed blocks [#4069](https://github.com/grafana/tempo/pull/4069) (@electron0zero)
-* [BUGFIX] Replace hedged requests roundtrips total with a counter. [#4063](https://github.com/grafana/tempo/pull/4063) [#4078](https://github.com/grafana/tempo/pull/4078) (@galalen)
-* [BUGFIX] Metrics generators: Correctly drop from the ring before stopping ingestion to reduce drops during a rollout. [#4101](https://github.com/grafana/tempo/pull/4101) (@joe-elliott)
-* [BUGFIX] Correctly handle 400 Bad Request and 404 Not Found in gRPC streaming [#4144](https://github.com/grafana/tempo/pull/4144) (@mapno)
-* [BUGFIX] Pushes a 0 to classic histogram's counter when the series is new to allow Prometheus to start from a non-null value. [#4140](https://github.com/grafana/tempo/pull/4140) (@mapno)
 * [CHANGE] TraceByID: don't allow concurrent_shards greater than query_shards. [#4074](https://github.com/grafana/tempo/pull/4074) (@electron0zero)
 * [CHANGE] **BREAKING CHANGE** The dynamic injection of X-Scope-OrgID header for metrics generator remote-writes is changed. If the header is aleady set in per-tenant overrides or global tempo configuration, then it is honored and not overwritten. [#4021](https://github.com/grafana/tempo/pull/4021) (@mdisibio)
 * [CHANGE] **BREAKING CHANGE** Migrate from OpenTracing to OpenTelemetry instrumentation. Removed the `use_otel_tracer` configuration option. Use the OpenTelemetry environment variables to configure the span exporter [#3646](https://github.com/grafana/tempo/pull/3646) (@andreasgerstmayr)
@@ -41,6 +30,19 @@
 * [ENHANCEMENT] TraceQL metrics queries: add max_over_time  [#4065](https://github.com/grafana/tempo/pull/4065) (@javiermolinar)
 * [ENHANCEMENT] Write tenantindex as proto and json with a prefernce for proto [#4072](https://github.com/grafana/tempo/pull/4072) (@zalegrala)
 * [ENHANCEMENT] Pool zstd encoding/decoding for tmepodb/backend [#4208](https://github.com/grafana/tempo/pull/4208) (@zalegrala)
+* [ENHANCEMENT] The span multiplier now also sources its value from the resource attributes. [#4210](https://github.com/grafana/tempo/pull/4210)
+* [ENHANCEMENT] Changed log level from INFO to DEBUG for the TempoDB Find operation using traceId to reduce excessive/unwanted logs in log search. [#4179](https://github.com/grafana/tempo/pull/4179) (@Aki0x137)
+* [ENHANCEMENT] Pushdown collection of results from generators in the querier [#4119](https://github.com/grafana/tempo/pull/4119) (@electron0zero)
+* [ENHANCEMENT] Send semver version in api/stattus/buildinfo for cloud deployments [#4110](https://github.com/grafana/tempo/pull/4110) [@Aki0x137]
+* [ENHANCEMENT] Speedup DistinctString and ScopedDistinctString collectors [#4109](https://github.com/grafana/tempo/pull/4109) (@electron0zero)
+* [ENHANCEMENT] Speedup collection of results from ingesters in the querier [#4100](https://github.com/grafana/tempo/pull/4100) (@electron0zero)
+* [ENHANCEMENT] Speedup DistinctValue collector and exit early for ingesters [#4104](https://github.com/grafana/tempo/pull/4104) (@electron0zero)
+* [ENHANCEMENT] Add disk caching in ingester SearchTagValuesV2 for completed blocks [#4069](https://github.com/grafana/tempo/pull/4069) (@electron0zero)
+* [BUGFIX] Replace hedged requests roundtrips total with a counter. [#4063](https://github.com/grafana/tempo/pull/4063) [#4078](https://github.com/grafana/tempo/pull/4078) (@galalen)
+* [BUGFIX] Metrics generators: Correctly drop from the ring before stopping ingestion to reduce drops during a rollout. [#4101](https://github.com/grafana/tempo/pull/4101) (@joe-elliott)
+* [BUGFIX] Correctly handle 400 Bad Request and 404 Not Found in gRPC streaming [#4144](https://github.com/grafana/tempo/pull/4144) (@mapno)
+* [BUGFIX] Pushes a 0 to classic histogram's counter when the series is new to allow Prometheus to start from a non-null value. [#4140](https://github.com/grafana/tempo/pull/4140) (@mapno)
+* [BUGFIX] Fix counter samples being downsampled by backdate to the previous minute the initial sample when the series is new [#44236](https://github.com/grafana/tempo/pull/4236) (@javiermolinar)
 
 # v2.6.1
 

--- a/modules/generator/registry/config.go
+++ b/modules/generator/registry/config.go
@@ -10,8 +10,8 @@ type Config struct {
 	// Defaults to 15s.
 	CollectionInterval time.Duration `yaml:"collection_interval"`
 
-	// StaleDuration controls how quickly series become stale and are deleted from the registry. An active
-	// series is deleted if it hasn't been updated more stale duration.
+	// StaleDuration controls how quickly series become stale and are deleted from the registry.
+	// An active series is deleted if it hasn't been updated for a more than the stale duration.
 	// Defaults to 15m.
 	StaleDuration time.Duration `yaml:"stale_duration"`
 

--- a/modules/generator/registry/counter_test.go
+++ b/modules/generator/registry/counter_test.go
@@ -13,7 +13,7 @@ import (
 
 func Test_counter(t *testing.T) {
 	var seriesAdded int
-	onAdd := func(count uint32) bool {
+	onAdd := func(_ uint32) bool {
 		seriesAdded++
 		return true
 	}
@@ -26,12 +26,12 @@ func Test_counter(t *testing.T) {
 	assert.Equal(t, 2, seriesAdded)
 
 	collectionTimeMs := time.Now().UnixMilli()
-	offsetCollectionTimeMs := time.UnixMilli(collectionTimeMs).Add(insertOffsetDuration).UnixMilli()
+	endOfLastMinuteMs := getEndOfLastMinuteMs(collectionTimeMs)
 	expectedSamples := []sample{
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, collectionTimeMs, 0),
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, offsetCollectionTimeMs, 1),
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-2"}, collectionTimeMs, 0),
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-2"}, offsetCollectionTimeMs, 2),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, endOfLastMinuteMs, 0),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, collectionTimeMs, 1),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-2"}, endOfLastMinuteMs, 0),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-2"}, collectionTimeMs, 2),
 	}
 	collectMetricAndAssert(t, c, collectionTimeMs, nil, 2, expectedSamples, nil)
 
@@ -41,12 +41,12 @@ func Test_counter(t *testing.T) {
 	assert.Equal(t, 3, seriesAdded)
 
 	collectionTimeMs = time.Now().UnixMilli()
-	offsetCollectionTimeMs = time.UnixMilli(collectionTimeMs).Add(insertOffsetDuration).UnixMilli()
+	endOfLastMinuteMs = getEndOfLastMinuteMs(collectionTimeMs)
 	expectedSamples = []sample{
 		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_counter", "label": "value-2"}, collectionTimeMs, 4),
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-3"}, collectionTimeMs, 0),
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-3"}, offsetCollectionTimeMs, 3),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-3"}, endOfLastMinuteMs, 0),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-3"}, collectionTimeMs, 3),
 	}
 
 	collectMetricAndAssert(t, c, collectionTimeMs, nil, 3, expectedSamples, nil)
@@ -54,7 +54,7 @@ func Test_counter(t *testing.T) {
 
 func TestCounterDifferentLabels(t *testing.T) {
 	var seriesAdded int
-	onAdd := func(count uint32) bool {
+	onAdd := func(_ uint32) bool {
 		seriesAdded++
 		return true
 	}
@@ -67,12 +67,12 @@ func TestCounterDifferentLabels(t *testing.T) {
 	assert.Equal(t, 2, seriesAdded)
 
 	collectionTimeMs := time.Now().UnixMilli()
-	offsetCollectionTimeMs := time.UnixMilli(collectionTimeMs).Add(insertOffsetDuration).UnixMilli()
+	endOfLastMinuteMs := getEndOfLastMinuteMs(collectionTimeMs)
 	expectedSamples := []sample{
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, collectionTimeMs, 0),
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, offsetCollectionTimeMs, 1),
-		newSample(map[string]string{"__name__": "my_counter", "another_label": "another_value"}, collectionTimeMs, 0),
-		newSample(map[string]string{"__name__": "my_counter", "another_label": "another_value"}, offsetCollectionTimeMs, 2),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, endOfLastMinuteMs, 0),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, collectionTimeMs, 1),
+		newSample(map[string]string{"__name__": "my_counter", "another_label": "another_value"}, endOfLastMinuteMs, 0),
+		newSample(map[string]string{"__name__": "my_counter", "another_label": "another_value"}, collectionTimeMs, 2),
 	}
 	collectMetricAndAssert(t, c, collectionTimeMs, nil, 2, expectedSamples, nil)
 }
@@ -93,12 +93,12 @@ func Test_counter_cantAdd(t *testing.T) {
 	c.Inc(newLabelValueCombo([]string{"label"}, []string{"value-2"}), 2.0)
 
 	collectionTimeMs := time.Now().UnixMilli()
-	offsetCollectionTimeMs := time.UnixMilli(collectionTimeMs).Add(insertOffsetDuration).UnixMilli()
+	endOfLastMinuteMs := getEndOfLastMinuteMs(collectionTimeMs)
 	expectedSamples := []sample{
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, collectionTimeMs, 0),
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, offsetCollectionTimeMs, 1),
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-2"}, collectionTimeMs, 0),
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-2"}, offsetCollectionTimeMs, 2),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, endOfLastMinuteMs, 0),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, collectionTimeMs, 1),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-2"}, endOfLastMinuteMs, 0),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-2"}, collectionTimeMs, 2),
 	}
 	collectMetricAndAssert(t, c, collectionTimeMs, nil, 2, expectedSamples, nil)
 
@@ -134,12 +134,12 @@ func Test_counter_removeStaleSeries(t *testing.T) {
 	assert.Equal(t, 0, removedSeries)
 
 	collectionTimeMs := time.Now().UnixMilli()
-	offsetCollectionTimeMs := time.UnixMilli(collectionTimeMs).Add(insertOffsetDuration).UnixMilli()
+	endOfLastMinuteMs := getEndOfLastMinuteMs(collectionTimeMs)
 	expectedSamples := []sample{
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, collectionTimeMs, 0),
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, offsetCollectionTimeMs, 1),
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-2"}, collectionTimeMs, 0),
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-2"}, offsetCollectionTimeMs, 2),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, endOfLastMinuteMs, 0),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, collectionTimeMs, 1),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-2"}, endOfLastMinuteMs, 0),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-2"}, collectionTimeMs, 2),
 	}
 	collectMetricAndAssert(t, c, collectionTimeMs, nil, 2, expectedSamples, nil)
 
@@ -167,12 +167,12 @@ func Test_counter_externalLabels(t *testing.T) {
 	c.Inc(newLabelValueCombo([]string{"label"}, []string{"value-2"}), 2.0)
 
 	collectionTimeMs := time.Now().UnixMilli()
-	offsetCollectionTimeMs := time.UnixMilli(collectionTimeMs).Add(insertOffsetDuration).UnixMilli()
+	endOfLastMinuteMs := getEndOfLastMinuteMs(collectionTimeMs)
 	expectedSamples := []sample{
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-1", "external_label": "external_value"}, collectionTimeMs, 0),
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-1", "external_label": "external_value"}, offsetCollectionTimeMs, 1),
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-2", "external_label": "external_value"}, collectionTimeMs, 0),
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-2", "external_label": "external_value"}, offsetCollectionTimeMs, 2),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-1", "external_label": "external_value"}, endOfLastMinuteMs, 0),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-1", "external_label": "external_value"}, collectionTimeMs, 1),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-2", "external_label": "external_value"}, endOfLastMinuteMs, 0),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-2", "external_label": "external_value"}, collectionTimeMs, 2),
 	}
 	collectMetricAndAssert(t, c, collectionTimeMs, map[string]string{"external_label": "external_value"}, 2, expectedSamples, nil)
 }
@@ -253,10 +253,10 @@ func Test_counter_concurrencyCorrectness(t *testing.T) {
 	wg.Wait()
 
 	collectionTimeMs := time.Now().UnixMilli()
-	offsetCollectionTimeMs := time.UnixMilli(collectionTimeMs).Add(insertOffsetDuration).UnixMilli()
+	endOfLastMinuteMs := getEndOfLastMinuteMs(collectionTimeMs)
 	expectedSamples := []sample{
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, collectionTimeMs, 0),
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, offsetCollectionTimeMs, totalCount.Load()),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, endOfLastMinuteMs, 0),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, collectionTimeMs, totalCount.Load()),
 	}
 	collectMetricAndAssert(t, c, collectionTimeMs, nil, 1, expectedSamples, nil)
 }

--- a/modules/generator/registry/gauge_test.go
+++ b/modules/generator/registry/gauge_test.go
@@ -12,7 +12,7 @@ import (
 
 func Test_gaugeInc(t *testing.T) {
 	var seriesAdded int
-	onAdd := func(count uint32) bool {
+	onAdd := func(_ uint32) bool {
 		seriesAdded++
 		return true
 	}
@@ -47,7 +47,7 @@ func Test_gaugeInc(t *testing.T) {
 
 func TestGaugeDifferentLabels(t *testing.T) {
 	var seriesAdded int
-	onAdd := func(count uint32) bool {
+	onAdd := func(_ uint32) bool {
 		seriesAdded++
 		return true
 	}
@@ -69,7 +69,7 @@ func TestGaugeDifferentLabels(t *testing.T) {
 
 func Test_gaugeSet(t *testing.T) {
 	var seriesAdded int
-	onAdd := func(count uint32) bool {
+	onAdd := func(_ uint32) bool {
 		seriesAdded++
 		return true
 	}

--- a/modules/generator/registry/histogram.go
+++ b/modules/generator/registry/histogram.go
@@ -165,8 +165,6 @@ func (h *histogram) collectMetrics(appender storage.Appender, timeMs int64, exte
 	h.seriesMtx.Lock()
 	defer h.seriesMtx.Unlock()
 
-	t := timeMs
-
 	activeSeries = len(h.series) * int(h.activeSeriesPerHistogramSerie())
 
 	labelsCount := 0
@@ -191,7 +189,10 @@ func (h *histogram) collectMetrics(appender storage.Appender, timeMs int64, exte
 		// we need to first insert a 0 value to allow Prometheus to start from a non-null value.
 		if s.isNew() {
 			lb.Set(labels.MetricName, h.nameCount)
-			_, err = appender.Append(0, lb.Labels(), t-1, 0) // t-1 to ensure that the next value is not at the same time
+			// We set the timestamp of the init serie at the end of the previous minute, that way we ensure it ends in a
+			// different aggregation interval to avoid be downsampled.
+			endOfLastMinuteMs := getEndOfLastMinuteMs(timeMs)
+			_, err = appender.Append(0, lb.Labels(), endOfLastMinuteMs, 0)
 			if err != nil {
 				return
 			}
@@ -200,14 +201,14 @@ func (h *histogram) collectMetrics(appender storage.Appender, timeMs int64, exte
 
 		// sum
 		lb.Set(labels.MetricName, h.nameSum)
-		_, err = appender.Append(0, lb.Labels(), t, s.sum.Load())
+		_, err = appender.Append(0, lb.Labels(), timeMs, s.sum.Load())
 		if err != nil {
 			return
 		}
 
 		// count
 		lb.Set(labels.MetricName, h.nameCount)
-		_, err = appender.Append(0, lb.Labels(), t, s.count.Load())
+		_, err = appender.Append(0, lb.Labels(), timeMs, s.count.Load())
 		if err != nil {
 			return
 		}
@@ -217,7 +218,7 @@ func (h *histogram) collectMetrics(appender storage.Appender, timeMs int64, exte
 
 		for i, bucketLabel := range h.bucketLabels {
 			lb.Set(labels.BucketLabel, bucketLabel)
-			ref, err := appender.Append(0, lb.Labels(), t, s.buckets[i].Load())
+			ref, err := appender.Append(0, lb.Labels(), timeMs, s.buckets[i].Load())
 			if err != nil {
 				return activeSeries, err
 			}
@@ -230,7 +231,7 @@ func (h *histogram) collectMetrics(appender storage.Appender, timeMs int64, exte
 						Value: ex,
 					}},
 					Value: s.exemplarValues[i].Load(),
-					Ts:    t,
+					Ts:    timeMs,
 				})
 				if err != nil {
 					return activeSeries, err

--- a/modules/generator/registry/histogram_test.go
+++ b/modules/generator/registry/histogram_test.go
@@ -14,7 +14,7 @@ import (
 
 func Test_histogram(t *testing.T) {
 	var seriesAdded int
-	onAdd := func(count uint32) bool {
+	onAdd := func(_ uint32) bool {
 		seriesAdded++
 		return true
 	}
@@ -27,15 +27,16 @@ func Test_histogram(t *testing.T) {
 	assert.Equal(t, 2, seriesAdded)
 
 	collectionTimeMs := time.Now().UnixMilli()
-	collectionTimeWithOffsetMs := collectionTimeMs - 1
+	endOfLastMinuteMs := getEndOfLastMinuteMs(collectionTimeMs)
+
 	expectedSamples := []sample{
-		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, collectionTimeWithOffsetMs, 0), // Zero entry for value-1 series
+		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, endOfLastMinuteMs, 0), // Zero entry for value-1 series
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-1"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "1"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "2"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "+Inf"}, collectionTimeMs, 1),
-		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-2"}, collectionTimeWithOffsetMs, 0), // Zero entry for value-2 series
+		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-2"}, endOfLastMinuteMs, 0), // Zero entry for value-2 series
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-2"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-2"}, collectionTimeMs, 1.5),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "1"}, collectionTimeMs, 0),
@@ -62,7 +63,7 @@ func Test_histogram(t *testing.T) {
 	assert.Equal(t, 3, seriesAdded)
 
 	collectionTimeMs = time.Now().UnixMilli()
-	collectionTimeWithOffsetMs = collectionTimeMs - 1
+	endOfLastMinuteMs = getEndOfLastMinuteMs(collectionTimeMs)
 	expectedSamples = []sample{
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-1"}, collectionTimeMs, 1),
@@ -74,7 +75,7 @@ func Test_histogram(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "1"}, collectionTimeMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "2"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "+Inf"}, collectionTimeMs, 2),
-		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-3"}, collectionTimeWithOffsetMs, 0), // Zero entry for value-3 series
+		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-3"}, endOfLastMinuteMs, 0), // Zero entry for value-3 series
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-3"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-3"}, collectionTimeMs, 3),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-3", "le": "1"}, collectionTimeMs, 0),
@@ -155,15 +156,15 @@ func Test_histogram_cantAdd(t *testing.T) {
 	h.ObserveWithExemplar(newLabelValueCombo([]string{"label"}, []string{"value-2"}), 1.5, "", 1.0)
 
 	collectionTimeMs := time.Now().UnixMilli()
-	collectionTimeWithOffsetMs := collectionTimeMs - 1
+	endOfLastMinuteMs := getEndOfLastMinuteMs(collectionTimeMs)
 	expectedSamples := []sample{
-		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, collectionTimeWithOffsetMs, 0),
+		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-1"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "1"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "2"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "+Inf"}, collectionTimeMs, 1),
-		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-2"}, collectionTimeWithOffsetMs, 0),
+		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-2"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-2"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-2"}, collectionTimeMs, 1.5),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "1"}, collectionTimeMs, 0),
@@ -212,15 +213,15 @@ func Test_histogram_removeStaleSeries(t *testing.T) {
 	assert.Equal(t, 0, removedSeries)
 
 	collectionTimeMs := time.Now().UnixMilli()
-	collectionTimeWithOffsetMs := collectionTimeMs - 1
+	endOfLastMinuteMs := getEndOfLastMinuteMs(collectionTimeMs)
 	expectedSamples := []sample{
-		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, collectionTimeWithOffsetMs, 0),
+		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-1"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "1"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "2"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "+Inf"}, collectionTimeMs, 1),
-		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-2"}, collectionTimeWithOffsetMs, 0),
+		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-2"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-2"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-2"}, collectionTimeMs, 1.5),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "1"}, collectionTimeMs, 0),
@@ -257,15 +258,15 @@ func Test_histogram_externalLabels(t *testing.T) {
 	h.ObserveWithExemplar(newLabelValueCombo([]string{"label"}, []string{"value-2"}), 1.5, "", 1.0)
 
 	collectionTimeMs := time.Now().UnixMilli()
-	collectionTimeWithOffsetMs := collectionTimeMs - 1
+	endOfLastMinuteMs := getEndOfLastMinuteMs(collectionTimeMs)
 	expectedSamples := []sample{
-		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1", "external_label": "external_value"}, collectionTimeWithOffsetMs, 0),
+		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1", "external_label": "external_value"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1", "external_label": "external_value"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-1", "external_label": "external_value"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "1", "external_label": "external_value"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "2", "external_label": "external_value"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "+Inf", "external_label": "external_value"}, collectionTimeMs, 1),
-		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-2", "external_label": "external_value"}, collectionTimeWithOffsetMs, 0),
+		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-2", "external_label": "external_value"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-2", "external_label": "external_value"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-2", "external_label": "external_value"}, collectionTimeMs, 1.5),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "1", "external_label": "external_value"}, collectionTimeMs, 0),
@@ -351,9 +352,9 @@ func Test_histogram_concurrencyCorrectness(t *testing.T) {
 	wg.Wait()
 
 	collectionTimeMs := time.Now().UnixMilli()
-	collectionTimeWithOffsetMs := collectionTimeMs - 1
+	endOfLastMinuteMs := getEndOfLastMinuteMs(collectionTimeMs)
 	expectedSamples := []sample{
-		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, collectionTimeWithOffsetMs, 0),
+		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, collectionTimeMs, float64(totalCount.Load())),
 		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-1"}, collectionTimeMs, 2*float64(totalCount.Load())),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "1"}, collectionTimeMs, 0),
@@ -369,9 +370,9 @@ func Test_histogram_span_multiplier(t *testing.T) {
 	h.ObserveWithExemplar(newLabelValueCombo([]string{"label"}, []string{"value-1"}), 2.0, "", 5)
 
 	collectionTimeMs := time.Now().UnixMilli()
-	collectionTimeWithOffsetMs := collectionTimeMs - 1
+	endOfLastMinuteMs := getEndOfLastMinuteMs(collectionTimeMs)
 	expectedSamples := []sample{
-		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, collectionTimeWithOffsetMs, 0),
+		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, collectionTimeMs, 6.5),
 		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-1"}, collectionTimeMs, 11.5),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "1"}, collectionTimeMs, 1.5),

--- a/modules/generator/registry/native_histogram.go
+++ b/modules/generator/registry/native_histogram.go
@@ -285,7 +285,8 @@ func (h *nativeHistogram) nativeHistograms(appender storage.Appender, lb *labels
 func (h *nativeHistogram) classicHistograms(appender storage.Appender, lb *labels.Builder, timeMs int64, s *nativeHistogramSeries) (activeSeries int, err error) {
 	if s.isNew() {
 		lb.Set(labels.MetricName, h.metricName+"_count")
-		_, err = appender.Append(0, lb.Labels(), timeMs-1, 0)
+		endOfLastMinuteMs := getEndOfLastMinuteMs(timeMs)
+		_, err = appender.Append(0, lb.Labels(), endOfLastMinuteMs, 0)
 		if err != nil {
 			return activeSeries, err
 		}

--- a/modules/generator/registry/native_histogram_test.go
+++ b/modules/generator/registry/native_histogram_test.go
@@ -48,7 +48,7 @@ func Test_Histograms(t *testing.T) {
 	}
 
 	collectionTimeMs := time.Now().UnixMilli()
-	collectionTimeWithOffsetMs := collectionTimeMs - 1
+	endOfLastMinuteMs := getEndOfLastMinuteMs(collectionTimeMs)
 
 	cases := []struct {
 		name        string
@@ -71,7 +71,7 @@ func Test_Histograms(t *testing.T) {
 						},
 					},
 					expectedSamples: []sample{
-						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, collectionTimeWithOffsetMs, 0), // zero count at the beginning
+						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, endOfLastMinuteMs, 0), // zero count at the beginning
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-1"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "1"}, collectionTimeMs, 1),
@@ -108,13 +108,13 @@ func Test_Histograms(t *testing.T) {
 						},
 					},
 					expectedSamples: []sample{
-						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, collectionTimeWithOffsetMs, 0), // zero count at the beginning
+						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, endOfLastMinuteMs, 0), // zero count at the beginning
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-1"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "1"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "2"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "+Inf"}, collectionTimeMs, 1),
-						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-2"}, collectionTimeWithOffsetMs, 0), // zero count at the beginning
+						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-2"}, endOfLastMinuteMs, 0), // zero count at the beginning
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-2"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-2"}, collectionTimeMs, 1.5),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-2", "le": "1"}, collectionTimeMs, 0),
@@ -156,13 +156,13 @@ func Test_Histograms(t *testing.T) {
 						},
 					},
 					expectedSamples: []sample{
-						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, collectionTimeWithOffsetMs, 0), // zero count at the beginning
+						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, endOfLastMinuteMs, 0), // zero count at the beginning
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-1"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "1"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "2"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "+Inf"}, collectionTimeMs, 1),
-						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-2"}, collectionTimeWithOffsetMs, 0), // zero count at the beginning
+						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-2"}, endOfLastMinuteMs, 0), // zero count at the beginning
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-2"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-2"}, collectionTimeMs, 1.5),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-2", "le": "1"}, collectionTimeMs, 0),
@@ -208,7 +208,7 @@ func Test_Histograms(t *testing.T) {
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-2", "le": "1"}, collectionTimeMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-2", "le": "2"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-2", "le": "+Inf"}, collectionTimeMs, 2),
-						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-3"}, collectionTimeWithOffsetMs, 0), // zero count at the beginning
+						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-3"}, endOfLastMinuteMs, 0), // zero count at the beginning
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-3"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-3"}, collectionTimeMs, 3),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-3", "le": "1"}, collectionTimeMs, 0),
@@ -250,13 +250,13 @@ func Test_Histograms(t *testing.T) {
 						},
 					},
 					expectedSamples: []sample{
-						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, collectionTimeWithOffsetMs, 0), // zero count at the beginning
+						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, endOfLastMinuteMs, 0), // zero count at the beginning
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, collectionTimeMs, 20),
 						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-1"}, collectionTimeMs, 20*1.5),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "1"}, collectionTimeMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "2"}, collectionTimeMs, 20),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "+Inf"}, collectionTimeMs, 20),
-						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-2"}, collectionTimeWithOffsetMs, 0), // zero count at the beginning
+						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-2"}, endOfLastMinuteMs, 0), // zero count at the beginning
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-2"}, collectionTimeMs, 13),
 						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-2"}, collectionTimeMs, 13*3),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-2", "le": "1"}, collectionTimeMs, 0),
@@ -299,13 +299,13 @@ func Test_Histograms(t *testing.T) {
 						},
 					},
 					expectedSamples: []sample{
-						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, collectionTimeWithOffsetMs, 0), // zero count at the beginning
+						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, endOfLastMinuteMs, 0), // zero count at the beginning
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-1"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "1"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "2"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "+Inf"}, collectionTimeMs, 1),
-						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-2"}, collectionTimeWithOffsetMs, 0), // zero count at the beginning
+						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-2"}, endOfLastMinuteMs, 0), // zero count at the beginning
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-2"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-2"}, collectionTimeMs, 1.5),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-2", "le": "1"}, collectionTimeMs, 0),
@@ -351,7 +351,7 @@ func Test_Histograms(t *testing.T) {
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-2", "le": "1"}, collectionTimeMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-2", "le": "2"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-2", "le": "+Inf"}, collectionTimeMs, 2),
-						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-3"}, collectionTimeWithOffsetMs, 0), // zero count at the beginning
+						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-3"}, endOfLastMinuteMs, 0), // zero count at the beginning
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-3"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-3"}, collectionTimeMs, 3),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-3", "le": "1"}, collectionTimeMs, 0),

--- a/modules/generator/registry/registry.go
+++ b/modules/generator/registry/registry.go
@@ -87,7 +87,7 @@ type metric interface {
 	removeStaleSeries(staleTimeMs int64)
 }
 
-const HighestAggregationInterval = 1 * time.Minute
+const highestAggregationInterval = 1 * time.Minute
 
 var _ Registry = (*ManagedRegistry)(nil)
 
@@ -290,5 +290,5 @@ func hasClassicHistograms(s HistogramMode) bool {
 }
 
 func getEndOfLastMinuteMs(timeMs int64) int64 {
-	return time.UnixMilli(timeMs).Truncate(HighestAggregationInterval).Add(-1 * time.Second).UnixMilli()
+	return time.UnixMilli(timeMs).Truncate(highestAggregationInterval).Add(-1 * time.Second).UnixMilli()
 }

--- a/modules/generator/registry/registry.go
+++ b/modules/generator/registry/registry.go
@@ -87,6 +87,8 @@ type metric interface {
 	removeStaleSeries(staleTimeMs int64)
 }
 
+const HighestAggregationInterval = 1 * time.Minute
+
 var _ Registry = (*ManagedRegistry)(nil)
 
 // New creates a ManagedRegistry. This Registry will scrape itself, write samples into an appender
@@ -285,4 +287,8 @@ func hasNativeHistograms(s HistogramMode) bool {
 
 func hasClassicHistograms(s HistogramMode) bool {
 	return s == HistogramModeClassic || s == HistogramModeBoth
+}
+
+func getEndOfLastMinuteMs(timeMs int64) int64 {
+	return time.UnixMilli(timeMs).Truncate(HighestAggregationInterval).Add(-1 * time.Second).UnixMilli()
 }


### PR DESCRIPTION
**What this PR does**:
It fixes an issue with adaptive metrics: when a series is new the init sample ends in the same aggregation bucket as the span one, and the later one is downsampled. The fix consists of backdating the initial one to the end of the previous minute:

previously:
(t-1ms, 0)
(t, 1)

current:
(t-1m, 0)
(t, 1)


**Checklist**
- [X] Tests updated
- [X] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`