### PR TITLE
[tempo-cli]: add client for submitting redaction jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [FEATURE] Add an extension mechanism for per-tenant overrides [#6758](https://github.com/grafana/tempo/pull/6758) (@stoewer)
 * [FEATURE] Single-binary mode: push distributor local ingest directly to live-store and metrics-generator without Kafka [#6729](https://github.com/grafana/tempo/pull/6729) (@javiermolinar)
 * [ENHANCEMENT] tempo-cli: Add `--header` flag to `query api` commands for custom headers [#6768](https://github.com/grafana/tempo/pull/6768) (@Nouuu)
+* [ENHANCEMENT] tempo-cli: add `redact` command to submit trace redaction jobs to the backend scheduler [#6832](https://github.com/grafana/tempo/pull/6832) (@zalegrala)
 * [ENHANCEMENT] Block builder: deduplicate spans within traces during block creation and track removed duplicates via `tempo_block_builder_spans_deduped_total` metric [#6539](https://github.com/grafana/tempo/pull/6539) (@zhxiaogg)
 * [ENHANCEMENT] metrics-generator: Support extracting span multiplier from W3C tracestate OTel probability sampling threshold via `enable_tracestate_span_multiplier` config option [#6684](https://github.com/grafana/tempo/pull/6684) (@cmarchbanks)
 * [ENHANCEMENT] Add new alerts and runbooks entries [#6276](https://github.com/grafana/tempo/pull/6276) (@javiermolinar)

--- a/cmd/tempo-cli/cmd-redact.go
+++ b/cmd/tempo-cli/cmd-redact.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"flag"
+	"fmt"
+	"os"
+
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/grafana/dskit/user"
+
+	schedulerclient "github.com/grafana/tempo/modules/backendscheduler/client"
+	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/grafana/tempo/pkg/util"
+)
+
+type redactCmd struct {
+	SchedulerAddr string `arg:"" help:"backend scheduler gRPC address (host:port)"`
+
+	TenantID string   `name:"tenant" required:"" help:"tenant ID"`
+	TraceIDs []string `name:"trace-id" required:"" help:"trace ID to redact (may be repeated)"`
+
+	TLS           bool   `name:"tls" help:"use TLS transport" default:"false"`
+	TLSServerName string `name:"tls-server-name" help:"override the TLS server name (SNI)"`
+	TLSCA         string `name:"tls-ca" help:"path to a PEM-encoded CA certificate file"`
+}
+
+func (cmd *redactCmd) Run(_ *globalOptions) error {
+	traceIDs, err := parseTraceIDs(cmd.TraceIDs)
+	if err != nil {
+		return err
+	}
+
+	transportCred, err := cmd.buildTransportCredentials()
+	if err != nil {
+		return fmt.Errorf("building transport credentials: %w", err)
+	}
+
+	c, err := schedulerclient.NewWithOptions(cmd.SchedulerAddr, defaultSchedulerClientConfig(), transportCred)
+	if err != nil {
+		return fmt.Errorf("creating scheduler client: %w", err)
+	}
+	defer c.Close()
+
+	resp, err := cmd.submit(context.Background(), c, traceIDs)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("batch_id:     %s\njobs_created: %d\n", resp.BatchId, resp.JobsCreated)
+	return nil
+}
+
+// submit injects the tenant org ID into the outgoing gRPC metadata and calls SubmitRedaction.
+func (cmd *redactCmd) submit(ctx context.Context, c tempopb.BackendSchedulerClient, traceIDs [][]byte) (*tempopb.SubmitRedactionResponse, error) {
+	ctx = user.InjectOrgID(ctx, cmd.TenantID)
+	ctx, err := user.InjectIntoGRPCRequest(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("injecting tenant ID into gRPC request: %w", err)
+	}
+
+	resp, err := c.SubmitRedaction(ctx, &tempopb.SubmitRedactionRequest{
+		TenantId: cmd.TenantID,
+		TraceIds: traceIDs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("submitting redaction: %w", err)
+	}
+	return resp, nil
+}
+
+func (cmd *redactCmd) buildTransportCredentials() (credentials.TransportCredentials, error) {
+	if !cmd.TLS {
+		return insecure.NewCredentials(), nil
+	}
+
+	certPool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("loading system cert pool: %w", err)
+	}
+	if certPool == nil {
+		certPool = x509.NewCertPool()
+	}
+
+	if cmd.TLSCA != "" {
+		pem, err := os.ReadFile(cmd.TLSCA)
+		if err != nil {
+			return nil, fmt.Errorf("reading CA cert %q: %w", cmd.TLSCA, err)
+		}
+		if !certPool.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("no valid certificates found in %q", cmd.TLSCA)
+		}
+	}
+
+	return credentials.NewTLS(&tls.Config{
+		ServerName: cmd.TLSServerName,
+		RootCAs:    certPool,
+	}), nil
+}
+
+// parseTraceIDs converts a slice of hex trace ID strings to raw byte slices.
+func parseTraceIDs(hexIDs []string) ([][]byte, error) {
+	traceIDs := make([][]byte, 0, len(hexIDs))
+	for _, id := range hexIDs {
+		b, err := util.HexStringToTraceID(id)
+		if err != nil {
+			return nil, fmt.Errorf("invalid trace ID %q: %w", id, err)
+		}
+		traceIDs = append(traceIDs, b)
+	}
+	return traceIDs, nil
+}
+
+// defaultSchedulerClientConfig returns a zero-value Config suitable for CLI use.
+func defaultSchedulerClientConfig() schedulerclient.Config {
+	var cfg schedulerclient.Config
+	cfg.GRPCClientConfig.RegisterFlagsWithPrefix("backendscheduler.client", &flag.FlagSet{})
+	return cfg
+}

--- a/cmd/tempo-cli/cmd-redact_test.go
+++ b/cmd/tempo-cli/cmd-redact_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/grafana/tempo/pkg/util"
+)
+
+// mockSchedulerClient captures the context and request from SubmitRedaction calls.
+type mockSchedulerClient struct {
+	tempopb.BackendSchedulerClient
+	capturedCtx context.Context
+	capturedReq *tempopb.SubmitRedactionRequest
+}
+
+func (m *mockSchedulerClient) SubmitRedaction(ctx context.Context, req *tempopb.SubmitRedactionRequest, _ ...grpc.CallOption) (*tempopb.SubmitRedactionResponse, error) {
+	m.capturedCtx = ctx
+	m.capturedReq = req
+	return &tempopb.SubmitRedactionResponse{BatchId: "test-batch", JobsCreated: 1}, nil
+}
+
+func TestRedactCmdSubmit(t *testing.T) {
+	const (
+		tenant     = "test-tenant"
+		traceIDHex = "931281e2a09876de16e15f45ff86283d"
+	)
+
+	traceIDBytes, err := util.HexStringToTraceID(traceIDHex)
+	require.NoError(t, err)
+
+	mock := &mockSchedulerClient{}
+	cmd := &redactCmd{TenantID: tenant}
+
+	resp, err := cmd.submit(context.Background(), mock, [][]byte{traceIDBytes})
+	require.NoError(t, err)
+	require.Equal(t, "test-batch", resp.BatchId)
+
+	// Org ID must be present in the outgoing gRPC metadata.
+	md, ok := metadata.FromOutgoingContext(mock.capturedCtx)
+	require.True(t, ok, "expected outgoing metadata on context")
+	require.Equal(t, []string{tenant}, md["x-scope-orgid"])
+
+	// Request body must carry the tenant and trace IDs.
+	require.Equal(t, tenant, mock.capturedReq.TenantId)
+	require.Equal(t, [][]byte{traceIDBytes}, mock.capturedReq.TraceIds)
+}
+
+func TestParseTraceIDs(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		ids, err := parseTraceIDs([]string{
+			"931281e2a09876de16e15f45ff86283d",
+			"00000000000000000000000000000001",
+		})
+		require.NoError(t, err)
+		require.Len(t, ids, 2)
+	})
+
+	t.Run("invalid hex", func(t *testing.T) {
+		_, err := parseTraceIDs([]string{"not-a-trace-id"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid trace ID")
+	})
+}

--- a/cmd/tempo-cli/main.go
+++ b/cmd/tempo-cli/main.go
@@ -91,6 +91,8 @@ var cli struct {
 	Suggest struct {
 		Columns suggestColumnsCmd `cmd:"" help:"Suggest columns for a tenant"`
 	} `cmd:""`
+
+	Redact redactCmd `cmd:"" help:"Submit a redaction request to the backend scheduler"`
 }
 
 func main() {

--- a/modules/backendscheduler/client/client.go
+++ b/modules/backendscheduler/client/client.go
@@ -8,7 +8,7 @@ import (
 	"github.com/grafana/dskit/grpcclient"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/grafana/tempo/pkg/tempopb"
@@ -30,14 +30,14 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.GRPCClientConfig.RegisterFlagsWithPrefix("backendscheduler.client", f)
 }
 
-// New returns a new backendscheduler client.
+// New returns a new backendscheduler client. Transport credentials are
+// determined by cfg.GRPCClientConfig (insecure when TLSEnabled=false, TLS otherwise).
 func New(addr string, cfg Config) (*Client, error) {
 	if addr == "" {
 		return nil, fmt.Errorf("backend scheduler address is required")
 	}
 
 	opts := []grpc.DialOption{
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 	}
 
@@ -47,6 +47,41 @@ func New(addr string, cfg Config) (*Client, error) {
 	}
 
 	opts = append(opts, instrumentationOpts...)
+	conn, err := grpc.NewClient(addr, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{
+		BackendSchedulerClient: tempopb.NewBackendSchedulerClient(conn),
+		HealthClient:           grpc_health_v1.NewHealthClient(conn),
+		Closer:                 conn,
+	}, nil
+}
+
+// NewWithOptions returns a new backendscheduler client using the supplied
+// transport credentials. transportCred overrides the transport credential that
+// cfg.GRPCClientConfig would otherwise provide, so cfg.GRPCClientConfig.TLSEnabled
+// has no effect on the connection. Other dial options from cfg.GRPCClientConfig
+// (interceptors, rate limiting, etc.) are still applied. This is intended for
+// callers such as the CLI that manage their own TLS configuration.
+func NewWithOptions(addr string, cfg Config, transportCred credentials.TransportCredentials) (*Client, error) {
+	if addr == "" {
+		return nil, fmt.Errorf("backend scheduler address is required")
+	}
+
+	opts := []grpc.DialOption{
+		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+	}
+
+	instrumentationOpts, err := cfg.GRPCClientConfig.DialOption(nil, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// transportCred must come after instrumentationOpts so it wins over the
+	// default insecure credential that dskit injects when TLSEnabled=false.
+	opts = append(opts, instrumentationOpts...)
+	opts = append(opts, grpc.WithTransportCredentials(transportCred))
 	conn, err := grpc.NewClient(addr, opts...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does**:

In #6459 we intoduced the redaction job scheduler.  Here we include the client to allow job submission over the gRPC interface.

**Which issue(s) this PR fixes**:
Related #6459 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`