### PR TITLE
rhythm: retry on commit error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [ENHANCEMENT] Increase query-frontend default batch size [#4844](https://github.com/grafana/tempo/pull/4844) (@javiermolinar) 
 * [ENHANCEMENT] Improve TraceQL perf by reverting EqualRowNumber to an inlineable function.[#4705](https://github.com/grafana/tempo/pull/4705) (@joe-elliott)
 * [ENHANCEMENT] Rhythm: fair partition consumption in blockbuilders [#4655](https://github.com/grafana/tempo/pull/4655) (@javiermolinar)
+* [ENHANCEMENT] Rhythm: retry on commit error [#4874](https://github.com/grafana/tempo/pull/4874) (@javiermolinar)
 * [ENHANCEMENT] Skip creating one span-traces for every pushed spans in metrics generator [#4844](https://github.com/grafana/tempo/pull/4844) (@javiermolinar)
 * [ENHANCEMENT] TraceQL: add support for querying by parent span id [#4692](https://github.com/grafana/tempo/pull/4692) (@ie-pham)
 * [ENHANCEMENT] metrics-generator: allow skipping localblocks and consuming from a different source of data [#4686](https://github.com/grafana/tempo/pull/4686) (@flxbk)

--- a/modules/blockbuilder/blockbuilder.go
+++ b/modules/blockbuilder/blockbuilder.go
@@ -22,7 +22,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/twmb/franz-go/pkg/kadm"
-	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 
@@ -432,15 +431,10 @@ func (b *BlockBuilder) commitOffset(ctx context.Context, offset kadm.Offset, gro
 		MaxRetries: 10,
 	})
 	for boff.Ongoing() {
-		resp, err := b.kadm.CommitOffsets(ctx, group, offsets)
-		commitOffsetErr := resp.Error()
-		if err == nil && commitOffsetErr == nil {
+		err := b.kadm.CommitAllOffsets(ctx, group, offsets)
+		if err == nil {
 			break
 		}
-		if !kerr.IsRetriable(commitOffsetErr) {
-			return commitOffsetErr
-		}
-
 		level.Warn(b.logger).Log(
 			"msg", "failed to commit offset, retrying",
 			"err", err,

--- a/modules/blockbuilder/blockbuilder_test.go
+++ b/modules/blockbuilder/blockbuilder_test.go
@@ -390,7 +390,7 @@ func TestBlockbuilder_retries_on_retriable_commit_error(t *testing.T) {
 	logger := test.NewTestingLogger(t)
 
 	client := newKafkaClient(t, cfg.IngestStorageConfig.Kafka)
-	producedRecords := sendReq(t, ctx, client)
+	producedRecords := sendReq(t, ctx, client, util.FakeTenantID)
 	lastRecordOffset := producedRecords[len(producedRecords)-1].Offset
 
 	b, err := New(cfg, logger, newPartitionRingReader(), &mockOverrides{}, store)
@@ -448,7 +448,7 @@ func TestBlockbuilder_retries_on_commit_error(t *testing.T) {
 	logger := test.NewTestingLogger(t)
 
 	client := newKafkaClient(t, cfg.IngestStorageConfig.Kafka)
-	producedRecords := sendReq(t, ctx, client)
+	producedRecords := sendReq(t, ctx, client, util.FakeTenantID)
 	lastRecordOffset := producedRecords[len(producedRecords)-1].Offset
 
 	b, err := New(cfg, logger, newPartitionRingReader(), &mockOverrides{}, store)
@@ -472,7 +472,7 @@ func TestBlockbuilder_retries_on_commit_error(t *testing.T) {
 	requireLastCommitEquals(t, ctx, client, lastRecordOffset+1)
 }
 
-func TestBlockbuilder_do_not_retry_on_on_retriable_commit_error(t *testing.T) {
+func TestBlockbuilder_do_not_retry_on_retriable_commit_error(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	t.Cleanup(func() { cancel(errors.New("test done")) })
 
@@ -502,7 +502,7 @@ func TestBlockbuilder_do_not_retry_on_on_retriable_commit_error(t *testing.T) {
 	logger := test.NewTestingLogger(t)
 
 	client := newKafkaClient(t, cfg.IngestStorageConfig.Kafka)
-	sendReq(t, ctx, client) // Send broken record
+	sendReq(t, ctx, client, util.FakeTenantID) // Send broken record
 
 	b, err := New(cfg, logger, newPartitionRingReader(), &mockOverrides{}, store)
 	require.NoError(t, err)


### PR DESCRIPTION
**What this PR does**:

It implements a retry strategy to handle transient commit errors



**Checklist**
- [X] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`