### PR TITLE
Compactor pooling changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [ENHANCEMENT] Improve memcached memory usage by pooling buffers [#4970](https://github.com/grafana/tempo/pull/4970) (@joe-elliott)
 * [ENHANCEMENT] metrics-generator: allow skipping localblocks and consuming from a different source of data [#4686](https://github.com/grafana/tempo/pull/4686) (@flxbk)
 * [ENHANCEMENT] compactor: restore dedicated columns logging for completed blocks [#4832](https://github.com/grafana/tempo/pull/4832) (@edgarkz)
+* [ENHANCEMENT] Compactor: pooling changes to reduce memory usage [#4985](https://github.com/grafana/tempo/pull/4985) (@mdisibio)
 * [ENHANCEMENT] distributor: add IPv6 support [#4840](https://github.com/grafana/tempo/pull/4840) (@gjacquet)
 * [ENHANCEMENT] Support TraceQL Metrics checks in Vulture [#4886](https://github.com/grafana/tempo/pull/4886) (@ruslan-mikhailov)
 * [ENHANCEMENT] Query-frontend: logs add msg to the log line [#4975](https://github.com/grafana/tempo/pull/4975) (@jmichalek132)

--- a/tempodb/encoding/vparquet4/compactor_test.go
+++ b/tempodb/encoding/vparquet4/compactor_test.go
@@ -21,13 +21,13 @@ import (
 
 func BenchmarkCompactor(b *testing.B) {
 	b.Run("Small", func(b *testing.B) {
-		benchmarkCompactor(b, 1000, 100, 100) // 10M spans
+		benchmarkCompactor(b, 10000, 10, 10) // 1M spans total, 100 spans per trace
 	})
 	b.Run("Medium", func(b *testing.B) {
-		benchmarkCompactor(b, 100, 100, 1000) // 10M spans
+		benchmarkCompactor(b, 100, 100, 100) // 1M spans total, 10K spans per trace
 	})
 	b.Run("Large", func(b *testing.B) {
-		benchmarkCompactor(b, 10, 1000, 1000) // 10M spans
+		benchmarkCompactor(b, 10, 100, 1000) // 1M spans total, 100K spans per trace
 	})
 }
 
@@ -67,7 +67,7 @@ func benchmarkCompactor(b *testing.B, traceCount, batchCount, spanCount int) {
 	}
 }
 
-func BenchmarkCompactorDupes(b *testing.B) {
+/*func BenchmarkCompactorDupes(b *testing.B) {
 	rawR, rawW, _, err := local.New(&local.Config{
 		Path: b.TempDir(),
 	})
@@ -103,7 +103,7 @@ func BenchmarkCompactorDupes(b *testing.B) {
 		_, err = c.Compact(ctx, l, r, w, inputs)
 		require.NoError(b, err)
 	}
-}
+}*/
 
 // createTestBlock with the number of given traces and the needed sizes.
 // Trace IDs are guaranteed to be monotonically increasing so that

--- a/tempodb/encoding/vparquet4/compactor_test.go
+++ b/tempodb/encoding/vparquet4/compactor_test.go
@@ -67,7 +67,7 @@ func benchmarkCompactor(b *testing.B, traceCount, batchCount, spanCount int) {
 	}
 }
 
-/*func BenchmarkCompactorDupes(b *testing.B) {
+func BenchmarkCompactorDupes(b *testing.B) {
 	rawR, rawW, _, err := local.New(&local.Config{
 		Path: b.TempDir(),
 	})
@@ -103,7 +103,7 @@ func benchmarkCompactor(b *testing.B, traceCount, batchCount, spanCount int) {
 		_, err = c.Compact(ctx, l, r, w, inputs)
 		require.NoError(b, err)
 	}
-}*/
+}
 
 // createTestBlock with the number of given traces and the needed sizes.
 // Trace IDs are guaranteed to be monotonically increasing so that


### PR DESCRIPTION
**What this PR does**:
Compactor memory usage and frequency of OOMs has increased over time and investigation showed that almost all of it is via the parquet row pool.  It's been hard to ascertain the exact reasons, but the pooling slices for large traces is not providing the benefit that it used to.  It seems that the large amount of pooled data no longer gets GC'ed like expected and accumulates.  I couldn't spot any bugs in repooling, so I think it is a change in behavior at runtime due to a combination of factors:  vParquet4 event/link attribute columns significantly increasing row sizes vs the prior json blobs, golang runtime, and environmental factors.  

This PR removes pooling for large traces, and it has been tested to have a huge improvement in memory, cutting memory high-water marks to less than half in a high traffic/tenant install.  

Some amount of pooling is needed to keep cpu, throughput, and GC rate maintained.  Now we have a fixed 1M default allocation size, which covers most traces.

**Initial Finding**
This profile prior to an OOM showed the row pool was holding 85% of inuse memory:
<img width="1284" alt="image" src="https://github.com/user-attachments/assets/5e98d2a1-aeaf-42e0-9474-bfdb129094d8" />

**Graph**
<img width="1061" alt="image" src="https://github.com/user-attachments/assets/7b9f0ab3-3e99-4164-8294-35919e4150db" />

**Benchmarks**
Our synthetic benchmarks of course show the large increase in allocs, and don't do a good job of capturing the real-world performance.  An area for improvement.

```
pkg: github.com/grafana/tempo/tempodb/encoding/vparquet4
cpu: Apple M4 Pro
                    │ before.txt │             after.txt             │
                    │   sec/op   │   sec/op    vs base               │
Compactor/Small-14    3.693 ± 2%   3.666 ± 1%        ~ (p=0.818 n=6)
Compactor/Medium-14   3.410 ± 1%   3.698 ± 1%   +8.47% (p=0.002 n=6)
Compactor/Large-14    3.115 ± 1%   4.016 ± 6%  +28.93% (p=0.002 n=6)
geomean               3.398        3.790       +11.55%

                    │  before.txt   │               after.txt               │
                    │     B/op      │     B/op       vs base                │
Compactor/Small-14    2.067Gi ±  2%    1.811Gi ± 2%   -12.41% (p=0.002 n=6)
Compactor/Medium-14   2.152Gi ± 13%   10.526Gi ± 0%  +389.18% (p=0.002 n=6)
Compactor/Large-14    3.609Gi ±  5%   18.665Gi ± 1%  +417.12% (p=0.002 n=6)
geomean               2.523Gi          7.086Gi       +180.87%

                    │ before.txt  │             after.txt             │
                    │  allocs/op  │  allocs/op   vs base              │
Compactor/Small-14    147.2k ± 1%   147.5k ± 1%       ~ (p=0.240 n=6)
Compactor/Medium-14   68.00k ± 0%   70.42k ± 0%  +3.56% (p=0.002 n=6)
Compactor/Large-14    55.23k ± 0%   58.10k ± 1%  +5.20% (p=0.002 n=6)
geomean               82.08k        84.51k       +2.97%
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`