### PR TITLE
GH action docker: specify platform in docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,7 +59,7 @@ jobs:
       - name: docker-build
         run: |
           TAG_ARCH="$TAG-${{ matrix.runner_arch.arch }}"
-          docker build -f cmd/${{ matrix.component }}/Dockerfile -t grafana/${{ matrix.component }}:$TAG_ARCH .
+          docker build --platform linux/${{ matrix.runner_arch.arch }} -f cmd/${{ matrix.component }}/Dockerfile -t grafana/${{ matrix.component }}:$TAG_ARCH .
 
       - name: Login to DockerHub
         uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3


### PR DESCRIPTION
**What this PR does**:

The [docker GH action](https://github.com/grafana/tempo/actions/runs/22058309522/job/63733090562) failed with the error: 
```
docker.io/grafana/tempo:main-16f06aa-amd64 is a manifest list"
```
A possible reason for this is that `docker manifest inspect grafana/tempo:main-16f06aa-amd64` shows two entries:
```json
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 3503,
         "digest": "sha256:5372590fdb1b3008436837377e390b72a1f8a8db02ce9d3f3bf1f84d8591b6a8",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 566,
         "digest": "sha256:64b21f1c603cab3ff3449f756122ed0d9302511d35fe4c1f7a6c482ba9111619",
         "platform": {
            "architecture": "unknown",
            "os": "unknown"
         }
      }
   ]
}
```

To prevent images with arm64/amd64 suffix like `tempo:main-16f06aa-amd64` to be built as multiarch, it should help to explicitly specify the platform.


**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`