### PR TITLE
CI: Push fetch tags into checkout

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,9 +23,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-
-      - name: fetch tags
-        run: git fetch --tags
+          fetch-depth: 0
+          fetch-tags: true
 
       - id: get-tag
         run: |
@@ -48,9 +47,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-
-      - name: fetch tags
-        run: git fetch --tags
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: build-tempo-binaries
         run: |
@@ -116,9 +114,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-
-      - name: fetch tags
-        run: git fetch --tags
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: get-tag
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-
-      - name: fetch tags
-        run: git fetch --tags
+          fetch-depth: 0
+          fetch-tags: true
 
       - id: "get-secrets"
         name: "get nfpm signing keys"


### PR DESCRIPTION
Release CI is failing with "would clobber existing tag" b/c we are pulling the release tag twice. Remove the fetch tags step and push into checkout.

![image](https://github.com/user-attachments/assets/90416bcb-56b8-435e-a2cb-b9f37885e908)

