### PR TITLE
fix: race condition in spss tests

### DIFF
--- a/modules/frontend/search_sharder_test.go
+++ b/modules/frontend/search_sharder_test.go
@@ -1329,7 +1329,6 @@ func TestDefaultSpansPerSpanSet(t *testing.T) {
 		configDefault      uint32
 		requestSpss        string // empty means no spss param
 		expectedSpss       uint32
-		expectError        bool
 		maxSpansPerSpanSet uint32
 	}{
 		{
@@ -1415,12 +1414,7 @@ func TestDefaultSpansPerSpanSet(t *testing.T) {
 				}
 			}
 
-			if tc.expectError {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tc.expectedSpss, capturedSpss, "spss value mismatch")
-			}
+			assert.Equal(t, tc.expectedSpss, capturedSpss, "spss value mismatch")
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does**:
A race condition was added here:

https://github.com/grafana/tempo/pull/5858

```
WARNING: DATA RACE
Read at 0x00c000c6206c by goroutine 50695:
  github.com/grafana/tempo/modules/frontend.TestDefaultSpansPerSpanSet.func1()
      /home/runner/work/tempo/tempo/modules/frontend/search_sharder_test.go:1412 +0x7a9
  testing.tRunner()
      /opt/hostedtoolcache/go/1.25.4/x64/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.25.4/x64/src/testing/testing.go:1997 +0x44

Previous write at 0x00c000c6206c by goroutine 50821:
  github.com/grafana/tempo/modules/frontend.TestDefaultSpansPerSpanSet.func1.1()
make: *** [Makefile:143: test-with-cover-others] Error 1
      /home/runner/work/tempo/tempo/modules/frontend/search_sharder_test.go:1381 +0x73
  github.com/grafana/tempo/modules/frontend/pipeline.AsyncRoundTripperFunc[go.shape.interface { HTTPResponse() *net/http.Response; IsMetadata() bool; RequestData() interface {} }].RoundTrip()
      /home/runner/work/tempo/tempo/modules/frontend/pipeline/pipeline.go:102 +0x47
  github.com/grafana/tempo/modules/frontend/pipeline.AsyncRoundTripperFunc[github.com/grafana/tempo/modules/frontend/combiner.PipelineResponse].RoundTrip()
      /home/runner/work/tempo/tempo/modules/frontend/pipeline/pipeline.go:101 +0x1b
  github.com/grafana/tempo/modules/frontend/pipeline.NewAsyncSharderChan.func1()
      /home/runner/work/tempo/tempo/modules/frontend/pipeline/async_sharding.go:83 +0x187
```

The problem is that `testRT.RoundTrip(pipeline.NewHTTPRequest(req))` returns inmediatelly. So different goroutines can read and write at the same time the variable `capturedSpss`.

To fix it we have to drain the responses by calling Next() which is a blocking operation. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`