### PR TITLE
Allow configuration of min/max input blocks for compaction provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [CHANGE] Adjust the definition of `tempo_metrics_generator_processor_service_graphs_expired_edges` to exclude edges that are counted in the service graph. [#5319](https://github.com/grafana/tempo/pull/5319) (@joe-elliott)
 * [CHANGE] Update Go to version 1.24.4 [#5323](https://github.com/grafana/tempo/pull/5323) (@stoewer)
 * [CHANGE] **BREAKING CHANGE** Drop unused `backend_scheduler.tenant_measurement_interval`, use `backend_scheduler.compaction.measure_interval` instead. [#5328](https://github.com/grafana/tempo/pull/5328) (@zalegrala)
+* [CHANGE] Allow configuration of min/max input blocks for compaction provider. [#5373](https://github.com/grafana/tempo/pull/5373) (@zalegrala)
 * [FEATURE] Add histograms `spans_distance_in_future_seconds` / `spans_distance_in_past_seconds` that count spans with end timestamp in the future / past. While spans in the future are accepted, they are invalid and may not be found using the Search API. [#4936](https://github.com/grafana/tempo/pull/4936) (@carles-grafana)
 * [FEATURE] Add counter `query_frontend_bytes_inspected_total`, which shows the total number of bytes read from disk and object storage [#5310](https://github.com/grafana/tempo/pull/5310) (@carles-grafana)
 * [ENHANCEMENT] Include backendwork dashboard and include additional alert [#5159](https://github.com/grafana/tempo/pull/5159) (@zalegrala)

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -1008,6 +1008,8 @@ backend_scheduler:
                 min_period: 100ms
                 max_period: 10s
                 max_retries: 0
+            min_input_blocks: 2
+            max_input_blocks: 4
     job_timeout: 15s
     local_work_path: /var/tempo
 backend_scheduler_client:


### PR DESCRIPTION
**What this PR does**:

With the new scheduled compactions, we're observing that jobs handed out in sequence of difficulty often mean that the jobs are too easy for workers to complete, which results in lower throughput because the scheduler has to spend more time scheduling and handling the jobs.  Eventually the jobs handed out are more difficult, but it can take some time before this happens, which results in a valley of low throughput.  This may happen at the beginning of working on a new tenant, for example, and in a large environment with many tenants, the performance is sub-optimal.  I believe this warrants an allowable configuration on the compaction provider, proposed here.

Historically, the min/max input blocks have been hard-coded to match the parquet version performance.  It would be easy to try and compact too many blocks and drive memory use while combining.  Looking at the memory and some recent improvements in the compaction process, I think we can begin to think about allowing this to be configurable.

Users should go slow and think hard about changing these defaults.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`