### PR TITLE
:Docs: Broken link on Tempo docs

### DIFF
--- a/docs/sources/tempo/troubleshooting/out-of-memory-errors.md
+++ b/docs/sources/tempo/troubleshooting/out-of-memory-errors.md
@@ -60,7 +60,7 @@ overrides:
         max_bytes_per_trace: 1.5e+07
 ```
 
-Refer to the [Standard overrides](# https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#standard-overrides) documentation for more information.
+Refer to the [Standard overrides](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#standard-overrides) documentation for more information.
 
 If you have long-running batch job traces, consider using span links to break them apart.
 


### PR DESCRIPTION
Fix broken reference link in documentation for Tempo: Troubleshoot out-of-memory errors

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: fix a link in the docs

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`