### PR TITLE
[Rhythm] Block-builder metrics and code cleanup

### DIFF
--- a/modules/blockbuilder/live_traces_iter.go
+++ b/modules/blockbuilder/live_traces_iter.go
@@ -1,0 +1,158 @@
+package blockbuilder
+
+import (
+	"bytes"
+	"context"
+	"slices"
+	"sync"
+
+	"github.com/grafana/tempo/pkg/livetraces"
+	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/grafana/tempo/tempodb/encoding/common"
+)
+
+type entry struct {
+	id   common.ID
+	hash uint64
+}
+
+type chEntry struct {
+	id  common.ID
+	tr  *tempopb.Trace
+	err error
+}
+
+// liveTracesIter iterates through a liveTraces proto bytes map, exposing
+// a common.Iterator interface. Uses channel internally so that unmarshaling
+// can be done concurrently with the consumption of the iterator.
+// Tracks the min/max timestamps seen across all traces that can be accessed
+// once all traces are iterated (unmarshaled), since this can't be known upfront.
+type liveTracesIter struct {
+	mtx        sync.Mutex
+	liveTraces *livetraces.LiveTraces[[]byte]
+	ch         chan []chEntry
+	chBuf      []chEntry
+	cancel     func()
+	start, end uint64
+}
+
+func newLiveTracesIter(liveTraces *livetraces.LiveTraces[[]byte]) *liveTracesIter {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	l := &liveTracesIter{
+		liveTraces: liveTraces,
+		ch:         make(chan []chEntry, 1),
+		cancel:     cancel,
+	}
+
+	go l.iter(ctx)
+
+	return l
+}
+
+func (i *liveTracesIter) Next(ctx context.Context) (common.ID, *tempopb.Trace, error) {
+	if len(i.chBuf) == 0 {
+		select {
+		case entries, ok := <-i.ch:
+			if !ok {
+				return nil, nil, nil
+			}
+			i.chBuf = entries
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		}
+	}
+
+	// Pop next entry
+	if len(i.chBuf) > 0 {
+		entry := i.chBuf[0]
+		i.chBuf = i.chBuf[1:]
+		return entry.id, entry.tr, entry.err
+	}
+
+	// Channel is open but buffer is empty?
+	return nil, nil, nil
+}
+
+func (i *liveTracesIter) iter(ctx context.Context) {
+	i.mtx.Lock()
+	defer i.mtx.Unlock()
+	defer close(i.ch)
+
+	// Get the list of all traces sorted by ID
+	entries := make([]entry, 0, len(i.liveTraces.Traces))
+	for hash, t := range i.liveTraces.Traces {
+		entries = append(entries, entry{t.ID, hash})
+	}
+	slices.SortFunc(entries, func(a, b entry) int {
+		return bytes.Compare(a.id, b.id)
+	})
+
+	// Begin sending to channel in chunks to reduce channel overhead.
+	seq := slices.Chunk(entries, 10)
+	for entries := range seq {
+		output := make([]chEntry, 0, len(entries))
+
+		for _, e := range entries {
+
+			entry := i.liveTraces.Traces[e.hash]
+
+			tr := new(tempopb.Trace)
+
+			for _, b := range entry.Batches {
+				// This unmarshal appends the batches onto the existing tempopb.Trace
+				// so we don't need to allocate another container temporarily
+				err := tr.Unmarshal(b)
+				if err != nil {
+					i.ch <- []chEntry{{err: err}}
+					return
+				}
+			}
+
+			// Update block timestamp bounds
+			for _, b := range tr.ResourceSpans {
+				for _, ss := range b.ScopeSpans {
+					for _, s := range ss.Spans {
+						if i.start == 0 || s.StartTimeUnixNano < i.start {
+							i.start = s.StartTimeUnixNano
+						}
+						if s.EndTimeUnixNano > i.end {
+							i.end = s.EndTimeUnixNano
+						}
+					}
+				}
+			}
+
+			tempopb.ReuseByteSlices(entry.Batches)
+			delete(i.liveTraces.Traces, e.hash)
+
+			output = append(output, chEntry{
+				id:  entry.ID,
+				tr:  tr,
+				err: nil,
+			})
+		}
+
+		select {
+		case i.ch <- output:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// MinMaxTimestamps returns the earliest start, and latest end span timestamps,
+// which can't be known until all contents are unmarshaled. The iterator must
+// be exhausted before this can be accessed.
+func (i *liveTracesIter) MinMaxTimestamps() (uint64, uint64) {
+	i.mtx.Lock()
+	defer i.mtx.Unlock()
+
+	return i.start, i.end
+}
+
+func (i *liveTracesIter) Close() {
+	i.cancel()
+}
+
+var _ common.Iterator = (*liveTracesIter)(nil)

--- a/modules/blockbuilder/partition_writer.go
+++ b/modules/blockbuilder/partition_writer.go
@@ -16,6 +16,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const flushConcurrency = 4
+
 type partitionSectionWriter interface {
 	pushBytes(ts time.Time, tenant string, req *tempopb.PushBytesRequest) error
 	flush(ctx context.Context, store tempodb.Writer) error

--- a/modules/blockbuilder/tenant_store.go
+++ b/modules/blockbuilder/tenant_store.go
@@ -1,10 +1,7 @@
 package blockbuilder
 
 import (
-	"bytes"
 	"context"
-	"slices"
-	"sync"
 	"time"
 
 	"github.com/go-kit/log"
@@ -18,7 +15,6 @@ import (
 	"github.com/grafana/tempo/tempodb"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding"
-	"github.com/grafana/tempo/tempodb/encoding/common"
 	"github.com/grafana/tempo/tempodb/wal"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -34,7 +30,6 @@ var metricBlockBuilderFlushedBlocks = promauto.NewCounterVec(
 
 const (
 	reasonTraceTooLarge = "trace_too_large"
-	flushConcurrency    = 4
 )
 
 type tenantStore struct {
@@ -191,144 +186,3 @@ func (s *tenantStore) adjustTimeRangeForSlack(start, end time.Time) (time.Time, 
 
 	return start, end
 }
-
-type entry struct {
-	id   common.ID
-	hash uint64
-}
-
-type chEntry struct {
-	id  common.ID
-	tr  *tempopb.Trace
-	err error
-}
-
-type liveTracesIter struct {
-	mtx        sync.Mutex
-	liveTraces *livetraces.LiveTraces[[]byte]
-	ch         chan []chEntry
-	chBuf      []chEntry
-	cancel     func()
-	start, end uint64
-}
-
-func newLiveTracesIter(liveTraces *livetraces.LiveTraces[[]byte]) *liveTracesIter {
-	ctx, cancel := context.WithCancel(context.Background())
-
-	l := &liveTracesIter{
-		liveTraces: liveTraces,
-		ch:         make(chan []chEntry, 1),
-		cancel:     cancel,
-	}
-
-	go l.iter(ctx)
-
-	return l
-}
-
-func (i *liveTracesIter) Next(ctx context.Context) (common.ID, *tempopb.Trace, error) {
-	if len(i.chBuf) == 0 {
-		select {
-		case entries, ok := <-i.ch:
-			if !ok {
-				return nil, nil, nil
-			}
-			i.chBuf = entries
-		case <-ctx.Done():
-			return nil, nil, ctx.Err()
-		}
-	}
-
-	// Pop next entry
-	if len(i.chBuf) > 0 {
-		entry := i.chBuf[0]
-		i.chBuf = i.chBuf[1:]
-		return entry.id, entry.tr, entry.err
-	}
-
-	// Channel is open but buffer is empty?
-	return nil, nil, nil
-}
-
-func (i *liveTracesIter) iter(ctx context.Context) {
-	i.mtx.Lock()
-	defer i.mtx.Unlock()
-	defer close(i.ch)
-
-	// Get the list of all traces sorted by ID
-	entries := make([]entry, 0, len(i.liveTraces.Traces))
-	for hash, t := range i.liveTraces.Traces {
-		entries = append(entries, entry{t.ID, hash})
-	}
-	slices.SortFunc(entries, func(a, b entry) int {
-		return bytes.Compare(a.id, b.id)
-	})
-
-	// Begin sending to channel in chunks to reduce channel overhead.
-	seq := slices.Chunk(entries, 10)
-	for entries := range seq {
-		output := make([]chEntry, 0, len(entries))
-
-		for _, e := range entries {
-
-			entry := i.liveTraces.Traces[e.hash]
-
-			tr := new(tempopb.Trace)
-
-			for _, b := range entry.Batches {
-				// This unmarshal appends the batches onto the existing tempopb.Trace
-				// so we don't need to allocate another container temporarily
-				err := tr.Unmarshal(b)
-				if err != nil {
-					i.ch <- []chEntry{{err: err}}
-					return
-				}
-			}
-
-			// Update block timestamp bounds
-			for _, b := range tr.ResourceSpans {
-				for _, ss := range b.ScopeSpans {
-					for _, s := range ss.Spans {
-						if i.start == 0 || s.StartTimeUnixNano < i.start {
-							i.start = s.StartTimeUnixNano
-						}
-						if s.EndTimeUnixNano > i.end {
-							i.end = s.EndTimeUnixNano
-						}
-					}
-				}
-			}
-
-			tempopb.ReuseByteSlices(entry.Batches)
-			delete(i.liveTraces.Traces, e.hash)
-
-			output = append(output, chEntry{
-				id:  entry.ID,
-				tr:  tr,
-				err: nil,
-			})
-		}
-
-		select {
-		case i.ch <- output:
-		case <-ctx.Done():
-			return
-		}
-	}
-}
-
-// MinMaxTimestamps returns the earliest start, and latest end span timestamps,
-// which can't be known until all contents are unmarshaled. The iterated must
-// be exhausted before this can be accessed.
-func (i *liveTracesIter) MinMaxTimestamps() (uint64, uint64) {
-	i.mtx.Lock()
-	defer i.mtx.Unlock()
-
-	return i.start, i.end
-}
-
-func (i *liveTracesIter) Close() {
-	i.cancel()
-}
-
-var _ common.Iterator = (*liveTracesIter)(nil)

--- a/modules/blockbuilder/tenant_store_test.go
+++ b/modules/blockbuilder/tenant_store_test.go
@@ -147,9 +147,10 @@ func TestTenantStoreEndToEndHistoricalData(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			meta := writeHistoricalData(t, count, startTime, tc.cycleDuration, tc.slackDuration, tc.traceStart, tc.traceEnd)
 
-			// NOTE - Truncate(0) drops the monotonic clock value and makes comparison work.
-			require.Equal(t, tc.expectedStartTime.Truncate(0), meta.StartTime)
-			require.Equal(t, tc.expectedEndTime.Truncate(0), meta.EndTime)
+			// NOTE - Roundtripped times from the meta json don't include the monotonic clock value,
+			//        therefore we do the same on the test values by calling Truncate(0).
+			require.Equal(t, tc.expectedStartTime.Truncate(0).UTC(), meta.StartTime.UTC())
+			require.Equal(t, tc.expectedEndTime.Truncate(0).UTC(), meta.EndTime.UTC())
 
 			// Verify other properties of the block
 			require.EqualValues(t, count, meta.TotalObjects)

--- a/modules/generator/generator_kafka.go
+++ b/modules/generator/generator_kafka.go
@@ -84,7 +84,7 @@ func (g *Generator) readKafka(ctx context.Context) error {
 	fetches.EachPartition(func(p kgo.FetchTopicPartition) {
 		if len(p.Records) > 0 {
 			lag := time.Since(p.Records[0].Timestamp)
-			ingest.SetPartitionLagSeconds(g.cfg.Ingest.Kafka.ConsumerGroup, int(p.Partition), lag)
+			ingest.SetPartitionLagSeconds(g.cfg.Ingest.Kafka.ConsumerGroup, p.Partition, lag)
 		}
 	})
 
@@ -177,6 +177,8 @@ func (g *Generator) handlePartitionsRevoked(partitions map[string][]int32) {
 	sort.Slice(revoked, func(i, j int) bool { return revoked[i] < revoked[j] })
 	// Remove revoked partitions
 	g.assignedPartitions = revokePartitions(g.assignedPartitions, revoked)
+
+	ingest.ResetLagMetricsForRevokedPartitions(g.cfg.Ingest.Kafka.ConsumerGroup, revoked)
 }
 
 // Helper function to format []int32 slice

--- a/pkg/ingest/metrics.go
+++ b/pkg/ingest/metrics.go
@@ -15,26 +15,33 @@ import (
 	"github.com/twmb/franz-go/pkg/kerr"
 )
 
+const (
+	labelGroup     = "group"
+	labelPartition = "partition"
+)
+
 var (
 	metricPartitionLag = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "tempo",
 		Subsystem: "ingest",
 		Name:      "group_partition_lag",
 		Help:      "Lag of a partition.",
-	}, []string{"group", "partition"})
+	}, []string{labelGroup, labelPartition})
 
 	metricPartitionLagSeconds = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "tempo",
 		Subsystem: "ingest",
 		Name:      "group_partition_lag_seconds",
 		Help:      "Lag of a partition in seconds.",
-	}, []string{"group", "partition"})
+	}, []string{labelGroup, labelPartition})
 )
 
 // ExportPartitionLagMetrics in a background goroutine by periodically querying Kafka state
 // for the assigned and active partitions.  This exports the lag metric in number of records
 // which is different than the lag metric for age.
-// TODO - Need to reset this metric when partitions are revoked so that it doesn't continue to export stale data.
+// Call ResetLagMetricsForRevokedPartitions when partitions are revoked to prevent exporting
+// stale data. For efficiency this is not detected automatically from changes inthe assigned
+// partition callback.
 func ExportPartitionLagMetrics(ctx context.Context, admClient *kadm.Client, log log.Logger, cfg Config, getAssignedActivePartitions func() []int32) {
 	go func() {
 		var (
@@ -66,9 +73,19 @@ func ExportPartitionLagMetrics(ctx context.Context, admClient *kadm.Client, log 
 
 // SetPartitionLagSeconds is similar to the auto exported lag, except it is in real clock seconds
 // which can only be known after the record is read from the queue, therefore it is set by the caller.
-// TODO - Need to reset this metric when partitions are revoked so that it doesn't continue to export stale data.
-func SetPartitionLagSeconds(group string, partition int, lag time.Duration) {
-	metricPartitionLagSeconds.WithLabelValues(group, strconv.Itoa(partition)).Set(lag.Seconds())
+// Call ResetLagMetricsForRevokedPartitions when partitions are revoked to prevent exporting stale data.
+func SetPartitionLagSeconds(group string, partition int32, lag time.Duration) {
+	metricPartitionLagSeconds.WithLabelValues(group, strconv.Itoa(int(partition))).Set(lag.Seconds())
+}
+
+// ResetLagMetricsForRevokedPartitions should be called when a partition is revoked to prevent
+// exporting stale metrics for partitions that the application no longer owns.
+func ResetLagMetricsForRevokedPartitions(group string, partitions []int32) {
+	for _, p := range partitions {
+		l := strconv.Itoa(int(p))
+		metricPartitionLag.DeletePartialMatch(prometheus.Labels{labelGroup: group, labelPartition: l})
+		metricPartitionLagSeconds.DeletePartialMatch(prometheus.Labels{labelGroup: group, labelPartition: l})
+	}
 }
 
 // getGroupLag is similar to `kadm.Client.Lag` but works when the group doesn't have live participants.

--- a/pkg/util/test/req.go
+++ b/pkg/util/test/req.go
@@ -413,6 +413,7 @@ func MakeTraceWithTags(traceID []byte, service string, intValue int64) *tempopb.
 }
 
 func MakePushBytesRequest(t testing.TB, requests int, traceID []byte, startTime, endTime uint64) *tempopb.PushBytesRequest {
+	traceID = ValidTraceID(traceID)
 	trace := MakeTraceWithTimeRange(requests, traceID, startTime, endTime)
 	b, err := proto.Marshal(trace)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Some small cleanup. This came about while writing tenantStore tests to verify handling of historical data, and decided to get a few more things:

* Block-builder move to the common `partition_lag_seconds` metric in pkg/ingest
* Clear old metrics when partitions are revoked
* Record lag at the end of the block builder loop so that we can see both the high and low-water marks, and fix to record zero lag when it knows the partition is caught up.
* Reorganize liveTracesIter and other consts

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`