### PR TITLE
ci: add zizmor config so zizmor works on PRs from forks

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,11 @@
+# This is also used as the default configuration for the Zizmor reusable workflow.
+# We need this file because we allow PRs from forks, and PRs from forks
+# can't access config files from shared-workflows repo.
+# This file is copied from: https://github.com/grafana/shared-workflows/blob/main/.github/zizmor.yml
+
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        actions/*: any # trust GitHub
+        grafana/*: any # trust Grafana


### PR DESCRIPTION
**What this PR does**:

zizmor workflow is failing on prs created from forks because we can't fetch the config from shared-workflows repo.

zizmor is not blocking right now but it will be blocking soon so we need to get the zizmor workflow to ✅ 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`