### PR TITLE
fix(vulture): honor -tempo-push-tls flag in normal operating mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [BUGFIX] Fix tempo-vulture ignoring `-tempo-push-tls` flag in normal operating mode. [#6974](https://github.com/grafana/tempo/pull/6974) (@xaque208)
 * [CHANGE] **BREAKING CHANGE** Remove duplicate "compaction" prefix from CompactorConfig CLI flags. Affected flags: `compaction.block-retention`, `compaction.max-objects-per-block`, `compaction.max-block-bytes`, `compaction.compaction-window`. [#6909](https://github.com/grafana/tempo/pull/6909) (@electron0zero)
 * [CHANGE] **BREAKING CHANGE** Centralize block and WAL config: `block_builder` and `live_store` now always use `storage.trace.block` settings; per-module block config fields are removed. [#6647](https://github.com/grafana/tempo/pull/6647) (@stoewer)
 * [CHANGE] **BREAKING CHANGE** Remove Opencensus receiver [#6523](https://github.com/grafana/tempo/pull/6523) (@javiermolinar)

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -165,7 +165,7 @@ func main() {
 	}
 
 	logger.Info("Tempo Vulture starting", zap.String("tempoQueryURL", vultureConfig.tempoQueryURL), zap.String("tempoPushURL", pushEndpoint))
-	jaegerClient, err := utilpkg.NewJaegerToOTLPExporter(pushEndpoint)
+	jaegerClient, err := utilpkg.NewJaegerToOTLPExporterWithAuth(pushEndpoint, "", "", vultureConfig.tempoPushTLS)
 	httpClient := createHTTPClient(vultureConfig.tempoQueryURL, vultureConfig.tempoOrgID, vultureConfig.tempoQueryLiveStores)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
**What this PR does**:

`NewJaegerToOTLPExporter` (used in the normal operating path) hardcoded `useTLS=false`, silently ignoring the `-tempo-push-tls` flag. The flag was already wired correctly in the validation-mode path via `NewJaegerToOTLPExporterWithAuth`. This PR applies the same call in the normal path so that TLS is actually used when `-tempo-push-tls=true` is set.

**Which issue(s) this PR fixes**:
N/A (bug discovered during deployment)

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`