### PR TITLE
[tempo-mixin] Adjust TempoBlockListRisingQuickly to include "by (namespace)"

### DIFF
--- a/operations/tempo-mixin/alerts.libsonnet
+++ b/operations/tempo-mixin/alerts.libsonnet
@@ -167,7 +167,7 @@
           {
             alert: 'TempoBlockListRisingQuickly',
             expr: |||
-              avg(tempodb_blocklist_length{namespace=~"%(namespace)s", container="compactor"}) / avg(tempodb_blocklist_length{namespace=~"%(namespace)s", container="compactor"} offset 7d) > 1.4
+              avg by (namespace) (tempodb_blocklist_length{}) / avg by(namespace) (tempodb_blocklist_length{} offset 7d) > 1.4
             ||| % { namespace: $._config.namespace },
             'for': '15m',
             labels: {


### PR DESCRIPTION
A routing issue caused this alert to end up in the wrong place.  Adding a namespace aggregation should resolve the routing.

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`