### PR TITLE
livestore: fix test logger data race

### DIFF
--- a/modules/livestore/instance_search_test.go
+++ b/modules/livestore/instance_search_test.go
@@ -580,7 +580,7 @@ func defaultLiveStore(t testing.TB, tmpDir string) (*LiveStore, error) {
 	// Create metrics
 	reg := prometheus.NewRegistry()
 
-	logger := &testLogger{t}
+	logger := test.NewTestingLogger(t)
 
 	// Use fake Kafka cluster for testing
 	liveStore, err := New(cfg, limits, logger, reg, true) // singlePartition = true for testing
@@ -589,17 +589,6 @@ func defaultLiveStore(t testing.TB, tmpDir string) (*LiveStore, error) {
 	}
 
 	return liveStore, services.StartAndAwaitRunning(t.Context(), liveStore)
-}
-
-var _ log.Logger = (*testLogger)(nil)
-
-type testLogger struct {
-	t testing.TB
-}
-
-func (l *testLogger) Log(keyvals ...interface{}) error {
-	l.t.Log(keyvals...)
-	return nil
 }
 
 func pushTracesToInstance(t *testing.T, i *instance, numTraces int) ([]*tempopb.Trace, [][]byte) {

--- a/modules/livestore/live_store_test.go
+++ b/modules/livestore/live_store_test.go
@@ -419,7 +419,7 @@ func TestLiveStoreQueryMethodsBeforeStarted(t *testing.T) {
 	// Create metrics
 	reg := prometheus.NewRegistry()
 
-	logger := &testLogger{t}
+	logger := test.NewTestingLogger(t)
 
 	// Create LiveStore but DO NOT start it
 	liveStore, err := New(cfg, limits, logger, reg, true)

--- a/modules/livestore/partition_reader_test.go
+++ b/modules/livestore/partition_reader_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/tempo/pkg/ingest"
 	"github.com/grafana/tempo/pkg/ingest/testkafka"
+	"github.com/grafana/tempo/pkg/util/test"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -92,7 +93,7 @@ func TestPartitionReaderCommits(t *testing.T) {
 }
 
 func defaultPartitionReaderWithCommitInterval(t *testing.T, address string, commitInterval time.Duration, consume consumeFn) *PartitionReader {
-	l := &testLogger{t}
+	l := test.NewTestingLogger(t)
 
 	cfg := ingest.KafkaConfig{}
 	flagext.DefaultValues(&cfg)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

I'm seeing more data races in tests that do not use the common test logger that avoids logging after the test has shut down.
Use the protected logger instead.

data race: https://github.com/grafana/tempo/actions/runs/18648340772/job/53160296368?pr=5762

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`