### PR TITLE
[jsonnet]: add KEDA autoscaling for live-store

### DIFF
--- a/operations/jsonnet-compiled/jsonnetfile.lock.json
+++ b/operations/jsonnet-compiled/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "7090c8d94f40e452ad906966c7de9add8c707eff",
+      "version": "e7a131e08a4c77ae42425dee1378f5fe87fd45f3",
       "sum": "0y3AFX9LQSpfWTxWKSwoLgbt0Wc9nnCwhMH2szKzHv0="
     },
     {
@@ -18,7 +18,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "7090c8d94f40e452ad906966c7de9add8c707eff",
+      "version": "e7a131e08a4c77ae42425dee1378f5fe87fd45f3",
       "sum": "zNTCDRaCqJUHjQSQRsxGR3jLrMP9tU7YNQb13dbm1bU="
     },
     {

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-block-builder.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-block-builder.yaml
@@ -15,9 +15,6 @@ spec:
     metadata:
       annotations:
         config_hash: 32561a7c801a4cc83b6f52f0f344dd19
-        grafana.com/rollout-mirror-replicas-from-resource-api-version: apps/v1
-        grafana.com/rollout-mirror-replicas-from-resource-kind: StatefulSet
-        grafana.com/rollout-mirror-replicas-from-resource-name: live-store-zone-a
       labels:
         app: block-builder
         name: block-builder

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-block-builder.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-block-builder.yaml
@@ -15,9 +15,6 @@ spec:
     metadata:
       annotations:
         config_hash: 35772ca8ace3c2f21537b08d1f875feb
-        grafana.com/rollout-mirror-replicas-from-resource-api-version: apps/v1
-        grafana.com/rollout-mirror-replicas-from-resource-kind: StatefulSet
-        grafana.com/rollout-mirror-replicas-from-resource-name: live-store-zone-a
       labels:
         app: block-builder
         name: block-builder

--- a/operations/jsonnet/microservices/autoscaling.libsonnet
+++ b/operations/jsonnet/microservices/autoscaling.libsonnet
@@ -78,16 +78,64 @@
       },
     },
 
-    // Block builder scales to match live-store zone-a pods via KEDA kubernetes-workload scaler.
-    // See: https://github.com/grafana/tempo/issues/6933
-    block_builder+: {
+    live_store+: {
       keda: {
         enabled: false,
         min_replicas: 1,
         max_replicas: 200,
         paused_replicas: 0,
+        // Time window (seconds) over which bytes written to Kafka are expected
+        // to be held in the live-store. Should be >= complete_block_timeout (20m
+        // default) plus any query_backend_after delay. Default: 30 minutes.
+        window_seconds: 30 * 60,
+        // Maximum bytes a single live-store pod is expected to hold over window_seconds.
+        // Expressed as ingest_rate_per_pod × window_seconds so the two knobs stay coupled:
+        //   default: 10 MB/s × 1800s ≈ 16 GiB per pod (observed production baseline)
+        // To tune for your environment, change the rate multiplier:
+        //   1 MB/s per pod  → 1 * 1000 * 1000 * self.window_seconds  (~1.7 GiB at 30m)
+        //   5 MB/s per pod  → 5 * 1000 * 1000 * self.window_seconds  (~8.4 GiB at 30m)
+        // Alternatively, set a literal byte value if you prefer to reason purely about
+        // total bytes held per pod (e.g. bytes_per_replica: 17 * 1024 * 1024 * 1024).
+        bytes_per_replica: 10 * 1000 * 1000 * self.window_seconds,
+        // Prometheus query returning total bytes expected to be held across all
+        // live-store pods. Measures the distributor (Kafka producer) side so that
+        // draining pods — which have abandoned their partitions but are still up
+        // for query — do not dilute the signal.
+        // When empty (default) the ScaledObject uses:
+        //   sum(rate(tempo_distributor_kafka_write_bytes_total{namespace="<ns>"}[10m])) * <window_seconds>
+        // Set to a non-empty string to replace this with a fully custom query.
+        query: '',
+        scale_up_stabilization_window_seconds: 60,
+        scale_up_pods: 2,
+        scale_up_period_seconds: 60,
+        // Minimum duration of sustained low load before KEDA issues a scale-down.
+        // Defaults to the live-store drain window (35m) so a load dip shorter than
+        // one full drain cycle cannot trigger a scale-down. Note: the drain itself
+        // runs after the signal, so total time from load drop to pod termination
+        // is roughly 2x this value.
+        scale_down_stabilization_window_seconds: 60 * 35,
+        scale_down_pods: 1,
+        scale_down_period_seconds: 60 * 5,
+        // Extra KEDA trigger objects appended after the default Prometheus trigger.
+        // Use this to inject environment-specific triggers (e.g. Kafka lag, CPU)
+        // from private config without requiring an upstream Jsonnet change.
+        // Each entry is a raw KEDA trigger object passed directly to withTriggersMixin.
+        additional_triggers: [],
+      },
+    },
+
+    // Block builder scales to match live-store zone-a pods via KEDA kubernetes-workload scaler.
+    block_builder+: {
+      keda: {
+        // Default to following live-store autoscaling so block-builder replicas
+        // stay coupled to live-store without separate configuration.
+        enabled: $._config.live_store.keda.enabled,
+        min_replicas: 1,
+        max_replicas: 200,
+        paused_replicas: 0,
         // Number of partitions each block-builder pod handles.
         // KEDA sets replicas = ceil(live-store-zone-a pods / partitions_per_instance).
+        // Defaults to 1 so block-builder replicas track live-store replicas 1:1.
         partitions_per_instance: 1,
         // Pod selector to count live-store zone-a pods.
         pod_selector: 'name=live-store-zone-a',
@@ -100,11 +148,6 @@
       },
     },
 
-    // Override block_builder_max_unavailable when block_builder autoscaling is enabled
-    // since the replica count is dynamic.
-    block_builder_max_unavailable:
-      if $._config.block_builder.keda.enabled then '100%'
-      else $.tempo_block_builder_statefulset.spec.replicas,
   },
 
   // Returns a KEDA Prometheus trigger using the shared autoscaling_prometheus_url and
@@ -246,6 +289,53 @@
       }])
     else {},
 
+  // Remove spec.replicas when KEDA manages block-builder directly, or when live-store KEDA
+  // is enabled and the rollout-operator mirrors the ReplicaTemplate count to block-builder.
   tempo_block_builder_statefulset+:
-    if $._config.block_builder.keda.enabled then $.removeReplicasFromSpec else {},
+    if $._config.block_builder.keda.enabled || $._config.live_store.keda.enabled
+    then $.removeReplicasFromSpec
+    else {},
+
+  //
+  // Live Store: Prometheus-based autoscaling on expected bytes held.
+  // Targets the ReplicaTemplate; the rollout-operator mirrors the replica count
+  // to both zone StatefulSets, which must not carry their own spec.replicas.
+  //
+  tempo_live_store_scaled_object:
+    if $._config.live_store.keda.enabled then
+      assert $._config.autoscaling_prometheus_url != '' : 'autoscaling_prometheus_url is required for live_store autoscaling';
+      local config = $._config.live_store.keda;
+      local query = if config.query != '' then config.query else
+        |||
+          sum(rate(tempo_distributor_kafka_write_bytes_total{namespace="%(namespace)s"}[10m])) * %(window_seconds)d
+        ||| % { namespace: $._config.namespace, window_seconds: config.window_seconds };
+      $.scaledObjectForController($.tempo_live_store_replica_template, 'live_store')
+      + scaledObject.spec.withTriggersMixin(
+        [
+          // metricType: Value → desiredReplicas = ceil(queryResult / threshold).
+          // The query returns total expected bytes across all pods, so we must use
+          // Value rather than the default AverageValue (which would multiply by
+          // currentReplicas and cause runaway scaling).
+          $.prometheusTrigger(
+            query=query,
+            metricName='tempo_live_store_expected_bytes',
+            threshold='%d' % config.bytes_per_replica,
+          ) + { metricType: 'Value' },
+        ] + config.additional_triggers
+      )
+    else {},
+
+  // When KEDA manages the live-store, omit spec.replicas from the ReplicaTemplate
+  // so that KEDA exclusively owns that field and Tanka apply does not fight it.
+  tempo_live_store_replica_template+:
+    if $._config.live_store.keda.enabled then {
+      spec+: { replicas+:: null },
+    } else {},
+
+  tempo_live_store_zone_a_statefulset+:
+    if $._config.live_store.keda.enabled then $.removeReplicasFromSpec else {},
+
+  tempo_live_store_zone_b_statefulset+:
+    if $._config.live_store.keda.enabled then $.removeReplicasFromSpec else {},
+
 }

--- a/operations/jsonnet/microservices/block-builder.libsonnet
+++ b/operations/jsonnet/microservices/block-builder.libsonnet
@@ -23,8 +23,6 @@
     'config.file': '/conf/tempo.yaml',
   },
 
-  tempo_block_builder_follow_controller:: $.tempo_live_store_zone_a_statefulset,
-
   tempo_block_builder_container::
     container.new(target_name, $._images.tempo_block_builder) +
     container.withPorts($.tempo_block_builder_ports) +
@@ -45,9 +43,6 @@
     statefulset.spec.template.spec.securityContext.withFsGroup(10001) +  // 10001 is the UID of the tempo user
     statefulset.mixin.spec.template.metadata.withAnnotations({
       config_hash: std.md5(std.toString($.tempo_block_builder_configmap.data['tempo.yaml'])),
-      'grafana.com/rollout-mirror-replicas-from-resource-name': $.tempo_block_builder_follow_controller.metadata.name,
-      'grafana.com/rollout-mirror-replicas-from-resource-kind': $.tempo_block_builder_follow_controller.kind,
-      'grafana.com/rollout-mirror-replicas-from-resource-api-version': $.tempo_block_builder_follow_controller.apiVersion,
     }) +
     statefulset.mixin.spec.template.spec.withVolumes([
       volume.fromConfigMap(tempo_config_volume, $.tempo_block_builder_configmap.metadata.name),

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -29,8 +29,8 @@
     // This feature modifies the block-builder StatefulSet which cannot be altered, so if it already exists it has to be deleted and re-applied again in order to be enabled.
     block_builder_concurrent_rollout_enabled: false,
     // Maximum number of unavailable replicas during a block-builder rollout when using block_builder_concurrent_rollout_enabled feature.
-    // Computed from block-builder replicas by default, but can also be specified as percentage, for example "25%".
-    block_builder_max_unavailable: $.tempo_block_builder_statefulset.spec.replicas,
+    // Defaults to 100% since block-builder pods are independent (each owns distinct Kafka partitions).
+    block_builder_max_unavailable: '100%',
 
     // disable tempo-query by default
     tempo_query: {

--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -89,9 +89,9 @@
 
   tempo_query_frontend_config:: $.tempo_config {},
   tempo_block_builder_config:: $.tempo_config + $.tempo_ingest_config + (
-    // When autoscaling is enabled, set partitions_per_instance to match the KEDA ratio
-    // so each block-builder pod consumes the correct number of partitions.
-    if $._config.block_builder.keda.enabled then {
+    // Inject partitions_per_instance when either KEDA scaler is managing block-builder
+    // replicas, since the pod count is then dynamic and must match the partition assignment.
+    if $._config.block_builder.keda.enabled || $._config.live_store.keda.enabled then {
       block_builder+: {
         partitions_per_instance: $._config.block_builder.keda.partitions_per_instance,
       },

--- a/operations/jsonnet/microservices/tempo.libsonnet
+++ b/operations/jsonnet/microservices/tempo.libsonnet
@@ -14,8 +14,8 @@
 (import 'memberlist.libsonnet') +
 (import 'vertical-pod-autoscaler.libsonnet') +
 (import 'pod-disruption-budget.libsonnet') +
-(import 'autoscaling.libsonnet') +
 (import 'rollout-operator/rollout-operator.libsonnet') +
+(import 'autoscaling.libsonnet') +
 
 {
   local k = import 'ksonnet-util/kausal.libsonnet',

--- a/operations/jsonnet/microservices/test/test1.jsonnet
+++ b/operations/jsonnet/microservices/test/test1.jsonnet
@@ -11,6 +11,15 @@ local withBackendWorkerKeda(url, tenant='') = default {
   },
 };
 
+// Helper: default env with live_store KEDA enabled and a given Prometheus URL/tenant.
+local withLiveStoreKeda(url, tenant='') = default {
+  _config+:: {
+    autoscaling_prometheus_url: url,
+    autoscaling_prometheus_tenant: tenant,
+    live_store+: { replicas: 1, keda+: { enabled: true } },
+  },
+};
+
 test.new(std.thisFile)
 + test.case.new(
   'Basic',
@@ -41,5 +50,130 @@ test.new(std.thisFile)
       'customHeaders'
     ),
     false
+  )
+)
++ test.case.new(
+  'live_store KEDA ScaledObject targets the ReplicaTemplate',
+  test.expect.eq(
+    withLiveStoreKeda('http://prometheus:9090').tempo_live_store_scaled_object.spec.scaleTargetRef.name,
+    'live-store'
+  )
+)
++ test.case.new(
+  'live_store KEDA ScaledObject scaleTargetRef kind is ReplicaTemplate',
+  test.expect.eq(
+    withLiveStoreKeda('http://prometheus:9090').tempo_live_store_scaled_object.spec.scaleTargetRef.kind,
+    'ReplicaTemplate'
+  )
+)
++ test.case.new(
+  'live_store KEDA Prometheus trigger uses autoscaling_prometheus_url',
+  test.expect.eq(
+    withLiveStoreKeda('http://prometheus:9090').tempo_live_store_scaled_object.spec.triggers[0].metadata.serverAddress,
+    'http://prometheus:9090'
+  )
+)
++ test.case.new(
+  'live_store KEDA Prometheus trigger includes X-Scope-OrgID header when tenant is set',
+  test.expect.eq(
+    withLiveStoreKeda('http://prometheus:9090', 'my-tenant').tempo_live_store_scaled_object.spec.triggers[0].metadata.customHeaders,
+    'X-Scope-OrgID=my-tenant'
+  )
+)
++ test.case.new(
+  'live_store KEDA Prometheus trigger omits customHeaders when tenant is empty',
+  test.expect.eq(
+    std.objectHas(
+      withLiveStoreKeda('http://prometheus:9090').tempo_live_store_scaled_object.spec.triggers[0].metadata,
+      'customHeaders'
+    ),
+    false
+  )
+)
++ test.case.new(
+  'live_store KEDA query embeds window_seconds from config',
+  test.expect.eq(
+    std.length(std.findSubstr(
+      '1800',
+      withLiveStoreKeda('http://prometheus:9090').tempo_live_store_scaled_object.spec.triggers[0].metadata.query,
+    )) > 0,
+    true
+  )
+)
++ test.case.new(
+  'live_store KEDA default query uses 10m rate window',
+  test.expect.eq(
+    std.length(std.findSubstr(
+      '[10m]',
+      withLiveStoreKeda('http://prometheus:9090').tempo_live_store_scaled_object.spec.triggers[0].metadata.query,
+    )) > 0,
+    true
+  )
+)
++ test.case.new(
+  'live_store KEDA additional_triggers are appended after the default trigger',
+  test.expect.eq(
+    (default {
+       _config+:: {
+         autoscaling_prometheus_url: 'http://prometheus:9090',
+         live_store+: {
+           replicas: 1,
+           keda+: {
+             enabled: true,
+             additional_triggers: [{ type: 'cpu', metricType: 'Utilization', metadata: { value: '80' } }],
+           },
+         },
+       },
+     }).tempo_live_store_scaled_object.spec.triggers[1],
+    { type: 'cpu', metricType: 'Utilization', metadata: { value: '80' } }
+  )
+)
++ test.case.new(
+  'live_store KEDA enabled removes spec.replicas from block-builder',
+  test.expect.eq(
+    std.objectHas(
+      withLiveStoreKeda('http://prometheus:9090').tempo_block_builder_statefulset.spec,
+      'replicas'
+    ),
+    false
+  )
+)
++ test.case.new(
+  'block_builder_max_unavailable defaults to 100%',
+  test.expect.eq(
+    default._config.block_builder_max_unavailable,
+    '100%'
+  )
+)
++ test.case.new(
+  'block_builder KEDA enabled defaults to live_store KEDA enabled',
+  test.expect.eq(
+    withLiveStoreKeda('http://prometheus:9090')._config.block_builder.keda.enabled,
+    true
+  )
+)
++ test.case.new(
+  'block_builder KEDA disabled when live_store KEDA disabled',
+  test.expect.eq(
+    default._config.block_builder.keda.enabled,
+    false
+  )
+)
++ test.case.new(
+  'live_store KEDA enabled injects partitions_per_instance into block-builder config',
+  test.expect.eq(
+    withLiveStoreKeda('http://prometheus:9090').tempo_block_builder_config.block_builder.partitions_per_instance,
+    1
+  )
+)
++ test.case.new(
+  'live_store KEDA disabled does not inject partitions_per_instance into block-builder config',
+  test.expect.eq(
+    std.get(
+      std.get(default.tempo_block_builder_config, 'block_builder', {}),
+      'partitions_per_instance',
+      null
+    ),
+    null
   )
 )


### PR DESCRIPTION
**What this PR does**:

Adds KEDA-based horizontal pod autoscaling for the live-store component in the microservices Jsonnet.

The scaler targets the `ReplicaTemplate` resource; the rollout-operator mirrors the replica count to both zone StatefulSets (zone-a and zone-b), which must not carry their own `spec.replicas`.

**Scaling signal**

The default trigger estimates total bytes held across all live-store pods from the Kafka write rate:

```
sum(rate(tempo_distributor_kafka_write_bytes_total{namespace="..."}[10m])) * window_seconds
```

This measures the distributor (producer) side of Kafka, not per-pod consumption, so draining pods during scale-down do not pollute the signal. The 10-minute rate window smooths over transient load dips to avoid triggering the scale-down stabilization clock prematurely.

KEDA uses `metricType: Value` so `replicas = ceil(query_result / bytes_per_replica)`, which scales based on total load rather than per-pod average.

**Scale-down and drain timing**

Live-store pods take ~35 minutes to drain after receiving a prepare-downscale call (partitions are abandoned immediately; pods remain live for query). The `scale_down_stabilization_window_seconds` defaults to 35 minutes, meaning KEDA requires sustained low load for 35 minutes before issuing a scale-down — decoupling the scale-down signal from short load fluctuations that occur during the drain window.

**Block-builder coupling**

When live-store KEDA is enabled, the block-builder StatefulSet has `spec.replicas` removed so the rollout-operator can mirror the ReplicaTemplate count to it directly. A separate block-builder KEDA ScaledObject is intentionally not provided here; the tight live-store → block-builder relationship is managed via the rollout-operator mirror annotation in deployment config.

**Config knobs** (all under `live_store.keda`):

| Field | Default | Description |
|---|---|---|
| `enabled` | `false` | Enable KEDA ScaledObject |
| `min_replicas` | `1` | Minimum pod count |
| `max_replicas` | `20` | Maximum pod count |
| `window_seconds` | `1800` | Retention window (s); should be >= `complete_block_timeout` + `query_backend_after` |
| `bytes_per_replica` | `10 MB/s × window_seconds` (~16 GiB) | Max bytes held per pod; expressed as rate × window so tuning is intuitive — change the `10 * 1000 * 1000` multiplier to match your per-pod throughput ceiling |
| `query` | `''` | Override the default Prometheus query entirely |
| `additional_triggers` | `[]` | Raw KEDA trigger objects appended after the default trigger (CPU, Kafka lag, etc.) without requiring an upstream change |
| `scale_down_stabilization_window_seconds` | `2100` (35m) | Hold peak replica count until sustained low load is confirmed |

**Which issue(s) this PR fixes**:
Fixes #6933

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`