### PR TITLE
Backport search and metrics streaming response segmentation to v3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * [FEATURE] Extend `TraceRedactor` interface to support hiding complete traces via `ErrTraceHidden`. [#6811](https://github.com/grafana/tempo/pull/6811) (@stoewer)
 * [FEATURE] Single-binary mode: push distributor local ingest directly to live-store and metrics-generator without Kafka [#6729](https://github.com/grafana/tempo/pull/6729) (@javiermolinar)
 * [FEATURE] Add experimental drain limiter to the metrics generator. This can reduce metrics cardinality by clustering similar span names. [#6098](https://github.com/grafana/tempo/pull/6098) (@Logiraptor)
+* [ENHANCEMENT] Query-frontend: split streamed search and metrics responses into smaller gRPC packets for better default client compatibility, and fix final streaming updates after metrics series limits are reached. [#6607](https://github.com/grafana/tempo/pull/6607) (@mdisibio)
 * [ENHANCEMENT] live-store: lock-free block reads via `atomic.Pointer[blockSnapshot]`; block deletion is two-phase (tombstone meta.json → meta.deleted.json, then reclaim files after `block_reclaim_grace`). Crash-safe; startup sweep reclaims any tombstoned dirs left by an unclean shutdown. [#7132](https://github.com/grafana/tempo/pull/7132) (@zhxiaogg)
 * [ENHANCEMENT] Support OR conditions for tag name and tag value autocomplete (search tags v2) [#6827](https://github.com/grafana/tempo/pull/6827) (@ie-pham)
 * [ENHANCEMENT] Expose MinIO retry settings via S3 config [#6561](https://github.com/grafana/tempo/pull/6561) (@rwhitty)

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -362,6 +362,7 @@ query_frontend:
         max_regex_conditions: 1
     mcp_server:
         enabled: false
+    max_grpc_streaming_packet_size: 2097152
     max_query_expression_size_bytes: 131072
     query_end_cutoff: 30s
 metrics_generator:

--- a/modules/frontend/combiner/common.go
+++ b/modules/frontend/combiner/common.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/bits"
 	"net/http"
 	"strings"
 	"sync"
@@ -43,6 +44,9 @@ type genericCombiner[T TResponse] struct {
 	finalize func(T) (T, error)
 	diff     func(T) (T, error)
 	quit     func(T) bool
+
+	// Segment one response into smaller ones, that fit within the given max size.
+	segment func(T, int) []T
 
 	// Used to determine the response code and when to stop
 	httpStatusCode int
@@ -232,6 +236,18 @@ func (c *genericCombiner[T]) GRPCDiff() (T, error) {
 	return diffClone.(T), nil
 }
 
+func (c *genericCombiner[T]) GRPCSegment(response T, maxSize int) ([]T, error) {
+	c.mu.Lock()
+	segment := c.segment
+	c.mu.Unlock()
+
+	if segment == nil {
+		return nil, fmt.Errorf("grpc response segmentation not supported for response type:  %T", response)
+	}
+
+	return segment(response, maxSize), nil
+}
+
 func (c *genericCombiner[T]) erroredResponse() (*http.Response, error) {
 	if c.httpStatusCode == http.StatusOK {
 		return nil, nil
@@ -341,4 +357,21 @@ type TraceRedactor interface {
 // The returned byte slice must not be modified.
 func unsafeStringToBytes(s string) []byte {
 	return unsafe.Slice(unsafe.StringData(s), len(s))
+}
+
+// protoStringSize returns the size in bytes of a string in a repeated string field.
+// Size is 1 byte for the field number, the string content itself, and then the string length encoded as varint.
+func protoStringSize(s string) int {
+	l := len(s)
+	// Calculation copied from sovTempo in tempopb.
+	varIntSize := (bits.Len64(uint64(l)|1) + 6) / 7
+	return 1 + l + varIntSize
+}
+
+// protoSizeMath returns the full size in bytes including overhead to store an entry in a proto slice.
+// It accounts for the field number, the length of the item itself, and then the length encoded as a varint.
+func protoSizeMath(item proto.Message) (n int) {
+	sz := proto.Size(item)
+	varIntSize := (bits.Len64(uint64(sz)|1) + 6) / 7
+	return 1 + sz + varIntSize
 }

--- a/modules/frontend/combiner/common_test.go
+++ b/modules/frontend/combiner/common_test.go
@@ -331,3 +331,11 @@ func fromHTTPResponse(t *testing.T, r *http.Response, pb proto.Message) {
 		require.NoError(t, err)
 	}
 }
+
+func requireProtoSegmentsFit[T proto.Message](t *testing.T, segments []T, maxSize int) {
+	t.Helper()
+
+	for i, segment := range segments {
+		require.LessOrEqualf(t, proto.Size(segment), maxSize, "segment %d exceeds max size", i)
+	}
+}

--- a/modules/frontend/combiner/interface.go
+++ b/modules/frontend/combiner/interface.go
@@ -27,4 +27,5 @@ type GRPCCombiner[T TResponse] interface {
 
 	GRPCFinal() (T, error)
 	GRPCDiff() (T, error)
+	GRPCSegment(response T, maxSize int) ([]T, error)
 }

--- a/modules/frontend/combiner/metrics_query_range.go
+++ b/modules/frontend/combiner/metrics_query_range.go
@@ -105,7 +105,7 @@ func NewQueryRange(req *tempopb.QueryRangeRequest, maxSeriesLimit int) (Combiner
 			// Check if any shards have completed
 			completedThrough := completionTracker.CompletedThroughSeconds()
 
-			// If no shards have completed yet or the completedThrough is the same as the lastCompletedThrough, return empty response
+			// If we are still waiting for new data, then send an interim empty diff.
 			if completedThrough == shardtracker.TimestampUnknown || completedThrough == lastCompletedThrough {
 				return &tempopb.QueryRangeResponse{
 					Series:  []*tempopb.TimeSeries{},
@@ -119,7 +119,6 @@ func NewQueryRange(req *tempopb.QueryRangeRequest, maxSeriesLimit int) (Combiner
 			}
 
 			// only trim the response if we're not at the end of the stream. for the final response, we'll send all the data.
-			// TODO: why aren't we using .GRPCFinal() correctly instead of doing this? also it looks like TimestampAlways is never set? so I don't think this ever works the way it's intended to.
 			if completedThrough != shardtracker.TimestampAlways {
 				trimSeriesToCompletedWindow(resp.Series, lastCompletedThrough, completedThrough)
 			}
@@ -148,6 +147,7 @@ func NewQueryRange(req *tempopb.QueryRangeRequest, maxSeriesLimit int) (Combiner
 			// will return an empty response
 			return combiner.MaxSeriesReached() && completionTracker.CompletedThroughSeconds() != shardtracker.TimestampUnknown
 		},
+		segment: segmentQueryRangeResponseToMaxPacketSize,
 	}
 
 	initHTTPCombiner(c, api.HeaderAcceptJSON)
@@ -161,6 +161,51 @@ func NewTypedQueryRange(req *tempopb.QueryRangeRequest, maxSeries int) (GRPCComb
 		return nil, err
 	}
 	return c.(GRPCCombiner[*tempopb.QueryRangeResponse]), nil
+}
+
+// segmentQueryRangeResponseToMaxPacketSize splits resp into one or more QueryRangeResponse values, each within
+// maxSize bytes (by proto Size()), accounting for the response object itself. Metrics are included
+// in every segment; Status and Message are set on the last segment.
+func segmentQueryRangeResponseToMaxPacketSize(resp *tempopb.QueryRangeResponse, maxSize int) []*tempopb.QueryRangeResponse {
+	// If not configured return as-is.
+	if maxSize <= 0 {
+		return []*tempopb.QueryRangeResponse{resp}
+	}
+
+	var out []*tempopb.QueryRangeResponse
+	var current *tempopb.QueryRangeResponse
+	var currentSz int
+
+	startNextPacket := func() {
+		current = &tempopb.QueryRangeResponse{
+			Metrics: resp.Metrics,
+		}
+		currentSz = current.Size()
+		out = append(out, current)
+	}
+
+	startNextPacket()
+
+	for _, s := range resp.Series {
+		seriesSz := protoSizeMath(s)
+
+		// Start a new packet if there isn't room for this entry,
+		// unless it's the first one, that way we always try to fit at least one.
+		if len(current.Series) > 0 && currentSz+seriesSz > maxSize {
+			startNextPacket()
+		}
+
+		current.Series = append(current.Series, s)
+		currentSz += seriesSz
+	}
+
+	// Attach real status and message only to the last packet
+	if len(out) > 0 {
+		out[len(out)-1].Status = resp.Status
+		out[len(out)-1].Message = resp.Message
+	}
+
+	return out
 }
 
 // trimSeriesToCompletedWindow filters series samples and exemplars to only include

--- a/modules/frontend/combiner/metrics_query_range_test.go
+++ b/modules/frontend/combiner/metrics_query_range_test.go
@@ -127,6 +127,69 @@ func buildSeriesForExemplarTest(start, end, step uint64, include func(i int) boo
 	return resp, expectedSeries
 }
 
+func TestSegmentQueryRangeResponseToMaxPacketSize(t *testing.T) {
+	input := &tempopb.QueryRangeResponse{
+		Metrics: &tempopb.SearchMetrics{},
+		Series: []*tempopb.TimeSeries{
+			{
+				Labels: []v1.KeyValue{
+					{Key: "name", Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "series0"}}},
+				},
+				Samples: []tempopb.Sample{{TimestampMs: 1000, Value: 1}},
+			},
+			{
+				Labels: []v1.KeyValue{
+					{Key: "name", Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "series1"}}},
+				},
+				Samples: []tempopb.Sample{{TimestampMs: 2000, Value: 2}},
+			},
+			{
+				Labels: []v1.KeyValue{
+					{Key: "name", Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "series2"}}},
+				},
+				Samples: []tempopb.Sample{{TimestampMs: 3000, Value: 3}},
+			},
+		},
+	}
+
+	t.Run("fits", func(t *testing.T) {
+		// Generate a test packet size that is large enough for only part of the data.
+		maxSize := (&tempopb.QueryRangeResponse{
+			Metrics: input.Metrics,
+			Series:  input.Series[:2],
+		}).Size()
+		out := segmentQueryRangeResponseToMaxPacketSize(input, maxSize)
+
+		require.Len(t, out, 2, "expected 2 responses")
+		requireProtoSegmentsFit(t, out, maxSize)
+		require.Len(t, out[0].Series, 2)
+		require.Len(t, out[1].Series, 1)
+		require.Equal(t, input.Series[0], out[0].Series[0])
+		require.Equal(t, input.Series[1], out[0].Series[1])
+		require.Equal(t, input.Series[2], out[1].Series[0])
+		// Metrics repeated in each segment
+		require.Equal(t, input.Metrics, out[0].Metrics)
+		require.Equal(t, input.Metrics, out[1].Metrics)
+	})
+
+	t.Run("at least one", func(t *testing.T) {
+		// This is smaller than every item but will test logic to ensure we always send at least one item even if too big
+		const maxSize = 1
+		out := segmentQueryRangeResponseToMaxPacketSize(input, maxSize)
+
+		require.Len(t, out, 3, "expected 3 responses")
+		require.Len(t, out[0].Series, 1)
+		require.Len(t, out[1].Series, 1)
+		require.Len(t, out[2].Series, 1)
+		require.Equal(t, input.Series[0], out[0].Series[0])
+		require.Equal(t, input.Series[1], out[1].Series[0])
+		require.Equal(t, input.Series[2], out[2].Series[0])
+		require.Equal(t, input.Metrics, out[0].Metrics)
+		require.Equal(t, input.Metrics, out[1].Metrics)
+		require.Equal(t, input.Metrics, out[2].Metrics)
+	})
+}
+
 func TestQueryRangemaxSeriesShouldQuit(t *testing.T) {
 	start := uint64(1100 * time.Second)
 	end := uint64(1300 * time.Second)

--- a/modules/frontend/combiner/search.go
+++ b/modules/frontend/combiner/search.go
@@ -132,6 +132,7 @@ func NewSearch(limit int, keepMostRecent bool, marshalingFormat api.MarshallingF
 
 			return metadataCombiner.IsCompleteFor(completedThroughSeconds)
 		},
+		segment: segmentSearchResponse,
 	}
 	initHTTPCombiner(c, marshalingFormat)
 	return c
@@ -154,4 +155,41 @@ func padTraceIDsInResponse(traces []*tempopb.TraceSearchMetadata) {
 	for _, t := range traces {
 		t.TraceID = util.PadTraceIDString(t.TraceID)
 	}
+}
+
+// segmentSearchResponse splits response into one or more SearchResponse values, each within
+// maxSize bytes (by proto Size()). Metrics are included in every segment.
+func segmentSearchResponse(response *tempopb.SearchResponse, maxSize int) []*tempopb.SearchResponse {
+	if maxSize <= 0 {
+		return []*tempopb.SearchResponse{response}
+	}
+
+	var out []*tempopb.SearchResponse
+	var current *tempopb.SearchResponse
+	var currentSz int
+
+	startNextPacket := func() {
+		current = &tempopb.SearchResponse{
+			Metrics: response.Metrics,
+		}
+		currentSz = current.Size()
+		out = append(out, current)
+	}
+
+	startNextPacket()
+
+	for _, t := range response.Traces {
+		traceSz := protoSizeMath(t)
+
+		// Start a new packet if there isn't room for this entry,
+		// unless it's the first one, that way we always try to fit at least one.
+		if len(current.Traces) > 0 && currentSz+traceSz > maxSize {
+			startNextPacket()
+		}
+
+		current.Traces = append(current.Traces, t)
+		currentSz += traceSz
+	}
+
+	return out
 }

--- a/modules/frontend/combiner/search_tag_values.go
+++ b/modules/frontend/combiner/search_tag_values.go
@@ -44,6 +44,7 @@ func NewSearchTagValues(maxDataBytes int, maxTagsValues uint32, staleValueThresh
 
 			return response, nil
 		},
+		segment: segmentSearchTagValuesResponse,
 	}
 	initHTTPCombiner(c, marshalingFormat)
 	return c
@@ -99,6 +100,7 @@ func NewSearchTagValuesV2(maxDataBytes int, maxTagsValues uint32, staleValueThre
 
 			return response, nil
 		},
+		segment: segmentSearchTagValuesV2Response,
 	}
 	initHTTPCombiner(c, marshalingFormat)
 	return c
@@ -106,4 +108,76 @@ func NewSearchTagValuesV2(maxDataBytes int, maxTagsValues uint32, staleValueThre
 
 func NewTypedSearchTagValuesV2(maxDataBytes int, maxTagsValues uint32, staleValueThreshold uint32, marshalingFormat api.MarshallingFormat) GRPCCombiner[*tempopb.SearchTagValuesV2Response] {
 	return NewSearchTagValuesV2(maxDataBytes, maxTagsValues, staleValueThreshold, marshalingFormat).(GRPCCombiner[*tempopb.SearchTagValuesV2Response])
+}
+
+// segmentSearchTagValuesResponse splits response into one or more SearchTagValuesResponse values, each within
+// maxSize bytes (by proto Size()). Metrics are included in every segment.
+func segmentSearchTagValuesResponse(response *tempopb.SearchTagValuesResponse, maxSize int) []*tempopb.SearchTagValuesResponse {
+	if maxSize <= 0 {
+		return []*tempopb.SearchTagValuesResponse{response}
+	}
+
+	var out []*tempopb.SearchTagValuesResponse
+	var current *tempopb.SearchTagValuesResponse
+	var currentSz int
+
+	startNextPacket := func() {
+		current = &tempopb.SearchTagValuesResponse{
+			TagValues: nil,
+			Metrics:   response.Metrics,
+		}
+		currentSz = current.Size()
+		out = append(out, current)
+	}
+
+	startNextPacket()
+
+	for _, v := range response.TagValues {
+		itemSz := protoStringSize(v)
+		// Start a new packet if there isn't room for this entry,
+		// unless it's the first one, that way we always try to fit at least one.
+		if len(current.TagValues) > 0 && currentSz+itemSz > maxSize {
+			startNextPacket()
+		}
+		current.TagValues = append(current.TagValues, v)
+		currentSz += itemSz
+	}
+
+	return out
+}
+
+// segmentSearchTagValuesV2Response splits response into one or more SearchTagValuesV2Response values, each within
+// maxSize bytes (by proto Size()). Metrics are included in every segment.
+func segmentSearchTagValuesV2Response(response *tempopb.SearchTagValuesV2Response, maxSize int) []*tempopb.SearchTagValuesV2Response {
+	if maxSize <= 0 {
+		return []*tempopb.SearchTagValuesV2Response{response}
+	}
+
+	var out []*tempopb.SearchTagValuesV2Response
+	var current *tempopb.SearchTagValuesV2Response
+	var currentSz int
+
+	startNextPacket := func() {
+		current = &tempopb.SearchTagValuesV2Response{
+			TagValues: nil,
+			Metrics:   response.Metrics,
+		}
+		currentSz = current.Size()
+		out = append(out, current)
+	}
+
+	startNextPacket()
+
+	for _, tv := range response.TagValues {
+		tvSz := tv.Size()
+		// Start a new packet if there isn't room for this entry,
+		// unless it's the first one, that way we always try to fit at least one.
+		if len(current.TagValues) > 0 && currentSz+tvSz > maxSize {
+			startNextPacket()
+		}
+		current.TagValues = append(current.TagValues, tv)
+		currentSz += tvSz
+	}
+
+	return out
 }

--- a/modules/frontend/combiner/search_tags.go
+++ b/modules/frontend/combiner/search_tags.go
@@ -46,6 +46,7 @@ func NewSearchTags(maxDataBytes int, maxTagsPerScope uint32, staleValueThreshold
 			response.Metrics = metricsCombiner.Metrics
 			return response, nil
 		},
+		segment: segmentSearchTagsResponse,
 	}
 	initHTTPCombiner(c, marshalingFormat)
 	return c
@@ -104,6 +105,7 @@ func NewSearchTagsV2(maxDataBytes int, maxTagsPerScope uint32, staleValueThresho
 			response.Metrics = metricsCombiner.Metrics
 			return response, nil
 		},
+		segment: segmentSearchTagsV2Response,
 	}
 	initHTTPCombiner(c, marshalingFormat)
 	return c
@@ -115,4 +117,89 @@ func NewTypedSearchTags(maxDataBytes int, maxTagsPerScope uint32, staleValueThre
 
 func NewTypedSearchTagsV2(maxDataBytes int, maxTagsPerScope uint32, staleValueThreshold uint32, marshalingFormat api.MarshallingFormat) GRPCCombiner[*tempopb.SearchTagsV2Response] {
 	return NewSearchTagsV2(maxDataBytes, maxTagsPerScope, staleValueThreshold, marshalingFormat).(GRPCCombiner[*tempopb.SearchTagsV2Response])
+}
+
+// segmentSearchTagsResponse splits response into one or more SearchTagsResponse values, each within
+// maxSize bytes (by proto Size()). Metrics are included in every segment.
+func segmentSearchTagsResponse(response *tempopb.SearchTagsResponse, maxSize int) []*tempopb.SearchTagsResponse {
+	if maxSize <= 0 {
+		return []*tempopb.SearchTagsResponse{response}
+	}
+
+	var out []*tempopb.SearchTagsResponse
+	var current *tempopb.SearchTagsResponse
+	var currentSz int
+
+	startNextPacket := func() {
+		current = &tempopb.SearchTagsResponse{
+			TagNames: nil,
+			Metrics:  response.Metrics,
+		}
+		currentSz = current.Size()
+		out = append(out, current)
+	}
+
+	startNextPacket()
+
+	for _, name := range response.TagNames {
+		sz := protoStringSize(name)
+		// Start a new packet if there isn't room for this entry,
+		// unless it's the first one, that way we always try to fit at least one.
+		if len(current.TagNames) > 0 && currentSz+sz > maxSize {
+			startNextPacket()
+		}
+		current.TagNames = append(current.TagNames, name)
+		currentSz += sz
+	}
+
+	return out
+}
+
+// segmentSearchTagsV2Response splits response into one or more SearchTagsV2Response values, each within
+// maxSize bytes (by proto Size()). Metrics are included in every segment. Scopes are split at the tag
+// level: when a scope doesn't fit, the same scope name is repeated in the next packet and tags keep
+// being added to it.
+func segmentSearchTagsV2Response(response *tempopb.SearchTagsV2Response, maxSize int) []*tempopb.SearchTagsV2Response {
+	if maxSize <= 0 {
+		return []*tempopb.SearchTagsV2Response{response}
+	}
+
+	var out []*tempopb.SearchTagsV2Response
+	var current *tempopb.SearchTagsV2Response
+	var currentSz int
+
+	startNextPacket := func() {
+		current = &tempopb.SearchTagsV2Response{
+			Scopes:  nil,
+			Metrics: response.Metrics,
+		}
+		currentSz = current.Size()
+		out = append(out, current)
+	}
+
+	startNextPacket()
+
+	for _, scope := range response.Scopes {
+		dest := &tempopb.SearchTagsV2Scope{Name: scope.Name}
+		current.Scopes = append(current.Scopes, dest)
+
+		for _, tag := range scope.Tags {
+			sz := protoStringSize(tag)
+
+			// Start a new packet if there isn't room for this entry,
+			// unless it's the first one, that way we always try to fit at least one.
+			if len(dest.Tags) > 0 && currentSz+sz > maxSize {
+				startNextPacket()
+
+				// Restart current scope in this new packet.
+				dest = &tempopb.SearchTagsV2Scope{Name: scope.Name}
+				current.Scopes = append(current.Scopes, dest)
+			}
+
+			dest.Tags = append(dest.Tags, tag)
+			currentSz += sz
+		}
+	}
+
+	return out
 }

--- a/modules/frontend/combiner/search_tags_test.go
+++ b/modules/frontend/combiner/search_tags_test.go
@@ -359,3 +359,192 @@ func testGRPCCombiner[T proto.Message](t *testing.T, combiner GRPCCombiner[T], r
 	sort(actualFinal)
 	require.Equal(t, expectedFinal, actualFinal)
 }
+
+func TestSegmentSearchTagsResponse(t *testing.T) {
+	input := &tempopb.SearchTagsResponse{
+		Metrics:  &tempopb.MetadataMetrics{},
+		TagNames: []string{"a", "b", "c"},
+	}
+
+	t.Run("fits", func(t *testing.T) {
+		// Generate a test packet size that is large enough for only part of the data.
+		maxSize := (&tempopb.SearchTagsResponse{
+			Metrics:  input.Metrics,
+			TagNames: input.TagNames[:2],
+		}).Size()
+		out := segmentSearchTagsResponse(input, maxSize)
+
+		require.Len(t, out, 2)
+		requireProtoSegmentsFit(t, out, maxSize)
+		require.Len(t, out[0].TagNames, 2)
+		require.Len(t, out[1].TagNames, 1)
+		require.Equal(t, input.TagNames[0], out[0].TagNames[0])
+		require.Equal(t, input.TagNames[1], out[0].TagNames[1])
+		require.Equal(t, input.TagNames[2], out[1].TagNames[0])
+		require.Equal(t, input.Metrics, out[0].Metrics)
+		require.Equal(t, input.Metrics, out[1].Metrics)
+	})
+
+	t.Run("at least one", func(t *testing.T) {
+		// This is smaller than every item but will test logic to ensure we always send at least one item even if too big
+		const maxSize = 1
+		out := segmentSearchTagsResponse(input, maxSize)
+
+		require.Len(t, out, 3)
+		require.Len(t, out[0].TagNames, 1)
+		require.Len(t, out[1].TagNames, 1)
+		require.Len(t, out[2].TagNames, 1)
+		require.Equal(t, input.TagNames[0], out[0].TagNames[0])
+		require.Equal(t, input.TagNames[1], out[1].TagNames[0])
+		require.Equal(t, input.TagNames[2], out[2].TagNames[0])
+		require.Equal(t, input.Metrics, out[0].Metrics)
+		require.Equal(t, input.Metrics, out[1].Metrics)
+		require.Equal(t, input.Metrics, out[2].Metrics)
+	})
+}
+
+func TestSegmentSearchTagsV2Response(t *testing.T) {
+	input := &tempopb.SearchTagsV2Response{
+		Metrics: &tempopb.MetadataMetrics{},
+		Scopes: []*tempopb.SearchTagsV2Scope{{
+			Name: "s1",
+			Tags: []string{
+				"aaaaaaaaaaaaaaaaaaaa",
+				"bbbbbbbbbbbbbbbbbbbb",
+				"cccccccccccccccccccc",
+			},
+		}},
+	}
+
+	t.Run("fits", func(t *testing.T) {
+		// Generate a test packet size that is large enough for only part of the data.
+		maxSize := (&tempopb.SearchTagsV2Response{
+			Metrics: input.Metrics,
+			Scopes: []*tempopb.SearchTagsV2Scope{
+				{Name: input.Scopes[0].Name, Tags: input.Scopes[0].Tags[:2]},
+			},
+		}).Size()
+		out := segmentSearchTagsV2Response(input, maxSize)
+
+		require.Len(t, out, 2)
+		requireProtoSegmentsFit(t, out, maxSize)
+		require.Len(t, out[0].Scopes, 1)
+		require.Len(t, out[1].Scopes, 1)
+		require.Equal(t, input.Scopes[0].Name, out[0].Scopes[0].Name)
+		require.Equal(t, input.Scopes[0].Name, out[1].Scopes[0].Name)
+		require.Equal(t, input.Scopes[0].Tags[0:2], out[0].Scopes[0].Tags)
+		require.Equal(t, input.Scopes[0].Tags[2:3], out[1].Scopes[0].Tags)
+		require.Equal(t, input.Metrics, out[0].Metrics)
+		require.Equal(t, input.Metrics, out[1].Metrics)
+	})
+
+	t.Run("at least one", func(t *testing.T) {
+		// This is smaller than every item but will test logic to ensure we always send at least one item even if too big
+		const maxSize = 1
+		out := segmentSearchTagsV2Response(input, maxSize)
+
+		require.Len(t, out, 3)
+		require.Len(t, out[0].Scopes, 1)
+		require.Len(t, out[1].Scopes, 1)
+		require.Len(t, out[2].Scopes, 1)
+		require.Equal(t, input.Scopes[0].Name, out[0].Scopes[0].Name)
+		require.Equal(t, input.Scopes[0].Name, out[1].Scopes[0].Name)
+		require.Equal(t, input.Scopes[0].Name, out[2].Scopes[0].Name)
+		require.Equal(t, input.Scopes[0].Tags[0:1], out[0].Scopes[0].Tags)
+		require.Equal(t, input.Scopes[0].Tags[1:2], out[1].Scopes[0].Tags)
+		require.Equal(t, input.Scopes[0].Tags[2:3], out[2].Scopes[0].Tags)
+		require.Equal(t, input.Metrics, out[0].Metrics)
+		require.Equal(t, input.Metrics, out[1].Metrics)
+		require.Equal(t, input.Metrics, out[2].Metrics)
+	})
+}
+
+func TestSegmentSearchTagValuesResponse(t *testing.T) {
+	input := &tempopb.SearchTagValuesResponse{
+		Metrics:   &tempopb.MetadataMetrics{},
+		TagValues: []string{"a", "b", "c"},
+	}
+
+	t.Run("fits", func(t *testing.T) {
+		// Generate a test packet size that is large enough for only part of the data.
+		maxSize := (&tempopb.SearchTagValuesResponse{
+			Metrics:   input.Metrics,
+			TagValues: input.TagValues[:2],
+		}).Size()
+		out := segmentSearchTagValuesResponse(input, maxSize)
+
+		require.Len(t, out, 2)
+		requireProtoSegmentsFit(t, out, maxSize)
+		require.Len(t, out[0].TagValues, 2)
+		require.Len(t, out[1].TagValues, 1)
+		require.Equal(t, input.TagValues[0], out[0].TagValues[0])
+		require.Equal(t, input.TagValues[1], out[0].TagValues[1])
+		require.Equal(t, input.TagValues[2], out[1].TagValues[0])
+		require.Equal(t, input.Metrics, out[0].Metrics)
+		require.Equal(t, input.Metrics, out[1].Metrics)
+	})
+
+	t.Run("at least one", func(t *testing.T) {
+		// This is smaller than every item but will test logic to ensure we always send at least one item even if too big
+		const maxSize = 1
+		out := segmentSearchTagValuesResponse(input, maxSize)
+
+		require.Len(t, out, 3)
+		require.Len(t, out[0].TagValues, 1)
+		require.Len(t, out[1].TagValues, 1)
+		require.Len(t, out[2].TagValues, 1)
+		require.Equal(t, input.TagValues[0], out[0].TagValues[0])
+		require.Equal(t, input.TagValues[1], out[1].TagValues[0])
+		require.Equal(t, input.TagValues[2], out[2].TagValues[0])
+		require.Equal(t, input.Metrics, out[0].Metrics)
+		require.Equal(t, input.Metrics, out[1].Metrics)
+		require.Equal(t, input.Metrics, out[2].Metrics)
+	})
+}
+
+func TestSegmentSearchTagValuesV2Response(t *testing.T) {
+	input := &tempopb.SearchTagValuesV2Response{
+		Metrics: &tempopb.MetadataMetrics{},
+		TagValues: []*tempopb.TagValue{
+			{Type: "string", Value: "a"},
+			{Type: "string", Value: "b"},
+			{Type: "string", Value: "c"},
+		},
+	}
+
+	t.Run("fits", func(t *testing.T) {
+		// Generate a test packet size that is large enough for only part of the data.
+		maxSize := (&tempopb.SearchTagValuesV2Response{
+			Metrics:   input.Metrics,
+			TagValues: input.TagValues[:2],
+		}).Size()
+		out := segmentSearchTagValuesV2Response(input, maxSize)
+
+		require.Len(t, out, 2)
+		requireProtoSegmentsFit(t, out, maxSize)
+		require.Len(t, out[0].TagValues, 2)
+		require.Len(t, out[1].TagValues, 1)
+		require.Equal(t, input.TagValues[0], out[0].TagValues[0])
+		require.Equal(t, input.TagValues[1], out[0].TagValues[1])
+		require.Equal(t, input.TagValues[2], out[1].TagValues[0])
+		require.Equal(t, input.Metrics, out[0].Metrics)
+		require.Equal(t, input.Metrics, out[1].Metrics)
+	})
+
+	t.Run("at least one", func(t *testing.T) {
+		// This is smaller than every item but will test logic to ensure we always send at least one item even if too big
+		const maxSize = 1
+		out := segmentSearchTagValuesV2Response(input, maxSize)
+
+		require.Len(t, out, 3)
+		require.Len(t, out[0].TagValues, 1)
+		require.Len(t, out[1].TagValues, 1)
+		require.Len(t, out[2].TagValues, 1)
+		require.Equal(t, input.TagValues[0], out[0].TagValues[0])
+		require.Equal(t, input.TagValues[1], out[1].TagValues[0])
+		require.Equal(t, input.TagValues[2], out[2].TagValues[0])
+		require.Equal(t, input.Metrics, out[0].Metrics)
+		require.Equal(t, input.Metrics, out[1].Metrics)
+		require.Equal(t, input.Metrics, out[2].Metrics)
+	})
+}

--- a/modules/frontend/combiner/search_test.go
+++ b/modules/frontend/combiner/search_test.go
@@ -787,3 +787,73 @@ func TestSearchCombinerPadTraceIDs(t *testing.T) {
 		})
 	}
 }
+
+func TestSegmentSearchResponse(t *testing.T) {
+	input := &tempopb.SearchResponse{
+		Metrics: &tempopb.SearchMetrics{},
+		Traces: []*tempopb.TraceSearchMetadata{
+			{
+				TraceID: "a",
+				SpanSet: &tempopb.SpanSet{
+					Spans: []*tempopb.Span{
+						{SpanID: "1", Name: "span1", StartTimeUnixNano: 1000, DurationNanos: 100},
+						{SpanID: "2", Name: "span2", StartTimeUnixNano: 2000, DurationNanos: 200},
+						{SpanID: "3", Name: "span3", StartTimeUnixNano: 3000, DurationNanos: 300},
+					},
+				},
+			},
+			{
+				TraceID: "b",
+				SpanSet: &tempopb.SpanSet{
+					Spans: []*tempopb.Span{
+						{SpanID: "4", Name: "span4", StartTimeUnixNano: 4000, DurationNanos: 400},
+					},
+				},
+			},
+			{
+				TraceID: "c",
+				SpanSet: &tempopb.SpanSet{
+					Spans: []*tempopb.Span{
+						{SpanID: "5", Name: "span5", StartTimeUnixNano: 5000, DurationNanos: 500},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("fits", func(t *testing.T) {
+		// Generate a test packet size that is large enough for only part of the data.
+		maxSize := (&tempopb.SearchResponse{
+			Metrics: input.Metrics,
+			Traces:  input.Traces[:2],
+		}).Size()
+		out := segmentSearchResponse(input, maxSize)
+
+		require.Len(t, out, 2)
+		requireProtoSegmentsFit(t, out, maxSize)
+		require.Len(t, out[0].Traces, 2)
+		require.Len(t, out[1].Traces, 1)
+		require.Equal(t, input.Traces[0], out[0].Traces[0])
+		require.Equal(t, input.Traces[1], out[0].Traces[1])
+		require.Equal(t, input.Traces[2], out[1].Traces[0])
+		require.Equal(t, input.Metrics, out[0].Metrics)
+		require.Equal(t, input.Metrics, out[1].Metrics)
+	})
+
+	t.Run("at least one", func(t *testing.T) {
+		// This is smaller than every item but will test logic to ensure we always send at least one item even if too big
+		const maxSize = 1
+		out := segmentSearchResponse(input, maxSize)
+
+		require.Len(t, out, 3)
+		require.Len(t, out[0].Traces, 1)
+		require.Len(t, out[1].Traces, 1)
+		require.Len(t, out[2].Traces, 1)
+		require.Equal(t, input.Traces[0], out[0].Traces[0])
+		require.Equal(t, input.Traces[1], out[1].Traces[0])
+		require.Equal(t, input.Traces[2], out[2].Traces[0])
+		require.Equal(t, input.Metrics, out[0].Metrics)
+		require.Equal(t, input.Metrics, out[1].Metrics)
+		require.Equal(t, input.Metrics, out[2].Metrics)
+	})
+}

--- a/modules/frontend/config.go
+++ b/modules/frontend/config.go
@@ -35,6 +35,12 @@ type Config struct {
 	// A list of regexes for black listing requests, these will apply for every request regardless the endpoint
 	URLDenyList []string `yaml:"url_deny_list,omitempty"`
 
+	// The maximum size of a response message returned over gRPC streaming calls.
+	// Diffs and final responses will be segmented into packets of this size.
+	// This is separate from the max grpc packet server response size for the process overall,
+	// because we may need to target smaller responses for downstream clients.
+	MaxGRPCStreamingPacketSize int `yaml:"max_grpc_streaming_packet_size,omitempty"`
+
 	// Maximum allowed size of the raw TraceQL Query expression in bytes
 	MaxQueryExpressionSizeBytes int `yaml:"max_query_expression_size_bytes,omitempty"`
 
@@ -91,6 +97,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.Config.MaxBatchSize = 7
 	cfg.MaxRetries = 2
 	cfg.ResponseConsumers = 10
+	cfg.MaxGRPCStreamingPacketSize = 2 * 1024 * 1024 // 2MB
 	cfg.Search = SearchConfig{
 		Sharder: SearchSharderConfig{
 			QueryBackendAfter:      15 * time.Minute,

--- a/modules/frontend/metrics_query_handler.go
+++ b/modules/frontend/metrics_query_handler.go
@@ -67,7 +67,7 @@ func newQueryInstantStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTri
 			return err
 		}
 
-		collector := pipeline.NewGRPCCollector(next, cfg.ResponseConsumers, c, func(qrr *tempopb.QueryRangeResponse) error {
+		collector := pipeline.NewGRPCCollector(next, cfg.ResponseConsumers, cfg.MaxGRPCStreamingPacketSize, c, func(qrr *tempopb.QueryRangeResponse) error {
 			// Translate each diff into the instant version and send it
 			resp := translateQueryRangeToInstant(*qrr)
 			finalResponse = &resp // Save last response for bytesProcessed for the SLO calculations

--- a/modules/frontend/metrics_query_range_handler.go
+++ b/modules/frontend/metrics_query_range_handler.go
@@ -87,7 +87,7 @@ func newQueryRangeStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripp
 			return err
 		}
 
-		collector := pipeline.NewGRPCCollector(next, cfg.ResponseConsumers, c, func(qrr *tempopb.QueryRangeResponse) error {
+		collector := pipeline.NewGRPCCollector(next, cfg.ResponseConsumers, cfg.MaxGRPCStreamingPacketSize, c, func(qrr *tempopb.QueryRangeResponse) error {
 			finalResponse = qrr // sadly we can't pass srv.Send directly into the collector. we need bytesProcessed for the SLO calculations
 			return srv.Send(qrr)
 		})
@@ -171,7 +171,7 @@ func newMetricsQueryRangeHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper
 		// ask for the typed diff and use that for the SLO hook. it will have up to date metrics
 		// todo: is there a way to remove this? it can be costly for large responses
 		var bytesProcessed uint64
-		queryRangeResp, _ := combiner.GRPCDiff()
+		queryRangeResp, _ := combiner.GRPCFinal()
 		if queryRangeResp != nil && queryRangeResp.Metrics != nil {
 			bytesProcessed = queryRangeResp.Metrics.InspectedBytes
 		}

--- a/modules/frontend/pipeline/collector_grpc.go
+++ b/modules/frontend/pipeline/collector_grpc.go
@@ -12,19 +12,20 @@ import (
 )
 
 type GRPCCollector[T combiner.TResponse] struct {
-	next      AsyncRoundTripper[combiner.PipelineResponse]
-	combiner  combiner.GRPCCombiner[T]
-	consumers int
-
-	send func(T) error
+	next           AsyncRoundTripper[combiner.PipelineResponse]
+	combiner       combiner.GRPCCombiner[T]
+	consumers      int
+	maxSegmentSize int
+	send           func(T) error
 }
 
-func NewGRPCCollector[T combiner.TResponse](next AsyncRoundTripper[combiner.PipelineResponse], consumers int, combiner combiner.GRPCCombiner[T], send func(T) error) *GRPCCollector[T] {
+func NewGRPCCollector[T combiner.TResponse](next AsyncRoundTripper[combiner.PipelineResponse], consumers int, maxSegmentSize int, combiner combiner.GRPCCombiner[T], send func(T) error) *GRPCCollector[T] {
 	return &GRPCCollector[T]{
-		next:      next,
-		combiner:  combiner,
-		consumers: consumers,
-		send:      send,
+		next:           next,
+		combiner:       combiner,
+		consumers:      consumers,
+		maxSegmentSize: maxSegmentSize,
+		send:           send,
 	}
 }
 
@@ -61,10 +62,8 @@ func (c GRPCCollector[T]) RoundTrip(req *http.Request) error {
 			if err != nil {
 				return err
 			}
-			err = c.send(resp)
-			if err != nil {
-				return err
-			}
+
+			return c.sendSegmented(req, resp, c.maxSegmentSize)
 		}
 
 		return nil
@@ -77,20 +76,38 @@ func (c GRPCCollector[T]) RoundTrip(req *http.Request) error {
 	span.AddEvent("consumeAndCombineResponses done")
 
 	// send the final diff if there is anything left
-	resp, err := c.combiner.GRPCDiff()
+	resp, err := c.combiner.GRPCFinal()
 	if err != nil {
 		return grpcError(err)
 	}
-	span.AddEvent("final combiner.GRPCDiff() done")
-	// check and return the context errors, like ctx cancelled, etc
-	if req.Context().Err() != nil {
-		return grpcError(req.Context().Err())
+	span.AddEvent("combiner.GRPCFinal() done")
+
+	return c.sendSegmented(req, resp, c.maxSegmentSize)
+}
+
+func (c GRPCCollector[T]) sendSegmented(req *http.Request, resp T, maxSize int) error {
+	// If no max, then send as-is.
+	if maxSize <= 0 {
+		return grpcError(c.send(resp))
 	}
-	err = c.send(resp)
+
+	// Split the response into smaller packets and send individually.
+	grpcPackets, err := c.combiner.GRPCSegment(resp, maxSize)
 	if err != nil {
 		return grpcError(err)
 	}
 
+	for _, packet := range grpcPackets {
+		// While sending, check and return the context errors, like ctx cancelled, etc
+		if req.Context().Err() != nil {
+			return grpcError(req.Context().Err())
+		}
+
+		err = c.send(packet)
+		if err != nil {
+			return grpcError(err)
+		}
+	}
 	return nil
 }
 

--- a/modules/frontend/pipeline/responses_test.go
+++ b/modules/frontend/pipeline/responses_test.go
@@ -336,7 +336,7 @@ func TestAsyncResponsesDoesNotLeak(t *testing.T) {
 					bridge := &pipelineBridge{
 						next: tc.finalRT(cancel),
 					}
-					grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](sharder{next: bridge}, 0, combiner.NewTypedSearch(0, false, api.HeaderAcceptJSON, false), func(_ *tempopb.SearchResponse) error { return nil })
+					grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](sharder{next: bridge}, 0, 0, combiner.NewTypedSearch(0, false, api.HeaderAcceptJSON, false), func(_ *tempopb.SearchResponse) error { return nil })
 
 					_ = grpcCollector.RoundTrip(req)
 
@@ -362,7 +362,7 @@ func TestAsyncResponsesDoesNotLeak(t *testing.T) {
 					}
 
 					s := sharder{next: sharder{next: bridge}, funcSharder: true}
-					grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](s, 0, combiner.NewTypedSearch(0, false, api.HeaderAcceptJSON, false), func(_ *tempopb.SearchResponse) error { return nil })
+					grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](s, 0, 0, combiner.NewTypedSearch(0, false, api.HeaderAcceptJSON, false), func(_ *tempopb.SearchResponse) error { return nil })
 
 					_ = grpcCollector.RoundTrip(req)
 
@@ -387,7 +387,7 @@ func TestAsyncResponsesDoesNotLeak(t *testing.T) {
 					}
 
 					s := sharder{next: sharder{next: bridge, funcSharder: true}}
-					grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](s, 0, combiner.NewTypedSearch(0, false, api.HeaderAcceptJSON, false), func(_ *tempopb.SearchResponse) error { return nil })
+					grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](s, 0, 0, combiner.NewTypedSearch(0, false, api.HeaderAcceptJSON, false), func(_ *tempopb.SearchResponse) error { return nil })
 
 					_ = grpcCollector.RoundTrip(req)
 

--- a/modules/frontend/search_handlers.go
+++ b/modules/frontend/search_handlers.go
@@ -65,7 +65,7 @@ func newSearchStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[c
 		}
 
 		var finalResponse *tempopb.SearchResponse
-		collector := pipeline.NewGRPCCollector[*tempopb.SearchResponse](next, cfg.ResponseConsumers, comb, func(sr *tempopb.SearchResponse) error {
+		collector := pipeline.NewGRPCCollector[*tempopb.SearchResponse](next, cfg.ResponseConsumers, cfg.MaxGRPCStreamingPacketSize, comb, func(sr *tempopb.SearchResponse) error {
 			finalResponse = sr // sadly we can't srv.Send directly into the collector. we need bytesProcessed for the SLO calculations
 			return srv.Send(sr)
 		})

--- a/modules/frontend/tag_handlers.go
+++ b/modules/frontend/tag_handlers.go
@@ -58,7 +58,7 @@ func newTagsStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[com
 
 		var finalResponse *tempopb.SearchTagsResponse
 		comb := combiner.NewTypedSearchTags(o.MaxBytesPerTagValuesQuery(tenant), req.MaxTagsPerScope, req.StaleValuesThreshold, api.MarshallingFormatProtobuf)
-		collector := pipeline.NewGRPCCollector(next, cfg.ResponseConsumers, comb, func(res *tempopb.SearchTagsResponse) error {
+		collector := pipeline.NewGRPCCollector(next, cfg.ResponseConsumers, cfg.MaxGRPCStreamingPacketSize, comb, func(res *tempopb.SearchTagsResponse) error {
 			finalResponse = res // to get the bytes processed for SLO calculations
 			return srv.Send(res)
 		})
@@ -121,7 +121,7 @@ func newTagsV2StreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[c
 
 		var finalResponse *tempopb.SearchTagsV2Response
 		comb := combiner.NewTypedSearchTagsV2(o.MaxBytesPerTagValuesQuery(tenant), req.MaxTagsPerScope, req.StaleValuesThreshold, api.MarshallingFormatProtobuf)
-		collector := pipeline.NewGRPCCollector(next, cfg.ResponseConsumers, comb, func(res *tempopb.SearchTagsV2Response) error {
+		collector := pipeline.NewGRPCCollector(next, cfg.ResponseConsumers, cfg.MaxGRPCStreamingPacketSize, comb, func(res *tempopb.SearchTagsV2Response) error {
 			finalResponse = res // to get the bytes processed for SLO calculations
 			return srv.Send(res)
 		})
@@ -189,7 +189,7 @@ func newTagValuesStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTrippe
 
 		var finalResponse *tempopb.SearchTagValuesResponse
 		comb := combiner.NewTypedSearchTagValues(o.MaxBytesPerTagValuesQuery(tenant), req.MaxTagValues, req.StaleValueThreshold, api.MarshallingFormatProtobuf)
-		collector := pipeline.NewGRPCCollector(next, cfg.ResponseConsumers, comb, func(res *tempopb.SearchTagValuesResponse) error {
+		collector := pipeline.NewGRPCCollector(next, cfg.ResponseConsumers, cfg.MaxGRPCStreamingPacketSize, comb, func(res *tempopb.SearchTagValuesResponse) error {
 			finalResponse = res // to get the bytes processed for SLO calculations
 			return srv.Send(res)
 		})
@@ -243,7 +243,7 @@ func newTagValuesV2StreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTrip
 
 		var finalResponse *tempopb.SearchTagValuesV2Response
 		comb := combiner.NewTypedSearchTagValuesV2(o.MaxBytesPerTagValuesQuery(tenant), req.MaxTagValues, req.StaleValueThreshold, api.MarshallingFormatProtobuf)
-		collector := pipeline.NewGRPCCollector(next, cfg.ResponseConsumers, comb, func(res *tempopb.SearchTagValuesV2Response) error {
+		collector := pipeline.NewGRPCCollector(next, cfg.ResponseConsumers, cfg.MaxGRPCStreamingPacketSize, comb, func(res *tempopb.SearchTagValuesV2Response) error {
 			finalResponse = res // to get the bytes processed for SLO calculations
 			return srv.Send(res)
 		})


### PR DESCRIPTION
Backports #6607 to `release-v3.0`:

Cherry-picked from commit 24338c9722d54740a9e900858709ffce1d24d14c.
