### PR TITLE
[jsonnet]: add KEDA autoscaling for live-store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## main / unreleased
 
+* [CHANGE] **BREAKING CHANGE** jsonnet: Remove `block_builder.keda` ScaledObject. Block-builder replicas are now managed by the rollout-operator mirroring live-store zone-a, which keeps block-builder alive through the live-store drain window. Remove any `_config.block_builder.keda` overrides from your config. [#7133](https://github.com/grafana/tempo/pull/7133) (@zachfi)
+* [FEATURE] jsonnet: Add KEDA autoscaling for live-store via a Prometheus trigger on expected bytes held (`tempo_distributor_kafka_write_bytes_total`). Enable with `live_store.keda.enabled: true`. Requires `rollout_operator_replica_template_access_enabled: true` and a Prometheus URL set via `autoscaling_prometheus_url`. [#7133](https://github.com/grafana/tempo/pull/7133) (@zachfi)
+* [ENHANCEMENT] jsonnet: add `autoscaling_prometheus_url` and `autoscaling_prometheus_tenant` top-level config fields for KEDA autoscaling. Setting `autoscaling_prometheus_tenant` sends an `X-Scope-OrgID` header on all Prometheus trigger requests, which is required when the backend is a multi-tenant system such as Grafana Mimir. [#7099](https://github.com/grafana/tempo/pull/7099) (@zachfi)
 * [FEATURE] Make individual AST transformations skippable via config and query hints [#7012](https://github.com/grafana/tempo/pull/7012) (@stoewer)
 * [ENHANCEMENT] Add `TempoDistributorKafkaProduceFailing` alert that triggers when Kafka records cannot be produced by the distributor. [#7148](https://github.com/grafana/tempo/pull/7148) (@javiermolinar)
 * [ENHANCEMENT] **BREAKING CHANGE** Query-frontend: new job sharding approach for trace lookups, using a new config option `blocks_per_shard` which replaces `query_shards`. [#7105](https://github.com/grafana/tempo/pull/7105) (@mdisibio)

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
@@ -368,9 +368,9 @@ storage+: {
 Enabling metrics generation and remote writing them to Grafana Cloud Metrics produces extra active series that could potentially impact your billing. For more information on billing, refer to [Billing and usage](/docs/grafana-cloud/billing-and-usage/). For more information on metrics generation, refer the [Metrics-generator documentation](/docs/tempo/<TEMPO_VERSION>/metrics-from-traces/metrics-generator/).
 {{< /admonition >}}
 
-### Optional: Enable KEDA autoscaling 
+### Optional: Enable KEDA autoscaling
 
-The microservices Jsonnet library includes optional KEDA-based horizontal autoscaling for distributor, metrics-generator, backend-worker, and block-builder components. All KEDA scalers are disabled by default (`enabled: false`), and you enable each component independently under `_config.<component>.keda`.
+The microservices Jsonnet library includes optional KEDA-based horizontal autoscaling for distributor, metrics-generator, backend-worker, and live-store components. All KEDA scalers are disabled by default (`enabled: false`), and you enable each component independently under `_config.<component>.keda`.
 
 Before you enable this option, make sure your cluster has the KEDA operator and CRDs installed.
 
@@ -380,6 +380,7 @@ The following example enables all supported KEDA scalers. Set `autoscaling_prome
 _config+:: {
   autoscaling_prometheus_url: 'http://prometheus-operated.monitoring.svc.cluster.local:9090',
   // autoscaling_prometheus_tenant: 'my-tenant',  // Required for multi-tenant backends (e.g. Grafana Mimir)
+  rollout_operator_replica_template_access_enabled: true,
   distributor+: {
     keda: {
       enabled: true,
@@ -404,19 +405,21 @@ _config+:: {
       threshold: 200,
     },
   },
-  block_builder+: {
+  live_store+: {
     keda: {
       enabled: true,
       min_replicas: 1,
       max_replicas: 200,
-      partitions_per_instance: 1,
-      pod_selector: 'name=live-store-zone-a',
+      // window_seconds: 1800,         // retention window; >= complete_block_timeout + query_backend_after
+      // bytes_per_replica: 16800000000, // ~16 GiB at 10 MB/s per pod over 30m
     },
   },
 },
 ```
 
-Tempo uses these trigger types when KEDA is enabled: CPU for distributor and metrics-generator, Prometheus for backend-worker, and kubernetes-workload for block-builder. When you enable block-builder autoscaling, Tempo also sets `block_builder.partitions_per_instance` from `_config.block_builder.keda.partitions_per_instance`.
+Tempo uses these trigger types when KEDA is enabled: CPU for distributor and metrics-generator, Prometheus for backend-worker and live-store.
+
+When live-store KEDA is enabled, block-builder replicas are managed automatically by the rollout-operator, which mirrors the live-store zone-a replica count to block-builder. This keeps block-builder alive through the live-store drain window so that in-flight data is not lost. You do not need to configure block-builder autoscaling separately. The value of `_config.block_builder.partitions_per_instance` (default: `1`) is injected into the block-builder config when live-store KEDA is active.
 
 ### Optional: Reduce component system requirements
 

--- a/operations/jsonnet-compiled/jsonnetfile.lock.json
+++ b/operations/jsonnet-compiled/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "7090c8d94f40e452ad906966c7de9add8c707eff",
+      "version": "e7a131e08a4c77ae42425dee1378f5fe87fd45f3",
       "sum": "0y3AFX9LQSpfWTxWKSwoLgbt0Wc9nnCwhMH2szKzHv0="
     },
     {
@@ -18,7 +18,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "7090c8d94f40e452ad906966c7de9add8c707eff",
+      "version": "e7a131e08a4c77ae42425dee1378f5fe87fd45f3",
       "sum": "zNTCDRaCqJUHjQSQRsxGR3jLrMP9tU7YNQb13dbm1bU="
     },
     {

--- a/operations/jsonnet/microservices/autoscaling.libsonnet
+++ b/operations/jsonnet/microservices/autoscaling.libsonnet
@@ -132,6 +132,7 @@
       partitions_per_instance: 1,
     },
 
+
   },
 
   // Returns a KEDA Prometheus trigger using the shared autoscaling_prometheus_url and
@@ -270,6 +271,8 @@
   tempo_live_store_scaled_object:
     if $._config.live_store.keda.enabled then
       assert $._config.autoscaling_prometheus_url != '' : 'autoscaling_prometheus_url is required for live_store autoscaling';
+      assert $._config.rollout_operator_replica_template_access_enabled :
+             'live_store.keda.enabled requires rollout_operator_replica_template_access_enabled=true so the rollout-operator can read the ReplicaTemplate scale';
       local config = $._config.live_store.keda;
       local query = if config.query != '' then config.query else
         |||

--- a/operations/jsonnet/microservices/autoscaling.libsonnet
+++ b/operations/jsonnet/microservices/autoscaling.libsonnet
@@ -78,33 +78,60 @@
       },
     },
 
-    // Block builder scales to match live-store zone-a pods via KEDA kubernetes-workload scaler.
-    // See: https://github.com/grafana/tempo/issues/6933
-    block_builder+: {
+    live_store+: {
       keda: {
         enabled: false,
         min_replicas: 1,
         max_replicas: 200,
         paused_replicas: 0,
-        // Number of partitions each block-builder pod handles.
-        // KEDA sets replicas = ceil(live-store-zone-a pods / partitions_per_instance).
-        partitions_per_instance: 1,
-        // Pod selector to count live-store zone-a pods.
-        pod_selector: 'name=live-store-zone-a',
+        // Time window (seconds) over which bytes written to Kafka are expected
+        // to be held in the live-store. Should be >= complete_block_timeout (20m
+        // default) plus any query_backend_after delay. Default: 30 minutes.
+        window_seconds: 30 * 60,
+        // Maximum bytes a single live-store pod is expected to hold over window_seconds.
+        // Expressed as ingest_rate_per_pod × window_seconds so the two knobs stay coupled:
+        //   default: 10 MB/s × 1800s ≈ 16 GiB per pod (observed production baseline)
+        // To tune for your environment, change the rate multiplier:
+        //   1 MB/s per pod  → 1 * 1000 * 1000 * self.window_seconds  (~1.7 GiB at 30m)
+        //   5 MB/s per pod  → 5 * 1000 * 1000 * self.window_seconds  (~8.4 GiB at 30m)
+        // Alternatively, set a literal byte value if you prefer to reason purely about
+        // total bytes held per pod (e.g. bytes_per_replica: 17 * 1024 * 1024 * 1024).
+        bytes_per_replica: 10 * 1000 * 1000 * self.window_seconds,
+        // Prometheus query returning total bytes expected to be held across all
+        // live-store pods. Measures the distributor (Kafka producer) side so that
+        // draining pods — which have abandoned their partitions but are still up
+        // for query — do not dilute the signal.
+        // When empty (default) the ScaledObject uses:
+        //   sum(rate(tempo_distributor_kafka_write_bytes_total{namespace="<ns>"}[10m])) * <window_seconds>
+        // Set to a non-empty string to replace this with a fully custom query.
+        query: '',
         scale_up_stabilization_window_seconds: 60,
-        scale_up_pods: 5,
+        scale_up_pods: 2,
         scale_up_period_seconds: 60,
-        scale_down_stabilization_window_seconds: 60 * 5,
-        scale_down_pods: 5,
+        // Minimum duration of sustained low load before KEDA issues a scale-down.
+        // Defaults to the live-store drain window (35m) so a load dip shorter than
+        // one full drain cycle cannot trigger a scale-down. Note: the drain itself
+        // runs after the signal, so total time from load drop to pod termination
+        // is roughly 2x this value.
+        scale_down_stabilization_window_seconds: 60 * 35,
+        scale_down_pods: 1,
         scale_down_period_seconds: 60 * 5,
+        // Extra KEDA trigger objects appended after the default Prometheus trigger.
+        // Use this to inject environment-specific triggers (e.g. Kafka lag, CPU)
+        // from private config without requiring an upstream Jsonnet change.
+        // Each entry is a raw KEDA trigger object passed directly to withTriggersMixin.
+        additional_triggers: [],
       },
     },
 
-    // Override block_builder_max_unavailable when block_builder autoscaling is enabled
-    // since the replica count is dynamic.
-    block_builder_max_unavailable:
-      if $._config.block_builder.keda.enabled then '100%'
-      else $.tempo_block_builder_statefulset.spec.replicas,
+    // Number of Kafka partitions each block-builder pod is responsible for.
+    // When live-store KEDA is enabled, replicas are dynamic; this value must
+    // stay coupled so the partition assignment math stays correct.
+    // Default: 1 (each block-builder pod mirrors one live-store pod 1:1).
+    block_builder+: {
+      partitions_per_instance: 1,
+    },
+
   },
 
   // Returns a KEDA Prometheus trigger using the shared autoscaling_prometheus_url and
@@ -230,22 +257,51 @@
   tempo_backend_worker_statefulset+:
     if $._config.backend_worker.keda.enabled then $.removeReplicasFromSpec else {},
 
+  // When live-store KEDA is enabled, remove spec.replicas from block-builder so
+  // the rollout-operator (mirroring from live-store zone-a) exclusively owns it.
+  tempo_block_builder_statefulset+:
+    if $._config.live_store.keda.enabled then $.removeReplicasFromSpec else {},
+
   //
-  // Block Builder: KEDA kubernetes-workload scaler matching live-store zone-a pod count.
+  // Live Store: Prometheus-based autoscaling on expected bytes held.
+  // Targets the ReplicaTemplate; the rollout-operator mirrors the replica count
+  // to both zone StatefulSets, which must not carry their own spec.replicas.
   //
-  tempo_block_builder_scaled_object:
-    if $._config.block_builder.keda.enabled then
-      assert $._config.block_builder.keda.partitions_per_instance > 0 : 'block_builder.keda.partitions_per_instance must be > 0';
-      $.scaledObjectForController($.tempo_block_builder_statefulset, 'block_builder')
-      + scaledObject.spec.withTriggersMixin([{
-        type: 'kubernetes-workload',
-        metadata: {
-          podSelector: $._config.block_builder.keda.pod_selector,
-          value: '%d' % $._config.block_builder.keda.partitions_per_instance,
-        },
-      }])
+  tempo_live_store_scaled_object:
+    if $._config.live_store.keda.enabled then
+      assert $._config.autoscaling_prometheus_url != '' : 'autoscaling_prometheus_url is required for live_store autoscaling';
+      local config = $._config.live_store.keda;
+      local query = if config.query != '' then config.query else
+        |||
+          sum(rate(tempo_distributor_kafka_write_bytes_total{namespace="%(namespace)s"}[10m])) * %(window_seconds)d
+        ||| % { namespace: $._config.namespace, window_seconds: config.window_seconds };
+      $.scaledObjectForController($.tempo_live_store_replica_template, 'live_store')
+      + scaledObject.spec.withTriggersMixin(
+        [
+          // metricType: Value → desiredReplicas = ceil(queryResult / threshold).
+          // The query returns total expected bytes across all pods, so we must use
+          // Value rather than the default AverageValue (which would multiply by
+          // currentReplicas and cause runaway scaling).
+          $.prometheusTrigger(
+            query=query,
+            metricName='tempo_live_store_expected_bytes',
+            threshold='%d' % config.bytes_per_replica,
+          ) + { metricType: 'Value' },
+        ] + config.additional_triggers
+      )
     else {},
 
-  tempo_block_builder_statefulset+:
-    if $._config.block_builder.keda.enabled then $.removeReplicasFromSpec else {},
+  // When KEDA manages the live-store, omit spec.replicas from the ReplicaTemplate
+  // so that KEDA exclusively owns that field and Tanka apply does not fight it.
+  tempo_live_store_replica_template+:
+    if $._config.live_store.keda.enabled then {
+      spec+: { replicas+:: null },
+    } else {},
+
+  tempo_live_store_zone_a_statefulset+:
+    if $._config.live_store.keda.enabled then $.removeReplicasFromSpec else {},
+
+  tempo_live_store_zone_b_statefulset+:
+    if $._config.live_store.keda.enabled then $.removeReplicasFromSpec else {},
+
 }

--- a/operations/jsonnet/microservices/block-builder.libsonnet
+++ b/operations/jsonnet/microservices/block-builder.libsonnet
@@ -23,6 +23,9 @@
     'config.file': '/conf/tempo.yaml',
   },
 
+  // Block-builder mirrors live-store zone-a replica count. This intentionally lags
+  // behind the ReplicaTemplate: the rollout-operator enforces the drain window before
+  // reducing zone-a, so block-builder stays alive while live-store data is still present.
   tempo_block_builder_follow_controller:: $.tempo_live_store_zone_a_statefulset,
 
   tempo_block_builder_container::

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -29,8 +29,8 @@
     // This feature modifies the block-builder StatefulSet which cannot be altered, so if it already exists it has to be deleted and re-applied again in order to be enabled.
     block_builder_concurrent_rollout_enabled: false,
     // Maximum number of unavailable replicas during a block-builder rollout when using block_builder_concurrent_rollout_enabled feature.
-    // Computed from block-builder replicas by default, but can also be specified as percentage, for example "25%".
-    block_builder_max_unavailable: $.tempo_block_builder_statefulset.spec.replicas,
+    // Defaults to 100% since block-builder pods are independent (each owns distinct Kafka partitions).
+    block_builder_max_unavailable: '100%',
 
     // disable tempo-query by default
     tempo_query: {

--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -89,11 +89,11 @@
 
   tempo_query_frontend_config:: $.tempo_config {},
   tempo_block_builder_config:: $.tempo_config + $.tempo_ingest_config + (
-    // When autoscaling is enabled, set partitions_per_instance to match the KEDA ratio
-    // so each block-builder pod consumes the correct number of partitions.
-    if $._config.block_builder.keda.enabled then {
+    // Inject partitions_per_instance when live-store KEDA is enabled because the
+    // block-builder replica count is then dynamic and must stay coupled to partition count.
+    if $._config.live_store.keda.enabled then {
       block_builder+: {
-        partitions_per_instance: $._config.block_builder.keda.partitions_per_instance,
+        partitions_per_instance: $._config.block_builder.partitions_per_instance,
       },
     } else {}
   ),

--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -91,11 +91,14 @@
   tempo_block_builder_config:: $.tempo_config + $.tempo_ingest_config + (
     // Inject partitions_per_instance when live-store KEDA is enabled because the
     // block-builder replica count is then dynamic and must stay coupled to partition count.
-    if $._config.live_store.keda.enabled then {
-      block_builder+: {
-        partitions_per_instance: $._config.block_builder.partitions_per_instance,
-      },
-    } else {}
+    if $._config.live_store.keda.enabled then
+      assert $._config.block_builder.partitions_per_instance > 0 : 'block_builder.partitions_per_instance must be > 0';
+      {
+        block_builder+: {
+          partitions_per_instance: $._config.block_builder.partitions_per_instance,
+        },
+      }
+    else {}
   ),
   tempo_live_store_config:: $.tempo_config + $.tempo_ingest_config {
     live_store: {

--- a/operations/jsonnet/microservices/tempo.libsonnet
+++ b/operations/jsonnet/microservices/tempo.libsonnet
@@ -14,8 +14,8 @@
 (import 'memberlist.libsonnet') +
 (import 'vertical-pod-autoscaler.libsonnet') +
 (import 'pod-disruption-budget.libsonnet') +
-(import 'autoscaling.libsonnet') +
 (import 'rollout-operator/rollout-operator.libsonnet') +
+(import 'autoscaling.libsonnet') +
 
 {
   local k = import 'ksonnet-util/kausal.libsonnet',

--- a/operations/jsonnet/microservices/test/test1.jsonnet
+++ b/operations/jsonnet/microservices/test/test1.jsonnet
@@ -11,6 +11,15 @@ local withBackendWorkerKeda(url, tenant='') = default {
   },
 };
 
+// Helper: default env with live_store KEDA enabled and a given Prometheus URL/tenant.
+local withLiveStoreKeda(url, tenant='') = default {
+  _config+:: {
+    autoscaling_prometheus_url: url,
+    autoscaling_prometheus_tenant: tenant,
+    live_store+: { replicas: 1, keda+: { enabled: true } },
+  },
+};
+
 test.new(std.thisFile)
 + test.case.new(
   'Basic',
@@ -41,5 +50,123 @@ test.new(std.thisFile)
       'customHeaders'
     ),
     false
+  )
+)
++ test.case.new(
+  'live_store KEDA ScaledObject targets the ReplicaTemplate',
+  test.expect.eq(
+    withLiveStoreKeda('http://prometheus:9090').tempo_live_store_scaled_object.spec.scaleTargetRef.name,
+    'live-store'
+  )
+)
++ test.case.new(
+  'live_store KEDA ScaledObject scaleTargetRef kind is ReplicaTemplate',
+  test.expect.eq(
+    withLiveStoreKeda('http://prometheus:9090').tempo_live_store_scaled_object.spec.scaleTargetRef.kind,
+    'ReplicaTemplate'
+  )
+)
++ test.case.new(
+  'live_store KEDA Prometheus trigger uses autoscaling_prometheus_url',
+  test.expect.eq(
+    withLiveStoreKeda('http://prometheus:9090').tempo_live_store_scaled_object.spec.triggers[0].metadata.serverAddress,
+    'http://prometheus:9090'
+  )
+)
++ test.case.new(
+  'live_store KEDA Prometheus trigger includes X-Scope-OrgID header when tenant is set',
+  test.expect.eq(
+    withLiveStoreKeda('http://prometheus:9090', 'my-tenant').tempo_live_store_scaled_object.spec.triggers[0].metadata.customHeaders,
+    'X-Scope-OrgID=my-tenant'
+  )
+)
++ test.case.new(
+  'live_store KEDA Prometheus trigger omits customHeaders when tenant is empty',
+  test.expect.eq(
+    std.objectHas(
+      withLiveStoreKeda('http://prometheus:9090').tempo_live_store_scaled_object.spec.triggers[0].metadata,
+      'customHeaders'
+    ),
+    false
+  )
+)
++ test.case.new(
+  'live_store KEDA query embeds window_seconds from config',
+  test.expect.eq(
+    std.length(std.findSubstr(
+      '1800',
+      withLiveStoreKeda('http://prometheus:9090').tempo_live_store_scaled_object.spec.triggers[0].metadata.query,
+    )) > 0,
+    true
+  )
+)
++ test.case.new(
+  'live_store KEDA default query uses 10m rate window',
+  test.expect.eq(
+    std.length(std.findSubstr(
+      '[10m]',
+      withLiveStoreKeda('http://prometheus:9090').tempo_live_store_scaled_object.spec.triggers[0].metadata.query,
+    )) > 0,
+    true
+  )
+)
++ test.case.new(
+  'live_store KEDA additional_triggers are appended after the default trigger',
+  test.expect.eq(
+    (default {
+       _config+:: {
+         autoscaling_prometheus_url: 'http://prometheus:9090',
+         live_store+: {
+           replicas: 1,
+           keda+: {
+             enabled: true,
+             additional_triggers: [{ type: 'cpu', metricType: 'Utilization', metadata: { value: '80' } }],
+           },
+         },
+       },
+     }).tempo_live_store_scaled_object.spec.triggers[1],
+    { type: 'cpu', metricType: 'Utilization', metadata: { value: '80' } }
+  )
+)
++ test.case.new(
+  'live_store KEDA enabled removes spec.replicas from block-builder',
+  test.expect.eq(
+    std.objectHas(
+      withLiveStoreKeda('http://prometheus:9090').tempo_block_builder_statefulset.spec,
+      'replicas'
+    ),
+    false
+  )
+)
++ test.case.new(
+  'block_builder_max_unavailable defaults to 100%',
+  test.expect.eq(
+    default._config.block_builder_max_unavailable,
+    '100%'
+  )
+)
++ test.case.new(
+  'live_store KEDA enabled block_builder follows live-store zone-a',
+  test.expect.eq(
+    withLiveStoreKeda('http://prometheus:9090').tempo_block_builder_statefulset.spec.template.metadata.annotations['grafana.com/rollout-mirror-replicas-from-resource-name'],
+    'live-store-zone-a'
+  )
+)
++ test.case.new(
+  'live_store KEDA enabled injects partitions_per_instance into block-builder config',
+  test.expect.eq(
+    withLiveStoreKeda('http://prometheus:9090').tempo_block_builder_config.block_builder.partitions_per_instance,
+    1
+  )
+)
++ test.case.new(
+  'live_store KEDA disabled does not inject partitions_per_instance into block-builder config',
+  test.expect.eq(
+    std.get(
+      std.get(default.tempo_block_builder_config, 'block_builder', {}),
+      'partitions_per_instance',
+      null
+    ),
+    null
   )
 )

--- a/operations/jsonnet/microservices/test/test1.jsonnet
+++ b/operations/jsonnet/microservices/test/test1.jsonnet
@@ -17,6 +17,7 @@ local withLiveStoreKeda(url, tenant='') = default {
     autoscaling_prometheus_url: url,
     autoscaling_prometheus_tenant: tenant,
     live_store+: { replicas: 1, keda+: { enabled: true } },
+    rollout_operator_replica_template_access_enabled: true,
   },
 };
 
@@ -116,6 +117,7 @@ test.new(std.thisFile)
     (default {
        _config+:: {
          autoscaling_prometheus_url: 'http://prometheus:9090',
+         rollout_operator_replica_template_access_enabled: true,
          live_store+: {
            replicas: 1,
            keda+: {


### PR DESCRIPTION
**What this PR does**:

Adds KEDA-based horizontal pod autoscaling for the live-store component in the microservices Jsonnet. This is an alternative to #7123, using the rollout-operator to couple block-builder scaling to live-store rather than a separate KEDA ScaledObject for block-builder.

The scaler targets the `ReplicaTemplate` resource; the rollout-operator mirrors the replica count to both zone StatefulSets (zone-a and zone-b), which must not carry their own `spec.replicas`.

**Scaling signal**

The default trigger estimates total bytes held across all live-store pods from the Kafka write rate:

```
sum(rate(tempo_distributor_kafka_write_bytes_total{namespace="..."}[10m])) * window_seconds
```

This measures the distributor (producer) side of Kafka, not per-pod consumption, so draining pods during scale-down do not pollute the signal. The 10-minute rate window smooths over transient load dips to avoid triggering the scale-down stabilization clock prematurely.

KEDA uses `metricType: Value` so `replicas = ceil(query_result / bytes_per_replica)`, which scales based on total load rather than per-pod average.

**Scale-down and drain timing**

Live-store pods take ~35 minutes to drain after receiving a prepare-downscale call (partitions are abandoned immediately; pods remain live for query). The `scale_down_stabilization_window_seconds` defaults to 35 minutes, meaning KEDA requires sustained low load for 35 minutes before issuing a scale-down.

**Block-builder coupling**

When live-store KEDA is enabled, the block-builder StatefulSet has `spec.replicas` removed so the rollout-operator can own the count. The block-builder mirrors live-store zone-a (via the existing `grafana.com/rollout-mirror-replicas-from-resource-*` annotations), intentionally lagging behind the ReplicaTemplate: the rollout-operator enforces the drain window before reducing zone-a, so block-builder stays alive while live-store data is still present.

The alternative approach (a separate KEDA ScaledObject for block-builder using a kubernetes-workload trigger) is in #7123.

**Config knobs** (all under `live_store.keda`):

| Field | Default | Description |
|---|---|---|
| `enabled` | `false` | Enable KEDA ScaledObject |
| `min_replicas` | `1` | Minimum pod count |
| `max_replicas` | `200` | Maximum pod count |
| `window_seconds` | `1800` | Retention window (s); should be >= `complete_block_timeout` + `query_backend_after` |
| `bytes_per_replica` | `10 MB/s x window_seconds` (~16 GiB) | Max bytes held per pod; change the multiplier to match your per-pod throughput ceiling |
| `query` | `''` | Override the default Prometheus query entirely |
| `additional_triggers` | `[]` | Raw KEDA trigger objects appended after the default trigger |
| `scale_down_stabilization_window_seconds` | `2100` (35m) | Hold peak replica count until sustained low load is confirmed |

`block_builder.partitions_per_instance` (default: `1`) is injected into the block-builder config when live-store KEDA is enabled so the partition assignment stays coupled to the dynamic replica count.

**Which issue(s) this PR fixes**:
Fixes #6933

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`