### PR TITLE
[DOC] Add non-deterministic content back to doc

### DIFF
--- a/docs/sources/tempo/shared/tempo-in-grafana.md
+++ b/docs/sources/tempo/shared/tempo-in-grafana.md
@@ -49,7 +49,7 @@ Use the Explore trace view to quickly diagnose errors and high latency events in
 Most search functions are deterministic. 
 When given the same criteria, a deterministic algorithm returns consistent results. 
 For example, let's say that you query a search engine for the definition of "traces." 
-The results consistently list the same top matches  for each query for "traces" in that search engine. 
+The results list the same top matches for each query for "traces" in that search engine. 
 
 However, Tempo search is non-deterministic.
 If you perform the same search twice, you’ll get different lists, assuming the possible number of results for your search is greater than the number of results you have your search set to return.

--- a/docs/sources/tempo/shared/tempo-in-grafana.md
+++ b/docs/sources/tempo/shared/tempo-in-grafana.md
@@ -46,7 +46,10 @@ Use the Explore trace view to quickly diagnose errors and high latency events in
 
 ### Search is non-deterministic
 
-Most search functions are deterministic: using the same search criteria results in the same results.
+Most search functions are deterministic. 
+When given the same criteria, a deterministic algorithm returns consistent results. 
+For example, let's say that you query a search engine for the definition of "traces." 
+The results consistently list the same top matches  for each query for "traces" in that search engine. 
 
 However, Tempo search is non-deterministic.
 If you perform the same search twice, you’ll get different lists, assuming the possible number of results for your search is greater than the number of results you have your search set to return.

--- a/docs/sources/tempo/shared/tempo-in-grafana.md
+++ b/docs/sources/tempo/shared/tempo-in-grafana.md
@@ -59,7 +59,7 @@ Even identical searches differ due to things like machine load and network laten
 This approach values speed over predictability and is quite simple; enforcing that the search results are consistent would introduce additional complexity (and increase the time the user spends waiting for results).
 TraceQL follows the same behavior.
 
-By adding `most_recent=true` to your TraceQL queries, the search results become deterministic.
+By adding `most_recent=true` to your TraceQL queries, the search results become deterministic. 
 For more information, refer to [Retrieve most recent results](https://grafana.com/docs/tempo/<TEMPO_VERSION>/traceql/#retrieving-most-recent-results-experimental)
 
 #### Use trace search results as panels in dashboards

--- a/docs/sources/tempo/shared/tempo-in-grafana.md
+++ b/docs/sources/tempo/shared/tempo-in-grafana.md
@@ -44,6 +44,21 @@ Use the Explore trace view to quickly diagnose errors and high latency events in
 
 ![Sample search visualization](/static/img/docs/grafana-cloud/trace_search.png)
 
+### Search is non-deterministic
+
+Most search functions are deterministic: using the same search criteria results in the same results.
+
+However, Tempo search is non-deterministic.
+If you perform the same search twice, you’ll get different lists, assuming the possible number of results for your search is greater than the number of results you have your search set to return.
+
+When performing a search, Tempo does a massively parallel search over the given time range, and takes the first `N` results.
+Even identical searches differ due to things like machine load and network latency.
+This approach values speed over predictability and is quite simple; enforcing that the search results are consistent would introduce additional complexity (and increase the time the user spends waiting for results).
+TraceQL follows the same behavior.
+
+By adding `most_recent=true` to your TraceQL queries, the search results become deterministic.
+For more information, refer to [Retrieve most recent results](https://grafana.com/docs/tempo/<TEMPO_VERSION>/traceql/#retrieving-most-recent-results-experimental)
+
 #### Use trace search results as panels in dashboards
 
 You can embed tracing panels and visualizations in dashboards.

--- a/docs/sources/tempo/traceql/_index.md
+++ b/docs/sources/tempo/traceql/_index.md
@@ -634,10 +634,11 @@ Refer to the [Tempo configuration reference](https://grafana.com/docs/tempo/<TEM
 
 ### Search impact using `most_recent`
 
-Most search functions are deterministic: using the same search criteria results in the same results.
+Most Tempo search functions are non-deterministic: using the same search criteria results in different results.
 
-When you use most_recent=true`, Tempo search is non-deterministic.
-If you perform the same search twice, you’ll get different lists, assuming the possible number of results for your search is greater than the number of results you have your search set to return.
+When you use `most_recent=true`, Tempo search is deterministic.
+
+If you perform the same search twice, you’ll get the same lists, assuming the possible number of results for your search is greater than the number of results you have your search set to return.
 
 ## Experimental TraceQL metrics
 


### PR DESCRIPTION

**What this PR does**:

Clarifies non-deterministic and deterministic search with most_recent="true" in the doc. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`