### PR TITLE
generator: back off when instance creation fails to avoid resource exhaustion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,8 @@
 * [BUGFIX] Fix issue with orphaned group nodes in vParquet5-preview6 [#6095](https://github.com/grafana/tempo/pull/6095) (@stoewer)
 * [BUGFIX] Fix disappearing dedicated event attrs in trace view and dedicated blob column validation in vParquet5-preview6 [#6100](https://github.com/grafana/tempo/pull/6100) (@stoewer)
 * [BUGFIX] Fix response-too-large.md ingestion config example in document [#6116](https://github.com/grafana/tempo/pull/6116) (@gamerslouis)
+* [BUGFIX] generator: back off when instance creation fails to avoid resource exhaustion [#6142](https://github.com/grafana/tempo/pull/6142) (@carles-grafana)
+
 
 # v2.9.0
 

--- a/modules/generator/generator.go
+++ b/modules/generator/generator.go
@@ -45,13 +45,17 @@ const (
 	// contained in the requests. This is intended to be used by clients that send
 	// requests for which span-derived metrics have already been generated elsewhere.
 	NoGenerateMetricsContextKey = "no-generate-metrics"
+
+	// failureBackoff is the duration to wait before retrying failed tenant instance creation.
+	failureBackoff = 1 * time.Minute
 )
 
 var tracer = otel.Tracer("modules/generator")
 
 var (
-	ErrUnconfigured = errors.New("no metrics_generator.storage.path configured, metrics generator will be disabled")
-	ErrReadOnly     = errors.New("metrics-generator is shutting down")
+	ErrUnconfigured            = errors.New("no metrics_generator.storage.path configured, metrics generator will be disabled")
+	ErrReadOnly                = errors.New("metrics-generator is shutting down")
+	errInstanceCreationBackoff = errors.New("instance creation in backoff")
 )
 
 type Generator struct {
@@ -62,8 +66,9 @@ type Generator struct {
 
 	ringLifecycler *ring.BasicLifecycler
 
-	instancesMtx sync.RWMutex
-	instances    map[string]*instance
+	instancesMtx    sync.RWMutex
+	instances       map[string]*instance
+	failedInstances map[string]time.Time // instance -> when creation last failed
 
 	subservices        *services.Manager
 	subservicesWatcher *services.FailureWatcher
@@ -107,7 +112,8 @@ func New(cfg *Config, overrides metricsGeneratorOverrides, reg prometheus.Regist
 		cfg:       cfg,
 		overrides: overrides,
 
-		instances: map[string]*instance{},
+		instances:       map[string]*instance{},
+		failedInstances: map[string]time.Time{},
 
 		store:         store,
 		partitionRing: partitionRing,
@@ -285,6 +291,7 @@ func (g *Generator) PushSpans(ctx context.Context, req *tempopb.PushSpansRequest
 }
 
 func (g *Generator) getOrCreateInstance(instanceID string) (*instance, error) {
+	// Fast path: check with read lock first
 	inst, ok := g.getInstanceByID(instanceID)
 	if ok {
 		return inst, nil
@@ -293,15 +300,28 @@ func (g *Generator) getOrCreateInstance(instanceID string) (*instance, error) {
 	g.instancesMtx.Lock()
 	defer g.instancesMtx.Unlock()
 
-	inst, ok = g.instances[instanceID]
-	if ok {
+	// Double-check after acquiring write lock
+	if inst, ok := g.instances[instanceID]; ok {
 		return inst, nil
+	}
+
+	// Check if this instance creation failed previously
+	if failedAt, ok := g.failedInstances[instanceID]; ok {
+		if time.Since(failedAt) < failureBackoff {
+			return nil, errInstanceCreationBackoff
+		}
+		// Backoff expired, clear the failure and retry
+		delete(g.failedInstances, instanceID)
 	}
 
 	inst, err := g.createInstance(instanceID)
 	if err != nil {
+		g.failedInstances[instanceID] = time.Now()
+		level.Error(g.logger).Log("msg", "instance creation failed, will retry after backoff",
+			"backoff", failureBackoff, "tenant", instanceID, "err", err)
 		return nil, err
 	}
+
 	g.instances[instanceID] = inst
 	return inst, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

When a processor validation fails and the instance creation fails, the generator will attempt again to create it indefinitely,
potentially causing OOM errors.

This change caches failed instances and backs off to prevent the issue.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`