### PR TITLE
docs: why we use gogo protobuf

### DIFF
--- a/docs/design-proposals/2025-11 Gogo Protobuf.md
+++ b/docs/design-proposals/2025-11 Gogo Protobuf.md
@@ -11,44 +11,43 @@ Last updated: 2025-11-25
 This is a retroactive document, intended to document a decision that has already
 been made.
 
-We use a fork of Protobuf, [`gogo/protobuf`], rather than upstream Protobuf
-libraries. This is fuelled by one major reason: upstream doesn't behave well
+We use a fork of Protobuf, [`gogo/protobuf`], rather than the official
+`google.golang.org/protobuf` or `github.com/golang/protobuf` libraries.
+This is fuelled by one major reason: the official libraries don't behave well
 enough in terms of performance. This is a decision that we inherited from
 OpenTelemetry, see also [this issue](https://github.com/open-telemetry/opentelemetry-collector/issues/7095).
 
-The primary problem with upstream Protobuf, as maintained by Google, is that it
-generates _a lot_ of memory allocations from its lack of supporting embedding
-structs as values rather than pointers. I.e. we often want `[]Value` rather than
-`[]*Value` because we already know all the values are non-null inside.
+The OpenTelemetry issue linked cites the large amount of memory allocations by
+the generated code from the official libraries as a particularly important
+reason for this decision. This is seen in generated code as use of `[]*Value`
+pointer-values instead of `[]Value` value-types.
 
 ## Alternatives
 
-As of writing, there are many alternatives that may be considered in an eventual
-migration in the future, including but not limited to:
+As of writing, there are many alternatives that exist, to varying degrees of
+sufficiency. When we look at migration, read up on the following projects, as
+well as anything that is relevant at that future time:
 
-* [vtprotobuf](https://github.com/planetscale/vtprotobuf)
-* [csproto](https://github.com/CrowdStrike/csproto)
-* [hyperpb](https://github.com/bufbuild/hyperpb-go)
-* [pdatagen](https://github.com/open-telemetry/opentelemetry-collector/tree/974da01f71487422c02fadadb8f66147162fcb14/internal/cmd/pdatagen)
-  * Note that this is an internal tool to OpenTelemetry. It may not be easy to
+- [vtprotobuf](https://github.com/planetscale/vtprotobuf)
+- [csproto](https://github.com/CrowdStrike/csproto)
+- [hyperpb](https://github.com/bufbuild/hyperpb-go)
+- [pdatagen](https://github.com/open-telemetry/opentelemetry-collector/tree/974da01f71487422c02fadadb8f66147162fcb14/internal/cmd/pdatagen)
+  - Note that this is an internal tool to OpenTelemetry. It may not be easy to
     adapt to our needs.
+  - pdatagen does not emit Protobuf code, rather it is used to create wrappers
+    from Protobuf objects. This is useful for them, but exactly how useful it is
+    in our project is unclear; evaluate it with the code-base as it exists at
+    the time of reading.
 
-We notably use the following features, which are required in a potential
-replacement:
+Our primary requirements are:
 
-* `gogoproto.customtype`: this lets us represent a field with a different type
-  than what is strictly prescribed by the Protobuf schema. For example, this
-  lets us represent a `bytes` type as `[16]byte` for a `uuid.UUID`; this saves
-  on memory pressure.
-* `gogoproto.nullable`: this lets us embed values as value structs rather than
-  pointers. E.g. `time.Time` rather than `*time.Time`. We know these values will
-  never be `nil` OR that the zero-type is sufficient to indicate its `nil`-ness,
-  and so we can save ourselves some stack/heap pressure.
-* `gogoproto.stdtime`: use `time.Time` rather than `timestamppb.Timestamp`.
-  This makes for simpler interop with Go.
-* `gogoproto.jsontag`: upstream Protobuf will output JSON tags with snake case.
-  We use camel-case, so e.g. `block_id` => `blockID` (upstream would use
-  `block_id`).
-  * Upstream Protobuf can replicate this with a field-level `[json_name]` tag.
+- Similar or better performance characteristics than `gogo/protobuf` in
+  benchmarks that simulate real-world deployment scenarios. Small regressions
+  can be acceptable; open a proposal with numbers to decide whether a solution
+  is sufficient.
+- The new solution must be either backwards-compatible with the existing encoded
+  data, OR have a clear and simple migration path. Ideally, the migration path
+  does not entail any work for operators, although this can be considered given
+  a thorough proposal.
 
 [`gogo/protobuf`]: https://github.com/gogo/protobuf


### PR DESCRIPTION
The `gogo/protobuf` library is deprecated and abandoned; it has not received any updates in over 4.5 years. As such, it may appear peculiar that we are still dependent on it, rather than some other solution.

At some point, someone else will surely also ask this same question, just like I did. This implements a retroactive design proposal to document why we use this fork, and what we require in a replacement. (These requirements are not currently fulfilled by a single alternative.)

Other references I've used to understand this decision and the alternatives include:
* https://github.com/gogo/protobuf
* https://github.com/CrowdStrike/csproto
* https://github.com/planetscale/vtprotobuf
* https://github.com/golang/protobuf/issues/1225
* https://github.com/open-telemetry/opentelemetry-collector/issues/7095
* https://github.com/bufbuild/hyperpb-go
  * https://mcyoung.xyz/2025/07/16/hyperpb