### PR TITLE
Migrate docker-ci-tools workflow to Github Actions

### DIFF
--- a/.github/workflows/docker-ci-tools.yml
+++ b/.github/workflows/docker-ci-tools.yml
@@ -1,0 +1,76 @@
+name: docker-ci-tools
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'tools/**'
+
+env:
+  IMAGE_NAME: grafana/tempo-ci-tools
+
+# Needed to login to DockerHub
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+
+  get-image-tag:
+    runs-on: ubuntu-24.04
+    outputs:
+      tag: ${{ steps.get-tag.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - id: get-tag
+        run: |
+          echo "tag=$(./tools/image-tag)" >> "$GITHUB_OUTPUT"
+
+  docker-ci-tools:
+    needs: get-image-tag
+    strategy:
+      matrix:
+        runner_arch: [ { runner: ubuntu-24.04, arch: amd64 }, { runner: github-hosted-ubuntu-arm64, arch: arm64 } ]
+    runs-on: ${{ matrix.runner_arch.runner }}
+    env:
+      TAG: ${{ needs.get-image-tag.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to DockerHub
+        uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login-v1.0.0
+
+      - name: docker-build-and-push
+        run: |
+          TAG_ARCH="$TAG-${{ matrix.runner_arch.arch }}"
+          docker build -f tools/Dockerfile -t $IMAGE_NAME:$TAG_ARCH .
+          docker push $IMAGE_NAME:$TAG_ARCH
+
+  manifest:
+    needs: ['get-image-tag', 'docker-ci-tools']
+    runs-on: ubuntu-latest
+    env:
+      TAG: ${{ needs.get-image-tag.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to DockerHub
+        uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login-v1.0.0
+
+      - name: docker-manifest-create-and-push
+        run: |
+          docker manifest create \
+          	$IMAGE_NAME:$TAG               \
+          	--amend $IMAGE_NAME:$TAG-amd64  \
+          	--amend $IMAGE_NAME:$TAG-arm64 
+          docker manifest push $IMAGE_NAME:$TAG
+
+          docker manifest create \
+          	$IMAGE_NAME:latest            \
+          	--amend $IMAGE_NAME:$TAG-amd64   \
+          	--amend $IMAGE_NAME:$TAG-arm64 
+          docker manifest push $IMAGE_NAME:latest


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Migrate the docker-ci-tools pipeline from Drone to Github Actions.
This includes building the Docker images, pushing them and creating the final manifest.

I've tested this in a branch of the main repo: https://github.com/grafana/tempo/actions/runs/12352580265/job/34469919545

Once merged, I'll test it by updating tools/go.mod and verifying that the produced image works.
Then we can delete the pipeline from Drone.

One change I've made from the original, to make it more efficient, is to trigger the workflow only when the tools directory changes, instead of on every commit.


**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`