### PR TITLE
Caching: Restore parquet page copy logic

### DIFF
--- a/tempodb/backend/cache/cache.go
+++ b/tempodb/backend/cache/cache.go
@@ -100,7 +100,7 @@ func (r *readerWriter) Read(ctx context.Context, name string, keypath backend.Ke
 
 	b, err := tempo_io.ReadAllWithEstimate(object, size)
 	if err == nil && cache != nil {
-		cache.Store(ctx, []string{k}, [][]byte{b})
+		store(ctx, cache, cacheInfo.Role, k, b)
 	}
 
 	return io.NopCloser(bytes.NewReader(b)), size, err
@@ -125,7 +125,7 @@ func (r *readerWriter) ReadRange(ctx context.Context, name string, keypath backe
 	// todo: reevaluate. should we pass the cacheInfo forward?
 	err := r.nextReader.ReadRange(ctx, name, keypath, offset, buffer, nil)
 	if err == nil && cache != nil {
-		cache.Store(ctx, []string{k}, [][]byte{buffer})
+		store(ctx, cache, cacheInfo.Role, k, b)
 	}
 
 	return err
@@ -215,4 +215,20 @@ func (r *readerWriter) cacheFor(cacheInfo *backend.CacheInfo) cache.Cache {
 	}
 
 	return nil
+}
+
+func store(ctx context.Context, cache cache.Cache, role cache.Role, key string, val []byte) {
+	write := val
+	if needsCopy(role) {
+		write = make([]byte, len(val))
+		copy(write, val)
+	}
+
+	cache.Store(ctx, []string{key}, [][]byte{write})
+}
+
+// needsCopy returns true if the role should be copied into a new buffer before being written to the cache
+// todo: should this be signalled through cacheinfo instead?
+func needsCopy(role cache.Role) bool {
+	return role == cache.RoleParquetPage // parquet pages are reused by the library. if we don't copy them then the buffer may be reused before written to cache
 }

--- a/tempodb/backend/cache/cache.go
+++ b/tempodb/backend/cache/cache.go
@@ -125,7 +125,7 @@ func (r *readerWriter) ReadRange(ctx context.Context, name string, keypath backe
 	// todo: reevaluate. should we pass the cacheInfo forward?
 	err := r.nextReader.ReadRange(ctx, name, keypath, offset, buffer, nil)
 	if err == nil && cache != nil {
-		store(ctx, cache, cacheInfo.Role, k, b)
+		store(ctx, cache, cacheInfo.Role, k, buffer)
 	}
 
 	return err


### PR DESCRIPTION
**What this PR does**:
Restores copy logic for parquet pages. Initial investigation made this feel safe but we (read I) had forgotten about the background cache functionality here:

https://github.com/grafana/tempo/blob/main/pkg/cache/background.go#L44

