### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,27 @@ Before reviewing code, read [`.agents/guidance/code-review.md`](.agents/guidance
 ## Pre-Commit Checklist
 
 Before pushing or opening a PR, read [`.agents/guidance/precommit.md`](.agents/guidance/precommit.md).
+
+## Cursor Cloud specific instructions
+
+### Environment
+
+The VM has Go 1.26.2, golangci-lint v2.11.3, gotestsum, and jsonnetfmt pre-installed. Dependencies are vendored.
+
+### Build, Test, Lint
+
+See `make help` for all targets. Key commands:
+
+- `make tempo` — build the tempo binary to `./bin/linux/tempo-amd64`
+- `make test` — run unit tests (uses gotestsum)
+- `golangci-lint run --config .golangci.yml` — lint locally (the `make lint` target uses Docker)
+
+### Running Tempo locally
+
+Create `/var/tempo` (writable by agent user) and use a config file with `backend: local`. Example config at `example/docker-compose/single-binary/tempo.yaml` (adjust listen addresses to `0.0.0.0`). The binary accepts `-config.file=<path>`.
+
+### Gotchas
+
+- Docker is not available. Targets that use Docker (e.g., `make fmt`, `make lint`, `make test-e2e`, `make jsonnet`) will fail. Run `golangci-lint` and `gofumpt`/`goimports` directly instead.
+- Some `./modules/` tests (Kafka-related) require a running Kafka broker and will fail without Docker. These are infrastructure-dependent, not code bugs.
+- The `make test` target uses `gotestsum` — make sure it's installed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to AGENTS.md with:

- Environment details (Go 1.26.2, golangci-lint v2.11.3, gotestsum, jsonnetfmt)
- Key build/test/lint commands (referencing existing Makefile docs)
- How to run Tempo locally with a minimal config
- Gotchas: Docker unavailability (affecting `make lint`, `make fmt`, e2e tests), Kafka-dependent test failures without Docker
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f15d794b-c2a8-466c-a860-9899566d8ad6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f15d794b-c2a8-466c-a860-9899566d8ad6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

