### PR TITLE
[DOC] Update command line flags doc for 3.0

### DIFF
--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/command-line-flags.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/command-line-flags.md
@@ -46,7 +46,6 @@ Valid target values:
 | `backend-scheduler` | Schedules and coordinates backend query jobs across workers. |
 | `backend-worker` | Executes query jobs assigned by the backend scheduler. |
 | `live-store` | Serves recently ingested data from Kafka for real-time queries. |
-| `metrics-generator-no-local-blocks` | Runs the metrics generator without local block storage. |
 
 {{< admonition type="note" >}}
   In Tempo 3.0, the `ingester`, `compactor`, and `scalable-single-binary` targets were removed as as part of the [Project Rhythm architecture](/docs/tempo/<TEMPO_VERSION>/introduction/architecture/#project-rhythm).


### PR DESCRIPTION
**What this PR does**:

Updates the command line flags documentation for the upcoming Tempo 3.0 release. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/tempo-squad/issues/1073

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`