### PR TITLE
chore: fix changelog for v2.9.0-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 ## main / unreleased
 
-* [CHANGE] Upgrade Tempo to go 1.25.0 [#5685](https://github.com/grafana/tempo/pull/5685) (@electron0zero)
-
 # v2.9.0-rc.0
 
+* [CHANGE] Upgrade Tempo to go 1.25.0 [#5685](https://github.com/grafana/tempo/pull/5685) (@electron0zero)
 * [CHANGE] **BREAKING CHANGE** We are no longer publishing rpm and deb packages due to an internal change to the handling of signing keys. [#5684](https://github.com/grafana/tempo/pull/5684) (@joe-elliott)
 * [CHANGE] Return Bad Request from all frontend endpoints if the tenant can't be extracted. [#5480](https://github.com/grafana/tempo/pull/5480) (@carles-grafana)
 * [CHANGE]  **BREAKING CHANGE** Migrated Tempo Vulture and Integration Tests from the deprecated Jaeger agent/exporter to the standard OTLP exporter. Vulture now pushes traces to the Tempo OTLP GRCP endpoint. [#5058](https://github.com/grafana/tempo/pull/5058) (@iamrajiv, @javiermolinar)


### PR DESCRIPTION
**What this PR does**:

https://github.com/grafana/tempo/pull/5685 is included in v2.9.0-rc.0 Pre-release but it's still under `main / unreleased`, move it into `v2.9.0-rc.0` section to show that v2.9.0-rc.0 includes https://github.com/grafana/tempo/pull/5685

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`