### PR TITLE
Drop `:latest` tags from `main` builds

### DIFF
--- a/.github/workflows/docker-ci-tools.yml
+++ b/.github/workflows/docker-ci-tools.yml
@@ -81,9 +81,3 @@ jobs:
           	--amend $IMAGE_NAME:$TAG-amd64  \
           	--amend $IMAGE_NAME:$TAG-arm64 
           docker manifest push $IMAGE_NAME:$TAG
-
-          docker manifest create \
-          	$IMAGE_NAME:latest            \
-          	--amend $IMAGE_NAME:$TAG-amd64   \
-          	--amend $IMAGE_NAME:$TAG-arm64 
-          docker manifest push $IMAGE_NAME:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -98,12 +98,6 @@ jobs:
           	--amend $IMAGE_NAME:$TAG-arm64
           docker manifest push $IMAGE_NAME:$TAG
 
-          docker manifest create \
-          	$IMAGE_NAME:latest            \
-          	--amend $IMAGE_NAME:$TAG-amd64   \
-          	--amend $IMAGE_NAME:$TAG-arm64
-          docker manifest push $IMAGE_NAME:latest
-
   cd-to-dev-env:
     # This job deploys the latest main commit to the dev environment
     if: github.repository == 'grafana/tempo' && github.ref == 'refs/heads/main'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [CHANGE] Update to go 1.24.3 [#5110](https://github.com/grafana/tempo/pull/5110) (@stoewer)
 * [CHANGE] Update to go 1.24.2 [#5057](https://github.com/grafana/tempo/pull/5057) [#5082](https://github.com/grafana/tempo/pull/5082) (@carsontham)
 * [CHANGE] Update to go 1.24.1 [#4704](https://github.com/grafana/tempo/pull/4704) (@ruslan-mikhailov) [#4793](https://github.com/grafana/tempo/pull/4793) (@javiermolinar)
+* [CHANGE] Stop pushing `:latest` docker image tags from `main` builds [#5116](https://github.com/grafana/tempo/pull/5116) (@zalegrala)
 * [FEATURE] Add throughput SLO and metrics for the TraceByID endpoint. [#4668](https://github.com/grafana/tempo/pull/4668) (@carles-grafana)
 configurable via the throughput_bytes_slo field, and it will populate op="traces" label in slo and throughput metrics.
 * [FEATURE] Added most_recent=true query hint to TraceQL to return most recent results. [#4238](https://github.com/grafana/tempo/pull/4238) (@joe-elliott)


### PR DESCRIPTION
**What this PR does**:

Here we drop the `:latest` tag from being applied to the `main` builds for the `tempo` and `tempo-ci-tools` images.

**Which issue(s) this PR fixes**:
Fixes #920

**Checklist**
- [x] CI updated
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`