### PR TITLE
Update golangci config for deprecation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,9 +51,9 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - megacheck
     - misspell
     - revive
+    - staticcheck
     - typecheck
     - unconvert
     - unparam


### PR DESCRIPTION
**What this PR does**:

Address the following deprecation warning.

```
WARN [lintersdb] The linter named "megacheck" is deprecated. It has been split into: gosimple, staticcheck, unused.
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`