### PR TITLE
Add golangci-lint cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,15 @@ jobs:
       - name: check-jsonnetfmt
         run: make check-jsonnetfmt
 
+      - name: Get year and week number
+        id: get-year-week-number
+        run: echo "date=$(date +"%Yweek%U")" >> $GITHUB_OUTPUT
+
       - name: cache golangci
         uses: actions/cache@v4
         with:
           path: .cache/golangci-lint
-          key: ${{ runner.os }}-lint-${{ hashFiles('go.mod', 'go.sum', '.golangci.yml', 'Makefile') }}
+          key: golangci-lint-${{ runner.os }}-${{ steps.get-year-week-number.outputs.date }}-${{ hashFiles('go.mod', '.golangci.yml') }}
 
       - name: lint
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,16 @@ jobs:
       - name: check-jsonnetfmt
         run: make check-jsonnetfmt
 
+      - name: cache golangci
+        uses: actions/cache@v4
+        with:
+          path: .cache/golangci-lint
+          key: ${{ runner.os }}-lint-${{ hashFiles('go.mod', 'go.sum', '.golangci.yml', 'Makefile') }}
+
       - name: lint
-        run: make lint base=origin/${{github.base_ref}}
+        run: |
+          make lint base=origin/${{github.base_ref}}
+          sudo chown -R $(id -u):$(id -g) .cache/golangci-lint  # needed to archive cache
 
   unit-tests:
     name: Run Unit Tests

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ integration/e2e/deployments/e2e_integration_test[0-9]*
 .tempo.yaml
 /tmp
 gh-token.txt
+.cache

--- a/Makefile
+++ b/Makefile
@@ -171,9 +171,9 @@ check-jsonnetfmt: jsonnetfmt
 .PHONY: lint
 lint: # linting
 ifneq ($(base),)
-	$(TOOLS_CMD) $(LINT) run --config .golangci.yml --new-from-rev=$(base)
+	$(LINT_CMD) $(LINT) run --config .golangci.yml --new-from-rev=$(base)
 else
-	$(TOOLS_CMD) $(LINT) run --config .golangci.yml
+	$(LINT_CMD) $(LINT) run --config .golangci.yml
 endif
 
 ##@ Docker Images

--- a/build/tools.mk
+++ b/build/tools.mk
@@ -17,6 +17,7 @@ TOOLS_IMAGE_TAG ?= main-e87b8d4
 GOTOOLS ?= $(shell cd $(TOOL_DIR) && go list -e -f '{{ .Imports }}' -tags tools |tr -d '[]')
 
 TOOLS_CMD = docker run --rm -t -v ${PWD}:/tools $(TOOLS_IMAGE):$(TOOLS_IMAGE_TAG)
+LINT_CMD =  docker run --rm -t -v ${PWD}:/tools -v ${PWD}/.cache/golangci-lint:/root/.cache/golangci-lint $(TOOLS_IMAGE):$(TOOLS_IMAGE_TAG)
 
 .PHONY: tools-image-build
 tools-image-build:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Make use of the linter cache to shorten duration in CI and locally.
In CI it goes approximately 2:30 to 1:30 minutes.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`