### PR TITLE
fix: use canonical byte size when parsing partition.id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [BUGFIX] Fix setting processors in user configurations overrides via API [#4741](https://github.com/grafana/tempo/pull/4741) (@ruslan-mikhailov)
 * [BUGFIX] Fix panic on startup [#4744](https://github.com/grafana/tempo/pull/4744) (@ruslan-mikhailov)
 * [BUGFIX] Fix intrinsic tag lookups dropped when max tag lookup response size is exceeded [#4784](https://github.com/grafana/tempo/pull/4784) (@mdisibio)
+* [BUGFIX] Use canonical bytesize when parsing partition.id in the distributor [#5033](https://github.com/grafana/tempo/pull/5033) (@javiermolinar)
 * [BUGFIX] Correctly cache frontend jobs for query range (TraceQL Metrics). [#4771](https://github.com/grafana/tempo/pull/4771) (@joe-elliott)
 * [BUGFIX] Various edge case fixes for query range (TraceQL Metrics) [#4962](https://github.com/grafana/tempo/pull/4962) (@ruslan-mikhailov)
 * [BUGFIX] Fix `TempoBlockListRisingQuickly` alert grouping. [#4876](https://github.com/grafana/tempo/pull/4876) (@mapno)

--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -640,7 +640,7 @@ func (d *Distributor) sendToKafka(ctx context.Context, userID string, keys []uin
 		}
 
 		// The partition ID is stored in the ring.InstanceDesc ID.
-		partitionID, err := strconv.ParseInt(partition.Id, 10, 31)
+		partitionID, err := strconv.ParseInt(partition.Id, 10, 32)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
It uses a canonical bytesize when parsing the partition.id. Currently it uses `31` bytes as byte size. 


**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`