### PR TITLE
[docs]: document backend scheduler/worker operational details

### DIFF
--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -905,7 +905,7 @@ Displays the current state of all jobs in the backend scheduler work cache.
 The response is a plain-text table with two sections:
 
 - **Active Jobs**: all jobs in the work cache, sorted by creation time. Use the `status` column to interpret each row. A non-empty `worker` field indicates the job is currently assigned to a worker.
-- **Pending Jobs**: redaction jobs waiting for compaction jobs that were active at submission time to complete before they can be issued as work.
+- **Pending Jobs**: redaction jobs in the pending queue. Some may already be eligible to run; others may still be waiting for the rescan or compaction preconditions to clear.
 
 This endpoint is only available when the backend scheduler component is running.
 

--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -904,8 +904,8 @@ Displays the current state of all jobs in the backend scheduler work cache.
 
 The response is a plain-text table with two sections:
 
-- **Active Jobs**: all jobs in the work cache, sorted by creation time. Use the `status` column to interpret each row. A non-empty `worker` field indicates the job is currently assigned to a worker.
-- **Pending Jobs**: redaction jobs in the pending queue. Some may already be eligible to run; others may still be waiting for the rescan or compaction preconditions to clear.
+- Active Jobs: all jobs in the work cache, sorted by creation time. Use the `status` column to interpret each row. A non-empty `worker` field indicates the job is currently assigned to a worker.
+- Pending Jobs: redaction jobs in the pending queue. Some may already be eligible to run; others may still be waiting for the rescan or compaction preconditions to clear.
 
 This endpoint is only available when the backend scheduler component is running.
 

--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -52,6 +52,7 @@ For externally supported gRPC API, [refer to Tempo gRPC API](#tempo-grpc-api).
 | [Partition ring status](#partition-ring-status)                                       | Distributor, Querier, Live store          | HTTP | `GET /partition-ring`                                     |
 | [Status](#status)                                                                     | Status                                    | HTTP | `GET /status`                                             |
 | [List build information](#list-build-information)                                     | Status                                    | HTTP | `GET /api/status/buildinfo`                               |
+| [Backend scheduler job status](#backend-scheduler-job-status)                        | Backend scheduler                         | HTTP | `GET /status/backendscheduler`                            |
 | [MCP Server](https://grafana.com/docs/tempo/<TEMPO_VERSION>/api_docs/mcp-server) (\*) | MCP                                       |      | `/api/mcp`                                                |
 
 _(\*) This endpoint isn't always available, check the specific section for more details._
@@ -892,6 +893,21 @@ GET /api/status/buildinfo
 ```
 
 Exposes the build information in a JSON object. The fields are `version`, `revision`, `branch`, `buildDate`, `buildUser`, and `goVersion`.
+
+### Backend scheduler job status
+
+```
+GET /status/backendscheduler
+```
+
+Displays the current state of all jobs in the backend scheduler work cache.
+
+The response is a plain-text table with two sections:
+
+- **Active Jobs**: all jobs in the work cache, sorted by creation time. Use the `status` column to interpret each row. A non-empty `worker` field indicates the job is currently assigned to a worker.
+- **Pending Jobs**: redaction jobs waiting for compaction jobs that were active at submission time to complete before they can be issued as work.
+
+This endpoint is only available when the backend scheduler component is running.
 
 ## Tempo gRPC API
 

--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -900,7 +900,7 @@ Exposes the build information in a JSON object. The fields are `version`, `revis
 GET /status/backendscheduler
 ```
 
-Displays the current state of all jobs in the backend scheduler work cache.
+Displays the current state of all jobs in the backend scheduler work cache and the pending redaction queue.
 
 The response is a plain-text table with two sections:
 

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -1024,6 +1024,19 @@ backend_scheduler:
       # Minimum time between compaction cycles for a tenant
       [min_cycle_interval: <duration> | default = 30s]
 
+    # Redaction job configuration
+    redaction:
+
+      # How often to check for pending redaction jobs when the queue is empty
+      [poll_interval: <duration> | default = 2s]
+
+      # How long to wait before rescanning for output blocks from compaction
+      # jobs that were active when the redaction was submitted
+      [rescan_delay: <duration> | default = 5m]
+
+      # Maximum number of rescan attempts before requiring operator resubmission
+      [max_rescan_generations: <int> | default = 5]
+
   # How long to wait for a worker to complete a job before timing out internally
   [job_timeout: <duration> | default = 15s]
 

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -1031,7 +1031,8 @@ backend_scheduler:
       [poll_interval: <duration> | default = 2s]
 
       # How long to wait before rescanning for output blocks from compaction
-      # jobs that were active when the redaction was submitted
+      # jobs that were active when the redaction was submitted.
+      # Must be less than work.prune_age or Tempo will fail to start.
       [rescan_delay: <duration> | default = 5m]
 
       # Maximum number of rescan attempts before requiring operator resubmission

--- a/docs/sources/tempo/reference-tempo-architecture/components/compaction.md
+++ b/docs/sources/tempo/reference-tempo-architecture/components/compaction.md
@@ -111,8 +111,9 @@ This endpoint is useful for diagnosing stalled jobs, verifying that workers are 
 | `tempodb_blocklist_length` | Number of live blocks per tenant; high values indicate compaction is falling behind |
 | `tempodb_compaction_outstanding_blocks` | Outstanding blocks awaiting compaction per tenant; the primary autoscaling signal |
 
-The scheduler job metrics carry `tenant` and `job_type` labels.
+Most scheduler job metrics carry `tenant` and `job_type` labels; `tempo_backend_scheduler_job_duration_seconds` carries only `job_type`.
 The `job_type` label uses protobuf enum string values: `JOB_TYPE_COMPACTION`, `JOB_TYPE_RETENTION`, and `JOB_TYPE_REDACTION`.
+The duration histogram measures elapsed time from job creation to completion, not execution time alone.
 
 ## Monitoring
 

--- a/docs/sources/tempo/reference-tempo-architecture/components/compaction.md
+++ b/docs/sources/tempo/reference-tempo-architecture/components/compaction.md
@@ -20,16 +20,20 @@ This split makes compaction horizontally scalable—you can add workers to incre
 
 ### Job types
 
-The scheduler produces two types of jobs:
+The scheduler produces three types of jobs:
 
 - Compaction: merges small blocks into larger ones to reduce the number of blocks queriers need to scan and improve query performance.
 - Retention: deletes blocks older than the configured retention period.
+- Redaction: rewrites blocks to remove matching trace data from object storage.
 
 ### Job lifecycle
 
 The scheduler uses providers to generate jobs.
-The compaction provider periodically measures tenants and produces compaction jobs based on the blocklist.
-The retention provider produces retention jobs on a schedule.
+Each provider runs independently and feeds jobs into a shared channel.
+
+- The compaction provider periodically measures tenants and produces compaction jobs based on the blocklist.
+- The retention provider produces retention jobs on a schedule.
+- The redaction provider drains a persistent queue of pending redaction requests, waiting for any compaction jobs that were active at submission time to complete before the rewritten blocks are eligible for querying.
 
 When a worker calls `Next`, the scheduler assigns an available job and persists the assignment to a local work cache.
 The worker executes the job and calls `UpdateJob` with a success or failure status.
@@ -76,14 +80,50 @@ When a worker receives a shutdown signal,
 it has a configurable timeout (`finish_on_shutdown_timeout`) to complete the current job before being terminated.
 This prevents partially completed jobs from being left in an inconsistent state.
 
+## Scheduler status API
+
+The backend scheduler exposes an HTTP endpoint that shows the current state of all jobs:
+
+```
+GET /status/backendscheduler
+```
+
+The response is a plain-text table with two sections:
+
+- **Active jobs**: jobs currently assigned to a worker, with columns for tenant, job ID, type, status, worker, and timestamps.
+- **Pending jobs**: jobs queued but not yet assigned, with columns for tenant, job ID, type, block ID, and batch ID.
+
+This endpoint is useful for diagnosing stalled jobs, verifying that workers are consuming work, and checking whether a redaction request has been processed.
+
 ## Key metrics
 
 | Metric | Description |
 |---|---|
-| `tempodb_compaction_blocks_total` | Total blocks compacted |
+| `tempodb_compaction_blocks_total` | Blocks compacted |
 | `tempodb_compaction_bytes_written_total` | Bytes written during compaction |
 | `tempodb_retention_blocks_cleared_total` | Blocks deleted by retention |
+| `tempo_backend_scheduler_jobs_created_total` | Jobs created, by type (compaction, retention, redaction) |
+| `tempo_backend_scheduler_jobs_completed_total` | Jobs completed successfully, by type |
+| `tempo_backend_scheduler_jobs_failed_total` | Jobs that failed, by type |
+| `tempo_backend_scheduler_jobs_active` | Jobs currently assigned to a worker, by type |
+| `tempo_backend_scheduler_job_duration_seconds` | Job execution duration histogram |
+| `tempodb_blocklist_length` | Number of live blocks per tenant; high values indicate compaction is falling behind |
+| `tempodb_compaction_outstanding_blocks` | Outstanding blocks awaiting compaction per tenant; the primary autoscaling signal |
+
+## Monitoring
+
+The Tempo mixin ships a pre-built Grafana dashboard, **Tempo - Backend Work**, that covers:
+
+- Blocklist length and poll duration
+- Active, completed, failed, and retried job counts
+- Compaction throughput (objects written, bytes written, blocks compacted)
+- Outstanding blocks per tenant
+- CPU and memory for both the backend scheduler and backend workers
+- A backend-worker autoscaling panel
+
+To use the dashboard, install the Tempo mixin from `operations/tempo-mixin/` and import the generated dashboard into your Grafana instance.
 
 ## Related resources
 
-Refer to the [compaction configuration](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#compaction) for the full list of options.
+- [Compaction operations](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/compaction/) for timing requirements and block selection details.
+- [Configuration reference](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#backend-scheduler) for the full list of options.

--- a/docs/sources/tempo/reference-tempo-architecture/components/compaction.md
+++ b/docs/sources/tempo/reference-tempo-architecture/components/compaction.md
@@ -33,7 +33,7 @@ Each provider runs independently and feeds jobs into a shared channel.
 
 - The compaction provider periodically measures tenants and produces compaction jobs based on the blocklist.
 - The retention provider produces retention jobs on a schedule.
-- The redaction provider drains a persistent queue of pending redaction requests, waiting for any compaction jobs that were active at submission time to complete before the rewritten blocks are eligible for querying.
+- The redaction provider drains a persistent queue of pending redaction requests. The scheduler's rescan logic handles waiting for any compaction jobs that were active at submission time to complete before the rewritten blocks become eligible for querying.
 
 When a worker calls `Next`, the scheduler assigns an available job and persists the assignment to a local work cache.
 The worker executes the job and calls `UpdateJob` with a success or failure status.
@@ -91,7 +91,7 @@ GET /status/backendscheduler
 The response is a plain-text table with two sections:
 
 - **Active Jobs**: all jobs in the scheduler work cache, sorted by creation time. This includes jobs in any state -- use the `status` column to interpret each row. A non-empty `worker` field indicates the job is currently assigned to a worker.
-- **Pending Jobs**: redaction jobs that are waiting for compaction jobs active at submission time to complete before they can be issued as work.
+- **Pending Jobs**: redaction jobs in the pending queue. Some may already be eligible to run; others may still be waiting for the rescan or compaction preconditions to clear.
 
 This endpoint is useful for diagnosing stalled jobs, verifying that workers are consuming work, and checking whether a redaction request has been processed.
 
@@ -103,13 +103,16 @@ This endpoint is useful for diagnosing stalled jobs, verifying that workers are 
 | `tempodb_compaction_bytes_written_total` | Bytes written during compaction |
 | `tempodb_retention_marked_for_deletion_total` | Blocks marked for deletion by retention |
 | `tempodb_retention_deleted_total` | Blocks deleted by retention |
-| `tempo_backend_scheduler_jobs_created_total` | Jobs created, by type (compaction, retention, redaction) |
-| `tempo_backend_scheduler_jobs_completed_total` | Jobs completed successfully, by type |
-| `tempo_backend_scheduler_jobs_failed_total` | Jobs that failed, by type |
-| `tempo_backend_scheduler_jobs_active` | Jobs currently assigned to a worker, by type |
+| `tempo_backend_scheduler_jobs_created_total` | Jobs created |
+| `tempo_backend_scheduler_jobs_completed_total` | Jobs completed successfully |
+| `tempo_backend_scheduler_jobs_failed_total` | Jobs that failed |
+| `tempo_backend_scheduler_jobs_active` | Jobs currently assigned to a worker |
 | `tempo_backend_scheduler_job_duration_seconds` | Job execution duration histogram |
 | `tempodb_blocklist_length` | Number of live blocks per tenant; high values indicate compaction is falling behind |
 | `tempodb_compaction_outstanding_blocks` | Outstanding blocks awaiting compaction per tenant; the primary autoscaling signal |
+
+The scheduler job metrics carry `tenant` and `job_type` labels.
+The `job_type` label uses protobuf enum string values: `JOB_TYPE_COMPACTION`, `JOB_TYPE_RETENTION`, and `JOB_TYPE_REDACTION`.
 
 ## Monitoring
 

--- a/docs/sources/tempo/reference-tempo-architecture/components/compaction.md
+++ b/docs/sources/tempo/reference-tempo-architecture/components/compaction.md
@@ -90,8 +90,8 @@ GET /status/backendscheduler
 
 The response is a plain-text table with two sections:
 
-- **Active jobs**: jobs currently assigned to a worker, with columns for tenant, job ID, type, status, worker, and timestamps.
-- **Pending jobs**: jobs queued but not yet assigned, with columns for tenant, job ID, type, block ID, and batch ID.
+- **Active Jobs**: all jobs in the scheduler work cache, sorted by creation time. This includes jobs in any state -- use the `status` column to interpret each row. A non-empty `worker` field indicates the job is currently assigned to a worker.
+- **Pending Jobs**: redaction jobs that are waiting for compaction jobs active at submission time to complete before they can be issued as work.
 
 This endpoint is useful for diagnosing stalled jobs, verifying that workers are consuming work, and checking whether a redaction request has been processed.
 
@@ -101,7 +101,8 @@ This endpoint is useful for diagnosing stalled jobs, verifying that workers are 
 |---|---|
 | `tempodb_compaction_blocks_total` | Blocks compacted |
 | `tempodb_compaction_bytes_written_total` | Bytes written during compaction |
-| `tempodb_retention_blocks_cleared_total` | Blocks deleted by retention |
+| `tempodb_retention_marked_for_deletion_total` | Blocks marked for deletion by retention |
+| `tempodb_retention_deleted_total` | Blocks deleted by retention |
 | `tempo_backend_scheduler_jobs_created_total` | Jobs created, by type (compaction, retention, redaction) |
 | `tempo_backend_scheduler_jobs_completed_total` | Jobs completed successfully, by type |
 | `tempo_backend_scheduler_jobs_failed_total` | Jobs that failed, by type |

--- a/docs/sources/tempo/reference-tempo-architecture/components/compaction.md
+++ b/docs/sources/tempo/reference-tempo-architecture/components/compaction.md
@@ -90,8 +90,8 @@ GET /status/backendscheduler
 
 The response is a plain-text table with two sections:
 
-- **Active Jobs**: all jobs in the scheduler work cache, sorted by creation time. This includes jobs in any state -- use the `status` column to interpret each row. A non-empty `worker` field indicates the job is currently assigned to a worker.
-- **Pending Jobs**: redaction jobs in the pending queue. Some may already be eligible to run; others may still be waiting for the rescan or compaction preconditions to clear.
+- Active Jobs: all jobs in the scheduler work cache, sorted by creation time. This includes jobs in any state -- use the `status` column to interpret each row. A non-empty `worker` field indicates the job is currently assigned to a worker.
+- Pending Jobs: redaction jobs in the pending queue. Some may already be eligible to run; others may still be waiting for the rescan or compaction preconditions to clear.
 
 This endpoint is useful for diagnosing stalled jobs, verifying that workers are consuming work, and checking whether a redaction request has been processed.
 


### PR DESCRIPTION
**What this PR does**:

Updates documentation for the backend scheduler and backend worker to cover all three job providers and give operators the information they need to configure and monitor the system.

- `configuration/_index.md`: adds the missing `redaction:` provider block (`poll_interval`, `rescan_delay`, `max_rescan_generations`) to the backend scheduler configuration reference, including a note on the `rescan_delay < work.prune_age` startup constraint
- `reference-tempo-architecture/components/compaction.md`: fixes the job type count (two -> three), expands the lifecycle section to describe all three providers, adds a Scheduler status API section, expands the key metrics table with accurate metric names, and adds a Monitoring section pointing operators to the Tempo - Backend Work mixin dashboard
- `api_docs/_index.md`: adds `GET /status/backendscheduler` to the HTTP API endpoint table and documents its response format

Note: the Related resources link to `/operations/compaction/` in the architecture doc resolves once grafana/tempo#6988 merges.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`