### PR TITLE
Add configurable no-auth tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 # v3.0.2
 * [FEATURE] Make individual AST transformations skippable via config and query hints [#7012](https://github.com/grafana/tempo/pull/7012) (@stoewer)
 * [ENHANCEMENT] Add `TempoDistributorKafkaProduceFailing` alert that triggers when Kafka records cannot be produced by the distributor. [#7148](https://github.com/grafana/tempo/pull/7148) (@javiermolinar)
-* [ENHANCEMENT] config: add `no_auth_tenant` to configure the tenant ID used when multitenancy is disabled. [#7104](https://github.com/grafana/tempo/issues/7104) (@officialasishkumar)
+* [ENHANCEMENT] config: add `no_auth_tenant` to configure the tenant ID used when multitenancy is disabled. [#7145](https://github.com/grafana/tempo/pull/7145) (@officialasishkumar)
 * [ENHANCEMENT] **BREAKING CHANGE** Query-frontend: new job sharding approach for trace lookups, using a new config option `blocks_per_shard` which replaces `query_shards`. [#7105](https://github.com/grafana/tempo/pull/7105) (@mdisibio)
 * [ENHANCEMENT] jsonnet: add `autoscaling_prometheus_url` and `autoscaling_prometheus_tenant` top-level config fields for KEDA autoscaling. Setting `autoscaling_prometheus_tenant` sends an `X-Scope-OrgID` header on all Prometheus trigger requests, which is required when the backend is a multi-tenant system such as Grafana Mimir. [#7099](https://github.com/grafana/tempo/pull/7099) (@zachfi)
 * [BUGFIX] live-store: Fix panic in legacy tag-based search against vParquet5 blocks when matching attributes stored in integer dedicated columns (for example `/api/search?http.status_code=500`). [#7135](https://github.com/grafana/tempo/pull/7135) (@mdisibio)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 <!-- next version -->
 
 # v3.0.2
+* [FEATURE] Make individual AST transformations skippable via config and query hints [#7012](https://github.com/grafana/tempo/pull/7012) (@stoewer)
+* [ENHANCEMENT] Add `TempoDistributorKafkaProduceFailing` alert that triggers when Kafka records cannot be produced by the distributor. [#7148](https://github.com/grafana/tempo/pull/7148) (@javiermolinar)
+* [ENHANCEMENT] config: add `no_auth_tenant` to configure the tenant ID used when multitenancy is disabled. [#7104](https://github.com/grafana/tempo/issues/7104) (@officialasishkumar)
+* [ENHANCEMENT] **BREAKING CHANGE** Query-frontend: new job sharding approach for trace lookups, using a new config option `blocks_per_shard` which replaces `query_shards`. [#7105](https://github.com/grafana/tempo/pull/7105) (@mdisibio)
+* [ENHANCEMENT] jsonnet: add `autoscaling_prometheus_url` and `autoscaling_prometheus_tenant` top-level config fields for KEDA autoscaling. Setting `autoscaling_prometheus_tenant` sends an `X-Scope-OrgID` header on all Prometheus trigger requests, which is required when the backend is a multi-tenant system such as Grafana Mimir. [#7099](https://github.com/grafana/tempo/pull/7099) (@zachfi)
+* [BUGFIX] live-store: Fix panic in legacy tag-based search against vParquet5 blocks when matching attributes stored in integer dedicated columns (for example `/api/search?http.status_code=500`). [#7135](https://github.com/grafana/tempo/pull/7135) (@mdisibio)
+* [BUGFIX] backend-scheduler: fix redaction batch not cleaned up after dead-job timeout, leaving tenant permanently blocked from new redaction submissions and compaction. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
+* [BUGFIX] backend-scheduler: fix outstanding-blocks metric suppressed to zero during active redaction batch, causing autoscaler to scale down workers mid-redaction. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
+* [BUGFIX] backend-scheduler: fix O(N) lock contention in GetJobForWorker under concurrent worker load; replace shard scan with O(1) index lookup. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
+* [BUGFIX] livestore: recover from panics in `iterateBlocks` per-block paths so a panic in vparquet/parquetquery (e.g. malformed `ByteArray` values) returns an error instead of crashing the process. [#7134](https://github.com/grafana/tempo/pull/7134) (@zhxiaogg)
+* [BUGFIX] user-configurable overrides: emit duration fields as flat YAML scalars on `/status/overrides/{tenant}` and omit `generate_native_histograms` when unset. [#7138](https://github.com/grafana/tempo/pull/7138) (@electron0zero)
 
 * [CHANGE] Upgrade Tempo to Go 1.26.3 [#7423](https://github.com/grafana/tempo/pull/7423) (@ie-pham)
 

--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -160,7 +160,7 @@ func (t *App) setupAuthMiddleware() {
 		noAuthTenant := t.cfg.NoAuthTenantID()
 		t.cfg.Generator.Storage.NoAuthTenant = noAuthTenant
 		t.cfg.Server.GRPCMiddleware = []grpc.UnaryServerInterceptor{
-			fakeGRPCAuthUniaryMiddleware(noAuthTenant),
+			fakeGRPCAuthUnaryMiddleware(noAuthTenant),
 		}
 		t.cfg.Server.GRPCStreamMiddleware = []grpc.StreamServerInterceptor{
 			fakeGRPCAuthStreamMiddleware(noAuthTenant),

--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -157,14 +157,16 @@ func (t *App) setupAuthMiddleware() {
 		t.HTTPAuthMiddleware = middleware.AuthenticateUser
 		t.TracesConsumerMiddleware = receiver.MultiTenancyMiddleware()
 	} else {
+		noAuthTenant := t.cfg.NoAuthTenantID()
+		t.cfg.Generator.Storage.NoAuthTenant = noAuthTenant
 		t.cfg.Server.GRPCMiddleware = []grpc.UnaryServerInterceptor{
-			fakeGRPCAuthUniaryMiddleware,
+			fakeGRPCAuthUniaryMiddleware(noAuthTenant),
 		}
 		t.cfg.Server.GRPCStreamMiddleware = []grpc.StreamServerInterceptor{
-			fakeGRPCAuthStreamMiddleware,
+			fakeGRPCAuthStreamMiddleware(noAuthTenant),
 		}
-		t.HTTPAuthMiddleware = fakeHTTPAuthMiddleware
-		t.TracesConsumerMiddleware = receiver.FakeTenantMiddleware()
+		t.HTTPAuthMiddleware = fakeHTTPAuthMiddleware(noAuthTenant)
+		t.TracesConsumerMiddleware = receiver.FakeTenantMiddlewareFor(noAuthTenant)
 	}
 }
 

--- a/cmd/tempo/app/config.go
+++ b/cmd/tempo/app/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	Target                 string        `yaml:"target,omitempty"`
 	AuthEnabled            bool          `yaml:"auth_enabled,omitempty"`
 	MultitenancyEnabled    bool          `yaml:"multitenancy_enabled,omitempty"`
+	NoAuthTenant           string        `yaml:"no_auth_tenant,omitempty"`
 	ShutdownDelay          time.Duration `yaml:"shutdown_delay,omitempty"`
 	StreamOverHTTPEnabled  bool          `yaml:"stream_over_http_enabled,omitempty"`
 	HTTPAPIPrefix          string        `yaml:"http_api_prefix"`
@@ -94,6 +95,7 @@ func (c *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 	f.StringVar(&c.Target, "target", SingleBinary, "target module")
 	f.BoolVar(&c.AuthEnabled, "auth.enabled", false, "Set to true to enable auth (deprecated: use multitenancy.enabled)")
 	f.BoolVar(&c.MultitenancyEnabled, "multitenancy.enabled", false, "Set to true to enable multitenancy.")
+	f.StringVar(&c.NoAuthTenant, "auth.no-auth-tenant", util.FakeTenantID, "Tenant ID to use when multitenancy is disabled.")
 	f.StringVar(&c.HTTPAPIPrefix, "http-api-prefix", "", "String prefix for all http api endpoints.")
 	f.BoolVar(&c.EnableGoRuntimeMetrics, "enable-go-runtime-metrics", false, "Set to true to enable all Go runtime metrics")
 	f.DurationVar(&c.ShutdownDelay, "shutdown-delay", 0, "How long to wait between SIGTERM and shutdown. After receiving SIGTERM, Tempo will report not-ready status via /ready endpoint.")
@@ -162,6 +164,14 @@ func (c *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 // MultitenancyIsEnabled checks if multitenancy is enabled
 func (c *Config) MultitenancyIsEnabled() bool {
 	return c.MultitenancyEnabled || c.AuthEnabled
+}
+
+// NoAuthTenantID returns the tenant ID to inject when multitenancy is disabled.
+func (c *Config) NoAuthTenantID() string {
+	if c.NoAuthTenant == "" {
+		return util.FakeTenantID
+	}
+	return c.NoAuthTenant
 }
 
 // CheckConfig checks if config values are suspect and returns a bundled list of warnings and explanation.

--- a/cmd/tempo/app/fake_auth.go
+++ b/cmd/tempo/app/fake_auth.go
@@ -6,28 +6,33 @@ import (
 
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/user"
-	"github.com/grafana/tempo/pkg/util"
 	"google.golang.org/grpc"
 )
 
-var fakeHTTPAuthMiddleware = middleware.Func(func(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := user.InjectOrgID(r.Context(), util.FakeTenantID)
-		next.ServeHTTP(w, r.WithContext(ctx))
+func fakeHTTPAuthMiddleware(tenantID string) middleware.Interface {
+	return middleware.Func(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := user.InjectOrgID(r.Context(), tenantID)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
 	})
-})
-
-var fakeGRPCAuthUniaryMiddleware = func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-	ctx = user.InjectOrgID(ctx, util.FakeTenantID)
-	return handler(ctx, req)
 }
 
-var fakeGRPCAuthStreamMiddleware = func(srv interface{}, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-	ctx := user.InjectOrgID(ss.Context(), util.FakeTenantID)
-	return handler(srv, serverStream{
-		ctx:          ctx,
-		ServerStream: ss,
-	})
+func fakeGRPCAuthUniaryMiddleware(tenantID string) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		ctx = user.InjectOrgID(ctx, tenantID)
+		return handler(ctx, req)
+	}
+}
+
+func fakeGRPCAuthStreamMiddleware(tenantID string) grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		ctx := user.InjectOrgID(ss.Context(), tenantID)
+		return handler(srv, serverStream{
+			ctx:          ctx,
+			ServerStream: ss,
+		})
+	}
 }
 
 type serverStream struct {

--- a/cmd/tempo/app/fake_auth.go
+++ b/cmd/tempo/app/fake_auth.go
@@ -18,7 +18,7 @@ func fakeHTTPAuthMiddleware(tenantID string) middleware.Interface {
 	})
 }
 
-func fakeGRPCAuthUniaryMiddleware(tenantID string) grpc.UnaryServerInterceptor {
+func fakeGRPCAuthUnaryMiddleware(tenantID string) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		ctx = user.InjectOrgID(ctx, tenantID)
 		return handler(ctx, req)

--- a/cmd/tempo/app/fake_auth_test.go
+++ b/cmd/tempo/app/fake_auth_test.go
@@ -38,7 +38,7 @@ func TestFakeHTTPAuthMiddlewareUsesConfiguredTenant(t *testing.T) {
 func TestFakeGRPCAuthUnaryMiddlewareUsesConfiguredTenant(t *testing.T) {
 	const tenantID = "custom-tenant"
 
-	_, err := fakeGRPCAuthUniaryMiddleware(tenantID)(
+	_, err := fakeGRPCAuthUnaryMiddleware(tenantID)(
 		context.Background(),
 		nil,
 		&grpc.UnaryServerInfo{},

--- a/cmd/tempo/app/fake_auth_test.go
+++ b/cmd/tempo/app/fake_auth_test.go
@@ -1,0 +1,64 @@
+package app
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/dskit/user"
+	"github.com/grafana/tempo/pkg/util"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func TestNoAuthTenantID(t *testing.T) {
+	require.Equal(t, util.FakeTenantID, (&Config{}).NoAuthTenantID())
+	require.Equal(t, "custom-tenant", (&Config{NoAuthTenant: "custom-tenant"}).NoAuthTenantID())
+	require.Equal(t, util.FakeTenantID, NewDefaultConfig().NoAuthTenantID())
+}
+
+func TestFakeHTTPAuthMiddlewareUsesConfiguredTenant(t *testing.T) {
+	const tenantID = "custom-tenant"
+
+	handler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		orgID, err := user.ExtractOrgID(r.Context())
+		require.NoError(t, err)
+		require.Equal(t, tenantID, orgID)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	resp := httptest.NewRecorder()
+
+	fakeHTTPAuthMiddleware(tenantID).Wrap(handler).ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+}
+
+func TestFakeGRPCAuthUnaryMiddlewareUsesConfiguredTenant(t *testing.T) {
+	const tenantID = "custom-tenant"
+
+	_, err := fakeGRPCAuthUniaryMiddleware(tenantID)(
+		context.Background(),
+		nil,
+		&grpc.UnaryServerInfo{},
+		func(ctx context.Context, _ interface{}) (interface{}, error) {
+			orgID, err := user.ExtractOrgID(ctx)
+			require.NoError(t, err)
+			require.Equal(t, tenantID, orgID)
+			return nil, nil
+		},
+	)
+
+	require.NoError(t, err)
+}
+
+func TestSetupAuthMiddlewareConfiguresGeneratorNoAuthTenant(t *testing.T) {
+	cfg := NewDefaultConfig()
+	cfg.NoAuthTenant = "custom-tenant"
+
+	app := &App{cfg: *cfg}
+	app.setupAuthMiddleware()
+
+	require.Equal(t, "custom-tenant", app.cfg.Generator.Storage.NoAuthTenant)
+}

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -128,11 +128,14 @@ For the complete mapping of all configuration blocks to deployment modes, refer 
 Tempo uses the server from `dskit/server`. For the full list of available server options, refer to the [dskit server configuration](https://github.com/grafana/dskit/blob/main/server/server.go#L66) and the [manifest](/docs/tempo/<TEMPO_VERSION>/configuration/manifest/).
 For details on how server settings apply across deployment modes, refer to the [Deployment modes](/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/deployment-modes/) documentation.
 
-Additional root-level options such as `target`, `shutdown_delay`, `auth_enabled`, `enable_go_runtime_metrics`, and `span_profiling` are available as [command-line flags](/docs/tempo/<TEMPO_VERSION>/set-up-for-tracing/setup-tempo/command-line-flags/).
+Additional root-level options such as `target`, `shutdown_delay`, `auth_enabled`, `no_auth_tenant`, `enable_go_runtime_metrics`, and `span_profiling` are available as [command-line flags](/docs/tempo/<TEMPO_VERSION>/set-up-for-tracing/setup-tempo/command-line-flags/).
 
 ```yaml
 # Optional. Setting to true enables multitenancy and requires X-Scope-OrgID header on all requests.
 [multitenancy_enabled: <bool> | default = false]
+
+# Optional. Tenant ID to use when multitenancy is disabled.
+[no_auth_tenant: <string> | default = single-tenant]
 
 # Optional. String prefix for all http api endpoints. Must include beginning slash.
 [http_api_prefix: <string>]

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -16,7 +16,6 @@ and other [configuration documentation](../). Most installations will require on
 
 ```yaml
 target: all
-no_auth_tenant: single-tenant
 http_api_prefix: ""
 memory:
     automemlimit_enabled: false

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -16,6 +16,7 @@ and other [configuration documentation](../). Most installations will require on
 
 ```yaml
 target: all
+no_auth_tenant: single-tenant
 http_api_prefix: ""
 memory:
     automemlimit_enabled: false

--- a/docs/sources/tempo/operations/manage-advanced-systems/multitenancy.md
+++ b/docs/sources/tempo/operations/manage-advanced-systems/multitenancy.md
@@ -90,6 +90,9 @@ otelcol.exporter.otlphttp "tempo" {
 
    This option forces all Tempo components to require the `X-Scope-OrgID` header.
 
+   When multi-tenancy is disabled, Tempo uses `single-tenant` as the tenant ID by default.
+   Set `no_auth_tenant` or `--auth.no-auth-tenant` to choose a different tenant ID for no-auth deployments.
+
 ## Configure per-tenant settings
 
 After you enable multi-tenancy, you can customize settings on a per-tenant basis using runtime overrides.

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/command-line-flags.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/command-line-flags.md
@@ -58,6 +58,7 @@ Refer to the [Plan your Tempo deployment](../plan/) documentation for informatio
 | --- | --- | --- |
 | `--multitenancy.enabled` | Set to true to enable multitenancy | `false` |
 | `--auth.enabled` | **Deprecated. Use `--multitenancy.enabled` instead.** Set to true to enable auth. This flag will be removed in a future release. | `false` |
+| `--auth.no-auth-tenant` | Tenant ID to use when multitenancy is disabled. | `single-tenant` |
 
 ## HTTP and API settings
 
@@ -196,4 +197,3 @@ Run a health check against a custom URL:
 ```bash
 tempo --health --health.url=http://localhost:3200/ready
 ```
-

--- a/modules/distributor/receiver/middleware.go
+++ b/modules/distributor/receiver/middleware.go
@@ -32,15 +32,26 @@ func (tc MiddlewareFunc) Wrap(next consumer.Traces) consumer.Traces {
 	return tc(next)
 }
 
-type fakeTenantMiddleware struct{}
-
 func FakeTenantMiddleware() Middleware {
-	return &fakeTenantMiddleware{}
+	return FakeTenantMiddlewareFor(util.FakeTenantID)
+}
+
+func FakeTenantMiddlewareFor(tenantID string) Middleware {
+	if tenantID == "" {
+		tenantID = util.FakeTenantID
+	}
+	return &fakeTenantMiddleware{
+		tenantID: tenantID,
+	}
+}
+
+type fakeTenantMiddleware struct {
+	tenantID string
 }
 
 func (m *fakeTenantMiddleware) Wrap(next consumer.Traces) consumer.Traces {
 	return ConsumeTracesFunc(func(ctx context.Context, td ptrace.Traces) error {
-		ctx = user.InjectOrgID(ctx, util.FakeTenantID)
+		ctx = user.InjectOrgID(ctx, m.tenantID)
 		return next.ConsumeTraces(ctx, td)
 	})
 }

--- a/modules/distributor/receiver/middleware_test.go
+++ b/modules/distributor/receiver/middleware_test.go
@@ -50,6 +50,20 @@ func TestFakeTenantMiddleware(t *testing.T) {
 		ctx := context.Background()
 		require.NoError(t, m.Wrap(consumer).ConsumeTraces(ctx, ptrace.Traces{}))
 	})
+
+	t.Run("injects configured org id", func(t *testing.T) {
+		tenantID := "custom-tenant"
+		m := FakeTenantMiddlewareFor(tenantID)
+
+		consumer := newAssertingConsumer(t, func(t *testing.T, ctx context.Context) {
+			orgID, err := user.ExtractOrgID(ctx)
+			require.NoError(t, err)
+			require.Equal(t, tenantID, orgID)
+		})
+
+		ctx := context.Background()
+		require.NoError(t, m.Wrap(consumer).ConsumeTraces(ctx, ptrace.Traces{}))
+	})
 }
 
 func TestMultiTenancyMiddleware(t *testing.T) {

--- a/modules/generator/storage/config.go
+++ b/modules/generator/storage/config.go
@@ -23,6 +23,9 @@ type Config struct {
 	// Add X-Scope-OrgID header in remote write requests
 	RemoteWriteAddOrgIDHeader bool `yaml:"remote_write_add_org_id_header,omitempty"`
 
+	// NoAuthTenant is the tenant ID used when multitenancy is disabled.
+	NoAuthTenant string `yaml:"-"`
+
 	// Prometheus remote write config
 	// https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
 	RemoteWrite []prometheus_config.RemoteWriteConfig `yaml:"remote_write,omitempty"`

--- a/modules/generator/storage/config_util.go
+++ b/modules/generator/storage/config_util.go
@@ -12,7 +12,11 @@ import (
 
 // generateTenantRemoteWriteConfigs creates a copy of the remote write configurations with the
 // X-Scope-OrgID header present for the given tenant, unless Tempo is run in single tenant mode or instructed not to add X-Scope-OrgID header.
-func generateTenantRemoteWriteConfigs(inputs []prometheus_config.RemoteWriteConfig, tenant string, headers map[string]string, addOrgIDHeader bool, logger *slog.Logger, sendNativeHistograms bool) []*prometheus_config.RemoteWriteConfig {
+func generateTenantRemoteWriteConfigs(inputs []prometheus_config.RemoteWriteConfig, tenant string, noAuthTenant string, headers map[string]string, addOrgIDHeader bool, logger *slog.Logger, sendNativeHistograms bool) []*prometheus_config.RemoteWriteConfig {
+	if noAuthTenant == "" {
+		noAuthTenant = util.FakeTenantID
+	}
+
 	var outputs []*prometheus_config.RemoteWriteConfig
 
 	for _, input := range inputs {
@@ -28,7 +32,7 @@ func generateTenantRemoteWriteConfigs(inputs []prometheus_config.RemoteWriteConf
 		}
 
 		// Inject X-Scope-OrgID header in multi-tenant setups if not set already
-		if tenant != util.FakeTenantID && addOrgIDHeader {
+		if tenant != noAuthTenant && addOrgIDHeader {
 			existing := ""
 			for k, v := range output.Headers {
 				if strings.EqualFold(user.OrgIDHeaderName, strings.TrimSpace(k)) {

--- a/modules/generator/storage/config_util_test.go
+++ b/modules/generator/storage/config_util_test.go
@@ -36,7 +36,7 @@ func Test_generateTenantRemoteWriteConfigs(t *testing.T) {
 
 	addOrgIDHeader := true
 
-	result := generateTenantRemoteWriteConfigs(original, "my-tenant", nil, addOrgIDHeader, logger, false)
+	result := generateTenantRemoteWriteConfigs(original, "my-tenant", "", nil, addOrgIDHeader, logger, false)
 
 	// First case doesn't have a header, gets set.
 	assert.Equal(t, original[0].URL, result[0].URL)
@@ -68,7 +68,7 @@ func Test_generateTenantRemoteWriteConfigs_singleTenant(t *testing.T) {
 
 	addOrgIDHeader := true
 
-	result := generateTenantRemoteWriteConfigs(original, util.FakeTenantID, nil, addOrgIDHeader, logger, false)
+	result := generateTenantRemoteWriteConfigs(original, util.FakeTenantID, "", nil, addOrgIDHeader, logger, false)
 
 	assert.Equal(t, original[0].URL, result[0].URL)
 
@@ -81,6 +81,9 @@ func Test_generateTenantRemoteWriteConfigs_singleTenant(t *testing.T) {
 	assert.Equal(t, map[string]string{"x-scope-orgid": "my-custom-tenant-id"}, original[1].Headers, "Original headers have been modified")
 	// X-Scope-OrgID has not been modified
 	assert.Equal(t, map[string]string{"x-scope-orgid": "my-custom-tenant-id"}, result[1].Headers)
+
+	result = generateTenantRemoteWriteConfigs(original, "anonymous", "anonymous", nil, addOrgIDHeader, logger, false)
+	assert.Equal(t, map[string]string{}, result[0].Headers)
 }
 
 func Test_generateTenantRemoteWriteConfigs_addOrgIDHeader(t *testing.T) {
@@ -102,7 +105,7 @@ func Test_generateTenantRemoteWriteConfigs_addOrgIDHeader(t *testing.T) {
 
 	addOrgIDHeader := false
 
-	result := generateTenantRemoteWriteConfigs(original, "my-tenant", nil, addOrgIDHeader, logger, false)
+	result := generateTenantRemoteWriteConfigs(original, "my-tenant", "", nil, addOrgIDHeader, logger, false)
 
 	assert.Equal(t, original[0].URL, result[0].URL)
 	assert.Empty(t, original[0].Headers, "X-Scope-OrgID header is not added")
@@ -121,10 +124,10 @@ func Test_generateTenantRemoteWriteConfigs_sendNativeHistograms(t *testing.T) {
 		},
 	}
 
-	result := generateTenantRemoteWriteConfigs(original, "my-tenant", nil, false, logger, true)
+	result := generateTenantRemoteWriteConfigs(original, "my-tenant", "", nil, false, logger, true)
 	assert.Equal(t, true, result[0].SendNativeHistograms, "SendNativeHistograms should be true")
 
-	result = generateTenantRemoteWriteConfigs(original, "my-tenant", nil, false, logger, false)
+	result = generateTenantRemoteWriteConfigs(original, "my-tenant", "", nil, false, logger, false)
 	assert.Equal(t, false, result[0].SendNativeHistograms, "SendNativeHistograms should be true")
 }
 
@@ -171,7 +174,7 @@ func Test_generateTenantRemoteWriteConfigs_writeRelabelConfigs(t *testing.T) {
 	// Validate once at startup, as the generator does in Config.Validate().
 	require.NoError(t, cfg.Validate())
 
-	result := generateTenantRemoteWriteConfigs(cfg.RemoteWrite, "my-tenant", nil, false, logger, false)
+	result := generateTenantRemoteWriteConfigs(cfg.RemoteWrite, "my-tenant", "", nil, false, logger, false)
 
 	// Simulate what the Prometheus remote write queue manager does: run the
 	// relabel configs against a label set. Before the fix this panics with

--- a/modules/generator/storage/instance.go
+++ b/modules/generator/storage/instance.go
@@ -102,7 +102,7 @@ func New(cfg *Config, o Overrides, tenant string, reg prometheus.Registerer, _ l
 	sendNativeHistograms := overrides.HasNativeHistograms(generateNativeHistograms)
 
 	remoteStorageConfig := &prometheus_config.Config{
-		RemoteWriteConfigs: generateTenantRemoteWriteConfigs(cfg.RemoteWrite, tenant, headers, cfg.RemoteWriteAddOrgIDHeader, logger, sendNativeHistograms),
+		RemoteWriteConfigs: generateTenantRemoteWriteConfigs(cfg.RemoteWrite, tenant, cfg.NoAuthTenant, headers, cfg.RemoteWriteAddOrgIDHeader, logger, sendNativeHistograms),
 	}
 
 	err = remoteStorage.ApplyConfig(remoteStorageConfig)
@@ -169,7 +169,7 @@ func (s *storageImpl) watchOverrides() {
 			if !headersEqual(s.currentHeaders, newHeaders) || s.sendNativeHistograms != newSendNativeHistograms {
 				s.logger.Info("updating remote write configuration")
 				err := s.remote.ApplyConfig(&prometheus_config.Config{
-					RemoteWriteConfigs: generateTenantRemoteWriteConfigs(s.cfg.RemoteWrite, s.tenantID, newHeaders, s.cfg.RemoteWriteAddOrgIDHeader, s.logger, newSendNativeHistograms),
+					RemoteWriteConfigs: generateTenantRemoteWriteConfigs(s.cfg.RemoteWrite, s.tenantID, s.cfg.NoAuthTenant, newHeaders, s.cfg.RemoteWriteAddOrgIDHeader, s.logger, newSendNativeHistograms),
 				})
 				if err != nil {
 					metricStorageRemoteWriteUpdateFailed.WithLabelValues(s.tenantID).Inc()


### PR DESCRIPTION
**What this PR does**:
Adds a root-level `no_auth_tenant` config option and `--auth.no-auth-tenant` flag, defaulting to the existing `single-tenant` value. When multitenancy is disabled, Tempo now injects the configured tenant through fake HTTP/gRPC auth and receiver middleware.

The metrics-generator remote-write setup also treats the configured no-auth tenant as the single-tenant value, so changing the no-auth tenant does not unintentionally add `X-Scope-OrgID` to single-tenant remote-write requests.

**Which issue(s) this PR fixes**:
Fixes #7104

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
