### PR TITLE
Measure incorrect results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
 * [ENHANCEMENT] Expose a new histogram metric to track the jobs per query distribution [#6343](https://github.com/grafana/tempo/pull/6343) (@javiermolinar)
 * [ENHANCEMENT] Do deep validation for filter policies in user configurable overrides API [#6407](https://github.com/grafana/tempo/pull/6407) (@electron0zero)
 * [ENHANCEMENT] Allow span_name_sanitization to be set via user-configurable overrides API [#6411](https://github.com/grafana/tempo/pull/6411) (@Logiraptor)
-* [ENHANCEMENT] Add `fail_on_high_lag` parameter to allow live-store to fail if it is lagged [#6363](https://github.com/grafana/tempo/pull/6363) [#6567](https://github.com/grafana/tempo/pull/6567) (@ruslan-mikhailov, @carles-grafana)
+* [ENHANCEMENT] Add `fail_on_high_lag` parameter to allow live-store to fail if it is lagged [#6363](https://github.com/grafana/tempo/pull/6363) [#6567](https://github.com/grafana/tempo/pull/6567) [#7066](https://github.com/grafana/tempo/pull/7066) (@ruslan-mikhailov, @carles-grafana)
 * [ENHANCEMENT] Add support for per-tenant left-padding of trace IDs [#6489](https://github.com/grafana/tempo/pull/6489) (@mapno)
 * [ENHANCEMENT] Add new metric for generator ring size: `tempo_distributor_metrics_generator_tenant_ring_size` [#5686](https://github.com/grafana/tempo/pull/5686) (@zalegrala)
 * [ENHANCEMENT] Remove explicit `runtime.GC()` calls in vParquet5 compactor/block creation and CLI [#6603](https://github.com/grafana/tempo/pull/6603) (@oleg-kozlyuk-grafana)

--- a/modules/livestore/live_store.go
+++ b/modules/livestore/live_store.go
@@ -115,6 +115,12 @@ var (
 		Name:      "ready",
 		Help:      "1 if ready to serve queries, 0 otherwise",
 	})
+
+	metricLaggedRequests = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "tempo_live_store",
+		Name:      "lagged_requests_total",
+		Help:      "Requests where the live-store could not guarantee complete results due to Kafka lag.",
+	}, []string{"method"})
 )
 
 type LiveStore struct {
@@ -824,6 +830,7 @@ func (s *LiveStore) FindTraceByID(ctx context.Context, req *tempopb.TraceByIDReq
 func (s *LiveStore) SearchRecent(ctx context.Context, req *tempopb.SearchRequest) (*tempopb.SearchResponse, error) {
 	return withInstance(ctx, s, func(inst *instance) (*tempopb.SearchResponse, error) {
 		if s.isLagged(int64(req.End) * 1e9) { // convert seconds to nanoseconds
+			metricLaggedRequests.WithLabelValues("/tempopb.Querier/SearchRecent").Inc()
 			if s.cfg.FailOnHighLag {
 				return nil, errLagged
 			}
@@ -869,6 +876,7 @@ func (s *LiveStore) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTa
 func (s *LiveStore) QueryRange(ctx context.Context, req *tempopb.QueryRangeRequest) (*tempopb.QueryRangeResponse, error) {
 	return withInstance(ctx, s, func(inst *instance) (*tempopb.QueryRangeResponse, error) {
 		if s.isLagged(int64(req.End)) { // end param is already nanos, no need to convert
+			metricLaggedRequests.WithLabelValues("/tempopb.Metrics/QueryRange").Inc()
 			if s.cfg.FailOnHighLag {
 				return nil, errLagged
 			}

--- a/modules/livestore/live_store.go
+++ b/modules/livestore/live_store.go
@@ -120,7 +120,7 @@ var (
 		Namespace: "tempo_live_store",
 		Name:      "lagged_requests_total",
 		Help:      "Requests where the live-store could not guarantee complete results due to Kafka lag.",
-	}, []string{"method"})
+	}, []string{"route"})
 )
 
 type LiveStore struct {

--- a/modules/livestore/live_store.go
+++ b/modules/livestore/live_store.go
@@ -824,7 +824,9 @@ func (s *LiveStore) FindTraceByID(ctx context.Context, req *tempopb.TraceByIDReq
 func (s *LiveStore) SearchRecent(ctx context.Context, req *tempopb.SearchRequest) (*tempopb.SearchResponse, error) {
 	return withInstance(ctx, s, func(inst *instance) (*tempopb.SearchResponse, error) {
 		if s.isLagged(int64(req.End) * 1e9) { // convert seconds to nanoseconds
-			return nil, errLagged
+			if s.cfg.FailOnHighLag {
+				return nil, errLagged
+			}
 		}
 		return inst.Search(ctx, req)
 	})
@@ -867,7 +869,9 @@ func (s *LiveStore) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTa
 func (s *LiveStore) QueryRange(ctx context.Context, req *tempopb.QueryRangeRequest) (*tempopb.QueryRangeResponse, error) {
 	return withInstance(ctx, s, func(inst *instance) (*tempopb.QueryRangeResponse, error) {
 		if s.isLagged(int64(req.End)) { // end param is already nanos, no need to convert
-			return nil, errLagged
+			if s.cfg.FailOnHighLag {
+				return nil, errLagged
+			}
 		}
 		return inst.QueryRange(ctx, req)
 	})
@@ -876,7 +880,7 @@ func (s *LiveStore) QueryRange(ctx context.Context, req *tempopb.QueryRangeReque
 var errLagged = errors.New("cannot guarantee complete results")
 
 func (s *LiveStore) isLagged(endNanos int64) bool {
-	if !s.cfg.FailOnHighLag || !s.cfg.ConsumeFromKafka { // if config disabled or no kafka consumption, never lagged
+	if !s.cfg.ConsumeFromKafka { // if config disabled or no kafka consumption, never lagged
 		return false
 	}
 	lag := s.calculateTimeLag(0)

--- a/modules/livestore/live_store_test.go
+++ b/modules/livestore/live_store_test.go
@@ -1106,6 +1106,7 @@ func TestIsLagged(t *testing.T) {
 		lastRecordNano int64
 		end            time.Time
 		expectedLagged bool
+		expectedError  bool
 		description    string
 	}{
 		{
@@ -1114,8 +1115,9 @@ func TestIsLagged(t *testing.T) {
 			readerLag:      50000000,                             // high lag
 			lastRecordNano: now.Add(-100 * time.Hour).UnixNano(), // high lag
 			end:            now.Add(-1 * time.Second),
-			expectedLagged: false,
-			description:    "When FailOnHighLag is disabled, isLagged should always return false",
+			expectedLagged: true,
+			expectedError:  false,
+			description:    "When FailOnHighLag is disabled, isLagged should returns true, but methods should not return error",
 		},
 		{
 			name:           "lag unknown - should be lagged",
@@ -1124,6 +1126,7 @@ func TestIsLagged(t *testing.T) {
 			lastRecordNano: now.Add(-100 * time.Hour).UnixNano(), // high lag
 			end:            now,
 			expectedLagged: true,
+			expectedError:  true,
 			description:    "When lag is unknown (nil), prefer error over potentially incomplete results",
 		},
 		{
@@ -1133,6 +1136,7 @@ func TestIsLagged(t *testing.T) {
 			lastRecordNano: -1, // no last record yet
 			end:            now,
 			expectedLagged: true,
+			expectedError:  true,
 			description:    "When no last record yet, should not be lagged",
 		},
 		{
@@ -1142,6 +1146,7 @@ func TestIsLagged(t *testing.T) {
 			lastRecordNano: now.UnixNano(), // no lag
 			end:            now.Add(-1 * time.Second),
 			expectedLagged: false,
+			expectedError:  false,
 			description:    "When lag is low (near zero), recent requests should not be lagged",
 		},
 		{
@@ -1151,6 +1156,7 @@ func TestIsLagged(t *testing.T) {
 			lastRecordNano: now.Add(-10 * time.Second).UnixNano(), // 10 seconds ago
 			end:            now.Add(-5 * time.Second),             // 5 seconds ago
 			expectedLagged: true,
+			expectedError:  true,
 			description:    "When lag is high and request is within the lag period, should be lagged",
 		},
 		{
@@ -1160,6 +1166,7 @@ func TestIsLagged(t *testing.T) {
 			lastRecordNano: now.Add(-10 * time.Second).UnixNano(), // 10 seconds ago
 			end:            now.Add(-100 * time.Second),           // 100 seconds ago (well before lag)
 			expectedLagged: false,
+			expectedError:  false,
 			description:    "When lag is high but request is old (outside lag period), should not be lagged",
 		},
 		{
@@ -1169,6 +1176,7 @@ func TestIsLagged(t *testing.T) {
 			lastRecordNano: now.Add(-10 * time.Second).UnixNano(), // last record was 10s ago
 			end:            now.Add(-10 * time.Second),            // request end is 10s ago
 			expectedLagged: false,
+			expectedError:  false,
 			description:    "When request end time is equals the calculated lag, should not be lagged",
 		},
 	}
@@ -1200,7 +1208,7 @@ func TestIsLagged(t *testing.T) {
 					End:   uint32(tc.end.Unix()),
 				})
 
-				if tc.expectedLagged {
+				if tc.expectedError {
 					require.ErrorIs(t, err, errLagged)
 					require.Nil(t, resp)
 				} else {
@@ -1217,7 +1225,7 @@ func TestIsLagged(t *testing.T) {
 					End:   uint64(tc.end.UnixNano()),
 					Step:  uint64(time.Second),
 				})
-				if tc.expectedLagged {
+				if tc.expectedError {
 					require.ErrorIs(t, err, errLagged)
 					require.Nil(t, resp)
 				} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: adds metrics tempo_live_store_lagged_requests_total that measures when lag overlaps with requested time range. Total request hits can be measured with existing
```
tempo_request_duration_seconds_count{method="gRPC",route="/tempopb.Querier/SearchRecent",status_code="success"}
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`