### PR TITLE
chore: make tempo singlebinary example to use the local backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [CHANGE] Allow duplicate dimensions for span metrics and service graphs. This is a valid use case if using different instrumentation libraries, with spans having "deployment.environment" and others "deployment_environment", for example. [#6288](https://github.com/grafana/tempo/pull/6288) (@carles-grafana)
 * [CHANGE] Updade default max duration for traceql metrics queries up to one day [#6285](https://github.com/grafana/tempo/pull/6285) (@javiermolinar)
 * [CHANGE] Set traceQL query metrics checks by default in Vulture [#6275](https://github.com/grafana/tempo/pull/6275) (@javiermolinar)
+* [CHANGE] Make tempo singlebinary example to use the local backend [#7033](https://github.com/grafana/tempo/pull/7033) (@javiermolinar)
 * [CHANGE] TraceQL metrics - change default step intervals to align with new vParquet5 timestamp columns [#6413](https://github.com/grafana/tempo/pull/6413) (@mdisibio)
 * [CHANGE] Remove all traces of ingesters from the dashboards [#6352](https://github.com/grafana/tempo/pull/6352) (@javiermolinar)
 * [CHANGE] **BREAKING CHANGE** tempo-cli: Support relative time (now, now-1h) for start/end args and standardize on RFC3339 in all commands. [#6458](https://github.com/grafana/tempo/pull/6458) (@electron0zero)

--- a/docs/sources/tempo/docker-example.md
+++ b/docs/sources/tempo/docker-example.md
@@ -102,7 +102,6 @@ Redpanda provides the durable queue that Tempo uses to decouple its write and re
    single-binary-alloy-1           "/bin/alloy run /etc…"   alloy               running             0.0.0.0:4319->4317/tcp, 0.0.0.0:12345->12345/tcp
    single-binary-grafana-1         "/run.sh"                grafana             running             0.0.0.0:3000->3000/tcp
    single-binary-k6-tracing-1      "/k6-tracing run /ex…"   k6-tracing          running
-   single-binary-minio-1           "sh -euc 'mkdir -p /…"   minio               running             0.0.0.0:9001->9001/tcp
    single-binary-prometheus-1      "/bin/prometheus --c…"   prometheus          running             0.0.0.0:9090->9090/tcp
    single-binary-redpanda-1        "/entrypoint.sh redp…"   redpanda            running             0.0.0.0:9092->9092/tcp
    single-binary-redpanda-console-1 "/bin/sh -c 'echo \"$…" redpanda-console    running             0.0.0.0:8080->8080/tcp

--- a/example/docker-compose/debug/docker-compose.yaml
+++ b/example/docker-compose/debug/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     command: [ "-target=all", "-config.file=/etc/tempo.yaml" ]
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml
-      - ./tempo-data:/var/tempo
+      - tempo-data:/var/tempo
     environment:
       - DEBUG_BLOCK=0
     ports:
@@ -55,3 +55,6 @@ services:
       ]
     depends_on:
       - tempo
+
+volumes:
+  tempo-data:

--- a/example/docker-compose/multitenant/docker-compose.yaml
+++ b/example/docker-compose/multitenant/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     command: [ "-config.file=/etc/tempo.yaml", "-target=all"]
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml
-      - ./tempo-data:/var/tempo
+      - tempo-data:/var/tempo
     ports:
       - "4317:4317"  # otlp grpc
       - "4318:4318"  # otlpc http
@@ -70,3 +70,6 @@ services:
       ]
     depends_on:
       - tempo
+
+volumes:
+  tempo-data:

--- a/example/docker-compose/readme.md
+++ b/example/docker-compose/readme.md
@@ -25,7 +25,7 @@ See below for a list of all examples and the features they demonstrate
 
 | Example | Deployment | Tenancy | Trace Ingestion | Storage | Other Features |
 |---------|------------|---------|-----------------|---------|------------------|
-| [Single Binary](./single-binary/) | Single binary | Single tenant | Alloy | S3 (MinIO) | vulture for data integrity, metrics generator, streaming queries, mcp |
+| [Single Binary](./single-binary/) | Single binary | Single tenant | Alloy | Local filesystem | vulture for data integrity, metrics generator, streaming queries, mcp |
 | [Distributed](./distributed/) | Distributed microservices | Single tenant | Alloy | S3 (MinIO) | vulture for data integrity, metrics-generator, streaming queries, mcp |
 | [Multitenant](./multitenant/) | Single binary | Multitenant | OTel Collector + Direct OTLP | Local filesystem | vulture for data integrity, multiple tenants (tenant-1, tenant-2), streaming queries, mcp |
 | [Debug](./debug/) | Single binary | Single tenant | Direct OTLP | Local filesystem | vulture for data integrity, tempo-debug image for breakpoint debugging, streaming queries, mcp | 

--- a/example/docker-compose/single-binary/docker-compose.yaml
+++ b/example/docker-compose/single-binary/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     restart: always
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml
-      - ./tempo-data:/var/tempo
+      - tempo-data:/var/tempo
     ports:
       - "3200:3200" # tempo
       - "4317:4317" # Tempo OTLP GRPC
@@ -76,3 +76,6 @@ services:
       ]
     depends_on:
       - tempo
+
+volumes:
+  tempo-data:

--- a/example/docker-compose/single-binary/docker-compose.yaml
+++ b/example/docker-compose/single-binary/docker-compose.yaml
@@ -11,21 +11,8 @@ services:
       - "4317:4317" # Tempo OTLP GRPC
       - "4318:4318" # Tempo OTLP HTTP
     environment:
-     - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
 
-  minio:
-    image: minio/minio:latest
-    environment:
-      - MINIO_ACCESS_KEY=tempo
-      - MINIO_SECRET_KEY=supersecret
-    ports:
-      - "9001:9001"
-    entrypoint:
-      - sh
-      - -euc
-      - mkdir -p /data/tempo && minio server /data --console-address ':9001'
-
- 
   # ingest pipeline
   k6-tracing:
     image: ghcr.io/grafana/xk6-client-tracing:v0.0.9

--- a/example/docker-compose/single-binary/tempo.yaml
+++ b/example/docker-compose/single-binary/tempo.yaml
@@ -34,15 +34,11 @@ query_frontend:
 
 storage:
   trace:
-    backend: s3
-    s3:
-      bucket: tempo
-      endpoint: minio:9000
-      access_key: tempo
-      secret_key: supersecret
-      insecure: true
+    backend: local
     wal:
       path: /var/tempo/wal # where to store the wal locally
+    local:
+      path: /var/tempo/blocks
 
 overrides:
   defaults:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
We don't have any example using local backend. Since Tempo singlebinary can be run with a persistent volume I think its beneficial to have a simpler example 


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`