### PR TITLE
enhancement: Use string interning using Go's builtin 'unique' package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [ENHANCEMENT] Use Go's `unique` package for process-wide string interning of low-cardinality parquet values (attribute keys, intrinsic fields) to reduce memory allocations during queries [#6746](https://github.com/grafana/tempo/pull/6746) (@mapno)
 * [BUGFIX] Fix integer overflow in query parameters by using `strconv.ParseUint` instead of `strconv.Atoi`/`strconv.ParseInt` for unsigned integer fields. [#6612](https://github.com/grafana/tempo/pull/6612) (@bejaratommy)
 * [CHANGE] **BREAKING CHANGE** Centralize block and WAL config: `block_builder` and `live_store` now always use `storage.trace.block` settings; per-module block config fields are removed. [#6647](https://github.com/grafana/tempo/pull/6647) (@stoewer)
 * [CHANGE] **BREAKING CHANGE** Remove Opencensus receiver [#6523](https://github.com/grafana/tempo/pull/6523) (@javiermolinar)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## main / unreleased
 
-* [ENHANCEMENT] Use Go's `unique` package for process-wide string interning of low-cardinality parquet values (attribute keys, intrinsic fields) to reduce memory allocations during queries [#6746](https://github.com/grafana/tempo/pull/6746) (@mapno)
+* [ENHANCEMENT] Use Go's `unique` package for string interning in `traceql.Static`, reducing memory allocations for repeated string values during query execution [#XXXX](https://github.com/grafana/tempo/pull/XXXX) (@oleg-kozlyuk)
 * [BUGFIX] Fix integer overflow in query parameters by using `strconv.ParseUint` instead of `strconv.Atoi`/`strconv.ParseInt` for unsigned integer fields. [#6612](https://github.com/grafana/tempo/pull/6612) (@bejaratommy)
 * [CHANGE] **BREAKING CHANGE** Centralize block and WAL config: `block_builder` and `live_store` now always use `storage.trace.block` settings; per-module block config fields are removed. [#6647](https://github.com/grafana/tempo/pull/6647) (@stoewer)
 * [CHANGE] **BREAKING CHANGE** Remove Opencensus receiver [#6523](https://github.com/grafana/tempo/pull/6523) (@javiermolinar)

--- a/pkg/parquetquery/intern/intern.go
+++ b/pkg/parquetquery/intern/intern.go
@@ -7,6 +7,7 @@
 package intern
 
 import (
+	"unique"
 	"unsafe"
 
 	pq "github.com/parquet-go/parquet-go"
@@ -50,6 +51,15 @@ func (i *Interner) internBytes(b []byte) []byte {
 func (i *Interner) Close() {
 	clear(i.m) // clear the map
 	i.m = nil
+}
+
+// InternString returns a process-wide deduplicated string from b.
+// It uses the stdlib unique package for GC-friendly, cross-query deduplication.
+func InternString(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	return unique.Make(string(b)).Value()
 }
 
 // bytesToString converts a byte slice to a string.

--- a/pkg/parquetquery/intern/intern.go
+++ b/pkg/parquetquery/intern/intern.go
@@ -53,20 +53,20 @@ func (i *Interner) Close() {
 	i.m = nil
 }
 
-func unsafeToString(b []byte) string {
-	if len(b) == 0 {
-		return ""
-	}
-	return unsafe.String(unsafe.SliceData(b), len(b))
-}
-
 // InternString returns a process-wide deduplicated string from b.
 // It uses the stdlib unique package for GC-friendly, cross-query deduplication.
+// Best suited for low-cardinality strings (attribute keys, intrinsic field values).
+//
+// Safety: bytesToString creates a string that aliases the original []byte without copying.
+// This is safe because unique.Make internally copies the string data (Go 1.24+),
+// so the returned string is independently owned and does not alias the input slice.
 func InternString(b []byte) string {
 	if len(b) == 0 {
 		return ""
 	}
-	return unique.Make(unsafeToString(b)).Value()
+	// Go has a targeted optimization that elides an extra string copy in this case
+	// https://go-review.googlesource.com/c/go/+/672135
+	return unique.Make(string(b)).Value()
 }
 
 // bytesToString converts a byte slice to a string.

--- a/pkg/parquetquery/intern/intern.go
+++ b/pkg/parquetquery/intern/intern.go
@@ -67,12 +67,6 @@ func UniqueBytes(b []byte) unique.Handle[string] {
 	return unique.Make(string(b))
 }
 
-// UniqueStringFromBytes returns a process-wide deduplicated string from b.
-// Convenience wrapper: calls UniqueBytes(b).Value().
-func UniqueStringFromBytes(b []byte) string {
-	return UniqueBytes(b).Value()
-}
-
 // UniqueString returns a process-wide deduplicated handle from s.
 // Convenience wrapper: calls unique.Make(s).
 func UniqueString(s string) unique.Handle[string] {

--- a/pkg/parquetquery/intern/intern.go
+++ b/pkg/parquetquery/intern/intern.go
@@ -53,13 +53,20 @@ func (i *Interner) Close() {
 	i.m = nil
 }
 
+func unsafeToString(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	return unsafe.String(unsafe.SliceData(b), len(b))
+}
+
 // InternString returns a process-wide deduplicated string from b.
 // It uses the stdlib unique package for GC-friendly, cross-query deduplication.
 func InternString(b []byte) string {
 	if len(b) == 0 {
 		return ""
 	}
-	return unique.Make(string(b)).Value()
+	return unique.Make(unsafeToString(b)).Value()
 }
 
 // bytesToString converts a byte slice to a string.

--- a/pkg/parquetquery/intern/intern.go
+++ b/pkg/parquetquery/intern/intern.go
@@ -53,12 +53,12 @@ func (i *Interner) Close() {
 	i.m = nil
 }
 
-// UniqueBytes returns a process-wide deduplicated handle from b.
+// UniqueStringFromBytes returns a process-wide deduplicated handle from b.
 // It uses the stdlib unique package for GC-friendly, cross-query deduplication.
 //
 // Safety: unique.Make internally copies the string data (Go 1.24+),
 // so the returned handle is independently owned and does not alias the input slice.
-func UniqueBytes(b []byte) unique.Handle[string] {
+func UniqueStringFromBytes(b []byte) unique.Handle[string] {
 	if len(b) == 0 {
 		return unique.Make("")
 	}

--- a/pkg/parquetquery/intern/intern.go
+++ b/pkg/parquetquery/intern/intern.go
@@ -53,20 +53,30 @@ func (i *Interner) Close() {
 	i.m = nil
 }
 
-// InternString returns a process-wide deduplicated string from b.
+// UniqueBytes returns a process-wide deduplicated handle from b.
 // It uses the stdlib unique package for GC-friendly, cross-query deduplication.
-// Best suited for low-cardinality strings (attribute keys, intrinsic field values).
 //
-// Safety: bytesToString creates a string that aliases the original []byte without copying.
-// This is safe because unique.Make internally copies the string data (Go 1.24+),
-// so the returned string is independently owned and does not alias the input slice.
-func InternString(b []byte) string {
+// Safety: unique.Make internally copies the string data (Go 1.24+),
+// so the returned handle is independently owned and does not alias the input slice.
+func UniqueBytes(b []byte) unique.Handle[string] {
 	if len(b) == 0 {
-		return ""
+		return unique.Make("")
 	}
 	// Go has a targeted optimization that elides an extra string copy in this case
 	// https://go-review.googlesource.com/c/go/+/672135
-	return unique.Make(string(b)).Value()
+	return unique.Make(string(b))
+}
+
+// UniqueStringFromBytes returns a process-wide deduplicated string from b.
+// Convenience wrapper: calls UniqueBytes(b).Value().
+func UniqueStringFromBytes(b []byte) string {
+	return UniqueBytes(b).Value()
+}
+
+// UniqueString returns a process-wide deduplicated handle from s.
+// Convenience wrapper: calls unique.Make(s).
+func UniqueString(s string) unique.Handle[string] {
+	return unique.Make(s)
 }
 
 // bytesToString converts a byte slice to a string.

--- a/pkg/parquetquery/intern/intern_test.go
+++ b/pkg/parquetquery/intern/intern_test.go
@@ -109,37 +109,70 @@ func TestPqValueConversion(t *testing.T) {
 	}
 }
 
-func TestInternString(t *testing.T) {
-	s1 := InternString([]byte("hello"))
-	s2 := InternString([]byte("hello"))
+func TestUniqueBytes(t *testing.T) {
+	h1 := UniqueBytes([]byte("hello"))
+	h2 := UniqueBytes([]byte("hello"))
 
-	// process-wide interning: identical content must yield the same pointer
-	if unsafe.StringData(s1) != unsafe.StringData(s2) {
-		t.Error("expected same backing pointer for equal strings")
+	// process-wide interning: identical content must yield the same handle
+	if h1 != h2 {
+		t.Error("expected same handle for equal strings")
 	}
 
-	s3 := InternString([]byte("world"))
-	if unsafe.StringData(s1) == unsafe.StringData(s3) {
-		t.Error("expected different backing pointer for different strings")
+	h3 := UniqueBytes([]byte("world"))
+	if h1 == h3 {
+		t.Error("expected different handle for different strings")
 	}
 
-	empty := InternString([]byte{})
+	if h1.Value() != "hello" {
+		t.Errorf("expected 'hello', got %q", h1.Value())
+	}
+
+	empty := UniqueBytes([]byte{})
+	if empty.Value() != "" {
+		t.Errorf("expected empty string, got %q", empty.Value())
+	}
+
+	nilResult := UniqueBytes(nil)
+	if nilResult.Value() != "" {
+		t.Errorf("expected empty string for nil input, got %q", nilResult.Value())
+	}
+}
+
+func TestUniqueStringFromBytes(t *testing.T) {
+	s := UniqueStringFromBytes([]byte("hello"))
+	if s != "hello" {
+		t.Errorf("expected 'hello', got %q", s)
+	}
+
+	empty := UniqueStringFromBytes(nil)
 	if empty != "" {
 		t.Errorf("expected empty string, got %q", empty)
 	}
+}
 
-	nilResult := InternString(nil)
-	if nilResult != "" {
-		t.Errorf("expected empty string for nil input, got %q", nilResult)
+func TestUniqueString(t *testing.T) {
+	h1 := UniqueString("hello")
+	h2 := UniqueString("hello")
+	if h1 != h2 {
+		t.Error("expected same handle for equal strings")
+	}
+	if h1.Value() != "hello" {
+		t.Errorf("expected 'hello', got %q", h1.Value())
 	}
 }
 
 func BenchmarkInternString(b *testing.B) {
 	words := []string{"foo", "bar", "baz", "qux", "quux", "corge", "grault", "garply", "waldo", "fred"}
 
-	b.Run("intern_string", func(b *testing.B) {
+	b.Run("unique_bytes", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_ = InternString([]byte(words[i%len(words)]))
+			_ = UniqueBytes([]byte(words[i%len(words)]))
+		}
+	})
+
+	b.Run("unique_string", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = UniqueString(words[i%len(words)])
 		}
 	})
 

--- a/pkg/parquetquery/intern/intern_test.go
+++ b/pkg/parquetquery/intern/intern_test.go
@@ -109,16 +109,16 @@ func TestPqValueConversion(t *testing.T) {
 	}
 }
 
-func TestUniqueBytes(t *testing.T) {
-	h1 := UniqueBytes([]byte("hello"))
-	h2 := UniqueBytes([]byte("hello"))
+func TestUniqueStringFromBytes(t *testing.T) {
+	h1 := UniqueStringFromBytes([]byte("hello"))
+	h2 := UniqueStringFromBytes([]byte("hello"))
 
 	// process-wide interning: identical content must yield the same handle
 	if h1 != h2 {
 		t.Error("expected same handle for equal strings")
 	}
 
-	h3 := UniqueBytes([]byte("world"))
+	h3 := UniqueStringFromBytes([]byte("world"))
 	if h1 == h3 {
 		t.Error("expected different handle for different strings")
 	}
@@ -127,12 +127,12 @@ func TestUniqueBytes(t *testing.T) {
 		t.Errorf("expected 'hello', got %q", h1.Value())
 	}
 
-	empty := UniqueBytes([]byte{})
+	empty := UniqueStringFromBytes([]byte{})
 	if empty.Value() != "" {
 		t.Errorf("expected empty string, got %q", empty.Value())
 	}
 
-	nilResult := UniqueBytes(nil)
+	nilResult := UniqueStringFromBytes(nil)
 	if nilResult.Value() != "" {
 		t.Errorf("expected empty string for nil input, got %q", nilResult.Value())
 	}
@@ -155,7 +155,7 @@ func BenchmarkInternString(b *testing.B) {
 
 	b.Run("unique_bytes", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_ = UniqueBytes([]byte(words[i%len(words)]))
+			_ = UniqueStringFromBytes([]byte(words[i%len(words)]))
 		}
 	})
 

--- a/pkg/parquetquery/intern/intern_test.go
+++ b/pkg/parquetquery/intern/intern_test.go
@@ -138,17 +138,6 @@ func TestUniqueBytes(t *testing.T) {
 	}
 }
 
-func TestUniqueStringFromBytes(t *testing.T) {
-	s := UniqueStringFromBytes([]byte("hello"))
-	if s != "hello" {
-		t.Errorf("expected 'hello', got %q", s)
-	}
-
-	empty := UniqueStringFromBytes(nil)
-	if empty != "" {
-		t.Errorf("expected empty string, got %q", empty)
-	}
-}
 
 func TestUniqueString(t *testing.T) {
 	h1 := UniqueString("hello")

--- a/pkg/parquetquery/intern/intern_test.go
+++ b/pkg/parquetquery/intern/intern_test.go
@@ -109,6 +109,47 @@ func TestPqValueConversion(t *testing.T) {
 	}
 }
 
+func TestInternString(t *testing.T) {
+	s1 := InternString([]byte("hello"))
+	s2 := InternString([]byte("hello"))
+
+	// process-wide interning: identical content must yield the same pointer
+	if unsafe.StringData(s1) != unsafe.StringData(s2) {
+		t.Error("expected same backing pointer for equal strings")
+	}
+
+	s3 := InternString([]byte("world"))
+	if unsafe.StringData(s1) == unsafe.StringData(s3) {
+		t.Error("expected different backing pointer for different strings")
+	}
+
+	empty := InternString([]byte{})
+	if empty != "" {
+		t.Errorf("expected empty string, got %q", empty)
+	}
+
+	nilResult := InternString(nil)
+	if nilResult != "" {
+		t.Errorf("expected empty string for nil input, got %q", nilResult)
+	}
+}
+
+func BenchmarkInternString(b *testing.B) {
+	words := []string{"foo", "bar", "baz", "qux", "quux", "corge", "grault", "garply", "waldo", "fred"}
+
+	b.Run("intern_string", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = InternString([]byte(words[i%len(words)]))
+		}
+	})
+
+	b.Run("plain_string_conv", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = string([]byte(words[i%len(words)]))
+		}
+	})
+}
+
 func BenchmarkIntern(b *testing.B) {
 	words := []string{"foo", "bar", "baz", "qux", "quux", "corge", "grault", "garply", "waldo", "fred", "plugh", "xyzzy", "thud"}
 	testCases := []struct {

--- a/pkg/traceql/ast.go
+++ b/pkg/traceql/ast.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 	"time"
+	"unique"
 	"unsafe"
 
 	"github.com/cespare/xxhash/v2"
@@ -655,9 +656,10 @@ func (o UnaryOperation) referencesSpan() bool {
 type Static struct {
 	Type StaticType
 
-	valScalar  uint64   // used for int, float64, bool, time.Duration, Kind, and Status
-	valBytes   []byte   // used for string, []int, []float64, []bool
-	valStrings []string // used for []string
+	valScalar  uint64                    // used for int, float64, bool, time.Duration, Kind, and Status
+	valHandle  unique.Handle[string]     // used for TypeString
+	valBytes   []byte                    // used for []int, []float64, []bool
+	valHandles []unique.Handle[string]   // used for TypeStringArray
 }
 
 type StaticMapKey struct {
@@ -686,8 +688,15 @@ func NewStaticFloat(f float64) Static {
 
 func NewStaticString(s string) Static {
 	return Static{
-		Type:     TypeString,
-		valBytes: unsafe.Slice(unsafe.StringData(s), len(s)),
+		Type:      TypeString,
+		valHandle: unique.Make(s),
+	}
+}
+
+func NewStaticStringFromHandle(h unique.Handle[string]) Static {
+	return Static{
+		Type:      TypeString,
+		valHandle: h,
 	}
 }
 
@@ -758,12 +767,23 @@ func NewStaticStringArray(s []string) Static {
 		return Static{Type: TypeStringArray}
 	}
 	if len(s) == 0 {
-		return Static{Type: TypeStringArray, valStrings: []string{}}
+		return Static{Type: TypeStringArray, valHandles: []unique.Handle[string]{}}
 	}
 
+	handles := make([]unique.Handle[string], len(s))
+	for i, str := range s {
+		handles[i] = unique.Make(str)
+	}
 	return Static{
 		Type:       TypeStringArray,
-		valStrings: s,
+		valHandles: handles,
+	}
+}
+
+func NewStaticStringArrayFromHandles(h []unique.Handle[string]) Static {
+	return Static{
+		Type:       TypeStringArray,
+		valHandles: h,
 	}
 }
 
@@ -792,11 +812,7 @@ func (s Static) MapKey() StaticMapKey {
 	case TypeNil:
 		return StaticMapKey{typ: TypeNil}
 	case TypeString:
-		var str string
-		if len(s.valBytes) > 0 {
-			str = unsafe.String(unsafe.SliceData(s.valBytes), len(s.valBytes))
-		}
-		return StaticMapKey{typ: s.Type, str: str}
+		return StaticMapKey{typ: s.Type, str: s.valHandle.Value()}
 	case TypeIntArray, TypeFloatArray, TypeBooleanArray:
 		if len(s.valBytes) == 0 {
 			return StaticMapKey{typ: s.Type}
@@ -806,14 +822,14 @@ func (s Static) MapKey() StaticMapKey {
 		_, _ = h.Write(s.valBytes)
 		return StaticMapKey{typ: s.Type, code: h.Sum64()}
 	case TypeStringArray:
-		if len(s.valStrings) == 0 {
+		if len(s.valHandles) == 0 {
 			return StaticMapKey{typ: s.Type}
 		}
 
 		h := xxhash.New()
 		_, _ = h.Write(seedBytes)
-		for _, str := range s.valStrings {
-			_, _ = h.Write([]byte(str))
+		for _, handle := range s.valHandles {
+			_, _ = h.Write([]byte(handle.Value()))
 			_, _ = h.Write(separatorByte)
 		}
 
@@ -855,10 +871,12 @@ func (s Static) Equals(o *Static) bool {
 		return sf == o.Float()
 	case TypeKind, TypeBoolean:
 		return s.Type == o.Type && s.valScalar == o.valScalar
-	case TypeString, TypeIntArray, TypeFloatArray, TypeBooleanArray:
+	case TypeString:
+		return o.Type == TypeString && s.valHandle == o.valHandle
+	case TypeIntArray, TypeFloatArray, TypeBooleanArray:
 		return s.Type == o.Type && bytes.Equal(s.valBytes, o.valBytes)
 	case TypeStringArray:
-		return s.Type == o.Type && slices.Equal(s.valStrings, o.valStrings)
+		return s.Type == o.Type && slices.Equal(s.valHandles, o.valHandles)
 	default:
 		// should not be reached
 		return false
@@ -883,10 +901,12 @@ func (s Static) StrictEquals(o *Static) bool {
 		sf := math.Float64frombits(s.valScalar)
 		of := math.Float64frombits(o.valScalar)
 		return sf == of
-	case TypeString, TypeIntArray, TypeFloatArray, TypeBooleanArray:
+	case TypeString:
+		return s.valHandle == o.valHandle
+	case TypeIntArray, TypeFloatArray, TypeBooleanArray:
 		return bytes.Equal(s.valBytes, o.valBytes)
 	case TypeStringArray:
-		return slices.Equal(s.valStrings, o.valStrings)
+		return slices.Equal(s.valHandles, o.valHandles)
 	case TypeNil:
 		return true
 	default:
@@ -907,7 +927,9 @@ func (s Static) compare(o *Static) int {
 	}
 
 	switch s.Type {
-	case TypeString, TypeBooleanArray:
+	case TypeString:
+		return strings.Compare(s.valHandle.Value(), o.valHandle.Value())
+	case TypeBooleanArray:
 		return bytes.Compare(s.valBytes, o.valBytes)
 	case TypeIntArray:
 		sa, _ := s.IntArray()
@@ -918,7 +940,9 @@ func (s Static) compare(o *Static) int {
 		oa, _ := o.FloatArray()
 		return slices.Compare(sa, oa)
 	case TypeStringArray:
-		return slices.Compare(s.valStrings, o.valStrings)
+		return slices.CompareFunc(s.valHandles, o.valHandles, func(a, b unique.Handle[string]) int {
+			return strings.Compare(a.Value(), b.Value())
+		})
 	case TypeNil:
 		return 0
 	default:
@@ -946,9 +970,8 @@ func (s Static) Elements() iter.Seq2[int, Static] {
 				}
 			}
 		case TypeStringArray:
-			strs, _ := s.StringArray()
-			for i, str := range strs {
-				if !fn(i, NewStaticString(str)) {
+			for i, h := range s.valHandles {
+				if !fn(i, NewStaticStringFromHandle(h)) {
 					return
 				}
 			}
@@ -1060,7 +1083,14 @@ func (s Static) StringArray() ([]string, bool) {
 		return nil, false
 	}
 
-	return s.valStrings, true
+	if s.valHandles == nil {
+		return nil, true
+	}
+	strs := make([]string, len(s.valHandles))
+	for i, h := range s.valHandles {
+		strs[i] = h.Value()
+	}
+	return strs, true
 }
 
 func (s Static) BooleanArray() ([]bool, bool) {

--- a/pkg/traceql/ast.go
+++ b/pkg/traceql/ast.go
@@ -13,6 +13,7 @@ import (
 	"unsafe"
 
 	"github.com/cespare/xxhash/v2"
+	"github.com/grafana/tempo/pkg/parquetquery/intern"
 	"github.com/grafana/tempo/pkg/regexp"
 )
 
@@ -697,6 +698,15 @@ func NewStaticStringFromHandle(h unique.Handle[string]) Static {
 	return Static{
 		Type:      TypeString,
 		valHandle: h,
+	}
+}
+
+// NewStaticUniqueStringFromBytes creates a TypeString Static from raw bytes,
+// using process-wide string interning via the unique package.
+func NewStaticUniqueStringFromBytes(b []byte) Static {
+	return Static{
+		Type:      TypeString,
+		valHandle: intern.UniqueStringFromBytes(b),
 	}
 }
 

--- a/pkg/traceql/ast_stringer.go
+++ b/pkg/traceql/ast_stringer.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"unsafe"
 )
 
 func (r RootExpr) String() string {
@@ -99,10 +98,7 @@ func (s Static) EncodeToString(quotes bool) string {
 		}
 		return f
 	case TypeString:
-		var str string
-		if len(s.valBytes) > 0 {
-			str = unsafe.String(unsafe.SliceData(s.valBytes), len(s.valBytes))
-		}
+		str := s.valHandle.Value()
 		if quotes {
 			return "`" + str + "`"
 		}
@@ -126,7 +122,8 @@ func (s Static) EncodeToString(quotes bool) string {
 		floats, _ := s.FloatArray()
 		return arrayToString(floats, false)
 	case TypeStringArray:
-		return arrayToString(s.valStrings, true)
+		strs, _ := s.StringArray()
+		return arrayToString(strs, true)
 	case TypeBooleanArray:
 		booleans, _ := s.BooleanArray()
 		return arrayToString(booleans, false)

--- a/pkg/traceql/engine.go
+++ b/pkg/traceql/engine.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"time"
+	"unique"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -300,11 +301,20 @@ func (e *Engine) createAutocompleteRequest(tag Attribute, pipeline Pipeline) Fet
 	return autocompleteReq
 }
 
+// handleValue safely extracts the string from a unique.Handle, returning
+// empty string for zero-value handles (which panic on .Value()).
+func handleValue(h unique.Handle[string]) string {
+	if h == (unique.Handle[string]{}) {
+		return ""
+	}
+	return h.Value()
+}
+
 func asTraceSearchMetadata(spanset *Spanset) *tempopb.TraceSearchMetadata {
 	metadata := &tempopb.TraceSearchMetadata{
 		TraceID:           util.TraceIDToHexString(spanset.TraceID),
-		RootServiceName:   spanset.RootServiceName,
-		RootTraceName:     spanset.RootSpanName,
+		RootServiceName:   handleValue(spanset.RootServiceName),
+		RootTraceName:     handleValue(spanset.RootSpanName),
 		StartTimeUnixNano: spanset.StartTimeUnixNanos,
 		DurationMs:        uint32(spanset.DurationNanos / 1_000_000),
 		ServiceStats:      make(map[string]*tempopb.ServiceStats, len(spanset.ServiceStats)),

--- a/pkg/traceql/engine_test.go
+++ b/pkg/traceql/engine_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unique"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,8 +35,8 @@ func TestEngine_Execute(t *testing.T) {
 			results: []*Spanset{
 				{
 					TraceID:         []byte{1},
-					RootSpanName:    "HTTP GET",
-					RootServiceName: "my-service",
+					RootSpanName:    unique.Make("HTTP GET"),
+					RootServiceName: unique.Make("my-service"),
 					ServiceStats: map[string]ServiceStats{
 						"my-service": {
 							SpanCount:  6,
@@ -89,8 +90,8 @@ func TestEngine_Execute(t *testing.T) {
 				},
 				{
 					TraceID:         []byte{2},
-					RootSpanName:    "HTTP POST",
-					RootServiceName: "my-service",
+					RootSpanName:    unique.Make("HTTP POST"),
+					RootServiceName: unique.Make("my-service"),
 					Spans: []Span{
 						&mockSpan{
 							id: []byte{3},
@@ -214,8 +215,8 @@ func TestEngine_asTraceSearchMetadata(t *testing.T) {
 
 	spanSet := &Spanset{
 		TraceID:            traceID,
-		RootServiceName:    "my-service",
-		RootSpanName:       "HTTP GET",
+		RootServiceName:    unique.Make("my-service"),
+		RootSpanName:       unique.Make("HTTP GET"),
 		StartTimeUnixNanos: 1000,
 		DurationNanos:      uint64(time.Second.Nanoseconds()),
 		ServiceStats: map[string]ServiceStats{
@@ -602,8 +603,8 @@ func TestExecuteTagValues(t *testing.T) {
 				results: []*Spanset{
 					{
 						TraceID:         []byte{1},
-						RootSpanName:    "HTTP GET",
-						RootServiceName: "my-service",
+						RootSpanName:    unique.Make("HTTP GET"),
+						RootServiceName: unique.Make("my-service"),
 						Spans: []Span{
 							&mockSpan{
 								id: []byte{1},
@@ -627,8 +628,8 @@ func TestExecuteTagValues(t *testing.T) {
 					},
 					{
 						TraceID:         []byte{2},
-						RootSpanName:    "HTTP POST",
-						RootServiceName: "my-service",
+						RootSpanName:    unique.Make("HTTP POST"),
+						RootServiceName: unique.Make("my-service"),
 						Spans: []Span{
 							&mockSpan{
 								id: []byte{3},

--- a/pkg/traceql/storage.go
+++ b/pkg/traceql/storage.go
@@ -3,6 +3,7 @@ package traceql
 import (
 	"context"
 	"time"
+	"unique"
 
 	"github.com/grafana/tempo/pkg/util"
 )
@@ -209,8 +210,8 @@ type Spanset struct {
 	Spans  []Span
 
 	TraceID            []byte
-	RootSpanName       string
-	RootServiceName    string
+	RootSpanName       unique.Handle[string]
+	RootServiceName    unique.Handle[string]
 	StartTimeUnixNanos uint64
 	DurationNanos      uint64
 	ServiceStats       map[string]ServiceStats

--- a/pkg/traceql/storage_test.go
+++ b/pkg/traceql/storage_test.go
@@ -3,6 +3,7 @@ package traceql
 import (
 	"reflect"
 	"testing"
+	"unique"
 
 	"github.com/stretchr/testify/require"
 )
@@ -19,8 +20,8 @@ func TestSpansetClone(t *testing.T) {
 			},
 			Scalar:             NewStaticFloat(3.2),
 			TraceID:            []byte{0x02},
-			RootSpanName:       "a",
-			RootServiceName:    "b",
+			RootSpanName:       unique.Make("a"),
+			RootServiceName:    unique.Make("b"),
 			StartTimeUnixNanos: 1,
 			DurationNanos:      5,
 			Attributes:         []*SpansetAttribute{{Name: "foo", Val: NewStaticString("bar")}},
@@ -35,8 +36,8 @@ func TestSpansetClone(t *testing.T) {
 			},
 			Scalar:             NewStaticFloat(3.2),
 			TraceID:            []byte{0x02},
-			RootSpanName:       "a",
-			RootServiceName:    "b",
+			RootSpanName:       unique.Make("a"),
+			RootServiceName:    unique.Make("b"),
 			StartTimeUnixNanos: 1,
 			DurationNanos:      5,
 		},

--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -2822,10 +2822,10 @@ func (c *traceCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			finalSpanset.DurationNanos = e.Value.Uint64()
 			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceDurationAttribute, traceql.NewStaticDuration(time.Duration(finalSpanset.DurationNanos))})
 		case columnPathRootSpanName:
-			finalSpanset.RootSpanName = intern.UniqueBytes(e.Value.Bytes())
+			finalSpanset.RootSpanName = intern.UniqueStringFromBytes(e.Value.Bytes())
 			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootSpanAttribute, traceql.NewStaticStringFromHandle(finalSpanset.RootSpanName)})
 		case columnPathRootServiceName:
-			finalSpanset.RootServiceName = intern.UniqueBytes(e.Value.Bytes())
+			finalSpanset.RootServiceName = intern.UniqueStringFromBytes(e.Value.Bytes())
 			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootServiceAttribute, traceql.NewStaticStringFromHandle(finalSpanset.RootServiceName)})
 		}
 	}

--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -10,11 +10,13 @@ import (
 	"sort"
 	"sync"
 	"time"
+	"unique"
 	"unsafe"
 
 	"github.com/parquet-go/parquet-go"
 
 	"github.com/grafana/tempo/pkg/parquetquery"
+	"github.com/grafana/tempo/pkg/parquetquery/intern"
 	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	"github.com/grafana/tempo/pkg/traceql"
 	"github.com/grafana/tempo/pkg/util"
@@ -741,8 +743,8 @@ func getSpanset() *traceql.Spanset {
 func putSpanset(ss *traceql.Spanset) {
 	ss.Attributes = ss.Attributes[:0]
 	ss.DurationNanos = 0
-	ss.RootServiceName = ""
-	ss.RootSpanName = ""
+	ss.RootServiceName = unique.Handle[string]{}
+	ss.RootSpanName = unique.Handle[string]{}
 	ss.Scalar = traceql.NewStaticNil()
 	ss.StartTimeUnixNanos = 0
 	ss.TraceID = nil
@@ -1187,10 +1189,10 @@ func (i *rebatchIterator) Next() (*parquetquery.IteratorResult, error) {
 			if len(sp.cbSpanset.TraceID) == 0 {
 				sp.cbSpanset.TraceID = ss.TraceID
 			}
-			if len(sp.cbSpanset.RootSpanName) == 0 {
+			if sp.cbSpanset.RootSpanName == (unique.Handle[string]{}) {
 				sp.cbSpanset.RootSpanName = ss.RootSpanName
 			}
-			if len(sp.cbSpanset.RootServiceName) == 0 {
+			if sp.cbSpanset.RootServiceName == (unique.Handle[string]{}) {
 				sp.cbSpanset.RootServiceName = ss.RootServiceName
 			}
 			if sp.cbSpanset.StartTimeUnixNanos == 0 {
@@ -2820,11 +2822,11 @@ func (c *traceCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			finalSpanset.DurationNanos = e.Value.Uint64()
 			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceDurationAttribute, traceql.NewStaticDuration(time.Duration(finalSpanset.DurationNanos))})
 		case columnPathRootSpanName:
-			finalSpanset.RootSpanName = unsafeToString(e.Value.Bytes())
-			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootSpanAttribute, traceql.NewStaticString(finalSpanset.RootSpanName)})
+			finalSpanset.RootSpanName = intern.UniqueBytes(e.Value.Bytes())
+			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootSpanAttribute, traceql.NewStaticStringFromHandle(finalSpanset.RootSpanName)})
 		case columnPathRootServiceName:
-			finalSpanset.RootServiceName = unsafeToString(e.Value.Bytes())
-			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootServiceAttribute, traceql.NewStaticString(finalSpanset.RootServiceName)})
+			finalSpanset.RootServiceName = intern.UniqueBytes(e.Value.Bytes())
+			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootServiceAttribute, traceql.NewStaticStringFromHandle(finalSpanset.RootServiceName)})
 		}
 	}
 

--- a/tempodb/encoding/vparquet3/block_traceql_meta_test.go
+++ b/tempodb/encoding/vparquet3/block_traceql_meta_test.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"testing"
 	"time"
+	"unique"
 
 	"github.com/grafana/tempo/pkg/parquetquery"
 	"github.com/grafana/tempo/pkg/traceql"
@@ -27,8 +28,8 @@ func TestBackendBlockSearchFetchMetaData(t *testing.T) {
 	makeSpanset := func(traceID []byte, rootSpanName, rootServiceName string, startTimeUnixNano, durationNanos uint64, spans ...traceql.Span) *traceql.Spanset {
 		return &traceql.Spanset{
 			TraceID:            traceID,
-			RootSpanName:       rootSpanName,
-			RootServiceName:    rootServiceName,
+			RootSpanName:       unique.Make(rootSpanName),
+			RootServiceName:    unique.Make(rootServiceName),
 			StartTimeUnixNanos: startTimeUnixNano,
 			DurationNanos:      durationNanos,
 			Spans:              spans,

--- a/tempodb/encoding/vparquet4/block_autocomplete.go
+++ b/tempodb/encoding/vparquet4/block_autocomplete.go
@@ -1106,7 +1106,7 @@ func (d *distinctAttrCollector) KeepGroup(result *parquetquery.IteratorResult) b
 
 		if d.attrNames {
 			if e.Key == "key" {
-				name := intern.UniqueBytes(e.Value.ByteArray()).Value()
+				name := intern.UniqueStringFromBytes(e.Value.ByteArray()).Value()
 				key := tagNameKey{name: name, scope: d.scope}
 				if !d.existsTagName(key) {
 					result.AppendOtherValue(name, d.scope)
@@ -1115,7 +1115,7 @@ func (d *distinctAttrCollector) KeepGroup(result *parquetquery.IteratorResult) b
 		} else {
 			switch e.Key {
 			case "string":
-				val = traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
+				val = traceql.NewStaticUniqueStringFromBytes(e.Value.ByteArray())
 			case "int":
 				val = traceql.NewStaticInt(int(e.Value.Int64()))
 			case "float":
@@ -1179,7 +1179,7 @@ func (d distinctValueCollector) KeepGroup(result *parquetquery.IteratorResult) b
 
 func mapEventAttr(e entry) traceql.Static {
 	if e.Key == ColumnPathEventName {
-		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
+		return traceql.NewStaticUniqueStringFromBytes(e.Value.ByteArray())
 	}
 	return traceql.NewStaticNil()
 }
@@ -1198,7 +1198,7 @@ func mapSpanAttr(e entry) traceql.Static {
 	case columnPathSpanDuration:
 		return traceql.NewStaticDuration(time.Duration(e.Value.Int64()))
 	case ColumnPathSpanName:
-		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
+		return traceql.NewStaticUniqueStringFromBytes(e.Value.ByteArray())
 	case columnPathSpanStatusCode:
 		// Map OTLP status code back to TraceQL enum.
 		// For other values, use the raw integer.
@@ -1215,7 +1215,7 @@ func mapSpanAttr(e entry) traceql.Static {
 		}
 		return traceql.NewStaticStatus(status)
 	case columnPathSpanStatusMessage:
-		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
+		return traceql.NewStaticUniqueStringFromBytes(e.Value.ByteArray())
 	case columnPathSpanKind:
 		var kind traceql.Kind
 		switch e.Value.Uint64() {
@@ -1245,7 +1245,7 @@ func mapSpanAttr(e entry) traceql.Static {
 		case parquet.Float:
 			return traceql.NewStaticFloat(e.Value.Double())
 		case parquet.ByteArray, parquet.FixedLenByteArray:
-			return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
+			return traceql.NewStaticUniqueStringFromBytes(e.Value.ByteArray())
 		}
 	}
 	return traceql.NewStaticNil()
@@ -1254,7 +1254,7 @@ func mapSpanAttr(e entry) traceql.Static {
 func mapInstrumentationAttr(e entry) traceql.Static {
 	switch e.Key {
 	case columnPathInstrumentationName, columnPathInstrumentationVersion:
-		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
+		return traceql.NewStaticUniqueStringFromBytes(e.Value.ByteArray())
 	}
 	return traceql.Static{}
 }
@@ -1268,7 +1268,7 @@ func mapResourceAttr(e entry) traceql.Static {
 	case parquet.Float:
 		return traceql.NewStaticFloat(e.Value.Double())
 	case parquet.ByteArray, parquet.FixedLenByteArray:
-		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
+		return traceql.NewStaticUniqueStringFromBytes(e.Value.ByteArray())
 	default:
 		return traceql.NewStaticNil()
 	}
@@ -1280,9 +1280,9 @@ func mapTraceAttr(e entry) traceql.Static {
 	case columnPathDurationNanos:
 		return traceql.NewStaticDuration(time.Duration(e.Value.Int64()))
 	case columnPathRootSpanName:
-		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
+		return traceql.NewStaticUniqueStringFromBytes(e.Value.ByteArray())
 	case columnPathRootServiceName:
-		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
+		return traceql.NewStaticUniqueStringFromBytes(e.Value.ByteArray())
 	}
 	return traceql.NewStaticNil()
 }

--- a/tempodb/encoding/vparquet4/block_autocomplete.go
+++ b/tempodb/encoding/vparquet4/block_autocomplete.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/grafana/tempo/pkg/parquetquery"
+	"github.com/grafana/tempo/pkg/parquetquery/intern"
 	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	"github.com/grafana/tempo/pkg/traceql"
 	"github.com/grafana/tempo/tempodb/backend"
@@ -1105,7 +1106,7 @@ func (d *distinctAttrCollector) KeepGroup(result *parquetquery.IteratorResult) b
 
 		if d.attrNames {
 			if e.Key == "key" {
-				name := unsafeToString(e.Value.ByteArray())
+				name := intern.InternString(e.Value.ByteArray())
 				key := tagNameKey{name: name, scope: d.scope}
 				if !d.existsTagName(key) {
 					result.AppendOtherValue(name, d.scope)
@@ -1178,7 +1179,7 @@ func (d distinctValueCollector) KeepGroup(result *parquetquery.IteratorResult) b
 
 func mapEventAttr(e entry) traceql.Static {
 	if e.Key == ColumnPathEventName {
-		return traceql.NewStaticString(unsafeToString(e.Value.ByteArray()))
+		return traceql.NewStaticString(intern.InternString(e.Value.ByteArray()))
 	}
 	return traceql.NewStaticNil()
 }
@@ -1197,7 +1198,7 @@ func mapSpanAttr(e entry) traceql.Static {
 	case columnPathSpanDuration:
 		return traceql.NewStaticDuration(time.Duration(e.Value.Int64()))
 	case ColumnPathSpanName:
-		return traceql.NewStaticString(unsafeToString(e.Value.ByteArray()))
+		return traceql.NewStaticString(intern.InternString(e.Value.ByteArray()))
 	case columnPathSpanStatusCode:
 		// Map OTLP status code back to TraceQL enum.
 		// For other values, use the raw integer.
@@ -1214,7 +1215,7 @@ func mapSpanAttr(e entry) traceql.Static {
 		}
 		return traceql.NewStaticStatus(status)
 	case columnPathSpanStatusMessage:
-		return traceql.NewStaticString(unsafeToString(e.Value.ByteArray()))
+		return traceql.NewStaticString(intern.InternString(e.Value.ByteArray()))
 	case columnPathSpanKind:
 		var kind traceql.Kind
 		switch e.Value.Uint64() {
@@ -1253,7 +1254,7 @@ func mapSpanAttr(e entry) traceql.Static {
 func mapInstrumentationAttr(e entry) traceql.Static {
 	switch e.Key {
 	case columnPathInstrumentationName, columnPathInstrumentationVersion:
-		return traceql.NewStaticString(unsafeToString(e.Value.ByteArray()))
+		return traceql.NewStaticString(intern.InternString(e.Value.ByteArray()))
 	}
 	return traceql.Static{}
 }
@@ -1279,9 +1280,9 @@ func mapTraceAttr(e entry) traceql.Static {
 	case columnPathDurationNanos:
 		return traceql.NewStaticDuration(time.Duration(e.Value.Int64()))
 	case columnPathRootSpanName:
-		return traceql.NewStaticString(unsafeToString(e.Value.ByteArray()))
+		return traceql.NewStaticString(intern.InternString(e.Value.ByteArray()))
 	case columnPathRootServiceName:
-		return traceql.NewStaticString(unsafeToString(e.Value.ByteArray()))
+		return traceql.NewStaticString(intern.InternString(e.Value.ByteArray()))
 	}
 	return traceql.NewStaticNil()
 }

--- a/tempodb/encoding/vparquet4/block_autocomplete.go
+++ b/tempodb/encoding/vparquet4/block_autocomplete.go
@@ -1106,7 +1106,7 @@ func (d *distinctAttrCollector) KeepGroup(result *parquetquery.IteratorResult) b
 
 		if d.attrNames {
 			if e.Key == "key" {
-				name := intern.UniqueStringFromBytes(e.Value.ByteArray())
+				name := intern.UniqueBytes(e.Value.ByteArray()).Value()
 				key := tagNameKey{name: name, scope: d.scope}
 				if !d.existsTagName(key) {
 					result.AppendOtherValue(name, d.scope)

--- a/tempodb/encoding/vparquet4/block_autocomplete.go
+++ b/tempodb/encoding/vparquet4/block_autocomplete.go
@@ -1106,7 +1106,7 @@ func (d *distinctAttrCollector) KeepGroup(result *parquetquery.IteratorResult) b
 
 		if d.attrNames {
 			if e.Key == "key" {
-				name := intern.InternString(e.Value.ByteArray())
+				name := intern.UniqueStringFromBytes(e.Value.ByteArray())
 				key := tagNameKey{name: name, scope: d.scope}
 				if !d.existsTagName(key) {
 					result.AppendOtherValue(name, d.scope)
@@ -1115,7 +1115,7 @@ func (d *distinctAttrCollector) KeepGroup(result *parquetquery.IteratorResult) b
 		} else {
 			switch e.Key {
 			case "string":
-				val = traceql.NewStaticString(unsafeToString(e.Value.ByteArray()))
+				val = traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
 			case "int":
 				val = traceql.NewStaticInt(int(e.Value.Int64()))
 			case "float":
@@ -1179,7 +1179,7 @@ func (d distinctValueCollector) KeepGroup(result *parquetquery.IteratorResult) b
 
 func mapEventAttr(e entry) traceql.Static {
 	if e.Key == ColumnPathEventName {
-		return traceql.NewStaticString(intern.InternString(e.Value.ByteArray()))
+		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
 	}
 	return traceql.NewStaticNil()
 }
@@ -1198,7 +1198,7 @@ func mapSpanAttr(e entry) traceql.Static {
 	case columnPathSpanDuration:
 		return traceql.NewStaticDuration(time.Duration(e.Value.Int64()))
 	case ColumnPathSpanName:
-		return traceql.NewStaticString(intern.InternString(e.Value.ByteArray()))
+		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
 	case columnPathSpanStatusCode:
 		// Map OTLP status code back to TraceQL enum.
 		// For other values, use the raw integer.
@@ -1215,7 +1215,7 @@ func mapSpanAttr(e entry) traceql.Static {
 		}
 		return traceql.NewStaticStatus(status)
 	case columnPathSpanStatusMessage:
-		return traceql.NewStaticString(intern.InternString(e.Value.ByteArray()))
+		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
 	case columnPathSpanKind:
 		var kind traceql.Kind
 		switch e.Value.Uint64() {
@@ -1245,7 +1245,7 @@ func mapSpanAttr(e entry) traceql.Static {
 		case parquet.Float:
 			return traceql.NewStaticFloat(e.Value.Double())
 		case parquet.ByteArray, parquet.FixedLenByteArray:
-			return traceql.NewStaticString(unsafeToString(e.Value.ByteArray()))
+			return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
 		}
 	}
 	return traceql.NewStaticNil()
@@ -1254,7 +1254,7 @@ func mapSpanAttr(e entry) traceql.Static {
 func mapInstrumentationAttr(e entry) traceql.Static {
 	switch e.Key {
 	case columnPathInstrumentationName, columnPathInstrumentationVersion:
-		return traceql.NewStaticString(intern.InternString(e.Value.ByteArray()))
+		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
 	}
 	return traceql.Static{}
 }
@@ -1268,7 +1268,7 @@ func mapResourceAttr(e entry) traceql.Static {
 	case parquet.Float:
 		return traceql.NewStaticFloat(e.Value.Double())
 	case parquet.ByteArray, parquet.FixedLenByteArray:
-		return traceql.NewStaticString(unsafeToString(e.Value.ByteArray()))
+		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
 	default:
 		return traceql.NewStaticNil()
 	}
@@ -1280,9 +1280,9 @@ func mapTraceAttr(e entry) traceql.Static {
 	case columnPathDurationNanos:
 		return traceql.NewStaticDuration(time.Duration(e.Value.Int64()))
 	case columnPathRootSpanName:
-		return traceql.NewStaticString(intern.InternString(e.Value.ByteArray()))
+		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
 	case columnPathRootServiceName:
-		return traceql.NewStaticString(intern.InternString(e.Value.ByteArray()))
+		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
 	}
 	return traceql.NewStaticNil()
 }

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -3168,11 +3168,11 @@ func (c *spanCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			sp.durationNanos = durationNanos
 			sp.addSpanAttr(traceql.IntrinsicDurationAttribute, traceql.NewStaticDuration(time.Duration(durationNanos)))
 		case ColumnPathSpanName:
-			sp.addSpanAttr(traceql.IntrinsicNameAttribute, traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())))
+			sp.addSpanAttr(traceql.IntrinsicNameAttribute, traceql.NewStaticUniqueStringFromBytes(kv.Value.Bytes()))
 		case columnPathSpanStatusCode:
 			sp.addSpanAttr(traceql.IntrinsicStatusAttribute, traceql.NewStaticStatus(otlpStatusToTraceqlStatus(kv.Value.Uint64())))
 		case columnPathSpanStatusMessage:
-			sp.addSpanAttr(traceql.IntrinsicStatusMessageAttribute, traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())))
+			sp.addSpanAttr(traceql.IntrinsicStatusMessageAttribute, traceql.NewStaticUniqueStringFromBytes(kv.Value.Bytes()))
 		case columnPathSpanKind:
 			sp.addSpanAttr(traceql.IntrinsicKindAttribute, traceql.NewStaticKind(otlpKindToTraceqlKind(kv.Value.Uint64())))
 		case columnPathSpanParentID:
@@ -3201,7 +3201,7 @@ func (c *spanCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			case parquet.Float:
 				sp.addSpanAttr(newSpanAttr(kv.Key), traceql.NewStaticFloat(kv.Value.Double()))
 			case parquet.ByteArray:
-				sp.addSpanAttr(newSpanAttr(kv.Key), traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())))
+				sp.addSpanAttr(newSpanAttr(kv.Key), traceql.NewStaticUniqueStringFromBytes(kv.Value.Bytes()))
 			default:
 				// This is a null value, indicating the attribute doesn't exist
 				if kv.Value.IsNull() {
@@ -3270,12 +3270,12 @@ func (c *instrumentationCollector) KeepGroup(res *parquetquery.IteratorResult) b
 		case columnPathInstrumentationName:
 			c.instrumentationAttrs = append(c.instrumentationAttrs, attrVal{
 				a: traceql.IntrinsicInstrumentationNameAttribute,
-				s: traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())),
+				s: traceql.NewStaticUniqueStringFromBytes(kv.Value.Bytes()),
 			})
 		case columnPathInstrumentationVersion:
 			c.instrumentationAttrs = append(c.instrumentationAttrs, attrVal{
 				a: traceql.IntrinsicInstrumentationVersionAttribute,
-				s: traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())),
+				s: traceql.NewStaticUniqueStringFromBytes(kv.Value.Bytes()),
 			})
 		default:
 			// This is a null value, indicating the attribute doesn't exist
@@ -3363,7 +3363,7 @@ func (c *batchCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		case parquet.Int64:
 			c.resAttrs = append(c.resAttrs, attrVal{newResAttr(e.Key), traceql.NewStaticInt(int(e.Value.Int64()))})
 		case parquet.ByteArray:
-			c.resAttrs = append(c.resAttrs, attrVal{newResAttr(e.Key), traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.Bytes()))})
+			c.resAttrs = append(c.resAttrs, attrVal{newResAttr(e.Key), traceql.NewStaticUniqueStringFromBytes(e.Value.Bytes())})
 		default:
 			// This is a null value, indicating the attribute doesn't exist
 			if e.Value.IsNull() {
@@ -3464,10 +3464,10 @@ func (c *traceCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			finalSpanset.DurationNanos = e.Value.Uint64()
 			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceDurationAttribute, traceql.NewStaticDuration(time.Duration(finalSpanset.DurationNanos))})
 		case columnPathRootSpanName:
-			finalSpanset.RootSpanName = intern.UniqueBytes(e.Value.Bytes())
+			finalSpanset.RootSpanName = intern.UniqueStringFromBytes(e.Value.Bytes())
 			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootSpanAttribute, traceql.NewStaticStringFromHandle(finalSpanset.RootSpanName)})
 		case columnPathRootServiceName:
-			finalSpanset.RootServiceName = intern.UniqueBytes(e.Value.Bytes())
+			finalSpanset.RootServiceName = intern.UniqueStringFromBytes(e.Value.Bytes())
 			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootServiceAttribute, traceql.NewStaticStringFromHandle(finalSpanset.RootServiceName)})
 		}
 	}
@@ -3581,10 +3581,10 @@ func (c *attributeCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		}
 		switch e.Key {
 		case "key":
-			key = intern.UniqueBytes(e.Value.Bytes()).Value()
+			key = intern.UniqueStringFromBytes(e.Value.Bytes()).Value()
 
 		case "string":
-			c.strBuffer = append(c.strBuffer, intern.UniqueBytes(e.Value.Bytes()))
+			c.strBuffer = append(c.strBuffer, intern.UniqueStringFromBytes(e.Value.Bytes()))
 		case "int":
 			c.intBuffer = append(c.intBuffer, int(e.Value.Int64()))
 		case "float":
@@ -3685,7 +3685,7 @@ func (c *eventCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		case ColumnPathEventName:
 			ev.attrs = append(ev.attrs, attrVal{
 				a: traceql.IntrinsicEventNameAttribute,
-				s: traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.Bytes())),
+				s: traceql.NewStaticUniqueStringFromBytes(e.Value.Bytes()),
 			})
 		case columnPathEventTimeSinceStart:
 			ev.attrs = append(ev.attrs, attrVal{

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -3200,7 +3200,7 @@ func (c *spanCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			case parquet.Float:
 				sp.addSpanAttr(newSpanAttr(kv.Key), traceql.NewStaticFloat(kv.Value.Double()))
 			case parquet.ByteArray:
-				sp.addSpanAttr(newSpanAttr(kv.Key), traceql.NewStaticString(intern.InternString(kv.Value.Bytes())))
+				sp.addSpanAttr(newSpanAttr(kv.Key), traceql.NewStaticString(unsafeToString(kv.Value.Bytes())))
 			default:
 				// This is a null value, indicating the attribute doesn't exist
 				if kv.Value.IsNull() {
@@ -3362,7 +3362,7 @@ func (c *batchCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		case parquet.Int64:
 			c.resAttrs = append(c.resAttrs, attrVal{newResAttr(e.Key), traceql.NewStaticInt(int(e.Value.Int64()))})
 		case parquet.ByteArray:
-			c.resAttrs = append(c.resAttrs, attrVal{newResAttr(e.Key), traceql.NewStaticString(intern.InternString(e.Value.Bytes()))})
+			c.resAttrs = append(c.resAttrs, attrVal{newResAttr(e.Key), traceql.NewStaticString(unsafeToString(e.Value.Bytes()))})
 		default:
 			// This is a null value, indicating the attribute doesn't exist
 			if e.Value.IsNull() {
@@ -3583,7 +3583,7 @@ func (c *attributeCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			key = intern.InternString(e.Value.Bytes())
 
 		case "string":
-			c.strBuffer = append(c.strBuffer, intern.InternString(e.Value.Bytes()))
+			c.strBuffer = append(c.strBuffer, unsafeToString(e.Value.Bytes()))
 		case "int":
 			c.intBuffer = append(c.intBuffer, int(e.Value.Int64()))
 		case "float":

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -872,8 +872,8 @@ func getSpanset() *traceql.Spanset {
 func putSpanset(ss *traceql.Spanset) {
 	ss.Attributes = ss.Attributes[:0]
 	ss.DurationNanos = 0
-	ss.RootServiceName = ""
-	ss.RootSpanName = ""
+	ss.RootServiceName = unique.Handle[string]{}
+	ss.RootSpanName = unique.Handle[string]{}
 	ss.Scalar = traceql.NewStaticNil()
 	ss.StartTimeUnixNanos = 0
 	ss.TraceID = nil
@@ -1353,10 +1353,10 @@ func (i *rebatchIterator) Next() (*parquetquery.IteratorResult, error) {
 			if len(sp.cbSpanset.TraceID) == 0 {
 				sp.cbSpanset.TraceID = ss.TraceID
 			}
-			if len(sp.cbSpanset.RootSpanName) == 0 {
+			if sp.cbSpanset.RootSpanName == (unique.Handle[string]{}) {
 				sp.cbSpanset.RootSpanName = ss.RootSpanName
 			}
-			if len(sp.cbSpanset.RootServiceName) == 0 {
+			if sp.cbSpanset.RootServiceName == (unique.Handle[string]{}) {
 				sp.cbSpanset.RootServiceName = ss.RootServiceName
 			}
 			if sp.cbSpanset.StartTimeUnixNanos == 0 {
@@ -3464,11 +3464,11 @@ func (c *traceCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			finalSpanset.DurationNanos = e.Value.Uint64()
 			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceDurationAttribute, traceql.NewStaticDuration(time.Duration(finalSpanset.DurationNanos))})
 		case columnPathRootSpanName:
-			finalSpanset.RootSpanName = intern.UniqueStringFromBytes(e.Value.Bytes())
-			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootSpanAttribute, traceql.NewStaticString(finalSpanset.RootSpanName)})
+			finalSpanset.RootSpanName = intern.UniqueBytes(e.Value.Bytes())
+			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootSpanAttribute, traceql.NewStaticStringFromHandle(finalSpanset.RootSpanName)})
 		case columnPathRootServiceName:
-			finalSpanset.RootServiceName = intern.UniqueStringFromBytes(e.Value.Bytes())
-			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootServiceAttribute, traceql.NewStaticString(finalSpanset.RootServiceName)})
+			finalSpanset.RootServiceName = intern.UniqueBytes(e.Value.Bytes())
+			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootServiceAttribute, traceql.NewStaticStringFromHandle(finalSpanset.RootServiceName)})
 		}
 	}
 
@@ -3581,7 +3581,7 @@ func (c *attributeCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		}
 		switch e.Key {
 		case "key":
-			key = intern.UniqueStringFromBytes(e.Value.Bytes())
+			key = intern.UniqueBytes(e.Value.Bytes()).Value()
 
 		case "string":
 			c.strBuffer = append(c.strBuffer, intern.UniqueBytes(e.Value.Bytes()))

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"sync"
 	"time"
+	"unique"
 	"unsafe"
 
 	"github.com/parquet-go/parquet-go"
@@ -3167,11 +3168,11 @@ func (c *spanCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			sp.durationNanos = durationNanos
 			sp.addSpanAttr(traceql.IntrinsicDurationAttribute, traceql.NewStaticDuration(time.Duration(durationNanos)))
 		case ColumnPathSpanName:
-			sp.addSpanAttr(traceql.IntrinsicNameAttribute, traceql.NewStaticString(intern.InternString(kv.Value.Bytes())))
+			sp.addSpanAttr(traceql.IntrinsicNameAttribute, traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())))
 		case columnPathSpanStatusCode:
 			sp.addSpanAttr(traceql.IntrinsicStatusAttribute, traceql.NewStaticStatus(otlpStatusToTraceqlStatus(kv.Value.Uint64())))
 		case columnPathSpanStatusMessage:
-			sp.addSpanAttr(traceql.IntrinsicStatusMessageAttribute, traceql.NewStaticString(intern.InternString(kv.Value.Bytes())))
+			sp.addSpanAttr(traceql.IntrinsicStatusMessageAttribute, traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())))
 		case columnPathSpanKind:
 			sp.addSpanAttr(traceql.IntrinsicKindAttribute, traceql.NewStaticKind(otlpKindToTraceqlKind(kv.Value.Uint64())))
 		case columnPathSpanParentID:
@@ -3200,7 +3201,7 @@ func (c *spanCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			case parquet.Float:
 				sp.addSpanAttr(newSpanAttr(kv.Key), traceql.NewStaticFloat(kv.Value.Double()))
 			case parquet.ByteArray:
-				sp.addSpanAttr(newSpanAttr(kv.Key), traceql.NewStaticString(unsafeToString(kv.Value.Bytes())))
+				sp.addSpanAttr(newSpanAttr(kv.Key), traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())))
 			default:
 				// This is a null value, indicating the attribute doesn't exist
 				if kv.Value.IsNull() {
@@ -3269,12 +3270,12 @@ func (c *instrumentationCollector) KeepGroup(res *parquetquery.IteratorResult) b
 		case columnPathInstrumentationName:
 			c.instrumentationAttrs = append(c.instrumentationAttrs, attrVal{
 				a: traceql.IntrinsicInstrumentationNameAttribute,
-				s: traceql.NewStaticString(intern.InternString(kv.Value.Bytes())),
+				s: traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())),
 			})
 		case columnPathInstrumentationVersion:
 			c.instrumentationAttrs = append(c.instrumentationAttrs, attrVal{
 				a: traceql.IntrinsicInstrumentationVersionAttribute,
-				s: traceql.NewStaticString(intern.InternString(kv.Value.Bytes())),
+				s: traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())),
 			})
 		default:
 			// This is a null value, indicating the attribute doesn't exist
@@ -3362,7 +3363,7 @@ func (c *batchCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		case parquet.Int64:
 			c.resAttrs = append(c.resAttrs, attrVal{newResAttr(e.Key), traceql.NewStaticInt(int(e.Value.Int64()))})
 		case parquet.ByteArray:
-			c.resAttrs = append(c.resAttrs, attrVal{newResAttr(e.Key), traceql.NewStaticString(unsafeToString(e.Value.Bytes()))})
+			c.resAttrs = append(c.resAttrs, attrVal{newResAttr(e.Key), traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.Bytes()))})
 		default:
 			// This is a null value, indicating the attribute doesn't exist
 			if e.Value.IsNull() {
@@ -3463,10 +3464,10 @@ func (c *traceCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			finalSpanset.DurationNanos = e.Value.Uint64()
 			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceDurationAttribute, traceql.NewStaticDuration(time.Duration(finalSpanset.DurationNanos))})
 		case columnPathRootSpanName:
-			finalSpanset.RootSpanName = intern.InternString(e.Value.Bytes())
+			finalSpanset.RootSpanName = intern.UniqueStringFromBytes(e.Value.Bytes())
 			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootSpanAttribute, traceql.NewStaticString(finalSpanset.RootSpanName)})
 		case columnPathRootServiceName:
-			finalSpanset.RootServiceName = intern.InternString(e.Value.Bytes())
+			finalSpanset.RootServiceName = intern.UniqueStringFromBytes(e.Value.Bytes())
 			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootServiceAttribute, traceql.NewStaticString(finalSpanset.RootServiceName)})
 		}
 	}
@@ -3550,7 +3551,7 @@ func (c *serviceStatsCollector) KeepGroup(res *parquetquery.IteratorResult) bool
 // columns and joins them together into map[key]value entries with the
 // right type.
 type attributeCollector struct {
-	strBuffer   []string
+	strBuffer   []unique.Handle[string]
 	intBuffer   []int
 	floatBuffer []float64
 	boolBuffer  []bool
@@ -3580,10 +3581,10 @@ func (c *attributeCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		}
 		switch e.Key {
 		case "key":
-			key = intern.InternString(e.Value.Bytes())
+			key = intern.UniqueStringFromBytes(e.Value.Bytes())
 
 		case "string":
-			c.strBuffer = append(c.strBuffer, unsafeToString(e.Value.Bytes()))
+			c.strBuffer = append(c.strBuffer, intern.UniqueBytes(e.Value.Bytes()))
 		case "int":
 			c.intBuffer = append(c.intBuffer, int(e.Value.Int64()))
 		case "float":
@@ -3597,7 +3598,7 @@ func (c *attributeCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 	switch {
 	// keep len == 1 cases first so we short-circuit early for non-array case
 	case len(c.strBuffer) == 1:
-		val = traceql.NewStaticString(c.strBuffer[0])
+		val = traceql.NewStaticStringFromHandle(c.strBuffer[0])
 	case len(c.intBuffer) == 1:
 		val = traceql.NewStaticInt(c.intBuffer[0])
 	case len(c.floatBuffer) == 1:
@@ -3605,7 +3606,7 @@ func (c *attributeCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 	case len(c.boolBuffer) == 1:
 		val = traceql.NewStaticBool(c.boolBuffer[0])
 	case len(c.strBuffer) > 1:
-		val = traceql.NewStaticStringArray(util.Clone(c.strBuffer))
+		val = traceql.NewStaticStringArrayFromHandles(util.Clone(c.strBuffer))
 	case len(c.intBuffer) > 1:
 		val = traceql.NewStaticIntArray(util.Clone(c.intBuffer))
 	case len(c.floatBuffer) > 1:
@@ -3684,7 +3685,7 @@ func (c *eventCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		case ColumnPathEventName:
 			ev.attrs = append(ev.attrs, attrVal{
 				a: traceql.IntrinsicEventNameAttribute,
-				s: traceql.NewStaticString(intern.InternString(e.Value.Bytes())),
+				s: traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.Bytes())),
 			})
 		case columnPathEventTimeSinceStart:
 			ev.attrs = append(ev.attrs, attrVal{
@@ -3833,13 +3834,6 @@ func orIfNeeded(preds []parquetquery.Predicate) parquetquery.Predicate {
 	}
 }
 
-// unsafeToString casts a byte slice to a string w/o allocating
-func unsafeToString(b []byte) string {
-	if len(b) == 0 {
-		return ""
-	}
-	return unsafe.String(unsafe.SliceData(b), len(b))
-}
 
 func otlpStatusToTraceqlStatus(v uint64) traceql.Status {
 	// Map OTLP status code back to TraceQL enum.

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -15,6 +15,7 @@ import (
 	"github.com/parquet-go/parquet-go"
 
 	"github.com/grafana/tempo/pkg/parquetquery"
+	"github.com/grafana/tempo/pkg/parquetquery/intern"
 	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	"github.com/grafana/tempo/pkg/traceql"
 	"github.com/grafana/tempo/pkg/util"
@@ -3166,11 +3167,11 @@ func (c *spanCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			sp.durationNanos = durationNanos
 			sp.addSpanAttr(traceql.IntrinsicDurationAttribute, traceql.NewStaticDuration(time.Duration(durationNanos)))
 		case ColumnPathSpanName:
-			sp.addSpanAttr(traceql.IntrinsicNameAttribute, traceql.NewStaticString(unsafeToString(kv.Value.Bytes())))
+			sp.addSpanAttr(traceql.IntrinsicNameAttribute, traceql.NewStaticString(intern.InternString(kv.Value.Bytes())))
 		case columnPathSpanStatusCode:
 			sp.addSpanAttr(traceql.IntrinsicStatusAttribute, traceql.NewStaticStatus(otlpStatusToTraceqlStatus(kv.Value.Uint64())))
 		case columnPathSpanStatusMessage:
-			sp.addSpanAttr(traceql.IntrinsicStatusMessageAttribute, traceql.NewStaticString(unsafeToString(kv.Value.Bytes())))
+			sp.addSpanAttr(traceql.IntrinsicStatusMessageAttribute, traceql.NewStaticString(intern.InternString(kv.Value.Bytes())))
 		case columnPathSpanKind:
 			sp.addSpanAttr(traceql.IntrinsicKindAttribute, traceql.NewStaticKind(otlpKindToTraceqlKind(kv.Value.Uint64())))
 		case columnPathSpanParentID:
@@ -3199,7 +3200,7 @@ func (c *spanCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			case parquet.Float:
 				sp.addSpanAttr(newSpanAttr(kv.Key), traceql.NewStaticFloat(kv.Value.Double()))
 			case parquet.ByteArray:
-				sp.addSpanAttr(newSpanAttr(kv.Key), traceql.NewStaticString(unsafeToString(kv.Value.Bytes())))
+				sp.addSpanAttr(newSpanAttr(kv.Key), traceql.NewStaticString(intern.InternString(kv.Value.Bytes())))
 			default:
 				// This is a null value, indicating the attribute doesn't exist
 				if kv.Value.IsNull() {
@@ -3268,12 +3269,12 @@ func (c *instrumentationCollector) KeepGroup(res *parquetquery.IteratorResult) b
 		case columnPathInstrumentationName:
 			c.instrumentationAttrs = append(c.instrumentationAttrs, attrVal{
 				a: traceql.IntrinsicInstrumentationNameAttribute,
-				s: traceql.NewStaticString(unsafeToString(kv.Value.Bytes())),
+				s: traceql.NewStaticString(intern.InternString(kv.Value.Bytes())),
 			})
 		case columnPathInstrumentationVersion:
 			c.instrumentationAttrs = append(c.instrumentationAttrs, attrVal{
 				a: traceql.IntrinsicInstrumentationVersionAttribute,
-				s: traceql.NewStaticString(unsafeToString(kv.Value.Bytes())),
+				s: traceql.NewStaticString(intern.InternString(kv.Value.Bytes())),
 			})
 		default:
 			// This is a null value, indicating the attribute doesn't exist
@@ -3361,7 +3362,7 @@ func (c *batchCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		case parquet.Int64:
 			c.resAttrs = append(c.resAttrs, attrVal{newResAttr(e.Key), traceql.NewStaticInt(int(e.Value.Int64()))})
 		case parquet.ByteArray:
-			c.resAttrs = append(c.resAttrs, attrVal{newResAttr(e.Key), traceql.NewStaticString(unsafeToString(e.Value.Bytes()))})
+			c.resAttrs = append(c.resAttrs, attrVal{newResAttr(e.Key), traceql.NewStaticString(intern.InternString(e.Value.Bytes()))})
 		default:
 			// This is a null value, indicating the attribute doesn't exist
 			if e.Value.IsNull() {
@@ -3462,10 +3463,10 @@ func (c *traceCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			finalSpanset.DurationNanos = e.Value.Uint64()
 			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceDurationAttribute, traceql.NewStaticDuration(time.Duration(finalSpanset.DurationNanos))})
 		case columnPathRootSpanName:
-			finalSpanset.RootSpanName = unsafeToString(e.Value.Bytes())
+			finalSpanset.RootSpanName = intern.InternString(e.Value.Bytes())
 			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootSpanAttribute, traceql.NewStaticString(finalSpanset.RootSpanName)})
 		case columnPathRootServiceName:
-			finalSpanset.RootServiceName = unsafeToString(e.Value.Bytes())
+			finalSpanset.RootServiceName = intern.InternString(e.Value.Bytes())
 			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootServiceAttribute, traceql.NewStaticString(finalSpanset.RootServiceName)})
 		}
 	}
@@ -3579,10 +3580,10 @@ func (c *attributeCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		}
 		switch e.Key {
 		case "key":
-			key = unsafeToString(e.Value.Bytes())
+			key = intern.InternString(e.Value.Bytes())
 
 		case "string":
-			c.strBuffer = append(c.strBuffer, unsafeToString(e.Value.Bytes()))
+			c.strBuffer = append(c.strBuffer, intern.InternString(e.Value.Bytes()))
 		case "int":
 			c.intBuffer = append(c.intBuffer, int(e.Value.Int64()))
 		case "float":
@@ -3683,7 +3684,7 @@ func (c *eventCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		case ColumnPathEventName:
 			ev.attrs = append(ev.attrs, attrVal{
 				a: traceql.IntrinsicEventNameAttribute,
-				s: traceql.NewStaticString(unsafeToString(e.Value.Bytes())),
+				s: traceql.NewStaticString(intern.InternString(e.Value.Bytes())),
 			})
 		case columnPathEventTimeSinceStart:
 			ev.attrs = append(ev.attrs, attrVal{

--- a/tempodb/encoding/vparquet4/block_traceql_meta_test.go
+++ b/tempodb/encoding/vparquet4/block_traceql_meta_test.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"testing"
 	"time"
+	"unique"
 
 	"github.com/grafana/tempo/pkg/parquetquery"
 	"github.com/grafana/tempo/pkg/traceql"
@@ -27,8 +28,8 @@ func TestBackendBlockSearchFetchMetaData(t *testing.T) {
 	makeSpanset := func(traceID []byte, rootSpanName, rootServiceName string, startTimeUnixNano, durationNanos uint64, spans ...traceql.Span) *traceql.Spanset {
 		return &traceql.Spanset{
 			TraceID:            traceID,
-			RootSpanName:       rootSpanName,
-			RootServiceName:    rootServiceName,
+			RootSpanName:       unique.Make(rootSpanName),
+			RootServiceName:    unique.Make(rootServiceName),
 			StartTimeUnixNanos: startTimeUnixNano,
 			DurationNanos:      durationNanos,
 			ServiceStats: map[string]traceql.ServiceStats{

--- a/tempodb/encoding/vparquet4/block_traceql_test.go
+++ b/tempodb/encoding/vparquet4/block_traceql_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"text/tabwriter"
 	"time"
+	"unique"
 
 	kitlog "github.com/go-kit/log"
 	"github.com/google/uuid"
@@ -1334,8 +1335,8 @@ func trimForSelectAll(tr *Trace) {
 func flattenForSelectAll(tr *Trace, dcm dedicatedColumnMapping) *traceql.Spanset {
 	var traceAttrs []attrVal
 	newSS := &traceql.Spanset{
-		RootServiceName: tr.RootServiceName,
-		RootSpanName:    tr.RootSpanName,
+		RootServiceName: unique.Make(tr.RootServiceName),
+		RootSpanName:    unique.Make(tr.RootSpanName),
 		TraceID:         tr.TraceID,
 		DurationNanos:   tr.DurationNano,
 	}

--- a/tempodb/encoding/vparquet5/block_autocomplete.go
+++ b/tempodb/encoding/vparquet5/block_autocomplete.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/grafana/tempo/pkg/parquetquery"
+	"github.com/grafana/tempo/pkg/parquetquery/intern"
 	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	"github.com/grafana/tempo/pkg/traceql"
 	"github.com/grafana/tempo/tempodb/backend"
@@ -1150,7 +1151,7 @@ func (d *distinctAttrCollector) KeepGroup(result *parquetquery.IteratorResult) b
 
 		if d.attrNames {
 			if e.Key == "key" {
-				name := unsafeToString(e.Value.ByteArray())
+				name := intern.InternString(e.Value.ByteArray())
 				key := tagNameKey{name: name, scope: d.scope}
 				if !d.existsTagName(key) {
 					result.AppendOtherValue(name, d.scope)
@@ -1224,7 +1225,7 @@ func (d distinctValueCollector) KeepGroup(result *parquetquery.IteratorResult) b
 func mapEventAttr(e entry) traceql.Static {
 	switch e.Key {
 	case ColumnPathEventName:
-		return traceql.NewStaticString(unsafeToString(e.Value.ByteArray()))
+		return traceql.NewStaticString(intern.InternString(e.Value.ByteArray()))
 	default:
 		// This exists for event-level dedicated columns
 		switch e.Value.Kind() {
@@ -1256,7 +1257,7 @@ func mapSpanAttr(e entry) traceql.Static {
 	case columnPathSpanDuration:
 		return traceql.NewStaticDuration(time.Duration(e.Value.Int64()))
 	case ColumnPathSpanName:
-		return traceql.NewStaticString(unsafeToString(e.Value.ByteArray()))
+		return traceql.NewStaticString(intern.InternString(e.Value.ByteArray()))
 	case columnPathSpanStatusCode:
 		// Map OTLP status code back to TraceQL enum.
 		// For other values, use the raw integer.
@@ -1273,7 +1274,7 @@ func mapSpanAttr(e entry) traceql.Static {
 		}
 		return traceql.NewStaticStatus(status)
 	case columnPathSpanStatusMessage:
-		return traceql.NewStaticString(unsafeToString(e.Value.ByteArray()))
+		return traceql.NewStaticString(intern.InternString(e.Value.ByteArray()))
 	case columnPathSpanKind:
 		var kind traceql.Kind
 		switch e.Value.Uint64() {
@@ -1312,7 +1313,7 @@ func mapSpanAttr(e entry) traceql.Static {
 func mapInstrumentationAttr(e entry) traceql.Static {
 	switch e.Key {
 	case columnPathInstrumentationName, columnPathInstrumentationVersion:
-		return traceql.NewStaticString(unsafeToString(e.Value.ByteArray()))
+		return traceql.NewStaticString(intern.InternString(e.Value.ByteArray()))
 	}
 	return traceql.Static{}
 }
@@ -1338,9 +1339,9 @@ func mapTraceAttr(e entry) traceql.Static {
 	case columnPathDurationNanos:
 		return traceql.NewStaticDuration(time.Duration(e.Value.Int64()))
 	case columnPathRootSpanName:
-		return traceql.NewStaticString(unsafeToString(e.Value.ByteArray()))
+		return traceql.NewStaticString(intern.InternString(e.Value.ByteArray()))
 	case columnPathRootServiceName:
-		return traceql.NewStaticString(unsafeToString(e.Value.ByteArray()))
+		return traceql.NewStaticString(intern.InternString(e.Value.ByteArray()))
 	}
 	return traceql.NewStaticNil()
 }

--- a/tempodb/encoding/vparquet5/block_autocomplete.go
+++ b/tempodb/encoding/vparquet5/block_autocomplete.go
@@ -1151,7 +1151,7 @@ func (d *distinctAttrCollector) KeepGroup(result *parquetquery.IteratorResult) b
 
 		if d.attrNames {
 			if e.Key == "key" {
-				name := intern.InternString(e.Value.ByteArray())
+				name := intern.UniqueStringFromBytes(e.Value.ByteArray())
 				key := tagNameKey{name: name, scope: d.scope}
 				if !d.existsTagName(key) {
 					result.AppendOtherValue(name, d.scope)
@@ -1160,7 +1160,7 @@ func (d *distinctAttrCollector) KeepGroup(result *parquetquery.IteratorResult) b
 		} else {
 			switch e.Key {
 			case "string":
-				val = traceql.NewStaticString(unsafeToString(e.Value.ByteArray()))
+				val = traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
 			case "int":
 				val = traceql.NewStaticInt(int(e.Value.Int64()))
 			case "float":
@@ -1225,7 +1225,7 @@ func (d distinctValueCollector) KeepGroup(result *parquetquery.IteratorResult) b
 func mapEventAttr(e entry) traceql.Static {
 	switch e.Key {
 	case ColumnPathEventName:
-		return traceql.NewStaticString(intern.InternString(e.Value.ByteArray()))
+		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
 	default:
 		// This exists for event-level dedicated columns
 		switch e.Value.Kind() {
@@ -1236,7 +1236,7 @@ func mapEventAttr(e entry) traceql.Static {
 		case parquet.Float:
 			return traceql.NewStaticFloat(e.Value.Double())
 		case parquet.ByteArray, parquet.FixedLenByteArray:
-			return traceql.NewStaticString(unsafeToString(e.Value.ByteArray()))
+			return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
 		}
 	}
 
@@ -1257,7 +1257,7 @@ func mapSpanAttr(e entry) traceql.Static {
 	case columnPathSpanDuration:
 		return traceql.NewStaticDuration(time.Duration(e.Value.Int64()))
 	case ColumnPathSpanName:
-		return traceql.NewStaticString(intern.InternString(e.Value.ByteArray()))
+		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
 	case columnPathSpanStatusCode:
 		// Map OTLP status code back to TraceQL enum.
 		// For other values, use the raw integer.
@@ -1274,7 +1274,7 @@ func mapSpanAttr(e entry) traceql.Static {
 		}
 		return traceql.NewStaticStatus(status)
 	case columnPathSpanStatusMessage:
-		return traceql.NewStaticString(intern.InternString(e.Value.ByteArray()))
+		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
 	case columnPathSpanKind:
 		var kind traceql.Kind
 		switch e.Value.Uint64() {
@@ -1304,7 +1304,7 @@ func mapSpanAttr(e entry) traceql.Static {
 		case parquet.Float:
 			return traceql.NewStaticFloat(e.Value.Double())
 		case parquet.ByteArray, parquet.FixedLenByteArray:
-			return traceql.NewStaticString(unsafeToString(e.Value.ByteArray()))
+			return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
 		}
 	}
 	return traceql.NewStaticNil()
@@ -1313,7 +1313,7 @@ func mapSpanAttr(e entry) traceql.Static {
 func mapInstrumentationAttr(e entry) traceql.Static {
 	switch e.Key {
 	case columnPathInstrumentationName, columnPathInstrumentationVersion:
-		return traceql.NewStaticString(intern.InternString(e.Value.ByteArray()))
+		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
 	}
 	return traceql.Static{}
 }
@@ -1327,7 +1327,7 @@ func mapResourceAttr(e entry) traceql.Static {
 	case parquet.Float:
 		return traceql.NewStaticFloat(e.Value.Double())
 	case parquet.ByteArray, parquet.FixedLenByteArray:
-		return traceql.NewStaticString(unsafeToString(e.Value.ByteArray()))
+		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
 	default:
 		return traceql.NewStaticNil()
 	}
@@ -1339,9 +1339,9 @@ func mapTraceAttr(e entry) traceql.Static {
 	case columnPathDurationNanos:
 		return traceql.NewStaticDuration(time.Duration(e.Value.Int64()))
 	case columnPathRootSpanName:
-		return traceql.NewStaticString(intern.InternString(e.Value.ByteArray()))
+		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
 	case columnPathRootServiceName:
-		return traceql.NewStaticString(intern.InternString(e.Value.ByteArray()))
+		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
 	}
 	return traceql.NewStaticNil()
 }

--- a/tempodb/encoding/vparquet5/block_autocomplete.go
+++ b/tempodb/encoding/vparquet5/block_autocomplete.go
@@ -1151,7 +1151,7 @@ func (d *distinctAttrCollector) KeepGroup(result *parquetquery.IteratorResult) b
 
 		if d.attrNames {
 			if e.Key == "key" {
-				name := intern.UniqueStringFromBytes(e.Value.ByteArray())
+				name := intern.UniqueBytes(e.Value.ByteArray()).Value()
 				key := tagNameKey{name: name, scope: d.scope}
 				if !d.existsTagName(key) {
 					result.AppendOtherValue(name, d.scope)

--- a/tempodb/encoding/vparquet5/block_autocomplete.go
+++ b/tempodb/encoding/vparquet5/block_autocomplete.go
@@ -1151,7 +1151,7 @@ func (d *distinctAttrCollector) KeepGroup(result *parquetquery.IteratorResult) b
 
 		if d.attrNames {
 			if e.Key == "key" {
-				name := intern.UniqueBytes(e.Value.ByteArray()).Value()
+				name := intern.UniqueStringFromBytes(e.Value.ByteArray()).Value()
 				key := tagNameKey{name: name, scope: d.scope}
 				if !d.existsTagName(key) {
 					result.AppendOtherValue(name, d.scope)
@@ -1160,7 +1160,7 @@ func (d *distinctAttrCollector) KeepGroup(result *parquetquery.IteratorResult) b
 		} else {
 			switch e.Key {
 			case "string":
-				val = traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
+				val = traceql.NewStaticUniqueStringFromBytes(e.Value.ByteArray())
 			case "int":
 				val = traceql.NewStaticInt(int(e.Value.Int64()))
 			case "float":
@@ -1225,7 +1225,7 @@ func (d distinctValueCollector) KeepGroup(result *parquetquery.IteratorResult) b
 func mapEventAttr(e entry) traceql.Static {
 	switch e.Key {
 	case ColumnPathEventName:
-		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
+		return traceql.NewStaticUniqueStringFromBytes(e.Value.ByteArray())
 	default:
 		// This exists for event-level dedicated columns
 		switch e.Value.Kind() {
@@ -1236,7 +1236,7 @@ func mapEventAttr(e entry) traceql.Static {
 		case parquet.Float:
 			return traceql.NewStaticFloat(e.Value.Double())
 		case parquet.ByteArray, parquet.FixedLenByteArray:
-			return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
+			return traceql.NewStaticUniqueStringFromBytes(e.Value.ByteArray())
 		}
 	}
 
@@ -1257,7 +1257,7 @@ func mapSpanAttr(e entry) traceql.Static {
 	case columnPathSpanDuration:
 		return traceql.NewStaticDuration(time.Duration(e.Value.Int64()))
 	case ColumnPathSpanName:
-		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
+		return traceql.NewStaticUniqueStringFromBytes(e.Value.ByteArray())
 	case columnPathSpanStatusCode:
 		// Map OTLP status code back to TraceQL enum.
 		// For other values, use the raw integer.
@@ -1274,7 +1274,7 @@ func mapSpanAttr(e entry) traceql.Static {
 		}
 		return traceql.NewStaticStatus(status)
 	case columnPathSpanStatusMessage:
-		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
+		return traceql.NewStaticUniqueStringFromBytes(e.Value.ByteArray())
 	case columnPathSpanKind:
 		var kind traceql.Kind
 		switch e.Value.Uint64() {
@@ -1304,7 +1304,7 @@ func mapSpanAttr(e entry) traceql.Static {
 		case parquet.Float:
 			return traceql.NewStaticFloat(e.Value.Double())
 		case parquet.ByteArray, parquet.FixedLenByteArray:
-			return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
+			return traceql.NewStaticUniqueStringFromBytes(e.Value.ByteArray())
 		}
 	}
 	return traceql.NewStaticNil()
@@ -1313,7 +1313,7 @@ func mapSpanAttr(e entry) traceql.Static {
 func mapInstrumentationAttr(e entry) traceql.Static {
 	switch e.Key {
 	case columnPathInstrumentationName, columnPathInstrumentationVersion:
-		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
+		return traceql.NewStaticUniqueStringFromBytes(e.Value.ByteArray())
 	}
 	return traceql.Static{}
 }
@@ -1327,7 +1327,7 @@ func mapResourceAttr(e entry) traceql.Static {
 	case parquet.Float:
 		return traceql.NewStaticFloat(e.Value.Double())
 	case parquet.ByteArray, parquet.FixedLenByteArray:
-		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
+		return traceql.NewStaticUniqueStringFromBytes(e.Value.ByteArray())
 	default:
 		return traceql.NewStaticNil()
 	}
@@ -1339,9 +1339,9 @@ func mapTraceAttr(e entry) traceql.Static {
 	case columnPathDurationNanos:
 		return traceql.NewStaticDuration(time.Duration(e.Value.Int64()))
 	case columnPathRootSpanName:
-		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
+		return traceql.NewStaticUniqueStringFromBytes(e.Value.ByteArray())
 	case columnPathRootServiceName:
-		return traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.ByteArray()))
+		return traceql.NewStaticUniqueStringFromBytes(e.Value.ByteArray())
 	}
 	return traceql.NewStaticNil()
 }

--- a/tempodb/encoding/vparquet5/block_traceql.go
+++ b/tempodb/encoding/vparquet5/block_traceql.go
@@ -15,6 +15,7 @@ import (
 	"github.com/parquet-go/parquet-go"
 
 	"github.com/grafana/tempo/pkg/parquetquery"
+	"github.com/grafana/tempo/pkg/parquetquery/intern"
 	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	"github.com/grafana/tempo/pkg/traceql"
 	"github.com/grafana/tempo/pkg/util"
@@ -3255,11 +3256,11 @@ func (c *spanCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			sp.durationNanos = durationNanos
 			sp.addSpanAttr(traceql.IntrinsicDurationAttribute, traceql.NewStaticDuration(time.Duration(durationNanos)))
 		case ColumnPathSpanName:
-			sp.addSpanAttr(traceql.IntrinsicNameAttribute, traceql.NewStaticString(unsafeToString(kv.Value.Bytes())))
+			sp.addSpanAttr(traceql.IntrinsicNameAttribute, traceql.NewStaticString(intern.InternString(kv.Value.Bytes())))
 		case columnPathSpanStatusCode:
 			sp.addSpanAttr(traceql.IntrinsicStatusAttribute, traceql.NewStaticStatus(otlpStatusToTraceqlStatus(kv.Value.Uint64())))
 		case columnPathSpanStatusMessage:
-			sp.addSpanAttr(traceql.IntrinsicStatusMessageAttribute, traceql.NewStaticString(unsafeToString(kv.Value.Bytes())))
+			sp.addSpanAttr(traceql.IntrinsicStatusMessageAttribute, traceql.NewStaticString(intern.InternString(kv.Value.Bytes())))
 		case columnPathSpanKind:
 			sp.addSpanAttr(traceql.IntrinsicKindAttribute, traceql.NewStaticKind(otlpKindToTraceqlKind(kv.Value.Uint64())))
 		case columnPathSpanParentID:
@@ -3290,7 +3291,7 @@ func (c *spanCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			case parquet.Float:
 				sp.addSpanAttr(newSpanAttr(kv.Key), traceql.NewStaticFloat(kv.Value.Double()))
 			case parquet.ByteArray:
-				sp.addSpanAttr(newSpanAttr(kv.Key), traceql.NewStaticString(unsafeToString(kv.Value.Bytes())))
+				sp.addSpanAttr(newSpanAttr(kv.Key), traceql.NewStaticString(intern.InternString(kv.Value.Bytes())))
 			default:
 				// This is a null value, indicating the attribute doesn't exist
 				if kv.Value.IsNull() {
@@ -3359,12 +3360,12 @@ func (c *instrumentationCollector) KeepGroup(res *parquetquery.IteratorResult) b
 		case columnPathInstrumentationName:
 			c.instrumentationAttrs = append(c.instrumentationAttrs, attrVal{
 				a: traceql.IntrinsicInstrumentationNameAttribute,
-				s: traceql.NewStaticString(unsafeToString(kv.Value.Bytes())),
+				s: traceql.NewStaticString(intern.InternString(kv.Value.Bytes())),
 			})
 		case columnPathInstrumentationVersion:
 			c.instrumentationAttrs = append(c.instrumentationAttrs, attrVal{
 				a: traceql.IntrinsicInstrumentationVersionAttribute,
-				s: traceql.NewStaticString(unsafeToString(kv.Value.Bytes())),
+				s: traceql.NewStaticString(intern.InternString(kv.Value.Bytes())),
 			})
 		default:
 			// This is a null value, indicating the attribute doesn't exist
@@ -3452,7 +3453,7 @@ func (c *batchCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		case parquet.Int64:
 			c.resAttrs = append(c.resAttrs, attrVal{newResAttr(e.Key), traceql.NewStaticInt(int(e.Value.Int64()))})
 		case parquet.ByteArray:
-			c.resAttrs = append(c.resAttrs, attrVal{newResAttr(e.Key), traceql.NewStaticString(unsafeToString(e.Value.Bytes()))})
+			c.resAttrs = append(c.resAttrs, attrVal{newResAttr(e.Key), traceql.NewStaticString(intern.InternString(e.Value.Bytes()))})
 		default:
 			// This is a null value, indicating the attribute doesn't exist
 			if e.Value.IsNull() {
@@ -3553,10 +3554,10 @@ func (c *traceCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			finalSpanset.DurationNanos = e.Value.Uint64()
 			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceDurationAttribute, traceql.NewStaticDuration(time.Duration(finalSpanset.DurationNanos))})
 		case columnPathRootSpanName:
-			finalSpanset.RootSpanName = unsafeToString(e.Value.Bytes())
+			finalSpanset.RootSpanName = intern.InternString(e.Value.Bytes())
 			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootSpanAttribute, traceql.NewStaticString(finalSpanset.RootSpanName)})
 		case columnPathRootServiceName:
-			finalSpanset.RootServiceName = unsafeToString(e.Value.Bytes())
+			finalSpanset.RootServiceName = intern.InternString(e.Value.Bytes())
 			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootServiceAttribute, traceql.NewStaticString(finalSpanset.RootServiceName)})
 		}
 	}
@@ -3670,10 +3671,10 @@ func (c *attributeCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		}
 		switch e.Key {
 		case "key":
-			key = unsafeToString(e.Value.Bytes())
+			key = intern.InternString(e.Value.Bytes())
 
 		case "string":
-			c.strBuffer = append(c.strBuffer, unsafeToString(e.Value.Bytes()))
+			c.strBuffer = append(c.strBuffer, intern.InternString(e.Value.Bytes()))
 		case "int":
 			c.intBuffer = append(c.intBuffer, int(e.Value.Int64()))
 		case "float":
@@ -3774,7 +3775,7 @@ func (c *eventCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		case ColumnPathEventName:
 			ev.attrs = append(ev.attrs, attrVal{
 				a: traceql.IntrinsicEventNameAttribute,
-				s: traceql.NewStaticString(unsafeToString(e.Value.Bytes())),
+				s: traceql.NewStaticString(intern.InternString(e.Value.Bytes())),
 			})
 		case columnPathEventTimeSinceStart:
 			ev.attrs = append(ev.attrs, attrVal{
@@ -3792,7 +3793,7 @@ func (c *eventCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			case parquet.Float:
 				ev.attrs = append(ev.attrs, attrVal{a: newEventAttr(e.Key), s: traceql.NewStaticFloat(e.Value.Double())})
 			case parquet.ByteArray:
-				ev.attrs = append(ev.attrs, attrVal{a: newEventAttr(e.Key), s: traceql.NewStaticString(unsafeToString(e.Value.Bytes()))})
+				ev.attrs = append(ev.attrs, attrVal{a: newEventAttr(e.Key), s: traceql.NewStaticString(intern.InternString(e.Value.Bytes()))})
 			default:
 				// null value indicates attribute doesn't exist
 				if e.Value.IsNull() {

--- a/tempodb/encoding/vparquet5/block_traceql.go
+++ b/tempodb/encoding/vparquet5/block_traceql.go
@@ -3291,7 +3291,7 @@ func (c *spanCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			case parquet.Float:
 				sp.addSpanAttr(newSpanAttr(kv.Key), traceql.NewStaticFloat(kv.Value.Double()))
 			case parquet.ByteArray:
-				sp.addSpanAttr(newSpanAttr(kv.Key), traceql.NewStaticString(intern.InternString(kv.Value.Bytes())))
+				sp.addSpanAttr(newSpanAttr(kv.Key), traceql.NewStaticString(unsafeToString(kv.Value.Bytes())))
 			default:
 				// This is a null value, indicating the attribute doesn't exist
 				if kv.Value.IsNull() {
@@ -3453,7 +3453,7 @@ func (c *batchCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		case parquet.Int64:
 			c.resAttrs = append(c.resAttrs, attrVal{newResAttr(e.Key), traceql.NewStaticInt(int(e.Value.Int64()))})
 		case parquet.ByteArray:
-			c.resAttrs = append(c.resAttrs, attrVal{newResAttr(e.Key), traceql.NewStaticString(intern.InternString(e.Value.Bytes()))})
+			c.resAttrs = append(c.resAttrs, attrVal{newResAttr(e.Key), traceql.NewStaticString(unsafeToString(e.Value.Bytes()))})
 		default:
 			// This is a null value, indicating the attribute doesn't exist
 			if e.Value.IsNull() {
@@ -3674,7 +3674,7 @@ func (c *attributeCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			key = intern.InternString(e.Value.Bytes())
 
 		case "string":
-			c.strBuffer = append(c.strBuffer, intern.InternString(e.Value.Bytes()))
+			c.strBuffer = append(c.strBuffer, unsafeToString(e.Value.Bytes()))
 		case "int":
 			c.intBuffer = append(c.intBuffer, int(e.Value.Int64()))
 		case "float":
@@ -3793,7 +3793,7 @@ func (c *eventCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			case parquet.Float:
 				ev.attrs = append(ev.attrs, attrVal{a: newEventAttr(e.Key), s: traceql.NewStaticFloat(e.Value.Double())})
 			case parquet.ByteArray:
-				ev.attrs = append(ev.attrs, attrVal{a: newEventAttr(e.Key), s: traceql.NewStaticString(intern.InternString(e.Value.Bytes()))})
+				ev.attrs = append(ev.attrs, attrVal{a: newEventAttr(e.Key), s: traceql.NewStaticString(unsafeToString(e.Value.Bytes()))})
 			default:
 				// null value indicates attribute doesn't exist
 				if e.Value.IsNull() {

--- a/tempodb/encoding/vparquet5/block_traceql.go
+++ b/tempodb/encoding/vparquet5/block_traceql.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"sync"
 	"time"
+	"unique"
 	"unsafe"
 
 	"github.com/parquet-go/parquet-go"
@@ -3256,11 +3257,11 @@ func (c *spanCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			sp.durationNanos = durationNanos
 			sp.addSpanAttr(traceql.IntrinsicDurationAttribute, traceql.NewStaticDuration(time.Duration(durationNanos)))
 		case ColumnPathSpanName:
-			sp.addSpanAttr(traceql.IntrinsicNameAttribute, traceql.NewStaticString(intern.InternString(kv.Value.Bytes())))
+			sp.addSpanAttr(traceql.IntrinsicNameAttribute, traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())))
 		case columnPathSpanStatusCode:
 			sp.addSpanAttr(traceql.IntrinsicStatusAttribute, traceql.NewStaticStatus(otlpStatusToTraceqlStatus(kv.Value.Uint64())))
 		case columnPathSpanStatusMessage:
-			sp.addSpanAttr(traceql.IntrinsicStatusMessageAttribute, traceql.NewStaticString(intern.InternString(kv.Value.Bytes())))
+			sp.addSpanAttr(traceql.IntrinsicStatusMessageAttribute, traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())))
 		case columnPathSpanKind:
 			sp.addSpanAttr(traceql.IntrinsicKindAttribute, traceql.NewStaticKind(otlpKindToTraceqlKind(kv.Value.Uint64())))
 		case columnPathSpanParentID:
@@ -3291,7 +3292,7 @@ func (c *spanCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			case parquet.Float:
 				sp.addSpanAttr(newSpanAttr(kv.Key), traceql.NewStaticFloat(kv.Value.Double()))
 			case parquet.ByteArray:
-				sp.addSpanAttr(newSpanAttr(kv.Key), traceql.NewStaticString(unsafeToString(kv.Value.Bytes())))
+				sp.addSpanAttr(newSpanAttr(kv.Key), traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())))
 			default:
 				// This is a null value, indicating the attribute doesn't exist
 				if kv.Value.IsNull() {
@@ -3360,12 +3361,12 @@ func (c *instrumentationCollector) KeepGroup(res *parquetquery.IteratorResult) b
 		case columnPathInstrumentationName:
 			c.instrumentationAttrs = append(c.instrumentationAttrs, attrVal{
 				a: traceql.IntrinsicInstrumentationNameAttribute,
-				s: traceql.NewStaticString(intern.InternString(kv.Value.Bytes())),
+				s: traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())),
 			})
 		case columnPathInstrumentationVersion:
 			c.instrumentationAttrs = append(c.instrumentationAttrs, attrVal{
 				a: traceql.IntrinsicInstrumentationVersionAttribute,
-				s: traceql.NewStaticString(intern.InternString(kv.Value.Bytes())),
+				s: traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())),
 			})
 		default:
 			// This is a null value, indicating the attribute doesn't exist
@@ -3453,7 +3454,7 @@ func (c *batchCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		case parquet.Int64:
 			c.resAttrs = append(c.resAttrs, attrVal{newResAttr(e.Key), traceql.NewStaticInt(int(e.Value.Int64()))})
 		case parquet.ByteArray:
-			c.resAttrs = append(c.resAttrs, attrVal{newResAttr(e.Key), traceql.NewStaticString(unsafeToString(e.Value.Bytes()))})
+			c.resAttrs = append(c.resAttrs, attrVal{newResAttr(e.Key), traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.Bytes()))})
 		default:
 			// This is a null value, indicating the attribute doesn't exist
 			if e.Value.IsNull() {
@@ -3554,10 +3555,10 @@ func (c *traceCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			finalSpanset.DurationNanos = e.Value.Uint64()
 			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceDurationAttribute, traceql.NewStaticDuration(time.Duration(finalSpanset.DurationNanos))})
 		case columnPathRootSpanName:
-			finalSpanset.RootSpanName = intern.InternString(e.Value.Bytes())
+			finalSpanset.RootSpanName = intern.UniqueStringFromBytes(e.Value.Bytes())
 			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootSpanAttribute, traceql.NewStaticString(finalSpanset.RootSpanName)})
 		case columnPathRootServiceName:
-			finalSpanset.RootServiceName = intern.InternString(e.Value.Bytes())
+			finalSpanset.RootServiceName = intern.UniqueStringFromBytes(e.Value.Bytes())
 			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootServiceAttribute, traceql.NewStaticString(finalSpanset.RootServiceName)})
 		}
 	}
@@ -3641,7 +3642,7 @@ func (c *serviceStatsCollector) KeepGroup(res *parquetquery.IteratorResult) bool
 // columns and joins them together into map[key]value entries with the
 // right type.
 type attributeCollector struct {
-	strBuffer   []string
+	strBuffer   []unique.Handle[string]
 	intBuffer   []int
 	floatBuffer []float64
 	boolBuffer  []bool
@@ -3671,10 +3672,10 @@ func (c *attributeCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		}
 		switch e.Key {
 		case "key":
-			key = intern.InternString(e.Value.Bytes())
+			key = intern.UniqueStringFromBytes(e.Value.Bytes())
 
 		case "string":
-			c.strBuffer = append(c.strBuffer, unsafeToString(e.Value.Bytes()))
+			c.strBuffer = append(c.strBuffer, intern.UniqueBytes(e.Value.Bytes()))
 		case "int":
 			c.intBuffer = append(c.intBuffer, int(e.Value.Int64()))
 		case "float":
@@ -3688,7 +3689,7 @@ func (c *attributeCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 	switch {
 	// keep len == 1 cases first so we short-circuit early for non-array case
 	case len(c.strBuffer) == 1:
-		val = traceql.NewStaticString(c.strBuffer[0])
+		val = traceql.NewStaticStringFromHandle(c.strBuffer[0])
 	case len(c.intBuffer) == 1:
 		val = traceql.NewStaticInt(c.intBuffer[0])
 	case len(c.floatBuffer) == 1:
@@ -3696,7 +3697,7 @@ func (c *attributeCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 	case len(c.boolBuffer) == 1:
 		val = traceql.NewStaticBool(c.boolBuffer[0])
 	case len(c.strBuffer) > 1:
-		val = traceql.NewStaticStringArray(util.Clone(c.strBuffer))
+		val = traceql.NewStaticStringArrayFromHandles(util.Clone(c.strBuffer))
 	case len(c.intBuffer) > 1:
 		val = traceql.NewStaticIntArray(util.Clone(c.intBuffer))
 	case len(c.floatBuffer) > 1:
@@ -3775,7 +3776,7 @@ func (c *eventCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		case ColumnPathEventName:
 			ev.attrs = append(ev.attrs, attrVal{
 				a: traceql.IntrinsicEventNameAttribute,
-				s: traceql.NewStaticString(intern.InternString(e.Value.Bytes())),
+				s: traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.Bytes())),
 			})
 		case columnPathEventTimeSinceStart:
 			ev.attrs = append(ev.attrs, attrVal{
@@ -3793,7 +3794,7 @@ func (c *eventCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			case parquet.Float:
 				ev.attrs = append(ev.attrs, attrVal{a: newEventAttr(e.Key), s: traceql.NewStaticFloat(e.Value.Double())})
 			case parquet.ByteArray:
-				ev.attrs = append(ev.attrs, attrVal{a: newEventAttr(e.Key), s: traceql.NewStaticString(unsafeToString(e.Value.Bytes()))})
+				ev.attrs = append(ev.attrs, attrVal{a: newEventAttr(e.Key), s: traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.Bytes()))})
 			default:
 				// null value indicates attribute doesn't exist
 				if e.Value.IsNull() {

--- a/tempodb/encoding/vparquet5/block_traceql.go
+++ b/tempodb/encoding/vparquet5/block_traceql.go
@@ -954,8 +954,8 @@ func getSpanset() *traceql.Spanset {
 func putSpanset(ss *traceql.Spanset) {
 	ss.Attributes = ss.Attributes[:0]
 	ss.DurationNanos = 0
-	ss.RootServiceName = ""
-	ss.RootSpanName = ""
+	ss.RootServiceName = unique.Handle[string]{}
+	ss.RootSpanName = unique.Handle[string]{}
 	ss.Scalar = traceql.NewStaticNil()
 	ss.StartTimeUnixNanos = 0
 	ss.TraceID = nil
@@ -1414,10 +1414,10 @@ func (i *rebatchIterator) Next() (*parquetquery.IteratorResult, error) {
 			if len(sp.cbSpanset.TraceID) == 0 {
 				sp.cbSpanset.TraceID = ss.TraceID
 			}
-			if len(sp.cbSpanset.RootSpanName) == 0 {
+			if sp.cbSpanset.RootSpanName == (unique.Handle[string]{}) {
 				sp.cbSpanset.RootSpanName = ss.RootSpanName
 			}
-			if len(sp.cbSpanset.RootServiceName) == 0 {
+			if sp.cbSpanset.RootServiceName == (unique.Handle[string]{}) {
 				sp.cbSpanset.RootServiceName = ss.RootServiceName
 			}
 			if sp.cbSpanset.StartTimeUnixNanos == 0 {
@@ -3555,11 +3555,11 @@ func (c *traceCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			finalSpanset.DurationNanos = e.Value.Uint64()
 			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceDurationAttribute, traceql.NewStaticDuration(time.Duration(finalSpanset.DurationNanos))})
 		case columnPathRootSpanName:
-			finalSpanset.RootSpanName = intern.UniqueStringFromBytes(e.Value.Bytes())
-			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootSpanAttribute, traceql.NewStaticString(finalSpanset.RootSpanName)})
+			finalSpanset.RootSpanName = intern.UniqueBytes(e.Value.Bytes())
+			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootSpanAttribute, traceql.NewStaticStringFromHandle(finalSpanset.RootSpanName)})
 		case columnPathRootServiceName:
-			finalSpanset.RootServiceName = intern.UniqueStringFromBytes(e.Value.Bytes())
-			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootServiceAttribute, traceql.NewStaticString(finalSpanset.RootServiceName)})
+			finalSpanset.RootServiceName = intern.UniqueBytes(e.Value.Bytes())
+			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootServiceAttribute, traceql.NewStaticStringFromHandle(finalSpanset.RootServiceName)})
 		}
 	}
 
@@ -3672,7 +3672,7 @@ func (c *attributeCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		}
 		switch e.Key {
 		case "key":
-			key = intern.UniqueStringFromBytes(e.Value.Bytes())
+			key = intern.UniqueBytes(e.Value.Bytes()).Value()
 
 		case "string":
 			c.strBuffer = append(c.strBuffer, intern.UniqueBytes(e.Value.Bytes()))

--- a/tempodb/encoding/vparquet5/block_traceql.go
+++ b/tempodb/encoding/vparquet5/block_traceql.go
@@ -3257,11 +3257,11 @@ func (c *spanCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			sp.durationNanos = durationNanos
 			sp.addSpanAttr(traceql.IntrinsicDurationAttribute, traceql.NewStaticDuration(time.Duration(durationNanos)))
 		case ColumnPathSpanName:
-			sp.addSpanAttr(traceql.IntrinsicNameAttribute, traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())))
+			sp.addSpanAttr(traceql.IntrinsicNameAttribute, traceql.NewStaticUniqueStringFromBytes(kv.Value.Bytes()))
 		case columnPathSpanStatusCode:
 			sp.addSpanAttr(traceql.IntrinsicStatusAttribute, traceql.NewStaticStatus(otlpStatusToTraceqlStatus(kv.Value.Uint64())))
 		case columnPathSpanStatusMessage:
-			sp.addSpanAttr(traceql.IntrinsicStatusMessageAttribute, traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())))
+			sp.addSpanAttr(traceql.IntrinsicStatusMessageAttribute, traceql.NewStaticUniqueStringFromBytes(kv.Value.Bytes()))
 		case columnPathSpanKind:
 			sp.addSpanAttr(traceql.IntrinsicKindAttribute, traceql.NewStaticKind(otlpKindToTraceqlKind(kv.Value.Uint64())))
 		case columnPathSpanParentID:
@@ -3292,7 +3292,7 @@ func (c *spanCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			case parquet.Float:
 				sp.addSpanAttr(newSpanAttr(kv.Key), traceql.NewStaticFloat(kv.Value.Double()))
 			case parquet.ByteArray:
-				sp.addSpanAttr(newSpanAttr(kv.Key), traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())))
+				sp.addSpanAttr(newSpanAttr(kv.Key), traceql.NewStaticUniqueStringFromBytes(kv.Value.Bytes()))
 			default:
 				// This is a null value, indicating the attribute doesn't exist
 				if kv.Value.IsNull() {
@@ -3361,12 +3361,12 @@ func (c *instrumentationCollector) KeepGroup(res *parquetquery.IteratorResult) b
 		case columnPathInstrumentationName:
 			c.instrumentationAttrs = append(c.instrumentationAttrs, attrVal{
 				a: traceql.IntrinsicInstrumentationNameAttribute,
-				s: traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())),
+				s: traceql.NewStaticUniqueStringFromBytes(kv.Value.Bytes()),
 			})
 		case columnPathInstrumentationVersion:
 			c.instrumentationAttrs = append(c.instrumentationAttrs, attrVal{
 				a: traceql.IntrinsicInstrumentationVersionAttribute,
-				s: traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())),
+				s: traceql.NewStaticUniqueStringFromBytes(kv.Value.Bytes()),
 			})
 		default:
 			// This is a null value, indicating the attribute doesn't exist
@@ -3454,7 +3454,7 @@ func (c *batchCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		case parquet.Int64:
 			c.resAttrs = append(c.resAttrs, attrVal{newResAttr(e.Key), traceql.NewStaticInt(int(e.Value.Int64()))})
 		case parquet.ByteArray:
-			c.resAttrs = append(c.resAttrs, attrVal{newResAttr(e.Key), traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.Bytes()))})
+			c.resAttrs = append(c.resAttrs, attrVal{newResAttr(e.Key), traceql.NewStaticUniqueStringFromBytes(e.Value.Bytes())})
 		default:
 			// This is a null value, indicating the attribute doesn't exist
 			if e.Value.IsNull() {
@@ -3555,10 +3555,10 @@ func (c *traceCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			finalSpanset.DurationNanos = e.Value.Uint64()
 			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceDurationAttribute, traceql.NewStaticDuration(time.Duration(finalSpanset.DurationNanos))})
 		case columnPathRootSpanName:
-			finalSpanset.RootSpanName = intern.UniqueBytes(e.Value.Bytes())
+			finalSpanset.RootSpanName = intern.UniqueStringFromBytes(e.Value.Bytes())
 			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootSpanAttribute, traceql.NewStaticStringFromHandle(finalSpanset.RootSpanName)})
 		case columnPathRootServiceName:
-			finalSpanset.RootServiceName = intern.UniqueBytes(e.Value.Bytes())
+			finalSpanset.RootServiceName = intern.UniqueStringFromBytes(e.Value.Bytes())
 			c.traceAttrs = append(c.traceAttrs, attrVal{traceql.IntrinsicTraceRootServiceAttribute, traceql.NewStaticStringFromHandle(finalSpanset.RootServiceName)})
 		}
 	}
@@ -3672,10 +3672,10 @@ func (c *attributeCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		}
 		switch e.Key {
 		case "key":
-			key = intern.UniqueBytes(e.Value.Bytes()).Value()
+			key = intern.UniqueStringFromBytes(e.Value.Bytes()).Value()
 
 		case "string":
-			c.strBuffer = append(c.strBuffer, intern.UniqueBytes(e.Value.Bytes()))
+			c.strBuffer = append(c.strBuffer, intern.UniqueStringFromBytes(e.Value.Bytes()))
 		case "int":
 			c.intBuffer = append(c.intBuffer, int(e.Value.Int64()))
 		case "float":
@@ -3776,7 +3776,7 @@ func (c *eventCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		case ColumnPathEventName:
 			ev.attrs = append(ev.attrs, attrVal{
 				a: traceql.IntrinsicEventNameAttribute,
-				s: traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.Bytes())),
+				s: traceql.NewStaticUniqueStringFromBytes(e.Value.Bytes()),
 			})
 		case columnPathEventTimeSinceStart:
 			ev.attrs = append(ev.attrs, attrVal{
@@ -3794,7 +3794,7 @@ func (c *eventCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			case parquet.Float:
 				ev.attrs = append(ev.attrs, attrVal{a: newEventAttr(e.Key), s: traceql.NewStaticFloat(e.Value.Double())})
 			case parquet.ByteArray:
-				ev.attrs = append(ev.attrs, attrVal{a: newEventAttr(e.Key), s: traceql.NewStaticStringFromHandle(intern.UniqueBytes(e.Value.Bytes()))})
+				ev.attrs = append(ev.attrs, attrVal{a: newEventAttr(e.Key), s: traceql.NewStaticUniqueStringFromBytes(e.Value.Bytes())})
 			default:
 				// null value indicates attribute doesn't exist
 				if e.Value.IsNull() {

--- a/tempodb/encoding/vparquet5/block_traceql_fetch.go
+++ b/tempodb/encoding/vparquet5/block_traceql_fetch.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"time"
+	"unique"
 
 	"github.com/grafana/tempo/pkg/parquetquery"
 	"github.com/grafana/tempo/pkg/parquetquery/intern"
@@ -998,7 +999,7 @@ type scopedAttributeCollector struct {
 	atRes parquetquery.IteratorResult
 	at    attrVal
 
-	strBuffer   []string
+	strBuffer   []unique.Handle[string]
 	intBuffer   []int
 	floatBuffer []float64
 	boolBuffer  []bool
@@ -1034,9 +1035,9 @@ func (c *scopedAttributeCollector) Collect(res *parquetquery.IteratorResult, _ a
 		}
 		switch e.Key {
 		case "key":
-			c.at.a.Name = intern.InternString(e.Value.Bytes())
+			c.at.a.Name = unsafeToString(e.Value.Bytes())
 		case "string":
-			c.strBuffer = append(c.strBuffer, unsafeToString(e.Value.Bytes()))
+			c.strBuffer = append(c.strBuffer, intern.UniqueBytes(e.Value.Bytes()))
 		case "int":
 			c.intBuffer = append(c.intBuffer, int(e.Value.Int64()))
 		case "float":
@@ -1052,7 +1053,7 @@ func (c *scopedAttributeCollector) Result() *parquetquery.IteratorResult {
 	switch {
 	// keep len == 1 cases first so we short-circuit early for non-array case
 	case len(c.strBuffer) == 1:
-		c.at.s = traceql.NewStaticString(c.strBuffer[0])
+		c.at.s = traceql.NewStaticStringFromHandle(c.strBuffer[0])
 	case len(c.intBuffer) == 1:
 		c.at.s = traceql.NewStaticInt(c.intBuffer[0])
 	case len(c.floatBuffer) == 1:
@@ -1060,7 +1061,7 @@ func (c *scopedAttributeCollector) Result() *parquetquery.IteratorResult {
 	case len(c.boolBuffer) == 1:
 		c.at.s = traceql.NewStaticBool(c.boolBuffer[0])
 	case len(c.strBuffer) > 1:
-		c.at.s = traceql.NewStaticStringArray(util.Clone(c.strBuffer))
+		c.at.s = traceql.NewStaticStringArrayFromHandles(util.Clone(c.strBuffer))
 	case len(c.intBuffer) > 1:
 		c.at.s = traceql.NewStaticIntArray(c.intBuffer)
 	case len(c.floatBuffer) > 1:
@@ -1337,9 +1338,9 @@ func (c *spanCollector2) Collect(res *parquetquery.IteratorResult, param any) {
 		// Trace-level columns:
 		// --------------------
 		case columnPathRootSpanName:
-			sp.traceAttrs = append(sp.traceAttrs, attrVal{traceql.IntrinsicTraceRootSpanAttribute, traceql.NewStaticString(intern.InternString(kv.Value.Bytes()))})
+			sp.traceAttrs = append(sp.traceAttrs, attrVal{traceql.IntrinsicTraceRootSpanAttribute, traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes()))})
 		case columnPathRootServiceName:
-			sp.traceAttrs = append(sp.traceAttrs, attrVal{traceql.IntrinsicTraceRootServiceAttribute, traceql.NewStaticString(intern.InternString(kv.Value.Bytes()))})
+			sp.traceAttrs = append(sp.traceAttrs, attrVal{traceql.IntrinsicTraceRootServiceAttribute, traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes()))})
 		case columnPathTraceID:
 			sp.traceAttrs = append(sp.traceAttrs, attrVal{traceql.IntrinsicTraceIDAttribute, traceql.NewStaticString(util.TraceIDToHexString(kv.Value.ByteArray()))})
 		case columnPathDurationNanos:
@@ -1372,11 +1373,11 @@ func (c *spanCollector2) Collect(res *parquetquery.IteratorResult, param any) {
 			sp.durationNanos = durationNanos
 			sp.addSpanAttr(traceql.IntrinsicDurationAttribute, traceql.NewStaticDuration(time.Duration(durationNanos)))
 		case ColumnPathSpanName:
-			sp.addSpanAttr(traceql.IntrinsicNameAttribute, traceql.NewStaticString(intern.InternString(kv.Value.Bytes())))
+			sp.addSpanAttr(traceql.IntrinsicNameAttribute, traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())))
 		case columnPathSpanStatusCode:
 			sp.addSpanAttr(traceql.IntrinsicStatusAttribute, traceql.NewStaticStatus(otlpStatusToTraceqlStatus(kv.Value.Uint64())))
 		case columnPathSpanStatusMessage:
-			sp.addSpanAttr(traceql.IntrinsicStatusMessageAttribute, traceql.NewStaticString(intern.InternString(kv.Value.Bytes())))
+			sp.addSpanAttr(traceql.IntrinsicStatusMessageAttribute, traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())))
 		case columnPathSpanKind:
 			sp.addSpanAttr(traceql.IntrinsicKindAttribute, traceql.NewStaticKind(otlpKindToTraceqlKind(kv.Value.Uint64())))
 		case columnPathSpanParentID:
@@ -1398,16 +1399,16 @@ func (c *spanCollector2) Collect(res *parquetquery.IteratorResult, param any) {
 		// Instrumentation-level columns:
 		// -------------------------
 		case columnPathInstrumentationName:
-			sp.instrumentationAttrs = append(sp.instrumentationAttrs, attrVal{traceql.IntrinsicInstrumentationNameAttribute, traceql.NewStaticString(intern.InternString(kv.Value.Bytes()))})
+			sp.instrumentationAttrs = append(sp.instrumentationAttrs, attrVal{traceql.IntrinsicInstrumentationNameAttribute, traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes()))})
 		case columnPathInstrumentationVersion:
-			sp.instrumentationAttrs = append(sp.instrumentationAttrs, attrVal{traceql.IntrinsicInstrumentationVersionAttribute, traceql.NewStaticString(intern.InternString(kv.Value.Bytes()))})
+			sp.instrumentationAttrs = append(sp.instrumentationAttrs, attrVal{traceql.IntrinsicInstrumentationVersionAttribute, traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes()))})
 		// -------------------------
 		// Resource-level columns:
 		// -------------------------
 		case ColumnPathResourceServiceName:
 			sp.resourceAttrs = append(sp.resourceAttrs, attrVal{
 				traceql.NewScopedAttribute(traceql.AttributeScopeResource, false, "service.name"),
-				traceql.NewStaticString(intern.InternString(kv.Value.Bytes())),
+				traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())),
 			})
 		default:
 			// Decomposed attributes from dedicated columns.
@@ -1424,7 +1425,7 @@ func (c *spanCollector2) Collect(res *parquetquery.IteratorResult, param any) {
 			case parquet.Float:
 				x.s = traceql.NewStaticFloat(kv.Value.Double())
 			case parquet.ByteArray:
-				x.s = traceql.NewStaticString(unsafeToString(kv.Value.Bytes()))
+				x.s = traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes()))
 			default:
 				if kv.Value.IsNull() {
 					// Enter placeholder string that indicates a nil check passed.

--- a/tempodb/encoding/vparquet5/block_traceql_fetch.go
+++ b/tempodb/encoding/vparquet5/block_traceql_fetch.go
@@ -1037,7 +1037,7 @@ func (c *scopedAttributeCollector) Collect(res *parquetquery.IteratorResult, _ a
 		case "key":
 			c.at.a.Name = unsafeToString(e.Value.Bytes())
 		case "string":
-			c.strBuffer = append(c.strBuffer, intern.UniqueBytes(e.Value.Bytes()))
+			c.strBuffer = append(c.strBuffer, intern.UniqueStringFromBytes(e.Value.Bytes()))
 		case "int":
 			c.intBuffer = append(c.intBuffer, int(e.Value.Int64()))
 		case "float":
@@ -1338,9 +1338,9 @@ func (c *spanCollector2) Collect(res *parquetquery.IteratorResult, param any) {
 		// Trace-level columns:
 		// --------------------
 		case columnPathRootSpanName:
-			sp.traceAttrs = append(sp.traceAttrs, attrVal{traceql.IntrinsicTraceRootSpanAttribute, traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes()))})
+			sp.traceAttrs = append(sp.traceAttrs, attrVal{traceql.IntrinsicTraceRootSpanAttribute, traceql.NewStaticUniqueStringFromBytes(kv.Value.Bytes())})
 		case columnPathRootServiceName:
-			sp.traceAttrs = append(sp.traceAttrs, attrVal{traceql.IntrinsicTraceRootServiceAttribute, traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes()))})
+			sp.traceAttrs = append(sp.traceAttrs, attrVal{traceql.IntrinsicTraceRootServiceAttribute, traceql.NewStaticUniqueStringFromBytes(kv.Value.Bytes())})
 		case columnPathTraceID:
 			sp.traceAttrs = append(sp.traceAttrs, attrVal{traceql.IntrinsicTraceIDAttribute, traceql.NewStaticString(util.TraceIDToHexString(kv.Value.ByteArray()))})
 		case columnPathDurationNanos:
@@ -1373,11 +1373,11 @@ func (c *spanCollector2) Collect(res *parquetquery.IteratorResult, param any) {
 			sp.durationNanos = durationNanos
 			sp.addSpanAttr(traceql.IntrinsicDurationAttribute, traceql.NewStaticDuration(time.Duration(durationNanos)))
 		case ColumnPathSpanName:
-			sp.addSpanAttr(traceql.IntrinsicNameAttribute, traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())))
+			sp.addSpanAttr(traceql.IntrinsicNameAttribute, traceql.NewStaticUniqueStringFromBytes(kv.Value.Bytes()))
 		case columnPathSpanStatusCode:
 			sp.addSpanAttr(traceql.IntrinsicStatusAttribute, traceql.NewStaticStatus(otlpStatusToTraceqlStatus(kv.Value.Uint64())))
 		case columnPathSpanStatusMessage:
-			sp.addSpanAttr(traceql.IntrinsicStatusMessageAttribute, traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())))
+			sp.addSpanAttr(traceql.IntrinsicStatusMessageAttribute, traceql.NewStaticUniqueStringFromBytes(kv.Value.Bytes()))
 		case columnPathSpanKind:
 			sp.addSpanAttr(traceql.IntrinsicKindAttribute, traceql.NewStaticKind(otlpKindToTraceqlKind(kv.Value.Uint64())))
 		case columnPathSpanParentID:
@@ -1399,16 +1399,16 @@ func (c *spanCollector2) Collect(res *parquetquery.IteratorResult, param any) {
 		// Instrumentation-level columns:
 		// -------------------------
 		case columnPathInstrumentationName:
-			sp.instrumentationAttrs = append(sp.instrumentationAttrs, attrVal{traceql.IntrinsicInstrumentationNameAttribute, traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes()))})
+			sp.instrumentationAttrs = append(sp.instrumentationAttrs, attrVal{traceql.IntrinsicInstrumentationNameAttribute, traceql.NewStaticUniqueStringFromBytes(kv.Value.Bytes())})
 		case columnPathInstrumentationVersion:
-			sp.instrumentationAttrs = append(sp.instrumentationAttrs, attrVal{traceql.IntrinsicInstrumentationVersionAttribute, traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes()))})
+			sp.instrumentationAttrs = append(sp.instrumentationAttrs, attrVal{traceql.IntrinsicInstrumentationVersionAttribute, traceql.NewStaticUniqueStringFromBytes(kv.Value.Bytes())})
 		// -------------------------
 		// Resource-level columns:
 		// -------------------------
 		case ColumnPathResourceServiceName:
 			sp.resourceAttrs = append(sp.resourceAttrs, attrVal{
 				traceql.NewScopedAttribute(traceql.AttributeScopeResource, false, "service.name"),
-				traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes())),
+				traceql.NewStaticUniqueStringFromBytes(kv.Value.Bytes()),
 			})
 		default:
 			// Decomposed attributes from dedicated columns.
@@ -1425,7 +1425,7 @@ func (c *spanCollector2) Collect(res *parquetquery.IteratorResult, param any) {
 			case parquet.Float:
 				x.s = traceql.NewStaticFloat(kv.Value.Double())
 			case parquet.ByteArray:
-				x.s = traceql.NewStaticStringFromHandle(intern.UniqueBytes(kv.Value.Bytes()))
+				x.s = traceql.NewStaticUniqueStringFromBytes(kv.Value.Bytes())
 			default:
 				if kv.Value.IsNull() {
 					// Enter placeholder string that indicates a nil check passed.

--- a/tempodb/encoding/vparquet5/block_traceql_fetch.go
+++ b/tempodb/encoding/vparquet5/block_traceql_fetch.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/grafana/tempo/pkg/parquetquery"
+	"github.com/grafana/tempo/pkg/parquetquery/intern"
 	"github.com/grafana/tempo/pkg/traceql"
 	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/tempodb/backend"
@@ -1033,7 +1034,7 @@ func (c *scopedAttributeCollector) Collect(res *parquetquery.IteratorResult, _ a
 		}
 		switch e.Key {
 		case "key":
-			c.at.a.Name = unsafeToString(e.Value.Bytes())
+			c.at.a.Name = intern.InternString(e.Value.Bytes())
 		case "string":
 			c.strBuffer = append(c.strBuffer, unsafeToString(e.Value.Bytes()))
 		case "int":
@@ -1336,9 +1337,9 @@ func (c *spanCollector2) Collect(res *parquetquery.IteratorResult, param any) {
 		// Trace-level columns:
 		// --------------------
 		case columnPathRootSpanName:
-			sp.traceAttrs = append(sp.traceAttrs, attrVal{traceql.IntrinsicTraceRootSpanAttribute, traceql.NewStaticString(unsafeToString(kv.Value.Bytes()))})
+			sp.traceAttrs = append(sp.traceAttrs, attrVal{traceql.IntrinsicTraceRootSpanAttribute, traceql.NewStaticString(intern.InternString(kv.Value.Bytes()))})
 		case columnPathRootServiceName:
-			sp.traceAttrs = append(sp.traceAttrs, attrVal{traceql.IntrinsicTraceRootServiceAttribute, traceql.NewStaticString(unsafeToString(kv.Value.Bytes()))})
+			sp.traceAttrs = append(sp.traceAttrs, attrVal{traceql.IntrinsicTraceRootServiceAttribute, traceql.NewStaticString(intern.InternString(kv.Value.Bytes()))})
 		case columnPathTraceID:
 			sp.traceAttrs = append(sp.traceAttrs, attrVal{traceql.IntrinsicTraceIDAttribute, traceql.NewStaticString(util.TraceIDToHexString(kv.Value.ByteArray()))})
 		case columnPathDurationNanos:
@@ -1371,11 +1372,11 @@ func (c *spanCollector2) Collect(res *parquetquery.IteratorResult, param any) {
 			sp.durationNanos = durationNanos
 			sp.addSpanAttr(traceql.IntrinsicDurationAttribute, traceql.NewStaticDuration(time.Duration(durationNanos)))
 		case ColumnPathSpanName:
-			sp.addSpanAttr(traceql.IntrinsicNameAttribute, traceql.NewStaticString(unsafeToString(kv.Value.Bytes())))
+			sp.addSpanAttr(traceql.IntrinsicNameAttribute, traceql.NewStaticString(intern.InternString(kv.Value.Bytes())))
 		case columnPathSpanStatusCode:
 			sp.addSpanAttr(traceql.IntrinsicStatusAttribute, traceql.NewStaticStatus(otlpStatusToTraceqlStatus(kv.Value.Uint64())))
 		case columnPathSpanStatusMessage:
-			sp.addSpanAttr(traceql.IntrinsicStatusMessageAttribute, traceql.NewStaticString(unsafeToString(kv.Value.Bytes())))
+			sp.addSpanAttr(traceql.IntrinsicStatusMessageAttribute, traceql.NewStaticString(intern.InternString(kv.Value.Bytes())))
 		case columnPathSpanKind:
 			sp.addSpanAttr(traceql.IntrinsicKindAttribute, traceql.NewStaticKind(otlpKindToTraceqlKind(kv.Value.Uint64())))
 		case columnPathSpanParentID:
@@ -1397,16 +1398,16 @@ func (c *spanCollector2) Collect(res *parquetquery.IteratorResult, param any) {
 		// Instrumentation-level columns:
 		// -------------------------
 		case columnPathInstrumentationName:
-			sp.instrumentationAttrs = append(sp.instrumentationAttrs, attrVal{traceql.IntrinsicInstrumentationNameAttribute, traceql.NewStaticString(unsafeToString(kv.Value.Bytes()))})
+			sp.instrumentationAttrs = append(sp.instrumentationAttrs, attrVal{traceql.IntrinsicInstrumentationNameAttribute, traceql.NewStaticString(intern.InternString(kv.Value.Bytes()))})
 		case columnPathInstrumentationVersion:
-			sp.instrumentationAttrs = append(sp.instrumentationAttrs, attrVal{traceql.IntrinsicInstrumentationVersionAttribute, traceql.NewStaticString(unsafeToString(kv.Value.Bytes()))})
+			sp.instrumentationAttrs = append(sp.instrumentationAttrs, attrVal{traceql.IntrinsicInstrumentationVersionAttribute, traceql.NewStaticString(intern.InternString(kv.Value.Bytes()))})
 		// -------------------------
 		// Resource-level columns:
 		// -------------------------
 		case ColumnPathResourceServiceName:
 			sp.resourceAttrs = append(sp.resourceAttrs, attrVal{
 				traceql.NewScopedAttribute(traceql.AttributeScopeResource, false, "service.name"),
-				traceql.NewStaticString(unsafeToString(kv.Value.Bytes())),
+				traceql.NewStaticString(intern.InternString(kv.Value.Bytes())),
 			})
 		default:
 			// Decomposed attributes from dedicated columns.

--- a/tempodb/encoding/vparquet5/block_traceql_meta_test.go
+++ b/tempodb/encoding/vparquet5/block_traceql_meta_test.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"testing"
 	"time"
+	"unique"
 
 	"github.com/grafana/tempo/pkg/parquetquery"
 	"github.com/grafana/tempo/pkg/traceql"
@@ -27,8 +28,8 @@ func TestBackendBlockSearchFetchMetaData(t *testing.T) {
 	makeSpanset := func(traceID []byte, rootSpanName, rootServiceName string, startTimeUnixNano, durationNanos uint64, spans ...traceql.Span) *traceql.Spanset {
 		return &traceql.Spanset{
 			TraceID:            traceID,
-			RootSpanName:       rootSpanName,
-			RootServiceName:    rootServiceName,
+			RootSpanName:       unique.Make(rootSpanName),
+			RootServiceName:    unique.Make(rootServiceName),
 			StartTimeUnixNanos: startTimeUnixNano,
 			DurationNanos:      durationNanos,
 			ServiceStats: map[string]traceql.ServiceStats{

--- a/tempodb/encoding/vparquet5/block_traceql_pool_test.go
+++ b/tempodb/encoding/vparquet5/block_traceql_pool_test.go
@@ -2,6 +2,7 @@ package vparquet5
 
 import (
 	"testing"
+	"unique"
 
 	"github.com/parquet-go/parquet-go"
 	"github.com/stretchr/testify/assert"
@@ -73,8 +74,8 @@ func TestSpansetPoolRelease(t *testing.T) {
 	// Get a spanset from the pool and populate it
 	spanset1 := getSpanset()
 	spanset1.TraceID = []byte("trace-id")
-	spanset1.RootSpanName = "root"
-	spanset1.RootServiceName = "service"
+	spanset1.RootSpanName = unique.Make("root")
+	spanset1.RootServiceName = unique.Make("service")
 	spanset1.StartTimeUnixNanos = 12345
 	spanset1.DurationNanos = 67890
 	spanset1.Scalar = traceql.NewStaticString("scalar")
@@ -92,8 +93,8 @@ func TestSpansetPoolRelease(t *testing.T) {
 
 	// Verify the reused spanset is properly cleared
 	assert.Nil(t, spanset2.TraceID, "TraceID should be cleared")
-	assert.Empty(t, spanset2.RootSpanName, "RootSpanName should be cleared")
-	assert.Empty(t, spanset2.RootServiceName, "RootServiceName should be cleared")
+	assert.Equal(t, unique.Handle[string]{}, spanset2.RootSpanName, "RootSpanName should be cleared")
+	assert.Equal(t, unique.Handle[string]{}, spanset2.RootServiceName, "RootServiceName should be cleared")
 	assert.Zero(t, spanset2.StartTimeUnixNanos, "StartTimeUnixNanos should be cleared")
 	assert.Zero(t, spanset2.DurationNanos, "DurationNanos should be cleared")
 	assert.Equal(t, traceql.TypeNil, spanset2.Scalar.Type, "Scalar should be cleared")

--- a/tempodb/encoding/vparquet5/block_traceql_test.go
+++ b/tempodb/encoding/vparquet5/block_traceql_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"text/tabwriter"
 	"time"
+	"unique"
 
 	kitlog "github.com/go-kit/log"
 	"github.com/google/uuid"
@@ -1513,8 +1514,8 @@ func trimForSelectAll(tr *Trace) {
 func flattenForSelectAll(tr *Trace, dcm dedicatedColumnMapping) *traceql.Spanset {
 	var traceAttrs []attrVal
 	newSS := &traceql.Spanset{
-		RootServiceName: tr.RootServiceName,
-		RootSpanName:    tr.RootSpanName,
+		RootServiceName: unique.Make(tr.RootServiceName),
+		RootSpanName:    unique.Make(tr.RootSpanName),
 		TraceID:         tr.TraceID,
 		DurationNanos:   tr.DurationNano,
 	}


### PR DESCRIPTION
**What this PR does**:

Adds an optimization on reading from Parquet v4/v5 that 'interns' strings. As most of spans have repeated info, this 
should result in reduction of memory footprint

Ref: https://github.com/golang/go/issues/71926 - in recent versions, `unique.Make` should not perform extra allocations, which makes this a viable alternative to `unsafeToString`

TODO: gather metrics

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`