### PR TITLE
Rhythm: Separate non-flushing local blocks processor to store new queue data for reads

### DIFF
--- a/modules/blockbuilder/config.go
+++ b/modules/blockbuilder/config.go
@@ -55,7 +55,7 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("block config validation failed: %w", err)
 	}
 
-	if err := wal.ValidateConfig(&c.WAL); err != nil {
+	if err := c.WAL.Validate(); err != nil {
 		return fmt.Errorf("wal config validation failed: %w", err)
 	}
 

--- a/modules/generator/config.go
+++ b/modules/generator/config.go
@@ -55,6 +55,8 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.Storage.RegisterFlagsAndApplyDefaults(prefix, f)
 	cfg.TracesWAL.RegisterFlags(f)
 	cfg.TracesWAL.Version = encoding.DefaultEncoding().Version()
+	cfg.TracesQueryWAL.RegisterFlags(f)
+	cfg.TracesQueryWAL.Version = encoding.DefaultEncoding().Version()
 
 	// setting default for max span age before discarding to 30s
 	cfg.MetricsIngestionSlack = 30 * time.Second
@@ -79,17 +81,11 @@ func (cfg *Config) Validate() error {
 
 	// Only validate if being used
 	if cfg.TracesWAL.Filepath != "" {
-		if cfg.TracesWAL.Version == "" {
-			cfg.TracesWAL.Version = encoding.LatestEncoding().Version()
-		}
 		if err := cfg.TracesWAL.Validate(); err != nil {
 			return err
 		}
 	}
 	if cfg.TracesQueryWAL.Filepath != "" {
-		if cfg.TracesQueryWAL.Version == "" {
-			cfg.TracesQueryWAL.Version = encoding.LatestEncoding().Version()
-		}
 		if err := cfg.TracesQueryWAL.Validate(); err != nil {
 			return err
 		}

--- a/modules/generator/config.go
+++ b/modules/generator/config.go
@@ -29,11 +29,12 @@ const (
 
 // Config for a generator.
 type Config struct {
-	Ring      RingConfig      `yaml:"ring"`
-	Processor ProcessorConfig `yaml:"processor"`
-	Registry  registry.Config `yaml:"registry"`
-	Storage   storage.Config  `yaml:"storage"`
-	TracesWAL wal.Config      `yaml:"traces_storage"`
+	Ring           RingConfig      `yaml:"ring"`
+	Processor      ProcessorConfig `yaml:"processor"`
+	Registry       registry.Config `yaml:"registry"`
+	Storage        storage.Config  `yaml:"storage"`
+	TracesWAL      wal.Config      `yaml:"traces_storage"`
+	TracesQueryWAL wal.Config      `yaml:"traces_query_storage"`
 	// MetricsIngestionSlack is the max amount of time passed since a span's end time
 	// for the span to be considered in metrics generation
 	MetricsIngestionSlack time.Duration `yaml:"metrics_ingestion_time_range_slack"`
@@ -72,6 +73,24 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 func (cfg *Config) Validate() error {
 	if cfg.Ingest.Enabled {
 		if err := cfg.Ingest.Kafka.Validate(); err != nil {
+			return err
+		}
+	}
+
+	// Only validate if being used
+	if cfg.TracesWAL.Filepath != "" {
+		if cfg.TracesWAL.Version == "" {
+			cfg.TracesWAL.Version = encoding.LatestEncoding().Version()
+		}
+		if err := cfg.TracesWAL.Validate(); err != nil {
+			return err
+		}
+	}
+	if cfg.TracesQueryWAL.Filepath != "" {
+		if cfg.TracesQueryWAL.Version == "" {
+			cfg.TracesQueryWAL.Version = encoding.LatestEncoding().Version()
+		}
+		if err := cfg.TracesQueryWAL.Validate(); err != nil {
 			return err
 		}
 	}

--- a/modules/generator/generator.go
+++ b/modules/generator/generator.go
@@ -319,7 +319,7 @@ func (g *Generator) createInstance(id string) (*instance, error) {
 	}
 
 	// Create traces wal if configured
-	var tracesWAL *tempodb_wal.WAL
+	var tracesWAL, tracesWAL2 *tempodb_wal.WAL
 
 	if g.cfg.TracesWAL.Filepath != "" {
 		// Create separate wals per tenant by prefixing path with tenant ID
@@ -332,9 +332,17 @@ func (g *Generator) createInstance(id string) (*instance, error) {
 			_ = wal.Close()
 			return nil, err
 		}
+
+		tracesWALCfg2 := tracesWALCfg
+		tracesWALCfg2.Filepath += "2"
+		tracesWAL2, err = tempodb_wal.New(&tracesWALCfg2)
+		if err != nil {
+			_ = wal.Close()
+			return nil, err
+		}
 	}
 
-	inst, err := newInstance(g.cfg, id, g.overrides, wal, reg, g.logger, tracesWAL, g.store)
+	inst, err := newInstance(g.cfg, id, g.overrides, wal, reg, g.logger, tracesWAL, tracesWAL2, g.store)
 	if err != nil {
 		_ = wal.Close()
 		return nil, err

--- a/modules/generator/generator_test.go
+++ b/modules/generator/generator_test.go
@@ -165,7 +165,7 @@ func BenchmarkPushSpans(b *testing.B) {
 	wal, err := storage.New(walcfg, o, tenant, reg, log)
 	require.NoError(b, err)
 
-	inst, err := newInstance(cfg, tenant, o, wal, reg, log, nil, nil)
+	inst, err := newInstance(cfg, tenant, o, wal, reg, log, nil, nil, nil)
 	require.NoError(b, err)
 	defer inst.shutdown()
 
@@ -234,7 +234,7 @@ func BenchmarkCollect(b *testing.B) {
 	wal, err := storage.New(walcfg, o, tenant, reg, log)
 	require.NoError(b, err)
 
-	inst, err := newInstance(cfg, tenant, o, wal, reg, log, nil, nil)
+	inst, err := newInstance(cfg, tenant, o, wal, reg, log, nil, nil, nil)
 	require.NoError(b, err)
 	defer inst.shutdown()
 

--- a/modules/generator/instance_test.go
+++ b/modules/generator/instance_test.go
@@ -33,10 +33,10 @@ func Test_instance_concurrency(t *testing.T) {
 		servicegraphs.Name: {},
 	}
 
-	instance1, err := newInstance(&Config{}, "test", overrides, &noopStorage{}, prometheus.DefaultRegisterer, log.NewNopLogger(), nil, nil)
+	instance1, err := newInstance(&Config{}, "test", overrides, &noopStorage{}, prometheus.DefaultRegisterer, log.NewNopLogger(), nil, nil, nil)
 	assert.NoError(t, err)
 
-	instance2, err := newInstance(&Config{}, "test", overrides, &noopStorage{}, prometheus.DefaultRegisterer, log.NewNopLogger(), nil, nil)
+	instance2, err := newInstance(&Config{}, "test", overrides, &noopStorage{}, prometheus.DefaultRegisterer, log.NewNopLogger(), nil, nil, nil)
 	assert.NoError(t, err)
 
 	end := make(chan struct{})
@@ -87,7 +87,7 @@ func Test_instance_updateProcessors(t *testing.T) {
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
 	overrides := mockOverrides{}
 
-	instance, err := newInstance(&cfg, "test", &overrides, &noopStorage{}, prometheus.DefaultRegisterer, logger, nil, nil)
+	instance, err := newInstance(&cfg, "test", &overrides, &noopStorage{}, prometheus.DefaultRegisterer, logger, nil, nil, nil)
 	assert.NoError(t, err)
 
 	// stop the update goroutine

--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -1101,14 +1101,21 @@ func (e *MetricsEvalulator) sampleExemplar(id []byte) bool {
 // MetricsFrontendEvaluator pipes the sharded job results back into the engine for the rest
 // of the pipeline.  i.e. This evaluator is for the query-frontend.
 type MetricsFrontendEvaluator struct {
+	mtx             sync.Mutex
 	metricsPipeline metricsFirstStageElement
 }
 
 func (m *MetricsFrontendEvaluator) ObserveSeries(in []*tempopb.TimeSeries) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
 	m.metricsPipeline.observeSeries(in)
 }
 
 func (m *MetricsFrontendEvaluator) Results() SeriesSet {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
 	return m.metricsPipeline.result()
 }
 

--- a/tempodb/config.go
+++ b/tempodb/config.go
@@ -163,7 +163,7 @@ func validateConfig(cfg *Config) error {
 		cfg.WAL.Version = cfg.Block.Version
 	}
 
-	err := wal.ValidateConfig(cfg.WAL)
+	err := cfg.WAL.Validate()
 	if err != nil {
 		return fmt.Errorf("wal config validation failed: %w", err)
 	}

--- a/tempodb/wal/wal.go
+++ b/tempodb/wal/wal.go
@@ -37,7 +37,7 @@ func (c *Config) RegisterFlags(*flag.FlagSet) {
 	c.IngestionSlack = 2 * time.Minute
 }
 
-func ValidateConfig(c *Config) error {
+func (c *Config) Validate() error {
 	if _, err := encoding.FromVersion(c.Version); err != nil {
 		return fmt.Errorf("failed to validate block version %s: %w", c.Version, err)
 	}


### PR DESCRIPTION
**What this PR does**:
As part of the new architecture rollout, this introduces a secondary instance of the local blocks processor.  It is used to serve traceql metrics queries of recent data received from the queue, and never flushes to object storage.  This isn't the long-term setup, but a transition between the current and new architectures. 

Some notes:
* The secondary local blocks processor lifetime follows the main processor. It is added or removed with it.
* It requires a separate WAL and config to ensure there is never any overlap with the data received to the normal processor.
* Updated some of the WAL config validation.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`