### PR TITLE
[blocklist]: use RWMutex in List to allow concurrent reads

### DIFF
--- a/tempodb/blocklist/list.go
+++ b/tempodb/blocklist/list.go
@@ -15,7 +15,7 @@ type PerTenantCompacted map[string][]*backend.CompactedBlockMeta
 
 // List controls access to a per tenant blocklist and compacted blocklist
 type List struct {
-	mtx            sync.Mutex
+	mtx            sync.RWMutex
 	metas          PerTenant
 	compactedMetas PerTenantCompacted
 
@@ -40,8 +40,8 @@ func New() *List {
 
 // Tenants returns a slice of tenant ids with metas (compacted metas are ignored.)
 func (l *List) Tenants() []string {
-	l.mtx.Lock()
-	defer l.mtx.Unlock()
+	l.mtx.RLock()
+	defer l.mtx.RUnlock()
 
 	tenants := make([]string, 0, len(l.metas))
 	for tenant := range l.metas {
@@ -56,8 +56,8 @@ func (l *List) Metas(tenantID string) []*backend.BlockMeta {
 		return nil
 	}
 
-	l.mtx.Lock()
-	defer l.mtx.Unlock()
+	l.mtx.RLock()
+	defer l.mtx.RUnlock()
 
 	copiedBlocklist := make([]*backend.BlockMeta, 0, len(l.metas[tenantID]))
 	copiedBlocklist = append(copiedBlocklist, l.metas[tenantID]...)
@@ -69,8 +69,8 @@ func (l *List) CompactedMetas(tenantID string) []*backend.CompactedBlockMeta {
 		return nil
 	}
 
-	l.mtx.Lock()
-	defer l.mtx.Unlock()
+	l.mtx.RLock()
+	defer l.mtx.RUnlock()
 
 	copiedBlocklist := make([]*backend.CompactedBlockMeta, 0, len(l.compactedMetas[tenantID]))
 	copiedBlocklist = append(copiedBlocklist, l.compactedMetas[tenantID]...)


### PR DESCRIPTION
**What this PR does**:

`Metas`, `CompactedMetas`, and `Tenants` are read-only — they copy the slice under the lock and return. Holding an exclusive write lock for these prevented concurrent callers (e.g. poller and compactor goroutines) from reading the blocklist in parallel.

Change `mtx sync.Mutex` to `mtx sync.RWMutex` and use `RLock/RUnlock` in the three read-only methods. `ApplyPollResults` and `Update` retain the exclusive write lock since they mutate `metas` and `compactedMetas`.

Correctness is verified by running the existing test suite under `-race`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`