### PR TITLE
Add service graph latency histogram toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [FEATURE] Make individual AST transformations skippable via config and query hints [#7012](https://github.com/grafana/tempo/pull/7012) (@stoewer)
 * [ENHANCEMENT] Add `TempoDistributorKafkaProduceFailing` alert that triggers when Kafka records cannot be produced by the distributor. [#7148](https://github.com/grafana/tempo/pull/7148) (@javiermolinar)
+* [ENHANCEMENT] metrics-generator: add service graph options to disable client and server latency histograms independently. [#3464](https://github.com/grafana/tempo/issues/3464) (@officialasishkumar)
 * [ENHANCEMENT] **BREAKING CHANGE** Query-frontend: new job sharding approach for trace lookups, using a new config option `blocks_per_shard` which replaces `query_shards`. [#7105](https://github.com/grafana/tempo/pull/7105) (@mdisibio)
 * [ENHANCEMENT] jsonnet: add `autoscaling_prometheus_url` and `autoscaling_prometheus_tenant` top-level config fields for KEDA autoscaling. Setting `autoscaling_prometheus_tenant` sends an `X-Scope-OrgID` header on all Prometheus trigger requests, which is required when the backend is a multi-tenant system such as Grafana Mimir. [#7099](https://github.com/grafana/tempo/pull/7099) (@zachfi)
 * [BUGFIX] live-store: Fix panic in legacy tag-based search against vParquet5 blocks when matching attributes stored in integer dedicated columns (for example `/api/search?http.status_code=500`). [#7135](https://github.com/grafana/tempo/pull/7135) (@mdisibio)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * [FEATURE] Make individual AST transformations skippable via config and query hints [#7012](https://github.com/grafana/tempo/pull/7012) (@stoewer)
 * [ENHANCEMENT] Add `TempoDistributorKafkaProduceFailing` alert that triggers when Kafka records cannot be produced by the distributor. [#7148](https://github.com/grafana/tempo/pull/7148) (@javiermolinar)
-* [ENHANCEMENT] metrics-generator: add service graph options to disable client and server latency histograms independently. [#3464](https://github.com/grafana/tempo/issues/3464) (@officialasishkumar)
+* [ENHANCEMENT] metrics-generator: add service graph options to disable client and server latency histograms independently. [#7146](https://github.com/grafana/tempo/pull/7146) (@officialasishkumar)
 * [ENHANCEMENT] **BREAKING CHANGE** Query-frontend: new job sharding approach for trace lookups, using a new config option `blocks_per_shard` which replaces `query_shards`. [#7105](https://github.com/grafana/tempo/pull/7105) (@mdisibio)
 * [ENHANCEMENT] jsonnet: add `autoscaling_prometheus_url` and `autoscaling_prometheus_tenant` top-level config fields for KEDA autoscaling. Setting `autoscaling_prometheus_tenant` sends an `X-Scope-OrgID` header on all Prometheus trigger requests, which is required when the backend is a multi-tenant system such as Grafana Mimir. [#7099](https://github.com/grafana/tempo/pull/7099) (@zachfi)
 * [BUGFIX] live-store: Fix panic in legacy tag-based search against vParquet5 blocks when matching attributes stored in integer dedicated columns (for example `/api/search?http.status_code=500`). [#7135](https://github.com/grafana/tempo/pull/7135) (@mdisibio)

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -698,6 +698,12 @@ metrics_generator:
             # per additional dimension instead of one.
             [enable_client_server_prefix: <bool> | default = false]
 
+            # If enabled, the client latency histogram will be produced.
+            [enable_client_latency_histogram: <bool> | default = true]
+
+            # If enabled, the server latency histogram will be produced.
+            [enable_server_latency_histogram: <bool> | default = true]
+
             # If enabled another histogram will be produced for interactions over messaging systems middlewares
             # If this feature is relevant over long time ranges (high latencies) - consider increasing
             # `wait` value for this processor.
@@ -2393,6 +2399,8 @@ overrides:
           [dimensions: <list of string>]
           [peer_attributes: <list of string>]
           [enable_client_server_prefix: <bool>]
+          [enable_client_latency_histogram: <bool>]
+          [enable_server_latency_histogram: <bool>]
           [enable_messaging_system_latency_histogram: <bool>]
           [enable_virtual_node_label: <bool>]
           [span_multiplier_key: <string>]

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -422,6 +422,8 @@ metrics_generator:
                 - 12.8
             dimensions: []
             enable_client_server_prefix: false
+            enable_client_latency_histogram: true
+            enable_server_latency_histogram: true
             enable_messaging_system_latency_histogram: false
             peer_attributes:
                 - peer.service

--- a/docs/sources/tempo/metrics-from-traces/service_graphs/_index.md
+++ b/docs/sources/tempo/metrics-from-traces/service_graphs/_index.md
@@ -87,6 +87,7 @@ The following metrics are exported:
 <!-- vale Grafana.Spelling = YES -->
 
 The processor measures duration from both the client and server sides.
+You can disable the client or server latency histogram independently with `enable_client_latency_histogram` and `enable_server_latency_histogram`.
 
 Possible values for `connection_type`: unset, `virtual_node`, `messaging_system`, or `database`.
 

--- a/modules/generator/AGENTS.md
+++ b/modules/generator/AGENTS.md
@@ -65,6 +65,8 @@ metrics_generator:
     service_graphs:
       # Service-graphs specific options
       enable_client_server_prefix: false
+      enable_client_latency_histogram: true
+      enable_server_latency_histogram: true
       enable_messaging_system_latency_histogram: false
       peer_attributes: []
       

--- a/modules/generator/config.go
+++ b/modules/generator/config.go
@@ -232,6 +232,14 @@ func (cfg *ProcessorConfig) copyWithOverrides(o metricsGeneratorOverrides, userI
 		copyCfg.ServiceGraphs.EnableClientServerPrefix = enableClientServerPrefix
 	}
 
+	if enableClientLatencyHistogram, ok := o.MetricsGeneratorProcessorServiceGraphsEnableClientLatencyHistogram(userID); ok {
+		copyCfg.ServiceGraphs.EnableClientLatencyHistogram = enableClientLatencyHistogram
+	}
+
+	if enableServerLatencyHistogram, ok := o.MetricsGeneratorProcessorServiceGraphsEnableServerLatencyHistogram(userID); ok {
+		copyCfg.ServiceGraphs.EnableServerLatencyHistogram = enableServerLatencyHistogram
+	}
+
 	if enableMessagingSystemLatencyHistogram, ok := o.MetricsGeneratorProcessorServiceGraphsEnableMessagingSystemLatencyHistogram(userID); ok {
 		copyCfg.ServiceGraphs.EnableMessagingSystemLatencyHistogram = enableMessagingSystemLatencyHistogram
 	}

--- a/modules/generator/config_test.go
+++ b/modules/generator/config_test.go
@@ -30,6 +30,8 @@ func TestProcessorConfig_copyWithOverrides(t *testing.T) {
 	t.Run("test enable service graph flags", func(t *testing.T) {
 		o := &mockOverrides{
 			serviceGraphsEnableClientServerPrefix:              true,
+			serviceGraphsEnableClientLatencyHistogram:          boolPtr(false),
+			serviceGraphsEnableServerLatencyHistogram:          boolPtr(false),
 			serviceGraphsEnableVirtualNodeLabel:                boolPtr(true),
 			serviceGraphsEnableMessagingSystemLatencyHistogram: boolPtr(true),
 		}
@@ -37,6 +39,8 @@ func TestProcessorConfig_copyWithOverrides(t *testing.T) {
 		copied, err := original.copyWithOverrides(o, "tenant")
 		require.NoError(t, err)
 		assert.Equal(t, true, copied.ServiceGraphs.EnableClientServerPrefix)
+		assert.Equal(t, false, copied.ServiceGraphs.EnableClientLatencyHistogram)
+		assert.Equal(t, false, copied.ServiceGraphs.EnableServerLatencyHistogram)
 		assert.Equal(t, true, copied.ServiceGraphs.EnableVirtualNodeLabel)
 		assert.Equal(t, true, copied.ServiceGraphs.EnableMessagingSystemLatencyHistogram)
 	})

--- a/modules/generator/overrides.go
+++ b/modules/generator/overrides.go
@@ -30,6 +30,8 @@ type metricsGeneratorOverrides interface {
 	MetricsGeneratorProcessorSpanMetricsDimensionMappings(userID string) []sharedconfig.DimensionMappings
 	MetricsGeneratorProcessorSpanMetricsEnableTargetInfo(userID string) (bool, bool)
 	MetricsGeneratorProcessorServiceGraphsEnableClientServerPrefix(userID string) bool
+	MetricsGeneratorProcessorServiceGraphsEnableClientLatencyHistogram(userID string) (bool, bool)
+	MetricsGeneratorProcessorServiceGraphsEnableServerLatencyHistogram(userID string) (bool, bool)
 	MetricsGeneratorProcessorServiceGraphsEnableMessagingSystemLatencyHistogram(userID string) (bool, bool)
 	MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel(userID string) (bool, bool)
 	MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(userID string) []string

--- a/modules/generator/overrides_test.go
+++ b/modules/generator/overrides_test.go
@@ -19,6 +19,8 @@ type mockOverrides struct {
 	serviceGraphsPeerAttributes                        []string
 	serviceGraphsFilterPolicies                        []filterconfig.FilterPolicy
 	serviceGraphsEnableClientServerPrefix              bool
+	serviceGraphsEnableClientLatencyHistogram          *bool
+	serviceGraphsEnableServerLatencyHistogram          *bool
 	serviceGraphsEnableMessagingSystemLatencyHistogram *bool
 	serviceGraphsEnableVirtualNodeLabel                *bool
 	spanMetricsHistogramBuckets                        []float64
@@ -148,6 +150,20 @@ func (m *mockOverrides) MetricsGeneratorProcessorSpanMetricsEnableTargetInfo(str
 
 func (m *mockOverrides) MetricsGeneratorProcessorServiceGraphsEnableClientServerPrefix(string) bool {
 	return m.serviceGraphsEnableClientServerPrefix
+}
+
+func (m *mockOverrides) MetricsGeneratorProcessorServiceGraphsEnableClientLatencyHistogram(string) (bool, bool) {
+	if m.serviceGraphsEnableClientLatencyHistogram != nil {
+		return *m.serviceGraphsEnableClientLatencyHistogram, true
+	}
+	return false, false
+}
+
+func (m *mockOverrides) MetricsGeneratorProcessorServiceGraphsEnableServerLatencyHistogram(string) (bool, bool) {
+	if m.serviceGraphsEnableServerLatencyHistogram != nil {
+		return *m.serviceGraphsEnableServerLatencyHistogram, true
+	}
+	return false, false
 }
 
 func (m *mockOverrides) MetricsGeneratorProcessorServiceGraphsEnableMessagingSystemLatencyHistogram(string) (bool, bool) {

--- a/modules/generator/processor/servicegraphs/config.go
+++ b/modules/generator/processor/servicegraphs/config.go
@@ -36,6 +36,12 @@ type Config struct {
 	// per dimension.
 	EnableClientServerPrefix bool `yaml:"enable_client_server_prefix"`
 
+	// If enabled, the client latency histogram will be produced.
+	EnableClientLatencyHistogram bool `yaml:"enable_client_latency_histogram"`
+
+	// If enabled, the server latency histogram will be produced.
+	EnableServerLatencyHistogram bool `yaml:"enable_server_latency_histogram"`
+
 	// If enabled another histogram will be produced for interactions over messaging systems middlewares
 	EnableMessagingSystemLatencyHistogram bool `yaml:"enable_messaging_system_latency_histogram"`
 
@@ -74,6 +80,8 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {
 	}
 	cfg.PeerAttributes = peerAttr
 
+	cfg.EnableClientLatencyHistogram = true
+	cfg.EnableServerLatencyHistogram = true
 	cfg.EnableMessagingSystemLatencyHistogram = false
 
 	cfg.DatabaseNameAttributes = []string{

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -122,8 +122,6 @@ func New(cfg Config, tenant string, reg registry.Registry, logger log.Logger, fi
 
 		serviceGraphRequestTotal:                           reg.NewCounter(metricRequestTotal),
 		serviceGraphRequestFailedTotal:                     reg.NewCounter(metricRequestFailedTotal),
-		serviceGraphRequestServerSecondsHistogram:          reg.NewHistogram(metricRequestServerSeconds, cfg.HistogramBuckets, cfg.HistogramOverride),
-		serviceGraphRequestClientSecondsHistogram:          reg.NewHistogram(metricRequestClientSeconds, cfg.HistogramBuckets, cfg.HistogramOverride),
 		serviceGraphRequestMessagingSystemSecondsHistogram: reg.NewHistogram(metricRequestMessagingSystemSeconds, cfg.HistogramBuckets, cfg.HistogramOverride),
 		sanitizeCache: sanitizeCache,
 		filter:        filter,
@@ -136,6 +134,13 @@ func New(cfg Config, tenant string, reg registry.Registry, logger log.Logger, fi
 		metricExpiredEdges:                  metricExpiredEdges.WithLabelValues(tenant),
 		invalidUTF8Counter:                  invalidUTF8Counter,
 		logger:                              log.With(logger, "component", "service-graphs"),
+	}
+
+	if cfg.EnableServerLatencyHistogram {
+		p.serviceGraphRequestServerSecondsHistogram = reg.NewHistogram(metricRequestServerSeconds, cfg.HistogramBuckets, cfg.HistogramOverride)
+	}
+	if cfg.EnableClientLatencyHistogram {
+		p.serviceGraphRequestClientSecondsHistogram = reg.NewHistogram(metricRequestClientSeconds, cfg.HistogramBuckets, cfg.HistogramOverride)
 	}
 
 	p.store = store.NewStore(cfg.Wait, cfg.MaxItems, p.onComplete, p.onExpire, p.metricDroppedSpanSideCacheOverflows)
@@ -387,8 +392,12 @@ func (p *Processor) onComplete(e *store.Edge) {
 		p.serviceGraphRequestFailedTotal.Inc(registryLabelValues, 1*e.SpanMultiplier)
 	}
 
-	p.serviceGraphRequestServerSecondsHistogram.ObserveWithExemplar(registryLabelValues, e.ServerLatencySec, e.TraceID, e.SpanMultiplier)
-	p.serviceGraphRequestClientSecondsHistogram.ObserveWithExemplar(registryLabelValues, e.ClientLatencySec, e.TraceID, e.SpanMultiplier)
+	if p.Cfg.EnableServerLatencyHistogram {
+		p.serviceGraphRequestServerSecondsHistogram.ObserveWithExemplar(registryLabelValues, e.ServerLatencySec, e.TraceID, e.SpanMultiplier)
+	}
+	if p.Cfg.EnableClientLatencyHistogram {
+		p.serviceGraphRequestClientSecondsHistogram.ObserveWithExemplar(registryLabelValues, e.ClientLatencySec, e.TraceID, e.SpanMultiplier)
+	}
 
 	if p.Cfg.EnableMessagingSystemLatencyHistogram && e.ConnectionType == store.MessagingSystem {
 		messagingSystemLatencySec := unixNanosDiffSec(e.ClientEndTimeUnixNano, e.ServerStartTimeUnixNano)

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -186,6 +186,64 @@ func TestServiceGraphs_MessagingSystemLatencyHistogram(t *testing.T) {
 	assert.Equal(t, 1.0, testRegistry.Query(`traces_service_graph_request_messaging_system_seconds_count`, requesterToRecorderLabels))
 }
 
+func TestServiceGraphs_LatencyHistogramToggles(t *testing.T) {
+	cases := []struct {
+		name         string
+		enableClient bool
+		enableServer bool
+		wantClient   float64
+		wantServer   float64
+	}{
+		{
+			name:         "client disabled",
+			enableClient: false,
+			enableServer: true,
+			wantClient:   0,
+			wantServer:   1,
+		},
+		{
+			name:         "server disabled",
+			enableClient: true,
+			enableServer: false,
+			wantClient:   1,
+			wantServer:   0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			testRegistry := registry.NewTestRegistry()
+
+			cfg := Config{}
+			cfg.RegisterFlagsAndApplyDefaults("", nil)
+			cfg.HistogramBuckets = []float64{0.04}
+			cfg.Dimensions = []string{"beast", "god"}
+			cfg.EnableClientLatencyHistogram = tc.enableClient
+			cfg.EnableServerLatencyHistogram = tc.enableServer
+
+			p, err := New(cfg, "test", testRegistry, log.NewNopLogger(), prometheus.NewCounter(prometheus.CounterOpts{}), prometheus.NewCounter(prometheus.CounterOpts{}))
+			require.NoError(t, err)
+			defer p.Shutdown(context.Background())
+
+			request, err := loadTestData("testdata/trace-with-queue-database.json")
+			require.NoError(t, err)
+
+			p.PushSpans(context.Background(), request)
+
+			requesterToServerLabels := labels.FromMap(map[string]string{
+				"client": "mythical-requester",
+				"server": "mythical-server",
+				"beast":  "manticore",
+				"god":    "zeus",
+			})
+
+			assert.Equal(t, 1.0, testRegistry.Query(`traces_service_graph_request_total`, requesterToServerLabels))
+			assert.Equal(t, tc.wantClient, testRegistry.Query(`traces_service_graph_request_client_seconds_count`, requesterToServerLabels))
+			assert.Equal(t, tc.wantServer, testRegistry.Query(`traces_service_graph_request_server_seconds_count`, requesterToServerLabels))
+		})
+	}
+}
+
 func TestServiceGraphs_failedRequests(t *testing.T) {
 	testRegistry := registry.NewTestRegistry()
 

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -93,6 +93,8 @@ type ServiceGraphsOverrides struct {
 	PeerAttributes                        []string                    `yaml:"peer_attributes,omitempty" json:"peer_attributes,omitempty"`
 	FilterPolicies                        []filterconfig.FilterPolicy `yaml:"filter_policies,omitempty" json:"filter_policies,omitempty"`
 	EnableClientServerPrefix              *bool                       `yaml:"enable_client_server_prefix,omitempty" json:"enable_client_server_prefix,omitempty"`
+	EnableClientLatencyHistogram          *bool                       `yaml:"enable_client_latency_histogram,omitempty" json:"enable_client_latency_histogram,omitempty"`
+	EnableServerLatencyHistogram          *bool                       `yaml:"enable_server_latency_histogram,omitempty" json:"enable_server_latency_histogram,omitempty"`
 	EnableMessagingSystemLatencyHistogram *bool                       `yaml:"enable_messaging_system_latency_histogram,omitempty" json:"enable_messaging_system_latency_histogram,omitempty"`
 	EnableVirtualNodeLabel                *bool                       `yaml:"enable_virtual_node_label,omitempty" json:"enable_virtual_node_label,omitempty"`
 	SpanMultiplierKey                     string                      `yaml:"span_multiplier_key,omitempty" json:"span_multiplier_key,omitempty"`

--- a/modules/overrides/config_legacy.go
+++ b/modules/overrides/config_legacy.go
@@ -47,6 +47,8 @@ func (c *Overrides) toLegacy() LegacyOverrides {
 		MetricsGeneratorProcessorServiceGraphsPeerAttributes:                        c.MetricsGenerator.Processor.ServiceGraphs.PeerAttributes,
 		MetricsGeneratorProcessorServiceGraphsFilterPolicies:                        c.MetricsGenerator.Processor.ServiceGraphs.FilterPolicies,
 		MetricsGeneratorProcessorServiceGraphsEnableClientServerPrefix:              c.MetricsGenerator.Processor.ServiceGraphs.EnableClientServerPrefix,
+		MetricsGeneratorProcessorServiceGraphsEnableClientLatencyHistogram:          c.MetricsGenerator.Processor.ServiceGraphs.EnableClientLatencyHistogram,
+		MetricsGeneratorProcessorServiceGraphsEnableServerLatencyHistogram:          c.MetricsGenerator.Processor.ServiceGraphs.EnableServerLatencyHistogram,
 		MetricsGeneratorProcessorServiceGraphsEnableMessagingSystemLatencyHistogram: c.MetricsGenerator.Processor.ServiceGraphs.EnableMessagingSystemLatencyHistogram,
 		MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel:                c.MetricsGenerator.Processor.ServiceGraphs.EnableVirtualNodeLabel,
 		MetricsGeneratorProcessorServiceGraphsSpanMultiplierKey:                     c.MetricsGenerator.Processor.ServiceGraphs.SpanMultiplierKey,
@@ -135,6 +137,8 @@ type LegacyOverrides struct {
 	MetricsGeneratorProcessorServiceGraphsPeerAttributes                        []string                         `yaml:"metrics_generator_processor_service_graphs_peer_attributes" json:"metrics_generator_processor_service_graphs_peer_attributes"`
 	MetricsGeneratorProcessorServiceGraphsFilterPolicies                        []filterconfig.FilterPolicy      `yaml:"metrics_generator_processor_service_graphs_filter_policies" json:"metrics_generator_processor_service_graphs_filter_policies"`
 	MetricsGeneratorProcessorServiceGraphsEnableClientServerPrefix              *bool                            `yaml:"metrics_generator_processor_service_graphs_enable_client_server_prefix" json:"metrics_generator_processor_service_graphs_enable_client_server_prefix"`
+	MetricsGeneratorProcessorServiceGraphsEnableClientLatencyHistogram          *bool                            `yaml:"metrics_generator_processor_service_graphs_enable_client_latency_histogram" json:"metrics_generator_processor_service_graphs_enable_client_latency_histogram"`
+	MetricsGeneratorProcessorServiceGraphsEnableServerLatencyHistogram          *bool                            `yaml:"metrics_generator_processor_service_graphs_enable_server_latency_histogram" json:"metrics_generator_processor_service_graphs_enable_server_latency_histogram"`
 	MetricsGeneratorProcessorServiceGraphsEnableMessagingSystemLatencyHistogram *bool                            `yaml:"metrics_generator_processor_service_graphs_enable_messaging_system_latency_histogram" json:"metrics_generator_processor_service_graphs_enable_messaging_system_latency_histogram"`
 	MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel                *bool                            `yaml:"metrics_generator_processor_service_graphs_enable_virtual_node_label" json:"metrics_generator_processor_service_graphs_enable_virtual_node_label"`
 	MetricsGeneratorProcessorServiceGraphsSpanMultiplierKey                     string                           `yaml:"metrics_generator_processor_service_graphs_span_multiplier_key" json:"metrics_generator_processor_service_graphs_span_multiplier_key"`
@@ -352,6 +356,8 @@ func (l *LegacyOverrides) toNewLimits() *Overrides {
 					PeerAttributes:                        l.MetricsGeneratorProcessorServiceGraphsPeerAttributes,
 					FilterPolicies:                        l.MetricsGeneratorProcessorServiceGraphsFilterPolicies,
 					EnableClientServerPrefix:              l.MetricsGeneratorProcessorServiceGraphsEnableClientServerPrefix,
+					EnableClientLatencyHistogram:          l.MetricsGeneratorProcessorServiceGraphsEnableClientLatencyHistogram,
+					EnableServerLatencyHistogram:          l.MetricsGeneratorProcessorServiceGraphsEnableServerLatencyHistogram,
 					EnableMessagingSystemLatencyHistogram: l.MetricsGeneratorProcessorServiceGraphsEnableMessagingSystemLatencyHistogram,
 					EnableVirtualNodeLabel:                l.MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel,
 					SpanMultiplierKey:                     l.MetricsGeneratorProcessorServiceGraphsSpanMultiplierKey,

--- a/modules/overrides/config_test.go
+++ b/modules/overrides/config_test.go
@@ -125,6 +125,8 @@ metrics_generator_processor_service_graphs_histogram_buckets: [1,2]
 metrics_generator_processor_service_graphs_dimensions: ['foo']
 metrics_generator_processor_service_graphs_peer_attributes: ['foo']
 metrics_generator_processor_service_graphs_enable_client_server_prefix: false
+metrics_generator_processor_service_graphs_enable_client_latency_histogram: false
+metrics_generator_processor_service_graphs_enable_server_latency_histogram: true
 metrics_generator_processor_service_graphs_enable_messaging_system_latency_histogram: false
 metrics_generator_processor_span_metrics_histogram_buckets: [3,4]
 metrics_generator_processor_span_metrics_dimensions: ['foo']
@@ -205,6 +207,8 @@ defaults:
         peer_attributes:
         - foo
         enable_client_server_prefix: false
+        enable_client_latency_histogram: false
+        enable_server_latency_histogram: true
         enable_messaging_system_latency_histogram: false
       span_metrics:
         histogram_buckets:
@@ -419,6 +423,8 @@ func generateTestLegacyOverrides() LegacyOverrides {
 		MetricsGeneratorProcessorServiceGraphsPeerAttributes:                        []string{"attribute-1", "attribute-2"},
 		MetricsGeneratorProcessorServiceGraphsFilterPolicies:                        []filterconfig.FilterPolicy{{Exclude: &filterconfig.PolicyMatch{MatchType: "strict", Attributes: []filterconfig.MatchPolicyAttribute{{Key: "resource.service.name", Value: "my-service"}}}}},
 		MetricsGeneratorProcessorServiceGraphsEnableClientServerPrefix:              boolPtr(true),
+		MetricsGeneratorProcessorServiceGraphsEnableClientLatencyHistogram:          boolPtr(false),
+		MetricsGeneratorProcessorServiceGraphsEnableServerLatencyHistogram:          boolPtr(true),
 		MetricsGeneratorProcessorServiceGraphsEnableMessagingSystemLatencyHistogram: boolPtr(true),
 		MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel:                boolPtr(true),
 		MetricsGeneratorProcessorServiceGraphsSpanMultiplierKey:                     "custom_key",

--- a/modules/overrides/interface.go
+++ b/modules/overrides/interface.go
@@ -68,6 +68,8 @@ type Interface interface {
 	MetricsGeneratorProcessorSpanMetricsDimensionMappings(userID string) []sharedconfig.DimensionMappings
 	MetricsGeneratorProcessorSpanMetricsEnableTargetInfo(userID string) (bool, bool) // returns (enabled, isSet)
 	MetricsGeneratorProcessorServiceGraphsEnableClientServerPrefix(userID string) bool
+	MetricsGeneratorProcessorServiceGraphsEnableClientLatencyHistogram(userID string) (bool, bool)          // returns (enabled, isSet)
+	MetricsGeneratorProcessorServiceGraphsEnableServerLatencyHistogram(userID string) (bool, bool)          // returns (enabled, isSet)
 	MetricsGeneratorProcessorServiceGraphsEnableMessagingSystemLatencyHistogram(userID string) (bool, bool) // returns (enabled, isSet)
 	MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel(userID string) (bool, bool)                // returns (enabled, isSet)
 	MetricsGeneratorProcessorSpanMetricsTargetInfoExcludedDimensions(userID string) []string

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -572,6 +572,22 @@ func (o *runtimeConfigOverridesManager) MetricsGeneratorProcessorServiceGraphsEn
 	return false
 }
 
+func (o *runtimeConfigOverridesManager) MetricsGeneratorProcessorServiceGraphsEnableClientLatencyHistogram(userID string) (bool, bool) {
+	enableClientLatencyHistogram := o.getOverridesForUser(userID).MetricsGenerator.Processor.ServiceGraphs.EnableClientLatencyHistogram
+	if enableClientLatencyHistogram != nil {
+		return *enableClientLatencyHistogram, true
+	}
+	return false, false
+}
+
+func (o *runtimeConfigOverridesManager) MetricsGeneratorProcessorServiceGraphsEnableServerLatencyHistogram(userID string) (bool, bool) {
+	enableServerLatencyHistogram := o.getOverridesForUser(userID).MetricsGenerator.Processor.ServiceGraphs.EnableServerLatencyHistogram
+	if enableServerLatencyHistogram != nil {
+		return *enableServerLatencyHistogram, true
+	}
+	return false, false
+}
+
 // MetricsGeneratorProcessorServiceGraphsEnableMessagingSystemLatencyHistogram enables this metric
 func (o *runtimeConfigOverridesManager) MetricsGeneratorProcessorServiceGraphsEnableMessagingSystemLatencyHistogram(userID string) (bool, bool) {
 	enableMessagingSystemLatencyHistogram := o.getOverridesForUser(userID).MetricsGenerator.Processor.ServiceGraphs.EnableMessagingSystemLatencyHistogram

--- a/modules/overrides/user_configurable_overrides.go
+++ b/modules/overrides/user_configurable_overrides.go
@@ -317,6 +317,20 @@ func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorServiceGraph
 	return o.Interface.MetricsGeneratorProcessorServiceGraphsEnableClientServerPrefix(userID)
 }
 
+func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorServiceGraphsEnableClientLatencyHistogram(userID string) (bool, bool) {
+	if enableClientLatencyHistogram, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetServiceGraphs().GetEnableClientLatencyHistogram(); ok {
+		return enableClientLatencyHistogram, true
+	}
+	return o.Interface.MetricsGeneratorProcessorServiceGraphsEnableClientLatencyHistogram(userID)
+}
+
+func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorServiceGraphsEnableServerLatencyHistogram(userID string) (bool, bool) {
+	if enableServerLatencyHistogram, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetServiceGraphs().GetEnableServerLatencyHistogram(); ok {
+		return enableServerLatencyHistogram, true
+	}
+	return o.Interface.MetricsGeneratorProcessorServiceGraphsEnableServerLatencyHistogram(userID)
+}
+
 func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel(userID string) (bool, bool) {
 	if enableVirtualNodeLabel, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetServiceGraphs().GetEnableVirtualNodeLabel(); ok {
 		return enableVirtualNodeLabel, true

--- a/modules/overrides/userconfigurable/client/limits.go
+++ b/modules/overrides/userconfigurable/client/limits.go
@@ -158,6 +158,8 @@ func (l *LimitsMetricsGeneratorProcessor) GetHostInfo() *LimitsMetricGeneratorPr
 type LimitsMetricsGeneratorProcessorServiceGraphs struct {
 	Dimensions                            *[]string                    `yaml:"dimensions,omitempty" json:"dimensions,omitempty"`
 	EnableClientServerPrefix              *bool                        `yaml:"enable_client_server_prefix,omitempty" json:"enable_client_server_prefix,omitempty"`
+	EnableClientLatencyHistogram          *bool                        `yaml:"enable_client_latency_histogram,omitempty" json:"enable_client_latency_histogram,omitempty"`
+	EnableServerLatencyHistogram          *bool                        `yaml:"enable_server_latency_histogram,omitempty" json:"enable_server_latency_histogram,omitempty"`
 	EnableMessagingSystemLatencyHistogram *bool                        `yaml:"enable_messaging_system_latency_histogram,omitempty" json:"enable_messaging_system_latency_histogram,omitempty"`
 	EnableVirtualNodeLabel                *bool                        `yaml:"enable_virtual_node_label,omitempty" json:"enable_virtual_node_label,omitempty"`
 	PeerAttributes                        *[]string                    `yaml:"peer_attributes,omitempty" json:"peer_attributes,omitempty"`
@@ -177,6 +179,20 @@ func (l *LimitsMetricsGeneratorProcessorServiceGraphs) GetDimensions() ([]string
 func (l *LimitsMetricsGeneratorProcessorServiceGraphs) GetEnableClientServerPrefix() (bool, bool) {
 	if l != nil && l.EnableClientServerPrefix != nil {
 		return *l.EnableClientServerPrefix, true
+	}
+	return false, false
+}
+
+func (l *LimitsMetricsGeneratorProcessorServiceGraphs) GetEnableClientLatencyHistogram() (bool, bool) {
+	if l != nil && l.EnableClientLatencyHistogram != nil {
+		return *l.EnableClientLatencyHistogram, true
+	}
+	return false, false
+}
+
+func (l *LimitsMetricsGeneratorProcessorServiceGraphs) GetEnableServerLatencyHistogram() (bool, bool) {
+	if l != nil && l.EnableServerLatencyHistogram != nil {
+		return *l.EnableServerLatencyHistogram, true
 	}
 	return false, false
 }


### PR DESCRIPTION
**What this PR does**:
Adds service graph processor options to enable or disable the client and server latency histograms independently. Both histograms remain enabled by default to preserve current behavior.

The new options are available in metrics-generator config, runtime overrides, and legacy override conversion. This also updates docs, the generated manifest, and tests for disabled client/server histogram emission.

**Which issue(s) this PR fixes**:
Fixes #3464

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
