### PR TITLE
Livestore: Consolidate query logic

### DIFF
--- a/example/docker-compose/ingest-storage/tempo.yaml
+++ b/example/docker-compose/ingest-storage/tempo.yaml
@@ -60,6 +60,9 @@ metrics_generator:
     local_blocks:
       flush_to_storage: true
 
+query_frontend:
+  rf1_after: "1999-01-01T00:00:00Z"
+
 storage:
   trace:
     backend: s3

--- a/modules/livestore/instance.go
+++ b/modules/livestore/instance.go
@@ -427,10 +427,13 @@ func (i *instance) deleteOldBlocks() error {
 }
 
 func (i *instance) FindByTraceID(ctx context.Context, traceID []byte) (*tempopb.TraceByIDResponse, error) {
-	metrics := tempopb.TraceByIDMetrics{}
-	combiner := trace.NewCombiner(math.MaxInt64, true)
+	var (
+		metricsMtx sync.Mutex
+		metrics    = tempopb.TraceByIDMetrics{}
+		combiner   = trace.NewCombiner(math.MaxInt64, true)
+	)
 
-	// TODO MRD this code looks ripe for simplification. Its the same pattern repeated several times.
+	// Check live traces first
 	i.liveTracesMtx.Lock()
 	if liveTrace, ok := i.liveTraces.Traces[util.HashForTraceID(traceID)]; ok {
 		tempTrace := &tempopb.Trace{}
@@ -445,8 +448,7 @@ func (i *instance) FindByTraceID(ctx context.Context, traceID []byte) (*tempopb.
 	}
 	i.liveTracesMtx.Unlock()
 
-	// TODO MRD Add limits
-	loopBlock := func(b common.Finder) error {
+	search := func(ctx context.Context, _ *backend.BlockMeta, b block) error {
 		trace, err := b.FindTraceByID(ctx, traceID, common.DefaultSearchOptions())
 		if err != nil {
 			return err
@@ -454,37 +456,25 @@ func (i *instance) FindByTraceID(ctx context.Context, traceID []byte) (*tempopb.
 		if trace == nil {
 			return nil
 		}
+
 		_, err = combiner.Consume(trace.Trace)
 		if err != nil {
 			return err
 		}
+
 		if trace.Metrics != nil {
+			metricsMtx.Lock()
+			defer metricsMtx.Unlock()
+
 			metrics.InspectedBytes += trace.Metrics.InspectedBytes
 		}
 		return nil
 	}
 
-	i.blocksMtx.RLock()
-	defer i.blocksMtx.RUnlock()
-
-	// Loop over all the complete blocks looking for a specific ID. The implementation looks like it will return nil if the trace is not found.
-	for _, b := range i.completeBlocks {
-		err := loopBlock(b)
-		if err != nil {
-			return nil, fmt.Errorf("error searching in complete block %s: %w", b.BlockMeta().BlockID, err)
-		}
-	}
-
-	for _, b := range i.walBlocks {
-		err := loopBlock(b)
-		if err != nil {
-			return nil, fmt.Errorf("error searching in WAL block %s: %w", b.BlockMeta().BlockID, err)
-		}
-	}
-
-	err := loopBlock(i.headBlock)
+	err := i.iterateBlocks(ctx, 0, 0, search)
 	if err != nil {
-		return nil, fmt.Errorf("error searching in headblock %s: %w", i.headBlock.BlockMeta().BlockID, err)
+		level.Error(i.logger).Log("msg", "error in FindTraceByID", "err", err)
+		return nil, fmt.Errorf("error searching for trace: %w", err)
 	}
 
 	result, _ := combiner.Result()

--- a/modules/livestore/instance.go
+++ b/modules/livestore/instance.go
@@ -471,7 +471,7 @@ func (i *instance) FindByTraceID(ctx context.Context, traceID []byte) (*tempopb.
 		return nil
 	}
 
-	err := i.iterateBlocks(ctx, 0, 0, search)
+	err := i.iterateBlocks(ctx, time.Unix(0, 0), time.Unix(0, 0), search)
 	if err != nil {
 		level.Error(i.logger).Log("msg", "error in FindTraceByID", "err", err)
 		return nil, fmt.Errorf("error searching for trace: %w", err)

--- a/modules/livestore/instance_search_test.go
+++ b/modules/livestore/instance_search_test.go
@@ -263,7 +263,11 @@ func testSearchTagsAndValues(t *testing.T, ctx context.Context, i *instance, tag
 	checkSearchTags("event", true)
 	checkSearchTags("link", true)
 
-	srv, err := i.SearchTagValues(ctx, tagName, 0, 0)
+	srv, err := i.SearchTagValues(ctx, &tempopb.SearchTagValuesRequest{
+		TagName:             tagName,
+		MaxTagValues:        0,
+		StaleValueThreshold: 0,
+	})
 	require.NoError(t, err)
 	require.Greater(t, srv.Metrics.InspectedBytes, uint64(100)) // we scanned at-least 100 bytes
 
@@ -314,7 +318,11 @@ func TestInstanceSearchMaxBytesPerTagValuesQueryReturnsPartial(t *testing.T) {
 	userCtx := user.InjectOrgID(context.Background(), testTenantID)
 
 	t.Run("SearchTagValues", func(t *testing.T) {
-		resp, err := instance.SearchTagValues(userCtx, tagKey, 0, 0)
+		resp, err := instance.SearchTagValues(userCtx, &tempopb.SearchTagValuesRequest{
+			TagName:             tagKey,
+			MaxTagValues:        0,
+			StaleValueThreshold: 0,
+		})
 		require.NoError(t, err)
 		require.Equal(t, 2, len(resp.TagValues)) // Only two values of the form "bar<idx>" fit in the 12 byte limit above.
 	})
@@ -362,7 +370,11 @@ func TestInstanceSearchMaxBlocksPerTagValuesQueryReturnsPartial(t *testing.T) {
 
 	userCtx := user.InjectOrgID(context.Background(), testTenantID)
 
-	respV1, err := instance.SearchTagValues(userCtx, tagKey, 0, 0)
+	respV1, err := instance.SearchTagValues(userCtx, &tempopb.SearchTagValuesRequest{
+		TagName:             tagKey,
+		MaxTagValues:        0,
+		StaleValueThreshold: 0,
+	})
 	require.NoError(t, err)
 	// livestore writeTracesForSearch creates 5 values per block
 	assert.Equal(t, 5, len(respV1.TagValues))
@@ -376,7 +388,11 @@ func TestInstanceSearchMaxBlocksPerTagValuesQueryReturnsPartial(t *testing.T) {
 	assert.NoError(t, err, "unexpected error creating limits")
 	instance.overrides = limits2
 
-	respV1, err = instance.SearchTagValues(userCtx, tagKey, 0, 0)
+	respV1, err = instance.SearchTagValues(userCtx, &tempopb.SearchTagValuesRequest{
+		TagName:             tagKey,
+		MaxTagValues:        0,
+		StaleValueThreshold: 0,
+	})
 	require.NoError(t, err)
 	assert.Equal(t, 10, len(respV1.TagValues))
 
@@ -745,7 +761,11 @@ func TestInstanceSearchDoesNotRace(t *testing.T) {
 	go concurrent(func() {
 		// SearchTagValues queries now require userID in ctx
 		ctx := user.InjectOrgID(context.Background(), "test")
-		_, err := i.SearchTagValues(ctx, tagKey, 0, 0)
+		_, err := i.SearchTagValues(ctx, &tempopb.SearchTagValuesRequest{
+			TagName:             tagKey,
+			MaxTagValues:        0,
+			StaleValueThreshold: 0,
+		})
 		require.NoError(t, err, "error getting search tag values")
 	})
 

--- a/modules/livestore/instance_search_test.go
+++ b/modules/livestore/instance_search_test.go
@@ -156,7 +156,7 @@ func TestInstanceSearchWithStartAndEnd(t *testing.T) {
 		return sr
 	}
 
-	searchAndAssert := func(req *tempopb.SearchRequest, _ uint32) {
+	searchAndAssert := func(req *tempopb.SearchRequest) {
 		sr := search(req, 0, 0)
 		assert.Len(t, sr.Traces, len(ids))
 		checkEqual(t, ids, sr)
@@ -180,18 +180,18 @@ func TestInstanceSearchWithStartAndEnd(t *testing.T) {
 
 	// Test after appending to WAL.
 	// writeTracesforSearch() makes sure all traces are in the wal
-	searchAndAssert(req, uint32(100))
+	searchAndAssert(req)
 
 	// Test after cutting new headblock
 	blockID, err := i.cutBlocks(true)
 	require.NoError(t, err)
 	assert.NotEqual(t, blockID, uuid.Nil)
-	searchAndAssert(req, uint32(100))
+	searchAndAssert(req)
 
 	// Test after completing a block
 	err = i.completeBlock(context.Background(), blockID)
 	require.NoError(t, err)
-	searchAndAssert(req, uint32(200))
+	searchAndAssert(req)
 
 	err = services.StopAndAwaitTerminated(t.Context(), ls)
 	require.NoError(t, err)

--- a/modules/livestore/live_store.go
+++ b/modules/livestore/live_store.go
@@ -531,7 +531,7 @@ func (s *LiveStore) SearchTagValues(ctx context.Context, req *tempopb.SearchTagV
 		return nil, err
 	}
 
-	return inst.SearchTagValues(ctx, req.TagName, req.MaxTagValues, req.StaleValueThreshold)
+	return inst.SearchTagValues(ctx, req)
 }
 
 // SearchTagValuesV2 implements tempopb.Querier

--- a/modules/livestore/query_range.go
+++ b/modules/livestore/query_range.go
@@ -106,7 +106,7 @@ func (i *instance) QueryRange(ctx context.Context, req *tempopb.QueryRangeReques
 		return fmt.Errorf("unexpected block type: %T", b)
 	}
 
-	err = i.iterateBlocks(ctx, uint64(req.Start), uint64(req.End), search)
+	err = i.iterateBlocks(ctx, time.Unix(0, int64(req.Start)), time.Unix(0, int64(req.End)), search)
 	if err != nil {
 		level.Error(i.logger).Log("msg", "error in QueryRange", "err", err)
 		return nil, err

--- a/modules/livestore/query_range.go
+++ b/modules/livestore/query_range.go
@@ -77,7 +77,7 @@ func (i *instance) QueryRange(ctx context.Context, req *tempopb.QueryRangeReques
 	maxSeriesReached := atomic.Bool{}
 	maxSeriesReached.Store(false)
 
-	search := func(ctx context.Context, meta *backend.BlockMeta, b block) error {
+	search := func(ctx context.Context, _ *backend.BlockMeta, b block) error {
 		if walBlock, ok := b.(common.WALBlock); ok {
 			err := i.queryRangeWALBlock(ctx, walBlock, rawEval, maxSeries)
 			if err != nil {


### PR DESCRIPTION
This PR consolidates query logic in the livestore to remove redundant code and standardize the way we iterate through blocks in an instance. It is a combination of behaviors from the ingester and metrics generator read paths.

- Created an [iterateBlocks](https://github.com/grafana/tempo/pull/5583/files#diff-708a69e1ac83ae4c6c95163e2ef2a54174a348aa2c350864e928d65419d83f58R48) function and used it through all 5 search paths (search tags, tag values, search/traceql, query range and trace id lookup). This function standardizes
  - use of the concurrency setting
  - error handling
  - exit early behavior and context cancelling
  - logging/tracing
  - testing block range for inclusion in the query
- Cleaned up [some places](https://github.com/grafana/tempo/pull/5583/files#diff-708a69e1ac83ae4c6c95163e2ef2a54174a348aa2c350864e928d65419d83f58R347) where we were using the global logger instead of the instance one
- [Fixed ingest-storage](https://github.com/grafana/tempo/pull/5583/files#diff-ee30af768fd59c456189ca40bb715e2a581a9158db86d4dc16c315a0107601b1R64) docker-compose so that search queries would correctly find historical blocks
- [Adjusted SearchTagValues](https://github.com/grafana/tempo/pull/5583/files#diff-db1208c4a3db264a9c4e8c51890a05d09e42db7ce150e447c14c515031e300f3R534) to follow the same pattern as all other read path calls.

After this PR is merged I want to follow up with a final cleanup step where all read path functions are moved to the same file instead of scattered across 3. I left them where they are for now to help the reviewer.