### PR TITLE
Refactor to make encodings state if they are writeable or not

### DIFF
--- a/integration/e2e/encodings_test.go
+++ b/integration/e2e/encodings_test.go
@@ -8,7 +8,6 @@ import (
 
 	util2 "github.com/grafana/tempo/integration/util"
 	v2 "github.com/grafana/tempo/tempodb/encoding/v2"
-	"github.com/grafana/tempo/tempodb/encoding/vparquet2"
 
 	"github.com/grafana/e2e"
 	"github.com/stretchr/testify/require"
@@ -29,10 +28,7 @@ const (
 func TestEncodings(t *testing.T) {
 	const repeatedSearchCount = 10
 
-	for _, enc := range encoding.AllEncodings() {
-		if enc.Version() == vparquet2.VersionString {
-			continue // vParquet2 is deprecated
-		}
+	for _, enc := range encoding.AllEncodingsForWrites() {
 		t.Run(enc.Version(), func(t *testing.T) {
 			s, err := e2e.NewScenario("tempo_e2e")
 			require.NoError(t, err)

--- a/modules/generator/processor/localblocks/processor.go
+++ b/modules/generator/processor/localblocks/processor.go
@@ -88,7 +88,7 @@ func New(cfg Config, tenant string, wal *wal.WAL, writer tempodb.Writer, overrid
 
 	enc := encoding.DefaultEncoding()
 	if cfg.Block.Version != "" {
-		enc, err = encoding.FromVersion(cfg.Block.Version)
+		enc, err = encoding.FromVersionForWrites(cfg.Block.Version)
 		if err != nil {
 			return nil, err
 		}

--- a/tempodb/compactor_test.go
+++ b/tempodb/compactor_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/grafana/tempo/tempodb/blockselector"
 	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/grafana/tempo/tempodb/encoding/common"
-	"github.com/grafana/tempo/tempodb/encoding/vparquet2"
 	"github.com/grafana/tempo/tempodb/pool"
 	"github.com/grafana/tempo/tempodb/wal"
 )
@@ -73,11 +72,8 @@ func (m *mockOverrides) MaxCompactionRangeForTenant(_ string) time.Duration {
 }
 
 func TestCompactionRoundtrip(t *testing.T) {
-	for _, enc := range encoding.AllEncodings() {
+	for _, enc := range encoding.AllEncodingsForWrites() {
 		version := enc.Version()
-		if version == vparquet2.VersionString {
-			continue // vParquet2 is deprecated
-		}
 		t.Run(version, func(t *testing.T) {
 			t.Parallel()
 			testCompactionRoundtrip(t, version)
@@ -230,13 +226,9 @@ func testCompactionRoundtrip(t *testing.T, targetBlockVersion string) {
 }
 
 func TestSameIDCompaction(t *testing.T) {
-	for _, enc := range encoding.AllEncodings() {
-		version := enc.Version()
-		if version == vparquet2.VersionString {
-			continue // vParquet2 is deprecated
-		}
-		t.Run(version, func(t *testing.T) {
-			testSameIDCompaction(t, version)
+	for _, enc := range encoding.AllEncodingsForWrites() {
+		t.Run(enc.Version(), func(t *testing.T) {
+			testSameIDCompaction(t, enc.Version())
 		})
 	}
 }
@@ -597,14 +589,10 @@ func TestCompactionIteratesThroughTenants(t *testing.T) {
 }
 
 func TestCompactionHonorsBlockStartEndTimes(t *testing.T) {
-	for _, enc := range encoding.AllEncodings() {
-		version := enc.Version()
-		if version == vparquet2.VersionString {
-			continue // vParquet2 is deprecated
-		}
-		t.Run(version, func(t *testing.T) {
+	for _, enc := range encoding.AllEncodingsForWrites() {
+		t.Run(enc.Version(), func(t *testing.T) {
 			t.Parallel()
-			testCompactionHonorsBlockStartEndTimes(t, version)
+			testCompactionHonorsBlockStartEndTimes(t, enc.Version())
 		})
 	}
 }
@@ -677,14 +665,10 @@ func testCompactionHonorsBlockStartEndTimes(t *testing.T, targetBlockVersion str
 }
 
 func TestCompactionDropsTraces(t *testing.T) {
-	for _, enc := range encoding.AllEncodings() {
-		version := enc.Version()
-		if version == vparquet2.VersionString {
-			continue // vParquet2 is deprecated
-		}
-		t.Run(version, func(t *testing.T) {
+	for _, enc := range encoding.AllEncodingsForWrites() {
+		t.Run(enc.Version(), func(t *testing.T) {
 			t.Parallel()
-			testCompactionDropsTraces(t, version)
+			testCompactionDropsTraces(t, enc.Version())
 		})
 	}
 }
@@ -826,14 +810,10 @@ func TestDoForAtLeast(t *testing.T) {
 }
 
 func TestCompactWithConfig(t *testing.T) {
-	for _, enc := range encoding.AllEncodings() {
-		version := enc.Version()
-		if version == vparquet2.VersionString {
-			continue // vParquet2 is deprecated
-		}
-		t.Run(version, func(t *testing.T) {
+	for _, enc := range encoding.AllEncodingsForWrites() {
+		t.Run(enc.Version(), func(t *testing.T) {
 			t.Parallel()
-			testCompactWithConfig(t, version)
+			testCompactWithConfig(t, enc.Version())
 		})
 	}
 }
@@ -949,13 +929,9 @@ func makeTraceID(i int, j int) []byte {
 }
 
 func BenchmarkCompaction(b *testing.B) {
-	for _, enc := range encoding.AllEncodings() {
-		version := enc.Version()
-		if version == vparquet2.VersionString {
-			continue // vParquet2 is deprecated
-		}
-		b.Run(version, func(b *testing.B) {
-			benchmarkCompaction(b, version)
+	for _, enc := range encoding.AllEncodingsForWrites() {
+		b.Run(enc.Version(), func(b *testing.B) {
+			benchmarkCompaction(b, enc.Version())
 		})
 	}
 }

--- a/tempodb/config.go
+++ b/tempodb/config.go
@@ -190,7 +190,7 @@ func validateConfig(cfg *Config) error {
 		return fmt.Errorf("block config validation failed: %w", err)
 	}
 
-	_, err = encoding.FromVersion(cfg.Block.Version)
+	_, err = encoding.FromVersionForWrites(cfg.Block.Version)
 	if err != nil {
 		return fmt.Errorf("block version validation failed: %w", err)
 	}

--- a/tempodb/config_test.go
+++ b/tempodb/config_test.go
@@ -152,18 +152,7 @@ func TestDeprecatedVersions(t *testing.T) {
 					Version:              "vParquet4",
 				},
 			},
-			expectedConfig: &Config{
-				WAL: &wal.Config{
-					Version: vparquet2.VersionString,
-				},
-				Block: &common.BlockConfig{
-					IndexDownsampleBytes: 1,
-					IndexPageSizeBytes:   1,
-					BloomFP:              0.01,
-					BloomShardSizeBytes:  1,
-					Version:              "vParquet4",
-				},
-			},
+			err: "wal config validation failed: failed to validate block version vParquet2: vParquet2 is not a valid block version for creating blocks",
 		},
 		// block version is deprecaded and Wal is empty
 		{
@@ -177,7 +166,7 @@ func TestDeprecatedVersions(t *testing.T) {
 					Version:              vparquet2.VersionString,
 				},
 			},
-			err: fmt.Errorf(common.DeprecatedError, "vParquet2", "vParquet3").Error(),
+			err: "wal config validation failed: failed to validate block version vParquet2: vParquet2 is not a valid block version for creating blocks",
 		},
 		// block version is deprecated version of encoding
 		{
@@ -209,18 +198,7 @@ func TestDeprecatedVersions(t *testing.T) {
 					Version:              v2.VersionString,
 				},
 			},
-			expectedConfig: &Config{
-				WAL: &wal.Config{
-					Version: vparquet2.VersionString,
-				},
-				Block: &common.BlockConfig{
-					IndexDownsampleBytes: 1,
-					IndexPageSizeBytes:   1,
-					BloomFP:              0.01,
-					BloomShardSizeBytes:  1,
-					Version:              v2.VersionString,
-				},
-			},
+			err: "wal config validation failed: failed to validate block version vParquet2: vParquet2 is not a valid block version for creating blocks",
 		},
 	}
 

--- a/tempodb/encoding/common/config.go
+++ b/tempodb/encoding/common/config.go
@@ -71,6 +71,10 @@ func ValidateConfig(b *BlockConfig) error {
 		return fmt.Errorf("positive value required for bloom-filter shard size")
 	}
 
+	// Check for deprecated version,
+	// TODO - Cyclic dependency makes this awkward to improve by using the
+	// deprecation information in the encoding itself, in the versioned logic
+	// in the parent folder. So we are checking raw strings here.
 	if b.Version == "vParquet2" {
 		return fmt.Errorf(DeprecatedError, "vParquet2", "vParquet3")
 	}

--- a/tempodb/encoding/unsupported/encoding.go
+++ b/tempodb/encoding/unsupported/encoding.go
@@ -26,6 +26,10 @@ func (v Encoding) CompactionSupported() bool {
 	return false
 }
 
+func (v Encoding) WritesSupported() bool {
+	return false
+}
+
 func (v Encoding) OpenBlock(meta *backend.BlockMeta, _ backend.Reader) (common.BackendBlock, error) {
 	return Block{meta: meta}, nil
 }

--- a/tempodb/encoding/v2/encoding.go
+++ b/tempodb/encoding/v2/encoding.go
@@ -27,6 +27,10 @@ func (v Encoding) CompactionSupported() bool {
 	return true
 }
 
+func (v Encoding) WritesSupported() bool {
+	return true
+}
+
 func (v Encoding) OpenBlock(meta *backend.BlockMeta, r backend.Reader) (common.BackendBlock, error) {
 	return NewBackendBlock(meta, r)
 }

--- a/tempodb/encoding/versioned.go
+++ b/tempodb/encoding/versioned.go
@@ -29,7 +29,9 @@ type VersionedEncoding interface {
 	// encoding. It is expected to use internal details for efficiency.
 	NewCompactor(common.CompactionOptions) common.Compactor
 
-	CompactionSupported() bool
+	// Feature detection methods:
+	CompactionSupported() bool // Whether these blocks should be compacted, if false the compactor will ignore these.
+	WritesSupported() bool     // Whether this encoding can create new blocks, or is in deprecated read-only mode.
 
 	// CreateBlock with the given attributes and trace contents.
 	// BlockMeta is used as a container for many options. Required fields:
@@ -90,18 +92,14 @@ func FromVersion(v string) (VersionedEncoding, error) {
 // FromVersionForWrites returns a versioned encoding for the provided string, but only for
 // encodings that are supported for creating new blocks.  Deprecated or readonly encodings will return an error.
 func FromVersionForWrites(v string) (VersionedEncoding, error) {
-	switch v {
-	case v2.VersionString:
-		return v2.Encoding{}, nil
-	case vparquet3.VersionString:
-		return vparquet3.Encoding{}, nil
-	case vparquet4.VersionString:
-		return vparquet4.Encoding{}, nil
-	case vparquet5.VersionString:
-		return vparquet5.Encoding{}, nil
-	default:
+	enc, err := FromVersion(v)
+	if err != nil {
+		return nil, err
+	}
+	if !enc.WritesSupported() {
 		return nil, fmt.Errorf("%s is not a valid block version for creating blocks", v)
 	}
+	return enc, nil
 }
 
 // DefaultEncoding for newly written blocks.
@@ -123,6 +121,17 @@ func AllEncodings() []VersionedEncoding {
 		vparquet4.Encoding{},
 		vparquet5.Encoding{},
 	}
+}
+
+// AllEncodingsForWrites is the list of encodings that can create new blocks.
+func AllEncodingsForWrites() []VersionedEncoding {
+	var writeable []VersionedEncoding
+	for _, enc := range AllEncodings() {
+		if enc.WritesSupported() {
+			writeable = append(writeable, enc)
+		}
+	}
+	return writeable
 }
 
 // OpenBlock for reading in the backend. It automatically chooses the encoding for the given block.

--- a/tempodb/encoding/vparquet2/encoding.go
+++ b/tempodb/encoding/vparquet2/encoding.go
@@ -22,7 +22,11 @@ func (v Encoding) NewCompactor(opts common.CompactionOptions) common.Compactor {
 }
 
 func (v Encoding) CompactionSupported() bool {
-	return true
+	return false
+}
+
+func (v Encoding) WritesSupported() bool {
+	return false
 }
 
 func (v Encoding) OpenBlock(meta *backend.BlockMeta, r backend.Reader) (common.BackendBlock, error) {

--- a/tempodb/encoding/vparquet3/encoding.go
+++ b/tempodb/encoding/vparquet3/encoding.go
@@ -25,6 +25,10 @@ func (v Encoding) CompactionSupported() bool {
 	return true
 }
 
+func (v Encoding) WritesSupported() bool {
+	return true
+}
+
 func (v Encoding) OpenBlock(meta *backend.BlockMeta, r backend.Reader) (common.BackendBlock, error) {
 	return newBackendBlock(meta, r), nil
 }

--- a/tempodb/encoding/vparquet4/encoding.go
+++ b/tempodb/encoding/vparquet4/encoding.go
@@ -25,6 +25,10 @@ func (v Encoding) CompactionSupported() bool {
 	return true
 }
 
+func (v Encoding) WritesSupported() bool {
+	return true
+}
+
 func (v Encoding) OpenBlock(meta *backend.BlockMeta, r backend.Reader) (common.BackendBlock, error) {
 	return newBackendBlock(meta, r), nil
 }

--- a/tempodb/encoding/vparquet5/encoding.go
+++ b/tempodb/encoding/vparquet5/encoding.go
@@ -25,6 +25,10 @@ func (v Encoding) CompactionSupported() bool {
 	return true
 }
 
+func (v Encoding) WritesSupported() bool {
+	return true
+}
+
 func (v Encoding) OpenBlock(meta *backend.BlockMeta, r backend.Reader) (common.BackendBlock, error) {
 	return newBackendBlock(meta, r), nil
 }

--- a/tempodb/retention_test.go
+++ b/tempodb/retention_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/tempo/tempodb/backend/local"
 	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/grafana/tempo/tempodb/encoding/common"
-	"github.com/grafana/tempo/tempodb/encoding/vparquet2"
 	"github.com/grafana/tempo/tempodb/pool"
 	"github.com/grafana/tempo/tempodb/wal"
 )
@@ -281,13 +280,9 @@ func TestBlockRetentionOverrideDisabled(t *testing.T) {
 }
 
 func TestRetainWithConfig(t *testing.T) {
-	for _, enc := range encoding.AllEncodings() {
-		version := enc.Version()
-		if version == vparquet2.VersionString {
-			continue // vParquet2 is deprecated
-		}
-		t.Run(version, func(t *testing.T) {
-			testRetainWithConfig(t, version)
+	for _, enc := range encoding.AllEncodingsForWrites() {
+		t.Run(enc.Version(), func(t *testing.T) {
+			testRetainWithConfig(t, enc.Version())
 		})
 	}
 }

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -250,7 +250,7 @@ func (rw *readerWriter) CompleteBlock(ctx context.Context, block common.WALBlock
 // new block will have the same ID as the input block.
 func (rw *readerWriter) CompleteBlockWithBackend(ctx context.Context, block common.WALBlock, r backend.Reader, w backend.Writer) (common.BackendBlock, error) {
 	// The destination block format:
-	vers, err := encoding.FromVersion(rw.cfg.Block.Version)
+	vers, err := encoding.FromVersionForWrites(rw.cfg.Block.Version)
 	if err != nil {
 		return nil, err
 	}

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -46,11 +46,8 @@ const attributeWithTerminalChars = `{ } ( ) = ~ ! < > & | ^`
 
 func TestSearchCompleteBlock(t *testing.T) {
 	t.Parallel()
-	for _, v := range encoding.AllEncodings() {
+	for _, v := range encoding.AllEncodingsForWrites() {
 		vers := v.Version()
-		if vers == vparquet2.VersionString {
-			continue // vParquet2 is deprecated
-		}
 		t.Run(vers, func(t *testing.T) {
 			t.Parallel()
 			runCompleteBlockSearchTest(t, vers,
@@ -2659,12 +2656,8 @@ func TestSearchForTagsAndTagValues(t *testing.T) {
 }
 
 func TestSearchByShortTraceID(t *testing.T) {
-	for _, v := range encoding.AllEncodings() {
+	for _, v := range encoding.AllEncodingsForWrites() {
 		if v.Version() == v2.VersionString { // no support of the feature in v2
-			continue
-		}
-
-		if v.Version() == vparquet2.VersionString { // vparquet2 is deprecated
 			continue
 		}
 

--- a/tempodb/wal/wal.go
+++ b/tempodb/wal/wal.go
@@ -39,7 +39,7 @@ func (c *Config) RegisterFlags(*flag.FlagSet) {
 }
 
 func (c *Config) Validate() error {
-	if _, err := encoding.FromVersion(c.Version); err != nil {
+	if _, err := encoding.FromVersionForWrites(c.Version); err != nil {
 		return fmt.Errorf("failed to validate block version %s: %w", c.Version, err)
 	}
 
@@ -146,7 +146,7 @@ func (w *WAL) RescanBlocks(additionalStartSlack time.Duration, log log.Logger) (
 }
 
 func (w *WAL) NewBlock(meta *backend.BlockMeta, dataEncoding string) (common.WALBlock, error) {
-	v, err := encoding.FromVersion(w.c.Version)
+	v, err := encoding.FromVersionForWrites(w.c.Version)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does**:
Before deleting vParquet2 (which was deprecated in the last release), this is a refactor to make deprecating and cleaning up encodings easier in the future. We did a lot of work to touch all tests to skip over vParquet2 when it was deprecated, and this formalizes it with a new method `WritesSupported() bool` in the `Encoding` interface, and the helper method `AllEncodingsForWrites()`.  If we just removed the logic, we'd have to touch all tests again when deprecating vParquet3.

Also tightens up a few more places to use `FromVersionForWrites()` when validating block configs, to fail better if a read-only encoding is configured.

**Which issue(s) this PR fixes**:
Fixes n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`