### PR TITLE
[WIP] Evaluate spansets in metric queries

### DIFF
--- a/pkg/traceql/engine.go
+++ b/pkg/traceql/engine.go
@@ -83,7 +83,7 @@ func (e *Engine) ExecuteSearch(ctx context.Context, searchReq *tempopb.SearchReq
 			return nil, nil
 		}
 
-		// reduce all evalSS to their max length to reduce meta data lookups
+		// reduce all evalSS to their max length to reduce metadata lookups
 		for i := range evalSS {
 			l := len(evalSS[i].Spans)
 			evalSS[i].AddAttribute(attributeMatched, NewStaticInt(l))

--- a/tempodb/encoding/vparquet4/block_traceql_test.go
+++ b/tempodb/encoding/vparquet4/block_traceql_test.go
@@ -1205,6 +1205,7 @@ func TestBackendBlockQueryRange(t *testing.T) {
 			for _, s := range ss {
 				if s.Exemplars != nil && len(s.Exemplars) > 0 {
 					fmt.Println("series", s.Labels)
+					fmt.Println("values", s.Values)
 					fmt.Println("Exemplars", s.Exemplars)
 				}
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Evaluates spansets in TraceQL metric queries, as they are not completely filtered by the iterators in some queries.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`