### PR TITLE
distributor: add counter for spans in the future

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [CHANGE] Do not count cached querier responses for SLO metrics such as inspected bytes [#5185](https://github.com/grafana/tempo/pull/5185) (@carles-grafana)
 * [CHANGE] Assert max live traces limits in local-blocks processor [#5170](https://github.com/grafana/tempo/pull/5170) (@mapno)
+* [FEATURE] Add histograms `spans_distance_in_future_seconds` / `spans_distance_in_past_seconds` that count spans with end timestamp in the future / past. While spans in the future are accepted, they are invalid and may not be found using the Search API. [#4936](https://github.com/grafana/tempo/pull/4936) (@carles-grafana)
 * [ENHANCEMENT] Include backendwork dashboard and include additional alert [#5159](https://github.com/grafana/tempo/pull/5159) (@zalegrala)
 * [ENHANCEMENT] Add alert for high error rate reported by vulture [#5206](https://github.com/grafana/tempo/pull/5206) (@ruslan-mikhailov)
 * [ENHANCEMENT] Add backend scheduler and worker to the resources dashboard [#5206](https://github.com/grafana/tempo/pull/5241) (@javiermolinar)

--- a/pkg/dataquality/warnings.go
+++ b/pkg/dataquality/warnings.go
@@ -37,3 +37,17 @@ func WarnDisconnectedTrace(tenant string, phase string) {
 func WarnRootlessTrace(tenant string, phase string) {
 	metric.WithLabelValues(tenant, reasonRootlessTrace+phase).Inc()
 }
+
+var MetricSpanInFuture = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: "tempo",
+	Name:      "spans_distance_in_future_seconds",
+	Help:      "The number of seconds in the future of the span end time in relation to the ingestion time.",
+	Buckets:   []float64{300, 1800, 3600}, // 5m, 30m, 1h
+}, []string{"tenant"})
+
+var MetricSpanInPast = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: "tempo",
+	Name:      "spans_distance_in_past_seconds",
+	Help:      "The number of seconds in the past of the span end time in relation to the ingestion time.",
+	Buckets:   []float64{300, 1800, 3600}, // 5m, 30m, 1h
+}, []string{"tenant"})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This will allow us to find customers that send spans in the future,
which can't be found using the Search API.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`