### PR TITLE
[Rhythm] Remove redudant live traces sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [ENHANCEMENT] Update tempo operational dashboard for new block-builder and v2 traces api [#4559](https://github.com/grafana/tempo/pull/4559) (@mdisibio)
 * [ENHANCEMENT] Improve block-builder performance by flushing blocks concurrently [#4565](https://github.com/grafana/tempo/pull/4565) (@mdisibio)
 * [ENHANCEMENT] Improve block-builder performance [#4596](https://github.com/grafana/tempo/pull/4596) (@mdisibio)
+* [ENHANCEMENT] Improve block-builder performance by not using WAL stage [#4647](https://github.com/grafana/tempo/pull/4647) [#4671](https://github.com/grafana/tempo/pull/4671) (@mdisibio)
 * [ENHANCEMENT] Export new `tempo_ingest_group_partition_lag` metric from block-builders and metrics-generators [#4571](https://github.com/grafana/tempo/pull/4571) (@mdisibio)
 * [ENHANCEMENT] Use distroless base container images for improved security [#4556](https://github.com/grafana/tempo/pull/4556) (@carles-grafana)
 * [BUGFIX] Choose a default step for a gRPC streaming query range request if none is provided. [#4546](https://github.com/grafana/tempo/pull/4576) (@joe-elliott)

--- a/pkg/livetraces/livetraces_test.go
+++ b/pkg/livetraces/livetraces_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/tempo/pkg/tempopb"
 	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	"github.com/grafana/tempo/pkg/util/test"
 	"github.com/stretchr/testify/require"
@@ -43,5 +44,38 @@ func TestLiveTracesSizesAndLen(t *testing.T) {
 
 		require.Equal(t, expectedSz, lt.Size())
 		require.Equal(t, expectedLen, lt.Len())
+	}
+}
+
+func BenchmarkLiveTracesWrite(b *testing.B) {
+	lt := New[*v1.ResourceSpans](func(rs *v1.ResourceSpans) uint64 { return uint64(rs.Size()) })
+
+	var traces []*tempopb.Trace
+	for i := 0; i < 100_000; i++ {
+		traces = append(traces, test.MakeTrace(1, nil))
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for _, tr := range traces {
+			lt.Push(tr.ResourceSpans[0].ScopeSpans[0].Spans[0].TraceId, tr.ResourceSpans[0], 0)
+		}
+	}
+}
+
+func BenchmarkLiveTracesRead(b *testing.B) {
+	lt := New[*v1.ResourceSpans](func(rs *v1.ResourceSpans) uint64 { return uint64(rs.Size()) })
+
+	for i := 0; i < 100_000; i++ {
+		tr := test.MakeTrace(1, nil)
+		lt.Push(tr.ResourceSpans[0].ScopeSpans[0].Spans[0].TraceId, tr.ResourceSpans[0], 0)
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		// This won't anything, instead of will benchmark the map iteration performance.
+		lt.CutIdle(time.Now().Add(-time.Hour), false)
 	}
 }


### PR DESCRIPTION
**What this PR does**:
Accidentally left a redundant live traces ID sort in #4647 .  Also adds a benchmark for live traces. There are no changes but I was exploring some ideas and wanted to keep the benchmarks.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`