### PR TITLE
Backport r239: use latest tools image

### DIFF
--- a/build/tools.mk
+++ b/build/tools.mk
@@ -12,7 +12,7 @@ TOOL_DIR     ?= tools
 TOOL_CONFIG  ?= $(TOOL_DIR)/tools.go
 
 TOOLS_IMAGE ?= grafana/tempo-ci-tools
-TOOLS_IMAGE_TAG ?= main-d9d391d
+TOOLS_IMAGE_TAG ?= main-c4f476b
 
 GOTOOLS ?= $(shell cd $(TOOL_DIR) && go list -e -f '{{ .Imports }}' -tags tools |tr -d '[]')
 


### PR DESCRIPTION
**What this PR does**:
Use tools image from https://github.com/grafana/tempo/pull/6379 in TOOLS_IMAGE_TAG

**Which issue(s) this PR fixes**:
Might help to fix the weekly build for r239

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`