### PR TITLE
Backport - fix: handle collisions with job and instance labels when targetInfo is enabled (#5780)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [ENHANCEMENT] Improve shutdown time in the first 30 seconds [#5725](https://github.com/grafana/tempo/pull/5725) (@ldufr)
 * [BUGFIX] Correctly track and reject too large traces in live stores. [#5757](https://github.com/grafana/tempo/pull/5757) (@joe-elliott)
 * [BUGFIX] Fix issues related to integer dedicated columns in vParquet5-preview2 [#5716](https://github.com/grafana/tempo/pull/5716) (@stoewer)
+* [BUGFIX] Fix: handle collisions with job and instance labels when targetInfo is enabled [#5774](https://github.com/grafana/tempo/pull/5774) (@javiermolinar)
 * [FEATURE] Added validation mode and tests for tempo-vulture [#5605](https://github.com/grafana/tempo/pull/5605)
 
 # v2.9.0

--- a/modules/generator/processor/spanmetrics/config.go
+++ b/modules/generator/processor/spanmetrics/config.go
@@ -22,7 +22,10 @@ const (
 	dimInstance      = "instance"
 )
 
-var intrinsicLabels = []string{dimService, dimSpanName, dimSpanKind, dimStatusCode, dimStatusMessage}
+var (
+	intrinsicLabels           = []string{dimService, dimSpanName, dimSpanKind, dimStatusCode, dimStatusMessage}
+	targetInfoIntrinsicLabels = append(intrinsicLabels, dimJob, dimInstance)
+)
 
 type Config struct {
 	// Buckets for latency histogram in seconds.

--- a/modules/generator/processor/spanmetrics/spanmetrics.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics.go
@@ -73,11 +73,11 @@ func New(cfg Config, reg registry.Registry, filteredSpansCounter, invalidUTF8Cou
 	c := reclaimable.New(strutil.SanitizeLabelName, 10000)
 
 	for _, d := range cfg.Dimensions {
-		labels = append(labels, SanitizeLabelNameWithCollisions(d, intrinsicLabels, c.Get))
+		labels = append(labels, sanitizeLabelNameWithCollisions(d, intrinsicLabels, c.Get))
 	}
 
 	for _, m := range cfg.DimensionMappings {
-		labels = append(labels, SanitizeLabelNameWithCollisions(m.Name, intrinsicLabels, c.Get))
+		labels = append(labels, sanitizeLabelNameWithCollisions(m.Name, intrinsicLabels, c.Get))
 	}
 
 	err := validateUTF8LabelValues(labels)
@@ -135,7 +135,7 @@ func (p *Processor) aggregateMetrics(resourceSpans []*v1_trace.ResourceSpans) {
 		jobName := processor_util.GetJobValue(rs.Resource.Attributes)
 		instanceID, _ := processor_util.FindInstanceID(rs.Resource.Attributes)
 		if p.Cfg.EnableTargetInfo {
-			GetTargetInfoAttributesValues(&resourceLabels, &resourceValues, rs.Resource.Attributes, p.Cfg.TargetInfoExcludedDimensions, intrinsicLabels, p.sanitizeCache.Get)
+			getTargetInfoAttributesValues(&resourceLabels, &resourceValues, rs.Resource.Attributes, p.Cfg.TargetInfoExcludedDimensions, p.sanitizeCache.Get)
 		}
 		for _, ils := range rs.ScopeSpans {
 			for _, span := range ils.Spans {
@@ -270,7 +270,7 @@ func validateUTF8LabelValues(v []string) error {
 	return nil
 }
 
-func GetTargetInfoAttributesValues(keys, values *[]string, attributes []*v1_common.KeyValue, exclude, intrinsicLabels []string, sanitizeFn sanitizeFn) {
+func getTargetInfoAttributesValues(keys, values *[]string, attributes []*v1_common.KeyValue, exclude []string, sanitizeFn sanitizeFn) {
 	// TODO allocate with known length, or take new params for existing buffers
 	*keys = (*keys)[:0]
 	*values = (*values)[:0]
@@ -284,14 +284,14 @@ func GetTargetInfoAttributesValues(keys, values *[]string, attributes []*v1_comm
 			continue
 		}
 		if key != "service.name" && key != "service.namespace" && key != "service.instance.id" && !slices.Contains(exclude, key) {
-			*keys = append(*keys, SanitizeLabelNameWithCollisions(key, intrinsicLabels, sanitizeFn))
+			*keys = append(*keys, sanitizeLabelNameWithCollisions(key, targetInfoIntrinsicLabels, sanitizeFn))
 			value := tempo_util.StringifyAnyValue(attrs.Value)
 			*values = append(*values, value)
 		}
 	}
 }
 
-func SanitizeLabelNameWithCollisions(name string, dimensions []string, sansanitizeFn sanitizeFn) string {
+func sanitizeLabelNameWithCollisions(name string, dimensions []string, sansanitizeFn sanitizeFn) string {
 	sanitized := sansanitizeFn(name)
 
 	// check if same label as intrinsics

--- a/modules/generator/processor/util/util.go
+++ b/modules/generator/processor/util/util.go
@@ -56,14 +56,13 @@ func GetSpanMultiplier(ratioKey string, span *v1.Span, rs *v1_resource.Resource)
 
 func GetJobValue(attributes []*v1_common.KeyValue) string {
 	svName, _ := FindServiceName(attributes)
-	namespace, _ := FindServiceNamespace(attributes)
-
 	// if service name is not present, consider job value empty
 	if svName == "" {
 		return ""
-	} else if namespace != "" {
-		namespace += "/"
 	}
-
-	return namespace + svName
+	namespace, _ := FindServiceNamespace(attributes)
+	if namespace == "" {
+		return svName
+	}
+	return namespace + "/" + svName
 }

--- a/pkg/util/test/req.go
+++ b/pkg/util/test/req.go
@@ -41,7 +41,7 @@ func MakeSpanWithTimeWindow(traceID []byte, startTime uint64, endTime uint64) *v
 
 func makeSpanWithAttributeCount(traceID []byte, count int, startTime uint64, endTime uint64) *v1_trace.Span {
 	attributes := make([]*v1_common.KeyValue, 0, count)
-	for i := 0; i < count; i++ {
+	for range count {
 		attributes = append(attributes, &v1_common.KeyValue{
 			Key:   RandomString(),
 			Value: &v1_common.AnyValue{Value: &v1_common.AnyValue_StringValue{StringValue: RandomString()}},
@@ -122,7 +122,11 @@ func makeSpanWithAttributeCount(traceID []byte, count int, startTime uint64, end
 }
 
 func MakeBatch(spans int, traceID []byte) *v1_trace.ResourceSpans {
-	return makeBatchWithTimeRange(spans, traceID, nil)
+	return makeBatchWithTimeRange(spans, traceID, nil, nil)
+}
+
+func MakeBatchWithAttributes(spans int, traceID []byte, resAttributes []*v1_common.KeyValue) *v1_trace.ResourceSpans {
+	return makeBatchWithTimeRange(spans, traceID, nil, resAttributes)
 }
 
 type batchTimeRange struct {
@@ -130,7 +134,7 @@ type batchTimeRange struct {
 	end   uint64
 }
 
-func makeBatchWithTimeRange(spans int, traceID []byte, timeRange *batchTimeRange) *v1_trace.ResourceSpans {
+func makeBatchWithTimeRange(spans int, traceID []byte, timeRange *batchTimeRange, resAttributes []*v1_common.KeyValue) *v1_trace.ResourceSpans {
 	traceID = ValidTraceID(traceID)
 
 	batch := &v1_trace.ResourceSpans{
@@ -156,12 +160,16 @@ func makeBatchWithTimeRange(spans int, traceID []byte, timeRange *batchTimeRange
 		},
 	}
 
+	if resAttributes != nil {
+		batch.Resource.Attributes = append(batch.Resource.Attributes, resAttributes...)
+	}
+
 	var (
 		ss      *v1_trace.ScopeSpans
 		ssCount int
 	)
 
-	for i := 0; i < spans; i++ {
+	for range spans {
 		// occasionally make a new ss
 		if ss == nil || rand.Int()%3 == 0 {
 			ssCount++
@@ -191,7 +199,7 @@ func MakeTrace(requests int, traceID []byte) *tempopb.Trace {
 		ResourceSpans: make([]*v1_trace.ResourceSpans, 0),
 	}
 
-	for i := 0; i < requests; i++ {
+	for range requests {
 		trace.ResourceSpans = append(trace.ResourceSpans, MakeBatch(rand.Int()%20+1, traceID))
 	}
 
@@ -205,9 +213,9 @@ func MakeTraceWithTimeRange(requests int, traceID []byte, startTime, endTime uin
 		ResourceSpans: make([]*v1_trace.ResourceSpans, 0),
 	}
 
-	for i := 0; i < requests; i++ {
+	for range requests {
 		timeRange := &batchTimeRange{start: startTime, end: endTime}
-		trace.ResourceSpans = append(trace.ResourceSpans, makeBatchWithTimeRange(rand.Int()%20+1, traceID, timeRange))
+		trace.ResourceSpans = append(trace.ResourceSpans, makeBatchWithTimeRange(rand.Int()%20+1, traceID, timeRange, nil)) // #nosec G40
 	}
 
 	return trace
@@ -218,7 +226,7 @@ func MakeTraceWithSpanCount(requests int, spansEach int, traceID []byte) *tempop
 		ResourceSpans: make([]*v1_trace.ResourceSpans, 0),
 	}
 
-	for i := 0; i < requests; i++ {
+	for range requests {
 		trace.ResourceSpans = append(trace.ResourceSpans, MakeBatch(spansEach, traceID))
 	}
 


### PR DESCRIPTION
Backport: fix: handle collisions with job and instance labels when targetInfo is enabled

