### PR TITLE
Extend artificial delay with default configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 * [FEATURE] Add throughput SLO and metrics for the TraceByID endpoint. [#4668](https://github.com/grafana/tempo/pull/4668) (@carles-grafana)
 configurable via the throughput_bytes_slo field, and it will populate op="traces" label in slo and throughput metrics.
 * [FEATURE] Added most_recent=true query hint to TraceQL to return most recent results. [#4238](https://github.com/grafana/tempo/pull/4238) (@joe-elliott)
-* [FEATURE] Add ability to add artificial delay to push requests [#4716](https://github.com/grafana/tempo/pull/4716) (@yvrhdn)
+* [FEATURE] Add ability to add artificial delay to push requests [#4716](https://github.com/grafana/tempo/pull/4716) [#4899](https://github.com/grafana/tempo/pull/4899) (@yvrhdn, @mapno)
 * [FEATURE] TraceQL metrics: sum_over_time [#4786](https://github.com/grafana/tempo/pull/4786) (@javiermolinar)
 * [ENHANCEMENT] Improve Tempo build options [#4755](https://github.com/grafana/tempo/pull/4755) (@stoewer)
 * [ENHANCEMENT] Rewrite traces using rebatching [#4690](https://github.com/grafana/tempo/pull/4690) (@stoewer @joe-elliott)

--- a/modules/distributor/artificial_delay.go
+++ b/modules/distributor/artificial_delay.go
@@ -6,7 +6,11 @@ import (
 )
 
 func (d *Distributor) padWithArtificialDelay(reqStart time.Time, userID string) {
-	artificialDelay := d.overrides.IngestionArtificialDelay(userID)
+	artificialDelay := d.cfg.ArtificialDelay
+	if artificialDelayOverride, ok := d.overrides.IngestionArtificialDelay(userID); ok {
+		artificialDelay = artificialDelayOverride
+	}
+
 	if artificialDelay <= 0 {
 		return
 	}

--- a/modules/distributor/artificial_delay_test.go
+++ b/modules/distributor/artificial_delay_test.go
@@ -14,37 +14,53 @@ func Test_outerMaybeDelayMiddleware(t *testing.T) {
 	tests := []struct {
 		name          string
 		userID        string
-		delay         time.Duration
+		delayCfg      time.Duration
+		delayOverride *time.Duration
 		reqDuration   time.Duration
 		expectedSleep time.Duration
 	}{
 		{
-			name:          "No delay configured",
-			userID:        "user1",
-			delay:         0,
+			name:   "No delay configured",
+			userID: "user1",
+			// delayOverride is nil
 			reqDuration:   50 * time.Millisecond,
 			expectedSleep: 0,
 		},
 		{
 			name:          "Delay configured but request took longer than delay",
 			userID:        "user2",
-			delay:         500 * time.Millisecond,
+			delayOverride: durationPtr(500 * time.Millisecond),
 			reqDuration:   750 * time.Millisecond,
 			expectedSleep: 0,
 		},
 		{
 			name:          "Delay configured and request took less than delay",
 			userID:        "user3",
-			delay:         500 * time.Millisecond,
+			delayOverride: durationPtr(500 * time.Millisecond),
 			reqDuration:   50 * time.Millisecond,
 			expectedSleep: 450 * time.Millisecond,
+		},
+		{
+			name:          "Global delay configured",
+			userID:        "user4",
+			delayCfg:      500 * time.Millisecond,
+			reqDuration:   50 * time.Millisecond,
+			expectedSleep: 450 * time.Millisecond,
+		},
+		{
+			name:          "Global delay is overridden",
+			userID:        "user4",
+			delayCfg:      500 * time.Millisecond,
+			delayOverride: durationPtr(600 * time.Millisecond),
+			reqDuration:   50 * time.Millisecond,
+			expectedSleep: 550 * time.Millisecond,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			limits := overrides.Overrides{
 				Ingestion: overrides.IngestionOverrides{
-					ArtificialDelay: tc.delay,
+					ArtificialDelay: tc.delayOverride,
 				},
 			}
 			// Init limits overrides
@@ -61,6 +77,7 @@ func Test_outerMaybeDelayMiddleware(t *testing.T) {
 				overrides: overrides,
 				sleep:     timeSource.Sleep,
 				now:       timeSource.Now,
+				cfg:       Config{ArtificialDelay: tc.delayCfg},
 			}
 
 			// Add time spent on request
@@ -92,4 +109,8 @@ func (m *MockTimeSource) Sleep(d time.Duration) {
 
 func (m *MockTimeSource) Add(d time.Duration) {
 	m.CurrentTime = m.CurrentTime.Add(d)
+}
+
+func durationPtr(d time.Duration) *time.Duration {
+	return &d
 }

--- a/modules/distributor/artificial_delay_test.go
+++ b/modules/distributor/artificial_delay_test.go
@@ -55,6 +55,14 @@ func Test_outerMaybeDelayMiddleware(t *testing.T) {
 			reqDuration:   50 * time.Millisecond,
 			expectedSleep: 550 * time.Millisecond,
 		},
+		{
+			name:          "Override delay configured with 0",
+			userID:        "user4",
+			delayCfg:      500 * time.Millisecond,
+			delayOverride: durationPtr(0 * time.Millisecond),
+			reqDuration:   50 * time.Millisecond,
+			expectedSleep: 0,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/modules/distributor/config.go
+++ b/modules/distributor/config.go
@@ -58,6 +58,9 @@ type Config struct {
 	factory ring_client.PoolAddrFunc `yaml:"-"`
 
 	MaxAttributeBytes int `yaml:"max_attribute_bytes"`
+
+	// ArtificialDelay is an optional duration to introduce a delay for artificial processing in the distributor.
+	ArtificialDelay time.Duration `yaml:"artificial_delay,omitempty"`
 }
 
 type LogSpansConfig struct {

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -76,9 +76,9 @@ type IngestionOverrides struct {
 	MaxLocalTracesPerUser  int `yaml:"max_traces_per_user,omitempty" json:"max_traces_per_user,omitempty"`
 	MaxGlobalTracesPerUser int `yaml:"max_global_traces_per_user,omitempty" json:"max_global_traces_per_user,omitempty"`
 
-	TenantShardSize   int           `yaml:"tenant_shard_size,omitempty" json:"tenant_shard_size,omitempty"`
-	MaxAttributeBytes int           `yaml:"max_attribute_bytes,omitempty" json:"max_attribute_bytes,omitempty"`
-	ArtificialDelay   time.Duration `yaml:"artificial_delay,omitempty" json:"artificial_delay,omitempty"`
+	TenantShardSize   int            `yaml:"tenant_shard_size,omitempty" json:"tenant_shard_size,omitempty"`
+	MaxAttributeBytes int            `yaml:"max_attribute_bytes,omitempty" json:"max_attribute_bytes,omitempty"`
+	ArtificialDelay   *time.Duration `yaml:"artificial_delay,omitempty" json:"artificial_delay,omitempty"`
 }
 
 type ForwarderOverrides struct {

--- a/modules/overrides/interface.go
+++ b/modules/overrides/interface.go
@@ -33,7 +33,7 @@ type Interface interface {
 	MaxLocalTracesPerUser(userID string) int
 	MaxGlobalTracesPerUser(userID string) int
 	MaxBytesPerTrace(userID string) int
-	IngestionArtificialDelay(userID string) time.Duration
+	IngestionArtificialDelay(userID string) (time.Duration, bool)
 	MaxCompactionRange(userID string) time.Duration
 	Forwarders(userID string) []string
 	MaxBytesPerTagValuesQuery(userID string) int

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -330,8 +330,12 @@ func (o *runtimeConfigOverridesManager) IngestionMaxAttributeBytes(userID string
 	return o.getOverridesForUser(userID).Ingestion.MaxAttributeBytes
 }
 
-func (o *runtimeConfigOverridesManager) IngestionArtificialDelay(userID string) time.Duration {
-	return o.getOverridesForUser(userID).Ingestion.ArtificialDelay
+func (o *runtimeConfigOverridesManager) IngestionArtificialDelay(userID string) (time.Duration, bool) {
+	artificialDelay := o.getOverridesForUser(userID).Ingestion.ArtificialDelay
+	if artificialDelay != nil {
+		return *artificialDelay, true
+	}
+	return 0, false
 }
 
 // MaxBytesPerTrace returns the maximum size of a single trace in bytes allowed for a user.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This PR extends the artificial delay feature with default configuration in the distributor.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`