### PR TITLE
[jsonnet]: set block-builder to follow repliacs of live-store by default

### DIFF
--- a/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-block-builder.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-block-builder.yaml
@@ -15,6 +15,9 @@ spec:
     metadata:
       annotations:
         config_hash: 42cd6f6d5e54ec2a274f12dc9d7e8d7b
+        grafana.com/rollout-mirror-replicas-from-resource-api-version: apps/v1
+        grafana.com/rollout-mirror-replicas-from-resource-kind: StatefulSet
+        grafana.com/rollout-mirror-replicas-from-resource-name: live-store-zone-a
       labels:
         app: block-builder
         name: block-builder

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-block-builder.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-block-builder.yaml
@@ -15,6 +15,9 @@ spec:
     metadata:
       annotations:
         config_hash: a5b7fad9d4b66ac43fbbccf8f3b51ab0
+        grafana.com/rollout-mirror-replicas-from-resource-api-version: apps/v1
+        grafana.com/rollout-mirror-replicas-from-resource-kind: StatefulSet
+        grafana.com/rollout-mirror-replicas-from-resource-name: live-store-zone-a
       labels:
         app: block-builder
         name: block-builder

--- a/operations/jsonnet/microservices/block-builder.libsonnet
+++ b/operations/jsonnet/microservices/block-builder.libsonnet
@@ -23,6 +23,8 @@
     'mem-ballast-size-mbs': $._config.ballast_size_mbs,
   },
 
+  tempo_block_builder_follow_controller:: $.tempo_live_store_zone_a_statefulset,
+
   tempo_block_builder_container::
     container.new(target_name, $._images.tempo_block_builder) +
     container.withPorts($.tempo_block_builder_ports) +
@@ -42,6 +44,9 @@
     statefulset.spec.template.spec.securityContext.withFsGroup(10001) +  // 10001 is the UID of the tempo user
     statefulset.mixin.spec.template.metadata.withAnnotations({
       config_hash: std.md5(std.toString($.tempo_block_builder_configmap.data['tempo.yaml'])),
+      'grafana.com/rollout-mirror-replicas-from-resource-name': $.tempo_block_builder_follow_controller.metadata.name,
+      'grafana.com/rollout-mirror-replicas-from-resource-kind': $.tempo_block_builder_follow_controller.kind,
+      'grafana.com/rollout-mirror-replicas-from-resource-api-version': $.tempo_block_builder_follow_controller.apiVersion,
     }) +
     statefulset.mixin.spec.template.spec.withVolumes([
       volume.fromConfigMap(tempo_config_volume, $.tempo_block_builder_configmap.metadata.name),


### PR DESCRIPTION
**What this PR does**:

Here we set the rollout-operator to manage the replicas of the block-builder and follow the live-store, since the replicas should always match.  Rollout-operator is no longer optional for live-store, and so we continue to leverage it here for this purpose.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`