### PR TITLE
[rhythm] Make ID generator more robust

### DIFF
--- a/modules/blockbuilder/blockbuilder.go
+++ b/modules/blockbuilder/blockbuilder.go
@@ -297,7 +297,7 @@ func (b *BlockBuilder) consumePartitionSection(ctx context.Context, partition in
 	}(time.Now())
 
 	// TODO - Review what endTimestamp is used here
-	writer := newPartitionSectionWriter(b.logger, int64(partition), sectionEndTime.UnixMilli(), b.cfg.BlockConfig, b.overrides, b.wal, b.enc)
+	writer := newPartitionSectionWriter(b.logger, uint64(partition), uint64(sectionEndTime.UnixMilli()), b.cfg.BlockConfig, b.overrides, b.wal, b.enc)
 
 	// We always rewind the partition's offset to the commit offset by reassigning the partition to the client (this triggers partition assignment).
 	// This is so the cycle started exactly at the commit offset, and not at what was (potentially over-) consumed previously.

--- a/modules/blockbuilder/partition_writer.go
+++ b/modules/blockbuilder/partition_writer.go
@@ -26,7 +26,7 @@ type writer struct {
 	logger log.Logger
 
 	blockCfg              BlockConfig
-	partition, cycleEndTs int64
+	partition, cycleEndTs uint64
 
 	overrides Overrides
 	wal       *wal.WAL
@@ -36,7 +36,7 @@ type writer struct {
 	m   map[string]*tenantStore
 }
 
-func newPartitionSectionWriter(logger log.Logger, partition, cycleEndTs int64, blockCfg BlockConfig, overrides Overrides, wal *wal.WAL, enc encoding.VersionedEncoding) *writer {
+func newPartitionSectionWriter(logger log.Logger, partition, cycleEndTs uint64, blockCfg BlockConfig, overrides Overrides, wal *wal.WAL, enc encoding.VersionedEncoding) *writer {
 	return &writer{
 		logger:     logger,
 		partition:  partition,

--- a/modules/blockbuilder/tenant_store.go
+++ b/modules/blockbuilder/tenant_store.go
@@ -46,7 +46,7 @@ type tenantStore struct {
 	walBlocks []common.WALBlock
 }
 
-func newTenantStore(tenantID string, partitionID, endTimestamp int64, cfg BlockConfig, logger log.Logger, wal *wal.WAL, enc encoding.VersionedEncoding, o Overrides) (*tenantStore, error) {
+func newTenantStore(tenantID string, partitionID, endTimestamp uint64, cfg BlockConfig, logger log.Logger, wal *wal.WAL, enc encoding.VersionedEncoding, o Overrides) (*tenantStore, error) {
 	s := &tenantStore{
 		tenantID:     tenantID,
 		idGenerator:  util.NewDeterministicIDGenerator(tenantID, partitionID, endTimestamp),

--- a/modules/blockbuilder/util/id.go
+++ b/modules/blockbuilder/util/id.go
@@ -14,9 +14,7 @@ const (
 	sha1Version5 = 5
 )
 
-var (
-	ns = uuid.MustParse("28840903-6eb5-4ffb-8880-93a4fa98dbcb") // Random UUID
-)
+var ns = uuid.MustParse("28840903-6eb5-4ffb-8880-93a4fa98dbcb") // Random UUID
 
 type IDGenerator interface {
 	NewID() backend.UUID

--- a/modules/blockbuilder/util/id_test.go
+++ b/modules/blockbuilder/util/id_test.go
@@ -13,7 +13,7 @@ import (
 func TestDeterministicIDGenerator(t *testing.T) {
 	ts := time.Now().UnixMilli()
 
-	gen := NewDeterministicIDGenerator(util.FakeTenantID, 0, ts)
+	gen := NewDeterministicIDGenerator(util.FakeTenantID, 0, uint64(ts))
 
 	firstPassIDs := make(map[backend.UUID]struct{})
 	for seq := int64(0); seq < 10; seq++ {
@@ -27,7 +27,7 @@ func TestDeterministicIDGenerator(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	gen = NewDeterministicIDGenerator(util.FakeTenantID, 0, ts)
+	gen = NewDeterministicIDGenerator(util.FakeTenantID, 0, uint64(ts))
 	for seq := int64(0); seq < 10; seq++ {
 		id := gen.NewID()
 		if _, ok := firstPassIDs[id]; !ok {
@@ -39,8 +39,8 @@ func TestDeterministicIDGenerator(t *testing.T) {
 func FuzzDeterministicIDGenerator(f *testing.F) {
 	f.Skip()
 
-	f.Add(util.FakeTenantID, int64(42), int64(100))
-	f.Fuzz(func(t *testing.T, tenantID string, seed1, seed2 int64) {
+	f.Add(util.FakeTenantID, uint64(42), uint64(100))
+	f.Fuzz(func(t *testing.T, tenantID string, seed1, seed2 uint64) {
 		gen := NewDeterministicIDGenerator(tenantID, seed1, seed2)
 
 		for i := 0; i < 3; i++ {
@@ -56,8 +56,8 @@ func FuzzDeterministicIDGenerator(f *testing.F) {
 func BenchmarkDeterministicID(b *testing.B) {
 	tenant := util.FakeTenantID
 	ts := time.Now().UnixMilli()
-	partitionID := int64(0)
-	gen := NewDeterministicIDGenerator(tenant, partitionID, ts)
+	partitionID := uint64(0)
+	gen := NewDeterministicIDGenerator(tenant, partitionID, uint64(ts))
 	for i := 0; i < b.N; i++ {
 		_ = gen.NewID()
 	}

--- a/modules/blockbuilder/util/id_test.go
+++ b/modules/blockbuilder/util/id_test.go
@@ -36,9 +36,32 @@ func TestDeterministicIDGenerator(t *testing.T) {
 	}
 }
 
+func FuzzDeterministicIDGenerator(f *testing.F) {
+	f.Skip()
+
+	f.Add(util.FakeTenantID, int64(42))
+	f.Fuzz(func(t *testing.T, tenantID string, seed int64) {
+		gen := NewDeterministicIDGenerator(tenantID, seed)
+
+		for i := 0; i < 3; i++ {
+			if err := generateAndParse(gen); err != nil {
+				t.Errorf("Error generating and parsing ID: %v", err)
+			}
+		}
+	})
+}
+
+func generateAndParse(g IDGenerator) error {
+	id := g.NewID()
+	_, err := uuid.Parse(id.String())
+	return err
+}
+
 func BenchmarkDeterministicID(b *testing.B) {
+	tenant := util.FakeTenantID
 	ts := time.Now().UnixMilli()
-	gen := NewDeterministicIDGenerator(util.FakeTenantID, ts)
+	partitionID := int64(0)
+	gen := NewDeterministicIDGenerator(tenant, partitionID, ts)
 	for i := 0; i < b.N; i++ {
 		_ = gen.NewID()
 	}

--- a/modules/blockbuilder/util/id_test.go
+++ b/modules/blockbuilder/util/id_test.go
@@ -39,22 +39,18 @@ func TestDeterministicIDGenerator(t *testing.T) {
 func FuzzDeterministicIDGenerator(f *testing.F) {
 	f.Skip()
 
-	f.Add(util.FakeTenantID, int64(42))
-	f.Fuzz(func(t *testing.T, tenantID string, seed int64) {
-		gen := NewDeterministicIDGenerator(tenantID, seed)
+	f.Add(util.FakeTenantID, int64(42), int64(100))
+	f.Fuzz(func(t *testing.T, tenantID string, seed1, seed2 int64) {
+		gen := NewDeterministicIDGenerator(tenantID, seed1, seed2)
 
 		for i := 0; i < 3; i++ {
-			if err := generateAndParse(gen); err != nil {
-				t.Errorf("Error generating and parsing ID: %v", err)
+			id := gen.NewID()
+			_, err := uuid.Parse(id.String())
+			if err != nil {
+				t.Fatalf("failed to parse UUID: %v", err)
 			}
 		}
 	})
-}
-
-func generateAndParse(g IDGenerator) error {
-	id := g.NewID()
-	_, err := uuid.Parse(id.String())
-	return err
 }
 
 func BenchmarkDeterministicID(b *testing.B) {

--- a/modules/frontend/search_sharder.go
+++ b/modules/frontend/search_sharder.go
@@ -144,7 +144,7 @@ func (s *asyncSearchSharder) blockMetas(start, end int64, tenantID string) []*ba
 	for _, m := range allMetas {
 		if m.StartTime.Unix() <= end &&
 			m.EndTime.Unix() >= start &&
-			m.ReplicationFactor == backend.DefaultReplicationFactor { // This check skips generator blocks (RF=1)
+			m.ReplicationFactor == backend.MetricsGeneratorReplicationFactor { // This check skips generator blocks (RF=1)
 			metas = append(metas, m)
 		}
 	}

--- a/modules/frontend/search_sharder.go
+++ b/modules/frontend/search_sharder.go
@@ -144,7 +144,7 @@ func (s *asyncSearchSharder) blockMetas(start, end int64, tenantID string) []*ba
 	for _, m := range allMetas {
 		if m.StartTime.Unix() <= end &&
 			m.EndTime.Unix() >= start &&
-			m.ReplicationFactor == backend.MetricsGeneratorReplicationFactor { // This check skips generator blocks (RF=1)
+			m.ReplicationFactor == backend.DefaultReplicationFactor { // This check skips generator blocks (RF=1)
 			metas = append(metas, m)
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Improves the deterministic ID generator to allocate less memory and be robust to all kinds of inputs.

Probably not a fair comparison, but still:

<details>
<summary>
Benchmark vs `uuid.New()` 
</summary>

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/tempo/modules/blockbuilder/util
cpu: Apple M2 Pro
BenchmarkDeterministicID-12    	 8512278	       125.5 ns/op	     120 B/op	       4 allocs/op
BenchmarkDeterministicID-12    	 9522423	       124.7 ns/op	     120 B/op	       4 allocs/op
BenchmarkDeterministicID-12    	 9609878	       126.4 ns/op	     120 B/op	       4 allocs/op
BenchmarkDeterministicID-12    	 8931763	       136.2 ns/op	     120 B/op	       4 allocs/op
BenchmarkDeterministicID-12    	 8639715	       136.5 ns/op	     120 B/op	       4 allocs/op
BenchmarkDeterministicID-12    	 8680236	       146.6 ns/op	     120 B/op	       4 allocs/op
BenchmarkDeterministicID-12    	 8684743	       137.5 ns/op	     120 B/op	       4 allocs/op
BenchmarkDeterministicID-12    	 7703137	       140.7 ns/op	     120 B/op	       4 allocs/op
BenchmarkDeterministicID-12    	 8473578	       136.9 ns/op	     120 B/op	       4 allocs/op
BenchmarkDeterministicID-12    	 8839968	       149.4 ns/op	     120 B/op	       4 allocs/op
BenchmarkNewID-12              	 4698474	       256.1 ns/op	      16 B/op	       1 allocs/op
BenchmarkNewID-12              	 4671002	       255.4 ns/op	      16 B/op	       1 allocs/op
BenchmarkNewID-12              	 4707766	       255.3 ns/op	      16 B/op	       1 allocs/op
BenchmarkNewID-12              	 4633113	       257.3 ns/op	      16 B/op	       1 allocs/op
BenchmarkNewID-12              	 4654569	       257.4 ns/op	      16 B/op	       1 allocs/op
BenchmarkNewID-12              	 4631960	       260.3 ns/op	      16 B/op	       1 allocs/op
BenchmarkNewID-12              	 4648914	       257.1 ns/op	      16 B/op	       1 allocs/op
BenchmarkNewID-12              	 4283595	       257.9 ns/op	      16 B/op	       1 allocs/op
BenchmarkNewID-12              	 4703736	       254.7 ns/op	      16 B/op	       1 allocs/op
BenchmarkNewID-12              	 4499523	       256.0 ns/op	      16 B/op	       1 allocs/op
PASS
ok  	github.com/grafana/tempo/modules/blockbuilder/util	29.115s
```

</details>