### PR TITLE
Proposal: [bugfix] Do not start from start if block-builder is at the end of partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Additionally the `compaction_tenant_backoff_total` metric has been renamed to `c
 * [BUGFIX] Fix cache collision for incomplete query in SearchTagValuesV2 [#5549](https://github.com/grafana/tempo/pull/5549) (@ruslan-mikhailov)
 * [BUGFIX] Fix for structural operator with empty left-hand spanset [#5578](https://github.com/grafana/tempo/pull/5578) (@ruslan-mikhailov)
 * [BUGFIX] Deadlock on invalid query to api/v2/search/tags (SearchTagsV2) [#5607](https://github.com/grafana/tempo/pull/5607) (@ruslan-mikhailov)
+* [BUGFIX] Do not start from start if block-builder is at the end of partition [#5581](https://github.com/grafana/tempo/pull/5581) (@ruslan-mikhailov)
 
 # v2.8.2
 

--- a/modules/blockbuilder/blockbuilder.go
+++ b/modules/blockbuilder/blockbuilder.go
@@ -130,16 +130,10 @@ func (p partitionState) getStartOffset() kgo.Offset {
 	if p.commitOffset > commitOffsetAtEnd {
 		return kgo.NewOffset().At(p.commitOffset)
 	}
-	// If commit offset is AtEnd (-1), it nevertheless will consume from the start.
-	// This is a workaround for franz-go and default Kafka behaviour:
-	// in case consumer is new and has no committed offsets, it will start consuming from the end,
-	// while for block builder, it should consume from the earliest record.
-	// The workaround is dirty and can break the consumer if it starts returning AtEnd (-1) for
-	// already running consumer.
-	// TODO: replace the workaround with proper new consumer offset initialization
-	// if p.commitOffset == commitOffsetAtEnd {
-	// 	return kgo.NewOffset().AtEnd()
-	// }
+	if p.commitOffset == commitOffsetAtEnd {
+		return kgo.NewOffset().AtEnd()
+	}
+	// No commit offset, start at beginning
 	return kgo.NewOffset().AtStart()
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: addresses issue from
```go
func (p partitionState) getStartOffset() kgo.Offset {
	if p.commitOffset > commitOffsetAtEnd {
		return kgo.NewOffset().At(p.commitOffset)
	}
	// If commit offset is AtEnd (-1), it nevertheless will consume from the start.
	// This is a workaround for franz-go and default Kafka behaviour:
	// in case consumer is new and has no committed offsets, it will start consuming from the end,
	// while for block builder, it should consume from the earliest record.
	// The workaround is dirty and can break the consumer if it starts returning AtEnd (-1) for
	// already running consumer.
	// TODO: replace the workaround with proper new consumer offset initialization
	// if p.commitOffset == commitOffsetAtEnd {
	// 	return kgo.NewOffset().AtEnd()
	// }
	return kgo.NewOffset().AtStart()
}
```
So, the PR introduces 2 changes:
1. If kafka lib returns offset at end, it points the consumer to at end
2. It sets initial offset to -2 (at start):
- fetch all offsets from consumer group
- lookup for given partitions. If they are not found, set it to `AtStart`

I wrap the PR as a Proposal, because I'm not sure it is better or less hacky than the current solution. Another downside is that if we receive `AtEnd` from libs for a not-new consumer (timestamp 1), and we start consuming from the latest record (timestamp 2), there is a chance that between these two timestamps we can receive new records that will be lost. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`