### PR TITLE
fix(metrics-generator): prevent WAL deletion when tenant is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## main / unreleased
+* [BUGFIX] Prevent metrics-generator WAL deletion when tenant is empty [#5586](https://github.com/grafana/tempo/pull/5586) (@sienna011022)
 * [BUGFIX] Fix docker-compose port configuration for Alloy gRPC (4319 → 4317) [#5536](https://github.com/grafana/tempo/pull/5536)
 * [BUGFIX] Fix panic error from empty span id. [#5464](https://github.com/grafana/tempo/pull/5464)
 * [BUGFIX] Return Bad Request from frontend if the provided tag is invalid in SearchTagValuesV2 endpoint [#5493](https://github.com/grafana/tempo/pull/5493/) (@carles-grafana)

--- a/modules/generator/storage/instance.go
+++ b/modules/generator/storage/instance.go
@@ -61,10 +61,9 @@ var _ Storage = (*storageImpl)(nil)
 func New(cfg *Config, o Overrides, tenant string, reg prometheus.Registerer, _ log.Logger) (Storage, error) {
 	// TODO move this to the generator.go
 
-	// Validate empty tenant to prevent WAL directory deletion
-	if tenant == "" {
-		// Use Tempo standard default for single-tenant mode
-		tenant = "single-tenant"
+	// Validate empty tenant to prevent WAL directory deletion only when org ID header is required
+	if cfg.RemoteWriteAddOrgIDHeader && tenant == "" {
+		return nil, errors.New("tenant cannot be empty")
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{

--- a/modules/generator/storage/instance.go
+++ b/modules/generator/storage/instance.go
@@ -62,7 +62,7 @@ func New(cfg *Config, o Overrides, tenant string, reg prometheus.Registerer, _ l
 	// TODO move this to the generator.go
 
 	// Validate empty tenant to prevent WAL directory deletion only when org ID header is required
-	if cfg.RemoteWriteAddOrgIDHeader && tenant == "" {
+	if tenant == "" {
 		return nil, errors.New("tenant cannot be empty")
 	}
 

--- a/modules/generator/storage/instance_test.go
+++ b/modules/generator/storage/instance_test.go
@@ -381,11 +381,10 @@ func TestInstance_emptyTenantValidation(t *testing.T) {
 	o := &mockOverrides{}
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
 
-	t.Run("empty tenant should return error when RemoteWriteAddOrgIDHeader is true", func(t *testing.T) {
+	t.Run("empty tenant should return error", func(t *testing.T) {
 		var cfg Config
 		cfg.RegisterFlagsAndApplyDefaults("", nil)
 		cfg.Path = t.TempDir()
-		cfg.RemoteWriteAddOrgIDHeader = true
 		reg := prometheus.NewRegistry()
 
 		// Empty tenant should return error when org ID header is required

--- a/modules/generator/storage/instance_test.go
+++ b/modules/generator/storage/instance_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"testing"
@@ -373,3 +374,79 @@ func (n *noopRegisterer) Register(prometheus.Collector) error { return nil }
 func (n *noopRegisterer) MustRegister(...prometheus.Collector) {}
 
 func (n *noopRegisterer) Unregister(prometheus.Collector) bool { return true }
+
+func TestInstance_emptyTenantValidation(t *testing.T) {
+	t.Parallel()
+
+	o := &mockOverrides{}
+	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
+
+	t.Run("empty tenant should use single-tenant fallback", func(t *testing.T) {
+		var cfg Config
+		cfg.RegisterFlagsAndApplyDefaults("", nil)
+		cfg.Path = t.TempDir()
+		reg := prometheus.NewRegistry()
+
+		// Empty tenant should fallback to safe default
+		instance, err := New(&cfg, o, "", reg, logger)
+
+		require.NoError(t, err)
+		require.NotNil(t, instance)
+
+		// Verify WAL directory is created with safe tenant name
+		expectedPath := filepath.Join(cfg.Path, "single-tenant")
+		_, err = os.Stat(expectedPath)
+		assert.NoError(t, err, "WAL directory should be created with single-tenant fallback")
+
+		instance.Close()
+	})
+
+	t.Run("valid tenant should work normally", func(t *testing.T) {
+		var cfg Config
+		cfg.RegisterFlagsAndApplyDefaults("", nil)
+		cfg.Path = t.TempDir()
+		reg := prometheus.NewRegistry()
+
+		instance, err := New(&cfg, o, "valid-tenant", reg, logger)
+
+		require.NoError(t, err)
+		require.NotNil(t, instance)
+
+		// Verify correct WAL directory structure
+		expectedPath := filepath.Join(cfg.Path, "valid-tenant")
+		_, err = os.Stat(expectedPath)
+		assert.NoError(t, err, "WAL directory should be created for valid tenant")
+
+		instance.Close()
+	})
+
+	t.Run("prevent root directory deletion scenario", func(t *testing.T) {
+		var cfg Config
+		cfg.RegisterFlagsAndApplyDefaults("", nil)
+		cfg.Path = t.TempDir()
+		reg := prometheus.NewRegistry()
+
+		// Create some existing tenant directories to simulate multi-tenant environment
+		existingTenant1 := filepath.Join(cfg.Path, "tenant-1")
+		existingTenant2 := filepath.Join(cfg.Path, "tenant-2")
+		require.NoError(t, os.MkdirAll(existingTenant1, 0o755))
+		require.NoError(t, os.MkdirAll(existingTenant2, 0o755))
+
+		// Create instance with empty tenant (should use single-tenant fallback)
+		instance, err := New(&cfg, o, "", reg, logger)
+		require.NoError(t, err)
+
+		// Verify existing tenant directories are untouched
+		_, err1 := os.Stat(existingTenant1)
+		_, err2 := os.Stat(existingTenant2)
+		assert.NoError(t, err1, "Existing tenant-1 directory should remain")
+		assert.NoError(t, err2, "Existing tenant-2 directory should remain")
+
+		// Verify single-tenant directory was created instead of root deletion
+		singleTenantPath := filepath.Join(cfg.Path, "single-tenant")
+		_, err3 := os.Stat(singleTenantPath)
+		assert.NoError(t, err3, "single-tenant directory should be created")
+
+		instance.Close()
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does:**
Prevents metrics-generator from deleting the entire WAL root directory when an empty tenant is encountered. This issue could cause data loss for all tenants

**Root Cause:**
• Empty tenant ("") causes filepath.Join(cfg.Path, tenant) to resolve to the WAL root directory
• os.RemoveAll(walDir) then deletes the entire root, affecting all tenant WAL data
• This occurs when X-Scope-OrgID header is missing or internal metrics lack tenant labels

**Solution:**
• Throw Error when tenant is  empty when  multi tenancy environment enabled

**Testing:**
• Added TestInstance_emptyTenantValidation with 2 test cases
• All existing tests pass
• Verified WAL directory structure remains intact for existing tenants

Which issue(s) this PR fixes:
Fixes potential WAL data loss in multi-tenant environments (no existing issue number)

Checklist
* [x] Tests updated
* [x] Documentation added  
* [x] CHANGELOG.md updated - the order of entries should be [CHANGE], [FEATURE], [ENHANCEMENT], [BUGFIX]

