### PR TITLE
enhancement: use single queue to balance the WAL completion load

### DIFF
--- a/modules/ingester/flush.go
+++ b/modules/ingester/flush.go
@@ -213,14 +213,14 @@ func (i *Ingester) cutOneInstanceToWal(instance *instance, immediate bool) {
 	}
 }
 
-func (i *Ingester) flushLoop(j int) {
+func (i *Ingester) flushLoop() {
 	defer func() {
 		level.Debug(log.Logger).Log("msg", "Ingester.flushLoop() exited")
 		i.flushQueuesDone.Done()
 	}()
 
 	for {
-		op := i.flushQueues.Dequeue(j)
+		op := i.flushQueues.Dequeue()
 		if op == nil {
 			return
 		}

--- a/modules/ingester/ingester.go
+++ b/modules/ingester/ingester.go
@@ -97,7 +97,7 @@ func New(cfg Config, store storage.Store, overrides overrides.Interface, reg pro
 		cfg:          cfg,
 		instances:    map[string]*instance{},
 		store:        store,
-		flushQueues:  flushqueues.New[*flushOp](cfg.ConcurrentFlushes, metricFlushQueueLength),
+		flushQueues:  flushqueues.New[*flushOp](metricFlushQueueLength),
 		replayJitter: true,
 		overrides:    overrides,
 
@@ -171,7 +171,7 @@ func (i *Ingester) starting(ctx context.Context) error {
 
 	i.flushQueuesDone.Add(i.cfg.ConcurrentFlushes)
 	for j := 0; j < i.cfg.ConcurrentFlushes; j++ {
-		go i.flushLoop(j)
+		go i.flushLoop()
 	}
 
 	// Now that user states have been created, we can start the lifecycler.

--- a/modules/ingester/ingester.go
+++ b/modules/ingester/ingester.go
@@ -171,7 +171,7 @@ func (i *Ingester) starting(ctx context.Context) error {
 
 	i.flushQueuesDone.Add(i.cfg.ConcurrentFlushes)
 	for j := 0; j < i.cfg.ConcurrentFlushes; j++ {
-		go i.flushLoop()
+		go i.flushLoop() //nolint: gosec // G118
 	}
 
 	// Now that user states have been created, we can start the lifecycler.

--- a/modules/livestore/live_store.go
+++ b/modules/livestore/live_store.go
@@ -171,7 +171,7 @@ func New(cfg Config, overridesService overrides.Interface, logger log.Logger, re
 		cancel:                cancel,
 		instances:             make(map[string]*instance),
 		overrides:             overridesService,
-		completeQueues:        flushqueues.New[*completeOp](cfg.CompleteBlockConcurrency, metricCompleteQueueLength),
+		completeQueues:        flushqueues.New[*completeOp](metricCompleteQueueLength),
 		startupComplete:       make(chan struct{}),
 	}
 

--- a/modules/livestore/live_store_background.go
+++ b/modules/livestore/live_store_background.go
@@ -81,7 +81,7 @@ func (s *LiveStore) globalCompleteLoop(idx int) {
 		level.Info(s.logger).Log("msg", "shutdown completing loop", "index", idx)
 	}()
 	for {
-		op := s.completeQueues.Dequeue(idx)
+		op := s.completeQueues.Dequeue()
 		if op == nil {
 			return // queue is closed
 		}

--- a/pkg/flushqueues/exclusivequeues.go
+++ b/pkg/flushqueues/exclusivequeues.go
@@ -2,53 +2,45 @@ package flushqueues
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/atomic"
 )
 
 type ExclusiveQueues[T Op] struct {
-	queues     []*PriorityQueue[T]
-	index      *atomic.Int32
+	queue      *PriorityQueue[T]
 	activeKeys sync.Map
 	stopped    atomic.Bool
 }
 
 // New creates a new set of flush queues with a prom gauge to track current depth
-func New[T Op](queues int, metric prometheus.Gauge) *ExclusiveQueues[T] {
-	f := &ExclusiveQueues[T]{
-		queues: make([]*PriorityQueue[T], queues),
-		index:  atomic.NewInt32(0),
+func New[T Op](metric prometheus.Gauge) *ExclusiveQueues[T] {
+	return &ExclusiveQueues[T]{
+		queue: NewPriorityQueue[T](metric),
 	}
-
-	for j := 0; j < queues; j++ {
-		f.queues[j] = NewPriorityQueue[T](metric)
-	}
-
-	return f
 }
 
-// Enqueue adds the op to the next queue and prevents any other items to be added with this key
+// Enqueue adds the op to the queue and prevents any other items to be added with this key
 func (f *ExclusiveQueues[T]) Enqueue(op T) error {
-	_, ok := f.activeKeys.Load(op.Key())
-	if ok {
+	_, loaded := f.activeKeys.LoadOrStore(op.Key(), struct{}{})
+	if loaded {
 		return nil
 	}
 
-	f.activeKeys.Store(op.Key(), struct{}{})
 	return f.Requeue(op)
 }
 
-// Dequeue removes the next op from the requested queue.  After dequeueing the calling
-// process either needs to call ClearKey or Requeue
-func (f *ExclusiveQueues[T]) Dequeue(q int) T {
-	return f.queues[q].Dequeue()
+// Dequeue removes the next op from the queue. After dequeueing the calling
+// process either needs to call Clear or Requeue.
+// Multiple goroutines can call Dequeue concurrently; the underlying PriorityQueue
+// serializes access and blocks each caller until an item is available.
+func (f *ExclusiveQueues[T]) Dequeue() T {
+	return f.queue.Dequeue()
 }
 
 // Requeue adds an op that is presumed to already be covered by activeKeys
 func (f *ExclusiveQueues[T]) Requeue(op T) error {
-	flushQueueIndex := int(f.index.Inc()) % len(f.queues)
-	_, err := f.queues[flushQueueIndex].Enqueue(op)
+	_, err := f.queue.Enqueue(op)
 	return err
 }
 
@@ -68,13 +60,10 @@ func (f *ExclusiveQueues[T]) IsEmpty() bool {
 	return length <= 0
 }
 
-// Stop closes all queues
+// Stop closes the queue
 func (f *ExclusiveQueues[T]) Stop() {
 	f.stopped.Store(true)
-
-	for _, q := range f.queues {
-		q.Close()
-	}
+	f.queue.Close()
 }
 
 func (f *ExclusiveQueues[T]) IsStopped() bool {

--- a/pkg/flushqueues/exclusivequeues_test.go
+++ b/pkg/flushqueues/exclusivequeues_test.go
@@ -29,7 +29,7 @@ func TestExclusiveQueues(t *testing.T) {
 		Name:      "testersons",
 	})
 
-	q := New[mockOp](1, gauge)
+	q := New[mockOp](gauge)
 	op := mockOp{
 		key: "not unique",
 	}
@@ -50,7 +50,7 @@ func TestExclusiveQueues(t *testing.T) {
 	assert.Equal(t, 1, int(length))
 
 	// dequeue -> requeue
-	_ = q.Dequeue(0)
+	_ = q.Dequeue()
 	length, err = test.GetGaugeValue(gauge)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, int(length))
@@ -63,7 +63,7 @@ func TestExclusiveQueues(t *testing.T) {
 	assert.Equal(t, 1, int(length))
 
 	// dequeue -> clearkey -> enqueue
-	_ = q.Dequeue(0)
+	_ = q.Dequeue()
 	length, err = test.GetGaugeValue(gauge)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, int(length))
@@ -81,15 +81,14 @@ func TestExclusiveQueues(t *testing.T) {
 	assert.Equal(t, 1, int(length))
 }
 
-func TestMultipleQueues(t *testing.T) {
+func TestMultipleItems(t *testing.T) {
 	gauge := prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: "test",
 		Name:      "testersons",
 	})
 
-	totalQueues := 10
 	totalItems := 10
-	q := New[mockOp](totalQueues, gauge)
+	q := New[mockOp](gauge)
 
 	// add stuff to the queue and confirm the length matches expected
 	for i := 0; i < totalItems; i++ {
@@ -105,14 +104,14 @@ func TestMultipleQueues(t *testing.T) {
 		assert.Equal(t, i+1, int(length))
 	}
 
-	// each queue should have 1 thing
-	for i := 0; i < totalQueues; i++ {
-		op := q.Dequeue(i)
+	// dequeue all items
+	for i := 0; i < totalItems; i++ {
+		op := q.Dequeue()
 		assert.NotNil(t, op)
 
 		length, err := test.GetGaugeValue(gauge)
 		assert.NoError(t, err)
-		assert.Equal(t, totalQueues-(i+1), int(length))
+		assert.Equal(t, totalItems-(i+1), int(length))
 	}
 }
 
@@ -122,11 +121,11 @@ func TestExclusiveQueueLocks(t *testing.T) {
 		Name:      "testersons",
 	})
 
-	queue := New[simpleItem](1, gauge)
+	queue := New[simpleItem](gauge)
 	job := simpleItem(1)
 
 	assert.NoError(t, queue.Enqueue(job))
-	i := queue.Dequeue(0)
+	i := queue.Dequeue()
 	assert.Equal(t, job, i, "Expected to dequeue job")
 
 	// Requeueing the same job again will be added to the queue
@@ -146,7 +145,7 @@ func TestExclusiveQueueLocks(t *testing.T) {
 func waitForDequeue(queue *ExclusiveQueues[simpleItem]) bool {
 	done := make(chan struct{})
 	go func() {
-		queue.Dequeue(0)
+		queue.Dequeue()
 		done <- struct{}{}
 	}()
 	select {

--- a/pkg/flushqueues/exclusivequeues_test.go
+++ b/pkg/flushqueues/exclusivequeues_test.go
@@ -1,6 +1,7 @@
 package flushqueues
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -154,4 +155,96 @@ func waitForDequeue(queue *ExclusiveQueues[simpleItem]) bool {
 	case <-time.After(100 * time.Millisecond):
 		return false
 	}
+}
+
+// TestConcurrentDequeue verifies that multiple goroutines calling Dequeue
+// concurrently on a shared queue process every item exactly once.
+func TestConcurrentDequeue(t *testing.T) {
+	q := New[mockOp](nil)
+
+	totalItems := 500
+	numWorkers := 10
+
+	// Enqueue all items up front
+	keys := make([]string, totalItems)
+	for i := range totalItems {
+		keys[i] = uuid.New().String()
+		require.NoError(t, q.Enqueue(mockOp{key: keys[i]}))
+	}
+
+	// Track which keys each worker dequeued
+	var mu sync.Mutex
+	seen := make(map[string]int) // key -> count
+
+	// itemsDone tracks when all items have been processed
+	var itemsDone sync.WaitGroup
+	itemsDone.Add(totalItems)
+
+	var workers sync.WaitGroup
+	for range numWorkers {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for {
+				op := q.Dequeue()
+				if op.Key() == "" {
+					return // queue closed
+				}
+				mu.Lock()
+				seen[op.Key()]++
+				mu.Unlock()
+				q.Clear(op)
+				itemsDone.Done()
+			}
+		}()
+	}
+
+	// Wait for all items to be processed, then shut down workers
+	itemsDone.Wait()
+	q.Stop()
+	workers.Wait()
+
+	// Every key must have been dequeued exactly once
+	for _, key := range keys {
+		assert.Equal(t, 1, seen[key], "key %s dequeued %d times", key, seen[key])
+	}
+	assert.Equal(t, totalItems, len(seen), "expected %d unique keys, got %d", totalItems, len(seen))
+}
+
+// TestStopUnblocksAllWaiters verifies that calling Stop on an empty queue
+// unblocks all goroutines waiting in Dequeue, returning zero values.
+func TestStopUnblocksAllWaiters(t *testing.T) {
+	q := New[mockOp](nil)
+	numWorkers := 5
+
+	// allStarted signals when every worker has entered Dequeue.
+	// Each worker enqueues+dequeues a sentinel before blocking on the
+	// empty queue, so when allStarted completes we know they reached Dequeue.
+	var allStarted sync.WaitGroup
+	allStarted.Add(numWorkers)
+
+	var workers sync.WaitGroup
+	for i := range numWorkers {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			// Signal that this goroutine is running by round-tripping
+			// a unique sentinel through the queue.
+			sentinel := mockOp{key: uuid.New().String()}
+			require.NoError(t, q.Enqueue(sentinel))
+			got := q.Dequeue()
+			require.Equal(t, sentinel.Key(), got.Key())
+			q.Clear(got)
+			allStarted.Done()
+
+			// Now block on the empty queue
+			op := q.Dequeue()
+			assert.Equal(t, mockOp{}, op, "worker %d: expected zero value from closed queue", i)
+		}()
+	}
+
+	// All workers are confirmed to be inside Dequeue on the empty queue
+	allStarted.Wait()
+	q.Stop()
+	workers.Wait()
 }

--- a/pkg/flushqueues/priority_queue.go
+++ b/pkg/flushqueues/priority_queue.go
@@ -99,7 +99,7 @@ func (pq *PriorityQueue[T]) Enqueue(op T) (bool, error) {
 
 	pq.hit[op.Key()] = struct{}{}
 	heap.Push(&pq.queue, op)
-	pq.cond.Broadcast()
+	pq.cond.Signal()
 	if pq.lengthGauge != nil {
 		pq.lengthGauge.Inc()
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
- instead of using N queues + N workers for the WAL completion, use a 1 queue + N workers. This way we can balance the completion load and avoid head of line blocks.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`