### PR TITLE
chore: upgrade xk6-client-tracing to v0.0.9

### DIFF
--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/locally/linux.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/locally/linux.md
@@ -253,7 +253,7 @@ Docker compose uses an internal networking bridge to connect all of the defined 
    ```
    NAME             	IMAGE                                   	COMMAND              	SERVICE         	CREATED         	STATUS          	PORTS
    local-grafana-1  	grafana/grafana:9.3.2                   	"/run.sh"            	grafana         	2 minutes ago   	Up 3 seconds    	0.0.0.0:3000->3000/tcp, :::3000->3000/tcp
-   local-k6-tracing-1   ghcr.io/grafana/xk6-client-tracing:v0.0.2   "/k6-tracing run /ex…"   k6-tracing      	2 minutes ago   	Up 2 seconds
+   local-k6-tracing-1   ghcr.io/grafana/xk6-client-tracing:v0.0.9   "/k6-tracing run /ex…"   k6-tracing      	2 minutes ago   	Up 2 seconds
    local-prometheus-1   prom/prometheus:latest                  	"/bin/prometheus --c…"   prometheus      	2 minutes ago   	Up 2 seconds    	0.0.0.0:9090->9090/tcp, :::9090->9090/tcp
    ```
 

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/test/test-monolithic-local.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/test/test-monolithic-local.md
@@ -113,7 +113,7 @@ Docker compose uses an internal networking bridge to connect all of the defined 
    ```
    NAME             	IMAGE                                   	COMMAND              	SERVICE         	CREATED         	STATUS          	PORTS
    local-grafana-1  	grafana/grafana:9.3.2                   	"/run.sh"            	grafana         	2 minutes ago   	Up 3 seconds    	0.0.0.0:3000->3000/tcp, :::3000->3000/tcp
-   local-k6-tracing-1   ghcr.io/grafana/xk6-client-tracing:v0.0.2   "/k6-tracing run /ex…"   k6-tracing      	2 minutes ago   	Up 2 seconds
+   local-k6-tracing-1   ghcr.io/grafana/xk6-client-tracing:v0.0.9   "/k6-tracing run /ex…"   k6-tracing      	2 minutes ago   	Up 2 seconds
    local-prometheus-1   prom/prometheus:latest                  	"/bin/prometheus --c…"   prometheus      	2 minutes ago   	Up 2 seconds    	0.0.0.0:9090->9090/tcp, :::9090->9090/tcp
    ```
 

--- a/example/docker-compose/alloy/docker-compose.yaml
+++ b/example/docker-compose/alloy/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
 
   # Generate fake traces...
   k6-tracing:
-    image: ghcr.io/grafana/xk6-client-tracing:v0.0.7
+    image: ghcr.io/grafana/xk6-client-tracing:v0.0.9
     environment:
       - ENDPOINT=alloy:4317
     restart: always

--- a/example/docker-compose/alloy/readme.md
+++ b/example/docker-compose/alloy/readme.md
@@ -16,7 +16,7 @@ docker compose ps
 NAME                 IMAGE                                       COMMAND                  SERVICE      CREATED          STATUS         PORTS
 alloy-alloy-1        grafana/alloy:v1.3.1                        "/bin/alloy run /etc…"   alloy        48 seconds ago   Up 5 seconds   0.0.0.0:4319->4319/tcp, 0.0.0.0:12345->12345/tcp
 alloy-grafana-1      grafana/grafana:12.0.0                      "/run.sh"                grafana      48 seconds ago   Up 5 seconds   0.0.0.0:3000->3000/tcp
-alloy-k6-tracing-1   ghcr.io/grafana/xk6-client-tracing:v0.0.7   "/k6-tracing run /ex…"   k6-tracing   48 seconds ago   Up 4 seconds   
+alloy-k6-tracing-1   ghcr.io/grafana/xk6-client-tracing:v0.0.9   "/k6-tracing run /ex…"   k6-tracing   48 seconds ago   Up 4 seconds   
 alloy-prometheus-1   prom/prometheus:latest                      "/bin/prometheus --c…"   prometheus   48 seconds ago   Up 5 seconds   0.0.0.0:9090->9090/tcp
 alloy-tempo-1        grafana/tempo:latest                        "/tempo -config.file…"   tempo        48 seconds ago   Up 5 seconds   0.0.0.0:57508->3200/tcp, 0.0.0.0:57509->4317/tcp, 0.0.0.0:57505->4318/tcp, 0.0.0.0:57506->9411/tcp, 0.0.0.0:57507->14268/tcp
 ```

--- a/example/docker-compose/cross-cluster/docker-compose.yaml
+++ b/example/docker-compose/cross-cluster/docker-compose.yaml
@@ -151,7 +151,7 @@ services:
       - mkdir -p /data/tempo && minio server /data --console-address ':9001'
 
   k6-tracing:
-    image: ghcr.io/grafana/xk6-client-tracing:v0.0.7
+    image: ghcr.io/grafana/xk6-client-tracing:v0.0.9
     environment:
       - ENDPOINT=distributor-a:4317
     restart: always

--- a/example/docker-compose/debug/docker-compose.yaml
+++ b/example/docker-compose/debug/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
       - init
 
   k6-tracing:
-    image: ghcr.io/grafana/xk6-client-tracing:v0.0.7
+    image: ghcr.io/grafana/xk6-client-tracing:v0.0.9
     environment:
       - ENDPOINT=tempo:4317
     restart: always

--- a/example/docker-compose/distributed/docker-compose.yaml
+++ b/example/docker-compose/distributed/docker-compose.yaml
@@ -109,7 +109,7 @@ services:
       - mkdir -p /data/tempo && minio server /data --console-address ':9001'
 
   k6-tracing:
-    image: ghcr.io/grafana/xk6-client-tracing:v0.0.7
+    image: ghcr.io/grafana/xk6-client-tracing:v0.0.9
     environment:
       - ENDPOINT=distributor:4317
     restart: always

--- a/example/docker-compose/ingest-storage/docker-compose.yaml
+++ b/example/docker-compose/ingest-storage/docker-compose.yaml
@@ -228,7 +228,7 @@ services:
       - mkdir -p /data/tempo && minio server /data --console-address ':9001'
 
   k6-tracing:
-    image: ghcr.io/grafana/xk6-client-tracing:v0.0.7
+    image: ghcr.io/grafana/xk6-client-tracing:v0.0.9
     environment:
       - ENDPOINT=distributor:4317
     restart: always

--- a/example/docker-compose/local/docker-compose.yaml
+++ b/example/docker-compose/local/docker-compose.yaml
@@ -38,7 +38,7 @@ services:
       - memcached
 
   k6-tracing:
-    image: ghcr.io/grafana/xk6-client-tracing:v0.0.7
+    image: ghcr.io/grafana/xk6-client-tracing:v0.0.9
     environment:
       - ENDPOINT=tempo:4317
     restart: always

--- a/example/docker-compose/multi-tenant/docker-compose.yaml
+++ b/example/docker-compose/multi-tenant/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
       - init
 
   k6-tracing:
-    image: ghcr.io/grafana/xk6-client-tracing:v0.0.7
+    image: ghcr.io/grafana/xk6-client-tracing:v0.0.9
     environment:
       - ENDPOINT=tempo:4317
       - TEMPO_X_SCOPE_ORGID=test
@@ -40,7 +40,7 @@ services:
       - tempo
 
   k6-tracing-2:
-    image: ghcr.io/grafana/xk6-client-tracing:v0.0.7
+    image: ghcr.io/grafana/xk6-client-tracing:v0.0.9
     environment:
       - ENDPOINT=tempo:4317
       - TEMPO_X_SCOPE_ORGID=test2

--- a/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
+++ b/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
 
   # Generate fake traces...
   k6-tracing:
-    image: ghcr.io/grafana/xk6-client-tracing:v0.0.7
+    image: ghcr.io/grafana/xk6-client-tracing:v0.0.9
     environment:
       - ENDPOINT=otel-collector:4317
     restart: always

--- a/example/docker-compose/otel-collector/docker-compose.yaml
+++ b/example/docker-compose/otel-collector/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
 
   # Generate fake traces...
   k6-tracing:
-    image: ghcr.io/grafana/xk6-client-tracing:v0.0.7
+    image: ghcr.io/grafana/xk6-client-tracing:v0.0.9
     environment:
       - ENDPOINT=otel-collector:4317
     restart: always

--- a/example/docker-compose/scalable-single-binary/docker-compose.yaml
+++ b/example/docker-compose/scalable-single-binary/docker-compose.yaml
@@ -81,7 +81,7 @@ services:
       - 9001:9001
 
   k6-tracing:
-    image: ghcr.io/grafana/xk6-client-tracing:v0.0.7
+    image: ghcr.io/grafana/xk6-client-tracing:v0.0.9
     environment:
       - ENDPOINT=tempo1:4317
     restart: always

--- a/example/helm/microservices-extras.yaml
+++ b/example/helm/microservices-extras.yaml
@@ -40,6 +40,6 @@ spec:
       - env:
         - name: ENDPOINT
           value: tempo-distributor:4317
-        image: ghcr.io/grafana/xk6-client-tracing:v0.0.7
+        image: ghcr.io/grafana/xk6-client-tracing:v0.0.9
         imagePullPolicy: IfNotPresent
         name: xk6-tracing

--- a/example/helm/single-binary-extras.yaml
+++ b/example/helm/single-binary-extras.yaml
@@ -40,6 +40,6 @@ spec:
       - env:
         - name: ENDPOINT
           value: tempo:4317
-        image: ghcr.io/grafana/xk6-client-tracing:v0.0.7
+        image: ghcr.io/grafana/xk6-client-tracing:v0.0.9
         imagePullPolicy: IfNotPresent
         name: xk6-tracing

--- a/example/tk/lib/synthetic-load-generator/main.libsonnet
+++ b/example/tk/lib/synthetic-load-generator/main.libsonnet
@@ -4,7 +4,7 @@
   local deployment = k.apps.v1.deployment,
 
   synthetic_load_generator_container::
-    container.new('synthetic-load-gen', 'ghcr.io/grafana/xk6-client-tracing:v0.0.7') +
+    container.new('synthetic-load-gen', 'ghcr.io/grafana/xk6-client-tracing:v0.0.9') +
     container.withEnvMap({
       ENDPOINT: 'http://tempo:4317',
     }),


### PR DESCRIPTION
**What this PR does**:
Upgrade xk6-client-tracing image to version in examples [v0.0.9](https://github.com/grafana/xk6-client-tracing/releases/tag/v0.0.9)

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`