### PR TITLE
compaction: correctly load active jobs gauge on startup

### DIFF
--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -323,7 +323,6 @@ func (s *BackendScheduler) replayWorkOnBlocklist() {
 	// Get all the input blocks which have been successfully compacted
 	for _, j := range s.work.ListJobs() {
 		tenant = j.Tenant()
-
 		if j.GetStatus() != tempopb.JobStatus_JOB_STATUS_SUCCEEDED {
 			continue
 		}
@@ -333,6 +332,8 @@ func (s *BackendScheduler) replayWorkOnBlocklist() {
 		}
 
 		perTenantJobs[tenant] = append(perTenantJobs[tenant], j)
+		// As we load the jobs during replay, update the active jobs gauge
+		metricJobsActive.WithLabelValues(tenant, j.GetType().String()).Inc()
 	}
 
 	for tenant, jobs := range perTenantJobs {


### PR DESCRIPTION
**What this PR does**:
Fix https://github.com/grafana/tempo/issues/5246 by loading active jobs during startup of backendscheduler

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/tempo/issues/5246

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`