### PR TITLE
Pass context to the poller.Do method for clean shutdown in tests

### DIFF
--- a/integration/poller/poller_test.go
+++ b/integration/poller/poller_test.go
@@ -177,8 +177,11 @@ func TestPollerOwnership(t *testing.T) {
 					require.Equal(t, 0, len(cmResults))
 				}
 
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+
 				l := blocklist.New()
-				mm, cm, err := blocklistPoller.Do(l)
+				mm, cm, err := blocklistPoller.Do(ctx, l)
 				require.NoError(t, err)
 				// t.Logf("mm: %v", mm)
 				// t.Logf("cm: %v", cm)
@@ -285,7 +288,8 @@ func TestTenantDeletion(t *testing.T) {
 				var cc backend.Compactor
 
 				listBlockConcurrency := 3
-				ctx := context.Background()
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
 
 				e := hhh.Endpoint(hhh.HTTPPort())
 				switch tc.name {
@@ -321,7 +325,7 @@ func TestTenantDeletion(t *testing.T) {
 				}, OwnsEverythingSharder, r, cc, w, logger)
 
 				l := blocklist.New()
-				mm, cm, err := blocklistPoller.Do(l)
+				mm, cm, err := blocklistPoller.Do(ctx, l)
 				require.NoError(t, err)
 				t.Logf("mm: %v", mm)
 				t.Logf("cm: %v", cm)
@@ -339,7 +343,7 @@ func TestTenantDeletion(t *testing.T) {
 
 				time.Sleep(500 * time.Millisecond)
 
-				_, _, err = blocklistPoller.Do(l)
+				_, _, err = blocklistPoller.Do(ctx, l)
 				require.NoError(t, err)
 
 				tennants, err = r.Tenants(ctx)
@@ -357,7 +361,7 @@ func TestTenantDeletion(t *testing.T) {
 				}, OwnsEverythingSharder, r, cc, w, logger)
 
 				// Again
-				_, _, err = blocklistPoller.Do(l)
+				_, _, err = blocklistPoller.Do(ctx, l)
 				require.NoError(t, err)
 
 				tennants, err = r.Tenants(ctx)

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -136,7 +136,7 @@ func NewPoller(cfg *PollerConfig, sharder JobSharder, reader backend.Reader, com
 }
 
 // Do does the doing of getting a blocklist
-func (p *Poller) Do(previous *List) (PerTenant, PerTenantCompacted, error) {
+func (p *Poller) Do(ctx context.Context, previous *List) (PerTenant, PerTenantCompacted, error) {
 	start := time.Now()
 	defer func() {
 		diff := time.Since(start).Seconds()
@@ -145,7 +145,7 @@ func (p *Poller) Do(previous *List) (PerTenant, PerTenantCompacted, error) {
 		backend.ClearDedicatedColumns()
 	}()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	ctx, span := tracer.Start(ctx, "Poller.Do")

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -592,7 +592,7 @@ func (rw *readerWriter) EnablePolling(ctx context.Context, sharder blocklist.Job
 
 	// do the first poll cycle synchronously. this will allow the caller to know
 	// that when this method returns the block list is updated
-	rw.pollBlocklist()
+	rw.pollBlocklist(ctx)
 
 	go rw.pollingLoop(ctx)
 }
@@ -605,13 +605,13 @@ func (rw *readerWriter) pollingLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			rw.pollBlocklist()
+			rw.pollBlocklist(ctx)
 		}
 	}
 }
 
-func (rw *readerWriter) pollBlocklist() {
-	blocklist, compactedBlocklist, err := rw.blocklistPoller.Do(rw.blocklist)
+func (rw *readerWriter) pollBlocklist(ctx context.Context) {
+	blocklist, compactedBlocklist, err := rw.blocklistPoller.Do(ctx, rw.blocklist)
 	if err != nil {
 		level.Error(rw.logger).Log("msg", "failed to poll blocklist", "err", err)
 		return


### PR DESCRIPTION
**What this PR does**:

Sometimes in tests, I want to populate the `local` backend and poll it as a dependency for whatever I'm testing.  I occasionally see strange behavior when the go routine is still running when the test directory is cleaning up after a test.  To address this situation, we can pass a context into the `poller.Do` to allow for clean shutdown.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`