### PR TITLE
Tempo: remove internal error reason for discarded spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [CHANGE] **BREAKING CHANGE** Removed `internal_error` as a reason from `tempo_discarded_spans_total`. [#4554](https://github.com/grafana/tempo/pull/4554) (@joe-elliott)
 * [BUGFIX] Choose a default step for a gRPC streaming query range request if none is provided. [#4546](https://github.com/grafana/tempo/pull/4546) (@joe-elliott)
   Fix an issue where the tempo-cli was not correctly dumping exemplar results.
 

--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -54,8 +54,6 @@ const (
 	reasonTraceTooLarge = "trace_too_large"
 	// reasonLiveTracesExceeded indicates that tempo is already tracking too many live traces in the ingesters for this user
 	reasonLiveTracesExceeded = "live_traces_exceeded"
-	// reasonInternalError indicates an unexpected error occurred processing these spans. analogous to a 500
-	reasonInternalError = "internal_error"
 	// reasonUnknown indicates a pushByte error at the ingester level not related to GRPC
 	reasonUnknown = "unknown_error"
 
@@ -443,7 +441,6 @@ func (d *Distributor) PushTraces(ctx context.Context, traces ptrace.Traces) (*te
 
 	keys, rebatchedTraces, truncatedAttributeCount, err := requestsByTraceID(batches, userID, spanCount, d.cfg.MaxSpanAttrByte)
 	if err != nil {
-		overrides.RecordDiscardedSpans(spanCount, reasonInternalError, userID)
 		logDiscardedResourceSpans(batches, userID, &d.cfg.LogDiscardedSpans, d.logger)
 		return nil, err
 	}
@@ -537,7 +534,6 @@ func (d *Distributor) sendToIngestersViaBytes(ctx context.Context, userID string
 	}, ring.DoBatchOptions{})
 	// if err != nil, we discarded everything because of an internal error (like "context cancelled")
 	if err != nil {
-		overrides.RecordDiscardedSpans(totalSpanCount, reasonInternalError, userID)
 		logDiscardedRebatchedSpans(traces, userID, &d.cfg.LogDiscardedSpans, d.logger)
 		return err
 	}


### PR DESCRIPTION
**What this PR does**:
Removes the `internal_error` reason from `tempo_discarded_spans_total`. We are removing this reason for two reasons:

1) It's unnecessary. The sending process (otel collector, alloy, whatever) receives a gRPC error and is aware of any lost spans.
2) This metric was being incremented when the sending client cancelled context for any reason and stopped sending through no fault of Tempo's.

This change puts the responsibility of reporting failed sends on the sending process which has more context about why a send failed and can better log/metric the event.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`