### PR TITLE
Stop method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [BUGFIX] Correct instant query calculation [#5252](https://github.com/grafana/tempo/pull/5252) (@ruslan-mikhailov)
 * [BUGFIX] Fix tracing context propagation in distributor HTTP write requests [#5312](https://github.com/grafana/tempo/pull/5312) (@mapno)
 * [BUGFIX] Correctly apply trace idle period in ingesters and add the concept of trace live period. [#5346](https://github.com/grafana/tempo/pull/5346/files) (@joe-elliott)
+* [ENHANCEMENT] Add Stop method [#5293](https://github.com/grafana/tempo/pull/5293) (@stephanos)
 
 # v2.8.1
 

--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -218,7 +218,7 @@ func (t *App) Run() error {
 		// let's find out which module failed
 		for m, s := range serviceMap {
 			if s == service {
-				err = service.FailureCase()
+				err := service.FailureCase()
 				if errors.Is(err, modules.ErrStopProcess) {
 					level.Info(log.Logger).Log("msg", "received stop signal via return error", "module", m, "err", err)
 				} else if errors.Is(err, context.Canceled) {

--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -84,6 +84,7 @@ type App struct {
 	MemberlistKV         *memberlist.KVInitService
 	backendScheduler     *backendscheduler.BackendScheduler
 	backendWorker        *backendworker.BackendWorker
+	signalsHandler       *signals.Handler
 
 	HTTPAuthMiddleware       middleware.Interface
 	TracesConsumerMiddleware receiver.Middleware
@@ -167,7 +168,7 @@ func (t *App) setupAuthMiddleware() {
 	}
 }
 
-// Run starts, and blocks until a signal is received.
+// Run starts, and blocks until a signal is received or Stop is called.
 func (t *App) Run() error {
 	if !t.ModuleManager.IsUserVisibleModule(t.cfg.Target) {
 		level.Warn(log.Logger).Log("msg", "selected target is an internal module, is this intended?", "target", t.cfg.Target)
@@ -234,9 +235,9 @@ func (t *App) Run() error {
 	sm.AddListener(services.NewManagerListener(healthy, stopped, serviceFailed))
 
 	// Setup signal handler. If signal arrives, we stop the manager, which stops all the services.
-	handler := signals.NewHandler(t.Server.Log())
+	t.signalsHandler = signals.NewHandler(t.Server.Log())
 	go func() {
-		handler.Loop()
+		t.signalsHandler.Loop()
 
 		shutdownRequested.Store(true)
 		t.Server.SetKeepAlivesEnabled(false)
@@ -256,6 +257,14 @@ func (t *App) Run() error {
 	}
 
 	return sm.AwaitStopped(context.Background())
+}
+
+// Stop the app. It panics if the app is not running.
+func (t *App) Stop() {
+	if t.signalsHandler == nil {
+		panic("app is not running")
+	}
+	t.signalsHandler.Stop()
 }
 
 func (t *App) writeStatusVersion(w io.Writer) error {

--- a/cmd/tempo/app/app_test.go
+++ b/cmd/tempo/app/app_test.go
@@ -42,6 +42,7 @@ func TestApp_RunStop(t *testing.T) {
 	healthCheckURL := fmt.Sprintf("http://localhost:%d/ready", config.Server.HTTPListenPort)
 	require.Eventually(t, func() bool {
 		t.Log("Checking Tempo is up...")
+		// #nosec G107
 		resp, httpErr := http.Get(healthCheckURL)
 		return httpErr == nil && resp.StatusCode == http.StatusOK
 	}, 30*time.Second, 1*time.Second)
@@ -52,6 +53,7 @@ func TestApp_RunStop(t *testing.T) {
 	// check health endpoint is not reachable anymore
 	require.Eventually(t, func() bool {
 		t.Log("Checking Tempo is down...")
+		// #nosec G107
 		_, httpErr := http.Get(healthCheckURL)
 		return httpErr != nil
 	}, 30*time.Second, 1*time.Second)

--- a/cmd/tempo/app/app_test.go
+++ b/cmd/tempo/app/app_test.go
@@ -1,0 +1,54 @@
+package app
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/grafana/tempo/tempodb/backend"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApp_RunStop(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "tempo-test-app-*")
+	require.NoError(t, err)
+
+	defer func() {
+		err := os.RemoveAll(tempDir)
+		require.NoError(t, err)
+	}()
+
+	config := NewDefaultConfig()
+	config.StorageConfig.Trace.Backend = backend.Local
+	config.StorageConfig.Trace.Local.Path = filepath.Join(tempDir, "tempo")
+	config.StorageConfig.Trace.WAL.Filepath = filepath.Join(tempDir, "wal")
+	config.UsageReport.Enabled = false // speeds up the shutdown process
+
+	app, err := New(*config)
+	require.NoError(t, err)
+
+	// start Tempo
+	go func() {
+		require.NoError(t, app.Run())
+	}()
+
+	// check health endpoint is reachable
+	healthCheckURL := "http://localhost:3200/ready"
+	require.Eventually(t, func() bool {
+		t.Log("Checking Tempo is up...")
+		resp, httpErr := http.Get(healthCheckURL)
+		return httpErr == nil && resp.StatusCode == http.StatusOK
+	}, 30*time.Second, 1*time.Second)
+
+	// stop Tempo
+	app.Stop()
+
+	// check health endpoint is not reachable anymore
+	require.Eventually(t, func() bool {
+		t.Log("Checking Tempo is down...")
+		_, httpErr := http.Get(healthCheckURL)
+		return httpErr != nil
+	}, 30*time.Second, 1*time.Second)
+}

--- a/pkg/util/freeport.go
+++ b/pkg/util/freeport.go
@@ -1,0 +1,74 @@
+package util
+
+import (
+	"fmt"
+	"net"
+	"runtime"
+)
+
+// MustGetFreePort returns a TCP port that is available to listen on,
+// for the given (local) host.
+//
+// This works by binding a new TCP socket on port 0, which requests the OS to
+// allocate a free port. There is no strict guarantee that the port will remain
+// available after this function returns, but it should be safe to assume that
+// a given port will not be allocated again to any process on this machine
+// within a few seconds.
+//
+// On Unix-based systems, binding to the port returned by this function requires
+// setting the `SO_REUSEADDR` socket option (Go already does that by default,
+// but other languages may not); otherwise, the OS may fail with a message such
+// as "address already in use". Windows default behavior is already appropriate
+// in this regard; on that platform, `SO_REUSEADDR` has a different meaning and
+// should not be set (setting it may have unpredictable consequences).
+func MustGetFreePort() int {
+	port, err := getFreePort("127.0.0.1")
+	if err != nil {
+		// try ipv6
+		port, err = getFreePort("[::1]")
+		if err != nil {
+			panic(fmt.Errorf("failed assigning ephemeral port: %w", err))
+		}
+	}
+	return port
+}
+
+func getFreePort(host string) (int, error) {
+	l, err := net.Listen("tcp", host+":0")
+	if err != nil {
+		return 0, fmt.Errorf("failed to assign a free port: %v", err)
+	}
+	defer l.Close()
+	port := l.Addr().(*net.TCPAddr).Port
+
+	// On Linux and some BSD variants, ephemeral ports are randomized, and may
+	// consequently repeat within a short time frame after the listening end
+	// has been closed. To avoid this, we make a connection to the port, then
+	// close that connection from the server's side (this is very important),
+	// which puts the connection in TIME_WAIT state for some time (by default,
+	// 60s on Linux). While it remains in that state, the OS will not reallocate
+	// that port number for bind(:0) syscalls, yet we are not prevented from
+	// explicitly binding to it (thanks to SO_REUSEADDR).
+	//
+	// On macOS and Windows, the above technique is not necessary, as the OS
+	// allocates ephemeral ports sequentially, meaning a port number will only
+	// be reused after the entire range has been exhausted. Quite the opposite,
+	// given that these OSes use a significantly smaller range for ephemeral
+	// ports, making an extra connection just to reserve a port might actually
+	// be harmful (by hastening ephemeral port exhaustion).
+	if runtime.GOOS != "darwin" && runtime.GOOS != "windows" {
+		r, err := net.DialTCP("tcp", nil, l.Addr().(*net.TCPAddr))
+		if err != nil {
+			return 0, fmt.Errorf("failed to assign a free port: %v", err)
+		}
+		c, err := l.Accept()
+		if err != nil {
+			return 0, fmt.Errorf("failed to assign a free port: %v", err)
+		}
+		// Closing the socket from the server side
+		_ = c.Close()
+		defer r.Close()
+	}
+
+	return port, nil
+}

--- a/pkg/util/freeport.go
+++ b/pkg/util/freeport.go
@@ -21,6 +21,8 @@ import (
 // as "address already in use". Windows default behavior is already appropriate
 // in this regard; on that platform, `SO_REUSEADDR` has a different meaning and
 // should not be set (setting it may have unpredictable consequences).
+//
+// Copied from github.com/temporalio/temporal/blob/main/common/testing/freeport/freeport.go.
 func MustGetFreePort() int {
 	port, err := getFreePort("127.0.0.1")
 	if err != nil {


### PR DESCRIPTION
**What this PR does**:

Adds a `Stop` method to `app.App`.

**Which issue(s) this PR fixes**:

see https://github.com/grafana/tempo/discussions/5225

tl;dr it's helpful when embedding Tempo inside a Go application to be able to control it's full lifecycle, not just the start.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
