### PR TITLE
WIP: generator registry stale markers

### DIFF
--- a/modules/generator/instance.go
+++ b/modules/generator/instance.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/grafana/tempo/modules/generator/processor"
+	"github.com/grafana/tempo/modules/generator/processor/hostinfo"
 	"github.com/grafana/tempo/modules/generator/processor/localblocks"
 	"github.com/grafana/tempo/modules/generator/processor/servicegraphs"
 	"github.com/grafana/tempo/modules/generator/processor/spanmetrics"
@@ -37,6 +38,7 @@ var (
 		spanmetrics.Count.String(),
 		spanmetrics.Latency.String(),
 		spanmetrics.Size.String(),
+		hostinfo.Name,
 	}
 
 	metricActiveProcessors = promauto.NewGaugeVec(prometheus.GaugeOpts{

--- a/modules/generator/processor/hostinfo/processor.go
+++ b/modules/generator/processor/hostinfo/processor.go
@@ -12,7 +12,6 @@ import (
 const (
 	Name = "host-info"
 
-	hostInfoMetric     = "traces_host_info"
 	hostIdentifierAttr = "grafana.host.id"
 )
 

--- a/modules/generator/processor/hostinfo/processor_test.go
+++ b/modules/generator/processor/hostinfo/processor_test.go
@@ -43,10 +43,10 @@ func TestHostInfo(t *testing.T) {
 	lbls0 := labels.FromMap(map[string]string{
 		hostIdentifierAttr: "test0",
 	})
-	assert.Equal(t, 1.0, testRegistry.Query(hostInfoMetric, lbls0))
+	assert.Equal(t, 1.0, testRegistry.Query(defaultHostInfoMetric, lbls0))
 
 	lbls1 := labels.FromMap(map[string]string{
 		hostIdentifierAttr: "test1",
 	})
-	assert.Equal(t, 1.0, testRegistry.Query(hostInfoMetric, lbls1))
+	assert.Equal(t, 1.0, testRegistry.Query(defaultHostInfoMetric, lbls1))
 }

--- a/modules/generator/registry/counter.go
+++ b/modules/generator/registry/counter.go
@@ -33,6 +33,7 @@ type counterSeries struct {
 	// to the desired value.  This avoids Prometheus throwing away the first
 	// value in the series, due to the transition from null -> x.
 	firstSeries *atomic.Bool
+	stale       *atomic.Bool
 }
 
 var (
@@ -119,12 +120,14 @@ func (c *counter) newSeries(labelValueCombo *LabelValueCombo, value float64) *co
 		value:       atomic.NewFloat64(value),
 		lastUpdated: atomic.NewInt64(time.Now().UnixMilli()),
 		firstSeries: atomic.NewBool(true),
+		stale:       atomic.NewBool(false),
 	}
 }
 
 func (c *counter) updateSeries(s *counterSeries, value float64) {
 	s.value.Add(value)
 	s.lastUpdated.Store(time.Now().UnixMilli())
+	s.stale.Store(false)
 }
 
 func (c *counter) name() string {
@@ -133,11 +136,11 @@ func (c *counter) name() string {
 
 func (c *counter) collectMetrics(appender storage.Appender, timeMs int64) (activeSeries int, err error) {
 	c.seriesMtx.RLock()
-	defer c.seriesMtx.RUnlock()
 
 	activeSeries = len(c.series)
+	staleSeries := []uint64{}
 
-	for _, s := range c.series {
+	for hash, s := range c.series {
 		// If we are about to call Append for the first time on a series, we need
 		// to first insert a 0 value to allow Prometheus to start from a non-null
 		// value.
@@ -147,30 +150,55 @@ func (c *counter) collectMetrics(appender storage.Appender, timeMs int64) (activ
 			endOfLastMinuteMs := getEndOfLastMinuteMs(timeMs)
 			_, err = appender.Append(0, s.labels, endOfLastMinuteMs, 0)
 			if err != nil {
+				c.seriesMtx.RUnlock()
 				return
 			}
 			s.registerSeenSeries()
 		}
 
-		_, err = appender.Append(0, s.labels, timeMs, s.value.Load())
-		if err != nil {
-			return
+		if s.stale.Load() {
+			_, err = appender.Append(0, s.labels, timeMs, staleMarker())
+			if err != nil {
+				c.seriesMtx.RUnlock()
+				return
+			}
+			staleSeries = append(staleSeries, hash)
+			continue
 		}
 
-		// TODO: support exemplars
+		_, err = appender.Append(0, s.labels, timeMs, s.value.Load())
+		if err != nil {
+			c.seriesMtx.RUnlock()
+			return
+		}
+	}
+	c.seriesMtx.RUnlock()
+
+	// TODO: support exemplars
+
+	if len(staleSeries) > 0 {
+		c.seriesMtx.Lock()
+		defer c.seriesMtx.Unlock()
+
+		for _, hash := range staleSeries {
+			if s, ok := c.series[hash]; ok && s.stale.Load() {
+				delete(c.series, hash)
+			}
+		}
+
+		c.onRemoveSeries(uint32(len(staleSeries)))
 	}
 
 	return
 }
 
 func (c *counter) removeStaleSeries(staleTimeMs int64) {
-	c.seriesMtx.Lock()
-	defer c.seriesMtx.Unlock()
+	c.seriesMtx.RLock()
+	defer c.seriesMtx.RUnlock()
 
-	for hash, s := range c.series {
+	for _, s := range c.series {
 		if s.lastUpdated.Load() < staleTimeMs {
-			delete(c.series, hash)
-			c.onRemoveSeries(1)
+			s.stale.Store(true)
 		}
 	}
 }

--- a/modules/generator/registry/counter_test.go
+++ b/modules/generator/registry/counter_test.go
@@ -150,7 +150,9 @@ func Test_counter_removeStaleSeries(t *testing.T) {
 	c.Inc(newLabelValueCombo([]string{"label"}, []string{"value-2"}), 2.0)
 
 	c.removeStaleSeries(timeMs)
-
+	activeSeries, err := c.collectMetrics(&capturingAppender{}, timeMs)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, activeSeries)
 	assert.Equal(t, 1, removedSeries)
 
 	collectionTimeMs = time.Now().UnixMilli()

--- a/modules/generator/registry/gauge.go
+++ b/modules/generator/registry/gauge.go
@@ -185,7 +185,6 @@ func (g *gauge) collectMetrics(appender storage.Appender, timeMs int64) (activeS
 		for _, hash := range staleSeries {
 			if s, ok := g.series[hash]; ok && s.stale.Load() {
 				delete(g.series, hash)
-				activeSeries--
 			}
 		}
 

--- a/modules/generator/registry/gauge.go
+++ b/modules/generator/registry/gauge.go
@@ -100,6 +100,8 @@ func (g *gauge) updateSeries(labelValueCombo *LabelValueCombo, value float64, op
 		return
 	}
 
+	newSeries := g.newSeries(labelValueCombo, value)
+
 	// acquire full lock and recheck before adding
 	g.seriesMtx.Lock()
 	defer g.seriesMtx.Unlock()
@@ -114,7 +116,7 @@ func (g *gauge) updateSeries(labelValueCombo *LabelValueCombo, value float64, op
 	}
 
 	// create and add new series
-	g.series[hash] = g.newSeries(labelValueCombo, value)
+	g.series[hash] = newSeries
 }
 
 func (g *gauge) newSeries(labelValueCombo *LabelValueCombo, value float64) *gaugeSeries {

--- a/modules/generator/registry/gauge_test.go
+++ b/modules/generator/registry/gauge_test.go
@@ -172,7 +172,7 @@ func Test_gauge_removeStaleSeries(t *testing.T) {
 	c.removeStaleSeries(timeMs)
 	activeSeries, err := c.collectMetrics(&capturingAppender{}, timeMs)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, activeSeries)
+	assert.Equal(t, 2, activeSeries)
 	assert.Equal(t, 1, removedSeries)
 
 	collectionTimeMs = time.Now().UnixMilli()
@@ -296,7 +296,7 @@ func Test_gauge_sendStaleMarkers(t *testing.T) {
 
 	activeSeries, err := c.collectMetrics(appender, collectionTimeMs)
 	assert.NoError(t, err)
-	assert.Equal(t, 0, activeSeries)
+	assert.Equal(t, 1, activeSeries)
 	assert.False(t, appender.isCommitted)
 	assert.False(t, appender.isRolledback)
 	assert.Equal(t, expectedSamples[0].String(), appender.samples[0].String())

--- a/modules/generator/registry/histogram_test.go
+++ b/modules/generator/registry/histogram_test.go
@@ -258,7 +258,9 @@ func Test_histogram_removeStaleSeries(t *testing.T) {
 	h.ObserveWithExemplar(newLabelValueCombo([]string{"label"}, []string{"value-2"}), 2.5, "", 1.0)
 
 	h.removeStaleSeries(timeMs)
-
+	activeSeries, err := h.collectMetrics(&capturingAppender{}, timeMs)
+	assert.NoError(t, err)
+	assert.Equal(t, 10, activeSeries)
 	assert.Equal(t, 1, removedSeries)
 
 	collectionTimeMs = time.Now().UnixMilli()

--- a/modules/generator/registry/registry.go
+++ b/modules/generator/registry/registry.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"sync"
 	"time"
@@ -87,7 +88,10 @@ type metric interface {
 	removeStaleSeries(staleTimeMs int64)
 }
 
-const highestAggregationInterval = 1 * time.Minute
+const (
+	staleMarkerValue           = 0x7ff0000000000002
+	highestAggregationInterval = 1 * time.Minute
+)
 
 var _ Registry = (*ManagedRegistry)(nil)
 
@@ -291,4 +295,8 @@ func hasClassicHistograms(s HistogramMode) bool {
 
 func getEndOfLastMinuteMs(timeMs int64) int64 {
 	return time.UnixMilli(timeMs).Truncate(highestAggregationInterval).Add(-1 * time.Second).UnixMilli()
+}
+
+func staleMarker() float64 {
+	return math.Float64frombits(staleMarkerValue)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This PR adds stale marker support to the metrics generator registry. A series is marked stale when it's stale duration has elapsed. During the next collection interval, any series marked stale will append a stale marker value before removal from the metric's series map. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`