### PR TITLE
chore: replace go.uber.org/multierr with stdlib errors.Join

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0
 	go.uber.org/atomic v1.11.0
 	go.uber.org/goleak v1.3.0
-	go.uber.org/multierr v1.11.0
+	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.28.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/time v0.15.0

--- a/modules/distributor/forwarder.go
+++ b/modules/distributor/forwarder.go
@@ -2,6 +2,7 @@ package distributor
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"go.uber.org/multierr"
 
 	"github.com/grafana/tempo/modules/distributor/queue"
 	"github.com/grafana/tempo/modules/generator"
@@ -214,7 +214,7 @@ func (f *generatorForwarder) stop(_ error) error {
 			errs = append(errs, err)
 		}
 	}
-	return multierr.Combine(errs...)
+	return errors.Join(errs...)
 }
 
 func (f *generatorForwarder) processFunc(ctx context.Context, data *request) {

--- a/modules/distributor/forwarder/forwarder.go
+++ b/modules/distributor/forwarder/forwarder.go
@@ -2,6 +2,7 @@ package forwarder
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -17,7 +18,6 @@ import (
 	"go.opentelemetry.io/collector/processor"
 	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	tracenoop "go.opentelemetry.io/otel/trace/noop"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -40,7 +40,7 @@ func (l List) ForwardTraces(ctx context.Context, traces ptrace.Traces) error {
 		}
 	}
 
-	return multierr.Combine(errs...)
+	return errors.Join(errs...)
 }
 
 func New(cfg Config, logger log.Logger, logLevel dslog.Level) (Forwarder, error) {
@@ -139,7 +139,7 @@ func (f *FilterForwarder) Shutdown(ctx context.Context) error {
 		errs = append(errs, fmt.Errorf("failed to shutdown next forwarder: %w", err))
 	}
 
-	return multierr.Combine(errs...)
+	return errors.Join(errs...)
 }
 
 // GetExtensions implements component.Host

--- a/modules/distributor/forwarder/manager.go
+++ b/modules/distributor/forwarder/manager.go
@@ -2,6 +2,7 @@ package forwarder
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -11,7 +12,6 @@ import (
 	dslog "github.com/grafana/dskit/log"
 	"github.com/grafana/dskit/services"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	"go.uber.org/multierr"
 
 	"github.com/grafana/tempo/modules/distributor/queue"
 	"github.com/grafana/tempo/modules/overrides"
@@ -199,7 +199,7 @@ func (m *Manager) shutdown() error {
 
 	m.forwarderNameToForwarder = make(map[string]Forwarder)
 
-	return multierr.Combine(errs...)
+	return errors.Join(errs...)
 }
 
 func (m *Manager) shutdownQueueList(tenantID string, ql *queueList) {
@@ -274,7 +274,7 @@ func (l *queueList) shutdown(ctx context.Context) error {
 		delete(l.forwarderNameToQueue, forwarderName)
 	}
 
-	return multierr.Combine(errs...)
+	return errors.Join(errs...)
 }
 
 type queueAdapter struct {

--- a/modules/distributor/forwarder/otlpgrpc/forwarder.go
+++ b/modules/distributor/forwarder/otlpgrpc/forwarder.go
@@ -12,7 +12,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	"go.uber.org/multierr"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -83,7 +82,7 @@ func (f *Forwarder) ForwardTraces(ctx context.Context, traces ptrace.Traces) err
 	}
 	f.mu.RUnlock()
 
-	return multierr.Combine(errs...)
+	return errors.Join(errs...)
 }
 
 func (f *Forwarder) Shutdown(_ context.Context) error {
@@ -99,7 +98,7 @@ func (f *Forwarder) Shutdown(_ context.Context) error {
 		delete(f.connections, endpoint)
 	}
 
-	return multierr.Combine(errs...)
+	return errors.Join(errs...)
 }
 
 func (f *Forwarder) newTraceOTLPGRPCClientAndConn(ctx context.Context, endpoint string, cfg TLSConfig, opts ...grpc.DialOption) (ptraceotlp.GRPCClient, *grpc.ClientConn, error) {

--- a/modules/distributor/receiver/shim.go
+++ b/modules/distributor/receiver/shim.go
@@ -2,6 +2,7 @@ package receiver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -30,7 +31,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	otelcodes "go.opentelemetry.io/otel/codes"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
@@ -335,7 +335,7 @@ func (r *receiversShim) stopping(_ error) error {
 	}
 
 	if len(errs) > 0 {
-		return multierr.Combine(errs...)
+		return errors.Join(errs...)
 	}
 
 	return nil

--- a/modules/generator/config.go
+++ b/modules/generator/config.go
@@ -16,7 +16,6 @@ import (
 	"github.com/grafana/tempo/modules/generator/validation"
 	"github.com/grafana/tempo/pkg/ingest"
 	"github.com/grafana/tempo/pkg/ring"
-	"go.uber.org/multierr"
 )
 
 const (
@@ -170,7 +169,7 @@ func (cfg *ProcessorConfig) Validate() error {
 	}
 
 	if len(errs) > 0 {
-		return multierr.Combine(errs...)
+		return errors.Join(errs...)
 	}
 	return nil
 }

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -19,7 +19,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	oteltrace "go.opentelemetry.io/otel/trace"
-	"go.uber.org/multierr"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -254,7 +253,7 @@ func (q *Querier) FindTraceByID(ctx context.Context, req *tempopb.TraceByIDReque
 		}
 
 		if len(blockErrs) > 0 {
-			return nil, multierr.Combine(blockErrs...)
+			return nil, errors.Join(blockErrs...)
 		}
 
 		span.AddEvent("done searching store", oteltrace.WithAttributes(

--- a/tempodb/pool/pool_test.go
+++ b/tempodb/pool/pool_test.go
@@ -2,6 +2,7 @@ package pool
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"sync"
@@ -11,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
-	"go.uber.org/multierr"
 )
 
 func TestResults(t *testing.T) {
@@ -120,7 +120,7 @@ func TestError(t *testing.T) {
 	msg, funcErrs, err := p.RunJobs(context.Background(), payloads, fn)
 	assert.Nil(t, msg)
 	assert.Nil(t, err)
-	assert.Equal(t, ret, multierr.Combine(funcErrs...))
+	assert.ErrorIs(t, errors.Join(funcErrs...), ret)
 	goleak.VerifyNone(t, opts)
 
 	p.Shutdown()


### PR DESCRIPTION
**What this PR does**:

Replaces `go.uber.org/multierr` with stdlib `errors.Join` (available since Go 1.20) across all first-party call sites. The `go.uber.org/multierr` line moves from direct to indirect requires in `go.mod` (still pulled in transitively by other modules).

Files migrated:

- `tempodb/pool/pool_test.go`
- `modules/querier/querier.go`
- `modules/generator/config.go`
- `modules/distributor/forwarder.go`
- `modules/distributor/forwarder/forwarder.go`
- `modules/distributor/forwarder/manager.go`
- `modules/distributor/forwarder/otlpgrpc/forwarder.go`
- `modules/distributor/receiver/shim.go`

Behavioural notes:

- `errors.Join` formats joined errors with one per line vs `multierr`'s `; ` separation. `Error()` output strings differ, but `Is`/`As` semantics match.
- `tempodb/pool` `TestError` switched from `assert.Equal(t, ret, multierr.Combine(funcErrs...))` to `assert.ErrorIs(t, errors.Join(funcErrs...), ret)`. Reason: `multierr.Combine` unwraps a single error and returns it as-is, so `Equal` worked; `errors.Join` always wraps in a `*joinError`, so equality fails. `ErrorIs` checks chain containment, which is the property the test was really asserting.

**Which issue(s) this PR fixes**:
Part of #7218

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] \`CHANGELOG.md\` updated - the order of entries should be \`[CHANGE]\`, \`[FEATURE]\`, \`[ENHANCEMENT]\`, \`[BUGFIX]\`