### PR TITLE
slo: include all request cancellations within SLO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## main / unreleased
 * [FEATURE] tempo-cli: support dropping multiple traces in a single operation [#4266](https://github.com/grafana/tempo/pull/4266) (@ndk)
+* [CHANGE] slo: include all request cancellations within SLO [#4355] (https://github.com/grafana/tempo/pull/4355) (@electron0zero)
+  `tempo_query_frontend_queries_within_slo_total` is now more accurate by including all request cancellations within the SLO.
 * [CHANGE] update default config values to better align with production workloads [#4340](https://github.com/grafana/tempo/pull/4340) (@electron0zero)
 * [CHANGE] fix deprecation warning by switching to DoBatchWithOptions [#4343](https://github.com/grafana/tempo/pull/4343) (@dastrobu)
 * [CHANGE] **BREAKING CHANGE** The Tempo serverless is now deprecated and will be removed in an upcoming release [#4017](https://github.com/grafana/tempo/pull/4017/) @electron0zero

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## main / unreleased
 * [FEATURE] tempo-cli: support dropping multiple traces in a single operation [#4266](https://github.com/grafana/tempo/pull/4266) (@ndk)
 * [CHANGE] slo: include request cancellations within SLO [#4355] (https://github.com/grafana/tempo/pull/4355) (@electron0zero)
-  `tempo_query_frontend_queries_within_slo_total` includes request cancellations within the SLO, and provides `result` label with `completed`or `canceled` values to differentiate between completed and canceled requests.
+  request cancellations are exposed under `result` label in `tempo_query_frontend_queries_total` and `tempo_query_frontend_queries_within_slo_total` with `completed` or `canceled` values to differentiate between completed and canceled requests.
 * [CHANGE] update default config values to better align with production workloads [#4340](https://github.com/grafana/tempo/pull/4340) (@electron0zero)
 * [CHANGE] fix deprecation warning by switching to DoBatchWithOptions [#4343](https://github.com/grafana/tempo/pull/4343) (@dastrobu)
 * [CHANGE] **BREAKING CHANGE** The Tempo serverless is now deprecated and will be removed in an upcoming release [#4017](https://github.com/grafana/tempo/pull/4017/) @electron0zero

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## main / unreleased
 * [FEATURE] tempo-cli: support dropping multiple traces in a single operation [#4266](https://github.com/grafana/tempo/pull/4266) (@ndk)
-* [CHANGE] slo: include all request cancellations within SLO [#4355] (https://github.com/grafana/tempo/pull/4355) (@electron0zero)
-  `tempo_query_frontend_queries_within_slo_total` is now more accurate by including all request cancellations within the SLO.
+* [CHANGE] slo: include request cancellations within SLO [#4355] (https://github.com/grafana/tempo/pull/4355) (@electron0zero)
+  `tempo_query_frontend_queries_within_slo_total` includes request cancellations within the SLO, and provides `result` label with `completed`or `canceled` values to differentiate between completed and canceled requests.
 * [CHANGE] update default config values to better align with production workloads [#4340](https://github.com/grafana/tempo/pull/4340) (@electron0zero)
 * [CHANGE] fix deprecation warning by switching to DoBatchWithOptions [#4343](https://github.com/grafana/tempo/pull/4343) (@dastrobu)
 * [CHANGE] **BREAKING CHANGE** The Tempo serverless is now deprecated and will be removed in an upcoming release [#4017](https://github.com/grafana/tempo/pull/4017/) @electron0zero

--- a/example/docker-compose/local/tempo.yaml
+++ b/example/docker-compose/local/tempo.yaml
@@ -21,7 +21,12 @@ query_frontend:
         duration_slo: 5s
         throughput_bytes_slo: 1.073741824e+09
   trace_by_id:
+    duration_slo: 100ms
+  metrics:
+    max_duration: 120h                # maximum duration of a metrics query, increase for local setups
+    query_backend_after: 5m
     duration_slo: 5s
+    throughput_bytes_slo: 1.073741824e+09
 
 distributor:
   receivers:                           # this configuration will listen on all ports and protocols that tempo is capable of.
@@ -43,7 +48,7 @@ ingester:
 
 compactor:
   compaction:
-    block_retention: 1h                # overall Tempo trace retention. set for demo purposes
+    block_retention: 24h                # overall Tempo trace retention. set for demo purposes
 
 metrics_generator:
   registry:

--- a/modules/frontend/combiner/common.go
+++ b/modules/frontend/combiner/common.go
@@ -126,6 +126,8 @@ func (c *genericCombiner[T]) AddResponse(r PipelineResponse) error {
 
 // HTTPFinal, GRPCComplete, and GRPCDiff are all responsible for returning something
 // usable in grpc streaming/http response.
+// NOTE: returning error is reserved for unexpected errors, HTTP errors will be returned
+// in the response body. callers should check the http status code.
 func (c *genericCombiner[T]) HTTPFinal() (*http.Response, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/modules/frontend/combiner/common_test.go
+++ b/modules/frontend/combiner/common_test.go
@@ -231,8 +231,7 @@ func newTestResponse(t *testing.T) *testPipelineResponse {
 func newFailedTestResponse() *testPipelineResponse {
 	rec := httptest.NewRecorder()
 	rec.WriteHeader(http.StatusInternalServerError)
-	rec.Write([]byte("foo"))
-
+	_, _ = rec.Write([]byte("foo"))
 	return &testPipelineResponse{
 		r: rec.Result(),
 	}

--- a/modules/frontend/combiner/common_test.go
+++ b/modules/frontend/combiner/common_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gogo/status"
 	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/grafana/tempo/pkg/util"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 )
@@ -54,6 +55,17 @@ func TestErroredResponse(t *testing.T) {
 				Body:       io.NopCloser(strings.NewReader("foo")),
 			},
 			expectedErr: status.Error(codes.InvalidArgument, "foo"),
+		},
+		{
+			name:       "499",
+			statusCode: util.StatusClientClosedRequest,
+			respBody:   "foo",
+			expectedResp: &http.Response{
+				StatusCode: util.StatusClientClosedRequest,
+				Status:     util.StatusTextClientClosedRequest,
+				Body:       io.NopCloser(strings.NewReader("foo")),
+			},
+			expectedErr: status.Error(codes.Canceled, "foo"),
 		},
 	}
 

--- a/modules/frontend/combiner/common_test.go
+++ b/modules/frontend/combiner/common_test.go
@@ -231,6 +231,7 @@ func newTestResponse(t *testing.T) *testPipelineResponse {
 func newFailedTestResponse() *testPipelineResponse {
 	rec := httptest.NewRecorder()
 	rec.WriteHeader(http.StatusInternalServerError)
+	rec.Write([]byte("foo"))
 
 	return &testPipelineResponse{
 		r: rec.Result(),

--- a/modules/frontend/handler.go
+++ b/modules/frontend/handler.go
@@ -28,9 +28,9 @@ const (
 )
 
 var (
-	errCanceled              = httpgrpc.Errorf(util.StatusClientClosedRequest, context.Canceled.Error())
-	errDeadlineExceeded      = httpgrpc.Errorf(http.StatusGatewayTimeout, context.DeadlineExceeded.Error())
-	errRequestEntityTooLarge = httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "http: request body too large")
+	errCanceled              = httpgrpc.Error(util.StatusClientClosedRequest, context.Canceled.Error())
+	errDeadlineExceeded      = httpgrpc.Error(http.StatusGatewayTimeout, context.DeadlineExceeded.Error())
+	errRequestEntityTooLarge = httpgrpc.Error(http.StatusRequestEntityTooLarge, "http: request body too large")
 )
 
 // handler exists to wrap a roundtripper with an HTTP handler. It wraps all

--- a/modules/frontend/handler.go
+++ b/modules/frontend/handler.go
@@ -160,14 +160,9 @@ func writeError(w http.ResponseWriter, err error) error {
 		err = errCanceled
 	} else if errors.Is(err, context.DeadlineExceeded) {
 		err = errDeadlineExceeded
-	} else if isRequestBodyTooLarge(err) {
+	} else if util.IsRequestBodyTooLarge(err) {
 		err = errRequestEntityTooLarge
 	}
 	httpgrpc.WriteError(w, err)
 	return err
-}
-
-// isRequestBodyTooLarge returns true if the error is "http: request body too large".
-func isRequestBodyTooLarge(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "http: request body too large")
 }

--- a/modules/frontend/handler.go
+++ b/modules/frontend/handler.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/tempo/pkg/util"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -156,7 +157,7 @@ func copyHeader(dst, src http.Header) {
 // httpgrpc errors can bubble up to here and should be translated to http errors. It returns
 // httpgrpc error.
 func writeError(w http.ResponseWriter, err error) error {
-	if errors.Is(err, context.Canceled) {
+	if grpcutil.IsCanceled(err) {
 		err = errCanceled
 	} else if errors.Is(err, context.DeadlineExceeded) {
 		err = errDeadlineExceeded

--- a/modules/frontend/handler.go
+++ b/modules/frontend/handler.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/tempo/pkg/util"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
@@ -22,14 +23,12 @@ import (
 )
 
 const (
-	// StatusClientClosedRequest is the status code for when a client request cancellation of an http request
-	StatusClientClosedRequest = 499
 	// nil response in ServeHTTP
 	NilResponseError = "nil resp in ServeHTTP"
 )
 
 var (
-	errCanceled              = httpgrpc.Errorf(StatusClientClosedRequest, context.Canceled.Error())
+	errCanceled              = httpgrpc.Errorf(util.StatusClientClosedRequest, context.Canceled.Error())
 	errDeadlineExceeded      = httpgrpc.Errorf(http.StatusGatewayTimeout, context.DeadlineExceeded.Error())
 	errRequestEntityTooLarge = httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "http: request body too large")
 )
@@ -88,7 +87,7 @@ func (f *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		logMessage = append(
 			logMessage,
 			"status", statusCode,
-			"err", err.Error(),
+			"error", err.Error(),
 			"response_size", 0,
 		)
 		level.Info(f.logger).Log(logMessage...)

--- a/modules/frontend/pipeline/collector_grpc.go
+++ b/modules/frontend/pipeline/collector_grpc.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
@@ -83,5 +84,11 @@ func grpcError(err error) error {
 		return err
 	}
 
+	// if this is context cancelled, we return a grpc cancelled error
+	if errors.Is(err, context.Canceled) {
+		return status.Error(codes.Canceled, err.Error())
+	}
+
+	// rest all fall into internal server error
 	return status.Error(codes.Internal, err.Error())
 }

--- a/modules/frontend/pipeline/collector_grpc.go
+++ b/modules/frontend/pipeline/collector_grpc.go
@@ -28,24 +28,33 @@ func NewGRPCCollector[T combiner.TResponse](next AsyncRoundTripper[combiner.Pipe
 	}
 }
 
-// Handle
+// RoundTrip implements the http.RoundTripper interface
 func (c GRPCCollector[T]) RoundTrip(req *http.Request) error {
 	ctx := req.Context()
 	ctx, cancel := context.WithCancel(ctx) // create a new context with a cancel function
 	defer cancel()
+
+	ctx, span := tracer.Start(ctx, "GRPCCollector.RoundTrip")
+	defer span.End()
 
 	req = req.WithContext(ctx)
 	resps, err := c.next.RoundTrip(NewHTTPRequest(req))
 	if err != nil {
 		return grpcError(err)
 	}
+	span.AddEvent("next.RoundTrip done")
 
 	lastUpdate := time.Now()
-
-	err = consumeAndCombineResponses(ctx, c.consumers, resps, c.combiner, func() error {
+	// sendDiffCb should return an error if the context is cancelled,
+	// callback's error is used to exit early from the loop and return the error to the caller
+	sendDiffCb := func() error {
 		// check if we should send an update
 		if time.Since(lastUpdate) > 500*time.Millisecond {
 			lastUpdate = time.Now()
+			// check and return the context errors, like ctx cancelled, etc
+			if req.Context().Err() != nil {
+				return req.Context().Err()
+			}
 
 			// send a diff only during streaming
 			resp, err := c.combiner.GRPCDiff()
@@ -59,15 +68,23 @@ func (c GRPCCollector[T]) RoundTrip(req *http.Request) error {
 		}
 
 		return nil
-	})
+	}
+
+	err = consumeAndCombineResponses(ctx, c.consumers, resps, c.combiner, sendDiffCb)
 	if err != nil {
 		return grpcError(err)
 	}
+	span.AddEvent("consumeAndCombineResponses done")
 
 	// send the final diff if there is anything left
 	resp, err := c.combiner.GRPCDiff()
 	if err != nil {
 		return grpcError(err)
+	}
+	span.AddEvent("final combiner.GRPCDiff() done")
+	// check and return the context errors, like ctx cancelled, etc
+	if req.Context().Err() != nil {
+		return grpcError(req.Context().Err())
 	}
 	err = c.send(resp)
 	if err != nil {

--- a/modules/frontend/search_handlers_test.go
+++ b/modules/frontend/search_handlers_test.go
@@ -295,7 +295,7 @@ func runnerClientCancelContext(t *testing.T, f *QueryFrontend) {
 	}()
 	grpcReq := &tempopb.SearchRequest{}
 	err := f.streamingSearch(grpcReq, srv)
-	require.Equal(t, status.Error(codes.Internal, "context canceled"), err)
+	require.Equal(t, status.Error(codes.Canceled, "context canceled"), err)
 }
 
 func TestSearchLimitHonored(t *testing.T) {

--- a/modules/frontend/slos.go
+++ b/modules/frontend/slos.go
@@ -44,7 +44,7 @@ var (
 		Namespace: "tempo",
 		Name:      "query_frontend_queries_total",
 		Help:      "Total queries received per tenant.",
-	}, []string{"tenant", "op"})
+	}, []string{"tenant", "op", "result"})
 
 	traceByIDCounter = queriesPerTenant.MustCurryWith(prometheus.Labels{"op": traceByIDOp})
 	searchCounter    = queriesPerTenant.MustCurryWith(prometheus.Labels{"op": searchOp})
@@ -89,36 +89,45 @@ func metricsSLOPostHook(cfg SLOConfig) handlerPostHook {
 
 func sloHook(allByTenantCounter, withinSLOByTenantCounter *prometheus.CounterVec, throughputVec prometheus.ObserverVec, cfg SLOConfig) handlerPostHook {
 	return func(resp *http.Response, tenant string, bytesProcessed uint64, latency time.Duration, err error) {
-		// first record all queries
-		allByTenantCounter.WithLabelValues(tenant).Inc()
-
-		// most errors are SLO violations
+		// most errors are SLO violations but we have few exceptions.
 		if err != nil {
 			// However, gRPC resource exhausted error (429), invalid argument (400), not found (404) and
 			// request cancellations are considered within the SLO.
 			switch status.Code(err) {
 			case codes.ResourceExhausted, codes.InvalidArgument, codes.NotFound:
+				allByTenantCounter.WithLabelValues(tenant, resultCompleted).Inc()
 				withinSLOByTenantCounter.WithLabelValues(tenant, resultCompleted).Inc()
 				return
 			}
 
 			if grpcutil.IsCanceled(err) {
+				allByTenantCounter.WithLabelValues(tenant, resultCanceled).Inc()
 				withinSLOByTenantCounter.WithLabelValues(tenant, resultCanceled).Inc()
 				return
 			}
 
 			// check for the response and 499 in the status code, can come from http pipeline along with error
 			if resp != nil && resp.StatusCode == util.StatusClientClosedRequest {
+				allByTenantCounter.WithLabelValues(tenant, resultCanceled).Inc()
 				withinSLOByTenantCounter.WithLabelValues(tenant, resultCanceled).Inc()
+				return
 			}
+
+			// in case we have error, that doesn't fall into the above categories, it's a SLO violation
+			// so only increment the allByTenantCounter
+			allByTenantCounter.WithLabelValues(tenant, resultCompleted).Inc()
 			return
 		}
 
 		// we don't always get error in case of http pipeline, check for 499 status code
 		if resp != nil && resp.StatusCode == util.StatusClientClosedRequest {
+			allByTenantCounter.WithLabelValues(tenant, resultCanceled).Inc()
 			withinSLOByTenantCounter.WithLabelValues(tenant, resultCanceled).Inc()
 			return
 		}
+
+		// record all queries
+		allByTenantCounter.WithLabelValues(tenant, resultCompleted).Inc()
 
 		// all 200s/300s/400s are success
 		if resp != nil && resp.StatusCode >= 500 {

--- a/modules/frontend/slos_test.go
+++ b/modules/frontend/slos_test.go
@@ -26,29 +26,30 @@ func TestSLOHook(t *testing.T) {
 		latency        time.Duration
 		err            error
 
-		expectedWithSLO float64
+		expectedWithInSLO  float64
+		cancelledWithinSLO float64
 	}{
 		{
-			name:            "no slo passes",
-			expectedWithSLO: 1.0,
+			name:              "no slo passes",
+			expectedWithInSLO: 1.0,
 		},
 		{
 			name: "no slo fails : error",
 			err:  errors.New("foo"),
 		},
 		{
-			name:            "no slo passes : resource exhausted grpc error",
-			err:             status.Error(codes.ResourceExhausted, "foo"),
-			expectedWithSLO: 1.0,
+			name:              "no slo passes : resource exhausted grpc error",
+			err:               status.Error(codes.ResourceExhausted, "foo"),
+			expectedWithInSLO: 1.0,
 		},
 		{
 			name:           "no slo fails : 5XX status code",
 			httpStatusCode: http.StatusInternalServerError,
 		},
 		{
-			name:            "no slo passes : 4XX status code",
-			httpStatusCode:  http.StatusTooManyRequests,
-			expectedWithSLO: 1.0,
+			name:              "no slo passes : 4XX status code",
+			httpStatusCode:    http.StatusTooManyRequests,
+			expectedWithInSLO: 1.0,
 		},
 		{
 			name: "slo passes - both",
@@ -56,19 +57,19 @@ func TestSLOHook(t *testing.T) {
 				DurationSLO:        10 * time.Second,
 				ThroughputBytesSLO: 100,
 			},
-			latency:         5 * time.Second,
-			bytesProcessed:  110,
-			expectedWithSLO: 1.0,
+			latency:           5 * time.Second,
+			bytesProcessed:    110,
+			expectedWithInSLO: 1.0,
 		},
 		{
-			name: "slo passes - duration",
+			name: "slo passes - latency",
 			cfg: SLOConfig{
 				DurationSLO:        10 * time.Second,
 				ThroughputBytesSLO: 100,
 			},
-			latency:         5 * time.Second,
-			bytesProcessed:  90,
-			expectedWithSLO: 1.0,
+			latency:           5 * time.Second,
+			bytesProcessed:    90,
+			expectedWithInSLO: 1.0,
 		},
 		{
 			name: "slo passes - throughput",
@@ -76,27 +77,27 @@ func TestSLOHook(t *testing.T) {
 				DurationSLO:        10 * time.Second,
 				ThroughputBytesSLO: 100,
 			},
-			latency:         15 * time.Second,
-			bytesProcessed:  1650, // 15s * 110 bytes/s
-			expectedWithSLO: 1.0,
+			latency:           15 * time.Second,
+			bytesProcessed:    1650, // 15s * 110 bytes/s
+			expectedWithInSLO: 1.0,
 		},
 		{
 			name: "slo passes - no throughput configured",
 			cfg: SLOConfig{
 				DurationSLO: 10 * time.Second,
 			},
-			latency:         5 * time.Second,
-			bytesProcessed:  1,
-			expectedWithSLO: 1.0,
+			latency:           5 * time.Second,
+			bytesProcessed:    1,
+			expectedWithInSLO: 1.0,
 		},
 		{
-			name: "slo passes - no duration configured",
+			name: "slo passes - no latency configured",
 			cfg: SLOConfig{
 				ThroughputBytesSLO: 100,
 			},
-			latency:         15 * time.Second,
-			bytesProcessed:  1650, // 15s * 110 bytes/s
-			expectedWithSLO: 1.0,
+			latency:           15 * time.Second,
+			bytesProcessed:    1650, // 15s * 110 bytes/s
+			expectedWithInSLO: 1.0,
 		},
 		{
 			name: "slo fails - no throughput configured",
@@ -107,7 +108,7 @@ func TestSLOHook(t *testing.T) {
 			bytesProcessed: 1,
 		},
 		{
-			name: "slo fails - no duration configured",
+			name: "slo fails - no latency configured",
 			cfg: SLOConfig{
 				ThroughputBytesSLO: 100,
 			},
@@ -119,7 +120,7 @@ func TestSLOHook(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			allCounter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "all"}, []string{"tenant"})
-			sloCounter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "slo"}, []string{"tenant"})
+			sloCounter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "slo"}, []string{"tenant", "result"})
 			throughputVec := prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "throughput"}, []string{"tenant"})
 
 			hook := sloHook(allCounter, sloCounter, throughputVec, tc.cfg)
@@ -128,22 +129,24 @@ func TestSLOHook(t *testing.T) {
 				StatusCode: tc.httpStatusCode,
 			}
 
-			hook(resp, "tenant", uint64(tc.bytesProcessed), tc.latency, tc.err)
+			hook(resp, "test", uint64(tc.bytesProcessed), tc.latency, tc.err)
 
-			actualAll, err := test.GetCounterValue(allCounter.WithLabelValues("tenant"))
+			actualAll, err := test.GetCounterValue(allCounter.WithLabelValues("test"))
 			require.NoError(t, err)
-			actualSLO, err := test.GetCounterValue(sloCounter.WithLabelValues("tenant"))
-			require.NoError(t, err)
-
 			require.Equal(t, 1.0, actualAll)
-			require.Equal(t, tc.expectedWithSLO, actualSLO)
+
+			completedWithInSLO, err := test.GetCounterValue(sloCounter.WithLabelValues("test", resultCompleted))
+			cancelledWithInSLO, err := test.GetCounterValue(sloCounter.WithLabelValues("test", resultCanceled))
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedWithInSLO, completedWithInSLO+cancelledWithInSLO)
+			require.Equal(t, tc.cancelledWithinSLO, cancelledWithInSLO)
 		})
 	}
 }
 
 func TestBadRequest(t *testing.T) {
 	allCounter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "all"}, []string{"tenant"})
-	sloCounter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "slo"}, []string{"tenant"})
+	sloCounter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "slo"}, []string{"tenant", "result"})
 	throughputVec := prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "throughput"}, []string{"tenant"})
 
 	hook := sloHook(allCounter, sloCounter, throughputVec, SLOConfig{
@@ -157,86 +160,157 @@ func TestBadRequest(t *testing.T) {
 		Body:       io.NopCloser(strings.NewReader("foo")),
 	}
 
-	hook(res, "tenant", 0, 0, nil)
+	hook(res, "test", 0, 0, nil)
 
-	actualAll, err := test.GetCounterValue(allCounter.WithLabelValues("tenant"))
+	actualAll, err := test.GetCounterValue(allCounter.WithLabelValues("test"))
 	require.NoError(t, err)
-	actualSLO, err := test.GetCounterValue(sloCounter.WithLabelValues("tenant"))
-	require.NoError(t, err)
-
 	require.Equal(t, 1.0, actualAll)
-	require.Equal(t, 1.0, actualSLO)
+
+	completedWithInSLO, err := test.GetCounterValue(sloCounter.WithLabelValues("test", resultCompleted))
+	cancelledWithInSLO, err := test.GetCounterValue(sloCounter.WithLabelValues("test", resultCanceled))
+	require.NoError(t, err)
+	require.Equal(t, 1.0, completedWithInSLO+cancelledWithInSLO)
+	require.Equal(t, 0.0, cancelledWithInSLO)
 }
 
 func TestCanceledRequest(t *testing.T) {
 	tests := []struct {
-		name       string
-		statusCode int
-		err        error
-		withInSLO  bool
+		name               string
+		statusCode         int
+		latency            time.Duration
+		err                error
+		totalWithInSLO     float64
+		cancelledWithinSLO float64
 	}{
 		{
-			name:       "random error with http response has 499 status code",
-			statusCode: util.StatusClientClosedRequest,
-			err:        errors.New("foo"),
-			withInSLO:  true,
+			name:               "random error with http response has 499 status code",
+			statusCode:         util.StatusClientClosedRequest,
+			err:                errors.New("foo"),
+			latency:            5 * time.Second,
+			totalWithInSLO:     1.0,
+			cancelledWithinSLO: 1.0,
 		},
 		{
-			name:       "context.Canceled error with http response has 499 status code",
-			statusCode: util.StatusClientClosedRequest,
-			err:        context.Canceled,
-			withInSLO:  true,
+			name:               "random error with http response has 499 status code and 15s latency",
+			statusCode:         util.StatusClientClosedRequest,
+			err:                errors.New("foo"),
+			latency:            15 * time.Second, // latency > DurationSLO shouldn't be impacted
+			totalWithInSLO:     1.0,
+			cancelledWithinSLO: 1.0,
 		},
 		{
-			name:       "context.Canceled error with 500 status code",
+			name:               "nil error with http response has 499 status code",
+			statusCode:         util.StatusClientClosedRequest,
+			err:                nil,
+			latency:            5 * time.Second,
+			totalWithInSLO:     1.0,
+			cancelledWithinSLO: 1.0,
+		},
+		{
+			name:               "nil error with http response has 499 status code and 15s latency",
+			statusCode:         util.StatusClientClosedRequest,
+			err:                nil,
+			latency:            15 * time.Second,
+			totalWithInSLO:     1.0,
+			cancelledWithinSLO: 1.0,
+		},
+		{
+			name:               "context.Canceled error with http response has 499 status code",
+			statusCode:         util.StatusClientClosedRequest,
+			err:                context.Canceled,
+			latency:            15 * time.Second,
+			totalWithInSLO:     1.0,
+			cancelledWithinSLO: 1.0,
+		},
+		{
+			name:               "context.Canceled error with 500 status code",
+			statusCode:         http.StatusInternalServerError,
+			err:                context.Canceled,
+			latency:            15 * time.Second,
+			totalWithInSLO:     1.0,
+			cancelledWithinSLO: 1.0,
+		},
+		{
+			name:               "context.Canceled error with 200 status code",
+			statusCode:         http.StatusOK,
+			err:                context.Canceled,
+			latency:            15 * time.Second,
+			totalWithInSLO:     1.0,
+			cancelledWithinSLO: 1.0,
+		},
+		{
+			name:               "grpc codes.Canceled error with 500 status code",
+			statusCode:         http.StatusInternalServerError,
+			err:                status.Error(codes.Canceled, "foo"),
+			latency:            15 * time.Second,
+			totalWithInSLO:     1.0,
+			cancelledWithinSLO: 1.0,
+		},
+		{
+			name:           "grpc codes.ResourceExhausted error with 500 status code",
+			statusCode:     http.StatusInternalServerError,
+			err:            status.Error(codes.ResourceExhausted, "foo"),
+			latency:        15 * time.Second,
+			totalWithInSLO: 1.0,
+		},
+		{
+			name:           "grpc codes.InvalidArgument error with 500 status code",
+			statusCode:     http.StatusInternalServerError,
+			err:            status.Error(codes.InvalidArgument, "foo"),
+			latency:        15 * time.Second,
+			totalWithInSLO: 1.0,
+		},
+		{
+			name:           "grpc codes.NotFound error with 500 status code",
+			statusCode:     http.StatusInternalServerError,
+			err:            status.Error(codes.NotFound, "foo"),
+			latency:        15 * time.Second,
+			totalWithInSLO: 1.0,
+		},
+		{
+			name:       "nil error with 500 status code and 15s latency",
 			statusCode: http.StatusInternalServerError,
-			err:        context.Canceled,
-			withInSLO:  true,
+			err:        nil,
+			latency:    15 * time.Second,
 		},
 		{
-			name:       "context.Canceled error with 200 status code",
-			statusCode: http.StatusOK,
-			err:        context.Canceled,
-			withInSLO:  true,
+			name:               "nil error with http response has 499 status code",
+			statusCode:         util.StatusClientClosedRequest,
+			err:                nil,
+			latency:            15 * time.Second,
+			totalWithInSLO:     1.0,
+			cancelledWithinSLO: 1.0,
 		},
 		{
-			name:       "grpc codes.Canceled error with 500 status code",
-			statusCode: http.StatusInternalServerError,
-			err:        status.Error(codes.Canceled, "foo"),
-			withInSLO:  true,
+			name:               "grpc codes.Canceled error with 200 status code",
+			statusCode:         http.StatusOK,
+			err:                status.Error(codes.Canceled, "foo"),
+			latency:            15 * time.Second,
+			totalWithInSLO:     1.0,
+			cancelledWithinSLO: 1.0,
 		},
 		{
-			name:       "grpc codes.Canceled error with 200 status code",
-			statusCode: http.StatusOK,
-			err:        status.Error(codes.Canceled, "foo"),
-			withInSLO:  true,
-		},
-		{
-			name:       "no error with 200 status code",
+			name:       "nil error with 200 status code and 15s latency",
 			statusCode: http.StatusOK,
 			err:        nil,
-			withInSLO:  false,
+			latency:    15 * time.Second,
 		},
 		{
-			name:       "no error with 500 status code",
-			statusCode: http.StatusInternalServerError,
-			err:        nil,
-			withInSLO:  false,
-		},
-		{
-			name:       "no error with http response has 499 status code",
-			statusCode: util.StatusClientClosedRequest,
-			err:        nil,
-			withInSLO:  false,
+			name:           "nil error with 200 status code and 5s latency",
+			statusCode:     http.StatusOK,
+			err:            nil,
+			latency:        5 * time.Second,
+			totalWithInSLO: 1.0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			allCounter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "all"}, []string{"tenant"})
-			sloCounter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "slo"}, []string{"tenant"})
+			sloCounter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "slo"}, []string{"tenant", "result"})
 			throughputVec := prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "throughput"}, []string{"tenant"})
 
+			// anything over 10s is considered outside SLO
 			hook := sloHook(allCounter, sloCounter, throughputVec, SLOConfig{
 				DurationSLO:        10 * time.Second,
 				ThroughputBytesSLO: 100,
@@ -248,20 +322,17 @@ func TestCanceledRequest(t *testing.T) {
 				Body:       io.NopCloser(strings.NewReader("foo")),
 			}
 
-			// latency is below DurationSLO threshold
-			hook(res, "tenant", 0, 15*time.Second, tt.err)
+			hook(res, "test", 0, tt.latency, tt.err)
 
-			actualAll, err := test.GetCounterValue(allCounter.WithLabelValues("tenant"))
+			actualAll, err := test.GetCounterValue(allCounter.WithLabelValues("test"))
 			require.NoError(t, err)
 			require.Equal(t, 1.0, actualAll)
 
-			actualSLO, err := test.GetCounterValue(sloCounter.WithLabelValues("tenant"))
+			completedWithInSLO, err := test.GetCounterValue(sloCounter.WithLabelValues("test", resultCompleted))
+			cancelledWithInSLO, err := test.GetCounterValue(sloCounter.WithLabelValues("test", resultCanceled))
 			require.NoError(t, err)
-			if tt.withInSLO {
-				require.Equal(t, 1.0, actualSLO)
-			} else {
-				require.Equal(t, 0.0, actualSLO)
-			}
+			require.Equal(t, tt.totalWithInSLO, completedWithInSLO+cancelledWithInSLO)
+			require.Equal(t, tt.cancelledWithinSLO, cancelledWithInSLO)
 		})
 	}
 }

--- a/modules/frontend/slos_test.go
+++ b/modules/frontend/slos_test.go
@@ -1,6 +1,7 @@
 package frontend
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -8,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/pkg/util/test"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
@@ -164,4 +166,102 @@ func TestBadRequest(t *testing.T) {
 
 	require.Equal(t, 1.0, actualAll)
 	require.Equal(t, 1.0, actualSLO)
+}
+
+func TestCanceledRequest(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		err        error
+		withInSLO  bool
+	}{
+		{
+			name:       "random error with http response has 499 status code",
+			statusCode: util.StatusClientClosedRequest,
+			err:        errors.New("foo"),
+			withInSLO:  true,
+		},
+		{
+			name:       "context.Canceled error with http response has 499 status code",
+			statusCode: util.StatusClientClosedRequest,
+			err:        context.Canceled,
+			withInSLO:  true,
+		},
+		{
+			name:       "context.Canceled error with 500 status code",
+			statusCode: http.StatusInternalServerError,
+			err:        context.Canceled,
+			withInSLO:  true,
+		},
+		{
+			name:       "context.Canceled error with 200 status code",
+			statusCode: http.StatusOK,
+			err:        context.Canceled,
+			withInSLO:  true,
+		},
+		{
+			name:       "grpc codes.Canceled error with 500 status code",
+			statusCode: http.StatusInternalServerError,
+			err:        status.Error(codes.Canceled, "foo"),
+			withInSLO:  true,
+		},
+		{
+			name:       "grpc codes.Canceled error with 200 status code",
+			statusCode: http.StatusOK,
+			err:        status.Error(codes.Canceled, "foo"),
+			withInSLO:  true,
+		},
+		{
+			name:       "no error with 200 status code",
+			statusCode: http.StatusOK,
+			err:        nil,
+			withInSLO:  false,
+		},
+		{
+			name:       "no error with 500 status code",
+			statusCode: http.StatusInternalServerError,
+			err:        nil,
+			withInSLO:  false,
+		},
+		{
+			name:       "no error with http response has 499 status code",
+			statusCode: util.StatusClientClosedRequest,
+			err:        nil,
+			withInSLO:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			allCounter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "all"}, []string{"tenant"})
+			sloCounter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "slo"}, []string{"tenant"})
+			throughputVec := prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "throughput"}, []string{"tenant"})
+
+			hook := sloHook(allCounter, sloCounter, throughputVec, SLOConfig{
+				DurationSLO:        10 * time.Second,
+				ThroughputBytesSLO: 100,
+			})
+
+			res := &http.Response{
+				StatusCode: tt.statusCode,
+				Status:     "context canceled",
+				Body:       io.NopCloser(strings.NewReader("foo")),
+			}
+
+			// latency is below DurationSLO threshold
+			hook(res, "tenant", 0, 15*time.Second, tt.err)
+
+			actualAll, err := test.GetCounterValue(allCounter.WithLabelValues("tenant"))
+			require.NoError(t, err)
+			require.Equal(t, 1.0, actualAll)
+
+			actualSLO, err := test.GetCounterValue(sloCounter.WithLabelValues("tenant"))
+			require.NoError(t, err)
+			if tt.withInSLO {
+				require.Equal(t, 1.0, actualSLO)
+			} else {
+				require.Equal(t, 0.0, actualSLO)
+			}
+		})
+	}
 }

--- a/modules/frontend/slos_test.go
+++ b/modules/frontend/slos_test.go
@@ -136,6 +136,7 @@ func TestSLOHook(t *testing.T) {
 			require.Equal(t, 1.0, actualAll)
 
 			completedWithInSLO, err := test.GetCounterValue(sloCounter.WithLabelValues("test", resultCompleted))
+			require.NoError(t, err)
 			cancelledWithInSLO, err := test.GetCounterValue(sloCounter.WithLabelValues("test", resultCanceled))
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedWithInSLO, completedWithInSLO+cancelledWithInSLO)
@@ -167,6 +168,7 @@ func TestBadRequest(t *testing.T) {
 	require.Equal(t, 1.0, actualAll)
 
 	completedWithInSLO, err := test.GetCounterValue(sloCounter.WithLabelValues("test", resultCompleted))
+	require.NoError(t, err)
 	cancelledWithInSLO, err := test.GetCounterValue(sloCounter.WithLabelValues("test", resultCanceled))
 	require.NoError(t, err)
 	require.Equal(t, 1.0, completedWithInSLO+cancelledWithInSLO)
@@ -329,6 +331,7 @@ func TestCanceledRequest(t *testing.T) {
 			require.Equal(t, 1.0, actualAll)
 
 			completedWithInSLO, err := test.GetCounterValue(sloCounter.WithLabelValues("test", resultCompleted))
+			require.NoError(t, err)
 			cancelledWithInSLO, err := test.GetCounterValue(sloCounter.WithLabelValues("test", resultCanceled))
 			require.NoError(t, err)
 			require.Equal(t, tt.totalWithInSLO, completedWithInSLO+cancelledWithInSLO)

--- a/modules/frontend/tag_handlers_test.go
+++ b/modules/frontend/tag_handlers_test.go
@@ -128,7 +128,7 @@ func runnerTagsV2ClientCancelContext(t *testing.T, f *QueryFrontend) {
 	}()
 	grpcReq := &tempopb.SearchTagsRequest{}
 	err := f.streamingTagsV2(grpcReq, srv)
-	require.Equal(t, status.Error(codes.Internal, "context canceled"), err)
+	require.Equal(t, status.Error(codes.Canceled, "context canceled"), err)
 }
 
 func runnerTagValuesV2ClientCancelContext(t *testing.T, f *QueryFrontend) {
@@ -160,7 +160,7 @@ func runnerTagValuesV2ClientCancelContext(t *testing.T, f *QueryFrontend) {
 		TagName: "foo",
 	}
 	err := f.streamingTagValuesV2(grpcReq, srv)
-	require.Equal(t, status.Error(codes.Internal, "context canceled"), err)
+	require.Equal(t, status.Error(codes.Canceled, "context canceled"), err)
 }
 
 // todo: a lot of code is replicated between all of these "failure propagates from queriers" tests. we should refactor

--- a/modules/querier/querier_query_range.go
+++ b/modules/querier/querier_query_range.go
@@ -50,7 +50,7 @@ func (q *Querier) queryRangeRecent(ctx context.Context, req *tempopb.QueryRangeR
 	}
 	err = q.forGivenGenerators(ctx, replicationSet, forEach)
 	if err != nil {
-		_ = level.Error(log.Logger).Log("error querying generators in Querier.queryRangeRecent", "err", err)
+		_ = level.Error(log.Logger).Log("msg", "error querying generators in Querier.queryRangeRecent", "err", err)
 		return nil, fmt.Errorf("error querying generators in Querier.queryRangeRecent: %w", err)
 	}
 

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -3,34 +3,26 @@ package util
 import (
 	"errors"
 	"fmt"
-
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	"net/http"
 )
 
 var (
 	// ErrTraceNotFound can be used when we don't find a trace
 	ErrTraceNotFound = errors.New("trace not found")
 
-	// ErrSearchKeyValueNotFound is used to indicate the requested key/value pair was not found.
-	ErrSearchKeyValueNotFound = errors.New("key/value not found")
+	// StatusClientClosedRequest is the status code for when a client request cancellation of an http request
+	StatusClientClosedRequest     = 499
+	StatusTextClientClosedRequest = "Request Cancelled"
 
 	ErrUnsupported = fmt.Errorf("unsupported")
 )
 
-// IsConnCanceled returns true, if error is from a closed gRPC connection.
-// copied from https://github.com/etcd-io/etcd/blob/7f47de84146bdc9225d2080ec8678ca8189a2d2b/clientv3/client.go#L646
-func IsConnCanceled(err error) bool {
-	if err == nil {
-		return false
+func StatusText(code int) string {
+	switch code {
+	case StatusClientClosedRequest:
+		// 499 doesn't have status text in http package, so we define it here
+		return StatusTextClientClosedRequest
+	default:
+		return http.StatusText(code)
 	}
-
-	// >= gRPC v1.23.x
-	s, ok := status.FromError(err)
-	if ok {
-		// connection is canceled or server has already closed the connection
-		return s.Code() == codes.Canceled || s.Message() == "transport is closing"
-	}
-
-	return false
 }


### PR DESCRIPTION
**What this PR does**:
We count all request cancellations outside SLO, but that's not right because request cancellations are done by users and should fall within SLO.

Request cancellations are now exposed under `result` label in `tempo_query_frontend_queries_total` and `tempo_query_frontend_queries_within_slo_total` with `completed` or `canceled` values to differentiate between completed and canceled requests.

operators can filter `tempo_query_frontend_queries_within_slo_total` with `result=completed` to get the old behaviour of the metric where cancellations where excluded from the  metric.

with the result label, we also expose the information about the cancelled requests, and you can filter on `result=canceled` to see cancelled requests.

I also added a span and span events in the http and gRPC collector to expose more details of the pipeline.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`