### PR TITLE
fix: metrics duration check by moving it before request aligment

### DIFF
--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -246,8 +246,8 @@ func New(cfg Config, next pipeline.RoundTripper, o overrides.Interface, reader t
 	searchTagsV2 := newTagsV2HTTPHandler(cfg, searchTagsPipeline, o, logger, dataAccessController)
 	searchTagValues := newTagValuesHTTPHandler(cfg, searchTagValuesPipeline, o, logger, dataAccessController)
 	searchTagValuesV2 := newTagValuesV2HTTPHandler(cfg, searchTagValuesV2Pipeline, o, logger, dataAccessController)
-	queryInstant := newMetricsQueryInstantHTTPHandler(cfg, queryInstantPipeline, logger, dataAccessController) // Reuses the same pipeline
-	queryRange := newMetricsQueryRangeHTTPHandler(cfg, queryRangePipeline, logger, dataAccessController)
+	queryInstant := newMetricsQueryInstantHTTPHandler(cfg, queryInstantPipeline, o, logger, dataAccessController) // Reuses the same pipeline
+	queryRange := newMetricsQueryRangeHTTPHandler(cfg, queryRangePipeline, o, logger, dataAccessController)
 
 	f := &QueryFrontend{
 		// http/discrete
@@ -267,8 +267,8 @@ func New(cfg Config, next pipeline.RoundTripper, o overrides.Interface, reader t
 		streamingTagsV2:       newTagsV2StreamingGRPCHandler(cfg, searchTagsPipeline, apiPrefix, o, logger, dataAccessController),
 		streamingTagValues:    newTagValuesStreamingGRPCHandler(cfg, searchTagValuesPipeline, apiPrefix, o, logger, dataAccessController),
 		streamingTagValuesV2:  newTagValuesV2StreamingGRPCHandler(cfg, searchTagValuesV2Pipeline, apiPrefix, o, logger, dataAccessController),
-		streamingQueryRange:   newQueryRangeStreamingGRPCHandler(cfg, queryRangePipeline, apiPrefix, logger, dataAccessController),
-		streamingQueryInstant: newQueryInstantStreamingGRPCHandler(cfg, queryRangePipeline, apiPrefix, logger, dataAccessController), // Reuses the same pipeline
+		streamingQueryRange:   newQueryRangeStreamingGRPCHandler(cfg, queryRangePipeline, apiPrefix, o, logger, dataAccessController),
+		streamingQueryInstant: newQueryInstantStreamingGRPCHandler(cfg, queryRangePipeline, apiPrefix, o, logger, dataAccessController), // Reuses the same pipeline
 
 		cacheProvider: cacheProvider,
 		logger:        logger,

--- a/modules/frontend/metrics_query_handler.go
+++ b/modules/frontend/metrics_query_handler.go
@@ -17,12 +17,13 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/grafana/tempo/modules/frontend/combiner"
 	"github.com/grafana/tempo/modules/frontend/pipeline"
+	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/util/tracing"
 )
 
-func newQueryInstantStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], apiPrefix string, logger log.Logger, dataAccessController DataAccessController) streamingQueryInstantHandler {
+func newQueryInstantStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], apiPrefix string, o overrides.Interface, logger log.Logger, dataAccessController DataAccessController) streamingQueryInstantHandler {
 	postSLOHook := metricsSLOPostHook(cfg.Metrics.SLO)
 	downstreamPath := path.Join(apiPrefix, api.PathMetricsQueryRange)
 
@@ -53,6 +54,9 @@ func newQueryInstantStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTri
 			Step:  req.End - req.Start,
 		}
 		qr.SetInstant(true)
+		if err := validateQueryRangeReq(ctx, cfg, o, qr); err != nil {
+			return err
+		}
 
 		httpReq := api.BuildQueryRangeRequest(&http.Request{
 			URL:    &url.URL{Path: downstreamPath},
@@ -90,7 +94,7 @@ func newQueryInstantStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTri
 
 // newMetricsQueryInstantHTTPHandler handles instant queries.  Internally these are rewritten as query_range with single step
 // to make use of the existing pipeline.
-func newMetricsQueryInstantHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], logger log.Logger, dataAccessController DataAccessController) http.RoundTripper {
+func newMetricsQueryInstantHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], o overrides.Interface, logger log.Logger, dataAccessController DataAccessController) http.RoundTripper {
 	postSLOHook := metricsSLOPostHook(cfg.Metrics.SLO)
 
 	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
@@ -126,6 +130,9 @@ func newMetricsQueryInstantHTTPHandler(cfg Config, next pipeline.AsyncRoundTripp
 			Step:  i.End - i.Start,
 		}
 		qr.SetInstant(true)
+		if err := validateQueryRangeReq(req.Context(), cfg, o, qr); err != nil {
+			return httpInvalidRequest(err), nil
+		}
 
 		// Clone existing to keep it unaltered.
 		req = req.Clone(req.Context())

--- a/modules/frontend/metrics_query_range_handler.go
+++ b/modules/frontend/metrics_query_range_handler.go
@@ -3,8 +3,6 @@ package frontend
 import (
 	"bytes"
 	"context"
-	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -17,6 +15,7 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/grafana/tempo/modules/frontend/combiner"
 	"github.com/grafana/tempo/modules/frontend/pipeline"
+	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/pkg/util/tracing"
 
 	"github.com/grafana/tempo/pkg/api"
@@ -25,7 +24,7 @@ import (
 )
 
 // newQueryRangeStreamingGRPCHandler returns a handler that streams results from the HTTP handler
-func newQueryRangeStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], apiPrefix string, logger log.Logger, dataAccessController DataAccessController) streamingQueryRangeHandler {
+func newQueryRangeStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], apiPrefix string, o overrides.Interface, logger log.Logger, dataAccessController DataAccessController) streamingQueryRangeHandler {
 	postSLOHook := metricsSLOPostHook(cfg.Metrics.SLO)
 	downstreamPath := path.Join(apiPrefix, api.PathMetricsQueryRange)
 
@@ -49,7 +48,7 @@ func newQueryRangeStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripp
 		if !req.HasInstant() { // if not found, set it explicitly
 			req.SetInstant(false)
 		}
-		if err := validateQueryRangeReq(cfg, req); err != nil {
+		if err := validateQueryRangeReq(ctx, cfg, o, req); err != nil {
 			return err
 		}
 
@@ -107,7 +106,7 @@ func newQueryRangeStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripp
 }
 
 // newMetricsQueryRangeHTTPHandler returns a handler that returns a single response from the HTTP handler
-func newMetricsQueryRangeHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], logger log.Logger, dataAccessController DataAccessController) http.RoundTripper {
+func newMetricsQueryRangeHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], o overrides.Interface, logger log.Logger, dataAccessController DataAccessController) http.RoundTripper {
 	postSLOHook := metricsSLOPostHook(cfg.Metrics.SLO)
 
 	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
@@ -135,7 +134,7 @@ func newMetricsQueryRangeHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper
 		}
 		logQueryRangeRequest(logger, tenant, queryRangeReq)
 
-		if err := validateQueryRangeReq(cfg, queryRangeReq); err != nil {
+		if err := validateQueryRangeReq(req.Context(), cfg, o, queryRangeReq); err != nil {
 			return httpInvalidRequest(err), nil
 		}
 
@@ -269,19 +268,4 @@ func httpInvalidRequest(err error) *http.Response {
 		Status:     http.StatusText(http.StatusBadRequest),
 		Body:       io.NopCloser(strings.NewReader(err.Error())),
 	}
-}
-
-func validateQueryRangeReq(cfg Config, req *tempopb.QueryRangeRequest) error {
-	if req.Start > req.End {
-		return errors.New("end must be greater than start")
-	}
-	if cfg.Metrics.MaxIntervals != 0 && (req.Step == 0 || (req.End-req.Start)/req.Step > cfg.Metrics.MaxIntervals) {
-		minimumStep := (req.End - req.Start) / cfg.Metrics.MaxIntervals
-		return fmt.Errorf(
-			"step of %s is too small, minimum step for given range is %s",
-			time.Duration(req.Step).String(),
-			time.Duration(minimumStep).String(),
-		)
-	}
-	return nil
 }

--- a/modules/frontend/metrics_query_range_handler_test.go
+++ b/modules/frontend/metrics_query_range_handler_test.go
@@ -508,6 +508,66 @@ func TestQueryRangeHandlerWithEndCutoff(t *testing.T) {
 	})
 }
 
+func TestQueryRangeHandlerAllowsExactMaxDurationForMultiTenantQuery(t *testing.T) {
+	rt := &mockRoundTripperWithCapture{
+		rt: mockRoundTripper{
+			responseFn: func() proto.Message {
+				return &tempopb.QueryRangeResponse{
+					Metrics: &tempopb.SearchMetrics{InspectedTraces: 1, InspectedBytes: 1},
+				}
+			},
+		},
+	}
+
+	f := frontendWithSettings(t, rt, nil, nil, nil, func(c *Config, _ *overrides.Config) {
+		c.Metrics.Sharder.Interval = time.Hour
+		c.Metrics.Sharder.MaxDuration = 48 * time.Hour
+		c.Metrics.Sharder.QueryBackendAfter = 1000 * time.Hour
+	})
+
+	end := time.Now().Truncate(time.Second).Add(123 * time.Millisecond)
+	start := end.Add(-48 * time.Hour)
+
+	httpReq := httptest.NewRequest("GET", api.PathMetricsQueryRange, nil)
+	httpReq = api.BuildQueryRangeRequest(httpReq, &tempopb.QueryRangeRequest{
+		Query: "{} | rate()",
+		Start: uint64(start.UnixNano()),
+		End:   uint64(end.UnixNano()),
+		Step:  uint64(time.Hour.Nanoseconds()),
+	}, "")
+	httpReq = httpReq.WithContext(user.InjectOrgID(httpReq.Context(), "foo|bar"))
+
+	httpResp := httptest.NewRecorder()
+	f.MetricsQueryRangeHandler.ServeHTTP(httpResp, httpReq)
+
+	require.Equal(t, http.StatusOK, httpResp.Code)
+	require.NotNil(t, rt.req)
+	assert.Greater(t, time.Duration(rt.req.End-rt.req.Start), 48*time.Hour)
+}
+
+func TestQueryInstantHandlerRejectsOverMaxDurationForMultiTenantQuery(t *testing.T) {
+	f := frontendWithSettings(t, &mockRoundTripper{}, nil, nil, nil, func(c *Config, _ *overrides.Config) {
+		c.Metrics.Sharder.MaxDuration = 48 * time.Hour
+	})
+
+	end := time.Now().Truncate(time.Second)
+	start := end.Add(-49 * time.Hour)
+
+	httpReq := httptest.NewRequest("GET", api.PathMetricsQueryInstant, nil)
+	httpReq = api.BuildQueryInstantRequest(httpReq, &tempopb.QueryInstantRequest{
+		Query: "{} | rate()",
+		Start: uint64(start.UnixNano()),
+		End:   uint64(end.UnixNano()),
+	})
+	httpReq = httpReq.WithContext(user.InjectOrgID(httpReq.Context(), "foo|bar"))
+
+	httpResp := httptest.NewRecorder()
+	f.MetricsQueryInstantHandler.ServeHTTP(httpResp, httpReq)
+
+	require.Equal(t, http.StatusBadRequest, httpResp.Code)
+	assert.Contains(t, httpResp.Body.String(), "metrics query time range exceeds the maximum allowed duration of 48h0m0s")
+}
+
 // TestQueryRangeHandlerExemplarNormalization verifies that exemplars from shard responses are
 // kept in the final response when the client omits req.Exemplars (sends 0). Before the fix,
 // the frontend combiner was created with req.Exemplars=0 which caused it to immediately discard

--- a/modules/frontend/metrics_query_range_sharder.go
+++ b/modules/frontend/metrics_query_range_sharder.go
@@ -3,7 +3,6 @@ package frontend
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math"
 	"net/http"
 	"time"
@@ -103,15 +102,6 @@ func (s queryRangeSharder) RoundTrip(pipelineRequest pipeline.Request) (pipeline
 
 	if req.Step == 0 {
 		return pipeline.NewBadRequest(errors.New("step must be greater than 0")), nil
-	}
-
-	// calculate and enforce max search duration
-	// This is checked before alignment because we may need to read a larger
-	// range internally to satisfy the query.
-	maxDuration := s.maxDuration(tenantID)
-	if maxDuration != 0 && time.Duration(req.End-req.Start)*time.Nanosecond > maxDuration {
-		err = fmt.Errorf("metrics query time range exceeds the maximum allowed duration of %s", maxDuration)
-		return pipeline.NewBadRequest(err), nil
 	}
 
 	traceql.AlignRequest(req)
@@ -356,17 +346,6 @@ func (s *queryRangeSharder) generatorRequest(tenantID string, parent pipeline.Re
 	subR.SetResponseData(0) // generator requests are always shard 0
 
 	return subR, jobMetadata
-}
-
-// maxDuration returns the max search duration allowed for this tenant.
-func (s *queryRangeSharder) maxDuration(tenantID string) time.Duration {
-	// check overrides first, if no overrides then grab from our config
-	maxDuration := s.overrides.MaxMetricsDuration(tenantID)
-	if maxDuration != 0 {
-		return maxDuration
-	}
-
-	return s.cfg.MaxDuration
 }
 
 func (s *queryRangeSharder) jobSize(expr *traceql.RootExpr, allowUnsafe bool) int {

--- a/modules/frontend/metrics_query_validation.go
+++ b/modules/frontend/metrics_query_validation.go
@@ -1,0 +1,62 @@
+package frontend
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/grafana/dskit/tenant"
+	"github.com/grafana/tempo/modules/overrides"
+	"github.com/grafana/tempo/pkg/tempopb"
+)
+
+func validateQueryRangeReq(ctx context.Context, cfg Config, o overrides.Interface, req *tempopb.QueryRangeRequest) error {
+	if req.Start > req.End {
+		return errors.New("end must be greater than start")
+	}
+	if err := validateMetricsQueryMaxDuration(ctx, o, cfg.Metrics.Sharder.MaxDuration, req); err != nil {
+		return err
+	}
+	if cfg.Metrics.MaxIntervals != 0 && (req.Step == 0 || (req.End-req.Start)/req.Step > cfg.Metrics.MaxIntervals) {
+		minimumStep := (req.End - req.Start) / cfg.Metrics.MaxIntervals
+		return fmt.Errorf(
+			"step of %s is too small, minimum step for given range is %s",
+			time.Duration(req.Step).String(),
+			time.Duration(minimumStep).String(),
+		)
+	}
+	return nil
+}
+
+func validateMetricsQueryMaxDuration(ctx context.Context, o overrides.Interface, defaultMaxDuration time.Duration, req *tempopb.QueryRangeRequest) error {
+	tenants, err := tenant.TenantIDs(ctx)
+	if err != nil {
+		return err
+	}
+
+	rawDuration := time.Duration(req.End - req.Start)
+	var maxDuration time.Duration
+
+	for _, tenantID := range tenants {
+		tenantMaxDuration := defaultMaxDuration
+		if o != nil {
+			if overrideMaxDuration := o.MaxMetricsDuration(tenantID); overrideMaxDuration != 0 {
+				tenantMaxDuration = overrideMaxDuration
+			}
+		}
+
+		if tenantMaxDuration == 0 {
+			continue
+		}
+		if maxDuration == 0 || tenantMaxDuration < maxDuration {
+			maxDuration = tenantMaxDuration
+		}
+	}
+
+	if maxDuration != 0 && rawDuration > maxDuration {
+		return fmt.Errorf("metrics query time range exceeds the maximum allowed duration of %s", maxDuration)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

The validation of the max metrics duration is currently broken because is done before the request aligment:

1. User select a max valid range in Grafana ie 48h
2. The request is aligned. If the step is 15m then the duration can becomes either 48h:15m or 48h:30m
3. An error is returned

Since this config is user facing its missleading to return an error here. To address it I have moved the validation to the handler before any aligment is done. It also care about multitenant queries as it was done in the sharder (always happens before the multitenant fan out middleware)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`