### PR TITLE
generator: fix dimension_mappings being unconditionally overwritten b…

### DIFF
--- a/modules/generator/config.go
+++ b/modules/generator/config.go
@@ -234,13 +234,17 @@ func (cfg *ProcessorConfig) copyWithOverrides(o metricsGeneratorOverrides, userI
 		copyCfg.SpanMetrics.HistogramOverride = registry.HistogramModeToValue[string(histograms)]
 	}
 
-	copyCfg.SpanMetrics.DimensionMappings = o.MetricsGeneratorProcessorSpanMetricsDimensionMappings(userID)
+	if dimensionMappings := o.MetricsGeneratorProcessorSpanMetricsDimensionMappings(userID); dimensionMappings != nil {
+		copyCfg.SpanMetrics.DimensionMappings = dimensionMappings
+	}
 
 	if enableTargetInfo, ok := o.MetricsGeneratorProcessorSpanMetricsEnableTargetInfo(userID); ok {
 		copyCfg.SpanMetrics.EnableTargetInfo = enableTargetInfo
 	}
 
-	copyCfg.SpanMetrics.TargetInfoExcludedDimensions = o.MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(userID)
+	if targetInfoExcludedDimensions := o.MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(userID); targetInfoExcludedDimensions != nil {
+		copyCfg.SpanMetrics.TargetInfoExcludedDimensions = targetInfoExcludedDimensions
+	}
 
 	if EnableInstanceLabel, ok := o.MetricsGeneratorProcessorSpanMetricsEnableInstanceLabel(userID); ok {
 		copyCfg.SpanMetrics.EnableInstanceLabel = EnableInstanceLabel

--- a/modules/generator/config_test.go
+++ b/modules/generator/config_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/tempo/modules/generator/processor/servicegraphs"
 	"github.com/grafana/tempo/modules/generator/processor/spanmetrics"
+	"github.com/grafana/tempo/pkg/sharedconfig"
 	"github.com/grafana/tempo/pkg/spanfilter/config"
 )
 
@@ -144,6 +145,62 @@ func TestProcessorConfig_copyWithOverrides(t *testing.T) {
 				},
 			},
 		}, copied.SpanMetrics.FilterPolicies)
+	})
+
+	t.Run("dimension_mappings preserved when no override", func(t *testing.T) {
+		// Create original config with dimension_mappings set
+		originalWithMappings := &ProcessorConfig{
+			SpanMetrics: spanmetrics.Config{
+				DimensionMappings: []sharedconfig.DimensionMappings{
+					{Name: "env", SourceLabel: []string{"deployment.environment"}},
+				},
+				TargetInfoExcludedDimensions: []string{"telemetry.sdk.version"},
+			},
+		}
+
+		// Empty overrides should preserve base config values
+		o := &mockOverrides{}
+
+		copied, err := originalWithMappings.copyWithOverrides(o, "tenant")
+		require.NoError(t, err)
+
+		// Verify dimension_mappings from base config is preserved
+		assert.Equal(t, []sharedconfig.DimensionMappings{
+			{Name: "env", SourceLabel: []string{"deployment.environment"}},
+		}, copied.SpanMetrics.DimensionMappings)
+
+		// Verify target_info_excluded_dimensions from base config is preserved
+		assert.Equal(t, []string{"telemetry.sdk.version"}, copied.SpanMetrics.TargetInfoExcludedDimensions)
+	})
+
+	t.Run("dimension_mappings overridden when override is set", func(t *testing.T) {
+		// Create original config with dimension_mappings set
+		originalWithMappings := &ProcessorConfig{
+			SpanMetrics: spanmetrics.Config{
+				DimensionMappings: []sharedconfig.DimensionMappings{
+					{Name: "env", SourceLabel: []string{"deployment.environment"}},
+				},
+				TargetInfoExcludedDimensions: []string{"telemetry.sdk.version"},
+			},
+		}
+
+		// Override should replace base config values
+		o := &mockOverrides{
+			spanMetricsDimensionMappings: []sharedconfig.DimensionMappings{
+				{Name: "cluster", SourceLabel: []string{"k8s.cluster.name"}},
+			},
+			spanMetricsTargetInfoExcludedDimensions: []string{"process.runtime.version"},
+		}
+
+		copied, err := originalWithMappings.copyWithOverrides(o, "tenant")
+		require.NoError(t, err)
+
+		// Verify override replaced base config
+		assert.Equal(t, []sharedconfig.DimensionMappings{
+			{Name: "cluster", SourceLabel: []string{"k8s.cluster.name"}},
+		}, copied.SpanMetrics.DimensionMappings)
+
+		assert.Equal(t, []string{"process.runtime.version"}, copied.SpanMetrics.TargetInfoExcludedDimensions)
 	})
 }
 


### PR DESCRIPTION
…… (#6390)

* generator: fix dimension_mappings being unconditionally overwritten by overrides

Same with TargetInfoExcludedDimensions.

This caused this fields to be set to nil when they were set through the static config file but not in overrides.

fixes https://github.com/grafana/tempo/issues/3376

* changelog

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`