### PR TITLE
Tests: fix wrong WaitGroup usage

### DIFF
--- a/modules/generator/processor/localblocks/processor_test.go
+++ b/modules/generator/processor/localblocks/processor_test.go
@@ -132,19 +132,21 @@ func TestProcessorDoesNotRace(t *testing.T) {
 
 	concurrent := func(f func()) {
 		wg.Add(1)
-		defer wg.Done()
+		go func() {
+			defer wg.Done()
 
-		for {
-			select {
-			case <-end:
-				return
-			default:
-				f()
+			for {
+				select {
+				case <-end:
+					return
+				default:
+					f()
+				}
 			}
-		}
+		}()
 	}
 
-	go concurrent(func() {
+	concurrent(func() {
 		tr := test.MakeTrace(10, nil)
 		for _, b := range tr.ResourceSpans {
 			for _, ss := range b.ScopeSpans {
@@ -160,28 +162,28 @@ func TestProcessorDoesNotRace(t *testing.T) {
 		p.PushSpans(ctx, req)
 	})
 
-	go concurrent(func() {
+	concurrent(func() {
 		err := p.cutIdleTraces(true)
 		require.NoError(t, err, "cutting idle traces")
 	})
 
-	go concurrent(func() {
+	concurrent(func() {
 		err := p.cutBlocks(true)
 		require.NoError(t, err, "cutting blocks")
 	})
 
-	go concurrent(func() {
+	concurrent(func() {
 		err := p.flushBlock(uuid.New())
 		require.NoError(t, err, "flushing blocks")
 	})
 
-	go concurrent(func() {
+	concurrent(func() {
 		err := p.deleteOldBlocks()
 		require.NoError(t, err, "deleting old blocks")
 	})
 
 	// Run multiple queries
-	go concurrent(func() {
+	concurrent(func() {
 		_, err := p.GetMetrics(ctx, &tempopb.SpanMetricsRequest{
 			Query:   "{}",
 			GroupBy: "status",
@@ -189,7 +191,7 @@ func TestProcessorDoesNotRace(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	go concurrent(func() {
+	concurrent(func() {
 		_, err := p.GetMetrics(ctx, &tempopb.SpanMetricsRequest{
 			Query:   "{}",
 			GroupBy: "status",
@@ -197,7 +199,7 @@ func TestProcessorDoesNotRace(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	go concurrent(func() {
+	concurrent(func() {
 		err := p.QueryRange(ctx, *qr, me, je)
 		require.NoError(t, err)
 	})

--- a/modules/ingester/instance_search_test.go
+++ b/modules/ingester/instance_search_test.go
@@ -732,16 +732,21 @@ func TestWALBlockDeletedDuringSearch(t *testing.T) {
 	dec := model.MustNewSegmentDecoder(model.CurrentEncoding)
 
 	end := make(chan struct{})
+	wg := sync.WaitGroup{}
 
 	concurrent := func(f func()) {
-		for {
-			select {
-			case <-end:
-				return
-			default:
-				f()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-end:
+					return
+				default:
+					f()
+				}
 			}
-		}
+		}()
 	}
 
 	for j := 0; j < 500; j++ {
@@ -779,7 +784,7 @@ func TestWALBlockDeletedDuringSearch(t *testing.T) {
 	// Wait for go funcs to quit before
 	// exiting and cleaning up
 	close(end)
-	time.Sleep(2 * time.Second)
+	wg.Wait()
 }
 
 func TestInstanceSearchMetrics(t *testing.T) {
@@ -849,16 +854,21 @@ func BenchmarkInstanceSearchUnderLoad(b *testing.B) {
 	dec := model.MustNewSegmentDecoder(model.CurrentEncoding)
 
 	end := make(chan struct{})
+	wg := sync.WaitGroup{}
 
 	concurrent := func(f func()) {
-		for {
-			select {
-			case <-end:
-				return
-			default:
-				f()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-end:
+					return
+				default:
+					f()
+				}
 			}
-		}
+		}()
 	}
 
 	// Push data
@@ -930,7 +940,7 @@ func BenchmarkInstanceSearchUnderLoad(b *testing.B) {
 	close(end)
 	// Wait for go funcs to quit before
 	// exiting and cleaning up
-	time.Sleep(1 * time.Second)
+	wg.Wait()
 }
 
 func TestIncludeBlock(t *testing.T) {

--- a/modules/ingester/instance_test.go
+++ b/modules/ingester/instance_test.go
@@ -1075,17 +1075,19 @@ func BenchmarkInstanceContention(t *testing.B) {
 
 	concurrent := func(f func()) {
 		wg.Add(1)
-		defer wg.Done()
-		for {
-			select {
-			case <-end:
-				return
-			default:
-				f()
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-end:
+					return
+				default:
+					f()
+				}
 			}
-		}
+		}()
 	}
-	go concurrent(func() {
+	concurrent(func() {
 		request := makeRequestWithByteLimit(10_000, nil)
 		response := i.PushBytesRequest(ctx, request)
 		errored, _, _ := CheckPushBytesError(response)
@@ -1093,13 +1095,13 @@ func BenchmarkInstanceContention(t *testing.B) {
 		pushes++
 	})
 
-	go concurrent(func() {
+	concurrent(func() {
 		err := i.CutCompleteTraces(0, 0, true)
 		require.NoError(t, err, "error cutting complete traces")
 		traceFlushes++
 	})
 
-	go concurrent(func() {
+	concurrent(func() {
 		blockID, _ := i.CutBlockIfReady(0, 0, false)
 		if blockID != uuid.Nil {
 			err := i.CompleteBlock(context.Background(), blockID)
@@ -1114,19 +1116,19 @@ func BenchmarkInstanceContention(t *testing.B) {
 		blockFlushes++
 	})
 
-	go concurrent(func() {
+	concurrent(func() {
 		err := i.ClearOldBlocks(ingester.cfg.FlushObjectStorage, 0)
 		require.NoError(t, err, "error clearing flushed blocks")
 		retentions++
 	})
 
-	go concurrent(func() {
+	concurrent(func() {
 		_, err := i.FindTraceByID(ctx, []byte{0x01}, false)
 		require.NoError(t, err, "error finding trace by id")
 		finds++
 	})
 
-	go concurrent(func() {
+	concurrent(func() {
 		x, err := i.Search(ctx, &tempopb.SearchRequest{
 			Query: "{ .foo=`bar` }",
 		})
@@ -1135,7 +1137,7 @@ func BenchmarkInstanceContention(t *testing.B) {
 		searches++
 	})
 
-	go concurrent(func() {
+	concurrent(func() {
 		_, err := i.SearchTags(ctx, "")
 		require.NoError(t, err, "error searching tags")
 		searchTags++


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: fixes wrong usage of `WaitGroup`. `wg.Add` need to use outside of goroutine otherwise it can lead to a race where `wg.Wait()` call happens before `Add`. Another example of race: https://github.com/grafana/tempo/actions/runs/17299036103/job/49104817911?pr=5581

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`