### PR TITLE
fix: enforce metrics max_duration on user-provided range

### DIFF
--- a/.chloggen/worktree-fix-metrics-max-duration-alignment.yaml
+++ b/.chloggen/worktree-fix-metrics-max-duration-alignment.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: query-frontend
+note: enforce `max_metrics_duration` against the user-provided range, not the post-alignment range. A range query whose window falls entirely inside `query_end_cutoff` now returns 400 instead of an empty result; an instant query with the same condition is now also rejected explicitly. gRPC metrics queries now return `InvalidArgument` for max-duration validation failures.
+issues: [7170]
+subtext:
+user: carles-grafana

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -129,7 +129,6 @@ func New(cfg Config, next pipeline.RoundTripper, o overrides.Interface, reader t
 	}, []string{"op"})
 
 	adjustEndWareSeconds := pipeline.NewAdjustStartEndWare(cfg.Search.Sharder.QueryBackendAfter, cfg.QueryEndCutoff, false)
-	adjustEndWareNanos := pipeline.NewAdjustStartEndWare(cfg.Metrics.Sharder.QueryBackendAfter, cfg.QueryEndCutoff, true) // metrics queries work in nanoseconds
 	retryWare := pipeline.NewRetryWare(cfg.MaxRetries, cfg.Weights.RetryWithWeights, registerer)
 	cacheWare := pipeline.NewCachingWare(cacheProvider, cache.RoleFrontendSearch, logger)
 	statusCodeWare := pipeline.NewStatusCodeAdjustWare()
@@ -208,9 +207,6 @@ func New(cfg Config, next pipeline.RoundTripper, o overrides.Interface, reader t
 	queryRangePipeline := pipeline.Build(
 		[]pipeline.AsyncMiddleware[combiner.PipelineResponse]{
 			headerStripWare,
-			// due to alignments and combiner, it needs to be done in handler
-			// TODO: initialise combiner after middlewares and uncomment
-			// adjustEndWareNanos,
 			urlDenyListWare,
 			queryValidatorWare,
 			pipeline.NewWeightRequestWare(pipeline.TraceQLMetrics, cfg.Weights),
@@ -224,7 +220,6 @@ func New(cfg Config, next pipeline.RoundTripper, o overrides.Interface, reader t
 	queryInstantPipeline := pipeline.Build(
 		[]pipeline.AsyncMiddleware[combiner.PipelineResponse]{
 			headerStripWare,
-			adjustEndWareNanos,
 			urlDenyListWare,
 			queryValidatorWare,
 			pipeline.NewWeightRequestWare(pipeline.TraceQLMetrics, cfg.Weights),
@@ -242,8 +237,8 @@ func New(cfg Config, next pipeline.RoundTripper, o overrides.Interface, reader t
 	searchTagsV2 := newTagsV2HTTPHandler(cfg, searchTagsPipeline, o, logger, dataAccessController)
 	searchTagValues := newTagValuesHTTPHandler(cfg, searchTagValuesPipeline, o, logger, dataAccessController)
 	searchTagValuesV2 := newTagValuesV2HTTPHandler(cfg, searchTagValuesV2Pipeline, o, logger, dataAccessController)
-	queryInstant := newMetricsQueryInstantHTTPHandler(cfg, queryInstantPipeline, logger, dataAccessController) // Reuses the same pipeline
-	queryRange := newMetricsQueryRangeHTTPHandler(cfg, queryRangePipeline, logger, dataAccessController)
+	queryInstant := newMetricsQueryInstantHTTPHandler(cfg, queryInstantPipeline, o, logger, dataAccessController) // Reuses the same pipeline
+	queryRange := newMetricsQueryRangeHTTPHandler(cfg, queryRangePipeline, o, logger, dataAccessController)
 
 	f := &QueryFrontend{
 		// http/discrete
@@ -263,8 +258,8 @@ func New(cfg Config, next pipeline.RoundTripper, o overrides.Interface, reader t
 		streamingTagsV2:       newTagsV2StreamingGRPCHandler(cfg, searchTagsPipeline, apiPrefix, o, logger, dataAccessController),
 		streamingTagValues:    newTagValuesStreamingGRPCHandler(cfg, searchTagValuesPipeline, apiPrefix, o, logger, dataAccessController),
 		streamingTagValuesV2:  newTagValuesV2StreamingGRPCHandler(cfg, searchTagValuesV2Pipeline, apiPrefix, o, logger, dataAccessController),
-		streamingQueryRange:   newQueryRangeStreamingGRPCHandler(cfg, queryRangePipeline, apiPrefix, logger, dataAccessController),
-		streamingQueryInstant: newQueryInstantStreamingGRPCHandler(cfg, queryRangePipeline, apiPrefix, logger, dataAccessController), // Reuses the same pipeline
+		streamingQueryRange:   newQueryRangeStreamingGRPCHandler(cfg, queryRangePipeline, o, apiPrefix, logger, dataAccessController),
+		streamingQueryInstant: newQueryInstantStreamingGRPCHandler(cfg, queryRangePipeline, o, apiPrefix, logger, dataAccessController), // Reuses the same pipeline
 
 		cacheProvider: cacheProvider,
 		logger:        logger,

--- a/modules/frontend/metrics_query_handler.go
+++ b/modules/frontend/metrics_query_handler.go
@@ -14,15 +14,18 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/status"
 	"github.com/grafana/dskit/user"
 	"github.com/grafana/tempo/modules/frontend/combiner"
 	"github.com/grafana/tempo/modules/frontend/pipeline"
+	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/util/tracing"
+	"google.golang.org/grpc/codes"
 )
 
-func newQueryInstantStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], apiPrefix string, logger log.Logger, dataAccessController DataAccessController) streamingQueryInstantHandler {
+func newQueryInstantStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], o overrides.Interface, apiPrefix string, logger log.Logger, dataAccessController DataAccessController) streamingQueryInstantHandler {
 	postSLOHook := metricsSLOPostHook(cfg.Metrics.SLO)
 	downstreamPath := path.Join(apiPrefix, api.PathMetricsQueryRange)
 
@@ -53,6 +56,15 @@ func newQueryInstantStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTri
 			Step:  req.End - req.Start,
 		}
 		qr.SetInstant(true)
+
+		if err := clampQueryEndForValidation(cfg, qr); err != nil {
+			return status.Error(codes.InvalidArgument, err.Error())
+		}
+		qr.Step = qr.End - qr.Start // keep Step == End-Start for instant
+
+		if err := validateQueryRangeReq(ctx, cfg, o, qr); err != nil {
+			return status.Error(codes.InvalidArgument, err.Error())
+		}
 
 		httpReq := api.BuildQueryRangeRequest(&http.Request{
 			URL:    &url.URL{Path: downstreamPath},
@@ -90,7 +102,7 @@ func newQueryInstantStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTri
 
 // newMetricsQueryInstantHTTPHandler handles instant queries.  Internally these are rewritten as query_range with single step
 // to make use of the existing pipeline.
-func newMetricsQueryInstantHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], logger log.Logger, dataAccessController DataAccessController) http.RoundTripper {
+func newMetricsQueryInstantHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], o overrides.Interface, logger log.Logger, dataAccessController DataAccessController) http.RoundTripper {
 	postSLOHook := metricsSLOPostHook(cfg.Metrics.SLO)
 
 	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
@@ -126,6 +138,15 @@ func newMetricsQueryInstantHTTPHandler(cfg Config, next pipeline.AsyncRoundTripp
 			Step:  i.End - i.Start,
 		}
 		qr.SetInstant(true)
+
+		if err := clampQueryEndForValidation(cfg, qr); err != nil {
+			return httpInvalidRequest(err), nil
+		}
+		qr.Step = qr.End - qr.Start // keep Step == End-Start for instant
+
+		if err := validateQueryRangeReq(req.Context(), cfg, o, qr); err != nil {
+			return httpInvalidRequest(err), nil
+		}
 
 		// Clone existing to keep it unaltered.
 		req = req.Clone(req.Context())

--- a/modules/frontend/metrics_query_range_handler.go
+++ b/modules/frontend/metrics_query_range_handler.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -14,18 +13,23 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level" //nolint:all //deprecated
+	"github.com/gogo/status"
 	"github.com/grafana/dskit/user"
 	"github.com/grafana/tempo/modules/frontend/combiner"
 	"github.com/grafana/tempo/modules/frontend/pipeline"
+	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/pkg/util/tracing"
+	"google.golang.org/grpc/codes"
 
 	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/traceql"
 )
 
+var errQueryWindowWithinEndCutoff = errors.New("query window falls entirely within query_end_cutoff")
+
 // newQueryRangeStreamingGRPCHandler returns a handler that streams results from the HTTP handler
-func newQueryRangeStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], apiPrefix string, logger log.Logger, dataAccessController DataAccessController) streamingQueryRangeHandler {
+func newQueryRangeStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], o overrides.Interface, apiPrefix string, logger log.Logger, dataAccessController DataAccessController) streamingQueryRangeHandler {
 	postSLOHook := metricsSLOPostHook(cfg.Metrics.SLO)
 	downstreamPath := path.Join(apiPrefix, api.PathMetricsQueryRange)
 
@@ -49,8 +53,13 @@ func newQueryRangeStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripp
 		if !req.HasInstant() { // if not found, set it explicitly
 			req.SetInstant(false)
 		}
-		if err := validateQueryRangeReq(cfg, req); err != nil {
-			return err
+
+		if err := clampQueryEndForValidation(cfg, req); err != nil {
+			return status.Error(codes.InvalidArgument, err.Error())
+		}
+
+		if err := validateQueryRangeReq(ctx, cfg, o, req); err != nil {
+			return status.Error(codes.InvalidArgument, err.Error())
 		}
 
 		if err := normalizeRequestExemplars(req, cfg.Metrics.Sharder.MaxExemplars); err != nil {
@@ -58,18 +67,10 @@ func newQueryRangeStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripp
 		}
 
 		traceql.AlignRequest(req)
-
-		// the end time cutoff is applied here because it has to be done before combiner creation
-		// TODO: this is a copy of ClampDateRangeReq and needs to be removed after a proper fix
-		if cfg.QueryEndCutoff > 0 {
-			now := time.Now()
-			maxEnd := now.Add(-cfg.QueryEndCutoff)
-			reqEnd := time.Unix(0, int64(req.End))
-			if maxEnd.Before(reqEnd) {
-				req.End = uint64(maxEnd.UnixNano())
-				traceql.AlignEndToLeft(req) // realign, but always to the left
-			}
-		}
+		// AlignRequest's alignEnd rounds end up to the next step boundary, which
+		// can push it past now-QueryEndCutoff. Re-clamp to preserve the cutoff
+		// invariant and round range-query ends back down to a step boundary.
+		clampQueryEnd(cfg, req)
 
 		httpReq := api.BuildQueryRangeRequest(&http.Request{
 			URL:    &url.URL{Path: downstreamPath},
@@ -107,7 +108,7 @@ func newQueryRangeStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripp
 }
 
 // newMetricsQueryRangeHTTPHandler returns a handler that returns a single response from the HTTP handler
-func newMetricsQueryRangeHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], logger log.Logger, dataAccessController DataAccessController) http.RoundTripper {
+func newMetricsQueryRangeHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], o overrides.Interface, logger log.Logger, dataAccessController DataAccessController) http.RoundTripper {
 	postSLOHook := metricsSLOPostHook(cfg.Metrics.SLO)
 
 	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
@@ -135,7 +136,12 @@ func newMetricsQueryRangeHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper
 		}
 		logQueryRangeRequest(logger, tenant, queryRangeReq)
 
-		if err := validateQueryRangeReq(cfg, queryRangeReq); err != nil {
+		// Clamp end before validation so the cap is checked against the effective range.
+		if err := clampQueryEndForValidation(cfg, queryRangeReq); err != nil {
+			return httpInvalidRequest(err), nil
+		}
+
+		if err := validateQueryRangeReq(req.Context(), cfg, o, queryRangeReq); err != nil {
 			return httpInvalidRequest(err), nil
 		}
 
@@ -144,18 +150,10 @@ func newMetricsQueryRangeHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper
 		}
 
 		traceql.AlignRequest(queryRangeReq)
-
-		// the end time cutoff is applied here because it has to be done before combiner creation
-		// TODO: this is a copy of ClampDateRangeReq and needs to be removed after a proper fix
-		if cfg.QueryEndCutoff > 0 {
-			now := time.Now()
-			maxEnd := now.Add(-cfg.QueryEndCutoff)
-			reqEnd := time.Unix(0, int64(queryRangeReq.End))
-			if maxEnd.Before(reqEnd) {
-				queryRangeReq.End = uint64(maxEnd.UnixNano())
-				traceql.AlignEndToLeft(queryRangeReq) // realign, but always to the left
-			}
-		}
+		// AlignRequest's alignEnd rounds end up to the next step boundary, which
+		// can push it past now-QueryEndCutoff. Re-clamp to preserve the cutoff
+		// invariant and round range-query ends back down to a step boundary.
+		clampQueryEnd(cfg, queryRangeReq)
 		req = api.BuildQueryRangeRequest(req, queryRangeReq, "")
 
 		// build and use roundtripper
@@ -181,6 +179,42 @@ func newMetricsQueryRangeHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper
 		logQueryRangeResult(req.Context(), logger, tenant, duration.Seconds(), queryRangeReq, queryRangeResp, err)
 		return resp, err
 	})
+}
+
+// clampQueryEndForValidation clamps req.End to now-QueryEndCutoff without
+// step-aligning it, so validation sees the effective user range instead of an
+// internally aligned range. If the cutoff removes the whole query window, it
+// returns a cutoff-specific error instead of the generic start/end error.
+func clampQueryEndForValidation(cfg Config, req *tempopb.QueryRangeRequest) error {
+	if req.Start > req.End {
+		return nil
+	}
+
+	clamped := clampQueryEndToCutoff(cfg, req)
+	if clamped && req.Start > req.End {
+		return errQueryWindowWithinEndCutoff
+	}
+	return nil
+}
+
+// clampQueryEnd clamps req.End to now-QueryEndCutoff when end is past that
+// horizon, then rounds down to a step boundary for non-instant queries. When
+// cutoff is 0 the clamp horizon is now, so clock-skewed future ends are still
+// pulled back to the current frontend time.
+func clampQueryEnd(cfg Config, req *tempopb.QueryRangeRequest) {
+	if clampQueryEndToCutoff(cfg, req) {
+		traceql.AlignEndToLeft(req)
+	}
+}
+
+func clampQueryEndToCutoff(cfg Config, req *tempopb.QueryRangeRequest) bool {
+	maxEnd := time.Now().Add(-cfg.QueryEndCutoff)
+	reqEnd := time.Unix(0, int64(req.End))
+	if reqEnd.After(maxEnd) {
+		req.End = uint64(maxEnd.UnixNano())
+		return true
+	}
+	return false
 }
 
 // normalizeRequestExemplars resolves the final exemplar limit for a query range request.
@@ -269,19 +303,4 @@ func httpInvalidRequest(err error) *http.Response {
 		Status:     http.StatusText(http.StatusBadRequest),
 		Body:       io.NopCloser(strings.NewReader(err.Error())),
 	}
-}
-
-func validateQueryRangeReq(cfg Config, req *tempopb.QueryRangeRequest) error {
-	if req.Start > req.End {
-		return errors.New("end must be greater than start")
-	}
-	if cfg.Metrics.MaxIntervals != 0 && (req.Step == 0 || (req.End-req.Start)/req.Step > cfg.Metrics.MaxIntervals) {
-		minimumStep := (req.End - req.Start) / cfg.Metrics.MaxIntervals
-		return fmt.Errorf(
-			"step of %s is too small, minimum step for given range is %s",
-			time.Duration(req.Step).String(),
-			time.Duration(minimumStep).String(),
-		)
-	}
-	return nil
 }

--- a/modules/frontend/metrics_query_range_handler_test.go
+++ b/modules/frontend/metrics_query_range_handler_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
+	"github.com/gogo/status"
 	"github.com/grafana/dskit/user"
 	"github.com/grafana/tempo/modules/frontend/pipeline"
 	"github.com/grafana/tempo/modules/overrides"
@@ -24,8 +25,10 @@ import (
 	v1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
 	"github.com/grafana/tempo/pkg/util/test"
 	"github.com/grafana/tempo/tempodb/backend"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
 )
 
 func TestQueryRangeHandlerSucceeds(t *testing.T) {
@@ -785,6 +788,574 @@ func TestNormalizeRequestExemplars(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.Equal(t, tc.wantExemplars, req.Exemplars)
+		})
+	}
+}
+
+func TestQueryRangeMaxDurationCheckCapturesPostAlignmentInflation(t *testing.T) {
+	// Captures the forwarded request to assert AlignRequest still inflates
+	// past the cap — locks in the property the fix is about.
+	rt := &mockRoundTripperWithCapture{
+		rt: mockRoundTripper{
+			responseFn: func() proto.Message {
+				return &tempopb.QueryRangeResponse{
+					Metrics: &tempopb.SearchMetrics{InspectedTraces: 1, InspectedBytes: 1},
+				}
+			},
+		},
+	}
+
+	f := frontendWithSettings(t, rt, nil, nil, nil, func(c *Config, _ *overrides.Config) {
+		c.Metrics.Sharder.Interval = time.Hour
+		c.Metrics.Sharder.MaxDuration = 48 * time.Hour
+		c.Metrics.Sharder.QueryBackendAfter = 1000 * time.Hour
+	})
+
+	end := time.Now().Truncate(time.Second).Add(123 * time.Millisecond)
+	start := end.Add(-48 * time.Hour)
+
+	httpReq := httptest.NewRequest("GET", api.PathMetricsQueryRange, nil)
+	httpReq = api.BuildQueryRangeRequest(httpReq, &tempopb.QueryRangeRequest{
+		Query: "{} | rate()",
+		Start: uint64(start.UnixNano()),
+		End:   uint64(end.UnixNano()),
+		Step:  uint64(time.Hour.Nanoseconds()),
+	}, "")
+	httpReq = httpReq.WithContext(user.InjectOrgID(httpReq.Context(), "foo"))
+
+	httpResp := httptest.NewRecorder()
+	f.MetricsQueryRangeHandler.ServeHTTP(httpResp, httpReq)
+
+	require.Equal(t, http.StatusOK, httpResp.Code, "body: %s", httpResp.Body.String())
+	require.NotNil(t, rt.req)
+	// The forwarded request must be inflated, otherwise this test isn't proving anything.
+	assert.Greater(t, time.Duration(rt.req.End-rt.req.Start), 48*time.Hour)
+}
+
+func TestQueryRangeMaxDurationCheckRespectsConfigFallback(t *testing.T) {
+	// When no per-tenant override is set, the config-level cap
+	// (cfg.Metrics.Sharder.MaxDuration) must be honored.
+	f := frontendWithSettings(t, &mockRoundTripper{}, nil, nil, nil, func(c *Config, _ *overrides.Config) {
+		c.Metrics.Sharder.Interval = time.Hour
+		c.Metrics.Sharder.MaxDuration = 200 * time.Second
+	})
+
+	httpReq := httptest.NewRequest("GET", api.PathMetricsQueryRange, nil)
+	httpReq = api.BuildQueryRangeRequest(httpReq, &tempopb.QueryRangeRequest{
+		Query: "{} | rate()",
+		Start: uint64(1100 * time.Second),
+		End:   uint64(1100*time.Second + 201*time.Second),
+		Step:  uint64(100 * time.Second),
+	}, "")
+	httpReq = httpReq.WithContext(user.InjectOrgID(httpReq.Context(), "foo"))
+
+	httpResp := httptest.NewRecorder()
+	f.MetricsQueryRangeHandler.ServeHTTP(httpResp, httpReq)
+	require.Equal(t, http.StatusBadRequest, httpResp.Code, "body: %s", httpResp.Body.String())
+	require.Contains(t, httpResp.Body.String(), "exceeds the maximum allowed duration of 3m20s")
+}
+
+func TestQueryRangeMaxDurationCheckSkippedWhenBothZero(t *testing.T) {
+	// Both override and config fallback zero ⇒ no cap, request proceeds.
+	resp := &tempopb.QueryRangeResponse{
+		Metrics: &tempopb.SearchMetrics{InspectedTraces: 1, InspectedBytes: 1},
+	}
+	f := frontendWithSettings(t, &mockRoundTripper{
+		responseFn: func() proto.Message { return resp },
+	}, nil, nil, nil, func(c *Config, _ *overrides.Config) {
+		c.Metrics.Sharder.Interval = time.Hour
+	})
+
+	end := time.Now().Truncate(time.Second)
+	start := end.Add(-10 * 24 * time.Hour)
+	httpReq := httptest.NewRequest("GET", api.PathMetricsQueryRange, nil)
+	httpReq = api.BuildQueryRangeRequest(httpReq, &tempopb.QueryRangeRequest{
+		Query: "{} | rate()",
+		Start: uint64(start.UnixNano()),
+		End:   uint64(end.UnixNano()),
+		Step:  uint64(time.Hour),
+	}, "")
+	httpReq = httpReq.WithContext(user.InjectOrgID(httpReq.Context(), "foo"))
+
+	httpResp := httptest.NewRecorder()
+	f.MetricsQueryRangeHandler.ServeHTTP(httpResp, httpReq)
+	require.Equal(t, http.StatusOK, httpResp.Code, "body: %s", httpResp.Body.String())
+}
+
+func TestQueryInstantMaxDurationCheckRejectsOverLimit(t *testing.T) {
+	// Instant handlers must enforce the cap; the sharder check that used to
+	// cover them was removed.
+	f := frontendWithSettings(t, &mockRoundTripper{}, nil, nil, nil, func(c *Config, _ *overrides.Config) {
+		c.Metrics.Sharder.MaxDuration = 48 * time.Hour
+	})
+
+	end := time.Now().Truncate(time.Second)
+	start := end.Add(-49 * time.Hour)
+
+	httpReq := httptest.NewRequest("GET", api.PathMetricsQueryInstant, nil)
+	httpReq = api.BuildQueryInstantRequest(httpReq, &tempopb.QueryInstantRequest{
+		Query: "{} | rate()",
+		Start: uint64(start.UnixNano()),
+		End:   uint64(end.UnixNano()),
+	})
+	httpReq = httpReq.WithContext(user.InjectOrgID(httpReq.Context(), "foo"))
+
+	httpResp := httptest.NewRecorder()
+	f.MetricsQueryInstantHandler.ServeHTTP(httpResp, httpReq)
+	require.Equal(t, http.StatusBadRequest, httpResp.Code)
+	assert.Contains(t, httpResp.Body.String(), "exceeds the maximum allowed duration of 48h0m0s")
+}
+
+func TestQueryInstantGRPCMaxDurationCheckRejectsOverLimit(t *testing.T) {
+	const maxDuration = 48 * time.Hour
+	f := frontendWithSettings(t, &mockRoundTripper{}, nil, nil, nil, func(c *Config, _ *overrides.Config) {
+		c.Metrics.Sharder.MaxDuration = maxDuration
+	})
+
+	end := time.Now().Truncate(time.Second)
+	start := end.Add(-49 * time.Hour)
+
+	srv := newMockStreamingServer[*tempopb.QueryInstantResponse]("foo", nil)
+	err := f.MetricsQueryInstant(&tempopb.QueryInstantRequest{
+		Query: "{} | rate()",
+		Start: uint64(start.UnixNano()),
+		End:   uint64(end.UnixNano()),
+	}, srv)
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Contains(t, err.Error(), "exceeds the maximum allowed duration")
+}
+
+func TestQueryRangeMaxDurationCheckRespectsEndCutoff(t *testing.T) {
+	// End in the future (clock skew) must be clamped before the cap is checked,
+	// otherwise valid requests get rejected on the raw range.
+	resp := &tempopb.QueryRangeResponse{
+		Metrics: &tempopb.SearchMetrics{InspectedTraces: 1, InspectedBytes: 1},
+	}
+	f := frontendWithSettings(t, &mockRoundTripper{
+		responseFn: func() proto.Message { return resp },
+	}, nil, nil, nil, func(c *Config, _ *overrides.Config) {
+		c.Metrics.Sharder.Interval = time.Hour
+		c.Metrics.Sharder.MaxDuration = 168 * time.Hour
+		c.QueryEndCutoff = 5 * time.Minute
+	})
+
+	// Raw range 177h > cap; post-clamp ~167h < cap — must pass.
+	end := time.Now().Add(10 * time.Hour)
+	start := end.Add(-177 * time.Hour)
+
+	httpReq := httptest.NewRequest("GET", api.PathMetricsQueryRange, nil)
+	httpReq = api.BuildQueryRangeRequest(httpReq, &tempopb.QueryRangeRequest{
+		Query: "{} | rate()",
+		Start: uint64(start.UnixNano()),
+		End:   uint64(end.UnixNano()),
+		Step:  uint64(time.Hour),
+	}, "")
+	httpReq = httpReq.WithContext(user.InjectOrgID(httpReq.Context(), "foo"))
+
+	httpResp := httptest.NewRecorder()
+	f.MetricsQueryRangeHandler.ServeHTTP(httpResp, httpReq)
+	require.Equal(t, http.StatusOK, httpResp.Code, "body: %s", httpResp.Body.String())
+}
+
+func TestQueryRangeEndCutoffSurvivesAlignment(t *testing.T) {
+	// AlignRequest's alignEnd rounds end up to the next step boundary. For a
+	// user end just before now-QueryEndCutoff (so the pre-validation clamp is
+	// a no-op), that rounding can push end past the cutoff. The handler must
+	// re-clamp after AlignRequest to preserve the invariant. Uses synctest to
+	// guarantee end lands mid-step (not on a step boundary), otherwise alignEnd
+	// would be a no-op and the test would pass for the wrong reason.
+	synctest.Test(t, func(t *testing.T) {
+		// Advance to a non-step-aligned now: synctest starts at a known instant;
+		// 123ms makes time mod step != 0 so end (now - cutoff - 1s) is mid-step.
+		time.Sleep(123 * time.Millisecond)
+
+		rt := &mockRoundTripperWithCapture{
+			rt: mockRoundTripper{
+				responseFn: func() proto.Message {
+					return &tempopb.QueryRangeResponse{
+						Metrics: &tempopb.SearchMetrics{InspectedTraces: 1, InspectedBytes: 1},
+					}
+				},
+			},
+		}
+		cutoff := 30 * time.Second
+		step := time.Hour
+		f := frontendWithSettings(t, rt, nil, nil, nil, func(c *Config, _ *overrides.Config) {
+			c.Metrics.Sharder.Interval = time.Hour
+			c.QueryEndCutoff = cutoff
+			c.Metrics.Sharder.QueryBackendAfter = 1000 * time.Hour
+		})
+
+		now := time.Now()
+		end := now.Add(-cutoff - time.Second)
+		start := end.Add(-2 * time.Hour)
+
+		httpReq := httptest.NewRequest("GET", api.PathMetricsQueryRange, nil)
+		httpReq = api.BuildQueryRangeRequest(httpReq, &tempopb.QueryRangeRequest{
+			Query: "{} | rate()",
+			Start: uint64(start.UnixNano()),
+			End:   uint64(end.UnixNano()),
+			Step:  uint64(step),
+		}, "")
+		httpReq = httpReq.WithContext(user.InjectOrgID(httpReq.Context(), "foo"))
+
+		httpResp := httptest.NewRecorder()
+		f.MetricsQueryRangeHandler.ServeHTTP(httpResp, httpReq)
+		require.Equal(t, http.StatusOK, httpResp.Code, "body: %s", httpResp.Body.String())
+		require.NotNil(t, rt.req)
+		maxAllowedEnd := time.Now().Add(-cutoff)
+		assert.LessOrEqual(t, int64(rt.req.End), maxAllowedEnd.UnixNano(),
+			"end was %s; cutoff invariant says end <= now-cutoff (= %s)",
+			time.Unix(0, int64(rt.req.End)), maxAllowedEnd)
+	})
+}
+
+func TestQueryRangeGRPCEndCutoffSurvivesAlignment(t *testing.T) {
+	// gRPC streaming counterpart of TestQueryRangeEndCutoffSurvivesAlignment.
+	// Catches removal of the post-AlignRequest clampQueryEnd from the gRPC
+	// streaming range handler specifically.
+	synctest.Test(t, func(t *testing.T) {
+		time.Sleep(123 * time.Millisecond)
+
+		rt := &mockRoundTripperWithCapture{
+			rt: mockRoundTripper{
+				responseFn: func() proto.Message {
+					return &tempopb.QueryRangeResponse{
+						Metrics: &tempopb.SearchMetrics{InspectedTraces: 1, InspectedBytes: 1},
+					}
+				},
+			},
+		}
+		cutoff := 30 * time.Second
+		step := time.Hour
+		f := frontendWithSettings(t, rt, nil, nil, nil, func(c *Config, _ *overrides.Config) {
+			c.Metrics.Sharder.Interval = time.Hour
+			c.QueryEndCutoff = cutoff
+			c.Metrics.Sharder.QueryBackendAfter = 1000 * time.Hour
+		})
+
+		now := time.Now()
+		end := now.Add(-cutoff - time.Second)
+		start := end.Add(-2 * time.Hour)
+
+		srv := newMockStreamingServer[*tempopb.QueryRangeResponse]("foo", nil)
+		err := f.MetricsQueryRange(&tempopb.QueryRangeRequest{
+			Query: "{} | rate()",
+			Start: uint64(start.UnixNano()),
+			End:   uint64(end.UnixNano()),
+			Step:  uint64(step),
+		}, srv)
+		require.NoError(t, err)
+		require.NotNil(t, rt.req)
+		maxAllowedEnd := time.Now().Add(-cutoff)
+		assert.LessOrEqual(t, int64(rt.req.End), maxAllowedEnd.UnixNano(),
+			"end was %s; cutoff invariant says end <= now-cutoff (= %s)",
+			time.Unix(0, int64(rt.req.End)), maxAllowedEnd)
+	})
+}
+
+func TestQueryRangeEndCutoffRejectsWindowEntirelyInsideCutoff(t *testing.T) {
+	// A range query whose entire window falls inside QueryEndCutoff
+	// (start > end - cutoff) now returns 400 instead of an empty result from
+	// a silently-inverted window after the clamp pulls end below start.
+	cutoff := 30 * time.Second
+	f := frontendWithSettings(t, &mockRoundTripper{}, nil, nil, nil, func(c *Config, _ *overrides.Config) {
+		c.QueryEndCutoff = cutoff
+		c.Metrics.Sharder.QueryBackendAfter = 15 * time.Minute
+	})
+
+	now := time.Now()
+	httpReq := httptest.NewRequest("GET", api.PathMetricsQueryRange, nil)
+	httpReq = api.BuildQueryRangeRequest(httpReq, &tempopb.QueryRangeRequest{
+		Query: "{} | rate()",
+		Start: uint64(now.Add(-10 * time.Second).UnixNano()), // inside the 30s cutoff
+		End:   uint64(now.UnixNano()),
+		Step:  uint64(time.Second),
+	}, "")
+	httpReq = httpReq.WithContext(user.InjectOrgID(httpReq.Context(), "foo"))
+
+	httpResp := httptest.NewRecorder()
+	f.MetricsQueryRangeHandler.ServeHTTP(httpResp, httpReq)
+	require.Equal(t, http.StatusBadRequest, httpResp.Code, "body: %s", httpResp.Body.String())
+	require.Contains(t, httpResp.Body.String(), "query window falls entirely within query_end_cutoff")
+}
+
+func TestQueryRangeEndCutoffAllowsPartiallyQueryableCoarseStepWindow(t *testing.T) {
+	// Pre-validation clamping must not round end down to a step boundary. With a
+	// coarse step, the left-aligned cutoff can fall before start even though the
+	// raw cutoff leaves part of the requested window queryable.
+	synctest.Test(t, func(t *testing.T) {
+		targetNow := time.Now().Truncate(time.Hour).Add(34 * time.Minute)
+		if !targetNow.After(time.Now()) {
+			targetNow = targetNow.Add(time.Hour)
+		}
+		time.Sleep(time.Until(targetNow))
+
+		rt := &mockRoundTripperWithCapture{
+			rt: mockRoundTripper{
+				responseFn: func() proto.Message {
+					return &tempopb.QueryRangeResponse{
+						Metrics: &tempopb.SearchMetrics{InspectedTraces: 1, InspectedBytes: 1},
+					}
+				},
+			},
+		}
+		cutoff := 30 * time.Second
+		step := time.Hour
+		f := frontendWithSettings(t, rt, nil, nil, nil, func(c *Config, _ *overrides.Config) {
+			c.QueryEndCutoff = cutoff
+			c.Metrics.Sharder.QueryBackendAfter = 1000 * time.Hour
+		})
+
+		now := time.Now()
+		start := now.Truncate(time.Hour).Add(10 * time.Minute)
+		end := now
+
+		httpReq := httptest.NewRequest("GET", api.PathMetricsQueryRange, nil)
+		httpReq = api.BuildQueryRangeRequest(httpReq, &tempopb.QueryRangeRequest{
+			Query: "{} | rate()",
+			Start: uint64(start.UnixNano()),
+			End:   uint64(end.UnixNano()),
+			Step:  uint64(step),
+		}, "")
+		httpReq = httpReq.WithContext(user.InjectOrgID(httpReq.Context(), "foo"))
+
+		httpResp := httptest.NewRecorder()
+		f.MetricsQueryRangeHandler.ServeHTTP(httpResp, httpReq)
+		require.Equal(t, http.StatusOK, httpResp.Code, "body: %s", httpResp.Body.String())
+		require.NotNil(t, rt.req)
+	})
+}
+
+func TestQueryRangeGRPCMaxDurationCheckRespectsEndCutoff(t *testing.T) {
+	// gRPC streaming counterpart of TestQueryRangeMaxDurationCheckRespectsEndCutoff.
+	resp := &tempopb.QueryRangeResponse{
+		Metrics: &tempopb.SearchMetrics{InspectedTraces: 1, InspectedBytes: 1},
+	}
+	f := frontendWithSettings(t, &mockRoundTripper{
+		responseFn: func() proto.Message { return resp },
+	}, nil, nil, nil, func(c *Config, _ *overrides.Config) {
+		c.Metrics.Sharder.Interval = time.Hour
+		c.Metrics.Sharder.MaxDuration = 168 * time.Hour
+		c.QueryEndCutoff = 5 * time.Minute
+	})
+
+	end := time.Now().Add(10 * time.Hour)
+	start := end.Add(-177 * time.Hour)
+
+	srv := newMockStreamingServer[*tempopb.QueryRangeResponse]("foo", nil)
+	err := f.MetricsQueryRange(&tempopb.QueryRangeRequest{
+		Query: "{} | rate()",
+		Start: uint64(start.UnixNano()),
+		End:   uint64(end.UnixNano()),
+		Step:  uint64(time.Hour),
+	}, srv)
+	require.NoError(t, err)
+}
+
+func TestQueryInstantMaxDurationCheckRespectsEndCutoff(t *testing.T) {
+	// Instant HTTP counterpart of the range cutoff test.
+	resp := &tempopb.QueryRangeResponse{
+		Metrics: &tempopb.SearchMetrics{InspectedTraces: 1, InspectedBytes: 1},
+	}
+	f := frontendWithSettings(t, &mockRoundTripper{
+		responseFn: func() proto.Message { return resp },
+	}, nil, nil, nil, func(c *Config, _ *overrides.Config) {
+		c.Metrics.Sharder.MaxDuration = 168 * time.Hour
+		c.QueryEndCutoff = 5 * time.Minute
+	})
+
+	end := time.Now().Add(10 * time.Hour)
+	start := end.Add(-177 * time.Hour)
+
+	httpReq := httptest.NewRequest("GET", api.PathMetricsQueryInstant, nil)
+	httpReq = api.BuildQueryInstantRequest(httpReq, &tempopb.QueryInstantRequest{
+		Query: "{} | rate()",
+		Start: uint64(start.UnixNano()),
+		End:   uint64(end.UnixNano()),
+	})
+	httpReq = httpReq.WithContext(user.InjectOrgID(httpReq.Context(), "foo"))
+
+	httpResp := httptest.NewRecorder()
+	f.MetricsQueryInstantHandler.ServeHTTP(httpResp, httpReq)
+	require.Equal(t, http.StatusOK, httpResp.Code, "body: %s", httpResp.Body.String())
+}
+
+func TestQueryInstantGRPCMaxDurationCheckRespectsEndCutoff(t *testing.T) {
+	// gRPC streaming counterpart of the instant HTTP cutoff test.
+	resp := &tempopb.QueryRangeResponse{
+		Metrics: &tempopb.SearchMetrics{InspectedTraces: 1, InspectedBytes: 1},
+	}
+	f := frontendWithSettings(t, &mockRoundTripper{
+		responseFn: func() proto.Message { return resp },
+	}, nil, nil, nil, func(c *Config, _ *overrides.Config) {
+		c.Metrics.Sharder.MaxDuration = 168 * time.Hour
+		c.QueryEndCutoff = 5 * time.Minute
+	})
+
+	end := time.Now().Add(10 * time.Hour)
+	start := end.Add(-177 * time.Hour)
+
+	srv := newMockStreamingServer[*tempopb.QueryInstantResponse]("foo", nil)
+	err := f.MetricsQueryInstant(&tempopb.QueryInstantRequest{
+		Query: "{} | rate()",
+		Start: uint64(start.UnixNano()),
+		End:   uint64(end.UnixNano()),
+	}, srv)
+	require.NoError(t, err)
+}
+
+func TestQueryInstantMaxDurationCheckClampsFutureEndWithZeroCutoff(t *testing.T) {
+	// This test intentionally leaves the test harness QueryEndCutoff at 0.
+	// Pre-fix, the instant HTTP pipeline
+	// ran adjustEndWareNanos which clamped end to now even with cutoff=0
+	// (via ClampDateRangeReq with endBuffer=0 → maxEnd=now). The new clamp
+	// must preserve that fallback so clock-skewed clients don't fail the cap
+	// on a tiny overshoot.
+	resp := &tempopb.QueryRangeResponse{
+		Metrics: &tempopb.SearchMetrics{InspectedTraces: 1, InspectedBytes: 1},
+	}
+	f := frontendWithSettings(t, &mockRoundTripper{
+		responseFn: func() proto.Message { return resp },
+	}, nil, nil, nil, func(c *Config, _ *overrides.Config) {
+		c.Metrics.Sharder.MaxDuration = 24 * time.Hour
+		// QueryEndCutoff intentionally zero (test helper default; production default is 30s).
+	})
+
+	// Client clock skewed 15s ahead → computes end=now+15s, start=end-24h.
+	// Raw range = 24h, exceeds cap by 15s of skew (server sees start < server_now - 24h + 15s).
+	// Post-clamp end=server_now → range = 24h - 15s, fits.
+	end := time.Now().Add(15 * time.Second)
+	start := end.Add(-24 * time.Hour)
+
+	httpReq := httptest.NewRequest("GET", api.PathMetricsQueryInstant, nil)
+	httpReq = api.BuildQueryInstantRequest(httpReq, &tempopb.QueryInstantRequest{
+		Query: "{} | rate()",
+		Start: uint64(start.UnixNano()),
+		End:   uint64(end.UnixNano()),
+	})
+	httpReq = httpReq.WithContext(user.InjectOrgID(httpReq.Context(), "foo"))
+
+	httpResp := httptest.NewRecorder()
+	f.MetricsQueryInstantHandler.ServeHTTP(httpResp, httpReq)
+	require.Equal(t, http.StatusOK, httpResp.Code, "body: %s", httpResp.Body.String())
+}
+
+func TestQueryRangeMaxDurationCheckUsesUnalignedRange(t *testing.T) {
+	// Cap must be enforced against the user range, not the post-AlignRequest range.
+	const (
+		maxDuration = 200 * time.Second
+		step        = 100 * time.Second
+	)
+
+	tcs := []struct {
+		name     string
+		startNs  uint64
+		endNs    uint64
+		wantCode int
+	}{
+		{
+			name:     "range equals max duration passes",
+			startNs:  uint64(1100 * time.Second),
+			endNs:    uint64(1100*time.Second + maxDuration),
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "range below max duration passes",
+			startNs:  uint64(1100 * time.Second),
+			endNs:    uint64(1100*time.Second + maxDuration - time.Nanosecond),
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "range above max duration rejected",
+			startNs:  uint64(1100 * time.Second),
+			endNs:    uint64(1100*time.Second + maxDuration + time.Nanosecond),
+			wantCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &tempopb.QueryRangeResponse{
+				Metrics: &tempopb.SearchMetrics{InspectedTraces: 1, InspectedBytes: 1},
+			}
+			f := frontendWithSettings(t, &mockRoundTripper{
+				responseFn: func() proto.Message { return resp },
+			}, nil, nil, nil, func(c *Config, oc *overrides.Config) {
+				c.Metrics.Sharder.Interval = time.Hour
+				oc.Defaults.Read.MaxMetricsDuration = model.Duration(maxDuration)
+			})
+
+			httpReq := httptest.NewRequest("GET", api.PathMetricsQueryRange, nil)
+			httpReq = api.BuildQueryRangeRequest(httpReq, &tempopb.QueryRangeRequest{
+				Query: "{} | rate()",
+				Start: tc.startNs,
+				End:   tc.endNs,
+				Step:  uint64(step),
+			}, "")
+			httpReq = httpReq.WithContext(user.InjectOrgID(httpReq.Context(), "foo"))
+
+			httpResp := httptest.NewRecorder()
+			f.MetricsQueryRangeHandler.ServeHTTP(httpResp, httpReq)
+			require.Equal(t, tc.wantCode, httpResp.Code, "body: %s", httpResp.Body.String())
+		})
+	}
+}
+
+func TestQueryRangeGRPCMaxDurationCheckUsesUnalignedRange(t *testing.T) {
+	// Streaming gRPC counterpart of TestQueryRangeMaxDurationCheckUsesUnalignedRange.
+	const (
+		maxDuration = 200 * time.Second
+		step        = 100 * time.Second
+	)
+
+	tcs := []struct {
+		name    string
+		startNs uint64
+		endNs   uint64
+		wantErr bool
+	}{
+		{
+			name:    "range equals max duration passes",
+			startNs: uint64(1100 * time.Second),
+			endNs:   uint64(1100*time.Second + maxDuration),
+			wantErr: false,
+		},
+		{
+			name:    "range above max duration rejected",
+			startNs: uint64(1100 * time.Second),
+			endNs:   uint64(1100*time.Second + maxDuration + time.Nanosecond),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &tempopb.QueryRangeResponse{
+				Metrics: &tempopb.SearchMetrics{InspectedTraces: 1, InspectedBytes: 1},
+			}
+			f := frontendWithSettings(t, &mockRoundTripper{
+				responseFn: func() proto.Message { return resp },
+			}, nil, nil, nil, func(c *Config, oc *overrides.Config) {
+				c.Metrics.Sharder.Interval = time.Hour
+				oc.Defaults.Read.MaxMetricsDuration = model.Duration(maxDuration)
+			})
+
+			srv := newMockStreamingServer[*tempopb.QueryRangeResponse]("foo", nil)
+			err := f.MetricsQueryRange(&tempopb.QueryRangeRequest{
+				Query: "{} | rate()",
+				Start: tc.startNs,
+				End:   tc.endNs,
+				Step:  uint64(step),
+			}, srv)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Equal(t, codes.InvalidArgument, status.Code(err))
+				require.Contains(t, err.Error(), "exceeds the maximum allowed duration")
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/modules/frontend/metrics_query_range_sharder.go
+++ b/modules/frontend/metrics_query_range_sharder.go
@@ -3,7 +3,6 @@ package frontend
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math"
 	"net/http"
 	"time"
@@ -107,15 +106,6 @@ func (s queryRangeSharder) RoundTrip(pipelineRequest pipeline.Request) (pipeline
 
 	if req.Step == 0 {
 		return pipeline.NewBadRequest(errors.New("step must be greater than 0")), nil
-	}
-
-	// calculate and enforce max search duration
-	// This is checked before alignment because we may need to read a larger
-	// range internally to satisfy the query.
-	maxDuration := s.maxDuration(tenantID)
-	if maxDuration != 0 && time.Duration(req.End-req.Start)*time.Nanosecond > maxDuration {
-		err = fmt.Errorf("metrics query time range exceeds the maximum allowed duration of %s", maxDuration)
-		return pipeline.NewBadRequest(err), nil
 	}
 
 	traceql.AlignRequest(req)
@@ -361,17 +351,6 @@ func (s *queryRangeSharder) generatorRequest(tenantID string, parent pipeline.Re
 	subR.SetResponseData(0) // generator requests are always shard 0
 
 	return subR, jobMetadata
-}
-
-// maxDuration returns the max search duration allowed for this tenant.
-func (s *queryRangeSharder) maxDuration(tenantID string) time.Duration {
-	// check overrides first, if no overrides then grab from our config
-	maxDuration := s.overrides.MaxMetricsDuration(tenantID)
-	if maxDuration != 0 {
-		return maxDuration
-	}
-
-	return s.cfg.MaxDuration
 }
 
 func (s *queryRangeSharder) jobSize(expr *traceql.RootExpr, allowUnsafe bool) int {

--- a/modules/frontend/metrics_query_validation.go
+++ b/modules/frontend/metrics_query_validation.go
@@ -1,0 +1,53 @@
+package frontend
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/grafana/dskit/user"
+	"github.com/grafana/tempo/modules/overrides"
+	"github.com/grafana/tempo/pkg/tempopb"
+)
+
+// validateQueryRangeReq must run before traceql.AlignRequest, which inflates
+// the range by up to ~3*step and would cause valid requests to fail the cap.
+func validateQueryRangeReq(ctx context.Context, cfg Config, o overrides.Interface, req *tempopb.QueryRangeRequest) error {
+	if req.Start > req.End {
+		return errors.New("end must be greater than start")
+	}
+	if err := validateMetricsQueryMaxDuration(ctx, o, cfg.Metrics.Sharder.MaxDuration, req); err != nil {
+		return err
+	}
+	if cfg.Metrics.MaxIntervals != 0 && (req.Step == 0 || (req.End-req.Start)/req.Step > cfg.Metrics.MaxIntervals) {
+		minimumStep := (req.End - req.Start) / cfg.Metrics.MaxIntervals
+		return fmt.Errorf(
+			"step of %s is too small, minimum step for given range is %s",
+			time.Duration(req.Step).String(),
+			time.Duration(minimumStep).String(),
+		)
+	}
+	return nil
+}
+
+func validateMetricsQueryMaxDuration(ctx context.Context, o overrides.Interface, defaultMaxDuration time.Duration, req *tempopb.QueryRangeRequest) error {
+	tenantID, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		return err
+	}
+	maxDuration := defaultMaxDuration
+	if override := o.MaxMetricsDuration(tenantID); override != 0 {
+		maxDuration = override
+	}
+	if maxDuration == 0 {
+		return nil
+	}
+	// Negative cap: fail closed (matches prior sharder behavior).
+	// Unsigned compare: time.Duration is int64; a range > math.MaxInt64 ns
+	// would otherwise wrap negative and silently bypass the cap.
+	if maxDuration < 0 || req.End-req.Start > uint64(maxDuration) {
+		return fmt.Errorf("metrics query time range exceeds the maximum allowed duration of %s", maxDuration)
+	}
+	return nil
+}

--- a/modules/frontend/metrics_query_validation_test.go
+++ b/modules/frontend/metrics_query_validation_test.go
@@ -1,0 +1,125 @@
+package frontend
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/grafana/dskit/user"
+	"github.com/grafana/tempo/modules/overrides"
+	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/stretchr/testify/require"
+)
+
+// mockOverridesMaxMetricsDuration satisfies overrides.Interface for the
+// purpose of validateMetricsQueryMaxDuration tests. Embedding the interface
+// means any method other than MaxMetricsDuration will panic if called — the
+// tests below never trigger that.
+type mockOverridesMaxMetricsDuration struct {
+	overrides.Interface
+	perTenant map[string]time.Duration
+}
+
+func (m *mockOverridesMaxMetricsDuration) MaxMetricsDuration(userID string) time.Duration {
+	return m.perTenant[userID]
+}
+
+func TestValidateMetricsQueryMaxDuration(t *testing.T) {
+	tcs := []struct {
+		name      string
+		perTenant map[string]time.Duration
+		fallback  time.Duration
+		rangeDur  time.Duration
+		wantErr   bool
+	}{
+		{
+			name:      "override below range rejects",
+			perTenant: map[string]time.Duration{"foo": 24 * time.Hour},
+			rangeDur:  25 * time.Hour,
+			wantErr:   true,
+		},
+		{
+			name:      "override above range accepts",
+			perTenant: map[string]time.Duration{"foo": 48 * time.Hour},
+			rangeDur:  24 * time.Hour,
+			wantErr:   false,
+		},
+		{
+			name:     "fallback applies when tenant has no override",
+			fallback: 24 * time.Hour,
+			rangeDur: 25 * time.Hour,
+			wantErr:  true,
+		},
+		{
+			name:     "no override, no fallback -> unlimited",
+			rangeDur: 10 * 24 * time.Hour,
+			wantErr:  false,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := user.InjectOrgID(context.Background(), "foo")
+			req := &tempopb.QueryRangeRequest{
+				Start: uint64(1 * time.Hour),
+				End:   uint64(1*time.Hour + tc.rangeDur),
+			}
+			o := &mockOverridesMaxMetricsDuration{perTenant: tc.perTenant}
+
+			err := validateMetricsQueryMaxDuration(ctx, o, tc.fallback, req)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateMetricsQueryMaxDuration_NegativeCapFailsClosed(t *testing.T) {
+	// A negative max_metrics_duration is a misconfiguration. The prior sharder
+	// check failed closed (every query rejected) because `positive > -1s` is
+	// always true. The unsigned comparison must preserve that semantic instead
+	// of silently bypassing the cap via uint64 underflow wraparound.
+	tcs := []struct {
+		name      string
+		perTenant map[string]time.Duration
+		fallback  time.Duration
+	}{
+		{
+			name:      "per-tenant override is negative",
+			perTenant: map[string]time.Duration{"foo": -1 * time.Second},
+		},
+		{
+			name:     "config fallback is negative, no override",
+			fallback: -1 * time.Second,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := user.InjectOrgID(context.Background(), "foo")
+			o := &mockOverridesMaxMetricsDuration{perTenant: tc.perTenant}
+			req := &tempopb.QueryRangeRequest{
+				Start: uint64(1 * time.Hour),
+				End:   uint64(2 * time.Hour),
+			}
+			err := validateMetricsQueryMaxDuration(ctx, o, tc.fallback, req)
+			require.Error(t, err, "negative cap must fail closed, not silently bypass")
+		})
+	}
+}
+
+func TestValidateMetricsQueryMaxDuration_OverflowSafe(t *testing.T) {
+	// A range whose nanosecond delta exceeds math.MaxInt64 must not wrap to a
+	// negative time.Duration and silently bypass the cap.
+	ctx := user.InjectOrgID(context.Background(), "foo")
+	o := &mockOverridesMaxMetricsDuration{perTenant: map[string]time.Duration{"foo": time.Hour}}
+
+	req := &tempopb.QueryRangeRequest{
+		Start: 0,
+		End:   uint64(math.MaxInt64) + 1, // overflows int64 when cast directly
+	}
+	err := validateMetricsQueryMaxDuration(ctx, o, 0, req)
+	require.Error(t, err, "huge range must be rejected, not silently bypassed via overflow")
+}


### PR DESCRIPTION
AlignRequest inflates the range by up to ~3 steps before reaching the
sharder, causing the cap check to reject valid requests within the
configured limit. Moves the check into the metrics handlers (HTTP and
gRPC, range and instant), before alignment.

Cap is enforced against the effective range: QueryEndCutoff is applied
inline before validation so requests with end-in-future (clock skew)
that would post-clamp fit the cap are no longer rejected. Negative
caps fail closed; comparison uses unsigned arithmetic to avoid
wraparound.