### PR TITLE
[bugfix] Wrong sleep duration if one of partitions is inactive (#5855)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [BUGFIX] Fix issues related to integer dedicated columns in vParquet5-preview2 [#5716](https://github.com/grafana/tempo/pull/5716) (@stoewer)
 * [BUGFIX] Fix: handle collisions with job and instance labels when targetInfo is enabled [#5774](https://github.com/grafana/tempo/pull/5774) (@javiermolinar)
 * [BUGFIX] Fix search by trace:id for short IDs with leading zeros [#5587](https://github.com/grafana/tempo/pull/5587) (@ruslan-mikhailov)
+* [BUGFIX] Fix wrong sleep duration in block-builder if one of partitions is inactive [#5855](https://github.com/grafana/tempo/pull/5855) (@ruslan-mikhailov)
 * [BUGFIX] Fix S3 compactor multipart upload to ensure Cloudflare R2 compliance by using uniform chunk sizes [#5838](https://github.com/grafana/tempo/pull/5838) (@constantins2001)
 * [BUGFIX] Make top/bottomk deterministic by breaking ties with label vals. [#5846](https://github.com/grafana/tempo/pull/5846) (@joe-elliott)
 * [BUGFIX] Fix GetTrace() in tempo-query. [#5864](https://github.com/grafana/tempo/pull/5864) (@andreasgerstmayr)

--- a/modules/backendworker/backendworker_test.go
+++ b/modules/backendworker/backendworker_test.go
@@ -186,6 +186,10 @@ func newStoreWithLogger(ctx context.Context, t testing.TB, log log.Logger, tmpDi
 
 	s.EnablePolling(ctx, &ownsEverythingSharder{}, false)
 
+	t.Cleanup(func() {
+		s.StopAsync()
+		require.NoError(t, s.AwaitTerminated(context.Background()))
+	})
 	return s
 }
 

--- a/modules/blockbuilder/blockbuilder.go
+++ b/modules/blockbuilder/blockbuilder.go
@@ -292,12 +292,17 @@ func (b *BlockBuilder) consume(ctx context.Context) (time.Duration, error) {
 
 		laggiestPartition := ps[0]
 		if laggiestPartition.lastRecordTs.IsZero() {
-			return b.cfg.ConsumeCycleDuration, nil
+			return b.cfg.ConsumeCycleDuration, errors.New("partition has no last record timestamp")
 		}
 
 		lagTime := time.Since(laggiestPartition.lastRecordTs)
 		if lagTime < b.cfg.ConsumeCycleDuration {
 			return b.cfg.ConsumeCycleDuration - lagTime, nil
+		}
+		// If we don't know exact offset, we need to start over on next cycle to fetch offsets again.
+		// This can happen when pull timeouted or the consumer had no lag.
+		if laggiestPartition.commitOffset == commitOffsetAtEnd {
+			return 0, nil
 		}
 		lastRecordTs, lastRecordOffset, err := b.consumePartition(ctx, laggiestPartition)
 		if err != nil {
@@ -451,7 +456,7 @@ outer:
 		span.AddEvent("no data")
 		// No data means we are caught up
 		ingest.SetPartitionLagSeconds(group, ps.partition, 0)
-		return time.Time{}, commitOffsetAtEnd, nil
+		return time.Now(), commitOffsetAtEnd, nil
 	}
 
 	// Record lag at the end of the consumption

--- a/modules/blockbuilder/blockbuilder_test.go
+++ b/modules/blockbuilder/blockbuilder_test.go
@@ -897,7 +897,11 @@ type ownEverythingSharder struct{}
 func (o *ownEverythingSharder) Owns(string) bool { return true }
 
 func newStore(ctx context.Context, t testing.TB) storage.Store {
-	return newStoreWithLogger(ctx, t, test.NewTestingLogger(t), false)
+	store := newStoreWithLogger(ctx, t, test.NewTestingLogger(t), false)
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), store))
+	})
+	return store
 }
 
 func newStoreWithLogger(ctx context.Context, t testing.TB, log log.Logger, skipNoCompactBlocks bool) storage.Store {
@@ -1106,6 +1110,7 @@ func (s *slowStore) unlock() {
 // - committed offsets equal number of sent records.
 // The test highly coupled with the blockbuilder implementation. In case it stuck
 // due to channel, it is advised to debug consume cycle step by step.
+// If the test hangs, it is most likely because storage received unexpected writes.
 func TestBlockbuilder_twoPartitions_secondEmpty(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	t.Cleanup(func() { cancel(errors.New("test done")) })
@@ -1171,4 +1176,84 @@ func TestBlockbuilder_twoPartitions_secondEmpty(t *testing.T) {
 		require.True(t, ok, "partition %d should have a committed offset", partition)
 		require.Equal(t, expectedOffset, offset.At)
 	}
+}
+
+// TestBlockbuilder_threePartitions_oneWithNoLag verifies that when multiple partitions
+// are assigned and one partition has no lag (is caught up), the block builder efficiently
+// processes only the partitions with data without wasting time polling the caught-up partition.
+// This test ensures that a caught-up partition doesn't block processing of lagging partitions.
+func TestBlockbuilder_PartitionWithNoLag(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(errors.New("test done")) })
+	reqTime := time.Now().Add(-1 * time.Minute) // ensure records won't be filtered out
+	cycleDuration := 7 * time.Second            // increase if test is flaky
+
+	_, address := testkafka.CreateCluster(t, 2, testTopic)
+
+	// Setup block-builder
+	storageWrites := atomic.NewInt32(0)
+	store := newStoreWrapper(newStore(ctx, t), func(ctx context.Context, block tempodb.WriteableBlock, store storage.Store) error {
+		storageWrites.Inc()
+		return store.WriteBlock(ctx, block)
+	})
+	cfg := blockbuilderConfig(t, address, []int32{0, 1})
+	cfg.ConsumeCycleDuration = cycleDuration
+	partitionRing := newPartitionRingReaderWithPartitions(map[int32]ring.PartitionDesc{
+		0: {Id: 0, State: ring.PartitionActive},
+		1: {Id: 1, State: ring.PartitionInactive},
+	})
+
+	client := testkafka.NewKafkaClient(t, cfg.IngestStorageConfig.Kafka.Address, cfg.IngestStorageConfig.Kafka.Topic)
+
+	// Produce data to partition 0
+	for range 10 {
+		testkafka.SendReqWithOpts(ctx, t, client, ingest.Encode, testkafka.ReqOpts{Partition: 0, Time: reqTime, TenantID: util.FakeTenantID})
+	}
+	time.Sleep(2 * cycleDuration) // simulate lag
+	var lastRecordTime time.Time
+	for range 10 {
+		rec := testkafka.SendReqWithOpts(ctx, t, client, ingest.Encode, testkafka.ReqOpts{Partition: 0, Time: reqTime, TenantID: util.FakeTenantID})
+		lastRecordTime = rec[len(rec)-1].Timestamp
+	}
+
+	// Produce and commit one record to partition 1 and commit it (simulating it's already caught up)
+	rec := testkafka.SendReqWithOpts(ctx, t, client, ingest.Encode, testkafka.ReqOpts{Partition: 1, Time: reqTime, TenantID: util.FakeTenantID})
+	offsets := make(kadm.Offsets)
+	offsets.Add(kadm.Offset{
+		Topic:     testTopic,
+		Partition: 1,
+		At:        rec[len(rec)-1].Offset + 1, // Commit past the last record
+	})
+	admClient := kadm.NewClient(client)
+	require.NoError(t, admClient.CommitAllOffsets(ctx, cfg.IngestStorageConfig.Kafka.ConsumerGroup, offsets))
+
+	// Create and start the block builder
+	b, err := New(cfg, test.NewTestingLogger(t), partitionRing, &mockOverrides{}, store)
+	require.NoError(t, err)
+
+	// Verify builder is listening to all partitions
+	parts := b.getAssignedPartitions()
+	require.ElementsMatch(t, []int32{0, 1}, parts)
+
+	require.NoError(t, b.starting(ctx))
+
+	res, err := b.consume(ctx)
+	require.NoError(t, err)
+	elapsed := time.Since(lastRecordTime)
+	assert.InDelta(t, cycleDuration-elapsed, res, float64(100*time.Millisecond))
+	assert.Less(t, res, cycleDuration)
+
+	// Verify offsets - all partitions should be committed
+	offsetsResult, err := admClient.FetchOffsetsForTopics(ctx, testConsumerGroup, testTopic)
+	require.NoError(t, err)
+
+	for partition, expectedCount := range map[int32]int64{
+		0: 20,
+		1: 1,
+	} {
+		offset, ok := offsetsResult.Lookup(testTopic, partition)
+		require.True(t, ok, "partition %d should have a committed offset", partition)
+		assert.Equal(t, expectedCount, offset.At, "partition %d should have correct committed offset", partition)
+	}
+	assert.Equal(t, int32(2), storageWrites.Load(), "unexpected number of storage writes")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: backports #5855
```
git cherry-pick 1af2825f1b49bd2b415036fea8d938b5840d9fd1
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`