### PR TITLE
Fix race conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [CHANGE] Assert max live traces limits in local-blocks processor [#5170](https://github.com/grafana/tempo/pull/5170) (@mapno)
 * [ENHANCEMENT] Include backendwork dashboard and include additional alert [#5159](https://github.com/grafana/tempo/pull/5159) (@zalegrala)
 * [BUGFIX] Add nil check to partitionAssignmentVar [#5198](https://github.com/grafana/tempo/pull/5198) (@mapno)
+* [BUGFIX] Fix various race conditions [#5113](https://github.com/grafana/tempo/pull/5113) (@ruslan-mikhailov)
 
 # v2.8.0-rc.0
 

--- a/modules/frontend/v1/frontend.go
+++ b/modules/frontend/v1/frontend.go
@@ -257,6 +257,7 @@ func (f *Frontend) Process(server frontendv1pb.Frontend_ProcessServer) error {
 		resps := make(chan *frontendv1pb.ClientToFrontend, 1)
 		errs := make(chan error, 1)
 		go func() {
+			var err error
 			// todo: we are still sending the old Type_HTTP_REQUEST for backwards compat
 			// with queriers that don't support the new Type_HTTP_REQUEST_BATCH. this feature
 			// was introduced in 2.2. We should remove this in a few versions

--- a/modules/frontend/v1/request_batch.go
+++ b/modules/frontend/v1/request_batch.go
@@ -88,6 +88,10 @@ func (b *requestBatch) doneChan(stop <-chan struct{}) <-chan struct{} {
 		// tests each request context and only closes done if all are done.
 		// technically it is only testing one a time, but the loop will only complete
 		// if all are done.
+		// NOTE: The function has race conditions, but the impact is negligible.
+		// This occurs when all responses or an error are already received.
+		// In such cases, pipelineRequests can be modified during the loop iteration
+		// but will exit immediately afterward as the stop channel will be closed.
 		for _, r := range b.pipelineRequests {
 			select {
 			case <-r.OriginalContext().Done():

--- a/modules/ingester/instance_search.go
+++ b/modules/ingester/instance_search.go
@@ -53,11 +53,11 @@ func (i *instance) Search(ctx context.Context, req *tempopb.SearchRequest) (*tem
 	}
 
 	var (
-		resultsMtx = sync.Mutex{}
-		combiner   = traceql.NewMetadataCombiner(maxResults, mostRecent)
-		metrics    = &tempopb.SearchMetrics{}
-		opts       = common.DefaultSearchOptions()
-		anyErr     atomic.Error
+		searchMtx = sync.Mutex{}
+		combiner  = traceql.NewMetadataCombiner(maxResults, mostRecent)
+		metrics   = &tempopb.SearchMetrics{}
+		opts      = common.DefaultSearchOptions()
+		anyErr    atomic.Error
 	)
 
 	search := func(blockMeta *backend.BlockMeta, block common.Searcher, spanName string) {
@@ -103,8 +103,8 @@ func (i *instance) Search(ctx context.Context, req *tempopb.SearchRequest) (*tem
 			return
 		}
 
-		resultsMtx.Lock()
-		defer resultsMtx.Unlock()
+		searchMtx.Lock()
+		defer searchMtx.Unlock()
 
 		if resp.Metrics != nil {
 			metrics.InspectedTraces += resp.Metrics.InspectedTraces

--- a/modules/ingester/instance_search.go
+++ b/modules/ingester/instance_search.go
@@ -71,7 +71,10 @@ func (i *instance) Search(ctx context.Context, req *tempopb.SearchRequest) (*tem
 		var err error
 
 		// if the combiner is complete for the block's end time, we can skip searching it
-		if combiner.IsCompleteFor(uint32(blockMeta.EndTime.Unix())) {
+		searchMtx.Lock()
+		isComplete := combiner.IsCompleteFor(uint32(blockMeta.EndTime.Unix()))
+		searchMtx.Unlock()
+		if isComplete {
 			return
 		}
 

--- a/modules/ingester/instance_search.go
+++ b/modules/ingester/instance_search.go
@@ -71,9 +71,11 @@ func (i *instance) Search(ctx context.Context, req *tempopb.SearchRequest) (*tem
 		var err error
 
 		// if the combiner is complete for the block's end time, we can skip searching it
-		searchMtx.Lock()
-		isComplete := combiner.IsCompleteFor(uint32(blockMeta.EndTime.Unix()))
-		searchMtx.Unlock()
+		isComplete := func() bool {
+			searchMtx.Lock()
+			defer searchMtx.Unlock()
+			return combiner.IsCompleteFor(uint32(blockMeta.EndTime.Unix()))
+		}()
 		if isComplete {
 			return
 		}

--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -901,7 +901,11 @@ func (e *Engine) CompileMetricsQueryRange(req *tempopb.QueryRangeRequest, exempl
 	me.end = req.End
 
 	if me.maxExemplars > 0 {
-		cb := func() bool { return me.exemplarCount < me.maxExemplars }
+		cb := func() bool {
+			me.mtx.Lock()
+			defer me.mtx.Unlock()
+			return me.exemplarCount < me.maxExemplars
+		}
 		meta := ExemplarMetaConditionsWithout(cb, storageReq.SecondPassConditions, storageReq.AllConditions)
 		storageReq.SecondPassConditions = append(storageReq.SecondPassConditions, meta...)
 	}

--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -1141,6 +1141,8 @@ func (e *MetricsEvaluator) Do(ctx context.Context, f SpansetFetcher, fetcherStar
 }
 
 func (e *MetricsEvaluator) Length() int {
+	e.mtx.Lock()
+	defer e.mtx.Unlock()
 	return e.metricsPipeline.length()
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does
### Race 1
<details>
  <summary>Stack trace</summary>

  ```
tempo-1  | WARNING: DATA RACE
tempo-1  | Write at 0x00c0016a6a80 by goroutine 1236:
tempo-1  |   github.com/grafana/tempo/modules/frontend/v1.(*requestBatch).clear()
tempo-1  |       /build/modules/frontend/v1/request_batch.go:33 +0x298
tempo-1  |   github.com/grafana/tempo/modules/frontend/v1.(*Frontend).Process()
tempo-1  |       /build/modules/frontend/v1/frontend.go:228 +0x28c
tempo-1  |   github.com/grafana/tempo/modules/frontend/v1.(*Frontend).Process()
tempo-1  |       /build/modules/frontend/v1/frontend.go:205 +0x40
tempo-1  |   github.com/grafana/tempo/modules/frontend/v1/frontendv1pb._Frontend_Process_Handler()
tempo-1  |       /build/modules/frontend/v1/frontendv1pb/frontend.pb.go:437 +0xe8
tempo-1  |   github.com/grafana/tempo/cmd/tempo/app.init.func3()
tempo-1  |       /build/cmd/tempo/app/fake_auth.go:27 +0xcc
tempo-1  |   google.golang.org/grpc.getChainStreamHandler.func1()
tempo-1  |       /build/vendor/google.golang.org/grpc/server.go:1548 +0xd4
tempo-1  |   github.com/grafana/dskit/middleware.StreamServerInstrumentInterceptor.func1()
tempo-1  |       /build/vendor/github.com/grafana/dskit/middleware/grpc_instrumentation.go:62 +0x74
tempo-1  |   google.golang.org/grpc.getChainStreamHandler.func1()
tempo-1  |       /build/vendor/google.golang.org/grpc/server.go:1548 +0xd4
tempo-1  |   github.com/opentracing-contrib/go-grpc.OpenTracingStreamServerInterceptor.func1()
tempo-1  |       /build/vendor/github.com/opentracing-contrib/go-grpc/server.go:115 +0x334
tempo-1  |   google.golang.org/grpc.getChainStreamHandler.func1()
tempo-1  |       /build/vendor/google.golang.org/grpc/server.go:1548 +0xd4
tempo-1  |   github.com/grafana/dskit/middleware.GRPCServerLog.StreamServerInterceptor()
tempo-1  |       /build/vendor/github.com/grafana/dskit/middleware/grpc_logging.go:87 +0x80
tempo-1  |   github.com/grafana/dskit/middleware.GRPCServerLog.StreamServerInterceptor-fm()
tempo-1  |       <autogenerated>:1 +0x88
tempo-1  |   google.golang.org/grpc.NewServer.chainStreamServerInterceptors.chainStreamInterceptors.func2()
tempo-1  |       /build/vendor/google.golang.org/grpc/server.go:1539 +0xac
tempo-1  |   google.golang.org/grpc.(*Server).processStreamingRPC()
tempo-1  |       /build/vendor/google.golang.org/grpc/server.go:1702 +0x1714
tempo-1  |   google.golang.org/grpc.(*Server).handleStream()
tempo-1  |       /build/vendor/google.golang.org/grpc/server.go:1819 +0xe14
tempo-1  |   google.golang.org/grpc.(*Server).serveStreams.func2.1()
tempo-1  |       /build/vendor/google.golang.org/grpc/server.go:1035 +0xe8
tempo-1  | 
tempo-1  | Previous read at 0x00c0016a6a80 by goroutine 695631:
tempo-1  |   github.com/grafana/tempo/modules/frontend/v1.(*requestBatch).doneChan.func1()
tempo-1  |       /build/modules/frontend/v1/request_batch.go:91 +0x84
tempo-1  | 
  ```
  
</details>

The impact is negligible. This occurs when all responses or errors are already been received. In such cases, pipelineRequests can be modified during the loop iteration, but will exit immediately afterward as the stop channel will be closed.

When happens. Process function runs goroutine ([here](https://github.com/grafana/tempo/blob/ab100cd8ef6235966b67f1b9f245ff9d3513dc40/modules/frontend/v1/frontend.go#L303) -> [here](https://github.com/grafana/tempo/blob/ab100cd8ef6235966b67f1b9f245ff9d3513dc40/modules/frontend/v1/request_batch.go#L86)). It [receives response](https://github.com/grafana/tempo/blob/ab100cd8ef6235966b67f1b9f245ff9d3513dc40/modules/frontend/v1/frontend.go#L315) and goes to the next loop iteration and calls [clear](https://github.com/grafana/tempo/blob/ab100cd8ef6235966b67f1b9f245ff9d3513dc40/modules/frontend/v1/frontend.go#L228) or [add](https://github.com/grafana/tempo/blob/ab100cd8ef6235966b67f1b9f245ff9d3513dc40/modules/frontend/v1/frontend.go#L240) while the goroutine [reads from changed pipelineRequests](https://github.com/grafana/tempo/blob/ab100cd8ef6235966b67f1b9f245ff9d3513dc40/modules/frontend/v1/request_batch.go#L91).


Fixed in commit `[bugfix] Fix race in request batching`

### Race 2
<details>
  <summary>Stack trace</summary>

  ```
tempo-1  | WARNING: DATA RACE
tempo-1  | Write at 0x00c007f1f590 by goroutine 8241039:
tempo-1  |   runtime.mapaccess2()
tempo-1  |       /usr/local/go/src/internal/runtime/maps/runtime_swiss.go:117 +0x2dc
tempo-1  |   github.com/grafana/tempo/pkg/traceql.(*GroupingAggregator[go.shape.[1]github.com/grafana/tempo/pkg/traceql.StaticMapKey,go.shape.[1]github.com/grafana/tempo/pkg/traceql.Static]).getSeries()
tempo-1  |       /build/pkg/traceql/engine_metrics.go:653 +0x2b4
tempo-1  |   github.com/grafana/tempo/pkg/traceql.(*GroupingAggregator[go.shape.[1]github.com/grafana/tempo/pkg/traceql.StaticMapKey,go.shape.[1]github.com/grafana/tempo/pkg/traceql.Static]).Observe()
tempo-1  |       /build/pkg/traceql/engine_metrics.go:668 +0x70
tempo-1  |   github.com/grafana/tempo/pkg/traceql.(*GroupingAggregator[github.com/grafana/tempo/pkg/traceql.FastStatic1,github.com/grafana/tempo/pkg/traceql.StaticVals1]).Observe()
tempo-1  |       /build/pkg/traceql/engine_metrics.go:663 +0x48
tempo-1  |   github.com/grafana/tempo/pkg/traceql.(*MetricsAggregate).observe()
tempo-1  |       /build/pkg/traceql/ast_metrics.go:243 +0x58
tempo-1  |   github.com/grafana/tempo/pkg/traceql.(*MetricsEvaluator).Do()
tempo-1  |       /build/pkg/traceql/engine_metrics.go:1107 +0x8b8
tempo-1  |   github.com/grafana/tempo/modules/generator/processor/localblocks.(*Processor).queryRangeWALBlock()
tempo-1  |       /build/modules/generator/processor/localblocks/query_range.go:155 +0x5c4
tempo-1  |   github.com/grafana/tempo/modules/generator/processor/localblocks.(*Processor).QueryRange.func3()
tempo-1  |       /build/modules/generator/processor/localblocks/query_range.go:97 +0xc8
tempo-1  |   github.com/grafana/tempo/modules/generator/processor/localblocks.(*Processor).QueryRange.gowrap3()
tempo-1  |       /build/modules/generator/processor/localblocks/query_range.go:104 +0x54
tempo-1  | 
tempo-1  | Previous read at 0x00c007f1f590 by goroutine 8241038:
tempo-1  |   github.com/grafana/tempo/pkg/traceql.(*GroupingAggregator[go.shape.[1]github.com/grafana/tempo/pkg/traceql.StaticMapKey,go.shape.[1]github.com/grafana/tempo/pkg/traceql.Static]).Length()
tempo-1  |       /build/pkg/traceql/engine_metrics.go:689 +0x4c
tempo-1  |   github.com/grafana/tempo/pkg/traceql.(*GroupingAggregator[github.com/grafana/tempo/pkg/traceql.FastStatic1,github.com/grafana/tempo/pkg/traceql.StaticVals1]).Length()
tempo-1  |       /build/pkg/traceql/engine_metrics.go:688 +0x24
tempo-1  |   github.com/grafana/tempo/pkg/traceql.(*MetricsAggregate).length()
tempo-1  |       /build/pkg/traceql/ast_metrics.go:267 +0x5c
tempo-1  |   github.com/grafana/tempo/pkg/traceql.(*MetricsEvaluator).Length()
tempo-1  |       /build/pkg/traceql/engine_metrics.go:1143 +0x12c
tempo-1  |   github.com/grafana/tempo/modules/generator/processor/localblocks.(*Processor).QueryRange.func2()
tempo-1  |       /build/modules/generator/processor/localblocks/query_range.go:77 +0x130
tempo-1  |   github.com/grafana/tempo/modules/generator/processor/localblocks.(*Processor).QueryRange.gowrap2()
tempo-1  |       /build/modules/generator/processor/localblocks/query_range.go:80 +0x54
tempo-1  | 
  ```
  
</details>

Two and more concurrent goroutines using shared var rawEval: https://github.com/grafana/tempo/blob/ab100cd8ef6235966b67f1b9f245ff9d3513dc40/modules/generator/processor/localblocks/query_range.go#L71-L80 and https://github.com/grafana/tempo/blob/ab100cd8ef6235966b67f1b9f245ff9d3513dc40/modules/generator/processor/localblocks/query_range.go#L95-L104


Fixed in commit `[bugfix] fix race in metrics evaluator`

### Race 3
<details>
  <summary>Stack trace</summary>

  ```
tempo-1  | WARNING: DATA RACE
tempo-1  | Read at 0x00c0235fdbc0 by goroutine 9038393:
tempo-1  |   github.com/grafana/tempo/pkg/traceql.(*anyCombiner).Count()
tempo-1  |       /build/pkg/traceql/combine.go:81 +0x40
tempo-1  |   github.com/grafana/tempo/pkg/traceql.(*anyCombiner).IsCompleteFor()
tempo-1  |       /build/pkg/traceql/combine.go:90 +0x50
tempo-1  |   github.com/grafana/tempo/modules/ingester.(*instance).Search.func1()
tempo-1  |       /build/modules/ingester/instance_search.go:74 +0x3a4
tempo-1  |   github.com/grafana/tempo/modules/ingester.(*instance).Search.func2()
tempo-1  |       /build/modules/ingester/instance_search.go:158 +0xdc
tempo-1  |   github.com/grafana/tempo/modules/ingester.(*instance).Search.gowrap3()
tempo-1  |       /build/modules/ingester/instance_search.go:159 +0x54
tempo-1  | 
tempo-1  | Previous write at 0x00c0235fdbc0 by goroutine 9038396:
tempo-1  |   runtime.mapaccess2()
tempo-1  |       /usr/local/go/src/internal/runtime/maps/runtime_swiss.go:117 +0x2dc
tempo-1  |   github.com/grafana/tempo/pkg/traceql.(*anyCombiner).AddMetadata()
tempo-1  |       /build/pkg/traceql/combine.go:76 +0x11c
tempo-1  |   github.com/grafana/tempo/modules/ingester.(*instance).Search.func1()
tempo-1  |       /build/modules/ingester/instance_search.go:115 +0xca8
tempo-1  |   github.com/grafana/tempo/modules/ingester.(*instance).Search.func3()
tempo-1  |       /build/modules/ingester/instance_search.go:169 +0xbc
tempo-1  |   github.com/grafana/tempo/modules/ingester.(*instance).Search.gowrap4()
tempo-1  |       /build/modules/ingester/instance_search.go:170 +0x44
tempo-1  | 
  ```

</details>

A set of goroutines uses `search` function: https://github.com/ruslan-mikhailov/tempo/blob/ab100cd8ef6235966b67f1b9f245ff9d3513dc40/modules/ingester/instance_search.go#L150-L172

The function contains [combiner](https://github.com/ruslan-mikhailov/tempo/blob/ab100cd8ef6235966b67f1b9f245ff9d3513dc40/modules/ingester/instance_search.go#L57) which is
```
type anyCombiner struct {
	trs   map[string]*tempopb.TraceSearchMetadata
	limit int
}
```
- protected read+write by mutex: https://github.com/ruslan-mikhailov/tempo/blob/ab100cd8ef6235966b67f1b9f245ff9d3513dc40/modules/ingester/instance_search.go#L106-L121
It contains write to a map: https://github.com/grafana/tempo/blob/main/pkg/traceql/combine.go#L76


- unprotected read: https://github.com/ruslan-mikhailov/tempo/blob/ab100cd8ef6235966b67f1b9f245ff9d3513dc40/modules/ingester/instance_search.go#L74-L76

which reads from the map:
```
func (c *anyCombiner) Count() int {
	return len(c.trs)
}

func (c *anyCombiner) IsCompleteFor(_ uint32) bool {
	return c.Count() >= c.limit && c.limit > 0
}
```

Fixed in commit `[bugfix] Fix race in search in ingesters`


### Race 4
<details>
  <summary>Stack trace</summary>

  ```
tempo-1  | WARNING: DATA RACE
tempo-1  | Write at 0x00c000d936c0 by goroutine 1232:
tempo-1  |   github.com/grafana/tempo/modules/frontend/v1.(*Frontend).Process()
tempo-1  |       /build/modules/frontend/v1/frontend.go:288 +0x4c8
tempo-1  |   github.com/grafana/tempo/modules/frontend/v1.(*Frontend).Process()
tempo-1  |       /build/modules/frontend/v1/frontend.go:205 +0x40
tempo-1  |   github.com/grafana/tempo/modules/frontend/v1/frontendv1pb._Frontend_Process_Handler()
tempo-1  |       /build/modules/frontend/v1/frontendv1pb/frontend.pb.go:437 +0xe8
tempo-1  |   github.com/grafana/tempo/cmd/tempo/app.init.func3()
tempo-1  |       /build/cmd/tempo/app/fake_auth.go:27 +0xcc
tempo-1  |   google.golang.org/grpc.getChainStreamHandler.func1()
tempo-1  |       /build/vendor/google.golang.org/grpc/server.go:1548 +0xd4
tempo-1  |   github.com/grafana/dskit/middleware.StreamServerInstrumentInterceptor.func1()
tempo-1  |       /build/vendor/github.com/grafana/dskit/middleware/grpc_instrumentation.go:62 +0x74
tempo-1  |   google.golang.org/grpc.getChainStreamHandler.func1()
tempo-1  |       /build/vendor/google.golang.org/grpc/server.go:1548 +0xd4
tempo-1  |   github.com/opentracing-contrib/go-grpc.OpenTracingStreamServerInterceptor.func1()
tempo-1  |       /build/vendor/github.com/opentracing-contrib/go-grpc/server.go:115 +0x334
tempo-1  |   google.golang.org/grpc.getChainStreamHandler.func1()
tempo-1  |       /build/vendor/google.golang.org/grpc/server.go:1548 +0xd4
tempo-1  |   github.com/grafana/dskit/middleware.GRPCServerLog.StreamServerInterceptor()
tempo-1  |       /build/vendor/github.com/grafana/dskit/middleware/grpc_logging.go:87 +0x80
tempo-1  |   github.com/grafana/dskit/middleware.GRPCServerLog.StreamServerInterceptor-fm()
tempo-1  |       <autogenerated>:1 +0x88
tempo-1  |   google.golang.org/grpc.NewServer.chainStreamServerInterceptors.chainStreamInterceptors.func2()
tempo-1  |       /build/vendor/google.golang.org/grpc/server.go:1539 +0xac
tempo-1  |   google.golang.org/grpc.(*Server).processStreamingRPC()
tempo-1  |       /build/vendor/google.golang.org/grpc/server.go:1702 +0x1714
tempo-1  |   google.golang.org/grpc.(*Server).handleStream()
tempo-1  |       /build/vendor/google.golang.org/grpc/server.go:1819 +0xe14
tempo-1  |   google.golang.org/grpc.(*Server).serveStreams.func2.1()
tempo-1  |       /build/vendor/google.golang.org/grpc/server.go:1035 +0xe8
tempo-1  | 
tempo-1  | Previous write at 0x00c000d936c0 by goroutine 9873960:
tempo-1  |   github.com/grafana/tempo/modules/frontend/v1.(*Frontend).Process.func1()
tempo-1  |       /build/modules/frontend/v1/frontend.go:264 +0x160
tempo-1  | 
  ```
  
</details>


Goroutine https://github.com/grafana/tempo/blob/ab100cd8ef6235966b67f1b9f245ff9d3513dc40/modules/frontend/v1/frontend.go#L259-L286 closures `err` var making a concurrent write with https://github.com/grafana/tempo/blob/ab100cd8ef6235966b67f1b9f245ff9d3513dc40/modules/frontend/v1/frontend.go#L288-L291

Fixed in commit `[bugfix] do not closure err to prevent race`

### Race 5
<details>
  <summary>Stack trace</summary>

  ```
tempo-1  | WARNING: DATA RACE
tempo-1  | Read at 0x00c025168aa0 by goroutine 25923308:
tempo-1  |   github.com/grafana/tempo/pkg/traceql.(*Engine).CompileMetricsQueryRange.func1()
tempo-1  |       /build/pkg/traceql/engine_metrics.go:903 +0x34
tempo-1  |   github.com/grafana/tempo/pkg/parquetquery.(*CallbackPredicate).KeepValue()
tempo-1  |       /build/pkg/parquetquery/predicates.go:480 +0x54
tempo-1  |   github.com/grafana/tempo/pkg/parquetquery.(*SyncIterator).next()
tempo-1  |       /build/pkg/parquetquery/iters.go:748 +0xa68
tempo-1  |   github.com/grafana/tempo/pkg/parquetquery.(*SyncIterator).Next()
tempo-1  |       /build/pkg/parquetquery/iters.go:454 +0x2c
tempo-1  |   github.com/grafana/tempo/pkg/parquetquery.(*LeftJoinIterator).collect.func1()
tempo-1  |       /build/pkg/parquetquery/iters.go:1518 +0x5a0
tempo-1  |   github.com/grafana/tempo/pkg/parquetquery.(*LeftJoinIterator).collect()
tempo-1  |       /build/pkg/parquetquery/iters.go:1536 +0x16c
tempo-1  |   github.com/grafana/tempo/pkg/parquetquery.(*LeftJoinIterator).Next()
tempo-1  |       /build/pkg/parquetquery/iters.go:1433 +0xf8
tempo-1  |   github.com/grafana/tempo/tempodb/encoding/vparquet4.(*rebatchIterator).Next()
tempo-1  |       /build/tempodb/encoding/vparquet4/block_traceql.go:1254 +0x1e8
tempo-1  |   github.com/grafana/tempo/tempodb/encoding/vparquet4.(*spansetIterator).Next()
tempo-1  |       /build/tempodb/encoding/vparquet4/block_traceql.go:1368 +0x40
tempo-1  |   github.com/grafana/tempo/tempodb/encoding/vparquet4.(*pageFileClosingIterator).Next()
tempo-1  |       /build/tempodb/encoding/vparquet4/wal_block.go:282 +0x48
tempo-1  |   github.com/grafana/tempo/tempodb/encoding/vparquet4.(*mergeSpansetIterator).Next()
tempo-1  |       /build/tempodb/encoding/vparquet4/block_traceql.go:1403 +0x88
tempo-1  |   github.com/grafana/tempo/pkg/traceql.(*MetricsEvaluator).Do()
tempo-1  |       /build/pkg/traceql/engine_metrics.go:1083 +0x354
tempo-1  |   github.com/grafana/tempo/modules/generator/processor/localblocks.(*Processor).queryRangeWALBlock()
tempo-1  |       /build/modules/generator/processor/localblocks/query_range.go:155 +0x5c4
tempo-1  |   github.com/grafana/tempo/modules/generator/processor/localblocks.(*Processor).QueryRange.func3()
tempo-1  |       /build/modules/generator/processor/localblocks/query_range.go:97 +0xc8
tempo-1  |   github.com/grafana/tempo/modules/generator/processor/localblocks.(*Processor).QueryRange.gowrap3()
tempo-1  |       /build/modules/generator/processor/localblocks/query_range.go:104 +0x54
tempo-1  | 
tempo-1  | Previous write at 0x00c025168aa0 by goroutine 25923307:
tempo-1  |   github.com/grafana/tempo/pkg/traceql.(*MetricsEvaluator).sampleExemplar()
tempo-1  |       /build/pkg/traceql/engine_metrics.go:1177 +0x4d4
tempo-1  |   github.com/grafana/tempo/pkg/traceql.(*MetricsEvaluator).Do()
tempo-1  |       /build/pkg/traceql/engine_metrics.go:1096 +0x374
tempo-1  |   github.com/grafana/tempo/modules/generator/processor/localblocks.(*Processor).queryRangeWALBlock()
tempo-1  |       /build/modules/generator/processor/localblocks/query_range.go:155 +0x5c4
tempo-1  |   github.com/grafana/tempo/modules/generator/processor/localblocks.(*Processor).QueryRange.func3()
tempo-1  |       /build/modules/generator/processor/localblocks/query_range.go:97 +0xc8
tempo-1  |   github.com/grafana/tempo/modules/generator/processor/localblocks.(*Processor).QueryRange.gowrap3()
tempo-1  |       /build/modules/generator/processor/localblocks/query_range.go:104 +0x54
tempo-1  | 
  ```
  
</details>

Two and more concurrent goroutines using shared var rawEval: https://github.com/grafana/tempo/blob/ab100cd8ef6235966b67f1b9f245ff9d3513dc40/modules/generator/processor/localblocks/query_range.go#L71-L80 and https://github.com/grafana/tempo/blob/ab100cd8ef6235966b67f1b9f245ff9d3513dc40/modules/generator/processor/localblocks/query_range.go#L95-L104 and operate over shared var `exemplarCount`:

- unprotected read: https://github.com/grafana/tempo/blob/ab100cd8ef6235966b67f1b9f245ff9d3513dc40/pkg/traceql/engine_metrics.go#L903
- protected write https://github.com/grafana/tempo/blob/ab100cd8ef6235966b67f1b9f245ff9d3513dc40/pkg/traceql/engine_metrics.go#L1177 -> https://github.com/grafana/tempo/blob/ab100cd8ef6235966b67f1b9f245ff9d3513dc40/pkg/traceql/engine_metrics.go#L1091-L1096

Fixed in commit `[bugfix] exemplar race fix`


## How the races have been detected and the fixes tested

1. Build Tempo image with race flag on
2. Run example/docker-compose/local (single binary has better chances to face race conditions)
3. Run k6 script to put read load on tempo:

<details>
  <summary>k6 script</summary>

  ```js
import http from 'k6/http';
import { sleep, check } from 'k6';
import { URL } from 'https://jslib.k6.io/url/1.0.0/index.js';

const vus = 50;
const iterations = 30;
const executor = 'per-vu-iterations';
// const executor = 'shared-iterations';


export const options = {
  scenarios: {
    basic: {
      executor: executor,
      vus: vus,
      iterations: iterations,
      exec: 'basicScenario',
    },
    countQuery: {
      executor: executor,
      vus: vus,
      iterations: iterations,
      exec: 'countQueryScenario',
    },
    avgDuration: {
      executor: executor,
      vus: vus,
      iterations: iterations,
      exec: 'avgDurationScenario',
    },
    minDuration: {
      executor: executor,
      vus: vus,
      iterations: iterations,
      exec: 'minDurationScenario',
    },
    maxDuration: {
      executor: executor,
      vus: vus,
      iterations: iterations,
      exec: 'maxDurationScenario',
    },
    sumDuration: {
      executor: executor,
      vus: vus,
      iterations: iterations,
      exec: 'sumDurationScenario',
    },
    idkQuery: {
      executor: executor,
      vus: vus,
      iterations: iterations,
      exec: 'idkQuery',
    },

    // TraceQL Metrics scenarios
    rate: {
      executor: executor,
      vus: vus,
      iterations: iterations,
      exec: 'rateScenario',
    },
    countOverTime: {
      executor: executor,
      vus: vus,
      iterations: iterations,
      exec: 'countOverTimeScenario',
    },
    countOverTimeByService: {
      executor: executor,
      vus: vus,
      iterations: iterations,
      exec: 'countOverTimeByServiceScenario',
    },
    minOverTime: {
      executor: executor,
      vus: vus,
      iterations: iterations,
      exec: 'minOverTimeScenario',
    },
    maxOverTime: {
      executor: executor,
      vus: vus,
      iterations: iterations,
      exec: 'maxOverTimeScenario',
    },
    avgOverTime: {
      executor: executor,
      vus: vus,
      iterations: iterations,
      exec: 'avgOverTimeScenario',
    },
    sumOverTime: {
      executor: executor,
      vus: vus,
      iterations: iterations,
      exec: 'sumOverTimeScenario',
    },
    quantileOverTime: {
      executor: executor,
      vus: vus,
      iterations: iterations,
      exec: 'quantileOverTimeScenario',
    },
    histogramOverTime: {
      executor: executor,
      vus: vus,
      iterations: iterations,
      exec: 'histogramOverTimeScenario',
    },
    compareEmpty: {
      executor: executor,
      vus: vus,
      iterations: iterations,
      exec: 'compareEmptyScenario',
    },
    compareTwoFilters: {
      executor: executor,
      vus: vus,
      iterations: iterations,
      exec: 'compareTwoFiltersScenario',
    },
    // Search Tag scenarios
    searchTag: {
      executor: executor,
      vus: vus,
      iterations: iterations,
      exec: 'searchTagScenario',
    },
    searchTagV2: {
      executor: executor,
      vus: vus,
      iterations: iterations,
      exec: 'searchTagV2Scenario',
    },
    searchTagValues: {
      executor: executor,
      vus: vus,
      iterations: iterations,
      exec: 'searchTagValuesScenario',
    },
    searchTagValuesV2: {
      executor: executor,
      vus: vus,
      iterations: iterations,
      exec: 'searchTagValuesV2Scenario',
    },
  },
};

const host = 'http://localhost:3200';

// Execute a search query and perform standard checks
function executeQuery(query) {
  const url = new URL(`${host}/api/search`);
  url.searchParams.append('q', query);

  let res = http.get(url.toString());
  check(res, { "status is 200": (res) => res.status === 200 });
  check(res, { "traces length is greater than 0": (res) => res.json().traces.length > 0 });
  
  sleep(1);
}

// Execute a metrics query and perform standard checks
function executeMetricsQuery(query, exemplars = 100) {
  const now = Math.floor(Date.now() / 1000);
  const oneHourAgo = now - 3600;
  const url = new URL(`${host}/api/metrics/query_range`);
  url.searchParams.append('q', query);
  url.searchParams.append('exemplars', exemplars.toString());
  url.searchParams.append('start', oneHourAgo.toString());
  url.searchParams.append('end', now.toString());
  url.searchParams.append('step', "1s");

  let res = http.get(url.toString());
  check(res, { "status is 200": (res) => res.status === 200 });
  
  sleep(1);
}

// Basic scenario with empty query
export function basicScenario() {
  executeQuery('{}');
}

// Count query scenario
export function countQueryScenario() {
  executeQuery('{} | count() > 2');
}

// Average duration scenario
export function avgDurationScenario() {
  executeQuery('{} | avg(duration) > 2');
}

// Min duration scenario
export function minDurationScenario() {
  executeQuery('{} | min(duration) > 2');
}

// Max duration scenario
export function maxDurationScenario() {
  executeQuery('{} | max(duration) > 2');
}

// Sum duration scenario
export function sumDurationScenario() {
  executeQuery('{} | sum(duration) > 2');
}

// Some random
export function idkQuery() {
  executeQuery('{} >> { link:traceID = "" }');
}

// TraceQL Metrics Scenarios

// Rate scenario
export function rateScenario() {
  executeMetricsQuery('{} | rate()');
}

// Count over time scenario
export function countOverTimeScenario() {
  executeMetricsQuery('{} | count_over_time()');
}

// Count over time by service name scenario
export function countOverTimeByServiceScenario() {
  executeMetricsQuery('{} | count_over_time() by (.service.name)');
}

// Min duration over time scenario
export function minOverTimeScenario() {
  executeMetricsQuery('{} | min_over_time(duration)');
}

// Max duration over time scenario
export function maxOverTimeScenario() {
  executeMetricsQuery('{} | max_over_time(duration)');
}

// Average duration over time scenario
export function avgOverTimeScenario() {
  executeMetricsQuery('{} | avg_over_time(duration)');
}

// Sum duration over time scenario
export function sumOverTimeScenario() {
  executeMetricsQuery('{} | sum_over_time(duration)');
}

// Quantile duration over time scenario
export function quantileOverTimeScenario() {
  executeMetricsQuery('{} | quantile_over_time(duration, .5)');
}

// Histogram duration over time scenario
export function histogramOverTimeScenario() {
  executeMetricsQuery('{} | histogram_over_time(duration)');
}

// Compare with empty set scenario
export function compareEmptyScenario() {
  executeMetricsQuery('{ .service.name="does_not_exist" } | compare({})');
}

// Compare two filters scenario
export function compareTwoFiltersScenario() {
  executeMetricsQuery('{ .service.name="does_not_exist" } | compare({ .service.name="does_not_exist_for_sure" })');
}

// For backwards compatibility, keeping the default function
export default function () {
  basicScenario();
}

export function searchTagScenario() {
  const url = new URL(`${host}/api/search/tags`);
  let res = http.get(url.toString());
  check(res, { "status is 200": (res) => res.status === 200 });
  check(res, { "tags length is greater than 0": (res) => res.json().tagNames.length > 0 });
  sleep(1);
}


export function searchTagV2Scenario() {
  const url = new URL(`${host}/api/v2/search/tags`);
  let res = http.get(url.toString());
  check(res, { "status is 200": (res) => res.status === 200 });
  sleep(1);
}

// Search tag values
// /api/search/tag/service.name/values
export function searchTagValuesScenario() {
  const url = new URL(`${host}/api/search/tag/service.name/values`);
  let res = http.get(url.toString());
  check(res, { "status is 200": (res) => res.status === 200 });
  sleep(1);
}

// Search tag values v2
// /api/v2/search/tag/.service.name/values
export function searchTagValuesV2Scenario() {
  const url = new URL(`${host}/api/v2/search/tag/.service.name/values`);
  let res = http.get(url.toString());
  check(res, { "status is 200": (res) => res.status === 200 });
  sleep(1);
}

  ```

</details>

  
Expected results: no races detected

## Which issue(s) this PR fixes
Fixes #<issue number>

## Checklist
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`