### PR TITLE
adjust backport workflow to use github app

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -26,8 +26,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ env.APP_ID }}
-          private-key: ${{ env.PRIVATE_KEY }}
+          app-id: ${{secrets.APP_ID}}
+          private-key: ${{secrets.APP_PRIVATE_KEY}}
           owner: ${{ github.repository_owner }}
 
       - name: Checkout Actions

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -6,15 +6,30 @@
 # command does not include "-m <n>" arg required for merge commits.
 name: Backport
 on:
-  pull_request_target:
+  pull_request:
     types:
       - closed
       - labeled
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   main:
-    runs-on: ubuntu-24.04
+    # this action keeps failing in all forks, only run in grafana/tempo.
+    # stats collection action is only useful in main repo.
+    if: github.repository == 'grafana/tempo'
+    runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ env.APP_ID }}
+          private-key: ${{ env.PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Checkout Actions
         uses: actions/checkout@v4
         with:
@@ -28,6 +43,6 @@ jobs:
       - name: Run backport
         uses: ./actions/backport
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{ steps.app-token.outputs.token }}
           labelsToAdd: "backport"
           title: "[{{base}}] {{originalTitle}}"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -17,8 +17,7 @@ permissions:
 
 jobs:
   main:
-    # this action keeps failing in all forks, only run in grafana/tempo.
-    # stats collection action is only useful in main repo.
+    # skip it in all forks, only run in grafana/tempo.
     if: github.repository == 'grafana/tempo'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
**What this PR does**:

This change does following things:
- move away from `pull_request_target` as it's not recommended
- move to using github app to trigger CI on backport PRs, see more https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs
- limit the workflow to only run on grafana/tempo so it doesn't run in forks.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`