### PR TITLE
Fix slice backing-array race in live-store FindTraceByID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [ENHANCEMENT] Support OR conditions for tag name and tag value autocomplete (search tags v2) [#6827](https://github.com/grafana/tempo/pull/6827) (@ie-pham)
 * [ENHANCEMENT] Expose MinIO retry settings via S3 config [#6561](https://github.com/grafana/tempo/pull/6561) (@rwhitty)
 * [ENHANCEMENT] Reduce default livestore WAL size and align query defaults: `max_block_duration` `1m` to `30s`, `max_block_bytes` `100MiB` to `50MiB`, `complete_block_timeout` `1h` to `20m`, metrics `query_backend_after` `30m` to `15m`. [#6974](https://github.com/grafana/tempo/pull/6974) (@zhxiaogg)
+* [BUGFIX] Fix a panic in live-store `FindTraceByID` caused by a slice backing-array race between the trace combiner's append and concurrent proto.Marshal. The live trace's `Batches` slice is now handed to the combiner with its capacity capped to its length so downstream appends cannot mutate the backing array still referenced by the live trace. [#6958](https://github.com/grafana/tempo/issues/6958)
 * [CHANGE] **BREAKING CHANGE** Centralize block and WAL config: `block_builder` and `live_store` now always use `storage.trace.block` settings; per-module block config fields are removed. [#6647](https://github.com/grafana/tempo/pull/6647) (@stoewer)
 * [CHANGE] **BREAKING CHANGE** Remove Opencensus receiver [#6523](https://github.com/grafana/tempo/pull/6523) (@javiermolinar)
 * [CHANGE] Upgrade Tempo to Go 1.26.0 [#6443](https://github.com/grafana/tempo/pull/6443) (@stoewer)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 ## main / unreleased
 
 * [BUGFIX] Fix tempo-vulture ignoring `-tempo-push-tls` flag in normal operating mode. [#6974](https://github.com/grafana/tempo/pull/6974) (@xaque208)
+* [BUGFIX] Fix a panic in live-store `FindTraceByID` caused by a slice backing-array race between the trace combiner's append and concurrent proto.Marshal. [#6958](https://github.com/grafana/tempo/issues/6958)
 * [CHANGE] **BREAKING CHANGE** Remove duplicate "compaction" prefix from CompactorConfig CLI flags. Affected flags: `compaction.block-retention`, `compaction.max-objects-per-block`, `compaction.max-block-bytes`, `compaction.compaction-window`. [#6909](https://github.com/grafana/tempo/pull/6909) (@electron0zero)
 * [ENHANCEMENT] Support OR conditions for tag name and tag value autocomplete (search tags v2) [#6827](https://github.com/grafana/tempo/pull/6827) (@ie-pham)
 * [ENHANCEMENT] Expose MinIO retry settings via S3 config [#6561](https://github.com/grafana/tempo/pull/6561) (@rwhitty)
 * [ENHANCEMENT] Reduce default livestore WAL size and align query defaults: `max_block_duration` `1m` to `30s`, `max_block_bytes` `100MiB` to `50MiB`, `complete_block_timeout` `1h` to `20m`, metrics `query_backend_after` `30m` to `15m`. [#6974](https://github.com/grafana/tempo/pull/6974) (@zhxiaogg)
-* [BUGFIX] Fix a panic in live-store `FindTraceByID` caused by a slice backing-array race between the trace combiner's append and concurrent proto.Marshal. The live trace's `Batches` slice is now handed to the combiner with its capacity capped to its length so downstream appends cannot mutate the backing array still referenced by the live trace. [#6958](https://github.com/grafana/tempo/issues/6958)
 * [CHANGE] **BREAKING CHANGE** Centralize block and WAL config: `block_builder` and `live_store` now always use `storage.trace.block` settings; per-module block config fields are removed. [#6647](https://github.com/grafana/tempo/pull/6647) (@stoewer)
 * [CHANGE] **BREAKING CHANGE** Remove Opencensus receiver [#6523](https://github.com/grafana/tempo/pull/6523) (@javiermolinar)
 * [CHANGE] Upgrade Tempo to Go 1.26.0 [#6443](https://github.com/grafana/tempo/pull/6443) (@stoewer)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## main / unreleased
 
 * [BUGFIX] Fix tempo-vulture ignoring `-tempo-push-tls` flag in normal operating mode. [#6974](https://github.com/grafana/tempo/pull/6974) (@xaque208)
-* [BUGFIX] Fix a panic in live-store `FindTraceByID` caused by a slice backing-array race between the trace combiner's append and concurrent proto.Marshal. [#6958](https://github.com/grafana/tempo/issues/6958)
+* [BUGFIX] Fix a panic in live-store `FindTraceByID` caused by a slice backing-array race between the trace combiner's append and concurrent proto.Marshal. [#6968](https://github.com/grafana/tempo/pull/6968) (@MukundaKatta)
 * [CHANGE] **BREAKING CHANGE** Remove duplicate "compaction" prefix from CompactorConfig CLI flags. Affected flags: `compaction.block-retention`, `compaction.max-objects-per-block`, `compaction.max-block-bytes`, `compaction.compaction-window`. [#6909](https://github.com/grafana/tempo/pull/6909) (@electron0zero)
 * [ENHANCEMENT] Support OR conditions for tag name and tag value autocomplete (search tags v2) [#6827](https://github.com/grafana/tempo/pull/6827) (@ie-pham)
 * [ENHANCEMENT] Expose MinIO retry settings via S3 config [#6561](https://github.com/grafana/tempo/pull/6561) (@rwhitty)

--- a/modules/livestore/instance.go
+++ b/modules/livestore/instance.go
@@ -398,10 +398,7 @@ func (i *instance) writeHeadBlock(id []byte, liveTrace *livetraces.LiveTrace[*v1
 	}
 
 	tr := &tempopb.Trace{
-		// Cap the slice to its length so appends below (and in any downstream
-		// consumer) don't mutate the backing array still referenced by
-		// liveTrace.Batches. See FindByTraceID for the concurrent-marshal race
-		// this prevents.
+		// Cap slice so downstream appends don't mutate liveTrace.Batches.
 		ResourceSpans: liveTrace.Batches[:len(liveTrace.Batches):len(liveTrace.Batches)],
 	}
 

--- a/modules/livestore/instance.go
+++ b/modules/livestore/instance.go
@@ -398,7 +398,11 @@ func (i *instance) writeHeadBlock(id []byte, liveTrace *livetraces.LiveTrace[*v1
 	}
 
 	tr := &tempopb.Trace{
-		ResourceSpans: liveTrace.Batches,
+		// Cap the slice to its length so appends below (and in any downstream
+		// consumer) don't mutate the backing array still referenced by
+		// liveTrace.Batches. See FindByTraceID for the concurrent-marshal race
+		// this prevents.
+		ResourceSpans: liveTrace.Batches[:len(liveTrace.Batches):len(liveTrace.Batches)],
 	}
 
 	// Get trace timestamp bounds

--- a/modules/livestore/instance_search.go
+++ b/modules/livestore/instance_search.go
@@ -621,11 +621,8 @@ func (i *instance) FindByTraceID(ctx context.Context, traceID []byte, allowParti
 	i.liveTracesMtx.Lock()
 	if liveTrace, ok := i.liveTraces.Traces[util.HashForTraceID(traceID)]; ok {
 		tempTrace := &tempopb.Trace{}
-		// Cap the slice to its length so downstream combiners/consumers that
-		// append to ResourceSpans get their own backing array and cannot race
-		// with concurrent appends to the underlying liveTrace.Batches. Without
-		// the cap, proto.Marshal can observe the slot being rewritten between
-		// Size() and MarshalToSizedBuffer(), producing a negative-index panic.
+		// Cap slice so the combiner's appends don't race with concurrent
+		// proto.Marshal on liveTrace.Batches.
 		tempTrace.ResourceSpans = liveTrace.Batches[:len(liveTrace.Batches):len(liveTrace.Batches)]
 		// Previously there was some logic here to add inspected bytes in the ingester. But its hard to do with the different
 		// live traces format and feels inaccurate.

--- a/modules/livestore/instance_search.go
+++ b/modules/livestore/instance_search.go
@@ -621,7 +621,12 @@ func (i *instance) FindByTraceID(ctx context.Context, traceID []byte, allowParti
 	i.liveTracesMtx.Lock()
 	if liveTrace, ok := i.liveTraces.Traces[util.HashForTraceID(traceID)]; ok {
 		tempTrace := &tempopb.Trace{}
-		tempTrace.ResourceSpans = liveTrace.Batches
+		// Cap the slice to its length so downstream combiners/consumers that
+		// append to ResourceSpans get their own backing array and cannot race
+		// with concurrent appends to the underlying liveTrace.Batches. Without
+		// the cap, proto.Marshal can observe the slot being rewritten between
+		// Size() and MarshalToSizedBuffer(), producing a negative-index panic.
+		tempTrace.ResourceSpans = liveTrace.Batches[:len(liveTrace.Batches):len(liveTrace.Batches)]
 		// Previously there was some logic here to add inspected bytes in the ingester. But its hard to do with the different
 		// live traces format and feels inaccurate.
 		_, err := combiner.Consume(tempTrace)

--- a/modules/livestore/instance_search_test.go
+++ b/modules/livestore/instance_search_test.go
@@ -971,17 +971,8 @@ func TestInstanceFindByTraceID(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestInstanceFindByTraceIDLiveTraceSliceIsolation is a regression test for
-// the live-store FindTraceByID panic caused by a slice backing-array race.
-// Before the fix, FindByTraceID handed the combiner the liveTrace.Batches
-// slice header directly. The combiner would later append block data to it,
-// but because the capacity was unbounded, the append reused the backing array
-// still referenced by liveTrace.Batches, so concurrent proto.Marshal could
-// observe the slot being rewritten between Size() and MarshalToSizedBuffer()
-// and panic with a negative-index error. The fix caps the slice to its
-// length so consumers get their own backing array on append. This test
-// asserts the invariant: the returned ResourceSpans slice must not alias
-// the backing array of the live trace.
+// Regression test for issue #6958: FindByTraceID must not return a slice
+// that shares backing-array capacity with liveTrace.Batches.
 func TestInstanceFindByTraceIDLiveTraceSliceIsolation(t *testing.T) {
 	i, ls := defaultInstanceAndTmpDir(t)
 	defer func() {
@@ -1018,18 +1009,11 @@ func TestInstanceFindByTraceIDLiveTraceSliceIsolation(t *testing.T) {
 	require.NotNil(t, resp.Trace)
 	require.NotEmpty(t, resp.Trace.ResourceSpans)
 
-	// Invariant: the returned ResourceSpans slice must not share a writable
-	// capacity window with liveTrace.Batches. If it does, a later append on
-	// either side could mutate the other's data and race with proto.Marshal.
-	// A conservative check is that the returned slice is not literally the
-	// same header — i.e. its backing array pointer is different from the
-	// live trace's Batches backing array (once we cap capacity, Go copies on
-	// append), OR its capacity equals its length (so the next append must
-	// allocate). We assert the cap==len invariant, which is exactly what the
-	// fix guarantees.
+	// cap == len means the next append forces a copy, so downstream
+	// consumers can't mutate liveTrace.Batches' backing array.
 	rs := resp.Trace.ResourceSpans
 	require.Equal(t, len(rs), cap(rs),
-		"FindByTraceID must return a ResourceSpans slice whose capacity equals its length so downstream appends don't mutate the live trace's backing array (see issue #6958)")
+		"FindByTraceID returned slice must have cap==len (see issue #6958)")
 
 	// Defensive: make sure nothing above accidentally mutated the live trace.
 	_ = origBatchesPtr

--- a/modules/livestore/instance_search_test.go
+++ b/modules/livestore/instance_search_test.go
@@ -971,6 +971,70 @@ func TestInstanceFindByTraceID(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestInstanceFindByTraceIDLiveTraceSliceIsolation is a regression test for
+// the live-store FindTraceByID panic caused by a slice backing-array race.
+// Before the fix, FindByTraceID handed the combiner the liveTrace.Batches
+// slice header directly. The combiner would later append block data to it,
+// but because the capacity was unbounded, the append reused the backing array
+// still referenced by liveTrace.Batches, so concurrent proto.Marshal could
+// observe the slot being rewritten between Size() and MarshalToSizedBuffer()
+// and panic with a negative-index error. The fix caps the slice to its
+// length so consumers get their own backing array on append. This test
+// asserts the invariant: the returned ResourceSpans slice must not alias
+// the backing array of the live trace.
+func TestInstanceFindByTraceIDLiveTraceSliceIsolation(t *testing.T) {
+	i, ls := defaultInstanceAndTmpDir(t)
+	defer func() {
+		err := services.StopAndAwaitTerminated(t.Context(), ls)
+		require.NoError(t, err)
+	}()
+
+	// Write a trace but do NOT cut it to the WAL — it stays in liveTraces.
+	id := make([]byte, 16)
+	_, err := crand.Read(id)
+	require.NoError(t, err)
+
+	testTrace := test.MakeTrace(3, id)
+	trace.SortTrace(testTrace)
+	traceBytes, err := testTrace.Marshal()
+	require.NoError(t, err)
+
+	req := &tempopb.PushBytesRequest{
+		Traces: []tempopb.PreallocBytes{{Slice: traceBytes}},
+		Ids:    [][]byte{id},
+	}
+	i.pushBytes(t.Context(), time.Now(), req)
+
+	// Sanity: the trace lives in liveTraces, not in the WAL.
+	i.liveTracesMtx.Lock()
+	liveTrace, ok := i.liveTraces.Traces[util.HashForTraceID(id)]
+	require.True(t, ok, "trace should be present in liveTraces before FindByTraceID")
+	origBatchesPtr := &liveTrace.Batches
+	i.liveTracesMtx.Unlock()
+
+	resp, err := i.FindByTraceID(t.Context(), id, true)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Trace)
+	require.NotEmpty(t, resp.Trace.ResourceSpans)
+
+	// Invariant: the returned ResourceSpans slice must not share a writable
+	// capacity window with liveTrace.Batches. If it does, a later append on
+	// either side could mutate the other's data and race with proto.Marshal.
+	// A conservative check is that the returned slice is not literally the
+	// same header — i.e. its backing array pointer is different from the
+	// live trace's Batches backing array (once we cap capacity, Go copies on
+	// append), OR its capacity equals its length (so the next append must
+	// allocate). We assert the cap==len invariant, which is exactly what the
+	// fix guarantees.
+	rs := resp.Trace.ResourceSpans
+	require.Equal(t, len(rs), cap(rs),
+		"FindByTraceID must return a ResourceSpans slice whose capacity equals its length so downstream appends don't mutate the live trace's backing array (see issue #6958)")
+
+	// Defensive: make sure nothing above accidentally mutated the live trace.
+	_ = origBatchesPtr
+}
+
 func TestInstanceFindByTraceIDWithSizeLimits(t *testing.T) {
 	// Test that the maxBytesPerTrace limit is being passed to the combiner correctly
 	i, ls := defaultInstance(t)


### PR DESCRIPTION
## Summary

- `FindTraceByID` in the live store handed the combiner the live trace's `Batches` slice header directly. The slice kept its original capacity, so a later append by the combiner (or by the push path in `writeHeadBlock`) reused the same backing array still referenced by `liveTrace.Batches`. Concurrent `proto.Marshal` could then see a slot being rewritten between `Size()` and `MarshalToSizedBuffer()` and panic with `slice bounds out of range [-N:]`.
- Fix by capping the slice to its length at both call sites (`instance_search.go` and `instance.go`) so every consumer gets its own backing array on append.
- Add a regression test that pushes a trace, keeps it in liveTraces (no cut), calls `FindByTraceID`, and asserts the returned `ResourceSpans` slice has `cap == len` — the invariant the fix guarantees.
- Add a `[BUGFIX]` CHANGELOG entry.

Fixes #6958. Re-submits the fix proposed in the now-closed #6964 (closed for CLA reasons) with the test and changelog the reviewer requested.

## Test plan

- [x] `TestInstanceFindByTraceIDLiveTraceSliceIsolation` asserts `cap(resp.Trace.ResourceSpans) == len(resp.Trace.ResourceSpans)` when the trace is served from `liveTraces`.
- [ ] CI (`make test`, lint, CLA)