### PR TITLE
enhancement: add TempoDistributorKafkaProduceFailing alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## main / unreleased
 
 * [FEATURE] Make individual AST transformations skippable via config and query hints [#7012](https://github.com/grafana/tempo/pull/7012) (@stoewer)
-* [ENHANCEMENT] Add `TempoDistributorKafkaProduceFailing` alert that triggers when Kafka records cannot be produced by the distributor. [#TBD](https://github.com/grafana/tempo/pull/TBD) (@javiermolinar)
+* [ENHANCEMENT] Add `TempoDistributorKafkaProduceFailing` alert that triggers when Kafka records cannot be produced by the distributor. [#7148](https://github.com/grafana/tempo/pull/7148) (@javiermolinar)
 * [ENHANCEMENT] **BREAKING CHANGE** Query-frontend: new job sharding approach for trace lookups, using a new config option `blocks_per_shard` which replaces `query_shards`. [#7105](https://github.com/grafana/tempo/pull/7105) (@mdisibio)
 * [ENHANCEMENT] jsonnet: add `autoscaling_prometheus_url` and `autoscaling_prometheus_tenant` top-level config fields for KEDA autoscaling. Setting `autoscaling_prometheus_tenant` sends an `X-Scope-OrgID` header on all Prometheus trigger requests, which is required when the backend is a multi-tenant system such as Grafana Mimir. [#7099](https://github.com/grafana/tempo/pull/7099) (@zachfi)
 * [BUGFIX] live-store: Fix panic in legacy tag-based search against vParquet5 blocks when matching attributes stored in integer dedicated columns (for example `/api/search?http.status_code=500`). [#7135](https://github.com/grafana/tempo/pull/7135) (@mdisibio)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## main / unreleased
 
+* [FEATURE] Make individual AST transformations skippable via config and query hints [#7012](https://github.com/grafana/tempo/pull/7012) (@stoewer)
 * [ENHANCEMENT] Add `TempoDistributorKafkaProduceFailing` alert that triggers when Kafka records cannot be produced by the distributor. [#TBD](https://github.com/grafana/tempo/pull/TBD) (@javiermolinar)
 * [ENHANCEMENT] **BREAKING CHANGE** Query-frontend: new job sharding approach for trace lookups, using a new config option `blocks_per_shard` which replaces `query_shards`. [#7105](https://github.com/grafana/tempo/pull/7105) (@mdisibio)
 * [ENHANCEMENT] jsonnet: add `autoscaling_prometheus_url` and `autoscaling_prometheus_tenant` top-level config fields for KEDA autoscaling. Setting `autoscaling_prometheus_tenant` sends an `X-Scope-OrgID` header on all Prometheus trigger requests, which is required when the backend is a multi-tenant system such as Grafana Mimir. [#7099](https://github.com/grafana/tempo/pull/7099) (@zachfi)
-* [FEATURE] Make individual AST transformations skippable via config and query hints [#7012](https://github.com/grafana/tempo/pull/7012) (@stoewer)
 * [BUGFIX] live-store: Fix panic in legacy tag-based search against vParquet5 blocks when matching attributes stored in integer dedicated columns (for example `/api/search?http.status_code=500`). [#7135](https://github.com/grafana/tempo/pull/7135) (@mdisibio)
 * [BUGFIX] backend-scheduler: fix redaction batch not cleaned up after dead-job timeout, leaving tenant permanently blocked from new redaction submissions and compaction. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
 * [BUGFIX] backend-scheduler: fix outstanding-blocks metric suppressed to zero during active redaction batch, causing autoscaler to scale down workers mid-redaction. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [ENHANCEMENT] Add `TempoDistributorKafkaProduceFailing` alert that triggers when Kafka records cannot be produced by the distributor. [#TBD](https://github.com/grafana/tempo/pull/TBD) (@javiermolinar)
 * [ENHANCEMENT] **BREAKING CHANGE** Query-frontend: new job sharding approach for trace lookups, using a new config option `blocks_per_shard` which replaces `query_shards`. [#7105](https://github.com/grafana/tempo/pull/7105) (@mdisibio)
 * [ENHANCEMENT] jsonnet: add `autoscaling_prometheus_url` and `autoscaling_prometheus_tenant` top-level config fields for KEDA autoscaling. Setting `autoscaling_prometheus_tenant` sends an `X-Scope-OrgID` header on all Prometheus trigger requests, which is required when the backend is a multi-tenant system such as Grafana Mimir. [#7099](https://github.com/grafana/tempo/pull/7099) (@zachfi)
 * [FEATURE] Make individual AST transformations skippable via config and query hints [#7012](https://github.com/grafana/tempo/pull/7012) (@stoewer)

--- a/operations/tempo-mixin-compiled/alerts.yaml
+++ b/operations/tempo-mixin-compiled/alerts.yaml
@@ -285,6 +285,18 @@
     "for": "30m"
     "labels":
       "severity": "critical"
+  - "alert": "TempoDistributorKafkaProduceFailing"
+    "annotations":
+      "message": "{{ $value | humanizePercentage }} of distributor -> Kafka record produces are failing in {{ $labels.cluster }}/{{ $labels.namespace }}."
+      "runbook_url": "https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoDistributorKafkaProduceFailing"
+    "expr": |
+      sum by (cluster, namespace) (rate(tempo_distributor_produce_failures_total{namespace=~".*", reason!="cancelled-before-producing"}[5m]))
+      /
+      sum by (cluster, namespace) (rate(tempo_distributor_produce_records_total{namespace=~".*"}[5m]))
+      > 0.001
+    "for": "5m"
+    "labels":
+      "severity": "critical"
   - "alert": "TempoMetricsGeneratorProcessorUpdatesFailing"
     "annotations":
       "message": "Metrics-generator processor updates are failing for tenant {{ $labels.tenant }} in {{ $labels.cluster }}/{{ $labels.namespace }}."

--- a/operations/tempo-mixin/alerts.libsonnet
+++ b/operations/tempo-mixin/alerts.libsonnet
@@ -441,6 +441,37 @@
             },
           },
           {
+            // Distributors produce trace records to Kafka. If a non-trivial fraction of records fail
+            // to produce, traces are dropped on the write path. This alert is a fast leading
+            // indicator for write path issues: the request-latency / SLO burn alerts only fire once
+            // the failures cascade back to cortex-gw as gRPC errors or >2.5s requests, which can
+            // take hours when the error rate is small but sustained.
+            //
+            // The 'cancelled-before-producing' reason is excluded because it is a caller-side
+            // cancellation (upstream context done) rather than a Kafka/producer problem.
+            alert: 'TempoDistributorKafkaProduceFailing',
+            expr: |||
+              sum by (%s) (rate(tempo_distributor_produce_failures_total{namespace=~"%s", reason!="cancelled-before-producing"}[5m]))
+              /
+              sum by (%s) (rate(tempo_distributor_produce_records_total{namespace=~"%s"}[5m]))
+              > %s
+            ||| % [
+              $._config.group_by_cluster,
+              $._config.namespace,
+              $._config.group_by_cluster,
+              $._config.namespace,
+              $._config.alerts.distributor_kafka_produce_failure_ratio,
+            ],
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              message: '{{ $value | humanizePercentage }} of distributor -> Kafka record produces are failing in {{ $labels.cluster }}/{{ $labels.namespace }}.',
+              runbook_url: 'https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoDistributorKafkaProduceFailing',
+            },
+          },
+          {
             alert: 'TempoMetricsGeneratorProcessorUpdatesFailing',
             expr: |||
               sum by (cluster, namespace, tenant) (

--- a/operations/tempo-mixin/config.libsonnet
+++ b/operations/tempo-mixin/config.libsonnet
@@ -41,6 +41,10 @@
       backend_scheduler_bad_jobs_count_per_minute: 0,  // alert if there are any bad jobs
       backend_worker_call_retries_count_per_minute: 5,  // 5 retries per minute
       vulture_error_rate_threshold: 0.1,  // 10% error rate
+      // Alert when more than this fraction of distributor -> Kafka record produces fail. Set well
+      // below the typical 99.9% write SLO budget so this fires as a fast leading indicator before
+      // the SLO burn-rate alerts can detect the issue.
+      distributor_kafka_produce_failure_ratio: 0.001,  // 0.1% of records
       // Livestore partition lag thresholds in seconds
       live_store_partition_lag_warning_seconds: 200,  // 3.3 minutes
       live_store_partition_lag_critical_seconds: 1200,  // 20 minutes

--- a/operations/tempo-mixin/runbook.md
+++ b/operations/tempo-mixin/runbook.md
@@ -446,6 +446,53 @@ This alert means that the tenant's cost attribution is not working or is incorre
 - Metric/query: `sum by (tenant, reason) (increase(tempo_distributor_usage_tracker_errors_total[1h]))`
 - Log query: `{container="distributor"} |= "failed to collect usage tracker metric"`
 
+## TempoDistributorKafkaProduceFailing
+
+The distributor writes incoming trace records to Kafka before they are picked up by live-stores and
+block-builders. This alert fires when more than 0.1% of those produce attempts are failing, sustained
+for 5 minutes. Failed records are dropped on the write path, so this is a direct ingest-data-loss
+signal.
+
+This alert is intended as a **fast leading indicator**. The request-latency / write SLO burn-rate
+alerts only fire once the failures propagate back to `cortex-gw` as gRPC errors or as requests slower
+than the SLO bucket. With small-but-sustained failure rates the cortex-gw signal can take hours to
+cross the SLO burn threshold; this alert fires from the producer side in minutes.
+
+### Failure reasons
+
+The `tempo_distributor_produce_failures_total` metric carries a `reason` label set by
+`pkg/ingest/writer_client.go::produceErrReason`:
+
+- `timeout` -- `context.DeadlineExceeded` or `kgo.ErrRecordTimeout`. Kafka did not ack the record
+  before the deadline. Most common real failure mode. Look at Kafka broker / Warpstream agent health.
+- `buffer-full` -- `kgo.ErrMaxBuffered`. The Kafka client's in-memory buffer reached its byte limit.
+  The producer is unable to flush fast enough; usually a downstream Kafka slowdown.
+- `record-too-large` -- `kerr.MessageTooLarge`. A single record exceeded the topic's max message size.
+  Usually points at a misbehaving tenant sending oversized spans/batches.
+- `canceled` -- `context.Canceled`. The source comments state this should never happen; investigate
+  immediately.
+- `other` -- anything else not matched above. Inspect distributor logs for the underlying error.
+- `cancelled-before-producing` -- the caller cancelled before the record was handed to the Kafka
+  client. This is a caller-side cancellation, not a producer problem, and is **excluded** from the
+  alert expression.
+
+### How to investigate
+
+1. Break the failure rate down by reason to identify the failure mode:
+   `sum by (cluster, namespace, reason) (rate(tempo_distributor_produce_failures_total[5m]))`.
+2. Check Kafka / Warpstream agent and controlplane health (latency, error rates, restarts, OOMKills).
+3. Check distributor pod health and resource saturation -- a slow distributor can cause `timeout`
+   even when Kafka is healthy.
+4. Compare against the produce rate and write latency to confirm whether the issue is throughput
+   (broker slow) or capacity (client buffer full).
+
+### Quick checks
+- Metric/query: `sum by (cluster, namespace, reason) (rate(tempo_distributor_produce_failures_total[5m]))`
+- Metric/query: `sum by (cluster, namespace, reason) (rate(tempo_distributor_produce_failures_total[5m])) / ignoring(reason) group_left sum by (cluster, namespace) (rate(tempo_distributor_produce_records_total[5m]))`
+- Metric/query: `histogram_quantile(0.99, sum by (le) (rate(tempo_distributor_kafka_write_latency_seconds_bucket[5m])))`
+- Metric/query: `tempo_distributor_buffered_produce_bytes / tempo_distributor_buffered_produce_bytes_limit`
+- Log query: `{container="distributor"} |~ "failed to produce|kafka"`
+
 ## TempoMetricsGeneratorProcessorUpdatesFailing
 
 The metrics-generator contains processors to convert spans into metrics. They can be enabled or disabled dynamically per


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
The distributor writes incoming trace records to Kafka. When a non-trivial fraction of those produces fail (tempo_distributor_produce_failures_total), traces are dropped on the write path. This pr adds a new alert that fires when more than 0.1% of distributor -> Kafka record produces fail for 5m, excluding the 'cancelled-before-producing' reason which is a caller-side cancellation rather than a producer-side failure

