### PR TITLE
Add .gitattributes: enable text normalization and union merge for CHANGELOG.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+CHANGELOG.md merge=union


### PR DESCRIPTION
Motivation: reduce number of merge conflicts in CHANGELOG.md