### PR TITLE
Return the operand as the only value if the tag is already filtered in the query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@
 * [BUGFIX] TraceQL incorrect results for additional spanset filters after a select operation [#4600](https://github.com/grafana/tempo/pull/4600) (@mdisibio)
 * [BUGFIX] TraceQL results caching bug for floats ending in .0 [#4539](https://github.com/grafana/tempo/pull/4539) (@carles-grafana)
 * [BUGFIX] Fix metrics streaming for all non-trivial metrics [#4624](https://github.com/grafana/tempo/pull/4624) (@joe-elliott)
-* [BUGFIX] Fix starting consuming log [#4539](https://github.com/grafana/tempo/pull/46299) (@javiermolinar)
+* [BUGFIX] Fix starting consuming log [#4539](https://github.com/grafana/tempo/pull/4539) (@javiermolinar)
+* [BUGFIX] Return the operand as the only value if the tag is already filtered in the query [#](https://github.com/grafana/tempo/pull/) (@mapno)
 
 # v2.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 * [BUGFIX] TraceQL results caching bug for floats ending in .0 [#4539](https://github.com/grafana/tempo/pull/4539) (@carles-grafana)
 * [BUGFIX] Fix metrics streaming for all non-trivial metrics [#4624](https://github.com/grafana/tempo/pull/4624) (@joe-elliott)
 * [BUGFIX] Fix starting consuming log [#4539](https://github.com/grafana/tempo/pull/4539) (@javiermolinar)
-* [BUGFIX] Return the operand as the only value if the tag is already filtered in the query [#](https://github.com/grafana/tempo/pull/) (@mapno)
+* [BUGFIX] Return the operand as the only value if the tag is already filtered in the query [#4673](https://github.com/grafana/tempo/pull/4673) (@mapno)
 
 # v2.7.0
 

--- a/pkg/traceql/engine.go
+++ b/pkg/traceql/engine.go
@@ -181,9 +181,11 @@ func (e *Engine) ExecuteTagValues(
 	// I.e. we are autocompleting resource.service.name and the query was {resource.service.name="foo"}
 	for _, c := range autocompleteReq.Conditions {
 		if c.Attribute == tag && c.Op == OpEqual {
-			// If the tag is already filtered in the query, then we can just return the operand
-			// as the only value.
-			cb(c.Operands[0])
+			// If the tag is already filtered in the query,
+			// then we can just return the operand as the only value.
+			if len(c.Operands) > 0 {
+				cb(c.Operands[0])
+			}
 			return nil
 		}
 	}

--- a/pkg/traceql/engine.go
+++ b/pkg/traceql/engine.go
@@ -181,6 +181,9 @@ func (e *Engine) ExecuteTagValues(
 	// I.e. we are autocompleting resource.service.name and the query was {resource.service.name="foo"}
 	for _, c := range autocompleteReq.Conditions {
 		if c.Attribute == tag && c.Op == OpEqual {
+			// If the tag is already filtered in the query, then we can just return the operand
+			// as the only value.
+			cb(c.Operands[0])
 			return nil
 		}
 	}

--- a/pkg/traceql/engine_test.go
+++ b/pkg/traceql/engine_test.go
@@ -670,7 +670,7 @@ func TestExecuteTagValues(t *testing.T) {
 			name:           "noop", // autocompleting an attribute already filtered by the query
 			attribute:      "name",
 			query:          `{ name = "foo" }`,
-			expectedValues: []tempopb.TagValue{},
+			expectedValues: []tempopb.TagValue{{Type: "string", Value: "foo"}},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Return the operand as the only value if the tag is already filtered in the query. I think this is more in line with what one would expect.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`