### PR TITLE
[backend-scheduler] move job sorting

### DIFF
--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -438,7 +439,14 @@ func (s *BackendScheduler) StatusHandler(w http.ResponseWriter, _ *http.Request)
 	x := table.NewWriter()
 	x.AppendHeader(table.Row{"tenant", "jobID", "type", "input", "output", "status", "worker", "created", "start", "end"})
 
-	for _, j := range s.work.ListJobs() {
+	jobs := s.work.ListJobs()
+
+	// sort jobs by creation time
+	sort.Slice(jobs, func(i, j int) bool {
+		return jobs[i].GetCreatedTime().After(jobs[j].GetCreatedTime())
+	})
+
+	for _, j := range jobs {
 		x.AppendRows([]table.Row{
 			{
 				j.Tenant(),

--- a/modules/backendscheduler/work/work.go
+++ b/modules/backendscheduler/work/work.go
@@ -6,7 +6,6 @@ import (
 	"hash/fnv"
 	"os"
 	"path/filepath"
-	"sort"
 	"sync"
 	"time"
 
@@ -172,11 +171,6 @@ func (w *Work) ListJobs() []*Job {
 
 		shard.mtx.Unlock()
 	}
-
-	// Sort jobs by creation time
-	sort.Slice(allJobs, func(i, j int) bool {
-		return allJobs[i].GetCreatedTime().Before(allJobs[j].GetCreatedTime())
-	})
 
 	return allJobs
 }


### PR DESCRIPTION
**What this PR does**:

Sorting the job list is only useful in the status handler.  Here we move the sorting to the status handler and reverse the order so that more recent jobs are on top to improve the UX.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`