### PR TITLE
fix(traceql): rename 'before' parameter to 'after' in TrimToAfter function

### DIFF
--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -108,12 +108,12 @@ func TrimToBefore(req *tempopb.QueryRangeRequest, before time.Time) {
 
 // TrimToAfter shortens the query window to only include after the given time.
 // Request must be in unix nanoseconds already.
-func TrimToAfter(req *tempopb.QueryRangeRequest, before time.Time) {
+func TrimToAfter(req *tempopb.QueryRangeRequest, after time.Time) {
 	wasInstant := IsInstant(req)
-	beforeNs := uint64(before.UnixNano())
+	afterNs := uint64(after.UnixNano())
 
-	req.Start = max(req.Start, beforeNs)
-	req.End = max(req.End, beforeNs)
+	req.Start = max(req.Start, afterNs)
+	req.End = max(req.End, afterNs)
 
 	if wasInstant {
 		// Maintain instant nature of the request


### PR DESCRIPTION
## Summary
- Fixed a copy-paste error in the `TrimToAfter` function in `pkg/traceql/engine_metrics.go`
- Renamed the parameter from `before` to `after` to match the function's purpose
- Renamed the local variable from `beforeNs` to `afterNs` for consistency

## Background
The `TrimToAfter` function was clearly copied from `TrimToBefore`, but the parameter and variable names were not updated. While the logic was correct (using `max()` instead of `min()`), the naming was confusing and inconsistent:

**Before:**
```go
func TrimToAfter(req *tempopb.QueryRangeRequest, before time.Time) {
    beforeNs := uint64(before.UnixNano())
    req.Start = max(req.Start, beforeNs)
```

**After:**
```go
func TrimToAfter(req *tempopb.QueryRangeRequest, after time.Time) {
    afterNs := uint64(after.UnixNano())
    req.Start = max(req.Start, afterNs)
```

## Testing
- All existing tests pass
- Build passes