### PR TITLE
TraceQL Metrics: Vulture checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [ENHANCEMENT] metrics-generator: allow skipping localblocks and consuming from a different source of data [#4686](https://github.com/grafana/tempo/pull/4686) (@flxbk)
 * [ENHANCEMENT] compactor: restore dedicated columns logging for completed blocks [#4832](https://github.com/grafana/tempo/pull/4832) (@edgarkz)
 * [ENHANCEMENT] distributor: add IPv6 support [#4840](https://github.com/grafana/tempo/pull/4840) (@gjacquet)
+* [ENHANCEMENT] Support TraceQL Metrics checks in Vulture [#4886](https://github.com/grafana/tempo/pull/4886) (@ruslan-mikhailov)
 * [BUGFIX] Choose a default step for a gRPC streaming query range request if none is provided. [#4546](https://github.com/grafana/tempo/pull/4576) (@joe-elliott)
   Correctly copy exemplars for metrics like `| rate()` when gRPC streaming.
 * [BUGFIX] Make comparison to nil symmetric [#4869](https://github.com/grafana/tempo/pull/4869) (@stoewer)

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -494,7 +494,7 @@ func searchTag(client httpclient.TempoHTTPClient, seed time.Time, config vulture
 	// Get the expected
 	expected, err := info.ConstructTraceFromEpoch()
 	if err != nil {
-		logger.Error("unable to construct trace from epoch", zap.Error(err))
+		l.Error("unable to construct trace from epoch", zap.Error(err))
 		return traceMetrics{}, err
 	}
 

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -323,7 +323,7 @@ func doRead(httpClient httpclient.TempoHTTPClient, tickerRead *time.Ticker, star
 						zap.Error(err),
 					)
 				}
-				pushMetrics(queryMetrics)
+				pushVultureMetrics(queryMetrics)
 			}
 		}()
 	}
@@ -354,7 +354,7 @@ func doSearch(httpClient httpclient.TempoHTTPClient, tickerSearch *time.Ticker, 
 						zap.Error(err),
 					)
 				}
-				pushMetrics(searchMetrics)
+				pushVultureMetrics(searchMetrics)
 
 				// traceql query
 				traceqlSearchMetrics, err := searchTraceql(httpClient, seed, config, l)
@@ -364,7 +364,7 @@ func doSearch(httpClient httpclient.TempoHTTPClient, tickerSearch *time.Ticker, 
 						zap.Error(err),
 					)
 				}
-				pushMetrics(traceqlSearchMetrics)
+				pushVultureMetrics(traceqlSearchMetrics)
 			}
 		}()
 	}
@@ -393,12 +393,12 @@ func doMetrics(httpClient httpclient.TempoHTTPClient, ticker *time.Ticker, start
 			if err != nil {
 				logger.Error("query metrics failed", zap.Error(err))
 			}
-			pushMetrics(m)
+			pushVultureMetrics(m)
 		}
 	}()
 }
 
-func pushMetrics(metrics traceMetrics) {
+func pushVultureMetrics(metrics traceMetrics) {
 	metricTracesInspected.Add(float64(metrics.requested))
 	metricTracesErrors.WithLabelValues("incorrectresult").Add(float64(metrics.incorrectResult))
 	metricTracesErrors.WithLabelValues("missingspans").Add(float64(metrics.missingSpans))

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -54,6 +54,7 @@ var (
 
 type traceMetrics struct {
 	incorrectResult         int
+	incorrectMetricsResult  int
 	missingSpans            int
 	notFoundByID            int
 	notFoundSearch          int
@@ -403,6 +404,7 @@ func doMetrics(httpClient httpclient.TempoHTTPClient, ticker *time.Ticker, start
 func pushVultureMetrics(metrics traceMetrics) {
 	metricTracesInspected.Add(float64(metrics.requested))
 	metricTracesErrors.WithLabelValues("incorrectresult").Add(float64(metrics.incorrectResult))
+	metricTracesErrors.WithLabelValues("incorrect_metrics_result").Add(float64(metrics.incorrectMetricsResult))
 	metricTracesErrors.WithLabelValues("missingspans").Add(float64(metrics.missingSpans))
 	metricTracesErrors.WithLabelValues("notfound_search").Add(float64(metrics.notFoundSearch))
 	metricTracesErrors.WithLabelValues("notfound_traceql").Add(float64(metrics.notFoundTraceQL))
@@ -700,12 +702,12 @@ func queryMetrics(client httpclient.TempoHTTPClient, seed time.Time, config vult
 	}
 
 	if len(resp.Series) > 1 {
-		tm.incorrectResult++
+		tm.incorrectMetricsResult++
 		return tm, fmt.Errorf("expected exactly 1 series, got %d", len(resp.Series))
 	}
 	timeSeries := resp.Series[0]
 	if timeSeries == nil {
-		tm.incorrectResult++
+		tm.incorrectMetricsResult++
 		return tm, errors.New("expected time series, got nil")
 	}
 

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -159,7 +159,7 @@ func main() {
 		httpClient.SetQueryParam(api.URLParamRF1After, rf1After.Format(time.RFC3339))
 	}
 
-	tickerWrite, tickerRead, tickerSearch, _, err := initTickers(
+	tickerWrite, tickerRead, tickerSearch, tickerMetrics, err := initTickers(
 		vultureConfig.tempoWriteBackoffDuration,
 		vultureConfig.tempoReadBackoffDuration,
 		vultureConfig.tempoSearchBackoffDuration,
@@ -175,6 +175,7 @@ func main() {
 	doWrite(jaegerClient, tickerWrite, interval, vultureConfig, logger)
 	doRead(httpClient, tickerRead, startTime, interval, r, vultureConfig, logger)
 	doSearch(httpClient, tickerSearch, startTime, interval, r, vultureConfig, logger)
+	doMetrics(httpClient, tickerMetrics, startTime, interval, r, vultureConfig, logger)
 
 	http.Handle(prometheusPath, promhttp.Handler())
 	log.Fatal(http.ListenAndServe(prometheusListenAddress, nil))
@@ -367,6 +368,34 @@ func doSearch(httpClient httpclient.TempoHTTPClient, tickerSearch *time.Ticker, 
 			}
 		}()
 	}
+}
+
+func doMetrics(httpClient httpclient.TempoHTTPClient, ticker *time.Ticker, startTime time.Time, interval time.Duration, r *rand.Rand, config vultureConfiguration, l *zap.Logger) {
+	if ticker == nil {
+		return
+	}
+	go func() {
+		for now := range ticker.C {
+			_, seed := selectPastTimestamp(startTime, now, interval, config.tempoRetentionDuration, r)
+			logger := l.With(
+				zap.String("org_id", config.tempoOrgID),
+				zap.Int64("seed", seed.Unix()),
+			)
+
+			info := util.NewTraceInfo(seed, config.tempoOrgID)
+
+			if !traceIsReady(info, now, startTime,
+				config.tempoWriteBackoffDuration, config.tempoLongWriteBackoffDuration) {
+				continue
+			}
+
+			m, err := queryMetrics(httpClient, seed, config, l)
+			if err != nil {
+				logger.Error("query metrics failed", zap.Error(err))
+			}
+			pushMetrics(m)
+		}
+	}()
 }
 
 func pushMetrics(metrics traceMetrics) {
@@ -611,6 +640,80 @@ func queryTrace(client httpclient.TempoHTTPClient, info *util.TraceInfo, l *zap.
 		return tm, nil
 	}
 
+	return tm, nil
+}
+
+// queryMetrics performs a TraceQL metrics query and verifies the results.
+// It is a basic smoke test to ensure that the traceql query is working.
+// It randomly selects an attribute from an expected trace and queries for its presence
+// in the metrics API within a time window around the seed time.
+func queryMetrics(client httpclient.TempoHTTPClient, seed time.Time, config vultureConfiguration, l *zap.Logger) (traceMetrics, error) {
+	tm := traceMetrics{
+		requested: 1,
+	}
+
+	info := util.NewTraceInfo(seed, config.tempoOrgID)
+	hexID := info.HexID()
+
+	expected, err := info.ConstructTraceFromEpoch()
+	if err != nil {
+		err = fmt.Errorf("unable to construct trace from epoch: %w", err)
+		return traceMetrics{}, err
+	}
+
+	attr := util.RandomAttrFromTrace(expected)
+	if attr == nil {
+		tm.notFoundSearchAttribute++
+		return tm, fmt.Errorf("no search attr selected from trace")
+	}
+
+	logger := l.With(
+		zap.Int64("seed", seed.Unix()),
+		zap.String("hexID", hexID),
+		zap.Duration("ago", time.Since(seed)),
+		zap.String("key", attr.Key),
+		zap.String("value", util.StringifyAnyValue(attr.Value)),
+	)
+	logger.Info("searching Tempo via metrics")
+
+	// Use the API to find details about the expected trace. give an hour range around the seed.
+	start := seed.Add(-30 * time.Minute).Unix()
+	end := seed.Add(30 * time.Minute).Unix()
+
+	resp, err := client.MetricsQueryRange(
+		fmt.Sprintf(`{.%s = "%s"} | count_over_time()`, attr.Key, util.StringifyAnyValue(attr.Value)),
+		int(start), int(end), "1m", 0,
+	)
+	if err != nil {
+		logger.Error("failed to query metrics", zap.Error(err))
+		tm.requestFailed++
+		return tm, err
+	}
+
+	if len(resp.Series) == 0 {
+		tm.notFoundByMetrics++
+		return tm, fmt.Errorf("expected trace %s not found in metrics", hexID)
+	}
+
+	if len(resp.Series) > 1 {
+		tm.incorrectResult++
+		return tm, fmt.Errorf("expected exactly 1 series, got %d", len(resp.Series))
+	}
+	timeSeries := resp.Series[0]
+	if timeSeries == nil {
+		tm.incorrectResult++
+		return tm, errors.New("expected time series, got nil")
+	}
+
+	var sum float64
+	for _, sample := range timeSeries.Samples {
+		sum += sample.Value
+	}
+
+	if sum < 1 {
+		tm.notFoundByMetrics++
+		return tm, fmt.Errorf("expected trace %s not found in metrics", hexID)
+	}
 	return tm, nil
 }
 

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -56,6 +56,7 @@ type traceMetrics struct {
 	notFoundByID            int
 	notFoundSearch          int
 	notFoundTraceQL         int
+	notFoundByMetrics       int
 	requested               int
 	requestFailed           int
 	notFoundSearchAttribute int
@@ -352,6 +353,7 @@ func pushMetrics(metrics traceMetrics) {
 	metricTracesErrors.WithLabelValues("notfound_search").Add(float64(metrics.notFoundSearch))
 	metricTracesErrors.WithLabelValues("notfound_traceql").Add(float64(metrics.notFoundTraceQL))
 	metricTracesErrors.WithLabelValues("notfound_byid").Add(float64(metrics.notFoundByID))
+	metricTracesErrors.WithLabelValues("notfound_metrics").Add(float64(metrics.notFoundByMetrics))
 	metricTracesErrors.WithLabelValues("requestfailed").Add(float64(metrics.requestFailed))
 	metricTracesErrors.WithLabelValues("notfound_search_attribute").Add(float64(metrics.notFoundSearchAttribute))
 }

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -120,7 +120,7 @@ func init() {
 	flag.DurationVar(&tempoLongWriteBackoffDuration, "tempo-long-write-backoff-duration", 1*time.Minute, "The amount of time to pause between long write Tempo calls")
 	flag.DurationVar(&tempoReadBackoffDuration, "tempo-read-backoff-duration", 30*time.Second, "The amount of time to pause between read Tempo calls")
 	flag.DurationVar(&tempoSearchBackoffDuration, "tempo-search-backoff-duration", 60*time.Second, "The amount of time to pause between search Tempo calls.  Set to 0s to disable search.")
-	flag.DurationVar(&tempoMetricsBackoffDuration, "tempo-metrics-backoff-duration", 60*time.Second, "The amount of time to pause between TraceQL Metrics Tempo calls.  Set to 0s to disable.")
+	flag.DurationVar(&tempoMetricsBackoffDuration, "tempo-metrics-backoff-duration", 0, "The amount of time to pause between TraceQL Metrics Tempo calls.  Set to 0s to disable.")
 	flag.DurationVar(&tempoRetentionDuration, "tempo-retention-duration", 336*time.Hour, "The block retention that Tempo is using")
 
 	flag.Var(newTimeVar(&rf1After), "rhythm-rf1-after", "Timestamp (RFC3339) after which only blocks with RF==1 are included in search and ID lookups")

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -716,6 +717,48 @@ func queryMetrics(client httpclient.TempoHTTPClient, seed time.Time, config vult
 		tm.notFoundByMetrics++
 		return tm, fmt.Errorf("expected trace %s not found in metrics", hexID)
 	}
+
+	// Advanced check: ensure metric results are accurate
+	// by checking actual number of spans
+	// skip if search check is disabled
+	if config.tempoSearchBackoffDuration == 0 {
+		return tm, nil
+	}
+	searchResp, err := client.SearchTraceQLWithRange(fmt.Sprintf(`{.%s = "%s"}`, attr.Key, util.StringifyAnyValue(attr.Value)), start, end)
+	if err != nil {
+		logger.Error(fmt.Sprintf("failed to search traces with traceql %s: %s", attr.Key, err.Error()))
+		tm.requestFailed++
+		return tm, err
+	}
+
+	var spansCount int
+	var traces []*tempopb.TraceSearchMetadata
+	if searchResp != nil {
+		traces = searchResp.Traces
+	}
+	for _, trace := range traces {
+		if trace == nil {
+			continue
+		}
+		for _, spanSet := range trace.SpanSets {
+			if spanSet == nil {
+				continue
+			}
+			spansCount += int(spanSet.Matched)
+		}
+	}
+
+	const delta = 1e-6
+	// if number of traces is not equal to the sum of metric values
+	if math.Abs(float64(spansCount)-sum) > delta {
+		tm.inaccurateMetrics++
+		err = fmt.Errorf(
+			"TraceQL Metrics results are inaccurate: metric count sum=%f, actual span count=%d",
+			sum, spansCount,
+		)
+		return tm, err
+	}
+
 	return tm, nil
 }
 

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -58,6 +58,7 @@ type traceMetrics struct {
 	notFoundSearch          int
 	notFoundTraceQL         int
 	notFoundByMetrics       int
+	inaccurateMetrics       int
 	requested               int
 	requestFailed           int
 	notFoundSearchAttribute int
@@ -406,6 +407,7 @@ func pushVultureMetrics(metrics traceMetrics) {
 	metricTracesErrors.WithLabelValues("notfound_traceql").Add(float64(metrics.notFoundTraceQL))
 	metricTracesErrors.WithLabelValues("notfound_byid").Add(float64(metrics.notFoundByID))
 	metricTracesErrors.WithLabelValues("notfound_metrics").Add(float64(metrics.notFoundByMetrics))
+	metricTracesErrors.WithLabelValues("inaccurate_metrics").Add(float64(metrics.inaccurateMetrics))
 	metricTracesErrors.WithLabelValues("requestfailed").Add(float64(metrics.requestFailed))
 	metricTracesErrors.WithLabelValues("notfound_search_attribute").Add(float64(metrics.notFoundSearchAttribute))
 }

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -695,6 +695,7 @@ func queryMetrics(client httpclient.TempoHTTPClient, seed time.Time, config vult
 
 	if len(resp.Series) == 0 {
 		tm.notFoundByMetrics++
+		logger.Error("failed to find trace by metrics", zap.Error(err))
 		return tm, fmt.Errorf("expected trace %s not found in metrics", hexID)
 	}
 
@@ -715,6 +716,7 @@ func queryMetrics(client httpclient.TempoHTTPClient, seed time.Time, config vult
 
 	if sum < 1 {
 		tm.notFoundByMetrics++
+		logger.Error("failed to find trace by metrics", zap.Error(err))
 		return tm, fmt.Errorf("expected trace %s not found in metrics", hexID)
 	}
 

--- a/cmd/tempo-vulture/main_test.go
+++ b/cmd/tempo-vulture/main_test.go
@@ -121,62 +121,81 @@ func TestEqualTraces(t *testing.T) {
 
 func TestInitTickers(t *testing.T) {
 	tests := []struct {
-		name                                        string
-		writeDuration, readDuration, searchDuration time.Duration
-		expectedWriteTicker                         bool
-		expectedReadTicker                          bool
-		expectedSearchTicker                        bool
-		expectedError                               string
+		name                            string
+		writeDuration, readDuration     time.Duration
+		searchDuration, metricsDuration time.Duration
+		expectedWriteTicker             bool
+		expectedReadTicker              bool
+		expectedSearchTicker            bool
+		expectedMetricsTicker           bool
+		expectedError                   string
 	}{
 		{
-			name:                 "Valid write and read durations",
-			writeDuration:        1 * time.Second,
-			readDuration:         2 * time.Second,
-			searchDuration:       0,
-			expectedWriteTicker:  true,
-			expectedReadTicker:   true,
-			expectedSearchTicker: false,
-			expectedError:        "",
+			name:                  "Valid write and read durations",
+			writeDuration:         1 * time.Second,
+			readDuration:          2 * time.Second,
+			searchDuration:        0,
+			expectedWriteTicker:   true,
+			expectedReadTicker:    true,
+			expectedSearchTicker:  false,
+			expectedMetricsTicker: false,
+			expectedError:         "",
 		},
 		{
-			name:                 "Invalid write duration (zero)",
-			writeDuration:        0,
-			readDuration:         0,
-			searchDuration:       0,
-			expectedWriteTicker:  false,
-			expectedReadTicker:   false,
-			expectedSearchTicker: false,
-			expectedError:        "tempo-write-backoff-duration must be greater than 0",
+			name:                  "Invalid write duration (zero)",
+			writeDuration:         0,
+			readDuration:          0,
+			searchDuration:        0,
+			expectedWriteTicker:   false,
+			expectedReadTicker:    false,
+			expectedSearchTicker:  false,
+			expectedMetricsTicker: false,
+			expectedError:         "tempo-write-backoff-duration must be greater than 0",
 		},
 		{
-			name:                 "No read durations set",
-			writeDuration:        1 * time.Second,
-			readDuration:         0,
-			searchDuration:       1 * time.Second,
-			expectedWriteTicker:  true,
-			expectedReadTicker:   false,
-			expectedSearchTicker: true,
-			expectedError:        "",
+			name:                  "No read durations set",
+			writeDuration:         1 * time.Second,
+			readDuration:          0,
+			searchDuration:        1 * time.Second,
+			expectedWriteTicker:   true,
+			expectedReadTicker:    false,
+			expectedSearchTicker:  true,
+			expectedMetricsTicker: false,
+			expectedError:         "",
 		},
 		{
-			name:                 "No read or search durations set",
-			writeDuration:        1 * time.Second,
-			readDuration:         0,
-			searchDuration:       0,
-			expectedWriteTicker:  false,
-			expectedReadTicker:   false,
-			expectedSearchTicker: false,
-			expectedError:        "at least one of tempo-search-backoff-duration or tempo-read-backoff-duration must be set",
+			name:                  "Valid metrics duration",
+			writeDuration:         1 * time.Second,
+			readDuration:          0,
+			searchDuration:        0,
+			metricsDuration:       1 * time.Second,
+			expectedWriteTicker:   true,
+			expectedReadTicker:    false,
+			expectedSearchTicker:  false,
+			expectedMetricsTicker: true,
+			expectedError:         "",
+		},
+		{
+			name:                  "No read or search durations set",
+			writeDuration:         1 * time.Second,
+			readDuration:          0,
+			searchDuration:        0,
+			expectedWriteTicker:   false,
+			expectedReadTicker:    false,
+			expectedSearchTicker:  false,
+			expectedMetricsTicker: false,
+			expectedError:         "at least one of tempo-search-backoff-duration, tempo-read-backoff-duration or tempo-metrics-backoff-duration must be set",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tickerWrite, tickerRead, tickerSearch, err := initTickers(tt.writeDuration, tt.readDuration, tt.searchDuration)
+			tickerWrite, tickerRead, tickerSearch, tickerMetrics, err := initTickers(tt.writeDuration, tt.readDuration, tt.searchDuration, tt.metricsDuration)
 
 			assert.Equal(t, tt.expectedWriteTicker, tickerWrite != nil, "TickerWrite")
 			assert.Equal(t, tt.expectedReadTicker, tickerRead != nil, "TickerRead")
 			assert.Equal(t, tt.expectedSearchTicker, tickerSearch != nil, "TickerSearch")
+			assert.Equal(t, tt.expectedMetricsTicker, tickerMetrics != nil, "TickerMetrics")
 
 			if tt.expectedError != "" {
 				assert.NotNil(t, err, "Expected error but got nil")

--- a/cmd/tempo-vulture/main_test.go
+++ b/cmd/tempo-vulture/main_test.go
@@ -828,8 +828,8 @@ func TestQueryMetrics(t *testing.T) {
 				Series: make([]*tempopb.TimeSeries, 1),
 			},
 			expectedMetrics: traceMetrics{
-				requested:       1,
-				incorrectResult: 1,
+				requested:              1,
+				incorrectMetricsResult: 1,
 			},
 			expectedError: "expected time series, got nil",
 		},
@@ -839,8 +839,8 @@ func TestQueryMetrics(t *testing.T) {
 				Series: make([]*tempopb.TimeSeries, 2),
 			},
 			expectedMetrics: traceMetrics{
-				requested:       1,
-				incorrectResult: 1,
+				requested:              1,
+				incorrectMetricsResult: 1,
 			},
 			expectedError: "expected exactly 1 series, got 2",
 		},

--- a/cmd/tempo-vulture/main_test.go
+++ b/cmd/tempo-vulture/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"math/rand"
 	"os"
 	"testing"
@@ -697,4 +698,179 @@ func TestNewJaegerGRPCClient(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Nil(t, client)
+}
+
+func TestQueryMetrics(t *testing.T) {
+	seed := time.Date(2008, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	config := vultureConfiguration{
+		tempoOrgID:                "orgID",
+		tempoWriteBackoffDuration: time.Second,
+	}
+
+	info := util.NewTraceInfo(seed, config.tempoOrgID)
+	hexID := info.HexID()
+
+	tests := []struct {
+		name            string
+		response        *tempopb.QueryRangeResponse
+		err             error
+		expectedMetrics traceMetrics
+		expectedError   string
+	}{
+		{
+			name: "successful metrics query",
+			response: &tempopb.QueryRangeResponse{
+				Series: []*tempopb.TimeSeries{
+					{
+						Samples: []tempopb.Sample{
+							{
+								TimestampMs: seed.UnixMilli(),
+								Value:       1.0,
+							},
+						},
+					},
+				},
+			},
+			expectedMetrics: traceMetrics{
+				requested: 1,
+			},
+		},
+		{
+			name: "no series in response",
+			response: &tempopb.QueryRangeResponse{
+				Series: []*tempopb.TimeSeries{},
+			},
+			expectedMetrics: traceMetrics{
+				requested:         1,
+				notFoundByMetrics: 1,
+			},
+			expectedError: fmt.Sprintf("expected trace %s not found in metrics", hexID),
+		},
+		{
+			name: "no series in response (nil)",
+			response: &tempopb.QueryRangeResponse{
+				Series: nil,
+			},
+			expectedMetrics: traceMetrics{
+				requested:         1,
+				notFoundByMetrics: 1,
+			},
+			expectedError: fmt.Sprintf("expected trace %s not found in metrics", hexID),
+		},
+		{
+			name: "invalid series data",
+			response: &tempopb.QueryRangeResponse{
+				Series: make([]*tempopb.TimeSeries, 1),
+			},
+			expectedMetrics: traceMetrics{
+				requested:       1,
+				incorrectResult: 1,
+			},
+			expectedError: "expected time series, got nil",
+		},
+		{
+			name: "too many series",
+			response: &tempopb.QueryRangeResponse{
+				Series: make([]*tempopb.TimeSeries, 2),
+			},
+			expectedMetrics: traceMetrics{
+				requested:       1,
+				incorrectResult: 1,
+			},
+			expectedError: "expected exactly 1 series, got 2",
+		},
+		{
+			name:     "query error",
+			response: nil,
+			err:      errors.New("metrics query failed"),
+			expectedMetrics: traceMetrics{
+				requested:     1,
+				requestFailed: 1,
+			},
+			expectedError: "metrics query failed",
+		},
+	}
+
+	logger = zap.NewNop()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockHTTPClient := &MockHTTPClient{
+				err:         tt.err,
+				metricsResp: tt.response,
+			}
+
+			metrics, err := queryMetrics(mockHTTPClient, seed, config, logger)
+			assert.Equal(t, tt.expectedMetrics, metrics)
+
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestDoMetrics(t *testing.T) {
+	seed := time.Date(2008, 1, 1, 12, 0, 0, 0, time.UTC)
+	startTime := time.Date(2007, 1, 1, 12, 0, 0, 0, time.UTC)
+	interval := time.Second
+
+	config := vultureConfiguration{
+		tempoOrgID: "orgID",
+		// This is a hack to ensure the trace is "ready"
+		tempoWriteBackoffDuration: -time.Hour * 10000,
+		tempoRetentionDuration:    time.Second * 10,
+	}
+
+	logger = zap.NewNop()
+	r := rand.New(rand.NewSource(startTime.Unix()))
+
+	tests := []struct {
+		name          string
+		ticker        *time.Ticker
+		expectedCalls int
+	}{
+		{
+			name:          "nil ticker",
+			ticker:        nil,
+			expectedCalls: 0,
+		},
+		{
+			name:          "active ticker",
+			ticker:        time.NewTicker(10 * time.Millisecond),
+			expectedCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockHTTPClient := &MockHTTPClient{
+				err: nil,
+				metricsResp: &tempopb.QueryRangeResponse{
+					Series: []*tempopb.TimeSeries{
+						{
+							Samples: []tempopb.Sample{
+								{
+									TimestampMs: seed.UnixMilli(),
+									Value:       1.0,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			doMetrics(mockHTTPClient, tt.ticker, startTime, interval, r, config, logger)
+
+			if tt.ticker != nil {
+				time.Sleep(20 * time.Millisecond)
+				tt.ticker.Stop()
+			}
+			assert.Equal(t, mockHTTPClient.GetMetricsCount(), tt.expectedCalls)
+		})
+	}
 }

--- a/cmd/tempo-vulture/mocks.go
+++ b/cmd/tempo-vulture/mocks.go
@@ -71,6 +71,11 @@ func (m *MockHTTPClient) MetricsSummary(query string, groupBy string, start int6
 }
 
 //nolint:all
+func (m *MockHTTPClient) MetricsQueryRange(query string, start, end int, step string, exemplars int) (*tempopb.QueryRangeResponse, error) {
+	panic("unimplemented")
+}
+
+//nolint:all
 func (m *MockHTTPClient) PatchOverrides(limits *userconfigurableoverrides.Limits) (*userconfigurableoverrides.Limits, string, error) {
 	panic("unimplemented")
 }

--- a/operations/jsonnet-compiled/Deployment-vulture.yaml
+++ b/operations/jsonnet-compiled/Deployment-vulture.yaml
@@ -26,6 +26,7 @@ spec:
         - -tempo-retention-duration=336h
         - -tempo-search-backoff-duration=5s
         - -tempo-read-backoff-duration=10s
+        - -tempo-metrics-backoff-duration=5s
         - -tempo-write-backoff-duration=10s
         image: grafana/tempo-vulture:latest
         imagePullPolicy: IfNotPresent

--- a/operations/jsonnet-compiled/Deployment-vulture.yaml
+++ b/operations/jsonnet-compiled/Deployment-vulture.yaml
@@ -28,6 +28,7 @@ spec:
         - -tempo-read-backoff-duration=10s
         - -tempo-metrics-backoff-duration=0s
         - -tempo-write-backoff-duration=10s
+        - -tempo-long-write-backoff-duration=50s
         image: grafana/tempo-vulture:latest
         imagePullPolicy: IfNotPresent
         name: vulture

--- a/operations/jsonnet-compiled/Deployment-vulture.yaml
+++ b/operations/jsonnet-compiled/Deployment-vulture.yaml
@@ -26,7 +26,7 @@ spec:
         - -tempo-retention-duration=336h
         - -tempo-search-backoff-duration=5s
         - -tempo-read-backoff-duration=10s
-        - -tempo-metrics-backoff-duration=5s
+        - -tempo-metrics-backoff-duration=0s
         - -tempo-write-backoff-duration=10s
         image: grafana/tempo-vulture:latest
         imagePullPolicy: IfNotPresent

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -168,6 +168,7 @@
       tempoOrgId: '',
       tempoRetentionDuration: '336h',
       tempoSearchBackoffDuration: '5s',
+      tempoMetricsBackoffDuration: '5s',
       tempoReadBackoffDuration: '10s',
       tempoWriteBackoffDuration: '10s',
     },

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -171,7 +171,7 @@
       tempoReadBackoffDuration: '10s',
       tempoWriteBackoffDuration: '10s',
       tempoMetricsBackoffDuration: '0s',  // TraceQL Metrics checks disabled
-      tempoLongWriteBackoffDuration: '1m',
+      tempoLongWriteBackoffDuration: '50s',
     },
     ballast_size_mbs: '1024',
     port: 3200,

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -171,6 +171,7 @@
       tempoReadBackoffDuration: '10s',
       tempoWriteBackoffDuration: '10s',
       tempoMetricsBackoffDuration: '0s',  // TraceQL Metrics checks disabled
+      tempoLongWriteBackoffDuration: '1m',
     },
     ballast_size_mbs: '1024',
     port: 3200,

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -168,9 +168,9 @@
       tempoOrgId: '',
       tempoRetentionDuration: '336h',
       tempoSearchBackoffDuration: '5s',
-      tempoMetricsBackoffDuration: '5s',
       tempoReadBackoffDuration: '10s',
       tempoWriteBackoffDuration: '10s',
+      tempoMetricsBackoffDuration: '0s',  // TraceQL Metrics checks disabled
     },
     ballast_size_mbs: '1024',
     port: 3200,

--- a/operations/jsonnet/microservices/vulture.libsonnet
+++ b/operations/jsonnet/microservices/vulture.libsonnet
@@ -20,6 +20,7 @@
       '-tempo-retention-duration=' + $._config.vulture.tempoRetentionDuration,
       '-tempo-search-backoff-duration=' + $._config.vulture.tempoSearchBackoffDuration,
       '-tempo-read-backoff-duration=' + $._config.vulture.tempoReadBackoffDuration,
+      '-tempo-metrics-backoff-duration=' + $._config.vulture.tempoMetricsBackoffDuration,
       '-tempo-write-backoff-duration=' + $._config.vulture.tempoWriteBackoffDuration,
     ]) +
     k.util.resourcesRequests('50m', '100Mi') +

--- a/operations/jsonnet/microservices/vulture.libsonnet
+++ b/operations/jsonnet/microservices/vulture.libsonnet
@@ -22,6 +22,7 @@
       '-tempo-read-backoff-duration=' + $._config.vulture.tempoReadBackoffDuration,
       '-tempo-metrics-backoff-duration=' + $._config.vulture.tempoMetricsBackoffDuration,
       '-tempo-write-backoff-duration=' + $._config.vulture.tempoWriteBackoffDuration,
+      '-tempo-long-write-backoff-duration=' + $._config.vulture.tempoLongWriteBackoffDuration,
     ]) +
     k.util.resourcesRequests('50m', '100Mi') +
     k.util.resourcesLimits('100m', '500Mi'),

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -51,6 +51,7 @@ type TempoHTTPClient interface {
 	SearchTraceQLWithRange(query string, start int64, end int64) (*tempopb.SearchResponse, error)
 	SearchTraceQLWithRangeAndLimit(query string, start int64, end int64, limit int64, spss int64) (*tempopb.SearchResponse, error)
 	MetricsSummary(query string, groupBy string, start int64, end int64) (*tempopb.SpanMetricsSummaryResponse, error)
+	MetricsQueryRange(query string, start, end int, step string, exemplars int) (*tempopb.QueryRangeResponse, error)
 	GetOverrides() (*userconfigurableoverrides.Limits, string, error)
 	SetOverrides(limits *userconfigurableoverrides.Limits, version string) (string, error)
 	PatchOverrides(limits *userconfigurableoverrides.Limits) (*userconfigurableoverrides.Limits, string, error)
@@ -380,6 +381,31 @@ func (c *Client) buildSearchQueryURL(queryType string, query string, start int64
 	joinURL.RawQuery = q.Encode()
 
 	return fmt.Sprint(joinURL)
+}
+
+func (c *Client) MetricsQueryRange(query string, start, end int, step string, exemplars int) (*tempopb.QueryRangeResponse, error) {
+	joinURL, _ := url.Parse(c.BaseURL + api.PathMetricsQueryRange + "?")
+	q := joinURL.Query()
+	if exemplars != 0 {
+		q.Set("exemplars", strconv.Itoa(exemplars))
+	}
+	if start != 0 && end != 0 {
+		q.Set("start", strconv.Itoa(start))
+		q.Set("end", strconv.Itoa(end))
+	}
+	if step != "" {
+		q.Set("step", step)
+	}
+	q.Set("q", query)
+	joinURL.RawQuery = q.Encode()
+
+	m := &tempopb.QueryRangeResponse{}
+	_, err := c.getFor(fmt.Sprint(joinURL), m)
+	if err != nil {
+		return m, err
+	}
+
+	return m, nil
 }
 
 func (c *Client) buildTagsQueryURL(start int64, end int64) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does
it adds TraceQL Metrics check:
1. For an existing trace, check thatthe  overall `count_over_time()` is not zero
2. Check the exact number by searching the trace

## Which issue(s) this PR fixes
Fixes #<issue number>

## How it has been tested
Run tempo and vulture locally via docker-compose.
Results:
![image](https://github.com/user-attachments/assets/092ebae3-518f-47d8-896a-a16a21eb8810)

High amount of notfound_metrics due to bug: https://github.com/grafana/tempo/issues/4896

After the fix https://github.com/grafana/tempo/pull/4962, checked locally via docker-compose with Rhytm enabled and with one binary mode, Rhythm disabled. Additionally, run in k8s with Rhythm enabled

![image](https://github.com/user-attachments/assets/dde5c711-262c-4696-8569-deb4b8d1d816)

**Checklist**



- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

