### PR TITLE
[DOC] Updates to Set up for K8s for v3

### DIFF
--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
@@ -76,13 +76,13 @@ Tanka requires the current context for your Kubernetes environment.
 
 ## Install libraries
 
-Install the `k.libsonnet`, Jsonnet, and Memcachd libraries.
+Install the `k.libsonnet`, Jsonnet, and Memcached libraries.
 
-1. Install `k.libsonnet` for your version of Kubernetes:
+1. Install `k.libsonnet` for your version of Kubernetes. Set `K8S_VERSION` to match your cluster's minor version (for example, `1.32`):
 
    ```bash
    mkdir -p lib
-   export K8S_VERSION=1.25
+   export K8S_VERSION=1.32
    jb install github.com/jsonnet-libs/k8s-libsonnet/${K8S_VERSION}@main
    cat <<EOF > lib/k.libsonnet
    import 'github.com/jsonnet-libs/k8s-libsonnet/${K8S_VERSION}/main.libsonnet'
@@ -167,10 +167,10 @@ Install the `k.libsonnet`, Jsonnet, and Memcachd libraries.
                - --console-address
                - ':9001'
              env:
-               # Minio access key and secret key
-               - name: MINIO_ACCESS_KEY
+               # MinIO root credentials
+               - name: MINIO_ROOT_USER
                  value: 'minio'
-               - name: MINIO_SECRET_KEY
+               - name: MINIO_ROOT_PASSWORD
                  value: 'minio123'
              ports:
                - containerPort: 9000
@@ -226,10 +226,9 @@ Install the `k.libsonnet`, Jsonnet, and Memcachd libraries.
    local containerPort = k.core.v1.containerPort;
 
    tempo {
-       _images+:: {
-           tempo: 'grafana/tempo:latest',
-           tempo_query: 'grafana/tempo-query:latest',
-       },
+    _images+:: {
+          tempo: 'grafana/tempo:latest',
+      },
 
        tempo_distributor_container+:: container.withPorts([
                containerPort.new('jaeger-grpc', 14250),
@@ -329,7 +328,11 @@ Install the `k.libsonnet`, Jsonnet, and Memcachd libraries.
                 },
             },
             overrides+: {
-                metrics_generator_processors: ['service-graphs', 'span-metrics'],
+                defaults+: {
+                    metrics_generator+: {
+                        processors: ['service-graphs', 'span-metrics'],
+                    },
+                },
             },
         },
     }
@@ -346,7 +349,7 @@ In the preceding configuration, [metrics generation](/docs/tempo/<TEMPO_VERSION>
 If you'd like to remote write these metrics onto a Prometheus compatible instance (such as Grafana Cloud metrics or a Mimir instance), you'll need to include the configuration block below in the `metrics_generator` section of the `tempo_config` block above (this assumes basic auth is required, if not then remove the `basic_auth` section).
 You can find the details for your Grafana Cloud metrics instance for your Grafana Cloud account by using the [Cloud Portal](/docs/grafana-cloud/account-management/cloud-portal/).
 
-````jsonnet
+```jsonnet
 storage+: {
     remote_write: [
         {
@@ -419,7 +422,7 @@ The Tempo instance will now accept the two configured trace protocols (OTLP gRPC
 - OTLP gRPC: `4317`
 - Jaeger gRPC: `14250`
 
-You can query Tempo using the `query-frontend.tempo.svc.cluster.local` service on port `3200` for Tempo queries or port `16686` or `16687` for Jaeger type queries.
+You can query Tempo using the `query-frontend.tempo.svc.cluster.local` service on port `3200`.
 
 Now that you've configured a Tempo cluster, you'll need to validate your deployment.
 Refer to the [Validate Kubernetes deployment using a test application](/docs/tempo/<TEMPO_VERSION>/set-up-for-tracing/setup-tempo/test/set-up-test-app/) for instructions.

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/test/set-up-test-app.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/test/set-up-test-app.md
@@ -18,8 +18,12 @@ For example, if you [set up Tempo using the Kubernetes with Tanka procedure](../
 You'll need:
 
 - Grafana 10.0.0 or higher
-- Microservice deployments require the Tempo querier URL, for example: `http://tempo-cluster-query-frontend.tempo.svc.cluster.local:3100/`
+- Microservice deployments require the Tempo query frontend URL, for example: `http://<QUERY-FRONTEND-SERVICE>.<NAMESPACE>.svc.cluster.local:3200/`
 - [OpenTelemetry telemetrygen](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/cmd/telemetrygen) for generating tracing data
+
+{{< admonition type="note" >}}
+Service names depend on how you deployed Tempo. For Tanka deployments, services use plain names like `distributor` and `query-frontend`. For Helm deployments, services are prefixed with the release name, for example `tempo-cluster-distributor`. Update the service names in the examples below to match your deployment.
+{{< /admonition >}}
 
 Refer to [Deploy Grafana on Kubernetes](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/installation/kubernetes/) if you are using Kubernetes.
 Otherwise, refer to [Install Grafana](/docs/grafana/<GRAFANA_VERSION>/setup-grafana/installation/) for more information.
@@ -33,7 +37,7 @@ You can skip this section if you have already configured Alloy to send traces to
 [//]: # "Shared content for best practices for traces"
 [//]: # "This content is located in /tempo/docs/sources/shared/alloy-remote-write-tempo.md"
 
-{{< docs/shared source="tempo" lookup="alloy-remote-write-tempo.md" version="next" >}}
+{{< docs/shared source="tempo" lookup="alloy-remote-write-tempo.md" version="latest">}}
 
 ## Create a Grafana Tempo data source
 
@@ -41,12 +45,14 @@ To allow Grafana to read traces from Tempo, you must create a Tempo data source.
 
 1. Navigate to **Connections** > **Data Sources**.
 
-1. Click on **Add data source**.
+1. Click **Add data source**.
 
 1. Select **Tempo**.
 
-1. Set the URL to `http://<TEMPO-QUERY-FRONTEND-SERVICE>:<HTTP-LISTEN-PORT>/`, filling in the path to the Tempo query frontend service and the configured HTTP API prefix.
-   If you followed [Deploy Tempo with Helm installation example](/docs/tempo/latest/set-up-for-tracing/setup-tempo/deploy/kubernetes/helm-chart/), the query frontend service's URL looks something like this: `http://tempo-cluster-query-frontend.<NAMESPACE>.svc.cluster.local:3100`
+1. Set the URL to `http://<TEMPO-QUERY-FRONTEND-SERVICE>:<HTTP-LISTEN-PORT>/`, filling in the path to the Tempo query frontend service and the HTTP listen port (default `3200`).
+   For example:
+   - Tanka deployment: `http://query-frontend.tempo.svc.cluster.local:3200`
+   - Helm deployment: `http://tempo-cluster-query-frontend.<NAMESPACE>.svc.cluster.local:3200`
 
 1. Click **Save & Test**.
 
@@ -61,35 +67,38 @@ For more information, refer to [Tempo in Grafana](https://grafana.com/docs/tempo
 
 You can use [OpenTelemetry `telemetrygen`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/cmd/telemetrygen) to generate tracing data to test your Tempo installation.
 
-These instructions use the endpoints for both Grafana Alloy and the Tempo distributor used previously, for example:
+These instructions use the endpoints for both Grafana Alloy and the Tempo distributor, for example:
 
 - `grafana-alloy.grafana-alloy.svc.cluster.local` for Grafana Alloy
-- `tempo-cluster-distributor.tempo.svc.cluster.local` for the Tempo distributor
+- `distributor.tempo.svc.cluster.local` for the Tempo distributor (Tanka deployment)
 
-Update the endpoints if you have altered the endpoint targets.
+Update the endpoints to match your deployment.
 
 1. Install `telemetrygen` using the [installation procedure](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/cmd/telemetrygen).
-   **NOTE**: You don't need to configure an OpenTelemetry Collector because we're using Grafana Alloy.
 
-2. Generate traces using `telemetrygen`:
+   {{< admonition type="note" >}}
+   You don't need to configure an OpenTelemetry Collector because this procedure uses Grafana Alloy.
+   {{< /admonition >}}
+
+1. Generate traces using `telemetrygen`:
    ```bash
    telemetrygen traces --otlp-insecure --rate 20 --duration 5s --otlp-endpoint grafana-alloy.grafana-alloy.svc.cluster.local:4317
    ```
    This configuration sends traces to Alloy for 5 seconds, at a rate of 20 traces per second.
 
-Optionally, you can also send the trace directly to the Tempo database without using Alloy as a collector by using the following:
+   Optionally, you can also send traces directly to Tempo without using Alloy as a collector:
 
-```bash
-telemetrygen traces --otlp-insecure --rate 20 --duration 5s --otlp-endpoint tempo-cluster-distributor.tempo.svc.cluster.local:4317
-```
+   ```bash
+   telemetrygen traces --otlp-insecure --rate 20 --duration 5s --otlp-endpoint distributor.tempo.svc.cluster.local:4317
+   ```
 
-If you're running `telemetrygen` on your local machine, ensure that you first port-forward to the relevant Alloy or Tempo distributor service, for example:
+   If you're running `telemetrygen` on your local machine, ensure that you first port-forward to the relevant Alloy or Tempo distributor service, for example:
 
-```bash
-kubectl port-forward services/grafana-alloy 4317:4317 --namespace grafana-alloy
-```
+   ```bash
+   kubectl port-forward services/grafana-alloy 4317:4317 --namespace grafana-alloy
+   ```
 
-3. Alternatively, you can create a cronjob to send traces periodically based on this template:
+1. Alternatively, you can create a cronjob to send traces periodically based on this template:
 
    ```
    apiVersion: batch/v1
@@ -109,7 +118,7 @@ kubectl port-forward services/grafana-alloy 4317:4317 --namespace grafana-alloy
            spec:
              containers:
              - name: traces
-               image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.96.0
+               image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
                args:
                  - traces
                  - --otlp-insecure
@@ -136,16 +145,14 @@ To view the tracing data:
 
 ### Test your configuration using the Intro to MLTP application
 
-The Intro to MLTP application provides an example five-service application generates data for Tempo, Mimir, Loki, and Pyroscope.
+The Intro to MLTP application provides an example five-service application that generates data for Tempo, Mimir, Loki, and Pyroscope.
 This procedure installs the application on your cluster so you can generate meaningful test data.
 
-1. Navigate to https://github.com/grafana/intro-to-mltp to get the Kubernetes manifests for the Intro to MLTP application.
-1. Clone the repository using commands similar to the ones below:
+1. Clone the [Intro to MLTP repository](https://github.com/grafana/intro-to-mltp):
    ```bash
-     git clone git+ssh://github.com/grafana/intro-to-mltp
-     cp intro-to-mltp/k8s/mythical/* ~/tmp/intro-to-mltp-k8s
+   git clone https://github.com/grafana/intro-to-mltp.git
+   cd intro-to-mltp/k8s/mythical
    ```
-1. Change to the cloned repository: `cd intro-to-mltp/k8s/mythical`
 1. In the `mythical-beasts-deployment.yaml` manifest, alter each `TRACING_COLLECTOR_HOST` environment variable instance value to point to the Grafana Alloy location. For example, based on Alloy installed in the default namespace and with a Helm installation called `test`:
    ```yaml
     	- env:

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/test/set-up-test-app.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/test/set-up-test-app.md
@@ -18,7 +18,7 @@ For example, if you [set up Tempo using the Kubernetes with Tanka procedure](../
 You'll need:
 
 - Grafana 10.0.0 or higher
-- Microservice deployments require the Tempo query frontend URL, for example: `http://<QUERY-FRONTEND-SERVICE>.<NAMESPACE>.svc.cluster.local:3200/`
+- Microservice deployments require the Tempo query frontend URL, for example: `http://<TEMPO-QUERY-FRONTEND-SERVICE>.<NAMESPACE>.svc.cluster.local:3200/`
 - [OpenTelemetry telemetrygen](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/cmd/telemetrygen) for generating tracing data
 
 {{< admonition type="note" >}}

--- a/docs/sources/tempo/shared/alloy-remote-write-tempo.md
+++ b/docs/sources/tempo/shared/alloy-remote-write-tempo.md
@@ -63,8 +63,8 @@ To do this, you need to create a configuration that can be used by Alloy to rece
          otelcol.exporter.otlp "tempo" {
              // Define the client for exporting.
              client {
-                 // Send to the locally running Tempo instance, on port 4317 (OTLP gRPC).
-                 endpoint = "tempo-cluster-distributor.tempo.svc.cluster.local:4317"
+                // Send to the Tempo distributor on port 4317 (OTLP gRPC).
+                endpoint = "distributor.tempo.svc.cluster.local:4317"
                  // Disable TLS for OTLP export.
                  tls {
                      // The connection is insecure.
@@ -76,13 +76,10 @@ To do this, you need to create a configuration that can be used by Alloy to rece
          }
    ```
 
-   Ensure that you use the specific namespace you've installed Tempo in for the OTLP exporter. In the line:
+   Update the distributor endpoint to match your deployment. The service name and namespace depend on how you deployed Tempo:
 
-   ```
-   endpoint = "tempo-cluster-distributor.tempo.svc.cluster.local:4317"
-   ```
-
-   change `tempo` to reference the namespace where Tempo is installed, for example: `tempo-cluster-distributor.my-tempo-namespace.svc.cluster.local:4317`.
+   - Tanka: `distributor.<NAMESPACE>.svc.cluster.local:4317`
+   - Helm: `<RELEASE-NAME>-distributor.<NAMESPACE>.svc.cluster.local:4317`
 
 1. Deploy Alloy using Helm:
    ```bash

--- a/docs/sources/tempo/shared/alloy-remote-write-tempo.md
+++ b/docs/sources/tempo/shared/alloy-remote-write-tempo.md
@@ -58,7 +58,7 @@ To do this, you need to create a configuration that can be used by Alloy to rece
            }
          }
 
-         // Define an OTLP gRPC exporter to send all received traces to GET.
+         // Define an OTLP gRPC exporter to send all received traces to Tempo.
          // The unique label 'tempo' is added to uniquely identify this exporter.
          otelcol.exporter.otlp "tempo" {
              // Define the client for exporting.


### PR DESCRIPTION
**What this PR does**:

Updates the Deploy Kubernetes and test Kubernetes docs for v3: 

- `tanka.md` -- Fix Tempo 3.0 blockers: convert legacy overrides to new scoped format, update `K8S_VERSION` from 1.25 to 1.32, update deprecated MinIO env vars, remove unused `tempo_query` image and nonexistent Jaeger query ports.
- `set-up-test-app.md` -- Fix incorrect port (3100 -> 3200), replace Helm-specific service names with deployment-agnostic examples covering both Tanka and Helm, update telemetrygen image to v0.150.0, fix broken git clone URL.
- `alloy-remote-write-tempo.md` -- Replace Helm-specific `tempo-cluster-distributor` endpoint with generic `distributor` naming and add examples for both Tanka and Helm deployments.

**Which issue(s) this PR fixes**:
Part of https://github.com/grafana/tempo-squad/issues/1078

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`