### PR TITLE
[TraceQL] Improve performance of select() queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ querier:
 * [ENHANCEMENT] Reduce allocs related to marshalling dedicated columns repeatedly in the query frontend. [#4007](https://github.com/grafana/tempo/pull/4007) (@joe-elliott)
 * [ENHANCEMENT] Improve performance of TraceQL queries [#4114](https://github.com/grafana/tempo/pull/4114) (@mdisibio)
 * [ENHANCEMENT] Improve performance of TraceQL queries [#4163](https://github.com/grafana/tempo/pull/4163) (@mdisibio) 
+* [ENHANCEMENT] Improve performance of some TraceQL queries using select() operation [#4438](https://github.com/grafana/tempo/pull/4438) (@mdisibio)
 * [ENHANCEMENT] Reduce memory usage of classic histograms in the span-metrics and service-graphs processors [#4232](https://github.com/grafana/tempo/pull/4232) (@mdisibio)
 * [ENHANCEMENT] Implement simple Fetch by key for cache items  [#4032](https://github.com/grafana/tempo/pull/4032) (@javiermolinar)
 * [ENHANCEMENT] Replace Grafana Agent example by Grafana Alloy[#4030](https://github.com/grafana/tempo/pull/4030) (@javiermolinar)

--- a/pkg/traceql/ast.go
+++ b/pkg/traceql/ast.go
@@ -159,10 +159,6 @@ func (p Pipeline) extractConditions(req *FetchSpansRequest) {
 	for _, element := range p.Elements {
 		element.extractConditions(req)
 	}
-	// TODO this needs to be fine-tuned a bit, e.g. { .foo = "bar" } | by(.namespace), AllConditions can still be true
-	if len(p.Elements) > 1 {
-		req.AllConditions = false
-	}
 }
 
 func (p Pipeline) evaluate(input []*Spanset) (result []*Spanset, err error) {
@@ -197,6 +193,7 @@ func newGroupOperation(e FieldExpression) GroupOperation {
 
 func (o GroupOperation) extractConditions(request *FetchSpansRequest) {
 	o.Expression.extractConditions(request)
+	request.AllConditions = false
 }
 
 type CoalesceOperation struct{}
@@ -265,7 +262,6 @@ func (o ScalarOperation) impliedType() StaticType {
 func (o ScalarOperation) extractConditions(request *FetchSpansRequest) {
 	o.LHS.extractConditions(request)
 	o.RHS.extractConditions(request)
-	request.AllConditions = false
 }
 
 type Aggregate struct {
@@ -292,6 +288,7 @@ func (a Aggregate) impliedType() StaticType {
 }
 
 func (a Aggregate) extractConditions(request *FetchSpansRequest) {
+	request.AllConditions = false
 	if a.e != nil {
 		a.e.extractConditions(request)
 	}
@@ -421,7 +418,6 @@ func (ScalarFilter) __spansetExpression() {}
 func (f ScalarFilter) extractConditions(request *FetchSpansRequest) {
 	f.lhs.extractConditions(request)
 	f.rhs.extractConditions(request)
-	request.AllConditions = false
 }
 
 // **********************

--- a/pkg/traceql/ast_conditions_test.go
+++ b/pkg/traceql/ast_conditions_test.go
@@ -147,6 +147,21 @@ func TestScalarFilter_extractConditions(t *testing.T) {
 			},
 			allConditions: false,
 		},
+		{
+			query: `({ span.http.status_code = 200 } | count()) > ({ span.http.status_code = 500 } | count())`,
+			conditions: []Condition{
+				newCondition(NewScopedAttribute(AttributeScopeSpan, false, "http.status_code"), OpEqual, NewStaticInt(200)),
+				newCondition(NewScopedAttribute(AttributeScopeSpan, false, "http.status_code"), OpEqual, NewStaticInt(500)),
+			},
+			allConditions: false,
+		},
+		{
+			query: `{ .foo = "a" } | 3 > 2`,
+			conditions: []Condition{
+				newCondition(NewAttribute("foo"), OpEqual, NewStaticString("a")),
+			},
+			allConditions: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.query, func(t *testing.T) {

--- a/pkg/traceql/ast_conditions_test.go
+++ b/pkg/traceql/ast_conditions_test.go
@@ -230,7 +230,7 @@ func TestSelect_extractConditions(t *testing.T) {
 			secondPassConditions: []Condition{
 				newCondition(NewScopedAttribute(AttributeScopeResource, false, "service.name"), OpNone),
 			},
-			allConditions: false,
+			allConditions: true,
 		},
 		{
 			query: `{ } | select(.name,name)`,
@@ -241,7 +241,7 @@ func TestSelect_extractConditions(t *testing.T) {
 				newCondition(NewAttribute("name"), OpNone),
 				newCondition(NewIntrinsic(IntrinsicName), OpNone),
 			},
-			allConditions: false,
+			allConditions: true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/traceql/ast_test.go
+++ b/pkg/traceql/ast_test.go
@@ -610,7 +610,7 @@ func TestPipelineExtractConditions(t *testing.T) {
 					newCondition(NewAttribute("foo1"), OpEqual, NewStaticString("a")),
 					newCondition(NewAttribute("foo2"), OpEqual, NewStaticString("b")),
 				},
-				AllConditions: false,
+				AllConditions: true,
 			},
 		},
 		{

--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -592,6 +592,7 @@ func BenchmarkBackendBlockTraceQL(b *testing.B) {
 		{"||", "{ resource.service.name = `loki-querier` } || { resource.service.name = `loki-gateway` }"},
 		{"mixed", `{resource.namespace!="" && resource.service.name="cortex-gateway" && duration>50ms && resource.cluster=~"prod.*"}`},
 		{"complex", `{resource.cluster=~"prod.*" && resource.namespace = "tempo-prod" && resource.container="query-frontend" && name = "HTTP GET - tempo_api_v2_search_tags" && span.http.status_code = 200 && duration > 1s}`},
+		{"select", `{resource.cluster=~"prod.*" && resource.namespace = "tempo-prod"} | select(resource.container)`},
 	}
 
 	ctx := context.TODO()

--- a/tempodb/encoding/vparquet4/block_traceql_test.go
+++ b/tempodb/encoding/vparquet4/block_traceql_test.go
@@ -943,6 +943,7 @@ func BenchmarkBackendBlockTraceQL(b *testing.B) {
 		{"||", "{ resource.service.name = `loki-querier` } || { resource.service.name = `loki-gateway` }"},
 		{"mixed", `{resource.namespace!="" && resource.service.name="cortex-gateway" && duration>50ms && resource.cluster=~"prod.*"}`},
 		{"complex", `{resource.cluster=~"prod.*" && resource.namespace = "tempo-prod" && resource.container="query-frontend" && name = "HTTP GET - tempo_api_v2_search_tags" && span.http.status_code = 200 && duration > 1s}`},
+		{"select", `{resource.cluster=~"prod.*" && resource.namespace = "tempo-prod"} | select(resource.container)`},
 	}
 
 	ctx := context.TODO()


### PR DESCRIPTION
**What this PR does**:
This fixes the internal processing of some traceql queries to support more cases where AllConditions should be true- notably `select()` queries. This means we can push all of the filtering down to storage more efficiently.    The code change is to remove the check at the top when any multiple pipeline stages exist, and instead push let the individual elements decide.  There are some remaining queries that maybe should also be AllConditions like `{ } | avg(duration) > 1s`, but they are left unchanged until they can be reviewed more thoroughly.  


Benchmark:
```
goos: darwin
goarch: arm64
pkg: github.com/grafana/tempo/tempodb/encoding/vparquet3
cpu: Apple M4 Pro
                                                 │  before.txt  │              after.txt               │
                                                 │    sec/op    │    sec/op      vs base               │
BackendBlockTraceQL/spanAttValMatch                 66.19m ± 1%    68.19m ±  2%   +3.03% (p=0.002 n=6)
BackendBlockTraceQL/spanAttValNoMatch               1.552m ± 1%    1.582m ±  1%   +1.97% (p=0.004 n=6)
BackendBlockTraceQL/spanAttIntrinsicMatch           36.95m ± 1%    37.99m ±  3%   +2.80% (p=0.004 n=6)
BackendBlockTraceQL/spanAttIntrinsicNoMatch         1.213m ± 1%    1.226m ± 29%   +1.05% (p=0.015 n=6)
BackendBlockTraceQL/resourceAttValMatch             290.4m ± 1%    294.8m ±  1%   +1.54% (p=0.002 n=6)
BackendBlockTraceQL/resourceAttValNoMatch           1.223m ± 1%    1.231m ±  1%   +0.65% (p=0.002 n=6)
BackendBlockTraceQL/resourceAttIntrinsicMatch       9.966m ± 1%   10.140m ±  1%   +1.75% (p=0.002 n=6)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01    1.203m ± 0%    1.213m ±  1%   +0.84% (p=0.002 n=6)
BackendBlockTraceQL/traceOrMatch                    149.1m ± 1%    149.8m ±  1%        ~ (p=0.132 n=6)
BackendBlockTraceQL/traceOrNoMatch                  143.2m ± 2%    146.3m ±  2%   +2.14% (p=0.009 n=6)
BackendBlockTraceQL/mixedValNoMatch                 93.23m ± 2%    93.67m ±  1%        ~ (p=0.310 n=6)
BackendBlockTraceQL/mixedValMixedMatchAnd           1.365m ± 1%    1.381m ±  1%        ~ (p=0.180 n=6)
BackendBlockTraceQL/mixedValMixedMatchOr            91.70m ± 1%    92.40m ±  1%        ~ (p=0.093 n=6)
BackendBlockTraceQL/count                           239.7m ± 2%    243.9m ±  2%        ~ (p=0.065 n=6)
BackendBlockTraceQL/struct                          268.8m ± 4%    268.9m ±  4%        ~ (p=0.818 n=6)
BackendBlockTraceQL/||                              106.0m ± 1%    106.0m ±  1%        ~ (p=0.937 n=6)
BackendBlockTraceQL/mixed                           30.36m ± 0%    30.71m ±  1%   +1.14% (p=0.002 n=6)
BackendBlockTraceQL/complex                         1.770m ± 1%    1.770m ±  2%        ~ (p=0.818 n=6)
BackendBlockTraceQL/select                         199.03m ± 2%    15.68m ±  3%  -92.12% (p=0.002 n=6)
geomean                                             24.97m         22.09m        -11.53%

                                                 │  before.txt  │                after.txt                │
                                                 │     B/s      │      B/s        vs base                 │
BackendBlockTraceQL/spanAttValMatch                216.9Mi ± 1%    210.5Mi ±  2%     -2.94% (p=0.002 n=6)
BackendBlockTraceQL/spanAttValNoMatch              1.076Gi ± 1%    1.055Gi ±  1%     -1.93% (p=0.004 n=6)
BackendBlockTraceQL/spanAttIntrinsicMatch          405.6Mi ± 1%    394.5Mi ±  3%     -2.72% (p=0.004 n=6)
BackendBlockTraceQL/spanAttIntrinsicNoMatch        960.2Mi ± 1%    950.2Mi ± 23%     -1.04% (p=0.015 n=6)
BackendBlockTraceQL/resourceAttValMatch            48.74Mi ± 1%    48.00Mi ±  1%     -1.51% (p=0.002 n=6)
BackendBlockTraceQL/resourceAttValNoMatch          141.1Mi ± 1%    140.2Mi ±  1%     -0.64% (p=0.002 n=6)
BackendBlockTraceQL/resourceAttIntrinsicMatch      1.234Gi ± 1%    1.213Gi ±  1%     -1.72% (p=0.002 n=6)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01   172.1Mi ± 0%    170.7Mi ±  1%     -0.83% (p=0.002 n=6)
BackendBlockTraceQL/traceOrMatch                   87.23Mi ± 1%    86.80Mi ±  1%          ~ (p=0.143 n=6)
BackendBlockTraceQL/traceOrNoMatch                 6.056Mi ± 2%    5.927Mi ±  2%     -2.13% (p=0.009 n=6)
BackendBlockTraceQL/mixedValNoMatch                21.25Mi ± 2%    21.16Mi ±  1%          ~ (p=0.310 n=6)
BackendBlockTraceQL/mixedValMixedMatchAnd          135.4Mi ± 1%    133.9Mi ±  1%          ~ (p=0.139 n=6)
BackendBlockTraceQL/mixedValMixedMatchOr           166.4Mi ± 1%    165.2Mi ±  1%          ~ (p=0.093 n=6)
BackendBlockTraceQL/count                          58.99Mi ± 2%    57.97Mi ±  2%          ~ (p=0.065 n=6)
BackendBlockTraceQL/struct                         58.67Mi ± 4%    58.66Mi ±  4%          ~ (p=0.851 n=6)
BackendBlockTraceQL/||                             134.2Mi ± 1%    134.2Mi ±  1%          ~ (p=0.937 n=6)
BackendBlockTraceQL/mixed                          460.6Mi ± 0%    455.4Mi ±  1%     -1.13% (p=0.002 n=6)
BackendBlockTraceQL/complex                        870.9Mi ± 3%    869.7Mi ±  1%          ~ (p=0.818 n=6)
BackendBlockTraceQL/select                         71.52Mi ± 2%   907.61Mi ±  3%  +1169.10% (p=0.002 n=6)
geomean                                            156.0Mi         176.4Mi          +13.02%

                                                 │ before.txt  │              after.txt              │
                                                 │  MB_io/op   │  MB_io/op    vs base                │
BackendBlockTraceQL/spanAttValMatch                 15.05 ± 0%    15.05 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/spanAttValNoMatch               1.793 ± 0%    1.793 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/spanAttIntrinsicMatch           15.72 ± 0%    15.72 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/spanAttIntrinsicNoMatch         1.221 ± 0%    1.221 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/resourceAttValMatch             14.84 ± 0%    14.84 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/resourceAttValNoMatch          180.9m ± 0%   180.9m ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/resourceAttIntrinsicMatch       13.21 ± 0%    13.21 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/resourceAttIntrinsicMatch#01   217.1m ± 0%   217.1m ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/traceOrMatch                    13.63 ± 0%    13.63 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/traceOrNoMatch                 909.1m ± 0%   909.1m ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/mixedValNoMatch                 2.078 ± 0%    2.078 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/mixedValMixedMatchAnd          193.9m ± 0%   193.9m ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/mixedValMixedMatchOr            16.00 ± 0%    16.00 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/count                           14.82 ± 0%    14.82 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/struct                          16.54 ± 0%    16.54 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/||                              14.91 ± 0%    14.91 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/mixed                           14.66 ± 0%    14.66 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/complex                         1.607 ± 1%    1.611 ± 2%       ~ (p=0.937 n=6)
BackendBlockTraceQL/select                          14.93 ± 0%    14.93 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                             4.085         4.085       +0.01%
¹ all samples are equal

                                                 │   before.txt   │              after.txt               │
                                                 │      B/op      │     B/op       vs base               │
BackendBlockTraceQL/spanAttValMatch                  29.68Mi ± 0%   29.74Mi ±  1%        ~ (p=0.699 n=6)
BackendBlockTraceQL/spanAttValNoMatch                1.539Mi ± 0%   1.539Mi ±  0%        ~ (p=0.329 n=6)
BackendBlockTraceQL/spanAttIntrinsicMatch            14.80Mi ± 0%   14.79Mi ±  1%        ~ (p=0.485 n=6)
BackendBlockTraceQL/spanAttIntrinsicNoMatch          1.096Mi ± 0%   1.096Mi ±  0%        ~ (p=0.781 n=6)
BackendBlockTraceQL/resourceAttValMatch              316.7Mi ± 0%   317.0Mi ±  0%        ~ (p=0.699 n=6)
BackendBlockTraceQL/resourceAttValNoMatch            1.071Mi ± 0%   1.071Mi ±  0%        ~ (p=0.275 n=6)
BackendBlockTraceQL/resourceAttIntrinsicMatch        1.321Mi ± 0%   1.321Mi ±  0%        ~ (p=0.331 n=6)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01     1.073Mi ± 0%   1.073Mi ±  0%        ~ (p=0.701 n=6)
BackendBlockTraceQL/traceOrMatch                     12.72Mi ± 7%   12.89Mi ±  5%        ~ (p=0.589 n=6)
BackendBlockTraceQL/traceOrNoMatch                   11.17Mi ± 0%   11.17Mi ±  2%        ~ (p=0.240 n=6)
BackendBlockTraceQL/mixedValNoMatch                  1.581Mi ± 0%   1.580Mi ±  0%        ~ (p=0.567 n=6)
BackendBlockTraceQL/mixedValMixedMatchAnd            1.074Mi ± 0%   1.074Mi ±  0%        ~ (p=0.922 n=6)
BackendBlockTraceQL/mixedValMixedMatchOr             2.117Mi ± 2%   2.116Mi ±  2%        ~ (p=0.589 n=6)
BackendBlockTraceQL/count                            231.6Mi ± 0%   231.4Mi ±  0%        ~ (p=0.589 n=6)
BackendBlockTraceQL/struct                           11.99Mi ± 4%   12.00Mi ± 23%        ~ (p=0.699 n=6)
BackendBlockTraceQL/||                               16.41Mi ± 0%   16.41Mi ±  0%        ~ (p=0.240 n=6)
BackendBlockTraceQL/mixed                            4.211Mi ± 0%   4.211Mi ±  0%        ~ (p=0.240 n=6)
BackendBlockTraceQL/complex                          1.139Mi ± 0%   1.138Mi ±  0%        ~ (p=0.180 n=6)
BackendBlockTraceQL/select                         112.879Mi ± 1%   1.675Mi ±  0%  -98.52% (p=0.002 n=6)
geomean                                              6.665Mi        5.344Mi        -19.82%

                                                 │  before.txt  │               after.txt               │
                                                 │  allocs/op   │  allocs/op    vs base                 │
BackendBlockTraceQL/spanAttValMatch                 313.6k ± 0%   313.6k ±  0%        ~ (p=0.589 n=6)
BackendBlockTraceQL/spanAttValNoMatch               17.30k ± 0%   17.30k ±  0%        ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/spanAttIntrinsicMatch           118.4k ± 0%   118.4k ±  0%        ~ (p=0.905 n=6)
BackendBlockTraceQL/spanAttIntrinsicNoMatch         17.23k ± 0%   17.23k ±  0%        ~ (p=1.000 n=6)
BackendBlockTraceQL/resourceAttValMatch             2.293M ± 0%   2.293M ±  0%        ~ (p=0.307 n=6)
BackendBlockTraceQL/resourceAttValNoMatch           17.26k ± 0%   17.26k ±  0%        ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/resourceAttIntrinsicMatch       18.55k ± 0%   18.55k ±  0%        ~ (p=1.000 n=6)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01    17.26k ± 0%   17.26k ±  0%        ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/traceOrMatch                    120.2k ± 4%   121.3k ±  3%        ~ (p=0.108 n=6)
BackendBlockTraceQL/traceOrNoMatch                  111.7k ± 0%   111.7k ±  0%        ~ (p=0.636 n=6)
BackendBlockTraceQL/mixedValNoMatch                 18.04k ± 0%   18.04k ±  0%        ~ (p=0.567 n=6)
BackendBlockTraceQL/mixedValMixedMatchAnd           17.30k ± 0%   17.30k ±  0%        ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/mixedValMixedMatchOr            24.17k ± 0%   24.17k ±  0%        ~ (p=0.697 n=6)
BackendBlockTraceQL/count                           1.476M ± 0%   1.476M ±  0%        ~ (p=0.327 n=6)
BackendBlockTraceQL/struct                          53.40k ± 3%   53.74k ± 26%        ~ (p=0.394 n=6)
BackendBlockTraceQL/||                              141.7k ± 0%   141.6k ±  0%        ~ (p=0.154 n=6)
BackendBlockTraceQL/mixed                           47.56k ± 0%   47.56k ±  0%   -0.00% (p=0.043 n=6)
BackendBlockTraceQL/complex                         17.76k ± 0%   17.76k ±  0%        ~ (p=0.922 n=6)
BackendBlockTraceQL/select                         941.82k ± 1%   22.88k ±  0%  -97.57% (p=0.002 n=6)
geomean                                             70.38k        57.91k        -17.71%
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`