### PR TITLE
feat(frontend): add traceID to query range response logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 * [CHANGE] Set traceQL query metrics checks by default in Vulture [#6275](https://github.com/grafana/tempo/pull/6275) (@javiermolinar)
 * [FEATURE] Add span_multiplier_key to overrides. This allows tenants to specify the attribute key used for span multiplier values to compensate for head-based sampling. [#6260](https://github.com/grafana/tempo/pull/6260) (@carles-grafana)
-* [ENHANCEMENT] Add traceID to query range response logs for easier navigation from logs to traces [#<PR_NUMBER>](https://github.com/grafana/tempo/pull/<PR_NUMBER>) (@FaqihMSY)
 * [BUGFIX] Correct avg_over_time calculation [#6252](https://github.com/grafana/tempo/pull/6252) (@ruslan-mikhailov)
 
 ### 3.0 Cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [CHANGE] Set traceQL query metrics checks by default in Vulture [#6275](https://github.com/grafana/tempo/pull/6275) (@javiermolinar)
 * [FEATURE] Add span_multiplier_key to overrides. This allows tenants to specify the attribute key used for span multiplier values to compensate for head-based sampling. [#6260](https://github.com/grafana/tempo/pull/6260) (@carles-grafana)
+* [ENHANCEMENT] Add traceID to query range response logs for easier navigation from logs to traces [#<PR_NUMBER>](https://github.com/grafana/tempo/pull/<PR_NUMBER>) (@FaqihMSY)
 * [BUGFIX] Correct avg_over_time calculation [#6252](https://github.com/grafana/tempo/pull/6252) (@ruslan-mikhailov)
 
 ### 3.0 Cleanup

--- a/modules/frontend/metrics_query_range_handler.go
+++ b/modules/frontend/metrics_query_range_handler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/traceql"
+	"github.com/grafana/tempo/pkg/util/tracing"
 )
 
 // newQueryRangeStreamingGRPCHandler returns a handler that streams results from the HTTP handler
@@ -57,6 +58,7 @@ func newQueryRangeStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripp
 
 		httpReq = httpReq.WithContext(ctx)
 		tenant, _ := user.ExtractOrgID(ctx)
+		traceID, _ := tracing.ExtractTraceID(ctx)
 		start := time.Now()
 
 		var finalResponse *tempopb.QueryRangeResponse
@@ -79,7 +81,7 @@ func newQueryRangeStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripp
 			bytesProcessed = finalResponse.Metrics.InspectedBytes
 		}
 		postSLOHook(nil, tenant, bytesProcessed, duration, err)
-		logQueryRangeResult(logger, tenant, duration.Seconds(), req, finalResponse, err)
+		logQueryRangeResult(logger, tenant, traceID, duration.Seconds(), req, finalResponse, err)
 		return err
 	}
 }
@@ -93,6 +95,7 @@ func newMetricsQueryRangeHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper
 		if errResp != nil {
 			return errResp, nil
 		}
+		traceID, _ := tracing.ExtractTraceID(req.Context())
 		start := time.Now()
 
 		if dataAccessController != nil {
@@ -135,16 +138,17 @@ func newMetricsQueryRangeHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper
 
 		duration := time.Since(start)
 		postSLOHook(resp, tenant, bytesProcessed, duration, err)
-		logQueryRangeResult(logger, tenant, duration.Seconds(), queryRangeReq, queryRangeResp, err)
+		logQueryRangeResult(logger, tenant, traceID, duration.Seconds(), queryRangeReq, queryRangeResp, err)
 		return resp, err
 	})
 }
 
-func logQueryRangeResult(logger log.Logger, tenantID string, durationSeconds float64, req *tempopb.QueryRangeRequest, resp *tempopb.QueryRangeResponse, err error) {
+func logQueryRangeResult(logger log.Logger, tenantID string, traceID string, durationSeconds float64, req *tempopb.QueryRangeRequest, resp *tempopb.QueryRangeResponse, err error) {
 	if resp == nil {
 		level.Info(logger).Log(
 			"msg", "query range response - no resp",
 			"tenant", tenantID,
+			"traceID", traceID,
 			"duration_seconds", durationSeconds,
 			"error", err)
 
@@ -155,6 +159,7 @@ func logQueryRangeResult(logger log.Logger, tenantID string, durationSeconds flo
 		level.Info(logger).Log(
 			"msg", "query range response - no metrics",
 			"tenant", tenantID,
+			"traceID", traceID,
 			"query", req.Query,
 			"range_nanos", req.End-req.Start,
 			"duration_seconds", durationSeconds,
@@ -165,6 +170,7 @@ func logQueryRangeResult(logger log.Logger, tenantID string, durationSeconds flo
 	level.Info(logger).Log(
 		"msg", "query range response",
 		"tenant", tenantID,
+		"traceID", traceID,
 		"query", req.Query,
 		"range_nanos", req.End-req.Start,
 		"max_series", req.MaxSeries,


### PR DESCRIPTION
**What this PR does**:
Adds `traceID` field to all query range response log statements in the query frontend. This enables easy navigation from logs to traces for that request, following the existing pattern in `handler.go`.

**Which issue(s) this PR fixes**:
Fixes #6280

**Verification**:
Verified manually via local compilation on Windows:
-  `gofmt -w` formatting applied
-  `go build ./modules/frontend/` -> PASSED
-  `go test ./modules/frontend/` -> PASSED (no tests to run, 0.192s)
-   No changes to dependencies (go.mod/vendor)

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`