### PR TITLE
Issue 4896 traceql metrics fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [BUGFIX] Fix panic on startup [#4744](https://github.com/grafana/tempo/pull/4744) (@ruslan-mikhailov)
 * [BUGFIX] Fix intrinsic tag lookups dropped when max tag lookup response size is exceeded [#4784](https://github.com/grafana/tempo/pull/4784) (@mdisibio)
 * [BUGFIX] Correctly cache frontend jobs for query range (TraceQL Metrics). [#4771](https://github.com/grafana/tempo/pull/4771) (@joe-elliott)
+* [BUGFIX] Various edge case fixes for query range (TraceQL Metrics) [#4962](https://github.com/grafana/tempo/pull/4962) (@ruslan-mikhailov)
 * [BUGFIX] Fix `TempoBlockListRisingQuickly` alert grouping. [#4876](https://github.com/grafana/tempo/pull/4876) (@mapno)
 
 # v2.7.2

--- a/modules/frontend/metrics_query_range_sharder.go
+++ b/modules/frontend/metrics_query_range_sharder.go
@@ -250,7 +250,7 @@ func (s *queryRangeSharder) buildBackendRequests(ctx context.Context, tenantID s
 			// Trim and align the request for this block. I.e. if the request is "Last Hour" we don't want to
 			// cache the response for that, we want only the few minutes time range for this block. This has
 			// size savings but the main thing is that the response is reuseable for any overlapping query.
-			start, end, step := traceql.TrimToOverlap(searchReq.Start, searchReq.End, searchReq.Step, uint64(m.StartTime.UnixNano()), uint64(m.EndTime.UnixNano()))
+			start, end, step := traceql.TrimToBlockOverlap(searchReq.Start, searchReq.End, searchReq.Step, m.StartTime, m.EndTime)
 			if start == end || step == 0 {
 				level.Warn(s.logger).Log("msg", "invalid start/step end. skipping", "start", start, "end", end, "step", step, "blockStart", m.StartTime.UnixNano(), "blockEnd", m.EndTime.UnixNano())
 				continue

--- a/modules/generator/processor/localblocks/processor_test.go
+++ b/modules/generator/processor/localblocks/processor_test.go
@@ -104,6 +104,7 @@ func TestProcessorDoesNotRace(t *testing.T) {
 
 	p, err := New(cfg, tenant, wal, &mockWriter{}, overrides)
 	require.NoError(t, err)
+	defer p.Shutdown(t.Context())
 
 	qr := &tempopb.QueryRangeRequest{
 		Query: "{} | rate() by (resource.service.name)",
@@ -200,7 +201,6 @@ func TestProcessorDoesNotRace(t *testing.T) {
 	// Cleanup
 	close(end)
 	wg.Wait()
-	p.Shutdown(ctx)
 }
 
 func TestReplicationFactor(t *testing.T) {
@@ -232,6 +232,7 @@ func TestReplicationFactor(t *testing.T) {
 
 	p, err := New(cfg, "fake", wal, mockWriter, &mockOverrides{})
 	require.NoError(t, err)
+	defer p.Shutdown(t.Context())
 
 	tr := test.MakeTrace(10, []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
 	p.PushSpans(context.TODO(), &tempopb.PushSpansRequest{
@@ -330,8 +331,9 @@ func TestBadBlocks(t *testing.T) {
 		},
 	}
 
-	_, err = New(cfg, "test-tenant", wal, nil, &mockOverrides{})
+	p, err := New(cfg, "test-tenant", wal, nil, &mockOverrides{})
 	require.NoError(t, err)
+	p.Shutdown(t.Context())
 }
 
 func TestProcessorWithNonEmptyWAL(t *testing.T) {
@@ -373,8 +375,9 @@ func TestProcessorWithNonEmptyWAL(t *testing.T) {
 		},
 	}
 
-	_, err = New(cfg, tenantID, wal, nil, &mockOverrides{})
+	p, err := New(cfg, tenantID, wal, nil, &mockOverrides{})
 	require.NoError(t, err)
+	p.Shutdown(t.Context())
 }
 
 func writeBadJSON(t *testing.T, path string) {

--- a/modules/generator/processor/localblocks/query_range.go
+++ b/modules/generator/processor/localblocks/query_range.go
@@ -54,7 +54,7 @@ func (p *Processor) QueryRange(ctx context.Context, req *tempopb.QueryRangeReque
 	withinRange := func(m *backend.BlockMeta) bool {
 		start := uint64(m.StartTime.UnixNano())
 		end := uint64(m.EndTime.UnixNano())
-		return req.Start < end && req.End > start
+		return req.Start <= end && req.End >= start
 	}
 
 	var (

--- a/modules/generator/processor/localblocks/query_range.go
+++ b/modules/generator/processor/localblocks/query_range.go
@@ -149,7 +149,7 @@ func (p *Processor) queryRangeCompleteBlock(ctx context.Context, b *ingester.Loc
 	// Trim and align the request for this block. I.e. if the request is "Last Hour" we don't want to
 	// cache the response for that, we want only the few minutes time range for this block. This has
 	// size savings but the main thing is that the response is reuseable for any overlapping query.
-	req.Start, req.End, req.Step = traceql.TrimToOverlap(req.Start, req.End, req.Step, uint64(m.StartTime.UnixNano()), uint64(m.EndTime.UnixNano()))
+	req.Start, req.End, req.Step = traceql.TrimToBlockOverlap(req.Start, req.End, req.Step, m.StartTime, m.EndTime)
 
 	if req.Start >= req.End {
 		// After alignment there is no overlap or something else isn't right

--- a/modules/generator/processor/localblocks/query_range_test.go
+++ b/modules/generator/processor/localblocks/query_range_test.go
@@ -1,0 +1,223 @@
+package localblocks
+
+import (
+	"flag"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/tempo/pkg/tempopb"
+	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	"github.com/grafana/tempo/pkg/traceql"
+	"github.com/grafana/tempo/pkg/util/test"
+	"github.com/grafana/tempo/tempodb"
+	"github.com/grafana/tempo/tempodb/backend"
+	"github.com/grafana/tempo/tempodb/backend/local"
+	"github.com/grafana/tempo/tempodb/encoding/common"
+	"github.com/grafana/tempo/tempodb/encoding/vparquet4"
+	"github.com/grafana/tempo/tempodb/wal"
+	"github.com/stretchr/testify/require"
+)
+
+func (m *mockOverrides) BlockRetentionForTenant(_ string) time.Duration     { return 0 }
+func (m *mockOverrides) CompactionDisabledForTenant(_ string) bool          { return false }
+func (m *mockOverrides) MaxBytesPerTraceForTenant(_ string) int             { return 0 }
+func (m *mockOverrides) MaxCompactionRangeForTenant(_ string) time.Duration { return 0 }
+
+func TestProcessor(t *testing.T) {
+	// init configuration
+	var (
+		tempDir      = t.TempDir()
+		blockVersion = vparquet4.VersionString
+	)
+
+	cfg := Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", &flag.FlagSet{})
+	cfg.FlushCheckPeriod = 10 * time.Millisecond
+	cfg.TraceIdlePeriod = 10 * time.Millisecond
+	cfg.MaxBlockDuration = 10 * time.Millisecond
+	cfg.FlushToStorage = true
+
+	tenant := "TestProcessor"
+
+	_, w, _, err := tempodb.New(&tempodb.Config{
+		Backend: backend.Local,
+		Local: &local.Config{
+			Path: path.Join(tempDir, "traces"),
+		},
+		Block: &common.BlockConfig{
+			IndexDownsampleBytes: 17,
+			BloomFP:              .01,
+			BloomShardSizeBytes:  100_000,
+			Version:              blockVersion,
+			IndexPageSizeBytes:   1000,
+			RowGroupSizeBytes:    10000,
+		},
+		WAL: &wal.Config{
+			Filepath:       path.Join(tempDir, "wal"),
+			IngestionSlack: time.Since(time.Time{}),
+		},
+		Search: &tempodb.SearchConfig{
+			ChunkSizeBytes:  1_000_000,
+			ReadBufferCount: 8, ReadBufferSizeBytes: 4 * 1024 * 1024,
+		},
+		BlocklistPoll: 0,
+	}, nil, log.NewNopLogger())
+	require.NoError(t, err)
+
+	// init components
+	wal := w.WAL()
+
+	processor, err := New(cfg, tenant, wal, w, &mockOverrides{})
+	require.NoError(t, err)
+	defer processor.Shutdown(t.Context())
+
+	// push spanes
+	now := time.Now()
+
+	duration := time.Millisecond
+	span1Start := now.Add(-10 * time.Second)
+	span2Start := now.Add(-time.Second + time.Millisecond)
+
+	sp := test.MakeSpan(test.ValidTraceID(nil))
+	sp.StartTimeUnixNano = uint64(span1Start.UnixNano())
+	sp.EndTimeUnixNano = uint64(span1Start.Add(duration).UnixNano())
+	sp.Kind = v1.Span_SPAN_KIND_SERVER
+
+	sp2 := test.MakeSpan(test.ValidTraceID(nil))
+	sp2.StartTimeUnixNano = uint64(span2Start.UnixNano())
+	sp2.EndTimeUnixNano = uint64(span2Start.Add(duration).UnixNano())
+	sp2.Kind = v1.Span_SPAN_KIND_SERVER
+
+	processor.PushSpans(t.Context(), &tempopb.PushSpansRequest{
+		Batches: []*v1.ResourceSpans{
+			{
+				ScopeSpans: []*v1.ScopeSpans{
+					{
+						Spans: []*v1.Span{
+							sp,
+						},
+					},
+				},
+			},
+			{
+				ScopeSpans: []*v1.ScopeSpans{
+					{
+						Spans: []*v1.Span{
+							sp2,
+						},
+					},
+				},
+			},
+		},
+	})
+
+	// wait for flush and check if block was created
+	time.Sleep(500 * time.Millisecond)
+	var block common.BackendBlock
+	func() {
+		processor.blocksMtx.Lock() // to avoid race condition with running processor
+		defer processor.blocksMtx.Unlock()
+		require.Equal(t, len(processor.completeBlocks), 1, "block was not flushed or flushed in multiple blocks")
+		for _, b := range processor.completeBlocks {
+			block = b
+			break
+		}
+	}()
+
+	type testCase struct {
+		name              string
+		req               *tempopb.QueryRangeRequest
+		expectedSpans     int
+		expectedExemplars int
+	}
+
+	for _, tc := range []testCase{
+		{
+			// -------------- SP1 ------- SP2 ---------
+			// ---------^------------^-----------------
+			// ------- START ------ END ---------------
+			name: "first trace",
+			req: &tempopb.QueryRangeRequest{
+				Query:     "{} | count_over_time()",
+				Start:     uint64(span1Start.Add(-1 * time.Second).UnixNano()),
+				End:       uint64(span1Start.Add(duration + time.Second).UnixNano()),
+				Step:      uint64(time.Second),
+				Exemplars: 2,
+			},
+			expectedSpans:     1,
+			expectedExemplars: 1,
+		},
+		{
+			// -------------- SP1 ------- SP2 ---------
+			// ----------------------^------------^----
+			// ------------------- START ------- END --
+			name: "second trace",
+			req: &tempopb.QueryRangeRequest{
+				Query:     "{} | count_over_time()",
+				Start:     uint64(span2Start.Add(-1 * time.Second).UnixNano()),
+				End:       uint64(now.UnixNano()),
+				Step:      uint64(time.Second),
+				Exemplars: 2,
+			},
+			expectedSpans:     1,
+			expectedExemplars: 1,
+		},
+		{
+			// -------------- SP1 ------- SP2 -----------
+			// ---------------^-------------------^------
+			// ------------- START ------------- END ----
+			name: "start of block included",
+			req: &tempopb.QueryRangeRequest{
+				Query:     "{} | count_over_time()",
+				Start:     uint64(block.BlockMeta().StartTime.UnixNano()),
+				End:       uint64(now.UnixNano()),
+				Step:      uint64(time.Second),
+				Exemplars: 2,
+			},
+			expectedSpans:     2,
+			expectedExemplars: 2,
+		},
+		{
+			// -------------- SP1 ------- SP2 ------------------
+			// ----------------------------^-------------^------
+			// ------------------------- START -------- END ----
+			name: "end of block included",
+			req: &tempopb.QueryRangeRequest{
+				Query:     "{} | count_over_time()",
+				Start:     uint64(block.BlockMeta().EndTime.UnixNano()),
+				End:       uint64(now.UnixNano()),
+				Step:      uint64(time.Second),
+				Exemplars: 2,
+			},
+			expectedSpans:     0, // TODO: possible bug
+			expectedExemplars: 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := tc.req
+			req.Start, req.End, req.Step = traceql.TrimToBlockOverlap(req.Start, req.End, req.Step, block.BlockMeta().StartTime, block.BlockMeta().EndTime)
+
+			e := traceql.NewEngine()
+			rawEval, err := e.CompileMetricsQueryRange(req, int(req.Exemplars), 0, false)
+			require.NoError(t, err)
+			jobEval, err := traceql.NewEngine().CompileMetricsQueryRangeNonRaw(req, traceql.AggregateModeSum)
+			require.NoError(t, err)
+
+			err = processor.QueryRange(t.Context(), req, rawEval, jobEval)
+			require.NoError(t, err)
+			results := jobEval.Results()
+
+			require.Equal(t, 1, len(results))
+			for _, ts := range results {
+				var sum float64
+				for _, val := range ts.Values {
+					sum += val
+				}
+				require.InDelta(t, tc.expectedSpans, sum, 0.000001)
+				require.Equal(t, tc.expectedExemplars, len(ts.Exemplars))
+			}
+		})
+	}
+}

--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -1013,7 +1013,9 @@ func (e *MetricsEvaluator) Do(ctx context.Context, f SpansetFetcher, fetcherStar
 	// Make a copy of the request so we can modify it.
 	storageReq := *e.storageReq
 
-	if fetcherStart > 0 && fetcherEnd > 0 {
+	if fetcherStart > 0 && fetcherEnd > 0 &&
+		// exclude special case for a block with the same start and end
+		fetcherStart != fetcherEnd {
 		// Dynamically decide whether to use the trace-level timestamp columns
 		// for filtering.
 		overlap := timeRangeOverlap(e.start, e.end, fetcherStart, fetcherEnd)

--- a/pkg/traceql/engine_metrics_test.go
+++ b/pkg/traceql/engine_metrics_test.go
@@ -96,7 +96,7 @@ func TestIntervalOf(t *testing.T) {
 	}
 }
 
-func TestTrimToOverlap(t *testing.T) {
+func TestTrimToBlockOverlap(t *testing.T) {
 	tc := []struct {
 		start1, end1               string
 		step                       time.Duration
@@ -108,7 +108,7 @@ func TestTrimToOverlap(t *testing.T) {
 			// Fully overlapping
 			"2024-01-01 01:00:00", "2024-01-01 02:00:00", 5 * time.Minute,
 			"2024-01-01 01:33:00", "2024-01-01 01:38:00",
-			"2024-01-01 01:33:00", "2024-01-01 01:38:00", 5 * time.Minute,
+			"2024-01-01 01:33:00", "2024-01-01 01:38:01", 5 * time.Minute, // added 1 second to include the last second of the block
 		},
 		{
 			// Partially Overlapping
@@ -132,12 +132,13 @@ func TestTrimToOverlap(t *testing.T) {
 		start2, _ := time.Parse(time.DateTime, c.start2)
 		end2, _ := time.Parse(time.DateTime, c.end2)
 
-		actualStart, actualEnd, actualStep := TrimToOverlap(
+		actualStart, actualEnd, actualStep := TrimToBlockOverlap(
 			uint64(start1.UnixNano()),
 			uint64(end1.UnixNano()),
 			uint64(c.step.Nanoseconds()),
-			uint64(start2.UnixNano()),
-			uint64(end2.UnixNano()))
+			start2,
+			end2,
+		)
 
 		require.Equal(t, c.expectedStart, time.Unix(0, int64(actualStart)).UTC().Format(time.DateTime))
 		require.Equal(t, c.expectedEnd, time.Unix(0, int64(actualEnd)).UTC().Format(time.DateTime))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does

Start and end of the trace in generator are converted to seconds, dropping the fractional part.
```go
// Convert from unix nanos to unix seconds
startSeconds := uint32(start / uint64(time.Second))
endSeconds := uint32(end / uint64(time.Second))

err := p.headBlock.AppendTrace(id, tr, startSeconds, endSeconds, p.Cfg.AdjustTimeRangeForSlack)
```
Additionally, blocks' start and end times are in seconds.

![image](https://github.com/user-attachments/assets/2e90228f-0f7f-460c-a255-0d83fbd87d98)

### Bug 1
Search in blocks was exclusive, but it should have included both edges. See https://github.com/grafana/tempo/blob/a1ab3f911f9656fc5a82e7f1bd76eea4494c7bc0/modules/frontend/frontend.go#L361 as a reference
### Bug 2. Losing the last trace in the block. 

![image](https://github.com/user-attachments/assets/11ae505d-ba66-47db-8bcb-b603b6eedc9e)

It filters here:
```
			if e.checkTime {
				st := s.StartTimeUnixNanos()
				if st < e.start || st >= e.end {
					continue
				}
			}
```

To fix it, need to include the right border, but _only_ when request's time range fully includes the right edge of the block

### Bug 3. Lonely trace in a block. 
It is possible to have a block with start==end, it can be reproduced if only one trace was pushed and flushed.

This results in skipping this block
```go
func (e *MetricsEvaluator) Do(ctx context.Context, f SpansetFetcher, fetcherStart, fetcherEnd uint64) error {
	// Make a copy of the request so we can modify it.
	storageReq := *e.storageReq

	if fetcherStart > 0 && fetcherEnd > 0 &&
		fetcherStart != fetcherEnd {
			overlap := timeRangeOverlap(e.start, e.end, fetcherStart, fetcherEnd)
			if overlap == 0.0 { // <------ overlap will be zero
				// This shouldn't happen but might as well check.
				// No overlap == nothing to do
				return nil
			}
```
 
### Bug 4. Exemplars are not filtered
```go
		for _, s := range ss.Spans {
			if e.checkTime {
				st := s.StartTimeUnixNanos()
				if st < e.start || st >= e.end {
					continue
				}
			}

			e.spansTotal++

			e.metricsPipeline.observe(s)
		}

		if len(ss.Spans) > 0 && e.sampleExemplar(ss.TraceID) {
			e.metricsPipeline.observeExemplar(ss.Spans[rand.Intn(len(ss.Spans))])
		}
```
This results in including traces outside of the requested time range

![image](https://github.com/user-attachments/assets/e3f88c07-194e-4150-8192-36e0e69bce98)


## Which issue(s) this PR fixes
Fixes https://github.com/grafana/tempo/issues/4896

## How it has been tested
### Vulture
It was checked by https://github.com/grafana/tempo/pull/4886

1. one binary docker compose (https://github.com/grafana/tempo/tree/main/example/docker-compose/local)
2. distributed docker compose (https://github.com/grafana/tempo/tree/main/example/docker-compose/distributed)
3. rhythm docker compose (https://github.com/grafana/tempo/tree/main/example/docker-compose/ingest-storage)
4. long run in k8s with rhythm enabled
![image](https://github.com/user-attachments/assets/ca4bf8da-36df-4388-8370-a025cf2c0404)

### Autotest
1. e2e test for a single trace
2. unit test for 2 traces to test border conditions


## Checklist
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`