### PR TITLE
fix: Reverting backport.yml until upstream action is fixed

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,15 +1,15 @@
-# This workflow checks the provided PR and creates backport PRs for each target branch
-# based on the "backport <release>" labels present on the provided PR.
+# This checks merged PRs for labels like "backport release-x.y"
+# and opens a new PR backporting the same commit to the release branch.
+# This workflow also runs when the PR is labeled or opened, but will
+# will only check a few things and detect that the PR is not yet merged.
 # At this time only squashed PRs are supported since the cherry-pick
 # command does not include "-m <n>" arg required for merge commits.
-name: Backport PR
+name: Backport PR Creator
 on:
-  workflow_dispatch:
-   inputs:
-      pr_number:
-        description: 'PR number to backport'
-        required: true
-        type: number
+  pull_request:
+    types:
+      - closed
+      - labeled
 
 permissions: {}
 
@@ -23,10 +23,15 @@ jobs:
       id-token: write
       pull-requests: write
     steps:
-      - name: Checkout
+      - name: Checkout Actions
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
+          repository: "grafana/grafana-github-actions"
+          path: ./actions
+          ref: main
           persist-credentials: false
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
       - name: Get Github App secrets from vault
         id: get-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@2d5a0678eb32b0fd6655b4f7a3a7ec72eaf530ca #get-vault-secrets 1.3.0
@@ -44,10 +49,8 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: tempo
       - name: Run backport
-        uses: grafana/grafana-github-actions-go/backport@main
+        uses: ./actions/backport
         with:
           token: ${{ steps.app-token.outputs.token }}
           labelsToAdd: "backport"
-          repo_owner: grafana
-          repo_name: tempo
-          pr_number: ${{ github.event.inputs.pr_number }}
+          title: "[{{base}}] {{originalTitle}}"


### PR DESCRIPTION
**What this PR does**:

Reverts backport workflow to older version due to discovered incompatibility with grafana/grafana-github-actions-go/backport