### PR TITLE
[Bugfix] Fix search by trace:id with short trace ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,13 @@
 * [ENHANCEMENT] Enable HTTP writes in the multi-tenant example [#5297](https://github.com/grafana/tempo/pull/5297)
 * [ENHANCEMENT] Drop invalid prometheus label names in spanmetrics processor [#5122](https://github.com/grafana/tempo/pull/5122) (@KyriosGN0)
 * [ENHANCEMENT] Added usage tracker example [#5356](https://github.com/grafana/tempo/pull/5356) (@javiermolinar)
+* [ENHANCEMENT] Add Stop method [#5293](https://github.com/grafana/tempo/pull/5293) (@stephanos)
 * [BUGFIX] Add nil check to partitionAssignmentVar [#5198](https://github.com/grafana/tempo/pull/5198) (@mapno)
 * [BUGFIX] Correct instant query calculation [#5252](https://github.com/grafana/tempo/pull/5252) (@ruslan-mikhailov)
 * [BUGFIX] Fix tracing context propagation in distributor HTTP write requests [#5312](https://github.com/grafana/tempo/pull/5312) (@mapno)
 * [BUGFIX] Correctly apply trace idle period in ingesters and add the concept of trace live period. [#5346](https://github.com/grafana/tempo/pull/5346/files) (@joe-elliott)
 * [BUGFIX] Fix invalid YAML output from /status/runtime_config endpoint by adding document separator. [#5146](https://github.com/grafana/tempo/issues/5146)
-* [ENHANCEMENT] Add Stop method [#5293](https://github.com/grafana/tempo/pull/5293) (@stephanos)
+* [BUGFIX] Fix search by trace:id with short trace ID [#5331](https://github.com/grafana/tempo/pull/5331) (@ruslan-mikhailov)
 
 # v2.8.1
 

--- a/pkg/parquetquery/predicates.gen.go
+++ b/pkg/parquetquery/predicates.gen.go
@@ -1021,7 +1021,7 @@ func (p ByteEqualPredicate) KeepPage(page pq.Page) bool {
 
 func (p ByteEqualPredicate) KeepValue(v pq.Value) bool {
 	vv := v.ByteArray()
-	return bytes.Equal(bytes.TrimLeft(vv, "\x00"), p.value)
+	return bytes.Equal(vv, p.value)
 }
 
 var _ Predicate = (*ByteNotEqualPredicate)(nil)
@@ -1072,5 +1072,5 @@ func (p ByteNotEqualPredicate) KeepPage(page pq.Page) bool {
 
 func (p ByteNotEqualPredicate) KeepValue(v pq.Value) bool {
 	vv := v.ByteArray()
-	return !bytes.Equal(bytes.TrimLeft(vv, "\x00"), p.value)
+	return !bytes.Equal(vv, p.value)
 }

--- a/pkg/parquetquerygen/predicates.go
+++ b/pkg/parquetquerygen/predicates.go
@@ -251,12 +251,12 @@ func (p {{ $structName }}) KeepValue(v pq.Value) bool {
 			Ops: []op{
 				{
 					Op:          "Equal",
-					CompareCond: `bytes.Equal(bytes.TrimLeft(vv, "\x00"), p.value)`,
+					CompareCond: `bytes.Equal(vv, p.value)`,
 					RangeCond:   "bytes.Compare(p.value, min) >= 0 && bytes.Compare(p.value, max) <= 0",
 				},
 				{
 					Op:          "NotEqual",
-					CompareCond: `!bytes.Equal(bytes.TrimLeft(vv, "\x00"), p.value)`,
+					CompareCond: `!bytes.Equal(vv, p.value)`,
 					RangeCond:   "!bytes.Equal(min, p.value) || !bytes.Equal(p.value, max)",
 				},
 			},

--- a/tempodb/encoding/vparquet2/block_traceql.go
+++ b/tempodb/encoding/vparquet2/block_traceql.go
@@ -1707,9 +1707,11 @@ func createBytesPredicate(op traceql.Operator, operands traceql.Operands, isSpan
 	}
 
 	var id []byte
-	id, err := util.HexStringToTraceID(s)
+	var err error
 	if isSpan {
 		id, err = util.HexStringToSpanID(s)
+	} else {
+		id, err = util.HexStringToTraceID(s)
 	}
 
 	if err != nil {

--- a/tempodb/encoding/vparquet2/block_traceql.go
+++ b/tempodb/encoding/vparquet2/block_traceql.go
@@ -1,7 +1,6 @@
 package vparquet2
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -1712,8 +1711,6 @@ func createBytesPredicate(op traceql.Operator, operands traceql.Operands, isSpan
 	if isSpan {
 		id, err = util.HexStringToSpanID(s)
 	}
-
-	id = bytes.TrimLeft(id, "\x00")
 
 	if err != nil {
 		return nil, nil

--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -2013,9 +2013,11 @@ func createBytesPredicate(op traceql.Operator, operands traceql.Operands, isSpan
 	}
 
 	var id []byte
-	id, err := util.HexStringToTraceID(s)
+	var err error
 	if isSpan {
 		id, err = util.HexStringToSpanID(s)
+	} else {
+		id, err = util.HexStringToTraceID(s)
 	}
 
 	if err != nil {

--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -1,7 +1,6 @@
 package vparquet3
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -2022,8 +2021,6 @@ func createBytesPredicate(op traceql.Operator, operands traceql.Operands, isSpan
 	if err != nil {
 		return nil, nil
 	}
-
-	id = bytes.TrimLeft(id, "\x00")
 
 	switch op {
 	case traceql.OpEqual:

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -2504,9 +2504,11 @@ func createBytesPredicate(op traceql.Operator, operands traceql.Operands, isSpan
 	}
 
 	var id []byte
-	id, err := util.HexStringToTraceID(s)
+	var err error
 	if isSpan {
 		id, err = util.HexStringToSpanID(s)
+	} else {
+		id, err = util.HexStringToTraceID(s)
 	}
 
 	if err != nil {

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -1784,7 +1784,7 @@ func createLinkIterator(makeIter makeIterFn, conditions []traceql.Condition, all
 			continue
 
 		case traceql.IntrinsicLinkSpanID:
-			pred, err := createBytesPredicate(cond.Op, cond.Operands, false)
+			pred, err := createBytesPredicate(cond.Op, cond.Operands, true)
 			if err != nil {
 				return nil, err
 			}

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -1,7 +1,6 @@
 package vparquet4
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -2513,8 +2512,6 @@ func createBytesPredicate(op traceql.Operator, operands traceql.Operands, isSpan
 	if err != nil {
 		return nil, nil
 	}
-
-	id = bytes.TrimLeft(id, "\x00")
 
 	switch op {
 	case traceql.OpEqual:

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -1867,7 +1867,7 @@ func runCompleteBlockSearchTest(t *testing.T, blockVersion string, runners ...ru
 	r.EnablePolling(ctx, &mockJobSharder{})
 	rw := r.(*readerWriter)
 
-	wantID, wantTr, start, end, wantMeta := makeExpectedTrace()
+	wantID, wantTr, start, end, wantMeta := makeExpectedTrace(nil)
 	searchesThatMatch, searchesThatDontMatch := searchTestSuite()
 
 	// Write to wal
@@ -1929,7 +1929,7 @@ func runEventLinkInstrumentationSearchTest(t *testing.T, blockVersion string) {
 	r.EnablePolling(ctx, &mockJobSharder{})
 	rw := r.(*readerWriter)
 
-	wantID, wantTr, start, end, wantMeta := makeExpectedTrace()
+	wantID, wantTr, start, end, wantMeta := makeExpectedTrace(nil)
 	wantIDText := util.TraceIDToHexString(wantID)
 
 	searchesThatMatch := []*tempopb.SearchRequest{
@@ -2095,13 +2095,17 @@ func addTraceQL(req *tempopb.SearchRequest) {
 //   - expected - The exact search result that should be returned for every matching request
 //   - searchesThatMatch - List of search requests that are expected to match the trace
 //   - searchesThatDontMatch - List of requests that don't match the trace
-func makeExpectedTrace() (
+func makeExpectedTrace(traceID []byte) (
 	id []byte,
 	tr *tempopb.Trace,
 	start, end uint32,
 	expected *tempopb.TraceSearchMetadata,
 ) {
-	id = test.ValidTraceID(nil)
+	if traceID == nil {
+		id = test.ValidTraceID(nil)
+	} else {
+		id = traceID
+	}
 
 	start = 1000
 	end = 1001

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -2641,7 +2641,7 @@ func TestSearchByShortTraceID(t *testing.T) {
 		dec := model.MustNewSegmentDecoder(model.CurrentEncoding)
 
 		totalTraces := 50
-		wantTrIdx := rand.Intn(totalTraces)
+		wantTrIdx := rand.Intn(totalTraces) // nolint:gosec // G404: Use of weak random number generator
 		for i := 0; i < totalTraces; i++ {
 			var tr *tempopb.Trace
 			var id []byte

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -192,6 +192,7 @@ func advancedTraceQLRunner(t *testing.T, wantTr *tempopb.Trace, wantMeta *tempop
 	}
 
 	searchesThatMatch := []*tempopb.SearchRequest{
+		{Query: "{}"},
 		// conditions
 		{Query: fmt.Sprintf("{%s && %s && %s && %s && %s}", rando(trueConditionsBySpan[0]), rando(trueConditionsBySpan[0]), rando(trueConditionsBySpan[0]), rando(trueConditionsBySpan[0]), rando(trueConditionsBySpan[0]))},
 		{Query: fmt.Sprintf("{%s || %s || %s || %s || %s}", rando(falseConditions), rando(falseConditions), rando(falseConditions), rando(trueConditionsBySpan[0]), rando(falseConditions))},

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -1836,6 +1836,13 @@ func testingConfig(dir string, version string, dc backend.DedicatedColumns) *Con
 	}
 }
 
+var testingCompactorConfig = &CompactorConfig{
+	ChunkSizeBytes:          10,
+	MaxCompactionRange:      time.Hour,
+	BlockRetention:          0,
+	CompactedBlockRetention: 0,
+}
+
 func runCompleteBlockSearchTest(t *testing.T, blockVersion string, runners ...runnerFn) {
 	// v2 doesn't support any search. just bail here before doing the work below to save resources
 	if blockVersion == v2.VersionString {
@@ -1853,12 +1860,7 @@ func runCompleteBlockSearchTest(t *testing.T, blockVersion string, runners ...ru
 	r, w, c, err := New(testingConfig(tempDir, blockVersion, dc), nil, log.NewNopLogger())
 	require.NoError(t, err)
 
-	err = c.EnableCompaction(context.Background(), &CompactorConfig{
-		ChunkSizeBytes:          10,
-		MaxCompactionRange:      time.Hour,
-		BlockRetention:          0,
-		CompactedBlockRetention: 0,
-	}, &mockSharder{}, &mockOverrides{})
+	err = c.EnableCompaction(context.Background(), testingCompactorConfig, &mockSharder{}, &mockOverrides{})
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -1920,12 +1922,7 @@ func runEventLinkInstrumentationSearchTest(t *testing.T, blockVersion string) {
 	r, w, c, err := New(testingConfig(tempDir, blockVersion, nil), nil, log.NewNopLogger())
 	require.NoError(t, err)
 
-	err = c.EnableCompaction(context.Background(), &CompactorConfig{
-		ChunkSizeBytes:          10,
-		MaxCompactionRange:      time.Hour,
-		BlockRetention:          0,
-		CompactedBlockRetention: 0,
-	}, &mockSharder{}, &mockOverrides{})
+	err = c.EnableCompaction(context.Background(), testingCompactorConfig, &mockSharder{}, &mockOverrides{})
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -2403,12 +2400,7 @@ func TestWALBlockGetMetrics(t *testing.T) {
 	r, w, c, err := New(testingConfig(tempDir, encoding.DefaultEncoding().Version(), nil), nil, log.NewNopLogger())
 	require.NoError(t, err)
 
-	err = c.EnableCompaction(context.Background(), &CompactorConfig{
-		ChunkSizeBytes:          10,
-		MaxCompactionRange:      time.Hour,
-		BlockRetention:          0,
-		CompactedBlockRetention: 0,
-	}, &mockSharder{}, &mockOverrides{})
+	err = c.EnableCompaction(context.Background(), testingCompactorConfig, &mockSharder{}, &mockOverrides{})
 	require.NoError(t, err)
 
 	r.EnablePolling(ctx, &mockJobSharder{})
@@ -2462,12 +2454,7 @@ func TestWALBlockGetMetrics(t *testing.T) {
 func TestSearchForTagsAndTagValues(t *testing.T) {
 	r, w, c, _ := testConfig(t, backend.EncGZIP, 0)
 
-	err := c.EnableCompaction(context.Background(), &CompactorConfig{
-		ChunkSizeBytes:          10,
-		MaxCompactionRange:      time.Hour,
-		BlockRetention:          0,
-		CompactedBlockRetention: 0,
-	}, &mockSharder{}, &mockOverrides{})
+	err := c.EnableCompaction(context.Background(), testingCompactorConfig, &mockSharder{}, &mockOverrides{})
 	require.NoError(t, err)
 
 	r.EnablePolling(context.Background(), &mockJobSharder{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Trace IDs are stored with leading zeros, no need to trim

1. Fixes search by short trace id in query: `{trace_id!="abc"}`. 
2. Fixes regression bug for search by `link:spanID`. The bug was hidden because with `bytes.TrimLeft(id, "\x00")` results after `HexStringToTraceID` and `HexStringToSpanID` were the same

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/tempo/issues/4437 and https://github.com/grafana/tempo/issues/4967

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`