### PR TITLE
Set gRPC compression default to snappy in all cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [CHANGE] **BREAKING CHANGE** Enforce max attribute size at event, link, and instrumentation scope. Make config per-tenant.
   Renamed max_span_attr_byte to max_attribute_bytes
   [#4633](https://github.com/grafana/tempo/pull/4633) (@ie-pham)
+* [CHANGE] Default to snappy compression for all gRPC communications internal to Tempo. For a discussion on alternatives see https://github.com/grafana/tempo/discussions/4683. [#4696](https://github.com/grafana/tempo/pull/4696) (@joe-elliott)
 * [FEATURE] Added most_recent=true query hint to TraceQL to return most recent results. [#4238](https://github.com/grafana/tempo/pull/4238) (@joe-elliott)
 * [ENHANCEMENT] Update minio to version [#4341](https://github.com/grafana/tempo/pull/4568) (@javiermolinar)
 * [ENHANCEMENT] Prevent queries in the ingester from blocking flushing traces to disk and memory spikes. [#4483](https://github.com/grafana/tempo/pull/4483) (@joe-elliott)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@
 * [CHANGE] **BREAKING CHANGE** Enforce max attribute size at event, link, and instrumentation scope. Make config per-tenant.
   Renamed max_span_attr_byte to max_attribute_bytes
   [#4633](https://github.com/grafana/tempo/pull/4633) (@ie-pham)
-* [CHANGE] Default to snappy compression for all gRPC communications internal to Tempo. For a discussion on alternatives see https://github.com/grafana/tempo/discussions/4683. [#4696](https://github.com/grafana/tempo/pull/4696) (@joe-elliott)
 * [FEATURE] Added most_recent=true query hint to TraceQL to return most recent results. [#4238](https://github.com/grafana/tempo/pull/4238) (@joe-elliott)
 * [ENHANCEMENT] Update minio to version [#4341](https://github.com/grafana/tempo/pull/4568) (@javiermolinar)
 * [ENHANCEMENT] Prevent queries in the ingester from blocking flushing traces to disk and memory spikes. [#4483](https://github.com/grafana/tempo/pull/4483) (@joe-elliott)
@@ -37,6 +36,10 @@
 * [BUGFIX] Fix metrics streaming for all non-trivial metrics [#4624](https://github.com/grafana/tempo/pull/4624) (@joe-elliott)
 * [BUGFIX] Fix starting consuming log [#4539](https://github.com/grafana/tempo/pull/4539) (@javiermolinar)
 * [BUGFIX] Return the operand as the only value if the tag is already filtered in the query [#4673](https://github.com/grafana/tempo/pull/4673) (@mapno)
+
+# v2.7.1
+
+* [CHANGE] Default to snappy compression for all gRPC communications internal to Tempo. We feel this is a nice balance of resource usage and network traffic. For a discussion on alternatives see https://github.com/grafana/tempo/discussions/4683. [#4696](https://github.com/grafana/tempo/pull/4696) (@joe-elliott)
 
 # v2.7.0
 

--- a/cmd/tempo/app/config.go
+++ b/cmd/tempo/app/config.go
@@ -118,9 +118,9 @@ func (c *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 
 	// Everything else
 	flagext.DefaultValues(&c.IngesterClient)
-	c.IngesterClient.GRPCClientConfig.GRPCCompression = ""
+	c.IngesterClient.GRPCClientConfig.GRPCCompression = "snappy"
 	flagext.DefaultValues(&c.GeneratorClient)
-	c.GeneratorClient.GRPCClientConfig.GRPCCompression = ""
+	c.GeneratorClient.GRPCClientConfig.GRPCCompression = "snappy"
 	c.Overrides.RegisterFlagsAndApplyDefaults(f)
 
 	c.Distributor.RegisterFlagsAndApplyDefaults(util.PrefixConfig(prefix, "distributor"), f)

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -214,7 +214,7 @@ ingester_client:
     grpc_client_config:
         max_recv_msg_size: 104857600
         max_send_msg_size: 104857600
-        grpc_compression: ""
+        grpc_compression: "snappy"
         rate_limit: 0
         rate_limit_burst: 0
         backoff_on_ratelimits: false
@@ -245,7 +245,7 @@ metrics_generator_client:
     grpc_client_config:
         max_recv_msg_size: 104857600
         max_send_msg_size: 104857600
-        grpc_compression: ""
+        grpc_compression: "snappy"
         rate_limit: 0
         rate_limit_burst: 0
         backoff_on_ratelimits: false
@@ -284,7 +284,7 @@ querier:
         grpc_client_config:
             max_recv_msg_size: 104857600
             max_send_msg_size: 16777216
-            grpc_compression: ""
+            grpc_compression: "snappy"
             rate_limit: 0
             rate_limit_burst: 0
             backoff_on_ratelimits: false

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -214,7 +214,7 @@ ingester_client:
     grpc_client_config:
         max_recv_msg_size: 104857600
         max_send_msg_size: 104857600
-        grpc_compression: "snappy"
+        grpc_compression: snappy
         rate_limit: 0
         rate_limit_burst: 0
         backoff_on_ratelimits: false
@@ -245,7 +245,7 @@ metrics_generator_client:
     grpc_client_config:
         max_recv_msg_size: 104857600
         max_send_msg_size: 104857600
-        grpc_compression: "snappy"
+        grpc_compression: snappy
         rate_limit: 0
         rate_limit_burst: 0
         backoff_on_ratelimits: false
@@ -284,7 +284,7 @@ querier:
         grpc_client_config:
             max_recv_msg_size: 104857600
             max_send_msg_size: 16777216
-            grpc_compression: "snappy"
+            grpc_compression: snappy
             rate_limit: 0
             rate_limit_burst: 0
             backoff_on_ratelimits: false

--- a/modules/querier/config.go
+++ b/modules/querier/config.go
@@ -61,7 +61,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 		GRPCClientConfig: grpcclient.Config{
 			MaxRecvMsgSize:  100 << 20,
 			MaxSendMsgSize:  16 << 20,
-			GRPCCompression: "",
+			GRPCCompression: "snappy",
 			BackoffConfig: backoff.Config{ // the max possible backoff should be lesser than QueryTimeout, with room for actual query response time
 				MinBackoff: 100 * time.Millisecond,
 				MaxBackoff: 1 * time.Second,


### PR DESCRIPTION
Sets gRPC compression between all components to be "snappy". This feels like a balanced approach to compression between components that will work for most installs. If you prefer a different balance of CPU/Memory and bandwidth consider disabling compression or using zstd. 

Some details here: https://github.com/grafana/tempo/discussions/4683

Revisits the choice made here: https://github.com/grafana/tempo/pull/4429