### PR TITLE
feat(overrides): Add separator line in `WriteStatusRuntimeConfig` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [BUGFIX] Correct instant query calculation [#5252](https://github.com/grafana/tempo/pull/5252) (@ruslan-mikhailov)
 * [BUGFIX] Fix tracing context propagation in distributor HTTP write requests [#5312](https://github.com/grafana/tempo/pull/5312) (@mapno)
 * [BUGFIX] Correctly apply trace idle period in ingesters and add the concept of trace live period. [#5346](https://github.com/grafana/tempo/pull/5346/files) (@joe-elliott)
+* [BUGFIX] Fix invalid YAML output from /status/runtime_config endpoint by adding document separator. [#5146](https://github.com/grafana/tempo/issues/5146)
 * [ENHANCEMENT] Add Stop method [#5293](https://github.com/grafana/tempo/pull/5293) (@stephanos)
 
 # v2.8.1

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -263,6 +263,11 @@ func (o *runtimeConfigOverridesManager) WriteStatusRuntimeConfig(w io.Writer, r 
 		return err
 	}
 
+	_, err = w.Write([]byte("---\n"))
+	if err != nil {
+		return err
+	}
+
 	_, err = w.Write(out)
 	if err != nil {
 		return err

--- a/modules/overrides/runtime_config_overrides_test.go
+++ b/modules/overrides/runtime_config_overrides_test.go
@@ -548,6 +548,15 @@ func TestRemoteWriteHeaders(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	require.NoError(t, overrides.WriteStatusRuntimeConfig(buff, req))
 
+	// Verify the YAML output can be unmarshalled back
+	var runtimeConfig struct {
+		Defaults           Overrides          `yaml:"defaults"`
+		PerTenantOverrides perTenantOverrides `yaml:",inline"`
+	}
+	require.NoError(t, yaml.UnmarshalStrict(buff.Bytes(), &runtimeConfig))
+
+	assert.Equal(t, "<secret>", string(runtimeConfig.Defaults.MetricsGenerator.RemoteWriteHeaders["Authorization"]))
+
 	fmt.Println(buff.String())
 }
 

--- a/modules/overrides/user_configurable_overrides.go
+++ b/modules/overrides/user_configurable_overrides.go
@@ -357,6 +357,11 @@ func (o *userConfigurableOverridesManager) WriteStatusRuntimeConfig(w io.Writer,
 		return err
 	}
 
+	_, err = w.Write([]byte("---\n"))
+	if err != nil {
+		return err
+	}
+
 	_, err = w.Write(out)
 	if err != nil {
 		return err

--- a/modules/overrides/user_configurable_overrides_test.go
+++ b/modules/overrides/user_configurable_overrides_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 
 	userconfigurableoverrides "github.com/grafana/tempo/modules/overrides/userconfigurable/client"
 	tempo_api "github.com/grafana/tempo/pkg/api"
@@ -269,6 +270,13 @@ func TestUserConfigOverridesManager_WriteStatusRuntimeConfig(t *testing.T) {
 			data := w.Body.String()
 			require.Contains(t, data, "user_configurable_overrides")
 			require.Contains(t, data, "my-other-forwarder")
+
+			// Verify the YAML output can be unmarshalled back
+			var config map[string]interface{}
+			require.NoError(t, yaml.UnmarshalStrict(w.Body.Bytes(), &config))
+
+			require.Contains(t, config, "defaults")
+			require.Contains(t, config, "overrides")
 
 			res := w.Result()
 			require.Equal(t, "text/plain; charset=utf-8", res.Header.Get(tempo_api.HeaderContentType))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before
  submitting:

  1. Read our CONTRIBUTING.md guide
  2. Rebase your PR if it gets out of sync with main
  -->

**What this PR does**:
Adds the missing YAML document separator `---\n` to the `/status/runtime_config` endpoint output. This fixes invalid YAML that was causing validation failures with tools like `yq`.

**Which issue(s) this PR fixes**:
Fixes #5146

**Checklist**

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should
      be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`:

Notes:

- Tests updated: Existing tests pass and
  verify the YAML output now includes the separator
- Documentation added: Not needed - this is a bug fix that
  doesn't change user-facing functionality
- CHANGELOG.md: You should add an entry under [BUGFIX]
  section if there is one, something like:

* [BUGFIX] Fix invalid YAML output from
  /status/runtime_config endpoint by adding document
  separator. #5146
