### PR TITLE
Reuse buffers

### DIFF
--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -1234,14 +1234,14 @@ live_store:
     commit_interval: 5s
     query_block_concurrency: 10
     complete_block_timeout: 1h0m0s
-    complete_block_concurrency: 4
+    complete_block_concurrency: 2
     flush_check_period: 10s
     flush_op_timeout: 5m0s
     max_trace_live: 30s
     max_trace_idle: 5s
     max_live_traces_bytes: 250000000
     max_block_duration: 30m0s
-    max_block_bytes: 524288000
+    max_block_bytes: 104857600
     block_config:
         bloom_filter_false_positive: 0.01
         bloom_filter_shard_size_bytes: 102400

--- a/modules/livestore/config.go
+++ b/modules/livestore/config.go
@@ -67,7 +67,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	// Set defaults for new fields
 	cfg.CompleteBlockTimeout = defaultCompleteBlockTimeout
 	cfg.QueryBlockConcurrency = 10
-	cfg.CompleteBlockConcurrency = 4
+	cfg.CompleteBlockConcurrency = 2
 	cfg.Metrics.TimeOverlapCutoff = 0.2
 
 	// Set defaults for timing configuration (based on ingester defaults)
@@ -77,7 +77,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.MaxTraceIdle = 5 * time.Second
 	cfg.MaxLiveTracesBytes = 250_000_000 // 250MB
 	cfg.MaxBlockDuration = 30 * time.Minute
-	cfg.MaxBlockBytes = 500 * 1024 * 1024
+	cfg.MaxBlockBytes = 100 * 1024 * 1024
 
 	cfg.CommitInterval = 5 * time.Second
 

--- a/modules/livestore/instance.go
+++ b/modules/livestore/instance.go
@@ -211,6 +211,9 @@ func (i *instance) pushBytes(ctx context.Context, ts time.Time, req *tempopb.Pus
 			continue
 		}
 
+		// Reuse the byte slice now that we've unmarshalled it
+		tempopb.ReuseByteSlices([][]byte{traceBytes.Slice})
+
 		i.liveTracesMtx.Lock()
 		// Push each batch in the trace to live traces
 		for _, batch := range trace.ResourceSpans {


### PR DESCRIPTION
Pass buffers to be reused and lower the default size and concurrency. This was found to create more stability. Long term need to see why it diverges from ingest.