### PR TITLE
[DOC] Fix traces.spanmetrics in Alloy config doc

### DIFF
--- a/docs/sources/tempo/configuration/grafana-alloy/span-metrics.md
+++ b/docs/sources/tempo/configuration/grafana-alloy/span-metrics.md
@@ -68,7 +68,7 @@ otelcol.connector.spanmetrics "default" {
 
   metrics_flush_interval = "15s"
 
-  namespace = "traces_spanmetrics"
+  namespace = "traces.spanmetrics"
 
   output {
     metrics = [otelcol.exporter.otlp.default.input]


### PR DESCRIPTION
**What this PR does**:

Corrects Alloy config for span metrics to use a `.` instead of `_`: 
```
  namespace = "traces.spanmetrics"
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`