### PR TITLE
add host_source label to track host identifier attribute

### DIFF
--- a/modules/generator/processor/hostinfo/processor_test.go
+++ b/modules/generator/processor/hostinfo/processor_test.go
@@ -17,8 +17,8 @@ import (
 
 func TestHostInfo(t *testing.T) {
 	testRegistry := registry.NewTestRegistry()
-
 	cfg := Config{}
+
 	cfg.RegisterFlagsAndApplyDefaults("", nil)
 	p, err := New(cfg, testRegistry, nil)
 	require.NoError(t, err)
@@ -42,11 +42,64 @@ func TestHostInfo(t *testing.T) {
 
 	lbls0 := labels.FromMap(map[string]string{
 		hostIdentifierAttr: "test0",
+		hostSourceAttr:     "host.id",
 	})
 	assert.Equal(t, 1.0, testRegistry.Query(hostInfoMetric, lbls0))
 
 	lbls1 := labels.FromMap(map[string]string{
 		hostIdentifierAttr: "test1",
+		hostSourceAttr:     "host.id",
 	})
 	assert.Equal(t, 1.0, testRegistry.Query(hostInfoMetric, lbls1))
+}
+
+func TestHostInfoHostSource(t *testing.T) {
+	testRegistry := registry.NewTestRegistry()
+
+	cfg := Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", nil)
+	p, err := New(cfg, testRegistry, nil)
+	require.NoError(t, err)
+	require.Equal(t, p.Name(), Name)
+	defer p.Shutdown(context.TODO())
+
+	req := &tempopb.PushSpansRequest{
+		Batches: []*trace_v1.ResourceSpans{
+			test.MakeBatch(10, nil),
+			test.MakeBatch(10, nil),
+		},
+	}
+
+	for i, b := range req.Batches {
+		if i%2 == 0 {
+			b.Resource.Attributes = append(b.Resource.Attributes, []*common_v1.KeyValue{
+				{Key: "k8s.node.name", Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "test" + strconv.Itoa(i)}}},
+			}...)
+		}
+		b.Resource.Attributes = append(b.Resource.Attributes, []*common_v1.KeyValue{
+			{Key: "host.id", Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "test" + strconv.Itoa(i)}}},
+		}...)
+	}
+
+	p.PushSpans(context.Background(), req)
+
+	for i := range len(req.Batches) {
+		hostIdLbls := labels.FromMap(map[string]string{
+			hostIdentifierAttr: "test" + strconv.Itoa(i),
+			hostSourceAttr:     "host.id",
+		})
+		k8sNodeNameLbls := labels.FromMap(map[string]string{
+			hostIdentifierAttr: "test" + strconv.Itoa(i),
+			hostSourceAttr:     "k8s.node.name",
+		})
+
+		if i%2 == 0 {
+			assert.Equal(t, 0.0, testRegistry.Query(hostInfoMetric, hostIdLbls))
+			assert.Equal(t, 1.0, testRegistry.Query(hostInfoMetric, k8sNodeNameLbls))
+		} else {
+			assert.Equal(t, 1.0, testRegistry.Query(hostInfoMetric, hostIdLbls))
+			assert.Equal(t, 0.0, testRegistry.Query(hostInfoMetric, k8sNodeNameLbls))
+		}
+
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This adds a new `host_source` label to the `host_info` metric generated by the host info processor. This will allow tracking of which host identifying resource attribute was used to generate the metric.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`