### PR TITLE
[DOC] Update consistent hash ring doc for 3.0

### DIFF
--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -49,6 +49,7 @@ For externally supported gRPC API, [refer to Tempo gRPC API](#tempo-grpc-api).
 | [Usage Metrics](#usage-metrics)                                                       | Distributor                               | HTTP | `GET /usage_metrics`                                      |
 | [Distributor ring status](#distributor-ring-status) (\*)                              | Distributor                               | HTTP | `GET /distributor/ring`                                   |
 | [Live-store ring status](#live-store-ring-status)                                     | Distributor, Querier                      | HTTP | `GET /live-store/ring`                                    |
+| [Partition ring status](#partition-ring-status)                                       | Distributor, Querier, Live store          | HTTP | `GET /partition-ring`                                     |
 | [Status](#status)                                                                     | Status                                    | HTTP | `GET /status`                                             |
 | [List build information](#list-build-information)                                     | Status                                    | HTTP | `GET /api/status/buildinfo`                               |
 | [MCP Server](https://grafana.com/docs/tempo/<TEMPO_VERSION>/api_docs/mcp-server) (\*) | MCP                                       |      | `/api/mcp`                                                |
@@ -803,6 +804,16 @@ GET /live-store/ring
 ```
 
 Displays a web page with the live-store hash ring status, including the state, health, and last heartbeat time of each live-store instance.
+
+For more information, refer to [consistent hash ring](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/manage-advanced-systems/consistent_hash_ring/).
+
+### Partition ring status
+
+```
+GET /partition-ring
+```
+
+Displays a web page with the partition ring status, showing partition ownership across live-store instances, including state, ownership percentage, and available actions.
 
 For more information, refer to [consistent hash ring](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/manage-advanced-systems/consistent_hash_ring/).
 

--- a/docs/sources/tempo/operations/manage-advanced-systems/consistent_hash_ring.md
+++ b/docs/sources/tempo/operations/manage-advanced-systems/consistent_hash_ring.md
@@ -13,7 +13,7 @@ Tempo uses the [Consistent Hash Ring](https://cortexmetrics.io/docs/architecture
 By default, the ring is gossiped between all Tempo components.
 However, it can be configured to use [Consul](https://www.consul.io/) or [Etcd](https://etcd.io/), if desired.
 
-Tempo uses several consistent hash rings. This topic describes the distributor, live-store (partition ring), and live-store rings.
+Tempo uses several consistent hash rings.
 Each hash ring exists for a distinct reason.
 
 ## Distributor
@@ -34,10 +34,33 @@ This ring is only used when `global` rate limits are used. The distributors use 
 
 The partition ring tracks which Tempo partitions are active and which live-stores own them. Distributors use this ring to determine which partitions to write to when sending data to Kafka. Queriers use it to find the live-stores for querying recent traces. Block-builders use it to determine which partitions to consume from.
 
+## Backend-worker
+
+**Participants:** Backend-workers
+
+**Used by:** Backend-workers
+
+The backend-worker ring shards tenant index writing across backend-workers. This ring is only active when the backend-worker is configured with an external KV store for ring membership.
+
+## Metrics-generator (partition ring)
+
+**Participants:** Metrics-generators
+
+**Used by:** Metrics-generators
+
+In microservices mode, the metrics-generator partition ring tracks which generator instances own which partitions. This ring is only active when `metrics_generator.ring_mode` is set to `generator`.
+
 ## Interacting with the rings
 
-Web pages are available at the following endpoints. They show every ring member, their tokens and includes the ability to "Forget" a ring member. "Forgetting" is useful when a
-ring member leaves the ring without properly shutting down, and therefore leaves its tokens in the ring.
+Web pages are available at the following endpoints. They show every ring member, their tokens, and include the ability to "Forget" a ring member. "Forgetting" is useful when a ring member leaves the ring without properly shutting down, and therefore leaves its tokens in the ring.
+
+To access a ring page, send a GET request to the Tempo HTTP API. By default, Tempo listens on port `3200` (configured with `server.http_listen_port`). For example:
+
+```
+http://<tempo-host>:3200/live-store/ring
+```
+
+In single-binary mode, all ring endpoints are available on the same host. In microservices mode, each endpoint is available on the component listed in the **Available on** field.
 
 ### Distributor
 
@@ -45,7 +68,11 @@ ring member leaves the ring without properly shutting down, and therefore leaves
 
 **Path:** `/distributor/ring`
 
-Unhealthy distributors have little impact but should be forgotten to reduce cost of maintaining the ring .
+{{< admonition type="note" >}}
+This endpoint is only available when Tempo is configured with [the global override strategy](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#overrides).
+{{< /admonition >}}
+
+Unhealthy distributors have little impact but should be forgotten to reduce the cost of maintaining the ring.
 
 ### Live-store (partition ring)
 
@@ -60,6 +87,30 @@ The partition ring shows partition ownership across live-stores. Unhealthy live-
 **Available on:** Distributors, Queriers, Live-stores
 
 **Path:** `/live-store/ring`
+
+### Backend-worker
+
+**Available on:** Backend-workers
+
+**Path:** `/backend-worker/ring`
+
+{{< admonition type="note" >}}
+This endpoint is only available when the backend-worker is configured with an external KV store for its ring.
+{{< /admonition >}}
+
+The backend-worker ring page shows how tenant index writing is distributed across workers. Forget unhealthy workers so that sharding redistributes correctly.
+
+### Metrics-generator (partition ring)
+
+**Available on:** Metrics-generators
+
+**Path:** `/partition/ring`
+
+{{< admonition type="note" >}}
+This endpoint is only available in microservices mode when `metrics_generator.ring_mode` is set to `generator`.
+{{< /admonition >}}
+
+The metrics-generator partition ring shows partition ownership across generator instances.
 
 ## Configuring the rings
 

--- a/docs/sources/tempo/operations/manage-advanced-systems/consistent_hash_ring.md
+++ b/docs/sources/tempo/operations/manage-advanced-systems/consistent_hash_ring.md
@@ -60,7 +60,7 @@ To access a ring page, send a GET request to the Tempo HTTP API. By default, Tem
 http://<tempo-host>:3200/live-store/ring
 ```
 
-In single-binary mode, all ring endpoints are available on the same host. In microservices mode, each endpoint is available on the component listed in the **Available on** field.
+In single-binary mode, any enabled ring endpoints are available on the same host. In microservices mode, each endpoint is available on the component listed in the **Available on** field.
 
 ### Distributor
 

--- a/docs/sources/tempo/operations/manage-advanced-systems/consistent_hash_ring.md
+++ b/docs/sources/tempo/operations/manage-advanced-systems/consistent_hash_ring.md
@@ -95,7 +95,7 @@ The partition ring shows partition ownership across live-stores. Unhealthy live-
 **Path:** `/backend-worker/ring`
 
 {{< admonition type="note" >}}
-This endpoint is only available when the backend-worker is configured with an external KV store for its ring.
+This endpoint is only available when `backend_worker.ring.kvstore.store` is set to a non-empty value other than `inmemory` (for example, `memberlist`, `consul`, or `etcd`).
 {{< /admonition >}}
 
 The backend-worker ring page shows how tenant index writing is distributed across workers. Forget unhealthy workers so that sharding redistributes correctly.


### PR DESCRIPTION
**What this PR does**:

Updates the consistent hash ring documentation for the 3.0 architecture. 

Clarifies how to access ring endpoints (default port, single-binary vs microservices) and adds a note that /distributor/ring requires the global override strategy. Documents two previously missing ring endpoints: /backend-worker/ring and /partition/ring. Adds /partition-ring to the API docs reference. All claims verified against the codebase. Addresses [#3918](https://github.com/grafana/tempo/issues/3918).

Created using assistance from Cursor/Opus 4.6.

**Which issue(s) this PR fixes**:
Fixes #3918 

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`