### PR TITLE
enhancement: tempodb: add tempodb_blocklist_bloom_shards_total metric

### DIFF
--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -77,6 +77,11 @@ var (
 		Name:      "blocklist_tenant_index_age_seconds",
 		Help:      "Age in seconds of the last pulled tenant index.",
 	}, []string{"tenant"})
+	metricBloomShards = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "tempodb",
+		Name:      "blocklist_bloom_shards_total",
+		Help:      "Total number of bloom filter shard files across all blocks.",
+	}, []string{"tenant", "status"})
 )
 
 // Config is used to configure the poller
@@ -229,12 +234,15 @@ func (p *Poller) Do(parentCtx context.Context, previous *List) (PerTenant, PerTe
 				metricBackendObjects.WithLabelValues(tenantID, blockStatusCompactedLabel).Set(float64(backendMetaMetrics.compactedBlockMetaTotalObjects))
 				metricBackendBytes.WithLabelValues(tenantID, blockStatusLiveLabel).Set(float64(backendMetaMetrics.blockMetaTotalBytes))
 				metricBackendBytes.WithLabelValues(tenantID, blockStatusCompactedLabel).Set(float64(backendMetaMetrics.compactedBlockMetaTotalBytes))
+				metricBloomShards.WithLabelValues(tenantID, blockStatusLiveLabel).Set(float64(backendMetaMetrics.blockMetaTotalBloomShards))
+				metricBloomShards.WithLabelValues(tenantID, blockStatusCompactedLabel).Set(float64(backendMetaMetrics.compactedBlockMetaTotalBloomShards))
 				return
 			}
 			metricBlocklistLength.DeleteLabelValues(tenantID)
 			metricBackendObjects.DeleteLabelValues(tenantID)
 			metricBackendObjects.DeleteLabelValues(tenantID)
 			metricBackendBytes.DeleteLabelValues(tenantID)
+			metricBloomShards.DeleteLabelValues(tenantID)
 		}(tenantID)
 	}
 
@@ -586,10 +594,12 @@ func (p *Poller) deleteTenant(ctx context.Context, tenantID string) error {
 }
 
 type backendMetaMetrics struct {
-	blockMetaTotalObjects          int
-	compactedBlockMetaTotalObjects int
-	blockMetaTotalBytes            uint64
-	compactedBlockMetaTotalBytes   uint64
+	blockMetaTotalObjects              int
+	compactedBlockMetaTotalObjects     int
+	blockMetaTotalBytes                uint64
+	compactedBlockMetaTotalBytes       uint64
+	blockMetaTotalBloomShards          uint64
+	compactedBlockMetaTotalBloomShards uint64
 }
 
 func sumTotalBackendMetaMetrics(
@@ -600,21 +610,27 @@ func sumTotalBackendMetaMetrics(
 	var sumTotalObjectsCBM int
 	var sumTotalBytesBM uint64
 	var sumTotalBytesCBM uint64
+	var sumTotalBloomShardsBM uint64
+	var sumTotalBloomShardsCBM uint64
 
 	for _, bm := range blockMeta {
 		sumTotalObjectsBM += int(bm.TotalObjects)
 		sumTotalBytesBM += bm.Size_
+		sumTotalBloomShardsBM += uint64(bm.BloomShardCount)
 	}
 
 	for _, cbm := range compactedBlockMeta {
 		sumTotalObjectsCBM += int(cbm.TotalObjects)
 		sumTotalBytesCBM += cbm.Size_
+		sumTotalBloomShardsCBM += uint64(cbm.BloomShardCount)
 	}
 
 	return backendMetaMetrics{
-		blockMetaTotalObjects:          sumTotalObjectsBM,
-		compactedBlockMetaTotalObjects: sumTotalObjectsCBM,
-		blockMetaTotalBytes:            sumTotalBytesBM,
-		compactedBlockMetaTotalBytes:   sumTotalBytesCBM,
+		blockMetaTotalObjects:              sumTotalObjectsBM,
+		compactedBlockMetaTotalObjects:     sumTotalObjectsCBM,
+		blockMetaTotalBytes:                sumTotalBytesBM,
+		compactedBlockMetaTotalBytes:       sumTotalBytesCBM,
+		blockMetaTotalBloomShards:          sumTotalBloomShardsBM,
+		compactedBlockMetaTotalBloomShards: sumTotalBloomShardsCBM,
 	}
 }

--- a/tempodb/blocklist/poller_test.go
+++ b/tempodb/blocklist/poller_test.go
@@ -530,6 +530,8 @@ func TestBlockListBackendMetrics(t *testing.T) {
 		expectedBackendBytesTotal            uint64
 		expectedCompactedBackendObjectsTotal int
 		expectedCompacteddBackendBytesTotal  uint64
+		expectedBloomShardsTotal             uint64
+		expectedCompactedBloomShardsTotal    uint64
 	}{
 		{
 			name: "total backend objects calculation is correct",
@@ -621,6 +623,26 @@ func TestBlockListBackendMetrics(t *testing.T) {
 			expectedCompacteddBackendBytesTotal:  1250,
 			testType:                             "backend bytes",
 		},
+		{
+			name: "total bloom shard calculation is correct",
+			list: PerTenant{
+				"test": []*backend.BlockMeta{
+					{BloomShardCount: 3},
+					{BloomShardCount: 5},
+					{BloomShardCount: 2},
+				},
+			},
+			compactedList: PerTenantCompacted{
+				"test": []*backend.CompactedBlockMeta{
+					{BlockMeta: backend.BlockMeta{BloomShardCount: 4}},
+					{BlockMeta: backend.BlockMeta{BloomShardCount: 1}},
+					{BlockMeta: backend.BlockMeta{BloomShardCount: 6}},
+				},
+			},
+			expectedBloomShardsTotal:          10,
+			expectedCompactedBloomShardsTotal: 11,
+			testType:                          "bloom shards",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -631,6 +653,8 @@ func TestBlockListBackendMetrics(t *testing.T) {
 			assert.Equal(t, tc.expectedCompactedBackendObjectsTotal, backendMetaMetrics.compactedBlockMetaTotalObjects)
 			assert.Equal(t, tc.expectedBackendBytesTotal, backendMetaMetrics.blockMetaTotalBytes)
 			assert.Equal(t, tc.expectedCompacteddBackendBytesTotal, backendMetaMetrics.compactedBlockMetaTotalBytes)
+			assert.Equal(t, tc.expectedBloomShardsTotal, backendMetaMetrics.blockMetaTotalBloomShards)
+			assert.Equal(t, tc.expectedCompactedBloomShardsTotal, backendMetaMetrics.compactedBlockMetaTotalBloomShards)
 		})
 	}
 }


### PR DESCRIPTION
## What this PR does

Adds a new gauge `tempodb_blocklist_bloom_shards_total{tenant, status}` that exposes the sum of `BloomShardCount` across all blocks per tenant, split by `live`/`compacted` status to mirror the existing `tempodb_backend_objects_total` and `tempodb_backend_bytes_total` layout.

## Why

There is currently no metric showing how many bloom-filter shard files a tenant owns in object storage, nor any way to size total bloom storage from existing metrics. Operators and capacity planners want to track this — bloom-filter shard files have a fixed on-disk size, so shard count multiplied by that constant gives total bloom bytes, which can be computed in PromQL or a recording rule on top of this gauge.

## Implementation

The blocklist poll loop already iterates every `BlockMeta`/`CompactedBlockMeta` to compute `tempodb_backend_objects_total` and `tempodb_backend_bytes_total` via `sumTotalBackendMetaMetrics`. The new gauge piggybacks on that single pass — no additional iteration, no extra backend calls.

`BlockMeta.BloomShardCount` is already populated by writers and persisted in the tenant index, so the data is available wherever the blocklist is.

## Tests

Extended `TestBlockListBackendMetrics` with a `total bloom shard calculation is correct` case covering both live and compacted paths.