### PR TITLE
refactor: Make InitAutoMemLimit a separate exported function to allow use in vendored context

### DIFF
--- a/cmd/tempo/app/automemlimit.go
+++ b/cmd/tempo/app/automemlimit.go
@@ -1,0 +1,37 @@
+package app
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/KimMachineGun/automemlimit/memlimit"
+)
+
+// InitAutoMemLimit configures Go's memory limit using automemlimit based on the
+// provided config. It is exported so that downstream consumers can call it.
+func InitAutoMemLimit(config *Config) {
+	if !config.Memory.AutoMemLimitEnabled {
+		return
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	limit, err := memlimit.SetGoMemLimitWithOpts(
+		memlimit.WithRatio(config.Memory.AutoMemLimitRatio),
+		memlimit.WithProvider(
+			memlimit.ApplyFallback(
+				memlimit.FromCgroup,
+				memlimit.FromSystem,
+			),
+		),
+		memlimit.WithRefreshInterval(15*time.Second),
+		memlimit.WithLogger(logger),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to set GOMEMLIMIT: %v\n", err)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "info: GOMEMLIMIT set to %d bytes (ratio: %.2f)\n", limit, config.Memory.AutoMemLimitRatio)
+}


### PR DESCRIPTION
**What this PR does**:

Changes `InitAutoMemLimit` to be an exported function instead of defining it locally in `main.go`. Allows to use this when Tempo is vendored as library

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`