### PR TITLE
docs: fix missing comma issue

### DIFF
--- a/docs/sources/tempo/configuration/grafana-alloy/service-graphs.md
+++ b/docs/sources/tempo/configuration/grafana-alloy/service-graphs.md
@@ -44,7 +44,7 @@ otelcol.receiver.otlp "default" {
   output {
     traces = [
       otelcol.connector.servicegraph.default.input,
-      otelcol.exporter.otlp.default.input
+      otelcol.exporter.otlp.default.input,
     ]
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

I got error when deploy Alloy Helm Chart 0.11.0

```
Error: /etc/alloy/config.alloy:152:42: missing ',' in expression list
interrupt received
Error: could not perform the initial load successfully
```

After adding this trailing comma, I can deploy successfully ☺️

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`