### PR TITLE
Release CI Fixes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,8 +23,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-          fetch-depth: 0
-          fetch-tags: true
+
+      - name: fetch tags
+        run: git fetch --tags --force
 
       - id: get-tag
         run: |
@@ -47,8 +48,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-          fetch-depth: 0
-          fetch-tags: true
+
+      - name: fetch tags
+        run: git fetch --tags --force
 
       - name: build-tempo-binaries
         run: |
@@ -114,8 +116,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-          fetch-depth: 0
-          fetch-tags: true
+
+      - name: fetch tags
+        run: git fetch --tags --force
 
       - name: get-tag
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: fetch tags
-        run: git fetch --tags
+        run: git fetch --tags --force
 
       - id: "get-secrets"
         name: "get nfpm signing keys"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-          fetch-depth: 0
-          fetch-tags: true
+
+      - name: fetch tags
+        run: git fetch --tags
 
       - id: "get-secrets"
         name: "get nfpm signing keys"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'grafana/tempo'  # skip in forks
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
+      contents: write
       id-token: write
     env:
       NFPM_SIGNING_KEY_FILE: /tmp/nfpm-private-key.key

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,7 @@ builds:
     env:
       - CGO_ENABLED=0
     goos:
-      - darwin
+#      - darwin  re-enable when https://github.com/golang/go/issues/73617 is fixed
       - linux
       - windows
     goarch:
@@ -41,7 +41,7 @@ builds:
     env:
       - CGO_ENABLED=0
     goos:
-      - darwin
+#      - darwin  re-enable when https://github.com/golang/go/issues/73617 is fixed
       - linux
       - windows
     goarch:
@@ -71,7 +71,7 @@ builds:
     env:
       - CGO_ENABLED=0
     goos:
-      - darwin
+#      - darwin  re-enable when https://github.com/golang/go/issues/73617 is fixed
       - linux
       - windows
     goarch:


### PR DESCRIPTION
**What this PR does**:

Brings in a collection of fixes discovered during the 2.8 release process:

- Removes pulling tags during checkout in favor of adding --force to fetch-tags. The release process failed to recognize the tags pulled during checkout for unknown reasons.
- Changed read -> write permission for the token in the release process to allow creating new releases.
- Removed darwin builds from our release due to [an issue with go](https://github.com/golang/go/issues/73617). We can re-enable once fixed.

