### PR TITLE
Bugfix? Improve EOF handling in readers.go

### DIFF
--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -608,7 +608,7 @@ func (rw *readerWriter) readRange(ctx context.Context, objName string, offset in
 		return nil
 	}
 
-	return fmt.Errorf("error in range read from s3 backend: %w", err)
+	return err
 }
 
 func fetchCreds(cfg *Config) (*credentials.Credentials, error) {


### PR DESCRIPTION
**What this PR does**:
We are currently chasing a very rare panic that occurs in parquet-go. While fixing a related issue in compactors I noticed that io.EOF was not being handled correctly in readers.go. This change makes the various ReaderAt's in vParquet4 handle io.EOF correctly.

Also removed the error wrapping in s3.go to be consistent with other backends.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`