### PR TITLE
fix: use proper job selector for livestores memory in use

### DIFF
--- a/operations/tempo-mixin-compiled/dashboards/tempo-resources.json
+++ b/operations/tempo-mixin-compiled/dashboards/tempo-resources.json
@@ -3322,7 +3322,7 @@
      "span": 4,
      "targets": [
       {
-       "expr": "sum by(instance) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/live-store\"})",
+       "expr": "sum by(instance) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/live-store-.*\"})",
        "format": "time_series",
        "interval": "1m",
        "legendFormat": "{{instance}}",

--- a/operations/tempo-mixin/dashboards/tempo-resources.libsonnet
+++ b/operations/tempo-mixin/dashboards/tempo-resources.libsonnet
@@ -157,7 +157,7 @@ dashboard_utils {
           $.containerMemoryWorkingSetPanel('Memory (workingset)', $._config.jobs.live_store),
         )
         .addPanel(
-          $.goHeapInUsePanel('Memory (go heap inuse)', $.jobMatcher($._config.jobs.live_store)),
+          $.goHeapInUsePanel('Memory (go heap inuse)', $.jobMatcher('live-store-.*')),
         )
       ),
   },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Use the proper job selector to include all the live store instances

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`