### PR TITLE
Livestore: Consume improvements

### DIFF
--- a/modules/blockbuilder/blockbuilder_test.go
+++ b/modules/blockbuilder/blockbuilder_test.go
@@ -603,6 +603,110 @@ func TestBlockBuilder_honor_maxBytesPerCycle(t *testing.T) {
 	}
 }
 
+func TestBlockbuilder_usesRecordTimestampForBlockStartAndEnd(t *testing.T) {
+	// default ingestion slack is 2 minutes. create some convenient times to help the test below
+	now := time.Unix(1000000, 0)
+	oneMinuteAgo := now.Add(-time.Minute)
+	oneMinuteLater := now.Add(time.Minute)
+	twoMinutesAgo := now.Add(-2 * time.Minute)
+	threeMinutesAgo := now.Add(-3 * time.Minute)
+
+	tcs := []struct {
+		name          string
+		startTime     time.Time
+		endTime       time.Time
+		recordTime    time.Time
+		expectedStart time.Time
+		expectedEnd   time.Time
+	}{
+		{ // records where the timestamp exactly matches the span timings
+			name:          "exact match",
+			startTime:     oneMinuteAgo,
+			endTime:       oneMinuteAgo,
+			recordTime:    oneMinuteAgo,
+			expectedStart: oneMinuteAgo,
+			expectedEnd:   oneMinuteAgo,
+		},
+		{ // records where the timestamp doesn't match the span timings, but within the ingestion slack
+			name:          "within ingestion slack",
+			startTime:     oneMinuteAgo,
+			endTime:       oneMinuteLater,
+			recordTime:    now,
+			expectedStart: oneMinuteAgo,
+			expectedEnd:   oneMinuteLater,
+		},
+		{ // records where the timestamp doesn't match the span timings and is outside the ingestion slack
+			name:          "outside ingestion slack",
+			startTime:     threeMinutesAgo,
+			endTime:       now,
+			recordTime:    now,
+			expectedStart: twoMinutesAgo, // default ingestion slack is 2 minutes
+			expectedEnd:   now,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancelCause(context.Background())
+			t.Cleanup(func() { cancel(errors.New("test done")) })
+
+			k, address := testkafka.CreateCluster(t, 1, testTopic)
+
+			kafkaCommits := atomic.NewInt32(0)
+			k.ControlKey(kmsg.OffsetCommit, func(kmsg.Request) (kmsg.Response, error, bool) {
+				kafkaCommits.Inc()
+				return nil, nil, false
+			})
+
+			store := newStore(ctx, t)
+			cfg := blockbuilderConfig(t, address, []int32{0})
+
+			client := newKafkaClient(t, cfg.IngestStorageConfig.Kafka)
+
+			// Create a trace with specific start/end times
+			traceID := generateTraceID(t)
+			startTimeNano := uint64(tc.startTime.UnixNano())
+			endTimeNano := uint64(tc.endTime.UnixNano())
+			req := test.MakePushBytesRequest(t, 1, traceID, startTimeNano, endTimeNano)
+			records, err := ingest.Encode(0, util.FakeTenantID, req, 1_000_000)
+			require.NoError(t, err)
+
+			// Set the record timestamp
+			for _, record := range records {
+				record.Timestamp = tc.recordTime
+			}
+
+			// Send the record
+			res := client.ProduceSync(ctx, records...)
+			require.NoError(t, res.FirstErr())
+
+			b, err := New(cfg, test.NewTestingLogger(t), newPartitionRingReader(), &mockOverrides{}, store)
+			require.NoError(t, err)
+			require.NoError(t, services.StartAndAwaitRunning(ctx, b))
+			t.Cleanup(func() {
+				require.NoError(t, services.StopAndAwaitTerminated(ctx, b))
+			})
+
+			// Wait for record to be consumed and committed
+			require.Eventually(t, func() bool {
+				return kafkaCommits.Load() > 0
+			}, time.Minute, time.Second)
+
+			// Wait for the block to be flushed
+			require.Eventually(t, func() bool {
+				return len(store.BlockMetas(util.FakeTenantID)) == 1
+			}, time.Minute, time.Second)
+
+			// Verify block timestamps
+			metas := store.BlockMetas(util.FakeTenantID)
+			require.Len(t, metas, 1)
+			meta := metas[0]
+			require.Equal(t, tc.expectedStart, meta.StartTime)
+			require.Equal(t, tc.expectedEnd, meta.EndTime)
+		})
+	}
+}
+
 func TestBlockbuilder_marksOldBlocksCompacted(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	t.Cleanup(func() { cancel(errors.New("test done")) })

--- a/modules/blockbuilder/blockbuilder_test.go
+++ b/modules/blockbuilder/blockbuilder_test.go
@@ -701,8 +701,8 @@ func TestBlockbuilder_usesRecordTimestampForBlockStartAndEnd(t *testing.T) {
 			metas := store.BlockMetas(util.FakeTenantID)
 			require.Len(t, metas, 1)
 			meta := metas[0]
-			require.Equal(t, tc.expectedStart, meta.StartTime)
-			require.Equal(t, tc.expectedEnd, meta.EndTime)
+			require.Equal(t, tc.expectedStart.Unix(), meta.StartTime.Unix())
+			require.Equal(t, tc.expectedEnd.Unix(), meta.EndTime.Unix())
 		})
 	}
 }

--- a/modules/livestore/live_store.go
+++ b/modules/livestore/live_store.go
@@ -354,7 +354,7 @@ func (s *LiveStore) consume(ctx context.Context, rs []record, now time.Time) err
 		}
 
 		// Push data to tenant instance
-		inst.pushBytes(time.Now(), pushReq)
+		inst.pushBytes(record.timestamp, pushReq)
 
 		metricRecordsProcessed.WithLabelValues(record.tenantID).Inc()
 	}

--- a/modules/livestore/partition_reader.go
+++ b/modules/livestore/partition_reader.go
@@ -3,7 +3,6 @@ package livestore
 import (
 	"context"
 	"fmt"
-	"math"
 	"strconv"
 	"time"
 
@@ -22,23 +21,12 @@ import (
 	"github.com/twmb/franz-go/plugin/kprom"
 )
 
-type record struct {
-	tenantID  string
-	content   []byte
-	offset    int64
-	timestamp time.Time
+type recordIter interface {
+	Next() *kgo.Record
+	Done() bool
 }
 
-func fromKGORecord(rec *kgo.Record) record {
-	return record{
-		tenantID:  string(rec.Key),
-		content:   rec.Value,
-		offset:    rec.Offset,
-		timestamp: rec.Timestamp,
-	}
-}
-
-type consumeFn func(context.Context, []record, time.Time) error
+type consumeFn func(context.Context, recordIter, time.Time) (*kadm.Offset, error)
 
 type PartitionReader struct {
 	services.Service
@@ -129,35 +117,16 @@ func collectFetchErrs(fetches kgo.Fetches) (_ error) {
 }
 
 func (r *PartitionReader) consumeFetches(ctx context.Context, fetches kgo.Fetches) *kadm.Offset {
-	records := make([]record, 0, fetches.NumRecords())
-
-	var lastRecord *kgo.Record
-
-	var (
-		minOffset = int64(math.MaxInt64)
-		maxOffset = int64(0)
-	)
-	fetches.EachRecord(func(rec *kgo.Record) {
-		minOffset = min(minOffset, rec.Offset)
-		maxOffset = max(maxOffset, rec.Offset)
-		records = append(records, fromKGORecord(rec))
-
-		lastRecord = rec
-	})
 
 	// Pass offset and byte information to the live-store
-	err := r.consume(ctx, records, time.Now())
+	offset, err := r.consume(ctx, fetches.RecordIter(), time.Now())
 	if err != nil {
-		level.Error(r.logger).Log("msg", "encountered error processing records; skipping", "min_offset", minOffset, "max_offset", maxOffset, "err", err)
 		// TODO abort ingesting & back off if it's a server error, ignore error if it's a client error
-	}
-
-	if lastRecord == nil {
+		level.Error(r.logger).Log("msg", "encountered error processing records; skipping", "err", err)
 		return nil
 	}
 
-	offset := kadm.NewOffsetFromRecord(lastRecord)
-	return &offset
+	return offset
 }
 
 func (r *PartitionReader) recordFetchesMetrics(fetches kgo.Fetches) {

--- a/modules/livestore/partition_reader.go
+++ b/modules/livestore/partition_reader.go
@@ -117,7 +117,6 @@ func collectFetchErrs(fetches kgo.Fetches) (_ error) {
 }
 
 func (r *PartitionReader) consumeFetches(ctx context.Context, fetches kgo.Fetches) *kadm.Offset {
-
 	// Pass offset and byte information to the live-store
 	offset, err := r.consume(ctx, fetches.RecordIter(), time.Now())
 	if err != nil {

--- a/pkg/livetraces/livetraces.go
+++ b/pkg/livetraces/livetraces.go
@@ -22,8 +22,8 @@ type LiveTrace[T LiveTraceBatchT] struct {
 	ID      []byte
 	Batches []T
 
-	lastAppend time.Time
-	createdAt  time.Time
+	LastAppend time.Time
+	CreatedAt  time.Time
 	sz         uint64
 }
 
@@ -80,7 +80,7 @@ func (l *LiveTraces[T]) PushWithTimestampAndLimits(ts time.Time, traceID []byte,
 
 		tr = &LiveTrace[T]{
 			ID:        traceID,
-			createdAt: ts,
+			CreatedAt: ts,
 		}
 		l.Traces[token] = tr
 	}
@@ -96,7 +96,7 @@ func (l *LiveTraces[T]) PushWithTimestampAndLimits(ts time.Time, traceID []byte,
 	l.sz += sz
 
 	tr.Batches = append(tr.Batches, batch)
-	tr.lastAppend = ts
+	tr.LastAppend = ts
 	return nil
 }
 
@@ -107,7 +107,7 @@ func (l *LiveTraces[T]) CutIdle(now time.Time, immediate bool) []*LiveTrace[T] {
 	liveSince := now.Add(-l.maxLiveTime)
 
 	for k, tr := range l.Traces {
-		if tr.lastAppend.Before(idleSince) || tr.createdAt.Before(liveSince) || immediate {
+		if tr.LastAppend.Before(idleSince) || tr.CreatedAt.Before(liveSince) || immediate {
 			res = append(res, tr)
 			l.sz -= tr.sz
 			delete(l.Traces, k)


### PR DESCRIPTION
Primarily this PR correctly persists the span start/end timestamps to the block start/end meta while using ingestion slack and record.timestamp. The blockbuilder already correctly did this.

Other changes:
- Adds a test to confirm that record.Timestamp, ingestion slack and span start/end are correctly used to generate block metas in the livestore
- Adds the same test in blockbuilder (no changes to blockbuilder logic. just locking down this behavior)
- Changed the consume loop to take a kgo.RecordIter to remove unnecessary allocs/transformations. [this was a change request on the original PR](https://github.com/grafana/tempo/pull/5563#discussion_r2298876135)
- Preferred dropping records to perfectly persisting data in the face of errors. Added drop reasons to metric failed records. I'm willing to discuss but it seems to me that it would be better in the livestore to favor "best effort" behavior to provide recent data as effectively as possible while the blockbuilder should favor "perfect" behavior.