### PR TITLE
[jsonnet] update memcached and exporter version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [CHANGE] Set querier default level to INFO [#4943](https://github.com/grafana/tempo/pull/4943) (@javiermolinar)
 * [CHANGE] Change retention to honor compactor disablement [#5044](https://github.com/grafana/tempo/pull/5044) (@zalegrala)
 * [CHANGE] Continue on error in tempo-cli rewrite-blocks [#5043](https://github.com/grafana/tempo/pull/5043) (@zalegrala)
+* [CHANGE] Update jsonnet memcached and exporter image versions [#5056](https://github.com/grafana/tempo/pull/5056) (@zalegrala)
 * [FEATURE] Add throughput SLO and metrics for the TraceByID endpoint. [#4668](https://github.com/grafana/tempo/pull/4668) (@carles-grafana)
 configurable via the throughput_bytes_slo field, and it will populate op="traces" label in slo and throughput metrics.
 * [FEATURE] Added most_recent=true query hint to TraceQL to return most recent results. [#4238](https://github.com/grafana/tempo/pull/4238) (@joe-elliott)

--- a/operations/jsonnet-compiled/StatefulSet-memcached.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-memcached.yaml
@@ -27,7 +27,7 @@ spec:
         - -I 5m
         - -c 4096
         - -v
-        image: memcached:1.6.32-alpine
+        image: memcached:1.6.38-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -42,7 +42,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.15.2
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/jsonnet-compiled/util/jsonnetfile.lock.json
+++ b/operations/jsonnet-compiled/util/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "357eee054c4a50b1033e22493fd9503c1174bf56",
+      "version": "42da78cf7f2735c0cf57dee8f80cc52e9e7e57d8",
       "sum": "0y3AFX9LQSpfWTxWKSwoLgbt0Wc9nnCwhMH2szKzHv0="
     },
     {
@@ -18,7 +18,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "357eee054c4a50b1033e22493fd9503c1174bf56",
+      "version": "42da78cf7f2735c0cf57dee8f80cc52e9e7e57d8",
       "sum": "Cc715Y3rgTuimgDFIw+FaKzXSJGRYwt1pFTMbdrNBD8="
     },
     {

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -4,8 +4,8 @@
     tempo_query: 'grafana/tempo-query:latest',
     tempo_vulture: 'grafana/tempo-vulture:latest',
     rollout_operator: 'grafana/rollout-operator:v0.23.0',
-    memcached: 'memcached:1.6.32-alpine',
-    memcachedExporter: 'prom/memcached-exporter:v0.14.3',
+    memcached: 'memcached:1.6.38-alpine',
+    memcachedExporter: 'prom/memcached-exporter:v0.15.2',
   },
 
   _config+:: {


### PR DESCRIPTION
**What this PR does**:

Here we update the default jsonnet versions for memcached and its exporter.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`