### PR TITLE
chore: Autofixing so that semgrep can also understand our #nosec lines

### DIFF
--- a/cmd/tempo/app/app_test.go
+++ b/cmd/tempo/app/app_test.go
@@ -42,7 +42,7 @@ func TestApp_RunStop(t *testing.T) {
 	healthCheckURL := fmt.Sprintf("http://localhost:%d/ready", config.Server.HTTPListenPort)
 	require.Eventually(t, func() bool {
 		t.Log("Checking Tempo is up...")
-		// #nosec G107
+		// #nosec G107 -- nosemgrep: tainted-url-host
 		resp, httpErr := http.Get(healthCheckURL)
 		return httpErr == nil && resp.StatusCode == http.StatusOK
 	}, 30*time.Second, 1*time.Second)
@@ -53,7 +53,7 @@ func TestApp_RunStop(t *testing.T) {
 	// check health endpoint is not reachable anymore
 	require.Eventually(t, func() bool {
 		t.Log("Checking Tempo is down...")
-		// #nosec G107
+		// #nosec G107 -- nosemgrep: tainted-url-host
 		_, httpErr := http.Get(healthCheckURL)
 		return httpErr != nil
 	}, 30*time.Second, 1*time.Second)

--- a/integration/e2e/metrics_generator_test.go
+++ b/integration/e2e/metrics_generator_test.go
@@ -416,7 +416,7 @@ func TestMetricsGeneratorMessagingSystemLatencyHistogramEnabled(t *testing.T) {
 	// Send a pair of spans with a messaging system relationship (producer -> consumer)
 	// ignore the gosec linter because we are using a random number generator to create trace IDs
 	// and span IDs, which is not a security risk in this context.
-	// #nosec G404
+	// #nosec G404 -- nosemgrep: math-random-used
 	r := rand.New(rand.NewSource(time.Now().UnixMilli()))
 	traceIDLow := r.Int63()
 	traceIDHigh := r.Int63()


### PR DESCRIPTION
**What this PR does**:

Security is working on rolling out semgrep across our codebase. Because of some parser deficiencies in semgrep (the user-configurable rule engine runs after AST parsing, which discards comments), we can't just force it to respect #nosec, so this PR converts lines with valid gosec suppression directives into lines that also contain a valid equivalent semgrep suppression. I know it's ugly, sorry.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [NA] Tests updated
- [NA] Documentation added
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`