### PR TITLE
chore: Add buf, protoc and legacy gogofaster proto compiler to tools image

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -3,7 +3,12 @@ FROM golang:1.25.5-alpine@sha256:ac09a5f469f307e5da71e766b0bd59c9c49ea460a528cc3
 ARG TARGETOS
 ARG TARGETARCH
 ENV GOOS=$TARGETOS GOARCH=$TARGETARCH
-RUN apk --update add --no-cache make git bash
+RUN apk --update add --no-cache make git bash protoc
+
+# Use explicit installation instead of tools.go to avoid dependency cross-contamination
+# Ref: https://buf.build/docs/cli/installation/
+RUN GOBIN=/usr/local/bin go install github.com/bufbuild/buf/cmd/buf@v1.63.0
+RUN GOBIN=/usr/local/bin go install github.com/gogo/protobuf/protoc-gen-gogofaster@v1.3.2
 
 WORKDIR /tools
 COPY tools /tools


### PR DESCRIPTION
**What this PR does**:

Adds `buf`, `protoc` and `protoc-gen-gogofaster` tools to `tempo-ci-tools` image in preparation for switching to `buf`

This is a prerequisite for #6130

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`