### PR TITLE
Backport #5196 to 2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [BUGFIX] Excluded nestedSetParent and other values from compare() function [#5196](https://github.com/grafana/tempo/pull/5196) (@mdisibio)
 * [BUGFIX] Fix distributor issue where a hash collision could lead to spans stored incorrectly [#5186](https://github.com/grafana/tempo/pull/5186) (@mdisibio)
 
 # v2.8.0-rc.0

--- a/pkg/traceql/engine_metrics_compare.go
+++ b/pkg/traceql/engine_metrics_compare.go
@@ -136,11 +136,15 @@ func (m *MetricsCompare) observe(span Span) {
 			return
 		}
 
-		// These attributes get pulled back by select all but we never
-		// group by them because the cardinality isn't useful.
+		// These attributes get pulled back by select all, or might be used in a comparison query,
+		// but we never group by them because the cardinality isn't useful.
 		switch a {
 		case IntrinsicSpanStartTimeAttribute,
-			IntrinsicTraceIDAttribute:
+			IntrinsicTraceIDAttribute,
+			IntrinsicParentIDAttribute,
+			IntrinsicNestedSetLeftAttribute,
+			IntrinsicNestedSetRightAttribute,
+			IntrinsicNestedSetParentAttribute:
 			return
 		}
 

--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -1660,9 +1660,11 @@ func createSpanIterator(makeIter makeIterFn, primaryIter parquetquery.Iterator, 
 			if entry.scope != intrinsicScopeSpan {
 				continue
 			}
-			// These intrinsics aren't included in select all because I say so.
+			// These intrinsics aren't included in select all because they
+			// aren't useful for compare().
 			switch intrins {
 			case traceql.IntrinsicSpanID,
+				traceql.IntrinsicParentID,
 				traceql.IntrinsicSpanStartTime,
 				traceql.IntrinsicStructuralDescendant,
 				traceql.IntrinsicStructuralChild,
@@ -2132,13 +2134,22 @@ func createAttributeIterator(makeIter makeIterFn, conditions []traceql.Condition
 ) (parquetquery.Iterator, error) {
 	if selectAll {
 		// Select all with no filtering
+		// Levels such as resource/instrumentation/span may have no attributes. When that
+		// occurs the columns are encoded as single null values, and the current attribute
+		// collector reads them as Nils.  We could skip them in the attribute collector,
+		// but this is more performant because it's at the lowest level.
+		// Alternatively, JoinIterators don't pay attention to -1 (undefined) when checking
+		// the definition level matches.  Fixing that would also work but would need wider testing first.
+		skipNils := &parquetquery.SkipNilsPredicate{}
 		return parquetquery.NewLeftJoinIterator(definitionLevel,
-			[]parquetquery.Iterator{makeIter(keyPath, nil, "key")},
 			[]parquetquery.Iterator{
-				makeIter(strPath, nil, "string"),
-				makeIter(intPath, nil, "int"),
-				makeIter(floatPath, nil, "float"),
-				makeIter(boolPath, nil, "bool"),
+				makeIter(keyPath, skipNils, "key"),
+			},
+			[]parquetquery.Iterator{
+				makeIter(strPath, skipNils, "string"),
+				makeIter(intPath, skipNils, "int"),
+				makeIter(floatPath, skipNils, "float"),
+				makeIter(boolPath, skipNils, "bool"),
 			},
 			&attributeCollector{},
 			parquetquery.WithPool(pqAttrPool))

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -2036,9 +2036,11 @@ func createSpanIterator(makeIter makeIterFn, innerIterators []parquetquery.Itera
 			if entry.scope != intrinsicScopeSpan {
 				continue
 			}
-			// These intrinsics aren't included in select all because I say so.
+			// These intrinsics aren't included in select all because they
+			// aren't useful for compare().
 			switch intrins {
 			case traceql.IntrinsicSpanID,
+				traceql.IntrinsicParentID,
 				traceql.IntrinsicSpanStartTime,
 				traceql.IntrinsicStructuralDescendant,
 				traceql.IntrinsicStructuralChild,
@@ -2605,13 +2607,23 @@ func createAttributeIterator(makeIter makeIterFn, conditions []traceql.Condition
 	allConditions bool, selectAll bool,
 ) (parquetquery.Iterator, error) {
 	if selectAll {
+		// Select all with no filtering
+		// Levels such as resource/instrumentation/span may have no attributes. When that
+		// occurs the columns are encoded as single null values, and the current attribute
+		// collector reads them as Nils.  We could skip them in the attribute collector,
+		// but this is more performant because it's at the lowest level.
+		// Alternatively, JoinIterators don't pay attention to -1 (undefined) when checking
+		// the definition level matches.  Fixing that would also work but would need wider testing first.
+		skipNils := &parquetquery.SkipNilsPredicate{}
 		return parquetquery.NewLeftJoinIterator(definitionLevel,
-			[]parquetquery.Iterator{makeIter(keyPath, nil, "key")},
 			[]parquetquery.Iterator{
-				makeIter(strPath, nil, "string"),
-				makeIter(intPath, nil, "int"),
-				makeIter(floatPath, nil, "float"),
-				makeIter(boolPath, nil, "bool"),
+				makeIter(keyPath, skipNils, "key"),
+			},
+			[]parquetquery.Iterator{
+				makeIter(strPath, skipNils, "string"),
+				makeIter(intPath, skipNils, "int"),
+				makeIter(floatPath, skipNils, "float"),
+				makeIter(boolPath, skipNils, "bool"),
 			},
 			&attributeCollector{},
 			parquetquery.WithPool(pqAttrPool))
@@ -3156,6 +3168,7 @@ func (c *attributeCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		switch e.Key {
 		case "key":
 			key = unsafeToString(e.Value.Bytes())
+
 		case "string":
 			c.strBuffer = append(c.strBuffer, unsafeToString(e.Value.Bytes()))
 		case "int":

--- a/tempodb/encoding/vparquet4/block_traceql_test.go
+++ b/tempodb/encoding/vparquet4/block_traceql_test.go
@@ -730,9 +730,9 @@ func TestBackendBlockSelectAll(t *testing.T) {
 
 	b := makeBackendBlockWithTraces(t, traces)
 
-	_, _, _, _, req, err := traceql.Compile("{}")
+	_, eval, _, _, req, err := traceql.Compile("{}")
 	require.NoError(t, err)
-	req.SecondPass = func(inSS *traceql.Spanset) ([]*traceql.Spanset, error) { return []*traceql.Spanset{inSS}, nil }
+	req.SecondPass = func(inSS *traceql.Spanset) ([]*traceql.Spanset, error) { return eval([]*traceql.Spanset{inSS}) }
 	req.SecondPassSelectAll = true
 
 	resp, err := b.Fetch(ctx, *req, common.DefaultSearchOptions())
@@ -887,7 +887,6 @@ func flattenForSelectAll(tr *Trace, dcm dedicatedColumnMapping) *traceql.Spanset
 				newS.addSpanAttr(traceql.IntrinsicNameAttribute, traceql.NewStaticString(s.Name))
 				newS.addSpanAttr(traceql.IntrinsicStatusAttribute, traceql.NewStaticStatus(otlpStatusToTraceqlStatus(uint64(s.StatusCode))))
 				newS.addSpanAttr(traceql.IntrinsicStatusMessageAttribute, traceql.NewStaticString(s.StatusMessage))
-				newS.addSpanAttr(traceql.IntrinsicParentIDAttribute, traceql.NewStaticString(util.SpanIDToHexString(s.ParentSpanID)))
 
 				if s.HttpStatusCode != nil {
 					newS.addSpanAttr(traceql.NewScopedAttribute(traceql.AttributeScopeSpan, false, LabelHTTPStatusCode), traceql.NewStaticInt(int(*s.HttpStatusCode)))


### PR DESCRIPTION
* Exclude parent span id from selectAll

* update test

* Fix to ignore nestedSetParent and other intrinisics from compare(). Fix where a nil attribute could be returned from selectall from scopes without any attributes

* changelog

* lint

* woops lint again

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`