### PR TITLE
Add support for pprof mutex/blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## main / unreleased
+* CHANGE Add defaults for mutex profiling #4979 (@mattdurham) 
 * [CHANGE] Update query range error message [#4929](https://github.com/grafana/tempo/pull/4929) (@joey-grafana)
 * [CHANGE] **BREAKING CHANGE** Upgrade OTEL Collector to v0.122.1 [#4893](https://github.com/grafana/tempo/pull/4893) (@javiermolinar)
   The `name` dimension from `tempo_receiver_accepted_span` and `tempo_receiver_refused_spans` changes from `tempo/jaeger_receiver` to `jaeger/jaeger_receiver`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
 ## main / unreleased
-* CHANGE Add defaults for mutex profiling #4979 (@mattdurham) 
 * [CHANGE] Update query range error message [#4929](https://github.com/grafana/tempo/pull/4929) (@joey-grafana)
 * [CHANGE] **BREAKING CHANGE** Upgrade OTEL Collector to v0.122.1 [#4893](https://github.com/grafana/tempo/pull/4893) (@javiermolinar)
   The `name` dimension from `tempo_receiver_accepted_span` and `tempo_receiver_refused_spans` changes from `tempo/jaeger_receiver` to `jaeger/jaeger_receiver`
@@ -32,6 +31,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [FEATURE] Added most_recent=true query hint to TraceQL to return most recent results. [#4238](https://github.com/grafana/tempo/pull/4238) (@joe-elliott)
 * [FEATURE] Add ability to add artificial delay to push requests [#4716](https://github.com/grafana/tempo/pull/4716) [#4899](https://github.com/grafana/tempo/pull/4899) (@yvrhdn, @mapno)
 * [FEATURE] TraceQL metrics: sum_over_time [#4786](https://github.com/grafana/tempo/pull/4786) (@javiermolinar)
+* ENHANCEMENT Add default mutex and blocking values. #4979 (@mattdurham) 
 * [ENHANCEMENT] Improve Tempo build options [#4755](https://github.com/grafana/tempo/pull/4755) (@stoewer)
 * [ENHANCEMENT] Rewrite traces using rebatching [#4690](https://github.com/grafana/tempo/pull/4690) (@stoewer @joe-elliott)
 * [ENHANCEMENT] Reorder span iterators [#4754](https://github.com/grafana/tempo/pull/4754) (@stoewer)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [FEATURE] Added most_recent=true query hint to TraceQL to return most recent results. [#4238](https://github.com/grafana/tempo/pull/4238) (@joe-elliott)
 * [FEATURE] Add ability to add artificial delay to push requests [#4716](https://github.com/grafana/tempo/pull/4716) [#4899](https://github.com/grafana/tempo/pull/4899) (@yvrhdn, @mapno)
 * [FEATURE] TraceQL metrics: sum_over_time [#4786](https://github.com/grafana/tempo/pull/4786) (@javiermolinar)
-* ENHANCEMENT Add default mutex and blocking values. #4979 (@mattdurham) 
+* [ENHANCEMENT] Add default mutex and blocking values. [#4979](https://github.com/grafana/tempo/pull/4979) (@mattdurham) 
 * [ENHANCEMENT] Improve Tempo build options [#4755](https://github.com/grafana/tempo/pull/4755) (@stoewer)
 * [ENHANCEMENT] Rewrite traces using rebatching [#4690](https://github.com/grafana/tempo/pull/4690) (@stoewer @joe-elliott)
 * [ENHANCEMENT] Reorder span iterators [#4754](https://github.com/grafana/tempo/pull/4754) (@stoewer)

--- a/cmd/tempo/main.go
+++ b/cmd/tempo/main.go
@@ -58,8 +58,8 @@ func init() {
 func main() {
 	printVersion := flag.Bool("version", false, "Print this builds version information")
 	ballastMBs := flag.Int("mem-ballast-size-mbs", 0, "Size of memory ballast to allocate in MBs.")
-	mutexProfileFraction := flag.Int("mutex-profile-fraction", 0, "Enable mutex profiling.")
-	blockProfileThreshold := flag.Int("block-profile-threshold", 0, "Enable block profiling.")
+	mutexProfileFraction := flag.Int("mutex-profile-fraction", 0, "Override default mutex profiling fraction.")
+	blockProfileThreshold := flag.Int("block-profile-threshold", 0, "Override default block profiling threshold.")
 
 	config, configVerify, err := loadConfig()
 	if err != nil {

--- a/cmd/tempo/main.go
+++ b/cmd/tempo/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"reflect"
 	"runtime"
+	"strconv"
 	"time"
 
 	"github.com/drone/envsubst"
@@ -98,9 +99,7 @@ func main() {
 		defer shutdownTracer()
 	}
 
-	if *mutexProfileFraction > 0 {
-		runtime.SetMutexProfileFraction(*mutexProfileFraction)
-	}
+	setMutexBlockProfiling(*mutexProfileFraction)
 
 	// Allocate a block of memory to alter GC behaviour. See https://github.com/golang/go/issues/23044
 	ballast := make([]byte, *ballastMBs*1024*1024)
@@ -282,4 +281,36 @@ type otelErrorHandlerFunc func(error)
 // Handle implements otel.ErrorHandler
 func (f otelErrorHandlerFunc) Handle(err error) {
 	f(err)
+}
+
+func setMutexBlockProfiling(mutexFraction int) {
+	mutexPercent := os.Getenv("PPROF_MUTEX_PROFILING_PERCENT")
+	// This is for backwards compatibility and allow the flag to override the env var.
+	if mutexFraction > 0 {
+		runtime.SetMutexProfileFraction(mutexFraction)
+	} else if mutexPercent != "" {
+		rate, err := strconv.Atoi(mutexPercent)
+		if err == nil && rate > 0 {
+			// The 100/rate is because the value is interpreted as 1/rate. So 50 would be 100/50 = 2 and become 1/2 or 50%.
+			runtime.SetMutexProfileFraction(100 / rate)
+		} else {
+			// This is 1/1000 sampling rate.
+			runtime.SetMutexProfileFraction(1000)
+		}
+	} else {
+		// Why 1000 because that is what istio defaults to and that seemed reasonable to start with.
+		runtime.SetMutexProfileFraction(1000)
+	}
+	blockRate := os.Getenv("PPROF_BLOCK_PROFILING_RATE")
+	if blockRate != "" {
+		rate, err := strconv.Atoi(blockRate)
+		if err == nil && rate > 0 {
+			runtime.SetBlockProfileRate(rate)
+		} else {
+			runtime.SetBlockProfileRate(10_000)
+		}
+	} else {
+		// This should have a negligible impact. This will track anything over 10_000ns, and will randomly sample shorter durations.
+		runtime.SetBlockProfileRate(10_000)
+	}
 }

--- a/cmd/tempo/main.go
+++ b/cmd/tempo/main.go
@@ -284,7 +284,6 @@ func (f otelErrorHandlerFunc) Handle(err error) {
 }
 
 func setMutexBlockProfiling(mutexFraction int, blockThreshold int) {
-	// This is for backwards compatibility and allow the flag to override the env var.
 	if mutexFraction > 0 {
 		// The this is evaluated as 1/mutexFraction sampling, so 1 is 100%.
 		runtime.SetMutexProfileFraction(mutexFraction)


### PR DESCRIPTION

**What this PR does**:

This adds default value for blocking and mutex contention. They are very low defaults to have minimal impact on cpu. In practice alloy has been running these same defaults for years. There is no documentation, I will add that in a separate PR since it will be a larger new section on starting tempo.


**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x]  `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`