### PR TITLE
[release-v2.9][DOCS] Add link to blog post, video to 2.9 notes

### DIFF
--- a/docs/sources/tempo/release-notes/v2-9.md
+++ b/docs/sources/tempo/release-notes/v2-9.md
@@ -23,6 +23,10 @@ This release gives you:
 
 These release notes highlight the most important features and bug fixes. For a complete list of changes, refer to the [Tempo CHANGELOG](https://github.com/grafana/tempo/releases).
 
+To learn more about this release, refer to the [Tempo 2.9 blog post](https://grafana.com/blog/2025/10/22/grafana-tempo-2-9-release-mcp-server-support-traceql-metrics-sampling-and-more/).
+
+{{< youtube id="dUQQwOsIAP4" >}}
+
 ## Access tracing data with the Tempo MCP server
 
 {{< docs/experimental product="Tempo MCP server" >}}
@@ -40,7 +44,6 @@ Using this feature will likely cause tracing data to be passed to an LLM or LLM 
 The feature is disabled by default and can be enabled per tenant for specific use cases.
 
 Refer to [MCP server](/docs/tempo/<TEMPO_VERSION>/api_docs/mcp-server/) for configuration details and examples.
-.
 
 For more information, refer to [LLM-powered insights into your tracing data: introducing MCP support in Grafana Cloud Traces](https://grafana.com/blog/2025/08/13/llm-powered-insights-into-your-tracing-data-introducing-mcp-support-in-grafana-cloud-traces/).
 


### PR DESCRIPTION
**What this PR does**:

Backports https://github.com/grafana/tempo/pull/5818 to release 2.9. This adds the link to the blog post and video into the 2.9 release notes. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`