### PR TITLE
fix: stop early when a  partial trace is reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [BUGFIX] Return the operand as the only value if the tag is already filtered in the query [#4673](https://github.com/grafana/tempo/pull/4673) (@mapno)
 * [BUGFIX] Fix flaky test [#4787](https://github.com/grafana/tempo/pull/4787) [#4995](https://github.com/grafana/tempo/pull/4995) (@javiermolinar)
 * [BUGFIX] Include cost attribution when converting from default config to legacy one [#4787](https://github.com/grafana/tempo/pull/4937) (@javiermolinar)
+* [BUGFIX] Stop early when a partial trace is reached  [#5094](https://github.com/grafana/tempo/pull/5094) (@javiermolinar)
 * [BUGFIX] Fix memcached settings for docker compose example [#4346](https://github.com/grafana/tempo/pull/4695) (@ruslan-mikhailov)
 * [BUGFIX] Update memcahed to respect cancelled context to prevent panic [#5041](https://github.com/grafana/tempo/pull/5041) (@joe-elliott)
 * [BUGFIX] Fix frontend cache key generation for TraceQL Metrics queries to prevent collisions. [#5017](https://github.com/grafana/tempo/pull/5017) (@joe-elliott)

--- a/modules/frontend/combiner/trace_by_id_v2.go
+++ b/modules/frontend/combiner/trace_by_id_v2.go
@@ -45,6 +45,9 @@ func NewTraceByIDV2(maxBytes int, marshalingFormat string) Combiner {
 
 			return resp, nil
 		},
+		quit: func(_ *tempopb.TraceByIDResponse) bool {
+			return partialTrace || combiner.IsPartialTrace()
+		},
 		new:     func() *tempopb.TraceByIDResponse { return &tempopb.TraceByIDResponse{} },
 		current: &tempopb.TraceByIDResponse{},
 	}


### PR DESCRIPTION
**What this PR does**:
This change bails early when a partial trace is detected. Instead of waiting for the entire query to complete, the query frontend combiner now stops as soon as a partial trace is found.


**Which issue(s) this PR fixes**:
Fixes #5080

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

 