### PR TITLE
Add tests to make unsafe usages more robust

### DIFF
--- a/pkg/parquetquery/intern/intern.go
+++ b/pkg/parquetquery/intern/intern.go
@@ -27,7 +27,7 @@ func NewWithSize(size int) *Interner {
 func (i *Interner) UnsafeClone(v *pq.Value) pq.Value {
 	switch v.Kind() {
 	case pq.ByteArray, pq.FixedLenByteArray:
-		// Look away, this is unsafe.
+		// This is unsafe but validated by tests.
 		a := *(*pqValue)(unsafe.Pointer(v))
 		a.ptr = addressOfBytes(i.internBytes(a.byteArray()))
 		return *(*pq.Value)(unsafe.Pointer(&a))
@@ -61,8 +61,8 @@ func bytesToString(b []byte) string { return unsafe.String(unsafe.SliceData(b), 
 // The data should not be modified after call.
 func addressOfBytes(data []byte) *byte { return unsafe.SliceData(data) }
 
-// bytes converts a pointer to a slice of bytes
-func bytes(data *byte, size int) []byte { return unsafe.Slice(data, size) }
+// bytesFromPtr converts a pointer to a slice of bytes
+func bytesFromPtr(data *byte, size int) []byte { return unsafe.Slice(data, size) }
 
 // pqValue is a slimmer version of github.com/parquet-go/parquet-go's pq.Value.
 type pqValue struct {
@@ -74,5 +74,5 @@ type pqValue struct {
 }
 
 func (v *pqValue) byteArray() []byte {
-	return bytes(v.ptr, int(v.u64))
+	return bytesFromPtr(v.ptr, int(v.u64))
 }

--- a/pkg/regexp/regexp.go
+++ b/pkg/regexp/regexp.go
@@ -90,23 +90,26 @@ func (r *Regexp) String() string {
 	return strings
 }
 
+// cheatToSeeInternals is a struct that mirrors the memory layout of labels.FastRegexMatcher
+// to allow unsafe access to its private fields for performance optimization decisions.
+// This struct must match the exact memory layout of FastRegexMatcher.
+type cheatToSeeInternals struct {
+	reString string
+	re       *regexp.Regexp
+
+	setMatches    []string
+	stringMatcher labels.StringMatcher
+	prefix        string
+	suffix        string
+	contains      []string
+
+	matchString func(string) bool
+}
+
 // shouldMemoize returns true if we believe that memoizing this regex would be faster
 // the evaluating it directly. see thoughts below.
 func shouldMemoize(m *labels.FastRegexMatcher) bool {
-	// matches labels.FastRegexMatcher
-	type cheatToSeeInternals struct {
-		reString string
-		re       *regexp.Regexp
-
-		setMatches    []string
-		stringMatcher labels.StringMatcher
-		prefix        string
-		suffix        string
-		contains      []string
-
-		matchString func(string) bool
-	}
-
+	// This is unsafe but validated by tests.
 	cheat := (*cheatToSeeInternals)(unsafe.Pointer(m))
 
 	// TODO: research and improve this. we're making a guess on whether an optimization will improve the regex

--- a/pkg/regexp/regexp_test.go
+++ b/pkg/regexp/regexp_test.go
@@ -2,6 +2,7 @@ package regexp
 
 import (
 	"testing"
+	"unsafe"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
@@ -21,6 +22,137 @@ func TestRegexpMatch(t *testing.T) {
 	require.False(t, r.Match([]byte("abc")))
 	require.False(t, r.MatchString("abc"))
 	require.True(t, r.MatchString("xyz"))
+}
+
+func TestCheatToSeeInternalsSafety(t *testing.T) {
+	// This test checks that our cheatToSeeInternals struct has compatible memory layout
+	// with Prometheus labels.FastRegexMatcher, in case the latter changes in the future.
+
+	t.Run("field_has_correct_order", func(t *testing.T) {
+		// This test validates that critical fields are at expected offsets to detect field reordering.
+		// Field reordering would pass size/alignment checks but cause reading wrong memory locations.
+
+		var cheat cheatToSeeInternals
+
+		require.Equal(t, uintptr(0), unsafe.Offsetof(cheat.reString),
+			"reString should be at offset 0 - struct field order may have changed")
+
+		stringMatcherOffset := unsafe.Offsetof(cheat.stringMatcher)
+		setMatchesOffset := unsafe.Offsetof(cheat.setMatches)
+		prefixOffset := unsafe.Offsetof(cheat.prefix)
+		suffixOffset := unsafe.Offsetof(cheat.suffix)
+
+		require.True(t, stringMatcherOffset > setMatchesOffset,
+			"stringMatcher should come after setMatches")
+		require.True(t, prefixOffset > stringMatcherOffset,
+			"prefix should come after stringMatcher")
+		require.True(t, suffixOffset > prefixOffset,
+			"suffix should come after prefix")
+	})
+
+	t.Run("struct_layout_validation", func(t *testing.T) {
+		var matcher labels.FastRegexMatcher
+
+		var cheat cheatToSeeInternals
+
+		matcherSize := unsafe.Sizeof(matcher)
+		cheatSize := unsafe.Sizeof(cheat)
+		require.Equal(t, matcherSize, cheatSize, "struct size mismatch")
+
+		matcherAlign := unsafe.Alignof(matcher)
+		cheatAlign := unsafe.Alignof(cheat)
+		require.Equal(t, matcherAlign, cheatAlign, "struct alignment mismatch")
+	})
+
+	t.Run("exact_string_should_have_reString_field_populated", func(t *testing.T) {
+		matcher, err := labels.NewFastRegexMatcher("simple-exact-match")
+		require.NoError(t, err, "should create matcher for simple-exact-match")
+
+		cheat := (*cheatToSeeInternals)(unsafe.Pointer(matcher))
+
+		require.Equal(t, "simple-exact-match", cheat.reString, "reString field should contain the original regex")
+
+		require.NotNil(t, cheat.matchString, "matchString function should not be nil")
+
+		require.True(t, cheat.matchString("simple-exact-match"), "matchString should work for exact match")
+		require.False(t, cheat.matchString("different"), "matchString should reject non-matches")
+	})
+
+	t.Run("prefix_pattern_should_have_prefix_field_set", func(t *testing.T) {
+		matcher, err := labels.NewFastRegexMatcher("prefix-test.*")
+		require.NoError(t, err, "should create matcher for prefix-test.*")
+
+		cheat := (*cheatToSeeInternals)(unsafe.Pointer(matcher))
+
+		require.Equal(t, "prefix-test.*", cheat.reString, "reString should match original")
+		require.Equal(t, "prefix-test", cheat.prefix, "prefix field should be set for prefix patterns")
+		require.Empty(t, cheat.suffix, "suffix should be empty for prefix patterns")
+
+		require.NotNil(t, cheat.matchString, "matchString should be available")
+		require.True(t, cheat.matchString("prefix-test-something"), "should match prefix pattern")
+		require.False(t, cheat.matchString("different-prefix"), "should not match different prefix")
+	})
+
+	t.Run("suffix_pattern_should_have_suffix_field_set", func(t *testing.T) {
+		matcher, err := labels.NewFastRegexMatcher(".*suffix-test")
+		require.NoError(t, err, "should create matcher for .*suffix-test")
+
+		cheat := (*cheatToSeeInternals)(unsafe.Pointer(matcher))
+
+		require.Equal(t, ".*suffix-test", cheat.reString, "reString should match original")
+		require.Equal(t, "suffix-test", cheat.suffix, "suffix field should be set for suffix patterns")
+		require.Empty(t, cheat.prefix, "prefix should be empty for suffix patterns")
+
+		require.NotNil(t, cheat.matchString, "matchString should be available")
+		require.True(t, cheat.matchString("something-suffix-test"), "should match suffix pattern")
+		require.False(t, cheat.matchString("suffix-test-extra"), "should not match with extra suffix")
+	})
+
+	t.Run("alternation_pattern_should_populate_setMatches", func(t *testing.T) {
+		matcher, err := labels.NewFastRegexMatcher("option1|option2|option3")
+		require.NoError(t, err, "should create matcher for option1|option2|option3")
+
+		cheat := (*cheatToSeeInternals)(unsafe.Pointer(matcher))
+
+		require.Equal(t, "option1|option2|option3", cheat.reString, "reString should match original")
+
+		expectedOptions := []string{"option1", "option2", "option3"}
+		for _, expected := range expectedOptions {
+			found := false
+			for _, actual := range cheat.setMatches {
+				if actual == expected {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Logf("expected option %q not found in setMatches %v", expected, cheat.setMatches)
+			}
+		}
+
+		require.NotNil(t, cheat.matchString, "matchString should be available")
+		require.True(t, cheat.matchString("option1"), "should match first option")
+		require.True(t, cheat.matchString("option2"), "should match second option")
+		require.True(t, cheat.matchString("option3"), "should match third option")
+		require.False(t, cheat.matchString("option4"), "should not match non-option")
+	})
+
+	t.Run("contains_pattern_should_populate_contains_field", func(t *testing.T) {
+		matcher, err := labels.NewFastRegexMatcher(".*contains.*test.*")
+		require.NoError(t, err, "should create matcher for .*contains.*test.*")
+
+		cheat := (*cheatToSeeInternals)(unsafe.Pointer(matcher))
+
+		require.Equal(t, ".*contains.*test.*", cheat.reString, "reString should match original")
+
+		require.Contains(t, cheat.contains, "contains", "should include 'contains' substring")
+		require.Contains(t, cheat.contains, "test", "should include 'test' substring")
+
+		require.NotNil(t, cheat.matchString, "matchString should be available")
+		require.True(t, cheat.matchString("prefix-contains-middle-test-suffix"), "should match when both substrings present")
+		require.False(t, cheat.matchString("contains-only"), "should not match with only first substring")
+		require.False(t, cheat.matchString("test-only"), "should not match with only second substring")
+	})
 }
 
 func TestShouldMemoize(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

We have a couple of unsafe usages which could use more verification
to ensure a change in upstream dependencies don't cause panics or
wrong results.

This is the case of pq.Value in parquet-go, and labels.FastRegexMatcher in prometheus

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`