### PR TITLE
traceql: canonicalize logical expressions before hashing

### DIFF
--- a/modules/frontend/search_sharder.go
+++ b/modules/frontend/search_sharder.go
@@ -366,6 +366,7 @@ func hashForSearchRequest(searchRequest *tempopb.SearchRequest) uint64 {
 	}
 
 	// forces the query into a canonical form
+	traceql.Normalize(ast)
 	query := ast.String()
 
 	// add the query, limit and spss to the hash

--- a/modules/frontend/search_sharder_test.go
+++ b/modules/frontend/search_sharder_test.go
@@ -1014,6 +1014,10 @@ func TestHashTraceQLQuery(t *testing.T) {
 	h2 = hashForSearchRequest(&tempopb.SearchRequest{Query: "{ span.foo = `bar` || span.bar = `foo` }"})
 	require.Equal(t, h1, h2)
 
+	h1 = hashForSearchRequest(&tempopb.SearchRequest{Query: "{ span.foo = `bar` || span.bar = `foo` }"})
+	h2 = hashForSearchRequest(&tempopb.SearchRequest{Query: "{ span.bar = `foo` || span.foo = `bar` }"})
+	require.Equal(t, h1, h2)
+
 	// different queries should have different hashes
 	h1 = hashForSearchRequest(&tempopb.SearchRequest{Query: "{ span.foo = `bar` }"})
 	h2 = hashForSearchRequest(&tempopb.SearchRequest{Query: "{ span.foo = `baz` }"})

--- a/pkg/traceql/normalize.go
+++ b/pkg/traceql/normalize.go
@@ -30,20 +30,28 @@ func normalizePipelineElement(e PipelineElement) {
 	case *SpansetFilter:
 		normalizeFieldExpr(n.Expression)
 
-	case SpansetOperation:
+	case *SpansetOperation:
 		normalizePipelineElement(n.LHS)
 		normalizePipelineElement(n.RHS)
 
-	case ScalarFilter:
+		if n.Op != OpAnd && n.Op != OpOr {
+			return
+		}
+
+		if n.LHS.String() > n.RHS.String() {
+			n.LHS, n.RHS = n.RHS, n.LHS
+		}
+
+	case *ScalarFilter:
 		normalizeScalarExpr(n.LHS)
 		normalizeScalarExpr(n.RHS)
 
-	case Aggregate:
+	case *Aggregate:
 		if n.e != nil {
 			normalizeFieldExpr(n.e)
 		}
 
-	case GroupOperation:
+	case *GroupOperation:
 		normalizeFieldExpr(n.Expression)
 	}
 }

--- a/pkg/traceql/normalize.go
+++ b/pkg/traceql/normalize.go
@@ -1,0 +1,100 @@
+package traceql
+
+// Normalize rewrites the AST into a canonical form suitable for hashing.
+// It preserves semantics and only reorders commutative logical expressions.
+func Normalize(e Element) {
+	if e == nil {
+		return
+	}
+	normalizeElement(e)
+}
+
+func normalizeElement(e Element) {
+	switch n := e.(type) {
+
+	case *RootExpr:
+		for _, elem := range n.Pipeline.Elements {
+			normalizePipelineElement(elem)
+		}
+
+	case Pipeline:
+		for _, elem := range n.Elements {
+			normalizePipelineElement(elem)
+		}
+	}
+}
+
+func normalizePipelineElement(e PipelineElement) {
+	switch n := e.(type) {
+
+	case *SpansetFilter:
+		normalizeFieldExpr(n.Expression)
+
+	case SpansetOperation:
+		normalizePipelineElement(n.LHS)
+		normalizePipelineElement(n.RHS)
+
+	case ScalarFilter:
+		normalizeScalarExpr(n.LHS)
+		normalizeScalarExpr(n.RHS)
+
+	case Aggregate:
+		if n.e != nil {
+			normalizeFieldExpr(n.e)
+		}
+
+	case GroupOperation:
+		normalizeFieldExpr(n.Expression)
+	}
+}
+
+func normalizeFieldExpr(e FieldExpression) {
+	switch n := e.(type) {
+
+	case *BinaryOperation:
+		normalizeBinaryOperation(n)
+
+	case UnaryOperation:
+		normalizeFieldExpr(n.Expression)
+	}
+}
+
+func normalizeScalarExpr(e ScalarExpression) {
+	switch n := e.(type) {
+
+	case ScalarOperation:
+		normalizeScalarExpr(n.LHS)
+		normalizeScalarExpr(n.RHS)
+
+	case Aggregate:
+		if n.e != nil {
+			normalizeFieldExpr(n.e)
+		}
+	}
+}
+
+func normalizeBinaryOperation(op *BinaryOperation) {
+	if op == nil {
+		return
+	}
+
+	// Normalize children first
+	if op.LHS != nil {
+		normalizeFieldExpr(op.LHS)
+	}
+	if op.RHS != nil {
+		normalizeFieldExpr(op.RHS)
+	}
+
+	// Only reorder commutative logical operators
+	if op.Op != OpAnd && op.Op != OpOr {
+		return
+	}
+
+	leftKey := op.LHS.String()
+	rightKey := op.RHS.String()
+
+	if leftKey > rightKey {
+		op.LHS, op.RHS = op.RHS, op.LHS
+	}
+}

--- a/pkg/traceql/normalize.go
+++ b/pkg/traceql/normalize.go
@@ -3,100 +3,127 @@ package traceql
 // Normalize rewrites the AST into a canonical form suitable for hashing.
 // It preserves semantics and only reorders commutative logical expressions.
 func Normalize(e Element) {
-	if e == nil {
-		return
-	}
-	normalizeElement(e)
-}
-
-func normalizeElement(e Element) {
 	switch n := e.(type) {
-
 	case *RootExpr:
-		for _, elem := range n.Pipeline.Elements {
-			normalizePipelineElement(elem)
+		if n == nil {
+			return
 		}
-
-	case Pipeline:
-		for _, elem := range n.Elements {
-			normalizePipelineElement(elem)
-		}
+		n.Pipeline = normalizePipeline(n.Pipeline)
 	}
 }
 
-func normalizePipelineElement(e PipelineElement) {
+func normalizePipeline(p Pipeline) Pipeline {
+	for i, elem := range p.Elements {
+		p.Elements[i] = normalizePipelineElement(elem)
+	}
+	return p
+}
+
+func normalizePipelineElement(e PipelineElement) PipelineElement {
 	switch n := e.(type) {
+	case Pipeline:
+		return normalizePipeline(n)
 
 	case *SpansetFilter:
-		normalizeFieldExpr(n.Expression)
+		n.Expression = normalizeFieldExpr(n.Expression)
+		return n
 
-	case *SpansetOperation:
-		normalizePipelineElement(n.LHS)
-		normalizePipelineElement(n.RHS)
+	case SpansetOperation:
+		n.LHS = normalizePipelineElement(n.LHS).(SpansetExpression)
+		n.RHS = normalizePipelineElement(n.RHS).(SpansetExpression)
 
-		if n.Op != OpAnd && n.Op != OpOr {
-			return
+		if n.Op != OpSpansetAnd && n.Op != OpSpansetUnion {
+			return n
 		}
 
 		if n.LHS.String() > n.RHS.String() {
 			n.LHS, n.RHS = n.RHS, n.LHS
 		}
+		return n
 
-	case *ScalarFilter:
-		normalizeScalarExpr(n.LHS)
-		normalizeScalarExpr(n.RHS)
-
-	case *Aggregate:
-		if n.e != nil {
-			normalizeFieldExpr(n.e)
-		}
-
-	case *GroupOperation:
-		normalizeFieldExpr(n.Expression)
-	}
-}
-
-func normalizeFieldExpr(e FieldExpression) {
-	switch n := e.(type) {
-
-	case *BinaryOperation:
-		normalizeBinaryOperation(n)
-
-	case UnaryOperation:
-		normalizeFieldExpr(n.Expression)
-	}
-}
-
-func normalizeScalarExpr(e ScalarExpression) {
-	switch n := e.(type) {
-
-	case ScalarOperation:
-		normalizeScalarExpr(n.LHS)
-		normalizeScalarExpr(n.RHS)
+	case ScalarFilter:
+		n.LHS = normalizeScalarExpr(n.LHS)
+		n.RHS = normalizeScalarExpr(n.RHS)
+		return n
 
 	case Aggregate:
 		if n.e != nil {
-			normalizeFieldExpr(n.e)
+			n.e = normalizeFieldExpr(n.e)
 		}
+		return n
+
+	case GroupOperation:
+		n.Expression = normalizeFieldExpr(n.Expression)
+		return n
 	}
+
+	return e
 }
 
-func normalizeBinaryOperation(op *BinaryOperation) {
+func normalizeFieldExpr(e FieldExpression) FieldExpression {
+	switch n := e.(type) {
+	case *BinaryOperation:
+		return normalizeBinaryOperation(n)
+
+	case UnaryOperation:
+		n.Expression = normalizeFieldExpr(n.Expression)
+		return n
+
+	case *UnaryOperation:
+		n.Expression = normalizeFieldExpr(n.Expression)
+		return n
+	}
+
+	return e
+}
+
+func normalizeScalarExpr(e ScalarExpression) ScalarExpression {
+	switch n := e.(type) {
+	case Pipeline:
+		return normalizePipeline(n)
+
+	case ScalarOperation:
+		n.LHS = normalizeScalarExpr(n.LHS)
+		n.RHS = normalizeScalarExpr(n.RHS)
+		return n
+
+	case *ScalarOperation:
+		n.LHS = normalizeScalarExpr(n.LHS)
+		n.RHS = normalizeScalarExpr(n.RHS)
+		return n
+
+	case Aggregate:
+		if n.e != nil {
+			n.e = normalizeFieldExpr(n.e)
+		}
+		return n
+
+	case *Aggregate:
+		if n.e != nil {
+			n.e = normalizeFieldExpr(n.e)
+		}
+		return n
+	}
+
+	return e
+}
+
+func normalizeBinaryOperation(op *BinaryOperation) *BinaryOperation {
 	if op == nil {
-		return
+		return nil
 	}
 
 	// Normalize children first
 	if op.LHS != nil {
-		normalizeFieldExpr(op.LHS)
+		op.LHS = normalizeFieldExpr(op.LHS)
 	}
 	if op.RHS != nil {
-		normalizeFieldExpr(op.RHS)
+		op.RHS = normalizeFieldExpr(op.RHS)
 	}
 
 	// Only reorder commutative logical operators
 	if op.Op != OpAnd && op.Op != OpOr {
-		return
+		return op
 	}
 
 	leftKey := op.LHS.String()
@@ -105,4 +132,6 @@ func normalizeBinaryOperation(op *BinaryOperation) {
 	if leftKey > rightKey {
 		op.LHS, op.RHS = op.RHS, op.LHS
 	}
+
+	return op
 }

--- a/pkg/traceql/normalize_test.go
+++ b/pkg/traceql/normalize_test.go
@@ -1,0 +1,83 @@
+package traceql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalize_OR_Order(t *testing.T) {
+	q1 := `{ span.foo = "bar" || span.bar = "foo" }`
+	q2 := `{ span.bar = "foo" || span.foo = "bar" }`
+
+	ast1, err := Parse(q1)
+	require.NoError(t, err)
+
+	ast2, err := Parse(q2)
+	require.NoError(t, err)
+
+	Normalize(ast1)
+	Normalize(ast2)
+
+	require.Equal(t, ast1.String(), ast2.String())
+}
+
+func TestNormalize_AND_Order(t *testing.T) {
+	q1 := `{ span.foo = "bar" && span.bar = "foo" }`
+	q2 := `{ span.bar = "foo" && span.foo = "bar" }`
+
+	ast1, err := Parse(q1)
+	require.NoError(t, err)
+
+	ast2, err := Parse(q2)
+	require.NoError(t, err)
+
+	Normalize(ast1)
+	Normalize(ast2)
+
+	require.Equal(t, ast1.String(), ast2.String())
+}
+
+func TestNormalize_NestedLogical(t *testing.T) {
+	q1 := `{ (span.a = 1 || span.b = 2) && span.c = 3 }`
+	q2 := `{ span.c = 3 && (span.b = 2 || span.a = 1) }`
+
+	ast1, err := Parse(q1)
+	require.NoError(t, err)
+
+	ast2, err := Parse(q2)
+	require.NoError(t, err)
+
+	Normalize(ast1)
+	Normalize(ast2)
+
+	require.Equal(t, ast1.String(), ast2.String())
+}
+
+func TestNormalize_DoesNotReorderComparisons(t *testing.T) {
+	q := `{ span.duration > 5s }`
+
+	ast, err := Parse(q)
+	require.NoError(t, err)
+
+	before := ast.String()
+	Normalize(ast)
+	after := ast.String()
+
+	require.Equal(t, before, after)
+}
+
+func TestNormalize_Idempotent(t *testing.T) {
+	q := `{ span.foo = "bar" || span.bar = "foo" }`
+
+	ast, err := Parse(q)
+	require.NoError(t, err)
+
+	Normalize(ast)
+	first := ast.String()
+
+	Normalize(ast)
+	second := ast.String()
+
+	require.Equal(t, first, second)
+}

--- a/pkg/traceql/normalize_test.go
+++ b/pkg/traceql/normalize_test.go
@@ -6,69 +6,52 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNormalize_OR_Order(t *testing.T) {
-	q1 := `{ span.foo = "bar" || span.bar = "foo" }`
-	q2 := `{ span.bar = "foo" || span.foo = "bar" }`
+func TestNormalize_CommutativeLogical(t *testing.T) {
+	tests := []struct {
+		name string
+		q1   string
+		q2   string
+	}{
+		{
+			name: "OR simple",
+			q1:   `{ span.foo = "bar" || span.bar = "foo" }`,
+			q2:   `{ span.bar = "foo" || span.foo = "bar" }`,
+		},
+		{
+			name: "AND simple",
+			q1:   `{ span.foo = "bar" && span.bar = "foo" }`,
+			q2:   `{ span.bar = "foo" && span.foo = "bar" }`,
+		},
+		{
+			name: "nested OR",
+			q1:   `{ (span.a = 1 || span.b = 2) || span.c = 3 }`,
+			q2:   `{ span.c = 3 || (span.b = 2 || span.a = 1) }`,
+		},
+		{
+			name: "mixed AND OR",
+			q1:   `{ (span.a = 1 || span.b = 2) && span.c = 3 }`,
+			q2:   `{ span.c = 3 && (span.b = 2 || span.a = 1) }`,
+		},
+	}
 
-	ast1, err := Parse(q1)
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast1, err := Parse(tt.q1)
+			require.NoError(t, err)
 
-	ast2, err := Parse(q2)
-	require.NoError(t, err)
+			ast2, err := Parse(tt.q2)
+			require.NoError(t, err)
 
-	Normalize(ast1)
-	Normalize(ast2)
+			Normalize(ast1)
+			Normalize(ast2)
 
-	require.Equal(t, ast1.String(), ast2.String())
-}
-
-func TestNormalize_AND_Order(t *testing.T) {
-	q1 := `{ span.foo = "bar" && span.bar = "foo" }`
-	q2 := `{ span.bar = "foo" && span.foo = "bar" }`
-
-	ast1, err := Parse(q1)
-	require.NoError(t, err)
-
-	ast2, err := Parse(q2)
-	require.NoError(t, err)
-
-	Normalize(ast1)
-	Normalize(ast2)
-
-	require.Equal(t, ast1.String(), ast2.String())
-}
-
-func TestNormalize_NestedLogical(t *testing.T) {
-	q1 := `{ (span.a = 1 || span.b = 2) && span.c = 3 }`
-	q2 := `{ span.c = 3 && (span.b = 2 || span.a = 1) }`
-
-	ast1, err := Parse(q1)
-	require.NoError(t, err)
-
-	ast2, err := Parse(q2)
-	require.NoError(t, err)
-
-	Normalize(ast1)
-	Normalize(ast2)
-
-	require.Equal(t, ast1.String(), ast2.String())
-}
-
-func TestNormalize_DoesNotReorderComparisons(t *testing.T) {
-	q := `{ span.duration > 5s }`
-
-	ast, err := Parse(q)
-	require.NoError(t, err)
-
-	before := ast.String()
-	Normalize(ast)
-	after := ast.String()
-
-	require.Equal(t, before, after)
+			require.Equal(t, ast1.String(), ast2.String())
+		})
+	}
 }
 
 func TestNormalize_Idempotent(t *testing.T) {
-	q := `{ span.foo = "bar" || span.bar = "foo" }`
+	q := `{ span.a = 1 || span.b = 2 }`
 
 	ast, err := Parse(q)
 	require.NoError(t, err)
@@ -80,4 +63,67 @@ func TestNormalize_Idempotent(t *testing.T) {
 	second := ast.String()
 
 	require.Equal(t, first, second)
+}
+
+func TestNormalize_DoesNotChangeNonCommutative(t *testing.T) {
+	q := `{ span.duration > 5s }`
+
+	ast, err := Parse(q)
+	require.NoError(t, err)
+
+	before := ast.String()
+
+	Normalize(ast)
+
+	after := ast.String()
+
+	require.Equal(t, before, after)
+}
+
+func TestNormalize_Spanset_AND_Order(t *testing.T) {
+	q1 := `({ span.a }) && ({ span.b })`
+	q2 := `({ span.b }) && ({ span.a })`
+
+	ast1, err := Parse(q1)
+	require.NoError(t, err)
+
+	ast2, err := Parse(q2)
+	require.NoError(t, err)
+
+	Normalize(ast1)
+	Normalize(ast2)
+
+	require.Equal(t, ast1.String(), ast2.String())
+}
+
+func TestNormalize_Spanset_OR_Order(t *testing.T) {
+	q1 := `({ span.a }) || ({ span.b })`
+	q2 := `({ span.b }) || ({ span.a })`
+
+	ast1, err := Parse(q1)
+	require.NoError(t, err)
+
+	ast2, err := Parse(q2)
+	require.NoError(t, err)
+
+	Normalize(ast1)
+	Normalize(ast2)
+
+	require.Equal(t, ast1.String(), ast2.String())
+}
+
+func TestNormalize_DifferentExpressionsStayDifferent(t *testing.T) {
+	q1 := `{ span.a = 1 || span.b = 2 }`
+	q2 := `{ span.a = 1 && span.b = 2 }`
+
+	ast1, err := Parse(q1)
+	require.NoError(t, err)
+
+	ast2, err := Parse(q2)
+	require.NoError(t, err)
+
+	Normalize(ast1)
+	Normalize(ast2)
+
+	require.NotEqual(t, ast1.String(), ast2.String())
 }


### PR DESCRIPTION
### What does this PR do?

TraceQL queries that are semantically equivalent but differ in operand order
(e.g. `a || b` vs `b || a`) currently produce different cache keys because the
AST is stringified without canonicalization.

This PR introduces a normalization pass over the TraceQL AST that canonicalizes
commutative logical expressions (`AND` / `OR`) before stringification and hashing.

### Why is this needed?

- Improves cache hit rate for equivalent TraceQL queries
- Prevents redundant backend work
- Preserves existing query semantics and execution behavior

### What changed?

- Added an AST normalization pass for TraceQL
- Canonicalized `AND` / `OR` binary operations recursively
- Invoked normalization before query hashing
- Added unit tests covering:
  - `AND` / `OR` commutativity
  - Nested logical expressions
  - Non-commutative safety

### Testing

- `go test ./pkg/traceql -p 1`
- `go test ./modules/frontend -p 1`

fix: #6214
Full test suite is covered by CI.
