### PR TITLE
Upgrade to go 1.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [CHANGE] **BREAKING CHANGE** Enforce max attribute size at event, link, and instrumentation scope. Make config per-tenant.
   Renamed max_span_attr_byte to max_attribute_bytes
   [#4633](https://github.com/grafana/tempo/pull/4633) (@ie-pham)
+* [CHANGE] Upgrade to go 1.24 [#4685](https://github.com/grafana/tempo/pull/4685) (@joe-elliott)
 * [ENHANCEMENT] Update minio to version [#4341](https://github.com/grafana/tempo/pull/4568) (@javiermolinar)
 * [ENHANCEMENT] Prevent queries in the ingester from blocking flushing traces to disk and memory spikes. [#4483](https://github.com/grafana/tempo/pull/4483) (@joe-elliott)
 * [ENHANCEMENT] Update tempo operational dashboard for new block-builder and v2 traces api [#4559](https://github.com/grafana/tempo/pull/4559) (@mdisibio)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/tempo
 
-go 1.23.3
+go 1.24.0
 
 require (
 	cloud.google.com/go/storage v1.41.0

--- a/modules/frontend/queue/queue_test.go
+++ b/modules/frontend/queue/queue_test.go
@@ -397,7 +397,7 @@ func assertChanReceived(t *testing.T, c chan struct{}, timeout time.Duration, ms
 	select {
 	case <-c:
 	case <-time.After(timeout):
-		t.Fatalf(msg)
+		t.Fatal(msg)
 	}
 }
 

--- a/pkg/api/http.go
+++ b/pkg/api/http.go
@@ -366,7 +366,7 @@ func ParseQueryRangeRequest(r *http.Request) (*tempopb.QueryRangeRequest, error)
 
 	step, err := step(vals, start, end)
 	if err != nil {
-		return nil, httpgrpc.Errorf(http.StatusBadRequest, "%s", err)
+		return nil, httpgrpc.Error(http.StatusBadRequest, err.Error())
 	}
 	req.Step = uint64(step.Nanoseconds())
 

--- a/pkg/api/http.go
+++ b/pkg/api/http.go
@@ -366,7 +366,7 @@ func ParseQueryRangeRequest(r *http.Request) (*tempopb.QueryRangeRequest, error)
 
 	step, err := step(vals, start, end)
 	if err != nil {
-		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
+		return nil, httpgrpc.Errorf(http.StatusBadRequest, "%s", err)
 	}
 	req.Step = uint64(step.Nanoseconds())
 
@@ -406,7 +406,7 @@ func ParseQueryRangeRequest(r *http.Request) (*tempopb.QueryRangeRequest, error)
 	if len(dedicatedColumns) > 0 {
 		err := json.Unmarshal([]byte(dedicatedColumns), &req.DedicatedColumns)
 		if err != nil {
-			return nil, httpgrpc.Errorf(http.StatusBadRequest, fmt.Errorf("failed to parse dedicated columns: %w", err).Error())
+			return nil, httpgrpc.Errorf(http.StatusBadRequest, "failed to parse dedicated columns: %s", err)
 		}
 	}
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/tempo/tools
 
-go 1.23.3
+go 1.24.0
 
 require (
 	github.com/golangci/golangci-lint v1.61.0


### PR DESCRIPTION
Upgrades to go 1.24. TraceQL benchmarks are mixed. These were done on OSX and I would feel comfortable if someone running Linux could run the benchmarks and post their results.

<details>
<summary>Benches</summary>

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/tempo/tempodb/encoding/vparquet4
cpu: Apple M3 Pro
                                                    │ before.txt  │              after.txt              │
                                                    │   sec/op    │   sec/op     vs base                │
BackendBlockTraceQL/spanAttValMatch-11                82.93m ± 1%   87.80m ± 1%   +5.86% (p=0.000 n=10)
BackendBlockTraceQL/spanAttValNoMatch-11              5.604m ± 1%   5.471m ± 0%   -2.36% (p=0.000 n=10)
BackendBlockTraceQL/spanAttIntrinsicMatch-11          60.08m ± 1%   63.23m ± 0%   +5.24% (p=0.000 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-11        5.541m ± 1%   5.428m ± 1%   -2.04% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttValMatch-11            405.1m ± 0%   398.3m ± 3%   -1.69% (p=0.023 n=10)
BackendBlockTraceQL/resourceAttValNoMatch-11          5.244m ± 2%   5.152m ± 0%   -1.76% (p=0.001 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-11      25.20m ± 0%   28.28m ± 0%  +12.22% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01-11   5.298m ± 1%   5.173m ± 0%   -2.35% (p=0.000 n=10)
BackendBlockTraceQL/traceOrMatch-11                   244.4m ± 0%   246.1m ± 0%   +0.67% (p=0.004 n=10)
BackendBlockTraceQL/traceOrNoMatch-11                 245.2m ± 0%   245.8m ± 0%   +0.28% (p=0.011 n=10)
BackendBlockTraceQL/mixedValNoMatch-11                180.2m ± 1%   187.5m ± 0%   +4.06% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd-11          5.106m ± 0%   4.942m ± 1%   -3.20% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr-11           149.4m ± 0%   152.9m ± 0%   +2.33% (p=0.000 n=10)
BackendBlockTraceQL/count-11                          332.2m ± 0%   323.8m ± 0%   -2.53% (p=0.000 n=10)
BackendBlockTraceQL/struct-11                         439.1m ± 2%   436.1m ± 2%   -0.68% (p=0.035 n=10)
BackendBlockTraceQL/||-11                             154.7m ± 0%   157.2m ± 0%   +1.59% (p=0.000 n=10)
BackendBlockTraceQL/mixed-11                          25.85m ± 0%   26.79m ± 0%   +3.64% (p=0.000 n=10)
BackendBlockTraceQL/complex-11                        5.173m ± 1%   4.971m ± 1%   -3.90% (p=0.000 n=10)
BackendBlockTraceQL/select-11                         5.131m ± 0%   4.975m ± 1%   -3.05% (p=0.000 n=10)
geomean                                               41.53m        41.76m        +0.57%

                                                    │  before.txt  │              after.txt               │
                                                    │     B/s      │     B/s       vs base                │
BackendBlockTraceQL/spanAttValMatch-11                270.0Mi ± 1%   255.1Mi ± 1%   -5.54% (p=0.000 n=10)
BackendBlockTraceQL/spanAttValNoMatch-11              301.5Mi ± 1%   308.8Mi ± 0%   +2.42% (p=0.000 n=10)
BackendBlockTraceQL/spanAttIntrinsicMatch-11          387.7Mi ± 1%   368.4Mi ± 0%   -4.98% (p=0.000 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-11        447.0Mi ± 1%   456.3Mi ± 1%   +2.08% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttValMatch-11            54.24Mi ± 0%   55.17Mi ± 3%   +1.71% (p=0.022 n=10)
BackendBlockTraceQL/resourceAttValNoMatch-11          171.5Mi ± 2%   174.6Mi ± 0%   +1.80% (p=0.001 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-11      873.8Mi ± 0%   778.6Mi ± 0%  -10.89% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01-11   176.2Mi ± 1%   180.5Mi ± 0%   +2.41% (p=0.000 n=10)
BackendBlockTraceQL/traceOrMatch-11                   6.843Mi ± 0%   6.795Mi ± 0%   -0.70% (p=0.003 n=10)
BackendBlockTraceQL/traceOrNoMatch-11                 6.819Mi ± 0%   6.800Mi ± 0%   -0.28% (p=0.017 n=10)
BackendBlockTraceQL/mixedValNoMatch-11                10.93Mi ± 1%   10.51Mi ± 0%   -3.88% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd-11          174.9Mi ± 0%   180.6Mi ± 1%   +3.31% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr-11           18.46Mi ± 0%   18.04Mi ± 0%   -2.30% (p=0.000 n=10)
BackendBlockTraceQL/count-11                          66.13Mi ± 0%   67.84Mi ± 0%   +2.59% (p=0.000 n=10)
BackendBlockTraceQL/struct-11                         12.44Mi ± 2%   12.52Mi ± 2%   +0.69% (p=0.033 n=10)
BackendBlockTraceQL/||-11                             142.7Mi ± 0%   140.4Mi ± 0%   -1.57% (p=0.000 n=10)
BackendBlockTraceQL/mixed-11                          826.4Mi ± 0%   797.4Mi ± 0%   -3.51% (p=0.000 n=10)
BackendBlockTraceQL/complex-11                        174.0Mi ± 1%   181.1Mi ± 1%   +4.05% (p=0.000 n=10)
BackendBlockTraceQL/select-11                         175.4Mi ± 0%   180.9Mi ± 1%   +3.15% (p=0.000 n=10)
geomean                                               99.92Mi        99.35Mi        -0.57%

                                                    │ before.txt  │              after.txt               │
                                                    │  MB_io/op   │  MB_io/op    vs base                 │
BackendBlockTraceQL/spanAttValMatch-11                 23.48 ± 0%    23.48 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/spanAttValNoMatch-11               1.772 ± 0%    1.772 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/spanAttIntrinsicMatch-11           24.43 ± 0%    24.43 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/spanAttIntrinsicNoMatch-11         2.598 ± 0%    2.598 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/resourceAttValMatch-11             23.04 ± 0%    23.04 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/resourceAttValNoMatch-11          943.2m ± 0%   943.2m ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/resourceAttIntrinsicMatch-11       23.09 ± 0%    23.09 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/resourceAttIntrinsicMatch#01-11   979.0m ± 0%   979.0m ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/traceOrMatch-11                    1.753 ± 0%    1.753 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/traceOrNoMatch-11                  1.753 ± 0%    1.753 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixedValNoMatch-11                 2.067 ± 0%    2.067 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixedValMixedMatchAnd-11          936.1m ± 0%   936.1m ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixedValMixedMatchOr-11            2.893 ± 0%    2.893 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/count-11                           23.03 ± 0%    23.03 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/struct-11                          5.726 ± 0%    5.726 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/||-11                              23.14 ± 0%    23.14 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixed-11                           22.40 ± 0%    22.40 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/complex-11                        943.7m ± 0%   943.7m ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/select-11                         943.7m ± 0%   943.7m ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                4.351         4.351       +0.00%
¹ all samples are equal

                                                    │   before.txt   │               after.txt               │
                                                    │      B/op      │      B/op       vs base               │
BackendBlockTraceQL/spanAttValMatch-11                 44.99Mi ±  1%    45.09Mi ±  1%       ~ (p=0.796 n=10)
BackendBlockTraceQL/spanAttValNoMatch-11               6.636Mi ±  2%    6.708Mi ±  1%  +1.10% (p=0.015 n=10)
BackendBlockTraceQL/spanAttIntrinsicMatch-11           39.66Mi ±  1%    39.78Mi ±  1%       ~ (p=0.529 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-11         7.067Mi ±  1%    7.099Mi ±  1%       ~ (p=0.247 n=10)
BackendBlockTraceQL/resourceAttValMatch-11             575.8Mi ±  0%    576.6Mi ±  0%       ~ (p=0.315 n=10)
BackendBlockTraceQL/resourceAttValNoMatch-11           5.360Mi ±  2%    5.355Mi ±  1%       ~ (p=0.739 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-11       10.49Mi ±  1%    10.53Mi ±  1%       ~ (p=0.684 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01-11    6.773Mi ±  0%    6.779Mi ±  1%       ~ (p=0.853 n=10)
BackendBlockTraceQL/traceOrMatch-11                    9.014Mi ± 14%   10.205Mi ± 18%       ~ (p=0.165 n=10)
BackendBlockTraceQL/traceOrNoMatch-11                 10.006Mi ± 18%    9.618Mi ± 16%       ~ (p=0.063 n=10)
BackendBlockTraceQL/mixedValNoMatch-11                 8.187Mi ±  4%    7.886Mi ±  5%       ~ (p=0.089 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd-11           5.745Mi ±  0%    5.798Mi ±  2%  +0.93% (p=0.029 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr-11            8.166Mi ± 11%    8.250Mi ± 12%       ~ (p=0.796 n=10)
BackendBlockTraceQL/count-11                           418.1Mi ±  0%    418.0Mi ±  0%       ~ (p=0.529 n=10)
BackendBlockTraceQL/struct-11                          13.66Mi ± 21%    13.42Mi ± 25%       ~ (p=0.631 n=10)
BackendBlockTraceQL/||-11                              16.66Mi ±  4%    16.84Mi ±  2%       ~ (p=0.353 n=10)
BackendBlockTraceQL/mixed-11                           6.977Mi ±  2%    6.969Mi ±  1%       ~ (p=0.912 n=10)
BackendBlockTraceQL/complex-11                         5.615Mi ±  3%    5.698Mi ±  3%       ~ (p=0.393 n=10)
BackendBlockTraceQL/select-11                          5.518Mi ±  2%    5.734Mi ±  2%  +3.91% (p=0.001 n=10)
geomean                                                14.59Mi          14.69Mi        +0.73%

                                                    │ before.txt  │             after.txt              │
                                                    │  allocs/op  │  allocs/op   vs base               │
BackendBlockTraceQL/spanAttValMatch-11                498.5k ± 0%   498.4k ± 0%  -0.02% (p=0.000 n=10)
BackendBlockTraceQL/spanAttValNoMatch-11              79.46k ± 0%   79.48k ± 0%  +0.02% (p=0.000 n=10)
BackendBlockTraceQL/spanAttIntrinsicMatch-11          287.4k ± 0%   287.4k ± 0%  +0.00% (p=0.001 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-11        79.42k ± 0%   79.44k ± 0%  +0.02% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttValMatch-11            3.445M ± 0%   3.445M ± 0%  -0.00% (p=0.002 n=10)
BackendBlockTraceQL/resourceAttValNoMatch-11          79.47k ± 0%   79.48k ± 0%  +0.01% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-11      125.7k ± 0%   125.7k ± 0%  +0.01% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01-11   79.46k ± 0%   79.47k ± 0%  +0.01% (p=0.000 n=10)
BackendBlockTraceQL/traceOrMatch-11                   86.35k ± 1%   86.41k ± 1%       ~ (p=0.315 n=10)
BackendBlockTraceQL/traceOrNoMatch-11                 86.39k ± 1%   86.37k ± 0%       ~ (p=0.190 n=10)
BackendBlockTraceQL/mixedValNoMatch-11                80.30k ± 0%   80.30k ± 0%       ~ (p=0.796 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd-11          79.46k ± 0%   79.47k ± 0%  +0.02% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr-11           80.27k ± 0%   80.30k ± 0%  +0.05% (p=0.027 n=10)
BackendBlockTraceQL/count-11                          1.985M ± 0%   1.985M ± 0%  -0.00% (p=0.000 n=10)
BackendBlockTraceQL/struct-11                         93.51k ± 2%   93.48k ± 2%       ~ (p=0.796 n=10)
BackendBlockTraceQL/||-11                             161.5k ± 0%   161.5k ± 0%       ~ (p=0.128 n=10)
BackendBlockTraceQL/mixed-11                          87.83k ± 0%   87.94k ± 0%  +0.12% (p=0.000 n=10)
BackendBlockTraceQL/complex-11                        79.82k ± 0%   79.83k ± 0%  +0.02% (p=0.000 n=10)
BackendBlockTraceQL/select-11                         79.69k ± 0%   79.71k ± 0%  +0.02% (p=0.000 n=10)
geomean                                               147.4k        147.4k       +0.02%
```

</details>