### PR TITLE
Update the bad overrides alert from warning to crit

### DIFF
--- a/operations/tempo-mixin/alerts.libsonnet
+++ b/operations/tempo-mixin/alerts.libsonnet
@@ -185,7 +185,7 @@
             ||| % [$._config.namespace, $._config.group_by_job],
             'for': '15m',
             labels: {
-              severity: 'warning',
+              severity: 'critical',
             },
             annotations: {
               message: '{{ $labels.job }} failed to reload overrides.',


### PR DESCRIPTION
Failing to load overrides should be rare and is almost always due to human error and should be resolved quickly.