### PR TITLE
chore: increase query frontend default batch size from 5 to 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [ENHANCEMENT] Use distroless base container images for improved security [#4556](https://github.com/grafana/tempo/pull/4556) (@carles-grafana)
 * [ENHANCEMENT] rythm: add block builder to resources dashboard[#4556](https://github.com/grafana/tempo/pull/4669) (@javiermolinar)
 * [ENHANCEMENT] update dskit to latest version[#4681](https://github.com/grafana/tempo/pull/4681) (@javiermolinar)
+* [ENHANCEMENT] Increase query-frontend default batch size [#4844](https://github.com/grafana/tempo/pull/4844) (@javiermolinar)
 * [ENHANCEMENT] Improve TraceQL perf by reverting EqualRowNumber to an inlineable function.[#4705](https://github.com/grafana/tempo/pull/4705) (@joe-elliott)
 * [ENHANCEMENT] rhythm: fair partition consumption in blockbuilders[#4655](https://github.com/grafana/tempo/pull/4655) (@javiermolinar)
 * [ENHANCEMENT] TraceQL: add support for querying by parent span id [#4692](https://github.com/grafana/tempo/pull/4692) (@ie-pham)

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -630,7 +630,7 @@ query_frontend:
 
     # The number of jobs to batch together in one http request to the querier. Set to 1 to
     # disable.
-    # (default: 5)
+    # (default: 7)
     [max_batch_size: <int>]
 
     # Enable multi-tenant queries.

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -310,7 +310,7 @@ querier:
     query_relevant_ingesters: false
 query_frontend:
     max_outstanding_per_tenant: 2000
-    max_batch_size: 5
+    max_batch_size: 7
     log_query_request_headers: ""
     max_retries: 2
     search:

--- a/docs/sources/tempo/operations/backend_search.md
+++ b/docs/sources/tempo/operations/backend_search.md
@@ -208,8 +208,8 @@ Batching pushes jobs faster to the queriers, and reduce the time spent waiting a
 
 #### Guidelines
 
-* Default value of `max_batch_size` is set to `5`.
-* We DO NOT recommend changing the batch size from the default value of `5`. Based on testing at Grafana Labs, `5` is a good default.
+* Default value of `max_batch_size` is set to `7`.
+* We DO NOT recommend changing the batch size from the default value of `7`. Based on testing at Grafana Labs, `7` is a good default.
 * If the batch size is big, you push more jobs at once but it takes longer for the querier to process the batch and return the results back.
 * Big batch size will increase the latency of the querier requests, and they might start hitting timeouts of 5xx, which will increase the rate of retries.
 * Bigger `max_batch_size` results in pushing too many jobs to the queriers. The jobs then have to be canceled if a query is exited early.

--- a/modules/frontend/config.go
+++ b/modules/frontend/config.go
@@ -69,7 +69,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {
 	}
 
 	cfg.Config.MaxOutstandingPerTenant = 2000
-	cfg.Config.MaxBatchSize = 5
+	cfg.Config.MaxBatchSize = 7
 	cfg.MaxRetries = 2
 	cfg.ResponseConsumers = 10
 	cfg.Search = SearchConfig{


### PR DESCRIPTION
**What this PR does**:
This PR increases the default batch size from 5 to 7 to improve workload handling and reduce latency.

We recently introduced a mechanism to assign weights to query frontend jobs, allowing for better workload distribution between the frontend and queries: [#4076](https://github.com/grafana/tempo/pull/4076).

Our tests showed that the previous default batch size of 5 led to increased overall latency. With the new weighted scheduling in place, we can safely push more jobs simultaneously, making it beneficial to raise the batch size.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`