### PR TITLE
[DOC] [release-v2.9] Update 2.9.1. release notes 

### DIFF
--- a/docs/sources/tempo/release-notes/v2-9.md
+++ b/docs/sources/tempo/release-notes/v2-9.md
@@ -211,7 +211,7 @@ The following updates were made to address security issues.
 
 ### 2.9.1
 
-- Updated Go to version 1.25.5 to address [CVE-2025-61729](https://github.com/advisories/GHSA-7c64-f9jr-v9h2), [CVE-2025-47907](https://github.com/advisories/GHSA-j5pm-7495-qmr3), [CVE-2025-58183](https://github.com/advisories/GHSA-9gcr-gp5f-jw27), and [CVE-2025-61727](https://github.com/advisories/GHSA-5mh9-3jwc-rp59). [[PR 6089](https://github.com/grafana/tempo/pull/6089), [PR 6096](https://github.com/grafana/tempo/pull/6096), [PR 6233](https://github.com/grafana/tempo/pull/6233)]
+- Updated Go to version 1.25.5 to address [CVE-2025-61729](https://github.com/advisories/GHSA-7c64-f9jr-v9h2), [CVE-2025-47907](https://github.com/advisories/GHSA-j5pm-7495-qmr3), [CVE-2025-58183](https://github.com/advisories/GHSA-9gcr-gp5f-jw27), and [CVE-2025-61727](https://github.com/advisories/GHSA-5mh9-3jwc-rp59). [[PR 6089](https://github.com/grafana/tempo/pull/6089), [PR 6096](https://github.com/grafana/tempo/pull/6096), [PR 6233](https://github.com/grafana/tempo/pull/6233)] 
 - Updated `golang.org/x/crypto` to address [CVE-2025-47914](https://github.com/advisories/GHSA-f6x5-jh6r-wrfv), and [CVE-2025-58181](https://github.com/advisories/GHSA-j5w8-q4qc-rx2x). [[PR 6235](https://github.com/grafana/tempo/pull/6235)]
 - Updated `github.com/expr-lang/expr` to v1.17.7 to address [CVE-2025-68156](https://github.com/expr-lang/expr/security/advisories/GHSA-cfpf-hrx2-8rv6). [[PR 6234](https://github.com/grafana/tempo/pull/6234)]
 


### PR DESCRIPTION
**What this PR does**:

For release 2.9.1. Adds new security section listing the CVEs fixed in this release. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/tempo/issues/6244

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`