### PR TITLE
[DOC] Release notes update for 2.8.2

### DIFF
--- a/docs/sources/tempo/release-notes/v2-8.md
+++ b/docs/sources/tempo/release-notes/v2-8.md
@@ -244,6 +244,15 @@ In addition, these Tempo serverless related metrics have been removed: `tempo_qu
 
 For a complete list, refer to the [Tempo CHANGELOG](https://github.com/grafana/tempo/releases).
 
+### 2.8.2
+
+- Added a nil check to `partitionAssignmentVar`. [[PR 5198](https://github.com/grafana/tempo/pull/5198)]
+- Corrected instant query calculation. [[PR 5252](https://github.com/grafana/tempo/pull/5252)]
+- Fixed tracing context propagation in distributor HTTP write requests. [[PR 5312](https://github.com/grafana/tempo/pull/5312)]
+- Fixed search by `trace:id` with short trace ID. [[PR 5331](https://github.com/grafana/tempo/pull/5331)]
+- Fixed bug where `most_recent=true` wouldn't return most recent results when query overlapped ingesters and few other blocks. [[PR 5438](https://github.com/grafana/tempo/pull/5438)]
+- Fixed a panic when the counter series was missing during `avg_over_time` aggregation. [[PR 5300](https://github.com/grafana/tempo/pull/5300)]
+
 ### 2.8.1
 
 - Fixed an ingester issue where a hash collision could lead to spans stored incorrectly. ([PR 5276](https://github.com/grafana/tempo/pull/5276))

--- a/docs/sources/tempo/release-notes/v2-8.md
+++ b/docs/sources/tempo/release-notes/v2-8.md
@@ -161,13 +161,6 @@ Tempo 2.8 improves exemplars in TraceQL metrics.
 - Right exemplars for histogram and quantiles. ([PR 5145](https://github.com/grafana/tempo/pull/5145))
 - Fixed for queried number of exemplars. ([PR 5115](https://github.com/grafana/tempo/pull/5115))
 
-### Security improvements
-
-The following updates were made to address security issues:
-
-- Use distroless base container images for improved security. ([PR 4556](https://github.com/grafana/tempo/pull/4556))
-- Updated to go 1.24.3. ([PR 5110](https://github.com/grafana/tempo/pull/5110))
-
 ### Improved error handling and logging
 
 In addition, we’ve updated how Tempo handles errors so it’s easier to troubleshoot.
@@ -239,6 +232,19 @@ In addition, these Tempo serverless related metrics have been removed: `tempo_qu
 - Enforce max attribute size at event, link, and instrumentation scope. The configuration is now per-tenant. Renamed `max_span_attr_byte` to `max_attribute_bytes`. ([PR 4633](https://github.com/grafana/tempo/pull/4633))
 - Converted SLO metric `query_frontend_bytes_processed_per_second` from a histogram to a counter as it's more performant. ([PR 4748](https://github.com/grafana/tempo/pull/4748))
 - Removed the OpenTelemetry Jaeger exporter, which has been [deprecated](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/jaeger). ([PR 4926](https://github.com/grafana/tempo/pull/4926))
+
+## Security fixes
+
+The following updates were made to address security issues:
+
+### 2.8.2
+
+- Updated Go to version 1.24.4. Addresses [CVE-2025-22874](https://nvd.nist.gov/vuln/detail/CVE-2025-22874), [CVE-2025-4673](https://nvd.nist.gov/vuln/detail/CVE-2025-4673), [CVE-2025-0913](https://nvd.nist.gov/vuln/detail/CVE-2025-0913), and [GHSA-FV92-FJC5-JJ9H](https://www.wiz.io/vulnerability-database/cve/ghsa-fv92-fjc5-jj9h). [[PR 5323](https://github.com/grafana/tempo/pull/5323)]
+
+### 2.8.0
+
+- Used distroless base container images for improved security. ([PR 4556](https://github.com/grafana/tempo/pull/4556))
+- Updated to go 1.24.3. ([PR 5110](https://github.com/grafana/tempo/pull/5110))
 
 ## Bugfixes
 


### PR DESCRIPTION
**What this PR does**:

Updates the 2.8 release notes for changes in 2.8.2. 

**Which issue(s) this PR fixes**:
Related to https://github.com/grafana/tempo/pull/5484

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`