### PR TITLE
[DOC] Fix docker-compose.md links to point to v2.10 branch

### DIFF
--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/locally/docker-compose.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/locally/docker-compose.md
@@ -7,16 +7,20 @@ weight: 400
 
 # Deploy Tempo using Docker Compose
 
-The [`example` directory](https://github.com/grafana/tempo/tree/main/example/docker-compose) in the Tempo repository provides a `docker-compose` file that you can use to run Tempo locally with different configurations.
+The [`example` directory](https://github.com/grafana/tempo/tree/release-v2.10/example/docker-compose) in the Tempo repository provides a `docker-compose` file that you can use to run Tempo locally with different configurations.
 
-The easiest example to start with is [Local Storage](https://github.com/grafana/tempo/tree/main/example/docker-compose/local/readme.md).
+{{< admonition type="note" >}}
+The `example` directory in the Tempo repository is on the `release-v2.10` branch. The examples on the `main` branch are updated for the next release.
+{{< /admonition >}}
+
+The easiest example to start with is [Local Storage](https://github.com/grafana/tempo/tree/release-v2.10/example/docker-compose/local/readme.md).
 This example runs Tempo as a single binary together with the synthetic-load-generator, to generate traces, and Grafana, to query Tempo.
 Data is stored locally on disk.
 
 The following examples showcase specific features or integrations:
 
-- [Grafana Alloy](https://github.com/grafana/tempo/tree/main/example/docker-compose/alloy/readme.md) provides a simple example using the Grafana Alloy as a tracing pipeline.
-- [OpenTelemetry Collector](https://github.com/grafana/tempo/tree/main/example/docker-compose/otel-collector/readme.md) is a basic example using the OpenTelemetry Collector as a tracing pipeline.
-- [OpenTelemetry Collector Multitenant](https://github.com/grafana/tempo/tree/main/example/docker-compose/otel-collector-multitenant/readme.md) uses the OpenTelemetry Collector in an advanced multi-tenant configuration.
+- [Grafana Alloy](https://github.com/grafana/tempo/tree/release-v2.10/example/docker-compose/alloy/readme.md) provides a simple example using the Grafana Alloy as a tracing pipeline.
+- [OpenTelemetry Collector](https://github.com/grafana/tempo/tree/release-v2.10/example/docker-compose/otel-collector/readme.md) is a basic example using the OpenTelemetry Collector as a tracing pipeline.
+- [OpenTelemetry Collector Multitenant](https://github.com/grafana/tempo/tree/release-v2.10/example/docker-compose/otel-collector-multitenant/readme.md) uses the OpenTelemetry Collector in an advanced multi-tenant configuration.
 
-The [Local storage](https://github.com/grafana/tempo/tree/main/example/docker-compose/local/readme.md) example uses the `local` backend, suitable for local testing and development.
+The [Local storage](https://github.com/grafana/tempo/tree/release-v2.10/example/docker-compose/local/readme.md) example uses the `local` backend, suitable for local testing and development.


### PR DESCRIPTION
**What this PR does**:

Fixes links on docker-compose.md to point to the docker examples for 2.10. 

This is a direct doc fix in the release-2.10 branch. These changes shouldn't be on main. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/tempo/issues/6508 
Fixes https://github.com/grafana/tempo/issues/6499

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`