### PR TITLE
[backend-scheduler] Use backoff and lock to rate limit work flush

### DIFF
--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -1007,6 +1007,10 @@ backend_scheduler:
                 max_period: 10s
                 max_retries: 0
     job_timeout: 15s
+    backoff:
+        min_period: 100ms
+        max_period: 10s
+        max_retries: 10
 backend_scheduler_client:
     grpc_client_config:
         max_recv_msg_size: 104857600

--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -32,6 +32,8 @@ var tracer = otel.Tracer("modules/backendscheduler")
 type BackendScheduler struct {
 	services.Service
 
+	mtx sync.Mutex
+
 	cfg       Config
 	store     storage.Store
 	overrides overrides.Interface

--- a/modules/backendscheduler/config.go
+++ b/modules/backendscheduler/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/tempo/modules/backendscheduler/provider"
 	"github.com/grafana/tempo/modules/backendscheduler/work"
 	"github.com/grafana/tempo/pkg/util"
@@ -19,6 +20,7 @@ type Config struct {
 	// Provider configs
 	ProviderConfig provider.Config `yaml:"provider"`
 	JobTimeout     time.Duration   `yaml:"job_timeout"`
+	Backoff        backoff.Config  `yaml:"backoff"`
 }
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
@@ -29,6 +31,8 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.Work.RegisterFlagsAndApplyDefaults(util.PrefixConfig(prefix, "work"), f)
 
 	cfg.ProviderConfig.RegisterFlagsAndApplyDefaults(util.PrefixConfig(prefix, "provider"), f)
+
+	cfg.Backoff.RegisterFlagsWithPrefix(util.PrefixConfig(prefix, "backoff"), f)
 }
 
 func ValidateConfig(cfg *Config) error {


### PR DESCRIPTION
**What this PR does**:

Here we use a backoff and lock to reduce the concurrent writes to the work cache.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`