### PR TITLE
[DOC] Span profiling, lagged requests metric doc (#7063, #7066)

### DIFF
--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -128,7 +128,7 @@ For the complete mapping of all configuration blocks to deployment modes, refer 
 Tempo uses the server from `dskit/server`. For the full list of available server options, refer to the [dskit server configuration](https://github.com/grafana/dskit/blob/main/server/server.go#L66) and the [manifest](/docs/tempo/<TEMPO_VERSION>/configuration/manifest/).
 For details on how server settings apply across deployment modes, refer to the [Deployment modes](/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/deployment-modes/) documentation.
 
-Additional root-level options such as `target`, `shutdown_delay`, `auth_enabled`, and `enable_go_runtime_metrics` are available as [command-line flags](/docs/tempo/<TEMPO_VERSION>/set-up-for-tracing/setup-tempo/command-line-flags/).
+Additional root-level options such as `target`, `shutdown_delay`, `auth_enabled`, `enable_go_runtime_metrics`, and `span_profiling` are available as [command-line flags](/docs/tempo/<TEMPO_VERSION>/set-up-for-tracing/setup-tempo/command-line-flags/).
 
 ```yaml
 # Optional. Setting to true enables multitenancy and requires X-Scope-OrgID header on all requests.
@@ -139,6 +139,12 @@ Additional root-level options such as `target`, `shutdown_delay`, `auth_enabled`
 
 # Optional. Enables streaming query results over HTTP.
 [stream_over_http_enabled: <bool> | default = false]
+
+# Optional. Enables span profiling via otelpyroscope. When enabled, Tempo attaches pprof goroutine
+# labels (span_id, span_name) to OTel spans and adds a pyroscope.profile.id attribute to root spans,
+# enabling profile-to-trace correlation in Pyroscope.
+# Requires OTEL_TRACES_EXPORTER or OTEL_EXPORTER_OTLP_ENDPOINT to be set.
+[span_profiling: <bool> | default = false]
 
 server:
     # HTTP server listen host

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -143,7 +143,8 @@ Additional root-level options such as `target`, `shutdown_delay`, `auth_enabled`
 # Optional. Enables span profiling via otelpyroscope. When enabled, Tempo attaches pprof goroutine
 # labels (span_id, span_name) to OTel spans and adds a pyroscope.profile.id attribute to root spans,
 # enabling profile-to-trace correlation in Pyroscope.
-# Requires OTEL_TRACES_EXPORTER or OTEL_EXPORTER_OTLP_ENDPOINT to be set.
+# Requires OTEL_TRACES_EXPORTER, OTEL_EXPORTER_OTLP_ENDPOINT, or
+# OTEL_EXPORTER_OTLP_TRACES_ENDPOINT to be set.
 [span_profiling: <bool> | default = false]
 
 server:

--- a/docs/sources/tempo/operations/manage-trace-ingestion.md
+++ b/docs/sources/tempo/operations/manage-trace-ingestion.md
@@ -142,9 +142,13 @@ If the distributor is not refusing spans but traces are missing from query resul
 Live-stores consume trace data from Kafka and serve recent queries.
 If a live-store falls behind its Kafka partition, query results may be incomplete.
 
-The `fail_on_high_lag` setting (default `false`) controls this behavior:
+Monitor the `tempo_live_store_lagged_requests_total` metric to detect when this happens.
+This counter increments every time a search or metrics query hits a live-store whose Kafka lag overlaps the requested time range, meaning results may be incomplete.
+The metric is labeled by `route` (`/tempopb.Querier/SearchRecent` or `/tempopb.Metrics/QueryRange`).
 
-- When `false`, the live-store returns whatever data it has, which may be incomplete.
+The `fail_on_high_lag` setting (default `false`) controls how the live-store responds when lag is detected:
+
+- When `false`, the live-store returns whatever data it has, which may be incomplete. The metric still increments.
 - When `true`, the live-store returns an error when it cannot guarantee completeness.
 
 Refer to [Unable to find traces](https://grafana.com/docs/tempo/<TEMPO_VERSION>/troubleshooting/querying/unable-to-see-trace/) for query-side troubleshooting.

--- a/docs/sources/tempo/reference-tempo-architecture/components/live-store.md
+++ b/docs/sources/tempo/reference-tempo-architecture/components/live-store.md
@@ -106,6 +106,7 @@ These blocks are queryable until the data ages out of the live-store's retention
 | Metric | Description |
 |---|---|
 | `tempo_live_store_traces_created_total` | Total number of traces created in the live-store |
+| `tempo_live_store_lagged_requests_total` | Requests where the live-store could not guarantee complete results due to Kafka lag, labeled by `route` |
 | `tempo_warnings_total` | Warnings during trace processing, labeled by `reason` |
 | `tempo_ingest_group_partition_lag{group="live-store"}` | Consumer lag per partition |
 

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/command-line-flags.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/command-line-flags.md
@@ -67,6 +67,18 @@ Refer to the [Plan your Tempo deployment](../plan/) documentation for informatio
 | `--enable-go-runtime-metrics` | Set to true to enable all Go runtime metrics | `false` |
 | `--shutdown-delay` | How long to wait between SIGTERM and shutdown. After receiving SIGTERM, Tempo reports not-ready status via the `/ready` endpoint. | `0` |
 
+## Span profiling
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `--span-profiling` | Enable span profiling via `otelpyroscope`. When enabled, Tempo attaches pprof goroutine labels (`span_id`, `span_name`) to OTel spans and adds a `pyroscope.profile.id` attribute to root spans, enabling profile-to-trace correlation in Pyroscope. Requires an OTLP exporter to be configured through environment variables (`OTEL_TRACES_EXPORTER`, `OTEL_EXPORTER_OTLP_ENDPOINT`, or `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`). | `false` |
+
+You can also set this option in the configuration file:
+
+```yaml
+span_profiling: true
+```
+
 ## Health check
 
 | Flag | Description | Default |

--- a/docs/sources/tempo/troubleshooting/querying/unable-to-see-trace.md
+++ b/docs/sources/tempo/troubleshooting/querying/unable-to-see-trace.md
@@ -74,7 +74,30 @@ If the value of `tempo_live_store_traces_created_total` is 0, this can indicate 
 - Verify that Kafka is healthy and that the distributors can reach it.
 - Check live-store logs to ensure they are consuming from Kafka successfully. Look for consumer lag metrics to confirm data is flowing.
 
-## Case 3 - Trace is not recent
+## Case 3 - Live-store Kafka lag
+
+If the live-store is lagging behind its Kafka partition, queries for recent data may return incomplete results.
+
+To check whether lag is affecting queries, run the following PromQL query in Grafana or Prometheus:
+
+```promql
+rate(tempo_live_store_lagged_requests_total[5m])
+```
+
+A non-zero rate means that query time ranges are overlapping with the live-store's Kafka lag, and some recently ingested traces may be missing from results. The metric is labeled by `route`, so you can see which query type is affected (`/tempopb.Querier/SearchRecent` for search queries or `/tempopb.Metrics/QueryRange` for TraceQL metrics queries).
+
+### Solution
+
+- Check the raw consumer lag per partition:
+
+  ```promql
+  tempo_ingest_group_partition_lag{group="live-store"}
+  ```
+
+- If lag is persistent, the live-store may need more resources or partitions may need to be redistributed.
+- To make incomplete results explicit, set `fail_on_high_lag: true` in the [live-store configuration](/docs/tempo/<TEMPO_VERSION>/configuration/#live-store). When enabled, the live-store returns an error instead of silently incomplete results.
+
+## Case 4 - Trace is not recent
 
 Live-stores only serve recent data. Older traces are stored in blocks built by the block-builder. If a trace was ingested but can't be found, the block-builder may not be flushing blocks to the backend correctly.
 

--- a/docs/sources/tempo/troubleshooting/querying/unable-to-see-trace.md
+++ b/docs/sources/tempo/troubleshooting/querying/unable-to-see-trace.md
@@ -88,11 +88,13 @@ A non-zero rate means that query time ranges are overlapping with the live-store
 
 ### Solution
 
-- Check the raw consumer lag per partition:
+- Check the raw consumer lag per partition using your live-store consumer group label:
 
   ```promql
-  tempo_ingest_group_partition_lag{group="live-store"}
+  tempo_ingest_group_partition_lag{group="<CONSUMER_GROUP>"}
   ```
+
+  The `group` label is derived from the live-store ring instance ID. For example, in a zone-aware deployment the group might be `live-store-zone-a`.
 
 - If lag is persistent, the live-store may need more resources or partitions may need to be redistributed.
 - To make incomplete results explicit, set `fail_on_high_lag: true` in the [live-store configuration](/docs/tempo/<TEMPO_VERSION>/configuration/#live-store). When enabled, the live-store returns an error instead of silently incomplete results.


### PR DESCRIPTION
**Description**

- Document the new `span_profiling` config option and `--span-profiling` CLI flag introduced in #7063
- Document the `tempo_live_store_lagged_requests_total` metric added in #7066

## Changes

**Span profiling (#7063)**
- Add `span_profiling` to root-level config reference in `configuration/_index.md`
- Add `--span-profiling` section to `command-line-flags.md`

**Lagged requests metric (#7066)**
- Add `tempo_live_store_lagged_requests_total` to key metrics table in `live-store.md`
- Document the metric and its relationship to `fail_on_high_lag` in `manage-trace-ingestion.md`
- Add troubleshooting Case 3 for Kafka lag with PromQL examples in `unable-to-see-trace.md`

## Checklist
- [x] Documentation added
- [x] Claims verified against code
- [ ] Changelog