### PR TITLE
TraceQL Metrics: right exemplars for histogram and quantiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [BUGFIX] Reset `SkipMetricsGeneration` before reuse. [#5117](https://github.com/grafana/tempo/pull/5117) (@flxbk)
 * [BUGFIX] Fix metrics generator host info processor overrides config. [#5118](https://github.com/grafana/tempo/pull/5118) (@rlankfo)
 * [BUGFIX] Fix metrics generator target_info to skip attributes with no name to prevent downstream errors [#5148](https://github.com/grafana/tempo/pull/5148) (@mdisibio)
+* [BUGFIX] TraceQL Metrics: right exemplars for histogram and quantiles [#5145](https://github.com/grafana/tempo/pull/5145) (@ruslan-mikhailov)
 * [BUGFIX] Fix for queried number of exemplars (TraceQL Metrics) [#5115](https://github.com/grafana/tempo/pull/5115) (@ruslan-mikhailov)
 
 # v2.7.2

--- a/integration/e2e/api/query_range_test.go
+++ b/integration/e2e/api/query_range_test.go
@@ -86,6 +86,12 @@ sendLoop:
 		"{} | sum_over_time(duration)",
 		"{} | quantile_over_time(duration, .5)",
 		"{} | quantile_over_time(duration, .5, 0.9, 0.99)",
+
+		"{} | count_over_time() by (span.span_attr)",
+		"{} | count_over_time() by (resource.res_attr)",
+		"{} | count_over_time() by (.span_attr)",
+		"{} | count_over_time() by (.res_attr)",
+
 		"{} | histogram_over_time(duration)",
 		"{} | count_over_time() by (status)",
 		"{status != error} | count_over_time() by (status)",

--- a/integration/e2e/api/query_range_test.go
+++ b/integration/e2e/api/query_range_test.go
@@ -53,7 +53,20 @@ sendLoop:
 	for {
 		select {
 		case <-ticker.C:
-			require.NoError(t, jaegerClient.EmitBatch(context.Background(), util.MakeThriftBatch()))
+			require.NoError(t, jaegerClient.EmitBatch(context.Background(),
+				util.MakeThriftBatchWithSpanCountAttributeAndName(
+					1, "my operation",
+					"res_val", "span_val",
+					"res_attr", "span_attr",
+				),
+			))
+			require.NoError(t, jaegerClient.EmitBatch(context.Background(),
+				util.MakeThriftBatchWithSpanCountAttributeAndName(
+					1, "my operation",
+					"res_val2", "span_val2",
+					"res_attr", "span_attr",
+				),
+			))
 		case <-timer.C:
 			break sendLoop
 		}

--- a/integration/e2e/api/query_range_test.go
+++ b/integration/e2e/api/query_range_test.go
@@ -134,6 +134,36 @@ sendLoop:
 			targetAttribute:         ".res_attr",
 			targetExemplarAttribute: "resource.res_attr",
 		},
+		{
+			query:                   "{} | rate() by (span.span_attr)",
+			targetAttribute:         "span.span_attr",
+			targetExemplarAttribute: "span.span_attr",
+		},
+		{
+			query:                   "{} | count_over_time() by (span.span_attr)",
+			targetAttribute:         "span.span_attr",
+			targetExemplarAttribute: "span.span_attr",
+		},
+		{
+			query:                   "{} | min_over_time(duration) by (span.span_attr)",
+			targetAttribute:         "span.span_attr",
+			targetExemplarAttribute: "span.span_attr",
+		},
+		{
+			query:                   "{} | max_over_time(duration) by (span.span_attr)",
+			targetAttribute:         "span.span_attr",
+			targetExemplarAttribute: "span.span_attr",
+		},
+		{
+			query:                   "{} | avg_over_time(duration) by (span.span_attr)",
+			targetAttribute:         "span.span_attr",
+			targetExemplarAttribute: "span.span_attr",
+		},
+		{
+			query:                   "{} | sum_over_time(duration) by (span.span_attr)",
+			targetAttribute:         "span.span_attr",
+			targetExemplarAttribute: "span.span_attr",
+		},
 	} {
 		t.Run(testCase.query, func(t *testing.T) {
 			queryRangeRes := callQueryRange(t, tempo.Endpoint(tempoPort), testCase.query, debugMode)

--- a/integration/e2e/api/query_range_test.go
+++ b/integration/e2e/api/query_range_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -371,7 +370,9 @@ func callQueryRange(t *testing.T, endpoint, query string, printBody bool) tempop
 	}
 
 	queryRangeRes := tempopb.QueryRangeResponse{}
-	require.NoError(t, json.Unmarshal(body, &queryRangeRes))
+	readBody := strings.NewReader(string(body))
+	err = new(jsonpb.Unmarshaler).Unmarshal(readBody, &queryRangeRes)
+	require.NoError(t, err)
 	return queryRangeRes
 }
 

--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -1408,7 +1408,6 @@ func (h *HistogramAggregator) Combine(in []*tempopb.TimeSeries) {
 		var bucket Static
 		for _, l := range ts.Labels {
 			if l.Key == internalLabelBucket {
-				// bucket = int(l.Value.GetIntValue())
 				bucket = StaticFromAnyValue(l.Value)
 				continue
 			}

--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -1473,7 +1473,7 @@ func (h *HistogramAggregator) Combine(in []*tempopb.TimeSeries) {
 func (h *HistogramAggregator) Results() SeriesSet {
 	results := make(SeriesSet, len(h.ss)*len(h.qs))
 
-	for key, in := range h.ss {
+	for _, in := range h.ss {
 		// For each input series, we create a new series for each quantile.
 		for _, q := range h.qs {
 			// Append label for the quantile
@@ -1484,7 +1484,7 @@ func (h *HistogramAggregator) Results() SeriesSet {
 			ts := TimeSeries{
 				Labels:    labels,
 				Values:    make([]float64, len(in.hist)),
-				Exemplars: h.ss[key].exemplars,
+				Exemplars: in.exemplars,
 			}
 			for i := range in.hist {
 

--- a/pkg/traceql/engine_metrics_test.go
+++ b/pkg/traceql/engine_metrics_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/grafana/tempo/pkg/tempopb"
+	commonv1proto "github.com/grafana/tempo/pkg/tempopb/common/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1882,4 +1883,118 @@ func BenchmarkSumOverTime(b *testing.B) {
 	for b.Loop() {
 		_, _, _ = runTraceQLMetric(req, in, in2)
 	}
+}
+
+func BenchmarkHistogramAggregator_Combine(b *testing.B) {
+	// nolint:gosec // G115
+	req := &tempopb.QueryRangeRequest{
+		Start:     uint64(time.Now().Add(-1 * time.Hour).UnixNano()),
+		End:       uint64(time.Now().UnixNano()),
+		Step:      uint64(15 * time.Second.Nanoseconds()),
+		Exemplars: maxExemplars,
+	}
+	const seriesCount = 6
+
+	benchmarks := []struct {
+		name          string
+		samplesCount  int
+		exemplarCount int
+	}{
+		{"Small", 10, 5},
+		{"Medium", 100, 20},
+		{"Large", 1000, 100},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			series := generateTestTimeSeries(seriesCount, bm.samplesCount, bm.exemplarCount, req.Start, req.End)
+
+			for b.Loop() {
+				agg := NewHistogramAggregator(req, []float64{0.5, 0.9, 0.99})
+				agg.Combine(series)
+			}
+		})
+	}
+}
+
+// generateTestTimeSeries creates test time series data for benchmarking
+// nolint:gosec // G115
+func generateTestTimeSeries(seriesCount, samplesCount, exemplarCount int, start, end uint64) []*tempopb.TimeSeries {
+	result := make([]*tempopb.TimeSeries, seriesCount)
+
+	timeRange := end - start
+
+	for i := 0; i < seriesCount; i++ {
+		// Create unique labels for each series
+		labels := []commonv1proto.KeyValue{
+			{
+				Key: "service",
+				Value: &commonv1proto.AnyValue{
+					Value: &commonv1proto.AnyValue_StringValue{
+						StringValue: "service-" + fmt.Sprintf("%d", i),
+					},
+				},
+			},
+			{
+				Key: internalLabelBucket,
+				Value: &commonv1proto.AnyValue{
+					Value: &commonv1proto.AnyValue_DoubleValue{
+						DoubleValue: math.Pow(2, float64(i%20)), // Power of 2 as bucket
+					},
+				},
+			},
+		}
+
+		samples := make([]tempopb.Sample, samplesCount)
+		for j := 0; j < samplesCount; j++ {
+			// Distribute samples evenly across the time range
+			offset := (uint64(j) * timeRange) / uint64(samplesCount)
+			ts := time.Unix(0, int64(start+offset)).UnixMilli()
+			samples[j] = tempopb.Sample{
+				TimestampMs: ts,
+				Value:       float64(j % 100), // Simple pattern for test data
+			}
+		}
+
+		// Create exemplars
+		exemplars := make([]tempopb.Exemplar, exemplarCount)
+		for j := 0; j < exemplarCount; j++ {
+			// Distribute exemplars evenly across the time range
+			offset := (uint64(j) * timeRange) / uint64(exemplarCount)
+			ts := time.Unix(0, int64(start+offset)).UnixMilli()
+			exemplarLabels := []commonv1proto.KeyValue{
+				{
+					Key: "trace_id",
+					Value: &commonv1proto.AnyValue{
+						Value: &commonv1proto.AnyValue_StringValue{
+							StringValue: fmt.Sprintf("trace-%d", i*1000+j),
+						},
+					},
+				},
+				{
+					Key: "span_id",
+					Value: &commonv1proto.AnyValue{
+						Value: &commonv1proto.AnyValue_StringValue{
+							StringValue: fmt.Sprintf("span-%d", j),
+						},
+					},
+				},
+			}
+			exemplars[j] = tempopb.Exemplar{
+				Labels: exemplarLabels,
+
+				Value:       float64(j % 100), // Simple pattern for test data
+				TimestampMs: ts,
+			}
+		}
+
+		result[i] = &tempopb.TimeSeries{
+			PromLabels: fmt.Sprintf("{service=\"service-%d\",bucket=\"%d\"}", i, i%20),
+			Labels:     labels,
+			Samples:    samples,
+			Exemplars:  exemplars,
+		}
+	}
+
+	return result
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does

1. Fixes a bug with unmarshalling of TraceQL Metrics response in tests.
2. Fixes a bug when for histogram and quantiles exemplars were put in wrong series.

### Root cause
In this loop: https://github.com/ruslan-mikhailov/tempo/blob/17e20a43af0881ef0841d2e33eaeb190c422e549/pkg/traceql/engine_metrics.go#L1477
it iterates over the series set while putting all the exemplars into each resulting series without any filtration: https://github.com/ruslan-mikhailov/tempo/blob/17e20a43af0881ef0841d2e33eaeb190c422e549/pkg/traceql/engine_metrics.go#L1488

For example, if in total, we have the following exemplars:
E1 - span_attr=val_A
E2 - span_attr=val_A
E3 - span_attr=val_B
E4 - span_attr=val_C
For the following query:
```
{span.span_attr!=nil} | quantile_over_time(span:duration, 0.9) by(span.span_attr)
```

we have:
val_A time series exemplars: E1,E2,E3,E4
val_B time series exemplars: E1,E2,E3,E4
val_C time series exemplars: E1,E2,E3,E4

Expected results:
val_A time series exemplars: E1,E2
val_B time series exemplars: E3
val_C time series exemplars: E4

### Impact
In Grafana UI, after filtering by series, it provides wrong exemplars from another series, misleading users and providing a bad UX.

## How it has been tested
### Unit tests (in the PR)
Check that all exemplars have an attribute label that matches the corresponding time series label.

### Manual testing
1. Run local tempo using local docker compose from `example/docker-compose/local`
2. Run the following script to generate random traces

<details>
  <summary>Python script</summary>
  

```python
import random
import time
from datetime import datetime
from opentelemetry import trace
from opentelemetry.sdk.trace import TracerProvider
from opentelemetry.sdk.trace.export import BatchSpanProcessor
from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
from opentelemetry.sdk.resources import Resource
from opentelemetry.semconv.resource import ResourceAttributes

# Initialize trace provider
resource = Resource.create({
    ResourceAttributes.SERVICE_NAME: "fake-service",
    ResourceAttributes.SERVICE_VERSION: "0.1.0",
})

provider = TracerProvider(resource=resource)
processor = BatchSpanProcessor(OTLPSpanExporter(endpoint="http://localhost:4318/v1/traces"))
provider.add_span_processor(processor)
trace.set_tracer_provider(provider)

tracer = trace.get_tracer("fake-service-tracer")

# Database systems to include in spans
DB_SYSTEMS = ["mongodb", "redis", "elasticsearch", "postgres"]

def generate_nested_spans(depth=0, max_depth=3):
    """Generate nested spans with random operations"""
    if depth >= max_depth:
        return
    
    operations = ["query", "update", "delete", "insert", "get", "set", "scan"]
    operation = random.choice(operations)
    
    # Decide if this should be a database span
    is_db_span = random.random() < 0.3 and depth > 0
    
    # Create context for the span
    span_name = f"operation.{operation}"
    if is_db_span:
        span_name = f"db.{operation}"
    
    with tracer.start_as_current_span(span_name) as span:
        # Add random attributes
        span.set_attribute("operation.type", operation)
        span.set_attribute("timestamp", datetime.now().isoformat())
        
        # Add DB specific attributes for some spans
        if is_db_span:
            db_system = random.choice(DB_SYSTEMS)
            span.set_attribute("db.system", db_system)
            span.set_attribute("db.operation", operation)
            span.set_attribute("db.instance", f"{db_system}-instance-{random.randint(1, 5)}")
            
            # Add specific attributes based on DB type
            if db_system == "mongodb":
                span.set_attribute("db.mongodb.collection", f"collection-{random.randint(1, 10)}")
            elif db_system == "postgres":
                span.set_attribute("db.sql.table", f"table-{random.randint(1, 10)}")
            elif db_system == "redis":
                span.set_attribute("db.redis.database_index", random.randint(0, 15))
        
        # Random delay to simulate work
        time.sleep(random.uniform(0.01, 0.1))
        
        # Randomly generate errors
        if random.random() < 0.1:
            span.set_status(trace.Status(trace.StatusCode.ERROR))
            span.record_exception(Exception(f"Simulated error in {span_name}"))
        
        # Generate nested spans
        nested_count = random.randint(0, 3)
        for _ in range(nested_count):
            generate_nested_spans(depth + 1, max_depth)

def generate_trace():
    """Generate a complete trace with nested spans"""
    request_paths = ["/api/users", "/api/products", "/api/orders", "/api/search", "/api/auth"]
    methods = ["GET", "POST", "PUT", "DELETE"]
    
    path = random.choice(request_paths)
    method = random.choice(methods)
    
    with tracer.start_as_current_span(f"{method} {path}") as root_span:
        root_span.set_attribute("http.method", method)
        root_span.set_attribute("http.url", f"http://fake-service{path}")
        root_span.set_attribute("http.status_code", random.choice([200, 200, 200, 400, 500]))
        root_span.set_attribute("test.version", "1.0.0")
        
        # generate_nested_spans(max_depth=1)
        # Generate between 1-5 nested spans
        for _ in range(random.randint(1, 5)):
            generate_nested_spans(max_depth=5)

def main():
    print("Starting to generate fake traces...")
    try:
        while True:
            generate_trace()
            # Wait between 1-3 seconds between traces
            time.sleep(random.uniform(1, 3))
    except KeyboardInterrupt:
        print("Trace generation stopped.")

if __name__ == "__main__":
    main()

```

</details>

3. Run the following query:
```
{span.db.system!=nil} | quantile_over_time(span:duration, 0.9) by(span.db.system)
```
4. Check that `span.db.system` label in exemplars matches `"promLabels"` of the series

Main branch results:
```json
            "promLabels": "{p=\"0.9\", \"span.db.system\"=\"elasticsearch\"}", <------ elasicsearch
            "exemplars": [
                {
                    "labels": [
                        {
                            "key": "trace:id",
                            "value": {
                                "stringValue": "21c22617e0fb45fcc3cfafb6b792c52"
                            }
                        },
                        {
                            "key": "span.db.system",
                            "value": {
                                "stringValue": "mongodb" <----- wrong span, this is for mongodb, not ES. 
                            }
                        },
                        {
                            "key": "duration",
                            "value": {
                                "stringValue": "210.047ms" <--- value is also from the span that belongs to mongodb
                            }
                        }
                    ],
                    "value": 0.210047,
                    "timestampMs": "1747659434445"
                },
```

After the fix, only exemplars like this:
```json
            "promLabels": "{p=\"0.9\", \"span.db.system\"=\"elasticsearch\"}",
            "exemplars": [
                {
                    "labels": [
                        {
                            "key": "span.db.system",
                            "value": {
                                "stringValue": "elasticsearch"
                            }
                        },
                        {
                            "key": "duration",
                            "value": {
                                "stringValue": "286.236ms"
                            }
                        },
                        {
                            "key": "trace:id",
                            "value": {
                                "stringValue": "2c5cab26dda70db8f4fc5438f2ec1265"
                            }
                        }
                    ],
                    "value": 0.286236,
                    "timestampMs": "1747666540680"
                },

```

## Which issue(s) this PR fixes

Fixes #<issue number>

## Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

