### PR TITLE
Include new metric for generator ring size at the distributor

### DIFF
--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -72,6 +72,11 @@ var (
 		Name:      "distributor_metrics_generator_pushes_failures_total",
 		Help:      "The total number of failed span pushes sent to metrics-generators.",
 	}, []string{"metrics_generator"})
+	metricGeneratorTenantRingSize = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "tempo",
+		Name:      "distributor_metrics_generator_tenant_ring_size",
+		Help:      "The number of generator instances in the ring for a tenant",
+	}, []string{"tenant"})
 	metricSpansIngested = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "tempo",
 		Name:      "distributor_spans_received_total",
@@ -576,7 +581,11 @@ func (d *Distributor) sendToGenerators(ctx context.Context, userID string, keys 
 	// If an instance is unhealthy write to the next one (i.e. write extend is enabled)
 	op := ring.Write
 
-	readRing := d.generatorsRing.ShuffleShard(userID, d.overrides.MetricsGeneratorRingSize(userID))
+	ringSize := d.overrides.MetricsGeneratorRingSize(userID)
+
+	metricGeneratorTenantRingSize.WithLabelValues(userID).Set(float64(ringSize))
+
+	readRing := d.generatorsRing.ShuffleShard(userID, ringSize)
 
 	err := ring.DoBatchWithOptions(ctx, op, readRing, keys, func(generator ring.InstanceDesc, indexes []int) error {
 		localCtx, cancel := context.WithTimeout(ctx, d.generatorClientCfg.RemoteTimeout)


### PR DESCRIPTION
**What this PR does**:

Here we include a new metric `tempo_distributor_metrics_generator_tenant_ring_size` to increase observability in our metrics-generator pipeline.  When tenant metrics are being discarded, we often want to know more details about the tenant, and this looks like a gap in our metrics.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`