### PR TITLE
Reorder span iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [FEATURE] Added most_recent=true query hint to TraceQL to return most recent results. [#4238](https://github.com/grafana/tempo/pull/4238) (@joe-elliott)
 * [FEATURE] Add ability to add artificial delay to push requests [#4716](https://github.com/grafana/tempo/pull/4716) (@yvrhdn)
 * [ENHANCEMENT] Rewrite traces using rebatching [#4690](https://github.com/grafana/tempo/pull/4690) (@stoewer @joe-elliott)
+* [ENHANCEMENT] Reorder span iterators [#4754](https://github.com/grafana/tempo/pull/4754) (@stoewer)
 * [ENHANCEMENT] Update minio to version [#4341](https://github.com/grafana/tempo/pull/4568) (@javiermolinar)
 * [ENHANCEMENT] Prevent queries in the ingester from blocking flushing traces to disk and memory spikes. [#4483](https://github.com/grafana/tempo/pull/4483) (@joe-elliott)
 * [ENHANCEMENT] Update tempo operational dashboard for new block-builder and v2 traces api [#4559](https://github.com/grafana/tempo/pull/4559) (@mdisibio)

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -2058,6 +2058,10 @@ func createSpanIterator(makeIter makeIterFn, innerIterators []parquetquery.Itera
 		}
 	}
 
+	for columnPath, predicates := range columnPredicates {
+		iters = append(iters, makeIter(columnPath, orIfNeeded(predicates), columnSelectAs[columnPath]))
+	}
+
 	attrIter, err := createAttributeIterator(makeIter, genericConditions, DefinitionLevelResourceSpansILSSpanAttrs,
 		columnPathSpanAttrKey, columnPathSpanAttrString, columnPathSpanAttrInt, columnPathSpanAttrDouble, columnPathSpanAttrBool, allConditions, selectAll)
 	if err != nil {
@@ -2065,10 +2069,6 @@ func createSpanIterator(makeIter makeIterFn, innerIterators []parquetquery.Itera
 	}
 	if attrIter != nil {
 		iters = append(iters, attrIter)
-	}
-
-	for columnPath, predicates := range columnPredicates {
-		iters = append(iters, makeIter(columnPath, orIfNeeded(predicates), columnSelectAs[columnPath]))
 	}
 
 	var required []parquetquery.Iterator
@@ -2096,7 +2096,7 @@ func createSpanIterator(makeIter makeIterFn, innerIterators []parquetquery.Itera
 	// This is an optimization for when all of the span conditions must be met.
 	// We simply move all iterators into the required list.
 	if allConditions {
-		required = append(required, iters...)
+		required = append(iters, required...)
 		iters = nil
 	}
 


### PR DESCRIPTION
**What this PR does**:

Reorder iterators in `createSpanIterator`: move iterators of well-known attributes, intrinsic, and dedicated columns before attribute iterators (and link / event iterators).

This change shows improvements for some benchmarks.

<details>
<summary>Benchmark result</summary>

```
goos: linux
goarch: amd64
pkg: github.com/grafana/tempo/tempodb/encoding/vparquet4
cpu: AMD Ryzen 7 PRO 6850U with Radeon Graphics     
                                                 │ bench-traceql-02-dh-no-reorder.txt │   bench-traceql-02-dh-reorder.txt   │
                                                 │               sec/op               │   sec/op     vs base                │
BackendBlockTraceQL/spanAttVal01Match-16                                   11.43 ± 1%    11.80 ± 1%   +3.22% (p=0.000 n=10)
BackendBlockTraceQL/spanAttVal01NoMatch-16                                879.6m ± 3%   872.0m ± 1%   -0.86% (p=0.007 n=10)
BackendBlockTraceQL/spanAttVal02Match-16                                  113.7m ± 0%   114.9m ± 1%   +1.00% (p=0.019 n=10)
BackendBlockTraceQL/spanAttVal02NoMatch-16                                114.4m ± 1%   115.6m ± 1%   +1.03% (p=0.000 n=10)
BackendBlockTraceQL/mixedSpanDedicatedMatch-16                            828.9m ± 1%   834.7m ± 1%        ~ (p=0.436 n=10)
BackendBlockTraceQL/mixedSpanDedicatedNoMatch-16                          55.57m ± 1%   48.28m ± 1%  -13.12% (p=0.000 n=10)
BackendBlockTraceQL/mixedSpanWellKnownMatch-16                            118.2m ± 1%   113.0m ± 0%   -4.35% (p=0.000 n=10)
BackendBlockTraceQL/mixedSpanWellKnownNoMatch-16                          119.3m ± 1%   113.1m ± 1%   -5.20% (p=0.000 n=10)
geomean                                                                   309.8m        302.6m        -2.32%

                                                 │ bench-traceql-02-dh-no-reorder.txt │   bench-traceql-02-dh-reorder.txt   │
                                                 │                B/s                 │     B/s       vs base               │
BackendBlockTraceQL/spanAttVal01Match-16                                 213.3Mi ± 1%   206.7Mi ± 1%  -3.12% (p=0.000 n=10)
BackendBlockTraceQL/spanAttVal01NoMatch-16                               356.2Mi ± 2%   359.3Mi ± 1%  +0.86% (p=0.007 n=10)
BackendBlockTraceQL/spanAttVal02Match-16                                 384.1Mi ± 0%   380.3Mi ± 1%  -0.99% (p=0.019 n=10)
BackendBlockTraceQL/spanAttVal02NoMatch-16                               381.8Mi ± 1%   377.9Mi ± 1%  -1.02% (p=0.000 n=10)
BackendBlockTraceQL/mixedSpanDedicatedMatch-16                           667.3Mi ± 1%   662.7Mi ± 1%       ~ (p=0.436 n=10)
BackendBlockTraceQL/mixedSpanDedicatedNoMatch-16                         671.5Mi ± 1%   646.9Mi ± 1%  -3.67% (p=0.000 n=10)
BackendBlockTraceQL/mixedSpanWellKnownMatch-16                           421.1Mi ± 1%   386.4Mi ± 0%  -8.24% (p=0.000 n=10)
BackendBlockTraceQL/mixedSpanWellKnownNoMatch-16                         417.3Mi ± 1%   386.4Mi ± 1%  -7.41% (p=0.000 n=10)
geomean                                                                  414.9Mi        402.1Mi       -3.08%

                                                 │ bench-traceql-02-dh-no-reorder.txt │    bench-traceql-02-dh-reorder.txt    │
                                                 │              MB_io/op              │  MB_io/op    vs base                  │
BackendBlockTraceQL/spanAttVal01Match-16                                  2.557k ± 0%   2.557k ± 0%        ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/spanAttVal01NoMatch-16                                 328.5 ± 0%    328.5 ± 0%        ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/spanAttVal02Match-16                                   45.81 ± 0%    45.81 ± 0%        ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/spanAttVal02NoMatch-16                                 45.81 ± 0%    45.81 ± 0%        ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixedSpanDedicatedMatch-16                             580.0 ± 0%    580.0 ± 0%        ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixedSpanDedicatedNoMatch-16                           39.13 ± 0%    32.75 ± 0%  -16.30% (p=0.000 n=10)
BackendBlockTraceQL/mixedSpanWellKnownMatch-16                             52.19 ± 0%    45.81 ± 0%  -12.22% (p=0.000 n=10)
BackendBlockTraceQL/mixedSpanWellKnownNoMatch-16                           52.19 ± 0%    45.81 ± 0%  -12.22% (p=0.000 n=10)
geomean                                                                    134.8         127.6        -5.34%
¹ all samples are equal

                                                 │ bench-traceql-02-dh-no-reorder.txt │   bench-traceql-02-dh-reorder.txt    │
                                                 │                B/op                │     B/op      vs base                │
BackendBlockTraceQL/spanAttVal01Match-16                                 1.442Gi ± 5%   1.364Gi ± 8%        ~ (p=0.123 n=10)
BackendBlockTraceQL/spanAttVal01NoMatch-16                               1.034Gi ± 5%   1.035Gi ± 3%        ~ (p=0.579 n=10)
BackendBlockTraceQL/spanAttVal02Match-16                                 126.0Mi ± 1%   126.2Mi ± 1%        ~ (p=0.631 n=10)
BackendBlockTraceQL/spanAttVal02NoMatch-16                               126.3Mi ± 1%   125.9Mi ± 1%        ~ (p=0.529 n=10)
BackendBlockTraceQL/mixedSpanDedicatedMatch-16                           618.5Mi ± 4%   628.7Mi ± 6%        ~ (p=0.436 n=10)
BackendBlockTraceQL/mixedSpanDedicatedNoMatch-16                         58.82Mi ± 1%   37.46Mi ± 1%  -36.30% (p=0.000 n=10)
BackendBlockTraceQL/mixedSpanWellKnownMatch-16                           145.0Mi ± 1%   125.4Mi ± 1%  -13.51% (p=0.000 n=10)
BackendBlockTraceQL/mixedSpanWellKnownNoMatch-16                         145.4Mi ± 1%   126.1Mi ± 0%  -13.31% (p=0.000 n=10)
geomean                                                                  257.1Mi        233.2Mi        -9.28%

                                                 │ bench-traceql-02-dh-no-reorder.txt │  bench-traceql-02-dh-reorder.txt   │
                                                 │             allocs/op              │  allocs/op   vs base               │
BackendBlockTraceQL/spanAttVal01Match-16                                  785.4k ± 0%   785.1k ± 0%       ~ (p=0.342 n=10)
BackendBlockTraceQL/spanAttVal01NoMatch-16                                143.0k ± 0%   143.0k ± 0%       ~ (p=0.912 n=10)
BackendBlockTraceQL/spanAttVal02Match-16                                  140.6k ± 0%   140.6k ± 0%  -0.00% (p=0.024 n=10)
BackendBlockTraceQL/spanAttVal02NoMatch-16                                140.6k ± 0%   140.6k ± 0%       ~ (p=0.118 n=10)
BackendBlockTraceQL/mixedSpanDedicatedMatch-16                            182.1k ± 0%   182.1k ± 0%       ~ (p=0.436 n=10)
BackendBlockTraceQL/mixedSpanDedicatedNoMatch-16                          140.7k ± 0%   140.7k ± 0%  -0.01% (p=0.000 n=10)
BackendBlockTraceQL/mixedSpanWellKnownMatch-16                            140.8k ± 0%   140.7k ± 0%  -0.04% (p=0.000 n=10)
BackendBlockTraceQL/mixedSpanWellKnownNoMatch-16                          140.8k ± 0%   140.7k ± 0%  -0.04% (p=0.000 n=10)
geomean                                                                   180.5k        180.5k       -0.01%

```
</details>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`