### PR TITLE
Traces Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * [BUGFIX] Pushes a 0 to classic histogram's counter when the series is new to allow Prometheus to start from a non-null value. [#4140](https://github.com/grafana/tempo/pull/4140) (@mapno)
 * [BUGFIX] Fix counter samples being downsampled by backdate to the previous minute the initial sample when the series is new [#44236](https://github.com/grafana/tempo/pull/4236) (@javiermolinar)
 * [BUGFIX] Skip computing exemplars for instant queries. [#4204](https://github.com/grafana/tempo/pull/4204) (@javiermolinar)
+* [BUGFIX] Gave context to orphaned spans related to various maintenance processes. [#4260](https://github.com/grafana/tempo/pull/4260) (@joe-elliott)
 
 # v2.6.1
 

--- a/modules/generator/processor/localblocks/processor.go
+++ b/modules/generator/processor/localblocks/processor.go
@@ -354,6 +354,9 @@ func (p *Processor) completeBlock() error {
 		b      = firstWalBlock
 	)
 
+	ctx, span := tracer.Start(ctx, "Processor.CompleteBlock")
+	defer span.End()
+
 	iter, err := b.Iterator()
 	if err != nil {
 		return err

--- a/modules/ingester/ingester_test.go
+++ b/modules/ingester/ingester_test.go
@@ -193,7 +193,7 @@ func TestWalDropsZeroLength(t *testing.T) {
 		blockID, err := instance.CutBlockIfReady(0, 0, true)
 		require.NoError(t, err)
 
-		err = instance.CompleteBlock(blockID)
+		err = instance.CompleteBlock(context.Background(), blockID)
 		require.NoError(t, err)
 
 		err = instance.ClearCompletingBlock(blockID)
@@ -408,7 +408,7 @@ func TestDedicatedColumns(t *testing.T) {
 	inst.blocksMtx.RUnlock()
 
 	// Complete block
-	err = inst.CompleteBlock(blockID)
+	err = inst.CompleteBlock(context.Background(), blockID)
 	require.NoError(t, err)
 
 	// TODO: This check should be included as part of the read path

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -313,7 +313,7 @@ func (i *instance) CutBlockIfReady(maxBlockLifetime time.Duration, maxBlockBytes
 }
 
 // CompleteBlock moves a completingBlock to a completeBlock. The new completeBlock has the same ID.
-func (i *instance) CompleteBlock(blockID uuid.UUID) error {
+func (i *instance) CompleteBlock(ctx context.Context, blockID uuid.UUID) error {
 	i.blocksMtx.Lock()
 	var completingBlock common.WALBlock
 	for _, iterBlock := range i.completingBlocks {
@@ -327,8 +327,6 @@ func (i *instance) CompleteBlock(blockID uuid.UUID) error {
 	if completingBlock == nil {
 		return fmt.Errorf("error finding completingBlock")
 	}
-
-	ctx := context.Background()
 
 	backendBlock, err := i.writer.CompleteBlockWithBackend(ctx, completingBlock, i.localReader, i.localWriter)
 	if err != nil {

--- a/modules/ingester/instance_search.go
+++ b/modules/ingester/instance_search.go
@@ -296,7 +296,7 @@ func (i *instance) SearchTagsV2(ctx context.Context, req *tempopb.SearchTagsRequ
 	}
 
 	if distinctValues.Exceeded() {
-		level.Warn(log.Logger).Log("msg", "size of tags in instance exceeded limit, reduce cardinality or size of tags", "userID", userID, "limit", limit)
+		level.Warn(log.Logger).Log("msg", "size of tags in instance exceeded limit, reduce cardinality or size of tags", "tenant", userID, "limit", limit)
 	}
 
 	collected := distinctValues.Strings()
@@ -382,7 +382,7 @@ func (i *instance) SearchTagValues(ctx context.Context, tagName string) (*tempop
 	}
 
 	if distinctValues.Exceeded() {
-		level.Warn(log.Logger).Log("msg", "size of tag values in instance exceeded limit, reduce cardinality or size of tags", "tag", tagName, "userID", userID, "limit", limit, "size", distinctValues.Size())
+		level.Warn(log.Logger).Log("msg", "size of tag values in instance exceeded limit, reduce cardinality or size of tags", "tag", tagName, "tenant", userID, "limit", limit, "size", distinctValues.Size())
 	}
 
 	return &tempopb.SearchTagValuesResponse{
@@ -589,7 +589,7 @@ func (i *instance) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTag
 	}
 
 	if valueCollector.Exceeded() {
-		_ = level.Warn(log.Logger).Log("msg", "size of tag values exceeded limit, reduce cardinality or size of tags", "tag", req.TagName, "userID", userID, "limit", limit, "size", valueCollector.Size())
+		_ = level.Warn(log.Logger).Log("msg", "size of tag values exceeded limit, reduce cardinality or size of tags", "tag", req.TagName, "tenant", userID, "limit", limit, "size", valueCollector.Size())
 	}
 
 	resp := &tempopb.SearchTagValuesV2Response{

--- a/modules/ingester/instance_search_test.go
+++ b/modules/ingester/instance_search_test.go
@@ -65,7 +65,7 @@ func TestInstanceSearch(t *testing.T) {
 	checkEqual(t, ids, sr)
 
 	// Test after completing a block
-	err = i.CompleteBlock(blockID)
+	err = i.CompleteBlock(context.Background(), blockID)
 	require.NoError(t, err)
 
 	sr, err = i.Search(context.Background(), req)
@@ -133,7 +133,7 @@ func TestInstanceSearchTraceQL(t *testing.T) {
 			checkEqual(t, ids, sr)
 
 			// Test after completing a block
-			err = i.CompleteBlock(blockID)
+			err = i.CompleteBlock(context.Background(), blockID)
 			require.NoError(t, err)
 
 			sr, err = i.Search(context.Background(), req)
@@ -222,7 +222,7 @@ func TestInstanceSearchWithStartAndEnd(t *testing.T) {
 	searchAndAssert(req, uint32(100))
 
 	// Test after completing a block
-	err = i.CompleteBlock(blockID)
+	err = i.CompleteBlock(context.Background(), blockID)
 	require.NoError(t, err)
 	searchAndAssert(req, uint32(200))
 
@@ -267,7 +267,7 @@ func TestInstanceSearchTags(t *testing.T) {
 	testSearchTagsAndValues(t, userCtx, i, tagKey, expectedTagValues)
 
 	// Test after completing a block
-	err = i.CompleteBlock(blockID)
+	err = i.CompleteBlock(context.Background(), blockID)
 	require.NoError(t, err)
 
 	testSearchTagsAndValues(t, userCtx, i, tagKey, expectedTagValues)
@@ -332,7 +332,7 @@ func TestInstanceSearchTagAndValuesV2(t *testing.T) {
 	testSearchTagsAndValuesV2(t, userCtx, i, tagKey, queryThatMatches, expectedTagValues, expectedEventTagValues, expectedLinkTagValues)
 
 	// Test after completing a block
-	err = i.CompleteBlock(blockID)
+	err = i.CompleteBlock(context.Background(), blockID)
 	require.NoError(t, err)
 	require.NoError(t, i.ClearCompletingBlock(blockID)) // Clear the completing block
 
@@ -681,7 +681,7 @@ func TestInstanceSearchDoesNotRace(t *testing.T) {
 		// Cut wal, complete, delete wal, then flush
 		blockID, _ := i.CutBlockIfReady(0, 0, true)
 		if blockID != uuid.Nil {
-			err := i.CompleteBlock(blockID)
+			err := i.CompleteBlock(context.Background(), blockID)
 			require.NoError(t, err)
 			err = i.ClearCompletingBlock(blockID)
 			require.NoError(t, err)
@@ -837,7 +837,7 @@ func TestInstanceSearchMetrics(t *testing.T) {
 	require.Less(t, numBytes, m.InspectedBytes)
 
 	// Test after completing a block
-	err = i.CompleteBlock(blockID)
+	err = i.CompleteBlock(context.Background(), blockID)
 	require.NoError(t, err)
 	err = i.ClearCompletingBlock(blockID)
 	require.NoError(t, err)

--- a/modules/ingester/instance_test.go
+++ b/modules/ingester/instance_test.go
@@ -50,7 +50,7 @@ func TestInstance(t *testing.T) {
 	require.NoError(t, err, "unexpected error cutting block")
 	require.NotEqual(t, blockID, uuid.Nil)
 
-	err = i.CompleteBlock(blockID)
+	err = i.CompleteBlock(context.Background(), blockID)
 	require.NoError(t, err, "unexpected error completing block")
 
 	block := i.GetBlockToBeFlushed(blockID)
@@ -103,7 +103,7 @@ func TestInstanceFind(t *testing.T) {
 
 	queryAll(t, i, ids, traces)
 
-	err = i.CompleteBlock(blockID)
+	err = i.CompleteBlock(context.Background(), blockID)
 	require.NoError(t, err)
 
 	queryAll(t, i, ids, traces)
@@ -185,7 +185,7 @@ func TestInstanceDoesNotRace(t *testing.T) {
 	go concurrent(func() {
 		blockID, _ := i.CutBlockIfReady(0, 0, false)
 		if blockID != uuid.Nil {
-			err := i.CompleteBlock(blockID)
+			err := i.CompleteBlock(context.Background(), blockID)
 			require.NoError(t, err, "unexpected error completing block")
 			block := i.GetBlockToBeFlushed(blockID)
 			require.NotNil(t, block)
@@ -487,7 +487,7 @@ func TestInstanceCutBlockIfReady(t *testing.T) {
 			blockID, err := instance.CutBlockIfReady(tc.maxBlockLifetime, tc.maxBlockBytes, tc.immediate)
 			require.NoError(t, err)
 
-			err = instance.CompleteBlock(blockID)
+			err = instance.CompleteBlock(context.Background(), blockID)
 			if tc.expectedToCutBlock {
 				require.NoError(t, err, "unexpected error completing block")
 			}
@@ -738,7 +738,7 @@ func BenchmarkInstanceFindTraceByIDFromCompleteBlock(b *testing.B) {
 	require.NoError(b, err)
 	id, err := instance.CutBlockIfReady(0, 0, true)
 	require.NoError(b, err)
-	err = instance.CompleteBlock(id)
+	err = instance.CompleteBlock(context.Background(), id)
 	require.NoError(b, err)
 
 	require.Equal(b, 1, len(instance.completeBlocks))
@@ -776,7 +776,7 @@ func benchmarkInstanceSearch(b testing.TB) {
 	// force the traces to be in a complete block
 	id, err := instance.CutBlockIfReady(0, 0, true)
 	require.NoError(b, err)
-	err = instance.CompleteBlock(id)
+	err = instance.CompleteBlock(context.Background(), id)
 	require.NoError(b, err)
 
 	require.Equal(b, 1, len(instance.completeBlocks))
@@ -880,7 +880,7 @@ func BenchmarkInstanceContention(t *testing.B) {
 	go concurrent(func() {
 		blockID, _ := i.CutBlockIfReady(0, 0, false)
 		if blockID != uuid.Nil {
-			err := i.CompleteBlock(blockID)
+			err := i.CompleteBlock(context.Background(), blockID)
 			require.NoError(t, err, "unexpected error completing block")
 			err = i.ClearCompletingBlock(blockID)
 			require.NoError(t, err, "unexpected error clearing wal block")

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -149,7 +149,7 @@ func (p *Poller) Do(previous *List) (PerTenant, PerTenantCompacted, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	_, span := tracer.Start(ctx, "Poller.Do")
+	ctx, span := tracer.Start(ctx, "Poller.Do")
 	defer span.End()
 
 	tenants, err := p.reader.Tenants(ctx)


### PR DESCRIPTION
**What this PR does**:
I set out to clean up our traces and remove all orphaned spans, but there were fewer than expected. Our query path is entirely connected.

- Connected some local block operations in the generator.
- Similar fix in the ingester and also updated log lines to use "tenant" over "userID" which is preferred.
![image](https://github.com/user-attachments/assets/11c6debf-5ce3-489b-bf5d-6fed72237a7e)
- Gave context to some orphanned s3.Reads in usage stats
![image](https://github.com/user-attachments/assets/992bcd9f-6b71-4911-bed3-e3cc5c0e12d1)
- Connected some orphanned spans in our polling cycle

There are still two orphanned spans I can't figure out how to fix related to ring management. They create single span "CAS" and "GET" traces. I'll let the next person figure those out :).

https://github.com/grafana/dskit/blob/a4a4dca2b2e64cc70a1a719c5f3dbf7a5c81adba/kv/metrics.go#L97
https://github.com/grafana/dskit/blob/a4a4dca2b2e64cc70a1a719c5f3dbf7a5c81adba/kv/metrics.go#L81

There are also a fair number of "low value" traces. These are auto instrumented by our http server and may be best removed through sampling techniques. Things like getting metrics or health checks.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`