### PR TITLE
Metrics-Generators: Reduce Wal TruncateFrequency to reduce memory usage

### DIFF
--- a/modules/generator/storage/config.go
+++ b/modules/generator/storage/config.go
@@ -52,7 +52,7 @@ func agentDefaultOptions() agentOptions {
 		WALSegmentSize:    defaultOptions.WALSegmentSize,
 		WALCompression:    defaultOptions.WALCompression,
 		StripeSize:        defaultOptions.StripeSize,
-		TruncateFrequency: defaultOptions.TruncateFrequency,
+		TruncateFrequency: 15 * time.Minute, // the default truncate frequency is 2h which consumes a lot of standing memory to store all the series. this means we can incur at most a 15m network outage before data loss
 		MinWALTime:        defaultOptions.MinWALTime,
 		MaxWALTime:        defaultOptions.MaxWALTime,
 		NoLockfile:        defaultOptions.NoLockfile,


### PR DESCRIPTION
**What this PR does**:
Reduces memory usage in the metrics-generators by reducing the amount of data kept in the prom wal. This has been reduced from `2h` to `15m` on recommendation from @mattdurham of the github.com/grafana/alloy team.

The impact is that Tempo can now only suffer a 15m network outage before there is data loss on remote write.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`