### PR TITLE
docs: Fix broken link to metrics generator from span metrics doc.

### DIFF
--- a/docs/sources/tempo/metrics-generator/span_metrics.md
+++ b/docs/sources/tempo/metrics-generator/span_metrics.md
@@ -90,7 +90,7 @@ When a configured dimension collides with one of the default labels (for example
 
 Custom labeling of dimensions is also supported using the [`dimension_mapping` configuration option](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration#metrics-generator).
 
-An optional metric called `traces_target_info` using all resource level attributes as dimensions can be enabled in the [`enable_target_info` configuration option](https://grafana.com/docs/tmepo/<TEMPO_VERSION>/configuration#metrics-generator).
+An optional metric called `traces_target_info` using all resource level attributes as dimensions can be enabled in the [`enable_target_info` configuration option](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration#metrics-generator).
 
 If you use a ratio-based sampler, you can use the custom sampler below to not lose metric information. However, you also need to set `metrics_generator.processor.span_metrics.span_multiplier_key` to `"X-SampleRatio"`.
 


### PR DESCRIPTION
**What this PR does**:
Fixes a broken link from the span metrics documentation to the metrics generator configuration page.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`