### PR TITLE
Docs: fix trace:rootService example code

### DIFF
--- a/docs/sources/tempo/traceql/_index.md
+++ b/docs/sources/tempo/traceql/_index.md
@@ -116,7 +116,7 @@ The following table shows the current available scoped intrinsic fields:
 | `span:id`                | string      | span id using hex string                                        | `{ span:id = "0000000000000001" }`     |
 | `trace:duration`         | duration    | max(end) - min(start) time of the spans in the trace            | `{ trace:duration > 100ms }`           |
 | `trace:rootName`         | string      | if it exists the name of the root span in the trace             | `{ trace:rootName = "HTTP GET" }`      |
-| `trace:rootService`      | string      | if it exists the service name of the root span in the trace     | `{ trace:rootServiceName = "gateway" }`|
+| `trace:rootService`      | string      | if it exists the service name of the root span in the trace     | `{ trace:rootService = "gateway" }`    |
 | `trace:id`               | string      | trace id using hex string                                       | `{ trace:id = "1234567890abcde" }`     |
 | `event:name`             | string      | name of event                                                   | `{ event:name = "exception" }`         |
 | `event:timeSinceStart`   | duration    | time of event in relation to the span start time                | `{ event:timeSinceStart > 2ms}`        |

--- a/docs/sources/tempo/traceql/_index.md
+++ b/docs/sources/tempo/traceql/_index.md
@@ -106,26 +106,26 @@ Attributes example:
 
 The following table shows the current available scoped intrinsic fields:
 
-| **Field**                | **Type**    | **Definition**                                                  | **Example**                            |
-| ------------------------ | ----------- | --------------------------------------------------------------- | -------------------------------------- |
-| `span:status`            | status enum | status: error, ok, or unset                                     | `{ span:status = ok }`                 |
-| `span:statusMessage`     | string      | optional text accompanying the span status                      | `{ span:statusMessage = "Forbidden" }` |
-| `span:duration`          | duration    | end - start time of the span                                    | `{ span:duration > 100ms }`            |
-| `span:name`              | string      | operation or span name                                          | `{ span:name = "HTTP POST" }`          |
-| `span:kind`              | kind enum   | kind: server, client, producer, consumer, internal, unspecified | `{ span:kind = server }`               |
-| `span:id`                | string      | span id using hex string                                        | `{ span:id = "0000000000000001" }`     |
-| `trace:duration`         | duration    | max(end) - min(start) time of the spans in the trace            | `{ trace:duration > 100ms }`           |
-| `trace:rootName`         | string      | if it exists the name of the root span in the trace             | `{ trace:rootName = "HTTP GET" }`      |
-| `trace:rootService`      | string      | if it exists the service name of the root span in the trace     | `{ trace:rootService = "gateway" }`    |
-| `trace:id`               | string      | trace id using hex string                                       | `{ trace:id = "1234567890abcde" }`     |
-| `event:name`             | string      | name of event                                                   | `{ event:name = "exception" }`         |
-| `event:timeSinceStart`   | duration    | time of event in relation to the span start time                | `{ event:timeSinceStart > 2ms}`        |
-| `link:spanID`            | string      | link span id using hex string                                   | `{ link:spanID = "0000000000000001" }` |
-| `link:traceID`           | string      | link trace id using hex string                                  | `{ link:traceID = "1234567890abcde" }` |
+| **Field**                | **Type**    | **Definition**                                                  | **Example**                             |
+| ------------------------ | ----------- | --------------------------------------------------------------- | --------------------------------------- |
+| `span:status`            | status enum | status: error, ok, or unset                                     | `{ span:status = ok }`                  |
+| `span:statusMessage`     | string      | optional text accompanying the span status                      | `{ span:statusMessage = "Forbidden" }`  |
+| `span:duration`          | duration    | end - start time of the span                                    | `{ span:duration > 100ms }`             |
+| `span:name`              | string      | operation or span name                                          | `{ span:name = "HTTP POST" }`           |
+| `span:kind`              | kind enum   | kind: server, client, producer, consumer, internal, unspecified | `{ span:kind = server }`                |
+| `span:id`                | string      | span id using hex string                                        | `{ span:id = "0000000000000001" }`      |
+| `trace:duration`         | duration    | max(end) - min(start) time of the spans in the trace            | `{ trace:duration > 100ms }`            |
+| `trace:rootName`         | string      | if it exists, the name of the root span in the trace            | `{ trace:rootName = "HTTP GET" }`       |
+| `trace:rootService`      | string      | if it exists, the service name of the root span in the trace    | `{ trace:rootService = "gateway" }`     |
+| `trace:id`               | string      | trace id using hex string                                       | `{ trace:id = "1234567890abcde" }`      |
+| `event:name`             | string      | name of event                                                   | `{ event:name = "exception" }`          |
+| `event:timeSinceStart`   | duration    | time of event in relation to the span start time                | `{ event:timeSinceStart > 2ms}`         |
+| `link:spanID`            | string      | link span id using hex string                                   | `{ link:spanID = "0000000000000001" }`  |
+| `link:traceID`           | string      | link trace id using hex string                                  | `{ link:traceID = "1234567890abcde" }`  |
 
 <!-- instrumentation scope isn't included in the 2.6 documentation
-| `instrumentation:name`   | string      | instrumentation scope name                                      | `{ instrumentation:name = "grpc" }`    |
-| `instrumentation:version`| string      | instrumentation scope version                                   | `{ instrumentation:version = "1.0.0" }`|
+| `instrumentation:name`   | string      | instrumentation scope name                                      | `{ instrumentation:name = "grpc" }`     |
+| `instrumentation:version`| string      | instrumentation scope version                                   | `{ instrumentation:version = "1.0.0" }` |
 -->
 
 The trace-level intrinsics, `trace:duration`, `trace:rootName`, and `trace:rootService`, are the same for all spans in the same trace.


### PR DESCRIPTION
Update the example filter to match the actual intrinsic name.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This fixes a reference to `trace:rootServiceName` in the query intrinsics table. (`trace:rootServiceName` produces an error when you try to use it.)

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`