### PR TITLE
[DOC] Add link to MCP blog post to MCP doc

### DIFF
--- a/docs/sources/tempo/api_docs/mcp-server.md
+++ b/docs/sources/tempo/api_docs/mcp-server.md
@@ -1,13 +1,17 @@
 ---
-title: Tempo MCP Server
-description: Grafana Tempo exposes an MCP Server to allow LLMs and AI assistants to interact with your trace data
-menuTitle: MCP Server
+title: Tempo MCP server
+description: Grafana Tempo exposes an MCP server to allow LLMs and AI assistants to interact with your trace data.
+menuTitle: MCP server
 weight: 800
 ---
 
 # Model Context Protocol (MCP) Server
 
-Tempo includes an MCP (Model Context Protocol) server that provides AI assistants and Large Language Models with direct access to distributed tracing data through TraceQL queries and other endpoints.
+Tempo includes an MCP (Model Context Protocol) server that provides AI assistants and Large Language Models (LLMs) with direct access to distributed tracing data through TraceQL queries and other endpoints.
+
+For examples on how you can use the MCP server, refer to [LLM-powered insights into your tracing data: introducing MCP support in Grafana Cloud Traces](https://grafana.com/blog/2025/08/13/llm-powered-insights-into-your-tracing-data-introducing-mcp-support-in-grafana-cloud-traces/).
+
+For more information on MCP, refer to the [MCP documentation](https://modelcontextprotocol.io/docs/getting-started/intro).
 
 ## Configuration
 
@@ -27,10 +31,10 @@ Be aware that using this feature will likely cause tracing data to be passed to 
 
 To experiment with the MCP server using dummy data and Claude Code:
 
-1. Run the local docker-compose example in `/example/docker-compose/local`. This will expose the mcp server at http://localhost:3200/api/mcp
+1. Run the local docker-compose example in `/example/docker-compose/local`. This exposes the MCP server at `http://localhost:3200/api/mcp`
 1. Run `claude mcp add --transport=http tempo http://localhost:3200/api/mcp` to add a reference to Claude Code.
-1. Run `claude` and ask some questions
+1. Run `claude` and ask some questions.
 
-This MCP server has also been tested succesfully in cursor using the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) package.
+This MCP server has also been tested successfully in cursor using the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) package.
 
 ![Claude Code interacting with the Tempo MCP server](/static/img/docs/tempo/claude-code-tempo-mcp.png)


### PR DESCRIPTION
**What this PR does**:

Links Joe's blog post about the MCP server into the MCP server API doc. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`