### PR TITLE
Backport: read to first virtual row after seeking on a low definition level

### DIFF
--- a/tempodb/encoding/vparquet5/row_number_iterator.go
+++ b/tempodb/encoding/vparquet5/row_number_iterator.go
@@ -134,7 +134,10 @@ func (v *virtualRowNumberIterator) SeekTo(rowNumber pq.RowNumber, definitionLeve
 		v.rowsLeft--
 		v.at.RowNumber.Next(v.definitionLevel, v.definitionLevel, v.definitionLevel)
 	}
-	if v.rowsLeft == 0 && seek > 0 {
+
+	rowsExhausted := v.rowsLeft == 0 && seek > 0
+	defLevelNotDefined := v.at.RowNumber[v.definitionLevel] < 0
+	if rowsExhausted || defLevelNotDefined {
 		return v.Next()
 	}
 


### PR DESCRIPTION
**What this PR does**:
This helps avoid additional spans/op in queries with only resource attributes

This change part of grafana/tempo#6353

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`