### PR TITLE
vParquet4 WAL mapping fix

### DIFF
--- a/modules/blockbuilder/blockbuilder_test.go
+++ b/modules/blockbuilder/blockbuilder_test.go
@@ -494,11 +494,35 @@ func BenchmarkBlockBuilder(b *testing.B) {
 		store      = newStoreWithLogger(ctx, b, logger)
 		cfg        = blockbuilderConfig(b, address)
 		client     = newKafkaClient(b, cfg.IngestStorageConfig.Kafka)
+		o          = &mockOverrides{
+			dc: backend.DedicatedColumns{
+				backend.DedicatedColumn{Scope: backend.DedicatedColumnScopeResource, Name: "res0", Type: backend.DedicatedColumnTypeString},
+				backend.DedicatedColumn{Scope: backend.DedicatedColumnScopeResource, Name: "res1", Type: backend.DedicatedColumnTypeString},
+				backend.DedicatedColumn{Scope: backend.DedicatedColumnScopeResource, Name: "res2", Type: backend.DedicatedColumnTypeString},
+				backend.DedicatedColumn{Scope: backend.DedicatedColumnScopeResource, Name: "res3", Type: backend.DedicatedColumnTypeString},
+				backend.DedicatedColumn{Scope: backend.DedicatedColumnScopeResource, Name: "res4", Type: backend.DedicatedColumnTypeString},
+				backend.DedicatedColumn{Scope: backend.DedicatedColumnScopeResource, Name: "res5", Type: backend.DedicatedColumnTypeString},
+				backend.DedicatedColumn{Scope: backend.DedicatedColumnScopeResource, Name: "res6", Type: backend.DedicatedColumnTypeString},
+				backend.DedicatedColumn{Scope: backend.DedicatedColumnScopeResource, Name: "res7", Type: backend.DedicatedColumnTypeString},
+				backend.DedicatedColumn{Scope: backend.DedicatedColumnScopeResource, Name: "res8", Type: backend.DedicatedColumnTypeString},
+				backend.DedicatedColumn{Scope: backend.DedicatedColumnScopeResource, Name: "res9", Type: backend.DedicatedColumnTypeString},
+				backend.DedicatedColumn{Scope: backend.DedicatedColumnScopeSpan, Name: "span0", Type: backend.DedicatedColumnTypeString},
+				backend.DedicatedColumn{Scope: backend.DedicatedColumnScopeSpan, Name: "span1", Type: backend.DedicatedColumnTypeString},
+				backend.DedicatedColumn{Scope: backend.DedicatedColumnScopeSpan, Name: "span2", Type: backend.DedicatedColumnTypeString},
+				backend.DedicatedColumn{Scope: backend.DedicatedColumnScopeSpan, Name: "span3", Type: backend.DedicatedColumnTypeString},
+				backend.DedicatedColumn{Scope: backend.DedicatedColumnScopeSpan, Name: "span4", Type: backend.DedicatedColumnTypeString},
+				backend.DedicatedColumn{Scope: backend.DedicatedColumnScopeSpan, Name: "span5", Type: backend.DedicatedColumnTypeString},
+				backend.DedicatedColumn{Scope: backend.DedicatedColumnScopeSpan, Name: "span6", Type: backend.DedicatedColumnTypeString},
+				backend.DedicatedColumn{Scope: backend.DedicatedColumnScopeSpan, Name: "span7", Type: backend.DedicatedColumnTypeString},
+				backend.DedicatedColumn{Scope: backend.DedicatedColumnScopeSpan, Name: "span8", Type: backend.DedicatedColumnTypeString},
+				backend.DedicatedColumn{Scope: backend.DedicatedColumnScopeSpan, Name: "span9", Type: backend.DedicatedColumnTypeString},
+			},
+		}
 	)
 
 	cfg.ConsumeCycleDuration = 1 * time.Hour
 
-	bb := New(cfg, logger, newPartitionRingReader(), &mockOverrides{}, store)
+	bb := New(cfg, logger, newPartitionRingReader(), o, store)
 	defer func() { require.NoError(b, bb.stopping(nil)) }()
 
 	// Startup (without starting the background consume cycle)

--- a/tempodb/encoding/vparquet4/wal_block.go
+++ b/tempodb/encoding/vparquet4/wal_block.go
@@ -82,6 +82,8 @@ func openWALBlock(filename, path string, ingestionSlack, _ time.Duration) (commo
 		path:           path,
 		ids:            common.NewIDMap[int64](),
 		ingestionSlack: ingestionSlack,
+		dedcolsRes:     dedicatedColumnsToColumnMapping(meta.DedicatedColumns, backend.DedicatedColumnScopeResource),
+		dedcolsSpan:    dedicatedColumnsToColumnMapping(meta.DedicatedColumns, backend.DedicatedColumnScopeSpan),
 	}
 
 	// read all files in dir
@@ -161,6 +163,8 @@ func createWALBlock(meta *backend.BlockMeta, filepath, dataEncoding string, inge
 		path:           filepath,
 		ids:            common.NewIDMap[int64](),
 		ingestionSlack: ingestionSlack,
+		dedcolsRes:     dedicatedColumnsToColumnMapping(meta.DedicatedColumns, backend.DedicatedColumnScopeResource),
+		dedcolsSpan:    dedicatedColumnsToColumnMapping(meta.DedicatedColumns, backend.DedicatedColumnScopeSpan),
 	}
 
 	// build folder
@@ -284,6 +288,8 @@ type walBlock struct {
 	meta           *backend.BlockMeta
 	path           string
 	ingestionSlack time.Duration
+	dedcolsRes     dedicatedColumnMapping
+	dedcolsSpan    dedicatedColumnMapping
 
 	// Unflushed data
 	buffer        *Trace
@@ -331,7 +337,7 @@ func (b *walBlock) Append(id common.ID, buff []byte, start, end uint32) error {
 
 func (b *walBlock) AppendTrace(id common.ID, trace *tempopb.Trace, start, end uint32) error {
 	var connected bool
-	b.buffer, connected = traceToParquet(b.meta, id, trace, b.buffer)
+	b.buffer, connected = traceToParquetWithMapping(id, trace, b.buffer, b.dedcolsRes, b.dedcolsSpan)
 	if !connected {
 		dataquality.WarnDisconnectedTrace(b.meta.TenantID, dataquality.PhaseTraceFlushedToWal)
 	}


### PR DESCRIPTION
**What this PR does**:
vParquet4 WAL computes the dedicated column definitions for every trace that is written. The mapping doesn't change once the block is created, so this fixes it to be done once.

This is about a 10% perf improvement in the block builder.  Probably will be noticeable in ingesters also but didn't check.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`