### PR TITLE
More exemplar fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@
 * [BUGFIX] Pushes a 0 to classic histogram's counter when the series is new to allow Prometheus to start from a non-null value. [#4140](https://github.com/grafana/tempo/pull/4140) (@mapno)
 * [BUGFIX] Fix counter samples being downsampled by backdate to the previous minute the initial sample when the series is new [#4236](https://github.com/grafana/tempo/pull/4236) (@javiermolinar)
 * [BUGFIX] Fix traceql metrics time range handling at the cutoff between recent and backend data [#4257](https://github.com/grafana/tempo/issues/4257) (@mdisibio)
-* [BUGFIX] Fix several issues with exemplar values for traceql metrics [#4366](https://github.com/grafana/tempo/pull/4366) (@mdisibio)
+* [BUGFIX] Fix several issues with exemplar values for traceql metrics [#4366](https://github.com/grafana/tempo/pull/4366) [#4404](https://github.com/grafana/tempo/pull/4404) (@mdisibio)
 * [BUGFIX] Skip computing exemplars for instant queries. [#4204](https://github.com/grafana/tempo/pull/4204) (@javiermolinar)
 * [BUGFIX] Gave context to orphaned spans related to various maintenance processes. [#4260](https://github.com/grafana/tempo/pull/4260) (@joe-elliott)
 * [BUGFIX] Initialize histogram buckets to 0 to avoid downsampling. [#4366](https://github.com/grafana/tempo/pull/4366) (@javiermolinar)

--- a/modules/frontend/combiner/metrics_query_range.go
+++ b/modules/frontend/combiner/metrics_query_range.go
@@ -104,7 +104,7 @@ func attachExemplars(req *tempopb.QueryRangeRequest, res *tempopb.QueryRangeResp
 				// NOTE - Look for sample in same interval, not same value.
 				si := traceql.IntervalOfMs(s.TimestampMs, req.Start, req.End, req.Step)
 
-				// This returns negative, zero, or postive
+				// This returns negative, zero, or positive
 				return si - exemplarInterval
 			})
 			if ok {

--- a/modules/frontend/combiner/metrics_query_range.go
+++ b/modules/frontend/combiner/metrics_query_range.go
@@ -1,6 +1,8 @@
 package combiner
 
 import (
+	"math"
+	"slices"
 	"sort"
 	"strings"
 
@@ -42,6 +44,7 @@ func NewQueryRange(req *tempopb.QueryRangeRequest, trackDiffs bool) (Combiner, e
 				resp = &tempopb.QueryRangeResponse{}
 			}
 			sortResponse(resp)
+			attachExemplars(req, resp)
 			return resp, nil
 		},
 		diff: func(_ *tempopb.QueryRangeResponse) (*tempopb.QueryRangeResponse, error) {
@@ -79,5 +82,34 @@ func sortResponse(res *tempopb.QueryRangeResponse) {
 		sort.Slice(series.Exemplars, func(i, j int) bool {
 			return series.Exemplars[i].TimestampMs < series.Exemplars[j].TimestampMs
 		})
+	}
+}
+
+// attachExemplars to the final series outputs. Placeholder exemplars for things like rate()
+// have NaNs, and we can't attach them until the very end.
+func attachExemplars(req *tempopb.QueryRangeRequest, res *tempopb.QueryRangeResponse) {
+	for _, ss := range res.Series {
+		for i, e := range ss.Exemplars {
+
+			// Only needed for NaNs
+			if !math.IsNaN(e.Value) {
+				continue
+			}
+
+			exemplarInterval := traceql.IntervalOfMs(e.TimestampMs, req.Start, req.End, req.Step)
+
+			// Look for sample in the same slot.
+			// BinarySearch is possible because all samples were sorted previously.
+			j, ok := slices.BinarySearchFunc(ss.Samples, exemplarInterval, func(s tempopb.Sample, _ int) int {
+				// NOTE - Look for sample in same interval, not same value.
+				si := traceql.IntervalOfMs(s.TimestampMs, req.Start, req.End, req.Step)
+
+				// This returns negative, zero, or postive
+				return si - exemplarInterval
+			})
+			if ok {
+				ss.Exemplars[i].Value = ss.Samples[j].Value
+			}
+		}
 	}
 }

--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -296,6 +296,7 @@ func (set SeriesSet) ToProtoDiff(req *tempopb.QueryRangeRequest, rangeForLabels 
 					},
 				)
 			}
+
 			exemplars = append(exemplars, tempopb.Exemplar{
 				Labels:      labels,
 				Value:       e.Value,
@@ -1242,16 +1243,6 @@ func (b *SimpleAggregator) aggregateExemplars(ts *tempopb.TimeSeries, existing *
 }
 
 func (b *SimpleAggregator) Results() SeriesSet {
-	// Attach placeholder exemplars to the output
-	for _, ts := range b.ss {
-		for i, e := range ts.Exemplars {
-			if math.IsNaN(e.Value) {
-				interval := IntervalOfMs(int64(e.TimestampMs), b.start, b.end, b.step)
-				ts.Exemplars[i].Value = ts.Values[interval]
-			}
-		}
-	}
-
 	return b.ss
 }
 


### PR DESCRIPTION
**What this PR does**:
(1) Fix placeholder exemplars (NaNs) to be attached at the last step in the query-frontend. The previous location was too early and was partial job results instead of the final.
(2) Fix histogram_over_time to use placeholder exemplars. It outputs counts like count_over_time(), this means splitting out its case statement from quantile_over_time.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`