### PR TITLE
Prealloc tweaks

### DIFF
--- a/pkg/tempopb/pool/pool.go
+++ b/pkg/tempopb/pool/pool.go
@@ -79,22 +79,24 @@ func (p *Pool) Get(sz int) []byte {
 }
 
 // Put adds a slice to the right bucket in the pool.
-func (p *Pool) Put(s []byte) {
+func (p *Pool) Put(s []byte) int {
 	c := cap(s)
 
 	// valid slice?
-	if c%p.bktSize != 0 {
-		return
+	if (c-p.minBucket)%p.bktSize != 0 {
+		return -1
 	}
 	bkt := p.bucketFor(c) // -1 puts the slice in the pool below. it will be larger than all requested slices for this bucket
 	if bkt < 0 {
-		return
+		return -1
 	}
 	if bkt >= len(p.buckets) {
-		return
+		return -1
 	}
 
 	p.buckets[bkt].Put(s) // nolint: staticcheck
+
+	return bkt // for testing
 }
 
 func (p *Pool) bucketFor(sz int) int {

--- a/pkg/tempopb/pool/pool.go
+++ b/pkg/tempopb/pool/pool.go
@@ -11,79 +11,98 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-var metricAllocOutPool = promauto.NewCounter(prometheus.CounterOpts{
-	Namespace: "tempo",
-	Name:      "ingester_prealloc_miss_bytes_total",
-	Help:      "The total number of alloc'ed bytes that missed the sync pools.",
-})
+var metricMissOver prometheus.Counter
+var metricMissUnder prometheus.Counter
+
+func init() {
+	metricAllocOutPool := promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "tempo",
+		Name:      "ingester_prealloc_miss_bytes_total",
+		Help:      "The total number of alloc'ed bytes that missed the sync pools.",
+	}, []string{"direction"})
+
+	metricMissOver = metricAllocOutPool.WithLabelValues("over")
+	metricMissUnder = metricAllocOutPool.WithLabelValues("under")
+}
 
 // Pool is a linearly bucketed pool for variably sized byte slices.
 type Pool struct {
-	buckets []sync.Pool
-	bktSize int
+	buckets   []sync.Pool
+	bktSize   int
+	minBucket int
+
 	// make is the function used to create an empty slice when none exist yet.
 	make func(int) []byte
 }
 
 // New returns a new Pool with size buckets for minSize to maxSize
-func New(maxSize, bktSize int, makeFunc func(int) []byte) *Pool {
-	if maxSize < 1 {
-		panic("invalid maximum pool size")
+func New(minBucket, numBuckets, bktSize int, makeFunc func(int) []byte) *Pool {
+	if minBucket < 0 {
+		panic("invalid min bucket size")
 	}
 	if bktSize < 1 {
-		panic("invalid factor")
-	}
-	if maxSize%bktSize != 0 {
 		panic("invalid bucket size")
 	}
-
-	bkts := maxSize / bktSize
-
-	p := &Pool{
-		buckets: make([]sync.Pool, bkts),
-		bktSize: bktSize,
-		make:    makeFunc,
+	if numBuckets < 1 {
+		panic("invalid num buckets")
 	}
 
-	return p
+	return &Pool{
+		buckets:   make([]sync.Pool, numBuckets),
+		bktSize:   bktSize,
+		minBucket: minBucket,
+		make:      makeFunc,
+	}
 }
 
 // Get returns a new byte slices that fits the given size.
 func (p *Pool) Get(sz int) []byte {
 	if sz < 0 {
-		sz = 0 // just panic?
+		panic("requested negative size")
+	}
+
+	if sz < p.minBucket {
+		metricMissUnder.Add(float64(sz))
+		return p.make(sz)
 	}
 
 	// Find the right bucket.
-	bkt := sz / p.bktSize
+	bkt := p.bucketFor(sz)
 
 	if bkt >= len(p.buckets) {
-		metricAllocOutPool.Add(float64(sz)) // track the number of bytes alloc'ed outside the pool for future tuning
+		metricMissOver.Add(float64(sz))
 		return p.make(sz)
 	}
 
 	b := p.buckets[bkt].Get()
 	if b == nil {
-		sz := (bkt + 1) * p.bktSize
-		b = p.make(sz)
+		alignedSz := ((sz / p.bktSize) + 1) * p.bktSize // align to the next bucket up
+		b = p.make(alignedSz)
 	}
 	return b.([]byte)
 }
 
 // Put adds a slice to the right bucket in the pool.
-func (p *Pool) Put(s []byte) {
+func (p *Pool) Put(s []byte) int {
 	c := cap(s)
 
+	// valid slice?
 	if c%p.bktSize != 0 {
-		return
+		return -1
 	}
-	bkt := (c / p.bktSize) - 1
+	bkt := p.bucketFor(c) - 1 // -1 puts the slice in the pool below. it will be larger than all requested slices for this bucket
 	if bkt < 0 {
-		return
+		return -1
 	}
 	if bkt >= len(p.buckets) {
-		return
+		return -1
 	}
 
 	p.buckets[bkt].Put(s) // nolint: staticcheck
+
+	return bkt
+}
+
+func (p *Pool) bucketFor(sz int) int {
+	return (sz - p.minBucket) / p.bktSize
 }

--- a/pkg/tempopb/pool/pool_test.go
+++ b/pkg/tempopb/pool/pool_test.go
@@ -10,10 +10,11 @@ import (
 )
 
 func TestPoolGet(t *testing.T) {
-	testPool := New(5, 2, 5)
+	testPool := New(5, 2, 7)
 	cases := []struct {
 		size        int
 		expectedCap int
+		tooLarge    bool
 	}{
 		{ // under the smallest pool size, should return an unaligned slice
 			size:        3,
@@ -25,26 +26,31 @@ func TestPoolGet(t *testing.T) {
 		},
 		{
 			size:        6,
-			expectedCap: 10,
+			expectedCap: 12,
 		},
 		{
-			size:        10,
-			expectedCap: 10,
+			size:        12,
+			expectedCap: 12,
 		},
 		{
 			size:        15,
-			expectedCap: 15,
+			expectedCap: 19,
 		},
 		{ // over the largest pool size, should return an unaligned slice
-			size:        16,
-			expectedCap: 16,
+			size:        20,
+			expectedCap: 20,
+			tooLarge:    true,
 		},
 	}
 	for _, c := range cases {
 		for i := 0; i < 10; i++ {
 			ret := testPool.Get(c.size)
 			require.Equal(t, c.expectedCap, cap(ret))
-			testPool.Put(ret)
+			putBucket := testPool.Put(ret)
+
+			if !c.tooLarge {
+				require.Equal(t, testPool.bucketFor(cap(ret)), putBucket)
+			}
 		}
 	}
 }

--- a/pkg/tempopb/prealloc.go
+++ b/pkg/tempopb/prealloc.go
@@ -2,7 +2,15 @@ package tempopb
 
 import "github.com/grafana/tempo/pkg/tempopb/pool"
 
-var bytePool = pool.New(100_000, 400, func(size int) []byte { return make([]byte, 0, size) })
+var bytePool *pool.Pool
+
+func init() {
+	bktSize := 400
+	numBuckets := 250
+	minBucket := 0
+
+	bytePool = pool.New(minBucket, numBuckets, bktSize, func(size int) []byte { return make([]byte, 0, size) })
+}
 
 // PreallocBytes is a (repeated bytes slices) which preallocs slices on Unmarshal.
 type PreallocBytes struct {
@@ -35,6 +43,6 @@ func (r *PreallocBytes) Size() (n int) {
 // ReuseByteSlices puts the byte slice back into bytePool for reuse.
 func ReuseByteSlices(buffs [][]byte) {
 	for _, b := range buffs {
-		bytePool.Put(b[:0])
+		_ = bytePool.Put(b[:0])
 	}
 }

--- a/pkg/tempopb/prealloc.go
+++ b/pkg/tempopb/prealloc.go
@@ -48,7 +48,7 @@ func (r *PreallocBytes) Size() (n int) {
 // ReuseByteSlices puts the byte slice back into bytePool for reuse.
 func ReuseByteSlices(buffs [][]byte) {
 	for _, b := range buffs {
-		bytePool.Put(b[:0])
+		_ = bytePool.Put(b[:0])
 	}
 }
 

--- a/pkg/tempopb/prealloc.go
+++ b/pkg/tempopb/prealloc.go
@@ -14,7 +14,7 @@ func init() {
 	numBuckets := intFromEnv("PREALLOC_NUM_BUCKETS", 250)
 	minBucket := intFromEnv("PREALLOC_MIN_BUCKET", 0)
 
-	bytePool = pool.New(minBucket, numBuckets, bktSize, func(size int) []byte { return make([]byte, 0, size) })
+	bytePool = pool.New(minBucket, numBuckets, bktSize)
 }
 
 // PreallocBytes is a (repeated bytes slices) which preallocs slices on Unmarshal.
@@ -48,7 +48,7 @@ func (r *PreallocBytes) Size() (n int) {
 // ReuseByteSlices puts the byte slice back into bytePool for reuse.
 func ReuseByteSlices(buffs [][]byte) {
 	for _, b := range buffs {
-		_ = bytePool.Put(b[:0])
+		bytePool.Put(b[:0])
 	}
 }
 


### PR DESCRIPTION
**What this PR does**:
https://github.com/grafana/tempo/pull/4344 improved prealloc behavior gettings us 10-40% working set reductions across all our clusters. It also introduced a metric to help track prealloc "misses". This PR by default will not change any Tempo behavior but will give better information and tunable parameters for precise tuning of the prealloc buckets. 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`