### PR TITLE
Fix nil meta apply on parent context cancelation

### DIFF
--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -175,7 +175,7 @@ func (p *Poller) Do(parentCtx context.Context, previous *List) (PerTenant, PerTe
 		if parentCtx.Err() != nil {
 			// Wait for our work to complete.
 			wg.Wait()
-			return nil, nil, nil
+			return nil, nil, parentCtx.Err()
 		}
 
 		// Exit early if we have exceeded our tolerance for number of failing tenants.


### PR DESCRIPTION
**What this PR does**:

Handle the context error with grace to avoid trying to apply a nil meta map to the blocklist on shutdown.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`