### PR TITLE
[chore] restore the automated backport process

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,45 +1,112 @@
-# This checks merged PRs for labels like "backport release-x.y"
-# and opens a new PR backporting the same commit to the release branch.
-# This workflow also runs when the PR is labeled or opened, but will
-# will only check a few things and detect that the PR is not yet merged.
-# At this time only squashed PRs are supported since the cherry-pick
-# command does not include "-m <n>" arg required for merge commits.
+# This triggers on every push to main and finds the PR that was merged.
+# If the PR has any "backport release-*" labels, it opens a backport PR
+# targeting each labeled release branch.
+#
+# Manual re-trigger: Go to Actions → Backport PR Creator → Run workflow,
+# provide the PR number. Note: running twice on the same PR will post a
+# failure comment on the original PR (no deduplication).
 name: Backport PR Creator
+
 on:
-  pull_request:
-    types:
-      - closed
-      - labeled
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to backport (required for manual trigger)"
+        required: true
+        type: string
 
 permissions: {}
 
 jobs:
-  main:
-    # skip it in all forks, only run in grafana/tempo.
+  find-pr:
+    name: Find PR and check backport labels
+    # skip in forks — only run in grafana/tempo
     if: github.repository == 'grafana/tempo'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      pr_number: ${{ steps.find-pr.outputs.pr_number }}
+      has_backport_labels: ${{ steps.check-labels.outputs.has_backport_labels }}
+    steps:
+      - name: Find PR number
+        id: find-pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            PR_NUMBER="$INPUT_PR_NUMBER"
+          else
+            # Retry up to 5 times with 10s delay: the commits/{sha}/pulls API
+            # may not be indexed immediately after the push event fires.
+            for i in 1 2 3 4 5; do
+              PR_NUMBER=$(gh api \
+                "repos/${REPO}/commits/${SHA}/pulls" \
+                --header "Accept: application/vnd.github+json" \
+                --jq '.[0].number // empty')
+              [ -n "$PR_NUMBER" ] && break
+              echo "Attempt $i: no PR found yet, retrying in 10s..."
+              sleep 10
+            done
+          fi
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR found for commit ${SHA} after retries."
+            exit 1
+          fi
+          echo "Found PR number: $PR_NUMBER"
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      - name: Check for backport labels
+        id: check-labels
+        if: steps.find-pr.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.find-pr.outputs.pr_number }}
+          REPO: ${{ github.repository }}
+        run: |
+          COUNT=$(gh pr view "$PR_NUMBER" \
+            --repo "$REPO" \
+            --json labels \
+            --jq '[.labels[].name | select(startswith("backport release-"))] | length')
+
+          if [ "$COUNT" -gt "0" ]; then
+            echo "Found $COUNT backport label(s), will run backport."
+            echo "has_backport_labels=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No backport labels found, skipping backport."
+            echo "has_backport_labels=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  backport:
+    name: Backport PR
+    needs: find-pr
+    if: |
+      needs.find-pr.outputs.pr_number != '' &&
+      needs.find-pr.outputs.has_backport_labels == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
       pull-requests: write
     steps:
-      - name: Checkout Actions
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          repository: "grafana/grafana-github-actions"
-          path: ./actions
-          ref: main
-          persist-credentials: false
-      - name: Install Actions
-        run: npm install --production --prefix ./actions
       - name: Get Github App secrets from vault
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@e6dde86ffefaa91fc693b8cb4209cf9428a661d1 #get-vault-secrets 1.3.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@e6dde86ffefaa91fc693b8cb4209cf9428a661d1 # get-vault-secrets 1.3.0
         with:
           export_env: false
           repo_secrets: |
             APP_ID=tempo-ci-app:app-id
             PRIVATE_KEY=tempo-ci-app:private-key
+
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
@@ -48,9 +115,23 @@ jobs:
           private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: tempo
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config --global user.email "132647405+grafana-delivery-bot[bot]@users.noreply.github.com"
+          git config --global user.name "grafana-delivery-bot[bot]"
+
       - name: Run backport
-        uses: ./actions/backport
+        uses: grafana/grafana-github-actions-go/backport@main
         with:
           token: ${{ steps.app-token.outputs.token }}
           labelsToAdd: "backport"
-          title: "[{{base}}] {{originalTitle}}"
+          pr_number: ${{ needs.find-pr.outputs.pr_number }}
+          repo_owner: ${{ github.repository_owner }}
+          repo_name: ${{ github.event.repository.name }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Restored the automated backport workflow using https://github.com/grafana/grafana-github-actions-go.

Right now the new backport workflow:
1. requires the "backport release-*" label on PRs, and will be triggered when a PR merged to main
2. can also be triggered via github action UI with a PR number as input

**Which issue(s) this PR fixes**:
Fixes N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`