### PR TITLE
feature: implement a listOffset by partition client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [ENHANCEMENT] TraceQL metrics performance increase for simple queries [#5247](https://github.com/grafana/tempo/pull/5247) (@mdisibio)
 * [ENHANCEMENT] TraceQL search and metrics performance increase [#5280](https://github.com/grafana/tempo/pull/5280) (@mdisibio)
 * [ENHANCEMENT] Traceql performance improvement [#5218](https://github.com/grafana/tempo/pull/5218) (@mdisibio)
+* [ENHANCEMENT] Implement a listOffset by partition client [#5415](https://github.com/grafana/tempo/pull/5415) (@javiermolinar)
 * [ENHANCEMENT] Align traceql attribute struct for better performance [#5240](https://github.com/grafana/tempo/pull/5240) (@mdisibio)
 * [ENHANCEMENT] Enable HTTP writes in the multi-tenant example [#5297](https://github.com/grafana/tempo/pull/5297)
 * [ENHANCEMENT] Drop invalid prometheus label names in spanmetrics processor [#5122](https://github.com/grafana/tempo/pull/5122) (@KyriosGN0)

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -220,7 +220,6 @@ distributor:
         producer_max_buffered_bytes: 0
         target_consumer_lag_at_startup: 0s
         max_consumer_lag_at_startup: 0s
-        fetch_concurrency_max: 0
     extend_writes: true
     retry_after_on_resource_exhausted: 0s
     max_attribute_bytes: 2048
@@ -716,7 +715,6 @@ ingest:
         producer_max_buffered_bytes: 1073741824
         target_consumer_lag_at_startup: 2s
         max_consumer_lag_at_startup: 15s
-        fetch_concurrency_max: 0
 block_builder:
     instance_id: hostname
     assigned_partitions: {}

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -220,6 +220,7 @@ distributor:
         producer_max_buffered_bytes: 0
         target_consumer_lag_at_startup: 0s
         max_consumer_lag_at_startup: 0s
+        fetch_concurrency_max: 0
     extend_writes: true
     retry_after_on_resource_exhausted: 0s
     max_attribute_bytes: 2048
@@ -715,6 +716,7 @@ ingest:
         producer_max_buffered_bytes: 1073741824
         target_consumer_lag_at_startup: 2s
         max_consumer_lag_at_startup: 15s
+        fetch_concurrency_max: 0
 block_builder:
     instance_id: hostname
     assigned_partitions: {}

--- a/modules/blockbuilder/blockbuilder.go
+++ b/modules/blockbuilder/blockbuilder.go
@@ -206,8 +206,7 @@ func (b *BlockBuilder) starting(ctx context.Context) (err error) {
 
 	ingest.ExportPartitionLagMetrics(
 		ctx,
-		b.kadm,
-		b.partitionOffsetClient,
+		b.kafkaClient,
 		b.logger,
 		b.cfg.IngestStorageConfig,
 		b.getAssignedPartitions,

--- a/modules/blockbuilder/blockbuilder.go
+++ b/modules/blockbuilder/blockbuilder.go
@@ -93,10 +93,11 @@ type BlockBuilder struct {
 	logger log.Logger
 	cfg    Config
 
-	kafkaClient   *kgo.Client
-	kadm          *kadm.Client
-	decoder       *ingest.Decoder
-	partitionRing ring.PartitionRingReader
+	kafkaClient           *kgo.Client
+	partitionOffsetClient *ingest.PartitionOffsetClient
+	kadm                  *kadm.Client
+	decoder               *ingest.Decoder
+	partitionRing         ring.PartitionRingReader
 
 	overrides Overrides
 	enc       encoding.VersionedEncoding
@@ -158,7 +159,7 @@ func New(
 
 func (b *BlockBuilder) starting(ctx context.Context) (err error) {
 	level.Info(b.logger).Log("msg", "block builder starting")
-
+	topic := b.cfg.IngestStorageConfig.Kafka.Topic
 	b.enc = encoding.DefaultEncoding()
 	if version := b.cfg.BlockConfig.BlockCfg.Version; version != "" {
 		b.enc, err = encoding.FromVersion(version)
@@ -180,6 +181,8 @@ func (b *BlockBuilder) starting(ctx context.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to create kafka reader client: %w", err)
 	}
+
+	b.partitionOffsetClient = ingest.NewPartitionOffsetClient(b.kafkaClient, topic)
 
 	boff := backoff.New(ctx, backoff.Config{
 		MinBackoff: 100 * time.Millisecond,
@@ -204,6 +207,7 @@ func (b *BlockBuilder) starting(ctx context.Context) (err error) {
 	ingest.ExportPartitionLagMetrics(
 		ctx,
 		b.kadm,
+		b.partitionOffsetClient,
 		b.logger,
 		b.cfg.IngestStorageConfig,
 		b.getAssignedPartitions,
@@ -238,6 +242,7 @@ func (b *BlockBuilder) running(ctx context.Context) error {
 // all the partitions lag is less than the cycle duration. When that happen it returns time to wait before another consuming cycle, based on the last record timestamp
 func (b *BlockBuilder) consume(ctx context.Context) (time.Duration, error) {
 	partitions := b.getAssignedPartitions()
+
 	ctx, span := tracer.Start(ctx, "blockbuilder.consume", trace.WithAttributes(attribute.String("active_partitions", formatActivePartitions(partitions))))
 	defer span.End()
 
@@ -521,7 +526,7 @@ func (b *BlockBuilder) fetchPartitions(ctx context.Context, partitions []int32) 
 		MaxRetries: 5,
 	})
 	for boff.Ongoing() {
-		commits, endsOffsets, err = b.getPartitionOffsets(ctx)
+		commits, endsOffsets, err = b.getPartitionOffsets(ctx, partitions)
 		if err == nil {
 			break
 		}
@@ -541,7 +546,7 @@ func (b *BlockBuilder) fetchPartitions(ctx context.Context, partitions []int32) 
 
 // todo: this function fetches the offsets for all the partitions including the ones that are not assigned to this block builder.
 // improve it to only fetch the offsets for the assigned partitions
-func (b *BlockBuilder) getPartitionOffsets(ctx context.Context) (kadm.OffsetResponses, kadm.ListedOffsets, error) {
+func (b *BlockBuilder) getPartitionOffsets(ctx context.Context, partitionIDs []int32) (kadm.OffsetResponses, kadm.ListedOffsets, error) {
 	var (
 		topic = b.cfg.IngestStorageConfig.Kafka.Topic
 		group = b.cfg.IngestStorageConfig.Kafka.ConsumerGroup
@@ -554,7 +559,7 @@ func (b *BlockBuilder) getPartitionOffsets(ctx context.Context) (kadm.OffsetResp
 		return nil, nil, err
 	}
 
-	endsOffsets, err := b.kadm.ListEndOffsets(ctx, topic)
+	endsOffsets, err := b.partitionOffsetClient.FetchPartitionsLastProducedOffsets(ctx, partitionIDs)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/modules/blockbuilder/blockbuilder_test.go
+++ b/modules/blockbuilder/blockbuilder_test.go
@@ -126,7 +126,7 @@ func TestBlockbuilder_startWithCommit(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	t.Cleanup(func() { cancel(errors.New("test done")) })
 
-	k, address := testkafka.CreateCluster(t, 1, testTopic)
+	k, address := testkafka.CreateCluster(t, 100, testTopic)
 
 	kafkaCommits := atomic.NewInt32(0)
 	k.ControlKey(kmsg.OffsetCommit, func(kmsg.Request) (kmsg.Response, error, bool) {

--- a/modules/generator/generator.go
+++ b/modules/generator/generator.go
@@ -83,6 +83,7 @@ type Generator struct {
 	kafkaStop          func()
 	kafkaClient        *ingest.Client
 	kafkaAdm           *kadm.Client
+	partitionClient    *ingest.PartitionOffsetClient
 	partitionRing      ring.PartitionRingReader
 	partitionMtx       sync.RWMutex
 	assignedPartitions []int32
@@ -213,6 +214,7 @@ func (g *Generator) starting(ctx context.Context) (err error) {
 		}
 
 		g.kafkaAdm = kadm.NewClient(g.kafkaClient.Client)
+		g.partitionClient = ingest.NewPartitionOffsetClient(g.kafkaClient.Client, g.cfg.Ingest.Kafka.Topic)
 	}
 
 	return nil

--- a/modules/generator/generator_kafka.go
+++ b/modules/generator/generator_kafka.go
@@ -24,7 +24,6 @@ var metricEnqueueTime = promauto.NewCounter(prometheus.CounterOpts{
 
 func (g *Generator) startKafka() {
 	g.kafkaCh = make(chan *kgo.Record, g.cfg.IngestConcurrency)
-
 	// Create context that will be used to stop the goroutines.
 	var ctx context.Context
 	ctx, g.kafkaStop = context.WithCancel(context.Background())
@@ -36,7 +35,8 @@ func (g *Generator) startKafka() {
 
 	g.kafkaWG.Add(1)
 	go g.listenKafka(ctx)
-	ingest.ExportPartitionLagMetrics(ctx, g.kafkaAdm, g.logger, g.cfg.Ingest, g.getAssignedActivePartitions, g.kafkaClient.ForceMetadataRefresh)
+
+	ingest.ExportPartitionLagMetrics(ctx, g.kafkaAdm, g.partitionClient, g.logger, g.cfg.Ingest, g.getAssignedActivePartitions, g.kafkaClient.ForceMetadataRefresh)
 }
 
 func (g *Generator) stopKafka() {

--- a/modules/generator/generator_kafka.go
+++ b/modules/generator/generator_kafka.go
@@ -36,7 +36,7 @@ func (g *Generator) startKafka() {
 	g.kafkaWG.Add(1)
 	go g.listenKafka(ctx)
 
-	ingest.ExportPartitionLagMetrics(ctx, g.kafkaAdm, g.partitionClient, g.logger, g.cfg.Ingest, g.getAssignedActivePartitions, g.kafkaClient.ForceMetadataRefresh)
+	ingest.ExportPartitionLagMetrics(ctx, g.kafkaClient.Client, g.logger, g.cfg.Ingest, g.getAssignedActivePartitions, g.kafkaClient.ForceMetadataRefresh)
 }
 
 func (g *Generator) stopKafka() {

--- a/pkg/ingest/config.go
+++ b/pkg/ingest/config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/flagext"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -84,6 +85,15 @@ type KafkaConfig struct {
 
 	TargetConsumerLagAtStartup time.Duration `yaml:"target_consumer_lag_at_startup"`
 	MaxConsumerLagAtStartup    time.Duration `yaml:"max_consumer_lag_at_startup"`
+
+	FetchMaxWait                      time.Duration `yaml:"fetch_max_wait"`
+	FetchConcurrencyMax               int           `yaml:"fetch_concurrency_max"`
+	UseCompressedBytesAsFetchMaxBytes bool          `yaml:"use_compressed_bytes_as_fetch_max_bytes"`
+	MaxBufferedBytes                  int           `yaml:"max_buffered_bytes"`
+
+	// The fetch backoff config to use in the concurrent fetchers (when enabled). This setting
+	// is just used to change the default backoff in tests.
+	concurrentFetchersFetchBackoffConfig backoff.Config `yaml:"-"`
 }
 
 func (cfg *KafkaConfig) RegisterFlags(f *flag.FlagSet) {

--- a/pkg/ingest/config.go
+++ b/pkg/ingest/config.go
@@ -86,8 +86,6 @@ type KafkaConfig struct {
 	TargetConsumerLagAtStartup time.Duration `yaml:"target_consumer_lag_at_startup"`
 	MaxConsumerLagAtStartup    time.Duration `yaml:"max_consumer_lag_at_startup"`
 
-	FetchConcurrencyMax int `yaml:"fetch_concurrency_max"`
-
 	// The fetch backoff config to use in the concurrent fetchers (when enabled). This setting
 	// is just used to change the default backoff in tests.
 	concurrentFetchersFetchBackoffConfig backoff.Config `yaml:"-"`

--- a/pkg/ingest/config.go
+++ b/pkg/ingest/config.go
@@ -86,10 +86,7 @@ type KafkaConfig struct {
 	TargetConsumerLagAtStartup time.Duration `yaml:"target_consumer_lag_at_startup"`
 	MaxConsumerLagAtStartup    time.Duration `yaml:"max_consumer_lag_at_startup"`
 
-	FetchMaxWait                      time.Duration `yaml:"fetch_max_wait"`
-	FetchConcurrencyMax               int           `yaml:"fetch_concurrency_max"`
-	UseCompressedBytesAsFetchMaxBytes bool          `yaml:"use_compressed_bytes_as_fetch_max_bytes"`
-	MaxBufferedBytes                  int           `yaml:"max_buffered_bytes"`
+	FetchConcurrencyMax int `yaml:"fetch_concurrency_max"`
 
 	// The fetch backoff config to use in the concurrent fetchers (when enabled). This setting
 	// is just used to change the default backoff in tests.

--- a/pkg/ingest/metrics.go
+++ b/pkg/ingest/metrics.go
@@ -43,7 +43,7 @@ var (
 // Call ResetLagMetricsForRevokedPartitions when partitions are revoked to prevent exporting
 // stale data. For efficiency this is not detected automatically from changes inthe assigned
 // partition callback.
-func ExportPartitionLagMetrics(ctx context.Context, client *kadm.Client, partitionClient *PartitionOffsetClient, log log.Logger, cfg Config, getAssignedActivePartitions func() []int32, forceMetadataRefresh func()) {
+func ExportPartitionLagMetrics(ctx context.Context, admClient *kadm.Client, partitionClient *PartitionOffsetClient, log log.Logger, cfg Config, getAssignedActivePartitions func() []int32, forceMetadataRefresh func()) {
 	go func() {
 		var (
 			waitTime = time.Second * 15
@@ -66,7 +66,7 @@ func ExportPartitionLagMetrics(ctx context.Context, client *kadm.Client, partiti
 				assignedPartitions := getAssignedActivePartitions()
 				boff.Reset()
 				for boff.Ongoing() {
-					lag, err = getGroupLag(ctx, client, partitionClient, group, assignedPartitions)
+					lag, err = getGroupLag(ctx, admClient, partitionClient, group, assignedPartitions)
 					if err == nil {
 						break
 					}

--- a/pkg/ingest/partition_offset_client.go
+++ b/pkg/ingest/partition_offset_client.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package ingest
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+const (
+	// kafkaOffsetStart is a special offset value that means the beginning of the partition.
+	kafkaOffsetStart = int64(-2)
+
+	// kafkaOffsetEnd is a special offset value that means the end of the partition.
+	kafkaOffsetEnd = int64(-1)
+
+	// ReaderMetricsPrefix is the reader metrics prefix used by the ingest storage.
+	ReaderMetricsPrefix = "cortex_ingest_storage_reader"
+)
+
+// partitionOffsetClient is a client used to read partition offsets.
+type PartitionOffsetClient struct {
+	client *kgo.Client
+	admin  *kadm.Client
+
+	topic string
+}
+
+func NewPartitionOffsetClient(client *kgo.Client, topic string) *PartitionOffsetClient {
+	return &PartitionOffsetClient{
+		client: client,
+		admin:  kadm.NewClient(client),
+		topic:  topic,
+	}
+}
+
+// FetchPartitionsLastProducedOffsets fetches and returns the last produced offsets for all input partitions. The offset is
+// -1 if a partition has been created but no record has been produced yet. The returned offsets for each partition
+// are guaranteed to be always updated (no stale or cached offsets returned).
+//
+// The Kafka client used under the hood may retry a failed request until the retry timeout is hit.
+func (p *PartitionOffsetClient) FetchPartitionsLastProducedOffsets(ctx context.Context, partitionIDs []int32) (_ kadm.ListedOffsets, returnErr error) {
+	// Skip lookup and don't track any metric if no partition was requested.
+	if len(partitionIDs) == 0 {
+		return nil, nil
+	}
+	return p.fetchPartitionsOffsets(ctx, kafkaOffsetEnd, partitionIDs)
+}
+
+func (p *PartitionOffsetClient) FetchPartitionsStartProducedOffsets(ctx context.Context, partitionIDs []int32) (_ kadm.ListedOffsets, returnErr error) {
+	// Skip lookup and don't track any metric if no partition was requested.
+	if len(partitionIDs) == 0 {
+		return nil, nil
+	}
+
+	return p.fetchPartitionsOffsets(ctx, kafkaOffsetStart, partitionIDs)
+}
+
+// fetchPartitionsEndOffsets returns the end offset of each partition in input. This function returns
+// error if fails to get the offset of any partition (no partial result is returned).
+func (p *PartitionOffsetClient) fetchPartitionsOffsets(ctx context.Context, timestamp int64, partitionIDs []int32) (kadm.ListedOffsets, error) {
+	list := kadm.ListedOffsets{
+		p.topic: make(map[int32]kadm.ListedOffset, len(partitionIDs)),
+	}
+
+	// Prepare the request to list offsets.
+	topicReq := kmsg.NewListOffsetsRequestTopic()
+	topicReq.Topic = p.topic
+	for _, partitionID := range partitionIDs {
+		partitionReq := kmsg.NewListOffsetsRequestTopicPartition()
+		partitionReq.Partition = partitionID
+		partitionReq.Timestamp = timestamp
+
+		topicReq.Partitions = append(topicReq.Partitions, partitionReq)
+	}
+
+	req := kmsg.NewPtrListOffsetsRequest()
+	req.IsolationLevel = 0 // 0 means READ_UNCOMMITTED.
+	req.Topics = []kmsg.ListOffsetsRequestTopic{topicReq}
+
+	// Execute the request.
+	shards := p.client.RequestSharded(ctx, req)
+
+	for _, shard := range shards {
+		if shard.Err != nil {
+			return nil, shard.Err
+		}
+
+		res := shard.Resp.(*kmsg.ListOffsetsResponse)
+		if len(res.Topics) != 1 {
+			return nil, fmt.Errorf("unexpected number of topics in the response (expected: %d, got: %d)", 1, len(res.Topics))
+		}
+		if res.Topics[0].Topic != p.topic {
+			return nil, fmt.Errorf("unexpected topic in the response (expected: %s, got: %s)", p.topic, res.Topics[0].Topic)
+		}
+
+		for _, pt := range res.Topics[0].Partitions {
+			if err := kerr.ErrorForCode(pt.ErrorCode); err != nil {
+				return nil, err
+			}
+
+			list[p.topic][pt.Partition] = kadm.ListedOffset{
+				Topic:       p.topic,
+				Partition:   pt.Partition,
+				Timestamp:   pt.Timestamp,
+				Offset:      pt.Offset,
+				LeaderEpoch: pt.LeaderEpoch,
+			}
+		}
+	}
+
+	return list, nil
+}

--- a/pkg/ingest/partition_offset_client_test.go
+++ b/pkg/ingest/partition_offset_client_test.go
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package ingest
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+	"github.com/twmb/franz-go/plugin/kprom"
+
+	"github.com/grafana/dskit/backoff"
+	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/tempo/pkg/ingest/testkafka"
+	"github.com/grafana/tempo/pkg/util/test"
+)
+
+func TestPartitionOffsetClient_FetchPartitionsLastProducedOffsets(t *testing.T) {
+	const (
+		numPartitions = 3
+		topicName     = "test"
+	)
+
+	var (
+		ctx             = context.Background()
+		allPartitionIDs = []int32{0, 1, 2}
+	)
+
+	t.Run("should return the last produced offsets, or -1 if the partition is empty", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			_, clusterAddr = testkafka.CreateCluster(t, numPartitions, topicName)
+			kafkaCfg       = createTestKafkaConfig(clusterAddr, topicName)
+			client         = createTestKafkaClient(t, kafkaCfg)
+			reader         = NewPartitionOffsetClient(client, topicName)
+		)
+
+		offsets, err := reader.FetchPartitionsLastProducedOffsets(ctx, allPartitionIDs)
+		require.NoError(t, err)
+		assert.Equal(t, map[int32]int64{0: 0, 1: 0, 2: 0}, getPartitionsOffsets(offsets))
+
+		// Write some records.
+		produceRecord(ctx, t, client, topicName, 0, []byte("message 1"))
+		produceRecord(ctx, t, client, topicName, 0, []byte("message 2"))
+		produceRecord(ctx, t, client, topicName, 1, []byte("message 3"))
+
+		offsets, err = reader.FetchPartitionsLastProducedOffsets(ctx, allPartitionIDs)
+		require.NoError(t, err)
+		assert.Equal(t, map[int32]int64{0: 2, 1: 1, 2: 0}, getPartitionsOffsets(offsets))
+
+		// Write more records.
+		produceRecord(ctx, t, client, topicName, 0, []byte("message 4"))
+		produceRecord(ctx, t, client, topicName, 1, []byte("message 5"))
+		produceRecord(ctx, t, client, topicName, 2, []byte("message 6"))
+
+		offsets, err = reader.FetchPartitionsLastProducedOffsets(ctx, allPartitionIDs)
+		require.NoError(t, err)
+		assert.Equal(t, map[int32]int64{0: 3, 1: 2, 2: 1}, getPartitionsOffsets(offsets))
+
+		// Fetch offsets for a subset of partitions.
+		offsets, err = reader.FetchPartitionsLastProducedOffsets(ctx, []int32{0, 2})
+		require.NoError(t, err)
+		assert.Equal(t, map[int32]int64{0: 3, 2: 1}, getPartitionsOffsets(offsets))
+	})
+
+	t.Run("should return error if response contains an unexpected number of topics", func(t *testing.T) {
+		t.Parallel()
+
+		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+
+		// Configure a short retry timeout.
+		kafkaCfg := createTestKafkaConfig(clusterAddr, topicName)
+		kafkaCfg.LastProducedOffsetRetryTimeout = time.Second
+
+		client := createTestKafkaClient(t, kafkaCfg)
+		reader := NewPartitionOffsetClient(client, topicName)
+
+		cluster.ControlKey(kmsg.ListOffsets, func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+			cluster.KeepControl()
+
+			req := kreq.(*kmsg.ListOffsetsRequest)
+			res := req.ResponseKind().(*kmsg.ListOffsetsResponse)
+			res.Default()
+			res.Topics = []kmsg.ListOffsetsResponseTopic{
+				{Topic: topicName},
+				{Topic: "another-unknown-topic"},
+			}
+
+			return res, nil, true
+		})
+
+		_, err := reader.FetchPartitionsLastProducedOffsets(ctx, allPartitionIDs)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "unexpected number of topics in the response")
+	})
+
+	t.Run("should return error if response contains a 1 topic but its not the expected one", func(t *testing.T) {
+		t.Parallel()
+
+		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+
+		// Configure a short retry timeout.
+		kafkaCfg := createTestKafkaConfig(clusterAddr, topicName)
+		kafkaCfg.LastProducedOffsetRetryTimeout = time.Second
+
+		client := createTestKafkaClient(t, kafkaCfg)
+		reader := NewPartitionOffsetClient(client, topicName)
+
+		cluster.ControlKey(kmsg.ListOffsets, func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+			cluster.KeepControl()
+
+			req := kreq.(*kmsg.ListOffsetsRequest)
+			res := req.ResponseKind().(*kmsg.ListOffsetsResponse)
+			res.Default()
+			res.Topics = []kmsg.ListOffsetsResponseTopic{
+				{Topic: "another-unknown-topic"},
+			}
+
+			return res, nil, true
+		})
+
+		_, err := reader.FetchPartitionsLastProducedOffsets(ctx, allPartitionIDs)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "unexpected topic in the response")
+	})
+
+	t.Run("should return error if response contains an error for a partition", func(t *testing.T) {
+		t.Parallel()
+
+		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+
+		// Configure a short retry timeout.
+		kafkaCfg := createTestKafkaConfig(clusterAddr, topicName)
+		kafkaCfg.LastProducedOffsetRetryTimeout = time.Second
+
+		client := createTestKafkaClient(t, kafkaCfg)
+		reader := NewPartitionOffsetClient(client, topicName)
+
+		cluster.ControlKey(kmsg.ListOffsets, func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+			cluster.KeepControl()
+
+			req := kreq.(*kmsg.ListOffsetsRequest)
+			res := req.ResponseKind().(*kmsg.ListOffsetsResponse)
+			res.Default()
+			res.Topics = []kmsg.ListOffsetsResponseTopic{
+				{
+					Topic: topicName,
+					Partitions: []kmsg.ListOffsetsResponseTopicPartition{
+						{
+							Partition: 0,
+							Offset:    1,
+						}, {
+							Partition: 0,
+							ErrorCode: kerr.NotLeaderForPartition.Code,
+						},
+					},
+				},
+			}
+
+			return res, nil, true
+		})
+
+		_, err := reader.FetchPartitionsLastProducedOffsets(ctx, allPartitionIDs)
+		require.ErrorIs(t, err, kerr.NotLeaderForPartition)
+	})
+}
+
+func getPartitionsOffsets(offsets kadm.ListedOffsets) map[int32]int64 {
+	partitionOffsets := make(map[int32]int64)
+	offsets.Each(func(offset kadm.ListedOffset) {
+		partitionOffsets[offset.Partition] = offset.Offset
+	})
+	return partitionOffsets
+}
+
+func createTestKafkaConfig(clusterAddr, topicName string) KafkaConfig {
+	cfg := KafkaConfig{}
+	flagext.DefaultValues(&cfg)
+
+	fastFetchBackoffConfig := backoff.Config{
+		MinBackoff: 10 * time.Millisecond,
+		MaxBackoff: 10 * time.Millisecond,
+		MaxRetries: 0,
+	}
+
+	cfg.Address = clusterAddr
+	cfg.Topic = topicName
+	cfg.WriteTimeout = 5 * time.Second
+	cfg.FetchConcurrencyMax = 2
+	cfg.concurrentFetchersFetchBackoffConfig = fastFetchBackoffConfig
+
+	return cfg
+}
+
+func createTestKafkaClient(t *testing.T, cfg KafkaConfig) *kgo.Client {
+	metrics := kprom.NewMetrics("", kprom.Registerer(prometheus.NewPedanticRegistry()))
+	opts := commonKafkaClientOptions(cfg, metrics, test.NewTestingLogger(t))
+
+	// Use the manual partitioner because produceRecord() utility explicitly specifies
+	// the partition to write to in the kgo.Record itself.
+	opts = append(opts, kgo.RecordPartitioner(kgo.ManualPartitioner()))
+
+	client, err := kgo.NewClient(opts...)
+	require.NoError(t, err)
+
+	// Automatically close it at the end of the test.
+	t.Cleanup(client.Close)
+
+	return client
+}
+
+func produceRecord(ctx context.Context, t *testing.T, writeClient *kgo.Client, topicName string, partitionID int32, content []byte) int64 {
+	return produceRecordWithVersion(ctx, t, writeClient, topicName, partitionID, content, 1)
+}
+
+func produceRecordWithVersion(ctx context.Context, t *testing.T, writeClient *kgo.Client, topicName string, partitionID int32, content []byte, version int) int64 {
+	rec := &kgo.Record{
+		Value:     content,
+		Topic:     topicName,
+		Partition: partitionID,
+	}
+	if version == 0 {
+		rec.Headers = nil
+	} else {
+		rec.Headers = []kgo.RecordHeader{RecordVersionHeader(version)}
+	}
+
+	produceResult := writeClient.ProduceSync(ctx, rec)
+	require.NoError(t, produceResult.FirstErr())
+
+	return rec.Offset
+}
+
+func RecordVersionHeader(version int) kgo.RecordHeader {
+	var b [4]byte
+	binary.BigEndian.PutUint32(b[:], uint32(version))
+	return kgo.RecordHeader{
+		Key:   "Version",
+		Value: b[:],
+	}
+}

--- a/pkg/ingest/partition_offset_client_test.go
+++ b/pkg/ingest/partition_offset_client_test.go
@@ -218,7 +218,7 @@ func createTestKafkaClient(t *testing.T, cfg KafkaConfig) *kgo.Client {
 }
 
 func produceRecord(ctx context.Context, t *testing.T, writeClient *kgo.Client, partitionID int32, content []byte) {
-	_ := produceRecordWithVersion(ctx, t, writeClient, partitionID, content, 1)
+	_ = produceRecordWithVersion(ctx, t, writeClient, partitionID, content, 1)
 }
 
 func produceRecordWithVersion(ctx context.Context, t *testing.T, writeClient *kgo.Client, partitionID int32, content []byte, version int) int64 {

--- a/pkg/ingest/partition_offset_client_test.go
+++ b/pkg/ingest/partition_offset_client_test.go
@@ -194,7 +194,6 @@ func createTestKafkaConfig(clusterAddr string) KafkaConfig {
 	cfg.Address = clusterAddr
 	cfg.Topic = topicName
 	cfg.WriteTimeout = 5 * time.Second
-	cfg.FetchConcurrencyMax = 2
 	cfg.concurrentFetchersFetchBackoffConfig = fastFetchBackoffConfig
 
 	return cfg

--- a/pkg/ingest/partition_offset_client_test.go
+++ b/pkg/ingest/partition_offset_client_test.go
@@ -217,8 +217,8 @@ func createTestKafkaClient(t *testing.T, cfg KafkaConfig) *kgo.Client {
 	return client
 }
 
-func produceRecord(ctx context.Context, t *testing.T, writeClient *kgo.Client, partitionID int32, content []byte) int64 {
-	return produceRecordWithVersion(ctx, t, writeClient, partitionID, content, 1)
+func produceRecord(ctx context.Context, t *testing.T, writeClient *kgo.Client, partitionID int32, content []byte) {
+	_ := produceRecordWithVersion(ctx, t, writeClient, partitionID, content, 1)
 }
 
 func produceRecordWithVersion(ctx context.Context, t *testing.T, writeClient *kgo.Client, partitionID int32, content []byte, version int) int64 {

--- a/pkg/ingest/testkafka/cluster.go
+++ b/pkg/ingest/testkafka/cluster.go
@@ -60,6 +60,10 @@ func (c *Cluster) ControlKey(key kmsg.Key, fn controlFn) {
 	}
 }
 
+func (c *Cluster) KeepControl() {
+	c.fake.KeepControl()
+}
+
 func (c *Cluster) ensureConsumerGroupExists(consumerGroup string) {
 	if _, ok := c.committedOffsets[consumerGroup]; ok {
 		return
@@ -146,13 +150,11 @@ func (c *Cluster) offsetFetch(kreq kmsg.Request) (kmsg.Response, error, bool) {
 				})
 			}
 		}
-	} else {
-		if c.committedOffsets[consumerGroup][partitionID] >= 0 {
-			partitionsResp = append(partitionsResp, kmsg.OffsetFetchResponseGroupTopicPartition{
-				Partition: partitionID,
-				Offset:    c.committedOffsets[consumerGroup][partitionID],
-			})
-		}
+	} else if c.committedOffsets[consumerGroup][partitionID] >= 0 {
+		partitionsResp = append(partitionsResp, kmsg.OffsetFetchResponseGroupTopicPartition{
+			Partition: partitionID,
+			Offset:    c.committedOffsets[consumerGroup][partitionID],
+		})
 	}
 
 	// Prepare the list topics for which there are some committed offsets.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

The goal of this PR is to replace the 

kadm.ListStartOffsets and kadm.ListEndOffsets by a built-in compatible methods that accept a list of partitions. This is important to reduce the number of ListOffsets requests. Tests show a 50% reduction in requests


<img width="2467" height="1137" alt="Screenshot 2025-07-17 at 16 21 06" src="https://github.com/user-attachments/assets/87028961-e560-4582-8fa5-8df7d3f54e2f" />

<img width="1224" height="261" alt="Screenshot 2025-07-17 at 16 21 27" src="https://github.com/user-attachments/assets/93e2fa22-f834-431f-9cc7-c278f5a2106f" />



**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`