### PR TITLE
Allow max compaction level configuration in compaction block selector

### DIFF
--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -1049,6 +1049,7 @@ backend_scheduler:
             max_jobs_per_tenant: 1000
             min_input_blocks: 2
             max_input_blocks: 4
+            max_compaction_level: 0
             min_cycle_interval: 30s
     job_timeout: 15s
     local_work_path: /var/tempo

--- a/modules/backendscheduler/provider/compaction.go
+++ b/modules/backendscheduler/provider/compaction.go
@@ -28,12 +28,13 @@ import (
 var tracer = otel.Tracer("modules/backendscheduler/provider/compaction")
 
 type CompactionConfig struct {
-	MeasureInterval  time.Duration           `yaml:"measure_interval"`
-	Compactor        tempodb.CompactorConfig `yaml:"compaction"`
-	MaxJobsPerTenant int                     `yaml:"max_jobs_per_tenant"`
-	MinInputBlocks   int                     `yaml:"min_input_blocks"`
-	MaxInputBlocks   int                     `yaml:"max_input_blocks"`
-	MinCycleInterval time.Duration           `yaml:"min_cycle_interval"`
+	MeasureInterval    time.Duration           `yaml:"measure_interval"`
+	Compactor          tempodb.CompactorConfig `yaml:"compaction"`
+	MaxJobsPerTenant   int                     `yaml:"max_jobs_per_tenant"`
+	MinInputBlocks     int                     `yaml:"min_input_blocks"`
+	MaxInputBlocks     int                     `yaml:"max_input_blocks"`
+	MaxCompactionLevel int                     `yaml:"max_compaction_level"`
+	MinCycleInterval   time.Duration           `yaml:"min_cycle_interval"`
 }
 
 func (cfg *CompactionConfig) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
@@ -43,6 +44,7 @@ func (cfg *CompactionConfig) RegisterFlagsAndApplyDefaults(prefix string, f *fla
 	// Compaction
 	f.IntVar(&cfg.MinInputBlocks, prefix+".min-input-blocks", blockselector.DefaultMinInputBlocks, "Minimum number of blocks to compact in a single job.")
 	f.IntVar(&cfg.MaxInputBlocks, prefix+".max-input-blocks", blockselector.DefaultMaxInputBlocks, "Maximum number of blocks to compact in a single job.")
+	f.IntVar(&cfg.MaxCompactionLevel, prefix+".max-compaction-level", blockselector.DefaultMaxCompactionLevel, "Maximum compaction level to include in compaction jobs. 0 means no limit.")
 
 	// Tenant prioritization
 	f.DurationVar(&cfg.MinCycleInterval, prefix+".min-cycle-interval", 30*time.Second, "Minimum time between tenant prioritization cycles to prevent excessive CPU usage when no work is available.")
@@ -456,6 +458,7 @@ func (p *CompactionProvider) newBlockSelector(tenantID string) (blockselector.Co
 		p.cfg.Compactor.MaxBlockBytes,
 		p.cfg.MinInputBlocks,
 		p.cfg.MaxInputBlocks,
+		p.cfg.MaxCompactionLevel,
 	), len(blocklist)
 }
 

--- a/tempodb/blockselector/compaction_block_selector.go
+++ b/tempodb/blockselector/compaction_block_selector.go
@@ -14,9 +14,10 @@ type CompactionBlockSelector interface {
 }
 
 const (
-	activeWindowDuration  = 24 * time.Hour
-	DefaultMinInputBlocks = 2
-	DefaultMaxInputBlocks = 4
+	activeWindowDuration      = 24 * time.Hour
+	DefaultMinInputBlocks     = 2
+	DefaultMaxInputBlocks     = 4
+	DefaultMaxCompactionLevel = 0
 )
 
 /*************************** Time Window Block Selector **************************/
@@ -32,6 +33,7 @@ type timeWindowBlockSelector struct {
 	MaxCompactionRange   time.Duration // Size of the time window - say 6 hours
 	MaxCompactionObjects int           // maximum size of compacted objects
 	MaxBlockBytes        uint64        // maximum block size, estimate
+	MaxCompactionLevel   uint32        // maximum compaction level
 
 	entries []timeWindowBlockEntry
 }
@@ -45,13 +47,14 @@ type timeWindowBlockEntry struct {
 
 var _ (CompactionBlockSelector) = (*timeWindowBlockSelector)(nil)
 
-func NewTimeWindowBlockSelector(blocklist []*backend.BlockMeta, maxCompactionRange time.Duration, maxCompactionObjects int, maxBlockBytes uint64, minInputBlocks, maxInputBlocks int) CompactionBlockSelector {
+func NewTimeWindowBlockSelector(blocklist []*backend.BlockMeta, maxCompactionRange time.Duration, maxCompactionObjects int, maxBlockBytes uint64, minInputBlocks, maxInputBlocks, maxCompactionLevel int) CompactionBlockSelector {
 	twbs := &timeWindowBlockSelector{
 		MinInputBlocks:       minInputBlocks,
 		MaxInputBlocks:       maxInputBlocks,
 		MaxCompactionRange:   maxCompactionRange,
 		MaxCompactionObjects: maxCompactionObjects,
 		MaxBlockBytes:        maxBlockBytes,
+		MaxCompactionLevel:   uint32(maxCompactionLevel),
 	}
 
 	now := time.Now()
@@ -59,6 +62,11 @@ func NewTimeWindowBlockSelector(blocklist []*backend.BlockMeta, maxCompactionRan
 	activeWindow := twbs.windowForTime(now.Add(-activeWindowDuration))
 
 	for _, b := range blocklist {
+		if twbs.MaxCompactionLevel != 0 && b.CompactionLevel >= twbs.MaxCompactionLevel {
+			// skip blocks that are already at max compaction level
+			continue
+		}
+
 		w := twbs.windowForBlock(b)
 
 		// exclude blocks that fall in last window from active -> inactive cut-over

--- a/tempodb/blockselector/compaction_block_selector_test.go
+++ b/tempodb/blockselector/compaction_block_selector_test.go
@@ -15,15 +15,16 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 	tenantID := ""
 
 	tests := []struct {
-		name           string
-		blocklist      []*backend.BlockMeta
-		minInputBlocks int    // optional, defaults to global const
-		maxInputBlocks int    // optional, defaults to global const
-		maxBlockBytes  uint64 // optional, defaults to ???
-		expected       []*backend.BlockMeta
-		expectedHash   string
-		expectedSecond []*backend.BlockMeta
-		expectedHash2  string
+		name               string
+		blocklist          []*backend.BlockMeta
+		minInputBlocks     int    // optional, defaults to global const
+		maxInputBlocks     int    // optional, defaults to global const
+		maxBlockBytes      uint64 // optional, defaults to ???
+		maxCompactionLevel int    // optional, default to global const
+		expected           []*backend.BlockMeta
+		expectedHash       string
+		expectedSecond     []*backend.BlockMeta
+		expectedHash2      string
 	}{
 		{
 			name:      "nil - nil",
@@ -815,6 +816,59 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 			},
 			expectedHash2: fmt.Sprintf("%v-%v-%v-%v", tenantID, 0, now.Unix(), 3),
 		},
+		{
+			name: "blocks above the max compaction level are not selected for compaction",
+			blocklist: []*backend.BlockMeta{
+				{
+					BlockID:           backend.MustParse("00000000-0000-0000-0000-000000000001"),
+					EndTime:           now,
+					ReplicationFactor: 1,
+					CompactionLevel:   uint32(10),
+				},
+				{
+					BlockID:           backend.MustParse("00000000-0000-0000-0000-000000000002"),
+					EndTime:           now,
+					ReplicationFactor: 1,
+					CompactionLevel:   uint32(10),
+				},
+			},
+			maxCompactionLevel: 10,
+			expected:           nil,
+			expectedSecond:     nil,
+		},
+		{
+			name: "blocks under the max compaction level are selected for compaction",
+			blocklist: []*backend.BlockMeta{
+				{
+					BlockID:           backend.MustParse("00000000-0000-0000-0000-000000000001"),
+					EndTime:           now,
+					ReplicationFactor: 1,
+					CompactionLevel:   uint32(10),
+				},
+				{
+					BlockID:           backend.MustParse("00000000-0000-0000-0000-000000000002"),
+					EndTime:           now,
+					ReplicationFactor: 1,
+					CompactionLevel:   uint32(10),
+				},
+			},
+			maxCompactionLevel: 11,
+			expected: []*backend.BlockMeta{
+				{
+					BlockID:           backend.MustParse("00000000-0000-0000-0000-000000000001"),
+					EndTime:           now,
+					ReplicationFactor: 1,
+					CompactionLevel:   uint32(10),
+				},
+				{
+					BlockID:           backend.MustParse("00000000-0000-0000-0000-000000000002"),
+					EndTime:           now,
+					ReplicationFactor: 1,
+					CompactionLevel:   uint32(10),
+				},
+			},
+			expectedHash: fmt.Sprintf("%v-%v-%v-%v", tenantID, 10, now.Unix(), 1),
+		},
 	}
 
 	for _, tt := range tests {
@@ -834,7 +888,12 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 				maxSize = tt.maxBlockBytes
 			}
 
-			selector := NewTimeWindowBlockSelector(tt.blocklist, time.Second, 100, maxSize, minBlocks, maxBlocks)
+			maxLevel := DefaultMaxCompactionLevel
+			if tt.maxCompactionLevel > 0 {
+				maxLevel = tt.maxCompactionLevel
+			}
+
+			selector := NewTimeWindowBlockSelector(tt.blocklist, time.Second, 100, maxSize, minBlocks, maxBlocks, maxLevel)
 
 			actual, hash := selector.BlocksToCompact()
 			assert.Equal(t, tt.expected, actual)

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -136,7 +136,9 @@ func (rw *readerWriter) compactOneTenant(ctx context.Context) {
 		rw.compactorCfg.MaxCompactionObjects,
 		rw.compactorCfg.MaxBlockBytes,
 		blockselector.DefaultMinInputBlocks,
-		blockselector.DefaultMaxInputBlocks)
+		blockselector.DefaultMaxInputBlocks,
+		blockselector.DefaultMaxCompactionLevel,
+	)
 
 	start := time.Now()
 

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -164,7 +164,7 @@ func testCompactionRoundtrip(t *testing.T, targetBlockVersion string) {
 	rw.pollBlocklist(ctx)
 
 	blocklist := rw.blocklist.Metas(testTenantID)
-	blockSelector := blockselector.NewTimeWindowBlockSelector(blocklist, rw.compactorCfg.MaxCompactionRange, 10000, 1024*1024*1024, blockselector.DefaultMinInputBlocks, 2)
+	blockSelector := blockselector.NewTimeWindowBlockSelector(blocklist, rw.compactorCfg.MaxCompactionRange, 10000, 1024*1024*1024, blockselector.DefaultMinInputBlocks, 2, 0)
 
 	expectedCompactions := len(blocklist) / inputBlocks
 	compactions := 0
@@ -338,7 +338,7 @@ func testSameIDCompaction(t *testing.T, targetBlockVersion string) {
 
 	var blocks []*backend.BlockMeta
 	list := rw.blocklist.Metas(testTenantID)
-	blockSelector := blockselector.NewTimeWindowBlockSelector(list, rw.compactorCfg.MaxCompactionRange, 10000, 1024*1024*1024, blockselector.DefaultMinInputBlocks, blockCount)
+	blockSelector := blockselector.NewTimeWindowBlockSelector(list, rw.compactorCfg.MaxCompactionRange, 10000, 1024*1024*1024, blockselector.DefaultMinInputBlocks, blockCount, 0)
 	blocks, _ = blockSelector.BlocksToCompact()
 	require.Len(t, blocks, blockCount)
 


### PR DESCRIPTION
**What this PR does**:

Here we allow a configuration of the maximum compaction level a block can reach and still be considered for compaction.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`