### PR TITLE
Add make targets for multi-arch tempo docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,12 @@ docker-component: check-component exe # not intended to be used directly
 	docker build -t grafana/$(COMPONENT) --build-arg=TARGETARCH=$(GOARCH) -f ./cmd/$(COMPONENT)/Dockerfile .
 	docker tag grafana/$(COMPONENT) $(COMPONENT)
 
+.PHONY: docker-component-multi
+docker-component-multi: check-component # not intended to be used directly
+	GOOS=linux GOARCH=amd64 $(MAKE) $(COMPONENT)
+	GOOS=linux GOARCH=arm64 $(MAKE) $(COMPONENT)
+	docker buildx build -t grafana/$(COMPONENT) --platform linux/amd64,linux/arm64 --output type=docker -f ./cmd/$(COMPONENT)/Dockerfile .
+
 .PHONY: docker-component-debug
 docker-component-debug: check-component exe-debug 
 	docker build -t grafana/$(COMPONENT)-debug --build-arg=TARGETARCH=$(GOARCH) -f ./cmd/$(COMPONENT)/Dockerfile_debug .
@@ -191,6 +197,10 @@ docker-component-debug: check-component exe-debug
 .PHONY: docker-tempo 
 docker-tempo: ## Build tempo docker image
 	COMPONENT=tempo $(MAKE) docker-component
+
+.PHONY: docker-tempo-multi
+docker-tempo-multi: ## Build multiarch image locally, requires containerd image store
+	COMPONENT=tempo $(MAKE) docker-component-multi
 
 docker-tempo-debug: ## Build tempo debug docker image
 	COMPONENT=tempo $(MAKE) docker-component-debug


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds new make target `docker-tempo-multi` that builds a multi-arch image with both x64 and arm.  This is a recent need for testing out changes in kubernetes clusters with different node types, and the multi-arch image simplifies things.  The main thing to call out is that storing these images locally in docker requires some customization to switch to the `containerd` image store (the default image store doesn't support multi-arch images).  So this isn't expected to be widely used but mainly for the Tempo team.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`