### PR TITLE
Change default http-listen-port from 80 to 3200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## main / unreleased
-
 * [FEATURE] Add support for topk and bottomk functions for TraceQL metrics [#4646](https://github.com/grafana/tempo/pull/4646/) @electron0zero
+* [CHANGE] **BREAKING CHANGE** Change default http-listen-port from 80 to 3200 [#4960](https://github.com/grafana/tempo/pull/4960) (@martialblog)
 * [CHANGE] Update query range error message [#4929](https://github.com/grafana/tempo/pull/4929) (@joey-grafana)
 * [CHANGE] **BREAKING CHANGE** Upgrade OTEL Collector to v0.122.1 [#4893](https://github.com/grafana/tempo/pull/4893) (@javiermolinar)
   The `name` dimension from `tempo_receiver_accepted_span` and `tempo_receiver_refused_spans` changes from `tempo/jaeger_receiver` to `jaeger/jaeger_receiver`

--- a/cmd/tempo/app/config.go
+++ b/cmd/tempo/app/config.go
@@ -104,7 +104,7 @@ func (c *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 	c.Server.GRPCServerMinTimeBetweenPings = 10 * time.Second
 	c.Server.GRPCServerPingWithoutStreamAllowed = true
 
-	f.IntVar(&c.Server.HTTPListenPort, "server.http-listen-port", 80, "HTTP server listen port.")
+	f.IntVar(&c.Server.HTTPListenPort, "server.http-listen-port", 3200, "HTTP server listen port.")
 	f.IntVar(&c.Server.GRPCListenPort, "server.grpc-listen-port", 9095, "gRPC server listen port.")
 
 	// Memberlist settings

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -20,7 +20,7 @@ http_api_prefix: ""
 server:
     http_listen_network: tcp
     http_listen_address: ""
-    http_listen_port: 80
+    http_listen_port: 3200
     http_listen_conn_limit: 0
     grpc_listen_network: tcp
     grpc_listen_address: ""

--- a/docs/sources/tempo/configuration/use-trace-data.md
+++ b/docs/sources/tempo/configuration/use-trace-data.md
@@ -31,7 +31,7 @@ To configure Tempo with Grafana:
 1. Point the Grafana data source at your Tempo query frontend (or monolithic mode Tempo).
 1. Enter the URL: `http://<tempo hostname>:<http port number>`. For most of [the Tempo examples](https://github.com/grafana/tempo/tree/main/example/docker-compose) the following works.
 
-The port of 3200 is a common port used in our examples. Tempo default HTTP port is 80.
+The port of 3200 is a common port used in our examples. Tempo default HTTP port is 3200.
 
 ## Query the data source
 


### PR DESCRIPTION
**What this PR does**:

This PR changes the default http-listen-port from 80 to 3200.

**Which issue(s) this PR fixes**:

No open issue. See discussion here: https://github.com/grafana/tempo/discussions/4945 

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`