### PR TITLE
Remove pool goroutines from all components that don't need it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ querier:
 * [ENHANCEMENT] Update Azurite image. [#4298](https://github.com/grafana/tempo/pull/4464) (@javiermolinar)
 * [ENHANCEMENT] Update golang.org/x/crypto [#4474](https://github.com/grafana/tempo/pull/4474) (@javiermolinar)
 * [ENHANCEMENT] Distributor shim: add test verifying receiver works (including metrics) [#4477](https://github.com/grafana/tempo/pull/4477) (@yvrhdn)
-* [ENHANCEMENT] Reduce goroutines in all non-querier components and reduce ingester shutdown time. [#4484](https://github.com/grafana/tempo/pull/4484) (@joe-elliott)
+* [ENHANCEMENT] Reduce goroutines in all non-querier components. [#4484](https://github.com/grafana/tempo/pull/4484) (@joe-elliott)
 * [BUGFIX] Handle invalid TraceQL query filter in tag values v2 disk cache [#4392](https://github.com/grafana/tempo/pull/4392) (@electron0zero)
 * [BUGFIX] Replace hedged requests roundtrips total with a counter. [#4063](https://github.com/grafana/tempo/pull/4063) [#4078](https://github.com/grafana/tempo/pull/4078) (@galalen)
 * [BUGFIX] Metrics generators: Correctly drop from the ring before stopping ingestion to reduce drops during a rollout. [#4101](https://github.com/grafana/tempo/pull/4101) (@joe-elliott)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ querier:
 * [ENHANCEMENT] Update Azurite image. [#4298](https://github.com/grafana/tempo/pull/4464) (@javiermolinar)
 * [ENHANCEMENT] Update golang.org/x/crypto [#4474](https://github.com/grafana/tempo/pull/4474) (@javiermolinar)
 * [ENHANCEMENT] Distributor shim: add test verifying receiver works (including metrics) [#4477](https://github.com/grafana/tempo/pull/4477) (@yvrhdn)
+* [ENHANCEMENT] Reduce goroutines in all non-querier components and reduce ingester shutdown time. [#4484](https://github.com/grafana/tempo/pull/4484) (@joe-elliott)
 * [BUGFIX] Handle invalid TraceQL query filter in tag values v2 disk cache [#4392](https://github.com/grafana/tempo/pull/4392) (@electron0zero)
 * [BUGFIX] Replace hedged requests roundtrips total with a counter. [#4063](https://github.com/grafana/tempo/pull/4063) [#4078](https://github.com/grafana/tempo/pull/4078) (@galalen)
 * [BUGFIX] Metrics generators: Correctly drop from the ring before stopping ingestion to reduce drops during a rollout. [#4101](https://github.com/grafana/tempo/pull/4101) (@joe-elliott)

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -462,6 +462,13 @@ func (t *App) initOptionalStore() (services.Service, error) {
 }
 
 func (t *App) initStore() (services.Service, error) {
+	// the only component that needs a functioning tempodb pool are the queriers. all other components will just spin up
+	// hundreds of never used pool goroutines. set pool size to 0 here to avoid that.
+	if t.cfg.Target != Querier && t.cfg.Target != SingleBinary && t.cfg.Target != ScalableSingleBinary {
+		t.cfg.StorageConfig.Trace.Pool.MaxWorkers = 0
+		t.cfg.StorageConfig.Trace.Pool.QueueDepth = 0
+	}
+
 	store, err := tempo_storage.NewStore(t.cfg.StorageConfig, t.cacheProvider, log.Logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create store: %w", err)

--- a/modules/ingester/flush.go
+++ b/modules/ingester/flush.go
@@ -206,11 +206,6 @@ func (i *Ingester) flushLoop(j int) {
 		}
 
 		op := o.(*flushOp)
-		// if we're shutting down then abandon all work for the ingester to complete on startup
-		if i.flushQueues.IsStopped() {
-			handleAbandonedOp(op)
-			continue
-		}
 		op.attempts++
 
 		var retry bool

--- a/modules/ingester/flush.go
+++ b/modules/ingester/flush.go
@@ -204,7 +204,6 @@ func (i *Ingester) flushLoop(j int) {
 		if o == nil {
 			return
 		}
-
 		op := o.(*flushOp)
 		op.attempts++
 

--- a/modules/ingester/flush.go
+++ b/modules/ingester/flush.go
@@ -204,7 +204,13 @@ func (i *Ingester) flushLoop(j int) {
 		if o == nil {
 			return
 		}
+
 		op := o.(*flushOp)
+		// if we're shutting down then abandon all work for the ingester to complete on startup
+		if i.flushQueues.IsStopped() {
+			handleAbandonedOp(op)
+			continue
+		}
 		op.attempts++
 
 		var retry bool


### PR DESCRIPTION
**What this PR does**:
A few improvements that I wanted to keep out of https://github.com/grafana/tempo/pull/4483

- Set pool workers and queue len to 0 in all components that are not queriers. This just spins up dead goroutines for no reason.

![image](https://github.com/user-attachments/assets/ce5d0616-010c-44cf-b805-55b7c044a9dc)

- ~Complete all inflight jobs on ingester shutdown but refuse to do any new jobs. This should improve shutdown/restart time.~

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`