### PR TITLE
jsonnet: configurable block-builder autoscaling approach (rollout-operator or keda)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [FEATURE] jsonnet: Add KEDA autoscaling for live-store via Prometheus trigger on expected bytes held. Enable with `live_store.keda.enabled: true`. Configure block-builder coupling via `live_store.keda.block_builder_scaling`: `'rollout-operator'` (default, requires `rollout_operator_replica_template_access_enabled: true`) mirrors live-store zone-a replicas to block-builder; `'keda'` creates a dedicated block-builder KEDA ScaledObject using a kubernetes-workload trigger without requiring rollout-operator RBAC. [#7142](https://github.com/grafana/tempo/pull/7142) (@zachfi)
 * [FEATURE] Make individual AST transformations skippable via config and query hints [#7012](https://github.com/grafana/tempo/pull/7012) (@stoewer)
 * [ENHANCEMENT] Add `TempoDistributorKafkaProduceFailing` alert that triggers when Kafka records cannot be produced by the distributor. [#7148](https://github.com/grafana/tempo/pull/7148) (@javiermolinar)
 * [ENHANCEMENT] **BREAKING CHANGE** Query-frontend: new job sharding approach for trace lookups, using a new config option `blocks_per_shard` which replaces `query_shards`. [#7105](https://github.com/grafana/tempo/pull/7105) (@mdisibio)

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
@@ -414,24 +414,23 @@ _config+:: {
 
       // block_builder_scaling controls how block-builder replicas track live-store:
       //   'rollout-operator' (default): rollout-operator mirrors live-store zone-a replicas
-      //     to block-builder. Requires rollout_operator_replica_template_access_enabled: true.
-      //     Recommended: block-builder intentionally lags zone-a through the drain window
-      //     so in-flight data is not lost on scale-down.
+      //     directly to block-builder. Faster on both scale-up and scale-down.
+      //     Block-builder stays alive through the drain window so in-flight data is not lost.
+      //     rollout_operator_replica_template_access_enabled is set automatically.
       //   'keda': a dedicated block-builder KEDA ScaledObject uses a kubernetes-workload
-      //     trigger to count live-store zone-a pods. Does not require rollout-operator RBAC.
+      //     trigger to count live-store zone-a pods. Reaction time is bounded by KEDA's
+      //     polling cycle and stabilization windows. Does not require rollout-operator RBAC.
       // block_builder_scaling: 'rollout-operator',
     },
   },
-  // Required when live_store.keda.block_builder_scaling == 'rollout-operator' (the default):
-  rollout_operator_replica_template_access_enabled: true,
 },
 ```
 
 Tempo uses these trigger types when KEDA is enabled: CPU for distributor and metrics-generator, Prometheus for backend-worker and live-store.
 
-When live-store KEDA is enabled, block-builder replicas are coupled to live-store automatically. The default approach (`block_builder_scaling: 'rollout-operator'`) uses the rollout-operator to mirror the live-store zone-a replica count to block-builder, keeping block-builder alive through the live-store drain window so that in-flight data is not lost. This requires `rollout_operator_replica_template_access_enabled: true`.
+When live-store KEDA is enabled, block-builder replicas are coupled to live-store automatically. The default approach (`block_builder_scaling: 'rollout-operator'`) uses the rollout-operator to mirror the live-store zone-a replica count directly to block-builder. This is the faster approach on both scale-up and scale-down: block-builder reacts as soon as the ReplicaTemplate changes, which is the same signal zone-a responds to. Block-builder intentionally stays alive through the live-store drain window so that in-flight partition data is not lost before it is written to the backend. `rollout_operator_replica_template_access_enabled` is enabled automatically when this approach is active.
 
-Alternatively, set `block_builder_scaling: 'keda'` to use a dedicated KEDA ScaledObject (kubernetes-workload trigger) that counts live-store zone-a pods directly. This approach does not require the rollout-operator RBAC change, but block-builder scales concurrently with live-store without the drain-window lag. The value of `_config.block_builder.partitions_per_instance` (default: `1`) is injected into the block-builder config when live-store KEDA is active under either approach.
+Alternatively, set `block_builder_scaling: 'keda'` to use a dedicated KEDA ScaledObject (kubernetes-workload trigger) that counts live-store zone-a pods. Because KEDA must observe pod counts through its polling cycle and apply stabilization windows before acting, reaction time is longer than the rollout-operator approach — on scale-up, block-builder only reacts after new zone-a pods are running and counted; on scale-down, block-builder only reacts after zone-a pods have fully terminated. The block-builder KEDA defaults use aggressive scaling windows to minimize this delay. This approach does not require the rollout-operator RBAC change. The value of `_config.block_builder.partitions_per_instance` (default: `1`) is injected into the block-builder config when live-store KEDA is active under either approach.
 
 ### Optional: Reduce component system requirements
 

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
@@ -368,9 +368,9 @@ storage+: {
 Enabling metrics generation and remote writing them to Grafana Cloud Metrics produces extra active series that could potentially impact your billing. For more information on billing, refer to [Billing and usage](/docs/grafana-cloud/billing-and-usage/). For more information on metrics generation, refer the [Metrics-generator documentation](/docs/tempo/<TEMPO_VERSION>/metrics-from-traces/metrics-generator/).
 {{< /admonition >}}
 
-### Optional: Enable KEDA autoscaling 
+### Optional: Enable KEDA autoscaling
 
-The microservices Jsonnet library includes optional KEDA-based horizontal autoscaling for distributor, metrics-generator, backend-worker, and block-builder components. All KEDA scalers are disabled by default (`enabled: false`), and you enable each component independently under `_config.<component>.keda`.
+The microservices Jsonnet library includes optional KEDA-based horizontal autoscaling for distributor, metrics-generator, backend-worker, and live-store components. All KEDA scalers are disabled by default (`enabled: false`), and you enable each component independently under `_config.<component>.keda`.
 
 Before you enable this option, make sure your cluster has the KEDA operator and CRDs installed.
 
@@ -404,19 +404,34 @@ _config+:: {
       threshold: 200,
     },
   },
-  block_builder+: {
+  live_store+: {
     keda: {
       enabled: true,
       min_replicas: 1,
       max_replicas: 200,
-      partitions_per_instance: 1,
-      pod_selector: 'name=live-store-zone-a',
+      // window_seconds: 1800,           // retention window; >= complete_block_timeout + query_backend_after
+      // bytes_per_replica: 16800000000, // ~16 GiB at 10 MB/s per pod over 30m
+
+      // block_builder_scaling controls how block-builder replicas track live-store:
+      //   'rollout-operator' (default): rollout-operator mirrors live-store zone-a replicas
+      //     to block-builder. Requires rollout_operator_replica_template_access_enabled: true.
+      //     Recommended: block-builder intentionally lags zone-a through the drain window
+      //     so in-flight data is not lost on scale-down.
+      //   'keda': a dedicated block-builder KEDA ScaledObject uses a kubernetes-workload
+      //     trigger to count live-store zone-a pods. Does not require rollout-operator RBAC.
+      // block_builder_scaling: 'rollout-operator',
     },
   },
+  // Required when live_store.keda.block_builder_scaling == 'rollout-operator' (the default):
+  rollout_operator_replica_template_access_enabled: true,
 },
 ```
 
-Tempo uses these trigger types when KEDA is enabled: CPU for distributor and metrics-generator, Prometheus for backend-worker, and kubernetes-workload for block-builder. When you enable block-builder autoscaling, Tempo also sets `block_builder.partitions_per_instance` from `_config.block_builder.keda.partitions_per_instance`.
+Tempo uses these trigger types when KEDA is enabled: CPU for distributor and metrics-generator, Prometheus for backend-worker and live-store.
+
+When live-store KEDA is enabled, block-builder replicas are coupled to live-store automatically. The default approach (`block_builder_scaling: 'rollout-operator'`) uses the rollout-operator to mirror the live-store zone-a replica count to block-builder, keeping block-builder alive through the live-store drain window so that in-flight data is not lost. This requires `rollout_operator_replica_template_access_enabled: true`.
+
+Alternatively, set `block_builder_scaling: 'keda'` to use a dedicated KEDA ScaledObject (kubernetes-workload trigger) that counts live-store zone-a pods directly. This approach does not require the rollout-operator RBAC change, but block-builder scales concurrently with live-store without the drain-window lag. The value of `_config.block_builder.partitions_per_instance` (default: `1`) is injected into the block-builder config when live-store KEDA is active under either approach.
 
 ### Optional: Reduce component system requirements
 

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
@@ -370,7 +370,7 @@ Enabling metrics generation and remote writing them to Grafana Cloud Metrics pro
 
 ### Optional: Enable KEDA autoscaling
 
-The microservices Jsonnet library includes optional KEDA-based horizontal autoscaling for distributor, metrics-generator, backend-worker, and live-store components. All KEDA scalers are disabled by default (`enabled: false`), and you enable each component independently under `_config.<component>.keda`.
+The microservices Jsonnet library includes optional KEDA-based horizontal autoscaling for distributor, metrics-generator, backend-worker, live-store, and block-builder components. All KEDA scalers are disabled by default (`enabled: false`), and you enable each component independently under `_config.<component>.keda`.
 
 Before you enable this option, make sure your cluster has the KEDA operator and CRDs installed.
 

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
@@ -411,16 +411,20 @@ _config+:: {
       max_replicas: 200,
       // window_seconds: 1800,           // retention window; >= complete_block_timeout + query_backend_after
       // bytes_per_replica: 16800000000, // ~16 GiB at 10 MB/s per pod over 30m
-
-      // block_builder_scaling controls how block-builder replicas track live-store:
+    },
+  },
+  block_builder+: {
+    keda+: {
+      enabled: true,
+      // scaling controls how block-builder replicas track live-store:
       //   'rollout-operator' (default): rollout-operator mirrors live-store zone-a replicas
       //     directly to block-builder. Faster on both scale-up and scale-down.
-      //     Block-builder stays alive through the drain window so in-flight data is not lost.
-      //     rollout_operator_replica_template_access_enabled is set automatically.
-      //   'keda': a dedicated block-builder KEDA ScaledObject uses a kubernetes-workload
-      //     trigger to count live-store zone-a pods. Reaction time is bounded by KEDA's
-      //     polling cycle and stabilization windows. Does not require rollout-operator RBAC.
-      // block_builder_scaling: 'rollout-operator',
+      //     Requires live_store.keda.enabled=true. rollout_operator_replica_template_access_enabled
+      //     is set automatically.
+      //   'keda': a dedicated KEDA ScaledObject uses a kubernetes-workload trigger counting
+      //     live-store zone-a pods. Works with or without live-store KEDA. Reaction time is
+      //     bounded by KEDA's polling cycle and stabilization windows.
+      // scaling: 'rollout-operator',
     },
   },
 },
@@ -428,9 +432,9 @@ _config+:: {
 
 Tempo uses these trigger types when KEDA is enabled: CPU for distributor and metrics-generator, Prometheus for backend-worker and live-store.
 
-When live-store KEDA is enabled, block-builder replicas are coupled to live-store automatically. The default approach (`block_builder_scaling: 'rollout-operator'`) uses the rollout-operator to mirror the live-store zone-a replica count directly to block-builder. This is the faster approach on both scale-up and scale-down: block-builder reacts as soon as the ReplicaTemplate changes, which is the same signal zone-a responds to. Block-builder intentionally stays alive through the live-store drain window so that in-flight partition data is not lost before it is written to the backend. `rollout_operator_replica_template_access_enabled` is enabled automatically when this approach is active.
+Block-builder autoscaling is configured independently under `_config.block_builder.keda`. The default approach (`scaling: 'rollout-operator'`) uses the rollout-operator to mirror the live-store zone-a replica count directly to block-builder. This is the faster approach on both scale-up and scale-down: block-builder reacts as soon as the ReplicaTemplate changes, which is the same signal zone-a responds to. Block-builder intentionally stays alive through the live-store drain window so that in-flight partition data is not lost before it is written to the backend. This approach requires `live_store.keda.enabled=true`; `rollout_operator_replica_template_access_enabled` is set automatically.
 
-Alternatively, set `block_builder_scaling: 'keda'` to use a dedicated KEDA ScaledObject (kubernetes-workload trigger) that counts live-store zone-a pods. Because KEDA must observe pod counts through its polling cycle and apply stabilization windows before acting, reaction time is longer than the rollout-operator approach — on scale-up, block-builder only reacts after new zone-a pods are running and counted; on scale-down, block-builder only reacts after zone-a pods have fully terminated. The block-builder KEDA defaults use aggressive scaling windows to minimize this delay. This approach does not require the rollout-operator RBAC change. The value of `_config.block_builder.partitions_per_instance` (default: `1`) is injected into the block-builder config when live-store KEDA is active under either approach.
+Alternatively, set `scaling: 'keda'` to use a dedicated KEDA ScaledObject (kubernetes-workload trigger) that counts live-store zone-a pods. This approach works with or without live-store KEDA enabled. Because KEDA must observe pod counts through its polling cycle and apply stabilization windows before acting, reaction time is longer than the rollout-operator approach — on scale-up, block-builder only reacts after new zone-a pods are running and counted; on scale-down, block-builder only reacts after zone-a pods have fully terminated. The block-builder KEDA defaults use aggressive scaling windows to minimize this delay. The value of `_config.block_builder.partitions_per_instance` (default: `1`) is injected into the block-builder config when block-builder KEDA is active under either approach.
 
 ### Optional: Reduce component system requirements
 

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
@@ -381,7 +381,7 @@ _config+:: {
   autoscaling_prometheus_url: 'http://prometheus-operated.monitoring.svc.cluster.local:9090',
   // autoscaling_prometheus_tenant: 'my-tenant',  // Required for multi-tenant backends (e.g. Grafana Mimir)
   distributor+: {
-    keda: {
+    keda+: {
       enabled: true,
       min_replicas: 2,
       max_replicas: 200,
@@ -389,7 +389,7 @@ _config+:: {
     },
   },
   metrics_generator+: {
-    keda: {
+    keda+: {
       enabled: true,
       min_replicas: 1,
       max_replicas: 200,
@@ -397,7 +397,7 @@ _config+:: {
     },
   },
   backend_worker+: {
-    keda: {
+    keda+: {
       enabled: true,
       min_replicas: 3,
       max_replicas: 200,
@@ -405,7 +405,7 @@ _config+:: {
     },
   },
   live_store+: {
-    keda: {
+    keda+: {
       enabled: true,
       min_replicas: 1,
       max_replicas: 200,

--- a/operations/jsonnet-compiled/jsonnetfile.lock.json
+++ b/operations/jsonnet-compiled/jsonnetfile.lock.json
@@ -38,8 +38,8 @@
           "subdir": "1.32"
         }
       },
-      "version": "55380470fb7979e6ce0c4316cb9c27a266caf298",
-      "sum": "L70C3SiMFOsNCuIGOxRKAzd6wUBuabAoEGrgvCyeCBc="
+      "version": "ee5c4c5ee02571eaf82f1170c60af47eee5496be",
+      "sum": "DGibNpxoMxZQ1ZilgUWk4+fh7MiPihkehtjp1CnLtQo="
     },
     {
       "source": {
@@ -58,8 +58,8 @@
           "subdir": "1.0.0"
         }
       },
-      "version": "5d16cd466d12489e6ffba5b17813a0203016e68d",
-      "sum": "ksOv5A0fQkz4fRz4KMCHloLUiD7BPwGKvUn2sHIAB7s="
+      "version": "c134bafc39a51bc92e4099b1b17e5d11eca7121b",
+      "sum": "RzEwGx69ki17S4JaodFzZqD4mNKZzL2zDGXAP3oHoO8="
     },
     {
       "source": {

--- a/operations/jsonnet-compiled/jsonnetfile.lock.json
+++ b/operations/jsonnet-compiled/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "e7a131e08a4c77ae42425dee1378f5fe87fd45f3",
+      "version": "dfcbb28e54fa00e0b821af1b38a54ce5095a9f87",
       "sum": "0y3AFX9LQSpfWTxWKSwoLgbt0Wc9nnCwhMH2szKzHv0="
     },
     {
@@ -18,7 +18,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "e7a131e08a4c77ae42425dee1378f5fe87fd45f3",
+      "version": "dfcbb28e54fa00e0b821af1b38a54ce5095a9f87",
       "sum": "zNTCDRaCqJUHjQSQRsxGR3jLrMP9tU7YNQb13dbm1bU="
     },
     {

--- a/operations/jsonnet-compiled/jsonnetfile.lock.json
+++ b/operations/jsonnet-compiled/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "7090c8d94f40e452ad906966c7de9add8c707eff",
+      "version": "e7a131e08a4c77ae42425dee1378f5fe87fd45f3",
       "sum": "0y3AFX9LQSpfWTxWKSwoLgbt0Wc9nnCwhMH2szKzHv0="
     },
     {
@@ -18,7 +18,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "7090c8d94f40e452ad906966c7de9add8c707eff",
+      "version": "e7a131e08a4c77ae42425dee1378f5fe87fd45f3",
       "sum": "zNTCDRaCqJUHjQSQRsxGR3jLrMP9tU7YNQb13dbm1bU="
     },
     {

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-block-builder.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-block-builder.yaml
@@ -15,9 +15,6 @@ spec:
     metadata:
       annotations:
         config_hash: 32561a7c801a4cc83b6f52f0f344dd19
-        grafana.com/rollout-mirror-replicas-from-resource-api-version: apps/v1
-        grafana.com/rollout-mirror-replicas-from-resource-kind: StatefulSet
-        grafana.com/rollout-mirror-replicas-from-resource-name: live-store-zone-a
       labels:
         app: block-builder
         name: block-builder

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-block-builder.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-block-builder.yaml
@@ -15,9 +15,6 @@ spec:
     metadata:
       annotations:
         config_hash: 35772ca8ace3c2f21537b08d1f875feb
-        grafana.com/rollout-mirror-replicas-from-resource-api-version: apps/v1
-        grafana.com/rollout-mirror-replicas-from-resource-kind: StatefulSet
-        grafana.com/rollout-mirror-replicas-from-resource-name: live-store-zone-a
       labels:
         app: block-builder
         name: block-builder

--- a/operations/jsonnet-compiled/vendor/github.com/jsonnet-libs/k8s-libsonnet/1.32/_custom/autoscaling.libsonnet
+++ b/operations/jsonnet-compiled/vendor/github.com/jsonnet-libs/k8s-libsonnet/1.32/_custom/autoscaling.libsonnet
@@ -5,7 +5,6 @@ local withApiVersion = {
   withApiVersion(apiversion): { apiVersion: apiversion },
 };
 
-
 local withScaleTargetRef = {
   '#withScaleTargetRef':: d.fn(help='Set spec.ScaleTargetRef to `object`', args=[d.arg(name='object', type=d.T.object)]),
   withScaleTargetRef(object):

--- a/operations/jsonnet-compiled/vendor/github.com/jsonnet-libs/k8s-libsonnet/1.32/_custom/core.libsonnet
+++ b/operations/jsonnet-compiled/vendor/github.com/jsonnet-libs/k8s-libsonnet/1.32/_custom/core.libsonnet
@@ -39,7 +39,8 @@ local d = import 'doc-util/main.libsonnet';
             for envvar in env
           ]),
 
-        '#withEnvMap': d.fn(|||
+        '#withEnvMap': d.fn(
+          |||
 
             `withEnvMap` works like `withEnvMixin` but accepts a key/value map,
             this map is converted a list of core.v1.envVar(key, value)`.
@@ -234,19 +235,19 @@ local d = import 'doc-util/main.libsonnet';
         ]),
         fromSecret(name, secretName)::
           super.withName(name) + super.secret.withSecretName(secretName),
-        
+
         '#fromCsi': d.fn('Creates a new volume of type `csi`', [
           d.arg('name', d.T.string),
           d.arg('driver', d.T.string),
           d.arg('volumeAttributes', d.T.object, {}),
         ]),
         fromCsi(name, driver, volumeAttributes={})::
-          super.withName(name) + { 
+          super.withName(name) + {
             csi: {
               driver: driver,
               readOnly: true,
-              volumeAttributes: volumeAttributes
-            }
+              volumeAttributes: volumeAttributes,
+            },
           },
       },
 

--- a/operations/jsonnet-compiled/vendor/github.com/jsonnet-libs/vertical-pod-autoscaler-libsonnet/1.0.0/_custom/autoscaling.libsonnet
+++ b/operations/jsonnet-compiled/vendor/github.com/jsonnet-libs/vertical-pod-autoscaler-libsonnet/1.0.0/_custom/autoscaling.libsonnet
@@ -23,35 +23,35 @@ local patch = {
     ),
 
     '#withContainerName': d.fn(
-        'The name of the container that the policy applies to. If not specified, the policy serves as the default policy.',
-        [d.arg('name', d.T.string)]
+      'The name of the container that the policy applies to. If not specified, the policy serves as the default policy.',
+      [d.arg('name', d.T.string)]
     ),
     withContainerName(name):: {
-        containerName: name,
+      containerName: name,
     },
 
     '#withControlledResources': d.fn(
-        'Specifies the type of recommendations that will be computed (and possibly applied) by VPA. If not specified, the default of [ResourceCPU, ResourceMemory] will be used.',
-        [d.arg('resources', d.T.array)]
+      'Specifies the type of recommendations that will be computed (and possibly applied) by VPA. If not specified, the default of [ResourceCPU, ResourceMemory] will be used.',
+      [d.arg('resources', d.T.array)]
     ),
     withControlledResources(resources):: {
-        controlledResources: std.uniq(std.sort(resources)),
+      controlledResources: std.uniq(std.sort(resources)),
     },
 
     '#withControlledResourcesMixin': d.fn(
-        'withControlledResourcesMixin is like withControlledResources, but appends to the existing list',
-        [d.arg('resources', d.T.array)]
+      'withControlledResourcesMixin is like withControlledResources, but appends to the existing list',
+      [d.arg('resources', d.T.array)]
     ),
     withControlledResourcesMixin(resources):: {
-        controlledResources: std.uniq(std.sort(super.resources+resources)),
+      controlledResources: std.uniq(std.sort(super.resources + resources)),
     },
 
     '#withControlledValues': d.fn(
-        'Which resource values should be controlled by VPA. Valid values are "RequestsAndLimits" and "RequestsOnly". The default is "RequestsAndLimits".',
-        [d.arg('values', d.T.string)]
+      'Which resource values should be controlled by VPA. Valid values are "RequestsAndLimits" and "RequestsOnly". The default is "RequestsAndLimits".',
+      [d.arg('values', d.T.string)]
     ),
     withControlledValues(values):: {
-        controlledValues: values,
+      controlledValues: values,
     },
 
     '#withMaxAllowed': d.fn(

--- a/operations/jsonnet/microservices/autoscaling.libsonnet
+++ b/operations/jsonnet/microservices/autoscaling.libsonnet
@@ -283,7 +283,11 @@
   // When live-store KEDA is enabled, remove spec.replicas from block-builder so
   // the chosen scaling mechanism (rollout-operator or KEDA) exclusively owns it.
   tempo_block_builder_statefulset+:
-    if $._config.live_store.keda.enabled then $.removeReplicasFromSpec else {},
+    if $._config.live_store.keda.enabled then
+      assert std.member(['rollout-operator', 'keda'], $._config.live_store.keda.block_builder_scaling) :
+             'live_store.keda.block_builder_scaling must be "rollout-operator" or "keda", got: ' + $._config.live_store.keda.block_builder_scaling;
+      $.removeReplicasFromSpec
+    else {},
 
   //
   // Block Builder: KEDA kubernetes-workload scaler counting live-store zone-a pods.

--- a/operations/jsonnet/microservices/autoscaling.libsonnet
+++ b/operations/jsonnet/microservices/autoscaling.libsonnet
@@ -122,26 +122,23 @@
         // from private config without requiring an upstream Jsonnet change.
         // Each entry is a raw KEDA trigger object passed directly to withTriggersMixin.
         additional_triggers: [],
-        // How block-builder replicas are coupled to live-store when KEDA is enabled.
-        // 'rollout-operator' (default): rollout-operator mirrors live-store zone-a
-        //   replicas to block-builder. rollout_operator_replica_template_access_enabled is
-        //   automatically set to true when this mode is active.
-        //   Block-builder lags zone-a through the drain window, preventing data loss on scale-down.
-        // 'keda': dedicated KEDA ScaledObject using a kubernetes-workload trigger counting
-        //   live-store zone-a pods. Does not require rollout_operator_replica_template_access_enabled.
-        block_builder_scaling: 'rollout-operator',
       },
     },
 
     // Number of Kafka partitions each block-builder pod is responsible for.
-    // When live-store KEDA is enabled, replicas are dynamic; this value must
+    // When block-builder KEDA is enabled, replicas are dynamic; this value must
     // stay coupled so the partition assignment math stays correct.
     // Default: 1 (each block-builder pod mirrors one live-store pod 1:1).
     block_builder+: {
       partitions_per_instance: 1,
-      // KEDA config for block-builder, used when live_store.keda.block_builder_scaling == 'keda'.
-      // Ignored when block_builder_scaling == 'rollout-operator'.
       keda: {
+        enabled: false,
+        // 'rollout-operator' (default): rollout-operator mirrors live-store zone-a replicas
+        //   directly to block-builder. Faster on both scale-up and scale-down.
+        //   Requires live_store.keda.enabled=true.
+        // 'keda': a dedicated KEDA ScaledObject uses a kubernetes-workload trigger counting
+        //   live-store zone-a pods. Works with or without live-store KEDA.
+        scaling: 'rollout-operator',
         min_replicas: 1,
         max_replicas: 200,
         paused_replicas: 0,
@@ -295,21 +292,24 @@
   tempo_backend_worker_statefulset+:
     if $._config.backend_worker.keda.enabled then $.removeReplicasFromSpec else {},
 
-  // When live-store KEDA is enabled, remove spec.replicas from block-builder so
-  // the chosen scaling mechanism (rollout-operator or KEDA) exclusively owns it.
+  // When block-builder KEDA is enabled, remove spec.replicas so the chosen scaling
+  // mechanism (rollout-operator or KEDA ScaledObject) exclusively owns the replica count.
   tempo_block_builder_statefulset+:
-    if $._config.live_store.keda.enabled then
-      assert std.member(['rollout-operator', 'keda'], $._config.live_store.keda.block_builder_scaling) :
-             'live_store.keda.block_builder_scaling must be "rollout-operator" or "keda", got: ' + $._config.live_store.keda.block_builder_scaling;
+    if $._config.block_builder.keda.enabled then
+      assert std.member(['rollout-operator', 'keda'], $._config.block_builder.keda.scaling) :
+             'block_builder.keda.scaling must be "rollout-operator" or "keda", got: ' + $._config.block_builder.keda.scaling;
+      assert $._config.block_builder.keda.scaling != 'rollout-operator' || $._config.live_store.keda.enabled :
+             'block_builder.keda.scaling="rollout-operator" requires live_store.keda.enabled=true';
       $.removeReplicasFromSpec
     else {},
 
   //
   // Block Builder: KEDA kubernetes-workload scaler counting live-store zone-a pods.
-  // Used when live_store.keda.block_builder_scaling == 'keda'.
+  // Used when block_builder.keda.enabled and block_builder.keda.scaling == 'keda'.
+  // Works independently of live_store.keda.enabled.
   //
   tempo_block_builder_scaled_object:
-    if $._config.live_store.keda.enabled && $._config.live_store.keda.block_builder_scaling == 'keda' then
+    if $._config.block_builder.keda.enabled && $._config.block_builder.keda.scaling == 'keda' then
       assert $._config.block_builder.partitions_per_instance > 0 : 'block_builder.partitions_per_instance must be > 0';
       $.scaledObjectForController($.tempo_block_builder_statefulset, 'block_builder')
       + scaledObject.spec.withTriggersMixin([{
@@ -366,7 +366,7 @@
   // subresource to obtain the current replica count. The default rollout-operator role
   // grants apps/statefulsets (list/get/watch/patch) but not apps/statefulsets/scale.
   rollout_operator_role+:
-    if $._config.live_store.keda.enabled && $._config.live_store.keda.block_builder_scaling == 'rollout-operator' then
+    if $._config.block_builder.keda.enabled && $._config.block_builder.keda.scaling == 'rollout-operator' then
       local role = $.rbac.v1.role;
       local policyRule = $.rbac.v1.policyRule;
       role.withRulesMixin([

--- a/operations/jsonnet/microservices/autoscaling.libsonnet
+++ b/operations/jsonnet/microservices/autoscaling.libsonnet
@@ -102,8 +102,9 @@
         // draining pods — which have abandoned their partitions but are still up
         // for query — do not dilute the signal.
         // When empty (default) the ScaledObject uses:
-        //   sum(rate(tempo_distributor_kafka_write_bytes_total{namespace="<ns>"}[10m])) * <window_seconds>
-        // Set to a non-empty string to replace this with a fully custom query.
+        //   sum(rate(tempo_distributor_kafka_write_bytes_total{namespace="<ns>"}[<window_seconds>s])) * <window_seconds>
+        // The rate window matches window_seconds so the averaged rate and the accumulation
+        // window are always consistent. Set to a non-empty string to use a fully custom query.
         query: '',
         scale_up_stabilization_window_seconds: 60,
         scale_up_pods: 2,
@@ -123,7 +124,8 @@
         additional_triggers: [],
         // How block-builder replicas are coupled to live-store when KEDA is enabled.
         // 'rollout-operator' (default): rollout-operator mirrors live-store zone-a
-        //   replicas to block-builder. Requires rollout_operator_replica_template_access_enabled=true.
+        //   replicas to block-builder. rollout_operator_replica_template_access_enabled is
+        //   automatically set to true when this mode is active.
         //   Block-builder lags zone-a through the drain window, preventing data loss on scale-down.
         // 'keda': dedicated KEDA ScaledObject using a kubernetes-workload trigger counting
         //   live-store zone-a pods. Does not require rollout_operator_replica_template_access_enabled.
@@ -154,6 +156,13 @@
         scale_down_period_seconds: 60 * 5,
       },
     },
+
+    // Auto-derive: when the rollout-operator block-builder scaling approach is active,
+    // rollout_operator_replica_template_access_enabled must be true. Set it automatically
+    // so users only need to set live_store.keda.block_builder_scaling (one config key).
+    rollout_operator_replica_template_access_enabled:
+      super.rollout_operator_replica_template_access_enabled ||
+      (self.live_store.keda.enabled && self.live_store.keda.block_builder_scaling == 'rollout-operator'),
 
   },
 
@@ -314,12 +323,10 @@
   tempo_live_store_scaled_object:
     if $._config.live_store.keda.enabled then
       assert $._config.autoscaling_prometheus_url != '' : 'autoscaling_prometheus_url is required for live_store autoscaling';
-      assert $._config.live_store.keda.block_builder_scaling != 'rollout-operator' || $._config.rollout_operator_replica_template_access_enabled :
-             'live_store.keda with block_builder_scaling=rollout-operator requires rollout_operator_replica_template_access_enabled=true';
       local config = $._config.live_store.keda;
       local query = if config.query != '' then config.query else
         |||
-          sum(rate(tempo_distributor_kafka_write_bytes_total{namespace="%(namespace)s"}[10m])) * %(window_seconds)d
+          sum(rate(tempo_distributor_kafka_write_bytes_total{namespace="%(namespace)s"}[%(window_seconds)ds])) * %(window_seconds)d
         ||| % { namespace: $._config.namespace, window_seconds: config.window_seconds };
       $.scaledObjectForController($.tempo_live_store_replica_template, 'live_store')
       + scaledObject.spec.withTriggersMixin(

--- a/operations/jsonnet/microservices/autoscaling.libsonnet
+++ b/operations/jsonnet/microservices/autoscaling.libsonnet
@@ -121,6 +121,13 @@
         // from private config without requiring an upstream Jsonnet change.
         // Each entry is a raw KEDA trigger object passed directly to withTriggersMixin.
         additional_triggers: [],
+        // How block-builder replicas are coupled to live-store when KEDA is enabled.
+        // 'rollout-operator' (default): rollout-operator mirrors live-store zone-a
+        //   replicas to block-builder. Requires rollout_operator_replica_template_access_enabled=true.
+        //   Block-builder lags zone-a through the drain window, preventing data loss on scale-down.
+        // 'keda': dedicated KEDA ScaledObject using a kubernetes-workload trigger counting
+        //   live-store zone-a pods. Does not require rollout_operator_replica_template_access_enabled.
+        block_builder_scaling: 'rollout-operator',
       },
     },
 
@@ -130,6 +137,22 @@
     // Default: 1 (each block-builder pod mirrors one live-store pod 1:1).
     block_builder+: {
       partitions_per_instance: 1,
+      // KEDA config for block-builder, used when live_store.keda.block_builder_scaling == 'keda'.
+      // Ignored when block_builder_scaling == 'rollout-operator'.
+      keda: {
+        min_replicas: 1,
+        max_replicas: 200,
+        paused_replicas: 0,
+        // Pod selector to count live-store zone-a pods.
+        // KEDA sets block-builder replicas = ceil(matching pods / partitions_per_instance).
+        pod_selector: 'name=live-store-zone-a',
+        scale_up_stabilization_window_seconds: 60,
+        scale_up_pods: 5,
+        scale_up_period_seconds: 60,
+        scale_down_stabilization_window_seconds: 60 * 5,
+        scale_down_pods: 5,
+        scale_down_period_seconds: 60 * 5,
+      },
     },
 
   },
@@ -258,9 +281,26 @@
     if $._config.backend_worker.keda.enabled then $.removeReplicasFromSpec else {},
 
   // When live-store KEDA is enabled, remove spec.replicas from block-builder so
-  // the rollout-operator (mirroring from live-store zone-a) exclusively owns it.
+  // the chosen scaling mechanism (rollout-operator or KEDA) exclusively owns it.
   tempo_block_builder_statefulset+:
     if $._config.live_store.keda.enabled then $.removeReplicasFromSpec else {},
+
+  //
+  // Block Builder: KEDA kubernetes-workload scaler counting live-store zone-a pods.
+  // Used when live_store.keda.block_builder_scaling == 'keda'.
+  //
+  tempo_block_builder_scaled_object:
+    if $._config.live_store.keda.enabled && $._config.live_store.keda.block_builder_scaling == 'keda' then
+      assert $._config.block_builder.partitions_per_instance > 0 : 'block_builder.partitions_per_instance must be > 0';
+      $.scaledObjectForController($.tempo_block_builder_statefulset, 'block_builder')
+      + scaledObject.spec.withTriggersMixin([{
+        type: 'kubernetes-workload',
+        metadata: {
+          podSelector: $._config.block_builder.keda.pod_selector,
+          value: '%d' % $._config.block_builder.partitions_per_instance,
+        },
+      }])
+    else {},
 
   //
   // Live Store: Prometheus-based autoscaling on expected bytes held.
@@ -270,6 +310,8 @@
   tempo_live_store_scaled_object:
     if $._config.live_store.keda.enabled then
       assert $._config.autoscaling_prometheus_url != '' : 'autoscaling_prometheus_url is required for live_store autoscaling';
+      assert $._config.live_store.keda.block_builder_scaling != 'rollout-operator' || $._config.rollout_operator_replica_template_access_enabled :
+             'live_store.keda with block_builder_scaling=rollout-operator requires rollout_operator_replica_template_access_enabled=true';
       local config = $._config.live_store.keda;
       local query = if config.query != '' then config.query else
         |||

--- a/operations/jsonnet/microservices/autoscaling.libsonnet
+++ b/operations/jsonnet/microservices/autoscaling.libsonnet
@@ -349,4 +349,18 @@
   tempo_live_store_zone_b_statefulset+:
     if $._config.live_store.keda.enabled then $.removeReplicasFromSpec else {},
 
+  // The rollout-operator mirror-replicas feature reads the source StatefulSet's scale
+  // subresource to obtain the current replica count. The default rollout-operator role
+  // grants apps/statefulsets (list/get/watch/patch) but not apps/statefulsets/scale.
+  rollout_operator_role+:
+    if $._config.live_store.keda.enabled && $._config.live_store.keda.block_builder_scaling == 'rollout-operator' then
+      local role = $.rbac.v1.role;
+      local policyRule = $.rbac.v1.policyRule;
+      role.withRulesMixin([
+        policyRule.withApiGroups(['apps']) +
+        policyRule.withResources(['statefulsets/scale']) +
+        policyRule.withVerbs(['get']),
+      ])
+    else {},
+
 }

--- a/operations/jsonnet/microservices/autoscaling.libsonnet
+++ b/operations/jsonnet/microservices/autoscaling.libsonnet
@@ -78,33 +78,60 @@
       },
     },
 
-    // Block builder scales to match live-store zone-a pods via KEDA kubernetes-workload scaler.
-    // See: https://github.com/grafana/tempo/issues/6933
-    block_builder+: {
+    live_store+: {
       keda: {
         enabled: false,
         min_replicas: 1,
         max_replicas: 200,
         paused_replicas: 0,
-        // Number of partitions each block-builder pod handles.
-        // KEDA sets replicas = ceil(live-store-zone-a pods / partitions_per_instance).
-        partitions_per_instance: 1,
-        // Pod selector to count live-store zone-a pods.
-        pod_selector: 'name=live-store-zone-a',
+        // Time window (seconds) over which bytes written to Kafka are expected
+        // to be held in the live-store. Should be >= complete_block_timeout (20m
+        // default) plus any query_backend_after delay. Default: 30 minutes.
+        window_seconds: 30 * 60,
+        // Maximum bytes a single live-store pod is expected to hold over window_seconds.
+        // Expressed as ingest_rate_per_pod × window_seconds so the two knobs stay coupled:
+        //   default: 10 MB/s × 1800s ≈ 16 GiB per pod (observed production baseline)
+        // To tune for your environment, change the rate multiplier:
+        //   1 MB/s per pod  → 1 * 1000 * 1000 * self.window_seconds  (~1.7 GiB at 30m)
+        //   5 MB/s per pod  → 5 * 1000 * 1000 * self.window_seconds  (~8.4 GiB at 30m)
+        // Alternatively, set a literal byte value if you prefer to reason purely about
+        // total bytes held per pod (e.g. bytes_per_replica: 17 * 1024 * 1024 * 1024).
+        bytes_per_replica: 10 * 1000 * 1000 * self.window_seconds,
+        // Prometheus query returning total bytes expected to be held across all
+        // live-store pods. Measures the distributor (Kafka producer) side so that
+        // draining pods — which have abandoned their partitions but are still up
+        // for query — do not dilute the signal.
+        // When empty (default) the ScaledObject uses:
+        //   sum(rate(tempo_distributor_kafka_write_bytes_total{namespace="<ns>"}[10m])) * <window_seconds>
+        // Set to a non-empty string to replace this with a fully custom query.
+        query: '',
         scale_up_stabilization_window_seconds: 60,
-        scale_up_pods: 5,
+        scale_up_pods: 2,
         scale_up_period_seconds: 60,
-        scale_down_stabilization_window_seconds: 60 * 5,
-        scale_down_pods: 5,
+        // Minimum duration of sustained low load before KEDA issues a scale-down.
+        // Defaults to the live-store drain window (35m) so a load dip shorter than
+        // one full drain cycle cannot trigger a scale-down. Note: the drain itself
+        // runs after the signal, so total time from load drop to pod termination
+        // is roughly 2x this value.
+        scale_down_stabilization_window_seconds: 60 * 35,
+        scale_down_pods: 1,
         scale_down_period_seconds: 60 * 5,
+        // Extra KEDA trigger objects appended after the default Prometheus trigger.
+        // Use this to inject environment-specific triggers (e.g. Kafka lag, CPU)
+        // from private config without requiring an upstream Jsonnet change.
+        // Each entry is a raw KEDA trigger object passed directly to withTriggersMixin.
+        additional_triggers: [],
       },
     },
 
-    // Override block_builder_max_unavailable when block_builder autoscaling is enabled
-    // since the replica count is dynamic.
-    block_builder_max_unavailable:
-      if $._config.block_builder.keda.enabled then '100%'
-      else $.tempo_block_builder_statefulset.spec.replicas,
+    // Number of Kafka partitions each block-builder pod is responsible for.
+    // When live-store KEDA is enabled, replicas are dynamic; this value must
+    // stay coupled so the partition assignment math stays correct.
+    // Default: 1 (each block-builder pod mirrors one live-store pod 1:1).
+    block_builder+: {
+      partitions_per_instance: 1,
+    },
+
   },
 
   // Returns a KEDA Prometheus trigger using the shared autoscaling_prometheus_url and
@@ -230,22 +257,51 @@
   tempo_backend_worker_statefulset+:
     if $._config.backend_worker.keda.enabled then $.removeReplicasFromSpec else {},
 
+  // When live-store KEDA is enabled, remove spec.replicas from block-builder so
+  // the rollout-operator (mirroring from live-store zone-a) exclusively owns it.
+  tempo_block_builder_statefulset+:
+    if $._config.live_store.keda.enabled then $.removeReplicasFromSpec else {},
+
   //
-  // Block Builder: KEDA kubernetes-workload scaler matching live-store zone-a pod count.
+  // Live Store: Prometheus-based autoscaling on expected bytes held.
+  // Targets the ReplicaTemplate; the rollout-operator mirrors the replica count
+  // to both zone StatefulSets, which must not carry their own spec.replicas.
   //
-  tempo_block_builder_scaled_object:
-    if $._config.block_builder.keda.enabled then
-      assert $._config.block_builder.keda.partitions_per_instance > 0 : 'block_builder.keda.partitions_per_instance must be > 0';
-      $.scaledObjectForController($.tempo_block_builder_statefulset, 'block_builder')
-      + scaledObject.spec.withTriggersMixin([{
-        type: 'kubernetes-workload',
-        metadata: {
-          podSelector: $._config.block_builder.keda.pod_selector,
-          value: '%d' % $._config.block_builder.keda.partitions_per_instance,
-        },
-      }])
+  tempo_live_store_scaled_object:
+    if $._config.live_store.keda.enabled then
+      assert $._config.autoscaling_prometheus_url != '' : 'autoscaling_prometheus_url is required for live_store autoscaling';
+      local config = $._config.live_store.keda;
+      local query = if config.query != '' then config.query else
+        |||
+          sum(rate(tempo_distributor_kafka_write_bytes_total{namespace="%(namespace)s"}[10m])) * %(window_seconds)d
+        ||| % { namespace: $._config.namespace, window_seconds: config.window_seconds };
+      $.scaledObjectForController($.tempo_live_store_replica_template, 'live_store')
+      + scaledObject.spec.withTriggersMixin(
+        [
+          // metricType: Value → desiredReplicas = ceil(queryResult / threshold).
+          // The query returns total expected bytes across all pods, so we must use
+          // Value rather than the default AverageValue (which would multiply by
+          // currentReplicas and cause runaway scaling).
+          $.prometheusTrigger(
+            query=query,
+            metricName='tempo_live_store_expected_bytes',
+            threshold='%d' % config.bytes_per_replica,
+          ) + { metricType: 'Value' },
+        ] + config.additional_triggers
+      )
     else {},
 
-  tempo_block_builder_statefulset+:
-    if $._config.block_builder.keda.enabled then $.removeReplicasFromSpec else {},
+  // When KEDA manages the live-store, omit spec.replicas from the ReplicaTemplate
+  // so that KEDA exclusively owns that field and Tanka apply does not fight it.
+  tempo_live_store_replica_template+:
+    if $._config.live_store.keda.enabled then {
+      spec+: { replicas+:: null },
+    } else {},
+
+  tempo_live_store_zone_a_statefulset+:
+    if $._config.live_store.keda.enabled then $.removeReplicasFromSpec else {},
+
+  tempo_live_store_zone_b_statefulset+:
+    if $._config.live_store.keda.enabled then $.removeReplicasFromSpec else {},
+
 }

--- a/operations/jsonnet/microservices/autoscaling.libsonnet
+++ b/operations/jsonnet/microservices/autoscaling.libsonnet
@@ -148,12 +148,18 @@
         // Pod selector to count live-store zone-a pods.
         // KEDA sets block-builder replicas = ceil(matching pods / partitions_per_instance).
         pod_selector: 'name=live-store-zone-a',
-        scale_up_stabilization_window_seconds: 60,
-        scale_up_pods: 5,
-        scale_up_period_seconds: 60,
-        scale_down_stabilization_window_seconds: 60 * 5,
+        // Block-builder must scale up as fast as live-store: new live-store pods create new
+        // Kafka partitions that block-builders must immediately begin reading. Any delay on
+        // scale-up means partition backlogs accumulate. Use 0s stabilization so KEDA acts on
+        // the first observation (KEDA's ~30s polling interval is the practical floor).
+        scale_up_stabilization_window_seconds: 0,
+        scale_up_pods: 10,
+        scale_up_period_seconds: 30,
+        // Scale down quickly once live-store pods are gone: those partitions are reassigned
+        // and block-builder no longer needs capacity for them.
+        scale_down_stabilization_window_seconds: 60,
         scale_down_pods: 5,
-        scale_down_period_seconds: 60 * 5,
+        scale_down_period_seconds: 60,
       },
     },
 

--- a/operations/jsonnet/microservices/autoscaling.libsonnet
+++ b/operations/jsonnet/microservices/autoscaling.libsonnet
@@ -163,12 +163,12 @@
       },
     },
 
-    // Auto-derive: when the rollout-operator block-builder scaling approach is active,
-    // rollout_operator_replica_template_access_enabled must be true. Set it automatically
-    // so users only need to set live_store.keda.block_builder_scaling (one config key).
+    // Auto-derive: whenever live-store KEDA is enabled, rollout_operator_replica_template_access_enabled
+    // must be true — rollout-operator uses the ReplicaTemplate to sync both zone StatefulSets regardless
+    // of which block-builder scaling approach is active. The extra statefulsets/scale RBAC grant is
+    // still gated to block_builder_scaling == 'rollout-operator' (see rollout_operator_role+ below).
     rollout_operator_replica_template_access_enabled:
-      super.rollout_operator_replica_template_access_enabled ||
-      (self.live_store.keda.enabled && self.live_store.keda.block_builder_scaling == 'rollout-operator'),
+      super.rollout_operator_replica_template_access_enabled || self.live_store.keda.enabled,
 
   },
 

--- a/operations/jsonnet/microservices/autoscaling.libsonnet
+++ b/operations/jsonnet/microservices/autoscaling.libsonnet
@@ -337,12 +337,11 @@
       )
     else {},
 
-  // When KEDA manages the live-store, omit spec.replicas from the ReplicaTemplate
-  // so that KEDA exclusively owns that field and Tanka apply does not fight it.
+  // When KEDA manages the live-store, drop spec.replicas from the ReplicaTemplate and
+  // both zone StatefulSets so the ScaledObject exclusively owns the replica count and
+  // Tanka apply does not fight it.
   tempo_live_store_replica_template+:
-    if $._config.live_store.keda.enabled then {
-      spec+: { replicas+:: null },
-    } else {},
+    if $._config.live_store.keda.enabled then $.removeReplicasFromSpec else {},
 
   tempo_live_store_zone_a_statefulset+:
     if $._config.live_store.keda.enabled then $.removeReplicasFromSpec else {},

--- a/operations/jsonnet/microservices/block-builder.libsonnet
+++ b/operations/jsonnet/microservices/block-builder.libsonnet
@@ -52,7 +52,7 @@
     // The rollout-operator reads grafana.com/rollout-mirror-replicas-from-resource-* from the
     // StatefulSet's own metadata.annotations, not the pod template. Keep these separate.
     (
-      if $._config.live_store.keda.enabled && $._config.live_store.keda.block_builder_scaling == 'rollout-operator' then
+      if $._config.block_builder.keda.enabled && $._config.block_builder.keda.scaling == 'rollout-operator' then
         statefulset.mixin.metadata.withAnnotationsMixin({
           'grafana.com/rollout-mirror-replicas-from-resource-name': $.tempo_block_builder_follow_controller.metadata.name,
           'grafana.com/rollout-mirror-replicas-from-resource-kind': $.tempo_block_builder_follow_controller.kind,

--- a/operations/jsonnet/microservices/block-builder.libsonnet
+++ b/operations/jsonnet/microservices/block-builder.libsonnet
@@ -48,13 +48,17 @@
     statefulset.spec.template.spec.securityContext.withFsGroup(10001) +  // 10001 is the UID of the tempo user
     statefulset.mixin.spec.template.metadata.withAnnotations(
       { config_hash: std.md5(std.toString($.tempo_block_builder_configmap.data['tempo.yaml'])) }
-      + (
-        if $._config.live_store.keda.enabled && $._config.live_store.keda.block_builder_scaling == 'rollout-operator' then {
+    ) +
+    // The rollout-operator reads grafana.com/rollout-mirror-replicas-from-resource-* from the
+    // StatefulSet's own metadata.annotations, not the pod template. Keep these separate.
+    (
+      if $._config.live_store.keda.enabled && $._config.live_store.keda.block_builder_scaling == 'rollout-operator' then
+        statefulset.mixin.metadata.withAnnotationsMixin({
           'grafana.com/rollout-mirror-replicas-from-resource-name': $.tempo_block_builder_follow_controller.metadata.name,
           'grafana.com/rollout-mirror-replicas-from-resource-kind': $.tempo_block_builder_follow_controller.kind,
           'grafana.com/rollout-mirror-replicas-from-resource-api-version': $.tempo_block_builder_follow_controller.apiVersion,
-        } else {}
-      )
+        })
+      else {}
     ) +
     statefulset.mixin.spec.template.spec.withVolumes([
       volume.fromConfigMap(tempo_config_volume, $.tempo_block_builder_configmap.metadata.name),

--- a/operations/jsonnet/microservices/block-builder.libsonnet
+++ b/operations/jsonnet/microservices/block-builder.libsonnet
@@ -46,12 +46,16 @@
     statefulset.new(target_name, $._config.block_builder.replicas, $.tempo_block_builder_container, [], { app: target_name }) +
     statefulset.mixin.spec.withServiceName(target_name) +
     statefulset.spec.template.spec.securityContext.withFsGroup(10001) +  // 10001 is the UID of the tempo user
-    statefulset.mixin.spec.template.metadata.withAnnotations({
-      config_hash: std.md5(std.toString($.tempo_block_builder_configmap.data['tempo.yaml'])),
-      'grafana.com/rollout-mirror-replicas-from-resource-name': $.tempo_block_builder_follow_controller.metadata.name,
-      'grafana.com/rollout-mirror-replicas-from-resource-kind': $.tempo_block_builder_follow_controller.kind,
-      'grafana.com/rollout-mirror-replicas-from-resource-api-version': $.tempo_block_builder_follow_controller.apiVersion,
-    }) +
+    statefulset.mixin.spec.template.metadata.withAnnotations(
+      { config_hash: std.md5(std.toString($.tempo_block_builder_configmap.data['tempo.yaml'])) }
+      + (
+        if $._config.live_store.keda.enabled && $._config.live_store.keda.block_builder_scaling == 'rollout-operator' then {
+          'grafana.com/rollout-mirror-replicas-from-resource-name': $.tempo_block_builder_follow_controller.metadata.name,
+          'grafana.com/rollout-mirror-replicas-from-resource-kind': $.tempo_block_builder_follow_controller.kind,
+          'grafana.com/rollout-mirror-replicas-from-resource-api-version': $.tempo_block_builder_follow_controller.apiVersion,
+        } else {}
+      )
+    ) +
     statefulset.mixin.spec.template.spec.withVolumes([
       volume.fromConfigMap(tempo_config_volume, $.tempo_block_builder_configmap.metadata.name),
       volume.fromConfigMap(tempo_overrides_config_volume, $._config.overrides_configmap_name),

--- a/operations/jsonnet/microservices/block-builder.libsonnet
+++ b/operations/jsonnet/microservices/block-builder.libsonnet
@@ -23,6 +23,9 @@
     'config.file': '/conf/tempo.yaml',
   },
 
+  // Block-builder mirrors live-store zone-a replica count. This intentionally lags
+  // behind the ReplicaTemplate: the rollout-operator enforces the drain window before
+  // reducing zone-a, so block-builder stays alive while live-store data is still present.
   tempo_block_builder_follow_controller:: $.tempo_live_store_zone_a_statefulset,
 
   tempo_block_builder_container::

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -29,8 +29,8 @@
     // This feature modifies the block-builder StatefulSet which cannot be altered, so if it already exists it has to be deleted and re-applied again in order to be enabled.
     block_builder_concurrent_rollout_enabled: false,
     // Maximum number of unavailable replicas during a block-builder rollout when using block_builder_concurrent_rollout_enabled feature.
-    // Computed from block-builder replicas by default, but can also be specified as percentage, for example "25%".
-    block_builder_max_unavailable: $.tempo_block_builder_statefulset.spec.replicas,
+    // Defaults to 100% since block-builder pods are independent (each owns distinct Kafka partitions).
+    block_builder_max_unavailable: '100%',
 
     // disable tempo-query by default
     tempo_query: {

--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -89,10 +89,9 @@
 
   tempo_query_frontend_config:: $.tempo_config {},
   tempo_block_builder_config:: $.tempo_config + $.tempo_ingest_config + (
-    // Inject partitions_per_instance whenever live-store KEDA is active, regardless of
-    // which block-builder scaling approach is used, because replica count is dynamic and
-    // must match the partition assignment.
-    if $._config.live_store.keda.enabled then
+    // Inject partitions_per_instance whenever block-builder KEDA is active so that the
+    // dynamic replica count stays coupled to the partition assignment math.
+    if $._config.block_builder.keda.enabled then
       assert $._config.block_builder.partitions_per_instance > 0 : 'block_builder.partitions_per_instance must be > 0';
       {
         block_builder+: {

--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -89,11 +89,11 @@
 
   tempo_query_frontend_config:: $.tempo_config {},
   tempo_block_builder_config:: $.tempo_config + $.tempo_ingest_config + (
-    // When autoscaling is enabled, set partitions_per_instance to match the KEDA ratio
-    // so each block-builder pod consumes the correct number of partitions.
-    if $._config.block_builder.keda.enabled then {
+    // Inject partitions_per_instance when live-store KEDA is enabled because the
+    // block-builder replica count is then dynamic and must stay coupled to partition count.
+    if $._config.live_store.keda.enabled then {
       block_builder+: {
-        partitions_per_instance: $._config.block_builder.keda.partitions_per_instance,
+        partitions_per_instance: $._config.block_builder.partitions_per_instance,
       },
     } else {}
   ),

--- a/operations/jsonnet/microservices/configmap.libsonnet
+++ b/operations/jsonnet/microservices/configmap.libsonnet
@@ -89,13 +89,17 @@
 
   tempo_query_frontend_config:: $.tempo_config {},
   tempo_block_builder_config:: $.tempo_config + $.tempo_ingest_config + (
-    // Inject partitions_per_instance when live-store KEDA is enabled because the
-    // block-builder replica count is then dynamic and must stay coupled to partition count.
-    if $._config.live_store.keda.enabled then {
-      block_builder+: {
-        partitions_per_instance: $._config.block_builder.partitions_per_instance,
-      },
-    } else {}
+    // Inject partitions_per_instance whenever live-store KEDA is active, regardless of
+    // which block-builder scaling approach is used, because replica count is dynamic and
+    // must match the partition assignment.
+    if $._config.live_store.keda.enabled then
+      assert $._config.block_builder.partitions_per_instance > 0 : 'block_builder.partitions_per_instance must be > 0';
+      {
+        block_builder+: {
+          partitions_per_instance: $._config.block_builder.partitions_per_instance,
+        },
+      }
+    else {}
   ),
   tempo_live_store_config:: $.tempo_config + $.tempo_ingest_config {
     live_store: {

--- a/operations/jsonnet/microservices/tempo.libsonnet
+++ b/operations/jsonnet/microservices/tempo.libsonnet
@@ -14,8 +14,8 @@
 (import 'memberlist.libsonnet') +
 (import 'vertical-pod-autoscaler.libsonnet') +
 (import 'pod-disruption-budget.libsonnet') +
-(import 'autoscaling.libsonnet') +
 (import 'rollout-operator/rollout-operator.libsonnet') +
+(import 'autoscaling.libsonnet') +
 
 {
   local k = import 'ksonnet-util/kausal.libsonnet',

--- a/operations/jsonnet/microservices/test/test1.jsonnet
+++ b/operations/jsonnet/microservices/test/test1.jsonnet
@@ -11,12 +11,21 @@ local withBackendWorkerKeda(url, tenant='') = default {
   },
 };
 
-// Helper: default env with live_store KEDA enabled and a given Prometheus URL/tenant.
+// Helper: default env with live_store KEDA enabled (rollout-operator approach, the default).
 local withLiveStoreKeda(url, tenant='') = default {
   _config+:: {
     autoscaling_prometheus_url: url,
     autoscaling_prometheus_tenant: tenant,
+    rollout_operator_replica_template_access_enabled: true,
     live_store+: { replicas: 1, keda+: { enabled: true } },
+  },
+};
+
+// Helper: default env with live_store KEDA enabled and block-builder managed by KEDA.
+local withLiveStoreKedaBlockBuilderKeda(url) = default {
+  _config+:: {
+    autoscaling_prometheus_url: url,
+    live_store+: { replicas: 1, keda+: { enabled: true, block_builder_scaling: 'keda' } },
   },
 };
 
@@ -116,6 +125,7 @@ test.new(std.thisFile)
     (default {
        _config+:: {
          autoscaling_prometheus_url: 'http://prometheus:9090',
+         rollout_operator_replica_template_access_enabled: true,
          live_store+: {
            replicas: 1,
            keda+: {
@@ -168,5 +178,60 @@ test.new(std.thisFile)
       null
     ),
     null
+  )
+)
++ test.case.new(
+  'live_store KEDA default block_builder_scaling is rollout-operator',
+  test.expect.eq(
+    withLiveStoreKeda('http://prometheus:9090')._config.live_store.keda.block_builder_scaling,
+    'rollout-operator'
+  )
+)
++ test.case.new(
+  'live_store KEDA rollout-operator approach omits block-builder ScaledObject',
+  test.expect.eq(
+    withLiveStoreKeda('http://prometheus:9090').tempo_block_builder_scaled_object,
+    {}
+  )
+)
++ test.case.new(
+  'live_store KEDA disabled omits rollout-mirror annotations from block-builder',
+  test.expect.eq(
+    std.objectHas(
+      default.tempo_block_builder_statefulset.spec.template.metadata.annotations,
+      'grafana.com/rollout-mirror-replicas-from-resource-name'
+    ),
+    false
+  )
+)
++ test.case.new(
+  'live_store KEDA keda approach creates block-builder ScaledObject',
+  test.expect.eq(
+    withLiveStoreKedaBlockBuilderKeda('http://prometheus:9090').tempo_block_builder_scaled_object.spec.scaleTargetRef.name,
+    'block-builder'
+  )
+)
++ test.case.new(
+  'live_store KEDA keda approach block-builder ScaledObject uses kubernetes-workload trigger',
+  test.expect.eq(
+    withLiveStoreKedaBlockBuilderKeda('http://prometheus:9090').tempo_block_builder_scaled_object.spec.triggers[0].type,
+    'kubernetes-workload'
+  )
+)
++ test.case.new(
+  'live_store KEDA keda approach omits rollout-mirror annotations from block-builder',
+  test.expect.eq(
+    std.objectHas(
+      withLiveStoreKedaBlockBuilderKeda('http://prometheus:9090').tempo_block_builder_statefulset.spec.template.metadata.annotations,
+      'grafana.com/rollout-mirror-replicas-from-resource-name'
+    ),
+    false
+  )
+)
++ test.case.new(
+  'live_store KEDA keda approach uses pod_selector from block_builder.keda config',
+  test.expect.eq(
+    withLiveStoreKedaBlockBuilderKeda('http://prometheus:9090').tempo_block_builder_scaled_object.spec.triggers[0].metadata.podSelector,
+    'name=live-store-zone-a'
   )
 )

--- a/operations/jsonnet/microservices/test/test1.jsonnet
+++ b/operations/jsonnet/microservices/test/test1.jsonnet
@@ -12,11 +12,11 @@ local withBackendWorkerKeda(url, tenant='') = default {
 };
 
 // Helper: default env with live_store KEDA enabled (rollout-operator approach, the default).
+// rollout_operator_replica_template_access_enabled is auto-derived from the scaling mode.
 local withLiveStoreKeda(url, tenant='') = default {
   _config+:: {
     autoscaling_prometheus_url: url,
     autoscaling_prometheus_tenant: tenant,
-    rollout_operator_replica_template_access_enabled: true,
     live_store+: { replicas: 1, keda+: { enabled: true } },
   },
 };
@@ -110,10 +110,10 @@ test.new(std.thisFile)
   )
 )
 + test.case.new(
-  'live_store KEDA default query uses 10m rate window',
+  'live_store KEDA default query rate window matches window_seconds',
   test.expect.eq(
     std.length(std.findSubstr(
-      '[10m]',
+      '[1800s]',
       withLiveStoreKeda('http://prometheus:9090').tempo_live_store_scaled_object.spec.triggers[0].metadata.query,
     )) > 0,
     true
@@ -125,7 +125,6 @@ test.new(std.thisFile)
     (default {
        _config+:: {
          autoscaling_prometheus_url: 'http://prometheus:9090',
-         rollout_operator_replica_template_access_enabled: true,
          live_store+: {
            replicas: 1,
            keda+: {
@@ -194,6 +193,20 @@ test.new(std.thisFile)
   test.expect.eq(
     withLiveStoreKeda('http://prometheus:9090').tempo_block_builder_scaled_object,
     {}
+  )
+)
++ test.case.new(
+  'live_store KEDA rollout-operator approach auto-enables rollout_operator_replica_template_access_enabled',
+  test.expect.eq(
+    withLiveStoreKeda('http://prometheus:9090')._config.rollout_operator_replica_template_access_enabled,
+    true
+  )
+)
++ test.case.new(
+  'live_store KEDA keda approach does not auto-enable rollout_operator_replica_template_access_enabled',
+  test.expect.eq(
+    withLiveStoreKedaBlockBuilderKeda('http://prometheus:9090')._config.rollout_operator_replica_template_access_enabled,
+    false
   )
 )
 + test.case.new(

--- a/operations/jsonnet/microservices/test/test1.jsonnet
+++ b/operations/jsonnet/microservices/test/test1.jsonnet
@@ -11,6 +11,15 @@ local withBackendWorkerKeda(url, tenant='') = default {
   },
 };
 
+// Helper: default env with live_store KEDA enabled and a given Prometheus URL/tenant.
+local withLiveStoreKeda(url, tenant='') = default {
+  _config+:: {
+    autoscaling_prometheus_url: url,
+    autoscaling_prometheus_tenant: tenant,
+    live_store+: { replicas: 1, keda+: { enabled: true } },
+  },
+};
+
 test.new(std.thisFile)
 + test.case.new(
   'Basic',
@@ -41,5 +50,123 @@ test.new(std.thisFile)
       'customHeaders'
     ),
     false
+  )
+)
++ test.case.new(
+  'live_store KEDA ScaledObject targets the ReplicaTemplate',
+  test.expect.eq(
+    withLiveStoreKeda('http://prometheus:9090').tempo_live_store_scaled_object.spec.scaleTargetRef.name,
+    'live-store'
+  )
+)
++ test.case.new(
+  'live_store KEDA ScaledObject scaleTargetRef kind is ReplicaTemplate',
+  test.expect.eq(
+    withLiveStoreKeda('http://prometheus:9090').tempo_live_store_scaled_object.spec.scaleTargetRef.kind,
+    'ReplicaTemplate'
+  )
+)
++ test.case.new(
+  'live_store KEDA Prometheus trigger uses autoscaling_prometheus_url',
+  test.expect.eq(
+    withLiveStoreKeda('http://prometheus:9090').tempo_live_store_scaled_object.spec.triggers[0].metadata.serverAddress,
+    'http://prometheus:9090'
+  )
+)
++ test.case.new(
+  'live_store KEDA Prometheus trigger includes X-Scope-OrgID header when tenant is set',
+  test.expect.eq(
+    withLiveStoreKeda('http://prometheus:9090', 'my-tenant').tempo_live_store_scaled_object.spec.triggers[0].metadata.customHeaders,
+    'X-Scope-OrgID=my-tenant'
+  )
+)
++ test.case.new(
+  'live_store KEDA Prometheus trigger omits customHeaders when tenant is empty',
+  test.expect.eq(
+    std.objectHas(
+      withLiveStoreKeda('http://prometheus:9090').tempo_live_store_scaled_object.spec.triggers[0].metadata,
+      'customHeaders'
+    ),
+    false
+  )
+)
++ test.case.new(
+  'live_store KEDA query embeds window_seconds from config',
+  test.expect.eq(
+    std.length(std.findSubstr(
+      '1800',
+      withLiveStoreKeda('http://prometheus:9090').tempo_live_store_scaled_object.spec.triggers[0].metadata.query,
+    )) > 0,
+    true
+  )
+)
++ test.case.new(
+  'live_store KEDA default query uses 10m rate window',
+  test.expect.eq(
+    std.length(std.findSubstr(
+      '[10m]',
+      withLiveStoreKeda('http://prometheus:9090').tempo_live_store_scaled_object.spec.triggers[0].metadata.query,
+    )) > 0,
+    true
+  )
+)
++ test.case.new(
+  'live_store KEDA additional_triggers are appended after the default trigger',
+  test.expect.eq(
+    (default {
+       _config+:: {
+         autoscaling_prometheus_url: 'http://prometheus:9090',
+         live_store+: {
+           replicas: 1,
+           keda+: {
+             enabled: true,
+             additional_triggers: [{ type: 'cpu', metricType: 'Utilization', metadata: { value: '80' } }],
+           },
+         },
+       },
+     }).tempo_live_store_scaled_object.spec.triggers[1],
+    { type: 'cpu', metricType: 'Utilization', metadata: { value: '80' } }
+  )
+)
++ test.case.new(
+  'live_store KEDA enabled removes spec.replicas from block-builder',
+  test.expect.eq(
+    std.objectHas(
+      withLiveStoreKeda('http://prometheus:9090').tempo_block_builder_statefulset.spec,
+      'replicas'
+    ),
+    false
+  )
+)
++ test.case.new(
+  'block_builder_max_unavailable defaults to 100%',
+  test.expect.eq(
+    default._config.block_builder_max_unavailable,
+    '100%'
+  )
+)
++ test.case.new(
+  'live_store KEDA enabled block_builder follows live-store zone-a',
+  test.expect.eq(
+    withLiveStoreKeda('http://prometheus:9090').tempo_block_builder_statefulset.spec.template.metadata.annotations['grafana.com/rollout-mirror-replicas-from-resource-name'],
+    'live-store-zone-a'
+  )
+)
++ test.case.new(
+  'live_store KEDA enabled injects partitions_per_instance into block-builder config',
+  test.expect.eq(
+    withLiveStoreKeda('http://prometheus:9090').tempo_block_builder_config.block_builder.partitions_per_instance,
+    1
+  )
+)
++ test.case.new(
+  'live_store KEDA disabled does not inject partitions_per_instance into block-builder config',
+  test.expect.eq(
+    std.get(
+      std.get(default.tempo_block_builder_config, 'block_builder', {}),
+      'partitions_per_instance',
+      null
+    ),
+    null
   )
 )

--- a/operations/jsonnet/microservices/test/test1.jsonnet
+++ b/operations/jsonnet/microservices/test/test1.jsonnet
@@ -157,8 +157,10 @@ test.new(std.thisFile)
 )
 + test.case.new(
   'live_store KEDA enabled block_builder follows live-store zone-a',
+  // rollout-operator reads grafana.com/rollout-mirror-replicas-from-resource-* from StatefulSet
+  // metadata.annotations, NOT from the pod template spec.template.metadata.annotations.
   test.expect.eq(
-    withLiveStoreKeda('http://prometheus:9090').tempo_block_builder_statefulset.spec.template.metadata.annotations['grafana.com/rollout-mirror-replicas-from-resource-name'],
+    withLiveStoreKeda('http://prometheus:9090').tempo_block_builder_statefulset.metadata.annotations['grafana.com/rollout-mirror-replicas-from-resource-name'],
     'live-store-zone-a'
   )
 )
@@ -195,13 +197,23 @@ test.new(std.thisFile)
   )
 )
 + test.case.new(
-  'live_store KEDA disabled omits rollout-mirror annotations from block-builder',
+  'live_store KEDA disabled omits rollout-mirror annotations from block-builder metadata',
   test.expect.eq(
     std.objectHas(
-      default.tempo_block_builder_statefulset.spec.template.metadata.annotations,
+      std.get(default.tempo_block_builder_statefulset.metadata, 'annotations', {}),
       'grafana.com/rollout-mirror-replicas-from-resource-name'
     ),
     false
+  )
+)
++ test.case.new(
+  'live_store KEDA rollout-operator grants statefulsets/scale to rollout-operator role',
+  test.expect.eq(
+    std.filter(
+      function(r) std.member(r.resources, 'statefulsets/scale'),
+      withLiveStoreKeda('http://prometheus:9090').rollout_operator_role.rules
+    )[0].verbs,
+    ['get']
   )
 )
 + test.case.new(

--- a/operations/jsonnet/microservices/test/test1.jsonnet
+++ b/operations/jsonnet/microservices/test/test1.jsonnet
@@ -203,10 +203,10 @@ test.new(std.thisFile)
   )
 )
 + test.case.new(
-  'live_store KEDA keda approach does not auto-enable rollout_operator_replica_template_access_enabled',
+  'live_store KEDA keda approach also auto-enables rollout_operator_replica_template_access_enabled',
   test.expect.eq(
     withLiveStoreKedaBlockBuilderKeda('http://prometheus:9090')._config.rollout_operator_replica_template_access_enabled,
-    false
+    true
   )
 )
 + test.case.new(

--- a/operations/jsonnet/microservices/test/test1.jsonnet
+++ b/operations/jsonnet/microservices/test/test1.jsonnet
@@ -11,8 +11,7 @@ local withBackendWorkerKeda(url, tenant='') = default {
   },
 };
 
-// Helper: default env with live_store KEDA enabled (rollout-operator approach, the default).
-// rollout_operator_replica_template_access_enabled is auto-derived from the scaling mode.
+// Helper: live-store KEDA only (no block-builder autoscaling).
 local withLiveStoreKeda(url, tenant='') = default {
   _config+:: {
     autoscaling_prometheus_url: url,
@@ -21,11 +20,31 @@ local withLiveStoreKeda(url, tenant='') = default {
   },
 };
 
-// Helper: default env with live_store KEDA enabled and block-builder managed by KEDA.
-local withLiveStoreKedaBlockBuilderKeda(url) = default {
+// Helper: live-store + block-builder KEDA, rollout-operator approach (default).
+// Requires live_store.keda.enabled=true; rollout_operator_replica_template_access_enabled is auto-derived.
+local withBlockBuilderKedaRolloutOp(url, tenant='') = default {
   _config+:: {
     autoscaling_prometheus_url: url,
-    live_store+: { replicas: 1, keda+: { enabled: true, block_builder_scaling: 'keda' } },
+    autoscaling_prometheus_tenant: tenant,
+    live_store+: { replicas: 1, keda+: { enabled: true } },
+    block_builder+: { keda+: { enabled: true } },
+  },
+};
+
+// Helper: block-builder KEDA, keda approach (live-store KEDA also enabled here but not required).
+local withBlockBuilderKedaKeda(url) = default {
+  _config+:: {
+    autoscaling_prometheus_url: url,
+    live_store+: { replicas: 1, keda+: { enabled: true } },
+    block_builder+: { keda+: { enabled: true, scaling: 'keda' } },
+  },
+};
+
+// Helper: block-builder KEDA (keda approach) without live-store KEDA — proves decoupling.
+local withBlockBuilderKedaKedaOnly(url) = default {
+  _config+:: {
+    autoscaling_prometheus_url: url,
+    block_builder+: { keda+: { enabled: true, scaling: 'keda' } },
   },
 };
 
@@ -138,10 +157,10 @@ test.new(std.thisFile)
   )
 )
 + test.case.new(
-  'live_store KEDA enabled removes spec.replicas from block-builder',
+  'block_builder KEDA enabled removes spec.replicas from block-builder',
   test.expect.eq(
     std.objectHas(
-      withLiveStoreKeda('http://prometheus:9090').tempo_block_builder_statefulset.spec,
+      withBlockBuilderKedaRolloutOp('http://prometheus:9090').tempo_block_builder_statefulset.spec,
       'replicas'
     ),
     false
@@ -155,23 +174,23 @@ test.new(std.thisFile)
   )
 )
 + test.case.new(
-  'live_store KEDA enabled block_builder follows live-store zone-a',
+  'block_builder KEDA rollout-operator approach block_builder follows live-store zone-a',
   // rollout-operator reads grafana.com/rollout-mirror-replicas-from-resource-* from StatefulSet
   // metadata.annotations, NOT from the pod template spec.template.metadata.annotations.
   test.expect.eq(
-    withLiveStoreKeda('http://prometheus:9090').tempo_block_builder_statefulset.metadata.annotations['grafana.com/rollout-mirror-replicas-from-resource-name'],
+    withBlockBuilderKedaRolloutOp('http://prometheus:9090').tempo_block_builder_statefulset.metadata.annotations['grafana.com/rollout-mirror-replicas-from-resource-name'],
     'live-store-zone-a'
   )
 )
 + test.case.new(
-  'live_store KEDA enabled injects partitions_per_instance into block-builder config',
+  'block_builder KEDA enabled injects partitions_per_instance into block-builder config',
   test.expect.eq(
-    withLiveStoreKeda('http://prometheus:9090').tempo_block_builder_config.block_builder.partitions_per_instance,
+    withBlockBuilderKedaRolloutOp('http://prometheus:9090').tempo_block_builder_config.block_builder.partitions_per_instance,
     1
   )
 )
 + test.case.new(
-  'live_store KEDA disabled does not inject partitions_per_instance into block-builder config',
+  'block_builder KEDA disabled does not inject partitions_per_instance into block-builder config',
   test.expect.eq(
     std.get(
       std.get(default.tempo_block_builder_config, 'block_builder', {}),
@@ -182,35 +201,49 @@ test.new(std.thisFile)
   )
 )
 + test.case.new(
-  'live_store KEDA default block_builder_scaling is rollout-operator',
+  'block_builder KEDA default scaling is rollout-operator',
   test.expect.eq(
-    withLiveStoreKeda('http://prometheus:9090')._config.live_store.keda.block_builder_scaling,
+    (default { _config+:: { block_builder+: { keda+: { enabled: true } } } })._config.block_builder.keda.scaling,
     'rollout-operator'
   )
 )
 + test.case.new(
-  'live_store KEDA rollout-operator approach omits block-builder ScaledObject',
+  'block_builder KEDA rollout-operator approach omits block-builder ScaledObject',
   test.expect.eq(
-    withLiveStoreKeda('http://prometheus:9090').tempo_block_builder_scaled_object,
+    withBlockBuilderKedaRolloutOp('http://prometheus:9090').tempo_block_builder_scaled_object,
     {}
   )
 )
 + test.case.new(
-  'live_store KEDA rollout-operator approach auto-enables rollout_operator_replica_template_access_enabled',
+  'live_store KEDA auto-enables rollout_operator_replica_template_access_enabled',
   test.expect.eq(
     withLiveStoreKeda('http://prometheus:9090')._config.rollout_operator_replica_template_access_enabled,
     true
   )
 )
 + test.case.new(
-  'live_store KEDA keda approach also auto-enables rollout_operator_replica_template_access_enabled',
+  'block_builder KEDA rollout-operator approach auto-enables rollout_operator_replica_template_access_enabled',
   test.expect.eq(
-    withLiveStoreKedaBlockBuilderKeda('http://prometheus:9090')._config.rollout_operator_replica_template_access_enabled,
+    withBlockBuilderKedaRolloutOp('http://prometheus:9090')._config.rollout_operator_replica_template_access_enabled,
     true
   )
 )
 + test.case.new(
-  'live_store KEDA disabled omits rollout-mirror annotations from block-builder metadata',
+  'block_builder KEDA keda approach auto-enables rollout_operator_replica_template_access_enabled via live-store',
+  test.expect.eq(
+    withBlockBuilderKedaKeda('http://prometheus:9090')._config.rollout_operator_replica_template_access_enabled,
+    true
+  )
+)
++ test.case.new(
+  'block_builder KEDA keda approach without live-store KEDA does not auto-enable rollout_operator_replica_template_access_enabled',
+  test.expect.eq(
+    withBlockBuilderKedaKedaOnly('http://prometheus:9090')._config.rollout_operator_replica_template_access_enabled,
+    false
+  )
+)
++ test.case.new(
+  'block_builder KEDA disabled omits rollout-mirror annotations from block-builder metadata',
   test.expect.eq(
     std.objectHas(
       std.get(default.tempo_block_builder_statefulset.metadata, 'annotations', {}),
@@ -220,43 +253,50 @@ test.new(std.thisFile)
   )
 )
 + test.case.new(
-  'live_store KEDA rollout-operator grants statefulsets/scale to rollout-operator role',
+  'block_builder KEDA rollout-operator grants statefulsets/scale to rollout-operator role',
   test.expect.eq(
     std.filter(
       function(r) std.member(r.resources, 'statefulsets/scale'),
-      withLiveStoreKeda('http://prometheus:9090').rollout_operator_role.rules
+      withBlockBuilderKedaRolloutOp('http://prometheus:9090').rollout_operator_role.rules
     )[0].verbs,
     ['get']
   )
 )
 + test.case.new(
-  'live_store KEDA keda approach creates block-builder ScaledObject',
+  'block_builder KEDA keda approach creates block-builder ScaledObject',
   test.expect.eq(
-    withLiveStoreKedaBlockBuilderKeda('http://prometheus:9090').tempo_block_builder_scaled_object.spec.scaleTargetRef.name,
+    withBlockBuilderKedaKeda('http://prometheus:9090').tempo_block_builder_scaled_object.spec.scaleTargetRef.name,
     'block-builder'
   )
 )
 + test.case.new(
-  'live_store KEDA keda approach block-builder ScaledObject uses kubernetes-workload trigger',
+  'block_builder KEDA keda approach block-builder ScaledObject uses kubernetes-workload trigger',
   test.expect.eq(
-    withLiveStoreKedaBlockBuilderKeda('http://prometheus:9090').tempo_block_builder_scaled_object.spec.triggers[0].type,
+    withBlockBuilderKedaKeda('http://prometheus:9090').tempo_block_builder_scaled_object.spec.triggers[0].type,
     'kubernetes-workload'
   )
 )
 + test.case.new(
-  'live_store KEDA keda approach omits rollout-mirror annotations from block-builder',
+  'block_builder KEDA keda approach omits rollout-mirror annotations from block-builder metadata',
   test.expect.eq(
     std.objectHas(
-      withLiveStoreKedaBlockBuilderKeda('http://prometheus:9090').tempo_block_builder_statefulset.spec.template.metadata.annotations,
+      std.get(withBlockBuilderKedaKeda('http://prometheus:9090').tempo_block_builder_statefulset.metadata, 'annotations', {}),
       'grafana.com/rollout-mirror-replicas-from-resource-name'
     ),
     false
   )
 )
 + test.case.new(
-  'live_store KEDA keda approach uses pod_selector from block_builder.keda config',
+  'block_builder KEDA keda approach uses pod_selector from block_builder.keda config',
   test.expect.eq(
-    withLiveStoreKedaBlockBuilderKeda('http://prometheus:9090').tempo_block_builder_scaled_object.spec.triggers[0].metadata.podSelector,
+    withBlockBuilderKedaKeda('http://prometheus:9090').tempo_block_builder_scaled_object.spec.triggers[0].metadata.podSelector,
     'name=live-store-zone-a'
+  )
+)
++ test.case.new(
+  'block_builder KEDA keda approach works without live-store KEDA',
+  test.expect.eq(
+    withBlockBuilderKedaKedaOnly('http://prometheus:9090').tempo_block_builder_scaled_object.spec.scaleTargetRef.name,
+    'block-builder'
   )
 )


### PR DESCRIPTION
**What this PR does**:

Combines [#7123](https://github.com/grafana/tempo/pull/7123) and [#7133](https://github.com/grafana/tempo/pull/7133) into a single configurable implementation. Both PRs add KEDA-based live-store autoscaling but differ in how block-builder replicas track live-store — this PR makes that choice explicit and operator-configurable via `live_store.keda.block_builder_scaling`.

**New config key: `live_store.keda.block_builder_scaling`**

| Value | Behaviour | Extra requirement |
|-------|-----------|-------------------|
| `'rollout-operator'` **(default)** | rollout-operator mirrors live-store zone-a replicas to block-builder via pod annotations. Block-builder intentionally lags zone-a through the drain window to prevent data loss on scale-down. | `rollout_operator_replica_template_access_enabled: true` |
| `'keda'` | Dedicated block-builder `ScaledObject` (kubernetes-workload trigger counting live-store zone-a pods). | none |

The RBAC assertion (`rollout_operator_replica_template_access_enabled`) is gated on the `'rollout-operator'` approach, so choosing `'keda'` avoids that requirement entirely.

Other changes:
- `block_builder.keda` config section is **restored** (it was removed in #7133 as a breaking change)
- Rollout-mirror pod annotations on block-builder are now **conditional** (only when live-store KEDA + rollout-operator approach); the default compiled output no longer carries them unconditionally
- `block_builder.partitions_per_instance` is the single source of truth for partition math under both approaches
- Validation assert added so an unknown `block_builder_scaling` value fails fast rather than leaving block-builder without a replica manager
- Docs updated to show both approaches; example snippets use `keda+:` to merge with defaults

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`