### PR TITLE
Add ability to add artificial delay to push requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   Renamed max_span_attr_byte to max_attribute_bytes
   [#4633](https://github.com/grafana/tempo/pull/4633) (@ie-pham)
 * [FEATURE] Added most_recent=true query hint to TraceQL to return most recent results. [#4238](https://github.com/grafana/tempo/pull/4238) (@joe-elliott)
+* [FEATURE] Add ability to add artificial delay to push requests [#4716](https://github.com/grafana/tempo/pull/4716) (@yvrhdn)
 * [ENHANCEMENT] Update minio to version [#4341](https://github.com/grafana/tempo/pull/4568) (@javiermolinar)
 * [ENHANCEMENT] Prevent queries in the ingester from blocking flushing traces to disk and memory spikes. [#4483](https://github.com/grafana/tempo/pull/4483) (@joe-elliott)
 * [ENHANCEMENT] Update tempo operational dashboard for new block-builder and v2 traces api [#4559](https://github.com/grafana/tempo/pull/4559) (@mdisibio)

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -1644,6 +1644,10 @@ overrides:
 
       # Maximum bytes any attribute can be for both keys and values.
       [max_attribute_bytes: <int> | default = 0]
+      
+      # Pad push requests with an artificial delay, if set push requests will be delayed to ensure
+      # an average latency of at least artificial_delay.
+      [artificial_delay: <duration> | default = 0ms]
 
     # Read related overrides
     read:

--- a/modules/distributor/artificial_delay.go
+++ b/modules/distributor/artificial_delay.go
@@ -1,0 +1,31 @@
+package distributor
+
+import (
+	"math/rand"
+	"time"
+)
+
+func (d *Distributor) padWithArtificialDelay(reqStart time.Time, userID string) {
+	artificialDelay := d.overrides.IngestionArtificialDelay(userID)
+	if artificialDelay <= 0 {
+		return
+	}
+
+	// delay = targetDelay - time spent processing the request up until now
+	// If the request took longer than the target delay, we don't delay at all as sleep will return immediately for a negative value
+	reqDuration := d.now().Sub(reqStart)
+	delay := artificialDelay - reqDuration
+	d.sleep(durationWithJitter(delay, 0.10))
+}
+
+// durationWithJitter returns random duration from "input - input*variance" to "input + input*variance" interval.
+func durationWithJitter(input time.Duration, variancePerc float64) time.Duration {
+	variance := int64(float64(input) * variancePerc)
+	if variance <= 0 {
+		return 0
+	}
+
+	jitter := rand.Int63n(variance*2) - variance
+
+	return input + time.Duration(jitter)
+}

--- a/modules/distributor/artificial_delay_test.go
+++ b/modules/distributor/artificial_delay_test.go
@@ -1,0 +1,95 @@
+package distributor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/tempo/modules/overrides"
+)
+
+func Test_outerMaybeDelayMiddleware(t *testing.T) {
+	tests := []struct {
+		name          string
+		userID        string
+		delay         time.Duration
+		reqDuration   time.Duration
+		expectedSleep time.Duration
+	}{
+		{
+			name:          "No delay configured",
+			userID:        "user1",
+			delay:         0,
+			reqDuration:   50 * time.Millisecond,
+			expectedSleep: 0,
+		},
+		{
+			name:          "Delay configured but request took longer than delay",
+			userID:        "user2",
+			delay:         500 * time.Millisecond,
+			reqDuration:   750 * time.Millisecond,
+			expectedSleep: 0,
+		},
+		{
+			name:          "Delay configured and request took less than delay",
+			userID:        "user3",
+			delay:         500 * time.Millisecond,
+			reqDuration:   50 * time.Millisecond,
+			expectedSleep: 450 * time.Millisecond,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			limits := overrides.Overrides{
+				Ingestion: overrides.IngestionOverrides{
+					ArtificialDelay: tc.delay,
+				},
+			}
+			// Init limits overrides
+			overrides, err := overrides.NewOverrides(overrides.Config{
+				Defaults: limits,
+			}, nil, prometheus.DefaultRegisterer)
+			require.NoError(t, err)
+
+			// Mock to capture sleep and advance time.
+			timeSource := &MockTimeSource{CurrentTime: time.Now()}
+			reqStart := timeSource.CurrentTime
+
+			d := &Distributor{
+				overrides: overrides,
+				sleep:     timeSource.Sleep,
+				now:       timeSource.Now,
+			}
+
+			// Add time spent on request
+			timeSource.Add(tc.reqDuration)
+
+			d.padWithArtificialDelay(reqStart, tc.userID)
+
+			// Due to the 10% jitter we need to take into account that the number will not be deterministic in tests.
+			difference := timeSource.Slept - tc.expectedSleep
+			require.LessOrEqual(t, difference.Abs(), tc.expectedSleep/10)
+		})
+	}
+}
+
+type MockTimeSource struct {
+	CurrentTime time.Time
+	Slept       time.Duration
+}
+
+func (m *MockTimeSource) Now() time.Time {
+	return m.CurrentTime
+}
+
+func (m *MockTimeSource) Sleep(d time.Duration) {
+	if d > 0 {
+		m.Slept += d
+	}
+}
+
+func (m *MockTimeSource) Add(d time.Duration) {
+	m.CurrentTime = m.CurrentTime.Add(d)
+}

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -76,9 +76,9 @@ type IngestionOverrides struct {
 	MaxLocalTracesPerUser  int `yaml:"max_traces_per_user,omitempty" json:"max_traces_per_user,omitempty"`
 	MaxGlobalTracesPerUser int `yaml:"max_global_traces_per_user,omitempty" json:"max_global_traces_per_user,omitempty"`
 
-	TenantShardSize int `yaml:"tenant_shard_size,omitempty" json:"tenant_shard_size,omitempty"`
-
-	MaxAttributeBytes int `yaml:"max_attribute_bytes,omitempty" json:"max_attribute_bytes,omitempty"`
+	TenantShardSize   int           `yaml:"tenant_shard_size,omitempty" json:"tenant_shard_size,omitempty"`
+	MaxAttributeBytes int           `yaml:"max_attribute_bytes,omitempty" json:"max_attribute_bytes,omitempty"`
+	ArtificialDelay   time.Duration `yaml:"artificial_delay,omitempty" json:"artificial_delay,omitempty"`
 }
 
 type ForwarderOverrides struct {

--- a/modules/overrides/config_legacy.go
+++ b/modules/overrides/config_legacy.go
@@ -73,11 +73,12 @@ func (c *Overrides) toLegacy() LegacyOverrides {
 // limits via flags, or per-user limits via yaml config.
 type LegacyOverrides struct {
 	// Distributor enforced limits.
-	IngestionRateStrategy      string `yaml:"ingestion_rate_strategy" json:"ingestion_rate_strategy"`
-	IngestionRateLimitBytes    int    `yaml:"ingestion_rate_limit_bytes" json:"ingestion_rate_limit_bytes"`
-	IngestionBurstSizeBytes    int    `yaml:"ingestion_burst_size_bytes" json:"ingestion_burst_size_bytes"`
-	IngestionTenantShardSize   int    `yaml:"ingestion_tenant_shard_size" json:"ingestion_tenant_shard_size"`
-	IngestionMaxAttributeBytes int    `yaml:"ingestion_max_attribute_bytes" json:"ingestion_max_attribute_bytes"`
+	IngestionRateStrategy      string        `yaml:"ingestion_rate_strategy" json:"ingestion_rate_strategy"`
+	IngestionRateLimitBytes    int           `yaml:"ingestion_rate_limit_bytes" json:"ingestion_rate_limit_bytes"`
+	IngestionBurstSizeBytes    int           `yaml:"ingestion_burst_size_bytes" json:"ingestion_burst_size_bytes"`
+	IngestionTenantShardSize   int           `yaml:"ingestion_tenant_shard_size" json:"ingestion_tenant_shard_size"`
+	IngestionMaxAttributeBytes int           `yaml:"ingestion_max_attribute_bytes" json:"ingestion_max_attribute_bytes"`
+	IngestionArtificialDelay   time.Duration `yaml:"ingestion_artificial_delay" json:"ingestion_artificial_delay"`
 
 	// Ingester enforced limits.
 	MaxLocalTracesPerUser  int `yaml:"max_traces_per_user" json:"max_traces_per_user"`

--- a/modules/overrides/interface.go
+++ b/modules/overrides/interface.go
@@ -33,6 +33,7 @@ type Interface interface {
 	MaxLocalTracesPerUser(userID string) int
 	MaxGlobalTracesPerUser(userID string) int
 	MaxBytesPerTrace(userID string) int
+	IngestionArtificialDelay(userID string) time.Duration
 	MaxCompactionRange(userID string) time.Duration
 	Forwarders(userID string) []string
 	MaxBytesPerTagValuesQuery(userID string) int

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -330,6 +330,10 @@ func (o *runtimeConfigOverridesManager) IngestionMaxAttributeBytes(userID string
 	return o.getOverridesForUser(userID).Ingestion.MaxAttributeBytes
 }
 
+func (o *runtimeConfigOverridesManager) IngestionArtificialDelay(userID string) time.Duration {
+	return o.getOverridesForUser(userID).Ingestion.ArtificialDelay
+}
+
 // MaxBytesPerTrace returns the maximum size of a single trace in bytes allowed for a user.
 func (o *runtimeConfigOverridesManager) MaxBytesPerTrace(userID string) int {
 	return o.getOverridesForUser(userID).Global.MaxBytesPerTrace


### PR DESCRIPTION
**What this PR does**:

Add a tenant-specific override to pad push requests with an artificial delay. This makes it possible to simulate a slower version of Tempo and see how it impacts the tracing pipeline.

**Which issue(s) this PR fixes**:
~~Fixes #<issue number>~~

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`