### PR TITLE
ci(backport): bump grafana-github-actions-go pin to a version with signed commits

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -116,10 +116,9 @@ jobs:
           git config --global user.name "grafana-delivery-bot[bot]"
 
       - name: Run backport
-        uses: grafana/grafana-github-actions-go/backport@787c3c212b43ce951adcb68a816fd329c275a12d # main
+        uses: grafana/grafana-github-actions-go/backport@73932b01c802dd17e7a6218ba625365a4741d814
         with:
           token: ${{ steps.app-token.outputs.token }}
-          labelsToAdd: "backport"
           pr_number: ${{ needs.find-pr.outputs.pr_number }}
           repo_owner: ${{ github.repository_owner }}
           repo_name: ${{ github.event.repository.name }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -96,7 +96,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-      pull-requests: write
     steps:
       - name: Get GitHub App token
         id: app-token
@@ -110,13 +109,8 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
-      - name: Configure git identity
-        run: |
-          git config --global user.email "132647405+grafana-delivery-bot[bot]@users.noreply.github.com"
-          git config --global user.name "grafana-delivery-bot[bot]"
-
       - name: Run backport
-        uses: grafana/grafana-github-actions-go/backport@73932b01c802dd17e7a6218ba625365a4741d814
+        uses: grafana/grafana-github-actions-go/backport@6782bcaa01680648bdbba76cce1847e1862dbb22
         with:
           token: ${{ steps.app-token.outputs.token }}
           pr_number: ${{ needs.find-pr.outputs.pr_number }}


### PR DESCRIPTION
The org is heading toward required signed commits on protected branches. This PR migrates the backport workflow to a version of \`grafana/grafana-github-actions-go/backport\` that publishes via GitHub's GraphQL \`createCommitOnBranch\` mutation, so backport commits are signed on behalf of \`tempo-ci-app\`.

Changes:
- Bump action pin \`787c3c21…\` → \`6782bcaa…\` (current head of grafana-github-actions-go main; includes signed-commit support and the upstream fix for external consumers landed in [grafana-github-actions-go#208](https://github.com/grafana/grafana-github-actions-go/pull/208)).
- Drop \`labelsToAdd: \"backport\"\` — the input was removed from the action's schema, but the new action [hardcodes \`backport\` as a label](https://github.com/grafana/grafana-github-actions-go/blob/6782bcaa01680648bdbba76cce1847e1862dbb22/backport/backport.go#L163-L166) on every PR it creates, so the resulting label set is unchanged.
- Drop the \`Configure git identity\` step — the new action sets a default committer identity itself.
- Drop unused \`pull-requests: write\` from the backport job's permissions — every PR-mutating step uses the App token (which has its own \`pull_requests: write\` granted via GATB), not the default \`GITHUB_TOKEN\`. Matches mimir's permissions.

I've tested the equivalent change end-to-end in \`grafana/mimir\`. I will not test it here — codeowners are responsible for validating it post-merge on a real sentinel PR labeled \`backport release-X.Y\`.