### PR TITLE
frontend: unify tenant ID extraction across handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [CHANGE] Return Bad Request from all frontend endpoints if the tenant can't be extracted [#5480](https://github.com/grafana/tempo/pull/5480) (@carles-grafana)
 * [CHANGE]  **BREAKING CHANGE** Migrated Tempo Vulture and Integration Tests from the deprecated Jaeger agent/exporter to the standard OTLP exporter. Vulture now push traces to Tempo OTLP GRCP endpoint.[#5058](https://github.com/grafana/tempo/pull/5058) (@iamrajiv, @javiermolinar)
 * [CHANGE] Do not count cached querier responses for SLO metrics such as inspected bytes [#5185](https://github.com/grafana/tempo/pull/5185) (@carles-grafana)
 * [CHANGE] Assert max live traces limits in local-blocks processor [#5170](https://github.com/grafana/tempo/pull/5170) (@mapno)
@@ -47,7 +48,6 @@ Additionally the `compaction_tenant_backoff_total` metric has been renamed to `c
 * [BUGFIX] Fix bug where most_recent=true wouldn't return most recent results when query overlapped ingesters and few other blocks.[#5438](https://github.com/grafana/tempo/pull/5438) (@joe-elliott)
 * [BUGFIX] Fix panic when counter series is missing during avg_over_time aggregation [#5300](https://github.com/grafana/tempo/pull/5300) (@ie-pham)
 * [BUGFIX] Do not allow very small steps [#5441](https://github.com/grafana/tempo/pull/5441) (@ruslan-mikhailov)
-* [BUGFIX] Return Bad Request from all frontend endpoints if the tenant can't be extracted [#5480](https://github.com/grafana/tempo/pull/5480) (@carles-grafana)
 
 # v2.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Additionally the `compaction_tenant_backoff_total` metric has been renamed to `c
 * [BUGFIX] Fix bug where most_recent=true wouldn't return most recent results when query overlapped ingesters and few other blocks.[#5438](https://github.com/grafana/tempo/pull/5438) (@joe-elliott)
 * [BUGFIX] Fix panic when counter series is missing during avg_over_time aggregation [#5300](https://github.com/grafana/tempo/pull/5300) (@ie-pham)
 * [BUGFIX] Do not allow very small steps [#5441](https://github.com/grafana/tempo/pull/5441) (@ruslan-mikhailov)
+* [BUGFIX] Return Bad Request from all frontend endpoints if the tenant can't be extracted [#5480](https://github.com/grafana/tempo/pull/5480) (@carles-grafana)
 
 # v2.8.1
 

--- a/modules/frontend/metrics_query_handler.go
+++ b/modules/frontend/metrics_query_handler.go
@@ -84,7 +84,10 @@ func newMetricsQueryInstantHTTPHandler(cfg Config, next pipeline.AsyncRoundTripp
 	postSLOHook := metricsSLOPostHook(cfg.Metrics.SLO)
 
 	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		tenant, _ := user.ExtractOrgID(req.Context())
+		tenant, errResp := extractTenant(req, logger)
+		if errResp != nil {
+			return errResp, nil
+		}
 		start := time.Now()
 
 		// Parse request

--- a/modules/frontend/metrics_query_range_handler.go
+++ b/modules/frontend/metrics_query_range_handler.go
@@ -81,7 +81,10 @@ func newMetricsQueryRangeHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper
 	postSLOHook := metricsSLOPostHook(cfg.Metrics.SLO)
 
 	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		tenant, _ := user.ExtractOrgID(req.Context())
+		tenant, errResp := extractTenant(req, logger)
+		if errResp != nil {
+			return errResp, nil
+		}
 		start := time.Now()
 
 		// parse request

--- a/modules/frontend/search_handlers.go
+++ b/modules/frontend/search_handlers.go
@@ -79,7 +79,10 @@ func newSearchHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.P
 	postSLOHook := searchSLOPostHook(cfg.Search.SLO)
 
 	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		tenant, _ := user.ExtractOrgID(req.Context())
+		tenant, errResp := extractTenant(req, logger)
+		if errResp != nil {
+			return errResp, nil
+		}
 		start := time.Now()
 
 		// parse request

--- a/modules/frontend/tag_handlers.go
+++ b/modules/frontend/tag_handlers.go
@@ -216,9 +216,8 @@ func newTagsHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.Pip
 	postSLOHook := metadataSLOPostHook(cfg.Search.MetadataSLO)
 
 	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		// if error is not nil, return error Response but suppress the error
-		tenant, errResp, err := extractTenantWithErrorResp(req, logger)
-		if err != nil {
+		tenant, errResp := extractTenant(req, logger)
+		if errResp != nil {
 			return errResp, nil
 		}
 
@@ -264,9 +263,8 @@ func newTagsV2HTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.P
 	postSLOHook := metadataSLOPostHook(cfg.Search.MetadataSLO)
 
 	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		// if error is not nil, return error Response but suppress the error
-		tenant, errResp, err := extractTenantWithErrorResp(req, logger)
-		if err != nil {
+		tenant, errResp := extractTenant(req, logger)
+		if errResp != nil {
 			return errResp, nil
 		}
 
@@ -319,9 +317,8 @@ func newTagValuesHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combine
 	postSLOHook := metadataSLOPostHook(cfg.Search.MetadataSLO)
 
 	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		// if error is not nil, return error Response but suppress the error
-		tenant, errResp, err := extractTenantWithErrorResp(req, logger)
-		if err != nil {
+		tenant, errResp := extractTenant(req, logger)
+		if errResp != nil {
 			return errResp, nil
 		}
 
@@ -355,9 +352,8 @@ func newTagValuesV2HTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combi
 	postSLOHook := metadataSLOPostHook(cfg.Search.MetadataSLO)
 
 	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		// if error is not nil, return error Response but suppress the error
-		tenant, errResp, err := extractTenantWithErrorResp(req, logger)
-		if err != nil {
+		tenant, errResp := extractTenant(req, logger)
+		if errResp != nil {
 			return errResp, nil
 		}
 
@@ -388,19 +384,6 @@ func newTagValuesV2HTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combi
 }
 
 // helpers
-func extractTenantWithErrorResp(req *http.Request, logger log.Logger) (string, *http.Response, error) {
-	tenant, err := user.ExtractOrgID(req.Context())
-	if err != nil {
-		level.Error(logger).Log("msg", "tags failed to extract orgid", "err", err)
-		return "", &http.Response{
-			StatusCode: http.StatusBadRequest,
-			Status:     http.StatusText(http.StatusBadRequest),
-			Body:       io.NopCloser(strings.NewReader(err.Error())),
-		}, err
-	}
-	return tenant, nil, err
-}
-
 func buildTagsRequestAndExtractTenant(ctx context.Context, req *tempopb.SearchTagsRequest, downstreamPath string, logger log.Logger) (*http.Request, string, error) {
 	headers := headersFromGrpcContext(ctx)
 

--- a/modules/frontend/util.go
+++ b/modules/frontend/util.go
@@ -1,10 +1,30 @@
 package frontend
 
 import (
+	"io"
+	"net/http"
+	"strings"
 	"time"
 
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/user"
 	"github.com/grafana/tempo/tempodb/backend"
 )
+
+// extractTenant extracts tenant ID from request context and returns HTTP error response if extraction fails
+func extractTenant(req *http.Request, logger log.Logger) (string, *http.Response) {
+	tenant, err := user.ExtractOrgID(req.Context())
+	if err != nil {
+		level.Error(logger).Log("msg", "failed to extract tenant id", "err", err)
+		return "", &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Status:     http.StatusText(http.StatusBadRequest),
+			Body:       io.NopCloser(strings.NewReader(err.Error())),
+		}
+	}
+	return tenant, nil
+}
 
 func rf1FilterFn(rf1After time.Time) func(m *backend.BlockMeta) bool {
 	return func(m *backend.BlockMeta) bool {

--- a/modules/frontend/util_test.go
+++ b/modules/frontend/util_test.go
@@ -1,0 +1,75 @@
+package frontend
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/user"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractTenant(t *testing.T) {
+	logger := log.NewNopLogger()
+
+	t.Run("success case - tenant extracted from context", func(t *testing.T) {
+		// Create request with tenant in context
+		req, err := http.NewRequest("GET", "/api/traces/123", nil)
+		require.NoError(t, err)
+
+		// Inject tenant ID into context
+		ctx := user.InjectOrgID(req.Context(), "test-tenant")
+		req = req.WithContext(ctx)
+
+		// Call extractTenant
+		tenant, errResp := extractTenant(req, logger)
+
+		// Verify success
+		assert.Equal(t, "test-tenant", tenant)
+		assert.Nil(t, errResp)
+	})
+
+	t.Run("success case - single-tenant mode", func(t *testing.T) {
+		// Create request with single-tenant ID
+		req, err := http.NewRequest("GET", "/api/search", nil)
+		require.NoError(t, err)
+
+		// Inject single-tenant ID (simulating fake auth middleware)
+		ctx := user.InjectOrgID(req.Context(), "single-tenant")
+		req = req.WithContext(ctx)
+
+		// Call extractTenant
+		tenant, errResp := extractTenant(req, logger)
+
+		// Verify success
+		assert.Equal(t, "single-tenant", tenant)
+		assert.Nil(t, errResp)
+	})
+
+	t.Run("error case - no tenant in context", func(t *testing.T) {
+		// Create request without tenant in context
+		req, err := http.NewRequest("GET", "/api/traces/123", nil)
+		require.NoError(t, err)
+
+		// Call extractTenant
+		tenant, errResp := extractTenant(req, logger)
+
+		// Verify error response
+		assert.Empty(t, tenant)
+		require.NotNil(t, errResp)
+
+		// Check HTTP response details
+		assert.Equal(t, http.StatusBadRequest, errResp.StatusCode)
+		assert.Equal(t, "Bad Request", errResp.Status)
+
+		// Read response body
+		bodyBytes, err := io.ReadAll(errResp.Body)
+		require.NoError(t, err)
+		bodyStr := string(bodyBytes)
+
+		// Should contain error message about missing org ID
+		assert.Contains(t, bodyStr, "no org id")
+	})
+}


### PR DESCRIPTION
There was some inconsistencies and duplication.
Now the tenant extraction must succeed for all endpoints, or else fail.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`