### PR TITLE
fix: clean up YAML output on overrides status endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [BUGFIX] backend-scheduler: fix outstanding-blocks metric suppressed to zero during active redaction batch, causing autoscaler to scale down workers mid-redaction. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
 * [BUGFIX] backend-scheduler: fix O(N) lock contention in GetJobForWorker under concurrent worker load; replace shard scan with O(1) index lookup. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
 * [BUGFIX] livestore: recover from panics in `iterateBlocks` per-block paths so a panic in vparquet/parquetquery (e.g. malformed `ByteArray` values) returns an error instead of crashing the process. [#7134](https://github.com/grafana/tempo/pull/7134) (@zhxiaogg)
+* [BUGFIX] user-configurable overrides: emit duration fields as flat YAML scalars on `/status/overrides/{tenant}` and omit `generate_native_histograms` when unset. [#7138](https://github.com/grafana/tempo/pull/7138) (@electron0zero)
 
 # v3.0.0-rc.1
 

--- a/modules/overrides/userconfigurable/client/duration.go
+++ b/modules/overrides/userconfigurable/client/duration.go
@@ -45,7 +45,7 @@ func (d *Duration) UnmarshalJSON(input []byte) error {
 // nested "duration: 5m0s" map that yaml.v2's default reflection produces for
 // the embedded time.Duration field.
 func (d *Duration) MarshalYAML() (interface{}, error) {
-	return d.Duration.String(), nil
+	return d.String(), nil
 }
 
 // UnmarshalYAML parses a duration string ("5m0s") into d.

--- a/modules/overrides/userconfigurable/client/duration.go
+++ b/modules/overrides/userconfigurable/client/duration.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"go.yaml.in/yaml/v2"
 )
 
 type Duration struct {
@@ -39,7 +41,30 @@ func (d *Duration) UnmarshalJSON(input []byte) error {
 	return nil
 }
 
+// MarshalYAML emits the duration as a flat scalar ("5m0s") instead of the
+// nested "duration: 5m0s" map that yaml.v2's default reflection produces for
+// the embedded time.Duration field.
+func (d Duration) MarshalYAML() (interface{}, error) {
+	return d.Duration.String(), nil
+}
+
+// UnmarshalYAML parses a duration string ("5m0s") into d.
+func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	if err := unmarshal(&s); err != nil {
+		return err
+	}
+	parsed, err := time.ParseDuration(s)
+	if err != nil {
+		return err
+	}
+	d.Duration = parsed
+	return nil
+}
+
 var (
 	_ json.Marshaler   = (*Duration)(nil)
 	_ json.Unmarshaler = (*Duration)(nil)
+	_ yaml.Marshaler   = Duration{}
+	_ yaml.Unmarshaler = (*Duration)(nil)
 )

--- a/modules/overrides/userconfigurable/client/duration.go
+++ b/modules/overrides/userconfigurable/client/duration.go
@@ -44,7 +44,7 @@ func (d *Duration) UnmarshalJSON(input []byte) error {
 // MarshalYAML emits the duration as a flat scalar ("5m0s") instead of the
 // nested "duration: 5m0s" map that yaml.v2's default reflection produces for
 // the embedded time.Duration field.
-func (d Duration) MarshalYAML() (interface{}, error) {
+func (d *Duration) MarshalYAML() (interface{}, error) {
 	return d.Duration.String(), nil
 }
 
@@ -65,6 +65,6 @@ func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
 var (
 	_ json.Marshaler   = (*Duration)(nil)
 	_ json.Unmarshaler = (*Duration)(nil)
-	_ yaml.Marshaler   = Duration{}
+	_ yaml.Marshaler   = (*Duration)(nil)
 	_ yaml.Unmarshaler = (*Duration)(nil)
 )

--- a/modules/overrides/userconfigurable/client/duration_test.go
+++ b/modules/overrides/userconfigurable/client/duration_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.yaml.in/yaml/v2"
 )
 
 type mockStruct struct {
@@ -38,6 +39,21 @@ func TestDuration_MarshalJSON(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDuration_MarshalYAML guards the admin /status/overrides/{tenant} page,
+// which yaml.Marshal()s a struct containing *Duration fields. Without a
+// MarshalYAML method, yaml.v2 emits "duration: 5m0s" (the embedded
+// time.Duration as a nested map) instead of the flat scalar "5m0s".
+func TestDuration_MarshalYAML(t *testing.T) {
+	in := mockStruct{&Duration{60 * time.Second}}
+	out, err := yaml.Marshal(in)
+	assert.NoError(t, err)
+	assert.Equal(t, "duration: 1m0s\n", string(out))
+
+	var decoded mockStruct
+	assert.NoError(t, yaml.Unmarshal(out, &decoded))
+	assert.Equal(t, in.Duration.Duration, decoded.Duration.Duration)
 }
 
 func TestDuration_UnmarshalJSON(t *testing.T) {

--- a/modules/overrides/userconfigurable/client/limits.go
+++ b/modules/overrides/userconfigurable/client/limits.go
@@ -42,7 +42,7 @@ type LimitsMetricsGenerator struct {
 	CollectionInterval              *Duration                   `yaml:"collection_interval,omitempty" json:"collection_interval,omitempty"`
 	TraceIDLabelName                *string                     `yaml:"trace_id_label_name,omitempty" json:"trace_id_label_name,omitempty"`
 	IngestionSlack                  *Duration                   `yaml:"ingestion_time_range_slack,omitempty" json:"ingestion_time_range_slack,omitempty"`
-	GenerateNativeHistograms        *histograms.HistogramMethod `yaml:"generate_native_histograms" json:"generate_native_histograms,omitempty"`
+	GenerateNativeHistograms        *histograms.HistogramMethod `yaml:"generate_native_histograms,omitempty" json:"generate_native_histograms,omitempty"`
 	NativeHistogramMaxBucketNumber  *uint32                     `yaml:"native_histogram_max_bucket_number,omitempty" json:"native_histogram_max_bucket_number,omitempty"`
 	NativeHistogramBucketFactor     *float64                    `yaml:"native_histogram_bucket_factor,omitempty" json:"native_histogram_bucket_factor,omitempty"`
 	NativeHistogramMinResetDuration *Duration                   `yaml:"native_histogram_min_reset_duration,omitempty" json:"native_histogram_min_reset_duration,omitempty"`


### PR DESCRIPTION
**What this PR does**:

client.Duration only implemented JSON marshalers, so yaml.Marshal fell back to reflection on the embedded time.Duration and emitted a nested `duration: <value>` map in the results.

`generate_native_histograms` was also missing `,omitempty` on its YAML tag so it rendered as `null` when unset.

**Before:**

```yaml
  metrics_generator:
    disable_collection: true
    collection_interval:
      duration: 1m0s
    generate_native_histograms: null
```

**After:**

```yaml
  metrics_generator:
    disable_collection: true
    collection_interval: 1m0s
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`