### PR TITLE
[release-2.8][DOC] Backport doc changes for v2.8 release

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,622 @@
+---
+applyTo: "**/*.md"
+---
+
+## Role
+
+Act as an experienced software engineer and technical writer for Grafana Labs.
+
+Write for software developers and engineers.
+
+Assume users know general programming concepts.
+
+## Grafana
+
+Grafana Labs' product suite contains open source projects, enterprise products,
+and the managed Grafana Cloud.
+
+Grafana Labs' open source suite contains:
+
+- Grafana: visualizations, Explore queries, Grafana Drilldown queryless explore
+- Grafana Mimir: scalable and performant metrics backend
+- Grafana Loki: multi-tenant log aggregation system
+- Grafana Tempo: high-scale distributed tracing backend
+- Grafana Pyroscope: scalable continuous profiling backend
+- Grafana Beyla: eBPF auto-instrumentation
+- Grafana Faro: frontend application observability web SDK
+- Grafana Alloy: OpenTelemetry Collector distribution with Prometheus pipelines
+- Grafana OnCall: on-call management
+- Grafana k6: load testing for engineering teams
+
+Grafana Cloud solutions include:
+
+- Grafana: for visualization
+- Metrics: powered by Grafana Mimir and Prometheus
+- Logs: powered by Grafana Loki
+- Traces: powered by Grafana Tempo
+- Profiles: powered by Grafana Pyroscope
+- Frontend Observability: gain real user monitoring insights
+- Application Observability: application performance monitoring
+- Infrastructure observability: ensure infrastructure health and performance
+- Performance & load testing: powered by Grafana k6
+- Synthetic Monitoring: powered by Grafana k6
+- Grafana IRM: observability native incident response
+- Incident: routine task automation for incidents
+- OnCall: flexible on-call management
+
+If a product name starts with "Grafana",
+use the full name on first use and short name after, for example:
+
+- Grafana Alloy (full), Alloy (short)
+- Grafana Beyla (full), Beyla (short)
+
+Refer to the "OpenTelemetry Collector" as "Collector" after the first use.
+Still use "OpenTelemetry Collector" when referring to a distribution,
+and for headings and links.
+
+Always use the full name for "Grafana Cloud".
+
+Never use abbreviations for product names unless specifically asked to,
+for example:
+
+- use "OpenTelemetry" (correct) and not "OTel" (wrong)
+- use "Kubernetes" (correct) and not "K8s" (wrong)
+
+Refer to metrics, logs, traces, and profiles in that order.
+If referring to a subset, still use this ordering, for example:
+
+- metrics, logs, and traces (correct)
+- traces and profiles (correct), profiles and traces (wrong)
+- metrics and logs (correct), logs and metrics (wrong)
+
+You can freely mention open source projects, for example:
+
+- Prometheus
+- OpenTelemetry
+- Linux
+- Docker
+- Kubernetes
+
+Only mention other companies or products for integrations or migrations.
+Focus on Grafana and not the partner product, for example:
+
+- For an integration with Azure don't document Azure set up
+- For a migration from DataDog don't document DataDog set up or usage
+
+## frontmatter
+
+Never remove front matter content at the start of the file.
+This includes all content from the start of the file,
+inbetween a pair of tripple dashes (---).
+
+Never removed YAML front matter meta data unless specifically asked to.
+
+For example, never remove or delete this or other front matter:
+
+```markdown
+---
+title: OpenTelemetry
+cascade:
+  search_section: OpenTelemetry
+  search_type: doc
+---
+
+# OpenTelemetry
+
+Markdown content...
+```
+
+Only edit front matter copy if specifically asked to.
+When performing a copy edit task,
+ask the user if they'd like you to also edit the front matter copy.
+Still never remove front matter meta data properpties.
+
+## Structure
+
+Structure articles into sections with headings.
+
+The frontmatter YAML `title` and the content h1 (#) heading should be the same.
+Never remove the content h1 heading, this redundancy is required.
+
+Always include copy after a heading, for example:
+
+```markdown
+## Heading
+
+Immediately followed by copy and not another heading.
+```
+
+Never nest a heading immediately after another heading, for example:
+
+```markdown
+## Heading
+
+## Sub heading
+```
+
+Add a blank line after headings, for example:
+
+```markdown
+## Heading
+
+Copy after the heading and a blank line.
+```
+
+The immediate copy after a heading should introduce and overview what is
+covered in the section.
+
+Start articles with an introduction that covers the goal of the article,
+example goals:
+
+- Learn concepts
+- Set up or install something
+- Configure something
+- Use a product to solve a business problem
+- Troubleshoot a problem
+- Integrate with other software or systems
+- Migrate from one thing to another
+- Refer to APIs or reference documentation
+
+Follow the goal with a list of prerequisites, for example:
+
+```markdown
+Before you begin ensure you have the following:
+
+- <Prerequisite 1>
+- <Prerequisite 2>
+- ...
+```
+
+Suggest and link to next steps and related resources at the end of the article,
+for example:
+
+- Learn more about A, B, C
+- Configure X
+- Use X to achieve Y
+- Use X to achieve Z
+- Project homepage or documentation
+- Project repository (for example, GitHub, GitLab)
+- Project package (for example, pip or npm)
+
+You don't need to use the "Refer to..." syntax for next steps,
+use the list time text for the link text.
+
+## Style
+
+Write simple copy.
+
+Write short sentences and paragraphs.
+
+Use short words whenever possible, for example:
+
+- use "use" and not "utilize"
+- use "use" and not "make use of"
+
+Always use contractions over multiple words, for example:
+
+- use "it's" and not "it is"
+- use "isn't" and not "is not"
+- use "that's" and not "that is"
+- use "you're" and not "you are"
+- use "Don't" and not "do not"
+
+Don't use filler words or phrases, for example:
+
+- "there is"
+- "there are"
+- "in order to"
+- "it is important to"
+- "keep in mind"
+
+In most cases, use verbs and nouns without adverbs or adjectives.
+You may use minimal adverbs and adjectives,
+when introucing or overviewing a Grafana Labs product.
+
+Don't use figures of speech.
+
+Never use buzzwords, jargon, or cliches.
+
+Never use cultural references or charged language.
+
+## Tense
+
+Write in present simple tense.
+
+Avoid present continous tense.
+
+Only write in future tense to show future actions.
+
+## Voice
+
+Always write in an active voice.
+
+Never write in a passive voice.
+
+## Perspective
+
+Address users as "you".
+
+Don't use first person perspective.
+
+## Wordlist
+
+Use allowlist/blocklist instead of whitelist/blacklist.
+
+Use primary/secondary instead of master/slave.
+
+Use "refer to" instead of "see", "consult", "check out", and other phrases.
+
+## Formatting
+
+Use sentence case for titles and headings, for example:
+
+- This is sentence case (correct)
+- This is Title Case (wrong)
+
+Use the exact page or section title for link text.
+
+Use inline Markdown links, for example, [Link text](https://example.com).
+
+When linking to other sections within the same document,
+use a descriptive phrase that includes the section name,
+and a relative link to its heading anchor.
+For example, "For further details on setup, refer to the [Installation](#installation) section."
+
+Never remove links from copy unless specifically asked to.
+If you edit content that includes a link,
+always include the link in the edited version, for example:
+
+- It is [here](https://grafana.com) go check it out for details (before)
+- Refer to the [Grafana homepage](https://grafana.com) for details (after)
+
+Use two asterisks to bold text, for example `**bold**`.
+
+Use one underscore to emphasize copy, for example `_italics_`.
+
+For UI elements and product features that aren't product names,
+use sentence case as they appear in the UI, for example:
+
+- Click **Submit**. (If "Submit" is the exact text on the button)
+- Navigate to the **User settings** page. (If "User settings" is the title/label)
+- Configure the **alerting rules**. (General concept)
+- Open **Explore** in Grafana. (If "Explore" is the branded name of that section)
+
+Avoid using words created for UI features when possible, for example
+
+- In your Grafana Cloud stack, click **Connections**. (correct)
+- In your Grafana Cloud stack, click the **Connections** button. (wrong)
+
+## Lists
+
+Write complete sentences for lists, for example:
+
+- Works with all languages and frameworks (correct)
+- all languages and frameworks (wrong)
+
+Always use dashes for unordered lists, for example
+
+```markdown
+- List item 1
+- List item 2
+- List item 3
+```
+
+Never use asterisks for unordered lists, for example:
+
+```markdown
+* List item 1 (wrong)
+* List item 2 (wrong)
+* List item 3 (wrong)
+```
+
+Never use full stops at the end of unordered list items, for example:
+
+```markdown
+- Works with all languages and frameworks (correct)
+- Works with all languages and frameworks (wrong)
+```
+
+Always start every ordered list item with 1, for example:
+
+```markdown
+1. Ordered list item 1.
+1. Ordered list item 2.
+1. Ordered list item 3.
+```
+
+Never increment the numbers for ordered list items, for example:
+
+```markdown
+1. Ordered list item 1. (wrong)
+2. Ordered list item 2. (wrong)
+3. Ordered list item 3. (wrong)
+```
+
+Always start the next list item immediately on the next line, for example:
+
+```markdown
+- List item 1
+- List item 2
+- List item 3
+```
+
+Never use new lines between list items, for example:
+
+```markdown
+- List item 1
+
+- List item 2 (wrong)
+
+- List item 3 (wrong)
+```
+
+If a list starts with a keyword, bold the keyword and follow with a colon,
+for example:
+
+```markdown
+- **Keyword 1**: list item 1
+- **Keyword 2**: list item 2
+- **Keyword 3**: list item 3
+```
+
+## Images
+
+Always include descriptive alt text for images.
+The alt text should convey the essential information or purpose of the image.
+Avoid redundant phrases like "Image of..." or "Picture of...".
+
+For example:
+
+- Instead of `![Diagram of system](diagram.png)`
+- Use `![Architecture diagram showing data flow from client applications, through a load balancer, to backend services.](architecture-data-flow.png)`
+
+## Code
+
+Use single code backticks for:
+
+- user input
+- placeholders in markdown, for example _`<PLACEHOLDER_NAME>`_
+- files and directories, for example `/opt/file.md`
+- source code keywords and identifiers,
+  for example variables, function and class names
+- configuration options and values, for example `PORT` and `80`
+- status codes, for example `404`
+
+Use triple code backticks followed by the syntax for code blocks, for example:
+
+```javascript
+console.log("Hello World!");
+```
+
+Always introduce each code blocks with a short description.
+End the introduction with a colon if the code sample follows it, for example:
+
+```markdown
+The code sample outputs "Hello World!" to the browser console:
+
+<CODE_BLOCK>
+```
+
+Use descriptive placeholder names in code samples.
+Use uppercase letters with underscores to separate words in placeholders,
+for example:
+
+```sh
+OTEL_RESOURCE_ATTRIBUTES="service.name=<SERVICE_NAME>
+OTEL_EXPORTER_OTLP_ENDPOINT=<OTLP_ENDPOINT>
+```
+
+The placeholder includes the name and the less than and greater than symbols,
+for example <PLACEHOLDER_NAME>.
+
+If the placeholder is markdown emphasize it with underscores,
+for example _`<PLACEHOLDER_NAME>`_.
+
+In code blocks use the placeholder without additional backticks or emphasis,
+for example <PLACEHOLDER_NAME>.
+
+Always provide an explanation for each placeholder,
+typically in the text following the code block or in a configuration table.
+
+Never add new code block unless specifically asked to, for example,
+when asked to improve an article don't add new code.
+
+Never change existing code blocks unless specifically asked to, for example
+when asked to improve an article don't edit code.
+
+Always follow code samples with an explanation
+and configuration options for placeholders, for example:
+
+```markdown
+<CODE_BLOCK>
+
+This code sets required environment variables
+to send OTLP data to an OTLP endpoint.
+To configure the code for your needs,
+refer to the configuration table
+and select the appropriate configuration options for your use case.
+
+<CONFIGURATION_TABLE>
+```
+
+Never put configuration for a code block before the code block.
+
+## APIs
+
+When documenting API endpoints specify the HTTP method,
+for example `GET`, `POST`, `PUT`, `DELETE`.
+
+Provide the full request path, using backticks.
+
+Use backticks for parameter names and example values.
+
+Use placeholders like `{userId}` for path parameters, for example:
+
+- To retrieve user details, make a `GET` request to `/api/v1/users/{userId}`.
+
+Use a configuration table to describe query and header parameters,
+and request body fields.
+
+## CLI commands
+
+When presenting CLI commands and their output,
+introduce the command with a brief explanation of its purpose.
+Clearly distinguish the command from its output.
+
+For commands, use `sh` to specify the code block language.
+
+For output, use a generic specifier like `text`, `console`,
+or `json`/`yaml` if the output is structured.
+
+For example:
+
+````markdown
+To list all running pods in the `default` namespace, use the following command:
+
+```sh
+kubectl get pods --namespace default
+```
+````
+
+The output will resemble the following:
+
+```text
+NAME                               READY   STATUS    RESTARTS   AGE
+my-app-deployment-7fdb6c5f65-abcde   1/1     Running   0          2d1h
+another-service-pod-xyz123           2/2     Running   0          5h30m
+```
+
+## Configuration table
+
+Use Markdown tables to document configuration, including:
+
+- placeholders
+- parameters
+- YAML/JSON configuration
+- environment variables
+
+Add columns for "Option", "Summary", "Required", "Type", "Values", "Default"
+in that order.
+
+Use the following values for option:
+
+- YAML/JSON, code, or parameter field if one exists for that configuration
+- Environment variable field if one exists for that configuration
+- If there is a YAML and Environment variable option separate them with `<br>`
+
+Use a short sentence for the summary.
+After the summary sentence and in the same cell,
+link to further details using the following format,
+"Refer to [option](#option-anchor) for details."
+
+In the values column, describe acceptable values
+and include value options or ranges if they exist.
+Don't include example values in the table.
+
+An example configuration table:
+
+```markdown
+| Option                         | Summary                                                                                              | Required | Type   | Values                               | Default |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------- | -------- | ------ | ------------------------------------ | ------- |
+| `SERVICE_NAME`                 | The logical name of your application or service. Refer to [service name](#service-name) for details. | Yes      | String | A descriptive name for your service. | N/A     |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`  | The target URL for the OTLP exporter. Refer to [OTLP endpoint](#otlp-endpoint) for details.          | Yes      | String | A valid URL.                         | N/A     |
+| `logging.level`<br>`LOG_LEVEL` | Sets the logging verbosity. Refer to [logging level](#logging-level) for details.                    | No       | String | `debug`, `info`, `warn`, `error`     | `info`  |
+```
+
+In some ocassions, you can drop the Values column, for example,
+when all the configuration have a Boolean type (yes/no) or (1/0).
+
+After the table, for each configuration, add a sub-section.
+
+For each sub-section include a heading and more detailed information including:
+
+- a full description
+- an explanation of concepts
+- any related configuration
+- example values with explanations, don't use code blocks only single backticks
+  for example values
+
+Use sentence case for the heading and only capitalize known keywords.
+
+Example configuration sub-sections:
+
+```markdown
+<CONFIGURATION_TABLE>
+
+### Service name
+
+The `SERVICE_NAME` option specifies the name of your application or service.
+This name identifies your service in Grafana Cloud.
+It helps filter and query telemetry data.
+A name that describes the service helps organize your observability data.
+
+For example, if your microservice handles payments, a service name could be `payment-service`.
+If your application is a frontend, you might use `webapp-frontend`.
+
+### OTLP endpoint
+
+The `OTEL_EXPORTER_OTLP_ENDPOINT` option defines the target URL.
+The OpenTelemetry (OTLP) exporter sends your telemetry data to this URL.
+This endpoint is the ingestion point for your metrics, logs, traces, and profiles.
+For Grafana Cloud, this is your Grafana Cloud OTLP endpoint.
+
+An example OTLP endpoint URL is `https://otlp-gateway-prod-us-central-0.grafana.net/otlp`.
+Your endpoint URL depends on your Grafana Cloud stack and region.
+You find this URL in your Grafana Cloud account details.
+
+### Logging level
+
+The `logging.level` and `LOG_LEVEL` options control the verbosity of logging output.
+Use these options to adjust the level of detail in logs for debugging or monitoring purposes.
+
+The available levels are `debug`, `info`, `warn`, and `error`.
+For example, setting the level to `debug` provides detailed logs useful for troubleshooting,
+while `error` limits logs to critical issues.
+
+The default logging level is `info`, which provides a balance between verbosity and relevance.
+```
+
+## Comparison table
+
+Use a comparison table when users have multiple options to achieve similar
+outcomes and need to understand the trade-offs or key differences between them.
+
+Comparison tables help users make informed decisions by highlighting distinct features,
+requirements, or characteristics of each option side-by-side.
+
+Structure the table with options as rows and differentiating criteria as columns.
+Ensure each cell provides concise, directly comparable information.
+
+An example comparison table:
+
+```markdown
+| Method                      | Code changes             | Language support   | Use case                                                      |
+| --------------------------- | ------------------------ | ------------------ | ------------------------------------------------------------- |
+| Grafana OpenTelemetry Java  | Not required (JVM agent) | Java               | Offers advanced instrumentation features and Grafana support. |
+| Grafana OpenTelemetry .NET  | Required                 | .NET               | Offers advanced instrumentation features and Grafana support. |
+| Upstream OpenTelemetry SDKs | Required                 | Multiple languages | Provides standard instrumentation with community support.     |
+```
+
+## Shortcodes
+
+Don't use blockquotes for notes, cautions, or warnings.
+
+Use the custom admonition Hugo shortcode
+with <TYPE> as "note", "caution", or "warning":
+
+```markdown
+{{< admonition type="<TYPE>" >}}
+...
+{{< /admonition >}}
+```
+
+Use admonitions sparingly.
+Only include exceptional information in admonitions,
+this means you will use it more often for warnings than notes and cautions.
+
+Never delete Hugo shortcodes unless specifically asked to,
+for example don't delete shortcodes:
+
+```markdown
+{{< docs/shared source="tempo" lookup="grafana-cloud.md" version="" >}}
+```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Tempo implements [TraceQL](https://grafana.com/docs/tempo/latest/traceql/), a tr
 
 [TraceQL metrics](https://grafana.com/docs/tempo/latest/traceql/metrics-queries/) is an experimental feature in Grafana Tempo that creates metrics from traces. Metric queries extend trace queries by applying a function to trace query results. This powerful feature allows for ad hoc aggregation of any existing TraceQL query by any dimension available in your traces, much in the same way that LogQL metric queries create metrics from logs.
 
-Tempo is Jaeger, Zipkin, Kafka, OpenCensus, and OpenTelemetry compatible. It ingests batches in any of the mentioned formats, buffers them, and then writes them to Azure, GCS, S3, or local disk. As such, it is robust, cheap, and easy to operate!
+Tempo is Jaeger, Zipkin, Kafka, OpenCensus, and OpenTelemetry compatible. It ingests batches in any of the mentioned formats, buffers them, and then writes them to Azure, GCS, S3, or local disk. As such, it's robust, cheap, and easy to operate.
 
 ## Getting started with Tempo
 

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -95,7 +95,7 @@ server:
     [http_listen_address: <string>]
 
     # HTTP server listen port
-    [http_listen_port: <int> | default = 80]
+    [http_listen_port: <int> | default = 3200]
 
     # gRPC server listen host
     [grpc_listen_address: <string>]
@@ -712,7 +712,7 @@ query_frontend:
         [throughput_bytes_slo: <float> | default = 0 ]
 
         # The number of time windows to break a search up into when doing a most recent TraceQL search. This only impacts TraceQL
-        # searches with (most_recent=true)
+        # searches with (most_recent=true).
         [most_recent_shards: <int> | default = 200]
 
         # The number of shards to break ingester queries into.

--- a/docs/sources/tempo/configuration/grafana-alloy/span-metrics.md
+++ b/docs/sources/tempo/configuration/grafana-alloy/span-metrics.md
@@ -68,7 +68,7 @@ otelcol.connector.spanmetrics "default" {
 
   metrics_flush_interval = "15s"
 
-  namespace = "traces_spanmetrics"
+  namespace = "traces.spanmetrics"
 
   output {
     metrics = [otelcol.exporter.otlp.default.input]

--- a/docs/sources/tempo/operations/manage-advanced-systems/multitenancy.md
+++ b/docs/sources/tempo/operations/manage-advanced-systems/multitenancy.md
@@ -10,15 +10,38 @@ aliases:
 
 # Enable multi-tenancy
 
-Tempo is a multi-tenant distributed tracing backend. It supports multi-tenancy through the use
-of a header: `X-Scope-OrgID`.
+Tempo is a multi-tenant distributed tracing backend.
+Tempo uses the `X-Scope-OrgID` header to enforce multi-tenancy in Tempo and Grafana Enterprise Traces.
+It is set to the tenant (or “organization”) name.
+It is used for scoped writes (ingest) so that each span is stored under its specified tenant, and scoped reads so that queries return only that tenant’s data.
 
 If you're interested in setting up multi-tenancy, consult the [multi-tenant example](https://github.com/grafana/tempo/tree/main/example/docker-compose/otel-collector-multitenant)
 in the repository. This example uses the following settings to achieve multi-tenancy in Tempo.
 
-{{< admonition type="note" >}}
-Multi-tenancy on ingestion is currently [only working](https://github.com/grafana/tempo/issues/495) with GPRC and this may never change. It's strongly recommended to use the OpenTelemetry Collector to support multi-tenancy.
-{{< /admonition >}}
+Multi-tenancy on ingestion is supported with GPRC and HTTP for OTLP.
+You can add headers both in the OpenTelemetry Collector and Grafana Alloy or using `curl` or any other relevant HTTP/gRPC protocol tool.
+Here is an example configuration for Alloy.
+
+```
+otelcol.exporter.otlphttp "tempo" {
+    // Define the client for exporting.
+    client {
+        // Send the X-Scope-OrgID header to the Tempo instance for multi-tenancy (tenant 1234).
+        headers = {
+            "X-Scope-OrgID" = "1234",
+        }
+        // Send to the locally running Tempo instance, on port 4317 (OTLP gRPC).
+        endpoint = "http://tempo:4318"
+        // Configure TLS settings for communicating with the endpoint.
+        tls {
+            // The connection is insecure.
+            insecure = true
+            // Do not verify TLS certificates when connecting.
+            insecure_skip_verify = true
+        }
+    }
+}
+```
 
 ## Configure multi-tenancy
 

--- a/docs/sources/tempo/release-notes/v2-6.md
+++ b/docs/sources/tempo/release-notes/v2-6.md
@@ -88,17 +88,17 @@ To learn more, refer to the [Native histogram](https://grafana.com/docs/tempo/<T
 
 ### Performance improvements
 
-One of our major improvements in Tempo 2.6 is the reduction of memory usage due to polling improvements. [PRs [3950](https://github.com/grafana/tempo/pull/3950), [3951](https://github.com/grafana/tempo/pull/3951), [3952](https://github.com/grafana/tempo/pull/3952])
+One of our major improvements in Tempo 2.6 is the reduction of memory usage due to polling improvements. [PRs [3950](https://github.com/grafana/tempo/pull/3950), [3951](https://github.com/grafana/tempo/pull/3951), [3952](https://github.com/grafana/tempo/pull/3952])]
 
 ![Comparison graph showing the reduction of memory usage due to the polling improvements](/media/docs/tempo/tempo-2-6-poll-improvement.png)
 
 This improvement is a result of some of these changes:
 
-* Add data quality metric to measure traces without a root [[PR 3812](https://github.com/grafana/tempo/pull/3812)]
-* Reduce memory consumption of query-frontend [[PR 3888](https://github.com/grafana/tempo/pull/3888)]
-* Reduce allocs of caching middleware [[PR 3976](https://github.com/grafana/tempo/pull/3976)]
-* Reduce allocs building queriers sharded requests [[PR 3932](https://github.com/grafana/tempo/pull/3932)]
-* Improve trace id lookup from Tempo Vulture by selecting a date range [[PR 3874](https://github.com/grafana/tempo/pull/3874)]
+* Add data quality metric to measure traces without a root. [[PR 3812](https://github.com/grafana/tempo/pull/3812)]
+* Reduce memory consumption of query-frontend. [[PR 3888](https://github.com/grafana/tempo/pull/3888)]
+* Reduce allocations of caching middleware. [[PR 3976](https://github.com/grafana/tempo/pull/3976)]
+* Reduce allocations building queriers sharded requests. [[PR 3932](https://github.com/grafana/tempo/pull/3932)]
+* Improve trace id lookup from Tempo Vulture by selecting a date range. [[PR 3874](https://github.com/grafana/tempo/pull/3874)]
 
 ### Other enhancements and improvements
 
@@ -120,7 +120,7 @@ This release also has these notable updates.
 * Implement polling tenants concurrently. [[PR 3647](https://github.com/grafana/tempo/pull/3647)]
 * Add [native histograms](https://grafana.com/docs/tempo/<TEMPO_VERSION>/metrics-generator/#native-histograms) for internal metrics [[PR 3870](https://github.com/grafana/tempo/pull/3870)]
 * Add a Tempo CLI command to drop traces by id by rewriting blocks. [[PR 3856](https://github.com/grafana/tempo/pull/3856), [documentation](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/tempo_cli/#drop-trace-by-id)]
-* Add new OTel compatible Traces API V2.  [[PR 3912](https://github.com/grafana/tempo/pull/3912), [documentation](https://grafana.com/docs/tempo/next/api_docs/#query-v2)]
+* Add new OTel compatible Traces API V2. [[PR 3912](https://github.com/grafana/tempo/pull/3912), [documentation](https://grafana.com/docs/tempo/next/api_docs/#query-v2)]
 * Rename `Batches` to `ResourceSpans`. [[PR 3895](https://github.com/grafana/tempo/pull/3895)]
 
 ## Upgrade considerations

--- a/docs/sources/tempo/release-notes/v2-8.md
+++ b/docs/sources/tempo/release-notes/v2-8.md
@@ -1,0 +1,266 @@
+---
+title: Version 2.8 release notes
+menuTitle: V2.8
+description: Release notes for Grafana Tempo 2.8
+weight: 20
+---
+
+# Version 2.8 release notes
+
+<!-- vale Grafana.We = NO -->
+<!-- vale Grafana.GoogleWill = NO -->
+<!-- vale Grafana.Timeless = NO -->
+<!-- vale Grafana.Parentheses = NO -->
+
+The Tempo team is pleased to announce the release of Tempo 2.8.
+
+This release gives you:
+
+* New TraceQL features such as `most_recent`, parent-span filters, `sum_over_time`, and `topk`/`bottomk` to help surface the exact spans and metrics you need.
+* Concurrent block flushing, iterator optimizations, and back-pressure make ingestion and queries leaner and quicker.
+* Safer defaults with port 3200, distroless images, Go 1.24, and an upgraded OTLP Collector tighten security and simplify ops.
+
+These release notes highlight the most important features and bugfixes.
+For a complete list, refer to the [Tempo changelog](https://github.com/grafana/tempo/releases).
+
+{{< admonition type="note" >}}
+Tempo 2.8 has some major upgrade considerations including changing the default `http-listen-port` from 80 to 3200, removing serverless, and enforcing max attribute size at event, link, and instrumentation scopes.
+
+Refer to [Upgrade considerations](#upgrade-considerations) for details.
+{{< /admonition>}}
+
+
+<!-- Add link to the new blog post when ready
+Read the [Tempo 2.8 blog post](https://grafana.com/blog/2025/01/16/grafana-tempo-2.7-release-new-traceql-metrics-functions-operational-improvements-and-more/) for more examples and details about these improvements.
+
+{{< youtube id="0jUEvY-pCdw" >}}
+
+-->
+
+## New language features for TraceQL
+
+We’re excited to roll out three powerful enhancements to TraceQL, giving you more flexibility and performance when querying traces in Grafana Cloud with Tempo.
+
+* Rank your metrics with new `topk(n)` and `bottomk(n)` functions to quickly get your highest and lowest ranking time series.
+* Aggregate spans over time using `sum_over_time()` for built-in cumulative sums, such as total bytes, error counts.
+* Fetch the latest traces first via the experimental `most_recent=true` query hint.
+
+### Ranking `topk` and `bottomk` functions for TraceQL metrics
+
+When you’re looking at latency, error rates, or throughput across hundreds or thousands of services or endpoints, it’s easy to get lost in all the data.
+Previously, you’d have to pull back the full set of aggregates and then manually inspect or post‑process the results to find your worst offenders or best performers.
+
+With `topk(n)` and `bottomk(n)`, you can immediately narrow your focus to the top‑ or bottom‑ranked spans in a single, efficient query. This saves time and reduces the data volume you need to scan downstream.
+
+```
+{} | avg_over_time(span:duration) by (span:name) | topk(10)
+{} | count_over_time() by (span:name) | bottomk(10)
+```
+
+These are second stage functions used, where:
+
+* `topk(n)` returns the *n* series with the highest values from a first‑stage aggregation.
+* `bottomk(n)` returns the *n* series with the lowest values.
+
+For more information, refer to the [topk and bottomk documentation](https://grafana.com/docs/tempo/next/traceql/metrics-queries/functions/#topk-and-bottomk-functions) ([PR 4646](https://github.com/grafana/tempo/pull/4646/)).
+
+### The `sum_over_time` function for TraceQL metrics
+
+The `sum_over_time()` function lets you aggregate numerical values by computing the sum value of them. The time interval that the sum is computed over is set by the `step` parameter.
+
+```
+{ span.http.response_content_length > 0 } | sum_over_time(span.http.response_content_length)
+```
+
+With `sum_over_time()`, you can directly compute cumulative sums inside TraceQL, like total bytes transferred, total error counts, or resource consumption over time.
+
+```
+{}  | sum_over_time(span.http.response_content_length)
+```
+
+For each step interval, `sum_over_time(attr)` totals the values of `attr` across all matching spans.
+
+Refer to [TraceQL metrics functions](https://grafana.com/docs/tempo/next/traceql/metrics-queries/functions/#the-sum_over_time-min_over_time-max_over_time-and-avg_over_time--functions) for more information. ([PR 4786](https://github.com/grafana/tempo/pull/4786))
+
+### Experimental query hint `most_recent=true` to retrieve the most recent traces
+
+When troubleshooting a live incident or monitoring production health, you often need to see the absolute latest traces first. By default, Tempo’s query engine favors speed and returns the first `N` matching traces, which may not be the newest.
+
+The `most_recent` hint ensures you’re always looking at the freshest data, so you can diagnose recent errors or performance regressions without missing anything due to early row‑limit cuts.
+
+Examples:
+
+```
+{} with (most_recent=true)
+{ span.foo = "bar" } >> { status = error } with (most_recent=true)
+```
+
+With `most_recent=true`, Tempo performs a deeper search across data shards, retains the newest candidates, and returns traces sorted by start time rather than stopping at the first limit hit.
+([PR 4238]([https://github.com/grafana/tempo/pull/4238](https://github.com/grafana/tempo/pull/4238)))
+
+The TraceQL query hint `most_recent=true` can be used with any TraceQL selection query to force Tempo to return the most recent results ordered by time.
+
+For more information, refer to [Retrieve most recent results (experimental)](https://grafana.com/docs/tempo/latest/traceql/#retrieving-most-recent-results-experimental).
+
+### Query by parent span ID
+
+In addition, you can query by parent `span id`.
+Using `span:parentID`, you can ensure that you are looking at a child span of a specific parent, which is useful for example in span linking.
+Refer to the [documentation](https://grafana.com/docs/tempo/next/traceql/#intrinsic-fields) for more information.
+([PR 4692]([https://github.com/grafana/tempo/pull/4692](https://github.com/grafana/tempo/pull/4692)))
+
+## Major performance and memory usage improvements
+
+Tempo 2.8 removes pooling for large traces.
+In testing, removing large pooling impacted memory, cutting memory high-water marks to less than half in a high traffic/tenant installation.
+Some amount of pooling is needed to keep CPU, throughput, and GC rate maintained.
+Now, we have a fixed 1M default allocation size, which covers most traces.
+
+This graph illustrate the amount of memory used by the compactors.
+In one cell, we saw major improvements in compactor memory usage after PR [4985](https://github.com/grafana/tempo/pull/4985) was merged.
+Refer to PR [4985](https://github.com/grafana/tempo/pull/4985) for more information, including benchmarks and test results.
+
+{{< figure src="/media/docs/tempo/tempo-2.8-pr-4985-compactor-memory-graph.png" width="100%" >}}
+
+### Performance improvements
+
+TraceQL and Tempo generally see a number of performance improvements in this release. Refer to benchmarks in the PRs for additional information.
+
+* Improve TraceQL performance by reverting EqualRowNumber to an inlineable function. ([PR 4705](https://github.com/grafana/tempo/pull/4705))
+* Improve iterator performance by using max definition level to ignore parts of the RowNumber while nexting. Nexting is a function multiple in Tempo when you do a big query. Even minor improvements in nexting can have a major impact. ([PR 4753](https://github.com/grafana/tempo/pull/4753))
+* Increase query-frontend default batch size. TraceQL performance has improved enough to pass larger batches than before and still complete all jobs on one querier. ([PR 4844](https://github.com/grafana/tempo/pull/4844))
+* Improve Tempo build options. ([PR 4755](https://github.com/grafana/tempo/pull/4755))
+* Rewrite traces using rebatching. ([PR 4690](https://github.com/grafana/tempo/pull/4690))
+* Reorder span iterators. ([PR 4754](https://github.com/grafana/tempo/pull/4754))
+* Improve memcached memory usage by pooling buffers. ([PR 4970](https://github.com/grafana/tempo/pull/4970))
+
+## Features and enhancements
+
+This section highlights the most important features and enhancements in Tempo 2.8.
+
+### TraceQL correctness
+
+One of our major focuses with this release has been to improve TraceQL’s performance and correctness. The following list summarizes some of the more important improvements.
+
+* Fixed behavior for queries like `{.foo && true}` and `{.foo || false}`. ([PR 4855](https://github.com/grafana/tempo/pull/4855))
+* Make comparison to nil symmetric. ([PR 4869](https://github.com/grafana/tempo/pull/4869))
+* Corrected TraceQL incorrect results for additional spanset filters after a select operation. ([PR 4600](https://github.com/grafana/tempo/pull/4600))
+* Fixed TraceQL metrics incorrect results for queries with multiple filters that reside in non-dedicated columns that also group by the same variable. ([PR 4887](https://github.com/grafana/tempo/pull/4887))
+* Fixed metrics streaming for all non-trivial metrics. ([PR 4624](https://github.com/grafana/tempo/pull/4624))
+* Fixed behavior of `{} >> { span.attr-that-doesnt-exist != "foo" }`. ([PR 5007](https://github.com/grafana/tempo/pull/5007))
+* Fixed various edge cases for query range. ([PR 4962](https://github.com/grafana/tempo/pull/4962))
+* Excluded `nestedSetParent` and other values from the `compare()` function. ([PR 5196](https://github.com/grafana/tempo/pull/5196))
+
+The query frontend can cache job results for individual blocks when executing TraceQL. These bug fixes impact caching behavior.
+
+* TraceQL results caching bug for floats ending in `.0`. ([PR 4539](https://github.com/grafana/tempo/pull/4539))
+* Correctly cache frontend jobs for query range in TraceQL metrics. ([PR 4771](https://github.com/grafana/tempo/pull/4771))
+* Fixed frontend cache key generation for TraceQL metrics queries to prevent collisions. ([PR 5017](https://github.com/grafana/tempo/pull/5017))
+
+### TraceQL exemplar improvements and bugfixes
+
+Tempo 2.8 improves exemplars in TraceQL metrics.
+
+* Distribute exemplars over time and hard limit the number of exemplars. ([PR 5158](https://github.com/grafana/tempo/pull/5158))
+* Right exemplars for histogram and quantiles. ([PR 5145](https://github.com/grafana/tempo/pull/5145))
+* Fixed for queried number of exemplars. ([PR 5115](https://github.com/grafana/tempo/pull/5115))
+
+### Security improvements
+
+The following updates were made to address security issues:
+
+* Use distroless base container images for improved security. ([PR 4556](https://github.com/grafana/tempo/pull/4556))
+* Updated to go 1.24.3. ([PR 5110](https://github.com/grafana/tempo/pull/5110))
+
+
+### Improved error handling and logging
+
+In addition, we’ve updated how Tempo handles errors so it’s easier to troubleshoot.
+
+* Updated query range error message. ([PR 4929](https://github.com/grafana/tempo/pull/4929))
+* Improved rate limit error message when traces size exceeds rate limit. ([PR 4986](https://github.com/grafana/tempo/pull/4986/))
+* Restored dedicated columns logging for completed blocks in the compactor. ([PR 4832](https://github.com/grafana/tempo/pull/4832))
+* Query-frontend logs add a message to the log line. ([PR 4975](https://github.com/grafana/tempo/pull/4975))
+
+### Other enhancements and improvements
+
+This release also has these notable updates.
+
+* Added throughput SLO and metrics for the `TraceByID` endpoint. Configurable via the `throughput_bytes_slo` field, and it will populate `op="traces"` label in SLO and throughput metrics. ([PR 4668](https://github.com/grafana/tempo/pull/4668))
+* Prevented queries in the ingester from blocking flushing traces to disk and memory spikes. ([PR 4483](https://github.com/grafana/tempo/pull/4483))
+* Host Info Processor now tracks host identifying resource attribute in metric ([PR 5152](https://github.com/grafana/tempo/pull/5152))
+* Added IPv6 support to the distributor. ([PR 4840](https://github.com/grafana/tempo/pull/4840))
+* Added default mutex and blocking values. ([PR 4979](https://github.com/grafana/tempo/pull/4979))
+
+## Upgrade considerations
+
+When [upgrading](https://grafana.com/docs/tempo/latest/setup/upgrade/) to Tempo 2.7, be aware of these considerations and breaking changes.
+
+### Changed the default listening port
+
+With Tempo 2.8, the default `http_listen_port` changes from 80 to 3200. Check the configuration options for the `server:` block in your Tempo configuration file.
+
+```yaml
+server:
+    # HTTP server listen host
+    [http_listen_address: &lt;string>]
+
+    # HTTP server listen port
+    [http_listen_port: &lt;int> | default = 3200]
+```
+
+Refer to [issue 4945](https://github.com/grafana/tempo/discussions/4945) for more information for the rationale.
+[PR 4960](https://github.com/grafana/tempo/pull/4960)
+
+### Removed Tempo serverless
+
+Tempo serverless has been removed. The following configuration options are no longer  valid and should be removed from your Tempo configuration. [PR [4599](https://github.com/grafana/tempo/pull/4599/))
+
+```yaml
+querier:
+    search:
+        prefer_self: <int>
+        external_hedge_requests_at: <duration>
+        external_hedge_requests_up_to:  <duration>
+        external_backend: <string>
+        google_cloud_run: <string>
+        external_endpoints: <array>
+```
+
+In addition, these Tempo serverless related metrics have been removed: `tempo_querier_external_endpoint_duration_seconds`, `tempo_querier_external_endpoint_hedged_roundtrips_total`, and `tempo_feature_enabled`.
+
+### Updated, removed, or renamed configuration parameters
+
+| Parameter | Comments |
+|---|---|
+| `max_span_attr_byte` | Renamed to `max_attribute_bytes`. ([PR 4633](https://github.com/grafana/tempo/pull/4633)) |
+| `tempo_discarded_spans_total` | Removed `internal_error` as a reason from `tempo_discarded_spans_total`. ([PR 4554](https://github.com/grafana/tempo/pull/4554)) |
+| `tempo_receiver_accepted_span` and `tempo_receiver_refused_spans` | The `name` dimension from `tempo_receiver_accepted_span` and `tempo_receiver_refused_spans` changes from `tempo/jaeger_receiver` to `jaeger/jaeger_receiver`. ([PR 4893](https://github.com/grafana/tempo/pull/4893))  |
+
+### Other upgrade considerations
+
+* Upgrade OTEL Collector to v0.122.1. The `name` dimension from `tempo_receiver_accepted_span` and `tempo_receiver_refused_spans` changes from `tempo/jaeger_receiver` to `jaeger/jaeger_receiver`. ([PR 4893](https://github.com/grafana/tempo/pull/4893))
+* Replace `opentracing-contrib/go-grpc` by `otelgrpc` in Tempo query. ([PR 4958](https://github.com/grafana/tempo/pull/4958))
+* Enforce max attribute size at event, link, and instrumentation scope. The configuration is now per-tenant. Renamed `max_span_attr_byte` to `max_attribute_bytes`. ([PR 4633](https://github.com/grafana/tempo/pull/4633))
+* Converted SLO metric `query_frontend_bytes_processed_per_second` from a histogram to a counter as it's more performant. ([PR 4748](https://github.com/grafana/tempo/pull/4748))
+* Removed the OpenTelemetry Jaeger exporter, which has been [deprecated](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/jaeger). ([PR 4926](https://github.com/grafana/tempo/pull/4926))
+
+## Bugfixes
+
+For a complete list, refer to the [Tempo CHANGELOG](https://github.com/grafana/tempo/releases).
+
+* Chose a default step for a gRPC streaming query range request if none is provided. Correctly copy exemplars for metrics like `| rate()` when gRPC streaming. ([PR 4546](https://github.com/grafana/tempo/pull/4576))
+* Fixed distributor issue where a hash collision could lead to spans stored incorrectly ([PR 5186](https://github.com/grafana/tempo/pull/5186))
+* Added object name to cache key in ReadRange ([PR 4982](https://github.com/grafana/tempo/pull/4982))
+* Fixed rare panic during compaction ([PR 4915](https://github.com/grafana/tempo/pull/4915))
+* Returned the operand as the only value if the tag is already filtered in the query ([PR 4673](https://github.com/grafana/tempo/pull/4673))
+* Included cost attribution when converting from default configuration to legacy one. ([PR 4787](https://github.com/grafana/tempo/pull/4937))
+* Updated `memcached` to respect cancelled context to prevent panic. ([PR 5041](https://github.com/grafana/tempo/pull/5041))
+* Fixed setting processors in user configurations overrides via API. ([PR 4741](https://github.com/grafana/tempo/pull/4741))
+* Fixed panic on startup. ([PR 4744](https://github.com/grafana/tempo/pull/4744))
+* Fixed intrinsic tag lookups dropped when max tag lookup response size is exceeded. ([PR 4784](https://github.com/grafana/tempo/pull/4784))
+* Fixed error propagation in the SyncIterator. ([PR 5045](https://github.com/grafana/tempo/pull/5045))
+* Fixed mixin to include `otlp_v1_traces` HTTP write route ([PR 5072](https://github.com/grafana/tempo/pull/5072))
+* Fixed `TempoBlockListRisingQuickly` alert grouping. ([PR 4876](https://github.com/grafana/tempo/pull/4876))
+* Fixed metrics generator host info processor overrides configuration. ([PR 5118](https://github.com/grafana/tempo/pull/5118))
+* Fixed metrics generator `target_info` to skip attributes with no name to prevent downstream errors. ([PR 5148](https://github.com/grafana/tempo/pull/5148))

--- a/docs/sources/tempo/release-notes/v2-8.md
+++ b/docs/sources/tempo/release-notes/v2-8.md
@@ -194,7 +194,7 @@ This release also has these notable updates.
 
 ## Upgrade considerations
 
-When [upgrading](https://grafana.com/docs/tempo/latest/setup/upgrade/) to Tempo 2.7, be aware of these considerations and breaking changes.
+When [upgrading](https://grafana.com/docs/tempo/latest/setup/upgrade/) to Tempo 2.8, be aware of these considerations and breaking changes.
 
 ### Changed the default listening port
 
@@ -203,10 +203,10 @@ With Tempo 2.8, the default `http_listen_port` changes from 80 to 3200. Check th
 ```yaml
 server:
     # HTTP server listen host
-    [http_listen_address: &lt;string>]
+    [http_listen_address: <string>]
 
     # HTTP server listen port
-    [http_listen_port: &lt;int> | default = 3200]
+    [http_listen_port: <int> | default = 3200]
 ```
 
 Refer to [issue 4945](https://github.com/grafana/tempo/discussions/4945) for more information for the rationale.

--- a/docs/sources/tempo/setup/upgrade.md
+++ b/docs/sources/tempo/setup/upgrade.md
@@ -25,9 +25,63 @@ For detailed information about any release, refer to the [Release notes](../rele
 You can check your configuration options using the [`status` API endpoint](../../api_docs/#status) in your Tempo installation.
 {{< /admonition >}}
 
+## Upgrade to Tempo 2.8
+
+When upgrading to Tempo 2.8, be aware of these considerations and breaking changes.
+
+### Changed the default listening port
+
+With Tempo 2.8, the default `http_listen_port` changes from 80 to 3200. Check the configuration options for the `server:` block in your Tempo configuration file.
+
+```yaml
+server:
+    # HTTP server listen host
+    [http_listen_address: &lt;string>]
+
+    # HTTP server listen port
+    [http_listen_port: &lt;int> | default = 3200]
+```
+
+Refer to [issue 4945](https://github.com/grafana/tempo/discussions/4945) for more information for the rationale.
+[PR 4960](https://github.com/grafana/tempo/pull/4960)
+
+### Removed Tempo serverless
+
+Tempo serverless has been removed. The following configuration options are no longer  valid and should be removed from your Tempo configuration. [PR [4599](https://github.com/grafana/tempo/pull/4599/))
+
+```yaml
+querier:
+    search:
+        prefer_self: <int>
+        external_hedge_requests_at: <duration>
+        external_hedge_requests_up_to:  <duration>
+        external_backend: <string>
+        google_cloud_run: <string>
+        external_endpoints: <array>
+```
+
+In addition, these Tempo serverless related metrics have been removed: `tempo_querier_external_endpoint_duration_seconds`, `tempo_querier_external_endpoint_hedged_roundtrips_total`, and `tempo_feature_enabled`.
+
+### Updated, removed, or renamed configuration parameters
+
+| Parameter | Comments |
+|---|---|
+| `max_span_attr_byte` | Renamed to `max_attribute_bytes`. ([PR 4633](https://github.com/grafana/tempo/pull/4633)) |
+| `tempo_discarded_spans_total` | Removed `internal_error` as a reason from `tempo_discarded_spans_total`. ([PR 4554](https://github.com/grafana/tempo/pull/4554)) |
+| `tempo_receiver_accepted_span` and `tempo_receiver_refused_spans` | The `name` dimension from `tempo_receiver_accepted_span` and `tempo_receiver_refused_spans` changes from `tempo/jaeger_receiver` to `jaeger/jaeger_receiver`. ([PR 4893](https://github.com/grafana/tempo/pull/4893))  |
+
+### Other upgrade considerations
+
+* Upgrade OTEL Collector to v0.122.1. The `name` dimension from `tempo_receiver_accepted_span` and `tempo_receiver_refused_spans` changes from `tempo/jaeger_receiver` to `jaeger/jaeger_receiver`. ([PR 4893](https://github.com/grafana/tempo/pull/4893))
+* Replace `opentracing-contrib/go-grpc` by `otelgrpc` in Tempo query. ([PR 4958](https://github.com/grafana/tempo/pull/4958))
+* Enforce max attribute size at event, link, and instrumentation scope. The configuration is now per-tenant. Renamed `max_span_attr_byte` to `max_attribute_bytes`. ([PR 4633](https://github.com/grafana/tempo/pull/4633))
+* Converted SLO metric `query_frontend_bytes_processed_per_second` from a histogram to a counter as it's more performant. ([PR 4748](https://github.com/grafana/tempo/pull/4748))
+* Removed the OpenTelemetry Jaeger exporter, which has been [deprecated](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/jaeger). ([PR 4926](https://github.com/grafana/tempo/pull/4926))
+
+
 ## Upgrade to Tempo 2.7
 
-When [upgrading](https://grafana.com/docs/tempo/<TEMPO_VERSION>/setup/upgrade/) to Tempo 2.7, be aware of these considerations and breaking changes.
+When upgrading to Tempo 2.7, be aware of these considerations and breaking changes.
 
 ### OpenTelemetry Collector receiver listens on `localhost` by default
 

--- a/docs/sources/tempo/traceql/_index.md
+++ b/docs/sources/tempo/traceql/_index.md
@@ -592,7 +592,8 @@ find something like a single service with more than 1 error:
 
 ## Arithmetic
 
-TraceQL supports arbitrary arithmetic in your queries. This can be useful to make queries more human readable:
+TraceQL supports arbitrary arithmetic in your queries.
+Using arithmetic can make queries more human readable:
 ```
 { span.http.request_content_length > 10 * 1024 * 1024 }
 ```
@@ -601,24 +602,47 @@ or anything else that comes to mind.
 
 ## Selection
 
-TraceQL can select arbitrary fields from spans. This is particularly performant because the selected fields are not retrieved until all other criteria is met.
+TraceQL can select arbitrary fields from spans.
+This is particularly performant because the selected fields aren't retrieved until all other criteria is met.
+For example, to select the `span.http.status_code` and `span.http.url` from all spans that have an error status code:
+
 ```
-{ status=error } | select(span.http.status_code, span.http.url)
+{ status = error } | select(span.http.status_code, span.http.url)
 ```
 
 ## Retrieving most recent results (experimental)
 
-The TraceQL query hint `most_recent=true` can be used with any TraceQL selection query to force Tempo to return the most recent results ordered by time. Examples:
+When troubleshooting a live incident or monitoring production health, you often need to see the latest traces first.
+By default, Tempo’s query engine favors speed and returns the first `N` matching traces, which may not be the newest.
+
+The `most_recent` hint ensures you see the freshest data, so you can diagnose recent errors or performance regressions without missing anything due to early row‑limit cuts.
+
+You can use TraceQL query hint `most_recent=true` with any TraceQL selection query to force Tempo to return the most recent results ordered by time.
+
+Examples:
 
 ```
 {} with (most_recent=true)
 { span.foo = "bar" } >> { status = error } with (most_recent=true)
 ```
 
+With `most_recent=true`, Tempo performs a deeper search across data shards, retains the newest candidates, and returns traces sorted by start time rather than stopping at the first limit hit.
+
+You can specify the time window to break a search up into when doing a most recent TraceQL search using `most_recent_shards:` in the `query_frontend` configuration block.
+The default value is 200.
+Refer to the [Tempo configuration reference](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/query_frontend/) for more information.
+
+### Search impact using `most_recent`
+
+Most search functions are deterministic: using the same search criteria results in the same results.
+
+When you use most_recent=true`, Tempo search is non-deterministic.
+If you perform the same search twice, you’ll get different lists, assuming the possible number of results for your search is greater than the number of results you have your search set to return.
+
 ## Experimental TraceQL metrics
 
-TraceQL metrics are experimental, but easy to get started with.
-Refer to [the TraceQL metrics](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/traceql-metrics/) documentation for more information.
+TraceQL metrics are easy to get started with.
+Refer to [TraceQL metrics](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/traceql-metrics/) for more information.
 
 You can also use TraceQL metrics queries.
-For details, refer to [TraceQL metrics queries](https://grafana.com/docs/tempo/<TEMPO_VERSION>/traceql/metrics-queries/).
+Refer to [TraceQL metrics queries](https://grafana.com/docs/tempo/<TEMPO_VERSION>/traceql/metrics-queries/) for more information.

--- a/docs/sources/tempo/traceql/metrics-queries/functions.md
+++ b/docs/sources/tempo/traceql/metrics-queries/functions.md
@@ -231,9 +231,13 @@ These functions are similar to their equivalent PromQL functions. For example:
 When a query response is larger than the maximum, you can use these functions to return only the specified number
 from 1 through `k` of the number of the top or bottom results.
 
-For example: `{ resource.service.name = "foo" } | rate() by (span.http.url)  | topk(10)`
-The first part, `{ resource.service.name = "foo" }`, takes all spans in the service `foo` The spans
-are rated by the URL, for example, the most active endpoints on a service.
+For example:
+```
+`{ resource.service.name = "foo" } | rate() by (span.http.url)  | topk(10)`
+```
+
+The first part, `{ resource.service.name = "foo" }`, takes all spans in the service `foo`.
+The spans are rated by the URL, for example, the most active endpoints on a service.
 
 Adding `topk(10)` returns the top 10 most common instead of the entire list.
 Conversely, you can use `bottomk(10)` to see the least most used ones.


### PR DESCRIPTION
**What this PR does**:

Manual backport of doc changes for 2.8 from these PRs: 
* #5258 
* #5205 
* #5095 
* #5260 

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`