### PR TITLE
feat(servicegraphs): Add support for `db.system.name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1319,3 +1319,4 @@ Additionally, default label `span_status` is renamed to `status_code`.
 * [BUGFIX] Increase Prometheus `notfound` metric on tempo-vulture. [#301](https://github.com/grafana/tempo/pull/301)
 * [BUGFIX] Return 404 if searching for a tenant id that does not exist in the backend. [#321](https://github.com/grafana/tempo/pull/321)
 * [BUGFIX] Prune in-memory blocks from missing tenants. [#314](https://github.com/grafana/tempo/pull/314)
+* [ENHANCEMENT] Fix db.system.name attribute not being set in servicegraphs processor. [#4656](https://github.com/grafana/tempo/pull/4656)

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -276,7 +276,7 @@ func (p *Processor) upsertPeerNode(e *store.Edge, spanAttr []*v1_common.KeyValue
 }
 
 // upsertDatabaseRequest handles the logic of adding a database edge on the
-// graph.  If we have a db.name or db.system attribute, we assume this is a
+// graph.  If we have a db.name or db.system or db.system.name attribute, we assume this is a
 // database request.  The name of the edge is determined by the following
 // order:
 //
@@ -300,12 +300,21 @@ func (p *Processor) upsertDatabaseRequest(e *store.Edge, resourceAttr []*v1_comm
 
 	// Check for db.system only if we don't have db.name above
 	if !isDatabase {
-		if _, ok := processor_util.FindAttributeValue(string(semconv.DBSystemKey), resourceAttr, span.Attributes); ok {
+		if name, ok := processor_util.FindAttributeValue(string(semconv.DBSystemKey), resourceAttr, span.Attributes); ok {
+			dbName = name
 			isDatabase = true
 		}
 	}
 
-	// If neither db.system nor db.name are present, we can't determine if this is a database request
+	// Check for db.system.name if neither above is found
+	if !isDatabase {
+		if name, ok := processor_util.FindAttributeValue(string(semconv.DBSystemNameKey), resourceAttr, span.Attributes); ok {
+			dbName = name
+			isDatabase = true
+		}
+	}
+
+	// If neither db.system nor db.name nor db.system.name are present, we can't determine if this is a database request
 	if !isDatabase {
 		return
 	}

--- a/vendor/go.opentelemetry.io/otel/semconv/v1.25.0/attribute_group.go
+++ b/vendor/go.opentelemetry.io/otel/semconv/v1.25.0/attribute_group.go
@@ -2251,14 +2251,6 @@ const (
 	// Stability: experimental
 	DBSystemKey = attribute.Key("db.system")
 
-	// DBSystemNameKey is the attribute Key conforming to the "db.system.name" semantic
-	// conventions. It represents the name of the database management system (DBMS) product being used.
-	//
-	// Type: string
-	// RequirementLevel: Optional
-	// Stability: experimental
-	DBSystemNameKey = attribute.Key("db.system.name")
-
 	// DBUserKey is the attribute Key conforming to the "db.user" semantic
 	// conventions. It represents the username for accessing the database.
 	//

--- a/vendor/go.opentelemetry.io/otel/semconv/v1.25.0/attribute_group.go
+++ b/vendor/go.opentelemetry.io/otel/semconv/v1.25.0/attribute_group.go
@@ -2251,6 +2251,14 @@ const (
 	// Stability: experimental
 	DBSystemKey = attribute.Key("db.system")
 
+	// DBSystemNameKey is the attribute Key conforming to the "db.system.name" semantic
+	// conventions. It represents the name of the database management system (DBMS) product being used.
+	//
+	// Type: string
+	// RequirementLevel: Optional
+	// Stability: experimental
+	DBSystemNameKey = attribute.Key("db.system.name")
+
 	// DBUserKey is the attribute Key conforming to the "db.user" semantic
 	// conventions. It represents the username for accessing the database.
 	//

--- a/vendor/go.opentelemetry.io/otel/semconv/v1.25.0/attribute_group.go
+++ b/vendor/go.opentelemetry.io/otel/semconv/v1.25.0/attribute_group.go
@@ -2259,6 +2259,14 @@ const (
 	// Stability: experimental
 	// Examples: 'readonly_user', 'reporting_user'
 	DBUserKey = attribute.Key("db.user")
+
+	// DBSystemNameKey is the attribute Key conforming to the "db.system.name" semantic
+	// conventions. It represents the name of the database management system (DBMS) product being used.
+	//
+	// Type: string
+	// RequirementLevel: Optional
+	// Stability: experimental
+	DBSystemNameKey = attribute.Key("db.system.name")
 )
 
 var (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This PR adds support for the `db.system.name` attribute introduced in OpenTelemetry Semantic Conventions v1.30.0. The change maintains backward compatibility while supporting the new attribute name.

**Which issue(s) this PR fixes**:
Fixes #4640

**Checklist**

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
