### PR TITLE
chore: pinned tempo image to 2.9.2 in docs and jsonnets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -356,6 +356,26 @@ docs-test:
 	docker pull ${DOCS_IMAGE}
 	docker run -v ${PWD}/docs/sources/tempo:/hugo/content/docs/tempo/latest:z -p 3002:3002 --rm $(DOCS_IMAGE) /bin/bash -c 'mkdir -p content/docs/grafana/latest/ && touch content/docs/grafana/latest/menu.yaml && make prod'
 
+##@ Release
+
+TEMPO_IMAGE_TAG ?=
+.PHONY: bump-tempo-image-tag
+bump-tempo-image-tag: ## Bump grafana/tempo image tag in docker-compose and jsonnet files. Usage: make bump-tempo-image-tag TEMPO_IMAGE_TAG=2.10.2
+	@test -n "$(TEMPO_IMAGE_TAG)" || (echo "ERROR: TEMPO_IMAGE_TAG is required. Usage: make bump-tempo-image-tag TEMPO_IMAGE_TAG=<tag>"; exit 1)
+	@echo "$(TEMPO_IMAGE_TAG)" | grep -qE '^(latest|[0-9]+\.[0-9]+\.[0-9]+)$$' || (echo "ERROR: TEMPO_IMAGE_TAG must be 'latest' or a version like '2.10.2', got: $(TEMPO_IMAGE_TAG)"; exit 1)
+	@echo "Replacing grafana/tempo:<any> -> grafana/tempo:$(TEMPO_IMAGE_TAG)"
+	@find . \
+		-not -path './.claude/*' \
+		-not -path './.git/*' \
+		-not -path './vendor/*' \
+		-not -path './.worktrees/*' \
+		\( -name "*.yaml" -o -name "*.libsonnet" -o -name "*.jsonnet" -o -name "*.md" \) \
+		-print0 \
+		| xargs -0 grep -l "grafana/tempo:" \
+		| tr '\n' '\0' \
+		| xargs -0 -I{} sed -i '' -E "s#grafana/tempo:(latest|[0-9]+\.[0-9]+\.[0-9]+)#grafana/tempo:$(TEMPO_IMAGE_TAG)#g" {}
+	@echo "Done. Re-run 'make jsonnet' to regenerate compiled jsonnet if needed."
+
 ##@ jsonnet
 .PHONY: jsonnet jsonnet-check jsonnet-test
 jsonnet: tools-image ## Generate jsonnet

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
@@ -227,7 +227,7 @@ Install the `k.libsonnet`, Jsonnet, and Memcachd libraries.
 
    tempo {
        _images+:: {
-           tempo: 'grafana/tempo:latest',
+           tempo: 'grafana/tempo:2.9.2',
            tempo_query: 'grafana/tempo-query:latest',
        },
 

--- a/example/docker-compose/alloy/docker-compose.yaml
+++ b/example/docker-compose/alloy/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
   # Tempo runs as user 10001, and docker compose creates the volume as root.
   # As such, we need to chown the volume in order for Tempo to start correctly.
   init:
-    image: &tempoImage grafana/tempo:latest
+    image: &tempoImage grafana/tempo:2.9.2
     user: root
     entrypoint:
       - "chown"

--- a/example/docker-compose/alloy/readme.md
+++ b/example/docker-compose/alloy/readme.md
@@ -18,7 +18,7 @@ alloy-alloy-1        grafana/alloy:v1.3.1                        "/bin/alloy run
 alloy-grafana-1      grafana/grafana:12.0.0                      "/run.sh"                grafana      48 seconds ago   Up 5 seconds   0.0.0.0:3000->3000/tcp
 alloy-k6-tracing-1   ghcr.io/grafana/xk6-client-tracing:v0.0.7   "/k6-tracing run /ex…"   k6-tracing   48 seconds ago   Up 4 seconds   
 alloy-prometheus-1   prom/prometheus:latest                      "/bin/prometheus --c…"   prometheus   48 seconds ago   Up 5 seconds   0.0.0.0:9090->9090/tcp
-alloy-tempo-1        grafana/tempo:latest                        "/tempo -config.file…"   tempo        48 seconds ago   Up 5 seconds   0.0.0.0:57508->3200/tcp, 0.0.0.0:57509->4317/tcp, 0.0.0.0:57505->4318/tcp, 0.0.0.0:57506->9411/tcp, 0.0.0.0:57507->14268/tcp
+alloy-tempo-1        grafana/tempo:2.9.2                        "/tempo -config.file…"   tempo        48 seconds ago   Up 5 seconds   0.0.0.0:57508->3200/tcp, 0.0.0.0:57509->4317/tcp, 0.0.0.0:57505->4318/tcp, 0.0.0.0:57506->9411/tcp, 0.0.0.0:57507->14268/tcp
 ```
 
 2. If you're interested you can see the wal/blocks as they are being created.

--- a/example/docker-compose/cross-cluster/docker-compose.yaml
+++ b/example/docker-compose/cross-cluster/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
 
   # tempo - a
   distributor-a:
-    image: &tempoImage grafana/tempo:latest
+    image: &tempoImage grafana/tempo:2.9.2
     command: "-target=distributor -config.file=/etc/tempo.yaml"
     restart: always
     volumes:

--- a/example/docker-compose/distributed/docker-compose.yaml
+++ b/example/docker-compose/distributed/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
 
   distributor:
-    image: &tempoImage grafana/tempo:latest
+    image: &tempoImage grafana/tempo:2.9.2
     command: "-target=distributor -config.file=/etc/tempo.yaml"
     restart: always
     volumes:

--- a/example/docker-compose/ingest-storage/docker-compose.yaml
+++ b/example/docker-compose/ingest-storage/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   # Tempo runs as user 10001, and docker compose creates the volume as root.
   # As such, we need to chown the volume in order for Tempo to start correctly.
   init:
-    image: &tempoImage grafana/tempo:latest
+    image: &tempoImage grafana/tempo:2.9.2
     user: root
     entrypoint:
       - "chown"

--- a/example/docker-compose/local/docker-compose.yaml
+++ b/example/docker-compose/local/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   # Tempo runs as user 10001, and docker compose creates the volume as root.
   # As such, we need to chown the volume in order for Tempo to start correctly.
   init:
-    image: &tempoImage grafana/tempo:latest
+    image: &tempoImage grafana/tempo:2.9.2
     user: root
     entrypoint:
       - "chown"

--- a/example/docker-compose/multi-tenant/docker-compose.yaml
+++ b/example/docker-compose/multi-tenant/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
   # Tempo runs as user 10001, and docker compose creates the volume as root.
   # As such, we need to chown the volume in order for Tempo to start correctly.
   init:
-    image: &tempoImage grafana/tempo:latest
+    image: &tempoImage grafana/tempo:2.9.2
     user: root
     entrypoint:
       - "chown"

--- a/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
+++ b/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
   # Tempo runs as user 10001, and docker compose creates the volume as root.
   # As such, we need to chown the volume in order for Tempo to start correctly.
   init:
-    image: &tempoImage grafana/tempo:latest
+    image: &tempoImage grafana/tempo:2.9.2
     user: root
     entrypoint:
       - "chown"

--- a/example/docker-compose/otel-collector/docker-compose.yaml
+++ b/example/docker-compose/otel-collector/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
   # Tempo runs as user 10001, and docker compose creates the volume as root.
   # As such, we need to chown the volume in order for Tempo to start correctly.
   init:
-    image: &tempoImage grafana/tempo:latest
+    image: &tempoImage grafana/tempo:2.9.2
     user: root
     entrypoint:
       - "chown"

--- a/example/docker-compose/readme.md
+++ b/example/docker-compose/readme.md
@@ -32,7 +32,7 @@ This example uses the `local` backend, suitable for local testing and developmen
 This step is not necessary, but it can be nice for local testing.  For any of the above examples rebuilding these
 images will cause docker compose to use your local code when running the examples.
 
-Run the following from the project root folder to build the `grafana/tempo:latest` image that is used in all the examples:
+Run the following from the project root folder to build the `grafana/tempo:2.9.2` image that is used in all the examples:
 
 ```console
 make docker-images

--- a/example/docker-compose/scalable-single-binary/docker-compose.yaml
+++ b/example/docker-compose/scalable-single-binary/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
 
   tempo1:
-    image: grafana/tempo:latest
+    image: grafana/tempo:2.9.2
     command: "-target=scalable-single-binary -config.file=/etc/tempo.yaml"
     volumes:
       - ./tempo-scalable-single-binary.yaml:/etc/tempo.yaml
@@ -16,7 +16,7 @@ services:
       - 3200:3200
 
   tempo2:
-    image: grafana/tempo:latest
+    image: grafana/tempo:2.9.2
     command: "-target=scalable-single-binary -config.file=/etc/tempo.yaml"
     volumes:
       - ./tempo-scalable-single-binary.yaml:/etc/tempo.yaml
@@ -29,7 +29,7 @@ services:
       - minio
 
   tempo3:
-    image: grafana/tempo:latest
+    image: grafana/tempo:2.9.2
     command: "-target=scalable-single-binary -config.file=/etc/tempo.yaml"
     volumes:
       - ./tempo-scalable-single-binary.yaml:/etc/tempo.yaml

--- a/example/docker-compose/vulture/docker-compose.yaml
+++ b/example/docker-compose/vulture/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   # Tempo runs as user 10001, and docker compose creates the volume as root.
   # As such, we need to chown the volume in order for Tempo to start correctly.
   init:
-    image: &tempoImage grafana/tempo:latest
+    image: &tempoImage grafana/tempo:2.9.2
     user: root
     entrypoint:
       - "chown"

--- a/example/docker-compose/vulture/readme.md
+++ b/example/docker-compose/vulture/readme.md
@@ -16,7 +16,7 @@ docker compose ps
 ```
 ```
 NAME                IMAGE                          COMMAND                  SERVICE   CREATED         STATUS         PORTS
-vulture-tempo-1     grafana/tempo:latest           "/tempo -config.file…"   tempo     2 minutes ago   Up 2 minutes   0.0.0.0:3200->3200/tcp, 0.0.0.0:14250->14250/tcp
+vulture-tempo-1     grafana/tempo:2.9.2           "/tempo -config.file…"   tempo     2 minutes ago   Up 2 minutes   0.0.0.0:3200->3200/tcp, 0.0.0.0:14250->14250/tcp
 vulture-vulture-1   grafana/tempo-vulture:latest   "/tempo-vulture -tem…"   vulture   2 minutes ago   Up 2 minutes  
 ```
 

--- a/example/tk/readme.md
+++ b/example/tk/readme.md
@@ -22,7 +22,7 @@ k3d cluster create tempo --api-port 6443 --port "3000:80@loadbalancer"
 If you wish to use a local image, you can import these into k3d
 
 ```console
-k3d image import grafana/tempo:latest --cluster tempo
+k3d image import grafana/tempo:2.9.2 --cluster tempo
 ```
 
 Next either deploy the microservices or the single binary. You can also use tanka [inline environments](https://tanka.dev/inline-environments) to deploy Tempo with either of the two.

--- a/operations/jsonnet-compiled/Deployment-compactor.yaml
+++ b/operations/jsonnet-compiled/Deployment-compactor.yaml
@@ -31,7 +31,7 @@ spec:
         env:
         - name: GOMEMLIMIT
           value: 5GiB
-        image: grafana/tempo:latest
+        image: grafana/tempo:2.9.2
         imagePullPolicy: IfNotPresent
         name: compactor
         ports:

--- a/operations/jsonnet-compiled/Deployment-distributor.yaml
+++ b/operations/jsonnet-compiled/Deployment-distributor.yaml
@@ -30,7 +30,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=distributor
-        image: grafana/tempo:latest
+        image: grafana/tempo:2.9.2
         imagePullPolicy: IfNotPresent
         name: distributor
         ports:

--- a/operations/jsonnet-compiled/Deployment-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/Deployment-metrics-generator.yaml
@@ -28,7 +28,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=metrics-generator
-        image: grafana/tempo:latest
+        image: grafana/tempo:2.9.2
         name: metrics-generator
         ports:
         - containerPort: 3200

--- a/operations/jsonnet-compiled/Deployment-querier.yaml
+++ b/operations/jsonnet-compiled/Deployment-querier.yaml
@@ -30,7 +30,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=querier
-        image: grafana/tempo:latest
+        image: grafana/tempo:2.9.2
         imagePullPolicy: IfNotPresent
         name: querier
         ports:

--- a/operations/jsonnet-compiled/Deployment-query-frontend.yaml
+++ b/operations/jsonnet-compiled/Deployment-query-frontend.yaml
@@ -28,7 +28,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=query-frontend
-        image: grafana/tempo:latest
+        image: grafana/tempo:2.9.2
         imagePullPolicy: IfNotPresent
         name: query-frontend
         ports:

--- a/operations/jsonnet-compiled/StatefulSet-backend-scheduler.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-backend-scheduler.yaml
@@ -24,7 +24,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=backend-scheduler
-        image: grafana/tempo:latest
+        image: grafana/tempo:2.9.2
         imagePullPolicy: IfNotPresent
         name: backend-scheduler
         ports:

--- a/operations/jsonnet-compiled/StatefulSet-backend-worker.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-backend-worker.yaml
@@ -24,7 +24,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=backend-worker
-        image: grafana/tempo:latest
+        image: grafana/tempo:2.9.2
         imagePullPolicy: IfNotPresent
         name: backend-worker
         ports:

--- a/operations/jsonnet-compiled/StatefulSet-block-builder.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-block-builder.yaml
@@ -24,7 +24,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=block-builder
-        image: grafana/tempo:latest
+        image: grafana/tempo:2.9.2
         imagePullPolicy: IfNotPresent
         name: block-builder
         ports:

--- a/operations/jsonnet-compiled/StatefulSet-ingester.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-ingester.yaml
@@ -33,7 +33,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=ingester
-        image: grafana/tempo:latest
+        image: grafana/tempo:2.9.2
         name: ingester
         ports:
         - containerPort: 3200

--- a/operations/jsonnet-compiled/StatefulSet-live-store-zone-a.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-live-store-zone-a.yaml
@@ -43,7 +43,7 @@ spec:
         - -live-store.instance-availability-zone=zone-a
         - -mem-ballast-size-mbs=1024
         - -target=live-store
-        image: grafana/tempo:latest
+        image: grafana/tempo:2.9.2
         imagePullPolicy: IfNotPresent
         name: live-store
         ports:

--- a/operations/jsonnet-compiled/StatefulSet-live-store-zone-b.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-live-store-zone-b.yaml
@@ -43,7 +43,7 @@ spec:
         - -live-store.instance-availability-zone=zone-b
         - -mem-ballast-size-mbs=1024
         - -target=live-store
-        image: grafana/tempo:latest
+        image: grafana/tempo:2.9.2
         imagePullPolicy: IfNotPresent
         name: live-store
         ports:

--- a/operations/jsonnet-compiled/StatefulSet-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-metrics-generator.yaml
@@ -33,7 +33,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=metrics-generator
-        image: grafana/tempo:latest
+        image: grafana/tempo:2.9.2
         name: metrics-generator
         ports:
         - containerPort: 3200

--- a/operations/jsonnet-compiled/util/example/main.jsonnet
+++ b/operations/jsonnet-compiled/util/example/main.jsonnet
@@ -4,7 +4,7 @@ local tempo = import 'microservices/tempo.libsonnet';
 
 tempo {
   _images+:: {
-    tempo: 'grafana/tempo:latest',
+    tempo: 'grafana/tempo:2.9.2',
     tempo_vulture: 'grafana/tempo-vulture:latest',
     tempo_query: 'grafana/tempo-query:latest',
   },

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -1,6 +1,6 @@
 {
   _images+:: {
-    tempo: 'grafana/tempo:latest',
+    tempo: 'grafana/tempo:2.9.2',
     tempo_query: 'grafana/tempo-query:latest',
     tempo_vulture: 'grafana/tempo-vulture:latest',
     rollout_operator: 'grafana/rollout-operator:v0.23.0',

--- a/operations/jsonnet/single-binary/config.libsonnet
+++ b/operations/jsonnet/single-binary/config.libsonnet
@@ -1,6 +1,6 @@
 {
   _images+:: {
-    tempo: 'grafana/tempo:latest',
+    tempo: 'grafana/tempo:2.9.2',
     tempo_query: 'grafana/tempo-query:latest',
     tempo_vulture: 'grafana/tempo-vulture:latest',
   },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
- pined tempo docker image versions everywhere to next patching release 2.9.2
- cherry-picked make file target to help automate the work for this PR

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`