### PR TITLE
feat: add span profiling support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [FEATURE] Add span profiling support via otelpyroscope. Enable with `span_profiling: true` (or `-span-profiling` CLI flag) to attach pprof labels to OTel spans. [#7063](https://github.com/grafana/tempo/pull/7063) (@simonswine)
 * [BUGFIX] Fix tempo-vulture ignoring `-tempo-push-tls` flag in normal operating mode. [#6974](https://github.com/grafana/tempo/pull/6974) (@xaque208)
 * [CHANGE] **BREAKING CHANGE** Remove duplicate "compaction" prefix from CompactorConfig CLI flags. Affected flags: `compaction.block-retention`, `compaction.max-objects-per-block`, `compaction.max-block-bytes`, `compaction.compaction-window`. [#6909](https://github.com/grafana/tempo/pull/6909) (@electron0zero)
 * [ENHANCEMENT] Support OR conditions for tag name and tag value autocomplete (search tags v2) [#6827](https://github.com/grafana/tempo/pull/6827) (@ie-pham)

--- a/cmd/tempo/app/config.go
+++ b/cmd/tempo/app/config.go
@@ -95,7 +95,7 @@ func (c *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 	f.StringVar(&c.HTTPAPIPrefix, "http-api-prefix", "", "String prefix for all http api endpoints.")
 	f.BoolVar(&c.EnableGoRuntimeMetrics, "enable-go-runtime-metrics", false, "Set to true to enable all Go runtime metrics")
 	f.DurationVar(&c.ShutdownDelay, "shutdown-delay", 0, "How long to wait between SIGTERM and shutdown. After receiving SIGTERM, Tempo will report not-ready status via /ready endpoint.")
-	f.BoolVar(&c.SpanProfiling, "tracing.span-profiling", false, "Set to true to enable span profiling (pyroscope pprof labels on OTel spans).")
+	f.BoolVar(&c.SpanProfiling, "span-profiling", false, "Set to true to enable span profiling (pyroscope pprof labels on OTel spans).")
 
 	// Server settings
 	flagext.DefaultValues(&c.Server)

--- a/cmd/tempo/app/config.go
+++ b/cmd/tempo/app/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	StreamOverHTTPEnabled  bool          `yaml:"stream_over_http_enabled,omitempty"`
 	HTTPAPIPrefix          string        `yaml:"http_api_prefix"`
 	EnableGoRuntimeMetrics bool          `yaml:"enable_go_runtime_metrics,omitempty"`
+	SpanProfiling          bool          `yaml:"span_profiling,omitempty"`
 
 	Memory                 MemoryConfig                   `yaml:"memory,omitempty"`
 	Server                 server.Config                  `yaml:"server,omitempty"`
@@ -94,6 +95,7 @@ func (c *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 	f.StringVar(&c.HTTPAPIPrefix, "http-api-prefix", "", "String prefix for all http api endpoints.")
 	f.BoolVar(&c.EnableGoRuntimeMetrics, "enable-go-runtime-metrics", false, "Set to true to enable all Go runtime metrics")
 	f.DurationVar(&c.ShutdownDelay, "shutdown-delay", 0, "How long to wait between SIGTERM and shutdown. After receiving SIGTERM, Tempo will report not-ready status via /ready endpoint.")
+	f.BoolVar(&c.SpanProfiling, "tracing.span-profiling", false, "Set to true to enable span profiling (pyroscope pprof labels on OTel spans).")
 
 	// Server settings
 	flagext.DefaultValues(&c.Server)

--- a/cmd/tempo/main.go
+++ b/cmd/tempo/main.go
@@ -87,7 +87,7 @@ func main() {
 
 	// Init tracer if OTEL_TRACES_EXPORTER, OTEL_EXPORTER_OTLP_ENDPOINT or OTEL_EXPORTER_OTLP_TRACES_ENDPOINT is set
 	if os.Getenv("OTEL_TRACES_EXPORTER") != "" || os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") != "" || os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") != "" {
-		shutdownTracer, err := tracing.InstallOpenTelemetryTracer(appName, config.Target)
+		shutdownTracer, err := tracing.InstallOpenTelemetryTracer(appName, config.Target, config.SpanProfiling)
 		if err != nil {
 			level.Error(log.Logger).Log("msg", "error initialising tracer", "err", err)
 			os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -231,7 +231,7 @@ require (
 	github.com/google/go-tpm v0.9.8 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect
-	github.com/grafana/otel-profiling-go v0.5.1 // indirect
+	github.com/grafana/otel-profiling-go v0.5.1
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.9 // indirect
 	github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log/level"
+	otelpyroscope "github.com/grafana/otel-profiling-go"
 	"github.com/grafana/tempo/pkg/util/log"
 	"github.com/prometheus/common/version"
 	"go.opentelemetry.io/contrib/exporters/autoexport"
@@ -16,9 +17,10 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
+	"go.opentelemetry.io/otel/trace"
 )
 
-func InstallOpenTelemetryTracer(appName, target string) (func(), error) {
+func InstallOpenTelemetryTracer(appName, target string, spanProfiling bool) (func(), error) {
 	level.Info(log.Logger).Log("msg", "initialising OpenTelemetry tracer")
 
 	exp, err := autoexport.NewSpanExporter(context.Background())
@@ -42,16 +44,21 @@ func InstallOpenTelemetryTracer(appName, target string) (func(), error) {
 		level.Error(log.Logger).Log("msg", "OpenTelemetry.ErrorHandler", "err", err)
 	}))
 
-	tp := tracesdk.NewTracerProvider(
+	tpsdk := tracesdk.NewTracerProvider(
 		tracesdk.WithBatcher(exp),
 		tracesdk.WithResource(resources),
 	)
+
+	var tp trace.TracerProvider = tpsdk
+	if spanProfiling {
+		tp = otelpyroscope.NewTracerProvider(tp)
+	}
 	otel.SetTracerProvider(tp)
 
 	shutdown := func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		if err := tp.Shutdown(ctx); err != nil {
+		if err := tpsdk.Shutdown(ctx); err != nil {
 			level.Error(log.Logger).Log("msg", "OpenTelemetry trace provider failed to shutdown", "err", err)
 			os.Exit(1)
 		}


### PR DESCRIPTION
## Summary

Wraps the OTel `TracerProvider` with `otelpyroscope.NewTracerProvider` to link pprof goroutine labels (`span_id`, `span_name`) to OTel spans, enabling profile-to-trace correlation in Pyroscope.

- Adds `pyroscope.profile.id` attribute to root spans
- Promotes `github.com/grafana/otel-profiling-go` from indirect to direct dependency (already vendored at v0.5.1)
- Controlled by `-tracing.span-profiling` flag (`span_profiling` in YAML), **default: disabled**

## Equivalent implementations

- **Pyroscope**: [`pkg/pyroscope/tracing.go`](https://github.com/grafana/pyroscope/blob/main/pkg/pyroscope/tracing.go) — uses `profilingEnabled` param + `WithPyroscopeDisabled()` dskit option
- **Loki**: [`cmd/loki/main.go`](https://github.com/grafana/loki/blob/main/cmd/loki/main.go#L109) — uses dskit's `NewOTelOrJaegerFromEnv` which wraps with pyroscope by default
- **Tempo**: this PR — explicit opt-in flag, wraps provider directly

## Test plan

- [ ] Deploy to dev environment with `-tracing.span-profiling=true` and `OTEL_EXPORTER_OTLP_ENDPOINT` set
- [ ] Validate resource impact (CPU/memory overhead from pprof label tracking) is acceptable
- [ ] Verify spans in Grafana show `pyroscope.profile.id` attribute on root spans
- [ ] Verify Pyroscope profiles show `span_id`/`span_name` goroutine labels
- [ ] Roll out to all environments once resource impact is confirmed acceptable