### PR TITLE
[DOC] Correct example ports in linux.md

### DIFF
--- a/docs/sources/tempo/setup/linux.md
+++ b/docs/sources/tempo/setup/linux.md
@@ -75,6 +75,8 @@ Refer to the [Tempo configuration documentation](../../configuration/) for expla
 
 In the following configuration, Tempo options are altered to only listen to the OTLP gRPC and HTTP protocols.
 By default, Tempo listens for all compatible protocols.
+The OpenTelemetry Collector receiver binds to `localhost` instead of `0.0.0.0`.
+This example binds to all ports, bear in mind that this can be a security risk if your Tempo instance is exposed to the public internet.
 
 ```yaml
 server:
@@ -84,8 +86,10 @@ distributor:
   receivers:
       otlp:
         protocols:
-          http:
           grpc:
+            endpoint: "0.0.0.0:4317"
+         http:
+            endpoint: "0.0.0.0:4318"
 
 compactor:
   compaction:


### PR DESCRIPTION
**What this PR does**:

Corrects the default ports in the linux.md (Set up Linux) documentation. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/tempo/issues/5239

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`