### PR TITLE
[jsonnet]: include generator deployment fsGroup to match statefulset

### DIFF
--- a/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-metrics-generator.yaml
@@ -55,6 +55,8 @@ spec:
           name: metrics-generator-data
         - mountPath: /overrides
           name: overrides
+      securityContext:
+        fsGroup: 10001
       volumes:
       - configMap:
           name: tempo-metrics-generator

--- a/operations/jsonnet-compiled/microservices/gen/Deployment-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/Deployment-metrics-generator.yaml
@@ -55,6 +55,8 @@ spec:
           name: metrics-generator-data
         - mountPath: /overrides
           name: overrides
+      securityContext:
+        fsGroup: 10001
       volumes:
       - configMap:
           name: tempo-metrics-generator

--- a/operations/jsonnet/microservices/generator.libsonnet
+++ b/operations/jsonnet/microservices/generator.libsonnet
@@ -65,7 +65,8 @@
       volume.fromConfigMap(tempo_config_volume, $.tempo_metrics_generator_configmap.metadata.name),
       volume.fromConfigMap(tempo_overrides_config_volume, $._config.overrides_configmap_name),
       volume.fromEmptyDir(tempo_data_volume),
-    ])
+    ]) +
+    deployment.spec.template.spec.securityContext.withFsGroup(10001)  // 10001 is the UID of the tempo user
   ,
 
   newGeneratorStatefulSet(name, container, with_anti_affinity=true)::


### PR DESCRIPTION
**What this PR does**:

Here we match the generator `deployment` for `fsGroup` to match that of the `statefulset` in cases where appending to the container later adds additional mounts.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`