### PR TITLE
chore: upgrade tempo tools to go 1.25.1

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.0-alpine
+FROM golang:1.25.1-alpine
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/tempo/tools
 
-go 1.25.0
+go 1.25.1
 
 require (
 	github.com/golangci/golangci-lint/v2 v2.1.5


### PR DESCRIPTION
**What this PR does**:

go1.25.1 (released 2025-09-03) includes security fixes to the net/http package, as well as bug fixes to the go command, and the net, os, os/exec, and testing/synctest packages.

- https://go.dev/doc/devel/release#go1.25.minor
- https://github.com/golang/go/issues?q=milestone%3AGo1.25.1+label%3ACherryPickApproved

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`