### PR TITLE
chore(dep) replace davecgh/go-spew debug dumps

### DIFF
--- a/cmd/tempo-cli/cmd-query-trace-summary.go
+++ b/cmd/tempo-cli/cmd-query-trace-summary.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/google/uuid"
 
 	"github.com/grafana/tempo/pkg/boundedwaitgroup"
@@ -52,8 +51,7 @@ func (cmd *queryTraceSummaryCmd) Run(ctx *globalOptions) error {
 
 	fmt.Println("Root span info:")
 	if traceSummary.RootSpan != nil {
-		scs := spew.ConfigState{DisableMethods: true, Indent: " "}
-		scs.Dump(traceSummary.RootSpan)
+		fmt.Printf("%#v\n", traceSummary.RootSpan)
 	} else {
 		fmt.Println("No root span found")
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/alicebob/miniredis/v2 v2.37.0
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/cristalhq/hedgedhttp v0.9.1
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/drone/envsubst v1.0.3
 	github.com/dustin/go-humanize v1.0.1
 	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb

--- a/pkg/traceql/ast_validate_test.go
+++ b/pkg/traceql/ast_validate_test.go
@@ -2,10 +2,10 @@ package traceql
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
@@ -64,14 +64,13 @@ func TestExamples(t *testing.T) {
 		})
 	}
 
-	scs := spew.ConfigState{DisableMethods: true, Indent: " "}
 	for _, q := range queries.Dump {
 		t.Run("dump - "+q, func(t *testing.T) {
 			yyDebug = 3
 			p, err := Parse(q)
 			yyDebug = 0
 			require.NoError(t, err)
-			scs.Dump(p)
+			fmt.Printf("%#v\n", p)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does**:
Replace davecgh/go-spew debug dumps with stdlib fmt `%#v`.
Reason: dependency can be easily replaced.

**Which issue(s) this PR fixes**:
Contributes to #7218

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`