### PR TITLE
add doc about qemu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ docker-tempo: ## Build tempo docker image
 	COMPONENT=tempo make docker-component
 
 .PHONY: docker-tempo-multi
-docker-tempo-multi: ## Build multiarch image locally, requires containerd image store
+docker-tempo-multi: ## Build multiarch image locally, requires containerd image store and qemu installed 'docker run --privileged --rm tonistiigi/binfmt --install all'
 	COMPONENT=tempo make docker-component-multi
 
 docker-tempo-debug: ## Build tempo debug docker image


### PR DESCRIPTION
Had to install qemu to get the multi image docker running so adding doc on the easiest way to do that, if we want to use qemu more directly I can do that to but this adds a bundle of things.