### PR TITLE
[Bugfix] TraceQL Metrics fix for edge case

### DIFF
--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -136,7 +136,9 @@ func IntervalOfMs(tsmills int64, start, end, step uint64) int {
 func TrimToBlockOverlap(start, end, step uint64, blockStart, blockEnd time.Time) (uint64, uint64, uint64) {
 	wasInstant := end-start == step
 
-	start2 := uint64(blockStart.UnixNano())
+	// We subtract 1 nanosecond from the block's start time
+	// to make sure we include the left border of the block.
+	start2 := uint64(blockStart.UnixNano()) - 1
 	// Block's endTime is rounded down to the nearest second and considered inclusive.
 	// In order to include the right border with nanoseconds, we add 1 second
 	blockEnd = blockEnd.Add(time.Second)


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: Fixed an edge case bug: spans in a block with a single trace could not be queried if span's timestamp is rounded to seconds.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`