### PR TITLE
Add extension mechanism for per-tenant Overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   Slightly changes the array matching semantics of != and !~ operators and introduces stricter rules for regex literals.
 * [FEATURE] metrics-generator: Add per-label limiter to control cardinality [#6414](https://github.com/grafana/tempo/pull/6414) (@electron0zero)
   Adds `max_cardinality_per_label` per per-tenant override and new metrics to estimate per label cardinality demand estimate.
+* [FEATURE] Add an extension mechanism for per-tenant overrides [#6758](https://github.com/grafana/tempo/pull/6758) (@stoewer)
 * [ENHANCEMENT] Block builder: deduplicate spans within traces during block creation and track removed duplicates via `tempo_block_builder_spans_deduped_total` metric [#6539](https://github.com/grafana/tempo/pull/6539) (@zhxiaogg)
 * [ENHANCEMENT] Add new alerts and runbooks entries [#6276](https://github.com/grafana/tempo/pull/6276) (@javiermolinar)
 * [ENHANCEMENT] Double the maximum number of dedicated string columns in vParquet5 and update tempo-cli to determine the optimum number for the data [#6282](https://github.com/grafana/tempo/pull/6282) (@mdisibio)

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -305,11 +305,15 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// unmarshal() will not return an error for legacy configuration and we return immediately.
 
 	// Try to unmarshal it normally. Overrides.UnmarshalYAML calls processExtensions for c.Defaults.
+	// If the error is an extensionError, the config is in the new format but misconfigured.
 	type rawConfig Config
 	err := unmarshal((*rawConfig)(c))
 	if err == nil {
 		c.ConfigType = ConfigTypeNew
 		return nil
+	}
+	if isExtensionError(err) {
+		return err
 	}
 
 	// Try to unmarshal inline limits

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -341,11 +341,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return fmt.Errorf("defaults: %w", err)
 	}
 
-	var convErr error
-	c.Defaults, convErr = legacyCfg.DefaultOverrides.toNewLimits()
-	if convErr != nil {
-		return fmt.Errorf("failed to convert legacy defaults: %w", convErr)
-	}
+	c.Defaults = *legacyCfg.DefaultOverrides.toNewLimits()
 	if err := processExtensions(&c.Defaults); err != nil {
 		return fmt.Errorf("defaults: %w", err)
 	}

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -345,9 +345,6 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	c.Defaults = *legacyCfg.DefaultOverrides.toNewLimits()
-	if err := processExtensions(&c.Defaults); err != nil {
-		return fmt.Errorf("defaults: %w", err)
-	}
 	c.PerTenantOverrideConfig = legacyCfg.PerTenantOverrideConfig
 	c.PerTenantOverridePeriod = legacyCfg.PerTenantOverridePeriod
 	c.UserConfigurableOverridesConfig = legacyCfg.UserConfigurableOverridesConfig

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -212,15 +212,24 @@ type Overrides struct {
 	// Storage enforced overrides.
 	Storage         StorageOverrides         `yaml:"storage,omitempty" json:"storage,omitempty"`
 	CostAttribution CostAttributionOverrides `yaml:"cost_attribution,omitempty" json:"cost_attribution,omitempty"`
-
-	// Extra captures fields not recognised by this struct. This allows systems vendoring tempo to add their own overrides
-	Extra map[string]any `yaml:",inline" json:"-"`
+	// Extensions captures fields not recognised by this struct, enables systems vendoring tempo to extend overrides.
+	// After UnmarshalJSON or processExtensions(), all values are typed Extension instances keyed by Key().
+	// Raw map[string]any values are only present transiently after YAML unmarshal, before processExtensions is called.
+	Extensions map[string]any `yaml:",inline" json:"-"`
 }
 
 // knownOverridesJSONFields returns the JSON key names declared on Overrides
 var knownOverridesJSONFields = sync.OnceValue(func() map[string]struct{} {
 	return fieldNamesFor(Overrides{}, "json")
 })
+
+func (o *Overrides) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type plain Overrides
+	if err := unmarshal((*plain)(o)); err != nil {
+		return err
+	}
+	return processExtensions(o)
+}
 
 func (o *Overrides) UnmarshalJSON(data []byte) error {
 	type plain Overrides
@@ -240,15 +249,15 @@ func (o *Overrides) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	o.Extra = make(map[string]any, len(raw))
+	o.Extensions = make(map[string]any, len(raw))
 	for k, v := range raw {
 		var val any
 		if err := json.Unmarshal(v, &val); err != nil {
 			return err
 		}
-		o.Extra[k] = val
+		o.Extensions[k] = val
 	}
-	return nil
+	return processExtensions(o)
 }
 
 func (o Overrides) MarshalJSON() ([]byte, error) {
@@ -257,7 +266,7 @@ func (o Overrides) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(o.Extra) == 0 {
+	if len(o.Extensions) == 0 {
 		return data, nil
 	}
 
@@ -265,7 +274,7 @@ func (o Overrides) MarshalJSON() ([]byte, error) {
 	if err := json.Unmarshal(data, &m); err != nil {
 		return nil, err
 	}
-	for k, v := range o.Extra {
+	for k, v := range o.Extensions {
 		if _, exists := m[k]; exists {
 			continue // known fields take precedence
 		}
@@ -295,7 +304,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// Note: this implementation relies on callers using yaml.UnmarshalStrict. In non-strict mode
 	// unmarshal() will not return an error for legacy configuration and we return immediately.
 
-	// Try to unmarshal it normally
+	// Try to unmarshal it normally. Overrides.UnmarshalYAML calls processExtensions for c.Defaults.
 	type rawConfig Config
 	err := unmarshal((*rawConfig)(c))
 	if err == nil {
@@ -322,7 +331,20 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return fmt.Errorf("failed to unmarshal config: %w; also failed in legacy format: %w", err, legacyErr)
 	}
 
-	c.Defaults = legacyCfg.DefaultOverrides.toNewLimits()
+	// Ensure legacy extension flat keys are converted to typed instances before toNewLimits.
+	// processLegacyExtensions may not be triggered automatically for inline struct fields.
+	if err := processLegacyExtensions(&legacyCfg.DefaultOverrides); err != nil {
+		return fmt.Errorf("defaults: %w", err)
+	}
+
+	var convErr error
+	c.Defaults, convErr = legacyCfg.DefaultOverrides.toNewLimits()
+	if convErr != nil {
+		return fmt.Errorf("failed to convert legacy defaults: %w", convErr)
+	}
+	if err := processExtensions(&c.Defaults); err != nil {
+		return fmt.Errorf("defaults: %w", err)
+	}
 	c.PerTenantOverrideConfig = legacyCfg.PerTenantOverrideConfig
 	c.PerTenantOverridePeriod = legacyCfg.PerTenantOverridePeriod
 	c.UserConfigurableOverridesConfig = legacyCfg.UserConfigurableOverridesConfig

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -246,6 +246,8 @@ func (o *Overrides) UnmarshalJSON(data []byte) error {
 		delete(raw, key)
 	}
 	if len(raw) == 0 {
+		// No extension keys in this payload; clear any stale Extensions from a prior decode.
+		o.Extensions = nil
 		return nil
 	}
 

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -1,9 +1,13 @@
 package overrides
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
+	"reflect"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/prometheus/common/config"
@@ -208,6 +212,70 @@ type Overrides struct {
 	// Storage enforced overrides.
 	Storage         StorageOverrides         `yaml:"storage,omitempty" json:"storage,omitempty"`
 	CostAttribution CostAttributionOverrides `yaml:"cost_attribution,omitempty" json:"cost_attribution,omitempty"`
+
+	// Extra captures fields not recognised by this struct. This allows systems vendoring tempo to add their own overrides
+	Extra map[string]any `yaml:",inline" json:"-"`
+}
+
+// knownOverridesJSONFields returns the JSON key names declared on Overrides
+var knownOverridesJSONFields = sync.OnceValue(func() map[string]struct{} {
+	return fieldNamesFor(Overrides{}, "json")
+})
+
+func (o *Overrides) UnmarshalJSON(data []byte) error {
+	type plain Overrides
+	if err := json.Unmarshal(data, (*plain)(o)); err != nil {
+		return err
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	for key := range knownOverridesJSONFields() {
+		delete(raw, key)
+	}
+	if len(raw) == 0 {
+		return nil
+	}
+
+	o.Extra = make(map[string]any, len(raw))
+	for k, v := range raw {
+		var val any
+		if err := json.Unmarshal(v, &val); err != nil {
+			return err
+		}
+		o.Extra[k] = val
+	}
+	return nil
+}
+
+func (o Overrides) MarshalJSON() ([]byte, error) {
+	type plain Overrides
+	data, err := json.Marshal(plain(o))
+	if err != nil {
+		return nil, err
+	}
+	if len(o.Extra) == 0 {
+		return data, nil
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	for k, v := range o.Extra {
+		if _, exists := m[k]; exists {
+			continue // known fields take precedence
+		}
+		b, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		m[k] = b
+	}
+	return json.Marshal(m)
 }
 
 type Config struct {
@@ -325,4 +393,21 @@ func (u *Uint32Value) Set(s string) error {
 	}
 	*u = Uint32Value(v)
 	return nil
+}
+
+func fieldNamesFor(v any, tagKey string) map[string]struct{} {
+	t := reflect.TypeOf(v)
+	fields := make(map[string]struct{}, t.NumField())
+	for field := range t.Fields() {
+		tag := field.Tag.Get(tagKey)
+		if tag == "-" || tag == ",inline" {
+			continue
+		}
+		name, _, _ := strings.Cut(tag, ",")
+		if name == "" {
+			name = field.Name
+		}
+		fields[name] = struct{}{}
+	}
+	return fields
 }

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -314,7 +314,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		c.ConfigType = ConfigTypeNew
 		return nil
 	}
-	if isExtensionError(err) {
+
+	// Fail only on extension-specific errors, otherwise fallback to legacy mode
+	if isExtensionError(err) || isExtensionKeyError(err) {
 		return err
 	}
 

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -212,9 +212,8 @@ type Overrides struct {
 	// Storage enforced overrides.
 	Storage         StorageOverrides         `yaml:"storage,omitempty" json:"storage,omitempty"`
 	CostAttribution CostAttributionOverrides `yaml:"cost_attribution,omitempty" json:"cost_attribution,omitempty"`
-	// Extensions captures fields not recognised by this struct, enables systems vendoring tempo to extend overrides.
-	// After UnmarshalJSON or processExtensions(), all values are typed Extension instances keyed by Key().
-	// Raw map[string]any values are only present transiently after YAML unmarshal, before processExtensions is called.
+	// Extensions holds per-tenant overrides added by vendoring applications via RegisterExtension.
+	// Values are typed Extension instances after unmarshal.
 	Extensions map[string]any `yaml:",inline" json:"-"`
 }
 

--- a/modules/overrides/config_legacy.go
+++ b/modules/overrides/config_legacy.go
@@ -189,6 +189,18 @@ var knownLegacyOverridesJSONFields = sync.OnceValue(func() map[string]struct{} {
 	return fieldNamesFor(LegacyOverrides{}, "json")
 })
 
+// knownLegacyOverridesYAMLFields returns the YAML key names declared on LegacyOverrides.
+var knownLegacyOverridesYAMLFields = sync.OnceValue(func() map[string]struct{} {
+	return fieldNamesFor(LegacyOverrides{}, "yaml")
+})
+
+// isKnownLegacyOverridesField reports whether key matches any YAML or JSON field
+func isKnownLegacyOverridesField(key string) bool {
+	_, inJSON := knownLegacyOverridesJSONFields()[key]
+	_, inYAML := knownLegacyOverridesYAMLFields()[key]
+	return inJSON || inYAML
+}
+
 func (l *LegacyOverrides) UnmarshalJSON(data []byte) error {
 	type plain LegacyOverrides
 	if err := json.Unmarshal(data, (*plain)(l)); err != nil {

--- a/modules/overrides/config_legacy.go
+++ b/modules/overrides/config_legacy.go
@@ -176,11 +176,7 @@ type LegacyOverrides struct {
 	// tempodb limits
 	DedicatedColumns backend.DedicatedColumns `yaml:"parquet_dedicated_columns" json:"parquet_dedicated_columns"`
 
-	// Extensions captures fields not recognised by the above fields.
-	// After UnmarshalJSON or UnmarshalYAML (via processLegacyExtensions), typed Extension instances
-	// are stored here keyed by their nested Key() (e.g. "my_ext"), matching the semantics of
-	// Overrides.Extensions. The flat wire format (e.g. "my_ext_field") is only used during
-	// serialization, handled by MarshalJSON and MarshalYAML.
+	// Extensions mirrors Overrides.Extensions: typed instances keyed by nested Key() after unmarshal.
 	Extensions map[string]any `yaml:",inline" json:"-"`
 }
 
@@ -230,9 +226,8 @@ func (l *LegacyOverrides) UnmarshalJSON(data []byte) error {
 		l.Extensions[k] = val
 	}
 
-	// processLegacyExtensions converts registered extension flat keys (e.g. "my_ext_field") to
-	// typed instances keyed by their nested Key() (e.g. "my_ext"), matching Overrides.Extensions.
-	// processExtensions must NOT be called here: it expects nested keys, not flat legacy keys.
+	// Convert flat legacy keys to typed instances; processExtensions must not be called here
+	// as it expects nested keys (e.g. "my_ext"), not flat legacy keys (e.g. "my_ext_field").
 	return processLegacyExtensions(l)
 }
 
@@ -250,7 +245,7 @@ func (l LegacyOverrides) MarshalJSON() ([]byte, error) {
 	if err := json.Unmarshal(data, &m); err != nil {
 		return nil, err
 	}
-	// Flatten typed Extension instances to their legacy flat keys; copy other entries as-is.
+	// Flatten typed extensions to legacy flat keys; copy other entries as-is.
 	for k, v := range l.Extensions {
 		if ext, ok := v.(Extension); ok {
 			for fk, fv := range ext.ToLegacy() {
@@ -291,8 +286,7 @@ func (l LegacyOverrides) MarshalYAML() (interface{}, error) {
 	if len(l.Extensions) == 0 {
 		return plain(l), nil
 	}
-	// Flatten typed Extension instances to their legacy flat keys before marshaling,
-	// so that the YAML wire format uses flat keys (e.g. "my_ext_field"), not the nested key.
+	// Flatten typed extensions to legacy flat keys so the YAML wire format matches the legacy shape.
 	knownLegacy := knownLegacyOverridesJSONFields()
 	flat := flattenExtensionEntries(l.Extensions)
 	filtered := make(map[string]any, len(flat))
@@ -394,8 +388,7 @@ func (l *LegacyOverrides) toNewLimits() *Overrides {
 		},
 	}
 
-	// Extensions are already typed instances after processLegacyExtensions ran at unmarshal time.
-	// Simply copy them; processExtensions called by the caller will validate them.
+	// Extensions are already typed; the caller invokes processExtensions to validate them.
 	if len(l.Extensions) > 0 {
 		o.Extensions = make(map[string]any, len(l.Extensions))
 		for k, v := range l.Extensions {

--- a/modules/overrides/config_legacy.go
+++ b/modules/overrides/config_legacy.go
@@ -2,7 +2,6 @@ package overrides
 
 import (
 	"encoding/json"
-	"fmt"
 	"sync"
 	"time"
 
@@ -285,7 +284,7 @@ func (l LegacyOverrides) MarshalYAML() (interface{}, error) {
 	return plain(cp), nil
 }
 
-func (l *LegacyOverrides) toNewLimits() (Overrides, error) {
+func (l *LegacyOverrides) toNewLimits() *Overrides {
 	o := Overrides{
 		Ingestion: IngestionOverrides{
 			RateStrategy:           l.IngestionRateStrategy,
@@ -371,6 +370,7 @@ func (l *LegacyOverrides) toNewLimits() (Overrides, error) {
 			MaxCardinality: l.CostAttribution.MaxCardinality,
 		},
 	}
+
 	// Extensions are already typed instances after processLegacyExtensions ran at unmarshal time.
 	// Simply copy them; processExtensions called by the caller will validate them.
 	if len(l.Extensions) > 0 {
@@ -379,7 +379,8 @@ func (l *LegacyOverrides) toNewLimits() (Overrides, error) {
 			o.Extensions[k] = v
 		}
 	}
-	return o, nil
+
+	return &o
 }
 
 // perTenantLegacyOverrides represents the Overrides config file with the legacy representation
@@ -394,11 +395,7 @@ func (l *perTenantLegacyOverrides) toNewOverrides() (perTenantOverrides, error) 
 	}
 
 	for tenantID, legacyLimits := range l.TenantLimits {
-		limits, err := legacyLimits.toNewLimits()
-		if err != nil {
-			return perTenantOverrides{}, fmt.Errorf("tenant %q: %w", tenantID, err)
-		}
-		overrides.TenantLimits[tenantID] = &limits
+		overrides.TenantLimits[tenantID] = legacyLimits.toNewLimits()
 	}
 
 	return overrides, nil

--- a/modules/overrides/config_legacy.go
+++ b/modules/overrides/config_legacy.go
@@ -2,6 +2,7 @@ package overrides
 
 import (
 	"encoding/json"
+	"fmt"
 	"sync"
 	"time"
 
@@ -16,7 +17,7 @@ import (
 )
 
 func (c *Overrides) toLegacy() LegacyOverrides {
-	return LegacyOverrides{
+	result := LegacyOverrides{
 		IngestionRateStrategy:      c.Ingestion.RateStrategy,
 		IngestionRateLimitBytes:    c.Ingestion.RateLimitBytes,
 		IngestionBurstSizeBytes:    c.Ingestion.BurstSizeBytes,
@@ -84,8 +85,15 @@ func (c *Overrides) toLegacy() LegacyOverrides {
 			Dimensions:     c.CostAttribution.Dimensions,
 			MaxCardinality: c.CostAttribution.MaxCardinality,
 		},
-		Extra: c.Extra,
 	}
+	// Copy extensions; MarshalJSON/MarshalYAML flatten typed instances to legacy flat keys.
+	if len(c.Extensions) > 0 {
+		result.Extensions = make(map[string]any, len(c.Extensions))
+		for k, v := range c.Extensions {
+			result.Extensions[k] = v
+		}
+	}
+	return result
 }
 
 // LegacyOverrides describe all the limits for users; can be used to describe global default
@@ -169,8 +177,12 @@ type LegacyOverrides struct {
 	// tempodb limits
 	DedicatedColumns backend.DedicatedColumns `yaml:"parquet_dedicated_columns" json:"parquet_dedicated_columns"`
 
-	// Extra captures fields not recognised by this struct. See Overrides.Extra.
-	Extra map[string]any `yaml:",inline" json:"-"`
+	// Extensions captures fields not recognised by the above fields.
+	// After UnmarshalJSON or UnmarshalYAML (via processLegacyExtensions), typed Extension instances
+	// are stored here keyed by their nested Key() (e.g. "my_ext"), matching the semantics of
+	// Overrides.Extensions. The flat wire format (e.g. "my_ext_field") is only used during
+	// serialization, handled by MarshalJSON and MarshalYAML.
+	Extensions map[string]any `yaml:",inline" json:"-"`
 }
 
 // knownLegacyOverridesJSONFields returns the JSON key names declared on LegacyOverrides
@@ -178,10 +190,6 @@ var knownLegacyOverridesJSONFields = sync.OnceValue(func() map[string]struct{} {
 	return fieldNamesFor(LegacyOverrides{}, "json")
 })
 
-// knownLegacyOverridesYAMLFields returns the YAML key names declared on LegacyOverrides
-var knownLegacyOverridesYAMLFields = sync.OnceValue(func() map[string]struct{} {
-	return fieldNamesFor(LegacyOverrides{}, "yaml")
-})
 
 func (l *LegacyOverrides) UnmarshalJSON(data []byte) error {
 	type plain LegacyOverrides
@@ -201,15 +209,19 @@ func (l *LegacyOverrides) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	l.Extra = make(map[string]any, len(raw))
+	l.Extensions = make(map[string]any, len(raw))
 	for k, v := range raw {
 		var val any
 		if err := json.Unmarshal(v, &val); err != nil {
 			return err
 		}
-		l.Extra[k] = val
+		l.Extensions[k] = val
 	}
-	return nil
+
+	// processLegacyExtensions converts registered extension flat keys (e.g. "my_ext_field") to
+	// typed instances keyed by their nested Key() (e.g. "my_ext"), matching Overrides.Extensions.
+	// processExtensions must NOT be called here: it expects nested keys, not flat legacy keys.
+	return processLegacyExtensions(l)
 }
 
 func (l LegacyOverrides) MarshalJSON() ([]byte, error) {
@@ -218,7 +230,7 @@ func (l LegacyOverrides) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(l.Extra) == 0 {
+	if len(l.Extensions) == 0 {
 		return data, nil
 	}
 
@@ -226,21 +238,56 @@ func (l LegacyOverrides) MarshalJSON() ([]byte, error) {
 	if err := json.Unmarshal(data, &m); err != nil {
 		return nil, err
 	}
-	for k, v := range l.Extra {
-		if _, exists := m[k]; exists {
-			continue // known fields take precedence
+	// Flatten typed Extension instances to their legacy flat keys; copy other entries as-is.
+	for k, v := range l.Extensions {
+		if ext, ok := v.(Extension); ok {
+			for fk, fv := range ext.ToLegacy() {
+				if _, exists := m[fk]; exists {
+					continue // known fields take precedence
+				}
+				b, err := json.Marshal(fv)
+				if err != nil {
+					return nil, err
+				}
+				m[fk] = b
+			}
+		} else {
+			if _, exists := m[k]; exists {
+				continue // known fields take precedence
+			}
+			b, err := json.Marshal(v)
+			if err != nil {
+				return nil, err
+			}
+			m[k] = b
 		}
-		b, err := json.Marshal(v)
-		if err != nil {
-			return nil, err
-		}
-		m[k] = b
 	}
 	return json.Marshal(m)
 }
 
-func (l *LegacyOverrides) toNewLimits() Overrides {
-	return Overrides{
+func (l *LegacyOverrides) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type plain LegacyOverrides
+	if err := unmarshal((*plain)(l)); err != nil {
+		return err
+	}
+	// Convert registered extension flat keys to typed instances, matching Overrides.Extensions.
+	return processLegacyExtensions(l)
+}
+
+func (l LegacyOverrides) MarshalYAML() (interface{}, error) {
+	type plain LegacyOverrides
+	if len(l.Extensions) == 0 {
+		return plain(l), nil
+	}
+	// Flatten typed Extension instances to their legacy flat keys before marshaling,
+	// so that the YAML wire format uses flat keys (e.g. "my_ext_field"), not the nested key.
+	cp := l
+	cp.Extensions = flattenExtensionEntries(l.Extensions)
+	return plain(cp), nil
+}
+
+func (l *LegacyOverrides) toNewLimits() (Overrides, error) {
+	o := Overrides{
 		Ingestion: IngestionOverrides{
 			RateStrategy:           l.IngestionRateStrategy,
 			RateLimitBytes:         l.IngestionRateLimitBytes,
@@ -324,8 +371,16 @@ func (l *LegacyOverrides) toNewLimits() Overrides {
 			Dimensions:     l.CostAttribution.Dimensions,
 			MaxCardinality: l.CostAttribution.MaxCardinality,
 		},
-		Extra: l.Extra,
 	}
+	// Extensions are already typed instances after processLegacyExtensions ran at unmarshal time.
+	// Simply copy them; processExtensions called by the caller will validate them.
+	if len(l.Extensions) > 0 {
+		o.Extensions = make(map[string]any, len(l.Extensions))
+		for k, v := range l.Extensions {
+			o.Extensions[k] = v
+		}
+	}
+	return o, nil
 }
 
 // perTenantLegacyOverrides represents the Overrides config file with the legacy representation
@@ -334,15 +389,18 @@ type perTenantLegacyOverrides struct {
 }
 
 // Convert to new format
-func (l *perTenantLegacyOverrides) toNewOverrides() perTenantOverrides {
+func (l *perTenantLegacyOverrides) toNewOverrides() (perTenantOverrides, error) {
 	overrides := perTenantOverrides{
 		TenantLimits: make(map[string]*Overrides, len(l.TenantLimits)),
 	}
 
 	for tenantID, legacyLimits := range l.TenantLimits {
-		limits := legacyLimits.toNewLimits()
+		limits, err := legacyLimits.toNewLimits()
+		if err != nil {
+			return perTenantOverrides{}, fmt.Errorf("tenant %q: %w", tenantID, err)
+		}
 		overrides.TenantLimits[tenantID] = &limits
 	}
 
-	return overrides
+	return overrides, nil
 }

--- a/modules/overrides/config_legacy.go
+++ b/modules/overrides/config_legacy.go
@@ -276,7 +276,7 @@ func (l LegacyOverrides) MarshalYAML() (interface{}, error) {
 		return plain(l), nil
 	}
 	// Flatten typed extensions to legacy flat keys so the YAML wire format matches the legacy shape.
-	knownLegacy := knownLegacyOverridesJSONFields()
+	knownLegacy := knownLegacyOverridesYAMLFields()
 	flat := flattenExtensionEntries(l.Extensions)
 	filtered := make(map[string]any, len(flat))
 	for k, v := range flat {

--- a/modules/overrides/config_legacy.go
+++ b/modules/overrides/config_legacy.go
@@ -3,6 +3,7 @@ package overrides
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -297,7 +298,7 @@ func (l LegacyOverrides) MarshalYAML() (interface{}, error) {
 }
 
 func (l *LegacyOverrides) toNewLimits() *Overrides {
-	o := Overrides{
+	return &Overrides{
 		Ingestion: IngestionOverrides{
 			RateStrategy:           l.IngestionRateStrategy,
 			RateLimitBytes:         l.IngestionRateLimitBytes,
@@ -381,17 +382,8 @@ func (l *LegacyOverrides) toNewLimits() *Overrides {
 			Dimensions:     l.CostAttribution.Dimensions,
 			MaxCardinality: l.CostAttribution.MaxCardinality,
 		},
+		Extensions: maps.Clone(l.Extensions), // copy extensions to avoid modifying the original
 	}
-
-	// Extensions are already typed; the caller invokes processExtensions to validate them.
-	if len(l.Extensions) > 0 {
-		o.Extensions = make(map[string]any, len(l.Extensions))
-		for k, v := range l.Extensions {
-			o.Extensions[k] = v
-		}
-	}
-
-	return &o
 }
 
 // perTenantLegacyOverrides represents the Overrides config file with the legacy representation

--- a/modules/overrides/config_legacy.go
+++ b/modules/overrides/config_legacy.go
@@ -204,6 +204,8 @@ func (l *LegacyOverrides) UnmarshalJSON(data []byte) error {
 		delete(raw, key)
 	}
 	if len(raw) == 0 {
+		// No extension keys in this payload; clear any stale Extensions from a prior decode.
+		l.Extensions = nil
 		return nil
 	}
 

--- a/modules/overrides/config_legacy.go
+++ b/modules/overrides/config_legacy.go
@@ -281,8 +281,17 @@ func (l LegacyOverrides) MarshalYAML() (interface{}, error) {
 	}
 	// Flatten typed Extension instances to their legacy flat keys before marshaling,
 	// so that the YAML wire format uses flat keys (e.g. "my_ext_field"), not the nested key.
+	knownLegacy := knownLegacyOverridesJSONFields()
+	flat := flattenExtensionEntries(l.Extensions)
+	filtered := make(map[string]any, len(flat))
+	for k, v := range flat {
+		if _, known := knownLegacy[k]; known {
+			continue
+		}
+		filtered[k] = v
+	}
 	cp := l
-	cp.Extensions = flattenExtensionEntries(l.Extensions)
+	cp.Extensions = filtered
 	return plain(cp), nil
 }
 

--- a/modules/overrides/config_legacy.go
+++ b/modules/overrides/config_legacy.go
@@ -277,7 +277,11 @@ func (l LegacyOverrides) MarshalYAML() (interface{}, error) {
 	}
 	// Flatten typed extensions to legacy flat keys so the YAML wire format matches the legacy shape.
 	knownLegacy := knownLegacyOverridesYAMLFields()
-	flat := flattenExtensionEntries(l.Extensions)
+	flat, err := flattenExtensionEntries(l.Extensions)
+	if err != nil {
+		return nil, err
+	}
+
 	filtered := make(map[string]any, len(flat))
 	for k, v := range flat {
 		if _, known := knownLegacy[k]; known {

--- a/modules/overrides/config_legacy.go
+++ b/modules/overrides/config_legacy.go
@@ -190,7 +190,6 @@ var knownLegacyOverridesJSONFields = sync.OnceValue(func() map[string]struct{} {
 	return fieldNamesFor(LegacyOverrides{}, "json")
 })
 
-
 func (l *LegacyOverrides) UnmarshalJSON(data []byte) error {
 	type plain LegacyOverrides
 	if err := json.Unmarshal(data, (*plain)(l)); err != nil {

--- a/modules/overrides/config_legacy.go
+++ b/modules/overrides/config_legacy.go
@@ -400,7 +400,7 @@ type perTenantLegacyOverrides struct {
 }
 
 // Convert to new format
-func (l *perTenantLegacyOverrides) toNewOverrides() (perTenantOverrides, error) {
+func (l *perTenantLegacyOverrides) toNewOverrides() perTenantOverrides {
 	overrides := perTenantOverrides{
 		TenantLimits: make(map[string]*Overrides, len(l.TenantLimits)),
 	}
@@ -409,5 +409,5 @@ func (l *perTenantLegacyOverrides) toNewOverrides() (perTenantOverrides, error) 
 		overrides.TenantLimits[tenantID] = legacyLimits.toNewLimits()
 	}
 
-	return overrides, nil
+	return overrides
 }

--- a/modules/overrides/config_legacy.go
+++ b/modules/overrides/config_legacy.go
@@ -2,6 +2,7 @@ package overrides
 
 import (
 	"encoding/json"
+	"fmt"
 	"sync"
 	"time"
 
@@ -247,26 +248,20 @@ func (l LegacyOverrides) MarshalJSON() ([]byte, error) {
 	}
 	// Flatten typed extensions to legacy flat keys; copy other entries as-is.
 	for k, v := range l.Extensions {
-		if ext, ok := v.(Extension); ok {
-			for fk, fv := range ext.ToLegacy() {
-				if _, exists := m[fk]; exists {
-					continue // known fields take precedence
-				}
-				b, err := json.Marshal(fv)
-				if err != nil {
-					return nil, err
-				}
-				m[fk] = b
-			}
-		} else {
-			if _, exists := m[k]; exists {
+		ext, ok := v.(Extension)
+		if !ok {
+			return nil, fmt.Errorf("extension %q is not an Extension", k)
+		}
+
+		for fk, fv := range ext.ToLegacy() {
+			if _, exists := m[fk]; exists {
 				continue // known fields take precedence
 			}
-			b, err := json.Marshal(v)
+			b, err := json.Marshal(fv)
 			if err != nil {
 				return nil, err
 			}
-			m[k] = b
+			m[fk] = b
 		}
 	}
 	return json.Marshal(m)

--- a/modules/overrides/config_legacy.go
+++ b/modules/overrides/config_legacy.go
@@ -1,6 +1,8 @@
 package overrides
 
 import (
+	"encoding/json"
+	"sync"
 	"time"
 
 	"github.com/grafana/tempo/modules/overrides/histograms"
@@ -82,6 +84,7 @@ func (c *Overrides) toLegacy() LegacyOverrides {
 			Dimensions:     c.CostAttribution.Dimensions,
 			MaxCardinality: c.CostAttribution.MaxCardinality,
 		},
+		Extra: c.Extra,
 	}
 }
 
@@ -165,6 +168,75 @@ type LegacyOverrides struct {
 
 	// tempodb limits
 	DedicatedColumns backend.DedicatedColumns `yaml:"parquet_dedicated_columns" json:"parquet_dedicated_columns"`
+
+	// Extra captures fields not recognised by this struct. See Overrides.Extra.
+	Extra map[string]any `yaml:",inline" json:"-"`
+}
+
+// knownLegacyOverridesJSONFields returns the JSON key names declared on LegacyOverrides
+var knownLegacyOverridesJSONFields = sync.OnceValue(func() map[string]struct{} {
+	return fieldNamesFor(LegacyOverrides{}, "json")
+})
+
+// knownLegacyOverridesYAMLFields returns the YAML key names declared on LegacyOverrides
+var knownLegacyOverridesYAMLFields = sync.OnceValue(func() map[string]struct{} {
+	return fieldNamesFor(LegacyOverrides{}, "yaml")
+})
+
+func (l *LegacyOverrides) UnmarshalJSON(data []byte) error {
+	type plain LegacyOverrides
+	if err := json.Unmarshal(data, (*plain)(l)); err != nil {
+		return err
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	for key := range knownLegacyOverridesJSONFields() {
+		delete(raw, key)
+	}
+	if len(raw) == 0 {
+		return nil
+	}
+
+	l.Extra = make(map[string]any, len(raw))
+	for k, v := range raw {
+		var val any
+		if err := json.Unmarshal(v, &val); err != nil {
+			return err
+		}
+		l.Extra[k] = val
+	}
+	return nil
+}
+
+func (l LegacyOverrides) MarshalJSON() ([]byte, error) {
+	type plain LegacyOverrides
+	data, err := json.Marshal(plain(l))
+	if err != nil {
+		return nil, err
+	}
+	if len(l.Extra) == 0 {
+		return data, nil
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	for k, v := range l.Extra {
+		if _, exists := m[k]; exists {
+			continue // known fields take precedence
+		}
+		b, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		m[k] = b
+	}
+	return json.Marshal(m)
 }
 
 func (l *LegacyOverrides) toNewLimits() Overrides {
@@ -252,6 +324,7 @@ func (l *LegacyOverrides) toNewLimits() Overrides {
 			Dimensions:     l.CostAttribution.Dimensions,
 			MaxCardinality: l.CostAttribution.MaxCardinality,
 		},
+		Extra: l.Extra,
 	}
 }
 

--- a/modules/overrides/config_legacy.go
+++ b/modules/overrides/config_legacy.go
@@ -18,7 +18,7 @@ import (
 )
 
 func (c *Overrides) toLegacy() LegacyOverrides {
-	result := LegacyOverrides{
+	return LegacyOverrides{
 		IngestionRateStrategy:      c.Ingestion.RateStrategy,
 		IngestionRateLimitBytes:    c.Ingestion.RateLimitBytes,
 		IngestionBurstSizeBytes:    c.Ingestion.BurstSizeBytes,
@@ -86,15 +86,8 @@ func (c *Overrides) toLegacy() LegacyOverrides {
 			Dimensions:     c.CostAttribution.Dimensions,
 			MaxCardinality: c.CostAttribution.MaxCardinality,
 		},
+		Extensions: maps.Clone(c.Extensions), // Copy extensions to avoid modifying the original
 	}
-	// Copy extensions; MarshalJSON/MarshalYAML flatten typed instances to legacy flat keys.
-	if len(c.Extensions) > 0 {
-		result.Extensions = make(map[string]any, len(c.Extensions))
-		for k, v := range c.Extensions {
-			result.Extensions[k] = v
-		}
-	}
-	return result
 }
 
 // LegacyOverrides describe all the limits for users; can be used to describe global default

--- a/modules/overrides/config_test.go
+++ b/modules/overrides/config_test.go
@@ -500,8 +500,8 @@ func durationPtr(d time.Duration) *time.Duration {
 func TestLegacyOverridesExtensions_YAML(t *testing.T) {
 	input := `
 max_traces_per_user: 1000
-lbac:
-  trace_redaction_mode: mode_spans
+unregistered_ext:
+  ext_field: ext_value
 `
 	var l LegacyOverrides
 	decoder := yaml.NewDecoder(strings.NewReader(input))
@@ -509,7 +509,7 @@ lbac:
 	require.NoError(t, decoder.Decode(&l))
 
 	assert.Equal(t, 1000, l.MaxLocalTracesPerUser)
-	assert.NotNil(t, l.Extensions["lbac"], "expected Extensions to capture unknown 'lbac' key")
+	assert.NotNil(t, l.Extensions["unregistered_ext"], "expected Extensions to capture unknown 'unregistered_ext' key")
 
 	// Round-trip.
 	b, err := yaml.Marshal(&l)
@@ -518,17 +518,17 @@ lbac:
 	var l2 LegacyOverrides
 	require.NoError(t, yaml.Unmarshal(b, &l2))
 	assert.Equal(t, l.MaxLocalTracesPerUser, l2.MaxLocalTracesPerUser)
-	assert.NotNil(t, l2.Extensions["lbac"])
+	assert.NotNil(t, l2.Extensions["unregistered_ext"])
 }
 
 func TestLegacyOverridesExtensions_YAMLvsJSON(t *testing.T) {
 	inputYAML := `
 max_traces_per_user: 1000
-lbac_mode: mode_spans
+unregistered_flat_key: flat_value
 `
 	inputJSON := `{
 		"max_traces_per_user": 1000,
-		"lbac_mode": "mode_spans"
+		"unregistered_flat_key": "flat_value"
 	}`
 
 	var lYAML LegacyOverrides
@@ -544,26 +544,26 @@ lbac_mode: mode_spans
 func TestLegacyToNewLimits_ExtensionsPreserved(t *testing.T) {
 	input := `
 max_traces_per_user: 500
-lbac_mode: mode_spans
+unregistered_flat_key: flat_value
 `
 	var l LegacyOverrides
 	require.NoError(t, yaml.Unmarshal([]byte(input), &l))
-	require.Equal(t, "mode_spans", l.Extensions["lbac_mode"])
+	require.Equal(t, "flat_value", l.Extensions["unregistered_flat_key"])
 
 	o := l.toNewLimits()
 	assert.Equal(t, 500, o.Ingestion.MaxLocalTracesPerUser)
-	assert.Equal(t, "mode_spans", o.Extensions["lbac_mode"], "Extensions must survive toNewLimits()")
+	assert.Equal(t, "flat_value", o.Extensions["unregistered_flat_key"], "Extensions must survive toNewLimits()")
 }
 
 func TestToLegacy_ExtensionsPreserved(t *testing.T) {
 	o := Overrides{
-		Extensions: map[string]any{"lbac_mode": "mode_spans"},
+		Extensions: map[string]any{"unregistered_flat_key": "flat_value"},
 	}
 	o.Ingestion.MaxLocalTracesPerUser = 500
 
 	l := o.toLegacy()
 	assert.Equal(t, 500, l.MaxLocalTracesPerUser)
-	assert.Equal(t, "mode_spans", l.Extensions["lbac_mode"], "Extensions must survive toLegacy()")
+	assert.Equal(t, "flat_value", l.Extensions["unregistered_flat_key"], "Extensions must survive toLegacy()")
 }
 
 // Helper function to create ListToMap

--- a/modules/overrides/config_test.go
+++ b/modules/overrides/config_test.go
@@ -312,7 +312,8 @@ func TestFormatConversion(t *testing.T) {
 	ensureAllFieldsPopulated(t, legacyOverrides)
 
 	// Convert to new format and back
-	newOverrides := legacyOverrides.toNewLimits()
+	newOverrides, err := legacyOverrides.toNewLimits()
+	require.NoError(t, err)
 	convertedLegacyOverrides := newOverrides.toLegacy()
 
 	// Compare original and converted
@@ -334,7 +335,7 @@ func ensureAllFieldsPopulated(t *testing.T, o LegacyOverrides) {
 		fieldName := structType.Field(i).Name
 
 		// Skip certain fields that can be zero in valid configs
-		skip := []string{"IngestionArtificialDelay", "MetricsGeneratorSpanNameSanitization", "Extra"}
+		skip := []string{"IngestionArtificialDelay", "MetricsGeneratorSpanNameSanitization", "Extensions"}
 		if slices.Contains(skip, fieldName) {
 			continue
 		}
@@ -497,88 +498,6 @@ func durationPtr(d time.Duration) *time.Duration {
 	return &d
 }
 
-// --- Extra field tests for Overrides ---
-
-func TestOverridesExtra_YAML(t *testing.T) {
-	input := `
-ingestion:
-  max_traces_per_user: 1000
-lbac:
-  trace_redaction_mode: mode_spans
-`
-	var o Overrides
-	decoder := yaml.NewDecoder(strings.NewReader(input))
-	decoder.SetStrict(true)
-	require.NoError(t, decoder.Decode(&o))
-
-	assert.Equal(t, 1000, o.Ingestion.MaxLocalTracesPerUser)
-	assert.NotNil(t, o.Extra["lbac"], "expected Extra to capture unknown 'lbac' key")
-
-	// Round-trip: marshal back to YAML and decode again.
-	b, err := yaml.Marshal(&o)
-	require.NoError(t, err)
-
-	var o2 Overrides
-	require.NoError(t, yaml.Unmarshal(b, &o2))
-	assert.Equal(t, o.Ingestion.MaxLocalTracesPerUser, o2.Ingestion.MaxLocalTracesPerUser)
-	assert.NotNil(t, o2.Extra["lbac"])
-}
-
-func TestOverridesExtra_JSON(t *testing.T) {
-	input := `{
-		"ingestion": {"max_traces_per_user": 1000},
-		"lbac_mode": "mode_spans"
-	}`
-
-	var o Overrides
-	require.NoError(t, json.Unmarshal([]byte(input), &o))
-
-	assert.Equal(t, 1000, o.Ingestion.MaxLocalTracesPerUser)
-	assert.Equal(t, "mode_spans", o.Extra["lbac_mode"])
-
-	// Round-trip: marshal and unmarshal.
-	b, err := json.Marshal(&o)
-	require.NoError(t, err)
-
-	var o2 Overrides
-	require.NoError(t, json.Unmarshal(b, &o2))
-	assert.Equal(t, o, o2)
-
-	// Known fields take precedence: if Extra contains a key that matches a known field,
-	// the known field value should not be overwritten on marshal.
-	o.Extra["ingestion"] = "should-be-ignored"
-	b, err = json.Marshal(&o)
-	require.NoError(t, err)
-
-	var o3 Overrides
-	require.NoError(t, json.Unmarshal(b, &o3))
-	assert.Equal(t, 1000, o3.Ingestion.MaxLocalTracesPerUser, "known field must not be overwritten by Extra")
-}
-
-func TestOverridesExtra_YAMLvsJSON(t *testing.T) {
-	// Use flat string extra values to avoid YAML/JSON map type differences.
-	inputYAML := `
-ingestion:
-  max_traces_per_user: 1000
-lbac_mode: mode_spans
-`
-	inputJSON := `{
-		"ingestion": {"max_traces_per_user": 1000},
-		"lbac_mode": "mode_spans"
-	}`
-
-	var oYAML Overrides
-	require.NoError(t, yaml.Unmarshal([]byte(inputYAML), &oYAML))
-
-	var oJSON Overrides
-	require.NoError(t, json.Unmarshal([]byte(inputJSON), &oJSON))
-
-	assert.Equal(t, oYAML.Ingestion, oJSON.Ingestion)
-	assert.Equal(t, oYAML.Extra, oJSON.Extra)
-}
-
-// --- Extra field tests for LegacyOverrides ---
-
 func TestLegacyOverridesExtra_YAML(t *testing.T) {
 	input := `
 max_traces_per_user: 1000
@@ -591,7 +510,7 @@ lbac:
 	require.NoError(t, decoder.Decode(&l))
 
 	assert.Equal(t, 1000, l.MaxLocalTracesPerUser)
-	assert.NotNil(t, l.Extra["lbac"], "expected Extra to capture unknown 'lbac' key")
+	assert.NotNil(t, l.Extensions["lbac"], "expected Extensions to capture unknown 'lbac' key")
 
 	// Round-trip.
 	b, err := yaml.Marshal(&l)
@@ -600,10 +519,12 @@ lbac:
 	var l2 LegacyOverrides
 	require.NoError(t, yaml.Unmarshal(b, &l2))
 	assert.Equal(t, l.MaxLocalTracesPerUser, l2.MaxLocalTracesPerUser)
-	assert.NotNil(t, l2.Extra["lbac"])
+	assert.NotNil(t, l2.Extensions["lbac"])
 }
 
 func TestLegacyOverridesExtra_JSON(t *testing.T) {
+	// Unregistered flat keys are tolerated by processLegacyExtensions (passed through as-is).
+	// Strict rejection of unknown keys happens later in processExtensions on the converted Overrides.
 	input := `{
 		"max_traces_per_user": 1000,
 		"lbac_mode": "mode_spans"
@@ -613,28 +534,30 @@ func TestLegacyOverridesExtra_JSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(input), &l))
 
 	assert.Equal(t, 1000, l.MaxLocalTracesPerUser)
-	assert.Equal(t, "mode_spans", l.Extra["lbac_mode"])
+	assert.Equal(t, "mode_spans", l.Extensions["lbac_mode"])
 
-	// Round-trip: Extra and known fields survive marshal/unmarshal.
+	// Round-trip: Extensions and known fields survive marshal/unmarshal.
 	b, err := json.Marshal(&l)
 	require.NoError(t, err)
 
 	var l2 LegacyOverrides
 	require.NoError(t, json.Unmarshal(b, &l2))
 	assert.Equal(t, l.MaxLocalTracesPerUser, l2.MaxLocalTracesPerUser)
-	assert.Equal(t, l.Extra, l2.Extra)
+	assert.Equal(t, l.Extensions, l2.Extensions)
 
 	// Known fields take precedence.
-	l.Extra["max_traces_per_user"] = "should-be-ignored"
+	l.Extensions["max_traces_per_user"] = "should-be-ignored"
 	b, err = json.Marshal(&l)
 	require.NoError(t, err)
 
 	var l3 LegacyOverrides
 	require.NoError(t, json.Unmarshal(b, &l3))
-	assert.Equal(t, 1000, l3.MaxLocalTracesPerUser, "known field must not be overwritten by Extra")
+	assert.Equal(t, 1000, l3.MaxLocalTracesPerUser, "known field must not be overwritten by Extensions")
 }
 
 func TestLegacyOverridesExtra_YAMLvsJSON(t *testing.T) {
+	// Unregistered flat keys are tolerated by processLegacyExtensions (passed through as-is).
+	// Strict rejection of unknown keys happens later in processExtensions on the converted Overrides.
 	inputYAML := `
 max_traces_per_user: 1000
 lbac_mode: mode_spans
@@ -651,34 +574,35 @@ lbac_mode: mode_spans
 	require.NoError(t, json.Unmarshal([]byte(inputJSON), &lJSON))
 
 	assert.Equal(t, lYAML.MaxLocalTracesPerUser, lJSON.MaxLocalTracesPerUser)
-	assert.Equal(t, lYAML.Extra, lJSON.Extra)
+	assert.Equal(t, lYAML.Extensions, lJSON.Extensions)
 }
 
-// --- Conversion chain tests ---
-
 func TestLegacyToNewLimits_ExtraPreserved(t *testing.T) {
+	// Unregistered flat keys are tolerated by processLegacyExtensions (passed through as-is) and
+	// survive toNewLimits. Strict rejection happens later in processExtensions on the converted Overrides.
 	input := `
 max_traces_per_user: 500
 lbac_mode: mode_spans
 `
 	var l LegacyOverrides
 	require.NoError(t, yaml.Unmarshal([]byte(input), &l))
-	require.Equal(t, "mode_spans", l.Extra["lbac_mode"])
+	require.Equal(t, "mode_spans", l.Extensions["lbac_mode"])
 
-	o := l.toNewLimits()
+	o, err := l.toNewLimits()
+	require.NoError(t, err)
 	assert.Equal(t, 500, o.Ingestion.MaxLocalTracesPerUser)
-	assert.Equal(t, "mode_spans", o.Extra["lbac_mode"], "Extra must survive toNewLimits()")
+	assert.Equal(t, "mode_spans", o.Extensions["lbac_mode"], "Extensions must survive toNewLimits()")
 }
 
 func TestToLegacy_ExtraPreserved(t *testing.T) {
 	o := Overrides{
-		Extra: map[string]any{"lbac_mode": "mode_spans"},
+		Extensions: map[string]any{"lbac_mode": "mode_spans"},
 	}
 	o.Ingestion.MaxLocalTracesPerUser = 500
 
 	l := o.toLegacy()
 	assert.Equal(t, 500, l.MaxLocalTracesPerUser)
-	assert.Equal(t, "mode_spans", l.Extra["lbac_mode"], "Extra must survive toLegacy()")
+	assert.Equal(t, "mode_spans", l.Extensions["lbac_mode"], "Extensions must survive toLegacy()")
 }
 
 // Helper function to create ListToMap

--- a/modules/overrides/config_test.go
+++ b/modules/overrides/config_test.go
@@ -497,7 +497,7 @@ func durationPtr(d time.Duration) *time.Duration {
 	return &d
 }
 
-func TestLegacyOverridesExtra_YAML(t *testing.T) {
+func TestLegacyOverridesExtensions_YAML(t *testing.T) {
 	input := `
 max_traces_per_user: 1000
 lbac:
@@ -521,9 +521,7 @@ lbac:
 	assert.NotNil(t, l2.Extensions["lbac"])
 }
 
-func TestLegacyOverridesExtra_YAMLvsJSON(t *testing.T) {
-	// Unregistered flat keys are tolerated by processLegacyExtensions (passed through as-is).
-	// Strict rejection of unknown keys happens later in processExtensions on the converted Overrides.
+func TestLegacyOverridesExtensions_YAMLvsJSON(t *testing.T) {
 	inputYAML := `
 max_traces_per_user: 1000
 lbac_mode: mode_spans
@@ -543,9 +541,7 @@ lbac_mode: mode_spans
 	assert.Equal(t, lYAML.Extensions, lJSON.Extensions)
 }
 
-func TestLegacyToNewLimits_ExtraPreserved(t *testing.T) {
-	// Unregistered flat keys are tolerated by processLegacyExtensions (passed through as-is) and
-	// survive toNewLimits. Strict rejection happens later in processExtensions on the converted Overrides.
+func TestLegacyToNewLimits_ExtensionsPreserved(t *testing.T) {
 	input := `
 max_traces_per_user: 500
 lbac_mode: mode_spans
@@ -559,7 +555,7 @@ lbac_mode: mode_spans
 	assert.Equal(t, "mode_spans", o.Extensions["lbac_mode"], "Extensions must survive toNewLimits()")
 }
 
-func TestToLegacy_ExtraPreserved(t *testing.T) {
+func TestToLegacy_ExtensionsPreserved(t *testing.T) {
 	o := Overrides{
 		Extensions: map[string]any{"lbac_mode": "mode_spans"},
 	}

--- a/modules/overrides/config_test.go
+++ b/modules/overrides/config_test.go
@@ -312,8 +312,7 @@ func TestFormatConversion(t *testing.T) {
 	ensureAllFieldsPopulated(t, legacyOverrides)
 
 	// Convert to new format and back
-	newOverrides, err := legacyOverrides.toNewLimits()
-	require.NoError(t, err)
+	newOverrides := legacyOverrides.toNewLimits()
 	convertedLegacyOverrides := newOverrides.toLegacy()
 
 	// Compare original and converted
@@ -588,8 +587,7 @@ lbac_mode: mode_spans
 	require.NoError(t, yaml.Unmarshal([]byte(input), &l))
 	require.Equal(t, "mode_spans", l.Extensions["lbac_mode"])
 
-	o, err := l.toNewLimits()
-	require.NoError(t, err)
+	o := l.toNewLimits()
 	assert.Equal(t, 500, o.Ingestion.MaxLocalTracesPerUser)
 	assert.Equal(t, "mode_spans", o.Extensions["lbac_mode"], "Extensions must survive toNewLimits()")
 }

--- a/modules/overrides/config_test.go
+++ b/modules/overrides/config_test.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,11 +26,14 @@ import (
 // Copied from Cortex
 func TestConfigTagsYamlMatchJson(t *testing.T) {
 	overrides := reflect.TypeOf(LegacyOverrides{})
-	n := overrides.NumField()
 	var mismatch []string
 
-	for i := 0; i < n; i++ {
-		field := overrides.Field(i)
+	for field := range overrides.Fields() {
+
+		// Skip fields intentionally excluded from JSON
+		if field.Tag.Get("json") == "-" {
+			continue
+		}
 
 		// Note that we aren't requiring YAML and JSON tags to match, just that
 		// they either both exist or both don't exist.
@@ -63,9 +67,6 @@ compaction_window: 4h
 per_tenant_override_config: /etc/Overrides.yaml
 per_tenant_override_period: 1m
 
-metrics_generator_send_queue_size: 10
-metrics_generator_send_workers: 1
-
 max_search_duration: 5m
 `
 	inputJSON := `
@@ -85,9 +86,6 @@ max_search_duration: 5m
 
 	"per_tenant_override_config": "/etc/Overrides.yaml",
 	"per_tenant_override_period": "1m",
-
-	"metrics_generator_send_queue_size": 10,
-	"metrics_generator_send_workers": 1,
 
 	"max_search_duration": "5m"
 }`
@@ -336,7 +334,7 @@ func ensureAllFieldsPopulated(t *testing.T, o LegacyOverrides) {
 		fieldName := structType.Field(i).Name
 
 		// Skip certain fields that can be zero in valid configs
-		skip := []string{"IngestionArtificialDelay", "MetricsGeneratorSpanNameSanitization"}
+		skip := []string{"IngestionArtificialDelay", "MetricsGeneratorSpanNameSanitization", "Extra"}
 		if slices.Contains(skip, fieldName) {
 			continue
 		}
@@ -497,6 +495,190 @@ func generateTestLegacyOverrides() LegacyOverrides {
 // Helper function to create a duration pointer
 func durationPtr(d time.Duration) *time.Duration {
 	return &d
+}
+
+// --- Extra field tests for Overrides ---
+
+func TestOverridesExtra_YAML(t *testing.T) {
+	input := `
+ingestion:
+  max_traces_per_user: 1000
+lbac:
+  trace_redaction_mode: mode_spans
+`
+	var o Overrides
+	decoder := yaml.NewDecoder(strings.NewReader(input))
+	decoder.SetStrict(true)
+	require.NoError(t, decoder.Decode(&o))
+
+	assert.Equal(t, 1000, o.Ingestion.MaxLocalTracesPerUser)
+	assert.NotNil(t, o.Extra["lbac"], "expected Extra to capture unknown 'lbac' key")
+
+	// Round-trip: marshal back to YAML and decode again.
+	b, err := yaml.Marshal(&o)
+	require.NoError(t, err)
+
+	var o2 Overrides
+	require.NoError(t, yaml.Unmarshal(b, &o2))
+	assert.Equal(t, o.Ingestion.MaxLocalTracesPerUser, o2.Ingestion.MaxLocalTracesPerUser)
+	assert.NotNil(t, o2.Extra["lbac"])
+}
+
+func TestOverridesExtra_JSON(t *testing.T) {
+	input := `{
+		"ingestion": {"max_traces_per_user": 1000},
+		"lbac_mode": "mode_spans"
+	}`
+
+	var o Overrides
+	require.NoError(t, json.Unmarshal([]byte(input), &o))
+
+	assert.Equal(t, 1000, o.Ingestion.MaxLocalTracesPerUser)
+	assert.Equal(t, "mode_spans", o.Extra["lbac_mode"])
+
+	// Round-trip: marshal and unmarshal.
+	b, err := json.Marshal(&o)
+	require.NoError(t, err)
+
+	var o2 Overrides
+	require.NoError(t, json.Unmarshal(b, &o2))
+	assert.Equal(t, o, o2)
+
+	// Known fields take precedence: if Extra contains a key that matches a known field,
+	// the known field value should not be overwritten on marshal.
+	o.Extra["ingestion"] = "should-be-ignored"
+	b, err = json.Marshal(&o)
+	require.NoError(t, err)
+
+	var o3 Overrides
+	require.NoError(t, json.Unmarshal(b, &o3))
+	assert.Equal(t, 1000, o3.Ingestion.MaxLocalTracesPerUser, "known field must not be overwritten by Extra")
+}
+
+func TestOverridesExtra_YAMLvsJSON(t *testing.T) {
+	// Use flat string extra values to avoid YAML/JSON map type differences.
+	inputYAML := `
+ingestion:
+  max_traces_per_user: 1000
+lbac_mode: mode_spans
+`
+	inputJSON := `{
+		"ingestion": {"max_traces_per_user": 1000},
+		"lbac_mode": "mode_spans"
+	}`
+
+	var oYAML Overrides
+	require.NoError(t, yaml.Unmarshal([]byte(inputYAML), &oYAML))
+
+	var oJSON Overrides
+	require.NoError(t, json.Unmarshal([]byte(inputJSON), &oJSON))
+
+	assert.Equal(t, oYAML.Ingestion, oJSON.Ingestion)
+	assert.Equal(t, oYAML.Extra, oJSON.Extra)
+}
+
+// --- Extra field tests for LegacyOverrides ---
+
+func TestLegacyOverridesExtra_YAML(t *testing.T) {
+	input := `
+max_traces_per_user: 1000
+lbac:
+  trace_redaction_mode: mode_spans
+`
+	var l LegacyOverrides
+	decoder := yaml.NewDecoder(strings.NewReader(input))
+	decoder.SetStrict(true)
+	require.NoError(t, decoder.Decode(&l))
+
+	assert.Equal(t, 1000, l.MaxLocalTracesPerUser)
+	assert.NotNil(t, l.Extra["lbac"], "expected Extra to capture unknown 'lbac' key")
+
+	// Round-trip.
+	b, err := yaml.Marshal(&l)
+	require.NoError(t, err)
+
+	var l2 LegacyOverrides
+	require.NoError(t, yaml.Unmarshal(b, &l2))
+	assert.Equal(t, l.MaxLocalTracesPerUser, l2.MaxLocalTracesPerUser)
+	assert.NotNil(t, l2.Extra["lbac"])
+}
+
+func TestLegacyOverridesExtra_JSON(t *testing.T) {
+	input := `{
+		"max_traces_per_user": 1000,
+		"lbac_mode": "mode_spans"
+	}`
+
+	var l LegacyOverrides
+	require.NoError(t, json.Unmarshal([]byte(input), &l))
+
+	assert.Equal(t, 1000, l.MaxLocalTracesPerUser)
+	assert.Equal(t, "mode_spans", l.Extra["lbac_mode"])
+
+	// Round-trip: Extra and known fields survive marshal/unmarshal.
+	b, err := json.Marshal(&l)
+	require.NoError(t, err)
+
+	var l2 LegacyOverrides
+	require.NoError(t, json.Unmarshal(b, &l2))
+	assert.Equal(t, l.MaxLocalTracesPerUser, l2.MaxLocalTracesPerUser)
+	assert.Equal(t, l.Extra, l2.Extra)
+
+	// Known fields take precedence.
+	l.Extra["max_traces_per_user"] = "should-be-ignored"
+	b, err = json.Marshal(&l)
+	require.NoError(t, err)
+
+	var l3 LegacyOverrides
+	require.NoError(t, json.Unmarshal(b, &l3))
+	assert.Equal(t, 1000, l3.MaxLocalTracesPerUser, "known field must not be overwritten by Extra")
+}
+
+func TestLegacyOverridesExtra_YAMLvsJSON(t *testing.T) {
+	inputYAML := `
+max_traces_per_user: 1000
+lbac_mode: mode_spans
+`
+	inputJSON := `{
+		"max_traces_per_user": 1000,
+		"lbac_mode": "mode_spans"
+	}`
+
+	var lYAML LegacyOverrides
+	require.NoError(t, yaml.Unmarshal([]byte(inputYAML), &lYAML))
+
+	var lJSON LegacyOverrides
+	require.NoError(t, json.Unmarshal([]byte(inputJSON), &lJSON))
+
+	assert.Equal(t, lYAML.MaxLocalTracesPerUser, lJSON.MaxLocalTracesPerUser)
+	assert.Equal(t, lYAML.Extra, lJSON.Extra)
+}
+
+// --- Conversion chain tests ---
+
+func TestLegacyToNewLimits_ExtraPreserved(t *testing.T) {
+	input := `
+max_traces_per_user: 500
+lbac_mode: mode_spans
+`
+	var l LegacyOverrides
+	require.NoError(t, yaml.Unmarshal([]byte(input), &l))
+	require.Equal(t, "mode_spans", l.Extra["lbac_mode"])
+
+	o := l.toNewLimits()
+	assert.Equal(t, 500, o.Ingestion.MaxLocalTracesPerUser)
+	assert.Equal(t, "mode_spans", o.Extra["lbac_mode"], "Extra must survive toNewLimits()")
+}
+
+func TestToLegacy_ExtraPreserved(t *testing.T) {
+	o := Overrides{
+		Extra: map[string]any{"lbac_mode": "mode_spans"},
+	}
+	o.Ingestion.MaxLocalTracesPerUser = 500
+
+	l := o.toLegacy()
+	assert.Equal(t, 500, l.MaxLocalTracesPerUser)
+	assert.Equal(t, "mode_spans", l.Extra["lbac_mode"], "Extra must survive toLegacy()")
 }
 
 // Helper function to create ListToMap

--- a/modules/overrides/config_test.go
+++ b/modules/overrides/config_test.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"reflect"
 	"slices"
-	"strings"
 	"testing"
 	"time"
 
@@ -64,9 +63,6 @@ max_bytes_per_trace: 100_000
 block_retention: 24h
 compaction_window: 4h
 
-per_tenant_override_config: /etc/Overrides.yaml
-per_tenant_override_period: 1m
-
 max_search_duration: 5m
 `
 	inputJSON := `
@@ -83,9 +79,6 @@ max_search_duration: 5m
 
 	"block_retention": "24h",
 	"compaction_window": "4h",
-
-	"per_tenant_override_config": "/etc/Overrides.yaml",
-	"per_tenant_override_period": "1m",
 
 	"max_search_duration": "5m"
 }`
@@ -495,75 +488,6 @@ func generateTestLegacyOverrides() LegacyOverrides {
 // Helper function to create a duration pointer
 func durationPtr(d time.Duration) *time.Duration {
 	return &d
-}
-
-func TestLegacyOverridesExtensions_YAML(t *testing.T) {
-	input := `
-max_traces_per_user: 1000
-unregistered_ext:
-  ext_field: ext_value
-`
-	var l LegacyOverrides
-	decoder := yaml.NewDecoder(strings.NewReader(input))
-	decoder.SetStrict(true)
-	require.NoError(t, decoder.Decode(&l))
-
-	assert.Equal(t, 1000, l.MaxLocalTracesPerUser)
-	assert.NotNil(t, l.Extensions["unregistered_ext"], "expected Extensions to capture unknown 'unregistered_ext' key")
-
-	// Round-trip.
-	b, err := yaml.Marshal(&l)
-	require.NoError(t, err)
-
-	var l2 LegacyOverrides
-	require.NoError(t, yaml.Unmarshal(b, &l2))
-	assert.Equal(t, l.MaxLocalTracesPerUser, l2.MaxLocalTracesPerUser)
-	assert.NotNil(t, l2.Extensions["unregistered_ext"])
-}
-
-func TestLegacyOverridesExtensions_YAMLvsJSON(t *testing.T) {
-	inputYAML := `
-max_traces_per_user: 1000
-unregistered_flat_key: flat_value
-`
-	inputJSON := `{
-		"max_traces_per_user": 1000,
-		"unregistered_flat_key": "flat_value"
-	}`
-
-	var lYAML LegacyOverrides
-	require.NoError(t, yaml.Unmarshal([]byte(inputYAML), &lYAML))
-
-	var lJSON LegacyOverrides
-	require.NoError(t, json.Unmarshal([]byte(inputJSON), &lJSON))
-
-	assert.Equal(t, lYAML.MaxLocalTracesPerUser, lJSON.MaxLocalTracesPerUser)
-	assert.Equal(t, lYAML.Extensions, lJSON.Extensions)
-}
-
-func TestLegacyToNewLimits_ExtensionsPreserved(t *testing.T) {
-	input := `
-max_traces_per_user: 500
-unregistered_flat_key: flat_value
-`
-	var l LegacyOverrides
-	require.NoError(t, yaml.Unmarshal([]byte(input), &l))
-	require.Equal(t, "flat_value", l.Extensions["unregistered_flat_key"])
-
-	o := l.toNewLimits()
-	assert.Equal(t, 500, o.Ingestion.MaxLocalTracesPerUser)
-	assert.Equal(t, "flat_value", o.Extensions["unregistered_flat_key"], "Extensions must survive toNewLimits()")
-}
-
-func TestToLegacy_ExtensionsPreserved(t *testing.T) {
-	o := Overrides{
-		Extensions: map[string]any{"unregistered_flat_key": "flat_value"},
-	}
-	o.Ingestion.MaxLocalTracesPerUser = 500
-
-	l := o.toLegacy()
-	assert.Equal(t, 500, l.MaxLocalTracesPerUser)
-	assert.Equal(t, "flat_value", l.Extensions["unregistered_flat_key"], "Extensions must survive toLegacy()")
 }
 
 // Helper function to create ListToMap

--- a/modules/overrides/config_test.go
+++ b/modules/overrides/config_test.go
@@ -521,39 +521,6 @@ lbac:
 	assert.NotNil(t, l2.Extensions["lbac"])
 }
 
-func TestLegacyOverridesExtra_JSON(t *testing.T) {
-	// Unregistered flat keys are tolerated by processLegacyExtensions (passed through as-is).
-	// Strict rejection of unknown keys happens later in processExtensions on the converted Overrides.
-	input := `{
-		"max_traces_per_user": 1000,
-		"lbac_mode": "mode_spans"
-	}`
-
-	var l LegacyOverrides
-	require.NoError(t, json.Unmarshal([]byte(input), &l))
-
-	assert.Equal(t, 1000, l.MaxLocalTracesPerUser)
-	assert.Equal(t, "mode_spans", l.Extensions["lbac_mode"])
-
-	// Round-trip: Extensions and known fields survive marshal/unmarshal.
-	b, err := json.Marshal(&l)
-	require.NoError(t, err)
-
-	var l2 LegacyOverrides
-	require.NoError(t, json.Unmarshal(b, &l2))
-	assert.Equal(t, l.MaxLocalTracesPerUser, l2.MaxLocalTracesPerUser)
-	assert.Equal(t, l.Extensions, l2.Extensions)
-
-	// Known fields take precedence.
-	l.Extensions["max_traces_per_user"] = "should-be-ignored"
-	b, err = json.Marshal(&l)
-	require.NoError(t, err)
-
-	var l3 LegacyOverrides
-	require.NoError(t, json.Unmarshal(b, &l3))
-	assert.Equal(t, 1000, l3.MaxLocalTracesPerUser, "known field must not be overwritten by Extensions")
-}
-
 func TestLegacyOverridesExtra_YAMLvsJSON(t *testing.T) {
 	// Unregistered flat keys are tolerated by processLegacyExtensions (passed through as-is).
 	// Strict rejection of unknown keys happens later in processExtensions on the converted Overrides.

--- a/modules/overrides/extension.go
+++ b/modules/overrides/extension.go
@@ -183,7 +183,6 @@ func processLegacyExtensions(l *LegacyOverrides) error {
 	return nil
 }
 
-
 // flattenExtensionEntries returns a new map where typed Extension values are replaced by their
 // flat legacy key-value pairs (via ToLegacy). Non-Extension entries are copied as-is.
 // Used when marshaling LegacyOverrides to produce the flat wire format.

--- a/modules/overrides/extension.go
+++ b/modules/overrides/extension.go
@@ -77,7 +77,6 @@ func RegisterExtension[T Extension](e T) func(*Overrides) T {
 	}
 
 	legacyKeys := e.LegacyKeys()
-	knownLegacy := knownLegacyOverridesJSONFields()
 	seenLegacy := make(map[string]struct{}, len(legacyKeys))
 	for _, lk := range legacyKeys {
 		if lk == "" {
@@ -87,7 +86,7 @@ func RegisterExtension[T Extension](e T) func(*Overrides) T {
 			panic(fmt.Sprintf("overrides: extension %q has duplicate legacy key %q", key, lk))
 		}
 		seenLegacy[lk] = struct{}{}
-		if _, conflict := knownLegacy[lk]; conflict {
+		if isKnownLegacyOverridesField(lk) {
 			panic(fmt.Sprintf("overrides: extension %q legacy key %q conflicts with a built-in LegacyOverrides field; choose a different legacy key", key, lk))
 		}
 		// Guard against collisions with already-registered extensions' nested keys and legacy keys.

--- a/modules/overrides/extension.go
+++ b/modules/overrides/extension.go
@@ -1,0 +1,34 @@
+package overrides
+
+import (
+	"flag"
+	"sync"
+)
+
+// Extension describes an extension to the overrides config
+type Extension interface {
+	// Key used as a property in YAML/JSON to store the extended config
+	Key() string
+	// RegisterFlagsAndApplyDefaults registers flags and applies defaults for this overrides extension
+	RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
+	// Validate validates the config for this overrides extension
+	Validate() error
+	// LegacyKeys from the flattened legacy config
+	LegacyKeys() []string
+	// FromLegacy converts this overrides extension from the legacy config to the new config
+	FromLegacy(map[string]any)
+	// ToLegacy converts this overrides extension from the new config to the legacy config
+	ToLegacy() map[string]any
+}
+
+var registeredExtensions = struct {
+	sync.RWMutex
+	elements map[string]Extension
+}{elements: make(map[string]Extension)}
+
+func RegisterExtension(e Extension) {
+	registeredExtensions.Lock()
+	defer registeredExtensions.Unlock()
+
+	registeredExtensions.elements[e.Key()] = e
+}

--- a/modules/overrides/extension.go
+++ b/modules/overrides/extension.go
@@ -42,9 +42,10 @@ func (e *registryEntry) newInstance() Extension {
 }
 
 var extensionRegistry = struct {
+	allLegacyKeys map[string]struct{} // union of LegacyKeys() across all registered extensions
 	sync.RWMutex
 	entries map[string]*registryEntry
-}{entries: make(map[string]*registryEntry)}
+}{entries: make(map[string]*registryEntry), allLegacyKeys: make(map[string]struct{})}
 
 // RegisterExtension registers a per-tenant overrides extension. The extension e must be a non-nil
 // pointer to the extension struct (pointer receivers are required).
@@ -89,16 +90,12 @@ func RegisterExtension[T Extension](e T) func(*Overrides) T {
 		if _, conflict := knownLegacy[lk]; conflict {
 			panic(fmt.Sprintf("overrides: extension %q legacy key %q conflicts with a built-in LegacyOverrides field; choose a different legacy key", key, lk))
 		}
-		// Guard against collisions with already-registered extensions' keys and legacy keys.
-		for existingKey, entry := range extensionRegistry.entries {
-			if lk == existingKey {
-				panic(fmt.Sprintf("overrides: extension %q legacy key %q conflicts with the key of extension %q", key, lk, existingKey))
-			}
-			for _, existingLK := range entry.legacyKeys {
-				if lk == existingLK {
-					panic(fmt.Sprintf("overrides: extension %q legacy key %q conflicts with a legacy key of extension %q", key, lk, existingKey))
-				}
-			}
+		// Guard against collisions with already-registered extensions' nested keys and legacy keys.
+		if _, conflict := extensionRegistry.entries[lk]; conflict {
+			panic(fmt.Sprintf("overrides: extension %q legacy key %q conflicts with the key of extension %q", key, lk, lk))
+		}
+		if _, conflict := extensionRegistry.allLegacyKeys[lk]; conflict {
+			panic(fmt.Sprintf("overrides: extension %q legacy key %q conflicts with a legacy key of an already-registered extension", key, lk))
 		}
 	}
 
@@ -106,6 +103,9 @@ func RegisterExtension[T Extension](e T) func(*Overrides) T {
 		key:        key,
 		legacyKeys: legacyKeys,
 		elemType:   typ.Elem(),
+	}
+	for _, lk := range legacyKeys {
+		extensionRegistry.allLegacyKeys[lk] = struct{}{}
 	}
 
 	return func(o *Overrides) T {
@@ -285,14 +285,8 @@ func isExtensionError(err error) bool {
 // isRegisteredExtensionLegacyKey reports whether key matches a flat legacy key declared by any
 // registered extension. Must be called with extensionRegistry.RLock held.
 func isRegisteredExtensionLegacyKey(key string) bool {
-	for _, entry := range extensionRegistry.entries {
-		for _, lk := range entry.legacyKeys {
-			if key == lk {
-				return true
-			}
-		}
-	}
-	return false
+	_, ok := extensionRegistry.allLegacyKeys[key]
+	return ok
 }
 
 // unknownExtensionKeyError is returned by processExtensions when a key in

--- a/modules/overrides/extension.go
+++ b/modules/overrides/extension.go
@@ -2,6 +2,7 @@ package overrides
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"reflect"
@@ -15,7 +16,7 @@ type Extension interface {
 	Key() string
 	// RegisterFlagsAndApplyDefaults applies defaults for the extension config.
 	RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
-	// Validate validates the extension config after it has been decoded.
+	// Validate validates the extension config after it has been decoded. Validate must be idempotent.
 	Validate() error
 	// LegacyKeys returns the flat-key names used in the legacy overrides format.
 	// Return an empty slice if there are no legacy keys.
@@ -44,9 +45,11 @@ var extensionRegistry = struct {
 	entries map[string]*registryEntry
 }{entries: make(map[string]*registryEntry)}
 
-// RegisterExtension registers a per-tenant overrides extension.
-// e must be a non-nil pointer to the extension struct (pointer receivers are required).
-// Panics if an extension with the same Key() is already registered.
+// RegisterExtension registers a per-tenant overrides extension. The extension e must be a non-nil
+// pointer to the extension struct (pointer receivers are required).
+// Panics if an extension with the same Key() is already registered, or if the key
+// conflicts with a known Overrides field name (which would cause silent data loss
+// during JSON marshal/unmarshal).
 // Returns a typed getter that retrieves the extension value from an Overrides.
 func RegisterExtension[T Extension](e T) func(*Overrides) T {
 	key := e.Key()
@@ -61,6 +64,9 @@ func RegisterExtension[T Extension](e T) func(*Overrides) T {
 	typ := reflect.TypeOf(e)
 	if typ == nil || typ.Kind() != reflect.Ptr {
 		panic(fmt.Sprintf("overrides: extension %q must be registered as a pointer type", key))
+	}
+	if _, conflict := knownOverridesJSONFields()[key]; conflict {
+		panic(fmt.Sprintf("overrides: extension key %q conflicts with a built-in Overrides field; choose a different key", key))
 	}
 
 	extensionRegistry.entries[key] = &registryEntry{
@@ -96,10 +102,10 @@ func processExtensions(o *Overrides) error {
 			return fmt.Errorf("unknown extension key %q: must be registered via RegisterExtension before use", key)
 		}
 
-		// Already a typed Extension (e.g., set programmatically or after legacy conversion): just validate.
+		// Already a typed Extension (set programmatically or after legacy conversion)
 		if ext, alreadyTyped := raw.(Extension); alreadyTyped {
 			if err := ext.Validate(); err != nil {
-				return fmt.Errorf("extension %q: %w", key, err)
+				return &extensionError{fmt.Errorf("extension %q: %w", key, err)}
 			}
 			continue
 		}
@@ -109,17 +115,16 @@ func processExtensions(o *Overrides) error {
 		// Per-tenant extension configs have no CLI prefix.
 		instance.RegisterFlagsAndApplyDefaults("", flag.NewFlagSet("", flag.ContinueOnError))
 
-		// Decode via JSON round-trip, which also normalises map[any]any from YAML.
+		// Decode via JSON round-trip, which also normalizes map[any]any from YAML.
 		b, err := json.Marshal(normalizeYAMLValue(raw))
 		if err != nil {
-			return fmt.Errorf("extension %q: marshal: %w", key, err)
+			return &extensionError{fmt.Errorf("extension %q: marshal: %w", key, err)}
 		}
 		if err := json.Unmarshal(b, instance); err != nil {
-			return fmt.Errorf("extension %q: unmarshal: %w", key, err)
+			return &extensionError{fmt.Errorf("extension %q: unmarshal: %w", key, err)}
 		}
-
 		if err := instance.Validate(); err != nil {
-			return fmt.Errorf("extension %q: %w", key, err)
+			return &extensionError{fmt.Errorf("extension %q: %w", key, err)}
 		}
 
 		o.Extensions[key] = instance
@@ -175,9 +180,6 @@ func processLegacyExtensions(l *LegacyOverrides) error {
 		for _, fk := range entry.legacyKeys {
 			delete(l.Extensions, fk)
 		}
-		if l.Extensions == nil {
-			l.Extensions = make(map[string]any)
-		}
 		l.Extensions[entry.key] = instance
 	}
 	return nil
@@ -228,17 +230,14 @@ func normalizeYAMLValue(v any) any {
 	}
 }
 
-// ResetRegistryForTesting clears the extension registry and restores it after the test.
-// This prevents extension registrations in one test from leaking into others.
-func ResetRegistryForTesting(t interface{ Cleanup(func()) }) {
-	extensionRegistry.Lock()
-	saved := extensionRegistry.entries
-	extensionRegistry.entries = make(map[string]*registryEntry)
-	extensionRegistry.Unlock()
+// extensionError wraps errors that originate from extension unmarshal or validation.
+type extensionError struct{ err error }
 
-	t.Cleanup(func() {
-		extensionRegistry.Lock()
-		extensionRegistry.entries = saved
-		extensionRegistry.Unlock()
-	})
+func (e *extensionError) Error() string { return e.err.Error() }
+func (e *extensionError) Unwrap() error { return e.err }
+
+// isExtensionError reports whether err (or any error in its chain) is an extensionError.
+func isExtensionError(err error) bool {
+	var e *extensionError
+	return errors.As(err, &e)
 }

--- a/modules/overrides/extension.go
+++ b/modules/overrides/extension.go
@@ -65,6 +65,9 @@ func RegisterExtension[T Extension](e T) func(*Overrides) T {
 	}
 
 	key := e.Key()
+	if key == "" {
+		panic("overrides: extension Key() cannot be empty")
+	}
 
 	extensionRegistry.Lock()
 	defer extensionRegistry.Unlock()

--- a/modules/overrides/extension.go
+++ b/modules/overrides/extension.go
@@ -49,9 +49,13 @@ var extensionRegistry = struct {
 
 // RegisterExtension registers a per-tenant overrides extension. The extension e must be a non-nil
 // pointer to the extension struct (pointer receivers are required).
-// Panics if an extension with the same Key() is already registered, or if the key
-// conflicts with a known Overrides field name (which would cause silent data loss
-// during JSON marshal/unmarshal).
+// Panics if:
+//   - e is nil or not a pointer
+//   - Key() is empty or already registered
+//   - Key() conflicts with any built-in Overrides or LegacyOverrides field name
+//   - Key() conflicts with a legacy flat key of an already-registered extension
+//   - any LegacyKeys() entry is empty, duplicate, or conflicts with a built-in or already-registered name
+//
 // Returns a typed getter that retrieves the extension value from an Overrides.
 func RegisterExtension[T Extension](e T) func(*Overrides) T {
 	// Check for nil / typed-nil before any method call so callers get a clear
@@ -68,38 +72,13 @@ func RegisterExtension[T Extension](e T) func(*Overrides) T {
 	if key == "" {
 		panic("overrides: extension Key() cannot be empty")
 	}
+	legacyKeys := e.LegacyKeys()
 
 	extensionRegistry.Lock()
 	defer extensionRegistry.Unlock()
 
-	if _, exists := extensionRegistry.entries[key]; exists {
-		panic(fmt.Sprintf("overrides: extension %q already registered", key))
-	}
-	if _, conflict := knownOverridesJSONFields()[key]; conflict {
-		panic(fmt.Sprintf("overrides: extension key %q conflicts with a built-in Overrides field; choose a different key", key))
-	}
-
-	legacyKeys := e.LegacyKeys()
-	seenLegacy := make(map[string]struct{}, len(legacyKeys))
-	for _, lk := range legacyKeys {
-		if lk == "" {
-			panic(fmt.Sprintf("overrides: extension %q has an empty legacy key", key))
-		}
-		if _, dup := seenLegacy[lk]; dup {
-			panic(fmt.Sprintf("overrides: extension %q has duplicate legacy key %q", key, lk))
-		}
-		seenLegacy[lk] = struct{}{}
-		if isKnownLegacyOverridesField(lk) {
-			panic(fmt.Sprintf("overrides: extension %q legacy key %q conflicts with a built-in LegacyOverrides field; choose a different legacy key", key, lk))
-		}
-		// Guard against collisions with already-registered extensions' nested keys and legacy keys.
-		if _, conflict := extensionRegistry.entries[lk]; conflict {
-			panic(fmt.Sprintf("overrides: extension %q legacy key %q conflicts with the key of extension %q", key, lk, lk))
-		}
-		if _, conflict := extensionRegistry.allLegacyKeys[lk]; conflict {
-			panic(fmt.Sprintf("overrides: extension %q legacy key %q conflicts with a legacy key of an already-registered extension", key, lk))
-		}
-	}
+	validateExtensionKey(key)
+	validateExtensionLegacyKeys(key, legacyKeys)
 
 	extensionRegistry.entries[key] = &registryEntry{
 		key:        key,
@@ -117,6 +96,48 @@ func RegisterExtension[T Extension](e T) func(*Overrides) T {
 		}
 		v, _ := o.Extensions[key].(T)
 		return v
+	}
+}
+
+// validateExtensionKey checks that key does not conflict with any reserved name.
+// Must be called with extensionRegistry.Lock held.
+func validateExtensionKey(key string) {
+	if _, exists := extensionRegistry.entries[key]; exists {
+		panic(fmt.Sprintf("overrides: extension %q already registered", key))
+	}
+	if _, conflict := knownOverridesJSONFields()[key]; conflict {
+		panic(fmt.Sprintf("overrides: extension key %q conflicts with a built-in Overrides field; choose a different key", key))
+	}
+	if isKnownLegacyOverridesField(key) {
+		panic(fmt.Sprintf("overrides: extension key %q conflicts with a built-in LegacyOverrides field; choose a different key", key))
+	}
+	if _, conflict := extensionRegistry.allLegacyKeys[key]; conflict {
+		panic(fmt.Sprintf("overrides: extension key %q conflicts with a legacy key of an already-registered extension; choose a different key", key))
+	}
+}
+
+// validateExtensionLegacyKeys checks that legacyKeys declared by extension key are valid.
+// Must be called with extensionRegistry.Lock held.
+func validateExtensionLegacyKeys(key string, legacyKeys []string) {
+	seen := make(map[string]struct{}, len(legacyKeys))
+	for _, lk := range legacyKeys {
+		if lk == "" {
+			panic(fmt.Sprintf("overrides: extension %q has an empty legacy key", key))
+		}
+		if _, dup := seen[lk]; dup {
+			panic(fmt.Sprintf("overrides: extension %q has duplicate legacy key %q", key, lk))
+		}
+		seen[lk] = struct{}{}
+		if isKnownLegacyOverridesField(lk) {
+			panic(fmt.Sprintf("overrides: extension %q legacy key %q conflicts with a built-in LegacyOverrides field; choose a different legacy key", key, lk))
+		}
+		// Guard against collisions with already-registered extensions' nested keys and legacy keys.
+		if _, conflict := extensionRegistry.entries[lk]; conflict {
+			panic(fmt.Sprintf("overrides: extension %q legacy key %q conflicts with the key of extension %q", key, lk, lk))
+		}
+		if _, conflict := extensionRegistry.allLegacyKeys[lk]; conflict {
+			panic(fmt.Sprintf("overrides: extension %q legacy key %q conflicts with a legacy key of an already-registered extension", key, lk))
+		}
 	}
 }
 

--- a/modules/overrides/extension.go
+++ b/modules/overrides/extension.go
@@ -132,7 +132,8 @@ func processExtensions(o *Overrides) error {
 	for key, raw := range o.Extensions {
 		entry, ok := extensionRegistry.entries[key]
 		if !ok {
-			return &unknownExtensionKeyError{key: key, isLegacy: isKnownLegacyOverridesField(key)}
+			isLegacy := isKnownLegacyOverridesField(key) || isRegisteredExtensionLegacyKey(key)
+			return &unknownExtensionKeyError{key: key, isLegacy: isLegacy}
 		}
 
 		// Already a typed Extension (set programmatically or after legacy conversion)
@@ -177,8 +178,7 @@ func processExtensions(o *Overrides) error {
 // created, defaults applied, FromLegacy called, and the instance validated. The flat keys are
 // then removed and the typed instance stored under the extension's Key().
 //
-// Keys that don't correspond to any registered extension's LegacyKeys are left as-is; strict
-// validation for those happens later when processExtensions is called on the converted Overrides.
+// Any unregistered flat keys are rejected.
 func processLegacyExtensions(l *LegacyOverrides) error {
 	if len(l.Extensions) == 0 {
 		return nil
@@ -215,6 +215,13 @@ func processLegacyExtensions(l *LegacyOverrides) error {
 		}
 		l.Extensions[entry.key] = instance
 	}
+
+	// Reject any remaining / unregistered flat keys
+	for k, v := range l.Extensions {
+		if _, typed := v.(Extension); !typed {
+			return fmt.Errorf("unknown legacy extension key %q: must be registered via RegisterExtension and declared in LegacyKeys() before use", k)
+		}
+	}
 	return nil
 }
 
@@ -229,7 +236,7 @@ func flattenExtensionEntries(m map[string]any) map[string]any {
 				out[fk] = fv
 			}
 		} else {
-			out[k] = v
+			panic(fmt.Sprintf("overrides: flattenExtensionEntries: entry %q is not an Extension", k))
 		}
 	}
 	return out
@@ -273,6 +280,19 @@ func (e *extensionError) Unwrap() error { return e.err }
 func isExtensionError(err error) bool {
 	var e *extensionError
 	return errors.As(err, &e)
+}
+
+// isRegisteredExtensionLegacyKey reports whether key matches a flat legacy key declared by any
+// registered extension. Must be called with extensionRegistry.RLock held.
+func isRegisteredExtensionLegacyKey(key string) bool {
+	for _, entry := range extensionRegistry.entries {
+		for _, lk := range entry.legacyKeys {
+			if key == lk {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // unknownExtensionKeyError is returned by processExtensions when a key in

--- a/modules/overrides/extension.go
+++ b/modules/overrides/extension.go
@@ -53,6 +53,16 @@ var extensionRegistry = struct {
 // during JSON marshal/unmarshal).
 // Returns a typed getter that retrieves the extension value from an Overrides.
 func RegisterExtension[T Extension](e T) func(*Overrides) T {
+	// Check for nil / typed-nil before any method call so callers get a clear
+	// panic message instead of a nil-dereference inside Key() or LegacyKeys().
+	typ := reflect.TypeOf(e)
+	if typ == nil || typ.Kind() != reflect.Ptr {
+		panic("overrides: RegisterExtension requires a non-nil pointer to the extension struct")
+	}
+	if reflect.ValueOf(e).IsNil() {
+		panic("overrides: RegisterExtension requires a non-nil pointer to the extension struct")
+	}
+
 	key := e.Key()
 
 	extensionRegistry.Lock()
@@ -60,11 +70,6 @@ func RegisterExtension[T Extension](e T) func(*Overrides) T {
 
 	if _, exists := extensionRegistry.entries[key]; exists {
 		panic(fmt.Sprintf("overrides: extension %q already registered", key))
-	}
-
-	typ := reflect.TypeOf(e)
-	if typ == nil || typ.Kind() != reflect.Ptr {
-		panic(fmt.Sprintf("overrides: extension %q must be registered as a pointer type", key))
 	}
 	if _, conflict := knownOverridesJSONFields()[key]; conflict {
 		panic(fmt.Sprintf("overrides: extension key %q conflicts with a built-in Overrides field; choose a different key", key))

--- a/modules/overrides/extension.go
+++ b/modules/overrides/extension.go
@@ -132,7 +132,7 @@ func processExtensions(o *Overrides) error {
 	for key, raw := range o.Extensions {
 		entry, ok := extensionRegistry.entries[key]
 		if !ok {
-			return fmt.Errorf("unknown extension key %q: must be registered via RegisterExtension before use", key)
+			return &unknownExtensionKeyError{key: key, isLegacy: isKnownLegacyOverridesField(key)}
 		}
 
 		// Already a typed Extension (set programmatically or after legacy conversion)
@@ -275,4 +275,29 @@ func (e *extensionError) Unwrap() error { return e.err }
 func isExtensionError(err error) bool {
 	var e *extensionError
 	return errors.As(err, &e)
+}
+
+// unknownExtensionKeyError is returned by processExtensions when a key in
+// o.Extensions is not found in the registry
+type unknownExtensionKeyError struct {
+	key      string // the unknown extension key
+	isLegacy bool   // true if key matches a known LegacyOverrides field name
+}
+
+func (e *unknownExtensionKeyError) Error() string {
+	return fmt.Sprintf("unknown extension key %q: must be registered via RegisterExtension before use", e.key)
+}
+
+// isLegacyExtensionKeyError reports whether err is an unknownExtensionKeyError that matches a known
+// legacy field name. If true, this signals that it's safe to fallback to legacy format.
+func isLegacyExtensionKeyError(err error) bool {
+	var e *unknownExtensionKeyError
+	return errors.As(err, &e) && e.isLegacy
+}
+
+// isExtensionKeyError reports whether err is an unknownExtensionKeyError that does not match a known
+// legacy field name.
+func isExtensionKeyError(err error) bool {
+	var e *unknownExtensionKeyError
+	return errors.As(err, &e) && !e.isLegacy
 }

--- a/modules/overrides/extension.go
+++ b/modules/overrides/extension.go
@@ -155,7 +155,9 @@ func processExtensions(o *Overrides) error {
 		}
 		dec := json.NewDecoder(bytes.NewReader(b))
 		dec.DisallowUnknownFields()
-		if err := dec.Decode(instance); err != nil {
+
+		err = dec.Decode(instance)
+		if err != nil {
 			return &extensionError{fmt.Errorf("extension %q: unmarshal: %w", key, err)}
 		}
 		if err := instance.Validate(); err != nil {
@@ -183,15 +185,9 @@ func processLegacyExtensions(l *LegacyOverrides) error {
 	}
 
 	extensionRegistry.RLock()
-	entries := make([]*registryEntry, 0, len(extensionRegistry.entries))
-	for _, e := range extensionRegistry.entries {
-		if len(e.legacyKeys) > 0 {
-			entries = append(entries, e)
-		}
-	}
-	extensionRegistry.RUnlock()
+	defer extensionRegistry.RUnlock()
 
-	for _, entry := range entries {
+	for _, entry := range extensionRegistry.entries {
 		hasFlatKey := false
 		for _, fk := range entry.legacyKeys {
 			if _, ok := l.Extensions[fk]; ok {
@@ -204,14 +200,16 @@ func processLegacyExtensions(l *LegacyOverrides) error {
 		}
 
 		instance := entry.newInstance()
-		// Per-tenant extension configs have no CLI prefix.
-		instance.RegisterFlagsAndApplyDefaults("", flag.NewFlagSet("", flag.ContinueOnError))
-		if err := instance.FromLegacy(l.Extensions); err != nil {
+		instance.RegisterFlagsAndApplyDefaults("", flag.NewFlagSet("", flag.ContinueOnError)) // extension configs have no CLI prefix
+
+		err := instance.FromLegacy(l.Extensions)
+		if err != nil {
 			return fmt.Errorf("extension %q: from legacy: %w", entry.key, err)
 		}
 		if err := instance.Validate(); err != nil {
 			return fmt.Errorf("extension %q: %w", entry.key, err)
 		}
+
 		for _, fk := range entry.legacyKeys {
 			delete(l.Extensions, fk)
 		}

--- a/modules/overrides/extension.go
+++ b/modules/overrides/extension.go
@@ -1,34 +1,245 @@
 package overrides
 
 import (
+	"encoding/json"
 	"flag"
+	"fmt"
+	"reflect"
 	"sync"
 )
 
-// Extension describes an extension to the overrides config
+// Extension describes a typed extension to the per-tenant overrides config.
+// Implementations must use pointer receivers for all methods.
 type Extension interface {
-	// Key used as a property in YAML/JSON to store the extended config
+	// Key is the YAML/JSON property name used to store this extension's config.
 	Key() string
-	// RegisterFlagsAndApplyDefaults registers flags and applies defaults for this overrides extension
+	// RegisterFlagsAndApplyDefaults applies defaults for the extension config.
 	RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
-	// Validate validates the config for this overrides extension
+	// Validate validates the extension config after it has been decoded.
 	Validate() error
-	// LegacyKeys from the flattened legacy config
+	// LegacyKeys returns the flat-key names used in the legacy overrides format.
+	// Return an empty slice if there are no legacy keys.
 	LegacyKeys() []string
-	// FromLegacy converts this overrides extension from the legacy config to the new config
-	FromLegacy(map[string]any)
-	// ToLegacy converts this overrides extension from the new config to the legacy config
+	// FromLegacy populates this extension from the flat legacy key map.
+	// The full Extensions map is passed; implementations pick only their own keys.
+	FromLegacy(map[string]any) error
+	// ToLegacy serializes this extension to the flat legacy key map.
 	ToLegacy() map[string]any
 }
 
-var registeredExtensions = struct {
+// registryEntry holds the reflect metadata needed to instantiate an extension.
+type registryEntry struct {
+	key        string
+	legacyKeys []string
+	elemType   reflect.Type // struct type (T without pointer indirection)
+}
+
+// newInstance creates a zeroed pointer instance of the extension type, cast to Extension.
+func (e *registryEntry) newInstance() Extension {
+	return reflect.New(e.elemType).Interface().(Extension)
+}
+
+var extensionRegistry = struct {
 	sync.RWMutex
-	elements map[string]Extension
-}{elements: make(map[string]Extension)}
+	entries map[string]*registryEntry
+}{entries: make(map[string]*registryEntry)}
 
-func RegisterExtension(e Extension) {
-	registeredExtensions.Lock()
-	defer registeredExtensions.Unlock()
+// RegisterExtension registers a per-tenant overrides extension.
+// e must be a non-nil pointer to the extension struct (pointer receivers are required).
+// Panics if an extension with the same Key() is already registered.
+// Returns a typed getter that retrieves the extension value from an Overrides.
+func RegisterExtension[T Extension](e T) func(*Overrides) T {
+	key := e.Key()
 
-	registeredExtensions.elements[e.Key()] = e
+	extensionRegistry.Lock()
+	defer extensionRegistry.Unlock()
+
+	if _, exists := extensionRegistry.entries[key]; exists {
+		panic(fmt.Sprintf("overrides: extension %q already registered", key))
+	}
+
+	typ := reflect.TypeOf(e)
+	if typ == nil || typ.Kind() != reflect.Ptr {
+		panic(fmt.Sprintf("overrides: extension %q must be registered as a pointer type", key))
+	}
+
+	extensionRegistry.entries[key] = &registryEntry{
+		key:        key,
+		legacyKeys: e.LegacyKeys(),
+		elemType:   typ.Elem(),
+	}
+
+	return func(o *Overrides) T {
+		if o == nil || o.Extensions == nil {
+			var zero T
+			return zero
+		}
+		v, _ := o.Extensions[key].(T)
+		return v
+	}
+}
+
+// processExtensions validates all entries in o.Extensions against the registry, converts raw
+// decoded values (from YAML or JSON) to typed Extension instances, applies defaults, and
+// calls Validate on each. It is idempotent: already-typed entries are only re-validated.
+func processExtensions(o *Overrides) error {
+	if len(o.Extensions) == 0 {
+		return nil
+	}
+
+	extensionRegistry.RLock()
+	defer extensionRegistry.RUnlock()
+
+	for key, raw := range o.Extensions {
+		entry, ok := extensionRegistry.entries[key]
+		if !ok {
+			return fmt.Errorf("unknown extension key %q: must be registered via RegisterExtension before use", key)
+		}
+
+		// Already a typed Extension (e.g., set programmatically or after legacy conversion): just validate.
+		if ext, alreadyTyped := raw.(Extension); alreadyTyped {
+			if err := ext.Validate(); err != nil {
+				return fmt.Errorf("extension %q: %w", key, err)
+			}
+			continue
+		}
+
+		// Create a new instance and apply defaults.
+		instance := entry.newInstance()
+		// Per-tenant extension configs have no CLI prefix.
+		instance.RegisterFlagsAndApplyDefaults("", flag.NewFlagSet("", flag.ContinueOnError))
+
+		// Decode via JSON round-trip, which also normalises map[any]any from YAML.
+		b, err := json.Marshal(normalizeYAMLValue(raw))
+		if err != nil {
+			return fmt.Errorf("extension %q: marshal: %w", key, err)
+		}
+		if err := json.Unmarshal(b, instance); err != nil {
+			return fmt.Errorf("extension %q: unmarshal: %w", key, err)
+		}
+
+		if err := instance.Validate(); err != nil {
+			return fmt.Errorf("extension %q: %w", key, err)
+		}
+
+		o.Extensions[key] = instance
+	}
+	return nil
+}
+
+// processLegacyExtensions converts registered extension flat keys in l.Extensions to typed
+// Extension instances, giving LegacyOverrides.Extensions the same semantics as
+// Overrides.Extensions after processExtensions: typed instances keyed by their nested Key().
+//
+// For each registered extension whose LegacyKeys appear in l.Extensions, a typed instance is
+// created, defaults applied, FromLegacy called, and the instance validated. The flat keys are
+// then removed and the typed instance stored under the extension's Key().
+//
+// Keys that don't correspond to any registered extension's LegacyKeys are left as-is; strict
+// validation for those happens later when processExtensions is called on the converted Overrides.
+func processLegacyExtensions(l *LegacyOverrides) error {
+	if len(l.Extensions) == 0 {
+		return nil
+	}
+
+	extensionRegistry.RLock()
+	entries := make([]*registryEntry, 0, len(extensionRegistry.entries))
+	for _, e := range extensionRegistry.entries {
+		if len(e.legacyKeys) > 0 {
+			entries = append(entries, e)
+		}
+	}
+	extensionRegistry.RUnlock()
+
+	for _, entry := range entries {
+		hasFlatKey := false
+		for _, fk := range entry.legacyKeys {
+			if _, ok := l.Extensions[fk]; ok {
+				hasFlatKey = true
+				break
+			}
+		}
+		if !hasFlatKey {
+			continue
+		}
+
+		instance := entry.newInstance()
+		// Per-tenant extension configs have no CLI prefix.
+		instance.RegisterFlagsAndApplyDefaults("", flag.NewFlagSet("", flag.ContinueOnError))
+		if err := instance.FromLegacy(l.Extensions); err != nil {
+			return fmt.Errorf("extension %q: from legacy: %w", entry.key, err)
+		}
+		if err := instance.Validate(); err != nil {
+			return fmt.Errorf("extension %q: %w", entry.key, err)
+		}
+		for _, fk := range entry.legacyKeys {
+			delete(l.Extensions, fk)
+		}
+		if l.Extensions == nil {
+			l.Extensions = make(map[string]any)
+		}
+		l.Extensions[entry.key] = instance
+	}
+	return nil
+}
+
+
+// flattenExtensionEntries returns a new map where typed Extension values are replaced by their
+// flat legacy key-value pairs (via ToLegacy). Non-Extension entries are copied as-is.
+// Used when marshaling LegacyOverrides to produce the flat wire format.
+func flattenExtensionEntries(m map[string]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		if ext, ok := v.(Extension); ok {
+			for fk, fv := range ext.ToLegacy() {
+				out[fk] = fv
+			}
+		} else {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// normalizeYAMLValue converts map[any]any produced by go-yaml to map[string]any recursively,
+// making the value safe to pass to json.Marshal.
+func normalizeYAMLValue(v any) any {
+	switch val := v.(type) {
+	case map[any]any:
+		m := make(map[string]any, len(val))
+		for k, v2 := range val {
+			switch key := k.(type) {
+			case string:
+				m[key] = normalizeYAMLValue(v2)
+			case fmt.Stringer:
+				m[key.String()] = normalizeYAMLValue(v2)
+			default:
+				m[fmt.Sprintf("%v", k)] = normalizeYAMLValue(v2)
+			}
+		}
+		return m
+	case []any:
+		out := make([]any, len(val))
+		for i, elem := range val {
+			out[i] = normalizeYAMLValue(elem)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+// ResetRegistryForTesting clears the extension registry and restores it after the test.
+// This prevents extension registrations in one test from leaking into others.
+func ResetRegistryForTesting(t interface{ Cleanup(func()) }) {
+	extensionRegistry.Lock()
+	saved := extensionRegistry.entries
+	extensionRegistry.entries = make(map[string]*registryEntry)
+	extensionRegistry.Unlock()
+
+	t.Cleanup(func() {
+		extensionRegistry.Lock()
+		extensionRegistry.entries = saved
+		extensionRegistry.Unlock()
+	})
 }

--- a/modules/overrides/extension.go
+++ b/modules/overrides/extension.go
@@ -1,6 +1,7 @@
 package overrides
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -120,7 +121,9 @@ func processExtensions(o *Overrides) error {
 		if err != nil {
 			return &extensionError{fmt.Errorf("extension %q: marshal: %w", key, err)}
 		}
-		if err := json.Unmarshal(b, instance); err != nil {
+		dec := json.NewDecoder(bytes.NewReader(b))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(instance); err != nil {
 			return &extensionError{fmt.Errorf("extension %q: unmarshal: %w", key, err)}
 		}
 		if err := instance.Validate(); err != nil {

--- a/modules/overrides/extension.go
+++ b/modules/overrides/extension.go
@@ -227,19 +227,19 @@ func processLegacyExtensions(l *LegacyOverrides) error {
 // flattenExtensionEntries returns a new map where typed Extension values are replaced by their
 // flat legacy key-value pairs (via ToLegacy).
 // Used when marshaling LegacyOverrides to produce the flat wire format.
-func flattenExtensionEntries(m map[string]any) map[string]any {
+func flattenExtensionEntries(m map[string]any) (map[string]any, error) {
 	out := make(map[string]any, len(m))
 	for k, v := range m {
 		ext, ok := v.(Extension)
 		if !ok {
-			panic(fmt.Sprintf("overrides: flattenExtensionEntries: entry %q is not an Extension", k))
+			return nil, fmt.Errorf("overrides extensions: entry %q is not an Extension", k)
 		}
 
 		for fk, fv := range ext.ToLegacy() {
 			out[fk] = fv
 		}
 	}
-	return out
+	return out, nil
 }
 
 // normalizeYAMLValue converts map[any]any produced by go-yaml to map[string]any recursively,

--- a/modules/overrides/extension.go
+++ b/modules/overrides/extension.go
@@ -70,9 +70,36 @@ func RegisterExtension[T Extension](e T) func(*Overrides) T {
 		panic(fmt.Sprintf("overrides: extension key %q conflicts with a built-in Overrides field; choose a different key", key))
 	}
 
+	legacyKeys := e.LegacyKeys()
+	knownLegacy := knownLegacyOverridesJSONFields()
+	seenLegacy := make(map[string]struct{}, len(legacyKeys))
+	for _, lk := range legacyKeys {
+		if lk == "" {
+			panic(fmt.Sprintf("overrides: extension %q has an empty legacy key", key))
+		}
+		if _, dup := seenLegacy[lk]; dup {
+			panic(fmt.Sprintf("overrides: extension %q has duplicate legacy key %q", key, lk))
+		}
+		seenLegacy[lk] = struct{}{}
+		if _, conflict := knownLegacy[lk]; conflict {
+			panic(fmt.Sprintf("overrides: extension %q legacy key %q conflicts with a built-in LegacyOverrides field; choose a different legacy key", key, lk))
+		}
+		// Guard against collisions with already-registered extensions' keys and legacy keys.
+		for existingKey, entry := range extensionRegistry.entries {
+			if lk == existingKey {
+				panic(fmt.Sprintf("overrides: extension %q legacy key %q conflicts with the key of extension %q", key, lk, existingKey))
+			}
+			for _, existingLK := range entry.legacyKeys {
+				if lk == existingLK {
+					panic(fmt.Sprintf("overrides: extension %q legacy key %q conflicts with a legacy key of extension %q", key, lk, existingKey))
+				}
+			}
+		}
+	}
+
 	extensionRegistry.entries[key] = &registryEntry{
 		key:        key,
-		legacyKeys: e.LegacyKeys(),
+		legacyKeys: legacyKeys,
 		elemType:   typ.Elem(),
 	}
 

--- a/modules/overrides/extension.go
+++ b/modules/overrides/extension.go
@@ -225,17 +225,18 @@ func processLegacyExtensions(l *LegacyOverrides) error {
 }
 
 // flattenExtensionEntries returns a new map where typed Extension values are replaced by their
-// flat legacy key-value pairs (via ToLegacy). Non-Extension entries are copied as-is.
+// flat legacy key-value pairs (via ToLegacy).
 // Used when marshaling LegacyOverrides to produce the flat wire format.
 func flattenExtensionEntries(m map[string]any) map[string]any {
 	out := make(map[string]any, len(m))
 	for k, v := range m {
-		if ext, ok := v.(Extension); ok {
-			for fk, fv := range ext.ToLegacy() {
-				out[fk] = fv
-			}
-		} else {
+		ext, ok := v.(Extension)
+		if !ok {
 			panic(fmt.Sprintf("overrides: flattenExtensionEntries: entry %q is not an Extension", k))
+		}
+
+		for fk, fv := range ext.ToLegacy() {
+			out[fk] = fv
 		}
 	}
 	return out

--- a/modules/overrides/extension_test.go
+++ b/modules/overrides/extension_test.go
@@ -1,31 +1,422 @@
 package overrides
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v2"
 )
 
+func TestRegisterExtension_PanicsOnDuplicate(t *testing.T) {
+	ResetRegistryForTesting(t)
+	RegisterExtension(&testExtension{})
+	assert.Panics(t, func() { RegisterExtension(&testExtension{}) })
+}
+
+func TestRegisterExtension_TypedGetter(t *testing.T) {
+	ResetRegistryForTesting(t)
+	get := RegisterExtension(&testExtension{})
+
+	fieldB := 99
+	o := Overrides{
+		Extensions: map[string]any{"test_extension": &testExtension{FieldA: "hello", FieldB: &fieldB}},
+	}
+	ext := get(&o)
+	require.NotNil(t, ext)
+	assert.Equal(t, "hello", ext.FieldA)
+	assert.Equal(t, 99, *ext.FieldB)
+
+	// Nil Overrides and empty Extensions both return zero value.
+	assert.Nil(t, get(nil))
+	assert.Nil(t, get(&Overrides{}))
+}
+
 func TestOverridesExtension_MarshalJSON(t *testing.T) {
-	// TODO register the extension and test the marshaling
-	// implement a sub-test for legacy and non legacy overrides
+	t.Run("overrides", func(t *testing.T) {
+		ResetRegistryForTesting(t)
+		get := RegisterExtension(&testExtension{})
+
+		fieldB := 42
+		o := Overrides{}
+		o.Ingestion.MaxLocalTracesPerUser = 1000
+		o.Extensions = map[string]any{
+			"test_extension": &testExtension{FieldA: "custom", FieldB: &fieldB},
+		}
+
+		b, err := json.Marshal(&o)
+		require.NoError(t, err)
+
+		var o2 Overrides
+		require.NoError(t, json.Unmarshal(b, &o2))
+
+		assert.Equal(t, 1000, o2.Ingestion.MaxLocalTracesPerUser)
+		ext := get(&o2)
+		require.NotNil(t, ext)
+		assert.Equal(t, "custom", ext.FieldA)
+		assert.Equal(t, 42, *ext.FieldB)
+	})
+
+	t.Run("legacy overrides", func(t *testing.T) {
+		ResetRegistryForTesting(t)
+		RegisterExtension(&testExtension{})
+
+		fieldB := 7
+		o := Overrides{}
+		o.Ingestion.MaxLocalTracesPerUser = 500
+		o.Extensions = map[string]any{
+			"test_extension": &testExtension{FieldA: "flat_val", FieldB: &fieldB},
+		}
+		l := o.toLegacy()
+
+		// After toLegacy, Extensions holds the typed instance; flat keys appear only when marshaled.
+		extInLegacy, ok := l.Extensions["test_extension"].(*testExtension)
+		require.True(t, ok, "expected typed test_extension in LegacyOverrides.Extensions")
+		assert.Equal(t, "flat_val", extInLegacy.FieldA)
+
+		b, err := json.Marshal(&l)
+		require.NoError(t, err)
+
+		// The nested extension key must be replaced by its flat keys in JSON.
+		var m map[string]any
+		require.NoError(t, json.Unmarshal(b, &m))
+		assert.Equal(t, "flat_val", m["test_extension_field_a"], "flat key must appear in JSON")
+		assert.Nil(t, m["test_extension"], "nested key must not appear in JSON")
+
+		// Unmarshal the JSON back to LegacyOverrides; processLegacyExtensions converts flat keys
+		// to a typed instance under the nested key.
+		var l2 LegacyOverrides
+		require.NoError(t, json.Unmarshal(b, &l2))
+		ext2, ok2 := l2.Extensions["test_extension"].(*testExtension)
+		require.True(t, ok2, "expected typed test_extension in l2.Extensions after unmarshal")
+		assert.Equal(t, "flat_val", ext2.FieldA)
+	})
 }
 
 func TestOverridesExtension_UnmarshalJSON(t *testing.T) {
-	// TODO register the extension and test the marshaling
-	// implement a sub-test for legacy and non legacy overrides
-	// also test a JSON payload with an unregistered extension and check that it fails
+	t.Run("overrides", func(t *testing.T) {
+		ResetRegistryForTesting(t)
+		get := RegisterExtension(&testExtension{})
+
+		input := `{
+			"ingestion": {"max_traces_per_user": 1000},
+			"test_extension": {"field_a": "from_json", "field_b": 55}
+		}`
+		var o Overrides
+		require.NoError(t, json.Unmarshal([]byte(input), &o))
+
+		assert.Equal(t, 1000, o.Ingestion.MaxLocalTracesPerUser)
+		ext := get(&o)
+		require.NotNil(t, ext)
+		assert.Equal(t, "from_json", ext.FieldA)
+		assert.Equal(t, 55, *ext.FieldB)
+	})
+
+	t.Run("overrides defaults applied", func(t *testing.T) {
+		ResetRegistryForTesting(t)
+		get := RegisterExtension(&testExtension{})
+
+		// field_b is omitted — the default (pointer to 0) must be used.
+		input := `{"test_extension": {"field_a": "only_a"}}`
+		var o Overrides
+		require.NoError(t, json.Unmarshal([]byte(input), &o))
+
+		ext := get(&o)
+		require.NotNil(t, ext)
+		assert.Equal(t, "only_a", ext.FieldA)
+		require.NotNil(t, ext.FieldB, "default FieldB must be applied")
+		assert.Equal(t, 0, *ext.FieldB)
+	})
+
+	t.Run("overrides unregistered key", func(t *testing.T) {
+		ResetRegistryForTesting(t)
+
+		input := `{"ingestion": {"max_traces_per_user": 1}, "unknown_ext": {"x": 1}}`
+		var o Overrides
+		err := json.Unmarshal([]byte(input), &o)
+		require.ErrorContains(t, err, "unknown extension key")
+	})
+
+	t.Run("overrides validate error", func(t *testing.T) {
+		ResetRegistryForTesting(t)
+		RegisterExtension(&testExtension{})
+
+		// field_a is empty — Validate must reject it.
+		input := `{"test_extension": {"field_a": ""}}`
+		var o Overrides
+		err := json.Unmarshal([]byte(input), &o)
+		require.ErrorContains(t, err, "field_a cannot be empty")
+	})
+
+	t.Run("legacy overrides", func(t *testing.T) {
+		ResetRegistryForTesting(t)
+		RegisterExtension(&testExtension{})
+
+		// LegacyOverrides JSON may contain flat extension keys; processLegacyExtensions converts
+		// them to typed instances under the nested key immediately at unmarshal time.
+		input := `{"max_traces_per_user": 1000, "test_extension_field_a": "from_legacy_json"}`
+		var l LegacyOverrides
+		require.NoError(t, json.Unmarshal([]byte(input), &l))
+		assert.Equal(t, 1000, l.MaxLocalTracesPerUser)
+		ext, ok := l.Extensions["test_extension"].(*testExtension)
+		require.True(t, ok, "expected typed test_extension in l.Extensions after unmarshal")
+		assert.Equal(t, "from_legacy_json", ext.FieldA)
+		require.NotNil(t, ext.FieldB, "default for FieldB must be applied")
+		assert.Equal(t, 0, *ext.FieldB)
+	})
 }
 
 func TestOverridesExtension_MarshalYAML(t *testing.T) {
-	// TODO register the extension and test the marshaling
-	// implement a sub-test for legacy and non legacy overrides
+	t.Run("overrides", func(t *testing.T) {
+		ResetRegistryForTesting(t)
+		get := RegisterExtension(&testExtension{})
+
+		fieldB := 3
+		o := Overrides{}
+		o.Ingestion.MaxLocalTracesPerUser = 1000
+		o.Extensions = map[string]any{
+			"test_extension": &testExtension{FieldA: "yaml_val", FieldB: &fieldB},
+		}
+
+		b, err := yaml.Marshal(&o)
+		require.NoError(t, err)
+
+		// The marshaled YAML must contain the nested extension key.
+		assert.Contains(t, string(b), "test_extension:")
+
+		// Round-trip: unmarshal recovers the extension (Overrides.UnmarshalYAML calls processExtensions).
+		var o2 Overrides
+		require.NoError(t, yaml.Unmarshal(b, &o2))
+
+		assert.Equal(t, 1000, o2.Ingestion.MaxLocalTracesPerUser)
+		ext := get(&o2)
+		require.NotNil(t, ext)
+		assert.Equal(t, "yaml_val", ext.FieldA)
+		assert.Equal(t, 3, *ext.FieldB)
+	})
+
+	t.Run("legacy overrides", func(t *testing.T) {
+		ResetRegistryForTesting(t)
+		RegisterExtension(&testExtension{})
+
+		fieldB := 8
+		o := Overrides{}
+		o.Ingestion.MaxLocalTracesPerUser = 500
+		o.Extensions = map[string]any{
+			"test_extension": &testExtension{FieldA: "legacy_yaml", FieldB: &fieldB},
+		}
+		l := o.toLegacy()
+
+		b, err := yaml.Marshal(&l)
+		require.NoError(t, err)
+
+		// Flat keys must appear at the top level; nested key must not.
+		yamlStr := string(b)
+		assert.Contains(t, yamlStr, "test_extension_field_a:")
+		assert.NotContains(t, yamlStr, "test_extension:")
+	})
 }
 
 func TestOverridesExtension_UnmarshalYAML(t *testing.T) {
-	// TODO register the extension and test the marshaling
-	// implement a sub-test for legacy and non legacy overrides
-	// also test a JSON payload with an unregistered extension and check that it fails
+	t.Run("overrides", func(t *testing.T) {
+		ResetRegistryForTesting(t)
+		get := RegisterExtension(&testExtension{})
+
+		input := `
+ingestion:
+  max_traces_per_user: 1000
+test_extension:
+  field_a: from_yaml
+  field_b: 11
+`
+		var o Overrides
+		require.NoError(t, yaml.Unmarshal([]byte(input), &o))
+
+		assert.Equal(t, 1000, o.Ingestion.MaxLocalTracesPerUser)
+		ext := get(&o)
+		require.NotNil(t, ext)
+		assert.Equal(t, "from_yaml", ext.FieldA)
+		assert.Equal(t, 11, *ext.FieldB)
+	})
+
+	t.Run("Overrides_strict_decoder_absorbs_extension_key", func(t *testing.T) {
+		ResetRegistryForTesting(t)
+		RegisterExtension(&testExtension{})
+
+		input := `
+ingestion:
+  max_traces_per_user: 500
+test_extension:
+  field_a: strict_ok
+`
+		var o Overrides
+		decoder := yaml.NewDecoder(strings.NewReader(input))
+		decoder.SetStrict(true)
+		require.NoError(t, decoder.Decode(&o), "strict YAML decoder must not error on registered extension keys")
+	})
+
+	t.Run("overrides unregistered key", func(t *testing.T) {
+		ResetRegistryForTesting(t)
+
+		input := `
+ingestion:
+  max_traces_per_user: 1
+unknown_ext:
+  x: 1
+`
+		var o Overrides
+		err := yaml.Unmarshal([]byte(input), &o)
+		require.ErrorContains(t, err, "unknown extension key")
+	})
+
+	t.Run("legacy overrides", func(t *testing.T) {
+		ResetRegistryForTesting(t)
+		get := RegisterExtension(&testExtension{})
+
+		input := `
+max_traces_per_user: 1000
+test_extension_field_a: from_legacy_yaml
+`
+		var l LegacyOverrides
+		require.NoError(t, yaml.Unmarshal([]byte(input), &l))
+
+		assert.Equal(t, 1000, l.MaxLocalTracesPerUser)
+		// processLegacyExtensions converts the flat key to a typed instance at unmarshal time.
+		lExt, ok := l.Extensions["test_extension"].(*testExtension)
+		require.True(t, ok, "expected typed test_extension in l.Extensions after unmarshal")
+		assert.Equal(t, "from_legacy_yaml", lExt.FieldA)
+		// field_b was not in the YAML; the default (pointer to 0) must be used.
+		require.NotNil(t, lExt.FieldB)
+		assert.Equal(t, 0, *lExt.FieldB)
+
+		// toNewLimits copies typed extensions; processExtensions validates them.
+		o, err := l.toNewLimits()
+		require.NoError(t, err)
+		require.NoError(t, processExtensions(&o))
+
+		ext := get(&o)
+		require.NotNil(t, ext)
+		assert.Equal(t, "from_legacy_yaml", ext.FieldA)
+		require.NotNil(t, ext.FieldB)
+		assert.Equal(t, 0, *ext.FieldB)
+	})
+}
+
+func TestExtension_FullLegacyRoundTrip_perTenantOverrides(t *testing.T) {
+	ResetRegistryForTesting(t)
+	get := RegisterExtension(&testExtension{})
+
+	input := `
+overrides:
+  tenant-1:
+    max_traces_per_user: 1000
+    test_extension_field_a: roundtrip_val
+`
+	var pto perTenantOverrides
+	decoder := yaml.NewDecoder(strings.NewReader(input))
+	decoder.SetStrict(true)
+	require.NoError(t, decoder.Decode(&pto))
+	require.Equal(t, ConfigTypeLegacy, pto.ConfigType)
+
+	limits := pto.TenantLimits["tenant-1"]
+	require.NotNil(t, limits)
+	assert.Equal(t, 1000, limits.Ingestion.MaxLocalTracesPerUser)
+	ext := get(limits)
+	require.NotNil(t, ext)
+	assert.Equal(t, "roundtrip_val", ext.FieldA)
+}
+
+func TestExtension_FullNewFormatRoundTrip_perTenantOverrides(t *testing.T) {
+	ResetRegistryForTesting(t)
+	get := RegisterExtension(&testExtension{})
+
+	input := `
+overrides:
+  tenant-1:
+    ingestion:
+      max_traces_per_user: 2000
+    test_extension:
+      field_a: new_format_val
+      field_b: 5
+`
+	var pto perTenantOverrides
+	decoder := yaml.NewDecoder(strings.NewReader(input))
+	decoder.SetStrict(true)
+	require.NoError(t, decoder.Decode(&pto))
+	require.Equal(t, ConfigTypeNew, pto.ConfigType)
+
+	limits := pto.TenantLimits["tenant-1"]
+	require.NotNil(t, limits)
+	assert.Equal(t, 2000, limits.Ingestion.MaxLocalTracesPerUser)
+	ext := get(limits)
+	require.NotNil(t, ext)
+	assert.Equal(t, "new_format_val", ext.FieldA)
+	assert.Equal(t, 5, *ext.FieldB)
+}
+
+func TestExtension_JSONRoundTrip_Overrides(t *testing.T) {
+	ResetRegistryForTesting(t)
+	get := RegisterExtension(&testExtension{})
+
+	fieldB := 13
+	o := Overrides{}
+	o.Ingestion.MaxLocalTracesPerUser = 777
+	o.Extensions = map[string]any{
+		"test_extension": &testExtension{FieldA: "json_rt", FieldB: &fieldB},
+	}
+
+	b, err := json.Marshal(&o)
+	require.NoError(t, err)
+
+	var o2 Overrides
+	require.NoError(t, json.Unmarshal(b, &o2))
+
+	assert.Equal(t, 777, o2.Ingestion.MaxLocalTracesPerUser)
+	ext := get(&o2)
+	require.NotNil(t, ext)
+	assert.Equal(t, "json_rt", ext.FieldA)
+	assert.Equal(t, 13, *ext.FieldB)
+}
+
+func TestExtension_LegacyConversionRoundTrip(t *testing.T) {
+	ResetRegistryForTesting(t)
+	get := RegisterExtension(&testExtension{})
+
+	fieldB := 21
+	// Build an Overrides with a typed extension, convert to legacy and back.
+	o := Overrides{}
+	o.Extensions = map[string]any{
+		"test_extension": &testExtension{FieldA: "converted", FieldB: &fieldB},
+	}
+	l := o.toLegacy()
+
+	// After toLegacy(), Extensions holds the typed instance keyed by nested key.
+	// Flat keys only appear in the marshaled wire format.
+	extInLegacy, ok := l.Extensions["test_extension"].(*testExtension)
+	require.True(t, ok, "expected typed test_extension in LegacyOverrides.Extensions")
+	assert.Equal(t, "converted", extInLegacy.FieldA)
+
+	// When marshaled to JSON/YAML, the typed instance must produce flat legacy keys.
+	b, err := json.Marshal(&l)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(b, &m))
+	assert.Equal(t, "converted", m["test_extension_field_a"], "flat key must appear in JSON")
+	assert.Nil(t, m["test_extension"], "nested key must not appear in JSON")
+
+	// Round-trip through toNewLimits recovers the typed extension.
+	o2, err := l.toNewLimits()
+	require.NoError(t, err)
+	require.NoError(t, processExtensions(&o2))
+
+	ext := get(&o2)
+	require.NotNil(t, ext)
+	assert.Equal(t, "converted", ext.FieldA)
+	assert.Equal(t, 21, *ext.FieldB)
 }
 
 var _ Extension = (*testExtension)(nil)
@@ -35,13 +426,11 @@ type testExtension struct {
 	FieldB *int   `yaml:"field_b" json:"field_b"`
 }
 
-func (t *testExtension) Key() string {
-	return "test_extension"
-}
+func (t *testExtension) Key() string { return "test_extension" }
 
-func (t *testExtension) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
+func (t *testExtension) RegisterFlagsAndApplyDefaults(_ string, _ *flag.FlagSet) {
 	t.FieldA = "field_a_default"
-	t.FieldB = new(0)
+	t.FieldB = new(int) // default: pointer to 0
 }
 
 func (t *testExtension) Validate() error {
@@ -55,31 +444,29 @@ func (t *testExtension) Validate() error {
 }
 
 func (t *testExtension) LegacyKeys() []string {
-	return []string{
-		"test_extension_field_a",
-		"test_extension_field_b",
-	}
+	return []string{"test_extension_field_a", "test_extension_field_b"}
 }
 
-func (t *testExtension) FromLegacy(m map[string]any) {
-	if t == nil {
-		*t = testExtension{}
-	}
+func (t *testExtension) FromLegacy(m map[string]any) error {
 	if v, ok := m["test_extension_field_a"].(string); ok {
 		t.FieldA = v
 	}
 	if v, ok := m["test_extension_field_b"].(int); ok {
 		t.FieldB = &v
 	}
-
+	return nil
 }
 
 func (t *testExtension) ToLegacy() map[string]any {
 	if t == nil {
 		return nil
 	}
+	fieldB := 0
+	if t.FieldB != nil {
+		fieldB = *t.FieldB
+	}
 	return map[string]any{
 		"test_extension_field_a": t.FieldA,
-		"test_extension_field_b": *t.FieldB,
+		"test_extension_field_b": fieldB,
 	}
 }

--- a/modules/overrides/extension_test.go
+++ b/modules/overrides/extension_test.go
@@ -13,13 +13,13 @@ import (
 )
 
 func TestRegisterExtension_PanicsOnDuplicate(t *testing.T) {
-	ResetRegistryForTesting(t)
+	resetRegistryForTesting(t)
 	RegisterExtension(&testExtension{})
 	assert.Panics(t, func() { RegisterExtension(&testExtension{}) })
 }
 
 func TestRegisterExtension_TypedGetter(t *testing.T) {
-	ResetRegistryForTesting(t)
+	resetRegistryForTesting(t)
 	get := RegisterExtension(&testExtension{})
 
 	fieldB := 99
@@ -38,7 +38,7 @@ func TestRegisterExtension_TypedGetter(t *testing.T) {
 
 func TestOverridesExtension_MarshalJSON(t *testing.T) {
 	t.Run("overrides", func(t *testing.T) {
-		ResetRegistryForTesting(t)
+		resetRegistryForTesting(t)
 		get := RegisterExtension(&testExtension{})
 
 		fieldB := 42
@@ -62,7 +62,7 @@ func TestOverridesExtension_MarshalJSON(t *testing.T) {
 	})
 
 	t.Run("legacy overrides", func(t *testing.T) {
-		ResetRegistryForTesting(t)
+		resetRegistryForTesting(t)
 		RegisterExtension(&testExtension{})
 
 		fieldB := 7
@@ -99,7 +99,7 @@ func TestOverridesExtension_MarshalJSON(t *testing.T) {
 
 func TestOverridesExtension_UnmarshalJSON(t *testing.T) {
 	t.Run("overrides", func(t *testing.T) {
-		ResetRegistryForTesting(t)
+		resetRegistryForTesting(t)
 		get := RegisterExtension(&testExtension{})
 
 		input := `{
@@ -117,7 +117,7 @@ func TestOverridesExtension_UnmarshalJSON(t *testing.T) {
 	})
 
 	t.Run("overrides defaults applied", func(t *testing.T) {
-		ResetRegistryForTesting(t)
+		resetRegistryForTesting(t)
 		get := RegisterExtension(&testExtension{})
 
 		// field_b is omitted — the default (pointer to 0) must be used.
@@ -133,7 +133,7 @@ func TestOverridesExtension_UnmarshalJSON(t *testing.T) {
 	})
 
 	t.Run("overrides unregistered key", func(t *testing.T) {
-		ResetRegistryForTesting(t)
+		resetRegistryForTesting(t)
 
 		input := `{"ingestion": {"max_traces_per_user": 1}, "unknown_ext": {"x": 1}}`
 		var o Overrides
@@ -142,7 +142,7 @@ func TestOverridesExtension_UnmarshalJSON(t *testing.T) {
 	})
 
 	t.Run("overrides validate error", func(t *testing.T) {
-		ResetRegistryForTesting(t)
+		resetRegistryForTesting(t)
 		RegisterExtension(&testExtension{})
 
 		// field_a is empty — Validate must reject it.
@@ -153,7 +153,7 @@ func TestOverridesExtension_UnmarshalJSON(t *testing.T) {
 	})
 
 	t.Run("legacy overrides", func(t *testing.T) {
-		ResetRegistryForTesting(t)
+		resetRegistryForTesting(t)
 		RegisterExtension(&testExtension{})
 
 		// LegacyOverrides JSON may contain flat extension keys; processLegacyExtensions converts
@@ -172,7 +172,7 @@ func TestOverridesExtension_UnmarshalJSON(t *testing.T) {
 
 func TestOverridesExtension_MarshalYAML(t *testing.T) {
 	t.Run("overrides", func(t *testing.T) {
-		ResetRegistryForTesting(t)
+		resetRegistryForTesting(t)
 		get := RegisterExtension(&testExtension{})
 
 		fieldB := 3
@@ -200,7 +200,7 @@ func TestOverridesExtension_MarshalYAML(t *testing.T) {
 	})
 
 	t.Run("legacy overrides", func(t *testing.T) {
-		ResetRegistryForTesting(t)
+		resetRegistryForTesting(t)
 		RegisterExtension(&testExtension{})
 
 		fieldB := 8
@@ -223,7 +223,7 @@ func TestOverridesExtension_MarshalYAML(t *testing.T) {
 
 func TestOverridesExtension_UnmarshalYAML(t *testing.T) {
 	t.Run("overrides", func(t *testing.T) {
-		ResetRegistryForTesting(t)
+		resetRegistryForTesting(t)
 		get := RegisterExtension(&testExtension{})
 
 		input := `
@@ -244,7 +244,7 @@ test_extension:
 	})
 
 	t.Run("Overrides_strict_decoder_absorbs_extension_key", func(t *testing.T) {
-		ResetRegistryForTesting(t)
+		resetRegistryForTesting(t)
 		RegisterExtension(&testExtension{})
 
 		input := `
@@ -260,7 +260,7 @@ test_extension:
 	})
 
 	t.Run("overrides unregistered key", func(t *testing.T) {
-		ResetRegistryForTesting(t)
+		resetRegistryForTesting(t)
 
 		input := `
 ingestion:
@@ -274,7 +274,7 @@ unknown_ext:
 	})
 
 	t.Run("legacy overrides", func(t *testing.T) {
-		ResetRegistryForTesting(t)
+		resetRegistryForTesting(t)
 		get := RegisterExtension(&testExtension{})
 
 		input := `
@@ -307,7 +307,7 @@ test_extension_field_a: from_legacy_yaml
 }
 
 func TestExtension_FullLegacyRoundTrip_perTenantOverrides(t *testing.T) {
-	ResetRegistryForTesting(t)
+	resetRegistryForTesting(t)
 	get := RegisterExtension(&testExtension{})
 
 	input := `
@@ -331,7 +331,7 @@ overrides:
 }
 
 func TestExtension_FullNewFormatRoundTrip_perTenantOverrides(t *testing.T) {
-	ResetRegistryForTesting(t)
+	resetRegistryForTesting(t)
 	get := RegisterExtension(&testExtension{})
 
 	input := `
@@ -359,7 +359,7 @@ overrides:
 }
 
 func TestExtension_JSONRoundTrip_Overrides(t *testing.T) {
-	ResetRegistryForTesting(t)
+	resetRegistryForTesting(t)
 	get := RegisterExtension(&testExtension{})
 
 	fieldB := 13
@@ -383,7 +383,7 @@ func TestExtension_JSONRoundTrip_Overrides(t *testing.T) {
 }
 
 func TestExtension_LegacyConversionRoundTrip(t *testing.T) {
-	ResetRegistryForTesting(t)
+	resetRegistryForTesting(t)
 	get := RegisterExtension(&testExtension{})
 
 	fieldB := 21
@@ -417,6 +417,55 @@ func TestExtension_LegacyConversionRoundTrip(t *testing.T) {
 	require.NotNil(t, ext)
 	assert.Equal(t, "converted", ext.FieldA)
 	assert.Equal(t, 21, *ext.FieldB)
+}
+
+func TestRegisterExtension_PanicsOnKnownFieldConflict(t *testing.T) {
+	resetRegistryForTesting(t)
+	// "ingestion" is a known Overrides JSON field; registering an extension with
+	// that key must panic rather than silently cause data loss during marshal.
+	assert.Panics(t, func() {
+		RegisterExtension(&conflictingExtension{})
+	})
+}
+
+func TestExtensionValidationError_NotSwallowedByLegacyFallback(t *testing.T) {
+	resetRegistryForTesting(t)
+	RegisterExtension(&testExtension{})
+
+	// New-format config with a registered extension that fails validation (field_a is empty).
+	// The error must propagate to the caller rather than being silently swallowed by the
+	// legacy-format fallback path.
+	input := `
+overrides:
+  tenant-1:
+    ingestion:
+      max_traces_per_user: 1000
+    test_extension:
+      field_a: ""
+`
+	var pto perTenantOverrides
+	decoder := yaml.NewDecoder(strings.NewReader(input))
+	decoder.SetStrict(true)
+	err := decoder.Decode(&pto)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "field_a cannot be empty", "validation error must not be swallowed by legacy fallback")
+}
+
+// resetRegistryForTesting clears the extension registry for the duration of the test,
+// restoring the original state via t.Cleanup. This prevents extension registrations
+// in one test from leaking into others.
+func resetRegistryForTesting(t *testing.T) {
+	t.Helper()
+	extensionRegistry.Lock()
+	saved := extensionRegistry.entries
+	extensionRegistry.entries = make(map[string]*registryEntry)
+	extensionRegistry.Unlock()
+
+	t.Cleanup(func() {
+		extensionRegistry.Lock()
+		extensionRegistry.entries = saved
+		extensionRegistry.Unlock()
+	})
 }
 
 var _ Extension = (*testExtension)(nil)
@@ -470,3 +519,14 @@ func (t *testExtension) ToLegacy() map[string]any {
 		"test_extension_field_b": fieldB,
 	}
 }
+
+var _ Extension = (*conflictingExtension)(nil)
+
+type conflictingExtension struct{}
+
+func (c *conflictingExtension) Key() string                                             { return "ingestion" }
+func (c *conflictingExtension) RegisterFlagsAndApplyDefaults(_ string, _ *flag.FlagSet) {}
+func (c *conflictingExtension) Validate() error                                         { return nil }
+func (c *conflictingExtension) LegacyKeys() []string                                    { return nil }
+func (c *conflictingExtension) FromLegacy(_ map[string]any) error                       { return nil }
+func (c *conflictingExtension) ToLegacy() map[string]any                                { return nil }

--- a/modules/overrides/extension_test.go
+++ b/modules/overrides/extension_test.go
@@ -294,11 +294,10 @@ test_extension_field_a: from_legacy_yaml
 		assert.Equal(t, 0, *lExt.FieldB)
 
 		// toNewLimits copies typed extensions; processExtensions validates them.
-		o, err := l.toNewLimits()
-		require.NoError(t, err)
-		require.NoError(t, processExtensions(&o))
+		o := l.toNewLimits()
+		require.NoError(t, processExtensions(o))
 
-		ext := get(&o)
+		ext := get(o)
 		require.NotNil(t, ext)
 		assert.Equal(t, "from_legacy_yaml", ext.FieldA)
 		require.NotNil(t, ext.FieldB)
@@ -409,11 +408,10 @@ func TestExtension_LegacyConversionRoundTrip(t *testing.T) {
 	assert.Nil(t, m["test_extension"], "nested key must not appear in JSON")
 
 	// Round-trip through toNewLimits recovers the typed extension.
-	o2, err := l.toNewLimits()
-	require.NoError(t, err)
-	require.NoError(t, processExtensions(&o2))
+	o2 := l.toNewLimits()
+	require.NoError(t, processExtensions(o2))
 
-	ext := get(&o2)
+	ext := get(o2)
 	require.NotNil(t, ext)
 	assert.Equal(t, "converted", ext.FieldA)
 	assert.Equal(t, 21, *ext.FieldB)

--- a/modules/overrides/extension_test.go
+++ b/modules/overrides/extension_test.go
@@ -1,0 +1,85 @@
+package overrides
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+)
+
+func TestOverridesExtension_MarshalJSON(t *testing.T) {
+	// TODO register the extension and test the marshaling
+	// implement a sub-test for legacy and non legacy overrides
+}
+
+func TestOverridesExtension_UnmarshalJSON(t *testing.T) {
+	// TODO register the extension and test the marshaling
+	// implement a sub-test for legacy and non legacy overrides
+	// also test a JSON payload with an unregistered extension and check that it fails
+}
+
+func TestOverridesExtension_MarshalYAML(t *testing.T) {
+	// TODO register the extension and test the marshaling
+	// implement a sub-test for legacy and non legacy overrides
+}
+
+func TestOverridesExtension_UnmarshalYAML(t *testing.T) {
+	// TODO register the extension and test the marshaling
+	// implement a sub-test for legacy and non legacy overrides
+	// also test a JSON payload with an unregistered extension and check that it fails
+}
+
+var _ Extension = (*testExtension)(nil)
+
+type testExtension struct {
+	FieldA string `yaml:"field_a" json:"field_a"`
+	FieldB *int   `yaml:"field_b" json:"field_b"`
+}
+
+func (t *testExtension) Key() string {
+	return "test_extension"
+}
+
+func (t *testExtension) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
+	t.FieldA = "field_a_default"
+	t.FieldB = new(0)
+}
+
+func (t *testExtension) Validate() error {
+	if t.FieldA == "" {
+		return fmt.Errorf("field_a cannot be empty")
+	}
+	if t.FieldB == nil {
+		return fmt.Errorf("field_b cannot be nil")
+	}
+	return nil
+}
+
+func (t *testExtension) LegacyKeys() []string {
+	return []string{
+		"test_extension_field_a",
+		"test_extension_field_b",
+	}
+}
+
+func (t *testExtension) FromLegacy(m map[string]any) {
+	if t == nil {
+		*t = testExtension{}
+	}
+	if v, ok := m["test_extension_field_a"].(string); ok {
+		t.FieldA = v
+	}
+	if v, ok := m["test_extension_field_b"].(int); ok {
+		t.FieldB = &v
+	}
+
+}
+
+func (t *testExtension) ToLegacy() map[string]any {
+	if t == nil {
+		return nil
+	}
+	return map[string]any{
+		"test_extension_field_a": t.FieldA,
+		"test_extension_field_b": *t.FieldB,
+	}
+}

--- a/modules/overrides/extension_test.go
+++ b/modules/overrides/extension_test.go
@@ -523,13 +523,16 @@ defaults:
 func resetRegistryForTesting(t *testing.T) {
 	t.Helper()
 	extensionRegistry.Lock()
-	saved := extensionRegistry.entries
+	savedEntries := extensionRegistry.entries
+	savedLegacyKeys := extensionRegistry.allLegacyKeys
 	extensionRegistry.entries = make(map[string]*registryEntry)
+	extensionRegistry.allLegacyKeys = make(map[string]struct{})
 	extensionRegistry.Unlock()
 
 	t.Cleanup(func() {
 		extensionRegistry.Lock()
-		extensionRegistry.entries = saved
+		extensionRegistry.entries = savedEntries
+		extensionRegistry.allLegacyKeys = savedLegacyKeys
 		extensionRegistry.Unlock()
 	})
 }

--- a/modules/overrides/extension_test.go
+++ b/modules/overrides/extension_test.go
@@ -460,6 +460,63 @@ overrides:
 	assert.Contains(t, err.Error(), "field_a cannot be empty", "validation error must not be swallowed by legacy fallback")
 }
 
+func TestUnknownExtensionKey_NewFormat_BlocksLegacyFallback(t *testing.T) {
+	resetRegistryForTesting(t)
+
+	input := `
+overrides:
+  tenant-1:
+    ingestion:
+      max_traces_per_user: 1000
+    my_unregistered_ext:
+      field: value
+`
+	var pto perTenantOverrides
+	decoder := yaml.NewDecoder(strings.NewReader(input))
+	decoder.SetStrict(true)
+	err := decoder.Decode(&pto)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown extension key", "must propagate the unknown-key error, not a legacy-fallback error")
+	assert.Contains(t, err.Error(), "my_unregistered_ext")
+	assert.NotEqual(t, ConfigTypeLegacy, pto.ConfigType, "must not fall back to legacy format")
+}
+
+func TestUnknownExtensionKey_LegacyFormat_AllowsFallback(t *testing.T) {
+	resetRegistryForTesting(t)
+
+	input := `
+overrides:
+  tenant-1:
+    max_traces_per_user: 1000
+`
+	var pto perTenantOverrides
+	decoder := yaml.NewDecoder(strings.NewReader(input))
+	decoder.SetStrict(true)
+	require.NoError(t, decoder.Decode(&pto))
+	assert.Equal(t, ConfigTypeLegacy, pto.ConfigType)
+	require.NotNil(t, pto.TenantLimits["tenant-1"])
+	assert.Equal(t, 1000, pto.TenantLimits["tenant-1"].Ingestion.MaxLocalTracesPerUser)
+}
+
+func TestUnknownExtensionKey_Config_BlocksLegacyFallback(t *testing.T) {
+	resetRegistryForTesting(t)
+
+	input := `
+defaults:
+  ingestion:
+    max_traces_per_user: 500
+  my_unregistered_ext:
+    field: value
+`
+	var cfg Config
+	decoder := yaml.NewDecoder(strings.NewReader(input))
+	decoder.SetStrict(true)
+	err := decoder.Decode(&cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown extension key")
+	assert.Contains(t, err.Error(), "my_unregistered_ext")
+}
+
 // resetRegistryForTesting clears the extension registry for the duration of the test,
 // restoring the original state via t.Cleanup. This prevents extension registrations
 // in one test from leaking into others.

--- a/modules/overrides/extension_test.go
+++ b/modules/overrides/extension_test.go
@@ -498,8 +498,13 @@ func (t *testExtension) FromLegacy(m map[string]any) error {
 	if v, ok := m["test_extension_field_a"].(string); ok {
 		t.FieldA = v
 	}
-	if v, ok := m["test_extension_field_b"].(int); ok {
+	// JSON-decoded map[string]any represents numbers as float64; handle both int (YAML) and float64 (JSON).
+	switch v := m["test_extension_field_b"].(type) {
+	case int:
 		t.FieldB = &v
+	case float64:
+		vv := int(v)
+		t.FieldB = &vv
 	}
 	return nil
 }

--- a/modules/overrides/extension_test.go
+++ b/modules/overrides/extension_test.go
@@ -152,6 +152,17 @@ func TestOverridesExtension_UnmarshalJSON(t *testing.T) {
 		require.ErrorContains(t, err, "field_a cannot be empty")
 	})
 
+	t.Run("unknown field rejected", func(t *testing.T) {
+		resetRegistryForTesting(t)
+		RegisterExtension(&testExtension{})
+
+		// A typo in an extension field name must be rejected, not silently dropped.
+		input := `{"test_extension": {"field_a": "ok", "field_b": 1, "typo_field": "bad"}}`
+		var o Overrides
+		err := json.Unmarshal([]byte(input), &o)
+		require.ErrorContains(t, err, "typo_field")
+	})
+
 	t.Run("legacy overrides", func(t *testing.T) {
 		resetRegistryForTesting(t)
 		RegisterExtension(&testExtension{})

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -56,7 +56,7 @@ func (o *perTenantOverrides) UnmarshalYAML(unmarshal func(interface{}) error) er
 	if err := unmarshal(&legacyConfig); err != nil {
 		return err
 	}
-	
+
 	*o = legacyConfig.toNewOverrides()
 	o.ConfigType = ConfigTypeLegacy
 

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -71,7 +71,6 @@ func (o *perTenantOverrides) UnmarshalYAML(unmarshal func(interface{}) error) er
 	return nil
 }
 
-
 // forUser returns limits for a given tenant, or nil if there are no tenant-specific limits.
 func (o *perTenantOverrides) forUser(userID string) *Overrides {
 	l, ok := o.TenantLimits[userID]

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -56,12 +56,8 @@ func (o *perTenantOverrides) UnmarshalYAML(unmarshal func(interface{}) error) er
 	if err := unmarshal(&legacyConfig); err != nil {
 		return err
 	}
-
-	newOverrides, err := legacyConfig.toNewOverrides()
-	if err != nil {
-		return err
-	}
-	*o = newOverrides
+	
+	*o = legacyConfig.toNewOverrides()
 	o.ConfigType = ConfigTypeLegacy
 
 	for tenantID, limits := range o.TenantLimits {

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -48,7 +48,7 @@ func (o *perTenantOverrides) UnmarshalYAML(unmarshal func(interface{}) error) er
 		o.ConfigType = ConfigTypeNew
 		return nil
 	}
-	if isExtensionError(err) {
+	if isExtensionError(err) || !isLegacyExtensionKeyError(err) {
 		return err
 	}
 

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -41,10 +41,15 @@ func (o *perTenantOverrides) UnmarshalYAML(unmarshal func(interface{}) error) er
 	// tenant, which rejects unregistered extension keys — including legacy flat-key field names
 	// (e.g. "max_traces_per_user"). If any tenant uses legacy fields the first-pass will error
 	// and we fall through to the legacy path below.
+	// If the error is an extensionError, the config is in the new format but misconfigured.
 	type rawConfig perTenantOverrides
-	if err := unmarshal((*rawConfig)(o)); err == nil {
+	err := unmarshal((*rawConfig)(o))
+	if err == nil {
 		o.ConfigType = ConfigTypeNew
 		return nil
+	}
+	if isExtensionError(err) {
+		return err
 	}
 
 	var legacyConfig perTenantLegacyOverrides

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -43,8 +43,12 @@ func (o *perTenantOverrides) UnmarshalYAML(unmarshal func(interface{}) error) er
 	// Try to unmarshal it normally
 	type rawConfig perTenantOverrides
 	if err := unmarshal((*rawConfig)(o)); err == nil {
-		o.ConfigType = ConfigTypeNew
-		return nil
+		// Overrides.Extra absorbs unknown YAML fields without triggering a strict-mode error. Therefore,
+		// we check whether Overrides.Extra contains legacy fields.
+		if !o.containsLegacyFields() {
+			o.ConfigType = ConfigTypeNew
+			return nil
+		}
 	}
 
 	var legacyConfig perTenantLegacyOverrides
@@ -56,6 +60,23 @@ func (o *perTenantOverrides) UnmarshalYAML(unmarshal func(interface{}) error) er
 	o.ConfigType = ConfigTypeLegacy
 
 	return nil
+}
+
+// containsLegacyFields reports whether any tenant's Extra map holds a key that is a known
+// legacy field name, indicating the YAML was in legacy (flat) format.
+func (o *perTenantOverrides) containsLegacyFields() bool {
+	legacyFields := knownLegacyOverridesYAMLFields()
+	for _, limits := range o.TenantLimits {
+		if limits == nil {
+			continue
+		}
+		for key := range limits.Extra {
+			if _, isLegacy := legacyFields[key]; isLegacy {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // forUser returns limits for a given tenant, or nil if there are no tenant-specific limits.

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -59,16 +59,6 @@ func (o *perTenantOverrides) UnmarshalYAML(unmarshal func(interface{}) error) er
 
 	*o = legacyConfig.toNewOverrides()
 	o.ConfigType = ConfigTypeLegacy
-
-	for tenantID, limits := range o.TenantLimits {
-		if limits == nil {
-			continue
-		}
-		if err := processExtensions(limits); err != nil {
-			return fmt.Errorf("tenant %q: %w", tenantID, err)
-		}
-	}
-
 	return nil
 }
 

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -37,18 +37,14 @@ type perTenantOverrides struct {
 }
 
 func (o *perTenantOverrides) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	// Note: this implementation relies on callers using yaml.UnmarshalStrict. In non-strict mode
-	// unmarshal() will not return an error for legacy configuration and we return immediately.
-
-	// Try to unmarshal it normally
+	// Try to unmarshal as new format. Overrides.UnmarshalYAML calls processExtensions for each
+	// tenant, which rejects unregistered extension keys — including legacy flat-key field names
+	// (e.g. "max_traces_per_user"). If any tenant uses legacy fields the first-pass will error
+	// and we fall through to the legacy path below.
 	type rawConfig perTenantOverrides
 	if err := unmarshal((*rawConfig)(o)); err == nil {
-		// Overrides.Extra absorbs unknown YAML fields without triggering a strict-mode error. Therefore,
-		// we check whether Overrides.Extra contains legacy fields.
-		if !o.containsLegacyFields() {
-			o.ConfigType = ConfigTypeNew
-			return nil
-		}
+		o.ConfigType = ConfigTypeNew
+		return nil
 	}
 
 	var legacyConfig perTenantLegacyOverrides
@@ -56,28 +52,25 @@ func (o *perTenantOverrides) UnmarshalYAML(unmarshal func(interface{}) error) er
 		return err
 	}
 
-	*o = legacyConfig.toNewOverrides()
+	newOverrides, err := legacyConfig.toNewOverrides()
+	if err != nil {
+		return err
+	}
+	*o = newOverrides
 	o.ConfigType = ConfigTypeLegacy
+
+	for tenantID, limits := range o.TenantLimits {
+		if limits == nil {
+			continue
+		}
+		if err := processExtensions(limits); err != nil {
+			return fmt.Errorf("tenant %q: %w", tenantID, err)
+		}
+	}
 
 	return nil
 }
 
-// containsLegacyFields reports whether any tenant's Extra map holds a key that is a known
-// legacy field name, indicating the YAML was in legacy (flat) format.
-func (o *perTenantOverrides) containsLegacyFields() bool {
-	legacyFields := knownLegacyOverridesYAMLFields()
-	for _, limits := range o.TenantLimits {
-		if limits == nil {
-			continue
-		}
-		for key := range limits.Extra {
-			if _, isLegacy := legacyFields[key]; isLegacy {
-				return true
-			}
-		}
-	}
-	return false
-}
 
 // forUser returns limits for a given tenant, or nil if there are no tenant-specific limits.
 func (o *perTenantOverrides) forUser(userID string) *Overrides {


### PR DESCRIPTION
**What this PR does**:
Add extension mechanism for Temp's per-tenant Overrides. This enables applications who vendor tempo to add their own Overrides.

**Which issue(s) this PR fixes**:
Contributes to grafana/cloud-traces#270

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`