### PR TITLE
[DOC]Fix typo for 2.10 release notes 

### DIFF
--- a/docs/sources/tempo/release-notes/v2-10.md
+++ b/docs/sources/tempo/release-notes/v2-10.md
@@ -342,7 +342,7 @@ For a complete list, refer to the [Tempo CHANGELOG](https://github.com/grafana/t
 - Fixed issue with additional matched spans in queries with only resource attributes. [[PR 6432](https://github.com/grafana/tempo/pull/6432)]
 - Fixed live-store deadlock occurring after a complete block failure. [[PR 6338](https://github.com/grafana/tempo/pull/6338)]
 - Fixed `query_end_cutoff` parameter for query range. [[PR 6360](https://github.com/grafana/tempo/pull/6360)]
-- Fixed `dimension_mappings` being unconditionally overwritten by overrides, causing them to be set to nil when set through static config but not in overrides. [[PR 6390](https://github.com/grafana/tempo/pull/6390)]
+- Fixed `dimension_mappings` being unconditionally overwritten by overrides, causing them to be set to nil when set through static configuration but not in overrides. [[PR 6390](https://github.com/grafana/tempo/pull/6390)]
 - Fixed metrics-generator panic when `write_relabel_configs` is set, caused by uninitialized `NameValidationScheme` after Prometheus dependency upgrade. [[PR 6399](https://github.com/grafana/tempo/pull/6399)]
 
 ### 2.10.0
@@ -355,7 +355,7 @@ For a complete list, refer to the [Tempo CHANGELOG](https://github.com/grafana/t
 - Fixed `GetTrace()` in `tempo-query`. [[PR 5864](https://github.com/grafana/tempo/pull/5864)]
 - Fixed unsupported nonexistence nil operator for tags lookup. Fixed issue where some tag values/names were not returned due to distinctAttrCollector optimization. [[PR 5967](https://github.com/grafana/tempo/pull/5967)]
 - Fixed delete implementation for S3, GCS, and Azure backends to account for prefix. [[PR 6011](https://github.com/grafana/tempo/pull/6011)]
-- Fixed slow pod startup (~90s) in monolithic mode by returning false from `isSharded()` when `kvstore` is empty or in memory. [[PR 6090](https://github.com/grafana/tempo/pull/6090)]
+- Fixed slow Pod startup (~90s) in monolithic mode by returning false from `isSharded()` when `kvstore` is empty or in memory. [[PR 6090](https://github.com/grafana/tempo/pull/6090)]
 - Fixed metrics generator to cache failed instances and back off when processor validation or instance creation fails, preventing indefinite retry attempts that could cause out-of-memory errors. [[PR 6142](https://github.com/grafana/tempo/pull/6142)]
 - Fixed panic when trying to compact block with unsupported encodings such as vParquet previews. [[PR 6209](https://github.com/grafana/tempo/pull/6209)]
 - Fixed leading zero handling in native histograms implementations. [[PR 6033](https://github.com/grafana/tempo/pull/6033)]


### PR DESCRIPTION

**What this PR does**:

Fixes an incorrect link for PR 6090 in the bug fixes for the 2.10 release notes. Spells out the word "configuration". 

**Which issue(s) this PR fixes**:


**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`