### PR TITLE
ci: add contents read permission in backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -19,7 +19,8 @@ jobs:
     if: github.repository == 'grafana/tempo'
     runs-on: ubuntu-latest
     permissions:
-        id-token: write
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout Actions


### PR DESCRIPTION
**What this PR does**:

As per the [docs of the get-vault-secrets workflow](https://github.com/grafana/shared-workflows/tree/main/actions/get-vault-secrets#using-outputs), we need both  `contents: read` and `id-token: write ` permissions for auth to work

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`