### PR TITLE
Autoresearch metrics generator cpu mem

### DIFF
--- a/.chloggen/metrics-generator-performance.yaml
+++ b/.chloggen/metrics-generator-performance.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: metrics-generator
+note: Reduce CPU and memory allocations in metrics-generator span metrics, service graphs, and registry hot paths.
+issues: [7124]
+subtext:
+user: carles-grafana

--- a/modules/generator/generator_benchmark_test.go
+++ b/modules/generator/generator_benchmark_test.go
@@ -32,7 +32,7 @@ func BenchmarkPushSpansConfigurations(b *testing.B) {
 			overrides: func(o *mockOverrides) {
 				o.processors = map[string]struct{}{processor.SpanMetricsName: {}}
 			},
-			request: benchmarkGeneratorRequest(4, 100, false),
+			request: benchmarkGeneratorRequest(4, false),
 		},
 		{
 			name: "spanmetrics_target_info",
@@ -41,7 +41,7 @@ func BenchmarkPushSpansConfigurations(b *testing.B) {
 				o.spanMetricsEnableTargetInfo = boolPtr(true)
 				o.spanMetricsTargetInfoExcludedDimensions = []string{"excluded"}
 			},
-			request: benchmarkGeneratorRequest(4, 100, false),
+			request: benchmarkGeneratorRequest(4, false),
 		},
 		{
 			name: "spanmetrics_target_info_all_filtered",
@@ -59,7 +59,7 @@ func BenchmarkPushSpansConfigurations(b *testing.B) {
 					},
 				}}
 			},
-			request: benchmarkGeneratorRequest(4, 100, false),
+			request: benchmarkGeneratorRequest(4, false),
 		},
 		{
 			name: "spanmetrics_dimensions",
@@ -70,14 +70,14 @@ func BenchmarkPushSpansConfigurations(b *testing.B) {
 					{Name: "route_key", SourceLabel: []string{"http.method", "http.route", "http.status_code"}, Join: ":"},
 				}
 			},
-			request: benchmarkGeneratorRequest(4, 100, false),
+			request: benchmarkGeneratorRequest(4, false),
 		},
 		{
 			name: "servicegraphs_default",
 			overrides: func(o *mockOverrides) {
 				o.processors = map[string]struct{}{processor.ServiceGraphsName: {}}
 			},
-			request: benchmarkGeneratorRequest(2, 100, true),
+			request: benchmarkGeneratorRequest(2, true),
 		},
 		{
 			name: "servicegraphs_span_multiplier",
@@ -93,7 +93,7 @@ func BenchmarkPushSpansConfigurations(b *testing.B) {
 				o.processors = map[string]struct{}{processor.SpanMetricsName: {}}
 				benchmarkGeneratorProdOverrides(o)
 			},
-			request: benchmarkGeneratorProdRequest(4, 100, false),
+			request: benchmarkGeneratorProdRequest(4, false),
 		},
 		{
 			name: "servicegraphs_prod_7dims_prefix",
@@ -101,7 +101,7 @@ func BenchmarkPushSpansConfigurations(b *testing.B) {
 				o.processors = map[string]struct{}{processor.ServiceGraphsName: {}}
 				benchmarkGeneratorProdOverrides(o)
 			},
-			request: benchmarkGeneratorProdRequest(2, 100, true),
+			request: benchmarkGeneratorProdRequest(2, true),
 		},
 		{
 			name: "combined_target_info",
@@ -110,7 +110,7 @@ func BenchmarkPushSpansConfigurations(b *testing.B) {
 				o.spanMetricsEnableTargetInfo = boolPtr(true)
 				o.spanMetricsTargetInfoExcludedDimensions = []string{"excluded"}
 			},
-			request: benchmarkGeneratorRequest(4, 100, true),
+			request: benchmarkGeneratorRequest(4, true),
 		},
 		{
 			name: "combined_native_histograms",
@@ -120,7 +120,7 @@ func BenchmarkPushSpansConfigurations(b *testing.B) {
 				o.spanMetricsTargetInfoExcludedDimensions = []string{"excluded"}
 				o.nativeHistograms = histograms.HistogramMethodBoth
 			},
-			request: benchmarkGeneratorRequest(4, 100, true),
+			request: benchmarkGeneratorRequest(4, true),
 		},
 		{
 			name: "combined_prod_7dims_target_info_servicegraphs_prefix_filters",
@@ -128,7 +128,7 @@ func BenchmarkPushSpansConfigurations(b *testing.B) {
 				o.processors = map[string]struct{}{processor.SpanMetricsName: {}, processor.ServiceGraphsName: {}}
 				benchmarkGeneratorProdOverrides(o)
 			},
-			request: benchmarkGeneratorProdRequest(4, 100, true),
+			request: benchmarkGeneratorProdRequest(4, true),
 		},
 		{
 			name: "combined_prod_7dims_native_histograms",
@@ -137,7 +137,7 @@ func BenchmarkPushSpansConfigurations(b *testing.B) {
 				benchmarkGeneratorProdOverrides(o)
 				o.nativeHistograms = histograms.HistogramMethodBoth
 			},
-			request: benchmarkGeneratorProdRequest(4, 100, true),
+			request: benchmarkGeneratorProdRequest(4, true),
 		},
 	} {
 		b.Run(tc.name, func(b *testing.B) {
@@ -363,7 +363,9 @@ func benchmarkGeneratorInstance(b *testing.B, tune func(*mockOverrides)) *instan
 	return inst
 }
 
-func benchmarkGeneratorRequest(resources int, spansPerResource int, includeServiceGraphPairs bool) *tempopb.PushSpansRequest {
+func benchmarkGeneratorRequest(resources int, includeServiceGraphPairs bool) *tempopb.PushSpansRequest {
+	const spansPerResource = 100
+
 	if includeServiceGraphPairs {
 		return benchmarkGeneratorServiceGraphRequest(resources*spansPerResource/2, false)
 	}
@@ -426,7 +428,9 @@ func benchmarkGeneratorServiceGraphRequest(edges int, spanMultiplier bool) *temp
 	return &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{client, server}}
 }
 
-func benchmarkGeneratorProdRequest(resources int, spansPerResource int, includeServiceGraphPairs bool) *tempopb.PushSpansRequest {
+func benchmarkGeneratorProdRequest(resources int, includeServiceGraphPairs bool) *tempopb.PushSpansRequest {
+	const spansPerResource = 100
+
 	if includeServiceGraphPairs {
 		return benchmarkGeneratorProdServiceGraphRequest(resources * spansPerResource / 2)
 	}

--- a/modules/generator/generator_benchmark_test.go
+++ b/modules/generator/generator_benchmark_test.go
@@ -1,0 +1,682 @@
+package generator
+
+import (
+	"context"
+	"encoding/binary"
+	"flag"
+	"os"
+	"runtime"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/tempo/modules/generator/processor"
+	"github.com/grafana/tempo/modules/overrides/histograms"
+	"github.com/grafana/tempo/pkg/sharedconfig"
+	filterconfig "github.com/grafana/tempo/pkg/spanfilter/config"
+	"github.com/grafana/tempo/pkg/tempopb"
+	common_v1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	resource_v1 "github.com/grafana/tempo/pkg/tempopb/resource/v1"
+	trace_v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+)
+
+func BenchmarkPushSpansConfigurations(b *testing.B) {
+	for _, tc := range []struct {
+		name      string
+		overrides func(*mockOverrides)
+		request   *tempopb.PushSpansRequest
+	}{
+		{
+			name: "spanmetrics_default",
+			overrides: func(o *mockOverrides) {
+				o.processors = map[string]struct{}{processor.SpanMetricsName: {}}
+			},
+			request: benchmarkGeneratorRequest(4, 100, false),
+		},
+		{
+			name: "spanmetrics_target_info",
+			overrides: func(o *mockOverrides) {
+				o.processors = map[string]struct{}{processor.SpanMetricsName: {}}
+				o.spanMetricsEnableTargetInfo = boolPtr(true)
+				o.spanMetricsTargetInfoExcludedDimensions = []string{"excluded"}
+			},
+			request: benchmarkGeneratorRequest(4, 100, false),
+		},
+		{
+			name: "spanmetrics_target_info_all_filtered",
+			overrides: func(o *mockOverrides) {
+				o.processors = map[string]struct{}{processor.SpanMetricsName: {}}
+				o.spanMetricsEnableTargetInfo = boolPtr(true)
+				o.spanMetricsTargetInfoExcludedDimensions = []string{"excluded"}
+				o.spanMetricsFilterPolicies = []filterconfig.FilterPolicy{{
+					Exclude: &filterconfig.PolicyMatch{
+						MatchType: filterconfig.Strict,
+						Attributes: []filterconfig.MatchPolicyAttribute{{
+							Key:   "span.http.method",
+							Value: "GET",
+						}},
+					},
+				}}
+			},
+			request: benchmarkGeneratorRequest(4, 100, false),
+		},
+		{
+			name: "spanmetrics_dimensions",
+			overrides: func(o *mockOverrides) {
+				o.processors = map[string]struct{}{processor.SpanMetricsName: {}}
+				o.spanMetricsDimensions = []string{"k8s.cluster.name", "k8s.namespace.name", "http.method", "http.status_code"}
+				o.spanMetricsDimensionMappings = []sharedconfig.DimensionMappings{
+					{Name: "route_key", SourceLabel: []string{"http.method", "http.route", "http.status_code"}, Join: ":"},
+				}
+			},
+			request: benchmarkGeneratorRequest(4, 100, false),
+		},
+		{
+			name: "servicegraphs_default",
+			overrides: func(o *mockOverrides) {
+				o.processors = map[string]struct{}{processor.ServiceGraphsName: {}}
+			},
+			request: benchmarkGeneratorRequest(2, 100, true),
+		},
+		{
+			name: "servicegraphs_span_multiplier",
+			overrides: func(o *mockOverrides) {
+				o.processors = map[string]struct{}{processor.ServiceGraphsName: {}}
+				o.serviceGraphsSpanMultiplierKey = "sample.rate"
+			},
+			request: benchmarkGeneratorServiceGraphRequest(100, true),
+		},
+		{
+			name: "spanmetrics_prod_7dims_target_info_filters",
+			overrides: func(o *mockOverrides) {
+				o.processors = map[string]struct{}{processor.SpanMetricsName: {}}
+				benchmarkGeneratorProdOverrides(o)
+			},
+			request: benchmarkGeneratorProdRequest(4, 100, false),
+		},
+		{
+			name: "servicegraphs_prod_7dims_prefix",
+			overrides: func(o *mockOverrides) {
+				o.processors = map[string]struct{}{processor.ServiceGraphsName: {}}
+				benchmarkGeneratorProdOverrides(o)
+			},
+			request: benchmarkGeneratorProdRequest(2, 100, true),
+		},
+		{
+			name: "combined_target_info",
+			overrides: func(o *mockOverrides) {
+				o.processors = map[string]struct{}{processor.SpanMetricsName: {}, processor.ServiceGraphsName: {}}
+				o.spanMetricsEnableTargetInfo = boolPtr(true)
+				o.spanMetricsTargetInfoExcludedDimensions = []string{"excluded"}
+			},
+			request: benchmarkGeneratorRequest(4, 100, true),
+		},
+		{
+			name: "combined_native_histograms",
+			overrides: func(o *mockOverrides) {
+				o.processors = map[string]struct{}{processor.SpanMetricsName: {}, processor.ServiceGraphsName: {}}
+				o.spanMetricsEnableTargetInfo = boolPtr(true)
+				o.spanMetricsTargetInfoExcludedDimensions = []string{"excluded"}
+				o.nativeHistograms = histograms.HistogramMethodBoth
+			},
+			request: benchmarkGeneratorRequest(4, 100, true),
+		},
+		{
+			name: "combined_prod_7dims_target_info_servicegraphs_prefix_filters",
+			overrides: func(o *mockOverrides) {
+				o.processors = map[string]struct{}{processor.SpanMetricsName: {}, processor.ServiceGraphsName: {}}
+				benchmarkGeneratorProdOverrides(o)
+			},
+			request: benchmarkGeneratorProdRequest(4, 100, true),
+		},
+		{
+			name: "combined_prod_7dims_native_histograms",
+			overrides: func(o *mockOverrides) {
+				o.processors = map[string]struct{}{processor.SpanMetricsName: {}, processor.ServiceGraphsName: {}}
+				benchmarkGeneratorProdOverrides(o)
+				o.nativeHistograms = histograms.HistogramMethodBoth
+			},
+			request: benchmarkGeneratorProdRequest(4, 100, true),
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			inst := benchmarkGeneratorInstance(b, tc.overrides)
+			defer inst.shutdown()
+
+			ctx := context.Background()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				inst.pushSpans(ctx, tc.request)
+			}
+		})
+	}
+}
+
+func BenchmarkPushSpansProductionCardinality(b *testing.B) {
+	for _, tc := range []struct {
+		name       string
+		overrides  func(*mockOverrides)
+		seed       func(context.Context, *instance)
+		request    *tempopb.PushSpansRequest
+		requireEnv string
+	}{
+		{
+			name: "spanmetrics_prod_7dims_100k_series_steady",
+			overrides: func(o *mockOverrides) {
+				o.processors = map[string]struct{}{processor.SpanMetricsName: {}}
+				benchmarkGeneratorProdOverrides(o)
+			},
+			seed: func(ctx context.Context, inst *instance) {
+				benchmarkGeneratorSeedHighCardinalitySpanmetrics(ctx, inst, benchmarkGeneratorProdSpanmetrics100kResources)
+			},
+			request: benchmarkGeneratorProdHighCardinalitySpanmetricsRequest(0, benchmarkGeneratorHighCardinalityTimedResources),
+		},
+		{
+			name: "servicegraphs_prod_7dims_100k_series_steady",
+			overrides: func(o *mockOverrides) {
+				o.processors = map[string]struct{}{processor.ServiceGraphsName: {}}
+				benchmarkGeneratorProdOverrides(o)
+			},
+			seed: func(ctx context.Context, inst *instance) {
+				benchmarkGeneratorSeedHighCardinalityServiceGraph(ctx, inst, benchmarkGeneratorProdServiceGraphs100kEdges)
+			},
+			request: benchmarkGeneratorProdHighCardinalityServiceGraphRequest(0, benchmarkGeneratorHighCardinalityTimedEdges),
+		},
+		{
+			name: "combined_prod_7dims_100k_series_steady",
+			overrides: func(o *mockOverrides) {
+				o.processors = map[string]struct{}{processor.SpanMetricsName: {}, processor.ServiceGraphsName: {}}
+				benchmarkGeneratorProdOverrides(o)
+			},
+			seed: func(ctx context.Context, inst *instance) {
+				benchmarkGeneratorSeedHighCardinalityServiceGraph(ctx, inst, benchmarkGeneratorProdCombined100kEdges)
+			},
+			request: benchmarkGeneratorProdHighCardinalityServiceGraphRequest(0, benchmarkGeneratorHighCardinalityTimedEdges),
+		},
+		{
+			name: "combined_prod_7dims_100k_series_native_steady",
+			overrides: func(o *mockOverrides) {
+				o.processors = map[string]struct{}{processor.SpanMetricsName: {}, processor.ServiceGraphsName: {}}
+				benchmarkGeneratorProdOverrides(o)
+				o.nativeHistograms = histograms.HistogramMethodBoth
+			},
+			seed: func(ctx context.Context, inst *instance) {
+				benchmarkGeneratorSeedHighCardinalityServiceGraph(ctx, inst, benchmarkGeneratorProdCombinedNative100kEdges)
+			},
+			request: benchmarkGeneratorProdHighCardinalityServiceGraphRequest(0, benchmarkGeneratorHighCardinalityTimedEdges),
+		},
+		{
+			name: "combined_prod_7dims_1m_series_steady",
+			overrides: func(o *mockOverrides) {
+				o.processors = map[string]struct{}{processor.SpanMetricsName: {}, processor.ServiceGraphsName: {}}
+				benchmarkGeneratorProdOverrides(o)
+			},
+			seed: func(ctx context.Context, inst *instance) {
+				benchmarkGeneratorSeedHighCardinalityServiceGraph(ctx, inst, benchmarkGeneratorProdCombined1MEdges)
+			},
+			request:    benchmarkGeneratorProdHighCardinalityServiceGraphRequest(0, benchmarkGeneratorHighCardinalityTimedEdges),
+			requireEnv: "TEMPO_GENERATOR_BENCH_1M",
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			if tc.requireEnv != "" && os.Getenv(tc.requireEnv) == "" {
+				b.Skipf("set %s=1 to run this high-cardinality benchmark", tc.requireEnv)
+			}
+
+			inst := benchmarkGeneratorInstance(b, tc.overrides)
+			defer inst.shutdown()
+
+			ctx := context.Background()
+			tc.seed(ctx, inst)
+			runtime.GC()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				inst.pushSpans(ctx, tc.request)
+			}
+		})
+	}
+}
+
+const (
+	// The 100k cases seed enough metric label sets to create roughly 100k active
+	// time series before timing steady-state updates.
+	benchmarkGeneratorProdSpanmetrics100kResources    = 5000
+	benchmarkGeneratorProdServiceGraphs100kEdges      = 2858
+	benchmarkGeneratorProdCombined100kEdges           = 1334
+	benchmarkGeneratorProdCombinedNative100kEdges     = 1266
+	benchmarkGeneratorProdCombined1MEdges             = 13334
+	benchmarkGeneratorHighCardinalityTimedResources   = 400
+	benchmarkGeneratorHighCardinalityTimedEdges       = 200
+	benchmarkGeneratorHighCardinalitySeedResourceSize = 500
+	benchmarkGeneratorHighCardinalitySeedEdgeSize     = 250
+)
+
+var benchmarkGeneratorProdDimensions = []string{
+	"cloud.availability_zone",
+	"cloud.region",
+	"deployment.environment",
+	"k8s.cluster.name",
+	"k8s.namespace.name",
+	"service.namespace",
+	"service.version",
+}
+
+var benchmarkGeneratorProdBuckets = []float64{
+	0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10,
+}
+
+var benchmarkGeneratorProdTargetInfoExcludedDimensions = []string{
+	"k8s.pod.start_time",
+	"os.description",
+	"os.type",
+	"process.command_args",
+	"process.executable.path",
+	"process.pid",
+	"process.runtime.description",
+	"process.runtime.name",
+	"process.runtime.version",
+}
+
+var benchmarkGeneratorProdPeerAttributes = []string{
+	"peer.service",
+	"db.namespace",
+	"db.name",
+	"db.system",
+	"db.system.name",
+	"messaging.system",
+	"db.url",
+	"server.address",
+	"net.peer.name",
+}
+
+var benchmarkGeneratorProdFilterPolicies = []filterconfig.FilterPolicy{
+	{
+		Include: &filterconfig.PolicyMatch{
+			MatchType: filterconfig.Regex,
+			Attributes: []filterconfig.MatchPolicyAttribute{{
+				Key:   "kind",
+				Value: "SPAN_KIND_(SERVER|CONSUMER|CLIENT|PRODUCER)",
+			}},
+		},
+	},
+	{
+		Exclude: &filterconfig.PolicyMatch{
+			MatchType: filterconfig.Strict,
+			Attributes: []filterconfig.MatchPolicyAttribute{
+				{Key: "kind", Value: "SPAN_KIND_SERVER"},
+				{Key: "span.url.path", Value: "/healthz"},
+			},
+		},
+	},
+	{
+		Exclude: &filterconfig.PolicyMatch{
+			MatchType: filterconfig.Strict,
+			Attributes: []filterconfig.MatchPolicyAttribute{
+				{Key: "kind", Value: "SPAN_KIND_SERVER"},
+				{Key: "span.url.path", Value: "/health"},
+			},
+		},
+	},
+	{
+		Exclude: &filterconfig.PolicyMatch{
+			MatchType: filterconfig.Strict,
+			Attributes: []filterconfig.MatchPolicyAttribute{{
+				Key:   "resource.span.metrics.skip",
+				Value: true,
+			}},
+		},
+	},
+}
+
+func benchmarkGeneratorProdOverrides(o *mockOverrides) {
+	o.spanMetricsDimensions = benchmarkGeneratorProdDimensions
+	o.spanMetricsEnableTargetInfo = boolPtr(true)
+	o.spanMetricsTargetInfoExcludedDimensions = benchmarkGeneratorProdTargetInfoExcludedDimensions
+	o.spanMetricsHistogramBuckets = benchmarkGeneratorProdBuckets
+	o.spanMetricsFilterPolicies = benchmarkGeneratorProdFilterPolicies
+
+	o.serviceGraphsDimensions = benchmarkGeneratorProdDimensions
+	o.serviceGraphsEnableClientServerPrefix = true
+	o.serviceGraphsPeerAttributes = benchmarkGeneratorProdPeerAttributes
+	o.serviceGraphsHistogramBuckets = benchmarkGeneratorProdBuckets
+}
+
+func benchmarkGeneratorInstance(b *testing.B, tune func(*mockOverrides)) *instance {
+	b.Helper()
+
+	cfg := &Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", &flag.FlagSet{})
+	cfg.MetricsIngestionSlack = 365 * 24 * time.Hour
+
+	o := &mockOverrides{}
+	o.ingestionSlack = 365 * 24 * time.Hour
+	tune(o)
+
+	inst, err := newInstance(cfg, "bench-tenant", o, &noopStorage{}, log.NewNopLogger())
+	if err != nil {
+		b.Fatal(err)
+	}
+	return inst
+}
+
+func benchmarkGeneratorRequest(resources int, spansPerResource int, includeServiceGraphPairs bool) *tempopb.PushSpansRequest {
+	if includeServiceGraphPairs {
+		return benchmarkGeneratorServiceGraphRequest(resources*spansPerResource/2, false)
+	}
+
+	req := &tempopb.PushSpansRequest{
+		Batches: make([]*trace_v1.ResourceSpans, 0, resources),
+	}
+	now := uint64(time.Now().UnixNano())
+	for r := 0; r < resources; r++ {
+		rs := benchmarkGeneratorResource("svc-"+strconv.Itoa(r), r)
+		for s := 0; s < spansPerResource; s++ {
+			rs.ScopeSpans[0].Spans = append(rs.ScopeSpans[0].Spans, benchmarkGeneratorSpan(
+				benchmarkGeneratorTraceID(r),
+				benchmarkGeneratorSpanID(r*spansPerResource+s+1),
+				nil,
+				trace_v1.Span_SPAN_KIND_SERVER,
+				now+uint64(s),
+			))
+		}
+		req.Batches = append(req.Batches, rs)
+	}
+	return req
+}
+
+func benchmarkGeneratorServiceGraphRequest(edges int, spanMultiplier bool) *tempopb.PushSpansRequest {
+	now := uint64(time.Now().UnixNano())
+	client := benchmarkGeneratorResource("client", 0)
+	server := benchmarkGeneratorResource("server", 1)
+	for i := 0; i < edges; i++ {
+		traceID := benchmarkGeneratorTraceID(i)
+		clientSpanID := benchmarkGeneratorSpanID(i*2 + 1)
+		client.ScopeSpans[0].Spans = append(client.ScopeSpans[0].Spans, benchmarkGeneratorSpan(
+			traceID,
+			clientSpanID,
+			nil,
+			trace_v1.Span_SPAN_KIND_CLIENT,
+			now+uint64(i),
+		))
+		if spanMultiplier {
+			client.ScopeSpans[0].Spans[len(client.ScopeSpans[0].Spans)-1].Attributes = append(
+				client.ScopeSpans[0].Spans[len(client.ScopeSpans[0].Spans)-1].Attributes,
+				benchmarkGeneratorDoubleAttr("sample.rate", 0.5),
+			)
+		}
+
+		server.ScopeSpans[0].Spans = append(server.ScopeSpans[0].Spans, benchmarkGeneratorSpan(
+			traceID,
+			benchmarkGeneratorSpanID(i*2+2),
+			clientSpanID,
+			trace_v1.Span_SPAN_KIND_SERVER,
+			now+uint64(i),
+		))
+		if spanMultiplier {
+			server.ScopeSpans[0].Spans[len(server.ScopeSpans[0].Spans)-1].Attributes = append(
+				server.ScopeSpans[0].Spans[len(server.ScopeSpans[0].Spans)-1].Attributes,
+				benchmarkGeneratorDoubleAttr("sample.rate", 0.5),
+			)
+		}
+	}
+	return &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{client, server}}
+}
+
+func benchmarkGeneratorProdRequest(resources int, spansPerResource int, includeServiceGraphPairs bool) *tempopb.PushSpansRequest {
+	if includeServiceGraphPairs {
+		return benchmarkGeneratorProdServiceGraphRequest(resources * spansPerResource / 2)
+	}
+
+	req := &tempopb.PushSpansRequest{
+		Batches: make([]*trace_v1.ResourceSpans, 0, resources),
+	}
+	now := uint64(time.Now().UnixNano())
+	for r := 0; r < resources; r++ {
+		rs := benchmarkGeneratorProdResource("svc-"+strconv.Itoa(r), r)
+		for s := 0; s < spansPerResource; s++ {
+			rs.ScopeSpans[0].Spans = append(rs.ScopeSpans[0].Spans, benchmarkGeneratorProdSpan(
+				benchmarkGeneratorTraceID(r),
+				benchmarkGeneratorSpanID(r*spansPerResource+s+1),
+				nil,
+				trace_v1.Span_SPAN_KIND_SERVER,
+				now+uint64(s),
+			))
+		}
+		req.Batches = append(req.Batches, rs)
+	}
+	return req
+}
+
+func benchmarkGeneratorProdServiceGraphRequest(edges int) *tempopb.PushSpansRequest {
+	now := uint64(time.Now().UnixNano())
+	client := benchmarkGeneratorProdResource("client", 0)
+	server := benchmarkGeneratorProdResource("server", 1)
+	for i := 0; i < edges; i++ {
+		traceID := benchmarkGeneratorTraceID(i)
+		clientSpanID := benchmarkGeneratorSpanID(i*2 + 1)
+		client.ScopeSpans[0].Spans = append(client.ScopeSpans[0].Spans, benchmarkGeneratorProdSpan(
+			traceID,
+			clientSpanID,
+			nil,
+			trace_v1.Span_SPAN_KIND_CLIENT,
+			now+uint64(i),
+		))
+
+		server.ScopeSpans[0].Spans = append(server.ScopeSpans[0].Spans, benchmarkGeneratorProdSpan(
+			traceID,
+			benchmarkGeneratorSpanID(i*2+2),
+			clientSpanID,
+			trace_v1.Span_SPAN_KIND_SERVER,
+			now+uint64(i),
+		))
+	}
+	return &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{client, server}}
+}
+
+func benchmarkGeneratorSeedHighCardinalitySpanmetrics(ctx context.Context, inst *instance, resources int) {
+	for start := 0; start < resources; start += benchmarkGeneratorHighCardinalitySeedResourceSize {
+		count := min(benchmarkGeneratorHighCardinalitySeedResourceSize, resources-start)
+		inst.pushSpans(ctx, benchmarkGeneratorProdHighCardinalitySpanmetricsRequest(start, count))
+	}
+}
+
+func benchmarkGeneratorSeedHighCardinalityServiceGraph(ctx context.Context, inst *instance, edges int) {
+	for start := 0; start < edges; start += benchmarkGeneratorHighCardinalitySeedEdgeSize {
+		count := min(benchmarkGeneratorHighCardinalitySeedEdgeSize, edges-start)
+		inst.pushSpans(ctx, benchmarkGeneratorProdHighCardinalityServiceGraphRequest(start, count))
+	}
+}
+
+func benchmarkGeneratorProdHighCardinalitySpanmetricsRequest(startResource, resources int) *tempopb.PushSpansRequest {
+	req := &tempopb.PushSpansRequest{
+		Batches: make([]*trace_v1.ResourceSpans, 0, resources),
+	}
+	now := uint64(time.Now().UnixNano())
+	for r := 0; r < resources; r++ {
+		idx := startResource + r
+		rs := benchmarkGeneratorProdResource("svc-"+strconv.Itoa(idx), idx)
+		rs.ScopeSpans[0].Spans = append(rs.ScopeSpans[0].Spans, benchmarkGeneratorProdSpan(
+			benchmarkGeneratorTraceID(idx),
+			benchmarkGeneratorSpanID(idx+1),
+			nil,
+			trace_v1.Span_SPAN_KIND_SERVER,
+			now+uint64(r),
+		))
+		req.Batches = append(req.Batches, rs)
+	}
+	return req
+}
+
+func benchmarkGeneratorProdHighCardinalityServiceGraphRequest(startEdge, edges int) *tempopb.PushSpansRequest {
+	req := &tempopb.PushSpansRequest{
+		Batches: make([]*trace_v1.ResourceSpans, 0, edges*2),
+	}
+	now := uint64(time.Now().UnixNano())
+	for i := 0; i < edges; i++ {
+		edge := startEdge + i
+		traceID := benchmarkGeneratorTraceID(edge)
+		clientSpanID := benchmarkGeneratorSpanID(edge*2 + 1)
+
+		client := benchmarkGeneratorProdResource("client-"+strconv.Itoa(edge), edge*2)
+		client.ScopeSpans[0].Spans = append(client.ScopeSpans[0].Spans, benchmarkGeneratorProdSpan(
+			traceID,
+			clientSpanID,
+			nil,
+			trace_v1.Span_SPAN_KIND_CLIENT,
+			now+uint64(i),
+		))
+		req.Batches = append(req.Batches, client)
+
+		server := benchmarkGeneratorProdResource("server-"+strconv.Itoa(edge), edge*2+1)
+		server.ScopeSpans[0].Spans = append(server.ScopeSpans[0].Spans, benchmarkGeneratorProdSpan(
+			traceID,
+			benchmarkGeneratorSpanID(edge*2+2),
+			clientSpanID,
+			trace_v1.Span_SPAN_KIND_SERVER,
+			now+uint64(i),
+		))
+		req.Batches = append(req.Batches, server)
+	}
+	return req
+}
+
+func benchmarkGeneratorResource(service string, idx int) *trace_v1.ResourceSpans {
+	return &trace_v1.ResourceSpans{
+		Resource: &resource_v1.Resource{
+			Attributes: []*common_v1.KeyValue{
+				benchmarkGeneratorStringAttr("service.name", service),
+				benchmarkGeneratorStringAttr("service.namespace", "ns-"+strconv.Itoa(idx%2)),
+				benchmarkGeneratorStringAttr("service.instance.id", "instance-"+strconv.Itoa(idx)),
+				benchmarkGeneratorStringAttr("k8s.cluster.name", "cluster-a"),
+				benchmarkGeneratorStringAttr("k8s.namespace.name", "namespace-"+strconv.Itoa(idx%4)),
+				benchmarkGeneratorStringAttr("k8s.pod.name", "pod-"+strconv.Itoa(idx)),
+				benchmarkGeneratorStringAttr("k8s.node.name", "node-"+strconv.Itoa(idx%8)),
+				benchmarkGeneratorStringAttr("telemetry.sdk.language", "go"),
+				benchmarkGeneratorStringAttr("telemetry.sdk.version", "1.0.0"),
+				benchmarkGeneratorStringAttr("excluded", "drop-me"),
+			},
+		},
+		ScopeSpans: []*trace_v1.ScopeSpans{{}},
+	}
+}
+
+func benchmarkGeneratorProdResource(service string, idx int) *trace_v1.ResourceSpans {
+	return &trace_v1.ResourceSpans{
+		Resource: &resource_v1.Resource{
+			Attributes: []*common_v1.KeyValue{
+				benchmarkGeneratorStringAttr("service.name", service),
+				benchmarkGeneratorStringAttr("service.namespace", "ns-"+strconv.Itoa(idx%2)),
+				benchmarkGeneratorStringAttr("service.instance.id", "instance-"+strconv.Itoa(idx)),
+				benchmarkGeneratorStringAttr("service.version", "1."+strconv.Itoa(idx%10)+".0"),
+				benchmarkGeneratorStringAttr("cloud.availability_zone", "zone-"+strconv.Itoa(idx%3)),
+				benchmarkGeneratorStringAttr("cloud.region", "region-"+strconv.Itoa(idx%4)),
+				benchmarkGeneratorStringAttr("deployment.environment", "prod"),
+				benchmarkGeneratorStringAttr("k8s.cluster.name", "cluster-a"),
+				benchmarkGeneratorStringAttr("k8s.namespace.name", "namespace-"+strconv.Itoa(idx%4)),
+				benchmarkGeneratorStringAttr("k8s.pod.name", "pod-"+strconv.Itoa(idx)),
+				benchmarkGeneratorStringAttr("k8s.node.name", "node-"+strconv.Itoa(idx%8)),
+				benchmarkGeneratorStringAttr("telemetry.sdk.language", "go"),
+				benchmarkGeneratorStringAttr("telemetry.sdk.version", "1.0.0"),
+				benchmarkGeneratorStringAttr("k8s.pod.start_time", "2026-05-07T00:00:00Z"),
+				benchmarkGeneratorStringAttr("os.description", "linux"),
+				benchmarkGeneratorStringAttr("os.type", "linux"),
+				benchmarkGeneratorStringAttr("process.command_args", "tempo"),
+				benchmarkGeneratorStringAttr("process.executable.path", "/tempo"),
+				benchmarkGeneratorStringAttr("process.pid", strconv.Itoa(1000+idx)),
+				benchmarkGeneratorStringAttr("process.runtime.description", "go"),
+				benchmarkGeneratorStringAttr("process.runtime.name", "go"),
+				benchmarkGeneratorStringAttr("process.runtime.version", "go1.24"),
+				benchmarkGeneratorBoolAttr("resource.span.metrics.skip", false),
+			},
+		},
+		ScopeSpans: []*trace_v1.ScopeSpans{{}},
+	}
+}
+
+func benchmarkGeneratorSpan(traceID []byte, spanID []byte, parentSpanID []byte, kind trace_v1.Span_SpanKind, start uint64) *trace_v1.Span {
+	return &trace_v1.Span{
+		TraceId:           traceID,
+		SpanId:            spanID,
+		ParentSpanId:      parentSpanID,
+		Name:              "GET /api/:id",
+		Kind:              kind,
+		StartTimeUnixNano: start,
+		EndTimeUnixNano:   start + uint64(50*time.Millisecond),
+		Status:            &trace_v1.Status{Code: trace_v1.Status_STATUS_CODE_OK},
+		Attributes: []*common_v1.KeyValue{
+			benchmarkGeneratorStringAttr("http.method", "GET"),
+			benchmarkGeneratorStringAttr("http.route", "/api/:id"),
+			benchmarkGeneratorStringAttr("http.status_code", "200"),
+			benchmarkGeneratorStringAttr("span.attr.1", "one"),
+			benchmarkGeneratorStringAttr("span.attr.2", "two"),
+			benchmarkGeneratorStringAttr("peer.service", "server"),
+		},
+	}
+}
+
+func benchmarkGeneratorProdSpan(traceID []byte, spanID []byte, parentSpanID []byte, kind trace_v1.Span_SpanKind, start uint64) *trace_v1.Span {
+	return &trace_v1.Span{
+		TraceId:           traceID,
+		SpanId:            spanID,
+		ParentSpanId:      parentSpanID,
+		Name:              "GET /api/:id",
+		Kind:              kind,
+		StartTimeUnixNano: start,
+		EndTimeUnixNano:   start + uint64(50*time.Millisecond),
+		Status:            &trace_v1.Status{Code: trace_v1.Status_STATUS_CODE_OK},
+		Attributes: []*common_v1.KeyValue{
+			benchmarkGeneratorStringAttr("http.method", "GET"),
+			benchmarkGeneratorStringAttr("http.route", "/api/:id"),
+			benchmarkGeneratorStringAttr("http.status_code", "200"),
+			benchmarkGeneratorStringAttr("span.url.path", "/api/:id"),
+			benchmarkGeneratorStringAttr("span.attr.1", "one"),
+			benchmarkGeneratorStringAttr("span.attr.2", "two"),
+			benchmarkGeneratorStringAttr("peer.service", "server"),
+			benchmarkGeneratorStringAttr("server.address", "server"),
+			benchmarkGeneratorStringAttr("net.peer.name", "server"),
+		},
+	}
+}
+
+func benchmarkGeneratorTraceID(i int) []byte {
+	var id [16]byte
+	binary.BigEndian.PutUint64(id[8:], uint64(i+1))
+	return id[:]
+}
+
+func benchmarkGeneratorSpanID(i int) []byte {
+	var id [8]byte
+	binary.BigEndian.PutUint64(id[:], uint64(i+1))
+	return id[:]
+}
+
+func benchmarkGeneratorStringAttr(key, value string) *common_v1.KeyValue {
+	return &common_v1.KeyValue{
+		Key: key,
+		Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{
+			StringValue: value,
+		}},
+	}
+}
+
+func benchmarkGeneratorBoolAttr(key string, value bool) *common_v1.KeyValue {
+	return &common_v1.KeyValue{
+		Key: key,
+		Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_BoolValue{
+			BoolValue: value,
+		}},
+	}
+}
+
+func benchmarkGeneratorDoubleAttr(key string, value float64) *common_v1.KeyValue {
+	return &common_v1.KeyValue{
+		Key: key,
+		Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_DoubleValue{
+			DoubleValue: value,
+		}},
+	}
+}

--- a/modules/generator/instance.go
+++ b/modules/generator/instance.go
@@ -25,7 +25,6 @@ import (
 	"github.com/grafana/tempo/modules/generator/storage"
 	"github.com/grafana/tempo/modules/generator/validation"
 	"github.com/grafana/tempo/pkg/tempopb"
-	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 
 	"go.uber.org/atomic"
 )
@@ -475,27 +474,28 @@ func (i *instance) preprocessSpans(req *tempopb.PushSpansRequest) {
 	spanCount := 0
 	expiredSpanCount := 0
 	ingestionSlackNano := i.ingestionSlackOverride.Load()
+	nowNano := time.Now().UnixNano()
+	maxTimePast := uint64(nowNano - ingestionSlackNano)
+	maxTimeFuture := uint64(nowNano + ingestionSlackNano)
 
 	for _, b := range req.Batches {
 		size += b.Size()
 		for _, ss := range b.ScopeSpans {
 			spanCount += len(ss.Spans)
 			// filter spans that have end time > max_age and end time more than 5 days in the future
-			newSpansArr := make([]*v1.Span, len(ss.Spans))
-			timeNow := time.Now()
-			maxTimePast := uint64(timeNow.UnixNano() - ingestionSlackNano)
-			maxTimeFuture := uint64(timeNow.UnixNano() + ingestionSlackNano)
+			spans := ss.Spans
 
 			index := 0
-			for _, span := range ss.Spans {
+			for _, span := range spans {
 				if span.EndTimeUnixNano >= maxTimePast && span.EndTimeUnixNano <= maxTimeFuture {
-					newSpansArr[index] = span
+					spans[index] = span
 					index++
 				} else {
 					expiredSpanCount++
 				}
 			}
-			ss.Spans = newSpansArr[0:index]
+			clear(spans[index:])
+			ss.Spans = spans[0:index]
 		}
 	}
 	i.updatePushMetrics(size, spanCount, expiredSpanCount)

--- a/modules/generator/overrides_test.go
+++ b/modules/generator/overrides_test.go
@@ -40,11 +40,15 @@ type mockOverrides struct {
 	serviceGraphsEnableTraceStateSpanMultiplier        *bool
 	spanMetricsSpanMultiplierKey                       string
 	spanMetricsEnableTraceStateSpanMultiplier          *bool
+	ingestionSlack                                     time.Duration
 }
 
 var _ metricsGeneratorOverrides = (*mockOverrides)(nil)
 
 func (m *mockOverrides) MetricsGeneratorIngestionSlack(string) time.Duration {
+	if m.ingestionSlack != 0 {
+		return m.ingestionSlack
+	}
 	return 30 * time.Second
 }
 

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -322,10 +322,9 @@ type clientEdgeUpdate struct {
 }
 
 func updateClientEdge(e *store.Edge, u clientEdgeUpdate) {
-	// TraceID must be an owned string. Earlier optimizations sliced it out of
-	// e.keyBuf via unsafe.String, but the histogram exemplar stores the string
-	// directly and the edge is recycled (with keyBuf preserved) once complete,
-	// so a borrowed substring would be silently overwritten before the next scrape.
+	// TraceID is forwarded to histogram exemplars (which keep the string after
+	// scrape) and the edge is recycled with its keyBuf preserved, so this must
+	// be a freshly owned string, not a substring of any pooled buffer.
 	e.TraceID = tempo_util.TraceIDToHexString(u.span.TraceId)
 	e.ConnectionType = u.connectionType
 	e.ClientService = u.svcName

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unsafe"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -93,8 +94,9 @@ type Processor struct {
 	serviceGraphRequestClientSecondsHistogram          registry.Histogram
 	serviceGraphRequestMessagingSystemSecondsHistogram registry.Histogram
 	serviceGraphConnectionInfo                         registry.Gauge
-	sanitizeCache                                      reclaimable.Cache[string, string]
+	dimensionLabels                                    []dimensionLabel
 	filter                                             *spanfilter.SpanFilter
+	usesSpanMultiplier                                 bool
 
 	filteredSpansCounter                prometheus.Counter
 	metricDroppedSpans                  prometheus.Counter
@@ -106,12 +108,35 @@ type Processor struct {
 	logger                              log.Logger
 }
 
+type dimensionLabel struct {
+	name        string
+	label       string
+	clientName  string
+	clientLabel string
+	serverName  string
+	serverLabel string
+}
+
 func New(cfg Config, tenant string, reg registry.Registry, logger log.Logger, filteredSpansCounter, invalidUTF8Counter prometheus.Counter) (gen.Processor, error) {
 	if cfg.EnableVirtualNodeLabel {
 		cfg.Dimensions = append(cfg.Dimensions, virtualNodeLabel)
 	}
 
 	sanitizeCache := reclaimable.New(validation.SanitizeLabelName, 10000)
+	dimensionLabels := make([]dimensionLabel, len(cfg.Dimensions))
+	for i, dim := range cfg.Dimensions {
+		clientName := "client_" + dim
+		serverName := "server_" + dim
+		dimensionLabels[i] = dimensionLabel{
+			name:        dim,
+			label:       sanitizeCache.Get(dim),
+			clientName:  clientName,
+			clientLabel: sanitizeCache.Get(clientName),
+			serverName:  serverName,
+			serverLabel: sanitizeCache.Get(serverName),
+		}
+	}
+
 	filter, err := spanfilter.NewSpanFilter(cfg.FilterPolicies)
 	if err != nil {
 		return nil, err
@@ -122,8 +147,9 @@ func New(cfg Config, tenant string, reg registry.Registry, logger log.Logger, fi
 		registry: reg,
 		closeCh:  make(chan struct{}, 1),
 
-		sanitizeCache: sanitizeCache,
-		filter:        filter,
+		dimensionLabels:    dimensionLabels,
+		filter:             filter,
+		usesSpanMultiplier: cfg.SpanMultiplierKey != "" || cfg.EnableTraceStateSpanMultiplier,
 
 		filteredSpansCounter:                filteredSpansCounter,
 		metricDroppedSpans:                  metricDroppedSpans.WithLabelValues(tenant),
@@ -212,44 +238,50 @@ func (p *Processor) consume(resourceSpans []*v1_trace.ResourceSpans) (err error)
 				}
 
 				connectionType := store.Unknown
-				spanMultiplier := processor_util.GetSpanMultiplier(p.Cfg.SpanMultiplierKey, span, rs.Resource, p.Cfg.EnableTraceStateSpanMultiplier)
+				spanMultiplier := 1.0
+				if p.usesSpanMultiplier {
+					spanMultiplier = processor_util.GetSpanMultiplier(p.Cfg.SpanMultiplierKey, span, rs.Resource, p.Cfg.EnableTraceStateSpanMultiplier)
+				}
 				switch span.Kind {
 				case v1_trace.Span_SPAN_KIND_PRODUCER:
 					// override connection type and continue processing as span kind client
 					connectionType = store.MessagingSystem
 					fallthrough
 				case v1_trace.Span_SPAN_KIND_CLIENT:
-					key := buildKey(hex.EncodeToString(span.TraceId), hex.EncodeToString(span.SpanId))
-					isNew, err = p.store.UpsertEdge(key, store.Client, func(e *store.Edge) {
-						e.TraceID = tempo_util.TraceIDToHexString(span.TraceId)
-						e.ConnectionType = connectionType
-						e.ClientService = svcName
-						e.ClientLatencySec = spanDurationSec(span)
-						e.ClientEndTimeUnixNano = span.EndTimeUnixNano
-						e.Failed = e.Failed || p.spanFailed(span)
-						p.upsertDimensions("client_", e.Dimensions, rs.Resource.Attributes, span.Attributes)
-						e.SpanMultiplier = spanMultiplier
-						p.upsertPeerNode(e, span.Attributes)
-						p.upsertDatabaseRequest(e, rs.Resource.Attributes, span)
-					})
+					isNew, err = store.UpsertEdgeFromBytesWith(p.store, span.TraceId, span.SpanId, store.Client, clientEdgeUpdate{
+						p:              p,
+						resourceAttr:   rs.Resource.Attributes,
+						span:           span,
+						svcName:        svcName,
+						connectionType: connectionType,
+						spanMultiplier: spanMultiplier,
+					}, updateClientEdge)
 
 				case v1_trace.Span_SPAN_KIND_CONSUMER:
 					// override connection type and continue processing as span kind server
 					connectionType = store.MessagingSystem
 					fallthrough
 				case v1_trace.Span_SPAN_KIND_SERVER:
-					key := buildKey(hex.EncodeToString(span.TraceId), hex.EncodeToString(span.ParentSpanId))
-					isNew, err = p.store.UpsertEdge(key, store.Server, func(e *store.Edge) {
-						e.TraceID = tempo_util.TraceIDToHexString(span.TraceId)
-						e.ConnectionType = connectionType
-						e.ServerService = svcName
-						e.ServerLatencySec = spanDurationSec(span)
-						e.ServerStartTimeUnixNano = span.StartTimeUnixNano
-						e.Failed = e.Failed || p.spanFailed(span)
-						p.upsertDimensions("server_", e.Dimensions, rs.Resource.Attributes, span.Attributes)
-						e.SpanMultiplier = spanMultiplier
-						p.upsertPeerNode(e, span.Attributes)
-					})
+					if len(span.ParentSpanId) == 0 {
+						isNew, err = store.UpsertEdgeFromBytesWith(p.store, span.TraceId, span.ParentSpanId, store.Server, serverEdgeUpdate{
+							p:              p,
+							resourceAttr:   rs.Resource.Attributes,
+							span:           span,
+							svcName:        svcName,
+							connectionType: connectionType,
+							spanMultiplier: spanMultiplier,
+							root:           true,
+						}, updateServerEdge)
+					} else {
+						isNew, err = store.UpsertEdgeFromBytesWith(p.store, span.TraceId, span.ParentSpanId, store.Server, serverEdgeUpdate{
+							p:              p,
+							resourceAttr:   rs.Resource.Attributes,
+							span:           span,
+							svcName:        svcName,
+							connectionType: connectionType,
+							spanMultiplier: spanMultiplier,
+						}, updateServerEdge)
+					}
 				}
 
 				switch {
@@ -280,13 +312,70 @@ func (p *Processor) consume(resourceSpans []*v1_trace.ResourceSpans) (err error)
 	return nil
 }
 
+type clientEdgeUpdate struct {
+	p              *Processor
+	resourceAttr   []*v1_common.KeyValue
+	span           *v1_trace.Span
+	svcName        string
+	connectionType store.ConnectionType
+	spanMultiplier float64
+}
+
+func updateClientEdge(e *store.Edge, u clientEdgeUpdate) {
+	// TraceID must be an owned string. Earlier optimizations sliced it out of
+	// e.keyBuf via unsafe.String, but the histogram exemplar stores the string
+	// directly and the edge is recycled (with keyBuf preserved) once complete,
+	// so a borrowed substring would be silently overwritten before the next scrape.
+	e.TraceID = tempo_util.TraceIDToHexString(u.span.TraceId)
+	e.ConnectionType = u.connectionType
+	e.ClientService = u.svcName
+	e.ClientLatencySec = spanDurationSec(u.span)
+	e.ClientEndTimeUnixNano = u.span.EndTimeUnixNano
+	e.Failed = e.Failed || u.p.spanFailed(u.span)
+	u.p.upsertDimensions("client_", e.Dimensions, u.resourceAttr, u.span.Attributes)
+	e.SpanMultiplier = u.spanMultiplier
+	u.p.upsertPeerNode(e, u.span.Attributes)
+	u.p.upsertDatabaseRequest(e, u.resourceAttr, u.span)
+}
+
+type serverEdgeUpdate struct {
+	p              *Processor
+	resourceAttr   []*v1_common.KeyValue
+	span           *v1_trace.Span
+	svcName        string
+	connectionType store.ConnectionType
+	spanMultiplier float64
+	root           bool
+}
+
+func updateServerEdge(e *store.Edge, u serverEdgeUpdate) {
+	if u.root {
+		e.TraceID = tempo_util.TraceIDToHexString(u.span.TraceId)
+	}
+	e.ConnectionType = u.connectionType
+	e.ServerService = u.svcName
+	e.ServerLatencySec = spanDurationSec(u.span)
+	e.ServerStartTimeUnixNano = u.span.StartTimeUnixNano
+	e.Failed = e.Failed || u.p.spanFailed(u.span)
+	u.p.upsertDimensions("server_", e.Dimensions, u.resourceAttr, u.span.Attributes)
+	e.SpanMultiplier = u.spanMultiplier
+	if u.root {
+		// PeerNode is only used for root server-span virtual-node inference.
+		u.p.upsertPeerNode(e, u.span.Attributes)
+	}
+}
+
 func (p *Processor) upsertDimensions(prefix string, m map[string]string, resourceAttr, spanAttr []*v1_common.KeyValue) {
-	for _, dim := range p.Cfg.Dimensions {
-		if v, ok := processor_util.FindAttributeValue(dim, resourceAttr, spanAttr); ok {
+	for _, dim := range p.dimensionLabels {
+		if v, ok := processor_util.FindAttributeValue(dim.name, resourceAttr, spanAttr); ok {
 			if p.Cfg.EnableClientServerPrefix {
-				m[prefix+dim] = v
+				if prefix == "client_" {
+					m[dim.clientName] = v
+				} else {
+					m[dim.serverName] = v
+				}
 			} else {
-				m[dim] = v
+				m[dim.name] = v
 			}
 		}
 	}
@@ -349,7 +438,7 @@ func (p *Processor) upsertDatabaseRequest(e *store.Edge, resourceAttr []*v1_comm
 	// Check for network.peer.address and network.peer.port.  Use port if it is present.
 	if host, ok := processor_util.FindAttributeValue(string(semconv.NetworkPeerAddressKey), resourceAttr, span.Attributes); ok {
 		if port, ok := processor_util.FindAttributeValue(string(semconv.NetworkPeerPortKey), resourceAttr, span.Attributes); ok {
-			e.ServerService = fmt.Sprintf("%s:%s", host, port)
+			e.ServerService = host + ":" + port
 			return
 		}
 		e.ServerService = host
@@ -372,45 +461,46 @@ func (p *Processor) onComplete(e *store.Edge) {
 	builder.Add("server", e.ServerService)
 	builder.Add("connection_type", string(e.ConnectionType))
 
-	for _, dimension := range p.Cfg.Dimensions {
+	for _, dimension := range p.dimensionLabels {
 		if p.Cfg.EnableClientServerPrefix {
 			if p.Cfg.EnableVirtualNodeLabel {
 				// leave the extra label for this feature as-is
-				if dimension == virtualNodeLabel {
-					builder.Add(virtualNodeLabel, e.Dimensions[dimension])
+				if dimension.name == virtualNodeLabel {
+					builder.Add(virtualNodeLabel, e.Dimensions[dimension.name])
 					continue
 				}
 			}
-			builder.Add(p.sanitizeCache.Get("client_"+dimension), e.Dimensions["client_"+dimension])
-			builder.Add(p.sanitizeCache.Get("server_"+dimension), e.Dimensions["server_"+dimension])
+			builder.Add(dimension.clientLabel, e.Dimensions[dimension.clientName])
+			builder.Add(dimension.serverLabel, e.Dimensions[dimension.serverName])
 		} else {
-			builder.Add(p.sanitizeCache.Get(dimension), e.Dimensions[dimension])
+			builder.Add(dimension.label, e.Dimensions[dimension.name])
 		}
 	}
 
-	registryLabelValues, validUTF8 := builder.CloseAndBuildLabels()
+	registryLabelValues, validUTF8 := builder.CloseAndBorrowLabels()
 	if !validUTF8 {
 		p.invalidUTF8Counter.Inc()
 		return
 	}
+	updateTimeMs := time.Now().UnixMilli()
 
 	if p.Cfg.Subprocessors[Request] {
-		p.serviceGraphRequestTotal.Inc(registryLabelValues, 1*e.SpanMultiplier)
+		p.serviceGraphRequestTotal.IncWithHashAt(registryLabelValues.Labels, registryLabelValues.Hash, 1*e.SpanMultiplier, updateTimeMs)
 		if e.Failed {
-			p.serviceGraphRequestFailedTotal.Inc(registryLabelValues, 1*e.SpanMultiplier)
+			p.serviceGraphRequestFailedTotal.IncWithHashAt(registryLabelValues.Labels, registryLabelValues.Hash, 1*e.SpanMultiplier, updateTimeMs)
 		}
 	}
 
 	if p.Cfg.Subprocessors[Latency] {
-		p.serviceGraphRequestServerSecondsHistogram.ObserveWithExemplar(registryLabelValues, e.ServerLatencySec, e.TraceID, e.SpanMultiplier)
-		p.serviceGraphRequestClientSecondsHistogram.ObserveWithExemplar(registryLabelValues, e.ClientLatencySec, e.TraceID, e.SpanMultiplier)
+		p.serviceGraphRequestServerSecondsHistogram.ObserveWithExemplarWithHashAt(registryLabelValues.Labels, registryLabelValues.Hash, e.ServerLatencySec, e.TraceID, e.SpanMultiplier, updateTimeMs)
+		p.serviceGraphRequestClientSecondsHistogram.ObserveWithExemplarWithHashAt(registryLabelValues.Labels, registryLabelValues.Hash, e.ClientLatencySec, e.TraceID, e.SpanMultiplier, updateTimeMs)
 
 		if p.Cfg.EnableMessagingSystemLatencyHistogram && e.ConnectionType == store.MessagingSystem {
 			messagingSystemLatencySec := unixNanosDiffSec(e.ClientEndTimeUnixNano, e.ServerStartTimeUnixNano)
 			if messagingSystemLatencySec == 0 {
 				level.Warn(p.logger).Log("msg", "producerSpanEndTime must be smaller than consumerSpanStartTime. maybe the peers clocks are not synced", "messagingSystemLatencySec", messagingSystemLatencySec, "traceID", e.TraceID)
 			} else {
-				p.serviceGraphRequestMessagingSystemSecondsHistogram.ObserveWithExemplar(registryLabelValues, messagingSystemLatencySec, e.TraceID, e.SpanMultiplier)
+				p.serviceGraphRequestMessagingSystemSecondsHistogram.ObserveWithExemplarWithHashAt(registryLabelValues.Labels, registryLabelValues.Hash, messagingSystemLatencySec, e.TraceID, e.SpanMultiplier, updateTimeMs)
 			}
 		}
 	}
@@ -418,8 +508,10 @@ func (p *Processor) onComplete(e *store.Edge) {
 	if p.Cfg.Subprocessors[ConnectionInfo] {
 		// Presence-only info metric: held at 1 while the edge is being observed.
 		// The series goes stale and is pruned once edges stop completing for this label set.
-		p.serviceGraphConnectionInfo.Set(registryLabelValues, 1)
+		p.serviceGraphConnectionInfo.Set(registryLabelValues.Labels, 1)
 	}
+
+	registryLabelValues.Release()
 }
 
 func (p *Processor) onExpire(e *store.Edge) {
@@ -471,7 +563,7 @@ func (p *Processor) onExpire(e *store.Edge) {
 
 func (p *Processor) addDroppedSpanSide(span *v1_trace.Span) {
 	if isClient(span.Kind) {
-		key := buildKey(hex.EncodeToString(span.TraceId), hex.EncodeToString(span.SpanId))
+		key := buildKeyFromBytes(span.TraceId, span.SpanId)
 		if p.store.AddDroppedSpanSide(key, store.Client) {
 			p.metricDroppedEdges.Inc()
 		}
@@ -484,7 +576,7 @@ func (p *Processor) addDroppedSpanSide(span *v1_trace.Span) {
 			return
 		}
 
-		key := buildKey(hex.EncodeToString(span.TraceId), hex.EncodeToString(span.ParentSpanId))
+		key := buildKeyFromBytes(span.TraceId, span.ParentSpanId)
 		if p.store.AddDroppedSpanSide(key, store.Server) {
 			p.metricDroppedEdges.Inc()
 		}
@@ -517,10 +609,20 @@ func spanDurationSec(span *v1_trace.Span) float64 {
 }
 
 func buildKey(k1, k2 string) string {
-	return fmt.Sprintf("%s-%s", k1, k2)
+	return k1 + "-" + k2
+}
+
+func buildKeyFromBytes(k1, k2 []byte) string {
+	k1Len := hex.EncodedLen(len(k1))
+	buf := make([]byte, k1Len+1+hex.EncodedLen(len(k2)))
+	hex.Encode(buf[:k1Len], k1)
+	buf[k1Len] = '-'
+	hex.Encode(buf[k1Len+1:], k2)
+	// The buffer is private and is not mutated after conversion.
+	return unsafe.String(unsafe.SliceData(buf), len(buf))
 }
 
 func parseKey(key string) (string, string) {
-	parts := strings.Split(key, "-")
-	return parts[0], parts[1]
+	traceID, spanID, _ := strings.Cut(key, "-")
+	return traceID, spanID
 }

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 	"time"
-	"unsafe"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -624,8 +623,7 @@ func buildKeyFromBytes(k1, k2 []byte) string {
 	hex.Encode(buf[:k1Len], k1)
 	buf[k1Len] = '-'
 	hex.Encode(buf[k1Len+1:], k2)
-	// The buffer is private and is not mutated after conversion.
-	return unsafe.String(unsafe.SliceData(buf), len(buf))
+	return string(buf)
 }
 
 func parseKey(key string) (string, string) {

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -357,15 +357,16 @@ func updateServerEdge(e *store.Edge, u serverEdgeUpdate) {
 	e.Failed = e.Failed || u.p.spanFailed(u.span)
 	u.p.upsertDimensions("server_", e.Dimensions, u.resourceAttr, u.span.Attributes)
 	e.SpanMultiplier = u.spanMultiplier
-	if u.root {
-		// PeerNode is only consumed by virtual-node inference in onExpire (see
-		// the e.PeerNode reads at the end of this file), which only fires for
-		// root server spans without a paired client. Non-root server spans
-		// always pair with a client edge that already set PeerNode if
-		// applicable, so calling upsertPeerNode here would only overwrite the
-		// client's value with a server-side attribute — a behavior change vs
-		// pre-optimization but only observable for non-root server spans that
-		// carry peer.* attributes (uncommon in OTel SDKs).
+	if u.root || u.svcName == "" {
+		// PeerNode is only read in onExpire: (1) root server edges without a
+		// client span use it to name the external client service, and (2)
+		// client-only edges (ServerService empty) use it to name the external
+		// server service. A non-root server span's peer attributes can reach
+		// read (2) only when its ServerService stays empty, i.e. the degenerate
+		// case of a present-but-empty service.name — hence the svcName check.
+		// For ordinary non-root server spans PeerNode is never read (onComplete
+		// ignores it and neither onExpire branch applies), so the attribute
+		// scan is skipped without observable behavior change.
 		u.p.upsertPeerNode(e, u.span.Attributes)
 	}
 }

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -359,7 +359,14 @@ func updateServerEdge(e *store.Edge, u serverEdgeUpdate) {
 	u.p.upsertDimensions("server_", e.Dimensions, u.resourceAttr, u.span.Attributes)
 	e.SpanMultiplier = u.spanMultiplier
 	if u.root {
-		// PeerNode is only used for root server-span virtual-node inference.
+		// PeerNode is only consumed by virtual-node inference in onExpire (see
+		// the e.PeerNode reads at the end of this file), which only fires for
+		// root server spans without a paired client. Non-root server spans
+		// always pair with a client edge that already set PeerNode if
+		// applicable, so calling upsertPeerNode here would only overwrite the
+		// client's value with a server-side attribute — a behavior change vs
+		// pre-optimization but only observable for non-root server spans that
+		// carry peer.* attributes (uncommon in OTel SDKs).
 		u.p.upsertPeerNode(e, u.span.Attributes)
 	}
 }

--- a/modules/generator/processor/servicegraphs/servicegraphs_benchmark_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_benchmark_test.go
@@ -1,0 +1,168 @@
+package servicegraphs
+
+import (
+	"context"
+	"encoding/binary"
+	"strconv"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/tempo/modules/generator/registry"
+	"github.com/grafana/tempo/pkg/tempopb"
+	common_v1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	resource_v1 "github.com/grafana/tempo/pkg/tempopb/resource/v1"
+	trace_v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func BenchmarkServiceGraphsPushSpansSynthetic(b *testing.B) {
+	for _, tc := range []struct {
+		name           string
+		tune           func(*Config)
+		spanMultiplier bool
+	}{
+		{name: "default"},
+		{
+			name: "dimensions",
+			tune: func(cfg *Config) {
+				cfg.Dimensions = []string{"beast", "god"}
+			},
+		},
+		{
+			name: "client_server_prefix",
+			tune: func(cfg *Config) {
+				cfg.Dimensions = []string{"beast", "god"}
+				cfg.EnableClientServerPrefix = true
+			},
+		},
+		{
+			name: "span_multiplier",
+			tune: func(cfg *Config) {
+				cfg.SpanMultiplierKey = "sample.rate"
+			},
+			spanMultiplier: true,
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			cfg := Config{}
+			cfg.RegisterFlagsAndApplyDefaults("", nil)
+			cfg.HistogramBuckets = []float64{0.04, 0.1, 1}
+			if tc.tune != nil {
+				tc.tune(&cfg)
+			}
+
+			p, err := New(
+				cfg,
+				"bench",
+				registry.NewTestRegistry(),
+				log.NewNopLogger(),
+				prometheus.NewCounter(prometheus.CounterOpts{}),
+				prometheus.NewCounter(prometheus.CounterOpts{}),
+			)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer p.Shutdown(context.Background())
+
+			req := benchmarkServiceGraphRequest(100, tc.spanMultiplier)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				p.PushSpans(context.Background(), req)
+			}
+		})
+	}
+}
+
+func benchmarkServiceGraphRequest(edges int, spanMultiplier bool) *tempopb.PushSpansRequest {
+	client := &trace_v1.ResourceSpans{
+		Resource: &resource_v1.Resource{Attributes: []*common_v1.KeyValue{
+			benchmarkSGStringAttr("service.name", "client"),
+			benchmarkSGStringAttr("beast", "manticore"),
+		}},
+		ScopeSpans: []*trace_v1.ScopeSpans{{}},
+	}
+	server := &trace_v1.ResourceSpans{
+		Resource: &resource_v1.Resource{Attributes: []*common_v1.KeyValue{
+			benchmarkSGStringAttr("service.name", "server"),
+			benchmarkSGStringAttr("god", "athena"),
+		}},
+		ScopeSpans: []*trace_v1.ScopeSpans{{}},
+	}
+
+	for i := 0; i < edges; i++ {
+		traceID := benchmarkSGTraceID(i)
+		clientSpanID := benchmarkSGSpanID(i*2 + 1)
+		client.ScopeSpans[0].Spans = append(client.ScopeSpans[0].Spans, &trace_v1.Span{
+			TraceId:           traceID,
+			SpanId:            clientSpanID,
+			Name:              "GET /api/:id",
+			Kind:              trace_v1.Span_SPAN_KIND_CLIENT,
+			StartTimeUnixNano: uint64(1_700_000_000_000_000_000 + i),
+			EndTimeUnixNano:   uint64(1_700_000_000_050_000_000 + i),
+			Status:            &trace_v1.Status{Code: trace_v1.Status_STATUS_CODE_OK},
+			Attributes: []*common_v1.KeyValue{
+				benchmarkSGStringAttr("peer.service", "server"),
+				benchmarkSGStringAttr("beast", "client-"+strconv.Itoa(i%4)),
+			},
+		})
+		if spanMultiplier {
+			client.ScopeSpans[0].Spans[len(client.ScopeSpans[0].Spans)-1].Attributes = append(
+				client.ScopeSpans[0].Spans[len(client.ScopeSpans[0].Spans)-1].Attributes,
+				benchmarkSGDoubleAttr("sample.rate", 0.5),
+			)
+		}
+
+		server.ScopeSpans[0].Spans = append(server.ScopeSpans[0].Spans, &trace_v1.Span{
+			TraceId:           traceID,
+			SpanId:            benchmarkSGSpanID(i*2 + 2),
+			ParentSpanId:      clientSpanID,
+			Name:              "GET /api/:id",
+			Kind:              trace_v1.Span_SPAN_KIND_SERVER,
+			StartTimeUnixNano: uint64(1_700_000_000_010_000_000 + i),
+			EndTimeUnixNano:   uint64(1_700_000_000_040_000_000 + i),
+			Status:            &trace_v1.Status{Code: trace_v1.Status_STATUS_CODE_OK},
+			Attributes: []*common_v1.KeyValue{
+				benchmarkSGStringAttr("god", "server-"+strconv.Itoa(i%4)),
+			},
+		})
+		if spanMultiplier {
+			server.ScopeSpans[0].Spans[len(server.ScopeSpans[0].Spans)-1].Attributes = append(
+				server.ScopeSpans[0].Spans[len(server.ScopeSpans[0].Spans)-1].Attributes,
+				benchmarkSGDoubleAttr("sample.rate", 0.5),
+			)
+		}
+	}
+
+	return &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{client, server}}
+}
+
+func benchmarkSGTraceID(i int) []byte {
+	var id [16]byte
+	binary.BigEndian.PutUint64(id[8:], uint64(i+1))
+	return id[:]
+}
+
+func benchmarkSGSpanID(i int) []byte {
+	var id [8]byte
+	binary.BigEndian.PutUint64(id[:], uint64(i+1))
+	return id[:]
+}
+
+func benchmarkSGStringAttr(key, value string) *common_v1.KeyValue {
+	return &common_v1.KeyValue{
+		Key: key,
+		Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{
+			StringValue: value,
+		}},
+	}
+}
+
+func benchmarkSGDoubleAttr(key string, value float64) *common_v1.KeyValue {
+	return &common_v1.KeyValue{
+		Key: key,
+		Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_DoubleValue{
+			DoubleValue: value,
+		}},
+	}
+}

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -1184,3 +1184,119 @@ func withLe(lbls labels.Labels, le float64) labels.Labels {
 	lb = lb.Set(labels.BucketLabel, strconv.FormatFloat(le, 'f', -1, 64))
 	return lb.Labels()
 }
+
+func makeServiceGraphBatch(svcName string, kind tracev1.Span_SpanKind, traceID, spanID, parentSpanID []byte, spanAttrs ...*v1.KeyValue) *tracev1.ResourceSpans {
+	return &tracev1.ResourceSpans{
+		Resource: &resourcev1.Resource{
+			Attributes: []*v1.KeyValue{
+				{
+					Key: "service.name",
+					Value: &v1.AnyValue{
+						Value: &v1.AnyValue_StringValue{StringValue: svcName},
+					},
+				},
+			},
+		},
+		ScopeSpans: []*tracev1.ScopeSpans{
+			{
+				Spans: []*tracev1.Span{
+					{
+						TraceId:           traceID,
+						SpanId:            spanID,
+						ParentSpanId:      parentSpanID,
+						Kind:              kind,
+						StartTimeUnixNano: 1,
+						EndTimeUnixNano:   2,
+						Attributes:        spanAttrs,
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestServiceGraphs_nonRootServerSpanPeerAttributesDoNotChangeSeries locks in
+// that peer attributes on an ordinary non-root server span do not influence
+// the emitted service graph series: the completed edge uses the client and
+// server service names, and the peer value surfaces nowhere.
+func TestServiceGraphs_nonRootServerSpanPeerAttributesDoNotChangeSeries(t *testing.T) {
+	testRegistry := registry.NewTestRegistry()
+
+	cfg := Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", nil)
+	cfg.Wait = time.Nanosecond
+
+	p, err := New(cfg, "test", testRegistry, log.NewNopLogger(), prometheus.NewCounter(prometheus.CounterOpts{}), prometheus.NewCounter(prometheus.CounterOpts{}))
+	require.NoError(t, err)
+	defer p.Shutdown(context.Background())
+
+	traceID := []byte{0x0a}
+	clientSpanID := []byte{0x0b}
+
+	peerAttr := &v1.KeyValue{
+		Key: string(semconv.PeerServiceKey),
+		Value: &v1.AnyValue{
+			Value: &v1.AnyValue_StringValue{StringValue: "external-peer"},
+		},
+	}
+
+	request := &tempopb.PushSpansRequest{
+		Batches: []*tracev1.ResourceSpans{
+			makeServiceGraphBatch("svc-a", tracev1.Span_SPAN_KIND_CLIENT, traceID, clientSpanID, nil),
+			makeServiceGraphBatch("svc-b", tracev1.Span_SPAN_KIND_SERVER, traceID, []byte{0x0c}, clientSpanID, peerAttr),
+		},
+	}
+
+	p.PushSpans(context.Background(), request)
+	p.(*Processor).store.Expire()
+
+	completedLabels := labels.FromMap(map[string]string{
+		"client": "svc-a",
+		"server": "svc-b",
+	})
+	assert.Equal(t, 1.0, testRegistry.Query("traces_service_graph_request_total", completedLabels))
+	assert.NotContains(t, testRegistry.String(), "external-peer")
+}
+
+// TestServiceGraphs_emptyServiceNameServerSpanInfersVirtualNodeFromPeer covers
+// the degenerate case where the server resource carries a present-but-empty
+// service.name: ServerService stays empty, the edge never completes, and on
+// expiry the server span's peer attribute names the external server service.
+func TestServiceGraphs_emptyServiceNameServerSpanInfersVirtualNodeFromPeer(t *testing.T) {
+	testRegistry := registry.NewTestRegistry()
+
+	cfg := Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", nil)
+	cfg.Wait = time.Nanosecond
+
+	p, err := New(cfg, "test", testRegistry, log.NewNopLogger(), prometheus.NewCounter(prometheus.CounterOpts{}), prometheus.NewCounter(prometheus.CounterOpts{}))
+	require.NoError(t, err)
+	defer p.Shutdown(context.Background())
+
+	traceID := []byte{0x1a}
+	clientSpanID := []byte{0x1b}
+
+	peerAttr := &v1.KeyValue{
+		Key: string(semconv.PeerServiceKey),
+		Value: &v1.AnyValue{
+			Value: &v1.AnyValue_StringValue{StringValue: "external-peer"},
+		},
+	}
+
+	request := &tempopb.PushSpansRequest{
+		Batches: []*tracev1.ResourceSpans{
+			makeServiceGraphBatch("svc-a", tracev1.Span_SPAN_KIND_CLIENT, traceID, clientSpanID, nil),
+			makeServiceGraphBatch("", tracev1.Span_SPAN_KIND_SERVER, traceID, []byte{0x1c}, clientSpanID, peerAttr),
+		},
+	}
+
+	p.PushSpans(context.Background(), request)
+	p.(*Processor).store.Expire()
+
+	virtualNodeLabels := labels.FromMap(map[string]string{
+		"client":          "svc-a",
+		"server":          "external-peer",
+		"connection_type": "virtual_node",
+	})
+	assert.Equal(t, 1.0, testRegistry.Query("traces_service_graph_request_total", virtualNodeLabels))
+}

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -1263,19 +1263,6 @@ func TestServiceGraphs_nonRootServerSpanPeerAttributesDoNotChangeSeries(t *testi
 // service.name: ServerService stays empty, the edge never completes, and on
 // expiry the server span's peer attribute names the external server service.
 func TestServiceGraphs_emptyServiceNameServerSpanInfersVirtualNodeFromPeer(t *testing.T) {
-	testRegistry := registry.NewTestRegistry()
-
-	cfg := Config{}
-	cfg.RegisterFlagsAndApplyDefaults("", nil)
-	cfg.Wait = time.Nanosecond
-
-	p, err := New(cfg, "test", testRegistry, log.NewNopLogger(), prometheus.NewCounter(prometheus.CounterOpts{}), prometheus.NewCounter(prometheus.CounterOpts{}))
-	require.NoError(t, err)
-	defer p.Shutdown(context.Background())
-
-	traceID := []byte{0x1a}
-	clientSpanID := []byte{0x1b}
-
 	peerAttr := &v1.KeyValue{
 		Key: string(semconv.PeerServiceKey),
 		Value: &v1.AnyValue{
@@ -1283,20 +1270,58 @@ func TestServiceGraphs_emptyServiceNameServerSpanInfersVirtualNodeFromPeer(t *te
 		},
 	}
 
-	request := &tempopb.PushSpansRequest{
-		Batches: []*tracev1.ResourceSpans{
-			makeServiceGraphBatch("svc-a", tracev1.Span_SPAN_KIND_CLIENT, traceID, clientSpanID, nil),
-			makeServiceGraphBatch("", tracev1.Span_SPAN_KIND_SERVER, traceID, []byte{0x1c}, clientSpanID, peerAttr),
+	traceID := []byte{0x1a}
+	clientSpanID := []byte{0x1b}
+	serverSpanID := []byte{0x1c}
+
+	tests := []struct {
+		name    string
+		batches []*tracev1.ResourceSpans
+	}{
+		{
+			name: "client before server",
+			batches: []*tracev1.ResourceSpans{
+				makeServiceGraphBatch("svc-a", tracev1.Span_SPAN_KIND_CLIENT, traceID, clientSpanID, nil),
+				makeServiceGraphBatch("", tracev1.Span_SPAN_KIND_SERVER, traceID, serverSpanID, clientSpanID, peerAttr),
+			},
+		},
+		{
+			name: "server before client",
+			batches: []*tracev1.ResourceSpans{
+				makeServiceGraphBatch("", tracev1.Span_SPAN_KIND_SERVER, traceID, serverSpanID, clientSpanID, peerAttr),
+				makeServiceGraphBatch("svc-a", tracev1.Span_SPAN_KIND_CLIENT, traceID, clientSpanID, nil),
+			},
+		},
+		{
+			name: "producer and consumer messaging spans",
+			batches: []*tracev1.ResourceSpans{
+				makeServiceGraphBatch("svc-a", tracev1.Span_SPAN_KIND_PRODUCER, traceID, clientSpanID, nil),
+				makeServiceGraphBatch("", tracev1.Span_SPAN_KIND_CONSUMER, traceID, serverSpanID, clientSpanID, peerAttr),
+			},
 		},
 	}
 
-	p.PushSpans(context.Background(), request)
-	p.(*Processor).store.Expire()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testRegistry := registry.NewTestRegistry()
 
-	virtualNodeLabels := labels.FromMap(map[string]string{
-		"client":          "svc-a",
-		"server":          "external-peer",
-		"connection_type": "virtual_node",
-	})
-	assert.Equal(t, 1.0, testRegistry.Query("traces_service_graph_request_total", virtualNodeLabels))
+			cfg := Config{}
+			cfg.RegisterFlagsAndApplyDefaults("", nil)
+			cfg.Wait = time.Nanosecond
+
+			p, err := New(cfg, "test", testRegistry, log.NewNopLogger(), prometheus.NewCounter(prometheus.CounterOpts{}), prometheus.NewCounter(prometheus.CounterOpts{}))
+			require.NoError(t, err)
+			defer p.Shutdown(context.Background())
+
+			p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: tt.batches})
+			p.(*Processor).store.Expire()
+
+			virtualNodeLabels := labels.FromMap(map[string]string{
+				"client":          "svc-a",
+				"server":          "external-peer",
+				"connection_type": "virtual_node",
+			})
+			assert.Equal(t, 1.0, testRegistry.Query("traces_service_graph_request_total", virtualNodeLabels))
+		})
+	}
 }

--- a/modules/generator/processor/servicegraphs/store/edge.go
+++ b/modules/generator/processor/servicegraphs/store/edge.go
@@ -11,9 +11,21 @@ const (
 	VirtualNode     ConnectionType = "virtual_node"
 )
 
-// Edge is an Edge between two nodes in the graph
+// Edge is an Edge between two nodes in the graph.
+//
+// Edges are pool-allocated and pointers handed to update/onComplete/onExpire
+// callbacks are only valid for the duration of the callback — the store may
+// recycle the Edge after the callback returns. Do not retain *Edge or any
+// substrings of its fields past the callback.
 type Edge struct {
-	key string
+	// key is unsafe.String aliased over keyBuf and is only valid while the
+	// Edge is in the store's map. keyBuf is preserved across pool recycles
+	// and overwritten on the next grabEdgeFromBytes; substrings of key
+	// must not outlive the Edge in the store.
+	key    string
+	keyBuf []byte
+	// Intrusive list pointers; mutated only by *store under store.mtx.
+	prev, next *Edge
 
 	TraceID                                        string
 	ConnectionType                                 ConnectionType
@@ -43,6 +55,7 @@ type Edge struct {
 func resetEdge(e *Edge) {
 	*e = Edge{
 		Dimensions:     e.Dimensions,
+		keyBuf:         e.keyBuf,
 		SpanMultiplier: 1,
 	}
 	clear(e.Dimensions)

--- a/modules/generator/processor/servicegraphs/store/interface.go
+++ b/modules/generator/processor/servicegraphs/store/interface.go
@@ -7,12 +7,19 @@ const (
 	Server Side = "server"
 )
 
+// Callback is invoked by the store with a pooled *Edge while holding the
+// store mutex. The Edge pointer is only valid for the duration of the call —
+// the store may return it to the pool after the callback returns. Do not
+// retain the pointer, send it to another goroutine, or store substrings of
+// its fields beyond the callback's lifetime.
 type Callback func(e *Edge)
 
 // Store is an interface for building service graphs.
 type Store interface {
 	// UpsertEdge inserts or updates an edge.
 	UpsertEdge(key string, side Side, update Callback) (isNew bool, err error)
+	// UpsertEdgeFromBytes inserts or updates an edge from trace/span ID bytes.
+	UpsertEdgeFromBytes(traceID, spanID []byte, side Side, update Callback) (isNew bool, err error)
 	// AddDroppedSpanSide adds a dropped span side key and returns true if an
 	// existing buffered counterpart edge was removed.
 	AddDroppedSpanSide(key string, side Side) bool

--- a/modules/generator/processor/servicegraphs/store/store.go
+++ b/modules/generator/processor/servicegraphs/store/store.go
@@ -157,15 +157,21 @@ func UpsertEdgeFromBytesWith[T any](st Store, traceID, spanID []byte, side Side,
 	return upsertEdgeFromBytesWith(s, traceID, spanID, side, state, update)
 }
 
+// maxStackKeyLen is the largest encoded edge key built in a stack buffer
+// before falling back to the heap-allocating path. A spec-compliant key is
+// hex(16-byte trace ID) + "-" + hex(8-byte span ID) = 49 bytes, so 64 covers
+// normal IDs with headroom while keeping the buffer cheap to stack-allocate.
+const maxStackKeyLen = 64
+
 func upsertEdgeFromBytesWith[T any](s *store, traceID, spanID []byte, side Side, state T, update func(*Edge, T)) (isNew bool, err error) {
 	encodedLen := encodedKeyLen(traceID, spanID)
-	if encodedLen > 64 {
+	if encodedLen > maxStackKeyLen {
 		return s.UpsertEdge(encodeKey(traceID, spanID), side, func(edge *Edge) {
 			update(edge, state)
 		})
 	}
 
-	var buf [64]byte
+	var buf [maxStackKeyLen]byte
 	key := encodeKeyToString(buf[:encodedLen], traceID, spanID)
 
 	s.mtx.Lock()

--- a/modules/generator/processor/servicegraphs/store/store.go
+++ b/modules/generator/processor/servicegraphs/store/store.go
@@ -1,10 +1,11 @@
 package store
 
 import (
-	"container/list"
+	"encoding/hex"
 	"errors"
 	"sync"
 	"time"
+	"unsafe"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -17,10 +18,13 @@ var (
 var _ Store = (*store)(nil)
 
 type store struct {
-	l   *list.List
 	mtx sync.Mutex
-	m   map[string]*list.Element
+	m   map[string]*Edge
 	d   map[droppedSpanSideKey]int64
+
+	head  *Edge
+	tail  *Edge
+	items int
 
 	onComplete Callback
 	onExpire   Callback
@@ -41,8 +45,7 @@ type droppedSpanSideKey struct {
 // have not found their pair are deleted after ttl time.
 func NewStore(ttl time.Duration, maxItems int, onComplete, onExpire Callback, droppedSpanSideOverflowCounter prometheus.Counter) Store {
 	s := &store{
-		l: list.New(),
-		m: make(map[string]*list.Element),
+		m: make(map[string]*Edge),
 		d: make(map[droppedSpanSideKey]int64),
 
 		onComplete: onComplete,
@@ -61,7 +64,7 @@ func (s *store) len() int {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
-	return s.l.Len()
+	return s.items
 }
 
 // tryEvictHead checks if the oldest item (head of list) can be evicted and will delete it if so.
@@ -69,29 +72,26 @@ func (s *store) len() int {
 //
 // Must be called holding lock.
 func (s *store) tryEvictHead() bool {
-	head := s.l.Front()
-	if head == nil {
+	if s.head == nil {
 		// list is empty
 		return false
 	}
 
-	headEdge := head.Value.(*Edge)
-	if !headEdge.isExpired() {
+	if !s.head.isExpired() {
 		return false
 	}
 
-	s.onExpire(headEdge)
-	s.deleteEdge(head)
+	s.onExpire(s.head)
+	s.deleteEdge(s.head)
 
 	return true
 }
 
 // deleteEdge removes an edge from the map/list and returns it to the pool.
 // Must be called holding lock.
-func (s *store) deleteEdge(ele *list.Element) {
-	edge := ele.Value.(*Edge)
+func (s *store) deleteEdge(edge *Edge) {
 	delete(s.m, edge.key)
-	s.l.Remove(ele)
+	s.removeEdge(edge)
 	s.returnEdge(edge)
 }
 
@@ -102,13 +102,12 @@ func (s *store) UpsertEdge(key string, side Side, update Callback) (isNew bool, 
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
-	if storedEdge, ok := s.m[key]; ok {
-		edge := storedEdge.Value.(*Edge)
+	if edge, ok := s.m[key]; ok {
 		update(edge)
 
 		if edge.isComplete() {
 			s.onComplete(edge)
-			s.deleteEdge(storedEdge)
+			s.deleteEdge(edge)
 		}
 
 		return false, nil
@@ -128,16 +127,130 @@ func (s *store) UpsertEdge(key string, side Side, update Callback) (isNew bool, 
 	}
 
 	// Check we can add new edges
-	if s.l.Len() >= s.maxItems {
+	if s.items >= s.maxItems {
 		// todo: try to evict expired items
 		s.returnEdge(edge)
 		return false, ErrTooManyItems
 	}
 
-	ele := s.l.PushBack(edge)
-	s.m[key] = ele
+	s.pushBack(edge)
+	s.m[key] = edge
 
 	return true, nil
+}
+
+func (s *store) UpsertEdgeFromBytes(traceID, spanID []byte, side Side, update Callback) (isNew bool, err error) {
+	return UpsertEdgeFromBytesWith(s, traceID, spanID, side, update, func(edge *Edge, update Callback) {
+		update(edge)
+	})
+}
+
+// UpsertEdgeFromBytesWith is like Store.UpsertEdgeFromBytes, but passes typed
+// state to a top-level update function so callers can avoid per-call closures.
+func UpsertEdgeFromBytesWith[T any](st Store, traceID, spanID []byte, side Side, state T, update func(*Edge, T)) (isNew bool, err error) {
+	s, ok := st.(*store)
+	if !ok {
+		return st.UpsertEdgeFromBytes(traceID, spanID, side, func(edge *Edge) {
+			update(edge, state)
+		})
+	}
+	return upsertEdgeFromBytesWith(s, traceID, spanID, side, state, update)
+}
+
+func upsertEdgeFromBytesWith[T any](s *store, traceID, spanID []byte, side Side, state T, update func(*Edge, T)) (isNew bool, err error) {
+	encodedLen := encodedKeyLen(traceID, spanID)
+	if encodedLen > 64 {
+		return s.UpsertEdge(encodeKey(traceID, spanID), side, func(edge *Edge) {
+			update(edge, state)
+		})
+	}
+
+	var buf [64]byte
+	key := encodeKeyToString(buf[:encodedLen], traceID, spanID)
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	if edge, ok := s.m[key]; ok {
+		update(edge, state)
+
+		if edge.isComplete() {
+			s.onComplete(edge)
+			s.deleteEdge(edge)
+		}
+
+		return false, nil
+	}
+
+	if s.hasDroppedCounterpart(key, side) {
+		return true, ErrDroppedSpanSide
+	}
+
+	edge := s.grabEdgeFromBytes(traceID, spanID)
+	update(edge, state)
+
+	if edge.isComplete() {
+		s.onComplete(edge)
+		s.returnEdge(edge)
+		return true, nil
+	}
+
+	// Check we can add new edges
+	if s.items >= s.maxItems {
+		// todo: try to evict expired items
+		s.returnEdge(edge)
+		return false, ErrTooManyItems
+	}
+
+	s.pushBack(edge)
+	s.m[edge.key] = edge
+
+	return true, nil
+}
+
+func (s *store) pushBack(edge *Edge) {
+	edge.prev = s.tail
+	edge.next = nil
+	if s.tail != nil {
+		s.tail.next = edge
+	} else {
+		s.head = edge
+	}
+	s.tail = edge
+	s.items++
+}
+
+func (s *store) removeEdge(edge *Edge) {
+	if edge.prev != nil {
+		edge.prev.next = edge.next
+	} else {
+		s.head = edge.next
+	}
+	if edge.next != nil {
+		edge.next.prev = edge.prev
+	} else {
+		s.tail = edge.prev
+	}
+	edge.prev = nil
+	edge.next = nil
+	s.items--
+}
+
+func encodedKeyLen(k1, k2 []byte) int {
+	return hex.EncodedLen(len(k1)) + 1 + hex.EncodedLen(len(k2))
+}
+
+func encodeKey(k1, k2 []byte) string {
+	buf := make([]byte, encodedKeyLen(k1, k2))
+	return encodeKeyToString(buf, k1, k2)
+}
+
+func encodeKeyToString(buf []byte, k1, k2 []byte) string {
+	k1Len := hex.EncodedLen(len(k1))
+	hex.Encode(buf[:k1Len], k1)
+	buf[k1Len] = '-'
+	hex.Encode(buf[k1Len+1:], k2)
+	return unsafe.String(unsafe.SliceData(buf), len(buf))
 }
 
 // Expire evicts all expired items in the store.
@@ -157,12 +270,11 @@ func (s *store) AddDroppedSpanSide(key string, side Side) bool {
 	defer s.mtx.Unlock()
 
 	droppedCounterpartEdge := false
-	if storedEdge, ok := s.m[key]; ok {
-		edge := storedEdge.Value.(*Edge)
+	if edge, ok := s.m[key]; ok {
 		// If a counterpart edge is already buffered, drop it immediately instead of
 		// waiting for TTL expiration.
 		if !edge.isComplete() && getEdgeSide(edge) != side {
-			s.deleteEdge(storedEdge)
+			s.deleteEdge(edge)
 			droppedCounterpartEdge = true
 		}
 	}
@@ -230,6 +342,19 @@ func (s *store) grabEdge(key string) *Edge {
 	edge := edgePool.Get().(*Edge)
 	resetEdge(edge)
 	edge.key = key
+	edge.expiration = time.Now().Add(s.ttl).Unix()
+	return edge
+}
+
+func (s *store) grabEdgeFromBytes(traceID, spanID []byte) *Edge {
+	edge := edgePool.Get().(*Edge)
+	resetEdge(edge)
+	encodedLen := encodedKeyLen(traceID, spanID)
+	if cap(edge.keyBuf) < encodedLen {
+		edge.keyBuf = make([]byte, encodedLen)
+	}
+	edge.keyBuf = edge.keyBuf[:encodedLen]
+	edge.key = encodeKeyToString(edge.keyBuf, traceID, spanID)
 	edge.expiration = time.Now().Add(s.ttl).Unix()
 	return edge
 }

--- a/modules/generator/processor/servicegraphs/store/store.go
+++ b/modules/generator/processor/servicegraphs/store/store.go
@@ -250,7 +250,9 @@ func encodeKeyToString(buf []byte, k1, k2 []byte) string {
 	hex.Encode(buf[:k1Len], k1)
 	buf[k1Len] = '-'
 	hex.Encode(buf[k1Len+1:], k2)
-	return unsafe.String(unsafe.SliceData(buf), len(buf))
+	// The caller owns buf and keeps it immutable for as long as the returned
+	// key is in use. This avoids copying servicegraph keys on the hot path.
+	return unsafe.String(unsafe.SliceData(buf), len(buf)) // nosemgrep
 }
 
 // Expire evicts all expired items in the store.

--- a/modules/generator/processor/servicegraphs/store/store.go
+++ b/modules/generator/processor/servicegraphs/store/store.go
@@ -357,14 +357,21 @@ func (s *store) grabEdge(key string) *Edge {
 func (s *store) grabEdgeFromBytes(traceID, spanID []byte) *Edge {
 	edge := edgePool.Get().(*Edge)
 	resetEdge(edge)
+	setEdgeKeyFromBytes(edge, traceID, spanID)
+	edge.expiration = time.Now().Add(s.ttl).Unix()
+	return edge
+}
+
+// setEdgeKeyFromBytes encodes the key into the edge's reusable keyBuf and
+// aliases edge.key over it. It runs on freshly grabbed (possibly recycled)
+// edges, so it must fully overwrite any previous key contents.
+func setEdgeKeyFromBytes(edge *Edge, traceID, spanID []byte) {
 	encodedLen := encodedKeyLen(traceID, spanID)
 	if cap(edge.keyBuf) < encodedLen {
 		edge.keyBuf = make([]byte, encodedLen)
 	}
 	edge.keyBuf = edge.keyBuf[:encodedLen]
 	edge.key = encodeKeyToString(edge.keyBuf, traceID, spanID)
-	edge.expiration = time.Now().Add(s.ttl).Unix()
-	return edge
 }
 
 // returnEdge returns an Edge to the pool.

--- a/modules/generator/processor/servicegraphs/store/store_test.go
+++ b/modules/generator/processor/servicegraphs/store/store_test.go
@@ -569,3 +569,37 @@ func TestStoreUpsertEdgeFromBytesWith_pooledEdgeReuseDoesNotAliasKeys(t *testing
 	}
 	assert.Equal(t, 0, s.len())
 }
+
+func TestSetEdgeKeyFromBytes_reuseOverwritesPreviousKey(t *testing.T) {
+	// Deterministic version of the pooled-reuse scenario: when the same Edge
+	// (and its keyBuf) is reused for a different key, the encoded key must
+	// fully replace the previous contents, for shorter, equal, and longer keys.
+	e := &Edge{Dimensions: map[string]string{}}
+
+	traceA := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	spanA := []byte{0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8}
+	setEdgeKeyFromBytes(e, traceA, spanA)
+	require.Equal(t, encodeKey(traceA, spanA), e.Key())
+	bufA := &e.keyBuf[0]
+
+	// Shorter key: the buffer is reused in place and the key must not retain
+	// any trailing bytes of the previous key.
+	resetEdge(e)
+	traceShort := []byte{0x11}
+	spanShort := []byte{0x22}
+	setEdgeKeyFromBytes(e, traceShort, spanShort)
+	assert.Equal(t, encodeKey(traceShort, spanShort), e.Key())
+	assert.Same(t, bufA, &e.keyBuf[0], "shorter key should reuse the existing buffer")
+
+	// Longer key than current capacity: the buffer must grow and still encode
+	// the full key.
+	resetEdge(e)
+	traceLong := make([]byte, 32)
+	spanLong := make([]byte, 32)
+	for i := range traceLong {
+		traceLong[i] = byte(i + 1)
+		spanLong[i] = byte(i + 101)
+	}
+	setEdgeKeyFromBytes(e, traceLong, spanLong)
+	assert.Equal(t, encodeKey(traceLong, spanLong), e.Key())
+}

--- a/modules/generator/processor/servicegraphs/store/store_test.go
+++ b/modules/generator/processor/servicegraphs/store/store_test.go
@@ -372,6 +372,66 @@ func BenchmarkStoreUpsertEdge(b *testing.B) {
 	}
 }
 
+func TestStoreUpsertEdgeFromBytesWith_StackKey(t *testing.T) {
+	// Trace+span IDs with hex(16)+'-'+hex(16) = 33 bytes — fits in the 64-byte
+	// stack buffer fast path. Verify the typed-state callback runs and the
+	// edge pairs correctly across two calls (client then server).
+	type clientState struct{ svc string }
+
+	storeInterface := NewStore(time.Hour, 1, noopCallback, noopCallback, newTestCounter())
+	s := storeInterface.(*store)
+
+	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	spanID := []byte{0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8}
+
+	isNew, err := UpsertEdgeFromBytesWith(s, traceID, spanID, Client, clientState{svc: clientService}, func(e *Edge, st clientState) {
+		e.ClientService = st.svc
+	})
+	require.NoError(t, err)
+	require.True(t, isNew)
+	assert.Equal(t, 1, s.len())
+
+	type serverState struct{ svc string }
+	isNew, err = UpsertEdgeFromBytesWith(s, traceID, spanID, Server, serverState{svc: "server"}, func(e *Edge, st serverState) {
+		assert.Equal(t, clientService, e.ClientService)
+		e.ServerService = st.svc
+	})
+	require.NoError(t, err)
+	require.False(t, isNew)
+	// Edge completed and removed.
+	assert.Equal(t, 0, s.len())
+}
+
+func TestStoreUpsertEdgeFromBytesWith_HeapFallback(t *testing.T) {
+	// IDs whose hex+'-'+hex exceeds 64 bytes force the heap fallback at
+	// store.go:165. Use 33-byte IDs so encodedKeyLen = 66+1+66 = 133 > 64.
+	storeInterface := NewStore(time.Hour, 1, noopCallback, noopCallback, newTestCounter())
+	s := storeInterface.(*store)
+
+	bigTraceID := make([]byte, 33)
+	bigSpanID := make([]byte, 33)
+	for i := range bigTraceID {
+		bigTraceID[i] = byte(i + 1)
+		bigSpanID[i] = byte(i + 100)
+	}
+
+	isNew, err := UpsertEdgeFromBytesWith(s, bigTraceID, bigSpanID, Client, struct{}{}, func(e *Edge, _ struct{}) {
+		e.ClientService = clientService
+	})
+	require.NoError(t, err)
+	require.True(t, isNew)
+	assert.Equal(t, 1, s.len())
+
+	// Same key on the heap path must hit the existing edge.
+	isNew, err = UpsertEdgeFromBytesWith(s, bigTraceID, bigSpanID, Server, struct{}{}, func(e *Edge, _ struct{}) {
+		assert.Equal(t, clientService, e.ClientService)
+		e.ServerService = "server"
+	})
+	require.NoError(t, err)
+	require.False(t, isNew)
+	assert.Equal(t, 0, s.len())
+}
+
 func noopCallback(_ *Edge) {
 }
 

--- a/modules/generator/processor/servicegraphs/store/store_test.go
+++ b/modules/generator/processor/servicegraphs/store/store_test.go
@@ -490,3 +490,82 @@ func TestResetEdge(t *testing.T) {
 	newPtr := reflect.ValueOf(e.Dimensions).Pointer()
 	assert.Equal(t, originalPtr, newPtr, "Dimensions map should be the exact same instance, not reallocated")
 }
+
+func TestStoreUpsertEdgeFromBytesWith_droppedCounterpart(t *testing.T) {
+	// The stack-key fast path must find a dropped counterpart that was
+	// recorded under a heap-allocated key (as addDroppedSpanSide does).
+	storeInterface := NewStore(time.Hour, 10, noopCallback, noopCallback, newTestCounter())
+	s := storeInterface.(*store)
+
+	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	spanID := []byte{0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8}
+
+	s.AddDroppedSpanSide(encodeKey(traceID, spanID), Server)
+
+	isNew, err := UpsertEdgeFromBytesWith(s, traceID, spanID, Client, struct{}{}, func(e *Edge, _ struct{}) {
+		e.ClientService = clientService
+	})
+	require.ErrorIs(t, err, ErrDroppedSpanSide)
+	assert.True(t, isNew)
+	assert.Equal(t, 0, s.len())
+}
+
+func TestStoreUpsertEdgeFromBytesWith_pooledEdgeReuseDoesNotAliasKeys(t *testing.T) {
+	// Edges keep their key aliased over a reusable keyBuf that survives pool
+	// recycling. Expire an edge so its pooled Edge (including keyBuf) can be
+	// reused for a different key, then verify map lookups never alias the old
+	// key. The pool does not guarantee reuse, but when it happens this test
+	// exercises the overwrite path.
+	var expired int
+	storeInterface := NewStore(time.Hour, 10, noopCallback, countingCallback(&expired), newTestCounter())
+	s := storeInterface.(*store)
+
+	traceA := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	spanA := []byte{0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8}
+	traceB := []byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20}
+	spanB := []byte{0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8}
+
+	// Create edge A and expire it so its pooled Edge is recycled.
+	isNew, err := UpsertEdgeFromBytesWith(s, traceA, spanA, Client, struct{}{}, func(e *Edge, _ struct{}) {
+		e.ClientService = clientService
+		e.expiration = 0
+	})
+	require.NoError(t, err)
+	require.True(t, isNew)
+	require.True(t, s.tryEvictHead())
+	require.Equal(t, 1, expired)
+	require.Equal(t, 0, s.len())
+
+	// Insert edge B, which may reuse the recycled Edge and overwrite its keyBuf.
+	isNew, err = UpsertEdgeFromBytesWith(s, traceB, spanB, Client, struct{}{}, func(e *Edge, _ struct{}) {
+		e.ClientService = clientService
+	})
+	require.NoError(t, err)
+	require.True(t, isNew)
+
+	// B must be addressable under its own key; A's old key must be gone.
+	_, foundB := s.m[encodeKey(traceB, spanB)]
+	assert.True(t, foundB)
+	_, foundA := s.m[encodeKey(traceA, spanA)]
+	assert.False(t, foundA)
+
+	// Re-inserting A must create a fresh edge, not resurrect stale state.
+	isNew, err = UpsertEdgeFromBytesWith(s, traceA, spanA, Client, struct{}{}, func(e *Edge, _ struct{}) {
+		assert.Empty(t, e.ClientService)
+		e.ClientService = clientService
+	})
+	require.NoError(t, err)
+	require.True(t, isNew)
+	assert.Equal(t, 2, s.len())
+
+	// Pair both edges to completion to prove lookups keep working after reuse.
+	for _, ids := range [][2][]byte{{traceA, spanA}, {traceB, spanB}} {
+		isNew, err = UpsertEdgeFromBytesWith(s, ids[0], ids[1], Server, struct{}{}, func(e *Edge, _ struct{}) {
+			assert.Equal(t, clientService, e.ClientService)
+			e.ServerService = "server"
+		})
+		require.NoError(t, err)
+		require.False(t, isNew)
+	}
+	assert.Equal(t, 0, s.len())
+}

--- a/modules/generator/processor/spanmetrics/spanmetrics.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics.go
@@ -137,39 +137,51 @@ func (p *Processor) Shutdown(_ context.Context) {
 func (p *Processor) aggregateMetrics(resourceSpans []*v1_trace.ResourceSpans) {
 	resourceLabels := make([]string, 0)
 	resourceValues := make([]string, 0)
-	jobNameBuf := make([]byte, 0, 64)
 	for _, rs := range resourceSpans {
 		// already extract job name & instance id, so we only have to do it once per batch of spans
-		var svcName, jobName, instanceID string
-		svcName, jobName, instanceID, jobNameBuf = getResourceServiceLabels(rs.Resource.Attributes, jobNameBuf)
+		svcName, jobName, instanceID := getResourceServiceLabels(rs.Resource.Attributes)
 		targetInfoLabelsValid := true
 		targetInfoLabelsBuilt := false
-		targetInfoResourceLabelsBuilt := false
 		for _, ils := range rs.ScopeSpans {
 			for _, span := range ils.Spans {
-				if p.filter.ApplyFilterPolicy(rs.Resource, span) {
-					if p.Cfg.EnableTargetInfo && !targetInfoLabelsBuilt {
-						if !targetInfoResourceLabelsBuilt {
-							getTargetInfoAttributesValues(&resourceLabels, &resourceValues, rs.Resource.Attributes, p.targetInfoExcluded, p.sanitizeCache.Get)
-							targetInfoResourceLabelsBuilt = true
-						}
+				if !p.filter.ApplyFilterPolicy(rs.Resource, span) {
+					p.filteredSpansCounter.Inc()
+					continue
+				}
+				var traceID []byte
+				if p.Cfg.Subprocessors[Latency] {
+					traceID = span.TraceId
+				}
+				if !p.aggregateMetricsForSpan(svcName, jobName, instanceID, rs.Resource, span, traceID) {
+					continue
+				}
+				if p.Cfg.EnableTargetInfo {
+					// Register target_info only after a span's primary labels have been
+					// validated and its series updated. This preserves the pre-optimization
+					// ordering: span metrics claim active-series/entity limiter capacity
+					// before target_info, and a resource whose accepted spans all carry
+					// invalid UTF-8 labels emits no target_info at all. The labels are
+					// still built and registered at most once per resource batch.
+					if !targetInfoLabelsBuilt {
+						getTargetInfoAttributesValues(&resourceLabels, &resourceValues, rs.Resource.Attributes, p.targetInfoExcluded, p.sanitizeCache.Get)
 						targetInfoLabelsValid = p.buildAndSetTargetInfoLabels(resourceLabels, resourceValues, jobName, instanceID)
 						targetInfoLabelsBuilt = true
 					}
-					var traceID []byte
-					if p.Cfg.Subprocessors[Latency] {
-						traceID = span.TraceId
+					if !targetInfoLabelsValid {
+						// Pre-optimization behavior: every span that reached the target_info
+						// step with invalid target_info labels counted one discarded update.
+						p.invalidUTF8Counter.Inc()
 					}
-					p.aggregateMetricsForSpan(svcName, jobName, instanceID, rs.Resource, span, traceID, targetInfoLabelsValid)
-					continue
 				}
-				p.filteredSpansCounter.Inc()
 			}
 		}
 	}
 }
 
-func (p *Processor) aggregateMetricsForSpan(svcName string, jobName string, instanceID string, rs *v1.Resource, span *v1_trace.Span, traceID []byte, targetInfoLabelsValid bool) {
+// aggregateMetricsForSpan updates the span metrics series for a single span.
+// It reports whether the span's primary label set was valid UTF-8 and its
+// series were updated.
+func (p *Processor) aggregateMetricsForSpan(svcName string, jobName string, instanceID string, rs *v1.Resource, span *v1_trace.Span, traceID []byte) bool {
 	builder := p.registry.NewLabelBuilder()
 
 	if p.Cfg.IntrinsicDimensions.Service {
@@ -225,7 +237,7 @@ func (p *Processor) aggregateMetricsForSpan(svcName string, jobName string, inst
 	registryLabelValues, validUTF8 := builder.CloseAndBorrowLabels()
 	if !validUTF8 {
 		p.invalidUTF8Counter.Inc()
-		return
+		return false
 	}
 	updateTimeMs := time.Now().UnixMilli()
 
@@ -246,14 +258,8 @@ func (p *Processor) aggregateMetricsForSpan(svcName string, jobName string, inst
 		p.spanMetricsSizeTotal.IncWithHashAt(registryLabelValues.Labels, registryLabelValues.Hash, float64(span.Size()), updateTimeMs)
 	}
 
-	// abort if target_info labels were rejected for this resource batch.
-	if p.Cfg.EnableTargetInfo && !targetInfoLabelsValid {
-		registryLabelValues.Release()
-		p.invalidUTF8Counter.Inc()
-		return
-	}
-
 	registryLabelValues.Release()
+	return true
 }
 
 func (p *Processor) buildAndSetTargetInfoLabels(resourceLabels, resourceValues []string, jobName string, instanceID string) bool {
@@ -288,7 +294,7 @@ func (p *Processor) buildAndSetTargetInfoLabels(resourceLabels, resourceValues [
 	return true
 }
 
-func getResourceServiceLabels(attributes []*v1_common.KeyValue, jobNameBuf []byte) (svcName string, jobName string, instanceID string, returnedJobNameBuf []byte) {
+func getResourceServiceLabels(attributes []*v1_common.KeyValue) (svcName string, jobName string, instanceID string) {
 	var (
 		namespace       string
 		foundSvcName    bool
@@ -317,12 +323,12 @@ func getResourceServiceLabels(attributes []*v1_common.KeyValue, jobNameBuf []byt
 	}
 
 	if svcName == "" {
-		return svcName, "", instanceID, jobNameBuf[:0]
+		return svcName, "", instanceID
 	}
 	if namespace == "" {
-		return svcName, svcName, instanceID, jobNameBuf[:0]
+		return svcName, svcName, instanceID
 	}
-	return svcName, namespace + "/" + svcName, instanceID, jobNameBuf[:0]
+	return svcName, namespace + "/" + svcName, instanceID
 }
 
 func getTargetInfoAttributesValues(keys, values *[]string, attributes []*v1_common.KeyValue, exclude map[string]struct{}, sanitizeFn validation.SanitizeFn) {

--- a/modules/generator/processor/spanmetrics/spanmetrics.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics.go
@@ -178,9 +178,10 @@ func (p *Processor) aggregateMetrics(resourceSpans []*v1_trace.ResourceSpans) {
 	}
 }
 
-// aggregateMetricsForSpan updates the span metrics series for a single span.
-// It reports whether the span's primary label set was valid UTF-8 and its
-// series were updated.
+// aggregateMetricsForSpan updates the enabled span metric series for a single
+// span. It reports whether the span's primary label set was valid UTF-8;
+// callers gate target_info registration on this, independent of which
+// subprocessors are enabled.
 func (p *Processor) aggregateMetricsForSpan(svcName string, jobName string, instanceID string, rs *v1.Resource, span *v1_trace.Span, traceID []byte) bool {
 	builder := p.registry.NewLabelBuilder()
 

--- a/modules/generator/processor/spanmetrics/spanmetrics.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics.go
@@ -2,8 +2,9 @@ package spanmetrics
 
 import (
 	"context"
-	"slices"
+	"strings"
 	"time"
+	"unsafe"
 
 	"github.com/grafana/tempo/modules/generator/validation"
 	"github.com/prometheus/client_golang/prometheus"
@@ -25,6 +26,10 @@ const (
 	metricDurationSeconds = "traces_spanmetrics_latency"
 	metricSizeTotal       = "traces_spanmetrics_size_total"
 	targetInfo            = "traces_target_info"
+
+	serviceNameKey       = "service.name"
+	serviceNamespaceKey  = "service.namespace"
+	serviceInstanceIDKey = "service.instance.id"
 )
 
 type Processor struct {
@@ -37,10 +42,14 @@ type Processor struct {
 	spanMetricsSizeTotal       registry.Counter
 	spanMetricsTargetInfo      registry.Gauge
 
-	filter               *spanfilter.SpanFilter
-	filteredSpansCounter prometheus.Counter
-	invalidUTF8Counter   prometheus.Counter
-	sanitizeCache        reclaimable.Cache[string, string]
+	filter                 *spanfilter.SpanFilter
+	filteredSpansCounter   prometheus.Counter
+	invalidUTF8Counter     prometheus.Counter
+	sanitizeCache          reclaimable.Cache[string, string]
+	targetInfoExcluded     map[string]struct{}
+	dimensionLabels        []string
+	dimensionMappingLabels []string
+	usesSpanMultiplier     bool
 
 	// for testing
 	now func() time.Time
@@ -72,14 +81,28 @@ func New(cfg Config, reg registry.Registry, filteredSpansCounter, invalidUTF8Cou
 		return nil, err
 	}
 
+	dimensionLabels := make([]string, len(cfg.Dimensions))
+	for i, d := range cfg.Dimensions {
+		dimensionLabels[i] = validation.SanitizeLabelNameWithCollisions(d, validation.SupportedIntrinsicDimensionsSet, c.Get)
+	}
+
+	dimensionMappingLabels := make([]string, len(cfg.DimensionMappings))
+	for i, m := range cfg.DimensionMappings {
+		dimensionMappingLabels[i] = validation.SanitizeLabelNameWithCollisions(m.Name, validation.SupportedIntrinsicDimensionsSet, c.Get)
+	}
+
 	p := &Processor{
-		Cfg:                   cfg,
-		registry:              reg,
-		spanMetricsTargetInfo: reg.NewGauge(targetInfo),
-		now:                   time.Now,
-		filteredSpansCounter:  filteredSpansCounter,
-		invalidUTF8Counter:    invalidUTF8Counter,
-		sanitizeCache:         c,
+		Cfg:                    cfg,
+		registry:               reg,
+		spanMetricsTargetInfo:  reg.NewGauge(targetInfo),
+		now:                    time.Now,
+		filteredSpansCounter:   filteredSpansCounter,
+		invalidUTF8Counter:     invalidUTF8Counter,
+		sanitizeCache:          c,
+		targetInfoExcluded:     excludedDimensionsSet(cfg.TargetInfoExcludedDimensions),
+		dimensionLabels:        dimensionLabels,
+		dimensionMappingLabels: dimensionMappingLabels,
+		usesSpanMultiplier:     cfg.SpanMultiplierKey != "" || cfg.EnableTraceStateSpanMultiplier,
 	}
 
 	if cfg.Subprocessors[Latency] {
@@ -115,18 +138,30 @@ func (p *Processor) Shutdown(_ context.Context) {
 func (p *Processor) aggregateMetrics(resourceSpans []*v1_trace.ResourceSpans) {
 	resourceLabels := make([]string, 0)
 	resourceValues := make([]string, 0)
+	jobNameBuf := make([]byte, 0, 64)
 	for _, rs := range resourceSpans {
 		// already extract job name & instance id, so we only have to do it once per batch of spans
-		svcName, _ := processor_util.FindServiceName(rs.Resource.Attributes)
-		jobName := processor_util.GetJobValue(rs.Resource.Attributes)
-		instanceID, _ := processor_util.FindInstanceID(rs.Resource.Attributes)
-		if p.Cfg.EnableTargetInfo {
-			getTargetInfoAttributesValues(&resourceLabels, &resourceValues, rs.Resource.Attributes, p.Cfg.TargetInfoExcludedDimensions, p.sanitizeCache.Get)
-		}
+		var svcName, jobName, instanceID string
+		svcName, jobName, instanceID, jobNameBuf = getResourceServiceLabels(rs.Resource.Attributes, jobNameBuf)
+		targetInfoLabelsValid := true
+		targetInfoLabelsBuilt := false
+		targetInfoResourceLabelsBuilt := false
 		for _, ils := range rs.ScopeSpans {
 			for _, span := range ils.Spans {
 				if p.filter.ApplyFilterPolicy(rs.Resource, span) {
-					p.aggregateMetricsForSpan(svcName, jobName, instanceID, rs.Resource, span, resourceLabels, resourceValues)
+					if p.Cfg.EnableTargetInfo && !targetInfoLabelsBuilt {
+						if !targetInfoResourceLabelsBuilt {
+							getTargetInfoAttributesValues(&resourceLabels, &resourceValues, rs.Resource.Attributes, p.targetInfoExcluded, p.sanitizeCache.Get)
+							targetInfoResourceLabelsBuilt = true
+						}
+						targetInfoLabelsValid = p.buildAndSetTargetInfoLabels(resourceLabels, resourceValues, jobName, instanceID)
+						targetInfoLabelsBuilt = true
+					}
+					var traceID []byte
+					if p.Cfg.Subprocessors[Latency] {
+						traceID = span.TraceId
+					}
+					p.aggregateMetricsForSpan(svcName, jobName, instanceID, rs.Resource, span, traceID, targetInfoLabelsValid)
 					continue
 				}
 				p.filteredSpansCounter.Inc()
@@ -135,18 +170,8 @@ func (p *Processor) aggregateMetrics(resourceSpans []*v1_trace.ResourceSpans) {
 	}
 }
 
-func (p *Processor) aggregateMetricsForSpan(svcName string, jobName string, instanceID string, rs *v1.Resource, span *v1_trace.Span, resourceLabels []string, resourceValues []string) {
-	// Spans with negative latency are treated as zero.
-	latencySeconds := 0.0
-	if start, end := span.GetStartTimeUnixNano(), span.GetEndTimeUnixNano(); start < end {
-		latencySeconds = float64(end-start) / float64(time.Second.Nanoseconds())
-	}
-
+func (p *Processor) aggregateMetricsForSpan(svcName string, jobName string, instanceID string, rs *v1.Resource, span *v1_trace.Span, traceID []byte, targetInfoLabelsValid bool) {
 	builder := p.registry.NewLabelBuilder()
-	targetInfoBuilder := p.registry.NewInfoMetricLabelBuilder()
-	for i := range resourceLabels {
-		targetInfoBuilder.Add(resourceLabels[i], resourceValues[i])
-	}
 
 	if p.Cfg.IntrinsicDimensions.Service {
 		builder.Add(gen.DimService, svcName)
@@ -155,104 +180,168 @@ func (p *Processor) aggregateMetricsForSpan(svcName string, jobName string, inst
 		builder.Add(gen.DimSpanName, span.GetName())
 	}
 	if p.Cfg.IntrinsicDimensions.SpanKind {
-		builder.Add(gen.DimSpanKind, span.GetKind().String())
+		builder.Add(gen.DimSpanKind, spanKindString(span.GetKind()))
 	}
 	if p.Cfg.IntrinsicDimensions.StatusCode {
-		builder.Add(gen.DimStatusCode, span.GetStatus().GetCode().String())
+		builder.Add(gen.DimStatusCode, statusCodeString(span.GetStatus().GetCode()))
 	}
 	if p.Cfg.IntrinsicDimensions.StatusMessage {
 		builder.Add(gen.DimStatusMessage, span.GetStatus().GetMessage())
 	}
 
-	for _, d := range p.Cfg.Dimensions {
+	for i, d := range p.Cfg.Dimensions {
 		value, _ := processor_util.FindAttributeValue(d, rs.Attributes, span.Attributes)
-		label := validation.SanitizeLabelNameWithCollisions(d, validation.SupportedIntrinsicDimensionsSet, p.sanitizeCache.Get)
 		// if there is a collision, for example deployment.environment and deployment_environment,
 		// both sanitized to deployment_environment, we just take the last one configured.
-		builder.Add(label, value)
+		builder.Add(p.dimensionLabels[i], value)
 	}
 
-	for _, m := range p.Cfg.DimensionMappings {
-		values := ""
+	for i, m := range p.Cfg.DimensionMappings {
+		var values strings.Builder
 		for _, s := range m.SourceLabel {
 			if value, _ := processor_util.FindAttributeValue(s, rs.Attributes, span.Attributes); value != "" {
-				if values == "" {
-					values += value
-				} else {
-					values = values + m.Join + value
+				if values.Len() > 0 {
+					values.WriteString(m.Join)
 				}
+				values.WriteString(value)
 			}
 		}
-		label := validation.SanitizeLabelNameWithCollisions(m.Name, validation.SupportedIntrinsicDimensionsSet, p.sanitizeCache.Get)
-		builder.Add(label, values)
+		builder.Add(p.dimensionMappingLabels[i], values.String())
 	}
 
 	// add job label only if job is not blank and target_info is enabled
-	identifyingLabels := 0
 	if jobName != "" && p.Cfg.EnableTargetInfo {
 		builder.Add(gen.DimJob, jobName)
-		identifyingLabels++
 	}
 	// add instance label only if instance is not blank and enabled and target_info is enabled
 	if instanceID != "" && p.Cfg.EnableTargetInfo && p.Cfg.EnableInstanceLabel {
 		builder.Add(gen.DimInstance, instanceID)
-		identifyingLabels++
 	}
 
-	spanMultiplier := processor_util.GetSpanMultiplier(p.Cfg.SpanMultiplierKey, span, rs, p.Cfg.EnableTraceStateSpanMultiplier)
+	spanMultiplier := 1.0
+	if p.usesSpanMultiplier {
+		spanMultiplier = processor_util.GetSpanMultiplier(p.Cfg.SpanMultiplierKey, span, rs, p.Cfg.EnableTraceStateSpanMultiplier)
+	}
 
-	registryLabelValues, validUTF8 := builder.CloseAndBuildLabels()
+	registryLabelValues, validUTF8 := builder.CloseAndBorrowLabels()
 	if !validUTF8 {
 		p.invalidUTF8Counter.Inc()
 		return
 	}
+	updateTimeMs := time.Now().UnixMilli()
 
 	if p.Cfg.Subprocessors[Count] {
-		p.spanMetricsCallsTotal.Inc(registryLabelValues, 1*spanMultiplier)
+		p.spanMetricsCallsTotal.IncWithHashAt(registryLabelValues.Labels, registryLabelValues.Hash, 1*spanMultiplier, updateTimeMs)
 	}
 
 	if p.Cfg.Subprocessors[Latency] {
-		p.spanMetricsDurationSeconds.ObserveWithExemplar(registryLabelValues, latencySeconds, tempo_util.TraceIDToHexString(span.TraceId), spanMultiplier)
+		// Spans with negative latency are treated as zero.
+		latencySeconds := 0.0
+		if start, end := span.GetStartTimeUnixNano(), span.GetEndTimeUnixNano(); start < end {
+			latencySeconds = float64(end-start) / float64(time.Second.Nanoseconds())
+		}
+		p.spanMetricsDurationSeconds.ObserveWithExemplarTraceIDBytesWithHashAt(registryLabelValues.Labels, registryLabelValues.Hash, latencySeconds, traceID, spanMultiplier, updateTimeMs)
 	}
 
 	if p.Cfg.Subprocessors[Size] {
-		p.spanMetricsSizeTotal.Inc(registryLabelValues, float64(span.Size()))
+		p.spanMetricsSizeTotal.IncWithHashAt(registryLabelValues.Labels, registryLabelValues.Hash, float64(span.Size()), updateTimeMs)
 	}
 
-	// update target_info label values
-	if p.Cfg.EnableTargetInfo {
-		// TODO - The resource labels only need to be sanitized once
-		// TODO - attribute names are stable across applications
-		//        so let's cache the result of previous sanitizations
-
-		// add job label to target info only if job is not blank
-		if jobName != "" {
-			targetInfoBuilder.Add(gen.DimJob, jobName)
-		}
-		// add instance label to target info only if instance is not blank and enabled
-		if instanceID != "" && p.Cfg.EnableInstanceLabel {
-			targetInfoBuilder.Add(gen.DimInstance, instanceID)
-		}
-
-		targetInfoRegistryLabelValues, validUTF8 := targetInfoBuilder.CloseAndBuildLabels()
-		if !validUTF8 {
-			p.invalidUTF8Counter.Inc()
-			return
-		}
-
-		// Only register target_info if it has at least (job or instance) AND one other
-		// resource attribute in the built label set. We count from the built set because
-		// the Prometheus label builder drops empty-valued labels (Set("x","") calls Del("x")).
-		if identifyingLabels > 0 && targetInfoRegistryLabelValues.Len() > identifyingLabels {
-			p.spanMetricsTargetInfo.SetForTargetInfo(targetInfoRegistryLabelValues, 1)
-		}
+	// abort if target_info labels were rejected for this resource batch.
+	if p.Cfg.EnableTargetInfo && !targetInfoLabelsValid {
+		registryLabelValues.Release()
+		p.invalidUTF8Counter.Inc()
+		return
 	}
+
+	registryLabelValues.Release()
 }
 
-func getTargetInfoAttributesValues(keys, values *[]string, attributes []*v1_common.KeyValue, exclude []string, sanitizeFn validation.SanitizeFn) {
-	// TODO allocate with known length, or take new params for existing buffers
-	*keys = (*keys)[:0]
-	*values = (*values)[:0]
+func (p *Processor) buildAndSetTargetInfoLabels(resourceLabels, resourceValues []string, jobName string, instanceID string) bool {
+	targetInfoBuilder := p.registry.NewInfoMetricLabelBuilder()
+	for i := range resourceLabels {
+		targetInfoBuilder.Add(resourceLabels[i], resourceValues[i])
+	}
+
+	identifyingLabels := 0
+	// add job label to target info only if job is not blank
+	if jobName != "" {
+		targetInfoBuilder.Add(gen.DimJob, jobName)
+		identifyingLabels++
+	}
+	// add instance label to target info only if instance is not blank and enabled
+	if instanceID != "" && p.Cfg.EnableInstanceLabel {
+		targetInfoBuilder.Add(gen.DimInstance, instanceID)
+		identifyingLabels++
+	}
+
+	targetInfoLabels, validUTF8 := targetInfoBuilder.CloseAndBorrowLabels()
+	if !validUTF8 {
+		return false
+	}
+	// Only register target_info if it has at least (job or instance) AND one other
+	// resource attribute in the built label set. We count from the built set because
+	// the Prometheus label builder drops empty-valued labels (Set("x","") calls Del("x")).
+	if identifyingLabels > 0 && targetInfoLabels.Labels.Len() > identifyingLabels {
+		p.spanMetricsTargetInfo.SetForTargetInfoWithHashAt(targetInfoLabels.Labels, targetInfoLabels.Hash, 1, time.Now().UnixMilli())
+	}
+	targetInfoLabels.Release()
+	return true
+}
+
+func getResourceServiceLabels(attributes []*v1_common.KeyValue, jobNameBuf []byte) (svcName string, jobName string, instanceID string, returnedJobNameBuf []byte) {
+	var (
+		namespace       string
+		foundSvcName    bool
+		foundNamespace  bool
+		foundInstanceID bool
+	)
+
+	for _, kv := range attributes {
+		switch kv.Key {
+		case serviceNameKey:
+			if !foundSvcName {
+				svcName = tempo_util.StringifyAnyValue(kv.Value)
+				foundSvcName = true
+			}
+		case serviceNamespaceKey:
+			if !foundNamespace {
+				namespace = tempo_util.StringifyAnyValue(kv.Value)
+				foundNamespace = true
+			}
+		case serviceInstanceIDKey:
+			if !foundInstanceID {
+				instanceID = tempo_util.StringifyAnyValue(kv.Value)
+				foundInstanceID = true
+			}
+		}
+	}
+
+	if svcName == "" {
+		return svcName, "", instanceID, jobNameBuf[:0]
+	}
+	if namespace == "" {
+		return svcName, svcName, instanceID, jobNameBuf[:0]
+	}
+	jobNameBuf = append(jobNameBuf[:0], namespace...)
+	jobNameBuf = append(jobNameBuf, '/')
+	jobNameBuf = append(jobNameBuf, svcName...)
+	// The registry label builders copy label values before jobNameBuf is reused
+	// for the next resource.
+	return svcName, unsafe.String(unsafe.SliceData(jobNameBuf), len(jobNameBuf)), instanceID, jobNameBuf
+}
+
+func getTargetInfoAttributesValues(keys, values *[]string, attributes []*v1_common.KeyValue, exclude map[string]struct{}, sanitizeFn validation.SanitizeFn) {
+	if cap(*keys) < len(attributes) {
+		*keys = make([]string, 0, len(attributes))
+	} else {
+		*keys = (*keys)[:0]
+	}
+	if cap(*values) < len(attributes) {
+		*values = make([]string, 0, len(attributes))
+	} else {
+		*values = (*values)[:0]
+	}
 	for _, attrs := range attributes {
 		// ignoring job and instance
 		key := attrs.Key
@@ -262,10 +351,53 @@ func getTargetInfoAttributesValues(keys, values *[]string, attributes []*v1_comm
 		if key == "" || (key[0] >= '0' && key[0] <= '9') {
 			continue
 		}
-		if key != "service.name" && key != "service.namespace" && key != "service.instance.id" && !slices.Contains(exclude, key) {
+		if _, ok := exclude[key]; key != serviceNameKey && key != serviceNamespaceKey && key != serviceInstanceIDKey && !ok {
 			*keys = append(*keys, validation.SanitizeLabelNameWithCollisions(key, targetInfoIntrinsicLabelsSet, sanitizeFn))
 			value := tempo_util.StringifyAnyValue(attrs.Value)
 			*values = append(*values, value)
 		}
+	}
+}
+
+func excludedDimensionsSet(exclude []string) map[string]struct{} {
+	if len(exclude) == 0 {
+		return nil
+	}
+	m := make(map[string]struct{}, len(exclude))
+	for _, dim := range exclude {
+		m[dim] = struct{}{}
+	}
+	return m
+}
+
+func spanKindString(kind v1_trace.Span_SpanKind) string {
+	switch kind {
+	case v1_trace.Span_SPAN_KIND_UNSPECIFIED:
+		return "SPAN_KIND_UNSPECIFIED"
+	case v1_trace.Span_SPAN_KIND_INTERNAL:
+		return "SPAN_KIND_INTERNAL"
+	case v1_trace.Span_SPAN_KIND_SERVER:
+		return "SPAN_KIND_SERVER"
+	case v1_trace.Span_SPAN_KIND_CLIENT:
+		return "SPAN_KIND_CLIENT"
+	case v1_trace.Span_SPAN_KIND_PRODUCER:
+		return "SPAN_KIND_PRODUCER"
+	case v1_trace.Span_SPAN_KIND_CONSUMER:
+		return "SPAN_KIND_CONSUMER"
+	default:
+		return kind.String()
+	}
+}
+
+func statusCodeString(code v1_trace.Status_StatusCode) string {
+	switch code {
+	case v1_trace.Status_STATUS_CODE_UNSET:
+		return "STATUS_CODE_UNSET"
+	case v1_trace.Status_STATUS_CODE_OK:
+		return "STATUS_CODE_OK"
+	case v1_trace.Status_STATUS_CODE_ERROR:
+		return "STATUS_CODE_ERROR"
+	default:
+		return code.String()
 	}
 }

--- a/modules/generator/processor/spanmetrics/spanmetrics.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 	"time"
-	"unsafe"
 
 	"github.com/grafana/tempo/modules/generator/validation"
 	"github.com/prometheus/client_golang/prometheus"
@@ -323,12 +322,7 @@ func getResourceServiceLabels(attributes []*v1_common.KeyValue, jobNameBuf []byt
 	if namespace == "" {
 		return svcName, svcName, instanceID, jobNameBuf[:0]
 	}
-	jobNameBuf = append(jobNameBuf[:0], namespace...)
-	jobNameBuf = append(jobNameBuf, '/')
-	jobNameBuf = append(jobNameBuf, svcName...)
-	// The registry label builders copy label values before jobNameBuf is reused
-	// for the next resource.
-	return svcName, unsafe.String(unsafe.SliceData(jobNameBuf), len(jobNameBuf)), instanceID, jobNameBuf
+	return svcName, namespace + "/" + svcName, instanceID, jobNameBuf[:0]
 }
 
 func getTargetInfoAttributesValues(keys, values *[]string, attributes []*v1_common.KeyValue, exclude map[string]struct{}, sanitizeFn validation.SanitizeFn) {

--- a/modules/generator/processor/spanmetrics/spanmetrics_benchmark_test.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics_benchmark_test.go
@@ -24,7 +24,7 @@ func BenchmarkSpanMetricsPushSpans(b *testing.B) {
 	}{
 		{
 			name:    "default",
-			request: benchmarkSpanMetricsRequest(4, 100, true),
+			request: benchmarkSpanMetricsRequest(true),
 		},
 		{
 			name: "target_info",
@@ -32,7 +32,7 @@ func BenchmarkSpanMetricsPushSpans(b *testing.B) {
 				cfg.EnableTargetInfo = true
 				cfg.TargetInfoExcludedDimensions = []string{"excluded"}
 			},
-			request: benchmarkSpanMetricsRequest(4, 100, true),
+			request: benchmarkSpanMetricsRequest(true),
 		},
 		{
 			name: "target_info_all_filtered",
@@ -49,7 +49,7 @@ func BenchmarkSpanMetricsPushSpans(b *testing.B) {
 					},
 				}}
 			},
-			request: benchmarkSpanMetricsRequest(4, 100, true),
+			request: benchmarkSpanMetricsRequest(true),
 		},
 		{
 			name: "dimensions_and_mappings",
@@ -68,7 +68,7 @@ func BenchmarkSpanMetricsPushSpans(b *testing.B) {
 					{Name: "pod_key", SourceLabel: []string{"k8s.namespace.name", "k8s.pod.name"}, Join: "/"},
 				}
 			},
-			request: benchmarkSpanMetricsRequest(4, 100, true),
+			request: benchmarkSpanMetricsRequest(true),
 		},
 		{
 			name: "count_only",
@@ -76,7 +76,7 @@ func BenchmarkSpanMetricsPushSpans(b *testing.B) {
 				cfg.Subprocessors[Latency] = false
 				cfg.Subprocessors[Size] = false
 			},
-			request: benchmarkSpanMetricsRequest(4, 100, false),
+			request: benchmarkSpanMetricsRequest(false),
 		},
 	} {
 		b.Run(tc.name, func(b *testing.B) {
@@ -106,7 +106,12 @@ func BenchmarkSpanMetricsPushSpans(b *testing.B) {
 	}
 }
 
-func benchmarkSpanMetricsRequest(resources int, spansPerResource int, sameTracePerResource bool) *tempopb.PushSpansRequest {
+func benchmarkSpanMetricsRequest(sameTracePerResource bool) *tempopb.PushSpansRequest {
+	const (
+		resources        = 4
+		spansPerResource = 100
+	)
+
 	req := &tempopb.PushSpansRequest{
 		Batches: make([]*trace_v1.ResourceSpans, 0, resources),
 	}

--- a/modules/generator/processor/spanmetrics/spanmetrics_benchmark_test.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics_benchmark_test.go
@@ -1,0 +1,177 @@
+package spanmetrics
+
+import (
+	"context"
+	"encoding/binary"
+	"strconv"
+	"testing"
+
+	"github.com/grafana/tempo/modules/generator/registry"
+	"github.com/grafana/tempo/pkg/sharedconfig"
+	filterconfig "github.com/grafana/tempo/pkg/spanfilter/config"
+	"github.com/grafana/tempo/pkg/tempopb"
+	common_v1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	resource_v1 "github.com/grafana/tempo/pkg/tempopb/resource/v1"
+	trace_v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func BenchmarkSpanMetricsPushSpans(b *testing.B) {
+	for _, tc := range []struct {
+		name    string
+		tune    func(*Config)
+		request *tempopb.PushSpansRequest
+	}{
+		{
+			name:    "default",
+			request: benchmarkSpanMetricsRequest(4, 100, true),
+		},
+		{
+			name: "target_info",
+			tune: func(cfg *Config) {
+				cfg.EnableTargetInfo = true
+				cfg.TargetInfoExcludedDimensions = []string{"excluded"}
+			},
+			request: benchmarkSpanMetricsRequest(4, 100, true),
+		},
+		{
+			name: "target_info_all_filtered",
+			tune: func(cfg *Config) {
+				cfg.EnableTargetInfo = true
+				cfg.TargetInfoExcludedDimensions = []string{"excluded"}
+				cfg.FilterPolicies = []filterconfig.FilterPolicy{{
+					Exclude: &filterconfig.PolicyMatch{
+						MatchType: filterconfig.Strict,
+						Attributes: []filterconfig.MatchPolicyAttribute{{
+							Key:   "span.http.method",
+							Value: "GET",
+						}},
+					},
+				}}
+			},
+			request: benchmarkSpanMetricsRequest(4, 100, true),
+		},
+		{
+			name: "dimensions_and_mappings",
+			tune: func(cfg *Config) {
+				cfg.EnableTargetInfo = false
+				cfg.Dimensions = []string{
+					"k8s.cluster.name",
+					"k8s.namespace.name",
+					"http.method",
+					"http.status_code",
+					"span.attr.1",
+					"span.attr.2",
+				}
+				cfg.DimensionMappings = []sharedconfig.DimensionMappings{
+					{Name: "route_key", SourceLabel: []string{"http.method", "http.route", "http.status_code"}, Join: ":"},
+					{Name: "pod_key", SourceLabel: []string{"k8s.namespace.name", "k8s.pod.name"}, Join: "/"},
+				}
+			},
+			request: benchmarkSpanMetricsRequest(4, 100, true),
+		},
+		{
+			name: "count_only",
+			tune: func(cfg *Config) {
+				cfg.Subprocessors[Latency] = false
+				cfg.Subprocessors[Size] = false
+			},
+			request: benchmarkSpanMetricsRequest(4, 100, false),
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			cfg := Config{}
+			cfg.RegisterFlagsAndApplyDefaults("", nil)
+			if tc.tune != nil {
+				tc.tune(&cfg)
+			}
+
+			p, err := New(
+				cfg,
+				registry.NewTestRegistry(),
+				prometheus.NewCounter(prometheus.CounterOpts{}),
+				prometheus.NewCounter(prometheus.CounterOpts{}),
+			)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer p.Shutdown(context.Background())
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				p.PushSpans(context.Background(), tc.request)
+			}
+		})
+	}
+}
+
+func benchmarkSpanMetricsRequest(resources int, spansPerResource int, sameTracePerResource bool) *tempopb.PushSpansRequest {
+	req := &tempopb.PushSpansRequest{
+		Batches: make([]*trace_v1.ResourceSpans, 0, resources),
+	}
+	for r := 0; r < resources; r++ {
+		rs := &trace_v1.ResourceSpans{
+			Resource: &resource_v1.Resource{
+				Attributes: []*common_v1.KeyValue{
+					benchmarkStringAttr("service.name", "svc-"+strconv.Itoa(r)),
+					benchmarkStringAttr("service.namespace", "ns-"+strconv.Itoa(r%2)),
+					benchmarkStringAttr("service.instance.id", "instance-"+strconv.Itoa(r)),
+					benchmarkStringAttr("k8s.cluster.name", "cluster-a"),
+					benchmarkStringAttr("k8s.namespace.name", "namespace-"+strconv.Itoa(r%4)),
+					benchmarkStringAttr("k8s.pod.name", "pod-"+strconv.Itoa(r)),
+					benchmarkStringAttr("k8s.node.name", "node-"+strconv.Itoa(r%8)),
+					benchmarkStringAttr("telemetry.sdk.language", "go"),
+					benchmarkStringAttr("telemetry.sdk.version", "1.0.0"),
+					benchmarkStringAttr("excluded", "drop-me"),
+				},
+			},
+			ScopeSpans: []*trace_v1.ScopeSpans{{}},
+		}
+		for s := 0; s < spansPerResource; s++ {
+			traceID := benchmarkTraceID(r)
+			if !sameTracePerResource {
+				traceID = benchmarkTraceID(r*spansPerResource + s)
+			}
+			rs.ScopeSpans[0].Spans = append(rs.ScopeSpans[0].Spans, &trace_v1.Span{
+				TraceId:           traceID,
+				SpanId:            benchmarkSpanID(r*spansPerResource + s + 1),
+				Name:              "GET /api/:id",
+				Kind:              trace_v1.Span_SPAN_KIND_SERVER,
+				StartTimeUnixNano: uint64(1_700_000_000_000_000_000 + s),
+				EndTimeUnixNano:   uint64(1_700_000_000_100_000_000 + s),
+				Status:            &trace_v1.Status{Code: trace_v1.Status_STATUS_CODE_OK},
+				Attributes: []*common_v1.KeyValue{
+					benchmarkStringAttr("http.method", "GET"),
+					benchmarkStringAttr("http.route", "/api/:id"),
+					benchmarkStringAttr("http.status_code", "200"),
+					benchmarkStringAttr("span.attr.1", "one"),
+					benchmarkStringAttr("span.attr.2", "two"),
+				},
+			})
+		}
+		req.Batches = append(req.Batches, rs)
+	}
+	return req
+}
+
+func benchmarkTraceID(i int) []byte {
+	var id [16]byte
+	binary.BigEndian.PutUint64(id[8:], uint64(i+1))
+	return id[:]
+}
+
+func benchmarkSpanID(i int) []byte {
+	var id [8]byte
+	binary.BigEndian.PutUint64(id[:], uint64(i+1))
+	return id[:]
+}
+
+func benchmarkStringAttr(key, value string) *common_v1.KeyValue {
+	return &common_v1.KeyValue{
+		Key: key,
+		Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{
+			StringValue: value,
+		}},
+	}
+}

--- a/modules/generator/processor/spanmetrics/spanmetrics_test.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics_test.go
@@ -12,10 +12,12 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	gen "github.com/grafana/tempo/modules/generator/processor"
 	"github.com/grafana/tempo/modules/generator/registry"
 	"github.com/grafana/tempo/pkg/sharedconfig"
 	filterconfig "github.com/grafana/tempo/pkg/spanfilter/config"
@@ -1872,4 +1874,205 @@ func TestSpanMetricsTraceStateMultiplier(t *testing.T) {
 
 	// With 50% sampling (th:8), span multiplier is 2, so 1 span → count of 2
 	assert.Equal(t, 2.0, testRegistry.Query("traces_spanmetrics_calls_total", lbls))
+}
+
+// recordingRegistry wraps a TestRegistry and records the order of every metric
+// series update. The production registry limiter grants active-series and
+// entity capacity in call order, so tests use this to pin the relative
+// ordering of span metric and target_info updates.
+type recordingRegistry struct {
+	*registry.TestRegistry
+	calls []string
+}
+
+func newRecordingRegistry() *recordingRegistry {
+	return &recordingRegistry{TestRegistry: registry.NewTestRegistry()}
+}
+
+func (r *recordingRegistry) NewCounter(name string) registry.Counter {
+	return &recordingCounter{Counter: r.TestRegistry.NewCounter(name), name: name, calls: &r.calls}
+}
+
+func (r *recordingRegistry) NewGauge(name string) registry.Gauge {
+	return &recordingGauge{Gauge: r.TestRegistry.NewGauge(name), name: name, calls: &r.calls}
+}
+
+func (r *recordingRegistry) NewHistogram(name string, buckets []float64, mode registry.HistogramMode) registry.Histogram {
+	return &recordingHistogram{Histogram: r.TestRegistry.NewHistogram(name, buckets, mode), name: name, calls: &r.calls}
+}
+
+type recordingCounter struct {
+	registry.Counter
+	name  string
+	calls *[]string
+}
+
+func (c *recordingCounter) Inc(lbls labels.Labels, value float64) {
+	*c.calls = append(*c.calls, c.name)
+	c.Counter.Inc(lbls, value)
+}
+
+func (c *recordingCounter) IncWithHash(lbls labels.Labels, hash uint64, value float64) {
+	*c.calls = append(*c.calls, c.name)
+	c.Counter.IncWithHash(lbls, hash, value)
+}
+
+func (c *recordingCounter) IncWithHashAt(lbls labels.Labels, hash uint64, value float64, timeMs int64) {
+	*c.calls = append(*c.calls, c.name)
+	c.Counter.IncWithHashAt(lbls, hash, value, timeMs)
+}
+
+type recordingGauge struct {
+	registry.Gauge
+	name  string
+	calls *[]string
+}
+
+func (g *recordingGauge) Set(lbls labels.Labels, value float64) {
+	*g.calls = append(*g.calls, g.name)
+	g.Gauge.Set(lbls, value)
+}
+
+func (g *recordingGauge) Inc(lbls labels.Labels, value float64) {
+	*g.calls = append(*g.calls, g.name)
+	g.Gauge.Inc(lbls, value)
+}
+
+func (g *recordingGauge) SetForTargetInfo(lbls labels.Labels, value float64) {
+	*g.calls = append(*g.calls, g.name)
+	g.Gauge.SetForTargetInfo(lbls, value)
+}
+
+func (g *recordingGauge) SetForTargetInfoWithHash(lbls labels.Labels, hash uint64, value float64) {
+	*g.calls = append(*g.calls, g.name)
+	g.Gauge.SetForTargetInfoWithHash(lbls, hash, value)
+}
+
+func (g *recordingGauge) SetForTargetInfoWithHashAt(lbls labels.Labels, hash uint64, value float64, timeMs int64) {
+	*g.calls = append(*g.calls, g.name)
+	g.Gauge.SetForTargetInfoWithHashAt(lbls, hash, value, timeMs)
+}
+
+type recordingHistogram struct {
+	registry.Histogram
+	name  string
+	calls *[]string
+}
+
+func (h *recordingHistogram) ObserveWithExemplar(lbls labels.Labels, value float64, traceID string, multiplier float64) {
+	*h.calls = append(*h.calls, h.name)
+	h.Histogram.ObserveWithExemplar(lbls, value, traceID, multiplier)
+}
+
+func (h *recordingHistogram) ObserveWithExemplarWithHash(lbls labels.Labels, hash uint64, value float64, traceID string, multiplier float64) {
+	*h.calls = append(*h.calls, h.name)
+	h.Histogram.ObserveWithExemplarWithHash(lbls, hash, value, traceID, multiplier)
+}
+
+func (h *recordingHistogram) ObserveWithExemplarWithHashAt(lbls labels.Labels, hash uint64, value float64, traceID string, multiplier float64, timeMs int64) {
+	*h.calls = append(*h.calls, h.name)
+	h.Histogram.ObserveWithExemplarWithHashAt(lbls, hash, value, traceID, multiplier, timeMs)
+}
+
+func (h *recordingHistogram) ObserveWithExemplarTraceIDBytesWithHashAt(lbls labels.Labels, hash uint64, value float64, traceID []byte, multiplier float64, timeMs int64) {
+	*h.calls = append(*h.calls, h.name)
+	h.Histogram.ObserveWithExemplarTraceIDBytesWithHashAt(lbls, hash, value, traceID, multiplier, timeMs)
+}
+
+// TestSpanMetricsTargetInfoRegisteredAfterSpanMetrics pins the order in which
+// series are updated when target_info is enabled. The registry limiter grants
+// active-series and entity capacity in call order, so near the limit the span
+// metrics must claim the remaining capacity before target_info — not the
+// other way around. It also pins that target_info is registered exactly once
+// per resource batch.
+func TestSpanMetricsTargetInfoRegisteredAfterSpanMetrics(t *testing.T) {
+	recReg := newRecordingRegistry()
+	filteredSpansCounter := metricSpansDiscarded.WithLabelValues("test-tenant", "filtered", "span-metrics")
+	invalidUTF8SpanLabelsCounter := metricSpansDiscarded.WithLabelValues("test-tenant", "invalid_utf8", "span-metrics")
+
+	cfg := Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", nil)
+	cfg.HistogramBuckets = []float64{0.5, 1}
+	cfg.EnableTargetInfo = true
+
+	p, err := New(cfg, recReg, filteredSpansCounter, invalidUTF8SpanLabelsCounter)
+	require.NoError(t, err)
+	defer p.Shutdown(context.Background())
+
+	batch := test.MakeBatch(2, nil)
+	p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{batch}})
+
+	expected := []string{
+		// First accepted span updates its own series before target_info.
+		"traces_spanmetrics_calls_total",
+		"traces_spanmetrics_latency",
+		"traces_spanmetrics_size_total",
+		"traces_target_info",
+		// Subsequent spans of the same resource do not re-register target_info.
+		"traces_spanmetrics_calls_total",
+		"traces_spanmetrics_latency",
+		"traces_spanmetrics_size_total",
+	}
+	assert.Equal(t, expected, recReg.calls)
+}
+
+// TestSpanMetricsTargetInfoInvalidUTF8Spans verifies that target_info follows
+// the pre-optimization contract: it is registered only once a span's primary
+// labels validate, so a resource whose accepted spans all carry invalid UTF-8
+// labels emits no target_info at all.
+func TestSpanMetricsTargetInfoInvalidUTF8Spans(t *testing.T) {
+	newProcessor := func(t *testing.T) (*registry.TestRegistry, prometheus.Counter, gen.Processor) {
+		t.Helper()
+		testRegistry := registry.NewTestRegistry()
+		filteredSpansCounter := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_filtered_spans_total"})
+		invalidUTF8Counter := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_invalid_utf8_spans_total"})
+
+		cfg := Config{}
+		cfg.RegisterFlagsAndApplyDefaults("", nil)
+		cfg.HistogramBuckets = []float64{0.5, 1}
+		cfg.EnableTargetInfo = true
+
+		p, err := New(cfg, testRegistry, filteredSpansCounter, invalidUTF8Counter)
+		require.NoError(t, err)
+		return testRegistry, invalidUTF8Counter, p
+	}
+
+	t.Run("all spans invalid emits no target_info", func(t *testing.T) {
+		testRegistry, invalidUTF8Counter, p := newProcessor(t)
+		defer p.Shutdown(context.Background())
+
+		batch := test.MakeBatch(2, nil)
+		for _, ss := range batch.ScopeSpans {
+			for _, span := range ss.Spans {
+				span.Name = "invalid-\xff-utf8"
+			}
+		}
+
+		p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{batch}})
+
+		assert.NotContains(t, testRegistry.String(), "traces_target_info")
+		assert.NotContains(t, testRegistry.String(), "traces_spanmetrics_calls_total")
+		assert.Equal(t, 2.0, testutil.ToFloat64(invalidUTF8Counter))
+	})
+
+	t.Run("target_info registered after first valid span", func(t *testing.T) {
+		testRegistry, invalidUTF8Counter, p := newProcessor(t)
+		defer p.Shutdown(context.Background())
+
+		batch := test.MakeBatch(2, nil)
+		batch.ScopeSpans[0].Spans[0].Name = "invalid-\xff-utf8"
+
+		p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{batch}})
+
+		assert.Contains(t, testRegistry.String(), "traces_target_info")
+		lbls := labels.FromMap(map[string]string{
+			"service":     "test-service",
+			"span_name":   "test",
+			"span_kind":   "SPAN_KIND_CLIENT",
+			"status_code": "STATUS_CODE_OK",
+			"job":         "test-service",
+		})
+		assert.Equal(t, 1.0, testRegistry.Query("traces_spanmetrics_calls_total", lbls))
+		assert.Equal(t, 1.0, testutil.ToFloat64(invalidUTF8Counter))
+	})
 }

--- a/modules/generator/processor/spanmetrics/spanmetrics_test.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics_test.go
@@ -2075,4 +2075,72 @@ func TestSpanMetricsTargetInfoInvalidUTF8Spans(t *testing.T) {
 		assert.Equal(t, 1.0, testRegistry.Query("traces_spanmetrics_calls_total", lbls))
 		assert.Equal(t, 1.0, testutil.ToFloat64(invalidUTF8Counter))
 	})
+
+	t.Run("invalid target_info labels still emit span metrics", func(t *testing.T) {
+		testRegistry, invalidUTF8Counter, p := newProcessor(t)
+		defer p.Shutdown(context.Background())
+
+		// Valid spans, but a resource attribute with an invalid UTF-8 value
+		// poisons the target_info label set only.
+		batch := test.MakeBatchWithAttributes(2, nil, []*common_v1.KeyValue{
+			{
+				Key: "res.attr",
+				Value: &common_v1.AnyValue{
+					Value: &common_v1.AnyValue_StringValue{StringValue: "invalid-\xff-utf8"},
+				},
+			},
+		})
+
+		p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{batch}})
+
+		// Span metrics still emit for both spans; target_info is rejected and
+		// counted once per accepted span (pre-optimization contract).
+		lbls := labels.FromMap(map[string]string{
+			"service":     "test-service",
+			"span_name":   "test",
+			"span_kind":   "SPAN_KIND_CLIENT",
+			"status_code": "STATUS_CODE_OK",
+			"job":         "test-service",
+		})
+		assert.Equal(t, 2.0, testRegistry.Query("traces_spanmetrics_calls_total", lbls))
+		assert.NotContains(t, testRegistry.String(), "traces_target_info")
+		assert.Equal(t, 2.0, testutil.ToFloat64(invalidUTF8Counter))
+	})
+}
+
+// TestSpanMetricsTargetInfoWithDisabledSubprocessors pins that target_info
+// registration only depends on the span's primary labels being valid UTF-8,
+// not on any span metric series actually being updated.
+func TestSpanMetricsTargetInfoWithDisabledSubprocessors(t *testing.T) {
+	testRegistry := registry.NewTestRegistry()
+	filteredSpansCounter := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_filtered_spans_total"})
+	invalidUTF8Counter := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_invalid_utf8_spans_total"})
+
+	cfg := Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", nil)
+	cfg.EnableTargetInfo = true
+	cfg.Subprocessors[Count] = false
+	cfg.Subprocessors[Latency] = false
+	cfg.Subprocessors[Size] = false
+
+	p, err := New(cfg, testRegistry, filteredSpansCounter, invalidUTF8Counter)
+	require.NoError(t, err)
+	defer p.Shutdown(context.Background())
+
+	batch := test.MakeBatch(1, nil)
+	p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{batch}})
+
+	var resAttr string
+	for _, kv := range batch.Resource.Attributes {
+		if kv.Key == "random.res.attr" {
+			resAttr = kv.Value.GetStringValue()
+		}
+	}
+	targetInfoLabels := labels.FromMap(map[string]string{
+		"job":             "test-service",
+		"random_res_attr": resAttr,
+	})
+	assert.Equal(t, 1.0, testRegistry.Query("traces_target_info", targetInfoLabels))
+	assert.NotContains(t, testRegistry.String(), "traces_spanmetrics_calls_total")
+	assert.Equal(t, 0.0, testutil.ToFloat64(invalidUTF8Counter))
 }

--- a/modules/generator/registry/builder.go
+++ b/modules/generator/registry/builder.go
@@ -1,9 +1,10 @@
 package registry
 
 import (
+	"strings"
 	"sync"
+	"unicode/utf8"
 
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 )
 
@@ -15,7 +16,7 @@ func newSafeBuilderPool() *safeBuilderPool {
 	return &safeBuilderPool{
 		pool: sync.Pool{
 			New: func() interface{} {
-				return labels.NewBuilder(labels.New())
+				return labels.NewBuilder(labels.EmptyLabels())
 			},
 		},
 	}
@@ -26,59 +27,197 @@ func (p *safeBuilderPool) Get() *labels.Builder {
 }
 
 func (p *safeBuilderPool) Put(builder *labels.Builder) {
-	builder.Reset(labels.New())
+	builder.Reset(labels.EmptyLabels())
 	p.pool.Put(builder)
 }
 
-var builderPool = newSafeBuilderPool()
-
 type labelBuilder struct {
-	builder         *labels.Builder
 	sanitizer       Sanitizer
 	perLabelLimiter LabelLimiter
+	labels          []labels.Label
 
 	maxLabelNameLength  int
 	maxLabelValueLength int
+	closed              bool
 }
 
 var _ LabelBuilder = (*labelBuilder)(nil)
 
+var labelBuilderPool = sync.Pool{
+	New: func() interface{} {
+		return &labelBuilder{
+			labels: make([]labels.Label, 0, 16),
+		}
+	},
+}
+
+var scratchBuilderPool = sync.Pool{
+	New: func() interface{} {
+		b := labels.NewScratchBuilder(16)
+		return &b
+	},
+}
+
 func NewLabelBuilder(maxLabelNameLength int, maxLabelValueLength int, sanitizer Sanitizer, perLabelLimiter LabelLimiter) LabelBuilder {
-	builder := builderPool.Get()
-	return &labelBuilder{
-		builder:             builder,
-		sanitizer:           sanitizer,
-		perLabelLimiter:     perLabelLimiter,
-		maxLabelNameLength:  maxLabelNameLength,
-		maxLabelValueLength: maxLabelValueLength,
-	}
+	b := labelBuilderPool.Get().(*labelBuilder)
+	b.sanitizer = sanitizer
+	b.perLabelLimiter = perLabelLimiter
+	b.labels = b.labels[:0]
+	b.maxLabelNameLength = maxLabelNameLength
+	b.maxLabelValueLength = maxLabelValueLength
+	b.closed = false
+	return b
 }
 
 func (b *labelBuilder) Add(name, value string) {
+	if b.closed {
+		panic("label builder used after Close")
+	}
 	if b.maxLabelNameLength > 0 && len(name) > b.maxLabelNameLength {
 		name = name[:b.maxLabelNameLength]
 	}
 	if b.maxLabelValueLength > 0 && len(value) > b.maxLabelValueLength {
 		value = value[:b.maxLabelValueLength]
 	}
-	b.builder.Set(name, value)
+	if value == "" {
+		// Empty value deletes any prior label with this name (mirrors the
+		// prometheus.Builder.Set("x","") -> Del("x") semantics that callers
+		// depend on for sanitization-collision handling).
+		out := b.labels[:0]
+		for _, l := range b.labels {
+			if l.Name != name {
+				out = append(out, l)
+			}
+		}
+		b.labels = out
+		return
+	}
+	b.labels = append(b.labels, labels.Label{Name: name, Value: value})
 }
 
 func (b *labelBuilder) CloseAndBuildLabels() (labels.Labels, bool) {
+	b.closed = true
+	scratch := scratchBuilderPool.Get().(*labels.ScratchBuilder)
+	b.prepareScratch(scratch)
+	lbls := scratch.Labels()
+	scratchBuilderPool.Put(scratch)
+
 	// We always run sanitizer first and then run per label limiter to ensure that
 	// per label limits are always applied after sanitizer.
 	// Pipeline: sanitize labels --> per-label cardinality limit --> entity/series limit
-	lbls := b.sanitizer.Sanitize(b.builder.Labels())
+	lbls = b.sanitizer.Sanitize(lbls)
 	lbls = b.perLabelLimiter.Limit(lbls)
 	// it's no longer safe to use the builder after this point, so we drop our
-	// reference to it. this may cause a nil panic if the builder is used after
-	// this point, but it's better than memory corruption.
-	builderPool.Put(b.builder)
-	b.builder = nil
+	// reference to it. The closed flag is best-effort: it catches misuse against
+	// the same builder reference, but once the builder is recycled to the pool
+	// and re-issued, a stale reference would corrupt another caller's labels.
+	b.sanitizer = nil
+	b.perLabelLimiter = nil
+	b.labels = b.labels[:0]
+	b.maxLabelNameLength = 0
+	b.maxLabelValueLength = 0
+	labelBuilderPool.Put(b)
 
-	if !lbls.IsValid(model.UTF8Validation) {
+	if !validUTF8Labels(lbls) {
 		return lbls, false
 	}
 
 	return lbls, true
+}
+
+func (b *labelBuilder) CloseAndBorrowLabels() (BorrowedLabels, bool) {
+	b.closed = true
+	scratch := scratchBuilderPool.Get().(*labels.ScratchBuilder)
+	b.prepareScratch(scratch)
+	var lbls labels.Labels
+	scratch.Overwrite(&lbls)
+
+	// We always run sanitizer first and then run per label limiter to ensure that
+	// per label limits are always applied after sanitizer.
+	// Pipeline: sanitize labels --> per-label cardinality limit --> entity/series limit
+	lbls = b.sanitizer.Sanitize(lbls)
+	lbls = b.perLabelLimiter.Limit(lbls)
+	if !validUTF8Labels(lbls) {
+		b.releaseBorrowedLabels(scratch)
+		return BorrowedLabels{}, false
+	}
+
+	return BorrowedLabels{
+		Labels:  lbls,
+		Hash:    lbls.Hash(),
+		builder: b,
+		scratch: scratch,
+	}, true
+}
+
+func (b *labelBuilder) releaseBorrowedLabels(scratch *labels.ScratchBuilder) {
+	// it's no longer safe to use the builder after this point, so we drop our
+	// reference to it. this may cause a nil panic if the builder is used after
+	// this point, but it's better than memory corruption.
+	b.sanitizer = nil
+	b.perLabelLimiter = nil
+	b.labels = b.labels[:0]
+	b.maxLabelNameLength = 0
+	b.maxLabelValueLength = 0
+	scratchBuilderPool.Put(scratch)
+	labelBuilderPool.Put(b)
+}
+
+func (b *labelBuilder) prepareScratch(scratch *labels.ScratchBuilder) {
+	scratch.Reset()
+	sortLabels(b.labels)
+	b.labels = compactLabels(b.labels)
+	for _, l := range b.labels {
+		scratch.Add(l.Name, l.Value)
+	}
+}
+
+func validUTF8Labels(lbls labels.Labels) bool {
+	valid := true
+	lbls.Range(func(l labels.Label) {
+		if !valid {
+			return
+		}
+		valid = l.Name != "" && utf8.ValidString(l.Name) && utf8.ValidString(l.Value)
+	})
+	return valid
+}
+
+func sortLabels(lbls []labels.Label) {
+	for i := 1; i < len(lbls); i++ {
+		for j := i; j > 0 && strings.Compare(lbls[j-1].Name, lbls[j].Name) > 0; j-- {
+			lbls[j-1], lbls[j] = lbls[j], lbls[j-1]
+		}
+	}
+}
+
+func compactLabels(lbls []labels.Label) []labels.Label {
+	if len(lbls) == 0 {
+		return lbls
+	}
+
+	for i, l := range lbls {
+		if l.Value == "" || (i > 0 && l.Name == lbls[i-1].Name) {
+			return compactLabelsSlow(lbls)
+		}
+	}
+	return lbls
+}
+
+func compactLabelsSlow(lbls []labels.Label) []labels.Label {
+	write := 0
+	for read := 0; read < len(lbls); {
+		next := read + 1
+		for next < len(lbls) && lbls[next].Name == lbls[read].Name {
+			next++
+		}
+
+		last := lbls[next-1]
+		if last.Value != "" {
+			lbls[write] = last
+			write++
+		}
+		read = next
+	}
+	return lbls[:write]
 }

--- a/modules/generator/registry/builder.go
+++ b/modules/generator/registry/builder.go
@@ -8,29 +8,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 )
 
-type safeBuilderPool struct {
-	pool sync.Pool
-}
-
-func newSafeBuilderPool() *safeBuilderPool {
-	return &safeBuilderPool{
-		pool: sync.Pool{
-			New: func() interface{} {
-				return labels.NewBuilder(labels.EmptyLabels())
-			},
-		},
-	}
-}
-
-func (p *safeBuilderPool) Get() *labels.Builder {
-	return p.pool.Get().(*labels.Builder)
-}
-
-func (p *safeBuilderPool) Put(builder *labels.Builder) {
-	builder.Reset(labels.EmptyLabels())
-	p.pool.Put(builder)
-}
-
 type labelBuilder struct {
 	sanitizer       Sanitizer
 	perLabelLimiter LabelLimiter

--- a/modules/generator/registry/builder.go
+++ b/modules/generator/registry/builder.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"slices"
 	"strings"
 	"sync"
 	"unicode/utf8"
@@ -160,7 +161,21 @@ func validUTF8Labels(lbls labels.Labels) bool {
 	return valid
 }
 
+// insertionSortThreshold is the label count above which sortLabels falls back
+// to the standard library sort. Span metric label sets are almost always small
+// and nearly sorted, where insertion sort is faster and allocation-free, but it
+// is O(n²) so large label sets (e.g. target_info on resources with many
+// attributes) use O(n log n) instead. Both paths are stable: compactLabels
+// relies on the last-added duplicate name winning.
+const insertionSortThreshold = 16
+
 func sortLabels(lbls []labels.Label) {
+	if len(lbls) > insertionSortThreshold {
+		slices.SortStableFunc(lbls, func(a, b labels.Label) int {
+			return strings.Compare(a.Name, b.Name)
+		})
+		return
+	}
 	for i := 1; i < len(lbls); i++ {
 		for j := i; j > 0 && strings.Compare(lbls[j-1].Name, lbls[j].Name) > 0; j-- {
 			lbls[j-1], lbls[j] = lbls[j], lbls[j-1]

--- a/modules/generator/registry/builder_test.go
+++ b/modules/generator/registry/builder_test.go
@@ -155,10 +155,14 @@ func TestLabelBuilder_LargeLabelSetSortsAndDeduplicates(t *testing.T) {
 	builder := NewLabelBuilder(0, 0, newTestDrainSanitizer(SpanNameSanitizationDisabled), newTestLabelLimiter())
 
 	want := make(map[string]string, insertionSortThreshold+2)
-	// Add in reverse order to force real sorting work.
+	// Add every name once in reverse order, then again in reverse order with
+	// the final values: duplicates are interleaved across the whole set, so
+	// last-write-wins only holds if the fallback sort is stable.
+	for i := insertionSortThreshold + 1; i >= 0; i-- {
+		builder.Add(fmt.Sprintf("label_%03d", i), "first")
+	}
 	for i := insertionSortThreshold + 1; i >= 0; i-- {
 		name := fmt.Sprintf("label_%03d", i)
-		builder.Add(name, "first")
 		builder.Add(name, fmt.Sprintf("value_%03d", i))
 		want[name] = fmt.Sprintf("value_%03d", i)
 	}

--- a/modules/generator/registry/builder_test.go
+++ b/modules/generator/registry/builder_test.go
@@ -42,28 +42,27 @@ func TestLabelBuilder_InvalidUTF8(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestSafeBuilderPool(t *testing.T) {
-	pool := newSafeBuilderPool()
-	builder := pool.Get()
-	builder.Set("name", "value")
-	lbls := builder.Labels()
-
-	assert.Equal(t, labels.FromStrings("name", "value"), lbls)
-
-	// Putting the builder back into the pool should reset it.
-	pool.Put(builder)
-
-	reusedBuilder := pool.Get()
-	assert.Equal(t, builder, reusedBuilder)
-	assert.Equal(t, labels.EmptyLabels(), reusedBuilder.Labels())
-}
-
 type sanitizerFunc func(lbls labels.Labels) labels.Labels
 
 var _ Sanitizer = (*sanitizerFunc)(nil)
 
 func (s sanitizerFunc) Sanitize(lbls labels.Labels) labels.Labels {
 	return s(lbls)
+}
+
+func TestLabelBuilder_DuplicateNamesLastWriteWins(t *testing.T) {
+	// Two non-empty Adds with the same name must yield the last value, matching
+	// prometheus.Builder.Set semantics. compactLabels' fast path detects the
+	// duplicate and routes to compactLabelsSlow, which keeps the last entry of
+	// each contiguous group of equal names after stable sorting.
+	builder := NewLabelBuilder(0, 0, newTestDrainSanitizer(SpanNameSanitizationDisabled), newTestLabelLimiter())
+	builder.Add("dup", "first")
+	builder.Add("other", "v")
+	builder.Add("dup", "second")
+
+	lbls, ok := builder.CloseAndBuildLabels()
+	assert.True(t, ok)
+	assert.Equal(t, labels.FromStrings("dup", "second", "other", "v"), lbls)
 }
 
 func TestLabelBuilder_AddEmptyValueRemovesAllMatches(t *testing.T) {
@@ -82,10 +81,49 @@ func TestLabelBuilder_AddEmptyValueRemovesAllMatches(t *testing.T) {
 	assert.Equal(t, labels.FromStrings("other", "v"), lbls)
 }
 
+func TestBorrowedLabels_AppliesSanitizerAndLimiter(t *testing.T) {
+	// CloseAndBorrowLabels runs sanitizer then per-label limiter, like
+	// CloseAndBuildLabels. Verify the same transformations apply through the
+	// borrow path so callers can use either entry point interchangeably.
+	builder := NewLabelBuilder(0, 0, sanitizerFunc(func(_ labels.Labels) labels.Labels {
+		return labels.FromStrings("name", "sanitized")
+	}), newTestLabelLimiter())
+	builder.Add("name", "raw")
+
+	borrowed, ok := builder.CloseAndBorrowLabels()
+	assert.True(t, ok)
+	assert.Equal(t, "sanitized", borrowed.Labels.Get("name"))
+	borrowed.Release()
+}
+
+func TestBorrowedLabels_SequentialReuseDoesNotLeak(t *testing.T) {
+	// The scratch pool reissues the same buffer to the next caller after
+	// Release. Verify that a second borrow does not see labels from the first.
+	for range 5 {
+		builder := NewLabelBuilder(0, 0, newTestDrainSanitizer(SpanNameSanitizationDisabled), newTestLabelLimiter())
+		builder.Add("first", "a")
+		first, ok := builder.CloseAndBorrowLabels()
+		assert.True(t, ok)
+		assert.Equal(t, "a", first.Labels.Get("first"))
+		first.Release()
+
+		builder = NewLabelBuilder(0, 0, newTestDrainSanitizer(SpanNameSanitizationDisabled), newTestLabelLimiter())
+		builder.Add("second", "b")
+		second, ok := builder.CloseAndBorrowLabels()
+		assert.True(t, ok)
+		assert.Equal(t, "", second.Labels.Get("first"))
+		assert.Equal(t, "b", second.Labels.Get("second"))
+		second.Release()
+	}
+}
+
 func TestBorrowedLabels_ReleaseIsIdempotent(t *testing.T) {
-	// Release must not double-Put the builder/scratch into their pools.
-	// Calling it twice on the same value is a defensive guard against future
-	// callers that accidentally release through both a pointer and a copy.
+	// Release must not double-Put the builder/scratch into their pools when
+	// called more than once on the same struct value. This only protects
+	// repeated Release on the same value — Release on a copy of BorrowedLabels
+	// is documented as forbidden because each copy retains independent
+	// non-nil builder/scratch pointers and the second Release on the copy
+	// would still double-Put.
 	builder := NewLabelBuilder(0, 0, newTestDrainSanitizer(SpanNameSanitizationDisabled), newTestLabelLimiter())
 	builder.Add("name", "value")
 

--- a/modules/generator/registry/builder_test.go
+++ b/modules/generator/registry/builder_test.go
@@ -66,6 +66,39 @@ func (s sanitizerFunc) Sanitize(lbls labels.Labels) labels.Labels {
 	return s(lbls)
 }
 
+func TestLabelBuilder_AddEmptyValueRemovesAllMatches(t *testing.T) {
+	// Add(name, "") must mirror prometheus.Builder.Set("x","")->Del("x"), which
+	// removes every prior label with that name. Sanitization can collapse
+	// distinct input keys (foo.bar, foo_bar, foo-bar) onto the same name, and
+	// removing only the first match would leave a stale earlier value.
+	builder := NewLabelBuilder(0, 0, newTestDrainSanitizer(SpanNameSanitizationDisabled), newTestLabelLimiter())
+	builder.Add("dup", "first")
+	builder.Add("other", "v")
+	builder.Add("dup", "second")
+	builder.Add("dup", "")
+
+	lbls, ok := builder.CloseAndBuildLabels()
+	assert.True(t, ok)
+	assert.Equal(t, labels.FromStrings("other", "v"), lbls)
+}
+
+func TestBorrowedLabels_ReleaseIsIdempotent(t *testing.T) {
+	// Release must not double-Put the builder/scratch into their pools.
+	// Calling it twice on the same value is a defensive guard against future
+	// callers that accidentally release through both a pointer and a copy.
+	builder := NewLabelBuilder(0, 0, newTestDrainSanitizer(SpanNameSanitizationDisabled), newTestLabelLimiter())
+	builder.Add("name", "value")
+
+	borrowed, ok := builder.CloseAndBorrowLabels()
+	assert.True(t, ok)
+	assert.Equal(t, "value", borrowed.Labels.Get("name"))
+
+	borrowed.Release()
+	// second release is a no-op; would otherwise corrupt the sync.Pool.
+	borrowed.Release()
+	assert.Equal(t, labels.EmptyLabels(), borrowed.Labels)
+}
+
 func TestLabelBuilder_Sanitizer(t *testing.T) {
 	builder := NewLabelBuilder(0, 0, sanitizerFunc(func(_ labels.Labels) labels.Labels {
 		return labels.FromStrings("name", "sanitized_value")

--- a/modules/generator/registry/builder_test.go
+++ b/modules/generator/registry/builder_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -146,4 +147,23 @@ func TestLabelBuilder_Sanitizer(t *testing.T) {
 
 	assert.True(t, ok)
 	assert.Equal(t, labels.FromStrings("name", "sanitized_value"), lbls)
+}
+
+func TestLabelBuilder_LargeLabelSetSortsAndDeduplicates(t *testing.T) {
+	// More than insertionSortThreshold labels routes sortLabels to the stdlib
+	// stable sort. Last-write-wins for duplicates must hold on that path too.
+	builder := NewLabelBuilder(0, 0, newTestDrainSanitizer(SpanNameSanitizationDisabled), newTestLabelLimiter())
+
+	want := make(map[string]string, insertionSortThreshold+2)
+	// Add in reverse order to force real sorting work.
+	for i := insertionSortThreshold + 1; i >= 0; i-- {
+		name := fmt.Sprintf("label_%03d", i)
+		builder.Add(name, "first")
+		builder.Add(name, fmt.Sprintf("value_%03d", i))
+		want[name] = fmt.Sprintf("value_%03d", i)
+	}
+
+	lbls, ok := builder.CloseAndBuildLabels()
+	assert.True(t, ok)
+	assert.Equal(t, labels.FromMap(want), lbls)
 }

--- a/modules/generator/registry/counter.go
+++ b/modules/generator/registry/counter.go
@@ -59,12 +59,7 @@ func newCounter(name string, lifecycler Limiter, externalLabels map[string]strin
 }
 
 func (c *counter) Inc(lbls labels.Labels, value float64) {
-	if value < 0 {
-		panic("counter can only increase")
-	}
-
-	hash := lbls.Hash()
-	c.IncWithHash(lbls, hash, value)
+	c.IncWithHash(lbls, lbls.Hash(), value)
 }
 
 func (c *counter) IncWithHash(lbls labels.Labels, hash uint64, value float64) {

--- a/modules/generator/registry/counter.go
+++ b/modules/generator/registry/counter.go
@@ -64,14 +64,24 @@ func (c *counter) Inc(lbls labels.Labels, value float64) {
 	}
 
 	hash := lbls.Hash()
+	c.IncWithHash(lbls, hash, value)
+}
 
+func (c *counter) IncWithHash(lbls labels.Labels, hash uint64, value float64) {
+	c.IncWithHashAt(lbls, hash, value, time.Now().UnixMilli())
+}
+
+func (c *counter) IncWithHashAt(lbls labels.Labels, hash uint64, value float64, timeMs int64) {
+	if value < 0 {
+		panic("counter can only increase")
+	}
 	c.seriesMtx.RLock()
 	s, ok := c.series[hash]
 	c.seriesMtx.RUnlock()
 
 	c.seriesDemand.Insert(hash)
 	if ok {
-		c.updateSeries(hash, s, value)
+		c.updateSeries(hash, s, value, timeMs)
 		return
 	}
 
@@ -80,11 +90,11 @@ func (c *counter) Inc(lbls labels.Labels, value float64) {
 
 	s, lbls, hash = resolveSeries(c.series, hash, lbls, c.lifecycler, 1)
 	if s != nil {
-		c.updateSeries(hash, s, value)
+		c.updateSeries(hash, s, value, timeMs)
 		return
 	}
 
-	c.series[hash] = c.newSeries(lbls, value)
+	c.series[hash] = c.newSeries(lbls, value, timeMs)
 }
 
 func resolveSeries[T any](series map[uint64]*T, hash uint64, lbls labels.Labels, lifecycler Limiter, count uint32) (*T, labels.Labels, uint64) {
@@ -105,18 +115,18 @@ func resolveSeries[T any](series map[uint64]*T, hash uint64, lbls labels.Labels,
 	return nil, lbls, hash
 }
 
-func (c *counter) newSeries(lbls labels.Labels, value float64) *counterSeries {
+func (c *counter) newSeries(lbls labels.Labels, value float64, timeMs int64) *counterSeries {
 	return &counterSeries{
 		labels:      getSeriesLabels(c.metricName, lbls, c.externalLabels),
 		value:       atomic.NewFloat64(value),
-		lastUpdated: atomic.NewInt64(time.Now().UnixMilli()),
+		lastUpdated: atomic.NewInt64(timeMs),
 		firstSeries: atomic.NewBool(true),
 	}
 }
 
-func (c *counter) updateSeries(hash uint64, s *counterSeries, value float64) {
+func (c *counter) updateSeries(hash uint64, s *counterSeries, value float64, timeMs int64) {
 	s.value.Add(value)
-	s.lastUpdated.Store(time.Now().UnixMilli())
+	s.lastUpdated.Store(timeMs)
 	c.lifecycler.OnUpdate(hash, 1)
 }
 

--- a/modules/generator/registry/gauge.go
+++ b/modules/generator/registry/gauge.go
@@ -55,20 +55,26 @@ func newGauge(name string, lifecycler Limiter, externalLabels map[string]string,
 }
 
 func (g *gauge) Set(lbls labels.Labels, value float64) {
-	g.updateSeries(lbls, value, set, true)
+	g.updateSeries(lbls, lbls.Hash(), value, set, true, time.Now().UnixMilli())
 }
 
 func (g *gauge) Inc(lbls labels.Labels, value float64) {
-	g.updateSeries(lbls, value, add, true)
+	g.updateSeries(lbls, lbls.Hash(), value, add, true, time.Now().UnixMilli())
 }
 
 func (g *gauge) SetForTargetInfo(lbls labels.Labels, value float64) {
-	g.updateSeries(lbls, value, set, false)
+	g.SetForTargetInfoWithHash(lbls, lbls.Hash(), value)
 }
 
-func (g *gauge) updateSeries(lbls labels.Labels, value float64, operation string, updateIfAlreadyExist bool) {
-	hash := lbls.Hash()
+func (g *gauge) SetForTargetInfoWithHash(lbls labels.Labels, hash uint64, value float64) {
+	g.SetForTargetInfoWithHashAt(lbls, hash, value, time.Now().UnixMilli())
+}
 
+func (g *gauge) SetForTargetInfoWithHashAt(lbls labels.Labels, hash uint64, value float64, timeMs int64) {
+	g.updateSeries(lbls, hash, value, set, false, timeMs)
+}
+
+func (g *gauge) updateSeries(lbls labels.Labels, hash uint64, value float64, operation string, updateIfAlreadyExist bool, timeMs int64) {
 	g.seriesMtx.RLock()
 	s, ok := g.series[hash]
 	g.seriesMtx.RUnlock()
@@ -80,7 +86,7 @@ func (g *gauge) updateSeries(lbls labels.Labels, value float64, operation string
 		if !updateIfAlreadyExist {
 			return
 		}
-		g.updateSeriesValue(hash, s, value, operation)
+		g.updateSeriesValue(hash, s, value, operation, timeMs)
 		return
 	}
 
@@ -92,28 +98,28 @@ func (g *gauge) updateSeries(lbls labels.Labels, value float64, operation string
 		if !updateIfAlreadyExist {
 			return
 		}
-		g.updateSeriesValue(hash, s, value, operation)
+		g.updateSeriesValue(hash, s, value, operation, timeMs)
 		return
 	}
 
-	g.series[hash] = g.newSeries(lbls, value)
+	g.series[hash] = g.newSeries(lbls, value, timeMs)
 }
 
-func (g *gauge) newSeries(lbls labels.Labels, value float64) *gaugeSeries {
+func (g *gauge) newSeries(lbls labels.Labels, value float64, timeMs int64) *gaugeSeries {
 	return &gaugeSeries{
 		labels:      getSeriesLabels(g.metricName, lbls, g.externalLabels),
 		value:       atomic.NewFloat64(value),
-		lastUpdated: atomic.NewInt64(time.Now().UnixMilli()),
+		lastUpdated: atomic.NewInt64(timeMs),
 	}
 }
 
-func (g *gauge) updateSeriesValue(hash uint64, s *gaugeSeries, value float64, operation string) {
+func (g *gauge) updateSeriesValue(hash uint64, s *gaugeSeries, value float64, operation string, timeMs int64) {
 	if operation == add {
 		s.value.Add(value)
 	} else {
 		s.value.Store(value)
 	}
-	s.lastUpdated.Store(time.Now().UnixMilli())
+	s.lastUpdated.Store(timeMs)
 	g.lifecycler.OnUpdate(hash, 1)
 }
 

--- a/modules/generator/registry/histogram.go
+++ b/modules/generator/registry/histogram.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math"
 	"sort"
@@ -43,8 +44,9 @@ type histogramSeries struct {
 	sum   *atomic.Float64
 	// buckets includes the +Inf bucket
 	buckets []*atomic.Float64
-	// exemplar is stored as a single traceID
-	exemplars      []*atomic.String
+	// exemplars stores either a hex-encoded string traceID or a raw <=16 byte
+	// traceID per bucket; access is serialized by histogram.seriesMtx (no longer atomic).
+	exemplars      []histogramExemplar
 	exemplarValues []*atomic.Float64
 	lastUpdated    *atomic.Int64
 	// firstSeries is used to track if this series is new to the counter.  This
@@ -52,6 +54,36 @@ type histogramSeries struct {
 	// to the desired value.  This avoids Prometheus throwing away the first
 	// value in the series, due to the transition from null -> x.
 	firstSeries *atomic.Bool
+}
+
+type histogramExemplar struct {
+	traceID      string
+	traceIDBytes [16]byte
+	traceIDLen   int
+}
+
+func newHistogramStringExemplar(traceID string) histogramExemplar {
+	return histogramExemplar{traceID: traceID}
+}
+
+func newHistogramTraceIDBytesExemplar(traceID []byte) histogramExemplar {
+	if len(traceID) == 0 {
+		return histogramExemplar{}
+	}
+	if len(traceID) > 16 {
+		return histogramExemplar{traceID: traceIDBytesToHexString(traceID)}
+	}
+
+	ex := histogramExemplar{traceIDLen: len(traceID)}
+	copy(ex.traceIDBytes[:], traceID)
+	return ex
+}
+
+func (ex histogramExemplar) string() string {
+	if ex.traceIDLen == 0 {
+		return ex.traceID
+	}
+	return traceIDBytesToHexString(ex.traceIDBytes[:ex.traceIDLen])
 }
 
 func (hs *histogramSeries) isNew() bool {
@@ -97,7 +129,22 @@ func newHistogram(name string, buckets []float64, lifecycler Limiter, traceIDLab
 
 func (h *histogram) ObserveWithExemplar(lbls labels.Labels, value float64, traceID string, multiplier float64) {
 	hash := lbls.Hash()
+	h.ObserveWithExemplarWithHash(lbls, hash, value, traceID, multiplier)
+}
 
+func (h *histogram) ObserveWithExemplarWithHash(lbls labels.Labels, hash uint64, value float64, traceID string, multiplier float64) {
+	h.ObserveWithExemplarWithHashAt(lbls, hash, value, traceID, multiplier, time.Now().UnixMilli())
+}
+
+func (h *histogram) ObserveWithExemplarWithHashAt(lbls labels.Labels, hash uint64, value float64, traceID string, multiplier float64, timeMs int64) {
+	h.observeWithExemplarWithHashAt(lbls, hash, value, newHistogramStringExemplar(traceID), multiplier, timeMs)
+}
+
+func (h *histogram) ObserveWithExemplarTraceIDBytesWithHashAt(lbls labels.Labels, hash uint64, value float64, traceID []byte, multiplier float64, timeMs int64) {
+	h.observeWithExemplarWithHashAt(lbls, hash, value, newHistogramTraceIDBytesExemplar(traceID), multiplier, timeMs)
+}
+
+func (h *histogram) observeWithExemplarWithHashAt(lbls labels.Labels, hash uint64, value float64, ex histogramExemplar, multiplier float64, timeMs int64) {
 	h.seriesDemand.Insert(hash)
 
 	h.seriesMtx.Lock()
@@ -105,25 +152,24 @@ func (h *histogram) ObserveWithExemplar(lbls labels.Labels, value float64, trace
 
 	s, lbls, hash := resolveSeries(h.series, hash, lbls, h.lifecycler, h.activeSeriesPerHistogramSerie())
 	if s != nil {
-		h.updateSeries(hash, s, value, traceID, multiplier)
+		h.updateSeries(hash, s, value, ex, multiplier, timeMs)
 		return
 	}
-	h.series[hash] = h.newSeries(lbls, value, traceID, multiplier)
+	h.series[hash] = h.newSeries(lbls, hash, value, ex, multiplier, timeMs)
 }
 
-func (h *histogram) newSeries(lbls labels.Labels, value float64, traceID string, multiplier float64) *histogramSeries {
+func (h *histogram) newSeries(lbls labels.Labels, hash uint64, value float64, ex histogramExemplar, multiplier float64, timeMs int64) *histogramSeries {
 	newSeries := &histogramSeries{
 		count:          atomic.NewFloat64(0),
 		sum:            atomic.NewFloat64(0),
 		buckets:        make([]*atomic.Float64, 0, len(h.buckets)),
-		exemplars:      make([]*atomic.String, 0, len(h.buckets)),
+		exemplars:      make([]histogramExemplar, len(h.buckets)),
 		exemplarValues: make([]*atomic.Float64, 0, len(h.buckets)),
 		lastUpdated:    atomic.NewInt64(0),
 		firstSeries:    atomic.NewBool(true),
 	}
 	for i := 0; i < len(h.buckets); i++ {
 		newSeries.buckets = append(newSeries.buckets, atomic.NewFloat64(0))
-		newSeries.exemplars = append(newSeries.exemplars, atomic.NewString(""))
 		newSeries.exemplarValues = append(newSeries.exemplarValues, atomic.NewFloat64(0))
 	}
 
@@ -147,26 +193,24 @@ func (h *histogram) newSeries(lbls labels.Labels, value float64, traceID string,
 		newSeries.bucketLabels = append(newSeries.bucketLabels, lb.Labels())
 	}
 
-	h.updateSeries(lbls.Hash(), newSeries, value, traceID, multiplier)
+	h.updateSeries(hash, newSeries, value, ex, multiplier, timeMs)
 
 	return newSeries
 }
 
-func (h *histogram) updateSeries(hash uint64, s *histogramSeries, value float64, traceID string, multiplier float64) {
-	s.count.Add(1 * multiplier)
+func (h *histogram) updateSeries(hash uint64, s *histogramSeries, value float64, ex histogramExemplar, multiplier float64, timeMs int64) {
+	s.count.Add(multiplier)
 	s.sum.Add(value * multiplier)
 
-	for i, bucket := range h.buckets {
-		if value <= bucket {
-			s.buckets[i].Add(1 * multiplier)
-		}
+	bucket := sort.SearchFloat64s(h.buckets, value)
+	for i := bucket; i < len(h.buckets); i++ {
+		s.buckets[i].Add(multiplier)
 	}
 
-	bucket := sort.SearchFloat64s(h.buckets, value)
-	s.exemplars[bucket].Store(traceID)
+	s.exemplars[bucket] = ex
 	s.exemplarValues[bucket].Store(value)
 
-	s.lastUpdated.Store(time.Now().UnixMilli())
+	s.lastUpdated.Store(timeMs)
 	h.lifecycler.OnUpdate(hash, h.activeSeriesPerHistogramSerie())
 }
 
@@ -217,12 +261,13 @@ func (h *histogram) collectMetrics(appender storage.Appender, timeMs int64) erro
 				return err
 			}
 
-			ex := s.exemplars[i].Load()
-			if ex != "" {
+			ex := s.exemplars[i]
+			traceID := ex.string()
+			if traceID != "" {
 
 				lbls := []labels.Label{{
 					Name:  h.traceIDLabelName,
-					Value: ex,
+					Value: traceID,
 				}}
 
 				_, err = appender.AppendExemplar(ref, s.bucketLabels[i], exemplar.Exemplar{
@@ -235,7 +280,7 @@ func (h *histogram) collectMetrics(appender storage.Appender, timeMs int64) erro
 				}
 			}
 			// clear the exemplar so we don't emit it again
-			s.exemplars[i].Store("")
+			s.exemplars[i] = histogramExemplar{}
 		}
 
 		if s.isNew() {
@@ -278,4 +323,31 @@ func (h *histogram) activeSeriesPerHistogramSerie() uint32 {
 
 func formatFloat(value float64) string {
 	return strconv.FormatFloat(value, 'f', -1, 64)
+}
+
+func traceIDBytesToHexString(traceID []byte) string {
+	encodedLen := hex.EncodedLen(len(traceID))
+	if encodedLen == 0 {
+		return ""
+	}
+
+	var buf [32]byte
+	if encodedLen <= len(buf) {
+		hex.Encode(buf[:encodedLen], traceID)
+		for i := 0; i < encodedLen; i++ {
+			if buf[i] != '0' {
+				return string(buf[i:encodedLen])
+			}
+		}
+		return ""
+	}
+
+	dst := make([]byte, encodedLen)
+	hex.Encode(dst, traceID)
+	for i := 0; i < encodedLen; i++ {
+		if dst[i] != '0' {
+			return string(dst[i:])
+		}
+	}
+	return ""
 }

--- a/modules/generator/registry/histogram.go
+++ b/modules/generator/registry/histogram.go
@@ -1,7 +1,6 @@
 package registry
 
 import (
-	"encoding/hex"
 	"fmt"
 	"math"
 	"sort"
@@ -13,6 +12,8 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"go.uber.org/atomic"
+
+	tempo_util "github.com/grafana/tempo/pkg/util"
 )
 
 var _ metric = (*histogram)(nil)
@@ -45,7 +46,7 @@ type histogramSeries struct {
 	// buckets includes the +Inf bucket
 	buckets []*atomic.Float64
 	// exemplars stores either a hex-encoded string traceID or a raw <=16 byte
-	// traceID per bucket; access is serialized by histogram.seriesMtx (no longer atomic).
+	// traceID per bucket; access is serialized by histogram.seriesMtx.
 	exemplars      []histogramExemplar
 	exemplarValues []*atomic.Float64
 	lastUpdated    *atomic.Int64
@@ -71,7 +72,7 @@ func newHistogramTraceIDBytesExemplar(traceID []byte) histogramExemplar {
 		return histogramExemplar{}
 	}
 	if len(traceID) > 16 {
-		return histogramExemplar{traceID: traceIDBytesToHexString(traceID)}
+		return histogramExemplar{traceID: tempo_util.TraceIDToHexString(traceID)}
 	}
 
 	ex := histogramExemplar{traceIDLen: len(traceID)}
@@ -83,7 +84,7 @@ func (ex histogramExemplar) string() string {
 	if ex.traceIDLen == 0 {
 		return ex.traceID
 	}
-	return traceIDBytesToHexString(ex.traceIDBytes[:ex.traceIDLen])
+	return tempo_util.TraceIDToHexString(ex.traceIDBytes[:ex.traceIDLen])
 }
 
 func (hs *histogramSeries) isNew() bool {
@@ -323,31 +324,4 @@ func (h *histogram) activeSeriesPerHistogramSerie() uint32 {
 
 func formatFloat(value float64) string {
 	return strconv.FormatFloat(value, 'f', -1, 64)
-}
-
-func traceIDBytesToHexString(traceID []byte) string {
-	encodedLen := hex.EncodedLen(len(traceID))
-	if encodedLen == 0 {
-		return ""
-	}
-
-	var buf [32]byte
-	if encodedLen <= len(buf) {
-		hex.Encode(buf[:encodedLen], traceID)
-		for i := 0; i < encodedLen; i++ {
-			if buf[i] != '0' {
-				return string(buf[i:encodedLen])
-			}
-		}
-		return ""
-	}
-
-	dst := make([]byte, encodedLen)
-	hex.Encode(dst, traceID)
-	for i := 0; i < encodedLen; i++ {
-		if dst[i] != '0' {
-			return string(dst[i:])
-		}
-	}
-	return ""
 }

--- a/modules/generator/registry/histogram_benchmark_test.go
+++ b/modules/generator/registry/histogram_benchmark_test.go
@@ -21,6 +21,22 @@ func BenchmarkRegistryHistogramObserve(b *testing.B) {
 		}
 	})
 
+	// The path spanmetrics uses on the hot path: raw trace ID bytes plus a
+	// precomputed label hash.
+	b.Run("classic_trace_id_bytes_with_hash", func(b *testing.B) {
+		h := newHistogram("bench_histogram", []float64{0.01, 0.05, 0.1, 0.5, 1, 5}, noopLimiter, "trace_id", nil, 15*time.Minute)
+		traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+		hash := lbls.Hash()
+		timeMs := time.Now().UnixMilli()
+		h.ObserveWithExemplarTraceIDBytesWithHashAt(lbls, hash, 0.001, traceID, 1, timeMs)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			h.ObserveWithExemplarTraceIDBytesWithHashAt(lbls, hash, 0.001, traceID, 1, timeMs)
+		}
+	})
+
 	b.Run("classic_high_bucket", func(b *testing.B) {
 		h := newHistogram("bench_histogram", []float64{0.01, 0.05, 0.1, 0.5, 1, 5}, noopLimiter, "trace_id", nil, 15*time.Minute)
 		h.ObserveWithExemplar(lbls, 4, "trace-1", 1)

--- a/modules/generator/registry/histogram_benchmark_test.go
+++ b/modules/generator/registry/histogram_benchmark_test.go
@@ -1,0 +1,45 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+func BenchmarkRegistryHistogramObserve(b *testing.B) {
+	lbls := labels.FromStrings("service", "frontend", "span_name", "GET /api")
+
+	b.Run("classic_low_bucket", func(b *testing.B) {
+		h := newHistogram("bench_histogram", []float64{0.01, 0.05, 0.1, 0.5, 1, 5}, noopLimiter, "trace_id", nil, 15*time.Minute)
+		h.ObserveWithExemplar(lbls, 0.001, "trace-1", 1)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			h.ObserveWithExemplar(lbls, 0.001, "trace-1", 1)
+		}
+	})
+
+	b.Run("classic_high_bucket", func(b *testing.B) {
+		h := newHistogram("bench_histogram", []float64{0.01, 0.05, 0.1, 0.5, 1, 5}, noopLimiter, "trace_id", nil, 15*time.Minute)
+		h.ObserveWithExemplar(lbls, 4, "trace-1", 1)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			h.ObserveWithExemplar(lbls, 4, "trace-1", 1)
+		}
+	})
+
+	b.Run("native", func(b *testing.B) {
+		h := newNativeHistogram("bench_native_histogram", []float64{0.01, 0.05, 0.1, 0.5, 1, 5}, noopLimiter, "trace_id", HistogramModeNative, nil, testTenant, &mockOverrides{}, 15*time.Minute)
+		h.ObserveWithExemplar(lbls, 0.5, "trace-1", 1)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			h.ObserveWithExemplar(lbls, 0.5, "trace-1", 1)
+		}
+	})
+}

--- a/modules/generator/registry/interface.go
+++ b/modules/generator/registry/interface.go
@@ -26,9 +26,12 @@ type LabelBuilder interface {
 // scratch builder. The Labels and Hash are only valid between
 // CloseAndBorrowLabels and Release. Callers MUST NOT retain Labels (or substrings
 // of any Label.Value) past Release, store BorrowedLabels in a long-lived field,
-// or copy the value across goroutines — the underlying scratch buffer is reused
-// by other callers as soon as Release returns. Metric methods that accept
-// BorrowedLabels.Labels copy what they need synchronously before returning.
+// copy the value across goroutines, or copy the value at all and call Release
+// on more than one copy — the underlying scratch and builder are returned to
+// pools by Release, and a second Release on a copy double-Puts them and lets
+// later callers receive the same instance concurrently. Metric methods that
+// accept BorrowedLabels.Labels copy what they need synchronously before
+// returning.
 type BorrowedLabels struct {
 	Labels labels.Labels
 	Hash   uint64

--- a/modules/generator/registry/interface.go
+++ b/modules/generator/registry/interface.go
@@ -19,6 +19,35 @@ type Registry interface {
 type LabelBuilder interface {
 	Add(name, value string)
 	CloseAndBuildLabels() (labels.Labels, bool)
+	CloseAndBorrowLabels() (BorrowedLabels, bool)
+}
+
+// BorrowedLabels holds a label set whose backing memory is owned by a pooled
+// scratch builder. The Labels and Hash are only valid between
+// CloseAndBorrowLabels and Release. Callers MUST NOT retain Labels (or substrings
+// of any Label.Value) past Release, store BorrowedLabels in a long-lived field,
+// or copy the value across goroutines — the underlying scratch buffer is reused
+// by other callers as soon as Release returns. Metric methods that accept
+// BorrowedLabels.Labels copy what they need synchronously before returning.
+type BorrowedLabels struct {
+	Labels labels.Labels
+	Hash   uint64
+
+	builder *labelBuilder
+	scratch *labels.ScratchBuilder
+}
+
+// Release returns the underlying builder and scratch buffer to their pools.
+// It is safe to call multiple times: subsequent calls are no-ops.
+// After Release, Labels and Hash are no longer valid.
+func (b *BorrowedLabels) Release() {
+	if b.builder == nil {
+		return
+	}
+	b.builder.releaseBorrowedLabels(b.scratch)
+	b.builder = nil
+	b.scratch = nil
+	b.Labels = labels.EmptyLabels()
 }
 
 // Counter
@@ -27,6 +56,13 @@ type Counter interface {
 	metric
 
 	Inc(lbls labels.Labels, value float64)
+	// IncWithHash is like Inc but uses the supplied hash as the series key.
+	// Precondition: hash MUST equal lbls.Hash(). Supplying any other value
+	// silently maps to a different series and corrupts metrics.
+	IncWithHash(lbls labels.Labels, hash uint64, value float64)
+	// IncWithHashAt is like IncWithHash but uses timeMs as the lastUpdated stamp.
+	// Same hash precondition as IncWithHash.
+	IncWithHashAt(lbls labels.Labels, hash uint64, value float64, timeMs int64)
 }
 
 // Histogram
@@ -36,6 +72,17 @@ type Histogram interface {
 
 	// ObserveWithExemplar observes a datapoint with the given values. traceID will be added as exemplar.
 	ObserveWithExemplar(lbls labels.Labels, value float64, traceID string, multiplier float64)
+	// ObserveWithExemplarWithHash is like ObserveWithExemplar but uses the supplied hash.
+	// Precondition: hash MUST equal lbls.Hash().
+	ObserveWithExemplarWithHash(lbls labels.Labels, hash uint64, value float64, traceID string, multiplier float64)
+	// ObserveWithExemplarWithHashAt is like ObserveWithExemplarWithHash but uses timeMs as the lastUpdated stamp.
+	// Precondition: hash MUST equal lbls.Hash(). traceID MUST be an owned string —
+	// the histogram stores it without copying for the lifetime of the exemplar.
+	ObserveWithExemplarWithHashAt(lbls labels.Labels, hash uint64, value float64, traceID string, multiplier float64, timeMs int64)
+	// ObserveWithExemplarTraceIDBytesWithHashAt accepts the traceID as raw bytes.
+	// The histogram copies the bytes synchronously, so the slice may be reused after the call.
+	// Precondition: hash MUST equal lbls.Hash().
+	ObserveWithExemplarTraceIDBytesWithHashAt(lbls labels.Labels, hash uint64, value float64, traceID []byte, multiplier float64, timeMs int64)
 }
 
 // Gauge
@@ -48,6 +95,12 @@ type Gauge interface {
 	Set(lbls labels.Labels, value float64)
 	Inc(lbls labels.Labels, value float64)
 	SetForTargetInfo(lbls labels.Labels, value float64)
+	// SetForTargetInfoWithHash is like SetForTargetInfo but uses the supplied hash.
+	// Precondition: hash MUST equal lbls.Hash().
+	SetForTargetInfoWithHash(lbls labels.Labels, hash uint64, value float64)
+	// SetForTargetInfoWithHashAt is like SetForTargetInfoWithHash but uses timeMs as the lastUpdated stamp.
+	// Precondition: hash MUST equal lbls.Hash().
+	SetForTargetInfoWithHashAt(lbls labels.Labels, hash uint64, value float64, timeMs int64)
 }
 
 type HistogramMode int

--- a/modules/generator/registry/native_histogram.go
+++ b/modules/generator/registry/native_histogram.go
@@ -15,6 +15,8 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"go.uber.org/atomic"
+
+	tempo_util "github.com/grafana/tempo/pkg/util"
 )
 
 type nativeHistogram struct {
@@ -140,7 +142,7 @@ func (h *nativeHistogram) ObserveWithExemplarWithHashAt(lbls labels.Labels, hash
 }
 
 func (h *nativeHistogram) ObserveWithExemplarTraceIDBytesWithHashAt(lbls labels.Labels, hash uint64, value float64, traceID []byte, multiplier float64, timeMs int64) {
-	h.ObserveWithExemplarWithHashAt(lbls, hash, value, traceIDBytesToHexString(traceID), multiplier, timeMs)
+	h.ObserveWithExemplarWithHashAt(lbls, hash, value, tempo_util.TraceIDToHexString(traceID), multiplier, timeMs)
 }
 
 func (h *nativeHistogram) newSeries(lbls labels.Labels, hash uint64, value float64, traceID string, multiplier float64, timeMs int64) *nativeHistogramSeries {

--- a/modules/generator/registry/native_histogram.go
+++ b/modules/generator/registry/native_histogram.go
@@ -36,6 +36,7 @@ type nativeHistogram struct {
 	buckets []float64
 
 	traceIDLabelName string
+	exemplarLabels   prometheus.Labels
 
 	// Can be "native", classic", "both" to determine which histograms to
 	// generate.  A diff in the configured value on the processors will cause a
@@ -101,6 +102,7 @@ func newNativeHistogram(name string, buckets []float64, lifecycler Limiter, trac
 		seriesDemand:      NewCardinality(staleDuration, removeStaleSeriesInterval),
 		lifecycler:        lifecycler,
 		traceIDLabelName:  traceIDLabelName,
+		exemplarLabels:    make(prometheus.Labels, 1),
 		buckets:           buckets,
 		histogramOverride: histogramOverride,
 		externalLabels:    externalLabels,
@@ -116,7 +118,14 @@ func newNativeHistogram(name string, buckets []float64, lifecycler Limiter, trac
 
 func (h *nativeHistogram) ObserveWithExemplar(lbls labels.Labels, value float64, traceID string, multiplier float64) {
 	hash := lbls.Hash()
+	h.ObserveWithExemplarWithHash(lbls, hash, value, traceID, multiplier)
+}
 
+func (h *nativeHistogram) ObserveWithExemplarWithHash(lbls labels.Labels, hash uint64, value float64, traceID string, multiplier float64) {
+	h.ObserveWithExemplarWithHashAt(lbls, hash, value, traceID, multiplier, time.Now().UnixMilli())
+}
+
+func (h *nativeHistogram) ObserveWithExemplarWithHashAt(lbls labels.Labels, hash uint64, value float64, traceID string, multiplier float64, timeMs int64) {
 	h.seriesDemand.Insert(hash)
 
 	h.seriesMtx.Lock()
@@ -124,13 +133,17 @@ func (h *nativeHistogram) ObserveWithExemplar(lbls labels.Labels, value float64,
 
 	s, lbls, hash := resolveSeries(h.series, hash, lbls, h.lifecycler, h.activeSeriesPerHistogramSerie())
 	if s != nil {
-		h.updateSeries(hash, s, value, traceID, multiplier)
+		h.updateSeries(hash, s, value, traceID, multiplier, timeMs)
 		return
 	}
-	h.series[hash] = h.newSeries(lbls, value, traceID, multiplier)
+	h.series[hash] = h.newSeries(lbls, hash, value, traceID, multiplier, timeMs)
 }
 
-func (h *nativeHistogram) newSeries(lbls labels.Labels, value float64, traceID string, multiplier float64) *nativeHistogramSeries {
+func (h *nativeHistogram) ObserveWithExemplarTraceIDBytesWithHashAt(lbls labels.Labels, hash uint64, value float64, traceID []byte, multiplier float64, timeMs int64) {
+	h.ObserveWithExemplarWithHashAt(lbls, hash, value, traceIDBytesToHexString(traceID), multiplier, timeMs)
+}
+
+func (h *nativeHistogram) newSeries(lbls labels.Labels, hash uint64, value float64, traceID string, multiplier float64, timeMs int64) *nativeHistogramSeries {
 	// Configure histogram based on mode
 	//
 	// Native-only mode sets buckets to nil, and uses the histogram.Exemplars slice as the native exemplar format.
@@ -170,7 +183,7 @@ func (h *nativeHistogram) newSeries(lbls labels.Labels, value float64, traceID s
 		overridesHash: hsh,
 	}
 
-	h.updateSeries(lbls.Hash(), newSeries, value, traceID, multiplier)
+	h.updateSeries(hash, newSeries, value, traceID, multiplier, timeMs)
 
 	lb := newSeriesLabelsBuilder(lbls, h.externalLabels)
 
@@ -187,21 +200,32 @@ func (h *nativeHistogram) newSeries(lbls labels.Labels, value float64, traceID s
 	lb.Set(labels.MetricName, h.nameSum)
 	newSeries.sumLabels = lb.Labels()
 
+	// Keep the reusable bucket-label builder based on owned labels. The input
+	// labels may be borrowed by the caller and released after this update.
+	lb.Reset(newSeries.labels)
 	return newSeries
 }
 
-func (h *nativeHistogram) updateSeries(hash uint64, s *nativeHistogramSeries, value float64, traceID string, multiplier float64) {
+func (h *nativeHistogram) updateSeries(hash uint64, s *nativeHistogramSeries, value float64, traceID string, multiplier float64, timeMs int64) {
 	// Use Prometheus native exemplar handling
 	exemplarObserver := s.promHistogram.(prometheus.ExemplarObserver)
 
-	labels := prometheus.Labels{h.traceIDLabelName: traceID}
+	// ObserveWithExemplar copies the labels synchronously; seriesMtx serializes reuse.
+	h.exemplarLabels[h.traceIDLabelName] = traceID
+
+	if multiplier == 1 {
+		exemplarObserver.ObserveWithExemplar(value, h.exemplarLabels)
+		s.lastUpdated = timeMs
+		h.lifecycler.OnUpdate(hash, h.activeSeriesPerHistogramSerie())
+		return
+	}
 
 	for i := 0.0; i < multiplier; i++ {
 		// Let Prometheus handle exemplars natively
-		exemplarObserver.ObserveWithExemplar(value, labels)
+		exemplarObserver.ObserveWithExemplar(value, h.exemplarLabels)
 	}
 
-	s.lastUpdated = time.Now().UnixMilli()
+	s.lastUpdated = timeMs
 	h.lifecycler.OnUpdate(hash, h.activeSeriesPerHistogramSerie())
 }
 

--- a/modules/generator/registry/native_histogram.go
+++ b/modules/generator/registry/native_histogram.go
@@ -14,7 +14,6 @@ import (
 	promhistogram "github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
-	"go.uber.org/atomic"
 
 	tempo_util "github.com/grafana/tempo/pkg/util"
 )
@@ -69,7 +68,7 @@ type nativeHistogramSeries struct {
 	// This is used in classic histograms to ensure that new counters begin with 0.
 	// This avoids Prometheus throwing away the first value in the series,
 	// due to the transition from null -> x.
-	firstSeries *atomic.Bool
+	firstSeries bool
 
 	// classic
 	countLabels labels.Labels
@@ -81,11 +80,11 @@ type nativeHistogramSeries struct {
 }
 
 func (hs *nativeHistogramSeries) isNew() bool {
-	return hs.firstSeries.Load()
+	return hs.firstSeries
 }
 
 func (hs *nativeHistogramSeries) registerSeenSeries() {
-	hs.firstSeries.Store(false)
+	hs.firstSeries = false
 }
 
 var (
@@ -181,7 +180,7 @@ func (h *nativeHistogram) newSeries(lbls labels.Labels, hash uint64, value float
 	newSeries := &nativeHistogramSeries{
 		promHistogram: prometheus.NewHistogram(nativeOpts),
 		lastUpdated:   0,
-		firstSeries:   atomic.NewBool(true),
+		firstSeries:   true,
 		overridesHash: hsh,
 	}
 

--- a/modules/generator/registry/registry_test.go
+++ b/modules/generator/registry/registry_test.go
@@ -1046,3 +1046,62 @@ func collectDemandEstimateLabels(t *testing.T, tenant string) map[string]float64
 	}
 	return result
 }
+
+// TestManagedRegistry_borrowedLabelsSurviveScratchReuse verifies the
+// BorrowedLabels contract from the metric side: counter, histogram, and gauge
+// updates must copy everything they need synchronously, so that after Release
+// aggressive reuse of the pooled builder and scratch storage cannot corrupt
+// previously created series or exemplars.
+func TestManagedRegistry_borrowedLabelsSurviveScratchReuse(t *testing.T) {
+	appender := &capturingAppender{}
+
+	registry := New(&Config{}, &mockOverrides{}, "test", appender, log.NewNopLogger(), noopLimiter)
+	defer registry.Close()
+
+	counter := registry.NewCounter("my_counter")
+	histogram := registry.NewHistogram("my_histogram", []float64{1.0}, HistogramModeClassic)
+	gauge := registry.NewGauge("my_gauge")
+
+	builder := registry.NewLabelBuilder()
+	builder.Add("label", "value-1")
+	borrowed, valid := builder.CloseAndBorrowLabels()
+	require.True(t, valid)
+
+	timeMs := time.Now().UnixMilli()
+	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	counter.IncWithHashAt(borrowed.Labels, borrowed.Hash, 1.0, timeMs)
+	histogram.ObserveWithExemplarTraceIDBytesWithHashAt(borrowed.Labels, borrowed.Hash, 1.0, traceID, 1.0, timeMs)
+	gauge.SetForTargetInfoWithHashAt(borrowed.Labels, borrowed.Hash, 1.0, timeMs)
+	borrowed.Release()
+
+	// Churn the pooled builders and scratch buffers with other label values to
+	// overwrite the storage the borrowed labels were built in.
+	for i := 0; i < 100; i++ {
+		b := registry.NewLabelBuilder()
+		b.Add("label", fmt.Sprintf("scratch-%042d", i))
+		bl, ok := b.CloseAndBorrowLabels()
+		require.True(t, ok)
+		bl.Release()
+	}
+
+	expectedSamples := []sample{
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 0),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 1),
+		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 0),
+		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 1),
+		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 1),
+		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "__metrics_gen_instance": mustGetHostname(), "le": "1"}, 0, 0),
+		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "__metrics_gen_instance": mustGetHostname(), "le": "1"}, 0, 1),
+		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "__metrics_gen_instance": mustGetHostname(), "le": "+Inf"}, 0, 0),
+		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "__metrics_gen_instance": mustGetHostname(), "le": "+Inf"}, 0, 1),
+		newSample(map[string]string{"__name__": "my_gauge", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 1),
+	}
+	collectRegistryMetricsAndAssert(t, registry, appender, expectedSamples)
+
+	// The exemplar's trace ID bytes must have been copied out of the borrowed
+	// slice, and the exemplar series labels must be intact. Note
+	// TraceIDToHexString strips leading zeros.
+	require.Len(t, appender.exemplars, 1)
+	assert.Equal(t, "102030405060708090a0b0c0d0e0f10", appender.exemplars[0].e.Labels.Get("traceID"))
+	assert.Equal(t, "value-1", appender.exemplars[0].l.Get("label"))
+}

--- a/modules/generator/registry/registry_test.go
+++ b/modules/generator/registry/registry_test.go
@@ -1074,6 +1074,12 @@ func TestManagedRegistry_borrowedLabelsSurviveScratchReuse(t *testing.T) {
 	gauge.SetForTargetInfoWithHashAt(borrowed.Labels, borrowed.Hash, 1.0, timeMs)
 	borrowed.Release()
 
+	// Overwrite the caller-owned trace ID slice: the histogram must have
+	// copied the bytes synchronously.
+	for i := range traceID {
+		traceID[i] = 0xff
+	}
+
 	// Churn the pooled builders and scratch buffers with other label values to
 	// overwrite the storage the borrowed labels were built in.
 	for i := 0; i < 100; i++ {

--- a/modules/generator/registry/test.go
+++ b/modules/generator/registry/test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
+
+	tempo_util "github.com/grafana/tempo/pkg/util"
 )
 
 // newTestLabelLimiter returns a PerLabelLimiter with limiting disabled (maxCardinality=0).
@@ -226,7 +228,7 @@ func (t *testHistogram) ObserveWithExemplarWithHashAt(lbls labels.Labels, _ uint
 }
 
 func (t *testHistogram) ObserveWithExemplarTraceIDBytesWithHashAt(lbls labels.Labels, _ uint64, value float64, traceID []byte, multiplier float64, _ int64) {
-	t.ObserveWithExemplar(lbls, value, traceIDBytesToHexString(traceID), multiplier)
+	t.ObserveWithExemplar(lbls, value, tempo_util.TraceIDToHexString(traceID), multiplier)
 }
 
 func (t *testHistogram) name() string {

--- a/modules/generator/registry/test.go
+++ b/modules/generator/registry/test.go
@@ -112,6 +112,14 @@ func (t *testCounter) Inc(lbls labels.Labels, value float64) {
 	t.registry.addToMetric(t.n, lbls, value)
 }
 
+func (t *testCounter) IncWithHash(lbls labels.Labels, _ uint64, value float64) {
+	t.Inc(lbls, value)
+}
+
+func (t *testCounter) IncWithHashAt(lbls labels.Labels, _ uint64, value float64, _ int64) {
+	t.Inc(lbls, value)
+}
+
 func (t *testCounter) name() string {
 	return t.n
 }
@@ -153,6 +161,14 @@ func (t *testGauge) Set(lbls labels.Labels, value float64) {
 
 func (t *testGauge) SetForTargetInfo(lbls labels.Labels, value float64) {
 	t.Set(lbls, value)
+}
+
+func (t *testGauge) SetForTargetInfoWithHash(lbls labels.Labels, _ uint64, value float64) {
+	t.SetForTargetInfo(lbls, value)
+}
+
+func (t *testGauge) SetForTargetInfoWithHashAt(lbls labels.Labels, _ uint64, value float64, _ int64) {
+	t.SetForTargetInfo(lbls, value)
 }
 
 func (t *testGauge) name() string {
@@ -199,6 +215,18 @@ func (t *testHistogram) ObserveWithExemplar(lbls labels.Labels, value float64, _
 		}
 	}
 	t.registry.addToMetric(t.nameBucket, withLe(lbls, math.Inf(1)), 1*multiplier)
+}
+
+func (t *testHistogram) ObserveWithExemplarWithHash(lbls labels.Labels, _ uint64, value float64, traceID string, multiplier float64) {
+	t.ObserveWithExemplar(lbls, value, traceID, multiplier)
+}
+
+func (t *testHistogram) ObserveWithExemplarWithHashAt(lbls labels.Labels, _ uint64, value float64, traceID string, multiplier float64, _ int64) {
+	t.ObserveWithExemplar(lbls, value, traceID, multiplier)
+}
+
+func (t *testHistogram) ObserveWithExemplarTraceIDBytesWithHashAt(lbls labels.Labels, _ uint64, value float64, traceID []byte, multiplier float64, _ int64) {
+	t.ObserveWithExemplar(lbls, value, traceIDBytesToHexString(traceID), multiplier)
 }
 
 func (t *testHistogram) name() string {

--- a/pkg/spanfilter/policymatch/intrinsic.go
+++ b/pkg/spanfilter/policymatch/intrinsic.go
@@ -38,6 +38,7 @@ type IntrinsicFilter struct {
 	statusCode tracev1.Status_StatusCode
 	kind       tracev1.Span_SpanKind
 	regex      *regexp.Regexp
+	kindMask   uint8
 }
 
 // NewStrictIntrinsicFilter returns a new IntrinsicFilter that matches spans based on the given intrinsic and value.
@@ -98,7 +99,12 @@ func NewRegexpIntrinsicFilter(intrinsic traceql.Intrinsic, value interface{}) (I
 		return IntrinsicFilter{}, fmt.Errorf("invalid intrinsic filter regex: %v", err)
 	}
 	switch intrinsic {
-	case traceql.IntrinsicName, traceql.IntrinsicStatus, traceql.IntrinsicKind:
+	case traceql.IntrinsicName, traceql.IntrinsicStatus:
+		return IntrinsicFilter{intrinsic: intrinsic, regex: r}, nil
+	case traceql.IntrinsicKind:
+		if mask := kindRegexMask(stringValue); mask != 0 {
+			return IntrinsicFilter{intrinsic: intrinsic, kindMask: mask}, nil
+		}
 		return IntrinsicFilter{intrinsic: intrinsic, regex: r}, nil
 	default:
 		return IntrinsicFilter{}, fmt.Errorf("intrinsic not supported %s", intrinsic)
@@ -119,11 +125,52 @@ func (a *IntrinsicFilter) Matches(span *tracev1.Span) bool {
 		}
 		return a.statusCode == span.GetStatus().GetCode()
 	case traceql.IntrinsicKind:
+		if a.kindMask != 0 {
+			return a.kindMask&spanKindMask(span.Kind) != 0
+		}
 		if a.regex != nil {
 			return a.regex.MatchString(span.Kind.String())
 		}
 		return a.kind == span.Kind
 	default:
 		return false
+	}
+}
+
+const (
+	spanKindServerBit uint8 = 1 << iota
+	spanKindClientBit
+	spanKindProducerBit
+	spanKindConsumerBit
+)
+
+// kindRegexMask returns a bitmask for the regex if the regex is one of the
+// hard-coded canonical alternations matching all real span kinds. Any other
+// regex (including semantically equivalent ones with different ordering,
+// anchors, or whitespace) returns 0 and forces a fallback to the regexp engine.
+// This is intentionally narrow: it accelerates only the default service-graph
+// filter shipped in pkg/spanfilter/config defaults. Operators who customize the
+// kind filter will silently lose this fast path.
+func kindRegexMask(regex string) uint8 {
+	switch regex {
+	case "SPAN_KIND_(SERVER|CONSUMER|CLIENT|PRODUCER)":
+		return spanKindServerBit | spanKindConsumerBit | spanKindClientBit | spanKindProducerBit
+	default:
+		return 0
+	}
+}
+
+func spanKindMask(kind tracev1.Span_SpanKind) uint8 {
+	switch kind {
+	case tracev1.Span_SPAN_KIND_SERVER:
+		return spanKindServerBit
+	case tracev1.Span_SPAN_KIND_CLIENT:
+		return spanKindClientBit
+	case tracev1.Span_SPAN_KIND_PRODUCER:
+		return spanKindProducerBit
+	case tracev1.Span_SPAN_KIND_CONSUMER:
+		return spanKindConsumerBit
+	default:
+		return 0
 	}
 }

--- a/pkg/spanfilter/policymatch/intrinsic_test.go
+++ b/pkg/spanfilter/policymatch/intrinsic_test.go
@@ -139,28 +139,75 @@ func TestIntrinsicPolicyMatch_Matches(t *testing.T) {
 			},
 		},
 		{
-			name:   "matched optimized regex kind",
+			name:   "optimized regex kind matches SERVER",
 			expect: true,
 			policy: &IntrinsicPolicyMatch{
 				filters: []IntrinsicFilter{
 					must(NewRegexpIntrinsicFilter(traceql.IntrinsicKind, "SPAN_KIND_(SERVER|CONSUMER|CLIENT|PRODUCER)")),
 				},
 			},
-			span: &tracev1.Span{
-				Kind: tracev1.Span_SPAN_KIND_CONSUMER,
-			},
+			span: &tracev1.Span{Kind: tracev1.Span_SPAN_KIND_SERVER},
 		},
 		{
-			name:   "unmatched optimized regex kind",
+			name:   "optimized regex kind matches CLIENT",
+			expect: true,
+			policy: &IntrinsicPolicyMatch{
+				filters: []IntrinsicFilter{
+					must(NewRegexpIntrinsicFilter(traceql.IntrinsicKind, "SPAN_KIND_(SERVER|CONSUMER|CLIENT|PRODUCER)")),
+				},
+			},
+			span: &tracev1.Span{Kind: tracev1.Span_SPAN_KIND_CLIENT},
+		},
+		{
+			name:   "optimized regex kind matches PRODUCER",
+			expect: true,
+			policy: &IntrinsicPolicyMatch{
+				filters: []IntrinsicFilter{
+					must(NewRegexpIntrinsicFilter(traceql.IntrinsicKind, "SPAN_KIND_(SERVER|CONSUMER|CLIENT|PRODUCER)")),
+				},
+			},
+			span: &tracev1.Span{Kind: tracev1.Span_SPAN_KIND_PRODUCER},
+		},
+		{
+			name:   "optimized regex kind matches CONSUMER",
+			expect: true,
+			policy: &IntrinsicPolicyMatch{
+				filters: []IntrinsicFilter{
+					must(NewRegexpIntrinsicFilter(traceql.IntrinsicKind, "SPAN_KIND_(SERVER|CONSUMER|CLIENT|PRODUCER)")),
+				},
+			},
+			span: &tracev1.Span{Kind: tracev1.Span_SPAN_KIND_CONSUMER},
+		},
+		{
+			name:   "optimized regex kind rejects INTERNAL",
 			expect: false,
 			policy: &IntrinsicPolicyMatch{
 				filters: []IntrinsicFilter{
 					must(NewRegexpIntrinsicFilter(traceql.IntrinsicKind, "SPAN_KIND_(SERVER|CONSUMER|CLIENT|PRODUCER)")),
 				},
 			},
-			span: &tracev1.Span{
-				Kind: tracev1.Span_SPAN_KIND_INTERNAL,
+			span: &tracev1.Span{Kind: tracev1.Span_SPAN_KIND_INTERNAL},
+		},
+		{
+			name:   "optimized regex kind rejects UNSPECIFIED",
+			expect: false,
+			policy: &IntrinsicPolicyMatch{
+				filters: []IntrinsicFilter{
+					must(NewRegexpIntrinsicFilter(traceql.IntrinsicKind, "SPAN_KIND_(SERVER|CONSUMER|CLIENT|PRODUCER)")),
+				},
 			},
+			span: &tracev1.Span{Kind: tracev1.Span_SPAN_KIND_UNSPECIFIED},
+		},
+		{
+			name:   "non-canonical regex kind falls back to engine and matches SERVER",
+			expect: true,
+			policy: &IntrinsicPolicyMatch{
+				filters: []IntrinsicFilter{
+					// Different alternation order — must NOT take the bitmask fast path.
+					must(NewRegexpIntrinsicFilter(traceql.IntrinsicKind, "SPAN_KIND_(CLIENT|SERVER)")),
+				},
+			},
+			span: &tracev1.Span{Kind: tracev1.Span_SPAN_KIND_SERVER},
 		},
 	}
 

--- a/pkg/spanfilter/policymatch/intrinsic_test.go
+++ b/pkg/spanfilter/policymatch/intrinsic_test.go
@@ -138,6 +138,30 @@ func TestIntrinsicPolicyMatch_Matches(t *testing.T) {
 				Name: "test",
 			},
 		},
+		{
+			name:   "matched optimized regex kind",
+			expect: true,
+			policy: &IntrinsicPolicyMatch{
+				filters: []IntrinsicFilter{
+					must(NewRegexpIntrinsicFilter(traceql.IntrinsicKind, "SPAN_KIND_(SERVER|CONSUMER|CLIENT|PRODUCER)")),
+				},
+			},
+			span: &tracev1.Span{
+				Kind: tracev1.Span_SPAN_KIND_CONSUMER,
+			},
+		},
+		{
+			name:   "unmatched optimized regex kind",
+			expect: false,
+			policy: &IntrinsicPolicyMatch{
+				filters: []IntrinsicFilter{
+					must(NewRegexpIntrinsicFilter(traceql.IntrinsicKind, "SPAN_KIND_(SERVER|CONSUMER|CLIENT|PRODUCER)")),
+				},
+			},
+			span: &tracev1.Span{
+				Kind: tracev1.Span_SPAN_KIND_INTERNAL,
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/spanfilter/splitpolicy.go
+++ b/pkg/spanfilter/splitpolicy.go
@@ -84,7 +84,7 @@ func newSplitPolicy(policy *config.PolicyMatch) (*splitPolicy, error) {
 
 // Match returns true when the resource attributes and span attributes match the policy.
 func (p *splitPolicy) Match(rs *v1.Resource, span *tracev1.Span) bool {
-	return (p.ResourceMatch == nil || p.ResourceMatch.Matches(rs.Attributes)) &&
-		(p.SpanMatch == nil || p.SpanMatch.Matches(span.Attributes)) &&
-		(p.IntrinsicMatch == nil || p.IntrinsicMatch.Matches(span))
+	return (p.IntrinsicMatch == nil || p.IntrinsicMatch.Matches(span)) &&
+		(p.ResourceMatch == nil || p.ResourceMatch.Matches(rs.Attributes)) &&
+		(p.SpanMatch == nil || p.SpanMatch.Matches(span.Attributes))
 }

--- a/pkg/util/traceid.go
+++ b/pkg/util/traceid.go
@@ -48,9 +48,7 @@ func TraceIDToHexString(byteID []byte) string {
 	}
 	dst := make([]byte, encodedLen)
 	hex.Encode(dst, byteID)
-	p := unsafe.SliceData(dst)
-	id := unsafe.String(p, len(dst))
-	return strings.TrimLeft(id, "0")
+	return strings.TrimLeft(string(dst), "0")
 }
 
 // SpanIDToHexString converts a span ID to its string representation and WITHOUT removing any leading zeros.

--- a/pkg/util/traceid.go
+++ b/pkg/util/traceid.go
@@ -30,14 +30,27 @@ func PadTraceIDString(id string) string {
 
 // TraceIDToHexString converts a trace ID to its string representation and removes any leading zeros.
 func TraceIDToHexString(byteID []byte) string {
-	dst := make([]byte, hex.EncodedLen(len(byteID)))
+	encodedLen := hex.EncodedLen(len(byteID))
+	if encodedLen == 0 {
+		return ""
+	}
+	// Fast path: trace IDs are <=16 bytes (32 hex chars). Encode into a stack
+	// buffer and only heap-allocate the trimmed result.
+	if encodedLen <= 32 {
+		var buf [32]byte
+		hex.Encode(buf[:encodedLen], byteID)
+		for i := 0; i < encodedLen; i++ {
+			if buf[i] != '0' {
+				return string(buf[i:encodedLen])
+			}
+		}
+		return ""
+	}
+	dst := make([]byte, encodedLen)
 	hex.Encode(dst, byteID)
-	// fast conversion to string
 	p := unsafe.SliceData(dst)
 	id := unsafe.String(p, len(dst))
-	// remove leading zeros
-	id = strings.TrimLeft(id, "0")
-	return id
+	return strings.TrimLeft(id, "0")
 }
 
 // SpanIDToHexString converts a span ID to its string representation and WITHOUT removing any leading zeros.


### PR DESCRIPTION
# Metrics Generator Optimization Summary

This branch optimizes the Tempo metrics-generator hot path without intentionally changing config defaults, metric names, labels, label values, filtering behavior, or user-visible semantics.

## Main Improvements

- **Less label allocation:** registry label builders now reuse scratch storage and borrowed labels for hot updates, avoiding repeated label copying and hash recomputation.
- **Cheaper spanmetrics processing:** spanmetrics avoids unnecessary target_info work for filtered spans, caches/reuses common resource-derived values, fast-paths intrinsic enum labels, and avoids allocating trace ID strings for classic histogram exemplars.
- **Cheaper servicegraph processing:** servicegraphs reuses edge/key buffers, avoids trace ID formatting in server lookup paths, reduces peer/resource scans, and avoids allocation-heavy edge update patterns.
- **Lower registry overhead:** counters, gauges, histograms, limiter updates, timestamps, and exemplar handling were optimized to reduce per-span/per-series CPU and memory churn.
- **Faster filter matching:** common span kind intrinsic filters and regex patterns now use fast paths instead of general-purpose matching.

## Corrected Benchmark Results vs `origin/main`

| Benchmark group | What it measures | CPU | Memory | Allocations |
|---|---|---:|---:|---:|
| **All config benchmarks** | Broad coverage of default, spanmetrics, servicegraphs, combined, target_info, dimensions, and native histogram configs | **-45.2%** | **-92.1%** | **-94.5%** |
| **Prod-shaped configs** | Production-like configs with 7 dimensions, filters, target_info, servicegraph prefixes, prod buckets, and native histograms | **-51.8%** | **-92.9%** | **-96.0%** |
| **100k active-series** | Steady-state updates after seeding about 100k active series | **-33.4%** | **-97.4%** | **-99.3%** |
| **1M active-series validation** | Heavier combined prod-shaped workload after seeding about 1M active series | **-27.3%** | **-95.8%** | **-99.5%** |

## Interpretation

The biggest gains come from removing allocation-heavy label, trace ID, and servicegraph key work from the per-span/per-update path.

The benchmark evidence is strong for metrics-generator CPU and memory hot paths, especially high-cardinality tenants. The exact percentages should still be validated with production-like replay or profiles before treating them as production-wide savings.

# Results in tempo-dev-01

after 1 hour running in dev-01 (80K active series)
```
  Metric                         Before        Latest        Improvement
  -----------------------------  ------------  ------------  -----------
  CPU / input MiB/s              0.0190        0.0139        26.9% lower
  CPU cores                      0.915         0.790         13.6% lower

  Working set / 10k series       303 MiB       253 MiB       16.6% lower
  Go heap / 10k series           181 MiB       157 MiB       13.3% lower
  Objects / active series        175           152           13.2% lower
```