### PR TITLE
Improve EqualRowNumber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [ENHANCEMENT] Use distroless base container images for improved security [#4556](https://github.com/grafana/tempo/pull/4556) (@carles-grafana)
 * [ENHANCEMENT] rythm: add block builder to resources dashboard[#4556](https://github.com/grafana/tempo/pull/4669) (@javiermolinar)
 * [ENHANCEMENT] update dskit to latest version[#4681](https://github.com/grafana/tempo/pull/4681) (@javiermolinar)
+* [ENHANCEMENT] Improve TraceQL perf by reverting EqualRowNumber to an inlineable function.[#4705](https://github.com/grafana/tempo/pull/4705) (@joe-elliott)
 * [BUGFIX] Choose a default step for a gRPC streaming query range request if none is provided. [#4546](https://github.com/grafana/tempo/pull/4576) (@joe-elliott)
   Correctly copy exemplars for metrics like `| rate()` when gRPC streaming.
 * [BUGFIX] Fix performance bottleneck and file cleanup in block builder [#4550](https://github.com/grafana/tempo/pull/4550) (@mdisibio)

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -70,23 +70,12 @@ func CompareRowNumbers(upToDefinitionLevel int, a, b RowNumber) int {
 // EqualRowNumber compares the sequences of row numbers in a and b
 // for partial equality. A little faster than CompareRowNumbers(d,a,b)==0
 func EqualRowNumber(upToDefinitionLevel int, a, b RowNumber) bool {
-	/*for i := 0; i <= upToDefinitionLevel; i++ {
+	for i := 0; i <= upToDefinitionLevel; i++ {
 		if a[i] != b[i] {
 			return false
 		}
 	}
-	return true*/
-
-	// This is an unrolled version of the above loop, that is still
-	// small enough to be inlined and takes advantage of instruction pipelining.
-	return (a[0] == b[0]) &&
-		(a[1] == b[1] || upToDefinitionLevel < 1) &&
-		(a[2] == b[2] || upToDefinitionLevel < 2) &&
-		(a[3] == b[3] || upToDefinitionLevel < 3) &&
-		(a[4] == b[4] || upToDefinitionLevel < 4) &&
-		(a[5] == b[5] || upToDefinitionLevel < 5) &&
-		(a[6] == b[6] || upToDefinitionLevel < 6) &&
-		(a[7] == b[7] || upToDefinitionLevel < 7)
+	return true
 }
 
 func truncateRowNumberSlow(definitionLevelToKeep int, t RowNumber) RowNumber {


### PR DESCRIPTION
**What this PR does**:
Restores the old behavior of `EqualRowNumber`. The current version is no longer inlineable. This can be checked using a command like:

```
go build -gcflags="-m" . 2>&1 | grep 'can inline' | grep EqualRowNumber
```

The old version is inlineable and shows a perf improvement.

<details>
<summary>benches</summary>

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/tempo/tempodb/encoding/vparquet4
cpu: Apple M3 Pro
                                                    │ before.txt  │        after-old-eq-rn.txt         │
                                                    │   sec/op    │   sec/op     vs base               │
BackendBlockTraceQL/spanAttValMatch-11                82.76m ± 1%   82.36m ± 0%  -0.48% (p=0.000 n=10)
BackendBlockTraceQL/spanAttValNoMatch-11              5.468m ± 1%   5.524m ± 0%  +1.03% (p=0.001 n=10)
BackendBlockTraceQL/spanAttIntrinsicMatch-11          58.59m ± 0%   58.68m ± 1%       ~ (p=0.143 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-11        5.383m ± 2%   5.460m ± 1%  +1.42% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttValMatch-11            394.6m ± 1%   389.6m ± 1%  -1.26% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttValNoMatch-11          5.095m ± 0%   5.130m ± 1%       ~ (p=0.123 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-11      24.86m ± 0%   24.81m ± 0%       ~ (p=0.075 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01-11   5.170m ± 0%   5.247m ± 0%  +1.49% (p=0.000 n=10)
BackendBlockTraceQL/traceOrMatch-11                   240.7m ± 1%   234.3m ± 0%  -2.64% (p=0.000 n=10)
BackendBlockTraceQL/traceOrNoMatch-11                 241.4m ± 0%   234.7m ± 0%  -2.79% (p=0.000 n=10)
BackendBlockTraceQL/mixedValNoMatch-11                178.4m ± 0%   179.8m ± 1%  +0.74% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd-11          5.009m ± 1%   4.862m ± 0%  -2.93% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr-11           148.5m ± 0%   144.9m ± 0%  -2.46% (p=0.000 n=10)
BackendBlockTraceQL/count-11                          328.5m ± 0%   316.9m ± 0%  -3.53% (p=0.000 n=10)
BackendBlockTraceQL/struct-11                         429.4m ± 2%   413.8m ± 1%  -3.63% (p=0.000 n=10)
BackendBlockTraceQL/||-11                             152.5m ± 0%   146.2m ± 0%  -4.15% (p=0.000 n=10)
BackendBlockTraceQL/mixed-11                          25.34m ± 0%   25.26m ± 0%  -0.29% (p=0.000 n=10)
BackendBlockTraceQL/complex-11                        4.975m ± 1%   4.935m ± 2%       ~ (p=0.247 n=10)
BackendBlockTraceQL/select-11                         5.009m ± 1%   4.978m ± 1%       ~ (p=0.052 n=10)
geomean                                               40.72m        40.28m       -1.08%

                                                    │  before.txt  │         after-old-eq-rn.txt         │
                                                    │     B/s      │     B/s       vs base               │
BackendBlockTraceQL/spanAttValMatch-11                270.6Mi ± 1%   271.9Mi ± 0%  +0.49% (p=0.000 n=10)
BackendBlockTraceQL/spanAttValNoMatch-11              309.0Mi ± 1%   305.9Mi ± 0%  -1.02% (p=0.001 n=10)
BackendBlockTraceQL/spanAttIntrinsicMatch-11          397.6Mi ± 0%   396.9Mi ± 1%       ~ (p=0.143 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-11        460.2Mi ± 2%   453.7Mi ± 1%  -1.40% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttValMatch-11            55.69Mi ± 1%   56.40Mi ± 1%  +1.28% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttValNoMatch-11          176.5Mi ± 0%   175.4Mi ± 1%       ~ (p=0.110 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-11      885.8Mi ± 0%   887.5Mi ± 0%       ~ (p=0.075 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01-11   180.6Mi ± 0%   178.0Mi ± 0%  -1.47% (p=0.000 n=10)
BackendBlockTraceQL/traceOrMatch-11                   6.948Mi ± 0%   7.133Mi ± 0%  +2.68% (p=0.000 n=10)
BackendBlockTraceQL/traceOrNoMatch-11                 6.924Mi ± 0%   7.124Mi ± 0%  +2.89% (p=0.000 n=10)
BackendBlockTraceQL/mixedValNoMatch-11                11.05Mi ± 0%   10.96Mi ± 1%  -0.78% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd-11          178.2Mi ± 1%   183.6Mi ± 0%  +3.02% (p=0.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr-11           18.57Mi ± 0%   19.04Mi ± 0%  +2.52% (p=0.000 n=10)
BackendBlockTraceQL/count-11                          66.86Mi ± 0%   69.31Mi ± 0%  +3.67% (p=0.000 n=10)
BackendBlockTraceQL/struct-11                         12.72Mi ± 2%   13.20Mi ± 1%  +3.79% (p=0.000 n=10)
BackendBlockTraceQL/||-11                             144.8Mi ± 0%   151.0Mi ± 0%  +4.34% (p=0.000 n=10)
BackendBlockTraceQL/mixed-11                          843.2Mi ± 0%   845.7Mi ± 0%  +0.29% (p=0.000 n=10)
BackendBlockTraceQL/complex-11                        180.9Mi ± 1%   182.4Mi ± 1%       ~ (p=0.247 n=10)
BackendBlockTraceQL/select-11                         179.7Mi ± 1%   180.8Mi ± 1%       ~ (p=0.050 n=10)
geomean                                               101.9Mi        103.0Mi       +1.09%

                                                    │ before.txt  │         after-old-eq-rn.txt          │
                                                    │  MB_io/op   │  MB_io/op    vs base                 │
BackendBlockTraceQL/spanAttValMatch-11                 23.48 ± 0%    23.48 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/spanAttValNoMatch-11               1.772 ± 0%    1.772 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/spanAttIntrinsicMatch-11           24.43 ± 0%    24.43 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/spanAttIntrinsicNoMatch-11         2.598 ± 0%    2.598 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/resourceAttValMatch-11             23.04 ± 0%    23.04 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/resourceAttValNoMatch-11          943.2m ± 0%   943.2m ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/resourceAttIntrinsicMatch-11       23.09 ± 0%    23.09 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/resourceAttIntrinsicMatch#01-11   979.0m ± 0%   979.0m ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/traceOrMatch-11                    1.753 ± 0%    1.753 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/traceOrNoMatch-11                  1.753 ± 0%    1.753 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixedValNoMatch-11                 2.067 ± 0%    2.067 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixedValMixedMatchAnd-11          936.1m ± 0%   936.1m ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixedValMixedMatchOr-11            2.893 ± 0%    2.893 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/count-11                           23.03 ± 0%    23.03 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/struct-11                          5.726 ± 0%    5.726 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/||-11                              23.14 ± 0%    23.14 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixed-11                           22.40 ± 0%    22.40 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/complex-11                        943.7m ± 0%   943.7m ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/select-11                         943.7m ± 0%   943.7m ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                4.351         4.351       +0.00%
¹ all samples are equal

                                                    │  before.txt   │         after-old-eq-rn.txt          │
                                                    │     B/op      │     B/op       vs base               │
BackendBlockTraceQL/spanAttValMatch-11                45.28Mi ±  1%   45.05Mi ±  1%       ~ (p=0.353 n=10)
BackendBlockTraceQL/spanAttValNoMatch-11              6.693Mi ±  1%   6.700Mi ±  1%       ~ (p=0.684 n=10)
BackendBlockTraceQL/spanAttIntrinsicMatch-11          39.78Mi ±  1%   39.66Mi ±  1%       ~ (p=0.436 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-11        7.021Mi ±  2%   7.018Mi ±  2%       ~ (p=0.853 n=10)
BackendBlockTraceQL/resourceAttValMatch-11            576.8Mi ±  0%   576.7Mi ±  1%       ~ (p=0.353 n=10)
BackendBlockTraceQL/resourceAttValNoMatch-11          5.308Mi ±  1%   5.271Mi ±  2%       ~ (p=0.481 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-11      10.52Mi ±  1%   10.52Mi ±  2%       ~ (p=0.971 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01-11   6.768Mi ±  1%   6.754Mi ±  1%       ~ (p=0.247 n=10)
BackendBlockTraceQL/traceOrMatch-11                   9.428Mi ± 20%   9.799Mi ± 21%       ~ (p=0.853 n=10)
BackendBlockTraceQL/traceOrNoMatch-11                 10.02Mi ± 23%   10.82Mi ± 17%       ~ (p=0.436 n=10)
BackendBlockTraceQL/mixedValNoMatch-11                8.002Mi ± 11%   7.830Mi ±  3%       ~ (p=0.529 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd-11          5.743Mi ±  1%   5.807Mi ±  1%  +1.11% (p=0.003 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr-11           7.971Mi ±  8%   8.036Mi ±  8%       ~ (p=0.912 n=10)
BackendBlockTraceQL/count-11                          418.7Mi ±  0%   418.0Mi ±  0%       ~ (p=0.075 n=10)
BackendBlockTraceQL/struct-11                         13.66Mi ± 17%   13.69Mi ± 16%       ~ (p=0.912 n=10)
BackendBlockTraceQL/||-11                             16.74Mi ±  5%   16.80Mi ±  5%       ~ (p=1.000 n=10)
BackendBlockTraceQL/mixed-11                          7.048Mi ±  3%   6.911Mi ±  1%  -1.94% (p=0.003 n=10)
BackendBlockTraceQL/complex-11                        5.613Mi ±  1%   5.676Mi ±  3%       ~ (p=0.481 n=10)
BackendBlockTraceQL/select-11                         5.554Mi ±  2%   5.480Mi ±  2%       ~ (p=0.218 n=10)
geomean                                               14.61Mi         14.67Mi        +0.41%

                                                    │ before.txt  │        after-old-eq-rn.txt         │
                                                    │  allocs/op  │  allocs/op   vs base               │
BackendBlockTraceQL/spanAttValMatch-11                503.6k ± 0%   503.6k ± 0%  -0.00% (p=0.011 n=10)
BackendBlockTraceQL/spanAttValNoMatch-11              79.47k ± 0%   79.47k ± 0%       ~ (p=0.695 n=10)
BackendBlockTraceQL/spanAttIntrinsicMatch-11          288.1k ± 0%   288.1k ± 0%       ~ (p=0.810 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-11        79.42k ± 0%   79.42k ± 0%       ~ (p=0.866 n=10)
BackendBlockTraceQL/resourceAttValMatch-11            3.450M ± 0%   3.450M ± 0%       ~ (p=0.197 n=10)
BackendBlockTraceQL/resourceAttValNoMatch-11          79.47k ± 0%   79.47k ± 0%       ~ (p=0.746 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-11      126.1k ± 0%   126.1k ± 0%       ~ (p=0.753 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01-11   79.46k ± 0%   79.46k ± 0%       ~ (p=0.665 n=10)
BackendBlockTraceQL/traceOrMatch-11                   86.53k ± 2%   86.85k ± 1%       ~ (p=0.280 n=10)
BackendBlockTraceQL/traceOrNoMatch-11                 86.36k ± 0%   86.38k ± 0%       ~ (p=0.239 n=10)
BackendBlockTraceQL/mixedValNoMatch-11                80.29k ± 0%   80.29k ± 0%       ~ (p=0.867 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd-11          79.46k ± 0%   79.47k ± 0%  +0.00% (p=0.026 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr-11           80.29k ± 0%   80.27k ± 0%       ~ (p=0.210 n=10)
BackendBlockTraceQL/count-11                          1.991M ± 0%   1.991M ± 0%       ~ (p=0.280 n=10)
BackendBlockTraceQL/struct-11                         93.63k ± 7%   93.67k ± 1%       ~ (p=0.971 n=10)
BackendBlockTraceQL/||-11                             161.9k ± 0%   161.9k ± 0%       ~ (p=0.517 n=10)
BackendBlockTraceQL/mixed-11                          87.86k ± 0%   87.85k ± 0%  -0.01% (p=0.004 n=10)
BackendBlockTraceQL/complex-11                        79.82k ± 0%   79.82k ± 0%       ~ (p=0.750 n=10)
BackendBlockTraceQL/select-11                         79.70k ± 0%   79.70k ± 0%       ~ (p=0.151 n=10)
geomean                                               147.6k        147.6k       +0.02%
```

</details>
