### PR TITLE
fix: apply the artificial latency even on pushTrace errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [BUGFIX] Measure the write latency on append errors [#5034](https://github.com/grafana/tempo/pull/5034) (@javiermolinar)
 * [BUGFIX] Correctly cache frontend jobs for query range (TraceQL Metrics). [#4771](https://github.com/grafana/tempo/pull/4771) (@joe-elliott)
 * [BUGFIX] Fix error propagation in the SyncIterator. [#5045](https://github.com/grafana/tempo/pull/5045) (@joe-elliott)
+* [BUGFIX] Apply the artificial latency even on pushTrace errors  [#5153](https://github.com/grafana/tempo/pull/5153) (@javiermolinar)
 * [BUGFIX] Various edge case fixes for query range (TraceQL Metrics) [#4962](https://github.com/grafana/tempo/pull/4962) (@ruslan-mikhailov)
 * [BUGFIX] Fix mixin to include otlp_v1_traces http write route [#5072](https://github.com/grafana/tempo/pull/5072) (@mdisibio)
 * [BUGFIX] Fix `TempoBlockListRisingQuickly` alert grouping. [#4876](https://github.com/grafana/tempo/pull/4876) (@mapno)

--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -405,6 +405,8 @@ func (d *Distributor) PushTraces(ctx context.Context, traces ptrace.Traces) (*te
 		// can't record discarded spans here b/c there's no tenant
 		return nil, err
 	}
+	defer d.padWithArtificialDelay(reqStart, userID)
+
 	if spanCount == 0 {
 		return &tempopb.PushResponse{}, nil
 	}
@@ -480,8 +482,6 @@ func (d *Distributor) PushTraces(ctx context.Context, traces ptrace.Traces) (*te
 			d.generatorForwarder.SendTraces(ctx, userID, keys, rebatchedTraces)
 		}
 	}
-
-	d.padWithArtificialDelay(reqStart, userID)
 
 	return nil, nil // PushRequest is ignored, so no reason to create one
 }

--- a/modules/distributor/distributor_test.go
+++ b/modules/distributor/distributor_test.go
@@ -1770,7 +1770,8 @@ func TestArtificialLatency(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.GreaterOrEqual(t, time.Since(reqStart), latency, "Expected artificial latency not respected")
+	const tolerance = 10 * time.Millisecond
+	assert.GreaterOrEqual(t, time.Since(reqStart)+tolerance, latency, "Expected artificial latency not respected")
 }
 
 func TestArtificialLatencyIsAppliedOnError(t *testing.T) {
@@ -1794,7 +1795,7 @@ func TestArtificialLatencyIsAppliedOnError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
+	const tolerance = 10 * time.Millisecond
 	assert.GreaterOrEqual(t, time.Since(reqStart), latency, "Expected artificial latency not respected")
 }
 

--- a/modules/distributor/distributor_test.go
+++ b/modules/distributor/distributor_test.go
@@ -1796,7 +1796,7 @@ func TestArtificialLatencyIsAppliedOnError(t *testing.T) {
 		t.Fatal(err)
 	}
 	const tolerance = 10 * time.Millisecond
-	assert.GreaterOrEqual(t, time.Since(reqStart), latency, "Expected artificial latency not respected")
+	assert.GreaterOrEqual(t, time.Since(reqStart)+tolerance, latency, "Expected artificial latency not respected")
 }
 
 type testLogSpan struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
The artificial latency was not being applied on errors. For Tempo clusters with lot of refused spans this means that the artificial latency is not always used


**Checklist**
- [X] Tests updated
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`