### PR TITLE
feat: Add automerge configuration for patch updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -70,6 +70,8 @@
     {
       description: 'Automerge patch updates',
       matchUpdateTypes: ['patch'],
+      automergeStrategy: 'squash',
+      automergeType: 'branch',
       automerge: true
     },
   ],


### PR DESCRIPTION
**What this PR does**:

Enables automatic merge of "[patch](https://semver.org/)" level updates

NOTE: this would require changing repo settings to:
* Have a mandatory set of tests to pass before PR can be merged
* Allow Renovate to bypass "required reviewers" rule

Let me know if there are any concerns with either