### PR TITLE
[jsonnet]: ensure with-extras compiled output is checked

### DIFF
--- a/operations/jsonnet-compiled/Makefile
+++ b/operations/jsonnet-compiled/Makefile
@@ -25,6 +25,13 @@ check: check-examples
 check-examples: check-example/microservices check-example/microservices-with-extras
 
 check-example/%: gen-example/%
-	git diff --exit-code -- ../$*/gen/*.yaml
+	@# Check for modified tracked files
+	git diff --exit-code -- $*/gen
+	@# Check for untracked files (new files not yet in git)
+	@if [ -n "$$(git ls-files --others --exclude-standard $*/gen)" ]; then \
+		echo "Error: Untracked files found in $*/gen:"; \
+		git ls-files --others --exclude-standard $*/gen; \
+		exit 1; \
+	fi
 
 .PHONY: gen gen-examples gen-example/% check check-examples check-example/% jb jb-check


### PR DESCRIPTION
**What this PR does**:
In #6272 we included a "with extras" jsonnet compiled output such that we can configure features and know the output separate from the defaults, but we failed to include the make target to check the results.

Here we include the missing check for the "with extras" jsonnet compiled output.  We also fix an issue in the previous approach to catch new and deleted files.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`