### PR TITLE
Live-store: correct service name

### DIFF
--- a/operations/jsonnet-compiled/StatefulSet-live-store-zone-a.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-live-store-zone-a.yaml
@@ -14,7 +14,7 @@ spec:
     matchLabels:
       name: live-store-zone-a
       rollout-group: live-store
-  serviceName: live-store
+  serviceName: live-store-zone-a
   template:
     metadata:
       annotations:

--- a/operations/jsonnet-compiled/StatefulSet-live-store-zone-b.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-live-store-zone-b.yaml
@@ -14,7 +14,7 @@ spec:
     matchLabels:
       name: live-store-zone-b
       rollout-group: live-store
-  serviceName: live-store
+  serviceName: live-store-zone-b
   template:
     metadata:
       annotations:

--- a/operations/jsonnet-compiled/util/jsonnetfile.lock.json
+++ b/operations/jsonnet-compiled/util/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "cf2f84956c8d171647408b252a789c796cc0f262",
+      "version": "5d2c9c1fa845da48e6049bbbd8e98b9d6aab1805",
       "sum": "0y3AFX9LQSpfWTxWKSwoLgbt0Wc9nnCwhMH2szKzHv0="
     },
     {
@@ -18,7 +18,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "cf2f84956c8d171647408b252a789c796cc0f262",
+      "version": "5d2c9c1fa845da48e6049bbbd8e98b9d6aab1805",
       "sum": "f+DYmgxR3spwx8DbIyY4+qSaFsshg/SE+MDG6jUQhJg="
     },
     {

--- a/operations/jsonnet/microservices/live-store.libsonnet
+++ b/operations/jsonnet/microservices/live-store.libsonnet
@@ -111,7 +111,7 @@
         [$._config.gossip_member_label]: 'true',
       },
     )
-    + statefulSet.mixin.spec.withServiceName(target_name)
+    + statefulSet.mixin.spec.withServiceName(name)
     + statefulSet.mixin.spec.template.metadata.withAnnotations({
       config_hash: std.md5(std.toString($.tempo_live_store_configmap.data['tempo.yaml'])),
     })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: changes service name for each live-store from `live-store` to `live-store-zone-N`, where N is its zone.
This change will require recreating live-store statefulset

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`