### PR TITLE
Docs: Update link to `tempo` chart 

### DIFF
--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/helm-chart/_index.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/helm-chart/_index.md
@@ -22,4 +22,4 @@ The Tempo repository has an [example Helm chart](https://github.com/grafana/temp
 Tempo has two primary charts used for deployment:
 
 - [`tempo-distributed` Helm chart](https://github.com/grafana-community/helm-charts/tree/main/charts/tempo-distributed) deploys Tempo in microservices mode ([read the documentation](/docs/helm-charts/tempo-distributed/next/get-started-helm-charts))
-- [`tempo` Helm chart](https://github.com/grafana/helm-charts/tree/main/charts/tempo) deploys Tempo in monolithic (single binary) mode
+- [`tempo` Helm chart](https://github.com/grafana-community/helm-charts/tree/main/charts/tempo) deploys Tempo in monolithic (single binary) mode


### PR DESCRIPTION
**What this PR does**:

The docs page - https://grafana.com/docs/tempo/latest/set-up-for-tracing/setup-tempo/deploy/kubernetes/helm-chart/ has a link to the `tempo` Helm chart, clicking this link goes to a README that states 
> This chart has been migrated to [grafana-community/helm-charts](https://github.com/grafana-community/helm-charts).

This PR updates that link to point to the new Helm chart location (saves users a click) 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`