### PR TITLE
Fix GOARM64 build option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ ifeq ($(GOARCH),amd64)
 	GO_ENV+= GOAMD64=v2
 endif
 ifeq ($(GOARCH),arm64)
-	GO_ENV+= GOARM64=v8
+	GO_ENV+= GOARM64=v8.0
 endif
 
 GOTEST_OPT?= -race -timeout 25m -count=1 -v


### PR DESCRIPTION
**What this PR does**:

This fixes a bug introduced by https://github.com/grafana/tempo/pull/4755 that caused the CI to fail while building the arm64 docker image ([see here](https://github.com/grafana/tempo/actions/runs/13563657111))

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`