### PR TITLE
Backport #5688 to release-v2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 ## main / unreleased
 
-* [CHANGE] Upgrade Tempo to go 1.25.0 [#5685](https://github.com/grafana/tempo/pull/5685) (@electron0zero)
-
 # v2.9.0-rc.0
 
 * [CHANGE] **BREAKING CHANGE** We are no longer publishing rpm and deb packages due to an internal change to the handling of signing keys. [#5684](https://github.com/grafana/tempo/pull/5684) (@joe-elliott)
 * [CHANGE] Return Bad Request from all frontend endpoints if the tenant can't be extracted. [#5480](https://github.com/grafana/tempo/pull/5480) (@carles-grafana)
+* [CHANGE] **BREAKING CHANGE** Deprecating vParquet2 block format [#5688](https://github.com/grafana/tempo/pull/5688) (@ie-pham)
 * [CHANGE]  **BREAKING CHANGE** Migrated Tempo Vulture and Integration Tests from the deprecated Jaeger agent/exporter to the standard OTLP exporter. Vulture now pushes traces to the Tempo OTLP GRCP endpoint. [#5058](https://github.com/grafana/tempo/pull/5058) (@iamrajiv, @javiermolinar)
 * [CHANGE] Do not count cached querier responses for SLO metrics such as inspected bytes. [#5185](https://github.com/grafana/tempo/pull/5185) (@carles-grafana)
 * [CHANGE] Adjust the definition of `tempo_metrics_generator_processor_service_graphs_expired_edges` to exclude edges that are counted in the service graph. [#5319](https://github.com/grafana/tempo/pull/5319) (@joe-elliott)

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -1413,7 +1413,7 @@ Defines re-used configuration blocks.
 ### Block config
 
 ```yaml
-# block format version. options: v2, vParquet2, vParquet3, vParquet4
+# block format version. options: v2, vParquet3, vParquet4
 [version: <string> | default = vParquet4]
 
 # bloom filter false positive rate. lower values create larger filters but fewer false positives
@@ -1614,7 +1614,7 @@ The storage WAL configuration block.
 [ingestion_time_range_slack: <duration> | default = unset]
 
 # WAL file format version
-# Options: v2, vParquet, vParquet2, vParquet3
+# Options: v2, vParquet3, vParquet4
 [version: <string> | default = "vParquet3"]
 ```
 

--- a/docs/sources/tempo/configuration/parquet.md
+++ b/docs/sources/tempo/configuration/parquet.md
@@ -35,7 +35,7 @@ You can still use the previous format `vParquet3`.
 To enable it, set the block version option to `vParquet3` in the [Storage section](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#storage) of the configuration file.
 
 ```yaml
-# block format version. options: v2, vParquet2, vParquet3, vParquet4
+# block format version. options: v2, vParquet3, vParquet4
 [version: vParquet4]
 ```
 
@@ -44,7 +44,7 @@ Using the `v2` block format disables all forms of search, but also reduces resou
 To make this change, set the block version option to `v2` in the Storage section of the configuration file.
 
 ```yaml
-# block format version. options: v2, vParquet2, vParquet3, vParquet4
+# block format version. options: v2, vParquet3, vParquet4
 [version: v2]
 ```
 

--- a/integration/e2e/encodings_test.go
+++ b/integration/e2e/encodings_test.go
@@ -8,6 +8,7 @@ import (
 
 	util2 "github.com/grafana/tempo/integration/util"
 	v2 "github.com/grafana/tempo/tempodb/encoding/v2"
+	"github.com/grafana/tempo/tempodb/encoding/vparquet2"
 
 	"github.com/grafana/e2e"
 	"github.com/stretchr/testify/require"
@@ -29,6 +30,9 @@ func TestEncodings(t *testing.T) {
 	const repeatedSearchCount = 10
 
 	for _, enc := range encoding.AllEncodings() {
+		if enc.Version() == vparquet2.VersionString {
+			continue // vParquet2 is deprecated
+		}
 		t.Run(enc.Version(), func(t *testing.T) {
 			s, err := e2e.NewScenario("tempo_e2e")
 			require.NoError(t, err)

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/grafana/tempo/tempodb/blockselector"
 	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/grafana/tempo/tempodb/encoding/common"
+	"github.com/grafana/tempo/tempodb/encoding/vparquet2"
 	"github.com/grafana/tempo/tempodb/pool"
 	"github.com/grafana/tempo/tempodb/wal"
 )
@@ -74,6 +75,9 @@ func (m *mockOverrides) MaxCompactionRangeForTenant(_ string) time.Duration {
 func TestCompactionRoundtrip(t *testing.T) {
 	for _, enc := range encoding.AllEncodings() {
 		version := enc.Version()
+		if version == vparquet2.VersionString {
+			continue // vParquet2 is deprecated
+		}
 		t.Run(version, func(t *testing.T) {
 			t.Parallel()
 			testCompactionRoundtrip(t, version)
@@ -228,6 +232,9 @@ func testCompactionRoundtrip(t *testing.T, targetBlockVersion string) {
 func TestSameIDCompaction(t *testing.T) {
 	for _, enc := range encoding.AllEncodings() {
 		version := enc.Version()
+		if version == vparquet2.VersionString {
+			continue // vParquet2 is deprecated
+		}
 		t.Run(version, func(t *testing.T) {
 			testSameIDCompaction(t, version)
 		})
@@ -592,6 +599,9 @@ func TestCompactionIteratesThroughTenants(t *testing.T) {
 func TestCompactionHonorsBlockStartEndTimes(t *testing.T) {
 	for _, enc := range encoding.AllEncodings() {
 		version := enc.Version()
+		if version == vparquet2.VersionString {
+			continue // vParquet2 is deprecated
+		}
 		t.Run(version, func(t *testing.T) {
 			t.Parallel()
 			testCompactionHonorsBlockStartEndTimes(t, version)
@@ -669,6 +679,9 @@ func testCompactionHonorsBlockStartEndTimes(t *testing.T, targetBlockVersion str
 func TestCompactionDropsTraces(t *testing.T) {
 	for _, enc := range encoding.AllEncodings() {
 		version := enc.Version()
+		if version == vparquet2.VersionString {
+			continue // vParquet2 is deprecated
+		}
 		t.Run(version, func(t *testing.T) {
 			t.Parallel()
 			testCompactionDropsTraces(t, version)
@@ -815,6 +828,9 @@ func TestDoForAtLeast(t *testing.T) {
 func TestCompactWithConfig(t *testing.T) {
 	for _, enc := range encoding.AllEncodings() {
 		version := enc.Version()
+		if version == vparquet2.VersionString {
+			continue // vParquet2 is deprecated
+		}
 		t.Run(version, func(t *testing.T) {
 			t.Parallel()
 			testCompactWithConfig(t, version)
@@ -935,6 +951,9 @@ func makeTraceID(i int, j int) []byte {
 func BenchmarkCompaction(b *testing.B) {
 	for _, enc := range encoding.AllEncodings() {
 		version := enc.Version()
+		if version == vparquet2.VersionString {
+			continue // vParquet2 is deprecated
+		}
 		b.Run(version, func(b *testing.B) {
 			benchmarkCompaction(b, version)
 		})

--- a/tempodb/config_test.go
+++ b/tempodb/config_test.go
@@ -2,9 +2,13 @@ package tempodb
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/grafana/tempo/tempodb/encoding/common"
+	v2 "github.com/grafana/tempo/tempodb/encoding/v2"
+	"github.com/grafana/tempo/tempodb/encoding/vparquet2"
+	"github.com/grafana/tempo/tempodb/encoding/vparquet3"
 	"github.com/grafana/tempo/tempodb/wal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -73,19 +77,19 @@ func TestValidateConfig(t *testing.T) {
 					IndexPageSizeBytes:   1,
 					BloomFP:              0.01,
 					BloomShardSizeBytes:  1,
-					Version:              "v2",
+					Version:              v2.VersionString,
 				},
 			},
 			expectedConfig: &Config{
 				WAL: &wal.Config{
-					Version: "v2",
+					Version: v2.VersionString,
 				},
 				Block: &common.BlockConfig{
 					IndexDownsampleBytes: 1,
 					IndexPageSizeBytes:   1,
 					BloomFP:              0.01,
 					BloomShardSizeBytes:  1,
-					Version:              "v2",
+					Version:              v2.VersionString,
 				},
 			},
 		},
@@ -93,26 +97,26 @@ func TestValidateConfig(t *testing.T) {
 		{
 			cfg: &Config{
 				WAL: &wal.Config{
-					Version: "vParquet2",
+					Version: vparquet3.VersionString,
 				},
 				Block: &common.BlockConfig{
 					IndexDownsampleBytes: 1,
 					IndexPageSizeBytes:   1,
 					BloomFP:              0.01,
 					BloomShardSizeBytes:  1,
-					Version:              "v2",
+					Version:              v2.VersionString,
 				},
 			},
 			expectedConfig: &Config{
 				WAL: &wal.Config{
-					Version: "vParquet2",
+					Version: vparquet3.VersionString,
 				},
 				Block: &common.BlockConfig{
 					IndexDownsampleBytes: 1,
 					IndexPageSizeBytes:   1,
 					BloomFP:              0.01,
 					BloomShardSizeBytes:  1,
-					Version:              "v2",
+					Version:              v2.VersionString,
 				},
 			},
 		},
@@ -138,7 +142,7 @@ func TestDeprecatedVersions(t *testing.T) {
 		{
 			cfg: &Config{
 				WAL: &wal.Config{
-					Version: "vParquet2",
+					Version: vparquet2.VersionString,
 				},
 				Block: &common.BlockConfig{
 					IndexDownsampleBytes: 1,
@@ -150,7 +154,7 @@ func TestDeprecatedVersions(t *testing.T) {
 			},
 			expectedConfig: &Config{
 				WAL: &wal.Config{
-					Version: "vParquet2",
+					Version: vparquet2.VersionString,
 				},
 				Block: &common.BlockConfig{
 					IndexDownsampleBytes: 1,
@@ -158,6 +162,63 @@ func TestDeprecatedVersions(t *testing.T) {
 					BloomFP:              0.01,
 					BloomShardSizeBytes:  1,
 					Version:              "vParquet4",
+				},
+			},
+		},
+		// block version is deprecaded and Wal is empty
+		{
+			cfg: &Config{
+				WAL: &wal.Config{},
+				Block: &common.BlockConfig{
+					IndexDownsampleBytes: 1,
+					IndexPageSizeBytes:   1,
+					BloomFP:              0.01,
+					BloomShardSizeBytes:  1,
+					Version:              vparquet2.VersionString,
+				},
+			},
+			err: fmt.Errorf(common.DeprecatedError, "vParquet2", "vParquet3").Error(),
+		},
+		// block version is deprecated version of encoding
+		{
+			cfg: &Config{
+				WAL: &wal.Config{
+					Version: vparquet3.VersionString,
+				},
+				Block: &common.BlockConfig{
+					IndexDownsampleBytes: 1,
+					IndexPageSizeBytes:   1,
+					BloomFP:              0.01,
+					BloomShardSizeBytes:  1,
+					Version:              vparquet2.VersionString,
+				},
+			},
+			err: fmt.Errorf(common.DeprecatedError, "vParquet2", "vParquet3").Error(),
+		},
+		// block version does not have deprecated version value but WAL does
+		{
+			cfg: &Config{
+				WAL: &wal.Config{
+					Version: vparquet2.VersionString,
+				},
+				Block: &common.BlockConfig{
+					IndexDownsampleBytes: 1,
+					IndexPageSizeBytes:   1,
+					BloomFP:              0.01,
+					BloomShardSizeBytes:  1,
+					Version:              v2.VersionString,
+				},
+			},
+			expectedConfig: &Config{
+				WAL: &wal.Config{
+					Version: vparquet2.VersionString,
+				},
+				Block: &common.BlockConfig{
+					IndexDownsampleBytes: 1,
+					IndexPageSizeBytes:   1,
+					BloomFP:              0.01,
+					BloomShardSizeBytes:  1,
+					Version:              v2.VersionString,
 				},
 			},
 		},

--- a/tempodb/encoding/common/config.go
+++ b/tempodb/encoding/common/config.go
@@ -15,6 +15,8 @@ const (
 	DefaultIndexPageSizeBytes   = 250 * 1024
 )
 
+const DeprecatedError = "%s is no longer supported, please use %s or later"
+
 // BlockConfig holds configuration options for newly created blocks
 type BlockConfig struct {
 	BloomFP             float64          `yaml:"bloom_filter_false_positive"`
@@ -66,6 +68,10 @@ func ValidateConfig(b *BlockConfig) error {
 
 	if b.BloomShardSizeBytes <= 0 {
 		return fmt.Errorf("positive value required for bloom-filter shard size")
+	}
+
+	if b.Version == "vParquet2" {
+		return fmt.Errorf(DeprecatedError, "vParquet2", "vParquet3")
 	}
 
 	return b.DedicatedColumns.Validate()

--- a/tempodb/retention_test.go
+++ b/tempodb/retention_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/tempo/tempodb/backend/local"
 	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/grafana/tempo/tempodb/encoding/common"
+	"github.com/grafana/tempo/tempodb/encoding/vparquet2"
 	"github.com/grafana/tempo/tempodb/pool"
 	"github.com/grafana/tempo/tempodb/wal"
 )
@@ -282,6 +283,9 @@ func TestBlockRetentionOverrideDisabled(t *testing.T) {
 func TestRetainWithConfig(t *testing.T) {
 	for _, enc := range encoding.AllEncodings() {
 		version := enc.Version()
+		if version == vparquet2.VersionString {
+			continue // vParquet2 is deprecated
+		}
 		t.Run(version, func(t *testing.T) {
 			testRetainWithConfig(t, version)
 		})

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -48,6 +48,9 @@ func TestSearchCompleteBlock(t *testing.T) {
 	t.Parallel()
 	for _, v := range encoding.AllEncodings() {
 		vers := v.Version()
+		if vers == vparquet2.VersionString {
+			continue // vParquet2 is deprecated
+		}
 		t.Run(vers, func(t *testing.T) {
 			t.Parallel()
 			runCompleteBlockSearchTest(t, vers,
@@ -2654,6 +2657,10 @@ func TestSearchForTagsAndTagValues(t *testing.T) {
 func TestSearchByShortTraceID(t *testing.T) {
 	for _, v := range encoding.AllEncodings() {
 		if v.Version() == v2.VersionString { // no support of the feature in v2
+			continue
+		}
+
+		if v.Version() == vparquet2.VersionString { // vparquet2 is deprecated
 			continue
 		}
 

--- a/tempodb/tempodb_test.go
+++ b/tempodb/tempodb_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/golang/protobuf/proto" //nolint:all
 	"github.com/google/uuid"
 	v2 "github.com/grafana/tempo/tempodb/encoding/v2"
+	"github.com/grafana/tempo/tempodb/encoding/vparquet2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -575,7 +576,13 @@ func TestSearchCompactedBlocks(t *testing.T) {
 
 func TestCompleteBlock(t *testing.T) {
 	for _, from := range encoding.AllEncodings() {
+		if from.Version() == vparquet2.VersionString {
+			continue // vParquet2 is deprecated
+		}
 		for _, to := range encoding.AllEncodings() {
+			if from.Version() == vparquet2.VersionString {
+				continue // vParquet2 is deprecated
+			}
 			t.Run(fmt.Sprintf("%s->%s", from.Version(), to.Version()), func(t *testing.T) {
 				t.Parallel()
 				testCompleteBlock(t, from.Version(), to.Version())
@@ -639,6 +646,9 @@ func testCompleteBlock(t *testing.T, from, to string) {
 func TestCompleteBlockHonorsStartStopTimes(t *testing.T) {
 	for _, enc := range encoding.AllEncodings() {
 		version := enc.Version()
+		if version == vparquet2.VersionString {
+			continue // vParquet2 is deprecated
+		}
 		t.Run(version, func(t *testing.T) {
 			testCompleteBlockHonorsStartStopTimes(t, version)
 		})


### PR DESCRIPTION
Backporting https://github.com/grafana/tempo/pull/5688 to release-v2.9