### PR TITLE
ci: publish Docker images through GAR mirror

### DIFF
--- a/.github/workflows/docker-ci-tools.yml
+++ b/.github/workflows/docker-ci-tools.yml
@@ -8,9 +8,9 @@ on:
       - 'tools/**'
 
 env:
-  IMAGE_NAME: grafana/tempo-ci-tools
+  IMAGE_NAME: us-docker.pkg.dev/grafanalabs-global/dockerhub-tempo-prod-mirror/tempo-ci-tools
 
-# Needed to login to DockerHub
+# Needed to authenticate to GAR with OIDC.
 permissions:
   contents: read
 
@@ -39,6 +39,7 @@ jobs:
         runner_arch: [ { runner: ubuntu-24.04, arch: amd64 }, { runner: github-hosted-ubuntu-arm64, arch: arm64 } ]
     runs-on: ${{ matrix.runner_arch.runner }}
     permissions:
+      contents: read
       id-token: write
     env:
       TAG: ${{ needs.get-image-tag.outputs.tag }}
@@ -48,8 +49,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Login to DockerHub
-        uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
+      - name: Login to GAR
+        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+        with:
+          registry: us-docker.pkg.dev
 
       - name: docker-build-and-push
         run: |
@@ -62,6 +65,7 @@ jobs:
     needs: ['get-image-tag', 'docker-ci-tools']
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
     env:
       TAG: ${{ needs.get-image-tag.outputs.tag }}
@@ -71,8 +75,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Login to DockerHub
-        uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
+      - name: Login to GAR
+        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+        with:
+          registry: us-docker.pkg.dev
 
       - name: docker-manifest-create-and-push
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,13 +3,15 @@ on:
   push:
     branches:
       - 'main'
-      - 'r[0-9]+'
     tags:
       - 'v*'
 
-# Needed to login to DockerHub
+# Needed to authenticate to GAR with OIDC.
 permissions:
   contents: read
+
+env:
+  DOCKERHUB_MIRROR_REPOSITORY: us-docker.pkg.dev/grafanalabs-global/dockerhub-tempo-prod-mirror
 
 jobs:
 
@@ -40,6 +42,7 @@ jobs:
         runner_arch: [ { runner: ubuntu-24.04, arch: amd64 }, { runner: github-hosted-ubuntu-arm64, arch: arm64 } ]
     runs-on: ${{ matrix.runner_arch.runner }}
     permissions:
+      contents: read
       id-token: write
     env:
       TAG: ${{ needs.get-tag.outputs.tag }}
@@ -59,20 +62,23 @@ jobs:
       - name: docker-build
         run: |
           TAG_ARCH="$TAG-${{ matrix.runner_arch.arch }}"
-          docker build --provenance false --platform "linux/${{ matrix.runner_arch.arch }}" -f "cmd/${{ matrix.component }}/Dockerfile" -t "grafana/${{ matrix.component }}:$TAG_ARCH" .
+          docker build --provenance false --platform "linux/${{ matrix.runner_arch.arch }}" -f "cmd/${{ matrix.component }}/Dockerfile" -t "$DOCKERHUB_MIRROR_REPOSITORY/${{ matrix.component }}:$TAG_ARCH" .
 
-      - name: Login to DockerHub
-        uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
+      - name: Login to GAR
+        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+        with:
+          registry: us-docker.pkg.dev
 
       - name: docker-push
         run: |
-          TAG_ARCH="$TAG-${{ matrix.runner_arch.arch }}"          
-          docker push "grafana/${{ matrix.component }}:$TAG_ARCH"
+          TAG_ARCH="$TAG-${{ matrix.runner_arch.arch }}"
+          docker push "$DOCKERHUB_MIRROR_REPOSITORY/${{ matrix.component }}:$TAG_ARCH"
 
   manifest:
     if: github.repository == 'grafana/tempo'
     needs: ['get-tag', 'docker']
     permissions:
+      contents: read
       id-token: write
     strategy:
       matrix:
@@ -80,15 +86,17 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       TAG: ${{ needs.get-tag.outputs.tag }}
-      IMAGE_NAME: grafana/${{ matrix.component }}
+      IMAGE_NAME: us-docker.pkg.dev/grafanalabs-global/dockerhub-tempo-prod-mirror/${{ matrix.component }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
-      - name: Login to DockerHub
-        uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
+      - name: Login to GAR
+        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+        with:
+          registry: us-docker.pkg.dev
 
       - name: docker-manifest-create-and-push
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     tags:
       - 'v*'
 
-# Needed to login to DockerHub
+# No default token permissions; the release job grants only what it needs.
 permissions: {}
 jobs:
   release:

--- a/RELEASES.MD
+++ b/RELEASES.MD
@@ -5,8 +5,10 @@
 - Push a semver tag to main on the merge commit above.  Something like:
   - `git tag -a v1.2.0-rc.0`
   - `git push origin v1.2.0-rc.0`
-- This will initiate the build process in Github Actions.  The tagged docker image should
-  be available here shortly: https://hub.docker.com/r/grafana/tempo/tags?page=1&ordering=last_updated
+- This will initiate the build process in Github Actions. The `docker` workflow publishes
+  tagged images to GAR under `us-docker.pkg.dev/grafanalabs-global/dockerhub-tempo-prod-mirror/`.
+  `gar-image-mirror` asynchronously mirrors those images to Docker Hub; they should be
+  available here shortly after the workflow succeeds: https://hub.docker.com/r/grafana/tempo/tags?page=1&ordering=last_updated
 - A Github Release Draft should also be available here:  https://github.com/grafana/tempo/releases
   - Copy over the CHANGELOG entries for the release
   - Call out contributors for their work
@@ -81,7 +83,8 @@ Tag the release branch and push. This triggers the `release` and `docker` workfl
 ## 6. Verify CI
 Check that all workflows triggered by the tag succeeded:
 - `release` — creates the GitHub Release draft and binaries
-- `docker` — builds per-arch images and creates multi-arch manifests
+- `docker` — builds per-arch images and creates multi-arch manifests in GAR under `us-docker.pkg.dev/grafanalabs-global/dockerhub-tempo-prod-mirror/` for asynchronous mirroring to Docker Hub
+- Verify the tag appears in GAR first, then on Docker Hub after the mirror catches up
 - `publish-technical-documentation-release` — syncs docs (may show as failed if docs are already up to date; this is harmless)
 
 ## 7. Publish the GitHub Release


### PR DESCRIPTION
**What this PR does**:

Updates Docker image publishing to push to the GAR Docker Hub mirror repository instead of pushing directly to Docker Hub.

Images published by the `docker` workflow now go to:

```text
us-docker.pkg.dev/grafanalabs-global/dockerhub-tempo-prod-mirror/<image>:<tag>
```


