### PR TITLE
Updates to address IA changes

### DIFF
--- a/docs/sources/tempo/introduction/glossary.md
+++ b/docs/sources/tempo/introduction/glossary.md
@@ -18,11 +18,27 @@ Active series
 Cardinality
 : {{< docs/glossary "cardinality" >}}
 
+<!-- TODO: Add child span to the website glossary (data/glossary.yaml) and replace with shortcode. -->
+Child span
+: A span that is nested within a parent span. Each child span represents a sub-operation or downstream call within the broader operation represented by its parent. A child span can itself be a parent of other child spans.
+
 Data source
 : {{< docs/glossary "data source" >}}
 
+<!-- TODO: Add event attribute to the website glossary (data/glossary.yaml) and replace with shortcode. -->
+Event attribute
+: A key-value pair attached to a span event, which represents a unique point in time during the span's duration. For more information, refer to [Span events](https://opentelemetry.io/docs/concepts/signals/traces/#span-events) in the OpenTelemetry documentation.
+
 Exemplar
 : {{< docs/glossary "exemplar" >}}
+
+<!-- TODO: Add intrinsics to the website glossary (data/glossary.yaml) and replace with shortcode. -->
+Intrinsics
+: The core, built-in fields that are fundamental to the identity and lifecycle of spans and traces. Intrinsic fields include name, duration, status, and kind. These fields are defined by the OpenTelemetry specification and are always present.
+
+<!-- TODO: Add link attribute to the website glossary (data/glossary.yaml) and replace with shortcode. -->
+Link attribute
+: A key-value pair attached to a span link. A span link associates one span with one or more causally related spans. For more information, refer to [Span Links](https://opentelemetry.io/docs/concepts/signals/traces/#span-links) in the OpenTelemetry documentation.
 
 Log
 : {{< docs/glossary "log" >}}
@@ -30,8 +46,27 @@ Log
 Metric
 : {{< docs/glossary "metric" >}}
 
+<!-- TODO: Add resource attribute to the website glossary (data/glossary.yaml) and replace with shortcode. -->
+Resource attribute
+: A key-value pair that represents information about the entity producing a span, such as the cluster name, namespace, pod, or container name.
+
+<!-- TODO: Add root span to the website glossary (data/glossary.yaml) and replace with shortcode. -->
+Root span
+: The first span in a trace, representing the initial request or operation. A root span has no parent span and serves as the top of the span tree.
+
+<!-- TODO: Add semantic attribute to the website glossary (data/glossary.yaml) and replace with shortcode. -->
+Semantic attribute
+: A standardized naming scheme for attributes shared across languages, frameworks, and runtimes, as defined by the OpenTelemetry specification. For more information, refer to [Trace Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/general/trace/) in the OpenTelemetry documentation.
+
 Span
 : {{< docs/glossary "span" >}}
+
+<!-- TODO: Add span attribute to the website glossary (data/glossary.yaml) and replace with shortcode. -->
+Span attribute
+: A key-value pair that contains metadata to annotate a span with information about the operation it tracks. For example, a span tracking an "add to cart" operation might include the user ID, item ID, and cart ID as span attributes.
+
+Spanset
+: {{< docs/glossary "spanset" >}}
 
 Trace
 : {{< docs/glossary "trace" >}}

--- a/docs/sources/tempo/introduction/glossary.md
+++ b/docs/sources/tempo/introduction/glossary.md
@@ -48,7 +48,7 @@ Metric
 
 <!-- TODO: Add resource attribute to the website glossary (data/glossary.yaml) and replace with shortcode. -->
 Resource attribute
-: A key-value pair that represents information about the entity producing a span, such as the cluster name, namespace, pod, or container name.
+: A key-value pair that represents information about the entity producing a span, such as the cluster name, namespace, Pod, or container name.
 
 <!-- TODO: Add root span to the website glossary (data/glossary.yaml) and replace with shortcode. -->
 Root span

--- a/docs/sources/tempo/set-up-for-tracing/_index.md
+++ b/docs/sources/tempo/set-up-for-tracing/_index.md
@@ -110,4 +110,4 @@ Grafana Tempo is the distributed tracing backend used to store and query traces.
 ## Visualize tracing data with Grafana
 
 Grafana and Grafana Cloud have a built-in Tempo data source that you can use to query Tempo and visualize traces.
-For more information, refer to the [Tempo data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/) and the [Tempo in Grafana](https://grafana.com/docs/tempo/<TEMPO_VERSION>/introduction/tempo-in-grafana/) topics.
+For more information, refer to the [Tempo data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/) and the [Visualize tracing data in Grafana](https://grafana.com/docs/tempo/<TEMPO_VERSION>/visualize-traces/) topics.

--- a/docs/sources/tempo/traceql/_index.md
+++ b/docs/sources/tempo/traceql/_index.md
@@ -1,7 +1,7 @@
 ---
 title: TraceQL
-menuTitle: TraceQL
-description: Learn about TraceQL, Tempo's query language for traces
+menuTitle: Query with TraceQL
+description: Learn about TraceQL, the query language for traces
 weight: 600
 aliases:
   - /docs/tempo/latest/traceql/
@@ -17,13 +17,12 @@ keywords:
 
 TraceQL is a query language designed for selecting traces in Tempo.
 
-Distributed traces contain a wealth of information, and tools like auto-instrumentation make it easy to start capturing data. Extracting value from traces can be much harder.
+Distributed traces contain a wealth of information, and tools like auto-instrumentation simplify the process of capturing data. Extracting value from traces can be much harder.
 For example, Tempo metrics-generator can aggregate traces into service graphs and span metrics, and exemplars allow you to navigate from a spike in API latency to a trace that contributed to that spike.
 But traces can do so much more.
 
 Traces are the flow of events throughout your components.
 They have a tree structure—-with a root, branches, and leaves—-arbitrary key/value data at any location, and of course timestamps.
-What new questions can be answered with this structure? More than just finding isolated events, can we find sequences of events?
 
 For example, you can use traces to perform root cause analyses (RCA) on a service outage and use TraceQL to pinpoint the root cause. Refer to [Diagnose errors with traces](/docs/tempo/<TEMPO_VERSION>/solutions-with-traces/traces-diagnose-errors/#diagnose-errors-with-traces) for a use case example.
 

--- a/docs/sources/tempo/visualize-traces/_index.md
+++ b/docs/sources/tempo/visualize-traces/_index.md
@@ -5,6 +5,7 @@ description: Use Grafana to visualize, query, and explore your tracing data with
 weight: 400
 aliases:
   - ../getting-started/tempo-in-grafana/ #/docs/tempo/latest/introduction/tempo-in-grafana/
+  - ../introduction/tempo-in-grafana/ # /docs/tempo/<TEMPO_VERSION>/introduction/tempo-in-grafana/
 
 ---
 

--- a/docs/sources/tempo/visualize-traces/_index.md
+++ b/docs/sources/tempo/visualize-traces/_index.md
@@ -2,7 +2,7 @@
 title: Visualize tracing data in Grafana
 menuTitle: Visualize data
 description: Use Grafana to visualize, query, and explore your tracing data with the built-in Tempo data source.
-weight: 400
+weight: 650
 aliases:
   - ../getting-started/tempo-in-grafana/ #/docs/tempo/latest/introduction/tempo-in-grafana/
   - ../introduction/tempo-in-grafana/ # /docs/tempo/<TEMPO_VERSION>/introduction/tempo-in-grafana/


### PR DESCRIPTION
**What this PR does**:

Address documentation IA feedback from [grafana/tempo-squad#816](https://github.com/grafana/tempo-squad/issues/816).

- **`docs/sources/tempo/visualize-traces/_index.md`** -- Move "Visualize tracing data in Grafana" from `introduction/` to a new top-level `visualize-traces/` section (weight 650, after TraceQL); add alias for old path
- **`docs/sources/tempo/introduction/glossary.md`** -- Add trace-structure terms: child span, event attribute, intrinsics, link attribute, resource attribute, root span, semantic attribute, span attribute, spanset
- **`docs/sources/tempo/set-up-for-tracing/_index.md`** -- Update "Visualize" link to point to new `visualize-traces/` location
- **`docs/sources/tempo/traceql/_index.md`** -- Minor cleanup

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/tempo-squad/issues/816

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`