### PR TITLE
Rhythm/Live Store: Reject data enqueued older than CompleteBlockTimeout

### DIFF
--- a/modules/livestore/config.go
+++ b/modules/livestore/config.go
@@ -12,6 +12,8 @@ import (
 	"github.com/grafana/tempo/tempodb/wal"
 )
 
+const defaultCompleteBlockTimeout = time.Hour
+
 type Config struct {
 	Ring          ring.Config                  `yaml:"ring,omitempty"`
 	PartitionRing ingester.PartitionRingConfig `yaml:"partition_ring" category:"experimental"`
@@ -46,7 +48,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.PartitionRing.RegisterFlags(prefix, f)
 
 	// Set defaults for new fields
-	cfg.CompleteBlockTimeout = 1 * time.Hour
+	cfg.CompleteBlockTimeout = defaultCompleteBlockTimeout
 	cfg.QueryBlockConcurrency = 10
 	cfg.CompleteBlockConcurrency = 4
 	cfg.Metrics.TimeOverlapCutoff = 0.2

--- a/modules/livestore/live_store.go
+++ b/modules/livestore/live_store.go
@@ -316,8 +316,8 @@ func (s *LiveStore) stopping(error) error {
 		select {
 		case <-ticker.C:
 		case <-timeout.C:
-			level.Error(s.logger).Log("msg", "flush remaining blocks timed out", "isEmpty", s.completeQueues.IsEmpty()) // jpe
-			return nil                                                                                                  // shutdown timeout reached
+			level.Error(s.logger).Log("msg", "flush remaining blocks timed out")
+			return nil // shutdown timeout reached
 		}
 	}
 

--- a/pkg/util/test/metrics.go
+++ b/pkg/util/test/metrics.go
@@ -39,3 +39,11 @@ func GetCounterVecValue(metric *prometheus.CounterVec, label string) (float64, e
 	}
 	return m.Counter.GetValue(), nil
 }
+
+func MustGetCounterValue(metric prometheus.Counter) float64 {
+	value, err := GetCounterValue(metric)
+	if err != nil {
+		panic(err)
+	}
+	return value
+}


### PR DESCRIPTION
**What this PR does**:

Drops records by comparing the timestamp added to the queue vs complete block timeout. Deciding to reject or accept spans in the livestore based on time range is quite difficult. Consider the current ingesters. If you send a span 2 years in the past or future it will be consumed, added to a block and available for trace id search. Using span time to decide whether to consume a record doesn't feel like it would work. 

It's not perfect, but I decided to go with comparing CompleteBlockTimeout to the timestamp the record was added to the queue. This prevents the live store from unnecessarily drawing down hours of a queue unnecessarily while roughly approximating the behavior of the livestore if it was up to date on queue ingestion.

Also:
- Add a metric to record dropped records
- Test!