### PR TITLE
Support partial nested set data on broken traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [ENHANCEMENT] Support OR conditions for tag name and tag value autocomplete (search tags v2) [#6827](https://github.com/grafana/tempo/pull/6827) (@ie-pham)
 * [ENHANCEMENT] Expose MinIO retry settings via S3 config [#6561](https://github.com/grafana/tempo/pull/6561) (@rwhitty)
 * [ENHANCEMENT] Reduce default livestore WAL size and align query defaults: `max_block_duration` `1m` to `30s`, `max_block_bytes` `100MiB` to `50MiB`, `complete_block_timeout` `1h` to `20m`, metrics `query_backend_after` `30m` to `15m`. [#6974](https://github.com/grafana/tempo/pull/6974) (@zhxiaogg)
+* [ENHANCEMENT] Support structural operators on broken traces by assigning nested set data to orphaned sub-trees instead of skipping the entire trace. Broken spans can be identified via `{nestedSetParent=0}`; root span identification via `{nestedSetParent<0}` is unchanged. [#7115](https://github.com/grafana/tempo/pull/7115) (@mdisibio)
 * [CHANGE] **BREAKING CHANGE** Centralize block and WAL config: `block_builder` and `live_store` now always use `storage.trace.block` settings; per-module block config fields are removed. [#6647](https://github.com/grafana/tempo/pull/6647) (@stoewer)
 * [CHANGE] **BREAKING CHANGE** Remove Opencensus receiver [#6523](https://github.com/grafana/tempo/pull/6523) (@javiermolinar)
 * [CHANGE] Upgrade Tempo to Go 1.26.0 [#6443](https://github.com/grafana/tempo/pull/6443) (@stoewer)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,6 @@
 * [CHANGE] **BREAKING CHANGE** Remove duplicate "compaction" prefix from CompactorConfig CLI flags. Affected flags: `compaction.block-retention`, `compaction.max-objects-per-block`, `compaction.max-block-bytes`, `compaction.compaction-window`. [#6909](https://github.com/grafana/tempo/pull/6909) (@electron0zero)
 * [CHANGE] **BREAKING CHANGE** Enable RetryInfo by default. `distributor.retry_after_on_resource_exhausted` now defaults to `5s` (was `0`) so OTLP clients receive a retry hint on `ResourceExhausted` errors. [#7088](https://github.com/grafana/tempo/pull/7088) (@electron0zero)
   Set to `0` to disable cluster-wide, or set the per-tenant override `ingestion.retry_info_enabled: false` to disable for a single tenant.
-* [ENHANCEMENT] Support OR conditions for tag name and tag value autocomplete (search tags v2) [#6827](https://github.com/grafana/tempo/pull/6827) (@ie-pham)
-* [ENHANCEMENT] Expose MinIO retry settings via S3 config [#6561](https://github.com/grafana/tempo/pull/6561) (@rwhitty)
-* [ENHANCEMENT] Reduce default livestore WAL size and align query defaults: `max_block_duration` `1m` to `30s`, `max_block_bytes` `100MiB` to `50MiB`, `complete_block_timeout` `1h` to `20m`, metrics `query_backend_after` `30m` to `15m`. [#6974](https://github.com/grafana/tempo/pull/6974) (@zhxiaogg)
 * [CHANGE] **BREAKING CHANGE** Centralize block and WAL config: `block_builder` and `live_store` now always use `storage.trace.block` settings; per-module block config fields are removed. [#6647](https://github.com/grafana/tempo/pull/6647) (@stoewer)
 * [CHANGE] **BREAKING CHANGE** Remove Opencensus receiver [#6523](https://github.com/grafana/tempo/pull/6523) (@javiermolinar)
 * [CHANGE] **BREAKING CHANGE** Remove legacy `mem-ballast-size-mbs` cli flag. [#6403](https://github.com/grafana/tempo/pull/6403) (@orkhan-huseyn)

--- a/tempodb/encoding/vparquet4/nested_set_model.go
+++ b/tempodb/encoding/vparquet4/nested_set_model.go
@@ -32,12 +32,12 @@ func assignNestedSetModelBoundsAndServiceStats(trace *Trace) bool {
 		}
 	}
 
-	// find root spans and map span IDs to tree nodes
+	// map span IDs to tree nodes
 	var (
 		undoAssignment bool
+		hasRoot        bool
 		allNodes       = make([]spanNode, 0, spanCount)
 		nodesByID      = make(map[uint64][]*spanNode, spanCount)
-		rootNodes      []*spanNode
 	)
 
 	// initialize ServiceStats (spanCount and errorCount per service)
@@ -54,7 +54,7 @@ func assignNestedSetModelBoundsAndServiceStats(trace *Trace) bool {
 				node := &allNodes[len(allNodes)-1]
 
 				if s.IsRoot() {
-					rootNodes = append(rootNodes, node)
+					hasRoot = true
 				}
 
 				id := util.SpanIDToUint64(s.SpanID)
@@ -78,10 +78,6 @@ func assignNestedSetModelBoundsAndServiceStats(trace *Trace) bool {
 		trace.ServiceStats[rs.Resource.ServiceName] = serviceStats
 	}
 
-	// check preconditions before assignment
-	if len(rootNodes) == 0 {
-		return false
-	}
 	if undoAssignment {
 		for _, nodes := range nodesByID {
 			for _, n := range nodes {
@@ -95,7 +91,10 @@ func assignNestedSetModelBoundsAndServiceStats(trace *Trace) bool {
 		return false
 	}
 
-	connected := true
+	// If this trace has a root span it may be connected — verified below by checking that
+	// every non-root span finds its parent. A trace without a root span is never considered
+	// connected, and that includes empty traces.
+	connected := hasRoot
 	// build the tree
 	for i := range allNodes {
 		node := &allNodes[i]

--- a/tempodb/encoding/vparquet4/nested_set_model.go
+++ b/tempodb/encoding/vparquet4/nested_set_model.go
@@ -112,31 +112,34 @@ func assignNestedSetModelBoundsAndServiceStats(trace *Trace) bool {
 	}
 
 	// traverse the tree depth first. When going down the tree, assign NestedSetLeft
-	// and assign NestedSetRight when going up.
+	// and assign NestedSetRight when going up. Every sub-tree is traversed: true roots
+	// get ParentID=-1; orphan sub-roots (whose parent span is missing from the trace)
+	// keep ParentID=0 (its initialised value).
 	nestedSetBound := int32(1)
-	for _, root := range rootNodes {
-		node := root
-		node.span.NestedSetLeft = nestedSetBound
-		node.span.ParentID = nestedSetRootParent
+	for i := range allNodes {
+		root := &allNodes[i]
+		if root.parent != nil {
+			continue // not a sub-tree root; bounds are assigned via the parent's traversal
+		}
+		if root.span.IsRoot() {
+			root.span.ParentID = nestedSetRootParent
+		}
+		root.span.NestedSetLeft = nestedSetBound
 		nestedSetBound++
 
-		for node != nil {
+		for node := root; node != nil; {
 			if node.nextChild < len(node.children) {
 				// the current node has children that were not visited: go down to next child
-
 				next := node.children[node.nextChild]
 				node.nextChild++
-
 				next.span.NestedSetLeft = nestedSetBound
 				next.span.ParentID = node.span.NestedSetLeft // the left bound of the parent serves as numeric span ID
 				nestedSetBound++
 				node = next
 			} else {
 				// all children of the current node were visited: go up
-
 				node.span.NestedSetRight = nestedSetBound
 				nestedSetBound++
-
 				node = node.parent
 			}
 		}

--- a/tempodb/encoding/vparquet4/nested_set_model_test.go
+++ b/tempodb/encoding/vparquet4/nested_set_model_test.go
@@ -267,6 +267,9 @@ func TestAssignNestedSetModelBounds(t *testing.T) {
 			expectedConnected: false,
 		},
 		{
+			// A->B->C chain where A is dropped. With no true root present, B becomes
+			// an orphan sub-root and still receives valid nested set bounds so structural
+			// queries work within the connected B->C segment.
 			name: "no roots",
 			trace: [][]Span{
 				{
@@ -276,8 +279,8 @@ func TestAssignNestedSetModelBounds(t *testing.T) {
 			},
 			expected: [][]Span{
 				{
-					{SpanID: []byte("cccccccc"), ParentSpanID: []byte("bbbbbbbb")},
-					{SpanID: []byte("bbbbbbbb"), ParentSpanID: []byte("aaaaaaaa")},
+					{SpanID: []byte("cccccccc"), ParentSpanID: []byte("bbbbbbbb"), NestedSetLeft: 2, NestedSetRight: 3, ParentID: 1},
+					{SpanID: []byte("bbbbbbbb"), ParentSpanID: []byte("aaaaaaaa"), NestedSetLeft: 1, NestedSetRight: 4, ParentID: 0},
 				},
 			},
 			expectedConnected: false,

--- a/tempodb/encoding/vparquet4/nested_set_model_test.go
+++ b/tempodb/encoding/vparquet4/nested_set_model_test.go
@@ -187,6 +187,36 @@ func TestAssignNestedSetModelBounds(t *testing.T) {
 			expectedConnected: false,
 		},
 		{
+			// Linear chain A->B->C->D->E->F->G->H with C and F dropped (two gaps).
+			// Produces three disjoint connected segments: A->B, D->E, and G->H. Each
+			// segment gets its own nested-set interval range so the tail subtree G->H
+			// does not overlap [1,4] (A->B) or [5,8] (D->E).
+			name: "two gaps",
+			trace: [][]Span{
+				{
+					{SpanID: []byte("aaaaaaaa")},
+					{SpanID: []byte("bbbbbbbb"), ParentSpanID: []byte("aaaaaaaa")},
+					// cccccccc missing (dropped)
+					{SpanID: []byte("dddddddd"), ParentSpanID: []byte("cccccccc")},
+					{SpanID: []byte("eeeeeeee"), ParentSpanID: []byte("dddddddd")},
+					// ffffffff missing (dropped)
+					{SpanID: []byte("gggggggg"), ParentSpanID: []byte("ffffffff")},
+					{SpanID: []byte("hhhhhhhh"), ParentSpanID: []byte("gggggggg")},
+				},
+			},
+			expected: [][]Span{
+				{
+					{SpanID: []byte("aaaaaaaa"), NestedSetLeft: 1, NestedSetRight: 4, ParentID: -1},
+					{SpanID: []byte("bbbbbbbb"), ParentSpanID: []byte("aaaaaaaa"), NestedSetLeft: 2, NestedSetRight: 3, ParentID: 1},
+					{SpanID: []byte("dddddddd"), ParentSpanID: []byte("cccccccc"), NestedSetLeft: 5, NestedSetRight: 8, ParentID: 0},
+					{SpanID: []byte("eeeeeeee"), ParentSpanID: []byte("dddddddd"), NestedSetLeft: 6, NestedSetRight: 7, ParentID: 5},
+					{SpanID: []byte("gggggggg"), ParentSpanID: []byte("ffffffff"), NestedSetLeft: 9, NestedSetRight: 12, ParentID: 0},
+					{SpanID: []byte("hhhhhhhh"), ParentSpanID: []byte("gggggggg"), NestedSetLeft: 10, NestedSetRight: 11, ParentID: 9},
+				},
+			},
+			expectedConnected: false,
+		},
+		{
 			name: "partially assigned",
 			trace: [][]Span{
 				{

--- a/tempodb/encoding/vparquet4/nested_set_model_test.go
+++ b/tempodb/encoding/vparquet4/nested_set_model_test.go
@@ -1,6 +1,7 @@
 package vparquet4
 
 import (
+	"fmt"
 	"testing"
 
 	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
@@ -152,8 +153,35 @@ func TestAssignNestedSetModelBounds(t *testing.T) {
 					{SpanID: []byte("cccccccc"), ParentSpanID: []byte("bbbbbbbb"), NestedSetLeft: 3, NestedSetRight: 4, ParentID: 2},
 					{SpanID: []byte("dddddddd"), ParentSpanID: []byte("bbbbbbbb"), NestedSetLeft: 5, NestedSetRight: 6, ParentID: 2},
 
-					{SpanID: []byte("eeeeeeee"), ParentSpanID: []byte("xxxxxxxx")}, // <- interrupted
-					{SpanID: []byte("ffffffff"), ParentSpanID: []byte("eeeeeeee")},
+					// orphan sub-tree: eeeeeeee's parent is missing, so it becomes a sub-root with ParentID=0
+					{SpanID: []byte("eeeeeeee"), ParentSpanID: []byte("xxxxxxxx"), NestedSetLeft: 9, NestedSetRight: 12, ParentID: 0},
+					{SpanID: []byte("ffffffff"), ParentSpanID: []byte("eeeeeeee"), NestedSetLeft: 10, NestedSetRight: 11, ParentID: 9},
+				},
+			},
+			expectedConnected: false,
+		},
+		{
+			// Reproduces the scenario from https://github.com/grafana/tempo/issues/6393:
+			// a linear chain A->B->C->D->E where C is dropped. The connected sub-trees A->B
+			// and D->E should each receive valid nested set bounds so that structural queries
+			// work within each intact segment.
+			name: "dropped middle span A->B + D->E",
+			trace: [][]Span{
+				{
+					{SpanID: []byte("aaaaaaaa")},
+					{SpanID: []byte("bbbbbbbb"), ParentSpanID: []byte("aaaaaaaa")},
+					// cccccccc is missing (dropped)
+					{SpanID: []byte("dddddddd"), ParentSpanID: []byte("cccccccc")},
+					{SpanID: []byte("eeeeeeee"), ParentSpanID: []byte("dddddddd")},
+				},
+			},
+			expected: [][]Span{
+				{
+					{SpanID: []byte("aaaaaaaa"), NestedSetLeft: 1, NestedSetRight: 4, ParentID: -1},
+					{SpanID: []byte("bbbbbbbb"), ParentSpanID: []byte("aaaaaaaa"), NestedSetLeft: 2, NestedSetRight: 3, ParentID: 1},
+					// dddddddd's parent (cccccccc) is missing — becomes a sub-root with ParentID=0
+					{SpanID: []byte("dddddddd"), ParentSpanID: []byte("cccccccc"), NestedSetLeft: 5, NestedSetRight: 8, ParentID: 0},
+					{SpanID: []byte("eeeeeeee"), ParentSpanID: []byte("dddddddd"), NestedSetLeft: 6, NestedSetRight: 7, ParentID: 5},
 				},
 			},
 			expectedConnected: false,
@@ -386,4 +414,101 @@ func TestAssignServiceStats(t *testing.T) {
 			assert.Equal(t, tt.expected, trace.ServiceStats)
 		})
 	}
+}
+
+// BenchmarkAssignNestedSetModelBounds measures the nested set assignment across the main
+// structural cases: a fully connected trace (linear and branched) and incomplete traces
+// with one or many missing spans (partial cases).
+func BenchmarkAssignNestedSetModelBounds(b *testing.B) {
+	cases := []struct {
+		name  string
+		build func(n int) *Trace
+	}{
+		{
+			// fully connected chain: span[1] -> span[2] -> ... -> span[n]
+			name:  "complete/linear",
+			build: benchLinearTrace,
+		},
+		{
+			// fully connected tree with branching factor 4 (each node has up to 4 children)
+			name:  "complete/branched",
+			build: func(n int) *Trace { return benchBranchedTrace(n, 4) },
+		},
+		{
+			// single dropped span in the middle, leaving two connected sub-trees
+			name:  "partial/one_gap",
+			build: benchLinearTraceDropMiddle,
+		},
+		{
+			// every 10th span dropped (~10% missing), creating many disconnected sub-trees
+			name:  "partial/many_gaps",
+			build: func(n int) *Trace { return benchLinearTraceDropEvery(n, 10) },
+		},
+	}
+
+	for _, n := range []int{100, 1000, 10000} {
+		for _, tc := range cases {
+			b.Run(fmt.Sprintf("%s/spans=%d", tc.name, n), func(b *testing.B) {
+				tr := tc.build(n)
+				for b.Loop() {
+					assignNestedSetModelBoundsAndServiceStats(tr)
+				}
+			})
+		}
+	}
+}
+
+// benchSpanID returns a unique non-zero 8-byte span ID for index i (i must be >= 1).
+func benchSpanID(i int) []byte {
+	return []byte{0, 0, 0, 0, byte(i >> 24), byte(i >> 16), byte(i >> 8), byte(i)}
+}
+
+// benchLinearTrace builds a complete linear chain: span[1] -> span[2] -> ... -> span[n].
+func benchLinearTrace(n int) *Trace {
+	spans := make([]Span, n)
+	spans[0] = Span{SpanID: benchSpanID(1)}
+	for i := 1; i < n; i++ {
+		spans[i] = Span{SpanID: benchSpanID(i + 1), ParentSpanID: benchSpanID(i)}
+	}
+	return &Trace{ResourceSpans: []ResourceSpans{{ScopeSpans: []ScopeSpans{{Spans: spans}}}}}
+}
+
+// benchBranchedTrace builds a complete tree of n spans where each node has up to k children.
+func benchBranchedTrace(n, k int) *Trace {
+	spans := make([]Span, n)
+	spans[0] = Span{SpanID: benchSpanID(1)}
+	for i := 1; i < n; i++ {
+		parent := (i-1)/k + 1 // 1-indexed parent
+		spans[i] = Span{SpanID: benchSpanID(i + 1), ParentSpanID: benchSpanID(parent)}
+	}
+	return &Trace{ResourceSpans: []ResourceSpans{{ScopeSpans: []ScopeSpans{{Spans: spans}}}}}
+}
+
+// benchLinearTraceDropMiddle builds a linear trace of n spans with the single middle span
+// dropped, splitting the chain into two connected halves.
+func benchLinearTraceDropMiddle(n int) *Trace {
+	dropped := n / 2
+	spans := make([]Span, 0, n-1)
+	spans = append(spans, Span{SpanID: benchSpanID(1)})
+	for i := 1; i < n; i++ {
+		if i == dropped {
+			continue
+		}
+		spans = append(spans, Span{SpanID: benchSpanID(i + 1), ParentSpanID: benchSpanID(i)})
+	}
+	return &Trace{ResourceSpans: []ResourceSpans{{ScopeSpans: []ScopeSpans{{Spans: spans}}}}}
+}
+
+// benchLinearTraceDropEvery builds a linear trace of n spans with every period-th span
+// dropped, creating multiple disconnected sub-trees.
+func benchLinearTraceDropEvery(n, period int) *Trace {
+	spans := make([]Span, 0, n)
+	spans = append(spans, Span{SpanID: benchSpanID(1)})
+	for i := 1; i < n; i++ {
+		if i%period == 0 {
+			continue
+		}
+		spans = append(spans, Span{SpanID: benchSpanID(i + 1), ParentSpanID: benchSpanID(i)})
+	}
+	return &Trace{ResourceSpans: []ResourceSpans{{ScopeSpans: []ScopeSpans{{Spans: spans}}}}}
 }

--- a/tempodb/encoding/vparquet5/nested_set_model.go
+++ b/tempodb/encoding/vparquet5/nested_set_model.go
@@ -131,31 +131,34 @@ func assignNestedSetModelBoundsAndServiceStats(trace *Trace) bool {
 	}
 
 	// traverse the tree depth first. When going down the tree, assign NestedSetLeft
-	// and assign NestedSetRight when going up.
+	// and assign NestedSetRight when going up. Every sub-tree is traversed: true roots
+	// get ParentID=-1; orphan sub-roots (whose parent span is missing from the trace)
+	// keep ParentID=0 (its initialised value).
 	nestedSetBound := int32(1)
-	for _, root := range rootNodes {
-		node := root
-		node.span.NestedSetLeft = nestedSetBound
-		node.span.ParentID = nestedSetRootParent
+	for i := range allNodes {
+		root := &allNodes[i]
+		if root.parent != nil {
+			continue // not a sub-tree root; bounds are assigned via the parent's traversal
+		}
+		if root.span.IsRoot() {
+			root.span.ParentID = nestedSetRootParent
+		}
+		root.span.NestedSetLeft = nestedSetBound
 		nestedSetBound++
 
-		for node != nil {
+		for node := root; node != nil; {
 			if node.nextChild < len(node.children) {
 				// the current node has children that were not visited: go down to next child
-
 				next := node.children[node.nextChild]
 				node.nextChild++
-
 				next.span.NestedSetLeft = nestedSetBound
 				next.span.ParentID = node.span.NestedSetLeft // the left bound of the parent serves as numeric span ID
 				nestedSetBound++
 				node = next
 			} else {
 				// all children of the current node were visited: go up
-
 				node.span.NestedSetRight = nestedSetBound
 				nestedSetBound++
-
 				node = node.parent
 			}
 		}

--- a/tempodb/encoding/vparquet5/nested_set_model.go
+++ b/tempodb/encoding/vparquet5/nested_set_model.go
@@ -34,12 +34,12 @@ func assignNestedSetModelBoundsAndServiceStats(trace *Trace) bool {
 		}
 	}
 
-	// find root spans and map span IDs to tree nodes
+	// map span IDs to tree nodes
 	var (
 		undoAssignment bool
+		hasRoot        bool
 		allNodes       = make([]spanNode, 0, spanCount)
 		nodesByID      = make(map[uint64][]*spanNode, spanCount)
-		rootNodes      []*spanNode
 	)
 
 	// initialize ServiceStats (spanCount and errorCount per service)
@@ -57,7 +57,7 @@ func assignNestedSetModelBoundsAndServiceStats(trace *Trace) bool {
 				node := &allNodes[len(allNodes)-1]
 
 				if s.IsRoot() {
-					rootNodes = append(rootNodes, node)
+					hasRoot = true
 				}
 
 				id := util.SpanIDToUint64(s.SpanID)
@@ -91,10 +91,6 @@ func assignNestedSetModelBoundsAndServiceStats(trace *Trace) bool {
 		return trace.ServiceStats[i].ServiceName < trace.ServiceStats[j].ServiceName
 	})
 
-	// check preconditions before assignment
-	if len(rootNodes) == 0 {
-		return false
-	}
 	if undoAssignment {
 		for _, nodes := range nodesByID {
 			for _, n := range nodes {
@@ -109,7 +105,10 @@ func assignNestedSetModelBoundsAndServiceStats(trace *Trace) bool {
 		return false
 	}
 
-	connected := true
+	// If this trace has a root span it may be connected — verified below by checking that
+	// every non-root span finds its parent. A trace without a root span is never considered
+	// connected, and that includes empty traces.
+	connected := hasRoot
 	// build the tree
 	for i := range allNodes {
 		node := &allNodes[i]

--- a/tempodb/encoding/vparquet5/nested_set_model_test.go
+++ b/tempodb/encoding/vparquet5/nested_set_model_test.go
@@ -187,6 +187,36 @@ func TestAssignNestedSetModelBounds(t *testing.T) {
 			expectedConnected: false,
 		},
 		{
+			// Linear chain A->B->C->D->E->F->G->H with C and F dropped (two gaps).
+			// Produces three disjoint connected segments: A->B, D->E, and G->H. Each
+			// segment gets its own nested-set interval range so the tail subtree G->H
+			// does not overlap [1,4] (A->B) or [5,8] (D->E).
+			name: "two gaps",
+			trace: [][]Span{
+				{
+					{SpanID: []byte("aaaaaaaa")},
+					{SpanID: []byte("bbbbbbbb"), ParentSpanID: []byte("aaaaaaaa")},
+					// cccccccc missing (dropped)
+					{SpanID: []byte("dddddddd"), ParentSpanID: []byte("cccccccc")},
+					{SpanID: []byte("eeeeeeee"), ParentSpanID: []byte("dddddddd")},
+					// ffffffff missing (dropped)
+					{SpanID: []byte("gggggggg"), ParentSpanID: []byte("ffffffff")},
+					{SpanID: []byte("hhhhhhhh"), ParentSpanID: []byte("gggggggg")},
+				},
+			},
+			expected: [][]Span{
+				{
+					{SpanID: []byte("aaaaaaaa"), NestedSetLeft: 1, NestedSetRight: 4, ParentID: -1, ChildCount: 1},
+					{SpanID: []byte("bbbbbbbb"), ParentSpanID: []byte("aaaaaaaa"), NestedSetLeft: 2, NestedSetRight: 3, ParentID: 1, ChildCount: 0},
+					{SpanID: []byte("dddddddd"), ParentSpanID: []byte("cccccccc"), NestedSetLeft: 5, NestedSetRight: 8, ParentID: 0, ChildCount: 1},
+					{SpanID: []byte("eeeeeeee"), ParentSpanID: []byte("dddddddd"), NestedSetLeft: 6, NestedSetRight: 7, ParentID: 5, ChildCount: 0},
+					{SpanID: []byte("gggggggg"), ParentSpanID: []byte("ffffffff"), NestedSetLeft: 9, NestedSetRight: 12, ParentID: 0, ChildCount: 1},
+					{SpanID: []byte("hhhhhhhh"), ParentSpanID: []byte("gggggggg"), NestedSetLeft: 10, NestedSetRight: 11, ParentID: 9, ChildCount: 0},
+				},
+			},
+			expectedConnected: false,
+		},
+		{
 			name: "partially assigned",
 			trace: [][]Span{
 				{

--- a/tempodb/encoding/vparquet5/nested_set_model_test.go
+++ b/tempodb/encoding/vparquet5/nested_set_model_test.go
@@ -1,6 +1,7 @@
 package vparquet5
 
 import (
+	"fmt"
 	"testing"
 
 	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
@@ -152,8 +153,35 @@ func TestAssignNestedSetModelBounds(t *testing.T) {
 					{SpanID: []byte("cccccccc"), ParentSpanID: []byte("bbbbbbbb"), NestedSetLeft: 3, NestedSetRight: 4, ParentID: 2, ChildCount: 0},
 					{SpanID: []byte("dddddddd"), ParentSpanID: []byte("bbbbbbbb"), NestedSetLeft: 5, NestedSetRight: 6, ParentID: 2, ChildCount: 0},
 
-					{SpanID: []byte("eeeeeeee"), ParentSpanID: []byte("xxxxxxxx"), ChildCount: 1}, // <- interrupted
-					{SpanID: []byte("ffffffff"), ParentSpanID: []byte("eeeeeeee"), ChildCount: 0},
+					// orphan sub-tree: eeeeeeee's parent is missing, so it becomes a sub-root with ParentID=0
+					{SpanID: []byte("eeeeeeee"), ParentSpanID: []byte("xxxxxxxx"), NestedSetLeft: 9, NestedSetRight: 12, ParentID: 0, ChildCount: 1},
+					{SpanID: []byte("ffffffff"), ParentSpanID: []byte("eeeeeeee"), NestedSetLeft: 10, NestedSetRight: 11, ParentID: 9, ChildCount: 0},
+				},
+			},
+			expectedConnected: false,
+		},
+		{
+			// Reproduces the scenario from https://github.com/grafana/tempo/issues/6393:
+			// a linear chain A->B->C->D->E where C is dropped. The connected sub-trees A->B
+			// and D->E should each receive valid nested set bounds so that structural queries
+			// work within each intact segment.
+			name: "dropped middle span A->B + D->E",
+			trace: [][]Span{
+				{
+					{SpanID: []byte("aaaaaaaa")},
+					{SpanID: []byte("bbbbbbbb"), ParentSpanID: []byte("aaaaaaaa")},
+					// cccccccc is missing (dropped)
+					{SpanID: []byte("dddddddd"), ParentSpanID: []byte("cccccccc")},
+					{SpanID: []byte("eeeeeeee"), ParentSpanID: []byte("dddddddd")},
+				},
+			},
+			expected: [][]Span{
+				{
+					{SpanID: []byte("aaaaaaaa"), NestedSetLeft: 1, NestedSetRight: 4, ParentID: -1, ChildCount: 1},
+					{SpanID: []byte("bbbbbbbb"), ParentSpanID: []byte("aaaaaaaa"), NestedSetLeft: 2, NestedSetRight: 3, ParentID: 1, ChildCount: 0},
+					// dddddddd's parent (cccccccc) is missing — becomes a sub-root with ParentID=0
+					{SpanID: []byte("dddddddd"), ParentSpanID: []byte("cccccccc"), NestedSetLeft: 5, NestedSetRight: 8, ParentID: 0, ChildCount: 1},
+					{SpanID: []byte("eeeeeeee"), ParentSpanID: []byte("dddddddd"), NestedSetLeft: 6, NestedSetRight: 7, ParentID: 5, ChildCount: 0},
 				},
 			},
 			expectedConnected: false,
@@ -387,4 +415,101 @@ func TestAssignServiceStats(t *testing.T) {
 			assert.Equal(t, tt.expected, trace.ServiceStats)
 		})
 	}
+}
+
+// BenchmarkAssignNestedSetModelBounds measures the nested set assignment across the main
+// structural cases: a fully connected trace (linear and branched) and incomplete traces
+// with one or many missing spans (partial cases).
+func BenchmarkAssignNestedSetModelBounds(b *testing.B) {
+	cases := []struct {
+		name  string
+		build func(n int) *Trace
+	}{
+		{
+			// fully connected chain: span[1] -> span[2] -> ... -> span[n]
+			name:  "complete/linear",
+			build: benchLinearTrace,
+		},
+		{
+			// fully connected tree with branching factor 4 (each node has up to 4 children)
+			name:  "complete/branched",
+			build: func(n int) *Trace { return benchBranchedTrace(n, 4) },
+		},
+		{
+			// single dropped span in the middle, leaving two connected sub-trees
+			name:  "partial/one_gap",
+			build: benchLinearTraceDropMiddle,
+		},
+		{
+			// every 10th span dropped (~10% missing), creating many disconnected sub-trees
+			name:  "partial/many_gaps",
+			build: func(n int) *Trace { return benchLinearTraceDropEvery(n, 10) },
+		},
+	}
+
+	for _, n := range []int{100, 1000, 10000} {
+		for _, tc := range cases {
+			b.Run(fmt.Sprintf("%s/spans=%d", tc.name, n), func(b *testing.B) {
+				tr := tc.build(n)
+				for b.Loop() {
+					assignNestedSetModelBoundsAndServiceStats(tr)
+				}
+			})
+		}
+	}
+}
+
+// benchSpanID returns a unique non-zero 8-byte span ID for index i (i must be >= 1).
+func benchSpanID(i int) []byte {
+	return []byte{0, 0, 0, 0, byte(i >> 24), byte(i >> 16), byte(i >> 8), byte(i)}
+}
+
+// benchLinearTrace builds a complete linear chain: span[1] -> span[2] -> ... -> span[n].
+func benchLinearTrace(n int) *Trace {
+	spans := make([]Span, n)
+	spans[0] = Span{SpanID: benchSpanID(1)}
+	for i := 1; i < n; i++ {
+		spans[i] = Span{SpanID: benchSpanID(i + 1), ParentSpanID: benchSpanID(i)}
+	}
+	return &Trace{ResourceSpans: []ResourceSpans{{ScopeSpans: []ScopeSpans{{Spans: spans}}}}}
+}
+
+// benchBranchedTrace builds a complete tree of n spans where each node has up to k children.
+func benchBranchedTrace(n, k int) *Trace {
+	spans := make([]Span, n)
+	spans[0] = Span{SpanID: benchSpanID(1)}
+	for i := 1; i < n; i++ {
+		parent := (i-1)/k + 1 // 1-indexed parent
+		spans[i] = Span{SpanID: benchSpanID(i + 1), ParentSpanID: benchSpanID(parent)}
+	}
+	return &Trace{ResourceSpans: []ResourceSpans{{ScopeSpans: []ScopeSpans{{Spans: spans}}}}}
+}
+
+// benchLinearTraceDropMiddle builds a linear trace of n spans with the single middle span
+// dropped, splitting the chain into two connected halves.
+func benchLinearTraceDropMiddle(n int) *Trace {
+	dropped := n / 2
+	spans := make([]Span, 0, n-1)
+	spans = append(spans, Span{SpanID: benchSpanID(1)})
+	for i := 1; i < n; i++ {
+		if i == dropped {
+			continue
+		}
+		spans = append(spans, Span{SpanID: benchSpanID(i + 1), ParentSpanID: benchSpanID(i)})
+	}
+	return &Trace{ResourceSpans: []ResourceSpans{{ScopeSpans: []ScopeSpans{{Spans: spans}}}}}
+}
+
+// benchLinearTraceDropEvery builds a linear trace of n spans with every period-th span
+// dropped, creating multiple disconnected sub-trees.
+func benchLinearTraceDropEvery(n, period int) *Trace {
+	spans := make([]Span, 0, n)
+	spans = append(spans, Span{SpanID: benchSpanID(1)})
+	for i := 1; i < n; i++ {
+		if i%period == 0 {
+			continue
+		}
+		spans = append(spans, Span{SpanID: benchSpanID(i + 1), ParentSpanID: benchSpanID(i)})
+	}
+	return &Trace{ResourceSpans: []ResourceSpans{{ScopeSpans: []ScopeSpans{{Spans: spans}}}}}
 }

--- a/tempodb/encoding/vparquet5/nested_set_model_test.go
+++ b/tempodb/encoding/vparquet5/nested_set_model_test.go
@@ -267,6 +267,9 @@ func TestAssignNestedSetModelBounds(t *testing.T) {
 			expectedConnected: false,
 		},
 		{
+			// A->B->C chain where A is dropped. With no true root present, B becomes
+			// an orphan sub-root and still receives valid nested set bounds so structural
+			// queries work within the connected B->C segment.
 			name: "no roots",
 			trace: [][]Span{
 				{
@@ -276,8 +279,8 @@ func TestAssignNestedSetModelBounds(t *testing.T) {
 			},
 			expected: [][]Span{
 				{
-					{SpanID: []byte("cccccccc"), ParentSpanID: []byte("bbbbbbbb")},
-					{SpanID: []byte("bbbbbbbb"), ParentSpanID: []byte("aaaaaaaa")},
+					{SpanID: []byte("cccccccc"), ParentSpanID: []byte("bbbbbbbb"), NestedSetLeft: 2, NestedSetRight: 3, ParentID: 1, ChildCount: 0},
+					{SpanID: []byte("bbbbbbbb"), ParentSpanID: []byte("aaaaaaaa"), NestedSetLeft: 1, NestedSetRight: 4, ParentID: 0, ChildCount: 1},
 				},
 			},
 			expectedConnected: false,


### PR DESCRIPTION
**What this PR does**:
Instead of assigning nested set data all-or-nothing, this updates it with the logic as discussed in the issue.  It keeps assigning whatever it can, including disconnected sub-trees.

This introduces a potential breaking change when searching for broken traces.  I might have previously guided people to use `{nestedSetLeft=0}`, but this no longer works. Every span will get Left assigned and be non-zero.   What does work now is using `{nestedSetParent=0}`.  This will identify the spans that are known to be broken:  they have a parent span ID, but it wasn't present in the data.  

Drilldown Traces uses `{nestedSetParent<0}` to identify root spans, and that is preserved.

A further subtlety to the change is that previously you could tell a trace was broken via `any span` in the trace, because they were all left=0.   Now you can only tell by the specific ones which lost their parent.  From inside a sub-tree, everything looks good.

Honestly I think this is a good change and impact will be minor but I wanted to highlight it.  If you are querying nested set data in-depth enough to be impacted by this, this improvement will probably be welcome.

**Which issue(s) this PR fixes**:
Fixes #6393 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`