### PR TITLE
Backport fail-on-high-lag defaults to v3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # v3.0.0
 
+* [CHANGE] **BREAKING CHANGE** Recent data queries guarantee complete results by failing when an instance is lagging. Defaults `query_frontend.query_end_cutoff` to `30s` and `live_store.fail_on_high_lag` to `true`. [#7210](https://github.com/grafana/tempo/pull/7210) (@mapno)
 * [CHANGE] **BREAKING CHANGE** user-configurable overrides config `metrics_generator.processors` no longer merges with runtime overrides. `metrics_generator.processors` now takes precedence over the runtime overrides, matching every other config in user-configurable overrides. Setting `processors: []` disables all processors for the tenant. [#7176](https://github.com/grafana/tempo/pull/7176) (@electron0zero)
 * [CHANGE] Stop publishing 32-bit ARM binary archives. Release artifacts continue to include amd64 and arm64 binaries. [#7106](https://github.com/grafana/tempo/pull/7106) (@javiermolinar)
 

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -588,8 +588,11 @@ live_store:
     # Maximum time to wait for catching up at startup. Only used if readiness_target_lag > 0.
     [readiness_max_wait: <duration> | default = 30m]
 
-    # Fail on search and metrics requests if lag is high and live-store cannot guarantee completeness.
-    [fail_on_high_lag: <bool> | default = false]
+    # Fail search and metrics requests when the live-store cannot guarantee complete results,
+    # rather than returning a partial response. Trades availability for correctness.
+    # Requires `query_frontend.query_end_cutoff` to be non-zero.
+    # When disabled, lagged requests are still counted via `tempo_live_store_lagged_requests_total`.
+    [fail_on_high_lag: <bool> | default = true]
 
     # Remove partition owner from the ring on shutdown.
     [remove_owner_on_shutdown: <bool> | default = true]
@@ -926,10 +929,10 @@ query_frontend:
     # (default: 0)
     [api_timeout: <duration>]
 
-    # Prevents querying incomplete recent data by excluding the most recent portion of the time range.
-    # Useful when live-store data may not yet be fully available for querying.
-    # 0 disables this cutoff.
-    # (default: 0)
+    # Excludes the most recent portion of the time range from queries to avoid returning
+    # incomplete results. Required when `live_store.fail_on_high_lag` is enabled.
+    # Must be less than `query_frontend.search.query_backend_after`. 0 disables the cutoff.
+    # (default: 30s)
     [query_end_cutoff: <duration>]
 
     # A list of regular expressions for refusing matching requests, these will apply for every request regardless of the endpoint.

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -363,6 +363,7 @@ query_frontend:
     mcp_server:
         enabled: false
     max_query_expression_size_bytes: 131072
+    query_end_cutoff: 30s
 metrics_generator:
     ring:
         kvstore:
@@ -1061,6 +1062,6 @@ live_store:
     max_block_bytes: 52428800
     readiness_target_lag: 0s
     readiness_max_wait: 30m0s
-    fail_on_high_lag: false
+    fail_on_high_lag: true
     remove_owner_on_shutdown: true
 ```

--- a/integration/api/config-query-range-exemplars.yaml
+++ b/integration/api/config-query-range-exemplars.yaml
@@ -1,2 +1,5 @@
 query_frontend:
   query_end_cutoff: -5m # TestQueryRangeExemplars fails if this is not set. i don't know why
+
+live_store:
+  fail_on_high_lag: false # required because the test uses query_end_cutoff: -5m

--- a/integration/util/config-base.yaml
+++ b/integration/util/config-base.yaml
@@ -67,6 +67,9 @@ ingest:
     address: kafka:9092
     topic: tempo-ingest
 
+query_frontend:
+  query_end_cutoff: 1s # timings: keep the new-data exclusion window short so tests don't wait the production default (30s)
+
 querier:
   frontend_worker:
     frontend_address: query-frontend:9095

--- a/integration/util/config-query-backend.yaml
+++ b/integration/util/config-query-backend.yaml
@@ -3,6 +3,7 @@
 #
 
 query_frontend:
+  query_end_cutoff: 0s # required so query_end_cutoff <= query_backend_after (set to 0 below)
   search:
     query_backend_after: 0s
   metrics:

--- a/integration/util/harness.go
+++ b/integration/util/harness.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -119,6 +120,17 @@ type TempoHarness struct {
 
 	overridesPath  string
 	readinessProbe e2e.ReadinessProbe
+
+	// lastWriteUnixNano records the wall-clock time of the most recent successful
+	// trace write, used by WaitTracesQueryable to honor query_end_cutoff.
+	lastWriteUnixNano atomic.Int64
+}
+
+// recordWrite stamps the time of a successful trace write. Callers should invoke this
+// after every method that emits traces to the distributor so that WaitTracesQueryable
+// can wait for the query_end_cutoff window to elapse before tests assert queryability.
+func (h *TempoHarness) recordWrite() {
+	h.lastWriteUnixNano.Store(time.Now().UnixNano())
 }
 
 // TestHarnessConfig provides configuration options for the test harness
@@ -380,6 +392,41 @@ func (h *TempoHarness) WaitTracesQueryable(t *testing.T, traces int) {
 
 	liveStoreZoneB := h.Services[ServiceLiveStoreZoneB]
 	require.NoError(t, liveStoreZoneB.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(float64(traces)), []string{"tempo_live_store_traces_created_total"}, e2e.WaitMissingMetrics))
+
+	// Honor query_end_cutoff: the frontend clamps each request's `end` to `now - cutoff`,
+	// so a trace written at time T is not queryable until T + cutoff. Wait for that window
+	// to elapse since the most recent write before letting the test assert queryability.
+	h.waitForQueryEndCutoff(t)
+}
+
+// waitForQueryEndCutoff sleeps until enough wall-clock time has passed since the last
+// recorded write for traces to fall inside the queryable window defined by
+// query_frontend.query_end_cutoff. Skipped when no writes have been recorded or when
+// the cutoff is disabled (<= 0).
+func (h *TempoHarness) waitForQueryEndCutoff(t *testing.T) {
+	t.Helper()
+
+	lastWrite := h.lastWriteUnixNano.Load()
+	if lastWrite == 0 {
+		return
+	}
+
+	cfg, err := h.GetConfig()
+	require.NoError(t, err)
+
+	cutoff := cfg.Frontend.QueryEndCutoff
+	if cutoff <= 0 {
+		return
+	}
+
+	// Tiny buffer to absorb clock skew between this process and the live-store containers.
+	// The wait is already conservative: the trace's span timestamps were assigned before the
+	// write completed, so lastWrite is strictly newer than the trace timestamp.
+	const buffer = 100 * time.Millisecond
+	waitUntil := time.Unix(0, lastWrite).Add(cutoff).Add(buffer)
+	if remaining := time.Until(waitUntil); remaining > 0 {
+		time.Sleep(remaining)
+	}
 }
 
 func (h *TempoHarness) WaitTracesWrittenToBackend(t *testing.T, traces int) {

--- a/integration/util/harness_api_writes.go
+++ b/integration/util/harness_api_writes.go
@@ -88,7 +88,11 @@ func (h *TempoHarness) WriteTraceInfo(traceInfo *util.TraceInfo, tenant string) 
 	if err != nil {
 		return err
 	}
-	return traceInfo.EmitAllBatches(exporter)
+	if err := traceInfo.EmitAllBatches(exporter); err != nil {
+		return err
+	}
+	h.recordWrite()
+	return nil
 }
 
 func (h *TempoHarness) WriteJaegerBatch(batch *thrift.Batch, tenant string) error {
@@ -97,7 +101,11 @@ func (h *TempoHarness) WriteJaegerBatch(batch *thrift.Batch, tenant string) erro
 	if err != nil {
 		return err
 	}
-	return exporter.EmitBatch(context.Background(), batch)
+	if err := exporter.EmitBatch(context.Background(), batch); err != nil {
+		return err
+	}
+	h.recordWrite()
+	return nil
 }
 
 func (h *TempoHarness) WriteTempoProtoTraces(traces *tempopb.Trace, tenant string) error {
@@ -120,6 +128,7 @@ func (h *TempoHarness) WriteTempoProtoTraces(traces *tempopb.Trace, tenant strin
 	if err := exporter.ConsumeTraces(context.Background(), otlpTraces); err != nil {
 		return err
 	}
+	h.recordWrite()
 	return exporter.Shutdown(context.Background())
 }
 

--- a/modules/frontend/config.go
+++ b/modules/frontend/config.go
@@ -136,6 +136,8 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.MultiTenantQueriesEnabled = true
 	cfg.Metrics.MaxIntervals = 10_000
 
+	cfg.QueryEndCutoff = 30 * time.Second
+
 	// enabling an mcp server opens the door to send tracing data to an LLM. it should require
 	// explicit enabling. registers a flag in addition to YAML configuration.
 	f.BoolVar(&cfg.MCPServer.Enabled, util.PrefixConfig(prefix, "mcp-server.enabled"), false, "Set to true to enable the MCP server")

--- a/modules/livestore/config.go
+++ b/modules/livestore/config.go
@@ -119,6 +119,8 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.ReadinessTargetLag = 0
 	cfg.ReadinessMaxWait = 30 * time.Minute
 
+	cfg.FailOnHighLag = true
+
 	cfg.RemoveOwnerOnShutdown = true
 
 	cfg.initialBackoff = defaultInitialBackoff

--- a/modules/livestore/live_store.go
+++ b/modules/livestore/live_store.go
@@ -593,7 +593,6 @@ func (s *LiveStore) calculateTimeLag(lagShortcutThreshold int64) *time.Duration 
 
 	// Use cached high watermark from fetch responses (avoids extra API call)
 	lag := s.reader.lag.Load()
-	zero := time.Duration(0)
 
 	// If we haven't performed any fetches yet, we can't determine lag
 	if lag < 0 {
@@ -607,7 +606,7 @@ func (s *LiveStore) calculateTimeLag(lagShortcutThreshold int64) *time.Duration 
 		level.Debug(s.logger).Log(
 			"msg", "At or close to partition end",
 			"lag", lag)
-		return &zero
+		return new(time.Duration(0))
 	}
 
 	nanos := s.lastRecordTimeNanos.Load()
@@ -620,8 +619,7 @@ func (s *LiveStore) calculateTimeLag(lagShortcutThreshold int64) *time.Duration 
 	// Potential race condition that can result in negative lag?
 	// Assuming strictly monotonic timestamps in Kafka, can't cause an issue
 	lastRecordTime := time.Unix(0, nanos)
-	recordLag := time.Since(lastRecordTime)
-	return &recordLag
+	return new(time.Since(lastRecordTime))
 }
 
 func (s *LiveStore) consume(ctx context.Context, rs recordIter, now time.Time) (*kadm.Offset, error) {


### PR DESCRIPTION
Backports #7210 to `release-v3.0`:

- Defaults `live_store.fail_on_high_lag` to `true`.
- Defaults `query_frontend.query_end_cutoff` to `30s`.
- Updates docs, manifest, and integration test harness configs for the new defaults.
- Keeps the v3.0.0 changelog scoped to this backport.

Cherry-picked from commit 06dd3989a68c3e38e07658ff6dd3f8d0fadbdb86.

Tests run:

- `go test ./modules/frontend -run 'TestFrontendBadConfigFails|TestQueryRangeHandlerWithEndCutoff|TestSearchSharderConfigDefaults' -count=1`
- `go test ./modules/livestore -run 'TestConfigValidate|TestIsLagged|TestLiveStoreQueryMethodsBeforeStarted|TestLiveStoreQueryMethodsAfterStoppingWithFailOnHighLag|TestLiveStoreConsumeTracksPartitionLag' -count=1`
- `go test ./integration/util -count=1`
