### PR TITLE
[DOC] Fix typo in mltp link

### DIFF
--- a/docs/sources/tempo/docker-example.md
+++ b/docs/sources/tempo/docker-example.md
@@ -186,7 +186,7 @@ Now that you've explored the basics of Tempo, you can:
 
 ### Alternative: Complete MLTP example
 
-If you would like to use a demo with multiple telemetry signals, then try the [Introduction to Metrics, Logs, Traces, and Profiling in Grafana](https://github.com/grafana/intro-to-mlpt).
+If you would like to use a demo with multiple telemetry signals, then try the [Introduction to Metrics, Logs, Traces, and Profiling in Grafana](https://github.com/grafana/intro-to-mltp).
 `Intro-to-mltp` provides a self-contained environment for learning about Mimir, Loki, Tempo, Pyroscope, and Grafana.
 The project includes detailed explanations of each component and annotated configurations for a single-instance deployment.
 Data from `intro-to-mltp` can also be pushed to Grafana Cloud.


### PR DESCRIPTION
**What this PR does**:
Fixes a type in the docker-exapmle.md file for intro-to-mltp.

Original PR: https://github.com/grafana/tempo/pull/6076

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`