### PR TITLE
Implement poller hook on compaction provider for accurate delay

### DIFF
--- a/modules/backendscheduler/provider/compaction.go
+++ b/modules/backendscheduler/provider/compaction.go
@@ -216,6 +216,7 @@ func (p *CompactionProvider) prepareNextTenant(ctx context.Context) bool {
 			case <-ctx.Done():
 				return false
 			case <-p.store.PollNotification(ctx):
+				// We waited for the poll, but we may have been cancelled in the meantime.
 				if ctx.Err() != nil {
 					return false
 				}

--- a/modules/backendscheduler/provider/compaction_test.go
+++ b/modules/backendscheduler/provider/compaction_test.go
@@ -130,7 +130,7 @@ func TestCompactionProvider_EmptyStart(t *testing.T) {
 		w,
 	)
 
-	b := p.prepareNextTenant(ctx)
+	b := p.prepareNextTenant(ctx, false)
 	require.False(t, b, "no tenant should be found")
 	require.Nil(t, p.curTenant, "a tenant should not be set")
 	require.Nil(t, p.curSelector, "a block selector should not be set")
@@ -138,7 +138,7 @@ func TestCompactionProvider_EmptyStart(t *testing.T) {
 	writeTenantBlocks(ctx, t, backend.NewWriter(ww), tenant, 1)
 	time.Sleep(150 * time.Millisecond)
 
-	b = p.prepareNextTenant(ctx)
+	b = p.prepareNextTenant(ctx, false)
 	require.False(t, b, "no tenant with a single block should be found")
 	require.Nil(t, p.curTenant, "a tenant should not be set")
 	require.Nil(t, p.curSelector, "a block selector should not be set")
@@ -146,7 +146,7 @@ func TestCompactionProvider_EmptyStart(t *testing.T) {
 	writeTenantBlocks(ctx, t, backend.NewWriter(ww), tenant, 1)
 	time.Sleep(150 * time.Millisecond)
 
-	b = p.prepareNextTenant(ctx)
+	b = p.prepareNextTenant(ctx, false)
 	require.True(t, b, "tenant with two blocks should be found")
 	require.NotNil(t, p.curTenant, "a tenant should be set")
 	require.NotNil(t, p.curSelector, "a block selector should be set")

--- a/modules/frontend/search_sharder_test.go
+++ b/modules/frontend/search_sharder_test.go
@@ -89,6 +89,7 @@ func (m *mockReader) FetchTagNames(context.Context, *backend.BlockMeta, traceql.
 
 func (m *mockReader) EnablePolling(context.Context, blocklist.JobSharder, bool) {}
 func (m *mockReader) PollNow(context.Context)                                   {}
+func (m *mockReader) PollNotification(context.Context) <-chan struct{}          { return nil }
 func (m *mockReader) Shutdown()                                                 {}
 
 //nolint:all deprecated

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -218,13 +218,14 @@ func New(cfg *Config, cacheProvider cache.Provider, logger gkLog.Logger) (Reader
 	r := backend.NewReader(rawR)
 	w := backend.NewWriter(rawW)
 	rw := &readerWriter{
-		c:         c,
-		r:         r,
-		w:         w,
-		cfg:       cfg,
-		logger:    logger,
-		pool:      pool.NewPool(cfg.Pool),
-		blocklist: blocklist.New(),
+		c:                       c,
+		r:                       r,
+		w:                       w,
+		cfg:                     cfg,
+		logger:                  logger,
+		pool:                    pool.NewPool(cfg.Pool),
+		blocklist:               blocklist.New(),
+		pollerNotificationFuncs: make([]func(), 0),
 	}
 
 	rw.wal, err = wal.New(rw.cfg.WAL)
@@ -703,7 +704,8 @@ func (rw *readerWriter) pollBlocklist(ctx context.Context) {
 	for _, fn := range rw.pollerNotificationFuncs {
 		fn()
 	}
-	clear(rw.pollerNotificationFuncs)
+
+	rw.pollerNotificationFuncs = rw.pollerNotificationFuncs[:0]
 }
 
 // includeBlock indicates whether a given block should be included in a backend search

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -661,6 +661,9 @@ func (rw *readerWriter) PollNow(ctx context.Context) {
 	rw.pollBlocklist(ctx)
 }
 
+// PollNotification returns a context.Done() channel, the closure of which indicates
+// that the blocklist has been updated.  The channel is never written to, but
+// allows waiting more precisely for updated information from the backend.
 func (rw *readerWriter) PollNotification(ctx context.Context) <-chan struct{} {
 	ctx, cancel := context.WithCancel(ctx)
 

--- a/tempodb/tempodb_test.go
+++ b/tempodb/tempodb_test.go
@@ -986,6 +986,8 @@ func TestPollNotification(t *testing.T) {
 
 	_, err = w.CompleteBlock(ctx, head)
 	assert.NoError(t, err)
+	start := time.Now()
+	sleepTime := 1 * time.Second
 
 	wg := &sync.WaitGroup{}
 	for range 10 {
@@ -994,10 +996,11 @@ func TestPollNotification(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-r.PollNotification(ctx)
+			require.Greater(t, time.Since(start), sleepTime, "PollNotification should not return before the first PollNow call")
 		}()
 	}
 
-	// TODO: check that we have not returned too soon, that we do indeed wait for the PollNow call.
+	time.Sleep(sleepTime)
 
 	r.PollNow(ctx)
 

--- a/tempodb/tempodb_test.go
+++ b/tempodb/tempodb_test.go
@@ -956,7 +956,6 @@ func TestNoCompactFlag(t *testing.T) {
 }
 
 func TestPollNotification(t *testing.T) {
-	// Create several new go routines which call PollNotiication
 	r, w, _, _ := testConfig(t, backend.EncGZIP, 0)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)


### PR DESCRIPTION
**What this PR does**:

This change addresses two issues.

First, on startup, the scheduler hands out jobs on a potentially out of date blocklist, which means the scheduler possibly hands out jobs for blocks which don't exist.

Second, when we cycle for the min period, we only sleep the period, which is only useful if we expect new blocks to show up on this interval.  In reality, it will cycle here several times until the blocklist is polled.

In both cases, I think we want to know the moment a blocklist is updated, so that we can a) start the compaction provider and hand out accurate jobs and b) sleep until new work shows up once we've drained all tenants.

An implicit assumption here is that the poller on the worker is on the same interval as the poller on the scheduler.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`