### PR TITLE
Registry performance

### DIFF
--- a/modules/generator/registry/counter.go
+++ b/modules/generator/registry/counter.go
@@ -134,7 +134,7 @@ func (c *counter) name() string {
 	return c.metricName
 }
 
-func (c *counter) collectMetrics(appender storage.Appender, timeMs int64, externalLabels map[string]string) (activeSeries int, err error) {
+func (c *counter) collectMetrics(appender storage.Appender, timeMs int64) (activeSeries int, err error) {
 	c.seriesMtx.RLock()
 	defer c.seriesMtx.RUnlock()
 

--- a/modules/generator/registry/counter.go
+++ b/modules/generator/registry/counter.go
@@ -20,6 +20,8 @@ type counter struct {
 
 	onAddSeries    func(count uint32) bool
 	onRemoveSeries func(count uint32)
+
+	externalLabels map[string]string
 }
 
 type counterSeries struct {
@@ -31,6 +33,9 @@ type counterSeries struct {
 	// to the desired value.  This avoids Prometheus throwing away the first
 	// value in the series, due to the transition from null -> x.
 	firstSeries *atomic.Bool
+
+	lb         *labels.Builder
+	baseLabels labels.Labels
 }
 
 var (
@@ -46,7 +51,7 @@ func (co *counterSeries) registerSeenSeries() {
 	co.firstSeries.Store(false)
 }
 
-func newCounter(name string, onAddSeries func(uint32) bool, onRemoveSeries func(count uint32)) *counter {
+func newCounter(name string, onAddSeries func(uint32) bool, onRemoveSeries func(count uint32), externalLabels map[string]string) *counter {
 	if onAddSeries == nil {
 		onAddSeries = func(uint32) bool {
 			return true
@@ -61,6 +66,7 @@ func newCounter(name string, onAddSeries func(uint32) bool, onRemoveSeries func(
 		series:         make(map[uint64]*counterSeries),
 		onAddSeries:    onAddSeries,
 		onRemoveSeries: onRemoveSeries,
+		externalLabels: externalLabels,
 	}
 }
 
@@ -98,11 +104,24 @@ func (c *counter) Inc(labelValueCombo *LabelValueCombo, value float64) {
 }
 
 func (c *counter) newSeries(labelValueCombo *LabelValueCombo, value float64) *counterSeries {
+	// base labels
+	baseLabels := make(labels.Labels, 0, 1+len(c.externalLabels))
+
+	// add external labels
+	for name, value := range c.externalLabels {
+		baseLabels = append(baseLabels, labels.Label{Name: name, Value: value})
+	}
+
+	// add metric name
+	baseLabels = append(baseLabels, labels.Label{Name: labels.MetricName, Value: c.metricName})
+
 	return &counterSeries{
 		labels:      labelValueCombo.getLabelPair(),
 		value:       atomic.NewFloat64(value),
 		lastUpdated: atomic.NewInt64(time.Now().UnixMilli()),
 		firstSeries: atomic.NewBool(true),
+		lb:          labels.NewBuilder(baseLabels),
+		baseLabels:  baseLabels,
 	}
 }
 
@@ -121,31 +140,12 @@ func (c *counter) collectMetrics(appender storage.Appender, timeMs int64, extern
 
 	activeSeries = len(c.series)
 
-	labelsCount := 0
-	if activeSeries > 0 && c.series[0] != nil {
-		labelsCount = len(c.series[0].labels.names)
-	}
-
-	// base labels
-	baseLabels := make(labels.Labels, 0, 1+len(externalLabels)+labelsCount)
-
-	// add external labels
-	for name, value := range externalLabels {
-		baseLabels = append(baseLabels, labels.Label{Name: name, Value: value})
-	}
-
-	// add metric name
-	baseLabels = append(baseLabels, labels.Label{Name: labels.MetricName, Value: c.metricName})
-
-	// TODO: avoid allocation on each collection
-	lb := labels.NewBuilder(baseLabels)
-
 	for _, s := range c.series {
-		lb.Reset(baseLabels)
+		s.lb.Reset(s.baseLabels)
 
 		// set series-specific labels
 		for i, name := range s.labels.names {
-			lb.Set(name, s.labels.values[i])
+			s.lb.Set(name, s.labels.values[i])
 		}
 
 		// If we are about to call Append for the first time on a series, we need
@@ -155,14 +155,14 @@ func (c *counter) collectMetrics(appender storage.Appender, timeMs int64, extern
 			// We set the timestamp of the init serie at the end of the previous minute, that way we ensure it ends in a
 			// different aggregation interval to avoid be downsampled.
 			endOfLastMinuteMs := getEndOfLastMinuteMs(timeMs)
-			_, err = appender.Append(0, lb.Labels(), endOfLastMinuteMs, 0)
+			_, err = appender.Append(0, s.lb.Labels(), endOfLastMinuteMs, 0)
 			if err != nil {
 				return
 			}
 			s.registerSeenSeries()
 		}
 
-		_, err = appender.Append(0, lb.Labels(), timeMs, s.value.Load())
+		_, err = appender.Append(0, s.lb.Labels(), timeMs, s.value.Load())
 		if err != nil {
 			return
 		}

--- a/modules/generator/registry/counter_test.go
+++ b/modules/generator/registry/counter_test.go
@@ -18,7 +18,7 @@ func Test_counter(t *testing.T) {
 		return true
 	}
 
-	c := newCounter("my_counter", onAdd, nil)
+	c := newCounter("my_counter", onAdd, nil, map[string]string{"external_label": "external_value"})
 
 	c.Inc(newLabelValueCombo([]string{"label"}, []string{"value-1"}), 1.0)
 	c.Inc(newLabelValueCombo([]string{"label"}, []string{"value-2"}), 2.0)
@@ -28,10 +28,10 @@ func Test_counter(t *testing.T) {
 	collectionTimeMs := time.Now().UnixMilli()
 	endOfLastMinuteMs := getEndOfLastMinuteMs(collectionTimeMs)
 	expectedSamples := []sample{
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, endOfLastMinuteMs, 0),
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, collectionTimeMs, 1),
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-2"}, endOfLastMinuteMs, 0),
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-2"}, collectionTimeMs, 2),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-1", "external_label": "external_value"}, endOfLastMinuteMs, 0),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-1", "external_label": "external_value"}, collectionTimeMs, 1),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-2", "external_label": "external_value"}, endOfLastMinuteMs, 0),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-2", "external_label": "external_value"}, collectionTimeMs, 2),
 	}
 	collectMetricAndAssert(t, c, collectionTimeMs, nil, 2, expectedSamples, nil)
 
@@ -59,7 +59,7 @@ func TestCounterDifferentLabels(t *testing.T) {
 		return true
 	}
 
-	c := newCounter("my_counter", onAdd, nil)
+	c := newCounter("my_counter", onAdd, nil, nil)
 
 	c.Inc(newLabelValueCombo([]string{"label"}, []string{"value-1"}), 1.0)
 	c.Inc(newLabelValueCombo([]string{"another_label"}, []string{"another_value"}), 2.0)
@@ -84,7 +84,7 @@ func Test_counter_cantAdd(t *testing.T) {
 		return canAdd
 	}
 
-	c := newCounter("my_counter", onAdd, nil)
+	c := newCounter("my_counter", onAdd, nil, nil)
 
 	// allow adding new series
 	canAdd = true
@@ -123,7 +123,7 @@ func Test_counter_removeStaleSeries(t *testing.T) {
 		removedSeries++
 	}
 
-	c := newCounter("my_counter", nil, onRemove)
+	c := newCounter("my_counter", nil, onRemove, nil)
 
 	timeMs := time.Now().UnixMilli()
 	c.Inc(newLabelValueCombo([]string{"label"}, []string{"value-1"}), 1.0)
@@ -161,7 +161,7 @@ func Test_counter_removeStaleSeries(t *testing.T) {
 }
 
 func Test_counter_externalLabels(t *testing.T) {
-	c := newCounter("my_counter", nil, nil)
+	c := newCounter("my_counter", nil, nil, map[string]string{"external_label": "external_value"})
 
 	c.Inc(newLabelValueCombo([]string{"label"}, []string{"value-1"}), 1.0)
 	c.Inc(newLabelValueCombo([]string{"label"}, []string{"value-2"}), 2.0)
@@ -174,11 +174,11 @@ func Test_counter_externalLabels(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_counter", "label": "value-2", "external_label": "external_value"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_counter", "label": "value-2", "external_label": "external_value"}, collectionTimeMs, 2),
 	}
-	collectMetricAndAssert(t, c, collectionTimeMs, map[string]string{"external_label": "external_value"}, 2, expectedSamples, nil)
+	collectMetricAndAssert(t, c, collectionTimeMs, nil, 2, expectedSamples, nil)
 }
 
 func Test_counter_concurrencyDataRace(t *testing.T) {
-	c := newCounter("my_counter", nil, nil)
+	c := newCounter("my_counter", nil, nil, nil)
 
 	end := make(chan struct{})
 
@@ -224,7 +224,7 @@ func Test_counter_concurrencyDataRace(t *testing.T) {
 }
 
 func Test_counter_concurrencyCorrectness(t *testing.T) {
-	c := newCounter("my_counter", nil, nil)
+	c := newCounter("my_counter", nil, nil, nil)
 
 	var wg sync.WaitGroup
 	end := make(chan struct{})

--- a/modules/generator/registry/counter_test.go
+++ b/modules/generator/registry/counter_test.go
@@ -18,7 +18,7 @@ func Test_counter(t *testing.T) {
 		return true
 	}
 
-	c := newCounter("my_counter", onAdd, nil, map[string]string{"external_label": "external_value"})
+	c := newCounter("my_counter", onAdd, nil, nil)
 
 	c.Inc(newLabelValueCombo([]string{"label"}, []string{"value-1"}), 1.0)
 	c.Inc(newLabelValueCombo([]string{"label"}, []string{"value-2"}), 2.0)
@@ -28,12 +28,12 @@ func Test_counter(t *testing.T) {
 	collectionTimeMs := time.Now().UnixMilli()
 	endOfLastMinuteMs := getEndOfLastMinuteMs(collectionTimeMs)
 	expectedSamples := []sample{
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-1", "external_label": "external_value"}, endOfLastMinuteMs, 0),
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-1", "external_label": "external_value"}, collectionTimeMs, 1),
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-2", "external_label": "external_value"}, endOfLastMinuteMs, 0),
-		newSample(map[string]string{"__name__": "my_counter", "label": "value-2", "external_label": "external_value"}, collectionTimeMs, 2),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, endOfLastMinuteMs, 0),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, collectionTimeMs, 1),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-2"}, endOfLastMinuteMs, 0),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-2"}, collectionTimeMs, 2),
 	}
-	collectMetricAndAssert(t, c, collectionTimeMs, nil, 2, expectedSamples, nil)
+	collectMetricAndAssert(t, c, collectionTimeMs, 2, expectedSamples, nil)
 
 	c.Inc(newLabelValueCombo([]string{"label"}, []string{"value-2"}), 2.0)
 	c.Inc(newLabelValueCombo([]string{"label"}, []string{"value-3"}), 3.0)
@@ -49,7 +49,7 @@ func Test_counter(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_counter", "label": "value-3"}, collectionTimeMs, 3),
 	}
 
-	collectMetricAndAssert(t, c, collectionTimeMs, nil, 3, expectedSamples, nil)
+	collectMetricAndAssert(t, c, collectionTimeMs, 3, expectedSamples, nil)
 }
 
 func TestCounterDifferentLabels(t *testing.T) {
@@ -74,7 +74,7 @@ func TestCounterDifferentLabels(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_counter", "another_label": "another_value"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_counter", "another_label": "another_value"}, collectionTimeMs, 2),
 	}
-	collectMetricAndAssert(t, c, collectionTimeMs, nil, 2, expectedSamples, nil)
+	collectMetricAndAssert(t, c, collectionTimeMs, 2, expectedSamples, nil)
 }
 
 func Test_counter_cantAdd(t *testing.T) {
@@ -100,7 +100,7 @@ func Test_counter_cantAdd(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_counter", "label": "value-2"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_counter", "label": "value-2"}, collectionTimeMs, 2),
 	}
-	collectMetricAndAssert(t, c, collectionTimeMs, nil, 2, expectedSamples, nil)
+	collectMetricAndAssert(t, c, collectionTimeMs, 2, expectedSamples, nil)
 
 	// block new series - existing series can still be updated
 	canAdd = false
@@ -113,7 +113,7 @@ func Test_counter_cantAdd(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_counter", "label": "value-2"}, collectionTimeMs, 4),
 	}
-	collectMetricAndAssert(t, c, collectionTimeMs, nil, 2, expectedSamples, nil)
+	collectMetricAndAssert(t, c, collectionTimeMs, 2, expectedSamples, nil)
 }
 
 func Test_counter_removeStaleSeries(t *testing.T) {
@@ -141,7 +141,7 @@ func Test_counter_removeStaleSeries(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_counter", "label": "value-2"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_counter", "label": "value-2"}, collectionTimeMs, 2),
 	}
-	collectMetricAndAssert(t, c, collectionTimeMs, nil, 2, expectedSamples, nil)
+	collectMetricAndAssert(t, c, collectionTimeMs, 2, expectedSamples, nil)
 
 	time.Sleep(10 * time.Millisecond)
 	timeMs = time.Now().UnixMilli()
@@ -157,7 +157,7 @@ func Test_counter_removeStaleSeries(t *testing.T) {
 	expectedSamples = []sample{
 		newSample(map[string]string{"__name__": "my_counter", "label": "value-2"}, collectionTimeMs, 4),
 	}
-	collectMetricAndAssert(t, c, collectionTimeMs, nil, 1, expectedSamples, nil)
+	collectMetricAndAssert(t, c, collectionTimeMs, 1, expectedSamples, nil)
 }
 
 func Test_counter_externalLabels(t *testing.T) {
@@ -174,7 +174,7 @@ func Test_counter_externalLabels(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_counter", "label": "value-2", "external_label": "external_value"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_counter", "label": "value-2", "external_label": "external_value"}, collectionTimeMs, 2),
 	}
-	collectMetricAndAssert(t, c, collectionTimeMs, nil, 2, expectedSamples, nil)
+	collectMetricAndAssert(t, c, collectionTimeMs, 2, expectedSamples, nil)
 }
 
 func Test_counter_concurrencyDataRace(t *testing.T) {
@@ -211,7 +211,7 @@ func Test_counter_concurrencyDataRace(t *testing.T) {
 	})
 
 	go accessor(func() {
-		_, err := c.collectMetrics(&noopAppender{}, 0, nil)
+		_, err := c.collectMetrics(&noopAppender{}, 0)
 		assert.NoError(t, err)
 	})
 
@@ -258,13 +258,13 @@ func Test_counter_concurrencyCorrectness(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_counter", "label": "value-1"}, collectionTimeMs, totalCount.Load()),
 	}
-	collectMetricAndAssert(t, c, collectionTimeMs, nil, 1, expectedSamples, nil)
+	collectMetricAndAssert(t, c, collectionTimeMs, 1, expectedSamples, nil)
 }
 
-func collectMetricAndAssert(t *testing.T, m metric, collectionTimeMs int64, externalLabels map[string]string, expectedActiveSeries int, expectedSamples []sample, expectedExemplars []exemplarSample) {
+func collectMetricAndAssert(t *testing.T, m metric, collectionTimeMs int64, expectedActiveSeries int, expectedSamples []sample, expectedExemplars []exemplarSample) {
 	appender := &capturingAppender{}
 
-	activeSeries, err := m.collectMetrics(appender, collectionTimeMs, externalLabels)
+	activeSeries, err := m.collectMetrics(appender, collectionTimeMs)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedActiveSeries, activeSeries)
 

--- a/modules/generator/registry/gauge.go
+++ b/modules/generator/registry/gauge.go
@@ -145,7 +145,7 @@ func (g *gauge) name() string {
 	return g.metricName
 }
 
-func (g *gauge) collectMetrics(appender storage.Appender, timeMs int64, _ map[string]string) (activeSeries int, err error) {
+func (g *gauge) collectMetrics(appender storage.Appender, timeMs int64) (activeSeries int, err error) {
 	g.seriesMtx.RLock()
 	defer g.seriesMtx.RUnlock()
 

--- a/modules/generator/registry/gauge.go
+++ b/modules/generator/registry/gauge.go
@@ -24,6 +24,8 @@ type gauge struct {
 
 	onAddSeries    func(count uint32) bool
 	onRemoveSeries func(count uint32)
+
+	externalLabels map[string]string
 }
 
 type gaugeSeries struct {
@@ -31,6 +33,8 @@ type gaugeSeries struct {
 	labels      LabelPair
 	value       *atomic.Float64
 	lastUpdated *atomic.Int64
+	lb          *labels.Builder
+	baseLabels  labels.Labels
 }
 
 var (
@@ -43,7 +47,7 @@ const (
 	set = "set"
 )
 
-func newGauge(name string, onAddSeries func(uint32) bool, onRemoveSeries func(count uint32)) *gauge {
+func newGauge(name string, onAddSeries func(uint32) bool, onRemoveSeries func(count uint32), externalLabels map[string]string) *gauge {
 	if onAddSeries == nil {
 		onAddSeries = func(uint32) bool {
 			return true
@@ -58,6 +62,7 @@ func newGauge(name string, onAddSeries func(uint32) bool, onRemoveSeries func(co
 		series:         make(map[uint64]*gaugeSeries),
 		onAddSeries:    onAddSeries,
 		onRemoveSeries: onRemoveSeries,
+		externalLabels: externalLabels,
 	}
 }
 
@@ -107,10 +112,23 @@ func (g *gauge) updateSeries(labelValueCombo *LabelValueCombo, value float64, op
 }
 
 func (g *gauge) newSeries(labelValueCombo *LabelValueCombo, value float64) *gaugeSeries {
+	// base labels
+	baseLabels := make(labels.Labels, 1+len(g.externalLabels))
+
+	// add metric name
+	baseLabels = append(baseLabels, labels.Label{Name: labels.MetricName, Value: g.metricName})
+
+	// add external labels
+	for name, value := range g.externalLabels {
+		baseLabels = append(baseLabels, labels.Label{Name: name, Value: value})
+	}
+
 	return &gaugeSeries{
 		labels:      labelValueCombo.getLabelPair(),
 		value:       atomic.NewFloat64(value),
 		lastUpdated: atomic.NewInt64(time.Now().UnixMilli()),
+		lb:          labels.NewBuilder(baseLabels),
+		baseLabels:  baseLabels,
 	}
 }
 
@@ -127,43 +145,24 @@ func (g *gauge) name() string {
 	return g.metricName
 }
 
-func (g *gauge) collectMetrics(appender storage.Appender, timeMs int64, externalLabels map[string]string) (activeSeries int, err error) {
+func (g *gauge) collectMetrics(appender storage.Appender, timeMs int64, _ map[string]string) (activeSeries int, err error) {
 	g.seriesMtx.RLock()
 	defer g.seriesMtx.RUnlock()
 
 	activeSeries = len(g.series)
 
-	labelsCount := 0
-	if activeSeries > 0 && g.series[0] != nil {
-		labelsCount = len(g.series[0].labels.names)
-	}
-
-	// base labels
-	baseLabels := make(labels.Labels, 1+len(externalLabels)+labelsCount)
-
-	// add metric name
-	baseLabels = append(baseLabels, labels.Label{Name: labels.MetricName, Value: g.metricName})
-
-	// add external labels
-	for name, value := range externalLabels {
-		baseLabels = append(baseLabels, labels.Label{Name: name, Value: value})
-	}
-
-	// TODO: avoid allocation on each collection
-	lb := labels.NewBuilder(baseLabels)
-
 	for _, s := range g.series {
 		t := time.UnixMilli(timeMs)
 
 		// reset labels for every series
-		lb.Reset(baseLabels)
+		s.lb.Reset(s.baseLabels)
 
 		// set series-specific labels
 		for i, name := range s.labels.names {
-			lb.Set(name, s.labels.values[i])
+			s.lb.Set(name, s.labels.values[i])
 		}
 
-		_, err = appender.Append(0, lb.Labels(), t.UnixMilli(), s.value.Load())
+		_, err = appender.Append(0, s.lb.Labels(), t.UnixMilli(), s.value.Load())
 		if err != nil {
 			return
 		}

--- a/modules/generator/registry/gauge_test.go
+++ b/modules/generator/registry/gauge_test.go
@@ -29,7 +29,7 @@ func Test_gaugeInc(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_gauge", "label": "value-1"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_gauge", "label": "value-2"}, collectionTimeMs, 2),
 	}
-	collectMetricAndAssert(t, c, collectionTimeMs, nil, 2, expectedSamples, nil)
+	collectMetricAndAssert(t, c, collectionTimeMs, 2, expectedSamples, nil)
 
 	c.Inc(newLabelValueCombo([]string{"label"}, []string{"value-2"}), 2.0)
 	c.Inc(newLabelValueCombo([]string{"label"}, []string{"value-3"}), 3.0)
@@ -42,7 +42,7 @@ func Test_gaugeInc(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_gauge", "label": "value-2"}, collectionTimeMs, 4),
 		newSample(map[string]string{"__name__": "my_gauge", "label": "value-3"}, collectionTimeMs, 3),
 	}
-	collectMetricAndAssert(t, c, collectionTimeMs, nil, 3, expectedSamples, nil)
+	collectMetricAndAssert(t, c, collectionTimeMs, 3, expectedSamples, nil)
 }
 
 func TestGaugeDifferentLabels(t *testing.T) {
@@ -64,7 +64,7 @@ func TestGaugeDifferentLabels(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_gauge", "label": "value-1"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_gauge", "another_label": "another_value"}, collectionTimeMs, 2),
 	}
-	collectMetricAndAssert(t, c, collectionTimeMs, nil, 2, expectedSamples, nil)
+	collectMetricAndAssert(t, c, collectionTimeMs, 2, expectedSamples, nil)
 }
 
 func Test_gaugeSet(t *testing.T) {
@@ -86,7 +86,7 @@ func Test_gaugeSet(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_gauge", "label": "value-1"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_gauge", "label": "value-2"}, collectionTimeMs, 2),
 	}
-	collectMetricAndAssert(t, c, collectionTimeMs, nil, 2, expectedSamples, nil)
+	collectMetricAndAssert(t, c, collectionTimeMs, 2, expectedSamples, nil)
 
 	c.Set(newLabelValueCombo([]string{"label"}, []string{"value-2"}), 2.0)
 	c.Set(newLabelValueCombo([]string{"label"}, []string{"value-3"}), 3.0)
@@ -99,7 +99,7 @@ func Test_gaugeSet(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_gauge", "label": "value-2"}, collectionTimeMs, 2),
 		newSample(map[string]string{"__name__": "my_gauge", "label": "value-3"}, collectionTimeMs, 3),
 	}
-	collectMetricAndAssert(t, c, collectionTimeMs, nil, 3, expectedSamples, nil)
+	collectMetricAndAssert(t, c, collectionTimeMs, 3, expectedSamples, nil)
 }
 
 func Test_gauge_cantAdd(t *testing.T) {
@@ -122,7 +122,7 @@ func Test_gauge_cantAdd(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_gauge", "label": "value-1"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_gauge", "label": "value-2"}, collectionTimeMs, 2),
 	}
-	collectMetricAndAssert(t, c, collectionTimeMs, nil, 2, expectedSamples, nil)
+	collectMetricAndAssert(t, c, collectionTimeMs, 2, expectedSamples, nil)
 
 	// block new series - existing series can still be updated
 	canAdd = false
@@ -135,7 +135,7 @@ func Test_gauge_cantAdd(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_gauge", "label": "value-1"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_gauge", "label": "value-2"}, collectionTimeMs, 4),
 	}
-	collectMetricAndAssert(t, c, collectionTimeMs, nil, 2, expectedSamples, nil)
+	collectMetricAndAssert(t, c, collectionTimeMs, 2, expectedSamples, nil)
 }
 
 func Test_gauge_removeStaleSeries(t *testing.T) {
@@ -160,7 +160,7 @@ func Test_gauge_removeStaleSeries(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_gauge", "label": "value-1"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_gauge", "label": "value-2"}, collectionTimeMs, 2),
 	}
-	collectMetricAndAssert(t, c, collectionTimeMs, nil, 2, expectedSamples, nil)
+	collectMetricAndAssert(t, c, collectionTimeMs, 2, expectedSamples, nil)
 
 	time.Sleep(10 * time.Millisecond)
 	timeMs = time.Now().UnixMilli()
@@ -176,7 +176,7 @@ func Test_gauge_removeStaleSeries(t *testing.T) {
 	expectedSamples = []sample{
 		newSample(map[string]string{"__name__": "my_gauge", "label": "value-2"}, collectionTimeMs, 4),
 	}
-	collectMetricAndAssert(t, c, collectionTimeMs, nil, 1, expectedSamples, nil)
+	collectMetricAndAssert(t, c, collectionTimeMs, 1, expectedSamples, nil)
 }
 
 func Test_gauge_externalLabels(t *testing.T) {
@@ -190,7 +190,7 @@ func Test_gauge_externalLabels(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_gauge", "label": "value-1", "external_label": "external_value"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_gauge", "label": "value-2", "external_label": "external_value"}, collectionTimeMs, 2),
 	}
-	collectMetricAndAssert(t, c, collectionTimeMs, nil, 2, expectedSamples, nil)
+	collectMetricAndAssert(t, c, collectionTimeMs, 2, expectedSamples, nil)
 }
 
 func Test_gauge_concurrencyDataRace(t *testing.T) {
@@ -227,7 +227,7 @@ func Test_gauge_concurrencyDataRace(t *testing.T) {
 	})
 
 	go accessor(func() {
-		_, err := c.collectMetrics(&noopAppender{}, 0, nil)
+		_, err := c.collectMetrics(&noopAppender{}, 0)
 		assert.NoError(t, err)
 	})
 
@@ -272,5 +272,5 @@ func Test_gauge_concurrencyCorrectness(t *testing.T) {
 	expectedSamples := []sample{
 		newSample(map[string]string{"__name__": "my_gauge", "label": "value-1"}, collectionTimeMs, float64(totalCount.Load())),
 	}
-	collectMetricAndAssert(t, c, collectionTimeMs, nil, 1, expectedSamples, nil)
+	collectMetricAndAssert(t, c, collectionTimeMs, 1, expectedSamples, nil)
 }

--- a/modules/generator/registry/gauge_test.go
+++ b/modules/generator/registry/gauge_test.go
@@ -17,7 +17,7 @@ func Test_gaugeInc(t *testing.T) {
 		return true
 	}
 
-	c := newGauge("my_gauge", onAdd, nil)
+	c := newGauge("my_gauge", onAdd, nil, nil)
 
 	c.Inc(newLabelValueCombo([]string{"label"}, []string{"value-1"}), 1.0)
 	c.Inc(newLabelValueCombo([]string{"label"}, []string{"value-2"}), 2.0)
@@ -52,7 +52,7 @@ func TestGaugeDifferentLabels(t *testing.T) {
 		return true
 	}
 
-	c := newGauge("my_gauge", onAdd, nil)
+	c := newGauge("my_gauge", onAdd, nil, nil)
 
 	c.Inc(newLabelValueCombo([]string{"label"}, []string{"value-1"}), 1.0)
 	c.Inc(newLabelValueCombo([]string{"another_label"}, []string{"another_value"}), 2.0)
@@ -74,7 +74,7 @@ func Test_gaugeSet(t *testing.T) {
 		return true
 	}
 
-	c := newGauge("my_gauge", onAdd, nil)
+	c := newGauge("my_gauge", onAdd, nil, nil)
 
 	c.Set(newLabelValueCombo([]string{"label"}, []string{"value-1"}), 1.0)
 	c.Set(newLabelValueCombo([]string{"label"}, []string{"value-2"}), 2.0)
@@ -109,7 +109,7 @@ func Test_gauge_cantAdd(t *testing.T) {
 		return canAdd
 	}
 
-	c := newGauge("my_gauge", onAdd, nil)
+	c := newGauge("my_gauge", onAdd, nil, nil)
 
 	// allow adding new series
 	canAdd = true
@@ -145,7 +145,7 @@ func Test_gauge_removeStaleSeries(t *testing.T) {
 		removedSeries++
 	}
 
-	c := newGauge("my_gauge", nil, onRemove)
+	c := newGauge("my_gauge", nil, onRemove, nil)
 
 	timeMs := time.Now().UnixMilli()
 	c.Inc(newLabelValueCombo([]string{"label"}, []string{"value-1"}), 1.0)
@@ -180,7 +180,7 @@ func Test_gauge_removeStaleSeries(t *testing.T) {
 }
 
 func Test_gauge_externalLabels(t *testing.T) {
-	c := newGauge("my_gauge", nil, nil)
+	c := newGauge("my_gauge", nil, nil, map[string]string{"external_label": "external_value"})
 
 	c.Inc(newLabelValueCombo([]string{"label"}, []string{"value-1"}), 1.0)
 	c.Inc(newLabelValueCombo([]string{"label"}, []string{"value-2"}), 2.0)
@@ -190,11 +190,11 @@ func Test_gauge_externalLabels(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_gauge", "label": "value-1", "external_label": "external_value"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_gauge", "label": "value-2", "external_label": "external_value"}, collectionTimeMs, 2),
 	}
-	collectMetricAndAssert(t, c, collectionTimeMs, map[string]string{"external_label": "external_value"}, 2, expectedSamples, nil)
+	collectMetricAndAssert(t, c, collectionTimeMs, nil, 2, expectedSamples, nil)
 }
 
 func Test_gauge_concurrencyDataRace(t *testing.T) {
-	c := newGauge("my_gauge", nil, nil)
+	c := newGauge("my_gauge", nil, nil, nil)
 
 	end := make(chan struct{})
 
@@ -240,7 +240,7 @@ func Test_gauge_concurrencyDataRace(t *testing.T) {
 }
 
 func Test_gauge_concurrencyCorrectness(t *testing.T) {
-	c := newGauge("my_gauge", nil, nil)
+	c := newGauge("my_gauge", nil, nil, nil)
 
 	var wg sync.WaitGroup
 	end := make(chan struct{})

--- a/modules/generator/registry/histogram.go
+++ b/modules/generator/registry/histogram.go
@@ -192,7 +192,7 @@ func (h *histogram) name() string {
 	return h.metricName
 }
 
-func (h *histogram) collectMetrics(appender storage.Appender, timeMs int64, _ map[string]string) (activeSeries int, err error) {
+func (h *histogram) collectMetrics(appender storage.Appender, timeMs int64) (activeSeries int, err error) {
 	h.seriesMtx.Lock()
 	defer h.seriesMtx.Unlock()
 

--- a/modules/generator/registry/histogram_test.go
+++ b/modules/generator/registry/histogram_test.go
@@ -55,7 +55,7 @@ func Test_histogram(t *testing.T) {
 			Ts:     collectionTimeMs,
 		}),
 	}
-	collectMetricAndAssert(t, h, collectionTimeMs, nil, 10, expectedSamples, expectedExemplars)
+	collectMetricAndAssert(t, h, collectionTimeMs, 10, expectedSamples, expectedExemplars)
 
 	h.ObserveWithExemplar(newLabelValueCombo([]string{"label"}, []string{"value-2"}), 2.5, "trace-2.2", 1.0)
 	h.ObserveWithExemplar(newLabelValueCombo([]string{"label"}, []string{"value-3"}), 3.0, "trace-3", 1.0)
@@ -94,7 +94,7 @@ func Test_histogram(t *testing.T) {
 			Ts:     collectionTimeMs,
 		}),
 	}
-	collectMetricAndAssert(t, h, collectionTimeMs, nil, 15, expectedSamples, expectedExemplars)
+	collectMetricAndAssert(t, h, collectionTimeMs, 15, expectedSamples, expectedExemplars)
 
 	h.ObserveWithExemplar(newLabelValueCombo([]string{"label"}, []string{"value-2"}), 2.5, "trace-2.2", 20.0)
 	h.ObserveWithExemplar(newLabelValueCombo([]string{"label"}, []string{"value-3"}), 3.0, "trace-3", 13.5)
@@ -137,7 +137,7 @@ func Test_histogram(t *testing.T) {
 			Ts:     collectionTimeMs,
 		}),
 	}
-	collectMetricAndAssert(t, h, collectionTimeMs, nil, 15, expectedSamples, expectedExemplars)
+	collectMetricAndAssert(t, h, collectionTimeMs, 15, expectedSamples, expectedExemplars)
 }
 
 func Test_histogram_cantAdd(t *testing.T) {
@@ -171,7 +171,7 @@ func Test_histogram_cantAdd(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "2"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "+Inf"}, collectionTimeMs, 1),
 	}
-	collectMetricAndAssert(t, h, collectionTimeMs, nil, 10, expectedSamples, nil)
+	collectMetricAndAssert(t, h, collectionTimeMs, 10, expectedSamples, nil)
 
 	// block new series - existing series can still be updated
 	canAdd = false
@@ -192,7 +192,7 @@ func Test_histogram_cantAdd(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "2"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "+Inf"}, collectionTimeMs, 2),
 	}
-	collectMetricAndAssert(t, h, collectionTimeMs, nil, 10, expectedSamples, nil)
+	collectMetricAndAssert(t, h, collectionTimeMs, 10, expectedSamples, nil)
 }
 
 func Test_histogram_removeStaleSeries(t *testing.T) {
@@ -228,7 +228,7 @@ func Test_histogram_removeStaleSeries(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "2"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "+Inf"}, collectionTimeMs, 1),
 	}
-	collectMetricAndAssert(t, h, collectionTimeMs, nil, 10, expectedSamples, nil)
+	collectMetricAndAssert(t, h, collectionTimeMs, 10, expectedSamples, nil)
 
 	time.Sleep(10 * time.Millisecond)
 	timeMs = time.Now().UnixMilli()
@@ -248,7 +248,7 @@ func Test_histogram_removeStaleSeries(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "2"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "+Inf"}, collectionTimeMs, 2),
 	}
-	collectMetricAndAssert(t, h, collectionTimeMs, nil, 5, expectedSamples, nil)
+	collectMetricAndAssert(t, h, collectionTimeMs, 5, expectedSamples, nil)
 }
 
 func Test_histogram_externalLabels(t *testing.T) {
@@ -275,7 +275,7 @@ func Test_histogram_externalLabels(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "2", "external_label": "external_value"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "+Inf", "external_label": "external_value"}, collectionTimeMs, 1),
 	}
-	collectMetricAndAssert(t, h, collectionTimeMs, extLabels, 10, expectedSamples, nil)
+	collectMetricAndAssert(t, h, collectionTimeMs, 10, expectedSamples, nil)
 }
 
 func Test_histogram_concurrencyDataRace(t *testing.T) {
@@ -312,7 +312,7 @@ func Test_histogram_concurrencyDataRace(t *testing.T) {
 	})
 
 	go accessor(func() {
-		_, err := h.collectMetrics(&noopAppender{}, 0, nil)
+		_, err := h.collectMetrics(&noopAppender{}, 0)
 		assert.NoError(t, err)
 	})
 
@@ -363,7 +363,7 @@ func Test_histogram_concurrencyCorrectness(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "2"}, collectionTimeMs, float64(totalCount.Load())),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "+Inf"}, collectionTimeMs, float64(totalCount.Load())),
 	}
-	collectMetricAndAssert(t, h, collectionTimeMs, nil, 5, expectedSamples, nil)
+	collectMetricAndAssert(t, h, collectionTimeMs, 5, expectedSamples, nil)
 }
 
 func Test_histogram_span_multiplier(t *testing.T) {
@@ -381,5 +381,5 @@ func Test_histogram_span_multiplier(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "2"}, collectionTimeMs, 6.5),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "+Inf"}, collectionTimeMs, 6.5),
 	}
-	collectMetricAndAssert(t, h, collectionTimeMs, nil, 5, expectedSamples, nil)
+	collectMetricAndAssert(t, h, collectionTimeMs, 5, expectedSamples, nil)
 }

--- a/modules/generator/registry/native_histogram.go
+++ b/modules/generator/registry/native_histogram.go
@@ -190,7 +190,7 @@ func (h *nativeHistogram) name() string {
 	return h.metricName
 }
 
-func (h *nativeHistogram) collectMetrics(appender storage.Appender, timeMs int64, _ map[string]string) (activeSeries int, err error) {
+func (h *nativeHistogram) collectMetrics(appender storage.Appender, timeMs int64) (activeSeries int, err error) {
 	h.seriesMtx.Lock()
 	defer h.seriesMtx.Unlock()
 

--- a/modules/generator/registry/native_histogram_test.go
+++ b/modules/generator/registry/native_histogram_test.go
@@ -471,7 +471,7 @@ func Test_Histograms(t *testing.T) {
 }
 
 func collectMetricsAndAssertSeries(t *testing.T, m metric, collectionTimeMs int64, expectedSeries int, appender storage.Appender) {
-	activeSeries, err := m.collectMetrics(appender, collectionTimeMs, nil)
+	activeSeries, err := m.collectMetrics(appender, collectionTimeMs)
 	require.NoError(t, err)
 	require.Equal(t, expectedSeries, activeSeries)
 }

--- a/modules/generator/registry/registry.go
+++ b/modules/generator/registry/registry.go
@@ -144,7 +144,7 @@ func (r *ManagedRegistry) NewLabelValueCombo(labels []string, values []string) *
 }
 
 func (r *ManagedRegistry) NewCounter(name string) Counter {
-	c := newCounter(name, r.onAddMetricSeries, r.onRemoveMetricSeries)
+	c := newCounter(name, r.onAddMetricSeries, r.onRemoveMetricSeries, r.externalLabels)
 	r.registerMetric(c)
 	return c
 }

--- a/modules/generator/registry/registry.go
+++ b/modules/generator/registry/registry.go
@@ -166,7 +166,7 @@ func (r *ManagedRegistry) NewHistogram(name string, buckets []float64, histogram
 }
 
 func (r *ManagedRegistry) NewGauge(name string) Gauge {
-	g := newGauge(name, r.onAddMetricSeries, r.onRemoveMetricSeries)
+	g := newGauge(name, r.onAddMetricSeries, r.onRemoveMetricSeries, r.externalLabels)
 	r.registerMetric(g)
 	return g
 }

--- a/modules/generator/registry/registry.go
+++ b/modules/generator/registry/registry.go
@@ -83,7 +83,7 @@ type ManagedRegistry struct {
 // metric is the interface for a metric that is managed by ManagedRegistry.
 type metric interface {
 	name() string
-	collectMetrics(appender storage.Appender, timeMs int64, externalLabels map[string]string) (activeSeries int, err error)
+	collectMetrics(appender storage.Appender, timeMs int64) (activeSeries int, err error)
 	removeStaleSeries(staleTimeMs int64)
 }
 
@@ -226,7 +226,7 @@ func (r *ManagedRegistry) CollectMetrics(ctx context.Context) {
 	collectionTimeMs := time.Now().UnixMilli()
 
 	for _, m := range r.metrics {
-		active, err := m.collectMetrics(appender, collectionTimeMs, r.externalLabels)
+		active, err := m.collectMetrics(appender, collectionTimeMs)
 		if err != nil {
 			return
 		}

--- a/modules/generator/registry/test.go
+++ b/modules/generator/registry/test.go
@@ -109,7 +109,7 @@ func (t *testCounter) name() string {
 	return t.n
 }
 
-func (t *testCounter) collectMetrics(_ storage.Appender, _ int64, _ map[string]string) (activeSeries int, err error) {
+func (t *testCounter) collectMetrics(_ storage.Appender, _ int64) (activeSeries int, err error) {
 	return
 }
 
@@ -156,7 +156,7 @@ func (t *testGauge) name() string {
 	return t.n
 }
 
-func (t *testGauge) collectMetrics(_ storage.Appender, _ int64, _ map[string]string) (activeSeries int, err error) {
+func (t *testGauge) collectMetrics(_ storage.Appender, _ int64) (activeSeries int, err error) {
 	return 0, nil
 }
 
@@ -206,7 +206,7 @@ func withLe(lbls labels.Labels, le float64) labels.Labels {
 	return lb.Labels()
 }
 
-func (t *testHistogram) collectMetrics(_ storage.Appender, _ int64, _ map[string]string) (activeSeries int, err error) {
+func (t *testHistogram) collectMetrics(_ storage.Appender, _ int64) (activeSeries int, err error) {
 	panic("implement me")
 }
 


### PR DESCRIPTION
**What this PR does**:

Here we make some performance improvements to the `counter` and `gauge` in the registry.  This is a follow-on to #4232 and #4244.  Additionally, we modify the `metric` interface to skip passing of the `externalLabels` now that each implementation has been updated to take those labels at time of `new`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`