### PR TITLE
live-store: fix race conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
 * [BUGFIX] fix: respect context cancellation when reading WAL block iterator [#6928](https://github.com/grafana/tempo/pull/6928) (@zhxiaogg)
 * [BUGFIX] Complete lifecycler shutdown on errors [#6906](https://github.com/grafana/tempo/pull/6906) (@javiermolinar)
 * [BUGFIX] livestore: fix concurrent WAL writes from periodic and shutdown flushes [#6972](https://github.com/grafana/tempo/pull/6972) (@zhxiaogg)
+* [BUGFIX] live-store: fix race conditions for tag values endpoint [#7000](https://github.com/grafana/tempo/pull/7000) (@ruslan-mikhailov)
 
 ### 3.0 Cleanup
 

--- a/modules/livestore/instance_search.go
+++ b/modules/livestore/instance_search.go
@@ -409,10 +409,6 @@ func (i *instance) SearchTagValues(ctx context.Context, req *tempopb.SearchTagVa
 	}
 
 	search := func(ctx context.Context, _ *backend.BlockMeta, b block) error {
-		if maxBlocks > 0 && inspectedBlocks.Load() >= maxBlocks {
-			return nil
-		}
-
 		if b == nil {
 			return nil
 		}
@@ -421,7 +417,11 @@ func (i *instance) SearchTagValues(ctx context.Context, req *tempopb.SearchTagVa
 			return errComplete
 		}
 
-		inspectedBlocks.Inc()
+		// Atomically reserve a slot
+		if maxBlocks > 0 && inspectedBlocks.Inc() > maxBlocks {
+			return errComplete
+		}
+
 		err := b.SearchTagValues(ctx, tagName, distinctValues.Collect, mc.Add, common.DefaultSearchOptions())
 		if err != nil && !errors.Is(err, util.ErrUnsupported) {
 			return fmt.Errorf("unexpected error searching tag values (%s): %w", tagName, err)

--- a/modules/livestore/instance_search.go
+++ b/modules/livestore/instance_search.go
@@ -340,7 +340,7 @@ func (i *instance) SearchTagsV2(ctx context.Context, req *tempopb.SearchTagsRequ
 
 		// if the query is empty, use the unfiltered search
 		if len(conditionGroups) == 0 {
-			err = b.SearchTags(ctx, attributeScope, func(t string, scope traceql.AttributeScope) {
+			err := b.SearchTags(ctx, attributeScope, func(t string, scope traceql.AttributeScope) {
 				distinctValues.Collect(scope.String(), t)
 			}, mc.Add, common.DefaultSearchOptions())
 
@@ -402,13 +402,14 @@ func (i *instance) SearchTagValues(ctx context.Context, req *tempopb.SearchTagVa
 	distinctValues := collector.NewDistinctString(maxBytesPerTagValues, limit, staleValueThreshold)
 	mc := collector.NewMetricsCollector()
 
-	var inspectedBlocks, maxBlocks int
+	var inspectedBlocks atomic.Int32
+	var maxBlocks int32
 	if limit := i.overrides.MaxBlocksPerTagValuesQuery(userID); limit > 0 {
-		maxBlocks = limit
+		maxBlocks = int32(limit)
 	}
 
 	search := func(ctx context.Context, _ *backend.BlockMeta, b block) error {
-		if maxBlocks > 0 && inspectedBlocks >= maxBlocks {
+		if maxBlocks > 0 && inspectedBlocks.Load() >= maxBlocks {
 			return nil
 		}
 
@@ -420,8 +421,8 @@ func (i *instance) SearchTagValues(ctx context.Context, req *tempopb.SearchTagVa
 			return errComplete
 		}
 
-		inspectedBlocks++
-		err = b.SearchTagValues(ctx, tagName, distinctValues.Collect, mc.Add, common.DefaultSearchOptions())
+		inspectedBlocks.Inc()
+		err := b.SearchTagValues(ctx, tagName, distinctValues.Collect, mc.Add, common.DefaultSearchOptions())
 		if err != nil && !errors.Is(err, util.ErrUnsupported) {
 			return fmt.Errorf("unexpected error searching tag values (%s): %w", tagName, err)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: it fixes race conditions.
1. Mistakenly captured `err` variable searchBlock
2. atomic inspectedBlocks to avoid races (same as it was in ingesters)

To confirm the problem, I (well, not me, claude) wrote tests for each endpoint and ran with -race flag. They are slow, and I think it's overkill to include them in the PR.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`