### PR TITLE
Metrics Generator Performance

### DIFF
--- a/modules/generator/generator_test.go
+++ b/modules/generator/generator_test.go
@@ -155,7 +155,7 @@ func BenchmarkPushSpans(b *testing.B) {
 				"span-metrics":   {},
 				"service-graphs": {},
 			},
-			spanMetricsEnableTargetInfo:             true,
+			spanMetricsEnableTargetInfo:             false,
 			spanMetricsTargetInfoExcludedDimensions: []string{"excluded}"},
 		}
 	)
@@ -175,6 +175,12 @@ func BenchmarkPushSpans(b *testing.B) {
 			test.MakeBatch(100, nil),
 			test.MakeBatch(100, nil),
 			test.MakeBatch(100, nil),
+			test.MakeBatch(100, nil),
+			test.MakeBatch(100, nil),
+			test.MakeBatch(100, nil),
+			test.MakeBatch(100, nil),
+			test.MakeBatch(100, nil),
+			test.MakeBatch(100, nil),
 		},
 	}
 
@@ -189,11 +195,13 @@ func BenchmarkPushSpans(b *testing.B) {
 			{Key: "k8s.node.name", Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "test" + strconv.Itoa(i)}}},
 			{Key: "k8s.pod.ip", Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "test" + strconv.Itoa(i)}}},
 			{Key: "k8s.pod.name", Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "test" + strconv.Itoa(i)}}},
+			{Key: "service.instance.id", Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "test" + strconv.Itoa(i)}}},
 			{Key: "excluded", Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "test" + strconv.Itoa(i)}}},
 		}...)
 	}
 
 	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		inst.pushSpans(ctx, req)
 	}

--- a/modules/generator/processor/spanmetrics/config.go
+++ b/modules/generator/processor/spanmetrics/config.go
@@ -22,6 +22,8 @@ const (
 	dimInstance      = "instance"
 )
 
+var intrinsicLabels = []string{dimService, dimSpanName, dimSpanKind, dimStatusCode, dimStatusMessage}
+
 type Config struct {
 	// Buckets for latency histogram in seconds.
 	HistogramBuckets []float64 `yaml:"histogram_buckets"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: Generator improvements based on @mdisibio 's notes for things relating to target_info. 

```
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
          │ before-mg.out │            after-mg.out             │
          │    sec/op     │   sec/op     vs base                │
PushSpans     3.006m ± 3%   1.308m ± 1%  -56.49% (p=0.000 n=10)

          │ before-mg.out │            after-mg.out            │
          │  heap_in_use  │ heap_in_use  vs base               │
PushSpans     15.73M ± 0%   15.79M ± 0%  +0.36% (p=0.000 n=10)

          │ before-mg.out │             after-mg.out             │
          │     B/op      │     B/op      vs base                │
PushSpans    705.9Ki ± 0%   568.6Ki ± 0%  -19.44% (p=0.000 n=10)

          │ before-mg.out │            after-mg.out             │
          │   allocs/op   │  allocs/op   vs base                │
PushSpans    18.582k ± 0%   9.044k ± 0%  -51.33% (p=0.000 n=10)
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`