### PR TITLE
Respect configured S3 part size for compatibility with Cloudflare R2

### DIFF
--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -1029,7 +1029,7 @@ storage:
             secret_key: ""
             session_token: ""
             insecure: false
-            part_size: 104857600
+            part_size: 0
             hedge_requests_at: 0s
             hedge_requests_up_to: 2
             signature_v2: false
@@ -1122,7 +1122,7 @@ overrides:
                 secret_key: ""
                 session_token: ""
                 insecure: false
-                part_size: 104857600
+                part_size: 0
                 hedge_requests_at: 0s
                 hedge_requests_up_to: 2
                 signature_v2: false

--- a/tempodb/backend/s3/config.go
+++ b/tempodb/backend/s3/config.go
@@ -87,7 +87,6 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	f.StringVar(&cfg.SSE.KMSEncryptionContext, util.PrefixConfig(prefix, "s3.sse.kms-encryption-context"), "", "KMS Encryption Context used for object encryption. It expects JSON formatted string.")
 	f.StringVar(&cfg.SSE.CustomerEncryptionKey, util.PrefixConfig(prefix, "s3.sse.encryption-key"), "", "SSE-C Encryption Key used for object encryption.")
 	cfg.HedgeRequestsUpTo = 2
-	cfg.PartSize = 100 * 1024 * 1024 // 100MB default, matches parquet row group size (R2 compliant, min 5MB)
 }
 
 func (cfg *Config) PathMatches(other *Config) bool {


### PR DESCRIPTION
**Respect configured S3 part size for compatibility with Cloudflare R2**:
Upload compaction parts in uniform size except the last chunk to allow usage of Grafana Tempo with Cloudflare R2.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/tempo/issues/4099

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`