### PR TITLE
Improve WAL completion by reading pages sequentially with right-sized rows

### DIFF
--- a/tempodb/encoding/vparquet5/wal_block.go
+++ b/tempodb/encoding/vparquet5/wal_block.go
@@ -1,6 +1,7 @@
 package vparquet5
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -9,6 +10,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -264,10 +266,67 @@ func (w *walBlockFlush) rowIterator() (*rowIterator, error) {
 	}
 
 	pf := file.parquetFile
-
 	idx, _, _ := parquetquery.GetColumnIndexByPath(pf, TraceIDColumnName)
-	r := parquet.NewReader(pf)
-	return newRowIterator(r, file, w.ids.EntriesSortedByID(), idx), nil
+	r := parquet.NewReader(pf) //nolint:all //deprecated
+
+	entries := w.ids.EntriesSortedByID()
+
+	// Sort by physical row number for sequential I/O instead of
+	// random seeking by trace ID order.
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Entry < entries[j].Entry
+	})
+
+	// Read all rows sequentially into memory. We use a pooled buffer
+	// for reading but copy to a right-sized slice immediately, so the
+	// 3.2MB pool entry is returned and reused for the next row.
+	readBuf := completeBlockRowPool.Get()
+	defer completeBlockRowPool.Put(readBuf)
+
+	rows := make([]readRow, 0, len(entries))
+	for _, entry := range entries {
+		err := r.SeekToRow(entry.Entry)
+		if err != nil {
+			r.Close()
+			file.Close()
+			return nil, fmt.Errorf("error seeking to row %d: %w", entry.Entry, err)
+		}
+
+		readBuf = readBuf[:0]
+		pqRows := []parquet.Row{readBuf}
+		_, err = r.ReadRows(pqRows)
+		if err != nil && !errors.Is(err, io.EOF) {
+			r.Close()
+			file.Close()
+			return nil, fmt.Errorf("error reading row: %w", err)
+		}
+		readBuf = pqRows[0]
+
+		var id common.ID
+		for _, v := range readBuf {
+			if v.Column() == idx {
+				id = v.ByteArray()
+				break
+			}
+		}
+
+		// Copy to a right-sized slice (~16KB typical vs 3.2MB pool entry)
+		row := make(parquet.Row, len(readBuf))
+		copy(row, readBuf)
+
+		rows = append(rows, readRow{id: id, row: row})
+	}
+
+	// Close file immediately — all data is now in memory
+	r.Close()
+	file.Close()
+
+	// Re-sort by trace ID for the multiblock merge iterator
+	sort.Slice(rows, func(i, j int) bool {
+		return bytes.Compare(rows[i].id, rows[j].id) < 0
+	})
+
+	return newRowIterator(rows), nil
 }
 
 type pageFile struct {
@@ -912,67 +971,46 @@ func parseName(filename string) (uuid.UUID, string, string, error) {
 	return id, tenant, version, nil
 }
 
-// rowIterator is used to iterate a parquet file and implement iterIterator
-// traces are iterated according to the given row numbers, because there is
-// not a guarantee that the underlying parquet file is sorted
-type rowIterator struct {
-	reader       *parquet.Reader //nolint:all //deprecated
-	pageFile     *pageFile
-	rowNumbers   []common.IDMapEntry[int64]
-	traceIDIndex int
+// readRow holds a pre-read parquet row and its trace ID.
+type readRow struct {
+	id  common.ID
+	row parquet.Row
 }
 
-func newRowIterator(r *parquet.Reader, pageFile *pageFile, rowNumbers []common.IDMapEntry[int64], traceIDIndex int) *rowIterator { //nolint:all //deprecated
-	return &rowIterator{
-		reader:       r,
-		pageFile:     pageFile,
-		rowNumbers:   rowNumbers,
-		traceIDIndex: traceIDIndex,
-	}
+// rowIterator iterates pre-read parquet rows sorted by trace ID.
+// Rows are read eagerly and sequentially from the WAL page file during
+// construction (avoiding random-seek decompression overhead), then the
+// file is closed immediately. Each row is copied to a right-sized slice
+// so the heap stays compact and GC-friendly.
+type rowIterator struct {
+	rows   []readRow
+	cursor int
+}
+
+func newRowIterator(rows []readRow) *rowIterator {
+	return &rowIterator{rows: rows}
 }
 
 func (i *rowIterator) peekNextID(context.Context) (common.ID, error) { //nolint:unused //this is being marked as unused, but it's required to satisfy the bookmarkIterator interface
-	if len(i.rowNumbers) == 0 {
+	if i.cursor >= len(i.rows) {
 		return nil, nil
 	}
 
-	return i.rowNumbers[0].ID, nil
+	return i.rows[i.cursor].id, nil
 }
 
 func (i *rowIterator) Next(context.Context) (common.ID, parquet.Row, error) {
-	if len(i.rowNumbers) == 0 {
+	if i.cursor >= len(i.rows) {
 		return nil, nil, nil
 	}
 
-	nextRowNumber := i.rowNumbers[0]
-	i.rowNumbers = i.rowNumbers[1:]
-
-	err := i.reader.SeekToRow(nextRowNumber.Entry)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	rows := []parquet.Row{completeBlockRowPool.Get()}
-	_, err = i.reader.ReadRows(rows)
-	if err != nil && !errors.Is(err, io.EOF) {
-		return nil, nil, err
-	}
-
-	row := rows[0]
-	var id common.ID
-	for _, v := range row {
-		if v.Column() == i.traceIDIndex {
-			id = v.ByteArray()
-			break
-		}
-	}
-
-	return id, row, nil
+	r := i.rows[i.cursor]
+	i.cursor++
+	return r.id, r.row, nil
 }
 
 func (i *rowIterator) Close() {
-	i.reader.Close()
-	i.pageFile.Close()
+	i.rows = nil
 }
 
 var _ common.Iterator = (*commonIterator)(nil)

--- a/tempodb/encoding/vparquet5/wal_block_test.go
+++ b/tempodb/encoding/vparquet5/wal_block_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/tempo/pkg/traceql"
 	"github.com/grafana/tempo/pkg/util/test"
 	"github.com/grafana/tempo/tempodb/backend"
+	"github.com/grafana/tempo/tempodb/backend/local"
 	"github.com/grafana/tempo/tempodb/encoding/common"
 
 	"github.com/stretchr/testify/assert"
@@ -325,6 +326,111 @@ func testWalBlock(t *testing.T, f func(w *walBlock, ids []common.ID, trs []*temp
 	require.NoError(t, w.Flush())
 
 	f(w, ids, trs)
+}
+
+func BenchmarkWalBlockIterator(b *testing.B) {
+	for _, tc := range []struct {
+		name           string
+		tracesPerFlush int
+		flushes        int
+		spansPerTrace  int
+	}{
+		{"10traces_5flushes_10spans", 10, 5, 10},
+		{"100traces_10flushes_10spans", 100, 10, 10},
+		{"100traces_50flushes_10spans", 100, 50, 10},
+		// {"100traces_50flushes_100spans", 100, 50, 100},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			w := createBenchWALBlock(b, tc.tracesPerFlush, tc.flushes, tc.spansPerTrace)
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				iter, err := w.Iterator()
+				require.NoError(b, err)
+
+				for {
+					id, tr, err := iter.Next(context.Background())
+					require.NoError(b, err)
+					if id == nil || tr == nil {
+						break
+					}
+				}
+				iter.Close()
+			}
+		})
+	}
+}
+
+func BenchmarkWalBlockCompleteBlock(b *testing.B) {
+	for _, tc := range []struct {
+		name           string
+		tracesPerFlush int
+		flushes        int
+		spansPerTrace  int
+	}{
+		{"10traces_5flushes_10spans", 10, 5, 10},
+		{"100traces_10flushes_10spans", 100, 10, 10},
+		{"100traces_50flushes_10spans", 100, 50, 10},
+		// {"100traces_50flushes_100spans", 100, 50, 100},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			w := createBenchWALBlock(b, tc.tracesPerFlush, tc.flushes, tc.spansPerTrace)
+
+			cfg := &common.BlockConfig{
+				BloomFP:             0.01,
+				BloomShardSizeBytes: 100 * 1024,
+				RowGroupSizeBytes:   100_000_000,
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				dir := b.TempDir()
+				rawR, rawW, _, err := local.New(&local.Config{Path: dir})
+				require.NoError(b, err)
+				r := backend.NewReader(rawR)
+				wr := backend.NewWriter(rawW)
+
+				iter, err := w.Iterator()
+				require.NoError(b, err)
+
+				_, err = CreateBlock(context.Background(), cfg, w.BlockMeta(), iter, r, wr)
+				require.NoError(b, err)
+				iter.Close()
+			}
+		})
+	}
+}
+
+func createBenchWALBlock(b *testing.B, tracesPerFlush, flushes, spansPerTrace int) *walBlock {
+	b.Helper()
+
+	meta := backend.NewBlockMeta("fake", uuid.New(), VersionString)
+	w, err := createWALBlock(meta, b.TempDir(), model.CurrentEncoding, 0)
+	require.NoError(b, err)
+
+	decoder := model.MustNewSegmentDecoder(model.CurrentEncoding)
+
+	for f := 0; f < flushes; f++ {
+		for t := 0; t < tracesPerFlush; t++ {
+			id := test.ValidTraceID(nil)
+			tr := test.MakeTrace(spansPerTrace, id)
+			trace.SortTrace(tr)
+
+			b1, err := decoder.PrepareForWrite(tr, 0, 0)
+			require.NoError(b, err)
+			b2, err := decoder.ToObject([][]byte{b1})
+			require.NoError(b, err)
+
+			err = w.Append(id, b2, 0, 0, true)
+			require.NoError(b, err)
+		}
+		require.NoError(b, w.Flush())
+	}
+
+	return w
 }
 
 func BenchmarkWalTraceQL(b *testing.B) {


### PR DESCRIPTION
**What this PR does**:

Replaced the rowIterator from a lazy file-backed iterator to an eager memory-backed one. Now each WAL page file is:
(1) Rows read sequentially (sorted by physical row number)
(2) Copied to right-sized slices (~16KB vs 3.2MB pool entries)
(3) File closed immediately
(4) Rows re-sorted by trace ID and served from memory

This avoids random-seek decompression overhead in the parquet reader and keeps the heap compact by not holding oversized pool entries.

<details>

<summary> Benchmark </summary>
goos: darwin
goarch: arm64
pkg: github.com/grafana/tempo/tempodb/encoding/vparquet5
cpu: Apple M2 Pro
                                                     │   old.txt    │               new.txt               │
                                                     │    sec/op    │    sec/op     vs base               │
WalBlockIterator/10traces_5flushes_10spans-12           57.86m ± 5%   32.93m ±  3%  -43.10% (p=0.002 n=6)
WalBlockIterator/100traces_10flushes_10spans-12        3133.0m ± 1%   571.3m ±  6%  -81.76% (p=0.002 n=6)
WalBlockIterator/100traces_50flushes_10spans-12         15.876 ± 1%    3.031 ±  5%  -80.91% (p=0.002 n=6)
WalBlockCompleteBlock/10traces_5flushes_10spans-12      46.56m ± 5%   28.46m ± 10%  -38.88% (p=0.002 n=6)
WalBlockCompleteBlock/100traces_10flushes_10spans-12   3095.2m ± 2%   555.7m ± 10%  -82.04% (p=0.002 n=6)
WalBlockCompleteBlock/100traces_50flushes_10spans-12    15.965 ± 2%    3.128 ± 12%  -80.41% (p=0.002 n=6)
geomean                                                  1.370        375.9m        -72.57%

                                                     │    old.txt    │               new.txt               │
                                                     │     B/op      │     B/op      vs base               │
WalBlockIterator/10traces_5flushes_10spans-12          161.70Mi ± 1%   48.98Mi ± 3%  -69.71% (p=0.002 n=6)
WalBlockIterator/100traces_10flushes_10spans-12        3646.1Mi ± 0%   846.1Mi ± 1%  -76.79% (p=0.002 n=6)
WalBlockIterator/100traces_50flushes_10spans-12        17.802Gi ± 0%   4.103Gi ± 0%  -76.95% (p=0.002 n=6)
WalBlockCompleteBlock/10traces_5flushes_10spans-12      41.89Mi ± 6%   43.74Mi ± 7%        ~ (p=0.310 n=6)
WalBlockCompleteBlock/100traces_10flushes_10spans-12   1234.3Mi ± 1%   676.4Mi ± 3%  -45.20% (p=0.002 n=6)
WalBlockCompleteBlock/100traces_50flushes_10spans-12    5.733Gi ± 3%   3.152Gi ± 8%  -45.02% (p=0.002 n=6)
geomean                                                 1.189Gi        505.2Mi       -58.51%

                                                     │    old.txt    │              new.txt               │
                                                     │   allocs/op   │  allocs/op   vs base               │
WalBlockIterator/10traces_5flushes_10spans-12            632.4k ± 4%   543.4k ± 3%  -14.08% (p=0.002 n=6)
WalBlockIterator/100traces_10flushes_10spans-12          22.91M ± 1%   10.40M ± 1%  -54.58% (p=0.002 n=6)
WalBlockIterator/100traces_50flushes_10spans-12         114.92M ± 0%   51.97M ± 1%  -54.78% (p=0.002 n=6)
WalBlockCompleteBlock/10traces_5flushes_10spans-12      132.94k ± 8%   44.09k ± 2%  -66.84% (p=0.002 n=6)
WalBlockCompleteBlock/100traces_10flushes_10spans-12   12930.2k ± 1%   383.0k ± 1%  -97.04% (p=0.002 n=6)
WalBlockCompleteBlock/100traces_50flushes_10spans-12    64.530M ± 0%   1.864M ± 0%  -97.11% (p=0.002 n=6)
geomean                                                  7.546M        1.449M       -80.80%
</details>

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`