### PR TITLE
[rhythm] blockbuilder: fix cycle handling

### DIFF
--- a/modules/blockbuilder/blockbuilder.go
+++ b/modules/blockbuilder/blockbuilder.go
@@ -375,9 +375,10 @@ outer:
 		return time.Time{}, -1, err
 	}
 
-	// TODO - Retry commit
-
-	resp, err := b.kadm.CommitOffsets(ctx, group, kadm.OffsetsFromRecords(*lastRec))
+	offset := kadm.NewOffsetFromRecord(lastRec)
+	offsets := make(kadm.Offsets)
+	offsets.Add(offset)
+	resp, err := b.kadm.CommitOffsets(ctx, group, offsets) // TODO - Retry commit
 	if err != nil {
 		return time.Time{}, -1, err
 	}
@@ -387,11 +388,11 @@ outer:
 	level.Info(b.logger).Log(
 		"msg", "successfully committed offset to kafka",
 		"partition", ps.partition,
-		"commit_offset", lastRec.Offset+1,
+		"commit_offset", offset.At,
 		"processed_records", processedRecords,
 	)
 
-	return lastRec.Timestamp, lastRec.Offset + 1, nil
+	return lastRec.Timestamp, offset.At, nil
 }
 
 func formatActivePartitions(partitions []int32) string {

--- a/modules/blockbuilder/blockbuilder.go
+++ b/modules/blockbuilder/blockbuilder.go
@@ -101,14 +101,14 @@ type partitionState struct {
 	// Partition number
 	partition int32
 	// Start and end offset
-	startOffset, endOffset int64
+	commitOffset, endOffset int64
 	// Last committed record timestamp
 	lastRecordTs time.Time
 }
 
 func (p partitionState) getStartOffset() kgo.Offset {
-	if p.startOffset >= 0 {
-		return kgo.NewOffset().At(p.startOffset)
+	if p.commitOffset >= 0 {
+		return kgo.NewOffset().At(p.commitOffset)
 	}
 	return kgo.NewOffset().AtStart()
 }
@@ -233,12 +233,12 @@ func (b *BlockBuilder) consume(ctx context.Context) (time.Duration, error) {
 		if !p.hasRecords() { // No records, we can skip the partition
 			continue
 		}
-		lastRecordTs, lastRecordOffset, err := b.consumePartition(ctx, p)
+		lastRecordTs, commitOffset, err := b.consumePartition(ctx, p)
 		if err != nil {
 			return 0, err
 		}
 		ps[i].lastRecordTs = lastRecordTs
-		ps[i].startOffset = lastRecordOffset
+		ps[i].commitOffset = commitOffset
 	}
 
 	// Iterate over the laggiest partition until the lag is less than the cycle duration or none of the partitions has records
@@ -261,11 +261,11 @@ func (b *BlockBuilder) consume(ctx context.Context) (time.Duration, error) {
 			return 0, err
 		}
 		ps[0].lastRecordTs = lastRecordTs
-		ps[0].startOffset = lastRecordOffset
+		ps[0].commitOffset = lastRecordOffset
 	}
 }
 
-func (b *BlockBuilder) consumePartition(ctx context.Context, ps partitionState) (lastTs time.Time, lastOffset int64, err error) {
+func (b *BlockBuilder) consumePartition(ctx context.Context, ps partitionState) (lastTs time.Time, commitOffset int64, err error) {
 	defer func(t time.Time) {
 		metricProcessPartitionSectionDuration.WithLabelValues(strconv.Itoa(int(ps.partition))).Observe(time.Since(t).Seconds())
 	}(time.Now())
@@ -288,7 +288,7 @@ func (b *BlockBuilder) consumePartition(ctx context.Context, ps partitionState) 
 	level.Info(b.logger).Log(
 		"msg", "consuming partition",
 		"partition", ps.partition,
-		"commit_offset", ps.startOffset,
+		"commit_offset", ps.commitOffset,
 		"start_offset", startOffset,
 	)
 
@@ -364,7 +364,7 @@ outer:
 		level.Info(b.logger).Log(
 			"msg", "no data",
 			"partition", ps.partition,
-			"commit_offset", ps.startOffset,
+			"commit_offset", ps.commitOffset,
 			"start_offset", startOffset,
 		)
 		return time.Time{}, -1, nil
@@ -387,11 +387,11 @@ outer:
 	level.Info(b.logger).Log(
 		"msg", "successfully committed offset to kafka",
 		"partition", ps.partition,
-		"last_record", lastRec.Offset,
+		"commit_offset", lastRec.Offset+1,
 		"processed_records", processedRecords,
 	)
 
-	return lastRec.Timestamp, lastRec.Offset, nil
+	return lastRec.Timestamp, lastRec.Offset + 1, nil
 }
 
 func formatActivePartitions(partitions []int32) string {
@@ -439,12 +439,12 @@ func (b *BlockBuilder) fetchPartitions(ctx context.Context, partitions []int32) 
 func (b *BlockBuilder) getPartitionState(partition int32, commits kadm.OffsetResponses, endsOffsets kadm.ListedOffsets) partitionState {
 	var (
 		topic = b.cfg.IngestStorageConfig.Kafka.Topic
-		ps    = partitionState{partition: partition, startOffset: -1, endOffset: -2}
+		ps    = partitionState{partition: partition, commitOffset: -1, endOffset: -2}
 	)
 
 	lastCommit, found := commits.Lookup(topic, partition)
 	if found {
-		ps.startOffset = lastCommit.At
+		ps.commitOffset = lastCommit.At
 	}
 
 	lastRecord, found := endsOffsets.Lookup(topic, partition)

--- a/modules/blockbuilder/blockbuilder_test.go
+++ b/modules/blockbuilder/blockbuilder_test.go
@@ -319,7 +319,7 @@ func TestBlockbuilder_noDoubleConsumption(t *testing.T) {
 
 	// Track commits
 	kafkaCommits := atomic.NewInt32(0)
-	k.ControlKey(kmsg.OffsetCommit, func(req kmsg.Request) (kmsg.Response, error, bool) {
+	k.ControlKey(kmsg.OffsetCommit, func(_ kmsg.Request) (kmsg.Response, error, bool) {
 		kafkaCommits.Inc()
 		return nil, nil, false
 	})

--- a/modules/blockbuilder/blockbuilder_test.go
+++ b/modules/blockbuilder/blockbuilder_test.go
@@ -309,6 +309,69 @@ func TestBlockbuilder_committingFails(t *testing.T) {
 	requireLastCommitEquals(t, ctx, client, producedRecords[len(producedRecords)-1].Offset+1)
 }
 
+// TestBlockbuilder_noDoubleConsumption verifies that records are not consumed twice when there are no more records in the partition.
+// This test ensures that the BlockBuilder correctly commits the offset as lastRec.Offset + 1 instead of just lastRec.Offset.
+func TestBlockbuilder_noDoubleConsumption(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(errors.New("test done")) })
+
+	k, address := testkafka.CreateCluster(t, 1, testTopic)
+
+	// Track commits
+	kafkaCommits := atomic.NewInt32(0)
+	k.ControlKey(kmsg.OffsetCommit, func(req kmsg.Request) (kmsg.Response, error, bool) {
+		kafkaCommits.Inc()
+		return nil, nil, false
+	})
+
+	store := newStore(ctx, t)
+	cfg := blockbuilderConfig(t, address)
+	// Set a shorter consume cycle duration
+	cfg.ConsumeCycleDuration = 500 * time.Millisecond
+
+	client := newKafkaClient(t, cfg.IngestStorageConfig.Kafka)
+
+	// Send a single record
+	producedRecords := sendReq(t, ctx, client)
+	lastRecordOffset := producedRecords[len(producedRecords)-1].Offset
+
+	// Create the block builder
+	b, err := New(cfg, test.NewTestingLogger(t), newPartitionRingReader(), &mockOverrides{}, store)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, b))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, b))
+	})
+
+	// Wait for the record to be consumed and committed
+	require.Eventually(t, func() bool {
+		return kafkaCommits.Load() > 0
+	}, 30*time.Second, time.Second)
+
+	// Check that the offset was committed correctly (lastRec.Offset + 1)
+	requireLastCommitEquals(t, ctx, client, lastRecordOffset+1)
+
+	// Send another record
+	newRecords := sendReq(t, ctx, client)
+	newRecordOffset := newRecords[len(newRecords)-1].Offset
+
+	// Wait for the new record to be consumed and committed
+	require.Eventually(t, func() bool {
+		return kafkaCommits.Load() > 1
+	}, 30*time.Second, time.Second)
+
+	// Verify that the new offset was committed correctly
+	requireLastCommitEquals(t, ctx, client, newRecordOffset+1)
+
+
+	require.Eventually(t, func() bool {
+		return len(store.BlockMetas(util.FakeTenantID)) == 2
+	}, 30*time.Second, time.Second)
+
+	// Verify the total number of traces is correct (1 from each batch)
+	require.Equal(t, 2, countFlushedTraces(store))
+}
+
 func blockbuilderConfig(t testing.TB, address string) Config {
 	cfg := Config{}
 	flagext.DefaultValues(&cfg)

--- a/modules/blockbuilder/blockbuilder_test.go
+++ b/modules/blockbuilder/blockbuilder_test.go
@@ -363,7 +363,6 @@ func TestBlockbuilder_noDoubleConsumption(t *testing.T) {
 	// Verify that the new offset was committed correctly
 	requireLastCommitEquals(t, ctx, client, newRecordOffset+1)
 
-
 	require.Eventually(t, func() bool {
 		return len(store.BlockMetas(util.FakeTenantID)) == 2
 	}, 30*time.Second, time.Second)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Fix offset handling in BlockBuilder to prevent double consumption:

Align the return value of `consumePartition` with the committed offset (`lastRec.Offset + 1`). This ensures consistency between what's committed to Kafka and what's tracked in memory. This prevents records from being processed multiple times within the same consumption cycle.

Taken from https://github.com/grafana/tempo/pull/4750

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`