### PR TITLE
Issue 4578: Fix flaky test

### DIFF
--- a/integration/e2e/api/compression_test.go
+++ b/integration/e2e/api/compression_test.go
@@ -37,9 +37,9 @@ func TestCompression(t *testing.T) {
 	info := tempoUtil.NewTraceInfo(time.Now(), "")
 	require.NoError(t, info.EmitAllBatches(c))
 
-	apiClient := httpclient.New("http://"+tempo.Endpoint(3200), "")
+	apiClient := httpclient.New("http://"+tempo.Endpoint(tempoPort), "")
 
-	apiClientWithCompression := httpclient.NewWithCompression("http://"+tempo.Endpoint(3200), "")
+	apiClientWithCompression := httpclient.NewWithCompression("http://"+tempo.Endpoint(tempoPort), "")
 
 	util.QueryAndAssertTrace(t, apiClient, info)
 	queryAndAssertTraceCompression(t, apiClientWithCompression, info)

--- a/integration/e2e/api/cross_cluster_reads_test.go
+++ b/integration/e2e/api/cross_cluster_reads_test.go
@@ -47,7 +47,7 @@ func TestCrossClusterReads(t *testing.T) {
 	require.NoError(t, tempoDistributorA.WaitSumMetrics(e2e.Equals(util.SpanCount(expected)), "tempo_distributor_spans_received_total"))
 
 	// read from cluster B
-	apiClient := httpclient.New("http://"+tempoQueryFrontendB.Endpoint(3200), "")
+	apiClient := httpclient.New("http://"+tempoQueryFrontendB.Endpoint(tempoPort), "")
 
 	// query an in-memory trace
 	util.QueryAndAssertTrace(t, apiClient, info)

--- a/integration/e2e/api/https_test.go
+++ b/integration/e2e/api/https_test.go
@@ -59,14 +59,14 @@ func TestHTTPS(t *testing.T) {
 	info := tempoUtil.NewTraceInfo(time.Now(), "")
 	require.NoError(t, info.EmitAllBatches(c))
 
-	apiClient := httpclient.New("https://"+tempo.Endpoint(3200), "")
+	apiClient := httpclient.New("https://"+tempo.Endpoint(tempoPort), "")
 
 	// trust bad certs
 	defaultTransport := http.DefaultTransport.(*http.Transport).Clone()
 	defaultTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	apiClient.WithTransport(defaultTransport)
 
-	echoReq, err := http.NewRequest("GET", "https://"+tempo.Endpoint(3200)+"/api/echo", nil)
+	echoReq, err := http.NewRequest("GET", "https://"+tempo.Endpoint(tempoPort)+"/api/echo", nil)
 	require.NoError(t, err)
 	resp, err := apiClient.Do(echoReq)
 	require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestHTTPS(t *testing.T) {
 	util.SearchTraceQLAndAssertTrace(t, apiClient, info)
 
 	creds := credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})
-	grpcClient, err := util.NewSearchGRPCClientWithCredentials(context.Background(), tempo.Endpoint(3200), creds)
+	grpcClient, err := util.NewSearchGRPCClientWithCredentials(context.Background(), tempo.Endpoint(tempoPort), creds)
 	require.NoError(t, err)
 
 	now := time.Now()

--- a/integration/e2e/api/multi_tenant_test.go
+++ b/integration/e2e/api/multi_tenant_test.go
@@ -101,10 +101,10 @@ func testSearch(t *testing.T, tenant string, tenantSize int) {
 	time.Sleep(time.Second * 3)
 
 	// test echo
-	util.AssertEcho(t, "http://"+tempo.Endpoint(3200)+"/api/echo")
+	util.AssertEcho(t, "http://"+tempo.Endpoint(tempoPort)+"/api/echo")
 
 	// client will have testcase tenant id
-	apiClient := httpclient.New("http://"+tempo.Endpoint(3200), tenant)
+	apiClient := httpclient.New("http://"+tempo.Endpoint(tempoPort), tenant)
 
 	// check trace by id
 	resp, err := apiClient.QueryTrace(info.HexID())
@@ -177,7 +177,7 @@ func testSearch(t *testing.T, tenant string, tenantSize int) {
 	grpcCtx, err = user.InjectIntoGRPCRequest(grpcCtx)
 	require.NoError(t, err)
 
-	grpcClient, err := util.NewSearchGRPCClient(grpcCtx, tempo.Endpoint(3200))
+	grpcClient, err := util.NewSearchGRPCClient(grpcCtx, tempo.Endpoint(tempoPort))
 	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second) // ensure that blocklist poller has built the blocklist

--- a/integration/e2e/api/query_range_test.go
+++ b/integration/e2e/api/query_range_test.go
@@ -57,11 +57,11 @@ sendLoop:
 		"{} | compare({status=error})",
 	} {
 		t.Run(query, func(t *testing.T) {
-			callQueryRange(t, tempo.Endpoint(3200), query, debugMode)
+			callQueryRange(t, tempo.Endpoint(tempoPort), query, debugMode)
 		})
 	}
 
-	res := doRequest(t, tempo.Endpoint(3200), "{. a}")
+	res := doRequest(t, tempo.Endpoint(tempoPort), "{. a}")
 	require.Equal(t, 400, res.StatusCode)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Fixes flaky test TestSearchTagValuesV2 by changing sleep to waiting traces to be queryable.

**Which issue(s) this PR fixes**:
Fixes #4578

### How this PR has been tested:
- CI
- run TestSearchTagValuesV2 and TestSearchTagsV2 with -count=10
main branch results: fails
current branch results: passes (checked 3 times for TestSearchTagValuesV2 just in case, 30 runs in total)

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
