### PR TITLE
fix missing removeReplicasFromSpec

### DIFF
--- a/operations/jsonnet/microservices/common.libsonnet
+++ b/operations/jsonnet/microservices/common.libsonnet
@@ -22,6 +22,13 @@
     container.securityContext.withRunAsGroup(0) +
     {},
 
+  removeReplicasFromSpec:: {
+    spec+: {
+      // Remove the "replicas" field so that it isn't reconciled.
+      replicas+:: null,
+    },
+  },
+
   util+:: {
     local k = import 'ksonnet-util/kausal.libsonnet',
     local container = k.core.v1.container,

--- a/operations/jsonnet/microservices/live-store.libsonnet
+++ b/operations/jsonnet/microservices/live-store.libsonnet
@@ -126,12 +126,7 @@
     statefulSet.mixin.spec.updateStrategy.withType('OnDelete') +
     statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(1200) +
     (
-      if $._config.live_store.replicas > 0 then {
-        spec+: {
-          // Remove the "replicas" field so that it isn't reconciled.
-          replicas+:: null,
-        },
-      } else statefulSet.mixin.spec.withReplicas(0)
+      if $._config.live_store.replicas > 0 then $.removeReplicasFromSpec else statefulSet.mixin.spec.withReplicas(0)
     ) +  // Zone-aware live-store statefulsets follow the replicas in the ReplicaTemplate
     (if !std.isObject($._config.node_selector) then {} else statefulSet.mixin.spec.template.spec.withNodeSelectorMixin($._config.node_selector)) +
     statefulSet.spec.template.spec.securityContext.withFsGroup(10001) +  // 10001 is the UID of the tempo user


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
removeReplicasFromSpec was unintentionally deleted during the ingesters jsonnet cleanup
https://github.com/grafana/tempo/pull/6504

This PR fix it by bringing back the same behavior

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`