### PR TITLE
enhancement: Do not engage backpressure on WAL replay

### DIFF
--- a/modules/livestore/instance.go
+++ b/modules/livestore/instance.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -92,11 +93,12 @@ type instance struct {
 	enc encoding.VersionedEncoding
 
 	// Block management
-	blocksMtx      sync.RWMutex
-	headBlock      common.WALBlock
-	walBlocks      map[uuid.UUID]common.WALBlock
-	completeBlocks map[uuid.UUID]*ingester.LocalBlock
-	lastCutTime    time.Time
+	blocksMtx             sync.RWMutex
+	headBlock             common.WALBlock
+	walBlocks             map[uuid.UUID]common.WALBlock
+	completeBlocks        map[uuid.UUID]*ingester.LocalBlock
+	lastCutTime           time.Time
+	replayedWALBlockCount atomic.Int32 // tracks replayed WAL blocks to exclude from backpressure
 
 	// Live traces
 	liveTracesMtx  sync.Mutex
@@ -161,12 +163,13 @@ func (i *instance) backpressure(ctx context.Context) bool {
 		}
 	}
 
-	// Check outstanding wal blocks
+	// Check outstanding wal blocks, excluding replayed blocks already on disk
 	i.blocksMtx.RLock()
 	count := len(i.walBlocks)
 	i.blocksMtx.RUnlock()
 
-	if count > 1 {
+	adjustedCount := count - int(i.replayedWALBlockCount.Load())
+	if adjustedCount > 1 {
 		// There are multiple outstanding WAL blocks that need completion
 		// so wait a bit.
 		select {
@@ -479,6 +482,10 @@ func (i *instance) completeBlock(ctx context.Context, id uuid.UUID) error {
 		span.RecordError(err)
 	}
 	delete(i.walBlocks, (uuid.UUID)(walBlock.BlockMeta().BlockID))
+
+	if i.replayedWALBlockCount.Load() > 0 {
+		i.replayedWALBlockCount.Add(-1)
+	}
 
 	level.Info(i.logger).Log("msg", "completed block", "id", id.String())
 	span.AddEvent("block completed successfully")

--- a/modules/livestore/instance.go
+++ b/modules/livestore/instance.go
@@ -483,8 +483,8 @@ func (i *instance) completeBlock(ctx context.Context, id uuid.UUID) error {
 	}
 	delete(i.walBlocks, (uuid.UUID)(walBlock.BlockMeta().BlockID))
 
-	if i.replayedWALBlockCount.Load() > 0 {
-		i.replayedWALBlockCount.Add(-1)
+	if newVal := i.replayedWALBlockCount.Add(-1); newVal < 0 {
+		i.replayedWALBlockCount.Store(0)
 	}
 
 	level.Info(i.logger).Log("msg", "completed block", "id", id.String())

--- a/modules/livestore/live_store.go
+++ b/modules/livestore/live_store.go
@@ -299,6 +299,16 @@ func (s *LiveStore) starting(ctx context.Context) error {
 		return fmt.Errorf("failed to start livestore lifecycler: %w", err)
 	}
 
+	// Register completion workers and unblock background processes before starting
+	// the Kafka reader so replayed WAL blocks can begin draining immediately.
+	for i := range s.cfg.CompleteBlockConcurrency {
+		idx := i
+		s.runInBackground(func() {
+			s.globalCompleteLoop(idx)
+		})
+	}
+	s.startAllBackgroundProcesses()
+
 	s.client, err = ingest.NewReaderClient(
 		s.cfg.IngestConfig.Kafka,
 		ingest.NewReaderClientMetrics(liveStoreServiceName, s.reg),
@@ -334,16 +344,6 @@ func (s *LiveStore) starting(ctx context.Context) error {
 		func() []int32 { return []int32{s.ingestPartitionID} },
 		s.client.ForceMetadataRefresh,
 	)
-
-	for i := range s.cfg.CompleteBlockConcurrency {
-		idx := i
-		s.runInBackground(func() {
-			s.globalCompleteLoop(idx)
-		})
-	}
-
-	// allow background processes to start
-	s.startAllBackgroundProcesses()
 
 	// Wait for catch-up before marking ready (if enabled)
 	if err := s.waitForCatchUp(ctx); err != nil {

--- a/modules/livestore/live_store_background.go
+++ b/modules/livestore/live_store_background.go
@@ -234,9 +234,10 @@ func (s *LiveStore) reloadBlocks() error {
 
 			level.Info(s.logger).Log("msg", "reloaded wal block", "block", meta.BlockID.String())
 			inst.walBlocks[(uuid.UUID)(meta.BlockID)] = blk
+			inst.replayedWALBlockCount.Add(1)
 
 			level.Info(s.logger).Log("msg", "queueing replayed wal block for completion", "block", meta.BlockID.String())
-			if err := s.enqueueCompleteOp(meta.TenantID, uuid.UUID(meta.BlockID), true); err != nil {
+			if err := s.enqueueCompleteOp(meta.TenantID, uuid.UUID(meta.BlockID), false); err != nil {
 				return fmt.Errorf("failed to enqueue wal block for completion for tenant %s: %w", meta.TenantID, err)
 			}
 


### PR DESCRIPTION
**What this PR does**:

When live store starts with WAL files left over from previous launch, it adds them to completion queue, and delays ingestion of new records from Kafka, until open wal blocks is reduced to 1. This change attempts to circumvent the problem by subtracting the count of 'inherited' WAL blocks when calculating backpressure

Risks:

* This trades slower startup for slower searches for some time until all WAL blocks are replayed, as well as IO load

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`