### PR TITLE
return empty response for unsupported blocks instead of nil

### DIFF
--- a/tempodb/encoding/unsupported/block.go
+++ b/tempodb/encoding/unsupported/block.go
@@ -25,7 +25,7 @@ func (b Block) BlockMeta() *backend.BlockMeta {
 }
 
 func (b Block) Search(context.Context, *tempopb.SearchRequest, common.SearchOptions) (*tempopb.SearchResponse, error) {
-	return nil, nil
+	return &tempopb.SearchResponse{}, nil
 }
 
 func (b Block) SearchTags(context.Context, traceql.AttributeScope, common.TagsCallback, common.MetricsCallback, common.SearchOptions) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: return an empty response instead of nil when searching an unsupported block. when the response is nil, we get a `failed with response: 500 body: internal error: nil response\n`

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`