### PR TITLE
Fixes # 6902 Add flag for MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## main / unreleased
 
+* [ENHANCEMENT] Add flag for enabling MCP server. [#6903](https://github.com/grafana/tempo/pull/6903) (@tiffanyfay)
+
 # v2.10.3
 
 * [SECURITY] S3 SSE-C `encryption_key` is now treated as a secret to prevent it from being exposed in plaintext. Resolves CVE-2026-28377. [#6711](https://github.com/grafana/tempo/pull/6711) (@mattdurham)

--- a/cmd/tempo/app/config.go
+++ b/cmd/tempo/app/config.go
@@ -148,7 +148,7 @@ func (c *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 	c.Ingest.RegisterFlagsAndApplyDefaults(util.PrefixConfig(prefix, "ingest"), f)
 	c.BlockBuilder.RegisterFlagsAndApplyDefaults(util.PrefixConfig(prefix, "block-builder"), f)
 	c.Querier.RegisterFlagsAndApplyDefaults(util.PrefixConfig(prefix, "querier"), f)
-	c.Frontend.RegisterFlagsAndApplyDefaults(util.PrefixConfig(prefix, "frontend"), f)
+	c.Frontend.RegisterFlagsAndApplyDefaults(util.PrefixConfig(prefix, "query-frontend"), f)
 	c.Compactor.RegisterFlagsAndApplyDefaults(util.PrefixConfig(prefix, "compactor"), f)
 	c.StorageConfig.RegisterFlagsAndApplyDefaults(util.PrefixConfig(prefix, "storage"), f)
 	c.UsageReport.RegisterFlagsAndApplyDefaults(util.PrefixConfig(prefix, "reporting"), f)

--- a/docs/sources/tempo/api_docs/mcp-server.md
+++ b/docs/sources/tempo/api_docs/mcp-server.md
@@ -23,7 +23,7 @@ query_frontend:
     enabled: true
 ```
 
-Or via a command-line flag: `--frontend.mcp-server.enabled=true`.
+Or via a command-line flag: `--query-frontend.mcp-server.enabled=true`.
 
 {{< admonition type="warning" >}}
 Be aware that using this feature will likely cause tracing data to be passed to an LLM or LLM provider. Consider the content of your tracing data and organizational policies when enabling this.

--- a/docs/sources/tempo/api_docs/mcp-server.md
+++ b/docs/sources/tempo/api_docs/mcp-server.md
@@ -15,13 +15,15 @@ For more information on MCP, refer to the [MCP documentation](https://modelconte
 
 ## Configuration
 
-Enable the MCP server in your Tempo configuration:
+You can enable the MCP server in your Tempo configuration via YAML:
 
 ```yaml
 query_frontend:
   mcp_server:
     enabled: true
 ```
+
+Or via a command-line flag: `--frontend.mcp-server.enabled=true`.
 
 {{< admonition type="warning" >}}
 Be aware that using this feature will likely cause tracing data to be passed to an LLM or LLM provider. Consider the content of your tracing data and organizational policies when enabling this.

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/command-line-flags.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/command-line-flags.md
@@ -69,7 +69,7 @@ Refer to the [Plan your Tempo deployment](../plan/) documentation for informatio
 
 | Flag | Description | Default |
 | --- | --- | --- |
-| `--frontend.mcp-server.enabled` | Set to true to enable the MCP server | `false` |
+| `--query-frontend.mcp-server.enabled` | Set to true to enable the MCP server | `false` |
 
 Tempo includes an [MCP (Model Context Protocol)](https://modelcontextprotocol.io/docs/getting-started/intro) server that provides AI assistants and Large Language Models (LLMs) with direct access to distributed tracing data through TraceQL queries and other endpoints.
 

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/command-line-flags.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/command-line-flags.md
@@ -65,6 +65,16 @@ Refer to the [Plan your Tempo deployment](../plan/) documentation for informatio
 | `--memberlist.bind-port` | Port for memberlist to communicate on | `7946` |
 | `--memberlist.message-history-buffer-bytes` | Size in bytes for the message history buffer | `0` |
 
+## MCP server
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `--frontend.mcp-server.enabled` | Set to true to enable the MCP server | `false` |
+
+Tempo includes an [MCP (Model Context Protocol)](https://modelcontextprotocol.io/docs/getting-started/intro) server that provides AI assistants and Large Language Models (LLMs) with direct access to distributed tracing data through TraceQL queries and other endpoints.
+
+Refer to the [Model Context Protocol (MCP) Server documentation](https://grafana.com/docs/tempo/<TEMPO_VERSION>/api_docs/mcp-server/) for more information.
+
 ## Module configuration
 
 You can use additional flags to configuring individual Tempo modules, such as the distributor, ingester, querier, and their components. These flags follow a pattern like `--<module>.<setting>` and are extensively documented in the configuration file format.

--- a/modules/frontend/config.go
+++ b/modules/frontend/config.go
@@ -131,19 +131,14 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 		MaxTraceQLConditions: 4,
 	}
 
-	// enabling an mcp server opens the door to send tracing data to an LLM. it should require
-	// explicit enabling
-	cfg.MCPServer = MCPServerConfig{
-		Enabled: false,
-	}
-
 	// set default max query size to 128 KiB, queries larger than this will be rejected
 	cfg.MaxQueryExpressionSizeBytes = 128 * 1024
 	// enable multi tenant queries by default
 	cfg.MultiTenantQueriesEnabled = true
 	cfg.Metrics.MaxIntervals = 10_000
 
-	// flag to enable mcp server
+	// enabling an mcp server opens the door to send tracing data to an LLM. it should require
+	// explicit enabling. registers a flag in addition to YAML configuration.
 	f.BoolVar(&cfg.MCPServer.Enabled, util.PrefixConfig(prefix, "mcp-server.enabled"), false, "Set to true to enable the MCP server")
 }
 

--- a/modules/frontend/config.go
+++ b/modules/frontend/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/tempo/modules/frontend/pipeline"
 	v1 "github.com/grafana/tempo/modules/frontend/v1"
 	"github.com/grafana/tempo/pkg/usagestats"
+	"github.com/grafana/tempo/pkg/util"
 )
 
 var statVersion = usagestats.NewString("frontend_version")
@@ -80,7 +81,7 @@ type SLOConfig struct {
 	ThroughputBytesSLO float64       `yaml:"throughput_bytes_slo,omitempty"`
 }
 
-func (cfg *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {
+func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 	slo := SLOConfig{
 		DurationSLO:        0,
 		ThroughputBytesSLO: 0,
@@ -141,6 +142,9 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {
 	// enable multi tenant queries by default
 	cfg.MultiTenantQueriesEnabled = true
 	cfg.Metrics.MaxIntervals = 10_000
+
+	// flag to enable mcp server
+	f.BoolVar(&cfg.MCPServer.Enabled, util.PrefixConfig(prefix, "mcp-server.enabled"), false, "Set to true to enable the MCP server")
 }
 
 type CortexNoQuerierLimits struct{}

--- a/modules/frontend/frontend_test.go
+++ b/modules/frontend/frontend_test.go
@@ -1,6 +1,7 @@
 package frontend
 
 import (
+	"flag"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -16,6 +17,22 @@ import (
 var testSLOcfg = SLOConfig{
 	ThroughputBytesSLO: 0,
 	DurationSLO:        0,
+}
+
+func TestMCPServerEnabled(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	cfg := &Config{}
+	cfg.RegisterFlagsAndApplyDefaults("frontend", fs)
+
+	assert.False(t, cfg.MCPServer.Enabled)
+
+	require.NoError(t, fs.Parse([]string{"-frontend.mcp-server.enabled=true"}))
+	assert.True(t, cfg.MCPServer.Enabled)
+
+	qf, err := New(*cfg, &mockRoundTripper{}, nil, nil, nil, "", fakeHTTPAuthMiddleware, nil, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+	_, ok := qf.MCPHandler.(*MCPServer)
+	assert.True(t, ok)
 }
 
 func TestFrontendTagSearchRequiresOrgID(t *testing.T) {

--- a/modules/frontend/frontend_test.go
+++ b/modules/frontend/frontend_test.go
@@ -22,11 +22,11 @@ var testSLOcfg = SLOConfig{
 func TestMCPServerEnabled(t *testing.T) {
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	cfg := &Config{}
-	cfg.RegisterFlagsAndApplyDefaults("frontend", fs)
+	cfg.RegisterFlagsAndApplyDefaults("query-frontend", fs)
 
 	assert.False(t, cfg.MCPServer.Enabled)
 
-	require.NoError(t, fs.Parse([]string{"-frontend.mcp-server.enabled=true"}))
+	require.NoError(t, fs.Parse([]string{"-query-frontend.mcp-server.enabled=true"}))
 	assert.True(t, cfg.MCPServer.Enabled)
 
 	qf, err := New(*cfg, &mockRoundTripper{}, nil, nil, nil, "", fakeHTTPAuthMiddleware, nil, log.NewNopLogger(), nil)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds a flag to enable the MCP server instead of just by config.

**Which issue(s) this PR fixes**:
Fixes #6902 for the 2.10 branch

The OTel LGTM Docker image [currently uses v2.10.3](https://github.com/grafana/docker-otel-lgtm/blob/d16b3991fe51cdfacce4d9ad8e400ced4f216037/docker/Dockerfile#L7). Currently there's no clean way to enable the Tempo MCP server. This PR adds the flag `--frontend.mcp-server.enabled=true`. It also adds the flag to the command line flags doc and the MCP server doc.

This makes it so we can therefore do the following with a future image build of `grafana/otel-lgtm:latest`

From the run command, I could then use the env var `TEMPO_EXTRA_ARGS: "--frontend.mcp-server.enabled=true"` which is used in `run-tempo.sh`: https://github.com/grafana/docker-otel-lgtm/blob/main/docker/run-tempo.sh
```
#!/bin/bash

source ./logging.sh

extra_args=()
if [[ -n "${TEMPO_EXTRA_ARGS:-}" ]]; then
	read -ra extra_args <<<"${TEMPO_EXTRA_ARGS}"
fi
run_with_logging "Tempo ${TEMPO_VERSION}" "${ENABLE_LOGS_TEMPO:-false}" \
	./tempo/tempo --config.file=./tempo-config.yaml "${extra_args[@]}"
```

This was from my own build and run:
```
  lgtm:
    image: tiffanyfay/otel-lgtm:tempo-mcp-2.10.3-apr8-1511
    ports:
      - "3000:3000" # Grafana UI
      - "4317:4317" # OTLP gRPC
      - "4318:4318" # OTLP HTTP
      - "3200:3200"
    volumes:
      - ./grafana/custom-dashboard.json:/otel-lgtm/grafana/conf/provisioning/dashboards/custom/custom-custom-dashboard.json:ro
      - ./grafana/dashboards-provisioning.yaml:/otel-lgtm/grafana/conf/provisioning/dashboards/custom.yaml:ro
    environment:
      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /otel-lgtm/grafana/conf/provisioning/dashboards/custom/custom-custom-dashboard.json
      TEMPO_EXTRA_ARGS: "--frontend.mcp-server.enabled=true"
```
<img width="452" height="370" alt="image" src="https://github.com/user-attachments/assets/903a4317-7aa6-4ff4-a02d-fa04f114a7d8" />

I need to look at what I need to do to add this to the `main` branch as well...

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`