### PR TITLE
rhythm: fix block time range adjustment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * [BUGFIX] TraceQL results caching bug for floats ending in .0 [#4539](https://github.com/grafana/tempo/pull/4539) (@carles-grafana)
 * [BUGFIX] Fix metrics streaming for all non-trivial metrics [#4624](https://github.com/grafana/tempo/pull/4624) (@joe-elliott)
 * [BUGFIX] Fix starting consuming log [#4539](https://github.com/grafana/tempo/pull/4539) (@javiermolinar)
+* [BUGFIX] Rhythm - fix adjustment of the start and end range for livetraces blocks [#4744](https://github.com/grafana/tempo/pull/4744) (@javiermolinar)
 * [BUGFIX] Return the operand as the only value if the tag is already filtered in the query [#4673](https://github.com/grafana/tempo/pull/4673) (@mapno)
 * [BUGFIX] Fix memcached settings for docker compose example [#4346](https://github.com/grafana/tempo/pull/4695) (@ruslan-mikhailov)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 * [BUGFIX] TraceQL results caching bug for floats ending in .0 [#4539](https://github.com/grafana/tempo/pull/4539) (@carles-grafana)
 * [BUGFIX] Fix metrics streaming for all non-trivial metrics [#4624](https://github.com/grafana/tempo/pull/4624) (@joe-elliott)
 * [BUGFIX] Fix starting consuming log [#4539](https://github.com/grafana/tempo/pull/4539) (@javiermolinar)
-* [BUGFIX] Rhythm - fix adjustment of the start and end range for livetraces blocks [#4744](https://github.com/grafana/tempo/pull/4744) (@javiermolinar)
+* [BUGFIX] Rhythm - fix adjustment of the start and end range for livetraces blocks [#4746](https://github.com/grafana/tempo/pull/4746) (@javiermolinar)
 * [BUGFIX] Return the operand as the only value if the tag is already filtered in the query [#4673](https://github.com/grafana/tempo/pull/4673) (@mapno)
 * [BUGFIX] Fix memcached settings for docker compose example [#4346](https://github.com/grafana/tempo/pull/4695) (@ruslan-mikhailov)
 

--- a/modules/blockbuilder/tenant_store_test.go
+++ b/modules/blockbuilder/tenant_store_test.go
@@ -70,10 +70,10 @@ func TestAdjustTimeRangeForSlack(t *testing.T) {
 		},
 		{
 			name:          "end before start",
-			start:         startCycleTime.Add(-2 * time.Minute),
-			end:           startCycleTime.Add(-3 * time.Minute),
-			expectedStart: startCycleTime.Add(-2 * time.Minute),
-			expectedEnd:   startCycleTime.Add(-2 * time.Minute),
+			start:         startCycleTime.Add(-10 * time.Minute),
+			end:           startCycleTime.Add(-9 * time.Minute),
+			expectedStart: startCycleTime.Add(-slackDuration),
+			expectedEnd:   startCycleTime.Add(-slackDuration),
 		},
 		{
 			name:          "both start and end after slack range",

--- a/modules/blockbuilder/tenant_store_test.go
+++ b/modules/blockbuilder/tenant_store_test.go
@@ -58,7 +58,7 @@ func TestAdjustTimeRangeForSlack(t *testing.T) {
 			name:          "start before slack range",
 			start:         startCycleTime.Add(-10 * time.Minute),
 			end:           startCycleTime.Add(2 * time.Minute),
-			expectedStart: startCycleTime,
+			expectedStart: startCycleTime.Add(-slackDuration),
 			expectedEnd:   startCycleTime.Add(2 * time.Minute),
 		},
 		{
@@ -66,14 +66,21 @@ func TestAdjustTimeRangeForSlack(t *testing.T) {
 			start:         startCycleTime.Add(-2 * time.Minute),
 			end:           startCycleTime.Add(20 * time.Minute),
 			expectedStart: startCycleTime.Add(-2 * time.Minute),
-			expectedEnd:   startCycleTime,
+			expectedEnd:   startCycleTime.Add(slackDuration + cycleDuration),
 		},
 		{
 			name:          "end before start",
 			start:         startCycleTime.Add(-2 * time.Minute),
 			end:           startCycleTime.Add(-3 * time.Minute),
 			expectedStart: startCycleTime.Add(-2 * time.Minute),
-			expectedEnd:   startCycleTime,
+			expectedEnd:   startCycleTime.Add(-2 * time.Minute),
+		},
+		{
+			name:          "both start and end after slack range",
+			start:         startCycleTime.Add(5 * time.Minute),
+			end:           startCycleTime.Add(10 * time.Minute),
+			expectedStart: startCycleTime.Add(cycleDuration + slackDuration),
+			expectedEnd:   startCycleTime.Add(cycleDuration + slackDuration),
 		},
 	}
 


### PR DESCRIPTION
**What this PR does**:
This fixes the previous behavior, where the end date was always set to the start time. This was a translation of our behavior in the ingesters, where the start and end dates are set to now() if they are outside the time range.

 **How it works now**:
It checks independently the start and the end.
If the end is before the start it will set it to the start
If the end is after the end range it will set it to the end range


**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`



