### PR TITLE
New make target: test-e2e-clean for easy cleanup of old tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,17 @@ test-e2e-util: tools docker-tempo ## Run unit tests on the e2e test harness
 .PHONY: test-all
 test-all: test-with-cover test-e2e ## Run all tests
 
+# e2e test dirs are created by the host test process but their contents are written by
+# Tempo containers running as UID 10001. Clean up in two steps: first empty the contents
+# as UID 10001, then remove the now-empty dirs as the host user.
+.PHONY: test-e2e-clean
+test-e2e-clean: ## Remove leftover e2e test directories owned by Docker container UIDs
+	docker run --rm -u 10001 \
+		-v "$(shell pwd)/integration:/integration:z" \
+		alpine find /integration -maxdepth 3 -name 'e2e_integration_test*' -type d \
+		  -exec sh -c 'find "$$1" -mindepth 1 -delete' _ {} \;
+	find $(shell pwd)/integration -maxdepth 3 -name 'e2e_integration_test*' -type d -prune -exec rm -rf '{}' +
+
 ##@ Linters/Formatters
 
 .PHONY: fmt check-fmt


### PR DESCRIPTION
**What this PR does**:

Running the e2e tests locally leaves directories which require root access to clean, since they were created from the UID inside the container.  Here we include a make task to make the cleanup simple without using the root user.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`