### PR TITLE
Update go version to 1.24.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 * [CHANGE] Change retention to honor compactor disablement [#5044](https://github.com/grafana/tempo/pull/5044) (@zalegrala)
 * [CHANGE] Continue on error in tempo-cli rewrite-blocks [#5043](https://github.com/grafana/tempo/pull/5043) (@zalegrala)
 * [CHANGE] Update jsonnet memcached and exporter image versions [#5056](https://github.com/grafana/tempo/pull/5056) (@zalegrala)
-* [CHANGE] Update to go 1.24.2 [#5057](https://github.com/grafana/tempo/pull/5057) (@carsontham) 
+* [CHANGE] Update to go 1.24.2 [#5057](https://github.com/grafana/tempo/pull/5057) [#5082](https://github.com/grafana/tempo/pull/5082) [(@carsontham) 
 * [FEATURE] Add throughput SLO and metrics for the TraceByID endpoint. [#4668](https://github.com/grafana/tempo/pull/4668) (@carles-grafana)
 configurable via the throughput_bytes_slo field, and it will populate op="traces" label in slo and throughput metrics.
 * [FEATURE] Added most_recent=true query hint to TraceQL to return most recent results. [#4238](https://github.com/grafana/tempo/pull/4238) (@joe-elliott)

--- a/build/tools.mk
+++ b/build/tools.mk
@@ -12,7 +12,7 @@ TOOL_DIR     ?= tools
 TOOL_CONFIG  ?= $(TOOL_DIR)/tools.go
 
 TOOLS_IMAGE ?= grafana/tempo-ci-tools
-TOOLS_IMAGE_TAG ?= main-5dda5c6
+TOOLS_IMAGE_TAG ?= main-ab783a4
 
 GOTOOLS ?= $(shell cd $(TOOL_DIR) && go list -e -f '{{ .Imports }}' -tags tools |tr -d '[]')
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/tempo
 
-go 1.24.1
+go 1.24.2
 
 require (
 	cloud.google.com/go/storage v1.52.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This is a continuation to https://github.com/grafana/tempo/pull/5057. 
This second PR updates:
- the actual go version to 1.24.2
- update `TOOLS_IMAGE_TAG` to use the latest tag.

**Which issue(s) this PR fixes**:
Fixes #5040

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`