### PR TITLE
[bugfix] TraceQL Metrics: panic in compare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Additionally the `compaction_tenant_backoff_total` metric has been renamed to `c
 * [ENHANCEMENT] Make block ordering deterministic [#5411](https://github.com/grafana/tempo/pull/5411) (@rajiv-singh)
 * [BUGFIX] Fix race condition between compaction provider and backend-scheduler [#5409](https://github.com/grafana/tempo/pull/5409) (@zalegrala)
 * [BUGFIX] Do not allow very small steps [#5441](https://github.com/grafana/tempo/pull/5441) (@ruslan-mikhailov)
+* [BUGFIX] Fix incorrect results in TraceQL compare() for spans with array attributes [#5519](https://github.com/grafana/tempo/pull/5519) (@ruslan-mikhailov)
 
 # v2.8.2
 

--- a/pkg/util/slices.go
+++ b/pkg/util/slices.go
@@ -1,0 +1,12 @@
+package util
+
+// Clone returns a copy of the slice.
+// The elements are copied using assignment, so this is a shallow clone.
+// The difference with slices.Clone is that the result will not have additional unused capacity.
+func Clone[S ~[]E, E any](s S) S {
+	// Preserve nilness in case it matters.
+	if s == nil {
+		return nil
+	}
+	return append(make(S, 0, len(s)), s...)
+}

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -3334,13 +3334,13 @@ func (c *attributeCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 	case len(c.boolBuffer) == 1:
 		val = traceql.NewStaticBool(c.boolBuffer[0])
 	case len(c.strBuffer) > 1:
-		val = traceql.NewStaticStringArray(c.strBuffer)
+		val = traceql.NewStaticStringArray(util.Clone(c.strBuffer))
 	case len(c.intBuffer) > 1:
-		val = traceql.NewStaticIntArray(c.intBuffer)
+		val = traceql.NewStaticIntArray(util.Clone(c.intBuffer))
 	case len(c.floatBuffer) > 1:
-		val = traceql.NewStaticFloatArray(c.floatBuffer)
+		val = traceql.NewStaticFloatArray(util.Clone(c.floatBuffer))
 	case len(c.boolBuffer) > 1:
-		val = traceql.NewStaticBooleanArray(c.boolBuffer)
+		val = traceql.NewStaticBooleanArray(util.Clone(c.boolBuffer))
 	}
 
 	// reset the slices


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: 
This PR fixes origin issue that was unnoticed until it introduced a panic. Explanation why it panics can be found here: https://github.com/grafana/tempo/pull/5514

**The bug explanation.**
https://go.dev/play/p/P78nVSN44BP
The reason the value's changed in both slices is because they both point to the same array.

If we have two slices that point to one array:
<img width="1834" height="1190" alt="image" src="https://github.com/user-attachments/assets/1b5b7237-23f9-44ce-9fcc-1ca6360b022b" />

then we append to the first slice:
<img width="1934" height="1714" alt="image" src="https://github.com/user-attachments/assets/b8a44b6f-f95d-42bc-a4e1-6be8fc7e73f8" />

The same happens here.
1. We init struct with buffer [here](https://github.com/ruslan-mikhailov/tempo/blob/c73964fc471cdc2d10edb2f268e9bf90e9fce337/tempodb/encoding/vparquet4/block_traceql.go#L3337)
1. We reset buffer and append [here](https://github.com/ruslan-mikhailov/tempo/blob/c73964fc471cdc2d10edb2f268e9bf90e9fce337/tempodb/encoding/vparquet4/block_traceql.go#L3298-L3323)
1. We use the slice [here](https://github.com/ruslan-mikhailov/tempo/blob/c73964fc471cdc2d10edb2f268e9bf90e9fce337/pkg/traceql/ast.go#L755)

As the object is created per request, it does not expose data from other tenants, it just can mix attributes values from queried data.

In the end, at the moment request is processing [this line](https://github.com/ruslan-mikhailov/tempo/blob/c73964fc471cdc2d10edb2f268e9bf90e9fce337/pkg/traceql/engine_metrics_compare.go#L240), the value under the struct's already changed and calling `v.MapKey()` differs, which results in incorrect calculations.

**Note:** this change will increase number of allocated objects and increase pressure to GC which can lead to increased resource usage.


**How to reproduce the bug**:
Test case 1:

1. Run `examples/docker-compose/local`
2. In grafana (localhost:3000), open Traces Drilldown
3. Click on Duration histogram
4. Open Comparison Tab

Expected result: no error
Actual result: error `Query error An error occurred in the query`

Test case 2:
1. Run `examples/docker-compose/local` 
2. Execute query `{} | compare({})` in `/api/metrics/query_range`

Expected result: no error, returns 200 status code
Actual result: application crashed, panic in logs


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`