### PR TITLE
[DOC] Add flush_to_storage to metrics-gen config doc

### DIFF
--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -494,7 +494,11 @@ metrics_generator:
             # If enabled, only parent spans or spans with the SpanKind of `server` will be retained
             [filter_server_spans: <bool> | default = true]
 
-            # Number of blocks that are allowed to be processed concurently
+            # Whether server spans should be flushed to storage.
+            # Setting `flush_to_storage` to `true` ensures that metrics blocks are flushed to storage so TraceQL metrics queries against historical data.
+            [flush_to_storage: <bool> | default = false]
+
+            # Number of blocks that are allowed to be processed concurrently.
             [concurrent_blocks: <uint> | default = 10]
 
             # A tuning factor that controls whether the trace-level timestamp columns are used in a metrics query.

--- a/docs/sources/tempo/release-notes/v2-6.md
+++ b/docs/sources/tempo/release-notes/v2-6.md
@@ -170,7 +170,7 @@ metrics_generator:
 
 **For historical data**
 
-To run metrics queries on historical data, you must configure the local-blocks processor to flush rf1 blocks to object storage:
+To run metrics queries on historical data, you must configure the local-blocks processor to flush RF1 blocks to object storage:
 
 ```yaml
 metrics_generator:

--- a/docs/sources/tempo/setup/upgrade.md
+++ b/docs/sources/tempo/setup/upgrade.md
@@ -205,7 +205,7 @@ metrics_generator:
 
 **For historical data**
 
-To run metrics queries on historical data, you must configure the local-blocks processor to flush rf1 blocks to object storage:
+To run metrics queries on historical data, you must configure the local-blocks processor to flush RF1 blocks to object storage:
 
 ```yaml
 metrics_generator:


### PR DESCRIPTION

**What this PR does**:
Adds documentation for flush_to_storage to the metrics-generator configuration section. 

**Which issue(s) this PR fixes**:
Fixes #4139 

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`