### PR TITLE
TraceQL: Allow comparison duration to float

### DIFF
--- a/tempodb/encoding/vparquet2/block_traceql.go
+++ b/tempodb/encoding/vparquet2/block_traceql.go
@@ -1372,7 +1372,7 @@ func createSpanIterator(makeIter makeIterFn, primaryIter parquetquery.Iterator, 
 			continue
 
 		case traceql.IntrinsicDuration:
-			pred, err := createIntPredicate(cond.Op, cond.Operands)
+			pred, err := createDurationPredicate(cond.Op, cond.Operands)
 			if err != nil {
 				return nil, err
 			}
@@ -1727,6 +1727,85 @@ func createBytesPredicate(op traceql.Operator, operands traceql.Operands, isSpan
 	default:
 		return nil, fmt.Errorf("operator not supported for IDs: %+v", op)
 	}
+}
+
+func createDurationPredicate(op traceql.Operator, operands traceql.Operands) (parquetquery.Predicate, error) {
+	if op == traceql.OpNone {
+		return nil, nil
+	}
+
+	if operands[0].Type == traceql.TypeFloat {
+		// The column is already indexed as int, so we need to convert the float to int
+		return createIntPredicateFromFloat(op, operands)
+	}
+
+	return createIntPredicate(op, operands)
+}
+
+// createIntPredicateFromFloat adapts a float-based query operand to an int column.
+// If the float is exactly representable as an int64 (e.g. 42.0), we compare the
+// column to that integer. Otherwise, if the float is non-integer or out of the
+// int64 range, we return a "trivial" outcome:
+//
+//   - "=" on a non-integer float returns nil, meaning "no filter"
+//   - "!=" on a non-integer float always matches, implemented as a predicate
+//     that returns true for every row.
+//   - For "<", "<=", ">", ">=", we shift the boundary to the nearest integer.
+//     For example, "x < 10.3" becomes "x <= 10" for the int column.
+//
+// Note: If returning nil, no column-level filtering is applied for this condition.
+func createIntPredicateFromFloat(op traceql.Operator, operands traceql.Operands) (parquetquery.Predicate, error) {
+	if op == traceql.OpNone {
+		return nil, nil
+	}
+
+	if operands[0].Type != traceql.TypeFloat {
+		return nil, fmt.Errorf("operand is not float: %s", operands[0].EncodeToString(false))
+	}
+	f := operands[0].Float()
+
+	if math.IsNaN(f) {
+		return nil, nil
+	}
+
+	// Check if it's in [MinInt64, MaxInt64) range, and if so, see if it's an integer.
+	if float64(math.MinInt64) <= f && f < float64(math.MaxInt64) {
+		if intPart, frac := math.Modf(f); frac == 0 {
+			intOperands := traceql.Operands{traceql.NewStaticInt(int(intPart))}
+			return createIntPredicate(op, intOperands)
+		}
+	}
+
+	switch op {
+	case traceql.OpEqual:
+		return nil, nil
+	case traceql.OpNotEqual:
+		return parquetquery.NewCallbackPredicate(func() bool { return true }), nil
+	case traceql.OpGreater, traceql.OpGreaterEqual:
+		if f < float64(math.MinInt64) {
+			return parquetquery.NewCallbackPredicate(func() bool { return true }), nil
+		} else if float64(math.MaxInt64) <= f {
+			return nil, nil
+		} else if 0 < f {
+			// "x > 10.3" -> "x >= 11"
+			return parquetquery.NewIntGreaterEqualPredicate(int64(f) + 1), nil
+		}
+		// "x > -2.7" -> "x >= -2"
+		return parquetquery.NewIntGreaterEqualPredicate(int64(f)), nil
+	case traceql.OpLess, traceql.OpLessEqual:
+		if f < float64(math.MinInt64) {
+			return nil, nil
+		} else if float64(math.MaxInt64) <= f {
+			return parquetquery.NewCallbackPredicate(func() bool { return true }), nil
+		} else if f < 0 {
+			// "x < -2.7" -> "x <= -3"
+			return parquetquery.NewIntLessEqualPredicate(int64(f) - 1), nil
+		}
+		// "x < 10.3" -> "x <= 10"
+		return parquetquery.NewIntLessEqualPredicate(int64(f)), nil
+	}
+
+	return nil, fmt.Errorf("operator not supported for integers: %v", op)
 }
 
 func createIntPredicate(op traceql.Operator, operands traceql.Operands) (parquetquery.Predicate, error) {

--- a/tempodb/encoding/vparquet2/block_traceql.go
+++ b/tempodb/encoding/vparquet2/block_traceql.go
@@ -1590,7 +1590,7 @@ func createTraceIterator(makeIter makeIterFn, resourceIter parquetquery.Iterator
 			}
 			iters = append(iters, makeIter(columnPathTraceID, pred, columnPathTraceID))
 		case traceql.IntrinsicTraceDuration:
-			pred, err := createIntPredicate(cond.Op, cond.Operands)
+			pred, err := createDurationPredicate(cond.Op, cond.Operands)
 			if err != nil {
 				return nil, err
 			}

--- a/tempodb/encoding/vparquet2/block_traceql_test.go
+++ b/tempodb/encoding/vparquet2/block_traceql_test.go
@@ -4,12 +4,15 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"math/rand"
 	"path"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/parquet-go/parquet-go"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/tempo/pkg/tempopb"
@@ -23,6 +26,128 @@ import (
 	"github.com/grafana/tempo/tempodb/backend/local"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
+
+func TestCreateIntPredicateFromFloat(t *testing.T) {
+	f := func(query string, predicate string) {
+		req := traceql.MustExtractFetchSpansRequestWithMetadata(query)
+		require.Len(t, req.Conditions, 1)
+		p, err := createIntPredicateFromFloat(req.Conditions[0].Op, req.Conditions[0].Operands)
+		require.NoError(t, err)
+		np := "nil"
+		if p != nil {
+			r := strings.NewReplacer(
+				"IntEqualPredicate", "=",
+				"IntNotEqualPredicate", "!=",
+				"IntLessPredicate", "<",
+				"IntLessEqualPredicate", "<=",
+				"IntGreaterEqualPredicate", ">=",
+				"IntGreaterPredicate", ">",
+			)
+			np = r.Replace(p.String())
+			if np == "CallbackPredicate{}" {
+				if p.KeepValue(parquet.Value{}) {
+					np = "callback:true"
+				} else {
+					np = "callback:false"
+				}
+			}
+		}
+		require.Equal(t, predicate, np, "query:%s", query)
+	}
+	fe := func(query string, errorMessage string) {
+		req := traceql.MustExtractFetchSpansRequestWithMetadata(query)
+		require.Len(t, req.Conditions, 1)
+		_, err := createIntPredicateFromFloat(req.Conditions[0].Op, req.Conditions[0].Operands)
+		require.EqualError(t, err, errorMessage, "query:%s", query)
+	}
+
+	{
+		p, err := createIntPredicateFromFloat(traceql.OpNone, nil)
+		require.NoError(t, err)
+		require.Nil(t, p)
+	}
+	{
+		p, err := createIntPredicateFromFloat(traceql.OpEqual, traceql.Operands{traceql.NewStaticFloat(math.NaN())})
+		require.NoError(t, err)
+		require.Nil(t, p)
+	}
+
+	// Every float64 in range [math.MinInt64, math.MaxInt64) can be converted to int64 exactly,
+	// but you need to consider a fractional part of the float64 to adjust an operator.
+	// It's worth noting that float64 can have a fractional part
+	// in the range (-float64(1<<52)-0.5, float64(1<<52)+0.5)
+	f(`{.attr = -123.1}`, `nil`)
+	f(`{.attr != -123.1}`, `callback:true`)
+	f(`{.attr < -123.1}`, `<={-124}`)
+	f(`{.attr <= -123.1}`, `<={-124}`)
+	f(`{.attr > -123.1}`, `>={-123}`)
+	f(`{.attr >= -123.1}`, `>={-123}`)
+
+	f(`{.attr = -123.0}`, `={-123}`)
+	f(`{.attr != -123.0}`, `!={-123}`)
+	f(`{.attr < -123.0}`, `<{-123}`)
+	f(`{.attr <= -123.0}`, `<={-123}`)
+	f(`{.attr > -123.0}`, `>{-123}`)
+	f(`{.attr >= -123.0}`, `>={-123}`)
+
+	f(`{.attr = 123.0}`, `={123}`)
+	f(`{.attr != 123.0}`, `!={123}`)
+	f(`{.attr < 123.0}`, `<{123}`)
+	f(`{.attr <= 123.0}`, `<={123}`)
+	f(`{.attr > 123.0}`, `>{123}`)
+	f(`{.attr >= 123.0}`, `>={123}`)
+
+	f(`{.attr = 123.1}`, `nil`)
+	f(`{.attr != 123.1}`, `callback:true`)
+	f(`{.attr < 123.1}`, `<={123}`)
+	f(`{.attr <= 123.1}`, `<={123}`)
+	f(`{.attr > 123.1}`, `>={124}`)
+	f(`{.attr >= 123.1}`, `>={124}`)
+
+	// [MaxInt64, +Inf)
+	f(`{.attr = 9.223372036854776e+18}`, `nil`)
+	f(`{.attr != 9.223372036854776e+18}`, `callback:true`)
+	f(`{.attr > 9.223372036854776e+18}`, `nil`)
+	f(`{.attr >= 9.223372036854776e+18}`, `nil`)
+	f(`{.attr < 9.223372036854776e+18}`, `callback:true`)
+	f(`{.attr <= 9.223372036854776e+18}`, `callback:true`)
+
+	// (-Inf, MinInt64)
+	f(`{.attr = -9.223372036854777e+18}`, `nil`)
+	f(`{.attr != -9.223372036854777e+18}`, `callback:true`)
+	f(`{.attr > -9.223372036854777e+18}`, `callback:true`)
+	f(`{.attr >= -9.223372036854777e+18}`, `callback:true`)
+	f(`{.attr < -9.223372036854777e+18}`, `nil`)
+	f(`{.attr <= -9.223372036854777e+18}`, `nil`)
+
+	fe(`{.attr = 1}`, `operand is not float: 1`)
+	fe(`{.attr =~ -1.2}`, `operator not supported for integers: =~`)
+}
+
+func TestCreateNumericPredicate(t *testing.T) {
+	t.Run("none", func(t *testing.T) {
+		p, err := createDurationPredicate(traceql.OpNone, nil)
+		require.NoError(t, err)
+		require.Nil(t, p)
+	})
+
+	t.Run("float", func(t *testing.T) {
+		p, err := createDurationPredicate(traceql.OpGreater, traceql.Operands{traceql.NewStaticFloat(1.2)})
+		require.NoError(t, err)
+		require.Equal(t, "IntGreaterEqualPredicate{2}", p.String())
+	})
+
+	t.Run("int", func(t *testing.T) {
+		p, err := createDurationPredicate(traceql.OpGreater, traceql.Operands{traceql.NewStaticFloat(1)})
+		require.NoError(t, err)
+		require.Equal(t, "IntGreaterPredicate{1}", p.String())
+	})
+
+	t.Run("it forwards errors", func(t *testing.T) {
+		_, err := createDurationPredicate(traceql.OpGreater, traceql.Operands{traceql.NewStaticBool(true)})
+		require.EqualError(t, err, `operand is not int, duration, status or kind: true`)
+	})
+}
 
 func TestOne(t *testing.T) {
 	wantTr := fullyPopulatedTestTrace(nil)

--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -2088,27 +2088,31 @@ func createIntPredicateFromFloat(op traceql.Operator, operands traceql.Operands)
 	case traceql.OpNotEqual:
 		return parquetquery.NewCallbackPredicate(func() bool { return true }), nil
 	case traceql.OpGreater, traceql.OpGreaterEqual:
-		if f < float64(math.MinInt64) {
+		switch {
+		case f < float64(math.MinInt64):
 			return parquetquery.NewCallbackPredicate(func() bool { return true }), nil
-		} else if float64(math.MaxInt64) <= f {
+		case float64(math.MaxInt64) <= f:
 			return nil, nil
-		} else if 0 < f {
+		case 0 < f:
 			// "x > 10.3" -> "x >= 11"
 			return parquetquery.NewIntGreaterEqualPredicate(int64(f) + 1), nil
+		default:
+			// "x > -2.7" -> "x >= -2"
+			return parquetquery.NewIntGreaterEqualPredicate(int64(f)), nil
 		}
-		// "x > -2.7" -> "x >= -2"
-		return parquetquery.NewIntGreaterEqualPredicate(int64(f)), nil
 	case traceql.OpLess, traceql.OpLessEqual:
-		if f < float64(math.MinInt64) {
+		switch {
+		case f < float64(math.MinInt64):
 			return nil, nil
-		} else if float64(math.MaxInt64) <= f {
+		case float64(math.MaxInt64) <= f:
 			return parquetquery.NewCallbackPredicate(func() bool { return true }), nil
-		} else if f < 0 {
+		case f < 0:
 			// "x < -2.7" -> "x <= -3"
 			return parquetquery.NewIntLessEqualPredicate(int64(f) - 1), nil
+		default:
+			// "x < 10.3" -> "x <= 10"
+			return parquetquery.NewIntLessEqualPredicate(int64(f)), nil
 		}
-		// "x < 10.3" -> "x <= 10"
-		return parquetquery.NewIntLessEqualPredicate(int64(f)), nil
 	}
 
 	return nil, fmt.Errorf("operator not supported for integers: %v", op)

--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -1880,7 +1880,7 @@ func createTraceIterator(makeIter makeIterFn, resourceIter parquetquery.Iterator
 			}
 			iters = append(iters, makeIter(columnPathTraceID, pred, columnPathTraceID))
 		case traceql.IntrinsicTraceDuration:
-			pred, err := createIntPredicate(cond.Op, cond.Operands)
+			pred, err := createDurationPredicate(cond.Op, cond.Operands)
 			if err != nil {
 				return nil, err
 			}

--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -1531,7 +1531,7 @@ func createSpanIterator(makeIter makeIterFn, primaryIter parquetquery.Iterator, 
 			continue
 
 		case traceql.IntrinsicDuration:
-			pred, err := createIntPredicate(cond.Op, cond.Operands)
+			pred, err := createDurationPredicate(cond.Op, cond.Operands)
 			if err != nil {
 				return nil, err
 			}
@@ -2033,6 +2033,85 @@ func createBytesPredicate(op traceql.Operator, operands traceql.Operands, isSpan
 	default:
 		return nil, fmt.Errorf("operator not supported for IDs: %+v", op)
 	}
+}
+
+func createDurationPredicate(op traceql.Operator, operands traceql.Operands) (parquetquery.Predicate, error) {
+	if op == traceql.OpNone {
+		return nil, nil
+	}
+
+	if operands[0].Type == traceql.TypeFloat {
+		// The column is already indexed as int, so we need to convert the float to int
+		return createIntPredicateFromFloat(op, operands)
+	}
+
+	return createIntPredicate(op, operands)
+}
+
+// createIntPredicateFromFloat adapts a float-based query operand to an int column.
+// If the float is exactly representable as an int64 (e.g. 42.0), we compare the
+// column to that integer. Otherwise, if the float is non-integer or out of the
+// int64 range, we return a "trivial" outcome:
+//
+//   - "=" on a non-integer float returns nil, meaning "no filter"
+//   - "!=" on a non-integer float always matches, implemented as a predicate
+//     that returns true for every row.
+//   - For "<", "<=", ">", ">=", we shift the boundary to the nearest integer.
+//     For example, "x < 10.3" becomes "x <= 10" for the int column.
+//
+// Note: If returning nil, no column-level filtering is applied for this condition.
+func createIntPredicateFromFloat(op traceql.Operator, operands traceql.Operands) (parquetquery.Predicate, error) {
+	if op == traceql.OpNone {
+		return nil, nil
+	}
+
+	if operands[0].Type != traceql.TypeFloat {
+		return nil, fmt.Errorf("operand is not float: %s", operands[0].EncodeToString(false))
+	}
+	f := operands[0].Float()
+
+	if math.IsNaN(f) {
+		return nil, nil
+	}
+
+	// Check if it's in [MinInt64, MaxInt64) range, and if so, see if it's an integer.
+	if float64(math.MinInt64) <= f && f < float64(math.MaxInt64) {
+		if intPart, frac := math.Modf(f); frac == 0 {
+			intOperands := traceql.Operands{traceql.NewStaticInt(int(intPart))}
+			return createIntPredicate(op, intOperands)
+		}
+	}
+
+	switch op {
+	case traceql.OpEqual:
+		return nil, nil
+	case traceql.OpNotEqual:
+		return parquetquery.NewCallbackPredicate(func() bool { return true }), nil
+	case traceql.OpGreater, traceql.OpGreaterEqual:
+		if f < float64(math.MinInt64) {
+			return parquetquery.NewCallbackPredicate(func() bool { return true }), nil
+		} else if float64(math.MaxInt64) <= f {
+			return nil, nil
+		} else if 0 < f {
+			// "x > 10.3" -> "x >= 11"
+			return parquetquery.NewIntGreaterEqualPredicate(int64(f) + 1), nil
+		}
+		// "x > -2.7" -> "x >= -2"
+		return parquetquery.NewIntGreaterEqualPredicate(int64(f)), nil
+	case traceql.OpLess, traceql.OpLessEqual:
+		if f < float64(math.MinInt64) {
+			return nil, nil
+		} else if float64(math.MaxInt64) <= f {
+			return parquetquery.NewCallbackPredicate(func() bool { return true }), nil
+		} else if f < 0 {
+			// "x < -2.7" -> "x <= -3"
+			return parquetquery.NewIntLessEqualPredicate(int64(f) - 1), nil
+		}
+		// "x < 10.3" -> "x <= 10"
+		return parquetquery.NewIntLessEqualPredicate(int64(f)), nil
+	}
+
+	return nil, fmt.Errorf("operator not supported for integers: %v", op)
 }
 
 func createIntPredicate(op traceql.Operator, operands traceql.Operands) (parquetquery.Predicate, error) {

--- a/tempodb/encoding/vparquet3/block_traceql_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_test.go
@@ -4,13 +4,16 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"math/rand"
 	"path"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/parquet-go/parquet-go"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/tempo/pkg/tempopb"
@@ -23,6 +26,128 @@ import (
 	"github.com/grafana/tempo/tempodb/backend/local"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
+
+func TestCreateIntPredicateFromFloat(t *testing.T) {
+	f := func(query string, predicate string) {
+		req := traceql.MustExtractFetchSpansRequestWithMetadata(query)
+		require.Len(t, req.Conditions, 1)
+		p, err := createIntPredicateFromFloat(req.Conditions[0].Op, req.Conditions[0].Operands)
+		require.NoError(t, err)
+		np := "nil"
+		if p != nil {
+			r := strings.NewReplacer(
+				"IntEqualPredicate", "=",
+				"IntNotEqualPredicate", "!=",
+				"IntLessPredicate", "<",
+				"IntLessEqualPredicate", "<=",
+				"IntGreaterEqualPredicate", ">=",
+				"IntGreaterPredicate", ">",
+			)
+			np = r.Replace(p.String())
+			if np == "CallbackPredicate{}" {
+				if p.KeepValue(parquet.Value{}) {
+					np = "callback:true"
+				} else {
+					np = "callback:false"
+				}
+			}
+		}
+		require.Equal(t, predicate, np, "query:%s", query)
+	}
+	fe := func(query string, errorMessage string) {
+		req := traceql.MustExtractFetchSpansRequestWithMetadata(query)
+		require.Len(t, req.Conditions, 1)
+		_, err := createIntPredicateFromFloat(req.Conditions[0].Op, req.Conditions[0].Operands)
+		require.EqualError(t, err, errorMessage, "query:%s", query)
+	}
+
+	{
+		p, err := createIntPredicateFromFloat(traceql.OpNone, nil)
+		require.NoError(t, err)
+		require.Nil(t, p)
+	}
+	{
+		p, err := createIntPredicateFromFloat(traceql.OpEqual, traceql.Operands{traceql.NewStaticFloat(math.NaN())})
+		require.NoError(t, err)
+		require.Nil(t, p)
+	}
+
+	// Every float64 in range [math.MinInt64, math.MaxInt64) can be converted to int64 exactly,
+	// but you need to consider a fractional part of the float64 to adjust an operator.
+	// It's worth noting that float64 can have a fractional part
+	// in the range (-float64(1<<52)-0.5, float64(1<<52)+0.5)
+	f(`{.attr = -123.1}`, `nil`)
+	f(`{.attr != -123.1}`, `callback:true`)
+	f(`{.attr < -123.1}`, `<={-124}`)
+	f(`{.attr <= -123.1}`, `<={-124}`)
+	f(`{.attr > -123.1}`, `>={-123}`)
+	f(`{.attr >= -123.1}`, `>={-123}`)
+
+	f(`{.attr = -123.0}`, `={-123}`)
+	f(`{.attr != -123.0}`, `!={-123}`)
+	f(`{.attr < -123.0}`, `<{-123}`)
+	f(`{.attr <= -123.0}`, `<={-123}`)
+	f(`{.attr > -123.0}`, `>{-123}`)
+	f(`{.attr >= -123.0}`, `>={-123}`)
+
+	f(`{.attr = 123.0}`, `={123}`)
+	f(`{.attr != 123.0}`, `!={123}`)
+	f(`{.attr < 123.0}`, `<{123}`)
+	f(`{.attr <= 123.0}`, `<={123}`)
+	f(`{.attr > 123.0}`, `>{123}`)
+	f(`{.attr >= 123.0}`, `>={123}`)
+
+	f(`{.attr = 123.1}`, `nil`)
+	f(`{.attr != 123.1}`, `callback:true`)
+	f(`{.attr < 123.1}`, `<={123}`)
+	f(`{.attr <= 123.1}`, `<={123}`)
+	f(`{.attr > 123.1}`, `>={124}`)
+	f(`{.attr >= 123.1}`, `>={124}`)
+
+	// [MaxInt64, +Inf)
+	f(`{.attr = 9.223372036854776e+18}`, `nil`)
+	f(`{.attr != 9.223372036854776e+18}`, `callback:true`)
+	f(`{.attr > 9.223372036854776e+18}`, `nil`)
+	f(`{.attr >= 9.223372036854776e+18}`, `nil`)
+	f(`{.attr < 9.223372036854776e+18}`, `callback:true`)
+	f(`{.attr <= 9.223372036854776e+18}`, `callback:true`)
+
+	// (-Inf, MinInt64)
+	f(`{.attr = -9.223372036854777e+18}`, `nil`)
+	f(`{.attr != -9.223372036854777e+18}`, `callback:true`)
+	f(`{.attr > -9.223372036854777e+18}`, `callback:true`)
+	f(`{.attr >= -9.223372036854777e+18}`, `callback:true`)
+	f(`{.attr < -9.223372036854777e+18}`, `nil`)
+	f(`{.attr <= -9.223372036854777e+18}`, `nil`)
+
+	fe(`{.attr = 1}`, `operand is not float: 1`)
+	fe(`{.attr =~ -1.2}`, `operator not supported for integers: =~`)
+}
+
+func TestCreateNumericPredicate(t *testing.T) {
+	t.Run("none", func(t *testing.T) {
+		p, err := createDurationPredicate(traceql.OpNone, nil)
+		require.NoError(t, err)
+		require.Nil(t, p)
+	})
+
+	t.Run("float", func(t *testing.T) {
+		p, err := createDurationPredicate(traceql.OpGreater, traceql.Operands{traceql.NewStaticFloat(1.2)})
+		require.NoError(t, err)
+		require.Equal(t, "IntGreaterEqualPredicate{2}", p.String())
+	})
+
+	t.Run("int", func(t *testing.T) {
+		p, err := createDurationPredicate(traceql.OpGreater, traceql.Operands{traceql.NewStaticFloat(1)})
+		require.NoError(t, err)
+		require.Equal(t, "IntGreaterPredicate{1}", p.String())
+	})
+
+	t.Run("it forwards errors", func(t *testing.T) {
+		_, err := createDurationPredicate(traceql.OpGreater, traceql.Operands{traceql.NewStaticBool(true)})
+		require.EqualError(t, err, `operand is not int, duration, status or kind: true`)
+	})
+}
 
 func TestOne(t *testing.T) {
 	wantTr := fullyPopulatedTestTrace(nil)

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -2562,27 +2562,31 @@ func createIntPredicateFromFloat(op traceql.Operator, operands traceql.Operands)
 	case traceql.OpNotEqual:
 		return parquetquery.NewCallbackPredicate(func() bool { return true }), nil
 	case traceql.OpGreater, traceql.OpGreaterEqual:
-		if f < float64(math.MinInt64) {
+		switch {
+		case f < float64(math.MinInt64):
 			return parquetquery.NewCallbackPredicate(func() bool { return true }), nil
-		} else if float64(math.MaxInt64) <= f {
+		case float64(math.MaxInt64) <= f:
 			return nil, nil
-		} else if 0 < f {
+		case 0 < f:
 			// "x > 10.3" -> "x >= 11"
 			return parquetquery.NewIntGreaterEqualPredicate(int64(f) + 1), nil
+		default:
+			// "x > -2.7" -> "x >= -2"
+			return parquetquery.NewIntGreaterEqualPredicate(int64(f)), nil
 		}
-		// "x > -2.7" -> "x >= -2"
-		return parquetquery.NewIntGreaterEqualPredicate(int64(f)), nil
 	case traceql.OpLess, traceql.OpLessEqual:
-		if f < float64(math.MinInt64) {
+		switch {
+		case f < float64(math.MinInt64):
 			return nil, nil
-		} else if float64(math.MaxInt64) <= f {
+		case float64(math.MaxInt64) <= f:
 			return parquetquery.NewCallbackPredicate(func() bool { return true }), nil
-		} else if f < 0 {
+		case f < 0:
 			// "x < -2.7" -> "x <= -3"
 			return parquetquery.NewIntLessEqualPredicate(int64(f) - 1), nil
+		default:
+			// "x < 10.3" -> "x <= 10"
+			return parquetquery.NewIntLessEqualPredicate(int64(f)), nil
 		}
-		// "x < 10.3" -> "x <= 10"
-		return parquetquery.NewIntLessEqualPredicate(int64(f)), nil
 	}
 
 	return nil, fmt.Errorf("operator not supported for integers: %v", op)

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -2364,7 +2364,7 @@ func createTraceIterator(makeIter makeIterFn, resourceIter parquetquery.Iterator
 					iters = append(iters, makeIter(columnPathTraceID, pred, columnPathTraceID))
 				}
 			case traceql.IntrinsicTraceDuration:
-				pred, err := createIntPredicate(cond.Op, cond.Operands)
+				pred, err := createDurationPredicate(cond.Op, cond.Operands)
 				if err != nil {
 					return nil, err
 				}

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -1907,7 +1907,7 @@ func createSpanIterator(makeIter makeIterFn, innerIterators []parquetquery.Itera
 			continue
 
 		case traceql.IntrinsicDuration:
-			pred, err := createIntPredicate(cond.Op, cond.Operands)
+			pred, err := createDurationPredicate(cond.Op, cond.Operands)
 			if err != nil {
 				return nil, err
 			}
@@ -2507,6 +2507,85 @@ func createBytesPredicate(op traceql.Operator, operands traceql.Operands, isSpan
 	default:
 		return nil, fmt.Errorf("operator not supported for IDs: %+v", op)
 	}
+}
+
+func createDurationPredicate(op traceql.Operator, operands traceql.Operands) (parquetquery.Predicate, error) {
+	if op == traceql.OpNone {
+		return nil, nil
+	}
+
+	if operands[0].Type == traceql.TypeFloat {
+		// The column is already indexed as int, so we need to convert the float to int
+		return createIntPredicateFromFloat(op, operands)
+	}
+
+	return createIntPredicate(op, operands)
+}
+
+// createIntPredicateFromFloat adapts a float-based query operand to an int column.
+// If the float is exactly representable as an int64 (e.g. 42.0), we compare the
+// column to that integer. Otherwise, if the float is non-integer or out of the
+// int64 range, we return a "trivial" outcome:
+//
+//   - "=" on a non-integer float returns nil, meaning "no filter"
+//   - "!=" on a non-integer float always matches, implemented as a predicate
+//     that returns true for every row.
+//   - For "<", "<=", ">", ">=", we shift the boundary to the nearest integer.
+//     For example, "x < 10.3" becomes "x <= 10" for the int column.
+//
+// Note: If returning nil, no column-level filtering is applied for this condition.
+func createIntPredicateFromFloat(op traceql.Operator, operands traceql.Operands) (parquetquery.Predicate, error) {
+	if op == traceql.OpNone {
+		return nil, nil
+	}
+
+	if operands[0].Type != traceql.TypeFloat {
+		return nil, fmt.Errorf("operand is not float: %s", operands[0].EncodeToString(false))
+	}
+	f := operands[0].Float()
+
+	if math.IsNaN(f) {
+		return nil, nil
+	}
+
+	// Check if it's in [MinInt64, MaxInt64) range, and if so, see if it's an integer.
+	if float64(math.MinInt64) <= f && f < float64(math.MaxInt64) {
+		if intPart, frac := math.Modf(f); frac == 0 {
+			intOperands := traceql.Operands{traceql.NewStaticInt(int(intPart))}
+			return createIntPredicate(op, intOperands)
+		}
+	}
+
+	switch op {
+	case traceql.OpEqual:
+		return nil, nil
+	case traceql.OpNotEqual:
+		return parquetquery.NewCallbackPredicate(func() bool { return true }), nil
+	case traceql.OpGreater, traceql.OpGreaterEqual:
+		if f < float64(math.MinInt64) {
+			return parquetquery.NewCallbackPredicate(func() bool { return true }), nil
+		} else if float64(math.MaxInt64) <= f {
+			return nil, nil
+		} else if 0 < f {
+			// "x > 10.3" -> "x >= 11"
+			return parquetquery.NewIntGreaterEqualPredicate(int64(f) + 1), nil
+		}
+		// "x > -2.7" -> "x >= -2"
+		return parquetquery.NewIntGreaterEqualPredicate(int64(f)), nil
+	case traceql.OpLess, traceql.OpLessEqual:
+		if f < float64(math.MinInt64) {
+			return nil, nil
+		} else if float64(math.MaxInt64) <= f {
+			return parquetquery.NewCallbackPredicate(func() bool { return true }), nil
+		} else if f < 0 {
+			// "x < -2.7" -> "x <= -3"
+			return parquetquery.NewIntLessEqualPredicate(int64(f) - 1), nil
+		}
+		// "x < 10.3" -> "x <= 10"
+		return parquetquery.NewIntLessEqualPredicate(int64(f)), nil
+	}
+
+	return nil, fmt.Errorf("operator not supported for integers: %v", op)
 }
 
 func createIntPredicate(op traceql.Operator, operands traceql.Operands) (parquetquery.Predicate, error) {

--- a/tempodb/encoding/vparquet4/block_traceql_test.go
+++ b/tempodb/encoding/vparquet4/block_traceql_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"math/rand"
 	"os"
 	"sort"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/parquet-go/parquet-go"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/tempo/pkg/parquetquery"
@@ -27,6 +29,128 @@ import (
 	"github.com/grafana/tempo/tempodb/backend/local"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
+
+func TestCreateIntPredicateFromFloat(t *testing.T) {
+	f := func(query string, predicate string) {
+		req := traceql.MustExtractFetchSpansRequestWithMetadata(query)
+		require.Len(t, req.Conditions, 1)
+		p, err := createIntPredicateFromFloat(req.Conditions[0].Op, req.Conditions[0].Operands)
+		require.NoError(t, err)
+		np := "nil"
+		if p != nil {
+			r := strings.NewReplacer(
+				"IntEqualPredicate", "=",
+				"IntNotEqualPredicate", "!=",
+				"IntLessPredicate", "<",
+				"IntLessEqualPredicate", "<=",
+				"IntGreaterEqualPredicate", ">=",
+				"IntGreaterPredicate", ">",
+			)
+			np = r.Replace(p.String())
+			if np == "CallbackPredicate{}" {
+				if p.KeepValue(parquet.Value{}) {
+					np = "callback:true"
+				} else {
+					np = "callback:false"
+				}
+			}
+		}
+		require.Equal(t, predicate, np, "query:%s", query)
+	}
+	fe := func(query string, errorMessage string) {
+		req := traceql.MustExtractFetchSpansRequestWithMetadata(query)
+		require.Len(t, req.Conditions, 1)
+		_, err := createIntPredicateFromFloat(req.Conditions[0].Op, req.Conditions[0].Operands)
+		require.EqualError(t, err, errorMessage, "query:%s", query)
+	}
+
+	{
+		p, err := createIntPredicateFromFloat(traceql.OpNone, nil)
+		require.NoError(t, err)
+		require.Nil(t, p)
+	}
+	{
+		p, err := createIntPredicateFromFloat(traceql.OpEqual, traceql.Operands{traceql.NewStaticFloat(math.NaN())})
+		require.NoError(t, err)
+		require.Nil(t, p)
+	}
+
+	// Every float64 in range [math.MinInt64, math.MaxInt64) can be converted to int64 exactly,
+	// but you need to consider a fractional part of the float64 to adjust an operator.
+	// It's worth noting that float64 can have a fractional part
+	// in the range (-float64(1<<52)-0.5, float64(1<<52)+0.5)
+	f(`{.attr = -123.1}`, `nil`)
+	f(`{.attr != -123.1}`, `callback:true`)
+	f(`{.attr < -123.1}`, `<={-124}`)
+	f(`{.attr <= -123.1}`, `<={-124}`)
+	f(`{.attr > -123.1}`, `>={-123}`)
+	f(`{.attr >= -123.1}`, `>={-123}`)
+
+	f(`{.attr = -123.0}`, `={-123}`)
+	f(`{.attr != -123.0}`, `!={-123}`)
+	f(`{.attr < -123.0}`, `<{-123}`)
+	f(`{.attr <= -123.0}`, `<={-123}`)
+	f(`{.attr > -123.0}`, `>{-123}`)
+	f(`{.attr >= -123.0}`, `>={-123}`)
+
+	f(`{.attr = 123.0}`, `={123}`)
+	f(`{.attr != 123.0}`, `!={123}`)
+	f(`{.attr < 123.0}`, `<{123}`)
+	f(`{.attr <= 123.0}`, `<={123}`)
+	f(`{.attr > 123.0}`, `>{123}`)
+	f(`{.attr >= 123.0}`, `>={123}`)
+
+	f(`{.attr = 123.1}`, `nil`)
+	f(`{.attr != 123.1}`, `callback:true`)
+	f(`{.attr < 123.1}`, `<={123}`)
+	f(`{.attr <= 123.1}`, `<={123}`)
+	f(`{.attr > 123.1}`, `>={124}`)
+	f(`{.attr >= 123.1}`, `>={124}`)
+
+	// [MaxInt64, +Inf)
+	f(`{.attr = 9.223372036854776e+18}`, `nil`)
+	f(`{.attr != 9.223372036854776e+18}`, `callback:true`)
+	f(`{.attr > 9.223372036854776e+18}`, `nil`)
+	f(`{.attr >= 9.223372036854776e+18}`, `nil`)
+	f(`{.attr < 9.223372036854776e+18}`, `callback:true`)
+	f(`{.attr <= 9.223372036854776e+18}`, `callback:true`)
+
+	// (-Inf, MinInt64)
+	f(`{.attr = -9.223372036854777e+18}`, `nil`)
+	f(`{.attr != -9.223372036854777e+18}`, `callback:true`)
+	f(`{.attr > -9.223372036854777e+18}`, `callback:true`)
+	f(`{.attr >= -9.223372036854777e+18}`, `callback:true`)
+	f(`{.attr < -9.223372036854777e+18}`, `nil`)
+	f(`{.attr <= -9.223372036854777e+18}`, `nil`)
+
+	fe(`{.attr = 1}`, `operand is not float: 1`)
+	fe(`{.attr =~ -1.2}`, `operator not supported for integers: =~`)
+}
+
+func TestCreateNumericPredicate(t *testing.T) {
+	t.Run("none", func(t *testing.T) {
+		p, err := createDurationPredicate(traceql.OpNone, nil)
+		require.NoError(t, err)
+		require.Nil(t, p)
+	})
+
+	t.Run("float", func(t *testing.T) {
+		p, err := createDurationPredicate(traceql.OpGreater, traceql.Operands{traceql.NewStaticFloat(1.2)})
+		require.NoError(t, err)
+		require.Equal(t, "IntGreaterEqualPredicate{2}", p.String())
+	})
+
+	t.Run("int", func(t *testing.T) {
+		p, err := createDurationPredicate(traceql.OpGreater, traceql.Operands{traceql.NewStaticFloat(1)})
+		require.NoError(t, err)
+		require.Equal(t, "IntGreaterPredicate{1}", p.String())
+	})
+
+	t.Run("it forwards errors", func(t *testing.T) {
+		_, err := createDurationPredicate(traceql.OpGreater, traceql.Operands{traceql.NewStaticBool(true)})
+		require.EqualError(t, err, `operand is not int, duration, status or kind: true`)
+	})
+}
 
 func TestOne(t *testing.T) {
 	wantTr := fullyPopulatedTestTrace(nil)

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -1610,38 +1610,69 @@ func traceQLDuration(t *testing.T, _ *tempopb.Trace, wantMeta *tempopb.TraceSear
 	ctx := context.Background()
 	e := traceql.NewEngine()
 
-	// We've got two duration fields in traces: 1000000000ns && 2000000000ns
+	// We've got two `span:duration`: 1000000000ns && 2000000000ns
+	// We've got one `trace:duration`: 2000000000ns
 
 	quotedAttributesThatMatch := []*tempopb.SearchRequest{
-		{Query: `{ (span:duration >= 999999999) && span:duration <= 1000000001 }`},
-		{Query: `{ (span:duration > 999999999) && span:duration < 1000000001 }`},
-		{Query: `{ (span:duration >= 1000000000) && span:duration <= 1000000000 }`},
-		{Query: `{ (span:duration = 1000000000) }`},
+		{Query: `{ span:duration >= 999999999 && span:duration <= 1000000001 }`},
+		{Query: `{ span:duration > 999999999 && span:duration < 1000000001 }`},
+		{Query: `{ span:duration >= 1000000000 && span:duration <= 1000000000 }`},
+		{Query: `{ span:duration = 1000000000 }`},
 
-		{Query: `{ (span:duration >= 999999999.9) && (span:duration <= 1000000000.1) }`},
-		{Query: `{ (span:duration > 999999999.9) && (span:duration < 1000000000.1) }`},
-		{Query: `{ (span:duration >= 1000000000.0) && (span:duration <= 1000000000.0) }`},
-		{Query: `{ (span:duration = 1000000000.0) }`},
+		{Query: `{ span:duration >= 999999999.9 && span:duration <= 1000000000.1 }`},
+		{Query: `{ span:duration > 999999999.9 && span:duration < 1000000000.1 }`},
+		{Query: `{ span:duration >= 1000000000.0 && span:duration <= 1000000000.0 }`},
+		{Query: `{ span:duration = 1000000000.0 }`},
 
-		{Query: `{ (span:duration >= 2999999999ns / 3) && (span:duration <= 3000000001ns / 3) }`},
-		{Query: `{ (span:duration > 2999999999ns / 3) && (span:duration < 3000000001ns / 3) }`},
-		{Query: `{ (span:duration >= 3000000000ns / 3) && (span:duration <= 3000000000ns / 3) }`},
-		{Query: `{ (span:duration = 3000000000ns / 3) }`},
+		{Query: `{ span:duration >= 2999999999ns / 3 && span:duration <= 3000000001ns / 3 }`},
+		{Query: `{ span:duration > 2999999999ns / 3 && span:duration < 3000000001ns / 3 }`},
+		{Query: `{ span:duration >= 3000000000ns / 3 && span:duration <= 3000000000ns / 3 }`},
+		{Query: `{ span:duration = 3000000000ns / 3 }`},
 
-		{Query: `{ (span:duration >= 4999999999 * .2) && (span:duration <= 5000000001 * .2) }`},
-		{Query: `{ (span:duration > 4999999999 * .2) && (span:duration < 5000000001 * .2) }`},
-		{Query: `{ (span:duration >= 5000000000 * .2) && (span:duration <= 5000000000 * .2) }`},
-		{Query: `{ (span:duration = 5000000000 * .2) }`},
+		{Query: `{ span:duration >= 4999999999 * .2 && span:duration <= 5000000001 * .2 }`},
+		{Query: `{ span:duration > 4999999999 * .2 && span:duration < 5000000001 * .2 }`},
+		{Query: `{ span:duration >= 5000000000 * .2 && span:duration <= 5000000000 * .2 }`},
+		{Query: `{ span:duration = 5000000000 * .2 }`},
 
-		{Query: `{ (span:duration >= 3333333333ns * .3) && (span:duration <= 3333333334ns * .3) }`},
-		{Query: `{ (span:duration > 3333333333ns * .3) && (span:duration < 3333333334ns * .3) }`},
-		{Query: `{ (span:duration >= 5000000000ns * .2) && (span:duration <= 5000000000ns * .2) }`},
-		{Query: `{ (span:duration = 5000000000ns * .2) }`},
+		{Query: `{ span:duration >= 3333333333ns * .3 && span:duration <= 3333333334ns * .3 }`},
+		{Query: `{ span:duration > 3333333333ns * .3 && span:duration < 3333333334ns * .3 }`},
+		{Query: `{ span:duration >= 5000000000ns * .2 && span:duration <= 5000000000ns * .2 }`},
+		{Query: `{ span:duration = 5000000000ns * .2 }`},
 
-		{Query: `{ (span:duration >= 333333333ns * 3) && (span:duration <= 333333334ns * 3) }`},
-		{Query: `{ (span:duration > 333333333ns * 3) && (span:duration < 333333334ns * 3) }`},
-		{Query: `{ (span:duration >= 500000000 * 2) && (span:duration <= 500000000 * 2) }`},
-		{Query: `{ (span:duration = 500000000 * 2) }`},
+		{Query: `{ span:duration >= 333333333ns * 3 && span:duration <= 333333334ns * 3 }`},
+		{Query: `{ span:duration > 333333333ns * 3 && span:duration < 333333334ns * 3 }`},
+		{Query: `{ span:duration >= 500000000 * 2 && span:duration <= 500000000 * 2 }`},
+		{Query: `{ span:duration = 500000000 * 2 }`},
+
+		{Query: `{ trace:duration >= 1999999999 && trace:duration <= 2000000001 }`},
+		{Query: `{ trace:duration > 1999999999 && trace:duration < 2000000001 }`},
+		{Query: `{ trace:duration >= 2000000000 && trace:duration <= 2000000000 }`},
+		{Query: `{ trace:duration = 2000000000 }`},
+
+		{Query: `{ trace:duration >= 1999999999.9 && trace:duration <= 2000000000.1 }`},
+		{Query: `{ trace:duration > 1999999999.9 && trace:duration < 2000000000.1 }`},
+		{Query: `{ trace:duration >= 2000000000.0 && trace:duration <= 2000000000.0 }`},
+		{Query: `{ trace:duration = 2000000000.0 }`},
+
+		{Query: `{ trace:duration >= 5999999999ns / 3 && trace:duration <= 6000000001ns / 3 }`},
+		{Query: `{ trace:duration > 5999999999ns / 3 && trace:duration < 6000000001ns / 3 }`},
+		{Query: `{ trace:duration >= 6000000000ns / 3 && trace:duration <= 6000000000ns / 3 }`},
+		{Query: `{ trace:duration = 6000000000ns / 3 }`},
+
+		{Query: `{ trace:duration >= 9999999999 * .2 && trace:duration <= 10000000001 * .2 }`},
+		{Query: `{ trace:duration > 9999999999 * .2 && trace:duration < 10000000001 * .2 }`},
+		{Query: `{ trace:duration >= 10000000000 * .2 && trace:duration <= 10000000000 * .2 }`},
+		{Query: `{ trace:duration = 10000000000 * .2 }`},
+
+		{Query: `{ trace:duration >= 6666666666ns * .3 && trace:duration <= 6666666667ns * .3 }`},
+		{Query: `{ trace:duration > 6666666666ns * .3 && trace:duration < 6666666667ns * .3 }`},
+		{Query: `{ trace:duration >= 10000000000ns * .2 && trace:duration <= 10000000000ns * .2 }`},
+		{Query: `{ trace:duration = 10000000000ns * .2 }`},
+
+		{Query: `{ trace:duration >= 666666666ns * 3 && trace:duration <= 666666667ns * 3 }`},
+		{Query: `{ trace:duration > 666666666ns * 3 && trace:duration < 666666667ns * 3 }`},
+		{Query: `{ trace:duration >= 1000000000 * 2 && trace:duration <= 1000000000 * 2 }`},
+		{Query: `{ trace:duration = 1000000000 * 2 }`},
 	}
 
 	searchesThatMatch = append(searchesThatMatch, quotedAttributesThatMatch...)
@@ -1665,23 +1696,30 @@ func traceQLDuration(t *testing.T, _ *tempopb.Trace, wantMeta *tempopb.TraceSear
 	}
 
 	quotedAttributesThaDonttMatch := []*tempopb.SearchRequest{
-		{Query: `{ (span:duration < 1000000000) || span:duration > 2000000000 }`},
-		{Query: `{ (span:duration > 1000000000) && span:duration < 2000000000 }`},
+		{Query: `{ span:duration < 1000000000 || span:duration > 2000000000 }`},
+		{Query: `{ span:duration > 1000000000 && span:duration < 2000000000 }`},
 
-		{Query: `{ (span:duration < 1000000000.0) || (span:duration > 2000000000.0) }`},
-		{Query: `{ (span:duration > 1000000000.0) && (span:duration < 2000000000.0) }`},
+		{Query: `{ span:duration < 1000000000.0 || span:duration > 2000000000.0 }`},
+		{Query: `{ span:duration > 1000000000.0 && span:duration < 2000000000.0 }`},
 
-		{Query: `{ (span:duration < 3000000000ns / 3) || (span:duration > 6000000000ns / 3) }`},
-		{Query: `{ (span:duration > 3000000000ns / 3) && (span:duration < 6000000000ns / 3) }`},
+		{Query: `{ span:duration < 3000000000ns / 3 || span:duration > 6000000000ns / 3 }`},
+		{Query: `{ span:duration > 3000000000ns / 3 && span:duration < 6000000000ns / 3 }`},
 
-		{Query: `{ (span:duration < 5000000000 * .2) || (span:duration > 10000000000 * .2) }`},
-		{Query: `{ (span:duration > 5000000000 * .2) && (span:duration < 10000000000 * .2) }`},
+		{Query: `{ span:duration < 5000000000 * .2 || span:duration > 10000000000 * .2 }`},
+		{Query: `{ span:duration > 5000000000 * .2 && span:duration < 10000000000 * .2 }`},
 
-		{Query: `{ (span:duration < 5000000000ns * .2) || (span:duration > 10000000000ns * .2) }`},
-		{Query: `{ (span:duration > 5000000000ns * .2) && (span:duration < 10000000000ns * .2) }`},
+		{Query: `{ span:duration < 5000000000ns * .2 || span:duration > 10000000000ns * .2 }`},
+		{Query: `{ span:duration > 5000000000ns * .2 && span:duration < 10000000000ns * .2 }`},
 
-		{Query: `{ (span:duration < 500000000ns * 2) || (span:duration > 1000000000ns * 2) }`},
-		{Query: `{ (span:duration > 500000000ns * 2) && (span:duration < 1000000000ns * 2) }`},
+		{Query: `{ span:duration < 500000000ns * 2 || span:duration > 1000000000ns * 2 }`},
+		{Query: `{ span:duration > 500000000ns * 2 && span:duration < 1000000000ns * 2 }`},
+
+		{Query: `{ trace:duration < 2000000000 || trace:duration > 2000000000 }`},
+		{Query: `{ trace:duration < 2000000000.0 || trace:duration > 2000000000.0 }`},
+		{Query: `{ trace:duration < 6000000000ns / 3 || trace:duration > 6000000000ns / 3 }`},
+		{Query: `{ trace:duration < 10000000000 * .2 || trace:duration > 10000000000 * .2 }`},
+		{Query: `{ trace:duration < 10000000000ns * .2 || trace:duration > 10000000000ns * .2 }`},
+		{Query: `{ trace:duration < 1000000000ns * 2 || trace:duration > 1000000000ns * 2 }`},
 	}
 
 	searchesThatDontMatch = append(searchesThatDontMatch, quotedAttributesThaDonttMatch...)

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -58,6 +58,7 @@ func TestSearchCompleteBlock(t *testing.T) {
 				nestedSet,
 				tagValuesRunner,
 				tagNamesRunner,
+				traceQLDuration,
 			)
 		})
 		if vers == vparquet4.VersionString {
@@ -1602,6 +1603,96 @@ func tagNamesRunner(t *testing.T, _ *tempopb.Trace, _ *tempopb.TraceSearchMetada
 			// test that callback is recording bytes read
 			require.Greater(t, mc.TotalValue(), uint64(100))
 		})
+	}
+}
+
+func traceQLDuration(t *testing.T, _ *tempopb.Trace, wantMeta *tempopb.TraceSearchMetadata, searchesThatMatch, searchesThatDontMatch []*tempopb.SearchRequest, meta *backend.BlockMeta, r Reader, _ common.BackendBlock) {
+	ctx := context.Background()
+	e := traceql.NewEngine()
+
+	// We've got two duration fields in traces: 1000000000ns && 2000000000ns
+
+	quotedAttributesThatMatch := []*tempopb.SearchRequest{
+		{Query: `{ (span:duration >= 999999999) && span:duration <= 1000000001 }`},
+		{Query: `{ (span:duration > 999999999) && span:duration < 1000000001 }`},
+		{Query: `{ (span:duration >= 1000000000) && span:duration <= 1000000000 }`},
+		{Query: `{ (span:duration = 1000000000) }`},
+
+		{Query: `{ (span:duration >= 999999999.9) && (span:duration <= 1000000000.1) }`},
+		{Query: `{ (span:duration > 999999999.9) && (span:duration < 1000000000.1) }`},
+		{Query: `{ (span:duration >= 1000000000.0) && (span:duration <= 1000000000.0) }`},
+		{Query: `{ (span:duration = 1000000000.0) }`},
+
+		{Query: `{ (span:duration >= 2999999999ns / 3) && (span:duration <= 3000000001ns / 3) }`},
+		{Query: `{ (span:duration > 2999999999ns / 3) && (span:duration < 3000000001ns / 3) }`},
+		{Query: `{ (span:duration >= 3000000000ns / 3) && (span:duration <= 3000000000ns / 3) }`},
+		{Query: `{ (span:duration = 3000000000ns / 3) }`},
+
+		{Query: `{ (span:duration >= 4999999999 * .2) && (span:duration <= 5000000001 * .2) }`},
+		{Query: `{ (span:duration > 4999999999 * .2) && (span:duration < 5000000001 * .2) }`},
+		{Query: `{ (span:duration >= 5000000000 * .2) && (span:duration <= 5000000000 * .2) }`},
+		{Query: `{ (span:duration = 5000000000 * .2) }`},
+
+		{Query: `{ (span:duration >= 3333333333ns * .3) && (span:duration <= 3333333334ns * .3) }`},
+		{Query: `{ (span:duration > 3333333333ns * .3) && (span:duration < 3333333334ns * .3) }`},
+		{Query: `{ (span:duration >= 5000000000ns * .2) && (span:duration <= 5000000000ns * .2) }`},
+		{Query: `{ (span:duration = 5000000000ns * .2) }`},
+
+		{Query: `{ (span:duration >= 333333333ns * 3) && (span:duration <= 333333334ns * 3) }`},
+		{Query: `{ (span:duration > 333333333ns * 3) && (span:duration < 333333334ns * 3) }`},
+		{Query: `{ (span:duration >= 500000000 * 2) && (span:duration <= 500000000 * 2) }`},
+		{Query: `{ (span:duration = 500000000 * 2) }`},
+	}
+
+	searchesThatMatch = append(searchesThatMatch, quotedAttributesThatMatch...)
+	for _, req := range searchesThatMatch {
+		fetcher := traceql.NewSpansetFetcherWrapper(func(ctx context.Context, req traceql.FetchSpansRequest) (traceql.FetchSpansResponse, error) {
+			return r.Fetch(ctx, meta, req, common.DefaultSearchOptions())
+		})
+
+		res, err := e.ExecuteSearch(ctx, req, fetcher)
+		if errors.Is(err, common.ErrUnsupported) {
+			continue
+		}
+
+		require.NoError(t, err, "search request: %+v", req)
+		actual := actualForExpectedMeta(wantMeta, res)
+		require.NotNil(t, actual, "search request: %v", req)
+		actual.SpanSet = nil // todo: add the matching spansets to wantmeta
+		actual.SpanSets = nil
+		actual.ServiceStats = nil
+		require.Equal(t, wantMeta, actual, "search request: %v", req)
+	}
+
+	quotedAttributesThaDonttMatch := []*tempopb.SearchRequest{
+		{Query: `{ (span:duration < 1000000000) || span:duration > 2000000000 }`},
+		{Query: `{ (span:duration > 1000000000) && span:duration < 2000000000 }`},
+
+		{Query: `{ (span:duration < 1000000000.0) || (span:duration > 2000000000.0) }`},
+		{Query: `{ (span:duration > 1000000000.0) && (span:duration < 2000000000.0) }`},
+
+		{Query: `{ (span:duration < 3000000000ns / 3) || (span:duration > 6000000000ns / 3) }`},
+		{Query: `{ (span:duration > 3000000000ns / 3) && (span:duration < 6000000000ns / 3) }`},
+
+		{Query: `{ (span:duration < 5000000000 * .2) || (span:duration > 10000000000 * .2) }`},
+		{Query: `{ (span:duration > 5000000000 * .2) && (span:duration < 10000000000 * .2) }`},
+
+		{Query: `{ (span:duration < 5000000000ns * .2) || (span:duration > 10000000000ns * .2) }`},
+		{Query: `{ (span:duration > 5000000000ns * .2) && (span:duration < 10000000000ns * .2) }`},
+
+		{Query: `{ (span:duration < 500000000ns * 2) || (span:duration > 1000000000ns * 2) }`},
+		{Query: `{ (span:duration > 500000000ns * 2) && (span:duration < 1000000000ns * 2) }`},
+	}
+
+	searchesThatDontMatch = append(searchesThatDontMatch, quotedAttributesThaDonttMatch...)
+	for _, req := range searchesThatDontMatch {
+		fetcher := traceql.NewSpansetFetcherWrapper(func(ctx context.Context, req traceql.FetchSpansRequest) (traceql.FetchSpansResponse, error) {
+			return r.Fetch(ctx, meta, req, common.DefaultSearchOptions())
+		})
+
+		res, err := e.ExecuteSearch(ctx, req, fetcher)
+		require.NoError(t, err, "search request: %+v", req)
+		require.Nil(t, actualForExpectedMeta(wantMeta, res), "search request: %v", req)
 	}
 }
 


### PR DESCRIPTION
**What this PR does**

This PR enables comparisons between `span:duration` and floating-point values.

Previously, the query engine only supported integer comparisons.
The new helper `createIntPredicateFromFloat` rewrites float predicates into
equivalent integer predicates while preserving semantics. Because some floats
cannot be represented exactly as integers, the function adjusts the operator
accordingly. For example:

- `>= 10.1`   ->  `> 11`
- `< 10.1`    ->  `<= 10`

It seems that `v2` already handles floats internally due to different design. So no changes are required there.

**Which issue(s) this PR fixes**

Fixes #4046

**Checklist**

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated — entries should be ordered `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`