### PR TITLE
enhancement: Remove runtime.GC calls from hot path

### DIFF
--- a/tempodb/encoding/vparquet4/compactor.go
+++ b/tempodb/encoding/vparquet4/compactor.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"runtime"
 	"sync"
 	"time"
 
@@ -185,7 +184,6 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 
 		// Flush existing block data if the next trace can't fit
 		if currentBlock.EstimatedBufferedBytes() > 0 && currentBlock.EstimatedBufferedBytes()+estimateMarshalledSizeFromParquetRow(lowestObject) > c.opts.BlockConfig.RowGroupSizeBytes {
-			runtime.GC()
 			err = c.appendBlock(ctx, currentBlock, l)
 			if err != nil {
 				return nil, fmt.Errorf("error writing partial block: %w", err)
@@ -202,7 +200,6 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 
 		// Flush again if block is already full.
 		if currentBlock.EstimatedBufferedBytes() > c.opts.BlockConfig.RowGroupSizeBytes {
-			runtime.GC()
 			err = c.appendBlock(ctx, currentBlock, l)
 			if err != nil {
 				return nil, fmt.Errorf("error writing partial block: %w", err)

--- a/tempodb/encoding/vparquet4/create.go
+++ b/tempodb/encoding/vparquet4/create.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"runtime"
 
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/pkg/dataquality"
@@ -110,7 +109,6 @@ func CreateBlock(ctx context.Context, cfg *common.BlockConfig, meta *backend.Blo
 			if err != nil {
 				return nil, err
 			}
-			runtime.GC()
 		}
 	}
 

--- a/tempodb/encoding/vparquet5/compactor.go
+++ b/tempodb/encoding/vparquet5/compactor.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"runtime"
 	"sync"
 	"time"
 
@@ -185,7 +184,6 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 
 		// Flush existing block data if the next trace can't fit
 		if currentBlock.EstimatedBufferedBytes() > 0 && currentBlock.EstimatedBufferedBytes()+estimateMarshalledSizeFromParquetRow(lowestObject) > c.opts.BlockConfig.RowGroupSizeBytes {
-			runtime.GC()
 			err = c.appendBlock(ctx, currentBlock, l)
 			if err != nil {
 				return nil, fmt.Errorf("error writing partial block: %w", err)
@@ -202,7 +200,6 @@ func (c *Compactor) Compact(ctx context.Context, l log.Logger, r backend.Reader,
 
 		// Flush again if block is already full.
 		if currentBlock.EstimatedBufferedBytes() > c.opts.BlockConfig.RowGroupSizeBytes {
-			runtime.GC()
 			err = c.appendBlock(ctx, currentBlock, l)
 			if err != nil {
 				return nil, fmt.Errorf("error writing partial block: %w", err)

--- a/tempodb/encoding/vparquet5/create.go
+++ b/tempodb/encoding/vparquet5/create.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"runtime"
 
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/pkg/dataquality"
@@ -111,7 +110,6 @@ func CreateBlock(ctx context.Context, cfg *common.BlockConfig, meta *backend.Blo
 			if err != nil {
 				return nil, err
 			}
-			runtime.GC()
 		}
 	}
 


### PR DESCRIPTION
**What this PR does**:

Removes `runtime.GC` calls from hot path, as we already have `GOMEMLIMIT` set

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`