### PR TITLE
Change poller to not log completion in the event of early return

### DIFF
--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -141,7 +141,9 @@ func (p *Poller) Do(parentCtx context.Context, previous *List) (PerTenant, PerTe
 	defer func() {
 		diff := time.Since(start).Seconds()
 		metricBlocklistPollDuration.Observe(diff)
-		level.Info(p.logger).Log("msg", "blocklist poll complete", "seconds", diff)
+		if parentCtx.Err() == nil {
+			level.Info(p.logger).Log("msg", "blocklist poll complete", "seconds", diff)
+		}
 		backend.ClearDedicatedColumns()
 	}()
 

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -139,11 +139,6 @@ func NewPoller(cfg *PollerConfig, sharder JobSharder, reader backend.Reader, com
 func (p *Poller) Do(parentCtx context.Context, previous *List) (PerTenant, PerTenantCompacted, error) {
 	start := time.Now()
 	defer func() {
-		diff := time.Since(start).Seconds()
-		metricBlocklistPollDuration.Observe(diff)
-		if parentCtx.Err() == nil {
-			level.Info(p.logger).Log("msg", "blocklist poll complete", "seconds", diff)
-		}
 		backend.ClearDedicatedColumns()
 	}()
 
@@ -250,6 +245,10 @@ func (p *Poller) Do(parentCtx context.Context, previous *List) (PerTenant, PerTe
 	if tenantFailuresRemaining.Load() < 0 {
 		return nil, nil, errors.New("too many tenant failures; abandoning polling cycle")
 	}
+
+	diff := time.Since(start).Seconds()
+	metricBlocklistPollDuration.Observe(diff)
+	level.Info(p.logger).Log("msg", "blocklist poll complete", "seconds", diff)
 
 	return blocklist, compactedBlocklist, nil
 }


### PR DESCRIPTION
**What this PR does**:

Here we modify the poller so that it does not log a "complete" message if the context has been cancelled.  Occasionally we see a log message in a test which is written after a test is complete, which causes the test to fail.  Additionally, we don't signal to the user that the work has been completed when the work has actually been canceled or we exit for other reasons.

An example test failure can be seen [here](https://github.com/grafana/tempo/actions/runs/14781775278/job/41502068459#step:4:1432).

Additionally, [this issue](https://github.com/golang/go/issues/67701) describes the behavior.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`