### PR TITLE
Issue 4742: fix panic on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * [BUGFIX] Return the operand as the only value if the tag is already filtered in the query [#4673](https://github.com/grafana/tempo/pull/4673) (@mapno)
 * [BUGFIX] Fix memcached settings for docker compose example [#4346](https://github.com/grafana/tempo/pull/4695) (@ruslan-mikhailov)
 * [BUGFIX] Fix setting processors in user configurations overrides via API [#4741](https://github.com/grafana/tempo/pull/4741) (@ruslan-mikhailov)
+* [BUGFIX] Fix panic on startup [#4744](https://github.com/grafana/tempo/pull/4744) (@ruslan-mikhailov)
 
 # v2.7.1
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes [#4742](https://github.com/grafana/tempo/issues/4742)
The bug was introduced in https://github.com/grafana/tempo/pull/4721

### How it has been tested
#### Manual
1. Run docker compose from `example/docker-compose/local`. Before running, make sure /var/tempo (mounted as ./tempo-data) is empty.
Expected results: tempo starts up and runs well (no panics).
this and main branches results: same as expected.
1. Stop docker compose and run it again.
Expected results: tempo starts up and runs well (no panics).
this branch results: same as expected.
main branch results: panics with the following message:

```
tempo-1  | panic: runtime error: invalid memory address or nil pointer dereference
tempo-1  | [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1fe2170]
```

#### Unit
Fails in main branch, passes with the fix

**Checklist**

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

