### PR TITLE
chore: add find-stale-dependencies Claude skill

### DIFF
--- a/.claude/skills/find-stale-dependencies/SKILL.md
+++ b/.claude/skills/find-stale-dependencies/SKILL.md
@@ -93,11 +93,18 @@ Also record whether the dep is **quietly abandoned**: last release or `pushed_at
 
 ## Step 4 — Check for CVEs
 
-For each confirmed stale dep, fetch in parallel:
+For each confirmed stale dep, verify that the **current version in go.mod** falls within an unpatched advisory range — search results include already-fixed CVEs and must not trigger Critical on their own.
+
+Preferred: run `govulncheck` if available, which checks only the versions actually in use:
+```bash
+govulncheck -json ./... 2>/dev/null | jq -r '.Finding[] | select(.Trace != null) | .OSV'
+```
+
+Fallback: fetch the advisory list and cross-check the version manually:
 ```
 https://pkg.go.dev/search?m=vuln&q=<url-encoded-import-path>
 ```
-If vulnerability entries appear → mark as CVE-affected.
+For each advisory returned, fetch its detail page and verify that `<current-version>` is within the **affected** range and not in the **fixed** range. Only mark as **CVE-affected** if the current version is genuinely unpatched.
 
 ## Step 5 — Find replacement
 

--- a/.claude/skills/find-stale-dependencies/SKILL.md
+++ b/.claude/skills/find-stale-dependencies/SKILL.md
@@ -41,14 +41,14 @@ awk '/^require\s*\(/{p=1} p && !/\/\/ indirect/ && /^\t[a-z]/{print $1, $2} /^\)
 For `github.com/<owner>/<repo>/...` imports, the repo is `https://github.com/<owner>/<repo>`.
 
 For **all other imports** (vanity domains like `go.yaml.in/`, `gopkg.in/`, custom domains):
-1. Fetch `https://pkg.go.dev/<import-path>`
-2. Extract the repo link from:
-   ```html
-   <div class="UnitMeta-repo"><a href="REPO_URL">
+1. Resolve the source repository URL via the module proxy (module is usually already cached in vendor repos):
+   ```bash
+   go mod download -json <import-path>@<version> | jq -r '.Origin.URL // empty'
    ```
-3. Use that resolved GitHub URL for all subsequent checks
+2. If `.Origin.URL` is empty, fall back to `WebFetch` of `https://pkg.go.dev/<import-path>` and look for the source link.
+3. Use the resolved GitHub URL for all subsequent checks.
 
-Do not assume a vanity domain hosts its own repo — always follow the redirect via pkg.go.dev.
+Do not assume a vanity domain hosts its own repo — always resolve it first.
 
 ## Step 3 — Check repository staleness
 

--- a/.claude/skills/find-stale-dependencies/SKILL.md
+++ b/.claude/skills/find-stale-dependencies/SKILL.md
@@ -116,7 +116,7 @@ For each stale dep, run these in parallel:
 
 ```bash
 # Modules that depend on it (from the full dependency graph)
-go mod graph | awk '$2 ~ /^<module>@/ { print $1 }' | sort -u | wc -l
+go mod graph | awk -v mod="<module>@" '$2 ~ "^" mod { print $1 }' | sort -u | wc -l
 
 # Vendor packages that import it directly
 grep -r '"<import-path>' vendor/ --include="*.go" -l 2>/dev/null | xargs -r dirname | sort -u | wc -l

--- a/.claude/skills/find-stale-dependencies/SKILL.md
+++ b/.claude/skills/find-stale-dependencies/SKILL.md
@@ -116,7 +116,7 @@ For each stale dep, run these in parallel:
 
 ```bash
 # Modules that depend on it (from the full dependency graph)
-go mod graph | grep " <module>@" | cut -d' ' -f1 | sort -u | wc -l
+go mod graph | awk '$2 ~ /^<module>@/ { print $1 }' | sort -u | wc -l
 
 # Vendor packages that import it directly
 grep -r '"<import-path>' vendor/ --include="*.go" -l 2>/dev/null | xargs -r dirname | sort -u | wc -l

--- a/.claude/skills/find-stale-dependencies/SKILL.md
+++ b/.claude/skills/find-stale-dependencies/SKILL.md
@@ -75,7 +75,7 @@ If `gh` is unavailable, fall back to `WebFetch` of `https://github.com/<owner>/<
 
 - **Versioned import paths** (`/v2`, `/v8`, etc.): extract the major N from the path and check the last release for that specific major (use `per_page=100` — `--paginate` doesn't work with `--jq`):
   ```bash
-  MAJOR=$(echo "<import-path>" | grep -oP '/v\K[0-9]+' || echo "1")
+  MAJOR=$(echo "<import-path>" | sed -n 's|.*/v\([0-9][0-9]*\)$|\1|p'); MAJOR=${MAJOR:-1}
   gh api "repos/<owner>/<repo>/releases?per_page=100" --jq \
     "[.[] | select(.tag_name | startswith(\"v${MAJOR}.\"))] | sort_by(.published_at) | last | .published_at"
   ```

--- a/.claude/skills/find-stale-dependencies/SKILL.md
+++ b/.claude/skills/find-stale-dependencies/SKILL.md
@@ -46,7 +46,8 @@ For **all other imports** (vanity domains like `go.yaml.in/`, `gopkg.in/`, custo
    go mod download -json <import-path>@<version> | jq -r '.Origin.URL // empty'
    ```
 2. If `.Origin.URL` is empty, fall back to `WebFetch` of `https://pkg.go.dev/<import-path>` and look for the source link.
-3. Use the resolved GitHub URL for all subsequent checks.
+3. If both methods fail to produce a URL, **skip the dep and note it explicitly in the report** as "URL could not be resolved — skipped". Do not silently drop it.
+4. Use the resolved GitHub URL for all subsequent checks.
 
 Do not assume a vanity domain hosts its own repo — always resolve it first.
 

--- a/.claude/skills/find-stale-dependencies/SKILL.md
+++ b/.claude/skills/find-stale-dependencies/SKILL.md
@@ -126,10 +126,10 @@ For each stale dep, run these in parallel:
 
 ```bash
 # Modules that depend on it (from the full dependency graph)
-go mod graph | awk -v mod="<module>@" '$2 ~ "^" mod { print $1 }' | sort -u | wc -l
+go mod graph | awk -v mod="<module>@" 'index($2, mod) == 1 { print $1 }' | sort -u | wc -l
 
 # Vendor packages that import it directly
-grep -r '"<import-path>' vendor/ --include="*.go" -l 2>/dev/null | xargs -r dirname | sort -u | wc -l
+grep -r '"<import-path>' vendor/ --include="*.go" -l 2>/dev/null | awk 'NF { sub("/[^/]+$", "", $0); print }' | sort -u | wc -l
 ```
 
 Report both counts in the output.

--- a/.claude/skills/find-stale-dependencies/SKILL.md
+++ b/.claude/skills/find-stale-dependencies/SKILL.md
@@ -47,7 +47,9 @@ For **all other imports** (vanity domains like `go.yaml.in/`, `gopkg.in/`, custo
    ```
 2. If `.Origin.URL` is empty, fall back to `WebFetch` of `https://pkg.go.dev/<import-path>` and look for the source link.
 3. If both methods fail to produce a URL, **skip the dep and note it explicitly in the report** as "URL could not be resolved — skipped". Do not silently drop it.
-4. Use the resolved GitHub URL for all subsequent checks.
+4. **Branch by host**:
+   - **GitHub** (`https://github.com/...`): proceed with `gh api` calls in Step 3 as normal.
+   - **Non-GitHub** (GitLab, Bitbucket, Sourcehut, etc.): `gh api` does not apply. Use `WebFetch` of the resolved URL to check for archived/deprecated signals in the page content or README. Note in the report that the `go mod graph` blast-radius count is still available but `gh api`-based staleness details are not.
 
 Do not assume a vanity domain hosts its own repo — always resolve it first.
 

--- a/.claude/skills/find-stale-dependencies/SKILL.md
+++ b/.claude/skills/find-stale-dependencies/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: find-stale-dependencies
+description: Find stale direct Go dependencies by checking repository status, README, CVEs, blast radius, and usage context, then output a prioritized list
+allowed-tools: Bash, WebFetch, Grep, Read
+---
+
+# Find Stale Go Dependencies
+
+Scans all **direct** dependencies in `go.mod` for signs of abandonment and ranks them by risk.
+
+A dependency is **direct** if its line does NOT end with `// indirect`.
+
+## Staleness criteria (any one qualifies)
+
+- Repository is **archived**
+- README says: *deprecated*, *unmaintained*, *no longer maintained*, *use X instead*
+- Latest commit is **older than 2 years**
+
+## Step 1 — Extract direct dependencies
+
+Run this command to get all direct deps with versions (`.Indirect` is absent for direct deps, not `false`):
+
+```bash
+go mod edit -json | jq -r '.Require[] | select(.Indirect != true) | .Path + " " + .Version'
+```
+
+Fallback without `jq`:
+```bash
+awk '/^require\s*\(/{p=1} p && !/\/\/ indirect/ && /^\t[a-z]/{print $1, $2} /^\)/{p=0}' go.mod
+```
+
+**Skip these prefixes** (actively maintained by large orgs):
+`cloud.google.com`, `golang.org/x/`, `google.golang.org/`, `go.opentelemetry.io/`, `github.com/prometheus/`, `github.com/grafana/`, `github.com/Azure/`, `github.com/aws/`, `github.com/google/`, `github.com/hashicorp/`, `go.uber.org/`, `k8s.io/`
+
+**Extra scrutiny candidates** — check these even if the org is on the skip list:
+- Pseudo-versions (`v0.0.0-YYYYMMDD-hash`): if the embedded date is >2 years old, likely stale
+- Packages with `+incompatible` suffix: pre-modules era, often from inactive repos
+
+## Step 2 — Resolve the repository URL
+
+For `github.com/<owner>/<repo>/...` imports, the repo is `https://github.com/<owner>/<repo>`.
+
+For **all other imports** (vanity domains like `go.yaml.in/`, `gopkg.in/`, custom domains):
+1. Fetch `https://pkg.go.dev/<import-path>`
+2. Extract the repo link from:
+   ```html
+   <div class="UnitMeta-repo"><a href="REPO_URL">
+   ```
+3. Use that resolved GitHub URL for all subsequent checks
+
+Do not assume a vanity domain hosts its own repo — always follow the redirect via pkg.go.dev.
+
+## Step 3 — Check repository staleness
+
+Use the `gh` CLI for GitHub repos (issue multiple calls in parallel):
+
+```bash
+# Check archived status and last push date
+gh api repos/<owner>/<repo> --jq '{archived: .archived, pushed_at: .pushed_at}'
+
+# Fetch the README (first 60 lines is enough)
+gh api repos/<owner>/<repo>/readme --jq '.content' | base64 -d | head -60
+```
+
+If `gh` is unavailable, fall back to `WebFetch` of `https://github.com/<owner>/<repo>`.
+
+**Mark as stale if any of these are true:**
+- `archived: true`
+- README contains: *deprecated*, *unmaintained*, *no longer maintained*, *archived*, *use X instead*, *not actively maintained*, *paused maintenance*, *deprecation mode*
+- `pushed_at` is before **[today minus 2 years]**
+
+**Stop checking a dep once any one staleness signal fires** — no need to verify all three.
+
+**Major-version caveat**: `pushed_at` reflects activity across all branches and versions. For repos with multiple major versions, a recent `pushed_at` does not mean the version you depend on is maintained. Apply these additional checks:
+
+- **Versioned import paths** (`/v2`, `/v8`, etc.): extract the major N from the path and check the last release for that specific major (use `per_page=100` — `--paginate` doesn't work with `--jq`):
+  ```bash
+  MAJOR=$(echo "<import-path>" | grep -oP '/v\K[0-9]+' || echo "1")
+  gh api "repos/<owner>/<repo>/releases?per_page=100" --jq \
+    "[.[] | select(.tag_name | startswith(\"v${MAJOR}.\"))] | sort_by(.published_at) | last | .published_at"
+  ```
+  If the last vN release is >2 years old while a higher major exists → stale.
+
+- **Unversioned imports** (v0/v1): check whether a `/v2` successor exists in the same repo:
+  ```bash
+  gh api "repos/<owner>/<repo>/releases?per_page=100" --jq \
+    '[.[] | select(.tag_name | test("^v[2-9]"))] | length'
+  ```
+  If a higher major exists and v1 README or tags show no recent activity → likely frozen; check README for deprecation language.
+
+Also record whether the dep is **quietly abandoned**: last release or `pushed_at` before **[today minus 5 years]** with no explicit deprecation notice. Used for priority classification in step 7.
+
+## Step 4 — Check for CVEs
+
+For each confirmed stale dep, fetch in parallel:
+```
+https://pkg.go.dev/search?m=vuln&q=<url-encoded-import-path>
+```
+If vulnerability entries appear → mark as CVE-affected.
+
+## Step 5 — Find replacement
+
+For each stale dep, identify the recommended replacement:
+1. **README**: extract the suggested import path from phrases like "use X instead", "migrate to", "replaced by", "successor is"
+2. **pkg.go.dev**: check if the module page shows a "moved to" or "redirects to" notice
+
+If a replacement is found, check whether it's already in `go.mod`:
+```bash
+grep "^	<replacement-path> " go.mod
+```
+Report: **replacement already in go.mod** (migration effort only) vs **replacement not yet added** (requires dep bump + migration).
+
+## Step 6 — Measure blast radius
+
+For each stale dep, run these in parallel:
+
+```bash
+# Modules that depend on it (from the full dependency graph)
+go mod graph | grep " <module>@" | cut -d' ' -f1 | sort -u | wc -l
+
+# Vendor packages that import it directly
+grep -r '"<import-path>' vendor/ --include="*.go" -l 2>/dev/null | xargs -r dirname | sort -u | wc -l
+```
+
+Report both counts in the output.
+
+## Step 7 — Classify priority
+
+Assign priority using this decision order:
+
+1. **Critical** — has CVEs (from step 4)
+2. **High** — used in request/response handling, payload marshal/unmarshal, HTTP or gRPC middleware, authentication, or the networking stack
+3. **Medium** — quietly abandoned (>5 years since last commit, no explicit deprecation notice) but used only in internal utilities, CLI tools, or tests
+4. **Low** — stale but only used internally and last commit <5 years ago
+
+## Step 8 — Report
+
+Skip non-stale dependencies. Output only stale ones, sorted by priority:
+
+```
+## Stale Dependencies
+
+### Critical
+- `import/path@version` — reason: <archived | README says deprecated | last commit YYYY-MM-DD>
+  CVEs: <IDs or link>
+  Blast radius: N modules, M vendor packages
+  Replacement: `suggested/path` [already in go.mod | not yet added]
+  Recommendation: <replace with X | upgrade | remove>
+
+### High
+[same format, omit CVEs line]
+
+### Medium
+[same format]
+
+### Low
+[same format]
+```
+
+## Efficiency notes
+
+- **Parallel batching**: issue all `gh api` staleness checks for multiple repos in one turn; do the same for CVE fetches and blast radius greps
+- **Fail fast per dep**: once a staleness signal fires, skip remaining checks for that dep and move to replacement + blast radius
+- **CVE and blast radius in one batch**: after confirming staleness, fetch CVEs and measure blast radius simultaneously for all confirmed-stale deps

--- a/.claude/skills/find-stale-dependencies/SKILL.md
+++ b/.claude/skills/find-stale-dependencies/SKILL.md
@@ -26,7 +26,7 @@ go mod edit -json | jq -r '.Require[] | select(.Indirect != true) | .Path + " " 
 
 Fallback without `jq`:
 ```bash
-awk '/^require\s*\(/{p=1} p && !/\/\/ indirect/ && /^\t[a-z]/{print $1, $2} /^\)/{p=0}' go.mod
+awk '/^require\s*\(/{p=1} p && !/\/\/ indirect/ && /^\t[a-z]/{print $1, $2} /^\)/{p=0} /^require [a-z]/ && !/\/\/ indirect/{print $2, $3}' go.mod
 ```
 
 **Skip these prefixes** (actively maintained by large orgs):

--- a/.claude/skills/find-stale-dependencies/SKILL.md
+++ b/.claude/skills/find-stale-dependencies/SKILL.md
@@ -116,7 +116,7 @@ For each stale dep, identify the recommended replacement:
 
 If a replacement is found, check whether it's already in `go.mod`:
 ```bash
-grep "^	<replacement-path> " go.mod
+go mod edit -json | jq -r '.Require[].Path' | grep -Fx "<replacement-path>"
 ```
 Report: **replacement already in go.mod** (migration effort only) vs **replacement not yet added** (requires dep bump + migration).
 

--- a/.claude/skills/find-stale-dependencies/SKILL.md
+++ b/.claude/skills/find-stale-dependencies/SKILL.md
@@ -149,7 +149,7 @@ Report **replacement already in go.mod** (migration effort only) vs **replacemen
 Search the codebase for direct call sites:
 
 ```bash
-grep -rn "\"<import-path>" --include='*.go' . | head
+grep -rnF "\"<import-path>\"" --include='*.go' . | head
 ```
 
 Classify the usage as one of:

--- a/.claude/skills/find-stale-dependencies/SKILL.md
+++ b/.claude/skills/find-stale-dependencies/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: find-stale-dependencies
-description: Find stale direct Go dependencies by checking repository status, README, CVEs, blast radius, and usage context, then output a prioritized list
+description: Find stale direct Go dependencies by checking repository status, README, blast radius, and usage context, then output a prioritized list
 allowed-tools: Bash, WebFetch, Grep, Read
 ---
 
@@ -14,151 +14,166 @@ A dependency is **direct** if its line does NOT end with `// indirect`.
 
 - Repository is **archived**
 - README says: *deprecated*, *unmaintained*, *no longer maintained*, *use X instead*
-- Latest commit is **older than 2 years**
+- Latest commit (or last release for the depended-on major) is **older than 2 years**
+- Version itself is suspect (pinned to a >2-year-old pseudo-version, or `+incompatible`)
 
-## Step 1 — Extract direct dependencies
+## Step 1 — Run the data-collection script
 
-Run this command to get all direct deps with versions (`.Indirect` is absent for direct deps, not `false`):
+The skill ships with a script that gathers all deterministic facts about the project's direct dependencies in one pass: repo URL, GitHub archived/pushed_at, last release for the major, version-string smells, and blast radius.
 
 ```bash
-go mod edit -json | jq -r '.Require[] | select(.Indirect != true) | .Path + " " + .Version'
+.claude/skills/find-stale-dependencies/check-dependencies.sh > /tmp/deps-report.json
 ```
 
-Fallback without `jq`:
-```bash
-awk '/^require\s*\(/{p=1} p && !/\/\/ indirect/ && /^\t[a-z]/{print $1, $2} /^\)/{p=0} /^require [a-z]/ && !/\/\/ indirect/{print $2, $3}' go.mod
+The script:
+- Lists direct deps from `go mod edit -json`
+- Marks deps under trusted-org prefixes (`golang.org/x/`, `github.com/grafana/`, `github.com/google/`, `k8s.io/`, …) as `skipped`
+- Resolves vanity-domain modules (`go.yaml.in/`, `gopkg.in/`, …) via `go mod download -json` so non-GitHub origins are handled too
+- Flags suspect version strings (`+incompatible`, old pseudo-versions) via `extra_scrutiny`
+- Computes blast radius from `go mod graph` and `vendor/`
+
+Override the trusted-org list with `SKIP_PREFIXES=$'pfx1\npfx2'` if needed. Adjust parallelism with `PARALLELISM=N`.
+
+The output JSON has shape:
+
+```json
+{
+  "generated_at": "2026-05-05T12:00:00Z",
+  "module": "github.com/grafana/tempo",
+  "deps": [
+    {
+      "path": "github.com/foo/bar",
+      "version": "v1.2.3",
+      "skipped": false,
+      "extra_scrutiny": ["incompatible" | "old-pseudo-version"],
+      "repo_url": "https://github.com/foo/bar",
+      "github": {
+        "owner": "foo",
+        "name": "bar",
+        "archived": false,
+        "pushed_at": "2024-01-01T00:00:00Z",
+        "recent_releases": [
+          {"tag": "v1.2.3", "date": "2024-01-01T00:00:00Z"}
+        ]
+      },
+      "blast_radius": {"modules": 12, "vendor_packages": 3}
+    }
+  ]
+}
 ```
 
-**Skip these prefixes** (actively maintained by large orgs):
-`cloud.google.com`, `golang.org/x/`, `google.golang.org/`, `go.opentelemetry.io/`, `github.com/prometheus/`, `github.com/grafana/`, `github.com/Azure/`, `github.com/aws/`, `github.com/google/`, `github.com/hashicorp/`, `go.uber.org/`, `k8s.io/`
+`github` is `null` for non-GitHub origins (e.g., gopkg.in vanity paths the proxy doesn't resolve); `repo_url` carries the raw URL when available. `recent_releases` falls back to tag names with `date: null` when the repo publishes tags but no GitHub Releases.
 
-**Extra scrutiny candidates** — check these even if the org is on the skip list:
-- Pseudo-versions (`v0.0.0-YYYYMMDD-hash`): if the embedded date is >2 years old, likely stale
-- Packages with `+incompatible` suffix: pre-modules era, often from inactive repos
+`skipped: true` deps still carry their path/version but no other data — surface them only if `extra_scrutiny` is non-empty.
 
-## Step 2 — Resolve the repository URL
+## Step 2 — Pick the candidate set from the JSON
 
-For `github.com/<owner>/<repo>/...` imports, the repo is `https://github.com/<owner>/<repo>`.
+A dep is a **stale candidate** if any of these is true:
 
-For **all other imports** (vanity domains like `go.yaml.in/`, `gopkg.in/`, custom domains):
-1. Resolve the source repository URL via the module proxy (module is usually already cached in vendor repos):
-   ```bash
-   go mod download -json <import-path>@<version> | jq -r '.Origin.URL // empty'
-   ```
-2. If `.Origin.URL` is empty, fall back to `WebFetch` of `https://pkg.go.dev/<import-path>` and look for the source link.
-3. If both methods fail to produce a URL, **skip the dep and note it explicitly in the report** as "URL could not be resolved — skipped". Do not silently drop it.
-4. **Branch by host**:
-   - **GitHub** (`https://github.com/...`): proceed with `gh api` calls in Step 3 as normal.
-   - **Non-GitHub** (GitLab, Bitbucket, Sourcehut, etc.): `gh api` does not apply. Use `WebFetch` of the resolved URL to check for archived/deprecated signals in the page content or README. Note in the report that the `go mod graph` blast-radius count is still available but `gh api`-based staleness details are not.
+- `github.archived == true`
+- `github.pushed_at` is older than **today − 2 years**
+- `github.recent_releases` contains a release for a higher major than the path's `/vN` suffix (the depended-on major is frozen, a successor exists)
+- `extra_scrutiny` is non-empty
 
-Do not assume a vanity domain hosts its own repo — always resolve it first.
-
-## Step 3 — Check repository staleness
-
-Use the `gh` CLI for GitHub repos (issue multiple calls in parallel):
+Filter with jq:
 
 ```bash
-# Check archived status and last push date
-gh api repos/<owner>/<repo> --jq '{archived: .archived, pushed_at: .pushed_at}'
+TWO_YEARS_AGO=$(date -u -d '2 years ago' +%Y-%m-%dT%H:%M:%SZ)
+jq --arg cutoff "$TWO_YEARS_AGO" '
+  def path_major:
+    ((capture("/v(?<n>[0-9]+)$") | .n)? // "1") | tonumber;
+  def release_major(t):
+    (t | capture("^v(?<n>[0-9]+)\\.").n | tonumber)? // -1;
 
-# Fetch the README (first 60 lines is enough)
+  .deps | map(select(
+    (.skipped | not) and (
+      .github.archived == true
+      or (.github.pushed_at != null and .github.pushed_at < $cutoff)
+      or (
+        (.path | path_major) as $m
+        | (.github.recent_releases // []) | any(release_major(.tag) > $m)
+      )
+      or ((.extra_scrutiny // []) | length > 0)
+    )
+  ))
+' /tmp/deps-report.json
+```
+
+Skipped deps are also worth a second look when `extra_scrutiny` flags fire:
+
+```bash
+jq '.deps | map(select(.skipped and ((.extra_scrutiny // []) | length > 0)))' /tmp/deps-report.json
+```
+
+Stop checking a dep as soon as one criterion fires — no need to keep verifying.
+
+## Step 3 — Confirm via README (LLM judgment)
+
+For each candidate, fetch the README and look for explicit deprecation signals. Use `gh` for GitHub repos, `WebFetch` otherwise:
+
+```bash
 gh api repos/<owner>/<repo>/readme --jq '.content' | base64 -d | head -60
 ```
 
-If `gh` is unavailable, fall back to `WebFetch` of `https://github.com/<owner>/<repo>`.
+Confirming phrases:
 
-**Mark as stale if any of these are true:**
-- `archived: true`
-- README contains: *deprecated*, *unmaintained*, *no longer maintained*, *archived*, *use X instead*, *not actively maintained*, *paused maintenance*, *deprecation mode*
-- `pushed_at` is before **[today minus 2 years]**
+- *deprecated*, *unmaintained*, *no longer maintained*, *archived*
+- *use X instead*, *successor is X*, *replaced by X*, *moved to X*
+- *not actively maintained*, *paused maintenance*, *deprecation mode*
 
-**Stop checking a dep once any one staleness signal fires** — no need to verify all three.
+Record whether the README confirms staleness independently of the JSON signals — it strengthens the recommendation.
 
-**Major-version caveat**: `pushed_at` reflects activity across all branches and versions. For repos with multiple major versions, a recent `pushed_at` does not mean the version you depend on is maintained. Apply these additional checks:
+## Step 4 — Identify a replacement (LLM judgment)
 
-- **Versioned import paths** (`/v2`, `/v8`, etc.): extract the major N from the path and check the last release for that specific major (use `per_page=100` — `--paginate` doesn't work with `--jq`):
-  ```bash
-  MAJOR=$(echo "<import-path>" | sed -n 's|.*/v\([0-9][0-9]*\)$|\1|p'); MAJOR=${MAJOR:-1}
-  gh api "repos/<owner>/<repo>/releases?per_page=100" --jq \
-    "[.[] | select(.tag_name | startswith(\"v${MAJOR}.\"))] | sort_by(.published_at) | last | .published_at"
-  ```
-  If the last vN release is >2 years old while a higher major exists → stale.
+For each confirmed-stale dep:
 
-- **Unversioned imports** (v0/v1): check whether a `/v2` successor exists in the same repo:
-  ```bash
-  gh api "repos/<owner>/<repo>/releases?per_page=100" --jq \
-    '[.[] | select(.tag_name | test("^v[2-9]"))] | length'
-  ```
-  If a higher major exists and v1 README or tags show no recent activity → likely frozen; check README for deprecation language.
+1. Extract the recommended replacement from the README (phrases like *use X instead*, *migrate to*, *successor is*) or from a `pkg.go.dev` "moved to" notice.
+2. Check whether it's already in `go.mod`:
 
-Also record whether the dep is **quietly abandoned**: last release or `pushed_at` before **[today minus 5 years]** with no explicit deprecation notice. Used for priority classification in step 7.
-
-## Step 4 — Check for CVEs
-
-For each confirmed stale dep, verify that the **current version in go.mod** falls within an unpatched advisory range — search results include already-fixed CVEs and must not trigger Critical on their own.
-
-Preferred: run `govulncheck` if available, which checks only the versions actually in use:
-```bash
-govulncheck -json ./... 2>/dev/null | jq -r 'select(.finding.trace != null) | .finding.osv'
-```
-
-Fallback: fetch the advisory list and cross-check the version manually:
-```
-https://pkg.go.dev/search?m=vuln&q=<url-encoded-import-path>
-```
-For each advisory returned, fetch its detail page and verify that `<current-version>` is within the **affected** range and not in the **fixed** range. Only mark as **CVE-affected** if the current version is genuinely unpatched.
-
-## Step 5 — Find replacement
-
-For each stale dep, identify the recommended replacement:
-1. **README**: extract the suggested import path from phrases like "use X instead", "migrate to", "replaced by", "successor is"
-2. **pkg.go.dev**: check if the module page shows a "moved to" or "redirects to" notice
-
-If a replacement is found, check whether it's already in `go.mod`:
 ```bash
 go mod edit -json | jq -r '.Require[].Path' | grep -Fx "<replacement-path>"
 ```
-Report: **replacement already in go.mod** (migration effort only) vs **replacement not yet added** (requires dep bump + migration).
 
-## Step 6 — Measure blast radius
+Report **replacement already in go.mod** (migration effort only) vs **replacement not yet added** (requires dep bump + migration). If no replacement is identifiable, say so.
 
-For each stale dep, run these in parallel:
+## Step 5 — Determine usage context (LLM judgment)
+
+Search the codebase for direct call sites:
 
 ```bash
-# Modules that depend on it (from the full dependency graph)
-go mod graph | awk -v mod="<module>@" 'index($2, mod) == 1 { print $1 }' | sort -u | wc -l
-
-# Vendor packages that import it directly
-grep -r '"<import-path>' vendor/ --include="*.go" -l 2>/dev/null | awk 'NF { sub("/[^/]+$", "", $0); print }' | sort -u | wc -l
+grep -rn "\"<import-path>" --include='*.go' . | head
 ```
 
-Report both counts in the output.
+Classify the usage as one of:
 
-## Step 7 — Classify priority
+- **Hot path**: request/response handling, payload marshal/unmarshal, HTTP or gRPC middleware, authentication, networking stack
+- **Internal utility**: CLI tools, build helpers, internal logging, test fixtures
+- **Test-only**: only imported under `_test.go` files
 
-Assign priority using this decision order:
+This is what the JSON cannot give you — it requires reading the code.
 
-1. **Critical** — has CVEs (from step 4)
-2. **High** — used in request/response handling, payload marshal/unmarshal, HTTP or gRPC middleware, authentication, or the networking stack
-3. **Medium** — quietly abandoned (>5 years since last commit, no explicit deprecation notice) but used only in internal utilities, CLI tools, or tests
-4. **Low** — stale but only used internally and last commit <5 years ago
+## Step 6 — Classify priority
 
-## Step 8 — Report
+Use this decision order:
+
+1. **High** — confirmed deprecated/archived **and** on the hot path, **or** confirmed deprecated/archived **and** a maintained successor exists (migration is the obvious next step)
+2. **Medium** — quietly abandoned (>5 years since last activity, no explicit deprecation notice) but only used in internal utilities
+3. **Low** — stale but only used internally and last activity within the last 5 years
+
+The skill does not assign a Critical tier — vulnerabilities are handled by other tooling (govulncheck/Dependabot). If you do see a CVE-driven emergency on a stale dep, that's a security-tooling alert, not a staleness report.
+
+## Step 7 — Report
 
 Skip non-stale dependencies. Output only stale ones, sorted by priority:
 
 ```
 ## Stale Dependencies
 
-### Critical
-- `import/path@version` — reason: <archived | README says deprecated | last commit YYYY-MM-DD>
-  CVEs: <IDs or link>
-  Blast radius: N modules, M vendor packages
-  Replacement: `suggested/path` [already in go.mod | not yet added]
-  Recommendation: <replace with X | upgrade | remove>
-
 ### High
-[same format, omit CVEs line]
+- `import/path@version` — reason: <archived | README says deprecated | last commit YYYY-MM-DD | old-pseudo-version>
+  Blast radius: N modules, M vendor packages
+  Replacement: `suggested/path` [already in go.mod | not yet added | none]
+  Recommendation: <replace with X | upgrade | remove>
 
 ### Medium
 [same format]
@@ -169,6 +184,6 @@ Skip non-stale dependencies. Output only stale ones, sorted by priority:
 
 ## Efficiency notes
 
-- **Parallel batching**: issue all `gh api` staleness checks for multiple repos in one turn; do the same for CVE fetches and blast radius greps
-- **Fail fast per dep**: once a staleness signal fires, skip remaining checks for that dep and move to replacement + blast radius
-- **CVE and blast radius in one batch**: after confirming staleness, fetch CVEs and measure blast radius simultaneously for all confirmed-stale deps
+- The script does all the deterministic data collection in one pass — do not re-run individual `gh api` / `go mod` commands per dep
+- For LLM-only steps (README, usage context), batch the work: fetch all confirmed-stale READMEs in parallel `gh api` calls, then do all `grep` searches in parallel
+- Stop investigating a dep once one staleness signal is confirmed

--- a/.claude/skills/find-stale-dependencies/SKILL.md
+++ b/.claude/skills/find-stale-dependencies/SKILL.md
@@ -19,7 +19,7 @@ A dependency is **direct** if its line does NOT end with `// indirect`.
 
 ## Step 1 — Run the data-collection script
 
-The skill ships with a script that gathers all deterministic facts about the project's direct dependencies in one pass: repo URL, GitHub archived/pushed_at, last release for the major, version-string smells, and blast radius.
+The skill ships with a script that gathers all deterministic facts about the project's direct dependencies in one pass: repo URL, pkg.go.dev version timeline (with `deprecated`/`retracted` flags), GitHub `archived` status, and blast radius.
 
 ```bash
 .claude/skills/find-stale-dependencies/check-dependencies.sh > /tmp/deps-report.json
@@ -28,7 +28,9 @@ The skill ships with a script that gathers all deterministic facts about the pro
 The script:
 - Lists direct deps from `go mod edit -json`
 - Marks deps under trusted-org prefixes (`golang.org/x/`, `github.com/grafana/`, `github.com/google/`, `k8s.io/`, …) as `skipped`
-- Resolves vanity-domain modules (`go.yaml.in/`, `gopkg.in/`, …) via `go mod download -json` so non-GitHub origins are handled too
+- Queries pkg.go.dev's `/v1beta/versions/{path}` endpoint for the version timeline (works uniformly for GitHub, gopkg.in, and other vanity domains)
+- Detects whether a higher-major sibling module is published (`/v1beta/versions/{path-with-next-major}`)
+- Queries GitHub's API for the `archived` flag — **requires `gh auth login`** to avoid the 60/hour unauthenticated rate limit
 - Flags suspect version strings (`+incompatible`, old pseudo-versions) via `extra_scrutiny`
 - Computes blast radius from `go mod graph` and `vendor/`
 
@@ -47,36 +49,42 @@ The output JSON has shape:
       "skipped": false,
       "extra_scrutiny": ["incompatible", "old-pseudo-version"],
       "repo_url": "https://github.com/foo/bar",
-      "github": {
-        "owner": "foo",
-        "name": "bar",
-        "archived": false,
-        "pushed_at": "2024-01-01T00:00:00Z",
-        "recent_releases": [
-          {"tag": "v1.2.3", "date": "2024-01-01T00:00:00Z"}
+      "pkgsite": {
+        "latest_version": "v1.2.3",
+        "latest_commit_time": "2024-01-01T00:00:00Z",
+        "deprecated": false,
+        "retracted": false,
+        "higher_major_exists": false,
+        "recent_versions": [
+          {"version": "v1.2.3", "commit_time": "2024-01-01T00:00:00Z",
+           "deprecated": false, "retracted": false}
         ]
       },
+      "github": {"archived": false},
       "blast_radius": {"modules": 12, "vendor_packages": 3}
     }
   ]
 }
 ```
 
-`github` is `null` for non-GitHub origins (e.g., gopkg.in vanity paths the proxy doesn't resolve); `repo_url` carries the raw URL when available. `recent_releases` falls back to tag names with `date: null` when the repo publishes tags but no GitHub Releases.
+Semantics:
 
-`extra_scrutiny` is a (possibly empty) subset of `["incompatible", "old-pseudo-version"]`.
-
-If any GitHub API call failed, a `github.github_errors` array lists which subcalls failed (`meta`, `releases`, `tags`). Treat those deps as "data incomplete" rather than healthy.
-
-`skipped: true` deps still carry their path/version but no other data — surface them only if `extra_scrutiny` is non-empty.
+- `pkgsite: null` — pkg.go.dev had no data (private module, not yet indexed, network failure). Treat as "data incomplete".
+- `github: null` — repo isn't on GitHub (gopkg.in, GitLab, etc.). Not an error.
+- `github: {archived: null}` — repo IS on GitHub but the `gh api` call failed (often rate-limit). Treat as "archived status unknown".
+- `pkgsite.deprecated` and `pkgsite.retracted` reflect the **most recent version indexed on pkg.go.dev** — not the version pinned in this project's `go.mod`. `deprecated` is module-level (a `// Deprecated:` comment above `module` in the dep's go.mod), so when `true` every version reports it; `false` doesn't rule out informal README-only deprecation. `retracted` fires only when the latest indexed release has a `retract` directive — older retractions on otherwise-healthy projects do not fire, but a retracted *latest* release means even the maintainer says don't use it.
+- `extra_scrutiny` is a (possibly empty) subset of `["incompatible", "old-pseudo-version"]`.
+- `skipped: true` deps carry only path/version — surface them only if `extra_scrutiny` is non-empty.
 
 ## Step 2 — Pick the candidate set from the JSON
 
 A dep is a **stale candidate** if any of these is true:
 
 - `github.archived == true`
-- `github.pushed_at` is older than **today − 2 years**
-- `github.recent_releases` contains a release for a higher major than the path's `/vN` suffix (the depended-on major is frozen, a successor exists)
+- `pkgsite.deprecated == true` (formal go.mod deprecation)
+- `pkgsite.retracted == true` (latest version retracted)
+- `pkgsite.higher_major_exists == true` (a `path/v(N+1)` module is published — current major may be frozen)
+- `pkgsite.latest_commit_time` is older than **today − 2 years**
 - `extra_scrutiny` is non-empty
 
 Filter with jq:
@@ -86,19 +94,13 @@ Filter with jq:
 TWO_YEARS_AGO=$(date -u -d '2 years ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
     || date -u -v-2y +%Y-%m-%dT%H:%M:%SZ)
 jq --arg cutoff "$TWO_YEARS_AGO" '
-  def path_major:
-    ((capture("/v(?<n>[0-9]+)$") | .n)? // "1") | tonumber;
-  def release_major(t):
-    (t | capture("^v(?<n>[0-9]+)\\.").n | tonumber)? // -1;
-
   .deps | map(select(
     (.skipped | not) and (
       .github.archived == true
-      or (.github.pushed_at != null and .github.pushed_at < $cutoff)
-      or (
-        (.path | path_major) as $m
-        | (.github.recent_releases // []) | any(release_major(.tag) > $m)
-      )
+      or .pkgsite.deprecated == true
+      or .pkgsite.retracted == true
+      or .pkgsite.higher_major_exists == true
+      or ((.pkgsite.latest_commit_time // "9999") < $cutoff)
       or ((.extra_scrutiny // []) | length > 0)
     )
   ))

--- a/.claude/skills/find-stale-dependencies/SKILL.md
+++ b/.claude/skills/find-stale-dependencies/SKILL.md
@@ -45,7 +45,7 @@ The output JSON has shape:
       "path": "github.com/foo/bar",
       "version": "v1.2.3",
       "skipped": false,
-      "extra_scrutiny": ["incompatible" | "old-pseudo-version"],
+      "extra_scrutiny": ["incompatible", "old-pseudo-version"],
       "repo_url": "https://github.com/foo/bar",
       "github": {
         "owner": "foo",
@@ -64,6 +64,10 @@ The output JSON has shape:
 
 `github` is `null` for non-GitHub origins (e.g., gopkg.in vanity paths the proxy doesn't resolve); `repo_url` carries the raw URL when available. `recent_releases` falls back to tag names with `date: null` when the repo publishes tags but no GitHub Releases.
 
+`extra_scrutiny` is a (possibly empty) subset of `["incompatible", "old-pseudo-version"]`.
+
+If any GitHub API call failed, a `github.github_errors` array lists which subcalls failed (`meta`, `releases`, `tags`). Treat those deps as "data incomplete" rather than healthy.
+
 `skipped: true` deps still carry their path/version but no other data — surface them only if `extra_scrutiny` is non-empty.
 
 ## Step 2 — Pick the candidate set from the JSON
@@ -78,7 +82,9 @@ A dep is a **stale candidate** if any of these is true:
 Filter with jq:
 
 ```bash
-TWO_YEARS_AGO=$(date -u -d '2 years ago' +%Y-%m-%dT%H:%M:%SZ)
+# GNU date uses -d, BSD/macOS date uses -v; fall back to the BSD form if -d fails.
+TWO_YEARS_AGO=$(date -u -d '2 years ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -v-2y +%Y-%m-%dT%H:%M:%SZ)
 jq --arg cutoff "$TWO_YEARS_AGO" '
   def path_major:
     ((capture("/v(?<n>[0-9]+)$") | .n)? // "1") | tonumber;

--- a/.claude/skills/find-stale-dependencies/SKILL.md
+++ b/.claude/skills/find-stale-dependencies/SKILL.md
@@ -99,7 +99,7 @@ For each confirmed stale dep, verify that the **current version in go.mod** fall
 
 Preferred: run `govulncheck` if available, which checks only the versions actually in use:
 ```bash
-govulncheck -json ./... 2>/dev/null | jq -r '.Finding[] | select(.Trace != null) | .OSV'
+govulncheck -json ./... 2>/dev/null | jq -r 'select(.finding.trace != null) | .finding.osv'
 ```
 
 Fallback: fetch the advisory list and cross-check the version manually:

--- a/.claude/skills/find-stale-dependencies/check-dependencies.sh
+++ b/.claude/skills/find-stale-dependencies/check-dependencies.sh
@@ -277,6 +277,14 @@ main() {
     total=$(wc -l <"$WORK/deps.tsv" | tr -d ' ')
     log "found $total direct deps"
 
+    if [ "$total" -eq 0 ]; then
+        log "no direct dependencies to check"
+        jq -n --arg module "$(go list -m 2>/dev/null || echo "")" \
+            --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{generated_at: $generated_at, module: $module, deps: []}'
+        return 0
+    fi
+
     log "computing go mod graph"
     go mod graph >"$WORK/graph.txt"
 

--- a/.claude/skills/find-stale-dependencies/check-dependencies.sh
+++ b/.claude/skills/find-stale-dependencies/check-dependencies.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+#
+# Emit a JSON report of direct Go dependencies with the data needed
+# to decide whether each one is stale: repo URL, GitHub status,
+# recent releases (or tags), and blast radius.
+#
+# Usage:  check-dependencies.sh [project-dir]
+# Output: JSON document on stdout, progress logs on stderr.
+
+set -euo pipefail
+
+# Number of deps to process concurrently. Each worker issues a few gh api calls.
+PARALLELISM=${PARALLELISM:-8}
+# Module path prefixes that are skipped (trusted maintainers / large orgs).
+SKIP_PREFIXES=${SKIP_PREFIXES:-"cloud.google.com
+golang.org/x/
+google.golang.org/
+go.opentelemetry.io/
+github.com/prometheus/
+github.com/grafana/
+github.com/Azure/
+github.com/aws/
+github.com/google/
+github.com/hashicorp/
+go.uber.org/
+k8s.io/"}
+
+log() { printf '[check-deps] %s\n' "$*" >&2; }
+die() { log "$@"; exit 1; }
+
+# Check that each named command exists in PATH; die if any is missing.
+require_cmd() {
+    for c in "$@"; do
+        command -v "$c" >/dev/null 2>&1 || die "missing required command: $c"
+    done
+}
+
+# Return 0 if path starts with one of the trusted-org prefixes in $SKIP_PREFIXES.
+is_skipped() {
+    local path=$1 prefix
+    while IFS= read -r prefix; do
+        [ -z "$prefix" ] && continue
+        case "$path" in
+            "$prefix"*) return 0 ;;
+        esac
+    done <<<"$SKIP_PREFIXES"
+    return 1
+}
+
+# Pseudo-versions are <base>-<14digit-timestamp>-<12hex-hash>, with two common shapes:
+# - v0.0.0-YYYYMMDDHHMMSS-hash (no prior tag) and
+# - v1.2.3-0.YYYYMMDDHHMMSS-hash (pre-release form, after a tag).
+# Returns 0 (true) if the embedded timestamp is older than two years.
+is_old_pseudo_version() {
+    local version=$1 cutoff
+    if [[ "$version" =~ ([0-9]{14})-[0-9a-f]{12}$ ]]; then
+        cutoff=$(date -u -d '2 years ago' +%Y%m%d%H%M%S 2>/dev/null || date -u -v-2y +%Y%m%d%H%M%S)
+        [ "${BASH_REMATCH[1]}" -lt "$cutoff" ]
+    else
+        return 1
+    fi
+}
+
+# Emit a JSON array of suspicious-version flags (incompatible, old-pseudo-version).
+scrutiny_flags_json() {
+    local version=$1
+    local flags=()
+    if [[ "$version" == *+incompatible ]]; then
+        flags+=("incompatible")
+    fi
+    if is_old_pseudo_version "$version"; then
+        flags+=("old-pseudo-version")
+    fi
+    jq -nc --args '$ARGS.positional' "${flags[@]}"
+}
+
+# Echo the upstream repo URL for a module via go mod download, or empty.
+resolve_repo_url() {
+    local path=$1 version=$2
+    go mod download -json "$path@$version" 2>/dev/null | jq -r '.Origin.URL // empty' 2>/dev/null || true
+}
+
+# Fetch GitHub metadata + the most recent 20 releases (falling back to tag
+# names when the repo doesn't publish releases — date is null in that case).
+github_meta() {
+    local owner=$1 name=$2 meta releases
+
+    meta=$(gh api "repos/$owner/$name" --jq '{archived, pushed_at}' 2>/dev/null) || meta='{}'
+    releases=$(gh api "repos/$owner/$name/releases?per_page=20" \
+        --jq 'map({tag: .tag_name, date: .published_at})' 2>/dev/null) || releases='[]'
+    if [ "$(jq 'length' <<<"$releases")" -eq 0 ]; then
+        releases=$(gh api "repos/$owner/$name/tags?per_page=20" \
+            --jq 'map({tag: .name, date: null})' 2>/dev/null) || releases='[]'
+    fi
+
+    jq -n --arg owner "$owner" --arg name "$name" --argjson meta "$meta" --argjson releases "$releases" \
+        '{owner: $owner, name: $name} + $meta + {recent_releases: $releases}'
+}
+
+# Count distinct modules that require the given module@version from the graph.
+count_dependents() {
+    local module_at=$1 graph_file=$2
+    awk -v mod="$module_at" 'index($2, mod) == 1 { print $1 }' "$graph_file" | sort -u | wc -l | tr -d ' '
+}
+
+# Count vendored directories that import the given path.
+count_vendor_packages() {
+    local path=$1
+    [ -d vendor ] || { printf '0'; return; }
+    grep -r "\"$path" vendor/ --include='*.go' -l 2>/dev/null | awk 'NF { sub("/[^/]+$", "", $0); print }' \
+        | sort -u | wc -l | tr -d ' '
+}
+
+# Build the JSON record for a single direct dep and write it to $outfile.
+process_dep() {
+    local idx=$1 path=$2 version=$3 outfile=$4
+    local repo_url owner name meta scrutiny dependents vendor_pkgs
+
+    scrutiny=$(scrutiny_flags_json "$version")
+
+    if is_skipped "$path"; then
+        jq -n --arg path "$path" --arg version "$version" --argjson scrutiny "$scrutiny" \
+            '{path: $path, version: $version, skipped: true,
+              skip_reason: "trusted-prefix", extra_scrutiny: $scrutiny}' >"$outfile"
+        return
+    fi
+
+    repo_url=$(resolve_repo_url "$path" "$version")
+    owner=""; name=""
+    if [[ "$repo_url" =~ ^https?://github\.com/([^/]+)/([^/]+?)(\.git)?$ ]]; then
+        owner="${BASH_REMATCH[1]}"
+        name="${BASH_REMATCH[2]}"
+    elif [[ "$path" == github.com/*/* ]]; then
+        owner=$(printf '%s' "$path" | cut -d/ -f2)
+        name=$(printf '%s' "$path" | cut -d/ -f3)
+        repo_url=${repo_url:-"https://github.com/$owner/$name"}
+    fi
+
+    meta='null'
+    if [ -n "$owner" ] && [ -n "$name" ]; then
+        meta=$(github_meta "$owner" "$name") || meta='null'
+    fi
+
+    dependents=$(count_dependents "$path@$version" "$WORK/graph.txt")
+    vendor_pkgs=$(count_vendor_packages "$path")
+
+    jq -n \
+        --arg path "$path" \
+        --arg version "$version" \
+        --argjson scrutiny "$scrutiny" \
+        --arg repo_url "$repo_url" \
+        --argjson github "$meta" \
+        --argjson dependents "$dependents" \
+        --argjson vendor_pkgs "$vendor_pkgs" \
+        '{
+            path: $path,
+            version: $version,
+            skipped: false,
+            extra_scrutiny: $scrutiny,
+            repo_url: (if $repo_url == "" then null else $repo_url end),
+            github: $github,
+            blast_radius: {modules: $dependents, vendor_packages: $vendor_pkgs}
+        }' >"$outfile"
+}
+
+main() {
+    require_cmd go jq gh awk
+
+    local project_dir=${1:-.}
+    cd "$project_dir"
+    [ -f go.mod ] || die "no go.mod in $(pwd)"
+
+    WORK=$(mktemp -d)
+    trap 'rm -rf "$WORK"' EXIT
+
+    log "project: $(go list -m 2>/dev/null || echo unknown)"
+
+    go mod edit -json | jq -r '.Require[]? | select(.Indirect != true) | [.Path, .Version] | @tsv' >"$WORK/deps.tsv"
+    local total
+    total=$(wc -l <"$WORK/deps.tsv" | tr -d ' ')
+    log "found $total direct deps"
+
+    log "computing go mod graph"
+    go mod graph >"$WORK/graph.txt"
+
+    mkdir -p "$WORK/results"
+    log "processing deps with parallelism=$PARALLELISM"
+
+    local idx=0
+    while IFS=$'\t' read -r path version; do
+        process_dep "$idx" "$path" "$version" "$WORK/results/$idx.json" &
+        idx=$((idx + 1))
+        if [ "$((idx % PARALLELISM))" -eq 0 ]; then
+            wait
+        fi
+    done <"$WORK/deps.tsv"
+    wait
+
+    log "merging results"
+    local module
+    module=$(go list -m 2>/dev/null || echo "")
+    jq -s --arg module "$module" --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        '{generated_at: $generated_at, module: $module, deps: .}' "$WORK/results"/*.json
+}
+
+main "$@"

--- a/.claude/skills/find-stale-dependencies/check-dependencies.sh
+++ b/.claude/skills/find-stale-dependencies/check-dependencies.sh
@@ -260,7 +260,7 @@ process_dep() {
 }
 
 main() {
-    require_cmd go jq gh curl awk
+    require_cmd go jq gh curl awk grep sort wc tr mktemp date
 
     local project_dir=${1:-.}
     cd "$project_dir"

--- a/.claude/skills/find-stale-dependencies/check-dependencies.sh
+++ b/.claude/skills/find-stale-dependencies/check-dependencies.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
 #
 # Emit a JSON report of direct Go dependencies with the data needed
-# to decide whether each one is stale: repo URL, GitHub status,
-# recent releases (or tags), and blast radius.
+# to decide whether each one is stale: repo URL, pkg.go.dev version
+# timeline (with deprecated/retracted flags), GitHub archived status,
+# and blast radius.
 #
 # Usage:  check-dependencies.sh [project-dir]
 # Output: JSON document on stdout, progress logs on stderr.
 
 set -euo pipefail
 
-# Number of deps to process concurrently. Each worker issues a few gh api calls.
-PARALLELISM=${PARALLELISM:-8}
+# Number of deps to process concurrently. Each worker issues a few API calls.
+# Default is conservative (4) to stay under pkg.go.dev's rate limits when the
+# script is run several times in quick succession.
+PARALLELISM=${PARALLELISM:-4}
 # Module path prefixes that are skipped (trusted maintainers / large orgs).
 SKIP_PREFIXES=${SKIP_PREFIXES:-"cloud.google.com
 golang.org/x/
@@ -24,6 +27,8 @@ github.com/google/
 github.com/hashicorp/
 go.uber.org/
 k8s.io/"}
+
+PKGSITE=https://pkg.go.dev/v1beta
 
 log() { printf '[check-deps] %s\n' "$*" >&2; }
 die() { log "$@"; exit 1; }
@@ -74,39 +79,116 @@ scrutiny_flags_json() {
     jq -nc --args '$ARGS.positional' "${flags[@]}"
 }
 
-# Echo the upstream repo URL for a module via go mod download, or empty.
-resolve_repo_url() {
-    local path=$1 version=$2
-    go mod download -json "$path@$version" 2>/dev/null | jq -r '.Origin.URL // empty' 2>/dev/null || true
+# Construct the module path for the next semver major. Handles both Go-module
+# style (foo/v8 -> foo/v9) and gopkg.in style (yaml.v3 -> yaml.v4). Modules
+# without a major suffix return the /v2 candidate.
+next_major_path() {
+    local path=$1
+    if [[ "$path" =~ ^(.+)/v([0-9]+)$ ]]; then
+        printf '%s/v%d' "${BASH_REMATCH[1]}" "$((BASH_REMATCH[2] + 1))"
+    elif [[ "$path" =~ ^(.+)\.v([0-9]+)$ ]]; then
+        printf '%s.v%d' "${BASH_REMATCH[1]}" "$((BASH_REMATCH[2] + 1))"
+    else
+        printf '%s/v2' "$path"
+    fi
 }
 
-# Fetch GitHub metadata + the most recent 20 releases (falling back to tag
-# names when the repo doesn't publish releases — date is null in that case).
-# Records which API calls failed in `github_errors` so the consumer can
-# distinguish "repo healthy" from "data not available".
-github_meta() {
-    local owner=$1 name=$2 meta releases errs_json
-    local errs=()
+CURL_TIMEOUT=${CURL_TIMEOUT:-30}
 
-    if ! meta=$(gh api "repos/$owner/$name" --jq '{archived, pushed_at}' 2>/dev/null); then
-        meta='{}'; errs+=("meta")
-    fi
-    if ! releases=$(gh api "repos/$owner/$name/releases?per_page=20" \
-            --jq 'map({tag: .tag_name, date: .published_at})' 2>/dev/null); then
-        releases='[]'; errs+=("releases")
-    fi
-    if [ "$(jq 'length' <<<"$releases")" -eq 0 ]; then
-        if ! releases=$(gh api "repos/$owner/$name/tags?per_page=20" \
-                --jq 'map({tag: .name, date: null})' 2>/dev/null); then
-            releases='[]'; errs+=("tags")
-        fi
-    fi
-    errs_json=$(jq -nc --args '$ARGS.positional' "${errs[@]}")
+# Fetch <url> with retries differentiated by HTTP status:
+# - 2xx → body to stdout, return 0
+# - 429 (rate-limit) → sleep 10s and retry, up to 3 attempts total
+# - 5xx / network error → sleep 2s and retry, up to 3 attempts total
+# - 4xx (other than 429) → return 1 immediately (not retryable)
+# Persistent failures return 1; the caller logs context.
+curl_retry() {
+    local url=$1 body_file code rc attempts=0
+    body_file=$(mktemp "$WORK/curl-body.XXXXXX")
+    while [ "$attempts" -lt 3 ]; do
+        code=$(curl -sL --max-time "$CURL_TIMEOUT" -w '%{http_code}' \
+            -o "$body_file" "$url" 2>/dev/null) || code='000'
+        case "$code" in
+            2*)   cat "$body_file"; rm -f "$body_file"; return 0 ;;
+            429)  sleep 10 ;;
+            4*)   rm -f "$body_file"; return 1 ;;
+            *)    sleep 2 ;;
+        esac
+        attempts=$((attempts + 1))
+    done
+    rm -f "$body_file"
+    return 1
+}
 
-    jq -n --arg owner "$owner" --arg name "$name" --argjson meta "$meta" \
-        --argjson releases "$releases" --argjson errs "$errs_json" \
-        '{owner: $owner, name: $name} + $meta + {recent_releases: $releases}
-         + (if $errs == [] then {} else {github_errors: $errs} end)'
+# Resolve the upstream repo URL. github.com/<o>/<n>/... paths derive it
+# directly; anything else (gopkg.in, vanity domains) goes through pkg.go.dev.
+# Echoes the URL on success, empty on failure (failures logged to stderr).
+resolve_repo_url() {
+    local path=$1 raw
+    if [[ "$path" =~ ^github\.com/([^/]+)/([^/]+) ]]; then
+        printf 'https://github.com/%s/%s' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+        return
+    fi
+    if raw=$(curl_retry "$PKGSITE/module/$path"); then
+        printf '%s' "$raw" | jq -r '.repoUrl // empty' 2>/dev/null || true
+    else
+        log "pkgsite module $path: fetch failed (after retry)"
+    fi
+}
+
+# Fetch the most recent versions from pkg.go.dev. Echoes the items array (with
+# {version, commitTime, deprecated, retracted} per entry) on success, empty
+# array if the module has no versions or the fetch failed (logged to stderr).
+pkgsite_versions() {
+    local path=$1 raw
+    if ! raw=$(curl_retry "$PKGSITE/versions/$path?limit=20"); then
+        log "pkgsite versions $path: fetch failed (after retry)"
+        printf '[]'
+        return
+    fi
+    printf '%s' "$raw" | jq -c '[.items // [] | .[] | {
+        version: .version,
+        commit_time: .commitTime,
+        deprecated: (.deprecated // false),
+        retracted: (.retracted // false)
+    }]' 2>/dev/null || printf '[]'
+}
+
+# Returns "true" if a module at the next-major path is published on pkg.go.dev.
+# 404 means the next major doesn't exist (the common case) — not logged.
+# Honors 429 with a 10s backoff; other transient failures get a 2s backoff.
+higher_major_exists() {
+    local path=$1 next_path code attempts=0
+    next_path=$(next_major_path "$path")
+    while [ "$attempts" -lt 3 ]; do
+        code=$(curl -sL --max-time "$CURL_TIMEOUT" -o /dev/null \
+            -w '%{http_code}' "$PKGSITE/versions/$next_path?limit=1" 2>/dev/null) \
+            || code='000'
+        case "$code" in
+            200|404|410) break ;;
+            429)         sleep 10 ;;
+            *)           sleep 2 ;;
+        esac
+        attempts=$((attempts + 1))
+    done
+    case "$code" in
+        200)     printf 'true' ;;
+        404|410) printf 'false' ;;
+        *)       log "pkgsite higher-major $next_path: persistent status $code"
+                 printf 'false' ;;
+    esac
+}
+
+# Query gh for the GitHub repo's archived flag. Echoes "true"/"false" on
+# success, "null" if the repo URL isn't a GitHub path or the call fails.
+github_archived() {
+    local repo_url=$1 archived
+    if [[ "$repo_url" =~ ^https?://github\.com/([^/]+)/([^/]+?)(\.git)?$ ]]; then
+        archived=$(gh api "repos/${BASH_REMATCH[1]}/${BASH_REMATCH[2]}" \
+            --jq '.archived // false' 2>/dev/null) || archived='null'
+        printf '%s' "$archived"
+    else
+        printf 'null'
+    fi
 }
 
 # Count distinct modules that require the given module@version from the graph.
@@ -127,9 +209,12 @@ count_vendor_packages() {
 }
 
 # Build the JSON record for a single direct dep and write it to $outfile.
+# The three pkg.go.dev calls run sequentially within each dep (each ~2s) to
+# cap total concurrent connections at $PARALLELISM rather than 3*$PARALLELISM,
+# which avoids overloading pkg.go.dev and causing intermittent timeouts.
 process_dep() {
     local idx=$1 path=$2 version=$3 outfile=$4
-    local repo_url owner name meta scrutiny dependents vendor_pkgs
+    local scrutiny repo_url versions archived higher_major dependents vendor_pkgs
 
     scrutiny=$(scrutiny_flags_json "$version")
 
@@ -140,46 +225,42 @@ process_dep() {
         return
     fi
 
-    repo_url=$(resolve_repo_url "$path" "$version")
-    owner=""; name=""
-    if [[ "$repo_url" =~ ^https?://github\.com/([^/]+)/([^/]+?)(\.git)?$ ]]; then
-        owner="${BASH_REMATCH[1]}"
-        name="${BASH_REMATCH[2]}"
-    elif [[ "$path" == github.com/*/* ]]; then
-        owner=$(printf '%s' "$path" | cut -d/ -f2)
-        name=$(printf '%s' "$path" | cut -d/ -f3)
-        repo_url=${repo_url:-"https://github.com/$owner/$name"}
+    repo_url=$(resolve_repo_url "$path")
+    versions=$(pkgsite_versions "$path")
+    higher_major=$(higher_major_exists "$path")
+    archived='null'
+    if [ -n "$repo_url" ]; then
+        archived=$(github_archived "$repo_url")
     fi
-
-    meta='null'
-    if [ -n "$owner" ] && [ -n "$name" ]; then
-        meta=$(github_meta "$owner" "$name") || meta='null'
-    fi
-
     dependents=$(count_dependents "$path@$version" "$WORK/graph.txt")
     vendor_pkgs=$(count_vendor_packages "$path")
 
-    jq -n \
-        --arg path "$path" \
-        --arg version "$version" \
-        --argjson scrutiny "$scrutiny" \
-        --arg repo_url "$repo_url" \
-        --argjson github "$meta" \
-        --argjson dependents "$dependents" \
-        --argjson vendor_pkgs "$vendor_pkgs" \
+    jq -n --arg path "$path" --arg version "$version" --argjson scrutiny "$scrutiny" \
+        --arg repo_url "$repo_url" --argjson versions "$versions" \
+        --argjson higher_major "$higher_major" --argjson archived "$archived" \
+        --argjson dependents "$dependents" --argjson vendor_pkgs "$vendor_pkgs" \
+        --arg repo_host "$([[ "$repo_url" =~ ^https?://github\.com/ ]] && echo github || echo other)" \
         '{
             path: $path,
             version: $version,
             skipped: false,
             extra_scrutiny: $scrutiny,
             repo_url: (if $repo_url == "" then null else $repo_url end),
-            github: $github,
+            pkgsite: (if ($versions | length) == 0 then null else {
+                latest_version: $versions[0].version,
+                latest_commit_time: $versions[0].commit_time,
+                deprecated: $versions[0].deprecated,
+                retracted: $versions[0].retracted,
+                higher_major_exists: $higher_major,
+                recent_versions: $versions
+            } end),
+            github: (if $repo_host == "github" then {archived: $archived} else null end),
             blast_radius: {modules: $dependents, vendor_packages: $vendor_pkgs}
         }' >"$outfile"
 }
 
 main() {
-    require_cmd go jq gh awk
+    require_cmd go jq gh curl awk
 
     local project_dir=${1:-.}
     cd "$project_dir"
@@ -190,7 +271,8 @@ main() {
 
     log "project: $(go list -m 2>/dev/null || echo unknown)"
 
-    go mod edit -json | jq -r '.Require[]? | select(.Indirect != true) | [.Path, .Version] | @tsv' >"$WORK/deps.tsv"
+    go mod edit -json | jq -r '.Require[]? | select(.Indirect != true) | [.Path, .Version] | @tsv' \
+        >"$WORK/deps.tsv"
     local total
     total=$(wc -l <"$WORK/deps.tsv" | tr -d ' ')
     log "found $total direct deps"

--- a/.claude/skills/find-stale-dependencies/check-dependencies.sh
+++ b/.claude/skills/find-stale-dependencies/check-dependencies.sh
@@ -82,19 +82,31 @@ resolve_repo_url() {
 
 # Fetch GitHub metadata + the most recent 20 releases (falling back to tag
 # names when the repo doesn't publish releases — date is null in that case).
+# Records which API calls failed in `github_errors` so the consumer can
+# distinguish "repo healthy" from "data not available".
 github_meta() {
-    local owner=$1 name=$2 meta releases
+    local owner=$1 name=$2 meta releases errs_json
+    local errs=()
 
-    meta=$(gh api "repos/$owner/$name" --jq '{archived, pushed_at}' 2>/dev/null) || meta='{}'
-    releases=$(gh api "repos/$owner/$name/releases?per_page=20" \
-        --jq 'map({tag: .tag_name, date: .published_at})' 2>/dev/null) || releases='[]'
-    if [ "$(jq 'length' <<<"$releases")" -eq 0 ]; then
-        releases=$(gh api "repos/$owner/$name/tags?per_page=20" \
-            --jq 'map({tag: .name, date: null})' 2>/dev/null) || releases='[]'
+    if ! meta=$(gh api "repos/$owner/$name" --jq '{archived, pushed_at}' 2>/dev/null); then
+        meta='{}'; errs+=("meta")
     fi
+    if ! releases=$(gh api "repos/$owner/$name/releases?per_page=20" \
+            --jq 'map({tag: .tag_name, date: .published_at})' 2>/dev/null); then
+        releases='[]'; errs+=("releases")
+    fi
+    if [ "$(jq 'length' <<<"$releases")" -eq 0 ]; then
+        if ! releases=$(gh api "repos/$owner/$name/tags?per_page=20" \
+                --jq 'map({tag: .name, date: null})' 2>/dev/null); then
+            releases='[]'; errs+=("tags")
+        fi
+    fi
+    errs_json=$(jq -nc --args '$ARGS.positional' "${errs[@]}")
 
-    jq -n --arg owner "$owner" --arg name "$name" --argjson meta "$meta" --argjson releases "$releases" \
-        '{owner: $owner, name: $name} + $meta + {recent_releases: $releases}'
+    jq -n --arg owner "$owner" --arg name "$name" --argjson meta "$meta" \
+        --argjson releases "$releases" --argjson errs "$errs_json" \
+        '{owner: $owner, name: $name} + $meta + {recent_releases: $releases}
+         + (if $errs == [] then {} else {github_errors: $errs} end)'
 }
 
 # Count distinct modules that require the given module@version from the graph.
@@ -103,12 +115,15 @@ count_dependents() {
     awk -v mod="$module_at" 'index($2, mod) == 1 { print $1 }' "$graph_file" | sort -u | wc -l | tr -d ' '
 }
 
-# Count vendored directories that import the given path.
+# Count vendored directories that import the given path. Uses -F so that
+# regex metacharacters in the module path (e.g. `.`) aren't interpreted,
+# and matches both the exact import and any subpackage so that the count
+# doesn't pick up unrelated paths that share a prefix.
 count_vendor_packages() {
     local path=$1
     [ -d vendor ] || { printf '0'; return; }
-    grep -r "\"$path" vendor/ --include='*.go' -l 2>/dev/null | awk 'NF { sub("/[^/]+$", "", $0); print }' \
-        | sort -u | wc -l | tr -d ' '
+    grep -rl --include='*.go' -F -e "\"$path\"" -e "\"$path/" vendor/ 2>/dev/null \
+        | awk 'NF { sub("/[^/]+$", "", $0); print }' | sort -u | wc -l | tr -d ' '
 }
 
 # Build the JSON record for a single direct dep and write it to $outfile.


### PR DESCRIPTION
**What this PR does**:

Adds a new Claude Code skill (`/find-stale-dependencies`) that scans direct Go dependencies for signs of abandonment — archived repos, deprecated READMEs, or no commits in 2+ years. It checks GitHub status, ~~CVEs (verified against the current version's affected range)~~, blast radius, and usage context, then outputs a prioritized report. The skill was used on the Tempo `go.mod` to produce the sample output below.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

<details>
<summary>Sample output (outdated)</summary>

## Stale Dependencies

### Critical

_None._

### High

- `github.com/gogo/protobuf@v1.3.2` — reason: README says deprecated
  Blast radius: 19 modules, 28 vendor packages
  Replacement: `google.golang.org/protobuf` — already in go.mod at v1.36.11
  Recommendation: migrate all `gogo/protobuf/proto` and `jsonpb` call sites; drop the direct dep once `gogo/status` is also replaced

- `github.com/golang/protobuf@v1.5.4` — reason: README says superseded by `google.golang.org/protobuf`
  Blast radius: 45 modules, 7 vendor packages
  Replacement: `google.golang.org/protobuf` — already in go.mod at v1.36.11
  Recommendation: migrate `proto` and `jsonpb` call sites in `modules/querier/http.go`, `pkg/httpclient/client.go`

- `github.com/golang/snappy@v1.0.0` — reason: repository archived (pushed 2025-03-07)
  Blast radius: 17 modules, 8 vendor packages
  Replacement: `github.com/klauspost/compress/snappy` — already in go.mod at v1.18.5
  Recommendation: replace import in `pkg/util/http.go`; drop the direct dep

- `github.com/json-iterator/go@v1.1.12` — reason: repository archived (pushed 2024-05-27)
  Blast radius: 77 modules, 3 vendor packages
  Replacement: stdlib `encoding/json` (drop-in) or `github.com/bytedance/sonic` — already in go.mod at v1.15.0
  Recommendation: replace the handful of direct call sites in `modules/overrides/userconfigurable/api/` and `cmd/tempo/app/modules.go`

- `github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0` — reason: last v1 release 2023-03-15 (>2 yrs); v2 actively maintained
  Blast radius: 1 module, 0 vendor packages
  Replacement: `github.com/grpc-ecosystem/go-grpc-middleware/v2` — not yet in go.mod
  Recommendation: migrate in `modules/distributor/forwarder/otlpgrpc/` and `modules/frontend/interceptor/`

- `github.com/gogo/status@v1.1.1` — reason: last commit 2022-06-15 (>2 yrs); tied to deprecated `gogo/protobuf`
  Blast radius: 2 modules, 2 vendor packages
  Replacement: `google.golang.org/grpc/status` — already in go.mod via grpc v1.80.0
  Recommendation: straightforward drop-in; best done alongside the `gogo/protobuf` migration

- `github.com/go-redis/redis/v8@v8.11.5` — reason: last v8 release 2022-03-17 (>2 yrs); v9 actively maintained at `redis/go-redis`
  Blast radius: 1 module, 5 vendor packages
  Replacement: `github.com/go-redis/redis/v9` — not yet in go.mod
  Recommendation: upgrade in `pkg/cache/redis_cache.go` and `redis_client.go`; context now required in all method signatures

- `github.com/willf/bloom@v2.0.3+incompatible` — reason: repo transferred to `bits-and-blooms/bloom`; pre-modules `+incompatible` path is frozen
  Blast radius: 1 module, 0 vendor packages
  Replacement: `github.com/bits-and-blooms/bloom/v3` — not yet in go.mod
  Recommendation: replace in `tempodb/encoding/common/bloom.go` and the three `vparquet*/block_findtracebyid.go` files

### Medium

_None._

### Low

- `github.com/jsternberg/zap-logfmt@v1.3.0` — reason: last commit 2023-02-22 (>2 yrs); no explicit deprecation notice
  Blast radius: 1 module, 0 vendor packages
  Replacement: no direct successor identified
  Recommendation: low urgency; logging-only, no CVEs; address when touching those binaries

- `github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc` — reason: pushed 2024-04-06 (11 days past 2-yr cutoff)
  Blast radius: 196 modules (transitive), 4 vendor packages
  Replacement: `github.com/google/go-cmp` — already in go.mod at v0.7.0
  Recommendation: used only in `cmd/tempo-cli` and one test file; remove direct dep once testify covers the test-only usage

</details>

<details><summary>Sample output (new hybrid approach)</summary>

### High

- github.com/gogo/protobuf@v1.3.2 — reason: README says "GoGo Protobuf is Deprecated"; last release 2021-01-10
Blast radius: 18 modules, 28 vendor packages
Replacement: google.golang.org/protobuf [already in go.mod at v1.36.11]
Recommendation: migrate proto/jsonpb call sites across cmd/tempo-cli/*, cmd/tempo-query/, cmd/tempo-vulture/, and 50+ generated .pb.go files. Hot path (gRPC wire format).
- github.com/gogo/status@v1.1.1 — reason: last release 2022-06-15 (>2y); coupled to deprecated gogo/protobuf
Blast radius: 2 modules, 2 vendor packages
Replacement: google.golang.org/grpc/status [google.golang.org/grpc already in go.mod at v1.80.0]
Recommendation: drop together with the gogo/p direct imports in modules/distributor,modules/frontend, modules/backend{scheduler,worker}.
- github.com/json-iterator/go@v1.1.12 — reaso release 2021-09-11
Blast radius: 73 modules, 3 vendor packages
Replacement: stdlib encoding/json, or github. go.mod at v0.10.6], orgithub.com/bytedance/sonic [already in go.mod at v1.15.0]
Recommendation: migrate the 13 direct call sio, modules/overrides/userconfigurable/api/*,modules/backendscheduler/work/*, pkg/usagestats/*. Hot path (HTTP API marshal/unmarshal).
- github.com/go-redis/redis/v8@v8.11.5 — reaseleases show active v9.x (~20 v9 releasesincluding v9.19.0)
Blast radius: 1 module, 5 vendor packages
Replacement: github.com/redis/go-redis/v9 [not yet added]
Recommendation: bump cache layer (pkg/cache/rs_client.go) to v9. Method signatures now take context.Context. Hot path (request-path cache).

### Medium

- github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc — reason: old-pseudo-version flag; last tagged release
 2018-02-21 (>7y); no explicit deprecation, b
Blast radius: 20 modules, 4 vendor packages
Replacement: none required — stdlib fmt %#v /er most cases
Recommendation: leave for now. Direct usage is cmd/tempo-cli/cmd-query-trace-summary.go (debug helper) and one test file
 — internal utility only.

### Low

- github.com/facette/natsort@v0.0.0-201812100old-pseudo-version flag (2018); upstream still pushed in 2024 but never cuts tags
Blast radius: 3 modules, 1 vendor package
Replacement: none widely adopted (github.com/maruel/natural is one alternative)
Recommendation: bump to a fresher pseudo-versrithm. Used only inpkg/cache/memcached_client_selector.go for one-time server-list sort.

---
Filter dismissal: go.yaml.in/yaml/v2@v2.4.4 wen check (recent_releases include v3.0.x andv4.0.0-rc tags), but inspection shows the repo is the actively maintained YAML community fork — README explicitly says the YAML org took over maintenance from the n The v2 line is still being released (v2.4.4is recent), and Tempo uses it heavily (23 files across cmd/tempo, cmd/tempo-cli, integration/). Dropping from the stale list.

</details>