### PR TITLE
[DOC] Fix mimirtools link in metamonitoring doc

### DIFF
--- a/docs/sources/tempo/shared/metamonitoring.md
+++ b/docs/sources/tempo/shared/metamonitoring.md
@@ -189,7 +189,7 @@ The ‘Tempo Operational’ dashboard shows read (query) information:
 The rules and alerts need to be installed into your Mimir or Prometheus instance.
 To do this in Prometheus, refer to the [recording rules](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) and [alerting rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) documentation.
 
-For Mimir, you can use `[mimirtool](https://grafana.com/docs/mimir/latest/manage/tools/mimirtool/)` to upload [rule](https://grafana.com/docs/mimir/latest/manage/tools/mimirtool/#rules) and [alert](https://grafana.com/docs/mimir/latest/manage/tools/mimirtool/#alertmanager) configuration.
+For Mimir, you can use [mimirtool](https://grafana.com/docs/mimir/latest/manage/tools/mimirtool/) to upload [rule](https://grafana.com/docs/mimir/latest/manage/tools/mimirtool/#rules) and [alert](https://grafana.com/docs/mimir/latest/manage/tools/mimirtool/#alertmanager) configuration.
 Using a default installation of Mimir used as the metrics store for the Alloy configuration, you might run the following:
 
 ```bash


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This pull request fixes a link to mimirtools in [Set up monitoring for Tempo](https://grafana.com/docs/tempo/latest/operations/monitor/set-up-monitoring/) page.
This typo appears since [v2.4](https://grafana.com/docs/tempo/v2.4.x/operations/monitor/set-up-monitoring/).

<img width="763" height="182" alt="image" src="https://github.com/user-attachments/assets/8394216a-5208-4d11-832f-71e9663cdd41" />

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`