### PR TITLE
[DOCs] Missing docs for 3.0 release 

### DIFF
--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -191,7 +191,24 @@ server:
     # Allow clients to send pings even when there are no active streams.
     # Tempo enables this by default to prevent GOAWAY errors during idle periods.
     [grpc_server_ping_without_stream_allowed: <bool> | default = true]
+
+    # Size of the read buffer for each gRPC connection (bytes).
+    # A smaller buffer may reduce memory usage but may lead to more system calls.
+    [grpc_server_read_buffer_size: <int> | default = 32768]
+
+    # Size of the write buffer for each gRPC connection (bytes).
+    # A smaller buffer may reduce memory usage but may lead to more system calls.
+    [grpc_server_write_buffer_size: <int> | default = 32768]
 ```
+
+### Internal server
+
+Tempo can expose a separate HTTP server for internal endpoints (health checks, metrics, readiness) on a dedicated port.
+This keeps internal traffic isolated from the public API.
+The `internal_server` block accepts the same fields as `server` but defaults to port `3101` with instrumentation disabled.
+The internal server is disabled by default; set `internal_server.enable: true` to activate it.
+
+For the full list of `internal_server` options, refer to the [manifest](/docs/tempo/<TEMPO_VERSION>/configuration/manifest/).
 
 ## Memory
 
@@ -1866,6 +1883,11 @@ memberlist:
     # is not needed.
     [rejoin_interval: <duration> | default = 0s]
 
+    # Seed nodes to use for periodic rejoin. Takes precedence over join_members
+    # for rejoining. If not specified, join_members is used.
+    # Supports IP, hostname, or DNS Service Discovery format.
+    [rejoin_seed_nodes: <string> | default = ""]
+
     # Timeout for leaving memberlist cluster.
     [leave_timeout: <duration> | default = 20s]
 
@@ -1899,6 +1921,21 @@ memberlist:
 
     # Timeout for writing 'packet' data.
     [packet_write_timeout: <duration> | default = 5s]
+
+    # Experimental. Tracks how long gossip updates take to propagate across the cluster.
+    propagation_delay_tracker:
+        # Enable the propagation delay tracker.
+        [enabled: <bool> | default = false]
+
+        # How often to publish beacon messages for propagation measurement.
+        [beacon_interval: <duration> | default = 1m]
+
+        # How long a beacon lives before being garbage collected.
+        [beacon_lifetime: <duration> | default = 10m]
+
+        # Log a warning when beacon propagation delay exceeds this threshold.
+        # 0 disables logging.
+        [log_beacons_latency_longer_than: <duration> | default = 0s]
 
 ```
 

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -403,6 +403,9 @@ Any key or values that exceed the configured limit are truncated before storing.
 The default value is `2048`.
 
 Use the `tempo_distributor_attributes_truncated_total` metric to track how many attributes are truncated.
+This metric includes `tenant` and `scope` labels, where `scope` is one of `resource`, `scope`, `span`, `event`, or `link`.
+
+When truncation occurs, the distributor also emits a rate-limited log line (at most one per second) with diagnostic details including the tenant, total truncated count, configured limit, and an example of the first truncated attribute (scope, name, field, and original size).
 
 For additional information, refer to [Troubleshoot out-of-memory errors](https://grafana.com/docs/tempo/<TEMPO_VERSION>/troubleshooting/out-of-memory-errors/).
 

--- a/docs/sources/tempo/metrics-from-traces/service_graphs/_index.md
+++ b/docs/sources/tempo/metrics-from-traces/service_graphs/_index.md
@@ -92,6 +92,8 @@ Possible values for `connection_type`: unset, `virtual_node`, `messaging_system`
 
 You can include additional labels using the `dimensions` configuration option or the `enable_virtual_node_label` option.
 
+Duplicate dimensions are allowed after Prometheus label name conversion. This supports environments where different instrumentation libraries use different attribute naming conventions, for example, `deployment.environment` and `deployment_environment`. When a collision occurs, the last configured value wins.
+
 Since the service graph processor has to process both sides of an edge,
 it needs to process all spans of a trace to function properly.
 If spans of a trace spread across multiple instances, the processor can't pair them reliably.

--- a/docs/sources/tempo/metrics-from-traces/span-metrics/span-metrics-metrics-generator.md
+++ b/docs/sources/tempo/metrics-from-traces/span-metrics/span-metrics-metrics-generator.md
@@ -130,6 +130,12 @@ metrics_generator:
 Additional user defined labels can be created using the [`dimensions` configuration option](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration#metrics-generator).
 When a configured dimension collides with one of the default labels (for example, `status_code`), the label for the respective dimension is prefixed with double underscore (for example, `__status_code`).
 
+Duplicate dimensions are allowed after Prometheus label name conversion. This supports environments where different instrumentation libraries use different attribute naming conventions. For example, you can configure both `deployment.environment` and `deployment_environment` in the `dimensions` list even though both convert to the same Prometheus label `deployment_environment`. When a collision occurs, the last configured value wins.
+
+{{< admonition type="note" >}}
+Duplicate dimension validation still applies to `dimension_mappings`. If a `dimension_mapping` produces a label that collides with an existing dimension or another mapping, the configuration is rejected.
+{{< /admonition >}}
+
 ### Renaming dimensions with dimension_mappings
 
 Custom labeling of dimensions is also supported using the [`dimension_mappings` configuration option](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration#metrics-generator).
@@ -362,6 +368,19 @@ metrics_generator:
 ```
 
 In the above, we want to capture metrics for all production spans in the EU, but we also want to explicitly allow INTERNAL spans from the auth-service, which would otherwise be ignored by the include filter.
+
+#### Validation
+
+Tempo validates filter policies when they're submitted through the [user-configurable overrides API](/docs/tempo/<TEMPO_VERSION>/operations/manage-advanced-systems/user-configurable-overrides/) and rejects invalid configurations. The validation checks:
+
+- Each policy has at least one `include`, `include_any`, or `exclude` block.
+- The `match_type` is `strict` or `regex`.
+- Attribute keys are valid TraceQL identifiers.
+- Only `resource` and `span` scopes are supported. Other scopes such as `event`, `link`, or `instrumentation` are rejected.
+- Regex patterns compile successfully.
+- Intrinsic values are valid: `kind` must be a recognized `SPAN_KIND_*` value, `status` must be a recognized `STATUS_CODE_*` value.
+
+If you're upgrading from Tempo 2.x, refer to [Stricter filter policy validation](/docs/tempo/<TEMPO_VERSION>/release-notes/v3-0/#stricter-filter-policy-validation) in the 3.0 release notes for details on how this affects existing configurations.
 
 ## Example
 

--- a/docs/sources/tempo/operations/manage-advanced-systems/user-configurable-overrides.md
+++ b/docs/sources/tempo/operations/manage-advanced-systems/user-configurable-overrides.md
@@ -125,6 +125,12 @@ metrics_generator:
       [metric_name: <string>]
 ```
 
+### Filter policy validation
+
+Filter policies submitted through this API are fully validated. Tempo checks that attribute keys are valid TraceQL identifiers, only `resource` and `span` scopes are supported, regular expression patterns compile, and intrinsic values (`kind`, `status`) use recognized values. Invalid policies are rejected with a descriptive error.
+
+For the complete list of validation rules and supported values, refer to [Filtering](/docs/tempo/<TEMPO_VERSION>/metrics-from-traces/span-metrics/span-metrics-metrics-generator/#filtering).
+
 ## API
 
 All API requests are handled on the `/api/overrides` endpoint. The module supports `GET`, `POST`, `PATCH`, and `DELETE`

--- a/docs/sources/tempo/reference-tempo-architecture/components/block-builder.md
+++ b/docs/sources/tempo/reference-tempo-architecture/components/block-builder.md
@@ -40,6 +40,14 @@ Blocks are written in Apache Parquet format and contain the span data (`data.par
 block metadata (`meta.json`) including time range, tenant, and a `replaces` field for atomic block replacement,
 as well as bloom filters and indexes for efficient querying.
 
+### Span deduplication
+
+During block creation, the block-builder deduplicates spans within each trace.
+Because the block-builder rewinds to the last committed Kafka offset on each cycle, replicated or re-consumed records can produce duplicate spans.
+The block-builder identifies duplicates using a combination of span ID and span kind, and removes them before writing the block.
+
+Use the `tempo_block_builder_spans_deduped_total` metric (labeled by `tenant`) to track how many duplicate spans are removed.
+
 ### Deterministic block IDs
 
 The block-builder generates block IDs deterministically based on the partition, tenant, and Kafka offset range.
@@ -103,6 +111,7 @@ Size the scratch disk to hold at least one full consumption cycle's worth of dat
 | Metric | Description |
 |---|---|
 | `tempo_block_builder_flushed_blocks` | Number of blocks flushed to object storage |
+| `tempo_block_builder_spans_deduped_total` | Duplicate spans removed during block creation, by tenant |
 | `tempo_block_builder_fetch_errors_total` | Kafka fetch errors encountered |
 | `tempo_ingest_group_partition_lag{group="block-builder"}` | Consumer lag per partition |
 

--- a/docs/sources/tempo/release-notes/v3-0.md
+++ b/docs/sources/tempo/release-notes/v3-0.md
@@ -253,6 +253,12 @@ Refer to [Deployment modes](/docs/tempo/<TEMPO_VERSION>/reference-tempo-architec
 - Read configuration consolidated: `query_frontend.search.query_ingesters_until` is removed in favor of `query_frontend.search.query_backend_after`. [[PR 6507](https://github.com/grafana/tempo/pull/6507)]
 - Legacy overrides disabled: Tempo refuses to start if legacy (flat, non-scoped) overrides are detected. Use `tempo-cli migrate overrides-config` to convert them. Set `enable_legacy_overrides: true` to opt back in temporarily. Refer to the [Migrate from Tempo 2.x to 3.0](/docs/tempo/<TEMPO_VERSION>/set-up-for-tracing/setup-tempo/migrate-to-3/) guide for details. [[PR 6741](https://github.com/grafana/tempo/pull/6741)]
 
+### Stricter filter policy validation
+
+Filter policies submitted through the [user-configurable overrides API](/docs/tempo/<TEMPO_VERSION>/operations/manage-advanced-systems/user-configurable-overrides/) are now fully validated. Previously, invalid policies (for example, unsupported attribute scopes, malformed regular expressions, or unrecognized intrinsic values) were silently accepted. In Tempo 3.0, the API rejects them with a descriptive error.
+
+If you have existing filter policies, verify they use only `resource` and `span` scopes, valid `match_type` values (`strict` or `regex`), and recognized intrinsic values for `kind` and `status`. Refer to [Filtering](/docs/tempo/<TEMPO_VERSION>/metrics-from-traces/span-metrics/span-metrics-metrics-generator/#filtering) for the complete validation rules. [[PR 6407](https://github.com/grafana/tempo/pull/6407)]
+
 ### TraceQL array matching changes
 
 The TraceQL AST optimization changes the semantics of `!=` and `!~` operators when used with array attributes. `!=` now means `NOT IN` (was `CONTAINS NOT EQUAL`) and `!~` now means `MATCH NONE` (was `CONTAINS NON-MATCH`). Regex operands must be of type string or string array. Disable the optimization with the query hint `skip_optimization=true` if needed. [[PR 6353](https://github.com/grafana/tempo/pull/6353)]

--- a/docs/sources/tempo/release-notes/v3-0.md
+++ b/docs/sources/tempo/release-notes/v3-0.md
@@ -194,14 +194,14 @@ Refer to [TraceQL array matching changes](#traceql-array-matching-changes) in th
 
 The most important features and enhancements in Tempo 3.0 are highlighted below.
 
-- Added `automemlimit` support for automatic GOMEMLIMIT configuration. Enable with `memory.automemlimit_enabled: true`. Refer to [Configuration](/docs/tempo/<TEMPO_VERSION>/configuration/) for details. [[PR 6313](https://github.com/grafana/tempo/pull/6313)]
+- Added `automemlimit` support for automatic GOMEMLIMIT configuration. Enable with `memory.automemlimit_enabled: true`. Refer to [Configuration](/docs/tempo/<TEMPO_VERSION>/configuration/#memory) for details. [[PR 6313](https://github.com/grafana/tempo/pull/6313)]
 - Added KEDA-based horizontal Pod autoscaling support for microservices deployment in Jsonnet. [[PR 6970](https://github.com/grafana/tempo/pull/6970)]
 - Enabled native histogram emission for all `promauto`-registered histograms, including `tempo_request_duration_seconds`. Both classic and native formats are emitted simultaneously; existing scrapers are unaffected. [[PR 6910](https://github.com/grafana/tempo/pull/6910)]
 - Added an extension mechanism for per-tenant overrides. Refer to [User-configurable overrides](/docs/tempo/<TEMPO_VERSION>/operations/manage-advanced-systems/user-configurable-overrides/) for details. [[PR 6758](https://github.com/grafana/tempo/pull/6758)]
-- Added support for per-tenant left-padding of trace IDs. Refer to [Configuration](/docs/tempo/<TEMPO_VERSION>/configuration/) for the `left_pad_trace_ids` parameter. [[PR 6489](https://github.com/grafana/tempo/pull/6489)]
-- Improved attribute truncating observability and logging of truncated oversized attributes. (PRs [#6400](https://github.com/grafana/tempo/pull/6400), [#6467](https://github.com/grafana/tempo/pull/6467))
-- Exposed MinIO retry settings via S3 configuration. Refer to [Configuration](/docs/tempo/<TEMPO_VERSION>/configuration/) for the `retry_max_attempts`, `retry_backoff_initial`, and `retry_backoff_max` parameters. [[PR 6561](https://github.com/grafana/tempo/pull/6561)]
-- Block builder now deduplicates spans within traces during block creation. Removed duplicates are tracked via the `tempo_block_builder_spans_deduped_total` metric. [[PR 6539](https://github.com/grafana/tempo/pull/6539)]
+- Added support for per-tenant left-padding of trace IDs. Refer to [Configuration](/docs/tempo/<TEMPO_VERSION>/configuration/#overrides) for the `left_pad_trace_ids` parameter. [[PR 6489](https://github.com/grafana/tempo/pull/6489)]
+- Improved attribute truncating observability with per-scope metric labels and rate-limited diagnostic logging. Refer to [Set max attribute size](/docs/tempo/<TEMPO_VERSION>/configuration/#set-max-attribute-size-to-help-control-out-of-memory-errors) for details. (PRs [#6400](https://github.com/grafana/tempo/pull/6400), [#6467](https://github.com/grafana/tempo/pull/6467))
+- Exposed MinIO retry settings via S3 configuration. Refer to [Configuration](/docs/tempo/<TEMPO_VERSION>/configuration/#storage) for the `retry_max_attempts`, `retry_backoff_initial`, and `retry_backoff_max` parameters. [[PR 6561](https://github.com/grafana/tempo/pull/6561)]
+- Block builder now deduplicates spans within traces during block creation. Removed duplicates are tracked via the `tempo_block_builder_spans_deduped_total` metric. Refer to [Block-builder](/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/block-builder/#span-deduplication) for details. [[PR 6539](https://github.com/grafana/tempo/pull/6539)]
 - Added `--header` flag to `query api` commands for passing custom headers. Refer to the [Tempo CLI documentation](/docs/tempo/<TEMPO_VERSION>/operations/tempo_cli/#query-api-command) for usage details. [[PR 6768](https://github.com/grafana/tempo/pull/6768)]
 
 ## Upgrade considerations

--- a/docs/sources/tempo/release-notes/v3-0.md
+++ b/docs/sources/tempo/release-notes/v3-0.md
@@ -261,6 +261,10 @@ The TraceQL AST optimization changes the semantics of `!=` and `!~` operators wh
 
 The `query search` command no longer accepts timestamps without timezone (for example, `2024-01-01T00:00:00`). Use RFC3339 format (for example, `2024-01-01T00:00:00Z`) or relative time (for example, `now-1h`). Refer to the [Tempo CLI documentation](/docs/tempo/<TEMPO_VERSION>/operations/tempo_cli/) for details. [[PR 6458](https://github.com/grafana/tempo/pull/6458)]
 
+### Platform changes
+
+The 32-bit ARM binary archives are no longer published. Release artifacts continue to include amd64 and arm64 binaries. If you run Tempo on 32-bit ARM hardware, you need to build from source or migrate to arm64. [[PR 7106](https://github.com/grafana/tempo/pull/7106)]
+
 ### Go version upgrade
 
 Tempo 3.0 upgrades to Go 1.26.2. [[PR 6443](https://github.com/grafana/tempo/pull/6443)]
@@ -276,6 +280,8 @@ Tempo 3.0 upgrades to Go 1.26.2. [[PR 6443](https://github.com/grafana/tempo/pul
 
 For a complete list, refer to the [Tempo CHANGELOG](https://github.com/grafana/tempo/releases).
 
+- Fixed panic in livestore search when iterating blocks encounters an unexpected error. [[PR 7134](https://github.com/grafana/tempo/pull/7134)]
+- Fixed panic in old tag-style search when querying integer dedicated columns on vParquet5 blocks. [[PR 7135](https://github.com/grafana/tempo/pull/7135)]
 - Fixed incorrect search results for some queries on blob columns. [[PR 6815](https://github.com/grafana/tempo/pull/6815)]
 - Fixed active-series counter underflow in local series limiter when overflow series are deleted. [[PR 6568](https://github.com/grafana/tempo/pull/6568)]
 - Fixed per-label limiter and sanitizer being incorrectly applied to `target_info` and `host_info` metrics. [[PR 6660](https://github.com/grafana/tempo/pull/6660)]

--- a/docs/sources/tempo/troubleshooting/out-of-memory-errors.md
+++ b/docs/sources/tempo/troubleshooting/out-of-memory-errors.md
@@ -18,6 +18,10 @@ To avoid these out-of-memory crashes, use `max_attribute_bytes` to limit the max
 Any key or values that exceed the configured limit are truncated before storing.
 
 Use the `tempo_distributor_attributes_truncated_total` metric to track how many attributes are truncated.
+This metric includes `tenant` and `scope` labels, where `scope` is one of `resource`, `scope`, `span`, `event`, or `link`.
+Use the `scope` label to identify which part of your trace data produces the most oversized attributes.
+
+When truncation occurs, the distributor also emits a rate-limited log line (at most one per second) with an example of the truncated attribute, including its scope, name, whether the key or value was truncated, and the original size in bytes.
 
 ```yaml
    # Optional


### PR DESCRIPTION
**What this PR does**:

Add missing docs from the Tempo 3.0 release notes: 

* #7096 
* [Update release notes for two bug fixes](https://github.com/grafana/tempo/commit/ece16d2e024964d19b622b99f53dd644b39c9977)
* #6400 
* #6467 
* #6539 
* #6407 
* #6288 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`