### PR TITLE
Update local docker-compose example to scrape /usage_metrics

### DIFF
--- a/example/docker-compose/local/docker-compose.yaml
+++ b/example/docker-compose/local/docker-compose.yaml
@@ -53,7 +53,7 @@ services:
       - --enable-feature=exemplar-storage
       - --enable-feature=native-histograms
     volumes:
-      - ../shared/prometheus.yaml:/etc/prometheus.yaml
+      - ./prometheus.yaml:/etc/prometheus.yaml
     ports:
       - "9090:9090"
 

--- a/example/docker-compose/local/prometheus.yaml
+++ b/example/docker-compose/local/prometheus.yaml
@@ -1,0 +1,15 @@
+global:
+  scrape_interval:     15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+  - job_name: 'tempo'
+    static_configs:
+      - targets: ['tempo:3200']
+  - job_name: 'tempo-usage-metrics'
+    metrics_path: '/usage_metrics'
+    static_configs:
+      - targets: ['tempo:3200']


### PR DESCRIPTION
**What this PR does**:

We demoed this in [community call this week](https://www.youtube.com/watch?v=fdmLmJMlUjI), and when I was getting the demo ready I noticed that we don't scrape `/usage_metrics`. 

This PR copies over the shared prometheus.yaml and adds a scrape config to scrape `/usage_metrics` from tempo.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`