### PR TITLE
[Bugfix] Better validation for query_range endpoint: do not accept negative step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [BUGFIX] livestore: write the per-block query-range response cache atomically (temp file + rename) and log+ignore cache read errors. [#7155](https://github.com/grafana/tempo/pull/7155) (@zhxiaogg)
 * [BUGFIX] livestore: recover from panics in `iterateBlocks` per-block paths so a panic in vparquet/parquetquery (e.g. malformed `ByteArray` values) returns an error instead of crashing the process. [#7134](https://github.com/grafana/tempo/pull/7134) (@zhxiaogg)
 * [ENHANCEMENT] TraceQL metrics: enable new span-only fetch by default. Can be disabled per-tenant via `metrics_spanonly_fetch: false` or per-query via the unsafe hint `with(spanonly_fetch=false)`. [#7179](https://github.com/grafana/tempo/pull/7179) (@mdisibio)
+* [BUGFIX] Better validation for query_range endpoint: do not accept negative step [#7221](https://github.com/grafana/tempo/pull/7221) (@ruslan-mikhailov)
 * [BUGFIX] user-configurable overrides: emit duration fields as flat YAML scalars on `/status/overrides/{tenant}` and omit `generate_native_histograms` when unset. [#7138](https://github.com/grafana/tempo/pull/7138) (@electron0zero)
 
 # v3.0.0-rc.1

--- a/pkg/api/http.go
+++ b/pkg/api/http.go
@@ -654,7 +654,14 @@ func step(vals url.Values, start, end time.Time) (time.Duration, error) {
 	if value == "" {
 		return time.Duration(traceql.DefaultQueryRangeStep(uint64(start.UnixNano()), uint64(end.UnixNano()))), nil
 	}
-	return parseSecondsOrDuration(value)
+	dur, err := parseSecondsOrDuration(value)
+	if err != nil {
+		return dur, err
+	}
+	if dur < 0 {
+		return 0, fmt.Errorf("cannot parse %q: step must be positive", value)
+	}
+	return dur, nil
 }
 
 func parseSecondsOrDuration(value string) (time.Duration, error) {

--- a/pkg/api/http_test.go
+++ b/pkg/api/http_test.go
@@ -752,6 +752,19 @@ func TestParseQueryRequestInvalidBounds(t *testing.T) {
 	}
 }
 
+func TestParseQueryRangeNegativeStep(t *testing.T) {
+	for _, step := range []string{"-1h", "-30m", "-1.5", "-0.001"} {
+		t.Run(step, func(t *testing.T) {
+			r := makeReq(map[string]string{
+				"q": "{} | rate()", "start": "1700000000", "end": "1700003600", "step": step,
+			})
+			_, err := ParseQueryRangeRequest(r)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "step must be positive")
+		})
+	}
+}
+
 func TestQueryRangeRoundtripEmpty(t *testing.T) {
 	req := &tempopb.QueryRangeRequest{
 		Step: uint64(time.Second), // you can't actually roundtrip an empty query b/c Build/Parse will force a default step


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: do not accept negative steps

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`