### PR TITLE
blockbuilder: wait for blocklist poller on test cleanup

### DIFF
--- a/modules/blockbuilder/blockbuilder_test.go
+++ b/modules/blockbuilder/blockbuilder_test.go
@@ -813,7 +813,6 @@ func TestBlockbuilder_marksOldBlocksCompacted(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), b))
 		cancel(errors.New("test cleanup"))
-		store.Shutdown()
 	})
 
 	// Wait for the records to be consumed and committed
@@ -945,16 +944,18 @@ type ownEverythingSharder struct{}
 func (o *ownEverythingSharder) Owns(string) bool { return true }
 
 func newStore(ctx context.Context, t testing.TB) storage.Store {
-	// Use a derived context so we can stop the blocklist polling goroutine
-	// during cleanup. The store is never started as a dskit service, so
-	// StopAndAwaitTerminated transitions New→Terminated without calling
-	// stopping()/Shutdown(). The polling goroutine (started by EnablePolling)
-	// only exits when its context is cancelled. Without this, it races with
-	// t.TempDir() cleanup, writing files while os.RemoveAll runs.
+	// The store is never started as a dskit service, so StopAndAwaitTerminated
+	// transitions New→Terminated without calling stopping()/Shutdown(). cancel()
+	// signals the blocklist polling goroutine (started by EnablePolling) to
+	// exit, and store.Shutdown() blocks until it actually has. Both are needed:
+	// without cancel() the goroutine never exits; without Shutdown() we don't
+	// wait for it, and it races with t.TempDir() cleanup, writing tenant index
+	// files while os.RemoveAll runs.
 	ctx, cancel := context.WithCancel(ctx)
 	store := newStoreWithLogger(ctx, t, testLogger(t), false)
 	t.Cleanup(func() {
 		cancel()
+		store.Shutdown()
 		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), store))
 	})
 	return store


### PR DESCRIPTION
**What this PR does**:

Fixes flaky `TestBlockbuilder_flushingFails` failing in cleanup with `TempDir RemoveAll: directory not empty`.

Cause: the test cleanup calls `cancel()` on the poller context but doesn't wait for the goroutine to stop. With `ownEverythingSharder` the poller writes a tenant-index file every 100 ms, so `os.RemoveAll` races with it.

Fix: call `store.Shutdown()` — it blocks on `pollerShutdownCh` until the goroutine actually exits. Also drops a now-redundant manual `Shutdown()` in `TestBlockbuilder_marksOldBlocksCompacted` that would double-close.

Seen on https://github.com/grafana/tempo/actions/runs/24713659753/job/72284397535

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated — test-only, not user-facing