### PR TITLE
Log configuration warnings without blocking startup

### DIFF
--- a/cmd/tempo/main.go
+++ b/cmd/tempo/main.go
@@ -50,7 +50,8 @@ func main() {
 	mutexProfileFraction := flag.Int("mutex-profile-fraction", 0, "Override default mutex profiling fraction.")
 	blockProfileThreshold := flag.Int("block-profile-threshold", 0, "Override default block profiling threshold.")
 
-	config, _, err := loadConfig()
+	config, configVerify, err := loadConfig()
+	// configVerify is kept for backward compatibility with the CLI-based config verification flow.
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed parsing config: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
Configuration validation warnings are now returned and logged separately,
and no longer prevent Tempo from starting.

This preserves existing production configurations and integration tests
that intentionally trigger warnings.
