### PR TITLE
chore: improve observability with the livestore startup/shutdown

### DIFF
--- a/modules/livestore/instance.go
+++ b/modules/livestore/instance.go
@@ -522,6 +522,8 @@ func (i *instance) completeBlock(ctx context.Context, id uuid.UUID) error {
 	}
 
 	blockSize := walBlock.DataLength()
+
+	level.Info(i.logger).Log("msg", "completing WAL block", "blockSize", blockSize, "blockId", id.String())
 	metricCompletionSize.Observe(float64(blockSize))
 	span.SetAttributes(attribute.Int64("block_size", int64(blockSize)))
 
@@ -544,12 +546,15 @@ func (i *instance) completeBlock(ctx context.Context, id uuid.UUID) error {
 		return err
 	}
 
+	level.Info(i.logger).Log("msg", "opening newly completed block", "blockId", newMeta.BlockID.String())
 	newBlock, err := i.completeBlockEncoding.OpenBlock(newMeta, reader)
 	if err != nil {
 		level.Error(i.logger).Log("msg", "failed to open complete block", "id", id, "err", err)
 		span.RecordError(err)
 		return err
 	}
+
+	level.Info(i.logger).Log("msg", "swapping wal block with newly completed block")
 
 	i.blocksMtx.Lock()
 	defer i.blocksMtx.Unlock()

--- a/modules/livestore/live_store.go
+++ b/modules/livestore/live_store.go
@@ -281,12 +281,14 @@ func (s *LiveStore) starting(ctx context.Context) error {
 		return fmt.Errorf("failed to reload blocks from wal: %w", err)
 	}
 
+	level.Info(s.logger).Log("msg", "deleting old blocks")
 	for _, inst := range s.getInstances() {
 		err = inst.deleteOldBlocks()
 		if err != nil {
 			level.Warn(s.logger).Log("msg", "failed to delete old blocks", "err", err, "tenant", inst.tenantID)
 		}
 	}
+	level.Info(s.logger).Log("msg", "done deleting old blocks")
 
 	// Set eagerly so the flag is already in place when the lifecycler's stopping()
 	// checks it. Setting it in our own stopping() races with context-cancellation
@@ -317,11 +319,14 @@ func (s *LiveStore) starting(ctx context.Context) error {
 	}
 
 	// allow background processes to start
+	level.Info(s.logger).Log("msg", "starting all background processes")
 	s.startAllBackgroundProcesses()
 
+	level.Info(s.logger).Log("msg", "waiting for ingestion catching up")
 	if err := s.waitForIngestPathReady(ctx); err != nil {
 		return err
 	}
+	level.Info(s.logger).Log("msg", "done waiting for ingestion catching up")
 
 	// Mark as ready at end of starting()
 	s.readyErr.Store(nil)
@@ -440,7 +445,9 @@ func (s *LiveStore) stopping(error) error {
 	}
 
 	// Flush all data to disk.
+	level.Info(s.logger).Log("msg", "cutting all instances to WAL")
 	s.cutAllInstancesToWal()
+	level.Info(s.logger).Log("msg", "done cutting all instances to WAL")
 
 	// Remove the shutdown marker if it exists since we are shutting down.
 	shutdownMarkerPath := shutdownmarker.GetPath(s.cfg.ShutdownMarkerDir)
@@ -459,6 +466,7 @@ func (s *LiveStore) stopping(error) error {
 	timeout := time.NewTimer(s.cfg.InstanceCleanupPeriod)
 	defer timeout.Stop()
 
+	level.Info(s.logger).Log("msg", "stopping all background processes")
 	s.stopAllBackgroundProcesses()
 
 	return stopErr
@@ -592,6 +600,10 @@ func (s *LiveStore) consume(ctx context.Context, rs recordIter, now time.Time) (
 		record := rs.Next()
 		tenant := string(record.Key)
 
+		// Track partition lag in seconds
+		lag := now.Sub(record.Timestamp)
+		ingest.SetPartitionLagSeconds(s.cfg.IngestConfig.Kafka.ConsumerGroup, record.Partition, lag)
+
 		if record.Timestamp.Before(cutoff) {
 			metricRecordsDropped.WithLabelValues(tenant, droppedRecordReasonTooOld).Inc()
 			lastRecord = record
@@ -620,10 +632,6 @@ func (s *LiveStore) consume(ctx context.Context, rs recordIter, now time.Time) (
 
 		// Push data to tenant instance
 		inst.pushBytes(ctx, record.Timestamp, pushReq)
-
-		// Track partition lag in seconds
-		lag := now.Sub(record.Timestamp)
-		ingest.SetPartitionLagSeconds(s.cfg.IngestConfig.Kafka.ConsumerGroup, record.Partition, lag)
 
 		metricRecordsProcessed.WithLabelValues(tenant).Inc()
 		recordCount++

--- a/modules/livestore/live_store_background.go
+++ b/modules/livestore/live_store_background.go
@@ -76,6 +76,10 @@ func (s *LiveStore) runInBackground(fn func()) {
 }
 
 func (s *LiveStore) globalCompleteLoop(idx int) {
+	level.Info(s.logger).Log("msg", "starting completing loop", "index", idx)
+	defer func() {
+		level.Info(s.logger).Log("msg", "shutdown completing loop", "index", idx)
+	}()
 	for {
 		op := s.completeQueues.Dequeue(idx)
 		if op == nil {
@@ -282,6 +286,8 @@ func (s *LiveStore) reloadBlocks() error {
 	// ------------------------------------
 	// Complete blocks
 	// ------------------------------------
+	level.Info(s.logger).Log("msg", "reloading completed blocks")
+
 	var (
 		ctx = s.ctx
 		l   = s.wal.LocalBackend()
@@ -358,6 +364,8 @@ func (s *LiveStore) reloadBlocks() error {
 			inst.blocksMtx.Unlock()
 		}
 	}
+
+	level.Info(s.logger).Log("msg", "done reloading completed blocks")
 
 	return nil
 }

--- a/modules/livestore/live_store_test.go
+++ b/modules/livestore/live_store_test.go
@@ -488,6 +488,94 @@ func TestLiveStoreConsumeDropsOldRecords(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestLiveStoreConsumeTracksPartitionLag verifies that partition lag is tracked
+// for all records regardless of outcome: too old (dropped), decode failure, or
+// successfully processed.
+func TestLiveStoreConsumeTracksPartitionLag(t *testing.T) {
+	ls, err := defaultLiveStore(t, t.TempDir())
+	require.NoError(t, err)
+
+	// Use a unique consumer group to avoid flaky collisions with other packages
+	// that share the global default Prometheus registry.
+	consumerGroup := t.Name()
+	ls.cfg.IngestConfig.Kafka.ConsumerGroup = consumerGroup
+	t.Cleanup(func() {
+		ingest.ResetLagMetricsForRevokedPartitions(consumerGroup, []int32{0, 1, 2})
+	})
+
+	now := time.Now()
+	older := now.Add(-1 * (defaultCompleteBlockTimeout + time.Second))
+	newer := now.Add(-1 * (defaultCompleteBlockTimeout - time.Second))
+
+	// Each record uses a different partition so we can verify lag independently.
+	records := []*kgo.Record{
+		{
+			Key:       []byte("tenant1"),
+			Timestamp: older, // dropped as too old
+			Partition: 0,
+			Value:     createValidPushRequest(t),
+		},
+		{
+			Key:       []byte("tenant1"),
+			Timestamp: newer, // dropped due to decode failure
+			Partition: 1,
+			Value:     []byte("invalid-protobuf"),
+		},
+		{
+			Key:       []byte("tenant1"),
+			Timestamp: newer, // successfully processed
+			Partition: 2,
+			Value:     createValidPushRequest(t),
+		},
+	}
+
+	_, err = ls.consume(context.Background(), createRecordIter(records), now)
+	require.NoError(t, err)
+
+	// Partition lag should be tracked for every record, including dropped ones.
+	require.InDelta(t, now.Sub(older).Seconds(), getPartitionLagSecondsFromGatherer(t, consumerGroup, "0"), 0.1,
+		"partition lag should be tracked for too-old records")
+	require.InDelta(t, now.Sub(newer).Seconds(), getPartitionLagSecondsFromGatherer(t, consumerGroup, "1"), 0.1,
+		"partition lag should be tracked for decode-failure records")
+	require.InDelta(t, now.Sub(newer).Seconds(), getPartitionLagSecondsFromGatherer(t, consumerGroup, "2"), 0.1,
+		"partition lag should be tracked for successfully processed records")
+
+	err = services.StopAndAwaitTerminated(t.Context(), ls)
+	require.NoError(t, err)
+}
+
+// getPartitionLagSecondsFromGatherer reads the tempo_ingest_group_partition_lag_seconds gauge
+// from the default Prometheus gatherer.
+func getPartitionLagSecondsFromGatherer(t *testing.T, group, partition string) float64 {
+	t.Helper()
+
+	families, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	for _, f := range families {
+		if f.GetName() != "tempo_ingest_group_partition_lag_seconds" {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			var matchGroup, matchPartition bool
+			for _, l := range m.GetLabel() {
+				if l.GetName() == "group" && l.GetValue() == group {
+					matchGroup = true
+				}
+				if l.GetName() == "partition" && l.GetValue() == partition {
+					matchPartition = true
+				}
+			}
+			if matchGroup && matchPartition {
+				return m.GetGauge().GetValue()
+			}
+		}
+	}
+
+	t.Fatalf("metric tempo_ingest_group_partition_lag_seconds{group=%q, partition=%q} not found", group, partition)
+	return 0
+}
+
 func TestLiveStoreUsesRecordTimestampForBlockStartAndEnd(t *testing.T) {
 	// default ingestion slack is 2 minutes. create some convenient times to help the test below
 	now := time.Unix(1000000, 0)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
- added more fine grained logs over the livestore shutdown/startup process
- record the partition lag regardless of record state

**Which issue(s) this PR fixes**:
Fixes N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`