### PR TITLE
[DOC] operator: Remove hardcoded supported Kubernetes versions

### DIFF
--- a/docs/sources/tempo/setup/operator/_index.md
+++ b/docs/sources/tempo/setup/operator/_index.md
@@ -38,7 +38,7 @@ The supported Tempo version by the operator can be found in the [changelog](http
 
 ### Kubernetes
 
-The Tempo Operator is supported on Kubernetes versions v1.25 to v1.29.
+The supported Kubernetes versions can be found in the [changelog](https://github.com/grafana/tempo-operator/blob/main/CHANGELOG.md) or on the [release page](https://github.com/grafana/tempo-operator/releases).
 
 ### cert-manager
 


### PR DESCRIPTION
**What this PR does**:

The supported Kubernetes versions of the operator change regularly, therefore it makes more sense to link to the operator changelog instead of hardcoding the versions in the Tempo docs.

The Tempo operator changelog will contain the supported Kubernetes versions with the next release (v0.16.0, planned for this week).


**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`