### PR TITLE
feat: add tempo_cache_requests_total metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   Slightly changes the array matching semantics of != and !~ operators and introduces stricter rules for regex literals.
 * [FEATURE] metrics-generator: Add per-label limiter to control cardinality [#6414](https://github.com/grafana/tempo/pull/6414) (@electron0zero)
   Adds `max_cardinality_per_label` per per-tenant override and new metrics to estimate per label cardinality demand estimate.
+* [ENHANCEMENT] Add `tempo_cache_requests_total` metric with `status` label (`hit`, `miss`, `fail`) for memcached and redis cache backends. [#6742](https://github.com/grafana/tempo/pull/6742) (@oleg-kozlyuk)
 * [ENHANCEMENT] Block builder: deduplicate spans within traces during block creation and track removed duplicates via `tempo_block_builder_spans_deduped_total` metric [#6539](https://github.com/grafana/tempo/pull/6539) (@zhxiaogg)
 * [ENHANCEMENT] Add new alerts and runbooks entries [#6276](https://github.com/grafana/tempo/pull/6276) (@javiermolinar)
 * [ENHANCEMENT] Double the maximum number of dedicated string columns in vParquet5 and update tempo-cli to determine the optimum number for the data [#6282](https://github.com/grafana/tempo/pull/6282) (@mdisibio)

--- a/pkg/cache/memcached.go
+++ b/pkg/cache/memcached.go
@@ -46,6 +46,8 @@ type Memcached struct {
 	name            string
 	maxItemSize     int
 	requestDuration *instr.HistogramCollector
+	cacheHits       prometheus.Counter
+	cacheMisses     prometheus.Counter
 	logger          log.Logger
 }
 
@@ -70,6 +72,18 @@ func NewMemcached(cfg MemcachedConfig, client MemcachedClient, name string, maxI
 				ConstLabels:                     prometheus.Labels{"name": name},
 			}, []string{"method", "status_code"}),
 		),
+		cacheHits: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace:   "tempo",
+			Name:        "cache_hits_total",
+			Help:        "Total number of cache hits.",
+			ConstLabels: prometheus.Labels{"name": name, "type": "memcached"},
+		}),
+		cacheMisses: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace:   "tempo",
+			Name:        "cache_misses_total",
+			Help:        "Total number of cache misses.",
+			ConstLabels: prometheus.Labels{"name": name, "type": "memcached"},
+		}),
 	}
 	return c
 }
@@ -120,6 +134,8 @@ func (c *Memcached) Fetch(ctx context.Context, keys []string) (found []string, b
 			missed = append(missed, key)
 		}
 	}
+	c.cacheHits.Add(float64(len(found)))
+	c.cacheMisses.Add(float64(len(missed)))
 	return
 }
 
@@ -146,8 +162,10 @@ func (c *Memcached) FetchKey(ctx context.Context, key string) ([]byte, bool) {
 		return err
 	})
 	if err != nil {
+		c.cacheMisses.Add(1)
 		return nil, false
 	}
+	c.cacheHits.Add(1)
 	return item.Value, true
 }
 

--- a/pkg/cache/memcached.go
+++ b/pkg/cache/memcached.go
@@ -46,8 +46,7 @@ type Memcached struct {
 	name            string
 	maxItemSize     int
 	requestDuration *instr.HistogramCollector
-	cacheHits       prometheus.Counter
-	cacheMisses     prometheus.Counter
+	cacheRequests   *prometheus.CounterVec
 	logger          log.Logger
 }
 
@@ -72,18 +71,12 @@ func NewMemcached(cfg MemcachedConfig, client MemcachedClient, name string, maxI
 				ConstLabels:                     prometheus.Labels{"name": name},
 			}, []string{"method", "status_code"}),
 		),
-		cacheHits: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		cacheRequests: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace:   "tempo",
-			Name:        "cache_hits_total",
-			Help:        "Total number of cache hits.",
+			Name:        "cache_requests_total",
+			Help:        "Total number of cache requests by status (hit, miss, fail).",
 			ConstLabels: prometheus.Labels{"name": name, "type": "memcached"},
-		}),
-		cacheMisses: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Namespace:   "tempo",
-			Name:        "cache_misses_total",
-			Help:        "Total number of cache misses.",
-			ConstLabels: prometheus.Labels{"name": name, "type": "memcached"},
-		}),
+		}, []string{"status"}),
 	}
 	return c
 }
@@ -123,6 +116,7 @@ func (c *Memcached) Fetch(ctx context.Context, keys []string) (found []string, b
 		return err
 	})
 	if err != nil {
+		c.cacheRequests.WithLabelValues("fail").Add(float64(len(keys)))
 		return found, bufs, keys
 	}
 	for _, key := range keys {
@@ -134,8 +128,8 @@ func (c *Memcached) Fetch(ctx context.Context, keys []string) (found []string, b
 			missed = append(missed, key)
 		}
 	}
-	c.cacheHits.Add(float64(len(found)))
-	c.cacheMisses.Add(float64(len(missed)))
+	c.cacheRequests.WithLabelValues("hit").Add(float64(len(found)))
+	c.cacheRequests.WithLabelValues("miss").Add(float64(len(missed)))
 	return
 }
 
@@ -162,10 +156,14 @@ func (c *Memcached) FetchKey(ctx context.Context, key string) ([]byte, bool) {
 		return err
 	})
 	if err != nil {
-		c.cacheMisses.Add(1)
+		if errors.Is(err, memcache.ErrCacheMiss) {
+			c.cacheRequests.WithLabelValues("miss").Add(1)
+		} else {
+			c.cacheRequests.WithLabelValues("fail").Add(1)
+		}
 		return nil, false
 	}
-	c.cacheHits.Add(1)
+	c.cacheRequests.WithLabelValues("hit").Add(1)
 	return item.Value, true
 }
 

--- a/pkg/cache/memcached_test.go
+++ b/pkg/cache/memcached_test.go
@@ -190,15 +190,13 @@ func TestMemcachedCacheMetrics(t *testing.T) {
 	mc.FetchKey(ctx, "miss2")
 
 	expected := strings.NewReader(`
-# HELP tempo_cache_hits_total Total number of cache hits.
-# TYPE tempo_cache_hits_total counter
-tempo_cache_hits_total{name="test",type="memcached"} 3
-# HELP tempo_cache_misses_total Total number of cache misses.
-# TYPE tempo_cache_misses_total counter
-tempo_cache_misses_total{name="test",type="memcached"} 2
+# HELP tempo_cache_requests_total Total number of cache requests by status (hit, miss, fail).
+# TYPE tempo_cache_requests_total counter
+tempo_cache_requests_total{name="test",status="hit",type="memcached"} 3
+tempo_cache_requests_total{name="test",status="miss",type="memcached"} 2
 `)
 	require.NoError(t, testutil.GatherAndCompare(reg, expected,
-		"tempo_cache_hits_total", "tempo_cache_misses_total"))
+		"tempo_cache_requests_total"))
 }
 
 func TestMemcachedRespectsCancelledContext(t *testing.T) {

--- a/pkg/cache/memcached_test.go
+++ b/pkg/cache/memcached_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/gomemcache/memcache"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
@@ -168,6 +171,34 @@ func testMemcachedStopping(memcache *cache.Memcached) {
 
 	go memcache.Fetch(ctx, keys)
 	memcache.Stop()
+}
+
+func TestMemcachedCacheMetrics(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	client := newMockMemcache()
+	mc := cache.NewMemcached(cache.MemcachedConfig{}, client, "test", 0, reg, log.NewNopLogger())
+	defer mc.Stop()
+
+	ctx := context.Background()
+	mc.Store(ctx, []string{"hit1", "hit2"}, [][]byte{[]byte("v1"), []byte("v2")})
+
+	// Fetch: 2 hits, 1 miss
+	mc.Fetch(ctx, []string{"hit1", "hit2", "miss1"})
+
+	// FetchKey: 1 hit, 1 miss
+	mc.FetchKey(ctx, "hit1")
+	mc.FetchKey(ctx, "miss2")
+
+	expected := strings.NewReader(`
+# HELP tempo_cache_hits_total Total number of cache hits.
+# TYPE tempo_cache_hits_total counter
+tempo_cache_hits_total{name="test",type="memcached"} 3
+# HELP tempo_cache_misses_total Total number of cache misses.
+# TYPE tempo_cache_misses_total counter
+tempo_cache_misses_total{name="test",type="memcached"} 2
+`)
+	require.NoError(t, testutil.GatherAndCompare(reg, expected,
+		"tempo_cache_hits_total", "tempo_cache_misses_total"))
 }
 
 func TestMemcachedRespectsCancelledContext(t *testing.T) {

--- a/pkg/cache/redis_cache.go
+++ b/pkg/cache/redis_cache.go
@@ -21,8 +21,7 @@ type RedisCache struct {
 	redis           *RedisClient
 	logger          log.Logger
 	requestDuration *instr.HistogramCollector
-	cacheHits       prometheus.Counter
-	cacheMisses     prometheus.Counter
+	cacheRequests   *prometheus.CounterVec
 }
 
 // NewRedisCache creates a new RedisCache
@@ -43,18 +42,12 @@ func NewRedisCache(name string, redisClient *RedisClient, reg prometheus.Registe
 				ConstLabels:                     prometheus.Labels{"name": name},
 			}, []string{"method", "status_code"}),
 		),
-		cacheHits: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		cacheRequests: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace:   "tempo",
-			Name:        "cache_hits_total",
-			Help:        "Total number of cache hits.",
+			Name:        "cache_requests_total",
+			Help:        "Total number of cache requests by status (hit, miss, fail).",
 			ConstLabels: prometheus.Labels{"name": name, "type": "redis"},
-		}),
-		cacheMisses: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Namespace:   "tempo",
-			Name:        "cache_misses_total",
-			Help:        "Total number of cache misses.",
-			ConstLabels: prometheus.Labels{"name": name, "type": "redis"},
-		}),
+		}, []string{"status"}),
 	}
 	if err := cache.redis.Ping(context.Background()); err != nil {
 		level.Error(logger).Log("msg", "error connecting to redis", "name", name, "err", err)
@@ -89,6 +82,7 @@ func (c *RedisCache) Fetch(ctx context.Context, keys []string) (found []string, 
 		return nil
 	})
 	if err != nil {
+		c.cacheRequests.WithLabelValues("fail").Add(float64(len(keys)))
 		return found, bufs, keys
 	}
 
@@ -100,8 +94,8 @@ func (c *RedisCache) Fetch(ctx context.Context, keys []string) (found []string, 
 			missed = append(missed, key)
 		}
 	}
-	c.cacheHits.Add(float64(len(found)))
-	c.cacheMisses.Add(float64(len(missed)))
+	c.cacheRequests.WithLabelValues("hit").Add(float64(len(found)))
+	c.cacheRequests.WithLabelValues("miss").Add(float64(len(missed)))
 
 	return
 }
@@ -128,10 +122,14 @@ func (c *RedisCache) FetchKey(ctx context.Context, key string) (buf []byte, foun
 		return nil
 	})
 	if err != nil {
-		c.cacheMisses.Add(1)
+		if errors.Is(err, redis.Nil) {
+			c.cacheRequests.WithLabelValues("miss").Add(1)
+		} else {
+			c.cacheRequests.WithLabelValues("fail").Add(1)
+		}
 		return buf, false
 	}
-	c.cacheHits.Add(1)
+	c.cacheRequests.WithLabelValues("hit").Add(1)
 
 	return buf, true
 }

--- a/pkg/cache/redis_cache.go
+++ b/pkg/cache/redis_cache.go
@@ -21,6 +21,8 @@ type RedisCache struct {
 	redis           *RedisClient
 	logger          log.Logger
 	requestDuration *instr.HistogramCollector
+	cacheHits       prometheus.Counter
+	cacheMisses     prometheus.Counter
 }
 
 // NewRedisCache creates a new RedisCache
@@ -41,6 +43,18 @@ func NewRedisCache(name string, redisClient *RedisClient, reg prometheus.Registe
 				ConstLabels:                     prometheus.Labels{"name": name},
 			}, []string{"method", "status_code"}),
 		),
+		cacheHits: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace:   "tempo",
+			Name:        "cache_hits_total",
+			Help:        "Total number of cache hits.",
+			ConstLabels: prometheus.Labels{"name": name, "type": "redis"},
+		}),
+		cacheMisses: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace:   "tempo",
+			Name:        "cache_misses_total",
+			Help:        "Total number of cache misses.",
+			ConstLabels: prometheus.Labels{"name": name, "type": "redis"},
+		}),
 	}
 	if err := cache.redis.Ping(context.Background()); err != nil {
 		level.Error(logger).Log("msg", "error connecting to redis", "name", name, "err", err)
@@ -86,6 +100,8 @@ func (c *RedisCache) Fetch(ctx context.Context, keys []string) (found []string, 
 			missed = append(missed, key)
 		}
 	}
+	c.cacheHits.Add(float64(len(found)))
+	c.cacheMisses.Add(float64(len(missed)))
 
 	return
 }
@@ -112,8 +128,10 @@ func (c *RedisCache) FetchKey(ctx context.Context, key string) (buf []byte, foun
 		return nil
 	})
 	if err != nil {
+		c.cacheMisses.Add(1)
 		return buf, false
 	}
+	c.cacheHits.Add(1)
 
 	return buf, true
 }

--- a/pkg/cache/redis_cache_test.go
+++ b/pkg/cache/redis_cache_test.go
@@ -85,15 +85,13 @@ func TestRedisCacheMetrics(t *testing.T) {
 	c.FetchKey(ctx, "miss2")
 
 	expected := strings.NewReader(`
-# HELP tempo_cache_hits_total Total number of cache hits.
-# TYPE tempo_cache_hits_total counter
-tempo_cache_hits_total{name="test",type="redis"} 3
-# HELP tempo_cache_misses_total Total number of cache misses.
-# TYPE tempo_cache_misses_total counter
-tempo_cache_misses_total{name="test",type="redis"} 2
+# HELP tempo_cache_requests_total Total number of cache requests by status (hit, miss, fail).
+# TYPE tempo_cache_requests_total counter
+tempo_cache_requests_total{name="test",status="hit",type="redis"} 3
+tempo_cache_requests_total{name="test",status="miss",type="redis"} 2
 `)
 	require.NoError(t, testutil.GatherAndCompare(reg, expected,
-		"tempo_cache_hits_total", "tempo_cache_misses_total"))
+		"tempo_cache_requests_total"))
 }
 
 func mockRedisCache() (*RedisCache, error) {

--- a/pkg/cache/redis_cache_test.go
+++ b/pkg/cache/redis_cache_test.go
@@ -2,12 +2,15 @@ package cache
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/go-kit/log"
 	"github.com/go-redis/redis/v8"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -55,6 +58,42 @@ func TestRedisCache(t *testing.T) {
 
 	_, foundKey = c.FetchKey(ctx, miss[0])
 	assert.False(t, foundKey)
+}
+
+func TestRedisCacheMetrics(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	redisServer, err := miniredis.Run()
+	require.NoError(t, err)
+	redisClient := &RedisClient{
+		expiration: time.Minute,
+		timeout:    100 * time.Millisecond,
+		rdb: redis.NewUniversalClient(&redis.UniversalOptions{
+			Addrs: []string{redisServer.Addr()},
+		}),
+	}
+	c := NewRedisCache("test", redisClient, reg, log.NewNopLogger())
+	defer c.redis.Close()
+
+	ctx := context.Background()
+	c.Store(ctx, []string{"hit1", "hit2"}, [][]byte{[]byte("v1"), []byte("v2")})
+
+	// Fetch: 2 hits, 1 miss
+	c.Fetch(ctx, []string{"hit1", "hit2", "miss1"})
+
+	// FetchKey: 1 hit, 1 miss
+	c.FetchKey(ctx, "hit1")
+	c.FetchKey(ctx, "miss2")
+
+	expected := strings.NewReader(`
+# HELP tempo_cache_hits_total Total number of cache hits.
+# TYPE tempo_cache_hits_total counter
+tempo_cache_hits_total{name="test",type="redis"} 3
+# HELP tempo_cache_misses_total Total number of cache misses.
+# TYPE tempo_cache_misses_total counter
+tempo_cache_misses_total{name="test",type="redis"} 2
+`)
+	require.NoError(t, testutil.GatherAndCompare(reg, expected,
+		"tempo_cache_hits_total", "tempo_cache_misses_total"))
 }
 
 func mockRedisCache() (*RedisCache, error) {


### PR DESCRIPTION
**What this PR does**:

Adds dedicated hit/miss counters with a `type` label ("memcached" or "redis") to both Memcached and RedisCache, incremented in Fetch and FetchKey methods.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`