### PR TITLE
docs: add all the valid scopes to the tags search api doc

### DIFF
--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -375,7 +375,7 @@ curl -G -s http://localhost:3200/api/search/tags?scope=span  | jq
 
 Parameters:
 
-- `scope = (resource|span|intrinsic)`
+- `scope = (resource|span|intrinsic|event|link|instrumentation)`
   Optional. Specifies the scope of the tags. If not specified, it means all scopes.
   Default = `all`
 - `start = (unix epoch seconds)`
@@ -399,7 +399,7 @@ The tags endpoint takes a scope that controls the kinds of tags or attributes re
 If nothing is provided, the endpoint returns all resource and span tags.
 
 ```bash
-GET /api/v2/search/tags?scope=<resource|span|intrinsic>
+GET /api/v2/search/tags?scope=<resource|span|intrinsic|event|link|instrumentation>
 ```
 
 Parameters:


### PR DESCRIPTION

**What this PR does**:
New scopes were missing from the docs. This pr adds them


**Checklist**
- [X] Documentation added
