### PR TITLE
[BUGFIX] mixin alerts: add missing labels

### DIFF
--- a/operations/tempo-mixin-compiled/alerts.yaml
+++ b/operations/tempo-mixin-compiled/alerts.yaml
@@ -115,7 +115,7 @@
       "severity": "critical"
   - "alert": "TempoBlockListRisingQuickly"
     "annotations":
-      "message": "Tempo block list length is up 40 percent over the last 7 days.  Consider scaling compactors."
+      "message": "Tempo block list length is up 40 percent over the last 7 days. Consider scaling compactors."
       "runbook_url": "https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoBlockListRisingQuickly"
     "expr": |
       avg(tempodb_blocklist_length{namespace=~".*", container="compactor"}) / avg(tempodb_blocklist_length{namespace=~".*", container="compactor"} offset 7d) by (cluster, namespace) > 1.4
@@ -205,7 +205,7 @@
       "severity": "critical"
   - "alert": "TempoLiveStorePartitionLagWarning"
     "annotations":
-      "message": "Tempo ingest partition {{ $labels.partition }} for live store  {{ $labels.group }} is lagging by more than 300 seconds in {{ $labels.cluster }}/{{ $labels.namespace }}."
+      "message": "Tempo ingest partition {{ $labels.partition }} for live store {{ $labels.group }} is lagging by more than 300 seconds in {{ $labels.cluster }}/{{ $labels.namespace }}."
       "runbook_url": "https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoPartitionLag"
     "expr": |
       max by (cluster, namespace, partition, group) (avg_over_time(tempo_ingest_group_partition_lag_seconds{namespace=~".*", container="live-store"}[6m])) > 200

--- a/operations/tempo-mixin/alerts.libsonnet
+++ b/operations/tempo-mixin/alerts.libsonnet
@@ -188,7 +188,7 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'Tempo block list length is up 40 percent over the last 7 days.  Consider scaling compactors.',
+              message: 'Tempo block list length is up 40 percent over the last 7 days. Consider scaling compactors.',
               runbook_url: 'https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoBlockListRisingQuickly',
             },
           },
@@ -331,7 +331,7 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'Tempo ingest partition {{ $labels.partition }} for live store  {{ $labels.group }} is lagging by more than %d seconds in {{ $labels.%s }}/{{ $labels.namespace }}.' % [$._config.alerts.live_store_partition_lag_critical_seconds, $._config.per_cluster_label],
+              message: 'Tempo ingest partition {{ $labels.partition }} for live store {{ $labels.group }} is lagging by more than %d seconds in {{ $labels.%s }}/{{ $labels.namespace }}.' % [$._config.alerts.live_store_partition_lag_critical_seconds, $._config.per_cluster_label],
               runbook_url: 'https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoPartitionLag',
             },
           },


### PR DESCRIPTION
**What this PR does**:

Message templates were using some label that the query removed.
This PR makes sure we keep the labels so the message is complete.

This is quite a minor fix, and previous minor mixins PRs were not mentioned in CHANGELOG so I didn't.
I'm happy to update CHANGELOG if you consider it's needed.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`