### PR TITLE
Tempo 2.7 Changelog: Add proper breaking change warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -391,7 +391,7 @@ querier:
   Due to this, Tempo installations running inside Docker have to update the address they listen.
   For more details on this change, see [#4465](https://github.com/grafana/tempo/issues/4465)
   For more information about the security risk this change addresses, see https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md#safeguards-against-denial-of-service-attacks
-* [CHANGE] **BREAKING CHANGE** By default attributes are truncated to 2KB [#4335](https://github.com/grafana/tempo/pull/4335) (@ie-pham)
+* [CHANGE] **BREAKING CHANGE** By default, attributes are truncated to 2KB. [#4335](https://github.com/grafana/tempo/pull/4335) (@ie-pham)
 * [CHANGE] Replace `cespare/xxhash` with `cespare/xxhash/v2` [#4485](https://github.com/grafana/tempo/pull/4485) (@Juneezee)
 * [CHANGE] chore: remove gofakeit dependency [#4274](https://github.com/grafana/tempo/pull/4274) (@javiermolinar)
 * [CHANGE] Chore: delete spanlogger. [4312](https://github.com/grafana/tempo/pull/4312) (@javiermolinar)


### PR DESCRIPTION
As pointed out #4335 is a breaking change b/c it truncates span attributes to 2KB by default. After this PR is merged which corrects the changelog, I will update the [2.7.0 release](https://github.com/grafana/tempo/releases/tag/v2.7.0)