### PR TITLE
enhancement: add linux/riscv64 release artifacts

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,8 +19,11 @@ builds:
     goarch:
       - amd64
       - arm64
+      - riscv64
     ignore:
       - goarch: arm64
+        goos: windows
+      - goarch: riscv64
         goos: windows
     flags:
       - -v
@@ -44,8 +47,11 @@ builds:
     goarch:
       - amd64
       - arm64
+      - riscv64
     ignore:
       - goarch: arm64
+        goos: windows
+      - goarch: riscv64
         goos: windows
     flags:
       - -v
@@ -69,8 +75,11 @@ builds:
     goarch:
       - amd64
       - arm64
+      - riscv64
     ignore:
       - goarch: arm64
+        goos: windows
+      - goarch: riscv64
         goos: windows
     flags:
       - -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 <!-- next version -->
 
+* [ENHANCEMENT] Publish linux/riscv64 release artifacts (tar.gz, deb, rpm) for `tempo`, `tempo-query`, and `tempo-cli`. [#7201](https://github.com/grafana/tempo/pull/7201) (@gounthar)
+
 # v3.0.2
 
 * [CHANGE] Upgrade Tempo to Go 1.26.3 [#7423](https://github.com/grafana/tempo/pull/7423) (@ie-pham)


### PR DESCRIPTION
  **What this PR does**:

  Adds `linux/riscv64` to the three `builds` blocks in `.goreleaser.yml` (`tempo`, `tempo-query`, `tempo-cli`), plus `ignore` rules for `goos: windows` since Go has no
  windows/riscv64 target. The `nfpms` block inherits `goarch` from `builds`, so riscv64 deb and rpm packages fall out without extra config.

  PR #6756 already added a CI cross-compile check for riscv64, which catches regressions, but it doesn't touch the release pipeline. That's why v2.10.5 and v3.0.0-rc.1 still don't
   ship riscv64 artifacts. This change fills in the remaining piece by wiring riscv64 into the goreleaser config that drives \`make release\` on tag push.

  Validated on my fork: \`make release-snapshot\` against the updated config produced \`tempo_..._linux_riscv64.tar.gz\` (63 MB), \`.deb\` (63 MB), and \`.rpm\` (65 MB), matching
  the amd64 and arm64 output. CI evidence: gounthar/tempo#2.

  The Docker image manifest in \`.github/workflows/docker.yml\` is the other missing piece for full riscv64 support. It needs the RISE runner app installed on the grafana org (or
  a QEMU fallback), so it's held out of this PR pending maintainer input on the issue thread.

  **Which issue(s) this PR fixes**:

  Fixes #6753

  **Checklist**

  - [ ] Tests updated (N/A, config-only change)
  - [ ] Documentation added (N/A)
  - [x] \`CHANGELOG.md\` updated