### PR TITLE
bugfix: hash collision between instant and range queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [BUGFIX] user-configurable overrides: emit duration fields as flat YAML scalars on `/status/overrides/{tenant}` and omit `generate_native_histograms` when unset. [#7138](https://github.com/grafana/tempo/pull/7138) (@electron0zero)
 * [BUGFIX] Fix unsafe quoting in query attributes [#7220](https://github.com/grafana/tempo/pull/7220) (@ruslan-mikhailov)
 * [FEATURE] Support arithmetic operations in TraceQL Metrics [#6866](https://github.com/grafana/tempo/pull/6866) (@ruslan-mikhailov)
+* [BUGFIX] Fix rare cache collision between instant and range metrics queries [#7290](https://github.com/grafana/tempo/pull/7290) (@ruslan-mikhailov)
 
 # v3.0.0
 

--- a/modules/frontend/metrics_query_range_sharder.go
+++ b/modules/frontend/metrics_query_range_sharder.go
@@ -428,6 +428,13 @@ func hashForQueryRangeRequest(req *tempopb.QueryRangeRequest) uint64 {
 	for _, name := range req.SkipASTTransformations {
 		hash = fnv1a.AddString64(hash, name)
 	}
+	// adding a big number instead of 0 or 1
+	// to avoid hash collision on small input mutations
+	if traceql.IsInstant(req) {
+		hash = fnv1a.AddUint64(hash, 2147483629)
+	} else {
+		hash = fnv1a.AddUint64(hash, 1147483619)
+	}
 
 	return hash
 }

--- a/modules/frontend/metrics_query_range_sharder_test.go
+++ b/modules/frontend/metrics_query_range_sharder_test.go
@@ -441,3 +441,19 @@ func TestExemplarsCutoff(t *testing.T) {
 		})
 	}
 }
+
+func TestHashCollision(t *testing.T) {
+	queryRange := tempopb.QueryRangeRequest{
+		Query:     "{}",
+		Step:      60,
+		MaxSeries: 100,
+	}
+	queryRange.SetInstant(false)
+
+	instant := queryRange
+	instant.SetInstant(true)
+
+	baseHash := hashForQueryRangeRequest(&queryRange)
+	instantHash := hashForQueryRangeRequest(&instant)
+	assert.False(t, baseHash == instantHash, "Hash collision detected between range and instant query")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:  fixes hash collision. Impact of the issue is that querying query range with step == end - start, and then querying it as an instant query for the same time range will return result from the first query that might be incorrect under certain conditions. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`