### PR TITLE
Fix metrics generator panic when write_relabel_configs is set 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [BUGFIX] Correct instant query calculation for rate() [#6205](https://github.com/grafana/tempo/pull/6205) (@ruslan-mikhailov)
 * [BUGFIX] Fix live-store deadlock occurring after a complete block failure [#6338](https://github.com/grafana/tempo/pull/6338) (@ruslan-mikhailov)
 * [BUGFIX] generator: fix dimension_mappings and target_info_excluded_dimensions being unconditionally overwritten even when overrides were nil [#6390](https://github.com/grafana/tempo/pull/6390) (@carles-grafana)
+* [BUGFIX] generator: fix panic when `write_relabel_configs` is configured on remote write endpoints [#6396](https://github.com/grafana/tempo/pull/6396) (@carles-grafana)
 
 ### 3.0 Cleanup
 

--- a/modules/generator/config.go
+++ b/modules/generator/config.go
@@ -131,6 +131,10 @@ func (cfg *Config) Validate() error {
 		}
 	}
 
+	if err := cfg.Storage.Validate(); err != nil {
+		return err
+	}
+
 	if !slices.Contains(validCodecs, cfg.Codec) {
 		return fmt.Errorf("invalid codec: %s, valid choices are %s", cfg.Codec, validCodecs)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Fix metrics generator panic when write_relabel_configs is set (#6396)

  The Prometheus dependency upgrade from v0.304.2 to v0.307.3 (PR
  prometheus/prometheus#16928) moved label name validation from a global
  to a per-config NameValidationScheme field on relabel.Config. This field
  must be initialized by calling Validate() before use, otherwise
  relabeling panics with "Invalid name validation scheme requested: unset".

  Tempo constructs RemoteWriteConfig programmatically rather than going
  through Prometheus's config.Load() path, so Validate() was never called.

  Call RemoteWriteConfig.Validate(model.UTF8Validation) once at startup
  in storage.Config.Validate(), which initializes NameValidationScheme on
  all write relabel configs before any tenant storage instances are created.

  Also fix a pre-existing bug in watchOverrides where cached state was
  updated before ApplyConfig succeeded, preventing retries on failure.

**Which issue(s) this PR fixes**:
Fixes #6396 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`