### PR TITLE
enhancement: stale marker when series expire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
 * [ENHANCEMENT] Add metric to track livestore block cut reasons [#6922](https://github.com/grafana/tempo/pull/6922) (@zhxiaogg)
 * [ENHANCEMENT] Enable async parquet read mode for WAL completion path [#6967](https://github.com/grafana/tempo/pull/6967) (@zhxiaogg)
 * [ENHANCEMENT] metrics-generator: add `leave_consumer_group_on_shutdown` to send LeaveGroup on shutdown for immediate partition reassignment instead of waiting for session timeout [#6575](https://github.com/grafana/tempo/pull/6575) (@zalegrala)
+* [ENHANCEMENT] Send stale marker to remote write when series expire [#7056](https://github.com/grafana/tempo/pull/7056) (@LucasMRC)
 * [BUGFIX] Fix tempo-vulture ignoring `-tempo-push-tls` flag in normal operating mode. [#6976](https://github.com/grafana/tempo/pull/6976) (@xaque208)
 * [BUGFIX] livestore: check readiness before lag for SearchRecent and QueryRange queries [#6911](https://github.com/grafana/tempo/pull/6911) (@zhxiaogg)
 * [BUGFIX] Fix integer overflow in query parameters by using `strconv.ParseUint` instead of `strconv.Atoi`/`strconv.ParseInt` for unsigned integer fields. [#6612](https://github.com/grafana/tempo/pull/6612) (@bejaratommy)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 * [ENHANCEMENT] Add metric to track livestore block cut reasons [#6922](https://github.com/grafana/tempo/pull/6922) (@zhxiaogg)
 * [ENHANCEMENT] Enable async parquet read mode for WAL completion path [#6967](https://github.com/grafana/tempo/pull/6967) (@zhxiaogg)
 * [ENHANCEMENT] metrics-generator: add `leave_consumer_group_on_shutdown` to send LeaveGroup on shutdown for immediate partition reassignment instead of waiting for session timeout [#6575](https://github.com/grafana/tempo/pull/6575) (@zalegrala)
+* [ENHANCEMENT] Send stale marker to remote write when series expire [#7056](https://github.com/grafana/tempo/pull/7056) (@LucasMRC)
 * [BUGFIX] Fix tempo-vulture ignoring `-tempo-push-tls` flag in normal operating mode. [#6976](https://github.com/grafana/tempo/pull/6976) (@xaque208)
 * [BUGFIX] livestore: check readiness before lag for SearchRecent and QueryRange queries [#6911](https://github.com/grafana/tempo/pull/6911) (@zhxiaogg)
 * [BUGFIX] Fix integer overflow in query parameters by using `strconv.ParseUint` instead of `strconv.Atoi`/`strconv.ParseInt` for unsigned integer fields. [#6612](https://github.com/grafana/tempo/pull/6612) (@bejaratommy)

--- a/modules/generator/registry/appender_test.go
+++ b/modules/generator/registry/appender_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/prometheus/prometheus/model/exemplar"
@@ -57,6 +58,19 @@ func (n noopAppender) AppendHistogramCTZeroSample(_ storage.SeriesRef, _ labels.
 func (n noopAppender) AppendHistogramSTZeroSample(_ storage.SeriesRef, _ labels.Labels, _, _ int64, _ *prom_histogram.Histogram, _ *prom_histogram.FloatHistogram) (storage.SeriesRef, error) {
 	return 0, nil
 }
+
+type errorAppender struct {
+	noopAppender
+}
+
+func (n errorAppender) Append(storage.SeriesRef, labels.Labels, int64, float64) (storage.SeriesRef, error) {
+	return 0, errors.New("append error")
+}
+
+var (
+	_ storage.Appendable = (*errorAppender)(nil)
+	_ storage.Appender   = (*errorAppender)(nil)
+)
 
 type capturingAppender struct {
 	samples      []sample

--- a/modules/generator/registry/counter.go
+++ b/modules/generator/registry/counter.go
@@ -1,10 +1,12 @@
 package registry
 
 import (
+	"math"
 	"sync"
 	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"go.uber.org/atomic"
 )
@@ -177,6 +179,12 @@ func (c *counter) removeStaleSeries(appender storage.Appender, timeMs, staleTime
 
 	for hash, s := range c.series {
 		if s.lastUpdated.Load() < staleTimeMs {
+			if appender != nil {
+				_, err := appender.Append(0, s.labels, timeMs, math.Float64frombits(value.StaleNaN))
+				if err != nil {
+					// handle
+				}
+			}
 			delete(c.series, hash)
 			c.lifecycler.OnDelete(hash, 1)
 		}

--- a/modules/generator/registry/counter.go
+++ b/modules/generator/registry/counter.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"go.uber.org/atomic"
+	"go.uber.org/multierr"
 )
 
 type counter struct {
@@ -173,16 +174,18 @@ func (c *counter) countSeriesDemand() int {
 	return int(c.seriesDemand.Estimate())
 }
 
-func (c *counter) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) {
+func (c *counter) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) error {
 	c.seriesMtx.Lock()
 	defer c.seriesMtx.Unlock()
+
+	errs := []error{}
 
 	for hash, s := range c.series {
 		if s.lastUpdated.Load() < staleTimeMs {
 			if appender != nil {
 				_, err := appender.Append(0, s.labels, timeMs, math.Float64frombits(value.StaleNaN))
 				if err != nil {
-					// handle
+					errs = append(errs, err)
 				}
 			}
 			delete(c.series, hash)
@@ -190,4 +193,9 @@ func (c *counter) removeStaleSeries(appender storage.Appender, timeMs, staleTime
 		}
 	}
 	c.seriesDemand.Advance()
+
+	if len(errs) > 0 {
+		return multierr.Combine(errs...)
+	}
+	return nil
 }

--- a/modules/generator/registry/counter.go
+++ b/modules/generator/registry/counter.go
@@ -171,7 +171,7 @@ func (c *counter) countSeriesDemand() int {
 	return int(c.seriesDemand.Estimate())
 }
 
-func (c *counter) removeStaleSeries(staleTimeMs int64) {
+func (c *counter) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) {
 	c.seriesMtx.Lock()
 	defer c.seriesMtx.Unlock()
 

--- a/modules/generator/registry/counter.go
+++ b/modules/generator/registry/counter.go
@@ -1,10 +1,12 @@
 package registry
 
 import (
+	"math"
 	"sync"
 	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"go.uber.org/atomic"
 )
@@ -182,6 +184,12 @@ func (c *counter) removeStaleSeries(appender storage.Appender, timeMs, staleTime
 
 	for hash, s := range c.series {
 		if s.lastUpdated.Load() < staleTimeMs {
+			if appender != nil {
+				_, err := appender.Append(0, s.labels, timeMs, math.Float64frombits(value.StaleNaN))
+				if err != nil {
+					// handle
+				}
+			}
 			delete(c.series, hash)
 			c.lifecycler.OnDelete(hash, 1)
 		}

--- a/modules/generator/registry/counter.go
+++ b/modules/generator/registry/counter.go
@@ -176,7 +176,7 @@ func (c *counter) countSeriesDemand() int {
 	return int(c.seriesDemand.Estimate())
 }
 
-func (c *counter) removeStaleSeries(staleTimeMs int64) {
+func (c *counter) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) {
 	c.seriesMtx.Lock()
 	defer c.seriesMtx.Unlock()
 

--- a/modules/generator/registry/counter.go
+++ b/modules/generator/registry/counter.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"go.uber.org/atomic"
+	"go.uber.org/multierr"
 )
 
 type counter struct {
@@ -178,16 +179,18 @@ func (c *counter) countSeriesDemand() int {
 	return int(c.seriesDemand.Estimate())
 }
 
-func (c *counter) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) {
+func (c *counter) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) error {
 	c.seriesMtx.Lock()
 	defer c.seriesMtx.Unlock()
+
+	errs := []error{}
 
 	for hash, s := range c.series {
 		if s.lastUpdated.Load() < staleTimeMs {
 			if appender != nil {
 				_, err := appender.Append(0, s.labels, timeMs, math.Float64frombits(value.StaleNaN))
 				if err != nil {
-					// handle
+					errs = append(errs, err)
 				}
 			}
 			delete(c.series, hash)
@@ -195,4 +198,9 @@ func (c *counter) removeStaleSeries(appender storage.Appender, timeMs, staleTime
 		}
 	}
 	c.seriesDemand.Advance()
+
+	if len(errs) > 0 {
+		return multierr.Combine(errs...)
+	}
+	return nil
 }

--- a/modules/generator/registry/counter_test.go
+++ b/modules/generator/registry/counter_test.go
@@ -146,7 +146,7 @@ func Test_counter_removeStaleSeries(t *testing.T) {
 	c.Inc(buildTestLabels([]string{"label"}, []string{"value-1"}), 1.0)
 	c.Inc(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.0)
 
-	c.removeStaleSeries(timeMs)
+	c.removeStaleSeries(nil, 0, timeMs)
 
 	assert.Equal(t, 0, removedSeries)
 
@@ -166,7 +166,7 @@ func Test_counter_removeStaleSeries(t *testing.T) {
 	// update value-2 series
 	c.Inc(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.0)
 
-	c.removeStaleSeries(timeMs)
+	c.removeStaleSeries(nil, 0, timeMs)
 
 	assert.Equal(t, 1, removedSeries)
 
@@ -233,7 +233,7 @@ func Test_counter_concurrencyDataRace(t *testing.T) {
 	})
 
 	go accessor(func() {
-		c.removeStaleSeries(time.Now().UnixMilli())
+		c.removeStaleSeries(nil, 0, time.Now().UnixMilli())
 	})
 
 	time.Sleep(200 * time.Millisecond)
@@ -374,7 +374,7 @@ func Test_counter_demandDecay(t *testing.T) {
 
 	// Advance the cardinality tracker enough times to clear the window
 	for i := 0; i < 5; i++ {
-		c.removeStaleSeries(time.Now().UnixMilli())
+		c.removeStaleSeries(nil, 0, time.Now().UnixMilli())
 	}
 
 	// Demand should have decreased or be zero

--- a/modules/generator/registry/counter_test.go
+++ b/modules/generator/registry/counter_test.go
@@ -178,6 +178,28 @@ func Test_counter_removeStaleSeries(t *testing.T) {
 	collectMetricAndAssert(t, c, collectionTimeMs, 1, expectedSamples, nil)
 }
 
+func Test_counter_removeStaleSeries_appenderError(t *testing.T) {
+	var removedSeries int
+	lifecycler := &mockLimiter{
+		onDeleteFunc: func(_ uint64, count uint32) {
+			assert.Equal(t, uint32(1), count)
+			removedSeries++
+		},
+	}
+
+	c := newCounter("my_counter", lifecycler, map[string]string{}, 15*time.Minute)
+
+	c.Inc(buildTestLabels([]string{"label"}, []string{"value-1"}), 1.0)
+	c.Inc(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.0)
+
+	appender := errorAppender{}
+	timeMs := time.Now().Add(1 * time.Hour).UnixMilli()
+	err := c.removeStaleSeries(appender, 0, timeMs)
+
+	assert.Error(t, err)
+	assert.Equal(t, removedSeries, 2)
+}
+
 func Test_counter_externalLabels(t *testing.T) {
 	c := newCounter("my_counter", noopLimiter, map[string]string{"external_label": "external_value"}, 15*time.Minute)
 

--- a/modules/generator/registry/counter_test.go
+++ b/modules/generator/registry/counter_test.go
@@ -146,7 +146,8 @@ func Test_counter_removeStaleSeries(t *testing.T) {
 	c.Inc(buildTestLabels([]string{"label"}, []string{"value-1"}), 1.0)
 	c.Inc(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.0)
 
-	c.removeStaleSeries(nil, 0, timeMs)
+	appender := noopAppender{}
+	c.removeStaleSeries(appender, 0, timeMs)
 
 	assert.Equal(t, 0, removedSeries)
 
@@ -166,7 +167,7 @@ func Test_counter_removeStaleSeries(t *testing.T) {
 	// update value-2 series
 	c.Inc(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.0)
 
-	c.removeStaleSeries(nil, 0, timeMs)
+	c.removeStaleSeries(appender, 0, timeMs)
 
 	assert.Equal(t, 1, removedSeries)
 
@@ -233,7 +234,8 @@ func Test_counter_concurrencyDataRace(t *testing.T) {
 	})
 
 	go accessor(func() {
-		c.removeStaleSeries(nil, 0, time.Now().UnixMilli())
+		appender := noopAppender{}
+		c.removeStaleSeries(appender, 0, time.Now().UnixMilli())
 	})
 
 	time.Sleep(200 * time.Millisecond)
@@ -373,8 +375,9 @@ func Test_counter_demandDecay(t *testing.T) {
 	assert.Greater(t, initialDemand, 0)
 
 	// Advance the cardinality tracker enough times to clear the window
+	appender := noopAppender{}
 	for i := 0; i < 5; i++ {
-		c.removeStaleSeries(nil, 0, time.Now().UnixMilli())
+		c.removeStaleSeries(appender, 0, time.Now().UnixMilli())
 	}
 
 	// Demand should have decreased or be zero

--- a/modules/generator/registry/counter_test.go
+++ b/modules/generator/registry/counter_test.go
@@ -147,7 +147,7 @@ func Test_counter_removeStaleSeries(t *testing.T) {
 	c.Inc(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.0)
 
 	appender := noopAppender{}
-	c.removeStaleSeries(appender, 0, timeMs)
+	_ = c.removeStaleSeries(appender, 0, timeMs)
 
 	assert.Equal(t, 0, removedSeries)
 
@@ -167,7 +167,7 @@ func Test_counter_removeStaleSeries(t *testing.T) {
 	// update value-2 series
 	c.Inc(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.0)
 
-	c.removeStaleSeries(appender, 0, timeMs)
+	_ = c.removeStaleSeries(appender, 0, timeMs)
 
 	assert.Equal(t, 1, removedSeries)
 
@@ -235,7 +235,7 @@ func Test_counter_concurrencyDataRace(t *testing.T) {
 
 	go accessor(func() {
 		appender := noopAppender{}
-		c.removeStaleSeries(appender, 0, time.Now().UnixMilli())
+		_ = c.removeStaleSeries(appender, 0, time.Now().UnixMilli())
 	})
 
 	time.Sleep(200 * time.Millisecond)
@@ -377,7 +377,7 @@ func Test_counter_demandDecay(t *testing.T) {
 	// Advance the cardinality tracker enough times to clear the window
 	appender := noopAppender{}
 	for i := 0; i < 5; i++ {
-		c.removeStaleSeries(appender, 0, time.Now().UnixMilli())
+		_ = c.removeStaleSeries(appender, 0, time.Now().UnixMilli())
 	}
 
 	// Demand should have decreased or be zero

--- a/modules/generator/registry/gauge.go
+++ b/modules/generator/registry/gauge.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"go.uber.org/atomic"
+	"go.uber.org/multierr"
 )
 
 var _ metric = (*gauge)(nil)
@@ -152,16 +153,18 @@ func (g *gauge) countSeriesDemand() int {
 	return int(g.seriesDemand.Estimate())
 }
 
-func (g *gauge) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) {
+func (g *gauge) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) error {
 	g.seriesMtx.Lock()
 	defer g.seriesMtx.Unlock()
+
+	errs := []error{}
 
 	for hash, s := range g.series {
 		if s.lastUpdated.Load() < staleTimeMs {
 			if appender != nil {
 				_, err := appender.Append(0, s.labels, timeMs, math.Float64frombits(value.StaleNaN))
 				if err != nil {
-					// handle
+					errs = append(errs, err)
 				}
 			}
 			delete(g.series, hash)
@@ -169,4 +172,9 @@ func (g *gauge) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs
 		}
 	}
 	g.seriesDemand.Advance()
+
+	if len(errs) > 0 {
+		return multierr.Combine(errs...)
+	}
+	return nil
 }

--- a/modules/generator/registry/gauge.go
+++ b/modules/generator/registry/gauge.go
@@ -150,7 +150,7 @@ func (g *gauge) countSeriesDemand() int {
 	return int(g.seriesDemand.Estimate())
 }
 
-func (g *gauge) removeStaleSeries(staleTimeMs int64) {
+func (g *gauge) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) {
 	g.seriesMtx.Lock()
 	defer g.seriesMtx.Unlock()
 

--- a/modules/generator/registry/gauge.go
+++ b/modules/generator/registry/gauge.go
@@ -1,10 +1,12 @@
 package registry
 
 import (
+	"math"
 	"sync"
 	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"go.uber.org/atomic"
 )
@@ -156,6 +158,12 @@ func (g *gauge) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs
 
 	for hash, s := range g.series {
 		if s.lastUpdated.Load() < staleTimeMs {
+			if appender != nil {
+				_, err := appender.Append(0, s.labels, timeMs, math.Float64frombits(value.StaleNaN))
+				if err != nil {
+					// handle
+				}
+			}
 			delete(g.series, hash)
 			g.lifecycler.OnDelete(hash, 1)
 		}

--- a/modules/generator/registry/gauge.go
+++ b/modules/generator/registry/gauge.go
@@ -156,7 +156,7 @@ func (g *gauge) countSeriesDemand() int {
 	return int(g.seriesDemand.Estimate())
 }
 
-func (g *gauge) removeStaleSeries(staleTimeMs int64) {
+func (g *gauge) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) {
 	g.seriesMtx.Lock()
 	defer g.seriesMtx.Unlock()
 

--- a/modules/generator/registry/gauge.go
+++ b/modules/generator/registry/gauge.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"go.uber.org/atomic"
+	"go.uber.org/multierr"
 )
 
 var _ metric = (*gauge)(nil)
@@ -158,16 +159,18 @@ func (g *gauge) countSeriesDemand() int {
 	return int(g.seriesDemand.Estimate())
 }
 
-func (g *gauge) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) {
+func (g *gauge) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) error {
 	g.seriesMtx.Lock()
 	defer g.seriesMtx.Unlock()
+
+	errs := []error{}
 
 	for hash, s := range g.series {
 		if s.lastUpdated.Load() < staleTimeMs {
 			if appender != nil {
 				_, err := appender.Append(0, s.labels, timeMs, math.Float64frombits(value.StaleNaN))
 				if err != nil {
-					// handle
+					errs = append(errs, err)
 				}
 			}
 			delete(g.series, hash)
@@ -175,4 +178,9 @@ func (g *gauge) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs
 		}
 	}
 	g.seriesDemand.Advance()
+
+	if len(errs) > 0 {
+		return multierr.Combine(errs...)
+	}
+	return nil
 }

--- a/modules/generator/registry/gauge.go
+++ b/modules/generator/registry/gauge.go
@@ -1,10 +1,12 @@
 package registry
 
 import (
+	"math"
 	"sync"
 	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"go.uber.org/atomic"
 )
@@ -162,6 +164,12 @@ func (g *gauge) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs
 
 	for hash, s := range g.series {
 		if s.lastUpdated.Load() < staleTimeMs {
+			if appender != nil {
+				_, err := appender.Append(0, s.labels, timeMs, math.Float64frombits(value.StaleNaN))
+				if err != nil {
+					// handle
+				}
+			}
 			delete(g.series, hash)
 			g.lifecycler.OnDelete(hash, 1)
 		}

--- a/modules/generator/registry/gauge_test.go
+++ b/modules/generator/registry/gauge_test.go
@@ -170,7 +170,7 @@ func Test_gauge_removeStaleSeries(t *testing.T) {
 	c.Inc(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.0)
 
 	appender := noopAppender{}
-	c.removeStaleSeries(appender, 0, timeMs)
+	_ = c.removeStaleSeries(appender, 0, timeMs)
 
 	assert.Equal(t, 0, removedSeries)
 
@@ -187,7 +187,7 @@ func Test_gauge_removeStaleSeries(t *testing.T) {
 	// update value-2 series
 	c.Inc(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.0)
 
-	c.removeStaleSeries(appender, 0, timeMs)
+	_ = c.removeStaleSeries(appender, 0, timeMs)
 
 	assert.Equal(t, 1, removedSeries)
 
@@ -252,7 +252,7 @@ func Test_gauge_concurrencyDataRace(t *testing.T) {
 
 	go accessor(func() {
 		appender := noopAppender{}
-		c.removeStaleSeries(appender, 0, time.Now().UnixMilli())
+		_ = c.removeStaleSeries(appender, 0, time.Now().UnixMilli())
 	})
 
 	time.Sleep(200 * time.Millisecond)
@@ -373,7 +373,7 @@ func Test_gauge_demandDecay(t *testing.T) {
 	// Advance the cardinality tracker enough times to clear the window
 	appender := noopAppender{}
 	for i := 0; i < 5; i++ {
-		g.removeStaleSeries(appender, 0, time.Now().Add(time.Hour).UnixMilli())
+		_ = g.removeStaleSeries(appender, 0, time.Now().Add(time.Hour).UnixMilli())
 	}
 
 	// Demand should have decreased or be zero

--- a/modules/generator/registry/gauge_test.go
+++ b/modules/generator/registry/gauge_test.go
@@ -169,7 +169,7 @@ func Test_gauge_removeStaleSeries(t *testing.T) {
 	c.Inc(buildTestLabels([]string{"label"}, []string{"value-1"}), 1.0)
 	c.Inc(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.0)
 
-	c.removeStaleSeries(timeMs)
+	c.removeStaleSeries(nil, 0, timeMs)
 
 	assert.Equal(t, 0, removedSeries)
 
@@ -186,7 +186,7 @@ func Test_gauge_removeStaleSeries(t *testing.T) {
 	// update value-2 series
 	c.Inc(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.0)
 
-	c.removeStaleSeries(timeMs)
+	c.removeStaleSeries(nil, 0, timeMs)
 
 	assert.Equal(t, 1, removedSeries)
 
@@ -250,7 +250,7 @@ func Test_gauge_concurrencyDataRace(t *testing.T) {
 	})
 
 	go accessor(func() {
-		c.removeStaleSeries(time.Now().UnixMilli())
+		c.removeStaleSeries(nil, 0, time.Now().UnixMilli())
 	})
 
 	time.Sleep(200 * time.Millisecond)
@@ -370,7 +370,7 @@ func Test_gauge_demandDecay(t *testing.T) {
 
 	// Advance the cardinality tracker enough times to clear the window
 	for i := 0; i < 5; i++ {
-		g.removeStaleSeries(time.Now().Add(time.Hour).UnixMilli())
+		g.removeStaleSeries(nil, 0, time.Now().Add(time.Hour).UnixMilli())
 	}
 
 	// Demand should have decreased or be zero

--- a/modules/generator/registry/gauge_test.go
+++ b/modules/generator/registry/gauge_test.go
@@ -169,7 +169,8 @@ func Test_gauge_removeStaleSeries(t *testing.T) {
 	c.Inc(buildTestLabels([]string{"label"}, []string{"value-1"}), 1.0)
 	c.Inc(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.0)
 
-	c.removeStaleSeries(nil, 0, timeMs)
+	appender := noopAppender{}
+	c.removeStaleSeries(appender, 0, timeMs)
 
 	assert.Equal(t, 0, removedSeries)
 
@@ -186,7 +187,7 @@ func Test_gauge_removeStaleSeries(t *testing.T) {
 	// update value-2 series
 	c.Inc(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.0)
 
-	c.removeStaleSeries(nil, 0, timeMs)
+	c.removeStaleSeries(appender, 0, timeMs)
 
 	assert.Equal(t, 1, removedSeries)
 
@@ -250,7 +251,8 @@ func Test_gauge_concurrencyDataRace(t *testing.T) {
 	})
 
 	go accessor(func() {
-		c.removeStaleSeries(nil, 0, time.Now().UnixMilli())
+		appender := noopAppender{}
+		c.removeStaleSeries(appender, 0, time.Now().UnixMilli())
 	})
 
 	time.Sleep(200 * time.Millisecond)
@@ -369,8 +371,9 @@ func Test_gauge_demandDecay(t *testing.T) {
 	assert.Greater(t, initialDemand, 0)
 
 	// Advance the cardinality tracker enough times to clear the window
+	appender := noopAppender{}
 	for i := 0; i < 5; i++ {
-		g.removeStaleSeries(nil, 0, time.Now().Add(time.Hour).UnixMilli())
+		g.removeStaleSeries(appender, 0, time.Now().Add(time.Hour).UnixMilli())
 	}
 
 	// Demand should have decreased or be zero

--- a/modules/generator/registry/gauge_test.go
+++ b/modules/generator/registry/gauge_test.go
@@ -198,6 +198,28 @@ func Test_gauge_removeStaleSeries(t *testing.T) {
 	collectMetricAndAssert(t, c, collectionTimeMs, 1, expectedSamples, nil)
 }
 
+func Test_gauge_removeStaleSeries_appenderError(t *testing.T) {
+	var removedSeries int
+	lifecycler := &mockLimiter{
+		onDeleteFunc: func(_ uint64, count uint32) {
+			assert.Equal(t, uint32(1), count)
+			removedSeries++
+		},
+	}
+
+	c := newGauge("my_gauge", lifecycler, map[string]string{}, 15*time.Minute)
+
+	c.Inc(buildTestLabels([]string{"label"}, []string{"value-1"}), 1.0)
+	c.Inc(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.0)
+
+	appender := errorAppender{}
+	timeMs := time.Now().Add(1 * time.Hour).UnixMilli()
+	err := c.removeStaleSeries(appender, 0, timeMs)
+
+	assert.Error(t, err)
+	assert.Equal(t, removedSeries, 2)
+}
+
 func Test_gauge_externalLabels(t *testing.T) {
 	c := newGauge("my_gauge", noopLimiter, map[string]string{"external_label": "external_value"}, 15*time.Minute)
 

--- a/modules/generator/registry/gauge_test.go
+++ b/modules/generator/registry/gauge_test.go
@@ -122,6 +122,7 @@ func Test_gaugeSetBorrowed_refreshesExistingSeries(t *testing.T) {
 			seriesDeleted++
 		},
 	}
+	appender := noopAppender{}
 	g := newGauge("my_gauge", lifecycler, map[string]string{}, 15*time.Minute)
 	lbls := buildTestLabels([]string{"label"}, []string{"value"})
 	hash := lbls.Hash()
@@ -137,11 +138,11 @@ func Test_gaugeSetBorrowed_refreshesExistingSeries(t *testing.T) {
 	assert.Equal(t, int64(200), g.series[hash].lastUpdated.Load())
 	assert.Equal(t, 1, seriesUpdated)
 
-	g.removeStaleSeries(150)
+	g.removeStaleSeries(appender, 150, time.Now().UnixMilli())
 	assert.Len(t, g.series, 1)
 	assert.Equal(t, 0, seriesDeleted)
 
-	g.removeStaleSeries(201)
+	g.removeStaleSeries(appender, 201, time.Now().UnixMilli())
 	assert.Empty(t, g.series)
 	assert.Equal(t, 1, seriesDeleted)
 }

--- a/modules/generator/registry/gauge_test.go
+++ b/modules/generator/registry/gauge_test.go
@@ -205,7 +205,7 @@ func Test_gauge_removeStaleSeries(t *testing.T) {
 	c.Inc(buildTestLabels([]string{"label"}, []string{"value-1"}), 1.0)
 	c.Inc(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.0)
 
-	c.removeStaleSeries(timeMs)
+	c.removeStaleSeries(nil, 0, timeMs)
 
 	assert.Equal(t, 0, removedSeries)
 
@@ -222,7 +222,7 @@ func Test_gauge_removeStaleSeries(t *testing.T) {
 	// update value-2 series
 	c.Inc(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.0)
 
-	c.removeStaleSeries(timeMs)
+	c.removeStaleSeries(nil, 0, timeMs)
 
 	assert.Equal(t, 1, removedSeries)
 
@@ -286,7 +286,7 @@ func Test_gauge_concurrencyDataRace(t *testing.T) {
 	})
 
 	go accessor(func() {
-		c.removeStaleSeries(time.Now().UnixMilli())
+		c.removeStaleSeries(nil, 0, time.Now().UnixMilli())
 	})
 
 	time.Sleep(200 * time.Millisecond)
@@ -406,7 +406,7 @@ func Test_gauge_demandDecay(t *testing.T) {
 
 	// Advance the cardinality tracker enough times to clear the window
 	for i := 0; i < 5; i++ {
-		g.removeStaleSeries(time.Now().Add(time.Hour).UnixMilli())
+		g.removeStaleSeries(nil, 0, time.Now().Add(time.Hour).UnixMilli())
 	}
 
 	// Demand should have decreased or be zero

--- a/modules/generator/registry/gauge_test.go
+++ b/modules/generator/registry/gauge_test.go
@@ -207,7 +207,7 @@ func Test_gauge_removeStaleSeries(t *testing.T) {
 	c.Inc(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.0)
 
 	appender := noopAppender{}
-	c.removeStaleSeries(appender, 0, timeMs)
+	_ = c.removeStaleSeries(appender, 0, timeMs)
 
 	assert.Equal(t, 0, removedSeries)
 
@@ -224,7 +224,7 @@ func Test_gauge_removeStaleSeries(t *testing.T) {
 	// update value-2 series
 	c.Inc(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.0)
 
-	c.removeStaleSeries(appender, 0, timeMs)
+	_ = c.removeStaleSeries(appender, 0, timeMs)
 
 	assert.Equal(t, 1, removedSeries)
 
@@ -289,7 +289,7 @@ func Test_gauge_concurrencyDataRace(t *testing.T) {
 
 	go accessor(func() {
 		appender := noopAppender{}
-		c.removeStaleSeries(appender, 0, time.Now().UnixMilli())
+		_ = c.removeStaleSeries(appender, 0, time.Now().UnixMilli())
 	})
 
 	time.Sleep(200 * time.Millisecond)
@@ -410,7 +410,7 @@ func Test_gauge_demandDecay(t *testing.T) {
 	// Advance the cardinality tracker enough times to clear the window
 	appender := noopAppender{}
 	for i := 0; i < 5; i++ {
-		g.removeStaleSeries(appender, 0, time.Now().Add(time.Hour).UnixMilli())
+		_ = g.removeStaleSeries(appender, 0, time.Now().Add(time.Hour).UnixMilli())
 	}
 
 	// Demand should have decreased or be zero

--- a/modules/generator/registry/gauge_test.go
+++ b/modules/generator/registry/gauge_test.go
@@ -235,6 +235,28 @@ func Test_gauge_removeStaleSeries(t *testing.T) {
 	collectMetricAndAssert(t, c, collectionTimeMs, 1, expectedSamples, nil)
 }
 
+func Test_gauge_removeStaleSeries_appenderError(t *testing.T) {
+	var removedSeries int
+	lifecycler := &mockLimiter{
+		onDeleteFunc: func(_ uint64, count uint32) {
+			assert.Equal(t, uint32(1), count)
+			removedSeries++
+		},
+	}
+
+	c := newGauge("my_gauge", lifecycler, map[string]string{}, 15*time.Minute)
+
+	c.Inc(buildTestLabels([]string{"label"}, []string{"value-1"}), 1.0)
+	c.Inc(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.0)
+
+	appender := errorAppender{}
+	timeMs := time.Now().Add(1 * time.Hour).UnixMilli()
+	err := c.removeStaleSeries(appender, 0, timeMs)
+
+	assert.Error(t, err)
+	assert.Equal(t, removedSeries, 2)
+}
+
 func Test_gauge_externalLabels(t *testing.T) {
 	c := newGauge("my_gauge", noopLimiter, map[string]string{"external_label": "external_value"}, 15*time.Minute)
 

--- a/modules/generator/registry/gauge_test.go
+++ b/modules/generator/registry/gauge_test.go
@@ -205,7 +205,8 @@ func Test_gauge_removeStaleSeries(t *testing.T) {
 	c.Inc(buildTestLabels([]string{"label"}, []string{"value-1"}), 1.0)
 	c.Inc(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.0)
 
-	c.removeStaleSeries(nil, 0, timeMs)
+	appender := noopAppender{}
+	c.removeStaleSeries(appender, 0, timeMs)
 
 	assert.Equal(t, 0, removedSeries)
 
@@ -222,7 +223,7 @@ func Test_gauge_removeStaleSeries(t *testing.T) {
 	// update value-2 series
 	c.Inc(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.0)
 
-	c.removeStaleSeries(nil, 0, timeMs)
+	c.removeStaleSeries(appender, 0, timeMs)
 
 	assert.Equal(t, 1, removedSeries)
 
@@ -286,7 +287,8 @@ func Test_gauge_concurrencyDataRace(t *testing.T) {
 	})
 
 	go accessor(func() {
-		c.removeStaleSeries(nil, 0, time.Now().UnixMilli())
+		appender := noopAppender{}
+		c.removeStaleSeries(appender, 0, time.Now().UnixMilli())
 	})
 
 	time.Sleep(200 * time.Millisecond)
@@ -405,8 +407,9 @@ func Test_gauge_demandDecay(t *testing.T) {
 	assert.Greater(t, initialDemand, 0)
 
 	// Advance the cardinality tracker enough times to clear the window
+	appender := noopAppender{}
 	for i := 0; i < 5; i++ {
-		g.removeStaleSeries(nil, 0, time.Now().Add(time.Hour).UnixMilli())
+		g.removeStaleSeries(appender, 0, time.Now().Add(time.Hour).UnixMilli())
 	}
 
 	// Demand should have decreased or be zero

--- a/modules/generator/registry/histogram.go
+++ b/modules/generator/registry/histogram.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"go.uber.org/atomic"
 )
@@ -264,6 +265,22 @@ func (h *histogram) removeStaleSeries(appender storage.Appender, timeMs, staleTi
 
 	for hash, s := range h.series {
 		if s.lastUpdated.Load() < staleTimeMs {
+			if appender != nil {
+				_, err := appender.Append(0, s.countLabels, timeMs, math.Float64frombits(value.StaleNaN))
+				if err != nil {
+					// handle
+				}
+				_, err = appender.Append(0, s.sumLabels, timeMs, math.Float64frombits(value.StaleNaN))
+				if err != nil {
+					// handle
+				}
+				for _, l := range s.bucketLabels {
+					_, err = appender.Append(0, l, timeMs, math.Float64frombits(value.StaleNaN))
+					if err != nil {
+						// handle
+					}
+				}
+			}
 			delete(h.series, hash)
 			h.lifecycler.OnDelete(hash, h.activeSeriesPerHistogramSerie())
 		}

--- a/modules/generator/registry/histogram.go
+++ b/modules/generator/registry/histogram.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"go.uber.org/atomic"
+	"go.uber.org/multierr"
 )
 
 var _ metric = (*histogram)(nil)
@@ -259,25 +260,26 @@ func (h *histogram) countSeriesDemand() int {
 	return int(est) * int(h.activeSeriesPerHistogramSerie())
 }
 
-func (h *histogram) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) {
+func (h *histogram) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) error {
 	h.seriesMtx.Lock()
 	defer h.seriesMtx.Unlock()
 
+	errs := []error{}
 	for hash, s := range h.series {
 		if s.lastUpdated.Load() < staleTimeMs {
 			if appender != nil {
 				_, err := appender.Append(0, s.countLabels, timeMs, math.Float64frombits(value.StaleNaN))
 				if err != nil {
-					// handle
+					errs = append(errs, err)
 				}
 				_, err = appender.Append(0, s.sumLabels, timeMs, math.Float64frombits(value.StaleNaN))
 				if err != nil {
-					// handle
+					errs = append(errs, err)
 				}
 				for _, l := range s.bucketLabels {
 					_, err = appender.Append(0, l, timeMs, math.Float64frombits(value.StaleNaN))
 					if err != nil {
-						// handle
+						errs = append(errs, err)
 					}
 				}
 			}
@@ -286,6 +288,11 @@ func (h *histogram) removeStaleSeries(appender storage.Appender, timeMs, staleTi
 		}
 	}
 	h.seriesDemand.Advance()
+
+	if len(errs) > 0 {
+		return multierr.Combine(errs...)
+	}
+	return nil
 }
 
 func (h *histogram) activeSeriesPerHistogramSerie() uint32 {

--- a/modules/generator/registry/histogram.go
+++ b/modules/generator/registry/histogram.go
@@ -258,7 +258,7 @@ func (h *histogram) countSeriesDemand() int {
 	return int(est) * int(h.activeSeriesPerHistogramSerie())
 }
 
-func (h *histogram) removeStaleSeries(staleTimeMs int64) {
+func (h *histogram) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) {
 	h.seriesMtx.Lock()
 	defer h.seriesMtx.Unlock()
 

--- a/modules/generator/registry/histogram.go
+++ b/modules/generator/registry/histogram.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 
 	tempo_util "github.com/grafana/tempo/pkg/util"
@@ -315,6 +316,22 @@ func (h *histogram) removeStaleSeries(appender storage.Appender, timeMs, staleTi
 
 	for hash, s := range h.series {
 		if s.lastUpdated < staleTimeMs {
+			if appender != nil {
+				_, err := appender.Append(0, s.countLabels, timeMs, math.Float64frombits(value.StaleNaN))
+				if err != nil {
+					// handle
+				}
+				_, err = appender.Append(0, s.sumLabels, timeMs, math.Float64frombits(value.StaleNaN))
+				if err != nil {
+					// handle
+				}
+				for _, l := range s.bucketLabels {
+					_, err = appender.Append(0, l, timeMs, math.Float64frombits(value.StaleNaN))
+					if err != nil {
+						// handle
+					}
+				}
+			}
 			delete(h.series, hash)
 			h.lifecycler.OnDelete(hash, h.activeSeriesPerHistogramSerie())
 		}

--- a/modules/generator/registry/histogram.go
+++ b/modules/generator/registry/histogram.go
@@ -309,7 +309,7 @@ func (h *histogram) countSeriesDemand() int {
 	return int(est) * int(h.activeSeriesPerHistogramSerie())
 }
 
-func (h *histogram) removeStaleSeries(staleTimeMs int64) {
+func (h *histogram) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) {
 	h.seriesMtx.Lock()
 	defer h.seriesMtx.Unlock()
 

--- a/modules/generator/registry/histogram.go
+++ b/modules/generator/registry/histogram.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
+	"go.uber.org/multierr"
 
 	tempo_util "github.com/grafana/tempo/pkg/util"
 )
@@ -310,25 +311,26 @@ func (h *histogram) countSeriesDemand() int {
 	return int(est) * int(h.activeSeriesPerHistogramSerie())
 }
 
-func (h *histogram) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) {
+func (h *histogram) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) error {
 	h.seriesMtx.Lock()
 	defer h.seriesMtx.Unlock()
 
+	errs := []error{}
 	for hash, s := range h.series {
 		if s.lastUpdated < staleTimeMs {
 			if appender != nil {
 				_, err := appender.Append(0, s.countLabels, timeMs, math.Float64frombits(value.StaleNaN))
 				if err != nil {
-					// handle
+					errs = append(errs, err)
 				}
 				_, err = appender.Append(0, s.sumLabels, timeMs, math.Float64frombits(value.StaleNaN))
 				if err != nil {
-					// handle
+					errs = append(errs, err)
 				}
 				for _, l := range s.bucketLabels {
 					_, err = appender.Append(0, l, timeMs, math.Float64frombits(value.StaleNaN))
 					if err != nil {
-						// handle
+						errs = append(errs, err)
 					}
 				}
 			}
@@ -337,6 +339,11 @@ func (h *histogram) removeStaleSeries(appender storage.Appender, timeMs, staleTi
 		}
 	}
 	h.seriesDemand.Advance()
+
+	if len(errs) > 0 {
+		return multierr.Combine(errs...)
+	}
+	return nil
 }
 
 func (h *histogram) activeSeriesPerHistogramSerie() uint32 {

--- a/modules/generator/registry/histogram_test.go
+++ b/modules/generator/registry/histogram_test.go
@@ -294,6 +294,28 @@ func Test_histogram_removeStaleSeries(t *testing.T) {
 	collectMetricAndAssert(t, h, collectionTimeMs, 5, expectedSamples, nil)
 }
 
+func Test_histogram_removeStaleSeries_appenderError(t *testing.T) {
+	var removedSeries int
+	lifecycler := &mockLimiter{
+		onDeleteFunc: func(_ uint64, count uint32) {
+			assert.Equal(t, uint32(5), count)
+			removedSeries++
+		},
+	}
+
+	h := newHistogram("my_histogram", []float64{1.0, 2.0}, lifecycler, "", nil, 15*time.Minute)
+
+	timeMs := time.Now().Add(1 * time.Hour).UnixMilli()
+	h.ObserveWithExemplar(buildTestLabels([]string{"label"}, []string{"value-1"}), 1.0, "", 1.0)
+	h.ObserveWithExemplar(buildTestLabels([]string{"label"}, []string{"value-2"}), 1.5, "", 1.0)
+
+	appender := errorAppender{}
+	err := h.removeStaleSeries(appender, 0, timeMs)
+
+	assert.Error(t, err)
+	assert.Equal(t, removedSeries, 2)
+}
+
 func Test_histogram_externalLabels(t *testing.T) {
 	extLabels := map[string]string{"external_label": "external_value"}
 

--- a/modules/generator/registry/histogram_test.go
+++ b/modules/generator/registry/histogram_test.go
@@ -244,7 +244,7 @@ func Test_histogram_removeStaleSeries(t *testing.T) {
 	h.ObserveWithExemplar(buildTestLabels([]string{"label"}, []string{"value-1"}), 1.0, "", 1.0)
 	h.ObserveWithExemplar(buildTestLabels([]string{"label"}, []string{"value-2"}), 1.5, "", 1.0)
 
-	h.removeStaleSeries(timeMs)
+	h.removeStaleSeries(nil, 0, timeMs)
 
 	assert.Equal(t, 0, removedSeries)
 
@@ -278,7 +278,7 @@ func Test_histogram_removeStaleSeries(t *testing.T) {
 	// update value-2 series
 	h.ObserveWithExemplar(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.5, "", 1.0)
 
-	h.removeStaleSeries(timeMs)
+	h.removeStaleSeries(nil, 0, timeMs)
 
 	assert.Equal(t, 1, removedSeries)
 
@@ -365,7 +365,7 @@ func Test_histogram_concurrencyDataRace(t *testing.T) {
 	})
 
 	go accessor(func() {
-		h.removeStaleSeries(time.Now().UnixMilli())
+		h.removeStaleSeries(nil, 0, time.Now().UnixMilli())
 	})
 
 	time.Sleep(200 * time.Millisecond)

--- a/modules/generator/registry/histogram_test.go
+++ b/modules/generator/registry/histogram_test.go
@@ -244,7 +244,8 @@ func Test_histogram_removeStaleSeries(t *testing.T) {
 	h.ObserveWithExemplar(buildTestLabels([]string{"label"}, []string{"value-1"}), 1.0, "", 1.0)
 	h.ObserveWithExemplar(buildTestLabels([]string{"label"}, []string{"value-2"}), 1.5, "", 1.0)
 
-	h.removeStaleSeries(nil, 0, timeMs)
+	appender := noopAppender{}
+	h.removeStaleSeries(appender, 0, timeMs)
 
 	assert.Equal(t, 0, removedSeries)
 
@@ -278,7 +279,7 @@ func Test_histogram_removeStaleSeries(t *testing.T) {
 	// update value-2 series
 	h.ObserveWithExemplar(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.5, "", 1.0)
 
-	h.removeStaleSeries(nil, 0, timeMs)
+	h.removeStaleSeries(appender, 0, timeMs)
 
 	assert.Equal(t, 1, removedSeries)
 
@@ -365,7 +366,8 @@ func Test_histogram_concurrencyDataRace(t *testing.T) {
 	})
 
 	go accessor(func() {
-		h.removeStaleSeries(nil, 0, time.Now().UnixMilli())
+		appender := noopAppender{}
+		h.removeStaleSeries(appender, 0, time.Now().UnixMilli())
 	})
 
 	time.Sleep(200 * time.Millisecond)

--- a/modules/generator/registry/histogram_test.go
+++ b/modules/generator/registry/histogram_test.go
@@ -245,7 +245,7 @@ func Test_histogram_removeStaleSeries(t *testing.T) {
 	h.ObserveWithExemplar(buildTestLabels([]string{"label"}, []string{"value-2"}), 1.5, "", 1.0)
 
 	appender := noopAppender{}
-	h.removeStaleSeries(appender, 0, timeMs)
+	_ = h.removeStaleSeries(appender, 0, timeMs)
 
 	assert.Equal(t, 0, removedSeries)
 
@@ -279,7 +279,7 @@ func Test_histogram_removeStaleSeries(t *testing.T) {
 	// update value-2 series
 	h.ObserveWithExemplar(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.5, "", 1.0)
 
-	h.removeStaleSeries(appender, 0, timeMs)
+	_ = h.removeStaleSeries(appender, 0, timeMs)
 
 	assert.Equal(t, 1, removedSeries)
 
@@ -367,7 +367,7 @@ func Test_histogram_concurrencyDataRace(t *testing.T) {
 
 	go accessor(func() {
 		appender := noopAppender{}
-		h.removeStaleSeries(appender, 0, time.Now().UnixMilli())
+		_ = h.removeStaleSeries(appender, 0, time.Now().UnixMilli())
 	})
 
 	time.Sleep(200 * time.Millisecond)

--- a/modules/generator/registry/histogram_test.go
+++ b/modules/generator/registry/histogram_test.go
@@ -252,7 +252,7 @@ func Test_histogram_removeStaleSeries(t *testing.T) {
 	h.ObserveWithExemplar(buildTestLabels([]string{"label"}, []string{"value-2"}), 1.5, "", 1.0)
 
 	appender := noopAppender{}
-	h.removeStaleSeries(appender, 0, timeMs)
+	_ = h.removeStaleSeries(appender, 0, timeMs)
 
 	assert.Equal(t, 0, removedSeries)
 
@@ -288,7 +288,7 @@ func Test_histogram_removeStaleSeries(t *testing.T) {
 	// update value-2 series
 	h.ObserveWithExemplar(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.5, "", 1.0)
 
-	h.removeStaleSeries(appender, 0, timeMs)
+	_ = h.removeStaleSeries(appender, 0, timeMs)
 
 	assert.Equal(t, 1, removedSeries)
 
@@ -378,7 +378,7 @@ func Test_histogram_concurrencyDataRace(t *testing.T) {
 
 	go accessor(func() {
 		appender := noopAppender{}
-		h.removeStaleSeries(appender, 0, time.Now().UnixMilli())
+		_ = h.removeStaleSeries(appender, 0, time.Now().UnixMilli())
 	})
 
 	time.Sleep(200 * time.Millisecond)

--- a/modules/generator/registry/histogram_test.go
+++ b/modules/generator/registry/histogram_test.go
@@ -303,6 +303,28 @@ func Test_histogram_removeStaleSeries(t *testing.T) {
 	collectMetricAndAssert(t, h, collectionTimeMs, 5, expectedSamples, nil)
 }
 
+func Test_histogram_removeStaleSeries_appenderError(t *testing.T) {
+	var removedSeries int
+	lifecycler := &mockLimiter{
+		onDeleteFunc: func(_ uint64, count uint32) {
+			assert.Equal(t, uint32(5), count)
+			removedSeries++
+		},
+	}
+
+	h := newHistogram("my_histogram", []float64{1.0, 2.0}, lifecycler, "", nil, 15*time.Minute)
+
+	timeMs := time.Now().Add(1 * time.Hour).UnixMilli()
+	h.ObserveWithExemplar(buildTestLabels([]string{"label"}, []string{"value-1"}), 1.0, "", 1.0)
+	h.ObserveWithExemplar(buildTestLabels([]string{"label"}, []string{"value-2"}), 1.5, "", 1.0)
+
+	appender := errorAppender{}
+	err := h.removeStaleSeries(appender, 0, timeMs)
+
+	assert.Error(t, err)
+	assert.Equal(t, removedSeries, 2)
+}
+
 func Test_histogram_externalLabels(t *testing.T) {
 	extLabels := map[string]string{"external_label": "external_value"}
 

--- a/modules/generator/registry/histogram_test.go
+++ b/modules/generator/registry/histogram_test.go
@@ -251,7 +251,7 @@ func Test_histogram_removeStaleSeries(t *testing.T) {
 	h.ObserveWithExemplar(buildTestLabels([]string{"label"}, []string{"value-1"}), 1.0, "", 1.0)
 	h.ObserveWithExemplar(buildTestLabels([]string{"label"}, []string{"value-2"}), 1.5, "", 1.0)
 
-	h.removeStaleSeries(timeMs)
+	h.removeStaleSeries(nil, 0, timeMs)
 
 	assert.Equal(t, 0, removedSeries)
 
@@ -287,7 +287,7 @@ func Test_histogram_removeStaleSeries(t *testing.T) {
 	// update value-2 series
 	h.ObserveWithExemplar(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.5, "", 1.0)
 
-	h.removeStaleSeries(timeMs)
+	h.removeStaleSeries(nil, 0, timeMs)
 
 	assert.Equal(t, 1, removedSeries)
 
@@ -376,7 +376,7 @@ func Test_histogram_concurrencyDataRace(t *testing.T) {
 	})
 
 	go accessor(func() {
-		h.removeStaleSeries(time.Now().UnixMilli())
+		h.removeStaleSeries(nil, 0, time.Now().UnixMilli())
 	})
 
 	time.Sleep(200 * time.Millisecond)

--- a/modules/generator/registry/histogram_test.go
+++ b/modules/generator/registry/histogram_test.go
@@ -251,7 +251,8 @@ func Test_histogram_removeStaleSeries(t *testing.T) {
 	h.ObserveWithExemplar(buildTestLabels([]string{"label"}, []string{"value-1"}), 1.0, "", 1.0)
 	h.ObserveWithExemplar(buildTestLabels([]string{"label"}, []string{"value-2"}), 1.5, "", 1.0)
 
-	h.removeStaleSeries(nil, 0, timeMs)
+	appender := noopAppender{}
+	h.removeStaleSeries(appender, 0, timeMs)
 
 	assert.Equal(t, 0, removedSeries)
 
@@ -287,7 +288,7 @@ func Test_histogram_removeStaleSeries(t *testing.T) {
 	// update value-2 series
 	h.ObserveWithExemplar(buildTestLabels([]string{"label"}, []string{"value-2"}), 2.5, "", 1.0)
 
-	h.removeStaleSeries(nil, 0, timeMs)
+	h.removeStaleSeries(appender, 0, timeMs)
 
 	assert.Equal(t, 1, removedSeries)
 
@@ -376,7 +377,8 @@ func Test_histogram_concurrencyDataRace(t *testing.T) {
 	})
 
 	go accessor(func() {
-		h.removeStaleSeries(nil, 0, time.Now().UnixMilli())
+		appender := noopAppender{}
+		h.removeStaleSeries(appender, 0, time.Now().UnixMilli())
 	})
 
 	time.Sleep(200 * time.Millisecond)

--- a/modules/generator/registry/native_histogram.go
+++ b/modules/generator/registry/native_histogram.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"go.uber.org/atomic"
+	"go.uber.org/multierr"
 )
 
 type nativeHistogram struct {
@@ -267,12 +268,13 @@ func (h *nativeHistogram) countSeriesDemand() int {
 	return int(est) * int(h.activeSeriesPerHistogramSerie())
 }
 
-func (h *nativeHistogram) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) {
+func (h *nativeHistogram) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) error {
 	overridesHash, _, _, _ := h.hashOverrides()
 
 	h.seriesMtx.Lock()
 	defer h.seriesMtx.Unlock()
 
+	errs := []error{}
 	for hash, s := range h.series {
 		if s.overridesHash != overridesHash {
 			// The overrides have changed, so we need to recreate the series.
@@ -285,15 +287,15 @@ func (h *nativeHistogram) removeStaleSeries(appender storage.Appender, timeMs, s
 			if appender != nil {
 				_, err := appender.Append(0, s.countLabels, timeMs, math.Float64frombits(value.StaleNaN))
 				if err != nil {
-					// handle
+					errs = append(errs, err)
 				}
 				_, err = appender.Append(0, s.sumLabels, timeMs, math.Float64frombits(value.StaleNaN))
 				if err != nil {
-					// handle
+					errs = append(errs, err)
 				}
 				_, err = appender.Append(0, s.labels, timeMs, math.Float64frombits(value.StaleNaN))
 				if err != nil {
-					// handle
+					errs = append(errs, err)
 				}
 			}
 			delete(h.series, hash)
@@ -301,6 +303,11 @@ func (h *nativeHistogram) removeStaleSeries(appender storage.Appender, timeMs, s
 		}
 	}
 	h.seriesDemand.Advance()
+
+	if len(errs) > 0 {
+		return multierr.Combine(errs...)
+	}
+	return nil
 }
 
 func (h *nativeHistogram) hashOverrides() (uint64, float64, uint32, time.Duration) {

--- a/modules/generator/registry/native_histogram.go
+++ b/modules/generator/registry/native_histogram.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/prometheus/model/exemplar"
 	promhistogram "github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"go.uber.org/atomic"
 )
@@ -281,6 +282,20 @@ func (h *nativeHistogram) removeStaleSeries(appender storage.Appender, timeMs, s
 		}
 
 		if s.lastUpdated < staleTimeMs {
+			if appender != nil {
+				_, err := appender.Append(0, s.countLabels, timeMs, math.Float64frombits(value.StaleNaN))
+				if err != nil {
+					// handle
+				}
+				_, err = appender.Append(0, s.sumLabels, timeMs, math.Float64frombits(value.StaleNaN))
+				if err != nil {
+					// handle
+				}
+				_, err = appender.Append(0, s.labels, timeMs, math.Float64frombits(value.StaleNaN))
+				if err != nil {
+					// handle
+				}
+			}
 			delete(h.series, hash)
 			h.lifecycler.OnDelete(hash, h.activeSeriesPerHistogramSerie())
 		}

--- a/modules/generator/registry/native_histogram.go
+++ b/modules/generator/registry/native_histogram.go
@@ -266,7 +266,7 @@ func (h *nativeHistogram) countSeriesDemand() int {
 	return int(est) * int(h.activeSeriesPerHistogramSerie())
 }
 
-func (h *nativeHistogram) removeStaleSeries(staleTimeMs int64) {
+func (h *nativeHistogram) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) {
 	overridesHash, _, _, _ := h.hashOverrides()
 
 	h.seriesMtx.Lock()

--- a/modules/generator/registry/native_histogram.go
+++ b/modules/generator/registry/native_histogram.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
+	"go.uber.org/multierr"
 
 	tempo_util "github.com/grafana/tempo/pkg/util"
 )
@@ -307,12 +308,13 @@ func (h *nativeHistogram) countSeriesDemand() int {
 	return int(est) * int(h.activeSeriesPerHistogramSerie())
 }
 
-func (h *nativeHistogram) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) {
+func (h *nativeHistogram) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) error {
 	overridesHash, _, _, _ := h.hashOverrides()
 
 	h.seriesMtx.Lock()
 	defer h.seriesMtx.Unlock()
 
+	errs := []error{}
 	for hash, s := range h.series {
 		if s.overridesHash != overridesHash {
 			// The overrides have changed, so we need to recreate the series.
@@ -325,15 +327,15 @@ func (h *nativeHistogram) removeStaleSeries(appender storage.Appender, timeMs, s
 			if appender != nil {
 				_, err := appender.Append(0, s.countLabels, timeMs, math.Float64frombits(value.StaleNaN))
 				if err != nil {
-					// handle
+					errs = append(errs, err)
 				}
 				_, err = appender.Append(0, s.sumLabels, timeMs, math.Float64frombits(value.StaleNaN))
 				if err != nil {
-					// handle
+					errs = append(errs, err)
 				}
 				_, err = appender.Append(0, s.labels, timeMs, math.Float64frombits(value.StaleNaN))
 				if err != nil {
-					// handle
+					errs = append(errs, err)
 				}
 			}
 			delete(h.series, hash)
@@ -341,6 +343,11 @@ func (h *nativeHistogram) removeStaleSeries(appender storage.Appender, timeMs, s
 		}
 	}
 	h.seriesDemand.Advance()
+
+	if len(errs) > 0 {
+		return multierr.Combine(errs...)
+	}
+	return nil
 }
 
 func (h *nativeHistogram) hashOverrides() (uint64, float64, uint32, time.Duration) {

--- a/modules/generator/registry/native_histogram.go
+++ b/modules/generator/registry/native_histogram.go
@@ -306,7 +306,7 @@ func (h *nativeHistogram) countSeriesDemand() int {
 	return int(est) * int(h.activeSeriesPerHistogramSerie())
 }
 
-func (h *nativeHistogram) removeStaleSeries(staleTimeMs int64) {
+func (h *nativeHistogram) removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) {
 	overridesHash, _, _, _ := h.hashOverrides()
 
 	h.seriesMtx.Lock()

--- a/modules/generator/registry/native_histogram.go
+++ b/modules/generator/registry/native_histogram.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/prometheus/model/exemplar"
 	promhistogram "github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 
 	tempo_util "github.com/grafana/tempo/pkg/util"
@@ -321,6 +322,20 @@ func (h *nativeHistogram) removeStaleSeries(appender storage.Appender, timeMs, s
 		}
 
 		if s.lastUpdated < staleTimeMs {
+			if appender != nil {
+				_, err := appender.Append(0, s.countLabels, timeMs, math.Float64frombits(value.StaleNaN))
+				if err != nil {
+					// handle
+				}
+				_, err = appender.Append(0, s.sumLabels, timeMs, math.Float64frombits(value.StaleNaN))
+				if err != nil {
+					// handle
+				}
+				_, err = appender.Append(0, s.labels, timeMs, math.Float64frombits(value.StaleNaN))
+				if err != nil {
+					// handle
+				}
+			}
 			delete(h.series, hash)
 			h.lifecycler.OnDelete(hash, h.activeSeriesPerHistogramSerie())
 		}

--- a/modules/generator/registry/registry.go
+++ b/modules/generator/registry/registry.go
@@ -76,7 +76,7 @@ type metric interface {
 	countActiveSeries() int
 	// countSeriesDemand estimates the number of active series that would be created if the maxActiveSeries were unlimited.
 	countSeriesDemand() int
-	removeStaleSeries(staleTimeMs int64)
+	removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64)
 }
 
 const highestAggregationInterval = 1 * time.Minute
@@ -226,7 +226,7 @@ func (r *ManagedRegistry) registerMetric(m metric) {
 	if old, ok := r.metrics[m.name()]; ok {
 		level.Info(r.logger).Log("msg", "replacing metric, counters will be reset", "metric", m.name())
 		// Drain old series so the limiter's active count is properly decremented.
-		old.removeStaleSeries(math.MaxInt64)
+		old.removeStaleSeries(nil, 0, math.MaxInt64)
 	}
 	r.metrics[m.name()] = m
 }
@@ -288,18 +288,25 @@ func (r *ManagedRegistry) collectionInterval() time.Duration {
 	return r.cfg.CollectionInterval
 }
 
-func (r *ManagedRegistry) removeStaleSeries(context.Context) {
+func (r *ManagedRegistry) removeStaleSeries(ctx context.Context) {
 	r.metricsMtx.RLock()
 	defer r.metricsMtx.RUnlock()
 
 	timeMs := time.Now().Add(-1 * r.cfg.StaleDuration).UnixMilli()
+	appender := r.appendable.Appender(ctx)
+	collectionTimeMs := time.Now().UnixMilli()
 
 	remainingSeries := 0
 	for _, m := range r.metrics {
-		m.removeStaleSeries(timeMs)
+		m.removeStaleSeries(appender, collectionTimeMs, timeMs)
 		remainingSeries += m.countActiveSeries()
 	}
 	r.entityDemand.Advance()
+
+	err := appender.Commit()
+	if err != nil {
+		level.Error(r.logger).Log("msg", "commiting stale markers failed", "err", err)
+	}
 
 	level.Info(r.logger).Log("msg", "deleted stale series", "active_series", remainingSeries)
 }

--- a/modules/generator/registry/registry.go
+++ b/modules/generator/registry/registry.go
@@ -76,7 +76,7 @@ type metric interface {
 	countActiveSeries() int
 	// countSeriesDemand estimates the number of active series that would be created if the maxActiveSeries were unlimited.
 	countSeriesDemand() int
-	removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64)
+	removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) error
 }
 
 const highestAggregationInterval = 1 * time.Minute
@@ -298,7 +298,10 @@ func (r *ManagedRegistry) removeStaleSeries(ctx context.Context) {
 
 	remainingSeries := 0
 	for _, m := range r.metrics {
-		m.removeStaleSeries(appender, collectionTimeMs, timeMs)
+		err := m.removeStaleSeries(appender, collectionTimeMs, timeMs)
+		if err != nil {
+			level.Error(r.logger).Log("msg", "some stale markers failed to be added", "err", err)
+		}
 		remainingSeries += m.countActiveSeries()
 	}
 	r.entityDemand.Advance()

--- a/modules/generator/registry/registry.go
+++ b/modules/generator/registry/registry.go
@@ -226,7 +226,7 @@ func (r *ManagedRegistry) registerMetric(m metric) {
 	if old, ok := r.metrics[m.name()]; ok {
 		level.Info(r.logger).Log("msg", "replacing metric, counters will be reset", "metric", m.name())
 		// Drain old series so the limiter's active count is properly decremented.
-		old.removeStaleSeries(nil, 0, math.MaxInt64)
+		_ = old.removeStaleSeries(nil, 0, math.MaxInt64)
 	}
 	r.metrics[m.name()] = m
 }
@@ -294,11 +294,11 @@ func (r *ManagedRegistry) removeStaleSeries(ctx context.Context) {
 
 	timeMs := time.Now().Add(-1 * r.cfg.StaleDuration).UnixMilli()
 	appender := r.appendable.Appender(ctx)
-	collectionTimeMs := time.Now().UnixMilli()
+	removalTimeMs := time.Now().UnixMilli()
 
 	remainingSeries := 0
 	for _, m := range r.metrics {
-		err := m.removeStaleSeries(appender, collectionTimeMs, timeMs)
+		err := m.removeStaleSeries(appender, removalTimeMs, timeMs)
 		if err != nil {
 			level.Error(r.logger).Log("msg", "some stale markers failed to be added", "err", err)
 		}

--- a/modules/generator/registry/registry.go
+++ b/modules/generator/registry/registry.go
@@ -305,7 +305,7 @@ func (r *ManagedRegistry) removeStaleSeries(ctx context.Context) {
 
 	err := appender.Commit()
 	if err != nil {
-		level.Error(r.logger).Log("msg", "commiting stale markers failed", "err", err)
+		level.Error(r.logger).Log("msg", "committing stale markers failed", "err", err)
 	}
 
 	level.Info(r.logger).Log("msg", "deleted stale series", "active_series", remainingSeries)

--- a/modules/generator/registry/registry.go
+++ b/modules/generator/registry/registry.go
@@ -77,7 +77,7 @@ type metric interface {
 	countActiveSeries() int
 	// countSeriesDemand estimates the number of active series that would be created if the maxActiveSeries were unlimited.
 	countSeriesDemand() int
-	removeStaleSeries(staleTimeMs int64)
+	removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64)
 }
 
 const highestAggregationInterval = 1 * time.Minute
@@ -247,7 +247,7 @@ func (r *ManagedRegistry) registerMetric(m metric) {
 	if old, ok := r.metrics[m.name()]; ok {
 		level.Info(r.logger).Log("msg", "replacing metric, counters will be reset", "metric", m.name())
 		// Drain old series so the limiter's active count is properly decremented.
-		old.removeStaleSeries(math.MaxInt64)
+		old.removeStaleSeries(nil, 0, math.MaxInt64)
 	}
 	r.metrics[m.name()] = m
 }
@@ -309,18 +309,25 @@ func (r *ManagedRegistry) collectionInterval() time.Duration {
 	return r.cfg.CollectionInterval
 }
 
-func (r *ManagedRegistry) removeStaleSeries(context.Context) {
+func (r *ManagedRegistry) removeStaleSeries(ctx context.Context) {
 	r.metricsMtx.RLock()
 	defer r.metricsMtx.RUnlock()
 
 	timeMs := time.Now().Add(-1 * r.cfg.StaleDuration).UnixMilli()
+	appender := r.appendable.Appender(ctx)
+	collectionTimeMs := time.Now().UnixMilli()
 
 	remainingSeries := 0
 	for _, m := range r.metrics {
-		m.removeStaleSeries(timeMs)
+		m.removeStaleSeries(appender, collectionTimeMs, timeMs)
 		remainingSeries += m.countActiveSeries()
 	}
 	r.entityDemand.Advance()
+
+	err := appender.Commit()
+	if err != nil {
+		level.Error(r.logger).Log("msg", "commiting stale markers failed", "err", err)
+	}
 
 	level.Info(r.logger).Log("msg", "deleted stale series", "active_series", remainingSeries)
 }

--- a/modules/generator/registry/registry.go
+++ b/modules/generator/registry/registry.go
@@ -326,7 +326,7 @@ func (r *ManagedRegistry) removeStaleSeries(ctx context.Context) {
 
 	err := appender.Commit()
 	if err != nil {
-		level.Error(r.logger).Log("msg", "commiting stale markers failed", "err", err)
+		level.Error(r.logger).Log("msg", "committing stale markers failed", "err", err)
 	}
 
 	level.Info(r.logger).Log("msg", "deleted stale series", "active_series", remainingSeries)

--- a/modules/generator/registry/registry.go
+++ b/modules/generator/registry/registry.go
@@ -77,7 +77,7 @@ type metric interface {
 	countActiveSeries() int
 	// countSeriesDemand estimates the number of active series that would be created if the maxActiveSeries were unlimited.
 	countSeriesDemand() int
-	removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64)
+	removeStaleSeries(appender storage.Appender, timeMs, staleTimeMs int64) error	
 }
 
 const highestAggregationInterval = 1 * time.Minute
@@ -319,7 +319,10 @@ func (r *ManagedRegistry) removeStaleSeries(ctx context.Context) {
 
 	remainingSeries := 0
 	for _, m := range r.metrics {
-		m.removeStaleSeries(appender, collectionTimeMs, timeMs)
+		err := m.removeStaleSeries(appender, collectionTimeMs, timeMs)
+		if err != nil {
+			level.Error(r.logger).Log("msg", "some stale markers failed to be added", "err", err)
+		}
 		remainingSeries += m.countActiveSeries()
 	}
 	r.entityDemand.Advance()

--- a/modules/generator/registry/registry.go
+++ b/modules/generator/registry/registry.go
@@ -247,7 +247,7 @@ func (r *ManagedRegistry) registerMetric(m metric) {
 	if old, ok := r.metrics[m.name()]; ok {
 		level.Info(r.logger).Log("msg", "replacing metric, counters will be reset", "metric", m.name())
 		// Drain old series so the limiter's active count is properly decremented.
-		old.removeStaleSeries(nil, 0, math.MaxInt64)
+		_ = old.removeStaleSeries(nil, 0, math.MaxInt64)
 	}
 	r.metrics[m.name()] = m
 }
@@ -315,11 +315,11 @@ func (r *ManagedRegistry) removeStaleSeries(ctx context.Context) {
 
 	timeMs := time.Now().Add(-1 * r.cfg.StaleDuration).UnixMilli()
 	appender := r.appendable.Appender(ctx)
-	collectionTimeMs := time.Now().UnixMilli()
+	removalTimeMs := time.Now().UnixMilli()
 
 	remainingSeries := 0
 	for _, m := range r.metrics {
-		err := m.removeStaleSeries(appender, collectionTimeMs, timeMs)
+		err := m.removeStaleSeries(appender, removalTimeMs, timeMs)
 		if err != nil {
 			level.Error(r.logger).Log("msg", "some stale markers failed to be added", "err", err)
 		}

--- a/modules/generator/registry/registry_test.go
+++ b/modules/generator/registry/registry_test.go
@@ -663,7 +663,7 @@ func TestManagedRegistry_demandDecaysOverTime(t *testing.T) {
 	for _, m := range registry.metrics {
 		// Advance enough times to clear the sliding window
 		for i := 0; i < 5; i++ {
-			m.removeStaleSeries(nil, 0, time.Now().Add(time.Hour).UnixMilli())
+			m.removeStaleSeries(appender, 0, time.Now().Add(time.Hour).UnixMilli())
 		}
 	}
 	registry.metricsMtx.RUnlock()

--- a/modules/generator/registry/registry_test.go
+++ b/modules/generator/registry/registry_test.go
@@ -663,7 +663,7 @@ func TestManagedRegistry_demandDecaysOverTime(t *testing.T) {
 	for _, m := range registry.metrics {
 		// Advance enough times to clear the sliding window
 		for i := 0; i < 5; i++ {
-			m.removeStaleSeries(time.Now().Add(time.Hour).UnixMilli())
+			m.removeStaleSeries(nil, 0, time.Now().Add(time.Hour).UnixMilli())
 		}
 	}
 	registry.metricsMtx.RUnlock()

--- a/modules/generator/registry/registry_test.go
+++ b/modules/generator/registry/registry_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/value"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -196,6 +197,7 @@ func TestManagedRegistry_removeStaleSeries(t *testing.T) {
 
 	expectedSamples = []sample{
 		newSample(map[string]string{"__name__": "metric_2", "__metrics_gen_instance": mustGetHostname()}, 0, 4),
+		newSample(map[string]string{"__name__": "metric_1", "__metrics_gen_instance": mustGetHostname()}, 0, math.Float64frombits(value.StaleNaN)),
 	}
 	collectRegistryMetricsAndAssert(t, registry, appender, expectedSamples)
 }
@@ -471,7 +473,12 @@ func collectRegistryMetricsAndAssert(t *testing.T, r *ManagedRegistry, appender 
 		actual := actualSamples[i]
 
 		assert.Equal(t, expected.t, actual.t)
-		assert.Equal(t, expected.v, actual.v)
+		if math.IsNaN(expected.v) {
+			// Check for stale marker
+			assert.True(t, math.IsNaN(actual.v))
+		} else {
+			assert.Equal(t, expected.v, actual.v)
+		}
 		// Rely on the fact that Go prints map keys in sorted order.
 		// See https://tip.golang.org/doc/go1.12#fmt.
 		assert.Equal(t, fmt.Sprint(expected.l.Map()), fmt.Sprint(actual.l.Map()))
@@ -663,7 +670,7 @@ func TestManagedRegistry_demandDecaysOverTime(t *testing.T) {
 	for _, m := range registry.metrics {
 		// Advance enough times to clear the sliding window
 		for i := 0; i < 5; i++ {
-			m.removeStaleSeries(appender, 0, time.Now().Add(time.Hour).UnixMilli())
+			_ = m.removeStaleSeries(appender, 0, time.Now().Add(time.Hour).UnixMilli())
 		}
 	}
 	registry.metricsMtx.RUnlock()

--- a/modules/generator/registry/registry_test.go
+++ b/modules/generator/registry/registry_test.go
@@ -667,7 +667,7 @@ func TestManagedRegistry_demandDecaysOverTime(t *testing.T) {
 	for _, m := range registry.metrics {
 		// Advance enough times to clear the sliding window
 		for i := 0; i < 5; i++ {
-			m.removeStaleSeries(time.Now().Add(time.Hour).UnixMilli())
+			m.removeStaleSeries(nil, 0, time.Now().Add(time.Hour).UnixMilli())
 		}
 	}
 	registry.metricsMtx.RUnlock()

--- a/modules/generator/registry/registry_test.go
+++ b/modules/generator/registry/registry_test.go
@@ -667,7 +667,7 @@ func TestManagedRegistry_demandDecaysOverTime(t *testing.T) {
 	for _, m := range registry.metrics {
 		// Advance enough times to clear the sliding window
 		for i := 0; i < 5; i++ {
-			m.removeStaleSeries(nil, 0, time.Now().Add(time.Hour).UnixMilli())
+			m.removeStaleSeries(appender, 0, time.Now().Add(time.Hour).UnixMilli())
 		}
 	}
 	registry.metricsMtx.RUnlock()

--- a/modules/generator/registry/registry_test.go
+++ b/modules/generator/registry/registry_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/value"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -199,6 +200,7 @@ func TestManagedRegistry_removeStaleSeries(t *testing.T) {
 
 	expectedSamples = []sample{
 		newSample(map[string]string{"__name__": "metric_2", "__metrics_gen_instance": mustGetHostname()}, 0, 4),
+		newSample(map[string]string{"__name__": "metric_1", "__metrics_gen_instance": mustGetHostname()}, 0, math.Float64frombits(value.StaleNaN)),
 	}
 	collectRegistryMetricsAndAssert(t, registry, appender, expectedSamples)
 }
@@ -475,7 +477,12 @@ func collectRegistryMetricsAndAssert(t *testing.T, r *ManagedRegistry, appender 
 		actual := actualSamples[i]
 
 		assert.Equal(t, expected.t, actual.t)
-		assert.Equal(t, expected.v, actual.v)
+		if math.IsNaN(expected.v) {
+			// Check for stale marker
+			assert.True(t, math.IsNaN(actual.v))
+		} else {
+			assert.Equal(t, expected.v, actual.v)
+		}
 		// Rely on the fact that Go prints map keys in sorted order.
 		// See https://tip.golang.org/doc/go1.12#fmt.
 		assert.Equal(t, fmt.Sprint(expected.l.Map()), fmt.Sprint(actual.l.Map()))
@@ -667,7 +674,7 @@ func TestManagedRegistry_demandDecaysOverTime(t *testing.T) {
 	for _, m := range registry.metrics {
 		// Advance enough times to clear the sliding window
 		for i := 0; i < 5; i++ {
-			m.removeStaleSeries(appender, 0, time.Now().Add(time.Hour).UnixMilli())
+			_ = m.removeStaleSeries(appender, 0, time.Now().Add(time.Hour).UnixMilli())
 		}
 	}
 	registry.metricsMtx.RUnlock()

--- a/modules/generator/registry/test.go
+++ b/modules/generator/registry/test.go
@@ -120,7 +120,7 @@ func (t *testCounter) collectMetrics(_ storage.Appender, _ int64) error {
 	return nil
 }
 
-func (t *testCounter) removeStaleSeries(int64) {
+func (t *testCounter) removeStaleSeries(storage.Appender, int64, int64) {
 	panic("implement me")
 }
 
@@ -163,7 +163,7 @@ func (t *testGauge) collectMetrics(_ storage.Appender, _ int64) error {
 	return nil
 }
 
-func (t *testGauge) removeStaleSeries(int64) {
+func (t *testGauge) removeStaleSeries(storage.Appender, int64, int64) {
 	panic("implement me")
 }
 
@@ -215,7 +215,7 @@ func (t *testHistogram) collectMetrics(_ storage.Appender, _ int64) error {
 	panic("implement me")
 }
 
-func (t *testHistogram) removeStaleSeries(int64) {
+func (t *testHistogram) removeStaleSeries(storage.Appender, int64, int64) {
 	panic("implement me")
 }
 

--- a/modules/generator/registry/test.go
+++ b/modules/generator/registry/test.go
@@ -120,7 +120,7 @@ func (t *testCounter) collectMetrics(_ storage.Appender, _ int64) error {
 	return nil
 }
 
-func (t *testCounter) removeStaleSeries(storage.Appender, int64, int64) {
+func (t *testCounter) removeStaleSeries(storage.Appender, int64, int64) error {
 	panic("implement me")
 }
 
@@ -163,7 +163,7 @@ func (t *testGauge) collectMetrics(_ storage.Appender, _ int64) error {
 	return nil
 }
 
-func (t *testGauge) removeStaleSeries(storage.Appender, int64, int64) {
+func (t *testGauge) removeStaleSeries(storage.Appender, int64, int64) error {
 	panic("implement me")
 }
 
@@ -215,7 +215,7 @@ func (t *testHistogram) collectMetrics(_ storage.Appender, _ int64) error {
 	panic("implement me")
 }
 
-func (t *testHistogram) removeStaleSeries(storage.Appender, int64, int64) {
+func (t *testHistogram) removeStaleSeries(storage.Appender, int64, int64) error {
 	panic("implement me")
 }
 

--- a/modules/generator/registry/test.go
+++ b/modules/generator/registry/test.go
@@ -133,7 +133,7 @@ func (t *testCounter) collectMetrics(_ storage.Appender, _ int64) error {
 	return nil
 }
 
-func (t *testCounter) removeStaleSeries(int64) {
+func (t *testCounter) removeStaleSeries(storage.Appender, int64, int64) {
 	panic("implement me")
 }
 
@@ -184,7 +184,7 @@ func (t *testGauge) collectMetrics(_ storage.Appender, _ int64) error {
 	return nil
 }
 
-func (t *testGauge) removeStaleSeries(int64) {
+func (t *testGauge) removeStaleSeries(storage.Appender, int64, int64) {
 	panic("implement me")
 }
 
@@ -246,7 +246,7 @@ func (t *testHistogram) collectMetrics(_ storage.Appender, _ int64) error {
 	panic("implement me")
 }
 
-func (t *testHistogram) removeStaleSeries(int64) {
+func (t *testHistogram) removeStaleSeries(storage.Appender, int64, int64) {
 	panic("implement me")
 }
 

--- a/modules/generator/registry/test.go
+++ b/modules/generator/registry/test.go
@@ -133,7 +133,7 @@ func (t *testCounter) collectMetrics(_ storage.Appender, _ int64) error {
 	return nil
 }
 
-func (t *testCounter) removeStaleSeries(storage.Appender, int64, int64) {
+func (t *testCounter) removeStaleSeries(storage.Appender, int64, int64) error {
 	panic("implement me")
 }
 
@@ -184,7 +184,7 @@ func (t *testGauge) collectMetrics(_ storage.Appender, _ int64) error {
 	return nil
 }
 
-func (t *testGauge) removeStaleSeries(storage.Appender, int64, int64) {
+func (t *testGauge) removeStaleSeries(storage.Appender, int64, int64) error {
 	panic("implement me")
 }
 
@@ -246,7 +246,7 @@ func (t *testHistogram) collectMetrics(_ storage.Appender, _ int64) error {
 	panic("implement me")
 }
 
-func (t *testHistogram) removeStaleSeries(storage.Appender, int64, int64) {
+func (t *testHistogram) removeStaleSeries(storage.Appender, int64, int64) error {
 	panic("implement me")
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

I worked only inside the `/module/generator/registry` folder and I'm not familiar with the code outside of it, so I might be missing something. Please let me know if there's anything else I should do as part of this task!

Also, I updated the tests to cover for most of the code added in this PR, but didn't go all the way through to cover 100% of it yet. If it's required, I can work on further improving coverage.

---

**What this PR does**:
sends a stale marker to remote write when a series is removed as stale

**Which issue(s) this PR fixes**:
closes https://github.com/grafana/tempo/issues/6494

**Test chages**
* Start single-binary docker compose example 
* Navigate to `localhost:9090` and query `traces_spanmetrics_calls_total{service=~"((auth|article|cart)-service|shop-backend|tempo-vulture|postgres)"}` (metrics coming from vulture and k6). Check results
* Stop k6 and vulture containers `docker compose stop vulture k6-tracing`
* Wait `metrics_generator.registry.stale_duration` + `removeStaleSeriesInterval` and query again. Should return no results.

For testing purposes, I set
```yaml
...
metrics_generator:
  registry:
    stale_duration: 20s
    collection_interval: 5s
...
```
in [the tempo config](example/docker-compose/single-binary/tempo.yaml), and updated `removeStaleSeriesInterval` to 10 seconds in [the registry file](https://github.com/grafana/tempo/blob/main/modules/generator/registry/registry.go#L84)

**Checklist**
- [x] Tests updated
- [ ] ~Documentation added~
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`