### PR TITLE
Livestore: Partition ring fixes

### DIFF
--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -605,6 +605,7 @@ metrics_generator:
         instance_addr: ""
         instance_port: 0
         enable_inet6: false
+        instance_zone: ""
     processor:
         service_graphs:
             wait: 10s
@@ -1181,6 +1182,7 @@ live_store:
         instance_addr: ""
         instance_port: 0
         enable_inet6: false
+        instance_zone: ""
     partition_ring:
         kvstore:
             store: memberlist

--- a/example/docker-compose/ingest-storage/docker-compose.yaml
+++ b/example/docker-compose/ingest-storage/docker-compose.yaml
@@ -61,7 +61,7 @@ services:
     image: *tempoImage
     depends_on:
       - kafka
-    command: "-target=live-store -config.file=/etc/tempo.yaml"
+    command: "-target=live-store -config.file=/etc/tempo.yaml -live-store.instance-availability-zone=zone-a"
     restart: always
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml
@@ -76,7 +76,7 @@ services:
     image: *tempoImage
     depends_on:
       - kafka
-    command: "-target=live-store -config.file=/etc/tempo.yaml"
+    command: "-target=live-store -config.file=/etc/tempo.yaml -live-store.instance-availability-zone=zone-a"
     restart: always
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml
@@ -91,7 +91,7 @@ services:
     image: *tempoImage
     depends_on:
       - kafka
-    command: "-target=live-store -config.file=/etc/tempo.yaml"
+    command: "-target=live-store -config.file=/etc/tempo.yaml -live-store.instance-availability-zone=zone-b"
     restart: always
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml
@@ -106,7 +106,7 @@ services:
     image: *tempoImage
     depends_on:
       - kafka
-    command: "-target=live-store -config.file=/etc/tempo.yaml"
+    command: "-target=live-store -config.file=/etc/tempo.yaml -live-store.instance-availability-zone=zone-b"
     restart: always
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml

--- a/modules/livestore/config_test.go
+++ b/modules/livestore/config_test.go
@@ -128,13 +128,6 @@ func TestConfigValidate(t *testing.T) {
 			},
 			expectedErr: "max_trace_idle (20s) cannot be greater than max_trace_live (10s)",
 		},
-		{
-			name: "empty instance zone",
-			modifyConfig: func(cfg *Config) {
-				cfg.Ring.InstanceZone = ""
-			},
-			expectedErr: "instance_zone must be set",
-		},
 	}
 
 	for _, tt := range tests {
@@ -142,7 +135,6 @@ func TestConfigValidate(t *testing.T) {
 			// default config
 			cfg := Config{}
 			cfg.RegisterFlagsAndApplyDefaults("", &flag.FlagSet{})
-
 			tt.modifyConfig(&cfg)
 
 			err := cfg.Validate()

--- a/modules/livestore/config_test.go
+++ b/modules/livestore/config_test.go
@@ -128,6 +128,13 @@ func TestConfigValidate(t *testing.T) {
 			},
 			expectedErr: "max_trace_idle (20s) cannot be greater than max_trace_live (10s)",
 		},
+		{
+			name: "empty instance zone",
+			modifyConfig: func(cfg *Config) {
+				cfg.Ring.InstanceZone = ""
+			},
+			expectedErr: "instance_zone must be set",
+		},
 	}
 
 	for _, tt := range tests {
@@ -135,6 +142,7 @@ func TestConfigValidate(t *testing.T) {
 			// default config
 			cfg := Config{}
 			cfg.RegisterFlagsAndApplyDefaults("", &flag.FlagSet{})
+
 			tt.modifyConfig(&cfg)
 
 			err := cfg.Validate()

--- a/modules/livestore/instance_search_test.go
+++ b/modules/livestore/instance_search_test.go
@@ -414,7 +414,6 @@ func TestSearchTagsV2Limits(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("MaxBytesPerTagValuesQuery=%d", testCase.MaxBytesPerTagValuesQuery), func(t *testing.T) {
-
 			instance, ls := defaultInstance(t)
 			limits, err := overrides.NewOverrides(overrides.Config{
 				Defaults: overrides.Overrides{

--- a/pkg/ring/config.go
+++ b/pkg/ring/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	InstanceAddr           string   `yaml:"instance_addr"`
 	InstancePort           int      `yaml:"instance_port"`
 	EnableInet6            bool     `yaml:"enable_inet6"`
+	InstanceZone           string   `yaml:"instance_zone"`
 
 	// Injected internally
 	ListenPort int `yaml:"-"`
@@ -44,6 +45,8 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	}
 	cfg.InstanceID = hostname
 	cfg.InstanceInterfaceNames = []string{"eth0", "en0"}
+
+	f.StringVar(&cfg.InstanceZone, prefix+".instance-availability-zone", "", "Define Availability Zone in which this instance is running.")
 }
 
 func (cfg *Config) ToRingConfig() ring.Config {
@@ -66,12 +69,12 @@ func (cfg *Config) ToLifecyclerConfig(numTokens int) (ring.BasicLifecyclerConfig
 	}
 
 	instancePort := ring.GetInstancePort(cfg.InstancePort, cfg.ListenPort)
-
 	instanceAddrPort := net.JoinHostPort(instanceAddr, strconv.Itoa(instancePort))
 
 	return ring.BasicLifecyclerConfig{
 		ID:              cfg.InstanceID,
 		Addr:            instanceAddrPort,
+		Zone:            cfg.InstanceZone,
 		HeartbeatPeriod: cfg.HeartbeatPeriod,
 		NumTokens:       numTokens,
 	}, nil


### PR DESCRIPTION
- correctly set all partition ring fields to the live store when configured
- expose instance zone in the config and set it correctly for livestores. this makes the query path behave as expected