### PR TITLE
distributor: auto-forget unhealthy ring entries

### DIFF
--- a/.chloggen/distributor-ring-auto-forget.yaml
+++ b/.chloggen/distributor-ring-auto-forget.yaml
@@ -3,4 +3,4 @@ component: distributor
 note: 'Auto-forget unhealthy instances from the distributor ring after `2 × distributor.ring.heartbeat-timeout`, removing the need to manually click "Forget" on `/distributor/ring` after non-graceful pod terminations.'
 issues: []
 subtext:
-user: oleg-kozliuk
+user: oleg-kozlyuk-grafana

--- a/.chloggen/distributor-ring-auto-forget.yaml
+++ b/.chloggen/distributor-ring-auto-forget.yaml
@@ -1,21 +1,6 @@
-# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
-
-# One of: breaking | change | feature | enhancement | bug_fix | security
 change_type: enhancement
-
-# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
-# e.g. distributor, querier, query-frontend, storage, operations.
 component: distributor
-
-# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
 note: 'Auto-forget unhealthy instances from the distributor ring after `2 × distributor.ring.heartbeat-timeout`, removing the need to manually click "Forget" on `/distributor/ring` after non-graceful pod terminations.'
-
-# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
-# .chloggen/README.md.
 issues: []
-
-# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
 subtext:
-
-# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
 user: oleg-kozliuk

--- a/.chloggen/distributor-ring-auto-forget.yaml
+++ b/.chloggen/distributor-ring-auto-forget.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: distributor
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: 'Auto-forget unhealthy instances from the distributor ring after `2 × distributor.ring.heartbeat-timeout`, removing the need to manually click "Forget" on `/distributor/ring` after non-graceful pod terminations.'
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: oleg-kozliuk

--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/status"
+	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/limiter"
 	dslog "github.com/grafana/dskit/log"
 	"github.com/grafana/dskit/ring"
@@ -51,7 +52,19 @@ const (
 
 	// 16 covers the typical spans-per-trace seen in production.
 	maxPreallocSpansPerTrace = 16
+
+	// ringAutoForgetUnhealthyPeriods is how many heartbeat-timeout periods of
+	// silence elapse before a distributor entry is auto-removed from the ring.
+	ringAutoForgetUnhealthyPeriods = 2
+
+	// Distributors only need a single token: the ring is used for
+	// HealthyInstancesCount (global ingestion-rate divisor), not sharding.
+	ringNumTokens = 1
 )
+
+// ringOp matches the semantics of the legacy Lifecycler.HealthyInstancesCount:
+// count instances in the ACTIVE state, no extension into LEAVING.
+var ringOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, nil)
 
 var (
 	metricGeneratorPushes = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -238,20 +251,49 @@ func New(
 	var distributorRing *ring.Ring
 
 	if o.IngestionRateStrategy() == overrides.GlobalIngestionRateStrategy {
-		lifecyclerCfg := cfg.DistributorRing.ToLifecyclerConfig()
-		lifecycler, err := ring.NewLifecycler(lifecyclerCfg, nil, "distributor", cfg.OverrideRingKey, false, logger, prometheus.WrapRegistererWithPrefix("tempo_", reg))
+		ringReg := prometheus.WrapRegistererWithPrefix("tempo_", reg)
+
+		lifecyclerStore, err := kv.NewClient(
+			cfg.DistributorRing.KVStore,
+			ring.GetCodec(),
+			kv.RegistererWithKVName(ringReg, "distributor-lifecycler"),
+			logger,
+		)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unable to initialize distributor ring KV client: %w", err)
+		}
+
+		basicCfg, err := toBasicLifecyclerConfig(cfg.DistributorRing, logger)
+		if err != nil {
+			return nil, fmt.Errorf("invalid distributor ring config: %w", err)
+		}
+
+		// Delegates are chained in reverse order of invocation: AutoForget
+		// runs first on each heartbeat, then LeaveOnStopping on shutdown,
+		// then the Distributor's own delegate methods.
+		// Forget unhealthy peers after 2 * heartbeat_timeout, matching the
+		// pattern used by livestore and backendworker.
+		var delegate ring.BasicLifecyclerDelegate = &distributorLifecyclerDelegate{}
+		delegate = ring.NewLeaveOnStoppingDelegate(delegate, logger)
+		delegate = ring.NewAutoForgetDelegate(
+			ringAutoForgetUnhealthyPeriods*cfg.DistributorRing.HeartbeatTimeout,
+			delegate, logger)
+
+		lifecycler, err := ring.NewBasicLifecycler(
+			basicCfg, "distributor", cfg.OverrideRingKey,
+			lifecyclerStore, delegate, logger, ringReg)
+		if err != nil {
+			return nil, fmt.Errorf("unable to initialize distributor ring lifecycler: %w", err)
 		}
 		subservices = append(subservices, lifecycler)
-		ingestionRateStrategy = newGlobalIngestionRateStrategy(o, lifecycler)
 
-		ring, err := ring.New(lifecyclerCfg.RingConfig, "distributor", cfg.OverrideRingKey, logger, prometheus.WrapRegistererWithPrefix("tempo_", reg))
+		distributorRing, err = ring.New(cfg.DistributorRing.ToLifecyclerConfig().RingConfig, "distributor", cfg.OverrideRingKey, logger, ringReg)
 		if err != nil {
 			return nil, fmt.Errorf("unable to initialize distributor ring: %w", err)
 		}
-		distributorRing = ring
 		subservices = append(subservices, distributorRing)
+
+		ingestionRateStrategy = newGlobalIngestionRateStrategy(o, ringHealthyCounter{distributorRing})
 	} else {
 		ingestionRateStrategy = newLocalIngestionRateStrategy(o)
 	}

--- a/modules/distributor/distributor_ring.go
+++ b/modules/distributor/distributor_ring.go
@@ -2,9 +2,12 @@ package distributor
 
 import (
 	"flag"
+	"net"
 	"os"
+	"strconv"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/kv"
@@ -52,6 +55,72 @@ func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.InstanceAddr, "distributor.ring.instance-addr", "", "IP address to advertise in the ring.")
 	f.IntVar(&cfg.InstancePort, "distributor.ring.instance-port", 0, "Port to advertise in the ring (defaults to server.grpc-listen-port).")
 	f.StringVar(&cfg.InstanceID, "distributor.ring.instance-id", hostname, "Instance ID to register in the ring.")
+}
+
+// distributorLifecyclerDelegate implements ring.BasicLifecyclerDelegate for
+// the distributor. The distributor's ring entry is purely a presence record
+// (healthy-instance count for the global ingestion-rate divisor), so all
+// callbacks except register are no-ops.
+type distributorLifecyclerDelegate struct{}
+
+// OnRingInstanceRegister returns the initial state and tokens to register.
+// Distributors register as ACTIVE immediately (matching legacy JoinAfter=0).
+func (d *distributorLifecyclerDelegate) OnRingInstanceRegister(_ *ring.BasicLifecycler, ringDesc ring.Desc, instanceExists bool, _ string, instanceDesc ring.InstanceDesc) (ring.InstanceState, ring.Tokens) {
+	var tokens []uint32
+	if instanceExists {
+		tokens = instanceDesc.GetTokens()
+	}
+
+	takenTokens := ringDesc.GetTokens()
+	gen := ring.NewRandomTokenGenerator()
+	newTokens := gen.GenerateTokens(ringNumTokens-len(tokens), takenTokens)
+	tokens = append(tokens, newTokens...)
+
+	return ring.ACTIVE, tokens
+}
+
+func (d *distributorLifecyclerDelegate) OnRingInstanceTokens(*ring.BasicLifecycler, ring.Tokens) {
+}
+
+func (d *distributorLifecyclerDelegate) OnRingInstanceStopping(*ring.BasicLifecycler) {}
+
+func (d *distributorLifecyclerDelegate) OnRingInstanceHeartbeat(*ring.BasicLifecycler, *ring.Desc, *ring.InstanceDesc) {
+}
+
+// ringHealthyCounter adapts a *ring.Ring to the ReadLifecycler interface
+// expected by globalStrategy. BasicLifecycler does not expose
+// HealthyInstancesCount directly; the ring reader does the equivalent count.
+type ringHealthyCounter struct {
+	r *ring.Ring
+}
+
+func (c ringHealthyCounter) HealthyInstancesCount() int {
+	rs, err := c.r.GetAllHealthy(ringOp)
+	if err != nil {
+		return 0
+	}
+	return len(rs.Instances)
+}
+
+// toBasicLifecyclerConfig builds a BasicLifecyclerConfig from the distributor
+// ring config. Mirrors modules/backendworker/config.go: only the fields the
+// distributor needs are populated.
+func toBasicLifecyclerConfig(cfg RingConfig, logger log.Logger) (ring.BasicLifecyclerConfig, error) {
+	instanceAddr, err := ring.GetInstanceAddr(cfg.InstanceAddr, cfg.InstanceInterfaceNames, logger, cfg.EnableInet6)
+	if err != nil {
+		return ring.BasicLifecyclerConfig{}, err
+	}
+
+	instancePort := ring.GetInstancePort(cfg.InstancePort, cfg.ListenPort)
+	instanceAddrPort := net.JoinHostPort(instanceAddr, strconv.Itoa(instancePort))
+
+	return ring.BasicLifecyclerConfig{
+		ID:               cfg.InstanceID,
+		Addr:             instanceAddrPort,
+		HeartbeatPeriod:  cfg.HeartbeatPeriod,
+		HeartbeatTimeout: cfg.HeartbeatTimeout,
+		NumTokens:        ringNumTokens,
+	}, nil
 }
 
 // ToLifecyclerConfig returns a LifecyclerConfig based on the distributor

--- a/modules/distributor/distributor_ring.go
+++ b/modules/distributor/distributor_ring.go
@@ -1,6 +1,7 @@
 package distributor
 
 import (
+	"errors"
 	"flag"
 	"net"
 	"os"
@@ -46,8 +47,8 @@ func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet) {
 
 	// Ring flags
 	cfg.KVStore.RegisterFlagsWithPrefix("distributor.ring.", "collectors/", f)
-	f.DurationVar(&cfg.HeartbeatPeriod, "distributor.ring.heartbeat-period", 5*time.Second, "Period at which to heartbeat to the ring. 0 = disabled.")
-	f.DurationVar(&cfg.HeartbeatTimeout, "distributor.ring.heartbeat-timeout", time.Minute, "The heartbeat timeout after which distributors are considered unhealthy within the ring. 0 = never (timeout disabled).")
+	f.DurationVar(&cfg.HeartbeatPeriod, "distributor.ring.heartbeat-period", 5*time.Second, "Period at which to heartbeat to the ring. Must be greater than 0 when the global ingestion rate strategy is enabled.")
+	f.DurationVar(&cfg.HeartbeatTimeout, "distributor.ring.heartbeat-timeout", time.Minute, "The heartbeat timeout after which distributors are considered unhealthy within the ring. Must be greater than 0 when the global ingestion rate strategy is enabled.")
 
 	// Instance flags
 	cfg.InstanceInterfaceNames = []string{"eth0", "en0"}
@@ -106,6 +107,20 @@ func (c ringHealthyCounter) HealthyInstancesCount() int {
 // ring config. Mirrors modules/backendworker/config.go: only the fields the
 // distributor needs are populated.
 func toBasicLifecyclerConfig(cfg RingConfig, logger log.Logger) (ring.BasicLifecyclerConfig, error) {
+	// The legacy ring.Lifecycler rejected a zero heartbeat period/timeout via
+	// LifecyclerConfig.Validate(); BasicLifecycler does not, so re-check here to
+	// preserve fail-fast on this (global-strategy-only) path. A zero period
+	// disables heartbeating entirely, and a zero timeout makes the auto-forget
+	// period zero so every peer is evicted on the next heartbeat — both leave
+	// the ring broken. (<=0 also rejects negative values, which would panic the
+	// heartbeat ticker.)
+	if cfg.HeartbeatPeriod <= 0 {
+		return ring.BasicLifecyclerConfig{}, errors.New("distributor.ring.heartbeat-period must be greater than 0")
+	}
+	if cfg.HeartbeatTimeout <= 0 {
+		return ring.BasicLifecyclerConfig{}, errors.New("distributor.ring.heartbeat-timeout must be greater than 0")
+	}
+
 	instanceAddr, err := ring.GetInstanceAddr(cfg.InstanceAddr, cfg.InstanceInterfaceNames, logger, cfg.EnableInet6)
 	if err != nil {
 		return ring.BasicLifecyclerConfig{}, err

--- a/modules/distributor/distributor_ring_mixed_test.go
+++ b/modules/distributor/distributor_ring_mixed_test.go
@@ -1,0 +1,224 @@
+package distributor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/kv"
+	"github.com/grafana/dskit/kv/consul"
+	"github.com/grafana/dskit/ring"
+	"github.com/grafana/dskit/services"
+	"github.com/stretchr/testify/require"
+)
+
+const mixedTestRingKey = "distributor"
+
+// TestDistributorRing_MixedLifecyclerRollout exercises the rollout path where
+// some distributors run the legacy ring.Lifecycler and others run the new
+// ring.BasicLifecycler with AutoForget+LeaveOnStopping delegates against a
+// shared KV store. It pins down:
+//
+//   - Wire compatibility: a BasicLifecycler reads a Lifecycler's entry and
+//     vice versa.
+//   - Asymmetric rollout safety: AutoForget on a new-style peer evicts a
+//     stale legacy-shaped entry within ~2*heartbeat_timeout.
+//   - Graceful shutdown still removes the entry cleanly for both styles.
+//   - The HealthyInstancesCount adapter (used by globalStrategy) reflects
+//     reality across both versions.
+func TestDistributorRing_MixedLifecyclerRollout(t *testing.T) {
+	// Heartbeat timing scaled down so the test completes in seconds.
+	const (
+		heartbeatPeriod  = 50 * time.Millisecond
+		heartbeatTimeout = 200 * time.Millisecond
+		ringKey          = "distributor"
+	)
+	forgetPeriod := ringAutoForgetUnhealthyPeriods * heartbeatTimeout
+
+	logger := log.NewNopLogger()
+	ctx := context.Background()
+
+	// Single in-memory KV shared between all lifecyclers — simulates a single
+	// ring backend during a rolling deploy.
+	mockStore, closer := consul.NewInMemoryClient(ring.GetCodec(), logger, nil)
+	t.Cleanup(func() { _ = closer.Close() })
+
+	// Reader used to observe ring state from the test's perspective.
+	reader := newRingReader(t, mockStore, ringKey, heartbeatTimeout, logger)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
+	t.Cleanup(func() { _ = services.StopAndAwaitTerminated(ctx, reader) })
+
+	// "Old version" pod: legacy ring.Lifecycler, no delegate, no auto-forget.
+	// Built via the same ToLifecyclerConfig() path used in production today.
+	oldLC := newLegacyDistributorLifecycler(t, mockStore, ringKey, "old-pod", heartbeatPeriod, heartbeatTimeout, logger)
+
+	// "New version" pods: BasicLifecycler with AutoForget+LeaveOnStopping.
+	newLC1 := newBasicDistributorLifecycler(t, mockStore, ringKey, "new-pod-1", heartbeatPeriod, heartbeatTimeout, forgetPeriod, logger)
+	newLC2 := newBasicDistributorLifecycler(t, mockStore, ringKey, "new-pod-2", heartbeatPeriod, heartbeatTimeout, forgetPeriod, logger)
+
+	require.NoError(t, services.StartAndAwaitRunning(ctx, oldLC))
+	require.NoError(t, services.StartAndAwaitRunning(ctx, newLC1))
+	require.NoError(t, services.StartAndAwaitRunning(ctx, newLC2))
+
+	// (1) Coexistence: all three IDs visible & ACTIVE. If the codec or
+	// ring key ever drifts between Lifecycler and BasicLifecycler, this
+	// fails.
+	require.Eventually(t, func() bool {
+		ids := healthyIDs(t, reader)
+		return ids["old-pod"] && ids["new-pod-1"] && ids["new-pod-2"]
+	}, 2*time.Second, 10*time.Millisecond, "all three lifecyclers should appear ACTIVE in the ring")
+
+	// (4) HealthyInstancesCount adapter agrees with reality.
+	counter := ringHealthyCounter{r: reader}
+	require.Eventually(t, func() bool {
+		return counter.HealthyInstancesCount() == 3
+	}, time.Second, 10*time.Millisecond)
+
+	// (2) Inject a stale entry directly via CAS — simulates a pod that
+	// crashed without graceful unregister and left a stale record. The
+	// codec is identical between Lifecycler and BasicLifecycler, so this
+	// is exactly what either would have written.
+	const ghostID = "ghost-pod"
+	staleHeartbeat := time.Now().Add(-10 * forgetPeriod).Unix()
+	require.NoError(t, mockStore.CAS(ctx, ringKey, func(in any) (out any, retry bool, err error) {
+		desc := ring.GetOrCreateRingDesc(in)
+		desc.Ingesters[ghostID] = ring.InstanceDesc{
+			Id:        ghostID,
+			Addr:      "127.0.0.1:0",
+			Timestamp: staleHeartbeat,
+			State:     ring.ACTIVE,
+			Tokens:    []uint32{42},
+		}
+		return desc, true, nil
+	}))
+
+	// Verify the ghost is initially present in the raw KV.
+	require.Eventually(t, func() bool {
+		return allIDsFromKV(ctx, t, mockStore)[ghostID]
+	}, time.Second, 10*time.Millisecond)
+
+	// (3) AutoForget on the new lifecyclers must evict the stale entry on
+	// the next heartbeat past forgetPeriod. This is the load-bearing
+	// assertion for the migration: it works against legacy-shaped entries.
+	require.Eventually(t, func() bool {
+		return !allIDsFromKV(ctx, t, mockStore)[ghostID]
+	}, 5*forgetPeriod+time.Second, 10*time.Millisecond, "auto-forget should evict the stale entry")
+
+	// Survivors stay healthy. Eventually-wrap because the reader ring polls
+	// KV on its own cadence and may not have observed the ghost removal yet.
+	require.Eventually(t, func() bool {
+		return counter.HealthyInstancesCount() == 3
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// (5) Graceful shutdown of legacy lifecycler removes its entry.
+	require.NoError(t, services.StopAndAwaitTerminated(ctx, oldLC))
+	require.Eventually(t, func() bool {
+		return !allIDsFromKV(ctx, t, mockStore)["old-pod"]
+	}, 2*time.Second, 10*time.Millisecond, "legacy lifecycler should unregister on graceful stop")
+
+	// (6) Graceful shutdown of basic lifecycler also removes its entry —
+	// verifies LeaveOnStoppingDelegate + KeepInstanceInTheRingOnShutdown=false
+	// produce the same end state as the legacy UnregisterOnShutdown=true.
+	require.NoError(t, services.StopAndAwaitTerminated(ctx, newLC1))
+	require.Eventually(t, func() bool {
+		return !allIDsFromKV(ctx, t, mockStore)["new-pod-1"]
+	}, 2*time.Second, 10*time.Millisecond, "basic lifecycler should unregister on graceful stop")
+
+	// Last surviving instance count drops accordingly.
+	require.Eventually(t, func() bool {
+		return counter.HealthyInstancesCount() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, services.StopAndAwaitTerminated(ctx, newLC2))
+}
+
+// newLegacyDistributorLifecycler builds a ring.Lifecycler exactly as today's
+// production code does (RingConfig.ToLifecyclerConfig + ring.NewLifecycler
+// with a nil FlushTransferer). This is the call site being replaced; using it
+// here guarantees the test would have caught the original bug as well.
+func newLegacyDistributorLifecycler(t *testing.T, store kv.Client, ringKey, id string, heartbeatPeriod, heartbeatTimeout time.Duration, logger log.Logger) *ring.Lifecycler {
+	t.Helper()
+
+	cfg := RingConfig{}
+	flagext.DefaultValues(&cfg)
+	cfg.KVStore.Mock = store
+	cfg.HeartbeatPeriod = heartbeatPeriod
+	cfg.HeartbeatTimeout = heartbeatTimeout
+	cfg.InstanceID = id
+	cfg.InstanceAddr = "127.0.0.1"
+	cfg.InstancePort = 0
+	cfg.ListenPort = 0
+
+	lc, err := ring.NewLifecycler(cfg.ToLifecyclerConfig(), nil, "distributor", ringKey, false, logger, nil)
+	require.NoError(t, err)
+	return lc
+}
+
+// newBasicDistributorLifecycler builds a BasicLifecycler with the production
+// delegate chain (AutoForget -> LeaveOnStopping -> distributorLifecyclerDelegate).
+func newBasicDistributorLifecycler(t *testing.T, store kv.Client, ringKey, id string, heartbeatPeriod, heartbeatTimeout, forgetPeriod time.Duration, logger log.Logger) *ring.BasicLifecycler {
+	t.Helper()
+
+	cfg := RingConfig{}
+	flagext.DefaultValues(&cfg)
+	cfg.KVStore.Mock = store
+	cfg.HeartbeatPeriod = heartbeatPeriod
+	cfg.HeartbeatTimeout = heartbeatTimeout
+	cfg.InstanceID = id
+	cfg.InstanceAddr = "127.0.0.1"
+	cfg.InstancePort = 0
+	cfg.ListenPort = 0
+
+	basicCfg, err := toBasicLifecyclerConfig(cfg, logger)
+	require.NoError(t, err)
+
+	var delegate ring.BasicLifecyclerDelegate = &distributorLifecyclerDelegate{}
+	delegate = ring.NewLeaveOnStoppingDelegate(delegate, logger)
+	delegate = ring.NewAutoForgetDelegate(forgetPeriod, delegate, logger)
+
+	lc, err := ring.NewBasicLifecycler(basicCfg, "distributor", ringKey, store, delegate, logger, nil)
+	require.NoError(t, err)
+	return lc
+}
+
+func newRingReader(t *testing.T, store kv.Client, ringKey string, heartbeatTimeout time.Duration, logger log.Logger) *ring.Ring {
+	t.Helper()
+	cfg := ring.Config{}
+	flagext.DefaultValues(&cfg)
+	cfg.HeartbeatTimeout = heartbeatTimeout
+	cfg.ReplicationFactor = 1
+	r, err := ring.NewWithStoreClientAndStrategy(cfg, "distributor", ringKey, store, ring.NewDefaultReplicationStrategy(), nil, logger)
+	require.NoError(t, err)
+	return r
+}
+
+func healthyIDs(t *testing.T, r *ring.Ring) map[string]bool {
+	t.Helper()
+	rs, err := r.GetAllHealthy(ringOp)
+	require.NoError(t, err)
+	out := map[string]bool{}
+	for _, ing := range rs.Instances {
+		out[ing.Id] = true
+	}
+	return out
+}
+
+// allIDsFromKV reads the ring descriptor straight from the KV store, which
+// includes unhealthy/stale entries that GetAllHealthy filters out.
+func allIDsFromKV(ctx context.Context, t *testing.T, store kv.Client) map[string]bool {
+	t.Helper()
+	val, err := store.Get(ctx, mixedTestRingKey)
+	require.NoError(t, err)
+	out := map[string]bool{}
+	if val == nil {
+		return out
+	}
+	desc, ok := val.(*ring.Desc)
+	require.True(t, ok, "expected *ring.Desc")
+	for id := range desc.Ingesters {
+		out[id] = true
+	}
+	return out
+}

--- a/modules/distributor/distributor_ring_test.go
+++ b/modules/distributor/distributor_ring_test.go
@@ -1,0 +1,49 @@
+package distributor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/flagext"
+	"github.com/stretchr/testify/require"
+)
+
+// TestToBasicLifecyclerConfig_RejectsNonPositiveHeartbeat ensures the
+// BasicLifecycler path preserves the legacy ring.Lifecycler fail-fast on a
+// zero (or negative) heartbeat period/timeout. A zero period disables
+// heartbeating and a zero timeout makes the auto-forget period zero, both of
+// which leave the distributor ring in a broken state.
+func TestToBasicLifecyclerConfig_RejectsNonPositiveHeartbeat(t *testing.T) {
+	logger := log.NewNopLogger()
+
+	newCfg := func() RingConfig {
+		cfg := RingConfig{}
+		flagext.DefaultValues(&cfg)
+		cfg.InstanceID = "d1"
+		cfg.InstanceAddr = "127.0.0.1" // avoid network interface lookup
+		return cfg
+	}
+
+	t.Run("defaults are valid", func(t *testing.T) {
+		_, err := toBasicLifecyclerConfig(newCfg(), logger)
+		require.NoError(t, err)
+	})
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*RingConfig)
+	}{
+		{"zero heartbeat period", func(c *RingConfig) { c.HeartbeatPeriod = 0 }},
+		{"negative heartbeat period", func(c *RingConfig) { c.HeartbeatPeriod = -time.Second }},
+		{"zero heartbeat timeout", func(c *RingConfig) { c.HeartbeatTimeout = 0 }},
+		{"negative heartbeat timeout", func(c *RingConfig) { c.HeartbeatTimeout = -time.Second }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := newCfg()
+			tc.mutate(&cfg)
+			_, err := toBasicLifecyclerConfig(cfg, logger)
+			require.Error(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Migrates the distributor's ring lifecycler from the legacy `ring.Lifecycler` to `ring.BasicLifecycler` with an `AutoForget + LeaveOnStopping` delegate chain, matching the pattern already used by `livestore` and `backendworker`.
- Stale distributor entries (left behind by OOMs, non-graceful terminations, etc.) are now removed from the ring automatically after `2 × distributor.ring.heartbeat-timeout` — **10 minutes by default** (`distributor.ring.heartbeat-timeout` is defaulted to `5m` in `modules/distributor/config.go`, not the 1m flag default), still within the 15m `TempoDistributorUnhealthy` alert window.
- Removes the need for the manual `/distributor/ring` "Forget" workaround documented in the runbook.

## Why

`TempoDistributorUnhealthy` has been a recurring source of pager noise: the runbook (`operations/tempo-mixin/runbook.md`) currently requires an operator to click **Forget** on the distributor ring page. Both `livestore` and `backendworker` already self-heal via dskit's `AutoForgetDelegate`; the distributor was the outlier because it still used the older `ring.NewLifecycler(...)` API which doesn't accept delegates.

## Compatibility / rollout

The legacy `ring.Lifecycler` and the new `ring.BasicLifecycler` both serialize the same `ring.Desc` protobuf via the same `ring.GetCodec()` to the same KV key, with matching token count (1), initial state (`ACTIVE`), heartbeat semantics, and graceful-shutdown unregister behavior. Mixed-version pods coexist transparently:

- Old-version pods continue to heartbeat and unregister normally.
- New-version pods run auto-forget; from the *first* new pod up, stale entries from any version are cleaned up — including before the rollout finishes.
- Rollback is a plain revert. No KV migration, no flag deprecation.

The test `TestDistributorRing_MixedLifecyclerRollout` runs one legacy `ring.Lifecycler` and two new `ring.BasicLifecycler` instances against a shared in-memory KV and asserts: coexistence, eviction of a stale legacy-shaped entry by a new-style peer, graceful shutdown for both styles, and the `HealthyInstancesCount` adapter behavior.

## What changed

- `modules/distributor/distributor.go` — replaced `ring.NewLifecycler` call site with `ring.NewBasicLifecycler` + delegate chain. Added `ringAutoForgetUnhealthyPeriods = 2`, `ringNumTokens = 1`, and `ringOp` constants. Wired a small `*ring.Ring`-backed `HealthyInstancesCount` adapter into `globalStrategy` (since `BasicLifecycler` doesn't expose that method directly).
- `modules/distributor/distributor_ring.go` — added `toBasicLifecyclerConfig`, the `distributorLifecyclerDelegate` (stateless, registers as `ACTIVE` with one token), and `ringHealthyCounter`.
- `modules/distributor/distributor_ring_mixed_test.go` — new mixed-mode test described above.

No new flags, no YAML schema changes. Forget period is derived from the existing `distributor.ring.heartbeat-timeout`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./modules/...` (clean — pre-existing unrelated warning in `forwarder/manager_test.go` is not from this change)
- [x] `go test ./modules/distributor/...` (all packages green)
- [x] `go test -count=20 -failfast -run TestDistributorRing_MixedLifecyclerRollout ./modules/distributor/` (20/20 passes)
- [x] Manually verified in a multi-distributor deployment: orphan a ring entry by losing a distributor non-gracefully — e.g. `kubectl delete pod <distributor> --grace-period=0 --force` — then watch `/distributor/ring`. The old build leaves the entry `Unhealthy` indefinitely; the new build auto-forgets it after `2 × heartbeat_timeout` (~10m by default), and a freshly-started new pod also clears pre-existing stale entries before the rollout finishes.
  - Note: a graceful stop or an in-place `kill -9` does **not** reproduce this. `UnregisterOnShutdown = true` means SIGTERM deregisters cleanly, and a restarted container rejoins under the same pod-name instance ID. Orphaning requires the instance to come back under a new name (real OOM / node loss / force-delete).
- [ ] After bake: follow up to soften / remove the manual "Forget" instructions in `operations/tempo-mixin/runbook.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
