### PR TITLE
Vulture: check recent traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [ENHANCEMENT] Add memcached to the resources dashboard [#5049](https://github.com/grafana/tempo/pull/5049) (@javiermolinar)
 * [ENHANCEMENT] Query-frontend: logs add msg to the log line [#4975](https://github.com/grafana/tempo/pull/4975) (@jmichalek132)
 * [ENHANCEMENT] Host Info Processor: track host identifying resource attribute in metric [#5152](https://github.com/grafana/tempo/pull/5152) (@rlankfo)
+* [ENHANCEMENT] Vulture checks recent traces [#5157](https://github.com/grafana/tempo/pull/5157) (@ruslan-mikhailov)
 * [BUGFIX] Choose a default step for a gRPC streaming query range request if none is provided. [#4546](https://github.com/grafana/tempo/pull/4576) (@joe-elliott)
   Correctly copy exemplars for metrics like `| rate()` when gRPC streaming.
 * [BUGFIX] Make comparison to nil symmetric [#4869](https://github.com/grafana/tempo/pull/4869) (@stoewer)

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -36,16 +36,17 @@ var (
 	prometheusListenAddress string
 	prometheusPath          string
 
-	tempoQueryURL                 string
-	tempoPushURL                  string
-	tempoOrgID                    string
-	tempoWriteBackoffDuration     time.Duration
-	tempoLongWriteBackoffDuration time.Duration
-	tempoReadBackoffDuration      time.Duration
-	tempoSearchBackoffDuration    time.Duration
-	tempoMetricsBackoffDuration   time.Duration
-	tempoRetentionDuration        time.Duration
-	tempoPushTLS                  bool
+	tempoQueryURL                   string
+	tempoPushURL                    string
+	tempoOrgID                      string
+	tempoWriteBackoffDuration       time.Duration
+	tempoLongWriteBackoffDuration   time.Duration
+	tempoReadBackoffDuration        time.Duration
+	tempoSearchBackoffDuration      time.Duration
+	tempoMetricsBackoffDuration     time.Duration
+	tempoRetentionDuration          time.Duration
+	tempoRecentTracesCutoffDuration time.Duration
+	tempoPushTLS                    bool
 
 	rf1After time.Time
 
@@ -71,16 +72,17 @@ const (
 )
 
 type vultureConfiguration struct {
-	tempoQueryURL                 string
-	tempoPushURL                  string
-	tempoOrgID                    string
-	tempoWriteBackoffDuration     time.Duration
-	tempoLongWriteBackoffDuration time.Duration
-	tempoReadBackoffDuration      time.Duration
-	tempoSearchBackoffDuration    time.Duration
-	tempoMetricsBackoffDuration   time.Duration
-	tempoRetentionDuration        time.Duration
-	tempoPushTLS                  bool
+	tempoQueryURL                   string
+	tempoPushURL                    string
+	tempoOrgID                      string
+	tempoWriteBackoffDuration       time.Duration
+	tempoLongWriteBackoffDuration   time.Duration
+	tempoReadBackoffDuration        time.Duration
+	tempoSearchBackoffDuration      time.Duration
+	tempoMetricsBackoffDuration     time.Duration
+	tempoRetentionDuration          time.Duration
+	tempoRecentTracesCutoffDuration time.Duration
+	tempoPushTLS                    bool
 }
 
 var _ flag.Value = (*timeVar)(nil)
@@ -123,6 +125,7 @@ func init() {
 	flag.DurationVar(&tempoSearchBackoffDuration, "tempo-search-backoff-duration", 60*time.Second, "The amount of time to pause between search Tempo calls.  Set to 0s to disable search.")
 	flag.DurationVar(&tempoMetricsBackoffDuration, "tempo-metrics-backoff-duration", 0, "The amount of time to pause between TraceQL Metrics Tempo calls.  Set to 0s to disable.")
 	flag.DurationVar(&tempoRetentionDuration, "tempo-retention-duration", 336*time.Hour, "The block retention that Tempo is using")
+	flag.DurationVar(&tempoRecentTracesCutoffDuration, "tempo-recent-traces-backoff-duration", 5*time.Minute, "The amount of time to pause between Recent Traces Tempo calls. Set to 0s to disable.")
 
 	flag.Var(newTimeVar(&rf1After), "rhythm-rf1-after", "Timestamp (RFC3339) after which only blocks with RF==1 are included in search and ID lookups")
 }
@@ -140,16 +143,17 @@ func main() {
 	logger.Info("Tempo Vulture starting")
 
 	vultureConfig := vultureConfiguration{
-		tempoQueryURL:                 tempoQueryURL,
-		tempoPushURL:                  tempoPushURL,
-		tempoOrgID:                    tempoOrgID,
-		tempoWriteBackoffDuration:     tempoWriteBackoffDuration,
-		tempoLongWriteBackoffDuration: tempoLongWriteBackoffDuration,
-		tempoReadBackoffDuration:      tempoReadBackoffDuration,
-		tempoSearchBackoffDuration:    tempoSearchBackoffDuration,
-		tempoMetricsBackoffDuration:   tempoMetricsBackoffDuration,
-		tempoRetentionDuration:        tempoRetentionDuration,
-		tempoPushTLS:                  tempoPushTLS,
+		tempoQueryURL:                   tempoQueryURL,
+		tempoPushURL:                    tempoPushURL,
+		tempoOrgID:                      tempoOrgID,
+		tempoWriteBackoffDuration:       tempoWriteBackoffDuration,
+		tempoLongWriteBackoffDuration:   tempoLongWriteBackoffDuration,
+		tempoReadBackoffDuration:        tempoReadBackoffDuration,
+		tempoSearchBackoffDuration:      tempoSearchBackoffDuration,
+		tempoMetricsBackoffDuration:     tempoMetricsBackoffDuration,
+		tempoRetentionDuration:          tempoRetentionDuration,
+		tempoRecentTracesCutoffDuration: tempoRecentTracesCutoffDuration,
+		tempoPushTLS:                    tempoPushTLS,
 	}
 
 	jaegerClient, err := newJaegerGRPCClient(vultureConfig, logger)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

1. Refactoring to simplify code and reduce copy-paste
2. For reads, do two checks: for recent traces that are <5 minutes old, and for older traces. This allows to check read path that hits to generators and ingesters.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**How it has been tested**:
1. unit tests
2. run the new version in k8s for 4h+. Results: no errors reported

Additionally, checked via debug logs that checks run correctly

**Checklist**

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

