### PR TITLE
fix: reduce allocations in the Time Window Block Selector

### DIFF
--- a/tempodb/compaction_block_selector_test.go
+++ b/tempodb/compaction_block_selector_test.go
@@ -846,3 +846,27 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkBlockSelector(b *testing.B) {
+	blockMetas := make([]*backend.BlockMeta, 100000)
+	for i := range blockMetas {
+		blockMetas[i] = &backend.BlockMeta{
+			Size_:         1000,
+			TotalRecords:  100,
+			BlockID:       backend.MustParse("00000000-0000-0000-0000-000000000000"),
+			DataEncoding:  "json",
+			Encoding:      backend.EncGZIP,
+			IndexPageSize: 13,
+			Version:       "glarg",
+			TotalObjects:  540,
+			DedicatedColumns: backend.DedicatedColumns{
+				{Scope: "span", Name: "foo", Type: "int"},
+			},
+		}
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = newTimeWindowBlockSelector(blockMetas, time.Second, 100, uint64(1024*1024), defaultMaxInputBlocks, defaultMinInputBlocks)
+	}
+}


### PR DESCRIPTION
**What this PR does**:

I noticed a huge amount of objects allocated during compactions from the Sprintf method

<img width="950" alt="Screenshot 2024-10-31 at 10 09 33" src="https://github.com/user-attachments/assets/1c0d9937-78e4-4ece-bb92-f80a77d91171">

This PR reuses a string buffer to reduce these allocations

```
❯ benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/grafana/tempo/tempodb
cpu: Apple M3 Pro
              │   old.txt   │               new.txt               │
              │   sec/op    │   sec/op     vs base                │
BlockSelector   60.07m ± 1%   25.37m ± 2%  -57.77% (p=0.000 n=10)

              │   old.txt    │               new.txt                │
              │     B/op     │     B/op      vs base                │
BlockSelector   43.74Mi ± 0%   28.23Mi ± 0%  -35.45% (p=0.000 n=10)

              │   old.txt   │               new.txt               │
              │  allocs/op  │  allocs/op   vs base                │
BlockSelector   800.0k ± 0%   700.0k ± 0%  -12.50% (p=0.000 n=10)
```



**Checklist**
- [X] Tests updated

- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`