### PR TITLE
chore: bump Tempo image tag to 3.0.0

### DIFF
--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
@@ -227,7 +227,7 @@ Install the `k.libsonnet`, Jsonnet, and Memcached libraries.
 
    tempo {
     _images+:: {
-          tempo: 'grafana/tempo:latest',
+          tempo: 'grafana/tempo:3.0.0',
       },
 
        tempo_distributor_container+:: container.withPorts([

--- a/example/docker-compose/distributed/docker-compose.yaml
+++ b/example/docker-compose/distributed/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   # tempo, backend and kafka
   distributor:
-    image: &tempoImage grafana/tempo:latest
+    image: &tempoImage grafana/tempo:3.0.0
     depends_on:
       - redpanda
     command: "-target=distributor -config.file=/etc/tempo.yaml"

--- a/example/docker-compose/migrate-to-3/README.md
+++ b/example/docker-compose/migrate-to-3/README.md
@@ -14,7 +14,7 @@ change.
 | Profile  | Components                                                                                                                                              |
 | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `v2`     | distributor, ingester, querier, query-frontend, compactor, metrics-generator (`grafana/tempo:2.9.2`)                                                    |
-| `v3`     | distributor, live-store ×2, block-builder ×2, querier, query-frontend, backend-scheduler, backend-worker, metrics-generator + Redpanda (`grafana/tempo:3.0.0-rc.1`) |
+| `v3`     | distributor, live-store ×2, block-builder ×2, querier, query-frontend, backend-scheduler, backend-worker, metrics-generator + Redpanda (`grafana/tempo:3.0.0`) |
 | _shared_ | MinIO (object storage), Prometheus, Grafana, Alloy (trace router), `xk6-client-tracing` (load generator)                            |
 
 | URL                                            | What                          |
@@ -281,8 +281,8 @@ The `-v` flag removes MinIO and Alloy data volumes.
 - **v3 live-store stuck "starting"** → Check Redpanda is up and the
   `tempo-ingest` topic exists with 2 partitions: `docker compose exec redpanda
   rpk topic describe tempo-ingest`.
-- **`grafana/tempo:latest` doesn't have 3.0 components** → The `latest` tag may
-  lag behind `main` for unreleased majors. Pin to a 3.0 RC tag explicitly in
-  `docker-compose.yaml`'s `x-tempo-v3-image` anchor.
+- **v3 services fail to start because the image is stale** → Confirm
+  `docker-compose.yaml`'s `x-tempo-v3-image` anchor points at a Tempo 3.0
+  release image.
 - **v3 queries return nothing for old traces** → Confirm v2 used vParquet4+
   blocks (this example sets `storage.trace.block.version: vParquet4`).

--- a/example/docker-compose/migrate-to-3/docker-compose.yaml
+++ b/example/docker-compose/migrate-to-3/docker-compose.yaml
@@ -15,7 +15,7 @@
 # See README.md for the step-by-step playbook.
 
 x-tempo-v2-image: &tempoV2Image grafana/tempo:2.9.2
-x-tempo-v3-image: &tempoV3Image grafana/tempo:3.0.0-rc.1
+x-tempo-v3-image: &tempoV3Image grafana/tempo:3.0.0
 
 services:
   # =========================================================================

--- a/example/docker-compose/multitenant/docker-compose.yaml
+++ b/example/docker-compose/multitenant/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   tempo:
-    image: grafana/tempo:latest
+    image: grafana/tempo:3.0.0
     command: [ "-config.file=/etc/tempo.yaml", "-target=all"]
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml

--- a/example/docker-compose/readme.md
+++ b/example/docker-compose/readme.md
@@ -32,10 +32,10 @@ See below for a list of all examples and the features they demonstrate
 
 ### Build images (optional)
 
-This step is not necessary, but it can be nice for local testing.  For any of the above examples rebuilding these
-images will cause docker compose to use your local code when running the examples.
-
-Run the following from the project root folder to build the `grafana/tempo:latest` image that is used in all the examples:
+This step is not necessary, but it can be nice for local testing. The examples use the released
+`grafana/tempo:3.0.0` image by default. To test local code, run the following from the project root
+folder and either update the compose files to use `grafana/tempo:latest` or tag the locally built image
+as `grafana/tempo:3.0.0`:
 
 ```console
 make docker-images

--- a/example/docker-compose/single-binary/docker-compose.yaml
+++ b/example/docker-compose/single-binary/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   tempo:
-    image: grafana/tempo:latest
+    image: grafana/tempo:3.0.0
     command: "-target=all -config.file=/etc/tempo.yaml"
     restart: always
     volumes:

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-distributor.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-distributor.yaml
@@ -29,7 +29,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=distributor
-        image: grafana/tempo:latest
+        image: grafana/tempo:3.0.0
         imagePullPolicy: IfNotPresent
         name: distributor
         ports:

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-metrics-generator.yaml
@@ -27,7 +27,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=metrics-generator
-        image: grafana/tempo:latest
+        image: grafana/tempo:3.0.0
         name: metrics-generator
         ports:
         - containerPort: 3200

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-querier.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-querier.yaml
@@ -29,7 +29,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=querier
-        image: grafana/tempo:latest
+        image: grafana/tempo:3.0.0
         imagePullPolicy: IfNotPresent
         name: querier
         ports:

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-query-frontend.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-query-frontend.yaml
@@ -27,7 +27,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=query-frontend
-        image: grafana/tempo:latest
+        image: grafana/tempo:3.0.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
         ports:

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-backend-scheduler.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-backend-scheduler.yaml
@@ -23,7 +23,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=backend-scheduler
-        image: grafana/tempo:latest
+        image: grafana/tempo:3.0.0
         imagePullPolicy: IfNotPresent
         name: backend-scheduler
         ports:

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-backend-worker.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-backend-worker.yaml
@@ -23,7 +23,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=backend-worker
-        image: grafana/tempo:latest
+        image: grafana/tempo:3.0.0
         imagePullPolicy: IfNotPresent
         name: backend-worker
         ports:

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-block-builder.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-block-builder.yaml
@@ -27,7 +27,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=block-builder
-        image: grafana/tempo:latest
+        image: grafana/tempo:3.0.0
         imagePullPolicy: IfNotPresent
         name: block-builder
         ports:

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-live-store-zone-a.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-live-store-zone-a.yaml
@@ -67,7 +67,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -target=live-store
         - -live-store.instance-availability-zone=zone-a
-        image: grafana/tempo:latest
+        image: grafana/tempo:3.0.0
         imagePullPolicy: IfNotPresent
         name: live-store
         ports:

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-live-store-zone-b.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-live-store-zone-b.yaml
@@ -68,7 +68,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -target=live-store
         - -live-store.instance-availability-zone=zone-b
-        image: grafana/tempo:latest
+        image: grafana/tempo:3.0.0
         imagePullPolicy: IfNotPresent
         name: live-store
         ports:

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-metrics-generator.yaml
@@ -32,7 +32,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=metrics-generator
-        image: grafana/tempo:latest
+        image: grafana/tempo:3.0.0
         name: metrics-generator
         ports:
         - containerPort: 3200

--- a/operations/jsonnet-compiled/microservices-with-extras/main.jsonnet
+++ b/operations/jsonnet-compiled/microservices-with-extras/main.jsonnet
@@ -6,7 +6,7 @@ tempo
 + tempo.util.withInet6()
   {
   _images+:: {
-    tempo: 'grafana/tempo:latest',
+    tempo: 'grafana/tempo:3.0.0',
     tempo_vulture: 'grafana/tempo-vulture:latest',
     tempo_query: 'grafana/tempo-query:latest',
   },

--- a/operations/jsonnet-compiled/microservices/gen/Deployment-distributor.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/Deployment-distributor.yaml
@@ -29,7 +29,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=distributor
-        image: grafana/tempo:latest
+        image: grafana/tempo:3.0.0
         imagePullPolicy: IfNotPresent
         name: distributor
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/Deployment-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/Deployment-metrics-generator.yaml
@@ -27,7 +27,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=metrics-generator
-        image: grafana/tempo:latest
+        image: grafana/tempo:3.0.0
         name: metrics-generator
         ports:
         - containerPort: 3200

--- a/operations/jsonnet-compiled/microservices/gen/Deployment-querier.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/Deployment-querier.yaml
@@ -29,7 +29,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=querier
-        image: grafana/tempo:latest
+        image: grafana/tempo:3.0.0
         imagePullPolicy: IfNotPresent
         name: querier
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/Deployment-query-frontend.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/Deployment-query-frontend.yaml
@@ -27,7 +27,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=query-frontend
-        image: grafana/tempo:latest
+        image: grafana/tempo:3.0.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-backend-scheduler.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-backend-scheduler.yaml
@@ -23,7 +23,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=backend-scheduler
-        image: grafana/tempo:latest
+        image: grafana/tempo:3.0.0
         imagePullPolicy: IfNotPresent
         name: backend-scheduler
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-backend-worker.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-backend-worker.yaml
@@ -23,7 +23,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=backend-worker
-        image: grafana/tempo:latest
+        image: grafana/tempo:3.0.0
         imagePullPolicy: IfNotPresent
         name: backend-worker
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-block-builder.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-block-builder.yaml
@@ -27,7 +27,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=block-builder
-        image: grafana/tempo:latest
+        image: grafana/tempo:3.0.0
         imagePullPolicy: IfNotPresent
         name: block-builder
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-live-store-zone-a.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-live-store-zone-a.yaml
@@ -67,7 +67,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -target=live-store
         - -live-store.instance-availability-zone=zone-a
-        image: grafana/tempo:latest
+        image: grafana/tempo:3.0.0
         imagePullPolicy: IfNotPresent
         name: live-store
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-live-store-zone-b.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-live-store-zone-b.yaml
@@ -68,7 +68,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -target=live-store
         - -live-store.instance-availability-zone=zone-b
-        image: grafana/tempo:latest
+        image: grafana/tempo:3.0.0
         imagePullPolicy: IfNotPresent
         name: live-store
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-metrics-generator.yaml
@@ -32,7 +32,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=metrics-generator
-        image: grafana/tempo:latest
+        image: grafana/tempo:3.0.0
         name: metrics-generator
         ports:
         - containerPort: 3200

--- a/operations/jsonnet-compiled/microservices/main.jsonnet
+++ b/operations/jsonnet-compiled/microservices/main.jsonnet
@@ -4,7 +4,7 @@ local tempo = import 'microservices/tempo.libsonnet';
 
 tempo {
   _images+:: {
-    tempo: 'grafana/tempo:latest',
+    tempo: 'grafana/tempo:3.0.0',
     tempo_vulture: 'grafana/tempo-vulture:latest',
     tempo_query: 'grafana/tempo-query:latest',
   },

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -1,6 +1,6 @@
 {
   _images+:: {
-    tempo: 'grafana/tempo:latest',
+    tempo: 'grafana/tempo:3.0.0',
     tempo_query: 'grafana/tempo-query:latest',
     tempo_vulture: 'grafana/tempo-vulture:latest',
     memcached: 'memcached:1.6.40-alpine',

--- a/operations/jsonnet/single-binary/config.libsonnet
+++ b/operations/jsonnet/single-binary/config.libsonnet
@@ -1,6 +1,6 @@
 {
   _images+:: {
-    tempo: 'grafana/tempo:latest',
+    tempo: 'grafana/tempo:3.0.0',
     tempo_query: 'grafana/tempo-query:latest',
     tempo_vulture: 'grafana/tempo-vulture:latest',
   },


### PR DESCRIPTION
**What this PR does**:

Bumps the Tempo image tag used by release examples and Jsonnet from `latest` / `v3.0.0-rc.1` to `3.0.0`, then regenerates compiled Jsonnet manifests.


Validation:
- `make bump-tempo-image-tag TEMPO_IMAGE_TAG=3.0.0`
- `make jsonnet`
- `git diff --check`
- verified no `grafana/tempo:latest` or `grafana/tempo:3.0.0-rc.1` remains in YAML/Jsonnet/Markdown release examples, except local-testing instructions mentioning `latest`


