### PR TITLE
Ingester: Rate limit max trace logs and drop too many live traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [CHANGE] Return 422 for TRACE_TOO_LARGE queries [#4160](https://github.com/grafana/tempo/pull/4160) (@zalegrala)
 * [CHANGE] Upgrade OTEL sdk to reduce allocs [#4243](https://github.com/grafana/tempo/pull/4243) (@joe-elliott)
 * [CHANGE] Tighten file permissions [#4251](https://github.com/grafana/tempo/pull/4251) (@zalegrala)
+* [CHANGE] Drop max live traces log message and rate limit trace too large. [#4418](https://github.com/grafana/tempo/pull/4418) (@joe-elliott)
 * [FEATURE] tempo-cli: support dropping multiple traces in a single operation [#4266](https://github.com/grafana/tempo/pull/4266) (@ndk)
 * [FEATURE] Discarded span logging `log_discarded_spans` [#3957](https://github.com/grafana/tempo/issues/3957) (@dastrobu)
 * [FEATURE] TraceQL support for instrumentation scope [#3967](https://github.com/grafana/tempo/pull/3967) (@ie-pham)

--- a/pkg/util/log/rate_limited_logger.go
+++ b/pkg/util/log/rate_limited_logger.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	gkLog "github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"golang.org/x/time/rate"
 )
 
@@ -12,6 +14,14 @@ type RateLimitedLogger struct {
 	logger  gkLog.Logger
 }
 
+var metricDropedLines = promauto.NewCounter(prometheus.CounterOpts{
+	Namespace: "tempo",
+	Name:      "dropped_log_lines_total",
+	Help:      "The total number of log lines dropped by the rate limited logger.",
+})
+
+// NewRateLimitedLogger returns a new RateLimitedLogger that logs at most logsPerSecond messages per second.
+// TODO: migrate to the dskit rate limited logger
 func NewRateLimitedLogger(logsPerSecond int, logger gkLog.Logger) *RateLimitedLogger {
 	return &RateLimitedLogger{
 		limiter: rate.NewLimiter(rate.Limit(logsPerSecond), 1),
@@ -21,6 +31,7 @@ func NewRateLimitedLogger(logsPerSecond int, logger gkLog.Logger) *RateLimitedLo
 
 func (l *RateLimitedLogger) Log(keyvals ...interface{}) {
 	if !l.limiter.AllowN(time.Now(), 1) {
+		metricDropedLines.Inc()
 		return
 	}
 


### PR DESCRIPTION
**What this PR does**:
- Drops the max live traces log in the ingesters. This information is redundant with the `tempo_discarded_spans_total` metrics and costly to log in high volume envs
- Rate limit "max byte per trace" log lines.
- Convert instance to use a local logger instead of the global one

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`