### PR TITLE
[rhythm] Block-builder graceful shutdown

### DIFF
--- a/modules/blockbuilder/blockbuilder_test.go
+++ b/modules/blockbuilder/blockbuilder_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -412,6 +413,77 @@ func TestBlockbuilder_noDoubleConsumption(t *testing.T) {
 
 	// Verify the total number of traces is correct (1 from each batch)
 	require.Equal(t, 2, countFlushedTraces(store))
+}
+
+func TestBlockbuilder_gracefulShutdown(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(errors.New("test done")) })
+
+	k, address := testkafka.CreateCluster(t, 1, testTopic)
+
+	var cycleState atomic.Bool
+	var consumeCycle sync.WaitGroup
+
+	k.ControlKey(kmsg.OffsetCommit, func(kmsg.Request) (kmsg.Response, error, bool) {
+		cycleState.Store(false)
+		consumeCycle.Done()
+		return nil, nil, false
+	})
+
+	k.ControlKey(kmsg.OffsetFetch, func(kmsg.Request) (kmsg.Response, error, bool) {
+		cycleState.Store(true)
+		consumeCycle.Add(1)
+		return nil, nil, false
+	})
+
+	store := newStore(ctx, t)
+	cfg := blockbuilderConfig(t, address, []int32{0}) // Fix: Properly specify partition
+
+	// Start sending traces in the background
+	go func() {
+		sendTracesFor(t, ctx, newKafkaClient(t, cfg.IngestStorageConfig.Kafka), 60*time.Second, time.Second)
+	}()
+
+	b, err := New(cfg, test.NewTestingLogger(t), newPartitionRingReader(), &mockOverrides{}, store)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, b))
+
+	// Wait for cycle to be ongoing
+	require.Eventually(t, func() bool { return cycleState.Load() }, cfg.ConsumeCycleDuration*2, time.Second)
+
+	// Start the shutdown process
+	stopDone := make(chan struct{})
+	go func() {
+		defer close(stopDone)
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, b))
+	}()
+
+	// Wait until cycle is complete
+	cycleDone := make(chan struct{})
+	go func() {
+		defer close(cycleDone)
+		consumeCycle.Wait()
+	}()
+
+	// Check if shutdown waits for consume cycle to finish
+	select {
+	case <-cycleDone:
+	case <-stopDone:
+		t.Fatal("Shutdown completed before consume cycle finished - not graceful!")
+	case <-time.After(10 * time.Second):
+		t.Fatal("Timed out waiting for consume cycle to finish")
+	}
+
+	// Now wait for the shutdown to complete after we've verified it's graceful
+	select {
+	case <-stopDone:
+		// Good, shutdown completed after we checked
+	case <-time.After(5 * time.Second):
+		t.Fatal("Shutdown didn't complete after consume cycle finished")
+	}
+
+	// Verify blocks were written
+	require.Eventually(t, func() bool { return len(store.BlockMetas(util.FakeTenantID)) > 0 }, 30*time.Second, time.Second)
 }
 
 func blockbuilderConfig(t testing.TB, address string, assignedPartitions []int32) Config {

--- a/operations/jsonnet-compiled/StatefulSet-block-builder.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-block-builder.yaml
@@ -50,6 +50,7 @@ spec:
           name: overrides
       securityContext:
         fsGroup: 10001
+      terminationGracePeriodSeconds: 60
       volumes:
       - configMap:
           name: tempo-block-builder

--- a/operations/jsonnet-compiled/util/jsonnetfile.lock.json
+++ b/operations/jsonnet-compiled/util/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "e6f3db92b7d61f348aed812087f2865b207d7148",
+      "version": "a2d9d8ce88dcff15706a51406c1c1ecb6509a416",
       "sum": "0y3AFX9LQSpfWTxWKSwoLgbt0Wc9nnCwhMH2szKzHv0="
     },
     {
@@ -18,7 +18,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "e6f3db92b7d61f348aed812087f2865b207d7148",
+      "version": "a2d9d8ce88dcff15706a51406c1c1ecb6509a416",
       "sum": "Cc715Y3rgTuimgDFIw+FaKzXSJGRYwt1pFTMbdrNBD8="
     },
     {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Added proper graceful shutdown to the block builder component to ensure operational safety during service termination. Instead of abruptly terminating, it now:

1. Uses a separate cancelable context for consume operations
2. Properly signals when consumption cycles are complete
3. Waits for the current cycle to finish during shutdown

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`