### PR TITLE
BugFix: Blocks whose end second matches a query range throw an erroneous error

### DIFF
--- a/modules/frontend/cache_keys.go
+++ b/modules/frontend/cache_keys.go
@@ -22,7 +22,7 @@ func searchJobCacheKey(tenant string, queryHash uint64, start int64, end int64, 
 }
 
 func queryRangeCacheKey(tenant string, queryHash uint64, start int64, end int64, meta *backend.BlockMeta, startPage, pagesToSearch int) string {
-	startTime := time.Unix(0, start) // query range start/end are in nanoseconds
+	startTime := time.Unix(0, start)
 	endTime := time.Unix(0, end)
 	return cacheKey(cacheKeyPrefixQueryRange, tenant, queryHash, startTime, endTime, meta, startPage, pagesToSearch)
 }
@@ -37,8 +37,8 @@ func cacheKey(prefix string, tenant string, queryHash uint64, start, end time.Ti
 
 	// unless the search range completely encapsulates the block range we can't cache. this is b/c different search ranges will return different results
 	// for a given block unless the search range covers the entire block
-	if !(meta.StartTime.Before(start) &&
-		meta.EndTime.After(end)) {
+	if !(start.Before(meta.StartTime) && // search start is before block start
+		end.After(meta.EndTime)) { // search end is after block end
 		return ""
 	}
 

--- a/modules/frontend/cache_keys.go
+++ b/modules/frontend/cache_keys.go
@@ -15,16 +15,12 @@ const (
 	cacheKeyPrefixQueryRange      = "qr:"
 )
 
-func searchJobCacheKey(tenant string, queryHash uint64, start int64, end int64, meta *backend.BlockMeta, startPage, pagesToSearch int) string {
-	startTime := time.Unix(start, 0)
-	endTime := time.Unix(end, 0)
-	return cacheKey(cacheKeyPrefixSearchJob, tenant, queryHash, startTime, endTime, meta, startPage, pagesToSearch)
+func searchJobCacheKey(tenant string, queryHash uint64, start, end time.Time, meta *backend.BlockMeta, startPage, pagesToSearch int) string {
+	return cacheKey(cacheKeyPrefixSearchJob, tenant, queryHash, start, end, meta, startPage, pagesToSearch)
 }
 
-func queryRangeCacheKey(tenant string, queryHash uint64, start int64, end int64, meta *backend.BlockMeta, startPage, pagesToSearch int) string {
-	startTime := time.Unix(0, start)
-	endTime := time.Unix(0, end)
-	return cacheKey(cacheKeyPrefixQueryRange, tenant, queryHash, startTime, endTime, meta, startPage, pagesToSearch)
+func queryRangeCacheKey(tenant string, queryHash uint64, start, end time.Time, meta *backend.BlockMeta, startPage, pagesToSearch int) string {
+	return cacheKey(cacheKeyPrefixQueryRange, tenant, queryHash, start, end, meta, startPage, pagesToSearch)
 }
 
 // cacheKey returns a string that can be used as a cache key for a backend search job. if a valid key cannot be calculated

--- a/modules/frontend/cache_keys_test.go
+++ b/modules/frontend/cache_keys_test.go
@@ -138,7 +138,10 @@ func TestCacheKeyForJob(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := searchJobCacheKey(tc.tenant, tc.queryHash, int64(tc.req.Start), int64(tc.req.End), tc.meta, tc.searchPage, tc.pagesToSearch)
+			startTime := time.Unix(int64(tc.req.Start), 0)
+			endTime := time.Unix(int64(tc.req.End), 0)
+
+			actual := searchJobCacheKey(tc.tenant, tc.queryHash, startTime, endTime, tc.meta, tc.searchPage, tc.pagesToSearch)
 			require.Equal(t, tc.expected, actual)
 		})
 	}
@@ -155,8 +158,11 @@ func BenchmarkCacheKeyForJob(b *testing.B) {
 		EndTime:   time.Unix(16, 0),
 	}
 
+	startTime := time.Unix(int64(req.Start), 0)
+	endTime := time.Unix(int64(req.End), 0)
+
 	for i := 0; i < b.N; i++ {
-		s := searchJobCacheKey("foo", 10, int64(req.Start), int64(req.End), meta, 1, 2)
+		s := searchJobCacheKey("foo", 10, startTime, endTime, meta, 1, 2)
 		if len(s) == 0 {
 			b.Fatalf("expected non-empty string")
 		}

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -357,8 +357,10 @@ func multiTenantUnsupportedMiddleware(cfg Config, logger log.Logger) pipeline.As
 func blockMetasForSearch(allBlocks []*backend.BlockMeta, start, end time.Time, rf uint32) []*backend.BlockMeta {
 	blocks := make([]*backend.BlockMeta, 0, len(allBlocks)/50) // divide by 50 for luck
 	for _, m := range allBlocks {
-		if m.StartTime.Compare(end) <= 0 && // start time is before or equal to end
-			m.EndTime.Compare(start) >= 0 && // end time is after or equal to start
+		// Block overlaps with search range if:
+		// block start is before or equal to search end AND block end is after or equal to search start
+		if !m.StartTime.After(end) && // block start <= search end
+			!m.EndTime.Before(start) && // block end >= search start
 			m.ReplicationFactor == rf { // This check skips generator blocks (RF=1)
 			blocks = append(blocks, m)
 		}

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -355,7 +355,6 @@ func multiTenantUnsupportedMiddleware(cfg Config, logger log.Logger) pipeline.As
 // blockMetasForSearch returns a list of blocks that are relevant to the search query.
 // start and end are unix timestamps in seconds. rf is the replication factor of the blocks to return.
 func blockMetasForSearch(allBlocks []*backend.BlockMeta, start, end time.Time, rf uint32) []*backend.BlockMeta {
-
 	blocks := make([]*backend.BlockMeta, 0, len(allBlocks)/50) // divide by 50 for luck
 	for _, m := range allBlocks {
 		if m.StartTime.Compare(end) <= 0 && // start time is before or equal to end

--- a/modules/frontend/metrics_query_range_handler_test.go
+++ b/modules/frontend/metrics_query_range_handler_test.go
@@ -164,18 +164,16 @@ func TestQueryRangeAccessesCache(t *testing.T) {
 	step := 1000000000
 	query := "{} | rate()"
 	hash := hashForQueryRangeRequest(&tempopb.QueryRangeRequest{Query: query, Step: uint64(step)})
-	start := uint32(10)
-	end := uint32(20)
-	cacheKey := queryRangeCacheKey(tenant, hash, int64(start), int64(end), meta, step, 1)
+	startNS := 10 * time.Second
+	endNS := 20 * time.Second
+	cacheKey := queryRangeCacheKey(tenant, hash, int64(startNS), int64(endNS), meta, step, 1)
 
 	// confirm cache key coesn't exist
 	_, bufs, _ := c.Fetch(context.Background(), []string{cacheKey})
 	require.Equal(t, 0, len(bufs))
 
 	// execute query
-	// startNS := start * uint32(time.Second)
-	// endNS := end * uint32(time.Second)
-	path := fmt.Sprintf("/?start=%d&end=%d&q=%s", start, end, url.QueryEscape(query)) // encapsulates block above
+	path := fmt.Sprintf("/?start=%d&end=%d&q=%s", startNS, endNS, url.QueryEscape(query)) // encapsulates block above
 	req := httptest.NewRequest("GET", path, nil)
 	ctx := req.Context()
 	ctx = user.InjectOrgID(ctx, tenant)

--- a/modules/frontend/metrics_query_range_handler_test.go
+++ b/modules/frontend/metrics_query_range_handler_test.go
@@ -166,7 +166,7 @@ func TestQueryRangeAccessesCache(t *testing.T) {
 	hash := hashForQueryRangeRequest(&tempopb.QueryRangeRequest{Query: query, Step: uint64(step)})
 	startNS := 10 * time.Second
 	endNS := 20 * time.Second
-	cacheKey := queryRangeCacheKey(tenant, hash, int64(startNS), int64(endNS), meta, step, 1)
+	cacheKey := queryRangeCacheKey(tenant, hash, time.Unix(0, int64(startNS)), time.Unix(0, int64(endNS)), meta, step, 1)
 
 	// confirm cache key coesn't exist
 	_, bufs, _ := c.Fetch(context.Background(), []string{cacheKey})

--- a/modules/frontend/metrics_query_range_sharder.go
+++ b/modules/frontend/metrics_query_range_sharder.go
@@ -280,11 +280,8 @@ func (s *queryRangeSharder) buildBackendRequests(ctx context.Context, tenantID s
 				continue
 			}
 
-			// query range is in ns, but the cache function compares it to the block meta which is in seconds. converting here
-			startS := int64(searchReq.Start / uint64(time.Second))
-			endS := int64(searchReq.End / uint64(time.Second))
 			// TODO: Handle sampling rate
-			key := queryRangeCacheKey(tenantID, queryHash, startS, endS, m, int(step), pages)
+			key := queryRangeCacheKey(tenantID, queryHash, int64(searchReq.Start), int64(searchReq.End), m, int(step), pages)
 			if len(key) > 0 {
 				pipelineR.SetCacheKey(key)
 			}

--- a/modules/frontend/metrics_query_range_sharder.go
+++ b/modules/frontend/metrics_query_range_sharder.go
@@ -280,8 +280,10 @@ func (s *queryRangeSharder) buildBackendRequests(ctx context.Context, tenantID s
 				continue
 			}
 
+			startTime := time.Unix(0, int64(searchReq.Start)) // start/end are in nanoseconds
+			endTime := time.Unix(0, int64(searchReq.End))
 			// TODO: Handle sampling rate
-			key := queryRangeCacheKey(tenantID, queryHash, int64(searchReq.Start), int64(searchReq.End), m, int(step), pages)
+			key := queryRangeCacheKey(tenantID, queryHash, startTime, endTime, m, int(step), pages)
 			if len(key) > 0 {
 				pipelineR.SetCacheKey(key)
 			}

--- a/modules/frontend/metrics_query_range_sharder.go
+++ b/modules/frontend/metrics_query_range_sharder.go
@@ -185,9 +185,9 @@ func (s *queryRangeSharder) backendRequests(ctx context.Context, tenantID string
 
 	// Blocks within overall time range. This is just for instrumentation, more precise time
 	// range is checked for each window.
-	startS := uint32(backendReq.Start / uint64(time.Second))
-	endS := uint32(backendReq.End / uint64(time.Second))
-	blocks := blockMetasForSearch(s.reader.BlockMetas(tenantID), startS, endS, 1)
+	start := time.Unix(0, int64(backendReq.Start))
+	end := time.Unix(0, int64(backendReq.End))
+	blocks := blockMetasForSearch(s.reader.BlockMetas(tenantID), start, end, 1)
 	if len(blocks) == 0 {
 		// no need to search backend
 		close(reqCh)

--- a/modules/frontend/search_handlers_test.go
+++ b/modules/frontend/search_handlers_test.go
@@ -587,7 +587,7 @@ func TestSearchAccessesCache(t *testing.T) {
 	hash := hashForSearchRequest(&tempopb.SearchRequest{Query: query, Limit: 3, SpansPerSpanSet: 2})
 	start := uint32(10)
 	end := uint32(20)
-	cacheKey := searchJobCacheKey(tenant, hash, int64(start), int64(end), meta, 0, 1)
+	cacheKey := searchJobCacheKey(tenant, hash, time.Unix(int64(start), 0), time.Unix(int64(end), 0), meta, 0, 1)
 
 	// confirm cache key coesn't exist
 	_, bufs, _ := c.Fetch(context.Background(), []string{cacheKey})

--- a/modules/frontend/search_sharder.go
+++ b/modules/frontend/search_sharder.go
@@ -136,7 +136,9 @@ func (s *asyncSearchSharder) backendRequests(ctx context.Context, tenantID strin
 		return
 	}
 
-	blocks := blockMetasForSearch(s.reader.BlockMetas(tenantID), start, end, backend.DefaultReplicationFactor)
+	startT := time.Unix(int64(start), 0)
+	endT := time.Unix(int64(end), 0)
+	blocks := blockMetasForSearch(s.reader.BlockMetas(tenantID), startT, endT, backend.DefaultReplicationFactor)
 
 	// calculate metrics to return to the caller
 	resp.TotalBlocks = len(blocks)

--- a/modules/frontend/search_sharder.go
+++ b/modules/frontend/search_sharder.go
@@ -318,7 +318,9 @@ func buildBackendRequests(ctx context.Context, tenantID string, parent pipeline.
 			return
 		}
 
-		key := searchJobCacheKey(tenantID, queryHash, int64(searchReq.Start), int64(searchReq.End), m, startPage, pages)
+		startTime := time.Unix(int64(searchReq.Start), 0)
+		endTime := time.Unix(int64(searchReq.End), 0)
+		key := searchJobCacheKey(tenantID, queryHash, startTime, endTime, m, startPage, pages)
 		pipelineR.SetCacheKey(key)
 		pipelineR.SetResponseData(shard)
 

--- a/modules/frontend/tag_handlers_test.go
+++ b/modules/frontend/tag_handlers_test.go
@@ -477,7 +477,9 @@ func TestSearchTagsV2AccessesCache(t *testing.T) {
 	hash := fnv1a.HashString64(scope)
 	start := uint32(10)
 	end := uint32(20)
-	cacheKey := cacheKey(cacheKeyPrefixSearchTag, tenant, hash, int64(start), int64(end), meta, 0, 1)
+	startTime := time.Unix(int64(start), 0)
+	endTime := time.Unix(int64(end), 0)
+	cacheKey := cacheKey(cacheKeyPrefixSearchTag, tenant, hash, startTime, endTime, meta, 0, 1)
 
 	// confirm cache key coesn't exist
 	_, bufs, _ := c.Fetch(context.Background(), []string{cacheKey})

--- a/modules/frontend/tag_sharder.go
+++ b/modules/frontend/tag_sharder.go
@@ -273,6 +273,8 @@ func (s searchTagSharder) buildBackendRequests(ctx context.Context, tenantID str
 
 	hash := searchReq.hash()
 	keyPrefix := searchReq.keyPrefix()
+	startTime := time.Unix(int64(searchReq.start()), 0)
+	endTime := time.Unix(int64(searchReq.end()), 0)
 
 	for _, m := range metas {
 		pages := pagesPerRequest(m, bytesPerRequest)
@@ -290,8 +292,6 @@ func (s searchTagSharder) buildBackendRequests(ctx context.Context, tenantID str
 				continue
 			}
 
-			startTime := time.Unix(int64(searchReq.start()), 0)
-			endTime := time.Unix(int64(searchReq.end()), 0)
 			key := cacheKey(keyPrefix, tenantID, hash, startTime, endTime, m, startPage, pages)
 			pipelineR.SetCacheKey(key)
 

--- a/modules/frontend/tag_sharder.go
+++ b/modules/frontend/tag_sharder.go
@@ -290,7 +290,9 @@ func (s searchTagSharder) buildBackendRequests(ctx context.Context, tenantID str
 				continue
 			}
 
-			key := cacheKey(keyPrefix, tenantID, hash, int64(searchReq.start()), int64(searchReq.end()), m, startPage, pages)
+			startTime := time.Unix(int64(searchReq.start()), 0)
+			endTime := time.Unix(int64(searchReq.end()), 0)
+			key := cacheKey(keyPrefix, tenantID, hash, startTime, endTime, m, startPage, pages)
 			pipelineR.SetCacheKey(key)
 
 			select {

--- a/modules/frontend/tag_sharder.go
+++ b/modules/frontend/tag_sharder.go
@@ -255,7 +255,9 @@ func (s searchTagSharder) backendRequests(ctx context.Context, tenantID string, 
 	}
 
 	// get block metadata of blocks in start, end duration
-	blocks := blockMetasForSearch(s.reader.BlockMetas(tenantID), start, end, backend.DefaultReplicationFactor)
+	startT := time.Unix(int64(start), 0)
+	endT := time.Unix(int64(end), 0)
+	blocks := blockMetasForSearch(s.reader.BlockMetas(tenantID), startT, endT, backend.DefaultReplicationFactor)
 
 	targetBytesPerRequest := s.cfg.TargetBytesPerRequest
 


### PR DESCRIPTION
**What this PR does**:
Currently if you perform a query range search and the end of the time range matches the end second of a block it will fail with:

`end must be greater than start`

This is due a consolidation of code when [adding the most_recent=true query hint](https://github.com/grafana/tempo/pull/4238). A bug was introduced when consolidating `blockMetasForSearch`. The query range pipeline respects a nanosecond range but blockMetasForSearch was not. As a result it was possible for a block to be incorrectly included in the search if it's end time shared the same second as the end time of the requested range.

- Applied the same fix to the cache key function.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`