### PR TITLE
docs: clarify internal endpoint access

### DIFF
--- a/docs/sources/tempo/operations/authentication.md
+++ b/docs/sources/tempo/operations/authentication.md
@@ -29,7 +29,7 @@ For more information, read the [multi-tenancy](https://grafana.com/docs/tempo/<T
 
 Tempo exposes operational endpoints on component HTTP and gRPC listeners for status pages, ring inspection, flush, shutdown, downscale workflows, and backend scheduling.
 These endpoints are intended for internal operator access, automation, and component-to-component communication.
-They are not tenant-scoped API endpoints and should not be exposed to tenants or untrusted clients.
+They aren't tenant-scoped API endpoints and shouldn't be exposed to tenants or untrusted clients.
 
 Expose only the tenant-facing API routes that are required for ingestion and querying through public or tenant-facing ingress.
 Keep component listeners, such as backend-scheduler and live-store, restricted to internal networks.
@@ -45,7 +45,7 @@ Depending on the enabled components, internal HTTP routes include:
 - `/status/backendscheduler`
 
 The backend-scheduler also exposes gRPC methods for backend workers and redaction workflows.
-Do not expose the backend-scheduler gRPC service to untrusted clients.
+Don't expose the backend-scheduler gRPC service to untrusted clients.
 Restrict access to trusted backend workers and operators, including methods such as:
 
 - `/tempopb.BackendScheduler/Next`
@@ -53,4 +53,4 @@ Restrict access to trusted backend workers and operators, including methods such
 - `/tempopb.BackendScheduler/SubmitRedaction`
 
 The `X-Scope-OrgID` header scopes tenant data.
-It is not an administrative authorization mechanism for cluster-wide operational endpoints.
+It isn't an administrative authorization mechanism for cluster-wide operational endpoints.

--- a/docs/sources/tempo/operations/authentication.md
+++ b/docs/sources/tempo/operations/authentication.md
@@ -24,3 +24,33 @@ When using Tempo in multi-tenant mode, Tempo requires the HTTP header
 It's assumed that clients setting `X-Scope-OrgID` are trusted clients, and the responsibility of populating this value should be handled by the authenticating reverse proxy.
 For more information, read the [multi-tenancy](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/manage-advanced-systems/multitenancy/) documentation.
 {{< /admonition >}}
+
+## Protect internal and administrative endpoints
+
+Tempo exposes operational endpoints on component HTTP and gRPC listeners for status pages, ring inspection, flush, shutdown, downscale workflows, and backend scheduling.
+These endpoints are intended for internal operator access, automation, and component-to-component communication.
+They are not tenant-scoped API endpoints and should not be exposed to tenants or untrusted clients.
+
+Expose only the tenant-facing API routes that are required for ingestion and querying through public or tenant-facing ingress.
+Keep component listeners, such as backend-scheduler and live-store, restricted to internal networks.
+
+In monolithic deployments, or any deployment where a reverse proxy forwards a component listener, configure the proxy to block internal routes before forwarding requests to Tempo.
+Depending on the enabled components, internal HTTP routes include:
+
+- `/flush`
+- `/shutdown`
+- `/partition-ring`
+- `/live-store/prepare-partition-downscale`
+- `/live-store/prepare-downscale`
+- `/status/backendscheduler`
+
+The backend-scheduler also exposes gRPC methods for backend workers and redaction workflows.
+Do not expose the backend-scheduler gRPC service to untrusted clients.
+Restrict access to trusted backend workers and operators, including methods such as:
+
+- `/tempopb.BackendScheduler/Next`
+- `/tempopb.BackendScheduler/UpdateJob`
+- `/tempopb.BackendScheduler/SubmitRedaction`
+
+The `X-Scope-OrgID` header scopes tenant data.
+It is not an administrative authorization mechanism for cluster-wide operational endpoints.

--- a/docs/sources/tempo/operations/manage-advanced-systems/multitenancy.md
+++ b/docs/sources/tempo/operations/manage-advanced-systems/multitenancy.md
@@ -90,6 +90,12 @@ otelcol.exporter.otlphttp "tempo" {
 
    This option forces all Tempo components to require the `X-Scope-OrgID` header.
 
+{{< admonition type="note" >}}
+The `X-Scope-OrgID` header scopes tenant data.
+It is not an administrative authorization mechanism for internal operational endpoints.
+For guidance on restricting component HTTP and gRPC routes, refer to [Manage authentication](/docs/tempo/<TEMPO_VERSION>/operations/authentication/).
+{{< /admonition >}}
+
 ## Configure per-tenant settings
 
 After you enable multi-tenancy, you can customize settings on a per-tenant basis using runtime overrides.

--- a/docs/sources/tempo/reference-tempo-architecture/deployment-modes.md
+++ b/docs/sources/tempo/reference-tempo-architecture/deployment-modes.md
@@ -31,6 +31,12 @@ In monolithic mode, the required components run in a single process using `-targ
 
 No Kafka is required. The distributor pushes trace data in-process directly to the live-store and metrics-generator. Traces are flushed to the configured storage backend without an intermediate message queue. Object storage is recommended for production deployments.
 
+{{< admonition type="note" >}}
+In monolithic mode, tenant-facing APIs and internal operational endpoints share the same HTTP and gRPC listeners.
+If you expose these listeners through an ingress or reverse proxy, restrict routing to tenant-facing APIs and block internal management routes.
+For more information, refer to [Manage authentication](/docs/tempo/<TEMPO_VERSION>/operations/authentication/).
+{{< /admonition >}}
+
 ### When to use monolithic mode
 
 Monolithic mode is suitable for getting started, development environments, and low to moderate trace volumes where operational simplicity matters more than independent scaling.
@@ -52,6 +58,10 @@ For an annotated example configuration for Tempo, refer to the [Introduction to 
 ## Microservices mode
 
 In microservices mode, each component runs as a separate process with its own `-target`. This is the recommended mode for production.
+
+Expose only tenant-facing components and routes through ingress.
+Keep internal component HTTP and gRPC listeners, such as backend-scheduler and live-store, restricted to operator or cluster-internal access.
+For more information, refer to [Manage authentication](/docs/tempo/<TEMPO_VERSION>/operations/authentication/).
 
 The configuration associated with each component's deployment specifies a `target`. For example, to deploy a `querier`, the configuration would contain `target: querier`. A command-line deployment may specify the `-target=querier` flag.
 


### PR DESCRIPTION
Documents that Tempo component HTTP/gRPC operational endpoints are internal-only and should not be exposed to tenants or untrusted clients. Adds cross-links from deployment modes and multi-tenancy docs to the authentication guidance.
