### PR TITLE
[r188] Upgrade parquet-go to fix trace by id regression

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.118.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver v0.118.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.118.0
-	github.com/parquet-go/parquet-go v0.24.1-0.20250203011650-a58243e6e9c1
+	github.com/parquet-go/parquet-go v0.24.1-0.20250221124813-750802ae6cc3
 	github.com/stoewer/parquet-cli v0.0.9
 	github.com/twmb/franz-go v1.18.1
 	github.com/twmb/franz-go/pkg/kadm v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -733,8 +733,8 @@ github.com/openzipkin/zipkin-go v0.4.3 h1:9EGwpqkgnwdEIJ+Od7QVSEIH+ocmm5nPat0G7s
 github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LDHcMZmk3RmK7c=
 github.com/ovh/go-ovh v1.6.0 h1:ixLOwxQdzYDx296sXcgS35TOPEahJkpjMGtzPadCjQI=
 github.com/ovh/go-ovh v1.6.0/go.mod h1:cTVDnl94z4tl8pP1uZ/8jlVxntjSIf09bNcQ5TJSC7c=
-github.com/parquet-go/parquet-go v0.24.1-0.20250203011650-a58243e6e9c1 h1:/+DZVg5VqIXO3PZ+n5D3C6w8VfOvkgzSJmEZQtIn9+U=
-github.com/parquet-go/parquet-go v0.24.1-0.20250203011650-a58243e6e9c1/go.mod h1:OqBBRGBl7+llplCvDMql8dEKaDqjaFA/VAPw+OJiNiw=
+github.com/parquet-go/parquet-go v0.24.1-0.20250221124813-750802ae6cc3 h1:t2/tVHCiQe59lwktENtQ3XFEdQZppA+/MFFSvLUHFso=
+github.com/parquet-go/parquet-go v0.24.1-0.20250221124813-750802ae6cc3/go.mod h1:OqBBRGBl7+llplCvDMql8dEKaDqjaFA/VAPw+OJiNiw=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/vendor/github.com/parquet-go/parquet-go/column.go
+++ b/vendor/github.com/parquet-go/parquet-go/column.go
@@ -356,6 +356,8 @@ func (cl *columnLoader) open(file *File, metadata *format.FileMetaData, columnIn
 		c.typ = &mapType{}
 	} else if lt != nil && lt.List != nil {
 		c.typ = &listType{}
+	} else if lt != nil && lt.Variant != nil {
+		c.typ = &variantType{}
 	}
 	c.columns = make([]*Column, numChildren)
 

--- a/vendor/github.com/parquet-go/parquet-go/schema.go
+++ b/vendor/github.com/parquet-go/parquet-go/schema.go
@@ -89,7 +89,18 @@ func (v *onceValue[T]) load(f func() *T) *T {
 // Supported precisions are: nanosecond, millisecond and microsecond. Example:
 //
 //	type Message struct {
-//	  TimestrampMicros int64 `parquet:"timestamp_micros,timestamp(microsecond)"
+//	  TimestampMicros int64 `parquet:"timestamp_micros,timestamp(microsecond)"
+//	}
+//
+// Both the time and timestamp tags accept an optional second parameter
+// to set the `isAdjustedToUTC` annotation of the parquet logical type.
+// Valid values are "utc" or "local". If not specified, the default value
+// for this annotation will be "utc", which will set the `isAdjustedToUTC` annotation
+// value to true. Example:
+//
+//	type Message struct {
+//	  TimestampMicrosAdjusted int64 `parquet:"timestamp_micros_adjusted,timestamp(microsecond:utc)"
+//	  TimestampMicrosNotAdjusted int64 `parquet:"timestamp_micros_not_adjusted,timestamp(microsecond:local)"
 //	}
 //
 // The decimal tag must be followed by two integer parameters, the first integer
@@ -711,19 +722,41 @@ func parseIDArgs(args string) (int, error) {
 	return strconv.Atoi(args)
 }
 
-func parseTimestampArgs(args string) (TimeUnit, error) {
+func parseTimestampArgs(args string) (unit TimeUnit, isUTCNormalized bool, err error) {
 	if !strings.HasPrefix(args, "(") || !strings.HasSuffix(args, ")") {
-		return nil, fmt.Errorf("malformed timestamp args: %s", args)
+		return nil, false, fmt.Errorf("malformed timestamp args: %s", args)
 	}
 
 	args = strings.TrimPrefix(args, "(")
 	args = strings.TrimSuffix(args, ")")
 
 	if len(args) == 0 {
-		return Millisecond, nil
+		return Millisecond, true, nil
 	}
 
-	switch args {
+	parts := strings.Split(args, ":")
+	if len(parts) > 2 {
+		return nil, false, fmt.Errorf("malformed timestamp args: (%s)", args)
+	}
+
+	unit, err = parseTimeUnit(parts[0])
+	if err != nil {
+		return nil, false, err
+	}
+
+	adjusted := true
+	if len(parts) > 1 {
+		adjusted, err = parseUTCNormalization(parts[1])
+		if err != nil {
+			return nil, false, err
+		}
+	}
+
+	return unit, adjusted, nil
+}
+
+func parseTimeUnit(arg string) (TimeUnit, error) {
+	switch arg {
 	case "millisecond":
 		return Millisecond, nil
 	case "microsecond":
@@ -733,7 +766,18 @@ func parseTimestampArgs(args string) (TimeUnit, error) {
 	default:
 	}
 
-	return nil, fmt.Errorf("unknown time unit: %s", args)
+	return nil, fmt.Errorf("unknown time unit: %s", arg)
+}
+
+func parseUTCNormalization(arg string) (isUTCNormalized bool, err error) {
+	switch arg {
+	case "utc":
+		return true, nil
+	case "local":
+		return false, nil
+	default:
+		return false, fmt.Errorf("unknown utc normalization: %s", arg)
+	}
 }
 
 type goNode struct {
@@ -923,13 +967,13 @@ func makeNodeOf(t reflect.Type, name string, tag []string) Node {
 		case "time":
 			switch t.Kind() {
 			case reflect.Int32:
-				timeUnit, err := parseTimestampArgs(args)
+				timeUnit, adjusted, err := parseTimestampArgs(args)
 				if err != nil || timeUnit.Duration() < time.Millisecond {
 					throwInvalidTag(t, name, option+args)
 				}
-				setNode(Time(timeUnit))
+				setNode(TimeAdjusted(timeUnit, adjusted))
 			case reflect.Int64:
-				timeUnit, err := parseTimestampArgs(args)
+				timeUnit, adjusted, err := parseTimestampArgs(args)
 				if t == reflect.TypeOf(time.Duration(0)) {
 					if args == "()" {
 						timeUnit = Nanosecond
@@ -940,26 +984,26 @@ func makeNodeOf(t reflect.Type, name string, tag []string) Node {
 				if err != nil || timeUnit.Duration() == time.Millisecond {
 					throwInvalidTag(t, name, option+args)
 				}
-				setNode(Time(timeUnit))
+				setNode(TimeAdjusted(timeUnit, adjusted))
 			default:
 				throwInvalidTag(t, name, option)
 			}
 		case "timestamp":
 			switch t.Kind() {
 			case reflect.Int64:
-				timeUnit, err := parseTimestampArgs(args)
+				timeUnit, adjusted, err := parseTimestampArgs(args)
 				if err != nil {
 					throwInvalidTag(t, name, option+args)
 				}
-				setNode(Timestamp(timeUnit))
+				setNode(TimestampAdjusted(timeUnit, adjusted))
 			default:
 				switch t {
 				case reflect.TypeOf(time.Time{}):
-					timeUnit, err := parseTimestampArgs(args)
+					timeUnit, adjusted, err := parseTimestampArgs(args)
 					if err != nil {
 						throwInvalidTag(t, name, option+args)
 					}
-					setNode(Timestamp(timeUnit))
+					setNode(TimestampAdjusted(timeUnit, adjusted))
 				default:
 					throwInvalidTag(t, name, option)
 				}

--- a/vendor/github.com/parquet-go/parquet-go/type.go
+++ b/vendor/github.com/parquet-go/parquet-go/type.go
@@ -2274,6 +2274,94 @@ func (t *nullType) ConvertValue(val Value, _ Type) (Value, error) {
 	return val, nil
 }
 
+// Variant constructs a node of unshredded VARIANT logical type. It is a group with
+// two required fields, "metadata" and "value", both byte arrays.
+//
+// Experimental: The specification for variants is still being developed and the type
+// is not fully adopted. Support for this type is subject to change.
+//
+// Initial support does not attempt to process the variant data. So reading and writing
+// data of this type behaves as if it were just a group with two byte array fields, as
+// if the logical type annotation were absent. This may change in the future.
+//
+// https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#variant
+func Variant() Node {
+	return variantNode{Group{"metadata": Required(Leaf(ByteArrayType)), "value": Required(Leaf(ByteArrayType))}}
+}
+
+// TODO: add ShreddedVariant(Node) function, to create a shredded variant
+//  where the argument defines the type/structure of the shredded value(s).
+
+type variantNode struct{ Group }
+
+func (variantNode) Type() Type { return &variantType{} }
+
+type variantType format.VariantType
+
+func (t *variantType) String() string { return (*format.VariantType)(t).String() }
+
+func (t *variantType) Kind() Kind { panic("cannot call Kind on parquet VARIANT type") }
+
+func (t *variantType) Length() int { return 0 }
+
+func (t *variantType) EstimateSize(int) int { return 0 }
+
+func (t *variantType) EstimateNumValues(int) int { return 0 }
+
+func (t *variantType) Compare(Value, Value) int {
+	panic("cannot compare values on parquet VARIANT type")
+}
+
+func (t *variantType) ColumnOrder() *format.ColumnOrder { return nil }
+
+func (t *variantType) PhysicalType() *format.Type { return nil }
+
+func (t *variantType) LogicalType() *format.LogicalType {
+	return &format.LogicalType{Variant: (*format.VariantType)(t)}
+}
+
+func (t *variantType) ConvertedType() *deprecated.ConvertedType { return nil }
+
+func (t *variantType) NewColumnIndexer(int) ColumnIndexer {
+	panic("create create column indexer from parquet VARIANT type")
+}
+
+func (t *variantType) NewDictionary(int, int, encoding.Values) Dictionary {
+	panic("cannot create dictionary from parquet VARIANT type")
+}
+
+func (t *variantType) NewColumnBuffer(int, int) ColumnBuffer {
+	panic("cannot create column buffer from parquet VARIANT type")
+}
+
+func (t *variantType) NewPage(int, int, encoding.Values) Page {
+	panic("cannot create page from parquet VARIANT type")
+}
+
+func (t *variantType) NewValues(values []byte, _ []uint32) encoding.Values {
+	panic("cannot create values from parquet VARIANT type")
+}
+
+func (t *variantType) Encode(_ []byte, _ encoding.Values, _ encoding.Encoding) ([]byte, error) {
+	panic("cannot encode parquet VARIANT type")
+}
+
+func (t *variantType) Decode(_ encoding.Values, _ []byte, _ encoding.Encoding) (encoding.Values, error) {
+	panic("cannot decode parquet VARIANT type")
+}
+
+func (t *variantType) EstimateDecodeSize(_ int, _ []byte, _ encoding.Encoding) int {
+	panic("cannot estimate decode size of parquet VARIANT type")
+}
+
+func (t *variantType) AssignValue(reflect.Value, Value) error {
+	panic("cannot assign value to a parquet VARIANT type")
+}
+
+func (t *variantType) ConvertValue(Value, Type) (Value, error) {
+	panic("cannot convert value to a parquet VARIANT type")
+}
+
 type groupType struct{}
 
 func (groupType) String() string { return "group" }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1057,7 +1057,7 @@ github.com/opentracing/opentracing-go/log
 github.com/openzipkin/zipkin-go/model
 github.com/openzipkin/zipkin-go/proto/zipkin_proto3
 github.com/openzipkin/zipkin-go/reporter
-# github.com/parquet-go/parquet-go v0.24.1-0.20250203011650-a58243e6e9c1
+# github.com/parquet-go/parquet-go v0.24.1-0.20250221124813-750802ae6cc3
 ## explicit; go 1.22
 github.com/parquet-go/parquet-go
 github.com/parquet-go/parquet-go/bloom


### PR DESCRIPTION
Backport 1b63c9fffc78af00a341e659f5d4d18d9990b466 from #4730

---

Upgrades parquet-go to catch https://github.com/parquet-go/parquet-go/pull/246#pullrequestreview-2631732037
