### PR TITLE
Reduce log level for some downscaling logs

### DIFF
--- a/modules/livestore/downscale.go
+++ b/modules/livestore/downscale.go
@@ -64,7 +64,7 @@ func (s *LiveStore) PreparePartitionDownscaleHandler(w http.ResponseWriter, r *h
 			return
 		}
 		if state == ring.PartitionInactive {
-			level.Info(logger).Log("msg", "partition is already set to INACTIVE state")
+			level.Debug(logger).Log("msg", "partition is already set to INACTIVE state")
 			break
 		}
 
@@ -100,7 +100,7 @@ func (s *LiveStore) PreparePartitionDownscaleHandler(w http.ResponseWriter, r *h
 
 			level.Info(logger).Log("msg", "partition downscaling preparation cancelled")
 		} else {
-			level.Info(logger).Log("msg", "partition is not in INACTIVE state, so no need to cancel downscaling", "state", state.String())
+			level.Debug(logger).Log("msg", "partition is not in INACTIVE state, so no need to cancel downscaling", "state", state.String())
 		}
 	case http.MethodGet:
 	default:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Rollout operator repeatedly sends DELETE for active partitions and POST for inactive, which spams logs. This PR reduces log level for the case when partition state has already been set.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`