### PR TITLE
Set default block replication factor to 1

### DIFF
--- a/tempodb/backend/block_meta.go
+++ b/tempodb/backend/block_meta.go
@@ -132,7 +132,7 @@ func (o DedicatedColumnOptions) ToTempopb() (tempopb.DedicatedColumn_Option, err
 }
 
 const (
-	DefaultReplicationFactor          = 0 // Replication factor for blocks from the ingester. This is the default value to indicate RF3.
+	DefaultReplicationFactor          = 1 // Default replication factor for blocks when unspecified. All current block producers write RF1.
 	MetricsGeneratorReplicationFactor = 1
 	LiveStoreReplicationFactor        = MetricsGeneratorReplicationFactor
 )


### PR DESCRIPTION
**What this PR does**:

Changes `backend.DefaultReplicationFactor` from `0` to `1` in `tempodb/backend/block_meta.go`.

Historically, `0` was a sentinel meaning "legacy RF3 ingester block" and was paired with `rf1_after` time-based logic on the read path. That logic has been removed on r249 (the `rf1_after` config and its only callers in `modules/frontend/util.go` and `tempodb/tempodb.go` are gone), leaving the `0` default as dead weight. All current block producers (live-store, block-builder, metrics-generator) explicitly stamp RF1, so this update aligns the fallback with what actually gets written.

No live code on r249 branches on `ReplicationFactor == 0` anymore; the only remaining references are protobuf `!= 0` marshalling guards, which are serialization plumbing and semantically unaffected.

**Which issue(s) this PR fixes**:
N/A — cleanup following `rf1_after` removal.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] \`CHANGELOG.md\` updated - the order of entries should be \`[CHANGE]\`, \`[FEATURE]\`, \`[ENHANCEMENT]\`, \`[BUGFIX]\`