### PR TITLE
Improve CI pipeline

### DIFF
--- a/integration/e2e/api/api_test.go
+++ b/integration/e2e/api/api_test.go
@@ -31,6 +31,10 @@ const (
 
 	queryableTimeout    = 5 * time.Second        // timeout for waiting for traces to be queryable
 	queryableCheckEvery = 100 * time.Millisecond // check every 100ms for traces to be queryable
+
+	// Wait to block flushed to backend, 20 seconds is the complete_block_timeout configuration on all in one, we add
+	// 2s for security.
+	blockFlushTimeout = 22 * time.Second
 )
 
 func TestSearchTagsV2(t *testing.T) {
@@ -249,10 +253,8 @@ func TestSearchTagsV2(t *testing.T) {
 		})
 	}
 
-	// Wait to block flushed to backend, 20 seconds is the complete_block_timeout configuration on all in one, we add
-	// 2s for security.
 	util.CallFlush(t, tempo)
-	time.Sleep(time.Second * 22)
+	time.Sleep(blockFlushTimeout)
 	util.CallFlush(t, tempo)
 
 	// test metrics
@@ -428,10 +430,8 @@ func TestSearchTagValuesV2(t *testing.T) {
 		})
 	}
 
-	// Wait to block flushed to backend, 20 seconds is the complete_block_timeout configuration on all in one, we add
-	// 2s for security.
 	util.CallFlush(t, tempo)
-	time.Sleep(time.Second * 22)
+	time.Sleep(blockFlushTimeout)
 	util.CallFlush(t, tempo)
 
 	// test metrics
@@ -482,7 +482,7 @@ func TestSearchTags(t *testing.T) {
 	callSearchTagsAndAssert(t, tempo, searchTagsResponse{TagNames: []string{"service.name", "x", "xx"}}, 0, 0)
 
 	util.CallFlush(t, tempo)
-	time.Sleep(time.Second * 30)
+	time.Sleep(blockFlushTimeout)
 	util.CallFlush(t, tempo)
 
 	// test metrics
@@ -523,7 +523,7 @@ func TestSearchTagValues(t *testing.T) {
 	callSearchTagValuesAndAssert(t, tempo, "service.name", searchTagValuesResponse{TagValues: []string{"my-service"}}, 0, 0)
 
 	util.CallFlush(t, tempo)
-	time.Sleep(time.Second * 22)
+	time.Sleep(blockFlushTimeout)
 	util.CallFlush(t, tempo)
 
 	require.NoError(t, tempo.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_blocks_flushed_total"))

--- a/integration/e2e/api/api_test.go
+++ b/integration/e2e/api/api_test.go
@@ -32,9 +32,9 @@ const (
 	queryableTimeout    = 5 * time.Second        // timeout for waiting for traces to be queryable
 	queryableCheckEvery = 100 * time.Millisecond // check every 100ms for traces to be queryable
 
-	// Wait to block flushed to backend, 20 seconds is the complete_block_timeout configuration on all in one, we add
-	// 2s for security.
-	blockFlushTimeout = 22 * time.Second
+	// Wait to block flushed to backend, 5 seconds is the complete_block_timeout configuration on all in one, we add
+	// 100ms for security.
+	blockFlushTimeout = 5*time.Second + 100*time.Millisecond
 )
 
 func TestSearchTagsV2(t *testing.T) {

--- a/integration/e2e/api/multi_tenant_test.go
+++ b/integration/e2e/api/multi_tenant_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/grafana/dskit/user"
 	"github.com/grafana/e2e"
 	"github.com/grafana/tempo/integration/util"
@@ -35,23 +36,32 @@ type traceStringsMap struct {
 }
 
 func TestSingleTenantSearch(t *testing.T) {
+	t.Parallel()
 	testSearch(t, "test", 1)
 }
 
 func TestWildCardTenantSearch(t *testing.T) {
+	t.Parallel()
 	testSearch(t, "*", 1)
 }
 
 func TestTwoTenantsSearch(t *testing.T) {
+	t.Parallel()
 	testSearch(t, "test|test2", 2)
 }
 
 func TestThreeTenantsSearch(t *testing.T) {
+	t.Parallel()
 	testSearch(t, "test|test2|test3", 3)
 }
 
+func generateNetworkName() string {
+	uuid := uuid.New()
+	return uuid.String()
+}
+
 func testSearch(t *testing.T, tenant string, tenantSize int) {
-	s, err := e2e.NewScenario("tempo_e2e")
+	s, err := e2e.NewScenario(generateNetworkName())
 	require.NoError(t, err)
 	defer s.Close()
 

--- a/integration/e2e/config-encodings.tmpl.yaml
+++ b/integration/e2e/config-encodings.tmpl.yaml
@@ -32,6 +32,7 @@ ingester:
         store: inmemory
       replication_factor: 1
     final_sleep: 0s
+    min_ready_duration: 1s
   trace_idle_period: 1s
   max_block_duration: 5s
   complete_block_timeout: 5s

--- a/integration/e2e/config-limits-429.yaml
+++ b/integration/e2e/config-limits-429.yaml
@@ -28,6 +28,7 @@ ingester:
         store: inmemory
       replication_factor: 1
     final_sleep: 0s
+    min_ready_duration: 1s
   trace_idle_period: 3600s
 
 query_frontend:

--- a/integration/e2e/config-limits-partial-success.yaml
+++ b/integration/e2e/config-limits-partial-success.yaml
@@ -25,6 +25,7 @@ ingester:
         store: inmemory
       replication_factor: 1
     final_sleep: 0s
+    min_ready_duration: 1s
   trace_idle_period: 3600s
 
 storage:

--- a/integration/e2e/config-limits-query.yaml
+++ b/integration/e2e/config-limits-query.yaml
@@ -33,6 +33,7 @@ ingester:
         store: inmemory
       replication_factor: 1
     final_sleep: 0s
+    min_ready_duration: 1s
   trace_idle_period: 1ms
   flush_check_period: 1ms
   complete_block_timeout: 10s

--- a/integration/e2e/config-limits.yaml
+++ b/integration/e2e/config-limits.yaml
@@ -34,6 +34,7 @@ ingester:
         store: inmemory
       replication_factor: 1
     final_sleep: 0s
+    min_ready_duration: 1s
   trace_idle_period: 3600s
 
 storage:

--- a/integration/e2e/config-metrics-generator-targetinfo.yaml
+++ b/integration/e2e/config-metrics-generator-targetinfo.yaml
@@ -14,6 +14,7 @@ ingester:
   lifecycler:
     ring:
       replication_factor: 1
+    min_ready_duration: 1s
 
 metrics_generator:
   processor:

--- a/integration/e2e/config-metrics-generator.yaml
+++ b/integration/e2e/config-metrics-generator.yaml
@@ -12,6 +12,7 @@ distributor:
 
 ingester:
   lifecycler:
+    min_ready_duration: 1s
     ring:
       replication_factor: 1
 

--- a/integration/e2e/deployments/config-all-in-one-azurite.yaml
+++ b/integration/e2e/deployments/config-all-in-one-azurite.yaml
@@ -23,6 +23,7 @@ ingester:
         store: inmemory
       replication_factor: 1
     final_sleep: 0s
+    min_ready_duration: 1s
   trace_idle_period: 1s
   max_block_duration: 5s
   complete_block_timeout: 5s

--- a/integration/e2e/deployments/config-all-in-one-gcs.yaml
+++ b/integration/e2e/deployments/config-all-in-one-gcs.yaml
@@ -24,6 +24,7 @@ ingester:
         store: inmemory
       replication_factor: 1
     final_sleep: 0s
+    min_ready_duration: 1s
   trace_idle_period: 1s
   max_block_duration: 5s
   complete_block_timeout: 5s

--- a/integration/e2e/deployments/config-all-in-one-local.yaml
+++ b/integration/e2e/deployments/config-all-in-one-local.yaml
@@ -39,7 +39,7 @@ ingester:
   trace_idle_period: 1s
   max_block_bytes: 1
   max_block_duration: 2s
-  complete_block_timeout: 20s
+  complete_block_timeout: 5s
   flush_check_period: 1s
 
 storage:

--- a/integration/e2e/deployments/config-all-in-one-local.yaml
+++ b/integration/e2e/deployments/config-all-in-one-local.yaml
@@ -35,6 +35,7 @@ ingester:
         store: inmemory
       replication_factor: 1
     final_sleep: 0s
+    min_ready_duration: 1s
   trace_idle_period: 1s
   max_block_bytes: 1
   max_block_duration: 2s

--- a/integration/e2e/deployments/config-all-in-one-s3.yaml
+++ b/integration/e2e/deployments/config-all-in-one-s3.yaml
@@ -24,6 +24,7 @@ ingester:
         store: inmemory
       replication_factor: 1
     final_sleep: 0s
+    min_ready_duration: 1s
   trace_idle_period: 1s
   max_block_duration: 5s
   complete_block_timeout: 5s

--- a/integration/e2e/deployments/config-microservices.tmpl.yaml
+++ b/integration/e2e/deployments/config-microservices.tmpl.yaml
@@ -14,6 +14,7 @@ ingester:
       kvstore: {{ .KVStore }}
       replication_factor: 3
     heartbeat_period: 100ms
+    min_ready_duration: 1s
   trace_idle_period: 2s
   max_block_duration: 2s
   complete_block_timeout: 5s

--- a/integration/e2e/deployments/config-scalable-single-binary.yaml
+++ b/integration/e2e/deployments/config-scalable-single-binary.yaml
@@ -17,6 +17,7 @@ ingester:
         store: memberlist
       replication_factor: 3
     heartbeat_period: 100ms
+    min_ready_duration: 1s
   max_block_bytes: 1
   max_block_duration: 2s
   flush_check_period: 1s

--- a/integration/e2e/ingest/config-kafka.yaml
+++ b/integration/e2e/ingest/config-kafka.yaml
@@ -32,6 +32,7 @@ ingester:
         store: inmemory
       replication_factor: 1
     final_sleep: 0s
+    min_ready_duration: 1s
   trace_idle_period: 1s
   max_block_bytes: 1
   max_block_duration: 2s

--- a/modules/frontend/queue/queue_test.go
+++ b/modules/frontend/queue/queue_test.go
@@ -29,6 +29,7 @@ func (r *mockRequest) Weight() int {
 }
 
 func TestGetNextForQuerierOneUser(t *testing.T) {
+	t.Parallel()
 	messages := 10
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -58,6 +59,7 @@ func TestGetNextForQuerierOneUser(t *testing.T) {
 }
 
 func TestGetNextForQuerierRandomUsers(t *testing.T) {
+	t.Parallel()
 	messages := 100
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -86,6 +88,7 @@ func TestGetNextForQuerierRandomUsers(t *testing.T) {
 }
 
 func TestGetNextBatches(t *testing.T) {
+	t.Parallel()
 	messages := 10
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/modules/generator/storage/instance_test.go
+++ b/modules/generator/storage/instance_test.go
@@ -32,6 +32,7 @@ import (
 // Verify basic functionality like sending metrics and exemplars, buffering and retrying failed
 // requests.
 func TestInstance(t *testing.T) {
+	t.Parallel()
 	var err error
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
 
@@ -104,6 +105,7 @@ func TestInstance(t *testing.T) {
 
 // Verify multiple instances function next to each other, don't trample over each other and are isolated.
 func TestInstance_multiTenancy(t *testing.T) {
+	t.Parallel()
 	var err error
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
 

--- a/modules/ingester/instance_search_test.go
+++ b/modules/ingester/instance_search_test.go
@@ -297,6 +297,7 @@ func testSearchTagsAndValues(t *testing.T, ctx context.Context, i *instance, tag
 }
 
 func TestInstanceSearchTagAndValuesV2(t *testing.T) {
+	t.Parallel()
 	i, _ := defaultInstance(t)
 
 	// add dummy search data
@@ -787,6 +788,7 @@ func TestWALBlockDeletedDuringSearch(t *testing.T) {
 }
 
 func TestInstanceSearchMetrics(t *testing.T) {
+	t.Parallel()
 	i, _ := defaultInstance(t)
 
 	// This matches the encoding for live traces, since

--- a/modules/ingester/instance_test.go
+++ b/modules/ingester/instance_test.go
@@ -781,16 +781,16 @@ func BenchmarkInstanceFindTraceByIDFromCompleteBlock(b *testing.B) {
 }
 
 func BenchmarkInstanceSearchCompleteParquet(b *testing.B) {
-	benchmarkInstanceSearch(b)
+	benchmarkInstanceSearch(b, 1000, 100)
 }
 
 func TestInstanceSearchCompleteParquet(t *testing.T) {
-	benchmarkInstanceSearch(t)
+	benchmarkInstanceSearch(t, 100, 10)
 }
 
-func benchmarkInstanceSearch(b testing.TB) {
+func benchmarkInstanceSearch(b testing.TB, writes int, reads int) {
 	instance, _ := defaultInstance(b)
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < writes; i++ {
 		request := makeRequest(nil)
 		response := instance.PushBytesRequest(context.Background(), request)
 		errored, _, _ := CheckPushBytesError(response)
@@ -823,7 +823,7 @@ func benchmarkInstanceSearch(b testing.TB) {
 		return
 	}
 
-	for i := 0; i < 100; i++ {
+	for i := 0; i < reads; i++ {
 		resp, err := instance.SearchTags(ctx, "")
 		require.NoError(b, err)
 		require.NotNil(b, resp)

--- a/tempodb/backend/azure/azure_test.go
+++ b/tempodb/backend/azure/azure_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestCredentials(t *testing.T) {
+	t.Parallel()
 	_, _, _, err := New(&Config{})
 	require.Error(t, err)
 

--- a/tempodb/backend/s3/s3_test.go
+++ b/tempodb/backend/s3/s3_test.go
@@ -54,6 +54,7 @@ type ec2RoleCredRespBody struct {
 }
 
 func TestCredentials(t *testing.T) {
+	t.Parallel()
 	cwd, err := os.Getwd()
 	assert.NoError(t, err)
 

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -73,6 +73,7 @@ func TestCompactionRoundtrip(t *testing.T) {
 	for _, enc := range encoding.AllEncodings() {
 		version := enc.Version()
 		t.Run(version, func(t *testing.T) {
+			t.Parallel()
 			testCompactionRoundtrip(t, version)
 		})
 	}

--- a/tempodb/encoding/v2/streaming_block_test.go
+++ b/tempodb/encoding/v2/streaming_block_test.go
@@ -131,6 +131,7 @@ func TestStreamingBlockAddObject(t *testing.T) {
 }
 
 func TestStreamingBlockAll(t *testing.T) {
+	t.Parallel()
 	for i := 0; i < 10; i++ {
 		indexDownsampleBytes := rng.Intn(5000) + 1000
 		bloomFP := float64(rng.Intn(99)+1) / 100.0

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -43,9 +43,11 @@ type runnerFn func(*testing.T, *tempopb.Trace, *tempopb.TraceSearchMetadata, []*
 const attributeWithTerminalChars = `{ } ( ) = ~ ! < > & | ^`
 
 func TestSearchCompleteBlock(t *testing.T) {
+	t.Parallel()
 	for _, v := range encoding.AllEncodings() {
 		vers := v.Version()
 		t.Run(vers, func(t *testing.T) {
+			t.Parallel()
 			runCompleteBlockSearchTest(t, vers,
 				searchRunner,
 				traceQLRunner,

--- a/tempodb/tempodb_test.go
+++ b/tempodb/tempodb_test.go
@@ -484,6 +484,7 @@ func TestIncludeCompactedBlock(t *testing.T) {
 }
 
 func TestSearchCompactedBlocks(t *testing.T) {
+	t.Parallel()
 	r, w, c, _ := testConfig(t, backend.EncLZ4_256k, time.Hour)
 
 	err := c.EnableCompaction(context.Background(), &CompactorConfig{
@@ -566,6 +567,7 @@ func TestCompleteBlock(t *testing.T) {
 	for _, from := range encoding.AllEncodings() {
 		for _, to := range encoding.AllEncodings() {
 			t.Run(fmt.Sprintf("%s->%s", from.Version(), to.Version()), func(t *testing.T) {
+				t.Parallel()
 				testCompleteBlock(t, from.Version(), to.Version())
 			})
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does:
### E2E
1. Decreases `ingester.lifecycler.min_ready_duration` to 1 second for e2e to improve startup time
2. Decreases `complete_block_timeout` to speedup integration/e2e/api/api_test.go
3. Parallelised `integration/e2e/api/multi_tenant_test.go` by making network name for each test unique

Main branch pipeline duration:
<img width="207" alt="Pasted image 20250227145104" src="https://github.com/user-attachments/assets/8c29b8f1-67a5-4c2d-8f6c-cfd19d445386" />

After fix 1:
<img width="212" alt="Pasted image 20250227145117" src="https://github.com/user-attachments/assets/be4fa153-917c-4f17-9fed-0bbdd4bb4034" />

After fix 1 and 2:
<img width="221" alt="image" src="https://github.com/user-attachments/assets/2aa5f755-0bff-4eca-8026-8420f5279bdf" />

All fixes:
<img width="193" alt="image" src="https://github.com/user-attachments/assets/54769e40-4f7a-4c21-90bf-fabeb53f330b" />

### Unit tests
1. Parallelise slowest unit tests
2. TestInstanceSearchCompleteParquet took 5 minutes. Made it less heavy, now it takes less than a second.

Main branch pipeline duration:
<img width="194" alt="image" src="https://github.com/user-attachments/assets/d3eacb64-b438-4c10-857a-a8cd09e2b148" />


All fixes:
<img width="198" alt="image" src="https://github.com/user-attachments/assets/c25df534-df13-4aae-8b5b-55ece25e7d70" />

### Total result
CI duration went from 16 minutes to 12 minutes (25% improvement).

## Which issue(s) this PR fixes:
\-

## How this PR has been tested:
1. Some tests and files I run with -count=10 to be sure they are stable
2. A few empty commits to check stability. Over ~10 runs, failed `TestIngesterRequests` once. [link](https://github.com/grafana/tempo/actions/runs/13588700963/job/37989359038). As I did not touch it, I assumed it was a false fail.

## Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

