### PR TITLE
metrics-generator: fix EnableVirtualNodeLabel mutating caller dimensi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [BUGFIX] metrics-generator: prevent `enable_virtual_node_label=true` from mutating the caller's `dimensions` slice when its backing array has spare capacity. (@carles-grafana)
 * [BUGFIX] Fix tempo-vulture ignoring `-tempo-push-tls` flag in normal operating mode. [#6974](https://github.com/grafana/tempo/pull/6974) (@xaque208)
 * [CHANGE] **BREAKING CHANGE** Remove duplicate "compaction" prefix from CompactorConfig CLI flags. Affected flags: `compaction.block-retention`, `compaction.max-objects-per-block`, `compaction.max-block-bytes`, `compaction.compaction-window`. [#6909](https://github.com/grafana/tempo/pull/6909) (@electron0zero)
 * [ENHANCEMENT] Support OR conditions for tag name and tag value autocomplete (search tags v2) [#6827](https://github.com/grafana/tempo/pull/6827) (@ie-pham)

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -106,7 +106,13 @@ type Processor struct {
 
 func New(cfg Config, tenant string, reg registry.Registry, logger log.Logger, filteredSpansCounter, invalidUTF8Counter prometheus.Counter) (gen.Processor, error) {
 	if cfg.EnableVirtualNodeLabel {
-		cfg.Dimensions = append(cfg.Dimensions, virtualNodeLabel)
+		// Allocate a fresh backing array so append cannot mutate cfg.Dimensions'
+		// underlying storage, which is shared with callers (the per-tenant
+		// override slice or the static config).
+		dims := make([]string, len(cfg.Dimensions), len(cfg.Dimensions)+1)
+		copy(dims, cfg.Dimensions)
+		dims = append(dims, virtualNodeLabel)
+		cfg.Dimensions = dims
 	}
 
 	sanitizeCache := reclaimable.New(validation.SanitizeLabelName, 10000)

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -434,6 +434,29 @@ func TestServiceGraphs_virtualNodesExtraLabelsForUninstrumentedServices(t *testi
 	assert.Equal(t, 0.0, testRegistry.Query(`traces_service_graph_request_failed_total`, clientToVirtualPeerLabels))
 }
 
+// TestServiceGraphs_virtualNodeLabelDoesNotMutateCallerDimensions guards against the
+// regression where New appended virtualNodeLabel into cfg.Dimensions' shared backing
+// array when the slice had spare capacity, leaking the label into the caller's config.
+func TestServiceGraphs_virtualNodeLabelDoesNotMutateCallerDimensions(t *testing.T) {
+	original := make([]string, 1, 8)
+	original[0] = "http.method"
+
+	cfg := Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", nil)
+	cfg.EnableVirtualNodeLabel = true
+	cfg.Dimensions = original
+
+	p, err := New(cfg, "test", registry.NewTestRegistry(), log.NewNopLogger(), prometheus.NewCounter(prometheus.CounterOpts{}), prometheus.NewCounter(prometheus.CounterOpts{}))
+	require.NoError(t, err)
+	defer p.Shutdown(context.Background())
+
+	require.Equal(t, []string{"http.method"}, original, "caller's Dimensions slice must not be mutated")
+	require.Equal(t, "http.method", original[:cap(original)][0])
+	for i := 1; i < cap(original); i++ {
+		require.Empty(t, original[:cap(original)][i], "caller's underlying array must not contain leaked virtualNodeLabel at index %d", i)
+	}
+}
+
 func TestServiceGraphs_expiredEdges(t *testing.T) {
 	testRegistry := registry.NewTestRegistry()
 


### PR DESCRIPTION
…ons slice

When enable_virtual_node_label=true, servicegraphs.New did `cfg.Dimensions = append(cfg.Dimensions, virtualNodeLabel)`. cfg is passed by value, so the local slice header is fine, but if the caller's slice has spare capacity (cap > len) append writes virtualNodeLabel into the shared backing array. That memory is shared with the caller's per-tenant override slice or the static config, leaking the label across tenants/configs.

Fix by allocating a fresh backing array before the append. Adds a regression test that constructs a slice with spare capacity and verifies the caller's underlying array is untouched.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`