### PR TITLE
cache: enforce a configurable MaxItemSize for Redis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / unreleased
 
+* [ENHANCEMENT] cache: enforce a configurable MaxItemSize for Redis. [#7311](https://github.com/grafana/tempo/pull/7311) (@electron0zero)
 * [SECURITY] jsonnet: bump `memcached` to `1.6.42-alpine` and `prom/memcached-exporter` to `v0.16.0` to clear accumulated CVEs. [#7244](https://github.com/grafana/tempo/pull/7244) (@zhxiaogg)
 * [CHANGE] **BREAKING CHANGE** Recent data queries guarantee complete results by failing when an instance is lagging. Defaults `query_frontend.query_end_cutoff` to `30s` and `live_store.fail_on_high_lag` to `true`. [#7210](https://github.com/grafana/tempo/pull/7210) (@mapno)
 * [ENHANCEMENT] tempo-mixin: update backendwork dashboard with a Redaction section (active jobs, created/completed/failed/dropped by tenant, job duration), add Dropped and Job Duration panels to the Jobs row, and fix the Retry metric name (`jobs_retry` -> `jobs_retry_total`). [#7184](https://github.com/grafana/tempo/pull/7184) (@zalegrala)

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -2933,7 +2933,7 @@ cache:
 
             # Optional
             # The maximum size in bytes of an item stored in Redis.
-            # Bigger items are not stored. A value of 0 disables the limit.
+            # Items larger than this are not stored. A value of 0 disables the limit.
             # (default: 0)
             [max_item_size: <int>]
 

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -2932,6 +2932,12 @@ cache:
             [max_connection_age: <duration> | default = 0s]
 
             # Optional
+            # The maximum size in bytes of an item stored in Redis.
+            # Bigger items are not stored. A value of 0 disables the limit.
+            # (default: 0)
+            [max_item_size: <int>]
+
+            # Optional
             # TTL for cached keys.
             [ttl: <duration>]
 ```

--- a/modules/cache/redis/redis.go
+++ b/modules/cache/redis/redis.go
@@ -23,8 +23,8 @@ func NewClient(cfg *Config, cfgBackground *cache.BackgroundConfig, name string, 
 		cfg.ClientConfig.Expiration = cfg.TTL
 	}
 
-	client := cache.NewRedisClient(&cfg.ClientConfig)
-	c := cache.NewRedisCache(name, client, prometheus.DefaultRegisterer, logger)
+	client := cache.NewRedisClient(&cfg.ClientConfig, name, prometheus.DefaultRegisterer)
+	c := cache.NewRedisCache(name, client, cfg.ClientConfig.MaxItemSize, prometheus.DefaultRegisterer, logger)
 
 	return cache.NewBackground(name, *cfgBackground, c, prometheus.DefaultRegisterer)
 }

--- a/pkg/cache/memcached_client.go
+++ b/pkg/cache/memcached_client.go
@@ -166,7 +166,7 @@ func NewMemcachedClient(cfg MemcachedClientConfig, name string, r prometheus.Reg
 		skipped: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Namespace:   "tempo",
 			Name:        "memcache_client_set_skip_total",
-			Help:        "Total number of skipped set operations because of the value is larger than the max-item-size.",
+			Help:        "Total number of skipped set operations because the value is larger than max-item-size.",
 			ConstLabels: prometheus.Labels{"name": name},
 		}),
 	}

--- a/pkg/cache/redis_cache.go
+++ b/pkg/cache/redis_cache.go
@@ -17,20 +17,20 @@ import (
 
 // RedisCache type caches chunks in redis
 type RedisCache struct {
-	name            string
-	redis           *RedisClient
-	logger          log.Logger
-	requestDuration *instr.HistogramCollector
-	maxItemSize     int
+	name             string
+	redis            *RedisClient
+	logger           log.Logger
+	requestDuration  *instr.HistogramCollector
+	maxItemSizeBytes int
 }
 
 // NewRedisCache creates a new RedisCache
-func NewRedisCache(name string, redisClient *RedisClient, maxItemSize int, reg prometheus.Registerer, logger log.Logger) *RedisCache {
+func NewRedisCache(name string, redisClient *RedisClient, maxItemSizeBytes int, reg prometheus.Registerer, logger log.Logger) *RedisCache {
 	cache := &RedisCache{
-		name:        name,
-		redis:       redisClient,
-		logger:      logger,
-		maxItemSize: maxItemSize,
+		name:             name,
+		redis:            redisClient,
+		logger:           logger,
+		maxItemSizeBytes: maxItemSizeBytes,
 		requestDuration: instr.NewHistogramCollector(
 			promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 				Namespace:                       "tempo",
@@ -150,5 +150,5 @@ func (c *RedisCache) Release(_ []byte) {
 }
 
 func (c *RedisCache) MaxItemSize() int {
-	return c.maxItemSize
+	return c.maxItemSizeBytes
 }

--- a/pkg/cache/redis_cache.go
+++ b/pkg/cache/redis_cache.go
@@ -21,14 +21,16 @@ type RedisCache struct {
 	redis           *RedisClient
 	logger          log.Logger
 	requestDuration *instr.HistogramCollector
+	maxItemSize     int
 }
 
 // NewRedisCache creates a new RedisCache
-func NewRedisCache(name string, redisClient *RedisClient, reg prometheus.Registerer, logger log.Logger) *RedisCache {
+func NewRedisCache(name string, redisClient *RedisClient, maxItemSize int, reg prometheus.Registerer, logger log.Logger) *RedisCache {
 	cache := &RedisCache{
-		name:   name,
-		redis:  redisClient,
-		logger: logger,
+		name:        name,
+		redis:       redisClient,
+		logger:      logger,
+		maxItemSize: maxItemSize,
 		requestDuration: instr.NewHistogramCollector(
 			promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 				Namespace:                       "tempo",
@@ -147,7 +149,6 @@ func (c *RedisCache) Release(_ []byte) {
 	// buffer pooling unimplemented in redis
 }
 
-// redis doesn't have a max item size. todo: add
 func (c *RedisCache) MaxItemSize() int {
-	return 0
+	return c.maxItemSize
 }

--- a/pkg/cache/redis_cache_test.go
+++ b/pkg/cache/redis_cache_test.go
@@ -2,12 +2,12 @@ package cache
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/go-kit/log"
-	"github.com/go-redis/redis/v8"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -57,17 +57,26 @@ func TestRedisCache(t *testing.T) {
 	assert.False(t, foundKey)
 }
 
+func TestRedisCache_MaxItemSizeReturnsConfigured(t *testing.T) {
+	c, err := mockRedisCache()
+	require.NoError(t, err)
+	defer c.redis.Close()
+
+	require.Equal(t, c.MaxItemSize(), 10*1024*1024,
+		"RedisCache.MaxItemSize() must return the configured max size")
+}
+
 func mockRedisCache() (*RedisCache, error) {
 	redisServer, err := miniredis.Run()
 	if err != nil {
 		return nil, err
 	}
-	redisClient := &RedisClient{
-		expiration: time.Minute,
-		timeout:    100 * time.Millisecond,
-		rdb: redis.NewUniversalClient(&redis.UniversalOptions{
-			Addrs: []string{redisServer.Addr()},
-		}),
+	cfg := &RedisConfig{
+		Expiration:  time.Minute,
+		Timeout:     100 * time.Millisecond,
+		Endpoint:    strings.Join([]string{redisServer.Addr()}, ","),
+		MaxItemSize: 10 * 1024 * 1024,
 	}
-	return NewRedisCache("mock", redisClient, nil, log.NewNopLogger()), nil
+	redisClient := NewRedisClient(cfg, "mock", nil)
+	return NewRedisCache("mock", redisClient, cfg.MaxItemSize, nil, log.NewNopLogger()), nil
 }

--- a/pkg/cache/redis_cache_test.go
+++ b/pkg/cache/redis_cache_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -62,7 +63,7 @@ func TestRedisCache_MaxItemSizeReturnsConfigured(t *testing.T) {
 	require.NoError(t, err)
 	defer c.redis.Close()
 
-	require.Equal(t, c.MaxItemSize(), 10*1024*1024,
+	require.Equal(t, 10*1024*1024, c.MaxItemSize(),
 		"RedisCache.MaxItemSize() must return the configured max size")
 }
 
@@ -77,6 +78,6 @@ func mockRedisCache() (*RedisCache, error) {
 		Endpoint:    strings.Join([]string{redisServer.Addr()}, ","),
 		MaxItemSize: 10 * 1024 * 1024,
 	}
-	redisClient := NewRedisClient(cfg, "mock", nil)
-	return NewRedisCache("mock", redisClient, cfg.MaxItemSize, nil, log.NewNopLogger()), nil
+	redisClient := NewRedisClient(cfg, "mock", prometheus.NewRegistry())
+	return NewRedisCache("mock", redisClient, cfg.MaxItemSize, prometheus.NewRegistry(), log.NewNopLogger()), nil
 }

--- a/pkg/cache/redis_client.go
+++ b/pkg/cache/redis_client.go
@@ -33,8 +33,8 @@ type RedisConfig struct {
 	InsecureSkipVerify bool           `yaml:"tls_insecure_skip_verify"`
 	IdleTimeout        time.Duration  `yaml:"idle_timeout"`
 	MaxConnAge         time.Duration  `yaml:"max_connection_age"`
-	// MaxItemSize is the max size in bytes of an item stored in Redis. Items larger than this are not cached.
-	// 0 means no limit is enforced.
+	// MaxItemSize is the maximum size in bytes of an item stored in Redis.
+	// Items larger than this are not stored. A value of 0 disables the limit.
 	MaxItemSize int `yaml:"max_item_size"`
 }
 
@@ -54,7 +54,7 @@ func (cfg *RedisConfig) RegisterFlagsWithPrefix(prefix, description string, f *f
 	f.BoolVar(&cfg.InsecureSkipVerify, prefix+"redis.tls-insecure-skip-verify", false, description+"Skip validating server certificate.")
 	f.DurationVar(&cfg.IdleTimeout, prefix+"redis.idle-timeout", 0, description+"Close connections after remaining idle for this duration. If the value is zero, then idle connections are not closed.")
 	f.DurationVar(&cfg.MaxConnAge, prefix+"redis.max-connection-age", 0, description+"Close connections older than this duration. If the value is zero, then the pool does not close connections based on age.")
-	f.IntVar(&cfg.MaxItemSize, prefix+"redis.max-item-size", 0, description+"The maximum size in bytes of an item stored in Redis. Bigger items are not stored. If set to 0, no maximum size is enforced.")
+	f.IntVar(&cfg.MaxItemSize, prefix+"redis.max-item-size", 0, description+"The maximum size in bytes of an item stored in Redis. Items larger than this are not stored. A value of 0 disables the limit.")
 }
 
 type RedisClient struct {
@@ -62,8 +62,8 @@ type RedisClient struct {
 	timeout    time.Duration
 	rdb        redis.UniversalClient
 
-	maxItemSize int
-	skipped     prometheus.Counter
+	maxItemSizeBytes int
+	skipped          prometheus.Counter
 }
 
 // NewRedisClient creates Redis client
@@ -84,10 +84,10 @@ func NewRedisClient(cfg *RedisConfig, name string, reg prometheus.Registerer) *R
 		opt.TLSConfig = &tls.Config{InsecureSkipVerify: cfg.InsecureSkipVerify}
 	}
 	return &RedisClient{
-		expiration:  cfg.Expiration,
-		timeout:     cfg.Timeout,
-		rdb:         redis.NewUniversalClient(opt),
-		maxItemSize: cfg.MaxItemSize,
+		expiration:       cfg.Expiration,
+		timeout:          cfg.Timeout,
+		rdb:              redis.NewUniversalClient(opt),
+		maxItemSizeBytes: cfg.MaxItemSize,
 		skipped: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Namespace:   "tempo",
 			Name:        "rediscache_client_set_skip_total",
@@ -127,8 +127,8 @@ func (c *RedisClient) MSet(ctx context.Context, keys []string, values [][]byte) 
 
 	pipe := c.rdb.TxPipeline()
 	for i := range keys {
-		// Skip hitting redis at all if the item is bigger than the max allowed size.
-		if c.maxItemSize > 0 && len(values[i]) > c.maxItemSize {
+		// Skip hitting redis at all if the item is larger than the max allowed size.
+		if c.maxItemSizeBytes > 0 && len(values[i]) > c.maxItemSizeBytes {
 			c.skipped.Inc()
 			continue
 		}

--- a/pkg/cache/redis_client.go
+++ b/pkg/cache/redis_client.go
@@ -11,6 +11,8 @@ import (
 	"unsafe"
 
 	"github.com/go-redis/redis/v8"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/grafana/dskit/flagext"
 )
@@ -31,6 +33,9 @@ type RedisConfig struct {
 	InsecureSkipVerify bool           `yaml:"tls_insecure_skip_verify"`
 	IdleTimeout        time.Duration  `yaml:"idle_timeout"`
 	MaxConnAge         time.Duration  `yaml:"max_connection_age"`
+	// MaxItemSize is the max size in bytes of an item stored in Redis. Items larger than this are not cached.
+	// 0 means no limit is enforced.
+	MaxItemSize int `yaml:"max_item_size"`
 }
 
 // RegisterFlagsWithPrefix adds the flags required to config this to the given FlagSet
@@ -49,16 +54,20 @@ func (cfg *RedisConfig) RegisterFlagsWithPrefix(prefix, description string, f *f
 	f.BoolVar(&cfg.InsecureSkipVerify, prefix+"redis.tls-insecure-skip-verify", false, description+"Skip validating server certificate.")
 	f.DurationVar(&cfg.IdleTimeout, prefix+"redis.idle-timeout", 0, description+"Close connections after remaining idle for this duration. If the value is zero, then idle connections are not closed.")
 	f.DurationVar(&cfg.MaxConnAge, prefix+"redis.max-connection-age", 0, description+"Close connections older than this duration. If the value is zero, then the pool does not close connections based on age.")
+	f.IntVar(&cfg.MaxItemSize, prefix+"redis.max-item-size", 0, description+"The maximum size in bytes of an item stored in Redis. Bigger items are not stored. If set to 0, no maximum size is enforced.")
 }
 
 type RedisClient struct {
 	expiration time.Duration
 	timeout    time.Duration
 	rdb        redis.UniversalClient
+
+	maxItemSize int
+	skipped     prometheus.Counter
 }
 
 // NewRedisClient creates Redis client
-func NewRedisClient(cfg *RedisConfig) *RedisClient {
+func NewRedisClient(cfg *RedisConfig, name string, reg prometheus.Registerer) *RedisClient {
 	opt := &redis.UniversalOptions{
 		Addrs:            strings.Split(cfg.Endpoint, ","),
 		MasterName:       cfg.MasterName,
@@ -75,9 +84,16 @@ func NewRedisClient(cfg *RedisConfig) *RedisClient {
 		opt.TLSConfig = &tls.Config{InsecureSkipVerify: cfg.InsecureSkipVerify}
 	}
 	return &RedisClient{
-		expiration: cfg.Expiration,
-		timeout:    cfg.Timeout,
-		rdb:        redis.NewUniversalClient(opt),
+		expiration:  cfg.Expiration,
+		timeout:     cfg.Timeout,
+		rdb:         redis.NewUniversalClient(opt),
+		maxItemSize: cfg.MaxItemSize,
+		skipped: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace:   "tempo",
+			Name:        "rediscache_client_set_skip_total",
+			Help:        "Total number of skipped set operations because the value is larger than max-item-size.",
+			ConstLabels: prometheus.Labels{"name": name},
+		}),
 	}
 }
 
@@ -111,6 +127,11 @@ func (c *RedisClient) MSet(ctx context.Context, keys []string, values [][]byte) 
 
 	pipe := c.rdb.TxPipeline()
 	for i := range keys {
+		// Skip hitting redis at all if the item is bigger than the max allowed size.
+		if c.maxItemSize > 0 && len(values[i]) > c.maxItemSize {
+			c.skipped.Inc()
+			continue
+		}
 		pipe.Set(ctx, keys[i], values[i], c.expiration)
 	}
 	_, err := pipe.Exec(ctx)

--- a/pkg/cache/redis_client_test.go
+++ b/pkg/cache/redis_client_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	miniredis "github.com/alicebob/miniredis/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -80,6 +82,82 @@ func TestRedisClient(t *testing.T) {
 	}
 }
 
+func TestRedisClient_MSet_MaxItemSize(t *testing.T) {
+	const itemSize = 100
+
+	tests := []struct {
+		name        string
+		maxItemSize int
+		keys        []string
+		values      [][]byte
+		wantStored  []bool // parallel to keys; true = expected present in redis
+		wantSkipped int    // expected value of the skipped counter
+	}{
+		{
+			name:        "mixed batch skips oversized item",
+			maxItemSize: itemSize,
+			keys:        []string{"small1", "oversized", "small2"},
+			values:      [][]byte{[]byte("ok"), make([]byte, itemSize+1), []byte("also ok")},
+			wantStored:  []bool{true, false, true},
+			wantSkipped: 1,
+		},
+		{
+			name:        "boundary item exactly at the cap is stored",
+			maxItemSize: itemSize,
+			keys:        []string{"at-cap"},
+			values:      [][]byte{make([]byte, itemSize)},
+			wantStored:  []bool{true},
+			wantSkipped: 0,
+		},
+		{
+			name:        "all oversized batch skips every item and counter increments per item",
+			maxItemSize: itemSize,
+			keys:        []string{"big1", "big2", "big3"},
+			values:      [][]byte{make([]byte, itemSize+1), make([]byte, itemSize+50), make([]byte, itemSize*10)},
+			wantStored:  []bool{false, false, false},
+			wantSkipped: 3,
+		},
+		{
+			name:        "zero MaxItemSize disables the cap",
+			maxItemSize: 0,
+			keys:        []string{"huge"},
+			values:      [][]byte{make([]byte, 10*1024*1024)},
+			wantStored:  []bool{true},
+			wantSkipped: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			redisServer, err := miniredis.Run()
+			require.NoError(t, err)
+			defer redisServer.Close()
+
+			client := NewRedisClient(&RedisConfig{
+				Expiration:  time.Minute,
+				Timeout:     100 * time.Millisecond,
+				Endpoint:    redisServer.Addr(),
+				MaxItemSize: tc.maxItemSize,
+			}, "test", prometheus.NewRegistry())
+
+			require.NoError(t, client.MSet(context.Background(), tc.keys, tc.values))
+
+			got, err := client.MGet(context.Background(), tc.keys)
+			require.NoError(t, err)
+
+			for i, key := range tc.keys {
+				if tc.wantStored[i] {
+					require.Equal(t, tc.values[i], got[i], "key %q must be stored", key)
+				} else {
+					require.Nil(t, got[i], "key %q must be skipped", key)
+				}
+			}
+			require.Equal(t, float64(tc.wantSkipped), testutil.ToFloat64(client.skipped),
+				"skipped counter must equal the number of items above the cap")
+		})
+	}
+}
+
 func mockRedisClientSingle() (*RedisClient, error) {
 	redisServer, err := miniredis.Run()
 	if err != nil {
@@ -94,7 +172,7 @@ func mockRedisClientSingle() (*RedisClient, error) {
 		}, ","),
 	}
 
-	return NewRedisClient(cfg), nil
+	return NewRedisClient(cfg, "test", nil), nil
 }
 
 func mockRedisClientCluster() (*RedisClient, error) {
@@ -117,5 +195,5 @@ func mockRedisClientCluster() (*RedisClient, error) {
 		}, ","),
 	}
 
-	return NewRedisClient(cfg), nil
+	return NewRedisClient(cfg, "test", nil), nil
 }

--- a/pkg/cache/redis_client_test.go
+++ b/pkg/cache/redis_client_test.go
@@ -102,12 +102,12 @@ func TestRedisClient_MSet_MaxItemSize(t *testing.T) {
 			wantSkipped: 1,
 		},
 		{
-			name:        "boundary item exactly at the cap is stored",
+			name:        "boundary item exactly at the cap is stored and one byte over is skipped",
 			maxItemSize: itemSize,
-			keys:        []string{"at-cap"},
-			values:      [][]byte{make([]byte, itemSize)},
-			wantStored:  []bool{true},
-			wantSkipped: 0,
+			keys:        []string{"at-cap", "over-cap-by-1"},
+			values:      [][]byte{make([]byte, itemSize), make([]byte, itemSize+1)},
+			wantStored:  []bool{true, false},
+			wantSkipped: 1,
 		},
 		{
 			name:        "all oversized batch skips every item and counter increments per item",
@@ -120,8 +120,8 @@ func TestRedisClient_MSet_MaxItemSize(t *testing.T) {
 		{
 			name:        "zero MaxItemSize disables the cap",
 			maxItemSize: 0,
-			keys:        []string{"huge"},
-			values:      [][]byte{make([]byte, 10*1024*1024)},
+			keys:        []string{"larger-than-cap"},
+			values:      [][]byte{make([]byte, itemSize*100)},
 			wantStored:  []bool{true},
 			wantSkipped: 0,
 		},
@@ -172,7 +172,7 @@ func mockRedisClientSingle() (*RedisClient, error) {
 		}, ","),
 	}
 
-	return NewRedisClient(cfg, "test", nil), nil
+	return NewRedisClient(cfg, "test", prometheus.NewRegistry()), nil
 }
 
 func mockRedisClientCluster() (*RedisClient, error) {
@@ -195,5 +195,5 @@ func mockRedisClientCluster() (*RedisClient, error) {
 		}, ","),
 	}
 
-	return NewRedisClient(cfg, "test", nil), nil
+	return NewRedisClient(cfg, "test", prometheus.NewRegistry()), nil
 }


### PR DESCRIPTION
**What this PR does**:

- Add `MaxItemSize` to `RedisConfig` (yaml `max_item_size`, flag `redis.max-item-size`), default 0 = no limit.
- `RedisCache.MaxItemSize()` returns the configured value so the cache pipeline's per-item size guard at `pipeline/sync_handler_cache.go:80-83` finally applies to Redis.
- `RedisClient.MSet` filters oversized items per item and increments `tempo_rediscache_client_set_skip_total{name=...}` - defense-in-depth for callers that bypass the pipeline (e.g. background writer).
- Same logic as Memcached.


**Which issue(s) this PR fixes**:

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`