### PR TITLE
Vulture: fix for query_end_cutoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
 * [BUGFIX] livestore: fix concurrent WAL writes from periodic and shutdown flushes [#6972](https://github.com/grafana/tempo/pull/6972) (@zhxiaogg)
 * [BUGFIX] live-store: fix race conditions for tag values endpoint [#7000](https://github.com/grafana/tempo/pull/7000) (@ruslan-mikhailov)
 * [BUGFIX] live-store: correct backoff duration calculation [#6999](https://github.com/grafana/tempo/pull/6999) (@ruslan-mikhailov)
+* [BUGFIX] vulture: fix for recent traces when query_end_cutoff is enabled [#7018](https://github.com/grafana/tempo/pull/7018) (@ruslan-mikhailov)
 
 ### 3.0 Cleanup
 

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -694,7 +694,7 @@ func queryMetrics(client httpclient.TempoHTTPClient, seed time.Time, config vult
 
 	resp, err := client.MetricsQueryRange(
 		fmt.Sprintf(`{.%s = "%s"} | count_over_time()`, attr.Key, util.StringifyAnyValue(attr.Value)),
-		start, end, "1m", 0,
+		start, end, "10s", 0,
 	)
 	if err != nil {
 		logger.Error("failed to query metrics", zap.Error(err))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: it fixes vulture metrics check when query_end_cutoff is enabled. With step=1m, for traces that are close to `longWriteBackoff` (default is 1 minute), request will hit the cutoff and remove the last bucket. In order to solve the problem, I just reduce step duration to 10 seconds.

I ran it for some time to confirm it solves the problem:
<img width="1316" height="727" alt="image" src="https://github.com/user-attachments/assets/eb0a9a70-b936-4f0e-aedd-3cdd660c7cb3" />


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`