### PR TITLE
fix(http): add YAML document separator to /status/runtime_config output

### DIFF
--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -373,6 +373,10 @@ func (t *App) writeRuntimeConfig(w io.Writer, r *http.Request) error {
 		_, err := w.Write([]byte(fmt.Sprintf("overrides module not loaded in %s\n", t.cfg.Target)))
 		return err
 	}
+	_, err := w.Write([]byte("---\n"))
+	if err != nil {
+		return err
+	}
 	return t.Overrides.WriteStatusRuntimeConfig(w, r)
 }
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds the separator `---` in `writeRuntimeConfig` for compatibility with YAML parsers

**Which issue(s) this PR fixes**:
Fixes #5146 
**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`