### PR TITLE
Backport: [bugfix] Fix cache collision for incomplete query in SearchTagValuesV2

### DIFF
--- a/modules/livestore/instance_search.go
+++ b/modules/livestore/instance_search.go
@@ -612,23 +612,23 @@ func includeBlock(b *backend.BlockMeta, req *tempopb.SearchRequest) bool {
 // searchTagValuesV2CacheKey generates a cache key for the searchTagValuesV2 request
 // cache key is used as the filename to store the protobuf data on disk
 func searchTagValuesV2CacheKey(req *tempopb.SearchTagValuesRequest, limit int, prefix string) string {
-	query := req.Query
+	var cacheKey string
 	if req.Query != "" {
-		ast, err := traceql.Parse(req.Query)
-		if err == nil {
+		q := traceql.ExtractMatchers(req.Query)
+		if ast, err := traceql.Parse(q); err == nil {
 			// forces the query into a canonical form
-			query = ast.String()
+			cacheKey = ast.String()
 		} else {
 			// In case of a bad TraceQL query, we ignore the query and return unfiltered results.
 			// if we fail to parse the query, we will assume query is empty and compute the cache key.
-			query = ""
+			cacheKey = ""
 		}
 	}
 
 	// NOTE: we are not adding req.Start and req.End to the cache key because we don't respect the start and end
 	// please add them to cacheKey if we start respecting them
 	h := fnv1a.HashString64(req.TagName)
-	h = fnv1a.AddString64(h, query)
+	h = fnv1a.AddString64(h, cacheKey)
 	h = fnv1a.AddUint64(h, uint64(limit))
 
 	return fmt.Sprintf("%s_%v.buf", prefix, h)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: backports #5549 for live-store to keep modules in sync

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`