### PR TITLE
Add jitter to queuing blocks in the live-store

### DIFF
--- a/modules/livestore/live_store.go
+++ b/modules/livestore/live_store.go
@@ -446,11 +446,7 @@ func (s *LiveStore) cutOneInstanceToWal(inst *instance, immediate bool) {
 
 	// If head block is cut, enqueue complete operation
 	if blockID != uuid.Nil {
-		err = s.enqueueCompleteOp(inst.tenantID, blockID, false)
-		if err != nil {
-			level.Error(s.logger).Log("msg", "failed to enqueue complete operation", "tenant", inst.tenantID, "err", err)
-			return
-		}
+		s.enqueueCompleteOp(inst.tenantID, blockID)
 	}
 }
 

--- a/modules/livestore/live_store.go
+++ b/modules/livestore/live_store.go
@@ -446,7 +446,11 @@ func (s *LiveStore) cutOneInstanceToWal(inst *instance, immediate bool) {
 
 	// If head block is cut, enqueue complete operation
 	if blockID != uuid.Nil {
-		s.enqueueCompleteOp(inst.tenantID, blockID)
+		err = s.enqueueCompleteOp(inst.tenantID, blockID, false)
+		if err != nil {
+			level.Error(s.logger).Log("msg", "failed to enqueue complete operation", "tenant", inst.tenantID, "err", err)
+			return
+		}
 	}
 }
 

--- a/modules/livestore/live_store.go
+++ b/modules/livestore/live_store.go
@@ -446,7 +446,7 @@ func (s *LiveStore) cutOneInstanceToWal(inst *instance, immediate bool) {
 
 	// If head block is cut, enqueue complete operation
 	if blockID != uuid.Nil {
-		err = s.enqueueCompleteOp(inst.tenantID, blockID)
+		err = s.enqueueCompleteOp(inst.tenantID, blockID, false)
 		if err != nil {
 			level.Error(s.logger).Log("msg", "failed to enqueue complete operation", "tenant", inst.tenantID, "err", err)
 			return

--- a/modules/livestore/live_store_background.go
+++ b/modules/livestore/live_store_background.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"time"
 
 	"github.com/go-kit/log/level"
@@ -175,7 +175,7 @@ func (s *LiveStore) enqueueCompleteOp(tenantID string, blockID uuid.UUID, jitter
 }
 
 func (s *LiveStore) enqueueOpWithJitter(op *completeOp) error {
-	delay := time.Duration(rand.Float32() * float32(flushJitter))
+	delay := time.Duration(rand.Float32() * float32(flushJitter)) //gosec:disable G404 — It doesn't require strong randomness
 	go func() {
 		time.Sleep(delay)
 		if err := s.enqueueOp(op); err != nil {

--- a/modules/livestore/live_store_background.go
+++ b/modules/livestore/live_store_background.go
@@ -174,7 +174,7 @@ func (s *LiveStore) enqueueCompleteOp(tenantID string, blockID uuid.UUID, jitter
 }
 
 func (s *LiveStore) enqueueOpWithJitter(op *completeOp) error {
-	delay := time.Duration(rand.Int64N(1_000) * int64(time.Millisecond)) //gosec:disable G404 — It doesn't require strong randomness
+	delay := time.Duration(rand.Int64N(10_000) * int64(time.Millisecond)) //gosec:disable G404 — It doesn't require strong randomness
 	go func() {
 		time.Sleep(delay)
 		if err := s.enqueueOp(op); err != nil {

--- a/modules/livestore/live_store_background.go
+++ b/modules/livestore/live_store_background.go
@@ -19,7 +19,6 @@ const (
 	maxBackoff       = 120 * time.Second
 	initialBackoff   = 30 * time.Second
 	maxFlushAttempts = 10
-	flushJitter      = 10
 )
 
 type completeOp struct {
@@ -175,7 +174,7 @@ func (s *LiveStore) enqueueCompleteOp(tenantID string, blockID uuid.UUID, jitter
 }
 
 func (s *LiveStore) enqueueOpWithJitter(op *completeOp) error {
-	delay := time.Duration(rand.Float32() * float32(flushJitter)) //gosec:disable G404 — It doesn't require strong randomness
+	delay := time.Duration(rand.Int64N(1_000) * int64(time.Millisecond)) //gosec:disable G404 — It doesn't require strong randomness
 	go func() {
 		time.Sleep(delay)
 		if err := s.enqueueOp(op); err != nil {

--- a/modules/livestore/live_store_background.go
+++ b/modules/livestore/live_store_background.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/go-kit/log/level"
@@ -18,6 +19,7 @@ const (
 	maxBackoff       = 120 * time.Second
 	initialBackoff   = 30 * time.Second
 	maxFlushAttempts = 10
+	flushJitter      = 10
 )
 
 type completeOp struct {
@@ -156,14 +158,31 @@ func (s *LiveStore) perTenantCleanupLoop(inst *instance) {
 	}
 }
 
-func (s *LiveStore) enqueueCompleteOp(tenantID string, blockID uuid.UUID) error {
-	return s.enqueueOp(&completeOp{
+func (s *LiveStore) enqueueCompleteOp(tenantID string, blockID uuid.UUID, jitter bool) error {
+	op := &completeOp{
 		tenantID: tenantID,
 		blockID:  blockID,
 		// Initial priority and backoff
 		at: time.Now(),
 		bo: initialBackoff,
-	})
+	}
+
+	if jitter {
+		return s.enqueueOpWithJitter(op)
+	}
+
+	return s.enqueueOp(op)
+}
+
+func (s *LiveStore) enqueueOpWithJitter(op *completeOp) error {
+	delay := time.Duration(rand.Float32() * float32(flushJitter))
+	go func() {
+		time.Sleep(delay)
+		if err := s.enqueueOp(op); err != nil {
+			level.Error(s.logger).Log("msg", "failed to enqueue block", "tenant", op.tenantID, "block", op.blockID, "err", err)
+		}
+	}()
+	return nil
 }
 
 func (s *LiveStore) enqueueOp(op *completeOp) error {
@@ -208,7 +227,7 @@ func (s *LiveStore) reloadBlocks() error {
 			inst.walBlocks[(uuid.UUID)(meta.BlockID)] = blk
 
 			level.Info(s.logger).Log("msg", "queueing replayed wal block for completion", "block", meta.BlockID.String())
-			if err := s.enqueueCompleteOp(meta.TenantID, uuid.UUID(meta.BlockID)); err != nil {
+			if err := s.enqueueCompleteOp(meta.TenantID, uuid.UUID(meta.BlockID), true); err != nil {
 				return fmt.Errorf("failed to enqueue wal block for completion for tenant %s: %w", meta.TenantID, err)
 			}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Adds jitter to enqueuing blocks for completition in the live stores. This eases the memory pressure at startup and makes live-stores more stable in high-load scenarios.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`