### PR TITLE
chore(deps): replace stale dependency github.com/json-iterator/go

### DIFF
--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"embed"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -21,7 +22,6 @@ import (
 	"github.com/grafana/dskit/server"
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/tempo/modules/livestore"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 
@@ -857,12 +857,13 @@ func usageStatsHandler(urCfg usagestats.Config) http.HandlerFunc {
 	}
 
 	// usage stats is Enabled, build and return usage stats json
-	reportStr, err := jsoniter.MarshalToString(usagestats.BuildStats())
+	reportBytes, err := json.Marshal(usagestats.BuildStats())
 	if err != nil {
 		return func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "error building usage report", http.StatusInternalServerError)
 		}
 	}
+	reportStr := string(reportBytes)
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/grafana/e2e v0.1.2-0.20251205060319-9884d3ffb1bf
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/jedib0t/go-pretty/v6 v6.7.9
-	github.com/json-iterator/go v1.1.12
 	github.com/jsternberg/zap-logfmt v1.3.0
 	github.com/klauspost/compress v1.18.5
 	github.com/minio/minio-go/v7 v7.0.100
@@ -247,6 +246,7 @@ require (
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
 	github.com/kamstrup/intmap v0.5.2 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect

--- a/integration/api/overrides_api_test.go
+++ b/integration/api/overrides_api_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -10,7 +11,6 @@ import (
 	"github.com/grafana/tempo/modules/overrides/histograms"
 	"github.com/grafana/tempo/modules/overrides/userconfigurable/client"
 	"github.com/grafana/tempo/pkg/httpclient"
-	"encoding/json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/integration/api/overrides_api_test.go
+++ b/integration/api/overrides_api_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/tempo/modules/overrides/histograms"
 	"github.com/grafana/tempo/modules/overrides/userconfigurable/client"
 	"github.com/grafana/tempo/pkg/httpclient"
-	jsoniter "github.com/json-iterator/go"
+	"encoding/json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -788,7 +788,7 @@ func TestOverridesAPI_SpanNameSanitization(t *testing.T) {
 func printLimits(limits *client.Limits, version string) {
 	var str string
 	if limits != nil {
-		bytes, err := jsoniter.Marshal(limits)
+		bytes, err := json.Marshal(limits)
 		if err == nil {
 			str = string(bytes)
 		}

--- a/modules/backendscheduler/work/atomic_test.go
+++ b/modules/backendscheduler/work/atomic_test.go
@@ -1,13 +1,13 @@
 package work
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
 	"testing"
 
-	"encoding/json"
 	"github.com/stretchr/testify/require"
 )
 

--- a/modules/backendscheduler/work/atomic_test.go
+++ b/modules/backendscheduler/work/atomic_test.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"testing"
 
-	jsoniter "github.com/json-iterator/go"
+	"encoding/json"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,7 +57,7 @@ func TestAtomicWriteFileStress(t *testing.T) {
 
 	// Should be valid JSON
 	var result map[string]any
-	err = jsoniter.Unmarshal(finalData, &result)
+	err = json.Unmarshal(finalData, &result)
 	require.NoError(t, err, "Final file should contain valid JSON after stress test")
 
 	// Verify it's our expected data

--- a/modules/backendscheduler/work/work.go
+++ b/modules/backendscheduler/work/work.go
@@ -2,6 +2,7 @@ package work
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"hash/fnv"
 	"os"
@@ -10,7 +11,6 @@ import (
 	"time"
 
 	"github.com/grafana/tempo/pkg/tempopb"
-	jsoniter "github.com/json-iterator/go"
 	"go.opentelemetry.io/otel"
 )
 
@@ -383,7 +383,7 @@ func (w *Work) Marshal() ([]byte, error) {
 	}()
 
 	// For now, marshal the entire structure for compatibility
-	return jsoniter.Marshal(w)
+	return json.Marshal(w)
 }
 
 // MarshalShard marshals only a specific shard
@@ -396,7 +396,7 @@ func (w *Work) MarshalShard(shardID int) ([]byte, error) {
 	shard.mtx.Lock()
 	defer shard.mtx.Unlock()
 
-	return jsoniter.Marshal(shard)
+	return json.Marshal(shard)
 }
 
 // Unmarshal deserializes JSON to all shards with proper locking
@@ -415,7 +415,7 @@ func (w *Work) Unmarshal(data []byte) error {
 		}
 	}()
 
-	err := jsoniter.Unmarshal(data, w)
+	err := json.Unmarshal(data, w)
 	if err != nil {
 		return err
 	}
@@ -481,7 +481,7 @@ func (w *Work) UnmarshalShard(shardID int, data []byte) error {
 	shard.mtx.Lock()
 	defer shard.mtx.Unlock()
 
-	return jsoniter.Unmarshal(data, shard)
+	return json.Unmarshal(data, shard)
 }
 
 // GetShardStats returns statistics about job distribution across shards
@@ -571,7 +571,7 @@ func (w *Work) flushShards(localPath string, shards map[int]bool) error {
 			shard.mtx.Lock()
 			defer shard.mtx.Unlock()
 
-			shardData, err := jsoniter.Marshal(shard)
+			shardData, err := json.Marshal(shard)
 			if err != nil {
 				return err
 			}

--- a/modules/overrides/userconfigurable/api/api.go
+++ b/modules/overrides/userconfigurable/api/api.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/services"
-	jsoniter "github.com/json-iterator/go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -174,7 +173,7 @@ func (a *UserConfigOverridesAPI) delete(ctx context.Context, userID string, vers
 }
 
 func (a *UserConfigOverridesAPI) parseLimits(body io.Reader) (*client.Limits, error) {
-	d := jsoniter.NewDecoder(body)
+	d := json.NewDecoder(body)
 
 	// error in case of unwanted fields
 	d.DisallowUnknownFields()
@@ -199,12 +198,12 @@ func (a *UserConfigOverridesAPI) assertNoConflictingRuntimeOverrides(ctx context
 
 	// convert overrides.Overrides to client.Limits through marshalling and unmarshalling it from json
 	// this is the easiest way to convert the optional fields
-	marshalledOverrides, err := jsoniter.Marshal(runtimeOverrides)
+	marshalledOverrides, err := json.Marshal(runtimeOverrides)
 	if err != nil {
 		return err
 	}
 	var runtimeLimits client.Limits
-	err = jsoniter.Unmarshal(marshalledOverrides, &runtimeLimits)
+	err = json.Unmarshal(marshalledOverrides, &runtimeLimits)
 	if err != nil {
 		return err
 	}
@@ -241,7 +240,7 @@ func logLimits(limits *client.Limits) string {
 	if limits == nil {
 		return ""
 	}
-	bytes, err := jsoniter.Marshal(limits)
+	bytes, err := json.Marshal(limits)
 	if err != nil {
 		return ""
 	}

--- a/modules/overrides/userconfigurable/api/api_test.go
+++ b/modules/overrides/userconfigurable/api/api_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -11,7 +12,6 @@ import (
 	"time"
 
 	"github.com/grafana/dskit/user"
-	"encoding/json"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/modules/overrides/userconfigurable/api/api_test.go
+++ b/modules/overrides/userconfigurable/api/api_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/grafana/dskit/user"
-	jsoniter "github.com/json-iterator/go"
+	"encoding/json"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,7 +44,7 @@ func Test_UserConfigOverridesAPI_overridesHandlers(t *testing.T) {
 	}, backend.VersionNew)
 	require.NoError(t, err)
 
-	postJSON, err := jsoniter.Marshal(&client.Limits{
+	postJSON, err := json.Marshal(&client.Limits{
 		Forwarders: &[]string{"my-updated-forwarder"},
 	})
 	require.NoError(t, err)
@@ -82,7 +82,7 @@ func Test_UserConfigOverridesAPI_overridesHandlers(t *testing.T) {
 			name:           "POST - invalid JSON",
 			handler:        overridesAPI.PostHandler,
 			req:            prepareRequest(tenant, "POST", []byte("not a json")),
-			expResp:        "skipThreeBytes: expect ull, error found in #2 byte of ...|not a json|..., bigger context ...|not a json|...\n",
+			expResp:        "invalid character 'o' in literal null (expecting 'u')\n",
 			expContentType: "text/plain; charset=utf-8",
 			expStatusCode:  400,
 		},
@@ -90,7 +90,7 @@ func Test_UserConfigOverridesAPI_overridesHandlers(t *testing.T) {
 			name:           "POST - unknown field JSON",
 			handler:        overridesAPI.PostHandler,
 			req:            prepareRequest(tenant, "POST", []byte("{\"unknown\":true}")),
-			expResp:        "client.Limits.ReadObject: found unknown field: unknown, error found in #10 byte of ...|{\"unknown\":true}|..., bigger context ...|{\"unknown\":true}|...\n",
+			expResp:        "json: unknown field \"unknown\"\n",
 			expContentType: "text/plain; charset=utf-8",
 			expStatusCode:  400,
 		},
@@ -238,7 +238,7 @@ func Test_UserConfigOverridesAPI_patchOverridesHandlers(t *testing.T) {
 			name:          "PATCH - invalid patch",
 			patch:         `{"newField":true}`,
 			current:       `{"forwarders":["prior-forwarder"]}`,
-			expResp:       "client.Limits.ReadObject: found unknown field: newField, error found in #10 byte of ...|\"newField\":true}|..., bigger context ...|\":{},\"span_metrics\":{},\"host_info\":{}}},\"newField\":true}|...\n",
+			expResp:       "json: unknown field \"newField\"\n",
 			expStatusCode: 400,
 		},
 	}
@@ -518,7 +518,7 @@ func TestUserConfigOverridesAPI_assertConflictingRuntimeOverrides(t *testing.T) 
 
 			w := httptest.NewRecorder()
 
-			json, err := jsoniter.Marshal(tc.request)
+			json, err := json.Marshal(tc.request)
 			assert.NoError(t, err)
 
 			path := "/"
@@ -555,7 +555,7 @@ func prepareRequest(tenant, method string, payload []byte) *http.Request {
 
 func parseJSON(t *testing.T, s string) *client.Limits {
 	var limits client.Limits
-	err := jsoniter.Unmarshal([]byte(s), &limits)
+	err := json.Unmarshal([]byte(s), &limits)
 	require.NoError(t, err)
 	return &limits
 }
@@ -622,7 +622,7 @@ func Test_UserConfigOverridesAPI_CostAttribution(t *testing.T) {
 	overridesAPI.GetHandler(w, req)
 	assert.Equal(t, 200, w.Code)
 	var limits client.Limits
-	err = jsoniter.Unmarshal(w.Body.Bytes(), &limits)
+	err = json.Unmarshal(w.Body.Bytes(), &limits)
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"k8s.namespace.name": "namespace", "k8s.cluster": "cluster"}, *limits.CostAttribution.Dimensions)
 
@@ -635,7 +635,7 @@ func Test_UserConfigOverridesAPI_CostAttribution(t *testing.T) {
 	assert.Equal(t, 200, w.Code)
 
 	// Verify PATCH response body
-	err = jsoniter.Unmarshal(w.Body.Bytes(), &limits)
+	err = json.Unmarshal(w.Body.Bytes(), &limits)
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"k8s.namespace.name": "namespace", "k8s.cluster": "cluster", "namespace": ""}, *limits.CostAttribution.Dimensions)
 
@@ -649,7 +649,7 @@ func Test_UserConfigOverridesAPI_CostAttribution(t *testing.T) {
 	assert.Equal(t, 200, w.Code)
 
 	// Verify PATCH response body
-	err = jsoniter.Unmarshal(w.Body.Bytes(), &limits)
+	err = json.Unmarshal(w.Body.Bytes(), &limits)
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"k8s.namespace.name": "namespace", "k8s.cluster": "cluster", "namespace": "", "k8s.namespace": "namespace"}, *limits.CostAttribution.Dimensions)
 
@@ -659,7 +659,7 @@ func Test_UserConfigOverridesAPI_CostAttribution(t *testing.T) {
 	req = req.WithContext(user.InjectOrgID(req.Context(), tenant))
 	overridesAPI.GetHandler(w, req)
 	assert.Equal(t, 200, w.Code)
-	err = jsoniter.Unmarshal(w.Body.Bytes(), &limits)
+	err = json.Unmarshal(w.Body.Bytes(), &limits)
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"k8s.namespace.name": "namespace", "k8s.cluster": "cluster", "namespace": "", "k8s.namespace": "namespace"}, *limits.CostAttribution.Dimensions)
 	etag := w.Header().Get(headerEtag)

--- a/modules/overrides/userconfigurable/api/http.go
+++ b/modules/overrides/userconfigurable/api/http.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -9,7 +10,6 @@ import (
 	"strconv"
 
 	"github.com/go-kit/log/level"
-	jsoniter "github.com/json-iterator/go"
 	"go.opentelemetry.io/otel/codes"
 
 	"github.com/grafana/tempo/modules/overrides/userconfigurable/client"
@@ -190,7 +190,7 @@ func writeError(w http.ResponseWriter, err error) {
 }
 
 func writeLimits(w http.ResponseWriter, limits *client.Limits, version backend.Version) error {
-	data, err := jsoniter.Marshal(limits)
+	data, err := json.Marshal(limits)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return err

--- a/modules/overrides/userconfigurable/client/client.go
+++ b/modules/overrides/userconfigurable/client/client.go
@@ -10,7 +10,6 @@ import (
 	"path"
 
 	"github.com/go-kit/log/level"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel"
@@ -181,7 +180,7 @@ func (o *clientImpl) Set(ctx context.Context, userID string, limits *Limits, ver
 	ctx, span := tracer.Start(ctx, "clientImpl.Set", trace.WithAttributes(attribute.String("tenant", userID)))
 	defer span.End()
 
-	data, err := jsoniter.Marshal(limits)
+	data, err := json.Marshal(limits)
 	if err != nil {
 		return "", err
 	}

--- a/modules/overrides/userconfigurable/client/limits_test.go
+++ b/modules/overrides/userconfigurable/client/limits_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/grafana/tempo/modules/overrides/histograms"
 	"github.com/grafana/tempo/pkg/sharedconfig"
-	jsoniter "github.com/json-iterator/go"
+	"encoding/json"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -144,7 +144,7 @@ func TestLimits_parseJson(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var limits Limits
-			err := jsoniter.Unmarshal([]byte(tc.json), &limits)
+			err := json.Unmarshal([]byte(tc.json), &limits)
 			assert.NoError(t, err)
 
 			assert.Equal(t, tc.expected, limits)

--- a/modules/overrides/userconfigurable/client/limits_test.go
+++ b/modules/overrides/userconfigurable/client/limits_test.go
@@ -1,13 +1,13 @@
 package client
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/grafana/tempo/modules/overrides/histograms"
 	"github.com/grafana/tempo/pkg/sharedconfig"
-	"encoding/json"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/usagestats/reporter_test.go
+++ b/pkg/usagestats/reporter_test.go
@@ -3,6 +3,7 @@ package usagestats
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -12,7 +13,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/kv"
-	"encoding/json"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 

--- a/pkg/usagestats/reporter_test.go
+++ b/pkg/usagestats/reporter_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/kv"
-	jsoniter "github.com/json-iterator/go"
+	"encoding/json"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
@@ -154,7 +154,7 @@ func Test_ReportLoop(t *testing.T) {
 	reportsDone := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		var received Report
-		require.NoError(t, jsoniter.NewDecoder(r.Body).Decode(&received))
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&received))
 
 		mtx.Lock()
 		totalReport++

--- a/pkg/usagestats/seed.go
+++ b/pkg/usagestats/seed.go
@@ -1,10 +1,10 @@
 package usagestats
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
-	jsoniter "github.com/json-iterator/go"
 	prom "github.com/prometheus/prometheus/web/api/v1"
 
 	"github.com/grafana/dskit/kv/memberlist"
@@ -72,13 +72,13 @@ type jsonCodec struct{}
 // currently crashing because the in-memory kvstore use a singleton.
 func (jsonCodec) Decode(data []byte) (interface{}, error) {
 	var seed ClusterSeed
-	if err := jsoniter.ConfigFastest.Unmarshal(data, &seed); err != nil {
+	if err := json.Unmarshal(data, &seed); err != nil {
 		return nil, err
 	}
 	return &seed, nil
 }
 
 func (jsonCodec) Encode(obj interface{}) ([]byte, error) {
-	return jsoniter.ConfigFastest.Marshal(obj)
+	return json.Marshal(obj)
 }
 func (jsonCodec) CodecID() string { return "usagestats.jsonCodec" }

--- a/pkg/usagestats/stats.go
+++ b/pkg/usagestats/stats.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/tempo/cmd/tempo/build"
 
 	"github.com/cespare/xxhash/v2"
-	jsoniter "github.com/json-iterator/go"
 	prom "github.com/prometheus/prometheus/web/api/v1"
 	"go.uber.org/atomic"
 )
@@ -47,7 +46,7 @@ type Report struct {
 // sendReport sends the report to the stats server
 func sendReport(ctx context.Context, seed *ClusterSeed, interval time.Time) error {
 	report := buildReport(seed, interval)
-	out, err := jsoniter.MarshalIndent(report, "", " ")
+	out, err := json.MarshalIndent(report, "", " ")
 	if err != nil {
 		return err
 	}

--- a/pkg/usagestats/stats_test.go
+++ b/pkg/usagestats/stats_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/tempo/cmd/tempo/build"
 
 	"github.com/google/uuid"
-	jsoniter "github.com/json-iterator/go"
+	"encoding/json"
 	"github.com/stretchr/testify/require"
 )
 
@@ -62,7 +62,7 @@ func Test_BuildReport(t *testing.T) {
 	require.Equal(t, r.Metrics["query_throughput"].(map[string]interface{})["avg"], float64(25+300+5)/3)
 	require.Equal(t, r.Metrics["active_tenants"], int64(3))
 
-	out, _ := jsoniter.MarshalIndent(r, "", " ")
+	out, _ := json.MarshalIndent(r, "", " ")
 	t.Log(string(out))
 }
 
@@ -113,7 +113,7 @@ func Test_BuildStats(t *testing.T) {
 	require.Equal(t, r.CreatedAt, time.Time{})
 	require.Equal(t, r.Interval, time.Time{})
 
-	out, _ := jsoniter.MarshalIndent(r, "", " ")
+	out, _ := json.MarshalIndent(r, "", " ")
 	t.Log(string(out))
 }
 

--- a/pkg/usagestats/stats_test.go
+++ b/pkg/usagestats/stats_test.go
@@ -1,6 +1,7 @@
 package usagestats
 
 import (
+	"encoding/json"
 	"runtime"
 	"sync"
 	"testing"
@@ -10,7 +11,6 @@ import (
 	"github.com/grafana/tempo/cmd/tempo/build"
 
 	"github.com/google/uuid"
-	"encoding/json"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
**What this PR does**:
Replaces the archived `github.com/json-iterator/go` with stdlib `encoding/json` across all direct call sites. The library was originally adopted for better serialization performance, but stdlib `encoding/json` performance has improved significantly since then, and none of the replaced call sites are on performance-critical paths. Test assertions with jsoniter-specific error message strings were updated to match stdlib error format.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`