### PR TITLE
[Compaction] Add signals for duplicate rf1 data

### DIFF
--- a/cmd/tempo-cli/cmd-rewrite-blocks.go
+++ b/cmd/tempo-cli/cmd-rewrite-blocks.go
@@ -141,6 +141,7 @@ func rewriteBlock(ctx context.Context, r backend.Reader, w backend.Writer, meta 
 		SpansDiscarded:    func(_, _, _ string, _ int) {},
 		DisconnectedTrace: func() {},
 		RootlessTrace:     func() {},
+		DedupedSpans:      func(_, _ int) {},
 	}
 
 	compactor := enc.NewCompactor(opts)

--- a/tempodb/encoding/common/interfaces.go
+++ b/tempodb/encoding/common/interfaces.go
@@ -88,6 +88,7 @@ type CompactionOptions struct {
 	SpansDiscarded    func(traceID string, rootSpanName string, rootServiceName string, spans int)
 	DisconnectedTrace func()
 	RootlessTrace     func()
+	DedupedSpans      func(replFactor, dedupedSpans int)
 }
 
 type Iterator interface {

--- a/tempodb/encoding/vparquet4/combiner.go
+++ b/tempodb/encoding/vparquet4/combiner.go
@@ -42,7 +42,8 @@ func (c *Combiner) Consume(tr *Trace) (spanCount int) {
 }
 
 // ConsumeWithFinal consumes the trace, but allows for performance savings when
-// it is known that this is the last expected input trace.
+// it is known that this is the last expected input trace. the spanCount returned
+// is the number of duplicate spans between the two traces
 func (c *Combiner) ConsumeWithFinal(tr *Trace, final bool) (spanCount int) {
 	if tr == nil {
 		return
@@ -110,9 +111,10 @@ func (c *Combiner) ConsumeWithFinal(tr *Trace, final bool) (spanCount int) {
 
 			if len(notFoundSpans) > 0 {
 				ils.Spans = notFoundSpans
-				spanCount += len(notFoundSpans)
 				notFoundILS = append(notFoundILS, ils)
 			}
+
+			spanCount += len(ils.Spans) - len(notFoundSpans)
 		}
 
 		// if there were some spans not found in A, add everything left in the batch


### PR DESCRIPTION
**What this PR does**:
This PR adds telemetry to help the team understand the impact of compaction of RF1 data. It is likely these are temporary changes to help inform an improvement to prevent duplicate RF1 data. Due to this there is no changelog. Two things were added:

1) A log message when a compaction job completes if the compactor no longer owns that job
2) A metric to count deduped spans per replication factor. Presumably this should show 0 at RF1

Note that I changed the meaning of the returned spans count from the combiner. Nothing was using it so this seemed acceptable.