### PR TITLE
Fix querier panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [BUGFIX] Rhythm - fix adjustment of the start and end range for livetraces blocks [#4746](https://github.com/grafana/tempo/pull/4746) (@javiermolinar)
 * [BUGFIX] Return the operand as the only value if the tag is already filtered in the query [#4673](https://github.com/grafana/tempo/pull/4673) (@mapno)
 * [BUGFIX] Fix flaky test [#4787](https://github.com/grafana/tempo/pull/4787) (@javiermolinar)
+* [BUGFIX] Fix rare panic that occurred when a querier modified results from ingesters/generators while they were being marshalled to proto. [#4790](https://github.com/grafana/tempo/pull/4790) (@joe-elliott)
 * [BUGFIX] Fix memcached settings for docker compose example [#4346](https://github.com/grafana/tempo/pull/4695) (@ruslan-mikhailov)
 * [BUGFIX] Fix setting processors in user configurations overrides via API [#4741](https://github.com/grafana/tempo/pull/4741) (@ruslan-mikhailov)
 * [BUGFIX] Fix panic on startup [#4744](https://github.com/grafana/tempo/pull/4744) (@ruslan-mikhailov)

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -235,11 +235,16 @@ func (q *Querier) FindTraceByID(ctx context.Context, req *tempopb.TraceByIDReque
 		}
 
 		var spanCountTotal, traceCountTotal int64
-		var found bool
+		found := false
 
 		for _, partialTrace := range partialTraces {
-			found = true
 			resp := partialTrace.(*tempopb.TraceByIDResponse)
+			if resp.Trace == nil {
+				continue
+			}
+
+			found = true
+
 			spanCount, err := combiner.Consume(resp.Trace)
 			if err != nil {
 				return nil, fmt.Errorf("error combining ingester results in Querier.FindTraceByID: %w", err)

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -242,7 +242,7 @@ func (q *Querier) FindTraceByID(ctx context.Context, req *tempopb.TraceByIDReque
 			resp := partialTrace.(*tempopb.TraceByIDResponse)
 			spanCount, err := combiner.Consume(resp.Trace)
 			if err != nil {
-				return nil, err // jpe ?
+				return nil, fmt.Errorf("error combining ingester results in Querier.FindTraceByID: %w", err)
 			}
 
 			spanCountTotal += int64(spanCount)

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -512,6 +512,7 @@ func (q *Querier) SearchTags(ctx context.Context, req *tempopb.SearchTagsRequest
 		return nil, fmt.Errorf("error querying ingesters in Querier.SearchTags: %w", err)
 	}
 
+outer:
 	for _, result := range results {
 		resp := result.(*tempopb.SearchTagsResponse)
 		if resp.Metrics != nil {
@@ -521,7 +522,7 @@ func (q *Querier) SearchTags(ctx context.Context, req *tempopb.SearchTagsRequest
 		for _, tag := range resp.TagNames {
 			distinctValues.Collect(tag)
 			if distinctValues.Exceeded() {
-				break // jpe - doesn't perfectly break b/c of the double loop
+				break outer
 			}
 		}
 	}
@@ -554,6 +555,7 @@ func (q *Querier) SearchTagsV2(ctx context.Context, req *tempopb.SearchTagsReque
 		return nil, fmt.Errorf("error querying ingesters in Querier.SearchTags: %w", err)
 	}
 
+outer:
 	for _, result := range results {
 		resp := result.(*tempopb.SearchTagsV2Response)
 		if resp.Metrics != nil {
@@ -563,7 +565,7 @@ func (q *Querier) SearchTagsV2(ctx context.Context, req *tempopb.SearchTagsReque
 		for _, res := range resp.Scopes {
 			for _, tag := range res.Tags {
 				if distinctValues.Collect(res.Name, tag) {
-					break // jpe - doesn't perfectly break b/c of the triple loop
+					break outer
 				}
 			}
 		}
@@ -611,6 +613,7 @@ func (q *Querier) SearchTagValues(ctx context.Context, req *tempopb.SearchTagVal
 		return nil, fmt.Errorf("error querying ingesters in Querier.SearchTagValues: %w", err)
 	}
 
+outer:
 	for _, result := range results {
 		resp := result.(*tempopb.SearchTagValuesResponse)
 		if resp.Metrics != nil {
@@ -620,7 +623,7 @@ func (q *Querier) SearchTagValues(ctx context.Context, req *tempopb.SearchTagVal
 		for _, res := range resp.TagValues {
 			distinctValues.Collect(res)
 			if distinctValues.Exceeded() {
-				break // jpe - doesn't perfectly break b/c of the double loop
+				break outer
 			}
 		}
 	}
@@ -666,6 +669,7 @@ func (q *Querier) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTagV
 		return nil, fmt.Errorf("error querying ingesters in Querier.SearchTagValues: %w", err)
 	}
 
+outer:
 	for _, result := range results {
 		resp := result.(*tempopb.SearchTagValuesV2Response)
 		if resp.Metrics != nil {
@@ -675,7 +679,7 @@ func (q *Querier) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTagV
 		for _, res := range resp.TagValues {
 			distinctValues.Collect(*res)
 			if distinctValues.Exceeded() {
-				break // jpe - doesn't perfectly break b/c of the double loop
+				break outer
 			}
 		}
 	}

--- a/modules/querier/querier_query_range.go
+++ b/modules/querier/querier_query_range.go
@@ -25,7 +25,7 @@ func (q *Querier) QueryRange(ctx context.Context, req *tempopb.QueryRangeRequest
 }
 
 func (q *Querier) queryRangeRecent(ctx context.Context, req *tempopb.QueryRangeRequest) (*tempopb.QueryRangeResponse, error) {
-	// // Get results from all generators
+	// Get results from all generators
 	replicationSet, err := q.generatorRing.GetReplicationSetForOperation(ring.Read)
 	if err != nil {
 		return nil, fmt.Errorf("error finding generators in Querier.queryRangeRecent: %w", err)
@@ -36,10 +36,9 @@ func (q *Querier) queryRangeRecent(ctx context.Context, req *tempopb.QueryRangeR
 		return nil, err
 	}
 
-	forEach := func(ctx context.Context, client tempopb.MetricsGeneratorClient) (any, error) {
+	results, err := q.forGivenGenerators(ctx, replicationSet, func(ctx context.Context, client tempopb.MetricsGeneratorClient) (any, error) {
 		return client.QueryRange(ctx, req)
-	}
-	results, err := q.forGivenGenerators(ctx, replicationSet, forEach)
+	})
 	if err != nil {
 		_ = level.Error(log.Logger).Log("msg", "error querying generators in Querier.queryRangeRecent", "err", err)
 		return nil, fmt.Errorf("error querying generators in Querier.queryRangeRecent: %w", err)

--- a/modules/querier/querier_query_range.go
+++ b/modules/querier/querier_query_range.go
@@ -3,7 +3,6 @@ package querier
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/go-kit/log/level"
@@ -37,21 +36,18 @@ func (q *Querier) queryRangeRecent(ctx context.Context, req *tempopb.QueryRangeR
 		return nil, err
 	}
 
-	mtx := sync.Mutex{} // combiner doesn't lock, so take lock before calling Combine to make is safe
-	forEach := func(ctx context.Context, client tempopb.MetricsGeneratorClient) error {
-		resp, err := client.QueryRange(ctx, req)
-		if err != nil {
-			return err
-		}
-		mtx.Lock()
-		defer mtx.Unlock()
-		c.Combine(resp)
-		return nil
+	forEach := func(ctx context.Context, client tempopb.MetricsGeneratorClient) (any, error) {
+		return client.QueryRange(ctx, req)
 	}
-	err = q.forGivenGenerators(ctx, replicationSet, forEach)
+	results, err := q.forGivenGenerators(ctx, replicationSet, forEach)
 	if err != nil {
 		_ = level.Error(log.Logger).Log("msg", "error querying generators in Querier.queryRangeRecent", "err", err)
 		return nil, fmt.Errorf("error querying generators in Querier.queryRangeRecent: %w", err)
+	}
+
+	for _, result := range results {
+		resp := result.(*tempopb.QueryRangeResponse)
+		c.Combine(resp)
 	}
 
 	return c.Response(), nil


### PR DESCRIPTION
**What this PR does**:
A panic was [introduced here](https://github.com/grafana/tempo/pull/4100) by abusing the ring forEach function to collect results. [replicationSet.Do](https://github.com/grafana/tempo/blob/main/modules/querier/querier.go#L404) can return before all reads are complete if quorum is reached. Under certain, rare circumstances this caused the forEach function to modify a result [here](https://github.com/grafana/tempo/blob/main/modules/querier/querier.go#L240) after it has already been returned and was being marshalled by the gRPC stack into proto. 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`