### PR TITLE
[DOC] Update admonition for TraceQL metrics

### DIFF
--- a/docs/sources/tempo/shared/traceql-metrics-admonition.md
+++ b/docs/sources/tempo/shared/traceql-metrics-admonition.md
@@ -7,17 +7,18 @@ labels:
     - oss
 ---
 
-[//]: # 'This file creates a caution admonition for TraceQL metrics.'
-[//]: # 'This shared file is included in these locations:'
-[//]: # '/tempo/docs/sources/tempo/traceql/metrics-queries/_index.md'
-[//]: # '/tempo/docs/sources/tempo/traceql/metrics-queries/traceql-metrics-admonition.md'
-[//]: # '/tempo/docs/sources/tempo/traceql/_index.md'
+[//]: # "This file creates a caution admonition for TraceQL metrics."
+[//]: # "This shared file is included in these locations:"
+[//]: # "/tempo/docs/sources/tempo/traceql/metrics-queries/_index.md"
+[//]: # "/tempo/docs/sources/tempo/traceql/metrics-queries/traceql-metrics-admonition.md"
+[//]: # "/tempo/docs/sources/tempo/traceql/_index.md"
 [//]: #
-[//]: # 'If you make changes to this file, verify that the meaning and content are not changed in any place where the file is included.'
-[//]: # 'Any links should be fully qualified and not relative.'
+[//]: # "If you make changes to this file, verify that the meaning and content are not changed in any place where the file is included."
+[//]: # "Any links should be fully qualified and not relative."
 
 <!-- Using a custom admonition because no feature flag is required. -->
+
 {{< admonition type="caution" >}}
 TraceQL metrics is an [experimental feature](/docs/release-life-cycle/). Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided.
-Contact Grafana Support to enable this feature in Grafana Cloud.
+TraceQL metrics are enabled by default in Grafana Cloud.
 {{< /admonition >}}


### PR DESCRIPTION
**What this PR does**:

Updates the TraceQL metrics admonition noting that it's enabled by default in Grafana Cloud. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/support-escalations/issues/19656

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`