### PR TITLE
Reset `SkipMetricsGeneration` field before reusing `PushBytesRequest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [BUGFIX] Various edge case fixes for query range (TraceQL Metrics) [#4962](https://github.com/grafana/tempo/pull/4962) (@ruslan-mikhailov)
 * [BUGFIX] Fix mixin to include otlp_v1_traces http write route [#5072](https://github.com/grafana/tempo/pull/5072) (@mdisibio)
 * [BUGFIX] Fix `TempoBlockListRisingQuickly` alert grouping. [#4876](https://github.com/grafana/tempo/pull/4876) (@mapno)
+* [BUGFIX] Reset `SkipMetricsGeneration` before reuse. [#5117](https://github.com/grafana/tempo/pull/5117) (@flxbk)
 
 # v2.7.2
 

--- a/pkg/ingest/encoding.go
+++ b/pkg/ingest/encoding.go
@@ -34,6 +34,7 @@ func encoderPoolGet() *tempopb.PushBytesRequest {
 func encoderPoolPut(req *tempopb.PushBytesRequest) {
 	req.Traces = req.Traces[:0]
 	req.Ids = req.Ids[:0]
+	req.SkipMetricsGeneration = false
 	encoderPool.Put(req)
 }
 
@@ -139,6 +140,7 @@ func (d *Decoder) Reset() {
 	// Retain slice capacity
 	d.req.Ids = d.req.Ids[:0]
 	d.req.Traces = d.req.Traces[:0]
+	d.req.SkipMetricsGeneration = false
 }
 
 // sovPush calculates the size of varint-encoded uint64.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This PR resets the field `SkipMetricsGeneration` introduced in #4728 before reusing the containing `PushBytesRequest` struct. Without this, if there's a tenant for which this flag is set, all other tenants will also have that flag set most of the time.

Since the affected code path is used only in the new architecture, the classic architecture is not affected by this.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`