### PR TITLE
fix: usage tracker docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [ENHANCEMENT] Align traceql attribute struct for better performance [#5240](https://github.com/grafana/tempo/pull/5240) (@mdisibio)
 * [ENHANCEMENT] Enable HTTP writes in the multi-tenant example [#5297](https://github.com/grafana/tempo/pull/5297)
 * [ENHANCEMENT] Drop invalid prometheus label names in spanmetrics processor [#5122](https://github.com/grafana/tempo/pull/5122) (@KyriosGN0)
+* [ENHANCEMENT] Added usage tracker example [#5356](https://github.com/grafana/tempo/pull/5356) (@javiermolinar)
 * [BUGFIX] Add nil check to partitionAssignmentVar [#5198](https://github.com/grafana/tempo/pull/5198) (@mapno)
 * [BUGFIX] Correct instant query calculation [#5252](https://github.com/grafana/tempo/pull/5252) (@ruslan-mikhailov)
 * [BUGFIX] Fix tracing context propagation in distributor HTTP write requests [#5312](https://github.com/grafana/tempo/pull/5312) (@mapno)

--- a/docs/sources/tempo/configuration/usage-tracker.md
+++ b/docs/sources/tempo/configuration/usage-tracker.md
@@ -49,7 +49,7 @@ overrides:
     # Cost attribution usage tracker configuration
     cost_attribution:
       dimensions:
-        - service.name
+        service.name: ""
 ```
 
 You can also configure per tenant in the [runtime-overrides](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#runtime-overrides) or in the [user-configurable-overrides](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#user-configurable-overrides).

--- a/example/docker-compose/local/docker-compose.yaml
+++ b/example/docker-compose/local/docker-compose.yaml
@@ -1,5 +1,4 @@
 services:
-
   # Tempo runs as user 10001, and docker compose creates the volume as root.
   # As such, we need to chown the volume in order for Tempo to start correctly.
   init:
@@ -18,22 +17,22 @@ services:
     ports:
       - "11211:11211"
     environment:
-      - MEMCACHED_MAX_MEMORY=64m  # Set the maximum memory usage
-      - MEMCACHED_THREADS=4       # Number of threads to use
+      - MEMCACHED_MAX_MEMORY=64m # Set the maximum memory usage
+      - MEMCACHED_THREADS=4 # Number of threads to use
 
   tempo:
     image: *tempoImage
-    command: [ "-config.file=/etc/tempo.yaml" ]
+    command: ["-config.file=/etc/tempo.yaml"]
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml
       - ./tempo-data:/var/tempo
     ports:
-      - "14268:14268"  # jaeger ingest
-      - "3200:3200"   # tempo
+      - "14268:14268" # jaeger ingest
+      - "3200:3200" # tempo
       - "9095:9095" # tempo grpc
-      - "4317:4317"  # otlp grpc
-      - "4318:4318"  # otlp http
-      - "9411:9411"   # zipkin
+      - "4317:4317" # otlp grpc
+      - "4318:4318" # otlp http
+      - "9411:9411" # zipkin
     depends_on:
       - init
       - memcached

--- a/example/docker-compose/local/tempo.yaml
+++ b/example/docker-compose/local/tempo.yaml
@@ -3,37 +3,39 @@ server:
   http_listen_port: 3200
   log_level: info
 
-
 cache:
   background:
     writeback_goroutines: 5
   caches:
-  - roles:
-    - frontend-search  
-    memcached: 
-      addresses: dns+memcached:11211
+    - roles:
+        - frontend-search
+      memcached:
+        addresses: dns+memcached:11211
 
 query_frontend:
   search:
     duration_slo: 5s
     throughput_bytes_slo: 1.073741824e+09
     metadata_slo:
-        duration_slo: 5s
-        throughput_bytes_slo: 1.073741824e+09
+      duration_slo: 5s
+      throughput_bytes_slo: 1.073741824e+09
   trace_by_id:
     duration_slo: 100ms
   metrics:
-    max_duration: 200h                # maximum duration of a metrics query, increase for local setups
+    max_duration: 200h # maximum duration of a metrics query, increase for local setups
     query_backend_after: 5m
     duration_slo: 5s
     throughput_bytes_slo: 1.073741824e+09
 
 distributor:
-  receivers:                           # this configuration will listen on all ports and protocols that tempo is capable of.
-    jaeger:                            # the receives all come from the OpenTelemetry collector.  more configuration information can
-      protocols:                       # be found there: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver
-        thrift_http:                   #
-          endpoint: "tempo:14268"      # for a production deployment you should only enable the receivers you need!
+  usage:
+    cost_attribution:
+      enabled: true
+  receivers: # this configuration will listen on all ports and protocols that tempo is capable of.
+    jaeger: # the receives all come from the OpenTelemetry collector.  more configuration information can
+      protocols: # be found there: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver
+        thrift_http: #
+          endpoint: "tempo:14268" # for a production deployment you should only enable the receivers you need!
         grpc:
           endpoint: "tempo:14250"
         thrift_binary:
@@ -52,11 +54,11 @@ distributor:
       endpoint: "tempo:55678"
 
 ingester:
-  max_block_duration: 5m               # cut the headblock when this much time passes. this is being set for demo purposes and should probably be left alone normally
+  max_block_duration: 5m # cut the headblock when this much time passes. this is being set for demo purposes and should probably be left alone normally
 
 compactor:
   compaction:
-    block_retention: 720h                # overall Tempo trace retention. set for demo purposes
+    block_retention: 720h # overall Tempo trace retention. set for demo purposes
 
 metrics_generator:
   registry:
@@ -77,15 +79,17 @@ metrics_generator:
 
 storage:
   trace:
-    backend: local                     # backend configuration to use
+    backend: local # backend configuration to use
     wal:
-      path: /var/tempo/wal             # where to store the wal locally
+      path: /var/tempo/wal # where to store the wal locally
     local:
       path: /var/tempo/blocks
 
 overrides:
   defaults:
+    cost_attribution:
+      dimensions:
+        service.name: ""
     metrics_generator:
       processors: [service-graphs, span-metrics, local-blocks] # enables metrics generator
       generate_native_histograms: both
-      

--- a/example/docker-compose/shared/tempo.yaml
+++ b/example/docker-compose/shared/tempo.yaml
@@ -8,8 +8,8 @@ query_frontend:
     duration_slo: 5s
     throughput_bytes_slo: 1.073741824e+09
     metadata_slo:
-        duration_slo: 5s
-        throughput_bytes_slo: 1.073741824e+09
+      duration_slo: 5s
+      throughput_bytes_slo: 1.073741824e+09
   trace_by_id:
     duration_slo: 5s
 
@@ -21,11 +21,11 @@ distributor:
           endpoint: "tempo:4317"
 
 ingester:
-  max_block_duration: 5m               # cut the headblock when this much time passes. this is being set for demo purposes and should probably be left alone normally
+  max_block_duration: 5m # cut the headblock when this much time passes. this is being set for demo purposes and should probably be left alone normally
 
 compactor:
   compaction:
-    block_retention: 1h                # overall Tempo trace retention. set for demo purposes
+    block_retention: 1h # overall Tempo trace retention. set for demo purposes
 
 metrics_generator:
   registry:
@@ -42,9 +42,9 @@ metrics_generator:
 
 storage:
   trace:
-    backend: local                     # backend configuration to use
+    backend: local # backend configuration to use
     wal:
-      path: /var/tempo/wal             # where to store the wal locally
+      path: /var/tempo/wal # where to store the wal locally
     local:
       path: /var/tempo/blocks
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

There was a bug in the documentation. 

The YAML should look like:

```yaml
myMap:
  key1: value1
  key2: value2
````

Previously it was:

```yaml
myMap:
  - key1: value1
  - key2: value2
```
This is a list of maps: []map[string]string, not a map[string]string.


I have also enabled cost attribution for the docker-compose local example


**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`