### PR TITLE
WIP: [TraceQL] Fix to put all conditions following a select clause into the second pass

### DIFF
--- a/pkg/traceql/storage.go
+++ b/pkg/traceql/storage.go
@@ -124,6 +124,22 @@ func (f *FetchSpansRequest) HasAttribute(a Attribute) bool {
 	return false
 }
 
+func (f *FetchSpansRequest) HasAttributeWithOp(a Attribute, o Operator) bool {
+	for _, cc := range f.Conditions {
+		if cc.Attribute == a && cc.Op == o {
+			return true
+		}
+	}
+
+	for _, cc := range f.SecondPassConditions {
+		if cc.Attribute == a && cc.Op == o {
+			return true
+		}
+	}
+
+	return false
+}
+
 type Span interface {
 	// AttributeFor returns the attribute for the given key. If the attribute is not found then
 	// the second return value will be false.

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -239,6 +239,10 @@ func advancedTraceQLRunner(t *testing.T, wantTr *tempopb.Trace, wantMeta *tempop
 		// groupin' (.foo is a known attribute that is the same on both spans)
 		{Query: "{} | by(span.foo) | count() = 2"},
 		{Query: "{} | by(resource.service.name) | count() = 1"},
+		// Attribute == nil (current work-around version)
+		{Query: "{} | select(.missing) | { !(.missing != nil)}"},
+		{Query: "{} | select(span.missing) | { !(span.missing != nil)}"},
+		{Query: "{} | select(resource.missing) | { !(resource.missing != nil)}"},
 	}
 	searchesThatDontMatch := []*tempopb.SearchRequest{
 		// conditions


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Found some incorrect behavior from https://github.com/grafana/tempo/issues/2188#issuecomment-2608751948 and this fixes it.  The idea is that all clauses after a `select()` operation should be considered in the second pass and optional, but it was being put in the first pass and required.  Rare, but think it's worth fixing as this is a work-around for attribute == nil check.

**Which issue(s) this PR fixes**:
Relates to #2188 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`