### PR TITLE
ci: Add labels to PRs created by the renovatebot

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,10 +11,6 @@
   ignoreDeps: [],
   separateMajorMinor: true,
   separateMultipleMajor: true,
-  minimumReleaseAge: '14 days',
-  // Prevent PR creation until minimumReleaseAge has passed (blocks the renovate/stability-days check)
-  internalChecksFilter: 'strict',
-  // Add extra labels to PRs, can be used filter PRs created by renovate
   labels: ['dependencies', 'renovate'],
   packageRules: [
     {


### PR DESCRIPTION
**What this PR does**:

Added custom labels so we can filter PRs created by renovatebot with these labels.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`