### PR TITLE
[rhythm] Deterministically build blocks for partition sections

### DIFF
--- a/modules/blockbuilder/tenant_store.go
+++ b/modules/blockbuilder/tenant_store.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/tempo/modules/blockbuilder/util"
 	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/tempodb"
@@ -25,10 +26,13 @@ var metricBlockBuilderFlushedBlocks = promauto.NewCounterVec(
 	[]string{"tenant_id"},
 )
 
+// TODO - This needs locking
 type tenantStore struct {
 	tenantID string
-	cfg      BlockConfig
-	logger   log.Logger
+	ts       int64
+
+	cfg    BlockConfig
+	logger log.Logger
 
 	overrides Overrides
 	wal       *wal.WAL
@@ -37,9 +41,10 @@ type tenantStore struct {
 	enc       encoding.VersionedEncoding
 }
 
-func newTenantStore(tenantID string, cfg BlockConfig, logger log.Logger, wal *wal.WAL, enc encoding.VersionedEncoding, o Overrides) (*tenantStore, error) {
-	i := &tenantStore{
+func newTenantStore(tenantID string, ts int64, cfg BlockConfig, logger log.Logger, wal *wal.WAL, enc encoding.VersionedEncoding, o Overrides) (*tenantStore, error) {
+	s := &tenantStore{
 		tenantID:  tenantID,
+		ts:        ts,
 		cfg:       cfg,
 		logger:    logger,
 		overrides: o,
@@ -47,96 +52,100 @@ func newTenantStore(tenantID string, cfg BlockConfig, logger log.Logger, wal *wa
 		enc:       enc,
 	}
 
-	return i, i.resetHeadBlock()
+	return s, s.resetHeadBlock()
 }
 
-func (i *tenantStore) cutHeadBlock() error {
+func (s *tenantStore) cutHeadBlock() error {
 	// Flush the current head block if it exists
-	if i.headBlock != nil {
-		if err := i.headBlock.Flush(); err != nil {
+	if s.headBlock != nil {
+		if err := s.headBlock.Flush(); err != nil {
 			return err
 		}
-		i.walBlocks = append(i.walBlocks, i.headBlock)
-		i.headBlock = nil
+		s.walBlocks = append(s.walBlocks, s.headBlock)
+		s.headBlock = nil
 	}
 
 	return nil
 }
 
-func (i *tenantStore) resetHeadBlock() error {
+func (s *tenantStore) newUUID() backend.UUID {
+	return backend.UUID(util.NewDeterministicID(s.ts, int64(len(s.walBlocks))))
+}
+
+func (s *tenantStore) resetHeadBlock() error {
 	meta := &backend.BlockMeta{
-		BlockID:           backend.NewUUID(), // TODO - Deterministic UUID
-		TenantID:          i.tenantID,
-		DedicatedColumns:  i.overrides.DedicatedColumns(i.tenantID),
+		BlockID:           s.newUUID(),
+		TenantID:          s.tenantID,
+		DedicatedColumns:  s.overrides.DedicatedColumns(s.tenantID),
 		ReplicationFactor: backend.MetricsGeneratorReplicationFactor,
 	}
-	block, err := i.wal.NewBlock(meta, model.CurrentEncoding)
+	block, err := s.wal.NewBlock(meta, model.CurrentEncoding)
 	if err != nil {
 		return err
 	}
-	i.headBlock = block
+	s.headBlock = block
 	return nil
 }
 
-func (i *tenantStore) AppendTrace(traceID []byte, tr *tempopb.Trace, start, end uint32) error {
+func (s *tenantStore) AppendTrace(traceID []byte, tr *tempopb.Trace, start, end uint32) error {
 	// TODO - Do this async? This slows down consumption, but we need to be precise
-	if i.headBlock.DataLength() > i.cfg.MaxBlockBytes {
-		if err := i.resetHeadBlock(); err != nil {
+	if s.headBlock.DataLength() > s.cfg.MaxBlockBytes {
+		if err := s.resetHeadBlock(); err != nil {
 			return err
 		}
 	}
 
-	return i.headBlock.AppendTrace(traceID, tr, start, end)
+	return s.headBlock.AppendTrace(traceID, tr, start, end)
 }
 
-func (i *tenantStore) Flush(ctx context.Context, store tempodb.Writer) error {
+func (s *tenantStore) Flush(ctx context.Context, store tempodb.Writer) error {
 	// TODO - Advance some of this work if possible
 
 	// Cut head block
-	if err := i.cutHeadBlock(); err != nil {
+	if err := s.cutHeadBlock(); err != nil {
 		return err
 	}
-	completeBlocks := make([]tempodb.WriteableBlock, 0, len(i.walBlocks))
+	completeBlocks := make([]tempodb.WriteableBlock, 0, len(s.walBlocks))
 	// Write all blocks
-	for _, block := range i.walBlocks {
-		completeBlock, err := i.buildWriteableBlock(ctx, block)
+	for _, block := range s.walBlocks {
+		completeBlock, err := s.buildWriteableBlock(ctx, block)
 		if err != nil {
 			return err
 		}
 		completeBlocks = append(completeBlocks, completeBlock)
 	}
 
-	level.Info(i.logger).Log("msg", "writing blocks to storage", "num_blocks", len(completeBlocks))
+	level.Info(s.logger).Log("msg", "writing blocks to storage", "num_blocks", len(completeBlocks))
 	// Write all blocks to the store
 	for _, block := range completeBlocks {
-		level.Info(i.logger).Log("msg", "writing block to storage", "block_id", block.BlockMeta().BlockID.String())
+		level.Info(s.logger).Log("msg", "writing block to storage", "block_id", block.BlockMeta().BlockID.String())
 		if err := store.WriteBlock(ctx, block); err != nil {
 			return err
 		}
-		metricBlockBuilderFlushedBlocks.WithLabelValues(i.tenantID).Inc()
+		metricBlockBuilderFlushedBlocks.WithLabelValues(s.tenantID).Inc()
 	}
 
 	// Clear the blocks
-	i.walBlocks = i.walBlocks[:0]
+	s.walBlocks = s.walBlocks[:0]
 
-	return i.resetHeadBlock()
+	return s.resetHeadBlock()
 }
 
-func (i *tenantStore) buildWriteableBlock(ctx context.Context, b common.WALBlock) (tempodb.WriteableBlock, error) {
+func (s *tenantStore) buildWriteableBlock(ctx context.Context, b common.WALBlock) (tempodb.WriteableBlock, error) {
 	iter, err := b.Iterator()
 	if err != nil {
 		return nil, err
 	}
 	defer iter.Close()
 
-	reader, writer := backend.NewReader(i.wal.LocalBackend()), backend.NewWriter(i.wal.LocalBackend())
+	reader, writer := backend.NewReader(s.wal.LocalBackend()), backend.NewWriter(s.wal.LocalBackend())
 
-	newMeta, err := i.enc.CreateBlock(ctx, &i.cfg.BlockCfg, b.BlockMeta(), iter, reader, writer)
+	newMeta, err := s.enc.CreateBlock(ctx, &s.cfg.BlockCfg, b.BlockMeta(), iter, reader, writer)
 	if err != nil {
 		return nil, err
 	}
 
-	newBlock, err := i.enc.OpenBlock(newMeta, reader)
+	newBlock, err := s.enc.OpenBlock(newMeta, reader)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/blockbuilder/util/id.go
+++ b/modules/blockbuilder/util/id.go
@@ -1,0 +1,30 @@
+package util
+
+import (
+	"crypto/sha1"
+	"encoding/binary"
+
+	"github.com/google/uuid"
+)
+
+var (
+	ns   = uuid.MustParse("28840903-6eb5-4ffb-8880-93a4fa98dbcb") // Random UUID
+	hash = sha1.New()
+)
+
+func NewDeterministicID(ts, seq int64) uuid.UUID {
+	b := int64ToBytes(ts, seq)
+
+	return uuid.NewHash(hash, ns, b, 5)
+}
+
+func int64ToBytes(val1, val2 int64) []byte {
+	// 16 bytes = 8 bytes (int64) + 8 bytes (int64)
+	bytes := make([]byte, 16)
+
+	// Use binary.LittleEndian or binary.BigEndian depending on your requirement
+	binary.LittleEndian.PutUint64(bytes[0:8], uint64(val1))
+	binary.LittleEndian.PutUint64(bytes[8:16], uint64(val2))
+
+	return bytes
+}

--- a/modules/blockbuilder/util/id_test.go
+++ b/modules/blockbuilder/util/id_test.go
@@ -1,0 +1,38 @@
+package util
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestDeterministicID(t *testing.T) {
+	ts := time.Now().UnixMilli()
+
+	firstPassIDs := make(map[uuid.UUID]struct{})
+	for seq := int64(0); seq < 10; seq++ {
+		id := NewDeterministicID(ts, seq)
+		firstPassIDs[id] = struct{}{}
+	}
+
+	for seq := int64(0); seq < 10; seq++ {
+		id := NewDeterministicID(ts, seq)
+		if _, ok := firstPassIDs[id]; !ok {
+			t.Errorf("ID %s not found in first pass IDs", id)
+		}
+	}
+}
+
+func BenchmarkDeterministicID(b *testing.B) {
+	ts := time.Now().UnixMilli()
+	for i := 0; i < b.N; i++ {
+		_ = NewDeterministicID(ts, int64(i))
+	}
+}
+
+func BenchmarkNewID(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = uuid.New()
+	}
+}


### PR DESCRIPTION
Introduces deterministic IDs for partition section cycles and added a test to verify that it works. IDs are generated based on the section's end ts and the number of blocks produced in that section.