### PR TITLE
Adjust histogram buckets to have more granularity around 1s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 The configuration for `backend_scheduler.provider.compaction.backoff` has been removed.
 Additionally the `compaction_tenant_backoff_total` metric has been renamed to `compaction_empty_tenant_cycle_total` for clarity.
 * [CHANGE] Shard backend-scheduler work files locally and modify backend work structure to accommodate sharding approach [#5412](https://github.com/grafana/tempo/pull/5412) (@zalegrala)
+* [CHANGE] Remove .005s and add a 1.5s bucket to all request duration histograms [#5492](https://github.com/grafana/tempo/pull/5492) (@joe-elliott)
 * [CHANGE] **BREAKING CHANGE** TraceQL Metrics buckets are calculated based on data in past [#5366](https://github.com/grafana/tempo/pull/5366) (@ruslan-mikhailov)
 * [FEATURE] Add histograms `spans_distance_in_future_seconds` / `spans_distance_in_past_seconds` that count spans with end timestamp in the future / past. While spans in the future are accepted, they are invalid and may not be found using the Search API. [#4936](https://github.com/grafana/tempo/pull/4936) (@carles-grafana)
 * [FEATURE] Add MCP Server support. [#5212](https://github.com/grafana/tempo/pull/5212) (@joe-elliott)

--- a/cmd/tempo/app/server_service.go
+++ b/cmd/tempo/app/server_service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/gorilla/mux"
+	"github.com/grafana/dskit/instrument"
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/server"
 	"github.com/grafana/dskit/services"
@@ -19,6 +20,11 @@ import (
 
 	util_log "github.com/grafana/tempo/pkg/util/log"
 )
+
+func init() {
+	// overwriting default buckets []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25, 50, 100} to have more granularity around 1s
+	instrument.DefBuckets = []float64{.01, .025, .05, .1, .25, .5, 1, 1.5, 2.5, 5, 10, 25, 50, 100}
+}
 
 type TempoServer interface {
 	HTTPRouter() *mux.Router


### PR DESCRIPTION
**What this PR does**:

Removes the .005 bucket and adds a 1.5 bucket to increase granularity of all histograms around 1s.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`