### PR TITLE
Revert "Perf: Prevent unnecessary page decoding"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,6 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [ENHANCEMENT] Update dskit to latest version [#4681](https://github.com/grafana/tempo/pull/4681) (@javiermolinar) [#4865](https://github.com/grafana/tempo/pull/4865) (@javiermolinar)
 * [ENHANCEMENT] Increase query-frontend default batch size [#4844](https://github.com/grafana/tempo/pull/4844) (@javiermolinar) 
 * [ENHANCEMENT] Improve TraceQL perf by reverting EqualRowNumber to an inlineable function.[#4705](https://github.com/grafana/tempo/pull/4705) (@joe-elliott)
-* [ENHANCEMENT] Improve TraceQL perf by preventing unnecessary decode of the first page in a column chunk.[#5050](https://github.com/grafana/tempo/pull/5050) (@joe-elliott)
 * [ENHANCEMENT] Rhythm: Implement MaxBytesPerCycle [#4835](https://github.com/grafana/tempo/pull/4835) (@javiermolinar)
 * [ENHANCEMENT] Rhythm: fair partition consumption in blockbuilders [#4655](https://github.com/grafana/tempo/pull/4655) (@javiermolinar)
 * [ENHANCEMENT] Rhythm: retry on commit error [#4874](https://github.com/grafana/tempo/pull/4874) (@javiermolinar)

--- a/pkg/parquetquery/column.go
+++ b/pkg/parquetquery/column.go
@@ -18,19 +18,6 @@ func (h *ColumnChunkHelper) Dictionary() parquet.Dictionary {
 		h.pages = h.ColumnChunk.Pages()
 	}
 
-	// The FilePages struct in parquet-go exposes a ReadDictionary method that
-	// will return the dictionary w/o decoding the first "real" page of the column chunk.
-	// If the dictionary allows us to skip the column chunk, this prevents the unnecessary decoding
-	// of the first page.
-	if fp, ok := h.pages.(*parquet.FilePages); ok {
-		dict, err := fp.ReadDictionary()
-		if err != nil {
-			h.err = err
-			return nil
-		}
-		return dict
-	}
-
 	if h.firstPage == nil {
 		h.firstPage, h.err = h.pages.ReadPage()
 	}


### PR DESCRIPTION
Reverts grafana/tempo#5050

This change has no impact currently b/c we are interacting with AsyncPages and not FilePages. However, if we did swap to ReadModeSync it would have mixed impact. Queries that regularly missed the dictionary filters would be improved while queries that iterated through the values themselves would incur additional backend reads b/c [readDictionary](https://github.com/parquet-go/parquet-go/blob/401fed3de95633e24b110127f346a674f9c62a64/file.go#L861-L882) instantiates and uses it's own `bufio.Reader` instead of the main one on `FilePages`.

The overall impact is our fastest queries would be faster while our slowest queries would be slower.