### PR TITLE
integration/storage: fan tests out per backend via CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,15 +146,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-target:
-          [
-            test-e2e-operations,
-            test-e2e-api,
-            test-e2e-limits,
-            test-e2e-metrics-generator,
-            test-e2e-storage,
-            test-e2e-util,
-          ]
+        # test-e2e-storage is fanned out per backend onto separate runners. Each runner gets a
+        # clean docker host so the timing-sensitive backend-scheduler tests don't have to share
+        # resources with the other backends' microservice stacks. The 'local' entry covers tests
+        # that use the local filesystem backend (TestEncodings). TEMPO_E2E_BACKENDS is
+        # authoritative — tests whose declared Backends don't intersect the matrix value are
+        # skipped on this runner and run on a different matrix entry.
+        # All other targets run once with no backend axis.
+        include:
+          - test-target: test-e2e-operations
+          - test-target: test-e2e-api
+          - test-target: test-e2e-limits
+          - test-target: test-e2e-metrics-generator
+          - test-target: test-e2e-util
+          - test-target: test-e2e-storage
+            backend: local
+          - test-target: test-e2e-storage
+            backend: s3
+          - test-target: test-e2e-storage
+            backend: azure
+          - test-target: test-e2e-storage
+            backend: gcs
 
     steps:
       - name: Check out code
@@ -168,6 +180,10 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: Run Tests
+        env:
+          # Only set for the storage matrix entries; empty for everything else so the harness
+          # falls back to the test's declared Backends.
+          TEMPO_E2E_BACKENDS: ${{ matrix.backend }}
         run: make ${{ matrix.test-target }}
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,9 +181,10 @@ jobs:
           go-version-file: 'go.mod'
       - name: Run Tests
         env:
-          # Only set for the storage matrix entries; empty for everything else so the harness
-          # falls back to the test's declared Backends.
-          TEMPO_E2E_BACKENDS: ${{ matrix.backend }}
+          # Only the storage matrix entries set `backend`; for everything else `matrix.backend` is
+          # undefined and the `|| ''` fallback makes the empty-string default explicit, so the
+          # harness sees TEMPO_E2E_BACKENDS="" and falls back to each test's declared Backends.
+          TEMPO_E2E_BACKENDS: ${{ matrix.backend || '' }}
         run: make ${{ matrix.test-target }}
 
   build:

--- a/integration/util/harness.go
+++ b/integration/util/harness.go
@@ -201,7 +201,9 @@ type backendTestCase struct {
 }
 
 // parseBackendsEnv parses a comma-separated list of backend names ("s3", "azure", "gcs", "local")
-// into a BackendsMask. Used to honor the TEMPO_E2E_BACKENDS env var.
+// into a BackendsMask. Used to honor the TEMPO_E2E_BACKENDS env var. Returns an error if the
+// input contains no valid backend names — a silent zero mask would otherwise make the harness
+// skip every test and let CI look green while running nothing.
 func parseBackendsEnv(env string) (BackendsMask, error) {
 	var mask BackendsMask
 	for _, raw := range strings.Split(env, ",") {
@@ -219,6 +221,9 @@ func parseBackendsEnv(env string) (BackendsMask, error) {
 		default:
 			return 0, fmt.Errorf("unknown backend %q (expected s3|azure|gcs|local)", raw)
 		}
+	}
+	if mask == 0 {
+		return 0, fmt.Errorf("no valid backends in %q (expected s3|azure|gcs|local)", env)
 	}
 	return mask, nil
 }

--- a/integration/util/harness.go
+++ b/integration/util/harness.go
@@ -172,6 +172,20 @@ func RunIntegrationTests(t *testing.T, config TestHarnessConfig, testFunc func(*
 		config.Components = ComponentsRecentDataQuerying
 	}
 
+	// Optional CI override: TEMPO_E2E_BACKENDS lets the workflow fan a single test target out
+	// over a matrix of backends (one runner each), which avoids running multiple docker stacks
+	// concurrently on the same host. The variable is a comma-separated list of backend names:
+	// "s3", "azure", "gcs", "local". The mask is authoritative — a test that doesn't intersect
+	// the mask is skipped on this runner and is expected to run on a different matrix entry.
+	if env := os.Getenv("TEMPO_E2E_BACKENDS"); env != "" {
+		mask, err := parseBackendsEnv(env)
+		require.NoError(t, err, "invalid TEMPO_E2E_BACKENDS")
+		config.Backends &= mask
+		if config.Backends == 0 {
+			t.Skipf("no requested backend matches TEMPO_E2E_BACKENDS=%q", env)
+		}
+	}
+
 	backendTCs := backendTestCases(config.Backends)
 
 	// Run tests for each deployment mode and backend combination
@@ -184,6 +198,29 @@ func RunIntegrationTests(t *testing.T, config TestHarnessConfig, testFunc func(*
 type backendTestCase struct {
 	mask BackendsMask
 	name string
+}
+
+// parseBackendsEnv parses a comma-separated list of backend names ("s3", "azure", "gcs", "local")
+// into a BackendsMask. Used to honor the TEMPO_E2E_BACKENDS env var.
+func parseBackendsEnv(env string) (BackendsMask, error) {
+	var mask BackendsMask
+	for _, raw := range strings.Split(env, ",") {
+		switch strings.ToLower(strings.TrimSpace(raw)) {
+		case "":
+			continue
+		case "s3":
+			mask |= BackendObjectStorageS3
+		case "azure":
+			mask |= BackendObjectStorageAzure
+		case "gcs":
+			mask |= BackendObjectStorageGCS
+		case "local":
+			mask |= BackendLocal
+		default:
+			return 0, fmt.Errorf("unknown backend %q (expected s3|azure|gcs|local)", raw)
+		}
+	}
+	return mask, nil
 }
 
 // backendTestCases returns the list of backends to test based on the config

--- a/integration/util/harness_test.go
+++ b/integration/util/harness_test.go
@@ -4,7 +4,37 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestParseBackendsEnv(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    BackendsMask
+		wantErr bool
+	}{
+		{"single s3", "s3", BackendObjectStorageS3, false},
+		{"single azure", "azure", BackendObjectStorageAzure, false},
+		{"single gcs", "gcs", BackendObjectStorageGCS, false},
+		{"single local", "local", BackendLocal, false},
+		{"multi comma", "s3,azure", BackendObjectStorageS3 | BackendObjectStorageAzure, false},
+		{"whitespace and case", " S3 , Azure ", BackendObjectStorageS3 | BackendObjectStorageAzure, false},
+		{"empty entries ignored", "s3,,gcs", BackendObjectStorageS3 | BackendObjectStorageGCS, false},
+		{"unknown errors", "s3,foo", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseBackendsEnv(tt.in)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
 
 func TestMergeMaps(t *testing.T) {
 	base := map[any]any{

--- a/integration/util/harness_test.go
+++ b/integration/util/harness_test.go
@@ -22,6 +22,13 @@ func TestParseBackendsEnv(t *testing.T) {
 		{"whitespace and case", " S3 , Azure ", BackendObjectStorageS3 | BackendObjectStorageAzure, false},
 		{"empty entries ignored", "s3,,gcs", BackendObjectStorageS3 | BackendObjectStorageGCS, false},
 		{"unknown errors", "s3,foo", 0, true},
+		// Edge cases that previously returned (0, nil) silently and could mask a misconfigured CI matrix
+		// into looking green while skipping every test. Now they must error.
+		{"empty string errors", "", 0, true},
+		{"only comma errors", ",", 0, true},
+		{"many commas errors", ",,,", 0, true},
+		{"whitespace only errors", "   ", 0, true},
+		{"comma and whitespace errors", " , , ", 0, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Fans `test-e2e-storage` out across one CI runner per backend (`local`, `s3`, `azure`, `gcs`) so the four runs execute concurrently instead of one runner doing all four sequentially. Wall-clock for the storage e2e suite drops from sum-of-backends to max-of-backends with no coverage change.

A new env var `TEMPO_E2E_BACKENDS` filters `TestHarnessConfig.Backends` down to the requested backend; tests whose declared backends don't intersect the mask are `t.Skip`'d on this runner and run on a different matrix entry. When the env var is unset (every other `test-e2e-*` target and local `make test-e2e-storage`), behavior is unchanged.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
