### PR TITLE
Proposal: [Enhancement] TraceQL Metrics: return NaN values

### DIFF
--- a/integration/api/query_range_test.go
+++ b/integration/api/query_range_test.go
@@ -517,7 +517,9 @@ func TestQueryRangeExemplars(t *testing.T) {
 func sumSamples(samples []tempopb.Sample) float64 {
 	var sum float64
 	for _, sample := range samples {
-		sum += sample.Value
+		if !math.IsNaN(sample.Value) {
+			sum += sample.Value
+		}
 	}
 	return sum
 }

--- a/modules/frontend/metrics_query_range_handler_test.go
+++ b/modules/frontend/metrics_query_range_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -15,6 +16,8 @@ import (
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/grafana/dskit/user"
 	"github.com/grafana/tempo/modules/frontend/pipeline"
 	"github.com/grafana/tempo/modules/overrides"
@@ -105,7 +108,7 @@ func TestQueryRangeHandlerSucceeds(t *testing.T) {
 					},
 					{
 						TimestampMs: 1300_000,
-						Value:       0,
+						Value:       math.NaN(),
 					},
 				},
 			},
@@ -115,7 +118,7 @@ func TestQueryRangeHandlerSucceeds(t *testing.T) {
 	actualResp := &tempopb.QueryRangeResponse{}
 	err := jsonpb.Unmarshal(httpResp.Body, actualResp)
 	require.NoError(t, err)
-	require.Equal(t, expectedResp, actualResp)
+	require.True(t, cmp.Equal(expectedResp, actualResp, cmpopts.EquateNaNs()), "expected %v, got %v", expectedResp, actualResp)
 }
 
 func TestQueryRangeAccessesCache(t *testing.T) {

--- a/modules/generator/processor/localblocks/query_range_test.go
+++ b/modules/generator/processor/localblocks/query_range_test.go
@@ -2,6 +2,7 @@ package localblocks
 
 import (
 	"flag"
+	"math"
 	"path"
 	"testing"
 	"time"
@@ -211,7 +212,9 @@ func TestProcessor(t *testing.T) {
 			for _, ts := range results {
 				var sum float64
 				for _, val := range ts.Values {
-					sum += val
+					if !math.IsNaN(val) {
+						sum += val
+					}
 				}
 				require.InDelta(t, tc.expectedSpans, sum, 0.000001)
 				require.Equal(t, tc.expectedExemplars, len(ts.Exemplars))

--- a/modules/livestore/instance_search_test.go
+++ b/modules/livestore/instance_search_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"math"
 	"path"
 	"sort"
 	"strconv"
@@ -1249,7 +1250,9 @@ func TestLiveStoreQueryRange(t *testing.T) {
 			for _, ts := range results.Series {
 				var sum float64
 				for _, val := range ts.Samples {
-					sum += val.Value
+					if !math.IsNaN(val.Value) {
+						sum += val.Value
+					}
 				}
 				require.InDelta(t, tc.expectedSpans, sum, 0.000001)
 				require.Equal(t, tc.expectedExemplars, len(ts.Exemplars))

--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -360,11 +360,16 @@ func (set SeriesSet) ToProto(req *tempopb.QueryRangeRequest) []*tempopb.TimeSeri
 
 		intervals := mapper.IntervalCount()
 		samples := make([]tempopb.Sample, 0, intervals)
+		hasNonNaN := false
 		for i, value := range s.Values {
 			// todo: this loop should be able to be restructured to directly pass over
 			// the desired intervals
-			if i >= intervals || math.IsNaN(value) {
+			if i >= intervals {
 				continue
+			}
+
+			if !math.IsNaN(value) {
+				hasNonNaN = true
 			}
 
 			ts := mapper.TimestampOf(i)
@@ -373,8 +378,8 @@ func (set SeriesSet) ToProto(req *tempopb.QueryRangeRequest) []*tempopb.TimeSeri
 				Value:       value,
 			})
 		}
-		// Do not include empty TimeSeries
-		if len(samples) == 0 {
+		// Do not include TimeSeries with only NaN values (no actual data)
+		if !hasNonNaN {
 			continue
 		}
 

--- a/pkg/traceql/engine_metrics_compare.go
+++ b/pkg/traceql/engine_metrics_compare.go
@@ -445,7 +445,7 @@ func (b *BaselineAggregator) Combine(ss []*tempopb.TimeSeries) {
 
 		for _, sample := range s.Samples {
 			j := b.intervalMapper.IntervalMs(sample.TimestampMs)
-			if j >= 0 && j < len(ts.series.Values) {
+			if j >= 0 && j < len(ts.series.Values) && !math.IsNaN(sample.Value) {
 				ts.series.Values[j] += sample.Value
 			}
 		}
@@ -533,7 +533,9 @@ type topN[T any] struct {
 func (t *topN[T]) add(key T, values []float64) {
 	sum := 0.0
 	for _, v := range values {
-		sum += v
+		if !math.IsNaN(v) {
+			sum += v
+		}
 	}
 	t.entries = append(t.entries, struct {
 		key   T

--- a/pkg/traceql/engine_metrics_functions.go
+++ b/pkg/traceql/engine_metrics_functions.go
@@ -5,6 +5,9 @@ import "math"
 func sumOverTime() func(curr float64, n float64) (res float64) {
 	var comp float64 // Kahan compensation
 	return func(sum, inc float64) (res float64) {
+		if math.IsNaN(inc) {
+			return sum // Skip NaN values
+		}
 		if math.IsNaN(sum) {
 			return inc
 		}

--- a/pkg/traceql/engine_metrics_functions_test.go
+++ b/pkg/traceql/engine_metrics_functions_test.go
@@ -1,0 +1,64 @@
+package traceql
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNaNHandling tests that NaN values don't corrupt aggregation results.
+// This can happen because NaN + 1 is NaN
+func TestNaNHandling(t *testing.T) {
+	t.Run("sumOverTime skips NaN", func(t *testing.T) {
+		sumFunc := sumOverTime()
+
+		// Start with NaN (initial state)
+		result := sumFunc(math.NaN(), 10.0)
+		assert.Equal(t, 10.0, result)
+
+		// Add valid value
+		result = sumFunc(result, 20.0)
+		assert.Equal(t, 30.0, result)
+
+		// Add NaN - should be skipped
+		result = sumFunc(result, math.NaN())
+		assert.Equal(t, 30.0, result)
+
+		// Add another valid value
+		result = sumFunc(result, 5.0)
+		assert.Equal(t, 35.0, result)
+	})
+
+	t.Run("minOverTime handles NaN", func(t *testing.T) {
+		minFunc := minOverTime()
+
+		// Start with NaN
+		result := minFunc(math.NaN(), 10.0)
+		assert.Equal(t, 10.0, result)
+
+		// NaN comparison should not affect result
+		result = minFunc(result, math.NaN())
+		assert.Equal(t, 10.0, result)
+
+		// Normal min operation
+		result = minFunc(result, 5.0)
+		assert.Equal(t, 5.0, result)
+	})
+
+	t.Run("maxOverTime handles NaN", func(t *testing.T) {
+		maxFunc := maxOverTime()
+
+		// Start with NaN
+		result := maxFunc(math.NaN(), 10.0)
+		assert.Equal(t, 10.0, result)
+
+		// NaN comparison should not affect result
+		result = maxFunc(result, math.NaN())
+		assert.Equal(t, 10.0, result)
+
+		// Normal max operation
+		result = maxFunc(result, 15.0)
+		assert.Equal(t, 15.0, result)
+	})
+}

--- a/pkg/traceql/engine_metrics_test.go
+++ b/pkg/traceql/engine_metrics_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/grafana/tempo/pkg/tempopb"
 	commonv1proto "github.com/grafana/tempo/pkg/tempopb/common/v1"
 	"github.com/stretchr/testify/assert"
@@ -1381,14 +1383,14 @@ func TestMinOverTimeForSpanAttribute(t *testing.T) {
 
 	// Test that NaN values are not included in the samples after casting to proto
 	ts := result.ToProto(req)
-	fooBarSamples := []tempopb.Sample{{TimestampMs: 1000, Value: 100}, {TimestampMs: 2000, Value: 200}}
-	fooBazSamples := []tempopb.Sample{{TimestampMs: 1000, Value: 204}, {TimestampMs: 3000, Value: 200}}
+	fooBarSamples := []tempopb.Sample{{TimestampMs: 1000, Value: 100}, {TimestampMs: 2000, Value: 200}, {TimestampMs: 3000, Value: math.NaN()}}
+	fooBazSamples := []tempopb.Sample{{TimestampMs: 1000, Value: 204}, {TimestampMs: 2000, Value: math.NaN()}, {TimestampMs: 3000, Value: 200}}
 
 	for _, s := range ts {
 		if LabelsFromProto(s.Labels).String() == "{\"span.foo\"=\"bar\"}" {
-			assert.Equal(t, fooBarSamples, s.Samples)
+			assert.True(t, cmp.Equal(fooBarSamples, s.Samples, cmpopts.EquateNaNs()), "expected %v, got %v", fooBarSamples, s.Samples)
 		} else {
-			assert.Equal(t, fooBazSamples, s.Samples)
+			assert.True(t, cmp.Equal(fooBazSamples, s.Samples, cmpopts.EquateNaNs()), "expected %v, got %v", fooBazSamples, s.Samples)
 		}
 	}
 }
@@ -1606,14 +1608,14 @@ func TestAvgOverTimeForSpanAttribute(t *testing.T) {
 
 	// Test that NaN values are not included in the samples after casting to proto
 	ts := result.ToProto(req)
-	fooBarSamples := []tempopb.Sample{{TimestampMs: 1000, Value: 234}, {TimestampMs: 2000, Value: 200}}
-	fooBazSamples := []tempopb.Sample{{TimestampMs: 3000, Value: 250}}
+	fooBarSamples := []tempopb.Sample{{TimestampMs: 1000, Value: 234}, {TimestampMs: 2000, Value: 200}, {TimestampMs: 3000, Value: math.NaN()}}
+	fooBazSamples := []tempopb.Sample{{TimestampMs: 1000, Value: math.NaN()}, {TimestampMs: 2000, Value: math.NaN()}, {TimestampMs: 3000, Value: 250}}
 
 	for _, s := range ts {
 		if LabelsFromProto(s.Labels).String() == "{\"span.foo\"=\"bar\"}" {
-			assert.Equal(t, fooBarSamples, s.Samples)
+			assert.True(t, cmp.Equal(fooBarSamples, s.Samples, cmpopts.EquateNaNs()), "expected %v, got %v", fooBarSamples, s.Samples)
 		} else {
-			assert.Equal(t, fooBazSamples, s.Samples)
+			assert.True(t, cmp.Equal(fooBazSamples, s.Samples, cmpopts.EquateNaNs()), "expected %v, got %v", fooBazSamples, s.Samples)
 		}
 	}
 }
@@ -1935,14 +1937,14 @@ func TestMaxOverTimeForSpanAttribute(t *testing.T) {
 
 	// Test that NaN values are not included in the samples after casting to proto
 	ts := result.ToProto(req)
-	fooBarSamples := []tempopb.Sample{{TimestampMs: 1000, Value: 404}, {TimestampMs: 2000, Value: 403}}
-	fooBazSamples := []tempopb.Sample{{TimestampMs: 1000, Value: 204}, {TimestampMs: 3000, Value: 500}}
+	fooBarSamples := []tempopb.Sample{{TimestampMs: 1000, Value: 404}, {TimestampMs: 2000, Value: 403}, {TimestampMs: 3000, Value: math.NaN()}}
+	fooBazSamples := []tempopb.Sample{{TimestampMs: 1000, Value: 204}, {TimestampMs: 2000, Value: math.NaN()}, {TimestampMs: 3000, Value: 500}}
 
 	for _, s := range ts {
 		if LabelsFromProto(s.Labels).String() == "{\"span.foo\"=\"bar\"}" {
-			assert.Equal(t, fooBarSamples, s.Samples)
+			assert.True(t, cmp.Equal(fooBarSamples, s.Samples, cmpopts.EquateNaNs()), "expected %v, got %v", fooBarSamples, s.Samples)
 		} else {
-			assert.Equal(t, fooBazSamples, s.Samples)
+			assert.True(t, cmp.Equal(fooBazSamples, s.Samples, cmpopts.EquateNaNs()), "expected %v, got %v", fooBazSamples, s.Samples)
 		}
 	}
 }
@@ -2051,14 +2053,14 @@ func TestSumOverTimeForSpanAttribute(t *testing.T) {
 
 	// Test that NaN values are not included in the samples after casting to proto
 	ts := result.ToProto(req)
-	fooBarSamples := []tempopb.Sample{{TimestampMs: 1000, Value: 1200}, {TimestampMs: 2000, Value: 2400}}
-	fooBazSamples := []tempopb.Sample{{TimestampMs: 1000, Value: 200}, {TimestampMs: 3000, Value: 1700}}
+	fooBarSamples := []tempopb.Sample{{TimestampMs: 1000, Value: 1200}, {TimestampMs: 2000, Value: 2400}, {TimestampMs: 3000, Value: math.NaN()}}
+	fooBazSamples := []tempopb.Sample{{TimestampMs: 1000, Value: 200}, {TimestampMs: 2000, Value: math.NaN()}, {TimestampMs: 3000, Value: 1700}}
 
 	for _, s := range ts {
 		if LabelsFromProto(s.Labels).String() == "{\"span.foo\"=\"bar\"}" {
-			assert.Equal(t, fooBarSamples, s.Samples)
+			assert.True(t, cmp.Equal(fooBarSamples, s.Samples, cmpopts.EquateNaNs()), "expected %v, got %v", fooBarSamples, s.Samples)
 		} else {
-			assert.Equal(t, fooBazSamples, s.Samples)
+			assert.True(t, cmp.Equal(fooBazSamples, s.Samples, cmpopts.EquateNaNs()), "expected %v, got %v", fooBazSamples, s.Samples)
 		}
 	}
 }
@@ -3613,4 +3615,61 @@ func TestLog2QuantileWithBucket(t *testing.T) {
 				"Log2QuantileWithBucket should return same value as Log2Quantile")
 		})
 	}
+}
+
+func TestSeriesToProtoWithNaN(t *testing.T) {
+	// Test that NaN values are included in the output
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	step := 10 * time.Second
+	req := &tempopb.QueryRangeRequest{
+		Start: uint64(start.UnixNano()),
+		End:   uint64(start.Add(30 * time.Second).UnixNano()),
+		Step:  uint64(step.Nanoseconds()),
+	}
+
+	// Create a series with some NaN values
+	seriesSet := SeriesSet{
+		{}: TimeSeries{
+			Labels: Labels{
+				{Name: "service", Value: NewStaticString("test")},
+			},
+			Values: []float64{1.0, math.NaN(), 3.0},
+		},
+	}
+
+	result := seriesSet.ToProto(req)
+
+	require.Len(t, result, 1, "Should have 1 series")
+	require.Len(t, result[0].Samples, 3, "Should have 3 samples including NaN")
+
+	// Verify values
+	require.Equal(t, 1.0, result[0].Samples[0].Value)
+	require.True(t, math.IsNaN(result[0].Samples[1].Value), "Second sample should be NaN")
+	require.Equal(t, 3.0, result[0].Samples[2].Value)
+}
+
+func TestSeriesToProtoAllNaN(t *testing.T) {
+	// Test that a series with all NaN values is excluded from output
+	// (series with only NaN values represent "no data" and should not be included)
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	step := 10 * time.Second
+	req := &tempopb.QueryRangeRequest{
+		Start: uint64(start.UnixNano()),
+		End:   uint64(start.Add(30 * time.Second).UnixNano()),
+		Step:  uint64(step.Nanoseconds()),
+	}
+
+	// Create a series with all NaN values
+	seriesSet := SeriesSet{
+		{}: TimeSeries{
+			Labels: Labels{
+				{Name: "service", Value: NewStaticString("test")},
+			},
+			Values: []float64{math.NaN(), math.NaN(), math.NaN()},
+		},
+	}
+
+	result := seriesSet.ToProto(req)
+
+	require.Len(t, result, 0, "Should have 0 series because all values are NaN")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: returns NaN values instead of skipping bucket if returned value is NaN


**How has it been tested:** the easiest way to check is to run in docker compose version of this branch on top of https://github.com/grafana/tempo/pull/6474 and request traceql math. Results:
<img width="1834" height="874" alt="image" src="https://github.com/user-attachments/assets/5183e134-4aac-46cf-9829-38a5d5100c02" />
<img width="1817" height="881" alt="image" src="https://github.com/user-attachments/assets/d6c2052e-15db-4663-a38e-bad8e8fe16a7" />

Another example with avg_over_time(duration)
Before
<img width="1836" height="887" alt="image" src="https://github.com/user-attachments/assets/ab4f803c-71fd-407b-b1a1-de285f0b104f" />

After
<img width="1816" height="870" alt="image" src="https://github.com/user-attachments/assets/302a7ecd-f83b-4d72-af16-c730e0d0431b" />


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`