### PR TITLE
Add ability to drop instance label from span metrics

### DIFF
--- a/integration/e2e/overrides_test.go
+++ b/integration/e2e/overrides_test.go
@@ -141,6 +141,11 @@ func TestOverrides(t *testing.T) {
 			patch := &client.Limits{
 				MetricsGenerator: client.LimitsMetricsGenerator{
 					DisableCollection: boolPtr(true),
+					Processor: client.LimitsMetricsGeneratorProcessor{
+						SpanMetrics: client.LimitsMetricsGeneratorProcessorSpanMetrics{
+							DropInstanceLabel: boolPtr(true),
+						},
+					},
 				},
 			}
 
@@ -154,6 +159,9 @@ func TestOverrides(t *testing.T) {
 			processors, ok = limits.GetMetricsGenerator().GetProcessors()
 			assert.True(t, ok)
 			assert.ElementsMatch(t, keys(processors.GetMap()), []string{"span-metrics"})
+			dropInstanceLabel, dropInstanceLabelIsSet := limits.GetMetricsGenerator().GetProcessor().GetSpanMetrics().GetDropInstanceLabel()
+			assert.True(t, dropInstanceLabel)
+			assert.True(t, dropInstanceLabelIsSet)
 
 			// Delete overrides
 			if !tc.skipVersioning && tc.name != "gcs" {

--- a/modules/generator/config.go
+++ b/modules/generator/config.go
@@ -220,6 +220,10 @@ func (cfg *ProcessorConfig) copyWithOverrides(o metricsGeneratorOverrides, userI
 
 	copyCfg.SpanMetrics.TargetInfoExcludedDimensions = o.MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(userID)
 
+	if dropInstanceLabel, ok := o.MetricsGeneratorProcessorSpanMetricsDropInstanceLabel(userID); ok {
+		copyCfg.SpanMetrics.DropInstanceLabel = dropInstanceLabel
+	}
+
 	if enableClientServerPrefix := o.MetricsGeneratorProcessorServiceGraphsEnableClientServerPrefix(userID); enableClientServerPrefix {
 		copyCfg.ServiceGraphs.EnableClientServerPrefix = enableClientServerPrefix
 	}

--- a/modules/generator/overrides.go
+++ b/modules/generator/overrides.go
@@ -37,6 +37,7 @@ type metricsGeneratorOverrides interface {
 	MetricsGeneratorProcessorServiceGraphsEnableMessagingSystemLatencyHistogram(userID string) (bool, bool)
 	MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel(userID string) (bool, bool)
 	MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(userID string) []string
+	MetricsGeneratorProcessorSpanMetricsDropInstanceLabel(userID string) (bool, bool)
 	MetricsGeneratorProcessorHostInfoHostIdentifiers(userID string) []string
 	MetricsGeneratorProcessorHostInfoMetricName(userID string) string
 	DedicatedColumns(userID string) backend.DedicatedColumns

--- a/modules/generator/overrides_test.go
+++ b/modules/generator/overrides_test.go
@@ -27,6 +27,7 @@ type mockOverrides struct {
 	spanMetricsDimensionMappings                       []sharedconfig.DimensionMappings
 	spanMetricsEnableTargetInfo                        *bool
 	spanMetricsTargetInfoExcludedDimensions            []string
+	spanMetricsDropInstanceLabel                       *bool
 	localBlocksMaxLiveTraces                           uint64
 	localBlocksMaxBlockDuration                        time.Duration
 	localBlocksMaxBlockBytes                           uint64
@@ -176,6 +177,14 @@ func (m *mockOverrides) MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeL
 
 func (m *mockOverrides) MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(string) []string {
 	return m.spanMetricsTargetInfoExcludedDimensions
+}
+
+func (m *mockOverrides) MetricsGeneratorProcessorSpanMetricsDropInstanceLabel(string) (bool, bool) {
+	dropInstanceLabel := m.spanMetricsDropInstanceLabel
+	if dropInstanceLabel != nil {
+		return *dropInstanceLabel, true
+	}
+	return false, false
 }
 
 func (m *mockOverrides) DedicatedColumns(string) backend.DedicatedColumns {

--- a/modules/generator/processor/spanmetrics/config.go
+++ b/modules/generator/processor/spanmetrics/config.go
@@ -58,6 +58,9 @@ type Config struct {
 
 	// Allow user to specify labels they want to drop from target_info
 	TargetInfoExcludedDimensions []string `yaml:"target_info_excluded_dimensions"`
+
+	// Allow user to drop instance label
+	DropInstanceLabel bool `yaml:"drop_instance_label"`
 }
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {

--- a/modules/generator/processor/spanmetrics/spanmetrics.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics.go
@@ -206,7 +206,7 @@ func (p *Processor) aggregateMetricsForSpan(svcName string, jobName string, inst
 		labelValues = append(labelValues, jobName)
 	}
 	//  add instance label only if job is not blank
-	if instanceID != "" && p.Cfg.EnableTargetInfo {
+	if instanceID != "" && p.Cfg.EnableTargetInfo && !p.Cfg.DropInstanceLabel {
 		labels = append(labels, dimInstance)
 		labelValues = append(labelValues, instanceID)
 	}
@@ -246,7 +246,7 @@ func (p *Processor) aggregateMetricsForSpan(svcName string, jobName string, inst
 			targetInfoLabelValues = append(targetInfoLabelValues, jobName)
 		}
 		//  add instance label to target info only if job is not blank
-		if instanceID != "" {
+		if instanceID != "" && !p.Cfg.DropInstanceLabel {
 			targetInfoLabels = append(targetInfoLabels, dimInstance)
 			targetInfoLabelValues = append(targetInfoLabelValues, instanceID)
 		}

--- a/modules/generator/processor/spanmetrics/spanmetrics_test.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics_test.go
@@ -1054,6 +1054,269 @@ func TestTargetInfoWithDifferentBatches(t *testing.T) {
 	assert.Equal(t, 1.0, testRegistry.Query("traces_target_info", lbls3))
 }
 
+func TestDropInstanceLabel(t *testing.T) {
+	testRegistry := registry.NewTestRegistry()
+	filteredSpansCounter := metricSpansDiscarded.WithLabelValues("test-tenant", "filtered")
+	invalidUTF8SpanLabelsCounter := metricSpansDiscarded.WithLabelValues("test-tenant", "invalid_utf8")
+
+	cfg := Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", nil)
+	cfg.EnableTargetInfo = true
+	cfg.DropInstanceLabel = true
+	cfg.HistogramBuckets = []float64{0.5, 1}
+	cfg.Dimensions = []string{"http.method", "foo"}
+
+	p, err := New(cfg, testRegistry, filteredSpansCounter, invalidUTF8SpanLabelsCounter)
+	require.NoError(t, err)
+	defer p.Shutdown(context.Background())
+
+	// first batch will not have name-space nor instance id
+	// this will NOT create target_info metrics since it only has job but no other attributes
+
+	// TODO give these spans some duration so we can verify latencies are recorded correctly, in fact we should also test with various span names etc.
+
+	batchCount := 10
+	batch := test.MakeBatch(batchCount, nil)
+	batch.Resource.Attributes = []*common_v1.KeyValue{
+		// add service name
+		{
+			Key:   "service.name",
+			Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "test-service"}},
+		},
+		// add instance
+		{
+			Key:   "service.instance.id",
+			Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "abc-instance-id-test-abc"}},
+		},
+		// add cluster
+		{
+			Key:   "cluster",
+			Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "eu-west-0"}},
+		},
+	}
+	for _, ils := range batch.ScopeSpans {
+		for _, s := range ils.Spans {
+			s.Attributes = append(s.Attributes, &common_v1.KeyValue{
+				Key:   "http.method",
+				Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "GET"}},
+			})
+			s.Attributes = append(s.Attributes, &common_v1.KeyValue{
+				Key:   "foo",
+				Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "bar"}},
+			})
+		}
+	}
+
+	// batch 2 will have instance id & cluster
+	// this will create a target_info metric with job, instance, and cluster
+	batch2 := test.MakeBatch(batchCount, nil)
+	batch2.Resource.Attributes = []*common_v1.KeyValue{
+		// add service name
+		{
+			Key:   "service.name",
+			Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "test-service"}},
+		},
+		// add instance
+		{
+			Key:   "service.instance.id",
+			Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "abc-instance-id-test-def"}},
+		},
+		// add cluster
+		{
+			Key:   "cluster",
+			Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "eu-west-0"}},
+		},
+	}
+	for _, ils := range batch2.ScopeSpans {
+		for _, s := range ils.Spans {
+			s.Attributes = append(s.Attributes, &common_v1.KeyValue{
+				Key:   "http.method",
+				Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "GET"}},
+			})
+			s.Attributes = append(s.Attributes, &common_v1.KeyValue{
+				Key:   "foo",
+				Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "bar"}},
+			})
+		}
+	}
+
+	p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{batch, batch2}})
+
+	fmt.Println(testRegistry)
+
+	targetInfoLabels := labels.FromMap(map[string]string{
+		"job":     "test-service",
+		"cluster": "eu-west-0",
+	})
+
+	assert.Equal(t, 1.0, testRegistry.Query("traces_target_info", targetInfoLabels))
+
+	spanMetricsLabels := labels.FromMap(map[string]string{
+		"service":     "test-service",
+		"span_name":   "test",
+		"span_kind":   "SPAN_KIND_CLIENT",
+		"status_code": "STATUS_CODE_OK",
+		"http_method": "GET",
+		"foo":         "bar",
+		"job":         "test-service",
+	})
+	assert.Equal(t, float64(batchCount*2), testRegistry.Query("traces_spanmetrics_calls_total", spanMetricsLabels))
+	assert.Equal(t, float64(batchCount*2), testRegistry.Query("traces_spanmetrics_latency_count", spanMetricsLabels))
+	assert.Equal(t, float64(batchCount*2), testRegistry.Query("traces_spanmetrics_latency_sum", spanMetricsLabels))
+
+	expectedBuckets := map[float64]float64{
+		0.5:         0.0,
+		1.0:         20.0,
+		math.Inf(1): 20.0,
+	}
+	for le, expected := range expectedBuckets {
+		assert.Equal(t, expected, testRegistry.Query("traces_spanmetrics_latency_bucket", withLe(spanMetricsLabels, le)))
+	}
+}
+
+func TestDropInstanceLabelUnset(t *testing.T) {
+	testRegistry := registry.NewTestRegistry()
+	filteredSpansCounter := metricSpansDiscarded.WithLabelValues("test-tenant", "filtered")
+	invalidUTF8SpanLabelsCounter := metricSpansDiscarded.WithLabelValues("test-tenant", "invalid_utf8")
+
+	cfg := Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", nil)
+	cfg.EnableTargetInfo = true
+	cfg.HistogramBuckets = []float64{0.5, 1}
+	cfg.Dimensions = []string{"http.method", "foo"}
+
+	p, err := New(cfg, testRegistry, filteredSpansCounter, invalidUTF8SpanLabelsCounter)
+	require.NoError(t, err)
+	defer p.Shutdown(context.Background())
+
+	// first batch will not have name-space nor instance id
+	// this will NOT create target_info metrics since it only has job but no other attributes
+
+	// TODO give these spans some duration so we can verify latencies are recorded correctly, in fact we should also test with various span names etc.
+
+	batchCount := 10
+	batch := test.MakeBatch(batchCount, nil)
+	batch.Resource.Attributes = []*common_v1.KeyValue{
+		// add service name
+		{
+			Key:   "service.name",
+			Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "test-service"}},
+		},
+		// add instance
+		{
+			Key:   "service.instance.id",
+			Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "abc-instance-id-test-abc"}},
+		},
+		// add cluster
+		{
+			Key:   "cluster",
+			Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "eu-west-0"}},
+		},
+	}
+	for _, ils := range batch.ScopeSpans {
+		for _, s := range ils.Spans {
+			s.Attributes = append(s.Attributes, &common_v1.KeyValue{
+				Key:   "http.method",
+				Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "GET"}},
+			})
+			s.Attributes = append(s.Attributes, &common_v1.KeyValue{
+				Key:   "foo",
+				Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "bar"}},
+			})
+		}
+	}
+
+	// batch 2 will have instance id & cluster
+	// this will create a target_info metric with job, instance, and cluster
+	batch2 := test.MakeBatch(batchCount, nil)
+	batch2.Resource.Attributes = []*common_v1.KeyValue{
+		// add service name
+		{
+			Key:   "service.name",
+			Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "test-service"}},
+		},
+		// add instance
+		{
+			Key:   "service.instance.id",
+			Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "abc-instance-id-test-def"}},
+		},
+		// add cluster
+		{
+			Key:   "cluster",
+			Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "eu-west-0"}},
+		},
+	}
+	for _, ils := range batch2.ScopeSpans {
+		for _, s := range ils.Spans {
+			s.Attributes = append(s.Attributes, &common_v1.KeyValue{
+				Key:   "http.method",
+				Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "GET"}},
+			})
+			s.Attributes = append(s.Attributes, &common_v1.KeyValue{
+				Key:   "foo",
+				Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "bar"}},
+			})
+		}
+	}
+
+	p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{batch, batch2}})
+
+	fmt.Println(testRegistry)
+
+	targetInfoLabels1 := labels.FromMap(map[string]string{
+		"job":      "test-service",
+		"cluster":  "eu-west-0",
+		"instance": "abc-instance-id-test-abc",
+	})
+
+	targetInfoLabels2 := labels.FromMap(map[string]string{
+		"job":      "test-service",
+		"cluster":  "eu-west-0",
+		"instance": "abc-instance-id-test-def",
+	})
+
+	assert.Equal(t, 1.0, testRegistry.Query("traces_target_info", targetInfoLabels1))
+	assert.Equal(t, 1.0, testRegistry.Query("traces_target_info", targetInfoLabels2))
+
+	spanMetricsLabels1 := labels.FromMap(map[string]string{
+		"service":     "test-service",
+		"span_name":   "test",
+		"span_kind":   "SPAN_KIND_CLIENT",
+		"status_code": "STATUS_CODE_OK",
+		"http_method": "GET",
+		"foo":         "bar",
+		"job":         "test-service",
+		"instance":    "abc-instance-id-test-abc",
+	})
+
+	spanMetricsLabels2 := labels.FromMap(map[string]string{
+		"service":     "test-service",
+		"span_name":   "test",
+		"span_kind":   "SPAN_KIND_CLIENT",
+		"status_code": "STATUS_CODE_OK",
+		"http_method": "GET",
+		"foo":         "bar",
+		"job":         "test-service",
+		"instance":    "abc-instance-id-test-def",
+	})
+	assert.Equal(t, float64(batchCount), testRegistry.Query("traces_spanmetrics_calls_total", spanMetricsLabels1))
+	assert.Equal(t, float64(batchCount), testRegistry.Query("traces_spanmetrics_latency_count", spanMetricsLabels1))
+	assert.Equal(t, float64(batchCount), testRegistry.Query("traces_spanmetrics_latency_sum", spanMetricsLabels1))
+
+	assert.Equal(t, float64(batchCount), testRegistry.Query("traces_spanmetrics_calls_total", spanMetricsLabels2))
+	assert.Equal(t, float64(batchCount), testRegistry.Query("traces_spanmetrics_latency_count", spanMetricsLabels2))
+	assert.Equal(t, float64(batchCount), testRegistry.Query("traces_spanmetrics_latency_sum", spanMetricsLabels2))
+
+	expectedBuckets := map[float64]float64{
+		0.5:         0.0,
+		1.0:         10.0,
+		math.Inf(1): 10.0,
+	}
+	for le, expected := range expectedBuckets {
+		assert.Equal(t, expected, testRegistry.Query("traces_spanmetrics_latency_bucket", withLe(spanMetricsLabels1, le)))
+		assert.Equal(t, expected, testRegistry.Query("traces_spanmetrics_latency_bucket", withLe(spanMetricsLabels2, le)))
+	}
+}
 func TestSpanMetricsDimensionMapping(t *testing.T) {
 	testRegistry := registry.NewTestRegistry()
 	filteredSpansCounter := metricSpansDiscarded.WithLabelValues("test-tenant", "filtered")

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -105,6 +105,7 @@ type SpanMetricsOverrides struct {
 	DimensionMappings            []sharedconfig.DimensionMappings `yaml:"dimension_mappings,omitempty" json:"dimension_mapings,omitempty"`
 	EnableTargetInfo             *bool                            `yaml:"enable_target_info,omitempty" json:"enable_target_info,omitempty"`
 	TargetInfoExcludedDimensions []string                         `yaml:"target_info_excluded_dimensions,omitempty" json:"target_info_excluded_dimensions,omitempty"`
+	DropInstanceLabel            *bool                            `yaml:"drop_instance_label,omitempty" json:"drop_instance_label,omitempty"`
 }
 
 type LocalBlocksOverrides struct {

--- a/modules/overrides/config_legacy.go
+++ b/modules/overrides/config_legacy.go
@@ -48,6 +48,7 @@ func (c *Overrides) toLegacy() LegacyOverrides {
 		MetricsGeneratorProcessorSpanMetricsDimensionMappings:                       c.MetricsGenerator.Processor.SpanMetrics.DimensionMappings,
 		MetricsGeneratorProcessorSpanMetricsEnableTargetInfo:                        c.MetricsGenerator.Processor.SpanMetrics.EnableTargetInfo,
 		MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions:            c.MetricsGenerator.Processor.SpanMetrics.TargetInfoExcludedDimensions,
+		MetricsGeneratorProcessorSpanMetricsDropInstanceLabel:                       c.MetricsGenerator.Processor.SpanMetrics.DropInstanceLabel,
 		MetricsGeneratorProcessorLocalBlocksMaxLiveTraces:                           c.MetricsGenerator.Processor.LocalBlocks.MaxLiveTraces,
 		MetricsGeneratorProcessorLocalBlocksMaxBlockDuration:                        c.MetricsGenerator.Processor.LocalBlocks.MaxBlockDuration,
 		MetricsGeneratorProcessorLocalBlocksMaxBlockBytes:                           c.MetricsGenerator.Processor.LocalBlocks.MaxBlockBytes,
@@ -126,6 +127,7 @@ type LegacyOverrides struct {
 	MetricsGeneratorProcessorSpanMetricsDimensionMappings                       []sharedconfig.DimensionMappings `yaml:"metrics_generator_processor_span_metrics_dimension_mappings" json:"metrics_generator_processor_span_metrics_dimension_mapings"`
 	MetricsGeneratorProcessorSpanMetricsEnableTargetInfo                        *bool                            `yaml:"metrics_generator_processor_span_metrics_enable_target_info" json:"metrics_generator_processor_span_metrics_enable_target_info"`
 	MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions            []string                         `yaml:"metrics_generator_processor_span_metrics_target_info_excluded_dimensions" json:"metrics_generator_processor_span_metrics_target_info_excluded_dimensions"`
+	MetricsGeneratorProcessorSpanMetricsDropInstanceLabel                       *bool                            `yaml:"metrics_generator_processor_span_metrics_drop_instance_label" json:"metrics_generator_processor_span_metrics_drop_instance_label"`
 	MetricsGeneratorProcessorLocalBlocksMaxLiveTraces                           uint64                           `yaml:"metrics_generator_processor_local_blocks_max_live_traces" json:"metrics_generator_processor_local_blocks_max_live_traces"`
 	MetricsGeneratorProcessorLocalBlocksMaxBlockDuration                        time.Duration                    `yaml:"metrics_generator_processor_local_blocks_max_block_duration" json:"metrics_generator_processor_local_blocks_max_block_duration"`
 	MetricsGeneratorProcessorLocalBlocksMaxBlockBytes                           uint64                           `yaml:"metrics_generator_processor_local_blocks_max_block_bytes" json:"metrics_generator_processor_local_blocks_max_block_bytes"`
@@ -215,6 +217,7 @@ func (l *LegacyOverrides) toNewLimits() Overrides {
 					DimensionMappings:            l.MetricsGeneratorProcessorSpanMetricsDimensionMappings,
 					EnableTargetInfo:             l.MetricsGeneratorProcessorSpanMetricsEnableTargetInfo,
 					TargetInfoExcludedDimensions: l.MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions,
+					DropInstanceLabel:            l.MetricsGeneratorProcessorSpanMetricsDropInstanceLabel,
 				},
 				LocalBlocks: LocalBlocksOverrides{
 					MaxLiveTraces:        l.MetricsGeneratorProcessorLocalBlocksMaxLiveTraces,

--- a/modules/overrides/config_test.go
+++ b/modules/overrides/config_test.go
@@ -458,6 +458,7 @@ func generateTestLegacyOverrides() LegacyOverrides {
 		},
 		MetricsGeneratorProcessorSpanMetricsEnableTargetInfo:             boolPtr(true),
 		MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions: []string{"excluded-dim-1", "excluded-dim-2"},
+		MetricsGeneratorProcessorSpanMetricsDropInstanceLabel:            boolPtr(true),
 		MetricsGeneratorProcessorLocalBlocksMaxLiveTraces:                100,
 		MetricsGeneratorProcessorLocalBlocksMaxBlockDuration:             10 * time.Minute,
 		MetricsGeneratorProcessorLocalBlocksMaxBlockBytes:                1024 * 1024,

--- a/modules/overrides/interface.go
+++ b/modules/overrides/interface.go
@@ -72,6 +72,7 @@ type Interface interface {
 	MetricsGeneratorProcessorServiceGraphsEnableMessagingSystemLatencyHistogram(userID string) (bool, bool) // returns (enabled, isSet)
 	MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel(userID string) (bool, bool)                // returns (enabled, isSet)
 	MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(userID string) []string
+	MetricsGeneratorProcessorSpanMetricsDropInstanceLabel(userID string) (bool, bool)
 	MetricsGeneratorProcessorHostInfoHostIdentifiers(userID string) []string
 	MetricsGeneratorProcessorHostInfoMetricName(userID string) string
 	MetricsGeneratorNativeHistogramBucketFactor(userID string) float64

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -573,6 +573,14 @@ func (o *runtimeConfigOverridesManager) MetricsGeneratorProcessorSpanMetricsTarg
 	return o.getOverridesForUser(userID).MetricsGenerator.Processor.SpanMetrics.TargetInfoExcludedDimensions
 }
 
+func (o *runtimeConfigOverridesManager) MetricsGeneratorProcessorSpanMetricsDropInstanceLabel(userID string) (bool, bool) {
+	dropInstanceLabel := o.getOverridesForUser(userID).MetricsGenerator.Processor.SpanMetrics.DropInstanceLabel
+	if dropInstanceLabel != nil {
+		return *dropInstanceLabel, true
+	}
+	return false, false
+}
+
 func (o *runtimeConfigOverridesManager) MetricsGeneratorProcessorHostInfoHostIdentifiers(userID string) []string {
 	return o.getOverridesForUser(userID).MetricsGenerator.Processor.HostInfo.HostIdentifiers
 }

--- a/modules/overrides/runtime_config_overrides_test.go
+++ b/modules/overrides/runtime_config_overrides_test.go
@@ -267,6 +267,7 @@ func TestMetricsGeneratorOverrides(t *testing.T) {
 		expectedEnableTargetInfo             map[string]bool
 		expectedDimensionMappings            map[string][]sharedconfig.DimensionMappings
 		expectedTargetInfoExcludedDimensions map[string][]string
+		expectedDropInstanceLabel            map[string]bool
 	}{
 		{
 			name: "limits only",
@@ -282,6 +283,7 @@ func TestMetricsGeneratorOverrides(t *testing.T) {
 									Join:        "/",
 								},
 							},
+							DropInstanceLabel: boolPtr(false),
 						},
 					},
 				},
@@ -303,6 +305,7 @@ func TestMetricsGeneratorOverrides(t *testing.T) {
 					},
 				},
 			},
+			expectedDropInstanceLabel: map[string]bool{"user1": false, "user2": false},
 		},
 		{
 			name:          "basic Overrides",
@@ -321,6 +324,7 @@ func TestMetricsGeneratorOverrides(t *testing.T) {
 											Join:        "/",
 										},
 									},
+									DropInstanceLabel: boolPtr(true),
 								},
 							},
 						},
@@ -338,6 +342,7 @@ func TestMetricsGeneratorOverrides(t *testing.T) {
 				},
 				"user2": nil,
 			},
+			expectedDropInstanceLabel: map[string]bool{"user1": true, "user2": false},
 		},
 		{
 			name: "wildcard override",
@@ -443,6 +448,11 @@ func TestMetricsGeneratorOverrides(t *testing.T) {
 
 			for user, expectedVal := range tt.expectedTargetInfoExcludedDimensions {
 				assert.Equal(t, expectedVal, overrides.MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(user))
+			}
+
+			for user, expectedVal := range tt.expectedDropInstanceLabel {
+				dropInstanceLabelValue, _ := overrides.MetricsGeneratorProcessorSpanMetricsDropInstanceLabel(user)
+				assert.Equal(t, expectedVal, dropInstanceLabelValue)
 			}
 
 			err := services.StopAndAwaitTerminated(context.TODO(), overrides)

--- a/modules/overrides/user_configurable_overrides.go
+++ b/modules/overrides/user_configurable_overrides.go
@@ -322,6 +322,13 @@ func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorSpanMetricsT
 	return o.Interface.MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(userID)
 }
 
+func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorSpanMetricsDropInstanceLabel(userID string) (bool, bool) {
+	if dropInstanceLabel, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetSpanMetrics().GetDropInstanceLabel(); ok {
+		return dropInstanceLabel, true
+	}
+	return o.Interface.MetricsGeneratorProcessorSpanMetricsDropInstanceLabel(userID)
+}
+
 func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorHostInfoHostIdentifiers(userID string) []string {
 	if hostIdentifiers, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetHostInfo().GetHostIdentifiers(); ok {
 		return hostIdentifiers

--- a/modules/overrides/user_configurable_overrides_test.go
+++ b/modules/overrides/user_configurable_overrides_test.go
@@ -95,6 +95,9 @@ func TestUserConfigOverridesManager_allFields(t *testing.T) {
 	assert.Empty(t, mgr.MetricsGeneratorProcessorSpanMetricsFilterPolicies(tenant1))
 	assert.Empty(t, mgr.MetricsGeneratorProcessorSpanMetricsHistogramBuckets(tenant1))
 	assert.Empty(t, mgr.MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(tenant1))
+	dropInstanceLabel, dropInstanceLabelIsSet := mgr.MetricsGeneratorProcessorSpanMetricsDropInstanceLabel(tenant1)
+	assert.Equal(t, false, dropInstanceLabel)
+	assert.Equal(t, false, dropInstanceLabelIsSet)
 
 	// Inject user-configurable overrides
 	mgr.tenantLimits[tenant1] = &userconfigurableoverrides.Limits{
@@ -112,8 +115,9 @@ func TestUserConfigOverridesManager_allFields(t *testing.T) {
 					HistogramBuckets:         &[]float64{1, 2, 3, 4, 5},
 				},
 				SpanMetrics: userconfigurableoverrides.LimitsMetricsGeneratorProcessorSpanMetrics{
-					Dimensions:       &[]string{"sm-dimension"},
-					EnableTargetInfo: boolPtr(true),
+					Dimensions:        &[]string{"sm-dimension"},
+					EnableTargetInfo:  boolPtr(true),
+					DropInstanceLabel: boolPtr(true),
 					FilterPolicies: &[]filterconfig.FilterPolicy{
 						{
 							Include: &filterconfig.PolicyMatch{
@@ -161,6 +165,9 @@ func TestUserConfigOverridesManager_allFields(t *testing.T) {
 	assert.Equal(t, true, enableTargetInfoIsSet)
 	assert.Equal(t, []float64{10, 20, 30, 40, 50}, mgr.MetricsGeneratorProcessorSpanMetricsHistogramBuckets(tenant1))
 	assert.Equal(t, []string{"some-label"}, mgr.MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(tenant1))
+	dropInstanceLabel, dropInstanceLabelIsSet = mgr.MetricsGeneratorProcessorSpanMetricsDropInstanceLabel(tenant1)
+	assert.Equal(t, true, dropInstanceLabel)
+	assert.Equal(t, true, dropInstanceLabelIsSet)
 
 	filterPolicies := mgr.MetricsGeneratorProcessorSpanMetricsFilterPolicies(tenant1)
 	assert.NotEmpty(t, filterPolicies)
@@ -458,6 +465,10 @@ func TestUserConfigOverridesManager_MergeRuntimeConfig(t *testing.T) {
 	assert.Equal(t, mgr.BlockRetention(tenantID), baseMgr.BlockRetention(tenantID))
 	assert.Equal(t, mgr.MaxSearchDuration(tenantID), baseMgr.MaxSearchDuration(tenantID))
 	assert.Equal(t, mgr.DedicatedColumns(tenantID), baseMgr.DedicatedColumns(tenantID))
+	baseDropInstanceLabelValue, baseDropInstanceLabelIsSet := mgr.MetricsGeneratorProcessorSpanMetricsDropInstanceLabel(tenantID)
+	overrideDropInstanceLabelValue, overrideDropInstanceLabelIsSet := baseMgr.MetricsGeneratorProcessorSpanMetricsDropInstanceLabel(tenantID)
+	assert.Equal(t, overrideDropInstanceLabelValue, baseDropInstanceLabelValue)
+	assert.Equal(t, overrideDropInstanceLabelIsSet, baseDropInstanceLabelIsSet)
 }
 
 func perTenantRuntimeOverrides(tenantID string) *perTenantOverrides {
@@ -504,6 +515,7 @@ func perTenantRuntimeOverrides(tenantID string) *perTenantOverrides {
 							DimensionMappings:            []sharedconfig.DimensionMappings{{Name: "foo", SourceLabel: []string{"bar"}, Join: "baz"}},
 							EnableTargetInfo:             boolPtr(true),
 							TargetInfoExcludedDimensions: []string{"bar", "namespace", "env"},
+							DropInstanceLabel:            boolPtr(true),
 						},
 						LocalBlocks: LocalBlocksOverrides{
 							MaxLiveTraces:        100,

--- a/modules/overrides/userconfigurable/api/limits.go
+++ b/modules/overrides/userconfigurable/api/limits.go
@@ -32,6 +32,10 @@ func limitsFromOverrides(overrides overrides.Interface, userID string) *client.L
 					FilterPolicies:               filterPoliciesPtr(overrides.MetricsGeneratorProcessorSpanMetricsFilterPolicies(userID)),
 					HistogramBuckets:             floatArrPtr(overrides.MetricsGeneratorProcessorSpanMetricsHistogramBuckets(userID)),
 					TargetInfoExcludedDimensions: strArrPtr(overrides.MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(userID)),
+					DropInstanceLabel: func() *bool {
+						val, _ := overrides.MetricsGeneratorProcessorSpanMetricsDropInstanceLabel(userID)
+						return boolPtr(val)
+					}(),
 				},
 				HostInfo: client.LimitsMetricGeneratorProcessorHostInfo{
 					HostIdentifiers: strArrPtr(overrides.MetricsGeneratorProcessorHostInfoHostIdentifiers(userID)),

--- a/modules/overrides/userconfigurable/api/limits_test.go
+++ b/modules/overrides/userconfigurable/api/limits_test.go
@@ -30,8 +30,9 @@ func Test_limitsFromOverrides(t *testing.T) {
 						EnableClientServerPrefix: boolPtr(true),
 					},
 					SpanMetrics: overrides.SpanMetricsOverrides{
-						Dimensions:       []string{"your-dim1", "your-dim2"},
-						EnableTargetInfo: boolPtr(true),
+						Dimensions:        []string{"your-dim1", "your-dim2"},
+						EnableTargetInfo:  boolPtr(true),
+						DropInstanceLabel: boolPtr(true),
 						FilterPolicies: []filterconfig.FilterPolicy{
 							{
 								Exclude: &filterconfig.PolicyMatch{
@@ -116,7 +117,8 @@ func Test_limitsFromOverrides(t *testing.T) {
         ],
         "target_info_excluded_dimensions": [
           "no"
-        ]
+        ],
+        "drop_instance_label": true
       },
       "host_info": {
         "host_identifiers": [

--- a/modules/overrides/userconfigurable/client/limits.go
+++ b/modules/overrides/userconfigurable/client/limits.go
@@ -147,6 +147,7 @@ type LimitsMetricsGeneratorProcessorSpanMetrics struct {
 	FilterPolicies               *[]filterconfig.FilterPolicy `yaml:"filter_policies,omitempty" json:"filter_policies,omitempty"`
 	HistogramBuckets             *[]float64                   `yaml:"histogram_buckets,omitempty" json:"histogram_buckets,omitempty"`
 	TargetInfoExcludedDimensions *[]string                    `yaml:"target_info_excluded_dimensions,omitempty" json:"target_info_excluded_dimensions,omitempty"`
+	DropInstanceLabel            *bool                        `yaml:"drop_instance_label,omitempty" json:"drop_instance_label,omitempty"`
 }
 
 func (l *LimitsMetricsGeneratorProcessorSpanMetrics) GetDimensions() ([]string, bool) {
@@ -182,6 +183,13 @@ func (l *LimitsMetricsGeneratorProcessorSpanMetrics) GetTargetInfoExcludedDimens
 		return *l.TargetInfoExcludedDimensions, true
 	}
 	return nil, false
+}
+
+func (l *LimitsMetricsGeneratorProcessorSpanMetrics) GetDropInstanceLabel() (bool, bool) {
+	if l != nil && l.DropInstanceLabel != nil {
+		return *l.DropInstanceLabel, true
+	}
+	return false, false
 }
 
 type LimitsMetricGeneratorProcessorHostInfo struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: Add a config to allow dropping of the `instance` label from span_metrics timeseries since it tends to be very high in cardinality

**Which issue(s) this PR fixes**:
Fixes #4873 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`