### PR TITLE
Increase poll timeout to handle slow Kafka

### DIFF
--- a/modules/blockbuilder/blockbuilder.go
+++ b/modules/blockbuilder/blockbuilder.go
@@ -31,7 +31,6 @@ import (
 const (
 	blockBuilderServiceName = "block-builder"
 	ConsumerGroup           = "block-builder"
-	pollTimeout             = 10 * time.Second
 	cutTime                 = 10 * time.Second
 	emptyPartitionEndOffset = 0  // partition has no records
 	commitOffsetAtEnd       = -1 // offset is at the end of partition
@@ -39,6 +38,7 @@ const (
 )
 
 var (
+	pollTimeout         = 10 * time.Second
 	metricFetchDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace:                   "tempo",
 		Subsystem:                   "block_builder",

--- a/modules/blockbuilder/blockbuilder_test.go
+++ b/modules/blockbuilder/blockbuilder_test.go
@@ -39,6 +39,10 @@ const (
 	testPartition     = int32(0)
 )
 
+func TestMain(*testing.M) {
+	pollTimeout = 2 * time.Second // speed up the tests
+}
+
 // When the partition starts with no existing commit,
 // the block-builder looks back to consume all available records from the start and ensures they are committed and flushed into a block.
 func TestBlockbuilder_lookbackOnNoCommit(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: increases poll timeout. The solution is a short term. Block-builder cannot distinguish when there is no records or Kafka is just slow, the long-term solution should handle timeout situation properly.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`