### PR TITLE
fix(drone-sig): add missing `contents: read` permission

### DIFF
--- a/.github/workflows/drone-signature-check.yml
+++ b/.github/workflows/drone-signature-check.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   id-token: write
+  contents: read
 
 jobs:
   drone-signature-check:


### PR DESCRIPTION
**What this PR does**:

Currently, the workflow is broken as the reusable workflow requires `id-token: write` _and_ `contents: read`, but since we have overridden the default permissions, we need to re-add `contents: read`. 

[Workflow error example](https://github.com/grafana/tempo/actions/runs/12400150268):

> The workflow is not valid. .github/workflows/drone-signature-check.yml (Line: 17, Col: 3): Error calling workflow 'grafana/shared-workflows/.github/workflows/check-drone-signature.yaml@main'. The nested job 'check-drone-signature' is requesting 'contents: read', but is only allowed 'contents: none'.

**Which issue(s) this PR fixes**:
Fixes #

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`