### PR TITLE
[registry.LabelBuilder] pool builders

### DIFF
--- a/modules/generator/processor/hostinfo/processor.go
+++ b/modules/generator/processor/hostinfo/processor.go
@@ -53,7 +53,7 @@ func (p *Processor) PushSpans(_ context.Context, req *tempopb.PushSpansRequest) 
 			builder := p.registry.NewLabelBuilder()
 			builder.Add(hostIdentifierAttr, hostID)
 			builder.Add(hostSourceAttr, hostSource)
-			p.gauge.Set(builder.Labels(), 1)
+			p.gauge.Set(builder.CloseAndBuildLabels(), 1)
 		}
 	}
 }

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -348,7 +348,7 @@ func (p *Processor) onComplete(e *store.Edge) {
 		}
 	}
 
-	registryLabelValues := builder.Labels()
+	registryLabelValues := builder.CloseAndBuildLabels()
 
 	p.serviceGraphRequestTotal.Inc(registryLabelValues, 1*e.SpanMultiplier)
 	if e.Failed {

--- a/modules/generator/processor/spanmetrics/spanmetrics.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics.go
@@ -197,7 +197,7 @@ func (p *Processor) aggregateMetricsForSpan(svcName string, jobName string, inst
 
 	spanMultiplier := processor_util.GetSpanMultiplier(p.Cfg.SpanMultiplierKey, span, rs)
 
-	registryLabelValues := builder.Labels()
+	registryLabelValues := builder.CloseAndBuildLabels()
 	if !registryLabelValues.IsValid(model.UTF8Validation) {
 		p.invalidUTF8Counter.Inc()
 		return
@@ -231,7 +231,7 @@ func (p *Processor) aggregateMetricsForSpan(svcName string, jobName string, inst
 			targetInfoBuilder.Add(gen.DimInstance, instanceID)
 		}
 
-		targetInfoRegistryLabelValues := targetInfoBuilder.Labels()
+		targetInfoRegistryLabelValues := targetInfoBuilder.CloseAndBuildLabels()
 
 		// only register target info if at least (job or instance) AND one other attribute are present
 		// TODO - We can move this check to the top

--- a/modules/generator/registry/interface.go
+++ b/modules/generator/registry/interface.go
@@ -14,7 +14,7 @@ type Registry interface {
 
 type LabelBuilder interface {
 	Add(name, value string)
-	Labels() labels.Labels
+	CloseAndBuildLabels() labels.Labels
 }
 
 // Counter

--- a/modules/generator/registry/registry_test.go
+++ b/modules/generator/registry/registry_test.go
@@ -53,7 +53,7 @@ func buildTestLabels(names []string, values []string) labels.Labels {
 	for i := range names {
 		builder.Add(names[i], values[i])
 	}
-	return builder.Labels()
+	return builder.CloseAndBuildLabels()
 }
 
 // TODO: rewrite tests to use mocked limiter instead of this
@@ -329,10 +329,10 @@ func TestManagedRegistry_maxLabelNameLength(t *testing.T) {
 
 	builder := registry.NewLabelBuilder()
 	builder.Add("very_lengthy_label", "very_length_value")
-	counter.Inc(builder.Labels(), 1.0)
+	counter.Inc(builder.CloseAndBuildLabels(), 1.0)
 	builder = registry.NewLabelBuilder()
 	builder.Add("another_very_lengthy_label", "another_very_lengthy_value")
-	histogram.ObserveWithExemplar(builder.Labels(), 1.0, "", 1.0)
+	histogram.ObserveWithExemplar(builder.CloseAndBuildLabels(), 1.0, "", 1.0)
 
 	expectedSamples := []sample{
 		newSample(map[string]string{"__name__": "counter", "very_len": "very_", "__metrics_gen_instance": mustGetHostname()}, 0, 0.0),


### PR DESCRIPTION
This PR adds object pooling to the label builder code. It also defensively drops the reference to the pooled object once it is returned to the pool, to prevent memory corruption.

The allocations were the only thing left annoying me after #5953, so I can be at peace now 😄 

In a dev env, this reduced GC costs by around 50% and total CPU almost halved.

<img width="722" height="308" alt="Screenshot 2025-11-18 at 3 47 52 PM" src="https://github.com/user-attachments/assets/93b50fb6-b9a2-4ff4-a2f8-7a77b0531b05" />
<img width="1052" height="140" alt="Screenshot 2025-11-18 at 3 42 11 PM" src="https://github.com/user-attachments/assets/e776e77f-c87f-42aa-bd32-25d30eea595a" />
<img width="2154" height="702" alt="Screenshot 2025-11-18 at 3 41 22 PM" src="https://github.com/user-attachments/assets/1b9c19c1-f098-47c0-87b9-5a87cf5f9062" />
