### PR TITLE
Issue 4346: Fix docker compose example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [BUGFIX] Fix metrics streaming for all non-trivial metrics [#4624](https://github.com/grafana/tempo/pull/4624) (@joe-elliott)
 * [BUGFIX] Fix starting consuming log [#4539](https://github.com/grafana/tempo/pull/4539) (@javiermolinar)
 * [BUGFIX] Return the operand as the only value if the tag is already filtered in the query [#4673](https://github.com/grafana/tempo/pull/4673) (@mapno)
+* [BUGFIX] Fix memcached settings for docker compose example [#4346](https://github.com/grafana/tempo/pull/4695) (@ruslan-mikhailov)
 
 # v2.7.0
 

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -2017,7 +2017,7 @@ cache:
             # Optional
             # Comma separated addresses list in DNS Service Discovery format. Refer - https://cortexmetrics.io/docs/configuration/arguments/#dns-service-discovery.
             # (default: "")
-            # Example: "addresses: memcached"
+            # Example: "addresses: dns+memcached:11211"
             [addresses: <comma separated strings>]
 
             # Optional

--- a/example/docker-compose/local/tempo.yaml
+++ b/example/docker-compose/local/tempo.yaml
@@ -11,7 +11,7 @@ cache:
   - roles:
     - frontend-search  
     memcached: 
-      host: memcached:11211
+      addresses: dns+memcached:11211
 
 query_frontend:
   search:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

- Fix memcache settings for example. Docker DNS does not create SRV record, use A record instead
- Fix documentation. "memcached" is the wrong value for the addresses field

**Which issue(s) this PR fixes**:
Fixes #4346

**Checklist**

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

**How this PR has been tested**:
1. Add `c.Store(context.TODO(), []string{"testing"}, [][]byte{[]byte("testing")})` in modules/cache/memcached/memcached.go:34 to force memcache to write a value
2. Run docker-compose from `example/docker-compose/local`
3. Check that there are no errors in logs
4. Connect to memcached, get value under key "testing". Expected result: value is "testing" 

