### PR TITLE
[rhythm] block-builder: optimize partition sorting and improve cycle handling

### DIFF
--- a/modules/blockbuilder/blockbuilder.go
+++ b/modules/blockbuilder/blockbuilder.go
@@ -270,9 +270,8 @@ func (b *BlockBuilder) consume(ctx context.Context) (time.Duration, error) {
 
 		// Re-sort only if needed - find the correct position for the updated partition
 		// This is more efficient than sorting the entire slice again
-		for i := 0; i < len(ps)-1 && ps[i].lastRecordTs.After(ps[i+1].lastRecordTs); {
+		for i := 0; i < len(ps)-1 && ps[i].lastRecordTs.After(ps[i+1].lastRecordTs); i++ {
 			ps[i], ps[i+1] = ps[i+1], ps[i]
-			i++
 		}
 	}
 }

--- a/modules/blockbuilder/blockbuilder.go
+++ b/modules/blockbuilder/blockbuilder.go
@@ -249,11 +249,11 @@ func (b *BlockBuilder) consume(ctx context.Context) (time.Duration, error) {
 	// Iterate over the laggiest partition until the lag is less than the cycle duration or none of the partitions has records
 	for {
 		// The laggiest partition is always at index 0 after initial sort, or after we update and re-sort
-		laggiestPartition := ps[0]
-		if len(ps) == 0 || laggiestPartition.lastRecordTs.IsZero() {
+		if len(ps) == 0 || ps[0].lastRecordTs.IsZero() {
 			return b.cfg.ConsumeCycleDuration, nil
 		}
 
+		laggiestPartition := ps[0]
 		lagTime := time.Since(laggiestPartition.lastRecordTs)
 		if lagTime < b.cfg.ConsumeCycleDuration {
 			return b.cfg.ConsumeCycleDuration - lagTime, nil

--- a/modules/blockbuilder/blockbuilder.go
+++ b/modules/blockbuilder/blockbuilder.go
@@ -248,7 +248,7 @@ func (b *BlockBuilder) consume(ctx context.Context) (time.Duration, error) {
 
 	// Iterate over the laggiest partition until the lag is less than the cycle duration or none of the partitions has records
 	for {
-		// The laggiest partition is always at index 0 after initial sort or after we update and re-sort
+		// The laggiest partition is always at index 0 after initial sort, or after we update and re-sort
 		laggiestPartition := ps[0]
 		if len(ps) == 0 || laggiestPartition.lastRecordTs.IsZero() {
 			return b.cfg.ConsumeCycleDuration, nil
@@ -269,7 +269,6 @@ func (b *BlockBuilder) consume(ctx context.Context) (time.Duration, error) {
 		ps[0].commitOffset = commitOffset
 
 		// Re-sort only if needed - find the correct position for the updated partition
-		// This is more efficient than sorting the entire slice again
 		for i := 0; i < len(ps)-1 && ps[i].lastRecordTs.After(ps[i+1].lastRecordTs); i++ {
 			ps[i], ps[i+1] = ps[i+1], ps[i]
 		}

--- a/modules/blockbuilder/blockbuilder.go
+++ b/modules/blockbuilder/blockbuilder.go
@@ -101,20 +101,20 @@ type partitionState struct {
 	// Partition number
 	partition int32
 	// Start and end offset
-	startOffset, endOffset int64
+	commitOffset, endOffset int64
 	// Last committed record timestamp
 	lastRecordTs time.Time
 }
 
 func (p partitionState) getStartOffset() kgo.Offset {
-	if p.startOffset >= 0 {
-		return kgo.NewOffset().At(p.startOffset)
+	if p.commitOffset >= 0 {
+		return kgo.NewOffset().At(p.commitOffset)
 	}
 	return kgo.NewOffset().AtStart()
 }
 
 func (p partitionState) hasRecords() bool {
-	return p.endOffset >= -1
+	return p.endOffset > p.commitOffset
 }
 
 func New(
@@ -233,22 +233,24 @@ func (b *BlockBuilder) consume(ctx context.Context) (time.Duration, error) {
 		if !p.hasRecords() { // No records, we can skip the partition
 			continue
 		}
-		lastRecordTs, lastRecordOffset, err := b.consumePartition(ctx, p)
+		lastRecordTs, commitOffset, err := b.consumePartition(ctx, p)
 		if err != nil {
 			return 0, err
 		}
 		ps[i].lastRecordTs = lastRecordTs
-		ps[i].startOffset = lastRecordOffset
+		ps[i].commitOffset = commitOffset
 	}
+
+	sort.Slice(ps, func(i, j int) bool {
+		now := time.Now()
+		return now.Sub(ps[i].lastRecordTs) > now.Sub(ps[j].lastRecordTs)
+	})
 
 	// Iterate over the laggiest partition until the lag is less than the cycle duration or none of the partitions has records
 	for {
-		sort.Slice(ps, func(i, j int) bool {
-			return ps[i].lastRecordTs.Before(ps[j].lastRecordTs)
-		})
-
+		// The laggiest partition is always at index 0 after initial sort or after we update and re-sort
 		laggiestPartition := ps[0]
-		if laggiestPartition.lastRecordTs.IsZero() {
+		if len(ps) == 0 || laggiestPartition.lastRecordTs.IsZero() {
 			return b.cfg.ConsumeCycleDuration, nil
 		}
 
@@ -256,16 +258,26 @@ func (b *BlockBuilder) consume(ctx context.Context) (time.Duration, error) {
 		if lagTime < b.cfg.ConsumeCycleDuration {
 			return b.cfg.ConsumeCycleDuration - lagTime, nil
 		}
-		lastRecordTs, lastRecordOffset, err := b.consumePartition(ctx, laggiestPartition)
+
+		lastRecordTs, commitOffset, err := b.consumePartition(ctx, laggiestPartition)
 		if err != nil {
 			return 0, err
 		}
+
+		// Update the laggiest partition with new timestamp and offset
 		ps[0].lastRecordTs = lastRecordTs
-		ps[0].startOffset = lastRecordOffset
+		ps[0].commitOffset = commitOffset
+
+		// Re-sort only if needed - find the correct position for the updated partition
+		// This is more efficient than sorting the entire slice again
+		for i := 0; i < len(ps)-1 && ps[i].lastRecordTs.After(ps[i+1].lastRecordTs); {
+			ps[i], ps[i+1] = ps[i+1], ps[i]
+			i++
+		}
 	}
 }
 
-func (b *BlockBuilder) consumePartition(ctx context.Context, ps partitionState) (lastTs time.Time, lastOffset int64, err error) {
+func (b *BlockBuilder) consumePartition(ctx context.Context, ps partitionState) (lastTs time.Time, commitOffset int64, err error) {
 	defer func(t time.Time) {
 		metricProcessPartitionSectionDuration.WithLabelValues(strconv.Itoa(int(ps.partition))).Observe(time.Since(t).Seconds())
 	}(time.Now())
@@ -288,7 +300,7 @@ func (b *BlockBuilder) consumePartition(ctx context.Context, ps partitionState) 
 	level.Info(b.logger).Log(
 		"msg", "consuming partition",
 		"partition", ps.partition,
-		"commit_offset", ps.startOffset,
+		"commit_offset", ps.commitOffset,
 		"start_offset", startOffset,
 	)
 
@@ -364,7 +376,7 @@ outer:
 		level.Info(b.logger).Log(
 			"msg", "no data",
 			"partition", ps.partition,
-			"commit_offset", ps.startOffset,
+			"commit_offset", ps.commitOffset,
 			"start_offset", startOffset,
 		)
 		return time.Time{}, -1, nil
@@ -387,11 +399,11 @@ outer:
 	level.Info(b.logger).Log(
 		"msg", "successfully committed offset to kafka",
 		"partition", ps.partition,
-		"last_record", lastRec.Offset,
+		"commit_offset", lastRec.Offset+1,
 		"processed_records", processedRecords,
 	)
 
-	return lastRec.Timestamp, lastRec.Offset, nil
+	return lastRec.Timestamp, lastRec.Offset + 1, nil
 }
 
 func formatActivePartitions(partitions []int32) string {
@@ -439,12 +451,12 @@ func (b *BlockBuilder) fetchPartitions(ctx context.Context, partitions []int32) 
 func (b *BlockBuilder) getPartitionState(partition int32, commits kadm.OffsetResponses, endsOffsets kadm.ListedOffsets) partitionState {
 	var (
 		topic = b.cfg.IngestStorageConfig.Kafka.Topic
-		ps    = partitionState{partition: partition, startOffset: -1, endOffset: -2}
+		ps    = partitionState{partition: partition, commitOffset: -1, endOffset: -1}
 	)
 
 	lastCommit, found := commits.Lookup(topic, partition)
 	if found {
-		ps.startOffset = lastCommit.At
+		ps.commitOffset = lastCommit.At
 	}
 
 	lastRecord, found := endsOffsets.Lookup(topic, partition)


### PR DESCRIPTION
**What this PR does**:


1. Optimize partition sorting:
   - Move the sort operation outside the loop to avoid re-sorting all partitions on each iteration
   - Use a more efficient bubble-up approach to re-position only the updated partition
   - Add a safety check for empty partitions array

2. Fix cycle handling when records stop mid-cycle:

   - Ensure the block builder correctly stops a consumption cycle when records stop coming in
   - Prevent re-consumption of the same records in subsequent cycles

The changes ensure that when a consumption cycle starts but records stop before the cycle ends, the block builder correctly handles this case, stops at the appropriate time, and doesn't consume the same records again in the next cycle.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`