### PR TITLE
ci: pin dlv to v1.26.3 in debug Dockerfile and add govulncheck job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,13 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
 
+  govulncheck:
+    name: Run govulncheck
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        with:
+          go-version-file: go.mod
 
   unit-tests:
     name: Run Unit Tests

--- a/cmd/tempo/Dockerfile_debug
+++ b/cmd/tempo/Dockerfile_debug
@@ -1,6 +1,6 @@
 FROM golang:1.26.2-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS build-dlv
 
-RUN go install github.com/go-delve/delve/cmd/dlv@latest
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.26.3
 
 FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 as certs
 RUN apk --update add ca-certificates bash


### PR DESCRIPTION
**What this PR does**:
- Pins `dlv` to `v1.26.3` in `cmd/tempo/Dockerfile_debug` (was `@latest`). Matches the repo's pinning convention.
- Adds a `govulncheck` job to `ci.yml` using the official `golang/govulncheck-action`. Runs on PRs against production code (test files skipped by govulncheck default). 

PS: it's not added as a required check, so failures are visible (red X) without blocking merges - flip to required check later via branch protection settings when we fixed all the CVE's reported by govulncheck.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated