### PR TITLE
Add rpm deb

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,13 +2,13 @@ name: release
 on:
   push:
     tags:
-      - "v*"
+      - 'v*'
 
 # Needed to login to DockerHub
 permissions: {}
 jobs:
   release:
-    if: github.repository == 'grafana/tempo' # skip in forks
+    if: github.repository == 'grafana/tempo'  # skip in forks
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,14 +2,13 @@ name: release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 # Needed to login to DockerHub
 permissions: {}
 jobs:
-
   release:
-    if: github.repository == 'grafana/tempo'  # skip in forks
+    if: github.repository == 'grafana/tempo' # skip in forks
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -25,6 +24,25 @@ jobs:
 
       - name: test release
         run: make release-snapshot
+
+      - name: test deb package
+        run: |
+          # podman is simpler to make it work with systemd inside containers
+          podman run -d --name systemd-debian --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro jrei/systemd-debian:12
+          podman cp ./dist/tempo_*_linux_amd64.deb systemd-debian:.
+          podman cp ./tools/packaging/verify-deb-install.sh systemd-debian:.
+          podman cp ./tools/packaging/wait-for-ready.sh systemd-debian:.
+          podman exec systemd-debian ./verify-deb-install.sh
+          podman rm -f systemd-debian
+
+      - name: test rpm package
+        run: |
+          podman run -d --name systemd-centos --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro jrei/systemd-centos:8
+          podman cp ./dist/tempo_*_linux_amd64.rpm systemd-centos:.
+          podman cp ./tools/packaging/verify-rpm-install.sh systemd-centos:.
+          podman cp ./tools/packaging/wait-for-ready.sh systemd-centos:.
+          podman exec systemd-centos ./verify-rpm-install.sh
+          podman rm -f systemd-centos
 
       - name: release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,25 +25,6 @@ jobs:
       - name: test release
         run: make release-snapshot
 
-      - name: test deb package
-        run: |
-          # podman is simpler to make it work with systemd inside containers
-          podman run -d --name systemd-debian --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro jrei/systemd-debian:12
-          podman cp ./dist/tempo_*_linux_amd64.deb systemd-debian:.
-          podman cp ./tools/packaging/verify-deb-install.sh systemd-debian:.
-          podman cp ./tools/packaging/wait-for-ready.sh systemd-debian:.
-          podman exec systemd-debian ./verify-deb-install.sh
-          podman rm -f systemd-debian
-
-      - name: test rpm package
-        run: |
-          podman run -d --name systemd-centos --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro jrei/systemd-centos:8
-          podman cp ./dist/tempo_*_linux_amd64.rpm systemd-centos:.
-          podman cp ./tools/packaging/verify-rpm-install.sh systemd-centos:.
-          podman cp ./tools/packaging/wait-for-ready.sh systemd-centos:.
-          podman exec systemd-centos ./verify-rpm-install.sh
-          podman rm -f systemd-centos
-
       - name: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,7 @@ builds:
     env:
       - CGO_ENABLED=0
     goos:
-#      - darwin  re-enable when https://github.com/golang/go/issues/73617 is fixed
+      #      - darwin  re-enable when https://github.com/golang/go/issues/73617 is fixed
       - linux
       - windows
     goarch:
@@ -34,14 +34,14 @@ builds:
       - -X main.Branch={{ .Branch }}
       - -X main.Revision={{ .ShortCommit }}
       - -X main.Version={{ .Version }}
-    mod_timestamp: '{{ .CommitTimestamp }}'
+    mod_timestamp: "{{ .CommitTimestamp }}"
   - id: "tempo-query"
     main: ./cmd/tempo-query
     binary: tempo-query
     env:
       - CGO_ENABLED=0
     goos:
-#      - darwin  re-enable when https://github.com/golang/go/issues/73617 is fixed
+      #      - darwin  re-enable when https://github.com/golang/go/issues/73617 is fixed
       - linux
       - windows
     goarch:
@@ -64,14 +64,14 @@ builds:
       - -X main.Branch={{ .Branch }}
       - -X main.Revision={{ .ShortCommit }}
       - -X main.Version={{ .Version }}
-    mod_timestamp: '{{ .CommitTimestamp }}'
+    mod_timestamp: "{{ .CommitTimestamp }}"
   - id: "tempo-cli"
     main: ./cmd/tempo-cli
     binary: tempo-cli
     env:
       - CGO_ENABLED=0
     goos:
-#      - darwin  re-enable when https://github.com/golang/go/issues/73617 is fixed
+      #      - darwin  re-enable when https://github.com/golang/go/issues/73617 is fixed
       - linux
       - windows
     goarch:
@@ -94,20 +94,46 @@ builds:
       - -X main.Branch={{ .Branch }}
       - -X main.Revision={{ .ShortCommit }}
       - -X main.Version={{ .Version }}
-    mod_timestamp: '{{ .CommitTimestamp }}'
+    mod_timestamp: "{{ .CommitTimestamp }}"
 changelog:
   skip: true
   sort: asc
   filters:
     exclude:
-      - '^.github:'
-      - '^example:'
-      - '^integration:'
-      - '^vendor:'
+      - "^.github:"
+      - "^example:"
+      - "^integration:"
+      - "^vendor:"
 checksum:
   name_template: SHA256SUMS
 release:
   draft: true
   prerelease: auto
 snapshot:
-  name_template: '{{ .Version }}-SNAPSHOT-{{ .ShortCommit }}'
+  name_template: "{{ .Version }}-SNAPSHOT-{{ .ShortCommit }}"
+# RPM (yum) and deb (apt) packages
+nfpms:
+  - builds:
+      - tempo
+      - tempo-cli
+      - tempo-query
+    vendor: Grafana Labs Inc
+    homepage: https://grafana.com/oss/tempo/
+    maintainer: Grafana Labs <support@grafana.com>
+    description: |-
+      Grafana Tempo is an open source, easy-to-use, and high-scale distributed tracing backend.
+      Tempo is cost-efficient, requiring only object storage to operate, and is deeply integrated with Grafana, Prometheus, and Loki.
+    license: AGPL-3.0
+    formats:
+      - deb
+      - rpm
+    contents:
+      - src: ./tools/packaging/tempo.yaml
+        dst: /etc/tempo/config.yml
+        type: "config|noreplace"
+      - src: ./tools/packaging/tempo.service
+        dst: /etc/systemd/system/tempo.service
+    scripts:
+      postinstall: ./tools/packaging/tempo-postinstall.sh
+    rpm: {}
+    deb: {}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,7 @@ builds:
     env:
       - CGO_ENABLED=0
     goos:
-      #      - darwin  re-enable when https://github.com/golang/go/issues/73617 is fixed
+#      - darwin re-enable when https://github.com/golang/go/issues/73617 is fixed
       - linux
       - windows
     goarch:
@@ -34,14 +34,14 @@ builds:
       - -X main.Branch={{ .Branch }}
       - -X main.Revision={{ .ShortCommit }}
       - -X main.Version={{ .Version }}
-    mod_timestamp: "{{ .CommitTimestamp }}"
+    mod_timestamp: '{{ .CommitTimestamp }}'
   - id: "tempo-query"
     main: ./cmd/tempo-query
     binary: tempo-query
     env:
       - CGO_ENABLED=0
     goos:
-      #      - darwin  re-enable when https://github.com/golang/go/issues/73617 is fixed
+#      - darwin re-enable when https://github.com/golang/go/issues/73617 is fixed
       - linux
       - windows
     goarch:
@@ -64,7 +64,7 @@ builds:
       - -X main.Branch={{ .Branch }}
       - -X main.Revision={{ .ShortCommit }}
       - -X main.Version={{ .Version }}
-    mod_timestamp: "{{ .CommitTimestamp }}"
+    mod_timestamp: '{{ .CommitTimestamp }}'
   - id: "tempo-cli"
     main: ./cmd/tempo-cli
     binary: tempo-cli
@@ -100,10 +100,10 @@ changelog:
   sort: asc
   filters:
     exclude:
-      - "^.github:"
-      - "^example:"
-      - "^integration:"
-      - "^vendor:"
+      - '^.github:'
+      - '^example:'
+      - '^integration:'
+      - '^vendor:'
 checksum:
   name_template: SHA256SUMS
 release:

--- a/tools/packaging/tempo-postinstall.sh
+++ b/tools/packaging/tempo-postinstall.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+# Based on https://nfpm.goreleaser.com/tips/
+
+if ! command -V systemctl >/dev/null 2>&1; then
+  echo "Could not find systemd. Skipping system installation." && exit 0
+else
+    systemd_version=$(systemctl --version | head -1 | sed 's/systemd //g')
+fi
+
+cleanInstall() {
+    printf "\033[32m Post Install of a clean install\033[0m\n"
+
+    # Create the user
+    if ! id tempo > /dev/null 2>&1 ; then
+        adduser --system --shell /bin/false "tempo"
+    fi
+
+    # Create and assign permissions for default storage
+    mkdir -m 0700 /var/tempo
+    chown tempo /var/tempo
+
+    # rhel/centos7 cannot use ExecStartPre=+ to specify the pre start should be run as root
+    # even if you want your service to run as non root.
+    if [ "${systemd_version}" -lt 231 ]; then
+        printf "\033[31m systemd version %s is less then 231, fixing the service file \033[0m\n" "${systemd_version}"
+        sed -i "s/=+/=/g" /etc/systemd/system/tempo.service
+    fi
+    printf "\033[32m Reload the service unit from disk\033[0m\n"
+    systemctl daemon-reload ||:
+    printf "\033[32m Unmask the service\033[0m\n"
+    systemctl unmask tempo ||:
+    printf "\033[32m Set the preset flag for the service unit\033[0m\n"
+    systemctl preset tempo ||:
+    printf "\033[32m Set the enabled flag for the service unit\033[0m\n"
+    systemctl enable tempo ||:
+    systemctl restart tempo ||:
+}
+
+upgrade() {
+    :
+    # printf "\033[32m Post Install of an upgrade\033[0m\n"
+}
+
+action="$1"
+if  [ "$1" = "configure" ] && [ -z "$2" ]; then
+  # Alpine linux does not pass args, and deb passes $1=configure
+  action="install"
+elif [ "$1" = "configure" ] && [ -n "$2" ]; then
+    # deb passes $1=configure $2=<current version>
+    action="upgrade"
+fi
+
+case "${action}" in
+  "1" | "install")
+    cleanInstall
+    ;;
+  "2" | "upgrade")
+    upgrade
+    ;;
+  *)
+    # $1 == version being installed
+    printf "\033[32m Alpine\033[0m"
+    cleanInstall
+    ;;
+esac

--- a/tools/packaging/tempo.service
+++ b/tools/packaging/tempo.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Tempo service
+After=network.target
+
+[Service]
+Type=simple
+User=tempo
+ExecStart=/usr/bin/tempo -config.file /etc/tempo/config.yml
+# Give a reasonable amount of time for the server to start up/shut down
+TimeoutSec = 120
+Restart = on-failure
+RestartSec = 2
+
+[Install]
+WantedBy=multi-user.target

--- a/tools/packaging/tempo.yaml
+++ b/tools/packaging/tempo.yaml
@@ -1,0 +1,48 @@
+stream_over_http_enabled: true
+server:
+  http_listen_port: 3200
+  log_level: info
+
+query_frontend:
+  search:
+    duration_slo: 5s
+    throughput_bytes_slo: 1.073741824e+09
+    metadata_slo:
+        duration_slo: 5s
+        throughput_bytes_slo: 1.073741824e+09
+  trace_by_id:
+    duration_slo: 5s
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+      cluster: docker-compose
+  storage:
+    path: /var/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true
+  traces_storage:
+    path: /var/tempo/generator/traces
+
+storage:
+  trace:
+    backend: local                     # backend configuration to use
+    wal:
+      path: /var/tempo/wal             # where to store the wal locally
+    local:
+      path: /var/tempo/blocks
+
+overrides:
+  defaults:
+    metrics_generator:
+      processors: [service-graphs, span-metrics, local-blocks] # enables metrics generator
+      generate_native_histograms: both

--- a/tools/packaging/verify-deb-install.sh
+++ b/tools/packaging/verify-deb-install.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+# Install tempo and check it's running
+dpkg -i ./tempo_*_linux_amd64.deb
+[ "$(systemctl is-active tempo)" = "active" ] || (echo "tempo is inactive" && exit 1)
+
+# Wait for tempo to be ready.
+apt update && apt install -y curl
+./wait-for-ready.sh

--- a/tools/packaging/verify-rpm-install.sh
+++ b/tools/packaging/verify-rpm-install.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+# Import the Grafana GPG key
+rpm --import https://packages.grafana.com/gpg.key
+
+# Install tempo and check it's running
+rpm -i ./tempo_*_linux_amd64.rpm
+[ "$(systemctl is-active tempo)" = "active" ] || (echo "tempo is inactive" && exit 1)
+
+# Wait for tempo to be ready.
+./wait-for-ready.sh

--- a/tools/packaging/wait-for-ready.sh
+++ b/tools/packaging/wait-for-ready.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+status="$(curl -s http://localhost:3200/ready)"
+i=0
+while [ "${status}" != "ready" ]; do
+  if [ "${i}" -gt "15" ]; then
+    echo "tempo never became ready"
+    exit 1
+  fi
+  sleep 2
+  status="$(curl -s http://localhost:3200/ready)"
+  i=$((i+1))
+done


### PR DESCRIPTION
Created a draft release v0.0.999-rc-testdeb2 (which I will delete after merge). I was able to follow our internal pipeline to the point where it would publish the package. Manually running some of the commands with include-drafts-enabled it was able to find the packages though I could not test beyond that without pushing an actual package :)