### PR TITLE
fix(livestore): write query-range cache atomically; tolerate cache errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [BUGFIX] backend-scheduler: fix redaction batch not cleaned up after dead-job timeout, leaving tenant permanently blocked from new redaction submissions and compaction. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
 * [BUGFIX] backend-scheduler: fix outstanding-blocks metric suppressed to zero during active redaction batch, causing autoscaler to scale down workers mid-redaction. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
 * [BUGFIX] backend-scheduler: fix O(N) lock contention in GetJobForWorker under concurrent worker load; replace shard scan with O(1) index lookup. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
+* [BUGFIX] livestore: write the per-block query-range response cache atomically (temp file + rename) and log+ignore cache read errors. [#7155](https://github.com/grafana/tempo/pull/7155) (@zhxiaogg)
 * [BUGFIX] livestore: recover from panics in `iterateBlocks` per-block paths so a panic in vparquet/parquetquery (e.g. malformed `ByteArray` values) returns an error instead of crashing the process. [#7134](https://github.com/grafana/tempo/pull/7134) (@zhxiaogg)
 * [BUGFIX] user-configurable overrides: emit duration fields as flat YAML scalars on `/status/overrides/{tenant}` and omit `generate_native_histograms` when unset. [#7138](https://github.com/grafana/tempo/pull/7138) (@electron0zero)
 

--- a/modules/livestore/instance_search.go
+++ b/modules/livestore/instance_search.go
@@ -842,9 +842,12 @@ func (i *instance) queryRangeCompleteBlock(ctx context.Context, b *LocalBlock, r
 		return nil, nil
 	}
 
-	cached, name, err := i.queryRangeCacheGet(ctx, m, req)
+	name := queryRangeCacheName(req)
+
+	cached, err := i.queryRangeCacheGet(ctx, m, name)
 	if err != nil {
-		return nil, err
+		level.Warn(i.logger).Log("msg", "reading local query cache failed",
+			"block", m.BlockID.String(), "err", err)
 	}
 
 	span.SetAttributes(attribute.Bool("cached", cached != nil))
@@ -853,7 +856,6 @@ func (i *instance) queryRangeCompleteBlock(ctx context.Context, b *LocalBlock, r
 		return cached.Series, nil
 	}
 
-	// Not in cache or not cacheable, so execute
 	eval, err := traceql.NewEngine().CompileMetricsQueryRange(&req, compileOpts...)
 	if err != nil {
 		return nil, err
@@ -873,46 +875,41 @@ func (i *instance) queryRangeCompleteBlock(ctx context.Context, b *LocalBlock, r
 
 	results := eval.Results().ToProto(&req)
 
-	if name != "" {
-		err = i.queryRangeCacheSet(ctx, m, name, &tempopb.QueryRangeResponse{
-			Series: results,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("writing local query cache: %w", err)
-		}
+	if err := i.queryRangeCacheSet(ctx, m, name, &tempopb.QueryRangeResponse{
+		Series: results,
+	}); err != nil {
+		level.Warn(i.logger).Log("msg", "writing local query cache failed",
+			"block", m.BlockID.String(), "err", err)
 	}
 
 	return results, nil
 }
 
-func (i *instance) queryRangeCacheGet(ctx context.Context, m *backend.BlockMeta, req tempopb.QueryRangeRequest) (*tempopb.QueryRangeResponse, string, error) {
-	hash := queryRangeHashForBlock(req)
+func queryRangeCacheName(req tempopb.QueryRangeRequest) string {
+	return fmt.Sprintf("cache_query_range_%v.buf", queryRangeHashForBlock(req))
+}
 
-	name := fmt.Sprintf("cache_query_range_%v.buf", hash)
-
+func (i *instance) queryRangeCacheGet(ctx context.Context, m *backend.BlockMeta, name string) (*tempopb.QueryRangeResponse, error) {
 	keyPath := backend.KeyPathForBlock((uuid.UUID)(m.BlockID), m.TenantID)
 	reader, size, err := i.wal.LocalBackend().Read(ctx, name, keyPath, nil)
 	if err != nil {
 		if errors.Is(err, backend.ErrDoesNotExist) {
-			// Not cached, but return the name/keypath so it can be set after
-			return nil, name, nil
+			return nil, nil
 		}
-		return nil, "", err
+		return nil, err
 	}
 	defer reader.Close()
 
 	data, err := tempo_io.ReadAllWithEstimate(reader, size)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	resp := &tempopb.QueryRangeResponse{}
-	err = proto.Unmarshal(data, resp)
-	if err != nil {
-		return nil, "", err
+	if err := proto.Unmarshal(data, resp); err != nil {
+		return nil, err
 	}
-
-	return resp, name, nil
+	return resp, nil
 }
 
 func (i *instance) queryRangeCacheSet(ctx context.Context, m *backend.BlockMeta, name string, resp *tempopb.QueryRangeResponse) error {
@@ -922,7 +919,7 @@ func (i *instance) queryRangeCacheSet(ctx context.Context, m *backend.BlockMeta,
 	}
 
 	keyPath := backend.KeyPathForBlock((uuid.UUID)(m.BlockID), m.TenantID)
-	return i.wal.LocalBackend().Write(ctx, name, keyPath, bytes.NewReader(data), int64(len(data)), nil)
+	return i.wal.LocalBackend().WriteAtomic(ctx, name, keyPath, bytes.NewReader(data), int64(len(data)))
 }
 
 func queryRangeHashForBlock(req tempopb.QueryRangeRequest) uint64 {

--- a/modules/livestore/instance_search_test.go
+++ b/modules/livestore/instance_search_test.go
@@ -10,14 +10,17 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"os"
 	"path"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/gogo/protobuf/proto"
 	"github.com/google/uuid"
 	"github.com/grafana/dskit/kv/consul"
 	"github.com/grafana/dskit/ring"
@@ -1387,4 +1390,74 @@ func TestLiveStoreQueryRange(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestQueryRangeToleratesCorruptCache(t *testing.T) {
+	i, ls := defaultInstance(t)
+	writeTracesForSearch(t, i, "", foo, bar, true, false)
+
+	blockID, err := i.cutBlocks(t.Context(), true)
+	require.NoError(t, err)
+	_, err = i.completeBlock(t.Context(), blockID)
+	require.NoError(t, err)
+
+	var block *LocalBlock
+	for _, b := range i.blocks.Load().completeBlocks {
+		block = b
+		break
+	}
+	require.NotNil(t, block)
+
+	req := &tempopb.QueryRangeRequest{
+		Query:     "{} | count_over_time()",
+		Start:     uint64(block.BlockMeta().StartTime.Add(-time.Minute).UnixNano()),
+		End:       uint64(block.BlockMeta().EndTime.Add(time.Minute).UnixNano()),
+		Step:      uint64(time.Second),
+		MaxSeries: 10,
+	}
+
+	first, err := i.QueryRange(t.Context(), req)
+	require.NoError(t, err)
+
+	blockDir := path.Join(i.wal.GetFilepath(), "blocks", i.tenantID, block.BlockMeta().BlockID.String())
+	cacheFile := findCacheFile(t, blockDir)
+	require.NoError(t, os.WriteFile(cacheFile, []byte("garbage"), 0o600))
+
+	second, err := i.QueryRange(t.Context(), req)
+	require.NoError(t, err)
+	require.Equal(t, len(first.Series), len(second.Series))
+
+	cached, err := os.ReadFile(cacheFile)
+	require.NoError(t, err)
+	var healed tempopb.QueryRangeResponse
+	require.NoError(t, proto.Unmarshal(cached, &healed))
+
+	require.NoError(t, services.StopAndAwaitTerminated(t.Context(), ls))
+}
+
+func TestQueryRangeCacheName_StableForSameRequest(t *testing.T) {
+	req := tempopb.QueryRangeRequest{
+		Query: "{} | count_over_time()",
+		Start: 1_000_000_000,
+		End:   2_000_000_000,
+		Step:  uint64(time.Second),
+	}
+	require.Equal(t, queryRangeCacheName(req), queryRangeCacheName(req))
+
+	other := req
+	other.End = 3_000_000_000
+	require.NotEqual(t, queryRangeCacheName(req), queryRangeCacheName(other))
+}
+
+func findCacheFile(t *testing.T, blockDir string) string {
+	t.Helper()
+	entries, err := os.ReadDir(blockDir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "cache_query_range_") {
+			return path.Join(blockDir, e.Name())
+		}
+	}
+	t.Fatalf("no cache_query_range_*.buf file found in %s", blockDir)
+	return ""
 }

--- a/tempodb/backend/local/local.go
+++ b/tempodb/backend/local/local.go
@@ -47,7 +47,7 @@ func New(cfg *Config) (backend.RawReader, backend.RawWriter, backend.Compactor, 
 	return l, l, l, err
 }
 
-// Write implements backend.Writer
+// Write implements backend.Writer.
 func (rw *Backend) Write(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, _ int64, _ *backend.CacheInfo) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -71,6 +71,44 @@ func (rw *Backend) Write(ctx context.Context, name string, keypath backend.KeyPa
 		return err
 	}
 	return err
+}
+
+// WriteAtomic writes via a temp file + os.Rename so concurrent writers to
+// the same path never leave a partial or interleaved file on disk.
+func (rw *Backend) WriteAtomic(ctx context.Context, name string, keypath backend.KeyPath, data io.Reader, _ int64) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	blockFolder := rw.rootPath(keypath)
+	if err := os.MkdirAll(blockFolder, 0o700); err != nil {
+		return err
+	}
+
+	finalName := rw.objectFileName(keypath, name)
+	tmp, err := os.CreateTemp(blockFolder, "."+filepath.Base(name)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		if tmpName != "" {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := io.Copy(tmp, data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, finalName); err != nil {
+		return err
+	}
+	tmpName = ""
+	return nil
 }
 
 // Append implements backend.Writer

--- a/tempodb/backend/local/local_test.go
+++ b/tempodb/backend/local/local_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/google/uuid"
@@ -155,4 +156,118 @@ func blockExists(t *testing.T, blockID backend.UUID, tenant string, r backend.Ra
 	require.NoError(t, err)
 	require.Len(t, blocks, 1)
 	require.Equal(t, blockID.String(), blocks[0])
+}
+
+func TestWriteAtomicConcurrent(t *testing.T) {
+	b, err := NewBackend(&Config{Path: t.TempDir()})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	keypath := backend.KeyPath{"tenant", "block-uuid"}
+	name := "concurrent.buf"
+	payloadA := bytes.Repeat([]byte{0xAA}, 4*1024)
+	payloadB := bytes.Repeat([]byte{0xBB}, 1024)
+
+	const iters = 500
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	for _, p := range [][]byte{payloadA, payloadB} {
+		p := p
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				require.NoError(t, b.WriteAtomic(ctx, name, keypath, bytes.NewReader(p), int64(len(p))))
+			}
+		}()
+	}
+	go func() { wg.Wait(); close(done) }()
+
+	for {
+		select {
+		case <-done:
+			return
+		default:
+		}
+		r, sz, rerr := b.Read(ctx, name, keypath, nil)
+		if rerr != nil {
+			continue
+		}
+		got, rerr := io.ReadAllWithEstimate(r, sz)
+		r.Close()
+		require.NoError(t, rerr)
+		require.True(t, bytes.Equal(got, payloadA) || bytes.Equal(got, payloadB),
+			"read observed bytes that match neither payload")
+	}
+}
+
+func TestWriteAtomic(t *testing.T) {
+	b, err := NewBackend(&Config{Path: t.TempDir()})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	keypath := backend.KeyPath{"tenant", "block-uuid"}
+	name := "obj.buf"
+	payload := []byte("hello world")
+
+	require.NoError(t, b.WriteAtomic(ctx, name, keypath, bytes.NewReader(payload), int64(len(payload))))
+
+	r, sz, err := b.Read(ctx, name, keypath, nil)
+	require.NoError(t, err)
+	defer r.Close()
+	got, err := io.ReadAllWithEstimate(r, sz)
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+}
+
+func TestWriteAtomicOverwritesExistingFile(t *testing.T) {
+	b, err := NewBackend(&Config{Path: t.TempDir()})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	keypath := backend.KeyPath{"tenant", "block-uuid"}
+	name := "obj.buf"
+	first := []byte("first")
+	second := []byte("second value, larger than first")
+
+	require.NoError(t, b.WriteAtomic(ctx, name, keypath, bytes.NewReader(first), int64(len(first))))
+	require.NoError(t, b.WriteAtomic(ctx, name, keypath, bytes.NewReader(second), int64(len(second))))
+
+	r, sz, err := b.Read(ctx, name, keypath, nil)
+	require.NoError(t, err)
+	defer r.Close()
+	got, err := io.ReadAllWithEstimate(r, sz)
+	require.NoError(t, err)
+	require.Equal(t, second, got)
+}
+
+func TestWriteAtomicLeavesNoTempFiles(t *testing.T) {
+	root := t.TempDir()
+	b, err := NewBackend(&Config{Path: root})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	keypath := backend.KeyPath{"tenant", "block-uuid"}
+	name := "obj.buf"
+	require.NoError(t, b.WriteAtomic(ctx, name, keypath, bytes.NewReader([]byte("x")), 1))
+
+	entries, err := os.ReadDir(b.rootPath(keypath))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, name, entries[0].Name())
+}
+
+func TestWriteAtomicRespectsCancelledContext(t *testing.T) {
+	b, err := NewBackend(&Config{Path: t.TempDir()})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	keypath := backend.KeyPath{"tenant", "block-uuid"}
+	err = b.WriteAtomic(ctx, "obj.buf", keypath, bytes.NewReader([]byte("x")), 1)
+	require.ErrorIs(t, err, context.Canceled)
+
+	entries, _ := os.ReadDir(b.rootPath(keypath))
+	require.Empty(t, entries)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
The per-block query-range response cache (cache_query_range_*.buf) is written from queryRangeCacheSet through the local backend Write. Concurrent live-store metrics queries that share the same (block, query, start, end, step) hash race on the same path; the non-atomic os.Create + io.Copy leaves the file with interleaved bytes from both writers. Subsequent readers fail proto.Unmarshal with `proto: illegal wireType N` etc., and the corrupt cache file persists until the block ages out -- showing in prod as sustained 500s on TraceQL metrics queries from a tenant that hammers the same query.

Add a WriteAtomic method on the local backend (temp file + rename) and have queryRangeCacheSet use it. Backend.Write is unchanged -- all other writers (block flush, etc.) target per-block UUID paths with a single writer, so they don't need the extra fsync overhead.

queryRangeCacheGet is unchanged; queryRangeCompleteBlock now logs and continues on a cache read error rather than failing the user-facing request.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`