### PR TITLE
Fix compactor panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [BUGFIX] TraceQL results caching bug for floats ending in .0 [#4539](https://github.com/grafana/tempo/pull/4539) (@carles-grafana)
 * [BUGFIX] Rhythm: fix sorting order for partition consumption [#4747](https://github.com/grafana/tempo/pull/4747) (@javiermolinar)
 * [BUGFIX] Rhythm: fix block builder to not reuse a block ID if it was already flushed, to prevent read errors [#4872](https://github.com/grafana/tempo/pull/4872) (@mdisibio)
+* [BUGFIX] Fix rare panic during compaction. [#4915](https://github.com/grafana/tempo/pull/4915) (@joe-elliott)
 * [BUGFIX] Fix metrics streaming for all non-trivial metrics [#4624](https://github.com/grafana/tempo/pull/4624) (@joe-elliott)
 * [BUGFIX] Fix starting consuming log [#4539](https://github.com/grafana/tempo/pull/4539) (@javiermolinar)
 * [BUGFIX] Rhythm - fix adjustment of the start and end range for livetraces blocks [#4746](https://github.com/grafana/tempo/pull/4746) (@javiermolinar)

--- a/modules/compactor/compactor.go
+++ b/modules/compactor/compactor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
+	"math/rand/v2"
 	"time"
 
 	"github.com/go-kit/log/level"
@@ -193,6 +194,11 @@ func (c *Compactor) Owns(hash string) bool {
 	}
 
 	level.Debug(log.Logger).Log("msg", "checking hash", "hash", hash)
+
+	// 1 in a 100 chance of returning false
+	if rand.IntN(100) == 0 {
+		return false
+	}
 
 	hasher := fnv.New32a()
 	_, _ = hasher.Write([]byte(hash))

--- a/modules/compactor/compactor.go
+++ b/modules/compactor/compactor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
-	"math/rand/v2"
 	"time"
 
 	"github.com/go-kit/log/level"
@@ -194,11 +193,6 @@ func (c *Compactor) Owns(hash string) bool {
 	}
 
 	level.Debug(log.Logger).Log("msg", "checking hash", "hash", hash)
-
-	// 1 in a 100 chance of returning false
-	if rand.IntN(100) == 0 {
-		return false
-	}
 
 	hasher := fnv.New32a()
 	_, _ = hasher.Write([]byte(hash))

--- a/pkg/io/buffered.go
+++ b/pkg/io/buffered.go
@@ -68,7 +68,7 @@ func (r *BufferedReaderAt) populate(buf *readerBuffer) (int, error) {
 
 	// if err is fatal we need to invalidate the buffer by setting it back to 0s (uninitialized)
 	if isFatalError(err) {
-		buf.buf = buf.buf[:n]
+		buf.buf = buf.buf[:0]
 		buf.count = 0
 		buf.off = 0
 	}

--- a/pkg/io/buffered.go
+++ b/pkg/io/buffered.go
@@ -9,6 +9,10 @@ import (
 // Subsequent reads are returned from the buffers. Additionally it supports concurrent readers
 // by maintaining multiple buffers at different offsets, and matching up reads with existing
 // buffers where possible. When needed the least-recently-used buffer is overwritten with new reads.
+//
+// Note that the locking effectively serializes reads to the underlying io.ReaderAt. This reader
+// is not suitable for high-concurrency workloads, but does nicely reduce memory usage and backend calls
+// for batch workloads.
 type BufferedReaderAt struct {
 	mtx     sync.Mutex
 	ra      io.ReaderAt

--- a/pkg/io/buffered.go
+++ b/pkg/io/buffered.go
@@ -63,10 +63,10 @@ func (r *BufferedReaderAt) prep(buf *readerBuffer, offset, length int64) {
 }
 
 func (r *BufferedReaderAt) populate(buf *readerBuffer) (int, error) {
-	// Read
+	// read
 	n, err := r.ra.ReadAt(buf.buf, buf.off)
 
-	// if err != nil we need to invalidate the buffer by setting it back to 0s (uninitialized)
+	// if err is fatal we need to invalidate the buffer by setting it back to 0s (uninitialized)
 	if isFatalError(err) {
 		buf.buf = buf.buf[:n]
 		buf.count = 0

--- a/pkg/io/buffered.go
+++ b/pkg/io/buffered.go
@@ -61,6 +61,14 @@ func (r *BufferedReaderAt) prep(buf *readerBuffer, offset, length int64) {
 func (r *BufferedReaderAt) populate(buf *readerBuffer) (int, error) {
 	// Read
 	n, err := r.ra.ReadAt(buf.buf, buf.off)
+
+	// if err != nil we need to invalid the buffer by setting it back to 0s (uninitialized)
+	if err != nil {
+		buf.buf = buf.buf[:n]
+		buf.count = 0
+		buf.off = 0
+	}
+
 	return n, err
 }
 

--- a/pkg/io/buffered_test.go
+++ b/pkg/io/buffered_test.go
@@ -134,7 +134,7 @@ type erroringReaderAt struct {
 }
 
 func (e *erroringReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
-	if e.err != nil && e.err != io.EOF {
+	if e.err != nil && !errors.Is(e.err, io.EOF) {
 		// set all bytes to 0
 		for i := range p {
 			p[i] = 0

--- a/pkg/io/buffered_test.go
+++ b/pkg/io/buffered_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -114,21 +113,4 @@ func TestBufferedReaderConcurrency(t *testing.T) {
 			require.NoError(t, err)
 		}()
 	}
-}
-
-func TestBufferedWriterWithQueueWritesToBackend(t *testing.T) {
-	buf := bytes.NewBuffer(make([]byte, 0, 10))
-
-	b := NewBufferedWriterWithQueue(buf)
-
-	n, err := b.Write([]byte{0x01})
-	require.NoError(t, err)
-	require.Equal(t, 1, n)
-
-	require.NoError(t, b.Flush())
-	require.NoError(t, b.Close())
-
-	// eventual consistency :)
-	time.Sleep(100 * time.Millisecond)
-	require.Equal(t, []byte{0x01}, buf.Bytes())
 }

--- a/tempodb/encoding/vparquet4/block_iterator.go
+++ b/tempodb/encoding/vparquet4/block_iterator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
+// jpe - add comment
 func (b *backendBlock) open(ctx context.Context) (*parquet.File, *parquet.Reader, error) { //nolint:all //deprecated
 	rr := NewBackendReaderAt(ctx, b.r, DataFileName, b.meta)
 

--- a/tempodb/encoding/vparquet4/block_iterator.go
+++ b/tempodb/encoding/vparquet4/block_iterator.go
@@ -13,8 +13,9 @@ import (
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
-// jpe - add comment
-func (b *backendBlock) open(ctx context.Context) (*parquet.File, *parquet.Reader, error) { //nolint:all //deprecated
+// openForIteration opens and returns the parquet file. Note that this is currently only used for compaction and is tuned for this kind of workload.
+// In particular it uses the tempo_io.BufferedReaderAt which is slower but uses less memory and incurs fewer backend calls.
+func (b *backendBlock) openForIteration(ctx context.Context) (*parquet.File, *parquet.Reader, error) { //nolint:all //deprecated
 	rr := NewBackendReaderAt(ctx, b.r, DataFileName, b.meta)
 
 	// 128 MB memory buffering
@@ -37,7 +38,7 @@ func (b *backendBlock) open(ctx context.Context) (*parquet.File, *parquet.Reader
 }
 
 func (b *backendBlock) rawIter(ctx context.Context, pool *rowPool) (*rawIterator, error) {
-	pf, r, err := b.open(ctx)
+	pf, r, err := b.openForIteration(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does**:
Compactors rarely panic with a stack like:

```
        /enterprise-traces/vendor/github.com/parquet-go/parquet-go/page.go:129 +0xfd
created by github.com/parquet-go/parquet-go.AsyncPages in goroutine 33664
        /enterprise-traces/vendor/github.com/parquet-go/parquet-go/page.go:264 +0x178
github.com/parquet-go/parquet-go.readPages({0x3bc5390, 0xc06ed2f360}, 0xc0b09b2f50, 0xc0acc4b780, 0x3bea488?, 0xc0b09b3030)
        /enterprise-traces/vendor/github.com/parquet-go/parquet-go/file.go:801 +0x9f
github.com/parquet-go/parquet-go.(*FilePages).ReadPage(0xc06ed2f360)
        /enterprise-traces/vendor/github.com/parquet-go/parquet-go/file.go:916 +0x65
github.com/parquet-go/parquet-go.(*FilePages).readPage(0xc06ed2f360, 0xc096766f30, 0xc0795b8000)
        /enterprise-traces/vendor/github.com/parquet-go/parquet-go/buffer.go:532 +0xd7
github.com/parquet-go/parquet-go.(*bufferPool).get(0x5a1ff60?, 0xfffffffffffffffc?)
        /enterprise-traces/vendor/github.com/parquet-go/parquet-go/buffer.go:510 +0x2d
github.com/parquet-go/parquet-go.(*bufferPool).newBuffer(0x5a1ff60, 0xfffffffffffffffc, 0x1000)
goroutine 176675 [running]:   
        
panic: runtime error: makeslice: len out of range
```

This was caused by the `io.BufferedReaderAt` not invalidating buffers when an error was received here:

https://github.com/grafana/tempo/blob/c5e5978f1ba9bb0819df509f4de74625fc1eb5a4/pkg/io/buffered.go#L64-L68

Later it was possible to return data from this buffer as if it were correct even though the buffer was in an unknown state.

**Other Changes**

- Removed `BufferedWriterWithQueue` b/c it was unused.
- Added a test to replicate the described issue.
- Renamed open -> openForIteration and added comments to help clarify how the two open funcs are used.
- Simplified the locking in `BufferedReaderAt`. Previously it would drop the primary lock for per-buffer locking before it attempted to read from the backend. This was designed to prevent this struct from serializing calls to object storage. I believe this could be maintained with the fix, but it was getting quite complicated. Consider that you would need to handle a buffer being invalid after it had been already selected b/c the read might invalidate it. Since this code was only used in the compactors I favored simplicity over performance. There is a small, but reasonable performance hit.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`