### PR TITLE
[Rhythm] Block builder not mutate blocks across replays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [BUGFIX] TraceQL incorrect results for additional spanset filters after a select operation [#4600](https://github.com/grafana/tempo/pull/4600) (@mdisibio)
 * [BUGFIX] TraceQL results caching bug for floats ending in .0 [#4539](https://github.com/grafana/tempo/pull/4539) (@carles-grafana)
 * [BUGFIX] Rhythm: fix sorting order for partition consumption [#4747](https://github.com/grafana/tempo/pull/4747) (@javiermolinar)
+* [BUGFIX] Rhythm: fix block builder to not reuse a block ID if it was already flushed, to prevent read errors [#4872](https://github.com/grafana/tempo/pull/4872) (@mdisibio)
 * [BUGFIX] Fix metrics streaming for all non-trivial metrics [#4624](https://github.com/grafana/tempo/pull/4624) (@joe-elliott)
 * [BUGFIX] Fix starting consuming log [#4539](https://github.com/grafana/tempo/pull/4539) (@javiermolinar)
 * [BUGFIX] Rhythm - fix adjustment of the start and end range for livetraces blocks [#4746](https://github.com/grafana/tempo/pull/4746) (@javiermolinar)

--- a/modules/blockbuilder/blockbuilder_test.go
+++ b/modules/blockbuilder/blockbuilder_test.go
@@ -102,7 +102,8 @@ func TestBlockbuilder_without_partitions_assigned_returns_an_error(t *testing.T)
 }
 
 func TestBlockbuilder_getAssignedPartitions(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(errors.New("test done")) })
 
 	store := newStore(ctx, t)
 	cfg := blockbuilderConfig(t, "localhost", []int32{0, 2, 4, 6})

--- a/modules/blockbuilder/partition_writer.go
+++ b/modules/blockbuilder/partition_writer.go
@@ -20,7 +20,7 @@ const flushConcurrency = 4
 
 type partitionSectionWriter interface {
 	pushBytes(ts time.Time, tenant string, req *tempopb.PushBytesRequest) error
-	flush(ctx context.Context, store tempodb.Writer) error
+	flush(ctx context.Context, r tempodb.Reader, w tempodb.Writer, c tempodb.Compactor) error
 }
 
 type writer struct {
@@ -80,7 +80,7 @@ func (p *writer) pushBytes(ts time.Time, tenant string, req *tempopb.PushBytesRe
 	return nil
 }
 
-func (p *writer) flush(ctx context.Context, store tempodb.Writer) error {
+func (p *writer) flush(ctx context.Context, r tempodb.Reader, w tempodb.Writer, c tempodb.Compactor) error {
 	// TODO - Retry with backoff?
 
 	// Flush tenants concurrently
@@ -93,7 +93,7 @@ func (p *writer) flush(ctx context.Context, store tempodb.Writer) error {
 			st := time.Now()
 
 			level.Info(p.logger).Log("msg", "flushing tenant", "tenant", i.tenantID)
-			err := i.Flush(ctx, store)
+			err := i.Flush(ctx, r, w, c)
 			if err != nil {
 				return err
 			}

--- a/modules/blockbuilder/tenant_store.go
+++ b/modules/blockbuilder/tenant_store.go
@@ -88,15 +88,41 @@ func (s *tenantStore) AppendTrace(traceID []byte, tr []byte, ts time.Time) error
 	return nil
 }
 
-func (s *tenantStore) Flush(ctx context.Context, store tempodb.Writer) error {
+func (s *tenantStore) Flush(ctx context.Context, r tempodb.Reader, w tempodb.Writer, c tempodb.Compactor) error {
 	if s.liveTraces.Len() == 0 {
 		// This can happen if the tenant instance was created but
 		// no live traces were successfully pushed. i.e. all exceeded max trace size.
 		return nil
 	}
 
+	blockID, existingBlocksToBeCompacted, err := s.determineBlockIDs(ctx, r)
+	if err != nil {
+		return err
+	}
+
+	// TODO - Check if the existing block can be reused and exit early
+
+	if len(existingBlocksToBeCompacted) > 0 {
+		level.Info(s.logger).Log(
+			"msg", "Found existing blocks, marking them compacted",
+			"tenant", s.tenantID,
+			"existing_blocks", existingBlocksToBeCompacted,
+		)
+
+		for _, blockID := range existingBlocksToBeCompacted {
+			level.Info(s.logger).Log(
+				"msg", "Marking existing block compacted",
+				"tenant", s.tenantID,
+				"blockid", blockID,
+			)
+			if err := c.MarkBlockCompacted(s.tenantID, blockID); err != nil {
+				return err
+			}
+		}
+	}
+
 	// Initial meta for creating the block
-	meta := backend.NewBlockMeta(s.tenantID, uuid.UUID(s.idGenerator.NewID()), s.enc.Version(), backend.EncNone, "")
+	meta := backend.NewBlockMeta(s.tenantID, (uuid.UUID)(blockID), s.enc.Version(), backend.EncNone, "")
 	meta.DedicatedColumns = s.overrides.DedicatedColumns(s.tenantID)
 	meta.ReplicationFactor = 1
 	meta.TotalObjects = int64(s.liveTraces.Len())
@@ -131,7 +157,7 @@ func (s *tenantStore) Flush(ctx context.Context, store tempodb.Writer) error {
 		return err
 	}
 
-	if err := store.WriteBlock(ctx, NewWriteableBlock(newBlock, reader, writer)); err != nil {
+	if err := w.WriteBlock(ctx, NewWriteableBlock(newBlock, reader, writer)); err != nil {
 		return err
 	}
 
@@ -185,4 +211,34 @@ func (s *tenantStore) adjustTimeRangeForSlack(start, end time.Time) (time.Time, 
 	}
 
 	return start, end
+}
+
+func (s *tenantStore) determineBlockIDs(ctx context.Context, r tempodb.Reader) (backend.UUID, []backend.UUID, error) {
+	var (
+		nextID                      backend.UUID
+		existingBlocksToBeCompacted []backend.UUID
+	)
+
+	for {
+		nextID = s.idGenerator.NewID()
+
+		meta, compactedMeta, err := r.BlockMeta(ctx, s.tenantID, nextID)
+		if err != nil {
+			return backend.UUID{}, nil, err
+		}
+
+		if compactedMeta != nil {
+			// This ID is already in use but does not need to be compacted again
+			continue
+		}
+
+		if meta != nil {
+			// This ID is already in use and needs to be compacted
+			existingBlocksToBeCompacted = append(existingBlocksToBeCompacted, nextID)
+			continue
+		}
+
+		// This block is available
+		return nextID, existingBlocksToBeCompacted, nil
+	}
 }

--- a/modules/blockbuilder/tenant_store.go
+++ b/modules/blockbuilder/tenant_store.go
@@ -104,7 +104,7 @@ func (s *tenantStore) Flush(ctx context.Context, r tempodb.Reader, w tempodb.Wri
 
 	if len(existingBlocksToBeCompacted) > 0 {
 		for _, blockID := range existingBlocksToBeCompacted {
-			level.Info(s.logger).Log(
+			level.Warn(s.logger).Log(
 				"msg", "Marking existing block compacted",
 				"tenant", s.tenantID,
 				"blockid", blockID,

--- a/modules/blockbuilder/tenant_store.go
+++ b/modules/blockbuilder/tenant_store.go
@@ -103,12 +103,6 @@ func (s *tenantStore) Flush(ctx context.Context, r tempodb.Reader, w tempodb.Wri
 	// TODO - Check if the existing block can be reused and exit early
 
 	if len(existingBlocksToBeCompacted) > 0 {
-		level.Info(s.logger).Log(
-			"msg", "Found existing blocks, marking them compacted",
-			"tenant", s.tenantID,
-			"existing_blocks", existingBlocksToBeCompacted,
-		)
-
 		for _, blockID := range existingBlocksToBeCompacted {
 			level.Info(s.logger).Log(
 				"msg", "Marking existing block compacted",
@@ -213,12 +207,7 @@ func (s *tenantStore) adjustTimeRangeForSlack(start, end time.Time) (time.Time, 
 	return start, end
 }
 
-func (s *tenantStore) determineBlockIDs(ctx context.Context, r tempodb.Reader) (backend.UUID, []backend.UUID, error) {
-	var (
-		nextID                      backend.UUID
-		existingBlocksToBeCompacted []backend.UUID
-	)
-
+func (s *tenantStore) determineBlockIDs(ctx context.Context, r tempodb.Reader) (nextID backend.UUID, existingBlocksToBeCompacted []backend.UUID, err error) {
 	for {
 		nextID = s.idGenerator.NewID()
 

--- a/modules/blockbuilder/tenant_store_test.go
+++ b/modules/blockbuilder/tenant_store_test.go
@@ -177,7 +177,7 @@ func writeHistoricalData(t *testing.T, count int, startTime time.Time, cycleDura
 		}
 	}
 
-	err = ts.Flush(ctx, store)
+	err = ts.Flush(ctx, store, store, store)
 	require.NoError(t, err)
 
 	// This forces another immediate poll

--- a/modules/frontend/search_sharder_test.go
+++ b/modules/frontend/search_sharder_test.go
@@ -62,6 +62,10 @@ func (m *mockReader) Find(context.Context, string, common.ID, string, string, in
 	return nil, nil, nil
 }
 
+func (m *mockReader) BlockMeta(context.Context, string, backend.UUID) (*backend.BlockMeta, *backend.CompactedBlockMeta, error) {
+	return nil, nil, nil
+}
+
 func (m *mockReader) BlockMetas(string) []*backend.BlockMeta {
 	return m.metas
 }

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -283,12 +283,16 @@ func (rw *readerWriter) BlockMeta(ctx context.Context, tenantID string, blockID 
 		return nil, nil, err
 	}
 
+	if meta != nil {
+		return meta, nil, nil
+	}
+
 	compactedMeta, err := rw.c.CompactedBlockMeta((uuid.UUID)(blockID), tenantID)
 	if err != nil && !errors.Is(err, backend.ErrDoesNotExist) {
 		return nil, nil, err
 	}
 
-	return meta, compactedMeta, nil
+	return nil, compactedMeta, nil
 }
 
 func (rw *readerWriter) BlockMetas(tenantID string) []*backend.BlockMeta {


### PR DESCRIPTION
**What this PR does**:
Blocks in Tempo are immutable.  Once written, they are never changed, and the compactor and polling rely on this.  The current implementation of the block builder violates this by reflushing a new data.parquet to the same ID, with possibly different contents.    This gives the situation where the info in the block index no longer matches the contents and queries fail.

This changes the block builder to detect when a block from a previous attempt exists, and instead of overwriting it, mark it compacted and flush a new block.   Eventually the blocks will be repolled and effectively the old block is replaced with the new one.   Any number of replays are tolerated, because we use the deterministic block ID generator to continue forward until the next unused ID is found.

There are multiple efforts in this area, including #4870. Expect more follow up PRs.

Examples of handled scenarios:
* Block builder OOMs after flushing half of the tenants, restarts and begins another consumption cycle on the same commit
* Commit ultimately fails and the cycle must be restarted
* Cycle duration is changed, causing pod to restart. In this case the new block contents will always be different.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`