### PR TITLE
s3: Read AWS_EC2_METADATA_SERVICE_ENDPOINT for IAM credential resolution

### DIFF
--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -688,6 +688,17 @@ func (rw *readerWriter) readRange(ctx context.Context, objName string, offset in
 	return err
 }
 
+// iamEndpoint returns the IAM metadata endpoint for credential resolution.
+// Checks TEST_IAM_ENDPOINT (backward compat), then the standard
+// AWS_EC2_METADATA_SERVICE_ENDPOINT. If neither is set, returns empty
+// so that minio-go falls back to its default (169.254.169.254).
+func iamEndpoint() string {
+	if v := os.Getenv("TEST_IAM_ENDPOINT"); v != "" {
+		return v
+	}
+	return os.Getenv("AWS_EC2_METADATA_SERVICE_ENDPOINT")
+}
+
 func fetchCreds(cfg *Config) (*credentials.Credentials, error) {
 	wrapCredentialsProvider := func(p credentials.Provider) credentials.Provider {
 		if cfg.SignatureV2 {
@@ -712,7 +723,7 @@ func fetchCreds(cfg *Config) (*credentials.Credentials, error) {
 			Client: &http.Client{
 				Transport: http.DefaultTransport,
 			},
-			Endpoint: os.Getenv("TEST_IAM_ENDPOINT"),
+			Endpoint: iamEndpoint(),
 		}),
 	}
 


### PR DESCRIPTION
## Summary

The S3 backend's IAM credential provider hardcodes `TEST_IAM_ENDPOINT` as the only way to override minio-go's default IMDS endpoint (`169.254.169.254`). This makes it impossible to use custom IMDS-compatible credential providers — such as [AWS IAM Roles Anywhere credential helper](https://github.com/aws/rolesanywhere-credential-helper) in `serve` mode — without setting a test-only environment variable.

This adds `AWS_EC2_METADATA_SERVICE_ENDPOINT` as a standard fallback, matching the env var used by the AWS SDK for Go. Priority:

1. `TEST_IAM_ENDPOINT` (backward compat, no behavior change for existing users)
2. `AWS_EC2_METADATA_SERVICE_ENDPOINT` (standard AWS SDK env var)
3. minio-go default (`169.254.169.254`)

## Motivation

When running Tempo outside of EC2/ECS (e.g., on a Raspberry Pi with IAM Roles Anywhere), the credential helper provides an IMDS-compatible endpoint on a custom address (`127.0.0.1:9911`). The AWS SDK reads `AWS_EC2_METADATA_SERVICE_ENDPOINT` to find this endpoint, but Tempo's minio-go credential chain ignores it — causing a 90-second timeout against `169.254.169.254` followed by `Access Denied` on every S3 operation.

## Test plan

- Verified on Raspberry Pi 4 with IAM Roles Anywhere credential helper
- `TEST_IAM_ENDPOINT` behavior is unchanged (checked first)
- When neither env var is set, minio-go default behavior is preserved