### PR TITLE
Fix tempo cli arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 * [BUGFIX] Fix counter samples being downsampled by backdate to the previous minute the initial sample when the series is new [#44236](https://github.com/grafana/tempo/pull/4236) (@javiermolinar)
 * [BUGFIX] Skip computing exemplars for instant queries. [#4204](https://github.com/grafana/tempo/pull/4204) (@javiermolinar)
 * [BUGFIX] Gave context to orphaned spans related to various maintenance processes. [#4260](https://github.com/grafana/tempo/pull/4260) (@joe-elliott)
+* [BUGFIX] Utilize S3Pass and S3User parameters in tempo-cli options, which were previously unused in the code. [#44236](https://github.com/grafana/tempo/pull/4259) (@faridtmammadov)
 
 # v2.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * [ENHANCEMENT] Add disk caching in ingester SearchTagValuesV2 for completed blocks [#4069](https://github.com/grafana/tempo/pull/4069) (@electron0zero)
 * [ENHANCEMENT] Add a max flush attempts and metric to the metrics generator [#4254](https://github.com/grafana/tempo/pull/4254) (@joe-elliott)
 * [ENHANCEMENT] Collection of query-frontend changes to reduce allocs. [#4242]https://github.com/grafana/tempo/pull/4242 (@joe-elliott)
+* [ENHANCEMENT] Added `insecure-skip-verify` option in tempo-cli to skip SSL certificate validation when connecting to the S3 backend. [#44236](https://github.com/grafana/tempo/pull/4259) (@faridtmammadov)
 * [BUGFIX] Replace hedged requests roundtrips total with a counter. [#4063](https://github.com/grafana/tempo/pull/4063) [#4078](https://github.com/grafana/tempo/pull/4078) (@galalen)
 * [BUGFIX] Metrics generators: Correctly drop from the ring before stopping ingestion to reduce drops during a rollout. [#4101](https://github.com/grafana/tempo/pull/4101) (@joe-elliott)
 * [BUGFIX] Correctly handle 400 Bad Request and 404 Not Found in gRPC streaming [#4144](https://github.com/grafana/tempo/pull/4144) (@mapno)

--- a/cmd/tempo-cli/main.go
+++ b/cmd/tempo-cli/main.go
@@ -30,9 +30,10 @@ type backendOptions struct {
 	Backend string `help:"backend to connect to (s3/gcs/local/azure), optional, overrides backend in config file" enum:",s3,gcs,local,azure" default:""`
 	Bucket  string `help:"bucket (or path on local backend) to scan, optional, overrides bucket in config file"`
 
-	S3Endpoint string `name:"s3-endpoint" help:"s3 endpoint (s3.dualstack.us-east-2.amazonaws.com), optional, overrides endpoint in config file"`
-	S3User     string `name:"s3-user" help:"s3 username, optional, overrides username in config file"`
-	S3Pass     string `name:"s3-pass" help:"s3 password, optional, overrides password in config file"`
+	S3Endpoint         string `name:"s3-endpoint" help:"s3 endpoint (s3.dualstack.us-east-2.amazonaws.com), optional, overrides endpoint in config file"`
+	S3User             string `name:"s3-user" help:"s3 username, optional, overrides username in config file"`
+	S3Pass             string `name:"s3-pass" help:"s3 password, optional, overrides password in config file"`
+	InsecureSkipVerify bool   `name:"insecure-skip-verify" help:"skip TLS verification, only applies to S3 and GCS" default:"false"`
 }
 
 var cli struct {
@@ -130,6 +131,9 @@ func loadBackend(b *backendOptions, g *globalOptions) (backend.Reader, backend.W
 		cfg.StorageConfig.Trace.S3.Bucket = b.Bucket
 		cfg.StorageConfig.Trace.Azure.ContainerName = b.Bucket
 	}
+
+	cfg.StorageConfig.Trace.S3.InsecureSkipVerify = b.InsecureSkipVerify
+	cfg.StorageConfig.Trace.GCS.Insecure = b.InsecureSkipVerify
 
 	if b.S3Endpoint != "" {
 		cfg.StorageConfig.Trace.S3.Endpoint = b.S3Endpoint

--- a/cmd/tempo-cli/main.go
+++ b/cmd/tempo-cli/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/grafana/dskit/flagext"
 	"os"
 
 	"github.com/alecthomas/kong"
@@ -134,6 +135,14 @@ func loadBackend(b *backendOptions, g *globalOptions) (backend.Reader, backend.W
 
 	cfg.StorageConfig.Trace.S3.InsecureSkipVerify = b.InsecureSkipVerify
 	cfg.StorageConfig.Trace.GCS.Insecure = b.InsecureSkipVerify
+
+	if b.S3User != "" {
+		cfg.StorageConfig.Trace.S3.AccessKey = b.S3User
+	}
+
+	if b.S3Pass != "" {
+		cfg.StorageConfig.Trace.S3.SecretKey = flagext.SecretWithValue(b.S3Pass)
+	}
 
 	if b.S3Endpoint != "" {
 		cfg.StorageConfig.Trace.S3.Endpoint = b.S3Endpoint

--- a/cmd/tempo-cli/main.go
+++ b/cmd/tempo-cli/main.go
@@ -3,8 +3,9 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/grafana/dskit/flagext"
 	"os"
+
+	"github.com/grafana/dskit/flagext"
 
 	"github.com/alecthomas/kong"
 	"gopkg.in/yaml.v2"

--- a/docs/sources/tempo/operations/tempo_cli.md
+++ b/docs/sources/tempo/operations/tempo_cli.md
@@ -53,6 +53,7 @@ The backend can be configured in a few ways:
     * `--s3-endpoint <value>` The S3 API endpoint (i.e. s3.dualstack.us-east-2.amazonaws.com).
     * `--s3-user <value>`, `--s3-password <value>` The S3 user name and password (or access key and secret key).
       Optional, as Tempo CLI supports the same authentication mechanisms as Tempo. See [S3 permissions documentation]({{< relref "../configuration/hosted-storage/s3" >}}) for more information.
+    *  `--insecure-skip-verify` skip TLS verification, only applies to S3 and GCS.
 
 Each option applies only to the command in which it is used. For example, `--backend <value>` does not permanently change where Tempo stores data. It only changes it for command in which you apply the option.
 

--- a/docs/sources/tempo/operations/tempo_cli.md
+++ b/docs/sources/tempo/operations/tempo_cli.md
@@ -51,7 +51,7 @@ The backend can be configured in a few ways:
     * `--backend <value>` The storage backend type, one of `s3`, `gcs`, `azure`, and `local`.
     * `--bucket <value>` The bucket name. The meaning of this value is backend-specific. Refer to [Configuration]({{< relref "../configuration" >}}) documentation for more information.
     * `--s3-endpoint <value>` The S3 API endpoint (i.e. s3.dualstack.us-east-2.amazonaws.com).
-    * `--s3-user <value>`, `--s3-password <value>` The S3 user name and password (or access key and secret key).
+    * `--s3-user <value>`, `--s3-pass <value>` The S3 user name and password (or access key and secret key).
       Optional, as Tempo CLI supports the same authentication mechanisms as Tempo. See [S3 permissions documentation]({{< relref "../configuration/hosted-storage/s3" >}}) for more information.
     *  `--insecure-skip-verify` skip TLS verification, only applies to S3 and GCS.
 


### PR DESCRIPTION
**What this PR does**:
This PR fixes the unused S3Pass and S3User parameters in the CLI options by implementing them in the code. Additionally, it introduces a skip verify option to bypass SSL certificate validation when connecting to the S3 backend, enhancing flexibility for self-signed or internal certificates.

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`