### PR TITLE
fix: include cost attribution when converting from default config to legacy one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [BUGFIX] Rhythm - fix adjustment of the start and end range for livetraces blocks [#4746](https://github.com/grafana/tempo/pull/4746) (@javiermolinar)
 * [BUGFIX] Return the operand as the only value if the tag is already filtered in the query [#4673](https://github.com/grafana/tempo/pull/4673) (@mapno)
 * [BUGFIX] Fix flaky test [#4787](https://github.com/grafana/tempo/pull/4787) (@javiermolinar)
+* [BUGFIX] Include cost attribution when converting from default config to legacy one [#4787](https://github.com/grafana/tempo/pull/4937) (@javiermolinar)
 * [BUGFIX] Fix memcached settings for docker compose example [#4346](https://github.com/grafana/tempo/pull/4695) (@ruslan-mikhailov)
 * [BUGFIX] Fix setting processors in user configurations overrides via API [#4741](https://github.com/grafana/tempo/pull/4741) (@ruslan-mikhailov)
 * [BUGFIX] Fix panic on startup [#4744](https://github.com/grafana/tempo/pull/4744) (@ruslan-mikhailov)

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -206,7 +206,7 @@ type Overrides struct {
 	Global GlobalOverrides `yaml:"global,omitempty" json:"global,omitempty"`
 	// Storage enforced overrides.
 	Storage         StorageOverrides         `yaml:"storage,omitempty" json:"storage,omitempty"`
-	CostAttribution CostAttributionOverrides `yaml:"cost_attribution,omitempty" json:"cost_attribution,omitempty"`
+	CostAttribution CostAttributionOverrides `yaml:"cost_attribution" json:"cost_attribution"`
 }
 
 type Config struct {

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -206,7 +206,7 @@ type Overrides struct {
 	Global GlobalOverrides `yaml:"global,omitempty" json:"global,omitempty"`
 	// Storage enforced overrides.
 	Storage         StorageOverrides         `yaml:"storage,omitempty" json:"storage,omitempty"`
-	CostAttribution CostAttributionOverrides `yaml:"cost_attribution" json:"cost_attribution"`
+	CostAttribution CostAttributionOverrides `yaml:"cost_attribution,omitempty" json:"cost_attribution,omitempty"`
 }
 
 type Config struct {

--- a/modules/overrides/config_legacy.go
+++ b/modules/overrides/config_legacy.go
@@ -66,6 +66,7 @@ func (c *Overrides) toLegacy() LegacyOverrides {
 		MaxBytesPerTrace: c.Global.MaxBytesPerTrace,
 
 		DedicatedColumns: c.Storage.DedicatedColumns,
+		CostAttribution:  c.CostAttribution,
 	}
 }
 
@@ -139,7 +140,7 @@ type LegacyOverrides struct {
 	//  is not used when doing a trace by id lookup.
 	MaxBytesPerTrace int `yaml:"max_bytes_per_trace" json:"max_bytes_per_trace"`
 
-	CostAttribution CostAttributionOverrides `yaml:"cost_attribution,omitempty" json:"cost_attribution,omitempty"`
+	CostAttribution CostAttributionOverrides `yaml:"cost_attribution" json:"cost_attribution"`
 
 	// tempodb limits
 	DedicatedColumns backend.DedicatedColumns `yaml:"parquet_dedicated_columns" json:"parquet_dedicated_columns"`

--- a/modules/overrides/runtime_config_overrides_test.go
+++ b/modules/overrides/runtime_config_overrides_test.go
@@ -164,6 +164,7 @@ func TestRuntimeConfigOverrides(t *testing.T) {
 						Read: ReadOverrides{
 							MaxSearchDuration: model.Duration(16 * time.Second),
 						},
+						CostAttribution: CostAttributionOverrides{Dimensions: map[string]string{"foo": "bar"}},
 					},
 				},
 			},


### PR DESCRIPTION
**What this PR does**:
It includes the cost attribution when converting from default config to legacy one

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`