### PR TITLE
Update tools image to Go v1.24.3 (part 1)

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.2-alpine
+FROM golang:1.24.3-alpine
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/tempo/tools
 
-go 1.24.2
+go 1.24.3
 
 require (
 	github.com/golangci/golangci-lint/v2 v2.1.5


### PR DESCRIPTION
**What this PR does**:
Update Go version in tools image to v1.24.3. This is the first of two PRs. The follow up is #5110 which will be ready once the new tools image is built.

**Which issue(s) this PR fixes**:
Contributes to fixing CVE-2025-22873

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`