### PR TITLE
Break the compaction loop if context is cancelled

### DIFF
--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -81,9 +81,12 @@ func (rw *readerWriter) compactionLoop(ctx context.Context) {
 		compactionCycle = rw.compactorCfg.CompactionCycle
 	}
 
-	ticker := time.NewTicker(compactionCycle)
-	defer ticker.Stop()
 	for {
+		// if the context is cancelled, we're shutting down and need to stop compacting
+		if ctx.Err() != nil {
+			break
+		}
+
 		doForAtLeast(ctx, compactionCycle, func() {
 			rw.compactOneTenant(ctx)
 		})


### PR DESCRIPTION
**What this PR does**:

In [this PR](https://github.com/grafana/tempo/pull/4420) we improved the compactors to drop out of a job if it lost ownership. We also introduced a bug where, during shutdown, the code would spin endlessly in a tight loop. This impacts the single binary mode significantly more than the distributed mode where compactors shut down very quickly. Also removed an unused ticker.

Thanks to @Wessie for finding the issue.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`