### PR TITLE
[release-v3.0] ci: pin action dependencies and move actions to GATB

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -98,23 +98,11 @@ jobs:
       id-token: write
       pull-requests: write
     steps:
-      - name: Get GitHub App secrets from vault
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1
-        with:
-          export_env: false
-          repo_secrets: |
-            APP_ID=tempo-ci-app:app-id
-            PRIVATE_KEY=tempo-ci-app:private-key
-
-      - name: Generate GitHub App token
+      - name: Get GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).APP_ID }}
-          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: tempo
+          github_app: tempo-ci-app
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -128,7 +116,7 @@ jobs:
           git config --global user.name "grafana-delivery-bot[bot]"
 
       - name: Run backport
-        uses: grafana/grafana-github-actions-go/backport@main
+        uses: grafana/grafana-github-actions-go/backport@787c3c212b43ce951adcb68a816fd329c275a12d # main
         with:
           token: ${{ steps.app-token.outputs.token }}
           labelsToAdd: "backport"

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   deploy-pr-preview:
     if: "!github.event.pull_request.head.repo.fork"
-    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@4dbecae7443c69b3e5fdfeeac7037a339cb82e4c # main
     with:
       branch: ${{ github.head_ref }}
       event_number: ${{ github.event.number }}

--- a/.github/workflows/metrics-collector.yml
+++ b/.github/workflows/metrics-collector.yml
@@ -15,22 +15,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Get GitHub App secrets from vault
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1
-        with:
-          export_env: false
-          repo_secrets: |
-            APP_ID=tempo-ci-app:app-id
-            PRIVATE_KEY=tempo-ci-app:private-key
-      - name: Get app token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      - name: Get GitHub App token
         id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).APP_ID }}
-          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: tempo
+          github_app: tempo-ci-app
       - name: Checkout Actions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
Backport 4713b8ebf4dcf7e8f7b37dc192aee4d9a47e427c from #7186

---

**What this PR does**:
- pins all the action dependencies to sha
- move actions that need tokens over to the GATB

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
