### PR TITLE
ci: set fail fast to false in the tests jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
     name: Run Unit Tests
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         test-target:
           [
@@ -82,6 +83,7 @@ jobs:
     name: Run integration tests
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         test-target:
           [


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
It is a matter of fact that we introduce flaky tests from time to time. While we are always speedy in fixing them, in the meantime, it is quite annoying having to retry all the matrix steps when one of them fails:

![image](https://github.com/user-attachments/assets/aaab0ae8-de8d-4586-a7b7-7cb22197a46c)

Setting the `fail-fast: false` will make all the test steps to finish so only the failed one will need to be retried
 

