### PR TITLE
Abort appending during "unexpected" errors in compactor

### DIFF
--- a/tempodb/backend/azure/azure.go
+++ b/tempodb/backend/azure/azure.go
@@ -147,6 +147,12 @@ func (rw *Azure) Append(ctx context.Context, name string, keypath backend.KeyPat
 	return a, nil
 }
 
+// AbortAppend implements backend.Writer
+func (rw *Azure) AbortAppend(ctx context.Context, tracker backend.AppendTracker) error {
+	// TODO: implement AbortAppend
+	return nil
+}
+
 // CloseAppend implements backend.Writer
 func (rw *Azure) CloseAppend(context.Context, backend.AppendTracker) error {
 	return nil

--- a/tempodb/backend/backend.go
+++ b/tempodb/backend/backend.go
@@ -48,6 +48,8 @@ type Writer interface {
 	WriteBlockMeta(ctx context.Context, meta *BlockMeta) error
 	// Append starts or continues an Append job. Pass nil to AppendTracker to start a job.
 	Append(ctx context.Context, name string, blockID uuid.UUID, tenantID string, tracker AppendTracker, buffer []byte) (AppendTracker, error)
+	// AbortAppend aborts an Append job. This is a no-op if the AppendTracker is nil.
+	AbortAppend(ctx context.Context, tracker AppendTracker) error
 	// CloseAppend closes any resources associated with the AppendTracker
 	CloseAppend(ctx context.Context, tracker AppendTracker) error
 	// WriteTenantIndex writes the two meta slices as a tenant index

--- a/tempodb/backend/cache/cache.go
+++ b/tempodb/backend/cache/cache.go
@@ -158,6 +158,12 @@ func (r *readerWriter) Append(ctx context.Context, name string, keypath backend.
 	return r.nextWriter.Append(ctx, name, keypath, tracker, buffer)
 }
 
+// AbortAppend implements backend.Writer
+func (r *readerWriter) AbortAppend(ctx context.Context, tracker backend.AppendTracker) error {
+	// TODO: implement AbortAppend
+	return nil
+}
+
 // CloseAppend implements backend.Writer
 func (r *readerWriter) CloseAppend(ctx context.Context, tracker backend.AppendTracker) error {
 	return r.nextWriter.CloseAppend(ctx, tracker)

--- a/tempodb/backend/gcs/gcs.go
+++ b/tempodb/backend/gcs/gcs.go
@@ -163,6 +163,12 @@ func (rw *readerWriter) Append(ctx context.Context, name string, keypath backend
 	return w, nil
 }
 
+// AbortAppend implements backend.Writer
+func (rw *readerWriter) AbortAppend(_ context.Context, tracker backend.AppendTracker) error {
+	// TODO: implement AbortAppend
+	return nil
+}
+
 // CloseAppend implements backend.Writer
 func (rw *readerWriter) CloseAppend(_ context.Context, tracker backend.AppendTracker) error {
 	if tracker == nil {

--- a/tempodb/backend/local/local.go
+++ b/tempodb/backend/local/local.go
@@ -109,6 +109,12 @@ func (rw *Backend) Append(ctx context.Context, name string, keypath backend.KeyP
 	return dst, nil
 }
 
+// AbortAppend implements backend.Writer
+func (rw *Backend) AbortAppend(ctx context.Context, tracker backend.AppendTracker) error {
+	// TODO: implement AbortAppend
+	return nil
+}
+
 // CloseAppend implements backend.Writer
 func (rw *Backend) CloseAppend(ctx context.Context, tracker backend.AppendTracker) error {
 	if err := ctx.Err(); err != nil {

--- a/tempodb/backend/mocks.go
+++ b/tempodb/backend/mocks.go
@@ -97,6 +97,11 @@ func (m *MockRawWriter) Append(_ context.Context, _ string, _ KeyPath, _ AppendT
 	return nil, nil
 }
 
+func (m *MockRawWriter) AbortAppend(_ context.Context, _ AppendTracker) error {
+	// TODO: implement AbortAppend
+	return nil
+}
+
 func (m *MockRawWriter) CloseAppend(context.Context, AppendTracker) error {
 	m.closeAppendCalled = true
 	return nil
@@ -251,6 +256,10 @@ func (m *MockWriter) WriteBlockMeta(context.Context, *BlockMeta) error {
 
 func (m *MockWriter) Append(context.Context, string, uuid.UUID, string, AppendTracker, []byte) (AppendTracker, error) {
 	return nil, nil
+}
+
+func (m *MockWriter) AbortAppend(context.Context, AppendTracker) error {
+	return nil
 }
 
 func (m *MockWriter) CloseAppend(context.Context, AppendTracker) error {

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -51,6 +51,8 @@ type RawWriter interface {
 	Write(ctx context.Context, name string, keypath KeyPath, data io.Reader, size int64, cacheInfo *CacheInfo) error
 	// Append starts or continues an Append job. Pass nil to AppendTracker to start a job.
 	Append(ctx context.Context, name string, keypath KeyPath, tracker AppendTracker, buffer []byte) (AppendTracker, error)
+	// AbortAppend aborts an Append job. This is a no-op if the AppendTracker is nil.
+	AbortAppend(ctx context.Context, tracker AppendTracker) error
 	// CloseAppend closes any resources associated with the AppendTracker.
 	CloseAppend(ctx context.Context, tracker AppendTracker) error
 	// Delete deletes a file.
@@ -119,6 +121,12 @@ func (w *writer) WriteBlockMeta(ctx context.Context, meta *BlockMeta) error {
 // Write implements backend.Writer
 func (w *writer) Append(ctx context.Context, name string, blockID uuid.UUID, tenantID string, tracker AppendTracker, buffer []byte) (AppendTracker, error) {
 	return w.w.Append(ctx, name, KeyPathForBlock(blockID, tenantID), tracker, buffer)
+}
+
+// Write implements backend.Writer
+func (w *writer) AbortAppend(ctx context.Context, tracker AppendTracker) error {
+	//TODO: implement AbortAppend
+	return nil
 }
 
 // Write implements backend.Writer

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -251,8 +251,17 @@ func (rw *readerWriter) Append(ctx context.Context, name string, keypath backend
 
 // AbortAppend implements backend.Writer
 func (rw *readerWriter) AbortAppend(ctx context.Context, tracker backend.AppendTracker) error {
-	// TODO: implement AbortAppend
-	return nil
+	if tracker == nil {
+		return nil
+	}
+
+	a := tracker.(appendTracker)
+	err := rw.core.AbortMultipartUpload(ctx,
+		rw.cfg.Bucket,
+		a.objectName,
+		a.uploadID)
+
+	return fmt.Errorf("error aborting multipart upload, object: %s, uploadID: %s: %w", a.objectName, a.uploadID, err)
 }
 
 // CloseAppend implements backend.Writer

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -249,6 +249,12 @@ func (rw *readerWriter) Append(ctx context.Context, name string, keypath backend
 	return a, nil
 }
 
+// AbortAppend implements backend.Writer
+func (rw *readerWriter) AbortAppend(ctx context.Context, tracker backend.AppendTracker) error {
+	// TODO: implement AbortAppend
+	return nil
+}
+
 // CloseAppend implements backend.Writer
 func (rw *readerWriter) CloseAppend(ctx context.Context, tracker backend.AppendTracker) error {
 	if tracker == nil {

--- a/tempodb/encoding/vparquet4/compactor.go
+++ b/tempodb/encoding/vparquet4/compactor.go
@@ -20,16 +20,17 @@ import (
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
+var defaultMultiblockIteratorFactory = func(bookmarks []*bookmark[parquet.Row], combine combineFn[parquet.Row]) *MultiBlockIterator[parquet.Row] {
+	return newMultiblockIterator(bookmarks, combine)
+}
+var defaultStreamingBlockFactory = newStreamingBlock
+
 func NewCompactor(opts common.CompactionOptions) *Compactor {
 	return &Compactor{
 		opts: opts,
 
-		multiblockIteratorFactory: func(bookmarks []*bookmark[parquet.Row], combine combineFn[parquet.Row]) *MultiBlockIterator[parquet.Row] {
-			return newMultiblockIterator(bookmarks, combine)
-		},
-		streamingBlockFactory: func(ctx context.Context, cfg *common.BlockConfig, meta *backend.BlockMeta, r backend.Reader, to backend.Writer, createBufferedWriter func(w io.Writer) tempo_io.BufferedWriteFlusher) *streamingBlock {
-			return newStreamingBlock(ctx, cfg, meta, r, to, createBufferedWriter)
-		},
+		multiblockIteratorFactory: defaultMultiblockIteratorFactory,
+		streamingBlockFactory:     defaultStreamingBlockFactory,
 	}
 }
 

--- a/tempodb/encoding/vparquet4/compactor.go
+++ b/tempodb/encoding/vparquet4/compactor.go
@@ -226,6 +226,7 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 			runtime.GC()
 			err = c.appendBlock(ctx, currentBlock, l)
 			if err != nil {
+				currentBlock.Abort(ctx)
 				return nil, fmt.Errorf("error writing partial block: %w", err)
 			}
 		}

--- a/tempodb/encoding/vparquet4/compactor.go
+++ b/tempodb/encoding/vparquet4/compactor.go
@@ -222,8 +222,7 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 		}
 
 		// Flush again if block is already full.
-		estimatedBufferedBytes := currentBlock.EstimatedBufferedBytes()
-		if estimatedBufferedBytes > c.opts.BlockConfig.RowGroupSizeBytes {
+		if currentBlock.EstimatedBufferedBytes() > c.opts.BlockConfig.RowGroupSizeBytes {
 			runtime.GC()
 			err = c.appendBlock(ctx, currentBlock, l)
 			if err != nil {

--- a/tempodb/encoding/vparquet4/compactor.go
+++ b/tempodb/encoding/vparquet4/compactor.go
@@ -25,6 +25,21 @@ var defaultMultiblockIteratorFactory = func(bookmarks []*bookmark[parquet.Row], 
 }
 var defaultStreamingBlockFactory = newStreamingBlock
 
+func NewCompactorWithFactories(opts common.CompactionOptions, multiblockIteratorFactory func(bookmarks []*bookmark[parquet.Row], combine combineFn[parquet.Row]) *MultiBlockIterator[parquet.Row], streamingBlockFactory func(ctx context.Context, cfg *common.BlockConfig, meta *backend.BlockMeta, r backend.Reader, to backend.Writer, createBufferedWriter func(w io.Writer) tempo_io.BufferedWriteFlusher) *streamingBlock) *Compactor {
+
+	if multiblockIteratorFactory == nil {
+		multiblockIteratorFactory = defaultMultiblockIteratorFactory
+	}
+	if streamingBlockFactory == nil {
+		streamingBlockFactory = defaultStreamingBlockFactory
+	}
+	return &Compactor{
+		opts: opts,
+
+		multiblockIteratorFactory: multiblockIteratorFactory,
+		streamingBlockFactory:     streamingBlockFactory,
+	}
+}
 func NewCompactor(opts common.CompactionOptions) *Compactor {
 	return &Compactor{
 		opts: opts,

--- a/tempodb/encoding/vparquet4/create.go
+++ b/tempodb/encoding/vparquet4/create.go
@@ -273,6 +273,9 @@ func (b *streamingBlock) Complete() (int, error) {
 
 	return n, writeBlockMeta(b.ctx, b.to, b.meta, b.bloom, b.index)
 }
+func (b *streamingBlock) Abort(ctx context.Context) error {
+	return b.w.Abort()
+}
 
 // estimateMarshalledSizeFromTrace attempts to estimate the size of trace in bytes. This is used to make choose
 // when to cut a row group during block creation.

--- a/tempodb/encoding/vparquet4/create.go
+++ b/tempodb/encoding/vparquet4/create.go
@@ -31,7 +31,11 @@ func (b *backendWriter) Write(p []byte) (n int, err error) {
 	b.tracker, err = b.w.Append(b.ctx, b.name, b.blockID, b.tenantID, b.tracker, p)
 	return len(p), err
 }
-
+func (b *backendWriter) Abort() (err error) {
+	err = b.w.AbortAppend(b.ctx, b.tracker)
+	b.tracker = nil // TODO: discuss set to nil? close does not set to nil
+	return err
+}
 func (b *backendWriter) Close() error {
 	return b.w.CloseAppend(b.ctx, b.tracker)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This PR mitigates the issue when "unexpected" error happens during the appending part in the compactor phase.

We do this by introducing a `AbortAppend` on the `bakend.Writer` / `backend.RawWriter` interface, as those interface has a lot of different implementation we leave them all unimplemented expect the `s3` one. Here we call the abort multipart upload on the minio client with the values from the tracker.

Setting up the tests for that verify the call to the `AbortAppend` was a bit challanging and currently covers 2 of the 4 potential places where they need to be handled.

Therefore we

1. Introduce a factory for multiblockIterator to have the creation for those better under control 4d4cd49375f913e3663203ed8c8246ba0e1f07bb
2. same for the streamingBlock 04ab66da56a7f2bf0faba45d8db67b1095540a75
3. by default we use the current logic 81dd85ce4ed75e99e0e1b02ead9b50f7472b088e
4. But introduce another `NewCompactorWithFactories` to override them for testing purposes eebe3900a5936dbbeb3fbf1cd77d2e93fa2edce2
5. We introduc the `AbortAppend` method on the `backend.Writer` interface which produces a lot of noise df36a0c41506013c4dd4c5ab2f2f1f726e047c88
6. A mock `backend.Writer` to verify the call of the Abort methpd 796101a810238ab4184cbc9063ccaaca1dae859f
7.  we then inject a "faulty" iterator, which is a bit tricky but solved by letting the combine method fail on the second call and then implement the call to the abort method 712ee1d7df5a9a57c10efb21c69d14e8e2c9a0a0
8. concrete s3 abort (no tests as the whole append thing hasn't any there) bafdcc7f6e20a65d6a23ef9aa3c561ab44b38323
9.  catch another fail 68d4056119d75aba7cc00fcce55ea23134a82a62

todo: handle the other 2 unhandle errors

the streamingBlockFactory thing is currently not used but I think I might need it for those other errors

Overall the whole way how it is injected doesnt feel really right but I didnt see any other way without to much refactoring




**Which issue(s) this PR fixes**:
Fixes #4878

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`