### PR TITLE
chore(tempo-mixin): update rollout-progress dashboard

### DIFF
--- a/operations/tempo-mixin-compiled/dashboards/tempo-rollout-progress.json
+++ b/operations/tempo-mixin-compiled/dashboards/tempo-rollout-progress.json
@@ -1338,14 +1338,33 @@
    "type": "table"
   },
   {
-   "aliasColors": {
-
-   },
-   "bars": false,
-   "dashLength": 10,
-   "dashes": false,
    "datasource": "$datasource",
-   "fill": 1,
+   "fieldConfig": {
+    "defaults": {
+     "custom": {
+      "drawStyle": "line",
+      "fillOpacity": 1,
+      "lineWidth": 1,
+      "pointSize": 5,
+      "showPoints": "never",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      }
+     },
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+
+      ]
+     },
+     "unit": "s"
+    },
+    "overrides": [
+
+    ]
+   },
    "gridPos": {
     "h": 8,
     "w": 8,
@@ -1353,32 +1372,18 @@
     "y": 8
    },
    "id": 12,
-   "legend": {
-    "avg": false,
-    "current": false,
-    "max": false,
-    "min": false,
-    "show": true,
-    "total": false,
-    "values": false
-   },
-   "lines": true,
-   "linewidth": 1,
    "links": [
 
    ],
-   "nullPointMode": "null as zero",
-   "percentage": false,
-   "pointradius": 5,
-   "points": false,
-   "renderer": "flot",
-   "seriesOverrides": [
-
-   ],
-   "spaceLength": 10,
-   "span": 6,
-   "stack": false,
-   "steppedLine": false,
+   "options": {
+    "legend": {
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "single",
+     "sort": "none"
+    }
+   },
    "targets": [
     {
      "expr": "1 - (\n  avg_over_time(histogram_quantile(0.99, sum by (le) (tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw(-internal)?\", route=~\"opentelemetry_proto_collector_trace_v1_traceservice_export\"} offset 24h))[1h:])\n  /\n  avg_over_time(histogram_quantile(0.99, sum by (le) (tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw(-internal)?\", route=~\"opentelemetry_proto_collector_trace_v1_traceservice_export\"}))[1h:])\n)\n",
@@ -1395,27 +1400,8 @@
      "legendLink": null
     }
    ],
-   "thresholds": [
-
-   ],
-   "timeFrom": null,
-   "timeShift": null,
    "title": "Latency vs 24h ago",
-   "tooltip": {
-    "shared": true,
-    "sort": 2,
-    "value_type": "individual"
-   },
-   "type": "graph",
-   "xaxis": {
-    "buckets": null,
-    "mode": "time",
-    "name": null,
-    "show": true,
-    "values": [
-
-    ]
-   },
+   "type": "timeseries",
    "yaxes": [
     {
      "format": "percentunit",

--- a/operations/tempo-mixin/dashboards/rollout-progress.libsonnet
+++ b/operations/tempo-mixin/dashboards/rollout-progress.libsonnet
@@ -282,7 +282,7 @@ local filename = 'tempo-rollout-progress.json';
         //
         // Performance comparison with 24h ago
         //
-        $.panel('Latency vs 24h ago') +
+        $.timeseriesPanel('Latency vs 24h ago') +
         $.queryPanel([|||
           1 - (
             avg_over_time(histogram_quantile(0.99, sum by (le) (tempo_request_duration_seconds_bucket{%(gateway_job_matcher)s, route=~"%(gateway_write_routes_regex)s"} offset 24h))[1h:])


### PR DESCRIPTION
**What this PR does**:

Starting in Grafana 11, [angular plugins support was deprecated](https://grafana.com/docs/grafana/latest/developers/angular_deprecation/) and users were asked to migrate to React. The Rollout Progress dashboard is still using the [deprecated graph plugin](https://github.com/grafana/jsonnet-libs/blob/357eee054c4a50b1033e22493fd9503c1174bf56/grafana-builder/grafana.libsonnet#L217), so users installing this dashboard via the mixin are seeing a deprecation warning (and it will be completely unavailable in Grafana 12).

This PR moves this panel to the `timeseriesPanel`.