### PR TITLE
Improve backend-scheduler observability

### DIFF
--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -316,7 +316,7 @@ func (s *BackendScheduler) UpdateJob(ctx context.Context, req *tempopb.UpdateJob
 			return &tempopb.UpdateJobStatusResponse{}, status.Error(codes.Internal, ErrFlushFailed.Error())
 		}
 
-		err = s.loadBlocklistJobsForTenant(j.Tenant(), []*work.Job{j})
+		err = s.loadBlocklistJobsForTenant(ctx, j.Tenant(), []*work.Job{j})
 		if err != nil {
 			return &tempopb.UpdateJobStatusResponse{}, status.Error(codes.Internal, err.Error())
 		}
@@ -341,7 +341,10 @@ func (s *BackendScheduler) UpdateJob(ctx context.Context, req *tempopb.UpdateJob
 	}, nil
 }
 
-func (s *BackendScheduler) replayWorkOnBlocklist() {
+func (s *BackendScheduler) replayWorkOnBlocklist(ctx context.Context) {
+	ctx, span := tracer.Start(ctx, "replayWorkOnBlocklist")
+	defer span.End()
+
 	var (
 		err           error
 		tenant        string
@@ -371,19 +374,29 @@ func (s *BackendScheduler) replayWorkOnBlocklist() {
 	}
 
 	for tenant, jobs := range perTenantJobs {
-		err = s.loadBlocklistJobsForTenant(tenant, jobs)
+		err = s.loadBlocklistJobsForTenant(ctx, tenant, jobs)
 		if err != nil {
 			level.Error(log.Logger).Log("msg", "failed to load blocklist jobs for tenant", "tenant", tenant, "error", err)
 		}
 	}
 }
 
-func (s *BackendScheduler) loadBlocklistJobsForTenant(tenant string, jobs []*work.Job) error {
+func (s *BackendScheduler) loadBlocklistJobsForTenant(ctx context.Context, tenant string, jobs []*work.Job) error {
+	_, span := tracer.Start(ctx, "loadBlocklistJobsForTenant")
+	defer span.End()
+
 	var (
 		metas     = s.store.BlockMetas(tenant)
 		oldBlocks []*backend.BlockMeta
 		u         backend.UUID
 		err       error
+		m         *backend.BlockMeta
+		ok        bool
+	)
+
+	span.SetAttributes(
+		attribute.String("tenant", tenant),
+		attribute.Int("job_count", len(jobs)),
 	)
 
 	for _, j := range jobs {
@@ -398,11 +411,8 @@ func (s *BackendScheduler) loadBlocklistJobsForTenant(tenant string, jobs []*wor
 				continue
 			}
 
-			for _, m := range metas {
-				if m.BlockID == u {
-					oldBlocks = append(oldBlocks, m)
-					break
-				}
+			if m, ok = foundMetaInMetas(metas, u); ok {
+				oldBlocks = append(oldBlocks, m)
 			}
 		}
 	}
@@ -413,6 +423,15 @@ func (s *BackendScheduler) loadBlocklistJobsForTenant(tenant string, jobs []*wor
 	}
 
 	return nil
+}
+
+func foundMetaInMetas(metas []*backend.BlockMeta, u backend.UUID) (*backend.BlockMeta, bool) {
+	for _, m := range metas {
+		if m.BlockID == u {
+			return m, true
+		}
+	}
+	return nil, false
 }
 
 func (s *BackendScheduler) StatusHandler(w http.ResponseWriter, _ *http.Request) {

--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/codes"
 )
 
@@ -241,6 +242,10 @@ func (s *BackendScheduler) Next(ctx context.Context, req *tempopb.NextJobRequest
 	// Try to get a job from the merged channel
 	select {
 	case j := <-s.mergedJobs:
+		span.AddEvent("job received", trace.WithAttributes(
+			attribute.String("job_id", j.GetID()),
+		))
+
 		if j == nil {
 			// Channel closed, no jobs available
 			metricJobsNotFound.WithLabelValues(req.WorkerId).Inc()

--- a/modules/backendscheduler/cache.go
+++ b/modules/backendscheduler/cache.go
@@ -63,6 +63,9 @@ func (s *BackendScheduler) flushWorkCacheToBackend(ctx context.Context) error {
 
 // loadWorkCache loads the work cache from the local filesystem
 func (s *BackendScheduler) loadWorkCache(ctx context.Context) error {
+	ctx, span := tracer.Start(ctx, "loadWorkCache")
+	defer span.End()
+
 	// Try to load the local work cache first, falling back to the backend if it doesn't exist.
 	workPath := filepath.Join(s.cfg.LocalWorkPath, backend.WorkFileName)
 	data, err := os.ReadFile(workPath)
@@ -81,12 +84,15 @@ func (s *BackendScheduler) loadWorkCache(ctx context.Context) error {
 
 	// Once the work cache is loaded, replay the work list on top of the
 	// blocklist to ensure we only hand out jobs for blocks which need visiting.
-	s.replayWorkOnBlocklist()
+	s.replayWorkOnBlocklist(ctx)
 
 	return nil
 }
 
 func (s *BackendScheduler) loadWorkCacheFromBackend(ctx context.Context) error {
+	ctx, span := tracer.Start(ctx, "loadWorkCacheFromBackend")
+	defer span.End()
+
 	reader, _, err := s.reader.Read(ctx, backend.WorkFileName, backend.KeyPath{}, nil)
 	if err != nil {
 		return err
@@ -109,7 +115,7 @@ func (s *BackendScheduler) loadWorkCacheFromBackend(ctx context.Context) error {
 
 	// Once the work cache is loaded, replay the work list on top of the
 	// blocklist to ensure we only hand out jobs for blocks which need visiting.
-	s.replayWorkOnBlocklist()
+	s.replayWorkOnBlocklist(ctx)
 
 	return nil
 }

--- a/modules/backendscheduler/cache.go
+++ b/modules/backendscheduler/cache.go
@@ -14,6 +14,9 @@ import (
 )
 
 func (s *BackendScheduler) flushWorkCache(ctx context.Context) error {
+	_, span := tracer.Start(ctx, "flushWorkCache")
+	defer span.End()
+
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
@@ -38,6 +41,9 @@ func (s *BackendScheduler) flushWorkCache(ctx context.Context) error {
 }
 
 func (s *BackendScheduler) flushWorkCacheToBackend(ctx context.Context) error {
+	_, span := tracer.Start(ctx, "flushWorkCacheToBackend")
+	defer span.End()
+
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 

--- a/modules/backendscheduler/provider/compaction.go
+++ b/modules/backendscheduler/provider/compaction.go
@@ -182,7 +182,7 @@ func (p *CompactionProvider) prepareNextTenant(ctx context.Context) bool {
 }
 
 func (p *CompactionProvider) createJob(ctx context.Context) *work.Job {
-	_, span := tracer.Start(ctx, "create-job")
+	_, span := tracer.Start(ctx, "createJob")
 	defer span.End()
 
 	span.SetAttributes(attribute.String("tenant_id", p.curTenant.Value()))
@@ -225,7 +225,7 @@ func (p *CompactionProvider) getNextBlockIDs(_ context.Context) ([]string, bool)
 func (p *CompactionProvider) prioritizeTenants(ctx context.Context) {
 	tenants := []tenantselector.Tenant{}
 
-	_, span := tracer.Start(ctx, "prioritize-tenants")
+	_, span := tracer.Start(ctx, "prioritizeTenants")
 	defer span.End()
 
 	p.curPriority = tenantselector.NewPriorityQueue() // wipe and restart

--- a/modules/backendscheduler/provider/compaction.go
+++ b/modules/backendscheduler/provider/compaction.go
@@ -316,8 +316,11 @@ func (p *CompactionProvider) prioritizeTenants(ctx context.Context) {
 
 	for _, tenant := range tenants {
 		priority = ts.PriorityForTenant(tenant.ID)
-		item = tenantselector.NewItem(tenant.ID, priority)
-		heap.Push(p.curPriority, item)
+
+		if priority > 0 {
+			item = tenantselector.NewItem(tenant.ID, priority)
+			heap.Push(p.curPriority, item)
+		}
 	}
 }
 

--- a/modules/backendscheduler/provider/compaction.go
+++ b/modules/backendscheduler/provider/compaction.go
@@ -328,15 +328,14 @@ func (p *CompactionProvider) measureTenants() {
 	_, span := tracer.Start(context.Background(), "measureTenants")
 	defer span.End()
 
+	owns := func(_ string) bool {
+		return true
+	}
+
 	var blockSelector blockselector.CompactionBlockSelector
 	for _, tenant := range p.store.Tenants() {
 		blockSelector, _ = p.newBlockSelector(tenant)
-
-		yes := func(_ string) bool {
-			return true
-		}
-
-		tempodb.MeasureOutstandingBlocks(tenant, blockSelector, yes)
+		tempodb.MeasureOutstandingBlocks(tenant, blockSelector, owns)
 	}
 }
 

--- a/modules/backendscheduler/provider/compaction.go
+++ b/modules/backendscheduler/provider/compaction.go
@@ -202,6 +202,7 @@ func (p *CompactionProvider) prepareNextTenant(ctx context.Context) bool {
 
 	p.curTenant = heap.Pop(p.curPriority).(*tenantselector.Item)
 	if p.curTenant == nil {
+		span.AddEvent("no more tenants to compact")
 		return false
 	}
 

--- a/modules/backendscheduler/provider/compaction.go
+++ b/modules/backendscheduler/provider/compaction.go
@@ -317,11 +317,8 @@ func (p *CompactionProvider) prioritizeTenants(ctx context.Context) {
 
 	for _, tenant := range tenants {
 		priority = ts.PriorityForTenant(tenant.ID)
-
-		if priority > 0 {
-			item = tenantselector.NewItem(tenant.ID, priority)
-			heap.Push(p.curPriority, item)
-		}
+		item = tenantselector.NewItem(tenant.ID, priority)
+		heap.Push(p.curPriority, item)
 	}
 }
 

--- a/modules/backendscheduler/work/work.go
+++ b/modules/backendscheduler/work/work.go
@@ -96,7 +96,7 @@ func (q *Work) ListJobs() []*Job {
 }
 
 func (q *Work) Prune(ctx context.Context) {
-	ctx, span := tracer.Start(ctx, "Prune")
+	_, span := tracer.Start(ctx, "Prune")
 	defer span.End()
 
 	q.mtx.Lock()
@@ -136,7 +136,7 @@ func (q *Work) Len() int {
 }
 
 func (q *Work) GetJobForWorker(ctx context.Context, workerID string) *Job {
-	ctx, span := tracer.Start(ctx, "GetJobForWorker")
+	_, span := tracer.Start(ctx, "GetJobForWorker")
 	defer span.End()
 
 	q.mtx.RLock()


### PR DESCRIPTION
**What this PR does**:

In order to get a better understanding of where the time is spent, here we add a few spans and a tracer on the work package.  Additionally, the main loop is no longer blocked measuring tenants to avoid an area where we do block handing out jobs, but the duration is unknown and unmeasured, which we try to rectify here.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`