### PR TITLE
[DOC] Update network docs for 3.0 changes

### DIFF
--- a/docs/sources/tempo/configuration/network/ipv6.md
+++ b/docs/sources/tempo/configuration/network/ipv6.md
@@ -29,6 +29,7 @@ distributor:
   ring:
     enable_inet6: true
 
+# Only needed if the backend-worker ring is enabled (kvstore.store is set).
 backend_worker:
   ring:
     enable_inet6: true

--- a/docs/sources/tempo/configuration/network/ipv6.md
+++ b/docs/sources/tempo/configuration/network/ipv6.md
@@ -24,10 +24,13 @@ memberlist:
     - '::'
   bind_port: 7946
 
+# Required only when using the global ingestion rate strategy.
+distributor:
+  ring:
+    enable_inet6: true
+
 backend_worker:
   ring:
-    kvstore:
-      store: memberlist
     enable_inet6: true
 
 metrics_generator:
@@ -45,6 +48,10 @@ server:
   http_listen_port: 3200
 ```
 
+{{< admonition type="note" >}}
+The `live_store.partition_ring` doesn't expose `enable_inet6`. It inherits its address family from the top-level `memberlist` configuration.
+{{< /admonition >}}
+
 ## Kubernetes service configuration
 
 Each service fronting the workloads needs to be configured with `spec.ipFamilies` and `spec.ipFamilyPolicy` set. Refer to this `backend-worker` example:
@@ -56,7 +63,7 @@ metadata:
   labels:
     name: backend-worker
   name: backend-worker
-  namespace: trace
+  namespace: tracing
 spec:
   clusterIP: fccb::31a7
   clusterIPs:
@@ -77,17 +84,56 @@ spec:
   type: ClusterIP
 ```
 
-You can check the listening service from within a pod.
+In addition to the per-component services, Tempo components discover each other through a separate headless `gossip-ring` Service that exposes the memberlist port. Configure it as IPv6 so that components can join the cluster over IPv6.
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: gossip-ring
+  namespace: tracing
+spec:
+  clusterIP: None
+  ipFamilies:
+    - IPv6
+  ipFamilyPolicy: SingleStack
+  ports:
+    - name: gossip-ring
+      port: 7946
+      protocol: TCP
+      targetPort: 7946
+  selector:
+    tempo-gossip-member: "true"
+```
+
+Each Tempo component then joins `memberlist` by referencing the headless Service's DNS name in its `memberlist.join_members` configuration:
+
+```yaml
+memberlist:
+  join_members:
+    - dns+gossip-ring.tracing.svc.cluster.local.:7946
+```
+
+## Verify the listeners
+
+The Tempo container image is distroless and doesn't include a shell or networking utilities. You can't `exec` into a Tempo Pod directly to inspect listeners.
+
+To inspect listening sockets, attach an [ephemeral debug container](https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/#ephemeral-container) that shares the target Pod's network namespace, using a debug image that includes the `ss` utility:
 
 ```sh
-❯ k exec -it backend-worker-55c778b8d9-2kch2 -- sh
-/ # apk add iproute2
-OK: 12 MiB in 27 packages
-/ # ss -ltn -f inet
-State   Recv-Q   Send-Q     Local Address:Port     Peer Address:Port  Process
-/ # ss -ltn -f inet6
-State    Recv-Q   Send-Q     Local Address:Port     Peer Address:Port  Process
-LISTEN   0        4096                   *:7946                *:*
-LISTEN   0        4096                   *:9095                *:*
-LISTEN   0        4096                   *:3200                *:*
+kubectl debug -n tracing -it <pod-name> \
+  --image=<your-debug-image> \
+  --target=backend-worker \
+  -- ss -ltn
 ```
+
+You should see IPv6 wildcard listeners on the memberlist, gRPC, and HTTP ports:
+
+```text
+State   Recv-Q   Send-Q     Local Address:Port     Peer Address:Port
+LISTEN  0        4096                   *:7946                *:*
+LISTEN  0        4096                   *:9095                *:*
+LISTEN  0        4096                   *:3200                *:*
+```
+
+The `*` in `Local Address` indicates the process is listening on all addresses for the configured family.

--- a/docs/sources/tempo/configuration/network/sidecar-proxy.md
+++ b/docs/sources/tempo/configuration/network/sidecar-proxy.md
@@ -8,25 +8,36 @@ aliases:
 
 # Run Tempo distributed with sidecar proxies
 
-You can route inter-pod gRPC traffic run through a sidecar proxy to meet requirements such as custom security, routing, or logging.
+You can route inter-pod gRPC traffic through a sidecar proxy to meet requirements such as custom security, routing, or logging.
 Common examples include Envoy, Nginx, Traefik, or service meshes like Istio and Linkerd.
+
+This page applies only to the [microservices deployment mode](/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/deployment-modes/).
+In monolithic (single-binary) mode, components communicate in-process, so there's no inter-pod gRPC traffic for a sidecar to proxy.
 
 ## How Tempo pods communicate
 
-Tempo pods communicate using gRPC.
+In microservices mode, Tempo's write path runs through Kafka and the read path uses gRPC.
+Distributors write to Kafka, and live-stores, block-builders, and metrics-generators each consume from Kafka independently.
+Queriers contact live-stores over gRPC for recent data.
 
-The different components, like distributors, live-stores, and block-builders, find each other by a shared ring with the list of pods, their roles, and their addresses.
-Pods advertise their address and listening port into the ring when they start, and deregister themselves when they exit.
+For background on how each component communicates, refer to:
+
+- [Deployment modes](/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/deployment-modes/) for the overall network model.
+- [Live-store](/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/live-store/) and [Querier](/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/querier/) for the gRPC read path that this page covers.
+
+This page focuses on the querier-to-live-store gRPC traffic, which a sidecar proxy can wrap.
+Queriers discover live-stores through a shared hash ring: live-stores register their address and port in the ring at startup and deregister on exit.
 
 The overall network looks like this:
 
 ![Tempo distributed network overview](/static/img/docs/tempo/sidecar-proxy/tempo-network-sidecar-proxy-simple.svg)
 
-The low-level ring data can be viewed by browsing to the `/live-store/ring` URL on a distributor. It looks like this:
+You can view the low-level ring data by browsing to the `/live-store/ring` URL on any component that imports the live-store ring, for example a distributor or querier. It looks like this:
 
 ![Ring status with default port](/static/img/docs/tempo/sidecar-proxy/screenshot-tempo-sidecar.png)
 
-By default, gRPC traffic uses port 9095, but this can be changed by customizing the `grpc_listen_port` for each pod that needs it.
+By default, gRPC traffic uses port 9095, but you can change it by customizing `server.grpc_listen_port` on each pod that needs it.
+This setting changes the gRPC port for the entire process, so make sure any other components that connect to the pod, for example queriers connecting to a query-frontend, use the new port too.
 
 ```yaml
 server:
@@ -40,31 +51,28 @@ The ring contents reflect the new port:
 ## Run Tempo with proxies
 
 Some installations require that the inter-pod gRPC traffic runs through a sidecar proxy.
-Running Tempo with proxies requires setting two ports for each pod: one for the Tempo process and one for the sidecar.
-Additionally, the ring contents must reflect the proxy's port so that traffic from other pods goes through the proxy.
+Running Tempo with proxies requires setting two ports for the live-store: one for the live-store process and one for the sidecar.
+Additionally, the live-store ring contents must reflect the proxy's port so that traffic from queriers goes through the proxy.
 
 The overall network looks like this:
 
-![Tempo distributed network overview](/static/img/docs/tempo/sidecar-proxy/tempo-network-sidecar-proxy-complex.svg)
+![Tempo distributed network with sidecar proxies](/static/img/docs/tempo/sidecar-proxy/tempo-network-sidecar-proxy-complex.svg)
 
-This cannot be accomplished by setting the same `grpc_listen_port` as in the previous example. Instead, we need the live-store to _listen_ on port A but _advertise_ itself on port B. This is done by customizing the live-store's ring instance port:
+You can't accomplish this by setting the same `grpc_listen_port` as in the previous example. Instead, the live-store needs to _listen_ on port A but _advertise_ itself on port B. To do this, customize the live-store's ring instance port:
 
 ```yaml
 live_store:
-   ring:
-       instance_port: 12345
-```
-
-Now, the live-store is listening for regular traffic on port 9095, but other components route traffic to it on port 12345.
-
-## Metrics-generator proxy
-
-You can customize the instance port in the metrics-generator. To set an instance port for the metrics-generator, use this configuration:
-
-```yaml
-metrics_generator:
   ring:
     instance_port: 12345
 ```
 
-Replace `12345` with the correct port number.
+The live-store now listens for regular traffic on port 9095, but queriers route traffic to it on port 12345.
+
+## Other components
+
+Only the live-store advertises a gRPC address through a hash ring this way.
+Other components don't need or support a comparable `instance_port` setting:
+
+- The metrics-generator consumes trace data from Kafka in microservices mode, so distributors don't reach it through a hash ring. Refer to the [metrics-generator architecture](/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/metrics-generator/).
+- Distributors and block-builders also use Kafka for the write path. Refer to the [distributor](/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/distributor/) and [partition ring](/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/partition-ring/) documentation.
+- For other gRPC connections, such as querier-to-query-frontend, set `server.grpc_listen_port` on the destination pod and update the matching client address on the calling component.

--- a/docs/sources/tempo/configuration/network/sidecar-proxy.md
+++ b/docs/sources/tempo/configuration/network/sidecar-proxy.md
@@ -70,8 +70,8 @@ The live-store now listens for regular traffic on port 9095, but queriers route 
 
 ## Other components
 
-Only the live-store advertises a gRPC address through a hash ring this way.
-Other components don't need or support a comparable `instance_port` setting:
+Only the live-store ring's `instance_port` is relevant for this sidecar proxy pattern.
+Other components have their own rings, but those rings aren't used by queriers for gRPC routing:
 
 - The metrics-generator consumes trace data from Kafka in microservices mode, so distributors don't reach it through a hash ring. Refer to the [metrics-generator architecture](/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/metrics-generator/).
 - Distributors and block-builders also use Kafka for the write path. Refer to the [distributor](/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/distributor/) and [partition ring](/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/partition-ring/) documentation.

--- a/docs/sources/tempo/configuration/network/tls.md
+++ b/docs/sources/tempo/configuration/network/tls.md
@@ -94,8 +94,8 @@ The following fields are available in the receiver `tls` block:
 |---|---|---|
 | `cert_file` | Yes | Path to the TLS certificate file. |
 | `key_file` | Yes | Path to the TLS private key file. |
-| `ca_file` | No | Path to the CA certificate for verifying client certificates. Required for mutual TLS (mTLS). If omitted, the system root CA pool is used. |
-| `client_ca_file` | No | Path to the CA certificate used to verify client certificates. When set, the server requires and verifies client certificates (mTLS). |
+| `ca_file` | No | Path to a CA certificate bundle used by a TLS **client** to verify the server's certificate. Use this field on the sending side (for example, in an Alloy exporter or Kafka client) to trust a custom or internal CA. On receivers, this field has no effect because receivers don't initiate outbound TLS connections. If omitted, the system root CA pool is used. |
+| `client_ca_file` | No | Path to the CA certificate used by a TLS **server** to verify client certificates. When set on a receiver, it requires connecting clients to present a valid certificate signed by this CA (mTLS). Use this field to enable mTLS on receivers. |
 | `min_version` | No | Minimum TLS version to accept, for example `"1.2"` or `"1.3"`. |
 
 ### Configure server-only TLS
@@ -118,7 +118,7 @@ distributor:
 ### Configure mutual TLS (mTLS)
 
 For mutual TLS, both the server and client present certificates.
-Add `ca_file` or `client_ca_file` so the distributor verifies client certificates:
+Add `client_ca_file` so the distributor requires and verifies client certificates:
 
 ```yaml
 distributor:
@@ -129,7 +129,6 @@ distributor:
           tls:
             cert_file: /tls/tls.crt
             key_file: /tls/tls.key
-            ca_file: /tls/ca.crt
             client_ca_file: /tls/ca.crt
             min_version: "1.2"
 ```

--- a/docs/sources/tempo/configuration/network/tls.md
+++ b/docs/sources/tempo/configuration/network/tls.md
@@ -1,22 +1,27 @@
 ---
 title: Configure TLS communication
 menuTitle: Configure TLS
-description: Configure Tempo components to communicate using TLS.
+description: Configure TLS for Tempo server endpoints, gRPC clients, trace receivers, object storage, and caches to secure communication between components.
 aliases:
   - ../../configuration/tls/ # /docs/tempo/<TEMPO_VERSION>/configuration/tls/
 ---
 
 # Configure TLS communication
 
-Tempo can be configured to communicate between the components using Transport Layer Security, or TLS.
+Tempo can be configured to communicate between components using Transport Layer Security, or TLS.
+TLS secures three categories of connections:
+
+- Server and client: Communication between internal Tempo components (for example, querier to query-frontend).
+- Receiver: Incoming trace data from instrumented applications or collectors to the distributor.
+- Storage and cache: Connections to backend object storage (S3) and caches (Memcached, Redis).
 
 {{< admonition type="note" >}}
-The ciphers and TLS version here are for example purposes only. We are not recommending which ciphers or TLS versions for use in production environments.
+The ciphers and TLS version here are for example purposes only. We aren't recommending which ciphers or TLS versions to use in production environments.
 {{< /admonition >}}
 
 ## Server configuration
 
-This sample TLS server configuration shows supported options.
+Every Tempo component exposes gRPC and HTTP endpoints. Use the `server` block to enable TLS on these endpoints.
 
 ```yaml
 server:
@@ -35,15 +40,15 @@ server:
     client_ca_file: /tls/ca.crt
 ```
 
-Valid values for the `client_auth_type` are documented in the standard `crypt/tls` package under `ClientAuthType` [here](https://pkg.go.dev/crypto/tls#ClientAuthType).
+Valid values for the `client_auth_type` are documented in the standard `crypto/tls` package under [`ClientAuthType`](https://pkg.go.dev/crypto/tls#ClientAuthType).
 
 ## Client configuration
 
-Several components of Tempo need to configure the gRPC clients they use to communicate with other components. For example, when the `querier` contacts the `query-frontend` to request work, the client in use must enable TLS if the server is serving a TLS endpoint.
+Several Tempo components configure gRPC clients to communicate with other components. For example, the querier contacts the query-frontend to request work. If the server endpoint uses TLS, the corresponding client must also enable TLS.
 
-The Tempo configuration uses a standard configuration stanza for each of these client configurations. Below is an example of the configuration.
+Tempo uses a standard `grpc_client_config` stanza for each of these client connections.
 
-The optional configuration elements `tls_min_version`, `tls_cipher_suites`, and `tls_insecure_skip_verify` may be omitted. The option `tls_server_name` may or may not be required, depending on the environment.
+You can optionally omit `tls_min_version`, `tls_cipher_suites`, and `tls_insecure_skip_verify`. Whether `tls_server_name` is required depends on your environment.
 
 ```yaml
 grpc_client_config:
@@ -57,14 +62,15 @@ grpc_client_config:
   tls_min_version: VersionTLS12
 ```
 
-The configuration block needs to be set at the following configuration locations.
+Set this configuration block at the following locations:
 
 - `live_store_client.grpc_client_config`
 - `querier.frontend_worker.grpc_client_config`
+- `backend_scheduler_client.grpc_client_config`
 
 Additionally, `memberlist` must also be configured, but the client configuration is nested directly under `memberlist` as follows. The same configuration options are available as above.
 
-```
+```yaml
 memberlist:
     tls_enabled: true
     tls_cert_path: /tls/tls.crt
@@ -74,35 +80,160 @@ memberlist:
     tls_insecure_skip_verify: false
 ```
 
-### Receiver TLS
+## Receiver TLS
 
-Additional receiver configuration can be added to support TLS communication for traces being sent to Tempo. The receiver configuration is pulled in from the Open Telemetry collector, and is [documented upstream here](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/config.md#configtls-tlsserversetting).
-Addition TLS configuration of OTEL components can be found [here](https://github.com/open-telemetry/opentelemetry-collector/tree/main/config/configtls).
+Receiver TLS secures the connection between trace sources, such as instrumented applications, OpenTelemetry Collectors, or Grafana Alloy, and the Tempo distributor.
+The receiver configuration uses the OpenTelemetry Collector TLS settings.
+For the full set of options, refer to the upstream [OTLP receiver TLS documentation](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/config.md#configtls-tlsserversetting) and the [`configtls` package reference](https://github.com/open-telemetry/opentelemetry-collector/tree/main/config/configtls).
 
-An example `tls` block might look like the following:
+### TLS fields
+
+The following fields are available in the receiver `tls` block:
+
+| Field | Required | Description |
+|---|---|---|
+| `cert_file` | Yes | Path to the TLS certificate file. |
+| `key_file` | Yes | Path to the TLS private key file. |
+| `ca_file` | No | Path to the CA certificate for verifying client certificates. Required for mutual TLS (mTLS). If omitted, the system root CA pool is used. |
+| `client_ca_file` | No | Path to the CA certificate used to verify client certificates. When set, the server requires and verifies client certificates (mTLS). |
+| `min_version` | No | Minimum TLS version to accept, for example `"1.2"` or `"1.3"`. |
+
+### Configure server-only TLS
+
+For server-only TLS, the distributor presents its certificate and clients verify it.
+Only `cert_file` and `key_file` are required:
 
 ```yaml
-tls:
-  ca_file: /tls/ca.crt
-  cert_file: /tls/tls.crt
-  key_file: /tls/tls.key
-  min_version: "1.2"
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          tls:
+            cert_file: /tls/tls.crt
+            key_file: /tls/tls.key
+            min_version: "1.2"
 ```
 
-The above structure can be set on the following receiver configurations:
+### Configure mutual TLS (mTLS)
+
+For mutual TLS, both the server and client present certificates.
+Add `ca_file` or `client_ca_file` so the distributor verifies client certificates:
+
+```yaml
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          tls:
+            cert_file: /tls/tls.crt
+            key_file: /tls/tls.key
+            ca_file: /tls/ca.crt
+            client_ca_file: /tls/ca.crt
+            min_version: "1.2"
+```
+
+### Supported receiver TLS paths
+
+You can set a `tls` block on the following receiver configurations:
 
 - `distributor.receivers.otlp.protocols.grpc.tls`
 - `distributor.receivers.otlp.protocols.http.tls`
+- `distributor.receivers.kafka.tls` (client TLS for connecting to Kafka brokers)
 - `distributor.receivers.zipkin.tls`
 - `distributor.receivers.jaeger.protocols.grpc.tls`
 - `distributor.receivers.jaeger.protocols.thrift_http.tls`
 
-### Configure TLS with Helm
+{{< admonition type="note" >}}
+The Kafka receiver TLS block configures **client** TLS for the connection to Kafka brokers, unlike the other receiver TLS blocks which configure **server** TLS for incoming connections.
+{{< /admonition >}}
+
+### Configure the sending side
+
+When you enable TLS on the Tempo receiver, you must also configure TLS on the client that sends traces.
+The following example shows a matching Grafana Alloy configuration for an OTLP gRPC exporter with server-only TLS:
+
+```alloy
+otelcol.exporter.otlp "tempo" {
+  client {
+    endpoint = "tempo.trace.svc.cluster.local:4317"
+    tls {
+      ca_file = "/tls/ca.crt"
+    }
+  }
+}
+```
+
+For mTLS, include the client certificate and key:
+
+```alloy
+otelcol.exporter.otlp "tempo" {
+  client {
+    endpoint = "tempo.trace.svc.cluster.local:4317"
+    tls {
+      ca_file   = "/tls/ca.crt"
+      cert_file = "/tls/tls.crt"
+      key_file  = "/tls/tls.key"
+    }
+  }
+}
+```
+
+## Storage and cache TLS
+
+### S3 and S3-compatible storage
+
+If you use a self-managed S3-compatible backend (for example, MinIO) with a custom CA or client certificates, configure TLS on the S3 storage backend.
+The TLS fields are set inline under `storage.trace.s3`:
+
+```yaml
+storage:
+  trace:
+    backend: s3
+    s3:
+      bucket: tempo-traces
+      endpoint: minio.example.com:9000
+      tls_ca_path: /tls/ca.crt
+      tls_cert_path: /tls/tls.crt
+      tls_key_path: /tls/tls.key
+      tls_server_name: minio.example.com
+      tls_insecure_skip_verify: false
+      tls_min_version: VersionTLS12
+```
+
+GCS and Azure Blob Storage rely on their respective SDK defaults for TLS and don't expose separate TLS fields in the Tempo configuration.
+
+### Redis cache
+
+If you use Redis as a cache backend, enable TLS with the `tls_enabled` field.
+Redis TLS has limited configuration. It supports `tls_enabled` and `tls_insecure_skip_verify` but doesn't expose CA or client certificate path fields:
+
+```yaml
+cache:
+  caches:
+    - redis:
+        endpoint: redis.example.com:6380
+        tls_enabled: true
+        tls_insecure_skip_verify: false
+      roles:
+        - parquet-footer
+        - bloom
+        - frontend-search
+```
+
+## Gateway and ingress TLS
+
+Tempo doesn't include a built-in gateway component.
+If you end TLS at an ingress controller, load balancer, or reverse proxy in front of Tempo, configure TLS on that component rather than in the Tempo configuration.
+When TLS is ended at the ingress, Tempo receivers don't need TLS configured for internal connections.
+
+## Configure TLS with Helm
 
 To configure TLS with the Helm chart, you must have a TLS key-pair and CA certificate stored in a Kubernetes secret.
-The following example mounts a secret called `tempo-distributed-tls` into the pods at `/tls` and modifies the configuration of Tempo to make use of the files.
+The following example mounts a secret called `tempo-distributed-tls` into the pods at `/tls` and modifies the configuration of Tempo to use the files.
 In this example, the Tempo components share a single TLS certificate.
-Note that the `tls_server_name` configuration must match the certificate.
+The `tls_server_name` configuration must match the certificate.
 
 ```yaml
 distributor:
@@ -208,6 +339,13 @@ tempo:
         tls_enabled: true
         tls_key_path: /tls/tls.key
         tls_server_name: tempo-distributed.trace.svc.cluster.local
+    backend_scheduler_client:
+      grpc_client_config:
+        tls_ca_path: /tls/ca.crt
+        tls_cert_path: /tls/tls.crt
+        tls_enabled: true
+        tls_key_path: /tls/tls.key
+        tls_server_name: tempo-distributed.trace.svc.cluster.local
     cache:
       caches:
         - memcached:
@@ -250,7 +388,7 @@ traces:
 ```
 
 Refer to the [`prometheus.scrape` docs for Alloy](https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/components/prometheus/prometheus.scrape/) to configure TLS on the scrape.
-A relabel configuration like the following will do this configuration for you dynamically.
+A relabel configuration like the following does this configuration for you dynamically.
 
 ```json
 {


### PR DESCRIPTION
**What this PR does**:

Update configure/network docs for 3.0 updates, including TLS, side-car proxy, and IPv6. Addresses support issues from https://github.com/grafana/support-escalations/issues/13666. 

### Changes

- **`sidecar-proxy.md`**: Scoped to microservices mode, rewrote the communication model around Kafka writes and querier-to-live-store gRPC reads, and removed the obsolete `metrics_generator.ring.instance_port` guidance.
- **`tls.md`**: Added `backend_scheduler_client` to client and Helm examples, expanded receiver TLS (mTLS, Kafka, Alloy sending side), and added storage/cache and ingress TLS sections.
- **`ipv6.md`**: Added missing `distributor.ring.enable_inet6` and `gossip-ring` Service examples, and replaced the broken `kubectl exec` verification steps with a `kubectl debug` workflow for the distroless image.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/support-escalations/issues/13666

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`