### PR TITLE
chore(deps) migrate from gopkg.in/yaml.v3 to go.yaml.in/yaml/v3

### DIFF
--- a/cmd/tempo-cli/cmd-suggest-columns.go
+++ b/cmd/tempo-cli/cmd-suggest-columns.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/dustin/go-humanize"
 	"github.com/google/uuid"

--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -28,9 +28,9 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/prometheus/common/version"
 	"go.uber.org/atomic"
+	"go.yaml.in/yaml/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
-	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/tempo/cmd/tempo/build"
 	"github.com/grafana/tempo/modules/backendscheduler"

--- a/go.mod
+++ b/go.mod
@@ -57,12 +57,12 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.28.0
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/sync v0.20.0
 	golang.org/x/time v0.15.0
 	google.golang.org/api v0.276.0
 	google.golang.org/grpc v1.81.0
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (
@@ -423,7 +423,6 @@ require (
 	go.opentelemetry.io/otel/log v0.19.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.19.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
-	go.yaml.in/yaml/v3 v3.0.4
 	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect
 	golang.org/x/arch v0.0.0-20210923205945-b76863e36670 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
@@ -438,6 +437,7 @@ require (
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260406210006-6f92a3bedf2d // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apimachinery v0.36.0 // indirect
 	k8s.io/client-go v0.35.3 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	google.golang.org/api v0.276.0
 	google.golang.org/grpc v1.81.0
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
-	gopkg.in/yaml.v3 v3.0.1
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (
@@ -423,7 +423,7 @@ require (
 	go.opentelemetry.io/otel/log v0.19.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.19.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	go.yaml.in/yaml/v3 v3.0.4
 	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect
 	golang.org/x/arch v0.0.0-20210923205945-b76863e36670 // indirect
 	golang.org/x/crypto v0.50.0 // indirect

--- a/pkg/docsgen/generate_manifest.go
+++ b/pkg/docsgen/generate_manifest.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 
 	"github.com/grafana/tempo/cmd/tempo/app"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 const ManifestPath = "docs/sources/tempo/configuration/manifest.md"

--- a/pkg/traceql/ast_validate_test.go
+++ b/pkg/traceql/ast_validate_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type TestQueries struct {

--- a/tempodb/backend/s3/config_test.go
+++ b/tempodb/backend/s3/config_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/grafana/dskit/flagext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestSSEConfigEncryptionKeyRedacted(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:
Migrate from gopkg.in/yaml.v3 to go.yaml.in/yaml/v3
Reason: gopkg.in/yaml.v3 last release was 2022-05; upstream go-yaml/yaml is unmaintained. The YAML community has taken over at go.yaml.in/yaml/v3

**Which issue(s) this PR fixes**:
Contributes to #7218

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`