### PR TITLE
Automated the docker image tag update in Makefile

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -41,6 +41,19 @@
     'gomodTidy',
     'gomodVendor',
   ],
+  customManagers: [
+    {
+      description: 'Update tempo-ci-tools image tag in Makefile and build/tools.mk',
+      customType: 'regex',
+      managerFilePatterns: ['/^Makefile$/', '/^build\\/tools\\.mk$/'],
+      matchStrings: [
+        'TEMPO_CI_TOOLS_IMAGE\\s*\\?=\\s*(?<depName>grafana/tempo-ci-tools):(?<currentValue>main-[0-9a-f]{7}-\\d{8}-\\d{6})(?:@(?<currentDigest>sha256:[a-f0-9]+))?',
+        'TOOLS_IMAGE_TAG\\s*\\?=\\s*(?<currentValue>main-[0-9a-f]{7}-\\d{8}-\\d{6})',
+      ],
+      depNameTemplate: 'grafana/tempo-ci-tools',
+      datasourceTemplate: 'docker',
+    },
+  ],
   packageRules: [
     {
       description: 'Disable all non-vulnerability updates for releases',
@@ -99,6 +112,18 @@
         'dockerfile',
       ],
       groupName: 'docker',
+    },
+    {
+      description: 'Use regex versioning for tempo-ci-tools (branch-sha-datetime tags)',
+      matchManagers: [
+        'custom.regex',
+      ],
+      matchPackageNames: [
+        'grafana/tempo-ci-tools',
+      ],
+      groupName: 'tempo-ci-tools',
+      versioning: 'regex:^main-[0-9a-f]{7}-(?<major>\\d{8})-(?<patch>\\d{6})$',
+      minimumReleaseAge: '0 days',
     },
   ],
 }

--- a/.github/workflows/docker-ci-tools.yml
+++ b/.github/workflows/docker-ci-tools.yml
@@ -29,7 +29,7 @@ jobs:
 
       - id: get-tag
         run: |
-          echo "tag=$(./tools/image-tag)" >> "$GITHUB_OUTPUT"
+          echo "tag=$(./tools/image-tag)-$(date +%Y%m%d-%H%M%S)" >> "$GITHUB_OUTPUT"
 
   docker-ci-tools:
     if: github.repository == 'grafana/tempo'
@@ -85,5 +85,5 @@ jobs:
           docker manifest create \
           	$IMAGE_NAME:latest            \
           	--amend $IMAGE_NAME:$TAG-amd64   \
-          	--amend $IMAGE_NAME:$TAG-arm64 
+          	--amend $IMAGE_NAME:$TAG-arm64
           docker manifest push $IMAGE_NAME:latest


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
- Automates the docker image tag updates used by Makefile

**Test**:
- ` npx --yes --package renovate -- renovate-config-validator --no-global .github/renovate.json5`
- `RENOVATE_CONFIG_FILE=renovate-local.js LOG_LEVEL=info npx --yes --package renovate -- renovate 2>&1`

With `renovate-local.js`:
```
module.exports = {
  platform: 'local',
  dryRun: 'full',
  gitAuthor: 'Renovate Bot <bot@example.com>'
};
```

**Which issue(s) this PR fixes**:
Fixes N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`