### PR TITLE
chore: migrate dedicated columns cache from hashicorp/golang-lru/v2 to maypok86/otter/v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,6 @@ require (
 	github.com/googleapis/gax-go/v2 v2.22.0
 	github.com/grafana/gomemcache v0.0.0-20251127154401-74f93547077b
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
-	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jaegertracing/jaeger-idl v0.6.0
 	github.com/mark3labs/mcp-go v0.43.2
 	github.com/maypok86/otter/v2 v2.3.0
@@ -124,7 +123,10 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260406210006-6f92a3bedf2d
 )
 
-require github.com/Microsoft/go-winio v0.6.2 // indirect
+require (
+	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
+)
 
 require (
 	cel.dev/expr v0.25.1 // indirect

--- a/tempodb/backend/dedicated_columns_cache.go
+++ b/tempodb/backend/dedicated_columns_cache.go
@@ -4,22 +4,18 @@ import (
 	"bytes"
 	"unsafe"
 
-	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/maypok86/otter/v2"
 )
 
 var (
 	dedicatedColumnsCacheNull  = []byte("null")
 	dedicatedColumnsCacheEmpty = []byte("[]")
 	dedicatedColumnsCacheSize  = 1024
-	dedicatedColumnsCache      *lru.Cache[string, DedicatedColumns]
+	dedicatedColumnsCache      *otter.Cache[string, DedicatedColumns]
 )
 
 func init() {
-	var err error
-	dedicatedColumnsCache, err = lru.New[string, DedicatedColumns](dedicatedColumnsCacheSize)
-	if err != nil { // only errors if dedicatedColumnsCacheSize <= 0
-		panic(err)
-	}
+	dedicatedColumnsCache = otter.Must(&otter.Options[string, DedicatedColumns]{MaximumSize: dedicatedColumnsCacheSize})
 }
 
 func getDedicatedColumnsFromCache(marshalled []byte) (DedicatedColumns, bool) {
@@ -33,12 +29,12 @@ func getDedicatedColumnsFromCache(marshalled []byte) (DedicatedColumns, bool) {
 		return nil, false
 	}
 	s := unsafe.String(unsafe.SliceData(marshalled), len(marshalled)) // unsafe conversion is safe for lookups
-	return dedicatedColumnsCache.Get(s)
+	return dedicatedColumnsCache.GetIfPresent(s)
 }
 
 func putDedicatedColumnsToCache(marshalled []byte, cols DedicatedColumns) {
 	if len(marshalled) == 0 {
 		return
 	}
-	_ = dedicatedColumnsCache.Add(string(marshalled), cols)
+	dedicatedColumnsCache.Set(string(marshalled), cols)
 }

--- a/tempodb/backend/dedicated_columns_cache_test.go
+++ b/tempodb/backend/dedicated_columns_cache_test.go
@@ -42,7 +42,7 @@ func Test_getDedicatedColumnsFromCache(t *testing.T) {
 			jsonBytes := []byte(tc.jsonStr)
 
 			// clear the map so we start with a clean slate
-			dedicatedColumnsCache.Purge()
+			dedicatedColumnsCache.InvalidateAll()
 
 			if tc.isCached {
 				v, ok := getDedicatedColumnsFromCache(jsonBytes)

--- a/tempodb/backend/tenantindex_benchmark_test.go
+++ b/tempodb/backend/tenantindex_benchmark_test.go
@@ -20,7 +20,7 @@ func BenchmarkIndexMarshal(b *testing.B) {
 	b.Run("format=json", func(b *testing.B) {
 		for _, numBlocks := range []int{100, 1000, 10000} {
 			b.Run(fmt.Sprintf("blocks=%d", numBlocks), func(b *testing.B) {
-				dedicatedColumnsCache.Purge()
+				dedicatedColumnsCache.InvalidateAll()
 				idx := makeTestTenantIndex(numBlocks)
 				for b.Loop() {
 					doNotOptimizeBytes, _ = idx.marshal()
@@ -32,7 +32,7 @@ func BenchmarkIndexMarshal(b *testing.B) {
 	b.Run("format=proto", func(b *testing.B) {
 		for _, numBlocks := range []int{100, 1000, 10000} {
 			b.Run(fmt.Sprintf("blocks=%d", numBlocks), func(b *testing.B) {
-				dedicatedColumnsCache.Purge()
+				dedicatedColumnsCache.InvalidateAll()
 				idx := makeTestTenantIndex(numBlocks)
 				for b.Loop() {
 					doNotOptimizeBytes, _ = idx.marshalPb()
@@ -46,7 +46,7 @@ func BenchmarkIndexUnmarshal(b *testing.B) {
 	b.Run("format=json", func(b *testing.B) {
 		for _, numBlocks := range []int{100, 1000, 10000} {
 			b.Run(fmt.Sprintf("blocks=%d", numBlocks), func(b *testing.B) {
-				dedicatedColumnsCache.Purge()
+				dedicatedColumnsCache.InvalidateAll()
 				idx := makeTestTenantIndex(numBlocks)
 				idxBuf, err := idx.marshal()
 				require.NoError(b, err)
@@ -61,7 +61,7 @@ func BenchmarkIndexUnmarshal(b *testing.B) {
 	b.Run("format=proto", func(b *testing.B) {
 		for _, numBlocks := range []int{100, 1000, 10000} {
 			b.Run(fmt.Sprintf("blocks=%d", numBlocks), func(b *testing.B) {
-				dedicatedColumnsCache.Purge()
+				dedicatedColumnsCache.InvalidateAll()
 				idx := makeTestTenantIndex(numBlocks)
 				idxBuf, err := idx.marshal()
 				require.NoError(b, err)


### PR DESCRIPTION
**What this PR does**:

Migrates the dedicated-columns cache from `hashicorp/golang-lru/v2` to `maypok86/otter/v2`, which is already a direct dependency (used by \`pkg/drain/log_cluster_cache.go\`). Consolidating on otter/v2 drops golang-lru/v2 from direct requires (it remains indirect via \`dskit/ring\`).

Scope is small: one cache definition in \`tempodb/backend/dedicated_columns_cache.go\`, plus its test and benchmark callers.

API mapping for the single migrated call site:

| `golang-lru/v2`                | `otter/v2`                                                |
| ------------------------------ | --------------------------------------------------------- |
| \`lru.New[K,V](size)\`         | \`otter.Must(&otter.Options[K,V]{MaximumSize: size})\`    |
| \`Get(k)\` -> (V, bool)        | \`GetIfPresent(k)\` -> (V, bool)                          |
| \`Add(k, v)\` -> evicted bool  | \`Set(k, v)\` (no return value)                           |
| \`Purge()\`                    | \`InvalidateAll()\`                                       |

The \`unsafe.String\` zero-alloc lookup is preserved: \`GetIfPresent\` accepts a string key identically.

Behavioural notes:

- Eviction policy changes from strict LRU to otter's W-TinyLFU. The cache holds marshalled-JSON -> \`DedicatedColumns\` with 1024 entries and no test asserts eviction order, so this is fine. Hit rate may improve slightly under skewed access patterns.
- The old \`lru.New\` error path (errors only on \`size <= 0\`) is replaced by \`otter.Must\` which panics on the same condition, matching the prior \`panic(err)\` behaviour.

**Which issue(s) this PR fixes**:
Part of #7218

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] \`CHANGELOG.md\` updated - the order of entries should be \`[CHANGE]\`, \`[FEATURE]\`, \`[ENHANCEMENT]\`, \`[BUGFIX]\`