### PR TITLE
deps: drop direct go.uber.org/atomic dependency

### DIFF
--- a/modules/blockbuilder/blockbuilder_test.go
+++ b/modules/blockbuilder/blockbuilder_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -31,7 +32,6 @@ import (
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
-	"go.uber.org/atomic"
 )
 
 const (
@@ -53,9 +53,9 @@ func TestBlockbuilder_lookbackOnNoCommit(t *testing.T) {
 
 	k, address := testkafka.CreateCluster(t, 1, testTopic)
 
-	kafkaCommits := atomic.NewInt32(0)
+	kafkaCommits := &atomic.Int32{}
 	k.ControlKey(kmsg.OffsetCommit, func(kmsg.Request) (kmsg.Response, error, bool) {
-		kafkaCommits.Inc()
+		kafkaCommits.Add(1)
 		return nil, nil, false
 	})
 
@@ -92,9 +92,9 @@ func TestBlockbuilder_without_partitions_assigned_returns_an_error(t *testing.T)
 
 	k, address := testkafka.CreateCluster(t, 1, testTopic)
 
-	kafkaCommits := atomic.NewInt32(0)
+	kafkaCommits := &atomic.Int32{}
 	k.ControlKey(kmsg.OffsetCommit, func(kmsg.Request) (kmsg.Response, error, bool) {
-		kafkaCommits.Inc()
+		kafkaCommits.Add(1)
 		return nil, nil, false
 	})
 
@@ -130,9 +130,9 @@ func TestBlockbuilder_fetchMetricsIncrement(t *testing.T) {
 	t.Cleanup(func() { cancel(errors.New("test done")) })
 
 	k, address := testkafka.CreateCluster(t, 1, testTopic)
-	kafkaCommits := atomic.NewInt32(0)
+	kafkaCommits := &atomic.Int32{}
 	k.ControlKey(kmsg.OffsetCommit, func(kmsg.Request) (kmsg.Response, error, bool) {
-		kafkaCommits.Inc()
+		kafkaCommits.Add(1)
 		return nil, nil, false
 	})
 
@@ -176,9 +176,9 @@ func TestBlockbuilder_startWithCommit(t *testing.T) {
 
 	k, address := testkafka.CreateCluster(t, 100, testTopic)
 
-	kafkaCommits := atomic.NewInt32(0)
+	kafkaCommits := &atomic.Int32{}
 	k.ControlKey(kmsg.OffsetCommit, func(kmsg.Request) (kmsg.Response, error, bool) {
-		kafkaCommits.Inc()
+		kafkaCommits.Add(1)
 		return nil, nil, false
 	})
 
@@ -230,16 +230,16 @@ func TestBlockbuilder_flushingFails(t *testing.T) {
 
 	k, address := testkafka.CreateCluster(t, 1, "test-topic")
 
-	kafkaCommits := atomic.NewInt32(0)
+	kafkaCommits := &atomic.Int32{}
 	k.ControlKey(kmsg.OffsetCommit, func(kmsg.Request) (kmsg.Response, error, bool) {
-		kafkaCommits.Inc()
+		kafkaCommits.Add(1)
 		return nil, nil, false
 	})
 
-	storageWrites := atomic.NewInt32(0)
+	storageWrites := &atomic.Int32{}
 	store := newStoreWrapper(newStore(ctx, t), func(ctx context.Context, block tempodb.WriteableBlock, store storage.Store) error {
 		// Fail the first block write
-		if storageWrites.Inc() == 1 {
+		if storageWrites.Add(1) == 1 {
 			return errors.New("failed to write block")
 		}
 		return store.WriteBlock(ctx, block)
@@ -276,9 +276,9 @@ func TestBlockbuilder_receivesOldRecords(t *testing.T) {
 
 	k, address := testkafka.CreateCluster(t, 1, "test-topic")
 
-	kafkaCommits := atomic.NewInt32(0)
+	kafkaCommits := &atomic.Int32{}
 	k.ControlKey(kmsg.OffsetCommit, func(kmsg.Request) (kmsg.Response, error, bool) {
-		kafkaCommits.Inc()
+		kafkaCommits.Add(1)
 		return nil, nil, false
 	})
 
@@ -345,9 +345,9 @@ func TestBlockbuilder_committingFails(t *testing.T) {
 
 	k, address := testkafka.CreateCluster(t, 1, "test-topic")
 
-	kafkaCommits := atomic.NewInt32(0)
+	kafkaCommits := &atomic.Int32{}
 	k.ControlKey(kmsg.OffsetCommit, func(req kmsg.Request) (kmsg.Response, error, bool) {
-		kafkaCommits.Inc()
+		kafkaCommits.Add(1)
 
 		if kafkaCommits.Load() == 1 { // First commit fails
 			res := kmsg.NewOffsetCommitResponse()
@@ -402,9 +402,9 @@ func TestBlockbuilder_retries_on_retriable_commit_error(t *testing.T) {
 
 	k, address := testkafka.CreateCluster(t, 1, "test-topic")
 
-	kafkaCommits := atomic.NewInt32(0)
+	kafkaCommits := &atomic.Int32{}
 	k.ControlKey(kmsg.OffsetCommit, func(req kmsg.Request) (kmsg.Response, error, bool) {
-		kafkaCommits.Inc()
+		kafkaCommits.Add(1)
 
 		if kafkaCommits.Load() == 1 {
 			res := kmsg.NewOffsetCommitResponse()
@@ -461,9 +461,9 @@ func TestBlockbuilder_retries_on_commit_error(t *testing.T) {
 
 	k, address := testkafka.CreateCluster(t, 1, "test-topic")
 
-	kafkaCommits := atomic.NewInt32(0)
+	kafkaCommits := &atomic.Int32{}
 	k.ControlKey(kmsg.OffsetCommit, func(req kmsg.Request) (kmsg.Response, error, bool) {
-		kafkaCommits.Inc()
+		kafkaCommits.Add(1)
 
 		if kafkaCommits.Load() == 1 {
 			res := kmsg.NewOffsetCommitResponse()
@@ -521,9 +521,9 @@ func TestBlockbuilder_noDoubleConsumption(t *testing.T) {
 	k, address := testkafka.CreateCluster(t, 1, testTopic)
 
 	// Track commits
-	kafkaCommits := atomic.NewInt32(0)
+	kafkaCommits := &atomic.Int32{}
 	k.ControlKey(kmsg.OffsetCommit, func(_ kmsg.Request) (kmsg.Response, error, bool) {
-		kafkaCommits.Inc()
+		kafkaCommits.Add(1)
 		return nil, nil, false
 	})
 
@@ -608,15 +608,15 @@ func TestBlockBuilder_honor_maxBytesPerCycle(t *testing.T) {
 
 			k, address := testkafka.CreateCluster(t, 1, "test-topic")
 
-			kafkaCommits := atomic.NewInt32(0)
+			kafkaCommits := &atomic.Int32{}
 			k.ControlKey(kmsg.OffsetCommit, func(kmsg.Request) (kmsg.Response, error, bool) {
-				kafkaCommits.Inc()
+				kafkaCommits.Add(1)
 				return nil, nil, false
 			})
 
-			storageWrites := atomic.NewInt32(0)
+			storageWrites := &atomic.Int32{}
 			store := newStoreWrapper(newStore(ctx, t), func(ctx context.Context, block tempodb.WriteableBlock, store storage.Store) error {
-				storageWrites.Inc()
+				storageWrites.Add(1)
 				return store.WriteBlock(ctx, block)
 			})
 
@@ -697,9 +697,9 @@ func TestBlockbuilder_usesRecordTimestampForBlockStartAndEnd(t *testing.T) {
 
 			k, address := testkafka.CreateCluster(t, 1, testTopic)
 
-			kafkaCommits := atomic.NewInt32(0)
+			kafkaCommits := &atomic.Int32{}
 			k.ControlKey(kmsg.OffsetCommit, func(kmsg.Request) (kmsg.Response, error, bool) {
-				kafkaCommits.Inc()
+				kafkaCommits.Add(1)
 				return nil, nil, false
 			})
 
@@ -759,9 +759,9 @@ func TestBlockbuilder_marksOldBlocksCompacted(t *testing.T) {
 	k, address := testkafka.CreateCluster(t, 1, testTopic)
 
 	// Track commits
-	kafkaCommits := atomic.NewInt32(0)
+	kafkaCommits := &atomic.Int32{}
 	k.ControlKey(kmsg.OffsetCommit, func(_ kmsg.Request) (kmsg.Response, error, bool) {
-		kafkaCommits.Inc()
+		kafkaCommits.Add(1)
 		return nil, nil, false
 	})
 
@@ -781,14 +781,14 @@ func TestBlockbuilder_marksOldBlocksCompacted(t *testing.T) {
 	lastRecordOffset := producedRecords[len(producedRecords)-1].Offset
 
 	// Simulate failures on the first cycle
-	badWrites := atomic.NewInt32(0)
-	goodWrites := atomic.NewInt32(0)
+	badWrites := &atomic.Int32{}
+	goodWrites := &atomic.Int32{}
 	goodBlockIDs := []backend.UUID{}
 	store := newStoreWrapper(newStore(ctx, t), func(ctx context.Context, block tempodb.WriteableBlock, store storage.Store) error {
 		switch block.BlockMeta().TenantID {
 		case badTenantID:
 			// First flush on tenant 2 fails
-			if badWrites.Inc() == 1 {
+			if badWrites.Add(1) == 1 {
 				// Wait until flush on good tenant is complete
 				// and then return the error. Tenants are flushed in parallel
 				// so this is required to ensure we get a block flushed on the first cycle.
@@ -799,7 +799,7 @@ func TestBlockbuilder_marksOldBlocksCompacted(t *testing.T) {
 			}
 		case goodTenantID:
 			// Save all blocks flushed for good tenant
-			defer goodWrites.Inc()
+			defer goodWrites.Add(1)
 			goodBlockIDs = append(goodBlockIDs, block.BlockMeta().BlockID)
 		}
 		return store.WriteBlock(ctx, block)
@@ -1251,9 +1251,9 @@ func TestBlockbuilder_PartitionWithNoLag(t *testing.T) {
 	_, address := testkafka.CreateCluster(t, 2, testTopic)
 
 	// Setup block-builder
-	storageWrites := atomic.NewInt32(0)
+	storageWrites := &atomic.Int32{}
 	store := newStoreWrapper(newStore(ctx, t), func(ctx context.Context, block tempodb.WriteableBlock, store storage.Store) error {
-		storageWrites.Inc()
+		storageWrites.Add(1)
 		return store.WriteBlock(ctx, block)
 	})
 	cfg := blockbuilderConfig(t, address, []int32{0, 1})

--- a/modules/blockbuilder/util/id.go
+++ b/modules/blockbuilder/util/id.go
@@ -4,10 +4,10 @@ import (
 	"crypto/sha1"
 	"encoding/binary"
 	"hash"
+	"sync/atomic"
 
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/tempodb/backend"
-	"go.uber.org/atomic"
 )
 
 const (
@@ -24,14 +24,13 @@ var _ IDGenerator = (*DeterministicIDGenerator)(nil)
 
 type DeterministicIDGenerator struct {
 	buf  []byte
-	seq  *atomic.Uint64
+	seq  atomic.Uint64
 	hash hash.Hash
 }
 
 func NewDeterministicIDGenerator(tenantID string, seeds ...uint64) *DeterministicIDGenerator {
 	return &DeterministicIDGenerator{
 		buf:  newBuf([]byte(tenantID), seeds),
-		seq:  atomic.NewUint64(0),
 		hash: sha1.New(),
 	}
 }
@@ -49,7 +48,7 @@ func newBuf(tenantID []byte, seeds []uint64) []byte {
 }
 
 func (d *DeterministicIDGenerator) NewID() backend.UUID {
-	return backend.UUID(newDeterministicID(d.hash, d.buf, d.seq.Inc()))
+	return backend.UUID(newDeterministicID(d.hash, d.buf, d.seq.Add(1)))
 }
 
 func newDeterministicID(hash hash.Hash, data []byte, seq uint64) uuid.UUID {

--- a/modules/blockbuilder/writeable_block.go
+++ b/modules/blockbuilder/writeable_block.go
@@ -3,6 +3,7 @@ package blockbuilder
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -10,7 +11,6 @@ import (
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/grafana/tempo/tempodb/encoding/common"
-	"go.uber.org/atomic"
 )
 
 // Overrides is just the set of overrides needed here.

--- a/modules/distributor/forwarder/otlpgrpc/forwarder_test.go
+++ b/modules/distributor/forwarder/otlpgrpc/forwarder_test.go
@@ -3,6 +3,7 @@ package otlpgrpc
 import (
 	"context"
 	"net"
+	"sync/atomic"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -10,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
 )

--- a/modules/distributor/queue/queue_test.go
+++ b/modules/distributor/queue/queue_test.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 )
 
 func newQueue[T any](t *testing.T, size, workerCount int, processFunc ProcessFunc[T]) *Queue[T] {
@@ -69,13 +69,13 @@ func TestNew_ReturnsNotNilAndSetsCorrectFieldsFromConfig(t *testing.T) {
 
 func TestQueue_Push_ReturnsNoErrorAndWorkersInvokeProcessFuncCorrectNumberOfTimesWithRunningWorkers(t *testing.T) {
 	// Given
-	count := atomic.NewUint32(0)
+	count := &atomic.Uint32{}
 	wg := sync.WaitGroup{}
 	size := 10
 	workerCount := 3
 	processFunc := func(context.Context, any) {
 		defer wg.Done()
-		count.Inc()
+		count.Add(1)
 	}
 	q := newStartedQueue(t, size, workerCount, processFunc)
 
@@ -130,13 +130,13 @@ func TestQueue_Push_ReturnsErrorWhenPushingItemsToShutdownQueue(t *testing.T) {
 
 func TestQueue_Push_QueueGetsProperlyDrainedOnShutdown(t *testing.T) {
 	// Given
-	count := atomic.NewUint32(0)
+	count := &atomic.Uint32{}
 	wg := sync.WaitGroup{}
 	size := 10
 	workerCount := 3
 	processFunc := func(context.Context, any) {
 		defer wg.Done()
-		count.Inc()
+		count.Add(1)
 	}
 	q := newQueue(t, size, workerCount, processFunc)
 

--- a/modules/frontend/pipeline/async_handler_multitenant_test.go
+++ b/modules/frontend/pipeline/async_handler_multitenant_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -16,7 +17,6 @@ import (
 	"github.com/grafana/tempo/modules/frontend/combiner"
 	"github.com/grafana/tempo/pkg/util/test"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 )
 
 func TestMultiTenant(t *testing.T) {
@@ -53,7 +53,7 @@ func TestMultiTenant(t *testing.T) {
 
 			once := sync.Once{}
 			next := AsyncRoundTripperFunc[combiner.PipelineResponse](func(req Request) (Responses[combiner.PipelineResponse], error) {
-				reqCount.Inc() // Count the number of requests.
+				reqCount.Add(1) // Count the number of requests.
 
 				// Check if the tenant is in the list of tenants.
 				tenantID, err := user.ExtractOrgID(req.Context())

--- a/modules/frontend/pipeline/collector_http.go
+++ b/modules/frontend/pipeline/collector_http.go
@@ -5,9 +5,8 @@ import (
 	"net/http"
 	"sync"
 
-	"go.uber.org/atomic"
-
 	"github.com/grafana/tempo/modules/frontend/combiner"
+	"github.com/grafana/tempo/pkg/util/atomicx"
 )
 
 type httpCollector struct {
@@ -66,7 +65,7 @@ func (r httpCollector) RoundTrip(req *http.Request) (*http.Response, error) {
 
 func consumeAndCombineResponses(ctx context.Context, consumers int, resps Responses[combiner.PipelineResponse], c combiner.Combiner, callback func() error) error {
 	respChan := make(chan combiner.PipelineResponse)
-	overallErr := atomic.Error{}
+	var overallErr atomicx.Error
 	wg := sync.WaitGroup{}
 
 	setErr := func(err error) {

--- a/modules/frontend/pipeline/responses.go
+++ b/modules/frontend/pipeline/responses.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/grafana/tempo/modules/frontend/combiner"
-	"go.uber.org/atomic"
+	"github.com/grafana/tempo/pkg/util/atomicx"
 )
 
 type Responses[T any] interface {
@@ -97,7 +97,7 @@ var _ Responses[combiner.PipelineResponse] = &asyncResponse{}
 type asyncResponse struct {
 	respChan chan Responses[combiner.PipelineResponse]
 	errChan  chan error
-	err      *atomic.Error
+	err      *atomicx.Error
 
 	curResponses Responses[combiner.PipelineResponse]
 }
@@ -106,7 +106,7 @@ func newAsyncResponse() *asyncResponse {
 	return &asyncResponse{
 		respChan: make(chan Responses[combiner.PipelineResponse]),
 		errChan:  make(chan error, 1),
-		err:      atomic.NewError(nil),
+		err:      atomicx.NewError(nil),
 	}
 }
 

--- a/modules/frontend/pipeline/responses_test.go
+++ b/modules/frontend/pipeline/responses_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -16,7 +17,6 @@ import (
 	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"go.uber.org/goleak"
 )
 

--- a/modules/frontend/pipeline/sync_handler_retry_test.go
+++ b/modules/frontend/pipeline/sync_handler_retry_test.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 )
 
 func TestRetry(t *testing.T) {
@@ -27,7 +27,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "retry errors until success",
 			handler: RoundTripperFunc(func(_ Request) (*http.Response, error) {
-				if try.Inc() == 5 {
+				if try.Add(1) == 5 {
 					return &http.Response{StatusCode: 200}, nil
 				}
 				return nil, errors.New("this request failed")
@@ -40,7 +40,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "don't retry 400's",
 			handler: RoundTripperFunc(func(_ Request) (*http.Response, error) {
-				try.Inc()
+				try.Add(1)
 				return &http.Response{StatusCode: 400}, nil
 			}),
 			maxRetries:    5,
@@ -51,7 +51,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "don't retry GRPC request with HTTP 400's",
 			handler: RoundTripperFunc(func(_ Request) (*http.Response, error) {
-				try.Inc()
+				try.Add(1)
 				return nil, httpgrpc.ErrorFromHTTPResponse(&httpgrpc.HTTPResponse{Code: 400})
 			}),
 			maxRetries:    5,
@@ -62,7 +62,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "retry 500s",
 			handler: RoundTripperFunc(func(_ Request) (*http.Response, error) {
-				try.Inc()
+				try.Add(1)
 				return &http.Response{StatusCode: 503}, nil
 			}),
 			maxRetries:    5,
@@ -73,7 +73,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "return last error",
 			handler: RoundTripperFunc(func(_ Request) (*http.Response, error) {
-				if try.Inc() == 5 {
+				if try.Add(1) == 5 {
 					return nil, errors.New("request failed")
 				}
 				return nil, errors.New("not the last request")
@@ -86,7 +86,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "maxRetries=1",
 			handler: RoundTripperFunc(func(_ Request) (*http.Response, error) {
-				try.Inc()
+				try.Add(1)
 				return &http.Response{StatusCode: 500}, nil
 			}),
 			maxRetries:    1,
@@ -97,7 +97,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "maxRetries=0",
 			handler: RoundTripperFunc(func(_ Request) (*http.Response, error) {
-				try.Inc()
+				try.Add(1)
 				return &http.Response{StatusCode: 500}, nil
 			}),
 			maxRetries:    0,
@@ -135,7 +135,7 @@ func TestRetry_CancelledRequest(t *testing.T) {
 
 	_, err = NewRetryWare(5, false, prometheus.NewRegistry()).
 		Wrap(RoundTripperFunc(func(_ Request) (*http.Response, error) {
-			try.Inc()
+			try.Add(1)
 			return nil, ctx.Err()
 		})).RoundTrip(NewHTTPRequest(req))
 
@@ -150,7 +150,7 @@ func TestRetry_CancelledRequest(t *testing.T) {
 
 	_, err = NewRetryWare(5, false, prometheus.NewRegistry()).
 		Wrap(RoundTripperFunc(func(_ Request) (*http.Response, error) {
-			try.Inc()
+			try.Add(1)
 			cancel()
 			return nil, errors.New("this request failed")
 		})).RoundTrip(NewHTTPRequest(req))

--- a/modules/frontend/queue/queue_test.go
+++ b/modules/frontend/queue/queue_test.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 )
 
 const messages = 50_000
@@ -35,10 +35,10 @@ func TestGetNextForQuerierOneUser(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	stop := make(chan struct{})
-	requestsPulled := atomic.NewInt32(0)
+	requestsPulled := &atomic.Int32{}
 
 	q, start := queueWithListeners(ctx, 100, 1, func(_ []Request) {
-		i := requestsPulled.Inc()
+		i := requestsPulled.Add(1)
 		if i == int32(messages) {
 			close(stop)
 		}
@@ -65,10 +65,10 @@ func TestGetNextForQuerierRandomUsers(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	stop := make(chan struct{})
-	requestsPulled := atomic.NewInt32(0)
+	requestsPulled := &atomic.Int32{}
 
 	q, start := queueWithListeners(ctx, 100, 1, func(_ []Request) {
-		if requestsPulled.Inc() == int32(messages) {
+		if requestsPulled.Add(1) == int32(messages) {
 			close(stop)
 		}
 	})
@@ -94,7 +94,7 @@ func TestGetNextBatches(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	stop := make(chan struct{})
-	requestsPulled := atomic.NewInt32(0)
+	requestsPulled := &atomic.Int32{}
 
 	q, start := queueWithListeners(ctx, 100, 3, func(r []Request) {
 		if requestsPulled.Add(int32(len(r))) == int32(messages) {
@@ -134,10 +134,10 @@ func benchmarkGetNextForQuerier(b *testing.B, listeners int, messages int) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	stop := make(chan struct{})
-	requestsPulled := atomic.NewInt32(0)
+	requestsPulled := &atomic.Int32{}
 
 	q, start := queueWithListeners(ctx, listeners, 1, func(_ []Request) {
-		if requestsPulled.Inc() == int32(messages) {
+		if requestsPulled.Add(1) == int32(messages) {
 			stop <- struct{}{}
 		}
 	})
@@ -154,7 +154,7 @@ func benchmarkGetNextForQuerier(b *testing.B, listeners int, messages int) {
 		}
 
 		<-stop
-		requestsPulled.Sub(int32(messages))
+		requestsPulled.Add(-int32(messages))
 	}
 
 	err := q.stopping(nil)

--- a/modules/frontend/search_handlers_test.go
+++ b/modules/frontend/search_handlers_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -22,7 +23,6 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 
@@ -96,7 +96,7 @@ type mockGRPCStreaming[T proto.Message] struct {
 
 func (m *mockGRPCStreaming[T]) Send(r T) error {
 	m.lastResponse.Store(&r)
-	m.responses.Inc()
+	m.responses.Add(1)
 	if m.cb != nil {
 		m.cb(int(m.responses.Load()), r)
 	}

--- a/modules/generator/generator.go
+++ b/modules/generator/generator.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -18,7 +19,6 @@ import (
 	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/grafana/tempo/modules/generator/storage"

--- a/modules/generator/instance.go
+++ b/modules/generator/instance.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -26,8 +27,6 @@ import (
 	"github.com/grafana/tempo/modules/generator/validation"
 	"github.com/grafana/tempo/pkg/tempopb"
 	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
-
-	"go.uber.org/atomic"
 )
 
 var (

--- a/modules/generator/localserieslimiter/local_series_limiter.go
+++ b/modules/generator/localserieslimiter/local_series_limiter.go
@@ -1,7 +1,7 @@
 package localserieslimiter
 
 import (
-	"go.uber.org/atomic"
+	"sync/atomic"
 
 	"github.com/grafana/tempo/modules/generator/registry"
 	tempo_log "github.com/grafana/tempo/pkg/util/log"
@@ -127,7 +127,7 @@ func (l *LocalSeriesLimiter) OnDelete(hash uint64, seriesCount uint32) {
 		seriesCount = activeSeries
 	}
 
-	l.activeSeries.Sub(seriesCount)
+	l.activeSeries.Add(^(seriesCount - 1))
 	l.metricActiveSeries.Set(float64(l.activeSeries.Load()))
 	l.metricTotalSeriesRemoved.Add(float64(seriesCount))
 }

--- a/modules/generator/registry/counter.go
+++ b/modules/generator/registry/counter.go
@@ -107,15 +107,11 @@ func resolveSeries[T any](series map[uint64]*T, hash uint64, lbls labels.Labels,
 }
 
 func (c *counter) newSeries(lbls labels.Labels, value float64) *counterSeries {
-	lastUpdated := &atomic.Int64{}
-	lastUpdated.Store(time.Now().UnixMilli())
-	firstSeries := &atomic.Bool{}
-	firstSeries.Store(true)
 	return &counterSeries{
 		labels:      getSeriesLabels(c.metricName, lbls, c.externalLabels),
 		value:       atomicx.NewFloat64(value),
-		lastUpdated: lastUpdated,
-		firstSeries: firstSeries,
+		lastUpdated: atomicx.NewInt64(time.Now().UnixMilli()),
+		firstSeries: atomicx.NewBool(true),
 	}
 }
 

--- a/modules/generator/registry/counter.go
+++ b/modules/generator/registry/counter.go
@@ -2,11 +2,12 @@ package registry
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/grafana/tempo/pkg/util/atomicx"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
-	"go.uber.org/atomic"
 )
 
 type counter struct {
@@ -26,7 +27,7 @@ type counter struct {
 
 type counterSeries struct {
 	labels      labels.Labels
-	value       *atomic.Float64
+	value       *atomicx.Float64
 	lastUpdated *atomic.Int64
 	// firstSeries is used to track if this series is new to the counter.  This
 	// is used to ensure that new counters being with 0, and then are incremented
@@ -106,11 +107,15 @@ func resolveSeries[T any](series map[uint64]*T, hash uint64, lbls labels.Labels,
 }
 
 func (c *counter) newSeries(lbls labels.Labels, value float64) *counterSeries {
+	lastUpdated := &atomic.Int64{}
+	lastUpdated.Store(time.Now().UnixMilli())
+	firstSeries := &atomic.Bool{}
+	firstSeries.Store(true)
 	return &counterSeries{
 		labels:      getSeriesLabels(c.metricName, lbls, c.externalLabels),
-		value:       atomic.NewFloat64(value),
-		lastUpdated: atomic.NewInt64(time.Now().UnixMilli()),
-		firstSeries: atomic.NewBool(true),
+		value:       atomicx.NewFloat64(value),
+		lastUpdated: lastUpdated,
+		firstSeries: firstSeries,
 	}
 }
 

--- a/modules/generator/registry/counter_test.go
+++ b/modules/generator/registry/counter_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/tempo/pkg/util/atomicx"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/atomic"
 )
 
 func Test_counter(t *testing.T) {
@@ -246,7 +246,7 @@ func Test_counter_concurrencyCorrectness(t *testing.T) {
 	var wg sync.WaitGroup
 	end := make(chan struct{})
 
-	totalCount := atomic.NewFloat64(0)
+	totalCount := atomicx.NewFloat64(0)
 
 	for i := 0; i < 4; i++ {
 		wg.Add(1)

--- a/modules/generator/registry/gauge.go
+++ b/modules/generator/registry/gauge.go
@@ -101,12 +101,10 @@ func (g *gauge) updateSeries(lbls labels.Labels, value float64, operation string
 }
 
 func (g *gauge) newSeries(lbls labels.Labels, value float64) *gaugeSeries {
-	lastUpdated := &atomic.Int64{}
-	lastUpdated.Store(time.Now().UnixMilli())
 	return &gaugeSeries{
 		labels:      getSeriesLabels(g.metricName, lbls, g.externalLabels),
 		value:       atomicx.NewFloat64(value),
-		lastUpdated: lastUpdated,
+		lastUpdated: atomicx.NewInt64(time.Now().UnixMilli()),
 	}
 }
 

--- a/modules/generator/registry/gauge.go
+++ b/modules/generator/registry/gauge.go
@@ -2,11 +2,12 @@ package registry
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/grafana/tempo/pkg/util/atomicx"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
-	"go.uber.org/atomic"
 )
 
 var _ metric = (*gauge)(nil)
@@ -30,7 +31,7 @@ type gauge struct {
 
 type gaugeSeries struct {
 	labels      labels.Labels
-	value       *atomic.Float64
+	value       *atomicx.Float64
 	lastUpdated *atomic.Int64
 }
 
@@ -100,10 +101,12 @@ func (g *gauge) updateSeries(lbls labels.Labels, value float64, operation string
 }
 
 func (g *gauge) newSeries(lbls labels.Labels, value float64) *gaugeSeries {
+	lastUpdated := &atomic.Int64{}
+	lastUpdated.Store(time.Now().UnixMilli())
 	return &gaugeSeries{
 		labels:      getSeriesLabels(g.metricName, lbls, g.externalLabels),
-		value:       atomic.NewFloat64(value),
-		lastUpdated: atomic.NewInt64(time.Now().UnixMilli()),
+		value:       atomicx.NewFloat64(value),
+		lastUpdated: lastUpdated,
 	}
 }
 

--- a/modules/generator/registry/gauge_test.go
+++ b/modules/generator/registry/gauge_test.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/atomic"
 )
 
 func Test_gaugeInc(t *testing.T) {
@@ -263,7 +263,7 @@ func Test_gauge_concurrencyCorrectness(t *testing.T) {
 	var wg sync.WaitGroup
 	end := make(chan struct{})
 
-	totalCount := atomic.NewUint64(0)
+	totalCount := &atomic.Uint64{}
 
 	for i := 0; i < 4; i++ {
 		wg.Add(1)
@@ -275,7 +275,7 @@ func Test_gauge_concurrencyCorrectness(t *testing.T) {
 					return
 				default:
 					c.Inc(buildTestLabels([]string{"label"}, []string{"value-1"}), 1.0)
-					totalCount.Inc()
+					totalCount.Add(1)
 				}
 			}
 		}()

--- a/modules/generator/registry/histogram.go
+++ b/modules/generator/registry/histogram.go
@@ -113,8 +113,6 @@ func (h *histogram) ObserveWithExemplar(lbls labels.Labels, value float64, trace
 }
 
 func (h *histogram) newSeries(lbls labels.Labels, value float64, traceID string, multiplier float64) *histogramSeries {
-	firstSeries := &atomic.Bool{}
-	firstSeries.Store(true)
 	newSeries := &histogramSeries{
 		count:          atomicx.NewFloat64(0),
 		sum:            atomicx.NewFloat64(0),
@@ -122,7 +120,7 @@ func (h *histogram) newSeries(lbls labels.Labels, value float64, traceID string,
 		exemplars:      make([]*atomicx.String, 0, len(h.buckets)),
 		exemplarValues: make([]*atomicx.Float64, 0, len(h.buckets)),
 		lastUpdated:    &atomic.Int64{},
-		firstSeries:    firstSeries,
+		firstSeries:    atomicx.NewBool(true),
 	}
 	for i := 0; i < len(h.buckets); i++ {
 		newSeries.buckets = append(newSeries.buckets, atomicx.NewFloat64(0))

--- a/modules/generator/registry/histogram.go
+++ b/modules/generator/registry/histogram.go
@@ -6,12 +6,13 @@ import (
 	"sort"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/grafana/tempo/pkg/util/atomicx"
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
-	"go.uber.org/atomic"
 )
 
 var _ metric = (*histogram)(nil)
@@ -39,13 +40,13 @@ type histogramSeries struct {
 	sumLabels    labels.Labels
 	bucketLabels []labels.Labels
 
-	count *atomic.Float64
-	sum   *atomic.Float64
+	count *atomicx.Float64
+	sum   *atomicx.Float64
 	// buckets includes the +Inf bucket
-	buckets []*atomic.Float64
+	buckets []*atomicx.Float64
 	// exemplar is stored as a single traceID
-	exemplars      []*atomic.String
-	exemplarValues []*atomic.Float64
+	exemplars      []*atomicx.String
+	exemplarValues []*atomicx.Float64
 	lastUpdated    *atomic.Int64
 	// firstSeries is used to track if this series is new to the counter.  This
 	// is used to ensure that new counters being with 0, and then are incremented
@@ -112,19 +113,21 @@ func (h *histogram) ObserveWithExemplar(lbls labels.Labels, value float64, trace
 }
 
 func (h *histogram) newSeries(lbls labels.Labels, value float64, traceID string, multiplier float64) *histogramSeries {
+	firstSeries := &atomic.Bool{}
+	firstSeries.Store(true)
 	newSeries := &histogramSeries{
-		count:          atomic.NewFloat64(0),
-		sum:            atomic.NewFloat64(0),
-		buckets:        make([]*atomic.Float64, 0, len(h.buckets)),
-		exemplars:      make([]*atomic.String, 0, len(h.buckets)),
-		exemplarValues: make([]*atomic.Float64, 0, len(h.buckets)),
-		lastUpdated:    atomic.NewInt64(0),
-		firstSeries:    atomic.NewBool(true),
+		count:          atomicx.NewFloat64(0),
+		sum:            atomicx.NewFloat64(0),
+		buckets:        make([]*atomicx.Float64, 0, len(h.buckets)),
+		exemplars:      make([]*atomicx.String, 0, len(h.buckets)),
+		exemplarValues: make([]*atomicx.Float64, 0, len(h.buckets)),
+		lastUpdated:    &atomic.Int64{},
+		firstSeries:    firstSeries,
 	}
 	for i := 0; i < len(h.buckets); i++ {
-		newSeries.buckets = append(newSeries.buckets, atomic.NewFloat64(0))
-		newSeries.exemplars = append(newSeries.exemplars, atomic.NewString(""))
-		newSeries.exemplarValues = append(newSeries.exemplarValues, atomic.NewFloat64(0))
+		newSeries.buckets = append(newSeries.buckets, atomicx.NewFloat64(0))
+		newSeries.exemplars = append(newSeries.exemplars, atomicx.NewString(""))
+		newSeries.exemplarValues = append(newSeries.exemplarValues, atomicx.NewFloat64(0))
 	}
 
 	// Precompute all labels for all sub-metrics upfront

--- a/modules/generator/registry/histogram_test.go
+++ b/modules/generator/registry/histogram_test.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/atomic"
 )
 
 func Test_histogram(t *testing.T) {
@@ -378,7 +378,7 @@ func Test_histogram_concurrencyCorrectness(t *testing.T) {
 	var wg sync.WaitGroup
 	end := make(chan struct{})
 
-	totalCount := atomic.NewUint64(0)
+	totalCount := &atomic.Uint64{}
 
 	for i := 0; i < 4; i++ {
 		wg.Add(1)
@@ -390,7 +390,7 @@ func Test_histogram_concurrencyCorrectness(t *testing.T) {
 					return
 				default:
 					h.ObserveWithExemplar(buildTestLabels([]string{"label"}, []string{"value-1"}), 2.0, "", 1.0)
-					totalCount.Inc()
+					totalCount.Add(1)
 				}
 			}
 		}()

--- a/modules/generator/registry/native_histogram.go
+++ b/modules/generator/registry/native_histogram.go
@@ -15,6 +15,8 @@ import (
 	promhistogram "github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
+
+	"github.com/grafana/tempo/pkg/util/atomicx"
 )
 
 type nativeHistogram struct {
@@ -163,12 +165,10 @@ func (h *nativeHistogram) newSeries(lbls labels.Labels, value float64, traceID s
 		nativeOpts.NativeHistogramMaxExemplars = -1 // Use default
 	}
 
-	firstSeries := &atomic.Bool{}
-	firstSeries.Store(true)
 	newSeries := &nativeHistogramSeries{
 		promHistogram: prometheus.NewHistogram(nativeOpts),
 		lastUpdated:   0,
-		firstSeries:   firstSeries,
+		firstSeries:   atomicx.NewBool(true),
 		overridesHash: hsh,
 	}
 

--- a/modules/generator/registry/native_histogram.go
+++ b/modules/generator/registry/native_histogram.go
@@ -6,6 +6,7 @@ import (
 	"hash/fnv"
 	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -14,7 +15,6 @@ import (
 	promhistogram "github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
-	"go.uber.org/atomic"
 )
 
 type nativeHistogram struct {
@@ -163,10 +163,12 @@ func (h *nativeHistogram) newSeries(lbls labels.Labels, value float64, traceID s
 		nativeOpts.NativeHistogramMaxExemplars = -1 // Use default
 	}
 
+	firstSeries := &atomic.Bool{}
+	firstSeries.Store(true)
 	newSeries := &nativeHistogramSeries{
 		promHistogram: prometheus.NewHistogram(nativeOpts),
 		lastUpdated:   0,
-		firstSeries:   atomic.NewBool(true),
+		firstSeries:   firstSeries,
 		overridesHash: hsh,
 	}
 

--- a/modules/generator/storage/instance_test.go
+++ b/modules/generator/storage/instance_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -25,7 +26,6 @@ import (
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/tempo/modules/overrides/histograms"
 )
@@ -272,7 +272,7 @@ type mockPrometheusRemoteWriteServer struct {
 	mtx sync.Mutex
 
 	server         *httptest.Server
-	refuseRequests *atomic.Bool
+	refuseRequests atomic.Bool
 	timeSeries     map[string][]prompb.TimeSeries
 
 	// metrics
@@ -286,7 +286,6 @@ func newMockPrometheusRemoteWriterServer(logger log.Logger) *mockPrometheusRemot
 	logger = log.With(logger, "component", "mockserver")
 
 	m := &mockPrometheusRemoteWriteServer{
-		refuseRequests:   atomic.NewBool(false),
 		timeSeries:       make(map[string][]prompb.TimeSeries),
 		acceptedRequests: map[string]int{},
 		logger:           logger,

--- a/modules/livestore/instance_search.go
+++ b/modules/livestore/instance_search.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"runtime/debug"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -18,7 +19,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	oteltrace "go.opentelemetry.io/otel/trace"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -31,6 +31,7 @@ import (
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/traceql"
 	"github.com/grafana/tempo/pkg/util"
+	"github.com/grafana/tempo/pkg/util/atomicx"
 	"github.com/grafana/tempo/pkg/validation"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding/common"
@@ -63,7 +64,7 @@ func (i *instance) iterateBlocks(ctx context.Context, reqStart, reqEnd time.Time
 
 	snap := i.blocks.Load()
 
-	var anyErr atomic.Error
+	var anyErr atomicx.Error
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -447,7 +448,7 @@ func (i *instance) SearchTagValues(ctx context.Context, req *tempopb.SearchTagVa
 		}
 
 		// Atomically reserve a slot
-		if maxBlocks > 0 && inspectedBlocks.Inc() > maxBlocks {
+		if maxBlocks > 0 && inspectedBlocks.Add(1) > maxBlocks {
 			return errComplete
 		}
 
@@ -525,7 +526,7 @@ func (i *instance) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTag
 	// helper functions as closures, to access local variables
 	search := func(ctx context.Context, s common.Searcher, collect func(tempopb.TagValue) bool) error {
 		// note the interaction below with searchWithCache. if we ever return errComplete for reasons besides this we may need to adjust the error handling there
-		if maxBlocks > 0 && inspectedBlocks.Inc() > maxBlocks {
+		if maxBlocks > 0 && inspectedBlocks.Add(1) > maxBlocks {
 			return errComplete
 		}
 
@@ -758,9 +759,8 @@ func (i *instance) QueryRange(ctx context.Context, req *tempopb.QueryRangeReques
 	}
 
 	maxSeries := int(req.MaxSeries)
-	maxSeriesReached := atomic.Bool{}
-	maxSeriesReached.Store(false)
-	inspectedBytes := atomic.NewUint64(0)
+	var maxSeriesReached atomic.Bool
+	var inspectedBytes atomic.Uint64
 
 	search := func(ctx context.Context, _ *backend.BlockMeta, b block) error {
 		if walBlock, ok := b.(common.WALBlock); ok {

--- a/modules/livestore/local_block.go
+++ b/modules/livestore/local_block.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -13,7 +14,6 @@ import (
 	"github.com/grafana/tempo/tempodb/backend/local"
 	"github.com/grafana/tempo/tempodb/encoding"
 	"github.com/grafana/tempo/tempodb/encoding/common"
-	"go.uber.org/atomic"
 )
 
 const nameFlushed = "flushed"

--- a/modules/livestore/partition_reader_test.go
+++ b/modules/livestore/partition_reader_test.go
@@ -3,6 +3,7 @@ package livestore
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,7 +18,6 @@ import (
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
-	"go.uber.org/atomic"
 )
 
 const (
@@ -30,9 +30,9 @@ func TestPartitionReaderCommits(t *testing.T) {
 	t.Run("sync commits", func(t *testing.T) {
 		k, address := testkafka.CreateCluster(t, 1, testTopic)
 
-		kafkaCommits := atomic.NewInt32(0)
+		kafkaCommits := &atomic.Int32{}
 		k.ControlKey(kmsg.OffsetCommit, func(kmsg.Request) (kmsg.Response, error, bool) {
-			kafkaCommits.Inc()
+			kafkaCommits.Add(1)
 			return nil, nil, false
 		})
 
@@ -64,7 +64,7 @@ func TestPartitionReaderCommits(t *testing.T) {
 
 		k, address := testkafka.CreateCluster(t, 1, testTopic)
 		k.ControlKey(kmsg.OffsetCommit, func(kmsg.Request) (kmsg.Response, error, bool) {
-			asyncCommits.Inc()
+			asyncCommits.Add(1)
 			return nil, nil, false
 		})
 
@@ -98,9 +98,9 @@ func TestPartitionReaderCommits(t *testing.T) {
 func TestPartitionReaderLag(t *testing.T) {
 	k, address := testkafka.CreateCluster(t, 1, testTopic)
 
-	kafkaCommits := atomic.NewInt32(0)
+	kafkaCommits := &atomic.Int32{}
 	k.ControlKey(kmsg.OffsetCommit, func(kmsg.Request) (kmsg.Response, error, bool) {
-		kafkaCommits.Inc()
+		kafkaCommits.Add(1)
 		return nil, nil, false
 	})
 

--- a/modules/querier/worker/processor_manager.go
+++ b/modules/querier/worker/processor_manager.go
@@ -3,9 +3,9 @@ package worker
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 )
 
@@ -27,16 +27,15 @@ type processorManager struct {
 	cancelsMu sync.Mutex
 	cancels   []context.CancelFunc
 
-	currentProcessors *atomic.Int32
+	currentProcessors atomic.Int32
 }
 
 func newProcessorManager(ctx context.Context, p processor, conn *grpc.ClientConn, address string) *processorManager {
 	return &processorManager{
-		p:                 p,
-		ctx:               ctx,
-		conn:              conn,
-		address:           address,
-		currentProcessors: atomic.NewInt32(0),
+		p:       p,
+		ctx:     ctx,
+		conn:    conn,
+		address: address,
 	}
 }
 
@@ -72,8 +71,8 @@ func (pm *processorManager) concurrency(n int) {
 		go func() {
 			defer pm.wg.Done()
 
-			pm.currentProcessors.Inc()
-			defer pm.currentProcessors.Dec()
+			pm.currentProcessors.Add(1)
+			defer pm.currentProcessors.Add(-1)
 
 			pm.p.processQueriesOnSingleStream(ctx, pm.conn, pm.address)
 		}()

--- a/pkg/cache/memcached_test.go
+++ b/pkg/cache/memcached_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/gomemcache/memcache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/tempo/pkg/cache"
 )
@@ -79,7 +79,7 @@ func newMockMemcacheFailing() *mockMemcacheFailing {
 }
 
 func (c *mockMemcacheFailing) GetMulti(ctx context.Context, keys []string, _ ...memcache.Option) (map[string]*memcache.Item, error) {
-	calls := c.calls.Inc()
+	calls := c.calls.Add(1)
 	if calls%3 == 0 {
 		return nil, errors.New("fail")
 	}

--- a/pkg/collector/metrics_collector.go
+++ b/pkg/collector/metrics_collector.go
@@ -1,20 +1,18 @@
 package collector
 
 import (
-	"go.uber.org/atomic"
+	"sync/atomic"
 )
 
 // MetricsCollector is a thread-safe collector that uses atomic operations
 // to accumulate metrics. We primarily use it to collect the total bytes read from
 // a reader across a request
 type MetricsCollector struct {
-	totalValue *atomic.Uint64
+	totalValue atomic.Uint64
 }
 
 func NewMetricsCollector() *MetricsCollector {
-	return &MetricsCollector{
-		totalValue: atomic.NewUint64(0),
-	}
+	return &MetricsCollector{}
 }
 
 // Add adds new bytes read to TotalValue. this method is thread safe and

--- a/pkg/ingest/reader_client_test.go
+++ b/pkg/ingest/reader_client_test.go
@@ -1,6 +1,7 @@
 package ingest_test
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/twmb/franz-go/pkg/kfake"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
-	"go.uber.org/atomic"
 )
 
 const (
@@ -31,7 +31,7 @@ func TestLeaveConsumerGroupByInstanceID_NoOp(t *testing.T) {
 
 	var leaveGroupCalled atomic.Int32
 	fake.ControlKey(int16(kmsg.LeaveGroup), func(_ kmsg.Request) (kmsg.Response, error, bool) {
-		leaveGroupCalled.Inc()
+		leaveGroupCalled.Add(1)
 		return nil, nil, false
 	})
 

--- a/pkg/ingest/writer_client.go
+++ b/pkg/ingest/writer_client.go
@@ -20,6 +20,8 @@ import (
 	"github.com/twmb/franz-go/plugin/kprom"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/grafana/tempo/pkg/util/atomicx"
 )
 
 // NewWriterClient returns the kgo.Client that should be used by the Writer.
@@ -268,12 +270,11 @@ func (c *Producer) updateMetricsLoop() {
 // if the configured limit is reached.
 func (c *Producer) ProduceSync(ctx context.Context, records []*kgo.Record) kgo.ProduceResults {
 	var (
-		remaining = &atomic.Int64{}
+		remaining = atomicx.NewInt64(int64(len(records)))
 		done      = make(chan struct{})
 		resMx     sync.Mutex
 		res       = make(kgo.ProduceResults, 0, len(records))
 	)
-	remaining.Store(int64(len(records)))
 
 	// As a safety mechanism, we want to make sure that the context is not already canceled or its deadline exceeded.
 	// The reason is that once we buffer records to the Kafka client (later in this function), these records will be

--- a/pkg/ingest/writer_client.go
+++ b/pkg/ingest/writer_client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -19,7 +20,6 @@ import (
 	"github.com/twmb/franz-go/plugin/kprom"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/atomic"
 )
 
 // NewWriterClient returns the kgo.Client that should be used by the Writer.
@@ -181,7 +181,7 @@ type Producer struct {
 
 	// Keep track of Kafka records size (bytes) currently in-flight in the Kafka client.
 	// This counter is used to implement a limit on the max buffered bytes.
-	bufferedBytes *atomic.Int64
+	bufferedBytes atomic.Int64
 
 	// The max buffered bytes allowed. Once this limit is reached, produce requests fail.
 	maxBufferedBytes int64
@@ -201,7 +201,6 @@ func NewProducer(client *kgo.Client, maxBufferedBytes int64, reg prometheus.Regi
 		Client:           client,
 		closeOnce:        &sync.Once{},
 		closed:           make(chan struct{}),
-		bufferedBytes:    atomic.NewInt64(0),
 		maxBufferedBytes: maxBufferedBytes,
 
 		// Metrics.
@@ -269,11 +268,12 @@ func (c *Producer) updateMetricsLoop() {
 // if the configured limit is reached.
 func (c *Producer) ProduceSync(ctx context.Context, records []*kgo.Record) kgo.ProduceResults {
 	var (
-		remaining = atomic.NewInt64(int64(len(records)))
+		remaining = &atomic.Int64{}
 		done      = make(chan struct{})
 		resMx     sync.Mutex
 		res       = make(kgo.ProduceResults, 0, len(records))
 	)
+	remaining.Store(int64(len(records)))
 
 	// As a safety mechanism, we want to make sure that the context is not already canceled or its deadline exceeded.
 	// The reason is that once we buffer records to the Kafka client (later in this function), these records will be
@@ -303,7 +303,7 @@ func (c *Producer) ProduceSync(ctx context.Context, records []*kgo.Record) kgo.P
 		// In case of error we'll wait for all responses anyway before returning from produceSync().
 		// It allows us to keep code easier, given we don't expect this function to be frequently
 		// called with multiple records.
-		if remaining.Dec() == 0 {
+		if remaining.Add(-1) == 0 {
 			close(done)
 		}
 	}

--- a/pkg/usagestats/stats.go
+++ b/pkg/usagestats/stats.go
@@ -12,13 +12,14 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/grafana/tempo/cmd/tempo/build"
+	"github.com/grafana/tempo/pkg/util/atomicx"
 
 	"github.com/cespare/xxhash/v2"
 	prom "github.com/prometheus/prometheus/web/api/v1"
-	"go.uber.org/atomic"
 )
 
 var (
@@ -210,15 +211,15 @@ func Edition(edition string) {
 }
 
 type Statistics struct {
-	min   *atomic.Float64
-	max   *atomic.Float64
+	min   *atomicx.Float64
+	max   *atomicx.Float64
 	count *atomic.Int64
 
-	avg *atomic.Float64
+	avg *atomicx.Float64
 
 	// require for stddev and stdvar
-	mean  *atomic.Float64
-	value *atomic.Float64
+	mean  *atomicx.Float64
+	value *atomicx.Float64
 }
 
 // NewStatistics returns a new Statistics object.
@@ -233,12 +234,12 @@ type Statistics struct {
 // If a Statistics object with the same name already exists it is returned.
 func NewStatistics(name string) *Statistics {
 	s := &Statistics{
-		min:   atomic.NewFloat64(math.Inf(0)),
-		max:   atomic.NewFloat64(math.Inf(-1)),
-		count: atomic.NewInt64(0),
-		avg:   atomic.NewFloat64(0),
-		mean:  atomic.NewFloat64(0),
-		value: atomic.NewFloat64(0),
+		min:   atomicx.NewFloat64(math.Inf(0)),
+		max:   atomicx.NewFloat64(math.Inf(-1)),
+		count: &atomic.Int64{},
+		avg:   atomicx.NewFloat64(0),
+		mean:  atomicx.NewFloat64(0),
+		value: atomicx.NewFloat64(0),
 	}
 	existing := expvar.Get(statsPrefix + name)
 	if existing != nil {
@@ -318,7 +319,7 @@ func (s *Statistics) Record(v float64) {
 
 type Counter struct {
 	total *atomic.Int64
-	rate  *atomic.Float64
+	rate  *atomicx.Float64
 
 	resetTime time.Time
 }
@@ -327,8 +328,8 @@ type Counter struct {
 // If a Counter stats object with the same name already exists it is returned.
 func NewCounter(name string) *Counter {
 	c := &Counter{
-		total:     atomic.NewInt64(0),
-		rate:      atomic.NewFloat64(0),
+		total:     &atomic.Int64{},
+		rate:      atomicx.NewFloat64(0),
 		resetTime: time.Now(),
 	}
 	existing := expvar.Get(statsPrefix + name)
@@ -379,7 +380,7 @@ type WordCounter struct {
 // If a WordCounter stats object with the same name already exists it is returned.
 func NewWordCounter(name string) *WordCounter {
 	c := &WordCounter{
-		count: atomic.NewInt64(0),
+		count: &atomic.Int64{},
 		words: sync.Map{},
 	}
 	existing := expvar.Get(statsPrefix + name)

--- a/pkg/util/active_user.go
+++ b/pkg/util/active_user.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/grafana/dskit/services"
+
+	"github.com/grafana/tempo/pkg/util/atomicx"
 )
 
 // ActiveUsers keeps track of latest user's activity timestamp,
@@ -33,8 +35,7 @@ func (m *ActiveUsers) UpdateUserTimestamp(userID string, ts int64) {
 	}
 
 	// Pre-allocate new atomic to avoid doing allocation with lock held.
-	newAtomic := &atomic.Int64{}
-	newAtomic.Store(ts)
+	newAtomic := atomicx.NewInt64(ts)
 
 	// We need RW lock to create new entry.
 	m.mu.Lock()

--- a/pkg/util/active_user.go
+++ b/pkg/util/active_user.go
@@ -3,10 +3,10 @@ package util
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/grafana/dskit/services"
-	"go.uber.org/atomic"
 )
 
 // ActiveUsers keeps track of latest user's activity timestamp,
@@ -33,7 +33,8 @@ func (m *ActiveUsers) UpdateUserTimestamp(userID string, ts int64) {
 	}
 
 	// Pre-allocate new atomic to avoid doing allocation with lock held.
-	newAtomic := atomic.NewInt64(ts)
+	newAtomic := &atomic.Int64{}
+	newAtomic.Store(ts)
 
 	// We need RW lock to create new entry.
 	m.mu.Lock()

--- a/pkg/util/atomicx/atomicx.go
+++ b/pkg/util/atomicx/atomicx.go
@@ -1,0 +1,107 @@
+// Package atomicx provides atomic primitives that the standard library's
+// sync/atomic does not ship typed wrappers for: Float64, Error, String.
+//
+// Other atomic types (Int32/Int64/Uint32/Uint64/Bool/Pointer) should use
+// sync/atomic directly.
+package atomicx
+
+import (
+	"math"
+	"sync"
+	"sync/atomic"
+)
+
+// Float64 is an atomic float64 backed by an atomic.Uint64 via math.Float64bits.
+type Float64 struct {
+	_ noCopy
+	v atomic.Uint64
+}
+
+func NewFloat64(v float64) *Float64 {
+	f := &Float64{}
+	f.Store(v)
+	return f
+}
+
+func (f *Float64) Load() float64 { return math.Float64frombits(f.v.Load()) }
+
+func (f *Float64) Store(v float64) { f.v.Store(math.Float64bits(v)) }
+
+func (f *Float64) Add(delta float64) float64 {
+	for {
+		oldBits := f.v.Load()
+		newVal := math.Float64frombits(oldBits) + delta
+		if f.v.CompareAndSwap(oldBits, math.Float64bits(newVal)) {
+			return newVal
+		}
+	}
+}
+
+func (f *Float64) Sub(delta float64) float64 { return f.Add(-delta) }
+
+func (f *Float64) CompareAndSwap(old, new float64) bool {
+	return f.v.CompareAndSwap(math.Float64bits(old), math.Float64bits(new))
+}
+
+// String is an atomic string backed by atomic.Pointer[string].
+type String struct {
+	_ noCopy
+	v atomic.Pointer[string]
+}
+
+func NewString(s string) *String {
+	x := &String{}
+	x.Store(s)
+	return x
+}
+
+func (s *String) Load() string {
+	if p := s.v.Load(); p != nil {
+		return *p
+	}
+	return ""
+}
+
+func (s *String) Store(v string) { s.v.Store(&v) }
+
+// Error is an atomic error. Uses a mutex; intended for low-frequency error
+// propagation paths (first-writer-wins, completion handoff, etc.) — not hot
+// loops.
+type Error struct {
+	_  noCopy
+	mu sync.RWMutex
+	v  error
+}
+
+func NewError(err error) *Error {
+	return &Error{v: err}
+}
+
+func (e *Error) Load() error {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.v
+}
+
+func (e *Error) Store(err error) {
+	e.mu.Lock()
+	e.v = err
+	e.mu.Unlock()
+}
+
+func (e *Error) CompareAndSwap(old, new error) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.v == old {
+		e.v = new
+		return true
+	}
+	return false
+}
+
+// noCopy may be embedded into structs which must not be copied
+// after the first use. Detected by `go vet`'s -copylocks check.
+type noCopy struct{}
+
+func (*noCopy) Lock()   {}
+func (*noCopy) Unlock() {}

--- a/pkg/util/atomicx/atomicx.go
+++ b/pkg/util/atomicx/atomicx.go
@@ -7,7 +7,6 @@ package atomicx
 
 import (
 	"math"
-	"sync"
 	"sync/atomic"
 )
 
@@ -39,8 +38,8 @@ func (f *Float64) Add(delta float64) float64 {
 
 func (f *Float64) Sub(delta float64) float64 { return f.Add(-delta) }
 
-func (f *Float64) CompareAndSwap(old, new float64) bool {
-	return f.v.CompareAndSwap(math.Float64bits(old), math.Float64bits(new))
+func (f *Float64) CompareAndSwap(old, next float64) bool {
+	return f.v.CompareAndSwap(math.Float64bits(old), math.Float64bits(next))
 }
 
 // String is an atomic string backed by atomic.Pointer[string].
@@ -64,37 +63,39 @@ func (s *String) Load() string {
 
 func (s *String) Store(v string) { s.v.Store(&v) }
 
-// Error is an atomic error. Uses a mutex; intended for low-frequency error
-// propagation paths (first-writer-wins, completion handoff, etc.) — not hot
-// loops.
 type Error struct {
-	_  noCopy
-	mu sync.RWMutex
-	v  error
+	_ noCopy
+	v atomic.Value
 }
 
+type packedError struct{ Value error }
+
 func NewError(err error) *Error {
-	return &Error{v: err}
+	e := &Error{}
+	if err != nil {
+		e.Store(err)
+	}
+	return e
 }
 
 func (e *Error) Load() error {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
-	return e.v
+	v := e.v.Load()
+	if v == nil {
+		return nil
+	}
+	return v.(packedError).Value
 }
 
-func (e *Error) Store(err error) {
-	e.mu.Lock()
-	e.v = err
-	e.mu.Unlock()
-}
+func (e *Error) Store(err error) { e.v.Store(packedError{err}) }
 
-func (e *Error) CompareAndSwap(old, new error) bool {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	if e.v == old {
-		e.v = new
+func (e *Error) CompareAndSwap(old, next error) bool {
+	if e.v.CompareAndSwap(packedError{old}, packedError{next}) {
 		return true
+	}
+	// Before any Store, atomic.Value's internal state is the nil interface
+	// rather than a zero packedError, so the first CAS misses. Retry against nil.
+	if old == nil {
+		return e.v.CompareAndSwap(nil, packedError{next})
 	}
 	return false
 }

--- a/pkg/util/atomicx/atomicx.go
+++ b/pkg/util/atomicx/atomicx.go
@@ -99,6 +99,39 @@ func (e *Error) CompareAndSwap(old, new error) bool {
 	return false
 }
 
+// Constructors for stdlib atomic types initialized with a non-zero value.
+// For zero-value init, use the stdlib type directly (e.g. &atomic.Int64{}).
+
+func NewInt32(v int32) *atomic.Int32 {
+	x := &atomic.Int32{}
+	x.Store(v)
+	return x
+}
+
+func NewInt64(v int64) *atomic.Int64 {
+	x := &atomic.Int64{}
+	x.Store(v)
+	return x
+}
+
+func NewUint32(v uint32) *atomic.Uint32 {
+	x := &atomic.Uint32{}
+	x.Store(v)
+	return x
+}
+
+func NewUint64(v uint64) *atomic.Uint64 {
+	x := &atomic.Uint64{}
+	x.Store(v)
+	return x
+}
+
+func NewBool(v bool) *atomic.Bool {
+	x := &atomic.Bool{}
+	x.Store(v)
+	return x
+}
+
 // noCopy may be embedded into structs which must not be copied
 // after the first use. Detected by `go vet`'s -copylocks check.
 type noCopy struct{}

--- a/pkg/util/atomicx/atomicx_test.go
+++ b/pkg/util/atomicx/atomicx_test.go
@@ -79,3 +79,12 @@ func TestError(t *testing.T) {
 	var z Error
 	assert.NoError(t, z.Load())
 }
+
+func TestStdlibConstructors(t *testing.T) {
+	require.Equal(t, int32(7), NewInt32(7).Load())
+	require.Equal(t, int64(-9), NewInt64(-9).Load())
+	require.Equal(t, uint32(42), NewUint32(42).Load())
+	require.Equal(t, uint64(1<<40), NewUint64(1<<40).Load())
+	require.True(t, NewBool(true).Load())
+	require.False(t, NewBool(false).Load())
+}

--- a/pkg/util/atomicx/atomicx_test.go
+++ b/pkg/util/atomicx/atomicx_test.go
@@ -67,13 +67,24 @@ func TestError(t *testing.T) {
 	e.Store(err1)
 	require.ErrorIs(t, e.Load(), err1)
 
-	// CAS: only set if currently nil
 	first := errors.New("first")
 	second := errors.New("second")
+
+	// CAS from nil (lazy-init path)
 	overall := &Error{}
 	require.True(t, overall.CompareAndSwap(nil, first))
 	require.False(t, overall.CompareAndSwap(nil, second))
 	require.ErrorIs(t, overall.Load(), first)
+
+	// CAS with non-nil old
+	require.True(t, overall.CompareAndSwap(first, second))
+	require.ErrorIs(t, overall.Load(), second)
+	require.False(t, overall.CompareAndSwap(first, errors.New("third")))
+	require.ErrorIs(t, overall.Load(), second)
+
+	// CAS to nil
+	require.True(t, overall.CompareAndSwap(second, nil))
+	require.NoError(t, overall.Load())
 
 	// zero value reads as nil
 	var z Error

--- a/pkg/util/atomicx/atomicx_test.go
+++ b/pkg/util/atomicx/atomicx_test.go
@@ -1,0 +1,81 @@
+package atomicx
+
+import (
+	"errors"
+	"math"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFloat64(t *testing.T) {
+	f := NewFloat64(1.5)
+	require.Equal(t, 1.5, f.Load())
+
+	f.Store(2.5)
+	require.Equal(t, 2.5, f.Load())
+
+	require.Equal(t, 5.0, f.Add(2.5))
+	require.Equal(t, 5.0, f.Load())
+
+	require.Equal(t, 3.0, f.Sub(2.0))
+
+	require.True(t, f.CompareAndSwap(3.0, 7.0))
+	require.False(t, f.CompareAndSwap(3.0, 9.0))
+	require.Equal(t, 7.0, f.Load())
+
+	// NaN round-trip via bits
+	nan := NewFloat64(math.NaN())
+	require.True(t, math.IsNaN(nan.Load()))
+}
+
+func TestFloat64ConcurrentAdd(t *testing.T) {
+	f := NewFloat64(0)
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				f.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, 10000.0, f.Load())
+}
+
+func TestString(t *testing.T) {
+	s := NewString("hello")
+	require.Equal(t, "hello", s.Load())
+
+	s.Store("world")
+	require.Equal(t, "world", s.Load())
+
+	// zero value reads as ""
+	var z String
+	require.Equal(t, "", z.Load())
+}
+
+func TestError(t *testing.T) {
+	e := NewError(nil)
+	require.NoError(t, e.Load())
+
+	err1 := errors.New("boom")
+	e.Store(err1)
+	require.ErrorIs(t, e.Load(), err1)
+
+	// CAS: only set if currently nil
+	first := errors.New("first")
+	second := errors.New("second")
+	overall := &Error{}
+	require.True(t, overall.CompareAndSwap(nil, first))
+	require.False(t, overall.CompareAndSwap(nil, second))
+	require.ErrorIs(t, overall.Load(), first)
+
+	// zero value reads as nil
+	var z Error
+	assert.NoError(t, z.Load())
+}

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -19,7 +20,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/tempo/pkg/boundedwaitgroup"
 	"github.com/grafana/tempo/tempodb/backend"
@@ -159,11 +159,12 @@ func (p *Poller) Do(parentCtx context.Context, previous *List) (PerTenant, PerTe
 		blocklist          = PerTenant{}
 		compactedBlocklist = PerTenantCompacted{}
 
-		tenantFailuresRemaining = atomic.NewInt32(int32(p.cfg.TolerateTenantFailures))
+		tenantFailuresRemaining = &atomic.Int32{}
 
 		link  = trace.LinkFromContext(parentCtx)
 		bgCtx = context.Background()
 	)
+	tenantFailuresRemaining.Store(int32(p.cfg.TolerateTenantFailures))
 
 	for _, tenantID := range tenants {
 		// Do not continue if we have been canceled.
@@ -213,7 +214,7 @@ func (p *Poller) Do(parentCtx context.Context, previous *List) (PerTenant, PerTe
 				blocklist[tenantID] = previous.Metas(tenantID)
 				compactedBlocklist[tenantID] = previous.CompactedMetas(tenantID)
 
-				tenantFailuresRemaining.Dec()
+				tenantFailuresRemaining.Add(-1)
 
 				return
 			}

--- a/tempodb/blocklist/poller.go
+++ b/tempodb/blocklist/poller.go
@@ -8,7 +8,6 @@ import (
 	"path"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -22,6 +21,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/tempo/pkg/boundedwaitgroup"
+	"github.com/grafana/tempo/pkg/util/atomicx"
 	"github.com/grafana/tempo/tempodb/backend"
 )
 
@@ -159,12 +159,11 @@ func (p *Poller) Do(parentCtx context.Context, previous *List) (PerTenant, PerTe
 		blocklist          = PerTenant{}
 		compactedBlocklist = PerTenantCompacted{}
 
-		tenantFailuresRemaining = &atomic.Int32{}
+		tenantFailuresRemaining = atomicx.NewInt32(int32(p.cfg.TolerateTenantFailures))
 
 		link  = trace.LinkFromContext(parentCtx)
 		bgCtx = context.Background()
 	)
-	tenantFailuresRemaining.Store(int32(p.cfg.TolerateTenantFailures))
 
 	for _, tenantID := range tenants {
 		// Do not continue if we have been canceled.

--- a/tempodb/encoding/vparquet3/readers.go
+++ b/tempodb/encoding/vparquet3/readers.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"io"
-
-	"go.uber.org/atomic"
+	"sync/atomic"
 
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/pkg/cache"

--- a/tempodb/encoding/vparquet4/readers.go
+++ b/tempodb/encoding/vparquet4/readers.go
@@ -5,8 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
-
-	"go.uber.org/atomic"
+	"sync/atomic"
 
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/pkg/cache"

--- a/tempodb/encoding/vparquet5/readers.go
+++ b/tempodb/encoding/vparquet5/readers.go
@@ -5,8 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
-
-	"go.uber.org/atomic"
+	"sync/atomic"
 
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/pkg/cache"

--- a/tempodb/pool/pool.go
+++ b/tempodb/pool/pool.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"go.uber.org/atomic"
 )
 
 const (
@@ -48,7 +48,7 @@ type job struct {
 
 type Pool struct {
 	cfg  *Config
-	size *atomic.Int32
+	size atomic.Int32
 
 	workQueue  chan *job
 	shutdownCh chan struct{}
@@ -63,7 +63,6 @@ func NewPool(cfg *Config) *Pool {
 	p := &Pool{
 		cfg:        cfg,
 		workQueue:  q,
-		size:       atomic.NewInt32(0),
 		shutdownCh: make(chan struct{}),
 	}
 
@@ -90,7 +89,7 @@ func (p *Pool) RunJobs(ctx context.Context, payloads []interface{}, fn JobFunc) 
 	}
 
 	resultsCh := make(chan result, totalJobs) // way for jobs to send back results
-	stop := atomic.NewBool(false)             // way to signal to the jobs to quit
+	stop := &atomic.Bool{}                    // way to signal to the jobs to quit
 	wg := &sync.WaitGroup{}                   // way to wait for all jobs to complete
 
 	// add each job one at a time.  even though we checked length above these might still fail
@@ -107,7 +106,7 @@ func (p *Pool) RunJobs(ctx context.Context, payloads []interface{}, fn JobFunc) 
 
 		select {
 		case p.workQueue <- j:
-			p.size.Inc()
+			p.size.Add(1)
 		default:
 			wg.Done()
 			stop.Store(true)
@@ -150,7 +149,7 @@ func (p *Pool) worker(j <-chan *job) {
 				return
 			}
 			runJob(j)
-			p.size.Dec()
+			p.size.Add(-1)
 		}
 	}
 }


### PR DESCRIPTION
**Why**:
- The uber atomic is flagged as abandoned dependency by Renovate: https://github.com/grafana/tempo/issues/5750

**What this PR does**:

Replaces direct usage of `go.uber.org/atomic` across the tempo source with stdlib `sync/atomic` (for `Int32`/`Int64`/`Uint32`/`Uint64`/`Bool`/`Pointer`) plus a small in-tree `pkg/util/atomicx` package for the three types stdlib doesn't ship typed wrappers for (`Float64`/`Error`/`String`).

- `pkg/util/atomicx/atomicx.go` (~140 LoC + tests):
  - `Float64` backed by `atomic.Uint64` via `math.Float64bits`.
  - `String` backed by `atomic.Pointer[string]`.
  - `Error` backed by `atomic.Value` with a `packedError` wrapper struct (same trick `go.uber.org/atomic.Error` uses to satisfy `atomic.Value`'s "same concrete type" requirement); supports full `CompareAndSwap` semantics including non-nil `old`.
  - `NewInt32`/`NewInt64`/`NewUint32`/`NewUint64`/`NewBool` helpers mirroring uber's constructor shape for non-zero init.
- Mechanical migration of 38 source files. Method renames where stdlib differs: `.Inc()` → `.Add(1)`, `.Dec()` → `.Add(-1)`, `.CAS(` → `.CompareAndSwap(`. `atomic.NewXxx(0)` constructors dropped where the field can be value-typed (zero-value-safe).

**Caveat**: `cmd/tempo/app/app.go` still imports `go.uber.org/atomic` because dskit's `grpcutil.WithShutdownRequested(requested *atomic.Bool)` takes the uber type specifically. Removing the last direct import requires an upstream dskit change; until then the dep stays in `go.mod`.

**Which issue(s) this PR fixes**:
Refs #7218 (sub-item; not closing).

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`