### PR TITLE
[bugfix] Backend worker: do not preserve metrics for deleted tenants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * [BUGFIX] fix: skip per-label limiter and sanitizer for target_info and host_info metrics in metrics-generator [#6660](https://github.com/grafana/tempo/pull/6660) (@electron0zero)
 * [BUGFIX] fix(traceql): err on division by zero [#6580](https://github.com/grafana/tempo/pull/6580) (@Proximyst)
 * [BUGFIX] Return 400 instead of 500 when query_range or query_instant requests have unparseable start/end parameters [#6694](https://github.com/grafana/tempo/pull/6694) (@ruslan-mikhailov)
+* [BUGFIX] Clean up metrics for tenants that no longer exist in backend storage [#6710](https://github.com/grafana/tempo/pull/6710) (@ruslan-mikhailov)
 
 ### 3.0 Cleanup
 

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -244,6 +244,19 @@ func (p *Poller) Do(parentCtx context.Context, previous *List) (PerTenant, PerTe
 		return nil, nil, errors.New("too many tenant failures; abandoning polling cycle")
 	}
 
+	// Clean up metrics for tenants that no longer exist in the backend.
+	currentTenants := make(map[string]struct{}, len(tenants))
+	for _, t := range tenants {
+		currentTenants[t] = struct{}{}
+	}
+	for _, t := range previous.Tenants() {
+		if _, ok := currentTenants[t]; !ok {
+			metricTenantIndexAgeSeconds.DeleteLabelValues(t)
+			metricTenantIndexBuilder.DeleteLabelValues(t)
+			metricTenantIndexErrors.DeleteLabelValues(t)
+		}
+	}
+
 	diff := time.Since(start).Seconds()
 	metricBlocklistPollDuration.Observe(diff)
 	level.Info(p.logger).Log("msg", "blocklist poll complete", "seconds", diff)

--- a/tempodb/blocklist/poller_test.go
+++ b/tempodb/blocklist/poller_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-kit/log"
 	uuid "github.com/google/uuid"
+	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -196,6 +197,73 @@ func TestTenantIndexBuilder(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDeletedTenantMetrics checks that after tenant is deleted
+// it does not report its index age
+func TestDeletedTenantMetrics(t *testing.T) {
+	const (
+		activeTenant  = "active-tenant"
+		deletedTenant = "deleted-tenant"
+	)
+	one := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+
+	// Both tenants exist with blocks.
+	r := &backend.MockReader{
+		T: []string{activeTenant, deletedTenant},
+		BlocksFn: func(_ context.Context, _ string) ([]uuid.UUID, []uuid.UUID, error) {
+			return []uuid.UUID{one}, nil, nil
+		},
+	}
+	c := &backend.MockCompactor{}
+	w := &backend.MockWriter{}
+
+	// Use a non-builder (querier) that reads the tenant index.
+	// The index was created 30 minutes ago, so the metric will be ~1800.
+	r.TenantIndexFn = func(_ context.Context, _ string) (*backend.TenantIndex, error) {
+		return &backend.TenantIndex{
+			CreatedAt: time.Now().Add(-30 * time.Minute),
+			Meta:      []*backend.BlockMeta{{BlockID: backend.MustParse("00000000-0000-0000-0000-000000000001")}},
+		}, nil
+	}
+
+	poller := NewPoller(&PollerConfig{
+		PollConcurrency:       testPollConcurrency,
+		TenantPollConcurrency: testTenantPollConcurrency,
+		PollFallback:          false,
+		TenantIndexBuilders:   testBuilders,
+	}, &mockJobSharder{
+		owns: false, // non-builder (querier)
+	}, r, c, w, log.NewNopLogger())
+
+	ctx := context.Background()
+
+	// Poll 1: both tenants exist.
+	blocklist, compactedBlocklist, err := poller.Do(ctx, newBlocklist(PerTenant{}, PerTenantCompacted{}))
+	require.NoError(t, err)
+
+	// Verify metric is set to a non-zero age for both tenants.
+	for _, tenant := range []string{activeTenant, deletedTenant} {
+		gauge, err := metricTenantIndexAgeSeconds.GetMetricWithLabelValues(tenant)
+		require.NoError(t, err)
+		dto := &io_prometheus_client.Metric{}
+		require.NoError(t, gauge.Write(dto))
+		assert.Greater(t, dto.GetGauge().GetValue(), float64(0),
+			"metric should have non-zero age for %s after first poll", tenant)
+	}
+
+	// Poll 2: deletedTenant is gone from backend.
+	previous := newBlocklist(blocklist, compactedBlocklist)
+	r.T = []string{activeTenant}
+
+	_, _, err = poller.Do(ctx, previous)
+	require.NoError(t, err)
+
+	// The metric for the deleted tenant should not exist at all.
+	// Hacky way to check if label exists:
+	// DeleteLabelValues returns false if the label was already removed.
+	assert.False(t, metricTenantIndexAgeSeconds.DeleteLabelValues(deletedTenant),
+		"tenant_index_age_seconds should not exist for deleted tenant")
 }
 
 func TestTenantIndexFallback(t *testing.T) {

--- a/tempodb/blocklist/poller_test.go
+++ b/tempodb/blocklist/poller_test.go
@@ -259,11 +259,15 @@ func TestDeletedTenantMetrics(t *testing.T) {
 	_, _, err = poller.Do(ctx, previous)
 	require.NoError(t, err)
 
-	// The metric for the deleted tenant should not exist at all.
+	// The metrics for the deleted tenant should not exist at all.
 	// Hacky way to check if label exists:
 	// DeleteLabelValues returns false if the label was already removed.
 	assert.False(t, metricTenantIndexAgeSeconds.DeleteLabelValues(deletedTenant),
 		"tenant_index_age_seconds should not exist for deleted tenant")
+	assert.False(t, metricTenantIndexBuilder.DeleteLabelValues(deletedTenant),
+		"tenant_index_builder should not exist for deleted tenant")
+	assert.False(t, metricTenantIndexErrors.DeleteLabelValues(deletedTenant),
+		"tenant_index_errors should not exist for deleted tenant")
 }
 
 func TestTenantIndexFallback(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: if a tenant is deleted, it will never be polled again and their metrics will have the same stuck values until app restart. This PR drops metrics for deleted tenants

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`