### PR TITLE
Issue 3948: user cfg override fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * [BUGFIX] Fix starting consuming log [#4539](https://github.com/grafana/tempo/pull/4539) (@javiermolinar)
 * [BUGFIX] Return the operand as the only value if the tag is already filtered in the query [#4673](https://github.com/grafana/tempo/pull/4673) (@mapno)
 * [BUGFIX] Fix memcached settings for docker compose example [#4346](https://github.com/grafana/tempo/pull/4695) (@ruslan-mikhailov)
+* [BUGFIX] Fix setting processors in user configurations overrides via API [#4741](https://github.com/grafana/tempo/pull/4741) (@ruslan-mikhailov)
 
 # v2.7.1
 

--- a/modules/generator/instance.go
+++ b/modules/generator/instance.go
@@ -30,7 +30,14 @@ import (
 )
 
 var (
-	SupportedProcessors = []string{servicegraphs.Name, spanmetrics.Name, localblocks.Name}
+	SupportedProcessors = []string{
+		servicegraphs.Name,
+		spanmetrics.Name,
+		localblocks.Name,
+		spanmetrics.Count.String(),
+		spanmetrics.Latency.String(),
+		spanmetrics.Size.String(),
+	}
 
 	metricActiveProcessors = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "tempo",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: Allows to put "span-metrics-size", "span-metrics-count", "span-metrics-latency" into user configurations overrides via API

**Which issue(s) this PR fixes**:
Fixes [#3945](https://github.com/grafana/tempo/issues/3945)

### How it has been tested

**Step 1.** Run docker compose (here I used example/docker-compose/otel-collector-multitenant) with the following tempo.yaml:

```yaml
overrides:
  defaults:
    metrics_generator:
      processors: [local-blocks] # leave only local-blocks
      generate_native_histograms: both
  user_configurable_overrides:
    enabled: true
    poll_interval: 5s 
    client:
      backend: local
      local:
        path: /var/tempo/overrides
```

**Step 2.** Check current configurations:

1. Set processors to "local-blocks" (the same as in configurations):

```
curl -X POST -v -H "If-Match: 1697726795401423" -H "X-Scope-OrgID: foo-bar-baz" 'http://localhost:3200/api/overrides?scope=merged' --data '{"metrics_generator":{"processors": ["local-blocks"]}}'
```

2. Get current configurations:

```
curl -X GET -v -H "X-Scope-OrgID: foo-bar-baz" 'http://localhost:3200/api/overrides?scope=merged'
```

Expected results: HTTP status code 200, `metrics_generator.processors` has value `["local-blocks"]`
Actual results:

```json
{"forwarders":null,"cost_attribution":{},"metrics_generator":{"processors":["local-blocks"],"disable_collection":false,"collection_interval":"0s","processor":{"service_graphs":{"dimensions":null,"enable_client_server_prefix":false,"peer_attributes":null,"histogram_buckets":null},"span_metrics":{"dimensions":null,"enable_target_info":false,"filter_policies":null,"histogram_buckets":null,"target_info_excluded_dimensions":null}}}}
```

**Step 3.** Check metrics:

| Metric                         | Expected result |
| ------------------------------ | --------------- |
| tempo_metrics_generator_processor_local_blocks_bytes  | has data        |
| traces_spanmetrics_calls_total | no data         |
| traces_spanmetrics_latency     | no data         |
| traces_spanmetrics_size_total  | no data         |

**Step 4.** Publish "local-blocks", "span-metrics-size", "span-metrics-count", "span-metrics-latency":

```
curl -X POST -v -H "If-Match: 1697726795401423" -H "X-Scope-OrgID: foo-bar-baz" 'http://localhost:3200/api/overrides?scope=merged' --data '{"metrics_generator":{"processors": ["local-blocks", "span-metrics-size", "span-metrics-count", "span-metrics-latency"]}}'
```

Expected results: HTTP status code 200, no errors in logs
Production image results: HTTP status code 400, body:

```
metrics_generator.processor "span-metrics-latency" is not a known processor, valid values: [service-graphs span-metrics local-blocks]
```

**Step 5.** Check resulted configurations:

```
curl -X GET -v -H "X-Scope-OrgID: foo-bar-baz" 'http://localhost:3200/api/overrides?scope=merged'
```

Expected results: `metrics_generator.processors` has value `["local-blocks", "span-metrics-size", "span-metrics-count", "span-metrics-latency"]`
Actual results:

```json
{"forwarders":null,"cost_attribution":{},"metrics_generator":{"processors":["span-metrics-size","span-metrics-count","span-metrics-latency","local-blocks"],"disable_collection":false,"collection_interval":"0s","processor":{"service_graphs":{"dimensions":null,"enable_client_server_prefix":false,"peer_attributes":null,"histogram_buckets":null},"span_metrics":{"dimensions":null,"enable_target_info":false,"filter_policies":null,"histogram_buckets":null,"target_info_excluded_dimensions":null}}}}
```

**Step 6.** Check metrics

| Metric                         | Expected result |
| ------------------------------ | --------------- |
| tempo_metrics_generator_processor_local_blocks_bytes  | has data        |
| traces_spanmetrics_calls_total | has data        |
| traces_spanmetrics_latency     | has data        |
| traces_spanmetrics_size_total  | has data        |

**Checklist**

- [ ] Tests updated
(Tested manually)
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

