### PR TITLE
backend: fix double prefix in compactor and DeleteVersioned in azure and s3

### DIFF
--- a/.chloggen/7271_backend_double_prefix.yaml
+++ b/.chloggen/7271_backend_double_prefix.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: storage
+note: fix double prefix in compactor and DeleteVersioned in azure and s3.
+issues: [7271]
+subtext:
+user: electron0zero

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # v3.0.0
 
+* [BUGFIX] backend: fix double prefix in compactor and DeleteVersioned in azure and s3. [#7271](https://github.com/grafana/tempo/pull/7271) (@electron0zero)
 * [CHANGE] **BREAKING CHANGE** Recent data queries guarantee complete results by failing when an instance is lagging. Defaults `query_frontend.query_end_cutoff` to `30s` and `live_store.fail_on_high_lag` to `true`. [#7210](https://github.com/grafana/tempo/pull/7210) (@mapno)
 * [CHANGE] **BREAKING CHANGE** user-configurable overrides config `metrics_generator.processors` no longer merges with runtime overrides. `metrics_generator.processors` now takes precedence over the runtime overrides, matching every other config in user-configurable overrides. Setting `processors: []` disables all processors for the tenant. [#7176](https://github.com/grafana/tempo/pull/7176) (@electron0zero)
 * [CHANGE] Stop publishing 32-bit ARM binary archives. Release artifacts continue to include amd64 and arm64 binaries. [#7106](https://github.com/grafana/tempo/pull/7106) (@javiermolinar)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 # v3.0.0
 
-* [BUGFIX] backend: fix double prefix in compactor and DeleteVersioned in azure and s3. [#7271](https://github.com/grafana/tempo/pull/7271) (@electron0zero)
 * [CHANGE] **BREAKING CHANGE** Recent data queries guarantee complete results by failing when an instance is lagging. Defaults `query_frontend.query_end_cutoff` to `30s` and `live_store.fail_on_high_lag` to `true`. [#7210](https://github.com/grafana/tempo/pull/7210) (@mapno)
 * [CHANGE] **BREAKING CHANGE** user-configurable overrides config `metrics_generator.processors` no longer merges with runtime overrides. `metrics_generator.processors` now takes precedence over the runtime overrides, matching every other config in user-configurable overrides. Setting `processors: []` disables all processors for the tenant. [#7176](https://github.com/grafana/tempo/pull/7176) (@electron0zero)
 * [CHANGE] Stop publishing 32-bit ARM binary archives. Release artifacts continue to include amd64 and arm64 binaries. [#7106](https://github.com/grafana/tempo/pull/7106) (@javiermolinar)

--- a/tempodb/backend/azure/azure.go
+++ b/tempodb/backend/azure/azure.go
@@ -154,10 +154,15 @@ func (rw *Azure) CloseAppend(context.Context, backend.AppendTracker) error {
 
 func (rw *Azure) Delete(ctx context.Context, name string, keypath backend.KeyPath, _ *backend.CacheInfo) error {
 	keypath = backend.KeyPathWithPrefix(keypath, rw.cfg.Prefix)
+	return rw.deleteRaw(ctx, backend.ObjectFileName(keypath, name))
+}
 
-	blobClient, err := getBlobClient(ctx, rw.cfg, backend.ObjectFileName(keypath, name))
+// deleteRaw deletes a blob using its fully-qualified path verbatim. The caller
+// must include the configured prefix.
+func (rw *Azure) deleteRaw(ctx context.Context, path string) error {
+	blobClient, err := getBlobClient(ctx, rw.cfg, path)
 	if err != nil {
-		return fmt.Errorf("cannot get Azure blob client, name: %s: %w", backend.ObjectFileName(keypath, name), err)
+		return fmt.Errorf("cannot get Azure blob client, name: %s: %w", path, err)
 	}
 
 	snapshotType := blob.DeleteSnapshotsOptionTypeInclude
@@ -365,8 +370,7 @@ func (rw *Azure) WriteVersioned(ctx context.Context, name string, keypath backen
 }
 
 func (rw *Azure) DeleteVersioned(ctx context.Context, name string, keypath backend.KeyPath, version backend.Version) error {
-	keypath = backend.KeyPathWithPrefix(keypath, rw.cfg.Prefix)
-
+	// ReadVersioned and Delete both add the configured prefix; pre-prefixing here would double it.
 	// TODO use conditional if-match API
 	_, currentVersion, err := rw.ReadVersioned(ctx, name, keypath)
 	if err != nil && !errors.Is(err, backend.ErrDoesNotExist) {

--- a/tempodb/backend/azure/azure_test.go
+++ b/tempodb/backend/azure/azure_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/textproto"
 	"os"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -460,6 +461,148 @@ func TestListBlocksWithPrefix(t *testing.T) {
 			assert.ElementsMatchf(t, tc.compactedBlockIDs, compactedBlockIDs, "Compacted block IDs did not match")
 		})
 	}
+}
+
+func TestMarkBlockCompacted_DoesNotDoublePrefix(t *testing.T) {
+	const prefix = "a/b/c/"
+	tenantID := "test-tenant"
+	blockID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+
+	// path.Join normalizes the trailing slash on prefix.
+	expectedDeletePath := "/testing_account/blerg/a/b/c/" + tenantID + "/" + blockID.String() + "/" + backend.MetaName
+
+	const body = `{}`
+	var capturedDeletePath string
+	server := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			// readAll calls GetProperties first - SDK requires Content-Length and ETag.
+			w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+			w.Header().Set("ETag", `"etag123"`)
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			_, _ = w.Write([]byte(body))
+		case http.MethodPut:
+			w.WriteHeader(http.StatusCreated)
+		case http.MethodDelete:
+			capturedDeletePath = r.URL.Path
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	_, _, compactor, err := NewNoConfirm(&Config{
+		StorageAccountName: "testing_account",
+		StorageAccountKey:  flagext.SecretWithValue("YQo="),
+		MaxBuffers:         3,
+		BufferSize:         1000,
+		ContainerName:      "blerg",
+		Prefix:             prefix,
+		Endpoint:           server.URL[7:], // [7:] -> strip http://
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, compactor.MarkBlockCompacted(blockID, tenantID))
+	assert.Equal(t, expectedDeletePath, capturedDeletePath,
+		"DELETE key path must contain the configured prefix exactly once")
+}
+
+func TestClearBlock_DoesNotDoublePrefix(t *testing.T) {
+	const (
+		prefix   = "a/b/c/"
+		tenantID = "test-tenant"
+		blockID  = "00000000-0000-0000-0000-000000000002"
+		blobPath = "a/b/c/test-tenant/00000000-0000-0000-0000-000000000002/data.parquet"
+	)
+	expectedDeletePath := "/testing_account/blerg/" + blobPath
+
+	var capturedDeletePath string
+	server := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			assert.Equal(t, "a/b/c/test-tenant/"+blockID, r.URL.Query().Get("prefix"))
+			_, _ = w.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+				<EnumerationResults>
+				  <Prefix>a/b/c/</Prefix>
+				  <Blobs>
+				    <Blob>
+				      <Name>a/b/c/test-tenant/00000000-0000-0000-0000-000000000002/data.parquet</Name>
+				      <Properties>
+				        <Last-Modified>Fri, 01 Mar 2024 00:00:00 GMT</Last-Modified>
+				        <Etag>0x8CBFF45D8A29A19</Etag>
+				        <Content-Length>100</Content-Length>
+				        <BlobType>BlockBlob</BlobType>
+				      </Properties>
+				    </Blob>
+				  </Blobs>
+				  <NextMarker />
+				</EnumerationResults>`))
+		case http.MethodDelete:
+			capturedDeletePath = r.URL.Path
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	_, _, compactor, err := NewNoConfirm(&Config{
+		StorageAccountName: "testing_account",
+		StorageAccountKey:  flagext.SecretWithValue("YQo="),
+		MaxBuffers:         3,
+		BufferSize:         1000,
+		ContainerName:      "blerg",
+		Prefix:             prefix,
+		Endpoint:           server.URL[7:], // [7:] -> strip http://
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, compactor.ClearBlock(uuid.MustParse(blockID), tenantID))
+	assert.Equal(t, expectedDeletePath, capturedDeletePath,
+		"DELETE key path must contain the configured prefix exactly once")
+}
+
+func TestDeleteVersioned_DoesNotDoublePrefix(t *testing.T) {
+	const (
+		prefix             = "a/b/c/"
+		name               = "overrides.json"
+		etag               = `"etag123"`
+		body               = `{}`
+		expectedDeletePath = "/testing_account/blerg/a/b/c/overrides/tenant-1/" + name
+	)
+
+	var capturedDeletePath string
+	server := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+			w.Header().Set("ETag", etag)
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			w.Header().Set("ETag", etag)
+			_, _ = w.Write([]byte(body))
+		case http.MethodDelete:
+			capturedDeletePath = r.URL.Path
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	rw, err := NewVersionedReaderWriter(&Config{
+		StorageAccountName: "testing_account",
+		StorageAccountKey:  flagext.SecretWithValue("YQo="),
+		MaxBuffers:         3,
+		BufferSize:         1000,
+		ContainerName:      "blerg",
+		Prefix:             prefix,
+		Endpoint:           server.URL[7:], // [7:] -> strip http://
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, rw.DeleteVersioned(context.Background(), name, backend.KeyPath{"overrides", "tenant-1"}, backend.Version(etag)))
+	assert.Equal(t, expectedDeletePath, capturedDeletePath,
+		"DELETE key path must contain the configured prefix exactly once")
 }
 
 func testServer(t *testing.T, httpHandler http.HandlerFunc) *httptest.Server {

--- a/tempodb/backend/azure/compactor.go
+++ b/tempodb/backend/azure/compactor.go
@@ -44,8 +44,8 @@ func (rw *Azure) MarkBlockCompacted(blockID uuid.UUID, tenantID string) error {
 		return err
 	}
 
-	// delete the old file
-	return rw.Delete(ctx, metaFilename, []string{}, nil)
+	// metaFilename is already prefixed so use deleteRaw - rw.Delete would re-apply it.
+	return rw.deleteRaw(ctx, metaFilename)
 }
 
 func (rw *Azure) ClearBlock(blockID uuid.UUID, tenantID string) error {
@@ -78,7 +78,8 @@ func (rw *Azure) ClearBlock(blockID uuid.UUID, tenantID string) error {
 				return fmt.Errorf("unexpected empty blob name when listing %s: %w", prefix, err)
 			}
 
-			err = rw.Delete(ctx, *b.Name, []string{}, nil)
+			// b.Name from the listing is already prefixed so use deleteRaw - rw.Delete would re-apply it.
+			err = rw.deleteRaw(ctx, *b.Name)
 			if err != nil {
 				warning = err
 				continue

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -607,8 +607,7 @@ func (rw *readerWriter) DeleteVersioned(ctx context.Context, name string, keypat
 	// another process writes to the same object in between ReadVersioned and Delete its changes will
 	// be overwritten.
 	// TODO use rw.hedgedCore.GetObject, don't download the full object
-	keypath = backend.KeyPathWithPrefix(keypath, rw.cfg.Prefix)
-
+	// ReadVersioned and Delete both add the configured prefix; pre-prefixing here would double it.
 	_, currentVersion, err := rw.ReadVersioned(ctx, name, keypath)
 	if err != nil && !errors.Is(err, backend.ErrDoesNotExist) {
 		return err

--- a/tempodb/backend/s3/s3_test.go
+++ b/tempodb/backend/s3/s3_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -763,6 +764,56 @@ func TestObjectStorageClass(t *testing.T) {
 			require.Equal(t, tc.StorageClass, httpHeader.Get(storageClassHeader))
 		})
 	}
+}
+
+func TestDeleteVersioned_DoesNotDoublePrefix(t *testing.T) {
+	const (
+		prefix             = "a/b/c"
+		name               = "overrides.json"
+		etag               = `"etag123"`
+		body               = `{}`
+		expectedDeletePath = "/blerg/a/b/c/overrides/tenant-1/" + name
+	)
+
+	var capturedDeletePath string
+	server := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+			w.Header().Set("ETag", etag)
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			// New() probes the bucket with a list; ReadVersioned fetches the object body.
+			if strings.HasSuffix(r.URL.Path, "/"+name) {
+				w.Header().Set("ETag", etag)
+				w.Header().Set("Last-Modified", "Fri, 01 Mar 2024 00:00:00 GMT")
+				_, _ = w.Write([]byte(body))
+				return
+			}
+			_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><ListBucketResult></ListBucketResult>`))
+		case http.MethodDelete:
+			capturedDeletePath = r.URL.Path
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	rw, err := NewVersionedReaderWriter(&Config{
+		Region:    "blerg",
+		AccessKey: "test",
+		SecretKey: flagext.SecretWithValue("test"),
+		Bucket:    "blerg",
+		Prefix:    prefix,
+		Insecure:  true,
+		Endpoint:  server.URL[7:],
+	})
+	require.NoError(t, err)
+
+	// minio strips the surrounding quotes from the ETag in the response.
+	require.NoError(t, rw.DeleteVersioned(context.Background(), name, backend.KeyPath{"overrides", "tenant-1"}, backend.Version("etag123")))
+	assert.Equal(t, expectedDeletePath, capturedDeletePath,
+		"DELETE wire path must contain the configured prefix exactly once")
 }
 
 func testServer(t *testing.T, httpHandler http.HandlerFunc) *httptest.Server {


### PR DESCRIPTION
**What this PR does**:
Fixes a silent double-prefix bug in Azure and S3 backends. `MarkBlockCompacted`/`ClearBlock` (Azure) and `DeleteVersioned` (Azure + S3) passed already-prefixed paths to `rw.Delete`, which prepends the configured prefix again.

Example with `storage.trace.azure.prefix: a/b/c`:
- DELETE before: `/a/b/c/a/b/c/tenant/<id>/meta.json` -> 404, swallowed as `ErrDoesNotExist`, caller sees success while the real object is never deleted
- DELETE after: `/a/b/c/tenant/<id>/meta.json`

Fix matches GCS/local pattern: compactor uses a new `deleteRaw` helper that takes the path verbatim; `DeleteVersioned` no longer pre-prefixes.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated