### PR TITLE
[BugFix] Add object name to cache key

### DIFF
--- a/tempodb/backend/cache/cache.go
+++ b/tempodb/backend/cache/cache.go
@@ -111,9 +111,8 @@ func (r *readerWriter) ReadRange(ctx context.Context, name string, keypath backe
 	var k string
 	cache := r.cacheFor(cacheInfo)
 	if cache != nil {
-		// cache key is tenantID:blockID:offset:length - file name is not needed in key
 		keyGen := keypath
-		keyGen = append(keyGen, strconv.Itoa(int(offset)), strconv.Itoa(len(buffer)))
+		keyGen = append(keyGen, name, strconv.Itoa(int(offset)), strconv.Itoa(len(buffer)))
 		k = strings.Join(keyGen, ":")
 		b, found := cache.FetchKey(ctx, k)
 		if found {


### PR DESCRIPTION
**What this PR does**:
Very old caching code assumed that we did not need to use the object name in the cache key. I believe this is technically still true and can't convince myself this is currently causing issues. However, from the perspective of the caching layer there's no way to know this and it absolutely should use the object name in the cache key.

This will temporarily break page cache keys, but they should quickly settle on the new key names.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`