### PR TITLE
Backport r240: Export parse function that allows to skip AST optimizations

### DIFF
--- a/pkg/traceql/ast_rewriter_test.go
+++ b/pkg/traceql/ast_rewriter_test.go
@@ -175,7 +175,7 @@ func TestBinaryOpToArrayOpRewriter(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			expr, err := parseWithOptimizationOption(tc.query, true)
+			expr, err := ParseWithOptimizationOption(tc.query, true)
 			require.NoError(t, err)
 
 			rewrite := rewriter.RewriteRoot(expr)

--- a/pkg/traceql/ast_stringer_test.go
+++ b/pkg/traceql/ast_stringer_test.go
@@ -28,11 +28,11 @@ func TestStringer(t *testing.T) {
 	for _, s := range sets {
 		for _, q := range s {
 			t.Run(q, func(t *testing.T) {
-				pass1, err := parseWithOptimizationOption(q, false)
+				pass1, err := ParseWithOptimizationOption(q, false)
 				require.NoError(t, err)
 
 				// now parse it a second time and confirm that it parses the same way twice
-				pass2, err := parseWithOptimizationOption(pass1.String(), false)
+				pass2, err := ParseWithOptimizationOption(pass1.String(), false)
 				ok := assert.NoError(t, err)
 				if !ok {
 					t.Logf("\n\t1: %s", pass1.String())

--- a/pkg/traceql/parse.go
+++ b/pkg/traceql/parse.go
@@ -21,10 +21,10 @@ func init() {
 }
 
 func Parse(s string) (expr *RootExpr, err error) {
-	return parseWithOptimizationOption(s, true)
+	return ParseWithOptimizationOption(s, true)
 }
 
-func parseWithOptimizationOption(s string, astOptimization bool) (expr *RootExpr, err error) {
+func ParseWithOptimizationOption(s string, astOptimization bool) (expr *RootExpr, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			var ok bool


### PR DESCRIPTION
**What this PR does**:

Backport #6497 to r240

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`