### PR TITLE
Exclude parent span id from selectAll

### DIFF
--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -1660,9 +1660,11 @@ func createSpanIterator(makeIter makeIterFn, primaryIter parquetquery.Iterator, 
 			if entry.scope != intrinsicScopeSpan {
 				continue
 			}
-			// These intrinsics aren't included in select all because I say so.
+			// These intrinsics aren't included in select all because they
+			// aren't useful for compare().
 			switch intrins {
 			case traceql.IntrinsicSpanID,
+				traceql.IntrinsicParentID,
 				traceql.IntrinsicSpanStartTime,
 				traceql.IntrinsicStructuralDescendant,
 				traceql.IntrinsicStructuralChild,

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -2036,9 +2036,11 @@ func createSpanIterator(makeIter makeIterFn, innerIterators []parquetquery.Itera
 			if entry.scope != intrinsicScopeSpan {
 				continue
 			}
-			// These intrinsics aren't included in select all because I say so.
+			// These intrinsics aren't included in select all because they
+			// aren't useful for compare().
 			switch intrins {
 			case traceql.IntrinsicSpanID,
+				traceql.IntrinsicParentID,
 				traceql.IntrinsicSpanStartTime,
 				traceql.IntrinsicStructuralDescendant,
 				traceql.IntrinsicStructuralChild,

--- a/tempodb/encoding/vparquet4/block_traceql_test.go
+++ b/tempodb/encoding/vparquet4/block_traceql_test.go
@@ -887,7 +887,6 @@ func flattenForSelectAll(tr *Trace, dcm dedicatedColumnMapping) *traceql.Spanset
 				newS.addSpanAttr(traceql.IntrinsicNameAttribute, traceql.NewStaticString(s.Name))
 				newS.addSpanAttr(traceql.IntrinsicStatusAttribute, traceql.NewStaticStatus(otlpStatusToTraceqlStatus(uint64(s.StatusCode))))
 				newS.addSpanAttr(traceql.IntrinsicStatusMessageAttribute, traceql.NewStaticString(s.StatusMessage))
-				newS.addSpanAttr(traceql.IntrinsicParentIDAttribute, traceql.NewStaticString(util.SpanIDToHexString(s.ParentSpanID)))
 
 				if s.HttpStatusCode != nil {
 					newS.addSpanAttr(traceql.NewScopedAttribute(traceql.AttributeScopeSpan, false, LabelHTTPStatusCode), traceql.NewStaticInt(int(*s.HttpStatusCode)))


### PR DESCRIPTION
**What this PR does**:
When we added the intrinsic for parent span ID, it got automatically included in selectAll for the compare() function. But it isn't useful and excluding it will save significant cpu/mem.

```
                                                                      │ before.txt │             after.txt             │
                                                                      │   sec/op   │   sec/op    vs base               │
BackendBlockQueryRange/{_name_!=_nil_}_|_compare({status=error})/5-14   3.353 ± 2%   2.879 ± 3%  -14.12% (p=0.002 n=6)

                                                                      │ before.txt │             after.txt             │
                                                                      │  MB_IO/op  │  MB_IO/op   vs base               │
BackendBlockQueryRange/{_name_!=_nil_}_|_compare({status=error})/5-14   26.21 ± 0%   19.64 ± 0%  -25.07% (p=0.002 n=6)

                                                                      │ before.txt  │           after.txt            │
                                                                      │  spans/op   │  spans/op    vs base           │
BackendBlockQueryRange/{_name_!=_nil_}_|_compare({status=error})/5-14   819.6k ± 0%   819.6k ± 0%  ~ (p=1.000 n=6) ¹
¹ all samples are equal

                                                                      │ before.txt  │             after.txt              │
                                                                      │   spans/s   │   spans/s    vs base               │
BackendBlockQueryRange/{_name_!=_nil_}_|_compare({status=error})/5-14   244.5k ± 2%   284.7k ± 3%  +16.45% (p=0.002 n=6)

                                                                      │  before.txt   │              after.txt               │
                                                                      │     B/op      │     B/op       vs base               │
BackendBlockQueryRange/{_name_!=_nil_}_|_compare({status=error})/5-14   807.4Mi ± 27%   403.0Mi ± 42%  -50.08% (p=0.002 n=6)

                                                                      │ before.txt  │             after.txt              │
                                                                      │  allocs/op  │  allocs/op   vs base               │
BackendBlockQueryRange/{_name_!=_nil_}_|_compare({status=error})/5-14   6.359M ± 3%   2.746M ± 4%  -56.83% (p=0.002 n=6)
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`