### PR TITLE
Fix slice backing-array race in live-store

### DIFF
--- a/modules/livestore/instance.go
+++ b/modules/livestore/instance.go
@@ -398,7 +398,7 @@ func (i *instance) writeHeadBlock(id []byte, liveTrace *livetraces.LiveTrace[*v1
 	}
 
 	tr := &tempopb.Trace{
-		ResourceSpans: liveTrace.Batches,
+		ResourceSpans: liveTrace.Batches[:len(liveTrace.Batches):len(liveTrace.Batches)],
 	}
 
 	// Get trace timestamp bounds

--- a/modules/livestore/instance_search.go
+++ b/modules/livestore/instance_search.go
@@ -606,7 +606,7 @@ func (i *instance) FindByTraceID(ctx context.Context, traceID []byte, allowParti
 	i.liveTracesMtx.Lock()
 	if liveTrace, ok := i.liveTraces.Traces[util.HashForTraceID(traceID)]; ok {
 		tempTrace := &tempopb.Trace{}
-		tempTrace.ResourceSpans = liveTrace.Batches
+		tempTrace.ResourceSpans = liveTrace.Batches[:len(liveTrace.Batches):len(liveTrace.Batches)]
 		// Previously there was some logic here to add inspected bytes in the ingester. But its hard to do with the different
 		// live traces format and feels inaccurate.
 		_, err := combiner.Consume(tempTrace)


### PR DESCRIPTION
**What this PR does**: Fixes a race condition in FindTraceByID where concurrent modifications to `liveTrace.Batches` could cause panics. Using the slice copy pattern creates a fixed-capacity header, so appends to the original don't affect this copy.

**Which issue(s) this PR fixes**: Fixes #6958

**Checklist**:
- [ ] Tests updated
- [ ] Documentation added
- [ ] CHANGELOG.md updated - order: [CHANGE], [FEATURE], [ENHANCEMENT], [BUGFIX]