### PR TITLE
chore: adopt chloggen for changelog management

### DIFF
--- a/.chloggen/README.md
+++ b/.chloggen/README.md
@@ -1,0 +1,51 @@
+# Changelog entries
+
+Tempo manages `CHANGELOG.md` with [chloggen](../tools/chloggen) (the in-tree tool
+at `tools/chloggen`). Instead of editing `CHANGELOG.md` directly, every PR adds a
+small YAML file to this directory; the files are collated into the changelog at
+release time. This avoids merge conflicts on a shared file.
+
+## Add an entry
+
+```bash
+make chlog-new        # creates .chloggen/<your-branch>.yaml from TEMPLATE.yaml
+```
+
+Edit the generated file:
+
+```yaml
+change_type: enhancement       # breaking | change | feature | enhancement | bug_fix | security
+component: metrics-generator   # must be in the components allowlist in config.yaml
+note: A brief description of the change.
+issues: [1234]                 # PR or issue number(s)
+subtext:                       # optional extra detail
+user: your-github-handle       # rendered as "(@your-github-handle)"
+```
+
+`change_type` keywords render under these sections:
+
+| keyword       | section               |
+| ------------- | --------------------- |
+| `breaking`    | 🛑 Breaking changes 🛑 |
+| `change`      | 🔧 Changes 🔧          |
+| `feature`     | 🚀 Features 🚀         |
+| `enhancement` | 💡 Enhancements 💡     |
+| `bug_fix`     | 🧰 Bug fixes 🧰        |
+| `security`    | 🔒 Security 🔒         |
+
+`component` must be one of the values in the `components` allowlist in
+[`config.yaml`](./config.yaml); `chlog-validate` rejects anything else. Adding a
+new component? Add it to that list in the same PR.
+
+## Validate / preview
+
+```bash
+make chlog-validate   # validate all entry files
+make chlog-preview    # render the pending entries to stdout
+```
+
+## Release (maintainers)
+
+```bash
+make chlog-update VERSION=v2.11.0   # collate entries into CHANGELOG.md and delete them
+```

--- a/.chloggen/TEMPLATE.yaml
+++ b/.chloggen/TEMPLATE.yaml
@@ -1,0 +1,20 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type:
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component:
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note:
+
+# One or more PR or issue numbers, e.g. [1234].
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user:

--- a/.chloggen/_migrated_00_7207.yaml
+++ b/.chloggen/_migrated_00_7207.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: operations
+note: add `tempo-service-graph.json` dashboard visualizing the service topology from `traces_service_graph_connection_info`.
+issues: [7207]
+subtext:
+user: jcreixell

--- a/.chloggen/_migrated_01_7202.yaml
+++ b/.chloggen/_migrated_01_7202.yaml
@@ -1,0 +1,6 @@
+change_type: feature
+component: metrics-generator
+note: add `service-graphs-*` subprocessors and an opt-in `traces_service_graph_connection_info` presence gauge for topology detection under heavy sampling.
+issues: [7202]
+subtext:
+user: jcreixell

--- a/.chloggen/_migrated_02_6866.yaml
+++ b/.chloggen/_migrated_02_6866.yaml
@@ -1,0 +1,6 @@
+change_type: feature
+component: tempo
+note: Support arithmetic operations in TraceQL Metrics
+issues: [6866]
+subtext:
+user: ruslan-mikhailov

--- a/.chloggen/_migrated_03_7140.yaml
+++ b/.chloggen/_migrated_03_7140.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: storage
+note: replace O(N²) `slices.ContainsFunc` loops in `updateInternal` with pre-built map lookups, reducing per-poll cost from O(N·M) to O(N+M).
+issues: [7140]
+subtext:
+user: zalegrala

--- a/.chloggen/_migrated_04_7142.yaml
+++ b/.chloggen/_migrated_04_7142.yaml
@@ -1,0 +1,6 @@
+change_type: feature
+component: operations
+note: "Add KEDA autoscaling for live-store via Prometheus trigger on expected bytes held. Enable with `live_store.keda.enabled: true`. Configure block-builder coupling via `live_store.keda.block_builder_scaling`: `'rollout-operator'` (default, requires `rollout_operator_replica_template_access_enabled: true`) mirrors live-store zone-a replicas to block-builder; `'keda'` creates a dedicated block-builder KEDA ScaledObject using a kubernetes-workload trigger without requiring rollout-operator RBAC."
+issues: [7142]
+subtext:
+user: zachfi

--- a/.chloggen/_migrated_05_7311.yaml
+++ b/.chloggen/_migrated_05_7311.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: cache
+note: enforce a configurable MaxItemSize for Redis.
+issues: [7311]
+subtext:
+user: electron0zero

--- a/.chloggen/_migrated_06_7184.yaml
+++ b/.chloggen/_migrated_06_7184.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: operations
+note: update backendwork dashboard with a Redaction section (active jobs, created/completed/failed/dropped by tenant, job duration), add Dropped and Job Duration panels to the Jobs row, and fix the Retry metric name (`jobs_retry` -> `jobs_retry_total`).
+issues: [7184]
+subtext:
+user: zalegrala

--- a/.chloggen/_migrated_07_7240.yaml
+++ b/.chloggen/_migrated_07_7240.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: querier
+note: limit external endpoint response size to querier grpc MaxSendMsgSize.
+issues: [7240]
+subtext:
+user: electron0zero

--- a/.chloggen/_migrated_08_7141.yaml
+++ b/.chloggen/_migrated_08_7141.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: backend-scheduler
+note: eliminate O(256·M) shard scan in `HasJobsForTenant` and O(N) prefix scan in `BusyBlocksForTenant` via secondary indexes; `HasJobsForTenant` is now O(1), `BusyBlocksForTenant` is now O(|tenant blocks|). Add `splitPendingBlockKey` helper to centralise pending-block key parsing and decouple all index maintenance sites from the encoded key format.
+issues: [7141]
+subtext:
+user: zalegrala

--- a/.chloggen/_migrated_09_7152.yaml
+++ b/.chloggen/_migrated_09_7152.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: storage
+note: add `tempodb_cache_store_size_bytes` histogram labelled by `role` recording the size of every item written to the backend cache.
+issues: [7152]
+subtext:
+user: javiermolinar

--- a/.chloggen/_migrated_10_7148.yaml
+++ b/.chloggen/_migrated_10_7148.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: tempo
+note: Add `TempoDistributorKafkaProduceFailing` alert that triggers when Kafka records cannot be produced by the distributor.
+issues: [7148]
+subtext:
+user: javiermolinar

--- a/.chloggen/_migrated_11_7105.yaml
+++ b/.chloggen/_migrated_11_7105.yaml
@@ -1,0 +1,6 @@
+change_type: breaking
+component: query-frontend
+note: new job sharding approach for trace lookups, using a new config option `blocks_per_shard` which replaces `query_shards`.
+issues: [7105]
+subtext:
+user: mdisibio

--- a/.chloggen/_migrated_12_7099.yaml
+++ b/.chloggen/_migrated_12_7099.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: operations
+note: add `autoscaling_prometheus_url` and `autoscaling_prometheus_tenant` top-level config fields for KEDA autoscaling. Setting `autoscaling_prometheus_tenant` sends an `X-Scope-OrgID` header on all Prometheus trigger requests, which is required when the backend is a multi-tenant system such as Grafana Mimir.
+issues: [7099]
+subtext:
+user: zachfi

--- a/.chloggen/_migrated_13_7162.yaml
+++ b/.chloggen/_migrated_13_7162.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: live-store
+note: expose query inspected bytes as a metric.
+issues: [7162, 7163]
+subtext:
+user: zhxiaogg

--- a/.chloggen/_migrated_14_7204.yaml
+++ b/.chloggen/_migrated_14_7204.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: storage
+note: evict bloom filter and trace-id-index cache entries for blocks deleted during retention, freeing cache space for active blocks sooner.
+issues: [7204]
+subtext:
+user: zalegrala

--- a/.chloggen/_migrated_15_7204.yaml
+++ b/.chloggen/_migrated_15_7204.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: cache
+note: add `Remove` method to the `Cache` interface, implemented for memcached and redis.
+issues: [7204]
+subtext:
+user: zalegrala

--- a/.chloggen/_migrated_16_7179.yaml
+++ b/.chloggen/_migrated_16_7179.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: traceql
+note: "enable new span-only fetch by default. Can be disabled per-tenant via `metrics_spanonly_fetch: false` or per-query via the unsafe hint `with(spanonly_fetch=false)`."
+issues: [7179]
+subtext:
+user: mdisibio

--- a/.chloggen/_migrated_17_7244.yaml
+++ b/.chloggen/_migrated_17_7244.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: operations
+note: bump `memcached` to `1.6.42-alpine` and `prom/memcached-exporter` to `v0.16.0` to clear accumulated CVEs.
+issues: [7244]
+subtext:
+user: zhxiaogg

--- a/.chloggen/_migrated_18_6992.yaml
+++ b/.chloggen/_migrated_18_6992.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: backend-scheduler
+note: fix redaction batch not cleaned up after dead-job timeout, leaving tenant permanently blocked from new redaction submissions and compaction.
+issues: [6992]
+subtext:
+user: zalegrala

--- a/.chloggen/_migrated_19_6992.yaml
+++ b/.chloggen/_migrated_19_6992.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: backend-scheduler
+note: fix outstanding-blocks metric suppressed to zero during active redaction batch, causing autoscaler to scale down workers mid-redaction.
+issues: [6992]
+subtext:
+user: zalegrala

--- a/.chloggen/_migrated_20_6992.yaml
+++ b/.chloggen/_migrated_20_6992.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: backend-scheduler
+note: fix O(N) lock contention in GetJobForWorker under concurrent worker load; replace shard scan with O(1) index lookup.
+issues: [6992]
+subtext:
+user: zalegrala

--- a/.chloggen/_migrated_21_7155.yaml
+++ b/.chloggen/_migrated_21_7155.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: live-store
+note: write the per-block query-range response cache atomically (temp file + rename) and log+ignore cache read errors.
+issues: [7155]
+subtext:
+user: zhxiaogg

--- a/.chloggen/_migrated_22_7221.yaml
+++ b/.chloggen/_migrated_22_7221.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: tempo
+note: "Better validation for query_range endpoint: do not accept negative step"
+issues: [7221]
+subtext:
+user: ruslan-mikhailov

--- a/.chloggen/_migrated_23_7332.yaml
+++ b/.chloggen/_migrated_23_7332.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: tempo
+note: Return partial trace hint for the llm encoding
+issues: [7332]
+subtext:
+user: javiermolinar

--- a/.chloggen/_migrated_24_7138.yaml
+++ b/.chloggen/_migrated_24_7138.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: overrides
+note: emit duration fields as flat YAML scalars on `/status/overrides/{tenant}` and omit `generate_native_histograms` when unset.
+issues: [7138]
+subtext:
+user: electron0zero

--- a/.chloggen/_migrated_25_7220.yaml
+++ b/.chloggen/_migrated_25_7220.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: tempo
+note: Fix unsafe quoting in query attributes
+issues: [7220]
+subtext:
+user: ruslan-mikhailov

--- a/.chloggen/_migrated_26_7290.yaml
+++ b/.chloggen/_migrated_26_7290.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: tempo
+note: Fix rare cache collision between instant and range metrics queries
+issues: [7290]
+subtext:
+user: ruslan-mikhailov

--- a/.chloggen/_migrated_27_7153.yaml
+++ b/.chloggen/_migrated_27_7153.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: backend-scheduler
+note: fix cross-tenant escalation in SubmitRedaction -- tenant is now sourced exclusively from the authenticated request context (X-Scope-OrgID header) and the body tenant_id field is ignored.
+issues: [7153]
+subtext:
+user: zalegrala

--- a/.chloggen/config.yaml
+++ b/.chloggen/config.yaml
@@ -1,0 +1,64 @@
+# Configuration for chloggen (the in-tree tool at tools/chloggen).
+# See .chloggen/README.md for usage.
+
+# Directory holding individual, unreleased changelog entries (one YAML per change).
+entries_dir: .chloggen
+
+# Template copied by `chloggen new` / `make chlog-new`.
+template_yaml: .chloggen/TEMPLATE.yaml
+
+# Custom render template producing Tempo's CHANGELOG.md format.
+summary_template: .chloggen/summary.tmpl
+
+# Target changelog file(s). Tempo uses a single changelog.
+change_logs:
+  default: CHANGELOG.md
+
+# Changelog used when an entry does not set `change_logs`.
+default_change_logs: [default]
+
+# Change types, in render order, with their section headings. Derived from Tempo's
+# historical CHANGELOG categories ([CHANGE], [FEATURE], [ENHANCEMENT], [BUGFIX],
+# [SECURITY]) plus breaking changes (historically the `**BREAKING CHANGE**` marker).
+change_types:
+  - key: security
+    heading: 🔒 Security 🔒
+  - key: breaking
+    heading: 🛑 Breaking changes 🛑
+  - key: feature
+    heading: 🚀 Features 🚀
+  - key: enhancement
+    heading: 💡 Enhancements 💡
+  - key: bug_fix
+    heading: 🧰 Bug fixes 🧰
+  - key: change
+    heading: 🔧 Changes 🔧
+
+# Allowlist of valid `component` values. Entries with a component outside this
+# list fail `chlog-validate`. Add a new component here when introducing one.
+components:
+  # services / modules
+  - distributor
+  - querier
+  - query-frontend
+  - compactor
+  - metrics-generator
+  - block-builder
+  - live-store
+  - backend-scheduler
+  - backend-worker
+  - overrides
+  - cache
+  # storage / core
+  - storage
+  - traceql
+  - api
+  # binaries
+  - tempo
+  - tempo-cli
+  - tempo-query
+  - tempo-vulture
+  # operations / tooling / meta
+  - operations
+  - docs
+  - deps

--- a/.chloggen/summary.tmpl
+++ b/.chloggen/summary.tmpl
@@ -1,0 +1,24 @@
+{{- define "entry" -}}
+- `{{ .Component }}`: {{ .Note }} (
+{{- range $i, $issue := .Issues }}
+{{- if $i }}, {{ end -}}
+[#{{ $issue }}](https://github.com/grafana/tempo/issues/{{ $issue }})
+{{- end -}}
+)
+{{- if .User }} (@{{ .User }}){{- end }}
+{{- if .SubText }}
+{{ .SubText | indent 2 }}
+{{- end }}
+{{- end }}
+# {{ .Version }}
+{{- range .Groups }}
+{{- if .Entries }}
+
+## {{ .Heading }}
+{{- range $i, $change := .Entries }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,4 +12,4 @@ Fixes #<issue number>
 **Checklist**
 - [ ] Tests updated
 - [ ] Documentation added
-- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
+- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`; see `.chloggen/README.md`)

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,63 @@
+# Requires every PR targeting main to add a .chloggen entry.
+# Skip by adding the "Skip Changelog" label or using a "chore:" / "chore(scope):" / "[chore]" PR title.
+name: changelog
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request'
+      && !contains(github.event.pull_request.labels.*.name, 'dependencies')
+      && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog')
+      && !contains(github.event.pull_request.title, '[chore]')
+      && !startsWith(github.event.pull_request.title, 'chore:')
+      && !startsWith(github.event.pull_request.title, 'chore(')
+    env:
+      PR_HEAD: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Ensure CHANGELOG.md was not edited directly
+        run: |
+          base=$(git merge-base origin/main "$PR_HEAD")
+          if [[ -n "$(git diff --name-only "$base" "$PR_HEAD" ./CHANGELOG.md)" ]]; then
+            echo "CHANGELOG.md should not be edited directly."
+            echo "Add a .yaml file under ./.chloggen/ instead (run 'make chlog-new')."
+            echo "See .chloggen/README.md, or use a 'chore:' title / 'Skip Changelog' label to skip."
+            exit 1
+          fi
+          echo "CHANGELOG.md was not modified."
+
+      - name: Ensure a .chloggen entry was added
+        run: |
+          base=$(git merge-base origin/main "$PR_HEAD")
+          added=$(git diff --diff-filter=A --name-only "$base" "$PR_HEAD" ./.chloggen | grep -cE '\.ya?ml$' || true)
+          if [[ "$added" -lt 1 ]]; then
+            echo "No changelog entry was added under ./.chloggen/."
+            echo "Run 'make chlog-new' to create one. See .chloggen/README.md."
+            echo "Use a 'chore:' title / 'Skip Changelog' label to skip."
+            exit 1
+          fi
+          echo "A .chloggen entry was added."
+
+      - name: Validate .chloggen entries
+        run: make chlog-validate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,4 @@
-## main / unreleased
-
-* [ENHANCEMENT] tempo-mixin: add `tempo-service-graph.json` dashboard visualizing the service topology from `traces_service_graph_connection_info`. [#7207](https://github.com/grafana/tempo/pull/7207) (@jcreixell)
-* [FEATURE] metrics-generator: add `service-graphs-*` subprocessors and an opt-in `traces_service_graph_connection_info` presence gauge for topology detection under heavy sampling. [#7202](https://github.com/grafana/tempo/pull/7202) (@jcreixell)
-* [FEATURE] Support arithmetic operations in TraceQL Metrics [#6866](https://github.com/grafana/tempo/pull/6866) (@ruslan-mikhailov)
-* [ENHANCEMENT] blocklist: replace O(N²) `slices.ContainsFunc` loops in `updateInternal` with pre-built map lookups, reducing per-poll cost from O(N·M) to O(N+M). [#7140](https://github.com/grafana/tempo/pull/7140) (@zalegrala)
-* [FEATURE] jsonnet: Add KEDA autoscaling for live-store via Prometheus trigger on expected bytes held. Enable with `live_store.keda.enabled: true`. Configure block-builder coupling via `live_store.keda.block_builder_scaling`: `'rollout-operator'` (default, requires `rollout_operator_replica_template_access_enabled: true`) mirrors live-store zone-a replicas to block-builder; `'keda'` creates a dedicated block-builder KEDA ScaledObject using a kubernetes-workload trigger without requiring rollout-operator RBAC. [#7142](https://github.com/grafana/tempo/pull/7142) (@zachfi)
-* [ENHANCEMENT] cache: enforce a configurable MaxItemSize for Redis. [#7311](https://github.com/grafana/tempo/pull/7311) (@electron0zero)
-* [ENHANCEMENT] tempo-mixin: update backendwork dashboard with a Redaction section (active jobs, created/completed/failed/dropped by tenant, job duration), add Dropped and Job Duration panels to the Jobs row, and fix the Retry metric name (`jobs_retry` -> `jobs_retry_total`). [#7184](https://github.com/grafana/tempo/pull/7184) (@zalegrala)
-* [ENHANCEMENT] querier: limit external endpoint response size to querier grpc MaxSendMsgSize. [#7240](https://github.com/grafana/tempo/pull/7240) (@electron0zero)
-* [ENHANCEMENT] backend-scheduler: eliminate O(256·M) shard scan in `HasJobsForTenant` and O(N) prefix scan in `BusyBlocksForTenant` via secondary indexes; `HasJobsForTenant` is now O(1), `BusyBlocksForTenant` is now O(|tenant blocks|). Add `splitPendingBlockKey` helper to centralise pending-block key parsing and decouple all index maintenance sites from the encoded key format. [#7141](https://github.com/grafana/tempo/pull/7141) (@zalegrala)
-* [ENHANCEMENT] tempodb: add `tempodb_cache_store_size_bytes` histogram labelled by `role` recording the size of every item written to the backend cache. [#7152](https://github.com/grafana/tempo/pull/7152) (@javiermolinar)
-* [ENHANCEMENT] Add `TempoDistributorKafkaProduceFailing` alert that triggers when Kafka records cannot be produced by the distributor. [#7148](https://github.com/grafana/tempo/pull/7148) (@javiermolinar)
-* [ENHANCEMENT] **BREAKING CHANGE** Query-frontend: new job sharding approach for trace lookups, using a new config option `blocks_per_shard` which replaces `query_shards`. [#7105](https://github.com/grafana/tempo/pull/7105) (@mdisibio)
-* [ENHANCEMENT] jsonnet: add `autoscaling_prometheus_url` and `autoscaling_prometheus_tenant` top-level config fields for KEDA autoscaling. Setting `autoscaling_prometheus_tenant` sends an `X-Scope-OrgID` header on all Prometheus trigger requests, which is required when the backend is a multi-tenant system such as Grafana Mimir. [#7099](https://github.com/grafana/tempo/pull/7099) (@zachfi)
-* [ENHANCEMENT] live-store: expose query inspected bytes as a metric. [#7162](https://github.com/grafana/tempo/pull/7162) [#7163](https://github.com/grafana/tempo/pull/7163) (@zhxiaogg)
-* [ENHANCEMENT] tempodb: evict bloom filter and trace-id-index cache entries for blocks deleted during retention, freeing cache space for active blocks sooner. [#7204](https://github.com/grafana/tempo/pull/7204) (@zalegrala)
-* [ENHANCEMENT] cache: add `Remove` method to the `Cache` interface, implemented for memcached and redis. [#7204](https://github.com/grafana/tempo/pull/7204) (@zalegrala)
-* [ENHANCEMENT] TraceQL metrics: enable new span-only fetch by default. Can be disabled per-tenant via `metrics_spanonly_fetch: false` or per-query via the unsafe hint `with(spanonly_fetch=false)`. [#7179](https://github.com/grafana/tempo/pull/7179) (@mdisibio)
-* [ENHANCEMENT] jsonnet: bump `memcached` to `1.6.42-alpine` and `prom/memcached-exporter` to `v0.16.0` to clear accumulated CVEs. [#7244](https://github.com/grafana/tempo/pull/7244) (@zhxiaogg)
-* [BUGFIX] backend-scheduler: fix redaction batch not cleaned up after dead-job timeout, leaving tenant permanently blocked from new redaction submissions and compaction. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
-* [BUGFIX] backend-scheduler: fix outstanding-blocks metric suppressed to zero during active redaction batch, causing autoscaler to scale down workers mid-redaction. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
-* [BUGFIX] backend-scheduler: fix O(N) lock contention in GetJobForWorker under concurrent worker load; replace shard scan with O(1) index lookup. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
-* [BUGFIX] livestore: write the per-block query-range response cache atomically (temp file + rename) and log+ignore cache read errors. [#7155](https://github.com/grafana/tempo/pull/7155) (@zhxiaogg)
-* [BUGFIX] Better validation for query_range endpoint: do not accept negative step [#7221](https://github.com/grafana/tempo/pull/7221) (@ruslan-mikhailov)
-* [BUGFIX] Return partial trace hint for the llm encoding [#7332](https://github.com/grafana/tempo/pull/7332) (@javiermolinar)
-* [BUGFIX] user-configurable overrides: emit duration fields as flat YAML scalars on `/status/overrides/{tenant}` and omit `generate_native_histograms` when unset. [#7138](https://github.com/grafana/tempo/pull/7138) (@electron0zero)
-* [BUGFIX] Fix unsafe quoting in query attributes [#7220](https://github.com/grafana/tempo/pull/7220) (@ruslan-mikhailov)
-* [BUGFIX] Fix rare cache collision between instant and range metrics queries [#7290](https://github.com/grafana/tempo/pull/7290) (@ruslan-mikhailov)
-* [BUGFIX] backend-scheduler: fix cross-tenant escalation in SubmitRedaction -- tenant is now sourced exclusively from the authenticated request context (X-Scope-OrgID header) and the body tenant_id field is ignored. [#7153](https://github.com/grafana/tempo/pull/7153) (@zalegrala)
+<!-- next version -->
 
 # v3.0.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -386,7 +386,7 @@ Before marking a PR ready for review, confirm:
 
 - [ ] Tests updated or added for the changed behavior
 - [ ] Documentation added or updated (refer to the [Documentation](#documentation) section)
-- [ ] `CHANGELOG.md` updated (refer to the [Changelog entries](#changelog-entries) section)
+- [ ] Changelog entry added under `.chloggen/` (refer to the [Changelog entries](#changelog-entries) section)
 
 ### Commit messages
 
@@ -415,23 +415,37 @@ chore(deps): update module google.golang.org/api to v0.267.0
 
 ### Changelog entries
 
-All PRs that change behavior (features, enhancements, bug fixes, breaking changes) must include a `CHANGELOG.md` entry. Dependency-only updates and pure internal refactors do not require one.
+All PRs that change behavior (features, enhancements, bug fixes, breaking changes) must include a changelog entry. Dependency-only updates and pure internal refactors do not require one (label such PRs `Skip Changelog` or `dependencies`, or prefix the title with `chore:`).
 
-Add your entry under `## main / unreleased` in this format:
+Tempo manages `CHANGELOG.md` with [chloggen](./tools/chloggen): instead of editing `CHANGELOG.md`, add a YAML file under `.chloggen/`. This avoids merge conflicts on the shared changelog.
 
-```
-* [TYPE] Short description of the change [#<PR>](https://github.com/grafana/tempo/pull/<PR>) (@your-github-handle)
-```
+Create an entry:
 
-Valid types in order of precedence: `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
-
-Mark breaking changes explicitly:
-
-```
-* [CHANGE] **BREAKING CHANGE** Description of what changed and what users must do [#<PR>](https://github.com/grafana/tempo/pull/<PR>) (@your-github-handle)
+```bash
+make chlog-new
 ```
 
-Keep entries ordered as `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]` within each release section.
+Edit the generated `.chloggen/<branch>.yaml`:
+
+```yaml
+change_type: enhancement       # breaking | change | feature | enhancement | bug_fix | security
+component: metrics-generator   # must be in the components allowlist in .chloggen/config.yaml
+note: Short description of the change.
+issues: [<PR or issue number>]
+subtext:                       # optional extra detail
+user: <your-github-handle>     # rendered as "(@your-github-handle)"
+```
+
+`change_type` keywords render under these sections: `breaking` → Breaking changes, `change` → Changes, `feature` → Features, `enhancement` → Enhancements, `bug_fix` → Bug fixes, `security` → Security.
+
+Validate and preview before pushing:
+
+```bash
+make chlog-validate
+make chlog-preview
+```
+
+See `.chloggen/README.md` for details.
 
 ### Keeping your PR up to date
 

--- a/RELEASES.MD
+++ b/RELEASES.MD
@@ -1,7 +1,9 @@
 # Release Candidates
 
-- Create a branch named `changelog-<version>-<rc.#>`. Clean up the changelog, add the version heading
-  and merge to main. 
+- Create a branch named `changelog-<version>-<rc.#>`. Generate the changelog section from the
+  `.chloggen/` entries by running `make chlog-update VERSION=v<version>-<rc.#>` (this collates the
+  entries into `CHANGELOG.md` under the version heading and deletes the consumed files). Review the
+  result, then merge to main.
 - Push a semver tag to main on the merge commit above.  Something like:
   - `git tag -a v1.2.0-rc.0`
   - `git push origin v1.2.0-rc.0`
@@ -27,10 +29,10 @@ This document details release procedures for Tempo.
     - `git tag -a v1.2.0`
     - `git push origin v1.2.0`
   - Make sure that the "This is a pre-release" is unchecked when publishing the release.
-- Submit a PR cleaning up the changelog and moving everything under "main/unreleased" to be under
-  the newly minted version.
-  - Given that the changelog was already cleaned up for the RC above. This will likely be simply
-    renaming the release candidate to the full version.
+- Submit a PR updating the changelog for the full version. Because the RC above already ran
+  `make chlog-update` (consuming the `.chloggen/` entries), this is usually just renaming the
+  `# v<version>-<rc.#>` heading in `CHANGELOG.md` to the final `# v<version>`. If new entries landed
+  since the RC, run `make chlog-update VERSION=v<version>` instead to collate them.
 - Update the tempo image tag in example configs and operations files, then regenerate compiled jsonnet.
   Run `make bump-tempo-image-tag TEMPO_IMAGE_TAG=X.Y.Z && make jsonnet` and open a PR to the release
   branch. This is intentionally done before tagging so that users referencing the examples or docs
@@ -57,8 +59,9 @@ You need to cherry-pick each commit and open a PR to be merged into the release 
   `git cherry-pick <commit hash>`
 
 ## 3. Update the changelog
-- Verify all backported fixes have entries in the CHANGELOG. Cross-reference the commits on the release branch since the last tag (`git log --oneline $(git describe --tags --abbrev=0)..release-vX.Y`) against the CHANGELOG entries.
-- Add any missing entries and update the heading from `main / unreleased` to the new patch version (e.g. `v2.10.1`).
+- Verify all backported fixes have a `.chloggen/` entry on the release branch. Cross-reference the commits since the last tag (`git log --oneline $(git describe --tags --abbrev=0)..release-vX.Y`) against the entries in `.chloggen/`.
+- Add any missing entries with `make chlog-new`.
+- Generate the release section: `make chlog-update VERSION=vX.Y.Z` (e.g. `v2.10.1`). This collates all `.chloggen/*.yaml` files into `CHANGELOG.md` under the new version heading and deletes the consumed entry files.
 - Open a PR with the changelog update to the release branch.
 
 ## 4. Update the tempo image tag
@@ -91,4 +94,4 @@ Check that all workflows triggered by the tag succeeded:
 In [GitHub Releases](https://github.com/grafana/tempo/releases) there should be a "Draft" release. Add the changelog entries to the release notes. Make sure "Set as the latest release" is checked and hit "Publish release".
 
 ## 8. Submit a changelog PR to main
-Submit a PR to `main` moving the relevant entries from "main/unreleased" to be under the newly minted version.
+Submit a PR to `main` adding the new version's section to `CHANGELOG.md` so the released notes are reflected on `main`. Either cherry-pick the changelog commit from the release branch (step 3), or run `make chlog-update VERSION=vX.Y.Z` against the corresponding `.chloggen/` entries on `main`.


### PR DESCRIPTION
## What this PR does

Adopts the in-tree [chloggen](./tools/chloggen) tool (added in #7346 / #7351) to manage `CHANGELOG.md`. Instead of editing the shared changelog directly, each PR adds a small YAML file under `.chloggen/`; the entries are collated into `CHANGELOG.md` at release time. This eliminates merge conflicts on the changelog and gives entries a validated, structured format.

## Why

Every PR currently edits the same `## main / unreleased` section, causing frequent rebase/merge conflicts and offering no validation. Per-PR entry files remove that contention and let CI enforce that changes are documented.

## Contributor workflow

```bash
make chlog-new        # create .chloggen/<branch>.yaml from the template
make chlog-validate   # validate entries (also runs in CI)
make chlog-preview    # render the pending entries to stdout
```

```yaml
change_type: enhancement       # breaking | change | feature | enhancement | bug_fix | security
component: metrics-generator   # must be in the components allowlist in .chloggen/config.yaml
note: A brief description of the change.
issues: [1234]
subtext:                       # optional
user: your-github-handle       # rendered as "(@your-github-handle)"
```

At release, `make chlog-update VERSION=vX.Y.Z` collates entries into `CHANGELOG.md` and deletes them. `RELEASES.MD` is updated accordingly.

## Change types

Configured in `.chloggen/config.yaml`, derived from Tempo's historical changelog categories — `breaking`, `change`, `feature`, `enhancement`, `bug_fix`, `security` — each with its own emoji section heading. The in-tree tool now supports configurable change types and a required `user` (author) field, so entries keep the `(@handle)` attribution.

## Changes

- `.chloggen/` — `config.yaml` (change types, component allowlist, custom render template), `TEMPLATE.yaml`, `summary.tmpl`, `README.md`.
- `.github/workflows/changelog.yml` — require a `.chloggen/*.yaml` on PRs to `main`, validate it, forbid direct `CHANGELOG.md` edits. Skippable via the `Skip Changelog` label or a `chore:` / `chore(scope):` / `[chore]` title. Actions pinned to commit SHAs.
- `CHANGELOG.md` — added the `<!-- next version -->` marker; migrated the existing unreleased entries (with authors) into `.chloggen/`. Released history untouched.
- `CONTRIBUTING.md`, `.github/pull_request_template.md`, `RELEASES.MD` — documentation updated.

The `chlog-*` Make targets and the tool itself already landed in #7346 / #7351, so this PR does not touch the Makefile.

## Preview of the generated `CHANGELOG.md`

`make chlog-preview` renders the following (excerpt — one entry per section, shown verbatim so PR refs are not back-linked):

```markdown
# vTODO

## 🛑 Breaking changes 🛑
- `query-frontend`: new job sharding approach for trace lookups, using a new config option `blocks_per_shard` which replaces `query_shards`. ([#7105](https://github.com/grafana/tempo/pull/7105)) (@mdisibio)

## 🚀 Features 🚀
- `metrics-generator`: add `service-graphs-*` subprocessors and an opt-in `traces_service_graph_connection_info` presence gauge for topology detection under heavy sampling. ([#7202](https://github.com/grafana/tempo/pull/7202)) (@jcreixell)

## 💡 Enhancements 💡
- `backend-scheduler`: eliminate O(256·M) shard scan in `HasJobsForTenant` and O(N) prefix scan in `BusyBlocksForTenant` via secondary indexes; `HasJobsForTenant` is now O(1), `BusyBlocksForTenant` is now O(|tenant blocks|). Add `splitPendingBlockKey` helper to centralise pending-block key parsing and decouple all index maintenance sites from the encoded key format. ([#7141](https://github.com/grafana/tempo/pull/7141)) (@zalegrala)

## 🧰 Bug fixes 🧰
- `backend-scheduler`: fix cross-tenant escalation in SubmitRedaction -- tenant is now sourced exclusively from the authenticated request context (X-Scope-OrgID header) and the body tenant_id field is ignored. ([#7153](https://github.com/grafana/tempo/pull/7153)) (@zalegrala)
```
