### PR TITLE
[DOC] Add section on non-deterministic search

### DIFF
--- a/docs/sources/tempo/shared/tempo-in-grafana.md
+++ b/docs/sources/tempo/shared/tempo-in-grafana.md
@@ -44,6 +44,18 @@ Use the Explore trace view to quickly diagnose errors and high latency events in
 
 ![Sample search visualization](/static/img/docs/grafana-cloud/trace_search.png)
 
+### Search is non-deterministic 
+
+Most search functions are deterministic: using the same search criteria results in the same results.
+
+However, Tempo search is non-deterministic.
+If you perform the same search twice, you’ll get different lists, assuming the possible number of results for your search is greater than the number of results you have your search set to return.Add commentMore actions
+
+When performing a search, Tempo does a massively parallel search over the given time range, and takes the first N results.
+Even identical searches differ due to things like machine load and network latency.
+This approach values speed over predictability and is quite simple; enforcing that the search results are consistent would introduce additional complexity (and increase the time the user spends waiting for results).
+TraceQL follows the same behavior.
+
 #### Use trace search results as panels in dashboards
 
 You can embed tracing panels and visualizations in dashboards.


### PR DESCRIPTION
Restored a section on non-deterministic search to the tempo-in-grafana doc.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`