### PR TITLE
[rhythm] Improve Kafka partition management with idle consumer group and dynamic rebalancing

### DIFF
--- a/example/docker-compose/ingest-storage/docker-compose.yaml
+++ b/example/docker-compose/ingest-storage/docker-compose.yaml
@@ -70,6 +70,21 @@ services:
   #    environment:
   #      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
 
+  ingester-3:
+    image: *tempoImage
+    depends_on:
+      - kafka
+    command: "-target=ingester -config.file=/etc/tempo.yaml"
+    restart: always
+    volumes:
+      - ./tempo.yaml:/etc/tempo.yaml
+    ports:
+      - "3200"   # tempo
+    hostname: ingester-3
+  # Uncomment the following lines to enable tracing
+  #    environment:
+  #      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
+
   query-frontend:
     image: *tempoImage
     command: "-target=query-frontend -config.file=/etc/tempo.yaml -log.level=debug"

--- a/modules/blockbuilder/blockbuilder.go
+++ b/modules/blockbuilder/blockbuilder.go
@@ -186,6 +186,9 @@ func (b *BlockBuilder) starting(ctx context.Context) (err error) {
 			b.onRevoked(m)
 		}),
 	)
+	if err != nil {
+		return fmt.Errorf("failed to create kafka group reader client: %w", err)
+	}
 
 	boff := backoff.New(ctx, backoff.Config{
 		MinBackoff: 100 * time.Millisecond,

--- a/pkg/ingest/balancer.go
+++ b/pkg/ingest/balancer.go
@@ -95,6 +95,10 @@ func (s syncAssignments) IntoSyncAssignment() []kmsg.SyncGroupRequestGroupAssign
 }
 
 func (b *cooperativeActiveStickyBalancer) Balance(balancer *kgo.ConsumerBalancer, topics map[string]int32) kgo.IntoSyncAssignment {
+	// TODO: This function assumes that the active partitions are always the lowest numbered partitions.
+	//  This is true most of the time, but not guaranteed. It should be changed to find the active/inactive partitions,
+	//  instead of assuming the first N partitions are active.
+
 	// Get active partition count
 	actives := b.partitionRing.PartitionRing().PartitionsCount()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Simplify the Kafka partition management in Tempo's block builder component with two changes:

1. Idle Consumer Group for Partition Assignment:
    - Implemented a secondary "idle" consumer group that tracks partition assignments without consuming data.
    - Added partition state tracking with metrics for better observability
2. Dynamic Partition Rebalancing:
    - Modified the partition monitoring to trigger rebalances when active/inactive partitions change

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`