### PR TITLE
[DOC] Clarify dimension_mappings config for span  metrics

### DIFF
--- a/docs/sources/tempo/metrics-from-traces/span-metrics/span-metrics-metrics-generator.md
+++ b/docs/sources/tempo/metrics-from-traces/span-metrics/span-metrics-metrics-generator.md
@@ -142,6 +142,8 @@ You can use `dimension_mappings` to rename a single attribute to a different lab
 The `source_labels` field must contain the **original span or resource attribute names** (with dots), not sanitized Prometheus label names. For example, use `deployment.environment`, not `deployment_environment`.
 {{< /admonition >}}
 
+The `name` field can use either dots (`.`) or underscores (`_`), as both are converted to underscores (`_`) in the final Prometheus metric labels. For example, both `env` and `env.label` result in `env_label` in Prometheus metrics.
+
 The following example shows how to rename the `deployment.environment` attribute to a shorter label called `env`, for example:
 
 ```yaml


### PR DESCRIPTION
**What this PR does**:
Updates the span metrics documentation to fix accuracy issues, add missing feature documentation, and clarify dimension_mappings configuration to address GitHub issue #3376.

* Corrected "two metrics" to "three metrics" and added the missing `traces_spanmetrics_size_total` counter
* Clarified that `job`, `instance`, and `status_message` are optional labels requiring additional configuration, not defaults
* Added section on disabling intrinsic dimensions with `intrinsic_dimensions` configuration
* Added section on enabling specific metrics using subprocessors (`span-metrics-latency`, `span-metrics-count`, `span-metrics-size`)
* Added section on excluding dimensions from `target_info` using `target_info_excluded_dimensions`
* Added section heading for sampled traces handling

**Which issue(s) this PR fixes**:
Fixes #3376 

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`