### PR TITLE
chore: set querier default log level to INFO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@
   Renamed max_span_attr_byte to max_attribute_bytes
   [#4633](https://github.com/grafana/tempo/pull/4633) (@ie-pham)
 * [CHANGE] Update to go 1.24.1 [#4704](https://github.com/grafana/tempo/pull/4704) (@ruslan-mikhailov) [#4793](https://github.com/grafana/tempo/pull/4793) (@javiermolinar)
-* [CHANGE]  **BREAKING CHANGE** Removed otel jaeger exporter. [#4926](https://github.com/grafana/tempo/pull/4926) (@javiermolinar)
+* [CHANGE] **BREAKING CHANGE** Removed otel jaeger exporter. [#4926](https://github.com/grafana/tempo/pull/4926) (@javiermolinar)
 * [CHANGE] Finish polling current tenants on poller shutdown [#4897](https://github.com/grafana/tempo/pull/4897) (@zalegrala)
+* [CHANGE] Set querier default level to INFO [#4943](https://github.com/grafana/tempo/pull/4943) (@javiermolinar)
 * [FEATURE] Add throughput SLO and metrics for the TraceByID endpoint. [#4668](https://github.com/grafana/tempo/pull/4668) (@carles-grafana)
 configurable via the throughput_bytes_slo field, and it will populate op="traces" label in slo and throughput metrics.
 * [FEATURE] Added most_recent=true query hint to TraceQL to return most recent results. [#4238](https://github.com/grafana/tempo/pull/4238) (@joe-elliott)

--- a/operations/jsonnet-compiled/ConfigMap-tempo-querier.yaml
+++ b/operations/jsonnet-compiled/ConfigMap-tempo-querier.yaml
@@ -20,7 +20,6 @@ data:
             frontend_address: query-frontend-discovery.tracing.svc.cluster.local.:9095
     server:
         http_listen_port: 3200
-        log_level: debug
     storage:
         trace:
             azure:

--- a/operations/jsonnet-compiled/Deployment-querier.yaml
+++ b/operations/jsonnet-compiled/Deployment-querier.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        config_hash: 89dfae41b12d998719ac3ae0090cfe4f
+        config_hash: 4eceda35dd62a16a63572f339b7f15f4
       labels:
         app: querier
         name: querier

--- a/operations/jsonnet-compiled/util/jsonnetfile.lock.json
+++ b/operations/jsonnet-compiled/util/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "b837743c330d98f1f89fee864cca8f7df6c71eca",
+      "version": "357eee054c4a50b1033e22493fd9503c1174bf56",
       "sum": "0y3AFX9LQSpfWTxWKSwoLgbt0Wc9nnCwhMH2szKzHv0="
     },
     {
@@ -18,7 +18,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "b837743c330d98f1f89fee864cca8f7df6c71eca",
+      "version": "357eee054c4a50b1033e22493fd9503c1174bf56",
       "sum": "Cc715Y3rgTuimgDFIw+FaKzXSJGRYwt1pFTMbdrNBD8="
     },
     {

--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -92,9 +92,6 @@
   },
 
   tempo_querier_config:: $.tempo_config {
-    server+: {
-      log_level: 'debug',
-    },
     storage+: {
       trace+: {
         blocklist_poll: '5m',


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Queriers are the only components that we ship by default with log_level DEBUG. This PR set them to the default level which is INFO


**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`