### PR TITLE
renovate: automatically patch release versions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,7 +42,7 @@
   packageRules: [
     {
       description: 'Disable all non-vulnerability updates for releases',
-      matchBaseBranches: ['/^release-/'],
+      matchBaseBranches: ['/^release-v.*/'],
       matchPackageNames: ['*'],
       enabled: false,
     },


### PR DESCRIPTION
**What this PR does**:

Enables Renovate to patch release branches in addition to `main`, to reduce CVE numbers

Configuration based on: https://docs.renovatebot.com/presets-security/#securityonly-security-updates
