### PR TITLE
docs: Update user-configurable overrides supported fields in API

### DIFF
--- a/docs/sources/tempo/operations/manage-advanced-systems/user-configurable-overrides.md
+++ b/docs/sources/tempo/operations/manage-advanced-systems/user-configurable-overrides.md
@@ -91,10 +91,11 @@ metrics_generator:
       [enable_target_info: <bool>]
       [target_info_excluded_dimensions: <list of string>]
       [enable_instance_label: <bool>]
+      [enable_virtual_node_label: <string>]
 
     host_info:
-      [metric_name: <string>]
       [host_identifiers: <list of string>]
+      [metric_name: <string>]
 ```
 
 ## API


### PR DESCRIPTION
**What this PR does**:

Update https://grafana.com/docs/tempo/latest/operations/manage-advanced-systems/user-configurable-overrides/#supported-fields page to include the `enable_virtual_node_label`.

`enable_virtual_node_label` is support config fields in User-configurable overrides API but it's missing in docs

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`