### PR TITLE
[Bugfix] Fix for not-parent operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Additionally the `compaction_tenant_backoff_total` metric has been renamed to `c
 * [BUGFIX] Do not allow very small steps [#5441](https://github.com/grafana/tempo/pull/5441) (@ruslan-mikhailov)
 * [BUGFIX] Fix incorrect results in TraceQL compare() for spans with array attributes [#5519](https://github.com/grafana/tempo/pull/5519) (@ruslan-mikhailov)
 * [BUGFIX] Fix cache collision for incomplete query in SearchTagValuesV2 [#5549](https://github.com/grafana/tempo/pull/5549) (@ruslan-mikhailov)
+* [BUGFIX] Fix for structural operator with empty left-hand spanset [#5578](https://github.com/grafana/tempo/pull/5578) (@ruslan-mikhailov)
 
 # v2.8.2
 

--- a/pkg/traceql/ast_execute.go
+++ b/pkg/traceql/ast_execute.go
@@ -168,7 +168,7 @@ func (o SpansetOperation) evaluate(input []*Spanset) (output []*Spanset, err err
 // where the eval callback returns true.  For now the behavior is only defined when there is exactly one
 // spanset on both sides and will return an error if multiple spansets are present.
 func (o *SpansetOperation) joinSpansets(lhs, rhs []*Spanset, eval func(s Span, l, r []Span) []Span) ([]Span, error) {
-	if len(lhs) < 1 || len(rhs) < 1 {
+	if len(rhs) < 1 {
 		return nil, nil
 	}
 
@@ -181,7 +181,12 @@ func (o *SpansetOperation) joinSpansets(lhs, rhs []*Spanset, eval func(s Span, l
 		return nil, nil
 	}
 
-	return eval(rhs[0].Spans[0], lhs[0].Spans, rhs[0].Spans), nil
+	var lspans []Span
+	if len(lhs) >= 1 {
+		lspans = lhs[0].Spans
+	}
+
+	return eval(rhs[0].Spans[0], lspans, rhs[0].Spans), nil
 }
 
 // addSpanset is a helper function that adds a new spanset to the output. it clones

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -975,6 +975,46 @@ func traceQLStructural(t *testing.T, _ *tempopb.Trace, wantMeta *tempopb.TraceSe
 				},
 			},
 		},
+		{
+			req: &tempopb.SearchRequest{Query: "{ name = `does-not-exist` } !< { name = `MySpan` }"},
+			expected: []*tempopb.TraceSearchMetadata{
+				{
+					SpanSets: []*tempopb.SpanSet{
+						{
+							Spans: []*tempopb.Span{
+								{
+									SpanID:            "0000000000010203",
+									StartTimeUnixNano: 1000000000000,
+									DurationNanos:     1000000000,
+									Name:              "MySpan",
+								},
+							},
+							Matched: 1,
+						},
+					},
+				},
+			},
+		},
+		{
+			req: &tempopb.SearchRequest{Query: "{ name = `does-not-exist` } !> { name = `MySpan` }"},
+			expected: []*tempopb.TraceSearchMetadata{
+				{
+					SpanSets: []*tempopb.SpanSet{
+						{
+							Spans: []*tempopb.Span{
+								{
+									SpanID:            "0000000000010203",
+									StartTimeUnixNano: 1000000000000,
+									DurationNanos:     1000000000,
+									Name:              "MySpan",
+								},
+							},
+							Matched: 1,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	searchesThatDontMatch := []*tempopb.SearchRequest{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: fixes queries like `{ span:name = "not-exist" } !< { span:name = "exist" }` and `{ span:name = "not-exist" } !> { span:name = "exist" }`. The bug was in early exit if the first part of the query has no spans.

**Which issue(s) this PR fixes**:
Fixes #4804

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`