### PR TITLE
deps: inline github.com/grafana/otel-profiling-go into pkg/tracing/otelpyroscope

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -231,7 +231,7 @@ require (
 	github.com/google/go-tpm v0.9.8 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect
-	github.com/grafana/otel-profiling-go v0.5.1
+	github.com/grafana/otel-profiling-go v0.5.1 // indirect
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.9 // indirect
 	github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect

--- a/pkg/tracing/otelpyroscope/otelpyroscope.go
+++ b/pkg/tracing/otelpyroscope/otelpyroscope.go
@@ -1,0 +1,171 @@
+// Copied from github.com/grafana/otel-profiling-go (Apache-2.0).
+package otelpyroscope
+
+import (
+	"context"
+	"runtime/pprof"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+const (
+	spanIDLabelName   = "span_id"
+	spanNameLabelName = "span_name"
+)
+
+var profileIDSpanAttributeKey = attribute.Key("pyroscope.profile.id")
+
+// tracerProvider satisfies open telemetry TracerProvider interface.
+type tracerProvider struct {
+	noop.TracerProvider
+	tp     trace.TracerProvider
+	config config
+}
+
+type config struct {
+	spanNameScope scope
+	spanIDScope   scope
+}
+
+type Option func(*tracerProvider)
+
+// NewTracerProvider creates a new tracer provider that annotates pprof
+// samples with span_id label. This allows to establish a relationship
+// between pprof profiles and reported tracing spans.
+func NewTracerProvider(tp trace.TracerProvider, options ...Option) trace.TracerProvider {
+	p := tracerProvider{
+		tp: tp,
+		config: config{
+			spanNameScope: scopeRootSpan,
+			spanIDScope:   scopeRootSpan,
+		},
+	}
+	for _, o := range options {
+		o(&p)
+	}
+	return &p
+}
+
+func (w *tracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.Tracer {
+	return &profileTracer{p: w, tr: w.tp.Tracer(name, opts...)}
+}
+
+type profileTracer struct {
+	noop.Tracer
+	p  *tracerProvider
+	tr trace.Tracer
+}
+
+func (w *profileTracer) Start(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	ctx, span := w.tr.Start(ctx, spanName, opts...)
+	spanCtx := span.SpanContext()
+	addSpanIDLabel := w.p.config.spanIDScope != scopeNone && spanCtx.IsSampled()
+	addSpanNameLabel := w.p.config.spanNameScope != scopeNone && spanName != ""
+	if !(addSpanIDLabel || addSpanNameLabel) {
+		return ctx, span
+	}
+
+	spanID := spanCtx.SpanID().String()
+	s := spanWrapper{
+		Span: span,
+		ctx:  ctx,
+		p:    w.p,
+	}
+
+	rs, ok := rootSpanFromContext(ctx)
+	if !ok {
+		// This is the first local span.
+		rs.id = spanID
+		rs.name = spanName
+		ctx = withRootSpan(ctx, rs)
+	}
+
+	// We mark spans with "pyroscope.profile.id" attribute,
+	// only if they _can_ have profiles. Presence of the attribute
+	// does not indicate the fact that we actually have collected
+	// any samples for the span.
+	if (w.p.config.spanIDScope == scopeRootSpan && spanID == rs.id) ||
+		w.p.config.spanIDScope == scopeAllSpans {
+		span.SetAttributes(profileIDSpanAttributeKey.String(spanID))
+	}
+	labels := make([]string, 0, 4)
+	if addSpanNameLabel {
+		if w.p.config.spanNameScope == scopeRootSpan {
+			spanName = rs.name
+		}
+		labels = append(labels, spanNameLabelName, spanName)
+	}
+	if addSpanIDLabel {
+		if w.p.config.spanIDScope == scopeRootSpan {
+			spanID = rs.id
+		}
+		labels = append(labels, spanIDLabelName, spanID)
+	}
+
+	ctx = pprof.WithLabels(ctx, pprof.Labels(labels...))
+	pprof.SetGoroutineLabels(ctx)
+	return ctx, &s
+}
+
+type spanWrapper struct {
+	trace.Span
+	ctx context.Context
+	p   *tracerProvider
+}
+
+func (s spanWrapper) End(options ...trace.SpanEndOption) {
+	s.Span.End(options...)
+	pprof.SetGoroutineLabels(s.ctx)
+}
+
+type rootSpanCtxKey struct{}
+
+type rootSpan struct {
+	id   string
+	name string
+}
+
+func withRootSpan(ctx context.Context, s rootSpan) context.Context {
+	return context.WithValue(ctx, rootSpanCtxKey{}, s)
+}
+
+func rootSpanFromContext(ctx context.Context) (rootSpan, bool) {
+	s, ok := ctx.Value(rootSpanCtxKey{}).(rootSpan)
+	return s, ok
+}
+
+// TODO(kolesnikovae): Make options public.
+
+// withSpanNameLabelScope specifies whether the current span name should be
+// added to the profile labels. If the name is dynamic, i.e. includes
+// span-specific identifiers, such as URL or SQL query, this may significantly
+// deteriorate performance.
+//
+// By default, only the local root span name is recorded. Samples collected
+// during the child span execution will be included into the root span profile.
+func withSpanNameLabelScope(scope scope) Option {
+	return func(tp *tracerProvider) {
+		tp.config.spanNameScope = scope
+	}
+}
+
+// withSpanIDScope specifies whether the current span ID should be added to
+// the profile labels.
+//
+// By default, only the local root span ID is recorded. Samples collected
+// during the child span execution will be included into the root span profile.
+func withSpanIDScope(scope scope) Option {
+	return func(tp *tracerProvider) {
+		tp.config.spanNameScope = scope
+	}
+}
+
+type scope uint
+
+const (
+	scopeNone = iota
+	scopeRootSpan
+	scopeAllSpans
+)

--- a/pkg/tracing/otelpyroscope/otelpyroscope.go
+++ b/pkg/tracing/otelpyroscope/otelpyroscope.go
@@ -63,7 +63,7 @@ func (w *profileTracer) Start(ctx context.Context, spanName string, opts ...trac
 	spanCtx := span.SpanContext()
 	addSpanIDLabel := w.p.config.spanIDScope != scopeNone && spanCtx.IsSampled()
 	addSpanNameLabel := w.p.config.spanNameScope != scopeNone && spanName != ""
-	if !(addSpanIDLabel || addSpanNameLabel) {
+	if !addSpanIDLabel && !addSpanNameLabel {
 		return ctx, span
 	}
 
@@ -134,32 +134,6 @@ func withRootSpan(ctx context.Context, s rootSpan) context.Context {
 func rootSpanFromContext(ctx context.Context) (rootSpan, bool) {
 	s, ok := ctx.Value(rootSpanCtxKey{}).(rootSpan)
 	return s, ok
-}
-
-// TODO(kolesnikovae): Make options public.
-
-// withSpanNameLabelScope specifies whether the current span name should be
-// added to the profile labels. If the name is dynamic, i.e. includes
-// span-specific identifiers, such as URL or SQL query, this may significantly
-// deteriorate performance.
-//
-// By default, only the local root span name is recorded. Samples collected
-// during the child span execution will be included into the root span profile.
-func withSpanNameLabelScope(scope scope) Option {
-	return func(tp *tracerProvider) {
-		tp.config.spanNameScope = scope
-	}
-}
-
-// withSpanIDScope specifies whether the current span ID should be added to
-// the profile labels.
-//
-// By default, only the local root span ID is recorded. Samples collected
-// during the child span execution will be included into the root span profile.
-func withSpanIDScope(scope scope) Option {
-	return func(tp *tracerProvider) {
-		tp.config.spanNameScope = scope
-	}
 }
 
 type scope uint

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log/level"
-	otelpyroscope "github.com/grafana/otel-profiling-go"
+	"github.com/grafana/tempo/pkg/tracing/otelpyroscope"
 	"github.com/grafana/tempo/pkg/util/log"
 	"github.com/prometheus/common/version"
 	"go.opentelemetry.io/contrib/exporters/autoexport"


### PR DESCRIPTION
**What this PR does**:

Drops the direct dependency on `github.com/grafana/otel-profiling-go` by inlining its ~170 LoC tracer-provider wrapper into a new internal package `pkg/tracing/otelpyroscope`. The single first-party call site (`pkg/tracing/tracing.go:54`) now imports the internal package; the alias `otelpyroscope` and the `NewTracerProvider(tp)` call are unchanged.

The module remains in the build as an indirect dependency via `grafana/dskit/tracing` (vendored), which we cannot edit. The goal of this PR is removing Tempo's direct import, not eradicating the module.

Notes:

- Inlined source matches upstream byte-for-byte (no refactoring, no trimming). Single-line attribution comment at the top: \`// Copied from github.com/grafana/otel-profiling-go (Apache-2.0).\`
- Upstream's \`deprecated.go\` contains only no-op \`Config\`/\`WithXxx\` helpers documented as ignored by the tracer. Tempo's call site doesn't reference them, so they are not inlined.

**Which issue(s) this PR fixes**:
Part of #7218

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] \`CHANGELOG.md\` updated - the order of entries should be \`[CHANGE]\`, \`[FEATURE]\`, \`[ENHANCEMENT]\`, \`[BUGFIX]\`