### PR TITLE
Fix query range frontend caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [BUGFIX] Fix memcached settings for docker compose example [#4346](https://github.com/grafana/tempo/pull/4695) (@ruslan-mikhailov)
 * [BUGFIX] Fix setting processors in user configurations overrides via API [#4741](https://github.com/grafana/tempo/pull/4741) (@ruslan-mikhailov)
 * [BUGFIX] Fix panic on startup [#4744](https://github.com/grafana/tempo/pull/4744) (@ruslan-mikhailov)
-* [BUGFIX] Correctly cache frontend jobs for query range (TraceQL Metrics). [4771](https://github.com/grafana/tempo/pull/4771) (@joe-elliott)
+* [BUGFIX] Correctly cache frontend jobs for query range (TraceQL Metrics). [#4771](https://github.com/grafana/tempo/pull/4771) (@joe-elliott)
 
 # v2.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [BUGFIX] Fix memcached settings for docker compose example [#4346](https://github.com/grafana/tempo/pull/4695) (@ruslan-mikhailov)
 * [BUGFIX] Fix setting processors in user configurations overrides via API [#4741](https://github.com/grafana/tempo/pull/4741) (@ruslan-mikhailov)
 * [BUGFIX] Fix panic on startup [#4744](https://github.com/grafana/tempo/pull/4744) (@ruslan-mikhailov)
+* [BUGFIX] Correctly cache frontend jobs for query range (TraceQL Metrics). [4771](https://github.com/grafana/tempo/pull/4771) (@joe-elliott)
 
 # v2.7.1
 

--- a/modules/frontend/metrics_query_range_handler_test.go
+++ b/modules/frontend/metrics_query_range_handler_test.go
@@ -1,7 +1,12 @@
 package frontend
 
 import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -9,8 +14,11 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/grafana/dskit/user"
 	"github.com/grafana/tempo/pkg/api"
+	"github.com/grafana/tempo/pkg/cache"
 	"github.com/grafana/tempo/pkg/tempopb"
 	v1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	"github.com/grafana/tempo/pkg/util/test"
+	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/stretchr/testify/require"
 )
 
@@ -100,4 +108,99 @@ func TestQueryRangeHandlerSucceeds(t *testing.T) {
 	err := jsonpb.Unmarshal(httpResp.Body, actualResp)
 	require.NoError(t, err)
 	require.Equal(t, expectedResp, actualResp)
+}
+
+func TestQueryRangeAccessesCache(t *testing.T) {
+	tenant := "foo"
+	meta := &backend.BlockMeta{
+		StartTime:         time.Unix(15, 0),
+		EndTime:           time.Unix(16, 0),
+		Size_:             defaultTargetBytesPerRequest,
+		TotalRecords:      1,
+		BlockID:           backend.MustParse("00000000-0000-0000-0000-000000000123"),
+		ReplicationFactor: 1,
+	}
+	retResp := &tempopb.QueryRangeResponse{
+		Metrics: &tempopb.SearchMetrics{
+			InspectedTraces: 1,
+			InspectedBytes:  1,
+		},
+		Series: []*tempopb.TimeSeries{
+			{
+				PromLabels: "foo",
+				Labels: []v1.KeyValue{
+					{Key: "foo", Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "bar"}}},
+				},
+				Samples: []tempopb.Sample{
+					{
+						TimestampMs: 1200_000,
+						Value:       2,
+					},
+					{
+						TimestampMs: 1100_000,
+						Value:       1,
+					},
+				},
+			},
+		},
+	}
+
+	rdr := &mockReader{
+		metas: []*backend.BlockMeta{meta},
+	}
+
+	// setup mock cache
+	c := test.NewMockClient()
+	p := test.NewMockProvider()
+	err := p.AddCache(cache.RoleFrontendSearch, c)
+	require.NoError(t, err)
+	f := frontendWithSettings(t, &mockRoundTripper{
+		responseFn: func() proto.Message {
+			return retResp
+		},
+	}, rdr, nil, p)
+
+	// setup query
+	step := 1000000000
+	query := "{} | rate()"
+	hash := hashForQueryRangeRequest(&tempopb.QueryRangeRequest{Query: query, Step: uint64(step)})
+	start := uint32(10)
+	end := uint32(20)
+	cacheKey := queryRangeCacheKey(tenant, hash, int64(start), int64(end), meta, step, 1)
+
+	// confirm cache key coesn't exist
+	_, bufs, _ := c.Fetch(context.Background(), []string{cacheKey})
+	require.Equal(t, 0, len(bufs))
+
+	// execute query
+	// startNS := start * uint32(time.Second)
+	// endNS := end * uint32(time.Second)
+	path := fmt.Sprintf("/?start=%d&end=%d&q=%s", start, end, url.QueryEscape(query)) // encapsulates block above
+	req := httptest.NewRequest("GET", path, nil)
+	ctx := req.Context()
+	ctx = user.InjectOrgID(ctx, tenant)
+	req = req.WithContext(ctx)
+
+	respWriter := httptest.NewRecorder()
+	f.MetricsQueryRangeHandler.ServeHTTP(respWriter, req)
+
+	resp := respWriter.Result()
+	require.Equal(t, 200, resp.StatusCode)
+
+	actualResp := &tempopb.QueryRangeResponse{}
+	bytesResp, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	err = jsonpb.Unmarshal(bytes.NewReader(bytesResp), actualResp)
+	require.NoError(t, err)
+
+	// confirm cache key exists and matches the response above
+	_, bufs, _ = c.Fetch(context.Background(), []string{cacheKey})
+	require.Equal(t, 1, len(bufs))
+
+	actualCache := &tempopb.QueryRangeResponse{}
+	err = jsonpb.Unmarshal(bytes.NewReader(bufs[0]), actualCache)
+	require.NoError(t, err)
+
+	// zeroing these out b/c they are set by the sharder and won't be in cache
+	//cacheResponsesEqual(t, actualCache, actualResp)
 }

--- a/modules/frontend/metrics_query_range_handler_test.go
+++ b/modules/frontend/metrics_query_range_handler_test.go
@@ -200,7 +200,4 @@ func TestQueryRangeAccessesCache(t *testing.T) {
 	actualCache := &tempopb.QueryRangeResponse{}
 	err = jsonpb.Unmarshal(bytes.NewReader(bufs[0]), actualCache)
 	require.NoError(t, err)
-
-	// zeroing these out b/c they are set by the sharder and won't be in cache
-	//cacheResponsesEqual(t, actualCache, actualResp)
 }

--- a/modules/frontend/metrics_query_range_sharder.go
+++ b/modules/frontend/metrics_query_range_sharder.go
@@ -280,8 +280,11 @@ func (s *queryRangeSharder) buildBackendRequests(ctx context.Context, tenantID s
 				continue
 			}
 
+			// query range is in ns, but the cache function compares it to the block meta which is in seconds. converting here
+			startS := int64(searchReq.Start / uint64(time.Second))
+			endS := int64(searchReq.End / uint64(time.Second))
 			// TODO: Handle sampling rate
-			key := queryRangeCacheKey(tenantID, queryHash, int64(start), int64(end), m, int(step), pages)
+			key := queryRangeCacheKey(tenantID, queryHash, startS, endS, m, int(step), pages)
 			if len(key) > 0 {
 				pipelineR.SetCacheKey(key)
 			}


### PR DESCRIPTION
**What this PR does**:
Cache keys were not being generated for query range backend jobs due to a mismatch between seconds and nanoseconds. Block metas are only included if their start/end times are completely encapsulated in the query start/end times. The start/ends were ns but the blocks were seconds which made it so no cache keys were ever generated.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`