### PR TITLE
BUGFIX: Metrics Frontend Caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [BUGFIX] Fix flaky test [#4787](https://github.com/grafana/tempo/pull/4787) [#4995](https://github.com/grafana/tempo/pull/4995) (@javiermolinar)
 * [BUGFIX] Include cost attribution when converting from default config to legacy one [#4787](https://github.com/grafana/tempo/pull/4937) (@javiermolinar)
 * [BUGFIX] Fix memcached settings for docker compose example [#4346](https://github.com/grafana/tempo/pull/4695) (@ruslan-mikhailov)
+* [BUGFIX] Fix frontend cache key generation for TraceQL Metrics queries to prevent collisions. [#5017](https://github.com/grafana/tempo/pull/5017) (@joe-elliott)
 * [BUGFIX] Fix setting processors in user configurations overrides via API [#4741](https://github.com/grafana/tempo/pull/4741) (@ruslan-mikhailov)
 * [BUGFIX] Fix panic on startup [#4744](https://github.com/grafana/tempo/pull/4744) (@ruslan-mikhailov)
 * [BUGFIX] Fix intrinsic tag lookups dropped when max tag lookup response size is exceeded [#4784](https://github.com/grafana/tempo/pull/4784) (@mdisibio)

--- a/modules/frontend/metrics_query_range_handler_test.go
+++ b/modules/frontend/metrics_query_range_handler_test.go
@@ -167,7 +167,7 @@ func TestQueryRangeAccessesCache(t *testing.T) {
 	hash := hashForQueryRangeRequest(&tempopb.QueryRangeRequest{Query: query, Step: uint64(step)})
 	startNS := 10 * time.Second
 	endNS := 20 * time.Second
-	cacheKey := queryRangeCacheKey(tenant, hash, time.Unix(0, int64(startNS)), time.Unix(0, int64(endNS)), meta, step, 1)
+	cacheKey := queryRangeCacheKey(tenant, hash, time.Unix(0, int64(startNS)), time.Unix(0, int64(endNS)), meta, 0, 1)
 
 	// confirm cache key coesn't exist
 	_, bufs, _ := c.Fetch(context.Background(), []string{cacheKey})

--- a/modules/frontend/metrics_query_range_sharder.go
+++ b/modules/frontend/metrics_query_range_sharder.go
@@ -366,9 +366,11 @@ func hashForQueryRangeRequest(req *tempopb.QueryRangeRequest) uint64 {
 	// forces the query into a canonical form
 	query := ast.String()
 
-	// add the query, limit and spss to the hash
+	// add the query and other fields that change the response to the hash
 	hash := fnv1a.HashString64(query)
 	hash = fnv1a.AddUint64(hash, req.Step)
+	hash = fnv1a.AddUint64(hash, uint64(req.MaxSeries))
+	hash = fnv1a.AddUint64(hash, uint64(req.Exemplars))
 
 	return hash
 }

--- a/modules/frontend/metrics_query_range_sharder.go
+++ b/modules/frontend/metrics_query_range_sharder.go
@@ -293,7 +293,7 @@ func (s *queryRangeSharder) buildBackendRequests(ctx context.Context, tenantID s
 			startTime := time.Unix(0, int64(searchReq.Start)) // start/end are in nanoseconds
 			endTime := time.Unix(0, int64(searchReq.End))
 			// TODO: Handle sampling rate
-			key := queryRangeCacheKey(tenantID, queryHash, startTime, endTime, m, int(step), pages)
+			key := queryRangeCacheKey(tenantID, queryHash, startTime, endTime, m, startPage, pages)
 			if len(key) > 0 {
 				pipelineR.SetCacheKey(key)
 			}


### PR DESCRIPTION
**What this PR does**:

Frontend caching is broken for TraceQL Metrics queries. The cache key generation was incorrectly using the step instead of the start page which caused all jobs for the same block to collide.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`