### PR TITLE
doc: added 2.8.4 security fixes to release notes

### DIFF
--- a/docs/sources/tempo/release-notes/version-2/v2-8.md
+++ b/docs/sources/tempo/release-notes/version-2/v2-8.md
@@ -248,7 +248,7 @@ The following updates were made to address security issues.
 - Updated `github.com/go-jose/go-jose/v4` to v4.1.4 to address [CVE-2026-34986](https://github.com/advisories/GHSA-78h2-9frx-2jm8). [[PR 6908](https://github.com/grafana/tempo/pull/6908)]
 - Updated `github.com/antchfx/xpath` to v1.3.6 to address [CVE-2026-32287](https://nvd.nist.gov/vuln/detail/CVE-2026-32287). [[PR 6763](https://github.com/grafana/tempo/pull/6763)]
 - Capped the exemplars hint in TraceQL metrics queries to prevent unbounded memory allocation. Addresses CVE-2026-27878. [[PR 6792](https://github.com/grafana/tempo/pull/6792)]
-- Set default `max_result_limit` for search to 262144 (256×1024). The previous default of `0` allowed unbounded search result sets. Addresses CVE-2026-21728. [[PR 6525](https://github.com/grafana/tempo/pull/6525)]
+- Set default `max_result_limit` for search to `262144` (256×1024). The previous default of `0` allowed unbounded search result sets. Addresses CVE-2026-21728. [[PR 6525](https://github.com/grafana/tempo/pull/6525)]
 
 ### 2.8.3
 

--- a/docs/sources/tempo/release-notes/version-2/v2-8.md
+++ b/docs/sources/tempo/release-notes/version-2/v2-8.md
@@ -239,6 +239,17 @@ In addition, these Tempo serverless related metrics have been removed: `tempo_qu
 
 The following updates were made to address security issues.
 
+### 2.8.4
+
+- Updated Go to version 1.26.2 to address [CVE-2026-25679](https://nvd.nist.gov/vuln/detail/CVE-2026-25679). [[PR 6800](https://github.com/grafana/tempo/pull/6800)]
+- Patched gRPC modules to v1.79.3 and upgraded `go.opentelemetry.io/otel/sdk` to v1.40.0 to address [CVE-2026-33186](https://github.com/advisories/GHSA-p77j-4mvh-x3m3) and [CVE-2026-39883](https://github.com/advisories/GHSA-hfvc-g4fc-pqhx). [[PR 6899](https://github.com/grafana/tempo/pull/6899)]
+- Updated `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp` to v1.43.0 to address [CVE-2026-39882](https://github.com/advisories/GHSA-w8rr-5gcm-pp58). [[PR 6890](https://github.com/grafana/tempo/pull/6890)]
+- Updated `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp` to v1.43.0 to address [CVE-2026-39882](https://github.com/advisories/GHSA-w8rr-5gcm-pp58). [[PR 6889](https://github.com/grafana/tempo/pull/6889)]
+- Updated `github.com/go-jose/go-jose/v4` to v4.1.4 to address [CVE-2026-34986](https://github.com/advisories/GHSA-78h2-9frx-2jm8). [[PR 6908](https://github.com/grafana/tempo/pull/6908)]
+- Updated `github.com/antchfx/xpath` to v1.3.6 to address [CVE-2026-32287](https://nvd.nist.gov/vuln/detail/CVE-2026-32287). [[PR 6763](https://github.com/grafana/tempo/pull/6763)]
+- Capped the exemplars hint in TraceQL metrics queries to prevent unbounded memory allocation. Addresses CVE-2026-27878. [[PR 6792](https://github.com/grafana/tempo/pull/6792)]
+- Set default `max_result_limit` for search to 262144 (256×1024). The previous default of `0` allowed unbounded search result sets. Addresses CVE-2026-21728. [[PR 6525](https://github.com/grafana/tempo/pull/6525)]
+
 ### 2.8.3
 
 - Updated Go to version 1.25.5 to address [CVE-2025-61729](https://github.com/advisories/GHSA-7c64-f9jr-v9h2), [CVE-2025-47907](https://github.com/advisories/GHSA-j5pm-7495-qmr3), [CVE-2025-58183](https://github.com/advisories/GHSA-9gcr-gp5f-jw27), and [CVE-2025-61727](https://github.com/advisories/GHSA-5mh9-3jwc-rp59). [[PRs 6089](https://github.com/grafana/tempo/pull/6089), [6096](https://github.com/grafana/tempo/pull/6096), [6227](https://github.com/grafana/tempo/pull/6227)]


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
- Document CVE-addressing dependency upgrades and fixes shipped in Tempo 2.8.4 under the Security fixes section of v2-8.md.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`