### PR TITLE
[backend-scheduler] fix duplicate work handout during race

### DIFF
--- a/modules/backendscheduler/error.go
+++ b/modules/backendscheduler/error.go
@@ -3,7 +3,8 @@ package backendscheduler
 import "errors"
 
 var (
-	ErrFlushFailed = errors.New("failed to flush cache to store")
-	ErrNoJobsFound = errors.New("no jobs found")
-	ErrNilJob      = errors.New("nil job received")
+	ErrFlushFailed    = errors.New("failed to flush cache to store")
+	ErrNoJobsFound    = errors.New("no jobs found")
+	ErrNilJob         = errors.New("nil job received")
+	ErrDuplicateBlock = errors.New("duplicate block received")
 )

--- a/modules/backendscheduler/metrics.go
+++ b/modules/backendscheduler/metrics.go
@@ -38,6 +38,11 @@ var (
 		Name:      "backend_scheduler_jobs_not_found_total",
 		Help:      "The number of calls to get a job that were not found",
 	}, []string{"worker_id"})
+	metricJobsRejectedDuplicate = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "tempo",
+		Name:      "backend_scheduler_jobs_rejected_duplicate_total",
+		Help:      "The number of jobs rejected due to overlapping compaction blocks",
+	}, []string{"tenant"})
 	metricProviderJobsMerged = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "tempo",
 		Name:      "backend_scheduler_provider_jobs_merged_total",


### PR DESCRIPTION
**What this PR does**:

A race exists between the compaction provider and the Next call of the scheduler where the provider may detect the same block IDs for a job for which the cache has not yet been updated.  This results in the failed jobs and duplicate data in the backend due to two compactions happening on the same blocks.

Here we work around the race by checking the work list right before a job is handed out to a worker to ensure that we have not already assigned a job with the same block IDs.  This does not solve the underlying race, but prevents the conditions whereby this becomes a problem.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`