### PR TITLE
chore: add extra linters to golangci

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,9 @@ output:
 linters:
   enable:
     - errorlint
+    - forbidigo
+    - gocritic
+    - gosec
     - goconst
     - misspell
     - revive


### PR DESCRIPTION
It adds
- forbidigo: https://github.com/ashanbrown/forbidigo
- gocritic: https://github.com/go-critic/go-critic
- gosec: https://github.com/securego/gosec
