### PR TITLE
Fix distributor rebatch bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ configurable via the throughput_bytes_slo field, and it will populate op="traces
 * [BUGFIX] Choose a default step for a gRPC streaming query range request if none is provided. [#4546](https://github.com/grafana/tempo/pull/4576) (@joe-elliott)
   Correctly copy exemplars for metrics like `| rate()` when gRPC streaming.
 * [BUGFIX] Make comparison to nil symmetric [#4869](https://github.com/grafana/tempo/pull/4869) (@stoewer)
+* [BUGFIX] Fix distributor issue where a hash collision could lead to spans stored incorrectly [#5186](https://github.com/grafana/tempo/pull/5186) (@mdisibio)
 * [BUGFIX] Fix behavior for queries like {.foo && true} and {.foo || false} [#4855](https://github.com/grafana/tempo/pull/4855) (@stoewer)
 * [BUGFIX] Fix performance bottleneck and file cleanup in block builder [#4550](https://github.com/grafana/tempo/pull/4550) (@mdisibio)
 * [BUGFIX] Add object name to cache key in ReadRange [#4982](https://github.com/grafana/tempo/pull/4982) (@joe-elliott)

--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -42,8 +42,7 @@ import (
 	v1_common "github.com/grafana/tempo/pkg/tempopb/common/v1"
 	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	"github.com/grafana/tempo/pkg/usagestats"
-	tempo_util "github.com/grafana/tempo/pkg/util"
-
+	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/pkg/validation"
 )
 
@@ -472,7 +471,7 @@ func (d *Distributor) PushTraces(ctx context.Context, traces ptrace.Traces) (*te
 
 	maxAttributeBytes := d.getMaxAttributeBytes(userID)
 
-	keys, rebatchedTraces, truncatedAttributeCount, err := requestsByTraceID(batches, userID, spanCount, maxAttributeBytes)
+	ringTokens, rebatchedTraces, truncatedAttributeCount, err := requestsByTraceID(batches, userID, spanCount, maxAttributeBytes)
 	if err != nil {
 		logDiscardedResourceSpans(batches, userID, &d.cfg.LogDiscardedSpans, d.logger)
 		return nil, err
@@ -482,7 +481,7 @@ func (d *Distributor) PushTraces(ctx context.Context, traces ptrace.Traces) (*te
 		metricAttributesTruncated.WithLabelValues(userID).Add(float64(truncatedAttributeCount))
 	}
 
-	err = d.sendToIngestersViaBytes(ctx, userID, rebatchedTraces, keys)
+	err = d.sendToIngestersViaBytes(ctx, userID, rebatchedTraces, ringTokens)
 	if err != nil {
 		return nil, err
 	}
@@ -492,7 +491,7 @@ func (d *Distributor) PushTraces(ctx context.Context, traces ptrace.Traces) (*te
 	}
 
 	if d.kafkaProducer != nil {
-		err := d.sendToKafka(ctx, userID, keys, rebatchedTraces)
+		err := d.sendToKafka(ctx, userID, ringTokens, rebatchedTraces)
 		if err != nil {
 			level.Error(d.logger).Log("msg", "failed to write to kafka", "err", err)
 			return nil, err
@@ -500,7 +499,7 @@ func (d *Distributor) PushTraces(ctx context.Context, traces ptrace.Traces) (*te
 	} else {
 		// See if we need to send to the generators
 		if len(d.overrides.MetricsGeneratorProcessors(userID)) > 0 {
-			d.generatorForwarder.SendTraces(ctx, userID, keys, rebatchedTraces)
+			d.generatorForwarder.SendTraces(ctx, userID, ringTokens, rebatchedTraces)
 		}
 	}
 
@@ -704,11 +703,11 @@ func (d *Distributor) sendToKafka(ctx context.Context, userID string, keys []uin
 // and traces to pass onto the ingesters.
 func requestsByTraceID(batches []*v1.ResourceSpans, userID string, spanCount, maxSpanAttrSize int) ([]uint32, []*rebatchedTrace, int, error) {
 	const tracesPerBatch = 20 // p50 of internal env
-	tracesByID := make(map[uint32]*rebatchedTrace, tracesPerBatch)
+	tracesByID := make(map[uint64]*rebatchedTrace, tracesPerBatch)
 	truncatedAttributeCount := 0
 
 	for _, b := range batches {
-		spansByILS := make(map[uint32]*v1.ScopeSpans)
+		spansByILS := make(map[uint64]*v1.ScopeSpans)
 		// check resource for large attributes
 		if maxSpanAttrSize > 0 && b.Resource != nil {
 			resourceAttrTruncatedCount := processAttributes(b.Resource.Attributes, maxSpanAttrSize)
@@ -745,11 +744,11 @@ func requestsByTraceID(batches []*v1.ResourceSpans, userID string, spanCount, ma
 					return nil, nil, 0, status.Errorf(codes.InvalidArgument, "trace ids must be 128 bit, received %d bits", len(traceID)*8)
 				}
 
-				traceKey := tempo_util.TokenFor(userID, traceID)
+				traceKey := util.HashForTraceID(traceID)
 				ilsKey := traceKey
 				if ils.Scope != nil {
-					ilsKey = fnv1a.AddString32(ilsKey, ils.Scope.Name)
-					ilsKey = fnv1a.AddString32(ilsKey, ils.Scope.Version)
+					ilsKey = fnv1a.AddString64(ilsKey, ils.Scope.Name)
+					ilsKey = fnv1a.AddString64(ilsKey, ils.Scope.Version)
 				}
 
 				existingILS, ilsAdded := spansByILS[ilsKey]
@@ -800,15 +799,15 @@ func requestsByTraceID(batches []*v1.ResourceSpans, userID string, spanCount, ma
 
 	metricTracesPerBatch.Observe(float64(len(tracesByID)))
 
-	keys := make([]uint32, 0, len(tracesByID))
+	ringTokens := make([]uint32, 0, len(tracesByID))
 	traces := make([]*rebatchedTrace, 0, len(tracesByID))
 
-	for k, r := range tracesByID {
-		keys = append(keys, k)
-		traces = append(traces, r)
+	for _, tr := range tracesByID {
+		ringTokens = append(ringTokens, util.TokenFor(userID, tr.id))
+		traces = append(traces, tr)
 	}
 
-	return keys, traces, truncatedAttributeCount, nil
+	return ringTokens, traces, truncatedAttributeCount, nil
 }
 
 // find and truncate the span attributes that are too large
@@ -993,7 +992,7 @@ func logSpans(batches []*v1.ResourceSpans, cfg *LogSpansConfig, logger log.Logge
 				loggerWithAtts = log.With(
 					loggerWithAtts,
 					"span_"+strutil.SanitizeLabelName(a.GetKey()),
-					tempo_util.StringifyAnyValue(a.GetValue()))
+					util.StringifyAnyValue(a.GetValue()))
 			}
 		}
 
@@ -1015,7 +1014,7 @@ func logSpan(s *v1.Span, allAttributes bool, logger log.Logger) {
 			logger = log.With(
 				logger,
 				"span_"+strutil.SanitizeLabelName(a.GetKey()),
-				tempo_util.StringifyAnyValue(a.GetValue()))
+				util.StringifyAnyValue(a.GetValue()))
 		}
 
 		latencySeconds := float64(s.GetEndTimeUnixNano()-s.GetStartTimeUnixNano()) / float64(time.Second.Nanoseconds())

--- a/modules/distributor/distributor_test.go
+++ b/modules/distributor/distributor_test.go
@@ -76,8 +76,13 @@ func TestRequestsByTraceID(t *testing.T) {
 	traceIDA := []byte{0x0A, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}
 	traceIDB := []byte{0x0B, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}
 
+	// These 2 trace IDs are known to collide under fnv32
+	collision1, _ := util.HexStringToTraceID("fd5980503add11f09f80f77608c1b2da")
+	collision2, _ := util.HexStringToTraceID("091ea7803ade11f0998a055186ee1243")
+
 	tests := []struct {
 		name           string
+		emptyTenant    bool
 		batches        []*v1.ResourceSpans
 		expectedKeys   []uint32
 		expectedTraces []*tempopb.Trace
@@ -715,32 +720,206 @@ func TestRequestsByTraceID(t *testing.T) {
 			expectedStarts: []uint32{10, 60},
 			expectedEnds:   []uint32{50, 80},
 		},
+		{
+			// These 2 trace IDs are known to collide under fnv32
+			name:        "known collisions",
+			emptyTenant: true,
+			batches: []*v1.ResourceSpans{
+				{
+					Resource: &v1_resource.Resource{
+						DroppedAttributesCount: 3,
+					},
+					ScopeSpans: []*v1.ScopeSpans{
+						{
+							Scope: &v1_common.InstrumentationScope{
+								Name: "test",
+							},
+							Spans: []*v1.Span{
+								{
+									TraceId:           collision2,
+									Name:              "spanA",
+									StartTimeUnixNano: uint64(30 * time.Second),
+									EndTimeUnixNano:   uint64(40 * time.Second),
+								},
+								{
+									TraceId:           collision2,
+									Name:              "spanC",
+									StartTimeUnixNano: uint64(20 * time.Second),
+									EndTimeUnixNano:   uint64(50 * time.Second),
+								},
+								{
+									TraceId:           collision1,
+									Name:              "spanE",
+									StartTimeUnixNano: uint64(70 * time.Second),
+									EndTimeUnixNano:   uint64(80 * time.Second),
+								},
+							},
+						},
+					},
+				},
+				{
+					Resource: &v1_resource.Resource{
+						DroppedAttributesCount: 4,
+					},
+					ScopeSpans: []*v1.ScopeSpans{
+						{
+							Scope: &v1_common.InstrumentationScope{
+								Name: "test2",
+							},
+							Spans: []*v1.Span{
+								{
+									TraceId:           collision2,
+									Name:              "spanB",
+									StartTimeUnixNano: uint64(10 * time.Second),
+									EndTimeUnixNano:   uint64(30 * time.Second),
+								},
+								{
+									TraceId:           collision1,
+									Name:              "spanD",
+									StartTimeUnixNano: uint64(60 * time.Second),
+									EndTimeUnixNano:   uint64(80 * time.Second),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedKeys: []uint32{
+				util.TokenFor("", collision1),
+				util.TokenFor("", collision2),
+			},
+			expectedTraces: []*tempopb.Trace{
+				{
+					ResourceSpans: []*v1.ResourceSpans{
+						{
+							Resource: &v1_resource.Resource{
+								DroppedAttributesCount: 3,
+							},
+							ScopeSpans: []*v1.ScopeSpans{
+								{
+									Scope: &v1_common.InstrumentationScope{
+										Name: "test",
+									},
+									Spans: []*v1.Span{
+										{
+											TraceId:           collision1,
+											Name:              "spanE",
+											StartTimeUnixNano: uint64(70 * time.Second),
+											EndTimeUnixNano:   uint64(80 * time.Second),
+										},
+									},
+								},
+							},
+						},
+						{
+							Resource: &v1_resource.Resource{
+								DroppedAttributesCount: 4,
+							},
+							ScopeSpans: []*v1.ScopeSpans{
+								{
+									Scope: &v1_common.InstrumentationScope{
+										Name: "test2",
+									},
+									Spans: []*v1.Span{
+										{
+											TraceId:           collision1,
+											Name:              "spanD",
+											StartTimeUnixNano: uint64(60 * time.Second),
+											EndTimeUnixNano:   uint64(80 * time.Second),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ResourceSpans: []*v1.ResourceSpans{
+						{
+							Resource: &v1_resource.Resource{
+								DroppedAttributesCount: 3,
+							},
+							ScopeSpans: []*v1.ScopeSpans{
+								{
+									Scope: &v1_common.InstrumentationScope{
+										Name: "test",
+									},
+									Spans: []*v1.Span{
+										{
+											TraceId:           collision2,
+											Name:              "spanA",
+											StartTimeUnixNano: uint64(30 * time.Second),
+											EndTimeUnixNano:   uint64(40 * time.Second),
+										},
+										{
+											TraceId:           collision2,
+											Name:              "spanC",
+											StartTimeUnixNano: uint64(20 * time.Second),
+											EndTimeUnixNano:   uint64(50 * time.Second),
+										},
+									},
+								},
+							},
+						},
+						{
+							Resource: &v1_resource.Resource{
+								DroppedAttributesCount: 4,
+							},
+							ScopeSpans: []*v1.ScopeSpans{
+								{
+									Scope: &v1_common.InstrumentationScope{
+										Name: "test2",
+									},
+									Spans: []*v1.Span{
+										{
+											TraceId:           collision2,
+											Name:              "spanB",
+											StartTimeUnixNano: uint64(10 * time.Second),
+											EndTimeUnixNano:   uint64(30 * time.Second),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedIDs: [][]byte{
+				collision1,
+				collision2,
+			},
+			expectedStarts: []uint32{60, 10},
+			expectedEnds:   []uint32{80, 50},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			keys, rebatchedTraces, _, err := requestsByTraceID(tt.batches, util.FakeTenantID, 1, 1000)
-			require.Equal(t, len(keys), len(rebatchedTraces))
+			tenant := util.FakeTenantID
+			if tt.emptyTenant {
+				tenant = ""
+			}
+			ringTokens, rebatchedTraces, _, err := requestsByTraceID(tt.batches, tenant, 1, 1000)
+			require.Equal(t, len(ringTokens), len(rebatchedTraces))
 
-			for i, expectedKey := range tt.expectedKeys {
+			for i, expectedID := range tt.expectedIDs {
 				foundIndex := -1
-				for j, key := range keys {
-					if expectedKey == key {
+				for j, tr := range rebatchedTraces {
+					if bytes.Equal(expectedID, tr.id) {
 						foundIndex = j
+						break
 					}
 				}
 				require.NotEqual(t, -1, foundIndex, "expected key %d not found", foundIndex)
 
 				// now confirm that the request at this position is the expected one
-				expectedReq := tt.expectedTraces[i]
-				actualReq := rebatchedTraces[foundIndex].trace
-				assert.Equal(t, expectedReq, actualReq)
-				assert.Equal(t, tt.expectedIDs[i], rebatchedTraces[foundIndex].id)
-				assert.Equal(t, tt.expectedStarts[i], rebatchedTraces[foundIndex].start)
-				assert.Equal(t, tt.expectedEnds[i], rebatchedTraces[foundIndex].end)
+				require.Equal(t, tt.expectedIDs[i], rebatchedTraces[foundIndex].id)
+				require.Equal(t, tt.expectedTraces[i], rebatchedTraces[foundIndex].trace)
+				require.Equal(t, tt.expectedStarts[i], rebatchedTraces[foundIndex].start)
+				require.Equal(t, tt.expectedEnds[i], rebatchedTraces[foundIndex].end)
 			}
 
-			assert.Equal(t, tt.expectedErr, err)
+			require.Equal(t, tt.expectedErr, err)
 		})
 	}
 }

--- a/pkg/util/hash.go
+++ b/pkg/util/hash.go
@@ -4,7 +4,9 @@ import (
 	"hash/fnv"
 )
 
-// TokenFor generates a token used for finding ingesters from ring
+// TokenFor generates a token used for finding ingesters from ring.
+// Not suitable for in-memory hashing or deduping because it is only 32-bit.
+// The collision rate is about 1 in 8000.
 func TokenFor(userID string, b []byte) uint32 {
 	h := fnv.New32()
 	_, _ = h.Write([]byte(userID))
@@ -12,9 +14,17 @@ func TokenFor(userID string, b []byte) uint32 {
 	return h.Sum32()
 }
 
-// TokenForTraceID generates a hashed value for a trace id
+// TokenForTraceID generates a hashed value for a trace id.  Used for bloom lookups.
+// Do not change because it will break lookups on existing bloom filters.
 func TokenForTraceID(b []byte) uint32 {
 	h := fnv.New32()
 	_, _ = h.Write(b)
 	return h.Sum32()
+}
+
+// HashForTraceID generates a generic hash for the trace ID, suitable for mapping and deduping.
+func HashForTraceID(tid []byte) uint64 {
+	h := fnv.New64()
+	_, _ = h.Write(tid)
+	return h.Sum64()
 }

--- a/pkg/util/hash_test.go
+++ b/pkg/util/hash_test.go
@@ -1,0 +1,68 @@
+package util
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHashForNoCollisions(t *testing.T) {
+	// Verify cases of known collisions under TokenFor don't collide in HashForTraceID.
+	pairs := [][2]string{
+		{"fd5980503add11f09f80f77608c1b2da", "091ea7803ade11f0998a055186ee1243"},
+		{"9e0d446036dc11f09ac04988d2097052", "a61ed97036dc11f0883771db3b51b1ec"},
+		{"6b27f5501eda11f09e99db1b2c23c542", "6b4149b01eda11f0b0e2a966cf7ebbc8"},
+		{"3e9582202f9a11f0afb01b7c06024bd6", "370db6802f9a11f0a9a212dff3125239"},
+		{"978d70802a7311f0991f350653ef0ab4", "9b66da202a7311f09d292db17ccfd31a"},
+		{"de567f703bb711f0b8c377682d1667e6", "dc2d0fc03bb711f091de732fcf93048c"},
+	}
+	for _, pair := range pairs {
+		b1, _ := HexStringToTraceID(pair[0])
+		b2, _ := HexStringToTraceID(pair[1])
+
+		t1 := HashForTraceID(b1)
+		t2 := HashForTraceID(b2)
+
+		require.NotEqual(t, t1, t2)
+	}
+}
+
+// Verify HashForTraceID doesn't collide within reasonable numbers, and estimate the hash collision rate if it does.
+func TestHashForCollisionRate(t *testing.T) {
+	var (
+		n      = 1_000_000
+		tokens = map[uint64]struct{}{}
+		IDs    = make([][]byte, 0, n)
+	)
+
+	for i := 0; i < n; i++ {
+		traceID := make([]byte, 16)
+		_, err := rand.Read(traceID)
+		require.NoError(t, err)
+
+		IDs = append(IDs, traceID)
+		tokens[HashForTraceID(traceID)] = struct{}{}
+	}
+
+	// Ensure no duplicate span IDs accidentally generated
+	sort.Slice(IDs, func(i, j int) bool {
+		return bytes.Compare(IDs[i], IDs[j]) == -1
+	})
+	for i := 1; i < len(IDs); i++ {
+		if bytes.Equal(IDs[i-1], IDs[i]) {
+			panic("same trace ID was generated, oops")
+		}
+	}
+
+	missing := n - len(tokens)
+	if missing > 0 {
+		fmt.Printf("missing 1 out of every %.2f trace ids", float32(n)/float32(missing))
+	}
+
+	// There shouldn't be any collisions.
+	require.Equal(t, n, len(tokens))
+}

--- a/pkg/util/hash_test.go
+++ b/pkg/util/hash_test.go
@@ -3,7 +3,6 @@ package util
 import (
 	"bytes"
 	"crypto/rand"
-	"fmt"
 	"sort"
 	"testing"
 
@@ -59,10 +58,5 @@ func TestHashForCollisionRate(t *testing.T) {
 	}
 
 	missing := n - len(tokens)
-	if missing > 0 {
-		fmt.Printf("missing 1 out of every %.2f trace ids", float32(n)/float32(missing))
-	}
-
-	// There shouldn't be any collisions.
-	require.Equal(t, n, len(tokens))
+	require.Zerof(t, missing, "missing 1 out of every %.2f trace ids", float32(n)/float32(missing))
 }


### PR DESCRIPTION
**What this PR does**:
Distributors rebatch incoming writes by trace ID, in order to ensure that all spans for a given trace end up on the same ingesters over time.  It's using a 32-bit hash which can lead to collisions.  When 2 traces in the incoming write request have the same hash (collide), their spans will get intermixed, i.e. bad data.

The core issue is that the distributor logic was conflating hashing for the ring, and hashing for dedupe.  These don't need to be the same hash, nor should they be.  Because the ring requires 32-bit hashes and collisions there don't matter, it just means 2 traces go the same ingesters (normal and unavoidable).   

But collisions for dedupe must be avoided, and we do this by swapping that part to a 64-bit hash.  Same approach as in trace combiner for spans, and there are test cases for known trace ID collisions under the old method and a test to check the collision rate of the new method.  

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`