### PR TITLE
[Bugfix] Live-store: Cut head block if it exceeds MaxBlockBytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 * [BUGFIX] live-store: fix race conditions for tag values endpoint [#7000](https://github.com/grafana/tempo/pull/7000) (@ruslan-mikhailov)
 * [BUGFIX] live-store: correct backoff duration calculation [#6999](https://github.com/grafana/tempo/pull/6999) (@ruslan-mikhailov)
 * [BUGFIX] vulture: fix for recent traces when query_end_cutoff is enabled [#7018](https://github.com/grafana/tempo/pull/7018) (@ruslan-mikhailov)
+* [BUGFIX] Fix live-store producing WAL blocks exceeding max_block_bytes when flushing large batches of idle traces [#6971](https://github.com/grafana/tempo/pull/6971) (@ruslan-mikhailov)
 
 ### 3.0 Cleanup
 

--- a/modules/livestore/complete_block_lifecycle_test.go
+++ b/modules/livestore/complete_block_lifecycle_test.go
@@ -600,8 +600,8 @@ func createWalBlockForLifecycleTest(t *testing.T, liveStore *LiveStore) (*instan
 
 	inst, err := liveStore.getOrCreateInstance(testTenantID)
 	require.NoError(t, err)
-
-	require.NoError(t, inst.cutIdleTraces(t.Context(), true))
+	_, err = inst.cutIdleTraces(t.Context(), true)
+	require.NoError(t, err)
 
 	blockID, err := inst.cutBlocks(t.Context(), true)
 	require.NoError(t, err)

--- a/modules/livestore/complete_block_lifecycle_test.go
+++ b/modules/livestore/complete_block_lifecycle_test.go
@@ -600,8 +600,9 @@ func createWalBlockForLifecycleTest(t *testing.T, liveStore *LiveStore) (*instan
 
 	inst, err := liveStore.getOrCreateInstance(testTenantID)
 	require.NoError(t, err)
-	_, err = inst.cutIdleTraces(t.Context(), true)
+	blockIDs, err := inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
+	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
 
 	blockID, err := inst.cutBlocks(t.Context(), true)
 	require.NoError(t, err)

--- a/modules/livestore/complete_block_lifecycle_test.go
+++ b/modules/livestore/complete_block_lifecycle_test.go
@@ -600,9 +600,9 @@ func createWalBlockForLifecycleTest(t *testing.T, liveStore *LiveStore) (*instan
 
 	inst, err := liveStore.getOrCreateInstance(testTenantID)
 	require.NoError(t, err)
-	blockIDs, err := inst.cutIdleTraces(t.Context(), true)
+	drained, err := inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
-	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
+	require.True(t, drained, "should drain live traces in one iteration")
 
 	blockID, err := inst.cutBlocks(t.Context(), true)
 	require.NoError(t, err)

--- a/modules/livestore/instance.go
+++ b/modules/livestore/instance.go
@@ -331,7 +331,7 @@ func countSpans(trace *tempopb.Trace) int {
 	return count
 }
 
-func (i *instance) cutIdleTraces(ctx context.Context, immediate bool) error {
+func (i *instance) cutIdleTraces(ctx context.Context, immediate bool) ([]uuid.UUID, error) {
 	_, span := tracer.Start(ctx, "instance.cutIdleTraces",
 		oteltrace.WithAttributes(attribute.String("tenant", i.tenantID)))
 	defer span.End()
@@ -350,23 +350,45 @@ func (i *instance) cutIdleTraces(ctx context.Context, immediate bool) error {
 	span.SetAttributes(attribute.Int("traces_to_cut", len(tracesToCut)))
 
 	if len(tracesToCut) == 0 {
-		return nil
+		return nil, nil
 	}
 	// Sort by ID
 	sort.Slice(tracesToCut, func(i, j int) bool {
 		return bytes.Compare(tracesToCut[i].ID, tracesToCut[j].ID) == -1
 	})
-	// Collect the trace IDs that will be flushed
+
+	var cutBlockIDs []uuid.UUID
+
+	// Write traces to head block, cutting when MaxBlockBytes is reached.
 	span.AddEvent("writing traces to head block")
 	for _, t := range tracesToCut {
 		err := i.writeHeadBlock(t.ID, t)
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			return err
+			return cutBlockIDs, err
 		}
 
 		i.tracesCreatedTotal.Inc()
+
+		// if the head block has reached max block bytes,
+		// cut it and enqueue for completion later
+		i.blocksMtx.Lock()
+		reason := i.shouldCutHead(false)
+		i.blocksMtx.Unlock()
+		if reason&cutReasonMaxBlockBytes != 0 {
+			id, err := i.cutBlocks(ctx, false)
+			if err != nil {
+				span.RecordError(err)
+				return cutBlockIDs, err
+			}
+			if id != uuid.Nil {
+				span.AddEvent("cut oversized block", oteltrace.WithAttributes(
+					attribute.String("blockID", id.String()),
+				))
+				cutBlockIDs = append(cutBlockIDs, id)
+			}
+		}
 	}
 	span.AddEvent("wrote traces to head block")
 
@@ -381,12 +403,10 @@ func (i *instance) cutIdleTraces(ctx context.Context, immediate bool) error {
 		if err != nil {
 			span.SetStatus(codes.Error, err.Error())
 			span.RecordError(err)
-			return err
+			return cutBlockIDs, err
 		}
-
-		return nil
 	}
-	return nil
+	return cutBlockIDs, nil
 }
 
 func (i *instance) writeHeadBlock(id []byte, liveTrace *livetraces.LiveTrace[*v1.ResourceSpans]) error {
@@ -532,11 +552,28 @@ func (i *instance) cutBlocks(ctx context.Context, immediate bool) (uuid.UUID, er
 
 	i.traceSizes.ClearIdle(i.lastCutTime)
 
-	// Final flush
-	err := i.headBlock.Flush()
+	id, err := i.cutHeadLocked()
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		span.RecordError(err)
+		return uuid.Nil, err
+	}
+
+	span.SetAttributes(
+		attribute.String("blockID", id.String()),
+		attribute.Int64("block_size", int64(i.walBlocks[id].DataLength())),
+	)
+
+	recordBlockCutMetric(reason)
+
+	return id, nil
+}
+
+// cutHeadLocked flushes the head block, moves it to walBlocks, and resets the
+// head block. Caller must hold blocksMtx.
+func (i *instance) cutHeadLocked() (uuid.UUID, error) {
+	err := i.headBlock.Flush()
+	if err != nil {
 		return uuid.Nil, err
 	}
 
@@ -544,21 +581,12 @@ func (i *instance) cutBlocks(ctx context.Context, immediate bool) (uuid.UUID, er
 	blockSize := i.headBlock.DataLength()
 	i.walBlocks[id] = i.headBlock
 
-	span.SetAttributes(
-		attribute.String("blockID", id.String()),
-		attribute.Int64("block_size", int64(blockSize)),
-	)
-
 	level.Info(i.logger).Log("msg", "queueing wal block for completion", "block", id.String(), "size", blockSize)
 
 	err = i.resetHeadBlock()
 	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
 		return uuid.Nil, err
 	}
-
-	recordBlockCutMetric(reason)
 
 	return id, nil
 }

--- a/modules/livestore/instance.go
+++ b/modules/livestore/instance.go
@@ -330,7 +330,7 @@ func countSpans(trace *tempopb.Trace) int {
 	return count
 }
 
-func (i *instance) cutIdleTraces(ctx context.Context, immediate bool) error {
+func (i *instance) cutIdleTraces(ctx context.Context, immediate bool) ([]uuid.UUID, error) {
 	_, span := tracer.Start(ctx, "instance.cutIdleTraces",
 		oteltrace.WithAttributes(attribute.String("tenant", i.tenantID)))
 	defer span.End()
@@ -349,22 +349,45 @@ func (i *instance) cutIdleTraces(ctx context.Context, immediate bool) error {
 	span.SetAttributes(attribute.Int("traces_to_cut", len(tracesToCut)))
 
 	if len(tracesToCut) == 0 {
-		return nil
+		return nil, nil
 	}
 	// Sort by ID
 	sort.Slice(tracesToCut, func(i, j int) bool {
 		return bytes.Compare(tracesToCut[i].ID, tracesToCut[j].ID) == -1
 	})
-	// Collect the trace IDs that will be flushed
+
+	var cutBlockIDs []uuid.UUID
+
+	// Write traces to head block, cutting when MaxBlockBytes is reached.
 	span.AddEvent("writing traces to head block")
 	for _, t := range tracesToCut {
 		err := i.writeHeadBlock(t.ID, t)
 		if err != nil {
 			span.RecordError(err)
-			return err
+			return cutBlockIDs, err
 		}
 
 		i.tracesCreatedTotal.Inc()
+
+		// if the head block has reached max block bytes,
+		// cut it and enqueue for completion later
+		i.blocksMtx.Lock()
+		if reason := i.shouldCutHead(false); reason&cutReasonMaxBlockBytes != 0 {
+			i.traceSizes.ClearIdle(i.lastCutTime)
+			id, err := i.cutHeadLocked()
+			i.blocksMtx.Unlock()
+			if err != nil {
+				span.RecordError(err)
+				return cutBlockIDs, err
+			}
+			cutBlockIDs = append(cutBlockIDs, id)
+			span.AddEvent("cut oversized block", oteltrace.WithAttributes(
+				attribute.String("blockID", id.String()),
+			))
+			recordBlockCutMetric(cutReasonMaxBlockBytes)
+		} else {
+			i.blocksMtx.Unlock()
+		}
 	}
 	span.AddEvent("wrote traces to head block")
 
@@ -378,12 +401,10 @@ func (i *instance) cutIdleTraces(ctx context.Context, immediate bool) error {
 		err := i.headBlock.Flush()
 		if err != nil {
 			span.RecordError(err)
-			return err
+			return cutBlockIDs, err
 		}
-
-		return nil
 	}
-	return nil
+	return cutBlockIDs, nil
 }
 
 func (i *instance) writeHeadBlock(id []byte, liveTrace *livetraces.LiveTrace[*v1.ResourceSpans]) error {
@@ -529,10 +550,27 @@ func (i *instance) cutBlocks(ctx context.Context, immediate bool) (uuid.UUID, er
 
 	i.traceSizes.ClearIdle(i.lastCutTime)
 
-	// Final flush
-	err := i.headBlock.Flush()
+	id, err := i.cutHeadLocked()
 	if err != nil {
 		span.RecordError(err)
+		return uuid.Nil, err
+	}
+
+	span.SetAttributes(
+		attribute.String("blockID", id.String()),
+		attribute.Int64("block_size", int64(i.walBlocks[id].DataLength())),
+	)
+
+	recordBlockCutMetric(reason)
+
+	return id, nil
+}
+
+// cutHeadLocked flushes the head block, moves it to walBlocks, and resets the
+// head block. Caller must hold blocksMtx.
+func (i *instance) cutHeadLocked() (uuid.UUID, error) {
+	err := i.headBlock.Flush()
+	if err != nil {
 		return uuid.Nil, err
 	}
 
@@ -540,20 +578,12 @@ func (i *instance) cutBlocks(ctx context.Context, immediate bool) (uuid.UUID, er
 	blockSize := i.headBlock.DataLength()
 	i.walBlocks[id] = i.headBlock
 
-	span.SetAttributes(
-		attribute.String("blockID", id.String()),
-		attribute.Int64("block_size", int64(blockSize)),
-	)
-
 	level.Info(i.logger).Log("msg", "queueing wal block for completion", "block", id.String(), "size", blockSize)
 
 	err = i.resetHeadBlock()
 	if err != nil {
-		span.RecordError(err)
 		return uuid.Nil, err
 	}
-
-	recordBlockCutMetric(reason)
 
 	return id, nil
 }

--- a/modules/livestore/instance.go
+++ b/modules/livestore/instance.go
@@ -1,11 +1,10 @@
 package livestore
 
 import (
-	"bytes"
 	"context"
 	"encoding/hex"
 	"errors"
-	"sort"
+	"iter"
 	"sync"
 	"time"
 
@@ -123,10 +122,12 @@ type instance struct {
 	lastCutTime    time.Time
 
 	// Live traces
-	liveTracesMtx  sync.Mutex
-	liveTraces     *livetraces.LiveTraces[*v1.ResourceSpans]
-	traceSizes     *tracesizes.Tracker
-	maxTraceLogger *util_log.RateLimitedLogger
+	liveTracesMtx      sync.Mutex
+	liveTraces         *livetraces.LiveTraces[*v1.ResourceSpans]
+	traceSizes         *tracesizes.Tracker
+	maxTraceLogger     *util_log.RateLimitedLogger
+	liveTracesIterNext func() (*livetraces.LiveTrace[*v1.ResourceSpans], bool)
+	liveTracesIterStop func()
 
 	// Metrics
 	tracesCreatedTotal prometheus.Counter
@@ -331,7 +332,7 @@ func countSpans(trace *tempopb.Trace) int {
 	return count
 }
 
-func (i *instance) cutIdleTraces(ctx context.Context, immediate bool) ([]uuid.UUID, error) {
+func (i *instance) cutIdleTraces(ctx context.Context, immediate bool) (bool, error) {
 	_, span := tracer.Start(ctx, "instance.cutIdleTraces",
 		oteltrace.WithAttributes(attribute.String("tenant", i.tenantID)))
 	defer span.End()
@@ -342,54 +343,51 @@ func (i *instance) cutIdleTraces(ctx context.Context, immediate bool) ([]uuid.UU
 	// Set metrics before cutting (similar to ingester)
 	metricLiveTraces.WithLabelValues(i.tenantID).Set(float64(i.liveTraces.Len()))
 	metricLiveTraceBytes.WithLabelValues(i.tenantID).Set(float64(i.liveTraces.Size()))
+	if i.liveTracesIterNext == nil {
+		i.liveTracesIterNext, i.liveTracesIterStop = iter.Pull(i.liveTraces.CutIdle(time.Now(), immediate))
+	}
 
-	tracesToCut := i.liveTraces.CutIdle(time.Now(), immediate)
 	i.liveTracesMtx.Unlock()
 	span.AddEvent("released liveTracesMtx")
 
-	span.SetAttributes(attribute.Int("traces_to_cut", len(tracesToCut)))
-
-	if len(tracesToCut) == 0 {
-		return nil, nil
-	}
-	// Sort by ID
-	sort.Slice(tracesToCut, func(i, j int) bool {
-		return bytes.Compare(tracesToCut[i].ID, tracesToCut[j].ID) == -1
-	})
-
-	var cutBlockIDs []uuid.UUID
+	var tracesCut int
+	defer func() { span.SetAttributes(attribute.Int("traces_cut", tracesCut)) }()
 
 	// Write traces to head block, cutting when MaxBlockBytes is reached.
 	span.AddEvent("writing traces to head block")
-	for _, t := range tracesToCut {
-		err := i.writeHeadBlock(t.ID, t)
+	for {
+		i.liveTracesMtx.Lock()
+		t, ok := i.liveTracesIterNext()
+		i.liveTracesMtx.Unlock()
+		if !ok {
+			break
+		}
+		blockSize, err := i.writeHeadBlock(t.ID, t)
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			return cutBlockIDs, err
+			i.liveTracesIterStop()
+			i.liveTracesIterNext, i.liveTracesIterStop = nil, nil
+			return false, err
 		}
 
+		tracesCut++
 		i.tracesCreatedTotal.Inc()
 
 		// if the head block has reached max block bytes,
-		// cut it and enqueue for completion later
-		i.blocksMtx.Lock()
-		reason := i.shouldCutHead(false)
-		i.blocksMtx.Unlock()
-		if reason&cutReasonMaxBlockBytes != 0 {
-			id, err := i.cutBlocks(ctx, false)
-			if err != nil {
-				span.RecordError(err)
-				return cutBlockIDs, err
-			}
-			if id != uuid.Nil {
-				span.AddEvent("cut oversized block", oteltrace.WithAttributes(
-					attribute.String("blockID", id.String()),
-				))
-				cutBlockIDs = append(cutBlockIDs, id)
-			}
+		// we exit earlier in order to cut the block
+		if blockSize >= i.Cfg.MaxBlockBytes {
+			return false, nil
 		}
 	}
+
+	i.liveTracesIterStop()
+	i.liveTracesIterNext, i.liveTracesIterStop = nil, nil
+
+	if tracesCut == 0 { // no traces to process
+		return true, nil
+	}
+
 	span.AddEvent("wrote traces to head block")
 
 	i.blocksMtx.Lock()
@@ -403,20 +401,20 @@ func (i *instance) cutIdleTraces(ctx context.Context, immediate bool) ([]uuid.UU
 		if err != nil {
 			span.SetStatus(codes.Error, err.Error())
 			span.RecordError(err)
-			return cutBlockIDs, err
+			return false, err
 		}
 	}
-	return cutBlockIDs, nil
+	return true, nil
 }
 
-func (i *instance) writeHeadBlock(id []byte, liveTrace *livetraces.LiveTrace[*v1.ResourceSpans]) error {
+func (i *instance) writeHeadBlock(id []byte, liveTrace *livetraces.LiveTrace[*v1.ResourceSpans]) (uint64, error) {
 	i.blocksMtx.Lock()
 	defer i.blocksMtx.Unlock()
 
 	if i.headBlock == nil {
 		err := i.resetHeadBlock()
 		if err != nil {
-			return err
+			return 0, err
 		}
 	}
 
@@ -457,7 +455,8 @@ func (i *instance) writeHeadBlock(id []byte, liveTrace *livetraces.LiveTrace[*v1
 		endSeconds = maxEnd
 	}
 
-	return i.headBlock.AppendTrace(id, tr, startSeconds, endSeconds, false)
+	err := i.headBlock.AppendTrace(id, tr, startSeconds, endSeconds, false)
+	return i.headBlock.DataLength(), err
 }
 
 func (i *instance) getDedicatedColumns() backend.DedicatedColumns {
@@ -552,28 +551,11 @@ func (i *instance) cutBlocks(ctx context.Context, immediate bool) (uuid.UUID, er
 
 	i.traceSizes.ClearIdle(i.lastCutTime)
 
-	id, err := i.cutHeadLocked()
+	// Final flush
+	err := i.headBlock.Flush()
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		span.RecordError(err)
-		return uuid.Nil, err
-	}
-
-	span.SetAttributes(
-		attribute.String("blockID", id.String()),
-		attribute.Int64("block_size", int64(i.walBlocks[id].DataLength())),
-	)
-
-	recordBlockCutMetric(reason)
-
-	return id, nil
-}
-
-// cutHeadLocked flushes the head block, moves it to walBlocks, and resets the
-// head block. Caller must hold blocksMtx.
-func (i *instance) cutHeadLocked() (uuid.UUID, error) {
-	err := i.headBlock.Flush()
-	if err != nil {
 		return uuid.Nil, err
 	}
 
@@ -581,12 +563,21 @@ func (i *instance) cutHeadLocked() (uuid.UUID, error) {
 	blockSize := i.headBlock.DataLength()
 	i.walBlocks[id] = i.headBlock
 
+	span.SetAttributes(
+		attribute.String("blockID", id.String()),
+		attribute.Int64("block_size", int64(blockSize)),
+	)
+
 	level.Info(i.logger).Log("msg", "queueing wal block for completion", "block", id.String(), "size", blockSize)
 
 	err = i.resetHeadBlock()
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return uuid.Nil, err
 	}
+
+	recordBlockCutMetric(reason)
 
 	return id, nil
 }

--- a/modules/livestore/instance.go
+++ b/modules/livestore/instance.go
@@ -356,9 +356,7 @@ func (i *instance) cutIdleTraces(ctx context.Context, immediate bool) (bool, err
 	// Write traces to head block, cutting when MaxBlockBytes is reached.
 	span.AddEvent("writing traces to head block")
 	for {
-		i.liveTracesMtx.Lock()
 		t, ok := i.liveTracesIterNext()
-		i.liveTracesMtx.Unlock()
 		if !ok {
 			break
 		}

--- a/modules/livestore/instance_search_test.go
+++ b/modules/livestore/instance_search_test.go
@@ -112,7 +112,8 @@ func TestInstanceSearchTraceQL(t *testing.T) {
 			assert.Len(t, sr.Traces, 0)
 
 			// Test after appending to WAL
-			require.NoError(t, i.cutIdleTraces(t.Context(), true))
+			_, cutErr := i.cutIdleTraces(t.Context(), true)
+			require.NoError(t, cutErr)
 
 			sr, err = i.Search(t.Context(), req)
 			assert.NoError(t, err)
@@ -536,7 +537,7 @@ func TestSearchTagsV2Limits(t *testing.T) {
 					Ids:    [][]byte{id},
 				}
 				instance.pushBytes(t.Context(), time.Now(), req)
-				err = instance.cutIdleTraces(t.Context(), true)
+				_, err = instance.cutIdleTraces(t.Context(), true)
 				require.NoError(t, err)
 				blockID, err := instance.cutBlocks(t.Context(), true)
 				require.NoError(t, err)
@@ -758,7 +759,7 @@ func writeTracesForSearch(t *testing.T, i *instance, spanName, tagKey, tagValue 
 	}
 
 	// traces have to be cut to show up in searches
-	err := i.cutIdleTraces(t.Context(), true)
+	_, err := i.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
 
 	return ids, expectedTagValues, expectedEventTagValues, expectedLinkTagValues
@@ -811,7 +812,7 @@ func TestInstanceSearchDoesNotRace(t *testing.T) {
 	})
 
 	concurrent(func() {
-		err := i.cutIdleTraces(t.Context(), true)
+		_, err := i.cutIdleTraces(t.Context(), true)
 		require.NoError(t, err, "error cutting complete traces")
 	})
 
@@ -899,7 +900,7 @@ func TestInstanceSearchMetrics(t *testing.T) {
 	require.Equal(t, uint64(0), m.InspectedBytes)  // we don't search live traces
 
 	// Test after appending to WAL
-	err := i.cutIdleTraces(t.Context(), true)
+	_, err := i.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
 	m = search()
 	require.Less(t, numBytes, m.InspectedBytes)
@@ -1006,7 +1007,7 @@ func TestInstanceFindByTraceIDWithSizeLimits(t *testing.T) {
 	i.pushBytes(ctx, time.Now(), req)
 
 	// Cut to ensure we can find it
-	err = i.cutIdleTraces(t.Context(), true)
+	_, err = i.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
 
 	// and request it back
@@ -1209,7 +1210,7 @@ func TestLiveStoreQueryRange(t *testing.T) {
 	inst.pushBytes(t.Context(), now, pushReq)
 
 	// Force block creation by cutting traces and blocks
-	err = inst.cutIdleTraces(t.Context(), true)
+	_, err = inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
 
 	blockID, err := inst.cutBlocks(t.Context(), true)

--- a/modules/livestore/instance_search_test.go
+++ b/modules/livestore/instance_search_test.go
@@ -112,8 +112,9 @@ func TestInstanceSearchTraceQL(t *testing.T) {
 			assert.Len(t, sr.Traces, 0)
 
 			// Test after appending to WAL
-			_, cutErr := i.cutIdleTraces(t.Context(), true)
+			blockIDs, cutErr := i.cutIdleTraces(t.Context(), true)
 			require.NoError(t, cutErr)
+			require.Empty(t, blockIDs, "should not trigger mid-batch cut")
 
 			sr, err = i.Search(t.Context(), req)
 			assert.NoError(t, err)
@@ -537,8 +538,9 @@ func TestSearchTagsV2Limits(t *testing.T) {
 					Ids:    [][]byte{id},
 				}
 				instance.pushBytes(t.Context(), time.Now(), req)
-				_, err = instance.cutIdleTraces(t.Context(), true)
+				blockIDs, err := instance.cutIdleTraces(t.Context(), true)
 				require.NoError(t, err)
+				require.Empty(t, blockIDs, "should not trigger mid-batch cut")
 				blockID, err := instance.cutBlocks(t.Context(), true)
 				require.NoError(t, err)
 				_, err = instance.completeBlock(ctx, blockID)
@@ -759,8 +761,9 @@ func writeTracesForSearch(t *testing.T, i *instance, spanName, tagKey, tagValue 
 	}
 
 	// traces have to be cut to show up in searches
-	_, err := i.cutIdleTraces(t.Context(), true)
+	blockIDs, err := i.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
+	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
 
 	return ids, expectedTagValues, expectedEventTagValues, expectedLinkTagValues
 }
@@ -812,8 +815,9 @@ func TestInstanceSearchDoesNotRace(t *testing.T) {
 	})
 
 	concurrent(func() {
-		_, err := i.cutIdleTraces(t.Context(), true)
+		blockIDs, err := i.cutIdleTraces(t.Context(), true)
 		require.NoError(t, err, "error cutting complete traces")
+		require.Empty(t, blockIDs, "should not trigger mid-batch cut")
 	})
 
 	concurrent(func() {
@@ -900,8 +904,9 @@ func TestInstanceSearchMetrics(t *testing.T) {
 	require.Equal(t, uint64(0), m.InspectedBytes)  // we don't search live traces
 
 	// Test after appending to WAL
-	_, err := i.cutIdleTraces(t.Context(), true)
+	blockIDs, err := i.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
+	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
 	m = search()
 	require.Less(t, numBytes, m.InspectedBytes)
 
@@ -1007,8 +1012,9 @@ func TestInstanceFindByTraceIDWithSizeLimits(t *testing.T) {
 	i.pushBytes(ctx, time.Now(), req)
 
 	// Cut to ensure we can find it
-	_, err = i.cutIdleTraces(t.Context(), true)
+	blockIDs, err := i.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
+	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
 
 	// and request it back
 	resp, err := i.FindByTraceID(t.Context(), traceID, false)
@@ -1210,8 +1216,9 @@ func TestLiveStoreQueryRange(t *testing.T) {
 	inst.pushBytes(t.Context(), now, pushReq)
 
 	// Force block creation by cutting traces and blocks
-	_, err = inst.cutIdleTraces(t.Context(), true)
+	blockIDs, err := inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
+	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
 
 	blockID, err := inst.cutBlocks(t.Context(), true)
 	require.NoError(t, err)

--- a/modules/livestore/instance_search_test.go
+++ b/modules/livestore/instance_search_test.go
@@ -112,9 +112,9 @@ func TestInstanceSearchTraceQL(t *testing.T) {
 			assert.Len(t, sr.Traces, 0)
 
 			// Test after appending to WAL
-			blockIDs, cutErr := i.cutIdleTraces(t.Context(), true)
+			drained, cutErr := i.cutIdleTraces(t.Context(), true)
 			require.NoError(t, cutErr)
-			require.Empty(t, blockIDs, "should not trigger mid-batch cut")
+			require.True(t, drained, "should drain live traces in one iteration")
 
 			sr, err = i.Search(t.Context(), req)
 			assert.NoError(t, err)
@@ -538,9 +538,9 @@ func TestSearchTagsV2Limits(t *testing.T) {
 					Ids:    [][]byte{id},
 				}
 				instance.pushBytes(t.Context(), time.Now(), req)
-				blockIDs, err := instance.cutIdleTraces(t.Context(), true)
+				drained, err := instance.cutIdleTraces(t.Context(), true)
 				require.NoError(t, err)
-				require.Empty(t, blockIDs, "should not trigger mid-batch cut")
+				require.True(t, drained, "should drain live traces in one iteration")
 				blockID, err := instance.cutBlocks(t.Context(), true)
 				require.NoError(t, err)
 				_, err = instance.completeBlock(ctx, blockID)
@@ -761,9 +761,9 @@ func writeTracesForSearch(t *testing.T, i *instance, spanName, tagKey, tagValue 
 	}
 
 	// traces have to be cut to show up in searches
-	blockIDs, err := i.cutIdleTraces(t.Context(), true)
+	drained, err := i.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
-	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
+	require.True(t, drained, "should drain live traces in one iteration")
 
 	return ids, expectedTagValues, expectedEventTagValues, expectedLinkTagValues
 }
@@ -815,9 +815,9 @@ func TestInstanceSearchDoesNotRace(t *testing.T) {
 	})
 
 	concurrent(func() {
-		blockIDs, err := i.cutIdleTraces(t.Context(), true)
+		drained, err := i.cutIdleTraces(t.Context(), true)
 		require.NoError(t, err, "error cutting complete traces")
-		require.Empty(t, blockIDs, "should not trigger mid-batch cut")
+		require.True(t, drained, "should drain live traces in one iteration")
 	})
 
 	concurrent(func() {
@@ -904,9 +904,9 @@ func TestInstanceSearchMetrics(t *testing.T) {
 	require.Equal(t, uint64(0), m.InspectedBytes)  // we don't search live traces
 
 	// Test after appending to WAL
-	blockIDs, err := i.cutIdleTraces(t.Context(), true)
+	drained, err := i.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
-	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
+	require.True(t, drained, "should drain live traces in one iteration")
 	m = search()
 	require.Less(t, numBytes, m.InspectedBytes)
 
@@ -1012,9 +1012,9 @@ func TestInstanceFindByTraceIDWithSizeLimits(t *testing.T) {
 	i.pushBytes(ctx, time.Now(), req)
 
 	// Cut to ensure we can find it
-	blockIDs, err := i.cutIdleTraces(t.Context(), true)
+	drained, err := i.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
-	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
+	require.True(t, drained, "should drain live traces in one iteration")
 
 	// and request it back
 	resp, err := i.FindByTraceID(t.Context(), traceID, false)
@@ -1216,9 +1216,9 @@ func TestLiveStoreQueryRange(t *testing.T) {
 	inst.pushBytes(t.Context(), now, pushReq)
 
 	// Force block creation by cutting traces and blocks
-	blockIDs, err := inst.cutIdleTraces(t.Context(), true)
+	drained, err := inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
-	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
+	require.True(t, drained, "should drain live traces in one iteration")
 
 	blockID, err := inst.cutBlocks(t.Context(), true)
 	require.NoError(t, err)

--- a/modules/livestore/instance_test.go
+++ b/modules/livestore/instance_test.go
@@ -276,3 +276,35 @@ func TestInstanceWALBackpressure(t *testing.T) {
 
 	require.NoError(t, services.StopAndAwaitTerminated(t.Context(), ls))
 }
+
+func TestCutIdleTracesRespectsMaxBlockBytes(t *testing.T) {
+	inst, ls := defaultInstance(t)
+
+	inst.Cfg.MaxBlockBytes = 5 * 1024 * 1024 // 5 Mb
+
+	// Push enough traces to require multiple blocks.
+	traceCount := 100 // that will be around 119Mb
+	for i := 0; i < traceCount; i++ {
+		id := test.ValidTraceID(nil)
+		tr := test.MakeTraceWithSpanCount(50, 100, id)
+		pushTrace(t.Context(), t, inst, tr, id)
+	}
+
+	// Immediate cut — all live traces written to head block, then cut to WAL.
+	err := inst.cutIdleTraces(t.Context(), true)
+	require.NoError(t, err)
+	_, err = inst.cutBlocks(t.Context(), true)
+	require.NoError(t, err)
+
+	// Verify no WAL block exceeds MaxBlockBytes.
+	inst.blocksMtx.RLock()
+	assert.Greater(t, len(inst.walBlocks), 2, "expected multiple WAL blocks")
+	for id, blk := range inst.walBlocks {
+		// block size estimation can be x5 off, so we check that that block size at least makes sense
+		assert.LessOrEqual(t, blk.DataLength(), inst.Cfg.MaxBlockBytes*5,
+			"WAL block %s exceeds MaxBlockBytes: %d > %d", id, blk.DataLength(), inst.Cfg.MaxBlockBytes)
+	}
+	inst.blocksMtx.RUnlock()
+
+	require.NoError(t, services.StopAndAwaitTerminated(t.Context(), ls))
+}

--- a/modules/livestore/instance_test.go
+++ b/modules/livestore/instance_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -286,27 +287,46 @@ func TestCutIdleTracesRespectsMaxBlockBytes(t *testing.T) {
 
 	// Push enough traces to require multiple blocks.
 	traceCount := 100 // that will be around 119Mb
-	for i := 0; i < traceCount; i++ {
+	traceIDs := make([][]byte, 0, traceCount)
+	traces := make([]*tempopb.Trace, 0, traceCount)
+
+	for range traceCount {
 		id := test.ValidTraceID(nil)
 		tr := test.MakeTraceWithSpanCount(50, 100, id)
 		pushTrace(t.Context(), t, inst, tr, id)
+		traceIDs = append(traceIDs, id)
+		traces = append(traces, tr)
 	}
 
-	// Immediate cut — all live traces written to head block, then cut to WAL.
-	_, err := inst.cutIdleTraces(t.Context(), true)
+	walBlocks, err := inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
-	_, err = inst.cutBlocks(t.Context(), true)
+	for i := 0; i < traceCount; i += 5 { // sample, otherwise the test is slow
+		requireTraceInLiveStore(t, ls, traceIDs[i], traces[i])
+	}
+
+	walUUID, err := inst.cutBlocks(t.Context(), true)
 	require.NoError(t, err)
 
+	if walUUID != uuid.Nil {
+		walBlocks = append(walBlocks, walUUID)
+	}
+	actualWALBlocks := make([]uuid.UUID, 0, len(inst.walBlocks))
+	for wb := range inst.walBlocks {
+		actualWALBlocks = append(actualWALBlocks, wb)
+	}
+	require.ElementsMatch(t, walBlocks, actualWALBlocks, "some WAL blocks where not registered")
+
+	for i := 0; i < traceCount; i += 5 {
+		requireTraceInLiveStore(t, ls, traceIDs[i], traces[i])
+	}
+
 	// Verify no WAL block exceeds MaxBlockBytes.
-	inst.blocksMtx.RLock()
 	assert.Greater(t, len(inst.walBlocks), 2, "expected multiple WAL blocks")
 	for id, blk := range inst.walBlocks {
 		// block size estimation can be x5 off, so we check that that block size at least makes sense
 		assert.LessOrEqual(t, blk.DataLength(), inst.Cfg.MaxBlockBytes*5,
 			"WAL block %s exceeds MaxBlockBytes: %d > %d", id, blk.DataLength(), inst.Cfg.MaxBlockBytes)
 	}
-	inst.blocksMtx.RUnlock()
 
 	require.NoError(t, services.StopAndAwaitTerminated(t.Context(), ls))
 }

--- a/modules/livestore/instance_test.go
+++ b/modules/livestore/instance_test.go
@@ -96,7 +96,7 @@ func TestInstanceLimits(t *testing.T) {
 		pushTrace(t.Context(), t, instance, batch1, id)
 
 		// cut idle traces but we retain the too large trace in traceSizes
-		err := instance.cutIdleTraces(t.Context(), true)
+		_, err := instance.cutIdleTraces(t.Context(), true)
 		require.NoError(t, err)
 
 		// Second push with same id will fail b/c we are still tracking in traceSizes
@@ -117,7 +117,7 @@ func TestInstanceLimits(t *testing.T) {
 		pushTrace(t.Context(), t, instance, batch1, id)
 
 		// cut idle traces but we retain the too large trace in traceSizes
-		err := instance.cutIdleTraces(t.Context(), true)
+		_, err := instance.cutIdleTraces(t.Context(), true)
 		require.NoError(t, err)
 		blockID, err := instance.cutBlocks(t.Context(), true) // this won't clear the trace b/c the trace must not be seen for 2 head block cuts to be fully removed from live traces
 		require.NoError(t, err)
@@ -128,7 +128,7 @@ func TestInstanceLimits(t *testing.T) {
 		secondID := test.ValidTraceID(nil)
 		pushTrace(t.Context(), t, instance, batch1, secondID)
 
-		err = instance.cutIdleTraces(t.Context(), true)
+		_, err = instance.cutIdleTraces(t.Context(), true)
 		require.NoError(t, err)
 		blockID, err = instance.cutBlocks(t.Context(), true) // this will clear the trace b/c the trace has not been seen for 2 head block cuts
 		require.NoError(t, err)
@@ -229,7 +229,8 @@ func TestInstanceBackpressure(t *testing.T) {
 	require.Nil(t, res.Trace)
 
 	// Free up space for the blocked push
-	require.NoError(t, instance.cutIdleTraces(t.Context(), true))
+	_, cutErr := instance.cutIdleTraces(t.Context(), true)
+	require.NoError(t, cutErr)
 
 	// Wait for push to complete with timeout
 	select {
@@ -258,7 +259,8 @@ func TestInstanceWALBackpressure(t *testing.T) {
 	createWALBlock := func() {
 		id := test.ValidTraceID(nil)
 		pushTrace(t.Context(), t, inst, test.MakeTrace(1, id), id)
-		require.NoError(t, inst.cutIdleTraces(t.Context(), true))
+		_, cutErr := inst.cutIdleTraces(t.Context(), true)
+		require.NoError(t, cutErr)
 		walID, err := inst.cutBlocks(t.Context(), true)
 		require.NoError(t, err)
 		require.NotEqual(t, walID, [16]byte{})
@@ -291,7 +293,7 @@ func TestCutIdleTracesRespectsMaxBlockBytes(t *testing.T) {
 	}
 
 	// Immediate cut — all live traces written to head block, then cut to WAL.
-	err := inst.cutIdleTraces(t.Context(), true)
+	_, err := inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
 	_, err = inst.cutBlocks(t.Context(), true)
 	require.NoError(t, err)

--- a/modules/livestore/instance_test.go
+++ b/modules/livestore/instance_test.go
@@ -97,8 +97,9 @@ func TestInstanceLimits(t *testing.T) {
 		pushTrace(t.Context(), t, instance, batch1, id)
 
 		// cut idle traces but we retain the too large trace in traceSizes
-		_, err := instance.cutIdleTraces(t.Context(), true)
+		blockIDs, err := instance.cutIdleTraces(t.Context(), true)
 		require.NoError(t, err)
+		require.Empty(t, blockIDs, "should not trigger mid-batch cut")
 
 		// Second push with same id will fail b/c we are still tracking in traceSizes
 		pushTrace(t.Context(), t, instance, batch2, id)
@@ -118,8 +119,9 @@ func TestInstanceLimits(t *testing.T) {
 		pushTrace(t.Context(), t, instance, batch1, id)
 
 		// cut idle traces but we retain the too large trace in traceSizes
-		_, err := instance.cutIdleTraces(t.Context(), true)
+		blockIDs, err := instance.cutIdleTraces(t.Context(), true)
 		require.NoError(t, err)
+		require.Empty(t, blockIDs, "should not trigger mid-batch cut")
 		blockID, err := instance.cutBlocks(t.Context(), true) // this won't clear the trace b/c the trace must not be seen for 2 head block cuts to be fully removed from live traces
 		require.NoError(t, err)
 		_, err = instance.completeBlock(t.Context(), blockID)
@@ -129,8 +131,9 @@ func TestInstanceLimits(t *testing.T) {
 		secondID := test.ValidTraceID(nil)
 		pushTrace(t.Context(), t, instance, batch1, secondID)
 
-		_, err = instance.cutIdleTraces(t.Context(), true)
+		blockIDs, err = instance.cutIdleTraces(t.Context(), true)
 		require.NoError(t, err)
+		require.Empty(t, blockIDs, "should not trigger mid-batch cut")
 		blockID, err = instance.cutBlocks(t.Context(), true) // this will clear the trace b/c the trace has not been seen for 2 head block cuts
 		require.NoError(t, err)
 		_, err = instance.completeBlock(t.Context(), blockID)
@@ -230,8 +233,9 @@ func TestInstanceBackpressure(t *testing.T) {
 	require.Nil(t, res.Trace)
 
 	// Free up space for the blocked push
-	_, cutErr := instance.cutIdleTraces(t.Context(), true)
+	blockIDs, cutErr := instance.cutIdleTraces(t.Context(), true)
 	require.NoError(t, cutErr)
+	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
 
 	// Wait for push to complete with timeout
 	select {
@@ -260,8 +264,9 @@ func TestInstanceWALBackpressure(t *testing.T) {
 	createWALBlock := func() {
 		id := test.ValidTraceID(nil)
 		pushTrace(t.Context(), t, inst, test.MakeTrace(1, id), id)
-		_, cutErr := inst.cutIdleTraces(t.Context(), true)
+		blockIDs, cutErr := inst.cutIdleTraces(t.Context(), true)
 		require.NoError(t, cutErr)
+		require.Empty(t, blockIDs, "should not trigger mid-batch cut")
 		walID, err := inst.cutBlocks(t.Context(), true)
 		require.NoError(t, err)
 		require.NotEqual(t, walID, [16]byte{})

--- a/modules/livestore/instance_test.go
+++ b/modules/livestore/instance_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -97,9 +96,9 @@ func TestInstanceLimits(t *testing.T) {
 		pushTrace(t.Context(), t, instance, batch1, id)
 
 		// cut idle traces but we retain the too large trace in traceSizes
-		blockIDs, err := instance.cutIdleTraces(t.Context(), true)
+		drained, err := instance.cutIdleTraces(t.Context(), true)
 		require.NoError(t, err)
-		require.Empty(t, blockIDs, "should not trigger mid-batch cut")
+		require.True(t, drained, "should drain live traces in one iteration")
 
 		// Second push with same id will fail b/c we are still tracking in traceSizes
 		pushTrace(t.Context(), t, instance, batch2, id)
@@ -119,9 +118,9 @@ func TestInstanceLimits(t *testing.T) {
 		pushTrace(t.Context(), t, instance, batch1, id)
 
 		// cut idle traces but we retain the too large trace in traceSizes
-		blockIDs, err := instance.cutIdleTraces(t.Context(), true)
+		drained, err := instance.cutIdleTraces(t.Context(), true)
 		require.NoError(t, err)
-		require.Empty(t, blockIDs, "should not trigger mid-batch cut")
+		require.True(t, drained, "should drain live traces in one iteration")
 		blockID, err := instance.cutBlocks(t.Context(), true) // this won't clear the trace b/c the trace must not be seen for 2 head block cuts to be fully removed from live traces
 		require.NoError(t, err)
 		_, err = instance.completeBlock(t.Context(), blockID)
@@ -131,9 +130,9 @@ func TestInstanceLimits(t *testing.T) {
 		secondID := test.ValidTraceID(nil)
 		pushTrace(t.Context(), t, instance, batch1, secondID)
 
-		blockIDs, err = instance.cutIdleTraces(t.Context(), true)
+		drained, err = instance.cutIdleTraces(t.Context(), true)
 		require.NoError(t, err)
-		require.Empty(t, blockIDs, "should not trigger mid-batch cut")
+		require.True(t, drained, "should drain live traces in one iteration")
 		blockID, err = instance.cutBlocks(t.Context(), true) // this will clear the trace b/c the trace has not been seen for 2 head block cuts
 		require.NoError(t, err)
 		_, err = instance.completeBlock(t.Context(), blockID)
@@ -233,9 +232,9 @@ func TestInstanceBackpressure(t *testing.T) {
 	require.Nil(t, res.Trace)
 
 	// Free up space for the blocked push
-	blockIDs, cutErr := instance.cutIdleTraces(t.Context(), true)
+	drained, cutErr := instance.cutIdleTraces(t.Context(), true)
 	require.NoError(t, cutErr)
-	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
+	require.True(t, drained, "should drain live traces in one iteration")
 
 	// Wait for push to complete with timeout
 	select {
@@ -264,9 +263,9 @@ func TestInstanceWALBackpressure(t *testing.T) {
 	createWALBlock := func() {
 		id := test.ValidTraceID(nil)
 		pushTrace(t.Context(), t, inst, test.MakeTrace(1, id), id)
-		blockIDs, cutErr := inst.cutIdleTraces(t.Context(), true)
+		drained, cutErr := inst.cutIdleTraces(t.Context(), true)
 		require.NoError(t, cutErr)
-		require.Empty(t, blockIDs, "should not trigger mid-batch cut")
+		require.True(t, drained, "should drain live traces in one iteration")
 		walID, err := inst.cutBlocks(t.Context(), true)
 		require.NoError(t, err)
 		require.NotEqual(t, walID, [16]byte{})
@@ -303,35 +302,23 @@ func TestCutIdleTracesRespectsMaxBlockBytes(t *testing.T) {
 		traces = append(traces, tr)
 	}
 
-	walBlocks, err := inst.cutIdleTraces(t.Context(), true)
-	require.NoError(t, err)
-	for i := 0; i < traceCount; i += 5 { // sample, otherwise the test is slow
-		requireTraceInLiveStore(t, ls, traceIDs[i], traces[i])
-	}
-
-	walUUID, err := inst.cutBlocks(t.Context(), true)
-	require.NoError(t, err)
-
-	if walUUID != uuid.Nil {
-		walBlocks = append(walBlocks, walUUID)
-	}
-	actualWALBlocks := make([]uuid.UUID, 0, len(inst.walBlocks))
-	for wb := range inst.walBlocks {
-		actualWALBlocks = append(actualWALBlocks, wb)
-	}
-	require.ElementsMatch(t, walBlocks, actualWALBlocks, "some WAL blocks where not registered")
-
+	ls.cutOneInstanceToWal(t.Context(), inst, true)
 	for i := 0; i < traceCount; i += 5 {
 		requireTraceInLiveStore(t, ls, traceIDs[i], traces[i])
 	}
 
 	// Verify no WAL block exceeds MaxBlockBytes.
-	assert.Greater(t, len(inst.walBlocks), 2, "expected multiple WAL blocks")
+	walBlocksNum := len(inst.walBlocks)
+	assert.Greater(t, walBlocksNum, 2, "expected multiple WAL blocks")
 	for id, blk := range inst.walBlocks {
 		// block size estimation can be x5 off, so we check that that block size at least makes sense
 		assert.LessOrEqual(t, blk.DataLength(), inst.Cfg.MaxBlockBytes*5,
 			"WAL block %s exceeds MaxBlockBytes: %d > %d", id, blk.DataLength(), inst.Cfg.MaxBlockBytes)
 	}
+
+	// with no new traces, number of WAL blocks should not increase after another cut to WAL
+	ls.cutOneInstanceToWal(t.Context(), inst, true)
+	assert.Equal(t, walBlocksNum, len(inst.walBlocks), "expected no new WAL blocks after cut to WAL with no new traces")
 
 	require.NoError(t, services.StopAndAwaitTerminated(t.Context(), ls))
 }

--- a/modules/livestore/live_store.go
+++ b/modules/livestore/live_store.go
@@ -733,10 +733,20 @@ func (s *LiveStore) cutOneInstanceToWal(ctx context.Context, inst *instance, imm
 	defer span.End()
 
 	// Regular trace cuts (live traces -> head block)
-	err := inst.cutIdleTraces(ctx, immediate)
+	cutBlockIDs, err := inst.cutIdleTraces(ctx, immediate)
 	if err != nil {
 		level.Error(s.logger).Log("msg", "failed to cut idle traces", "tenant", inst.tenantID, "err", err)
 		span.RecordError(err)
+	}
+
+	// Enqueue any blocks that were cut mid-batch due to MaxBlockBytes.
+	for _, id := range cutBlockIDs {
+		span.AddEvent("block cut during cutIdleTraces",
+			oteltrace.WithAttributes(attribute.String("blockID", id.String())))
+		if err := s.enqueueCompleteOp(inst.tenantID, id, false); err != nil {
+			level.Error(s.logger).Log("msg", "failed to enqueue complete operation", "tenant", inst.tenantID, "err", err)
+			span.RecordError(err)
+		}
 	}
 
 	// Regular block cuts

--- a/modules/livestore/live_store.go
+++ b/modules/livestore/live_store.go
@@ -28,6 +28,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
@@ -732,39 +733,31 @@ func (s *LiveStore) cutOneInstanceToWal(ctx context.Context, inst *instance, imm
 		))
 	defer span.End()
 
-	// Regular trace cuts (live traces -> head block)
-	cutBlockIDs, err := inst.cutIdleTraces(ctx, immediate)
-	if err != nil {
-		level.Error(s.logger).Log("msg", "failed to cut idle traces", "tenant", inst.tenantID, "err", err)
-		span.RecordError(err)
-	}
-
-	// Enqueue any blocks that were cut mid-batch due to MaxBlockBytes.
-	for _, id := range cutBlockIDs {
-		span.AddEvent("block cut during cutIdleTraces",
-			oteltrace.WithAttributes(attribute.String("blockID", id.String())))
-		if err := s.enqueueCompleteOp(inst.tenantID, id, false); err != nil {
-			level.Error(s.logger).Log("msg", "failed to enqueue complete operation", "tenant", inst.tenantID, "err", err)
-			span.RecordError(err)
-		}
-	}
-
-	// Regular block cuts
-	blockID, err := inst.cutBlocks(ctx, immediate)
-	if err != nil {
-		level.Error(s.logger).Log("msg", "failed to cut blocks", "tenant", inst.tenantID, "err", err)
-		span.RecordError(err)
-	}
-
-	// If head block is cut, enqueue complete operation
-	if blockID != uuid.Nil {
-		span.AddEvent("block enqueued for completion",
-			oteltrace.WithAttributes(attribute.String("blockID", blockID.String())))
-		err = s.enqueueCompleteOp(inst.tenantID, blockID, false)
+	var liveTracesDrained bool
+	var err error
+	for !liveTracesDrained {
+		// Regular trace cuts (live traces -> head block)
+		liveTracesDrained, err = inst.cutIdleTraces(ctx, immediate)
 		if err != nil {
-			level.Error(s.logger).Log("msg", "failed to enqueue complete operation", "tenant", inst.tenantID, "err", err)
+			level.Error(s.logger).Log("msg", "failed to cut idle traces", "tenant", inst.tenantID, "err", err)
+			span.SetStatus(codes.Error, err.Error())
 			span.RecordError(err)
-			return
+			break
+		}
+		id, err := inst.cutBlocks(ctx, immediate)
+		if err != nil {
+			level.Error(s.logger).Log("msg", "failed to cut blocks", "tenant", inst.tenantID, "err", err)
+			span.SetStatus(codes.Error, err.Error())
+			span.RecordError(err)
+			break
+		}
+		if id != uuid.Nil {
+			span.AddEvent("block enqueued for completion",
+				oteltrace.WithAttributes(attribute.String("blockID", id.String())))
+			if err := s.enqueueCompleteOp(inst.tenantID, id, false); err != nil {
+				level.Error(s.logger).Log("msg", "failed to enqueue complete operation", "tenant", inst.tenantID, "err", err)
+				span.RecordError(err)
+			}
 		}
 	}
 }

--- a/modules/livestore/live_store_background_test.go
+++ b/modules/livestore/live_store_background_test.go
@@ -44,7 +44,7 @@ func TestProcessCompleteOpAbandonOnCancelledContext(t *testing.T) {
 
 	// Push a trace, flush live traces to head block, then cut to WAL.
 	pushTracesToInstance(t, inst, 1)
-	err = inst.cutIdleTraces(t.Context(), true)
+	_, err = inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
 	walID, err := inst.cutBlocks(t.Context(), true)
 	require.NoError(t, err)

--- a/modules/livestore/live_store_background_test.go
+++ b/modules/livestore/live_store_background_test.go
@@ -27,7 +27,7 @@ func TestProcessCompleteOpAbandonOnCancelledContext(t *testing.T) {
 
 	// Push a trace, flush live traces to head block, then cut to WAL.
 	pushTracesToInstance(t, inst, 1)
-	err = inst.cutIdleTraces(t.Context(), true)
+	_, err = inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
 	walID, err := inst.cutBlocks(t.Context(), true)
 	require.NoError(t, err)

--- a/modules/livestore/live_store_background_test.go
+++ b/modules/livestore/live_store_background_test.go
@@ -44,8 +44,9 @@ func TestProcessCompleteOpAbandonOnCancelledContext(t *testing.T) {
 
 	// Push a trace, flush live traces to head block, then cut to WAL.
 	pushTracesToInstance(t, inst, 1)
-	_, err = inst.cutIdleTraces(t.Context(), true)
+	blockIDs, err := inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
+	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
 	walID, err := inst.cutBlocks(t.Context(), true)
 	require.NoError(t, err)
 	require.NotEqual(t, uuid.Nil, walID)

--- a/modules/livestore/live_store_background_test.go
+++ b/modules/livestore/live_store_background_test.go
@@ -44,9 +44,9 @@ func TestProcessCompleteOpAbandonOnCancelledContext(t *testing.T) {
 
 	// Push a trace, flush live traces to head block, then cut to WAL.
 	pushTracesToInstance(t, inst, 1)
-	blockIDs, err := inst.cutIdleTraces(t.Context(), true)
+	drained, err := inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
-	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
+	require.True(t, drained, "should drain live traces in one iteration")
 	walID, err := inst.cutBlocks(t.Context(), true)
 	require.NoError(t, err)
 	require.NotEqual(t, uuid.Nil, walID)

--- a/modules/livestore/live_store_test.go
+++ b/modules/livestore/live_store_test.go
@@ -270,8 +270,9 @@ func TestLiveStoreFullBlockLifecycleCheating(t *testing.T) {
 	requireInstanceState(t, inst, instanceState{liveTraces: 1, walBlocks: 0, completeBlocks: 0})
 
 	// cut to head block and test
-	_, err = inst.cutIdleTraces(t.Context(), true)
+	blockIDs, err := inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
+	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
 
 	requireTraceInLiveStore(t, liveStore, expectedID, expectedTrace)
 	requireTraceInBlock(t, inst.headBlock, expectedID, expectedTrace)
@@ -333,8 +334,9 @@ func TestLiveStoreReplaysTraceInHeadBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	// cut to head block
-	_, err = inst.cutIdleTraces(t.Context(), true)
+	blockIDs, err := inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
+	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
 
 	// stop the live store and then create a new one to simulate a restart and replay the data on disk
 	err = services.StopAndAwaitTerminated(t.Context(), liveStore)
@@ -361,8 +363,9 @@ func TestLiveStoreReplaysTraceInWalBlocks(t *testing.T) {
 	require.NoError(t, err)
 
 	// cut to head block
-	_, err = inst.cutIdleTraces(t.Context(), true)
+	blockIDs, err := inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
+	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
 
 	// cut head to wal blocks
 	_, err = inst.cutBlocks(t.Context(), true)
@@ -393,8 +396,9 @@ func TestLiveStoreReplaysTraceInCompleteBlocks(t *testing.T) {
 	require.NoError(t, err)
 
 	// cut to head block
-	_, err = inst.cutIdleTraces(t.Context(), true)
+	blockIDs, err := inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
+	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
 
 	// cut head to wal blocks
 	walUUID, err := inst.cutBlocks(t.Context(), true)
@@ -425,8 +429,9 @@ func TestLiveStoreDropsInvalidCompleteBlocksOnRestart(t *testing.T) {
 	inst, err := liveStore.getOrCreateInstance(testTenantID)
 	require.NoError(t, err)
 
-	_, cutErr := inst.cutIdleTraces(t.Context(), true)
+	blockIDs, cutErr := inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, cutErr)
+	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
 	walUUID, err := inst.cutBlocks(t.Context(), true)
 	require.NoError(t, err)
 	_, err = inst.completeBlock(context.Background(), walUUID)
@@ -660,8 +665,9 @@ func TestLiveStoreUsesRecordTimestampForBlockStartAndEnd(t *testing.T) {
 		require.NoError(t, err)
 
 		// force just pushed traces to the head block
-		_, err = inst.cutIdleTraces(t.Context(), true)
+		blockIDs, err := inst.cutIdleTraces(t.Context(), true)
 		require.NoError(t, err)
+		require.Empty(t, blockIDs, "should not trigger mid-batch cut")
 
 		meta := inst.headBlock.BlockMeta()
 		require.Equal(t, tc.expectedStart, meta.StartTime)

--- a/modules/livestore/live_store_test.go
+++ b/modules/livestore/live_store_test.go
@@ -270,7 +270,7 @@ func TestLiveStoreFullBlockLifecycleCheating(t *testing.T) {
 	requireInstanceState(t, inst, instanceState{liveTraces: 1, walBlocks: 0, completeBlocks: 0})
 
 	// cut to head block and test
-	err = inst.cutIdleTraces(t.Context(), true)
+	_, err = inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
 
 	requireTraceInLiveStore(t, liveStore, expectedID, expectedTrace)
@@ -333,7 +333,7 @@ func TestLiveStoreReplaysTraceInHeadBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	// cut to head block
-	err = inst.cutIdleTraces(t.Context(), true)
+	_, err = inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
 
 	// stop the live store and then create a new one to simulate a restart and replay the data on disk
@@ -361,7 +361,7 @@ func TestLiveStoreReplaysTraceInWalBlocks(t *testing.T) {
 	require.NoError(t, err)
 
 	// cut to head block
-	err = inst.cutIdleTraces(t.Context(), true)
+	_, err = inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
 
 	// cut head to wal blocks
@@ -393,7 +393,7 @@ func TestLiveStoreReplaysTraceInCompleteBlocks(t *testing.T) {
 	require.NoError(t, err)
 
 	// cut to head block
-	err = inst.cutIdleTraces(t.Context(), true)
+	_, err = inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
 
 	// cut head to wal blocks
@@ -425,7 +425,8 @@ func TestLiveStoreDropsInvalidCompleteBlocksOnRestart(t *testing.T) {
 	inst, err := liveStore.getOrCreateInstance(testTenantID)
 	require.NoError(t, err)
 
-	require.NoError(t, inst.cutIdleTraces(t.Context(), true))
+	_, cutErr := inst.cutIdleTraces(t.Context(), true)
+	require.NoError(t, cutErr)
 	walUUID, err := inst.cutBlocks(t.Context(), true)
 	require.NoError(t, err)
 	_, err = inst.completeBlock(context.Background(), walUUID)
@@ -659,7 +660,7 @@ func TestLiveStoreUsesRecordTimestampForBlockStartAndEnd(t *testing.T) {
 		require.NoError(t, err)
 
 		// force just pushed traces to the head block
-		err = inst.cutIdleTraces(t.Context(), true)
+		_, err = inst.cutIdleTraces(t.Context(), true)
 		require.NoError(t, err)
 
 		meta := inst.headBlock.BlockMeta()

--- a/modules/livestore/live_store_test.go
+++ b/modules/livestore/live_store_test.go
@@ -270,9 +270,9 @@ func TestLiveStoreFullBlockLifecycleCheating(t *testing.T) {
 	requireInstanceState(t, inst, instanceState{liveTraces: 1, walBlocks: 0, completeBlocks: 0})
 
 	// cut to head block and test
-	blockIDs, err := inst.cutIdleTraces(t.Context(), true)
+	drained, err := inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
-	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
+	require.True(t, drained, "should drain live traces in one iteration")
 
 	requireTraceInLiveStore(t, liveStore, expectedID, expectedTrace)
 	requireTraceInBlock(t, inst.headBlock, expectedID, expectedTrace)
@@ -334,9 +334,9 @@ func TestLiveStoreReplaysTraceInHeadBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	// cut to head block
-	blockIDs, err := inst.cutIdleTraces(t.Context(), true)
+	drained, err := inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
-	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
+	require.True(t, drained, "should drain live traces in one iteration")
 
 	// stop the live store and then create a new one to simulate a restart and replay the data on disk
 	err = services.StopAndAwaitTerminated(t.Context(), liveStore)
@@ -363,9 +363,9 @@ func TestLiveStoreReplaysTraceInWalBlocks(t *testing.T) {
 	require.NoError(t, err)
 
 	// cut to head block
-	blockIDs, err := inst.cutIdleTraces(t.Context(), true)
+	drained, err := inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
-	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
+	require.True(t, drained, "should drain live traces in one iteration")
 
 	// cut head to wal blocks
 	_, err = inst.cutBlocks(t.Context(), true)
@@ -396,9 +396,9 @@ func TestLiveStoreReplaysTraceInCompleteBlocks(t *testing.T) {
 	require.NoError(t, err)
 
 	// cut to head block
-	blockIDs, err := inst.cutIdleTraces(t.Context(), true)
+	drained, err := inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
-	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
+	require.True(t, drained, "should drain live traces in one iteration")
 
 	// cut head to wal blocks
 	walUUID, err := inst.cutBlocks(t.Context(), true)
@@ -429,9 +429,9 @@ func TestLiveStoreDropsInvalidCompleteBlocksOnRestart(t *testing.T) {
 	inst, err := liveStore.getOrCreateInstance(testTenantID)
 	require.NoError(t, err)
 
-	blockIDs, cutErr := inst.cutIdleTraces(t.Context(), true)
+	drained, cutErr := inst.cutIdleTraces(t.Context(), true)
 	require.NoError(t, cutErr)
-	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
+	require.True(t, drained, "should drain live traces in one iteration")
 	walUUID, err := inst.cutBlocks(t.Context(), true)
 	require.NoError(t, err)
 	_, err = inst.completeBlock(context.Background(), walUUID)
@@ -665,9 +665,9 @@ func TestLiveStoreUsesRecordTimestampForBlockStartAndEnd(t *testing.T) {
 		require.NoError(t, err)
 
 		// force just pushed traces to the head block
-		blockIDs, err := inst.cutIdleTraces(t.Context(), true)
+		drained, err := inst.cutIdleTraces(t.Context(), true)
 		require.NoError(t, err)
-		require.Empty(t, blockIDs, "should not trigger mid-batch cut")
+		require.True(t, drained, "should drain live traces in one iteration")
 
 		meta := inst.headBlock.BlockMeta()
 		require.Equal(t, tc.expectedStart, meta.StartTime)

--- a/modules/livestore/metrics_test.go
+++ b/modules/livestore/metrics_test.go
@@ -137,8 +137,9 @@ func TestMetrics_PushBytesTracking(t *testing.T) {
 		"bytes received should increase by trace data size")
 
 	// Check live traces metric after cutting
-	_, err = setup.instance.cutIdleTraces(t.Context(), true) // immediate cut
+	blockIDs, err := setup.instance.cutIdleTraces(t.Context(), true) // immediate cut
 	require.NoError(t, err)
+	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
 
 	// Verify traces were created
 	finalTracesCreated, err := test.GetCounterValue(setup.instance.tracesCreatedTotal)
@@ -164,8 +165,9 @@ func TestMetrics_CompletionFlow(t *testing.T) {
 	setup.instance.pushBytes(t.Context(), time.Now(), req)
 
 	// Cut traces to head block
-	_, err = setup.instance.cutIdleTraces(t.Context(), true)
+	blockIDs, err := setup.instance.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
+	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
 
 	// Cut block to prepare for completion
 	blockID, err := setup.instance.cutBlocks(t.Context(), true)

--- a/modules/livestore/metrics_test.go
+++ b/modules/livestore/metrics_test.go
@@ -137,7 +137,7 @@ func TestMetrics_PushBytesTracking(t *testing.T) {
 		"bytes received should increase by trace data size")
 
 	// Check live traces metric after cutting
-	err = setup.instance.cutIdleTraces(t.Context(), true) // immediate cut
+	_, err = setup.instance.cutIdleTraces(t.Context(), true) // immediate cut
 	require.NoError(t, err)
 
 	// Verify traces were created
@@ -164,7 +164,7 @@ func TestMetrics_CompletionFlow(t *testing.T) {
 	setup.instance.pushBytes(t.Context(), time.Now(), req)
 
 	// Cut traces to head block
-	err = setup.instance.cutIdleTraces(t.Context(), true)
+	_, err = setup.instance.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
 
 	// Cut block to prepare for completion

--- a/modules/livestore/metrics_test.go
+++ b/modules/livestore/metrics_test.go
@@ -137,9 +137,9 @@ func TestMetrics_PushBytesTracking(t *testing.T) {
 		"bytes received should increase by trace data size")
 
 	// Check live traces metric after cutting
-	blockIDs, err := setup.instance.cutIdleTraces(t.Context(), true) // immediate cut
+	drained, err := setup.instance.cutIdleTraces(t.Context(), true) // immediate cut
 	require.NoError(t, err)
-	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
+	require.True(t, drained, "should drain live traces in one iteration")
 
 	// Verify traces were created
 	finalTracesCreated, err := test.GetCounterValue(setup.instance.tracesCreatedTotal)
@@ -165,9 +165,9 @@ func TestMetrics_CompletionFlow(t *testing.T) {
 	setup.instance.pushBytes(t.Context(), time.Now(), req)
 
 	// Cut traces to head block
-	blockIDs, err := setup.instance.cutIdleTraces(t.Context(), true)
+	drained, err := setup.instance.cutIdleTraces(t.Context(), true)
 	require.NoError(t, err)
-	require.Empty(t, blockIDs, "should not trigger mid-batch cut")
+	require.True(t, drained, "should drain live traces in one iteration")
 
 	// Cut block to prepare for completion
 	blockID, err := setup.instance.cutBlocks(t.Context(), true)

--- a/pkg/livetraces/livetraces.go
+++ b/pkg/livetraces/livetraces.go
@@ -1,9 +1,12 @@
 package livetraces
 
 import (
+	"bytes"
 	"errors"
 	"hash"
 	"hash/fnv"
+	"iter"
+	"sort"
 	"time"
 
 	kitlog "github.com/go-kit/log"
@@ -115,19 +118,33 @@ func (l *LiveTraces[T]) PushWithTimestampAndLimits(ts time.Time, traceID []byte,
 	return nil
 }
 
-func (l *LiveTraces[T]) CutIdle(now time.Time, immediate bool) []*LiveTrace[T] {
-	res := []*LiveTrace[T]{}
-
+func (l *LiveTraces[T]) CutIdle(now time.Time, immediate bool) iter.Seq[*LiveTrace[T]] {
 	idleSince := now.Add(-l.maxIdleTime)
 	liveSince := now.Add(-l.maxLiveTime)
 
+	type tokenTrace struct {
+		token uint64
+		tr    *LiveTrace[T]
+	}
+
+	var toCut []tokenTrace
 	for k, tr := range l.Traces {
 		if tr.LastAppend.Before(idleSince) || tr.CreatedAt.Before(liveSince) || immediate {
-			res = append(res, tr)
-			l.sz -= tr.sz
-			delete(l.Traces, k)
+			toCut = append(toCut, tokenTrace{token: k, tr: tr})
 		}
 	}
 
-	return res
+	sort.Slice(toCut, func(i, j int) bool {
+		return bytes.Compare(toCut[i].tr.ID, toCut[j].tr.ID) == -1
+	})
+
+	return func(yield func(*LiveTrace[T]) bool) {
+		for _, tt := range toCut {
+			l.sz -= tt.tr.sz
+			delete(l.Traces, tt.token)
+			if !yield(tt.tr) {
+				return
+			}
+		}
+	}
 }

--- a/pkg/livetraces/livetraces.go
+++ b/pkg/livetraces/livetraces.go
@@ -122,27 +122,22 @@ func (l *LiveTraces[T]) CutIdle(now time.Time, immediate bool) iter.Seq[*LiveTra
 	idleSince := now.Add(-l.maxIdleTime)
 	liveSince := now.Add(-l.maxLiveTime)
 
-	type tokenTrace struct {
-		token uint64
-		tr    *LiveTrace[T]
-	}
-
-	var toCut []tokenTrace
+	var toCut []*LiveTrace[T]
 	for k, tr := range l.Traces {
 		if tr.LastAppend.Before(idleSince) || tr.CreatedAt.Before(liveSince) || immediate {
-			toCut = append(toCut, tokenTrace{token: k, tr: tr})
+			l.sz -= tr.sz
+			delete(l.Traces, k)
+			toCut = append(toCut, tr)
 		}
 	}
 
 	sort.Slice(toCut, func(i, j int) bool {
-		return bytes.Compare(toCut[i].tr.ID, toCut[j].tr.ID) == -1
+		return bytes.Compare(toCut[i].ID, toCut[j].ID) == -1
 	})
 
 	return func(yield func(*LiveTrace[T]) bool) {
-		for _, tt := range toCut {
-			l.sz -= tt.tr.sz
-			delete(l.Traces, tt.token)
-			if !yield(tt.tr) {
+		for _, tr := range toCut {
+			if !yield(tr) {
 				return
 			}
 		}

--- a/pkg/livetraces/livetraces_test.go
+++ b/pkg/livetraces/livetraces_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math/rand/v2"
+	"slices"
 	"testing"
 	"time"
 
@@ -42,8 +43,7 @@ func TestLiveTracesSizesAndLen(t *testing.T) {
 		require.Equal(t, expectedLen, lt.Len())
 
 		// cut some traces and confirm size/len
-		cutTraces := lt.CutIdle(nowTime, false)
-		for _, tr := range cutTraces {
+		for tr := range lt.CutIdle(nowTime, false) {
 			for _, rs := range tr.Batches {
 				expectedSz -= uint64(rs.Size())
 			}
@@ -67,7 +67,7 @@ func TestCutIdleDueToIdleTime(t *testing.T) {
 	require.NoError(t, err)
 
 	// cut at 500 ms, should cut nothing
-	cutTraces := lt.CutIdle(rootTime.Add(500*time.Millisecond), false)
+	cutTraces := slices.Collect(lt.CutIdle(rootTime.Add(500*time.Millisecond), false))
 	require.Equal(t, 0, len(cutTraces))
 
 	// push at 1 second
@@ -75,11 +75,11 @@ func TestCutIdleDueToIdleTime(t *testing.T) {
 	require.NoError(t, err)
 
 	// cut at 1.5 seconds, should cut nothing
-	cutTraces = lt.CutIdle(rootTime.Add(1500*time.Millisecond), false)
+	cutTraces = slices.Collect(lt.CutIdle(rootTime.Add(1500*time.Millisecond), false))
 	require.Equal(t, 0, len(cutTraces))
 
 	// cut at 2.5 seconds, should cut the trace b/c it's been idle for 1.5 seconds
-	cutTraces = lt.CutIdle(rootTime.Add(2500*time.Millisecond), false)
+	cutTraces = slices.Collect(lt.CutIdle(rootTime.Add(2500*time.Millisecond), false))
 	require.Equal(t, 1, len(cutTraces))
 	require.Equal(t, id, cutTraces[0].ID)
 
@@ -98,7 +98,7 @@ func TestCutIdleDueToLiveTime(t *testing.T) {
 	require.NoError(t, err)
 
 	// cut at 500 ms, should cut nothing
-	cutTraces := lt.CutIdle(rootTime.Add(500*time.Millisecond), false)
+	cutTraces := slices.Collect(lt.CutIdle(rootTime.Add(500*time.Millisecond), false))
 	require.Equal(t, 0, len(cutTraces))
 
 	// push at 1 second
@@ -106,12 +106,12 @@ func TestCutIdleDueToLiveTime(t *testing.T) {
 	require.NoError(t, err)
 
 	// cut at 1.5 seconds, should cut the trace b/c it's been live for 1.5 seconds!
-	cutTraces = lt.CutIdle(rootTime.Add(1500*time.Millisecond), false)
+	cutTraces = slices.Collect(lt.CutIdle(rootTime.Add(1500*time.Millisecond), false))
 	require.Equal(t, 1, len(cutTraces))
 	require.Equal(t, id, cutTraces[0].ID)
 
 	// cut at 2.5 seconds, should cut nothing
-	cutTraces = lt.CutIdle(rootTime.Add(2500*time.Millisecond), false)
+	cutTraces = slices.Collect(lt.CutIdle(rootTime.Add(2500*time.Millisecond), false))
 	require.Equal(t, 0, len(cutTraces))
 
 	require.Equal(t, 0, len(lt.Traces))
@@ -178,7 +178,9 @@ func BenchmarkLiveTracesRead(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		// This won't anything, instead of will benchmark the map iteration performance.
-		lt.CutIdle(time.Now().Add(-time.Hour), false)
+		// This won't cut anything, instead will benchmark the map iteration performance.
+		//nolint:revive
+		for range lt.CutIdle(time.Now().Add(-time.Hour), false) {
+		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: when cutting live traces in `cutIdleTraces` it could be that block can exceed MaxBlockBytes, especially when there are big live traces, which can result in ignoring the config. This PR preliminary cuts head block for such case.

About this check in tests:
```go
		// block size estimation can be x5 off, so we check that that block size at least makes sense
		assert.LessOrEqual(t, blk.DataLength(), inst.Cfg.MaxBlockBytes*5,
			"WAL block %s exceeds MaxBlockBytes: %d > %d", id, blk.DataLength(), inst.Cfg.MaxBlockBytes)
```

Apparently `estimateMarshalledSizeFromTrace` can be off x5 times from real size. I checked for vparquet4 and 5 for a testing trace generated by `test.MakeTraceWithSpanCount(50, 100, id)`:

vp5:
actual size: 21'133'126
estimated size: 5'242'880
vp4:
actual size: 21'133'669
estimated size: 5'242'880

Therefore, in the test I just do a sanity check. Without the fix the test fails and catches the bug.
The problem with `estimateMarshalledSizeFromTrace` will be fixed separatly.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`