### PR TITLE
[DOC] Add overrides info to tempo-distributed doc

### DIFF
--- a/docs/sources/helm-charts/tempo-distributed/get-started-helm-charts/_index.md
+++ b/docs/sources/helm-charts/tempo-distributed/get-started-helm-charts/_index.md
@@ -507,7 +507,9 @@ This configuration:
 * An ingestion rate and burst size limit of 5MB/s, a maximum trace size of 10MB and a maximum of 1000 live traces in an ingester for all tenants
 * Overrides the '1234' tenant with a rate and burst size limit of 2MB/s, a maximum trace size of 5MB and a maximum of 400 live traces in an ingester
 
-Note that runtime configurations should include all options for a specific tenant.
+{{< admonition type="note" >}}
+Runtime configurations should include all options for a specific tenant.
+{{< /admonition >}}
 
 ## Install Grafana Tempo using the Helm chart
 

--- a/docs/sources/helm-charts/tempo-distributed/get-started-helm-charts/_index.md
+++ b/docs/sources/helm-charts/tempo-distributed/get-started-helm-charts/_index.md
@@ -464,6 +464,36 @@ To configure TLS with the Helm chart, you must have a TLS key-pair and CA certif
 
 For instructions, refer to [Configure TLS with Helm](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/network/tls/).
 
+### Optional: Use global or per-tenant overrides
+
+The `tempo-distributed` Helm chart provides a module for users to set global or per-tenant override settings:
+
+* Global overrides come under the `global_overrides` property, which pertain to the standard overrides
+* Per-tenant overrides come under the `overrides` property, and allow specific tenants to alter configuration associated with them as per tenant-specific runtime overrides. The Helm chart generates a `/runtime/overrides.yaml` configuration file for all per-tenant configuration.
+
+These overrides correlate to the standard (global) and tenant-specific (`per_tenant_overide_config`)overrides in Tempo and GET configuration.
+For more information about overrides, refer to the [Overrides configuration](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#overrides) documentation.
+
+Overrides can be used with both GET and Tempo.
+
+The following example configuration sets some global configuration options, as well as a set of options for a specific tenant:
+
+```yaml
+global_overrides:
+    default:
+        ingestion:
+          rate_limit_bytes: 5 * 1000 * 1000
+        metrics_generator:
+          processors: ['service-graphs', 'span-metrics']
+
+overrides:
+    '1234':
+        ingestion:
+          rate_limit_bytes: 2 * 1000 * 1000
+```
+
+This configuration enables the Span Metrics and Service Graph metrics-generator processors and an ingestion rate limit of 5MB/s for all tenants, *apart* from tenant '1234' which is ingestion rate limited to 2MB/s.
+
 ## Install Grafana Tempo using the Helm chart
 
 Use the following command to install Tempo using the configuration options you've specified in the `custom.yaml` file:

--- a/docs/sources/helm-charts/tempo-distributed/get-started-helm-charts/_index.md
+++ b/docs/sources/helm-charts/tempo-distributed/get-started-helm-charts/_index.md
@@ -483,6 +483,11 @@ global_overrides:
     default:
         ingestion:
           rate_limit_bytes: 5 * 1000 * 1000
+          burst_size_bytes: 5 * 1000 * 1000
+          max_traces_per_user: 1000
+        global:
+          max_bytes_per_trace: 10 * 1000 * 1000
+
         metrics_generator:
           processors: ['service-graphs', 'span-metrics']
 
@@ -490,9 +495,19 @@ overrides:
     '1234':
         ingestion:
           rate_limit_bytes: 2 * 1000 * 1000
+          burst_size_bytes: 2 * 1000 * 1000
+          max_traces_per_user: 400
+        global:
+          max_bytes_per_trace: 5 * 1000 * 1000
 ```
 
-This configuration enables the Span Metrics and Service Graph metrics-generator processors and an ingestion rate limit of 5MB/s for all tenants, *apart* from tenant '1234' which is ingestion rate limited to 2MB/s.
+This configuration:
+
+* Enables the Span Metrics and Service Graph metrics-generator processors for all tenants
+* An ingestion rate and burst size limit of 5MB/s, a maximum trace size of 10MB and a maximum of 1000 live traces in an ingester for all tenants
+* Overrides the '1234' tenant with a rate and burst size limit of 2MB/s, a maximum trace size of 5MB and a maximum of 400 live traces in an ingester
+
+Note that runtime configurations should include all options for a specific tenant.
 
 ## Install Grafana Tempo using the Helm chart
 


### PR DESCRIPTION
**What this PR does**:

Adds a section to the tempo-distributed Helm chart documentation explaining overrides and provide a sample configuration. 

The overrides section in the tempo-distributed Helm chart wasn't documented well and the configuration used didn't quite match the explanation in the Tempo configuration doc. This PR adds an example to the tempo-distributed Helm chart guide. We'll have another PR that will address issues in the tempo-distributed README. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/tempo/issues/3820

Related: 

- https://github.com/grafana/helm-charts/issues/2802, 
- https://github.com/grafana/tempo/issues/3987, 
- https://github.com/grafana/tempo/issues/4326
- https://github.com/grafana/tempo/issues/3855
- https://github.com/grafana/tempo/issues/3795
- https://github.com/grafana/helm-charts/issues/3171
- https://github.com/grafana/helm-charts/issues/3134
- https://github.com/grafana/helm-charts/pull/3463

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`