### PR TITLE
[Backport r251] Fix panic in old tag-style search + integer dedicated columns + vp5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,7 @@
 
 * [FEATURE] Add span profiling support via otelpyroscope. Enable with `span_profiling: true` (or `-span-profiling` CLI flag) to attach pprof labels to OTel spans. [#7063](https://github.com/grafana/tempo/pull/7063) (@simonswine)
 * [BUGFIX] Fix tempo-vulture ignoring `-tempo-push-tls` flag in normal operating mode. [#6974](https://github.com/grafana/tempo/pull/6974) (@xaque208)
-* [ENHANCEMENT] **BREAKING CHANGE** Query-frontend: new job sharding approach for trace lookups, using a new config option `blocks_per_shard` which replaces `query_shards`. [#7105](https://github.com/grafana/tempo/pull/7105) (@mdisibio)
-* [ENHANCEMENT] jsonnet: add `autoscaling_prometheus_url` and `autoscaling_prometheus_tenant` top-level config fields for KEDA autoscaling. Setting `autoscaling_prometheus_tenant` sends an `X-Scope-OrgID` header on all Prometheus trigger requests, which is required when the backend is a multi-tenant system such as Grafana Mimir. [#7099](https://github.com/grafana/tempo/pull/7099) (@zachfi)
-* [FEATURE] Make individual AST transformations skippable via config and query hints [#7012](https://github.com/grafana/tempo/pull/7012) (@stoewer)
 * [BUGFIX] live-store: Fix panic in legacy tag-based search against vParquet5 blocks when matching attributes stored in integer dedicated columns (for example `/api/search?http.status_code=500`). [#7135](https://github.com/grafana/tempo/pull/7135) (@mdisibio)
-* [BUGFIX] backend-scheduler: fix redaction batch not cleaned up after dead-job timeout, leaving tenant permanently blocked from new redaction submissions and compaction. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
-* [BUGFIX] backend-scheduler: fix outstanding-blocks metric suppressed to zero during active redaction batch, causing autoscaler to scale down workers mid-redaction. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
-* [BUGFIX] backend-scheduler: fix O(N) lock contention in GetJobForWorker under concurrent worker load; replace shard scan with O(1) index lookup. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
-* [BUGFIX] livestore: recover from panics in `iterateBlocks` per-block paths so a panic in vparquet/parquetquery (e.g. malformed `ByteArray` values) returns an error instead of crashing the process. [#7134](https://github.com/grafana/tempo/pull/7134) (@zhxiaogg)
-
-# v3.0.0-rc.1
-
-* [CHANGE] Stop publishing 32-bit ARM binary archives. Release artifacts continue to include amd64 and arm64 binaries. [#7106](https://github.com/grafana/tempo/pull/7106) (@javiermolinar)
-
-# v3.0.0-rc.0
-
 * [CHANGE] **BREAKING CHANGE** Remove duplicate "compaction" prefix from CompactorConfig CLI flags. Affected flags: `compaction.block-retention`, `compaction.max-objects-per-block`, `compaction.max-block-bytes`, `compaction.compaction-window`. [#6909](https://github.com/grafana/tempo/pull/6909) (@electron0zero)
 * [CHANGE] **BREAKING CHANGE** Enable RetryInfo by default. `distributor.retry_after_on_resource_exhausted` now defaults to `5s` (was `0`) so OTLP clients receive a retry hint on `ResourceExhausted` errors. [#7088](https://github.com/grafana/tempo/pull/7088) (@electron0zero)
   Set to `0` to disable cluster-wide, or set the per-tenant override `ingestion.retry_info_enabled: false` to disable for a single tenant.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 * [FEATURE] Add span profiling support via otelpyroscope. Enable with `span_profiling: true` (or `-span-profiling` CLI flag) to attach pprof labels to OTel spans. [#7063](https://github.com/grafana/tempo/pull/7063) (@simonswine)
 * [BUGFIX] Fix tempo-vulture ignoring `-tempo-push-tls` flag in normal operating mode. [#6974](https://github.com/grafana/tempo/pull/6974) (@xaque208)
+* [ENHANCEMENT] **BREAKING CHANGE** Query-frontend: new job sharding approach for trace lookups, using a new config option `blocks_per_shard` which replaces `query_shards`. [#7105](https://github.com/grafana/tempo/pull/7105) (@mdisibio)
+* [ENHANCEMENT] jsonnet: add `autoscaling_prometheus_url` and `autoscaling_prometheus_tenant` top-level config fields for KEDA autoscaling. Setting `autoscaling_prometheus_tenant` sends an `X-Scope-OrgID` header on all Prometheus trigger requests, which is required when the backend is a multi-tenant system such as Grafana Mimir. [#7099](https://github.com/grafana/tempo/pull/7099) (@zachfi)
+* [FEATURE] Make individual AST transformations skippable via config and query hints [#7012](https://github.com/grafana/tempo/pull/7012) (@stoewer)
+* [BUGFIX] live-store: Fix panic in legacy tag-based search against vParquet5 blocks when matching attributes stored in integer dedicated columns (for example `/api/search?http.status_code=500`). [#7135](https://github.com/grafana/tempo/pull/7135) (@mdisibio)
+* [BUGFIX] backend-scheduler: fix redaction batch not cleaned up after dead-job timeout, leaving tenant permanently blocked from new redaction submissions and compaction. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
+* [BUGFIX] backend-scheduler: fix outstanding-blocks metric suppressed to zero during active redaction batch, causing autoscaler to scale down workers mid-redaction. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
+* [BUGFIX] backend-scheduler: fix O(N) lock contention in GetJobForWorker under concurrent worker load; replace shard scan with O(1) index lookup. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
+* [BUGFIX] livestore: recover from panics in `iterateBlocks` per-block paths so a panic in vparquet/parquetquery (e.g. malformed `ByteArray` values) returns an error instead of crashing the process. [#7134](https://github.com/grafana/tempo/pull/7134) (@zhxiaogg)
+
+# v3.0.0-rc.1
+
+* [CHANGE] Stop publishing 32-bit ARM binary archives. Release artifacts continue to include amd64 and arm64 binaries. [#7106](https://github.com/grafana/tempo/pull/7106) (@javiermolinar)
+
+# v3.0.0-rc.0
+
 * [CHANGE] **BREAKING CHANGE** Remove duplicate "compaction" prefix from CompactorConfig CLI flags. Affected flags: `compaction.block-retention`, `compaction.max-objects-per-block`, `compaction.max-block-bytes`, `compaction.compaction-window`. [#6909](https://github.com/grafana/tempo/pull/6909) (@electron0zero)
 * [CHANGE] **BREAKING CHANGE** Enable RetryInfo by default. `distributor.retry_after_on_resource_exhausted` now defaults to `5s` (was `0`) so OTLP clients receive a retry hint on `ResourceExhausted` errors. [#7088](https://github.com/grafana/tempo/pull/7088) (@electron0zero)
   Set to `0` to disable cluster-wide, or set the per-tenant override `ingestion.retry_info_enabled: false` to disable for a single tenant.

--- a/tempodb/encoding/vparquet5/block_search.go
+++ b/tempodb/encoding/vparquet5/block_search.go
@@ -133,7 +133,19 @@ func makePipelineWithRowGroups(ctx context.Context, req *tempopb.SearchRequest, 
 	for k, v := range req.Tags {
 		// dedicated attribute columns
 		if c, ok := spanAndResourceColumnMapping.get(k); ok {
-			resourceIters = append(resourceIters, makeIter(c.ColumnPath, pq.NewSubstringPredicate(v), ""))
+			switch c.Type {
+			case backend.DedicatedColumnTypeInt:
+				if i, err := strconv.ParseInt(v, 10, 64); err == nil {
+					// Column is integer and so is input, do integer comparison.
+					resourceIters = append(resourceIters, makeIter(c.ColumnPath, pq.NewIntEqualPredicate(i), ""))
+				} else {
+					// Column is integer but input is not, so fallback to the generic string handling.
+					otherAttrConditions[k] = v
+					continue
+				}
+			case backend.DedicatedColumnTypeString:
+				resourceIters = append(resourceIters, makeIter(c.ColumnPath, pq.NewSubstringPredicate(v), ""))
+			}
 			continue
 		}
 
@@ -147,8 +159,8 @@ func makePipelineWithRowGroups(ctx context.Context, req *tempopb.SearchRequest, 
 		// most columns are just a substring predicate over the column, but we have
 		// special handling for http status code and span status
 		if k == LabelHTTPStatusCode {
-			if i, err := strconv.Atoi(v); err == nil {
-				resourceIters = append(resourceIters, makeIter(column, pq.NewIntBetweenPredicate(int64(i), int64(i)), ""))
+			if i, err := strconv.ParseInt(v, 10, 64); err == nil {
+				resourceIters = append(resourceIters, makeIter(column, pq.NewIntBetweenPredicate(i, i), ""))
 				continue
 			}
 			// Non-numeric string field

--- a/tempodb/encoding/vparquet5/block_search_test.go
+++ b/tempodb/encoding/vparquet5/block_search_test.go
@@ -11,7 +11,9 @@ import (
 
 	tempo_io "github.com/grafana/tempo/pkg/io"
 	"github.com/grafana/tempo/pkg/tempopb"
-	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	commonv1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	resourcev1 "github.com/grafana/tempo/pkg/tempopb/resource/v1"
+	tracev1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/pkg/util/test"
 	"github.com/grafana/tempo/tempodb/backend"
@@ -51,6 +53,7 @@ func TestBackendBlockSearch(t *testing.T) {
 						String03: []string{"dedicated-resource-attr-value-3"},
 						String04: []string{"dedicated-resource-attr-value-4"},
 						String05: []string{"dedicated-resource-attr-value-5"},
+						Int01:    []int64{123},
 					},
 				},
 				ScopeSpans: []ScopeSpans{
@@ -61,7 +64,7 @@ func TestBackendBlockSearch(t *testing.T) {
 								Name:         "hello",
 								SpanID:       []byte{},
 								ParentSpanID: []byte{},
-								StatusCode:   int(v1.Status_STATUS_CODE_ERROR),
+								StatusCode:   int(tracev1.Status_STATUS_CODE_ERROR),
 								Attrs: []Attribute{
 									attr("foo", "bar"),
 									attr("http.method", "get"),
@@ -74,6 +77,7 @@ func TestBackendBlockSearch(t *testing.T) {
 									String03: []string{"dedicated-span-attr-value-3"},
 									String04: []string{"dedicated-span-attr-value-4"},
 									String05: []string{test.DedicatedBlobTestString()},
+									Int01:    []int64{456},
 								},
 							},
 						},
@@ -148,6 +152,7 @@ func TestBackendBlockSearch(t *testing.T) {
 
 		// Dedicated resource attributes
 		makeReq("dedicated.resource.3", "dedicated-resource-attr-value-3"),
+		makeReq("dedicated.resource.6", "123"), // Will be converted to integer comparison
 
 		// Well-known span attributes
 		makeReq(LabelName, "ell"),
@@ -157,6 +162,7 @@ func TestBackendBlockSearch(t *testing.T) {
 
 		// Dedicated span attributes
 		makeReq("dedicated.span.4", "dedicated-span-attr-value-4"),
+		makeReq("dedicated.span.6", "456"), // Will be converted to integer comparison
 
 		// Span attributes
 		makeReq("foo", "bar"),
@@ -220,6 +226,7 @@ func TestBackendBlockSearch(t *testing.T) {
 
 		// Dedicated resource attributes
 		makeReq("dedicated.resource.3", "dedicated-resource-attr-value-1"),
+		makeReq("dedicated.resource.6", "9999"),
 
 		// Former well-known span attributes
 		makeReq(LabelHTTPMethod, "post"),
@@ -230,6 +237,7 @@ func TestBackendBlockSearch(t *testing.T) {
 
 		// Dedicated span attributes
 		makeReq("dedicated.span.4", "dedicated-span-attr-value-5"),
+		makeReq("dedicated.span.6", "9999"),
 
 		// Span attributes
 		makeReq("foo", "baz"),
@@ -248,6 +256,67 @@ func TestBackendBlockSearch(t *testing.T) {
 		meta := findInResults(expected.TraceID, res.Traces)
 		require.Nil(t, meta, req)
 	}
+}
+
+// TestSearchLegacyTagsHTTPStatusCode tests the old legacy tag-based search
+// against http.status_code stored in a new vParquet5 dedicated integer column.
+func TestSearchLegacyTagsHTTPStatusCode(t *testing.T) {
+	ctx := context.Background()
+	id := test.ValidTraceID(nil)
+
+	meta := &backend.BlockMeta{DedicatedColumns: backend.DefaultDedicatedColumns()}
+	pbTrace := &tempopb.Trace{
+		ResourceSpans: []*tracev1.ResourceSpans{{
+			Resource: &resourcev1.Resource{
+				Attributes: []*commonv1.KeyValue{{
+					Key: LabelServiceName,
+					Value: &commonv1.AnyValue{
+						Value: &commonv1.AnyValue_StringValue{StringValue: "foo"},
+					},
+				}},
+			},
+			ScopeSpans: []*tracev1.ScopeSpans{{
+				Spans: []*tracev1.Span{{
+					Name:              "span",
+					SpanId:            []byte("spanid01"),
+					StartTimeUnixNano: uint64(time.Second),
+					EndTimeUnixNano:   uint64(2 * time.Second),
+					Attributes: []*commonv1.KeyValue{{
+						Key: LabelHTTPStatusCode,
+						Value: &commonv1.AnyValue{
+							Value: &commonv1.AnyValue_IntValue{IntValue: 500},
+						},
+					}},
+				}},
+			}},
+		}},
+	}
+
+	pqTrace, _ := traceToParquet(meta, id, pbTrace, nil)
+	// Includes http.status_code as a span-level dedicated integer column.
+	dc := backend.DefaultDedicatedColumns()
+	b := makeBackendBlockWithTracesWithDedicatedColumns(t, []*Trace{pqTrace}, dc)
+
+	req := &tempopb.SearchRequest{
+		Tags: map[string]string{
+			LabelServiceName:    "foo",
+			LabelHTTPStatusCode: "500",
+		},
+		Limit: 10,
+	}
+
+	res, err := b.Search(ctx, req, common.DefaultSearchOptions())
+	require.NoError(t, err)
+	require.Len(t, res.Traces, 1)
+
+	expected := &tempopb.TraceSearchMetadata{
+		TraceID:           util.TraceIDToHexString(id),
+		StartTimeUnixNano: pqTrace.StartTimeUnixNano,
+		DurationMs:        uint32(pqTrace.DurationNano / uint64(time.Millisecond)),
+		RootServiceName:   pqTrace.RootServiceName,
+		RootTraceName:     pqTrace.RootSpanName,
+	}
+	require.Equal(t, expected, res.Traces[0])
 }
 
 func makeBackendBlockWithTraces(t *testing.T, trs []*Trace) *backendBlock {


### PR DESCRIPTION
**What this PR does**:
Backport #7135 to r251

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`