### PR TITLE
bugfix: set default max_result_limit for search to 256*1024 (#6525)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## main / unreleased
+
+* [CHANGE] Set default `max_result_limit` for search to 256*1024 [#6525](https://github.com/grafana/tempo/pull/6525) (@zhxiaogg)
+
 # v2.10.1
 
 * [CHANGE] Upgrade Tempo to Go 1.25.7 [#6449](https://github.com/grafana/tempo/pull/6449) (@zalegrala)

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -394,7 +394,7 @@ query_frontend:
         concurrent_jobs: 1000
         target_bytes_per_job: 104857600
         default_result_limit: 20
-        max_result_limit: 0
+        max_result_limit: 262144
         max_duration: 168h0m0s
         query_backend_after: 15m0s
         query_ingesters_until: 30m0s

--- a/modules/frontend/config.go
+++ b/modules/frontend/config.go
@@ -95,7 +95,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {
 			QueryBackendAfter:      15 * time.Minute,
 			QueryIngestersUntil:    30 * time.Minute,
 			DefaultLimit:           20,
-			MaxLimit:               0,
+			MaxLimit:               256 * 1024,
 			MaxDuration:            168 * time.Hour, // 1 week
 			ConcurrentRequests:     defaultConcurrentRequests,
 			TargetBytesPerRequest:  defaultTargetBytesPerRequest,

--- a/modules/frontend/config_test.go
+++ b/modules/frontend/config_test.go
@@ -1,0 +1,15 @@
+package frontend
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSearchSharderConfigDefaults(t *testing.T) {
+	cfg := &Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", &flag.FlagSet{})
+
+	assert.Equal(t, uint32(256*1024), cfg.Search.Sharder.MaxLimit)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
- Backport a CVE fix #6525 to 2.10.x

**Which issue(s) this PR fixes**:
Fixes N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`