### PR TITLE
Exemplar fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 * [BUGFIX] Pushes a 0 to classic histogram's counter when the series is new to allow Prometheus to start from a non-null value. [#4140](https://github.com/grafana/tempo/pull/4140) (@mapno)
 * [BUGFIX] Fix counter samples being downsampled by backdate to the previous minute the initial sample when the series is new [#4236](https://github.com/grafana/tempo/pull/4236) (@javiermolinar)
 * [BUGFIX] Fix traceql metrics time range handling at the cutoff between recent and backend data [#4257](https://github.com/grafana/tempo/issues/4257) (@mdisibio)
+* [BUGFIX] Fix several issues with exemplar values for traceql metrics [#4366](https://github.com/grafana/tempo/pull/4366) (@mdisibio)
 * [BUGFIX] Skip computing exemplars for instant queries. [#4204](https://github.com/grafana/tempo/pull/4204) (@javiermolinar)
 * [BUGFIX] Gave context to orphaned spans related to various maintenance processes. [#4260](https://github.com/grafana/tempo/pull/4260) (@joe-elliott)
 * [BUGFIX] Utilize S3Pass and S3User parameters in tempo-cli options, which were previously unused in the code. [#4259](https://github.com/grafana/tempo/pull/4259) (@faridtmammadov)

--- a/pkg/traceql/ast.go
+++ b/pkg/traceql/ast.go
@@ -1106,33 +1106,23 @@ func (a *MetricsAggregate) init(q *tempopb.QueryRangeRequest, mode AggregateMode
 	var innerAgg func() VectorAggregator
 	var byFunc func(Span) (Static, bool)
 	var byFuncLabel string
-	var exemplarFn getExemplar
 
 	switch a.op {
 	case metricsAggregateCountOverTime:
 		innerAgg = func() VectorAggregator { return NewCountOverTimeAggregator() }
 		a.simpleAggregationOp = sumAggregation
-		exemplarFn = func(s Span) (float64, uint64) {
-			return math.NaN(), a.spanStartTimeMs(s)
-		}
+
 	case metricsAggregateMinOverTime:
 		innerAgg = func() VectorAggregator { return NewOverTimeAggregator(a.attr, minAggregation) }
 		a.simpleAggregationOp = minAggregation
-		exemplarFn = func(s Span) (float64, uint64) {
-			return math.NaN(), a.spanStartTimeMs(s)
-		}
+
 	case metricsAggregateMaxOverTime:
 		innerAgg = func() VectorAggregator { return NewOverTimeAggregator(a.attr, maxAggregation) }
 		a.simpleAggregationOp = maxAggregation
-		exemplarFn = func(s Span) (float64, uint64) {
-			return math.NaN(), a.spanStartTimeMs(s)
-		}
+
 	case metricsAggregateRate:
 		innerAgg = func() VectorAggregator { return NewRateAggregator(1.0 / time.Duration(q.Step).Seconds()) }
 		a.simpleAggregationOp = sumAggregation
-		exemplarFn = func(s Span) (float64, uint64) {
-			return math.NaN(), a.spanStartTimeMs(s)
-		}
 
 	case metricsAggregateHistogramOverTime, metricsAggregateQuantileOverTime:
 		// Histograms and quantiles are implemented as count_over_time() by(2^log2(attr)) for now
@@ -1144,16 +1134,9 @@ func (a *MetricsAggregate) init(q *tempopb.QueryRangeRequest, mode AggregateMode
 		case IntrinsicDurationAttribute:
 			// Optimal implementation for duration attribute
 			byFunc = a.bucketizeSpanDuration
-			exemplarFn = func(s Span) (float64, uint64) {
-				return float64(s.DurationNanos()), a.spanStartTimeMs(s)
-			}
 		default:
 			// Basic implementation for all other attributes
 			byFunc = a.bucketizeAttribute
-			exemplarFn = func(s Span) (float64, uint64) {
-				v, _ := FloatizeAttribute(s, a.attr)
-				return v, a.spanStartTimeMs(s)
-			}
 		}
 	}
 
@@ -1170,11 +1153,7 @@ func (a *MetricsAggregate) init(q *tempopb.QueryRangeRequest, mode AggregateMode
 	a.agg = NewGroupingAggregator(a.op.String(), func() RangeAggregator {
 		return NewStepAggregator(q.Start, q.End, q.Step, innerAgg)
 	}, a.by, byFunc, byFuncLabel)
-	a.exemplarFn = exemplarFn
-}
-
-func (a *MetricsAggregate) spanStartTimeMs(s Span) uint64 {
-	return s.StartTimeUnixNanos() / uint64(time.Millisecond)
+	a.exemplarFn = exemplarFnFor(a.attr)
 }
 
 func (a *MetricsAggregate) bucketizeSpanDuration(s Span) (Static, bool) {
@@ -1206,6 +1185,39 @@ func (a *MetricsAggregate) bucketizeAttribute(s Span) (Static, bool) {
 		// TODO(mdisibio) - Add support for floats, we need to map them into buckets.
 		// Because of the range of floats, we need a native histogram approach.
 		return NewStaticNil(), false
+	}
+}
+
+func exemplarFnFor(a Attribute) func(Span) (float64, uint64) {
+	switch a {
+	case IntrinsicDurationAttribute:
+		return exemplarDuration
+	case Attribute{}:
+		// This records exemplars without a value, and they
+		// are attached to the series at the end.
+		return exemplarNaN
+	default:
+		return exemplarAttribute(a)
+	}
+}
+
+func exemplarNaN(s Span) (float64, uint64) {
+	return math.NaN(), s.StartTimeUnixNanos() / uint64(time.Millisecond)
+}
+
+func exemplarDuration(s Span) (float64, uint64) {
+	v := float64(s.DurationNanos()) / float64(time.Second)
+	t := s.StartTimeUnixNanos() / uint64(time.Millisecond)
+	return v, t
+}
+
+// exemplarAttribute captures a closure around the attribute so it doesn't have to be passed along with every span.
+// should be more efficient.
+func exemplarAttribute(a Attribute) func(Span) (float64, uint64) {
+	return func(s Span) (float64, uint64) {
+		v, _ := FloatizeAttribute(s, a)
+		t := s.StartTimeUnixNanos() / uint64(time.Millisecond)
+		return v, t
 	}
 }
 

--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -1233,13 +1233,9 @@ func (b *SimpleAggregator) aggregateExemplars(ts *tempopb.TimeSeries, existing *
 				Value: StaticFromAnyValue(l.Value),
 			})
 		}
-		value := exemplar.Value
-		/*if math.IsNaN(value) {
-			value = 0 // TODO: Use the value of the series at the same timestamp
-		}*/
 		existing.Exemplars = append(existing.Exemplars, Exemplar{
 			Labels:      labels,
-			Value:       value,
+			Value:       exemplar.Value,
 			TimestampMs: uint64(exemplar.TimestampMs),
 		})
 	}


### PR DESCRIPTION
**What this PR does**:
Fixes several issues with exemplars that were found when testing: https://github.com/grafana/grafana/pull/96859

1. quantile_over_time(duration) was returning exemplars in nanos instead of float seconds like the samples. This is fixed as well as for any other function like avg_over_time(duration).
2. Finishes the TODO for the other functions that were capturing placeholder exemplars but without values (always zero):
  - rate()/count_over_time() exemplars are attached to the final sample value. See screenshot below
  - min/max_over_time() use the value from the span
3. avg_over_time was accidentally dropping exemplars because of struct address issue.
4. Actually randomly samples a span.  Maybe it's my test dataset but the current approach of Spans[0] wasn't working well.  The first span in my spansets was always the root span, so quantile_over_time(duration, 0.5) was always choosing the span with the longest duration as the exemplar and it was flying outside the graph.  Randomly sampling alleviates this problem. 

<img width="1190" alt="image" src="https://github.com/user-attachments/assets/20bd3511-eefb-4147-8036-ad1e805764d0">

**TODOs**
This is a lot better but there are still some things we should revisit:

1. span ID?  I really want `{status=error} | rate()` to link directly to the failing spans like search. But for now we aren't reading the span ID column, which would greatly increase query overhead.  
2. min/max_over_time() exemplars are kind of funny, they are any random span that was considered.  I think the ideal behavior is for the exemplar to be *the* span that was the minimum or maximum.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`