### PR TITLE
Bump tools to 1.23.3

### DIFF
--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/tempo/tools
 
-go 1.23.1
+go 1.23.3
 
 require (
 	github.com/golangci/golangci-lint v1.61.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
I believe this is a chicken-or-egg problem where we have to bump tools first, so that it will tag the new tempo-ci-tools image, that we can use to bump Tempo.

https://github.com/grafana/tempo/pull/4380

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`