### PR TITLE
Use distroless base image for tempo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [ENHANCEMENT] Prevent queries in the ingester from blocking flushing traces to disk and memory spikes. [#4483](https://github.com/grafana/tempo/pull/4483) (@joe-elliott)
 * [ENHANCEMENT] Update tempo operational dashboard for new block-builder and v2 traces api [#4559](https://github.com/grafana/tempo/pull/4559) (@mdisibio)
 * [ENHANCEMENT] Improve block-builder performance by flushing blocks concurrently [#4565](https://github.com/grafana/tempo/pull/4565) (@mdisibio)
+* [ENHANCEMENT] Use distroless base container images for improved security [#4556](https://github.com/grafana/tempo/pull/4556) (@carles-grafana)
 * [BUGFIX] Choose a default step for a gRPC streaming query range request if none is provided. [#4546](https://github.com/grafana/tempo/pull/4576) (@joe-elliott)
   Correctly copy exemplars for metrics like `| rate()` when gRPC streaming.
 * [BUGFIX] Fix performance bottleneck and file cleanup in block builder [#4550](https://github.com/grafana/tempo/pull/4550) (@mdisibio)

--- a/cmd/tempo-cli/Dockerfile
+++ b/cmd/tempo-cli/Dockerfile
@@ -1,5 +1,12 @@
-FROM alpine:3.21 as certs
-RUN apk --update add ca-certificates
+FROM alpine:latest AS ca-certificates
+RUN apk add --update --no-cache ca-certificates
+
+FROM gcr.io/distroless/static-debian12:debug
+
+SHELL ["/busybox/sh", "-c"]
+
 ARG TARGETARCH
 COPY bin/linux/tempo-cli-${TARGETARCH} /tempo-cli
+COPY --from=ca-certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
 ENTRYPOINT ["/tempo-cli"]

--- a/cmd/tempo-query/Dockerfile
+++ b/cmd/tempo-query/Dockerfile
@@ -1,13 +1,17 @@
-FROM alpine:3.21 as certs
-RUN apk --update add ca-certificates
+FROM alpine:latest AS ca-certificates
+RUN apk add --update --no-cache ca-certificates
+
+FROM gcr.io/distroless/static-debian12:debug
+
+SHELL ["/busybox/sh", "-c"]
+
+RUN ["/busybox/addgroup", "-g", "10001", "-S", "tempo"]
+RUN ["/busybox/adduser", "-u", "10001", "-S", "tempo", "-G", "tempo"]
+
 ARG TARGETARCH
 COPY bin/linux/tempo-query-${TARGETARCH} /tempo-query
-
-RUN addgroup -g 10001 -S tempo && \
-    adduser -u 10001 -S tempo -G tempo
+COPY --from=ca-certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 USER 10001:10001
-
-COPY bin/linux/tempo-query-${TARGETARCH} /tempo-query
 
 ENTRYPOINT ["/tempo-query"]

--- a/cmd/tempo-vulture/Dockerfile
+++ b/cmd/tempo-vulture/Dockerfile
@@ -1,10 +1,16 @@
-FROM alpine:3.21 as certs
-RUN apk --update add ca-certificates
+FROM alpine:latest AS ca-certificates
+RUN apk add --update --no-cache ca-certificates
+
+FROM gcr.io/distroless/static-debian12:debug
+
+SHELL ["/busybox/sh", "-c"]
+
+RUN ["/busybox/addgroup", "-g", "10001", "-S", "tempo"]
+RUN ["/busybox/adduser", "-u", "10001", "-S", "tempo", "-G", "tempo"]
+
 ARG TARGETARCH
 COPY bin/linux/tempo-vulture-${TARGETARCH} /tempo-vulture
-
-RUN addgroup -g 10001 -S tempo && \
-    adduser -u 10001 -S tempo -G tempo
+COPY --from=ca-certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 USER 10001:10001
 

--- a/cmd/tempo/Dockerfile
+++ b/cmd/tempo/Dockerfile
@@ -1,13 +1,19 @@
-FROM alpine:3.21 AS certs
-RUN apk --update add ca-certificates
+FROM alpine:latest AS ca-certificates
+RUN apk add --update --no-cache ca-certificates
+
+FROM gcr.io/distroless/static-debian12:debug
+
+# we need this because some docker-compose files call chown assuming there's a shell
+SHELL ["/busybox/sh", "-c"]
+
+RUN ["/busybox/addgroup", "-g", "10001", "-S", "tempo"]
+RUN ["/busybox/adduser", "-u", "10001", "-S", "tempo", "-G", "tempo"]
+RUN ["/busybox/mkdir", "-p", "/var/tempo", "-m", "0700"]
+RUN ["/busybox/chown", "-R", "tempo:tempo", "/var/tempo"]
+
 ARG TARGETARCH
 COPY bin/linux/tempo-${TARGETARCH} /tempo
-
-RUN addgroup -g 10001 -S tempo && \
-    adduser -u 10001 -S tempo -G tempo
-
-RUN mkdir -p /var/tempo -m 0700 && \
-    chown -R tempo:tempo /var/tempo
+COPY --from=ca-certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 USER 10001:10001
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This image contains busybox, making debugging easier by running /busybox/sh

In addition, the latest ca-certificates from alpin are copied, as the ones in Debian are
severely out of date.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`