### PR TITLE
chore: log target mode in Tempo startup message

### DIFF
--- a/cmd/tempo/main.go
+++ b/cmd/tempo/main.go
@@ -112,11 +112,11 @@ func main() {
 		os.Exit(1)
 	}
 
-    level.Info(log.Logger).Log(
-        "msg", "Starting Tempo",
-        "version", version.Info(),
-        "target", config.Target,
-    )
+	level.Info(log.Logger).Log(
+		"msg", "Starting Tempo",
+		"version", version.Info(),
+		"target", config.Target,
+	)
 
 	if err := t.Run(); err != nil {
 		level.Error(log.Logger).Log("msg", "error running Tempo", "err", err)

--- a/cmd/tempo/main.go
+++ b/cmd/tempo/main.go
@@ -112,7 +112,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	level.Info(log.Logger).Log("msg", "Starting Tempo", "version", version.Info())
+    level.Info(log.Logger).Log(
+        "msg", "Starting Tempo",
+        "version", version.Info(),
+        "target", config.Target,
+    )
 
 	if err := t.Run(); err != nil {
 		level.Error(log.Logger).Log("msg", "error running Tempo", "err", err)


### PR DESCRIPTION
**What this PR does**:
Adds the `config.Target` value to the startup log message for clearer observability.

**Which issue(s) this PR fixes**:
None (minor logging enhancement).

**Checklist**
- [ ] Tests updated (not applicable)
- [ ] Documentation added (not applicable)
- [ ] `CHANGELOG.md` updated (not applicable; trivial logging improvement)
