### PR TITLE
Fix typo in nomad job definition. Fix tempo-monolith config

### DIFF
--- a/example/nomad/tempo-distributed/README.md
+++ b/example/nomad/tempo-distributed/README.md
@@ -16,7 +16,7 @@ Variables
 
 | Name | Value | Description |
 |---|---|---|
-| version | Default = "2.3.1" | Tempo version |
+| version | Default = "2.7.1" | Tempo version |
 | s3_access_key_id | Default = "any" | S3 Access Key ID |
 | s3_secret_access_key | Default = "any" | S3 Secret Access Key |
 
@@ -32,7 +32,7 @@ To deploy a different version change `variable.version` default value or
 specify from command line:
 
 ```shell
-nomad job run -var="version=2.6.1" tempo.hcl
+nomad job run -var="version=2.7.1" tempo.hcl
 ```
 
 ### Scale Tempo

--- a/example/nomad/tempo-distributed/tempo.hcl
+++ b/example/nomad/tempo-distributed/tempo.hcl
@@ -338,7 +338,7 @@ job "tempo" {
     network {
       port "http" {}
       port "grpc" {}
-      port "otpl" { to = 4317 }
+      port "otlp" { to = 4317 }
     }
 
     service {
@@ -356,8 +356,8 @@ job "tempo" {
     }
 
     service {
-      name = "tempo-distributor-otpl"
-      port = "otpl"
+      name = "tempo-distributor-otlp"
+      port = "otlp"
       tags = []
     }
 
@@ -385,7 +385,7 @@ job "tempo" {
         ports = [
           "http",
           "grpc",
-          "otpl",
+          "otlp",
         ]
 
         args = [

--- a/example/nomad/tempo-monolith/README.md
+++ b/example/nomad/tempo-monolith/README.md
@@ -13,7 +13,7 @@ Variables
 
 | Name | Value | Description |
 |---|---|---|
-| version | Default = "2.3.1" | Tempo version |
+| version | Default = "2.7.1" | Tempo version |
 | s3_url | Default = "s3.dummy.url.com" | S3 storage URL |
 | s3_access_key_id | Default = "any" | S3 Access Key ID |
 | s3_secret_access_key | Default = "any" | S3 Secret Access Key |
@@ -31,5 +31,5 @@ To deploy a different version change `variable.version` default value or
 specify from command line:
 
 ```shell
-nomad job run -var="version=2.6.1" tempo.hcl
+nomad job run -var="version=2.7.1" tempo.hcl
 ```

--- a/example/nomad/tempo-monolith/tempo.hcl
+++ b/example/nomad/tempo-monolith/tempo.hcl
@@ -69,8 +69,8 @@ job "tempo" {
     }
 
     service {
-      name = "tempo-otpl"
-      port = "otpl"
+      name = "tempo-otlp"
+      port = "otlp"
       tags = []
     }
 
@@ -84,6 +84,7 @@ job "tempo" {
         ports = [
           "http",
           "grpc",
+          "otlp"
         ]
 
         args = [
@@ -104,7 +105,8 @@ job "tempo" {
             otlp:
               protocols:
                 http:
-                grpc: 0.0.0.0:{{ env "NOMAD_PORT_otlp" }}
+                grpc: 
+                  endpoint: 0.0.0.0:{{ env "NOMAD_PORT_otlp" }}
 
         metrics_generator:
           processor:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Fix typo in nomad job definitions. Add missing `endpoint` for otlp configuration. Update README.md for nomad  exmples

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`