### PR TITLE
chore: upgrade go version to 1.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## main / unreleased
 
+* [CHANGE] Upgrade Tempo to go 1.25.0 [#5685](https://github.com/grafana/tempo/pull/5685) (@electron0zero)
+
 # v2.9.0-rc.0
 
 * [CHANGE] Return Bad Request from all frontend endpoints if the tenant can't be extracted. [#5480](https://github.com/grafana/tempo/pull/5480) (@carles-grafana)
@@ -12,7 +14,9 @@
 * [CHANGE] **BREAKING CHANGE** TraceQL Metrics buckets are calculated based on data in past. [#5366](https://github.com/grafana/tempo/pull/5366) (@ruslan-mikhailov)
 * [CHANGE] Upgrade Tempo to go 1.25.0. [#5548](https://github.com/grafana/tempo/pull/5548) (@javiermolinar)
 * [CHANGE] Drop tracing bridges in favor of OTEL only tracing. [#5594](https://github.com/grafana/tempo/pull/5594) (@zalegrala)
-* [CHANGE] **BREAKING CHANGE** Fix incorrect TraceQL metrics results when series labels include strings and integers with same textural representation. This also changes the TraceQL metrics responses of `/api/metrics/query_range` and `/api/metrics/query` to remove the redundant `prom_labels` field which was the error source. There may be an interruption to TraceQL metrics queries during rollout while components are running the previous version. [#5659](https://github.com/grafana/tempo/pull/5659) (@mdisibio)
+* [CHANGE] **BREAKING CHANGE** Fix incorrect TraceQL metrics results when series labels include strings and integers with same textural representation.
+  This also changes the TraceQL metrics responses of `/api/metrics/query_range` and `/api/metrics/query` to remove the redundant
+  `prom_labels` field which was the error source. There may be an interruption to TraceQL metrics queries during rollout while components are running the previous version. [#5659](https://github.com/grafana/tempo/pull/5659) (@mdisibio)
 * [CHANGE] Enable HTTP writes in the multi-tenant example. [#5297](https://github.com/grafana/tempo/pull/5297) (@carles-grafana)
 * [FEATURE] Add MCP Server support. [#5212](https://github.com/grafana/tempo/pull/5212) (@joe-elliott)
 * [FEATURE] Add query hints `sample=true` and `sample=0.xx` which can speed up TraceQL metrics queries by sampling a subset of the data to provide an approximate result. [#5469](https://github.com/grafana/tempo/pull/5469) (@mdisibio)

--- a/build/tools.mk
+++ b/build/tools.mk
@@ -12,7 +12,7 @@ TOOL_DIR     ?= tools
 TOOL_CONFIG  ?= $(TOOL_DIR)/tools.go
 
 TOOLS_IMAGE ?= grafana/tempo-ci-tools
-TOOLS_IMAGE_TAG ?= main-ef48673
+TOOLS_IMAGE_TAG ?= main-ab6822e
 
 GOTOOLS ?= $(shell cd $(TOOL_DIR) && go list -e -f '{{ .Imports }}' -tags tools |tr -d '[]')
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/tempo
 
-go 1.25.0
+go 1.25.1
 
 require (
 	cloud.google.com/go/storage v1.56.0


### PR DESCRIPTION
**What this PR does**:

go1.25.1 (released 2025-09-03) includes security fixes to the net/http package, as well as bug fixes to the go command, and the net, os, os/exec, and testing/synctest packages.

- https://go.dev/doc/devel/release#go1.25.minor
- https://github.com/golang/go/issues?q=milestone%3AGo1.25.1+label%3ACherryPickApproved

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`