### PR TITLE
[v2.5.x] Remove inline shortcodes

### DIFF
--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -93,7 +93,7 @@ Agent, OpenTelemetry Collector, or Jaeger Agent.
 |  Jaeger | GRPC | [Link](https://www.jaegertracing.io/docs/latest/apis/#span-reporting-apis) |
 |  Zipkin | HTTP | [Link](https://zipkin.io/zipkin-api/) |
 
-For information on how to use the Zipkin endpoint with curl (for debugging purposes), refer to [Pushing spans with HTTP](pushing-spans-with-http/).
+For information on how to use the Zipkin endpoint with curl (for debugging purposes), refer to [Pushing spans with HTTP](pushing-spans-with-http/). 
 
 ### Query
 

--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -93,7 +93,7 @@ Agent, OpenTelemetry Collector, or Jaeger Agent.
 |  Jaeger | GRPC | [Link](https://www.jaegertracing.io/docs/latest/apis/#span-reporting-apis) |
 |  Zipkin | HTTP | [Link](https://zipkin.io/zipkin-api/) |
 
-For information on how to use the Zipkin endpoint with curl (for debugging purposes), refer to [Pushing spans with HTTP](pushing-spans-with-http/). 
+For information on how to use the Zipkin endpoint with curl (for debugging purposes), refer to [Pushing spans with HTTP](pushing-spans-with-http/).
 
 ### Query
 

--- a/docs/sources/tempo/introduction/glossary.md
+++ b/docs/sources/tempo/introduction/glossary.md
@@ -1,5 +1,5 @@
 ---
-description: 'Glossary for traces'
+description: 'Glossary for traces' 
 keywords:
   - Grafana
   - traces

--- a/docs/sources/tempo/introduction/glossary.md
+++ b/docs/sources/tempo/introduction/glossary.md
@@ -1,5 +1,5 @@
 ---
-description: 'Glossary for traces' 
+description: 'Glossary for traces'
 keywords:
   - Grafana
   - traces

--- a/docs/sources/tempo/introduction/glossary.md
+++ b/docs/sources/tempo/introduction/glossary.md
@@ -1,5 +1,5 @@
 ---
-description: "Glossary for traces"
+description: 'Glossary for traces'
 keywords:
   - Grafana
   - traces
@@ -12,28 +12,26 @@ weight: 500
 
 The following terms are often used when discussing traces.
 
-{{< glossary.inline >}}{{ (index (where site.Data.glossary "keys" "intersect" (slice (.Get 0))) 0).value | markdownify }}{{< /glossary.inline >}}
-
 Active series
-: {{< glossary.inline "active series" />}}
+: {{< docs/glossary "active series" />}}
 
 Cardinality
-: {{< glossary.inline "cardinality" />}}
+: {{< docs/glossary "cardinality" />}}
 
 Data source
-: {{< glossary.inline "data source" />}}
+: {{< docs/glossary "data source" />}}
 
 Exemplar
-: {{< glossary.inline "exemplar" />}}
+: {{< docs/glossary "exemplar" />}}
 
 Log
-: {{< glossary.inline "log" />}}
+: {{< docs/glossary "log" />}}
 
 Metric
-: {{< glossary.inline "metric" />}}
+: {{< docs/glossary "metric" />}}
 
 Span
-: {{< glossary.inline "span" />}}
+: {{< docs/glossary "span" />}}
 
 Trace
-: {{< glossary.inline "trace" />}}
+: {{< docs/glossary "trace" />}}

--- a/docs/sources/tempo/introduction/glossary.md
+++ b/docs/sources/tempo/introduction/glossary.md
@@ -13,25 +13,25 @@ weight: 500
 The following terms are often used when discussing traces.
 
 Active series
-: {{< docs/glossary "active series" />}}
+: {{< docs/glossary "active series" >}}
 
 Cardinality
-: {{< docs/glossary "cardinality" />}}
+: {{< docs/glossary "cardinality" >}}
 
 Data source
-: {{< docs/glossary "data source" />}}
+: {{< docs/glossary "data source" >}}
 
 Exemplar
-: {{< docs/glossary "exemplar" />}}
+: {{< docs/glossary "exemplar" >}}
 
 Log
-: {{< docs/glossary "log" />}}
+: {{< docs/glossary "log" >}}
 
 Metric
-: {{< docs/glossary "metric" />}}
+: {{< docs/glossary "metric" >}}
 
 Span
-: {{< docs/glossary "span" />}}
+: {{< docs/glossary "span" >}}
 
 Trace
-: {{< docs/glossary "trace" />}}
+: {{< docs/glossary "trace" >}}


### PR DESCRIPTION
Inline shortcodes are powerful templating tools and allow source projects to iterate on HTML templates without a PR to the website repository.

However, by accident or malintent, they can be used break the website or expose information.

On the balance of things, the Docs Platform team believes that the risk outweighs the reward and will be disabling the feature.

The team believes it can support the prompt and safe creation of central shortcodes to satisfy the needs of the source projects.
All existing inline shortcodes have already been translated into central shortcodes that everyone can use.

Created-By: reverse-changes
Repository: grafana/tempo
Website-Pull-Request: https://github.com/grafana/website/pull/24705