### PR TITLE
feat: add `-health` CLI command for docker healthchecks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [CHANGE] Allow duplicate dimensions for span metrics and service graphs. This is a valid use case if using different instrumentation libraries, with spans having "deployment.environment" and others "deployment_environment", for example. [#6288](https://github.com/grafana/tempo/pull/6288) (@carles-grafana)
 * [CHANGE] Updade default max duration for traceql metrics queries up to one day [#6285](https://github.com/grafana/tempo/pull/6285) (@javiermolinar)
 * [CHANGE] Set traceQL query metrics checks by default in Vulture [#6275](https://github.com/grafana/tempo/pull/6275) (@javiermolinar)
+* [FEATURE] Add `-health` CLI command for docker healthchecks in distroless containers [#6536](https://github.com/grafana/tempo/issues/6536) (@Harry-kp)
 * [FEATURE] Add automemlimit support for automatic GOMEMLIMIT configuration. Enable with `memory.automemlimit_enabled: true`. [#6313](https://github.com/grafana/tempo/pull/6313) (@oleg-kozlyuk)
 * [CHANGE] TraceQL metrics - change default step intervals to align with new vParquet5 timestamp columns [#6413](https://github.com/grafana/tempo/pull/6413) (@mdisibio)
 * [CHANGE] Remove all traces of ingesters from the dashboards [#6352](https://github.com/grafana/tempo/pull/6352) (@javiermolinar)

--- a/cmd/tempo/health.go
+++ b/cmd/tempo/health.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"time"
+)
+
+const (
+	healthFlag       = "health"
+	defaultHealthURL = "http://localhost:3200/ready"
+	healthTimeout    = 5 * time.Second
+)
+
+// CheckHealth checks if args contain the -health flag.
+func CheckHealth(args []string) bool {
+	pattern := regexp.MustCompile(`^-+` + healthFlag + `$`)
+	for _, a := range args {
+		if pattern.MatchString(a) {
+			return true
+		}
+	}
+	return false
+}
+
+// RunHealthCheck performs a health check against the /ready endpoint.
+// Returns exit code 0 if healthy, 1 if unhealthy.
+func RunHealthCheck(args []string) int {
+	url := getHealthURL(args)
+
+	client := &http.Client{
+		Timeout: healthTimeout,
+	}
+
+	resp, err := client.Get(url)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Health check failed: %v\n", err)
+		return 1
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		fmt.Println("Tempo is healthy")
+		return 0
+	}
+
+	fmt.Fprintf(os.Stderr, "Tempo is unhealthy: status code %d\n", resp.StatusCode)
+	return 1
+}
+
+// getHealthURL extracts the URL from args or returns default.
+// Looks for -health.url=<url> or -health.url <url>.
+func getHealthURL(args []string) string {
+	urlPattern := regexp.MustCompile(`^-+health\.url[=:]?(.*)$`)
+	flagPattern := regexp.MustCompile(`^-`)
+
+	for i, a := range args {
+		if matches := urlPattern.FindStringSubmatch(a); matches != nil {
+			if matches[1] != "" {
+				return matches[1]
+			}
+			if i+1 < len(args) && !flagPattern.MatchString(args[i+1]) {
+				return args[i+1]
+			}
+		}
+	}
+	return defaultHealthURL
+}

--- a/cmd/tempo/health_test.go
+++ b/cmd/tempo/health_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckHealth(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"single dash", []string{"-health"}, true},
+		{"double dash", []string{"--health"}, true},
+		{"with other flags", []string{"-config.file=tempo.yaml", "-health"}, true},
+		{"no health flag", []string{"-config.file=tempo.yaml"}, false},
+		{"empty args", nil, false},
+		{"health as substring", []string{"-health.url=http://localhost:3200/ready"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, CheckHealth(tt.args))
+		})
+	}
+}
+
+func TestGetHealthURL(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"default when no url flag", []string{"-health"}, defaultHealthURL},
+		{"equals syntax", []string{"-health.url=http://custom:9090/ready"}, "http://custom:9090/ready"},
+		{"space syntax", []string{"-health.url", "http://custom:9090/ready"}, "http://custom:9090/ready"},
+		{"double dash equals", []string{"--health.url=http://custom:9090/ready"}, "http://custom:9090/ready"},
+		{"colon syntax", []string{"-health.url:http://custom:9090/ready"}, "http://custom:9090/ready"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, getHealthURL(tt.args))
+		})
+	}
+}
+
+func TestRunHealthCheck(t *testing.T) {
+	t.Run("healthy endpoint returns 0", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		code := RunHealthCheck([]string{"-health", "-health.url=" + srv.URL + "/ready"})
+		assert.Equal(t, 0, code)
+	})
+
+	t.Run("unhealthy endpoint returns 1", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer srv.Close()
+
+		code := RunHealthCheck([]string{"-health", "-health.url=" + srv.URL + "/ready"})
+		assert.Equal(t, 1, code)
+	})
+
+	t.Run("unreachable endpoint returns 1", func(t *testing.T) {
+		code := RunHealthCheck([]string{"-health", "-health.url=http://127.0.0.1:1/ready"})
+		assert.Equal(t, 1, code)
+	})
+}

--- a/cmd/tempo/main.go
+++ b/cmd/tempo/main.go
@@ -45,6 +45,13 @@ func init() {
 }
 
 func main() {
+	// Health check command — runs before any config parsing so it works in
+	// distroless containers without a shell.
+	// Usage: tempo -health [-health.url=http://localhost:3200/ready]
+	if CheckHealth(os.Args[1:]) {
+		os.Exit(RunHealthCheck(os.Args[1:]))
+	}
+
 	printVersion := flag.Bool("version", false, "Print this builds version information")
 	ballastMBs := flag.Int("mem-ballast-size-mbs", 0, "Size of memory ballast to allocate in MBs.")
 	mutexProfileFraction := flag.Int("mutex-profile-fraction", 0, "Override default mutex profiling fraction.")


### PR DESCRIPTION
## Summary

- Adds a built-in `-health` CLI flag that checks the `/ready` endpoint, enabling docker healthchecks in distroless containers without needing curl/wget/shell
- Mirrors the approach taken by Loki in grafana/loki#20313
- Supports custom URL via `-health.url=<url>`

**Fixes** #6536

## Usage

```
tempo -health
tempo -health -health.url=http://localhost:3200/ready
```

```dockerfile
HEALTHCHECK CMD ["tempo", "-health"]
```

## Changes

- `cmd/tempo/health.go` — `CheckHealth()`, `RunHealthCheck()`, `getHealthURL()` 
- `cmd/tempo/main.go` — early `-health` check before config parsing
- `cmd/tempo/health_test.go` — 14 test cases (flag detection, URL parsing, end-to-end with httptest)
- `CHANGELOG.md` — added `[FEATURE]` entry

## Test plan

- [x] `go test ./cmd/tempo/ -run "TestCheckHealth|TestGetHealthURL|TestRunHealthCheck"` — all 14 tests pass