### PR TITLE
Drop 32-bit ARM release artifacts

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,12 +17,7 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
     ignore:
-      - goarch: arm
-        goos: darwin
-      - goarch: arm
-        goos: windows
       - goarch: arm64
         goos: windows
     flags:
@@ -47,12 +42,7 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
     ignore:
-      - goarch: arm
-        goos: darwin
-      - goarch: arm
-        goos: windows
       - goarch: arm64
         goos: windows
     flags:
@@ -77,12 +67,7 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
     ignore:
-      - goarch: arm
-        goos: darwin
-      - goarch: arm
-        goos: windows
       - goarch: arm64
         goos: windows
     flags:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## main / unreleased
 
+# v3.0.0-rc.1
+
+* [CHANGE] Stop publishing 32-bit ARM binary archives. Release artifacts continue to include amd64 and arm64 binaries. [#7106](https://github.com/grafana/tempo/pull/7106) (@javiermolinar)
+
 # v3.0.0-rc.0
 
 * [CHANGE] **BREAKING CHANGE** Remove duplicate "compaction" prefix from CompactorConfig CLI flags. Affected flags: `compaction.block-retention`, `compaction.max-objects-per-block`, `compaction.max-block-bytes`, `compaction.compaction-window`. [#6909](https://github.com/grafana/tempo/pull/6909) (@electron0zero)


### PR DESCRIPTION
Drops GOARCH=arm from GoReleaser binary artifacts. The 3.0 RC release currently fails because bytedance/sonic does not support 32-bit architectures. Docker artifacts already only publish amd64 and arm64.