### PR TITLE
Exit early on autocomplete noops

### DIFF
--- a/pkg/traceql/engine.go
+++ b/pkg/traceql/engine.go
@@ -238,12 +238,6 @@ func (e *Engine) createAutocompleteRequest(tag Attribute, pipeline Pipeline) Fet
 
 	pipeline.extractConditions(&req)
 
-	// TODO: remove other conditions for the wantAttr we're searching for
-	// for _, cond := range fetchSpansRequest.Conditions {
-	// 	if cond.Attribute == wantAttr {
-	// 		return fmt.Errorf("cannot search for tag values for tag that is already used in query")
-	// 	}
-	// }
 	req.Conditions = append(req.Conditions, Condition{
 		Attribute: tag,
 		Op:        OpNone,

--- a/pkg/traceql/engine.go
+++ b/pkg/traceql/engine.go
@@ -177,6 +177,14 @@ func (e *Engine) ExecuteTagValues(
 	span.SetAttributes(attribute.String("pipeline", rootExpr.Pipeline.String()))
 	span.SetAttributes(attribute.String("autocompleteReq", fmt.Sprint(autocompleteReq)))
 
+	// If the tag we are fetching is already filtered in the query, then this is a noop.
+	// I.e. we are autocompleting resource.service.name and the query was {resource.service.name="foo"}
+	for _, c := range autocompleteReq.Conditions {
+		if c.Attribute == tag && c.Op == OpEqual {
+			return nil
+		}
+	}
+
 	return fetcher.Fetch(ctx, autocompleteReq, cb)
 }
 

--- a/pkg/traceql/engine_test.go
+++ b/pkg/traceql/engine_test.go
@@ -666,6 +666,12 @@ func TestExecuteTagValues(t *testing.T) {
 				{Type: "string", Value: "redis call"},
 			},
 		},
+		{
+			name:           "noop", // autocompleting an attribute already filtered by the query
+			attribute:      "name",
+			query:          `{ name = "foo" }`,
+			expectedValues: []tempopb.TagValue{},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			distinctValues := collector.NewDistinctValue[tempopb.TagValue](100_000, 0, 0, func(v tempopb.TagValue) int { return len(v.Type) + len(v.Value) })


### PR DESCRIPTION
**What this PR does**:
This fixes a gap in autocomplete where it's possible to autocomplete an attribute that's already being filtered in the query. This should be a noop but is actually executed.

Example:
`/api/v2/search/tag/name/values?query={name="foo"}`   

Since we already know `name` must be `foo`, there is no reason to scan for the autocomplete values.  

This PR adds the check to ExecuteTagValues in the engine. This is lower than preferred, ideally we would add this to the query-frontend, but the amount of pipeline reuse, and the location of the loose parsing of `query` make that non-trivial.  But want to get this fix in sooner.

Notes:
It's only valid to exit early when it is the Equal operation, and not any case where the attribute is present in the query.  For example these queries are filtering the same tag but can still return a range of values:

* `{ .foo =~ "bar.*"}`
* `{ .foo > 0 }`
* `{ .foo != nil }`


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`