### PR TITLE
bugfix(livestore): skip lookback replay when partition is Inactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@
 * [BUGFIX] live-store: correct backoff duration calculation [#6999](https://github.com/grafana/tempo/pull/6999) (@ruslan-mikhailov)
 * [BUGFIX] vulture: fix for recent traces when query_end_cutoff is enabled [#7018](https://github.com/grafana/tempo/pull/7018) (@ruslan-mikhailov)
 * [BUGFIX] Fix live-store producing WAL blocks exceeding max_block_bytes when flushing large batches of idle traces [#6971](https://github.com/grafana/tempo/pull/6971) (@ruslan-mikhailov)
+* [BUGFIX] live-store: skip lookback replay when partition is Inactive during scaling down [#7101](https://github.com/grafana/tempo/pull/7101) (@zhxiaogg)
 
 ### 3.0 Cleanup
 

--- a/modules/livestore/live_store.go
+++ b/modules/livestore/live_store.go
@@ -381,7 +381,9 @@ func (s *LiveStore) shouldForceFromLookback(ctx context.Context) bool {
 	state, _, err := s.ingestPartitionLifecycler.GetPartitionState(ctx)
 	if err != nil {
 		level.Warn(s.logger).Log("msg", "failed to read partition state, defaulting to lookback replay", "err", err)
-	} else if state == ring.PartitionInactive {
+		return true
+	}
+	if state == ring.PartitionInactive {
 		level.Info(s.logger).Log("msg", "skipping lookback replay because partition is Inactive")
 		return false
 	}

--- a/modules/livestore/live_store.go
+++ b/modules/livestore/live_store.go
@@ -372,11 +372,25 @@ func (s *LiveStore) startIngestPath(ctx context.Context) error {
 	return s.startKafkaIngestPath(ctx)
 }
 
-func (s *LiveStore) startKafkaIngestPath(ctx context.Context) error {
-	forceFromLookback := len(s.getInstances()) == 0
-	if forceFromLookback {
-		level.Info(s.logger).Log("msg", "no local data found after reload, will force reading from lookback period")
+// shouldForceFromLookback decides whether to re-read the Kafka lookback to rebuild query state.
+// Skipped when local data exists, or when the partition is Inactive (prior pod already drained).
+func (s *LiveStore) shouldForceFromLookback(ctx context.Context) bool {
+	if len(s.getInstances()) > 0 {
+		return false
 	}
+	state, _, err := s.ingestPartitionLifecycler.GetPartitionState(ctx)
+	if err != nil {
+		level.Warn(s.logger).Log("msg", "failed to read partition state, defaulting to lookback replay", "err", err)
+	} else if state == ring.PartitionInactive {
+		level.Info(s.logger).Log("msg", "skipping lookback replay because partition is Inactive")
+		return false
+	}
+	level.Info(s.logger).Log("msg", "no local data found after reload, will force reading from lookback period")
+	return true
+}
+
+func (s *LiveStore) startKafkaIngestPath(ctx context.Context) error {
+	forceFromLookback := s.shouldForceFromLookback(ctx)
 
 	client, err := ingest.NewReaderClient(
 		s.cfg.IngestConfig.Kafka,

--- a/modules/livestore/live_store_test.go
+++ b/modules/livestore/live_store_test.go
@@ -1327,3 +1327,51 @@ func requirePartitionOwnerEventually(t *testing.T, partitionKV kv.Client, instan
 		return desc.HasOwner(instanceID) == expected
 	}, 5*time.Second, 10*time.Millisecond, msg)
 }
+
+func TestShouldForceFromLookback_NoInstancesActivePartition(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := defaultConfig(t, tmpDir)
+
+	ls, err := liveStoreWithConfig(t, cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = services.StopAndAwaitTerminated(t.Context(), ls) })
+
+	require.Empty(t, ls.getInstances())
+
+	require.True(t, ls.shouldForceFromLookback(t.Context()),
+		"should force lookback when no local instances and partition is not Inactive")
+}
+
+func TestShouldForceFromLookback_NoInstancesInactivePartition(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := defaultConfig(t, tmpDir)
+
+	ls, err := liveStoreWithConfig(t, cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = services.StopAndAwaitTerminated(t.Context(), ls) })
+
+	require.Empty(t, ls.getInstances())
+
+	require.NoError(t, ls.ingestPartitionLifecycler.ChangePartitionState(t.Context(), ring.PartitionInactive))
+
+	require.Eventually(t, func() bool {
+		state, _, err := ls.ingestPartitionLifecycler.GetPartitionState(t.Context())
+		return err == nil && state == ring.PartitionInactive
+	}, 5*time.Second, 10*time.Millisecond, "partition should be observed as Inactive")
+
+	require.False(t, ls.shouldForceFromLookback(t.Context()),
+		"should NOT force lookback when partition is Inactive — no live ingest to recover")
+}
+
+func TestShouldForceFromLookback_InstancesExist(t *testing.T) {
+	tmpDir := t.TempDir()
+	ls, err := defaultLiveStore(t, tmpDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = services.StopAndAwaitTerminated(t.Context(), ls) })
+
+	pushToLiveStore(t, ls)
+	require.NotEmpty(t, ls.getInstances())
+
+	require.False(t, ls.shouldForceFromLookback(t.Context()),
+		"should NOT force lookback when local instances are present")
+}

--- a/modules/livestore/live_store_test.go
+++ b/modules/livestore/live_store_test.go
@@ -1328,7 +1328,7 @@ func requirePartitionOwnerEventually(t *testing.T, partitionKV kv.Client, instan
 	}, 5*time.Second, 10*time.Millisecond, msg)
 }
 
-func TestShouldForceFromLookback_NoInstancesActivePartition(t *testing.T) {
+func TestShouldForceFromLookback_NoInstancesNonInactivePartition(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := defaultConfig(t, tmpDir)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

- If a Livestore partition is marked as Inactive, due to `/prepare-partition-downscale`, then the Livestore instance should not replay from the beginning of the partition for any intermediate restarts.

**Why**:
This is to avoid partition lag due to concurrent scaling down and rolling restarts:
1. when downscaling starts, the `/prepare-partition-downscale` would set target partitions to be inactive
2. the corresponding livestore pod is turning into readonly until all the WAL blocks are expired
3. if there happen to be any rolling restarts and all WAL blocks are expired, the livestore might replay from the beginning of the partition. This is **unexpected**.
4. subsequent downscaling procedures still could succeed, but there could be partition lag due to the unexpected lookback replaying. This PR is to avoid the unexpected replaying for any intermediate rolling restarts.

**Which issue(s) this PR fixes**:
Fixes N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`