### PR TITLE
docs: document service graph filter policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [FEATURE] jsonnet: Add KEDA-based horizontal pod autoscaling support for microservices deployment [#6970](https://github.com/grafana/tempo/pull/6970) (@mapno)
 * [FEATURE] Add automemlimit support for automatic GOMEMLIMIT configuration. Enable with `memory.automemlimit_enabled: true`. [#6313](https://github.com/grafana/tempo/pull/6313) (@oleg-kozlyuk)
 * [FEATURE] Support comparison operators in TraceQL Metrics queries [#6474](https://github.com/grafana/tempo/pull/6474) (@ruslan-mikhailov)
+* [FEATURE] metrics-generator: Add span filtering to service graphs through `filter_policies`. [#6453](https://github.com/grafana/tempo/pull/6453) (@javiermolinar)
 * [FEATURE] Add new include_any filter policy for spanmetrics filter [#6392](https://github.com/grafana/tempo/pull/6392) (@javiermolinar)
 * [FEATURE] Add span_multiplier_key to overrides. This allows tenants to specify the attribute key used for span multiplier values to compensate for head-based sampling. [#6260](https://github.com/grafana/tempo/pull/6260) (@carles-grafana)
 * [FEATURE] metrics-generator: Add per-label limiter to control cardinality [#6414](https://github.com/grafana/tempo/pull/6414) (@electron0zero)

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -726,6 +726,9 @@ metrics_generator:
             # List of attribute names used to identify the database name from span attributes. If it isn't set, the order is peer.service -> server.address -> network.peer.address -> db.name
             [database_name_attributes: <list of string> | default = ["db.namespace","db.name","db.system"]]
 
+            # List of policies that will be applied to spans for inclusion or exclusion.
+            [filter_policies: <list of filter policies config> | default = []]
+
         span_metrics:
 
             # Buckets for the latency histogram in seconds.
@@ -2386,7 +2389,7 @@ overrides:
           [filter_policies: [
             [
               include/include_any/exclude:
-                match_type: <string> # options: strict, regexp
+                match_type: <string> # options: strict, regex
                 attributes:
                   - key: <string>
                     value: <any>
@@ -2401,7 +2404,7 @@ overrides:
           [filter_policies: [
             [
               include/include_any/exclude:
-                match_type: <string> # options: strict, regexp
+                match_type: <string> # options: strict, regex
                 attributes:
                   - key: <string>
                     value: <any>

--- a/docs/sources/tempo/metrics-from-traces/service_graphs/_index.md
+++ b/docs/sources/tempo/metrics-from-traces/service_graphs/_index.md
@@ -127,5 +127,40 @@ You can override this list to match your instrumentation if it uses non-standard
 
 ### Filter policies
 
-The `filter_policies` option lets you include or exclude spans from service graph generation based on span attributes.
-This works the same way as filter policies for [span metrics](/docs/tempo/<TEMPO_VERSION>/metrics-from-traces/span-metrics/span-metrics-metrics-generator/#filtering).
+The `filter_policies` option lets you include or exclude spans from service graph generation.
+It uses the same policy format as [span metrics](/docs/tempo/<TEMPO_VERSION>/metrics-from-traces/span-metrics/span-metrics-metrics-generator/#filtering).
+
+The service graph processor only evaluates spans that can form edges: `SPAN_KIND_CLIENT`, `SPAN_KIND_SERVER`, `SPAN_KIND_PRODUCER`, and `SPAN_KIND_CONSUMER`.
+When one side of an edge is filtered out, Tempo keeps a best-effort marker for the dropped side and drops the matching side if it arrives later or is already buffered.
+This reduces skewed edges and unwanted virtual nodes.
+The marker cache uses `wait` as its TTL and `max_items` as its maximum size.
+
+Policy behavior is:
+
+- `include`: all include policies must match.
+- `include_any`: any include_any policy can match. If only include_any policies are configured, non-matching spans are excluded.
+- `exclude`: matching spans are rejected, even if they match an include rule.
+
+Use scoped keys for resource and span attributes, such as `resource.service.name` or `span.http.route`.
+The supported intrinsic keys are `name`, `status`, and `kind`.
+Supported attribute value types are `bool`, `double`, `int`, and `string`.
+
+This example excludes service graph spans from `shop-backend`:
+
+```yaml
+metrics_generator:
+  processor:
+    service_graphs:
+      filter_policies:
+        - exclude:
+            match_type: strict
+            attributes:
+              - key: resource.service.name
+                value: shop-backend
+```
+
+Monitor service graph filtering with:
+
+- `tempo_metrics_generator_spans_discarded_total{reason="service_graphs_filtered", processor="service-graphs"}`
+- `tempo_metrics_generator_processor_service_graphs_dropped_edges_total`
+- `tempo_metrics_generator_processor_service_graphs_dropped_span_side_cache_overflow_total`

--- a/docs/sources/tempo/operations/manage-advanced-systems/user-configurable-overrides.md
+++ b/docs/sources/tempo/operations/manage-advanced-systems/user-configurable-overrides.md
@@ -91,7 +91,7 @@ metrics_generator:
       [filter_policies: [
         [
           include/include_any/exclude:
-            match_type: <string> # options: strict, regexp
+            match_type: <string> # options: strict, regex
             attributes:
               - key: <string>
                 value: <any>
@@ -105,12 +105,12 @@ metrics_generator:
       [filter_policies: [
         [
           include/include_any/exclude:
-            match_type: <string> # options: strict, regexp
+            match_type: <string> # options: strict, regex
             attributes:
               - key: <string>
                 value: <any>
         ]
-      ]
+      ]]
       [enable_target_info: <bool>]
       [target_info_excluded_dimensions: <list of string>]
       [enable_instance_label: <bool>]


### PR DESCRIPTION
Adds the missing docs and changelog entry for service graph span filtering from #6453.
