### PR TITLE
ci: re-add weekly release branch trigger to docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'r[0-9]+'
     tags:
       - 'v*'
 


### PR DESCRIPTION
**What this PR does**:
Re-adds `r[0-9]+` branches to the docker workflow push trigger. This was dropped in #7243, which breaks the weekly internal release process — the Argo CD pipeline creates `r{N}` branches and waits for docker CI to pass before creating the deployment_tools release dir and starting rollout.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`