### PR TITLE
Improve the readability of redis_client util method

### DIFF
--- a/pkg/cache/redis_client.go
+++ b/pkg/cache/redis_client.go
@@ -178,12 +178,7 @@ func (c *RedisClient) Close() error {
 	return c.rdb.Close()
 }
 
-// StringToBytes converts string to byte slice. (copied from vendor/github.com/go-redis/redis/v8/internal/util/unsafe.go)
+// StringToBytes reads the string header and returns a byte slice without copying.
 func StringToBytes(s string) []byte {
-	return *(*[]byte)(unsafe.Pointer(
-		&struct {
-			string
-			Cap int
-		}{s, len(s)},
-	))
+	return unsafe.Slice(unsafe.StringData(s), len(s))
 }


### PR DESCRIPTION
Here we modify a utility method in the redis client which is used to retrieve the bytes of the array backing a string.  New `unsafe` methods exist to support this use case, which is considerably more readable.

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`