### PR TITLE
fix: flaky livestore partition owner tests

### DIFF
--- a/modules/livestore/live_store_test.go
+++ b/modules/livestore/live_store_test.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/dskit/kv"
 	"github.com/gogo/protobuf/proto"
+	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/kv/consul"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"


### PR DESCRIPTION
These tests are flaky. This pr uses the require.Eventually helper to retry the hasOwner 