### PR TITLE
fix(ci): use [0-9]+ in publish-technical-documentation-release regex (release-v2.8)

### DIFF
--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -25,8 +25,8 @@ jobs:
           fetch-depth: 0
       - uses: grafana/writers-toolkit/publish-technical-documentation-release@6200164349ac8f24bab065ce3689dd8c9a093061
         with:
-          release_tag_regexp: "^v(\\d+)\\.(\\d+)\\.(\\d+)$"
-          release_branch_regexp: "^release-v(\\d+)\\.(\\d+)$"
-          release_branch_with_patch_regexp: "^release-v(\\d+)\\.(\\d+)\\.(\\d+)$"
+          release_tag_regexp: "^v([0-9]+)\\.([0-9]+)\\.([0-9]+)$"
+          release_branch_regexp: "^release-v([0-9]+)\\.([0-9]+)$"
+          release_branch_with_patch_regexp: "^release-v([0-9]+)\\.([0-9]+)\\.([0-9]+)$"
           source_directory: docs/sources/tempo
           website_directory: content/docs/tempo


### PR DESCRIPTION
## Summary

Backport the regex fix from `main` to `release-v2.8` so docs publishing works for v2.8.x tags.

## What's the bug

The `publish-technical-documentation-release` workflow uses a bash script inside the `grafana/writers-toolkit` action that matches release branches with `[[ \"\${branch}\" =~ \${BRANCH_REGEXP} ]]`. Bash `=~` uses POSIX ERE, which does **not** support `\d`. So `\d+` was interpreted as literal `d+`, and `^release-v(\d+)\.(\d+)\$` never matched `release-v2.8`.

Failing run from the v2.8.4 tag push:
https://github.com/grafana/tempo/actions/runs/24860642181/job/72786060259

Log excerpt:
```
Checking branch release-v2.8 against ^release-v(\d+)\.(\d+)$.
No release branch found for tag v2.8.4 matching ^release-v(\d+)\.(\d+)$. Exiting.
```

## The fix

Replace `\d+` with `[0-9]+` in the three regex inputs — same change that's already on `main`.

## Test plan

- [ ] CI workflow syntax is unchanged aside from the regex, so no meaningful pre-merge verification beyond lint.
- [ ] After merge, re-running the failed job (or pushing the next v2.8.x tag) should successfully match `release-v2.8` and publish docs.