### PR TITLE
Compaction provider improvements

### DIFF
--- a/modules/backendscheduler/provider/compaction.go
+++ b/modules/backendscheduler/provider/compaction.go
@@ -317,8 +317,11 @@ func (p *CompactionProvider) prioritizeTenants(ctx context.Context) {
 
 	for _, tenant := range tenants {
 		priority = ts.PriorityForTenant(tenant.ID)
-		item = tenantselector.NewItem(tenant.ID, priority)
-		heap.Push(p.curPriority, item)
+
+		if priority >= blockselector.DefaultMinInputBlocks {
+			item = tenantselector.NewItem(tenant.ID, priority)
+			heap.Push(p.curPriority, item)
+		}
 	}
 }
 

--- a/modules/backendscheduler/provider/compaction.go
+++ b/modules/backendscheduler/provider/compaction.go
@@ -123,11 +123,11 @@ func (p *CompactionProvider) Start(ctx context.Context) <-chan *work.Job {
 			}
 
 			if p.curSelector == nil {
+				b.Wait()
 				if !p.prepareNextTenant(loopCtx) {
 					level.Info(p.logger).Log("msg", "received empty tenant", "waiting", b.NextDelay())
 					metricTenantBackoff.Inc()
 					span.AddEvent("tenant not prepared")
-					b.Wait()
 				}
 				continue
 			}

--- a/modules/backendscheduler/provider/compaction.go
+++ b/modules/backendscheduler/provider/compaction.go
@@ -347,29 +347,19 @@ func (p *CompactionProvider) newBlockSelector(tenantID string) (blockselector.Co
 		blocklist     = make([]*backend.BlockMeta, 0, len(fullBlocklist))
 	)
 
-	// Query the work for the jobs and build up a list of UUIDs which we can match against.
+	// Query the work for the jobs and build up a list of UUIDs which we can match against and skip on the selector.
 	var (
 		perTenantBlockIDs = make(map[backend.UUID]struct{})
 		bid               backend.UUID
 		err               error
-
-		jobTenant string
-		jobType   tempopb.JobType
-		jobStatus tempopb.JobStatus
 	)
 
 	for _, job := range p.sched.ListJobs() {
-		jobTenant = job.Tenant()
-		if jobTenant != tenantID {
+		if job.Tenant() != tenantID {
 			continue
 		}
 
-		if jobType = job.GetType(); jobType == tempopb.JobType_JOB_TYPE_UNSPECIFIED {
-			continue
-		}
-
-		jobStatus = job.GetStatus()
-		if jobStatus != tempopb.JobStatus_JOB_STATUS_RUNNING && jobStatus != tempopb.JobStatus_JOB_STATUS_UNSPECIFIED {
+		if job.GetType() == tempopb.JobType_JOB_TYPE_UNSPECIFIED {
 			continue
 		}
 

--- a/modules/backendscheduler/provider/compaction_test.go
+++ b/modules/backendscheduler/provider/compaction_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/grafana/tempo/modules/backendscheduler/work"
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/modules/storage"
-	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/util/test"
 	"github.com/grafana/tempo/tempodb"

--- a/modules/backendscheduler/provider/compaction_test.go
+++ b/modules/backendscheduler/provider/compaction_test.go
@@ -8,9 +8,11 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/google/uuid"
 	"github.com/grafana/tempo/modules/backendscheduler/work"
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/modules/storage"
+	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/util/test"
 	"github.com/grafana/tempo/tempodb"
@@ -48,7 +50,7 @@ func TestCompactionProvider(t *testing.T) {
 
 	// Push some data to a few tenants
 	tenantCount := 3
-	for i := 0; i < tenantCount; i++ {
+	for i := range tenantCount {
 		testTenant := tenant + strconv.Itoa(i)
 		writeTenantBlocks(ctx, t, backend.NewWriter(ww), testTenant, 5)
 	}
@@ -80,11 +82,12 @@ func TestCompactionProvider(t *testing.T) {
 	for _, job := range receivedJobs {
 		require.NotNil(t, job)
 		require.Equal(t, tempopb.JobType_JOB_TYPE_COMPACTION, job.Type)
+		require.Greater(t, len(job.GetCompactionInput()), 0)
 		require.NotEqual(t, "", job.Tenant())
 		require.NotEqual(t, "", job.ID)
 
 		// Check that the newBlockSelector does not include the input blocks
-		for i := 0; i < tenantCount; i++ {
+		for i := range tenantCount {
 			testTenant := tenant + strconv.Itoa(i)
 			twbs, _ := p.newBlockSelector(testTenant)
 			require.NotNil(t, twbs)
@@ -96,16 +99,137 @@ func TestCompactionProvider(t *testing.T) {
 			require.Len(t, metas, 0)
 		}
 	}
-}
 
-func collectAllMetas(bs blockselector.CompactionBlockSelector) []*backend.BlockMeta {
-	metas, _ := bs.BlocksToCompact()
+	<-ctx.Done()
 
-	for newMetas, _ := bs.BlocksToCompact(); len(newMetas) > 0; {
-		metas = append(metas, newMetas...)
+	// Mark all tenant0 jobs as completed and set their output
+	for _, job := range receivedJobs {
+		if job.Tenant() == tenant+"0" {
+			job.Complete()
+			job.SetCompactionOutput([]string{
+				uuid.NewString(),
+				uuid.NewString(),
+				uuid.NewString(),
+				uuid.NewString(),
+			})
+		}
 	}
 
-	return metas
+	ctx = context.Background()
+
+	p.prioritizeTenants(ctx)
+	b := p.prepareNextTenant(ctx)
+	require.True(t, b)
+
+	items := p.curPriority.Items()
+	for _, item := range items {
+		require.NotEqual(t, item.Value(), tenant+"0", "tenant %s should not be selected for compaction after job completion", item.Value())
+	}
+
+	// Drain the selector
+
+	for blocks, _ := p.curSelector.BlocksToCompact(); len(blocks) > 0; {
+		blocks, _ = p.curSelector.BlocksToCompact()
+	}
+
+	require.NotNil(t, p.curSelector)
+	require.Len(t, p.curPriority.Items(), 0, "all tenants should be removed from the priority queue after compaction jobs are completed")
+
+	// Compact all the remaining tenants FOR NO REASON
+	for _, job := range receivedJobs {
+		if job.Tenant() == tenant+"0" {
+			job.Complete()
+		}
+	}
+}
+
+func TestCompactionProvider_EmptyStart(t *testing.T) {
+	cfg := CompactionConfig{}
+	cfg.RegisterFlagsAndApplyDefaults("", &flag.FlagSet{})
+	cfg.MaxJobsPerTenant = 1
+	cfg.MeasureInterval = 100 * time.Millisecond
+	cfg.Backoff.MinBackoff = 30 * time.Millisecond // twice the poll cycle
+	cfg.Backoff.MaxBackoff = 50 * time.Millisecond
+
+	tmpDir := t.TempDir()
+
+	var (
+		ctx, cancel  = context.WithTimeout(context.Background(), 5*time.Second)
+		store, _, ww = newStore(ctx, t, tmpDir)
+	)
+
+	defer func() {
+		cancel()
+		store.Shutdown()
+	}()
+
+	limits, err := overrides.NewOverrides(overrides.Config{Defaults: overrides.Overrides{}}, nil, prometheus.DefaultRegisterer)
+	require.NoError(t, err)
+
+	w := work.New(work.Config{})
+
+	p := NewCompactionProvider(
+		cfg,
+		test.NewTestingLogger(t),
+		store,
+		limits,
+		w,
+	)
+
+	b := p.prepareNextTenant(ctx)
+	require.False(t, b, "no tenant should be found")
+	require.Nil(t, p.curTenant, "a tenant should not be set")
+	require.Nil(t, p.curSelector, "a block selector should not be set")
+
+	writeTenantBlocks(ctx, t, backend.NewWriter(ww), tenant, 1)
+	time.Sleep(150 * time.Millisecond)
+
+	b = p.prepareNextTenant(ctx)
+	require.False(t, b, "no tenant with a single block should be found")
+	require.Nil(t, p.curTenant, "a tenant should not be set")
+	require.Nil(t, p.curSelector, "a block selector should not be set")
+
+	writeTenantBlocks(ctx, t, backend.NewWriter(ww), tenant, 1)
+	time.Sleep(150 * time.Millisecond)
+
+	b = p.prepareNextTenant(ctx)
+	require.True(t, b, "tenant with two blocks should be found")
+	require.NotNil(t, p.curTenant, "a tenant should be set")
+	require.NotNil(t, p.curSelector, "a block selector should be set")
+
+	jobChan := p.Start(ctx)
+	require.NotNil(t, jobChan, "job channel should not be nil")
+
+	blocksSeen := make(map[string]struct{})
+	var metas []*backend.BlockMeta
+
+	for job := range jobChan {
+		require.NotNil(t, job, "job should not be nil")
+		require.Equal(t, tempopb.JobType_JOB_TYPE_COMPACTION, job.Type, "job type should be compaction")
+		require.Equal(t, tenant, job.Tenant(), "job tenant should match the current tenant")
+		require.Greater(t, len(job.GetCompactionInput()), 0, "compaction input should not be empty")
+
+		metas = store.BlockMetas(tenant)
+
+		// Add each job to the work queue, so we don't process the blocks within.
+		err = w.AddJob(job)
+		require.NoError(t, err, "should be able to add job to work queue")
+
+		for _, blockID := range job.GetCompactionInput() {
+			_, seen := blocksSeen[blockID]
+			require.False(t, seen, "block ID %s should not have been seen before", blockID)
+			blocksSeen[blockID] = struct{}{}
+
+			u := backend.MustParse(blockID)
+			if _, ok := foundMetaInMetas(metas, u); ok {
+				// metas = append(metas, meta)
+				err = store.MarkBlockCompacted(tenant, u)
+				require.NoError(t, err, "should be able to mark block %s compacted for tenant %s", blockID, tenant)
+			}
+		}
+		require.Greater(t, len(metas), 0, "there should be some block metas to compact")
+
+	}
 }
 
 func newStore(ctx context.Context, t testing.TB, tmpDir string) (storage.Store, backend.RawReader, backend.RawWriter) {
@@ -147,10 +271,11 @@ func newStoreWithLogger(ctx context.Context, t testing.TB, log log.Logger, tmpDi
 
 func writeTenantBlocks(ctx context.Context, t *testing.T, w backend.Writer, tenant string, count int) {
 	var err error
-	for i := 0; i < count; i++ {
+	for range count {
 		meta := &backend.BlockMeta{
 			BlockID:  backend.NewUUID(),
 			TenantID: tenant,
+			Version:  encoding.LatestEncoding().Version(),
 		}
 
 		err = w.WriteBlockMeta(ctx, meta)
@@ -158,8 +283,27 @@ func writeTenantBlocks(ctx context.Context, t *testing.T, w backend.Writer, tena
 	}
 }
 
+func foundMetaInMetas(metas []*backend.BlockMeta, u backend.UUID) (*backend.BlockMeta, bool) {
+	for _, m := range metas {
+		if m.BlockID == u {
+			return m, true
+		}
+	}
+	return nil, false
+}
+
 type ownsEverythingSharder struct{}
 
 func (ownsEverythingSharder) Owns(_ string) bool {
 	return true
+}
+
+func collectAllMetas(bs blockselector.CompactionBlockSelector) []*backend.BlockMeta {
+	metas, _ := bs.BlocksToCompact()
+
+	for newMetas, _ := bs.BlocksToCompact(); len(newMetas) > 0; {
+		metas = append(metas, newMetas...)
+	}
+
+	return metas
 }


### PR DESCRIPTION
**What this PR does**:

Here we make a few small improvements to the compaction provider.
* skip tenants which have too low a priority to create a compaction job
* relocate a backoff to make testing easier and simplify
* allow jobs of any status which have input blocks to reduce what is visible to the block selector

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`