### PR TITLE
feat: improve tempo writes dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The configuration for `backend_scheduler.provider.compaction.backoff` has been r
 Additionally the `compaction_tenant_backoff_total` metric has been renamed to `compaction_empty_tenant_cycle_total` for clarity.
 * [CHANGE] Shard backend-scheduler work files locally and modify backend work structure to accommodate sharding approach [#5412](https://github.com/grafana/tempo/pull/5412) (@zalegrala)
 * [CHANGE] Remove .005s and add a 1.5s bucket to all request duration histograms [#5492](https://github.com/grafana/tempo/pull/5492) (@joe-elliott)
+* [CHANGE] Improve tempo writes dashboard [#5500](https://github.com/grafana/tempo/pull/5500) (@javiermolinar)
 * [CHANGE] **BREAKING CHANGE** TraceQL Metrics buckets are calculated based on data in past [#5366](https://github.com/grafana/tempo/pull/5366) (@ruslan-mikhailov)
 * [FEATURE] Add histograms `spans_distance_in_future_seconds` / `spans_distance_in_past_seconds` that count spans with end timestamp in the future / past. While spans in the future are accepted, they are invalid and may not be found using the Search API. [#4936](https://github.com/grafana/tempo/pull/4936) (@carles-grafana)
 * [FEATURE] Add MCP Server support. [#5212](https://github.com/grafana/tempo/pull/5212) (@joe-elliott)

--- a/operations/tempo-mixin-compiled/dashboards/tempo-writes.json
+++ b/operations/tempo-mixin-compiled/dashboards/tempo-writes.json
@@ -276,7 +276,7 @@
      "steppedLine": false,
      "targets": [
       {
-       "expr": "sum by (grpc_status) (\n    rate(\n        label_replace(\n            {cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw(-internal)?\", __name__=~\"envoy_cluster_grpc_proto_collector_trace_v1_TraceService_[0-9]+\"},\n            \"grpc_status\", \"$1\", \"__name__\", \"envoy_cluster_grpc_proto_collector_trace_v1_TraceService_(.+)\"\n        )\n        [$__rate_interval:30s]\n    )\n)\n",
+       "expr": "sum by (grpc_status) (\n  rate(\n    label_replace(\n      {__name__=~\"envoy_cluster_grpc_[0-9]+\", cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw(-internal)?\"\"},\n      \"grpc_status\", \"$1\", \"__name__\", \"envoy_cluster_grpc_([0-9]+)\"\n    )\n  [ $__rate_interval : 30s ])\n)\n",
        "format": "time_series",
        "interval": "1m",
        "legendFormat": "{{grpc_status}}",
@@ -392,6 +392,195 @@
 
      ],
      "spaceLength": 10,
+     "span": 6,
+     "stack": false,
+     "steppedLine": false,
+     "targets": [
+      {
+       "expr": "sum(rate(envoy_http_downstream_cx_destroy{namespace=\"$namespace\"}[5m])) by(job)\n/\nsum(envoy_cluster_upstream_rq_active{namespace=\"$namespace\"}) by(job)\n* 100\n",
+       "format": "time_series",
+       "interval": "1m",
+       "legendFormat": "{{job}}",
+       "legendLink": null
+      }
+     ],
+     "thresholds": [
+
+     ],
+     "timeFrom": null,
+     "timeShift": null,
+     "title": "Envoy dropped connections percentage",
+     "tooltip": {
+      "shared": true,
+      "sort": 2,
+      "value_type": "individual"
+     },
+     "type": "graph",
+     "xaxis": {
+      "buckets": null,
+      "mode": "time",
+      "name": null,
+      "show": true,
+      "values": [
+
+      ]
+     },
+     "yaxes": [
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": 0,
+       "show": true
+      },
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": null,
+       "show": false
+      }
+     ]
+    },
+    {
+     "aliasColors": {
+
+     },
+     "bars": false,
+     "dashLength": 10,
+     "dashes": false,
+     "datasource": "$datasource",
+     "fill": 1,
+     "id": 6,
+     "legend": {
+      "avg": false,
+      "current": false,
+      "max": false,
+      "min": false,
+      "show": true,
+      "total": false,
+      "values": false
+     },
+     "lines": true,
+     "linewidth": 1,
+     "links": [
+
+     ],
+     "nullPointMode": "null as zero",
+     "percentage": false,
+     "pointradius": 5,
+     "points": false,
+     "renderer": "flot",
+     "seriesOverrides": [
+
+     ],
+     "spaceLength": 10,
+     "span": 6,
+     "stack": false,
+     "steppedLine": false,
+     "targets": [
+      {
+       "expr": "min(envoy_cluster_circuit_breakers_default_remaining_rq{namespace=\"$namespace\"}) by(job)",
+       "format": "time_series",
+       "interval": "1m",
+       "legendFormat": "{{job}} rq",
+       "legendLink": null
+      },
+      {
+       "expr": "min(envoy_cluster_circuit_breakers_default_remaining_cx{namespace=\"$namespace\"}) by(job)",
+       "format": "time_series",
+       "interval": "1m",
+       "legendFormat": "{{job}} cx",
+       "legendLink": null
+      }
+     ],
+     "thresholds": [
+
+     ],
+     "timeFrom": null,
+     "timeShift": null,
+     "title": "Envoy remaining requests/connections",
+     "tooltip": {
+      "shared": true,
+      "sort": 2,
+      "value_type": "individual"
+     },
+     "type": "graph",
+     "xaxis": {
+      "buckets": null,
+      "mode": "time",
+      "name": null,
+      "show": true,
+      "values": [
+
+      ]
+     },
+     "yaxes": [
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": 0,
+       "show": true
+      },
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": null,
+       "show": false
+      }
+     ]
+    }
+   ],
+   "repeat": null,
+   "repeatIteration": null,
+   "repeatRowId": null,
+   "showTitle": true,
+   "title": "",
+   "titleSize": "h6"
+  },
+  {
+   "collapse": false,
+   "height": "250px",
+   "panels": [
+    {
+     "aliasColors": {
+
+     },
+     "bars": false,
+     "dashLength": 10,
+     "dashes": false,
+     "datasource": "$datasource",
+     "fill": 1,
+     "id": 7,
+     "legend": {
+      "avg": false,
+      "current": false,
+      "max": false,
+      "min": false,
+      "show": true,
+      "total": false,
+      "values": false
+     },
+     "lines": true,
+     "linewidth": 1,
+     "links": [
+
+     ],
+     "nullPointMode": "null as zero",
+     "percentage": false,
+     "pointradius": 5,
+     "points": false,
+     "renderer": "flot",
+     "seriesOverrides": [
+
+     ],
+     "spaceLength": 10,
      "span": 4,
      "stack": false,
      "steppedLine": false,
@@ -460,7 +649,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 1,
-     "id": 6,
+     "id": 8,
      "legend": {
       "avg": false,
       "current": false,
@@ -545,7 +734,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 1,
-     "id": 7,
+     "id": 9,
      "legend": {
       "avg": false,
       "current": false,
@@ -662,7 +851,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 1,
-     "id": 8,
+     "id": 10,
      "legend": {
       "avg": false,
       "current": false,
@@ -691,7 +880,203 @@
      "steppedLine": false,
      "targets": [
       {
-       "expr": "sum(rate(tempo_distributor_kafka_appends_total{cluster=~\"$cluster\", job=~\"($namespace)/distributor\", status=\"success\"}[$__rate_interval]))",
+       "expr": "sum(rate(tempo_receiver_accepted_spans{cluster=~\"$cluster\", job=~\"($namespace)/distributor\"}[$__rate_interval]))",
+       "format": "time_series",
+       "interval": "1m",
+       "legendFormat": "accepted",
+       "legendLink": null
+      },
+      {
+       "expr": "sum(rate(tempo_receiver_refused_spans{cluster=~\"$cluster\", job=~\"($namespace)/distributor\"}[$__rate_interval]))",
+       "format": "time_series",
+       "interval": "1m",
+       "legendFormat": "refused",
+       "legendLink": null
+      },
+      {
+       "expr": "sum(rate(tempo_distributor_ingester_append_failures_total{cluster=~\"$cluster\", job=~\"($namespace)/distributor\"}[$__rate_interval]))",
+       "format": "time_series",
+       "interval": "1m",
+       "legendFormat": "ingester append failure",
+       "legendLink": null
+      }
+     ],
+     "thresholds": [
+
+     ],
+     "timeFrom": null,
+     "timeShift": null,
+     "title": "Receiver spans / sec",
+     "tooltip": {
+      "shared": true,
+      "sort": 2,
+      "value_type": "individual"
+     },
+     "type": "graph",
+     "xaxis": {
+      "buckets": null,
+      "mode": "time",
+      "name": null,
+      "show": true,
+      "values": [
+
+      ]
+     },
+     "yaxes": [
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": 0,
+       "show": true
+      },
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": null,
+       "show": false
+      }
+     ]
+    },
+    {
+     "aliasColors": {
+
+     },
+     "bars": false,
+     "dashLength": 10,
+     "dashes": false,
+     "datasource": "$datasource",
+     "fill": 1,
+     "id": 11,
+     "legend": {
+      "avg": false,
+      "current": false,
+      "max": false,
+      "min": false,
+      "show": true,
+      "total": false,
+      "values": false
+     },
+     "lines": true,
+     "linewidth": 1,
+     "links": [
+
+     ],
+     "nullPointMode": "null as zero",
+     "percentage": false,
+     "pointradius": 5,
+     "points": false,
+     "renderer": "flot",
+     "seriesOverrides": [
+
+     ],
+     "spaceLength": 10,
+     "span": 6,
+     "stack": false,
+     "steppedLine": false,
+     "targets": [
+      {
+       "expr": "sum(rate(tempo_discarded_spans_total{cluster=~\"$cluster\", job=~\"($namespace)/distributor\"}[$__rate_interval])) by(reason)",
+       "format": "time_series",
+       "interval": "1m",
+       "legendFormat": "{{reason}}",
+       "legendLink": null
+      }
+     ],
+     "thresholds": [
+
+     ],
+     "timeFrom": null,
+     "timeShift": null,
+     "title": "Discarded spans",
+     "tooltip": {
+      "shared": true,
+      "sort": 2,
+      "value_type": "individual"
+     },
+     "type": "graph",
+     "xaxis": {
+      "buckets": null,
+      "mode": "time",
+      "name": null,
+      "show": true,
+      "values": [
+
+      ]
+     },
+     "yaxes": [
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": 0,
+       "show": true
+      },
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": null,
+       "show": false
+      }
+     ]
+    }
+   ],
+   "repeat": null,
+   "repeatIteration": null,
+   "repeatRowId": null,
+   "showTitle": true,
+   "title": "",
+   "titleSize": "h6"
+  },
+  {
+   "collapse": false,
+   "height": "250px",
+   "panels": [
+    {
+     "aliasColors": {
+
+     },
+     "bars": false,
+     "dashLength": 10,
+     "dashes": false,
+     "datasource": "$datasource",
+     "fill": 1,
+     "id": 12,
+     "legend": {
+      "avg": false,
+      "current": false,
+      "max": false,
+      "min": false,
+      "show": true,
+      "total": false,
+      "values": false
+     },
+     "lines": true,
+     "linewidth": 1,
+     "links": [
+
+     ],
+     "nullPointMode": "null as zero",
+     "percentage": false,
+     "pointradius": 5,
+     "points": false,
+     "renderer": "flot",
+     "seriesOverrides": [
+
+     ],
+     "spaceLength": 10,
+     "span": 6,
+     "stack": false,
+     "steppedLine": false,
+     "targets": [
+      {
+       "expr": "sum(rate(tempo_distributor_produce_records_total{cluster=~\"$cluster\", job=~\"($namespace)/distributor\"}[$__rate_interval]))",
        "format": "time_series",
        "interval": "1m",
        "legendFormat": "appends",
@@ -747,7 +1132,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 1,
-     "id": 9,
+     "id": 13,
      "legend": {
       "avg": false,
       "current": false,
@@ -776,10 +1161,10 @@
      "steppedLine": false,
      "targets": [
       {
-       "expr": "sum(rate(tempo_distributor_kafka_appends_total{cluster=~\"$cluster\", job=~\"($namespace)/distributor\", status=\"fail\"}[$__rate_interval]))",
+       "expr": "sum(rate(tempo_distributor_produce_failures_total{cluster=~\"$cluster\", job=~\"($namespace)/distributor\"}[$__rate_interval])) by(reason)",
        "format": "time_series",
        "interval": "1m",
-       "legendFormat": "failed",
+       "legendFormat": "{{reason}}",
        "legendLink": null
       }
      ],
@@ -844,7 +1229,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 1,
-     "id": 10,
+     "id": 14,
      "legend": {
       "avg": false,
       "current": false,
@@ -934,7 +1319,7 @@
       }
      },
      "fill": 1,
-     "id": 11,
+     "id": 15,
      "legend": {
       "avg": false,
       "current": false,
@@ -1053,7 +1438,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 10,
-     "id": 12,
+     "id": 16,
      "legend": {
       "avg": false,
       "current": false,
@@ -1138,7 +1523,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 1,
-     "id": 13,
+     "id": 17,
      "legend": {
       "avg": false,
       "current": false,
@@ -1263,7 +1648,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 10,
-     "id": 14,
+     "id": 18,
      "legend": {
       "avg": false,
       "current": false,
@@ -1348,7 +1733,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 1,
-     "id": 15,
+     "id": 19,
      "legend": {
       "avg": false,
       "current": false,
@@ -1473,7 +1858,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 10,
-     "id": 16,
+     "id": 20,
      "legend": {
       "avg": false,
       "current": false,
@@ -1558,7 +1943,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 1,
-     "id": 17,
+     "id": 21,
      "legend": {
       "avg": false,
       "current": false,
@@ -1683,7 +2068,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 10,
-     "id": 18,
+     "id": 22,
      "legend": {
       "avg": false,
       "current": false,
@@ -1768,7 +2153,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 1,
-     "id": 19,
+     "id": 23,
      "legend": {
       "avg": false,
       "current": false,
@@ -1893,7 +2278,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 10,
-     "id": 20,
+     "id": 24,
      "legend": {
       "avg": false,
       "current": false,
@@ -1978,7 +2363,7 @@
      "dashes": false,
      "datasource": "$datasource",
      "fill": 1,
-     "id": 21,
+     "id": 25,
      "legend": {
       "avg": false,
       "current": false,

--- a/operations/tempo-mixin-compiled/dashboards/tempo-writes.json
+++ b/operations/tempo-mixin-compiled/dashboards/tempo-writes.json
@@ -276,7 +276,7 @@
      "steppedLine": false,
      "targets": [
       {
-       "expr": "sum by (grpc_status) (\n  rate(\n    label_replace(\n      {__name__=~\"envoy_cluster_grpc_[0-9]+\", cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw(-internal)?\"\",\n      \"grpc_status\", \"$1\", \"__name__\", \"envoy_cluster_grpc_([0-9]+)\"}\n    )\n  [ $__rate_interval : 30s ])\n)\n",
+       "expr": "sum by (grpc_status) (\n  rate(\n    label_replace(\n      {__name__=~\"envoy_cluster_grpc_[0-9]+\", cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw(-internal)?\"\"},\n      \"grpc_status\", \"$1\", \"__name__\", \"envoy_cluster_grpc_([0-9]+)\"\n    )\n  [ $__rate_interval : 30s ])\n)\n",
        "format": "time_series",
        "interval": "1m",
        "legendFormat": "{{grpc_status}}",

--- a/operations/tempo-mixin-compiled/dashboards/tempo-writes.json
+++ b/operations/tempo-mixin-compiled/dashboards/tempo-writes.json
@@ -276,7 +276,7 @@
      "steppedLine": false,
      "targets": [
       {
-       "expr": "sum by (grpc_status) (\n  rate(\n    label_replace(\n      {__name__=~\"envoy_cluster_grpc_[0-9]+\", cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw(-internal)?\"\"},\n      \"grpc_status\", \"$1\", \"__name__\", \"envoy_cluster_grpc_([0-9]+)\"\n    )\n  [ $__rate_interval : 30s ])\n)\n",
+       "expr": "sum by (grpc_status) (\n  rate(\n    label_replace(\n      {__name__=~\"envoy_cluster_grpc_[0-9]+\", cluster=~\"$cluster\", job=~\"($namespace)/cortex-gw(-internal)?\"\",\n      \"grpc_status\", \"$1\", \"__name__\", \"envoy_cluster_grpc_([0-9]+)\"}\n    )\n  [ $__rate_interval : 30s ])\n)\n",
        "format": "time_series",
        "interval": "1m",
        "legendFormat": "{{grpc_status}}",

--- a/operations/tempo-mixin/dashboards/tempo-writes.libsonnet
+++ b/operations/tempo-mixin/dashboards/tempo-writes.libsonnet
@@ -26,8 +26,8 @@ dashboard_utils {
               sum by (grpc_status) (
                 rate(
                   label_replace(
-                    {__name__=~"envoy_cluster_grpc_[0-9]+", %s",
-                    "grpc_status", "$1", "__name__", "envoy_cluster_grpc_([0-9]+)"}
+                    {__name__=~"envoy_cluster_grpc_[0-9]+", %s"},
+                    "grpc_status", "$1", "__name__", "envoy_cluster_grpc_([0-9]+)"
                   )
                 [ $__rate_interval : 30s ])
               )

--- a/operations/tempo-mixin/dashboards/tempo-writes.libsonnet
+++ b/operations/tempo-mixin/dashboards/tempo-writes.libsonnet
@@ -26,8 +26,8 @@ dashboard_utils {
               sum by (grpc_status) (
                 rate(
                   label_replace(
-                    {__name__=~"envoy_cluster_grpc_[0-9]+", %s"},
-                    "grpc_status", "$1", "__name__", "envoy_cluster_grpc_([0-9]+)"
+                    {__name__=~"envoy_cluster_grpc_[0-9]+", %s",
+                    "grpc_status", "$1", "__name__", "envoy_cluster_grpc_([0-9]+)"}
                   )
                 [ $__rate_interval : 30s ])
               )


### PR DESCRIPTION
**What this PR does**:
This PR improves the tempo write dashboard:
1. It uses the proper envoy metric

<img width="2154" height="518" alt="image" src="https://github.com/user-attachments/assets/e848df16-0f5f-4c55-94e7-c4d17d23bffd" />

2. It adds more envoy panels
<img width="4354" height="428" alt="image" src="https://github.com/user-attachments/assets/67f97e5e-e136-40a4-9399-472aea2fe5a8" />


3. Distributor now aggregates the discarded spans by reason

<img width="1454" height="530" alt="image" src="https://github.com/user-attachments/assets/e3e2e909-fe83-4a81-98a2-0944f7eae67f" />


5. Kafka records/s and Kafka failed appends now use: `tempo_distributor_kafka_write_bytes_total` and `tempo_distributor_produce_failures_total` metrics


**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`