### PR TITLE
Perf: Prevent unnecessary page decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [ENHANCEMENT] Update dskit to latest version [#4681](https://github.com/grafana/tempo/pull/4681) (@javiermolinar) [#4865](https://github.com/grafana/tempo/pull/4865) (@javiermolinar)
 * [ENHANCEMENT] Increase query-frontend default batch size [#4844](https://github.com/grafana/tempo/pull/4844) (@javiermolinar) 
 * [ENHANCEMENT] Improve TraceQL perf by reverting EqualRowNumber to an inlineable function.[#4705](https://github.com/grafana/tempo/pull/4705) (@joe-elliott)
+* [ENHANCEMENT] Improve TraceQL perf by preventing unnecessary decode of the first page in a column chunk.[#5050](https://github.com/grafana/tempo/pull/5050) (@joe-elliott)
 * [ENHANCEMENT] Rhythm: Implement MaxBytesPerCycle [#4835](https://github.com/grafana/tempo/pull/4835) (@javiermolinar)
 * [ENHANCEMENT] Rhythm: fair partition consumption in blockbuilders [#4655](https://github.com/grafana/tempo/pull/4655) (@javiermolinar)
 * [ENHANCEMENT] Rhythm: retry on commit error [#4874](https://github.com/grafana/tempo/pull/4874) (@javiermolinar)

--- a/pkg/parquetquery/column.go
+++ b/pkg/parquetquery/column.go
@@ -18,12 +18,12 @@ func (h *ColumnChunkHelper) Dictionary() parquet.Dictionary {
 		h.pages = h.ColumnChunk.Pages()
 	}
 
-	type dictReader interface {
-		ReadDictionary() (parquet.Dictionary, error)
-	}
-
-	if dr, ok := h.pages.(dictReader); ok {
-		dict, err := dr.ReadDictionary()
+	// The FilePages struct in parquet-go exposes a ReadDictionary method that
+	// will return the dictionary w/o decoding the first "real" page of the column chunk.
+	// If the dictionary allows us to skip the column chunk, this prevents the unnecessary decoding
+	// of the first page.
+	if fp, ok := h.pages.(*parquet.FilePages); ok {
+		dict, err := fp.ReadDictionary()
 		if err != nil {
 			h.err = err
 			return nil

--- a/pkg/parquetquery/column.go
+++ b/pkg/parquetquery/column.go
@@ -18,6 +18,19 @@ func (h *ColumnChunkHelper) Dictionary() parquet.Dictionary {
 		h.pages = h.ColumnChunk.Pages()
 	}
 
+	type dictReader interface {
+		ReadDictionary() (parquet.Dictionary, error)
+	}
+
+	if dr, ok := h.pages.(dictReader); ok {
+		dict, err := dr.ReadDictionary()
+		if err != nil {
+			h.err = err
+			return nil
+		}
+		return dict
+	}
+
 	if h.firstPage == nil {
 		h.firstPage, h.err = h.pages.ReadPage()
 	}


### PR DESCRIPTION
**What this PR does**:
Uses a somewhat recently exposed method on parquet.FilePages to prevent decoding of the first page of a column chunk when the dictionary allows us to skip it.

<details>

<summary>benches</summary>

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/tempo/tempodb/encoding/vparquet4
cpu: Apple M3 Pro
                                                    │ before.txt  │             after.txt              │
                                                    │   sec/op    │   sec/op     vs base               │
BackendBlockTraceQL/spanAttValMatch-11                79.16m ± 1%   77.39m ± 1%  -2.24% (p=0.000 n=10)
BackendBlockTraceQL/spanAttValNoMatch-11              5.504m ± 1%   5.265m ± 2%  -4.35% (p=0.000 n=10)
BackendBlockTraceQL/spanAttIntrinsicMatch-11          56.43m ± 0%   55.98m ± 1%  -0.80% (p=0.000 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-11        5.360m ± 1%   5.252m ± 1%  -2.01% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttValMatch-11            374.6m ± 0%   365.4m ± 1%  -2.45% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttValNoMatch-11          5.073m ± 1%   5.014m ± 1%  -1.16% (p=0.003 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-11      24.38m ± 0%   24.18m ± 0%  -0.84% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01-11   5.133m ± 0%   5.129m ± 1%       ~ (p=0.971 n=10)
BackendBlockTraceQL/traceOrMatch-11                   228.0m ± 0%   228.6m ± 1%       ~ (p=0.247 n=10)
BackendBlockTraceQL/traceOrNoMatch-11                 228.9m ± 0%   227.9m ± 1%       ~ (p=0.089 n=10)
BackendBlockTraceQL/mixedValNoMatch-11                170.6m ± 0%   170.4m ± 1%       ~ (p=0.684 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd-11          4.967m ± 0%   4.936m ± 1%  -0.62% (p=0.015 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr-11           135.9m ± 0%   135.3m ± 0%  -0.42% (p=0.003 n=10)
BackendBlockTraceQL/count-11                          307.0m ± 1%   305.0m ± 1%  -0.65% (p=0.002 n=10)
BackendBlockTraceQL/struct-11                         418.0m ± 2%   415.6m ± 0%       ~ (p=0.165 n=10)
BackendBlockTraceQL/||-11                             137.8m ± 0%   137.6m ± 0%       ~ (p=0.089 n=10)
BackendBlockTraceQL/mixed-11                          24.86m ± 1%   24.80m ± 0%       ~ (p=0.105 n=10)
BackendBlockTraceQL/complex-11                        4.969m ± 2%   4.909m ± 2%       ~ (p=0.529 n=10)
BackendBlockTraceQL/select-11                         4.938m ± 1%   4.891m ± 2%       ~ (p=0.075 n=10)
geomean                                               39.37m        38.97m       -1.01%

                                                    │  before.txt  │              after.txt              │
                                                    │     B/s      │     B/s       vs base               │
BackendBlockTraceQL/spanAttValMatch-11                282.9Mi ± 1%   289.4Mi ± 1%  +2.30% (p=0.000 n=10)
BackendBlockTraceQL/spanAttValNoMatch-11              307.0Mi ± 1%   320.9Mi ± 2%  +4.55% (p=0.000 n=10)
BackendBlockTraceQL/spanAttIntrinsicMatch-11          412.8Mi ± 0%   416.1Mi ± 1%  +0.81% (p=0.000 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-11        462.2Mi ± 1%   471.7Mi ± 1%  +2.05% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttValMatch-11            58.66Mi ± 0%   60.13Mi ± 1%  +2.51% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttValNoMatch-11          177.3Mi ± 1%   179.4Mi ± 1%  +1.17% (p=0.003 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-11      903.1Mi ± 0%   910.8Mi ± 0%  +0.85% (p=0.000 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01-11   181.9Mi ± 0%   182.0Mi ± 1%       ~ (p=0.971 n=10)
BackendBlockTraceQL/traceOrMatch-11                   7.329Mi ± 0%   7.315Mi ± 1%       ~ (p=0.250 n=10)
BackendBlockTraceQL/traceOrNoMatch-11                 7.300Mi ± 0%   7.339Mi ± 1%       ~ (p=0.084 n=10)
BackendBlockTraceQL/mixedValNoMatch-11                11.55Mi ± 0%   11.57Mi ± 1%       ~ (p=0.697 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd-11          179.7Mi ± 0%   180.8Mi ± 1%  +0.62% (p=0.016 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr-11           20.30Mi ± 0%   20.39Mi ± 0%  +0.42% (p=0.003 n=10)
BackendBlockTraceQL/count-11                          71.54Mi ± 1%   72.01Mi ± 1%  +0.65% (p=0.002 n=10)
BackendBlockTraceQL/struct-11                         13.06Mi ± 2%   13.14Mi ± 0%       ~ (p=0.183 n=10)
BackendBlockTraceQL/||-11                             160.2Mi ± 0%   160.4Mi ± 0%       ~ (p=0.093 n=10)
BackendBlockTraceQL/mixed-11                          859.2Mi ± 1%   861.4Mi ± 0%       ~ (p=0.105 n=10)
BackendBlockTraceQL/complex-11                        181.1Mi ± 2%   183.3Mi ± 2%       ~ (p=0.529 n=10)
BackendBlockTraceQL/select-11                         182.3Mi ± 1%   184.0Mi ± 2%       ~ (p=0.075 n=10)
geomean                                               105.4Mi        106.5Mi       +1.03%

                                                    │ before.txt  │              after.txt               │
                                                    │  MB_io/op   │  MB_io/op    vs base                 │
BackendBlockTraceQL/spanAttValMatch-11                 23.48 ± 0%    23.48 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/spanAttValNoMatch-11               1.772 ± 0%    1.772 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/spanAttIntrinsicMatch-11           24.43 ± 0%    24.43 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/spanAttIntrinsicNoMatch-11         2.598 ± 0%    2.598 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/resourceAttValMatch-11             23.04 ± 0%    23.04 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/resourceAttValNoMatch-11          943.2m ± 0%   943.2m ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/resourceAttIntrinsicMatch-11       23.09 ± 0%    23.09 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/resourceAttIntrinsicMatch#01-11   979.0m ± 0%   979.0m ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/traceOrMatch-11                    1.753 ± 0%    1.753 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/traceOrNoMatch-11                  1.753 ± 0%    1.753 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixedValNoMatch-11                 2.067 ± 0%    2.067 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixedValMixedMatchAnd-11          936.1m ± 0%   936.1m ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixedValMixedMatchOr-11            2.893 ± 0%    2.893 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/count-11                           23.03 ± 0%    23.03 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/struct-11                          5.726 ± 0%    5.726 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/||-11                              23.14 ± 0%    23.14 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/mixed-11                           22.40 ± 0%    22.40 ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/complex-11                        943.7m ± 0%   943.7m ± 0%       ~ (p=1.000 n=10) ¹
BackendBlockTraceQL/select-11                         943.7m ± 0%   943.7m ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                4.351         4.351       +0.00%
¹ all samples are equal

                                                    │   before.txt   │               after.txt               │
                                                    │      B/op      │      B/op       vs base               │
BackendBlockTraceQL/spanAttValMatch-11                 45.14Mi ±  1%    45.31Mi ±  1%       ~ (p=0.218 n=10)
BackendBlockTraceQL/spanAttValNoMatch-11               6.711Mi ±  1%    6.692Mi ±  1%       ~ (p=0.971 n=10)
BackendBlockTraceQL/spanAttIntrinsicMatch-11           39.75Mi ±  0%    39.86Mi ±  1%       ~ (p=0.190 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-11         7.058Mi ±  2%    7.086Mi ±  1%       ~ (p=0.579 n=10)
BackendBlockTraceQL/resourceAttValMatch-11             575.6Mi ±  0%    576.0Mi ±  0%       ~ (p=0.971 n=10)
BackendBlockTraceQL/resourceAttValNoMatch-11           5.387Mi ±  2%    5.411Mi ±  1%       ~ (p=0.739 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-11       10.56Mi ±  2%    10.56Mi ±  2%       ~ (p=0.796 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01-11    6.785Mi ±  1%    6.778Mi ±  1%       ~ (p=0.315 n=10)
BackendBlockTraceQL/traceOrMatch-11                    9.288Mi ± 14%   10.041Mi ± 22%       ~ (p=0.280 n=10)
BackendBlockTraceQL/traceOrNoMatch-11                 11.073Mi ± 13%    9.099Mi ± 40%       ~ (p=0.247 n=10)
BackendBlockTraceQL/mixedValNoMatch-11                 7.944Mi ±  7%    8.007Mi ± 10%       ~ (p=0.393 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd-11           5.765Mi ±  1%    5.773Mi ±  1%       ~ (p=0.353 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr-11            7.405Mi ± 19%    7.826Mi ±  7%       ~ (p=0.579 n=10)
BackendBlockTraceQL/count-11                           418.6Mi ±  0%    417.5Mi ±  0%       ~ (p=0.075 n=10)
BackendBlockTraceQL/struct-11                          13.74Mi ± 17%    12.95Mi ± 19%       ~ (p=0.052 n=10)
BackendBlockTraceQL/||-11                              16.83Mi ±  3%    16.59Mi ±  1%       ~ (p=0.143 n=10)
BackendBlockTraceQL/mixed-11                           6.884Mi ±  2%    7.017Mi ±  2%       ~ (p=0.089 n=10)
BackendBlockTraceQL/complex-11                         5.629Mi ±  4%    5.606Mi ±  2%       ~ (p=0.912 n=10)
BackendBlockTraceQL/select-11                          5.568Mi ±  2%    5.563Mi ±  1%       ~ (p=0.912 n=10)
geomean                                                14.63Mi          14.55Mi        -0.54%

                                                    │ before.txt  │             after.txt              │
                                                    │  allocs/op  │  allocs/op   vs base               │
BackendBlockTraceQL/spanAttValMatch-11                503.5k ± 0%   503.5k ± 0%       ~ (p=0.287 n=10)
BackendBlockTraceQL/spanAttValNoMatch-11              79.48k ± 0%   79.48k ± 0%       ~ (p=0.613 n=10)
BackendBlockTraceQL/spanAttIntrinsicMatch-11          288.1k ± 0%   288.1k ± 0%       ~ (p=0.697 n=10)
BackendBlockTraceQL/spanAttIntrinsicNoMatch-11        79.44k ± 0%   79.44k ± 0%       ~ (p=0.301 n=10)
BackendBlockTraceQL/resourceAttValMatch-11            3.450M ± 0%   3.450M ± 0%       ~ (p=1.000 n=10)
BackendBlockTraceQL/resourceAttValNoMatch-11          79.48k ± 0%   79.48k ± 0%       ~ (p=0.814 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch-11      126.1k ± 0%   126.1k ± 0%       ~ (p=0.925 n=10)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01-11   79.47k ± 0%   79.47k ± 0%       ~ (p=0.893 n=10)
BackendBlockTraceQL/traceOrMatch-11                   86.57k ± 2%   86.40k ± 1%       ~ (p=0.075 n=10)
BackendBlockTraceQL/traceOrNoMatch-11                 86.49k ± 0%   86.34k ± 0%       ~ (p=0.061 n=10)
BackendBlockTraceQL/mixedValNoMatch-11                80.30k ± 0%   80.29k ± 0%       ~ (p=0.926 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd-11          79.47k ± 0%   79.47k ± 0%       ~ (p=1.000 n=10)
BackendBlockTraceQL/mixedValMixedMatchOr-11           80.25k ± 0%   80.27k ± 0%       ~ (p=0.404 n=10)
BackendBlockTraceQL/count-11                          1.990M ± 0%   1.990M ± 0%       ~ (p=0.424 n=10)
BackendBlockTraceQL/struct-11                         93.84k ± 7%   93.62k ± 1%       ~ (p=0.645 n=10)
BackendBlockTraceQL/||-11                             161.9k ± 0%   161.9k ± 0%       ~ (p=0.541 n=10)
BackendBlockTraceQL/mixed-11                          87.95k ± 0%   87.96k ± 0%       ~ (p=0.642 n=10)
BackendBlockTraceQL/complex-11                        79.83k ± 0%   79.83k ± 0%       ~ (p=0.868 n=10)
BackendBlockTraceQL/select-11                         79.71k ± 0%   79.71k ± 0%       ~ (p=0.928 n=10)
geomean                                               147.6k        147.6k       -0.03%
```

</details>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`