### PR TITLE
[DOC] Update gRPC compressiong admonition

### DIFF
--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -276,6 +276,7 @@ Tempo 2.7 disabled gRPC compression in the querier and distributor for performan
 Benchmark testing suggested that without compression, queriers and distributors used less CPU and memory.
 
 However, you may notice an increase in ingester data and network traffic especially for larger clusters.
+This increased data can impact billing for Grafana Cloud.
 
 You can configure the gRPC compression in the `querier`, `ingester`, and `metrics_generator` clients of the distributor.
 To re-enable the compression, use `snappy` with the following settings:
@@ -1620,7 +1621,7 @@ overrides:
       # Should not be lower than RF.
       [tenant_shard_size: <int> | default = 0]
 
-      # Maximum bytes any attribute can be for both keys and values. 
+      # Maximum bytes any attribute can be for both keys and values.
       [max_attribute_bytes: <int> | default = 0]
 
     # Read related overrides

--- a/docs/sources/tempo/release-notes/v2-7.md
+++ b/docs/sources/tempo/release-notes/v2-7.md
@@ -32,6 +32,11 @@ For a complete list, refer to the [Tempo changelog](https://github.com/grafana/t
 
 The most important features and enhancements in Tempo 2.7 are highlighted below.
 
+{{< admonition type="note" >}}
+This release disables gRPC compression by default to improve performance.
+This change may increase data usage and network traffic, which can impact Grafana Cloud billing, especially for larger clusters. Refer to [gRPC compression](#grpc-compression-disabled) for more information.
+{{< /admonition >}}
+
 ### Track ingested traffic and attribute costs
 
 This new feature lets tenants precisely measure and attribute costs for their ingested trace data by leveraging custom labels.
@@ -209,7 +214,25 @@ max_spans_per_span_set
 This release disables gRPC compression in the querier and distributor for performance reasons. ([#4429](https://github.com/grafana/tempo/pull/4429))
 Our benchmark suggests that without compression, queriers and distributors use less CPU and memory.
 
+{{< admonition type="note" >}}
+While disabling gRPC compression improves performance, it may increase data usage and network traffic, which can impact Grafana Cloud billing, especially for larger clusters.
+{{< /admonition >}}
+
 If you notice increased network traffic or issues, check the gRPC compression settings.
+You can enable gRPC compression using `snappy`:
+
+```yaml
+  ingester_client:
+      grpc_client_config:
+          grpc_compression: "snappy"
+  metrics_generator_client:
+      grpc_client_config:
+          grpc_compression: "snappy"
+  querier:
+      frontend_worker:
+          grpc_client_config:
+              grpc_compression: "snappy"
+```
 
 Refer to [gRPC compression configuration](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#grpc-compression) for more information.
 

--- a/docs/sources/tempo/release-notes/v2-7.md
+++ b/docs/sources/tempo/release-notes/v2-7.md
@@ -34,7 +34,7 @@ The most important features and enhancements in Tempo 2.7 are highlighted below.
 
 {{< admonition type="note" >}}
 This release disables gRPC compression by default to improve performance.
-This change may increase data usage and network traffic, which can impact Grafana Cloud billing, especially for larger clusters. Refer to [gRPC compression](#grpc-compression-disabled) for more information.
+This change will increase data usage and network traffic, which can impact cloud billing depending on your configuration. Refer to [gRPC compression](#grpc-compression-disabled) for more information.
 {{< /admonition >}}
 
 ### Track ingested traffic and attribute costs
@@ -215,7 +215,7 @@ This release disables gRPC compression in the querier and distributor for perfor
 Our benchmark suggests that without compression, queriers and distributors use less CPU and memory.
 
 {{< admonition type="note" >}}
-While disabling gRPC compression improves performance, it may increase data usage and network traffic, which can impact Grafana Cloud billing, especially for larger clusters.
+While disabling gRPC compression improves performance, it will increase data usage and network traffic, which can impact cloud billing depending on your configuration.
 {{< /admonition >}}
 
 If you notice increased network traffic or issues, check the gRPC compression settings.

--- a/docs/sources/tempo/setup/upgrade.md
+++ b/docs/sources/tempo/setup/upgrade.md
@@ -102,7 +102,7 @@ This release disables gRPC compression in the querier and distributor for perfor
 Our benchmark suggests that without compression, queriers and distributors use less CPU and memory.
 
 {{< admonition type="note" >}}
-This change may increase data usage and network traffic, which can impact Grafana Cloud billing.
+This change may increase data usage and network traffic, which can impact cloud billing.
 {{< /admonition >}}
 
 If you notice increased network traffic or issues, check the gRPC compression settings.

--- a/docs/sources/tempo/setup/upgrade.md
+++ b/docs/sources/tempo/setup/upgrade.md
@@ -101,11 +101,13 @@ For Jaeger exporting, set `OTEL_TRACES_EXPORTER=jaeger`.For more information, re
 This release disables gRPC compression in the querier and distributor for performance reasons. ([#4429](https://github.com/grafana/tempo/pull/4429))
 Our benchmark suggests that without compression, queriers and distributors use less CPU and memory.
 
-However, you may notice an increase in ingester data and network traffic.
+{{< admonition type="note" >}}
+This change may increase data usage and network traffic, which can impact Grafana Cloud billing.
+{{< /admonition >}}
 
 If you notice increased network traffic or issues, check the gRPC compression settings.
 
-Refer to [gRPC compression configuration](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#grpc-compression) for more information.
+For instructions how to enable gRPC compression, refer to [gRPC compression configuration](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#grpc-compression) for more information.
 
 ### Added, updated, removed, or renamed configuration parameters
 


### PR DESCRIPTION
**What this PR does**:

Adds an admonition about gRPC compression to make it more prominent in the release notes, uprade, and configuration doc. 

**Which issue(s) this PR fixes**:
Related to https://github.com/grafana/tempo/issues/4606

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`