### PR TITLE
Update default live store flush settings

### DIFF
--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -1254,12 +1254,12 @@ live_store:
     complete_block_timeout: 1h0m0s
     complete_block_concurrency: 2
     shutdown_marker_dir: /var/tempo/live-store/shutdown-marker
-    flush_check_period: 10s
+    flush_check_period: 5s
     flush_op_timeout: 5m0s
     max_trace_live: 30s
     max_trace_idle: 5s
     max_live_traces_bytes: 250000000
-    max_block_duration: 30m0s
+    max_block_duration: 1m0s
     max_block_bytes: 104857600
     block_config:
         bloom_filter_false_positive: 0.01

--- a/modules/livestore/config.go
+++ b/modules/livestore/config.go
@@ -100,12 +100,12 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.Metrics.TimeOverlapCutoff = 0.2
 
 	// Set defaults for timing configuration (based on ingester defaults)
-	cfg.InstanceFlushPeriod = 10 * time.Second
+	cfg.InstanceFlushPeriod = 5 * time.Second
 	cfg.InstanceCleanupPeriod = 5 * time.Minute
 	cfg.MaxTraceLive = 30 * time.Second
 	cfg.MaxTraceIdle = 5 * time.Second
 	cfg.MaxLiveTracesBytes = 250_000_000 // 250MB
-	cfg.MaxBlockDuration = 30 * time.Minute
+	cfg.MaxBlockDuration = 1 * time.Minute
 	cfg.MaxBlockBytes = 100 * 1024 * 1024
 
 	cfg.CommitInterval = 5 * time.Second


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Update the live store default flush settings to what we use internally. This is found to help prevent long startup/shutdown times by limiting the amount of data that must be replayed by WAL.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`