### PR TITLE
[backend-scheduler] fix race condition between scheduler and compaction provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Additionally the `compaction_tenant_backoff_total` metric has been renamed to `c
 * [BUGFIX] Correctly apply trace idle period in ingesters and add the concept of trace live period. [#5346](https://github.com/grafana/tempo/pull/5346/files) (@joe-elliott)
 * [BUGFIX] Fix invalid YAML output from /status/runtime_config endpoint by adding document separator. [#5146](https://github.com/grafana/tempo/issues/5146)
 * [BUGFIX] Fix search by trace:id with short trace ID [#5331](https://github.com/grafana/tempo/pull/5331) (@ruslan-mikhailov)
+* [BUGFIX] Fix race condition between compaction provider and backend-scheduler [#5409](https://github.com/grafana/tempo/pull/5409) (@zalegrala)
 
 # v2.8.1
 

--- a/cmd/tempo/app/config.go
+++ b/cmd/tempo/app/config.go
@@ -174,6 +174,10 @@ func (c *Config) CheckConfig() []ConfigWarning {
 		warnings = append(warnings, warnBlocklistPollConcurrency)
 	}
 
+	if c.BackendScheduler.Work.PruneAge <= (c.StorageConfig.Trace.BlocklistPoll * 2) {
+		warnings = append(warnings, warnBackendSchedulerPruneAgeLessThanBlocklistPoll)
+	}
+
 	if c.Distributor.LogReceivedSpans.Enabled {
 		warnings = append(warnings, warnLogReceivedTraces)
 	}
@@ -315,6 +319,11 @@ var (
 	warnMCPServerEnabled = ConfigWarning{
 		Message: "c.Frontend.MCPServer.Enabled is enabled.",
 		Explain: "Querying Tempo with an LLM will result in tracing data being sent to the LLM. Review your LLM provider's documentation and confirm you are comfortable with this.",
+	}
+
+	warnBackendSchedulerPruneAgeLessThanBlocklistPoll = ConfigWarning{
+		Message: "c.BackendScheduler.Work.PruneAge must be greater than 2x the storage.trace.blocklist_poll duration",
+		Explain: "The backend scheduler needs not to prune work faster than the block list poll duration to avoid losing track of blocks which may have been have been compacted, but whose status has not been rediscovered during polling.",
 	}
 )
 

--- a/cmd/tempo/app/config.go
+++ b/cmd/tempo/app/config.go
@@ -174,10 +174,6 @@ func (c *Config) CheckConfig() []ConfigWarning {
 		warnings = append(warnings, warnBlocklistPollConcurrency)
 	}
 
-	if c.BackendScheduler.Work.PruneAge <= (c.StorageConfig.Trace.BlocklistPoll * 2) {
-		warnings = append(warnings, warnBackendSchedulerPruneAgeLessThanBlocklistPoll)
-	}
-
 	if c.Distributor.LogReceivedSpans.Enabled {
 		warnings = append(warnings, warnLogReceivedTraces)
 	}
@@ -247,6 +243,10 @@ func (c *Config) CheckConfig() []ConfigWarning {
 
 	if c.BlockBuilder.BlockConfig.BlockCfg.Version != c.BlockBuilder.WAL.Version {
 		warnings = append(warnings, warnBlockAndWALVersionMismatch)
+	}
+
+	if c.BackendScheduler.Work.PruneAge <= (c.StorageConfig.Trace.BlocklistPoll * 2) {
+		warnings = append(warnings, warnBackendSchedulerPruneAgeLessThanBlocklistPoll)
 	}
 
 	return warnings

--- a/cmd/tempo/app/config_test.go
+++ b/cmd/tempo/app/config_test.go
@@ -75,6 +75,7 @@ func TestConfig_CheckConfig(t *testing.T) {
 				warnNativeAWSAuthEnabled,
 				warnConfiguredLegacyCache,
 				warnTraceByIDConcurrentShards,
+				warnBackendSchedulerPruneAgeLessThanBlocklistPoll,
 			},
 		},
 		{

--- a/integration/backendscheduler/backendscheduler_test.go
+++ b/integration/backendscheduler/backendscheduler_test.go
@@ -145,21 +145,18 @@ func TestBackendScheduler(t *testing.T) {
 	// - one between the provider pull and the scheduler push
 	// - one in the merged channel
 
-	// NOTE: Since the measurement of outstanding blocks also skips the
-	// blocks from jobs which have not been processed, we expect our
-	// outstanding blocks to be N - 16, where N is the actual outstanding
-	// blocks minus 4 blocks per job for those which are on the way to the
-	// scheduler.  The order of tenants is non-defined when all tenants have
-	// the same block count, so we don't know which tenant will be first.
-	// Measure total outstanding blocks instead of per tenant for this
-	// reason.
+	// NOTE: Since the measurement of outstanding blocks also skips the blocks
+	// from jobs which have not been processed, we expect our outstanding blocks
+	// to be N-M, where N is the actual outstanding blocks and M is the number of
+	// blocks attached to jobs which have not been recorded by the scheduler. The
+	// order of tenants is non-defined when all tenants have the same block
+	// count, so we don't know which tenant will be first. Measure total
+	// outstanding blocks instead of per tenant for this reason.
 
-	// NOTE: Due to timing of the and window selection, we may not fully populate
-	// a job, and we may end up with jobs which between 2 and 4 blocks
-	// outstanding.  This means that for the four jobs not yet recorded, we
-	// should expect to have between 6 and 16 blocks short of the actual
-	// outstanding count.
-
+	// NOTE: Due to timing and window selection, we may not fully populate a job,
+	// and we may end up with jobs which between 2 and 4 blocks outstanding.
+	// - 4 jobs not yet recorded by the scheduler (no worker running yet)
+	// - between 2 and 4 blocks per job (default settings)
 	expectedTotalOutstandingMin := totalOutstanding - 16
 	expectedTotalOutstandingMax := totalOutstanding - 8
 

--- a/integration/backendscheduler/backendscheduler_test.go
+++ b/integration/backendscheduler/backendscheduler_test.go
@@ -138,15 +138,16 @@ func TestBackendScheduler(t *testing.T) {
 
 	// NOTE: the compaction provider has a channel capacity of 1, and the
 	// backendscheduler has a channel capacity of 1.  This means that the
-	// compaction provider can create 3 jobs before they are processed in the
+	// compaction provider can create 4 jobs before they are processed in the
 	// Next call of the scheduler.
-	// - one in the merged channel
+	// - one recorded before pushing into the compaction provider channel
 	// - one in the compaction provider channel
 	// - one between the provider pull and the scheduler push
+	// - one in the merged channel
 
 	// NOTE: Since the measurement of outstanding blocks also skips the
 	// blocks from jobs which have not been processed, we expect our
-	// outstanding blocks to be N - 12, where N is the actual outstanding
+	// outstanding blocks to be N - 16, where N is the actual outstanding
 	// blocks minus 4 blocks per job for those which are on the way to the
 	// scheduler.  The order of tenants is non-defined when all tenants have
 	// the same block count, so we don't know which tenant will be first.
@@ -155,12 +156,12 @@ func TestBackendScheduler(t *testing.T) {
 
 	// NOTE: Due to timing of the and window selection, we may not fully populate
 	// a job, and we may end up with jobs which between 2 and 4 blocks
-	// outstanding.  This means that for the three jobs not yet recorded, we
-	// should expect to have between 6 and 12 blocks short of the actual
+	// outstanding.  This means that for the four jobs not yet recorded, we
+	// should expect to have between 6 and 16 blocks short of the actual
 	// outstanding count.
 
-	expectedTotalOutstandingMin := totalOutstanding - 12
-	expectedTotalOutstandingMax := totalOutstanding - 6
+	expectedTotalOutstandingMin := totalOutstanding - 16
+	expectedTotalOutstandingMax := totalOutstanding - 8
 
 	outstanding, err := scheduler.SumMetrics([]string{"tempodb_compaction_outstanding_blocks"})
 	require.NoError(t, err)

--- a/integration/backendscheduler/backendscheduler_test.go
+++ b/integration/backendscheduler/backendscheduler_test.go
@@ -134,7 +134,7 @@ func TestBackendScheduler(t *testing.T) {
 		})
 	}
 
-	time.Sleep(5 * time.Second) // Wait for polling and measurement to catch up
+	time.Sleep(8 * time.Second) // Wait for polling and measurement to catch up
 
 	// NOTE: the compaction provider has a channel capacity of 1, and the
 	// backendscheduler has a channel capacity of 1.  This means that the

--- a/integration/backendscheduler/backendscheduler_test.go
+++ b/integration/backendscheduler/backendscheduler_test.go
@@ -101,6 +101,7 @@ func TestBackendScheduler(t *testing.T) {
 	// We continue to write blocks through these tests, so our expectations need
 	// to grow as well.
 	accumulant := make(map[string]*expectations)
+	totalOutstanding := 0
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -120,25 +121,55 @@ func TestBackendScheduler(t *testing.T) {
 
 				expectedBlocks := accumulant[tenant].blocks
 				expectedOutstanding := accumulant[tenant].outstanding
+				totalOutstanding += expectedOutstanding
 
 				t.Logf("Waiting for %d blocks in the blocklist for tenant: %s", expectedBlocks, tenantID)
 
 				require.NoError(t, scheduler.WaitSumMetricsWithOptions(e2e.Equals(float64(expectedBlocks)), []string{"tempodb_blocklist_length"},
 					e2e.WaitMissingMetrics,
 					tenantMatcher,
-					printMetricValue(t),
-				))
-
-				t.Logf("Waiting for %d outstanding blocks for tenant: %s", expectedOutstanding, tenantID)
-
-				require.NoError(t, scheduler.WaitSumMetricsWithOptions(e2e.Equals(float64(expectedOutstanding)), []string{"tempodb_compaction_outstanding_blocks"},
-					e2e.WaitMissingMetrics,
-					tenantMatcher,
-					printMetricValue(t),
+					printMetricValue(t, fmt.Sprintf("%d", expectedBlocks), "tempodb_blocklist_length"),
 				))
 			}
 		})
 	}
+
+	time.Sleep(5 * time.Second) // Wait for polling and measurement to catch up
+
+	// NOTE: the compaction provider has a channel capacity of 1, and the
+	// backendscheduler has a channel capacity of 1.  This means that the
+	// compaction provider can create 3 jobs before they are processed in the
+	// Next call of the scheduler.
+	// - one in the merged channel
+	// - one in the compaction provider channel
+	// - one between the provider pull and the scheduler push
+
+	// NOTE: Since the measurement of outstanding blocks also skips the
+	// blocks from jobs which have not been processed, we expect our
+	// outstanding blocks to be N - 12, where N is the actual outstanding
+	// blocks minus 4 blocks per job for those which are on the way to the
+	// scheduler.  The order of tenants is non-defined when all tenants have
+	// the same block count, so we don't know which tenant will be first.
+	// Measure total outstanding blocks instead of per tenant for this
+	// reason.
+
+	// NOTE: Due to timing of the and window selection, we may not fully populate
+	// a job, and we may end up with jobs which between 2 and 4 blocks
+	// outstanding.  This means that for the three jobs not yet recorded, we
+	// should expect to have between 6 and 12 blocks short of the actual
+	// outstanding count.
+
+	expectedTotalOutstandingMin := totalOutstanding - 12
+	expectedTotalOutstandingMax := totalOutstanding - 6
+
+	outstanding, err := scheduler.SumMetrics([]string{"tempodb_compaction_outstanding_blocks"})
+	require.NoError(t, err)
+	require.Len(t, outstanding, 1, "expected only one outstanding block metric")
+	t.Logf("Total outstanding blocks: %f", outstanding[0])
+	t.Logf("Expected outstanding blocks range: [%d, %d]", expectedTotalOutstandingMin, expectedTotalOutstandingMax)
+	t.Logf("Total outstanding blocks: %d", totalOutstanding)
+	require.LessOrEqual(t, outstanding[0], float64(expectedTotalOutstandingMax), "unexpected maximum outstanding blocks count")
+	require.GreaterOrEqual(t, outstanding[0], float64(expectedTotalOutstandingMin), "unexpected minimum outstanding blocks count")
 
 	// Delay starting the work to ensure we have a clean state of the data before
 	// the worker starts processing jobs.
@@ -152,43 +183,52 @@ func TestBackendScheduler(t *testing.T) {
 		t.Run(fmt.Sprintf("work-finished-check-wait-%s", tenantID), func(t *testing.T) {
 			tenantMatcher := e2e.WithLabelMatchers(&labels.Matcher{Type: labels.MatchEqual, Name: "tenant", Value: tenantID})
 
-			require.NoError(t, scheduler.WaitSumMetricsWithOptions(e2e.Equals(float64(2)), []string{"tempodb_blocklist_length"},
+			// Due to timing, we may have 2 or three blocks per tenant
+			require.NoError(t, scheduler.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(float64(2)), []string{"tempodb_blocklist_length"},
 				e2e.WaitMissingMetrics,
 				tenantMatcher,
-				printMetricValue(t),
+				printMetricValue(t, fmt.Sprintf("%d+", 2), "tempodb_blocklist_length"),
 			))
 		})
 	}
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	// Stop the worker to ensure it is not running while we check the metrics.
 	require.NoError(t, s.Stop(worker))
 
-	// each tenant has the same expectations
-	expected := &expectations{
+	// Some variance in the number of expected due to the notes above.  We should
+	// expect that a fully compacted tenant has between 2 and 4 blocks, and
+	// between 0 and 1 outstanding blocks.  The sleep above should be enough to
+	// allow the worker to finish processing all the outstanding blocks.
+	expectedMin := &expectations{
 		blocks:      2,
-		outstanding: 0, // two blocks remain, but their group is not the same, and so they will not be compacted together.
+		outstanding: 0,
+	}
+
+	expectedMax := &expectations{
+		blocks:      4,
+		outstanding: 1,
 	}
 
 	for _, tenantID := range tenants {
 		t.Run(fmt.Sprintf("prestop-check-%s", tenantID), func(t *testing.T) {
 			tenantMatcher := e2e.WithLabelMatchers(&labels.Matcher{Type: labels.MatchEqual, Name: "tenant", Value: tenantID})
 
-			t.Logf("Waiting for blocklist metric: %s: %d", tenantID, expected.blocks)
+			t.Logf("Waiting for blocklist metric: %s: %d-%d", tenantID, expectedMin.blocks, expectedMax.blocks)
 
-			require.NoError(t, scheduler.WaitSumMetricsWithOptions(e2e.Equals(float64(expected.blocks)), []string{"tempodb_blocklist_length"},
+			require.NoError(t, scheduler.WaitSumMetricsWithOptions(e2e.Between(float64(expectedMin.blocks), float64(expectedMax.blocks)), []string{"tempodb_blocklist_length"},
 				e2e.WaitMissingMetrics,
 				tenantMatcher,
-				printMetricValue(t),
+				printMetricValue(t, fmt.Sprintf("%d-%d", expectedMin.blocks, expectedMax.blocks), "tempodb_blocklist_length"),
 			))
 
-			t.Logf("Waiting for outstanding blocks metric: %s: %d", tenantID, expected.outstanding)
+			t.Logf("Waiting for outstanding blocks metric: %s: %d-%d", tenantID, expectedMin.outstanding, expectedMax.outstanding)
 
-			require.NoError(t, scheduler.WaitSumMetricsWithOptions(e2e.Equals(float64(expected.outstanding)), []string{"tempodb_compaction_outstanding_blocks"},
+			require.NoError(t, scheduler.WaitSumMetricsWithOptions(e2e.Between(float64(expectedMin.outstanding), float64(expectedMax.outstanding)), []string{"tempodb_compaction_outstanding_blocks"},
 				e2e.WaitMissingMetrics,
 				tenantMatcher,
-				printMetricValue(t),
+				printMetricValue(t, fmt.Sprintf("%d-%d", expectedMin.outstanding, expectedMax.outstanding), "tempodb_compaction_outstanding_blocks"),
 			))
 		})
 	}
@@ -205,38 +245,36 @@ func TestBackendScheduler(t *testing.T) {
 		t.Run(fmt.Sprintf("final-check-%s", tenantID), func(t *testing.T) {
 			tenantMatcher := e2e.WithLabelMatchers(&labels.Matcher{Type: labels.MatchEqual, Name: "tenant", Value: tenantID})
 
-			t.Logf("Waiting for blocklist metric: %s: %d", tenantID, expected.blocks)
+			t.Logf("Waiting for blocklist metric: %s: %d-%d", tenantID, expectedMin.blocks, expectedMax.blocks)
 
-			require.NoError(t, scheduler.WaitSumMetricsWithOptions(e2e.Equals(float64(expected.blocks)), []string{"tempodb_blocklist_length"},
+			require.NoError(t, scheduler.WaitSumMetricsWithOptions(e2e.Between(float64(expectedMin.blocks), float64(expectedMax.blocks)), []string{"tempodb_blocklist_length"},
 				e2e.WaitMissingMetrics,
 				tenantMatcher,
-				printMetricValue(t),
+				printMetricValue(t, fmt.Sprintf("%d-%d", expectedMin.blocks, expectedMax.blocks), "tempodb_blocklist_length"),
 			))
 
-			t.Logf("Waiting for outstanding blocks metric: %s: %d", tenantID, expected.outstanding)
+			t.Logf("Waiting for outstanding blocks metric: %s: %d-%d", tenantID, expectedMin.outstanding, expectedMax.outstanding)
 
-			require.NoError(t, scheduler.WaitSumMetricsWithOptions(e2e.Equals(float64(expected.outstanding)), []string{"tempodb_compaction_outstanding_blocks"},
+			require.NoError(t, scheduler.WaitSumMetricsWithOptions(e2e.Between(float64(expectedMin.outstanding), float64(expectedMax.outstanding)), []string{"tempodb_compaction_outstanding_blocks"},
 				e2e.WaitMissingMetrics,
 				tenantMatcher,
-				printMetricValue(t),
+				printMetricValue(t, fmt.Sprintf("%d-%d", expectedMin.outstanding, expectedMax.outstanding), "tempodb_compaction_outstanding_blocks"),
 			))
 		})
 	}
-
-	// Check some additional metrics to ensure the scheduler is working properly.
 }
 
-func printValues(t *testing.T) e2e.GetMetricValueFunc {
+func printValues(t *testing.T, expected string, metric string) e2e.GetMetricValueFunc {
 	return func(m *io_prometheus_client.Metric) float64 {
 		v := e2e.DefaultMetricsOptions.GetValue(m)
-		t.Logf("metric %q: %f", m.GetLabel()[0].GetValue(), v)
+		t.Logf("metric %q: label %q: current %f, expected %s", metric, m.GetLabel()[0].GetValue(), v, expected)
 		return v
 	}
 }
 
-func printMetricValue(t *testing.T) e2e.MetricsOption {
+func printMetricValue(t *testing.T, expectedValue string, metric string) e2e.MetricsOption {
 	return func(opts *e2e.MetricsOptions) {
-		opts.GetValue = printValues(t)
+		opts.GetValue = printValues(t, expectedValue, metric)
 	}
 }
 

--- a/integration/backendscheduler/config.yaml
+++ b/integration/backendscheduler/config.yaml
@@ -37,6 +37,7 @@ storage:
 backend_scheduler:
   provider:
     compaction:
+      min_cycle_interval: 50ms
       measure_interval: 1s
 backend_worker:
   backend_scheduler_addr: tempo-integration-backend-scheduler:9095

--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -116,9 +116,6 @@ func (s *BackendScheduler) starting(ctx context.Context) error {
 		return fmt.Errorf("failed to load work cache: %w", err)
 	}
 
-	// Start providers and collect job channels
-	s.mergedJobs = make(chan *work.Job, len(s.providers))
-
 	wg := sync.WaitGroup{}
 
 	for i := range s.providers {

--- a/modules/backendscheduler/config.go
+++ b/modules/backendscheduler/config.go
@@ -2,6 +2,7 @@ package backendscheduler
 
 import (
 	"flag"
+	"fmt"
 	"time"
 
 	"github.com/grafana/tempo/modules/backendscheduler/provider"
@@ -40,6 +41,15 @@ func ValidateConfig(cfg *Config) error {
 
 	if err := provider.ValidateConfig(&cfg.ProviderConfig); err != nil {
 		return err
+	}
+
+	// Validate the measurement interval is twice the speed of the prune interval
+	// so that the when newBlockSelector is called it has enough time to delete
+	// the temporary entry and know that it has been persisted to the work cache.
+	// If the prune age is too short, work could get deleted before the
+	// newBlockSelector is able to delete the temporary entry.
+	if cfg.ProviderConfig.Compaction.MeasureInterval > cfg.Work.PruneAge/2 {
+		return fmt.Errorf("provider.compaction.measure_interval must be at least twice the work.prune_age, got %s and %s", cfg.ProviderConfig.Compaction.MeasureInterval, cfg.Work.PruneAge/2)
 	}
 
 	return nil

--- a/modules/backendscheduler/config.go
+++ b/modules/backendscheduler/config.go
@@ -49,7 +49,7 @@ func ValidateConfig(cfg *Config) error {
 	// If the prune age is too short, work could get deleted before the
 	// newBlockSelector is able to delete the temporary entry.
 	if cfg.ProviderConfig.Compaction.MeasureInterval > cfg.Work.PruneAge/2 {
-		return fmt.Errorf("provider.compaction.measure_interval must be at least twice the work.prune_age, got %s and %s", cfg.ProviderConfig.Compaction.MeasureInterval, cfg.Work.PruneAge/2)
+		return fmt.Errorf("provider.compaction.measure_interval must be no more than half of work.prune_age; tenant measurement should happen at least twice as often as the work prune, got %s and %s", cfg.ProviderConfig.Compaction.MeasureInterval, cfg.Work.PruneAge/2)
 	}
 
 	return nil

--- a/modules/backendscheduler/provider/compaction.go
+++ b/modules/backendscheduler/provider/compaction.go
@@ -416,12 +416,10 @@ func (p *CompactionProvider) newBlockSelector(tenantID string) (blockselector.Co
 	p.outstandingJobsMtx.Unlock()
 
 	for _, block := range fullBlocklist {
-		if _, ok := inProgressBlockIDs[block.BlockID]; ok {
-			// Skip blocks that are already in the input list from another job or recent jobs
-			continue
+		if _, ok := inProgressBlockIDs[block.BlockID]; !ok {
+			// Include blocks that are not already in the input list from another job or recent jobs
+			blocklist = append(blocklist, block)
 		}
-
-		blocklist = append(blocklist, block)
 	}
 
 	if window == 0 {

--- a/modules/backendscheduler/provider/compaction_test.go
+++ b/modules/backendscheduler/provider/compaction_test.go
@@ -263,8 +263,7 @@ func TestCompactionProvider_RecentJobsCachePreventseDuplicatesAndCleansUp(t *tes
 	cfg.RegisterFlagsAndApplyDefaults("", &flag.FlagSet{})
 	cfg.MaxJobsPerTenant = 1000 // Set high enough so we don't hit the limit
 	cfg.MeasureInterval = 100 * time.Millisecond
-	cfg.Backoff.MinBackoff = 10 * time.Millisecond
-	cfg.Backoff.MaxBackoff = 100 * time.Millisecond
+	cfg.MinCycleInterval = 100 * time.Millisecond
 
 	tmpDir := t.TempDir()
 

--- a/modules/backendscheduler/provider/compaction_test.go
+++ b/modules/backendscheduler/provider/compaction_test.go
@@ -191,7 +191,7 @@ func TestCompactionProvider_RecentJobsCache(t *testing.T) {
 	provider := &CompactionProvider{
 		logger:          log.NewNopLogger(),
 		sched:           &mockScheduler{},
-		outstandingJobs: make(map[string][]string),
+		outstandingJobs: make(map[string][]backend.UUID),
 	}
 
 	// Cache starts empty

--- a/modules/backendscheduler/provider/compaction_test.go
+++ b/modules/backendscheduler/provider/compaction_test.go
@@ -186,6 +186,178 @@ func TestCompactionProvider_EmptyStart(t *testing.T) {
 	}
 }
 
+func TestCompactionProvider_RecentJobsCache(t *testing.T) {
+	// Create a test provider
+	provider := &CompactionProvider{
+		logger:     log.NewNopLogger(),
+		sched:      &mockScheduler{},
+		recentJobs: make(map[string][]string),
+	}
+
+	// Cache starts empty
+	require.Len(t, provider.recentJobs, 0, "Cache should start empty")
+
+	job1 := &work.Job{
+		ID:   "job1",
+		Type: tempopb.JobType_JOB_TYPE_COMPACTION,
+		JobDetail: tempopb.JobDetail{
+			Compaction: &tempopb.CompactionDetail{
+				Input: []string{"block1", "block2"},
+			},
+		},
+	}
+
+	provider.addToRecentJobs(job1)
+	require.Len(t, provider.recentJobs, 1, "Cache should contain one job")
+	require.Contains(t, provider.recentJobs, "job1", "Cache should contain job1")
+	require.Equal(t, []string{"block1", "block2"}, provider.recentJobs["job1"], "Cache should contain correct blocks")
+
+	job2 := &work.Job{
+		ID:   "job2",
+		Type: tempopb.JobType_JOB_TYPE_COMPACTION,
+		JobDetail: tempopb.JobDetail{
+			Compaction: &tempopb.CompactionDetail{
+				Input: []string{"block3", "block4"},
+			},
+		},
+	}
+
+	provider.addToRecentJobs(job2)
+	require.Len(t, provider.recentJobs, 2, "Cache should contain two jobs")
+	require.Equal(t, []string{"block3", "block4"}, provider.recentJobs["job2"], "Cache should contain correct blocks for job2")
+
+	// Non-compaction job should not be added to cache
+	retentionJob := &work.Job{
+		ID:   "retention1",
+		Type: tempopb.JobType_JOB_TYPE_RETENTION,
+	}
+
+	provider.addToRecentJobs(retentionJob)
+	require.Len(t, provider.recentJobs, 2, "Non-compaction jobs should not be added to cache")
+
+	// Empty compaction input should not be added
+	emptyJob := &work.Job{
+		ID:   "empty-job",
+		Type: tempopb.JobType_JOB_TYPE_COMPACTION,
+		JobDetail: tempopb.JobDetail{
+			Compaction: &tempopb.CompactionDetail{
+				Input: []string{}, // Empty input
+			},
+		},
+	}
+
+	provider.addToRecentJobs(emptyJob)
+	require.Len(t, provider.recentJobs, 2, "Jobs with empty input should not be added to cache")
+}
+
+func TestCompactionProvider_RecentJobsCachePreventseDuplicatesAndCleansUp(t *testing.T) {
+	const tenant = "test-tenant"
+	cfg := CompactionConfig{}
+	cfg.RegisterFlagsAndApplyDefaults("", &flag.FlagSet{})
+	cfg.MaxJobsPerTenant = 1000 // Set high enough so we don't hit the limit
+	cfg.MeasureInterval = 100 * time.Millisecond
+	cfg.Backoff.MinBackoff = 10 * time.Millisecond
+	cfg.Backoff.MaxBackoff = 100 * time.Millisecond
+
+	tmpDir := t.TempDir()
+
+	var (
+		ctx, cancel  = context.WithTimeout(context.Background(), 5*time.Second)
+		store, _, ww = newStore(ctx, t, tmpDir)
+	)
+
+	defer func() {
+		cancel()
+		store.Shutdown()
+	}()
+
+	// Push some data to one tenant - enough blocks to create multiple compaction jobs
+	writeTenantBlocks(ctx, t, backend.NewWriter(ww), tenant, 10)
+
+	time.Sleep(100 * time.Millisecond)
+
+	limits, err := overrides.NewOverrides(overrides.Config{Defaults: overrides.Overrides{}}, nil, prometheus.DefaultRegisterer)
+	require.NoError(t, err)
+
+	w := work.New(work.Config{})
+
+	p := NewCompactionProvider(
+		cfg,
+		test.NewTestingLogger(t),
+		store,
+		limits,
+		w,
+	)
+
+	jobChan := p.Start(ctx)
+
+	var receivedJobs []*work.Job
+	blockIDs := make(map[string]int)
+
+	for job := range jobChan {
+		receivedJobs = append(receivedJobs, job)
+		// Collect the jobs but do not add them to the work queue yet
+
+		for _, blockID := range job.GetCompactionInput() {
+			// Count how many times each block ID appears across all jobs
+			blockIDs[blockID]++
+			require.Equal(t, 1, blockIDs[blockID], "Block ID %s should only appear once across all jobs", blockID)
+		}
+	}
+
+	for _, job := range receivedJobs {
+		require.NotNil(t, job)
+		require.Equal(t, tempopb.JobType_JOB_TYPE_COMPACTION, job.Type)
+		require.Greater(t, len(job.GetCompactionInput()), 0)
+		require.Equal(t, tenant, job.Tenant(), "Job tenant should match the test tenant")
+		require.NotEqual(t, "", job.ID)
+
+		// // Check that the newBlockSelector does not include the input blocks
+		// twbs, _ := p.newBlockSelector(tenant)
+		// require.NotNil(t, twbs)
+		//
+		// metas := collectAllMetas(twbs)
+		//
+		// // All blocks which have been received were addded to the work queue.
+		// // New instances of the block selector should yield zero blocks.
+		// require.Len(t, metas, 0)
+	}
+
+	// Verify that all received jobs are present in the recent jobs cache
+	require.Len(t, p.recentJobs, len(receivedJobs), "Recent jobs cache should contain all received jobs")
+	for _, job := range receivedJobs {
+		require.Contains(t, p.recentJobs, job.ID, "Recent jobs cache should contain job %s", job.ID)
+		require.Equal(t, job.GetCompactionInput(), p.recentJobs[job.ID], "Recent jobs cache should contain correct blocks for job %s", job.ID)
+	}
+
+	// Now add a job to the work queue and verify it is removed from the recent jobs cache
+	firstJob := receivedJobs[0]
+	err = w.AddJob(firstJob)
+	require.NoError(t, err, "should be able to add first job to work queue")
+
+	// Get a new block selector for the tenant
+	twbs, _ := p.newBlockSelector(tenant)
+	require.NotNil(t, twbs)
+
+	// Verify the recent jobs cache was cleaned up
+	require.NotContains(t, p.recentJobs, firstJob.ID, "Job should be removed from recent jobs cache after being added to work queue")
+
+	metas := collectAllMetas(twbs)
+	// Verify that the blocks in the first job are not present in the metas
+	for _, blockID := range firstJob.GetCompactionInput() {
+		u := backend.MustParse(blockID)
+		meta, found := foundMetaInMetas(metas, u)
+		require.False(t, found, "Block %s from job %s should not be present in the block selector after being added to work queue", blockID, firstJob.ID)
+		require.Nil(t, meta, "Block %s from job %s should not be present in the block selector after being added to work queue", blockID, firstJob.ID)
+	}
+
+	// Verify that the remaining jobs are still in the cache
+	for _, job := range receivedJobs[1:] {
+		require.Contains(t, p.recentJobs, job.ID, "Recent jobs cache should still contain job %s", job.ID)
+		require.Equal(t, job.GetCompactionInput(), p.recentJobs[job.ID], "Recent jobs cache should contain correct blocks for job %s", job.ID)
+	}
+}
+
 func newStore(ctx context.Context, t testing.TB, tmpDir string) (storage.Store, backend.RawReader, backend.RawWriter) {
 	rr, ww, _, err := local.New(&local.Config{
 		Path: tmpDir + "/traces",
@@ -261,3 +433,16 @@ func collectAllMetas(bs blockselector.CompactionBlockSelector) []*backend.BlockM
 
 	return metas
 }
+
+// mockScheduler implements the Scheduler interface for testing
+type mockScheduler struct {
+	jobs []*work.Job
+}
+
+func (m *mockScheduler) ListJobs() []*work.Job {
+	return m.jobs
+}
+
+// func (m *mockScheduler) addJob(job *work.Job) {
+// 	m.jobs = append(m.jobs, job)
+// }


### PR DESCRIPTION
**What this PR does**:

This is an alternative approach to the same issue described in #5405.

Here we fix the race by keeping track of the recent jobs which were created and their blocks.  This cache is used to skip blocks on the block selector from being considered.  Once the next blockselector is called, we use the job list to identify what cache needs to be pruned.  This allows a small delay between when the compaction provider created the job and when the scheduler assigns the job, but without the additional overhead of looping through the work list as proposed in #5405.

**Which issue(s) this PR fixes**:
Fixes #5405

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`