### PR TITLE
[release-v2.9] Backport 5758 to 2.9 docs

### DIFF
--- a/docs/sources/tempo/shared/tempo-in-grafana.md
+++ b/docs/sources/tempo/shared/tempo-in-grafana.md
@@ -21,6 +21,11 @@ labels:
 
 Using tracing data in Grafana and Grafana Cloud Traces, you can search for traces, generate metrics from spans, and link your tracing data with logs, metrics, and profiles.
 
+{{< admonition type="note" >}}
+Trace results for matching spans are returned on a first-match basis. These results may not be the latest traces stored by Tempo.
+{{< /admonition >}}
+
+
 ### Use Traces Drilldown to investigate tracing data
 
 [Grafana Traces Drilldown](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/traces/) helps you visualize insights from your Tempo traces data.
@@ -58,7 +63,7 @@ This approach values speed over predictability and is quite simple; enforcing th
 TraceQL follows the same behavior.
 
 By adding `most_recent=true` to your TraceQL queries, the search results become deterministic.
-For more information, refer to [Retrieve most recent results](https://grafana.com/docs/tempo/<TEMPO_VERSION>/traceql/#retrieving-most-recent-results-experimental)
+For more information, refer to [Retrieve most recent results](https://grafana.com/docs/tempo/<TEMPO_VERSION>/traceql/#retrieving-most-recent-results-experimental).
 
 #### Use trace search results as panels in dashboards
 

--- a/docs/sources/tempo/shared/traceql-query-structure.md
+++ b/docs/sources/tempo/shared/traceql-query-structure.md
@@ -52,5 +52,5 @@ The query response is also limited by the number of traces (**Limit**) and spans
 
 1. TraceQL query editor
 2. Query options: **Limit**, **Span Limit** and **Table Format** (Traces or Spans).
-3. Trace (by Trace ID). The **Name** and **Service** columns are displaying the trace root span name and associated service.
+3. Trace (by Trace ID). The **Name** and **Service** columns are displaying the trace root span name and associated service. *Note:* Trace results for matching spans are returned on a first-match basis. These results may not be the latest traces stored by Tempo.
 4. Spans associated to the Trace


### PR DESCRIPTION
**What this PR does**:

Backports https://github.com/grafana/tempo/pull/5758

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`