### PR TITLE
feat(servicegraphs): Add support for db.system.name

### DIFF
--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -459,6 +459,10 @@ metrics_generator:
             # resouce and span level attributes
             [span_multiplier_key: <string> | default = ""]
 
+            # database name attributes is the attribute name list used to identify the databasename from span attributes
+            # the  deafault value is ["db.name", "db.system.name"]
+            [database_name_attributes: <list of string> | default = ["db.name", "db.system.name"]]
+
             # Enables additional labels for services and virtual nodes.
             [enable_virtual_node_label: <bool> | default = false]
 
@@ -1789,6 +1793,7 @@ overrides:
           [histogram_buckets: <list of float>]
           [dimensions: <list of string>]
           [peer_attributes: <list of string>]
+          [database_name_attributes: <list of string>]
           [enable_client_server_prefix: <bool>]
           [enable_messaging_system_latency_histogram: <bool>]
 

--- a/modules/generator/processor/servicegraphs/config.go
+++ b/modules/generator/processor/servicegraphs/config.go
@@ -47,6 +47,10 @@ type Config struct {
 	// If enabled attribute value will be used for metric calculation
 	SpanMultiplierKey string `yaml:"span_multiplier_key"`
 
+	// DatabaseNameAttributes is the attribute name list used to identify the database name from span attributes
+	// The default value is {"db.name", "db.system.name"}
+	DatabaseNameAttributes []string `yaml:"database_name_attributes"`
+
 	// EnableVirtualNodeLabel enables additional labels for uninstrumented services
 	EnableVirtualNodeLabel bool `yaml:"enable_virtual_node_label"`
 }
@@ -64,6 +68,9 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {
 		peerAttr = append(peerAttr, string(attr))
 	}
 	cfg.PeerAttributes = peerAttr
+
+	// Set default database name attributes to support both old and new semantic conventions
+	cfg.DatabaseNameAttributes = []string{"db.name", "db.system.name"}
 
 	cfg.EnableMessagingSystemLatencyHistogram = false
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This PR adds support for the `db.system.name` attribute introduced in OpenTelemetry Semantic Conventions v1.30.0. The change maintains backward compatibility while supporting the new attribute name.

**Which issue(s) this PR fixes**:
Fixes #4640

**Checklist**

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
