### PR TITLE
Finish polling current tenants before shut down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   Renamed max_span_attr_byte to max_attribute_bytes
   [#4633](https://github.com/grafana/tempo/pull/4633) (@ie-pham)
 * [CHANGE] Update to go 1.24.1 [#4704](https://github.com/grafana/tempo/pull/4704) (@ruslan-mikhailov) [#4793](https://github.com/grafana/tempo/pull/4793) (@javiermolinar)
+* [CHANGE] Finish polling current tenants on poller shutdown [#4897](https://github.com/grafana/tempo/pull/4897) (@zalegrala)
 * [FEATURE] Add throughput SLO and metrics for the TraceByID endpoint. [#4668](https://github.com/grafana/tempo/pull/4668) (@carles-grafana)
 configurable via the throughput_bytes_slo field, and it will populate op="traces" label in slo and throughput metrics.
 * [FEATURE] Added most_recent=true query hint to TraceQL to return most recent results. [#4238](https://github.com/grafana/tempo/pull/4238) (@joe-elliott)

--- a/modules/backendscheduler/backendscheduler_test.go
+++ b/modules/backendscheduler/backendscheduler_test.go
@@ -42,8 +42,11 @@ func TestBackendScheduler(t *testing.T) {
 		ctx, cancel   = context.WithCancel(context.Background())
 		store, rr, ww = newStore(ctx, t, tmpDir)
 	)
-	defer cancel()
-	defer store.Shutdown()
+
+	defer func() {
+		cancel()
+		store.Shutdown()
+	}()
 
 	limits, err := overrides.NewOverrides(overrides.Config{Defaults: overrides.Overrides{}}, nil, prometheus.DefaultRegisterer)
 	require.NoError(t, err)

--- a/modules/blockbuilder/blockbuilder_test.go
+++ b/modules/blockbuilder/blockbuilder_test.go
@@ -603,8 +603,8 @@ func TestBlockbuilder_marksOldBlocksCompacted(t *testing.T) {
 	// Check that the offset was committed correctly (lastRec.Offset + 1)
 	requireLastCommitEquals(t, ctx, client, lastRecordOffset+1)
 
-	// Enable polling to trigger another immediate poll
-	store.EnablePolling(ctx, &ownEverythingSharder{})
+	// Sleep to let the poller cycle
+	time.Sleep(100 * time.Millisecond)
 
 	// Verify that each tenant only has 1 active block
 	require.Equal(t, 1, len(store.BlockMetas(goodTenantID)))
@@ -746,7 +746,7 @@ func newStoreWithLogger(ctx context.Context, t testing.TB, log log.Logger) stora
 			WAL: &wal.Config{
 				Filepath: tmpDir,
 			},
-			BlocklistPoll: 5 * time.Second,
+			BlocklistPoll: 100 * time.Millisecond,
 		},
 	}, nil, log)
 	require.NoError(t, err)

--- a/modules/blockbuilder/tenant_store_test.go
+++ b/modules/blockbuilder/tenant_store_test.go
@@ -180,8 +180,8 @@ func writeHistoricalData(t *testing.T, count int, startTime time.Time, cycleDura
 	err = ts.Flush(ctx, store, store, store)
 	require.NoError(t, err)
 
-	// This forces another immediate poll
-	store.EnablePolling(ctx, &ownEverythingSharder{})
+	// This allows a polling cycle
+	time.Sleep(100 * time.Millisecond)
 
 	metas := store.BlockMetas(ts.tenantID)
 	require.Equal(t, 1, len(metas))

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -136,7 +136,7 @@ func NewPoller(cfg *PollerConfig, sharder JobSharder, reader backend.Reader, com
 }
 
 // Do does the doing of getting a blocklist
-func (p *Poller) Do(ctx context.Context, previous *List) (PerTenant, PerTenantCompacted, error) {
+func (p *Poller) Do(parentCtx context.Context, previous *List) (PerTenant, PerTenantCompacted, error) {
 	start := time.Now()
 	defer func() {
 		diff := time.Since(start).Seconds()
@@ -145,13 +145,13 @@ func (p *Poller) Do(ctx context.Context, previous *List) (PerTenant, PerTenantCo
 		backend.ClearDedicatedColumns()
 	}()
 
-	ctx, cancel := context.WithCancel(ctx)
+	parentCtx, cancel := context.WithCancel(parentCtx)
 	defer cancel()
 
-	ctx, span := tracer.Start(ctx, "Poller.Do")
-	defer span.End()
+	parentCtx, parentSpan := tracer.Start(parentCtx, "Poller.Do")
+	defer parentSpan.End()
 
-	tenants, err := p.reader.Tenants(ctx)
+	tenants, err := p.reader.Tenants(parentCtx)
 	if err != nil {
 		metricBlocklistErrors.WithLabelValues("").Inc()
 		return nil, nil, err
@@ -165,9 +165,17 @@ func (p *Poller) Do(ctx context.Context, previous *List) (PerTenant, PerTenantCo
 		compactedBlocklist = PerTenantCompacted{}
 
 		tenantFailuresRemaining = atomic.NewInt32(int32(p.cfg.TolerateTenantFailures))
+
+		link  = trace.LinkFromContext(parentCtx)
+		bgCtx = context.Background()
 	)
 
 	for _, tenantID := range tenants {
+		// Do not continue if our parent has been cancelled.
+		if parentCtx.Err() != nil {
+			return nil, nil, parentCtx.Err()
+		}
+
 		// Exit early if we have exceeded our tolerance for number of failing tenants.
 		if tenantFailuresRemaining.Load() < 0 {
 			level.Error(p.logger).Log("msg", "exiting polling loop early because too many errors")
@@ -178,6 +186,12 @@ func (p *Poller) Do(ctx context.Context, previous *List) (PerTenant, PerTenantCo
 		go func(tenantID string) {
 			defer wg.Done()
 
+			bgCtx, bgSpan := tracer.Start(bgCtx, "Poller.Do.func")
+			defer bgSpan.End()
+
+			bgSpan.SetAttributes(attribute.String("tenant", tenantID))
+			bgSpan.AddLink(link)
+
 			var (
 				consecutiveErrorsRemaining = p.cfg.TolerateConsecutiveErrors
 				newBlockList               = make([]*backend.BlockMeta, 0)
@@ -186,7 +200,7 @@ func (p *Poller) Do(ctx context.Context, previous *List) (PerTenant, PerTenantCo
 			)
 
 			for consecutiveErrorsRemaining >= 0 {
-				newBlockList, newCompactedBlockList, err = p.pollTenantAndCreateIndex(ctx, tenantID, previous)
+				newBlockList, newCompactedBlockList, err = p.pollTenantAndCreateIndex(bgCtx, tenantID, previous)
 				if err == nil {
 					break
 				}
@@ -285,7 +299,7 @@ func (p *Poller) pollTenantAndCreateIndex(
 
 	// everything is happy, write this tenant index
 	level.Info(p.logger).Log("msg", "writing tenant index", "tenant", tenantID, "metas", len(blocklist), "compactedMetas", len(compactedBlocklist))
-	err = p.writer.WriteTenantIndex(derivedCtx, tenantID, blocklist, compactedBlocklist)
+	err = p.writer.WriteTenantIndex(ctx, tenantID, blocklist, compactedBlocklist)
 	if err != nil {
 		metricTenantIndexErrors.WithLabelValues(tenantID).Inc()
 		level.Error(p.logger).Log("msg", "failed to write tenant index", "tenant", tenantID, "err", err)

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -171,9 +171,11 @@ func (p *Poller) Do(parentCtx context.Context, previous *List) (PerTenant, PerTe
 	)
 
 	for _, tenantID := range tenants {
-		// Do not continue if our parent has been cancelled.
+		// Do not continue if we have been canceled.
 		if parentCtx.Err() != nil {
-			return nil, nil, parentCtx.Err()
+			// Wait for our work to complete.
+			wg.Wait()
+			return nil, nil, nil
 		}
 
 		// Exit early if we have exceeded our tolerance for number of failing tenants.


### PR DESCRIPTION
**What this PR does**:

Currently, the module context is passed to the poller.  In the event of a termination request, this context is used on the backend reader/writer and fail because of the cancellation.  Here we use a background context for the polling so that once a poll for a tenant has started to ensure the index is written.  The store module is updated to block shutdown until the poller is done.  This is necessary because the polling process is run in a routine, and during rollout of the index-writers, we see alerts due to stale index.  Allowing the poller to complete tenants which it has started should improve this siutaiton.
 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`