### PR TITLE
[Bugfix] Deadlock on invalid query to api/v2/search/tags (#5607)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Additionally the `compaction_tenant_backoff_total` metric has been renamed to `c
 * [BUGFIX] Fix incorrect results in TraceQL compare() for spans with array attributes [#5519](https://github.com/grafana/tempo/pull/5519) (@ruslan-mikhailov)
 * [BUGFIX] Fix cache collision for incomplete query in SearchTagValuesV2 [#5549](https://github.com/grafana/tempo/pull/5549) (@ruslan-mikhailov)
 * [BUGFIX] Fix for structural operator with empty left-hand spanset [#5578](https://github.com/grafana/tempo/pull/5578) (@ruslan-mikhailov)
+* [BUGFIX] Deadlock on invalid query to api/v2/search/tags (SearchTagsV2) [#5607](https://github.com/grafana/tempo/pull/5607) (@ruslan-mikhailov)
 
 # v2.8.2
 

--- a/integration/e2e/api/api_test.go
+++ b/integration/e2e/api/api_test.go
@@ -103,6 +103,24 @@ func TestSearchTagsV2(t *testing.T) {
 			},
 		},
 		{
+			name:  "invalid query",
+			query: ` { a="test" } `,
+			scope: "none",
+			// same results as no filtering
+			expected: searchTagsV2Response{
+				Scopes: []ScopedTags{
+					{
+						Name: "span",
+						Tags: []string{firstBatch.SpanAttr, secondBatch.SpanAttr},
+					},
+					{
+						Name: "resource",
+						Tags: []string{firstBatch.resourceAttr, secondBatch.resourceAttr, "service.name"},
+					},
+				},
+			},
+		},
+		{
 			name:  "first batch - resource",
 			query: fmt.Sprintf(`{ name="%s" }`, firstBatch.name),
 			scope: "resource",

--- a/pkg/traceql/engine.go
+++ b/pkg/traceql/engine.go
@@ -224,7 +224,9 @@ func (e *Engine) ExecuteTagNames(
 		Scope:      scope,
 	}
 
-	span.SetAttributes(attribute.String("pipeline", rootExpr.Pipeline.String()))
+	if rootExpr != nil {
+		span.SetAttributes(attribute.String("pipeline", rootExpr.Pipeline.String()))
+	}
 	span.SetAttributes(attribute.String("autocompleteReq", fmt.Sprint(autocompleteReq)))
 
 	return fetcher.Fetch(ctx, autocompleteReq, cb)

--- a/pkg/traceql/engine_test.go
+++ b/pkg/traceql/engine_test.go
@@ -562,6 +562,29 @@ func TestExamplesInEngine(t *testing.T) {
 	}
 }
 
+func TestExecuteTagNames_InvalidQuery(t *testing.T) {
+	e := NewEngine()
+
+	invalidQuery := "{ invalid syntax }"
+	err := e.ExecuteTagNames(
+		context.Background(),
+		AttributeScopeSpan,
+		invalidQuery,
+		func(string, AttributeScope) bool {
+			return false
+		},
+		&MockTagNamesFetcher{},
+	)
+
+	require.NoError(t, err)
+}
+
+type MockTagNamesFetcher struct{}
+
+func (m *MockTagNamesFetcher) Fetch(context.Context, FetchTagsRequest, FetchTagsCallback) error {
+	return nil
+}
+
 func TestExecuteTagValues(t *testing.T) {
 	// TODO: This test is stupid, it's using the traceql engine to execute the query
 	//  and doesn't actually test the ExecuteTagValues function


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: backport #5607 to r216

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`