### PR TITLE
Tempo 3.0 migration: docker-compose example + doc tweaks

### DIFF
--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/migrate-to-3.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/migrate-to-3.md
@@ -219,7 +219,11 @@ To validate the deployment:
 
 1. Verify that all components start successfully and connect to Kafka. Check that `tempo_live_store_ready` equals `1`. The log message `"live-store ready to serve queries"` confirms the live-store is ready. At this point, no traffic is flowing through the 3.0 distributors yet, so write metrics will be at zero.
 
-1. It's highly recommended to validate the deployment end-to-end using [Tempo Vulture](/docs/tempo/<TEMPO_VERSION>/operations/tempo-vulture/), Tempo's built-in testing tool. Vulture writes traces to the distributor and reads them back through the query frontend, validating the full write and read path. Point it at the 3.0 deployment and let it run for 10–15 minutes. Confirm that `tempo_vulture_trace_mismatches_total` stays at zero.
+   {{< admonition type="note" >}}
+   On a fresh deployment with no traffic flowing yet, the live-store can take up to `live_store.readiness_max_wait` (default 5 minutes) to become ready, because there's no Kafka high-water mark to compare against. This is normal. Once traffic starts flowing in the next step, restarts are near-instant.
+   {{< /admonition >}}
+
+1. It's highly recommended to validate the deployment end-to-end using [Tempo Vulture](/docs/tempo/<TEMPO_VERSION>/operations/tempo-vulture/), Tempo's built-in testing tool. Vulture writes traces to the distributor and reads them back through the query frontend, validating the full write and read path. Point it at the 3.0 deployment and let it run for 10–15 minutes. Confirm that `tempo_vulture_trace_error_total` stays at zero and `tempo_vulture_trace_total` is increasing.
 
    You can also validate manually by querying the 3.0 deployment directly — for example, using `curl` against the query frontend API or querying from Grafana:
 
@@ -229,7 +233,14 @@ To validate the deployment:
 
    Use a trace ID that you know exists in your 2.x deployment. If the query returns trace data, the new deployment is reading from storage correctly.
 
-Before proceeding, confirm all components are healthy.
+Before proceeding to the cutover, confirm all of the following:
+
+- `tempo_live_store_ready` equals `1` on every live-store replica.
+- `rate(tempo_block_builder_fetch_errors_total[5m])` is at or near zero on every block-builder.
+- Vulture has been running for 10–15 minutes with `tempo_vulture_trace_error_total` at zero and `tempo_vulture_trace_total` increasing.
+- At least one trace-by-ID query for a trace that exists in your 2.x deployment returns data when sent to the 3.0 query frontend.
+
+If any of these aren't satisfied, resolve them before continuing. Switching traffic with an unhealthy 3.0 deployment risks data loss for newly ingested traces.
 
 ## Switch traffic to Tempo 3.0
 

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/migrate-to-3.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/migrate-to-3.md
@@ -220,7 +220,7 @@ To validate the deployment:
 1. Verify that all components start successfully and connect to Kafka. Check that `tempo_live_store_ready` equals `1`. The log message `"live-store ready to serve queries"` confirms the live-store is ready. At this point, no traffic is flowing through the 3.0 distributors yet, so write metrics will be at zero.
 
    {{< admonition type="note" >}}
-   On a fresh deployment with no traffic flowing yet, the live-store can take up to `live_store.readiness_max_wait` (default 5 minutes) to become ready, because there's no Kafka high-water mark to compare against. This is normal. Once traffic starts flowing in the next step, restarts are near-instant.
+   On a fresh deployment with no traffic flowing yet, the live-store can take up to `live_store.readiness_max_wait` (default 30 minutes) to become ready, because there's no Kafka high-water mark to compare against. This is normal. Once traffic starts flowing in the next step, restarts are near-instant.
    {{< /admonition >}}
 
 1. It's highly recommended to validate the deployment end-to-end using [Tempo Vulture](/docs/tempo/<TEMPO_VERSION>/operations/tempo-vulture/), Tempo's built-in testing tool. Vulture writes traces to the distributor and reads them back through the query frontend, validating the full write and read path. Point it at the 3.0 deployment and let it run for 10–15 minutes. Confirm that `tempo_vulture_trace_error_total` stays at zero and `tempo_vulture_trace_total` is increasing.

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/migrate-to-3.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/migrate-to-3.md
@@ -223,7 +223,7 @@ To validate the deployment:
    On a fresh deployment with no traffic flowing yet, the live-store can take up to `live_store.readiness_max_wait` (default 30 minutes) to become ready, because there's no Kafka high-water mark to compare against. This is normal. Once traffic starts flowing in the next step, restarts are near-instant.
    {{< /admonition >}}
 
-1. It's highly recommended to validate the deployment end-to-end using [Tempo Vulture](/docs/tempo/<TEMPO_VERSION>/operations/tempo-vulture/), Tempo's built-in testing tool. Vulture writes traces to the distributor and reads them back through the query frontend, validating the full write and read path. Point it at the 3.0 deployment and let it run for 10–15 minutes. Confirm that `tempo_vulture_trace_error_total` stays at zero and `tempo_vulture_trace_total` is increasing.
+1. Validate the deployment end-to-end using [Tempo Vulture](/docs/tempo/<TEMPO_VERSION>/operations/tempo-vulture/), Tempo's built-in testing tool. Vulture writes traces to the distributor and reads them back through the query frontend, validating the full write and read path. Point it at the 3.0 deployment and let it run for 10–15 minutes. Confirm that `tempo_vulture_trace_error_total` stays at zero and `tempo_vulture_trace_total` is increasing.
 
    You can also validate manually by querying the 3.0 deployment directly — for example, using `curl` against the query frontend API or querying from Grafana:
 
@@ -240,7 +240,7 @@ Before proceeding to the cutover, confirm all of the following:
 - Vulture has been running for 10–15 minutes with `tempo_vulture_trace_error_total` at zero and `tempo_vulture_trace_total` increasing.
 - At least one trace-by-ID query for a trace that exists in your 2.x deployment returns data when sent to the 3.0 query frontend.
 
-If any of these aren't satisfied, resolve them before continuing. Switching traffic with an unhealthy 3.0 deployment risks data loss for newly ingested traces.
+Resolve any issues so all of these conditions are satisfied. Switching traffic with an unhealthy 3.0 deployment risks data loss for newly ingested traces.
 
 ## Switch traffic to Tempo 3.0
 

--- a/example/docker-compose/migrate-to-3/README.md
+++ b/example/docker-compose/migrate-to-3/README.md
@@ -73,8 +73,13 @@ This starts Redpanda, creates the `tempo-ingest` topic with 2 partitions, and
 brings up every v3 component. Traffic is **still flowing to v2** — Alloy hasn't
 been touched.
 
-Confirm v3 is healthy before moving on. Open Grafana at <http://localhost:3000>
-→ **Explore** → select the **Prometheus** datasource and run:
+**First, verify that `compaction_disabled: true` is set in `tempo-v3.yaml`
+overrides** (it already is in this example). If both compactors run against
+the shared MinIO bucket at the same time, they can corrupt each other's work.
+
+Then confirm v3 is healthy before moving on. Open Grafana at
+<http://localhost:3000> → **Explore** → select the **Prometheus** datasource
+and run:
 
 ```promql
 # Both live-store replicas should report 1.
@@ -95,10 +100,6 @@ docker compose logs -f tempo-v3-live-store-0 tempo-v3-live-store-1 | grep -E 're
 > `live_store.readiness_max_wait` (30 s in this example, 30 m default) before
 > giving up and going ready. Once you switch traffic in step 4, restarts are
 > instant because there's data in the topic.
-
-Verify that `compaction_disabled: true` is set in `tempo-v3.yaml` overrides
-(it already is in this example) so the v3 deployment doesn't fight the v2
-compactor over shared storage.
 
 The `v3` profile also brings up [Tempo Vulture](https://grafana.com/docs/tempo/latest/operations/tempo-vulture/),
 which pushes synthetic traces directly to the v3 distributor and reads them

--- a/example/docker-compose/migrate-to-3/README.md
+++ b/example/docker-compose/migrate-to-3/README.md
@@ -92,7 +92,7 @@ docker compose logs -f tempo-v3-live-store-0 tempo-v3-live-store-1 | grep -E 're
 
 > **Why does the live-store take 30 s to be ready?** With an empty Kafka topic
 > the live-store has no record to use as a high-water mark, so it waits
-> `live_store.readiness_max_wait` (30 s in this example, 5 m default) before
+> `live_store.readiness_max_wait` (30 s in this example, 30 m default) before
 > giving up and going ready. Once you switch traffic in step 4, restarts are
 > instant because there's data in the topic.
 

--- a/example/docker-compose/migrate-to-3/README.md
+++ b/example/docker-compose/migrate-to-3/README.md
@@ -42,6 +42,11 @@ change.
 This mirrors the structure of the migration guide. Each step lists the commands
 to run plus what to look for before moving on.
 
+> **Where to run the queries.** All `promql` snippets below are intended for
+> Grafana Explore: open <http://localhost:3000>, click **Explore**, select the
+> **Prometheus** datasource, and paste the query. TraceQL queries use the
+> **Tempo 2.x** or **Tempo 3.0** datasources from the same Explore view.
+
 ### 1. Start Tempo 2.x and generate traffic
 
 ```bash
@@ -52,11 +57,11 @@ This brings up the shared infrastructure and the full v2 stack. `k6-tracing`
 starts pushing spans into Alloy, which forwards them to `tempo-v2-distributor`
 (the default `ALLOY_OTLP_UPSTREAM`).
 
-Wait ~30 s, then confirm:
+Wait ~30 s, then confirm in Grafana Explore:
 
-- Grafana → **Tempo 2.x** datasource → run a TraceQL search like `{}`. You
-  should see traces.
-- `curl -s localhost:9090/api/v1/query?query=tempo_distributor_spans_received_total | jq .` returns non-zero values for the v2 distributor.
+- **Tempo 2.x** datasource: a TraceQL search like `{}` returns traces.
+- **Prometheus** datasource: `tempo_distributor_spans_received_total{job="tempo-v2"}`
+  is greater than 0.
 
 ### 2. Bring up Tempo 3.0 alongside 2.x
 
@@ -68,14 +73,15 @@ This starts Redpanda, creates the `tempo-ingest` topic with 2 partitions, and
 brings up every v3 component. Traffic is **still flowing to v2** — Alloy hasn't
 been touched.
 
-Confirm v3 is healthy before moving on:
+Confirm v3 is healthy before moving on. Open Grafana at <http://localhost:3000>
+→ **Explore** → select the **Prometheus** datasource and run:
 
-```bash
-# Live-store readiness — should print "1" for both replicas:
-curl -s 'http://localhost:9090/api/v1/query?query=tempo_live_store_ready' | jq -r '.data.result[] | select(.metric.instance | test("live-store")) | .value[1]'
+```promql
+# Both live-store replicas should report 1.
+tempo_live_store_ready{job="tempo-v3"}
 
-# Block-builders should have partition assignments (1 each):
-curl -s 'http://localhost:9090/api/v1/query?query=tempo_block_builder_owned_partitions' | jq -r '.data.result[] | "\(.metric.instance) owned=\(.value[1])"'
+# Each block-builder should own one partition.
+tempo_block_builder_owned_partitions
 ```
 
 You can also tail the logs:
@@ -97,21 +103,21 @@ compactor over shared storage.
 The `v3` profile also brings up [Tempo Vulture](https://grafana.com/docs/tempo/latest/operations/tempo-vulture/),
 which pushes synthetic traces directly to the v3 distributor and reads them
 back through the v3 query-frontend (trace-by-id, search tag, TraceQL, metrics).
-The migration guide recommends letting Vulture run for 10–15 minutes and
-confirming there are zero errors:
+The migration guide recommends letting Vulture run for 10–15 minutes. In
+Grafana Explore (Prometheus):
 
-```bash
+```promql
 # Trace-level issues (missing spans, incorrect results, etc.) — should stay 0.
 # Note: this is a *Vec counter, so on a clean run no samples are emitted at
-# all (sum() correctly returns 0).
-curl -s 'http://localhost:9090/api/v1/query?query=sum(tempo_vulture_trace_error_total)' | jq -r '.data.result[].value[1] // "0"'
+# all; using sum() correctly returns 0.
+sum(tempo_vulture_trace_error_total)
 
-# Generic transport/HTTP errors — should also stay 0:
-curl -s 'http://localhost:9090/api/v1/query?query=tempo_vulture_error_total' | jq -r '.data.result[].value[1]'
+# Generic transport/HTTP errors — should also stay 0.
+tempo_vulture_error_total
 
-# Should be increasing once Vulture has been running ~2 min (proves the
-# write+read path works end-to-end):
-curl -s 'http://localhost:9090/api/v1/query?query=tempo_vulture_trace_total' | jq -r '.data.result[].value[1]'
+# Should be increasing once Vulture has been running ~2 min, proving the
+# end-to-end write + read path works.
+tempo_vulture_trace_total
 ```
 
 > Vulture writes a trace and waits a couple of minutes before reading it back,
@@ -125,23 +131,17 @@ the **v3** frontend. "Already flushed" means older than v2's `max_block_duration
 (5 min in `tempo-v2.yaml`) — fresher traces still live in the v2 ingester's
 memory, which v3 has no way to read.
 
-The simplest way: let the demo run for ~6 minutes after step 1, then pick any
-trace from Grafana's **Tempo 2.x** datasource. Or grab one from the v2 search
-API like this:
+Let the demo run for ~6 minutes after step 1 so v2 has flushed at least one
+block, then in Grafana Explore:
 
-```bash
-# Pick a trace from > 6 minutes ago to ensure it's in MinIO, not the ingester:
-NOW=$(date +%s)
-TRACE_ID=$(curl -s -G 'http://localhost:3200/api/search' \
-  --data-urlencode 'q={}' --data-urlencode 'limit=1' \
-  --data-urlencode "start=$((NOW - 1800))" \
-  --data-urlencode "end=$((NOW - 360))" | jq -r '.traces[0].traceID')
+1. Select the **Tempo 2.x** datasource. Set the time range to something like
+   `now-30m` to `now-6m` (avoids picking up traces that are still only in the
+   v2 ingester's memory). Run a search like `{}` and copy any returned trace ID.
+2. Switch to the **Tempo 3.0** datasource. Paste the trace ID into the **Trace ID**
+   query type and run it.
 
-echo "Querying $TRACE_ID via v3..."
-curl -s "http://localhost:3201/api/traces/${TRACE_ID}" | jq '.batches | length'
-```
-
-A non-zero number means the v3 querier successfully read a v2 (RF3) block.
+The trace should resolve with the same spans as on the v2 datasource, proving
+the v3 querier successfully read a v2 (RF3) block from shared object storage.
 
 > **404 from v3 even though the block is in MinIO?** The v3 querier polls
 > object storage on a fixed cycle (`storage.trace.blocklist_poll`, set to 1 m
@@ -161,31 +161,30 @@ Repoint Alloy at the v3 distributor:
 ALLOY_OTLP_UPSTREAM=tempo-v3-distributor:4317 docker compose up -d alloy
 ```
 
-Within ~15 s, check that v3 is now ingesting:
+Within ~15 s, check that v3 is now ingesting. In Grafana Explore (Prometheus):
 
-```bash
-# v3 distributor writes to Kafka:
-curl -s 'http://localhost:9090/api/v1/query?query=rate(tempo_distributor_kafka_write_bytes_total[1m])' | jq
+```promql
+# v3 distributor writes to Kafka.
+sum(rate(tempo_distributor_kafka_write_bytes_total[1m]))
 
-# v3 block-builders are consuming:
-curl -s 'http://localhost:9090/api/v1/query?query=rate(tempo_block_builder_fetch_records_total[1m])' | jq
+# v3 block-builders are consuming.
+sum by (instance) (rate(tempo_block_builder_fetch_records_total[1m]))
 
-# v2 distributor receives nothing new:
-curl -s 'http://localhost:9090/api/v1/query?query=rate(tempo_distributor_spans_received_total{job="tempo-v2"}[1m])' | jq
+# v2 distributor receives nothing new (should be 0).
+sum(rate(tempo_distributor_bytes_received_total{job="tempo-v2"}[1m]))
 ```
 
-Recent traces from the new pipeline should be queryable via Grafana's
-**Tempo 3.0** datasource.
+Recent traces from the new pipeline should also be queryable via Grafana's
+**Tempo 3.0** datasource (Explore → select **Tempo 3.0** → search `{}`).
 
 ### 5. Drain the 2.x ingesters
 
 With no new traffic arriving, the 2.x ingesters need to flush their in-memory
-traces to MinIO:
+traces to MinIO. In Grafana Explore (Prometheus), watch these drift toward 0:
 
-```bash
-# Should drift toward 0:
-curl -s 'http://localhost:9090/api/v1/query?query=tempo_ingester_live_traces' | jq
-curl -s 'http://localhost:9090/api/v1/query?query=tempo_ingester_flush_queue_length' | jq
+```promql
+tempo_ingester_live_traces
+tempo_ingester_flush_queue_length
 ```
 
 With this example's `max_block_duration: 5m` and default `complete_block_timeout`,
@@ -233,17 +232,19 @@ docker compose logs -f tempo-v3-backend-worker | grep -i 'compact'
 
 ### 7. Verify the migration
 
-Mirrors the **Verify the migration** section of the doc:
+Mirrors the **Verify the migration** section of the doc. Run these in Grafana
+Explore against the **Prometheus** datasource (last column shows the expected
+healthy state):
 
-| Check                                        | Query                                                       |
-| -------------------------------------------- | ----------------------------------------------------------- |
-| Distributors writing to Kafka                | `rate(tempo_distributor_kafka_write_bytes_total[1m])`       |
-| Block-builders consuming, no errors          | `rate(tempo_block_builder_fetch_records_total[1m])` / `rate(tempo_block_builder_fetch_errors_total[1m])` |
-| Live-stores ready                            | `tempo_live_store_ready == 1`                               |
-| No dropped records                           | `tempo_live_store_records_dropped_total == 0`               |
-| Kafka lag healthy                            | `tempo_ingest_group_partition_lag_seconds`                  |
-| Historical queries work                      | TraceQL search via the **Tempo 3.0** datasource             |
-| Vulture sees no errors (10–15 min run)       | `tempo_vulture_trace_error_total == 0` and `tempo_vulture_trace_total` increasing |
+| Check                               | Query                                                                                                    | Expected     |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------ |
+| Distributors writing to Kafka       | `sum(rate(tempo_distributor_kafka_write_bytes_total[1m]))`                                               | > 0          |
+| Block-builders consuming, no errors | `sum by (instance) (rate(tempo_block_builder_fetch_records_total[1m]))` / `tempo_block_builder_fetch_errors_total` | > 0  /  0    |
+| Live-stores ready                   | `tempo_live_store_ready`                                                                                 | 1            |
+| No dropped records                  | `tempo_live_store_records_dropped_total`                                                                 | 0            |
+| Kafka lag healthy                   | `tempo_ingest_group_partition_lag_seconds`                                                               | sub-second   |
+| Historical queries work             | TraceQL search via the **Tempo 3.0** datasource (Explore → Tempo 3.0 → `{}`)                              | results return |
+| Vulture clean (10–15 min run)       | `sum(tempo_vulture_trace_error_total)` and `tempo_vulture_trace_total`                                   | 0  /  rising |
 
 ---
 

--- a/example/docker-compose/migrate-to-3/README.md
+++ b/example/docker-compose/migrate-to-3/README.md
@@ -131,13 +131,16 @@ the **v3** frontend. "Already flushed" means older than v2's `max_block_duration
 (5 min in `tempo-v2.yaml`) — fresher traces still live in the v2 ingester's
 memory, which v3 has no way to read.
 
-Let the demo run for ~6 minutes after step 1 so v2 has flushed at least one
-block, then in Grafana Explore:
+Let the demo run for at least `max_block_duration` (5 min in `tempo-v2.yaml`)
+plus ~1 min of flush overhead — so **6 min** total — after step 1, so v2 has
+guaranteed to have flushed at least one block. Then in Grafana Explore:
 
-1. Select the **Tempo 2.x** datasource. Set the time range to something like
-   `now-30m` to `now-6m` (avoids picking up traces that are still only in the
-   v2 ingester's memory). Run a search like `{}` and copy any returned trace ID.
-2. Switch to the **Tempo 3.0** datasource. Paste the trace ID into the **Trace ID**
+1. Select the **Tempo 2.x** datasource. Set the **end** of the time range to
+   `now - 6m` (older than `max_block_duration + flush overhead`, so the result
+   excludes traces still only in the v2 ingester's memory). A start of
+   `now - 30m` is a reasonable upper bound. Run a search like `{}` and copy
+   any returned trace ID.
+2. Switch to the **Tempo 3.0** datasource. Paste the trace ID into the **TraceID**
    query type and run it.
 
 The trace should resolve with the same spans as on the v2 datasource, proving

--- a/example/docker-compose/migrate-to-3/README.md
+++ b/example/docker-compose/migrate-to-3/README.md
@@ -144,7 +144,9 @@ guaranteed to have flushed at least one block. Then in Grafana Explore:
    query type and run it.
 
 The trace should resolve with the same spans as on the v2 datasource, proving
-the v3 querier successfully read a v2 (RF3) block from shared object storage.
+the v3 querier successfully read a v2 block from shared object storage. (This
+example uses RF=1 for simplicity; real 2.x deployments typically use RF=3, and
+v3 transparently reads both.)
 
 > **404 from v3 even though the block is in MinIO?** The v3 querier polls
 > object storage on a fixed cycle (`storage.trace.blocklist_poll`, set to 1 m

--- a/example/docker-compose/migrate-to-3/README.md
+++ b/example/docker-compose/migrate-to-3/README.md
@@ -1,0 +1,281 @@
+# Migrate Tempo 2.x → 3.0 (microservices)
+
+A self-contained Docker Compose environment to walk through and validate the
+migration documented at
+[Migrate from Tempo 2.x to 3.0](../../../docs/sources/tempo/set-up-for-tracing/setup-tempo/migrate-to-3.md).
+
+It runs a Tempo 2.x microservices deployment and a Tempo 3.0 microservices
+deployment side by side, both pointed at the same MinIO bucket, with Alloy as
+the trace router so you can flip traffic between the two with a single env-var
+change.
+
+## What's in the box
+
+| Profile  | Components                                                                                                                                              |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `v2`     | distributor, ingester, querier, query-frontend, compactor, metrics-generator (`grafana/tempo:2.9.2`)                                                    |
+| `v3`     | distributor, live-store ×2, block-builder ×2, querier, query-frontend, backend-scheduler, backend-worker, metrics-generator + Redpanda (`grafana/tempo:3.0.0-rc.1`) |
+| _shared_ | MinIO (object storage), Prometheus, Grafana, Alloy (trace router), `xk6-client-tracing` (load generator)                            |
+
+| URL                                            | What                          |
+| ---------------------------------------------- | ----------------------------- |
+| http://localhost:3000                          | Grafana (anonymous admin)     |
+| http://localhost:3200                          | Tempo 2.x query frontend      |
+| http://localhost:3201                          | Tempo 3.0 query frontend      |
+| http://localhost:9090                          | Prometheus                    |
+| http://localhost:9001 (`tempo` / `supersecret`) | MinIO console                |
+| http://localhost:8080                          | Redpanda console (v3 only)    |
+| http://localhost:12345                         | Alloy UI                      |
+
+## Prerequisites
+
+- Docker Compose v2 (`docker compose ...`).
+- ~3 GB of free RAM.
+
+> **Note.** Both image tags are pinned in `docker-compose.yaml`
+> (`x-tempo-v2-image`, `x-tempo-v3-image`). Bump them to test other versions.
+
+---
+
+## The playbook
+
+This mirrors the structure of the migration guide. Each step lists the commands
+to run plus what to look for before moving on.
+
+### 1. Start Tempo 2.x and generate traffic
+
+```bash
+docker compose --profile v2 up -d
+```
+
+This brings up the shared infrastructure and the full v2 stack. `k6-tracing`
+starts pushing spans into Alloy, which forwards them to `tempo-v2-distributor`
+(the default `ALLOY_OTLP_UPSTREAM`).
+
+Wait ~30 s, then confirm:
+
+- Grafana → **Tempo 2.x** datasource → run a TraceQL search like `{}`. You
+  should see traces.
+- `curl -s localhost:9090/api/v1/query?query=tempo_distributor_spans_received_total | jq .` returns non-zero values for the v2 distributor.
+
+### 2. Bring up Tempo 3.0 alongside 2.x
+
+```bash
+docker compose --profile v3 up -d
+```
+
+This starts Redpanda, creates the `tempo-ingest` topic with 2 partitions, and
+brings up every v3 component. Traffic is **still flowing to v2** — Alloy hasn't
+been touched.
+
+Confirm v3 is healthy before moving on:
+
+```bash
+# Live-store readiness — should print "1" for both replicas:
+curl -s 'http://localhost:9090/api/v1/query?query=tempo_live_store_ready' | jq -r '.data.result[] | select(.metric.instance | test("live-store")) | .value[1]'
+
+# Block-builders should have partition assignments (1 each):
+curl -s 'http://localhost:9090/api/v1/query?query=tempo_block_builder_owned_partitions' | jq -r '.data.result[] | "\(.metric.instance) owned=\(.value[1])"'
+```
+
+You can also tail the logs:
+
+```bash
+docker compose logs -f tempo-v3-live-store-0 tempo-v3-live-store-1 | grep -E 'ready to serve|fail'
+```
+
+> **Why does the live-store take 30 s to be ready?** With an empty Kafka topic
+> the live-store has no record to use as a high-water mark, so it waits
+> `live_store.readiness_max_wait` (30 s in this example, 5 m default) before
+> giving up and going ready. Once you switch traffic in step 4, restarts are
+> instant because there's data in the topic.
+
+Verify that `compaction_disabled: true` is set in `tempo-v3.yaml` overrides
+(it already is in this example) so the v3 deployment doesn't fight the v2
+compactor over shared storage.
+
+The `v3` profile also brings up [Tempo Vulture](https://grafana.com/docs/tempo/latest/operations/tempo-vulture/),
+which pushes synthetic traces directly to the v3 distributor and reads them
+back through the v3 query-frontend (trace-by-id, search tag, TraceQL, metrics).
+The migration guide recommends letting Vulture run for 10–15 minutes and
+confirming there are zero errors:
+
+```bash
+# Trace-level issues (missing spans, incorrect results, etc.) — should stay 0.
+# Note: this is a *Vec counter, so on a clean run no samples are emitted at
+# all (sum() correctly returns 0).
+curl -s 'http://localhost:9090/api/v1/query?query=sum(tempo_vulture_trace_error_total)' | jq -r '.data.result[].value[1] // "0"'
+
+# Generic transport/HTTP errors — should also stay 0:
+curl -s 'http://localhost:9090/api/v1/query?query=tempo_vulture_error_total' | jq -r '.data.result[].value[1]'
+
+# Should be increasing once Vulture has been running ~2 min (proves the
+# write+read path works end-to-end):
+curl -s 'http://localhost:9090/api/v1/query?query=tempo_vulture_trace_total' | jq -r '.data.result[].value[1]'
+```
+
+> Vulture writes a trace and waits a couple of minutes before reading it back,
+> so `tempo_vulture_trace_total` stays at 0 for the first ~2 minutes. That's
+> normal.
+
+### 3. Validate the v3 deployment can read v2 blocks
+
+Pick a trace ID **that's already been flushed to MinIO** and query it through
+the **v3** frontend. "Already flushed" means older than v2's `max_block_duration`
+(5 min in `tempo-v2.yaml`) — fresher traces still live in the v2 ingester's
+memory, which v3 has no way to read.
+
+The simplest way: let the demo run for ~6 minutes after step 1, then pick any
+trace from Grafana's **Tempo 2.x** datasource. Or grab one from the v2 search
+API like this:
+
+```bash
+# Pick a trace from > 6 minutes ago to ensure it's in MinIO, not the ingester:
+NOW=$(date +%s)
+TRACE_ID=$(curl -s -G 'http://localhost:3200/api/search' \
+  --data-urlencode 'q={}' --data-urlencode 'limit=1' \
+  --data-urlencode "start=$((NOW - 1800))" \
+  --data-urlencode "end=$((NOW - 360))" | jq -r '.traces[0].traceID')
+
+echo "Querying $TRACE_ID via v3..."
+curl -s "http://localhost:3201/api/traces/${TRACE_ID}" | jq '.batches | length'
+```
+
+A non-zero number means the v3 querier successfully read a v2 (RF3) block.
+
+> **404 from v3 even though the block is in MinIO?** The v3 querier polls
+> object storage on a fixed cycle (`storage.trace.blocklist_poll`, set to 1 m
+> in `tempo-v3.yaml` for this demo; 5 m by default in real deployments).
+> Newly flushed v2 blocks aren't visible to v3 until the next poll. Wait up to
+> a poll interval and retry, or check the v3 querier logs for
+> `"blocklist poll complete"` messages.
+>
+> In a real migration this is a non-issue — v2 has been running for hours or
+> days, and every block has been polled many times before you bring up v3.
+
+### 4. Switch traffic to Tempo 3.0
+
+Repoint Alloy at the v3 distributor:
+
+```bash
+ALLOY_OTLP_UPSTREAM=tempo-v3-distributor:4317 docker compose up -d alloy
+```
+
+Within ~15 s, check that v3 is now ingesting:
+
+```bash
+# v3 distributor writes to Kafka:
+curl -s 'http://localhost:9090/api/v1/query?query=rate(tempo_distributor_kafka_write_bytes_total[1m])' | jq
+
+# v3 block-builders are consuming:
+curl -s 'http://localhost:9090/api/v1/query?query=rate(tempo_block_builder_fetch_records_total[1m])' | jq
+
+# v2 distributor receives nothing new:
+curl -s 'http://localhost:9090/api/v1/query?query=rate(tempo_distributor_spans_received_total{job="tempo-v2"}[1m])' | jq
+```
+
+Recent traces from the new pipeline should be queryable via Grafana's
+**Tempo 3.0** datasource.
+
+### 5. Drain the 2.x ingesters
+
+With no new traffic arriving, the 2.x ingesters need to flush their in-memory
+traces to MinIO:
+
+```bash
+# Should drift toward 0:
+curl -s 'http://localhost:9090/api/v1/query?query=tempo_ingester_live_traces' | jq
+curl -s 'http://localhost:9090/api/v1/query?query=tempo_ingester_flush_queue_length' | jq
+```
+
+With this example's `max_block_duration: 5m` and default `complete_block_timeout`,
+the drain finishes in well under 20 minutes. (Real deployments take ~45 minutes
+with default settings.)
+
+### 6. Decommission v2 and re-enable v3 compaction
+
+Once the ingester is drained, scale v2 down:
+
+```bash
+docker compose stop \
+  tempo-v2-distributor \
+  tempo-v2-ingester \
+  tempo-v2-querier \
+  tempo-v2-query-frontend \
+  tempo-v2-compactor \
+  tempo-v2-metrics-generator
+```
+
+Now remove the `compaction_disabled` override from `tempo-v3.yaml`. Delete this
+block:
+
+```yaml
+    compaction:
+      compaction_disabled: true
+```
+
+…and restart the v3 components that read overrides:
+
+```bash
+docker compose restart \
+  tempo-v3-block-builder-0 tempo-v3-block-builder-1 \
+  tempo-v3-live-store-0 tempo-v3-live-store-1 \
+  tempo-v3-backend-scheduler tempo-v3-backend-worker \
+  tempo-v3-querier tempo-v3-query-frontend
+```
+
+The backend-worker should now start compacting any blocks left behind by the
+v2 ingesters plus new RF1 blocks from the block-builders. Watch:
+
+```bash
+docker compose logs -f tempo-v3-backend-worker | grep -i 'compact'
+```
+
+### 7. Verify the migration
+
+Mirrors the **Verify the migration** section of the doc:
+
+| Check                                        | Query                                                       |
+| -------------------------------------------- | ----------------------------------------------------------- |
+| Distributors writing to Kafka                | `rate(tempo_distributor_kafka_write_bytes_total[1m])`       |
+| Block-builders consuming, no errors          | `rate(tempo_block_builder_fetch_records_total[1m])` / `rate(tempo_block_builder_fetch_errors_total[1m])` |
+| Live-stores ready                            | `tempo_live_store_ready == 1`                               |
+| No dropped records                           | `tempo_live_store_records_dropped_total == 0`               |
+| Kafka lag healthy                            | `tempo_ingest_group_partition_lag_seconds`                  |
+| Historical queries work                      | TraceQL search via the **Tempo 3.0** datasource             |
+| Vulture sees no errors (10–15 min run)       | `tempo_vulture_trace_error_total == 0` and `tempo_vulture_trace_total` increasing |
+
+---
+
+## Roll back
+
+To revert during the parallel-deployment phase (steps 2–5):
+
+```bash
+ALLOY_OTLP_UPSTREAM=tempo-v2-distributor:4317 docker compose up -d alloy
+```
+
+Traffic flips back to v2 instantly. Stop the v3 stack with
+`docker compose --profile v3 down` if you want to abandon the migration.
+
+After step 6 there's no in-place rollback — you'd have to restart the v2 stack
+and replay everything from MinIO.
+
+## Tear down
+
+```bash
+docker compose --profile v2 --profile v3 down -v
+```
+
+The `-v` flag removes MinIO and Alloy data volumes.
+
+## Troubleshooting
+
+- **v3 live-store stuck "starting"** → Check Redpanda is up and the
+  `tempo-ingest` topic exists with 2 partitions: `docker compose exec redpanda
+  rpk topic describe tempo-ingest`.
+- **`grafana/tempo:latest` doesn't have 3.0 components** → The `latest` tag may
+  lag behind `main` for unreleased majors. Pin to a 3.0 RC tag explicitly in
+  `docker-compose.yaml`'s `x-tempo-v3-image` anchor.
+- **v3 queries return nothing for old traces** → Confirm v2 used vParquet4+
+  blocks (this example sets `storage.trace.block.version: vParquet4`).

--- a/example/docker-compose/migrate-to-3/config.alloy
+++ b/example/docker-compose/migrate-to-3/config.alloy
@@ -1,0 +1,22 @@
+otelcol.receiver.otlp "otlp_receiver" {
+  grpc {
+    endpoint = "0.0.0.0:4317"
+  }
+  http {
+    endpoint = "0.0.0.0:4318"
+  }
+
+  output {
+    traces = [otelcol.exporter.otlp.grafanacloud.input,]
+  }
+}
+
+otelcol.exporter.otlp "grafanacloud" {
+  client {
+    endpoint = env("ALLOY_OTLP_UPSTREAM")
+    tls {
+			insecure = true
+		}
+  }
+}
+

--- a/example/docker-compose/migrate-to-3/docker-compose.yaml
+++ b/example/docker-compose/migrate-to-3/docker-compose.yaml
@@ -294,6 +294,7 @@ services:
     hostname: tempo-v3-backend-worker
     depends_on:
       - minio
+      - tempo-v3-backend-scheduler
 
   tempo-v3-metrics-generator:
     image: *tempoV3Image

--- a/example/docker-compose/migrate-to-3/docker-compose.yaml
+++ b/example/docker-compose/migrate-to-3/docker-compose.yaml
@@ -179,9 +179,10 @@ services:
         until rpk cluster info --brokers redpanda:9092 2>/dev/null; do
           echo "Waiting for Redpanda..."; sleep 2
         done
-        rpk topic create tempo-ingest --partitions 1 --brokers redpanda:9092 || true
-        rpk topic add-partitions tempo-ingest --num 1 --brokers redpanda:9092 || true
-        echo "Topic tempo-ingest ready with 2 partitions."
+        # Idempotent: create with the desired partition count on first run;
+        # on subsequent runs the topic already exists and this is a no-op.
+        rpk topic create tempo-ingest --partitions 2 --brokers redpanda:9092 || true
+        echo "Topic tempo-ingest ready."
 
   redpanda-console:
     image: docker.redpanda.com/redpandadata/console:v3.5.0

--- a/example/docker-compose/migrate-to-3/docker-compose.yaml
+++ b/example/docker-compose/migrate-to-3/docker-compose.yaml
@@ -1,0 +1,325 @@
+# Docker Compose example for the Tempo 2.x -> 3.0 microservices migration.
+#
+# Layout:
+#   - "v2" profile: a Tempo 2.x microservices deployment (distributor, ingester,
+#     querier, query-frontend, compactor, metrics-generator).
+#   - "v3" profile: a Tempo 3.0 microservices deployment (distributor, live-store,
+#     block-builder, querier, query-frontend, backend-scheduler, backend-worker,
+#     metrics-generator) plus Redpanda for Kafka.
+#   - default (no profile): shared infrastructure (MinIO, Prometheus, Grafana,
+#     Alloy as the trace router, k6 trace generator).
+#
+# Both Tempo deployments share the same MinIO bucket, which is the whole point
+# of the parallel-deployment migration story.
+#
+# See README.md for the step-by-step playbook.
+
+x-tempo-v2-image: &tempoV2Image grafana/tempo:2.9.2
+x-tempo-v3-image: &tempoV3Image grafana/tempo:3.0.0-rc.1
+
+services:
+  # =========================================================================
+  # Shared infrastructure (always on)
+  # =========================================================================
+
+  minio:
+    image: minio/minio:latest
+    environment:
+      - MINIO_ACCESS_KEY=tempo
+      - MINIO_SECRET_KEY=supersecret
+    ports:
+      - "9001:9001"
+    entrypoint:
+      - sh
+      - -euc
+      - mkdir -p /data/tempo && minio server /data --console-address ':9001'
+
+  # The trace router. k6-tracing -> alloy -> distributor.
+  # To switch traffic between v2 and v3, edit the ALLOY_OTLP_UPSTREAM env var
+  # (in .env or inline) and `docker compose up -d alloy`.
+  alloy:
+    image: grafana/alloy:v1.16.0
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy
+    command:
+      - run
+      - /etc/alloy/config.alloy
+      - --storage.path=/var/lib/alloy/data
+      - --server.http.listen-addr=0.0.0.0:12345
+    environment:
+      - ALLOY_OTLP_UPSTREAM=${ALLOY_OTLP_UPSTREAM:-tempo-v2-distributor:4317}
+    ports:
+      - "12345:12345"
+
+  k6-tracing:
+    image: ghcr.io/grafana/xk6-client-tracing:v0.0.9
+    environment:
+      - ENDPOINT=alloy:4317
+    restart: always
+    depends_on:
+      - alloy
+
+  prometheus:
+    image: prom/prometheus:latest
+    command:
+      - --config.file=/etc/prometheus.yaml
+      - --web.enable-remote-write-receiver
+      - --enable-feature=exemplar-storage
+      - --enable-feature=native-histograms
+    volumes:
+      - ./prometheus.yaml:/etc/prometheus.yaml
+    ports:
+      - "9090:9090"
+
+  grafana:
+    image: grafana/grafana:13.0.1
+    volumes:
+      - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor metricsSummary
+    ports:
+      - "3000:3000"
+
+  # =========================================================================
+  # Tempo 2.x microservices (profile: v2)
+  # =========================================================================
+
+  tempo-v2-distributor:
+    image: *tempoV2Image
+    profiles: ["v2"]
+    command: "-target=distributor -config.file=/etc/tempo.yaml"
+    restart: always
+    volumes:
+      - ./tempo-v2.yaml:/etc/tempo.yaml
+    hostname: tempo-v2-distributor
+    depends_on:
+      - minio
+
+  tempo-v2-ingester:
+    image: *tempoV2Image
+    profiles: ["v2"]
+    command: "-target=ingester -config.file=/etc/tempo.yaml"
+    restart: always
+    volumes:
+      - ./tempo-v2.yaml:/etc/tempo.yaml
+    hostname: tempo-v2-ingester
+    depends_on:
+      - minio
+
+  tempo-v2-querier:
+    image: *tempoV2Image
+    profiles: ["v2"]
+    command: "-target=querier -config.file=/etc/tempo.yaml"
+    restart: always
+    volumes:
+      - ./tempo-v2.yaml:/etc/tempo.yaml
+    hostname: tempo-v2-querier
+    depends_on:
+      - minio
+
+  tempo-v2-query-frontend:
+    image: *tempoV2Image
+    profiles: ["v2"]
+    command: "-target=query-frontend -config.file=/etc/tempo.yaml"
+    restart: always
+    volumes:
+      - ./tempo-v2.yaml:/etc/tempo.yaml
+    hostname: tempo-v2-query-frontend
+    ports:
+      - "3200:3200" # query API for v2
+
+  tempo-v2-compactor:
+    image: *tempoV2Image
+    profiles: ["v2"]
+    command: "-target=compactor -config.file=/etc/tempo.yaml"
+    restart: always
+    volumes:
+      - ./tempo-v2.yaml:/etc/tempo.yaml
+    hostname: tempo-v2-compactor
+    depends_on:
+      - minio
+
+  tempo-v2-metrics-generator:
+    image: *tempoV2Image
+    profiles: ["v2"]
+    command: "-target=metrics-generator -config.file=/etc/tempo.yaml"
+    restart: always
+    volumes:
+      - ./tempo-v2.yaml:/etc/tempo.yaml
+    hostname: tempo-v2-metrics-generator
+    depends_on:
+      - prometheus
+
+  # =========================================================================
+  # Tempo 3.0 microservices (profile: v3)
+  # =========================================================================
+
+  redpanda:
+    image: redpandadata/redpanda:latest
+    profiles: ["v3"]
+    ports:
+      - "9092:9092"
+    command: >
+      redpanda start --overprovisioned
+      --mode=dev-container
+      --kafka-addr=PLAINTEXT://0.0.0.0:9092
+      --advertise-kafka-addr=PLAINTEXT://redpanda:9092
+
+  redpanda-init:
+    image: redpandadata/redpanda:latest
+    profiles: ["v3"]
+    depends_on:
+      - redpanda
+    entrypoint: ["/bin/bash", "-c"]
+    command:
+      - |
+        until rpk cluster info --brokers redpanda:9092 2>/dev/null; do
+          echo "Waiting for Redpanda..."; sleep 2
+        done
+        rpk topic create tempo-ingest --partitions 1 --brokers redpanda:9092 || true
+        rpk topic add-partitions tempo-ingest --num 1 --brokers redpanda:9092 || true
+        echo "Topic tempo-ingest ready with 2 partitions."
+
+  redpanda-console:
+    image: docker.redpanda.com/redpandadata/console:v3.5.0
+    profiles: ["v3"]
+    environment:
+      - CONFIG_FILEPATH=/etc/redpanda/redpanda-console-config.yaml
+    volumes:
+      - ./redpanda-console.yaml:/etc/redpanda/redpanda-console-config.yaml
+    ports:
+      - "8080:8080"
+    depends_on:
+      - redpanda
+
+  tempo-v3-distributor:
+    image: *tempoV3Image
+    profiles: ["v3"]
+    command: "-target=distributor -config.file=/etc/tempo.yaml"
+    restart: always
+    volumes:
+      - ./tempo-v3.yaml:/etc/tempo.yaml
+    hostname: tempo-v3-distributor
+    depends_on:
+      - redpanda
+      - minio
+
+  tempo-v3-live-store-0:
+    image: *tempoV3Image
+    profiles: ["v3"]
+    command: "-target=live-store -config.file=/etc/tempo.yaml -live-store.instance-availability-zone=zone-a"
+    restart: always
+    volumes:
+      - ./tempo-v3.yaml:/etc/tempo.yaml
+    hostname: tempo-v3-live-store-0
+    depends_on:
+      - redpanda
+
+  tempo-v3-live-store-1:
+    image: *tempoV3Image
+    profiles: ["v3"]
+    command: "-target=live-store -config.file=/etc/tempo.yaml -live-store.instance-availability-zone=zone-a"
+    restart: always
+    volumes:
+      - ./tempo-v3.yaml:/etc/tempo.yaml
+    hostname: tempo-v3-live-store-1
+    depends_on:
+      - redpanda
+
+  tempo-v3-block-builder-0:
+    image: *tempoV3Image
+    profiles: ["v3"]
+    command: "-target=block-builder -config.file=/etc/tempo.yaml"
+    restart: always
+    volumes:
+      - ./tempo-v3.yaml:/etc/tempo.yaml
+    hostname: tempo-v3-block-builder-0
+    depends_on:
+      - redpanda
+      - minio
+
+  tempo-v3-block-builder-1:
+    image: *tempoV3Image
+    profiles: ["v3"]
+    command: "-target=block-builder -config.file=/etc/tempo.yaml"
+    restart: always
+    volumes:
+      - ./tempo-v3.yaml:/etc/tempo.yaml
+    hostname: tempo-v3-block-builder-1
+    depends_on:
+      - redpanda
+      - minio
+
+  tempo-v3-querier:
+    image: *tempoV3Image
+    profiles: ["v3"]
+    command: "-target=querier -config.file=/etc/tempo.yaml"
+    restart: always
+    volumes:
+      - ./tempo-v3.yaml:/etc/tempo.yaml
+    hostname: tempo-v3-querier
+
+  tempo-v3-query-frontend:
+    image: *tempoV3Image
+    profiles: ["v3"]
+    command: "-target=query-frontend -config.file=/etc/tempo.yaml"
+    restart: always
+    volumes:
+      - ./tempo-v3.yaml:/etc/tempo.yaml
+    hostname: tempo-v3-query-frontend
+    ports:
+      - "3201:3200" # query API for v3
+
+  tempo-v3-backend-scheduler:
+    image: *tempoV3Image
+    profiles: ["v3"]
+    command: "-target=backend-scheduler -config.file=/etc/tempo.yaml"
+    restart: always
+    volumes:
+      - ./tempo-v3.yaml:/etc/tempo.yaml
+    hostname: tempo-v3-backend-scheduler
+    depends_on:
+      - minio
+
+  tempo-v3-backend-worker:
+    image: *tempoV3Image
+    profiles: ["v3"]
+    command: "-target=backend-worker -config.file=/etc/tempo.yaml"
+    restart: always
+    volumes:
+      - ./tempo-v3.yaml:/etc/tempo.yaml
+    hostname: tempo-v3-backend-worker
+    depends_on:
+      - minio
+
+  tempo-v3-metrics-generator:
+    image: *tempoV3Image
+    profiles: ["v3"]
+    command: "-target=metrics-generator -config.file=/etc/tempo.yaml"
+    restart: always
+    volumes:
+      - ./tempo-v3.yaml:/etc/tempo.yaml
+    hostname: tempo-v3-metrics-generator
+    depends_on:
+      - redpanda
+      - prometheus
+
+  # Tempo Vulture: synthetic write/read validator pointed at the v3 deployment.
+  # The migration guide recommends running Vulture for 10–15 minutes and
+  # confirming tempo_vulture_trace_mismatches_total stays at 0.
+  # Independent of the k6+alloy traffic above, which represents real app traces.
+  vulture:
+    image: grafana/tempo-vulture:latest
+    profiles: ["v3"]
+    restart: always
+    hostname: vulture
+    command:
+      - "-prometheus-listen-address=:8080"
+      - "-tempo-query-url=http://tempo-v3-query-frontend:3200"
+      - "-tempo-push-url=http://tempo-v3-distributor:4317"
+    depends_on:
+      - tempo-v3-distributor
+      - tempo-v3-query-frontend

--- a/example/docker-compose/migrate-to-3/docker-compose.yaml
+++ b/example/docker-compose/migrate-to-3/docker-compose.yaml
@@ -309,7 +309,7 @@ services:
 
   # Tempo Vulture: synthetic write/read validator pointed at the v3 deployment.
   # The migration guide recommends running Vulture for 10–15 minutes and
-  # confirming tempo_vulture_trace_mismatches_total stays at 0.
+  # confirming tempo_vulture_trace_error_total stays at 0.
   # Independent of the k6+alloy traffic above, which represents real app traces.
   vulture:
     image: grafana/tempo-vulture:latest

--- a/example/docker-compose/migrate-to-3/grafana-datasources.yaml
+++ b/example/docker-compose/migrate-to-3/grafana-datasources.yaml
@@ -1,0 +1,50 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    orgId: 1
+    url: http://prometheus:9090
+    basicAuth: false
+    isDefault: false
+    version: 1
+    editable: false
+    jsonData:
+      httpMethod: GET
+
+  - name: Tempo 2.x
+    type: tempo
+    uid: tempo-v2
+    access: proxy
+    orgId: 1
+    url: http://tempo-v2-query-frontend:3200
+    basicAuth: false
+    isDefault: false
+    version: 1
+    editable: false
+    apiVersion: 1
+    jsonData:
+      httpMethod: GET
+      serviceMap:
+        datasourceUid: prometheus
+
+  - name: Tempo 3.0
+    type: tempo
+    uid: tempo-v3
+    access: proxy
+    orgId: 1
+    url: http://tempo-v3-query-frontend:3200
+    basicAuth: false
+    isDefault: true
+    version: 1
+    editable: false
+    apiVersion: 1
+    jsonData:
+      httpMethod: GET
+      serviceMap:
+        datasourceUid: prometheus
+      streamingEnabled:
+        search: true
+        metrics: true

--- a/example/docker-compose/migrate-to-3/prometheus.yaml
+++ b/example/docker-compose/migrate-to-3/prometheus.yaml
@@ -1,0 +1,36 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'tempo-v2'
+    static_configs:
+      - targets:
+          - 'tempo-v2-distributor:3200'
+          - 'tempo-v2-ingester:3200'
+          - 'tempo-v2-querier:3200'
+          - 'tempo-v2-query-frontend:3200'
+          - 'tempo-v2-compactor:3200'
+          - 'tempo-v2-metrics-generator:3200'
+
+  - job_name: 'tempo-v3'
+    static_configs:
+      - targets:
+          - 'tempo-v3-distributor:3200'
+          - 'tempo-v3-live-store-0:3200'
+          - 'tempo-v3-live-store-1:3200'
+          - 'tempo-v3-block-builder-0:3200'
+          - 'tempo-v3-block-builder-1:3200'
+          - 'tempo-v3-querier:3200'
+          - 'tempo-v3-query-frontend:3200'
+          - 'tempo-v3-backend-scheduler:3200'
+          - 'tempo-v3-backend-worker:3200'
+          - 'tempo-v3-metrics-generator:3200'
+
+  - job_name: 'vulture'
+    static_configs:
+      - targets: ['vulture:8080']

--- a/example/docker-compose/migrate-to-3/redpanda-console.yaml
+++ b/example/docker-compose/migrate-to-3/redpanda-console.yaml
@@ -1,0 +1,3 @@
+kafka:
+  brokers:
+    - redpanda:9092

--- a/example/docker-compose/migrate-to-3/tempo-v2.yaml
+++ b/example/docker-compose/migrate-to-3/tempo-v2.yaml
@@ -1,0 +1,90 @@
+# Tempo 2.x microservices configuration.
+# Shared by all v2 components; each runs with -target=<role>.
+#
+# This is intentionally minimal: RF=1 with a single ingester. Real 2.x
+# deployments typically use RF=3, but the migration story (parallel deployment,
+# shared object storage, traffic switch) is identical.
+
+stream_over_http_enabled: true
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+        http:
+          endpoint: "0.0.0.0:4318"
+
+ingester:
+  trace_idle_period: 10s
+  max_block_bytes: 1_000_000
+  max_block_duration: 5m
+  lifecycler:
+    ring:
+      replication_factor: 1
+      kvstore:
+        store: memberlist
+
+memberlist:
+  cluster_label: tempo-v2
+  abort_if_cluster_join_fails: false
+  bind_port: 7946
+  join_members:
+    - tempo-v2-distributor:7946
+    - tempo-v2-ingester:7946
+    - tempo-v2-querier:7946
+    - tempo-v2-query-frontend:7946
+    - tempo-v2-compactor:7946
+    - tempo-v2-metrics-generator:7946
+
+compactor:
+  compaction:
+    block_retention: 1h
+  ring:
+    kvstore:
+      store: memberlist
+
+querier:
+  frontend_worker:
+    frontend_address: tempo-v2-query-frontend:9095
+
+metrics_generator:
+  ring:
+    kvstore:
+      store: memberlist
+  registry:
+    external_labels:
+      source: tempo
+      cluster: docker-compose-v2
+  storage:
+    path: /var/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true
+
+storage:
+  trace:
+    backend: s3
+    s3:
+      bucket: tempo
+      endpoint: minio:9000
+      access_key: tempo
+      secret_key: supersecret
+      insecure: true
+    wal:
+      path: /var/tempo/wal
+    block:
+      version: vParquet4 # Tempo 3.0 requires vParquet4+ to read these blocks.
+
+overrides:
+  defaults:
+    metrics_generator:
+      processors: ["span-metrics", "service-graphs"]
+      generate_native_histograms: both
+
+usage_report:
+  reporting_enabled: false

--- a/example/docker-compose/migrate-to-3/tempo-v3.yaml
+++ b/example/docker-compose/migrate-to-3/tempo-v3.yaml
@@ -1,0 +1,110 @@
+# Tempo 3.0 microservices configuration.
+# Shared by all v3 components; each runs with -target=<role>.
+#
+# Notes vs the 2.x config:
+#   - No `ingester:`, `compactor:`, `ingester_client:`, `metrics_generator_client:` blocks.
+#   - New `ingest:` block points at Redpanda/Kafka.
+#   - New `block_builder:` block with explicit partition assignments.
+#   - New `live_store:` and `backend_scheduler:`/`backend_worker:` blocks.
+#   - `compaction_disabled: true` is set in overrides for the parallel-deployment
+#     phase. REMOVE that override after the 2.x deployment is decommissioned
+#     (see step 6 in README.md).
+
+stream_over_http_enabled: true
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+        http:
+          endpoint: "0.0.0.0:4318"
+
+memberlist:
+  cluster_label: tempo-v3
+  abort_if_cluster_join_fails: false
+  bind_port: 7946
+  join_members:
+    - tempo-v3-live-store-0:7946
+    - tempo-v3-live-store-1:7946
+
+ingest:
+  kafka:
+    address: redpanda:9092
+    topic: tempo-ingest
+
+block_builder:
+  consume_cycle_duration: 30s
+  partitions_per_instance: 1
+
+live_store:
+  readiness_target_lag: 5s
+  # Lowered from the 5m default so this demo doesn't block for 5 minutes when
+  # the live-store starts against an empty Kafka topic (it has no record to use
+  # as a high-water mark, so it always waits the full max_wait). Real
+  # deployments should leave this at 5m.
+  readiness_max_wait: 30s
+
+backend_scheduler:
+  provider:
+    compaction:
+      compaction:
+        block_retention: 1h
+
+backend_worker:
+  backend_scheduler_addr: tempo-v3-backend-scheduler:3200
+  compaction:
+    block_retention: 1h
+  ring:
+    kvstore:
+      store: memberlist
+
+querier:
+  frontend_worker:
+    frontend_address: tempo-v3-query-frontend:9095
+
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+      cluster: docker-compose-v3
+  storage:
+    path: /var/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true
+
+storage:
+  trace:
+    backend: s3
+    # Lowered from the 5m default so newly-flushed v2 blocks become visible to
+    # the v3 querier within ~1m during this demo. Real deployments can leave
+    # this at 5m — v2 will have been running long enough that the lag is
+    # invisible.
+    blocklist_poll: 1m
+    s3:
+      bucket: tempo # SAME bucket as v2 -- shared object storage.
+      endpoint: minio:9000
+      access_key: tempo
+      secret_key: supersecret
+      insecure: true
+    wal:
+      path: /var/tempo/wal
+
+overrides:
+  defaults:
+    metrics_generator:
+      processors: ["span-metrics", "service-graphs"]
+      generate_native_histograms: both
+    # Disable compaction in 3.0 while v2 compactors are still running.
+    # Only one compaction system can safely write to shared storage at a time.
+    # Remove this block after step 6 in README.md (decommissioning v2).
+    compaction:
+      compaction_disabled: true
+
+usage_report:
+  reporting_enabled: false

--- a/example/docker-compose/migrate-to-3/tempo-v3.yaml
+++ b/example/docker-compose/migrate-to-3/tempo-v3.yaml
@@ -4,7 +4,7 @@
 # Notes vs the 2.x config:
 #   - No `ingester:`, `compactor:`, `ingester_client:`, `metrics_generator_client:` blocks.
 #   - New `ingest:` block points at Redpanda/Kafka.
-#   - New `block_builder:` block with explicit partition assignments.
+#   - New `block_builder:` block (one Kafka partition per replica).
 #   - New `live_store:` and `backend_scheduler:`/`backend_worker:` blocks.
 #   - `compaction_disabled: true` is set in overrides for the parallel-deployment
 #     phase. REMOVE that override after the 2.x deployment is decommissioned

--- a/example/docker-compose/migrate-to-3/tempo-v3.yaml
+++ b/example/docker-compose/migrate-to-3/tempo-v3.yaml
@@ -43,10 +43,10 @@ block_builder:
 
 live_store:
   readiness_target_lag: 5s
-  # Lowered from the 5m default so this demo doesn't block for 5 minutes when
-  # the live-store starts against an empty Kafka topic (it has no record to use
-  # as a high-water mark, so it always waits the full max_wait). Real
-  # deployments should leave this at 5m.
+  # Lowered from the 30m default so this demo doesn't block for a long time
+  # when the live-store starts against an empty Kafka topic (it has no record
+  # to use as a high-water mark, so it always waits the full max_wait). Real
+  # deployments can usually leave the default in place.
   readiness_max_wait: 30s
 
 backend_scheduler:

--- a/example/docker-compose/migrate-to-3/tempo-v3.yaml
+++ b/example/docker-compose/migrate-to-3/tempo-v3.yaml
@@ -56,7 +56,7 @@ backend_scheduler:
         block_retention: 1h
 
 backend_worker:
-  backend_scheduler_addr: tempo-v3-backend-scheduler:3200
+  backend_scheduler_addr: tempo-v3-backend-scheduler:9095
   compaction:
     block_retention: 1h
   ring:

--- a/modules/livestore/config.go
+++ b/modules/livestore/config.go
@@ -55,7 +55,7 @@ type Config struct {
 	// below this value. Set to 0 to disable readiness waiting (default, backward compatible).
 	ReadinessTargetLag time.Duration `yaml:"readiness_target_lag"`
 
-	// ReadinessMaxWait is the maximum time to wait for catching up a˛t startup.
+	// ReadinessMaxWait is the maximum time to wait for catching up at startup.
 	// If this timeout is exceeded, the live-store becomes ready anyway.
 	// Only used if ReadinessTargetLag > 0. Default: 30m.
 	ReadinessMaxWait time.Duration `yaml:"readiness_max_wait"`


### PR DESCRIPTION
**What this PR does**:

Adds a self-contained docker-compose example reproducing the Tempo 2.x → 3.0 microservices migration, plus small fixes to the migration doc surfaced while running the playbook end-to-end against it.

- **`example/docker-compose/migrate-to-3/`**: v2 + v3 stacks side by side (shared MinIO bucket, Redpanda for Kafka), Alloy as the trace router for one-line traffic switching, Vulture for end-to-end validation. README mirrors the doc's 7-step playbook.
- **`docs/.../migrate-to-3.md`**:
  - Fix Vulture metric name (`tempo_vulture_trace_mismatches_total` → `tempo_vulture_trace_error_total`; the former never existed).
  - Note that live-store readiness can take up to `readiness_max_wait` on a fresh deployment with an empty Kafka topic.
  - Replace "confirm all components are healthy" with an explicit pre-cutover checklist.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated (N/A — no code changes)
- [x] Documentation added
- [ ] `CHANGELOG.md` updated
