### PR TITLE
chore(renovate): use glob patterns instead of regex in matchPackageNames

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -72,7 +72,7 @@
       ],
       groupName: 'opentelemetry-otel',
       matchPackageNames: [
-        '/^go\\.opentelemetry\\.io/otel/',
+        'go.opentelemetry.io/otel/**',
       ],
     },
     {
@@ -82,8 +82,8 @@
       ],
       groupName: 'opentelemetry-contrib',
       matchPackageNames: [
-        '/^go\\.opentelemetry\\.io/contrib/',
-        '/^github\\.com/open-telemetry/opentelemetry-collector-contrib/',
+        'go.opentelemetry.io/contrib/**',
+        'github.com/open-telemetry/opentelemetry-collector-contrib/**',
       ],
     },
     {
@@ -93,7 +93,7 @@
       ],
       groupName: 'opentelemetry-collector',
       matchPackageNames: [
-        '/^go\\.opentelemetry\\.io/collector/',
+        'go.opentelemetry.io/collector/**',
       ],
     },
     {
@@ -103,7 +103,7 @@
       ],
       groupName: 'k8s.io',
       matchPackageNames: [
-        '/^k8s\\.io//',
+        'k8s.io/**',
       ],
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -72,7 +72,7 @@
       ],
       groupName: 'opentelemetry-otel',
       matchPackageNames: [
-        'go.opentelemetry.io/otel/**',
+        'go.opentelemetry.io/otel{,/**}',
       ],
     },
     {
@@ -82,8 +82,8 @@
       ],
       groupName: 'opentelemetry-contrib',
       matchPackageNames: [
-        'go.opentelemetry.io/contrib/**',
-        'github.com/open-telemetry/opentelemetry-collector-contrib/**',
+        'go.opentelemetry.io/contrib{,/**}',
+        'github.com/open-telemetry/opentelemetry-collector-contrib{,/**}',
       ],
     },
     {
@@ -93,7 +93,7 @@
       ],
       groupName: 'opentelemetry-collector',
       matchPackageNames: [
-        'go.opentelemetry.io/collector/**',
+        'go.opentelemetry.io/collector{,/**}',
       ],
     },
     {
@@ -103,7 +103,7 @@
       ],
       groupName: 'k8s.io',
       matchPackageNames: [
-        'k8s.io/**',
+        'k8s.io{,/**}',
       ],
     },
     {


### PR DESCRIPTION
## Summary
- Replace regex patterns in `matchPackageNames` with glob patterns for better readability
- e.g. `/^go\.opentelemetry\.io/otel/` → `go.opentelemetry.io/otel/**`
- Functionally equivalent, avoids ambiguity with unescaped `/` in regex

## Test plan
- [ ] Renovate validation workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)