### PR TITLE
Commit changes to prevent mutex locking

### DIFF
--- a/modules/livestore/instance.go
+++ b/modules/livestore/instance.go
@@ -22,7 +22,6 @@ import (
 	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 	"github.com/grafana/tempo/tempodb/wal"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 

--- a/modules/livestore/live_store.go
+++ b/modules/livestore/live_store.go
@@ -317,16 +317,16 @@ func (s *LiveStore) stopping(error) error {
 
 	timeout := time.NewTimer(s.cfg.InstanceCleanupPeriod)
 	defer timeout.Stop()
-
-	for !s.completeQueues.IsEmpty() {
-		select {
-		case <-ticker.C:
-		case <-timeout.C:
-			level.Error(s.logger).Log("msg", "flush remaining blocks timed out")
-			return nil // shutdown timeout reached
+	/*
+		for !s.completeQueues.IsEmpty() {
+			select {
+			case <-ticker.C:
+			case <-timeout.C:
+				level.Error(s.logger).Log("msg", "flush remaining blocks timed out")
+				return nil // shutdown timeout reached
+			}
 		}
-	}
-
+	*/
 	s.stopAllBackgroundProcesses()
 
 	return nil


### PR DESCRIPTION
Removed the blocking out of iterateBlocks and depend on the parent blocking. Its not the most intuitive but this is a relatively low rate of code change to fix the issue.