### PR TITLE
[mixin] Add External Requests row to tempo-reads dashboard

### DIFF
--- a/operations/tempo-mixin-compiled/dashboards/tempo-reads.json
+++ b/operations/tempo-mixin-compiled/dashboards/tempo-reads.json
@@ -1382,6 +1382,178 @@
    "showTitle": true,
    "title": "Backend",
    "titleSize": "h6"
+  },
+  {
+   "collapse": false,
+   "height": "250px",
+   "panels": [
+    {
+     "aliasColors": {
+      "1xx": "#EAB839",
+      "2xx": "#7EB26D",
+      "3xx": "#6ED0E0",
+      "4xx": "#EF843C",
+      "5xx": "#E24D42",
+      "OK": "#7EB26D",
+      "cancel": "#A9A9A9",
+      "error": "#E24D42",
+      "success": "#7EB26D"
+     },
+     "datasource": "$datasource",
+     "fieldConfig": {
+      "defaults": {
+       "custom": {
+        "drawStyle": "line",
+        "fillOpacity": 1,
+        "lineWidth": 1,
+        "pointSize": 5,
+        "showPoints": "never",
+        "spanNulls": false,
+        "stacking": {
+         "mode": "normal"
+        }
+       },
+       "thresholds": {
+        "mode": "absolute",
+        "steps": [
+
+        ]
+       },
+       "unit": "ops"
+      },
+      "overrides": [
+
+      ]
+     },
+     "fill": 10,
+     "id": 18,
+     "linewidth": 0,
+     "links": [
+
+     ],
+     "options": {
+      "legend": {
+       "showLegend": true
+      },
+      "tooltip": {
+       "mode": "single",
+       "sort": "none"
+      }
+     },
+     "span": 6,
+     "stack": true,
+     "targets": [
+      {
+       "expr": "sum by (status) (\n  label_replace(label_replace(rate(tempo_querier_external_endpoint_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/querier\"}[$__rate_interval]),\n  \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"),\n  \"status\", \"${1}\", \"status_code\", \"([a-zA-Z_]+)\"))\n",
+       "format": "time_series",
+       "interval": "1m",
+       "legendFormat": "{{status}}",
+       "refId": "A"
+      }
+     ],
+     "title": "QPS",
+     "type": "timeseries"
+    },
+    {
+     "datasource": "$datasource",
+     "fieldConfig": {
+      "defaults": {
+       "custom": {
+        "drawStyle": "line",
+        "fillOpacity": 1,
+        "lineWidth": 1,
+        "pointSize": 5,
+        "showPoints": "never",
+        "spanNulls": false,
+        "stacking": {
+         "group": "A",
+         "mode": "none"
+        }
+       },
+       "thresholds": {
+        "mode": "absolute",
+        "steps": [
+
+        ]
+       },
+       "unit": "ms"
+      },
+      "overrides": [
+
+      ]
+     },
+     "id": 19,
+     "links": [
+
+     ],
+     "nullPointMode": "null as zero",
+     "options": {
+      "legend": {
+       "showLegend": true
+      },
+      "tooltip": {
+       "mode": "single",
+       "sort": "none"
+      }
+     },
+     "span": 6,
+     "targets": [
+      {
+       "expr": "histogram_quantile(0.99, sum(rate(tempo_querier_external_endpoint_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/querier\"}[$__rate_interval])) by (le,)) * 1e3",
+       "format": "time_series",
+       "interval": "1m",
+       "intervalFactor": 2,
+       "legendFormat": "{{route}} 99th",
+       "refId": "A",
+       "step": 10
+      },
+      {
+       "expr": "histogram_quantile(0.50, sum(rate(tempo_querier_external_endpoint_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/querier\"}[$__rate_interval])) by (le,)) * 1e3",
+       "format": "time_series",
+       "interval": "1m",
+       "intervalFactor": 2,
+       "legendFormat": "{{route}} 50th",
+       "refId": "B",
+       "step": 10
+      },
+      {
+       "expr": "sum(rate(tempo_querier_external_endpoint_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/querier\"}[$__rate_interval])) by () * 1e3 / sum(rate(tempo_querier_external_endpoint_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/querier\"}[$__rate_interval])) by ()",
+       "format": "time_series",
+       "interval": "1m",
+       "intervalFactor": 2,
+       "legendFormat": "{{route}} Average",
+       "refId": "C",
+       "step": 10
+      }
+     ],
+     "title": "Latency",
+     "type": "timeseries",
+     "yaxes": [
+      {
+       "format": "ms",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": 0,
+       "show": true
+      },
+      {
+       "format": "short",
+       "label": null,
+       "logBase": 1,
+       "max": null,
+       "min": null,
+       "show": false
+      }
+     ]
+    }
+   ],
+   "repeat": null,
+   "repeatIteration": null,
+   "repeatRowId": null,
+   "showTitle": true,
+   "title": "External Requests",
+   "titleSize": "h6"
   }
  ],
  "schemaVersion": 14,

--- a/operations/tempo-mixin/dashboards/tempo-reads.libsonnet
+++ b/operations/tempo-mixin/dashboards/tempo-reads.libsonnet
@@ -115,6 +115,17 @@ dashboard_utils {
           $.panel('Latency') +
           $.latencyPanel('tempodb_backend_request_duration_seconds', '{%s,operation="GET"}' % $.jobMatcher($._config.jobs.querier))
         )
+      )
+      .addRow(
+        g.row('External Requests')
+        .addPanel(
+          $.panel('QPS') +
+          $.qpsPanel('tempo_querier_external_endpoint_request_duration_seconds_count{%s}' % $.jobMatcher($._config.jobs.querier))
+        )
+        .addPanel(
+          $.panel('Latency') +
+          $.latencyPanel('tempo_querier_external_endpoint_request_duration_seconds', '{%s}' % $.jobMatcher($._config.jobs.querier))
+        )
       ),
   },
 }


### PR DESCRIPTION
Adds QPS and Latency panels for `tempo_querier_external_endpoint_request_duration_seconds` to the tempo-reads dashboard.

Made with [Cursor](https://cursor.com)