### PR TITLE
chore: Replace minio with SeaweedFS

### DIFF
--- a/example/docker-compose/cross-cluster/docker-compose.yaml
+++ b/example/docker-compose/cross-cluster/docker-compose.yaml
@@ -138,17 +138,13 @@ services:
     ports:
       - "3200"   # tempo
 
-  minio:
-    image: minio/minio:latest
-    environment:
-      - MINIO_ACCESS_KEY=tempo
-      - MINIO_SECRET_KEY=supersecret
+  seaweedfs:
+    image: chrislusf/seaweedfs:latest
+    command: 'server -s3 -s3.port=9000 -s3.config=/etc/seaweedfs/s3.json -dir=/data'
+    volumes:
+      - ../shared/seaweedfs-s3.json:/etc/seaweedfs/s3.json:ro
     ports:
-      - "9001:9001"
-    entrypoint:
-      - sh
-      - -euc
-      - mkdir -p /data/tempo && minio server /data --console-address ':9001'
+      - "9000:9000"
 
   k6-tracing:
     image: ghcr.io/grafana/xk6-client-tracing:v0.0.9

--- a/example/docker-compose/cross-cluster/tempo-distributed-a.yaml
+++ b/example/docker-compose/cross-cluster/tempo-distributed-a.yaml
@@ -49,7 +49,7 @@ storage:
     backend: s3
     s3:
       bucket: tempo
-      endpoint: minio:9000
+      endpoint: seaweedfs:9000
       access_key: tempo
       secret_key: supersecret
       insecure: true

--- a/example/docker-compose/cross-cluster/tempo-distributed-b.yaml
+++ b/example/docker-compose/cross-cluster/tempo-distributed-b.yaml
@@ -49,7 +49,7 @@ storage:
     backend: s3
     s3:
       bucket: tempo
-      endpoint: minio:9000
+      endpoint: seaweedfs:9000
       access_key: tempo
       secret_key: supersecret
       insecure: true

--- a/example/docker-compose/distributed/docker-compose.yaml
+++ b/example/docker-compose/distributed/docker-compose.yaml
@@ -91,17 +91,13 @@ services:
     environment:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
 
-  minio:
-    image: minio/minio:latest
-    environment:
-      - MINIO_ACCESS_KEY=tempo
-      - MINIO_SECRET_KEY=supersecret
+  seaweedfs:
+    image: chrislusf/seaweedfs:latest
+    command: 'server -s3 -s3.port=9000 -s3.config=/etc/seaweedfs/s3.json -dir=/data'
+    volumes:
+      - ../shared/seaweedfs-s3.json:/etc/seaweedfs/s3.json:ro
     ports:
-      - "9001:9001"
-    entrypoint:
-      - sh
-      - -euc
-      - mkdir -p /data/tempo && minio server /data --console-address ':9001'
+      - "9000:9000"
 
   k6-tracing:
     image: ghcr.io/grafana/xk6-client-tracing:v0.0.9

--- a/example/docker-compose/distributed/tempo-distributed.yaml
+++ b/example/docker-compose/distributed/tempo-distributed.yaml
@@ -50,7 +50,7 @@ storage:
     backend: s3
     s3:
       bucket: tempo
-      endpoint: minio:9000
+      endpoint: seaweedfs:9000
       access_key: tempo
       secret_key: supersecret
       insecure: true

--- a/example/docker-compose/ingest-storage-single-binary/docker-compose.yaml
+++ b/example/docker-compose/ingest-storage-single-binary/docker-compose.yaml
@@ -27,17 +27,13 @@ services:
   #    environment:
   #      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
 
-  minio:
-    image: minio/minio:latest
-    environment:
-      - MINIO_ACCESS_KEY=tempo
-      - MINIO_SECRET_KEY=supersecret
+  seaweedfs:
+    image: chrislusf/seaweedfs:latest
+    command: 'server -s3 -s3.port=9000 -s3.config=/etc/seaweedfs/s3.json -dir=/data'
+    volumes:
+      - ../shared/seaweedfs-s3.json:/etc/seaweedfs/s3.json:ro
     ports:
-      - "9001:9001"
-    entrypoint:
-      - sh
-      - -euc
-      - mkdir -p /data/tempo && minio server /data --console-address ':9001'
+      - "9000:9000"
 
   k6-tracing:
     image: ghcr.io/grafana/xk6-client-tracing:v0.0.9

--- a/example/docker-compose/ingest-storage-single-binary/tempo.yaml
+++ b/example/docker-compose/ingest-storage-single-binary/tempo.yaml
@@ -48,7 +48,7 @@ storage:
     backend: s3
     s3:
       bucket: tempo
-      endpoint: minio:9000
+      endpoint: seaweedfs:9000
       access_key: tempo
       secret_key: supersecret
       insecure: true

--- a/example/docker-compose/ingest-storage/docker-compose.yaml
+++ b/example/docker-compose/ingest-storage/docker-compose.yaml
@@ -172,17 +172,13 @@ services:
     environment:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
 
-  minio:
-    image: minio/minio:latest
-    environment:
-      - MINIO_ACCESS_KEY=tempo
-      - MINIO_SECRET_KEY=supersecret
+  seaweedfs:
+    image: chrislusf/seaweedfs:latest
+    command: 'server -s3 -s3.port=9000 -s3.config=/etc/seaweedfs/s3.json -dir=/data'
+    volumes:
+      - ../shared/seaweedfs-s3.json:/etc/seaweedfs/s3.json:ro
     ports:
-      - "9001:9001"
-    entrypoint:
-      - sh
-      - -euc
-      - mkdir -p /data/tempo && minio server /data --console-address ':9001'
+      - "9000:9000"
 
   k6-tracing:
     image: ghcr.io/grafana/xk6-client-tracing:v0.0.9

--- a/example/docker-compose/ingest-storage/tempo.yaml
+++ b/example/docker-compose/ingest-storage/tempo.yaml
@@ -69,7 +69,7 @@ storage:
     backend: s3
     s3:
       bucket: tempo
-      endpoint: minio:9000
+      endpoint: seaweedfs:9000
       access_key: tempo
       secret_key: supersecret
       insecure: true

--- a/example/docker-compose/scalable-single-binary/docker-compose.yaml
+++ b/example/docker-compose/scalable-single-binary/docker-compose.yaml
@@ -71,14 +71,13 @@ services:
     ports:
       - 3000:3000
 
-  minio:
-    image: minio/minio:latest
-    environment:
-      - MINIO_ROOT_USER=tempo
-      - MINIO_ROOT_PASSWORD=supersecret
-    entrypoint: /bin/sh -c "mc mb --ignore-existing /data/tempo ; minio server /data --console-address ':9001'"
+  seaweedfs:
+    image: chrislusf/seaweedfs:latest
+    command: 'server -s3 -s3.port=9000 -s3.config=/etc/seaweedfs/s3.json -dir=/data'
+    volumes:
+      - ../shared/seaweedfs-s3.json:/etc/seaweedfs/s3.json:ro
     ports:
-      - 9001:9001
+      - "9000:9000"
 
   k6-tracing:
     image: ghcr.io/grafana/xk6-client-tracing:v0.0.9

--- a/example/docker-compose/scalable-single-binary/tempo-scalable-single-binary.yaml
+++ b/example/docker-compose/scalable-single-binary/tempo-scalable-single-binary.yaml
@@ -49,7 +49,7 @@ storage:
       path: /var/tempo/wal             # where to store the wal locally
     s3:
       bucket: tempo                    # how to store data in s3
-      endpoint: minio:9000
+      endpoint: seaweedfs:9000
       access_key: tempo
       secret_key: supersecret
       insecure: true

--- a/example/docker-compose/shared/seaweedfs-s3.json
+++ b/example/docker-compose/shared/seaweedfs-s3.json
@@ -1,0 +1,20 @@
+{
+  "identities": [
+    {
+      "name": "tempo",
+      "credentials": [
+        {
+          "accessKey": "tempo",
+          "secretKey": "supersecret"
+        }
+      ],
+      "actions": [
+        "Admin",
+        "Read",
+        "Write",
+        "List",
+        "Tagging"
+      ]
+    }
+  ]
+}

--- a/example/helm/enterprise.yaml
+++ b/example/helm/enterprise.yaml
@@ -12,7 +12,9 @@ enterpriseGateway:
 gateway:
   enabled: false
 minio:
-  enabled: true
+  # Disabled - using SeaweedFS instead
+  # Deploy SeaweedFS separately and configure the endpoint below
+  enabled: false
   # buckets:
   #   - name: 'enterprise-traces'
   #   - name: 'enterprise-admin'
@@ -23,7 +25,7 @@ storage:
       access_key: 'grafana-tempo'
       secret_key: 'supersecret'
       bucket: 'enterprise-traces'
-      endpoint: 'tempo-minio:9000'
+      endpoint: 'seaweedfs:9000'
       insecure: true
   admin:
     backend: s3
@@ -31,7 +33,7 @@ storage:
       access_key_id: 'grafana-tempo'
       secret_access_key: 'supersecret'
       bucket_name: 'enterprise-traces-admin'
-      endpoint: 'tempo-minio:9000'
+      endpoint: 'seaweedfs:9000'
       insecure: true
 traces:
   otlp:

--- a/example/helm/microservices-tempo-values.yaml
+++ b/example/helm/microservices-tempo-values.yaml
@@ -4,7 +4,9 @@ global:
 gateway:
   enabled: true
 minio:
-  enabled: true
+  # Disabled - using SeaweedFS instead
+  # Deploy SeaweedFS separately and configure the endpoint below
+  enabled: false
 storage:
   trace:
     backend: s3
@@ -12,7 +14,7 @@ storage:
       access_key: 'grafana-tempo'
       secret_key: 'supersecret'
       bucket: 'tempo-traces'
-      endpoint: 'tempo-minio:9000'
+      endpoint: 'seaweedfs:9000'
       insecure: true
 traces:
   otlp:

--- a/example/tk/lib/seaweedfs/seaweedfs.libsonnet
+++ b/example/tk/lib/seaweedfs/seaweedfs.libsonnet
@@ -1,0 +1,54 @@
+{
+  local k = import 'ksonnet-util/kausal.libsonnet',
+  local configMap = k.core.v1.configMap,
+  local container = k.core.v1.container,
+  local containerPort = k.core.v1.containerPort,
+  local deployment = k.apps.v1.deployment,
+  local volumeMount = k.core.v1.volumeMount,
+  local volume = k.core.v1.volume,
+
+  seaweedfs_config_map::
+    configMap.new('seaweedfs-s3-config') +
+    configMap.withData({
+      's3.json': std.manifestJsonEx({
+        identities: [{
+          name: 'tempo',
+          credentials: [{
+            accessKey: 'tempo',
+            secretKey: 'supersecret',
+          }],
+          actions: ['Admin', 'Read', 'Write', 'List', 'Tagging'],
+        }],
+      }, '  '),
+    }),
+
+  seaweedfs_container::
+    container.new('seaweedfs', 'chrislusf/seaweedfs:latest') +
+    container.withPorts([
+      containerPort.new('s3', 9000),
+      containerPort.new('master', 9333),
+    ]) +
+    container.withCommand([
+      'weed',
+      'server',
+      '-s3',
+      '-s3.port=9000',
+      '-s3.config=/etc/seaweedfs/s3.json',
+      '-dir=/data',
+    ]) +
+    container.withVolumeMounts([
+      volumeMount.new('s3-config', '/etc/seaweedfs', readOnly=true),
+    ]),
+
+  seaweedfs_deployment:
+    deployment.new('seaweedfs',
+                   1,
+                   [$.seaweedfs_container],
+                   { app: 'seaweedfs' }) +
+    deployment.mixin.spec.template.spec.withVolumes([
+      volume.fromConfigMap('s3-config', 'seaweedfs-s3-config'),
+    ]),
+
+  seaweedfs_service:
+    k.util.serviceFor($.seaweedfs_deployment),
+}

--- a/example/tk/tempo-microservices/main.jsonnet
+++ b/example/tk/tempo-microservices/main.jsonnet
@@ -2,10 +2,10 @@ local tempo = import '../../../operations/jsonnet/microservices/tempo.libsonnet'
 local dashboards = import 'dashboards/grafana.libsonnet';
 local kafka = import 'kafka/kafka.libsonnet';
 local metrics = import 'metrics/prometheus.libsonnet';
-local minio = import 'minio/minio.libsonnet';
+local seaweedfs = import 'seaweedfs/seaweedfs.libsonnet';
 local load = import 'synthetic-load-generator/main.libsonnet';
 
-minio + metrics + load + kafka + tempo {
+seaweedfs + metrics + load + kafka + tempo {
 
   dashboards:
     dashboards.deploy(),
@@ -69,12 +69,12 @@ minio + metrics + load + kafka + tempo {
     tempo_query_url: 'http://query-frontend:3200',
   },
 
-  // manually overriding to get tempo to talk to minio
+  // manually overriding to get tempo to talk to seaweedfs
   tempo_config+:: {
     storage+: {
       trace+: {
         s3+: {
-          endpoint: 'minio:9000',
+          endpoint: 'seaweedfs:9000',
           access_key: 'tempo',
           secret_key: 'supersecret',
           insecure: true,

--- a/integration/backendscheduler/config.yaml
+++ b/integration/backendscheduler/config.yaml
@@ -27,7 +27,7 @@ storage:
     backend: s3
     s3:
       bucket: tempo
-      endpoint: tempo-integration-minio-9000:9000 # TODO: this is brittle, fix this eventually
+      endpoint: tempo-integration-seaweedfs-9000:9000 # TODO: this is brittle, fix this eventually
       access_key: Cheescake # TODO: use cortex_e2e.MinioAccessKey
       secret_key: supersecret # TODO: use cortex_e2e.MinioSecretKey
       insecure: true

--- a/integration/e2e/api/config-all-in-one-s3-overrides.yaml
+++ b/integration/e2e/api/config-all-in-one-s3-overrides.yaml
@@ -59,7 +59,7 @@ overrides:
       s3:
         # TODO use separate bucket?
         bucket: tempo
-        endpoint: tempo_e2e-minio-9000:9000 # TODO: this is brittle, fix this eventually
+        endpoint: tempo_e2e-seaweedfs-9000:9000 # TODO: this is brittle, fix this eventually
         access_key: Cheescake # TODO: use cortex_e2e.MinioAccessKey
         secret_key: supersecret # TODO: use cortex_e2e.MinioSecretKey
         insecure: true

--- a/integration/e2e/api/config-cross-cluster-a.yaml
+++ b/integration/e2e/api/config-cross-cluster-a.yaml
@@ -27,7 +27,7 @@ storage:
     backend: s3
     s3:
       bucket: tempo
-      endpoint: tempo_active_active-minio-9000:9000 # TODO: this is brittle, fix this eventually
+      endpoint: tempo_active_active-seaweedfs-9000:9000 # TODO: this is brittle, fix this eventually
       access_key: Cheescake # TODO: use cortex_e2e.MinioAccessKey
       secret_key: supersecret # TODO: use cortex_e2e.MinioSecretKey
       insecure: true

--- a/integration/e2e/api/config-cross-cluster-b.yaml
+++ b/integration/e2e/api/config-cross-cluster-b.yaml
@@ -27,7 +27,7 @@ storage:
     backend: s3
     s3:
       bucket: tempo
-      endpoint: tempo_active_active-minio-9000:9000 # TODO: this is brittle, fix this eventually
+      endpoint: tempo_active_active-seaweedfs-9000:9000 # TODO: this is brittle, fix this eventually
       access_key: Cheescake # TODO: use cortex_e2e.MinioAccessKey
       secret_key: supersecret # TODO: use cortex_e2e.MinioSecretKey
       insecure: true

--- a/integration/e2e/deployments/config-all-in-one-s3.yaml
+++ b/integration/e2e/deployments/config-all-in-one-s3.yaml
@@ -58,7 +58,7 @@ overrides:
       s3:
         # TODO use separate bucket?
         bucket: tempo
-        endpoint: tempo_e2e-minio-9000:9000 # TODO: this is brittle, fix this eventually
+        endpoint: tempo_e2e-seaweedfs-9000:9000 # TODO: this is brittle, fix this eventually
         access_key: Cheescake # TODO: use cortex_e2e.MinioAccessKey
         secret_key: supersecret # TODO: use cortex_e2e.MinioSecretKey
         insecure: true

--- a/integration/e2e/deployments/config-microservices.tmpl.yaml
+++ b/integration/e2e/deployments/config-microservices.tmpl.yaml
@@ -32,7 +32,7 @@ storage:
     backend: s3
     s3:
       bucket: tempo
-      endpoint: tempo_e2e-minio-9000:9000 # TODO: this is brittle, fix this eventually
+      endpoint: tempo_e2e-seaweedfs-9000:9000 # TODO: this is brittle, fix this eventually
       access_key: Cheescake # TODO: use cortex_e2e.MinioAccessKey
       secret_key: supersecret # TODO: use cortex_e2e.MinioSecretKey
       insecure: true

--- a/integration/e2e/deployments/config-scalable-single-binary.yaml
+++ b/integration/e2e/deployments/config-scalable-single-binary.yaml
@@ -33,7 +33,7 @@ storage:
     backend: s3
     s3:
       bucket: tempo
-      endpoint: tempo_e2e-minio-9000:9000 # TODO: this is brittle, fix this eventually
+      endpoint: tempo_e2e-seaweedfs-9000:9000 # TODO: this is brittle, fix this eventually
       access_key: Cheescake # TODO: use cortex_e2e.MinioAccessKey
       secret_key: supersecret # TODO: use cortex_e2e.MinioSecretKey
       insecure: true

--- a/integration/e2e/ingest/config-partition-downscale.yaml
+++ b/integration/e2e/ingest/config-partition-downscale.yaml
@@ -62,7 +62,7 @@ storage:
     backend: s3
     s3:
       bucket: tempo
-      endpoint: tempo_e2e-minio-9000:9000 # TODO: this is brittle, fix this eventually
+      endpoint: tempo_e2e-seaweedfs-9000:9000 # TODO: this is brittle, fix this eventually
       access_key: Cheescake # TODO: use cortex_e2e.MinioAccessKey
       secret_key: supersecret # TODO: use cortex_e2e.MinioSecretKey
       insecure: true

--- a/integration/poller/config-s3.yaml
+++ b/integration/poller/config-s3.yaml
@@ -51,7 +51,7 @@ overrides:
       s3:
         # TODO use separate bucket?
         bucket: tempo
-        endpoint: tempo-integration-minio-9000:9000  # TODO: this is brittle, fix this eventually
+        endpoint: tempo-integration-seaweedfs-9000:9000  # TODO: this is brittle, fix this eventually
         access_key: Cheescake # TODO: use cortex_e2e.MinioAccessKey
         secret_key: supersecret # TODO: use cortex_e2e.MinioSecretKey
         insecure: true

--- a/operations/jsonnet/microservices/test/environments/default/main.jsonnet
+++ b/operations/jsonnet/microservices/test/environments/default/main.jsonnet
@@ -54,12 +54,12 @@ tempo {
     overrides+:: {},
   },
 
-  // manually overriding to get tempo to talk to minio
+  // manually overriding to get tempo to talk to seaweedfs
   tempo_config+:: {
     storage+: {
       trace+: {
         s3+: {
-          endpoint: 'minio:9000',
+          endpoint: 'seaweedfs:9000',
           access_key: 'tempo',
           secret_key: 'supersecret',
           insecure: true,


### PR DESCRIPTION
**What this PR does**:

Replaces Minio with SeaweedFS - Apache-licensed open-source S3 implementation

**Which issue(s) this PR fixes**:

Mitigates security risks associated with Minio usage

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`