### PR TITLE
Document weekly Tempo doc gaps from issue #15

### DIFF
--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -924,6 +924,11 @@ To enable the streaming service over the HTTP port for use with Grafana, set the
 stream_over_http_enabled: true
 ```
 
+The query frontend segments streamed diffs and final responses into smaller packets.
+The default packet size is 2 MiB.
+To change the packet size, configure `query_frontend.max_grpc_streaming_packet_size`.
+For details, refer to the [query frontend configuration](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#query-frontend).
+
 The query frontend supports the following interface. Refer to [`tempo.proto`](https://github.com/grafana/tempo/blob/main/pkg/tempopb/tempo.proto) for complete details of all objects.
 
 ```protobuf

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -949,6 +949,14 @@ query_frontend:
     # (default: 0)
     [api_timeout: <duration>]
 
+    # The maximum size in bytes of a response message returned over gRPC streaming calls.
+    # Diffs and final responses are segmented into packets of this size.
+    # This is separate from the process-wide gRPC server response size because downstream clients
+    # might need smaller streamed responses.
+    # Set to 0 to disable segmentation.
+    # (default: 2097152)
+    [max_grpc_streaming_packet_size: <int>]
+
     # Excludes the most recent portion of the time range from queries to avoid returning
     # incomplete results. Required when `live_store.fail_on_high_lag` is enabled.
     # Must be less than `query_frontend.search.query_backend_after`. 0 disables the cutoff.

--- a/docs/sources/tempo/operations/caching.md
+++ b/docs/sources/tempo/operations/caching.md
@@ -33,6 +33,25 @@ For configuration parameters and an example, refer to the [Cache](https://grafan
 
 For information about search performance, refer to [Tune search performance](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/backend_search/).
 
+## Monitor cache item sizes
+
+Tempo emits the `tempodb_cache_store_size_bytes` histogram for every item written to the tempodb backend cache.
+The metric is labeled by `role`, so you can compare item sizes for backend cache roles such as `bloom`, `trace-id-index`, `parquet-footer`, `parquet-column-idx`, `parquet-offset-idx`, and `parquet-page`.
+
+Use this metric when you tune Memcached slab classes or decide whether to split high-volume cache roles onto a dedicated cache.
+For example, chart the P95 cache item size by role:
+
+```promql
+histogram_quantile(
+  0.95,
+  sum by (role, le) (
+    rate(tempodb_cache_store_size_bytes_bucket[5m])
+  )
+)
+```
+
+If a role regularly writes larger items than the cache can store efficiently, move that role to a cache sized for larger objects or adjust the cache configuration before increasing query concurrency.
+
 ## Memcached
 
 Memcached is used by default in the Tanka and Helm examples.

--- a/docs/sources/tempo/operations/monitor/_index.md
+++ b/docs/sources/tempo/operations/monitor/_index.md
@@ -25,11 +25,12 @@ The [Tempo mixin](#dashboards) provides several dashboards using these metrics.
 
 #### Query frontend inspected bytes
 
-Use `tempo_query_frontend_bytes_inspected_total` to monitor how many bytes the query frontend reads from disk and object storage.
+Use `tempo_query_frontend_bytes_inspected_total` to monitor how many bytes the query path behind the query frontend inspects.
 This counter is emitted per `tenant` and `op` (`traces`, `search`, `metadata`, `metrics`).
-Because cached responses from queriers are excluded, it reflects actual storage and network I/O.
+Because cached responses from queriers are excluded, it reflects uncached query I/O.
+For recent-data queries, use `tempo_live_store_query_inspected_bytes_total` to isolate bytes inspected by live-stores.
 
-For PromQL examples and alerting guidance, refer to [Query query IO and time stamp distance](/docs/tempo/<TEMPO_VERSION>/operations/monitor/query-io-and-timestamp-distance/).
+For PromQL examples and alerting guidance, refer to [Monitor query I/O and span timestamp distance](/docs/tempo/<TEMPO_VERSION>/operations/monitor/query-io-and-timestamp-distance/).
 
 ### Logs
 

--- a/docs/sources/tempo/operations/monitor/query-io-and-timestamp-distance.md
+++ b/docs/sources/tempo/operations/monitor/query-io-and-timestamp-distance.md
@@ -11,20 +11,26 @@ weight: 50
 
 You can use these metrics to monitor query I/O and span timestamp quality:
 
-- `tempo_query_frontend_bytes_inspected_total` measures how many bytes the frontend reads per request type and tenant. This value shows the total number of bytes read from disk and object storage.
+- `tempo_query_frontend_bytes_inspected_total` measures how many bytes a query inspects per request type and tenant. This value includes TraceQL metrics queries.
+- `tempo_live_store_query_inspected_bytes_total` measures how many bytes live-store queries inspect per operation and tenant.
 - `tempo_spans_distance_in_future_seconds` and `tempo_spans_distance_in_past_seconds` measure how far a span end time is from the ingestion time. This capability lets you find customers that send spans too far in the future or past, which may not be found using the Search API.
 
 Use these metrics together to correlate query cost with data quality and pipeline health.
 
 ## Reference
 
-The query frontend emits `tempo_query_frontend_bytes_inspected_total` when a request finishes, aggregating bytes inspected by queriers.
+The query frontend emits `tempo_query_frontend_bytes_inspected_total` when a request finishes, aggregating bytes inspected by the query path.
+The `op` label uses `traces`, `search`, `metadata`, or `metrics`.
+
+The live-store emits `tempo_live_store_query_inspected_bytes_total` while serving recent data.
+Use it to separate recent-data query cost from the total cost reported by the query frontend.
 
 The distributor emits `tempo_spans_distance_in_future_seconds` and `tempo_spans_distance_in_past_seconds` by comparing span end time with ingestion time.
 
 | Names | Type | Labels | Buckets | Emitted | Notes |
 |---|---|---|---|---|---|
-| `tempo_query_frontend_bytes_inspected_total` | Counter | `tenant`, `op` | - | On request completion at the query frontend; aggregates bytes from queriers; excludes cached querier responses. |  |
+| `tempo_query_frontend_bytes_inspected_total` | Counter | `tenant`, `op` | - | On request completion at the query frontend; aggregates bytes inspected by the query path; excludes cached querier responses. | Includes TraceQL metrics queries with `op="metrics"`. |
+| `tempo_live_store_query_inspected_bytes_total` | Counter | `tenant`, `op` | - | During live-store query execution. | Live-store `op` values are `search`, `search_tags`, `search_tag_values`, `trace_by_id`, and `query_range`. |
 | `tempo_spans_distance_in_future_seconds`, `tempo_spans_distance_in_past_seconds` | Histogram | `tenant` | 300s, 1800s, 3600s (5m, 30m, 1h) | In the distributor on ingest; observes seconds between span end time and ingestion time. | Spans in the future are accepted but invalid and might not be searchable. |
 
 ## PromQL examples
@@ -42,6 +48,14 @@ Inspect query read throughput (`bytes/s`) by tenant and operation:
 ```promql
 sum by (tenant, op) (
   rate(tempo_query_frontend_bytes_inspected_total[5m])
+)
+```
+
+Inspect recent-data query throughput from live-stores:
+
+```promql
+sum by (tenant, op) (
+  rate(tempo_live_store_query_inspected_bytes_total[5m])
 )
 ```
 

--- a/docs/sources/tempo/reference-tempo-architecture/components/live-store.md
+++ b/docs/sources/tempo/reference-tempo-architecture/components/live-store.md
@@ -107,9 +107,15 @@ These blocks are queryable until the data ages out of the live-store's retention
 |---|---|
 | `tempo_live_store_traces_created_total` | Total number of traces created in the live-store |
 | `tempo_live_store_lagged_requests_total` | Requests where the live-store could not guarantee complete results due to Kafka lag, labeled by `route` |
+| `tempo_live_store_query_inspected_bytes_total` | Total bytes inspected by live-store queries, labeled by `tenant` and `op` |
 | `tempo_warnings_total` | Warnings during trace processing, labeled by `reason` |
 | `tempo_ingest_group_partition_lag{group="live-store"}` | Consumer lag per partition |
+
+The `op` label for `tempo_live_store_query_inspected_bytes_total` identifies the live-store query operation.
+Possible values are `search`, `search_tags`, `search_tag_values`, `trace_by_id`, and `query_range`.
+Use this metric to understand recent-data query cost before the query frontend aggregates inspected bytes across the full query path.
 
 ## Related resources
 
 Refer to the [live-store configuration](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#live-store) for the full list of options.
+For query I/O PromQL examples, refer to [Monitor query I/O and span timestamp distance](/docs/tempo/<TEMPO_VERSION>/operations/monitor/query-io-and-timestamp-distance/).

--- a/docs/sources/tempo/troubleshooting/querying/response-too-large.md
+++ b/docs/sources/tempo/troubleshooting/querying/response-too-large.md
@@ -21,6 +21,20 @@ with messages between the querier and the query frontend.
 
 ## Solutions
 
+### Query frontend streaming responses
+
+For gRPC streaming search, tag, and TraceQL metrics responses, the query frontend can split streamed diffs and final responses into smaller packets.
+Use `query_frontend.max_grpc_streaming_packet_size` to set the target packet size in bytes.
+The default is `2097152` bytes, or 2 MiB.
+
+```yaml
+query_frontend:
+  max_grpc_streaming_packet_size: 2097152
+```
+
+This setting applies to gRPC streaming responses from the query frontend.
+It doesn't increase the process-wide gRPC message limit for other Tempo component communication.
+
 ### Tempo server (general)
 
 Tempo components communicate with each other via gRPC requests.


### PR DESCRIPTION
Documents the actionable gaps from knylander-grafana/tempo-doc-work#15 for upstream Tempo PRs #7152, #7162, #7163, and #6607:
- Adds cache item-size monitoring guidance for tempodb_cache_store_size_bytes.
- Adds live-store inspected-byte metric documentation and query I/O PromQL guidance.
- Adds query_frontend.max_grpc_streaming_packet_size to configuration, API, and response-size troubleshooting docs.