### PR TITLE
[backend-scheduler] require minimum time between tenant sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * [CHANGE] Command tempo-cli analyse block(s) excludes attributes with array values [#5380](https://github.com/grafana/tempo/pull/5380) (@stoewer)
 * [CHANGE] **BREAKING CHANGE** Drop unused `backend_scheduler.tenant_measurement_interval`, use `backend_scheduler.compaction.measure_interval` instead. [#5328](https://github.com/grafana/tempo/pull/5328) (@zalegrala)
 * [CHANGE] Allow configuration of min/max input blocks for compaction provider. [#5373](https://github.com/grafana/tempo/pull/5373) (@zalegrala)
+* [CHANGE] **BREAKING CHANGE** Add require minimum time between tenant sorting in backend-scheduler. [#5410](https://github.com/grafana/tempo/pull/5410) (@zalegrala)
+The configuration for `backend_scheduler.provider.compaction.backoff` has been removed.
 * [FEATURE] Add histograms `spans_distance_in_future_seconds` / `spans_distance_in_past_seconds` that count spans with end timestamp in the future / past. While spans in the future are accepted, they are invalid and may not be found using the Search API. [#4936](https://github.com/grafana/tempo/pull/4936) (@carles-grafana)
 * [FEATURE] Add MCP Server support. [#5212](https://github.com/grafana/tempo/pull/5212) (@joe-elliott)
 * [FEATURE] Add counter `query_frontend_bytes_inspected_total`, which shows the total number of bytes read from disk and object storage [#5310](https://github.com/grafana/tempo/pull/5310) (@carles-grafana)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [CHANGE] Allow configuration of min/max input blocks for compaction provider. [#5373](https://github.com/grafana/tempo/pull/5373) (@zalegrala)
 * [CHANGE] **BREAKING CHANGE** Add require minimum time between tenant sorting in backend-scheduler. [#5410](https://github.com/grafana/tempo/pull/5410) (@zalegrala)
 The configuration for `backend_scheduler.provider.compaction.backoff` has been removed.
+Additionally the `compaction_tenant_backoff_total` metric has been renamed to `compaction_empty_tenant_cycle_total` for clarity.
 * [FEATURE] Add histograms `spans_distance_in_future_seconds` / `spans_distance_in_past_seconds` that count spans with end timestamp in the future / past. While spans in the future are accepted, they are invalid and may not be found using the Search API. [#4936](https://github.com/grafana/tempo/pull/4936) (@carles-grafana)
 * [FEATURE] Add MCP Server support. [#5212](https://github.com/grafana/tempo/pull/5212) (@joe-elliott)
 * [FEATURE] Add counter `query_frontend_bytes_inspected_total`, which shows the total number of bytes read from disk and object storage [#5310](https://github.com/grafana/tempo/pull/5310) (@carles-grafana)

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -1006,12 +1006,9 @@ backend_scheduler:
                 max_time_per_tenant: 5m0s
                 compaction_cycle: 30s
             max_jobs_per_tenant: 1000
-            backoff:
-                min_period: 100ms
-                max_period: 10s
-                max_retries: 0
             min_input_blocks: 2
             max_input_blocks: 4
+            min_cycle_interval: 30s
     job_timeout: 15s
     local_work_path: /var/tempo
 backend_scheduler_client:

--- a/modules/backendscheduler/provider/compaction.go
+++ b/modules/backendscheduler/provider/compaction.go
@@ -30,10 +30,9 @@ type CompactionConfig struct {
 	MeasureInterval  time.Duration           `yaml:"measure_interval"`
 	Compactor        tempodb.CompactorConfig `yaml:"compaction"`
 	MaxJobsPerTenant int                     `yaml:"max_jobs_per_tenant"`
-	// Backoff          backoff.Config          `yaml:"backoff"`
-	MinInputBlocks   int           `yaml:"min_input_blocks"`
-	MaxInputBlocks   int           `yaml:"max_input_blocks"`
-	MinCycleInterval time.Duration `yaml:"min_cycle_interval"`
+	MinInputBlocks   int                     `yaml:"min_input_blocks"`
+	MaxInputBlocks   int                     `yaml:"max_input_blocks"`
+	MinCycleInterval time.Duration           `yaml:"min_cycle_interval"`
 }
 
 func (cfg *CompactionConfig) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
@@ -129,8 +128,8 @@ func (p *CompactionProvider) Start(ctx context.Context) <-chan *work.Job {
 			if p.curSelector == nil {
 				if !p.prepareNextTenant(loopCtx) {
 					level.Info(p.logger).Log("msg", "received empty tenant")
-					metricTenantBackoff.Inc()
-					span.AddEvent("tenant not prepared")
+					metricEmptyTenantCycle.Inc()
+					span.AddEvent("no tenant selected")
 				}
 
 				if p.curTenant != nil {

--- a/modules/backendscheduler/provider/compaction.go
+++ b/modules/backendscheduler/provider/compaction.go
@@ -132,10 +132,6 @@ func (p *CompactionProvider) Start(ctx context.Context) <-chan *work.Job {
 					span.AddEvent("no tenant selected")
 				}
 
-				if p.curTenant != nil {
-					level.Info(p.logger).Log("msg", "new tenant selected", "tenant_id", p.curTenant.Value())
-				}
-
 				continue
 			}
 
@@ -224,6 +220,8 @@ func (p *CompactionProvider) prepareNextTenant(ctx context.Context) bool {
 		span.AddEvent("no more tenants to compact")
 		return false
 	}
+
+	level.Info(p.logger).Log("msg", "new tenant selected", "tenant_id", p.curTenant.Value())
 
 	p.curSelector, _ = p.newBlockSelector(p.curTenant.Value())
 	return true

--- a/modules/backendscheduler/provider/compaction_test.go
+++ b/modules/backendscheduler/provider/compaction_test.go
@@ -31,8 +31,6 @@ func TestCompactionProvider(t *testing.T) {
 	cfg.RegisterFlagsAndApplyDefaults("", &flag.FlagSet{})
 	cfg.MaxJobsPerTenant = 2
 	cfg.MeasureInterval = 100 * time.Millisecond
-	cfg.Backoff.MinBackoff = 10 * time.Millisecond
-	cfg.Backoff.MaxBackoff = 100 * time.Millisecond
 	cfg.MinCycleInterval = 100 * time.Millisecond
 
 	tmpDir := t.TempDir()
@@ -105,8 +103,6 @@ func TestCompactionProvider_EmptyStart(t *testing.T) {
 	cfg.RegisterFlagsAndApplyDefaults("", &flag.FlagSet{})
 	cfg.MaxJobsPerTenant = 1
 	cfg.MeasureInterval = 100 * time.Millisecond
-	cfg.Backoff.MinBackoff = 30 * time.Millisecond // twice the poll cycle
-	cfg.Backoff.MaxBackoff = 50 * time.Millisecond
 	cfg.MinCycleInterval = 100 * time.Millisecond
 
 	tmpDir := t.TempDir()

--- a/modules/backendscheduler/provider/compaction_test.go
+++ b/modules/backendscheduler/provider/compaction_test.go
@@ -33,6 +33,7 @@ func TestCompactionProvider(t *testing.T) {
 	cfg.MeasureInterval = 100 * time.Millisecond
 	cfg.Backoff.MinBackoff = 10 * time.Millisecond
 	cfg.Backoff.MaxBackoff = 100 * time.Millisecond
+	cfg.MinCycleInterval = 100 * time.Millisecond
 
 	tmpDir := t.TempDir()
 
@@ -106,6 +107,7 @@ func TestCompactionProvider_EmptyStart(t *testing.T) {
 	cfg.MeasureInterval = 100 * time.Millisecond
 	cfg.Backoff.MinBackoff = 30 * time.Millisecond // twice the poll cycle
 	cfg.Backoff.MaxBackoff = 50 * time.Millisecond
+	cfg.MinCycleInterval = 100 * time.Millisecond
 
 	tmpDir := t.TempDir()
 

--- a/modules/backendscheduler/provider/config.go
+++ b/modules/backendscheduler/provider/config.go
@@ -24,7 +24,7 @@ func ValidateConfig(cfg *Config) error {
 	}
 
 	if cfg.Compaction.MinCycleInterval <= 0 {
-		return fmt.Errorf("min_cycle_interval must be greater than 0")
+		return fmt.Errorf("min_cycle_interval must be greater than 0, and should be at least a few seconds for practical use")
 	}
 
 	if cfg.Compaction.MeasureInterval <= 0 {

--- a/modules/backendscheduler/provider/config.go
+++ b/modules/backendscheduler/provider/config.go
@@ -24,7 +24,7 @@ func ValidateConfig(cfg *Config) error {
 	}
 
 	if cfg.Compaction.MinCycleInterval <= 0 {
-		return fmt.Errorf("min_cycle_interval must be greater than 0, and should be at least a few seconds for practical use")
+		return fmt.Errorf("min_cycle_interval must be greater than 0, and should be at least half the blocklist_poll cycle for general use")
 	}
 
 	if cfg.Compaction.MeasureInterval <= 0 {

--- a/modules/backendscheduler/provider/config.go
+++ b/modules/backendscheduler/provider/config.go
@@ -23,8 +23,8 @@ func ValidateConfig(cfg *Config) error {
 		return fmt.Errorf("max_jobs_per_tenant must be greater than 0")
 	}
 
-	if cfg.Compaction.Backoff.MaxRetries != 0 {
-		return fmt.Errorf("max_retries must be 0, since it is not respected")
+	if cfg.Compaction.MinCycleInterval <= 0 {
+		return fmt.Errorf("min_cycle_interval must be greater than 0")
 	}
 
 	if cfg.Compaction.MeasureInterval <= 0 {

--- a/modules/backendscheduler/provider/metrics.go
+++ b/modules/backendscheduler/provider/metrics.go
@@ -16,10 +16,10 @@ var (
 		Name:      "compaction_tenant_reset_total",
 		Help:      "The number of times the tenant is changed",
 	}, []string{"tenant"})
-	metricTenantBackoff = promauto.NewCounter(prometheus.CounterOpts{
+	metricEmptyTenantCycle = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: "tempo_backend_scheduler",
-		Name:      "compaction_tenant_backoff_total",
-		Help:      "The number of times the backoff is triggered",
+		Name:      "compaction_empty_tenant_cycle_total",
+		Help:      "The number of compaction cycles where no tenant had work available",
 	})
 	metricTenantEmptyJob = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: "tempo_backend_scheduler",


### PR DESCRIPTION
**What this PR does**:

Here we use a minimum cycle time to ensure we move fast when we can, but not too fast when we don't need to.

New blocks arrive at the end of a poll cycle, and we shouldn't expect to find new work on a tenant which has been drained until then.

**BREAKING CHANGE**
The config setting `provider.compaction.backoff` has been removed in favor of this simplified approach.

Additionally the `compaction_tenant_backoff_total` metric has been renamed to `compaction_empty_tenant_cycle_total` for clarity.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`