### PR TITLE
Increase length of time compactions have to fail

### DIFF
--- a/operations/tempo-mixin-compiled/alerts.yaml
+++ b/operations/tempo-mixin-compiled/alerts.yaml
@@ -36,7 +36,7 @@
     "expr": |
       sum by (cluster, namespace) (increase(tempodb_compaction_errors_total{}[1h])) > 2 and
       sum by (cluster, namespace) (increase(tempodb_compaction_errors_total{}[5m])) > 0
-    "for": "5m"
+    "for": "1h"
     "labels":
       "severity": "critical"
   - "alert": "TempoIngesterFlushesUnhealthy"

--- a/operations/tempo-mixin/alerts.libsonnet
+++ b/operations/tempo-mixin/alerts.libsonnet
@@ -50,7 +50,7 @@
           },
           {
             alert: 'TempoCompactionsFailing',
-            'for': '5m',
+            'for': '1h',
             expr: |||
               sum by (%s) (increase(tempodb_compaction_errors_total{}[1h])) > %s and
               sum by (%s) (increase(tempodb_compaction_errors_total{}[5m])) > 0


### PR DESCRIPTION
Adjust jsonnet mixin alert to require failed compactions for a longer period of time to alert. Currently, if object storage has a short blip we will see this alert hit. However, this alert is really not concerning unless it continues for a significant period of time. Hence increasing the 'for' value to 1h.