### PR TITLE
docs: Update 2.10.2 notes and config defaults

### DIFF
--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -735,8 +735,8 @@ query_frontend:
 
         # The maximum allowed value of the limit parameter on search requests. If the search request limit parameter
         # exceeds the value configured here the frontend will return a 400.
-        # The default value of 0 disables this limit.
-        # (default: 0)
+        # The default value is 262144 (256*1024). Set to 0 to disable this limit.
+        # (default: 262144)
         [max_result_limit: <int>]
 
         # The maximum allowed time range for a search.
@@ -821,7 +821,8 @@ query_frontend:
         # 0 disables this limit.
         [max_duration: <duration> | default = 3h ]
 
-        # Maximun number of exemplars per range query. Limited to 100.
+        # Maximum number of exemplars per range query.
+        # Set to 0 to disable exemplars.
         [max_exemplars: <int> | default = 100 ]
 
         # Maximum number of time series returned for a metrics query.

--- a/docs/sources/tempo/release-notes/v2-10.md
+++ b/docs/sources/tempo/release-notes/v2-10.md
@@ -201,6 +201,12 @@ This release also includes these enhancements:
 
 When [upgrading](/docs/tempo/<TEMPO_VERSION>/set-up-for-tracing/setup-tempo/upgrade/) to Tempo 2.10, be aware of these considerations and breaking changes.
 
+### Search default result limit changed in 2.10.2
+
+Tempo 2.10.2 sets the default `max_result_limit` for search to `256*1024`. This helps prevent unbounded search responses from returning excessive data by default. [[PR 6525](https://github.com/grafana/tempo/pull/6525)]
+
+If your existing workflows rely on larger search result sets, explicitly configure `max_result_limit` to match your environment and query patterns.
+
 ### Busybox removed from Tempo image
 
 The Tempo container image no longer includes busybox. This change reduces the image size and attack surface, preventing future busybox-related vulnerabilities from affecting Tempo deployments. [[PR 5717](https://github.com/grafana/tempo/pull/5717)]
@@ -301,9 +307,24 @@ Refer to the [Tempo rearchitecture](https://github.com/grafana/tempo/releases/ta
 - Jsonnet: Correctly add `tempo-gossip-member: true` labels to block-builders and live-stores. [[PR 6125](https://github.com/grafana/tempo/pull/6125)]
 - Fix wrong sleep duration in block-builder if one of partitions is inactive. [[PR 5855](https://github.com/grafana/tempo/pull/5855)]
 
+## Security fixes
+
+The following updates were made in Tempo 2.10.2 to address security issues.
+
+### 2.10.2
+
+- Fixed exemplar hint handling in metrics queries to enforce the configured safety cap end-to-end. Addresses CVE-2026-27878. [[PR 6559](https://github.com/grafana/tempo/pull/6559)]
+- Set the default `query_frontend.search.max_result_limit` to `256*1024` to avoid unbounded search results by default. Addresses CVE-2026-21728. [[PR 6525](https://github.com/grafana/tempo/pull/6525)]
+
 ## Bug fixes
 
 For a complete list, refer to the [Tempo CHANGELOG](https://github.com/grafana/tempo/releases).
+
+### 2.10.2
+
+- Applied exemplar hints end-to-end and fixed a safety cap bypass in metrics queries. [[PR 6559](https://github.com/grafana/tempo/pull/6559)]
+- Used frontend `MaxExemplars` configuration as the single source of truth for exemplar limits and added a safety cap at TraceQL engine entry points. [[PR 6515](https://github.com/grafana/tempo/pull/6515)]
+- Set the default search `max_result_limit` to `256*1024`. [[PR 6525](https://github.com/grafana/tempo/pull/6525)]
 
 ### 2.10.1
 


### PR DESCRIPTION
Update the release notes to include v2.10.2 changes, CVE patches, and bug fixes. Updated the configuration doc for updates to max_result_limit and max_exemplars. 

**Which issue(s) this PR fixes**:
Fixes #6676 
**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`