### PR TITLE
[Enhancement] Allow block-builder to operate over empty partitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Additionally the `compaction_tenant_backoff_total` metric has been renamed to `c
 * [ENHANCEMENT] Make block ordering deterministic [#5411](https://github.com/grafana/tempo/pull/5411) (@rajiv-singh)
 * [ENHANCEMENT] Improve exemplar selection in quantile_over_time() [#5278](https://github.com/grafana/tempo/pull/5278) (@zalegrala)
 * [ENHANCEMENT] Add live store to jsonnet lib [#5591](https://github.com/grafana/tempo/pull/5591) [#5606](https://github.com/grafana/tempo/pull/5606) [#5609](https://github.com/grafana/tempo/pull/5609) (@mapno)
+* [ENHANCEMENT] Allow block-builder to operate over empty partitions [#5581](https://github.com/grafana/tempo/pull/5581) (@ruslan-mikhailov)
 * [BUGFIX] Correctly apply trace idle period in ingesters and add the concept of trace live period. [#5346](https://github.com/grafana/tempo/pull/5346/files) (@joe-elliott)
 * [BUGFIX] Fix invalid YAML output from /status/runtime_config endpoint by adding document separator. [#5146](https://github.com/grafana/tempo/issues/5146)
 * [BUGFIX] Fix race condition between compaction provider and backend-scheduler [#5409](https://github.com/grafana/tempo/pull/5409) (@zalegrala)

--- a/modules/blockbuilder/blockbuilder.go
+++ b/modules/blockbuilder/blockbuilder.go
@@ -584,7 +584,7 @@ func (b *BlockBuilder) getPartitionOffsets(ctx context.Context, partitionIDs []i
 func (b *BlockBuilder) getPartitionState(partition int32, commits kadm.OffsetResponses, endsOffsets kadm.ListedOffsets) partitionState {
 	var (
 		topic = b.cfg.IngestStorageConfig.Kafka.Topic
-		ps    = partitionState{partition: partition, commitOffset: -1, endOffset: -2}
+		ps    = partitionState{partition: partition, commitOffset: -1, endOffset: 0}
 	)
 
 	lastCommit, found := commits.Lookup(topic, partition)

--- a/modules/blockbuilder/blockbuilder.go
+++ b/modules/blockbuilder/blockbuilder.go
@@ -130,6 +130,16 @@ func (p partitionState) getStartOffset() kgo.Offset {
 	if p.commitOffset > commitOffsetAtEnd {
 		return kgo.NewOffset().At(p.commitOffset)
 	}
+	// If commit offset is AtEnd (-1), it nevertheless will consume from the start.
+	// This is a workaround for franz-go and default Kafka behaviour:
+	// in case consumer is new and has no committed offsets, it will start consuming from the end,
+	// while for block builder, it should consume from the earliest record.
+	// The workaround is dirty and can break the consumer if it starts returning AtEnd (-1) for
+	// already running consumer.
+	// TODO: replace the workaround with proper new consumer offset initialization
+	// if p.commitOffset == commitOffsetAtEnd {
+	// 	return kgo.NewOffset().AtEnd()
+	// }
 	return kgo.NewOffset().AtStart()
 }
 

--- a/modules/blockbuilder/blockbuilder_test.go
+++ b/modules/blockbuilder/blockbuilder_test.go
@@ -824,9 +824,13 @@ func TestBlockbuilder_gracefulShutdown(t *testing.T) {
 	store := newStore(ctx, t)
 	cfg := blockbuilderConfig(t, address, []int32{0}) // Fix: Properly specify partition
 
+	// Send initial traces to ensure the partition has records
+	client := newKafkaClient(t, cfg.IngestStorageConfig.Kafka)
+	sendReq(ctx, t, client, util.FakeTenantID)
+
 	// Start sending traces in the background
 	go func() {
-		sendTracesFor(t, ctx, newKafkaClient(t, cfg.IngestStorageConfig.Kafka), 60*time.Second, time.Second)
+		sendTracesFor(t, ctx, client, 60*time.Second, time.Second)
 	}()
 
 	b, err := New(cfg, test.NewTestingLogger(t), newPartitionRingReader(), &mockOverrides{}, store)

--- a/modules/blockbuilder/blockbuilder_test.go
+++ b/modules/blockbuilder/blockbuilder_test.go
@@ -539,7 +539,7 @@ func TestBlockBuilder_honor_maxBytesPerCycle(t *testing.T) {
 		{
 			name:             "Limited to 1 bytes per cycle",
 			maxBytesPerCycle: 1,
-			expectedCommits:  1,
+			expectedCommits:  2,
 			expectedWrites:   2,
 		},
 		{


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
In case partition is empty during consumption cycle, it is possible that previously empty partition started to receive data

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`