### PR TITLE
compactor: return error if encoding is unsupported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@
 * [BUGFIX] Fix response-too-large.md ingestion config example in document [#6116](https://github.com/grafana/tempo/pull/6116) (@gamerslouis)
 * [BUGFIX] generator: back off when instance creation fails to avoid resource exhaustion [#6142](https://github.com/grafana/tempo/pull/6142) (@carles-grafana)
 * [BUGFIX] Correct handle whitespace or invisible separators in filters in attribute values in tag value search [#6124](https://github.com/grafana/tempo/pull/6124) (@mapno)
+* [BUGFIX] Fix panic when trying to compact block with unsupported encodings such as vParquet previews. [#6209
+](https://github.com/grafana/tempo/pull/6209
+) (@carles-grafana)
 
 
 ### vParquet5

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -289,6 +289,10 @@ func (rw *readerWriter) CompactWithConfig(ctx context.Context, blockMetas []*bac
 		return nil, err
 	}
 
+	if !enc.CompactionSupported() {
+		return nil, fmt.Errorf("compaction not supported for block version %s", blockMetas[0].Version)
+	}
+
 	compactionLevel := CompactionLevelForBlocks(blockMetas)
 	compactionLevelLabel := strconv.Itoa(int(compactionLevel))
 


### PR DESCRIPTION
Otherwise it will panic.
This happens when trying to compact preview blocks.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`