### PR TITLE
[tempo-cli] do not solely rely on the meta for dedicated columns

### DIFF
--- a/cmd/tempo-cli/cmd-analyse-block.go
+++ b/cmd/tempo-cli/cmd-analyse-block.go
@@ -336,6 +336,9 @@ func aggregateScope(pf *parquet.File, meta *backend.BlockMeta, paths scopeAttrib
 	res.dedicated = make(map[string]struct{})
 
 	for i, c := range strings {
+		if i >= len(paths.dedicatedColsPaths) {
+			break
+		}
 		cardinality, err := aggregateStringColumn(pf, paths.dedicatedColsPaths[i])
 		if err != nil {
 			return res, err
@@ -364,6 +367,9 @@ func aggregateScope(pf *parquet.File, meta *backend.BlockMeta, paths scopeAttrib
 	}
 
 	for i, c := range ints {
+		if i >= len(paths.dedicatedColsPathsInt) {
+			break
+		}
 		path := paths.dedicatedColsPathsInt[i]
 		count, err := aggregateIntegerColumn(pf, path)
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: vParquet version < 5 can choose to ignore some dedicated columns in meta  so the length do not always match

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`