### PR TITLE
Bump to 1.23.3

### DIFF
--- a/.github/workflows/dependabot_serverless_gomod.yml
+++ b/.github/workflows/dependabot_serverless_gomod.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
-      - name: Set up Go 1.22
+      - name: Set up Go 1.23
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.1
+          go-version: 1.23.3
 
       - name: Get app token
         uses: actions/create-github-app-token@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * [CHANGE] **BREAKING CHANGE** Migrate from OpenTracing to OpenTelemetry instrumentation. Removed the `use_otel_tracer` configuration option. Use the OpenTelemetry environment variables to configure the span exporter [#3646](https://github.com/grafana/tempo/pull/3646) (@andreasgerstmayr)
   To continue using the Jaeger exporter, use the following environment variable: `OTEL_TRACES_EXPORTER=jaeger`.
 * [CHANGE] No longer send the final diff in GRPC streaming. Instead we rely on the streamed intermediate results. [#4062](https://github.com/grafana/tempo/pull/4062) (@joe-elliott)
-* [CHANGE] Update Go to 1.23.1 [#4146](https://github.com/grafana/tempo/pull/4146) [#4147](https://github.com/grafana/tempo/pull/4147) (@javiermolinar)
+* [CHANGE] Update Go to 1.23.3 [#4146](https://github.com/grafana/tempo/pull/4146) [#4147](https://github.com/grafana/tempo/pull/4147) [#4380](https://github.com/grafana/tempo/pull/4380) (@javiermolinar @mdisibio)
 * [CHANGE] TraceQL: Add range condition for byte predicates [#4198](https://github.com/grafana/tempo/pull/4198) (@ie-pham)
 * [CHANGE] Return 422 for TRACE_TOO_LARGE queries [#4160](https://github.com/grafana/tempo/pull/4160) (@zalegrala)
 * [CHANGE] Upgrade OTEL sdk to reduce allocs [#4243](https://github.com/grafana/tempo/pull/4243) (@joe-elliott)

--- a/build/tools.mk
+++ b/build/tools.mk
@@ -12,7 +12,7 @@ TOOL_DIR     ?= tools
 TOOL_CONFIG  ?= $(TOOL_DIR)/tools.go
 
 TOOLS_IMAGE ?= grafana/tempo-ci-tools
-TOOLS_IMAGE_TAG ?= main-a46ac6d
+TOOLS_IMAGE_TAG ?= main-e87b8d4
 
 GOTOOLS ?= $(shell cd $(TOOL_DIR) && go list -e -f '{{ .Imports }}' -tags tools |tr -d '[]')
 

--- a/cmd/tempo-serverless/cloud-run/go.mod
+++ b/cmd/tempo-serverless/cloud-run/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/tempo/cmd/tempo-serverless/cloud-run
 
-go 1.23.1
+go 1.23.3
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/cmd/tempo-serverless/lambda/go.mod
+++ b/cmd/tempo-serverless/lambda/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/tempo/cmd/tempo-serverless/lambda
 
-go 1.23.1
+go 1.23.3
 
 require (
 	github.com/aws/aws-lambda-go v1.28.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/tempo
 
-go 1.23.1
+go 1.23.3
 
 require (
 	cloud.google.com/go/storage v1.41.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Bump golang to resolve occasional compactor panics for `too many concurrent timer firings`.  The fix is released in 1.23.3: https://github.com/golang/go/issues/69882

It's possible that we are using timers sub-optimally, but I believe the the timer change in the framework was unintentional, and not worth digging into at this time.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`