### PR TITLE
feat: include trace ID in query-frontend response logs

### DIFF
--- a/modules/frontend/metrics_query_handler.go
+++ b/modules/frontend/metrics_query_handler.go
@@ -2,6 +2,7 @@ package frontend
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -18,6 +19,7 @@ import (
 	"github.com/grafana/tempo/modules/frontend/pipeline"
 	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/grafana/tempo/pkg/util/tracing"
 )
 
 func newQueryInstantStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], apiPrefix string, logger log.Logger, dataAccessController DataAccessController) streamingQueryInstantHandler {
@@ -81,7 +83,7 @@ func newQueryInstantStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTri
 			bytesProcessed = finalResponse.Metrics.InspectedBytes
 		}
 		postSLOHook(nil, tenant, bytesProcessed, duration, err)
-		logQueryInstantResult(logger, tenant, duration.Seconds(), req, finalResponse, err)
+		logQueryInstantResult(ctx, logger, tenant, duration.Seconds(), req, finalResponse, err)
 		return err
 	}
 }
@@ -176,7 +178,7 @@ func newMetricsQueryInstantHTTPHandler(cfg Config, next pipeline.AsyncRoundTripp
 			bytesProcessed = qiResp.Metrics.InspectedBytes
 		}
 		postSLOHook(resp, tenant, bytesProcessed, duration, err)
-		logQueryInstantResult(logger, tenant, duration.Seconds(), i, &qiResp, err)
+		logQueryInstantResult(req.Context(), logger, tenant, duration.Seconds(), i, &qiResp, err)
 
 		return resp, nil
 	})
@@ -201,11 +203,14 @@ func translateQueryRangeToInstant(input tempopb.QueryRangeResponse) tempopb.Quer
 	return output
 }
 
-func logQueryInstantResult(logger log.Logger, tenantID string, durationSeconds float64, req *tempopb.QueryInstantRequest, resp *tempopb.QueryInstantResponse, err error) {
+func logQueryInstantResult(ctx context.Context, logger log.Logger, tenantID string, durationSeconds float64, req *tempopb.QueryInstantRequest, resp *tempopb.QueryInstantResponse, err error) {
+	traceID, _ := tracing.ExtractTraceID(ctx)
+
 	if resp == nil {
 		level.Info(logger).Log(
 			"msg", "query instant results - no resp",
 			"tenant", tenantID,
+			"traceID", traceID,
 			"duration_seconds", durationSeconds,
 			"error", err)
 
@@ -216,6 +221,7 @@ func logQueryInstantResult(logger log.Logger, tenantID string, durationSeconds f
 		level.Info(logger).Log(
 			"msg", "query instant results - no metrics",
 			"tenant", tenantID,
+			"traceID", traceID,
 			"query", req.Query,
 			"range_nanos", req.End-req.Start,
 			"duration_seconds", durationSeconds,
@@ -226,6 +232,7 @@ func logQueryInstantResult(logger log.Logger, tenantID string, durationSeconds f
 	level.Info(logger).Log(
 		"msg", "query instant results",
 		"tenant", tenantID,
+		"traceID", traceID,
 		"query", req.Query,
 		"range_nanos", req.End-req.Start,
 		"duration_seconds", durationSeconds,

--- a/modules/frontend/metrics_query_range_handler.go
+++ b/modules/frontend/metrics_query_range_handler.go
@@ -2,6 +2,7 @@ package frontend
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -16,6 +17,7 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/grafana/tempo/modules/frontend/combiner"
 	"github.com/grafana/tempo/modules/frontend/pipeline"
+	"github.com/grafana/tempo/pkg/util/tracing"
 
 	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/tempopb"
@@ -99,7 +101,7 @@ func newQueryRangeStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripp
 			bytesProcessed = finalResponse.Metrics.InspectedBytes
 		}
 		postSLOHook(nil, tenant, bytesProcessed, duration, err)
-		logQueryRangeResult(logger, tenant, duration.Seconds(), req, finalResponse, err)
+		logQueryRangeResult(ctx, logger, tenant, duration.Seconds(), req, finalResponse, err)
 		return err
 	}
 }
@@ -176,7 +178,7 @@ func newMetricsQueryRangeHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper
 
 		duration := time.Since(start)
 		postSLOHook(resp, tenant, bytesProcessed, duration, err)
-		logQueryRangeResult(logger, tenant, duration.Seconds(), queryRangeReq, queryRangeResp, err)
+		logQueryRangeResult(req.Context(), logger, tenant, duration.Seconds(), queryRangeReq, queryRangeResp, err)
 		return resp, err
 	})
 }
@@ -203,11 +205,14 @@ func normalizeRequestExemplars(req *tempopb.QueryRangeRequest, maxExemplars uint
 	return nil
 }
 
-func logQueryRangeResult(logger log.Logger, tenantID string, durationSeconds float64, req *tempopb.QueryRangeRequest, resp *tempopb.QueryRangeResponse, err error) {
+func logQueryRangeResult(ctx context.Context, logger log.Logger, tenantID string, durationSeconds float64, req *tempopb.QueryRangeRequest, resp *tempopb.QueryRangeResponse, err error) {
+	traceID, _ := tracing.ExtractTraceID(ctx)
+
 	if resp == nil {
 		level.Info(logger).Log(
 			"msg", "query range response - no resp",
 			"tenant", tenantID,
+			"traceID", traceID,
 			"duration_seconds", durationSeconds,
 			"error", err)
 
@@ -218,6 +223,7 @@ func logQueryRangeResult(logger log.Logger, tenantID string, durationSeconds flo
 		level.Info(logger).Log(
 			"msg", "query range response - no metrics",
 			"tenant", tenantID,
+			"traceID", traceID,
 			"query", req.Query,
 			"range_nanos", req.End-req.Start,
 			"duration_seconds", durationSeconds,
@@ -228,6 +234,7 @@ func logQueryRangeResult(logger log.Logger, tenantID string, durationSeconds flo
 	level.Info(logger).Log(
 		"msg", "query range response",
 		"tenant", tenantID,
+		"traceID", traceID,
 		"query", req.Query,
 		"range_nanos", req.End-req.Start,
 		"max_series", req.MaxSeries,

--- a/modules/frontend/search_handlers.go
+++ b/modules/frontend/search_handlers.go
@@ -2,6 +2,7 @@ package frontend
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/grafana/tempo/modules/frontend/combiner"
 	"github.com/grafana/tempo/modules/frontend/pipeline"
+	"github.com/grafana/tempo/pkg/util/tracing"
 	"google.golang.org/grpc/codes"
 
 	"github.com/grafana/tempo/modules/overrides"
@@ -77,7 +79,7 @@ func newSearchStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[c
 			bytesProcessed = finalResponse.Metrics.InspectedBytes
 		}
 		postSLOHook(nil, tenant, bytesProcessed, duration, err)
-		logResult(logger, tenant, duration.Seconds(), req, finalResponse, nil, err)
+		logResult(ctx, logger, tenant, duration.Seconds(), req, finalResponse, nil, err)
 		return err
 	}
 }
@@ -132,7 +134,7 @@ func newSearchHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.P
 
 		duration := time.Since(start)
 		postSLOHook(resp, tenant, bytesProcessed, duration, err)
-		logResult(logger, tenant, duration.Seconds(), searchReq, searchResp, resp, err)
+		logResult(req.Context(), logger, tenant, duration.Seconds(), searchReq, searchResp, resp, err)
 		return resp, err
 	})
 }
@@ -172,7 +174,9 @@ func adjustLimit(limit, defaultLimit, maxLimit uint32) (uint32, error) {
 	return limit, nil
 }
 
-func logResult(logger log.Logger, tenantID string, durationSeconds float64, req *tempopb.SearchRequest, resp *tempopb.SearchResponse, httpResp *http.Response, err error) {
+func logResult(ctx context.Context, logger log.Logger, tenantID string, durationSeconds float64, req *tempopb.SearchRequest, resp *tempopb.SearchResponse, httpResp *http.Response, err error) {
+	traceID, _ := tracing.ExtractTraceID(ctx)
+
 	statusCode := -1
 	if httpResp != nil {
 		statusCode = httpResp.StatusCode
@@ -184,6 +188,7 @@ func logResult(logger log.Logger, tenantID string, durationSeconds float64, req 
 		level.Info(logger).Log(
 			"msg", "search response - no resp",
 			"tenant", tenantID,
+			"traceID", traceID,
 			"duration_seconds", durationSeconds,
 			"status_code", statusCode,
 			"error", err)
@@ -195,6 +200,7 @@ func logResult(logger log.Logger, tenantID string, durationSeconds float64, req 
 		level.Info(logger).Log(
 			"msg", "search response - no metrics",
 			"tenant", tenantID,
+			"traceID", traceID,
 			"query", req.Query,
 			"range_seconds", req.End-req.Start,
 			"duration_seconds", durationSeconds,
@@ -206,6 +212,7 @@ func logResult(logger log.Logger, tenantID string, durationSeconds float64, req 
 	level.Info(logger).Log(
 		"msg", "search response",
 		"tenant", tenantID,
+		"traceID", traceID,
 		"query", req.Query,
 		"range_seconds", req.End-req.Start,
 		"duration_seconds", durationSeconds,

--- a/modules/frontend/tag_handlers.go
+++ b/modules/frontend/tag_handlers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grafana/tempo/pkg/search"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/traceql"
+	"github.com/grafana/tempo/pkg/util/tracing"
 	"google.golang.org/grpc/codes"
 )
 
@@ -85,7 +86,7 @@ func newTagsStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[com
 			bytesProcessed = finalResponse.Metrics.InspectedBytes
 		}
 		postSLOHook(nil, tenant, bytesProcessed, duration, err)
-		logTagsResult(logger, tenant, "SearchTagsStreaming", req.Scope, req.End-req.Start, duration.Seconds(), bytesProcessed, err)
+		logTagsResult(srv.Context(), logger, tenant, "SearchTagsStreaming", req.Scope, req.End-req.Start, duration.Seconds(), bytesProcessed, err)
 
 		return err
 	}
@@ -147,7 +148,7 @@ func newTagsV2StreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[c
 			bytesProcessed = finalResponse.Metrics.InspectedBytes
 		}
 		postSLOHook(nil, tenant, bytesProcessed, duration, err)
-		logTagsResult(logger, tenant, "SearchTagsV2Streaming", req.Scope, req.End-req.Start, duration.Seconds(), bytesProcessed, err)
+		logTagsResult(ctx, logger, tenant, "SearchTagsV2Streaming", req.Scope, req.End-req.Start, duration.Seconds(), bytesProcessed, err)
 
 		return err
 	}
@@ -195,7 +196,7 @@ func newTagValuesStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTrippe
 			bytesProcessed = finalResponse.Metrics.InspectedBytes
 		}
 		postSLOHook(nil, tenant, bytesProcessed, duration, err)
-		logTagValuesResult(logger, tenant, "SearchTagValuesStreaming", req.TagName, req.Query, req.End-req.Start, duration.Seconds(), bytesProcessed, err)
+		logTagValuesResult(ctx, logger, tenant, "SearchTagValuesStreaming", req.TagName, req.Query, req.End-req.Start, duration.Seconds(), bytesProcessed, err)
 
 		return err
 	}
@@ -241,7 +242,7 @@ func newTagValuesV2StreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTrip
 			bytesProcessed = finalResponse.Metrics.InspectedBytes
 		}
 		postSLOHook(nil, tenant, bytesProcessed, duration, err)
-		logTagValuesResult(logger, tenant, "SearchTagValuesV2Streaming", req.TagName, req.Query, req.End-req.Start, duration.Seconds(), bytesProcessed, err)
+		logTagValuesResult(ctx, logger, tenant, "SearchTagValuesV2Streaming", req.TagName, req.Query, req.End-req.Start, duration.Seconds(), bytesProcessed, err)
 
 		return err
 	}
@@ -300,7 +301,7 @@ func newTagsHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.Pip
 
 		duration := time.Since(start)
 		postSLOHook(resp, tenant, bytesProcessed, duration, err)
-		logTagsResult(logger, tenant, "SearchTags", scope, rangeDur, duration.Seconds(), bytesProcessed, err)
+		logTagsResult(req.Context(), logger, tenant, "SearchTags", scope, rangeDur, duration.Seconds(), bytesProcessed, err)
 
 		return resp, err
 	})
@@ -365,7 +366,7 @@ func newTagsV2HTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.P
 
 		duration := time.Since(start)
 		postSLOHook(resp, tenant, bytesProcessed, duration, err)
-		logTagsResult(logger, tenant, "SearchTagsV2", scope, rangeDur, duration.Seconds(), bytesProcessed, err)
+		logTagsResult(req.Context(), logger, tenant, "SearchTagsV2", scope, rangeDur, duration.Seconds(), bytesProcessed, err)
 
 		return resp, err
 	})
@@ -410,7 +411,7 @@ func newTagValuesHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combine
 
 		duration := time.Since(start)
 		postSLOHook(resp, tenant, bytesProcessed, duration, err)
-		logTagValuesResult(logger, tenant, "SearchTagValues", tagName, query, rangeDur, duration.Seconds(), bytesProcessed, err)
+		logTagValuesResult(req.Context(), logger, tenant, "SearchTagValues", tagName, query, rangeDur, duration.Seconds(), bytesProcessed, err)
 
 		return resp, err
 	})
@@ -455,7 +456,7 @@ func newTagValuesV2HTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combi
 
 		duration := time.Since(start)
 		postSLOHook(resp, tenant, bytesProcessed, duration, err)
-		logTagValuesResult(logger, tenant, "SearchTagValuesV2", tagName, query, rangeDur, duration.Seconds(), bytesProcessed, err)
+		logTagValuesResult(req.Context(), logger, tenant, "SearchTagValuesV2", tagName, query, rangeDur, duration.Seconds(), bytesProcessed, err)
 
 		return resp, err
 	})
@@ -523,10 +524,12 @@ func logTagsRequest(logger log.Logger, tenantID, handler, scope string, rangeSec
 		"range_seconds", rangeSeconds)
 }
 
-func logTagsResult(logger log.Logger, tenantID, handler, scope string, rangeSeconds uint32, durationSeconds float64, inspectedBytes uint64, err error) {
+func logTagsResult(ctx context.Context, logger log.Logger, tenantID, handler, scope string, rangeSeconds uint32, durationSeconds float64, inspectedBytes uint64, err error) {
+	traceID, _ := tracing.ExtractTraceID(ctx)
 	level.Info(logger).Log(
 		"msg", "search tag response",
 		"tenant", tenantID,
+		"traceID", traceID,
 		"handler", handler,
 		"scope", scope,
 		"range_seconds", rangeSeconds,
@@ -546,10 +549,12 @@ func logTagValuesRequest(logger log.Logger, tenantID, handler, tagName, query st
 		"range_seconds", rangeSeconds)
 }
 
-func logTagValuesResult(logger log.Logger, tenantID, handler, tagName, query string, rangeSeconds uint32, durationSeconds float64, inspectedBytes uint64, err error) {
+func logTagValuesResult(ctx context.Context, logger log.Logger, tenantID, handler, tagName, query string, rangeSeconds uint32, durationSeconds float64, inspectedBytes uint64, err error) {
+	traceID, _ := tracing.ExtractTraceID(ctx)
 	level.Info(logger).Log(
 		"msg", "search tag values response",
 		"tenant", tenantID,
+		"traceID", traceID,
 		"handler", handler,
 		"tag", tagName,
 		"query", query,

--- a/modules/frontend/traceid_handlers.go
+++ b/modules/frontend/traceid_handlers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/grafana/tempo/pkg/util/tracing"
 )
 
 // newTraceIDHandler creates a http.handler for trace by id requests
@@ -68,9 +69,11 @@ func newTraceIDHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.Pipe
 		}
 		postSLOHook(resp, tenant, inspectBytes, elapsed, err)
 
+		traceID, _ := tracing.ExtractTraceID(req.Context())
 		level.Info(logger).Log(
 			"msg", "trace id response",
 			"tenant", tenant,
+			"traceID", traceID,
 			"path", req.URL.Path,
 			"duration_seconds", elapsed.Seconds(),
 			"inspected_bytes", inspectBytes,
@@ -138,9 +141,11 @@ func newTraceIDV2Handler(cfg Config, next pipeline.AsyncRoundTripper[combiner.Pi
 
 		postSLOHook(resp, tenant, bytesProcessed, elapsed, err)
 
+		traceID, _ := tracing.ExtractTraceID(req.Context())
 		level.Info(logger).Log(
 			"msg", "trace id response",
 			"tenant", tenant,
+			"traceID", traceID,
 			"path", req.URL.Path,
 			"inspected_bytes", bytesProcessed,
 			"request_throughput", float64(bytesProcessed)/elapsed.Seconds(),


### PR DESCRIPTION
## What this PR does

Adds `traceID` field to all query-frontend response log lines, enabling easy navigation from logs to traces for debugging.

Currently, the trace ID is only logged in the outer `handler.go` "query stats" log line but **not** in the per-handler response logs (search, query range, query instant, trace by ID, tags, tag values). This makes it difficult to correlate detailed response metrics with their traces.

## Changes

All `logXxxResult` functions now accept a `context.Context` parameter and extract the trace ID using the existing `tracing.ExtractTraceID(ctx)` utility.

**Files modified:**
- `modules/frontend/search_handlers.go` — `logResult`
- `modules/frontend/metrics_query_range_handler.go` — `logQueryRangeResult`
- `modules/frontend/metrics_query_handler.go` — `logQueryInstantResult`
- `modules/frontend/traceid_handlers.go` — inline log statements
- `modules/frontend/tag_handlers.go` — `logTagsResult`, `logTagValuesResult`

The `traceID` key name is consistent with `handler.go:78`.

Closes #6280