### PR TITLE
[Bugfix] TraceQL Metrics fix for edge case

### DIFF
--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -136,7 +136,9 @@ func IntervalOfMs(tsmills int64, start, end, step uint64) int {
 func TrimToBlockOverlap(start, end, step uint64, blockStart, blockEnd time.Time) (uint64, uint64, uint64) {
 	wasInstant := end-start == step
 
-	start2 := uint64(blockStart.UnixNano())
+	// We subtract 1 nanosecond from the block's start time
+	// to make sure we include the left border of the block.
+	start2 := uint64(blockStart.UnixNano()) - 1
 	// Block's endTime is rounded down to the nearest second and considered inclusive.
 	// In order to include the right border with nanoseconds, we add 1 second
 	blockEnd = blockEnd.Add(time.Second)

--- a/pkg/traceql/engine_metrics_test.go
+++ b/pkg/traceql/engine_metrics_test.go
@@ -221,13 +221,13 @@ func TestTrimToBlockOverlap(t *testing.T) {
 			// Fully overlapping
 			"2024-01-01 01:00:00", "2024-01-01 02:00:00", 5 * time.Minute,
 			"2024-01-01 01:33:00", "2024-01-01 01:38:00",
-			"2024-01-01 01:33:00", "2024-01-01 01:38:01", 5 * time.Minute, // added 1 second to include the last second of the block
+			"2024-01-01 01:32:59", "2024-01-01 01:38:01", 5 * time.Minute, // added 1 second to include the last second of the block
 		},
 		{
 			// Partially Overlapping
 			"2024-01-01 01:01:00", "2024-01-01 02:01:00", 5 * time.Minute,
 			"2024-01-01 01:31:00", "2024-01-01 02:31:00",
-			"2024-01-01 01:31:00", "2024-01-01 02:01:00", 5 * time.Minute,
+			"2024-01-01 01:30:59", "2024-01-01 02:01:00", 5 * time.Minute,
 		},
 		{
 			// Instant query
@@ -235,7 +235,7 @@ func TestTrimToBlockOverlap(t *testing.T) {
 			// Inner overlap is only 30m and step is updated to match
 			"2024-01-01 01:00:00", "2024-01-01 02:00:00", time.Hour,
 			"2024-01-01 01:30:00", "2024-01-01 02:30:00",
-			"2024-01-01 01:30:00", "2024-01-01 02:00:00", 30 * time.Minute,
+			"2024-01-01 01:29:59", "2024-01-01 02:00:00", 30*time.Minute + time.Nanosecond,
 		},
 	}
 
@@ -253,9 +253,9 @@ func TestTrimToBlockOverlap(t *testing.T) {
 			end2,
 		)
 
-		require.Equal(t, c.expectedStart, time.Unix(0, int64(actualStart)).UTC().Format(time.DateTime))
-		require.Equal(t, c.expectedEnd, time.Unix(0, int64(actualEnd)).UTC().Format(time.DateTime))
-		require.Equal(t, c.expectedStep, time.Duration(actualStep))
+		assert.Equal(t, c.expectedStart, time.Unix(0, int64(actualStart)).UTC().Format(time.DateTime))
+		assert.Equal(t, c.expectedEnd, time.Unix(0, int64(actualEnd)).UTC().Format(time.DateTime))
+		assert.Equal(t, c.expectedStep, time.Duration(actualStep))
 	}
 }
 


### PR DESCRIPTION
Fixes an edge case bug: if span matches block's
start time (e.g. spans in a block with a single trace), it could not be queried if span's timestamp is rounded to seconds.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: cherry-picks #5507 to `r212`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`