### PR TITLE
fix: use Renovate's own automerge due to dual set of repo rules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -72,7 +72,8 @@
       matchUpdateTypes: ['patch'],
       automergeStrategy: 'squash',
       automergeType: 'pr',
-      automerge: true
+      automerge: true,
+      platformAutomerge: false
     },
   ],
 }


### PR DESCRIPTION
**What this PR does**:

As tempo repo has dual set of rules (Rulesets+regular branch rules), GitHub's own automerge was set up but did not work. To work around this, this PR switches to using regular Renovate automerge (not GitHub platform one)

**Which issue(s) this PR fixes**:

Should allow this PR: https://github.com/grafana/tempo/pull/5926 to be automerged