### PR TITLE
dependabot: group dependencies and increase PR limit to 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,21 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    open-pull-requests-limit: 10
+    groups:
+      opentelemetry-otel:
+        patterns:
+          - go.opentelemetry.io/otel/*
+      opentelemetry-contrib:
+        patterns:
+          - go.opentelemetry.io/contrib/*
+          - github.com/open-telemetry/opentelemetry-collector-contrib/*
+      opentelemetry-collector:
+        patterns:
+          - go.opentelemetry.io/collector/*
+      k8s.io:
+        patterns:
+          - k8s.io/*
 
   - package-ecosystem: 'docker'
     directory: '/'


### PR DESCRIPTION
**What this PR does**:
groups the dependabot update PRs to make them more useful and not break things.

also bump the max open PRs to 10 so we can have 10 open PRs from dependabot.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`