### PR TITLE
[rhythm] Add support for `rf1After` query param in vulture.

### DIFF
--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -44,6 +44,8 @@ var (
 	tempoRetentionDuration        time.Duration
 	tempoPushTLS                  bool
 
+	rf1After time.Time
+
 	logger *zap.Logger
 )
 
@@ -74,6 +76,32 @@ type vultureConfiguration struct {
 	tempoPushTLS                  bool
 }
 
+var _ flag.Value = (*timeVar)(nil)
+
+type timeVar struct {
+	t *time.Time
+}
+
+func newTimeVar(t *time.Time) *timeVar { return &timeVar{t: t} }
+
+func (v timeVar) String() string {
+	return (*v.t).Format(time.RFC3339)
+}
+
+func (v timeVar) Set(s string) error {
+	if s == "" {
+		return nil
+	}
+
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return err
+	}
+	*v.t = t
+
+	return nil
+}
+
 func init() {
 	flag.StringVar(&prometheusPath, "prometheus-path", "/metrics", "The path to publish Prometheus metrics to.")
 	flag.StringVar(&prometheusListenAddress, "prometheus-listen-address", ":80", "The address to listen on for Prometheus scrapes.")
@@ -87,6 +115,8 @@ func init() {
 	flag.DurationVar(&tempoReadBackoffDuration, "tempo-read-backoff-duration", 30*time.Second, "The amount of time to pause between read Tempo calls")
 	flag.DurationVar(&tempoSearchBackoffDuration, "tempo-search-backoff-duration", 60*time.Second, "The amount of time to pause between search Tempo calls.  Set to 0s to disable search.")
 	flag.DurationVar(&tempoRetentionDuration, "tempo-retention-duration", 336*time.Hour, "The block retention that Tempo is using")
+
+	flag.Var(newTimeVar(&rf1After), "rhythm-rf1-after", "Timestamp (RFC3339) after which only blocks with RF==1 are included in search and ID lookups")
 }
 
 func main() {
@@ -118,6 +148,10 @@ func main() {
 		panic(err)
 	}
 	httpClient := httpclient.New(vultureConfig.tempoQueryURL, vultureConfig.tempoOrgID)
+
+	if !rf1After.IsZero() {
+		httpClient.SetQueryParam("rf1_after", rf1After.Format(time.RFC3339))
+	}
 
 	tickerWrite, tickerRead, tickerSearch, err := initTickers(vultureConfig.tempoWriteBackoffDuration, vultureConfig.tempoReadBackoffDuration, vultureConfig.tempoSearchBackoffDuration)
 	if err != nil {

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
+	"github.com/grafana/tempo/pkg/api"
 	jaeger_grpc "github.com/jaegertracing/jaeger/cmd/agent/app/reporter/grpc"
 	zaplogfmt "github.com/jsternberg/zap-logfmt"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -150,7 +151,7 @@ func main() {
 	httpClient := httpclient.New(vultureConfig.tempoQueryURL, vultureConfig.tempoOrgID)
 
 	if !rf1After.IsZero() {
-		httpClient.SetQueryParam("rf1_after", rf1After.Format(time.RFC3339))
+		httpClient.SetQueryParam(api.URLParamRF1After, rf1After.Format(time.RFC3339))
 	}
 
 	tickerWrite, tickerRead, tickerSearch, err := initTickers(vultureConfig.tempoWriteBackoffDuration, vultureConfig.tempoReadBackoffDuration, vultureConfig.tempoSearchBackoffDuration)

--- a/cmd/tempo-vulture/main_test.go
+++ b/cmd/tempo-vulture/main_test.go
@@ -112,6 +112,11 @@ func TestEqualTraces(t *testing.T) {
 	require.NoError(t, err)
 
 	require.True(t, equalTraces(a, b))
+
+	// Subsequent calls also reconstruct identical traces
+	c, err := info1.ConstructTraceFromEpoch()
+	require.NoError(t, err)
+	require.True(t, equalTraces(b, c))
 }
 
 func TestInitTickers(t *testing.T) {

--- a/pkg/api/http.go
+++ b/pkg/api/http.go
@@ -501,9 +501,6 @@ func BuildQueryRequest(req *http.Request, queryParams map[string]string) *http.R
 	}
 	qb := newQueryBuilder(req.URL.RawQuery)
 	for k, v := range queryParams {
-		if v == "" {
-			continue
-		}
 		qb.addParam(k, v)
 	}
 	req.URL.RawQuery = qb.query()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Follow-up to https://github.com/grafana/tempo/pull/4857

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`