### PR TITLE
fix trace:id search for ids less than 128 bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [BUGFIX] Correctly cache frontend jobs for query range (TraceQL Metrics). [#4771](https://github.com/grafana/tempo/pull/4771) (@joe-elliott)
 * [BUGFIX] Various edge case fixes for query range (TraceQL Metrics) [#4962](https://github.com/grafana/tempo/pull/4962) (@ruslan-mikhailov)
 * [BUGFIX] Fix `TempoBlockListRisingQuickly` alert grouping. [#4876](https://github.com/grafana/tempo/pull/4876) (@mapno)
+* [BUGFIX] Fix trace:id search for trace ids not 128 bit [#4718](https://github.com/grafana/tempo/pull/4718) (@ie-pham)
 
 # v2.7.2
 

--- a/pkg/parquetquery/predicates.gen.go
+++ b/pkg/parquetquery/predicates.gen.go
@@ -1021,7 +1021,7 @@ func (p ByteEqualPredicate) KeepPage(page pq.Page) bool {
 
 func (p ByteEqualPredicate) KeepValue(v pq.Value) bool {
 	vv := v.ByteArray()
-	return bytes.Equal(bytes.TrimLeft(vv, "\x00"), p.value)
+	return bytes.Equal(vv, p.value)
 }
 
 var _ Predicate = (*ByteNotEqualPredicate)(nil)
@@ -1072,5 +1072,5 @@ func (p ByteNotEqualPredicate) KeepPage(page pq.Page) bool {
 
 func (p ByteNotEqualPredicate) KeepValue(v pq.Value) bool {
 	vv := v.ByteArray()
-	return !bytes.Equal(bytes.TrimLeft(vv, "\x00"), p.value)
+	return !bytes.Equal(vv, p.value)
 }

--- a/pkg/parquetquery/predicates.gen.go
+++ b/pkg/parquetquery/predicates.gen.go
@@ -1074,3 +1074,67 @@ func (p ByteNotEqualPredicate) KeepValue(v pq.Value) bool {
 	vv := v.ByteArray()
 	return !bytes.Equal(vv, p.value)
 }
+
+var _ Predicate = (*NoRangeByteEqualPredicate)(nil)
+
+type NoRangeByteEqualPredicate struct {
+	value []byte
+}
+
+func NewNoRangeByteEqualPredicate(val []byte) NoRangeByteEqualPredicate {
+	return NoRangeByteEqualPredicate{value: val}
+}
+
+func (p NoRangeByteEqualPredicate) String() string {
+	return fmt.Sprintf("NoRangeByteEqualPredicate{%s}", p.value)
+}
+
+func (p NoRangeByteEqualPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
+	if d := c.Dictionary(); d != nil {
+		return keepDictionary(d, p.KeepValue)
+	}
+
+	return true
+}
+
+func (p NoRangeByteEqualPredicate) KeepPage(page pq.Page) bool {
+
+	return true
+}
+
+func (p NoRangeByteEqualPredicate) KeepValue(v pq.Value) bool {
+	vv := v.ByteArray()
+	return bytes.Equal(bytes.TrimLeft(vv, "\x00"), bytes.TrimLeft(p.value, "\x00"))
+}
+
+var _ Predicate = (*NoRangeByteNotEqualPredicate)(nil)
+
+type NoRangeByteNotEqualPredicate struct {
+	value []byte
+}
+
+func NewNoRangeByteNotEqualPredicate(val []byte) NoRangeByteNotEqualPredicate {
+	return NoRangeByteNotEqualPredicate{value: val}
+}
+
+func (p NoRangeByteNotEqualPredicate) String() string {
+	return fmt.Sprintf("NoRangeByteNotEqualPredicate{%s}", p.value)
+}
+
+func (p NoRangeByteNotEqualPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
+	if d := c.Dictionary(); d != nil {
+		return keepDictionary(d, p.KeepValue)
+	}
+
+	return true
+}
+
+func (p NoRangeByteNotEqualPredicate) KeepPage(page pq.Page) bool {
+
+	return true
+}
+
+func (p NoRangeByteNotEqualPredicate) KeepValue(v pq.Value) bool {
+	vv := v.ByteArray()
+	return !bytes.Equal(bytes.TrimLeft(vv, "\x00"), bytes.TrimLeft(p.value, "\x00"))
+}

--- a/pkg/parquetquerygen/predicates.go
+++ b/pkg/parquetquerygen/predicates.go
@@ -251,12 +251,12 @@ func (p {{ $structName }}) KeepValue(v pq.Value) bool {
 			Ops: []op{
 				{
 					Op:          "Equal",
-					CompareCond: `bytes.Equal(bytes.TrimLeft(vv, "\x00"), p.value)`,
+					CompareCond: `bytes.Equal(vv, p.value)`,
 					RangeCond:   "bytes.Compare(p.value, min) >= 0 && bytes.Compare(p.value, max) <= 0",
 				},
 				{
 					Op:          "NotEqual",
-					CompareCond: `!bytes.Equal(bytes.TrimLeft(vv, "\x00"), p.value)`,
+					CompareCond: `!bytes.Equal(vv, p.value)`,
 					RangeCond:   "!bytes.Equal(min, p.value) || !bytes.Equal(p.value, max)",
 				},
 			},

--- a/pkg/parquetquerygen/predicates.go
+++ b/pkg/parquetquerygen/predicates.go
@@ -261,6 +261,24 @@ func (p {{ $structName }}) KeepValue(v pq.Value) bool {
 				},
 			},
 		},
+		{
+			Name:           "NoRangeByte",
+			Type:           "[]byte",
+			ParquetFunc:    "ByteArray()",
+			FormatModifier: "%s",
+			Ops: []op{
+				{
+					Op:          "Equal",
+					CompareCond: `bytes.Equal(bytes.TrimLeft(vv, "\x00"), bytes.TrimLeft(p.value, "\x00"))`,
+					RangeCond:   "",
+				},
+				{
+					Op:          "NotEqual",
+					CompareCond: `!bytes.Equal(bytes.TrimLeft(vv, "\x00"), bytes.TrimLeft(p.value, "\x00"))`,
+					RangeCond:   "",
+				},
+			},
+		},
 	}
 
 	funcMap := template.FuncMap{

--- a/pkg/traceql/ast_conditions_test.go
+++ b/pkg/traceql/ast_conditions_test.go
@@ -110,12 +110,24 @@ func TestSpansetFilter_extractConditions(t *testing.T) {
 			conditions: []Condition{
 				newCondition(NewAttribute("foo"), OpNone),
 			},
+		},
+		{
+			query: `{ span:id = "123" }`,
+			conditions: []Condition{
+				newCondition(NewIntrinsic(IntrinsicSpanID), OpEqual, NewStaticString("0000000000000123")),
+			},
 			allConditions: true,
 		},
 		{
 			query: `{ true || .foo }`,
 			conditions: []Condition{
 				newCondition(NewAttribute("foo"), OpNone),
+			},
+		},
+		{
+			query: `{ link:spanID = "40506" }`,
+			conditions: []Condition{
+				newCondition(NewIntrinsic(IntrinsicLinkSpanID), OpEqual, NewStaticString("0000000000040506")),
 			},
 			allConditions: true,
 		},

--- a/pkg/util/traceid.go
+++ b/pkg/util/traceid.go
@@ -50,11 +50,11 @@ func IDToTrimmedHexString(byteID []byte) string {
 
 func HexStringToNonTraceID(id string) ([]byte, error) {
 	id = strings.TrimLeft(id, "0")
-	byteId, err := hexStringToID(id)
+	byteID, err := hexStringToID(id)
 	if err != nil {
 		return nil, err
 	}
-	return bytes.TrimLeft(byteId, "\x00"), nil
+	return bytes.TrimLeft(byteID, "\x00"), nil
 }
 
 // spanKindFNVHashes contains pre-calculated FNV hashes for all span kind values (and two spares)

--- a/pkg/util/traceid.go
+++ b/pkg/util/traceid.go
@@ -141,7 +141,7 @@ func hexStringToID(id string, isSpan bool) ([]byte, error) {
 		// if size < 8 {
 		// 	byteID = append(make([]byte, 8-size), byteID...)
 		// }
-		return byteID, nil
+		return bytes.TrimLeft(byteID, "\x00"), nil
 	}
 
 	if size > 16 {

--- a/pkg/util/traceid_test.go
+++ b/pkg/util/traceid_test.go
@@ -285,7 +285,7 @@ func TestPadTraceIDTo16Bytes(t *testing.T) {
 	}
 }
 
-func TestHexStringToSpanID(t *testing.T) {
+func TestHexStringToNonTraceID(t *testing.T) {
 	tc := []struct {
 		id          string
 		expected    []byte
@@ -307,7 +307,7 @@ func TestHexStringToSpanID(t *testing.T) {
 
 	for _, tt := range tc {
 		t.Run(tt.id, func(t *testing.T) {
-			actual, err := HexStringToSpanID(tt.id)
+			actual, err := HexStringToNonTraceID(tt.id)
 
 			if tt.expectError != nil {
 				assert.Equal(t, tt.expectError, err)

--- a/tempodb/encoding/vparquet2/block_traceql.go
+++ b/tempodb/encoding/vparquet2/block_traceql.go
@@ -1,7 +1,6 @@
 package vparquet2
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -1707,13 +1706,11 @@ func createBytesPredicate(op traceql.Operator, operands traceql.Operands, isSpan
 		return nil, fmt.Errorf("operand is not string: %s", s)
 	}
 
-	var id []byte
 	id, err := util.HexStringToTraceID(s)
+
 	if isSpan {
 		id, err = util.HexStringToSpanID(s)
 	}
-
-	id = bytes.TrimLeft(id, "\x00")
 
 	if err != nil {
 		return nil, nil

--- a/tempodb/encoding/vparquet2/block_traceql.go
+++ b/tempodb/encoding/vparquet2/block_traceql.go
@@ -1326,7 +1326,7 @@ func createSpanIterator(makeIter makeIterFn, primaryIter parquetquery.Iterator, 
 		switch cond.Attribute.Intrinsic {
 		case traceql.IntrinsicSpanID:
 
-			pred, err := createBytesPredicate(cond.Op, cond.Operands, true)
+			pred, err := createBytesPredicate(cond.Op, cond.Operands, false)
 			if err != nil {
 				return nil, err
 			}
@@ -1583,7 +1583,7 @@ func createTraceIterator(makeIter makeIterFn, resourceIter parquetquery.Iterator
 	for _, cond := range conds {
 		switch cond.Attribute.Intrinsic {
 		case traceql.IntrinsicTraceID:
-			pred, err := createBytesPredicate(cond.Op, cond.Operands, false)
+			pred, err := createBytesPredicate(cond.Op, cond.Operands, true)
 			if err != nil {
 				return nil, err
 			}
@@ -1696,7 +1696,7 @@ func createStringPredicate(op traceql.Operator, operands traceql.Operands) (parq
 	}
 }
 
-func createBytesPredicate(op traceql.Operator, operands traceql.Operands, isSpan bool) (parquetquery.Predicate, error) {
+func createBytesPredicate(op traceql.Operator, operands traceql.Operands, isTraceID bool) (parquetquery.Predicate, error) {
 	if op == traceql.OpNone {
 		return nil, nil
 	}
@@ -1706,21 +1706,35 @@ func createBytesPredicate(op traceql.Operator, operands traceql.Operands, isSpan
 		return nil, fmt.Errorf("operand is not string: %s", s)
 	}
 
-	id, err := util.HexStringToTraceID(s)
+	// trace id is sanitized at ingestion to left pad to 16 bytes
+	// can benefit from ranged conditions
+	if isTraceID {
+		id, err := util.HexStringToTraceID(s)
+		if err != nil {
+			return nil, nil
+		}
 
-	if isSpan {
-		id, err = util.HexStringToSpanID(s)
+		switch op {
+		case traceql.OpEqual:
+			return parquetquery.NewByteEqualPredicate(id), nil
+		case traceql.OpNotEqual:
+			return parquetquery.NewByteNotEqualPredicate(id), nil
+		default:
+			return nil, fmt.Errorf("operator not supported for IDs: %+v", op)
+		}
 	}
 
+	// every other IDs are not standardized and the range conditions do not work
+	id, err := util.HexStringToNonTraceID(s)
 	if err != nil {
 		return nil, nil
 	}
 
 	switch op {
 	case traceql.OpEqual:
-		return parquetquery.NewStringEqualPredicate(id), nil
+		return parquetquery.NewNoRangeByteEqualPredicate(id), nil
 	case traceql.OpNotEqual:
-		return parquetquery.NewStringNotEqualPredicate(id), nil
+		return parquetquery.NewNoRangeByteNotEqualPredicate(id), nil
 	default:
 		return nil, fmt.Errorf("operator not supported for IDs: %+v", op)
 	}

--- a/tempodb/encoding/vparquet2/block_traceql.go
+++ b/tempodb/encoding/vparquet2/block_traceql.go
@@ -1335,7 +1335,7 @@ func createSpanIterator(makeIter makeIterFn, primaryIter parquetquery.Iterator, 
 			continue
 
 		case traceql.IntrinsicParentID:
-			pred, err := createBytesPredicate(cond.Op, cond.Operands, true)
+			pred, err := createBytesPredicate(cond.Op, cond.Operands, false)
 			if err != nil {
 				return nil, err
 			}

--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -1494,7 +1494,7 @@ func createSpanIterator(makeIter makeIterFn, primaryIter parquetquery.Iterator, 
 			continue
 
 		case traceql.IntrinsicParentID:
-			pred, err := createBytesPredicate(cond.Op, cond.Operands, true)
+			pred, err := createBytesPredicate(cond.Op, cond.Operands, false)
 			if err != nil {
 				return nil, err
 			}

--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -1,7 +1,6 @@
 package vparquet3
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -2011,8 +2010,8 @@ func createBytesPredicate(op traceql.Operator, operands traceql.Operands, isSpan
 		return nil, fmt.Errorf("operand is not string: %s", s)
 	}
 
-	var id []byte
 	id, err := util.HexStringToTraceID(s)
+
 	if isSpan {
 		id, err = util.HexStringToSpanID(s)
 	}
@@ -2020,8 +2019,6 @@ func createBytesPredicate(op traceql.Operator, operands traceql.Operands, isSpan
 	if err != nil {
 		return nil, nil
 	}
-
-	id = bytes.TrimLeft(id, "\x00")
 
 	switch op {
 	case traceql.OpEqual:

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -1870,7 +1870,7 @@ func createSpanIterator(makeIter makeIterFn, innerIterators []parquetquery.Itera
 			continue
 
 		case traceql.IntrinsicParentID:
-			pred, err := createBytesPredicate(cond.Op, cond.Operands, true)
+			pred, err := createBytesPredicate(cond.Op, cond.Operands, false)
 			if err != nil {
 				return nil, err
 			}
@@ -3352,11 +3352,13 @@ func (c *linkCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 	for _, e := range res.Entries {
 		switch e.Key {
 		case columnPathLinkTraceID:
+			fmt.Printf("trace id: %s\n", util.TraceIDToHexString(e.Value.Bytes()))
 			l.attrs = append(l.attrs, attrVal{
 				a: traceql.NewIntrinsic(traceql.IntrinsicLinkTraceID),
 				s: traceql.NewStaticString(util.TraceIDToHexString(e.Value.Bytes())),
 			})
 		case columnPathLinkSpanID:
+			fmt.Printf("span id: %s\n", util.SpanIDToHexString(e.Value.Bytes()))
 			l.attrs = append(l.attrs, attrVal{
 				a: traceql.NewIntrinsic(traceql.IntrinsicLinkSpanID),
 				s: traceql.NewStaticString(util.SpanIDToHexString(e.Value.Bytes())),

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -1,7 +1,6 @@
 package vparquet4
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -1768,7 +1767,7 @@ func createLinkIterator(makeIter makeIterFn, conditions []traceql.Condition, all
 			continue
 
 		case traceql.IntrinsicLinkSpanID:
-			pred, err := createBytesPredicate(cond.Op, cond.Operands, false)
+			pred, err := createBytesPredicate(cond.Op, cond.Operands, true)
 			if err != nil {
 				return nil, err
 			}
@@ -2485,8 +2484,8 @@ func createBytesPredicate(op traceql.Operator, operands traceql.Operands, isSpan
 		return nil, fmt.Errorf("operand is not string: %s", s)
 	}
 
-	var id []byte
 	id, err := util.HexStringToTraceID(s)
+
 	if isSpan {
 		id, err = util.HexStringToSpanID(s)
 	}
@@ -2494,8 +2493,6 @@ func createBytesPredicate(op traceql.Operator, operands traceql.Operands, isSpan
 	if err != nil {
 		return nil, nil
 	}
-
-	id = bytes.TrimLeft(id, "\x00")
 
 	switch op {
 	case traceql.OpEqual:

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -1767,7 +1767,7 @@ func createLinkIterator(makeIter makeIterFn, conditions []traceql.Condition, all
 			continue
 
 		case traceql.IntrinsicLinkSpanID:
-			pred, err := createBytesPredicate(cond.Op, cond.Operands, true)
+			pred, err := createBytesPredicate(cond.Op, cond.Operands, false)
 			if err != nil {
 				return nil, err
 			}
@@ -1861,7 +1861,7 @@ func createSpanIterator(makeIter makeIterFn, innerIterators []parquetquery.Itera
 		// Intrinsic?
 		switch cond.Attribute.Intrinsic {
 		case traceql.IntrinsicSpanID:
-			pred, err := createBytesPredicate(cond.Op, cond.Operands, true)
+			pred, err := createBytesPredicate(cond.Op, cond.Operands, false)
 			if err != nil {
 				return nil, err
 			}
@@ -2354,7 +2354,7 @@ func createTraceIterator(makeIter makeIterFn, resourceIter parquetquery.Iterator
 				if cond.Op == traceql.OpNone && cond.CallBack != nil {
 					metaIters = append(metaIters, makeIter(columnPathTraceID, parquetquery.NewCallbackPredicate(cond.CallBack), columnPathTraceID))
 				} else {
-					pred, err := createBytesPredicate(cond.Op, cond.Operands, false)
+					pred, err := createBytesPredicate(cond.Op, cond.Operands, true)
 					if err != nil {
 						return nil, err
 					}
@@ -2474,7 +2474,7 @@ func createStringPredicate(op traceql.Operator, operands traceql.Operands) (parq
 	}
 }
 
-func createBytesPredicate(op traceql.Operator, operands traceql.Operands, isSpan bool) (parquetquery.Predicate, error) {
+func createBytesPredicate(op traceql.Operator, operands traceql.Operands, isTraceID bool) (parquetquery.Predicate, error) {
 	if op == traceql.OpNone {
 		return nil, nil
 	}
@@ -2484,21 +2484,35 @@ func createBytesPredicate(op traceql.Operator, operands traceql.Operands, isSpan
 		return nil, fmt.Errorf("operand is not string: %s", s)
 	}
 
-	id, err := util.HexStringToTraceID(s)
+	// trace id is sanitized at ingestion to left pad to 16 bytes
+	// can benefit from ranged conditions
+	if isTraceID {
+		id, err := util.HexStringToTraceID(s)
+		if err != nil {
+			return nil, nil
+		}
 
-	if isSpan {
-		id, err = util.HexStringToSpanID(s)
+		switch op {
+		case traceql.OpEqual:
+			return parquetquery.NewByteEqualPredicate(id), nil
+		case traceql.OpNotEqual:
+			return parquetquery.NewByteNotEqualPredicate(id), nil
+		default:
+			return nil, fmt.Errorf("operator not supported for IDs: %+v", op)
+		}
 	}
 
+	// every other IDs are not standardized and the range conditions do not work
+	id, err := util.HexStringToNonTraceID(s)
 	if err != nil {
 		return nil, nil
 	}
 
 	switch op {
 	case traceql.OpEqual:
-		return parquetquery.NewByteEqualPredicate(id), nil
+		return parquetquery.NewNoRangeByteEqualPredicate(id), nil
 	case traceql.OpNotEqual:
-		return parquetquery.NewByteNotEqualPredicate(id), nil
+		return parquetquery.NewNoRangeByteNotEqualPredicate(id), nil
 	default:
 		return nil, fmt.Errorf("operator not supported for IDs: %+v", op)
 	}

--- a/tempodb/encoding/vparquet4/block_traceql_test.go
+++ b/tempodb/encoding/vparquet4/block_traceql_test.go
@@ -486,7 +486,7 @@ func fullyPopulatedTestTrace(id common.ID) *Trace {
 
 func fullyPopulatedTestTraceWithOption(id common.ID, parentIDTest bool) *Trace {
 	linkTraceID, _ := util.HexStringToTraceID("1234567890abcdef1234567890abcdef")
-	linkSpanID, _ := util.HexStringToSpanID("1234567890abcdef")
+	linkSpanID, _ := util.HexStringToNonTraceID("1234567890abcdef")
 	parentID := []byte{}
 	if parentIDTest {
 		parentID = []byte("parentid")

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -1823,6 +1823,8 @@ func runEventLinkInstrumentationSearchTest(t *testing.T, blockVersion string) {
 
 	wantID, wantTr, start, end, wantMeta := makeExpectedTrace()
 	wantIDText := util.TraceIDToHexString(wantID)
+	sixtyFourByteSpanID := util.SpanIDToHexString([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef})
+	shortSpanID := util.SpanIDToHexString([]byte{4, 5, 6})
 
 	searchesThatMatch := []*tempopb.SearchRequest{
 		{
@@ -1839,6 +1841,12 @@ func runEventLinkInstrumentationSearchTest(t *testing.T, blockVersion string) {
 		},
 		{
 			Query: "{ link:traceID = `" + wantIDText + "` }",
+		},
+		{
+			Query: "{ link:spanID = `" + sixtyFourByteSpanID + "` }",
+		},
+		{
+			Query: "{ link:spanID = `" + shortSpanID + "` }",
 		},
 		{
 			Query: "{ instrumentation:name = `scope-1` }",
@@ -2058,6 +2066,13 @@ func makeExpectedTrace() (
 									},
 								},
 								Links: []*v1.Span_Link{
+									{
+										TraceId: id,
+										SpanId:  []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef},
+										Attributes: []*v1_common.KeyValue{
+											stringKV("relation", "child-of"),
+										},
+									},
 									{
 										TraceId: id,
 										SpanId:  []byte{4, 5, 6},

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -97,14 +97,13 @@ func traceQLRunner(t *testing.T, _ *tempopb.Trace, wantMeta *tempopb.TraceSearch
 		{Query: `{ ."res-dedicated.02" = "res-2a" }`},
 		{Query: `{ resource."k8s.namespace.name" = "k8sNamespace" }`},
 	}
-	parentID := util.SpanIDToHexString([]byte{4, 5, 6})
 	parentIDQuery := &tempopb.SearchRequest{
-		Query: fmt.Sprintf("{ span:parentID = %q }", parentID),
+		Query: fmt.Sprintf("{ span:parentID = %q }", "40506"),
 	}
 
 	spanIDTThatMatch := []*tempopb.SearchRequest{
-		{Query: fmt.Sprintf("{ span:id = %q }", util.SpanIDToHexString([]byte{1, 2, 3}))},
-		{Query: fmt.Sprintf("{ span:id = %q }", util.SpanIDToHexString([]byte{4, 5, 6}))},
+		{Query: fmt.Sprintf("{ span:id = %q }", "10203")},
+		{Query: fmt.Sprintf("{ span:id = %q }", "40506")},
 	}
 
 	searchesThatMatch = append(searchesThatMatch, quotedAttributesThatMatch...)
@@ -1830,7 +1829,7 @@ func runEventLinkInstrumentationSearchTest(t *testing.T, blockVersion string) {
 	wantID, wantTr, start, end, wantMeta := makeExpectedTrace()
 	wantIDText := util.TraceIDToHexString(wantID)
 	sixtyFourByteSpanID := util.SpanIDToHexString([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef})
-	shortSpanID := util.SpanIDToHexString([]byte{4, 5, 6})
+	shortSpanID := "40506"
 	shortLinkTraceID := util.TraceIDToHexString([]byte{1, 2, 3})
 
 	searchesThatMatch := []*tempopb.SearchRequest{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: 

`trace:id` queries were not working because of inconsistent trimming in bytes predicate caused by this [PR](https://github.com/grafana/tempo/pull/4198) 

Also force left pad `span:id`, `link:spanID`, `span:parentID` queries for IDs that are provided that are shorter than 8 bytes. 

**Which issue(s) this PR fixes**:
Fixes #4437

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`