### PR TITLE
Restructure integration tests and consolidate target methods

### DIFF
--- a/integration/backendscheduler/backendscheduler_test.go
+++ b/integration/backendscheduler/backendscheduler_test.go
@@ -63,7 +63,7 @@ func TestBackendScheduler(t *testing.T) {
 	e := b.Endpoint(b.HTTPPort())
 	t.Logf("Endpoint: %s", e)
 
-	scheduler := util.NewTempoTarget("backend-scheduler")
+	scheduler := util.NewTempoTarget(util.TargetBackendScheduler)
 	require.NoError(t, s.StartAndWaitReady(scheduler))
 
 	// Setup tempodb with local backend
@@ -142,7 +142,7 @@ func TestBackendScheduler(t *testing.T) {
 
 	// Delay starting the work to ensure we have a clean state of the data before
 	// the worker starts processing jobs.
-	worker := util.NewTempoTarget("backend-worker")
+	worker := util.NewTempoTarget(util.TargetBackendWorker)
 	require.NoError(t, s.StartAndWaitReady(worker))
 
 	// Allow the worker some time to process the blocks.

--- a/integration/backendscheduler/backendscheduler_test.go
+++ b/integration/backendscheduler/backendscheduler_test.go
@@ -33,7 +33,7 @@ const (
 )
 
 func TestBackendScheduler(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	s, err := e2e.NewScenario("tempo-integration")
@@ -63,7 +63,7 @@ func TestBackendScheduler(t *testing.T) {
 	e := b.Endpoint(b.HTTPPort())
 	t.Logf("Endpoint: %s", e)
 
-	scheduler := util.NewTempoTarget("backend-scheduler", configFile)
+	scheduler := util.NewTempoTarget("backend-scheduler")
 	require.NoError(t, s.StartAndWaitReady(scheduler))
 
 	// Setup tempodb with local backend
@@ -142,7 +142,7 @@ func TestBackendScheduler(t *testing.T) {
 
 	// Delay starting the work to ensure we have a clean state of the data before
 	// the worker starts processing jobs.
-	worker := util.NewTempoTarget("backend-worker", configFile)
+	worker := util.NewTempoTarget("backend-worker")
 	require.NoError(t, s.StartAndWaitReady(worker))
 
 	// Allow the worker some time to process the blocks.

--- a/integration/e2e/deployments/microservices_test.go
+++ b/integration/e2e/deployments/microservices_test.go
@@ -83,13 +83,12 @@ func TestMicroservicesWithKVStores(t *testing.T) {
 			require.NotNil(t, minio)
 			require.NoError(t, s.StartAndWaitReady(minio))
 
-			tempoIngester1 := util.NewTempoIngester(1)
-			tempoIngester2 := util.NewTempoIngester(2)
-			tempoIngester3 := util.NewTempoIngester(3)
+			ingesters := util.NewTempoTargetReplicas(util.TargetIngester, 3, nil)
+			tempoIngester1, tempoIngester2, tempoIngester3 := ingesters[0], ingesters[1], ingesters[2]
 
-			tempoDistributor := util.NewTempoDistributor()
-			tempoQueryFrontend := util.NewTempoQueryFrontend()
-			tempoQuerier := util.NewTempoQuerier()
+			tempoDistributor := util.NewTempoTarget(util.TargetDistributor, 14250)
+			tempoQueryFrontend := util.NewTempoTarget(util.TargetQueryFrontend)
+			tempoQuerier := util.NewTempoTarget(util.TargetQuerier)
 			require.NoError(t, s.StartAndWaitReady(tempoIngester1, tempoIngester2, tempoIngester3, tempoDistributor, tempoQueryFrontend, tempoQuerier))
 
 			// wait for active ingesters

--- a/integration/e2e/metrics_generator_test.go
+++ b/integration/e2e/metrics_generator_test.go
@@ -32,9 +32,9 @@ func TestMetricsGenerator(t *testing.T) {
 	defer s.Close()
 
 	require.NoError(t, util.CopyFileToSharedDir(s, configMetricsGenerator, "config.yaml"))
-	tempoDistributor := util.NewTempoDistributor()
-	tempoIngester := util.NewTempoIngester(1)
-	tempoMetricsGenerator := util.NewTempoMetricsGenerator()
+	tempoDistributor := util.NewTempoTarget(util.TargetDistributor, 14250)
+	tempoIngester := util.NewTempoTarget(util.TargetIngester)
+	tempoMetricsGenerator := util.NewTempoTarget(util.TargetMetricsGenerator)
 	prometheus := util.NewPrometheus()
 	require.NoError(t, s.StartAndWaitReady(tempoDistributor, tempoIngester, tempoMetricsGenerator, prometheus))
 
@@ -221,9 +221,9 @@ func TestMetricsGeneratorTargetInfoEnabled(t *testing.T) {
 	defer s.Close()
 
 	require.NoError(t, util.CopyFileToSharedDir(s, configMetricsGeneratorTargetInfo, "config.yaml"))
-	tempoDistributor := util.NewTempoDistributor()
-	tempoIngester := util.NewTempoIngester(1)
-	tempoMetricsGenerator := util.NewTempoMetricsGenerator()
+	tempoDistributor := util.NewTempoTarget(util.TargetDistributor, 14250)
+	tempoIngester := util.NewTempoTarget(util.TargetIngester)
+	tempoMetricsGenerator := util.NewTempoTarget(util.TargetMetricsGenerator)
 	prometheus := util.NewPrometheus()
 	require.NoError(t, s.StartAndWaitReady(tempoDistributor, tempoIngester, tempoMetricsGenerator, prometheus))
 

--- a/integration/util/util.go
+++ b/integration/util/util.go
@@ -197,11 +197,11 @@ func NewTempoScalableSingleBinary(replica int, extraArgs ...string) *e2e.HTTPSer
 }
 
 func NewTempoTarget(target Target, extraPorts ...int) *e2e.HTTPService {
-	return NewTempoTargetNamed(target, target.String(), "config.yaml", nil, extraPorts)
+	return NewTempoTargetNamed(target, target.String(), nil, extraPorts)
 }
 
 func NewTempoTargetWithArgs(target Target, extraArgs []string, extraPorts ...int) *e2e.HTTPService {
-	return NewTempoTargetNamed(target, target.String(), "config.yaml", extraArgs, extraPorts)
+	return NewTempoTargetNamed(target, target.String(), extraArgs, extraPorts)
 }
 
 func NewTempoTargetReplicas(target Target, replicaCount int, extraArgs []string, extraPorts ...int) []*e2e.HTTPService {
@@ -209,13 +209,14 @@ func NewTempoTargetReplicas(target Target, replicaCount int, extraArgs []string,
 
 	for i := range replicaCount {
 		name := fmt.Sprintf("%s-%d", target, i)
-		replicas = append(replicas, NewTempoTargetNamed(target, name, "config.yaml", extraArgs, extraPorts))
+		replicas = append(replicas, NewTempoTargetNamed(target, name, extraArgs, extraPorts))
 	}
 
 	return replicas
 }
 
-func NewTempoTargetNamed(target Target, name string, configFile string, extraArgs []string, exraPorts []int) *e2e.HTTPService {
+func NewTempoTargetNamed(target Target, name string, extraArgs []string, exraPorts []int) *e2e.HTTPService {
+	configFile := "config.yaml"
 	args := []string{
 		"-config.file=" + filepath.Join(e2e.ContainerSharedDir, configFile),
 		"-target=" + target.String(),


### PR DESCRIPTION
**What this PR does**:

For each new tempo target, instead of creating new e2e methods to generate a target HTTP service, here I propose we consolidate this into a smaller set of methods to handle the common integration test cases where we need to create an instance of a tempo target.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`