### PR TITLE
Updated memcached client to honor a cancelled context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [BUGFIX] Fix flaky test [#4787](https://github.com/grafana/tempo/pull/4787) [#4995](https://github.com/grafana/tempo/pull/4995) (@javiermolinar)
 * [BUGFIX] Include cost attribution when converting from default config to legacy one [#4787](https://github.com/grafana/tempo/pull/4937) (@javiermolinar)
 * [BUGFIX] Fix memcached settings for docker compose example [#4346](https://github.com/grafana/tempo/pull/4695) (@ruslan-mikhailov)
+* [BUGFIX] Update memcahed to respect cancelled context to prevent panic [#5041](https://github.com/grafana/tempo/pull/5041) (@joe-elliott)
 * [BUGFIX] Fix frontend cache key generation for TraceQL Metrics queries to prevent collisions. [#5017](https://github.com/grafana/tempo/pull/5017) (@joe-elliott)
 * [BUGFIX] Fix setting processors in user configurations overrides via API [#4741](https://github.com/grafana/tempo/pull/4741) (@ruslan-mikhailov)
 * [BUGFIX] Fix panic on startup [#4744](https://github.com/grafana/tempo/pull/4744) (@ruslan-mikhailov)

--- a/pkg/cache/memcached.go
+++ b/pkg/cache/memcached.go
@@ -153,13 +153,13 @@ func (c *Memcached) FetchKey(ctx context.Context, key string) ([]byte, bool) {
 
 // Store stores the key in the cache.
 func (c *Memcached) Store(ctx context.Context, keys []string, bufs [][]byte) {
-	select {
-	case <-ctx.Done():
-		return
-	default:
-	}
-
 	for i := range keys {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
 		err := measureRequest(ctx, "Memcache.Put", c.requestDuration, memcacheStatusCode, func(_ context.Context) error {
 			item := memcache.Item{
 				Key:        keys[i],

--- a/pkg/cache/memcached.go
+++ b/pkg/cache/memcached.go
@@ -74,46 +74,18 @@ func NewMemcached(cfg MemcachedConfig, client MemcachedClient, name string, maxI
 	return c
 }
 
-func memcacheStatusCode(err error) string {
-	// See https://godoc.org/github.com/bradfitz/gomemcache/memcache#pkg-variables
-	if errors.Is(err, memcache.ErrCacheMiss) {
-		return "404"
-	}
-	if errors.Is(err, memcache.ErrMalformedKey) {
-		return "400"
-	}
-	if err != nil {
-		return "500"
-	}
-	return "200"
-}
-
-// Fetch gets keys from the cache. The keys that are found must be in the order of the keys requested.
+// Fetch gets keys from the cache. The keys that are found must be in the order of the keys requested. jpe - just remove
 func (c *Memcached) Fetch(ctx context.Context, keys []string) (found []string, bufs [][]byte, missed []string) {
+	select {
+	case <-ctx.Done():
+		found = nil
+		bufs = nil
+		missed = keys
+		return
+	default:
+	}
 	found, bufs, missed = c.fetch(ctx, keys)
 	return
-}
-
-// FetchKey gets a single key from the cache
-func (c *Memcached) FetchKey(ctx context.Context, key string) ([]byte, bool) {
-	const method = "Memcache.Get"
-	var item *memcache.Item
-	err := measureRequest(ctx, method, c.requestDuration, memcacheStatusCode, func(_ context.Context) error {
-		var err error
-		item, err = c.memcache.Get(key, memcache.WithAllocator(cacheBufAllocator))
-		if err != nil {
-			if errors.Is(err, memcache.ErrCacheMiss) {
-				level.Debug(c.logger).Log("msg", "Failed to get key from memcached", "err", err, "key", key)
-			} else {
-				level.Error(c.logger).Log("msg", "Error getting key from memcached", "err", err, "key", key)
-			}
-		}
-		return err
-	})
-	if err != nil {
-		return nil, false
-	}
-	return item.Value, true
 }
 
 func (c *Memcached) fetch(ctx context.Context, keys []string) (found []string, bufs [][]byte, missed []string) {
@@ -143,8 +115,56 @@ func (c *Memcached) fetch(ctx context.Context, keys []string) (found []string, b
 	return
 }
 
+func memcacheStatusCode(err error) string {
+	// See https://godoc.org/github.com/bradfitz/gomemcache/memcache#pkg-variables
+	if errors.Is(err, memcache.ErrCacheMiss) {
+		return "404"
+	}
+	if errors.Is(err, memcache.ErrMalformedKey) {
+		return "400"
+	}
+	if err != nil {
+		return "500"
+	}
+	return "200"
+}
+
+// FetchKey gets a single key from the cache
+func (c *Memcached) FetchKey(ctx context.Context, key string) ([]byte, bool) {
+	select {
+	case <-ctx.Done():
+		return nil, false
+	default:
+	}
+
+	const method = "Memcache.Get"
+	var item *memcache.Item
+	err := measureRequest(ctx, method, c.requestDuration, memcacheStatusCode, func(_ context.Context) error {
+		var err error
+		item, err = c.memcache.Get(key, memcache.WithAllocator(cacheBufAllocator))
+		if err != nil {
+			if errors.Is(err, memcache.ErrCacheMiss) {
+				level.Debug(c.logger).Log("msg", "Failed to get key from memcached", "err", err, "key", key)
+			} else {
+				level.Error(c.logger).Log("msg", "Error getting key from memcached", "err", err, "key", key)
+			}
+		}
+		return err
+	})
+	if err != nil {
+		return nil, false
+	}
+	return item.Value, true
+}
+
 // Store stores the key in the cache.
 func (c *Memcached) Store(ctx context.Context, keys []string, bufs [][]byte) {
+	select {
+	case <-ctx.Done():
+		return
+	default:
+	}
+
 	for i := range keys {
 		err := measureRequest(ctx, "Memcache.Put", c.requestDuration, memcacheStatusCode, func(_ context.Context) error {
 			item := memcache.Item{

--- a/pkg/cache/memcached_test.go
+++ b/pkg/cache/memcached_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/grafana/tempo/pkg/cache"
 )
 
+// jpe - test
+
 func TestMemcached(t *testing.T) {
 	t.Run("unbatched", func(t *testing.T) {
 		client := newMockMemcache()

--- a/pkg/cache/memcached_test.go
+++ b/pkg/cache/memcached_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/grafana/tempo/pkg/cache"
 )
 
-// jpe - test
-
 func TestMemcached(t *testing.T) {
 	t.Run("unbatched", func(t *testing.T) {
 		client := newMockMemcache()
@@ -170,4 +168,29 @@ func testMemcachedStopping(memcache *cache.Memcached) {
 
 	go memcache.Fetch(ctx, keys)
 	memcache.Stop()
+}
+
+func TestMemcachedRespectsCancelledContext(t *testing.T) {
+	client := newMockMemcache()
+	memcache := cache.NewMemcached(cache.MemcachedConfig{}, client,
+		"test", 0, nil, log.NewNopLogger())
+	defer memcache.Stop()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	found, bufs, missing := memcache.Fetch(ctx, []string{"1"})
+	require.Nil(t, found)
+	require.Nil(t, bufs)
+	require.Equal(t, []string{"1"}, missing)
+
+	val, f := memcache.FetchKey(ctx, "1")
+	require.Nil(t, val)
+	require.False(t, f)
+
+	memcache.Store(ctx, []string{"1"}, [][]byte{[]byte("1")})
+	// confirm that the value is not stored
+	mi, err := client.Get("1")
+	require.ErrorContains(t, err, "cache miss")
+	require.Nil(t, mi)
 }


### PR DESCRIPTION
**What this PR does**:
Updates the memcached client to honor a cancelled context. This prevents a somewhat rare panic from occurring:

```
	/Users/joe/dev/joe-elliott/tempo/vendor/github.com/parquet-go/parquet-go/page.go:129 +0xfd
created by github.com/parquet-go/parquet-go.AsyncPages in goroutine 610894
	/Users/joe/dev/joe-elliott/tempo/vendor/github.com/parquet-go/parquet-go/page.go:269 +0x178
github.com/parquet-go/parquet-go.readPages({0x3fdf8f0, 0xc0bf919ae0}, 0xc10c1dc310, 0xc095e75880, 0x4007b18?, 0xc10c1dc3f0)
	/Users/joe/dev/joe-elliott/tempo/vendor/github.com/parquet-go/parquet-go/file.go:801 +0x9f
github.com/parquet-go/parquet-go.(*FilePages).ReadPage(0xc0bf919ae0)
	/Users/joe/dev/joe-elliott/tempo/vendor/github.com/parquet-go/parquet-go/file.go:916 +0x65
github.com/parquet-go/parquet-go.(*FilePages).readPage(0xc0bf919ae0, 0xc07d7b5740, 0xc096ba61e0)
	/Users/joe/dev/joe-elliott/tempo/vendor/github.com/parquet-go/parquet-go/buffer.go:534 +0x12d
github.com/parquet-go/parquet-go.(*bufferPool).get(0x623bf20?, 0xfffffffffffffffc?)
goroutine 611543 [running]:

panic: runtime error: slice bounds out of range [:-4]
```

The believed series of events that create this panic are:

1. While [decoding a header](https://github.com/parquet-go/parquet-go/blob/main/file.go#L798) in FilePages.ReadPage the thrift code will read short segments and sometimes [individual bytes](https://github.com/parquet-go/parquet-go/blob/main/encoding/thrift/binary.go#L207).
1. One of these very short reads misses the [bufio.Reader's](https://github.com/parquet-go/parquet-go/blob/ba969aa4929b45459259ea5c2c4a09876a881c04/file.go#L759) internal buffer triggering a read from the backend.
1. Cache misses and the backend read fails with `context.Canceled` b/c the job was canceled for any number of reasons.
1. Something else successfully reads that exact parquet page and stores it in cache.
1. The [AsyncPages](https://github.com/parquet-go/parquet-go/blob/ba969aa4929b45459259ea5c2c4a09876a881c04/page.go#L263-L289) loop comes back around and calls `ReadPage` again.
1. [Decoder.decode](https://github.com/parquet-go/parquet-go/blob/main/file.go#L798) is called again but now the underlying buffer is misaligned. We are N bytes into the header instead of at the start of the header. This wouldn't matter if the backend would just return `context.Canceled` again but...
1. This time cache hits and returns successfully because memcached [doesn't honor context](https://github.com/grafana/tempo/blob/4ab3c173af81c037af9e5d77f30309e78d57eed7/pkg/cache/memcached.go#L98-L100).

Other notes:
- The redis client seems to already respect context? It takes one but I've found it difficult to trace exactly how it's using it.
- Long term we should probably swap to the [dskit cache clients](https://github.com/grafana/dskit/tree/main/cache)

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`