### PR TITLE
[rhythm] Changes to simplify operations

### DIFF
--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -314,7 +314,7 @@ func (t *App) initGenerator() (services.Service, error) {
 
 	if t.cfg.Target == SingleBinary && len(t.cfg.Generator.AssignedPartitions) == 0 {
 		// In SingleBinary mode always use partition 0. This is for small installs or local/debugging setups.
-		t.cfg.Generator.AssignedPartitions[t.cfg.Generator.InstanceID] = append(t.cfg.Generator.AssignedPartitions[t.cfg.Generator.InstanceID], 0)
+		t.cfg.Generator.AssignedPartitions = map[string][]int32{t.cfg.Generator.InstanceID: {0}}
 	}
 
 	genSvc, err := generator.New(&t.cfg.Generator, t.Overrides, prometheus.DefaultRegisterer, t.partitionRing, t.store, log.Logger)
@@ -348,7 +348,7 @@ func (t *App) initBlockBuilder() (services.Service, error) {
 
 	if t.cfg.Target == SingleBinary && len(t.cfg.BlockBuilder.AssignedPartitions) == 0 {
 		// In SingleBinary mode always use partition 0. This is for small installs or local/debugging setups.
-		t.cfg.BlockBuilder.AssignedPartitions[t.cfg.BlockBuilder.InstanceID] = append(t.cfg.BlockBuilder.AssignedPartitions[t.cfg.BlockBuilder.InstanceID], 0)
+		t.cfg.BlockBuilder.AssignedPartitions = map[string][]int32{t.cfg.BlockBuilder.InstanceID: {0}}
 	}
 
 	t.blockBuilder = blockbuilder.New(t.cfg.BlockBuilder, log.Logger, t.partitionRing, t.Overrides, t.store)

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -348,7 +348,7 @@ func (t *App) initBlockBuilder() (services.Service, error) {
 
 	if t.cfg.Target == SingleBinary && len(t.cfg.BlockBuilder.AssignedPartitions) == 0 {
 		// In SingleBinary mode always use partition 0. This is for small installs or local/debugging setups.
-		t.cfg.BlockBuilder.AssignedPartitions = append(t.cfg.BlockBuilder.AssignedPartitions, 0)
+		t.cfg.BlockBuilder.AssignedPartitions[t.cfg.BlockBuilder.InstanceID] = append(t.cfg.BlockBuilder.AssignedPartitions[t.cfg.BlockBuilder.InstanceID], 0)
 	}
 
 	t.blockBuilder = blockbuilder.New(t.cfg.BlockBuilder, log.Logger, t.partitionRing, t.Overrides, t.store)

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -314,7 +314,7 @@ func (t *App) initGenerator() (services.Service, error) {
 
 	if t.cfg.Target == SingleBinary && len(t.cfg.Generator.AssignedPartitions) == 0 {
 		// In SingleBinary mode always use partition 0. This is for small installs or local/debugging setups.
-		t.cfg.Generator.AssignedPartitions = append(t.cfg.Generator.AssignedPartitions, 0)
+		t.cfg.Generator.AssignedPartitions[t.cfg.Generator.InstanceID] = append(t.cfg.Generator.AssignedPartitions[t.cfg.Generator.InstanceID], 0)
 	}
 
 	genSvc, err := generator.New(&t.cfg.Generator, t.Overrides, prometheus.DefaultRegisterer, t.partitionRing, t.store, log.Logger)

--- a/modules/blockbuilder/blockbuilder.go
+++ b/modules/blockbuilder/blockbuilder.go
@@ -340,7 +340,7 @@ func (b *BlockBuilder) pushTraces(tenantBytes, reqBytes []byte, p partitionSecti
 func (b *BlockBuilder) getAssignedActivePartitions() []int32 {
 	activePartitionsCount := b.partitionRing.PartitionRing().ActivePartitionsCount()
 	assignedActivePartitions := make([]int32, 0, activePartitionsCount)
-	for _, partition := range b.cfg.AssignedPartitions {
+	for _, partition := range b.cfg.AssignedPartitions[b.cfg.InstanceID] {
 		if partition > int32(activePartitionsCount) {
 			break
 		}

--- a/modules/blockbuilder/blockbuilder_test.go
+++ b/modules/blockbuilder/blockbuilder_test.go
@@ -337,7 +337,7 @@ func blockbuilderConfig(_ *testing.T, address string) Config {
 	cfg.IngestStorageConfig.Kafka.Topic = testTopic
 	cfg.IngestStorageConfig.Kafka.ConsumerGroup = "test-consumer-group"
 
-	cfg.AssignedPartitions = []int32{0}
+	cfg.AssignedPartitions = map[string][]int32{cfg.InstanceID: {0}}
 	cfg.LookbackOnNoCommit = 15 * time.Second
 	cfg.ConsumeCycleDuration = 5 * time.Second
 

--- a/modules/generator/generator_kafka.go
+++ b/modules/generator/generator_kafka.go
@@ -212,7 +212,7 @@ func getGroupLag(ctx context.Context, admClient *kadm.Client, topic, group strin
 func (g *Generator) getAssignedActivePartitions() []int32 {
 	activePartitionsCount := g.partitionRing.PartitionRing().ActivePartitionsCount()
 	assignedActivePartitions := make([]int32, 0, activePartitionsCount)
-	for _, partition := range g.cfg.AssignedPartitions {
+	for _, partition := range g.cfg.AssignedPartitions[g.cfg.InstanceID] {
 		if partition > int32(activePartitionsCount) {
 			break
 		}

--- a/pkg/ingest/config.go
+++ b/pkg/ingest/config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/flagext"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kgo"
 )
@@ -44,6 +45,7 @@ var (
 	ErrInconsistentConsumerLagAtStartup  = errors.New("the target and max consumer lag at startup must be either both set to 0 or to a value greater than 0")
 	ErrInvalidMaxConsumerLagAtStartup    = errors.New("the configured max consumer lag at startup must greater or equal than the configured target consumer lag")
 	ErrInvalidProducerMaxRecordSizeBytes = fmt.Errorf("the configured producer max record size bytes must be a value between %d and %d", minProducerRecordDataBytesLimit, maxProducerRecordDataBytesLimit)
+	ErrInconsistentSASLCredentials       = errors.New("the SASL username and password must be both configured to enable SASL authentication")
 )
 
 type Config struct {
@@ -71,6 +73,9 @@ type KafkaConfig struct {
 	DialTimeout  time.Duration `yaml:"dial_timeout"`
 	WriteTimeout time.Duration `yaml:"write_timeout"`
 
+	SASLUsername string         `yaml:"sasl_username"`
+	SASLPassword flagext.Secret `yaml:"sasl_password"`
+
 	ConsumerGroup                     string        `yaml:"consumer_group"`
 	ConsumerGroupOffsetCommitInterval time.Duration `yaml:"consumer_group_offset_commit_interval"`
 
@@ -96,6 +101,9 @@ func (cfg *KafkaConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) 
 	f.StringVar(&cfg.ClientID, prefix+".client-id", "", "The Kafka client ID.")
 	f.DurationVar(&cfg.DialTimeout, prefix+".dial-timeout", 2*time.Second, "The maximum time allowed to open a connection to a Kafka broker.")
 	f.DurationVar(&cfg.WriteTimeout, prefix+".write-timeout", 10*time.Second, "How long to wait for an incoming write request to be successfully committed to the Kafka backend.")
+
+	f.StringVar(&cfg.SASLUsername, prefix+".sasl-username", "", "The SASL username for authentication.")
+	f.Var(&cfg.SASLPassword, prefix+".sasl-password", "The SASL password for authentication.")
 
 	f.StringVar(&cfg.ConsumerGroup, prefix+".consumer-group", "", "The consumer group used by the consumer to track the last consumed offset. The consumer group must be different for each ingester. If the configured consumer group contains the '<partition>' placeholder, it is replaced with the actual partition ID owned by the ingester. When empty (recommended), Mimir uses the ingester instance ID to guarantee uniqueness.")
 	f.DurationVar(&cfg.ConsumerGroupOffsetCommitInterval, prefix+".consumer-group-offset-commit-interval", time.Second, "How frequently a consumer should commit the consumed offset to Kafka. The last committed offset is used at startup to continue the consumption from where it was left.")
@@ -128,6 +136,10 @@ func (cfg *KafkaConfig) Validate() error {
 	}
 	if cfg.MaxConsumerLagAtStartup < cfg.TargetConsumerLagAtStartup {
 		return ErrInvalidMaxConsumerLagAtStartup
+	}
+
+	if (cfg.SASLUsername == "") != (cfg.SASLPassword.String() == "") {
+		return ErrInconsistentSASLCredentials
 	}
 
 	return nil

--- a/pkg/ingest/writer_client.go
+++ b/pkg/ingest/writer_client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
+	"github.com/twmb/franz-go/pkg/sasl/plain"
 	"github.com/twmb/franz-go/plugin/kotel"
 	"github.com/twmb/franz-go/plugin/kprom"
 	"go.opentelemetry.io/otel/propagation"
@@ -139,6 +140,16 @@ func commonKafkaClientOptions(cfg KafkaConfig, metrics *kprom.Metrics, logger lo
 
 	if cfg.AutoCreateTopicEnabled {
 		opts = append(opts, kgo.AllowAutoTopicCreation())
+	}
+
+	// SASL plain auth.
+	if cfg.SASLUsername != "" && cfg.SASLPassword.String() != "" {
+		opts = append(opts, kgo.SASL(plain.Plain(func(_ context.Context) (plain.Auth, error) {
+			return plain.Auth{
+				User: cfg.SASLUsername,
+				Pass: cfg.SASLPassword.String(),
+			}, nil
+		})))
 	}
 
 	tracer := kotel.NewTracer(

--- a/vendor/github.com/twmb/franz-go/pkg/sasl/plain/plain.go
+++ b/vendor/github.com/twmb/franz-go/pkg/sasl/plain/plain.go
@@ -1,0 +1,60 @@
+// Package plain provides PLAIN sasl authentication as specified in RFC4616.
+package plain
+
+import (
+	"context"
+	"errors"
+
+	"github.com/twmb/franz-go/pkg/sasl"
+)
+
+// Auth contains information for authentication.
+type Auth struct {
+	// Zid is an optional authorization ID to use in authenticating.
+	Zid string
+
+	// User is username to use for authentication.
+	User string
+
+	// Pass is the password to use for authentication.
+	Pass string
+
+	_ struct{} // require explicit field initialization
+}
+
+// AsMechanism returns a sasl mechanism that will use 'a' as credentials for
+// all sasl sessions.
+//
+// This is a shortcut for using the Plain function and is useful when you do
+// not need to live-rotate credentials.
+func (a Auth) AsMechanism() sasl.Mechanism {
+	return Plain(func(context.Context) (Auth, error) {
+		return a, nil
+	})
+}
+
+// Plain returns a sasl mechanism that will call authFn whenever sasl
+// authentication is needed. The returned Auth is used for a single session.
+func Plain(authFn func(context.Context) (Auth, error)) sasl.Mechanism {
+	return plain(authFn)
+}
+
+type plain func(context.Context) (Auth, error)
+
+func (plain) Name() string { return "PLAIN" }
+func (fn plain) Authenticate(ctx context.Context, _ string) (sasl.Session, []byte, error) {
+	auth, err := fn(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	if auth.User == "" || auth.Pass == "" {
+		return nil, nil, errors.New("PLAIN user and pass must be non-empty")
+	}
+	return session{}, []byte(auth.Zid + "\x00" + auth.User + "\x00" + auth.Pass), nil
+}
+
+type session struct{}
+
+func (session) Challenge([]byte) (bool, []byte, error) {
+	return true, nil, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1244,6 +1244,7 @@ github.com/twmb/franz-go/pkg/kgo
 github.com/twmb/franz-go/pkg/kgo/internal/sticky
 github.com/twmb/franz-go/pkg/kversion
 github.com/twmb/franz-go/pkg/sasl
+github.com/twmb/franz-go/pkg/sasl/plain
 # github.com/twmb/franz-go/pkg/kadm v1.13.0
 ## explicit; go 1.21
 github.com/twmb/franz-go/pkg/kadm


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This PR contains a couple of changes to simplify operations
* Adds support for SASL auth in the Kafka clients
* Changes `assigned_partitions` from a slice to a map. Now, the partition config for all instances can be passed, and each instance can pick up their own via their instance ID. This is simpler operationally than passing a different config per pod.