### PR TITLE
fix: use counter instead of gauge for compactor deduped spans metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [BUGFIX] fix: live store honor the config options for block and WAL versions [#6509](https://github.com/grafana/tempo/pull/6509) (@mdisibio)
 * [BUGFIX] fix: block builder honor the global storage block config for block and WAL versions [#6451](https://github.com/grafana/tempo/issues/6451) (@Harry-kp)
 * [BUGFIX] fix: normalize allowlist headers when building the allowlist map [#6481](https://github.com/grafana/tempo/pull/6481) (@javiermolinar)
+* [BUGFIX] fix: compactor deduped spans metric uses wrong type (gauge instead of counter) [#6558](https://github.com/grafana/tempo/issues/6558) (@bejaratommy)
 
 ### 3.0 Cleanup
 

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -63,10 +63,10 @@ var (
 		Name:      "compaction_outstanding_blocks",
 		Help:      "Number of blocks remaining to be compacted before next maintenance cycle",
 	}, []string{"tenant"})
-	metricDedupedSpans = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	metricDedupedSpans = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "tempodb",
-		Name:      "compaction_spans_combined_total",
-		Help:      "Number of spans that are deduped per replication factor.",
+		Name:      "compaction_spans_deduped_total",
+		Help:      "Total number of spans that are deduped per replication factor.",
 	}, []string{"replication_factor"})
 
 	errCompactionJobNoLongerOwned = fmt.Errorf("compaction job no longer owned")


### PR DESCRIPTION
**What this PR does**:

The `metricDedupedSpans` metric in the compactor was declared as a `prometheus.GaugeVec`, but it tracks a monotonically increasing count of deduplicated spans during compaction. This should be a `CounterVec` instead.

The metric name has also been changed from `tempodb_compaction_spans_combined_total` to `tempodb_compaction_spans_deduped_total` to avoid Prometheus type conflicts with the previous gauge metric and to better describe what it measures.

Changes:
- `tempodb/compactor.go`: Changed `metricDedupedSpans` from `NewGaugeVec`/`GaugeOpts` to `NewCounterVec`/`CounterOpts`
- `tempodb/compactor.go`: Renamed metric from `compaction_spans_combined_total` to `compaction_spans_deduped_total`
- `CHANGELOG.md`: Added bugfix entry

Notes:
- The metric is only used via `.Add()` which works identically on both `CounterVec` and `GaugeVec`
- No dashboards, alerting rules, or jsonnet mixins in the repo reference this metric
- No tests reference this metric directly

**Which issue(s) this PR fixes**:

Fixes #6558

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`