### PR TITLE
Move all intrinsic tag lookup to the query-frontend and prioritize them in the results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [BUGFIX] Fix memcached settings for docker compose example [#4346](https://github.com/grafana/tempo/pull/4695) (@ruslan-mikhailov)
 * [BUGFIX] Fix setting processors in user configurations overrides via API [#4741](https://github.com/grafana/tempo/pull/4741) (@ruslan-mikhailov)
 * [BUGFIX] Fix panic on startup [#4744](https://github.com/grafana/tempo/pull/4744) (@ruslan-mikhailov)
+* [BUGFIX] Fix intrinsic tag lookups dropped when max tag lookup response size is exceeded [#4784](https://github.com/grafana/tempo/pull/4784) (@mdisibio)
 * [BUGFIX] Correctly cache frontend jobs for query range (TraceQL Metrics). [#4771](https://github.com/grafana/tempo/pull/4771) (@joe-elliott)
 
 # v2.7.1

--- a/integration/e2e/api/api_test.go
+++ b/integration/e2e/api/api_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/grafana/e2e"
 	"github.com/grafana/tempo/integration/util"
-	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/search"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/stretchr/testify/require"
@@ -493,7 +492,7 @@ func TestSearchTags(t *testing.T) {
 	require.NoError(t, tempo.WaitSumMetrics(e2e.Equals(1), "tempo_ingester_blocks_cleared_total"))
 
 	// Assert no more on the ingester
-	callSearchTagsAndAssert(t, tempo, searchTagsResponse{}, 0, 0)
+	callSearchTagsAndAssert(t, tempo, searchTagsResponse{TagNames: []string{}}, 0, 0)
 
 	// Wait to blocklist_poll to be completed
 	time.Sleep(time.Second * 2)
@@ -656,7 +655,7 @@ func callSearchTagsV2AndAssert(t *testing.T, svc *e2e.HTTPService, scope, query 
 
 	// Expected will not have the intrinsic results to make the tests simpler,
 	// they are added here based on the scope.
-	if scope == "" || scope == api.ParamScopeIntrinsic {
+	if scope == "none" || scope == "" || scope == "intrinsic" {
 		expected.Scopes = append(expected.Scopes, ScopedTags{
 			Name: "intrinsic",
 			Tags: search.GetVirtualIntrinsicValues(),

--- a/integration/e2e/api/api_test.go
+++ b/integration/e2e/api/api_test.go
@@ -86,7 +86,7 @@ func TestSearchTagsV2(t *testing.T) {
 		{
 			name:  "no filtering",
 			query: "",
-			scope: "",
+			scope: "none",
 			expected: searchTagsV2Response{
 				Scopes: []ScopedTags{
 					{
@@ -168,7 +168,7 @@ func TestSearchTagsV2(t *testing.T) {
 		{
 			name:  "too restrictive query",
 			query: fmt.Sprintf(`{ resource.%s="%s" && resource.y="%s" }`, firstBatch.resourceAttr, firstBatch.resourceAttVal, secondBatch.resourceAttVal),
-			scope: "",
+			scope: "none",
 			expected: searchTagsV2Response{
 				Scopes: []ScopedTags{
 					{
@@ -182,7 +182,7 @@ func TestSearchTagsV2(t *testing.T) {
 		{
 			name:  "unscoped span attribute",
 			query: fmt.Sprintf(`{ .x="%s" }`, firstBatch.spanAttVal),
-			scope: "",
+			scope: "none",
 			expected: searchTagsV2Response{
 				Scopes: []ScopedTags{
 					{
@@ -199,7 +199,7 @@ func TestSearchTagsV2(t *testing.T) {
 		{
 			name:  "unscoped res attribute",
 			query: fmt.Sprintf(`{ .xx="%s" }`, firstBatch.resourceAttVal),
-			scope: "",
+			scope: "none",
 			expected: searchTagsV2Response{
 				Scopes: []ScopedTags{
 					{
@@ -216,7 +216,7 @@ func TestSearchTagsV2(t *testing.T) {
 		{
 			name:  "both batches - name and resource attribute",
 			query: `{ resource.service.name="my-service"}`,
-			scope: "",
+			scope: "none",
 			expected: searchTagsV2Response{
 				Scopes: []ScopedTags{
 					{
@@ -233,7 +233,7 @@ func TestSearchTagsV2(t *testing.T) {
 		{
 			name:  "bad query - unfiltered results",
 			query: fmt.Sprintf("%s = bar", spanX), // bad query, missing quotes
-			scope: "",
+			scope: "none",
 			expected: searchTagsV2Response{
 				Scopes: []ScopedTags{
 					{

--- a/integration/util/util.go
+++ b/integration/util/util.go
@@ -39,7 +39,6 @@ import (
 
 	"github.com/grafana/tempo/pkg/httpclient"
 	"github.com/grafana/tempo/pkg/model/trace"
-	"github.com/grafana/tempo/pkg/search"
 	"github.com/grafana/tempo/pkg/tempopb"
 	tempoUtil "github.com/grafana/tempo/pkg/util"
 )
@@ -477,17 +476,15 @@ func SearchAndAssertTraceBackend(t *testing.T, client *httpclient.Client, info *
 // by passing a time range and using a query_ingesters_until/backend_after of 0 we can force the queriers
 // to look in the backend blocks
 func SearchAndAsserTagsBackend(t *testing.T, client *httpclient.Client, start, end int64) {
-	intrinsicsLen := len(search.GetVirtualIntrinsicValues())
-
-	// There are no tags in recent data except for the intrinsics
+	// There are no tags in recent data
 	resp, err := client.SearchTags()
 	require.NoError(t, err)
-	require.Equal(t, len(resp.TagNames), intrinsicsLen)
+	require.Equal(t, len(resp.TagNames), 0)
 
 	// There are additional tags in the backend
 	resp, err = client.SearchTagsWithRange(start, end)
 	require.NoError(t, err)
-	require.True(t, len(resp.TagNames) > intrinsicsLen)
+	require.True(t, len(resp.TagNames) > 0)
 }
 
 func traceIDInResults(t *testing.T, hexID string, resp *tempopb.SearchResponse) bool {

--- a/modules/frontend/combiner/common.go
+++ b/modules/frontend/combiner/common.go
@@ -137,11 +137,11 @@ func (c *genericCombiner[T]) AddResponse(r PipelineResponse) error {
 	return nil
 }
 
-func (c *genericCombiner[T]) AddTypedResponse(r T) {
+func (c *genericCombiner[T]) AddTypedResponse(r T) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.combine(r, c.current, nil)
+	return c.combine(r, c.current, nil)
 }
 
 // HTTPFinal, GRPCComplete, and GRPCDiff are all responsible for returning something

--- a/modules/frontend/combiner/common.go
+++ b/modules/frontend/combiner/common.go
@@ -137,6 +137,13 @@ func (c *genericCombiner[T]) AddResponse(r PipelineResponse) error {
 	return nil
 }
 
+func (c *genericCombiner[T]) AddTypedResponse(r T) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.combine(r, c.current, nil)
+}
+
 // HTTPFinal, GRPCComplete, and GRPCDiff are all responsible for returning something
 // usable in grpc streaming/http response.
 // NOTE: returning error is reserved for unexpected errors, HTTP errors will be returned

--- a/modules/frontend/combiner/interface.go
+++ b/modules/frontend/combiner/interface.go
@@ -17,8 +17,13 @@ type Combiner interface {
 	HTTPFinal() (*http.Response, error)
 }
 
+type TypedCombiner[T TResponse] interface {
+	AddTypedResponse(r T)
+}
+
 type GRPCCombiner[T TResponse] interface {
 	Combiner
+	TypedCombiner[T]
 
 	GRPCFinal() (T, error)
 	GRPCDiff() (T, error)

--- a/modules/frontend/combiner/interface.go
+++ b/modules/frontend/combiner/interface.go
@@ -18,7 +18,7 @@ type Combiner interface {
 }
 
 type TypedCombiner[T TResponse] interface {
-	AddTypedResponse(r T)
+	AddTypedResponse(r T) error
 }
 
 type GRPCCombiner[T TResponse] interface {

--- a/modules/frontend/metrics_query_range_handler_test.go
+++ b/modules/frontend/metrics_query_range_handler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 	"github.com/grafana/dskit/user"
+	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/cache"
 	"github.com/grafana/tempo/pkg/tempopb"
@@ -52,7 +53,7 @@ func TestQueryRangeHandlerSucceeds(t *testing.T) {
 		responseFn: func() proto.Message {
 			return resp
 		},
-	}, nil, nil, nil, func(c *Config) {
+	}, nil, nil, nil, func(c *Config, _ *overrides.Config) {
 		c.Metrics.Sharder.Interval = time.Hour
 	})
 

--- a/modules/frontend/search_handlers_test.go
+++ b/modules/frontend/search_handlers_test.go
@@ -718,7 +718,7 @@ func BenchmarkSearchPipeline(b *testing.B) {
 // frontendWithSettings returns a new frontend with the given settings. any nil options
 // are given "happy path" defaults
 func frontendWithSettings(t require.TestingT, next pipeline.RoundTripper, rdr tempodb.Reader, cfg *Config, cacheProvider cache.Provider,
-	opts ...func(*Config),
+	opts ...func(*Config, *overrides.Config),
 ) *QueryFrontend {
 	if next == nil {
 		next = &mockRoundTripper{
@@ -802,11 +802,13 @@ func frontendWithSettings(t require.TestingT, next pipeline.RoundTripper, rdr te
 		}
 	}
 
+	overridesCfg := &overrides.Config{}
+
 	for _, o := range opts {
-		o(cfg)
+		o(cfg, overridesCfg)
 	}
 
-	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.DefaultRegisterer)
+	o, err := overrides.NewOverrides(*overridesCfg, nil, prometheus.DefaultRegisterer)
 	require.NoError(t, err)
 
 	f, err := New(*cfg, next, o, rdr, cacheProvider, "", log.NewNopLogger(), nil)

--- a/modules/frontend/tag_handlers.go
+++ b/modules/frontend/tag_handlers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/search"
 	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/grafana/tempo/pkg/traceql"
 	"google.golang.org/grpc/codes"
 )
 
@@ -100,7 +101,9 @@ func newTagsV2StreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[c
 
 		// Add intrinsics first so that they aren't dropped by the response size limit
 		// NOTE - V2 tag lookup returns intrinsics for both unscoped and explicit scope requests.
-		if req.Scope == "" || req.Scope == api.ParamScopeIntrinsic {
+		if req.Scope == "" ||
+			req.Scope == api.ParamScopeIntrinsic ||
+			req.Scope == traceql.AttributeScopeNone.String() {
 			err := comb.AddTypedResponse(&tempopb.SearchTagsV2Response{
 				Scopes: []*tempopb.SearchTagsV2Scope{
 					{
@@ -267,7 +270,9 @@ func newTagsV2HTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.P
 
 		// Add intrinsics first so that they aren't dropped by the response size limit
 		// NOTE - V2 tag lookup returns intrinsics for both unscoped and explicit scope requests.
-		if scope == "" || scope == api.ParamScopeIntrinsic {
+		if scope == "" ||
+			scope == api.ParamScopeIntrinsic ||
+			scope == traceql.AttributeScopeNone.String() {
 			err := comb.AddTypedResponse(&tempopb.SearchTagsV2Response{
 				Scopes: []*tempopb.SearchTagsV2Scope{
 					{

--- a/modules/frontend/tag_handlers.go
+++ b/modules/frontend/tag_handlers.go
@@ -56,9 +56,12 @@ func newTagsStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[com
 
 		// Add intrinsics first so that they aren't dropped by the response size limit
 		if req.Scope == "" || req.Scope == api.ParamScopeIntrinsic {
-			comb.AddTypedResponse(&tempopb.SearchTagsResponse{
+			err := comb.AddTypedResponse(&tempopb.SearchTagsResponse{
 				TagNames: search.GetVirtualIntrinsicValues(),
 			})
+			if err != nil {
+				return err
+			}
 		}
 
 		start := time.Now()
@@ -96,7 +99,7 @@ func newTagsV2StreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[c
 
 		// Add intrinsics first so that they aren't dropped by the response size limit
 		if req.Scope == "" || req.Scope == api.ParamScopeIntrinsic {
-			comb.AddTypedResponse(&tempopb.SearchTagsV2Response{
+			err := comb.AddTypedResponse(&tempopb.SearchTagsV2Response{
 				Scopes: []*tempopb.SearchTagsV2Scope{
 					{
 						Name: api.ParamScopeIntrinsic,
@@ -104,6 +107,9 @@ func newTagsV2StreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[c
 					},
 				},
 			})
+			if err != nil {
+				return err
+			}
 		}
 
 		start := time.Now()
@@ -213,9 +219,12 @@ func newTagsHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.Pip
 
 		// Add intrinsics first so that they aren't dropped by the response size limit
 		if scope == "" || scope == api.ParamScopeIntrinsic {
-			comb.AddTypedResponse(&tempopb.SearchTagsResponse{
+			err := comb.AddTypedResponse(&tempopb.SearchTagsResponse{
 				TagNames: search.GetVirtualIntrinsicValues(),
 			})
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		rt := pipeline.NewHTTPCollector(next, cfg.ResponseConsumers, comb)
@@ -255,7 +264,7 @@ func newTagsV2HTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.P
 
 		// Add intrinsics first so that they aren't dropped by the response size limit
 		if scope == "" || scope == api.ParamScopeIntrinsic {
-			comb.AddTypedResponse(&tempopb.SearchTagsV2Response{
+			err := comb.AddTypedResponse(&tempopb.SearchTagsV2Response{
 				Scopes: []*tempopb.SearchTagsV2Scope{
 					{
 						Name: api.ParamScopeIntrinsic,
@@ -263,6 +272,9 @@ func newTagsV2HTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.P
 					},
 				},
 			})
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		rt := pipeline.NewHTTPCollector(next, cfg.ResponseConsumers, comb)

--- a/modules/frontend/tag_handlers.go
+++ b/modules/frontend/tag_handlers.go
@@ -55,7 +55,8 @@ func newTagsStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[com
 		})
 
 		// Add intrinsics first so that they aren't dropped by the response size limit
-		if req.Scope == "" || req.Scope == api.ParamScopeIntrinsic {
+		// NOTE - V1 tag lookup only returns intrinsics when scope is set explicitly.
+		if req.Scope == api.ParamScopeIntrinsic {
 			err := comb.AddTypedResponse(&tempopb.SearchTagsResponse{
 				TagNames: search.GetVirtualIntrinsicValues(),
 			})
@@ -98,6 +99,7 @@ func newTagsV2StreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[c
 		})
 
 		// Add intrinsics first so that they aren't dropped by the response size limit
+		// NOTE - V2 tag lookup returns intrinsics for both unscoped and explicit scope requests.
 		if req.Scope == "" || req.Scope == api.ParamScopeIntrinsic {
 			err := comb.AddTypedResponse(&tempopb.SearchTagsV2Response{
 				Scopes: []*tempopb.SearchTagsV2Scope{
@@ -218,7 +220,8 @@ func newTagsHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.Pip
 		comb := combiner.NewTypedSearchTags(o.MaxBytesPerTagValuesQuery(tenant), maxTagsPerScope, staleValueThreshold)
 
 		// Add intrinsics first so that they aren't dropped by the response size limit
-		if scope == "" || scope == api.ParamScopeIntrinsic {
+		// NOTE - V1 tag lookup only returns intrinsics when scope is set explicitly.
+		if scope == api.ParamScopeIntrinsic {
 			err := comb.AddTypedResponse(&tempopb.SearchTagsResponse{
 				TagNames: search.GetVirtualIntrinsicValues(),
 			})
@@ -263,6 +266,7 @@ func newTagsV2HTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.P
 		comb := combiner.NewTypedSearchTagsV2(o.MaxBytesPerTagValuesQuery(tenant), maxTagsPerScope, staleValueThreshold)
 
 		// Add intrinsics first so that they aren't dropped by the response size limit
+		// NOTE - V2 tag lookup returns intrinsics for both unscoped and explicit scope requests.
 		if scope == "" || scope == api.ParamScopeIntrinsic {
 			err := comb.AddTypedResponse(&tempopb.SearchTagsV2Response{
 				Scopes: []*tempopb.SearchTagsV2Scope{

--- a/modules/frontend/tag_handlers.go
+++ b/modules/frontend/tag_handlers.go
@@ -64,6 +64,8 @@ func newTagsStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[com
 			if err != nil {
 				return err
 			}
+			// TODO: Exit early here, no need to issue more requests downstream, but some
+			//  work needed to ensure things are still logged/metriced correctly.
 		}
 
 		start := time.Now()
@@ -115,6 +117,8 @@ func newTagsV2StreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[c
 			if err != nil {
 				return err
 			}
+			// TODO: For intrinsic scope only, exit early here, no need to issue more requests downstream, but some
+			//  work needed to ensure things are still logged/metriced correctly.
 		}
 
 		start := time.Now()
@@ -231,6 +235,8 @@ func newTagsHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.Pip
 			if err != nil {
 				return nil, err
 			}
+			// TODO: Exit early here, no need to issue more requests downstream, but some
+			//  work needed to ensure things are still logged/metriced correctly.
 		}
 
 		rt := pipeline.NewHTTPCollector(next, cfg.ResponseConsumers, comb)
@@ -284,6 +290,8 @@ func newTagsV2HTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.P
 			if err != nil {
 				return nil, err
 			}
+			// TODO: For intrinsic scope only, exit early here, no need to issue more requests downstream, but some
+			//  work needed to ensure things are still logged/metriced correctly.
 		}
 
 		rt := pipeline.NewHTTPCollector(next, cfg.ResponseConsumers, comb)

--- a/modules/frontend/tag_handlers_test.go
+++ b/modules/frontend/tag_handlers_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"regexp"
+	"sort"
 	"testing"
 	"time"
 
@@ -208,6 +209,12 @@ func TestSearchTagsV2AlwaysReturnsIntrinsics(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, 2, len(resp.Scopes))
+
+	// Sort scopes to give stable comparison
+	sort.Slice(resp.Scopes, func(i, j int) bool {
+		return resp.Scopes[i].Name < resp.Scopes[j].Name
+	})
+
 	require.Equal(t, api.ParamScopeIntrinsic, resp.Scopes[0].Name)
 	require.Equal(t, mockScope, resp.Scopes[1].Name)
 	require.ElementsMatch(t, search.GetVirtualIntrinsicValues(), resp.Scopes[0].Tags)

--- a/modules/ingester/instance_search.go
+++ b/modules/ingester/instance_search.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/boundedwaitgroup"
 	"github.com/grafana/tempo/pkg/collector"
-	"github.com/grafana/tempo/pkg/search"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/traceql"
 	"github.com/grafana/tempo/pkg/util/log"
@@ -219,17 +218,11 @@ func (i *instance) SearchTagsV2(ctx context.Context, req *tempopb.SearchTagsRequ
 	}
 
 	scope := req.Scope
-	// check if it's the special intrinsic scope
+
 	if scope == api.ParamScopeIntrinsic {
-		return &tempopb.SearchTagsV2Response{
-			Scopes: []*tempopb.SearchTagsV2Scope{
-				{
-					Name: api.ParamScopeIntrinsic,
-					Tags: search.GetVirtualIntrinsicValues(),
-				},
-			},
-			Metrics: &tempopb.MetadataMetrics{InspectedBytes: 0}, // no bytes read for intrinsics
-		}, nil
+		// For the intrinsic scope there is nothing to do in the ingester,
+		// these are always added by the frontend.
+		return &tempopb.SearchTagsV2Response{}, nil
 	}
 
 	// parse for normal scopes
@@ -316,14 +309,6 @@ func (i *instance) SearchTagsV2(ctx context.Context, req *tempopb.SearchTagsRequ
 		resp.Scopes = append(resp.Scopes, &tempopb.SearchTagsV2Scope{
 			Name: scope,
 			Tags: vals,
-		})
-	}
-
-	// add intrinsic tags if scope is none
-	if attributeScope == traceql.AttributeScopeNone {
-		resp.Scopes = append(resp.Scopes, &tempopb.SearchTagsV2Scope{
-			Name: api.ParamScopeIntrinsic,
-			Tags: search.GetVirtualIntrinsicValues(),
 		})
 	}
 

--- a/modules/ingester/instance_search.go
+++ b/modules/ingester/instance_search.go
@@ -191,11 +191,6 @@ func (i *instance) SearchTags(ctx context.Context, scope string) (*tempopb.Searc
 
 	// flatten v2 response
 	for _, s := range v2Response.Scopes {
-		// SearchTags does not include intrinsics on an empty scope, but v2 does.
-		if scope == "" && s.Name == api.ParamScopeIntrinsic {
-			continue
-		}
-
 		for _, t := range s.Tags {
 			distinctValues.Collect(t)
 		}

--- a/modules/ingester/instance_search_test.go
+++ b/modules/ingester/instance_search_test.go
@@ -420,28 +420,13 @@ func cacheKeysForTestSearchTagValuesV2(tagKey, query string, limit int) []string
 
 // TestInstanceSearchTagsSpecialCases tess that SearchTags errors on an unknown scope and
 // returns known instrinics for the "intrinsic" scope
-func TestInstanceSearchTagsSpecialCases(t *testing.T) {
+func TestInstanceSearchUnknownScope(t *testing.T) {
 	i, _ := defaultInstance(t)
 	userCtx := user.InjectOrgID(context.Background(), "fake")
 
 	resp, err := i.SearchTags(userCtx, "foo")
 	require.Error(t, err)
 	require.Nil(t, resp)
-
-	resp, err = i.SearchTags(userCtx, "intrinsic")
-	require.NoError(t, err)
-	require.Equal(
-		t,
-		[]string{
-			"duration", "event:name", "event:timeSinceStart",
-			"instrumentation:name", "instrumentation:version",
-			"kind", "name", "rootName", "rootServiceName",
-			"span:duration", "span:kind", "span:name",
-			"span:status", "span:statusMessage", "status", "statusMessage",
-			"trace:duration", "trace:rootName", "trace:rootService", "traceDuration",
-		},
-		resp.TagNames,
-	)
 }
 
 // TestInstanceSearchMaxBytesPerTagValuesQueryReturnsPartial confirms that SearchTagValues returns

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -876,19 +876,10 @@ func (q *Querier) SearchBlock(ctx context.Context, req *tempopb.SearchBlockReque
 }
 
 func (q *Querier) internalTagsSearchBlockV2(ctx context.Context, req *tempopb.SearchTagsBlockRequest) (*tempopb.SearchTagsV2Response, error) {
-	// check if it's the special intrinsic scope
-	// note that every block search passes the same values up. this could be handled in the frontend and be far more efficient
+	// For the intrinsic scope there is nothing to do in the querier,
+	// these are always added by the frontend.
 	if req.SearchReq.Scope == api.ParamScopeIntrinsic {
-		return &tempopb.SearchTagsV2Response{
-			Scopes: []*tempopb.SearchTagsV2Scope{
-				{
-					Name: api.ParamScopeIntrinsic,
-					Tags: search.GetVirtualIntrinsicValues(),
-				},
-			},
-			// no bytes were scanned to return the intrinsic values
-			Metrics: &tempopb.MetadataMetrics{InspectedBytes: 0},
-		}, nil
+		return &tempopb.SearchTagsV2Response{}, nil
 	}
 
 	tenantID, err := user.ExtractOrgID(ctx)
@@ -930,20 +921,7 @@ func (q *Querier) internalTagsSearchBlockV2(ctx context.Context, req *tempopb.Se
 
 	query := traceql.ExtractMatchers(req.SearchReq.Query)
 	if traceql.IsEmptyQuery(query) {
-		resp, err := q.store.SearchTags(ctx, meta, req, opts)
-		if err != nil {
-			return nil, err
-		}
-
-		// add intrinsic tags if scope is none
-		if req.SearchReq.Scope == "" {
-			resp.Scopes = append(resp.Scopes, &tempopb.SearchTagsV2Scope{
-				Name: api.ParamScopeIntrinsic,
-				Tags: search.GetVirtualIntrinsicValues(),
-			})
-		}
-
-		return resp, nil
+		return q.store.SearchTags(ctx, meta, req, opts)
 	}
 
 	valueCollector := collector.NewScopedDistinctString(q.limits.MaxBytesPerTagValuesQuery(tenantID), req.MaxTagsPerScope, req.StaleValueThreshold)

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -485,11 +485,6 @@ func (q *Querier) SearchTagsBlocks(ctx context.Context, req *tempopb.SearchTagsB
 
 	// flatten v2 response
 	for _, s := range v2Response.Scopes {
-		// SearchTags does not include intrinsics on an empty scope, but v2 does.
-		if req.SearchReq.Scope == "" && s.Name == api.ParamScopeIntrinsic {
-			continue
-		}
-
 		for _, t := range s.Tags {
 			distinctValues.Collect(t)
 			if distinctValues.Exceeded() {


### PR DESCRIPTION
**What this PR does**:
Fixes #4769 by ensuring intrinsic tags are added first to the value collectors.  Because they are static, there is also no need to return them from queriers and ingesters, and instead the query-frontend adds them statically.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`