### PR TITLE
[DOC] Release notes for 2.7.1

### DIFF
--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -270,15 +270,24 @@ For additional information, refer to [Troubleshoot out-of-memory errors](https:/
 
 ### gRPC compression
 
-If you notice increased network traffic or issues, check the gRPC compression settings.
+Starting with Tempo 2.7.1, gRPC compression between all components defaults to `snappy`.
+Using `snappy` provides a balanced approach to compression between components that will work for most installations.
 
-Tempo 2.7 disabled gRPC compression in the querier and distributor for performance reasons. ([#4429](https://github.com/grafana/tempo/pull/4429))
+If you prefer a different balance of CPU/Memory and bandwidth, consider disabling compression or using `zstd`.
+
+For a discussion on alternatives, refer to [this discussion thread](https://github.com/grafana/tempo/discussions/4683). ([#4696](https://github.com/grafana/tempo/pull/4696)).
+
+
+Disabling comrpession may provide some performance boosts.
 Benchmark testing suggested that without compression, queriers and distributors used less CPU and memory.
 
 However, you may notice an increase in ingester data and network traffic especially for larger clusters.
 This increased data can impact billing for Grafana Cloud.
 
 You can configure the gRPC compression in the `querier`, `ingester`, and `metrics_generator` clients of the distributor.
+
+To disable compression, remove `snappy` from the `grpc_compression` lines.
+
 To re-enable the compression, use `snappy` with the following settings:
 
   ```yaml

--- a/docs/sources/tempo/release-notes/v2-7.md
+++ b/docs/sources/tempo/release-notes/v2-7.md
@@ -33,8 +33,8 @@ For a complete list, refer to the [Tempo changelog](https://github.com/grafana/t
 The most important features and enhancements in Tempo 2.7 are highlighted below.
 
 {{< admonition type="note" >}}
-This release disables gRPC compression by default to improve performance.
-This change will increase data usage and network traffic, which can impact cloud billing depending on your configuration. Refer to [gRPC compression](#grpc-compression-disabled) for more information.
+This release changes gRPC compression to `snappy` by default to improve performance.
+Refer to [gRPC compression](#grpc-compression-set-to-snappy) for more information.
 {{< /admonition >}}
 
 ### Track ingested traffic and attribute costs
@@ -100,7 +100,13 @@ For more information about TraceQL metrics, refer to [TraceQL metrics functions]
 
 ### Other enhancements and improvements
 
-This release also has these notable updates:
+This release also has these notable updates.
+
+### 2.7.1
+
+* Default to snappy compression for all gRPC communications internal to Tempo. We feel this is a nice balance of resource usage and network traffic. For a discussion on alternatives, refer to [this discussion thread](https://github.com/grafana/tempo/discussions/4683). ([#4696](https://github.com/grafana/tempo/pull/4696))
+
+### 2.7.0
 
 * The [metrics-generator](https://grafana.com/docs/tempo/latest/metrics-generator/) introduces a generous limit of 100 for failed flush attempts ([#4254](https://github.com/grafana/tempo/pull/4254)) to prevent constant retries on corrupted blocks. A new metric also tracks these flush failures, offering better visibility into potential issues during ingestion.
 * For [span metrics](https://grafana.com/docs/tempo/latest/metrics-generator/span_metrics/), the span multiplier now also sources its value from the resource attributes ([#4210](https://github.com/grafana/tempo/pull/4210)). This makes it possible to adjust and correct metrics using service or environment configuration, ensuring more accurate data reporting.
@@ -156,7 +162,7 @@ Prepare to migrate any serverless workflows to alternative deployments. ([#4017]
 
 There are no changes to this release for serverless. However, you'll need to remove these configurations before the next release.
 
-### Anchored regular expressioon matchers in TraceQL
+### Anchored regular expression matchers in TraceQL
 
 TraceQL now uses the Prometheus "fast regex" engine to accelerate regular expression-based filtering ([#4329](https://github.com/grafana/tempo/pull/4329)).
 As part of this update, all regular expression matches are now fully anchored.
@@ -167,7 +173,7 @@ For more information, refer to the [Comparison operators TraceQL](http://localho
 
 ### Migration from OpenTracing to OpenTelemetry
 
-The `use_otel_tracer` option is removed.
+This release removes the `use_otel_tracer` option.
 Configure your spans via standard OpenTelemetry environment variables.
 For Jaeger exporting, set `OTEL_TRACES_EXPORTER=jaeger`.For more information, refer to the [OpenTelemetry documentation](https://www.google.com/url?q=https://opentelemetry.io/docs/languages/sdk-configuration/&sa=D&source=docs&ust=1736460391410238&usg=AOvVaw3bykVWwn34XfhrnFK73uM_). ([#3646](https://github.com/grafana/tempo/pull/3646))
 
@@ -209,10 +215,21 @@ max_spans_per_span_set
   </tr>
 </table>
 
-### gRPC compression disabled
+### gRPC compression set to snappy
 
-This release disables gRPC compression in the querier and distributor for performance reasons. ([#4429](https://github.com/grafana/tempo/pull/4429))
+Tempo 2.7.1 sets gRPC compression between all components to be `snappy`.
+Using `snappy` provides a balanced approach to compression between components that will work for most installations.
+
+If you prefer a different balance of CPU/Memory and bandwidth, consider disabling compression or using zstd.
+
+For a discussion on alternatives, refer to [this discussion thread](https://github.com/grafana/tempo/discussions/4683). ([#4696](https://github.com/grafana/tempo/pull/4696)).
+
+#### gRPC compression disabled
+
+Tempo 2.7.0 release disabled gRPC compression in the querier and distributor for performance reasons. ([#4429](https://github.com/grafana/tempo/pull/4429)).
 Our benchmark suggests that without compression, queriers and distributors use less CPU and memory.
+
+Tempo 2.7.1 changed the default value to `snappy` for internal components.
 
 {{< admonition type="note" >}}
 While disabling gRPC compression improves performance, it will increase data usage and network traffic, which can impact cloud billing depending on your configuration.

--- a/docs/sources/tempo/setup/upgrade.md
+++ b/docs/sources/tempo/setup/upgrade.md
@@ -96,10 +96,21 @@ The `use_otel_tracer` option is removed.
 Configure your spans via standard OpenTelemetry environment variables.
 For Jaeger exporting, set `OTEL_TRACES_EXPORTER=jaeger`.For more information, refer to the [OpenTelemetry documentation](https://www.google.com/url?q=https://opentelemetry.io/docs/languages/sdk-configuration/&sa=D&source=docs&ust=1736460391410238&usg=AOvVaw3bykVWwn34XfhrnFK73uM_). ([#3646](https://github.com/grafana/tempo/pull/3646))
 
-### gRPC compression disabled
+### gRPC compression set to snappy
 
-This release disables gRPC compression in the querier and distributor for performance reasons. ([#4429](https://github.com/grafana/tempo/pull/4429))
+Tempo 2.7.1 set gRPC compression between all components to be `snappy`.
+Using `snappy` provides a balanced approach to compression between components that will work for most installations.
+
+If you prefer a different balance of CPU/Memory and bandwidth, consider disabling compression or using zstd.
+
+For a discussion on alternatives, refer to [this discussion thread](https://github.com/grafana/tempo/discussions/4683). ([#4696](https://github.com/grafana/tempo/pull/4696)).
+
+#### gRPC compression disabled
+
+Tempo 2.7.0 release disabled gRPC compression in the querier and distributor for performance reasons. ([#4429](https://github.com/grafana/tempo/pull/4429)).
 Our benchmark suggests that without compression, queriers and distributors use less CPU and memory.
+
+Tempo 2.7.1 changed the default value to `snappy` for internal components.
 
 {{< admonition type="note" >}}
 This change may increase data usage and network traffic, which can impact cloud billing.
@@ -107,7 +118,6 @@ This change may increase data usage and network traffic, which can impact cloud 
 
 If you notice increased network traffic or issues, check the gRPC compression settings.
 
-For instructions how to enable gRPC compression, refer to [gRPC compression configuration](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#grpc-compression) for more information.
 For instructions how to enable gRPC compression, refer to [gRPC compression configuration](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#grpc-compression) for more information.
 
 ### Added, updated, removed, or renamed configuration parameters


### PR DESCRIPTION

**What this PR does**:

Updates docs to change the default value for gRPC compression to snappy, per https://github.com/grafana/tempo/pull/4696

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`