### PR TITLE
Update the go tools image to 1.24

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine
+FROM golang:1.24-alpine
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/tempo/tools
 
-go 1.23.3
+go 1.24.0
 
 require (
 	github.com/golangci/golangci-lint v1.61.0


### PR DESCRIPTION
**What this PR does**:
 
Updates our go tools image to a go 1.24. This is required to merge: https://github.com/grafana/tempo/pull/4685

I decided to pin the major/minor rev and float the patch on our tools image. wdyt?