### PR TITLE
chore: Increase Renovate concurrent PR limit from 5 to 20

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,7 @@
   "extends": ["config:best-practices"],
   "timezone": "UTC",
   "schedule": ["before 4am on monday"],
-  "prConcurrentLimit": 5,
+  "prConcurrentLimit": 20,
   "ignoreDeps": [],
   "separateMajorMinor": true,
   "separateMultipleMajor": true,


### PR DESCRIPTION
**What this PR does**:

Raises Renovate PR limit to 20 as no issues observed