### PR TITLE
fix(storage): cancel polling context on store shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 <!-- next version -->
 
+* [BUGFIX] fix(storage): cancel polling context on store shutdown. [#7081](https://github.com/grafana/tempo/pull/7081) (@fgouteroux)
+
 # v3.0.2
 
 * [CHANGE] Upgrade Tempo to Go 1.26.3 [#7423](https://github.com/grafana/tempo/pull/7423) (@ie-pham)

--- a/modules/storage/store.go
+++ b/modules/storage/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/tempo/pkg/cache"
 	"github.com/grafana/tempo/pkg/usagestats"
 	"github.com/grafana/tempo/tempodb"
+	"github.com/grafana/tempo/tempodb/blocklist"
 )
 
 var (
@@ -28,7 +29,8 @@ type Store interface {
 type store struct {
 	services.Service
 
-	cfg Config
+	cfg           Config
+	pollingCancel context.CancelFunc
 
 	tempodb.Reader
 	tempodb.Writer
@@ -60,7 +62,18 @@ func (s *store) starting(_ context.Context) error {
 	return nil
 }
 
+// EnablePolling overrides the embedded method to capture a cancellable context
+// so that the polling goroutine exits promptly when the store service stops.
+func (s *store) EnablePolling(ctx context.Context, sharder blocklist.JobSharder, skipNoCompact bool) {
+	pollingCtx, cancel := context.WithCancel(context.Background())
+	s.pollingCancel = cancel
+	s.Reader.EnablePolling(pollingCtx, sharder, skipNoCompact)
+}
+
 func (s *store) stopping(_ error) error {
+	if s.pollingCancel != nil {
+		s.pollingCancel()
+	}
 	s.Reader.Shutdown()
 
 	return nil

--- a/modules/storage/store.go
+++ b/modules/storage/store.go
@@ -65,7 +65,7 @@ func (s *store) starting(_ context.Context) error {
 // EnablePolling overrides the embedded method to capture a cancellable context
 // so that the polling goroutine exits promptly when the store service stops.
 func (s *store) EnablePolling(ctx context.Context, sharder blocklist.JobSharder, skipNoCompact bool) {
-	pollingCtx, cancel := context.WithCancel(context.Background())
+	pollingCtx, cancel := context.WithCancel(ctx)
 	s.pollingCancel = cancel
 	s.Reader.EnablePolling(pollingCtx, sharder, skipNoCompact)
 }

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -430,7 +430,13 @@ func (p *Poller) pollUnknown(
 			defer bg.Done()
 
 			if p.cfg.PollJitterMs > 0 {
-				time.Sleep(time.Duration(rand.Intn(p.cfg.PollJitterMs)) * time.Millisecond)
+				jitter := time.NewTimer(time.Duration(rand.Intn(p.cfg.PollJitterMs)) * time.Millisecond)
+				select {
+				case <-jitter.C:
+				case <-derivedCtx.Done():
+					jitter.Stop()
+					return
+				}
 			}
 
 			m, cm, pollBlockErr := p.pollBlock(derivedCtx, tenantID, id, compacted)

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -435,6 +435,7 @@ func (p *Poller) pollUnknown(
 				case <-jitter.C:
 				case <-derivedCtx.Done():
 					jitter.Stop()
+					errs = append(errs, derivedCtx.Err())
 					return
 				}
 			}


### PR DESCRIPTION
---
**What this PR does**:

**Context:** 

In a production setup where Tempo runs as a systemd-managed microservice, **SIGTERM** is sent by systemd on systemctl stop / rolling restart.

The expected behaviour is a clean shutdown but instead, the process hangs for up to 5 minutes (default blocklist_poll interval) before exiting, causing systemd to hit its **TimeoutStopSec** (default 120s) and send **SIGKILL** — resulting in a dirty kill rather than a graceful shutdown.

**Root cause:** 

EnablePolling is called with `context.Background()` (a context that never cancels) in both `initQuerier` and `initQueryFrontend`. 
When the store service stops, `Shutdown()` blocks on `<-pollerShutdownCh`, which is only closed when `pollingLoop` exits via `ctx.Done()` — but that never fires.

Additionally, the per-block jitter sleep inside pollUnknown uses a bare time.Sleep, which ignores context cancellation entirely and further delays in-flight poll goroutines.

Tested on: Tempo v2.10.1

Before:

```
Apr 28 07:57:07 tempoquery systemd[1]: Stopping Tempo service...
Apr 28 07:57:07 tempoquery tempo[1066]: {"caller":"app.go:244","level":"info","msg":"=== received SIGINT/SIGTERM ===\n*** exiting","ts":"2026-04-28T07:57:07.422663313Z"}
Apr 28 07:57:07 tempoquery tempo[1066]: {"caller":"module_service.go:120","level":"info","module":"querier","msg":"module stopped","ts":"2026-04-28T07:57:07.540618477Z"}
Apr 28 07:57:07 tempoquery tempo[1066]: {"caller":"module_service.go:120","level":"info","module":"ring","msg":"module stopped","ts":"2026-04-28T07:57:07.540888043Z"}
Apr 28 07:57:07 tempoquery tempo[1066]: {"caller":"module_service.go:120","level":"info","module":"live-store-ring","msg":"module stopped","ts":"2026-04-28T07:57:07.540964012Z"}
Apr 28 07:57:07 tempoquery tempo[1066]: {"caller":"module_service.go:120","level":"info","module":"metrics-generator-ring","msg":"module stopped","ts":"2026-04-28T07:57:07.540965282Z"}
Apr 28 07:57:07 tempoquery tempo[1066]: {"caller":"module_service.go:120","level":"info","module":"secondary-ring","msg":"module stopped","ts":"2026-04-28T07:57:07.541025746Z"}
Apr 28 07:57:07 tempoquery tempo[1066]: {"caller":"module_service.go:120","level":"info","module":"overrides","msg":"module stopped","ts":"2026-04-28T07:57:07.541071574Z"}
Apr 28 07:57:07 tempoquery tempo[1066]: {"caller":"memberlist_client.go:892","level":"info","msg":"leaving memberlist cluster","ts":"2026-04-28T07:57:07.541132124Z"}
Apr 28 07:57:08 tempoquery tempo[1066]: {"caller":"module_service.go:120","level":"info","module":"memberlist-kv","msg":"module stopped","ts":"2026-04-28T07:57:08.867685719Z"}
Apr 28 07:57:10 tempoquery tempo[1066]: {"caller":"memberlist_logger.go:74","level":"error","msg":"Failed to send indirect UDP ping: transport is shutting down","ts":"2026-04-28T07:57:10.862634508Z"}
Apr 28 07:57:10 tempoquery tempo[1066]: {"caller":"memberlist_logger.go:74","level":"error","msg":"Failed to send indirect UDP ping: transport is shutting down","ts":"2026-04-28T07:57:10.862815501Z"}
Apr 28 07:57:10 tempoquery tempo[1066]: {"caller":"memberlist_logger.go:74","level":"error","msg":"Failed to send indirect UDP ping: transport is shutting down","ts":"2026-04-28T07:57:10.86288274Z"}
Apr 28 07:58:44 tempoquery tempo[1066]: {"caller":"poller.go:273","compactedMetas":242,"createdAt":"2026-04-28T07:57:50.916398064Z","level":"info","metas":772,"msg":"successfully pulled tenant index","tenant":"test1","ts":"2026-04-28T07:58:44.253871271Z"}
Apr 28 07:58:44 tempoquery tempo[1066]: {"caller":"poller.go:273","compactedMetas":232,"createdAt":"2026-04-28T07:54:22.467417231Z","level":"info","metas":631,"msg":"successfully pulled tenant index","tenant":"test2","ts":"2026-04-28T07:58:44.306194133Z"}
Apr 28 07:58:44 tempoquery tempo[1066]: {"caller":"poller.go:249","level":"info","msg":"blocklist poll complete","seconds":0.287242413,"ts":"2026-04-28T07:58:44.306379165Z"}
Apr 28 07:59:07 tempoquery systemd[1]: tempo.service: State 'stop-sigterm' timed out. Killing.
Apr 28 07:59:07 tempoquery systemd[1]: tempo.service: Killing process 1066 (tempo) with signal SIGKILL.
Apr 28 07:59:07 tempoquery systemd[1]: tempo.service: Killing process 1428 (tempo) with signal SIGKILL.
Apr 28 07:59:07 tempoquery systemd[1]: tempo.service: Killing process 1429 (tempo) with signal SIGKILL.
Apr 28 07:59:07 tempoquery systemd[1]: tempo.service: Killing process 1430 (n/a) with signal SIGKILL.
Apr 28 07:59:07 tempoquery systemd[1]: tempo.service: Killing process 7426 (n/a) with signal SIGKILL.
Apr 28 07:59:07 tempoquery systemd[1]: tempo.service: Killing process 143743 (n/a) with signal SIGKILL.
Apr 28 07:59:07 tempoquery systemd[1]: tempo.service: Main process exited, code=killed, status=9/KILL
Apr 28 07:59:07 tempoquery systemd[1]: tempo.service: Failed with result 'timeout'.
Apr 28 07:59:07 tempoquery systemd[1]: Stopped Tempo service.
```

After:

```
Apr 28 09:30:34 tempoquery systemd[1]: Stopping Tempo service...
Apr 28 09:30:34 tempoquery tempo[499788]: {"caller":"module_service.go:120","level":"info","module":"querier","msg":"module stopped","ts":"2026-04-28T09:30:34.515803359Z"}
Apr 28 09:30:34 tempoquery tempo[499788]: {"caller":"module_service.go:120","level":"info","module":"ring","msg":"module stopped","ts":"2026-04-28T09:30:34.516184689Z"}
Apr 28 09:30:34 tempoquery tempo[499788]: {"caller":"module_service.go:120","level":"info","module":"metrics-generator-ring","msg":"module stopped","ts":"2026-04-28T09:30:34.516195976Z"}
Apr 28 09:30:34 tempoquery tempo[499788]: {"caller":"module_service.go:120","level":"info","module":"store","msg":"module stopped","ts":"2026-04-28T09:30:34.516435854Z"}
Apr 28 09:30:34 tempoquery tempo[499788]: {"caller":"module_service.go:120","level":"info","module":"overrides","msg":"module stopped","ts":"2026-04-28T09:30:34.516452416Z"}
Apr 28 09:30:34 tempoquery tempo[499788]: {"caller":"module_service.go:120","level":"info","module":"secondary-ring","msg":"module stopped","ts":"2026-04-28T09:30:34.516204701Z"}
Apr 28 09:30:34 tempoquery tempo[499788]: {"caller":"module_service.go:120","level":"info","module":"cache-provider","msg":"module stopped","ts":"2026-04-28T09:30:34.516739583Z"}
Apr 28 09:30:34 tempoquery tempo[499788]: {"caller":"module_service.go:120","level":"info","module":"live-store-ring","msg":"module stopped","ts":"2026-04-28T09:30:34.516449668Z"}
Apr 28 09:30:34 tempoquery tempo[499788]: {"caller":"memberlist_client.go:892","level":"info","msg":"leaving memberlist cluster","ts":"2026-04-28T09:30:34.517413287Z"}
Apr 28 09:30:35 tempoquery tempo[499788]: {"caller":"memberlist_logger.go:74","level":"error","msg":"Failed to send UDP ping: transport is shutting down","ts":"2026-04-28T09:30:35.919996102Z"}
Apr 28 09:30:35 tempoquery tempo[499788]: {"caller":"module_service.go:120","level":"info","module":"memberlist-kv","msg":"module stopped","ts":"2026-04-28T09:30:35.926199553Z"}
Apr 28 09:30:36 tempoquery tempo[499788]: {"caller":"server_service.go:170","level":"info","msg":"server stopped","ts":"2026-04-28T09:30:36.980450287Z"}
Apr 28 09:30:36 tempoquery tempo[499788]: {"caller":"module_service.go:120","level":"info","module":"server","msg":"module stopped","ts":"2026-04-28T09:30:36.98061117Z"}
Apr 28 09:30:36 tempoquery tempo[499788]: {"caller":"module_service.go:120","level":"info","module":"internal-server","msg":"module stopped","ts":"2026-04-28T09:30:36.980831007Z"}
Apr 28 09:30:36 tempoquery tempo[499788]: {"caller":"app.go:217","level":"info","msg":"Tempo stopped","ts":"2026-04-28T09:30:36.981012578Z"}
Apr 28 09:30:36 tempoquery systemd[1]: tempo.service: Deactivated successfully.
Apr 28 09:30:36 tempoquery systemd[1]: Stopped Tempo service.
```

**Which issue(s) this PR fixes**:
Fixes #

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`