### PR TITLE
[jsonnet] chown livestore's volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ Additionally the `compaction_tenant_backoff_total` metric has been renamed to `c
 * [ENHANCEMENT] Upgrade Azurite and Fake-gcs-server to latest version [#5512](https://github.com/grafana/tempo/pull/5512) (@javiermolinar)
 * [ENHANCEMENT] Make block ordering deterministic [#5411](https://github.com/grafana/tempo/pull/5411) (@rajiv-singh)
 * [ENHANCEMENT] Improve exemplar selection in quantile_over_time() [#5278](https://github.com/grafana/tempo/pull/5278) (@zalegrala)
-* [ENHANCEMENT] Add live store to jsonnet lib [#5591](https://github.com/grafana/tempo/pull/5591) (@mapno)
+* [ENHANCEMENT] Add live store to jsonnet lib [#5591](https://github.com/grafana/tempo/pull/5591) [#5606](https://github.com/grafana/tempo/pull/5606) (@mapno)
 * [BUGFIX] Correctly apply trace idle period in ingesters and add the concept of trace live period. [#5346](https://github.com/grafana/tempo/pull/5346/files) (@joe-elliott)
 * [BUGFIX] Fix invalid YAML output from /status/runtime_config endpoint by adding document separator. [#5146](https://github.com/grafana/tempo/issues/5146)
 * [BUGFIX] Fix race condition between compaction provider and backend-scheduler [#5409](https://github.com/grafana/tempo/pull/5409) (@zalegrala)

--- a/operations/jsonnet-compiled/util/jsonnetfile.lock.json
+++ b/operations/jsonnet-compiled/util/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "7a55aea78ce69ed10222877e50479911f6323539",
+      "version": "a0c465d0ad8f65bd6e877278db14f9dd94c2d2c3",
       "sum": "0y3AFX9LQSpfWTxWKSwoLgbt0Wc9nnCwhMH2szKzHv0="
     },
     {
@@ -18,7 +18,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "7a55aea78ce69ed10222877e50479911f6323539",
+      "version": "a0c465d0ad8f65bd6e877278db14f9dd94c2d2c3",
       "sum": "f+DYmgxR3spwx8DbIyY4+qSaFsshg/SE+MDG6jUQhJg="
     },
     {

--- a/operations/jsonnet/microservices/common.libsonnet
+++ b/operations/jsonnet/microservices/common.libsonnet
@@ -107,6 +107,16 @@
         statefulset.spec.template.spec.withInitContainers([
           $.tempo_chown_container('ingester-data'),
         ]),
+
+      tempo_live_store_zone_a_statefulset+:
+        statefulset.spec.template.spec.withInitContainers([
+          $.tempo_chown_container('live-store-data'),
+        ]),
+
+      tempo_live_store_zone_b_statefulset+:
+        statefulset.spec.template.spec.withInitContainers([
+          $.tempo_chown_container('live-store-data'),
+        ]),
     },
   },
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Changes the ownership of the folder used by the live-store's volumes. Missed in https://github.com/grafana/tempo/pull/5591

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`