### PR TITLE
[bugfix] fix avg_over_time & compare queries panic with max series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [BUGFIX] Correctly cache frontend jobs for query range (TraceQL Metrics). [#4771](https://github.com/grafana/tempo/pull/4771) (@joe-elliott)
 * [BUGFIX] Various edge case fixes for query range (TraceQL Metrics) [#4962](https://github.com/grafana/tempo/pull/4962) (@ruslan-mikhailov)
 * [BUGFIX] Fix `TempoBlockListRisingQuickly` alert grouping. [#4876](https://github.com/grafana/tempo/pull/4876) (@mapno)
+* [BUGFIX] Fix panic when aggregating avg_over_time metrics with truncated timeseries [#5016](https://github.com/grafana/tempo/pull/5016) (@ie-pham)
 
 # v2.7.2
 

--- a/modules/frontend/combiner/metrics_query_range.go
+++ b/modules/frontend/combiner/metrics_query_range.go
@@ -58,7 +58,9 @@ func NewQueryRange(req *tempopb.QueryRangeRequest, maxSeriesLimit int) (Combiner
 			if combiner.MaxSeriesReached() {
 				// Truncating the final response because even if we bail as soon as len(resp.Series) >= maxSeries
 				// it's possible that the last response pushed us over the max series limit.
-				resp.Series = resp.Series[:maxSeries]
+				if len(resp.Series) > maxSeries {
+					resp.Series = resp.Series[:maxSeries]
+				}
 				resp.Status = tempopb.PartialStatus_PARTIAL
 				resp.Message = maxSeriesReachedErrorMsg
 			}
@@ -73,7 +75,7 @@ func NewQueryRange(req *tempopb.QueryRangeRequest, maxSeriesLimit int) (Combiner
 			}
 
 			sortResponse(resp)
-			if combiner.MaxSeriesReached() {
+			if len(resp.Series) > maxSeries {
 				// Truncating the final response because even if we bail as soon as len(resp.Series) >= maxSeries
 				// it's possible that the last response pushed us over the max series limit.
 				resp.Series = resp.Series[:maxSeries]

--- a/modules/frontend/combiner/metrics_query_range.go
+++ b/modules/frontend/combiner/metrics_query_range.go
@@ -58,7 +58,7 @@ func NewQueryRange(req *tempopb.QueryRangeRequest, maxSeriesLimit int) (Combiner
 			if combiner.MaxSeriesReached() {
 				// Truncating the final response because even if we bail as soon as len(resp.Series) >= maxSeries
 				// it's possible that the last response pushed us over the max series limit.
-				if len(resp.Series) > maxSeries {
+				if len(resp.Series) > maxSeries && maxSeries > 0 {
 					resp.Series = resp.Series[:maxSeries]
 				}
 				resp.Status = tempopb.PartialStatus_PARTIAL
@@ -75,7 +75,7 @@ func NewQueryRange(req *tempopb.QueryRangeRequest, maxSeriesLimit int) (Combiner
 			}
 
 			sortResponse(resp)
-			if len(resp.Series) > maxSeries {
+			if len(resp.Series) > maxSeries && maxSeries > 0 {
 				// Truncating the final response because even if we bail as soon as len(resp.Series) >= maxSeries
 				// it's possible that the last response pushed us over the max series limit.
 				resp.Series = resp.Series[:maxSeries]

--- a/pkg/traceql/combine.go
+++ b/pkg/traceql/combine.go
@@ -354,7 +354,7 @@ func (q *QueryRangeCombiner) Combine(resp *tempopb.QueryRangeResponse) {
 	q.eval.ObserveSeries(resp.Series)
 	seriesCount := q.eval.Length()
 
-	if (q.maxSeries > 0 && seriesCount >= q.maxSeries) || resp.Status == tempopb.PartialStatus_PARTIAL {
+	if q.maxSeries > 0 && (seriesCount >= q.maxSeries || resp.Status == tempopb.PartialStatus_PARTIAL) {
 		q.maxSeriesReached = true
 	}
 

--- a/pkg/traceql/engine_metrics_average.go
+++ b/pkg/traceql/engine_metrics_average.go
@@ -273,6 +273,11 @@ func (b *averageOverTimeSeriesAggregator) Combine(in []*tempopb.TimeSeries) {
 			// This is a counter series, we can skip it
 			continue
 		}
+		countIndex, ok := countPosMapper[ts.PromLabels]
+		if !ok {
+			// The count series might have been truncated, skip this value
+			continue
+		}
 		for i, sample := range ts.Samples {
 			pos := IntervalOfMs(sample.TimestampMs, b.start, b.end, b.step)
 			if pos < 0 || pos >= len(b.weightedAverageSeries[ts.PromLabels].values) {
@@ -280,7 +285,7 @@ func (b *averageOverTimeSeriesAggregator) Combine(in []*tempopb.TimeSeries) {
 			}
 
 			incomingMean := sample.Value
-			incomingWeight := in[countPosMapper[ts.PromLabels]].Samples[i].Value
+			incomingWeight := in[countIndex].Samples[i].Value
 			existing.addWeigthedMean(pos, incomingMean, incomingWeight)
 			b.aggregateExemplars(ts, b.weightedAverageSeries[ts.PromLabels])
 		}

--- a/pkg/traceql/engine_metrics_compare.go
+++ b/pkg/traceql/engine_metrics_compare.go
@@ -286,6 +286,9 @@ func (m *MetricsCompare) result() SeriesSet {
 }
 
 func (m *MetricsCompare) length() int {
+	if m.seriesAgg != nil {
+		return m.seriesAgg.Length()
+	}
 	return len(m.baselines) + len(m.selections) + len(m.baselineTotals) + len(m.selectionTotals)
 }
 

--- a/pkg/traceql/engine_metrics_test.go
+++ b/pkg/traceql/engine_metrics_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand/v2"
+	"strings"
 	"testing"
 	"time"
 
@@ -1020,6 +1021,79 @@ func TestObserveSeriesAverageOverTimeForSpanAttribute(t *testing.T) {
 	assert.Equal(t, 260.0, fooBar.Values[0])
 	assert.Equal(t, 200.0, fooBar.Values[1])
 	assert.Equal(t, 100.0, fooBar.Values[2])
+}
+
+func TestObserveSeriesAverageOverTimeForSpanAttributeWithTruncation(t *testing.T) {
+	req := &tempopb.QueryRangeRequest{
+		Start: uint64(1 * time.Second),
+		End:   uint64(3 * time.Second),
+		Step:  uint64(1 * time.Second),
+		Query: "{ } | avg_over_time(span.http.status_code) by (span.foo)",
+	}
+
+	// A variety of spans across times, durations, and series. All durations are powers of 2 for simplicity
+	in := []Span{
+		newMockSpan(nil).WithStartTime(uint64(1*time.Second)).WithSpanString("foo", "bar").WithSpanInt("http.status_code", 200),
+		newMockSpan(nil).WithStartTime(uint64(1*time.Second)).WithSpanString("foo", "bar").WithSpanInt("http.status_code", 300),
+		newMockSpan(nil).WithStartTime(uint64(1*time.Second)).WithSpanString("foo", "bar").WithSpanInt("http.status_code", 400),
+
+		newMockSpan(nil).WithStartTime(uint64(2*time.Second)).WithSpanString("foo", "bar").WithSpanInt("http.status_code", 200),
+		newMockSpan(nil).WithStartTime(uint64(2*time.Second)).WithSpanString("foo", "bar").WithSpanInt("http.status_code", 200),
+		newMockSpan(nil).WithStartTime(uint64(2*time.Second)).WithSpanString("foo", "bar").WithSpanInt("http.status_code", 100),
+		newMockSpan(nil).WithStartTime(uint64(2*time.Second)).WithSpanString("foo", "bar").WithSpanInt("http.status_code", 100),
+
+		newMockSpan(nil).WithStartTime(uint64(3*time.Second)).WithSpanString("foo", "baz").WithSpanInt("http.status_code", 200),
+		newMockSpan(nil).WithStartTime(uint64(3*time.Second)).WithSpanString("foo", "baz").WithSpanInt("http.status_code", 400),
+		newMockSpan(nil).WithStartTime(uint64(3*time.Second)).WithSpanString("foo", "baz").WithSpanInt("http.status_code", 500),
+	}
+
+	in2 := []Span{
+		newMockSpan(nil).WithStartTime(uint64(1*time.Second)).WithSpanString("foo", "bar").WithSpanInt("http.status_code", 100),
+		newMockSpan(nil).WithStartTime(uint64(1*time.Second)).WithSpanString("foo", "bar").WithSpanInt("http.status_code", 300),
+
+		newMockSpan(nil).WithStartTime(uint64(2*time.Second)).WithSpanString("foo", "bar").WithSpanInt("http.status_code", 400),
+		newMockSpan(nil).WithStartTime(uint64(2*time.Second)).WithSpanString("foo", "bar").WithSpanInt("http.status_code", 200),
+
+		newMockSpan(nil).WithStartTime(uint64(3*time.Second)).WithSpanString("foo", "baz").WithSpanInt("http.status_code", 100),
+		newMockSpan(nil).WithStartTime(uint64(3*time.Second)).WithSpanString("foo", "bar").WithSpanInt("http.status_code", 100),
+	}
+
+	e := NewEngine()
+	layer1A, _ := e.CompileMetricsQueryRange(req, 0, 0, false)
+	layer1B, _ := e.CompileMetricsQueryRange(req, 0, 0, false)
+	layer2A, _ := e.CompileMetricsQueryRangeNonRaw(req, AggregateModeSum)
+	layer2B, _ := e.CompileMetricsQueryRangeNonRaw(req, AggregateModeSum)
+	layer3, _ := e.CompileMetricsQueryRangeNonRaw(req, AggregateModeFinal)
+
+	for _, s := range in {
+		layer1A.metricsPipeline.observe(s)
+	}
+
+	layer2A.ObserveSeries(layer1A.Results().ToProto(req))
+
+	for _, s := range in2 {
+		layer1B.metricsPipeline.observe(s)
+	}
+
+	layer2B.ObserveSeries(layer1B.Results().ToProto(req))
+
+	layer3.ObserveSeries(layer2A.Results().ToProto(req))
+	layer2bResults := layer2B.Results().ToProto(req)
+	truncated2bResults := make([]*tempopb.TimeSeries, 0, len(layer2bResults)-1)
+	for _, ts := range layer2bResults {
+		if !strings.Contains(ts.PromLabels, internalLabelMetaType) {
+			// add all values series
+			truncated2bResults = append(truncated2bResults, ts)
+		} else {
+			// the panic appears when the count series with 3 samples is missing
+			if len(ts.Samples) != 3 {
+				truncated2bResults = append(truncated2bResults, ts)
+			}
+		}
+	}
+	assert.NotPanics(t, func() {
+		layer3.ObserveSeries(truncated2bResults)
+	}, "should not panic on truncation")
 }
 
 func TestMaxOverTimeForDuration(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: 
1. Max series PR introduced a bug for avg_over_time metrics queries. The metrics calculation relies on a pair of series per actual value and when the max series limit truncated the series, in some occurrences, one of the pair is no longer in the resulting time series - leading to a panic during aggregations. 
2. Truncating the series caused issues for the frontend because it expects at least one _total series per key (attribute key). This PR add different truncating logic for compare queries. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`