### PR TITLE
[rhythm] Multiple fixes to block-builder consumption

### DIFF
--- a/modules/blockbuilder/blockbuilder.go
+++ b/modules/blockbuilder/blockbuilder.go
@@ -251,7 +251,6 @@ func (b *BlockBuilder) consumePartition(ctx context.Context, partition int32, pa
 		// We iterate through all the ConsumeInterval intervals, starting from the first one after the last commit until the cycleEndTime,
 		// i.e. [T, T+interval), [T+interval, T+2*interval), ... [T+S*interval, cycleEndTime)
 		// where T is the CommitRecordTimestamp, the timestamp of the record, whose offset we committed previously.
-		// When there is no kafka commit, we play safe and assume LastSeenOffset, and LastBlockEnd were 0 to not discard any samples unnecessarily.
 		sectionEndTime, _ = nextCycleEnd(commitRecTs, b.cfg.ConsumeCycleDuration)
 	}
 

--- a/modules/blockbuilder/blockbuilder_test.go
+++ b/modules/blockbuilder/blockbuilder_test.go
@@ -326,6 +326,46 @@ func TestCycleEndAtStartup(t *testing.T) {
 	}
 }
 
+func TestNextCycleEnd(t *testing.T) {
+	tests := []struct {
+		name         string
+		t            time.Time
+		interval     time.Duration
+		expectedTime time.Time
+		expectedWait time.Duration
+	}{
+		{
+			name:         "ExactInterval",
+			t:            time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC),
+			interval:     time.Hour,
+			expectedTime: time.Date(2023, 10, 1, 13, 0, 0, 0, time.UTC),
+			expectedWait: time.Hour,
+		},
+		{
+			name:         "PastInterval",
+			t:            time.Date(2023, 10, 1, 12, 30, 0, 0, time.UTC),
+			interval:     time.Hour,
+			expectedTime: time.Date(2023, 10, 1, 13, 0, 0, 0, time.UTC),
+			expectedWait: 30 * time.Minute,
+		},
+		{
+			name:         "FutureInterval",
+			t:            time.Date(2023, 10, 1, 12, 0, 0, 1, time.UTC),
+			interval:     time.Hour,
+			expectedTime: time.Date(2023, 10, 1, 13, 0, 0, 0, time.UTC),
+			expectedWait: 59*time.Minute + 59*time.Second,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resultTime, resultWait := nextCycleEnd(tc.t, tc.interval)
+			require.Equal(t, tc.expectedTime, resultTime)
+			require.Equal(t, tc.expectedWait, resultWait)
+		})
+	}
+}
+
 func blockbuilderConfig(t *testing.T, address string) Config {
 	cfg := Config{}
 	flagext.DefaultValues(&cfg)

--- a/modules/blockbuilder/blockbuilder_test.go
+++ b/modules/blockbuilder/blockbuilder_test.go
@@ -353,7 +353,7 @@ func TestNextCycleEnd(t *testing.T) {
 			t:            time.Date(2023, 10, 1, 12, 0, 0, 1, time.UTC),
 			interval:     time.Hour,
 			expectedTime: time.Date(2023, 10, 1, 13, 0, 0, 0, time.UTC),
-			expectedWait: 59*time.Minute + 59*time.Second,
+			expectedWait: 59*time.Minute + 59*time.Second + 999999999*time.Nanosecond,
 		},
 	}
 

--- a/modules/blockbuilder/commit_meta.go
+++ b/modules/blockbuilder/commit_meta.go
@@ -1,0 +1,38 @@
+package blockbuilder
+
+import "fmt"
+
+const (
+	kafkaCommitMetaV1 = 1
+)
+
+// marshallCommitMeta generates the commit metadata string.
+// commitRecTs: timestamp of the record which was committed (and not the commit time).
+func marshallCommitMeta(commitRecTs int64) string {
+	return fmt.Sprintf("%d,%d", kafkaCommitMetaV1, commitRecTs)
+}
+
+// unmarshallCommitMeta parses the commit metadata string.
+// commitRecTs: timestamp of the record which was committed (and not the commit time).
+func unmarshallCommitMeta(s string) (commitRecTs int64, err error) {
+	if s == "" {
+		return
+	}
+	var (
+		version int
+		metaStr string
+	)
+	_, err = fmt.Sscanf(s, "%d,%s", &version, &metaStr)
+	if err != nil {
+		return 0, fmt.Errorf("invalid commit metadata format: parse meta version: %w", err)
+	}
+
+	if version != kafkaCommitMetaV1 {
+		return 0, fmt.Errorf("unsupported commit meta version %d", version)
+	}
+	_, err = fmt.Sscanf(metaStr, "%d", &commitRecTs)
+	if err != nil {
+		return 0, fmt.Errorf("invalid commit metadata format: %w", err)
+	}
+	return
+}

--- a/modules/blockbuilder/commit_meta_test.go
+++ b/modules/blockbuilder/commit_meta_test.go
@@ -1,0 +1,47 @@
+package blockbuilder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshallCommitMeta(t *testing.T) {
+	tests := []struct {
+		name         string
+		commitRecTs  int64
+		expectedMeta string
+	}{
+		{"ValidTimestamp", 1627846261, "1,1627846261"},
+		{"ZeroTimestamp", 0, "1,0"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			meta := marshallCommitMeta(tc.commitRecTs)
+			assert.Equal(t, tc.expectedMeta, meta, "expected: %s, got: %s", tc.expectedMeta, meta)
+		})
+	}
+}
+
+func TestUnmarshallCommitMeta(t *testing.T) {
+	tests := []struct {
+		name          string
+		meta          string
+		expectedTs    int64
+		expectedError bool
+	}{
+		{"ValidMeta", "1,1627846261", 1627846261, false},
+		{"InvalidMetaFormat", "1,invalid", 0, true},
+		{"UnsupportedVersion", "2,1627846261", 0, true},
+		{"EmptyMeta", "", 0, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ts, err := unmarshallCommitMeta(tc.meta)
+			assert.Equal(t, tc.expectedError, err != nil, "expected error: %v, got: %v", tc.expectedError, err)
+			assert.Equal(t, tc.expectedTs, ts, "expected: %d, got: %d", tc.expectedTs, ts)
+		})
+	}
+}

--- a/modules/blockbuilder/config_test.go
+++ b/modules/blockbuilder/config_test.go
@@ -59,7 +59,6 @@ func TestConfig_validate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.cfg.Validate()
 			assert.Equal(t, tc.expectedErr, err != nil, "unexpected error: %v", err)
-
 		})
 	}
 }

--- a/modules/blockbuilder/config_test.go
+++ b/modules/blockbuilder/config_test.go
@@ -29,7 +29,7 @@ func TestConfig_validate(t *testing.T) {
 						BloomFP:              0.1,
 						BloomShardSizeBytes:  1,
 						DedicatedColumns: backend.DedicatedColumns{
-							{backend.DedicatedColumnScopeResource, "foo", backend.DedicatedColumnTypeString},
+							{Scope: backend.DedicatedColumnScopeResource, Name: "foo", Type: backend.DedicatedColumnTypeString},
 						},
 					},
 				},

--- a/modules/blockbuilder/config_test.go
+++ b/modules/blockbuilder/config_test.go
@@ -1,0 +1,65 @@
+package blockbuilder
+
+import (
+	"testing"
+
+	"github.com/grafana/tempo/tempodb/backend"
+	"github.com/grafana/tempo/tempodb/encoding"
+	"github.com/grafana/tempo/tempodb/encoding/common"
+	v2 "github.com/grafana/tempo/tempodb/encoding/v2"
+	"github.com/grafana/tempo/tempodb/encoding/vparquet4"
+	"github.com/grafana/tempo/tempodb/wal"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfig_validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         Config
+		expectedErr bool
+	}{
+		{
+			name: "ValidConfig",
+			cfg: Config{
+				BlockConfig: BlockConfig{
+					BlockCfg: common.BlockConfig{
+						Version:              encoding.LatestEncoding().Version(),
+						IndexDownsampleBytes: 1,
+						IndexPageSizeBytes:   1,
+						BloomFP:              0.1,
+						BloomShardSizeBytes:  1,
+						DedicatedColumns: backend.DedicatedColumns{
+							{backend.DedicatedColumnScopeResource, "foo", backend.DedicatedColumnTypeString},
+						},
+					},
+				},
+				WAL: wal.Config{
+					Version: encoding.LatestEncoding().Version(),
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "InvalidBlockConfig",
+			cfg: Config{
+				BlockConfig: BlockConfig{
+					BlockCfg: common.BlockConfig{
+						Version:              vparquet4.VersionString,
+						IndexDownsampleBytes: 0,
+					},
+				},
+				WAL: wal.Config{
+					Version: v2.VersionString,
+				},
+			},
+			expectedErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			assert.Equal(t, tc.expectedErr, err != nil, "unexpected error: %v", err)
+
+		})
+	}
+}

--- a/modules/blockbuilder/partition_writer.go
+++ b/modules/blockbuilder/partition_writer.go
@@ -3,6 +3,7 @@ package blockbuilder
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -50,11 +51,11 @@ func newPartitionSectionWriter(logger log.Logger, partition, cycleEndTs int64, b
 }
 
 func (p *writer) pushBytes(tenant string, req *tempopb.PushBytesRequest) error {
-	level.Info(p.logger).Log(
+	level.Debug(p.logger).Log(
 		"msg", "pushing bytes",
 		"tenant", tenant,
 		"num_traces", len(req.Traces),
-		"id", util.TraceIDToHexString(req.Ids[0]),
+		"id", idsToString(req.Ids),
 	)
 
 	i, err := p.instanceForTenant(tenant)
@@ -120,4 +121,18 @@ func (p *writer) instanceForTenant(tenant string) (*tenantStore, error) {
 	p.m[tenant] = i
 
 	return i, nil
+}
+
+func idsToString(ids [][]byte) string {
+	b := strings.Builder{}
+	b.WriteString("[")
+	for i, id := range ids {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(util.TraceIDToHexString(id))
+	}
+	b.WriteString("]")
+
+	return b.String()
 }

--- a/modules/blockbuilder/util/id.go
+++ b/modules/blockbuilder/util/id.go
@@ -3,7 +3,6 @@ package util
 import (
 	"crypto/sha1"
 	"encoding/binary"
-	"unsafe"
 
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/tempodb/backend"
@@ -46,8 +45,9 @@ func newDeterministicID(seeds []int64) uuid.UUID {
 	return uuid.NewHash(hash, ns, b, 5)
 }
 
+// TODO - Try to avoid allocs here
 func stringToBytes(s string) []byte {
-	return unsafe.Slice(unsafe.StringData(s), unsafe.Sizeof(s))
+	return []byte(s)
 }
 
 func int64ToBytes(seeds ...int64) []byte {

--- a/modules/blockbuilder/util/id_test.go
+++ b/modules/blockbuilder/util/id_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/stretchr/testify/assert"
 )
@@ -12,7 +13,7 @@ import (
 func TestDeterministicIDGenerator(t *testing.T) {
 	ts := time.Now().UnixMilli()
 
-	gen := NewDeterministicIDGenerator(0, ts)
+	gen := NewDeterministicIDGenerator(util.FakeTenantID, 0, ts)
 
 	firstPassIDs := make(map[backend.UUID]struct{})
 	for seq := int64(0); seq < 10; seq++ {
@@ -26,7 +27,7 @@ func TestDeterministicIDGenerator(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	gen = NewDeterministicIDGenerator(0, ts)
+	gen = NewDeterministicIDGenerator(util.FakeTenantID, 0, ts)
 	for seq := int64(0); seq < 10; seq++ {
 		id := gen.NewID()
 		if _, ok := firstPassIDs[id]; !ok {
@@ -37,7 +38,7 @@ func TestDeterministicIDGenerator(t *testing.T) {
 
 func BenchmarkDeterministicID(b *testing.B) {
 	ts := time.Now().UnixMilli()
-	gen := NewDeterministicIDGenerator(ts)
+	gen := NewDeterministicIDGenerator(util.FakeTenantID, ts)
 	for i := 0; i < b.N; i++ {
 		_ = gen.NewID()
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This PR contains multiple fixes around block-builder consumption:

(1) Block IDs were identical between tenants. Now, the tenant ID has been added as parameter to generate IDs.
(2) `lag.Commit.At` was being used as the timestamp of the last commit, when in reality is the offset of the commit. This made calculations for consuming partition sections wrong and it was always falling back to `lookback_on_no_commit`. Now that the commit's timestamp is passed in the its meta and logic has been updated to fallback only when there is no commit meta.
(3) It was possible to consume the same section multiple times because we were using the commit's timestamp, instead of the commit's section end time.

Other fixes:

(4) Added more logs and reduced the level of some very noisy ones.
(5) Added and updated more tests.
