### PR TITLE
Reduce lock contention in backendscheduler

### DIFF
--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -38,8 +38,6 @@ type BackendScheduler struct {
 
 	work *work.Work
 
-	mtx sync.Mutex
-
 	reader backend.RawReader
 	writer backend.RawWriter
 

--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -186,9 +186,6 @@ func (s *BackendScheduler) stopping(_ error) error {
 
 // Next implements the BackendSchedulerServer interface.  It returns the next queued job for a worker.
 func (s *BackendScheduler) Next(ctx context.Context, req *tempopb.NextJobRequest) (*tempopb.NextJobResponse, error) {
-	s.mtx.Lock()
-	defer s.mtx.Unlock()
-
 	ctx, span := tracer.Start(ctx, "Next")
 	defer span.End()
 
@@ -269,9 +266,6 @@ func (s *BackendScheduler) Next(ctx context.Context, req *tempopb.NextJobRequest
 
 // UpdateJob implements the BackendSchedulerServer interface
 func (s *BackendScheduler) UpdateJob(ctx context.Context, req *tempopb.UpdateJobStatusRequest) (*tempopb.UpdateJobStatusResponse, error) {
-	s.mtx.Lock()
-	defer s.mtx.Unlock()
-
 	j := s.work.GetJob(req.JobId)
 	if j == nil {
 		return &tempopb.UpdateJobStatusResponse{}, status.Error(codes.NotFound, work.ErrJobNotFound.Error())

--- a/modules/backendscheduler/cache.go
+++ b/modules/backendscheduler/cache.go
@@ -12,9 +12,6 @@ import (
 )
 
 func (s *BackendScheduler) flushWorkCache(ctx context.Context) error {
-	s.mtx.Lock()
-	defer s.mtx.Unlock()
-
 	b, err := s.work.Marshal()
 	if err != nil {
 		return fmt.Errorf("failed to marshal work cache: %w", err)

--- a/modules/backendscheduler/cache.go
+++ b/modules/backendscheduler/cache.go
@@ -12,6 +12,9 @@ import (
 )
 
 func (s *BackendScheduler) flushWorkCache(ctx context.Context) error {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
 	b, err := s.work.Marshal()
 	if err != nil {
 		return fmt.Errorf("failed to marshal work cache: %w", err)

--- a/modules/backendscheduler/provider/compaction.go
+++ b/modules/backendscheduler/provider/compaction.go
@@ -98,6 +98,7 @@ func (p *CompactionProvider) Start(ctx context.Context) <-chan *work.Job {
 		)
 
 		reset := func() {
+			metricTenantReset.WithLabelValues(p.curTenant.Value()).Inc()
 			p.curSelector = nil
 			p.curTenant = nil
 			p.curTenantJobCount = 0
@@ -131,6 +132,7 @@ func (p *CompactionProvider) Start(ctx context.Context) <-chan *work.Job {
 				// Measure the tenants to get their current compaction status
 				p.measureTenants()
 			case jobs <- job:
+				metricJobsCreated.WithLabelValues(p.curTenant.Value()).Inc()
 				b.Reset()
 			}
 		}

--- a/modules/backendscheduler/provider/metrics.go
+++ b/modules/backendscheduler/provider/metrics.go
@@ -1,0 +1,19 @@
+package provider
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	metricJobsCreated = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "tempo_backend_scheduler",
+		Name:      "compaction_jobs_created_total",
+		Help:      "Total number of compaction jobs created",
+	}, []string{"tenant"})
+	metricTenantReset = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "tempo_backend_scheduler",
+		Name:      "compaction_tenant_reset_total",
+		Help:      "The number of times the tenant is changed",
+	}, []string{"tenant"})
+)

--- a/modules/backendscheduler/work/job.go
+++ b/modules/backendscheduler/work/job.go
@@ -120,21 +120,21 @@ func (j *Job) GetWorkerID() string {
 func (j *Job) OnBlock(id string) bool {
 	switch j.GetType() {
 	case tempopb.JobType_JOB_TYPE_COMPACTION:
+
+		status := j.GetStatus()
+		if status != tempopb.JobStatus_JOB_STATUS_RUNNING && status != tempopb.JobStatus_JOB_STATUS_UNSPECIFIED {
+			return false
+		}
+
 		for _, b := range j.GetCompactionInput() {
 			if b == id {
-				switch j.GetStatus() {
-				case tempopb.JobStatus_JOB_STATUS_RUNNING, tempopb.JobStatus_JOB_STATUS_UNSPECIFIED:
-					return true
-				}
+				return true
 			}
 		}
 
 		for _, b := range j.GetCompactionOutput() {
 			if b == id {
-				switch j.GetStatus() {
-				case tempopb.JobStatus_JOB_STATUS_RUNNING, tempopb.JobStatus_JOB_STATUS_UNSPECIFIED:
-					return true
-				}
+				return true
 			}
 		}
 	default:

--- a/modules/backendscheduler/work/job.go
+++ b/modules/backendscheduler/work/job.go
@@ -159,8 +159,8 @@ func (j *Job) GetCompactionInput() []string {
 }
 
 func (j *Job) GetCompactionOutput() []string {
-	j.mtx.Lock()
-	defer j.mtx.Unlock()
+	j.mtx.RLock()
+	defer j.mtx.RUnlock()
 
 	switch j.Type {
 	case tempopb.JobType_JOB_TYPE_COMPACTION:

--- a/modules/backendscheduler/work/job.go
+++ b/modules/backendscheduler/work/job.go
@@ -118,24 +118,28 @@ func (j *Job) GetWorkerID() string {
 
 // OnBlock returns true if the job is operating on a block.
 func (j *Job) OnBlock(id string) bool {
-	for _, b := range j.GetCompactionInput() {
-		if b == id {
-			switch j.GetStatus() {
-			case tempopb.JobStatus_JOB_STATUS_RUNNING, tempopb.JobStatus_JOB_STATUS_UNSPECIFIED:
-				return true
+	switch j.GetType() {
+	case tempopb.JobType_JOB_TYPE_COMPACTION:
+		for _, b := range j.GetCompactionInput() {
+			if b == id {
+				switch j.GetStatus() {
+				case tempopb.JobStatus_JOB_STATUS_RUNNING, tempopb.JobStatus_JOB_STATUS_UNSPECIFIED:
+					return true
+				}
 			}
 		}
-	}
 
-	for _, b := range j.GetCompactionOutput() {
-		if b == id {
-			switch j.GetStatus() {
-			case tempopb.JobStatus_JOB_STATUS_RUNNING, tempopb.JobStatus_JOB_STATUS_UNSPECIFIED:
-				return true
+		for _, b := range j.GetCompactionOutput() {
+			if b == id {
+				switch j.GetStatus() {
+				case tempopb.JobStatus_JOB_STATUS_RUNNING, tempopb.JobStatus_JOB_STATUS_UNSPECIFIED:
+					return true
+				}
 			}
 		}
+	default:
+		return false
 	}
-
 	return false
 }
 

--- a/modules/backendscheduler/work/job_test.go
+++ b/modules/backendscheduler/work/job_test.go
@@ -66,12 +66,14 @@ func TestCompactionDetail(t *testing.T) {
 
 func TestOnBlock(t *testing.T) {
 	j := &Job{
-		ID:   uuid.NewString(),
-		Type: tempopb.JobType_JOB_TYPE_COMPACTION,
-		JobDetail: tempopb.JobDetail{
-			Tenant:     tenant,
-			Compaction: &tempopb.CompactionDetail{},
-		},
+		ID: uuid.NewString(),
+	}
+
+	require.False(t, j.OnBlock("block1"))
+	j.Type = tempopb.JobType_JOB_TYPE_COMPACTION
+	j.JobDetail = tempopb.JobDetail{
+		Tenant:     tenant,
+		Compaction: &tempopb.CompactionDetail{},
 	}
 
 	idOne := uuid.NewString()


### PR DESCRIPTION
**What this PR does**:

Previous to #5019 a lock for the RPC calls was sufficient, but we only need it for the work, which has its own lock.  Here we drop the locking from the backendworker entirely to rely on the job and work mutex.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`