### PR TITLE
Fix page weights in release notes

### DIFF
--- a/docs/sources/tempo/release-notes/v3-0.md
+++ b/docs/sources/tempo/release-notes/v3-0.md
@@ -2,7 +2,7 @@
 title: Version 3.0 release notes
 menuTitle: V3.0
 description: Release notes for Grafana Tempo 3.0
-weight: 200
+weight: 700
 ---
 
 # Version 3.0 release notes

--- a/docs/sources/tempo/release-notes/version-1/_index.md
+++ b/docs/sources/tempo/release-notes/version-1/_index.md
@@ -2,7 +2,7 @@
 title: Version 1 release notes
 menuTitle: Version 1
 description: Release notes for Grafana Tempo version 1.x
-weight: 200
+weight: 900
 ---
 
 # Version 1 release notes

--- a/docs/sources/tempo/release-notes/version-2/_index.md
+++ b/docs/sources/tempo/release-notes/version-2/_index.md
@@ -2,7 +2,7 @@
 title: Version 2 release notes
 menuTitle: Version 2
 description: Release notes for Grafana Tempo version 2.x
-weight: 100
+weight: 875
 ---
 
 # Version 2 release notes


### PR DESCRIPTION
**What this PR does**:

Fixes the page weights in the release notes folder so the 3.0 release notes are at the top instead of the bottom. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`