### PR TITLE
tempodb: rename deduped spans metric to counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [BUGFIX] fix: live store honor the config options for block and WAL versions [#6509](https://github.com/grafana/tempo/pull/6509) (@mdisibio)
 * [BUGFIX] fix: block builder honor the global storage block config for block and WAL versions [#6451](https://github.com/grafana/tempo/issues/6451) (@Harry-kp)
 * [BUGFIX] fix: normalize allowlist headers when building the allowlist map [#6481](https://github.com/grafana/tempo/pull/6481) (@javiermolinar)
+* [CHANGE] **BREAKING CHANGE** Rename compactor deduped spans metric from `tempodb_compaction_spans_combined_total` (gauge) to `tempodb_compaction_deduped_spans_total` (counter). [#6558](https://github.com/grafana/tempo/issues/6558)
 
 ### 3.0 Cleanup
 

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/upgrade.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/upgrade.md
@@ -27,6 +27,18 @@ For detailed information about any release, refer to the [Release notes](https:/
 You can check your configuration options using the [`status` API endpoint](https://grafana.com/docs/tempo/<TEMPO_VERSION>/api_docs/#status) in your Tempo installation.
 {{< /admonition >}}
 
+## Upcoming metric changes
+
+### Compactor deduped spans metric renamed
+
+The compactor deduped spans metric has been renamed and its type corrected:
+
+- Removed: `tempodb_compaction_spans_combined_total` (gauge)
+- Added: `tempodb_compaction_deduped_spans_total` (counter)
+
+Update dashboards, alerts, and recording rules to use the new metric name.
+There is no dual-emission compatibility period for this change.
+
 ## Upgrade to Tempo 2.10
 
 When upgrading to Tempo 2.10, be aware of these considerations and breaking changes.

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -63,9 +63,9 @@ var (
 		Name:      "compaction_outstanding_blocks",
 		Help:      "Number of blocks remaining to be compacted before next maintenance cycle",
 	}, []string{"tenant"})
-	metricDedupedSpans = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	metricDedupedSpans = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "tempodb",
-		Name:      "compaction_spans_combined_total",
+		Name:      "compaction_deduped_spans_total",
 		Help:      "Number of spans that are deduped per replication factor.",
 	}, []string{"replication_factor"})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

- Fixes the compactor deduped spans metric type by replacing a gauge with a counter.
- Renames metric `tempodb_compaction_spans_combined_total` (gauge) to `tempodb_compaction_deduped_spans_total` (counter), since Prometheus does not support changing metric type in-place.
- Adds `TestCompactionDedupedSpansMetric` to verify the deduped spans counter increases after compaction.
- Updates upgrade docs and changelog with the breaking metric rename and migration note (no dual-emission period).

**Which issue(s) this PR fixes**:
Fixes #6558

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`