### PR TITLE
Fix nil spanset dereference and ssBuf data race in metrics query path

### DIFF
--- a/operations/jsonnet-compiled/jsonnetfile.lock.json
+++ b/operations/jsonnet-compiled/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "7e2ef76a95fb762a2a744d850695a0f4c5d9a611",
+      "version": "142f1ceed0f31df01566cb93570d06d1bbcbf6ad",
       "sum": "0y3AFX9LQSpfWTxWKSwoLgbt0Wc9nnCwhMH2szKzHv0="
     },
     {
@@ -18,7 +18,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "7e2ef76a95fb762a2a744d850695a0f4c5d9a611",
+      "version": "142f1ceed0f31df01566cb93570d06d1bbcbf6ad",
       "sum": "zNTCDRaCqJUHjQSQRsxGR3jLrMP9tU7YNQb13dbm1bU="
     },
     {

--- a/operations/jsonnet-compiled/jsonnetfile.lock.json
+++ b/operations/jsonnet-compiled/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "142f1ceed0f31df01566cb93570d06d1bbcbf6ad",
+      "version": "7e2ef76a95fb762a2a744d850695a0f4c5d9a611",
       "sum": "0y3AFX9LQSpfWTxWKSwoLgbt0Wc9nnCwhMH2szKzHv0="
     },
     {
@@ -18,7 +18,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "142f1ceed0f31df01566cb93570d06d1bbcbf6ad",
+      "version": "7e2ef76a95fb762a2a744d850695a0f4c5d9a611",
       "sum": "zNTCDRaCqJUHjQSQRsxGR3jLrMP9tU7YNQb13dbm1bU="
     },
     {

--- a/pkg/traceql/ast.go
+++ b/pkg/traceql/ast.go
@@ -448,8 +448,8 @@ func (f *SpansetFilter) evaluate(input []*Spanset) ([]*Spanset, error) {
 	}
 
 	for i, ss := range input {
-		if len(ss.Spans) == 0 {
-			// This spanset is empty so it's dropped.
+		if ss == nil || len(ss.Spans) == 0 {
+			// This spanset is nil or empty so it's dropped.
 			fork(i)
 			continue
 		}

--- a/pkg/traceql/ast_test.go
+++ b/pkg/traceql/ast_test.go
@@ -795,6 +795,18 @@ func TestSpansetFilterEvaluate(t *testing.T) {
 			},
 		},
 		{
+			"{ true }",
+			[]*Spanset{
+				// Nil spanset is dropped without panic
+				nil,
+				{Spans: []Span{&mockSpan{}}},
+				nil,
+			},
+			[]*Spanset{
+				{Spans: []Span{&mockSpan{}}},
+			},
+		},
+		{
 			"{ .foo = `a` }",
 			[]*Spanset{
 				{Spans: []Span{

--- a/pkg/traceql/engine.go
+++ b/pkg/traceql/engine.go
@@ -95,7 +95,7 @@ func (e *Engine) ExecuteSearch(ctx context.Context, searchReq *tempopb.SearchReq
 	spansetsEvaluated := 0
 	// set up the expression evaluation as a filter to reduce data pulled
 	fetchSpansRequest.SecondPass = func(inSS *Spanset) ([]*Spanset, error) {
-		if len(inSS.Spans) == 0 {
+		if inSS == nil || len(inSS.Spans) == 0 {
 			return nil, nil
 		}
 

--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -1163,7 +1163,17 @@ func (e *Engine) CompileMetricsQueryRange(req *tempopb.QueryRangeRequest, opts .
 		me.mtx.Lock()
 		defer me.mtx.Unlock()
 		ssBuf[0] = s
-		return eval(ssBuf)
+		result, err := eval(ssBuf)
+		if err != nil {
+			return nil, err
+		}
+		// Pipeline.evaluate can return the input slice directly (no-fork path).
+		// Since that slice is the shared ssBuf, we must copy before releasing
+		// the mutex so the caller doesn't race with the next call.
+		if len(result) > 0 && &result[0] == &ssBuf[0] {
+			return append(make([]*Spanset, 0, len(result)), result...), nil
+		}
+		return result, nil
 	}
 
 	optimize(storageReq)

--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -1156,6 +1156,9 @@ func (e *Engine) CompileMetricsQueryRange(req *tempopb.QueryRangeRequest, opts .
 	}
 	// Setup second pass callback.  It might be optimized away
 	storageReq.SecondPass = func(s *Spanset) ([]*Spanset, error) {
+		if s == nil || len(s.Spans) == 0 {
+			return nil, nil
+		}
 		// The traceql engine isn't thread-safe.
 		// But parallelization is required for good metrics performance.
 		// So we do external locking here.

--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -1155,25 +1155,13 @@ func (e *Engine) CompileMetricsQueryRange(req *tempopb.QueryRangeRequest, opts .
 		storageReq.SecondPassConditions = append(storageReq.SecondPassConditions, meta...)
 	}
 	// Setup second pass callback.  It might be optimized away
-	ssBuf := make([]*Spanset, 1)
 	storageReq.SecondPass = func(s *Spanset) ([]*Spanset, error) {
 		// The traceql engine isn't thread-safe.
 		// But parallelization is required for good metrics performance.
 		// So we do external locking here.
 		me.mtx.Lock()
 		defer me.mtx.Unlock()
-		ssBuf[0] = s
-		result, err := eval(ssBuf)
-		if err != nil {
-			return nil, err
-		}
-		// Pipeline.evaluate can return the input slice directly (no-fork path).
-		// Since that slice is the shared ssBuf, we must copy before releasing
-		// the mutex so the caller doesn't race with the next call.
-		if len(result) > 0 && &result[0] == &ssBuf[0] {
-			return append(make([]*Spanset, 0, len(result)), result...), nil
-		}
-		return result, nil
+		return eval([]*Spanset{s})
 	}
 
 	optimize(storageReq)


### PR DESCRIPTION
**What this PR does**:

Fixes a nil pointer dereference in `SpansetFilter.evaluate` and a data race in the metrics `SecondPass` callback.

<details>
<summary>Stack trace</summary>

```
1776350867596	2026-04-16T14:47:47.596Z	info: GOMEMLIMIT set to 7730941132 bytes (ratio: 0.80)
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/github.com/grafana/tempo/modules/livestore/instance_search.go:147 +0xd09
1776350867115	2026-04-16T14:47:47.115Z	created by github.com/grafana/tempo/modules/livestore.(*instance).iterateBlocks in goroutine 11104938
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/github.com/grafana/tempo/modules/livestore/instance_search.go:158 +0x325
1776350867115	2026-04-16T14:47:47.115Z	github.com/grafana/tempo/modules/livestore.(*instance).iterateBlocks.func4(0x1f05d7c83c40)
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/github.com/grafana/tempo/modules/livestore/instance_search.go:715 +0x258
1776350867115	2026-04-16T14:47:47.115Z	github.com/grafana/tempo/modules/livestore.(*instance).QueryRange.func1({0x3f235e8?, 0x1f063f8005d0?}, 0x1?, {0x3f618e0?, 0x1f05d7c83c40?})
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/github.com/grafana/tempo/modules/livestore/instance_search.go:816 +0x94d
1776350867115	2026-04-16T14:47:47.115Z	github.com/grafana/tempo/modules/livestore.(*instance).queryRangeCompleteBlock(0x1f05aa43e008, {0x3f235e8, 0x1f063f8005d0}, 0x1f05d7c83c40, {{0x1f05a8e9f9d0, 0x66}, 0x18a6dc10a045696c, 0x18a6dd8cd6043800, 0x45d964b800, {0x1f05b3a0f672, ...}, ...}, ...)
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/github.com/grafana/tempo/pkg/traceql/engine_metrics.go:1309 +0x3c8
1776350867115	2026-04-16T14:47:47.115Z	github.com/grafana/tempo/pkg/traceql.(*MetricsEvaluator).Do(0x1f05e8c88540, {0x3f235e8, 0x1f063f800600}, {0x3efdd08?, 0x1f063c4ed6e0?}, 0x1f05b3a0f672?, 0x6?, 0x2710)
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/github.com/grafana/tempo/tempodb/encoding/vparquet4/block_traceql.go:1430 +0x1f
1776350867115	2026-04-16T14:47:47.115Z	github.com/grafana/tempo/tempodb/encoding/vparquet4.(*spansetIterator).Next(0x1f05ca2b0c30?, {0x3f62180?, 0x1f05d71381e0?})
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/github.com/grafana/tempo/tempodb/encoding/vparquet4/block_traceql.go:1316 +0x199
1776350867115	2026-04-16T14:47:47.115Z	github.com/grafana/tempo/tempodb/encoding/vparquet4.(*rebatchIterator).Next(0x1f05e4e15470)
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/github.com/grafana/tempo/pkg/parquetquery/iters.go:1347 +0x317
1776350867115	2026-04-16T14:47:47.115Z	github.com/grafana/tempo/pkg/parquetquery.(*LeftJoinIterator).Next(0x1f05d959bb00)
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/github.com/grafana/tempo/pkg/parquetquery/iters.go:1584 +0x99
1776350867115	2026-04-16T14:47:47.115Z	github.com/grafana/tempo/pkg/parquetquery.(*LeftJoinIterator).collect(0x1f05d959bb00)
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/github.com/grafana/tempo/pkg/parquetquery/iters.go:1511 +0x9d
1776350867115	2026-04-16T14:47:47.115Z	github.com/grafana/tempo/pkg/parquetquery.(*LeftJoinIterator).collectRequired(0x1f05d959bb00, {0xd9, 0x0, 0x0, 0x5, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff})
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/github.com/grafana/tempo/pkg/parquetquery/iters.go:1347 +0x317
1776350867115	2026-04-16T14:47:47.115Z	github.com/grafana/tempo/pkg/parquetquery.(*LeftJoinIterator).Next(0x1f05d959b9e0)
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/github.com/grafana/tempo/pkg/parquetquery/iters.go:1584 +0x99
1776350867115	2026-04-16T14:47:47.115Z	github.com/grafana/tempo/pkg/parquetquery.(*LeftJoinIterator).collect(0x1f05d959b9e0)
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/github.com/grafana/tempo/pkg/parquetquery/iters.go:1511 +0x9d
1776350867115	2026-04-16T14:47:47.115Z	github.com/grafana/tempo/pkg/parquetquery.(*LeftJoinIterator).collectRequired(0x1f05d959b9e0, {0x8c, 0x3, 0x0, 0x1, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff})
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/github.com/grafana/tempo/pkg/parquetquery/iters.go:1347 +0x317
1776350867115	2026-04-16T14:47:47.115Z	github.com/grafana/tempo/pkg/parquetquery.(*LeftJoinIterator).Next(0x1f05d959b8c0)
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/github.com/grafana/tempo/pkg/parquetquery/iters.go:1584 +0x99
1776350867115	2026-04-16T14:47:47.115Z	github.com/grafana/tempo/pkg/parquetquery.(*LeftJoinIterator).collect(0x1f05d959b8c0)
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/github.com/grafana/tempo/pkg/parquetquery/iters.go:1511 +0x9d
1776350867115	2026-04-16T14:47:47.115Z	github.com/grafana/tempo/pkg/parquetquery.(*LeftJoinIterator).collectRequired(0x1f05d959b8c0, {0xd9, 0x0, 0x0, 0x1, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff})
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/github.com/grafana/tempo/pkg/parquetquery/iters.go:1347 +0x317
1776350867115	2026-04-16T14:47:47.115Z	github.com/grafana/tempo/pkg/parquetquery.(*LeftJoinIterator).Next(0x1f05d959b7a0)
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/github.com/grafana/tempo/pkg/parquetquery/iters.go:1584 +0x99
1776350867115	2026-04-16T14:47:47.115Z	github.com/grafana/tempo/pkg/parquetquery.(*LeftJoinIterator).collect(0x1f05d959b7a0)
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/github.com/grafana/tempo/pkg/parquetquery/iters.go:1511 +0x9d
1776350867115	2026-04-16T14:47:47.115Z	github.com/grafana/tempo/pkg/parquetquery.(*LeftJoinIterator).collectRequired(0x1f05d959b7a0, {0x2bf, 0x1, 0x0, 0x3, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff})
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/github.com/grafana/tempo/tempodb/encoding/vparquet4/block_traceql.go:1218 +0x21f
1776350867115	2026-04-16T14:47:47.115Z	github.com/grafana/tempo/tempodb/encoding/vparquet4.(*bridgeIterator).Next(0x1f05efcd8b80)
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/github.com/grafana/tempo/pkg/traceql/engine_metrics.go:1123 +0x10b
1776350867115	2026-04-16T14:47:47.115Z	github.com/grafana/tempo/pkg/traceql.(*Engine).CompileMetricsQueryRange.func2(0x1f05e4e15290?)
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/github.com/grafana/tempo/pkg/traceql/ast.go:238 +0x65
1776350867115	2026-04-16T14:47:47.115Z	github.com/grafana/tempo/pkg/traceql.Pipeline.evaluate({{0x1f063c4ed650?, 0x32f5460?, 0x3b502e0?}}, {0x1f06207e6288?, 0x425ab4?, 0x7efe31482d88?})
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/github.com/grafana/tempo/pkg/traceql/ast.go:451 +0x6e
1776350867115	2026-04-16T14:47:47.115Z	github.com/grafana/tempo/pkg/traceql.(*SpansetFilter).evaluate(0x1f063f800690, {0x1f06207e6288, 0x1, 0x1})
1776350867115	2026-04-16T14:47:47.115Z		/opt/hostedtoolcache/go/1.26.1/x64/src/runtime/panic.go:860 +0x13a
1776350867115	2026-04-16T14:47:47.115Z	panic({0x350d560?, 0x6738b50?})
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/go.opentelemetry.io/otel/sdk/trace/span.go:528 +0xc7b
1776350867115	2026-04-16T14:47:47.115Z	go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0x1f06206b0000, {0x0, 0x0, 0x1f05aa88e1e0?})
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/go.opentelemetry.io/otel/sdk/trace/span.go:478 +0x1b
1776350867115	2026-04-16T14:47:47.115Z	go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()
1776350867115	2026-04-16T14:47:47.115Z		/opt/hostedtoolcache/go/1.26.1/x64/src/runtime/panic.go:860 +0x13a
1776350867115	2026-04-16T14:47:47.115Z	panic({0x350d560?, 0x6738b50?})
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/go.opentelemetry.io/otel/sdk/trace/span.go:528 +0xc7b
1776350867115	2026-04-16T14:47:47.115Z	go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0x1f05a8e85a40, {0x0, 0x0, 0x1f05aa88e1e0?})
1776350867115	2026-04-16T14:47:47.115Z		/home/runner/work/cloud-traces/cloud-traces/vendor/go.opentelemetry.io/otel/sdk/trace/span.go:478 +0x1b
1776350867115	2026-04-16T14:47:47.115Z	go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()
1776350867115	2026-04-16T14:47:47.115Z	goroutine 11105027 [running]:
1776350867115	2026-04-16T14:47:47.115Z	
1776350867115	2026-04-16T14:47:47.115Z	[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x15bb66e]
1776350867115	2026-04-16T14:47:47.115Z	panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
```

</details>

**Changes:**

1. **Nil guard in `SpansetFilter.evaluate`** (`ast.go`): Add `ss == nil` check before accessing `ss.Spans` to prevent panic regardless of upstream cause.

2. **Fix `ssBuf` data race** (`engine_metrics.go`): The `SecondPass` callback used a shared `ssBuf` slice. When `Pipeline.evaluate` takes the no-fork path (all spans pass the filter), it returns the input slice directly. The mutex is released before the caller (bridge iterator) reads the returned slice. Another goroutine calling `SecondPass` could then overwrite `ssBuf[0]`, corrupting the first goroutine's view. Fix: allocate a fresh `[]*Spanset{s}` per call instead of reusing the shared buffer. Benchmarked against a 19GB block with 8.5M spans — no measurable regression.

3. **Nil guard in search `SecondPass`** (`engine.go`): Same defensive nil check for the search path's callback.

**Which issue(s) this PR fixes**:

N/A — production incident investigation.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`