### PR TITLE
Allow per-tenant configuration of native histograms

### DIFF
--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -907,6 +907,8 @@ overrides:
         metrics_generator:
             generate_native_histograms: classic
             ingestion_time_range_slack: 0s
+            native_histogram_bucket_factor: 1.1
+            native_histogram_min_reset_duration: 15m0s
         global:
             max_bytes_per_trace: 5000000
     per_tenant_override_config: ""

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -908,6 +908,7 @@ overrides:
             generate_native_histograms: classic
             ingestion_time_range_slack: 0s
             native_histogram_bucket_factor: 1.1
+            native_histogram_max_bucket_number: 100
             native_histogram_min_reset_duration: 15m0s
         global:
             max_bytes_per_trace: 5000000

--- a/modules/generator/overrides_test.go
+++ b/modules/generator/overrides_test.go
@@ -133,15 +133,15 @@ func (m *mockOverrides) MetricsGeneratorProcessorSpanMetricsDimensionMappings(st
 	return m.spanMetricsDimensionMappings
 }
 
-func (m *mockOverrides) MetricsGeneratorNativeHistogramBucketFactor(userID string) float64 {
+func (m *mockOverrides) MetricsGeneratorNativeHistogramBucketFactor(string) float64 {
 	return m.nativeHistogramBucketFactor
 }
 
-func (m *mockOverrides) MetricsGeneratorNativeHistogramMaxBucketNumber(userID string) uint32 {
+func (m *mockOverrides) MetricsGeneratorNativeHistogramMaxBucketNumber(string) uint32 {
 	return m.nativeHistogramMaxBucketNumber
 }
 
-func (m *mockOverrides) MetricsGeneratorNativeHistogramMinResetDuration(userID string) time.Duration {
+func (m *mockOverrides) MetricsGeneratorNativeHistogramMinResetDuration(string) time.Duration {
 	return m.nativeHistogramMinResetDuration
 }
 

--- a/modules/generator/overrides_test.go
+++ b/modules/generator/overrides_test.go
@@ -11,6 +11,9 @@ import (
 
 type mockOverrides struct {
 	processors                                         map[string]struct{}
+	nativeHistogramMaxBucketNumber                     uint32
+	nativeHistogramBucketFactor                        float64
+	nativeHistogramMinResetDuration                    time.Duration
 	serviceGraphsHistogramBuckets                      []float64
 	serviceGraphsDimensions                            []string
 	serviceGraphsPeerAttributes                        []string
@@ -128,6 +131,18 @@ func (m *mockOverrides) MetricsGeneratorProcessorLocalBlocksCompleteBlockTimeout
 // MetricsGeneratorProcessorSpanMetricsDimensionMappings controls custom dimension mapping
 func (m *mockOverrides) MetricsGeneratorProcessorSpanMetricsDimensionMappings(string) []sharedconfig.DimensionMappings {
 	return m.spanMetricsDimensionMappings
+}
+
+func (m *mockOverrides) MetricsGeneratorNativeHistogramBucketFactor(userID string) float64 {
+	return m.nativeHistogramBucketFactor
+}
+
+func (m *mockOverrides) MetricsGeneratorNativeHistogramMaxBucketNumber(userID string) uint32 {
+	return m.nativeHistogramMaxBucketNumber
+}
+
+func (m *mockOverrides) MetricsGeneratorNativeHistogramMinResetDuration(userID string) time.Duration {
+	return m.nativeHistogramMinResetDuration
 }
 
 // MetricsGeneratorProcessorSpanMetricsEnableTargetInfo enables target_info metrics

--- a/modules/generator/registry/native_histogram.go
+++ b/modules/generator/registry/native_histogram.go
@@ -306,7 +306,6 @@ func (h *nativeHistogram) hashOverrides() (uint64, float64, uint32, time.Duratio
 	)
 
 	hsh := fnv.New64a()
-	hsh.Write([]byte(h.tenant))
 
 	_ = binary.Write(hsh, binary.LittleEndian, bucketFactor)
 	_ = binary.Write(hsh, binary.LittleEndian, maxBucketNum)

--- a/modules/generator/registry/native_histogram.go
+++ b/modules/generator/registry/native_histogram.go
@@ -273,6 +273,10 @@ func (h *nativeHistogram) removeStaleSeries(staleTimeMs int64) {
 	h.seriesMtx.Lock()
 	defer h.seriesMtx.Unlock()
 	for hash, s := range h.series {
+		// TODO: native histogram bucket configuration is only checked when the
+		// series is created.  We need a way to determine if the overrides has
+		// changed, and recreate the series if needed.  Without this, the bucket
+		// config is only set at startup.
 		if s.lastUpdated < staleTimeMs {
 			delete(h.series, hash)
 			h.onRemoveSerie(h.activeSeriesPerHistogramSerie())

--- a/modules/generator/registry/native_histogram.go
+++ b/modules/generator/registry/native_histogram.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"encoding/binary"
 	"fmt"
 	"hash/fnv"
 	"math"
@@ -304,9 +305,13 @@ func (h *nativeHistogram) hashOverrides() (uint64, float64, uint32, time.Duratio
 		minResetDur  = h.overrides.MetricsGeneratorNativeHistogramMinResetDuration(h.tenant)
 	)
 
-	s := fmt.Sprintf("%s%f%d%s", h.tenant, bucketFactor, maxBucketNum, minResetDur)
 	hsh := fnv.New64a()
-	hsh.Write([]byte(s))
+	hsh.Write([]byte(h.tenant))
+
+	_ = binary.Write(hsh, binary.LittleEndian, bucketFactor)
+	_ = binary.Write(hsh, binary.LittleEndian, maxBucketNum)
+	_ = binary.Write(hsh, binary.LittleEndian, minResetDur)
+
 	return hsh.Sum64(), bucketFactor, maxBucketNum, minResetDur
 }
 

--- a/modules/generator/registry/native_histogram_test.go
+++ b/modules/generator/registry/native_histogram_test.go
@@ -23,7 +23,7 @@ func Test_ObserveWithExemplar_duplicate(t *testing.T) {
 		return true
 	}
 
-	h := newNativeHistogram("my_histogram", []float64{0.1, 0.2}, onAdd, nil, "trace_id", HistogramModeBoth, nil, testTenant, nil)
+	h := newNativeHistogram("my_histogram", []float64{0.1, 0.2}, onAdd, nil, "trace_id", HistogramModeBoth, nil, testTenant, &mockOverrides{})
 
 	lv := newLabelValueCombo([]string{"label"}, []string{"value-1"})
 
@@ -499,7 +499,7 @@ func Test_Histograms(t *testing.T) {
 				}
 
 				onAdd := func(uint32) bool { return true }
-				h := newNativeHistogram("test_histogram", tc.buckets, onAdd, nil, "trace_id", HistogramModeBoth, nil, testTenant, nil)
+				h := newNativeHistogram("test_histogram", tc.buckets, onAdd, nil, "trace_id", HistogramModeBoth, nil, testTenant, &mockOverrides{})
 				testHistogram(t, h, tc.collections)
 			})
 		})
@@ -596,9 +596,15 @@ func Test_NativeOnlyExemplars(t *testing.T) {
 	collectionTimeMs := time.Now().UnixMilli()
 
 	t.Run("native_only_with_exemplars", func(t *testing.T) {
+		overrides := &mockOverrides{
+			nativeHistogramBucketFactor:     1.5,
+			nativeHistogramMaxBucketNumber:  10,
+			nativeHistogramMinResetDuration: time.Minute,
+		}
+
 		onAdd := func(uint32) bool { return true }
 		// Use HistogramModeNative to test native-only behavior
-		h := newNativeHistogram("test_native_histogram", buckets, onAdd, nil, "trace_id", HistogramModeNative, nil, testTenant, nil)
+		h := newNativeHistogram("test_native_histogram", buckets, onAdd, nil, "trace_id", HistogramModeNative, nil, testTenant, overrides)
 
 		// Add some observations with exemplars
 		lvc := newLabelValueCombo([]string{"service"}, []string{"test-service"})
@@ -640,8 +646,14 @@ func Test_NativeOnlyExemplars(t *testing.T) {
 	t.Run("native_only_histogram_exemplars", func(t *testing.T) {
 		onAdd := func(uint32) bool { return true }
 
+		overrides := &mockOverrides{
+			nativeHistogramBucketFactor:     1.5,
+			nativeHistogramMaxBucketNumber:  10,
+			nativeHistogramMinResetDuration: time.Minute,
+		}
+
 		// Create a native histogram with empty buckets to force native-only mode
-		h := newNativeHistogram("test_native_only", []float64{}, onAdd, nil, "trace_id", HistogramModeNative, nil, testTenant, nil)
+		h := newNativeHistogram("test_native_only", []float64{}, onAdd, nil, "trace_id", HistogramModeNative, nil, testTenant, overrides)
 
 		// Add some observations with exemplars
 		lvc := newLabelValueCombo([]string{"service"}, []string{"native-only-xyz"})

--- a/modules/generator/registry/native_histogram_test.go
+++ b/modules/generator/registry/native_histogram_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var testTenant = "test-tenant"
+
 // Duplicate labels should not grow the series count.
 func Test_ObserveWithExemplar_duplicate(t *testing.T) {
 	var seriesAdded int
@@ -21,7 +23,7 @@ func Test_ObserveWithExemplar_duplicate(t *testing.T) {
 		return true
 	}
 
-	h := newNativeHistogram("my_histogram", []float64{0.1, 0.2}, onAdd, nil, "trace_id", HistogramModeBoth, nil)
+	h := newNativeHistogram("my_histogram", []float64{0.1, 0.2}, onAdd, nil, "trace_id", HistogramModeBoth, nil, testTenant, nil)
 
 	lv := newLabelValueCombo([]string{"label"}, []string{"value-1"})
 
@@ -497,7 +499,7 @@ func Test_Histograms(t *testing.T) {
 				}
 
 				onAdd := func(uint32) bool { return true }
-				h := newNativeHistogram("test_histogram", tc.buckets, onAdd, nil, "trace_id", HistogramModeBoth, nil)
+				h := newNativeHistogram("test_histogram", tc.buckets, onAdd, nil, "trace_id", HistogramModeBoth, nil, testTenant, nil)
 				testHistogram(t, h, tc.collections)
 			})
 		})
@@ -596,7 +598,7 @@ func Test_NativeOnlyExemplars(t *testing.T) {
 	t.Run("native_only_with_exemplars", func(t *testing.T) {
 		onAdd := func(uint32) bool { return true }
 		// Use HistogramModeNative to test native-only behavior
-		h := newNativeHistogram("test_native_histogram", buckets, onAdd, nil, "trace_id", HistogramModeNative, nil)
+		h := newNativeHistogram("test_native_histogram", buckets, onAdd, nil, "trace_id", HistogramModeNative, nil, testTenant, nil)
 
 		// Add some observations with exemplars
 		lvc := newLabelValueCombo([]string{"service"}, []string{"test-service"})
@@ -639,7 +641,7 @@ func Test_NativeOnlyExemplars(t *testing.T) {
 		onAdd := func(uint32) bool { return true }
 
 		// Create a native histogram with empty buckets to force native-only mode
-		h := newNativeHistogram("test_native_only", []float64{}, onAdd, nil, "trace_id", HistogramModeNative, nil)
+		h := newNativeHistogram("test_native_only", []float64{}, onAdd, nil, "trace_id", HistogramModeNative, nil, testTenant, nil)
 
 		// Add some observations with exemplars
 		lvc := newLabelValueCombo([]string{"service"}, []string{"native-only-xyz"})

--- a/modules/generator/registry/overrides.go
+++ b/modules/generator/registry/overrides.go
@@ -12,6 +12,9 @@ type Overrides interface {
 	MetricsGeneratorDisableCollection(userID string) bool
 	MetricsGeneratorGenerateNativeHistograms(userID string) overrides.HistogramMethod
 	MetricsGenerationTraceIDLabelName(userID string) string
+	MetricsGeneratorNativeHistogramBucketFactor(userID string) float64
+	MetricsGeneratorNativeHistogramMaxBucketNumber(userID string) uint32
+	MetricsGeneratorNativeHistogramMinResetDuration(userID string) time.Duration
 }
 
 var _ Overrides = (overrides.Interface)(nil)

--- a/modules/generator/registry/registry.go
+++ b/modules/generator/registry/registry.go
@@ -156,7 +156,7 @@ func (r *ManagedRegistry) NewHistogram(name string, buckets []float64, histogram
 	// are disabled, eventually the new implementation can handle all cases
 
 	if hasNativeHistograms(histogramOverride) {
-		h = newNativeHistogram(name, buckets, r.onAddMetricSeries, r.onRemoveMetricSeries, traceIDLabelName, histogramOverride, r.externalLabels)
+		h = newNativeHistogram(name, buckets, r.onAddMetricSeries, r.onRemoveMetricSeries, traceIDLabelName, histogramOverride, r.externalLabels, r.tenant, r.overrides)
 	} else {
 		h = newHistogram(name, buckets, r.onAddMetricSeries, r.onRemoveMetricSeries, traceIDLabelName, r.externalLabels)
 	}

--- a/modules/generator/registry/registry_test.go
+++ b/modules/generator/registry/registry_test.go
@@ -372,15 +372,15 @@ func (m *mockOverrides) MetricsGenerationTraceIDLabelName(string) string {
 	return ""
 }
 
-func (m *mockOverrides) MetricsGeneratorNativeHistogramBucketFactor(userID string) float64 {
+func (m *mockOverrides) MetricsGeneratorNativeHistogramBucketFactor(string) float64 {
 	return m.nativeHistogramBucketFactor
 }
 
-func (m *mockOverrides) MetricsGeneratorNativeHistogramMaxBucketNumber(userID string) uint32 {
+func (m *mockOverrides) MetricsGeneratorNativeHistogramMaxBucketNumber(string) uint32 {
 	return m.nativeHistogramMaxBucketNumber
 }
 
-func (m *mockOverrides) MetricsGeneratorNativeHistogramMinResetDuration(userID string) time.Duration {
+func (m *mockOverrides) MetricsGeneratorNativeHistogramMinResetDuration(string) time.Duration {
 	return m.nativeHistogramMinResetDuration
 }
 

--- a/modules/generator/registry/registry_test.go
+++ b/modules/generator/registry/registry_test.go
@@ -342,9 +342,12 @@ func collectRegistryMetricsAndAssert(t *testing.T, r *ManagedRegistry, appender 
 }
 
 type mockOverrides struct {
-	maxActiveSeries          uint32
-	disableCollection        bool
-	generateNativeHistograms overrides.HistogramMethod
+	maxActiveSeries                 uint32
+	disableCollection               bool
+	generateNativeHistograms        overrides.HistogramMethod
+	nativeHistogramMaxBucketNumber  uint32
+	nativeHistogramBucketFactor     float64
+	nativeHistogramMinResetDuration time.Duration
 }
 
 var _ Overrides = (*mockOverrides)(nil)
@@ -367,6 +370,18 @@ func (m *mockOverrides) MetricsGeneratorGenerateNativeHistograms(_ string) overr
 
 func (m *mockOverrides) MetricsGenerationTraceIDLabelName(string) string {
 	return ""
+}
+
+func (m *mockOverrides) MetricsGeneratorNativeHistogramBucketFactor(userID string) float64 {
+	return m.nativeHistogramBucketFactor
+}
+
+func (m *mockOverrides) MetricsGeneratorNativeHistogramMaxBucketNumber(userID string) uint32 {
+	return m.nativeHistogramMaxBucketNumber
+}
+
+func (m *mockOverrides) MetricsGeneratorNativeHistogramMinResetDuration(userID string) time.Duration {
+	return m.nativeHistogramMinResetDuration
 }
 
 func mustGetHostname() string {

--- a/modules/generator/registry/test.go
+++ b/modules/generator/registry/test.go
@@ -110,7 +110,7 @@ func (t *testCounter) name() string {
 }
 
 func (t *testCounter) collectMetrics(_ storage.Appender, _ int64) (activeSeries int, err error) {
-	return
+	return activeSeries, err
 }
 
 func (t *testCounter) removeStaleSeries(int64) {

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -2,6 +2,8 @@ package overrides
 
 import (
 	"flag"
+	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/prometheus/common/config"
@@ -154,6 +156,10 @@ type MetricsGeneratorOverrides struct {
 	Forwarder      ForwarderOverrides `yaml:"forwarder,omitempty" json:"forwarder,omitempty"`
 	Processor      ProcessorOverrides `yaml:"processor,omitempty" json:"processor,omitempty"`
 	IngestionSlack time.Duration      `yaml:"ingestion_time_range_slack" json:"ingestion_time_range_slack"`
+
+	NativeHistogramBucketFactor     float64       `yaml:"native_histogram_bucket_factor,omitempty" json:"native_histogram_bucket_factor,omitempty"`
+	NativeHistogramMaxBucketNumber  uint32        `yaml:"native_histogram_max_bucket_number,omitempty" json:"native_histogram_max_bucket_number,omitempty"`
+	NativeHistogramMinResetDuration time.Duration `yaml:"native_histogram_min_reset_duration,omitempty" json:"native_histogram_min_reset_duration,omitempty"`
 }
 
 type ReadOverrides struct {
@@ -280,6 +286,11 @@ func (c *Config) RegisterFlagsAndApplyDefaults(f *flag.FlagSet) {
 	f.IntVar(&c.Defaults.Read.MaxBytesPerTagValuesQuery, "querier.max-bytes-per-tag-values-query", 10e5, "Maximum size of response for a tag-values query. Used mainly to limit large the number of values associated with a particular tag")
 	f.IntVar(&c.Defaults.Read.MaxBlocksPerTagValuesQuery, "querier.max-blocks-per-tag-values-query", 0, "Maximum number of blocks to query for a tag-values query. 0 to disable.")
 
+	// Generator - NativeHistograms config
+	f.Float64Var(&c.Defaults.MetricsGenerator.NativeHistogramBucketFactor, "metrics-generator.native-histogram-bucket-factor", 1.1, "The growth factor between buckets for native histograms.")
+	f.Var((*Uint32Value)(&c.Defaults.MetricsGenerator.NativeHistogramMaxBucketNumber), "metrics-generator.native-histogram-max-bucket-number", "The maximum number of buckets for native histograms.")
+	f.DurationVar(&c.Defaults.MetricsGenerator.NativeHistogramMinResetDuration, "metrics-generator.native-histogram-min-reset-duration", 15*time.Minute, "The minimum duration before a native histogram can be reset.")
+
 	f.StringVar(&c.PerTenantOverrideConfig, "config.per-user-override-config", "", "File name of per-user Overrides.")
 	_ = c.PerTenantOverridePeriod.Set("10s")
 	f.Var(&c.PerTenantOverridePeriod, "config.per-user-override-period", "Period with this to reload the Overrides.")
@@ -305,4 +316,16 @@ func (c *Config) Collect(ch chan<- prometheus.Metric) {
 
 func HasNativeHistograms(s HistogramMethod) bool {
 	return s == HistogramMethodNative || s == HistogramMethodBoth
+}
+
+type Uint32Value uint32
+
+func (u *Uint32Value) String() string { return fmt.Sprintf("%d", *u) }
+func (u *Uint32Value) Set(s string) error {
+	v, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return err
+	}
+	*u = Uint32Value(v)
+	return nil
 }

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -288,6 +288,7 @@ func (c *Config) RegisterFlagsAndApplyDefaults(f *flag.FlagSet) {
 
 	// Generator - NativeHistograms config
 	f.Float64Var(&c.Defaults.MetricsGenerator.NativeHistogramBucketFactor, "metrics-generator.native-histogram-bucket-factor", 1.1, "The growth factor between buckets for native histograms.")
+	_ = (*Uint32Value)(&c.Defaults.MetricsGenerator.NativeHistogramMaxBucketNumber).Set("100")
 	f.Var((*Uint32Value)(&c.Defaults.MetricsGenerator.NativeHistogramMaxBucketNumber), "metrics-generator.native-histogram-max-bucket-number", "The maximum number of buckets for native histograms.")
 	f.DurationVar(&c.Defaults.MetricsGenerator.NativeHistogramMinResetDuration, "metrics-generator.native-histogram-min-reset-duration", 15*time.Minute, "The minimum duration before a native histogram can be reset.")
 

--- a/modules/overrides/config_legacy.go
+++ b/modules/overrides/config_legacy.go
@@ -57,6 +57,9 @@ func (c *Overrides) toLegacy() LegacyOverrides {
 		MetricsGeneratorProcessorHostInfoHostIdentifiers:                            c.MetricsGenerator.Processor.HostInfo.HostIdentifiers,
 		MetricsGeneratorProcessorHostInfoMetricName:                                 c.MetricsGenerator.Processor.HostInfo.MetricName,
 		MetricsGeneratorIngestionSlack:                                              c.MetricsGenerator.IngestionSlack,
+		MetricsGeneratorNativeHistogramBucketFactor:                                 c.MetricsGenerator.NativeHistogramBucketFactor,
+		MetricsGeneratorNativeHistogramMaxBucketNumber:                              c.MetricsGenerator.NativeHistogramMaxBucketNumber,
+		MetricsGeneratorNativeHistogramMinResetDuration:                             c.MetricsGenerator.NativeHistogramMinResetDuration,
 
 		BlockRetention:     c.Compaction.BlockRetention,
 		CompactionWindow:   c.Compaction.CompactionWindow,
@@ -103,6 +106,9 @@ type LegacyOverrides struct {
 	MetricsGeneratorCollectionInterval                                          time.Duration                    `yaml:"metrics_generator_collection_interval" json:"metrics_generator_collection_interval"`
 	MetricsGeneratorDisableCollection                                           bool                             `yaml:"metrics_generator_disable_collection" json:"metrics_generator_disable_collection"`
 	MetricsGeneratorGenerateNativeHistograms                                    HistogramMethod                  `yaml:"metrics_generator_generate_native_histograms" json:"metrics_generator_generate_native_histograms"`
+	MetricsGeneratorNativeHistogramBucketFactor                                 float64                          `yaml:"metrics_generator_native_histogram_bucket_factor,omitempty" json:"metrics_generator_native_histogram_bucket_factor,omitempty"`
+	MetricsGeneratorNativeHistogramMaxBucketNumber                              uint32                           `yaml:"metrics_generator_native_histogram_max_bucket_number,omitempty" json:"metrics_generator_native_histogram_max_bucket_number,omitempty"`
+	MetricsGeneratorNativeHistogramMinResetDuration                             time.Duration                    `yaml:"metrics_generator_native_histogram_min_reset_duration,omitempty" json:"native_histogram_min_reset_duration,omitempty"`
 	MetricsGeneratorTraceIDLabelName                                            string                           `yaml:"metrics_generator_trace_id_label_name" json:"metrics_generator_trace_id_label_name"`
 	MetricsGeneratorForwarderQueueSize                                          int                              `yaml:"metrics_generator_forwarder_queue_size" json:"metrics_generator_forwarder_queue_size"`
 	MetricsGeneratorForwarderWorkers                                            int                              `yaml:"metrics_generator_forwarder_workers" json:"metrics_generator_forwarder_workers"`
@@ -223,6 +229,9 @@ func (l *LegacyOverrides) toNewLimits() Overrides {
 					MetricName:      l.MetricsGeneratorProcessorHostInfoMetricName,
 				},
 			},
+			NativeHistogramBucketFactor:     l.MetricsGeneratorNativeHistogramBucketFactor,
+			NativeHistogramMaxBucketNumber:  l.MetricsGeneratorNativeHistogramMaxBucketNumber,
+			NativeHistogramMinResetDuration: l.MetricsGeneratorNativeHistogramMinResetDuration,
 		},
 		Forwarders: l.Forwarders,
 		Global: GlobalOverrides{

--- a/modules/overrides/config_test.go
+++ b/modules/overrides/config_test.go
@@ -467,6 +467,9 @@ func generateTestLegacyOverrides() LegacyOverrides {
 		MetricsGeneratorProcessorHostInfoHostIdentifiers:                 []string{"host-id-1", "host-id-2"},
 		MetricsGeneratorProcessorHostInfoMetricName:                      "host_info",
 		MetricsGeneratorIngestionSlack:                                   1 * time.Minute,
+		MetricsGeneratorNativeHistogramBucketFactor:                      1.5,
+		MetricsGeneratorNativeHistogramMaxBucketNumber:                   200,
+		MetricsGeneratorNativeHistogramMinResetDuration:                  10 * time.Minute,
 
 		BlockRetention:     model.Duration(7 * 24 * time.Hour),
 		CompactionDisabled: true,

--- a/modules/overrides/config_test.go
+++ b/modules/overrides/config_test.go
@@ -149,6 +149,9 @@ metrics_generator_processor_local_blocks_flush_check_period: 11s
 metrics_generator_processor_local_blocks_trace_idle_period: 12s
 metrics_generator_processor_local_blocks_complete_block_timeout: 13s
 metrics_generator_generate_native_histograms: true
+metrics_generator_native_histogram_bucket_factor: 1.1
+metrics_generator_native_histogram_max_bucket_number: 100
+metrics_generator_native_histogram_min_reset_duration: 15m
 block_retention: 14s
 max_bytes_per_tag_values_query: 15
 max_blocks_per_tag_values_query: 16
@@ -195,6 +198,9 @@ defaults:
       queue_size: 6
       workers: 7
     generate_native_histograms: true
+    native_histogram_bucket_factor: 1.1
+    native_histogram_max_bucket_number: 100
+    native_histogram_min_reset_duration: 15m
     processor:
       service_graphs:
         histogram_buckets:

--- a/modules/overrides/interface.go
+++ b/modules/overrides/interface.go
@@ -74,6 +74,9 @@ type Interface interface {
 	MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(userID string) []string
 	MetricsGeneratorProcessorHostInfoHostIdentifiers(userID string) []string
 	MetricsGeneratorProcessorHostInfoMetricName(userID string) string
+	MetricsGeneratorNativeHistogramBucketFactor(userID string) float64
+	MetricsGeneratorNativeHistogramMaxBucketNumber(userID string) uint32
+	MetricsGeneratorNativeHistogramMinResetDuration(userID string) time.Duration
 	BlockRetention(userID string) time.Duration
 	CompactionDisabled(userID string) bool
 	MaxSearchDuration(userID string) time.Duration

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -427,15 +427,24 @@ func (o *runtimeConfigOverridesManager) MetricsGeneratorGenerateNativeHistograms
 }
 
 func (o *runtimeConfigOverridesManager) MetricsGeneratorNativeHistogramBucketFactor(userID string) float64 {
-	return o.getOverridesForUser(userID).MetricsGenerator.NativeHistogramBucketFactor
+	if factor := o.getOverridesForUser(userID).MetricsGenerator.NativeHistogramBucketFactor; factor != 0.0 {
+		return factor
+	}
+	return o.defaultLimits.MetricsGenerator.NativeHistogramBucketFactor
 }
 
 func (o *runtimeConfigOverridesManager) MetricsGeneratorNativeHistogramMaxBucketNumber(userID string) uint32 {
-	return o.getOverridesForUser(userID).MetricsGenerator.NativeHistogramMaxBucketNumber
+	if num := o.getOverridesForUser(userID).MetricsGenerator.NativeHistogramMaxBucketNumber; num != 0 {
+		return num
+	}
+	return o.defaultLimits.MetricsGenerator.NativeHistogramMaxBucketNumber
 }
 
 func (o *runtimeConfigOverridesManager) MetricsGeneratorNativeHistogramMinResetDuration(userID string) time.Duration {
-	return o.getOverridesForUser(userID).MetricsGenerator.NativeHistogramMinResetDuration
+	if dur := o.getOverridesForUser(userID).MetricsGenerator.NativeHistogramMinResetDuration; dur != 0 {
+		return dur
+	}
+	return o.defaultLimits.MetricsGenerator.NativeHistogramMinResetDuration
 }
 
 // MetricsGenerationTraceIDLabelName is the label name used for the trace ID in metrics.

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -426,6 +426,18 @@ func (o *runtimeConfigOverridesManager) MetricsGeneratorGenerateNativeHistograms
 	return o.getOverridesForUser(userID).MetricsGenerator.GenerateNativeHistograms
 }
 
+func (o *runtimeConfigOverridesManager) MetricsGeneratorNativeHistogramBucketFactor(userID string) float64 {
+	return o.getOverridesForUser(userID).MetricsGenerator.NativeHistogramBucketFactor
+}
+
+func (o *runtimeConfigOverridesManager) MetricsGeneratorNativeHistogramMaxBucketNumber(userID string) uint32 {
+	return o.getOverridesForUser(userID).MetricsGenerator.NativeHistogramMaxBucketNumber
+}
+
+func (o *runtimeConfigOverridesManager) MetricsGeneratorNativeHistogramMinResetDuration(userID string) time.Duration {
+	return o.getOverridesForUser(userID).MetricsGenerator.NativeHistogramMinResetDuration
+}
+
 // MetricsGenerationTraceIDLabelName is the label name used for the trace ID in metrics.
 // "TraceID" is used if no value is provided.
 func (o *runtimeConfigOverridesManager) MetricsGenerationTraceIDLabelName(userID string) string {


### PR DESCRIPTION
**What this PR does**:

Here we add three new override configurations which allow the tuning of the buckets in the native histograms implementaion in the metrics-generator.  This allows tenants of vartying needs to keep their histograms more relevant to their use cases.
The three new configurations are:
- `native_histogram_bucket_factor` - the minimum required distance between buckets
- `native_histogram_max_bucket_number` - the maximum number of buckets to create
- `native_histogram_min_reset_duration` - the minimum duration before a histogram is reset

The value of these configurations are passed directly to the prometheus client library when creating a new histogram.  More detail on these parameters can be found in the [client documentation](https://github.com/prometheus/client_golang/blob/14ccb93091c00f86b85af7753100aa372d63602b/prometheus/histogram.go?plain=1#L405).

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`