### PR TITLE
[TraceQL] Fix string comparison bug of strings starting with numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 * [BUGFIX] Fix invalid YAML output from /status/runtime_config endpoint by adding document separator. [#5146](https://github.com/grafana/tempo/issues/5146)
 * [BUGFIX] Fix race condition between compaction provider and backend-scheduler [#5409](https://github.com/grafana/tempo/pull/5409) (@zalegrala)
 * [BUGFIX] Do not allow very small steps [#5441](https://github.com/grafana/tempo/pull/5441) (@ruslan-mikhailov)
+* [BUGFIX] Fix incorrect TraceQL string comparison of strings starting with numbers [$5658](https://github.com/grafana/tempo/pull/5658) (@mdisibio)
 * [BUGFIX] Fix incorrect results in TraceQL compare() for spans with array attributes [#5519](https://github.com/grafana/tempo/pull/5519) (@ruslan-mikhailov)
 * [BUGFIX] Fix cache collision for incomplete query in SearchTagValuesV2 [#5549](https://github.com/grafana/tempo/pull/5549) (@ruslan-mikhailov)
 * [BUGFIX] Fix for structural operator with empty left-hand spanset [#5578](https://github.com/grafana/tempo/pull/5578) (@ruslan-mikhailov)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
 * [BUGFIX] Fix invalid YAML output from /status/runtime_config endpoint by adding document separator. [#5146](https://github.com/grafana/tempo/issues/5146)
 * [BUGFIX] Fix race condition between compaction provider and backend-scheduler [#5409](https://github.com/grafana/tempo/pull/5409) (@zalegrala)
 * [BUGFIX] Do not allow very small steps [#5441](https://github.com/grafana/tempo/pull/5441) (@ruslan-mikhailov)
-* [BUGFIX] Fix incorrect TraceQL string comparison of strings starting with numbers [$5658](https://github.com/grafana/tempo/pull/5658) (@mdisibio)
+* [BUGFIX] Fix incorrect TraceQL string comparison of strings starting with numbers [#5658](https://github.com/grafana/tempo/pull/5658) (@mdisibio)
 * [BUGFIX] Fix incorrect results in TraceQL compare() for spans with array attributes [#5519](https://github.com/grafana/tempo/pull/5519) (@ruslan-mikhailov)
 * [BUGFIX] Fix cache collision for incomplete query in SearchTagValuesV2 [#5549](https://github.com/grafana/tempo/pull/5549) (@ruslan-mikhailov)
 * [BUGFIX] Fix for structural operator with empty left-hand spanset [#5578](https://github.com/grafana/tempo/pull/5578) (@ruslan-mikhailov)

--- a/pkg/traceql/ast_execute.go
+++ b/pkg/traceql/ast_execute.go
@@ -419,34 +419,38 @@ func (o *BinaryOperation) execute(span Span) (Static, error) {
 	}
 
 	if lhsT == TypeString && rhsT == TypeString {
+		// All operations are done on raw unquoted values.
+		lhsS := lhs.EncodeToString(false)
+		rhsS := rhs.EncodeToString(false)
+
 		switch o.Op {
 		case OpGreater:
-			return NewStaticBool(strings.Compare(lhs.String(), rhs.String()) > 0), nil
+			return NewStaticBool(strings.Compare(lhsS, rhsS) > 0), nil
 		case OpGreaterEqual:
-			return NewStaticBool(strings.Compare(lhs.String(), rhs.String()) >= 0), nil
+			return NewStaticBool(strings.Compare(lhsS, rhsS) >= 0), nil
 		case OpLess:
-			return NewStaticBool(strings.Compare(lhs.String(), rhs.String()) < 0), nil
+			return NewStaticBool(strings.Compare(lhsS, rhsS) < 0), nil
 		case OpLessEqual:
-			return NewStaticBool(strings.Compare(lhs.String(), rhs.String()) <= 0), nil
+			return NewStaticBool(strings.Compare(lhsS, rhsS) <= 0), nil
 		case OpRegex:
 			if o.compiledExpression == nil {
-				o.compiledExpression, err = regexp.NewRegexp([]string{rhs.EncodeToString(false)}, true)
+				o.compiledExpression, err = regexp.NewRegexp([]string{rhsS}, true)
 				if err != nil {
 					return NewStaticNil(), err
 				}
 			}
 
-			matched := o.compiledExpression.MatchString(lhs.EncodeToString(false))
+			matched := o.compiledExpression.MatchString(lhsS)
 			return NewStaticBool(matched), err
 		case OpNotRegex:
 			if o.compiledExpression == nil {
-				o.compiledExpression, err = regexp.NewRegexp([]string{rhs.EncodeToString(false)}, false)
+				o.compiledExpression, err = regexp.NewRegexp([]string{rhsS}, false)
 				if err != nil {
 					return NewStaticNil(), err
 				}
 			}
 
-			matched := o.compiledExpression.MatchString(lhs.EncodeToString(false))
+			matched := o.compiledExpression.MatchString(lhsS)
 			return NewStaticBool(matched), err
 		default:
 		}

--- a/pkg/traceql/ast_execute_test.go
+++ b/pkg/traceql/ast_execute_test.go
@@ -1766,6 +1766,39 @@ func TestBinaryOperationsWorkAcrossNumberTypes(t *testing.T) {
 	}
 }
 
+func TestBinOp(t *testing.T) {
+	testCases := []struct {
+		op       Operator
+		lhs      Static
+		rhs      Static
+		expected Static
+	}{
+		{
+			op:       OpGreater,
+			lhs:      NewStaticString("foo"),
+			rhs:      NewStaticString(""),
+			expected: StaticTrue,
+		},
+		{
+			// Comparison of strings starting with a number were previously broken.
+			op:       OpGreater,
+			lhs:      NewStaticString("123"),
+			rhs:      NewStaticString(""),
+			expected: StaticTrue,
+		},
+	}
+	for _, tc := range testCases {
+		b := newBinaryOperation(tc.op, tc.lhs, tc.rhs)
+
+		// Static operations are already "compiled" away so recreate via string here.
+		text := tc.lhs.String() + " " + tc.op.String() + " " + tc.rhs.String()
+
+		actual, err := b.execute(nil)
+		require.NoError(t, err)
+		require.Equal(t, tc.expected, actual, text)
+	}
+}
+
 func TestArithmetic(t *testing.T) {
 	testCases := []evalTC{
 		// static arithmetic works

--- a/pkg/traceql/ast_validate.go
+++ b/pkg/traceql/ast_validate.go
@@ -212,7 +212,16 @@ func (o *BinaryOperation) validate() error {
 
 	// if this is a regex operator confirm the RHS is a valid regex
 	if o.Op == OpRegex || o.Op == OpNotRegex {
-		_, err := regexp.Compile(o.RHS.String())
+		// Ensure that we validate against the raw/unquoted string when possible.
+		// When RHS is a hardcoded string in the query which is compiled to a Static.
+		var text string
+		if static, ok := o.RHS.(Static); ok {
+			text = static.EncodeToString(false)
+		} else {
+			text = o.RHS.String()
+		}
+
+		_, err := regexp.Compile(text)
 		if err != nil {
 			return fmt.Errorf("invalid regex: %s", o.RHS.String())
 		}


### PR DESCRIPTION
**What this PR does**:
Fixes a bug in the traceql engine comparing strings starting with numbers.  `"5" > ""` should be true, but the engine bug was making this false.  Internally it was quoting both hand sides first, so it became ```"`5`" > "``"```, the backtick is before numbers in the ascii table.  The fix is not quote both hand sides, which is both more correct and more performant. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`