### PR TITLE
[jsonnet/microservices]: include live-store in withInet6 and target specific config

### DIFF
--- a/operations/jsonnet/microservices/common.libsonnet
+++ b/operations/jsonnet/microservices/common.libsonnet
@@ -76,24 +76,44 @@
           http_listen_address: '::0',
           grpc_listen_address: '::0',
         },
-        ingester+: {
-          lifecycler+: {
-            enable_inet6: true,
-          },
-        },
         memberlist+: {
           bind_addr: ['::'],
         },
+      },
+
+      tempo_compactor_config+: {
         compactor+: {
           ring+: {
             enable_inet6: true,
           },
         },
+      },
+
+      tempo_backend_worker_config+: {
         backend_worker+: {
           ring+: {
             enable_inet6: true,
           },
         },
+      },
+
+      tempo_ingester_config+: {
+        ingester+: {
+          lifecycler+: {
+            enable_inet6: true,
+          },
+        },
+      },
+
+      tempo_live_store_config+: {
+        live_store+: {
+          ring+: {
+            enable_inet6: true,
+          },
+        },
+      },
+
+      tempo_metrics_generator_config+: {
         metrics_generator+: {
           ring+: {
             enable_inet6: true,


### PR DESCRIPTION
**What this PR does**:

Here we include the live-store memberlist configuration in the withInet6 jsonnet utility.

<img width="1173" height="1126" alt="image" src="https://github.com/user-attachments/assets/4f7993a1-cfd8-4bbd-9f8f-a262d920c26c" />

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`