### PR TITLE
Allow Go and CI tools image updates on release branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -66,6 +66,14 @@
       enabled: false,
     },
     {
+      description: 'Allow Go and CI tools image updates on release branches to keep lint working',
+      matchBaseBranches: [
+        '/^release-v.*/',
+      ],
+      matchDepNames: ['go', 'golang', 'grafana/tempo-ci-tools'],
+      enabled: true,
+    },
+    {
       description: 'Group OpenTelemetry OTEL updates',
       matchManagers: [
         'gomod',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -66,7 +66,7 @@
       enabled: false,
     },
     {
-      description: 'Allow Go and CI tools image updates on release branches to keep lint working',
+      description: 'Allow Go and CI tools image updates on release branches to be up2date on CVE',
       matchBaseBranches: [
         '/^release-v.*/',
       ],


### PR DESCRIPTION
## Summary
- Adds a Renovate package rule to re-enable `go`, `golang`, and `grafana/tempo-ci-tools` updates on release branches
- The blanket "disable all non-vulnerability updates for releases" rule also blocks Go version updates and CI tools image tag updates, which are prerequisites for Go version bumps to pass CI
- This enables automatic Go version upgrades on release branches, keeping them in sync with the toolchain updates that land on main

## Context
See #7022 for the full investigation. The CI tools image tag on `main` was in a format Renovate couldn't match, blocking Go 1.26.2 updates. That's now fixed, but the same update chain was broken on release branches because these updates were disabled entirely.

## Test plan
- [ ] Verify Renovate creates CI tools image tag update PRs on release branches
- [ ] Verify Go version update PRs on release branches pass CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)