### PR TITLE
vulture: add parent to generated spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [FEATURE] Added most_recent=true query hint to TraceQL to return most recent results. [#4238](https://github.com/grafana/tempo/pull/4238) (@joe-elliott)
 * [FEATURE] Add ability to add artificial delay to push requests [#4716](https://github.com/grafana/tempo/pull/4716) [#4899](https://github.com/grafana/tempo/pull/4899) [#5035](https://github.com/grafana/tempo/pull/5035) (@yvrhdn, @mapno)
 * [FEATURE] TraceQL metrics: sum_over_time [#4786](https://github.com/grafana/tempo/pull/4786) (@javiermolinar)
+* [ENHANCEMENT] tempo-vulture now generates spans with a parent, instead of only root spans [#5154](https://github.com/grafana/tempo/pull/5154) (@carles-grafana)
 * [ENHANCEMENT] Add default mutex and blocking values. [#4979](https://github.com/grafana/tempo/pull/4979) (@mattdurham) 
 * [ENHANCEMENT] Improve Tempo build options [#4755](https://github.com/grafana/tempo/pull/4755) (@stoewer)
 * [ENHANCEMENT] Rewrite traces using rebatching [#4690](https://github.com/grafana/tempo/pull/4690) (@stoewer @joe-elliott)

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -618,7 +618,6 @@ func queryTrace(client httpclient.TempoHTTPClient, info *util.TraceInfo, l *zap.
 		return tm, nil
 	}
 
-	// iterate through
 	if hasMissingSpans(trace) {
 		logger.Error("trace has missing spans")
 		tm.missingSpans++
@@ -774,20 +773,20 @@ func equalTraces(a, b *tempopb.Trace) bool {
 }
 
 func hasMissingSpans(t *tempopb.Trace) bool {
-	// collect all parent span IDs
-	linkedSpanIDs := make([][]byte, 0)
+	// check that all parent spans exist in the trace
+	parentSpanIDs := make([][]byte, 0)
 
 	for _, b := range t.ResourceSpans {
 		for _, ss := range b.ScopeSpans {
 			for _, s := range ss.Spans {
 				if len(s.ParentSpanId) > 0 {
-					linkedSpanIDs = append(linkedSpanIDs, s.ParentSpanId)
+					parentSpanIDs = append(parentSpanIDs, s.ParentSpanId)
 				}
 			}
 		}
 	}
 
-	for _, id := range linkedSpanIDs {
+	for _, id := range parentSpanIDs {
 		found := false
 
 	B:

--- a/cmd/tempo-vulture/testdata/trace.json
+++ b/cmd/tempo-vulture/testdata/trace.json
@@ -112,6 +112,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "MaSlu9+OmtM=",
+              "parentSpanId": "JOzOehYQAj4=",
               "name": "vulture-47",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000082000",
@@ -375,6 +376,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "U0zLC99qJRg=",
+              "parentSpanId": "YoO3VnVCu5A=",
               "name": "vulture-10",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000094000",
@@ -558,6 +560,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "RKpoZaS43G8=",
+              "parentSpanId": "FJqfJhH5hHM=",
               "name": "vulture-38",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000016000",
@@ -698,6 +701,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "VwCj9LoPYtw=",
+              "parentSpanId": "RKpoZaS43G8=",
               "name": "vulture-62",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000003000",
@@ -957,6 +961,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "MpZcQbqgWkE=",
+              "parentSpanId": "b1kdTyceTsU=",
               "name": "vulture-36",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000030000",
@@ -1039,6 +1044,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "Qnv5gLdo3mA=",
+              "parentSpanId": "MpZcQbqgWkE=",
               "name": "vulture-67",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000082000",
@@ -1109,6 +1115,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "HKgTGlqMnxg=",
+              "parentSpanId": "Qnv5gLdo3mA=",
               "name": "vulture-81",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000045000",
@@ -1298,6 +1305,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "LHSmWp3GTZc=",
+              "parentSpanId": "V44AV0XxAeI=",
               "name": "vulture-64",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000018000",
@@ -1486,6 +1494,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "OAVNaHlwL5k=",
+              "parentSpanId": "cOmTcl2W+TU=",
               "name": "vulture-73",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000062000",
@@ -1556,6 +1565,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "Z2q4YtdoMOc=",
+              "parentSpanId": "OAVNaHlwL5k=",
               "name": "vulture-94",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000061000",
@@ -1803,6 +1813,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "Zuy0zydsCKc=",
+              "parentSpanId": "dEvAKsJfeN8=",
               "name": "vulture-24",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000097000",
@@ -1925,6 +1936,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "LhkOF9Qir1o=",
+              "parentSpanId": "Zuy0zydsCKc=",
               "name": "vulture-8",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000073000",
@@ -1983,6 +1995,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "QoiSbdw1jWA=",
+              "parentSpanId": "LhkOF9Qir1o=",
               "name": "vulture-76",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000033000",
@@ -2172,6 +2185,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "GQZfyLGl9DU=",
+              "parentSpanId": "eX11PkWR7/U=",
               "name": "vulture-22",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000097000",
@@ -2242,6 +2256,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "amlTKv36azs=",
+              "parentSpanId": "GQZfyLGl9DU=",
               "name": "vulture-83",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000036000",
@@ -2523,6 +2538,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "KoCq8Fwo+O4=",
+              "parentSpanId": "HoKLYl94RRg=",
               "name": "vulture-61",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000021000",
@@ -2593,6 +2609,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "VvqffnRCAVw=",
+              "parentSpanId": "KoCq8Fwo+O4=",
               "name": "vulture-48",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000070000",
@@ -2816,6 +2833,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "JRfsQbbqoTA=",
+              "parentSpanId": "FiHBKfLuSo8=",
               "name": "vulture-96",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000055000",
@@ -2944,6 +2962,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "JehDhsbZwwg=",
+              "parentSpanId": "JRfsQbbqoTA=",
               "name": "vulture-45",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000033000",
@@ -3139,6 +3158,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "A6W2oLkGL1U=",
+              "parentSpanId": "CLF/KWb5tZE=",
               "name": "vulture-42",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000044000",
@@ -3250,6 +3270,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "NS8nJt7eKtM=",
+              "parentSpanId": "A6W2oLkGL1U=",
               "name": "vulture-37",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000073000",
@@ -3456,6 +3477,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "D0OHr0cI5lo=",
+              "parentSpanId": "bBfIWctLWVo=",
               "name": "vulture-92",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000054000",
@@ -3561,6 +3583,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "fDQCFQXBISk=",
+              "parentSpanId": "D0OHr0cI5lo=",
               "name": "vulture-94",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000083000",
@@ -3666,6 +3689,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "QQM1rdF2I/E=",
+              "parentSpanId": "fDQCFQXBISk=",
               "name": "vulture-53",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000075000",
@@ -3877,6 +3901,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "H8bLLHJKAW4=",
+              "parentSpanId": "Du5ajMQehCA=",
               "name": "vulture-44",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000065000",
@@ -3988,6 +4013,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "VZ9YK67tu40=",
+              "parentSpanId": "H8bLLHJKAW4=",
               "name": "vulture-3",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000097000",
@@ -4069,6 +4095,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "WcSlH3kOa6A=",
+              "parentSpanId": "VZ9YK67tu40=",
               "name": "vulture-21",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000044000",
@@ -4286,6 +4313,7 @@
             {
               "traceId": "CSCPj2v0UkJjHavLBtfJxg==",
               "spanId": "UeGD9oKF+sA=",
+              "parentSpanId": "b/phdO27Mbk=",
               "name": "vulture-64",
               "startTimeUnixNano": "1636729665000000000",
               "endTimeUnixNano": "1636729665000020000",

--- a/pkg/util/trace_info.go
+++ b/pkg/util/trace_info.go
@@ -151,12 +151,16 @@ func (t *TraceInfo) generateRandomInt(min, max int64) int64 {
 func (t *TraceInfo) makeThriftBatch(TraceIDHigh, TraceIDLow int64) *thrift.Batch {
 	var spans []*thrift.Span
 	count := t.generateRandomInt(1, 5)
+	lastSpanID, nextSpanID := int64(0), int64(0)
+	// Each span has the previous span as parent, creating a tree with a single branch per batch.
 	for i := int64(0); i < count; i++ {
+		nextSpanID = t.r.Int63()
+
 		spans = append(spans, &thrift.Span{
 			TraceIdLow:    TraceIDLow,
 			TraceIdHigh:   TraceIDHigh,
-			SpanId:        t.r.Int63(),
-			ParentSpanId:  0,
+			SpanId:        nextSpanID,
+			ParentSpanId:  lastSpanID,
 			OperationName: fmt.Sprintf("vulture-%d", t.generateRandomInt(0, 100)),
 			References:    nil,
 			Flags:         0,
@@ -165,6 +169,8 @@ func (t *TraceInfo) makeThriftBatch(TraceIDHigh, TraceIDLow int64) *thrift.Batch
 			Tags:          t.generateRandomTags(),
 			Logs:          t.generateRandomLogs(),
 		})
+
+		lastSpanID = nextSpanID
 	}
 
 	process := &thrift.Process{
@@ -178,12 +184,16 @@ func (t *TraceInfo) makeThriftBatch(TraceIDHigh, TraceIDLow int64) *thrift.Batch
 func (t *TraceInfo) makeJaegerBatch(TraceIDHigh, TraceIDLow int64) *jaeger.Batch {
 	var spans []*jaeger.Span
 	count := t.generateRandomInt(1, 5)
+	lastSpanID, nextSpanID := int64(0), int64(0)
+	// Each span has the previous span as parent, creating a tree with a single branch per batch.
 	for i := int64(0); i < count; i++ {
+		nextSpanID = t.r.Int63()
+
 		spans = append(spans, &jaeger.Span{
 			TraceIdLow:    TraceIDLow,
 			TraceIdHigh:   TraceIDHigh,
-			SpanId:        t.r.Int63(),
-			ParentSpanId:  0,
+			SpanId:        nextSpanID,
+			ParentSpanId:  lastSpanID,
 			OperationName: fmt.Sprintf("vulture-%d", t.generateRandomInt(0, 100)),
 			References:    nil,
 			Flags:         0,
@@ -192,6 +202,8 @@ func (t *TraceInfo) makeJaegerBatch(TraceIDHigh, TraceIDLow int64) *jaeger.Batch
 			Tags:          t.generateRandomJaegerTags(),
 			Logs:          t.generateRandomJaegerLogs(),
 		})
+
+		lastSpanID = nextSpanID
 	}
 
 	process := &jaeger.Process{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Currently all spans emitted by vulture are root spans. With this change, most spans will have a parent, making the traces a bit more realistic. The main motive is to test spans with a parent.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`