### PR TITLE
enhancement: Remove legacy `mem-ballast-size-mbs` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [CHANGE] **BREAKING CHANGE** Remove Opencensus receiver [#6523](https://github.com/grafana/tempo/pull/6523) (@javiermolinar)
 * [ENHANCEMENT] Block builder: deduplicate spans within traces during block creation and track removed duplicates via `tempo_block_builder_spans_deduped_total` metric [#6539](https://github.com/grafana/tempo/pull/6539) (@zhxiaogg)
 * [CHANGE] Upgrade Tempo to Go 1.26.0 [#6443](https://github.com/grafana/tempo/pull/6443) (@stoewer)
+* [CHANGE] **BREAKING CHANGE** Remove legacy `mem-ballast-size-mbs` cli flag. [#6403](https://github.com/grafana/tempo/pull/6403) (@orkhan-huseyn)
 * [CHANGE] Allow duplicate dimensions for span metrics and service graphs. This is a valid use case if using different instrumentation libraries, with spans having "deployment.environment" and others "deployment_environment", for example. [#6288](https://github.com/grafana/tempo/pull/6288) (@carles-grafana)
 * [CHANGE] Updade default max duration for traceql metrics queries up to one day [#6285](https://github.com/grafana/tempo/pull/6285) (@javiermolinar)
 * [CHANGE] Set traceQL query metrics checks by default in Vulture [#6275](https://github.com/grafana/tempo/pull/6275) (@javiermolinar)

--- a/cmd/tempo/main.go
+++ b/cmd/tempo/main.go
@@ -48,7 +48,6 @@ func main() {
 	printVersion := flag.Bool("version", false, "Print this builds version information")
 	healthCheck := flag.Bool("health", false, "Run a health check against the /ready endpoint and exit")
 	healthURL := flag.String("health.url", defaultHealthURL, "URL to check when running health check")
-	ballastMBs := flag.Int("mem-ballast-size-mbs", 0, "Size of memory ballast to allocate in MBs.")
 	mutexProfileFraction := flag.Int("mutex-profile-fraction", 0, "Override default mutex profiling fraction.")
 	blockProfileThreshold := flag.Int("block-profile-threshold", 0, "Override default block profiling threshold.")
 
@@ -98,9 +97,6 @@ func main() {
 
 	setMutexBlockProfiling(*mutexProfileFraction, *blockProfileThreshold)
 
-	// Allocate a block of memory to alter GC behaviour. See https://github.com/golang/go/issues/23044
-	ballast := make([]byte, *ballastMBs*1024*1024)
-
 	// Start Tempo
 	t, err := app.New(*config)
 	if err != nil {
@@ -118,7 +114,6 @@ func main() {
 		level.Error(log.Logger).Log("msg", "error running Tempo", "err", err)
 		os.Exit(1)
 	}
-	runtime.KeepAlive(ballast)
 }
 
 func configIsValid(config *app.Config) bool {

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/command-line-flags.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/command-line-flags.md
@@ -16,7 +16,6 @@ Tempo provides various command-line flags to configure its behavior when startin
 | Flag | Description | Default |
 | --- | --- | --- |
 | `--version` | Print this build's version information and exit | `false` |
-| `--mem-ballast-size-mbs` | Size of memory ballast to allocate in MBs | `0` |
 | `--mutex-profile-fraction` | Override default mutex profiling fraction | `0` |
 | `--block-profile-threshold` | Override default block profiling threshold | `0` |
 | `--config.file` | Configuration file to load | |

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-distributor.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-distributor.yaml
@@ -28,7 +28,6 @@ spec:
       containers:
       - args:
         - -config.file=/conf/tempo.yaml
-        - -mem-ballast-size-mbs=1024
         - -target=distributor
         image: grafana/tempo:latest
         imagePullPolicy: IfNotPresent

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-metrics-generator.yaml
@@ -26,7 +26,6 @@ spec:
       containers:
       - args:
         - -config.file=/conf/tempo.yaml
-        - -mem-ballast-size-mbs=1024
         - -target=metrics-generator
         image: grafana/tempo:latest
         name: metrics-generator

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-querier.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-querier.yaml
@@ -28,7 +28,6 @@ spec:
       containers:
       - args:
         - -config.file=/conf/tempo.yaml
-        - -mem-ballast-size-mbs=1024
         - -target=querier
         image: grafana/tempo:latest
         imagePullPolicy: IfNotPresent

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-query-frontend.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-query-frontend.yaml
@@ -26,7 +26,6 @@ spec:
       containers:
       - args:
         - -config.file=/conf/tempo.yaml
-        - -mem-ballast-size-mbs=1024
         - -target=query-frontend
         image: grafana/tempo:latest
         imagePullPolicy: IfNotPresent

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-backend-scheduler.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-backend-scheduler.yaml
@@ -22,7 +22,6 @@ spec:
       containers:
       - args:
         - -config.file=/conf/tempo.yaml
-        - -mem-ballast-size-mbs=1024
         - -target=backend-scheduler
         image: grafana/tempo:latest
         imagePullPolicy: IfNotPresent

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-backend-worker.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-backend-worker.yaml
@@ -22,7 +22,6 @@ spec:
       containers:
       - args:
         - -config.file=/conf/tempo.yaml
-        - -mem-ballast-size-mbs=1024
         - -target=backend-worker
         image: grafana/tempo:latest
         imagePullPolicy: IfNotPresent

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-block-builder.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-block-builder.yaml
@@ -26,7 +26,6 @@ spec:
       containers:
       - args:
         - -config.file=/conf/tempo.yaml
-        - -mem-ballast-size-mbs=1024
         - -target=block-builder
         image: grafana/tempo:latest
         imagePullPolicy: IfNotPresent

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-live-store-zone-a.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-live-store-zone-a.yaml
@@ -51,7 +51,6 @@ spec:
       containers:
       - args:
         - -config.file=/conf/tempo.yaml
-        - -mem-ballast-size-mbs=1024
         - -target=live-store
         - -live-store.instance-availability-zone=zone-a
         image: grafana/tempo:latest

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-live-store-zone-b.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-live-store-zone-b.yaml
@@ -52,7 +52,6 @@ spec:
       containers:
       - args:
         - -config.file=/conf/tempo.yaml
-        - -mem-ballast-size-mbs=1024
         - -target=live-store
         - -live-store.instance-availability-zone=zone-b
         image: grafana/tempo:latest

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-metrics-generator.yaml
@@ -31,7 +31,6 @@ spec:
       containers:
       - args:
         - -config.file=/conf/tempo.yaml
-        - -mem-ballast-size-mbs=1024
         - -target=metrics-generator
         image: grafana/tempo:latest
         name: metrics-generator

--- a/operations/jsonnet-compiled/microservices/gen/Deployment-distributor.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/Deployment-distributor.yaml
@@ -28,7 +28,6 @@ spec:
       containers:
       - args:
         - -config.file=/conf/tempo.yaml
-        - -mem-ballast-size-mbs=1024
         - -target=distributor
         image: grafana/tempo:latest
         imagePullPolicy: IfNotPresent

--- a/operations/jsonnet-compiled/microservices/gen/Deployment-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/Deployment-metrics-generator.yaml
@@ -26,7 +26,6 @@ spec:
       containers:
       - args:
         - -config.file=/conf/tempo.yaml
-        - -mem-ballast-size-mbs=1024
         - -target=metrics-generator
         image: grafana/tempo:latest
         name: metrics-generator

--- a/operations/jsonnet-compiled/microservices/gen/Deployment-querier.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/Deployment-querier.yaml
@@ -28,7 +28,6 @@ spec:
       containers:
       - args:
         - -config.file=/conf/tempo.yaml
-        - -mem-ballast-size-mbs=1024
         - -target=querier
         image: grafana/tempo:latest
         imagePullPolicy: IfNotPresent

--- a/operations/jsonnet-compiled/microservices/gen/Deployment-query-frontend.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/Deployment-query-frontend.yaml
@@ -26,7 +26,6 @@ spec:
       containers:
       - args:
         - -config.file=/conf/tempo.yaml
-        - -mem-ballast-size-mbs=1024
         - -target=query-frontend
         image: grafana/tempo:latest
         imagePullPolicy: IfNotPresent

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-backend-scheduler.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-backend-scheduler.yaml
@@ -22,7 +22,6 @@ spec:
       containers:
       - args:
         - -config.file=/conf/tempo.yaml
-        - -mem-ballast-size-mbs=1024
         - -target=backend-scheduler
         image: grafana/tempo:latest
         imagePullPolicy: IfNotPresent

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-backend-worker.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-backend-worker.yaml
@@ -22,7 +22,6 @@ spec:
       containers:
       - args:
         - -config.file=/conf/tempo.yaml
-        - -mem-ballast-size-mbs=1024
         - -target=backend-worker
         image: grafana/tempo:latest
         imagePullPolicy: IfNotPresent

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-block-builder.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-block-builder.yaml
@@ -26,7 +26,6 @@ spec:
       containers:
       - args:
         - -config.file=/conf/tempo.yaml
-        - -mem-ballast-size-mbs=1024
         - -target=block-builder
         image: grafana/tempo:latest
         imagePullPolicy: IfNotPresent

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-live-store-zone-a.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-live-store-zone-a.yaml
@@ -51,7 +51,6 @@ spec:
       containers:
       - args:
         - -config.file=/conf/tempo.yaml
-        - -mem-ballast-size-mbs=1024
         - -target=live-store
         - -live-store.instance-availability-zone=zone-a
         image: grafana/tempo:latest

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-live-store-zone-b.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-live-store-zone-b.yaml
@@ -52,7 +52,6 @@ spec:
       containers:
       - args:
         - -config.file=/conf/tempo.yaml
-        - -mem-ballast-size-mbs=1024
         - -target=live-store
         - -live-store.instance-availability-zone=zone-b
         image: grafana/tempo:latest

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-metrics-generator.yaml
@@ -31,7 +31,6 @@ spec:
       containers:
       - args:
         - -config.file=/conf/tempo.yaml
-        - -mem-ballast-size-mbs=1024
         - -target=metrics-generator
         image: grafana/tempo:latest
         name: metrics-generator

--- a/operations/jsonnet/microservices/backend-scheduler.libsonnet
+++ b/operations/jsonnet/microservices/backend-scheduler.libsonnet
@@ -22,7 +22,6 @@
   tempo_backend_scheduler_args:: {
     target: target_name,
     'config.file': '/conf/tempo.yaml',
-    'mem-ballast-size-mbs': $._config.ballast_size_mbs,
   },
 
   tempo_backend_scheduler_pvc::

--- a/operations/jsonnet/microservices/backend-worker.libsonnet
+++ b/operations/jsonnet/microservices/backend-worker.libsonnet
@@ -20,7 +20,6 @@
   tempo_backend_worker_args:: {
     target: target_name,
     'config.file': '/conf/tempo.yaml',
-    'mem-ballast-size-mbs': $._config.ballast_size_mbs,
   },
 
   tempo_backend_worker_container::

--- a/operations/jsonnet/microservices/block-builder.libsonnet
+++ b/operations/jsonnet/microservices/block-builder.libsonnet
@@ -21,7 +21,6 @@
   tempo_block_builder_args:: {
     target: target_name,
     'config.file': '/conf/tempo.yaml',
-    'mem-ballast-size-mbs': $._config.ballast_size_mbs,
   },
 
   tempo_block_builder_follow_controller:: $.tempo_live_store_zone_a_statefulset,

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -173,7 +173,6 @@
       tempoMetricsBackoffDuration: '0s',  // TraceQL Metrics checks disabled
       tempoLongWriteBackoffDuration: '50s',
     },
-    ballast_size_mbs: '1024',
     port: 3200,
     http_api_prefix: '',
     gossip_ring_port: 7946,

--- a/operations/jsonnet/microservices/distributor.libsonnet
+++ b/operations/jsonnet/microservices/distributor.libsonnet
@@ -15,7 +15,6 @@
   tempo_distributor_args:: {
     target: target_name,
     'config.file': '/conf/tempo.yaml',
-    'mem-ballast-size-mbs': $._config.ballast_size_mbs,
   },
 
   tempo_distributor_container::

--- a/operations/jsonnet/microservices/frontend.libsonnet
+++ b/operations/jsonnet/microservices/frontend.libsonnet
@@ -18,7 +18,6 @@
   tempo_query_frontend_args:: {
     target: target_name,
     'config.file': '/conf/tempo.yaml',
-    'mem-ballast-size-mbs': $._config.ballast_size_mbs,
   },
 
   tempo_query_frontend_container::

--- a/operations/jsonnet/microservices/generator.libsonnet
+++ b/operations/jsonnet/microservices/generator.libsonnet
@@ -19,7 +19,6 @@
   tempo_metrics_generator_args:: {
     target: target_name,
     'config.file': '/conf/tempo.yaml',
-    'mem-ballast-size-mbs': $._config.ballast_size_mbs,
   },
 
   tempo_metrics_generator_pvc::

--- a/operations/jsonnet/microservices/live-store.libsonnet
+++ b/operations/jsonnet/microservices/live-store.libsonnet
@@ -32,7 +32,6 @@
   tempo_live_store_args:: {
     target: target_name,
     'config.file': '/conf/tempo.yaml',
-    'mem-ballast-size-mbs': $._config.ballast_size_mbs,
   },
 
   tempo_live_store_pvc::

--- a/operations/jsonnet/microservices/querier.libsonnet
+++ b/operations/jsonnet/microservices/querier.libsonnet
@@ -14,7 +14,6 @@
   tempo_querier_args:: {
     target: target_name,
     'config.file': '/conf/tempo.yaml',
-    'mem-ballast-size-mbs': $._config.ballast_size_mbs,
   },
 
   tempo_querier_container::

--- a/operations/jsonnet/single-binary/config.libsonnet
+++ b/operations/jsonnet/single-binary/config.libsonnet
@@ -18,7 +18,6 @@
     pvc_size: error 'Must specify a pvc size',
     pvc_storage_class: error 'Must specify a pvc storage class',
     receivers: error 'Must specify receivers',
-    ballast_size_mbs: '1024',
     jaeger_ui: {
       base_path: '/',
     },

--- a/operations/jsonnet/single-binary/tempo.libsonnet
+++ b/operations/jsonnet/single-binary/tempo.libsonnet
@@ -44,7 +44,6 @@
     container.withArgs([
       '-target=scalable-single-binary',
       '-config.file=/conf/tempo.yaml',
-      '-mem-ballast-size-mbs=' + $._config.ballast_size_mbs,
     ]) +
     container.withVolumeMounts([
       volumeMount.new(tempo_config_volume, '/conf'),


### PR DESCRIPTION
**What this PR does**:

**Which issue(s) this PR fixes**:
Removes `mem-ballast-size-mbs` flag, which is no longer needed in newer Go versions. Currently, Tempo uses `go 1.25.6`.
The flag has been removed from `tempo-distributed` helm chart and needs to be removed from `tempo-operator` as well.

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`