### PR TITLE
Fix Grpc streaming handling of Authorization header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 * [BUGFIX] Replace hedged requests roundtrips total with a counter. [#4063](https://github.com/grafana/tempo/pull/4063) [#4078](https://github.com/grafana/tempo/pull/4078) (@galalen)
 * [BUGFIX] Metrics generators: Correctly drop from the ring before stopping ingestion to reduce drops during a rollout. [#4101](https://github.com/grafana/tempo/pull/4101) (@joe-elliott)
 * [BUGFIX] Correctly handle 400 Bad Request and 404 Not Found in gRPC streaming [#4144](https://github.com/grafana/tempo/pull/4144) (@mapno)
+* [BUGFIX] Correctly handle Authorization header in gRPC streaming [#4419](https://github.com/grafana/tempo/pull/4419) (@mdisibio)
 * [BUGFIX] Pushes a 0 to classic histogram's counter when the series is new to allow Prometheus to start from a non-null value. [#4140](https://github.com/grafana/tempo/pull/4140) (@mapno)
 * [BUGFIX] Fix counter samples being downsampled by backdate to the previous minute the initial sample when the series is new [#4236](https://github.com/grafana/tempo/pull/4236) (@javiermolinar)
 * [BUGFIX] Fix traceql metrics returning incorrect data for falsey queries and unscoped attributes [#4409](https://github.com/grafana/tempo/pull/4409) (@mdisibio)

--- a/modules/frontend/grpc_util.go
+++ b/modules/frontend/grpc_util.go
@@ -1,0 +1,31 @@
+package frontend
+
+import (
+	"context"
+	"net/http"
+
+	"google.golang.org/grpc/metadata"
+)
+
+var copyHeaders = []string{
+	"Authorization",
+	"X-Scope-OrgID",
+}
+
+func headersFromGrpcContext(ctx context.Context) (hs http.Header) {
+	hs = http.Header{}
+
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		// Tests may not have metadata so skip
+		return
+	}
+
+	for _, h := range copyHeaders {
+		if v := md.Get(h); len(v) > 0 {
+			hs[h] = v
+		}
+	}
+
+	return
+}

--- a/modules/frontend/metrics_query_handler.go
+++ b/modules/frontend/metrics_query_handler.go
@@ -32,6 +32,8 @@ func newQueryInstantStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTri
 			return err
 		}
 
+		headers := headersFromGrpcContext(ctx)
+
 		// --------------------------------------------------
 		// Rewrite into a query_range request.
 		// --------------------------------------------------
@@ -43,7 +45,7 @@ func newQueryInstantStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTri
 		}
 		httpReq := api.BuildQueryRangeRequest(&http.Request{
 			URL:    &url.URL{Path: downstreamPath},
-			Header: http.Header{},
+			Header: headers,
 			Body:   io.NopCloser(bytes.NewReader([]byte{})),
 		}, qr, "") // dedicated cols are never passed from the caller
 		httpReq = httpReq.Clone(ctx)

--- a/modules/frontend/metrics_query_range_handler.go
+++ b/modules/frontend/metrics_query_range_handler.go
@@ -25,13 +25,16 @@ func newQueryRangeStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripp
 	downstreamPath := path.Join(apiPrefix, api.PathMetricsQueryRange)
 
 	return func(req *tempopb.QueryRangeRequest, srv tempopb.StreamingQuerier_MetricsQueryRangeServer) error {
+		ctx := srv.Context()
+
+		headers := headersFromGrpcContext(ctx)
+
 		httpReq := api.BuildQueryRangeRequest(&http.Request{
 			URL:    &url.URL{Path: downstreamPath},
-			Header: http.Header{},
+			Header: headers,
 			Body:   io.NopCloser(bytes.NewReader([]byte{})),
 		}, req, "") // dedicated cols are never passed from the caller
 
-		ctx := srv.Context()
 		httpReq = httpReq.WithContext(ctx)
 		tenant, _ := user.ExtractOrgID(ctx)
 		start := time.Now()

--- a/modules/frontend/tag_handlers.go
+++ b/modules/frontend/tag_handlers.go
@@ -332,9 +332,11 @@ func extractTenantWithErrorResp(req *http.Request, logger log.Logger) (string, *
 }
 
 func buildTagsRequestAndExtractTenant(ctx context.Context, req *tempopb.SearchTagsRequest, downstreamPath string, logger log.Logger) (*http.Request, string, error) {
+	headers := headersFromGrpcContext(ctx)
+
 	httpReq, err := api.BuildSearchTagsRequest(&http.Request{
 		URL:    &url.URL{Path: downstreamPath},
-		Header: http.Header{},
+		Header: headers,
 		Body:   io.NopCloser(bytes.NewReader([]byte{})),
 	}, req)
 	if err != nil {
@@ -353,9 +355,11 @@ func buildTagsRequestAndExtractTenant(ctx context.Context, req *tempopb.SearchTa
 }
 
 func buildTagValuesRequestAndExtractTenant(ctx context.Context, req *tempopb.SearchTagValuesRequest, downstreamPath string, logger log.Logger) (*http.Request, string, error) {
+	headers := headersFromGrpcContext(ctx)
+
 	httpReq, err := api.BuildSearchTagValuesRequest(&http.Request{
 		URL:    &url.URL{Path: downstreamPath},
-		Header: http.Header{},
+		Header: headers,
 		Body:   io.NopCloser(bytes.NewReader([]byte{})),
 	}, req)
 	if err != nil {


### PR DESCRIPTION
**What this PR does**:
The gRPC streaming endpoints are unintentionally dropping auth-related headers when issuing jobs to the queriers, so streaming + auth fails.  We need to extract them from the gRPC metadata and include them in the job.  The fix is here, but it is for downstream [Grafana Enterprise Traces](https://grafana.com/docs/enterprise-traces/latest/)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`