### PR TITLE
Improve Tempo build options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [CHANGE] Update to go 1.24.0 [#4704](https://github.com/grafana/tempo/pull/4704) (@ruslan-mikhailov)
 * [FEATURE] Added most_recent=true query hint to TraceQL to return most recent results. [#4238](https://github.com/grafana/tempo/pull/4238) (@joe-elliott)
 * [FEATURE] Add ability to add artificial delay to push requests [#4716](https://github.com/grafana/tempo/pull/4716) (@yvrhdn)
+* [ENHANCEMENT] Improve Tempo build options [#4755](https://github.com/grafana/tempo/pull/4755) (@stoewer)
 * [ENHANCEMENT] Rewrite traces using rebatching [#4690](https://github.com/grafana/tempo/pull/4690) (@stoewer @joe-elliott)
 * [ENHANCEMENT] Update minio to version [#4341](https://github.com/grafana/tempo/pull/4568) (@javiermolinar)
 * [ENHANCEMENT] Prevent queries in the ingester from blocking flushing traces to disk and memory spikes. [#4483](https://github.com/grafana/tempo/pull/4483) (@joe-elliott)

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,6 @@ FILES_TO_JSONNETFMT=$(shell find ./operations/jsonnet ./operations/tempo-mixin -
 ##@ Building
 .PHONY: tempo 	
 tempo: ## Build tempo
-	echo $(GOARCH)
 	$(GO_ENV) go build $(GO_OPT) -o ./bin/$(GOOS)/tempo-$(GOARCH) $(BUILD_INFO) ./cmd/tempo
 
 .PHONY: tempo-query

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ else
 	GO_OPT+= -ldflags -w
 endif
 
-GO_ENV=GO111MODULE=on CGO_ENABLED=0
+GO_ENV=CGO_ENABLED=0
 ifeq ($(GOARCH),amd64)
 	GO_ENV+= GOAMD64=v2
 endif

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,14 @@ ifeq ($(BUILD_DEBUG), 1)
 	GO_OPT+= -gcflags="all=-N -l"
 endif
 
+GO_ENV=GO111MODULE=on CGO_ENABLED=0
+ifeq ($(GOARCH),amd64)
+	GO_ENV+= GOAMD64=v2
+endif
+ifeq ($(GOARCH),arm64)
+	GO_ENV+= GOARM64=v8
+endif
+
 GOTEST_OPT?= -race -timeout 25m -count=1 -v
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -cover
 GOTEST=gotestsum --format=testname --
@@ -66,19 +74,20 @@ FILES_TO_JSONNETFMT=$(shell find ./operations/jsonnet ./operations/tempo-mixin -
 ##@ Building
 .PHONY: tempo 	
 tempo: ## Build tempo
-	GO111MODULE=on CGO_ENABLED=0 go build $(GO_OPT) -o ./bin/$(GOOS)/tempo-$(GOARCH) $(BUILD_INFO) ./cmd/tempo 
+	echo $(GOARCH)
+	$(GO_ENV) go build $(GO_OPT) -o ./bin/$(GOOS)/tempo-$(GOARCH) $(BUILD_INFO) ./cmd/tempo
 
 .PHONY: tempo-query
 tempo-query: ## Build tempo-query
-	GO111MODULE=on CGO_ENABLED=0 go build $(GO_OPT) -o ./bin/$(GOOS)/tempo-query-$(GOARCH) $(BUILD_INFO) ./cmd/tempo-query
+	$(GO_ENV) go build $(GO_OPT) -o ./bin/$(GOOS)/tempo-query-$(GOARCH) $(BUILD_INFO) ./cmd/tempo-query
 
 .PHONY: tempo-cli
 tempo-cli: ## Build tempo-cli
-	GO111MODULE=on CGO_ENABLED=0 go build $(GO_OPT) -o ./bin/$(GOOS)/tempo-cli-$(GOARCH) $(BUILD_INFO) ./cmd/tempo-cli
+	$(GO_ENV) go build $(GO_OPT) -o ./bin/$(GOOS)/tempo-cli-$(GOARCH) $(BUILD_INFO) ./cmd/tempo-cli
 
 .PHONY: tempo-vulture  ## Build tempo-vulture
 tempo-vulture:
-	GO111MODULE=on CGO_ENABLED=0 go build $(GO_OPT) -o ./bin/$(GOOS)/tempo-vulture-$(GOARCH) $(BUILD_INFO) ./cmd/tempo-vulture
+	$(GO_ENV) go build $(GO_OPT) -o ./bin/$(GOOS)/tempo-vulture-$(GOARCH) $(BUILD_INFO) ./cmd/tempo-vulture
 
 .PHONY: exe  ## Build exe
 exe:

--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,14 @@ ALL_DOC := $(shell find . \( -name "*.md" -o -name "*.yaml" \) \
 # ALL_PKGS is used with 'go cover'
 ALL_PKGS := $(shell go list $(sort $(dir $(ALL_SRC))))
 
-GO_OPT= -mod vendor -ldflags "-X main.Branch=$(GIT_BRANCH) -X main.Revision=$(GIT_REVISION) -X main.Version=$(VERSION)"
+LD_FLAGS=-X main.Branch=$(GIT_BRANCH) -X main.Revision=$(GIT_REVISION) -X main.Version=$(VERSION)
+ifeq ($(BUILD_DEBUG),)
+	LD_FLAGS+= -w
+endif
+
+GO_OPT= -mod vendor -ldflags "$(LD_FLAGS)"
 ifeq ($(BUILD_DEBUG), 1)
 	GO_OPT+= -gcflags="all=-N -l"
-else
-	GO_OPT+= -ldflags -w
 endif
 
 GO_ENV=CGO_ENABLED=0

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ ALL_PKGS := $(shell go list $(sort $(dir $(ALL_SRC))))
 GO_OPT= -mod vendor -ldflags "-X main.Branch=$(GIT_BRANCH) -X main.Revision=$(GIT_REVISION) -X main.Version=$(VERSION)"
 ifeq ($(BUILD_DEBUG), 1)
 	GO_OPT+= -gcflags="all=-N -l"
+else
+	GO_OPT+= -ldflags -w
 endif
 
 GO_ENV=GO111MODULE=on CGO_ENABLED=0


### PR DESCRIPTION
**What this PR does**:

This PR makes the following changes to Tempos build options:
* Remove debug info from production builds `-ldflags -w`. This reduces the tempo binary size by ~20%
* Set the architecture API version for amd64 and arm64. This allows the compiler to use more advanced instructions and has a small positive effect on code execution time on amd64 (see benchmark below).
* Remove `GO111MODULE=on` as this is the default since [Go 1.16](https://go.dev/doc/go1.16). 

The changes are inspired by the 2025 FOSDEM talk [Build better Go release binaries](https://cuddly.tube/w/e7Ks1zQhFovnGwbZFRcL1d)

<details>
<summary>Benchmarks amd64 v1 vs v2 vs v3</summary>

```
goos: linux
goarch: amd64
pkg: github.com/grafana/tempo/tempodb/encoding/vparquet4
cpu: AMD Ryzen 7 PRO 6850U with Radeon Graphics     
                                                    │ bench-build-02-amd64-v1.txt │    bench-build-02-amd64-v2.txt     │    bench-build-02-amd64-v3.txt     │
                                                    │           sec/op            │   sec/op     vs base               │   sec/op     vs base               │
BackendBlockTraceQL/spanAttValMatch-16                                249.7m ± 1%   240.1m ± 0%  -3.85% (p=0.000 n=12)   233.0m ± 1%  -6.70% (p=0.000 n=12)
BackendBlockTraceQL/spanAttValNoMatch-16                              6.906m ± 1%   6.439m ± 1%  -6.77% (p=0.000 n=12)   6.442m ± 1%  -6.72% (p=0.000 n=12)
BackendBlockTraceQL/spanAttIntrinsicMatch-16                          175.0m ± 0%   170.2m ± 0%  -2.71% (p=0.000 n=12)   166.3m ± 0%  -4.96% (p=0.000 n=12)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-16                        7.001m ± 1%   6.563m ± 1%  -6.26% (p=0.000 n=12)   6.587m ± 1%  -5.91% (p=0.000 n=12)
BackendBlockTraceQL/resourceAttValMatch-16                            832.5m ± 1%   810.0m ± 1%  -2.71% (p=0.000 n=12)   803.3m ± 1%  -3.51% (p=0.000 n=12)
BackendBlockTraceQL/resourceAttValNoMatch-16                          6.627m ± 3%   6.161m ± 1%  -7.03% (p=0.000 n=12)   6.188m ± 1%  -6.62% (p=0.000 n=12)
BackendBlockTraceQL/resourceAttIntrinsicMatch-16                      49.52m ± 0%   48.88m ± 1%  -1.29% (p=0.000 n=12)   46.42m ± 1%  -6.25% (p=0.000 n=12)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01-16                   6.811m ± 1%   6.489m ± 1%  -4.74% (p=0.000 n=12)   6.493m ± 1%  -4.68% (p=0.000 n=12)
BackendBlockTraceQL/traceOrMatch-16                                   556.1m ± 0%   543.4m ± 1%  -2.27% (p=0.000 n=12)   556.7m ± 1%       ~ (p=0.410 n=12)
BackendBlockTraceQL/traceOrNoMatch-16                                 558.6m ± 1%   545.9m ± 1%  -2.26% (p=0.000 n=12)   559.0m ± 0%       ~ (p=0.514 n=12)
BackendBlockTraceQL/mixedValNoMatch-16                                370.0m ± 1%   365.8m ± 0%  -1.15% (p=0.000 n=12)   365.2m ± 0%  -1.30% (p=0.000 n=12)
BackendBlockTraceQL/mixedValMixedMatchAnd-16                          6.585m ± 1%   6.286m ± 0%  -4.54% (p=0.000 n=12)   6.245m ± 1%  -5.16% (p=0.000 n=12)
BackendBlockTraceQL/mixedValMixedMatchOr-16                           282.6m ± 1%   280.0m ± 0%  -0.94% (p=0.007 n=12)   278.5m ± 1%  -1.47% (p=0.000 n=12)
BackendBlockTraceQL/count-16                                          649.2m ± 2%   651.6m ± 1%       ~ (p=0.932 n=12)   643.1m ± 1%  -0.94% (p=0.002 n=12)
BackendBlockTraceQL/struct-16                                          1.016 ± 1%    1.030 ± 1%  +1.40% (p=0.007 n=12)    1.056 ± 2%  +3.94% (p=0.001 n=12)
BackendBlockTraceQL/||-16                                             298.0m ± 0%   300.5m ± 0%  +0.86% (p=0.000 n=12)   295.6m ± 1%  -0.78% (p=0.000 n=12)
BackendBlockTraceQL/mixed-16                                          55.69m ± 0%   56.22m ± 1%  +0.96% (p=0.012 n=12)   53.96m ± 1%  -3.10% (p=0.000 n=12)
BackendBlockTraceQL/complex-16                                        6.511m ± 1%   6.437m ± 1%  -1.14% (p=0.008 n=12)   6.222m ± 0%  -4.45% (p=0.000 n=12)
BackendBlockTraceQL/select-16                                         6.555m ± 1%   6.493m ± 1%  -0.94% (p=0.001 n=12)   6.254m ± 2%  -4.59% (p=0.000 n=12)
geomean                                                               74.71m        72.92m       -2.40%                  72.20m       -3.36%

                                                    │ bench-build-02-amd64-v1.txt │     bench-build-02-amd64-v2.txt     │     bench-build-02-amd64-v3.txt     │
                                                    │             B/s             │     B/s       vs base               │     B/s       vs base               │
BackendBlockTraceQL/spanAttValMatch-16                               123.4Mi ± 1%   128.3Mi ± 0%  +4.00% (p=0.000 n=12)   132.2Mi ± 1%  +7.18% (p=0.000 n=12)
BackendBlockTraceQL/spanAttValNoMatch-16                             270.8Mi ± 1%   290.4Mi ± 1%  +7.26% (p=0.000 n=12)   290.3Mi ± 1%  +7.21% (p=0.000 n=12)
BackendBlockTraceQL/spanAttIntrinsicMatch-16                         183.0Mi ± 0%   188.1Mi ± 0%  +2.78% (p=0.000 n=12)   192.6Mi ± 0%  +5.22% (p=0.000 n=12)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-16                       387.3Mi ± 1%   413.1Mi ± 1%  +6.67% (p=0.000 n=12)   411.6Mi ± 1%  +6.28% (p=0.000 n=12)
BackendBlockTraceQL/resourceAttValMatch-16                           36.35Mi ± 1%   37.37Mi ± 1%  +2.79% (p=0.000 n=12)   37.68Mi ± 1%  +3.65% (p=0.000 n=12)
BackendBlockTraceQL/resourceAttValNoMatch-16                         112.0Mi ± 3%   120.4Mi ± 1%  +7.56% (p=0.000 n=12)   119.9Mi ± 1%  +7.09% (p=0.000 n=12)
BackendBlockTraceQL/resourceAttIntrinsicMatch-16                     613.2Mi ± 0%   621.2Mi ± 1%  +1.31% (p=0.000 n=12)   654.1Mi ± 1%  +6.67% (p=0.000 n=12)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01-16                  120.5Mi ± 1%   126.5Mi ± 1%  +4.97% (p=0.000 n=12)   126.4Mi ± 1%  +4.91% (p=0.000 n=12)
BackendBlockTraceQL/traceOrMatch-16                                  3.171Mi ± 0%   3.247Mi ± 1%  +2.41% (p=0.000 n=12)   3.166Mi ± 1%       ~ (p=0.379 n=12)
BackendBlockTraceQL/traceOrNoMatch-16                                3.157Mi ± 1%   3.228Mi ± 0%  +2.27% (p=0.000 n=12)   3.157Mi ± 0%       ~ (p=0.741 n=12)
BackendBlockTraceQL/mixedValNoMatch-16                               6.075Mi ± 0%   6.142Mi ± 0%  +1.10% (p=0.000 n=12)   6.151Mi ± 0%  +1.26% (p=0.000 n=12)
BackendBlockTraceQL/mixedValMixedMatchAnd-16                         111.1Mi ± 1%   116.4Mi ± 0%  +4.75% (p=0.000 n=12)   117.2Mi ± 1%  +5.44% (p=0.000 n=12)
BackendBlockTraceQL/mixedValMixedMatchOr-16                          10.92Mi ± 1%   11.03Mi ± 0%  +0.96% (p=0.009 n=12)   11.09Mi ± 1%  +1.53% (p=0.000 n=12)
BackendBlockTraceQL/count-16                                         46.60Mi ± 2%   46.43Mi ± 1%       ~ (p=0.921 n=12)   47.04Mi ± 1%  +0.95% (p=0.002 n=12)
BackendBlockTraceQL/struct-16                                        5.941Mi ± 1%   5.860Mi ± 1%  -1.36% (p=0.006 n=12)   5.717Mi ± 2%  -3.77% (p=0.001 n=12)
BackendBlockTraceQL/||-16                                            102.3Mi ± 0%   101.4Mi ± 0%  -0.86% (p=0.000 n=12)   103.1Mi ± 1%  +0.78% (p=0.000 n=12)
BackendBlockTraceQL/mixed-16                                         539.6Mi ± 0%   534.5Mi ± 1%  -0.95% (p=0.011 n=12)   556.9Mi ± 1%  +3.20% (p=0.000 n=12)
BackendBlockTraceQL/complex-16                                       113.8Mi ± 1%   115.2Mi ± 1%  +1.16% (p=0.008 n=12)   119.1Mi ± 0%  +4.65% (p=0.000 n=12)
BackendBlockTraceQL/select-16                                        113.1Mi ± 1%   114.2Mi ± 1%  +0.94% (p=0.001 n=12)   118.5Mi ± 2%  +4.81% (p=0.000 n=12)
geomean                                                              61.69Mi        63.21Mi       +2.46%                  63.84Mi       +3.48%

                                                    │ bench-build-02-amd64-v1.txt │     bench-build-02-amd64-v2.txt      │     bench-build-02-amd64-v3.txt      │
                                                    │          MB_io/op           │  MB_io/op    vs base                 │  MB_io/op    vs base                 │
BackendBlockTraceQL/spanAttValMatch-16                                 32.31 ± 0%    32.31 ± 0%       ~ (p=1.000 n=12) ¹    32.31 ± 0%       ~ (p=1.000 n=12) ¹
BackendBlockTraceQL/spanAttValNoMatch-16                               1.961 ± 0%    1.961 ± 0%       ~ (p=1.000 n=12) ¹    1.961 ± 0%       ~ (p=1.000 n=12) ¹
BackendBlockTraceQL/spanAttIntrinsicMatch-16                           33.58 ± 0%    33.58 ± 0%       ~ (p=1.000 n=12) ¹    33.58 ± 0%       ~ (p=1.000 n=12) ¹
BackendBlockTraceQL/spanAttIntrinsicNoMatch-16                         2.843 ± 0%    2.843 ± 0%       ~ (p=1.000 n=12) ¹    2.843 ± 0%       ~ (p=1.000 n=12) ¹
BackendBlockTraceQL/resourceAttValMatch-16                             31.74 ± 0%    31.74 ± 0%       ~ (p=1.000 n=12) ¹    31.74 ± 0%       ~ (p=1.000 n=12) ¹
BackendBlockTraceQL/resourceAttValNoMatch-16                          777.9m ± 0%   777.9m ± 0%       ~ (p=1.000 n=12) ¹   777.9m ± 0%       ~ (p=1.000 n=12) ¹
BackendBlockTraceQL/resourceAttIntrinsicMatch-16                       31.84 ± 0%    31.84 ± 0%       ~ (p=1.000 n=12) ¹    31.84 ± 0%       ~ (p=1.000 n=12) ¹
BackendBlockTraceQL/resourceAttIntrinsicMatch#01-16                   860.6m ± 0%   860.6m ± 0%       ~ (p=1.000 n=12) ¹   860.6m ± 0%       ~ (p=1.000 n=12) ¹
BackendBlockTraceQL/traceOrMatch-16                                    1.849 ± 0%    1.849 ± 0%       ~ (p=1.000 n=12) ¹    1.849 ± 0%       ~ (p=1.000 n=12) ¹
BackendBlockTraceQL/traceOrNoMatch-16                                  1.849 ± 0%    1.849 ± 0%       ~ (p=1.000 n=12) ¹    1.849 ± 0%       ~ (p=1.000 n=12) ¹
BackendBlockTraceQL/mixedValNoMatch-16                                 2.356 ± 0%    2.356 ± 0%       ~ (p=1.000 n=12) ¹    2.356 ± 0%       ~ (p=1.000 n=12) ¹
BackendBlockTraceQL/mixedValMixedMatchAnd-16                          767.4m ± 0%   767.4m ± 0%       ~ (p=1.000 n=12) ¹   767.4m ± 0%       ~ (p=1.000 n=12) ¹
BackendBlockTraceQL/mixedValMixedMatchOr-16                            3.238 ± 0%    3.238 ± 0%       ~ (p=1.000 n=12) ¹    3.238 ± 0%       ~ (p=1.000 n=12) ¹
BackendBlockTraceQL/count-16                                           31.72 ± 0%    31.72 ± 0%       ~ (p=1.000 n=12) ¹    31.72 ± 0%       ~ (p=1.000 n=12) ¹
BackendBlockTraceQL/struct-16                                          6.330 ± 0%    6.330 ± 0%       ~ (p=1.000 n=12) ¹    6.330 ± 0%       ~ (p=1.000 n=12) ¹
BackendBlockTraceQL/||-16                                              31.95 ± 0%    31.95 ± 0%       ~ (p=1.000 n=12) ¹    31.95 ± 0%       ~ (p=1.000 n=12) ¹
BackendBlockTraceQL/mixed-16                                           31.51 ± 0%    31.51 ± 0%       ~ (p=1.000 n=12) ¹    31.51 ± 0%       ~ (p=1.000 n=12) ¹
BackendBlockTraceQL/complex-16                                        777.3m ± 0%   777.3m ± 0%       ~ (p=1.000 n=12) ¹   777.3m ± 0%       ~ (p=1.000 n=12) ¹
BackendBlockTraceQL/select-16                                         777.3m ± 0%   777.3m ± 0%       ~ (p=1.000 n=12) ¹   777.3m ± 0%       ~ (p=1.000 n=12) ¹
geomean                                                                4.833         4.833       +0.00%                     4.833       +0.00%
¹ all samples are equal

                                                    │ bench-build-02-amd64-v1.txt │      bench-build-02-amd64-v2.txt       │      bench-build-02-amd64-v3.txt       │
                                                    │            B/op             │      B/op       vs base                │      B/op       vs base                │
BackendBlockTraceQL/spanAttValMatch-16                              69.15Mi ±  1%    69.10Mi ±  1%        ~ (p=0.443 n=12)    68.91Mi ±  1%        ~ (p=0.089 n=12)
BackendBlockTraceQL/spanAttValNoMatch-16                            5.003Mi ±  1%    4.880Mi ±  1%   -2.45% (p=0.000 n=12)    5.001Mi ±  1%        ~ (p=0.671 n=12)
BackendBlockTraceQL/spanAttIntrinsicMatch-16                        74.40Mi ±  1%    74.63Mi ±  1%        ~ (p=0.713 n=12)    74.34Mi ±  0%        ~ (p=0.198 n=12)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-16                      5.082Mi ±  1%    5.008Mi ±  1%   -1.44% (p=0.007 n=12)    5.133Mi ±  2%   +1.02% (p=0.014 n=12)
BackendBlockTraceQL/resourceAttValMatch-16                          793.7Mi ±  0%    794.3Mi ±  0%        ~ (p=0.178 n=12)    794.1Mi ±  0%        ~ (p=0.977 n=12)
BackendBlockTraceQL/resourceAttValNoMatch-16                        4.822Mi ±  1%    4.751Mi ±  1%   -1.49% (p=0.000 n=12)    4.856Mi ±  1%   +0.69% (p=0.020 n=12)
BackendBlockTraceQL/resourceAttIntrinsicMatch-16                    11.23Mi ±  1%    11.28Mi ±  2%        ~ (p=0.977 n=12)    11.31Mi ±  1%        ~ (p=0.198 n=12)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01-16                 5.280Mi ±  1%    5.217Mi ±  1%        ~ (p=0.068 n=12)    5.336Mi ±  1%        ~ (p=0.068 n=12)
BackendBlockTraceQL/traceOrMatch-16                                 8.476Mi ± 58%   11.069Mi ± 38%        ~ (p=0.347 n=12)    9.697Mi ± 28%        ~ (p=0.887 n=12)
BackendBlockTraceQL/traceOrNoMatch-16                              13.037Mi ± 14%    8.823Mi ± 52%  -32.32% (p=0.039 n=12)   10.119Mi ± 25%  -22.38% (p=0.012 n=12)
BackendBlockTraceQL/mixedValNoMatch-16                              5.553Mi ±  6%    5.590Mi ±  6%        ~ (p=0.319 n=12)    5.488Mi ±  8%        ~ (p=0.671 n=12)
BackendBlockTraceQL/mixedValMixedMatchAnd-16                        4.871Mi ±  1%    4.839Mi ±  0%   -0.65% (p=0.002 n=12)    4.900Mi ±  1%        ~ (p=0.198 n=12)
BackendBlockTraceQL/mixedValMixedMatchOr-16                         5.829Mi ±  5%    5.718Mi ±  6%        ~ (p=0.266 n=12)    5.551Mi ±  8%        ~ (p=0.378 n=12)
BackendBlockTraceQL/count-16                                        578.2Mi ±  0%    578.2Mi ±  0%        ~ (p=0.932 n=12)    578.5Mi ±  1%        ~ (p=0.843 n=12)
BackendBlockTraceQL/struct-16                                       20.01Mi ± 19%    20.84Mi ± 13%        ~ (p=0.887 n=12)    18.70Mi ± 15%        ~ (p=0.178 n=12)
BackendBlockTraceQL/||-16                                           50.89Mi ±  2%    50.09Mi ±  2%        ~ (p=0.114 n=12)    50.53Mi ±  2%        ~ (p=0.242 n=12)
BackendBlockTraceQL/mixed-16                                        7.180Mi ±  2%    7.319Mi ±  2%        ~ (p=0.089 n=12)    7.248Mi ±  1%        ~ (p=0.266 n=12)
BackendBlockTraceQL/complex-16                                      4.952Mi ±  1%    4.972Mi ±  1%        ~ (p=0.242 n=12)    4.971Mi ±  0%        ~ (p=0.514 n=12)
BackendBlockTraceQL/select-16                                       4.930Mi ±  1%    4.928Mi ±  1%        ~ (p=0.977 n=12)    4.957Mi ±  1%        ~ (p=0.319 n=12)
geomean                                                             15.71Mi          15.58Mi         -0.81%                   15.55Mi         -1.04%

                                                    │ bench-build-02-amd64-v1.txt │    bench-build-02-amd64-v2.txt     │    bench-build-02-amd64-v3.txt     │
                                                    │          allocs/op          │  allocs/op   vs base               │  allocs/op   vs base               │
BackendBlockTraceQL/spanAttValMatch-16                                725.1k ± 0%   725.1k ± 0%       ~ (p=0.247 n=12)   725.1k ± 0%       ~ (p=0.201 n=12)
BackendBlockTraceQL/spanAttValNoMatch-16                              65.15k ± 0%   65.15k ± 0%  -0.01% (p=0.000 n=12)   65.15k ± 0%       ~ (p=0.632 n=12)
BackendBlockTraceQL/spanAttIntrinsicMatch-16                          470.5k ± 0%   470.5k ± 0%       ~ (p=0.385 n=12)   470.5k ± 0%       ~ (p=0.722 n=12)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-16                        65.11k ± 0%   65.11k ± 0%  -0.00% (p=0.004 n=12)   65.11k ± 0%       ~ (p=0.067 n=12)
BackendBlockTraceQL/resourceAttValMatch-16                            4.789M ± 0%   4.789M ± 0%       ~ (p=0.921 n=12)   4.789M ± 0%       ~ (p=0.755 n=12)
BackendBlockTraceQL/resourceAttValNoMatch-16                          65.22k ± 0%   65.22k ± 0%  -0.01% (p=0.000 n=12)   65.22k ± 0%       ~ (p=0.058 n=12)
BackendBlockTraceQL/resourceAttIntrinsicMatch-16                      125.6k ± 0%   125.6k ± 0%       ~ (p=0.809 n=12)   125.6k ± 0%       ~ (p=0.449 n=12)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01-16                   65.16k ± 0%   65.15k ± 0%  -0.00% (p=0.047 n=12)   65.16k ± 0%       ~ (p=0.296 n=12)
BackendBlockTraceQL/traceOrMatch-16                                   76.45k ± 2%   76.76k ± 2%       ~ (p=0.378 n=12)   76.79k ± 1%       ~ (p=0.266 n=12)
BackendBlockTraceQL/traceOrNoMatch-16                                 76.30k ± 1%   76.52k ± 1%       ~ (p=0.561 n=12)   76.27k ± 0%  -0.05% (p=0.008 n=12)
BackendBlockTraceQL/mixedValNoMatch-16                                65.98k ± 0%   65.98k ± 0%       ~ (p=0.702 n=12)   65.98k ± 0%       ~ (p=0.212 n=12)
BackendBlockTraceQL/mixedValMixedMatchAnd-16                          65.20k ± 0%   65.20k ± 0%  -0.00% (p=0.004 n=12)   65.20k ± 0%       ~ (p=0.680 n=12)
BackendBlockTraceQL/mixedValMixedMatchOr-16                           65.99k ± 0%   65.98k ± 0%       ~ (p=0.541 n=12)   65.98k ± 0%       ~ (p=0.247 n=12)
BackendBlockTraceQL/count-16                                          2.769M ± 0%   2.769M ± 0%       ~ (p=0.386 n=12)   2.769M ± 0%       ~ (p=0.702 n=12)
BackendBlockTraceQL/struct-16                                         88.38k ± 2%   88.48k ± 2%       ~ (p=0.932 n=12)   88.68k ± 2%       ~ (p=0.478 n=12)
BackendBlockTraceQL/||-16                                             331.6k ± 0%   331.5k ± 0%       ~ (p=0.086 n=12)   331.5k ± 0%  -0.01% (p=0.040 n=12)
BackendBlockTraceQL/mixed-16                                          82.36k ± 0%   82.37k ± 0%       ~ (p=0.097 n=12)   82.36k ± 0%       ~ (p=0.172 n=12)
BackendBlockTraceQL/complex-16                                        65.56k ± 0%   65.56k ± 0%       ~ (p=0.814 n=12)   65.56k ± 0%       ~ (p=0.499 n=12)
BackendBlockTraceQL/select-16                                         65.44k ± 0%   65.44k ± 0%       ~ (p=0.453 n=12)   65.44k ± 0%       ~ (p=0.758 n=12)
geomean                                                               148.2k        148.2k       +0.04%                  148.2k       +0.04%

```
</details>

Based on the benchmark results it would be interesting to find out if we can also use `GOAMD64=v3`. v3 corresponds to the [AVX2](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions) instruction set which was first introduced in 2013. There could still be some hardware around that does not support it.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`