### PR TITLE
TraceQL performance and parquetquery cleanup

### DIFF
--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -190,8 +190,12 @@ func (r *IteratorResult) Reset() {
 }
 
 func (r *IteratorResult) Append(rr *IteratorResult) {
-	r.Entries = append(r.Entries, rr.Entries...)
-	r.OtherEntries = append(r.OtherEntries, rr.OtherEntries...)
+	if len(rr.Entries) > 0 {
+		r.Entries = append(r.Entries, rr.Entries...)
+	}
+	if len(rr.OtherEntries) > 0 {
+		r.OtherEntries = append(r.OtherEntries, rr.OtherEntries...)
+	}
 }
 
 func (r *IteratorResult) AppendValue(k string, v pq.Value) {
@@ -313,7 +317,7 @@ func (o PoolOption) applyToLeftJoinIterator(j *LeftJoinIterator) {
 	j.pool = o.pool
 }
 
-type SyncIteratorOpt func(*SyncIterator)
+type SyncIteratorOpt func(i *SyncIterator)
 
 // SyncIteratorOptIntern enables interning of string values.
 // This is useful when the same string value is repeated many times.
@@ -325,6 +329,49 @@ func SyncIteratorOptIntern() SyncIteratorOpt {
 	}
 }
 
+// SyncIteratorOptPredicate uses the given predicate to filter column values.
+func SyncIteratorOptPredicate(p Predicate) SyncIteratorOpt {
+	return func(i *SyncIterator) {
+		i.filter = p
+	}
+}
+
+// SyncIteratorOptColumnName sets the column name for the iterator.
+// This is used for tracing and debugging only. All work is done
+// using the column index which is a required parameter on creation.
+func SyncIteratorOptColumnName(columnName string) SyncIteratorOpt {
+	return func(i *SyncIterator) {
+		i.columnName = columnName
+	}
+}
+
+// SyncIteratorOptSelectAs returns the values of the columns with this name
+// in the IteratorResult. By default the iterator only looks for matches and
+// returns their row numbers. This option is used when you also want the actual
+// found values back.
+func SyncIteratorOptSelectAs(selectAs string) SyncIteratorOpt {
+	return func(i *SyncIterator) {
+		i.selectAs = selectAs
+	}
+}
+
+// SyncIteratorOptBufferSize overrides the default buffer size. This is how many
+// values are unpacked from the column on each read.
+func SyncIteratorOptBufferSize(bufferSize int) SyncIteratorOpt {
+	return func(i *SyncIterator) {
+		i.readSize = bufferSize
+	}
+}
+
+// SyncIteratorOptMaxDefinitionLevel specifies the maximum definition level that
+// can be expected for this column. Allows for better efficiency, but not
+// required for correct behavior.
+func SyncIteratorOptMaxDefinitionLevel(maxDefinitionLevel int) SyncIteratorOpt {
+	return func(i *SyncIterator) {
+		i.maxDefinitionLevel = maxDefinitionLevel
+	}
+}
+
 // SyncIterator is a synchronous column iterator. It scans through the given row
 // groups and column, and applies the optional predicate to each chunk, page, and value.
 // Results are read by calling Next() until it returns nil.
@@ -332,6 +379,7 @@ type SyncIterator struct {
 	// Config
 	column     int
 	columnName string
+	selectAs   string
 	rgs        []pq.RowGroup
 	rgsMin     []RowNumber
 	rgsMax     []RowNumber // Exclusive, row number of next one past the row group
@@ -362,7 +410,14 @@ type SyncIterator struct {
 
 var _ Iterator = (*SyncIterator)(nil)
 
-func NewSyncIterator(ctx context.Context, rgs []pq.RowGroup, column int, columnName string, readSize int, filter Predicate, selectAs string, maxDefinitionLevel int, opts ...SyncIteratorOpt) *SyncIterator {
+// NewSyncIterator iterates values in a column of a parquet file. Required values
+// are the numeric column index and the row groups to iterate over.  The column index
+// can be found by name using GetColumnIndexByPath.  By default it does the minimal
+// amount of work, which is to scan for matches (using the given predicate if specified),
+// and return their row values. To retrieve the found values back, pass SyncIteratorOptSelectAs.
+//
+// Not safe for concurrent use.
+func NewSyncIterator(ctx context.Context, rgs []pq.RowGroup, column int, opts ...SyncIteratorOpt) *SyncIterator {
 	// Assign row group bounds.
 	// Lower bound is inclusive
 	// Upper bound is exclusive, points at the first row of the next group
@@ -376,41 +431,37 @@ func NewSyncIterator(ctx context.Context, rgs []pq.RowGroup, column int, columnN
 		rn.Skip(rg.NumRows())
 	}
 
-	_, span := tracer.Start(ctx, "syncIterator", trace.WithAttributes(
-		attribute.Int("columnIndex", column),
-		attribute.String("column", columnName),
-	))
-
-	at := IteratorResult{}
-	if selectAs != "" {
-		// Preallocate 1 entry with the given name.
-		at.Entries = []struct {
-			Key   string
-			Value pq.Value
-		}{
-			{Key: selectAs},
-		}
-	}
-
 	// Create the iterator
 	i := &SyncIterator{
-		span:               span,
 		column:             column,
-		columnName:         columnName,
 		rgs:                rgs,
-		readSize:           readSize,
+		readSize:           1000, // default value
 		rgsMin:             rgsMin,
 		rgsMax:             rgsMax,
-		filter:             filter,
 		curr:               EmptyRowNumber(),
-		at:                 at,
-		maxDefinitionLevel: maxDefinitionLevel,
+		at:                 IteratorResult{},
+		maxDefinitionLevel: MaxDefinitionLevel, // default value
 	}
 
 	// Apply options
 	for _, opt := range opts {
 		opt(i)
 	}
+
+	if i.selectAs != "" {
+		// Preallocate 1 entry with the given name.
+		i.at.Entries = []struct {
+			Key   string
+			Value pq.Value
+		}{
+			{Key: i.selectAs},
+		}
+	}
+
+	_, i.span = tracer.Start(ctx, "syncIterator", trace.WithAttributes(
+		attribute.Int("columnIndex", column),
+		attribute.String("column", i.columnName),
+	))
 
 	return i
 }
@@ -1100,7 +1151,12 @@ outer:
 }
 
 func (j *LeftJoinIterator) SeekTo(t RowNumber, d int) (*IteratorResult, error) {
-	err := j.seekAll(t, d)
+	err := j.seekAllRequired(t, d)
+	if err != nil {
+		return nil, err
+	}
+
+	err = j.seekAllOptional(t, d)
 	if err != nil {
 		return nil, err
 	}
@@ -1109,7 +1165,6 @@ func (j *LeftJoinIterator) SeekTo(t RowNumber, d int) (*IteratorResult, error) {
 }
 
 func (j *LeftJoinIterator) seek(iterNum int, t RowNumber, d int) (err error) {
-	t = TruncateRowNumber(d, t)
 	if j.peeksRequired[iterNum] == nil || CompareRowNumbers(d, j.peeksRequired[iterNum].RowNumber, t) == -1 {
 		j.peeksRequired[iterNum], err = j.required[iterNum].SeekTo(t, d)
 		if err != nil {
@@ -1119,8 +1174,7 @@ func (j *LeftJoinIterator) seek(iterNum int, t RowNumber, d int) (err error) {
 	return nil
 }
 
-func (j *LeftJoinIterator) seekAll(t RowNumber, d int) (err error) {
-	t = TruncateRowNumber(d, t)
+func (j *LeftJoinIterator) seekAllRequired(t RowNumber, d int) (err error) {
 	for iterNum, iter := range j.required {
 		if j.peeksRequired[iterNum] == nil || CompareRowNumbers(d, j.peeksRequired[iterNum].RowNumber, t) == -1 {
 			j.peeksRequired[iterNum], err = iter.SeekTo(t, d)
@@ -1133,6 +1187,10 @@ func (j *LeftJoinIterator) seekAll(t RowNumber, d int) (err error) {
 			}
 		}
 	}
+	return nil
+}
+
+func (j *LeftJoinIterator) seekAllOptional(t RowNumber, d int) (err error) {
 	for iterNum, iter := range j.optional {
 		if j.peeksOptional[iterNum] == nil || CompareRowNumbers(d, j.peeksOptional[iterNum].RowNumber, t) == -1 {
 			j.peeksOptional[iterNum], err = iter.SeekTo(t, d)
@@ -1170,7 +1228,6 @@ func (j *LeftJoinIterator) collect(rowNumber RowNumber) (*IteratorResult, error)
 			// Collect matches
 			for peeks[i] != nil && EqualRowNumber(j.definitionLevel, peeks[i].RowNumber, rowNumber) {
 				result.Append(peeks[i])
-				// peeks[i].Release()
 				peeks[i], err = iters[i].Next()
 				if err != nil {
 					return
@@ -1179,7 +1236,9 @@ func (j *LeftJoinIterator) collect(rowNumber RowNumber) (*IteratorResult, error)
 		}
 	}
 
-	err = j.seekAll(rowNumber, j.definitionLevel)
+	// Collect is only called after we have found a match among all
+	// required iterators, therefore we only need to seek the optional ones to same location.
+	err = j.seekAllOptional(rowNumber, j.definitionLevel)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/parquetquery/predicate_test.go
+++ b/pkg/parquetquery/predicate_test.go
@@ -239,7 +239,7 @@ func testPredicate(t *testing.T, tc predicateTestCase) {
 
 	p := InstrumentedPredicate{Pred: tc.predicate}
 
-	i := NewSyncIterator(context.TODO(), r.RowGroups(), 0, "test", 100, &p, "", MaxDefinitionLevel)
+	i := NewSyncIterator(context.TODO(), r.RowGroups(), 0, SyncIteratorOptPredicate(&p))
 	for {
 		res, err := i.Next()
 		require.NoError(t, err)

--- a/tempodb/encoding/vparquet2/block_findtracebyid.go
+++ b/tempodb/encoding/vparquet2/block_findtracebyid.go
@@ -227,7 +227,10 @@ func findTraceByID(ctx context.Context, traceID common.ID, meta *backend.BlockMe
 	}
 
 	// Now iterate the matching row group
-	iter := parquetquery.NewSyncIterator(ctx, pf.RowGroups()[rowGroup:rowGroup+1], colIndex, "", 1000, parquetquery.NewStringInPredicate([]string{string(traceID)}), "", maxDef)
+	iter := parquetquery.NewSyncIterator(ctx, pf.RowGroups()[rowGroup:rowGroup+1], colIndex,
+		parquetquery.SyncIteratorOptPredicate(parquetquery.NewStringInPredicate([]string{string(traceID)})),
+		parquetquery.SyncIteratorOptMaxDefinitionLevel(maxDef),
+	)
 	defer iter.Close()
 
 	res, err := iter.Next()

--- a/tempodb/encoding/vparquet2/block_search.go
+++ b/tempodb/encoding/vparquet2/block_search.go
@@ -356,12 +356,18 @@ func makeIterFunc(ctx context.Context, rgs []parquet.RowGroup, pf *parquet.File)
 			panic("column not found in parquet file:" + name)
 		}
 
-		var opts []pq.SyncIteratorOpt
+		opts := []pq.SyncIteratorOpt{
+			pq.SyncIteratorOptColumnName(name),
+			pq.SyncIteratorOptPredicate(predicate),
+			pq.SyncIteratorOptSelectAs(selectAs),
+			pq.SyncIteratorOptMaxDefinitionLevel(maxDef),
+		}
+
 		if name != columnPathSpanID && name != columnPathTraceID {
 			opts = append(opts, pq.SyncIteratorOptIntern())
 		}
 
-		return pq.NewSyncIterator(ctx, rgs, index, name, 1000, predicate, selectAs, maxDef, opts...)
+		return pq.NewSyncIterator(ctx, rgs, index, opts...)
 	}
 }
 

--- a/tempodb/encoding/vparquet3/block_findtracebyid.go
+++ b/tempodb/encoding/vparquet3/block_findtracebyid.go
@@ -230,7 +230,10 @@ func findTraceByID(ctx context.Context, traceID common.ID, meta *backend.BlockMe
 	}
 
 	// Now iterate the matching row group
-	iter := parquetquery.NewSyncIterator(ctx, pf.RowGroups()[rowGroup:rowGroup+1], colIndex, "", 1000, parquetquery.NewStringInPredicate([]string{string(traceID)}), "", maxDef)
+	iter := parquetquery.NewSyncIterator(ctx, pf.RowGroups()[rowGroup:rowGroup+1], colIndex,
+		parquetquery.SyncIteratorOptPredicate(parquetquery.NewStringInPredicate([]string{string(traceID)})),
+		parquetquery.SyncIteratorOptMaxDefinitionLevel(maxDef),
+	)
 	defer iter.Close()
 
 	res, err := iter.Next()

--- a/tempodb/encoding/vparquet3/block_search.go
+++ b/tempodb/encoding/vparquet3/block_search.go
@@ -354,12 +354,17 @@ func makeIterFunc(ctx context.Context, rgs []parquet.RowGroup, pf *parquet.File)
 			panic("column not found in parquet file:" + name)
 		}
 
-		var opts []pq.SyncIteratorOpt
+		opts := []pq.SyncIteratorOpt{
+			pq.SyncIteratorOptColumnName(name),
+			pq.SyncIteratorOptPredicate(predicate),
+			pq.SyncIteratorOptSelectAs(selectAs),
+			pq.SyncIteratorOptMaxDefinitionLevel(maxDef),
+		}
 		if name != columnPathSpanID && name != columnPathTraceID {
 			opts = append(opts, pq.SyncIteratorOptIntern())
 		}
 
-		return pq.NewSyncIterator(ctx, rgs, index, name, 1000, predicate, selectAs, maxDef, opts...)
+		return pq.NewSyncIterator(ctx, rgs, index, opts...)
 	}
 }
 

--- a/tempodb/encoding/vparquet4/block_findtracebyid.go
+++ b/tempodb/encoding/vparquet4/block_findtracebyid.go
@@ -237,7 +237,10 @@ func findTraceByID(ctx context.Context, traceID common.ID, meta *backend.BlockMe
 	}
 
 	// Now iterate the matching row group
-	iter := parquetquery.NewSyncIterator(ctx, pf.RowGroups()[rowGroup:rowGroup+1], colIndex, "", 1000, parquetquery.NewStringInPredicate([]string{string(traceID)}), "", maxDef)
+	iter := parquetquery.NewSyncIterator(ctx, pf.RowGroups()[rowGroup:rowGroup+1], colIndex,
+		parquetquery.SyncIteratorOptPredicate(parquetquery.NewStringInPredicate([]string{string(traceID)})),
+		parquetquery.SyncIteratorOptMaxDefinitionLevel(maxDef),
+	)
 	defer iter.Close()
 
 	res, err := iter.Next()

--- a/tempodb/encoding/vparquet4/block_search.go
+++ b/tempodb/encoding/vparquet4/block_search.go
@@ -357,12 +357,17 @@ func makeIterFunc(ctx context.Context, rgs []parquet.RowGroup, pf *parquet.File)
 			panic("column not found in parquet file:" + name)
 		}
 
-		var opts []pq.SyncIteratorOpt
+		opts := []pq.SyncIteratorOpt{
+			pq.SyncIteratorOptColumnName(name),
+			pq.SyncIteratorOptPredicate(predicate),
+			pq.SyncIteratorOptSelectAs(selectAs),
+			pq.SyncIteratorOptMaxDefinitionLevel(maxDef),
+		}
 		if name != columnPathSpanID && name != columnPathTraceID {
 			opts = append(opts, pq.SyncIteratorOptIntern())
 		}
 
-		return pq.NewSyncIterator(ctx, rgs, index, name, 1000, predicate, selectAs, maxDef, opts...)
+		return pq.NewSyncIterator(ctx, rgs, index, opts...)
 	}
 }
 


### PR DESCRIPTION
**What this PR does**:
Similar to #5247 , this fixes some inefficiencies that I found while digging into metrics queries, and prepping for some big upcoming changes (🚀)

The performance improvements are:
* Removed an unnecessary round of checking/peeking from left join iterator in collect.   
* Removed more unnecessary slice rebuilding in batchCollector when it's not configured to filter spans.
* Super micro-optimization in result.Append

The other change is to introduce more of the Options pattern to SyncIterator.  This is something I've wanted to do for awhile, and just some tidying up before upcoming changes.

<details>

<summary> Search benchmarks </summary>

```
                                                 │ before_traceql.txt │          after_traceql.txt          │
                                                 │       sec/op       │    sec/op     vs base               │
BackendBlockTraceQL/spanAttValMatch                      159.1m ±  2%   154.8m ±  2%   -2.71% (p=0.004 n=6)
BackendBlockTraceQL/spanAttValNoMatch                    1.190m ±  2%   1.168m ±  3%   -1.88% (p=0.026 n=6)
BackendBlockTraceQL/spanAttIntrinsicMatch                110.9m ±  2%   107.8m ±  4%        ~ (p=0.132 n=6)
BackendBlockTraceQL/spanAttIntrinsicNoMatch              1.178m ±  4%   1.167m ±  1%   -0.90% (p=0.015 n=6)
BackendBlockTraceQL/resourceAttValMatch                  507.9m ±  2%   480.3m ±  3%   -5.45% (p=0.002 n=6)
BackendBlockTraceQL/resourceAttValNoMatch                2.123m ±  3%   2.102m ±  3%        ~ (p=0.699 n=6)
BackendBlockTraceQL/resourceAttIntrinsicMatch            65.23m ±  3%   64.25m ±  1%   -1.51% (p=0.002 n=6)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01         1.036m ±  7%   1.012m ±  6%   -2.29% (p=0.041 n=6)
BackendBlockTraceQL/traceOrMatch                         315.2m ±  5%   292.5m ±  8%   -7.18% (p=0.002 n=6)
BackendBlockTraceQL/traceOrNoMatch                       348.6m ±  5%   304.0m ±  6%  -12.78% (p=0.002 n=6)
BackendBlockTraceQL/mixedValNoMatch                      217.4m ±  1%   143.5m ±  1%  -34.01% (p=0.002 n=6)
BackendBlockTraceQL/mixedValMixedMatchAnd                1.309m ±  1%   1.294m ±  0%   -1.15% (p=0.026 n=6)
BackendBlockTraceQL/mixedValMixedMatchOr                 169.7m ±  1%   135.0m ±  0%  -20.41% (p=0.002 n=6)
BackendBlockTraceQL/count                                942.8m ± 12%   895.9m ± 12%   -4.97% (p=0.041 n=6)
BackendBlockTraceQL/struct                               579.5m ±  8%   543.5m ±  5%        ~ (p=0.132 n=6)
BackendBlockTraceQL/||                                   300.8m ±  1%   272.3m ±  1%   -9.47% (p=0.002 n=6)
BackendBlockTraceQL/mixed                                40.05m ±  2%   39.93m ±  1%        ~ (p=0.485 n=6)
BackendBlockTraceQL/complex                              1.311m ±  1%   1.297m ±  1%        ~ (p=0.093 n=6)
BackendBlockTraceQL/select                               1.305m ±  7%   1.309m ±  5%        ~ (p=0.699 n=6)
geomean                                                  33.73m         31.53m         -6.52%

                                                 │ before_traceql.txt │          after_traceql.txt           │
                                                 │        B/s         │      B/s       vs base               │
BackendBlockTraceQL/spanAttValMatch                     232.3Mi ±  2%   238.7Mi ±  2%   +2.78% (p=0.004 n=6)
BackendBlockTraceQL/spanAttValNoMatch                   1.744Gi ±  2%   1.777Gi ±  3%   +1.91% (p=0.026 n=6)
BackendBlockTraceQL/spanAttIntrinsicMatch               350.1Mi ±  2%   360.4Mi ±  4%        ~ (p=0.132 n=6)
BackendBlockTraceQL/spanAttIntrinsicNoMatch             1.762Gi ±  4%   1.778Gi ±  1%   +0.91% (p=0.015 n=6)
BackendBlockTraceQL/resourceAttValMatch                 72.42Mi ±  2%   76.58Mi ±  3%   +5.75% (p=0.002 n=6)
BackendBlockTraceQL/resourceAttValNoMatch               1.215Gi ±  3%   1.227Gi ±  3%        ~ (p=0.699 n=6)
BackendBlockTraceQL/resourceAttIntrinsicMatch           566.3Mi ±  3%   575.0Mi ±  1%   +1.53% (p=0.002 n=6)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01        342.6Mi ±  6%   350.7Mi ±  6%   +2.34% (p=0.041 n=6)
BackendBlockTraceQL/traceOrMatch                        6.003Mi ±  5%   6.466Mi ±  9%   +7.70% (p=0.002 n=6)
BackendBlockTraceQL/traceOrNoMatch                      5.431Mi ±  5%   6.223Mi ±  6%  +14.57% (p=0.002 n=6)
BackendBlockTraceQL/mixedValNoMatch                     16.61Mi ±  1%   25.18Mi ±  1%  +51.55% (p=0.002 n=6)
BackendBlockTraceQL/mixedValMixedMatchAnd               812.8Mi ±  1%   822.2Mi ±  0%   +1.17% (p=0.026 n=6)
BackendBlockTraceQL/mixedValMixedMatchOr                21.29Mi ±  1%   26.75Mi ±  0%  +25.65% (p=0.002 n=6)
BackendBlockTraceQL/count                               38.94Mi ± 11%   40.97Mi ± 11%   +5.23% (p=0.041 n=6)
BackendBlockTraceQL/struct                              62.88Mi ±  8%   67.01Mi ±  4%        ~ (p=0.132 n=6)
BackendBlockTraceQL/||                                  123.6Mi ±  1%   136.5Mi ±  1%  +10.46% (p=0.002 n=6)
BackendBlockTraceQL/mixed                               844.0Mi ±  2%   846.6Mi ±  1%        ~ (p=0.485 n=6)
BackendBlockTraceQL/complex                             273.2Mi ±  1%   276.1Mi ±  1%        ~ (p=0.084 n=6)
BackendBlockTraceQL/select                              274.4Mi ±  7%   273.6Mi ±  5%        ~ (p=0.699 n=6)
geomean                                                 160.7Mi         171.9Mi         +6.97%

                                                 │ before_traceql.txt │          after_traceql.txt          │
                                                 │      MB_io/op      │  MB_io/op    vs base                │
BackendBlockTraceQL/spanAttValMatch                        38.75 ± 0%    38.75 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/spanAttValNoMatch                      2.228 ± 0%    2.228 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/spanAttIntrinsicMatch                  40.73 ± 0%    40.73 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/spanAttIntrinsicNoMatch                2.228 ± 0%    2.228 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/resourceAttValMatch                    38.57 ± 0%    38.57 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/resourceAttValNoMatch                  2.769 ± 0%    2.769 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/resourceAttIntrinsicMatch              38.73 ± 0%    38.73 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/resourceAttIntrinsicMatch#01          372.2m ± 0%   372.2m ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/traceOrMatch                           1.985 ± 0%    1.985 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/traceOrNoMatch                         1.985 ± 0%    1.985 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/mixedValNoMatch                        3.787 ± 0%    3.787 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/mixedValMixedMatchAnd                  1.116 ± 0%    1.116 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/mixedValMixedMatchOr                   3.787 ± 0%    3.787 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/count                                  38.49 ± 0%    38.49 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/struct                                 38.18 ± 0%    38.18 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/||                                     38.98 ± 0%    38.98 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/mixed                                  35.45 ± 0%    35.45 ± 0%       ~ (p=0.652 n=6)
BackendBlockTraceQL/complex                               375.5m ± 0%   375.5m ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockTraceQL/select                                375.5m ± 0%   375.5m ± 0%       ~ (p=1.000 n=6) ¹
geomean                                                    5.684         5.684       +0.00%
¹ all samples are equal

                                                 │ before_traceql.txt │          after_traceql.txt          │
                                                 │        B/op        │     B/op       vs base              │
BackendBlockTraceQL/spanAttValMatch                     74.90Mi ±  2%   73.79Mi ±  2%       ~ (p=0.180 n=6)
BackendBlockTraceQL/spanAttValNoMatch                   905.5Ki ±  0%   907.2Ki ±  0%  +0.19% (p=0.002 n=6)
BackendBlockTraceQL/spanAttIntrinsicMatch               40.74Mi ±  7%   39.31Mi ±  5%       ~ (p=0.132 n=6)
BackendBlockTraceQL/spanAttIntrinsicNoMatch             977.3Ki ±  0%   978.9Ki ±  0%  +0.16% (p=0.002 n=6)
BackendBlockTraceQL/resourceAttValMatch                 567.6Mi ±  0%   568.4Mi ±  0%  +0.14% (p=0.026 n=6)
BackendBlockTraceQL/resourceAttValNoMatch               1.634Mi ±  0%   1.636Mi ±  0%  +0.11% (p=0.002 n=6)
BackendBlockTraceQL/resourceAttIntrinsicMatch           8.521Mi ±  2%   8.518Mi ±  2%       ~ (p=0.937 n=6)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01        878.4Ki ±  0%   880.1Ki ±  0%  +0.20% (p=0.002 n=6)
BackendBlockTraceQL/traceOrMatch                        3.696Mi ± 29%   3.698Mi ± 29%       ~ (p=0.699 n=6)
BackendBlockTraceQL/traceOrNoMatch                      3.978Mi ±  8%   3.646Mi ±  0%       ~ (p=1.000 n=6)
BackendBlockTraceQL/mixedValNoMatch                     959.7Ki ±  0%   959.4Ki ±  9%       ~ (p=0.372 n=6)
BackendBlockTraceQL/mixedValMixedMatchAnd               872.2Ki ±  0%   874.1Ki ±  0%  +0.21% (p=0.002 n=6)
BackendBlockTraceQL/mixedValMixedMatchOr                1.055Mi ±  4%   1.044Mi ±  3%       ~ (p=1.000 n=6)
BackendBlockTraceQL/count                               909.4Mi ±  1%   909.6Mi ±  1%       ~ (p=0.699 n=6)
BackendBlockTraceQL/struct                              30.68Mi ±  9%   30.54Mi ±  4%       ~ (p=0.818 n=6)
BackendBlockTraceQL/||                                  122.8Mi ±  1%   122.9Mi ±  2%       ~ (p=1.000 n=6)
BackendBlockTraceQL/mixed                               2.650Mi ±  2%   2.649Mi ±  0%       ~ (p=0.485 n=6)
BackendBlockTraceQL/complex                             899.4Ki ±  0%   901.5Ki ±  0%  +0.23% (p=0.002 n=6)
BackendBlockTraceQL/select                              888.7Ki ±  0%   890.8Ki ±  0%  +0.23% (p=0.002 n=6)
geomean                                                 6.291Mi         6.245Mi        -0.72%

                                                 │ before_traceql.txt │         after_traceql.txt          │
                                                 │     allocs/op      │  allocs/op    vs base              │
BackendBlockTraceQL/spanAttValMatch                      753.3k ±  0%   753.3k ±  0%  +0.01% (p=0.002 n=6)
BackendBlockTraceQL/spanAttValNoMatch                    12.88k ±  0%   12.93k ±  0%  +0.40% (p=0.002 n=6)
BackendBlockTraceQL/spanAttIntrinsicMatch                414.7k ±  0%   414.7k ±  0%  +0.01% (p=0.002 n=6)
BackendBlockTraceQL/spanAttIntrinsicNoMatch              12.84k ±  0%   12.88k ±  0%  +0.37% (p=0.002 n=6)
BackendBlockTraceQL/resourceAttValMatch                  3.505M ±  0%   3.506M ±  0%  +0.00% (p=0.002 n=6)
BackendBlockTraceQL/resourceAttValNoMatch                12.94k ±  0%   12.99k ±  0%  +0.43% (p=0.002 n=6)
BackendBlockTraceQL/resourceAttIntrinsicMatch            116.0k ±  0%   116.1k ±  0%  +0.04% (p=0.002 n=6)
BackendBlockTraceQL/resourceAttIntrinsicMatch#01         12.87k ±  0%   12.92k ±  0%  +0.40% (p=0.002 n=6)
BackendBlockTraceQL/traceOrMatch                         105.3k ± 11%   105.4k ± 11%       ~ (p=0.589 n=6)
BackendBlockTraceQL/traceOrNoMatch                       104.7k ±  0%   104.8k ±  0%  +0.05% (p=0.002 n=6)
BackendBlockTraceQL/mixedValNoMatch                      13.70k ±  0%   13.76k ±  0%  +0.44% (p=0.002 n=6)
BackendBlockTraceQL/mixedValMixedMatchAnd                12.91k ±  0%   12.97k ±  0%  +0.43% (p=0.002 n=6)
BackendBlockTraceQL/mixedValMixedMatchOr                 13.70k ±  0%   13.76k ±  0%  +0.42% (p=0.002 n=6)
BackendBlockTraceQL/count                                6.696M ±  0%   6.696M ±  0%  +0.00% (p=0.037 n=6)
BackendBlockTraceQL/struct                               297.6k ±  6%   295.2k ±  4%       ~ (p=0.589 n=6)
BackendBlockTraceQL/||                                   818.0k ±  0%   818.0k ±  0%  +0.01% (p=0.002 n=6)
BackendBlockTraceQL/mixed                                27.57k ±  0%   27.62k ±  0%  +0.20% (p=0.002 n=6)
BackendBlockTraceQL/complex                              13.27k ±  0%   13.33k ±  0%  +0.48% (p=0.002 n=6)
BackendBlockTraceQL/select                               13.15k ±  0%   13.21k ±  0%  +0.46% (p=0.002 n=6)
geomean                                                  77.20k         77.34k        +0.18%
```
</details>

<details>

<summary>Metrics benchmarks</summary>

```
                                                                                                       │ before.txt  │             after.txt              │
                                                                                                       │   sec/op    │   sec/op     vs base               │
BackendBlockQueryRange/{}_|_rate()/5                                                                     75.38m ± 1%   65.22m ± 1%  -13.48% (p=0.002 n=6)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.status_code)/5                                          192.0m ± 3%   168.5m ± 4%  -12.26% (p=0.002 n=6)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/5                                          113.1m ± 2%   101.0m ± 2%  -10.70% (p=0.002 n=6)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/5                                                  1.618m ± 1%   1.563m ± 0%   -3.41% (p=0.002 n=6)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/5                                10.57m ± 1%   10.05m ± 2%   -4.88% (p=0.002 n=6)
BackendBlockQueryRange/{span.http.host_!=_``_&&_span.http.flavor=`2`}_|_rate()_by_(span.http.flavor)/5   13.30m ± 0%   13.06m ± 1%   -1.84% (p=0.002 n=6)
BackendBlockQueryRange/{status=error}_|_rate()/5                                                         11.61m ± 1%   11.26m ± 5%        ~ (p=0.065 n=6)
BackendBlockQueryRange/{}_|_quantile_over_time(duration,_.99,_.9,_.5)/5                                  165.4m ± 2%   147.1m ± 2%  -11.04% (p=0.002 n=6)
BackendBlockQueryRange/{}_|_quantile_over_time(duration,_.99)_by_(span.http.status_code)/5               277.0m ± 3%   248.2m ± 2%  -10.42% (p=0.002 n=6)
BackendBlockQueryRange/{}_|_histogram_over_time(duration)/5                                              163.5m ± 7%   147.3m ± 0%   -9.91% (p=0.002 n=6)
BackendBlockQueryRange/{}_|_avg_over_time(duration)_by_(span.http.status_code)/5                         224.7m ± 1%   199.4m ± 2%  -11.24% (p=0.002 n=6)
BackendBlockQueryRange/{}_|_max_over_time(duration)_by_(span.http.status_code)/5                         225.6m ± 1%   204.7m ± 2%   -9.26% (p=0.002 n=6)
BackendBlockQueryRange/{}_|_min_over_time(duration)_by_(span.http.status_code)/5                         228.0m ± 2%   204.5m ± 3%  -10.29% (p=0.002 n=6)
BackendBlockQueryRange/{_name_!=_nil_}_|_compare({status=error})/5                                        2.591 ± 2%    2.506 ± 1%   -3.28% (p=0.002 n=6)
BackendBlockQueryRange/{}_>_{}_|_rate()_by_(name)/5                                                      359.2m ± 2%   336.8m ± 2%   -6.21% (p=0.002 n=6)
geomean                                                                                                  93.20m        85.60m        -8.16%

                                                                                                       │ before.txt │             after.txt              │
                                                                                                       │  MB_IO/op  │  MB_IO/op   vs base                │
BackendBlockQueryRange/{}_|_rate()/5                                                                     2.922 ± 0%   2.921 ± 0%  -0.03% (p=0.015 n=6)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.status_code)/5                                          3.073 ± 0%   3.072 ± 0%       ~ (p=0.182 n=6)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/5                                          2.961 ± 0%   2.959 ± 0%  -0.07% (p=0.006 n=6)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/5                                                  1.437 ± 0%   1.438 ± 0%       ~ (p=1.000 n=6)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/5                                2.954 ± 0%   2.954 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockQueryRange/{span.http.host_!=_``_&&_span.http.flavor=`2`}_|_rate()_by_(span.http.flavor)/5   3.470 ± 0%   3.470 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockQueryRange/{status=error}_|_rate()/5                                                         3.079 ± 0%   3.079 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockQueryRange/{}_|_quantile_over_time(duration,_.99,_.9,_.5)/5                                  5.553 ± 0%   5.553 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockQueryRange/{}_|_quantile_over_time(duration,_.99)_by_(span.http.status_code)/5               5.705 ± 0%   5.702 ± 0%  -0.05% (p=0.015 n=6)
BackendBlockQueryRange/{}_|_histogram_over_time(duration)/5                                              5.553 ± 0%   5.553 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockQueryRange/{}_|_avg_over_time(duration)_by_(span.http.status_code)/5                         5.702 ± 0%   5.700 ± 0%  -0.04% (p=0.015 n=6)
BackendBlockQueryRange/{}_|_max_over_time(duration)_by_(span.http.status_code)/5                         5.702 ± 0%   5.702 ± 0%       ~ (p=1.000 n=6) ¹
BackendBlockQueryRange/{}_|_min_over_time(duration)_by_(span.http.status_code)/5                         5.702 ± 0%   5.701 ± 0%       ~ (p=0.182 n=6)
BackendBlockQueryRange/{_name_!=_nil_}_|_compare({status=error})/5                                       19.60 ± 0%   19.64 ± 0%  +0.20% (p=0.002 n=6)
BackendBlockQueryRange/{}_>_{}_|_rate()_by_(name)/5                                                      5.906 ± 0%   5.906 ± 0%       ~ (p=1.000 n=6)
geomean                                                                                                  4.404        4.404       +0.00%
¹ all samples are equal

                                                                                                       │  before.txt   │              after.txt               │
                                                                                                       │   spans/op    │   spans/op    vs base                │
BackendBlockQueryRange/{}_|_rate()/5                                                                     819.6k ± 0%     819.6k ±  0%       ~ (p=1.000 n=6) ¹
BackendBlockQueryRange/{}_|_rate()_by_(span.http.status_code)/5                                          819.6k ± 0%     819.6k ±  0%       ~ (p=1.000 n=6) ¹
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/5                                          819.6k ± 0%     819.6k ±  0%       ~ (p=1.000 n=6) ¹
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/5                                                   436.5 ± 2%      413.3 ± 10%  -5.30% (p=0.002 n=6)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/5                                21.92k ± 0%     21.92k ±  0%       ~ (p=1.000 n=6) ¹
BackendBlockQueryRange/{span.http.host_!=_``_&&_span.http.flavor=`2`}_|_rate()_by_(span.http.flavor)/5    0.000 ± 0%      0.000 ±  0%       ~ (p=1.000 n=6) ¹
BackendBlockQueryRange/{status=error}_|_rate()/5                                                         3.231k ± 0%     3.231k ±  0%       ~ (p=1.000 n=6) ¹
BackendBlockQueryRange/{}_|_quantile_over_time(duration,_.99,_.9,_.5)/5                                  819.6k ± 0%     819.6k ±  0%       ~ (p=1.000 n=6) ¹
BackendBlockQueryRange/{}_|_quantile_over_time(duration,_.99)_by_(span.http.status_code)/5               819.6k ± 0%     819.6k ±  0%       ~ (p=1.000 n=6) ¹
BackendBlockQueryRange/{}_|_histogram_over_time(duration)/5                                              819.6k ± 0%     819.6k ±  0%       ~ (p=1.000 n=6) ¹
BackendBlockQueryRange/{}_|_avg_over_time(duration)_by_(span.http.status_code)/5                         819.6k ± 0%     819.6k ±  0%       ~ (p=1.000 n=6) ¹
BackendBlockQueryRange/{}_|_max_over_time(duration)_by_(span.http.status_code)/5                         819.6k ± 0%     819.6k ±  0%       ~ (p=1.000 n=6) ¹
BackendBlockQueryRange/{}_|_min_over_time(duration)_by_(span.http.status_code)/5                         819.6k ± 0%     819.6k ±  0%       ~ (p=1.000 n=6) ¹
BackendBlockQueryRange/{_name_!=_nil_}_|_compare({status=error})/5                                       819.6k ± 0%     819.6k ±  0%       ~ (p=1.000 n=6) ¹
BackendBlockQueryRange/{}_>_{}_|_rate()_by_(name)/5                                                      512.6k ± 0%     512.6k ±  0%       ~ (p=1.000 n=6) ¹
geomean                                                                                                              ²                 -0.36%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                                                                       │  before.txt   │               after.txt               │
                                                                                                       │    spans/s    │   spans/s     vs base                 │
BackendBlockQueryRange/{}_|_rate()/5                                                                     10.87M ± 1%     12.57M ±  1%  +15.59% (p=0.002 n=6)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.status_code)/5                                          4.268M ± 3%     4.864M ±  4%  +13.97% (p=0.002 n=6)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/5                                          7.247M ± 2%     8.114M ±  2%  +11.98% (p=0.002 n=6)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/5                                                  269.3k ± 2%     264.3k ± 10%   -1.86% (p=0.004 n=6)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/5                                2.075M ± 1%     2.181M ±  2%   +5.13% (p=0.002 n=6)
BackendBlockQueryRange/{span.http.host_!=_``_&&_span.http.flavor=`2`}_|_rate()_by_(span.http.flavor)/5    0.000 ± 0%      0.000 ±  0%        ~ (p=1.000 n=6) ¹
BackendBlockQueryRange/{status=error}_|_rate()/5                                                         278.3k ± 1%     287.0k ±  5%        ~ (p=0.065 n=6)
BackendBlockQueryRange/{}_|_quantile_over_time(duration,_.99,_.9,_.5)/5                                  4.957M ± 2%     5.572M ±  2%  +12.41% (p=0.002 n=6)
BackendBlockQueryRange/{}_|_quantile_over_time(duration,_.99)_by_(span.http.status_code)/5               2.959M ± 3%     3.303M ±  2%  +11.63% (p=0.002 n=6)
BackendBlockQueryRange/{}_|_histogram_over_time(duration)/5                                              5.014M ± 6%     5.565M ±  0%  +11.00% (p=0.002 n=6)
BackendBlockQueryRange/{}_|_avg_over_time(duration)_by_(span.http.status_code)/5                         3.649M ± 1%     4.111M ±  2%  +12.66% (p=0.002 n=6)
BackendBlockQueryRange/{}_|_max_over_time(duration)_by_(span.http.status_code)/5                         3.634M ± 1%     4.004M ±  2%  +10.20% (p=0.002 n=6)
BackendBlockQueryRange/{}_|_min_over_time(duration)_by_(span.http.status_code)/5                         3.596M ± 2%     4.008M ±  3%  +11.46% (p=0.002 n=6)
BackendBlockQueryRange/{_name_!=_nil_}_|_compare({status=error})/5                                       316.4k ± 2%     327.1k ±  1%   +3.39% (p=0.002 n=6)
BackendBlockQueryRange/{}_>_{}_|_rate()_by_(name)/5                                                      1.427M ± 2%     1.522M ±  2%   +6.63% (p=0.002 n=6)
geomean                                                                                                              ²                  +8.36%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                                                                       │   before.txt   │              after.txt               │
                                                                                                       │      B/op      │      B/op       vs base              │
BackendBlockQueryRange/{}_|_rate()/5                                                                      974.7Ki ±  9%    951.9Ki ±  6%  -2.34% (p=0.037 n=6)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.status_code)/5                                           21.00Mi ±  4%    20.97Mi ±  6%       ~ (p=0.589 n=6)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/5                                           991.2Ki ±  1%    956.1Ki ±  2%  -3.54% (p=0.006 n=6)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/5                                                   1.878Mi ±  0%    1.876Mi ±  0%  -0.09% (p=0.002 n=6)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/5                                 3.448Mi ±  1%    3.452Mi ±  0%       ~ (p=0.699 n=6)
BackendBlockQueryRange/{span.http.host_!=_``_&&_span.http.flavor=`2`}_|_rate()_by_(span.http.flavor)/5    1.219Mi ±  1%    1.212Mi ±  1%       ~ (p=0.310 n=6)
BackendBlockQueryRange/{status=error}_|_rate()/5                                                          887.4Ki ±  1%    887.7Ki ±  1%       ~ (p=0.394 n=6)
BackendBlockQueryRange/{}_|_quantile_over_time(duration,_.99,_.9,_.5)/5                                  1022.8Ki ±  0%   1023.2Ki ± 15%  +0.04% (p=0.002 n=6)
BackendBlockQueryRange/{}_|_quantile_over_time(duration,_.99)_by_(span.http.status_code)/5                22.85Mi ±  7%    22.13Mi ±  6%       ~ (p=0.310 n=6)
BackendBlockQueryRange/{}_|_histogram_over_time(duration)/5                                              1022.8Ki ±  0%   1023.2Ki ± 15%  +0.03% (p=0.002 n=6)
BackendBlockQueryRange/{}_|_avg_over_time(duration)_by_(span.http.status_code)/5                          21.67Mi ±  4%    21.53Mi ±  7%       ~ (p=1.000 n=6)
BackendBlockQueryRange/{}_|_max_over_time(duration)_by_(span.http.status_code)/5                          22.47Mi ±  6%    22.98Mi ± 10%       ~ (p=0.310 n=6)
BackendBlockQueryRange/{}_|_min_over_time(duration)_by_(span.http.status_code)/5                          21.40Mi ±  4%    21.60Mi ±  5%       ~ (p=0.937 n=6)
BackendBlockQueryRange/{_name_!=_nil_}_|_compare({status=error})/5                                        302.5Mi ± 55%    268.5Mi ± 75%       ~ (p=0.699 n=6)
BackendBlockQueryRange/{}_>_{}_|_rate()_by_(name)/5                                                       61.21Mi ±  2%    60.00Mi ±  1%  -1.99% (p=0.015 n=6)
geomean                                                                                                   6.086Mi          6.001Mi        -1.39%

                                                                                                       │  before.txt  │             after.txt              │
                                                                                                       │  allocs/op   │  allocs/op    vs base              │
BackendBlockQueryRange/{}_|_rate()/5                                                                     12.85k ±  0%   12.86k ±  0%  +0.05% (p=0.002 n=6)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.status_code)/5                                          39.58k ±  6%   38.65k ± 12%       ~ (p=0.485 n=6)
BackendBlockQueryRange/{}_|_rate()_by_(resource.service.name)/5                                          13.06k ±  0%   13.06k ±  0%       ~ (p=0.600 n=6)
BackendBlockQueryRange/{}_|_rate()_by_(span.http.url)/5                                                  12.74k ±  0%   12.75k ±  0%  +0.06% (p=0.002 n=6)
BackendBlockQueryRange/{resource.service.name=`loki-ingester`}_|_rate()/5                                28.32k ±  0%   28.33k ±  0%  +0.04% (p=0.002 n=6)
BackendBlockQueryRange/{span.http.host_!=_``_&&_span.http.flavor=`2`}_|_rate()_by_(span.http.flavor)/5   13.04k ±  0%   13.05k ±  0%  +0.12% (p=0.002 n=6)
BackendBlockQueryRange/{status=error}_|_rate()/5                                                         13.82k ±  0%   13.83k ±  0%  +0.09% (p=0.002 n=6)
BackendBlockQueryRange/{}_|_quantile_over_time(duration,_.99,_.9,_.5)/5                                  13.27k ±  0%   13.28k ±  0%  +0.09% (p=0.002 n=6)
BackendBlockQueryRange/{}_|_quantile_over_time(duration,_.99)_by_(span.http.status_code)/5               47.89k ± 17%   44.48k ± 13%       ~ (p=0.394 n=6)
BackendBlockQueryRange/{}_|_histogram_over_time(duration)/5                                              13.27k ±  0%   13.28k ±  0%  +0.09% (p=0.002 n=6)
BackendBlockQueryRange/{}_|_avg_over_time(duration)_by_(span.http.status_code)/5                         40.74k ± 13%   42.46k ± 15%       ~ (p=0.394 n=6)
BackendBlockQueryRange/{}_|_max_over_time(duration)_by_(span.http.status_code)/5                         46.01k ± 15%   48.70k ± 20%       ~ (p=0.485 n=6)
BackendBlockQueryRange/{}_|_min_over_time(duration)_by_(span.http.status_code)/5                         39.33k ± 17%   42.91k ± 10%       ~ (p=0.589 n=6)
BackendBlockQueryRange/{_name_!=_nil_}_|_compare({status=error})/5                                       1.761M ±  9%   1.705M ± 12%       ~ (p=1.000 n=6)
BackendBlockQueryRange/{}_>_{}_|_rate()_by_(name)/5                                                      92.47k ±  7%   85.80k ±  1%       ~ (p=0.119 n=6)
geomean                                                                                                  32.31k         32.28k        -0.10%
```

</details

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`