### PR TITLE
[Bugfix] Fix alloy gRPC endpoint port configuration from 4317 to 4319

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## main / unreleased
+* [BUGFIX] Fix docker-compose port configuration for Alloy gRPC (4319 → 4317) [#5536](https://github.com/grafana/tempo/pull/5536)
 * [BUGFIX] Fix panic error from empty span id. [#5464](https://github.com/grafana/tempo/pull/5464)
 * [BUGFIX] Return Bad Request from frontend if the provided tag is invalid in SearchTagValuesV2 endpoint [#5493](https://github.com/grafana/tempo/pull/5493/) (@carles-grafana)
 * [CHANGE] Add test for cost_attribution in user-configurable overrides API [#5481](https://github.com/grafana/tempo/pull/5481/) (@electron0zero)

--- a/example/docker-compose/alloy/docker-compose.yaml
+++ b/example/docker-compose/alloy/docker-compose.yaml
@@ -46,7 +46,7 @@ services:
       - --server.http.listen-addr=0.0.0.0:12345
     ports:
       - "12345:12345"
-      - "4319:4319"
+      - "4319:4317"
     depends_on:
       - tempo
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
* The Docker Compose file correctly exposes port 4319, but the mounted Alloy configuration is misconfigured to use 4317 for the gRPC endpoint. This mismatch causes connection failures when attempting to access the service. This PR updates the Alloy configuration to use the correct gRPC endpoint port 4319, ensuring consistency with the Docker Compose export and restoring proper connectivity



**Which issue(s) this PR fixes**:
* Resolves #5536

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`