### PR TITLE
Allow multiple compaction provider instances

### DIFF
--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -1059,6 +1059,7 @@ backend_scheduler:
             max_input_blocks: 4
             max_compaction_level: 0
             min_cycle_interval: 30s
+            max_concurrent_tenants: 1
     job_timeout: 15s
     local_work_path: /var/tempo
 backend_scheduler_client:

--- a/integration/backendscheduler/backendscheduler_test.go
+++ b/integration/backendscheduler/backendscheduler_test.go
@@ -170,6 +170,8 @@ func testWithConfig(t *testing.T, configFile string) {
 	// - one in the compaction provider channel
 	// - one between the provider pull and the scheduler push
 	// - one in the merged channel
+	// - one job created per instance which has not been received by the provider
+	// - one job created per instance which has been received by the provider, but not written to the scheduler channel
 
 	// NOTE: Since the measurement of outstanding blocks also skips the blocks
 	// from jobs which have not been processed, we expect our outstanding blocks
@@ -183,8 +185,8 @@ func testWithConfig(t *testing.T, configFile string) {
 	// and we may end up with jobs which between 2 and 4 blocks outstanding.
 	// - 4 jobs not yet recorded by the scheduler (no worker running yet)
 	// - between 2 and 4 blocks per job (default settings)
-	expectedTotalOutstandingMin := totalOutstanding - 16
-	expectedTotalOutstandingMax := totalOutstanding - 8
+	expectedTotalOutstandingMin := totalOutstanding - (4 * 4) - (cfg.BackendScheduler.ProviderConfig.Compaction.MaxConcurrentTenants * 2 * 4)
+	expectedTotalOutstandingMax := totalOutstanding - (4 * 2) - (cfg.BackendScheduler.ProviderConfig.Compaction.MaxConcurrentTenants * 2 * 2)
 
 	outstanding, err := scheduler.SumMetrics([]string{"tempodb_compaction_outstanding_blocks"})
 	require.NoError(t, err)

--- a/integration/backendscheduler/config.yaml
+++ b/integration/backendscheduler/config.yaml
@@ -39,6 +39,7 @@ backend_scheduler:
     compaction:
       min_cycle_interval: 50ms
       measure_interval: 1s
+      max_concurrent_tenants: 3
 backend_worker:
   backend_scheduler_addr: tempo-integration-backend-scheduler:9095
   finish_on_shutdown_timeout: 1s

--- a/modules/backendscheduler/provider/compaction.go
+++ b/modules/backendscheduler/provider/compaction.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/google/uuid"
 	"github.com/grafana/tempo/modules/backendscheduler/work"
 	"github.com/grafana/tempo/modules/backendscheduler/work/tenantselector"
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/modules/storage"
+	"github.com/grafana/tempo/pkg/boundedwaitgroup"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/tempodb"
@@ -21,20 +21,26 @@ import (
 	"github.com/grafana/tempo/tempodb/blockselector"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
 
 var tracer = otel.Tracer("modules/backendscheduler/provider/compaction")
 
+type jobTracker interface {
+	addToRecentJobs(ctx context.Context, job *work.Job) (added bool)
+}
+
+var _ jobTracker = (*CompactionProvider)(nil)
+
 type CompactionConfig struct {
-	MeasureInterval    time.Duration           `yaml:"measure_interval"`
-	Compactor          tempodb.CompactorConfig `yaml:"compaction"`
-	MaxJobsPerTenant   int                     `yaml:"max_jobs_per_tenant"`
-	MinInputBlocks     int                     `yaml:"min_input_blocks"`
-	MaxInputBlocks     int                     `yaml:"max_input_blocks"`
-	MaxCompactionLevel int                     `yaml:"max_compaction_level"`
-	MinCycleInterval   time.Duration           `yaml:"min_cycle_interval"`
+	MeasureInterval      time.Duration           `yaml:"measure_interval"`
+	Compactor            tempodb.CompactorConfig `yaml:"compaction"`
+	MaxJobsPerTenant     int                     `yaml:"max_jobs_per_tenant"`
+	MinInputBlocks       int                     `yaml:"min_input_blocks"`
+	MaxInputBlocks       int                     `yaml:"max_input_blocks"`
+	MaxCompactionLevel   int                     `yaml:"max_compaction_level"`
+	MinCycleInterval     time.Duration           `yaml:"min_cycle_interval"`
+	MaxConcurrentTenants int                     `yaml:"max_concurrent_tenants"`
 }
 
 func (cfg *CompactionConfig) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
@@ -45,6 +51,7 @@ func (cfg *CompactionConfig) RegisterFlagsAndApplyDefaults(prefix string, f *fla
 	f.IntVar(&cfg.MinInputBlocks, prefix+".min-input-blocks", blockselector.DefaultMinInputBlocks, "Minimum number of blocks to compact in a single job.")
 	f.IntVar(&cfg.MaxInputBlocks, prefix+".max-input-blocks", blockselector.DefaultMaxInputBlocks, "Maximum number of blocks to compact in a single job.")
 	f.IntVar(&cfg.MaxCompactionLevel, prefix+".max-compaction-level", blockselector.DefaultMaxCompactionLevel, "Maximum compaction level to include in compaction jobs. 0 means no limit.")
+	f.IntVar(&cfg.MaxConcurrentTenants, prefix+"backend-scheduler.compaction-provider.max-concurrent-tenants", 1, "Maximum number of tenants to compact concurrently.")
 
 	// Tenant prioritization
 	f.DurationVar(&cfg.MinCycleInterval, prefix+".min-cycle-interval", 30*time.Second, "Minimum time between tenant prioritization cycles to prevent excessive CPU usage when no work is available.")
@@ -65,14 +72,17 @@ type CompactionProvider struct {
 	sched Scheduler
 
 	// Dependencies needed for tenant selection
-	curPriority        *tenantselector.PriorityQueue
-	curTenant          *tenantselector.Item
-	curSelector        blockselector.CompactionBlockSelector
+	priority           *tenantselector.PriorityQueue
+	priorityMtx        sync.Mutex
 	lastPrioritizeTime time.Time
 
 	// Recent jobs cache for duplicate block ID prevention.
 	outstandingJobs    map[string][]backend.UUID
 	outstandingJobsMtx sync.Mutex
+
+	// Keep track of active tenants
+	activeTenants    map[string]struct{}
+	activeTenantsMtx sync.Mutex
 }
 
 func NewCompactionProvider(
@@ -87,106 +97,176 @@ func NewCompactionProvider(
 		logger:          logger,
 		store:           store,
 		overrides:       overrides,
-		curPriority:     tenantselector.NewPriorityQueue(),
+		priority:        tenantselector.NewPriorityQueue(),
 		sched:           scheduler,
 		outstandingJobs: make(map[string][]backend.UUID),
+		activeTenants:   make(map[string]struct{}, cfg.MaxConcurrentTenants),
 	}
 }
 
 func (p *CompactionProvider) Start(ctx context.Context) <-chan *work.Job {
-	jobs := make(chan *work.Job, 1)
+	var (
+		// jobs is the main output channel for jobs created by this provider
+		jobs = make(chan *work.Job, 1)
+		// instanceJobs is the channel used by instances to send jobs to the provider
+		instanceJobs = make(chan *work.Job)
+		// tenantCh is the channel used to send tenants to the instance manager
+		tenantCh = make(chan *tenantselector.Item)
+	)
 
+	// Main job creation loop.
 	go func() {
-		defer close(jobs)
+		defer func() {
+			level.Info(p.logger).Log("msg", "compaction provider stopping")
+			close(jobs)
+		}()
 
 		level.Info(p.logger).Log("msg", "compaction provider started")
-
-		var (
-			job               *work.Job
-			curTenantJobCount int
-			span              trace.Span
-			loopCtx           context.Context
-			spanStarted       bool
-			drained           bool // Signal that we have drained the current work and should wait for the next poll
-		)
-
-		reset := func() {
-			metricTenantReset.WithLabelValues(p.curTenant.Value()).Inc()
-			span.AddEvent("tenant reset", trace.WithAttributes(
-				attribute.String("tenant_id", p.curTenant.Value()),
-				attribute.Int("job_count", curTenantJobCount),
-			))
-			p.curSelector = nil
-			p.curTenant = nil
-			curTenantJobCount = 0
-			span.End()
-			spanStarted = false
-		}
 
 		level.Info(p.logger).Log("msg", "compaction provider waiting for poll notification")
 		<-p.store.PollNotification(ctx)
 
+		var (
+			job *work.Job
+			ok  bool
+		)
+
 		for {
-			if ctx.Err() != nil {
-				level.Info(p.logger).Log("msg", "compaction provider stopping")
+			select {
+			case <-ctx.Done():
 				return
-			}
-
-			if !spanStarted {
-				loopCtx, span = tracer.Start(ctx, "compactionProviderLoop")
-				spanStarted = true
-			}
-
-			if p.curSelector == nil {
-				if !p.prepareNextTenant(loopCtx, drained) {
-					level.Info(p.logger).Log("msg", "received empty tenant")
-					// If we don't have a tenant with enough blocks, we signal drained to wait for next poll.
-					drained = true
-					metricEmptyTenantCycle.Inc()
-					span.AddEvent("no tenant selected")
-				} else {
-					// A tenant with enough blocks was selected, reset the drained state.
-					drained = false
+			case job, ok = <-instanceJobs:
+				if !ok {
+					return
 				}
-
-				continue
 			}
 
-			if curTenantJobCount >= p.cfg.MaxJobsPerTenant {
-				level.Info(p.logger).Log("msg", "max jobs per tenant reached, skipping to next tenant")
-				span.AddEvent("max jobs per tenant reached")
-				reset()
-				continue
-			}
-
-			job = p.createJob(loopCtx)
 			if job == nil {
-				level.Info(p.logger).Log("msg", "tenant exhausted, skipping to next tenant")
-				span.AddEvent("tenant exhausted")
-				// we don't have a job, reset the curTenant and try again
 				metricTenantEmptyJob.Inc()
-				reset()
 				continue
 			}
-
-			// Job successfully created, add to recent jobs cache before we send it.
-			p.addToRecentJobs(ctx, job)
 
 			select {
 			case <-ctx.Done():
 				level.Info(p.logger).Log("msg", "compaction provider stopping")
-				span.AddEvent("context done")
-				span.End()
 				return
 			case jobs <- job:
-				metricJobsCreated.WithLabelValues(p.curTenant.Value()).Inc()
-				curTenantJobCount++
-				span.AddEvent("job created", trace.WithAttributes(
-					attribute.String("job_id", job.ID),
-					attribute.String("tenant_id", p.curTenant.Value()),
-				))
-				span.End()
-				spanStarted = false
+				level.Info(p.logger).Log("msg", "compaction job created", "job_id", job.ID, "tenant_id", job.Tenant())
+			}
+		}
+	}()
+
+	// Manage the instances which operate on a tenant
+	go func() {
+		var (
+			wg       = boundedwaitgroup.New(uint(p.cfg.MaxConcurrentTenants))
+			tenant   *tenantselector.Item
+			ok       bool
+			tenantID string
+		)
+
+		for {
+			select {
+			case <-ctx.Done():
+				level.Info(p.logger).Log("msg", "compaction provider instance manager stopping")
+				wg.Wait()
+				return
+			case tenant, ok = <-tenantCh:
+				if !ok {
+					wg.Wait()
+					return
+				}
+
+				if tenant == nil {
+					continue
+				}
+
+				tenantID = tenant.Value()
+
+				p.activeTenantsMtx.Lock()
+				if _, ok := p.activeTenants[tenantID]; ok {
+					// Tenant is already being processed, skip it.
+					p.activeTenantsMtx.Unlock()
+					continue
+				}
+
+				p.activeTenants[tenantID] = struct{}{}
+				p.activeTenantsMtx.Unlock()
+
+				// Merge instance jobs into main jobs channel
+				wg.Add(1)
+				go func(tenantID string) {
+					defer func() {
+						p.activeTenantsMtx.Lock()
+						level.Info(p.logger).Log("msg", "compaction instance for tenant stopped", "tenant_id", tenantID)
+						delete(p.activeTenants, tenantID)
+						p.activeTenantsMtx.Unlock()
+
+						wg.Done()
+					}()
+
+					level.Info(p.logger).Log("msg", "starting compaction instance for tenant", "tenant_id", tenantID)
+
+					var (
+						selector, _ = p.newBlockSelector(tenantID)
+						i           = newInstance(tenantID, selector, p.cfg, p.logger, p)
+						ch          = i.run(ctx)
+					)
+
+					for {
+						select {
+						case <-ctx.Done():
+							level.Debug(p.logger).Log("msg", "compaction provider instance job merger stopping")
+							return
+						case job, ok := <-ch:
+							if !ok {
+								level.Info(p.logger).Log("msg", "compaction provider instance job channel closed")
+								return
+							}
+
+							select {
+							case <-ctx.Done():
+								level.Info(p.logger).Log("msg", "compaction provider instance job merger stopping")
+								return
+							case instanceJobs <- job:
+								level.Info(p.logger).Log("msg", "compaction provider instance job sent to main job channel", "job_id", job.ID, "tenant_id", tenantID)
+								metricJobsCreated.WithLabelValues(tenantID).Inc()
+							}
+						}
+					}
+				}(tenantID)
+			}
+		}
+	}()
+
+	// Tenant channel writer.  Prioritizes tenants and sends them to the instance manager.
+	go func() {
+		defer close(tenantCh)
+
+		var tenant *tenantselector.Item
+
+		level.Info(p.logger).Log("msg", "tenant priority loop started")
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-p.store.PollNotification(ctx):
+				p.prioritizeTenants(ctx)
+
+			default:
+				tenant = p.getNextTenant(ctx)
+				if tenant == nil {
+					continue
+				}
+
+				select {
+				case <-ctx.Done():
+					return
+				case tenantCh <- tenant:
+					metricTenantReset.WithLabelValues(tenant.Value()).Inc()
+					level.Info(p.logger).Log("msg", "sent tenant to instance manager")
+				}
 			}
 		}
 	}()
@@ -210,113 +290,75 @@ func (p *CompactionProvider) Start(ctx context.Context) <-chan *work.Job {
 	return jobs
 }
 
-func (p *CompactionProvider) prepareNextTenant(ctx context.Context, drained bool) bool {
-	_, span := tracer.Start(ctx, "prepareNextTenant")
+func (p *CompactionProvider) getNextTenant(ctx context.Context) *tenantselector.Item {
+	_, span := tracer.Start(ctx, "getNextTenant")
 	defer span.End()
 
-	if p.curPriority.Len() == 0 {
-		// Rate limit calls to prioritizeTenants to prevent excessive CPU usage
-		// when cycling through tenants with no available work.
-		//
-		// We only expect new work for tenants after a the next blocklist poll.  If
-		// we have been drained, wait for the next poll.
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			// If we have not prioritized any tenants yet, do so now.
+			if p.priority.Len() == 0 {
+				level.Info(p.logger).Log("msg", "priority queue empty, prioritizing tenants")
+				p.prioritizeTenants(ctx)
 
-		if drained {
-			level.Debug(p.logger).Log("msg", "rate limiting tenant prioritization; waiting for next poll")
-			select {
-			case <-ctx.Done():
-				return false
-			case <-p.store.PollNotification(ctx):
-				// We waited for the poll, but we may have been cancelled in the meantime.
-				if ctx.Err() != nil {
-					return false
+				if p.priority.Len() == 0 {
+					level.Info(p.logger).Log("msg", "no tenants with work available, waiting for poll notification")
+					<-p.store.PollNotification(ctx)
+
+					continue
 				}
-
-				// Continue to prioritizeTenants
 			}
+
+			tenant := heap.Pop(p.priority).(*tenantselector.Item)
+			if tenant != nil {
+				return tenant
+			}
+
+			// If we have an empty tenant, then we have read all tenants from the
+			// current priority queue.  However, its possible that we got here
+			// because we did not fully drain all tenants due to per-tenant job
+			// limits.  Repopulate the priority queue and try again.
+			p.prioritizeTenants(ctx)
+			tenant = heap.Pop(p.priority).(*tenantselector.Item)
+			if tenant != nil {
+				return tenant
+			}
+
 		}
-
-		if elapsed := time.Since(p.lastPrioritizeTime); elapsed < p.cfg.MinCycleInterval {
-			level.Debug(p.logger).Log("msg", "rate limiting tenant prioritization; waiting")
-			time.Sleep(p.cfg.MinCycleInterval - elapsed)
-
-			// Continue to prioritizeTenants
-		}
-
-		p.prioritizeTenants(ctx)
-		p.lastPrioritizeTime = time.Now()
-		if p.curPriority.Len() == 0 {
-			return false
-		}
 	}
-
-	p.curTenant = heap.Pop(p.curPriority).(*tenantselector.Item)
-	if p.curTenant == nil {
-		span.AddEvent("no more tenants to compact")
-		return false
-	}
-
-	level.Info(p.logger).Log("msg", "new tenant selected", "tenant_id", p.curTenant.Value())
-
-	p.curSelector, _ = p.newBlockSelector(p.curTenant.Value())
-	return true
-}
-
-func (p *CompactionProvider) createJob(ctx context.Context) *work.Job {
-	_, span := tracer.Start(ctx, "createJob")
-	defer span.End()
-
-	span.SetAttributes(attribute.String("tenant_id", p.curTenant.Value()))
-
-	input, ok := p.getNextBlockIDs(ctx)
-	if !ok {
-		span.AddEvent("not-enough-input-blocks", trace.WithAttributes(
-			attribute.Int("input_blocks", len(input)),
-		))
-
-		span.SetStatus(codes.Error, "not enough input blocks for compaction")
-		return nil
-	}
-
-	span.AddEvent("input blocks selected", trace.WithAttributes(
-		attribute.Int("input_blocks", len(input)),
-		attribute.StringSlice("input_block_ids", input),
-	))
-	span.SetStatus(codes.Ok, "compaction job created")
-	return &work.Job{
-		ID:   uuid.New().String(),
-		Type: tempopb.JobType_JOB_TYPE_COMPACTION,
-		JobDetail: tempopb.JobDetail{
-			Tenant:     p.curTenant.Value(),
-			Compaction: &tempopb.CompactionDetail{Input: input},
-		},
-	}
-}
-
-func (p *CompactionProvider) getNextBlockIDs(_ context.Context) ([]string, bool) {
-	ids := make([]string, 0, p.cfg.MaxInputBlocks)
-
-	toBeCompacted, _ := p.curSelector.BlocksToCompact()
-
-	if len(toBeCompacted) == 0 {
-		return nil, false
-	}
-
-	for _, b := range toBeCompacted {
-		ids = append(ids, b.BlockID.String())
-	}
-
-	return ids, len(ids) >= p.cfg.MinInputBlocks
 }
 
 // prioritizeTenants prioritizes tenants based on the number of outstanding blocks.
 func (p *CompactionProvider) prioritizeTenants(ctx context.Context) {
+	if ctx.Err() != nil {
+		return
+	}
+
+	p.priorityMtx.Lock()
+	defer func() {
+		p.lastPrioritizeTime = time.Now()
+		p.priorityMtx.Unlock()
+	}()
+
+	level.Info(p.logger).Log("msg", "prioritizing tenants for compaction")
+
+	// If we have been called too recently, wait until the min cycle interval has passed.
+	if elapsed := time.Since(p.lastPrioritizeTime); elapsed < p.cfg.MinCycleInterval {
+		level.Debug(p.logger).Log("msg", "rate limiting tenant prioritization; waiting")
+		time.Sleep(p.cfg.MinCycleInterval - elapsed)
+
+		// Continue
+	}
+
 	tenants := []tenantselector.Tenant{}
 
 	_, span := tracer.Start(ctx, "prioritizeTenants")
 	defer span.End()
 
-	p.curPriority = tenantselector.NewPriorityQueue() // wipe and restart
+	p.priority = tenantselector.NewPriorityQueue() // wipe and restart
 
 	var (
 		blocklistLen      int
@@ -372,7 +414,7 @@ func (p *CompactionProvider) prioritizeTenants(ctx context.Context) {
 
 		if priority >= p.cfg.MinInputBlocks {
 			item = tenantselector.NewItem(tenant.ID, priority)
-			heap.Push(p.curPriority, item)
+			heap.Push(p.priority, item)
 		}
 	}
 }
@@ -464,17 +506,17 @@ func (p *CompactionProvider) newBlockSelector(tenantID string) (blockselector.Co
 }
 
 // addToRecentJobs adds a job to the recent jobs cache
-func (p *CompactionProvider) addToRecentJobs(ctx context.Context, job *work.Job) {
+func (p *CompactionProvider) addToRecentJobs(ctx context.Context, job *work.Job) bool {
 	_, span := tracer.Start(ctx, "addToRecentJobs")
 	defer span.End()
 
 	if job.Type != tempopb.JobType_JOB_TYPE_COMPACTION || job.JobDetail.Compaction == nil {
-		return
+		return false
 	}
 
 	// Don't cache jobs with empty input
 	if len(job.JobDetail.Compaction.Input) == 0 {
-		return
+		return false
 	}
 
 	// Copy the input block IDs
@@ -483,7 +525,7 @@ func (p *CompactionProvider) addToRecentJobs(ctx context.Context, job *work.Job)
 		bid, err := backend.ParseUUID(blockID)
 		if err != nil {
 			level.Error(p.logger).Log("msg", "failed to parse block ID", "block_id", blockID, "err", err)
-			return
+			return false
 		}
 		blockIDs[i] = bid
 	}
@@ -491,4 +533,5 @@ func (p *CompactionProvider) addToRecentJobs(ctx context.Context, job *work.Job)
 	p.outstandingJobsMtx.Lock()
 	p.outstandingJobs[job.ID] = blockIDs
 	p.outstandingJobsMtx.Unlock()
+	return true
 }

--- a/modules/backendscheduler/provider/compaction_instance.go
+++ b/modules/backendscheduler/provider/compaction_instance.go
@@ -1,0 +1,162 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/google/uuid"
+	"github.com/grafana/tempo/modules/backendscheduler/work"
+	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/grafana/tempo/tempodb/blockselector"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type tenantDrainer interface {
+	run(ctx context.Context) <-chan *work.Job
+}
+
+var _ tenantDrainer = (*compactionInstance)(nil)
+
+// compactionInstance operates on a single tenant to push compaction jobs to the scheduler.
+type compactionInstance struct {
+	tenant   string
+	selector blockselector.CompactionBlockSelector
+	cfg      CompactionConfig
+	logger   log.Logger
+	tracker  jobTracker
+}
+
+func newInstance(
+	tenantID string,
+	selector blockselector.CompactionBlockSelector,
+	cfg CompactionConfig,
+	logger log.Logger,
+	tracker jobTracker,
+) tenantDrainer {
+	i := &compactionInstance{
+		tenant:   tenantID,
+		selector: selector,
+		cfg:      cfg,
+		logger:   log.With(logger, "tenant_id", tenantID),
+		tracker:  tracker,
+	}
+
+	return i
+}
+
+func (i *compactionInstance) run(ctx context.Context) <-chan *work.Job {
+	_, span := tracer.Start(ctx, "compactionInstance.run")
+	defer span.End()
+
+	instanceJobs := make(chan *work.Job)
+
+	go func() {
+		defer close(instanceJobs)
+
+		level.Debug(i.logger).Log("msg", "compaction instance started")
+
+		jobCount := 0
+		var job *work.Job
+		var added bool
+
+		for {
+			select {
+			case <-ctx.Done():
+				level.Debug(i.logger).Log("msg", "compaction instance stopping")
+				span.AddEvent("context done")
+				return
+			default:
+				job = i.createJob(ctx)
+				if job == nil {
+					span.AddEvent("tenant exhausted", trace.WithAttributes(
+						attribute.String("tenant_id", i.tenant),
+					))
+					return
+				}
+
+				added = i.tracker.addToRecentJobs(ctx, job)
+				if !added {
+					// Job was a duplicate, try again.
+					continue
+				}
+
+				if jobCount >= i.cfg.MaxJobsPerTenant {
+					level.Info(i.logger).Log("msg", "max jobs per tenant reached, stopping instance")
+					span.AddEvent("max jobs per tenant reached", trace.WithAttributes(
+						attribute.String("tenant_id", i.tenant),
+						attribute.Int("job_count", jobCount),
+					))
+					return
+				}
+
+				select {
+				case <-ctx.Done():
+					level.Debug(i.logger).Log("msg", "compaction instance stopping")
+					span.AddEvent("context done")
+					return
+				case instanceJobs <- job:
+					span.AddEvent("job created", trace.WithAttributes(
+						attribute.String("job_id", job.ID),
+						attribute.String("tenant_id", i.tenant),
+					))
+
+					metricJobsCreated.WithLabelValues(i.tenant).Inc()
+
+					jobCount++
+				}
+			}
+		}
+	}()
+
+	return instanceJobs
+}
+
+func (i *compactionInstance) createJob(ctx context.Context) *work.Job {
+	_, span := tracer.Start(ctx, "compactionInstance.createJob")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("tenant_id", i.tenant))
+
+	input, ok := i.getNextBlockIDs(ctx)
+	if !ok {
+		span.AddEvent("not-enough-input-blocks", trace.WithAttributes(
+			attribute.Int("input_blocks", len(input)),
+		))
+
+		span.SetStatus(codes.Error, "not enough input blocks for compaction")
+		return nil
+	}
+
+	span.AddEvent("input blocks selected", trace.WithAttributes(
+		attribute.Int("input_blocks", len(input)),
+		attribute.StringSlice("input_block_ids", input),
+	))
+	span.SetStatus(codes.Ok, "compaction job created")
+	return &work.Job{
+		ID:   uuid.New().String(),
+		Type: tempopb.JobType_JOB_TYPE_COMPACTION,
+		JobDetail: tempopb.JobDetail{
+			Tenant:     i.tenant,
+			Compaction: &tempopb.CompactionDetail{Input: input},
+		},
+	}
+}
+
+func (i *compactionInstance) getNextBlockIDs(_ context.Context) ([]string, bool) {
+	ids := make([]string, 0, i.cfg.MaxInputBlocks)
+
+	toBeCompacted, _ := i.selector.BlocksToCompact()
+
+	if len(toBeCompacted) == 0 {
+		return nil, false
+	}
+
+	for _, b := range toBeCompacted {
+		ids = append(ids, b.BlockID.String())
+	}
+
+	return ids, len(ids) >= i.cfg.MinInputBlocks
+}


### PR DESCRIPTION
**What this PR does**:

Here we modify the compaction provider to operate on multiple tenants at once.

Currently, the scheduler only hands out jobs for a single tenant at a time.  To avoid a single tenant monopolizing the workers, we have a `max_jobs_per_tenant` setting which limits the number of sequential jobs for a single tenant before moving on.  However, in high-tenant count environments, the cycle time back around means that the outstanding blocks can grow for a large number of tenants and their level 0 blocks can grow very large.  When combined with autoscale based on the outstanding blocks, this can lead to overscale.

By working on multiple tenants at once, we can ensure that the level 0 blocks for all tenants are kept in check, allowing the autoscale to be more effective.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`