### PR TITLE
Service graph: Use peer attribute for client service virtual nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [ENHANCEMENT] Drop invalid prometheus label names in spanmetrics processor [#5122](https://github.com/grafana/tempo/pull/5122) (@KyriosGN0)
 * [ENHANCEMENT] Added usage tracker example [#5356](https://github.com/grafana/tempo/pull/5356) (@javiermolinar)
 * [ENHANCEMENT] Add Stop method [#5293](https://github.com/grafana/tempo/pull/5293) (@stephanos)
+* [ENHANCEMENT] Use peer attributes to determine the name of a client service virtual node in the service gra0ph [#5381](https://github.com/grafana/tempo/pull/5381) (@martenm)
 * [BUGFIX] Add nil check to partitionAssignmentVar [#5198](https://github.com/grafana/tempo/pull/5198) (@mapno)
 * [BUGFIX] Correct instant query calculation [#5252](https://github.com/grafana/tempo/pull/5252) (@ruslan-mikhailov)
 * [BUGFIX] Fix tracing context propagation in distributor HTTP write requests [#5312](https://github.com/grafana/tempo/pull/5312) (@mapno)

--- a/docs/sources/tempo/metrics-generator/service_graphs/_index.md
+++ b/docs/sources/tempo/metrics-generator/service_graphs/_index.md
@@ -51,7 +51,8 @@ For example, you might not collect spans for an external service for payment pro
 
 Virtual nodes can be detected in two different ways:
 
-- The root span has `span.kind` set to `server`. This indicates that the request has initiated by an external system that's not instrumented, like a frontend application or an engineer via `curl`.
+- The root span has `span.kind` set to `server` or `consumer`. This indicates that the request or message was initiated by an external system that's not instrumented, like a frontend application or an engineer via `curl`.
+   - When no service name can be inferred from the span peer attributes, the name of the service defaults to `user`.
 - A `client` span doesn't have its matching `server` span, but has a peer attribute present. In this case, assume that a call was made to an external service, for which Tempo won't receive spans.
    - The default peer attributes are `peer.service`, `db.name` and `db.system`.
    - The order of the attributes is important, as the first one is used as the virtual node name.

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -391,9 +391,16 @@ func (p *Processor) onExpire(e *store.Edge) {
 	if len(e.ClientService) == 0 {
 		// If the client service is not set, it means that the span could have been initiated by an external system,
 		// like a frontend application or an engineer via `curl`.
-		// We check if the span we have is the root span, and if so, we set the client service to "user".
+		// We check if the span we have is the root span, and if so, we set the client service appropriately.
 		if _, parentSpan := parseKey(e.Key()); len(parentSpan) == 0 {
-			e.ClientService = "user"
+
+			// If a peer attribute is present, it is used to name the external client service.
+			if len(e.PeerNode) > 0 {
+				e.ClientService = e.PeerNode
+			} else {
+				// Request came from an unknown source. No information inferred from the peer attributes.
+				e.ClientService = "user"
+			}
 
 			if p.Cfg.EnableVirtualNodeLabel {
 				e.Dimensions[virtualNodeLabel] = "client"

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -264,12 +264,21 @@ func TestServiceGraphs_virtualNodes(t *testing.T) {
 		"connection_type": "virtual_node",
 	})
 
+	virtualProducerToConsumer := labels.FromMap(map[string]string{
+		"client":          "external-producer",
+		"server":          "internal-consumer",
+		"connection_type": "virtual_node",
+	})
+
 	// counters
 	assert.Equal(t, 1.0, testRegistry.Query(`traces_service_graph_request_total`, userToServerLabels))
 	assert.Equal(t, 0.0, testRegistry.Query(`traces_service_graph_request_failed_total`, userToServerLabels))
 
 	assert.Equal(t, 1.0, testRegistry.Query(`traces_service_graph_request_total`, clientToVirtualPeerLabels))
 	assert.Equal(t, 0.0, testRegistry.Query(`traces_service_graph_request_failed_total`, clientToVirtualPeerLabels))
+
+	assert.Equal(t, 1.0, testRegistry.Query(`traces_service_graph_request_total`, virtualProducerToConsumer))
+	assert.Equal(t, 0.0, testRegistry.Query(`traces_service_graph_request_failed_total`, virtualProducerToConsumer))
 }
 
 func TestServiceGraphs_virtualNodesExtraLabelsForUninstrumentedServices(t *testing.T) {

--- a/modules/generator/processor/servicegraphs/testdata/trace-with-virtual-nodes.json
+++ b/modules/generator/processor/servicegraphs/testdata/trace-with-virtual-nodes.json
@@ -79,6 +79,45 @@
           ]
         }
       ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "internal-consumer"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "q0o5CtL+O4U0QEyfciOjkA==",
+              "spanId": "TZs4v7dQT40=",
+              "name": "Consumed",
+              "kind": "SPAN_KIND_CONSUMER",
+              "startTimeUnixNano": "1658320854877839616",
+              "endTimeUnixNano": "1658320854878545408",
+              "attributes": [
+                {
+                  "key": "peer.service",
+                  "value": {
+                    "stringValue": "external-producer"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
**What this PR does**:
This PR gives client service virtual nodes a more descriptive name when a peer attribute is present in the received span.

**Which issue(s) this PR fixes**:
Related to #5268

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`