### PR TITLE
Add query-frontend limit for max length of query expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [CHANGE] slo: include request cancellations within SLO [#4355] (https://github.com/grafana/tempo/pull/4355) (@electron0zero)
   request cancellations are exposed under `result` label in `tempo_query_frontend_queries_total` and `tempo_query_frontend_queries_within_slo_total` with `completed` or `canceled` values to differentiate between completed and canceled requests.
 * [CHANGE] update default config values to better align with production workloads [#4340](https://github.com/grafana/tempo/pull/4340) (@electron0zero)
+* [CHANGE] Add query-frontend limit for max length of query expression [##4397](https://github.com/grafana/tempo/pull/4397) (@electron0zero)
 * [CHANGE] fix deprecation warning by switching to DoBatchWithOptions [#4343](https://github.com/grafana/tempo/pull/4343) (@dastrobu)
 * [CHANGE] **BREAKING CHANGE** The Tempo serverless is now deprecated and will be removed in an upcoming release [#4017](https://github.com/grafana/tempo/pull/4017/) @electron0zero
 * [CHANGE] **BREAKING CHANGE** Change the AWS Lambda serverless build tooling output from "main" to "bootstrap". Refer to https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/ for migration steps [#3852](https://github.com/grafana/tempo/pull/3852) (@zatlodan)

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -593,6 +593,10 @@ query_frontend:
     # A list of regular expressions for refusing matching requests, these will apply for every request regardless of the endpoint.
     [url_deny_list: <list of strings> | default = <empty list>]]
 
+    # Max allowed TraceQL expression size, in bytes. queries bigger then this size will be rejected.
+    # (default: 128 KiB)
+    [max_query_expression_size_bytes: <int> | default = 131072]]
+
     search:
 
         # The number of concurrent jobs to execute when searching the backend.

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -18,7 +18,7 @@ go run ./cmd/tempo --storage.trace.backend=local --storage.trace.local.path=/var
 ## Complete configuration
 
 {{< admonition type="note" >}}
-This manifest was generated on 2024-11-18.
+This manifest was generated on 2024-11-28.
 {{% /admonition %}}
 
 ```yaml
@@ -188,7 +188,6 @@ distributor:
     forwarders: []
     usage:
         cost_attribution:
-            enabled: false
             max_cardinality: 10000
             stale_duration: 15m0s
     extend_writes: true
@@ -317,6 +316,7 @@ query_frontend:
         query_backend_after: 15m0s
         query_ingesters_until: 30m0s
         ingester_shards: 3
+        max_spans_per_span_set: 100
     trace_by_id:
         query_shards: 50
     metrics:
@@ -333,6 +333,7 @@ query_frontend:
         retry_with_weights: true
         max_traceql_conditions: 4
         max_regex_conditions: 1
+    max_query_expression_size_bytes: 131072
 compactor:
     ring:
         kvstore:
@@ -799,6 +800,7 @@ memberlist:
     gossip_to_dead_nodes_time: 30s
     dead_node_reclaim_time: 0s
     compression_enabled: false
+    notify_interval: 0s
     advertise_addr: ""
     advertise_port: 7946
     cluster_label: ""
@@ -817,6 +819,8 @@ memberlist:
     bind_port: 7946
     packet_dial_timeout: 2s
     packet_write_timeout: 5s
+    max_concurrent_writes: 3
+    acquire_writer_timeout: 250ms
     tls_enabled: false
     tls_cert_path: ""
     tls_key_path: ""

--- a/modules/frontend/config.go
+++ b/modules/frontend/config.go
@@ -32,6 +32,9 @@ type Config struct {
 	// A list of regexes for black listing requests, these will apply for every request regardless the endpoint
 	URLDenyList []string `yaml:"url_deny_list,omitempty"`
 
+	// Maximum allowed size of the raw TraceQL Query expression in bytes
+	MaxQueryExpressionSizeBytes int `yaml:"max_query_expression_size_bytes,omitempty"`
+
 	// A list of headers allowed through the HTTP pipeline. Everything else will be stripped.
 	AllowedHeaders []string `yaml:"-"`
 }
@@ -105,6 +108,8 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {
 		MaxTraceQLConditions: 4,
 	}
 
+	// set default max query size to 128 KiB, queries larger than this will be rejected
+	cfg.MaxQueryExpressionSizeBytes = 128 * 1024
 	// enable multi tenant queries by default
 	cfg.MultiTenantQueriesEnabled = true
 }

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -95,7 +95,7 @@ func New(cfg Config, next pipeline.RoundTripper, o overrides.Interface, reader t
 	statusCodeWare := pipeline.NewStatusCodeAdjustWare()
 	traceIDStatusCodeWare := pipeline.NewStatusCodeAdjustWareWithAllowedCode(http.StatusNotFound)
 	urlDenyListWare := pipeline.NewURLDenyListWare(cfg.URLDenyList)
-	queryValidatorWare := pipeline.NewQueryValidatorWare()
+	queryValidatorWare := pipeline.NewQueryValidatorWare(cfg.MaxQueryExpressionSizeBytes)
 	headerStripWare := pipeline.NewStripHeadersWare(cfg.AllowedHeaders)
 
 	tracePipeline := pipeline.Build(

--- a/modules/frontend/pipeline/async_query_validator_middleware.go
+++ b/modules/frontend/pipeline/async_query_validator_middleware.go
@@ -40,17 +40,18 @@ func (c queryValidatorWare) validateTraceQLQuery(queryParams url.Values) error {
 		traceQLQuery = queryParams.Get("query")
 	}
 	if traceQLQuery != "" {
+		// reject query if the query expression size exceeds the maximum allowed size.
+		// reject huge queries before we parse them, this avoids parsing huge queries.
+		if len(traceQLQuery) > c.maxQuerySizeBytes {
+			return fmt.Errorf("TraceQL expression exceeds the configured maximum size of %d bytes, reduce the query expression size or contact your system administrator", c.maxQuerySizeBytes)
+		}
+
 		expr, err := traceql.Parse(traceQLQuery)
 		if err == nil {
 			err = traceql.Validate(expr)
 		}
 		if err != nil {
 			return fmt.Errorf("invalid TraceQL query: %w", err)
-		}
-
-		// reject query if the query expression size exceeds the maximum allowed size
-		if len(traceQLQuery) > c.maxQuerySizeBytes {
-			return fmt.Errorf("TraceQL expression exceeds the configured maximum size of %d bytes, reduce the query expression size or contact your system administrator", c.maxQuerySizeBytes)
 		}
 	}
 	return nil

--- a/modules/frontend/search_handlers_test.go
+++ b/modules/frontend/search_handlers_test.go
@@ -314,7 +314,8 @@ func TestSearchLimitHonored(t *testing.T) {
 			}
 		},
 	}, nil, &Config{
-		MultiTenantQueriesEnabled: true,
+		MultiTenantQueriesEnabled:   true,
+		MaxQueryExpressionSizeBytes: 10000,
 		TraceByID: TraceByIDConfig{
 			QueryShards: minQueryShards,
 			SLO:         testSLOcfg,
@@ -768,7 +769,8 @@ func frontendWithSettings(t require.TestingT, next pipeline.RoundTripper, rdr te
 	}
 	if cfg == nil {
 		cfg = &Config{
-			MultiTenantQueriesEnabled: true,
+			MultiTenantQueriesEnabled:   true,
+			MaxQueryExpressionSizeBytes: 100000,
 			TraceByID: TraceByIDConfig{
 				QueryShards: minQueryShards,
 				SLO:         testSLOcfg,


### PR DESCRIPTION
**What this PR does**:

In order to protect tempo from massive queries, it's helpful to put a cap on the max query length.

Having a limit on the size of the query saves us from being DOSed by issuing huge queries against tempo.

Added `query_frontend.max_query_expression_size_bytes` config param for query frontends, defaults to 128 KiB.

this can be configured to a value lower of higher by setting it in query_frontend config section like:

```yaml
query_frontend:
  max_query_expression_size_bytes: 10000
```

users will see it as an error like this:
![image](https://github.com/user-attachments/assets/a4002a4c-27cd-4fab-b807-81420158a9ef)


Loki also limits the size of query expression to 128kb and Mimir has a configurable limit with same name (see https://github.com/grafana/mimir/pull/4604), and both were added for same reasons. 


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`