### PR TITLE
[Bugfix] Default step for grpc

### DIFF
--- a/modules/frontend/metrics_query_range_handler.go
+++ b/modules/frontend/metrics_query_range_handler.go
@@ -29,12 +29,12 @@ func newQueryRangeStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripp
 		ctx := srv.Context()
 
 		headers := headersFromGrpcContext(ctx)
-		traceql.AlignRequest(req)
 
 		// default step if not set
 		if req.Step == 0 {
 			req.Step = traceql.DefaultQueryRangeStep(req.Start, req.End)
 		}
+		traceql.AlignRequest(req)
 
 		httpReq := api.BuildQueryRangeRequest(&http.Request{
 			URL:    &url.URL{Path: downstreamPath},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: Align request in grpc query range call only when default step is applied.

The bug was introduced in https://github.com/grafana/tempo/pull/5366 in commit https://github.com/grafana/tempo/pull/5366/commits/c26423c7a824d45affd96b583f2b3b9c2f8de4cf

**How it has been tested:**
1. http in e2e tests
2. Because we don't have e2e tests for it, grpc was checked manually, by calling MetricsQueryRange grpc method with step=0.
Before the fix (main branch):
```
StatusCode.UNKNOWN, start required
```

After the fix: returned 301 intervals, no errors

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`