### PR TITLE
chore: fix ingester flaky test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [ENHANCEMENT] Rewrite traces using rebatching [#4690](https://github.com/grafana/tempo/pull/4690) (@stoewer @joe-elliott)
 * [ENHANCEMENT] Reorder span iterators [#4754](https://github.com/grafana/tempo/pull/4754) (@stoewer)
 * [ENHANCEMENT] Update minio to version [#4341](https://github.com/grafana/tempo/pull/4568) (@javiermolinar)
+* [ENHANCEMENT] Fix flaky ingester test [#4846](https://github.com/grafana/tempo/pull/4846) (@javiermolinar)
 * [ENHANCEMENT] Prevent queries in the ingester from blocking flushing traces to disk and memory spikes. [#4483](https://github.com/grafana/tempo/pull/4483) (@joe-elliott)
 * [ENHANCEMENT] Update tempo operational dashboard for new block-builder and v2 traces api [#4559](https://github.com/grafana/tempo/pull/4559) (@mdisibio)
 * [ENHANCEMENT] Improve metrics-generator performance and stability by applying queue back pressure and concurrency [#4721](https://github.com/grafana/tempo/pull/4721) (@mdisibio)

--- a/modules/ingester/instance_test.go
+++ b/modules/ingester/instance_test.go
@@ -552,7 +552,7 @@ func TestInstanceFailsLargeTracesEvenAfterFlushing(t *testing.T) {
 	i, err := ingester.getOrCreateInstance(testTenantID)
 	require.NoError(t, err)
 
-	req := makeRequestWithByteLimit(maxTraceBytes, id)
+	req := makeRequestWithByteLimit(maxTraceBytes-100, id)
 	reqSize := 0
 	for _, b := range req.Traces {
 		reqSize += len(b.Slice)
@@ -561,7 +561,7 @@ func TestInstanceFailsLargeTracesEvenAfterFlushing(t *testing.T) {
 	// Fill up trace to max
 	response := i.PushBytesRequest(ctx, req)
 	errored, _, _ := CheckPushBytesError(response)
-	require.False(t, errored, "push failed: %w", response.ErrorsByTrace)
+	require.False(t, errored, "push failed: %+v", response.ErrorsByTrace)
 
 	// Pushing again fails
 	response = i.PushBytesRequest(ctx, req)


### PR DESCRIPTION
**What this PR does**:
Try to fix a flaky test and improve the assert output

```
modules/ingester TestInstanceFailsLargeTracesEvenAfterFlushing (0.04s)
    instance_test.go:564: 
        	Error Trace:	/home/runner/work/tempo/tempo/modules/ingester/instance_test.go:564
        	Error:      	Should be false
        	Test:       	TestInstanceFailsLargeTracesEvenAfterFlushing
        	Messages:   	push failed: %!w([]tempopb.PushErrorReason=[2])
```

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`