### PR TITLE
[DOC] Updates to Parquet docs for 3.0 architecture

### DIFF
--- a/docs/sources/tempo/configuration/parquet.md
+++ b/docs/sources/tempo/configuration/parquet.md
@@ -11,41 +11,53 @@ Tempo has a default columnar block format based on Apache Parquet.
 This format is required for tags-based search as well as [TraceQL](../../traceql/), the query language for traces.
 The columnar block format improves search performance and enables an ecosystem of tools, including [Tempo CLI](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/tempo_cli/#analyse-blocks), to access the underlying trace data.
 
-For more information, refer to [Issue 4694](https://github.com/grafana/tempo/issues/4694).
-
 ## Considerations
 
-The Parquet block format is enabled by default since Tempo 2.0.
+The Parquet block format has been the default since Tempo 2.0 and is the only supported block format in Tempo 3.0.
 
 If you install using the [Tempo Helm charts](https://grafana.com/docs/tempo/<TEMPO_VERSION>/setup/helm-chart/), then Parquet is enabled by default.
 No data conversion or upgrade process is necessary.
-As soon as a block format is enabled, Tempo starts writing data in that format, leaving existing data as-is.
+As soon as a block format version is enabled, Tempo starts writing data in that format, leaving existing data as-is.
 
-Block formats based on Parquet require more CPU and memory resources than the previous `v2` format (which has been removed in Tempo 3.0) but provide search and TraceQL functionality.
-
-## Choose a different block format
+## Block format versions
 
 {{< admonition type="warning" >}}
-`vParquet3` has been deprecated and will be removed in a future Tempo release. The `v2` block format has been removed in Tempo 3.0. In order to cleanly migrate forward to Tempo 3.0 you will need `vParquet4` or higher blocks.
+The `v2` block format has been removed in Tempo 3.0 and `vParquet3` is deprecated.
+Use `vParquet4` (default) or `vParquet5`. If you have existing `vParquet3` blocks, they remain readable but you should migrate to `vParquet4` or later.
 {{< /admonition >}}
 
-The default block format is `vParquet4`, which is the latest iteration of the Parquet-based columnar block format in Tempo.
-vParquet4 introduces columns that enable querying for data in array attributes as well as events and links.
+### vParquet4 (default)
+
+`vParquet4` is the default block format in Tempo 3.0.
+It introduces columns that support querying array attributes, events, and links.
 For more information, refer to [Dedicated attribute columns](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/dedicated_columns/).
 
-You can still use the previous format `vParquet3`.
-To enable it, set the block version option to `vParquet3` in the [Storage section](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#storage) of the configuration file.
+### vParquet5
+
+`vParquet5` is production-ready and available as an opt-in alternative to `vParquet4`.
+It builds on vParquet4 with the following improvements:
+
+- **Expanded dedicated columns**: Up to 20 dedicated string columns and 5 dedicated integer columns per scope (span, resource, and event), compared with 10 string columns per scope in vParquet4.
+- **Event-scoped dedicated columns**: Dedicated attribute columns can target event-scoped attributes such as `exception.message`.
+- **Blob column support**: High-cardinality or high-length string attributes (for example, stack traces or UUIDs) can use `zstd` compression instead of dictionary encoding for better efficiency.
+- **Array-valued dedicated columns**: Dedicated columns can store multiple values per attribute using the `options: ["array"]` configuration.
+
+For details on configuring dedicated attribute columns with vParquet5 features, refer to [Dedicated attribute columns](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/dedicated_columns/).
+
+## Change the block format version
+
+To change the block format version, set the `version` option in the [Storage section](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#storage) of the configuration file:
 
 ```yaml
-# block format version. options: vParquet4
-[version: vParquet3]
+storage:
+  trace:
+    block:
+      version: <version>
 ```
 
-{{< admonition type="warning" >}}
-The `v2` block format has been removed in Tempo 3.0. Only Parquet-based formats (vParquet3, vParquet4, vParquet5) are supported.
-{{< /admonition >}}
+Replace `<version>` with `vParquet4` or `vParquet5`.
 
-To re-enable the default `vParquet4` format, remove the block version option from the [Storage section](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#storage) of the configuration file or set the option to `vParquet4`.
+To restore the default `vParquet4` format, remove the `version` option from the configuration file or set it to `vParquet4`.
 
 ## Parquet configuration parameters
 

--- a/docs/sources/tempo/configuration/parquet.md
+++ b/docs/sources/tempo/configuration/parquet.md
@@ -22,8 +22,8 @@ As soon as a block format version is enabled, Tempo starts writing data in that 
 ## Block format versions
 
 {{< admonition type="warning" >}}
-The `v2` block format has been removed in Tempo 3.0 and `vParquet3` is deprecated.
-Use `vParquet4` (default) or `vParquet5`. If you have existing `vParquet3` blocks, they remain readable but you should migrate to `vParquet4` or later.
+The `v2` and `vParquet3` block formats have been removed in Tempo 3.0.
+Use `vParquet4` (default) or `vParquet5`.
 {{< /admonition >}}
 
 ### vParquet4 (default)
@@ -37,10 +37,10 @@ For more information, refer to [Dedicated attribute columns](https://grafana.com
 `vParquet5` is production-ready and available as an opt-in alternative to `vParquet4`.
 It builds on vParquet4 with the following improvements:
 
-- **Expanded dedicated columns**: Up to 20 dedicated string columns and 5 dedicated integer columns per scope (span, resource, and event), compared with 10 string columns per scope in vParquet4.
-- **Event-scoped dedicated columns**: Dedicated attribute columns can target event-scoped attributes such as `exception.message`.
-- **Blob column support**: High-cardinality or high-length string attributes (for example, stack traces or UUIDs) can use `zstd` compression instead of dictionary encoding for better efficiency.
-- **Array-valued dedicated columns**: Dedicated columns can store multiple values per attribute using the `options: ["array"]` configuration.
+- Expanded dedicated columns: Up to 20 dedicated string columns and 5 dedicated integer columns per scope (span, resource, and event), compared with 10 string columns per scope in vParquet4.
+- Event-scoped dedicated columns: Dedicated attribute columns can target event-scoped attributes such as `exception.message`.
+- Blob column support: High-cardinality or high-length string attributes (for example, stack traces or UUIDs) can use `zstd` compression instead of dictionary encoding for better efficiency.
+- Array-valued dedicated columns: Dedicated columns can store multiple values per attribute using the `options: ["array"]` configuration.
 
 For details on configuring dedicated attribute columns with vParquet5 features, refer to [Dedicated attribute columns](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/dedicated_columns/).
 

--- a/docs/sources/tempo/operations/dedicated_columns.md
+++ b/docs/sources/tempo/operations/dedicated_columns.md
@@ -9,8 +9,7 @@ weight: 400
 Dedicated attribute columns improve query performance by storing the most frequently used attributes in their own columns,
 rather than in the generic attribute key-value list.
 
-Introduced with `vParquet3`, dedicated attribute columns are available when using `vParquet3` or later storage formats.
-Even though `vParquet3` is deprecated, this feature is available when using the current value of `vParquet4`.
+Dedicated attribute columns are available when using `vParquet4` or later block formats.
 
 With `vParquet5`, dedicated attribute columns gain support for array-valued attributes, event-scoped attributes, and blob attributes using the `options` field.
 

--- a/docs/sources/tempo/operations/dedicated_columns.md
+++ b/docs/sources/tempo/operations/dedicated_columns.md
@@ -64,7 +64,7 @@ Similarly, default overrides take precedence over storage block configuration.
 
 ## Usage
 
-Dedicated attribute columns are limited to 20 string attributes and 10 integer attributes per scope (span, resource, and event).
+Dedicated attribute columns are limited to 20 string attributes and 5 integer attributes per scope (span, resource, and event).
 As a rule of thumb, good candidates for dedicated attribute columns are attributes that contribute the most to the block size,
 even if they aren't frequently queried.
 Reducing the generic attribute key-value list size significantly improves query performance.

--- a/docs/sources/tempo/reference-tempo-architecture/block-format.md
+++ b/docs/sources/tempo/reference-tempo-architecture/block-format.md
@@ -23,13 +23,13 @@ Columnar data also compresses well because values in a column tend to be similar
 
 A block is a directory in object storage containing several files.
 
-| File | Purpose |
-|---|---|
-| `meta.json` | Block metadata: time range, tenant, block ID, `replaces` field for atomic replacement |
-| `data.parquet` | Trace data in columnar format |
-| Bloom filters | Probabilistic data structures for efficient trace ID lookups |
-| Index | Maps trace IDs to row groups within `data.parquet` |
-| `nocompact.flg` | Temporary flag preventing compaction (present during block-builder flushes) |
+| File            | Purpose                                                                               |
+| --------------- | ------------------------------------------------------------------------------------- |
+| `meta.json`     | Block metadata: time range, tenant, block ID, `replaces` field for atomic replacement |
+| `data.parquet`  | Trace data in columnar format                                                         |
+| Bloom filters   | Probabilistic data structures for efficient trace ID lookups                          |
+| Index           | Maps trace IDs to row groups within `data.parquet`                                    |
+| `nocompact.flg` | Temporary flag preventing compaction (present during block-builder flushes)           |
 
 Blocks are stored under `<tenant-id>/<block-id>/` in object storage.
 
@@ -81,11 +81,11 @@ Refer to [Dedicated attribute columns](https://grafana.com/docs/tempo/<TEMPO_VER
 
 Tempo uses versioned block formats.
 
-| Version | Status |
-|---|---|
-| vParquet3 | Deprecated |
-| vParquet4 | Default and latest in Tempo 3.0 |
-| vParquet5 | Experimental |
+| Version   | Status                             |
+| --------- | ---------------------------------- |
+| vParquet3 | Deprecated in 2.10, removed in 3.0 |
+| vParquet4 | Default and latest in Tempo 3.0    |
+| vParquet5 | Production-ready, opt-in           |
 
 The block format is configured in:
 


### PR DESCRIPTION
**What this PR does**:

Updated the Parquet.md configuration doc and the dedicated-columns.md doc for Tempo 3.0 architecture changes and to address issue 3922. 

- Updated `parquet.md` for Tempo 3.0: removed stale v2 references, consolidated duplicate warnings, added vParquet5 features (expanded dedicated columns, event-scoped columns, blob and array support), and separated version-change instructions into their own section.
- Fixed `dedicated_columns.md`: corrected the maximum dedicated integer attributes per scope from 10 to 5, validated against the codebase.

Updates completed with assistance from Cursor/Opus 4.6. 

**Which issue(s) this PR fixes**:
Fixes #3922 

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`