### PR TITLE
[rhythm] Implement group-consuming in the metrics-generator

### DIFF
--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -309,11 +309,6 @@ func (t *App) initGenerator() (services.Service, error) {
 	t.cfg.Generator.Ingest = t.cfg.Ingest
 	t.cfg.Generator.Ingest.Kafka.ConsumerGroup = generator.ConsumerGroup
 
-	if t.cfg.Target == SingleBinary && len(t.cfg.Generator.AssignedPartitions) == 0 {
-		// In SingleBinary mode always use partition 0. This is for small installs or local/debugging setups.
-		t.cfg.Generator.AssignedPartitions = map[string][]int32{t.cfg.Generator.InstanceID: {0}}
-	}
-
 	genSvc, err := generator.New(&t.cfg.Generator, t.Overrides, prometheus.DefaultRegisterer, t.partitionRing, t.store, log.Logger)
 	if errors.Is(err, generator.ErrUnconfigured) && t.cfg.Target != MetricsGenerator { // just warn if we're not running the metrics-generator
 		level.Warn(log.Logger).Log("msg", "metrics-generator is not configured.", "err", err)

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -658,7 +658,6 @@ metrics_generator:
     metrics_ingestion_time_range_slack: 30s
     query_timeout: 30s
     override_ring_key: metrics-generator
-    assigned_partitions: {}
     instance_id: hostname
 ingest:
     enabled: false

--- a/example/docker-compose/distributed/tempo-distributed.yaml
+++ b/example/docker-compose/distributed/tempo-distributed.yaml
@@ -18,6 +18,8 @@ memberlist:
   - ingester-0:7946
   - ingester-1:7946
   - ingester-2:7946
+  - metrics-generator-0:7946
+  - metrics-generator-1:7946
 
 compactor:
   compaction:

--- a/example/docker-compose/ingest-storage/docker-compose.yaml
+++ b/example/docker-compose/ingest-storage/docker-compose.yaml
@@ -196,19 +196,19 @@ services:
       - --enable-feature=exemplar-storage
       - --enable-feature=native-histograms
     volumes:
-      - ../shared/prometheus.yaml:/etc/prometheus.yaml
+      - ./prometheus.yaml:/etc/prometheus.yaml
     ports:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:11.0.0
+    image: grafana/grafana:11.4.0
     volumes:
-      - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+      - ../distributed/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_DISABLE_LOGIN_FORM=true
-      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor traceQLStreaming metricsSummary
+      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor metricsSummary
     ports:
       - "3000:3000"
 
@@ -235,3 +235,14 @@ services:
       "timeout": "1s"
     "ports":
       - "29092:29092"
+
+  "redpanda-console":
+    "image": "docker.redpanda.com/redpandadata/console:v2.7.0@sha256:6ee7ed1203a7d4fd4181765929b28cb2450296402d82cd4d1c491c2d5191f45d"
+    "environment":
+      - "CONFIG_FILEPATH=/etc/redpanda/redpanda-console-config.yaml"
+    volumes:
+      - "../shared/redpanda-console.yaml:/etc/redpanda/redpanda-console-config.yaml"
+    "ports":
+      - "8080:8080"
+    "depends_on":
+      - "kafka"

--- a/example/docker-compose/ingest-storage/prometheus.yaml
+++ b/example/docker-compose/ingest-storage/prometheus.yaml
@@ -1,0 +1,22 @@
+global:
+  scrape_interval:     15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: [ 'localhost:9090' ]
+  - job_name: 'tempo'
+    static_configs:
+      - targets:
+          - 'distributor:3200'
+          - 'ingester-0:3200'
+          - 'ingester-1:3200'
+          - 'ingester-2:3200'
+          - 'compactor:3200'
+          - 'querier:3200'
+          - 'query-frontend:3200'
+          - 'metrics-generator-0:3200'
+          - 'metrics-generator-1:3200'
+          - 'block-builder-0:3200'
+          - 'block-builder-1:3200'

--- a/example/docker-compose/ingest-storage/tempo.yaml
+++ b/example/docker-compose/ingest-storage/tempo.yaml
@@ -8,6 +8,7 @@ distributor:
     otlp:
       protocols:
         grpc:
+          endpoint: "distributor:4317"
   log_received_spans:
     enabled: true
   log_discarded_spans:
@@ -47,9 +48,11 @@ metrics_generator:
         send_exemplars: true
   traces_storage:
     path: /var/tempo/generator/traces
-  assigned_partitions:
-    metrics-generator-0: [0,2]
-    metrics-generator-1: [1]
+  traces_query_storage:
+    path: /var/tempo/generator/query_traces
+  processor:
+    local_blocks:
+      flush_to_storage: true
 
 storage:
   trace:
@@ -68,7 +71,7 @@ storage:
 overrides:
   defaults:
     metrics_generator:
-      processors: ['local-blocks']
+      processors: ['local-blocks', 'span-metrics', 'service-graphs']
       generate_native_histograms: both
 
 ingest:
@@ -78,7 +81,6 @@ ingest:
     topic:   tempo-ingest
 
 block_builder:
-  lookback_on_no_commit: 2m
   consume_cycle_duration: 30s
   assigned_partitions:
     block-builder-0: [0,2]

--- a/example/docker-compose/shared/redpanda-console.yaml
+++ b/example/docker-compose/shared/redpanda-console.yaml
@@ -1,0 +1,3 @@
+kafka:
+  brokers:
+    - kafka:9092

--- a/modules/generator/generator_kafka.go
+++ b/modules/generator/generator_kafka.go
@@ -3,17 +3,11 @@ package generator
 import (
 	"context"
 	"errors"
-	"fmt"
-	"sync"
 	"time"
 
 	"github.com/go-kit/log/level"
 	"github.com/grafana/tempo/pkg/ingest"
 	"github.com/grafana/tempo/pkg/tempopb"
-
-	"github.com/twmb/franz-go/pkg/kadm"
-	"github.com/twmb/franz-go/pkg/kerr"
-	"github.com/twmb/franz-go/pkg/kgo"
 )
 
 func (g *Generator) startKafka() {
@@ -42,7 +36,7 @@ func (g *Generator) listenKafka(ctx context.Context) {
 				// Starting up or shutting down
 				continue
 			}
-			err := g.readKafka(ctx)
+			err := g.consumePartition(ctx)
 			if err != nil {
 				level.Error(g.logger).Log("msg", "readKafka failed", "err", err)
 				continue
@@ -53,58 +47,8 @@ func (g *Generator) listenKafka(ctx context.Context) {
 	}
 }
 
-func (g *Generator) readKafka(ctx context.Context) error {
-	fallback := time.Now().Add(-time.Minute)
-
-	groupLag, err := getGroupLag(
-		ctx,
-		kadm.NewClient(g.kafkaClient),
-		g.cfg.Ingest.Kafka.Topic,
-		g.cfg.Ingest.Kafka.ConsumerGroup,
-		fallback,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to get group lag: %w", err)
-	}
-
-	assignedPartitions := g.getAssignedActivePartitions()
-
-	for _, partition := range assignedPartitions {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-
-		partitionLag, ok := groupLag.Lookup(g.cfg.Ingest.Kafka.Topic, partition)
-		if !ok {
-			return fmt.Errorf("lag for partition %d not found", partition)
-		}
-
-		if partitionLag.Lag <= 0 {
-			// Nothing to consume
-			continue
-		}
-
-		err := g.consumePartition(ctx, partition, partitionLag)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (g *Generator) consumePartition(ctx context.Context, partition int32, lag kadm.GroupMemberLag) error {
+func (g *Generator) consumePartition(ctx context.Context) error {
 	d := ingest.NewDecoder()
-
-	// We always rewind the partition's offset to the commit offset by reassigning the partition to the client (this triggers partition assignment).
-	// This is so the cycle started exactly at the commit offset, and not at what was (potentially over-) consumed previously.
-	// In the end, we remove the partition from the client (refer to the defer below) to guarantee the client always consumes
-	// from one partition at a time. I.e. when this partition is consumed, we start consuming the next one.
-	g.kafkaClient.AddConsumePartitions(map[string]map[int32]kgo.Offset{
-		g.cfg.Ingest.Kafka.Topic: {
-			partition: kgo.NewOffset().At(lag.Commit.At),
-		},
-	})
-	defer g.kafkaClient.RemoveConsumePartitions(map[string][]int32{g.cfg.Ingest.Kafka.Topic: {partition}})
 
 	fetches := g.kafkaClient.PollFetches(ctx)
 	fetches.EachError(func(_ string, _ int32, err error) {
@@ -142,82 +86,5 @@ func (g *Generator) consumePartition(ctx context.Context, partition int32, lag k
 		}
 	}
 
-	offsets := kadm.OffsetsFromFetches(fetches)
-	err := g.kafkaAdm.CommitAllOffsets(ctx, g.cfg.Ingest.Kafka.ConsumerGroup, offsets)
-	if err != nil {
-		return fmt.Errorf("generator failed to commit offsets: %w", err)
-	}
-
 	return nil
-}
-
-func getGroupLag(ctx context.Context, admClient *kadm.Client, topic, group string, fallback time.Time) (kadm.GroupLag, error) {
-	offsets, err := admClient.FetchOffsets(ctx, group)
-	if err != nil {
-		if !errors.Is(err, kerr.GroupIDNotFound) {
-			return nil, fmt.Errorf("fetch offsets: %w", err)
-		}
-	}
-	if err := offsets.Error(); err != nil {
-		return nil, fmt.Errorf("fetch offsets got error in response: %w", err)
-	}
-
-	startOffsets, err := admClient.ListStartOffsets(ctx, topic)
-	if err != nil {
-		return nil, err
-	}
-	endOffsets, err := admClient.ListEndOffsets(ctx, topic)
-	if err != nil {
-		return nil, err
-	}
-
-	resolveFallbackOffsets := sync.OnceValues(func() (kadm.ListedOffsets, error) {
-		return admClient.ListOffsetsAfterMilli(ctx, fallback.UnixMilli(), topic)
-	})
-	// If the group-partition in offsets doesn't have a commit, fall back depending on where fallbackOffsetMillis points at.
-	for topic, pt := range startOffsets.Offsets() {
-		for partition, startOffset := range pt {
-			if _, ok := offsets.Lookup(topic, partition); ok {
-				continue
-			}
-			fallbackOffsets, err := resolveFallbackOffsets()
-			if err != nil {
-				return nil, fmt.Errorf("resolve fallback offsets: %w", err)
-			}
-			o, ok := fallbackOffsets.Lookup(topic, partition)
-			if !ok {
-				return nil, fmt.Errorf("partition %d not found in fallback offsets for topic %s", partition, topic)
-			}
-			if o.Offset < startOffset.At {
-				// Skip the resolved fallback offset if it's before the partition's start offset (i.e. before the earliest offset of the partition).
-				// This should not happen in Kafka, but can happen in Kafka-compatible systems, e.g. Warpstream.
-				continue
-			}
-			offsets.Add(kadm.OffsetResponse{Offset: kadm.Offset{
-				Topic:       o.Topic,
-				Partition:   o.Partition,
-				At:          o.Offset,
-				LeaderEpoch: o.LeaderEpoch,
-			}})
-		}
-	}
-
-	descrGroup := kadm.DescribedGroup{
-		// "Empty" is the state that indicates that the group doesn't have active consumer members; this is always the case for block-builder,
-		// because we don't use group consumption.
-		State: "Empty",
-	}
-	return kadm.CalculateGroupLagWithStartOffsets(descrGroup, offsets, startOffsets, endOffsets), nil
-}
-
-func (g *Generator) getAssignedActivePartitions() []int32 {
-	activePartitionsCount := g.partitionRing.PartitionRing().ActivePartitionsCount()
-	assignedActivePartitions := make([]int32, 0, activePartitionsCount)
-	for _, partition := range g.cfg.AssignedPartitions[g.cfg.InstanceID] {
-		if partition > int32(activePartitionsCount) {
-			break
-		}
-		assignedActivePartitions = append(assignedActivePartitions, partition)
-	}
-	return assignedActivePartitions
 }

--- a/pkg/ingest/balancer.go
+++ b/pkg/ingest/balancer.go
@@ -1,0 +1,161 @@
+// Forked from https://github.com/grafana/loki/blob/fa6ef0a2caeeb4d31700287e9096e5f2c3c3a0d4/pkg/kafka/partitionring/consumer/balancer.go
+
+package ingest
+
+import (
+	"sort"
+
+	"github.com/grafana/dskit/ring"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+type cooperativeActiveStickyBalancer struct {
+	kgo.GroupBalancer
+	partitionRing ring.PartitionRingReader
+}
+
+// NewCooperativeActiveStickyBalancer creates a balancer that combines Kafka's cooperative sticky balancing
+// with partition ring awareness. It works by:
+//
+// 1. Using the partition ring to determine which partitions are "active" (i.e. should be processed)
+// 2. Filtering out inactive partitions from member assignments during rebalancing, but still assigning them
+// 3. Applying cooperative sticky balancing only to the active partitions
+//
+// This ensures that:
+// - Active partitions are balanced evenly across consumers using sticky assignment for optimal processing
+// - Inactive partitions are still assigned and consumed in a round-robin fashion, but without sticky assignment
+// - All partitions are monitored even if inactive, allowing quick activation when needed
+// - Partition handoff happens cooperatively to avoid stop-the-world rebalances
+//
+// This balancer should be used with [NewGroupClient] which monitors the partition ring and triggers
+// rebalancing when the set of active partitions changes. This ensures optimal partition distribution
+// as the active partition set evolves.
+func NewCooperativeActiveStickyBalancer(partitionRing ring.PartitionRingReader) kgo.GroupBalancer {
+	return &cooperativeActiveStickyBalancer{
+		GroupBalancer: kgo.CooperativeStickyBalancer(),
+		partitionRing: partitionRing,
+	}
+}
+
+func (*cooperativeActiveStickyBalancer) ProtocolName() string {
+	return "cooperative-active-sticky"
+}
+
+func (b *cooperativeActiveStickyBalancer) MemberBalancer(members []kmsg.JoinGroupResponseMember) (kgo.GroupMemberBalancer, map[string]struct{}, error) {
+	// Get active partitions from ring
+	activePartitions := make(map[int32]struct{})
+	for _, id := range b.partitionRing.PartitionRing().PartitionIDs() {
+		activePartitions[id] = struct{}{}
+	}
+
+	// Filter member metadata to only include active partitions
+	filteredMembers := make([]kmsg.JoinGroupResponseMember, len(members))
+	for i, member := range members {
+		var meta kmsg.ConsumerMemberMetadata
+		err := meta.ReadFrom(member.ProtocolMetadata)
+		if err != nil {
+			continue
+		}
+
+		// Filter owned partitions to only include active ones
+		filteredOwned := make([]kmsg.ConsumerMemberMetadataOwnedPartition, 0, len(meta.OwnedPartitions))
+		for _, owned := range meta.OwnedPartitions {
+			filtered := kmsg.ConsumerMemberMetadataOwnedPartition{
+				Topic:      owned.Topic,
+				Partitions: make([]int32, 0, len(owned.Partitions)),
+			}
+			for _, p := range owned.Partitions {
+				if _, isActive := activePartitions[p]; isActive {
+					filtered.Partitions = append(filtered.Partitions, p)
+				}
+			}
+			if len(filtered.Partitions) > 0 {
+				filteredOwned = append(filteredOwned, filtered)
+			}
+		}
+		meta.OwnedPartitions = filteredOwned
+
+		// Create filtered member
+		filteredMembers[i] = kmsg.JoinGroupResponseMember{
+			MemberID:         member.MemberID,
+			ProtocolMetadata: meta.AppendTo(nil),
+		}
+	}
+
+	balancer, err := kgo.NewConsumerBalancer(b, filteredMembers)
+	return balancer, balancer.MemberTopics(), err
+}
+
+// syncAssignments implements kgo.IntoSyncAssignment
+type syncAssignments []kmsg.SyncGroupRequestGroupAssignment
+
+func (s syncAssignments) IntoSyncAssignment() []kmsg.SyncGroupRequestGroupAssignment {
+	return s
+}
+
+func (b *cooperativeActiveStickyBalancer) Balance(balancer *kgo.ConsumerBalancer, topics map[string]int32) kgo.IntoSyncAssignment {
+	// Get active partition count
+	actives := b.partitionRing.PartitionRing().PartitionsCount()
+
+	// First, let the sticky balancer handle active partitions
+	activeTopics := make(map[string]int32)
+	inactiveTopics := make(map[string]int32)
+	for topic, total := range topics {
+		activeTopics[topic] = int32(actives)
+		if total > int32(actives) {
+			inactiveTopics[topic] = total - int32(actives)
+		}
+	}
+
+	// Get active partition assignment
+	assignment := b.GroupBalancer.(kgo.ConsumerBalancerBalance).Balance(balancer, activeTopics)
+
+	plan := assignment.IntoSyncAssignment()
+
+	// Get sorted list of members for deterministic round-robin
+	members := make([]string, 0, len(plan))
+	for _, m := range plan {
+		members = append(members, m.MemberID)
+	}
+	sort.Strings(members)
+
+	// Distribute inactive partitions round-robin
+	memberIdx := 0
+	for topic, numInactive := range inactiveTopics {
+		for p := int32(actives); p < int32(actives)+numInactive; p++ {
+			// Find the member's assignment
+			for i, m := range plan {
+				if m.MemberID == members[memberIdx] {
+					var meta kmsg.ConsumerMemberAssignment
+					err := meta.ReadFrom(m.MemberAssignment)
+					if err != nil {
+						continue
+					}
+
+					// Find or create topic assignment
+					found := false
+					for j, t := range meta.Topics {
+						if t.Topic == topic {
+							meta.Topics[j].Partitions = append(t.Partitions, p)
+							found = true
+							break
+						}
+					}
+					if !found {
+						meta.Topics = append(meta.Topics, kmsg.ConsumerMemberAssignmentTopic{
+							Topic:      topic,
+							Partitions: []int32{p},
+						})
+					}
+
+					plan[i].MemberAssignment = meta.AppendTo(nil)
+					break
+				}
+			}
+			memberIdx = (memberIdx + 1) % len(members)
+		}
+	}
+
+	return syncAssignments(plan)
+}

--- a/pkg/ingest/reader_client.go
+++ b/pkg/ingest/reader_client.go
@@ -3,9 +3,12 @@
 package ingest
 
 import (
+	"sync"
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/ring"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -36,6 +39,79 @@ func NewReaderClient(kafkaCfg KafkaConfig, metrics *kprom.Metrics, logger log.Lo
 		kafkaCfg.SetDefaultNumberOfPartitionsForAutocreatedTopics(logger)
 	}
 	return client, nil
+}
+
+type Client struct {
+	logger log.Logger
+	*kgo.Client
+
+	wg            sync.WaitGroup
+	stopCh        chan struct{}
+	partitionRing ring.PartitionRingReader
+}
+
+func NewGroupReaderClient(kafkaCfg KafkaConfig, partitionRing ring.PartitionRingReader, metrics *kprom.Metrics, logger log.Logger, opts ...kgo.Opt) (*Client, error) {
+	opts = append(opts,
+		kgo.ConsumerGroup(kafkaCfg.ConsumerGroup),
+		kgo.ConsumeTopics(kafkaCfg.Topic),
+		kgo.Balancers(NewCooperativeActiveStickyBalancer(partitionRing)),
+		kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()),
+	)
+
+	client, err := NewReaderClient(kafkaCfg, metrics, logger, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &Client{
+		Client:        client,
+		logger:        logger,
+		stopCh:        make(chan struct{}),
+		partitionRing: partitionRing,
+	}
+	// Start the partition monitor goroutine
+	c.wg.Add(1)
+	go c.monitorPartitions()
+
+	return c, nil
+}
+
+func (c *Client) monitorPartitions() {
+	defer c.wg.Done()
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	// Get initial partition count from the ring
+	lastPartitionCount := c.partitionRing.PartitionRing().PartitionsCount()
+
+	for {
+		select {
+		case <-c.stopCh:
+			return
+		case <-ticker.C:
+			// Get current partition count from the ring
+			currentPartitionCount := c.partitionRing.PartitionRing().PartitionsCount()
+			if currentPartitionCount != lastPartitionCount {
+				level.Info(c.logger).Log(
+					"msg", "partition count changed, triggering rebalance",
+					"previous_count", lastPartitionCount,
+					"current_count", currentPartitionCount,
+				)
+				// Trigger a rebalance to update partition assignments
+				// All consumers trigger the rebalance, but only the group leader will actually perform it
+				// For non-leader consumers, triggering the rebalance has no effect
+				c.ForceRebalance()
+				lastPartitionCount = currentPartitionCount
+			}
+		}
+	}
+}
+
+func (c *Client) Close() {
+	close(c.stopCh)  // Signal the monitor goroutine to stop
+	c.wg.Wait()      // Wait for the monitor goroutine to exit
+	c.Client.Close() // Close the underlying client
 }
 
 func NewReaderClientMetrics(component string, reg prometheus.Registerer) *kprom.Metrics {

--- a/pkg/ingest/reader_client.go
+++ b/pkg/ingest/reader_client.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-only
+// Forked from https://github.com/grafana/loki/blob/fa6ef0a2caeeb4d31700287e9096e5f2c3c3a0d4/pkg/kafka/partitionring/consumer/client.go
 
 package ingest
 
@@ -54,6 +54,8 @@ func NewGroupReaderClient(kafkaCfg KafkaConfig, partitionRing ring.PartitionRing
 	opts = append(opts,
 		kgo.ConsumerGroup(kafkaCfg.ConsumerGroup),
 		kgo.ConsumeTopics(kafkaCfg.Topic),
+		kgo.SessionTimeout(3*time.Minute),
+		kgo.RebalanceTimeout(5*time.Minute),
 		kgo.Balancers(NewCooperativeActiveStickyBalancer(partitionRing)),
 		kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()),
 	)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This PR introduces group consuming to the generators, instead of the previously used direct consuming. Group consuming delegates partitions assignment to Kafka, which greatly simplifies operations for the generators.

It uses a custom balancer that combines Kafka's cooperative sticky balancing with partition ring awareness. This implementation is [forked from Loki](https://github.com/grafana/loki/blob/889404791d9125d2d17a7da963ae0fc2b268e2e7/pkg/kafka/partitionring/consumer/balancer.go).

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`