### PR TITLE
fix(s3): paginate ClearBlock deletes and add configurable S3 response header timeout

### DIFF
--- a/tempodb/backend/s3/compactor.go
+++ b/tempodb/backend/s3/compactor.go
@@ -55,20 +55,33 @@ func (rw *readerWriter) ClearBlock(blockID uuid.UUID, tenantID string) error {
 		return backend.ErrEmptyBlockID
 	}
 
-	path := backend.RootPath(blockID, tenantID, rw.cfg.Prefix) + "/"
+	path := backend.RootPath(blockID, tenantID, rw.cfg.Prefix)
+	if len(path) > 0 {
+		path += "/"
+	}
 	level.Debug(rw.logger).Log("msg", "deleting block", "block path", path)
 
-	// ListObjects(bucket, prefix, marker, delimiter string, maxKeys int)
-	res, err := rw.core.ListObjects(rw.cfg.Bucket, path, "", "/", 0)
-	if err != nil {
-		return fmt.Errorf("error listing objects in bucket %s: %w", rw.cfg.Bucket, err)
-	}
-
-	level.Debug(rw.logger).Log("msg", "listing objects", "found", len(res.Contents))
-	for _, obj := range res.Contents {
-		err = rw.core.RemoveObject(context.TODO(), rw.cfg.Bucket, obj.Key, minio.RemoveObjectOptions{})
+	// List all object keys under the block prefix (paginated). A single ListObjects with
+	// delimiter "/" can miss keys (truncation, or non-flat layouts); match GCS/azure behavior.
+	nextToken := ""
+	isTruncated := true
+	var res minio.ListBucketV2Result
+	for isTruncated {
+		var err error
+		res, err = rw.core.ListObjectsV2(rw.cfg.Bucket, path, "", nextToken, "", 0)
 		if err != nil {
-			return fmt.Errorf("error deleting obj from s3: %s: %w", obj.Key, err)
+			return fmt.Errorf("error listing objects in bucket %s: %w", rw.cfg.Bucket, err)
+		}
+		isTruncated = res.IsTruncated
+		nextToken = res.NextContinuationToken
+
+		level.Debug(rw.logger).Log("msg", "listing objects", "found", len(res.Contents), "truncated", isTruncated)
+
+		for _, obj := range res.Contents {
+			err = rw.core.RemoveObject(context.TODO(), rw.cfg.Bucket, obj.Key, minio.RemoveObjectOptions{})
+			if err != nil {
+				return fmt.Errorf("error deleting obj from s3: %s: %w", obj.Key, err)
+			}
 		}
 	}
 

--- a/tempodb/backend/s3/config.go
+++ b/tempodb/backend/s3/config.go
@@ -61,6 +61,8 @@ type Config struct {
 	RetryMaxAttempts    int            `yaml:"retry_max_attempts"`
 	RetryBackoffInitial time.Duration  `yaml:"retry_backoff_initial"`
 	RetryBackoffMax     time.Duration  `yaml:"retry_backoff_max"`
+	// ResponseHeaderTimeout sets Transport.ResponseHeaderTimeout; 0 leaves minio default (1m).
+	ResponseHeaderTimeout time.Duration `yaml:"response_header_timeout,omitempty"`
 	// SignatureV2 configures the object storage to use V2 signing instead of V4
 	SignatureV2      bool              `yaml:"signature_v2"`
 	ForcePathStyle   bool              `yaml:"forcepathstyle"`
@@ -85,6 +87,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	f.Var(&cfg.SecretKey, util.PrefixConfig(prefix, "s3.secret_key"), "s3 secret key.")
 	f.Var(&cfg.SessionToken, util.PrefixConfig(prefix, "s3.session_token"), "s3 session token.")
 	f.IntVar(&cfg.ListBlocksConcurrency, util.PrefixConfig(prefix, "s3.list_blocks_concurrency"), 3, "number of concurrent list calls to make to backend")
+	f.DurationVar(&cfg.ResponseHeaderTimeout, util.PrefixConfig(prefix, "s3.response-header-timeout"), 0, "HTTP response header timeout for S3 requests; 0 uses minio default (1m)")
 
 	f.StringVar(&cfg.SSE.Type, util.PrefixConfig(prefix, "s3.sse.type"), "", fmt.Sprintf("Enable AWS Server Side Encryption. Supported values: %s.", strings.Join(supportedSSETypes, ", ")))
 	f.StringVar(&cfg.SSE.KMSKeyID, util.PrefixConfig(prefix, "s3.sse.kms-key-id"), "", "KMS Key ID used to encrypt objects in S3")

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -741,6 +741,10 @@ func createCore(cfg *Config, hedge bool) (*minio.Core, error) {
 	customTransport.MaxIdleConnsPerHost = 100
 	customTransport.MaxIdleConns = 100
 
+	if cfg.ResponseHeaderTimeout > 0 {
+		customTransport.ResponseHeaderTimeout = cfg.ResponseHeaderTimeout
+	}
+
 	tlsConfig, err := cfg.GetTLSConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create TLS config: %w", err)


### PR DESCRIPTION
Fix retention cleanup against S3-compatible backends where listing under a block
prefix can return truncated results or take longer than a single ListObjects
round-trip allows.

ClearBlock now walks object keys with ListObjectsV2 pagination so all objects
under a block prefix are deleted, matching behavior expected for retention.

Add optional storage.trace.s3.response_header_timeout so deployments on slow
S3 gateways (e.g. long ListObjects) can raise the HTTP client response header
timeout above the minio default (1m). When unset, behavior is unchanged.

Build: use tempo-distributed Helm 2.10.x with image built from v2.10.2-based
branches, not main (config schema differs).