### PR TITLE
chore(renovate): drop release-v2.8 from base branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,7 +9,6 @@
   ],
   baseBranchPatterns: [
     'main',
-    'release-v2.8',
     'release-v2.9',
     'release-v2.10',
     '/^release-v3.*/',


### PR DESCRIPTION
**What this PR does**:

Drops `release-v2.8` from Renovate's `baseBranchPatterns` now that v3.0 has shipped, leaving the supported window as `release-v2.9`, `release-v2.10`, and `/^release-v3.*/`. v3.x is already covered by the existing regex, so no addition is needed.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
