### PR TITLE
Protect span metrics target_info against resource attributes with empty key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [BUGFIX] Fix `TempoBlockListRisingQuickly` alert grouping. [#4876](https://github.com/grafana/tempo/pull/4876) (@mapno)
 * [BUGFIX] Reset `SkipMetricsGeneration` before reuse. [#5117](https://github.com/grafana/tempo/pull/5117) (@flxbk)
 * [BUGFIX] Fix metrics generator host info processor overrides config. [#5118](https://github.com/grafana/tempo/pull/5118) (@rlankfo)
+* [BUGFIX] Fix metrics generator target_info to skip attributes with no name to prevent downstream errors [#5148](https://github.com/grafana/tempo/pull/5148) (@mdisibio)
 * [BUGFIX] Fix for queried number of exemplars (TraceQL Metrics) [#5115](https://github.com/grafana/tempo/pull/5115) (@ruslan-mikhailov)
 
 # v2.7.2

--- a/modules/generator/processor/spanmetrics/spanmetrics.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics.go
@@ -277,6 +277,12 @@ func GetTargetInfoAttributesValues(keys, values *[]string, attributes []*v1_comm
 	for _, attrs := range attributes {
 		// ignoring job and instance
 		key := attrs.Key
+		// Skip empty string keys, which are out of spec but
+		// technically possible in the proto. These will cause
+		// issues downstream for metrics datasources
+		if key == "" {
+			continue
+		}
 		if key != "service.name" && key != "service.namespace" && key != "service.instance.id" && !slices.Contains(exclude, key) {
 			*keys = append(*keys, SanitizeLabelNameWithCollisions(key, intrinsicLabels, sanitizeFn))
 			value := tempo_util.StringifyAnyValue(attrs.Value)


### PR DESCRIPTION
**What this PR does**:
It is technically possible to send a resource attribute with an empty key over the wire, and these cause issues for span metrics target_info.  It will lead to invalid label errors downstream in metrics datasources. This skips over them.

Note - Target info pulls in all resource attributes dynamically (minus any exclusions). So I think it is ok to skip silently here.  Versus, for the regular span metrics, dimensions are configured explicitly. In that case I think the current behavior of bubbling those errors up is preferred.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`