### PR TITLE
test: fix test race condition in test logger

### DIFF
--- a/pkg/util/test/logger.go
+++ b/pkg/util/test/logger.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,32 +12,52 @@ import (
 var _ log.Logger = (*TestingLogger)(nil)
 
 type TestingLogger struct {
-	t   testing.TB
-	mtx *sync.Mutex
+	t    testing.TB
+	mtx  *sync.Mutex
+	done atomic.Bool
 }
 
 func NewTestingLogger(t testing.TB) *TestingLogger {
-	return &TestingLogger{
+	logger := &TestingLogger{
 		t:   t,
 		mtx: &sync.Mutex{},
 	}
+	registerCleanup(t, logger)
+	return logger
 }
 
 // WithT returns a new logger that logs to t. Writes between the new logger and the original logger are synchronized.
 func (l *TestingLogger) WithT(t testing.TB) log.Logger {
-	return &TestingLogger{
+	child := &TestingLogger{
 		t:   t,
 		mtx: l.mtx,
 	}
+	registerCleanup(t, child)
+	return child
 }
 
 func (l *TestingLogger) Log(keyvals ...interface{}) error {
+	if l.done.Load() {
+		return nil
+	}
+
 	// Prepend log with timestamp.
 	keyvals = append([]interface{}{time.Now().String()}, keyvals...)
 
 	l.mtx.Lock()
 	defer l.mtx.Unlock()
+
+	if l.done.Load() {
+		return nil
+	}
+
 	l.t.Log(keyvals...)
 
 	return nil
+}
+
+func registerCleanup(t testing.TB, l *TestingLogger) {
+	t.Cleanup(func() {
+		l.done.Store(true)
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Fix race conditions when calling the test log after the test has finished by adding a "done" flag in the test logger.
This can happen in tests with services that are not shut down correctly.

I've seen it in different test in the past months, and recently again in a blockbuilder tests such as: https://github.com/grafana/tempo/actions/runs/18311278340/job/52140208404?pr=5710#step:4:12769

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`