### PR TITLE
[rhythm] Fix ID generator copy bug

### DIFF
--- a/modules/blockbuilder/util/id.go
+++ b/modules/blockbuilder/util/id.go
@@ -39,7 +39,7 @@ func NewDeterministicIDGenerator(tenantID string, seeds ...uint64) *Deterministi
 func newBuf(tenantID []byte, seeds []uint64) []byte {
 	dl, sl := len(tenantID), len(seeds)
 	data := make([]byte, dl+sl*8+8) // tenantID bytes + 8 bytes per uint64 + 8 bytes for seq
-	copy(tenantID, data)
+	copy(data, tenantID)
 
 	for i, seed := range seeds {
 		binary.LittleEndian.PutUint64(data[dl+i*8:], seed)

--- a/modules/blockbuilder/util/id_test.go
+++ b/modules/blockbuilder/util/id_test.go
@@ -36,6 +36,18 @@ func TestDeterministicIDGenerator(t *testing.T) {
 	}
 }
 
+func TestDeterministicIDGeneratorWithDifferentTenants(t *testing.T) {
+	ts := time.Now().UnixMilli()
+	seed := uint64(42)
+
+	gen1 := NewDeterministicIDGenerator("tenant-1", seed, uint64(ts))
+	gen2 := NewDeterministicIDGenerator("tenant-2", seed, uint64(ts))
+
+	for i := 0; i < 10; i++ {
+		assert.NotEqualf(t, gen1.NewID(), gen2.NewID(), "IDs should be different")
+	}
+}
+
 func FuzzDeterministicIDGenerator(f *testing.F) {
 	f.Skip()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Fixes a bug in the deterministic ID generator in which the tenant ID was not being correctly copied to the bytes buffer

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`