### PR TITLE
feat: log x-plugin-id header

### DIFF
--- a/modules/frontend/grpc_util.go
+++ b/modules/frontend/grpc_util.go
@@ -3,13 +3,16 @@ package frontend
 import (
 	"context"
 	"net/http"
+	"strings"
 
+	"github.com/grafana/tempo/pkg/api"
 	"google.golang.org/grpc/metadata"
 )
 
 var copyHeaders = []string{
 	"Authorization",
 	"X-Scope-OrgID",
+	api.HeaderPluginID,
 }
 
 func headersFromGrpcContext(ctx context.Context) (hs http.Header) {
@@ -22,8 +25,8 @@ func headersFromGrpcContext(ctx context.Context) (hs http.Header) {
 	}
 
 	for _, h := range copyHeaders {
-		if v := md.Get(h); len(v) > 0 {
-			hs[h] = v
+		if v := md.Get(strings.ToLower(h)); len(v) > 0 {
+			hs[http.CanonicalHeaderKey(h)] = v
 		}
 	}
 

--- a/modules/frontend/grpc_util_test.go
+++ b/modules/frontend/grpc_util_test.go
@@ -1,0 +1,31 @@
+package frontend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/tempo/pkg/api"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestHeadersFromGrpcContextCopiesPluginID(t *testing.T) {
+	md := metadata.New(map[string]string{
+		"authorization":    "Bearer abc",
+		"x-scope-orgid":    "tenant-a",
+		"x-plugin-id":      "grafana-assistant",
+		"x-ignored-header": "nope",
+	})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	headers := headersFromGrpcContext(ctx)
+	require.Equal(t, "Bearer abc", headers.Get("Authorization"))
+	require.Equal(t, "tenant-a", headers.Get("X-Scope-OrgID"))
+	require.Equal(t, "grafana-assistant", headers.Get(api.HeaderPluginID))
+	require.Empty(t, headers.Get("X-Ignored-Header"))
+}
+
+func TestHeadersFromGrpcContextWithoutMetadata(t *testing.T) {
+	headers := headersFromGrpcContext(context.Background())
+	require.Empty(t, headers)
+}

--- a/modules/frontend/handler_test.go
+++ b/modules/frontend/handler_test.go
@@ -1,10 +1,14 @@
 package frontend
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 func TestFormatRequestHeaders(t *testing.T) {
@@ -20,4 +24,20 @@ func TestFormatRequestHeaders(t *testing.T) {
 	}
 
 	require.Equal(t, expected, fields)
+}
+
+func TestSetRequestSpanAttributes(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+
+	ctx, span := tp.Tracer("test").Start(context.Background(), "root")
+	setRequestSpanAttributes(span, "tenant-a", "grafana-assistant")
+	span.End()
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+	require.Contains(t, spans[0].Attributes(), attribute.String("orgID", "tenant-a"))
+	require.Contains(t, spans[0].Attributes(), attribute.String("pluginID", "grafana-assistant"))
+
+	_ = tp.Shutdown(ctx)
 }

--- a/modules/querier/http.go
+++ b/modules/querier/http.go
@@ -31,6 +31,16 @@ const (
 	QueryModeExternal  = "external"
 )
 
+func setRequestSpanAttributes(span oteltrace.Span, r *http.Request) {
+	if span == nil || r == nil {
+		return
+	}
+
+	if pluginID := r.Header.Get(api.HeaderPluginID); pluginID != "" {
+		span.SetAttributes(attribute.String("pluginID", pluginID))
+	}
+}
+
 // TraceByIDHandler is a http.HandlerFunc to retrieve traces
 func (q *Querier) TraceByIDHandler(w http.ResponseWriter, r *http.Request) {
 	// Enforce the query timeout while querying backends
@@ -39,6 +49,7 @@ func (q *Querier) TraceByIDHandler(w http.ResponseWriter, r *http.Request) {
 
 	ctx, span := tracer.Start(ctx, "Querier.TraceByIDHandler")
 	defer span.End()
+	setRequestSpanAttributes(span, r)
 
 	byteID, err := api.ParseTraceID(r)
 	if err != nil {
@@ -92,6 +103,7 @@ func (q *Querier) TraceByIDHandlerV2(w http.ResponseWriter, r *http.Request) {
 
 	ctx, span := tracer.Start(ctx, "Querier.TraceByIDHandlerV2")
 	defer span.End()
+	setRequestSpanAttributes(span, r)
 
 	byteID, err := api.ParseTraceID(r)
 	if err != nil {
@@ -143,6 +155,7 @@ func (q *Querier) SearchHandler(w http.ResponseWriter, r *http.Request) {
 
 	ctx, span := tracer.Start(ctx, "Querier.SearchHandler")
 	defer span.End()
+	setRequestSpanAttributes(span, r)
 
 	span.SetAttributes(attribute.String("requestURI", r.RequestURI))
 	span.SetAttributes(attribute.Bool("isSearchBlock", isSearchBlock))
@@ -192,6 +205,7 @@ func (q *Querier) SearchTagsHandler(w http.ResponseWriter, r *http.Request) {
 
 	ctx, span := tracer.Start(ctx, "Querier.SearchTagsHandler")
 	defer span.End()
+	setRequestSpanAttributes(span, r)
 
 	var resp *tempopb.SearchTagsResponse
 	if !isSearchBlock {
@@ -231,6 +245,7 @@ func (q *Querier) SearchTagsV2Handler(w http.ResponseWriter, r *http.Request) {
 
 	ctx, span := tracer.Start(ctx, "Querier.SearchTagsHandler")
 	defer span.End()
+	setRequestSpanAttributes(span, r)
 
 	var resp *tempopb.SearchTagsV2Response
 	if !isSearchBlock {
@@ -272,6 +287,7 @@ func (q *Querier) SearchTagValuesHandler(w http.ResponseWriter, r *http.Request)
 
 	ctx, span := tracer.Start(ctx, "Querier.SearchTagValuesHandler")
 	defer span.End()
+	setRequestSpanAttributes(span, r)
 
 	var resp *tempopb.SearchTagValuesResponse
 	if !isSearchBlock {
@@ -313,6 +329,7 @@ func (q *Querier) SearchTagValuesV2Handler(w http.ResponseWriter, r *http.Reques
 
 	ctx, span := tracer.Start(ctx, "Querier.SearchTagValuesV2Handler")
 	defer span.End()
+	setRequestSpanAttributes(span, r)
 
 	var resp *tempopb.SearchTagValuesV2Response
 	var err error
@@ -350,6 +367,7 @@ func (q *Querier) SpanMetricsSummaryHandler(w http.ResponseWriter, r *http.Reque
 
 	ctx, span := tracer.Start(ctx, "Querier.SpanMetricsSummaryHandler")
 	defer span.End()
+	setRequestSpanAttributes(span, r)
 
 	req, err := api.ParseSpanMetricsSummaryRequest(r)
 	if err != nil {
@@ -378,6 +396,7 @@ func (q *Querier) QueryRangeHandler(w http.ResponseWriter, r *http.Request) {
 
 	ctx, span := tracer.Start(ctx, "Querier.QueryRangeHandler")
 	defer span.End()
+	setRequestSpanAttributes(span, r)
 
 	// Special error handling to update the span.
 	defer func() {

--- a/modules/querier/http_test.go
+++ b/modules/querier/http_test.go
@@ -1,0 +1,31 @@
+package querier
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/tempo/pkg/api"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestSetRequestSpanAttributes(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	ctx, span := tp.Tracer("test").Start(context.Background(), "root")
+
+	req := httptest.NewRequest("GET", "/api/search", nil)
+	req.Header.Set(api.HeaderPluginID, "grafana-assistant")
+
+	setRequestSpanAttributes(span, req)
+	span.End()
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+	require.Contains(t, spans[0].Attributes(), attribute.String("pluginID", "grafana-assistant"))
+
+	_ = tp.Shutdown(ctx)
+}

--- a/pkg/api/http.go
+++ b/pkg/api/http.go
@@ -62,6 +62,7 @@ const (
 
 	HeaderAccept           = "Accept"
 	HeaderContentType      = "Content-Type"
+	HeaderPluginID         = "X-Plugin-Id"
 	HeaderAcceptProtobuf   = "application/protobuf"
 	HeaderAcceptJSON       = "application/json"
 	HeaderAcceptLLM        = "application/vnd.grafana.llm"


### PR DESCRIPTION
Grafana plugings like the assistant injects the X-Plugin-ID header in its requests. Logging in we can measure the assistant usage.
