### PR TITLE
Maintenance: remove outdated yaml and json dependencies

### DIFF
--- a/cmd/tempo-cli/cmd-migrate-overrides-config.go
+++ b/cmd/tempo-cli/cmd-migrate-overrides-config.go
@@ -36,7 +36,7 @@ func (cmd *migrateOverridesConfigCmd) Run(*globalOptions) error {
 		return fmt.Errorf("failed to read configFile %s: %w", cmd.ConfigFile, err)
 	}
 
-	if err := util.UnmarshalStrict(buff, &cfg); err != nil {
+	if err := util.YAMLUnmarshalStrict(buff, &cfg); err != nil {
 		return fmt.Errorf("failed to parse configFile %s: %w", cmd.ConfigFile, err)
 	}
 
@@ -58,7 +58,7 @@ func (cmd *migrateOverridesConfigCmd) Run(*globalOptions) error {
 		Defaults           overrides.Overrides         `yaml:"defaults"`
 		PerTenantOverrides map[string]overrides.Config `yaml:"overrides"`
 	}
-	if err := util.UnmarshalStrict(buffer.Bytes(), &runtimeConfig); err != nil {
+	if err := util.YAMLUnmarshalStrict(buffer.Bytes(), &runtimeConfig); err != nil {
 		return fmt.Errorf("failed parsing overrides config: %w", err)
 	}
 

--- a/cmd/tempo-cli/cmd-migrate-overrides-config.go
+++ b/cmd/tempo-cli/cmd-migrate-overrides-config.go
@@ -11,10 +11,11 @@ import (
 
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/grafana/tempo/cmd/tempo/app"
 	"github.com/grafana/tempo/modules/overrides"
+	"github.com/grafana/tempo/pkg/util"
 )
 
 type migrateOverridesConfigCmd struct {
@@ -35,7 +36,7 @@ func (cmd *migrateOverridesConfigCmd) Run(*globalOptions) error {
 		return fmt.Errorf("failed to read configFile %s: %w", cmd.ConfigFile, err)
 	}
 
-	if err := yaml.UnmarshalStrict(buff, &cfg); err != nil {
+	if err := util.UnmarshalStrict(buff, &cfg); err != nil {
 		return fmt.Errorf("failed to parse configFile %s: %w", cmd.ConfigFile, err)
 	}
 
@@ -57,7 +58,7 @@ func (cmd *migrateOverridesConfigCmd) Run(*globalOptions) error {
 		Defaults           overrides.Overrides         `yaml:"defaults"`
 		PerTenantOverrides map[string]overrides.Config `yaml:"overrides"`
 	}
-	if err := yaml.UnmarshalStrict(buffer.Bytes(), &runtimeConfig); err != nil {
+	if err := util.UnmarshalStrict(buffer.Bytes(), &runtimeConfig); err != nil {
 		return fmt.Errorf("failed parsing overrides config: %w", err)
 	}
 

--- a/cmd/tempo-cli/cmd-suggest-columns.go
+++ b/cmd/tempo-cli/cmd-suggest-columns.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/dustin/go-humanize"
 	"github.com/google/uuid"

--- a/cmd/tempo-cli/main.go
+++ b/cmd/tempo-cli/main.go
@@ -114,7 +114,7 @@ func loadBackend(b *backendOptions, g *globalOptions) (backend.Reader, backend.W
 			return nil, nil, nil, fmt.Errorf("failed to read configFile %s: %w", g.ConfigFile, err)
 		}
 
-		err = util.UnmarshalStrict(buff, &cfg)
+		err = util.YAMLUnmarshalStrict(buff, &cfg)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to parse configFile %s: %w", g.ConfigFile, err)
 		}

--- a/cmd/tempo-cli/main.go
+++ b/cmd/tempo-cli/main.go
@@ -8,9 +8,8 @@ import (
 	"github.com/grafana/dskit/flagext"
 
 	"github.com/alecthomas/kong"
-	"go.yaml.in/yaml/v2"
-
 	"github.com/grafana/tempo/cmd/tempo/app"
+	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/azure"
 	"github.com/grafana/tempo/tempodb/backend/gcs"
@@ -115,7 +114,7 @@ func loadBackend(b *backendOptions, g *globalOptions) (backend.Reader, backend.W
 			return nil, nil, nil, fmt.Errorf("failed to read configFile %s: %w", g.ConfigFile, err)
 		}
 
-		err = yaml.UnmarshalStrict(buff, &cfg)
+		err = util.UnmarshalStrict(buff, &cfg)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to parse configFile %s: %w", g.ConfigFile, err)
 		}

--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -28,9 +28,9 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/prometheus/common/version"
 	"go.uber.org/atomic"
+	"go.yaml.in/yaml/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
-	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/tempo/cmd/tempo/build"
 	"github.com/grafana/tempo/modules/backendscheduler"

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"embed"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -21,7 +22,6 @@ import (
 	"github.com/grafana/dskit/server"
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/tempo/modules/livestore"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 
@@ -835,12 +835,13 @@ func usageStatsHandler(urCfg usagestats.Config) http.HandlerFunc {
 	}
 
 	// usage stats is Enabled, build and return usage stats json
-	reportStr, err := jsoniter.MarshalToString(usagestats.BuildStats())
+	reportBytes, err := json.Marshal(usagestats.BuildStats())
 	if err != nil {
 		return func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "error building usage report", http.StatusInternalServerError)
 		}
 	}
+	reportStr := string(reportBytes)
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/cmd/tempo/main.go
+++ b/cmd/tempo/main.go
@@ -182,7 +182,7 @@ func loadConfig() (*app.Config, bool, error) {
 			buff = []byte(s)
 		}
 
-		err = util.UnmarshalStrict(buff, config)
+		err = util.YAMLUnmarshalStrict(buff, config)
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to parse configFile %s: %w", configFile, err)
 		}

--- a/cmd/tempo/main.go
+++ b/cmd/tempo/main.go
@@ -16,11 +16,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	ver "github.com/prometheus/client_golang/prometheus/collectors/version"
 	"github.com/prometheus/common/version"
-	"go.yaml.in/yaml/v2"
 	"google.golang.org/grpc/encoding"
 
 	"github.com/grafana/tempo/cmd/tempo/app"
 	"github.com/grafana/tempo/pkg/gogocodec"
+	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/pkg/util/log"
 )
 
@@ -182,7 +182,7 @@ func loadConfig() (*app.Config, bool, error) {
 			buff = []byte(s)
 		}
 
-		err = yaml.UnmarshalStrict(buff, config)
+		err = util.UnmarshalStrict(buff, config)
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to parse configFile %s: %w", configFile, err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -122,7 +122,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.42.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.42.0
 	go.opentelemetry.io/proto/otlp v1.10.0
-	go.yaml.in/yaml/v2 v2.4.4
 	golang.org/x/net v0.52.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171
 )
@@ -419,6 +418,7 @@ require (
 	gonum.org/v1/gonum v0.17.0 // indirect
 	google.golang.org/genproto v0.0.0-20260217215200-42d3e9bedb6d // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260226221140-a57be14db171 // indirect
+	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apimachinery v0.35.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/grafana/e2e v0.1.2-0.20251205060319-9884d3ffb1bf
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/jedib0t/go-pretty/v6 v6.7.8
-	github.com/json-iterator/go v1.1.12
+	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/jsternberg/zap-logfmt v1.3.0
 	github.com/klauspost/compress v1.18.4
 	github.com/minio/minio-go/v7 v7.0.99
@@ -407,6 +407,7 @@ require (
 	go.opentelemetry.io/otel/log v0.18.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.18.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.42.0 // indirect
+	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	golang.org/x/arch v0.0.0-20210923205945-b76863e36670 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect
@@ -418,7 +419,6 @@ require (
 	gonum.org/v1/gonum v0.17.0 // indirect
 	google.golang.org/genproto v0.0.0-20260217215200-42d3e9bedb6d // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260226221140-a57be14db171 // indirect
-	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apimachinery v0.35.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -62,12 +62,12 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.1
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/sync v0.20.0
 	golang.org/x/time v0.15.0
 	google.golang.org/api v0.271.0
 	google.golang.org/grpc v1.79.3
 	google.golang.org/protobuf v1.36.11
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -408,7 +408,6 @@ require (
 	go.opentelemetry.io/otel/log v0.18.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.18.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.42.0 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.0.0-20210923205945-b76863e36670 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect
@@ -421,6 +420,7 @@ require (
 	google.golang.org/genproto v0.0.0-20260217215200-42d3e9bedb6d // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260226221140-a57be14db171 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apimachinery v0.35.2 // indirect
 	k8s.io/client-go v0.34.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/integration/api/overrides_api_test.go
+++ b/integration/api/overrides_api_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -10,7 +11,6 @@ import (
 	"github.com/grafana/tempo/modules/overrides/histograms"
 	"github.com/grafana/tempo/modules/overrides/userconfigurable/client"
 	"github.com/grafana/tempo/pkg/httpclient"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -788,7 +788,7 @@ func TestOverridesAPI_SpanNameSanitization(t *testing.T) {
 func printLimits(limits *client.Limits, version string) {
 	var str string
 	if limits != nil {
-		bytes, err := jsoniter.Marshal(limits)
+		bytes, err := json.Marshal(limits)
 		if err == nil {
 			str = string(bytes)
 		}

--- a/integration/util/harness.go
+++ b/integration/util/harness.go
@@ -18,7 +18,9 @@ import (
 	"github.com/grafana/tempo/tempodb/backend/azure"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
+
+	"github.com/grafana/tempo/pkg/util"
 )
 
 const (
@@ -314,7 +316,7 @@ func (h *TempoHarness) GetConfig() (app.Config, error) {
 	}
 
 	var cfg app.Config
-	err = yaml.UnmarshalStrict(buff, &cfg)
+	err = util.YAMLUnmarshalStrict(buff, &cfg)
 	if err != nil {
 		return app.Config{}, fmt.Errorf("failed to unmarshal config: %w", err)
 	}

--- a/integration/util/harness_config_overlay.go
+++ b/integration/util/harness_config_overlay.go
@@ -12,7 +12,9 @@ import (
 	"github.com/grafana/tempo/cmd/tempo/app"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
+
+	"github.com/grafana/tempo/pkg/util"
 )
 
 const (
@@ -110,7 +112,7 @@ func setupConfig(t *testing.T, s *e2e.Scenario, config *TestHarnessConfig, reque
 	require.NoError(t, err, "failed to read merged config file")
 
 	var cfg app.Config
-	err = yaml.UnmarshalStrict(configBytes, &cfg)
+	err = util.YAMLUnmarshalStrict(configBytes, &cfg)
 	require.NoError(t, err, "failed to unmarshal merged config into app.Config")
 
 	return cfg
@@ -128,7 +130,7 @@ func applyConfigOverlay(s *e2e.Scenario, overlayPath string, templateData map[st
 		return fmt.Errorf("failed to read shared config file: %w", err)
 	}
 
-	var baseMap map[any]any
+	var baseMap map[string]any
 	err = yaml.Unmarshal(baseBuff, &baseMap)
 	if err != nil {
 		return fmt.Errorf("failed to parse shared config file: %w", err)
@@ -159,7 +161,7 @@ func applyConfigOverlay(s *e2e.Scenario, overlayPath string, templateData map[st
 		}
 
 		// Parse overlay
-		var overlayMap map[any]any
+		var overlayMap map[string]any
 		err = yaml.Unmarshal(overlayBuff, &overlayMap)
 		if err != nil {
 			return fmt.Errorf("failed to parse config overlay file: %w", err)
@@ -183,10 +185,10 @@ func applyConfigOverlay(s *e2e.Scenario, overlayPath string, templateData map[st
 	return nil
 }
 
-// mergeMaps recursively merges overlay map onto base map
-// Values in overlay take precedence over base values
-func mergeMaps(base, overlay map[any]any) map[any]any {
-	result := make(map[any]any)
+// mergeMaps recursively merges overlay map onto base map. Values in overlay take precedence over base values.
+// go.yaml.in/yaml/v3 always produces map[string]any when unmarshaling into interface{}.
+func mergeMaps(base, overlay map[string]any) map[string]any {
+	result := make(map[string]any, len(base))
 
 	// Copy all base values
 	for k, v := range base {
@@ -202,8 +204,8 @@ func mergeMaps(base, overlay map[any]any) map[any]any {
 
 		// If both base and overlay have a map at this key, merge recursively
 		if baseVal, exists := result[k]; exists {
-			baseMap, baseIsMap := toMapAnyAny(baseVal)
-			overlayMap, overlayIsMap := toMapAnyAny(v)
+			baseMap, baseIsMap := baseVal.(map[string]any)
+			overlayMap, overlayIsMap := v.(map[string]any)
 
 			if baseIsMap && overlayIsMap {
 				result[k] = mergeMaps(baseMap, overlayMap)
@@ -216,20 +218,4 @@ func mergeMaps(base, overlay map[any]any) map[any]any {
 	}
 
 	return result
-}
-
-// toMapAnyAny converts various map types to map[any]any
-func toMapAnyAny(v any) (map[any]any, bool) {
-	switch m := v.(type) {
-	case map[any]any:
-		return m, true
-	case map[string]any:
-		result := make(map[any]any)
-		for k, v := range m {
-			result[k] = v
-		}
-		return result, true
-	default:
-		return nil, false
-	}
 }

--- a/integration/util/harness_test.go
+++ b/integration/util/harness_test.go
@@ -7,30 +7,30 @@ import (
 )
 
 func TestMergeMaps(t *testing.T) {
-	base := map[any]any{
-		"distributor": map[any]any{
-			"receivers": map[any]any{
-				"otlp": map[any]any{
-					"protocols": map[any]any{
-						"grpc": map[any]any{
+	base := map[string]any{
+		"distributor": map[string]any{
+			"receivers": map[string]any{
+				"otlp": map[string]any{
+					"protocols": map[string]any{
+						"grpc": map[string]any{
 							"endpoint": "0.0.0.0:4317",
 						},
 					},
 				},
 			},
 		},
-		"server": map[any]any{
+		"server": map[string]any{
 			"http_listen_port": 3200,
 		},
 	}
 
-	overlay := map[any]any{
-		"distributor": map[any]any{
+	overlay := map[string]any{
+		"distributor": map[string]any{
 			"retry_after_on_resource_exhausted": "1s",
 		},
-		"overrides": map[any]any{
-			"defaults": map[any]any{
-				"ingestion": map[any]any{
+		"overrides": map[string]any{
+			"defaults": map[string]any{
+				"ingestion": map[string]any{
 					"max_traces_per_user": 1,
 				},
 			},
@@ -40,55 +40,25 @@ func TestMergeMaps(t *testing.T) {
 	result := mergeMaps(base, overlay)
 
 	// Check that base distributor.receivers is preserved
-	distributor, _ := toMapAnyAny(result["distributor"])
+	distributor := result["distributor"].(map[string]any)
 	assert.NotNil(t, distributor["receivers"], "distributor.receivers should be preserved")
 
-	receivers, _ := toMapAnyAny(distributor["receivers"])
-	otlp, _ := toMapAnyAny(receivers["otlp"])
-	protocols, _ := toMapAnyAny(otlp["protocols"])
-	grpc, _ := toMapAnyAny(protocols["grpc"])
+	receivers := distributor["receivers"].(map[string]any)
+	otlp := receivers["otlp"].(map[string]any)
+	protocols := otlp["protocols"].(map[string]any)
+	grpc := protocols["grpc"].(map[string]any)
 	assert.Equal(t, "0.0.0.0:4317", grpc["endpoint"], "distributor.receivers.otlp.protocols.grpc.endpoint should be preserved")
 
 	// Check that overlay distributor.retry_after_on_resource_exhausted is added
 	assert.Equal(t, "1s", distributor["retry_after_on_resource_exhausted"], "distributor.retry_after_on_resource_exhausted should be added from overlay")
 
 	// Check that server config is preserved
-	server, _ := toMapAnyAny(result["server"])
+	server := result["server"].(map[string]any)
 	assert.Equal(t, 3200, server["http_listen_port"], "server.http_listen_port should be preserved")
 
 	// Check that overrides is added
-	overrides, _ := toMapAnyAny(result["overrides"])
-	defaults, _ := toMapAnyAny(overrides["defaults"])
-	ingestion, _ := toMapAnyAny(defaults["ingestion"])
+	overrides := result["overrides"].(map[string]any)
+	defaults := overrides["defaults"].(map[string]any)
+	ingestion := defaults["ingestion"].(map[string]any)
 	assert.Equal(t, 1, ingestion["max_traces_per_user"], "overrides.defaults.ingestion.max_traces_per_user should be added from overlay")
-}
-
-func TestToMapAnyAny(t *testing.T) {
-	// Test map[interface{}]interface{} conversion
-	input := map[interface{}]interface{}{
-		"key1": "value1",
-		"key2": map[interface{}]interface{}{
-			"nested": "value",
-		},
-	}
-
-	result, ok := toMapAnyAny(input)
-	assert.True(t, ok)
-	assert.Equal(t, "value1", result["key1"])
-
-	nested, ok := toMapAnyAny(result["key2"])
-	assert.True(t, ok)
-	assert.Equal(t, "value", nested["nested"])
-
-	// Test map[string]any conversion
-	stringMap := map[string]any{
-		"key": "value",
-	}
-	result, ok = toMapAnyAny(stringMap)
-	assert.True(t, ok)
-	assert.Equal(t, "value", result["key"])
-
-	// Test non-map
-	_, ok = toMapAnyAny("not a map")
-	assert.False(t, ok)
 }

--- a/modules/backendscheduler/work/atomic_test.go
+++ b/modules/backendscheduler/work/atomic_test.go
@@ -1,13 +1,13 @@
 package work
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
 	"testing"
 
-	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,7 +57,7 @@ func TestAtomicWriteFileStress(t *testing.T) {
 
 	// Should be valid JSON
 	var result map[string]any
-	err = jsoniter.Unmarshal(finalData, &result)
+	err = json.Unmarshal(finalData, &result)
 	require.NoError(t, err, "Final file should contain valid JSON after stress test")
 
 	// Verify it's our expected data

--- a/modules/backendscheduler/work/work.go
+++ b/modules/backendscheduler/work/work.go
@@ -2,6 +2,7 @@ package work
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"hash/fnv"
 	"os"
@@ -10,7 +11,6 @@ import (
 	"time"
 
 	"github.com/grafana/tempo/pkg/tempopb"
-	jsoniter "github.com/json-iterator/go"
 	"go.opentelemetry.io/otel"
 )
 
@@ -295,7 +295,7 @@ func (w *Work) Marshal() ([]byte, error) {
 	}()
 
 	// For now, marshal the entire structure for compatibility
-	return jsoniter.Marshal(w)
+	return json.Marshal(w)
 }
 
 // MarshalShard marshals only a specific shard
@@ -308,7 +308,7 @@ func (w *Work) MarshalShard(shardID int) ([]byte, error) {
 	shard.mtx.Lock()
 	defer shard.mtx.Unlock()
 
-	return jsoniter.Marshal(shard)
+	return json.Marshal(shard)
 }
 
 // Unmarshal deserializes JSON to all shards with proper locking
@@ -327,7 +327,7 @@ func (w *Work) Unmarshal(data []byte) error {
 		}
 	}()
 
-	err := jsoniter.Unmarshal(data, w)
+	err := json.Unmarshal(data, w)
 	if err != nil {
 		return err
 	}
@@ -356,7 +356,7 @@ func (w *Work) UnmarshalShard(shardID int, data []byte) error {
 	shard.mtx.Lock()
 	defer shard.mtx.Unlock()
 
-	return jsoniter.Unmarshal(data, shard)
+	return json.Unmarshal(data, shard)
 }
 
 // GetShardStats returns statistics about job distribution across shards
@@ -446,7 +446,7 @@ func (w *Work) flushShards(localPath string, shards map[int]bool) error {
 			shard.mtx.Lock()
 			defer shard.mtx.Unlock()
 
-			shardData, err := jsoniter.Marshal(shard)
+			shardData, err := json.Marshal(shard)
 			if err != nil {
 				return err
 			}

--- a/modules/generator/storage/config_test.go
+++ b/modules/generator/storage/config_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/tempo/pkg/util"
 	prometheus_common_config "github.com/prometheus/common/config"
 	prometheus_config "github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/util/compression"
 	"github.com/stretchr/testify/assert"
-	tempo_util "github.com/grafana/tempo/pkg/util"
 )
 
 func TestConfig(t *testing.T) {
@@ -27,7 +27,7 @@ remote_write:
 	var cfg Config
 	cfg.RegisterFlagsAndApplyDefaults("", nil)
 
-	err := tempo_util.UnmarshalStrict([]byte(cfgStr), &cfg)
+	err := util.YAMLUnmarshalStrict([]byte(cfgStr), &cfg)
 	assert.NoError(t, err)
 
 	walCfg := agentDefaultOptions()

--- a/modules/generator/storage/config_test.go
+++ b/modules/generator/storage/config_test.go
@@ -9,7 +9,7 @@ import (
 	prometheus_config "github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/util/compression"
 	"github.com/stretchr/testify/assert"
-	"go.yaml.in/yaml/v2"
+	tempo_util "github.com/grafana/tempo/pkg/util"
 )
 
 func TestConfig(t *testing.T) {
@@ -27,7 +27,7 @@ remote_write:
 	var cfg Config
 	cfg.RegisterFlagsAndApplyDefaults("", nil)
 
-	err := yaml.UnmarshalStrict([]byte(cfgStr), &cfg)
+	err := tempo_util.UnmarshalStrict([]byte(cfgStr), &cfg)
 	assert.NoError(t, err)
 
 	walCfg := agentDefaultOptions()

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/prometheus/common/config"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/grafana/tempo/modules/overrides/histograms"
 	"github.com/grafana/tempo/pkg/util/listtomap"
@@ -223,42 +224,59 @@ type Config struct {
 	ExpandEnv  bool       `yaml:"-" json:"-"`
 }
 
-func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	// Note: this implementation relies on callers using yaml.UnmarshalStrict. In non-strict mode
-	// unmarshal() will not return an error for legacy configuration and we return immediately.
+// newConfigTopLevelKeys is the complete set of valid top-level YAML keys for the new overrides
+// config format. Any key outside this set indicates a legacy flat-format config.
+var newConfigTopLevelKeys = map[string]bool{
+	"defaults":                    true,
+	"per_tenant_override_config":  true,
+	"per_tenant_override_period":  true,
+	"user_configurable_overrides": true,
+}
 
-	// Try to unmarshal it normally
-	type rawConfig Config
-	err := unmarshal((*rawConfig)(c))
-	if err == nil {
-		c.ConfigType = ConfigTypeNew
+func isLegacyConfigNode(node *yaml.Node) bool {
+	if node.Kind != yaml.MappingNode {
+		return false
+	}
+	for i := 0; i < len(node.Content); i += 2 {
+		if !newConfigTopLevelKeys[node.Content[i].Value] {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Config) UnmarshalYAML(value *yaml.Node) error {
+	if isLegacyConfigNode(value) {
+		// Unmarshal inline limits using the legacy flat format
+		type legacyConfig struct {
+			DefaultOverrides                LegacyOverrides                 `yaml:",inline"`
+			PerTenantOverrideConfig         string                          `yaml:"per_tenant_override_config"`
+			PerTenantOverridePeriod         model.Duration                  `yaml:"per_tenant_override_period"`
+			UserConfigurableOverridesConfig UserConfigurableOverridesConfig `yaml:"user_configurable_overrides"`
+		}
+		var legacyCfg legacyConfig
+		legacyCfg.DefaultOverrides = c.Defaults.toLegacy()
+		legacyCfg.PerTenantOverrideConfig = c.PerTenantOverrideConfig
+		legacyCfg.PerTenantOverridePeriod = c.PerTenantOverridePeriod
+		legacyCfg.UserConfigurableOverridesConfig = c.UserConfigurableOverridesConfig
+
+		if err := value.Decode(&legacyCfg); err != nil {
+			return fmt.Errorf("failed to unmarshal legacy config: %w", err)
+		}
+
+		c.Defaults = legacyCfg.DefaultOverrides.toNewLimits()
+		c.PerTenantOverrideConfig = legacyCfg.PerTenantOverrideConfig
+		c.PerTenantOverridePeriod = legacyCfg.PerTenantOverridePeriod
+		c.UserConfigurableOverridesConfig = legacyCfg.UserConfigurableOverridesConfig
+		c.ConfigType = ConfigTypeLegacy
 		return nil
 	}
 
-	// Try to unmarshal inline limits
-	type legacyConfig struct {
-		DefaultOverrides LegacyOverrides `yaml:",inline"`
-
-		PerTenantOverrideConfig string         `yaml:"per_tenant_override_config"`
-		PerTenantOverridePeriod model.Duration `yaml:"per_tenant_override_period"`
-
-		UserConfigurableOverridesConfig UserConfigurableOverridesConfig `yaml:"user_configurable_overrides"`
+	type rawConfig Config
+	if err := value.Decode((*rawConfig)(c)); err != nil {
+		return err
 	}
-	var legacyCfg legacyConfig
-	legacyCfg.DefaultOverrides = c.Defaults.toLegacy()
-	legacyCfg.PerTenantOverrideConfig = c.PerTenantOverrideConfig
-	legacyCfg.PerTenantOverridePeriod = c.PerTenantOverridePeriod
-	legacyCfg.UserConfigurableOverridesConfig = c.UserConfigurableOverridesConfig
-
-	if legacyErr := unmarshal(&legacyCfg); legacyErr != nil {
-		return fmt.Errorf("failed to unmarshal config: %w; also failed in legacy format: %w", err, legacyErr)
-	}
-
-	c.Defaults = legacyCfg.DefaultOverrides.toNewLimits()
-	c.PerTenantOverrideConfig = legacyCfg.PerTenantOverrideConfig
-	c.PerTenantOverridePeriod = legacyCfg.PerTenantOverridePeriod
-	c.UserConfigurableOverridesConfig = legacyCfg.UserConfigurableOverridesConfig
-	c.ConfigType = ConfigTypeLegacy
+	c.ConfigType = ConfigTypeNew
 	return nil
 }
 

--- a/modules/overrides/config_test.go
+++ b/modules/overrides/config_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
 
-	tempo_util "github.com/grafana/tempo/pkg/util"
+	"github.com/grafana/tempo/pkg/util"
 
 	"github.com/grafana/tempo/modules/overrides/histograms"
 	"github.com/grafana/tempo/modules/overrides/userconfigurable/client"
@@ -162,7 +162,7 @@ user_configurable_overrides:
 
 	legacyCfg := Config{}
 	legacyCfg.RegisterFlagsAndApplyDefaults(&flag.FlagSet{})
-	assert.NoError(t, tempo_util.UnmarshalStrict([]byte(legacyRawYaml), &legacyCfg))
+	assert.NoError(t, util.YAMLUnmarshalStrict([]byte(legacyRawYaml), &legacyCfg))
 	assert.Equal(t, ConfigTypeLegacy, legacyCfg.ConfigType)
 	legacyCfg.ConfigType = ConfigTypeNew // For comparison vs new config
 
@@ -240,7 +240,7 @@ user_configurable_overrides:
 `
 	cfg := Config{}
 	cfg.RegisterFlagsAndApplyDefaults(&flag.FlagSet{})
-	assert.NoError(t, tempo_util.UnmarshalStrict([]byte(rawYaml), &cfg))
+	assert.NoError(t, util.YAMLUnmarshalStrict([]byte(rawYaml), &cfg))
 
 	assert.Equal(t, cfg, legacyCfg)
 }

--- a/modules/overrides/config_test.go
+++ b/modules/overrides/config_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
+
+	tempo_util "github.com/grafana/tempo/pkg/util"
 
 	"github.com/grafana/tempo/modules/overrides/histograms"
 	"github.com/grafana/tempo/modules/overrides/userconfigurable/client"
@@ -160,7 +162,7 @@ user_configurable_overrides:
 
 	legacyCfg := Config{}
 	legacyCfg.RegisterFlagsAndApplyDefaults(&flag.FlagSet{})
-	assert.NoError(t, yaml.UnmarshalStrict([]byte(legacyRawYaml), &legacyCfg))
+	assert.NoError(t, tempo_util.UnmarshalStrict([]byte(legacyRawYaml), &legacyCfg))
 	assert.Equal(t, ConfigTypeLegacy, legacyCfg.ConfigType)
 	legacyCfg.ConfigType = ConfigTypeNew // For comparison vs new config
 
@@ -238,7 +240,7 @@ user_configurable_overrides:
 `
 	cfg := Config{}
 	cfg.RegisterFlagsAndApplyDefaults(&flag.FlagSet{})
-	assert.NoError(t, yaml.UnmarshalStrict([]byte(rawYaml), &cfg))
+	assert.NoError(t, tempo_util.UnmarshalStrict([]byte(rawYaml), &cfg))
 
 	assert.Equal(t, cfg, legacyCfg)
 }

--- a/modules/overrides/overrides_tenant_status_http.go
+++ b/modules/overrides/overrides_tenant_status_http.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/grafana/tempo/pkg/util"
 )

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -15,7 +15,7 @@ import (
 	"github.com/grafana/dskit/runtimeconfig"
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/grafana/tempo/modules/overrides/histograms"
 	"github.com/grafana/tempo/pkg/sharedconfig"
@@ -36,25 +36,65 @@ type perTenantOverrides struct {
 	ConfigType ConfigType `yaml:"-"` // ConfigType is the type of overrides config we are using: legacy or new
 }
 
-func (o *perTenantOverrides) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	// Note: this implementation relies on callers using yaml.UnmarshalStrict. In non-strict mode
-	// unmarshal() will not return an error for legacy configuration and we return immediately.
+// newFormatOverridesKeys is the complete set of valid top-level YAML keys for an Overrides value
+// in the new per-tenant overrides format. Any key outside this set indicates a legacy flat-format entry.
+var newFormatOverridesKeys = map[string]bool{
+	"ingestion":        true,
+	"read":             true,
+	"compaction":       true,
+	"metrics_generator": true,
+	"forwarders":       true,
+	"global":           true,
+	"storage":          true,
+	"cost_attribution": true,
+}
 
-	// Try to unmarshal it normally
-	type rawConfig perTenantOverrides
-	if err := unmarshal((*rawConfig)(o)); err == nil {
-		o.ConfigType = ConfigTypeNew
+// isLegacyPerTenantOverridesNode inspects the YAML node for the per-tenant overrides config and
+// returns true if any tenant entry uses the legacy flat-key format.
+func isLegacyPerTenantOverridesNode(node *yaml.Node) bool {
+	if node.Kind != yaml.MappingNode {
+		return false
+	}
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		if node.Content[i].Value != "overrides" {
+			continue
+		}
+		overridesMap := node.Content[i+1]
+		if overridesMap.Kind != yaml.MappingNode {
+			return false
+		}
+		// Check each tenant's overrides value for legacy flat keys.
+		for j := 1; j < len(overridesMap.Content); j += 2 {
+			tenantLimits := overridesMap.Content[j]
+			if tenantLimits.Kind != yaml.MappingNode {
+				continue
+			}
+			for k := 0; k < len(tenantLimits.Content); k += 2 {
+				if !newFormatOverridesKeys[tenantLimits.Content[k].Value] {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func (o *perTenantOverrides) UnmarshalYAML(value *yaml.Node) error {
+	if isLegacyPerTenantOverridesNode(value) {
+		var legacyConfig perTenantLegacyOverrides
+		if err := value.Decode(&legacyConfig); err != nil {
+			return err
+		}
+		*o = legacyConfig.toNewOverrides()
+		o.ConfigType = ConfigTypeLegacy
 		return nil
 	}
 
-	var legacyConfig perTenantLegacyOverrides
-	if err := unmarshal(&legacyConfig); err != nil {
+	type rawConfig perTenantOverrides
+	if err := value.Decode((*rawConfig)(o)); err != nil {
 		return err
 	}
-
-	*o = legacyConfig.toNewOverrides()
-	o.ConfigType = ConfigTypeLegacy
-
+	o.ConfigType = ConfigTypeNew
 	return nil
 }
 
@@ -87,7 +127,7 @@ func loadPerTenantOverrides(validator Validator, typ ConfigType, expandEnv bool)
 		}
 
 		decoder := yaml.NewDecoder(r)
-		decoder.SetStrict(true)
+		decoder.KnownFields(true)
 		if err := decoder.Decode(&overrides); err != nil {
 			return nil, err
 		}
@@ -215,20 +255,23 @@ func (o *runtimeConfigOverridesManager) tenantOverrides() *perTenantOverrides {
 }
 
 // statusRuntimeConfig is a struct used to print the complete runtime config (defaults + overrides)
+// statusRuntimeConfig is the marshaling type for WriteStatusRuntimeConfig.
+// Note: perTenantOverrides cannot be used with yaml:",inline" here because yaml.v3 silently
+// drops inline fields whose type implements yaml.Unmarshaler but not yaml.Marshaler.
 type statusRuntimeConfig struct {
-	Defaults           *Overrides         `yaml:"defaults"`
-	PerTenantOverrides perTenantOverrides `yaml:",inline"`
+	Defaults     *Overrides            `yaml:"defaults"`
+	TenantLimits map[string]*Overrides `yaml:"overrides"`
 }
 
 func (o *runtimeConfigOverridesManager) WriteStatusRuntimeConfig(w io.Writer, r *http.Request) error {
 	var tenantOverrides perTenantOverrides
-	if o.tenantOverrides() != nil {
-		tenantOverrides = *o.tenantOverrides()
+	if to := o.tenantOverrides(); to != nil {
+		tenantOverrides = *to
 	}
 	var output interface{}
 	cfg := statusRuntimeConfig{
-		Defaults:           o.defaultLimits,
-		PerTenantOverrides: tenantOverrides,
+		Defaults:     o.defaultLimits,
+		TenantLimits: tenantOverrides.TenantLimits,
 	}
 
 	mode := r.URL.Query().Get("mode")
@@ -244,7 +287,7 @@ func (o *runtimeConfigOverridesManager) WriteStatusRuntimeConfig(w io.Writer, r 
 			}
 		}
 
-		cfgYaml, err := util.YAMLMarshalUnmarshal(cfg.PerTenantOverrides)
+		cfgYaml, err := util.YAMLMarshalUnmarshal(tenantOverrides)
 		if err != nil {
 			return err
 		}

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -39,14 +39,14 @@ type perTenantOverrides struct {
 // newFormatOverridesKeys is the complete set of valid top-level YAML keys for an Overrides value
 // in the new per-tenant overrides format. Any key outside this set indicates a legacy flat-format entry.
 var newFormatOverridesKeys = map[string]bool{
-	"ingestion":        true,
-	"read":             true,
-	"compaction":       true,
+	"ingestion":         true,
+	"read":              true,
+	"compaction":        true,
 	"metrics_generator": true,
-	"forwarders":       true,
-	"global":           true,
-	"storage":          true,
-	"cost_attribution": true,
+	"forwarders":        true,
+	"global":            true,
+	"storage":           true,
+	"cost_attribution":  true,
 }
 
 // isLegacyPerTenantOverridesNode inspects the YAML node for the per-tenant overrides config and

--- a/modules/overrides/runtime_config_overrides_test.go
+++ b/modules/overrides/runtime_config_overrides_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
 
-	tempo_util "github.com/grafana/tempo/pkg/util"
+	"github.com/grafana/tempo/pkg/util"
 
 	"github.com/grafana/tempo/pkg/sharedconfig"
 	"github.com/grafana/tempo/tempodb/backend"
@@ -564,10 +564,10 @@ func TestRemoteWriteHeaders(t *testing.T) {
 
 	// Verify the YAML output can be unmarshalled back
 	var runtimeConfig struct {
-		Defaults     Overrides            `yaml:"defaults"`
+		Defaults     Overrides             `yaml:"defaults"`
 		TenantLimits map[string]*Overrides `yaml:"overrides"`
 	}
-	require.NoError(t, tempo_util.UnmarshalStrict(buff.Bytes(), &runtimeConfig))
+	require.NoError(t, util.YAMLUnmarshalStrict(buff.Bytes(), &runtimeConfig))
 
 	assert.Equal(t, "<secret>", string(runtimeConfig.Defaults.MetricsGenerator.RemoteWriteHeaders["Authorization"]))
 

--- a/modules/overrides/runtime_config_overrides_test.go
+++ b/modules/overrides/runtime_config_overrides_test.go
@@ -18,7 +18,9 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
+
+	tempo_util "github.com/grafana/tempo/pkg/util"
 
 	"github.com/grafana/tempo/pkg/sharedconfig"
 	"github.com/grafana/tempo/tempodb/backend"
@@ -562,10 +564,10 @@ func TestRemoteWriteHeaders(t *testing.T) {
 
 	// Verify the YAML output can be unmarshalled back
 	var runtimeConfig struct {
-		Defaults           Overrides          `yaml:"defaults"`
-		PerTenantOverrides perTenantOverrides `yaml:",inline"`
+		Defaults     Overrides            `yaml:"defaults"`
+		TenantLimits map[string]*Overrides `yaml:"overrides"`
 	}
-	require.NoError(t, yaml.UnmarshalStrict(buff.Bytes(), &runtimeConfig))
+	require.NoError(t, tempo_util.UnmarshalStrict(buff.Bytes(), &runtimeConfig))
 
 	assert.Equal(t, "<secret>", string(runtimeConfig.Defaults.MetricsGenerator.RemoteWriteHeaders["Authorization"]))
 

--- a/modules/overrides/user_configurable_overrides.go
+++ b/modules/overrides/user_configurable_overrides.go
@@ -17,7 +17,7 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/grafana/tempo/modules/overrides/histograms"
 	userconfigurableoverrides "github.com/grafana/tempo/modules/overrides/userconfigurable/client"

--- a/modules/overrides/user_configurable_overrides_test.go
+++ b/modules/overrides/user_configurable_overrides_test.go
@@ -11,11 +11,11 @@ import (
 	"time"
 
 	"github.com/grafana/dskit/services"
+	"github.com/grafana/tempo/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	tempo_util "github.com/grafana/tempo/pkg/util"
 
 	"github.com/grafana/tempo/modules/overrides/histograms"
 	userconfigurableoverrides "github.com/grafana/tempo/modules/overrides/userconfigurable/client"
@@ -378,7 +378,7 @@ func TestUserConfigOverridesManager_WriteStatusRuntimeConfig(t *testing.T) {
 
 			// Verify the YAML output can be unmarshalled back
 			var config map[string]interface{}
-			require.NoError(t, tempo_util.UnmarshalStrict(w.Body.Bytes(), &config))
+			require.NoError(t, util.YAMLUnmarshalStrict(w.Body.Bytes(), &config))
 
 			require.Contains(t, config, "defaults")
 			require.Contains(t, config, "overrides")

--- a/modules/overrides/user_configurable_overrides_test.go
+++ b/modules/overrides/user_configurable_overrides_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	tempo_util "github.com/grafana/tempo/pkg/util"
 
 	"github.com/grafana/tempo/modules/overrides/histograms"
 	userconfigurableoverrides "github.com/grafana/tempo/modules/overrides/userconfigurable/client"
@@ -378,7 +378,7 @@ func TestUserConfigOverridesManager_WriteStatusRuntimeConfig(t *testing.T) {
 
 			// Verify the YAML output can be unmarshalled back
 			var config map[string]interface{}
-			require.NoError(t, yaml.UnmarshalStrict(w.Body.Bytes(), &config))
+			require.NoError(t, tempo_util.UnmarshalStrict(w.Body.Bytes(), &config))
 
 			require.Contains(t, config, "defaults")
 			require.Contains(t, config, "overrides")

--- a/modules/overrides/userconfigurable/api/api.go
+++ b/modules/overrides/userconfigurable/api/api.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/services"
-	jsoniter "github.com/json-iterator/go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -174,7 +173,7 @@ func (a *UserConfigOverridesAPI) delete(ctx context.Context, userID string, vers
 }
 
 func (a *UserConfigOverridesAPI) parseLimits(body io.Reader) (*client.Limits, error) {
-	d := jsoniter.NewDecoder(body)
+	d := json.NewDecoder(body)
 
 	// error in case of unwanted fields
 	d.DisallowUnknownFields()
@@ -199,12 +198,12 @@ func (a *UserConfigOverridesAPI) assertNoConflictingRuntimeOverrides(ctx context
 
 	// convert overrides.Overrides to client.Limits through marshalling and unmarshalling it from json
 	// this is the easiest way to convert the optional fields
-	marshalledOverrides, err := jsoniter.Marshal(runtimeOverrides)
+	marshalledOverrides, err := json.Marshal(runtimeOverrides)
 	if err != nil {
 		return err
 	}
 	var runtimeLimits client.Limits
-	err = jsoniter.Unmarshal(marshalledOverrides, &runtimeLimits)
+	err = json.Unmarshal(marshalledOverrides, &runtimeLimits)
 	if err != nil {
 		return err
 	}
@@ -241,7 +240,7 @@ func logLimits(limits *client.Limits) string {
 	if limits == nil {
 		return ""
 	}
-	bytes, err := jsoniter.Marshal(limits)
+	bytes, err := json.Marshal(limits)
 	if err != nil {
 		return ""
 	}

--- a/modules/overrides/userconfigurable/api/api_test.go
+++ b/modules/overrides/userconfigurable/api/api_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -11,7 +12,6 @@ import (
 	"time"
 
 	"github.com/grafana/dskit/user"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,7 +44,7 @@ func Test_UserConfigOverridesAPI_overridesHandlers(t *testing.T) {
 	}, backend.VersionNew)
 	require.NoError(t, err)
 
-	postJSON, err := jsoniter.Marshal(&client.Limits{
+	postJSON, err := json.Marshal(&client.Limits{
 		Forwarders: &[]string{"my-updated-forwarder"},
 	})
 	require.NoError(t, err)
@@ -82,7 +82,7 @@ func Test_UserConfigOverridesAPI_overridesHandlers(t *testing.T) {
 			name:           "POST - invalid JSON",
 			handler:        overridesAPI.PostHandler,
 			req:            prepareRequest(tenant, "POST", []byte("not a json")),
-			expResp:        "skipThreeBytes: expect ull, error found in #2 byte of ...|not a json|..., bigger context ...|not a json|...\n",
+			expResp:        "invalid character 'o' in literal null (expecting 'u')\n",
 			expContentType: "text/plain; charset=utf-8",
 			expStatusCode:  400,
 		},
@@ -90,7 +90,7 @@ func Test_UserConfigOverridesAPI_overridesHandlers(t *testing.T) {
 			name:           "POST - unknown field JSON",
 			handler:        overridesAPI.PostHandler,
 			req:            prepareRequest(tenant, "POST", []byte("{\"unknown\":true}")),
-			expResp:        "client.Limits.ReadObject: found unknown field: unknown, error found in #10 byte of ...|{\"unknown\":true}|..., bigger context ...|{\"unknown\":true}|...\n",
+			expResp:        "json: unknown field \"unknown\"\n",
 			expContentType: "text/plain; charset=utf-8",
 			expStatusCode:  400,
 		},
@@ -238,7 +238,7 @@ func Test_UserConfigOverridesAPI_patchOverridesHandlers(t *testing.T) {
 			name:          "PATCH - invalid patch",
 			patch:         `{"newField":true}`,
 			current:       `{"forwarders":["prior-forwarder"]}`,
-			expResp:       "client.Limits.ReadObject: found unknown field: newField, error found in #10 byte of ...|\"newField\":true}|..., bigger context ...|\":{},\"span_metrics\":{},\"host_info\":{}}},\"newField\":true}|...\n",
+			expResp:       "json: unknown field \"newField\"\n",
 			expStatusCode: 400,
 		},
 	}
@@ -518,14 +518,14 @@ func TestUserConfigOverridesAPI_assertConflictingRuntimeOverrides(t *testing.T) 
 
 			w := httptest.NewRecorder()
 
-			json, err := jsoniter.Marshal(tc.request)
+			reqBody, err := json.Marshal(tc.request)
 			assert.NoError(t, err)
 
 			path := "/"
 			if tc.skipConflictingOverridesCheck != "" {
 				path = fmt.Sprintf("%s?%s=%s", path, queryParamSkipConflictingOverridesCheck, tc.skipConflictingOverridesCheck)
 			}
-			r := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(json))
+			r := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(reqBody))
 			r.Header.Set(headerIfMatch, string(version))
 			ctx := user.InjectOrgID(r.Context(), tenant)
 			r = r.WithContext(ctx)
@@ -555,7 +555,7 @@ func prepareRequest(tenant, method string, payload []byte) *http.Request {
 
 func parseJSON(t *testing.T, s string) *client.Limits {
 	var limits client.Limits
-	err := jsoniter.Unmarshal([]byte(s), &limits)
+	err := json.Unmarshal([]byte(s), &limits)
 	require.NoError(t, err)
 	return &limits
 }
@@ -622,7 +622,7 @@ func Test_UserConfigOverridesAPI_CostAttribution(t *testing.T) {
 	overridesAPI.GetHandler(w, req)
 	assert.Equal(t, 200, w.Code)
 	var limits client.Limits
-	err = jsoniter.Unmarshal(w.Body.Bytes(), &limits)
+	err = json.Unmarshal(w.Body.Bytes(), &limits)
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"k8s.namespace.name": "namespace", "k8s.cluster": "cluster"}, *limits.CostAttribution.Dimensions)
 
@@ -635,7 +635,7 @@ func Test_UserConfigOverridesAPI_CostAttribution(t *testing.T) {
 	assert.Equal(t, 200, w.Code)
 
 	// Verify PATCH response body
-	err = jsoniter.Unmarshal(w.Body.Bytes(), &limits)
+	err = json.Unmarshal(w.Body.Bytes(), &limits)
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"k8s.namespace.name": "namespace", "k8s.cluster": "cluster", "namespace": ""}, *limits.CostAttribution.Dimensions)
 
@@ -649,7 +649,7 @@ func Test_UserConfigOverridesAPI_CostAttribution(t *testing.T) {
 	assert.Equal(t, 200, w.Code)
 
 	// Verify PATCH response body
-	err = jsoniter.Unmarshal(w.Body.Bytes(), &limits)
+	err = json.Unmarshal(w.Body.Bytes(), &limits)
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"k8s.namespace.name": "namespace", "k8s.cluster": "cluster", "namespace": "", "k8s.namespace": "namespace"}, *limits.CostAttribution.Dimensions)
 
@@ -659,7 +659,7 @@ func Test_UserConfigOverridesAPI_CostAttribution(t *testing.T) {
 	req = req.WithContext(user.InjectOrgID(req.Context(), tenant))
 	overridesAPI.GetHandler(w, req)
 	assert.Equal(t, 200, w.Code)
-	err = jsoniter.Unmarshal(w.Body.Bytes(), &limits)
+	err = json.Unmarshal(w.Body.Bytes(), &limits)
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"k8s.namespace.name": "namespace", "k8s.cluster": "cluster", "namespace": "", "k8s.namespace": "namespace"}, *limits.CostAttribution.Dimensions)
 	etag := w.Header().Get(headerEtag)

--- a/modules/overrides/userconfigurable/api/http.go
+++ b/modules/overrides/userconfigurable/api/http.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -9,7 +10,6 @@ import (
 	"strconv"
 
 	"github.com/go-kit/log/level"
-	jsoniter "github.com/json-iterator/go"
 	"go.opentelemetry.io/otel/codes"
 
 	"github.com/grafana/tempo/modules/overrides/userconfigurable/client"
@@ -190,7 +190,7 @@ func writeError(w http.ResponseWriter, err error) {
 }
 
 func writeLimits(w http.ResponseWriter, limits *client.Limits, version backend.Version) error {
-	data, err := jsoniter.Marshal(limits)
+	data, err := json.Marshal(limits)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return err

--- a/modules/overrides/userconfigurable/client/client.go
+++ b/modules/overrides/userconfigurable/client/client.go
@@ -10,7 +10,6 @@ import (
 	"path"
 
 	"github.com/go-kit/log/level"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel"
@@ -181,7 +180,7 @@ func (o *clientImpl) Set(ctx context.Context, userID string, limits *Limits, ver
 	ctx, span := tracer.Start(ctx, "clientImpl.Set", trace.WithAttributes(attribute.String("tenant", userID)))
 	defer span.End()
 
-	data, err := jsoniter.Marshal(limits)
+	data, err := json.Marshal(limits)
 	if err != nil {
 		return "", err
 	}

--- a/modules/overrides/userconfigurable/client/limits_test.go
+++ b/modules/overrides/userconfigurable/client/limits_test.go
@@ -1,13 +1,13 @@
 package client
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/grafana/tempo/modules/overrides/histograms"
 	"github.com/grafana/tempo/pkg/sharedconfig"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -144,7 +144,7 @@ func TestLimits_parseJson(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var limits Limits
-			err := jsoniter.Unmarshal([]byte(tc.json), &limits)
+			err := json.Unmarshal([]byte(tc.json), &limits)
 			assert.NoError(t, err)
 
 			assert.Equal(t, tc.expected, limits)

--- a/pkg/docsgen/generate_manifest.go
+++ b/pkg/docsgen/generate_manifest.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 
 	"github.com/grafana/tempo/cmd/tempo/app"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 const ManifestPath = "docs/sources/tempo/configuration/manifest.md"

--- a/pkg/traceql/ast_stringer_test.go
+++ b/pkg/traceql/ast_stringer_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 )
 
 const testExamplesFile = "./test_examples.yaml"

--- a/pkg/traceql/ast_validate_test.go
+++ b/pkg/traceql/ast_validate_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type TestQueries struct {

--- a/pkg/traceql/engine_test.go
+++ b/pkg/traceql/engine_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/grafana/tempo/pkg/collector"
 	"github.com/grafana/tempo/pkg/tempopb"

--- a/pkg/usagestats/reporter_test.go
+++ b/pkg/usagestats/reporter_test.go
@@ -3,6 +3,7 @@ package usagestats
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -12,7 +13,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/kv"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
@@ -154,7 +154,7 @@ func Test_ReportLoop(t *testing.T) {
 	reportsDone := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		var received Report
-		require.NoError(t, jsoniter.NewDecoder(r.Body).Decode(&received))
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&received))
 
 		mtx.Lock()
 		totalReport++

--- a/pkg/usagestats/seed.go
+++ b/pkg/usagestats/seed.go
@@ -1,10 +1,10 @@
 package usagestats
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
-	jsoniter "github.com/json-iterator/go"
 	prom "github.com/prometheus/prometheus/web/api/v1"
 
 	"github.com/grafana/dskit/kv/memberlist"
@@ -72,13 +72,13 @@ type jsonCodec struct{}
 // currently crashing because the in-memory kvstore use a singleton.
 func (jsonCodec) Decode(data []byte) (interface{}, error) {
 	var seed ClusterSeed
-	if err := jsoniter.ConfigFastest.Unmarshal(data, &seed); err != nil {
+	if err := json.Unmarshal(data, &seed); err != nil {
 		return nil, err
 	}
 	return &seed, nil
 }
 
 func (jsonCodec) Encode(obj interface{}) ([]byte, error) {
-	return jsoniter.ConfigFastest.Marshal(obj)
+	return json.Marshal(obj)
 }
 func (jsonCodec) CodecID() string { return "usagestats.jsonCodec" }

--- a/pkg/usagestats/stats.go
+++ b/pkg/usagestats/stats.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/tempo/cmd/tempo/build"
 
 	"github.com/cespare/xxhash/v2"
-	jsoniter "github.com/json-iterator/go"
 	prom "github.com/prometheus/prometheus/web/api/v1"
 	"go.uber.org/atomic"
 )
@@ -47,7 +46,7 @@ type Report struct {
 // sendReport sends the report to the stats server
 func sendReport(ctx context.Context, seed *ClusterSeed, interval time.Time) error {
 	report := buildReport(seed, interval)
-	out, err := jsoniter.MarshalIndent(report, "", " ")
+	out, err := json.MarshalIndent(report, "", " ")
 	if err != nil {
 		return err
 	}

--- a/pkg/usagestats/stats_test.go
+++ b/pkg/usagestats/stats_test.go
@@ -1,6 +1,7 @@
 package usagestats
 
 import (
+	"encoding/json"
 	"runtime"
 	"sync"
 	"testing"
@@ -10,7 +11,6 @@ import (
 	"github.com/grafana/tempo/cmd/tempo/build"
 
 	"github.com/google/uuid"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -62,7 +62,7 @@ func Test_BuildReport(t *testing.T) {
 	require.Equal(t, r.Metrics["query_throughput"].(map[string]interface{})["avg"], float64(25+300+5)/3)
 	require.Equal(t, r.Metrics["active_tenants"], int64(3))
 
-	out, _ := jsoniter.MarshalIndent(r, "", " ")
+	out, _ := json.MarshalIndent(r, "", " ")
 	t.Log(string(out))
 }
 
@@ -113,7 +113,7 @@ func Test_BuildStats(t *testing.T) {
 	require.Equal(t, r.CreatedAt, time.Time{})
 	require.Equal(t, r.Interval, time.Time{})
 
-	out, _ := jsoniter.MarshalIndent(r, "", " ")
+	out, _ := json.MarshalIndent(r, "", " ")
 	t.Log(string(out))
 }
 

--- a/pkg/util/config.go
+++ b/pkg/util/config.go
@@ -6,8 +6,8 @@ import (
 )
 
 // DiffConfig utility function that returns the diff between two config map objects
-func DiffConfig(defaultConfig, actualConfig map[interface{}]interface{}) (map[interface{}]interface{}, error) {
-	output := make(map[interface{}]interface{})
+func DiffConfig(defaultConfig, actualConfig map[string]interface{}) (map[string]interface{}, error) {
+	output := make(map[string]interface{})
 
 	for key, value := range actualConfig {
 
@@ -47,10 +47,11 @@ func DiffConfig(defaultConfig, actualConfig map[interface{}]interface{}) (map[in
 			if defaultValue != nil {
 				output[key] = v
 			}
-		case map[interface{}]interface{}:
-			defaultV, ok := defaultValue.(map[interface{}]interface{})
+		case map[string]interface{}:
+			defaultV, ok := defaultValue.(map[string]interface{})
 			if !ok {
 				output[key] = value
+				continue
 			}
 			diff, err := DiffConfig(defaultV, v)
 			if err != nil {

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -17,7 +17,7 @@ import (
 	"github.com/golang/snappy"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 )
 
 const messageSizeLargerErrFmt = "received message larger than max (%d vs %d)"

--- a/pkg/util/listtomap/list_to_map.go
+++ b/pkg/util/listtomap/list_to_map.go
@@ -3,7 +3,7 @@ package listtomap
 import (
 	"encoding/json"
 
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 )
 
 type ListToMap map[string]struct{}
@@ -29,10 +29,9 @@ func (l ListToMap) MarshalYAML() (interface{}, error) {
 }
 
 // UnmarshalYAML implements the Unmarshaler interface of the yaml pkg.
-func (l *ListToMap) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	list := make([]string, 0)
-	err := unmarshal(&list)
-	if err != nil {
+func (l *ListToMap) UnmarshalYAML(value *yaml.Node) error {
+	var list []string
+	if err := value.Decode(&list); err != nil {
 		return err
 	}
 

--- a/pkg/util/listtomap/list_to_map_test.go
+++ b/pkg/util/listtomap/list_to_map_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestListToMapMarshalOperationsYAML(t *testing.T) {

--- a/pkg/util/yaml.go
+++ b/pkg/util/yaml.go
@@ -1,19 +1,31 @@
 package util
 
-import "go.yaml.in/yaml/v2"
+import (
+	"bytes"
+
+	"go.yaml.in/yaml/v3"
+)
 
 // YAMLMarshalUnmarshal utility function that converts a YAML interface in a map
 // doing marshal and unmarshal of the parameter
-func YAMLMarshalUnmarshal(in interface{}) (map[interface{}]interface{}, error) {
+func YAMLMarshalUnmarshal(in interface{}) (map[string]interface{}, error) {
 	yamlBytes, err := yaml.Marshal(in)
 	if err != nil {
 		return nil, err
 	}
 
-	object := make(map[interface{}]interface{})
+	object := make(map[string]interface{})
 	if err := yaml.Unmarshal(yamlBytes, object); err != nil {
 		return nil, err
 	}
 
 	return object, nil
+}
+
+// UnmarshalStrict unmarshals YAML and returns an error for any unknown fields.
+// yaml.v3 removed yaml.UnmarshalStrict; this is the canonical replacement.
+func UnmarshalStrict(data []byte, v interface{}) error {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	return dec.Decode(v)
 }

--- a/pkg/util/yaml.go
+++ b/pkg/util/yaml.go
@@ -22,9 +22,9 @@ func YAMLMarshalUnmarshal(in interface{}) (map[string]interface{}, error) {
 	return object, nil
 }
 
-// UnmarshalStrict unmarshals YAML and returns an error for any unknown fields.
-// yaml.v3 removed yaml.UnmarshalStrict; this is the canonical replacement.
-func UnmarshalStrict(data []byte, v interface{}) error {
+// YAMLUnmarshalStrict unmarshals YAML and returns an error for any unknown fields.
+// go.yaml.in/yaml/v3 removed yaml.UnmarshalStrict; this is the canonical replacement.
+func YAMLUnmarshalStrict(data []byte, v interface{}) error {
 	dec := yaml.NewDecoder(bytes.NewReader(data))
 	dec.KnownFields(true)
 	return dec.Decode(v)

--- a/tempodb/backend/s3/config_test.go
+++ b/tempodb/backend/s3/config_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/grafana/dskit/flagext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestSSEConfigEncryptionKeyRedacted(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:

Remove outdated dependencies for YAML and JSON (un)marshaling and replace them with maintained and more consistent alternatives.

YAML:
- Replace `gopkg.in/yaml.v3` with `go.yaml.in/yaml/v3`
  - `gopkg.in/yaml.v3` is no longer maintained (see [go-yaml/yaml](https://github.com/go-yaml/yaml))
- Migrate from `go.yaml.in/yaml/v2` to `go.yaml.in/yaml/v3`
  - v3 provides a more flexible `Unmarshaler` interface
    - Simplifies custom unmarshaling logic
    - Removes reliance on error-based control flow (e.g., for legacy overrides detection)
    - Enables a cleaner extension mechanism for overrides
  - v3 is already used in Tempo, so this avoids mixing two different APIs (v2 and v3)
    - v2 will remain as an indirect dependency
  - v3 is close to the latest v4 version (v4 is the only version being actively developed)
    - This migration makes a future upgrade to v4 easier

JSON:
- Replace `github.com/json-iterator/go` with the standard library `encoding/json`
  - `json-iterator` is no longer maintained (see [json-iterator/go](https://github.com/json-iterator/go))
  - Although `json-iterator` can be faster, it was mainly used in the overrides API where performance is not critical
  - For performance-sensitive JSON workloads, we should prefer `github.com/bytedance/sonic` (already a direct dependency)

Motivation:
- Remove unmaintained dependencies
- Align with maintained and widely supported libraries
- Prepare for future migrations (e.g., YAML v4, encoding/json/v2)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`