### PR TITLE
[DOC] Move v2 release notes into version-2 subdirectory

### DIFF
--- a/docs/sources/tempo/release-notes/version-2/_index.md
+++ b/docs/sources/tempo/release-notes/version-2/_index.md
@@ -1,0 +1,12 @@
+---
+title: Version 2 release notes
+menuTitle: Version 2
+description: Release notes for Grafana Tempo version 2.x
+weight: 100
+---
+
+# Version 2 release notes
+
+Release notes for Grafana Tempo version 2.x releases.
+
+{{< section >}}

--- a/docs/sources/tempo/release-notes/version-2/v2-0.md
+++ b/docs/sources/tempo/release-notes/version-2/v2-0.md
@@ -3,6 +3,8 @@ title: Version 2.0 release notes
 menuTitle: V2.0
 description: Release notes for Grafana Tempo 2.0
 weight: 60
+aliases:
+  - ../v2-0/ # /docs/tempo/<TEMPO_VERSION>/release-notes/v2-0/
 ---
 
 # Version 2.0 release notes

--- a/docs/sources/tempo/release-notes/version-2/v2-1.md
+++ b/docs/sources/tempo/release-notes/version-2/v2-1.md
@@ -3,6 +3,8 @@ title: Version 2.1 release notes
 menuTitle: V2.1
 description: Release notes for Grafana Tempo 2.1
 weight: 55
+aliases:
+  - ../v2-1/ # /docs/tempo/<TEMPO_VERSION>/release-notes/v2-1/
 ---
 
 # Version 2.1 release notes

--- a/docs/sources/tempo/release-notes/version-2/v2-10.md
+++ b/docs/sources/tempo/release-notes/version-2/v2-10.md
@@ -3,6 +3,8 @@ title: Version 2.10 release notes
 menuTitle: V2.10
 description: Release notes for Grafana Tempo 2.10
 weight: 10
+aliases:
+  - ../v2-10/ # /docs/tempo/<TEMPO_VERSION>/release-notes/v2-10/
 ---
 
 # Version 2.10 release notes

--- a/docs/sources/tempo/release-notes/version-2/v2-2.md
+++ b/docs/sources/tempo/release-notes/version-2/v2-2.md
@@ -3,6 +3,8 @@ title: Version 2.2 release notes
 menuTitle: V2.2
 description: Release notes for Grafana Tempo 2.2
 weight: 50
+aliases:
+  - ../v2-2/ # /docs/tempo/<TEMPO_VERSION>/release-notes/v2-2/
 ---
 
 # Version 2.2 release notes

--- a/docs/sources/tempo/release-notes/version-2/v2-3.md
+++ b/docs/sources/tempo/release-notes/version-2/v2-3.md
@@ -3,6 +3,8 @@ title: Version 2.3 release notes
 menuTitle: V2.3
 description: Release notes for Grafana Tempo 2.3
 weight: 45
+aliases:
+  - ../v2-3/ # /docs/tempo/<TEMPO_VERSION>/release-notes/v2-3/
 ---
 
 # Version 2.3 release notes

--- a/docs/sources/tempo/release-notes/version-2/v2-4.md
+++ b/docs/sources/tempo/release-notes/version-2/v2-4.md
@@ -3,6 +3,8 @@ title: Version 2.4 release notes
 menuTitle: V2.4
 description: Release notes for Grafana Tempo 2.4
 weight: 40
+aliases:
+  - ../v2-4/ # /docs/tempo/<TEMPO_VERSION>/release-notes/v2-4/
 ---
 
 # Version 2.4 release notes

--- a/docs/sources/tempo/release-notes/version-2/v2-5.md
+++ b/docs/sources/tempo/release-notes/version-2/v2-5.md
@@ -3,6 +3,8 @@ title: Version 2.5 release notes
 menuTitle: V2.5
 description: Release notes for Grafana Tempo 2.5
 weight: 35
+aliases:
+  - ../v2-5/ # /docs/tempo/<TEMPO_VERSION>/release-notes/v2-5/
 ---
 
 # Version 2.5 release notes

--- a/docs/sources/tempo/release-notes/version-2/v2-6.md
+++ b/docs/sources/tempo/release-notes/version-2/v2-6.md
@@ -3,6 +3,8 @@ title: Version 2.6 release notes
 menuTitle: V2.6
 description: Release notes for Grafana Tempo 2.6
 weight: 30
+aliases:
+  - ../v2-6/ # /docs/tempo/<TEMPO_VERSION>/release-notes/v2-6/
 ---
 
 # Version 2.6 release notes

--- a/docs/sources/tempo/release-notes/version-2/v2-7.md
+++ b/docs/sources/tempo/release-notes/version-2/v2-7.md
@@ -3,6 +3,8 @@ title: Version 2.7 release notes
 menuTitle: V2.7
 description: Release notes for Grafana Tempo 2.7
 weight: 25
+aliases:
+  - ../v2-7/ # /docs/tempo/<TEMPO_VERSION>/release-notes/v2-7/
 ---
 
 # Version 2.7 release notes

--- a/docs/sources/tempo/release-notes/version-2/v2-8.md
+++ b/docs/sources/tempo/release-notes/version-2/v2-8.md
@@ -3,6 +3,8 @@ title: Version 2.8 release notes
 menuTitle: V2.8
 description: Release notes for Grafana Tempo 2.8
 weight: 20
+aliases:
+  - ../v2-8/ # /docs/tempo/<TEMPO_VERSION>/release-notes/v2-8/
 ---
 
 # Version 2.8 release notes

--- a/docs/sources/tempo/release-notes/version-2/v2-9.md
+++ b/docs/sources/tempo/release-notes/version-2/v2-9.md
@@ -3,6 +3,8 @@ title: Version 2.9 release notes
 menuTitle: V2.9
 description: Release notes for Grafana Tempo 2.9
 weight: 15
+aliases:
+  - ../v2-9/ # /docs/tempo/<TEMPO_VERSION>/release-notes/v2-9/
 ---
 
 # Version 2.9 release notes


### PR DESCRIPTION
This PR prepares for the v3.0 release notes. It moves the v2.x release notes into a new version-2 folder. We did the same thing with the 1.x release notes when 2.0 came out. 

There are not other changes to the text in the files. Frontmatter updates to add aliases.

- Moves all v2.x release note files (`v2-0.md` through `v2-10.md`) into a `version-2/` subdirectory under `release-notes/`, matching the existing `version-1/` folder structure.
- Adds a `version-2/_index.md` section index page.
- Adds Hugo aliases to each moved file so old URLs (`/release-notes/v2-X/`) redirect to the new locations (`/release-notes/version-2/v2-X/`).

Made with assistance from Cursor/Opus 4.6. 

- [X] Documentation added. 