### PR TITLE
[Rhythm] Block builder performance improvement

### DIFF
--- a/modules/blockbuilder/blockbuilder_test.go
+++ b/modules/blockbuilder/blockbuilder_test.go
@@ -510,7 +510,6 @@ func BenchmarkBlockBuilder(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 
 		var records []*kgo.Record
-
 		for i := 0; i < 1000; i++ {
 			records = append(records, sendReq(b, ctx, client)...)
 		}
@@ -519,8 +518,6 @@ func BenchmarkBlockBuilder(b *testing.B) {
 		for _, r := range records {
 			size += len(r.Value)
 		}
-
-		b.ResetTimer()
 
 		err = bb.consume(ctx)
 		require.NoError(b, err)

--- a/modules/blockbuilder/partition_writer.go
+++ b/modules/blockbuilder/partition_writer.go
@@ -2,14 +2,12 @@ package blockbuilder
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/gogo/protobuf/proto"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/tempodb"
@@ -64,12 +62,7 @@ func (p *writer) pushBytes(ts time.Time, tenant string, req *tempopb.PushBytesRe
 	}
 
 	for j, trace := range req.Traces {
-		tr := new(tempopb.Trace) // TODO - Pool?
-		if err := proto.Unmarshal(trace.Slice, tr); err != nil {
-			return fmt.Errorf("failed to unmarshal trace: %w", err)
-		}
-
-		if err := i.AppendTrace(req.Ids[j], tr, ts); err != nil {
+		if err := i.AppendTrace(req.Ids[j], trace.Slice, ts); err != nil {
 			return err
 		}
 	}

--- a/modules/generator/processor/localblocks/processor.go
+++ b/modules/generator/processor/localblocks/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	flushqueue *flushqueues.PriorityQueue
 
 	liveTracesMtx sync.Mutex
-	liveTraces    *livetraces.LiveTraces
+	liveTraces    *livetraces.LiveTraces[*v1.ResourceSpans]
 	traceSizes    *tracesizes.Tracker
 
 	writer tempodb.Writer
@@ -104,7 +104,7 @@ func New(cfg Config, tenant string, wal *wal.WAL, writer tempodb.Writer, overrid
 		walBlocks:      map[uuid.UUID]common.WALBlock{},
 		completeBlocks: map[uuid.UUID]*ingester.LocalBlock{},
 		flushqueue:     flushqueues.NewPriorityQueue(metricFlushQueueSize.WithLabelValues(tenant)),
-		liveTraces:     livetraces.New(),
+		liveTraces:     livetraces.New[*v1.ResourceSpans](func(rs *v1.ResourceSpans) uint64 { return uint64(rs.Size()) }),
 		traceSizes:     tracesizes.New(),
 		closeCh:        make(chan struct{}),
 		wg:             sync.WaitGroup{},

--- a/pkg/ingest/encoding.go
+++ b/pkg/ingest/encoding.go
@@ -134,7 +134,12 @@ func (d *Decoder) Decode(data []byte) (*tempopb.PushBytesRequest, error) {
 }
 
 func (d *Decoder) Reset() {
-	d.req.Reset()
+	for _, b := range d.req.Traces {
+		tempopb.ReusePreallocBytes(b)
+	}
+	// Retain slice capacity
+	d.req.Ids = d.req.Ids[:0]
+	d.req.Traces = d.req.Traces[:0]
 }
 
 // sovPush calculates the size of varint-encoded uint64.

--- a/pkg/ingest/encoding.go
+++ b/pkg/ingest/encoding.go
@@ -134,9 +134,6 @@ func (d *Decoder) Decode(data []byte) (*tempopb.PushBytesRequest, error) {
 }
 
 func (d *Decoder) Reset() {
-	for _, b := range d.req.Traces {
-		tempopb.ReusePreallocBytes(b)
-	}
 	// Retain slice capacity
 	d.req.Ids = d.req.Ids[:0]
 	d.req.Traces = d.req.Traces[:0]

--- a/pkg/livetraces/livetraces.go
+++ b/pkg/livetraces/livetraces.go
@@ -8,47 +8,53 @@ import (
 	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 )
 
-type LiveTrace struct {
+type LiveTraceBatchT interface {
+	*v1.ResourceSpans | []byte
+}
+
+type LiveTrace[T LiveTraceBatchT] struct {
 	ID        []byte
 	timestamp time.Time
-	Batches   []*v1.ResourceSpans
+	Batches   []T
 
 	sz uint64
 }
 
-type LiveTraces struct {
+type LiveTraces[T LiveTraceBatchT] struct {
 	hash   hash.Hash64
-	Traces map[uint64]*LiveTrace
+	Traces map[uint64]*LiveTrace[T]
 
-	sz uint64
+	sz     uint64
+	szFunc func(T) uint64
 }
 
-func New() *LiveTraces {
-	return &LiveTraces{
+func New[T LiveTraceBatchT](sizeFunc func(T) uint64) *LiveTraces[T] {
+	return &LiveTraces[T]{
 		hash:   fnv.New64(),
-		Traces: make(map[uint64]*LiveTrace),
+		Traces: make(map[uint64]*LiveTrace[T]),
+		szFunc: sizeFunc,
 	}
 }
 
-func (l *LiveTraces) token(traceID []byte) uint64 {
+func (l *LiveTraces[T]) token(traceID []byte) uint64 {
 	l.hash.Reset()
 	l.hash.Write(traceID)
 	return l.hash.Sum64()
 }
 
-func (l *LiveTraces) Len() uint64 {
+func (l *LiveTraces[T]) Len() uint64 {
 	return uint64(len(l.Traces))
 }
 
-func (l *LiveTraces) Size() uint64 {
+func (l *LiveTraces[T]) Size() uint64 {
 	return l.sz
 }
 
-func (l *LiveTraces) Push(traceID []byte, batch *v1.ResourceSpans, max uint64) bool {
+func (l *LiveTraces[T]) Push(traceID []byte, batch T, max uint64) bool {
 	return l.PushWithTimestamp(time.Now(), traceID, batch, max)
 }
 
-func (l *LiveTraces) PushWithTimestamp(ts time.Time, traceID []byte, batch *v1.ResourceSpans, max uint64) bool {
+func (l *LiveTraces[T]) PushWithTimestamp(ts time.Time, traceID []byte, batch T, max uint64) bool {
 	token := l.token(traceID)
 
 	tr := l.Traces[token]
@@ -60,13 +66,13 @@ func (l *LiveTraces) PushWithTimestamp(ts time.Time, traceID []byte, batch *v1.R
 			return false
 		}
 
-		tr = &LiveTrace{
+		tr = &LiveTrace[T]{
 			ID: traceID,
 		}
 		l.Traces[token] = tr
 	}
 
-	sz := uint64(batch.Size())
+	sz := l.szFunc(batch)
 	tr.sz += sz
 	l.sz += sz
 
@@ -75,8 +81,8 @@ func (l *LiveTraces) PushWithTimestamp(ts time.Time, traceID []byte, batch *v1.R
 	return true
 }
 
-func (l *LiveTraces) CutIdle(idleSince time.Time, immediate bool) []*LiveTrace {
-	res := []*LiveTrace{}
+func (l *LiveTraces[T]) CutIdle(idleSince time.Time, immediate bool) []*LiveTrace[T] {
+	res := []*LiveTrace[T]{}
 
 	for k, tr := range l.Traces {
 		if tr.timestamp.Before(idleSince) || immediate {

--- a/pkg/livetraces/livetraces_test.go
+++ b/pkg/livetraces/livetraces_test.go
@@ -5,12 +5,13 @@ import (
 	"testing"
 	"time"
 
+	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	"github.com/grafana/tempo/pkg/util/test"
 	"github.com/stretchr/testify/require"
 )
 
 func TestLiveTracesSizesAndLen(t *testing.T) {
-	lt := New()
+	lt := New[*v1.ResourceSpans](func(rs *v1.ResourceSpans) uint64 { return uint64(rs.Size()) })
 
 	expectedSz := uint64(0)
 	expectedLen := uint64(0)

--- a/pkg/tempopb/prealloc.go
+++ b/pkg/tempopb/prealloc.go
@@ -45,10 +45,6 @@ func (r *PreallocBytes) Size() (n int) {
 	return len(r.Slice)
 }
 
-func ReusePreallocBytes(r PreallocBytes) {
-	bytePool.Put(r.Slice[:0])
-}
-
 // ReuseByteSlices puts the byte slice back into bytePool for reuse.
 func ReuseByteSlices(buffs [][]byte) {
 	for _, b := range buffs {

--- a/pkg/tempopb/prealloc.go
+++ b/pkg/tempopb/prealloc.go
@@ -45,6 +45,10 @@ func (r *PreallocBytes) Size() (n int) {
 	return len(r.Slice)
 }
 
+func ReusePreallocBytes(r PreallocBytes) {
+	bytePool.Put(r.Slice[:0])
+}
+
 // ReuseByteSlices puts the byte slice back into bytePool for reuse.
 func ReuseByteSlices(buffs [][]byte) {
 	for _, b := range buffs {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
More low-hanging improvements to block builder:

* Convert live traces to store byte slices to reduce GC scanning of complex objects.  It is now a generic type and the generators still use tempopb structs.  Ingesters could now make use of this too.
* Parallelize proto unmarshal
* Repoll prealloc slices
* Query partition end offset and use it to avoid the last empty poll (this is mostly for benchmarking and testing, it is minor for actual performance)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`