### PR TITLE
feat: add tempodb_cache_store_size_bytes histogram labelled by role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## main / unreleased
 
-* [ENHANCEMENT] tempodb: add `tempodb_cache_store_size_bytes` histogram labelled by `role` recording the size of every item written to the backend cache. [#XXXX](https://github.com/grafana/tempo/pull/XXXX) (@javiermolinar)
+* [ENHANCEMENT] tempodb: add `tempodb_cache_store_size_bytes` histogram labelled by `role` recording the size of every item written to the backend cache. [#7152](https://github.com/grafana/tempo/pull/7152) (@javiermolinar)
 * [ENHANCEMENT] **BREAKING CHANGE** Query-frontend: new job sharding approach for trace lookups, using a new config option `blocks_per_shard` which replaces `query_shards`. [#7105](https://github.com/grafana/tempo/pull/7105) (@mdisibio)
 * [ENHANCEMENT] jsonnet: add `autoscaling_prometheus_url` and `autoscaling_prometheus_tenant` top-level config fields for KEDA autoscaling. Setting `autoscaling_prometheus_tenant` sends an `X-Scope-OrgID` header on all Prometheus trigger requests, which is required when the backend is a multi-tenant system such as Grafana Mimir. [#7099](https://github.com/grafana/tempo/pull/7099) (@zachfi)
 * [FEATURE] Make individual AST transformations skippable via config and query hints [#7012](https://github.com/grafana/tempo/pull/7012) (@stoewer)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [ENHANCEMENT] tempodb: add `tempodb_cache_store_size_bytes` histogram labelled by `role` recording the size of every item written to the backend cache. [#XXXX](https://github.com/grafana/tempo/pull/XXXX) (@javiermolinar)
 * [ENHANCEMENT] **BREAKING CHANGE** Query-frontend: new job sharding approach for trace lookups, using a new config option `blocks_per_shard` which replaces `query_shards`. [#7105](https://github.com/grafana/tempo/pull/7105) (@mdisibio)
 * [ENHANCEMENT] jsonnet: add `autoscaling_prometheus_url` and `autoscaling_prometheus_tenant` top-level config fields for KEDA autoscaling. Setting `autoscaling_prometheus_tenant` sends an `X-Scope-OrgID` header on all Prometheus trigger requests, which is required when the backend is a multi-tenant system such as Grafana Mimir. [#7099](https://github.com/grafana/tempo/pull/7099) (@zachfi)
 * [FEATURE] Make individual AST transformations skippable via config and query hints [#7012](https://github.com/grafana/tempo/pull/7012) (@stoewer)

--- a/tempodb/backend/cache/cache.go
+++ b/tempodb/backend/cache/cache.go
@@ -11,12 +11,22 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/grafana/tempo/pkg/cache"
 
 	tempo_io "github.com/grafana/tempo/pkg/io"
 	"github.com/grafana/tempo/tempodb/backend"
 )
+
+// cacheStoreSizeBytes records the byte size of every item written to a tempodb backend cache, labelled by role.
+var cacheStoreSizeBytes = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: "tempodb",
+	Name:      "cache_store_size_bytes",
+	Help:      "Distribution of item sizes written to tempodb backend caches, by role.",
+	Buckets:   prometheus.ExponentialBuckets(512, 2, 15), // 512 B, 1 KiB, ..., 8 MiB
+}, []string{"role"})
 
 type BloomConfig struct {
 	CacheMinCompactionLevel uint8         `yaml:"cache_min_compaction_level"`
@@ -143,6 +153,7 @@ func (r *readerWriter) Write(ctx context.Context, name string, keypath backend.K
 	}
 
 	if cache := r.cacheFor(cacheInfo); cache != nil {
+		cacheStoreSizeBytes.WithLabelValues(string(cacheInfo.Role)).Observe(float64(len(b)))
 		cache.Store(ctx, []string{key(keypath, name)}, [][]byte{b})
 	}
 
@@ -217,6 +228,8 @@ func (r *readerWriter) cacheFor(cacheInfo *backend.CacheInfo) cache.Cache {
 }
 
 func store(ctx context.Context, cache cache.Cache, role cache.Role, key string, val []byte) {
+	cacheStoreSizeBytes.WithLabelValues(string(role)).Observe(float64(len(val)))
+
 	write := val
 	if needsCopy(role) {
 		write = make([]byte, len(val))


### PR DESCRIPTION
**What this PR does**:
Add a new metrics that records the byte size of every item written to a tempodb backend cache. This can help to undestand better how to tune Memcached slabs.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`