### PR TITLE
Fix structural metrics rate by aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [ENHANCEMENT] Include backendwork dashboard and include additional alert [#5159](https://github.com/grafana/tempo/pull/5159) (@zalegrala)
 * [BUGFIX] Excluded nestedSetParent and other values from compare() function [#5196](https://github.com/grafana/tempo/pull/5196) (@mdisibio)
 * [BUGFIX] Add nil check to partitionAssignmentVar [#5198](https://github.com/grafana/tempo/pull/5198) (@mapno)
+* [BUGFIX] Fix structural metrics rate by aggregation [#5204](https://github.com/grafana/tempo/pull/5204) (@zalegrala)
 
 # v2.8.0-rc.0
 

--- a/pkg/traceql/engine_metrics_test.go
+++ b/pkg/traceql/engine_metrics_test.go
@@ -303,6 +303,31 @@ func TestCompileMetricsQueryRangeFetchSpansRequest(t *testing.T) {
 				},
 			},
 		},
+		"structural_rate_by": {
+			q: "{name=`foo`} > {} | rate() by (name)",
+			expectedReq: FetchSpansRequest{
+				AllConditions: false,
+				Conditions: []Condition{
+					{
+						Attribute: NewIntrinsic(IntrinsicStructuralChild),
+					},
+					{
+						Attribute: IntrinsicNameAttribute,
+						Op:        OpEqual,
+						Operands:  Operands{NewStaticString("foo")},
+					},
+				},
+				SecondPassConditions: []Condition{
+					{
+						Attribute: IntrinsicNameAttribute,
+					},
+					{
+						// Since there is already a second pass then span start time isn't optimized to the first pass.
+						Attribute: IntrinsicSpanStartTimeAttribute,
+					},
+				},
+			},
+		},
 	}
 
 	for n, tc := range tc {

--- a/pkg/traceql/storage.go
+++ b/pkg/traceql/storage.go
@@ -124,6 +124,16 @@ func (f *FetchSpansRequest) HasAttribute(a Attribute) bool {
 	return false
 }
 
+func (f *FetchSpansRequest) SecondPassHasAttribute(a Attribute) bool {
+	for _, cc := range f.SecondPassConditions {
+		if cc.Attribute == a {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (f *FetchSpansRequest) HasAttributeWithOp(a Attribute, o Operator) bool {
 	for _, cc := range f.Conditions {
 		if cc.Attribute == a && cc.Op == o {

--- a/tempodb/encoding/vparquet4/block_traceql_test.go
+++ b/tempodb/encoding/vparquet4/block_traceql_test.go
@@ -1114,6 +1114,7 @@ func BenchmarkBackendBlockQueryRange(b *testing.B) {
 		"{} | max_over_time(duration) by (span.http.status_code)",
 		"{} | min_over_time(duration) by (span.http.status_code)",
 		"{ name != nil } | compare({status=error})",
+		"{} > {} | rate() by (name)", // structural
 	}
 
 	e := traceql.NewEngine()


### PR DESCRIPTION
**What this PR does**:

When using structural operators for metrics queries in combination with a `rate by` aggregator, it is necessary for each of the span set filters to contain the attributes for which we expect to produce a metrics series.

`{name=~"noop"} > {} | rate() by (name)`

In the above query, the first filter matches spans against the `name` attribute the results are then further filtered by the `childOf` operator against the second "empty" filter.  The `rate() by` is performed on the against the second spanset filter, but we have not loaded any columns, and so when we go to generate the series, in some cases we have nil values.

Here we make an adjustment so that each attribute which we want to `rate() by` is included in the second pass when the `AllConditions` is set to false, as is the case with the `childOf` operations.  This ensures that we load the appropriate columns and are able to generate the desired series.

**Which issue(s) this PR fixes**:
Fixes #4828

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`