### PR TITLE
[Rhythm] Fix rewind to latest commit

### DIFF
--- a/modules/blockbuilder/blockbuilder.go
+++ b/modules/blockbuilder/blockbuilder.go
@@ -221,7 +221,7 @@ func (b *BlockBuilder) consumePartition(ctx context.Context, partition int32, ov
 
 	lastCommit, ok := commits.Lookup(topic, partition)
 	if ok && lastCommit.At >= 0 {
-		startOffset = startOffset.At(lastCommit.At)
+		startOffset = kgo.NewOffset().At(lastCommit.At)
 	} else {
 		startOffset = kgo.NewOffset().AtStart()
 	}


### PR DESCRIPTION
**What this PR does**:
Initializes the startoffset more correctly when rewinding.  Works for Kafka locally but then found to be an issue for other installs internally.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`