### PR TITLE
docs: cover KEDA autoscaling and partition ring config removal

### DIFF
--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
@@ -368,6 +368,55 @@ storage+: {
 Enabling metrics generation and remote writing them to Grafana Cloud Metrics produces extra active series that could potentially impact your billing. For more information on billing, refer to [Billing and usage](/docs/grafana-cloud/billing-and-usage/). For more information on metrics generation, refer the [Metrics-generator documentation](/docs/tempo/<TEMPO_VERSION>/metrics-from-traces/metrics-generator/).
 {{< /admonition >}}
 
+### Optional: Enable KEDA autoscaling (Tempo 3.0 and later)
+
+Starting in Tempo 3.0, the microservices Jsonnet library includes optional KEDA-based horizontal autoscaling for distributor, metrics-generator, backend-worker, and block-builder components. All KEDA scalers are disabled by default (`enabled: false`), and you enable each component independently under `_config.<component>.keda`.
+
+Before you enable this option, make sure your cluster has the KEDA operator and CRDs installed.
+
+The following example enables all supported KEDA scalers and sets the required backend-worker Prometheus address:
+
+```jsonnet
+_config+:: {
+  distributor+: {
+    keda: {
+      enabled: true,
+      min_replicas: 2,
+      max_replicas: 200,
+      target_cpu: '330m',
+    },
+  },
+  metrics_generator+: {
+    keda: {
+      enabled: true,
+      min_replicas: 1,
+      max_replicas: 200,
+      target_cpu: '500m',
+    },
+  },
+  backend_worker+: {
+    keda: {
+      enabled: true,
+      min_replicas: 3,
+      max_replicas: 200,
+      prometheus_address: 'http://prometheus-operated.monitoring.svc.cluster.local:9090',
+      threshold: 200,
+    },
+  },
+  block_builder+: {
+    keda: {
+      enabled: true,
+      min_replicas: 1,
+      max_replicas: 200,
+      partitions_per_instance: 1,
+      pod_selector: 'name=live-store-zone-a',
+    },
+  },
+},
+```
+
+Tempo uses these trigger types when KEDA is enabled: CPU for distributor and metrics-generator, Prometheus for backend-worker, and kubernetes-workload for block-builder. When you enable block-builder autoscaling, Tempo also sets `block_builder.partitions_per_instance` from `_config.block_builder.keda.partitions_per_instance`.
+
 ### Optional: Reduce component system requirements
 
 Smaller ingestion and query volumes could allow the use of smaller resources. If you wish to lower the resources allocated to components, then you can do this via a container configuration. For example, to change the CPU and memory resource allocation for the block-builders or live-stores.

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
@@ -368,9 +368,9 @@ storage+: {
 Enabling metrics generation and remote writing them to Grafana Cloud Metrics produces extra active series that could potentially impact your billing. For more information on billing, refer to [Billing and usage](/docs/grafana-cloud/billing-and-usage/). For more information on metrics generation, refer the [Metrics-generator documentation](/docs/tempo/<TEMPO_VERSION>/metrics-from-traces/metrics-generator/).
 {{< /admonition >}}
 
-### Optional: Enable KEDA autoscaling (Tempo 3.0 and later)
+### Optional: Enable KEDA autoscaling 
 
-Starting in Tempo 3.0, the microservices Jsonnet library includes optional KEDA-based horizontal autoscaling for distributor, metrics-generator, backend-worker, and block-builder components. All KEDA scalers are disabled by default (`enabled: false`), and you enable each component independently under `_config.<component>.keda`.
+The microservices Jsonnet library includes optional KEDA-based horizontal autoscaling for distributor, metrics-generator, backend-worker, and block-builder components. All KEDA scalers are disabled by default (`enabled: false`), and you enable each component independently under `_config.<component>.keda`.
 
 Before you enable this option, make sure your cluster has the KEDA operator and CRDs installed.
 

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/upgrade.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/upgrade.md
@@ -129,6 +129,24 @@ storage:
         - { scope: resource, name: service.name, type: string }
 ```
 
+### `partition_ring_live_store` removed
+
+Tempo 3.0 removes the top-level `partition_ring_live_store` setting. Tempo now uses a single partition ring, so this configuration toggle is no longer needed. [[PR 6981](https://github.com/grafana/tempo/pull/6981)]
+
+If your 2.x configuration still includes this field, remove it before or during your 3.0 upgrade.
+
+Before:
+
+```yaml
+partition_ring_live_store: true
+```
+
+After:
+
+```yaml
+# Remove partition_ring_live_store
+```
+
 ### Live-store and query defaults reduced
 
 The default values for several live-store and query-frontend settings have been reduced to produce smaller WAL blocks, release completed blocks sooner, and align the metrics query backend boundary with search.


### PR DESCRIPTION
**What this PR does**:

- Updates the Tanka deployment guide with a new optional section for KEDA autoscaling in Tempo 3.0+, including `_config.<component>.keda` usage and a runnable Jsonnet example for distributor, metrics-generator, backend-worker, and block-builder.
- Updates the upgrade guide with a Tempo 3.0 migration note that `partition_ring_live_store` was removed and should be deleted from existing configs.

**Which issue(s) this PR fixes**:

Documents the user-facing changes from #6970 (KEDA autoscaling in microservices jsonnet) and #6981 (removal of partition ring livestore config).

**Checklist**

- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

Made with [Cursor](https://cursor.com)