### PR TITLE
fix: add recover to livestore iterateblocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [BUGFIX] backend-scheduler: fix redaction batch not cleaned up after dead-job timeout, leaving tenant permanently blocked from new redaction submissions and compaction. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
 * [BUGFIX] backend-scheduler: fix outstanding-blocks metric suppressed to zero during active redaction batch, causing autoscaler to scale down workers mid-redaction. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
 * [BUGFIX] backend-scheduler: fix O(N) lock contention in GetJobForWorker under concurrent worker load; replace shard scan with O(1) index lookup. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
+* [BUGFIX] livestore: recover from panics in `iterateBlocks` per-block paths so a panic in vparquet/parquetquery (e.g. malformed `ByteArray` values) returns an error instead of crashing the process. [#7134](https://github.com/grafana/tempo/pull/7134) (@zhxiaogg)
 
 # v3.0.0-rc.1
 

--- a/modules/livestore/instance_search.go
+++ b/modules/livestore/instance_search.go
@@ -93,9 +93,17 @@ func (i *instance) iterateBlocks(ctx context.Context, reqStart, reqEnd time.Time
 			ctx, span := tracer.Start(ctx, "process.headBlock")
 			span.SetAttributes(attribute.String("blockID", meta.BlockID.String()))
 
-			if err := fn(ctx, meta, i.headBlock); err != nil {
-				handleErr(fmt.Errorf("processing head block (%s): %w", meta.BlockID, err))
-			}
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						level.Error(i.logger).Log("msg", "panic in iterateBlocks head block", "blockID", meta.BlockID, "panic", r, "stack", string(debug.Stack()))
+						handleErr(fmt.Errorf("processing head block (%s): panic: %v", meta.BlockID, r))
+					}
+				}()
+				if err := fn(ctx, meta, i.headBlock); err != nil {
+					handleErr(fmt.Errorf("processing head block (%s): %w", meta.BlockID, err))
+				}
+			}()
 			span.End()
 		}
 	}

--- a/modules/livestore/instance_search.go
+++ b/modules/livestore/instance_search.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -119,6 +120,12 @@ func (i *instance) iterateBlocks(ctx context.Context, reqStart, reqEnd time.Time
 		wg.Add(1)
 		go func(block common.WALBlock) {
 			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					level.Error(i.logger).Log("msg", "panic in iterateBlocks wal block", "blockID", meta.BlockID, "panic", r, "stack", string(debug.Stack()))
+					handleErr(fmt.Errorf("processing wal block (%s): panic: %v", meta.BlockID, r))
+				}
+			}()
 
 			if ctx.Err() != nil {
 				return
@@ -148,6 +155,12 @@ func (i *instance) iterateBlocks(ctx context.Context, reqStart, reqEnd time.Time
 		wg.Add(1)
 		go func(block *LocalBlock) {
 			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					level.Error(i.logger).Log("msg", "panic in iterateBlocks complete block", "blockID", meta.BlockID, "panic", r, "stack", string(debug.Stack()))
+					handleErr(fmt.Errorf("processing complete block (%s): panic: %v", meta.BlockID, r))
+				}
+			}()
 
 			if ctx.Err() != nil {
 				return

--- a/modules/livestore/instance_search_test.go
+++ b/modules/livestore/instance_search_test.go
@@ -1046,6 +1046,58 @@ func TestInstanceFindByTraceIDWithSizeLimits(t *testing.T) {
 	require.NotNil(t, resp.Trace) // can't validate the trace b/c its a subset of the original trace. as long as its non-nil, we're good
 }
 
+// TestIterateBlocksRecoversPanic verifies that a panic raised inside the
+// per-block worker goroutines (wal block path or complete block path) of
+// iterateBlocks is converted into a normal error rather than crashing the
+// process. This guards against panics originating deep in vparquet/parquetquery
+// (e.g. malformed parquet ByteArray Values) which previously crashed livestore
+// pods because those goroutines had no defer-recover.
+func TestIterateBlocksRecoversPanic(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		complete bool
+	}{
+		{name: "wal block", complete: false},
+		{name: "complete block", complete: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			i, ls := defaultInstanceAndTmpDir(t)
+			defer func() {
+				err := services.StopAndAwaitTerminated(t.Context(), ls)
+				if err != nil && !errors.Is(err, context.Canceled) {
+					require.NoError(t, err)
+				}
+			}()
+
+			// populate one WAL block by writing traces and cutting
+			_, _, _, _ = writeTracesForSearch(t, i, "", foo, bar, false, false)
+			blockID, err := i.cutBlocks(t.Context(), true)
+			require.NoError(t, err)
+			require.NotEqual(t, uuid.Nil, blockID)
+
+			if tc.complete {
+				_, err = i.completeBlock(t.Context(), blockID)
+				require.NoError(t, err)
+			}
+
+			// neutralize the synchronous head block path; iterateBlocks recovery
+			// is only required for the goroutine-spawning wal/complete paths,
+			// the headBlock path is covered by the gRPC handler recover.
+			i.blocksMtx.Lock()
+			i.headBlock = nil
+			i.blocksMtx.Unlock()
+
+			panicFn := func(_ context.Context, _ *backend.BlockMeta, _ block) error {
+				panic("simulated parquet ByteArray panic")
+			}
+
+			err = i.iterateBlocks(t.Context(), time.Unix(0, 0), time.Unix(0, 0), panicFn)
+			require.Error(t, err, "iterateBlocks should return an error rather than crash on panic")
+			require.Contains(t, err.Error(), "panic")
+		})
+	}
+}
+
 func TestIncludeBlock(t *testing.T) {
 	tests := []struct {
 		blocKStart int64

--- a/modules/livestore/instance_search_test.go
+++ b/modules/livestore/instance_search_test.go
@@ -1046,19 +1046,43 @@ func TestInstanceFindByTraceIDWithSizeLimits(t *testing.T) {
 	require.NotNil(t, resp.Trace) // can't validate the trace b/c its a subset of the original trace. as long as its non-nil, we're good
 }
 
-// TestIterateBlocksRecoversPanic verifies that a panic raised inside the
-// per-block worker goroutines (wal block path or complete block path) of
-// iterateBlocks is converted into a normal error rather than crashing the
-// process. This guards against panics originating deep in vparquet/parquetquery
-// (e.g. malformed parquet ByteArray Values) which previously crashed livestore
-// pods because those goroutines had no defer-recover.
 func TestIterateBlocksRecoversPanic(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
-		complete bool
+		populate func(t *testing.T, i *instance)
 	}{
-		{name: "wal block", complete: false},
-		{name: "complete block", complete: true},
+		{
+			name: "head block",
+			populate: func(t *testing.T, i *instance) {
+				_, _, _, _ = writeTracesForSearch(t, i, "", foo, bar, false, false)
+			},
+		},
+		{
+			name: "wal block",
+			populate: func(t *testing.T, i *instance) {
+				_, _, _, _ = writeTracesForSearch(t, i, "", foo, bar, false, false)
+				blockID, err := i.cutBlocks(t.Context(), true)
+				require.NoError(t, err)
+				require.NotEqual(t, uuid.Nil, blockID)
+				i.blocksMtx.Lock()
+				i.headBlock = nil
+				i.blocksMtx.Unlock()
+			},
+		},
+		{
+			name: "complete block",
+			populate: func(t *testing.T, i *instance) {
+				_, _, _, _ = writeTracesForSearch(t, i, "", foo, bar, false, false)
+				blockID, err := i.cutBlocks(t.Context(), true)
+				require.NoError(t, err)
+				require.NotEqual(t, uuid.Nil, blockID)
+				_, err = i.completeBlock(t.Context(), blockID)
+				require.NoError(t, err)
+				i.blocksMtx.Lock()
+				i.headBlock = nil
+				i.blocksMtx.Unlock()
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			i, ls := defaultInstanceAndTmpDir(t)
@@ -1069,29 +1093,13 @@ func TestIterateBlocksRecoversPanic(t *testing.T) {
 				}
 			}()
 
-			// populate one WAL block by writing traces and cutting
-			_, _, _, _ = writeTracesForSearch(t, i, "", foo, bar, false, false)
-			blockID, err := i.cutBlocks(t.Context(), true)
-			require.NoError(t, err)
-			require.NotEqual(t, uuid.Nil, blockID)
-
-			if tc.complete {
-				_, err = i.completeBlock(t.Context(), blockID)
-				require.NoError(t, err)
-			}
-
-			// neutralize the synchronous head block path; iterateBlocks recovery
-			// is only required for the goroutine-spawning wal/complete paths,
-			// the headBlock path is covered by the gRPC handler recover.
-			i.blocksMtx.Lock()
-			i.headBlock = nil
-			i.blocksMtx.Unlock()
+			tc.populate(t, i)
 
 			panicFn := func(_ context.Context, _ *backend.BlockMeta, _ block) error {
 				panic("simulated parquet ByteArray panic")
 			}
 
-			err = i.iterateBlocks(t.Context(), time.Unix(0, 0), time.Unix(0, 0), panicFn)
+			err := i.iterateBlocks(t.Context(), time.Unix(0, 0), time.Unix(0, 0), panicFn)
 			require.Error(t, err, "iterateBlocks should return an error rather than crash on panic")
 			require.Contains(t, err.Error(), "panic")
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
- add recover to handle potential panics in livestore

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`