### PR TITLE
[DOC] Tempo 2.8 release notes 

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,622 @@
+---
+applyTo: "**/*.md"
+---
+
+## Role
+
+Act as an experienced software engineer and technical writer for Grafana Labs.
+
+Write for software developers and engineers.
+
+Assume users know general programming concepts.
+
+## Grafana
+
+Grafana Labs' product suite contains open source projects, enterprise products,
+and the managed Grafana Cloud.
+
+Grafana Labs' open source suite contains:
+
+- Grafana: visualizations, Explore queries, Grafana Drilldown queryless explore
+- Grafana Mimir: scalable and performant metrics backend
+- Grafana Loki: multi-tenant log aggregation system
+- Grafana Tempo: high-scale distributed tracing backend
+- Grafana Pyroscope: scalable continuous profiling backend
+- Grafana Beyla: eBPF auto-instrumentation
+- Grafana Faro: frontend application observability web SDK
+- Grafana Alloy: OpenTelemetry Collector distribution with Prometheus pipelines
+- Grafana OnCall: on-call management
+- Grafana k6: load testing for engineering teams
+
+Grafana Cloud solutions include:
+
+- Grafana: for visualization
+- Metrics: powered by Grafana Mimir and Prometheus
+- Logs: powered by Grafana Loki
+- Traces: powered by Grafana Tempo
+- Profiles: powered by Grafana Pyroscope
+- Frontend Observability: gain real user monitoring insights
+- Application Observability: application performance monitoring
+- Infrastructure observability: ensure infrastructure health and performance
+- Performance & load testing: powered by Grafana k6
+- Synthetic Monitoring: powered by Grafana k6
+- Grafana IRM: observability native incident response
+- Incident: routine task automation for incidents
+- OnCall: flexible on-call management
+
+If a product name starts with "Grafana",
+use the full name on first use and short name after, for example:
+
+- Grafana Alloy (full), Alloy (short)
+- Grafana Beyla (full), Beyla (short)
+
+Refer to the "OpenTelemetry Collector" as "Collector" after the first use.
+Still use "OpenTelemetry Collector" when referring to a distribution,
+and for headings and links.
+
+Always use the full name for "Grafana Cloud".
+
+Never use abbreviations for product names unless specifically asked to,
+for example:
+
+- use "OpenTelemetry" (correct) and not "OTel" (wrong)
+- use "Kubernetes" (correct) and not "K8s" (wrong)
+
+Refer to metrics, logs, traces, and profiles in that order.
+If referring to a subset, still use this ordering, for example:
+
+- metrics, logs, and traces (correct)
+- traces and profiles (correct), profiles and traces (wrong)
+- metrics and logs (correct), logs and metrics (wrong)
+
+You can freely mention open source projects, for example:
+
+- Prometheus
+- OpenTelemetry
+- Linux
+- Docker
+- Kubernetes
+
+Only mention other companies or products for integrations or migrations.
+Focus on Grafana and not the partner product, for example:
+
+- For an integration with Azure don't document Azure set up
+- For a migration from DataDog don't document DataDog set up or usage
+
+## frontmatter
+
+Never remove front matter content at the start of the file.
+This includes all content from the start of the file,
+inbetween a pair of tripple dashes (---).
+
+Never removed YAML front matter meta data unless specifically asked to.
+
+For example, never remove or delete this or other front matter:
+
+```markdown
+---
+title: OpenTelemetry
+cascade:
+  search_section: OpenTelemetry
+  search_type: doc
+---
+
+# OpenTelemetry
+
+Markdown content...
+```
+
+Only edit front matter copy if specifically asked to.
+When performing a copy edit task,
+ask the user if they'd like you to also edit the front matter copy.
+Still never remove front matter meta data properpties.
+
+## Structure
+
+Structure articles into sections with headings.
+
+The frontmatter YAML `title` and the content h1 (#) heading should be the same.
+Never remove the content h1 heading, this redundancy is required.
+
+Always include copy after a heading, for example:
+
+```markdown
+## Heading
+
+Immediately followed by copy and not another heading.
+```
+
+Never nest a heading immediately after another heading, for example:
+
+```markdown
+## Heading
+
+## Sub heading
+```
+
+Add a blank line after headings, for example:
+
+```markdown
+## Heading
+
+Copy after the heading and a blank line.
+```
+
+The immediate copy after a heading should introduce and overview what is
+covered in the section.
+
+Start articles with an introduction that covers the goal of the article,
+example goals:
+
+- Learn concepts
+- Set up or install something
+- Configure something
+- Use a product to solve a business problem
+- Troubleshoot a problem
+- Integrate with other software or systems
+- Migrate from one thing to another
+- Refer to APIs or reference documentation
+
+Follow the goal with a list of prerequisites, for example:
+
+```markdown
+Before you begin ensure you have the following:
+
+- <Prerequisite 1>
+- <Prerequisite 2>
+- ...
+```
+
+Suggest and link to next steps and related resources at the end of the article,
+for example:
+
+- Learn more about A, B, C
+- Configure X
+- Use X to achieve Y
+- Use X to achieve Z
+- Project homepage or documentation
+- Project repository (for example, GitHub, GitLab)
+- Project package (for example, pip or npm)
+
+You don't need to use the "Refer to..." syntax for next steps,
+use the list time text for the link text.
+
+## Style
+
+Write simple copy.
+
+Write short sentences and paragraphs.
+
+Use short words whenever possible, for example:
+
+- use "use" and not "utilize"
+- use "use" and not "make use of"
+
+Always use contractions over multiple words, for example:
+
+- use "it's" and not "it is"
+- use "isn't" and not "is not"
+- use "that's" and not "that is"
+- use "you're" and not "you are"
+- use "Don't" and not "do not"
+
+Don't use filler words or phrases, for example:
+
+- "there is"
+- "there are"
+- "in order to"
+- "it is important to"
+- "keep in mind"
+
+In most cases, use verbs and nouns without adverbs or adjectives.
+You may use minimal adverbs and adjectives,
+when introucing or overviewing a Grafana Labs product.
+
+Don't use figures of speech.
+
+Never use buzzwords, jargon, or cliches.
+
+Never use cultural references or charged language.
+
+## Tense
+
+Write in present simple tense.
+
+Avoid present continous tense.
+
+Only write in future tense to show future actions.
+
+## Voice
+
+Always write in an active voice.
+
+Never write in a passive voice.
+
+## Perspective
+
+Address users as "you".
+
+Don't use first person perspective.
+
+## Wordlist
+
+Use allowlist/blocklist instead of whitelist/blacklist.
+
+Use primary/secondary instead of master/slave.
+
+Use "refer to" instead of "see", "consult", "check out", and other phrases.
+
+## Formatting
+
+Use sentence case for titles and headings, for example:
+
+- This is sentence case (correct)
+- This is Title Case (wrong)
+
+Use the exact page or section title for link text.
+
+Use inline Markdown links, for example, [Link text](https://example.com).
+
+When linking to other sections within the same document,
+use a descriptive phrase that includes the section name,
+and a relative link to its heading anchor.
+For example, "For further details on setup, refer to the [Installation](#installation) section."
+
+Never remove links from copy unless specifically asked to.
+If you edit content that includes a link,
+always include the link in the edited version, for example:
+
+- It is [here](https://grafana.com) go check it out for details (before)
+- Refer to the [Grafana homepage](https://grafana.com) for details (after)
+
+Use two asterisks to bold text, for example `**bold**`.
+
+Use one underscore to emphasize copy, for example `_italics_`.
+
+For UI elements and product features that aren't product names,
+use sentence case as they appear in the UI, for example:
+
+- Click **Submit**. (If "Submit" is the exact text on the button)
+- Navigate to the **User settings** page. (If "User settings" is the title/label)
+- Configure the **alerting rules**. (General concept)
+- Open **Explore** in Grafana. (If "Explore" is the branded name of that section)
+
+Avoid using words created for UI features when possible, for example
+
+- In your Grafana Cloud stack, click **Connections**. (correct)
+- In your Grafana Cloud stack, click the **Connections** button. (wrong)
+
+## Lists
+
+Write complete sentences for lists, for example:
+
+- Works with all languages and frameworks (correct)
+- all languages and frameworks (wrong)
+
+Always use dashes for unordered lists, for example
+
+```markdown
+- List item 1
+- List item 2
+- List item 3
+```
+
+Never use asterisks for unordered lists, for example:
+
+```markdown
+* List item 1 (wrong)
+* List item 2 (wrong)
+* List item 3 (wrong)
+```
+
+Never use full stops at the end of unordered list items, for example:
+
+```markdown
+- Works with all languages and frameworks (correct)
+- Works with all languages and frameworks (wrong)
+```
+
+Always start every ordered list item with 1, for example:
+
+```markdown
+1. Ordered list item 1.
+1. Ordered list item 2.
+1. Ordered list item 3.
+```
+
+Never increment the numbers for ordered list items, for example:
+
+```markdown
+1. Ordered list item 1. (wrong)
+2. Ordered list item 2. (wrong)
+3. Ordered list item 3. (wrong)
+```
+
+Always start the next list item immediately on the next line, for example:
+
+```markdown
+- List item 1
+- List item 2
+- List item 3
+```
+
+Never use new lines between list items, for example:
+
+```markdown
+- List item 1
+
+- List item 2 (wrong)
+
+- List item 3 (wrong)
+```
+
+If a list starts with a keyword, bold the keyword and follow with a colon,
+for example:
+
+```markdown
+- **Keyword 1**: list item 1
+- **Keyword 2**: list item 2
+- **Keyword 3**: list item 3
+```
+
+## Images
+
+Always include descriptive alt text for images.
+The alt text should convey the essential information or purpose of the image.
+Avoid redundant phrases like "Image of..." or "Picture of...".
+
+For example:
+
+- Instead of `![Diagram of system](diagram.png)`
+- Use `![Architecture diagram showing data flow from client applications, through a load balancer, to backend services.](architecture-data-flow.png)`
+
+## Code
+
+Use single code backticks for:
+
+- user input
+- placeholders in markdown, for example _`<PLACEHOLDER_NAME>`_
+- files and directories, for example `/opt/file.md`
+- source code keywords and identifiers,
+  for example variables, function and class names
+- configuration options and values, for example `PORT` and `80`
+- status codes, for example `404`
+
+Use triple code backticks followed by the syntax for code blocks, for example:
+
+```javascript
+console.log("Hello World!");
+```
+
+Always introduce each code blocks with a short description.
+End the introduction with a colon if the code sample follows it, for example:
+
+```markdown
+The code sample outputs "Hello World!" to the browser console:
+
+<CODE_BLOCK>
+```
+
+Use descriptive placeholder names in code samples.
+Use uppercase letters with underscores to separate words in placeholders,
+for example:
+
+```sh
+OTEL_RESOURCE_ATTRIBUTES="service.name=<SERVICE_NAME>
+OTEL_EXPORTER_OTLP_ENDPOINT=<OTLP_ENDPOINT>
+```
+
+The placeholder includes the name and the less than and greater than symbols,
+for example <PLACEHOLDER_NAME>.
+
+If the placeholder is markdown emphasize it with underscores,
+for example _`<PLACEHOLDER_NAME>`_.
+
+In code blocks use the placeholder without additional backticks or emphasis,
+for example <PLACEHOLDER_NAME>.
+
+Always provide an explanation for each placeholder,
+typically in the text following the code block or in a configuration table.
+
+Never add new code block unless specifically asked to, for example,
+when asked to improve an article don't add new code.
+
+Never change existing code blocks unless specifically asked to, for example
+when asked to improve an article don't edit code.
+
+Always follow code samples with an explanation
+and configuration options for placeholders, for example:
+
+```markdown
+<CODE_BLOCK>
+
+This code sets required environment variables
+to send OTLP data to an OTLP endpoint.
+To configure the code for your needs,
+refer to the configuration table
+and select the appropriate configuration options for your use case.
+
+<CONFIGURATION_TABLE>
+```
+
+Never put configuration for a code block before the code block.
+
+## APIs
+
+When documenting API endpoints specify the HTTP method,
+for example `GET`, `POST`, `PUT`, `DELETE`.
+
+Provide the full request path, using backticks.
+
+Use backticks for parameter names and example values.
+
+Use placeholders like `{userId}` for path parameters, for example:
+
+- To retrieve user details, make a `GET` request to `/api/v1/users/{userId}`.
+
+Use a configuration table to describe query and header parameters,
+and request body fields.
+
+## CLI commands
+
+When presenting CLI commands and their output,
+introduce the command with a brief explanation of its purpose.
+Clearly distinguish the command from its output.
+
+For commands, use `sh` to specify the code block language.
+
+For output, use a generic specifier like `text`, `console`,
+or `json`/`yaml` if the output is structured.
+
+For example:
+
+````markdown
+To list all running pods in the `default` namespace, use the following command:
+
+```sh
+kubectl get pods --namespace default
+```
+````
+
+The output will resemble the following:
+
+```text
+NAME                               READY   STATUS    RESTARTS   AGE
+my-app-deployment-7fdb6c5f65-abcde   1/1     Running   0          2d1h
+another-service-pod-xyz123           2/2     Running   0          5h30m
+```
+
+## Configuration table
+
+Use Markdown tables to document configuration, including:
+
+- placeholders
+- parameters
+- YAML/JSON configuration
+- environment variables
+
+Add columns for "Option", "Summary", "Required", "Type", "Values", "Default"
+in that order.
+
+Use the following values for option:
+
+- YAML/JSON, code, or parameter field if one exists for that configuration
+- Environment variable field if one exists for that configuration
+- If there is a YAML and Environment variable option separate them with `<br>`
+
+Use a short sentence for the summary.
+After the summary sentence and in the same cell,
+link to further details using the following format,
+"Refer to [option](#option-anchor) for details."
+
+In the values column, describe acceptable values
+and include value options or ranges if they exist.
+Don't include example values in the table.
+
+An example configuration table:
+
+```markdown
+| Option                         | Summary                                                                                              | Required | Type   | Values                               | Default |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------- | -------- | ------ | ------------------------------------ | ------- |
+| `SERVICE_NAME`                 | The logical name of your application or service. Refer to [service name](#service-name) for details. | Yes      | String | A descriptive name for your service. | N/A     |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`  | The target URL for the OTLP exporter. Refer to [OTLP endpoint](#otlp-endpoint) for details.          | Yes      | String | A valid URL.                         | N/A     |
+| `logging.level`<br>`LOG_LEVEL` | Sets the logging verbosity. Refer to [logging level](#logging-level) for details.                    | No       | String | `debug`, `info`, `warn`, `error`     | `info`  |
+```
+
+In some ocassions, you can drop the Values column, for example,
+when all the configuration have a Boolean type (yes/no) or (1/0).
+
+After the table, for each configuration, add a sub-section.
+
+For each sub-section include a heading and more detailed information including:
+
+- a full description
+- an explanation of concepts
+- any related configuration
+- example values with explanations, don't use code blocks only single backticks
+  for example values
+
+Use sentence case for the heading and only capitalize known keywords.
+
+Example configuration sub-sections:
+
+```markdown
+<CONFIGURATION_TABLE>
+
+### Service name
+
+The `SERVICE_NAME` option specifies the name of your application or service.
+This name identifies your service in Grafana Cloud.
+It helps filter and query telemetry data.
+A name that describes the service helps organize your observability data.
+
+For example, if your microservice handles payments, a service name could be `payment-service`.
+If your application is a frontend, you might use `webapp-frontend`.
+
+### OTLP endpoint
+
+The `OTEL_EXPORTER_OTLP_ENDPOINT` option defines the target URL.
+The OpenTelemetry (OTLP) exporter sends your telemetry data to this URL.
+This endpoint is the ingestion point for your metrics, logs, traces, and profiles.
+For Grafana Cloud, this is your Grafana Cloud OTLP endpoint.
+
+An example OTLP endpoint URL is `https://otlp-gateway-prod-us-central-0.grafana.net/otlp`.
+Your endpoint URL depends on your Grafana Cloud stack and region.
+You find this URL in your Grafana Cloud account details.
+
+### Logging level
+
+The `logging.level` and `LOG_LEVEL` options control the verbosity of logging output.
+Use these options to adjust the level of detail in logs for debugging or monitoring purposes.
+
+The available levels are `debug`, `info`, `warn`, and `error`.
+For example, setting the level to `debug` provides detailed logs useful for troubleshooting,
+while `error` limits logs to critical issues.
+
+The default logging level is `info`, which provides a balance between verbosity and relevance.
+```
+
+## Comparison table
+
+Use a comparison table when users have multiple options to achieve similar
+outcomes and need to understand the trade-offs or key differences between them.
+
+Comparison tables help users make informed decisions by highlighting distinct features,
+requirements, or characteristics of each option side-by-side.
+
+Structure the table with options as rows and differentiating criteria as columns.
+Ensure each cell provides concise, directly comparable information.
+
+An example comparison table:
+
+```markdown
+| Method                      | Code changes             | Language support   | Use case                                                      |
+| --------------------------- | ------------------------ | ------------------ | ------------------------------------------------------------- |
+| Grafana OpenTelemetry Java  | Not required (JVM agent) | Java               | Offers advanced instrumentation features and Grafana support. |
+| Grafana OpenTelemetry .NET  | Required                 | .NET               | Offers advanced instrumentation features and Grafana support. |
+| Upstream OpenTelemetry SDKs | Required                 | Multiple languages | Provides standard instrumentation with community support.     |
+```
+
+## Shortcodes
+
+Don't use blockquotes for notes, cautions, or warnings.
+
+Use the custom admonition Hugo shortcode
+with <TYPE> as "note", "caution", or "warning":
+
+```markdown
+{{< admonition type="<TYPE>" >}}
+...
+{{< /admonition >}}
+```
+
+Use admonitions sparingly.
+Only include exceptional information in admonitions,
+this means you will use it more often for warnings than notes and cautions.
+
+Never delete Hugo shortcodes unless specifically asked to,
+for example don't delete shortcodes:
+
+```markdown
+{{< docs/shared source="tempo" lookup="grafana-cloud.md" version="" >}}
+```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Tempo implements [TraceQL](https://grafana.com/docs/tempo/latest/traceql/), a tr
 
 [TraceQL metrics](https://grafana.com/docs/tempo/latest/traceql/metrics-queries/) is an experimental feature in Grafana Tempo that creates metrics from traces. Metric queries extend trace queries by applying a function to trace query results. This powerful feature allows for ad hoc aggregation of any existing TraceQL query by any dimension available in your traces, much in the same way that LogQL metric queries create metrics from logs.
 
-Tempo is Jaeger, Zipkin, Kafka, OpenCensus, and OpenTelemetry compatible. It ingests batches in any of the mentioned formats, buffers them, and then writes them to Azure, GCS, S3, or local disk. As such, it is robust, cheap, and easy to operate!
+Tempo is Jaeger, Zipkin, Kafka, OpenCensus, and OpenTelemetry compatible. It ingests batches in any of the mentioned formats, buffers them, and then writes them to Azure, GCS, S3, or local disk. As such, it's robust, cheap, and easy to operate.
 
 ## Getting started with Tempo
 

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -95,7 +95,7 @@ server:
     [http_listen_address: <string>]
 
     # HTTP server listen port
-    [http_listen_port: <int> | default = 80]
+    [http_listen_port: <int> | default = 3200]
 
     # gRPC server listen host
     [grpc_listen_address: <string>]
@@ -712,7 +712,7 @@ query_frontend:
         [throughput_bytes_slo: <float> | default = 0 ]
 
         # The number of time windows to break a search up into when doing a most recent TraceQL search. This only impacts TraceQL
-        # searches with (most_recent=true)
+        # searches with (most_recent=true).
         [most_recent_shards: <int> | default = 200]
 
         # The number of shards to break ingester queries into.

--- a/docs/sources/tempo/release-notes/v2-6.md
+++ b/docs/sources/tempo/release-notes/v2-6.md
@@ -88,17 +88,17 @@ To learn more, refer to the [Native histogram](https://grafana.com/docs/tempo/<T
 
 ### Performance improvements
 
-One of our major improvements in Tempo 2.6 is the reduction of memory usage due to polling improvements. [PRs [3950](https://github.com/grafana/tempo/pull/3950), [3951](https://github.com/grafana/tempo/pull/3951), [3952](https://github.com/grafana/tempo/pull/3952])
+One of our major improvements in Tempo 2.6 is the reduction of memory usage due to polling improvements. [PRs [3950](https://github.com/grafana/tempo/pull/3950), [3951](https://github.com/grafana/tempo/pull/3951), [3952](https://github.com/grafana/tempo/pull/3952])]
 
 ![Comparison graph showing the reduction of memory usage due to the polling improvements](/media/docs/tempo/tempo-2-6-poll-improvement.png)
 
 This improvement is a result of some of these changes:
 
-* Add data quality metric to measure traces without a root [[PR 3812](https://github.com/grafana/tempo/pull/3812)]
-* Reduce memory consumption of query-frontend [[PR 3888](https://github.com/grafana/tempo/pull/3888)]
-* Reduce allocs of caching middleware [[PR 3976](https://github.com/grafana/tempo/pull/3976)]
-* Reduce allocs building queriers sharded requests [[PR 3932](https://github.com/grafana/tempo/pull/3932)]
-* Improve trace id lookup from Tempo Vulture by selecting a date range [[PR 3874](https://github.com/grafana/tempo/pull/3874)]
+* Add data quality metric to measure traces without a root. [[PR 3812](https://github.com/grafana/tempo/pull/3812)]
+* Reduce memory consumption of query-frontend. [[PR 3888](https://github.com/grafana/tempo/pull/3888)]
+* Reduce allocations of caching middleware. [[PR 3976](https://github.com/grafana/tempo/pull/3976)]
+* Reduce allocations building queriers sharded requests. [[PR 3932](https://github.com/grafana/tempo/pull/3932)]
+* Improve trace id lookup from Tempo Vulture by selecting a date range. [[PR 3874](https://github.com/grafana/tempo/pull/3874)]
 
 ### Other enhancements and improvements
 
@@ -120,7 +120,7 @@ This release also has these notable updates.
 * Implement polling tenants concurrently. [[PR 3647](https://github.com/grafana/tempo/pull/3647)]
 * Add [native histograms](https://grafana.com/docs/tempo/<TEMPO_VERSION>/metrics-generator/#native-histograms) for internal metrics [[PR 3870](https://github.com/grafana/tempo/pull/3870)]
 * Add a Tempo CLI command to drop traces by id by rewriting blocks. [[PR 3856](https://github.com/grafana/tempo/pull/3856), [documentation](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/tempo_cli/#drop-trace-by-id)]
-* Add new OTel compatible Traces API V2.  [[PR 3912](https://github.com/grafana/tempo/pull/3912), [documentation](https://grafana.com/docs/tempo/next/api_docs/#query-v2)]
+* Add new OTel compatible Traces API V2. [[PR 3912](https://github.com/grafana/tempo/pull/3912), [documentation](https://grafana.com/docs/tempo/next/api_docs/#query-v2)]
 * Rename `Batches` to `ResourceSpans`. [[PR 3895](https://github.com/grafana/tempo/pull/3895)]
 
 ## Upgrade considerations

--- a/docs/sources/tempo/release-notes/v2-8.md
+++ b/docs/sources/tempo/release-notes/v2-8.md
@@ -1,0 +1,286 @@
+---
+title: Version 2.8 release notes
+menuTitle: V2.8
+description: Release notes for Grafana Tempo 2.8
+weight: 20
+---
+
+# Version 2.7 release notes
+
+<!-- vale Grafana.We = NO -->
+<!-- vale Grafana.GoogleWill = NO -->
+<!-- vale Grafana.Timeless = NO -->
+<!-- vale Grafana.Parentheses = NO -->
+
+The Tempo team is pleased to announce the release of Tempo 2.8.
+
+This release gives you:
+
+* Ability to precisely track ingested traffic and attribute costs based on custom labels
+* A series of enhancements that significantly boost Tempo performance and reduce its overall resource footprint.
+* New TraceQL capabilities
+* Improvements to TraceQL metrics
+
+These release notes highlight the most important features and bugfixes.
+For a complete list, refer to the [Tempo changelog](https://github.com/grafana/tempo/releases).
+
+<!-- Add link to the new blog post when ready
+Read the [Tempo 2.8 blog post](https://grafana.com/blog/2025/01/16/grafana-tempo-2.7-release-new-traceql-metrics-functions-operational-improvements-and-more/) for more examples and details about these improvements.
+
+{{< youtube id="0jUEvY-pCdw" >}}
+
+-->
+
+## Features and enhancements
+
+The most important features and enhancements in Tempo 2.7 are highlighted below.
+
+{{< admonition type="note" >}}
+This release changes gRPC compression to `snappy` by default to improve performance.
+Refer to [gRPC compression](#grpc-compression-set-to-snappy) for more information.
+{{< /admonition >}}
+
+### Track ingested traffic and attribute costs
+
+This new feature lets tenants precisely measure and attribute costs for their ingested trace data by leveraging custom labels.
+This functionality provides a more accurate alternative to existing size-based metrics and meets the growing need for detailed cost attribution and billing transparency.
+
+Modern organizations are increasingly reliant on distributed traces for observability, yet reconciling the costs associated with different teams, services, or departments can be challenging.
+The existing size metric isn't accurate enough by missing non-span data and can lead to under- or over-counting.
+The new usage tracking feature overcomes these issues by splitting resource-level data fairly and providing up to 99% accuracy—perfect for cost reconciliation.
+
+Unlike the previous method, this new feature precisely accounts for every byte of trace data in the distributor—the only Tempo component with the original payload.
+A new API endpoint, `/usage_metrics`, exposes the per-tenant metrics on ingested data and cost attribution, and can be controlled with per-tenant configuration.
+
+This feature is designed as a foundation for broader usage tracking capabilities, where additional trackers will allow organizations to measure and report on a range of usage metrics. ([#4162](https://github.com/grafana/tempo/pull/4162))
+
+For additional information, refer to the [Usage metrics documentation](https://grafana.com/docs/tempo/<TEMPO_VERSION>/api_docs/#usage-metrics).
+
+### Major performance and memory usage improvements
+
+We're excited to announce a series of enhancements that significantly boost Tempo performance and reduce its overall resource footprint.
+
+**Better refuse large traces:** The ingester now reuses generator code to better detect and reject oversized traces.
+This change makes trace ingestion more reliable and prevents capacity overloads.
+Plus, two new metrics `tempo_metrics_generator_live_trace_bytes` and `tempo_ingester_live_trace_bytes` provide deeper visibility into per-tenant byte usage. ([#4365](https://github.com/grafana/tempo/pull/4365))
+
+**Reduced allocations:** We've refined how the query-frontend handles incoming traffic to eliminate unnecessary allocations when query demand is low.
+As part of these improvements, the `querier_forget_delay` configuration option has been removed because it no longer served a practical purpose. ([#3996](https://github.com/grafana/tempo/pull/3996))
+This release also reduces the ingester working set by improving prelloc behavior.
+It also adds tunable prealloc env variables `PREALLOC_BKT_SIZE`, `PREALLOC_NUM_BUCKETS`, `PREALLOC_MIN_BUCKET`, and metric `tempo_ingester_prealloc_miss_bytes_total` to observe and tune prealloc behavior. ([#4344](https://github.com/grafana/tempo/pull/4344), [#4369](https://github.com/grafana/tempo/pull/4369))
+
+**Faster tag lookups and collector operations:** Multiple optimizations ([#4100](https://github.com/grafana/tempo/pull/4100), [#4104](https://github.com/grafana/tempo/pull/4104), [#4109](https://github.com/grafana/tempo/pull/4109)) make tag lookups and collector tasks more responsive, particularly for distinct value searches. Additionally, enabling disk caching for completed blocks in ingesters significantly cuts down on query latency and lowers overall I/O overhead. ([#4069](https://github.com/grafana/tempo/pull/4069))
+
+**Reduce goroutines in non-querier components:** A simplified design across non-querier components lowers the total number of goroutines, making Tempo more efficient and easier to scale—even with high trace volumes. ([#4484](https://github.com/grafana/tempo/pull/4484))
+
+### New TraceQL capabilities
+
+New in Tempo 2.7, TraceQL now allows you to query the [instrumentation scope](https://opentelemetry.io/docs/concepts/instrumentation-scope/) fields ([#3967](https://github.com/grafana/tempo/pull/3967)), letting you filter and explore your traces based on where and how they were instrumented.
+
+We've extended TraceQL to automatically collect matches from array values ([#3867](https://github.com/grafana/tempo/pull/3867)), making it easier to parse spans containing arrays of attributes.
+
+Query times are notably faster, thanks to multiple optimizations ([#4114](https://github.com/grafana/tempo/pull/4114), [#4163](https://github.com/grafana/tempo/pull/4163), [#4438](https://github.com/grafana/tempo/pull/4438)).
+Whether you're running standard queries or advanced filters, you should see a significant speed boost.
+
+Tempo now uses the Prometheus "fast regex" engine to accelerate regular expression-based filtering ([#4329](https://github.com/grafana/tempo/pull/4329)).
+As part of this update, all regular expressions matches are now fully anchored.
+This breaking change means `span.foo =~ "bar"` is evaluated as `span.foo =~ "^bar$"`.
+Update any affected queries accordingly.
+
+### Query improvements
+
+In API v2 queries, Tempo can now return partial traces even when they exceed the max bytes limit ([#3941](https://github.com/grafana/tempo/pull/3941)).
+This ensures you can still retrieve and inspect useful segments of large traces to aid in debugging.
+Refer to the [query v2 API endpoint](https://grafana.com/docs/tempo/<TEMPO_VERSION>/api_docs/#query-v2) documentation for more information.
+
+### TraceQL metrics improvements (experimental)
+
+In TraceQL metrics, we've added a new `avg_over_time` function ([#4073](https://github.com/grafana/tempo/pull/4073)) to help you compute average values for trace-based metrics over specified time ranges, making it simpler to spot trends and anomalies.
+
+Tempo now supports `min_over_time` ([#3975](https://github.com/grafana/tempo/pull/3975)) and `max_over_time` ([#4065](https://github.com/grafana/tempo/pull/4065)) queries, giving you more flexibility in analyzing the smallest or largest values across your trace data.
+
+For more information about TraceQL metrics, refer to [TraceQL metrics functions](https://grafana.com/docs/tempo/<TEMPO_VERSION>/traceql/metrics-queries/functions/#traceql-metrics-functions).
+
+### Other enhancements and improvements
+
+This release also has these notable updates.
+
+### 2.7.1
+
+* Default to snappy compression for all gRPC communications internal to Tempo. We feel this is a nice balance of resource usage and network traffic. For a discussion on alternatives, refer to [this discussion thread](https://github.com/grafana/tempo/discussions/4683). ([#4696](https://github.com/grafana/tempo/pull/4696))
+
+### 2.7.0
+
+* The [metrics-generator](https://grafana.com/docs/tempo/latest/metrics-generator/) introduces a generous limit of 100 for failed flush attempts ([#4254](https://github.com/grafana/tempo/pull/4254)) to prevent constant retries on corrupted blocks. A new metric also tracks these flush failures, offering better visibility into potential issues during ingestion.
+* For [span metrics](https://grafana.com/docs/tempo/latest/metrics-generator/span_metrics/), the span multiplier now also sources its value from the resource attributes ([#4210](https://github.com/grafana/tempo/pull/4210)). This makes it possible to adjust and correct metrics using service or environment configuration, ensuring more accurate data reporting.
+* The `tempo-cli` now supports dropping multiple trace IDs in a single command, speeding up administrative tasks and simplifying cleanup operations. ([#4266](https://github.com/grafana/tempo/pull/4266))
+* An optional log, `log_discarded_spans`, tracks spans discarded by Tempo. This improves visibility into data ingestion workflows and helps you quickly diagnose any dropped spans. ([#3957](https://github.com/grafana/tempo/issues/3957))
+* You can now impose limits on tag and tag-value lookups, preventing runaway queries in large-scale deployments and ensuring a smoother user experience. ([#4320](https://github.com/grafana/tempo/pull/4320))
+* The tags and tag-values endpoints have gained new throughput and SLO-related metrics. Get deeper insights into query performance and reliability straight from Tempo's built-in monitoring. ([#4148](https://github.com/grafana/tempo/pull/4148))
+* Tempo now exposes a SemVer version in its `/api/status/buildinfo` endpoint, providing clear visibility into versioning, particularly useful for cloud deployments and automated pipelines. ([#4110](https://github.com/grafana/tempo/pull/4110))
+
+## Upgrade considerations
+
+When [upgrading](https://grafana.com/docs/tempo/latest/setup/upgrade/) to Tempo 2.7, be aware of these considerations and breaking changes.
+
+### OpenTelemetry Collector receiver listens on `localhost` by default
+
+After this change, the OpenTelemetry Collector receiver defaults to binding on `localhost` rather than `0.0.0.0`. Tempo installations running in Docker or other container environments must update their listener address to continue receiving data. ([#4465](https://github.com/grafana/tempo/pull/4465))
+
+Most Tempo installations use the receivers with the default configuration:
+
+```yaml
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+        http:
+```
+
+This used to work fine since the receivers defaulted to `0.0.0.0:4317` and `0.0.0.0:4318` respectively. With the changes to replace unspecified addresses, the receivers now default to `localhost:4317` and `localhost:4318`.
+
+As a result, connections to Tempo running in a Docker container won't work anymore.
+
+To workaround this, you need to specify the address you want to bind to explicitly. For instance, if Tempo is running in a container with hostname `tempo`, this should work:
+
+```yaml
+# ...
+        http:
+          endpoint: "tempo:4318"
+```
+
+You can also explicitly bind to `0.0.0.0` still, but this has potential security risks:
+
+```yaml
+# ...
+        http:
+          endpoint: "0.0.0.0:4318"
+```
+
+### Tempo serverless deprecation
+
+Tempo serverless is now officially deprecated and will be removed in an upcoming release.
+Prepare to migrate any serverless workflows to alternative deployments. ([#4017](https://github.com/grafana/tempo/pull/4017), [documentation](https://grafana.com/docs/tempo/latest/operations/backend_search/#serverless-environment))
+
+There are no changes to this release for serverless. However, you'll need to remove these configurations before the next release.
+
+### Anchored regular expression matchers in TraceQL
+
+TraceQL now uses the Prometheus "fast regex" engine to accelerate regular expression-based filtering ([#4329](https://github.com/grafana/tempo/pull/4329)).
+As part of this update, all regular expression matches are now fully anchored.
+This breaking change means `span.foo =~ "bar"` is evaluated as `span.foo =~ "^bar$"`.
+Update any affected queries accordingly.
+
+For more information, refer to the [Comparison operators TraceQL](http://localhost:3002/docs/tempo/<TEMPO_VERSION>/traceql/#comparison-operators) documentation.
+
+### Migration from OpenTracing to OpenTelemetry
+
+This release removes the `use_otel_tracer` option.
+Configure your spans via standard OpenTelemetry environment variables.
+For Jaeger exporting, set `OTEL_TRACES_EXPORTER=jaeger`.For more information, refer to the [OpenTelemetry documentation](https://www.google.com/url?q=https://opentelemetry.io/docs/languages/sdk-configuration/&sa=D&source=docs&ust=1736460391410238&usg=AOvVaw3bykVWwn34XfhrnFK73uM_). ([#3646](https://github.com/grafana/tempo/pull/3646))
+
+### Added, updated, removed, or renamed configuration parameters
+
+<table>
+  <tr>
+   <td><strong>Parameter</strong>
+   </td>
+   <td><strong>Comments</strong>
+   </td>
+  </tr>
+  <tr>
+   <td><code>querier_forget_delay</code>
+   </td>
+   <td>Removed. The <code>querier_forget_delay</code> setting provided no effective functionality and has been dropped. (<a href="https://github.com/grafana/tempo/pull/3996">#3996</a>)
+   </td>
+  </tr>
+  <tr>
+   <td><code>use_otel_tracer</code>
+   </td>
+   <td>Removed. Configure your spans via standard OpenTelemetry environment variables. For Jaeger exporting, set <code>OTEL_TRACES_EXPORTER=jaeger</code>. (<a href="https://github.com/grafana/tempo/pull/3646">#3646</a>)
+   </td>
+  </tr>
+  <tr>
+   <td>
+   <code>
+max_spans_per_span_set
+   </code>
+   </td>
+   <td>Added to query-frontend configuration. The limit is enabled by default and set to 100. Set it to `0` to restore the old behavior (unlimited). Otherwise, spans beyond the configured max are dropped. (<a href="https://github.com/grafana/tempo/pull/4383">#4275</a>)
+   </td>
+  </tr>
+  <tr>
+   <td><code>use_otel_tracer</code>
+   </td>
+   <td>The <code>use_otel_tracer</code> option is removed. Configure your spans via standard OpenTelemetry environment variables. For Jaeger exporting, set <code>OTEL_TRACES_EXPORTER=jaeger</code>. (<a href="https://github.com/grafana/tempo/pull/3646">#3646</a>)
+   </td>
+  </tr>
+</table>
+
+### gRPC compression set to snappy
+
+Tempo 2.7.1 sets gRPC compression between all components to be `snappy`.
+Using `snappy` provides a balanced approach to compression between components that will work for most installations.
+
+If you prefer a different balance of CPU/Memory and bandwidth, consider disabling compression or using zstd.
+
+For a discussion on alternatives, refer to [this discussion thread](https://github.com/grafana/tempo/discussions/4683). ([#4696](https://github.com/grafana/tempo/pull/4696)).
+
+#### gRPC compression disabled
+
+Tempo 2.7.0 release disabled gRPC compression in the querier and distributor for performance reasons. ([#4429](https://github.com/grafana/tempo/pull/4429)).
+Our benchmark suggests that without compression, queriers and distributors use less CPU and memory.
+
+Tempo 2.7.1 changed the default value to `snappy` for internal components.
+
+{{< admonition type="note" >}}
+While disabling gRPC compression improves performance, it will increase data usage and network traffic, which can impact cloud billing depending on your configuration.
+{{< /admonition >}}
+
+If you notice increased network traffic or issues, check the gRPC compression settings.
+You can enable gRPC compression using `snappy`:
+
+```yaml
+  ingester_client:
+      grpc_client_config:
+          grpc_compression: "snappy"
+  metrics_generator_client:
+      grpc_client_config:
+          grpc_compression: "snappy"
+  querier:
+      frontend_worker:
+          grpc_client_config:
+              grpc_compression: "snappy"
+```
+
+Refer to [gRPC compression configuration](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#grpc-compression) for more information.
+
+### Other upgrade considerations
+
+* The Tempo CLI now targets the `/api/v2/traces` endpoint by default. Use the `--v1` flag if you still rely on the older `/api/traces` endpoint. ([#4127](https://github.com/grafana/tempo/pull/4127))
+* If you already set the `X-Scope-OrgID` header in per-tenant overrides or global Tempo configuration, it's now honored and not overwritten by Tempo. This may change behavior if you previously depended on automatic injection. ([#4021](https://github.com/grafana/tempo/pull/4021))
+* The AWS Lambda build output changes from main to bootstrap. Follow the [AWS migration steps](https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/) to ensure your Lambda functions continue to work. ([#3852](https://github.com/grafana/tempo/pull/3852))
+
+## Bugfixes
+
+For a complete list, refer to the [Tempo CHANGELOG](https://github.com/grafana/tempo/releases).
+
+### 2.7.2
+
+* Fix rare panic that occurred when a querier modified results from ingesters and generators while they were being marshalled to proto. This bug also impacted query correctness on recent trace data by returning incomplete results before they were ready. ([#4790](https://github.com/grafana/tempo/pull/4790))
+
+### 2.7.0
+
+* Add `invalid_utf8` to reasons span metrics will discard spans. ([#4293](https://github.com/grafana/tempo/pull/4293)) We now catch values in your tracing data that can't be used as valid metrics labels. If you want span metrics by foo, but foo has illegal prom changes in it, then they won't be written.
+* Metrics-generators: Correctly drop from the ring before stopping ingestion to reduce drops during a rollout. ([#4101](https://github.com/grafana/tempo/pull/4101))
+* Correctly handle 400 Bad Request and 404 Not Found in gRPC streaming. ([#4144](https://github.com/grafana/tempo/pull/4144))
+* Correctly handle Authorization header in gRPC streaming. ([#4419](https://github.com/grafana/tempo/pull/4419))
+* Fix TraceQL metrics time range handling at the cutoff between recent and backend data. ([#4257](https://github.com/grafana/tempo/issues/4257))
+* Fix several issues with exemplar values for TraceQL metrics. ([#4366](https://github.com/grafana/tempo/pull/4366), [#4404](https://github.com/grafana/tempo/pull/4404))
+* Utilize S3Pass and S3User parameters in `tempo-cli` options, which were previously unused in the code. ([#4259](https://github.com/grafana/tempo/pull/4259))
+
+<!-- vale Grafana.We = YES -->
+<!-- vale Grafana.GoogleWill = YES -->
+<!-- vale Grafana.Timeless = YES -->
+<!-- vale Grafana.Parentheses = YES -->

--- a/docs/sources/tempo/release-notes/v2-8.md
+++ b/docs/sources/tempo/release-notes/v2-8.md
@@ -5,7 +5,7 @@ description: Release notes for Grafana Tempo 2.8
 weight: 20
 ---
 
-# Version 2.7 release notes
+# Version 2.8 release notes
 
 <!-- vale Grafana.We = NO -->
 <!-- vale Grafana.GoogleWill = NO -->
@@ -16,13 +16,19 @@ The Tempo team is pleased to announce the release of Tempo 2.8.
 
 This release gives you:
 
-* Ability to precisely track ingested traffic and attribute costs based on custom labels
-* A series of enhancements that significantly boost Tempo performance and reduce its overall resource footprint.
-* New TraceQL capabilities
-* Improvements to TraceQL metrics
+* New TraceQL features such as `most_recent`, parent-span filters, `sum_over_time`, and `topk`/`bottomk` to help surface the exact spans and metrics you need.
+* Concurrent block flushing, iterator optimizations, and back-pressure make ingestion and queries leaner and quicker.
+* Safer defaults with port 3200, distroless images, Go 1.24, and an upgraded OTLP Collector tighten security and simplify ops.
 
 These release notes highlight the most important features and bugfixes.
 For a complete list, refer to the [Tempo changelog](https://github.com/grafana/tempo/releases).
+
+{{< admonition type="note" >}}
+Tempo 2.8 has some major upgrade considerations including changing the default `http-listen-port` from 80 to 3200, removing serverless, and enforcing max attribute size at event, link, and instrumentation scopes.
+
+Refer to [Upgrade considerations](#upgrade-considerations) for details.
+{{< /admonition>}}
+
 
 <!-- Add link to the new blog post when ready
 Read the [Tempo 2.8 blog post](https://grafana.com/blog/2025/01/16/grafana-tempo-2.7-release-new-traceql-metrics-functions-operational-improvements-and-more/) for more examples and details about these improvements.
@@ -31,256 +37,230 @@ Read the [Tempo 2.8 blog post](https://grafana.com/blog/2025/01/16/grafana-tempo
 
 -->
 
+## New language features for TraceQL
+
+We’re excited to roll out three powerful enhancements to TraceQL, giving you more flexibility and performance when querying traces in Grafana Cloud with Tempo.
+
+* Rank your metrics with new `topk(n)` and `bottomk(n)` functions to quickly get your highest and lowest ranking time series.
+* Aggregate spans over time using `sum_over_time()` for built-in cumulative sums, such as total bytes, error counts.
+* Fetch the latest traces first via the experimental `most_recent=true` query hint.
+
+### Ranking `topk` and `bottomk` functions for TraceQL metrics
+
+When you’re looking at latency, error rates, or throughput across hundreds or thousands of services or endpoints, it’s easy to get lost in all the data.
+Previously, you’d have to pull back the full set of aggregates and then manually inspect or post‑process the results to find your worst offenders or best performers.
+
+With `topk(n)` and `bottomk(n)`, you can immediately narrow your focus to the top‑ or bottom‑ranked spans in a single, efficient query. This saves time and reduces the data volume you need to scan downstream.
+
+```
+{} | avg_over_time(span:duration) by (span:name) | topk(10)
+{} | count_over_time() by (span:name) | bottomk(10)
+```
+
+These are second stage functions used, where:
+
+* `topk(n)` returns the *n* series with the highest values from a first‑stage aggregation.
+* `bottomk(n)` returns the *n* series with the lowest values.
+
+For more information, refer to the [topk and bottomk documentation](https://grafana.com/docs/tempo/next/traceql/metrics-queries/functions/#topk-and-bottomk-functions) ([PR 4646](https://github.com/grafana/tempo/pull/4646/)).
+
+### The `sum_over_time` function for TraceQL metrics
+
+The `sum_over_time()` function lets you aggregate numerical values by computing the sum value of them. The time interval that the sum is computed over is set by the `step` parameter.
+
+```
+{ span.http.response_content_length > 0 } | sum_over_time(span.http.response_content_length)
+```
+
+With `sum_over_time()`, you can directly compute cumulative sums inside TraceQL, like total bytes transferred, total error counts, or resource consumption over time.
+
+```
+{}  | sum_over_time(span.http.response_content_length)
+```
+
+For each step interval, `sum_over_time(attr)` totals the values of `attr` across all matching spans.
+
+Refer to [TraceQL metrics functions](https://grafana.com/docs/tempo/next/traceql/metrics-queries/functions/#the-sum_over_time-min_over_time-max_over_time-and-avg_over_time--functions) for more information. ([PR 4786](https://github.com/grafana/tempo/pull/4786))
+
+### Experimental query hint `most_recent=true` to retrieve the most recent traces
+
+When troubleshooting a live incident or monitoring production health, you often need to see the absolute latest traces first. By default, Tempo’s query engine favors speed and returns the first `N` matching traces, which may not be the newest.
+
+The `most_recent` hint ensures you’re always looking at the freshest data, so you can diagnose recent errors or performance regressions without missing anything due to early row‑limit cuts.
+
+Examples:
+
+```
+{} with (most_recent=true)
+{ span.foo = "bar" } >> { status = error } with (most_recent=true)
+```
+
+With `most_recent=true`, Tempo performs a deeper search across data shards, retains the newest candidates, and returns traces sorted by start time rather than stopping at the first limit hit.
+([PR 4238]([https://github.com/grafana/tempo/pull/4238](https://github.com/grafana/tempo/pull/4238)))
+
+The TraceQL query hint `most_recent=true` can be used with any TraceQL selection query to force Tempo to return the most recent results ordered by time.
+
+For more information, refer to [Retrieve most recent results (experimental)](https://grafana.com/docs/tempo/latest/traceql/#retrieving-most-recent-results-experimental).
+
+### Query by parent span ID
+
+In addition, you can query by parent `span id`.
+Using `span:parentID`, you can ensure that you are looking at a child span of a specific parent, which is useful for example in span linking.
+Refer to the [documentation](https://grafana.com/docs/tempo/next/traceql/#intrinsic-fields) for more information.
+([PR 4692]([https://github.com/grafana/tempo/pull/4692](https://github.com/grafana/tempo/pull/4692)))
+
+## Major performance and memory usage improvements
+
+Tempo 2.8 removes pooling for large traces.
+In testing, removing large pooling impacted memory, cutting memory high-water marks to less than half in a high traffic/tenant installation.
+Some amount of pooling is needed to keep CPU, throughput, and GC rate maintained.
+Now, we have a fixed 1M default allocation size, which covers most traces.
+
+This graph illustrate the amount of memory used by the compactors.
+In one cell, we saw major improvements in compactor memory usage after PR [4985](https://github.com/grafana/tempo/pull/4985) was merged.
+Refer to PR [4985](https://github.com/grafana/tempo/pull/4985) for more information, including benchmarks and test results.
+
+{{< figure src="/media/docs/tempo/tempo-2.8-pr-4985-compactor-memory-graph.png" width="100%" >}}
+
+### Performance improvements
+
+TraceQL and Tempo generally see a number of performance improvements in this release. Refer to benchmarks in the PRs for additional information.
+
+* Improve TraceQL performance by reverting EqualRowNumber to an inlineable function. ([PR 4705](https://github.com/grafana/tempo/pull/4705))
+* Improve iterator performance by using max definition level to ignore parts of the RowNumber while nexting. Nexting is a function multiple in Tempo when you do a big query. Even minor improvements in nexting can have a major impact. ([PR 4753](https://github.com/grafana/tempo/pull/4753))
+* Increase query-frontend default batch size. TraceQL performance has improved enough to pass larger batches than before and still complete all jobs on one querier. ([PR 4844](https://github.com/grafana/tempo/pull/4844))
+* Improve Tempo build options. ([PR 4755](https://github.com/grafana/tempo/pull/4755))
+* Rewrite traces using rebatching. ([PR 4690](https://github.com/grafana/tempo/pull/4690))
+* Reorder span iterators. ([PR 4754](https://github.com/grafana/tempo/pull/4754))
+* Improve memcached memory usage by pooling buffers. ([PR 4970](https://github.com/grafana/tempo/pull/4970))
+
 ## Features and enhancements
 
-The most important features and enhancements in Tempo 2.7 are highlighted below.
+This section highlights the most important features and enhancements in Tempo 2.8.
 
-{{< admonition type="note" >}}
-This release changes gRPC compression to `snappy` by default to improve performance.
-Refer to [gRPC compression](#grpc-compression-set-to-snappy) for more information.
-{{< /admonition >}}
+### TraceQL correctness
 
-### Track ingested traffic and attribute costs
+One of our major focuses with this release has been to improve TraceQL’s performance and correctness. The following list summarizes some of the more important improvements.
 
-This new feature lets tenants precisely measure and attribute costs for their ingested trace data by leveraging custom labels.
-This functionality provides a more accurate alternative to existing size-based metrics and meets the growing need for detailed cost attribution and billing transparency.
+* Fixed behavior for queries like `{.foo && true}` and `{.foo || false}`. ([PR 4855](https://github.com/grafana/tempo/pull/4855))
+* Make comparison to nil symmetric. ([PR 4869](https://github.com/grafana/tempo/pull/4869))
+* Corrected TraceQL incorrect results for additional spanset filters after a select operation. ([PR 4600](https://github.com/grafana/tempo/pull/4600))
+* Fixed TraceQL metrics incorrect results for queries with multiple filters that reside in non-dedicated columns that also group by the same variable. ([PR 4887](https://github.com/grafana/tempo/pull/4887))
+* Fixed metrics streaming for all non-trivial metrics. ([PR 4624](https://github.com/grafana/tempo/pull/4624))
+* Fixed behavior of `{} >> { span.attr-that-doesnt-exist != "foo" }`. ([PR 5007](https://github.com/grafana/tempo/pull/5007))
+* Fixed various edge cases for query range. ([PR 4962](https://github.com/grafana/tempo/pull/4962))
+* Excluded `nestedSetParent` and other values from the `compare()` function. ([PR 5196](https://github.com/grafana/tempo/pull/5196))
 
-Modern organizations are increasingly reliant on distributed traces for observability, yet reconciling the costs associated with different teams, services, or departments can be challenging.
-The existing size metric isn't accurate enough by missing non-span data and can lead to under- or over-counting.
-The new usage tracking feature overcomes these issues by splitting resource-level data fairly and providing up to 99% accuracy—perfect for cost reconciliation.
+The query frontend can cache job results for individual blocks when executing TraceQL. These bug fixes impact caching behavior.
 
-Unlike the previous method, this new feature precisely accounts for every byte of trace data in the distributor—the only Tempo component with the original payload.
-A new API endpoint, `/usage_metrics`, exposes the per-tenant metrics on ingested data and cost attribution, and can be controlled with per-tenant configuration.
+* TraceQL results caching bug for floats ending in `.0`. ([PR 4539](https://github.com/grafana/tempo/pull/4539))
+* Correctly cache frontend jobs for query range in TraceQL metrics. ([PR 4771](https://github.com/grafana/tempo/pull/4771))
+* Fixed frontend cache key generation for TraceQL metrics queries to prevent collisions. ([PR 5017](https://github.com/grafana/tempo/pull/5017))
 
-This feature is designed as a foundation for broader usage tracking capabilities, where additional trackers will allow organizations to measure and report on a range of usage metrics. ([#4162](https://github.com/grafana/tempo/pull/4162))
+### TraceQL exemplar improvements and bugfixes
 
-For additional information, refer to the [Usage metrics documentation](https://grafana.com/docs/tempo/<TEMPO_VERSION>/api_docs/#usage-metrics).
+Tempo 2.8 improves exemplars in TraceQL metrics.
 
-### Major performance and memory usage improvements
+* Distribute exemplars over time and hard limit the number of exemplars. ([PR 5158](https://github.com/grafana/tempo/pull/5158))
+* Right exemplars for histogram and quantiles. ([PR 5145](https://github.com/grafana/tempo/pull/5145))
+* Fixed for queried number of exemplars. ([PR 5115](https://github.com/grafana/tempo/pull/5115))
 
-We're excited to announce a series of enhancements that significantly boost Tempo performance and reduce its overall resource footprint.
+### Security improvements
 
-**Better refuse large traces:** The ingester now reuses generator code to better detect and reject oversized traces.
-This change makes trace ingestion more reliable and prevents capacity overloads.
-Plus, two new metrics `tempo_metrics_generator_live_trace_bytes` and `tempo_ingester_live_trace_bytes` provide deeper visibility into per-tenant byte usage. ([#4365](https://github.com/grafana/tempo/pull/4365))
+The following updates were made to address security issues:
 
-**Reduced allocations:** We've refined how the query-frontend handles incoming traffic to eliminate unnecessary allocations when query demand is low.
-As part of these improvements, the `querier_forget_delay` configuration option has been removed because it no longer served a practical purpose. ([#3996](https://github.com/grafana/tempo/pull/3996))
-This release also reduces the ingester working set by improving prelloc behavior.
-It also adds tunable prealloc env variables `PREALLOC_BKT_SIZE`, `PREALLOC_NUM_BUCKETS`, `PREALLOC_MIN_BUCKET`, and metric `tempo_ingester_prealloc_miss_bytes_total` to observe and tune prealloc behavior. ([#4344](https://github.com/grafana/tempo/pull/4344), [#4369](https://github.com/grafana/tempo/pull/4369))
+* Use distroless base container images for improved security. ([PR 4556](https://github.com/grafana/tempo/pull/4556))
+* Updated to go 1.24.3. ([PR 5110](https://github.com/grafana/tempo/pull/5110))
 
-**Faster tag lookups and collector operations:** Multiple optimizations ([#4100](https://github.com/grafana/tempo/pull/4100), [#4104](https://github.com/grafana/tempo/pull/4104), [#4109](https://github.com/grafana/tempo/pull/4109)) make tag lookups and collector tasks more responsive, particularly for distinct value searches. Additionally, enabling disk caching for completed blocks in ingesters significantly cuts down on query latency and lowers overall I/O overhead. ([#4069](https://github.com/grafana/tempo/pull/4069))
 
-**Reduce goroutines in non-querier components:** A simplified design across non-querier components lowers the total number of goroutines, making Tempo more efficient and easier to scale—even with high trace volumes. ([#4484](https://github.com/grafana/tempo/pull/4484))
+### Improved error handling and logging
 
-### New TraceQL capabilities
+In addition, we’ve updated how Tempo handles errors so it’s easier to troubleshoot.
 
-New in Tempo 2.7, TraceQL now allows you to query the [instrumentation scope](https://opentelemetry.io/docs/concepts/instrumentation-scope/) fields ([#3967](https://github.com/grafana/tempo/pull/3967)), letting you filter and explore your traces based on where and how they were instrumented.
-
-We've extended TraceQL to automatically collect matches from array values ([#3867](https://github.com/grafana/tempo/pull/3867)), making it easier to parse spans containing arrays of attributes.
-
-Query times are notably faster, thanks to multiple optimizations ([#4114](https://github.com/grafana/tempo/pull/4114), [#4163](https://github.com/grafana/tempo/pull/4163), [#4438](https://github.com/grafana/tempo/pull/4438)).
-Whether you're running standard queries or advanced filters, you should see a significant speed boost.
-
-Tempo now uses the Prometheus "fast regex" engine to accelerate regular expression-based filtering ([#4329](https://github.com/grafana/tempo/pull/4329)).
-As part of this update, all regular expressions matches are now fully anchored.
-This breaking change means `span.foo =~ "bar"` is evaluated as `span.foo =~ "^bar$"`.
-Update any affected queries accordingly.
-
-### Query improvements
-
-In API v2 queries, Tempo can now return partial traces even when they exceed the max bytes limit ([#3941](https://github.com/grafana/tempo/pull/3941)).
-This ensures you can still retrieve and inspect useful segments of large traces to aid in debugging.
-Refer to the [query v2 API endpoint](https://grafana.com/docs/tempo/<TEMPO_VERSION>/api_docs/#query-v2) documentation for more information.
-
-### TraceQL metrics improvements (experimental)
-
-In TraceQL metrics, we've added a new `avg_over_time` function ([#4073](https://github.com/grafana/tempo/pull/4073)) to help you compute average values for trace-based metrics over specified time ranges, making it simpler to spot trends and anomalies.
-
-Tempo now supports `min_over_time` ([#3975](https://github.com/grafana/tempo/pull/3975)) and `max_over_time` ([#4065](https://github.com/grafana/tempo/pull/4065)) queries, giving you more flexibility in analyzing the smallest or largest values across your trace data.
-
-For more information about TraceQL metrics, refer to [TraceQL metrics functions](https://grafana.com/docs/tempo/<TEMPO_VERSION>/traceql/metrics-queries/functions/#traceql-metrics-functions).
+* Updated query range error message. ([PR 4929](https://github.com/grafana/tempo/pull/4929))
+* Improved rate limit error message when traces size exceeds rate limit. ([PR 4986](https://github.com/grafana/tempo/pull/4986/))
+* Restored dedicated columns logging for completed blocks in the compactor. ([PR 4832](https://github.com/grafana/tempo/pull/4832))
+* Query-frontend logs add a message to the log line. ([PR 4975](https://github.com/grafana/tempo/pull/4975))
 
 ### Other enhancements and improvements
 
 This release also has these notable updates.
 
-### 2.7.1
-
-* Default to snappy compression for all gRPC communications internal to Tempo. We feel this is a nice balance of resource usage and network traffic. For a discussion on alternatives, refer to [this discussion thread](https://github.com/grafana/tempo/discussions/4683). ([#4696](https://github.com/grafana/tempo/pull/4696))
-
-### 2.7.0
-
-* The [metrics-generator](https://grafana.com/docs/tempo/latest/metrics-generator/) introduces a generous limit of 100 for failed flush attempts ([#4254](https://github.com/grafana/tempo/pull/4254)) to prevent constant retries on corrupted blocks. A new metric also tracks these flush failures, offering better visibility into potential issues during ingestion.
-* For [span metrics](https://grafana.com/docs/tempo/latest/metrics-generator/span_metrics/), the span multiplier now also sources its value from the resource attributes ([#4210](https://github.com/grafana/tempo/pull/4210)). This makes it possible to adjust and correct metrics using service or environment configuration, ensuring more accurate data reporting.
-* The `tempo-cli` now supports dropping multiple trace IDs in a single command, speeding up administrative tasks and simplifying cleanup operations. ([#4266](https://github.com/grafana/tempo/pull/4266))
-* An optional log, `log_discarded_spans`, tracks spans discarded by Tempo. This improves visibility into data ingestion workflows and helps you quickly diagnose any dropped spans. ([#3957](https://github.com/grafana/tempo/issues/3957))
-* You can now impose limits on tag and tag-value lookups, preventing runaway queries in large-scale deployments and ensuring a smoother user experience. ([#4320](https://github.com/grafana/tempo/pull/4320))
-* The tags and tag-values endpoints have gained new throughput and SLO-related metrics. Get deeper insights into query performance and reliability straight from Tempo's built-in monitoring. ([#4148](https://github.com/grafana/tempo/pull/4148))
-* Tempo now exposes a SemVer version in its `/api/status/buildinfo` endpoint, providing clear visibility into versioning, particularly useful for cloud deployments and automated pipelines. ([#4110](https://github.com/grafana/tempo/pull/4110))
+* Added throughput SLO and metrics for the `TraceByID` endpoint. Configurable via the `throughput_bytes_slo` field, and it will populate `op="traces"` label in SLO and throughput metrics. ([PR 4668](https://github.com/grafana/tempo/pull/4668))
+* Prevented queries in the ingester from blocking flushing traces to disk and memory spikes. ([PR 4483](https://github.com/grafana/tempo/pull/4483))
+* Host Info Processor now tracks host identifying resource attribute in metric ([PR 5152](https://github.com/grafana/tempo/pull/5152))
+* Added IPv6 support to the distributor. ([PR 4840](https://github.com/grafana/tempo/pull/4840))
+* Added default mutex and blocking values. ([PR 4979](https://github.com/grafana/tempo/pull/4979))
 
 ## Upgrade considerations
 
 When [upgrading](https://grafana.com/docs/tempo/latest/setup/upgrade/) to Tempo 2.7, be aware of these considerations and breaking changes.
 
-### OpenTelemetry Collector receiver listens on `localhost` by default
+### Changed the default listening port
 
-After this change, the OpenTelemetry Collector receiver defaults to binding on `localhost` rather than `0.0.0.0`. Tempo installations running in Docker or other container environments must update their listener address to continue receiving data. ([#4465](https://github.com/grafana/tempo/pull/4465))
-
-Most Tempo installations use the receivers with the default configuration:
+With Tempo 2.8, the default `http_listen_port` changes from 80 to 3200. Check the configuration options for the `server:` block in your Tempo configuration file.
 
 ```yaml
-distributor:
-  receivers:
-    otlp:
-      protocols:
-        grpc:
-        http:
+server:
+    # HTTP server listen host
+    [http_listen_address: &lt;string>]
+
+    # HTTP server listen port
+    [http_listen_port: &lt;int> | default = 3200]
 ```
 
-This used to work fine since the receivers defaulted to `0.0.0.0:4317` and `0.0.0.0:4318` respectively. With the changes to replace unspecified addresses, the receivers now default to `localhost:4317` and `localhost:4318`.
+Refer to [issue 4945](https://github.com/grafana/tempo/discussions/4945) for more information for the rationale.
+[PR 4960](https://github.com/grafana/tempo/pull/4960)
 
-As a result, connections to Tempo running in a Docker container won't work anymore.
+### Removed Tempo serverless
 
-To workaround this, you need to specify the address you want to bind to explicitly. For instance, if Tempo is running in a container with hostname `tempo`, this should work:
+Tempo serverless has been removed. The following configuration options are no longer  valid and should be removed from your Tempo configuration. [PR [4599](https://github.com/grafana/tempo/pull/4599/))
 
 ```yaml
-# ...
-        http:
-          endpoint: "tempo:4318"
+querier:
+    search:
+        prefer_self: <int>
+        external_hedge_requests_at: <duration>
+        external_hedge_requests_up_to:  <duration>
+        external_backend: <string>
+        google_cloud_run: <string>
+        external_endpoints: <array>
 ```
 
-You can also explicitly bind to `0.0.0.0` still, but this has potential security risks:
+In addition, these Tempo serverless related metrics have been removed: `tempo_querier_external_endpoint_duration_seconds`, `tempo_querier_external_endpoint_hedged_roundtrips_total`, and `tempo_feature_enabled`.
 
-```yaml
-# ...
-        http:
-          endpoint: "0.0.0.0:4318"
-```
+### Updated, removed, or renamed configuration parameters
 
-### Tempo serverless deprecation
-
-Tempo serverless is now officially deprecated and will be removed in an upcoming release.
-Prepare to migrate any serverless workflows to alternative deployments. ([#4017](https://github.com/grafana/tempo/pull/4017), [documentation](https://grafana.com/docs/tempo/latest/operations/backend_search/#serverless-environment))
-
-There are no changes to this release for serverless. However, you'll need to remove these configurations before the next release.
-
-### Anchored regular expression matchers in TraceQL
-
-TraceQL now uses the Prometheus "fast regex" engine to accelerate regular expression-based filtering ([#4329](https://github.com/grafana/tempo/pull/4329)).
-As part of this update, all regular expression matches are now fully anchored.
-This breaking change means `span.foo =~ "bar"` is evaluated as `span.foo =~ "^bar$"`.
-Update any affected queries accordingly.
-
-For more information, refer to the [Comparison operators TraceQL](http://localhost:3002/docs/tempo/<TEMPO_VERSION>/traceql/#comparison-operators) documentation.
-
-### Migration from OpenTracing to OpenTelemetry
-
-This release removes the `use_otel_tracer` option.
-Configure your spans via standard OpenTelemetry environment variables.
-For Jaeger exporting, set `OTEL_TRACES_EXPORTER=jaeger`.For more information, refer to the [OpenTelemetry documentation](https://www.google.com/url?q=https://opentelemetry.io/docs/languages/sdk-configuration/&sa=D&source=docs&ust=1736460391410238&usg=AOvVaw3bykVWwn34XfhrnFK73uM_). ([#3646](https://github.com/grafana/tempo/pull/3646))
-
-### Added, updated, removed, or renamed configuration parameters
-
-<table>
-  <tr>
-   <td><strong>Parameter</strong>
-   </td>
-   <td><strong>Comments</strong>
-   </td>
-  </tr>
-  <tr>
-   <td><code>querier_forget_delay</code>
-   </td>
-   <td>Removed. The <code>querier_forget_delay</code> setting provided no effective functionality and has been dropped. (<a href="https://github.com/grafana/tempo/pull/3996">#3996</a>)
-   </td>
-  </tr>
-  <tr>
-   <td><code>use_otel_tracer</code>
-   </td>
-   <td>Removed. Configure your spans via standard OpenTelemetry environment variables. For Jaeger exporting, set <code>OTEL_TRACES_EXPORTER=jaeger</code>. (<a href="https://github.com/grafana/tempo/pull/3646">#3646</a>)
-   </td>
-  </tr>
-  <tr>
-   <td>
-   <code>
-max_spans_per_span_set
-   </code>
-   </td>
-   <td>Added to query-frontend configuration. The limit is enabled by default and set to 100. Set it to `0` to restore the old behavior (unlimited). Otherwise, spans beyond the configured max are dropped. (<a href="https://github.com/grafana/tempo/pull/4383">#4275</a>)
-   </td>
-  </tr>
-  <tr>
-   <td><code>use_otel_tracer</code>
-   </td>
-   <td>The <code>use_otel_tracer</code> option is removed. Configure your spans via standard OpenTelemetry environment variables. For Jaeger exporting, set <code>OTEL_TRACES_EXPORTER=jaeger</code>. (<a href="https://github.com/grafana/tempo/pull/3646">#3646</a>)
-   </td>
-  </tr>
-</table>
-
-### gRPC compression set to snappy
-
-Tempo 2.7.1 sets gRPC compression between all components to be `snappy`.
-Using `snappy` provides a balanced approach to compression between components that will work for most installations.
-
-If you prefer a different balance of CPU/Memory and bandwidth, consider disabling compression or using zstd.
-
-For a discussion on alternatives, refer to [this discussion thread](https://github.com/grafana/tempo/discussions/4683). ([#4696](https://github.com/grafana/tempo/pull/4696)).
-
-#### gRPC compression disabled
-
-Tempo 2.7.0 release disabled gRPC compression in the querier and distributor for performance reasons. ([#4429](https://github.com/grafana/tempo/pull/4429)).
-Our benchmark suggests that without compression, queriers and distributors use less CPU and memory.
-
-Tempo 2.7.1 changed the default value to `snappy` for internal components.
-
-{{< admonition type="note" >}}
-While disabling gRPC compression improves performance, it will increase data usage and network traffic, which can impact cloud billing depending on your configuration.
-{{< /admonition >}}
-
-If you notice increased network traffic or issues, check the gRPC compression settings.
-You can enable gRPC compression using `snappy`:
-
-```yaml
-  ingester_client:
-      grpc_client_config:
-          grpc_compression: "snappy"
-  metrics_generator_client:
-      grpc_client_config:
-          grpc_compression: "snappy"
-  querier:
-      frontend_worker:
-          grpc_client_config:
-              grpc_compression: "snappy"
-```
-
-Refer to [gRPC compression configuration](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#grpc-compression) for more information.
+| Parameter | Comments |
+|---|---|
+| `max_span_attr_byte` | Renamed to `max_attribute_bytes`. ([PR 4633](https://github.com/grafana/tempo/pull/4633)) |
+| `tempo_discarded_spans_total` | Removed `internal_error` as a reason from `tempo_discarded_spans_total`. ([PR 4554](https://github.com/grafana/tempo/pull/4554)) |
+| `tempo_receiver_accepted_span` and `tempo_receiver_refused_spans` | The `name` dimension from `tempo_receiver_accepted_span` and `tempo_receiver_refused_spans` changes from `tempo/jaeger_receiver` to `jaeger/jaeger_receiver`. ([PR 4893](https://github.com/grafana/tempo/pull/4893))  |
 
 ### Other upgrade considerations
 
-* The Tempo CLI now targets the `/api/v2/traces` endpoint by default. Use the `--v1` flag if you still rely on the older `/api/traces` endpoint. ([#4127](https://github.com/grafana/tempo/pull/4127))
-* If you already set the `X-Scope-OrgID` header in per-tenant overrides or global Tempo configuration, it's now honored and not overwritten by Tempo. This may change behavior if you previously depended on automatic injection. ([#4021](https://github.com/grafana/tempo/pull/4021))
-* The AWS Lambda build output changes from main to bootstrap. Follow the [AWS migration steps](https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/) to ensure your Lambda functions continue to work. ([#3852](https://github.com/grafana/tempo/pull/3852))
+* Upgrade OTEL Collector to v0.122.1. The `name` dimension from `tempo_receiver_accepted_span` and `tempo_receiver_refused_spans` changes from `tempo/jaeger_receiver` to `jaeger/jaeger_receiver`. ([PR 4893](https://github.com/grafana/tempo/pull/4893))
+* Replace `opentracing-contrib/go-grpc` by `otelgrpc` in Tempo query. ([PR 4958](https://github.com/grafana/tempo/pull/4958))
+* Enforce max attribute size at event, link, and instrumentation scope. The configuration is now per-tenant. Renamed `max_span_attr_byte` to `max_attribute_bytes`. ([PR 4633](https://github.com/grafana/tempo/pull/4633))
+* Converted SLO metric `query_frontend_bytes_processed_per_second` from a histogram to a counter as it's more performant. ([PR 4748](https://github.com/grafana/tempo/pull/4748))
+* Removed the OpenTelemetry Jaeger exporter, which has been [deprecated](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/jaeger). ([PR 4926](https://github.com/grafana/tempo/pull/4926))
 
 ## Bugfixes
 
 For a complete list, refer to the [Tempo CHANGELOG](https://github.com/grafana/tempo/releases).
 
-### 2.7.2
-
-* Fix rare panic that occurred when a querier modified results from ingesters and generators while they were being marshalled to proto. This bug also impacted query correctness on recent trace data by returning incomplete results before they were ready. ([#4790](https://github.com/grafana/tempo/pull/4790))
-
-### 2.7.0
-
-* Add `invalid_utf8` to reasons span metrics will discard spans. ([#4293](https://github.com/grafana/tempo/pull/4293)) We now catch values in your tracing data that can't be used as valid metrics labels. If you want span metrics by foo, but foo has illegal prom changes in it, then they won't be written.
-* Metrics-generators: Correctly drop from the ring before stopping ingestion to reduce drops during a rollout. ([#4101](https://github.com/grafana/tempo/pull/4101))
-* Correctly handle 400 Bad Request and 404 Not Found in gRPC streaming. ([#4144](https://github.com/grafana/tempo/pull/4144))
-* Correctly handle Authorization header in gRPC streaming. ([#4419](https://github.com/grafana/tempo/pull/4419))
-* Fix TraceQL metrics time range handling at the cutoff between recent and backend data. ([#4257](https://github.com/grafana/tempo/issues/4257))
-* Fix several issues with exemplar values for TraceQL metrics. ([#4366](https://github.com/grafana/tempo/pull/4366), [#4404](https://github.com/grafana/tempo/pull/4404))
-* Utilize S3Pass and S3User parameters in `tempo-cli` options, which were previously unused in the code. ([#4259](https://github.com/grafana/tempo/pull/4259))
-
-<!-- vale Grafana.We = YES -->
-<!-- vale Grafana.GoogleWill = YES -->
-<!-- vale Grafana.Timeless = YES -->
-<!-- vale Grafana.Parentheses = YES -->
+* Chose a default step for a gRPC streaming query range request if none is provided. Correctly copy exemplars for metrics like `| rate()` when gRPC streaming. ([PR 4546](https://github.com/grafana/tempo/pull/4576))
+* Fixed distributor issue where a hash collision could lead to spans stored incorrectly ([PR 5186](https://github.com/grafana/tempo/pull/5186))
+* Added object name to cache key in ReadRange ([PR 4982](https://github.com/grafana/tempo/pull/4982))
+* Fixed rare panic during compaction ([PR 4915](https://github.com/grafana/tempo/pull/4915))
+* Returned the operand as the only value if the tag is already filtered in the query ([PR 4673](https://github.com/grafana/tempo/pull/4673))
+* Included cost attribution when converting from default configuration to legacy one. ([PR 4787](https://github.com/grafana/tempo/pull/4937))
+* Updated `memcached` to respect cancelled context to prevent panic. ([PR 5041](https://github.com/grafana/tempo/pull/5041))
+* Fixed setting processors in user configurations overrides via API. ([PR 4741](https://github.com/grafana/tempo/pull/4741))
+* Fixed panic on startup. ([PR 4744](https://github.com/grafana/tempo/pull/4744))
+* Fixed intrinsic tag lookups dropped when max tag lookup response size is exceeded. ([PR 4784](https://github.com/grafana/tempo/pull/4784))
+* Fixed error propagation in the SyncIterator. ([PR 5045](https://github.com/grafana/tempo/pull/5045))
+* Fixed mixin to include `otlp_v1_traces` HTTP write route ([PR 5072](https://github.com/grafana/tempo/pull/5072))
+* Fixed `TempoBlockListRisingQuickly` alert grouping. ([PR 4876](https://github.com/grafana/tempo/pull/4876))
+* Fixed metrics generator host info processor overrides configuration. ([PR 5118](https://github.com/grafana/tempo/pull/5118))
+* Fixed metrics generator `target_info` to skip attributes with no name to prevent downstream errors. ([PR 5148](https://github.com/grafana/tempo/pull/5148))

--- a/docs/sources/tempo/traceql/_index.md
+++ b/docs/sources/tempo/traceql/_index.md
@@ -592,7 +592,8 @@ find something like a single service with more than 1 error:
 
 ## Arithmetic
 
-TraceQL supports arbitrary arithmetic in your queries. This can be useful to make queries more human readable:
+TraceQL supports arbitrary arithmetic in your queries.
+Using arithmetic can make queries more human readable:
 ```
 { span.http.request_content_length > 10 * 1024 * 1024 }
 ```
@@ -601,24 +602,41 @@ or anything else that comes to mind.
 
 ## Selection
 
-TraceQL can select arbitrary fields from spans. This is particularly performant because the selected fields are not retrieved until all other criteria is met.
+TraceQL can select arbitrary fields from spans.
+This is particularly performant because the selected fields aren't retrieved until all other criteria is met.
+For example, to select the `span.http.status_code` and `span.http.url` from all spans that have an error status code:
+
 ```
-{ status=error } | select(span.http.status_code, span.http.url)
+{ status = error } | select(span.http.status_code, span.http.url)
 ```
 
 ## Retrieving most recent results (experimental)
 
-The TraceQL query hint `most_recent=true` can be used with any TraceQL selection query to force Tempo to return the most recent results ordered by time. Examples:
+When troubleshooting a live incident or monitoring production health, you often need to see the latest traces first.
+By default, Tempo’s query engine favors speed and returns the first `N` matching traces, which may not be the newest.
+
+The `most_recent` hint ensures you see the freshest data, so you can diagnose recent errors or performance regressions without missing anything due to early row‑limit cuts.
+
+You can use TraceQL query hint `most_recent=true` with any TraceQL selection query to force Tempo to return the most recent results ordered by time.
+
+Examples:
 
 ```
 {} with (most_recent=true)
 { span.foo = "bar" } >> { status = error } with (most_recent=true)
 ```
 
+With `most_recent=true`, Tempo performs a deeper search across data shards, retains the newest candidates, and returns traces sorted by start time rather than stopping at the first limit hit.
+
+You can specify the time window to break a search up into when doing a most recent TraceQL search using `most_recent_shards:` in the `query_frontend` configuration block.
+The default value is 200.
+Refer to the [Tempo configuration reference](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/query_frontend/) for more information.
+
+
 ## Experimental TraceQL metrics
 
-TraceQL metrics are experimental, but easy to get started with.
-Refer to [the TraceQL metrics](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/traceql-metrics/) documentation for more information.
+TraceQL metrics are easy to get started with.
+Refer to [TraceQL metrics](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/traceql-metrics/) for more information.
 
 You can also use TraceQL metrics queries.
-For details, refer to [TraceQL metrics queries](https://grafana.com/docs/tempo/<TEMPO_VERSION>/traceql/metrics-queries/).
+Refer to [TraceQL metrics queries](https://grafana.com/docs/tempo/<TEMPO_VERSION>/traceql/metrics-queries/) for more information.

--- a/docs/sources/tempo/traceql/_index.md
+++ b/docs/sources/tempo/traceql/_index.md
@@ -632,6 +632,12 @@ You can specify the time window to break a search up into when doing a most rece
 The default value is 200.
 Refer to the [Tempo configuration reference](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/query_frontend/) for more information.
 
+### Search impact using `most_recent`
+
+Most search functions are deterministic: using the same search criteria results in the same results.
+
+When you use most_recent=true`, Tempo search is non-deterministic.
+If you perform the same search twice, you’ll get different lists, assuming the possible number of results for your search is greater than the number of results you have your search set to return.
 
 ## Experimental TraceQL metrics
 

--- a/docs/sources/tempo/traceql/metrics-queries/functions.md
+++ b/docs/sources/tempo/traceql/metrics-queries/functions.md
@@ -231,9 +231,13 @@ These functions are similar to their equivalent PromQL functions. For example:
 When a query response is larger than the maximum, you can use these functions to return only the specified number
 from 1 through `k` of the number of the top or bottom results.
 
-For example: `{ resource.service.name = "foo" } | rate() by (span.http.url)  | topk(10)`
-The first part, `{ resource.service.name = "foo" }`, takes all spans in the service `foo` The spans
-are rated by the URL, for example, the most active endpoints on a service.
+For example:
+```
+`{ resource.service.name = "foo" } | rate() by (span.http.url)  | topk(10)`
+```
+
+The first part, `{ resource.service.name = "foo" }`, takes all spans in the service `foo`.
+The spans are rated by the URL, for example, the most active endpoints on a service.
 
 Adding `topk(10)` returns the top 10 most common instead of the entire list.
 Conversely, you can use `bottomk(10)` to see the least most used ones.


### PR DESCRIPTION
**What this PR does**:

Draft Tempo 2.8 release notes. 
* Update docs for some of the release items
* Fixes some mistakes in previous release notes (missing periods, etc.)
* Adds copilot-instructions under .github to allow automation using CoPilot 

**Which issue(s) this PR fixes**:
Fixes #5201 

Related: https://github.com/grafana/tempo/pull/5259

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`