### PR TITLE
[blocklist]: precompute tenantIndexBuilder job prefixes in NewPoller

### DIFF
--- a/.chloggen/7143_blocklist_poller_prefix_precompute.yaml
+++ b/.chloggen/7143_blocklist_poller_prefix_precompute.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: storage
+note: precompute tenant-index job prefixes in the blocklist poller's `NewPoller`, hoisting the per-builder `strconv.Itoa` and prefix concatenation out of the per-tenant ownership check that runs on every poll cycle.
+issues: [7143]
+subtext:
+user: zalegrala

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -119,20 +119,27 @@ type Poller struct {
 
 	cfg *PollerConfig
 
-	sharder JobSharder
-	logger  log.Logger
+	sharder             JobSharder
+	logger              log.Logger
+	tenantIndexPrefixes []string // precomputed: ["build-tenant-index-0-", ...]
 }
 
 // NewPoller creates the Poller
 func NewPoller(cfg *PollerConfig, sharder JobSharder, reader backend.Reader, compactor backend.Compactor, writer backend.Writer, logger log.Logger) *Poller {
+	prefixes := make([]string, cfg.TenantIndexBuilders)
+	for i := range cfg.TenantIndexBuilders {
+		prefixes[i] = jobPrefix + strconv.Itoa(i) + "-"
+	}
+
 	return &Poller{
 		reader:    reader,
 		compactor: compactor,
 		writer:    writer,
 
-		cfg:     cfg,
-		sharder: sharder,
-		logger:  logger,
+		cfg:                 cfg,
+		sharder:             sharder,
+		logger:              logger,
+		tenantIndexPrefixes: prefixes,
 	}
 }
 
@@ -515,9 +522,8 @@ func (p *Poller) pollBlock(
 
 // tenantIndexBuilder returns true if this poller owns this tenant
 func (p *Poller) tenantIndexBuilder(tenant string) bool {
-	for i := 0; i < p.cfg.TenantIndexBuilders; i++ {
-		job := jobPrefix + strconv.Itoa(i) + "-" + tenant
-		if p.sharder.Owns(job) {
+	for _, prefix := range p.tenantIndexPrefixes {
+		if p.sharder.Owns(prefix + tenant) {
 			return true
 		}
 	}


### PR DESCRIPTION
**What this PR does**:

Precomputes the blocklist poller's per-tenant ownership-check job-prefix strings in `NewPoller` instead of rebuilding them on every call.

`tenantIndexBuilder` runs on every poll cycle (`blocklist_poll`, default 5m), for every tenant, on every poller-enabled component — querier, query-frontend, and backend-worker in our fleet. This includes replicas that never own the build: the ownership check runs first regardless, before falling through to the cheap `TenantIndex` pull path. For each call it looped `TenantIndexBuilders` times rebuilding `jobPrefix + strconv.Itoa(i) + "-" + tenant`, redoing the `strconv.Itoa(i)` and static prefix concatenation even though neither changes after construction.

Precompute `["build-tenant-index-0-", ...]` once in `NewPoller` and store it as `[]string` on the `Poller`. The inner loop becomes `prefix + tenant`. `TenantIndexBuilders` is start-time storage config (`blocklist_poll_tenant_index_builders`), not a per-tenant override, and the poller is constructed once — so the precomputed slice can never go stale.

**Why**: this loop isn't a one-time startup cost — it's permanent and recurring: tenants × poller replicas × poll cycles, indefinitely, across the whole fleet. Moving fixed index-to-string formatting out of that loop and into one-time construction is both more readable and removes real (if small) recurring work from a hot path that never stops running.

**Performance**: microbenchmark shows ~39 → ~32 ns/op per call at our default of 1 builder (~18%). Allocations are unchanged (Go folds the concat into a single `concatstrings` call; `Itoa` of small ints doesn't allocate). The relative gain grows with builder count, though we don't run above 1 today.

In absolute terms this is invisible in production: validated on a znet deployment of this branch, `tenantIndexBuilder` doesn't appear as a distinct symbol in CPU profiles on any poller-enabled component, including backend-worker while actively building tenant indexes (the entire `pollTenantAndCreateIndex` call path was <0.5% of an already-small total CPU footprint). Expected — per-tenant backend I/O dominates by orders of magnitude. The value here is eliminating needless recurring work on a permanent hot loop, not a measurable throughput or latency win.

**Which issue(s) this PR fixes**:
N/A — internal cleanup.

**Checklist**
- [x] Tests updated — no behavior change; covered by existing `TestTenantIndexBuilder` (job strings are byte-identical to the previous construction).
- [ ] Documentation added
- [x] `CHANGELOG.md` updated — added `.chloggen/7143_blocklist_poller_prefix_precompute.yaml` (Tempo now manages the changelog via chloggen).
