### PR TITLE
Issue 4632: TraceQL Metrics: respect exemplars parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [BUGFIX] Fix error propagation in the SyncIterator. [#5045](https://github.com/grafana/tempo/pull/5045) (@joe-elliott)
 * [BUGFIX] Various edge case fixes for query range (TraceQL Metrics) [#4962](https://github.com/grafana/tempo/pull/4962) (@ruslan-mikhailov)
 * [BUGFIX] Fix `TempoBlockListRisingQuickly` alert grouping. [#4876](https://github.com/grafana/tempo/pull/4876) (@mapno)
+* [BUGFIX] TraceQL Metrics: respect exemplars para [#4976](https://github.com/grafana/tempo/pull/4976) (@ruslan-mikhailov)
 
 # v2.7.2
 

--- a/integration/e2e/api/query_range_test.go
+++ b/integration/e2e/api/query_range_test.go
@@ -85,11 +85,10 @@ sendLoop:
 			require.GreaterOrEqual(t, len(queryRangeRes.GetSeries()), 1)
 			exemplarCount := 0
 			for _, series := range queryRangeRes.GetSeries() {
-				exemplars := len(series.GetExemplars())
-				exemplarCount += exemplars
-				assert.LessOrEqual(t, exemplars, maxExemplars)
+				exemplarCount += len(series.GetExemplars())
 			}
-			assert.GreaterOrEqual(t, exemplarCount, 1)
+			assert.LessOrEqual(t, exemplarCount, maxExemplars, "should have at most %d exemplars", maxExemplars)
+			assert.GreaterOrEqual(t, exemplarCount, 1, "should have at least one exemplar")
 		})
 	}
 

--- a/modules/frontend/combiner/metrics_query_range.go
+++ b/modules/frontend/combiner/metrics_query_range.go
@@ -209,8 +209,13 @@ func diffResponse(prev, curr *tempopb.QueryRangeResponse) *tempopb.QueryRangeRes
 // have NaNs, and we can't attach them until the very end.
 func attachExemplars(req *tempopb.QueryRangeRequest, res *tempopb.QueryRangeResponse) {
 	for _, ss := range res.Series {
+		if ss == nil {
+			continue
+		}
+		if len(ss.Exemplars) > int(req.Exemplars) {
+			ss.Exemplars = ss.Exemplars[len(ss.Exemplars)-int(req.Exemplars):]
+		}
 		for i, e := range ss.Exemplars {
-
 			// Only needed for NaNs
 			if !math.IsNaN(e.Value) {
 				continue


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Respect exemplars parameters by limiting returned exemplars on query frontend side.
I decided to leave the latest traces as most probably they have more value.

**Which issue(s) this PR fixes**:
Fixes #4632

**How it has been tested:**

1. Added check in e2e tests. The test fails with master tempo image
2. Unit test to reflect changes
3. Manually tested using `example/docker-compose/local`:
    A. Reproduce the issue with master tempo image by sending query with the following query parameters:
```json
{
    "q": "{} | rate()",
    "since": "3h",
    "step": "1m",
    "exemplars": 5,
}
```


B. Apply the fix. Expected result: number of exemplars returned is limited to 5

**Checklist**

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

