### PR TITLE
[poller]: skip polling compacted blocks when the meta is known

### DIFF
--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -373,7 +373,8 @@ func (p *Poller) pollTenantBlocks(
 		// If we previously had this block as a live block, we already have all BlockMeta content.
 		// meta.compacted.json is a copy of meta.json, so the content is identical. Use time.Now()
 		// for CompactedTime — it's within one polling interval of the actual compaction time,
-		// which is acceptable since it's only used for deletion cutoffs in retention.go.
+		// which is acceptable for current consumers of CompactedTime, including deletion cutoffs
+		// in retention.go and deciding whether compacted blocks are included in backend searches.
 		if v, ok := mm[backend.UUID(blockID)]; ok {
 			newCompactedBlocklist = append(newCompactedBlocklist, &backend.CompactedBlockMeta{
 				BlockMeta:     *v,

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -364,18 +364,25 @@ func (p *Poller) pollTenantBlocks(
 	}
 
 	for _, blockID := range currentCompactedBlockIDs {
-		// if we already have this block id in our previous list, use the existing data.
+		// if we already have this block id in our previous compacted list, use the existing data.
 		if v, ok := cm[backend.UUID(blockID)]; ok {
 			newCompactedBlocklist = append(newCompactedBlocklist, v)
 			continue
 		}
 
-		// TODO: Review the ability  to avoid polling for compacted blocks that we
-		// know about.  We need to know the compacted time, but perhaps there is
-		// another way to get that, like the object creation time.
+		// If we previously had this block as a live block, we already have all BlockMeta content.
+		// meta.compacted.json is a copy of meta.json, so the content is identical. Use time.Now()
+		// for CompactedTime — it's within one polling interval of the actual compaction time,
+		// which is acceptable since it's only used for deletion cutoffs in retention.go.
+		if v, ok := mm[backend.UUID(blockID)]; ok {
+			newCompactedBlocklist = append(newCompactedBlocklist, &backend.CompactedBlockMeta{
+				BlockMeta:     *v,
+				CompactedTime: time.Now(),
+			})
+			continue
+		}
 
 		unknownBlockIDs[blockID] = true
-
 	}
 
 	newM, newCm, err := p.pollUnknown(derivedCtx, unknownBlockIDs, tenantID)

--- a/tempodb/blocklist/poller_test.go
+++ b/tempodb/blocklist/poller_test.go
@@ -895,12 +895,9 @@ func TestPollComparePreviousResults(t *testing.T) {
 					(uuid.UUID)(eff): 1,
 				},
 			},
-			expectedCompactedBlockMetaCalls: map[string]map[uuid.UUID]int{
-				"test": {
-					(uuid.UUID)(aaa):  1,
-					(uuid.UUID)(zero): 1,
-				},
-			},
+			// zero and aaa were previously known as live blocks, so their CompactedBlockMeta
+			// is synthesized from cached data — no backend fetch required.
+			expectedCompactedBlockMetaCalls: nil,
 		},
 		{
 			name:              "with previous compactions should be known",
@@ -1082,13 +1079,72 @@ func TestPollComparePreviousResults(t *testing.T) {
 					x := bytes.Compare(expectedCompactedMetas[i].BlockID[:], expectedCompactedMetas[j].BlockID[:])
 					return x > 0
 				})
-				require.Equal(t, expectedCompactedMetas, l)
+
+				// Strip CompactedTime before comparing: blocks synthesized from previously-known
+				// live blocks use time.Now(), which we cannot predict in expected values.
+				stripped := make([]*backend.CompactedBlockMeta, len(l))
+				for i, m := range l {
+					stripped[i] = &backend.CompactedBlockMeta{BlockMeta: m.BlockMeta}
+				}
+				require.Equal(t, expectedCompactedMetas, stripped)
 			}
 
 			require.Equal(t, tc.expectedBlockMetaCalls, r.(*backend.MockReader).BlockMetaCalls)
 			require.Equal(t, tc.expectedCompactedBlockMetaCalls, c.(*backend.MockCompactor).CompactedBlockMetaCalls)
 		})
 	}
+}
+
+// TestPollLiveToCompactedSynthesized verifies that blocks previously known as live are
+// synthesized into CompactedBlockMeta without a backend fetch, and that CompactedTime is set.
+func TestPollLiveToCompactedSynthesized(t *testing.T) {
+	blockID := backend.MustParse("00000000-0000-0000-0000-000000000001")
+	tenantID := "test"
+
+	previousMeta := &backend.BlockMeta{
+		BlockID:  blockID,
+		TenantID: tenantID,
+	}
+
+	// Previous poll saw the block as live; current poll reports it as compacted.
+	previous := newBlocklist(
+		PerTenant{tenantID: []*backend.BlockMeta{previousMeta}},
+		PerTenantCompacted{},
+	)
+	currentCompacted := PerTenantCompacted{
+		tenantID: []*backend.CompactedBlockMeta{
+			{BlockMeta: backend.BlockMeta{BlockID: blockID}},
+		},
+	}
+
+	c := newMockCompactor(currentCompacted, false)
+	r := newMockReader(PerTenant{}, currentCompacted, false)
+	w := &backend.MockWriter{}
+	s := &mockJobSharder{owns: true}
+
+	poller := NewPoller(&PollerConfig{
+		PollConcurrency:       testPollConcurrency,
+		TenantPollConcurrency: testTenantPollConcurrency,
+		PollFallback:          testPollFallback,
+		TenantIndexBuilders:   testBuilders,
+	}, s, r, c, w, log.NewNopLogger())
+
+	before := time.Now()
+	_, compactedMetas, err := poller.Do(context.Background(), previous)
+	require.NoError(t, err)
+
+	// Block should appear in the compacted list.
+	require.Len(t, compactedMetas[tenantID], 1)
+	got := compactedMetas[tenantID][0]
+	require.Equal(t, blockID, got.BlockID)
+	require.Equal(t, *previousMeta, got.BlockMeta)
+
+	// CompactedTime must be set (non-zero and after our start time).
+	require.False(t, got.CompactedTime.IsZero(), "CompactedTime should be set for synthesized compacted block")
+	require.True(t, got.CompactedTime.After(before) || got.CompactedTime.Equal(before))
+
+	// No backend fetch should have occurred for this block.
+	require.Empty(t, c.(*backend.MockCompactor).CompactedBlockMetaCalls)
 }
 
 func BenchmarkPoller10k(b *testing.B) {


### PR DESCRIPTION
**What this PR does**:

During each poll cycle, the poller iterates over all block IDs reported as compacted by the backend. For each one, it first checks whether the block is already in the previous compacted list (cache hit). If not, it had to fetch `meta.compacted.json` from object storage — one backend read per newly-compacted block per poll interval.

This PR adds a second cache check: if the block was present in the previous *live* block list, we already have its full `BlockMeta`. Since `meta.compacted.json` is structurally identical to `meta.json`, we can construct the `CompactedBlockMeta` directly without a backend read. `CompactedTime` is set to `time.Now()`, which is within one polling interval of the actual compaction timestamp. This approximation is acceptable for all current consumers of `CompactedTime` (retention cutoffs in `retention.go` and backend search filtering).

The result is that blocks transitioning from live to compacted no longer incur a backend read on their first poll after compaction. Only blocks that appear in the compacted list without any prior knowledge (truly unknown blocks) are fetched.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`