### PR TITLE
Livestore/Rhythm cleanup

### DIFF
--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -332,6 +332,9 @@ querier:
     metrics:
         concurrent_blocks: 2
         time_overlap_cutoff: 0.2
+    partition_ring:
+        minimize_requests: true
+        hedging_delay: 3s
     max_concurrent_queries: 20
     frontend_worker:
         frontend_address: ""
@@ -1215,4 +1218,21 @@ live_store:
     query_block_concurrency: 10
     complete_block_timeout: 1h0m0s
     complete_block_concurrency: 4
+    flush_check_period: 10s
+    flush_op_timeout: 5m0s
+    max_trace_live: 30s
+    max_trace_idle: 5s
+    max_block_duration: 30m0s
+    max_block_bytes: 524288000
+    block_config:
+        bloom_filter_false_positive: 0.01
+        bloom_filter_shard_size_bytes: 102400
+        version: ""
+        search_encoding: snappy
+        search_page_size_bytes: 1048576
+        v2_index_downsample_bytes: 1048576
+        v2_index_page_size_bytes: 256000
+        v2_encoding: zstd
+        parquet_row_group_size_bytes: 100000000
+        parquet_dedicated_columns: []
 ```

--- a/integration/e2e/ingest/config-live-store.yaml
+++ b/integration/e2e/ingest/config-live-store.yaml
@@ -1,4 +1,5 @@
 stream_over_http_enabled: true
+partition_ring_live_store: true
 
 server:
   http_listen_port: 3200

--- a/integration/e2e/ingest/live_store_test.go
+++ b/integration/e2e/ingest/live_store_test.go
@@ -31,7 +31,7 @@ func TestLiveStore(t *testing.T) {
 	// Wait until joined to partition ring
 	matchers := []*labels.Matcher{
 		{Type: labels.MatchEqual, Name: "state", Value: "Active"},
-		{Type: labels.MatchEqual, Name: "name", Value: "ingester-partitions"},
+		{Type: labels.MatchEqual, Name: "name", Value: "livestore-partitions"},
 	}
 	require.NoError(t, liveStore0.WaitSumMetricsWithOptions(e2e.Equals(2), []string{"tempo_partition_ring_partitions"}, e2e.WithLabelMatchers(matchers...)))
 

--- a/modules/livestore/config.go
+++ b/modules/livestore/config.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grafana/tempo/modules/ingester"
 	"github.com/grafana/tempo/pkg/ingest"
 	"github.com/grafana/tempo/pkg/ring"
-	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 	"github.com/grafana/tempo/tempodb/wal"
@@ -40,8 +39,7 @@ type Config struct {
 	MaxBlockBytes         uint64        `yaml:"max_block_bytes"`
 
 	// Block configuration
-	BlockConfig      common.BlockConfig       `yaml:"block_config"`
-	DedicatedColumns backend.DedicatedColumns `yaml:"-"`
+	BlockConfig common.BlockConfig `yaml:"block_config"`
 
 	// testing config
 	holdAllBackgroundProcesses bool `yaml:"-"` // if this is set to true, the live store will never release its background processes

--- a/modules/livestore/config_test.go
+++ b/modules/livestore/config_test.go
@@ -17,7 +17,7 @@ func TestConfigValidate(t *testing.T) {
 	}{
 		{
 			name: "valid config",
-			modifyConfig: func(cfg *Config) {
+			modifyConfig: func(_ *Config) {
 				// Default valid config, no modifications needed
 			},
 			expectedErr: "",

--- a/modules/livestore/config_test.go
+++ b/modules/livestore/config_test.go
@@ -1,0 +1,150 @@
+package livestore
+
+import (
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigValidate(t *testing.T) {
+	tests := []struct {
+		name         string
+		modifyConfig func(*Config)
+		expectedErr  string
+	}{
+		{
+			name: "valid config",
+			modifyConfig: func(cfg *Config) {
+				// Default valid config, no modifications needed
+			},
+			expectedErr: "",
+		},
+		{
+			name: "negative complete block timeout",
+			modifyConfig: func(cfg *Config) {
+				cfg.CompleteBlockTimeout = -1 * time.Second
+			},
+			expectedErr: "complete_block_timeout must be greater than 0",
+		},
+		{
+			name: "zero query block concurrency",
+			modifyConfig: func(cfg *Config) {
+				cfg.QueryBlockConcurrency = 0
+			},
+			expectedErr: "query_blocks must be greater than 0",
+		},
+		{
+			name: "negative complete block concurrency",
+			modifyConfig: func(cfg *Config) {
+				cfg.CompleteBlockConcurrency = -1
+			},
+			expectedErr: "complete_block_concurrency must be greater than 0",
+		},
+		{
+			name: "negative instance flush period",
+			modifyConfig: func(cfg *Config) {
+				cfg.InstanceFlushPeriod = -1 * time.Second
+			},
+			expectedErr: "flush_check_period must be greater than 0",
+		},
+		{
+			name: "zero instance flush period",
+			modifyConfig: func(cfg *Config) {
+				cfg.InstanceFlushPeriod = 0
+			},
+			expectedErr: "flush_check_period must be greater than 0",
+		},
+		{
+			name: "negative instance cleanup period",
+			modifyConfig: func(cfg *Config) {
+				cfg.InstanceCleanupPeriod = -1 * time.Second
+			},
+			expectedErr: "flush_op_timeout must be greater than 0",
+		},
+		{
+			name: "zero instance cleanup period",
+			modifyConfig: func(cfg *Config) {
+				cfg.InstanceCleanupPeriod = 0
+			},
+			expectedErr: "flush_op_timeout must be greater than 0",
+		},
+		{
+			name: "negative max trace live",
+			modifyConfig: func(cfg *Config) {
+				cfg.MaxTraceLive = -1 * time.Second
+			},
+			expectedErr: "max_trace_live must be greater than 0",
+		},
+		{
+			name: "zero max trace live",
+			modifyConfig: func(cfg *Config) {
+				cfg.MaxTraceLive = 0
+			},
+			expectedErr: "max_trace_live must be greater than 0",
+		},
+		{
+			name: "negative max trace idle",
+			modifyConfig: func(cfg *Config) {
+				cfg.MaxTraceIdle = -1 * time.Second
+			},
+			expectedErr: "max_trace_idle must be greater than 0",
+		},
+		{
+			name: "zero max trace idle",
+			modifyConfig: func(cfg *Config) {
+				cfg.MaxTraceIdle = 0
+			},
+			expectedErr: "max_trace_idle must be greater than 0",
+		},
+		{
+			name: "negative max block duration",
+			modifyConfig: func(cfg *Config) {
+				cfg.MaxBlockDuration = -1 * time.Second
+			},
+			expectedErr: "max_block_duration must be greater than 0",
+		},
+		{
+			name: "zero max block duration",
+			modifyConfig: func(cfg *Config) {
+				cfg.MaxBlockDuration = 0
+			},
+			expectedErr: "max_block_duration must be greater than 0",
+		},
+		{
+			name: "zero max block bytes",
+			modifyConfig: func(cfg *Config) {
+				cfg.MaxBlockBytes = 0
+			},
+			expectedErr: "max_block_bytes must be greater than 0",
+		},
+		{
+			name: "max trace idle greater than max trace live",
+			modifyConfig: func(cfg *Config) {
+				cfg.MaxTraceLive = 10 * time.Second
+				cfg.MaxTraceIdle = 20 * time.Second
+			},
+			expectedErr: "max_trace_idle (20s) cannot be greater than max_trace_live (10s)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// default config
+			cfg := Config{}
+			cfg.RegisterFlagsAndApplyDefaults("", &flag.FlagSet{})
+			tt.modifyConfig(&cfg)
+
+			err := cfg.Validate()
+
+			if tt.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+			}
+		})
+	}
+}

--- a/modules/livestore/flush.go
+++ b/modules/livestore/flush.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	maxBackoff       = 120 * time.Second
+	initialBackoff   = 30 * time.Second
 	maxFlushAttempts = 10
 )
 
@@ -122,7 +123,7 @@ func (s *LiveStore) globalCompleteLoop(idx int) {
 
 func (s *LiveStore) perTenantCutToWalLoop(instance *instance) {
 	// ticker
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := time.NewTicker(s.cfg.InstanceFlushPeriod)
 	defer ticker.Stop()
 
 	for {
@@ -137,7 +138,7 @@ func (s *LiveStore) perTenantCutToWalLoop(instance *instance) {
 
 func (s *LiveStore) perTenantCleanupLoop(inst *instance) {
 	// ticker
-	ticker := time.NewTicker(30 * time.Second)
+	ticker := time.NewTicker(s.cfg.InstanceCleanupPeriod)
 	defer ticker.Stop()
 
 	for {
@@ -160,7 +161,7 @@ func (s *LiveStore) enqueueCompleteOp(tenantID string, blockID uuid.UUID) error 
 		blockID:  blockID,
 		// Initial priority and backoff
 		at: time.Now(),
-		bo: 30 * time.Second,
+		bo: initialBackoff,
 	})
 }
 

--- a/modules/livestore/instance.go
+++ b/modules/livestore/instance.go
@@ -292,7 +292,6 @@ func (i *instance) cutBlocks(immediate bool) (uuid.UUID, error) {
 	return id, nil
 }
 
-
 func (i *instance) completeBlock(ctx context.Context, id uuid.UUID) error {
 	ctx, span := tracer.Start(ctx, "instance.completeBlock",
 		oteltrace.WithAttributes(

--- a/modules/livestore/instance.go
+++ b/modules/livestore/instance.go
@@ -2,7 +2,6 @@ package livestore
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"math"
 	"sync"
@@ -114,7 +113,7 @@ func newInstance(instanceID string, cfg Config, wal *wal.WAL, overrides override
 		enc:                enc,
 		walBlocks:          map[uuid.UUID]common.WALBlock{},
 		completeBlocks:     map[uuid.UUID]*ingester.LocalBlock{},
-		liveTraces:         livetraces.New[*v1.ResourceSpans](func(rs *v1.ResourceSpans) uint64 { return uint64(rs.Size()) }, 30*time.Second, 5*time.Minute),
+		liveTraces:         livetraces.New[*v1.ResourceSpans](func(rs *v1.ResourceSpans) uint64 { return uint64(rs.Size()) }, cfg.MaxTraceLive, cfg.MaxTraceIdle),
 		traceSizes:         tracesizes.New(),
 		overrides:          overrides,
 		tracesCreatedTotal: metricTracesCreatedTotal.WithLabelValues(instanceID),
@@ -270,11 +269,7 @@ func (i *instance) cutBlocks(immediate bool) (uuid.UUID, error) {
 		return uuid.Nil, nil
 	}
 
-	// TODO: Configurable
-	maxBlockDuration := 5 * time.Minute
-	maxBlockBytes := uint64(100 * 1024 * 1024) // 100MB
-
-	if !immediate && time.Since(i.lastCutTime) < maxBlockDuration && i.headBlock.DataLength() < maxBlockBytes {
+	if !immediate && time.Since(i.lastCutTime) < i.Cfg.MaxBlockDuration && i.headBlock.DataLength() < i.Cfg.MaxBlockBytes {
 		return uuid.Nil, nil
 	}
 
@@ -297,12 +292,6 @@ func (i *instance) cutBlocks(immediate bool) (uuid.UUID, error) {
 	return id, nil
 }
 
-var blockConfig = common.BlockConfig{}
-
-func init() {
-	// TODO MRD this is a hack until we roll the config into the livestore
-	blockConfig.RegisterFlagsAndApplyDefaults("", &flag.FlagSet{})
-}
 
 func (i *instance) completeBlock(ctx context.Context, id uuid.UUID) error {
 	ctx, span := tracer.Start(ctx, "instance.completeBlock",
@@ -338,7 +327,7 @@ func (i *instance) completeBlock(ctx context.Context, id uuid.UUID) error {
 	}
 	defer iter.Close()
 
-	newMeta, err := i.enc.CreateBlock(ctx, &blockConfig, walBlock.BlockMeta(), iter, reader, writer)
+	newMeta, err := i.enc.CreateBlock(ctx, &i.Cfg.BlockConfig, walBlock.BlockMeta(), iter, reader, writer)
 	if err != nil {
 		level.Error(i.logger).Log("msg", "failed to create complete block", "id", id, "err", err)
 		span.RecordError(err)

--- a/modules/livestore/live_store.go
+++ b/modules/livestore/live_store.go
@@ -310,7 +310,7 @@ func (s *LiveStore) stopping(error) error {
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
-	timeout := time.NewTimer(30 * time.Second) // TODO: Configurable?
+	timeout := time.NewTimer(s.cfg.InstanceCleanupPeriod)
 	defer timeout.Stop()
 
 	for !s.completeQueues.IsEmpty() {
@@ -491,7 +491,7 @@ func (s *LiveStore) SearchBlock(_ context.Context, _ *tempopb.SearchBlockRequest
 	return nil, fmt.Errorf("SearchBlock not implemented in livestore")
 }
 
-// SearchTags implements tempopb.Querier
+// SearchTags implements tempopb.Querier epj consolidate below code
 func (s *LiveStore) SearchTags(ctx context.Context, req *tempopb.SearchTagsRequest) (*tempopb.SearchTagsResponse, error) {
 	instanceID, err := user.ExtractOrgID(ctx)
 	if err != nil {

--- a/modules/livestore/live_store.go
+++ b/modules/livestore/live_store.go
@@ -3,7 +3,6 @@ package livestore
 import (
 	"context"
 	"fmt"
-	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -441,11 +440,7 @@ func (s *LiveStore) cutOneInstanceToWal(inst *instance, immediate bool) {
 
 // OnRingInstanceRegister implements ring.BasicLifecyclerDelegate
 func (s *LiveStore) OnRingInstanceRegister(_ *ring.BasicLifecycler, _ ring.Desc, _ bool, _ string, _ ring.InstanceDesc) (ring.InstanceState, ring.Tokens) {
-	// tokens don't matter for the livestore ring, we just need to be in the ring for service discovery
-	token := rand.Uint32() //nolint: gosec // G404 we don't need a cryptographic random number here
-	level.Info(s.logger).Log("msg", "registered in livestore ring", "token", token, "partition", s.ingestPartitionID)
-
-	return ring.ACTIVE, []uint32{token}
+	return ring.ACTIVE, nil
 }
 
 // OnRingInstanceTokens implements ring.BasicLifecyclerDelegate

--- a/modules/livestore/live_store.go
+++ b/modules/livestore/live_store.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/user"
-	"github.com/grafana/tempo/modules/ingester"
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/pkg/flushqueues"
 	"github.com/grafana/tempo/pkg/ingest"
@@ -34,6 +33,9 @@ const (
 	// ringAutoForgetUnhealthyPeriods is how many consecutive timeout periods an unhealthy instance
 	// in the ring will be automatically removed.
 	ringAutoForgetUnhealthyPeriods = 2
+
+	PartitionRingKey  = "livestore-partitions"
+	PartitionRingName = "livestore-partitions"
 )
 
 var (
@@ -145,7 +147,7 @@ func New(cfg Config, overridesService overrides.Interface, logger log.Logger, re
 	} else {
 		s.ingestPartitionID, err = ingest.IngesterPartitionID(cfg.Ring.InstanceID)
 		if err != nil {
-			return nil, fmt.Errorf("calculating ingester partition ID: %w", err)
+			return nil, fmt.Errorf("calculating livestore partition ID: %w", err)
 		}
 	}
 
@@ -153,22 +155,22 @@ func New(cfg Config, overridesService overrides.Interface, logger log.Logger, re
 	//  https://raintank-corp.slack.com/archives/C05CAA0ULUF/p1752847274420489
 	s.cfg.IngestConfig.Kafka.ConsumerGroup, err = ingest.LiveStoreConsumerGroupID(cfg.Ring.InstanceID)
 	if err != nil {
-		return nil, fmt.Errorf("calculating ingester consumer group ID: %w", err)
+		return nil, fmt.Errorf("calculating livestore consumer group ID: %w", err)
 	}
 
 	// setup partition ring
 	partitionRingKV := cfg.PartitionRing.KVStore.Mock
 	if partitionRingKV == nil {
-		partitionRingKV, err = kv.NewClient(cfg.PartitionRing.KVStore, ring.GetPartitionRingCodec(), kv.RegistererWithKVName(reg, ingester.PartitionRingName+"-lifecycler"), logger)
+		partitionRingKV, err = kv.NewClient(cfg.PartitionRing.KVStore, ring.GetPartitionRingCodec(), kv.RegistererWithKVName(reg, PartitionRingName+"-lifecycler"), logger)
 		if err != nil {
-			return nil, fmt.Errorf("creating KV store for ingester partition ring: %w", err)
+			return nil, fmt.Errorf("creating KV store for livestore partition ring: %w", err)
 		}
 	}
 
 	s.ingestPartitionLifecycler = ring.NewPartitionInstanceLifecycler(
 		s.cfg.PartitionRing.ToLifecyclerConfig(s.ingestPartitionID, cfg.Ring.InstanceID),
-		ingester.PartitionRingName,
-		ingester.PartitionRingKey,
+		PartitionRingName,
+		PartitionRingKey,
 		partitionRingKV,
 		logger,
 		prometheus.WrapRegistererWithPrefix("tempo_", reg))
@@ -187,7 +189,7 @@ func New(cfg Config, overridesService overrides.Interface, logger log.Logger, re
 		}
 	}
 
-	lifecyclerCfg, err := cfg.Ring.ToLifecyclerConfig(ringNumTokens)
+	lifecyclerCfg, err := cfg.Ring.ToLifecyclerConfig(ringNumTokens) // jpe 0?
 	if err != nil {
 		return nil, fmt.Errorf("invalid ring lifecycler config: %w", err)
 	}
@@ -440,7 +442,7 @@ func (s *LiveStore) cutOneInstanceToWal(inst *instance, immediate bool) {
 
 // OnRingInstanceRegister implements ring.BasicLifecyclerDelegate
 func (s *LiveStore) OnRingInstanceRegister(_ *ring.BasicLifecycler, _ ring.Desc, _ bool, _ string, _ ring.InstanceDesc) (ring.InstanceState, ring.Tokens) {
-	return ring.ACTIVE, nil
+	return ring.ACTIVE, nil // no tokens needed for the livestore ring, we just need to be in the ring for service discovery
 }
 
 // OnRingInstanceTokens implements ring.BasicLifecyclerDelegate

--- a/modules/livestore/live_store.go
+++ b/modules/livestore/live_store.go
@@ -491,7 +491,7 @@ func (s *LiveStore) SearchBlock(_ context.Context, _ *tempopb.SearchBlockRequest
 	return nil, fmt.Errorf("SearchBlock not implemented in livestore")
 }
 
-// SearchTags implements tempopb.Querier epj consolidate below code
+// SearchTags implements tempopb.Querier
 func (s *LiveStore) SearchTags(ctx context.Context, req *tempopb.SearchTagsRequest) (*tempopb.SearchTagsResponse, error) {
 	instanceID, err := user.ExtractOrgID(ctx)
 	if err != nil {

--- a/modules/livestore/live_store.go
+++ b/modules/livestore/live_store.go
@@ -189,7 +189,7 @@ func New(cfg Config, overridesService overrides.Interface, logger log.Logger, re
 		}
 	}
 
-	lifecyclerCfg, err := cfg.Ring.ToLifecyclerConfig(ringNumTokens) // jpe 0?
+	lifecyclerCfg, err := cfg.Ring.ToLifecyclerConfig(0)
 	if err != nil {
 		return nil, fmt.Errorf("invalid ring lifecycler config: %w", err)
 	}

--- a/modules/livestore/metrics_test.go
+++ b/modules/livestore/metrics_test.go
@@ -2,6 +2,7 @@ package livestore
 
 import (
 	"context"
+	"flag"
 	"testing"
 	"time"
 
@@ -50,8 +51,10 @@ func setupTest(t *testing.T) *testSetup {
 
 	// Create instance
 	cfg := Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", &flag.FlagSet{})
 	instance, err := newInstance(testTenant, cfg, w, o, log.NewNopLogger())
 	require.NoError(t, err)
+
 	return &testSetup{
 		tmpDir:    tmpDir,
 		wal:       w,

--- a/modules/livestore/query_range_test.go
+++ b/modules/livestore/query_range_test.go
@@ -2,6 +2,7 @@ package livestore
 
 import (
 	"context"
+	"flag"
 	"path"
 	"testing"
 	"time"
@@ -28,6 +29,7 @@ func TestLiveStoreQueryRange(t *testing.T) {
 	)
 
 	cfg := Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", &flag.FlagSet{})
 	cfg.Metrics.TimeOverlapCutoff = 0.5
 	cfg.QueryBlockConcurrency = 10
 	cfg.CompleteBlockTimeout = 5 * time.Minute

--- a/modules/querier/config.go
+++ b/modules/querier/config.go
@@ -12,9 +12,10 @@ import (
 
 // Config for a querier.
 type Config struct {
-	Search    SearchConfig    `yaml:"search"`
-	TraceByID TraceByIDConfig `yaml:"trace_by_id"`
-	Metrics   MetricsConfig   `yaml:"metrics"`
+	Search        SearchConfig        `yaml:"search"`
+	TraceByID     TraceByIDConfig     `yaml:"trace_by_id"`
+	Metrics       MetricsConfig       `yaml:"metrics"`
+	PartitionRing PartitionRingConfig `yaml:"partition_ring"`
 
 	ExtraQueryDelay                        time.Duration `yaml:"extra_query_delay,omitempty"`
 	MaxConcurrentQueries                   int           `yaml:"max_concurrent_queries"`
@@ -45,6 +46,12 @@ type MetricsConfig struct {
 	TimeOverlapCutoff float64 `yaml:"time_overlap_cutoff,omitempty"`
 }
 
+type PartitionRingConfig struct {
+	MinimizeRequests             bool          `yaml:"minimize_requests"`
+	MinimizeRequestsHedgingDelay time.Duration `yaml:"hedging_delay"`
+	PreferredZone                string        `yaml:"preferred_zone,omitempty"`
+}
+
 // RegisterFlagsAndApplyDefaults register flags.
 func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 	cfg.TraceByID.QueryTimeout = 10 * time.Second
@@ -71,6 +78,9 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 		DNSLookupPeriod: 10 * time.Second,
 	}
 	cfg.ShuffleShardingIngestersLookbackPeriod = 1 * time.Hour
+	cfg.PartitionRing.MinimizeRequests = true
+	cfg.PartitionRing.MinimizeRequestsHedgingDelay = 3 * time.Second
+	cfg.PartitionRing.PreferredZone = ""
 
 	f.StringVar(&cfg.Worker.FrontendAddress, prefix+".frontend-address", "", "Address of query frontend service, in host:port format.")
 }

--- a/modules/querier/partition_ring.go
+++ b/modules/querier/partition_ring.go
@@ -3,7 +3,6 @@ package querier
 import (
 	"context"
 	"math/rand/v2"
-	"time"
 
 	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/ring"
@@ -35,11 +34,11 @@ func forPartitionRingReplicaSets[R any, TClient any](ctx context.Context, q *Que
 
 // queryQuorumConfigForReplicationSets returns the config to use with "do until quorum" functions when running queries.
 func (q *Querier) queryQuorumConfigForReplicationSets(_ context.Context, _ []ring.ReplicationSet) ring.DoUntilQuorumConfig {
-	zoneSorter := queryIngesterPartitionsRingZoneSorter("") // todo: make configurable
+	zoneSorter := queryIngesterPartitionsRingZoneSorter(q.cfg.PartitionRing.PreferredZone)
 
 	return ring.DoUntilQuorumConfig{
-		MinimizeRequests: true, // todo: make configurable
-		HedgingDelay:     500 * time.Millisecond,
+		MinimizeRequests: q.cfg.PartitionRing.MinimizeRequests,
+		HedgingDelay:     q.cfg.PartitionRing.MinimizeRequestsHedgingDelay,
 		ZoneSorter:       zoneSorter,
 		Logger:           nil, // pass a logger?
 	}


### PR DESCRIPTION
**What this PR does**:

- Splits the ingester and livestore partition rings. Previously they used the same ring but this makes them independent.
- Added config options for livestore that were previously hardcoded (used ingester defaults)
- Added BlockConfig and properly defaulted it
- Added validation/tests for livestore config
- Added config to the querier to control how the partition ring is queried