### PR TITLE
servicegraphs: support SERVER→SERVER edges (dual-upsert, parent synth…

### DIFF
--- a/modules/generator/processor/servicegraphs/store/edge.go
+++ b/modules/generator/processor/servicegraphs/store/edge.go
@@ -36,6 +36,10 @@ type Edge struct {
 
 	// Span multiplier is used for multiplying metrics
 	SpanMultiplier float64
+
+	// SyntheticClient marks edges whose client side was synthesized from a SERVER span
+
+	SyntheticClient bool
 }
 
 // resetEdge resets the Edge to its zero state.


### PR DESCRIPTION
servicegraphs: Adding support for SERVER→SERVER edges (dual-upsert, parent synthesis

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adding support for server to server edges

**Which issue(s) this PR fixes**:
Fixes #Metrics Generator:: Include server/server spans as well
[#3414](https://github.com/grafana/tempo/issues/3414)

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`