### PR TITLE
[backend-scheduler] fix nil pointer on shutdown

### DIFF
--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -242,15 +242,15 @@ func (s *BackendScheduler) Next(ctx context.Context, req *tempopb.NextJobRequest
 	// Try to get a job from the merged channel
 	select {
 	case j := <-s.mergedJobs:
-		span.AddEvent("job received", trace.WithAttributes(
-			attribute.String("job_id", j.GetID()),
-		))
-
 		if j == nil {
 			// Channel closed, no jobs available
 			metricJobsNotFound.WithLabelValues(req.WorkerId).Inc()
 			return &tempopb.NextJobResponse{}, status.Error(codes.Internal, ErrNilJob.Error())
 		}
+
+		span.AddEvent("job received", trace.WithAttributes(
+			attribute.String("job_id", j.GetID()),
+		))
 
 		resp := &tempopb.NextJobResponse{
 			JobId:  j.ID,


### PR DESCRIPTION
**What this PR does**:
Fix a nil pointer in the scheduler, which was added as part of https://github.com/grafana/tempo/pull/5321 to include some instrumentation.  We only want to check the ID of the job if the job is not nil.  This only shows up on shutdown of the scheduler.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`