### PR TITLE
[Bugfix] Deadlock on invalid query to api/v2/search/tags (#5607) to v2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # v2.8.3
 * [CHANGE] Upgrade Tempo to Go 1.25.5 [#6096](https://github.com/grafana/tempo/pull/6096) [#6089](https://github.com/grafana/tempo/pull/6089) (@joe-elliott)
+* [BUGFIX] Deadlock on invalid query to api/v2/search/tags (SearchTagsV2) [#5607](https://github.com/grafana/tempo/pull/5607) (@ruslan-mikhailov)
 
 # v2.8.2
 

--- a/integration/e2e/api/api_test.go
+++ b/integration/e2e/api/api_test.go
@@ -103,6 +103,24 @@ func TestSearchTagsV2(t *testing.T) {
 			},
 		},
 		{
+			name:  "invalid query",
+			query: ` { a="test" } `,
+			scope: "none",
+			// same results as no filtering
+			expected: searchTagsV2Response{
+				Scopes: []ScopedTags{
+					{
+						Name: "span",
+						Tags: []string{firstBatch.SpanAttr, secondBatch.SpanAttr},
+					},
+					{
+						Name: "resource",
+						Tags: []string{firstBatch.resourceAttr, secondBatch.resourceAttr, "service.name"},
+					},
+				},
+			},
+		},
+		{
 			name:  "first batch - resource",
 			query: fmt.Sprintf(`{ name="%s" }`, firstBatch.name),
 			scope: "resource",

--- a/modules/ingester/instance_search.go
+++ b/modules/ingester/instance_search.go
@@ -266,10 +266,12 @@ func (i *instance) SearchTagsV2(ctx context.Context, req *tempopb.SearchTagsRequ
 		}, fetcher)
 	}
 
-	i.headBlockMtx.RLock()
-	span.AddEvent("acquired headblock mtx")
-	err = searchBlock(ctx, i.headBlock, "headBlock")
-	i.headBlockMtx.RUnlock()
+	func() { // anon function to defer unlock right after search
+		i.headBlockMtx.RLock()
+		defer i.headBlockMtx.RUnlock()
+		span.AddEvent("acquired headblock mtx")
+		err = searchBlock(ctx, i.headBlock, "headBlock")
+	}()
 	if err != nil {
 		return nil, fmt.Errorf("unexpected error searching head block (%s): %w", i.headBlock.BlockMeta().BlockID, err)
 	}
@@ -541,6 +543,8 @@ func (i *instance) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTag
 				anyErr.Store(fmt.Errorf("unexpected error searching head block (%s): %w", i.headBlock.BlockMeta().BlockID, err))
 			}
 		}()
+	} else {
+		i.headBlockMtx.RUnlock()
 	}
 
 	i.blocksMtx.RLock()

--- a/pkg/traceql/engine.go
+++ b/pkg/traceql/engine.go
@@ -224,7 +224,9 @@ func (e *Engine) ExecuteTagNames(
 		Scope:      scope,
 	}
 
-	span.SetAttributes(attribute.String("pipeline", rootExpr.Pipeline.String()))
+	if rootExpr != nil {
+		span.SetAttributes(attribute.String("pipeline", rootExpr.Pipeline.String()))
+	}
 	span.SetAttributes(attribute.String("autocompleteReq", fmt.Sprint(autocompleteReq)))
 
 	return fetcher.Fetch(ctx, autocompleteReq, cb)

--- a/pkg/traceql/engine_test.go
+++ b/pkg/traceql/engine_test.go
@@ -562,6 +562,29 @@ func TestExamplesInEngine(t *testing.T) {
 	}
 }
 
+func TestExecuteTagNames_InvalidQuery(t *testing.T) {
+	e := NewEngine()
+
+	invalidQuery := "{ invalid syntax }"
+	err := e.ExecuteTagNames(
+		context.Background(),
+		AttributeScopeSpan,
+		invalidQuery,
+		func(string, AttributeScope) bool {
+			return false
+		},
+		&MockTagNamesFetcher{},
+	)
+
+	require.NoError(t, err)
+}
+
+type MockTagNamesFetcher struct{}
+
+func (m *MockTagNamesFetcher) Fetch(context.Context, FetchTagsRequest, FetchTagsCallback) error {
+	return nil
+}
+
 func TestExecuteTagValues(t *testing.T) {
 	// TODO: This test is stupid, it's using the traceql engine to execute the query
 	//  and doesn't actually test the ExecuteTagValues function


### PR DESCRIPTION
+ [Bugfix] Fix potential deadlock in SearchTagValuesV2

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`