### PR TITLE
TraceQL: fix queries like {.foo && true} and {.foo || false}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [ENHANCEMENT] distributor: add IPv6 support [#4840](https://github.com/grafana/tempo/pull/4840) (@gjacquet)
 * [BUGFIX] Choose a default step for a gRPC streaming query range request if none is provided. [#4546](https://github.com/grafana/tempo/pull/4576) (@joe-elliott)
   Correctly copy exemplars for metrics like `| rate()` when gRPC streaming.
+* [BUGFIX] Fix behavior for queries like {.foo && true} and {.foo || false} [#4855](https://github.com/grafana/tempo/pull/4855) (@stoewer)
 * [BUGFIX] Fix performance bottleneck and file cleanup in block builder [#4550](https://github.com/grafana/tempo/pull/4550) (@mdisibio)
 * [BUGFIX] TraceQL incorrect results for additional spanset filters after a select operation [#4600](https://github.com/grafana/tempo/pull/4600) (@mdisibio)
 * [BUGFIX] TraceQL results caching bug for floats ending in .0 [#4539](https://github.com/grafana/tempo/pull/4539) (@carles-grafana)

--- a/pkg/traceql/ast_conditions.go
+++ b/pkg/traceql/ast_conditions.go
@@ -54,6 +54,12 @@ func (o *BinaryOperation) extractConditions(request *FetchSpansRequest) {
 					Op:        OpNone,
 					Operands:  nil,
 				})
+			} else if o.RHS.(Static).Type == TypeBoolean && (o.Op == OpOr || o.Op == OpAnd) {
+				request.appendCondition(Condition{
+					Attribute: o.LHS.(Attribute),
+					Op:        OpNone,
+					Operands:  nil,
+				})
 			} else {
 				request.appendCondition(Condition{
 					Attribute: o.LHS.(Attribute),
@@ -89,6 +95,12 @@ func (o *BinaryOperation) extractConditions(request *FetchSpansRequest) {
 			return
 		case Attribute:
 			if (o.LHS.(Static).Type == TypeNil && o.Op == OpNotEqual) || !o.Op.isBoolean() { // the fetch layer can't build predicates on operators that are not boolean
+				request.appendCondition(Condition{
+					Attribute: o.RHS.(Attribute),
+					Op:        OpNone,
+					Operands:  nil,
+				})
+			} else if o.LHS.(Static).Type == TypeBoolean && (o.Op == OpOr || o.Op == OpAnd) {
 				request.appendCondition(Condition{
 					Attribute: o.RHS.(Attribute),
 					Op:        OpNone,

--- a/pkg/traceql/ast_conditions_test.go
+++ b/pkg/traceql/ast_conditions_test.go
@@ -105,6 +105,20 @@ func TestSpansetFilter_extractConditions(t *testing.T) {
 			},
 			allConditions: true,
 		},
+		{
+			query: `{ .foo && true }`,
+			conditions: []Condition{
+				newCondition(NewAttribute("foo"), OpNone),
+			},
+			allConditions: true,
+		},
+		{
+			query: `{ true || .foo }`,
+			conditions: []Condition{
+				newCondition(NewAttribute("foo"), OpNone),
+			},
+			allConditions: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.query, func(t *testing.T) {

--- a/tempodb/encoding/vparquet4/block_traceql_test.go
+++ b/tempodb/encoding/vparquet4/block_traceql_test.go
@@ -214,6 +214,8 @@ func TestBackendBlockSearchTraceQL(t *testing.T) {
 		{"service.name present on span", traceql.MustExtractFetchSpansRequestWithMetadata(`{.` + LabelServiceName + ` = "spanservicename"}`)},
 		{"http.status_code doesn't match type of dedicated column", traceql.MustExtractFetchSpansRequestWithMetadata(`{.` + LabelHTTPStatusCode + ` = "500ouch"}`)},
 		{`.foo = "def"`, traceql.MustExtractFetchSpansRequestWithMetadata(`{.foo = "def"}`)},
+		{".bool && true", traceql.MustExtractFetchSpansRequestWithMetadata(`{.bool && true}`)},
+		{"false || .bool", traceql.MustExtractFetchSpansRequestWithMetadata(`{false || .bool}`)},
 		{
 			name: "Range at unscoped",
 			req: traceql.FetchSpansRequest{


### PR DESCRIPTION
**What this PR does**:
Fix behavior for queries single attributes that are &&ed or ||ed with a boolean.

**Which issue(s) this PR fixes**:
Fixes #4839

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`