### PR TITLE
[ingest]: fix partition lag reporting for live groups and rebalance state

### DIFF
--- a/pkg/ingest/metrics.go
+++ b/pkg/ingest/metrics.go
@@ -69,7 +69,7 @@ func ExportPartitionLagMetrics(ctx context.Context, kclient *kgo.Client, log log
 				assignedPartitions := getAssignedActivePartitions()
 				boff.Reset()
 				for boff.Ongoing() {
-					lag, err = getGroupLag(ctx, admClient, partitionClient, group, assignedPartitions)
+					lag, err = getGroupLag(ctx, admClient, partitionClient, group, topic, assignedPartitions)
 					if err == nil {
 						break
 					}
@@ -119,7 +119,15 @@ func ResetLagMetricsForRevokedPartitions(group string, partitions []int32) {
 // the lag is the difference between the last produced offset and the offset committed in the consumer group.
 // Otherwise, if the block builder didn't commit an offset for a given partition yet (e.g. block builder is
 // running for the first time), then the lag is the difference between the last produced offset and fallbackOffsetMillis.
-func getGroupLag(ctx context.Context, admClient *kadm.Client, partitionClient *PartitionOffsetClient, group string, assignedPartitions []int32) (kadm.GroupLag, error) {
+//
+// When the group has current members (DescribeGroups), we use CalculateGroupLagWithStartOffsets so lag is
+// computed for each member's assignment. When the group has no members (e.g. rebalancing, or block-builder
+// which does not use consumer groups), we compute lag manually for (topic, assignedPartitions) so that
+// newly assigned partitions (e.g. after a rebalance) report correct lag.
+func getGroupLag(ctx context.Context, admClient *kadm.Client, partitionClient *PartitionOffsetClient, group, topic string, assignedPartitions []int32) (kadm.GroupLag, error) {
+	if len(assignedPartitions) == 0 {
+		return kadm.GroupLag{}, nil
+	}
 	offsets, err := admClient.FetchOffsets(ctx, group)
 	if err != nil {
 		if !errors.Is(err, kerr.GroupIDNotFound) {
@@ -139,10 +147,58 @@ func getGroupLag(ctx context.Context, admClient *kadm.Client, partitionClient *P
 		return nil, err
 	}
 
-	descrGroup := kadm.DescribedGroup{
-		// "Empty" is the state that indicates that the group doesn't have active consumer members; this is always the case for block-builder,
-		// because we don't use group consumption.
-		State: "Empty",
+	// Prefer the real group description so lag is computed for all members' assignments.
+	if described, err := admClient.DescribeGroups(ctx, group); err == nil {
+		if g, ok := described[group]; ok && len(g.Members) > 0 {
+			return kadm.CalculateGroupLagWithStartOffsets(g, offsets, startOffsets, endOffsets), nil
+		}
 	}
-	return kadm.CalculateGroupLagWithStartOffsets(descrGroup, offsets, startOffsets, endOffsets), nil
+
+	// No members (rebalancing, or group not using consumer protocol). Compute lag for our assigned partitions
+	// so that when assignment lands on this instance (e.g. after abandoned partitions time out), lag is correct.
+	tcommit := offsets[topic]
+	tstart := startOffsets[topic]
+	tend := endOffsets[topic]
+	if tend == nil {
+		return kadm.GroupLag{}, nil
+	}
+	result := make(kadm.GroupLag)
+	result[topic] = make(map[int32]kadm.GroupMemberLag)
+	for _, p := range assignedPartitions {
+		pend, ok := tend[p]
+		if !ok || pend.Err != nil {
+			// Preserve error semantics: emit Lag=-1 with Err set rather than omitting
+			// the partition, which would leave any previously-set gauge value stale.
+			// fetchPartitionsOffsets currently converts per-partition errors to
+			// function-level errors, so this path is reached only if the broker
+			// omits a requested partition from the ListOffsets response entirely.
+			perr := pend.Err
+			if !ok {
+				perr = fmt.Errorf("missing end offset for partition %d", p)
+			}
+			result[topic][p] = kadm.GroupMemberLag{Topic: topic, Partition: p, Lag: -1, Err: perr}
+			continue
+		}
+		lag := int64(0)
+		hasCommit := false
+		if tcommit != nil {
+			if pcommit, ok := tcommit[p]; ok && pcommit.Err == nil && pcommit.At >= 0 {
+				lag = pend.Offset - pcommit.At
+				hasCommit = true
+			}
+		}
+		// Only fall back to start offset when no committed offset exists.
+		// If a commit exists but lag is negative (e.g. after log truncation),
+		// clamp to zero rather than reporting a spuriously large lag.
+		if !hasCommit && tstart != nil {
+			if pstart, ok := tstart[p]; ok && pstart.Err == nil {
+				lag = pend.Offset - pstart.Offset
+			}
+		}
+		if lag < 0 {
+			lag = 0
+		}
+		result[topic][p] = kadm.GroupMemberLag{Topic: topic, Partition: p, Lag: lag}
+	}
+	return result, nil
 }

--- a/pkg/ingest/metrics_test.go
+++ b/pkg/ingest/metrics_test.go
@@ -1,0 +1,135 @@
+package ingest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// newGetGroupLagCluster creates a kfake cluster with 2 partitions for topicName
+// (defined in partition_offset_client_test.go as "test").
+// Returns the kgo client, kadm admin client, and partition offset client.
+func newGetGroupLagCluster(t *testing.T) (*kgo.Client, *kadm.Client, *PartitionOffsetClient) {
+	t.Helper()
+	fake, err := kfake.NewCluster(kfake.NumBrokers(1), kfake.SeedTopics(2, topicName))
+	require.NoError(t, err)
+	t.Cleanup(fake.Close)
+
+	client, err := kgo.NewClient(
+		kgo.SeedBrokers(fake.ListenAddrs()...),
+		kgo.DisableClientMetrics(),
+		kgo.RecordPartitioner(kgo.ManualPartitioner()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+
+	return client, kadm.NewClient(client), NewPartitionOffsetClient(client, topicName)
+}
+
+// commitOffset commits a single offset for topicName/partition to the given group via
+// the kadm admin API (standalone commit, no group membership required).
+func commitOffset(ctx context.Context, t *testing.T, adm *kadm.Client, group string, partition int32, offset int64) {
+	t.Helper()
+	var os kadm.Offsets
+	os.Add(kadm.Offset{Topic: topicName, Partition: partition, At: offset})
+	_, err := adm.CommitOffsets(ctx, group, os)
+	require.NoError(t, err)
+}
+
+func TestGetGroupLag(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("empty assigned partitions returns empty lag", func(t *testing.T) {
+		t.Parallel()
+		_, adm, partClient := newGetGroupLagCluster(t)
+
+		lag, err := getGroupLag(ctx, adm, partClient, "test-group", topicName, nil)
+		require.NoError(t, err)
+		assert.Empty(t, lag)
+	})
+
+	t.Run("no commit falls back to start offset", func(t *testing.T) {
+		t.Parallel()
+		client, adm, partClient := newGetGroupLagCluster(t)
+
+		// Produce 5 records to partition 0; end=5, start=0.
+		for range 5 {
+			produceRecord(ctx, t, client, 0, []byte("x"))
+		}
+
+		lag, err := getGroupLag(ctx, adm, partClient, "test-group", topicName, []int32{0})
+		require.NoError(t, err)
+
+		l, ok := lag.Lookup(topicName, 0)
+		require.True(t, ok)
+		assert.Equal(t, int64(5), l.Lag)
+	})
+
+	t.Run("committed offset produces positive lag", func(t *testing.T) {
+		t.Parallel()
+		client, adm, partClient := newGetGroupLagCluster(t)
+
+		for range 5 {
+			produceRecord(ctx, t, client, 0, []byte("x"))
+		}
+		// Consume through offset 2 (next to read = 3); lag = 5-3 = 2.
+		commitOffset(ctx, t, adm, "test-group", 0, 3)
+
+		lag, err := getGroupLag(ctx, adm, partClient, "test-group", topicName, []int32{0})
+		require.NoError(t, err)
+
+		l, ok := lag.Lookup(topicName, 0)
+		require.True(t, ok)
+		assert.Equal(t, int64(2), l.Lag)
+	})
+
+	t.Run("commit ahead of end is clamped to zero", func(t *testing.T) {
+		t.Parallel()
+		client, adm, partClient := newGetGroupLagCluster(t)
+
+		for range 3 {
+			produceRecord(ctx, t, client, 0, []byte("x"))
+		}
+		// Commit beyond end (e.g. after log truncation); raw lag = 3-10 = -7.
+		commitOffset(ctx, t, adm, "test-group", 0, 10)
+
+		lag, err := getGroupLag(ctx, adm, partClient, "test-group", topicName, []int32{0})
+		require.NoError(t, err)
+
+		l, ok := lag.Lookup(topicName, 0)
+		require.True(t, ok)
+		assert.Equal(t, int64(0), l.Lag) // clamped from -7 to 0
+	})
+
+	t.Run("multiple partitions reported independently", func(t *testing.T) {
+		t.Parallel()
+		client, adm, partClient := newGetGroupLagCluster(t)
+
+		// partition 0: 4 records, committed at 2 → lag 2
+		for range 4 {
+			produceRecord(ctx, t, client, 0, []byte("x"))
+		}
+		commitOffset(ctx, t, adm, "test-group", 0, 2)
+
+		// partition 1: 3 records, no commit → lag 3 (end-start = 3-0)
+		for range 3 {
+			produceRecord(ctx, t, client, 1, []byte("x"))
+		}
+
+		lag, err := getGroupLag(ctx, adm, partClient, "test-group", topicName, []int32{0, 1})
+		require.NoError(t, err)
+
+		l0, ok := lag.Lookup(topicName, 0)
+		require.True(t, ok)
+		assert.Equal(t, int64(2), l0.Lag)
+
+		l1, ok := lag.Lookup(topicName, 1)
+		require.True(t, ok)
+		assert.Equal(t, int64(3), l1.Lag)
+	})
+}


### PR DESCRIPTION
**What this PR does**:

Fixes three bugs in `getGroupLag` / `ExportPartitionLagMetrics` in `pkg/ingest`:

1. **Newly assigned partitions silently omitted.** The original code always passed `DescribedGroup{State: "Empty"}` (no members) to `CalculateGroupLagWithStartOffsets`. That function's empty-group fallback only iterates over previously committed partitions — a newly assigned partition with no committed offset is never included, so its lag gauge stays stale or is never set. Fix: call `DescribeGroups` first; use the real group description when members are present, fall back to manual per-partition computation over `assignedPartitions` (including uncommitted partitions, using start offset) when there are none.

2. **Spuriously large lag after log truncation.** The `lag == -1` sentinel used to gate the start-offset fallback would incorrectly trigger when a valid commit existed but `endOffset - committedOffset < 0`. Fix: replace with an explicit `hasCommit` bool; fall back to start offset only when no commit exists, clamp to zero otherwise.

3. **Stale gauge on missing end offset.** When a partition's end offset was absent from the broker response the old code `continue`d silently, leaving the gauge frozen. Fix: emit `Lag=-1` with `Err` set so callers can distinguish zero lag from a failed measurement.

Note: neither old nor new code reports lag for genuinely unowned partitions (those absent from every instance's `assignedPartitions`). This pre-existing observability gap is tracked as follow-up work.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`