### PR TITLE
[bugfix] TraceQL Metrics: panic in compare

### DIFF
--- a/pkg/traceql/engine_metrics_compare.go
+++ b/pkg/traceql/engine_metrics_compare.go
@@ -234,6 +234,7 @@ func (m *MetricsCompare) result(multiplier float64) SeriesSet {
 	}
 
 	addValues := func(prefix Label, data map[Attribute]map[StaticMapKey]*staticWithCounts) {
+		var value *staticWithCounts
 		for a, values := range data {
 			// Compute topN values for this attribute
 			top.reset()
@@ -242,10 +243,15 @@ func (m *MetricsCompare) result(multiplier float64) SeriesSet {
 			}
 
 			top.get(m.topN, func(v Static) {
+				value = values[v.MapKey()]
+				var counts []float64
+				if value != nil {
+					counts = value.counts
+				}
 				add(Labels{
 					prefix,
 					{Name: a.String(), Value: v},
-				}, values[v.MapKey()].counts)
+				}, counts)
 			})
 
 			if len(values) > m.topN {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: fixes panic in TraceQL Metrics for Grafana Traces Drilldown query `{nestedSetParent>0 && true} | compare({})`

The bug is introduced by the following change https://github.com/grafana/tempo/pull/5419/files#diff-eb271e624dd1b0e372f056c46bbf31ed659448234bad1c80d87ccfe6e7a60f60L224-R236
Before the change, if a value not found under the given key, it would use empty struct, while here it becomes a nil pointer, which results in panic in `values[v.MapKey()].counts`

**How to reproduce the bug**:
Test case 1:

1. Run `examples/docker-compose/local`
2. In grafana (localhost:3000), open Traces Drilldown
3. Click on Duration histogram
4. Open Comparison Tab

Expected result: no error
Actual result: error `Query error An error occurred in the query`

Test case 2:
1. Run `examples/docker-compose/local` 
2. Execute query `{} | compare({})` in `/api/metrics/query_range`

Expected result: no error, returns 200 status code
Actual result: application crashed, panic in logs

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`