### PR TITLE
fix: Alloy invocation in docker-compose recipes

### DIFF
--- a/example/docker-compose/alloy/docker-compose.yaml
+++ b/example/docker-compose/alloy/docker-compose.yaml
@@ -44,6 +44,8 @@ services:
       - /etc/alloy/config.alloy
       - --storage.path=/var/lib/alloy/data
       - --server.http.listen-addr=0.0.0.0:12345
+    environment:
+      - ALLOY_OTLP_UPSTREAM=tempo:4317
     ports:
       - "12345:12345"
       - "4319:4317"

--- a/example/docker-compose/distributed/docker-compose.yaml
+++ b/example/docker-compose/distributed/docker-compose.yaml
@@ -1,3 +1,6 @@
+# Note: this compose file describes obsolete deployment architecture
+# See example/docker-compose/ingest-storage/docker-compose.yaml for newer version
+
 services:
   distributor:
     image: &tempoImage grafana/tempo:latest
@@ -8,9 +11,8 @@ services:
     ports:
       - "3200" # tempo
       - "4317:4317"
-  # Uncomment the following lines to enable tracing
-  #    environment:
-  #      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
 
   ingester-0:
     image: *tempoImage
@@ -20,9 +22,8 @@ services:
       - ./tempo-distributed.yaml:/etc/tempo.yaml
     ports:
       - "3200" # tempo
-  # Uncomment the following lines to enable tracing
-  #    environment:
-  #      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
 
   ingester-1:
     image: *tempoImage
@@ -32,9 +33,8 @@ services:
       - ./tempo-distributed.yaml:/etc/tempo.yaml
     ports:
       - "3200" # tempo
-  # Uncomment the following lines to enable tracing
-  #    environment:
-  #      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
 
   ingester-2:
     image: *tempoImage
@@ -44,9 +44,8 @@ services:
       - ./tempo-distributed.yaml:/etc/tempo.yaml
     ports:
       - "3200" # tempo
-  # Uncomment the following lines to enable tracing
-  #    environment:
-  #      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
 
   query-frontend:
     image: *tempoImage
@@ -56,9 +55,8 @@ services:
       - ./tempo-distributed.yaml:/etc/tempo.yaml
     ports:
       - "3200:3200" # tempo
-  # Uncomment the following lines to enable tracing
-  #    environment:
-  #      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
 
   querier:
     image: *tempoImage
@@ -68,9 +66,8 @@ services:
       - ./tempo-distributed.yaml:/etc/tempo.yaml
     ports:
       - "3200" # tempo
-  # Uncomment the following lines to enable tracing
-  #    environment:
-  #      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
 
   compactor:
     image: *tempoImage
@@ -80,9 +77,8 @@ services:
       - ./tempo-distributed.yaml:/etc/tempo.yaml
     ports:
       - "3200" # tempo
-  # Uncomment the following lines to enable tracing
-  #    environment:
-  #      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
 
   metrics-generator:
     image: *tempoImage
@@ -92,9 +88,8 @@ services:
       - ./tempo-distributed.yaml:/etc/tempo.yaml
     ports:
       - "3200" # tempo
-  # Uncomment the following lines to enable tracing
-  #    environment:
-  #      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
 
   minio:
     image: minio/minio:latest
@@ -141,16 +136,19 @@ services:
       - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor
     ports:
       - "3000:3000"
-# Uncomment the following lines to enable tracing
-# alloy:
-#   image: grafana/alloy:v1.3.1
-#   volumes:
-#     - ../shared/config.alloy:/etc/alloy/config.alloy
-#   command:
-#     - run
-#     - /etc/alloy/config.alloy
-#     - --storage.path=/var/lib/alloy/data
-#     - --server.http.listen-addr=0.0.0.0:12345
-#   ports:
-#     - "12345:12345"
-#     - "4319:4319"
+
+  alloy:
+    image: grafana/alloy:v1.3.1
+    volumes:
+      - ../shared/config.alloy:/etc/alloy/config.alloy
+    command:
+      - run
+      - /etc/alloy/config.alloy
+      - --storage.path=/var/lib/alloy/data
+      - --server.http.listen-addr=0.0.0.0:12345
+    environment:
+      - ALLOY_OTLP_UPSTREAM=distributor:4317
+    ports:
+      - "12345:12345"
+    depends_on:
+      - distributor

--- a/example/docker-compose/ingest-storage/docker-compose.yaml
+++ b/example/docker-compose/ingest-storage/docker-compose.yaml
@@ -21,9 +21,8 @@ services:
       - ./tempo.yaml:/etc/tempo.yaml
     ports:
       - "3200"   # tempo
-  # Uncomment the following lines to enable tracing
-  #    environment:
-  #      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
 
   # ingester-0:
   #   image: *tempoImage
@@ -68,9 +67,8 @@ services:
     ports:
       - "3201:3200"   # tempo
     hostname: live-store-zone-a-0
-  # Uncomment the following lines to enable tracing
-  #    environment:
-  #      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
 
   live-store-zone-a-1:
     image: *tempoImage
@@ -83,9 +81,8 @@ services:
     ports:
       - "3200"   # tempo
     hostname: live-store-zone-a-1
-  # Uncomment the following lines to enable tracing
-  #    environment:
-  #      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
 
   live-store-zone-b-0:
     image: *tempoImage
@@ -98,9 +95,8 @@ services:
     ports:
       - "3200"   # tempo
     hostname: live-store-zone-b-0
-  # Uncomment the following lines to enable tracing
-  #    environment:
-  #      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
 
   live-store-zone-b-1:
     image: *tempoImage
@@ -113,9 +109,8 @@ services:
     ports:
       - "3200"   # tempo
     hostname: live-store-zone-b-1
-  # Uncomment the following lines to enable tracing
-  #    environment:
-  #      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
 
   query-frontend:
     image: *tempoImage
@@ -137,9 +132,8 @@ services:
       - ./tempo.yaml:/etc/tempo.yaml
     ports:
       - "3200"   # tempo
-  # Uncomment the following lines to enable tracing
-  #    environment:
-  #      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
 
   compactor:
     image: *tempoImage
@@ -151,9 +145,8 @@ services:
       - ./tempo.yaml:/etc/tempo.yaml
     ports:
       - "3200"   # tempo
-  # Uncomment the following lines to enable tracing
-  #    environment:
-  #      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
 
   metrics-generator-0:
     image: *tempoImage
@@ -166,9 +159,8 @@ services:
       - ./tempo.yaml:/etc/tempo.yaml
     ports:
       - "3200"   # tempo
-  # Uncomment the following lines to enable tracing
-  #    environment:
-  #      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
 
   metrics-generator-1:
     image: *tempoImage
@@ -181,9 +173,8 @@ services:
       - ./tempo.yaml:/etc/tempo.yaml
     ports:
       - "3200"   # tempo
-  # Uncomment the following lines to enable tracing
-  #    environment:
-  #      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
 
   block-builder-0:
     image: *tempoImage
@@ -196,9 +187,8 @@ services:
       - ./tempo.yaml:/etc/tempo.yaml
     ports:
       - "3200"   # tempo
-  # Uncomment the following lines to enable tracing
-  #    environment:
-  #      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
 
   block-builder-1:
     image: *tempoImage
@@ -211,9 +201,8 @@ services:
       - ./tempo.yaml:/etc/tempo.yaml
     ports:
         - "3200"   # tempo
-  # Uncomment the following lines to enable tracing
-  #    environment:
-  #      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
 
   minio:
     image: minio/minio:latest
@@ -294,3 +283,19 @@ services:
       - "8080:8080"
     "depends_on":
       - "kafka"
+
+  alloy:
+    image: grafana/alloy:v1.3.1
+    volumes:
+      - ../shared/config.alloy:/etc/alloy/config.alloy
+    command:
+      - run
+      - /etc/alloy/config.alloy
+      - --storage.path=/var/lib/alloy/data
+      - --server.http.listen-addr=0.0.0.0:12345
+    environment:
+      - ALLOY_OTLP_UPSTREAM=distributor:4317
+    ports:
+      - "12345:12345"
+    depends_on:
+      - distributor

--- a/example/docker-compose/shared/config.alloy
+++ b/example/docker-compose/shared/config.alloy
@@ -13,7 +13,7 @@ otelcol.receiver.otlp "otlp_receiver" {
 
 otelcol.exporter.otlp "grafanacloud" {
   client {
-    endpoint = "tempo:4317"
+    endpoint = env("ALLOY_OTLP_UPSTREAM")
     tls {
 			insecure = true
 		}


### PR DESCRIPTION
**What this PR does**:

* enables Alloy by default in docker-compose recipes
* fixes shared config
* adds a note pointing to new Rhythm architecture 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`