### PR TITLE
linter: disable gosec rule g115

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,9 @@ linters:
         - (github.com/go-kit/log.Logger).Log
     errorlint:
       errorf: false
+    gosec:
+      excludes:
+        - G115
   exclusions:
     generated: lax
     presets:


### PR DESCRIPTION
G115: Potential integer overflow when converting between integer types

This rule introduced a lot of noise as we have a lot of cases where we truncate or change the sign of an integer type. In addition, in many cases protobuf definitions are involved, which require regeneration. But most importantly, `len` always returns `int`, which means we should add a conditional every time we need to convert it, potentially affecting performance.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`