### PR TITLE
[backendscheduler] small memory allocation improvements

### DIFF
--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -137,7 +138,7 @@ func (s *BackendScheduler) starting(ctx context.Context) error {
 
 				select {
 				case s.mergedJobs <- job:
-					metricProviderJobsMerged.WithLabelValues(fmt.Sprintf("%d", i)).Inc()
+					metricProviderJobsMerged.WithLabelValues(strconv.Itoa(i)).Inc()
 				case <-ctx.Done():
 					level.Info(log.Logger).Log("msg", "stopping provider", "provider", i)
 					return

--- a/modules/backendscheduler/provider/compaction.go
+++ b/modules/backendscheduler/provider/compaction.go
@@ -271,8 +271,9 @@ func (p *CompactionProvider) prioritizeTenants(ctx context.Context) {
 }
 
 func (p *CompactionProvider) measureTenants() {
+	var blockSelector blockselector.CompactionBlockSelector
 	for _, tenant := range p.store.Tenants() {
-		blockSelector, _ := p.newBlockSelector(tenant)
+		blockSelector, _ = p.newBlockSelector(tenant)
 
 		yes := func(_ string) bool {
 			return true

--- a/modules/backendscheduler/provider/compaction.go
+++ b/modules/backendscheduler/provider/compaction.go
@@ -220,16 +220,22 @@ func (p *CompactionProvider) prioritizeTenants(ctx context.Context) {
 
 	p.curPriority = tenantselector.NewPriorityQueue() // wipe and restart
 
+	var (
+		blocklistLen      int
+		blockSelector     blockselector.CompactionBlockSelector
+		outstandingBlocks int
+		toBeCompacted     []*backend.BlockMeta
+	)
+
 	for _, tenantID := range p.store.Tenants() {
 		if p.overrides.CompactionDisabled(tenantID) {
 			continue
 		}
 
-		var (
-			outstandingBlocks           = 0
-			toBeCompacted               []*backend.BlockMeta
-			blockSelector, blocklistLen = p.newBlockSelector(tenantID)
-		)
+		outstandingBlocks = 0
+		clear(toBeCompacted)
+
+		blockSelector, blocklistLen = p.newBlockSelector(tenantID)
 
 		// Measure the outstanding blocks
 		for {


### PR DESCRIPTION
**What this PR does**:

Here we save a few memory allocations when retrieving the blocklist for tenants.  This happens at metric time, and also when we re-prioritize the tenant list. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`