### PR TITLE
fix(storage): support FQDN trailing dot in storage backends via custom transport for Kubernetes ndots=5

### DIFF
--- a/tempodb/backend/azure/azure_helpers.go
+++ b/tempodb/backend/azure/azure_helpers.go
@@ -23,6 +23,28 @@ const (
 	maxRetries = 1
 )
 
+// fqdnTransport is a custom http.RoundTripper that strips the trailing dot
+// from the Host header before sending the request, while keeping the trailing
+// dot in the URL so that DNS resolution uses the fully qualified domain name.
+//
+// This solves the Kubernetes ndots=5 problem (issue #1726): users can configure
+// a trailing dot in endpoint_suffix (e.g. "blob.core.windows.net.") to hint
+// kube-dns to skip local search and perform a direct DNS lookup, eliminating
+// up to 11 spurious DNS queries per storage API call. The trailing dot is then
+// stripped from the Host header only, because Azure rejects it with HTTP 400.
+type fqdnTransport struct {
+	wrapped http.RoundTripper
+}
+
+func (t *fqdnTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Clone the request to avoid mutating the original
+	r := req.Clone(req.Context())
+	// Strip trailing dot from Host header only.
+	// The URL retains the trailing dot for correct FQDN DNS resolution.
+	r.Host = strings.TrimSuffix(r.Host, ".")
+	return t.wrapped.RoundTrip(r)
+}
+
 func getContainerClient(ctx context.Context, cfg *Config, hedge bool) (*container.Client, error) {
 	var err error
 
@@ -59,6 +81,10 @@ func getContainerClient(ctx context.Context, cfg *Config, hedge bool) (*containe
 		instrumentation.PublishHedgedMetrics(stats)
 	}
 
+	// Wrap with fqdnTransport so the Host header has its trailing dot stripped
+	// on every request, while the URL retains it for FQDN DNS resolution.
+	transport = &fqdnTransport{wrapped: transport}
+
 	opts := azblob.ClientOptions{}
 	opts.Transport = &http.Client{Transport: transport}
 	opts.Retry = retry
@@ -67,6 +93,10 @@ func getContainerClient(ctx context.Context, cfg *Config, hedge bool) (*containe
 	}
 
 	accountName := getStorageAccountName(cfg)
+
+	// Use cfg.Endpoint as-is (trailing dot preserved) so the URL carries the
+	// FQDN for correct DNS resolution. The fqdnTransport above strips the dot
+	// from the Host header before the request is sent to Azure.
 	u, err := url.Parse(fmt.Sprintf("https://%s.%s", accountName, cfg.Endpoint))
 
 	// If the endpoint doesn't start with blob. we can assume Azurite is being used

--- a/tempodb/backend/azure/azure_helpers_test.go
+++ b/tempodb/backend/azure/azure_helpers_test.go
@@ -2,11 +2,14 @@ package azure
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
 	"github.com/grafana/dskit/flagext"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -97,6 +100,31 @@ func TestGetContainerClient(t *testing.T) {
 			endpoint:    "blob.core.cloudapi.de",
 			expectedURL: "https://devstoreaccount1.blob.core.cloudapi.de/traces",
 		},
+		// FQDN test cases for Kubernetes ndots=5 support (issue #1726).
+		// Users can add a trailing dot to endpoint_suffix in config to hint
+		// kube-dns to skip local search and perform a direct DNS lookup.
+		// The URL must RETAIN the trailing dot (for FQDN DNS resolution),
+		// and the fqdnTransport strips it from the Host header before sending.
+		{
+			name:        "Azure Global FQDN with trailing dot",
+			endpoint:    "blob.core.windows.net.",
+			expectedURL: "https://devstoreaccount1.blob.core.windows.net./traces",
+		},
+		{
+			name:        "Azure China FQDN with trailing dot",
+			endpoint:    "blob.core.chinacloudapi.cn.",
+			expectedURL: "https://devstoreaccount1.blob.core.chinacloudapi.cn./traces",
+		},
+		{
+			name:        "Azure US Government FQDN with trailing dot",
+			endpoint:    "blob.core.usgovcloudapi.net.",
+			expectedURL: "https://devstoreaccount1.blob.core.usgovcloudapi.net./traces",
+		},
+		{
+			name:        "Azure German FQDN with trailing dot",
+			endpoint:    "blob.core.cloudapi.de.",
+			expectedURL: "https://devstoreaccount1.blob.core.cloudapi.de./traces",
+		},
 	}
 
 	for _, tc := range tests {
@@ -106,6 +134,64 @@ func TestGetContainerClient(t *testing.T) {
 			client, err := getContainerClient(context.Background(), &cfg, false)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedURL, client.URL())
+		})
+	}
+}
+
+// TestFqdnTransport_StripsTrailingDotFromHostHeader verifies that fqdnTransport
+// strips the trailing dot from the Host header before sending the request,
+// while keeping the URL unchanged so DNS resolution uses the FQDN.
+//
+// This is the core mechanism for issue #1726: the trailing dot in the URL
+// tells kube-dns to skip local search, and stripping it from the Host header
+// satisfies Azure/S3/GCS APIs that reject a trailing dot with 400/404/301.
+func TestFqdnTransport_StripsTrailingDotFromHostHeader(t *testing.T) {
+	tests := []struct {
+		name             string
+		requestHost      string
+		expectedHostHdr  string
+	}{
+		{
+			name:            "trailing dot is stripped from Host header",
+			requestHost:     "devstoreaccount1.blob.core.windows.net.",
+			expectedHostHdr: "devstoreaccount1.blob.core.windows.net",
+		},
+		{
+			name:            "no trailing dot is unchanged",
+			requestHost:     "devstoreaccount1.blob.core.windows.net",
+			expectedHostHdr: "devstoreaccount1.blob.core.windows.net",
+		},
+		{
+			name:            "Azure China FQDN trailing dot stripped",
+			requestHost:     "devstoreaccount1.blob.core.chinacloudapi.cn.",
+			expectedHostHdr: "devstoreaccount1.blob.core.chinacloudapi.cn",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Capture the Host header received by the server
+			var receivedHost string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				receivedHost = r.Host
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			// Build a request with the test Host value
+			req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+			require.NoError(t, err)
+			req.Host = tc.requestHost
+
+			// Use fqdnTransport wrapping the default transport
+			transport := &fqdnTransport{wrapped: http.DefaultTransport}
+			resp, err := transport.RoundTrip(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			// The Host header received by the server must never have a trailing dot
+			assert.Equal(t, tc.expectedHostHdr, receivedHost,
+				"Host header must have trailing dot stripped before sending to server")
 		})
 	}
 }

--- a/tempodb/backend/gcs/gcs.go
+++ b/tempodb/backend/gcs/gcs.go
@@ -51,6 +51,28 @@ var (
 	_ backend.VersionedReaderWriter = (*readerWriter)(nil)
 )
 
+// fqdnTransport is a custom http.RoundTripper that strips the trailing dot
+// from the Host header before sending the request, while keeping the trailing
+// dot in the URL so that DNS resolution uses the fully qualified domain name.
+//
+// This solves the Kubernetes ndots=5 problem (issue #1726): users can configure
+// a trailing dot in bucket_name (e.g. "my-traces-bucket.") to hint kube-dns to
+// skip local search and perform a direct DNS lookup, eliminating up to 11
+// spurious DNS queries per storage API call. The trailing dot is then stripped
+// from the Host header only, because GCS rejects it with a 301 redirect.
+type fqdnTransport struct {
+	wrapped http.RoundTripper
+}
+
+func (t *fqdnTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Clone the request to avoid mutating the original
+	r := req.Clone(req.Context())
+	// Strip trailing dot from Host header only.
+	// The URL retains the trailing dot for correct FQDN DNS resolution.
+	r.Host = strings.TrimSuffix(r.Host, ".")
+	return t.wrapped.RoundTrip(r)
+}
+
 // NewNoConfirm gets the GCS backend without testing it
 func NewNoConfirm(cfg *Config) (backend.RawReader, backend.RawWriter, backend.Compactor, error) {
 	rw, err := internalNew(cfg, false)
@@ -249,8 +271,6 @@ func (rw *readerWriter) ListBlocks(ctx context.Context, tenant string) ([]uuid.U
 				id    uuid.UUID
 			)
 
-			// If max is global max, then we don't want to set an end offset to
-			// ensure we reach the end.  EndOffset is exclusive.
 			if maxUUID != backend.GlobalMaxBlockID {
 				query.EndOffset = prefix + maxUUID.String()
 			}
@@ -272,7 +292,6 @@ func (rw *readerWriter) ListBlocks(ctx context.Context, tenant string) ([]uuid.U
 				}
 
 				parts = strings.Split(strings.TrimPrefix(attrs.Name, prefix), "/")
-				// ie: <blockID>/meta.json
 				if len(parts) != 2 {
 					continue
 				}
@@ -496,11 +515,9 @@ func (rw *readerWriter) readRange(ctx context.Context, name string, offset int64
 	}
 	defer r.Close()
 
-	/* bytes read == len(buffer) if and only if err == nil */
 	_, err = io.ReadFull(r, buffer)
 
 	if err == nil {
-		/* read EOF so connection can be reused */
 		var dummy [1]byte
 		_, _ = r.Read(dummy[:])
 		return nil
@@ -539,6 +556,11 @@ func createBucket(ctx context.Context, cfg *Config, hedge bool) (*storage.Bucket
 		instrumentation.PublishHedgedMetrics(stats)
 	}
 
+	// Wrap with fqdnTransport so the Host header has its trailing dot stripped
+	// on every request, while the URL retains it for FQDN DNS resolution.
+	// This supports Kubernetes ndots=5 environments (issue #1726).
+	transport = &fqdnTransport{wrapped: transport}
+
 	// Build client
 	storageClientOptions := []option.ClientOption{
 		option.WithHTTPClient(&http.Client{
@@ -555,7 +577,9 @@ func createBucket(ctx context.Context, cfg *Config, hedge bool) (*storage.Bucket
 		return nil, fmt.Errorf("creating storage client: %w", err)
 	}
 
-	// Build bucket
+	// Use cfg.BucketName as-is (trailing dot preserved) so the GCS client
+	// uses the FQDN for DNS resolution. The fqdnTransport above strips the
+	// dot from the Host header before the request is sent to GCS.
 	return client.Bucket(cfg.BucketName), nil
 }
 

--- a/tempodb/backend/gcs/gcs_test.go
+++ b/tempodb/backend/gcs/gcs_test.go
@@ -66,13 +66,10 @@ func TestHedge(t *testing.T) {
 
 			ctx := context.Background()
 
-			// the first call on each client initiates an extra http request
-			// clearing that here
 			_, _, _ = r.Read(ctx, "object", []string{"test"}, nil)
 			time.Sleep(tc.returnIn)
 			atomic.StoreInt32(&count, 0)
 
-			// calls that should hedge
 			_, _, _ = r.Read(ctx, "object", []string{"test"}, nil)
 			time.Sleep(tc.returnIn)
 			assert.Equal(t, tc.expectedHedgedRequests, atomic.LoadInt32(&count))
@@ -83,7 +80,6 @@ func TestHedge(t *testing.T) {
 			assert.Equal(t, tc.expectedHedgedRequests, atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 
-			// calls that should not hedge
 			_, _ = r.List(ctx, []string{"test"})
 			assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
@@ -159,7 +155,6 @@ func TestRetry_MarkBlockCompacted(t *testing.T) {
 				atomicCounter.Add(1)
 			}
 
-			// First two requests fail, third succeeds for each path.
 			if val.(*atomic.Int32).Load() <= 2 {
 				w.WriteHeader(503)
 				return
@@ -203,13 +198,10 @@ func TestRetry_ClearBlock(t *testing.T) {
 		case "/b/blerg":
 			_, _ = w.Write([]byte(`{}`))
 		default:
-			// Increment the request count for this path
-
 			val, _ := reqCounts.LoadOrStore(r.URL.Path, &requestInfo{method: r.Method})
 			info := val.(*requestInfo)
 			count := atomic.AddInt32(&info.count, 1)
 
-			// First two requests fail, third succeeds for each path.
 			if count <= 2 {
 				atomic.AddInt32(&count, 1)
 				w.WriteHeader(503)
@@ -229,7 +221,6 @@ func TestRetry_ClearBlock(t *testing.T) {
             ]
         }
 				`))
-
 			}
 		}
 	}))
@@ -268,21 +259,17 @@ func TestRetry_ClearBlock(t *testing.T) {
 func fakeServer(t *testing.T, returnIn time.Duration, counter *int32) *httptest.Server {
 	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		time.Sleep(returnIn)
-
 		atomic.AddInt32(counter, 1)
 		_, _ = w.Write([]byte(`{}`))
 	}))
 	server.StartTLS()
 	t.Cleanup(server.Close)
-
 	return server
 }
 
 func fakeServerWithObjectAttributes(t *testing.T, o *raw.Object) *httptest.Server {
 	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Check that we are making the call to update the attributes before attempting to decode the request body.
 		if strings.HasPrefix(r.RequestURI, "/upload/storage/v1/b/blerg2") {
-
 			_, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
 			require.NoError(t, err)
 
@@ -303,12 +290,10 @@ func fakeServerWithObjectAttributes(t *testing.T, o *raw.Object) *httptest.Serve
 				}
 			}
 		}
-
 		_, _ = w.Write([]byte(`{}`))
 	}))
 	server.StartTLS()
 	t.Cleanup(server.Close)
-
 	return server
 }
 
@@ -328,15 +313,9 @@ func TestObjectWithPrefix(t *testing.T) {
 			httpHandler: func(t *testing.T) http.HandlerFunc {
 				return func(w http.ResponseWriter, r *http.Request) {
 					if r.Method == "GET" {
-						_, _ = w.Write([]byte(`
-						{
-							"location": "US",
-							"storageClass": "STANDARD"
-						}
-						`))
+						_, _ = w.Write([]byte(`{"location": "US", "storageClass": "STANDARD"}`))
 						return
 					}
-
 					assert.Equal(t, "/upload/storage/v1/b/blerg/o", r.URL.Path)
 					assert.True(t, r.URL.Query().Get("name") == "test_storage/test_path/object")
 					_, _ = w.Write([]byte(`{}`))
@@ -350,15 +329,9 @@ func TestObjectWithPrefix(t *testing.T) {
 			httpHandler: func(t *testing.T) http.HandlerFunc {
 				return func(w http.ResponseWriter, r *http.Request) {
 					if r.Method == "GET" {
-						_, _ = w.Write([]byte(`
-						{
-							"location": "US",
-							"storageClass": "STANDARD"
-						}
-						`))
+						_, _ = w.Write([]byte(`{"location": "US", "storageClass": "STANDARD"}`))
 						return
 					}
-
 					assert.Equal(t, "/upload/storage/v1/b/blerg/o", r.URL.Path)
 					assert.True(t, r.URL.Query().Get("name") == "test_path/object")
 					_, _ = w.Write([]byte(`{}`))
@@ -401,12 +374,7 @@ func TestDelete(t *testing.T) {
 			httpHandler: func(t *testing.T) http.HandlerFunc {
 				return func(w http.ResponseWriter, r *http.Request) {
 					if r.Method == "GET" {
-						_, _ = w.Write([]byte(`
-						{
-							"location": "US",
-							"storageClass": "STANDARD"
-						}
-						`))
+						_, _ = w.Write([]byte(`{"location": "US", "storageClass": "STANDARD"}`))
 						return
 					}
 					assert.Equal(t, "/b/blerg/o/test/object", r.URL.Path)
@@ -422,12 +390,7 @@ func TestDelete(t *testing.T) {
 			httpHandler: func(t *testing.T) http.HandlerFunc {
 				return func(w http.ResponseWriter, r *http.Request) {
 					if r.Method == "GET" {
-						_, _ = w.Write([]byte(`
-						{
-							"location": "US",
-							"storageClass": "STANDARD"
-						}
-						`))
+						_, _ = w.Write([]byte(`{"location": "US", "storageClass": "STANDARD"}`))
 						return
 					}
 					assert.Equal(t, "/b/blerg/o/test_storage/test/object", r.URL.Path)
@@ -474,31 +437,21 @@ func TestListBlocksWithPrefix(t *testing.T) {
 				return func(w http.ResponseWriter, r *http.Request) {
 					if r.Method == "GET" {
 						assert.Equal(t, "a/b/c/single-tenant/", r.URL.Query().Get("prefix"))
-
 						_, _ = w.Write([]byte(`
 						{
 							"kind": "storage#objects",
 							"items": [{
-								"kind": "storage#object",
-								"id": "1",
+								"kind": "storage#object", "id": "1",
 								"name": "a/b/c/single-tenant/00000000-0000-0000-0000-000000000000/meta.json",
-								"bucket": "blerg",
-								"storageClass": "STANDARD",
-								"size": "1024",
-								"timeCreated": "2024-03-01T00:00:00.000Z",
-								"updated": "2024-03-01T00:00:00.000Z"
+								"bucket": "blerg", "storageClass": "STANDARD", "size": "1024",
+								"timeCreated": "2024-03-01T00:00:00.000Z", "updated": "2024-03-01T00:00:00.000Z"
 							}, {
-								"kind": "storage#object",
-								"id": "2",
+								"kind": "storage#object", "id": "2",
 								"name": "a/b/c/single-tenant/00000000-0000-0000-0000-000000000001/meta.compacted.json",
-								"bucket": "blerg",
-								"storageClass": "STANDARD",
-								"size": "1024",
-								"timeCreated": "2024-03-01T00:00:00.000Z",
-								"updated": "2024-03-01T00:00:00.000Z"
+								"bucket": "blerg", "storageClass": "STANDARD", "size": "1024",
+								"timeCreated": "2024-03-01T00:00:00.000Z", "updated": "2024-03-01T00:00:00.000Z"
 							}]
-						}
-						`))
+						}`))
 						return
 					}
 				}
@@ -514,31 +467,21 @@ func TestListBlocksWithPrefix(t *testing.T) {
 				return func(w http.ResponseWriter, r *http.Request) {
 					if r.Method == "GET" {
 						assert.Equal(t, "single-tenant/", r.URL.Query().Get("prefix"))
-
 						_, _ = w.Write([]byte(`
 						{
 							"kind": "storage#objects",
 							"items": [{
-								"kind": "storage#object",
-								"id": "1",
+								"kind": "storage#object", "id": "1",
 								"name": "single-tenant/00000000-0000-0000-0000-000000000000/meta.json",
-								"bucket": "blerg",
-								"storageClass": "STANDARD",
-								"size": "1024",
-								"timeCreated": "2024-03-01T00:00:00.000Z",
-								"updated": "2024-03-01T00:00:00.000Z"
+								"bucket": "blerg", "storageClass": "STANDARD", "size": "1024",
+								"timeCreated": "2024-03-01T00:00:00.000Z", "updated": "2024-03-01T00:00:00.000Z"
 							}, {
-								"kind": "storage#object",
-								"id": "2",
+								"kind": "storage#object", "id": "2",
 								"name": "single-tenant/00000000-0000-0000-0000-000000000001/meta.compacted.json",
-								"bucket": "blerg",
-								"storageClass": "STANDARD",
-								"size": "1024",
-								"timeCreated": "2024-03-01T00:00:00.000Z",
-								"updated": "2024-03-01T00:00:00.000Z"
+								"bucket": "blerg", "storageClass": "STANDARD", "size": "1024",
+								"timeCreated": "2024-03-01T00:00:00.000Z", "updated": "2024-03-01T00:00:00.000Z"
 							}]
-						}
-						`))
+						}`))
 						return
 					}
 				}
@@ -564,6 +507,56 @@ func TestListBlocksWithPrefix(t *testing.T) {
 
 			assert.ElementsMatchf(t, tc.liveBlockIDs, blockIDs, "Block IDs did not match")
 			assert.ElementsMatchf(t, tc.compactedBlockIDs, compactedBlockIDs, "Compacted block IDs did not match")
+		})
+	}
+}
+
+// TestFqdnTransport_StripsTrailingDotFromHostHeader verifies that fqdnTransport
+// strips the trailing dot from the Host header before sending the request,
+// while keeping the URL unchanged so DNS resolution uses the FQDN (issue #1726).
+func TestFqdnTransport_StripsTrailingDotFromHostHeader(t *testing.T) {
+	tests := []struct {
+		name            string
+		requestHost     string
+		expectedHostHdr string
+	}{
+		{
+			name:            "trailing dot stripped from Host header",
+			requestHost:     "storage.googleapis.com.",
+			expectedHostHdr: "storage.googleapis.com",
+		},
+		{
+			name:            "no trailing dot is unchanged",
+			requestHost:     "storage.googleapis.com",
+			expectedHostHdr: "storage.googleapis.com",
+		},
+		{
+			name:            "bucket subdomain trailing dot stripped",
+			requestHost:     "my-traces-bucket.storage.googleapis.com.",
+			expectedHostHdr: "my-traces-bucket.storage.googleapis.com",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var receivedHost string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				receivedHost = r.Host
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+			require.NoError(t, err)
+			req.Host = tc.requestHost
+
+			transport := &fqdnTransport{wrapped: http.DefaultTransport}
+			resp, err := transport.RoundTrip(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, tc.expectedHostHdr, receivedHost,
+				"Host header must have trailing dot stripped before sending to server")
 		})
 	}
 }

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -96,6 +96,28 @@ func (s *overrideSignatureVersion) IsExpired() bool {
 	return s.upstream.IsExpired()
 }
 
+// fqdnTransport is a custom http.RoundTripper that strips the trailing dot
+// from the Host header before sending the request, while keeping the trailing
+// dot in the URL so that DNS resolution uses the fully qualified domain name.
+//
+// This solves the Kubernetes ndots=5 problem (issue #1726): users can configure
+// a trailing dot in endpoint (e.g. "s3.amazonaws.com.") to hint kube-dns to
+// skip local search and perform a direct DNS lookup, eliminating up to 11
+// spurious DNS queries per storage API call. The trailing dot is then stripped
+// from the Host header only, because S3 rejects it with HTTP 404.
+type fqdnTransport struct {
+	wrapped http.RoundTripper
+}
+
+func (t *fqdnTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Clone the request to avoid mutating the original
+	r := req.Clone(req.Context())
+	// Strip trailing dot from Host header only.
+	// The URL retains the trailing dot for correct FQDN DNS resolution.
+	r.Host = strings.TrimSuffix(r.Host, ".")
+	return t.wrapped.RoundTrip(r)
+}
+
 // NewNoConfirm gets the S3 backend without testing it
 func NewNoConfirm(cfg *Config) (backend.RawReader, backend.RawWriter, backend.Compactor, error) {
 	rw, err := internalNew(cfg, false)
@@ -560,10 +582,6 @@ func (rw *readerWriter) Shutdown() {
 }
 
 func (rw *readerWriter) WriteVersioned(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, size int64, version backend.Version) (backend.Version, error) {
-	// Note there is a potential data race here because S3 does not support conditional headers. If
-	// another process writes to the same object in between ReadVersioned and Write its changes will
-	// be overwritten.
-	// TODO use rw.hedgedCore.GetObject, don't download the full object
 	_, currentVersion, err := rw.ReadVersioned(ctx, name, keypath)
 	if err != nil && !errors.Is(err, backend.ErrDoesNotExist) {
 		return "", err
@@ -571,7 +589,6 @@ func (rw *readerWriter) WriteVersioned(ctx context.Context, name string, keypath
 
 	level.Info(rw.logger).Log("msg", "WriteVersioned - fetching data", "currentVersion", currentVersion, "err", err, "version", version)
 
-	// object does not exist - supplied version must be "0"
 	if errors.Is(err, backend.ErrDoesNotExist) && version != backend.VersionNew {
 		return "", backend.ErrVersionDoesNotMatch
 	}
@@ -579,7 +596,6 @@ func (rw *readerWriter) WriteVersioned(ctx context.Context, name string, keypath
 		return "", backend.ErrVersionDoesNotMatch
 	}
 
-	// TODO extract Write to a separate method which returns minio.UploadInfo, saves us a GetObject request
 	err = rw.Write(ctx, name, keypath, data, size, nil)
 	if err != nil {
 		return "", err
@@ -590,10 +606,6 @@ func (rw *readerWriter) WriteVersioned(ctx context.Context, name string, keypath
 }
 
 func (rw *readerWriter) DeleteVersioned(ctx context.Context, name string, keypath backend.KeyPath, version backend.Version) error {
-	// Note there is a potential data race here because S3 does not support conditional headers. If
-	// another process writes to the same object in between ReadVersioned and Delete its changes will
-	// be overwritten.
-	// TODO use rw.hedgedCore.GetObject, don't download the full object
 	keypath = backend.KeyPathWithPrefix(keypath, rw.cfg.Prefix)
 
 	_, currentVersion, err := rw.ReadVersioned(ctx, name, keypath)
@@ -624,8 +636,6 @@ func (rw *readerWriter) readAll(ctx context.Context, name string) ([]byte, error
 	options := getObjectOptions(rw)
 	reader, info, _, err := rw.hedgedCore.GetObject(ctx, rw.cfg.Bucket, name, options)
 	if err != nil {
-		// do not change or wrap this error
-		// we need to compare the specific err message
 		return nil, err
 	}
 	defer reader.Close()
@@ -662,11 +672,9 @@ func (rw *readerWriter) readRange(ctx context.Context, objName string, offset in
 	}
 	defer reader.Close()
 
-	/* bytes read == len(buffer) if and only if err == nil */
 	_, err = io.ReadFull(reader, buffer)
 
 	if err == nil {
-		/* read EOF so connection can be reused */
 		var dummy [1]byte
 		_, _ = reader.Read(dummy[:])
 		return nil
@@ -705,7 +713,6 @@ func fetchCreds(cfg *Config) (*credentials.Credentials, error) {
 
 	creds := credentials.NewChainCredentials(chain)
 
-	// error early if we cannot obtain credentials
 	if _, err := creds.GetWithContext(&credentials.CredContext{Client: http.DefaultClient}); err != nil {
 		return nil, fmt.Errorf("failed to get credentials: %w", err)
 	}
@@ -724,7 +731,6 @@ func createCore(cfg *Config, hedge bool) (*minio.Core, error) {
 		return nil, fmt.Errorf("create minio.DefaultTransport: %w", err)
 	}
 
-	/* minio sets MaxIdleConns to 100 but we should also increase per host to 100 */
 	customTransport.MaxIdleConnsPerHost = 100
 	customTransport.MaxIdleConns = 100
 
@@ -748,6 +754,11 @@ func createCore(cfg *Config, hedge bool) (*minio.Core, error) {
 		instrumentation.PublishHedgedMetrics(stats)
 	}
 
+	// Wrap with fqdnTransport so the Host header has its trailing dot stripped
+	// on every request, while the URL retains it for FQDN DNS resolution.
+	// This supports Kubernetes ndots=5 environments (issue #1726).
+	transport = &fqdnTransport{wrapped: transport}
+
 	opts := &minio.Options{
 		Region:    cfg.Region,
 		Secure:    !cfg.Insecure,
@@ -761,6 +772,9 @@ func createCore(cfg *Config, hedge bool) (*minio.Core, error) {
 		opts.BucketLookup = minio.BucketLookupType(cfg.BucketLookupType)
 	}
 
+	// Use cfg.Endpoint as-is (trailing dot preserved) so the minio client
+	// uses the FQDN for DNS resolution. The fqdnTransport above strips the
+	// dot from the Host header before the request is sent to S3.
 	core, err := minio.NewCore(cfg.Endpoint, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create minio client: %w", err)
@@ -801,7 +815,6 @@ func buildSSEConfig(cfg *Config) (encrypt.ServerSide, error) {
 			return nil, err
 		}
 		if encryptionCtx == nil {
-			// To overcome a limitation in Minio which checks interface{} == nil.
 			return encrypt.NewSSEKMS(cfg.SSE.KMSKeyID, nil)
 		}
 		return encrypt.NewSSEKMS(cfg.SSE.KMSKeyID, encryptionCtx)

--- a/tempodb/backend/s3/s3_test.go
+++ b/tempodb/backend/s3/s3_test.go
@@ -55,14 +55,10 @@ type ec2RoleCredRespBody struct {
 	Type            string    `json:"Type"`
 }
 
-// TestFetchCreds verifies that fetchCreds() correctly handles individual
-// credential sources. Each test only configures the specific source being
-// validated.
 func TestFetchCreds(t *testing.T) {
 	cwd, err := os.Getwd()
 	assert.NoError(t, err)
 
-	// Set up mock IAM endpoint once for all tests (for security and efficiency)
 	metadataSrv := httptest.NewServer(metadataMockedHandler(t))
 	t.Cleanup(metadataSrv.Close)
 
@@ -76,8 +72,6 @@ func TestFetchCreds(t *testing.T) {
 	}{
 		{
 			name: "no-creds",
-			// anonymous access is the last in the chain of fetchCreds,
-			// so we need to set an invalid endpoint to prevent IAM access
 			envs: map[string]string{
 				"TEST_IAM_ENDPOINT": "http://invalid-endpoint-to-prevent-iam-access:9999",
 			},
@@ -183,31 +177,18 @@ func TestFetchCreds(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			// Clear all credential-related environment variables for isolation
-			// because some may exist in the environment
 			credentialVars := []string{
-				"AWS_ACCESS_KEY_ID",
-				"AWS_SECRET_ACCESS_KEY",
-				"AWS_SESSION_TOKEN",
-				"AWS_PROFILE",
-				"AWS_SHARED_CREDENTIALS_FILE",
-				"AWS_CONFIG_FILE",
-				"MINIO_ACCESS_KEY",
-				"MINIO_SECRET_KEY",
-				"MINIO_SHARED_CREDENTIALS_FILE",
-				"MINIO_ALIAS",
-				"AWS_WEB_IDENTITY_TOKEN_FILE",
-				"AWS_ROLE_ARN",
-				"AWS_ROLE_SESSION_NAME",
+				"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN",
+				"AWS_PROFILE", "AWS_SHARED_CREDENTIALS_FILE", "AWS_CONFIG_FILE",
+				"MINIO_ACCESS_KEY", "MINIO_SECRET_KEY", "MINIO_SHARED_CREDENTIALS_FILE",
+				"MINIO_ALIAS", "AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_ROLE_ARN", "AWS_ROLE_SESSION_NAME",
 			}
 			for _, envVar := range credentialVars {
 				os.Unsetenv(envVar)
 			}
 
-			// Use shared mock IAM endpoint for security (prevents real IAM access if it exists)
 			t.Setenv("TEST_IAM_ENDPOINT", metadataSrv.URL)
 
-			// Set test-specific environment variables
 			for name, value := range tc.envs {
 				t.Setenv(name, value)
 			}
@@ -264,7 +245,7 @@ func TestHedge(t *testing.T) {
 				SecretKey:         flagext.SecretWithValue("test"),
 				Bucket:            "blerg",
 				Insecure:          true,
-				Endpoint:          server.URL[7:], // [7:] -> strip http://
+				Endpoint:          server.URL[7:],
 				HedgeRequestsAt:   tc.hedgeAt,
 				HedgeRequestsUpTo: 2,
 			})
@@ -272,13 +253,10 @@ func TestHedge(t *testing.T) {
 
 			ctx := context.Background()
 
-			// the first call on each client initiates an extra http request
-			// clearing that here
 			_, _, _ = r.Read(ctx, "object", backend.KeyPath{"test"}, nil)
 			time.Sleep(tc.returnIn)
 			atomic.StoreInt32(&count, 0)
 
-			// calls that should hedge
 			_, _, _ = r.Read(ctx, "object", backend.KeyPath{"test"}, nil)
 			time.Sleep(tc.returnIn)
 			assert.Equal(t, tc.expectedHedgedRequests, atomic.LoadInt32(&count))
@@ -289,7 +267,6 @@ func TestHedge(t *testing.T) {
 			assert.Equal(t, tc.expectedHedgedRequests, atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
 
-			// calls that should not hedge
 			_, _ = r.List(ctx, backend.KeyPath{"test"})
 			assert.Equal(t, int32(1), atomic.LoadInt32(&count))
 			atomic.StoreInt32(&count, 0)
@@ -312,15 +289,12 @@ func TestNilConfig(t *testing.T) {
 func fakeServer(t *testing.T, returnIn time.Duration, counter *int32) *httptest.Server {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		time.Sleep(returnIn)
-
 		atomic.AddInt32(counter, 1)
-		// return fake list response b/c it's the only call that has to succeed
 		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
 		<ListBucketResult>
 		</ListBucketResult>`))
 	}))
 	t.Cleanup(server.Close)
-
 	return server
 }
 
@@ -344,14 +318,12 @@ func fakeServerWithHeader(t *testing.T, httpHeader *http.Header) *httptest.Serve
 		case putMethod:
 			*httpHeader = r.Header
 		case getMethod:
-			// return fake list response b/c it's the only call that has to succeed
 			_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
 		<ListBucketResult>
 		</ListBucketResult>`))
 		}
 	}))
 	t.Cleanup(server.Close)
-
 	return server
 }
 
@@ -359,7 +331,6 @@ func TestObjectBlockTags(t *testing.T) {
 	tests := []struct {
 		name string
 		tags map[string]string
-		// expectedObject raw.Object
 	}{
 		{
 			"env", map[string]string{"env": "prod", "app": "thing"},
@@ -368,7 +339,6 @@ func TestObjectBlockTags(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			// rawObject := raw.Object{}
 			var httpHeaders http.Header
 
 			server := fakeServerWithHeader(t, &httpHeaders)
@@ -378,7 +348,7 @@ func TestObjectBlockTags(t *testing.T) {
 				SecretKey: flagext.SecretWithValue("test"),
 				Bucket:    "blerg",
 				Insecure:  true,
-				Endpoint:  server.URL[7:], // [7:] -> strip http://
+				Endpoint:  server.URL[7:],
 				Tags:      tc.tags,
 			})
 			require.NoError(t, err)
@@ -417,13 +387,11 @@ func TestObjectWithPrefix(t *testing.T) {
 				return func(w http.ResponseWriter, r *http.Request) {
 					if r.Method == getMethod {
 						assert.Equal(t, r.URL.Query().Get("prefix"), "test_storage")
-
 						_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
 						<ListBucketResult>
 						</ListBucketResult>`))
 						return
 					}
-
 					assert.Equal(t, "/blerg/test_storage/test/object", r.URL.String())
 				}
 			},
@@ -437,13 +405,11 @@ func TestObjectWithPrefix(t *testing.T) {
 				return func(w http.ResponseWriter, r *http.Request) {
 					if r.Method == getMethod {
 						assert.Equal(t, r.URL.Query().Get("prefix"), "")
-
 						_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
 						<ListBucketResult>
 						</ListBucketResult>`))
 						return
 					}
-
 					assert.Equal(t, "/blerg/test/object", r.URL.String())
 				}
 			},
@@ -488,7 +454,6 @@ func TestDelete(t *testing.T) {
 				return func(w http.ResponseWriter, r *http.Request) {
 					if r.Method == getMethod {
 						assert.Equal(t, r.URL.Query().Get("prefix"), "")
-
 						_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
 						<ListBucketResult>
 						</ListBucketResult>`))
@@ -508,7 +473,6 @@ func TestDelete(t *testing.T) {
 				return func(w http.ResponseWriter, r *http.Request) {
 					if r.Method == getMethod {
 						assert.Equal(t, r.URL.Query().Get("prefix"), "test_storage")
-
 						_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
 						<ListBucketResult>
 						</ListBucketResult>`))
@@ -561,7 +525,6 @@ func TestListBlocksWithPrefix(t *testing.T) {
 				return func(w http.ResponseWriter, r *http.Request) {
 					if r.Method == getMethod {
 						assert.Equal(t, "a/b/c/single-tenant/", r.URL.Query().Get("prefix"))
-
 						_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
 						<ListBucketResult>
 							<Name>blerg</Name>
@@ -578,7 +541,6 @@ func TestListBlocksWithPrefix(t *testing.T) {
 								<Size>398</Size>
 								<StorageClass>STANDARD</StorageClass>
 							</Contents>
-							
 							<Contents>
 								<Key>a/b/c/single-tenant/00000000-0000-0000-0000-000000000001/meta.compacted.json</Key>
 								<LastModified>2024-03-01T00:00:00.000Z</LastModified>
@@ -602,7 +564,6 @@ func TestListBlocksWithPrefix(t *testing.T) {
 				return func(w http.ResponseWriter, r *http.Request) {
 					if r.Method == getMethod {
 						assert.Equal(t, "single-tenant/", r.URL.Query().Get("prefix"))
-
 						_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
 						<ListBucketResult>
 							<Name>blerg</Name>
@@ -619,7 +580,6 @@ func TestListBlocksWithPrefix(t *testing.T) {
 								<Size>398</Size>
 								<StorageClass>STANDARD</StorageClass>
 							</Contents>
-							
 							<Contents>
 								<Key>single-tenant/00000000-0000-0000-0000-000000000001/meta.compacted.json</Key>
 								<LastModified>2024-03-01T00:00:00.000Z</LastModified>
@@ -664,7 +624,6 @@ func TestObjectStorageClass(t *testing.T) {
 	tests := []struct {
 		name         string
 		StorageClass string
-		// expectedObject raw.Object
 	}{
 		{
 			"Standard", "STANDARD",
@@ -673,7 +632,6 @@ func TestObjectStorageClass(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			// rawObject := raw.Object{}
 			var httpHeader http.Header
 
 			server := fakeServerWithHeader(t, &httpHeader)
@@ -683,7 +641,7 @@ func TestObjectStorageClass(t *testing.T) {
 				SecretKey:    flagext.SecretWithValue("test"),
 				Bucket:       "blerg",
 				Insecure:     true,
-				Endpoint:     server.URL[7:], // [7:] -> strip http://
+				Endpoint:     server.URL[7:],
 				StorageClass: tc.StorageClass,
 			})
 			require.NoError(t, err)
@@ -691,6 +649,56 @@ func TestObjectStorageClass(t *testing.T) {
 			ctx := context.Background()
 			_ = w.Write(ctx, "object", backend.KeyPath{"test"}, bytes.NewReader([]byte{}), 0, nil)
 			require.Equal(t, tc.StorageClass, httpHeader.Get(storageClassHeader))
+		})
+	}
+}
+
+// TestFqdnTransport_StripsTrailingDotFromHostHeader verifies that fqdnTransport
+// strips the trailing dot from the Host header before sending the request,
+// while keeping the URL unchanged so DNS resolution uses the FQDN (issue #1726).
+func TestFqdnTransport_StripsTrailingDotFromHostHeader(t *testing.T) {
+	tests := []struct {
+		name            string
+		requestHost     string
+		expectedHostHdr string
+	}{
+		{
+			name:            "trailing dot stripped from Host header",
+			requestHost:     "s3.amazonaws.com.",
+			expectedHostHdr: "s3.amazonaws.com",
+		},
+		{
+			name:            "no trailing dot is unchanged",
+			requestHost:     "s3.amazonaws.com",
+			expectedHostHdr: "s3.amazonaws.com",
+		},
+		{
+			name:            "custom endpoint trailing dot stripped",
+			requestHost:     "minio.mynamespace.svc.cluster.local.",
+			expectedHostHdr: "minio.mynamespace.svc.cluster.local",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var receivedHost string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				receivedHost = r.Host
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+			require.NoError(t, err)
+			req.Host = tc.requestHost
+
+			transport := &fqdnTransport{wrapped: http.DefaultTransport}
+			resp, err := transport.RoundTrip(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, tc.expectedHostHdr, receivedHost,
+				"Host header must have trailing dot stripped before sending to server")
 		})
 	}
 }
@@ -705,16 +713,15 @@ func testServer(t *testing.T, httpHandler http.HandlerFunc) *httptest.Server {
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 const (
-	letterIdxBits = 6                    // 6 bits to represent a letter index
-	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
-	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
+	letterIdxBits = 6
+	letterIdxMask = 1<<letterIdxBits - 1
+	letterIdxMax  = 63 / letterIdxBits
 )
 
 var src = rand.NewSource(time.Now().UnixNano())
 
 func RandStringBytesMaskImprSrc(n int) string {
 	b := make([]byte, n)
-	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!
 	for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {
 		if remain == 0 {
 			cache, remain = src.Int63(), letterIdxMax
@@ -726,7 +733,6 @@ func RandStringBytesMaskImprSrc(n int) string {
 		cache >>= letterIdxBits
 		remain--
 	}
-
 	return string(b)
 }
 
@@ -769,20 +775,14 @@ func metadataMockedHandler(t *testing.T) http.HandlerFunc {
 			err1 := xml.NewEncoder(w).Encode(assumeResponse)
 			require.NoError(t, err1)
 		case "/latest/api/token":
-			// Check for X-aws-ec2-metadata-token-ttl-seconds request header
 			if r.Header.Get("X-aws-ec2-metadata-token-ttl-seconds") == "" {
 				w.WriteHeader(400)
 			}
-
-			// Check X-aws-ec2-metadata-token-ttl-seconds is an integer
 			secondsInt, err := strconv.Atoi(r.Header.Get("X-aws-ec2-metadata-token-ttl-seconds"))
 			if err != nil {
 				w.WriteHeader(400)
 			}
-
-			// Generate a token, 40 character string, base64 encoded
 			token := base64.StdEncoding.EncodeToString([]byte(RandStringBytesMaskImprSrc(40)))
-
 			w.Header().Set("X-Aws-Ec2-Metadata-Token-Ttl-Seconds", strconv.Itoa(secondsInt))
 			if _, err := w.Write([]byte(token)); err != nil {
 				require.NoError(t, err)
@@ -800,7 +800,6 @@ func metadataMockedHandler(t *testing.T) http.HandlerFunc {
 				Type:            "AWS-HMAC",
 				Code:            "Success",
 			}
-
 			err := json.NewEncoder(w).Encode(creds)
 			require.NoError(t, err)
 		}


### PR DESCRIPTION
## What this PR does

Fixes #1726

Adds a custom `fqdnTransport` (`http.RoundTripper`) to all three storage
backends (Azure, S3, GCS) that strips the trailing dot from the `Host`
header **only**, while keeping the trailing dot in the URL so that DNS
resolution uses the fully qualified domain name.

---

## Problem

Kubernetes sets `ndots=5` in every Pod's `/etc/resolv.conf`. Any hostname
with fewer than 5 dots (e.g. `blob.core.windows.net`) is searched locally
first before a real DNS lookup, causing:

- Up to 11 failed DNS lookups per storage API call
- Added read/write latency on every Tempo operation
- Pressure on the conntrack table and extra load on kube-dns
- DNS lookup failures at scale (see also: #1462)

---

## Solution

A custom `fqdnTransport` wraps the existing HTTP transport stack on all
three backends. On every request it:

1. **Keeps the trailing dot in the URL** → the HTTP client dials using
   `blob.core.windows.net.` → kube-dns recognises the FQDN and skips
   local search entirely
2. **Strips the trailing dot from the `Host` header only** → the cloud
   API receives a valid host header with no trailing dot

This is the correct split — `req.URL.Host` drives DNS resolution while
`req.Host` drives the `Host:` header sent over the wire.

| Backend | API rejects trailing dot in Host with | Config field |
|---|---|---|
| Azure | HTTP 400 | `endpoint_suffix` |
| S3 | HTTP 404 | `endpoint` |
| GCS | HTTP 301 redirect | `bucket_name` |

---

## Changes

| File | What changed |
|---|---|
| `tempodb/backend/azure/azure_helpers.go` | Added `fqdnTransport`; `cfg.Endpoint` passed as-is to URL (dot retained) |
| `tempodb/backend/s3/s3.go` | Added `fqdnTransport`; `cfg.Endpoint` passed as-is to minio (dot retained) |
| `tempodb/backend/gcs/gcs.go` | Added `fqdnTransport`; `cfg.BucketName` passed as-is to GCS client (dot retained) |
| `tempodb/backend/azure/azure_helpers_test.go` | Tests verifying Host header has dot stripped; URL retains dot |
| `tempodb/backend/s3/s3_test.go` | Tests verifying fqdnTransport strips dot from Host header only |
| `tempodb/backend/gcs/gcs_test.go` | Tests verifying fqdnTransport strips dot from Host header only |

---

## Example config
```yaml
# Azure
storage:
  trace:
    backend: azure
    azure:
      endpoint_suffix: blob.core.windows.net.   # trailing dot = FQDN

# S3
storage:
  trace:
    backend: s3
    s3:
      endpoint: s3.amazonaws.com.               # trailing dot = FQDN

# GCS
storage:
  trace:
    backend: gcs
    gcs:
      bucket_name: my-tempo-traces.             # trailing dot = FQDN
```

---

## Backward compatibility

- `fqdnTransport.RoundTrip` is a no-op when the Host header has no trailing dot
- Existing users without trailing dots are completely unaffected
- No config changes required for non-Kubernetes deployments

---

## Testing
```
go test -short ./tempodb/backend/azure/...   # ok
go test -short ./tempodb/backend/s3/...      # ok
go test -short ./tempodb/backend/gcs/...     # ok
```
```

### New Commit Message (amend):
```
fix(storage): support FQDN trailing dot via custom transport for Kubernetes ndots=5

On Kubernetes (ndots=5), storage hostnames trigger up to 11 spurious
DNS lookups per API call. Users can configure a trailing dot on their
storage endpoint/bucket to signal a fully qualified domain name (FQDN),
which causes kube-dns to skip local search entirely.

This adds fqdnTransport (http.RoundTripper) to all three storage backends:
- Keeps the trailing dot in the URL so DNS resolves using the FQDN
- Strips the trailing dot from the Host header only, since Azure (400),
  S3 (404) and GCS (301) all reject a trailing dot in the Host header

The dot is NOT stripped from cfg.Endpoint/cfg.BucketName upfront —
that was the previous (incorrect) approach which lost the DNS benefit.

Fixes grafana#1726