### PR TITLE
[DOC] Update storage config doc for 3.0 changes

### DIFF
--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -56,6 +56,7 @@ The Tempo configuration options include:
         - [Runtime overrides](#runtime-overrides)
         - [User-configurable overrides](#user-configurable-overrides)
       - [Ingestion rate strategy](#ingestion-rate-strategy)
+        - [Examples](#examples-1)
   - [Usage-report](#usage-report)
     - [Configure usage-reporting](#configure-usage-reporting)
   - [Cache](#cache)
@@ -1248,6 +1249,13 @@ storage:
         # CLI flag -storage.trace.backend
         [backend: <string>]
 
+        # Local backend configuration. Will be used only if value of backend is "local".
+        # For development and testing only. Use object storage for production workloads.
+        local:
+
+            # Path to store trace data on local disk
+            [path: <string>]
+
         # GCS configuration. Will be used only if value of backend is "gcs"
         # Check the GCS doc within this folder for information on GCS specific permissions.
         gcs:
@@ -1305,6 +1313,9 @@ storage:
             # See the GCS documentation for more detail: https://cloud.google.com/storage/docs/metadata
             [object_metadata: <map[string]string>]
 
+            # Optional. Default is 3
+            # Number of times to retry failed requests to GCS.
+            [max_retries: <int> | default = 3]
 
         # S3 configuration. Will be used only if value of backend is "s3"
         # Check the S3 doc within this folder for information on s3 specific permissions.
@@ -1350,6 +1361,10 @@ storage:
             # enable if endpoint is http
             [insecure: <bool>]
 
+            # Optional. Default is 0 (disabled)
+            # Part size for multipart uploads. Set to a non-zero value to enable multipart uploads.
+            [part_size: <int>]
+
             # optional.
             # Path to the client certificate file.
             [tls_cert_path: <string>]
@@ -1377,6 +1392,10 @@ storage:
             # optional.
             # Override the default minimum TLS version. The default value is VersionTLS12. Allowed values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13
             [tls_min_version: <string>]
+
+            # Optional. Default is false.
+            # Use V2 signing instead of V4 for S3 requests.
+            [signature_v2: <bool>]
 
             # optional.
             # enable to use path-style requests.
@@ -1429,6 +1448,18 @@ storage:
             # See the [S3 documentation on object tagging](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html) for more detail.
             [tags: <map[string]string>]
 
+            # Optional.
+            # S3 storage class for uploaded objects. If unset, the default storage class of the bucket is used.
+            # See the [S3 documentation on storage classes](https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html) for valid values.
+            [storage_class: <string>]
+
+            # Optional.
+            # A map of key-value strings for user-defined metadata to store on S3 objects.
+            [metadata: <map[string]string>]
+
+            # Deprecated. Use native AWS authentication mechanisms (IAM roles, environment
+            # variables) instead.
+            [native_aws_auth_enabled: <bool> | default = false]
 
             [sse: <map[string]string>]:
               # Optional
@@ -1451,8 +1482,7 @@ storage:
               # It expects a 32 byte long string.
               encryption_key:
 
-        # azure configuration. Will be used only if value of backend is "azure"
-        # EXPERIMENTAL
+        # Azure configuration. Will be used only if value of backend is "azure".
         azure:
 
             # store traces in this container.
@@ -1490,7 +1520,15 @@ storage:
 
             # optional.
             # The Client ID for the user-assigned Azure Managed Identity used to access Azure storage.
-            [user_assigned_id: <bool>]
+            [user_assigned_id: <string>]
+
+            # Optional. Default is 4
+            # Number of simultaneous uploads to Azure.
+            [max_buffers: <int> | default = 4]
+
+            # Optional. Default is 3145728 (3 MiB)
+            # Buffer size for uploads to Azure.
+            [buffer_size: <int> | default = 3145728]
 
             # Optional. Default is 0 (disabled)
             # Example: "hedge_requests_at: 500ms"
@@ -1518,7 +1556,7 @@ storage:
         # the index. Default 2.
         [blocklist_poll_tenant_index_builders: <int>]
 
-        # Number of tenants to poll concurrently. Default is 1.
+        # Number of tenants to poll concurrently. Default is 0 (no limit).
         [blocklist_poll_tenant_concurrency: <int>]
 
         # The oldest allowable tenant index. If an index is pulled that is older than this duration,
@@ -1551,7 +1589,7 @@ storage:
         # Used to tune how quickly the poller will delete any remaining backend
         # objects found in the tenant path.  This functionality requires enabling
         # below.
-        # Default: 12h
+        # Default: 0s (disabled)
         [empty_tenant_deletion_age: <duration>]
 
         # Polling will delete the index for a tenant if no blocks are found to
@@ -1596,10 +1634,10 @@ storage:
         pool:
 
             # total number of workers pulling jobs from the queue
-            [max_workers: <int> | default = 30]
+            [max_workers: <int> | default = 400]
 
             # length of job queue. important for querier as it queues a job for every block it has to search
-            [queue_depth: <int> | default = 10000 ]
+            [queue_depth: <int> | default = 20000]
 
         # configuration block for the Write Ahead Log (WAL)
         wal: <WAL config>

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -1313,8 +1313,8 @@ storage:
             # See the GCS documentation for more detail: https://cloud.google.com/storage/docs/metadata
             [object_metadata: <map[string]string>]
 
-            # Optional. Default is 3
-            # Number of times to retry failed requests to GCS.
+            # Optional. Default is 3.
+            # Number of times to retry GCS copy and delete operations used by compaction and retention.
             [max_retries: <int> | default = 3]
 
         # S3 configuration. Will be used only if value of backend is "s3"
@@ -1361,8 +1361,9 @@ storage:
             # enable if endpoint is http
             [insecure: <bool>]
 
-            # Optional. Default is 0 (disabled)
-            # Part size for multipart uploads. Set to a non-zero value to enable multipart uploads.
+            # Optional. Default is 0 (disabled).
+            # Part size in bytes for multipart uploads. Set to 0 to disable multipart uploads.
+            # Non-zero values must be at least 5 MiB (5242880 bytes).
             [part_size: <int>]
 
             # optional.
@@ -1457,8 +1458,9 @@ storage:
             # A map of key-value strings for user-defined metadata to store on S3 objects.
             [metadata: <map[string]string>]
 
-            # Deprecated. Use native AWS authentication mechanisms (IAM roles, environment
-            # variables) instead.
+            # Deprecated and ignored. This setting has no effect other than emitting a startup
+            # warning, and will be removed in a future release. Use native AWS authentication
+            # mechanisms (IAM roles, environment variables) instead.
             [native_aws_auth_enabled: <bool> | default = false]
 
             [sse: <map[string]string>]:
@@ -1556,7 +1558,7 @@ storage:
         # the index. Default 2.
         [blocklist_poll_tenant_index_builders: <int>]
 
-        # Number of tenants to poll concurrently. Default is 0 (no limit).
+        # Number of tenants to poll concurrently. Default is 1.
         [blocklist_poll_tenant_concurrency: <int>]
 
         # The oldest allowable tenant index. If an index is pulled that is older than this duration,
@@ -1589,7 +1591,7 @@ storage:
         # Used to tune how quickly the poller will delete any remaining backend
         # objects found in the tenant path.  This functionality requires enabling
         # below.
-        # Default: 0s (disabled)
+        # Default: 12h
         [empty_tenant_deletion_age: <duration>]
 
         # Polling will delete the index for a tenant if no blocks are found to


### PR DESCRIPTION
**What this PR does**:
Updates storage configuration section for Tempo 3.0. Add missing YAML configuration options and fix inaccurate defaults in the storage section.

Added missing options (verified against manifest and Go source):
- GCS: `max_retries`
- S3: `part_size`, `signature_v2`, `storage_class`, `metadata`, `native_aws_auth_enabled` (deprecated)
- Azure: `max_buffers`, `buffer_size`
- Local: added the entire `local:` block (previously absent)

Fixed incorrect defaults:
- `pool.max_workers`: 30 → 400
- `pool.queue_depth`: 10000 → 20000
- `blocklist_poll_tenant_concurrency`: 1 → 0
- `empty_tenant_deletion_age`: 12h → 0s

Fixed incorrect type:
- `azure.user_assigned_id`: `<bool>` → `<string>`

Removed stale label:
- Removed "EXPERIMENTAL" from Azure backend header


**Which issue(s) this PR fixes**:
Part of https://github.com/grafana/tempo-squad/issues/1144

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`