### PR TITLE
[release-v2.7] [DOC] Update gRPC compressiong admonition

### DIFF
--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -11,7 +11,7 @@ This document explains the configuration options for Tempo as well as the detail
 
 {{< admonition type="tip" >}}
 Instructions for configuring Tempo data sources are available in the [Grafana Cloud](/docs/grafana-cloud/send-data/traces/) and [Grafana](/docs/grafana/latest/datasources/tempo/) documentation.
-{{< /admonition >}} 
+{{< /admonition >}}
 
 The Tempo configuration options include:
 
@@ -276,6 +276,7 @@ Tempo 2.7 disabled gRPC compression in the querier and distributor for performan
 Benchmark testing suggested that without compression, queriers and distributors used less CPU and memory.
 
 However, you may notice an increase in ingester data and network traffic especially for larger clusters.
+This increased data can impact billing for Grafana Cloud.
 
 You can configure the gRPC compression in the `querier`, `ingester`, and `metrics_generator` clients of the distributor.
 To re-enable the compression, use `snappy` with the following settings:
@@ -521,7 +522,7 @@ metrics_generator:
             [filter_server_spans: <bool> | default = true]
 
             # Whether server spans should be flushed to storage.
-            # Setting `flush_to_storage` to `true` ensures that metrics blocks are flushed to storage so TraceQL metrics queries against historical data. 
+            # Setting `flush_to_storage` to `true` ensures that metrics blocks are flushed to storage so TraceQL metrics queries against historical data.
             [flush_to_storage: <bool> | default = false]
 
             # Number of blocks that are allowed to be processed concurrently.
@@ -1655,6 +1656,9 @@ overrides:
       # Shuffle sharding shards used for this user. A value of 0 uses all ingesters in the ring.
       # Should not be lower than RF.
       [tenant_shard_size: <int> | default = 0]
+
+      # Maximum bytes any attribute can be for both keys and values.
+      [max_attribute_bytes: <int> | default = 0]
 
     # Read related overrides
     read:

--- a/docs/sources/tempo/release-notes/v2-7.md
+++ b/docs/sources/tempo/release-notes/v2-7.md
@@ -32,6 +32,11 @@ For a complete list, refer to the [Tempo changelog](https://github.com/grafana/t
 
 The most important features and enhancements in Tempo 2.7 are highlighted below.
 
+{{< admonition type="note" >}}
+This release disables gRPC compression by default to improve performance.
+This change will increase data usage and network traffic, which can impact cloud billing depending on your configuration. Refer to [gRPC compression](#grpc-compression-disabled) for more information.
+{{< /admonition >}}
+
 ### Track ingested traffic and attribute costs
 
 This new feature lets tenants precisely measure and attribute costs for their ingested trace data by leveraging custom labels.
@@ -209,7 +214,25 @@ max_spans_per_span_set
 This release disables gRPC compression in the querier and distributor for performance reasons. ([#4429](https://github.com/grafana/tempo/pull/4429))
 Our benchmark suggests that without compression, queriers and distributors use less CPU and memory.
 
+{{< admonition type="note" >}}
+While disabling gRPC compression improves performance, it will increase data usage and network traffic, which can impact cloud billing depending on your configuration.
+{{< /admonition >}}
+
 If you notice increased network traffic or issues, check the gRPC compression settings.
+You can enable gRPC compression using `snappy`:
+
+```yaml
+  ingester_client:
+      grpc_client_config:
+          grpc_compression: "snappy"
+  metrics_generator_client:
+      grpc_client_config:
+          grpc_compression: "snappy"
+  querier:
+      frontend_worker:
+          grpc_client_config:
+              grpc_compression: "snappy"
+```
 
 Refer to [gRPC compression configuration](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#grpc-compression) for more information.
 

--- a/docs/sources/tempo/setup/upgrade.md
+++ b/docs/sources/tempo/setup/upgrade.md
@@ -101,11 +101,13 @@ For Jaeger exporting, set `OTEL_TRACES_EXPORTER=jaeger`.For more information, re
 This release disables gRPC compression in the querier and distributor for performance reasons. ([#4429](https://github.com/grafana/tempo/pull/4429))
 Our benchmark suggests that without compression, queriers and distributors use less CPU and memory.
 
-However, you may notice an increase in ingester data and network traffic.
+{{< admonition type="note" >}}
+This change may increase data usage and network traffic, which can impact cloud billing.
+{{< /admonition >}}
 
 If you notice increased network traffic or issues, check the gRPC compression settings.
 
-Refer to [gRPC compression configuration](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#grpc-compression) for more information.
+For instructions how to enable gRPC compression, refer to [gRPC compression configuration](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#grpc-compression) for more information.
 
 ### Added, updated, removed, or renamed configuration parameters
 


### PR DESCRIPTION
Backport c7b435db37650cbfef9e301420e2419d7498d08f from #4644

---

**What this PR does**:

Adds an admonition about gRPC compression to make it more prominent in the release notes, uprade, and configuration doc. 

**Which issue(s) this PR fixes**:
Related to https://github.com/grafana/tempo/issues/4606

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
