### PR TITLE
chore: remove openMtx from vparquet backendBlock

### DIFF
--- a/tempodb/encoding/vparquet3/block.go
+++ b/tempodb/encoding/vparquet3/block.go
@@ -2,7 +2,6 @@ package vparquet3
 
 import (
 	"context"
-	"sync"
 
 	"github.com/grafana/tempo/pkg/traceql"
 	"github.com/grafana/tempo/pkg/util"
@@ -20,8 +19,6 @@ var tracer = otel.Tracer("tempodb/encoding/vparquet3")
 type backendBlock struct {
 	meta *backend.BlockMeta
 	r    backend.Reader
-
-	openMtx sync.Mutex
 }
 
 var _ common.BackendBlock = (*backendBlock)(nil)

--- a/tempodb/encoding/vparquet3/block_search.go
+++ b/tempodb/encoding/vparquet3/block_search.go
@@ -55,9 +55,6 @@ var KindMapping = map[string]int{
 
 // openForSearch consolidates all the logic for opening a parquet file
 func (b *backendBlock) openForSearch(ctx context.Context, opts common.SearchOptions) (*parquet.File, *BackendReaderAt, error) {
-	b.openMtx.Lock()
-	defer b.openMtx.Unlock()
-
 	// TODO: ctx is also cached when we cache backendReaderAt, not ideal but leaving it as is for now
 	backendReaderAt := NewBackendReaderAt(ctx, b.r, DataFileName, b.meta)
 	// no searches currently require bloom filters or the page index. so just add them statically

--- a/tempodb/encoding/vparquet4/block.go
+++ b/tempodb/encoding/vparquet4/block.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"sync"
 
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/pkg/traceql"
@@ -24,8 +23,6 @@ var tracer = otel.Tracer("tempodb/encoding/vparquet4")
 type backendBlock struct {
 	meta *backend.BlockMeta
 	r    backend.Reader
-
-	openMtx sync.Mutex
 }
 
 var _ common.BackendBlock = (*backendBlock)(nil)

--- a/tempodb/encoding/vparquet4/block_search.go
+++ b/tempodb/encoding/vparquet4/block_search.go
@@ -55,9 +55,6 @@ var KindMapping = map[string]int{
 
 // openForSearch consolidates all the logic for opening a parquet file
 func (b *backendBlock) openForSearch(ctx context.Context, opts common.SearchOptions) (*parquet.File, *BackendReaderAt, error) {
-	b.openMtx.Lock()
-	defer b.openMtx.Unlock()
-
 	// TODO: ctx is also cached when we cache backendReaderAt, not ideal but leaving it as is for now
 	backendReaderAt := NewBackendReaderAt(ctx, b.r, DataFileName, b.meta)
 	// no searches currently require bloom filters or the page index. so just add them statically

--- a/tempodb/encoding/vparquet5/block.go
+++ b/tempodb/encoding/vparquet5/block.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"sync"
 
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/tempodb/backend"
@@ -22,8 +21,6 @@ var tracer = otel.Tracer("tempodb/encoding/vparquet5")
 type backendBlock struct {
 	meta *backend.BlockMeta
 	r    backend.Reader
-
-	openMtx sync.Mutex
 }
 
 var _ common.BackendBlock = (*backendBlock)(nil)

--- a/tempodb/encoding/vparquet5/block_search.go
+++ b/tempodb/encoding/vparquet5/block_search.go
@@ -55,9 +55,6 @@ var KindMapping = map[string]int{
 
 // openForSearch consolidates all the logic for opening a parquet file
 func (b *backendBlock) openForSearch(ctx context.Context, opts common.SearchOptions) (*parquet.File, *BackendReaderAt, error) {
-	b.openMtx.Lock()
-	defer b.openMtx.Unlock()
-
 	// TODO: ctx is also cached when we cache backendReaderAt, not ideal but leaving it as is for now
 	backendReaderAt := NewBackendReaderAt(ctx, b.r, DataFileName, b.meta)
 

--- a/tempodb/encoding/vparquet5/block_search.go
+++ b/tempodb/encoding/vparquet5/block_search.go
@@ -55,7 +55,7 @@ var KindMapping = map[string]int{
 
 // openForSearch consolidates all the logic for opening a parquet file
 func (b *backendBlock) openForSearch(ctx context.Context, opts common.SearchOptions) (*parquet.File, *BackendReaderAt, error) {
-	// TODO: ctx is also cached when we cache backendReaderAt, not ideal but leaving it as is for now
+	// openForSearch creates a fresh BackendReaderAt for each call using the provided context.
 	backendReaderAt := NewBackendReaderAt(ctx, b.r, DataFileName, b.meta)
 
 	schema, _, _ := SchemaWithDynamicChanges(b.meta.DedicatedColumns)


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
The openMtx mutex was added in #1817 to protect a cached *parquet.File and *BackendReaderAt on backendBlock so the file would be opened only once per block. PR #2273 deleted the cached fields ("never used") but left the mutex behind. openForSearch now reads only immutable fields (b.meta, b.r) and produces fresh per-call objects, so the lock no longer protects any state.

It still serialises concurrent searches against the same block, which adds tail latency under fan-out (live-store searches creating many per-block goroutines) without any benefit. Remove it from vparquet3, vparquet4, and vparquet5.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`