### PR TITLE
My ubuntu version did not have eth0 or any of the other named interfaces

### DIFF
--- a/modules/backendworker/backendworker_test.go
+++ b/modules/backendworker/backendworker_test.go
@@ -72,7 +72,7 @@ func setupDependencies(ctx context.Context, t *testing.T, limits overrides.Confi
 	workerConfig.BackendSchedulerAddr = "localhost:1234"
 	workerConfig.Ring.KVStore.Store = "inmemory"
 	workerConfig.Ring.KVStore.Mock = nil
-	workerConfig.Ring.InstanceInterfaceNames = []string{"eth0", "en0", "lo0", "enp102s0f4u1u3"}
+	workerConfig.Ring.InstanceInterfaceNames = []string{"eth0", "en0", "lo0", "enp102s0f4u1u3", "eno1"}
 
 	overrides, err := overrides.NewOverrides(limits, nil, prometheus.DefaultRegisterer)
 	require.NoError(t, err)

--- a/modules/generator/generator_test.go
+++ b/modules/generator/generator_test.go
@@ -63,6 +63,7 @@ overrides:
 	generatorConfig.RegisterFlagsAndApplyDefaults("", &flag.FlagSet{})
 	generatorConfig.Storage.Path = t.TempDir()
 	generatorConfig.Ring.KVStore.Store = "inmemory"
+	generatorConfig.Ring.InstanceInterfaceNames = []string{"eth0", "en0", "lo0", "enp102s0f4u1u3", "eno1"}
 	g, err := New(generatorConfig, o, prometheus.NewRegistry(), nil, nil, newTestLogger(t))
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), g))


### PR DESCRIPTION
Relevant links https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/ and https://superuser.com/questions/1053003/what-is-the-difference-between-eth1-and-eno1