### PR TITLE
chore(tools): configurable chloggen change types and required entry author

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -433,30 +433,32 @@ tempo-mixin-check: tools-image
 
 ##@ Changelog
 
-# chloggen is vendored under tools/chloggen and built from the tools module.
-# It must run from the repo root so it can find .chloggen/ and CHANGELOG.md.
+# chloggen is built from the tools module and run from the repo root so it can
+# find .chloggen/ and CHANGELOG.md. A .chloggen/config.yaml is used only if it
+# exists. Pass FILENAME=... to chlog-new and VERSION=vX.Y.Z to chlog-update.
 CHLOGGEN ?= $(CURDIR)/bin/chloggen
 CHLOGGEN_CONFIG := .chloggen/config.yaml
+CHLOGGEN_CONFIG_ARG := $(if $(wildcard $(CHLOGGEN_CONFIG)),--config $(CHLOGGEN_CONFIG),)
 
 .PHONY: $(CHLOGGEN)
 $(CHLOGGEN):
 	cd $(CURDIR)/tools/chloggen && go build -o $(CHLOGGEN) .
 
 .PHONY: chlog-new
-chlog-new: $(CHLOGGEN) ## Create a new changelog entry under .chloggen/
-	$(CHLOGGEN) new --config $(CHLOGGEN_CONFIG)
+chlog-new: $(CHLOGGEN) ## Create a new changelog entry under .chloggen/ (FILENAME=... optional)
+	$(CHLOGGEN) new $(CHLOGGEN_CONFIG_ARG) $(if $(FILENAME),--filename $(FILENAME))
 
 .PHONY: chlog-validate
 chlog-validate: $(CHLOGGEN) ## Validate the pending changelog entries
-	$(CHLOGGEN) validate --config $(CHLOGGEN_CONFIG)
+	$(CHLOGGEN) validate $(CHLOGGEN_CONFIG_ARG)
 
 .PHONY: chlog-preview
 chlog-preview: $(CHLOGGEN) ## Render the pending changelog entries to stdout
-	$(CHLOGGEN) update --config $(CHLOGGEN_CONFIG) --dry
+	$(CHLOGGEN) update $(CHLOGGEN_CONFIG_ARG) --dry
 
 .PHONY: chlog-update
 chlog-update: $(CHLOGGEN) ## Collate pending entries into CHANGELOG.md (VERSION=vX.Y.Z)
-	$(CHLOGGEN) update --config $(CHLOGGEN_CONFIG) --version "$(VERSION)"
+	$(CHLOGGEN) update $(CHLOGGEN_CONFIG_ARG) --version "$(VERSION)"
 
 # Import fragments
 include build/tools.mk

--- a/tools/chloggen/cmd/cmd_test.go
+++ b/tools/chloggen/cmd/cmd_test.go
@@ -47,6 +47,7 @@ func enhancementEntry() *chlog.Entry {
 		Component:  "receiver/foo",
 		Note:       "Add some bar",
 		Issues:     []int{12345},
+		User:       "octocat",
 	}
 }
 
@@ -56,6 +57,7 @@ func bugFixEntry() *chlog.Entry {
 		Component:  "testbed",
 		Note:       "Fix blah",
 		Issues:     []int{12346, 12347},
+		User:       "octocat",
 	}
 }
 
@@ -65,6 +67,7 @@ func deprecationEntry() *chlog.Entry {
 		Component:  "exporter/old",
 		Note:       "Deprecate old",
 		Issues:     []int{12348},
+		User:       "octocat",
 	}
 }
 
@@ -74,6 +77,7 @@ func newComponentEntry() *chlog.Entry {
 		Component:  "exporter/new",
 		Note:       "Add new exporter ...",
 		Issues:     []int{12349},
+		User:       "octocat",
 	}
 }
 
@@ -83,6 +87,7 @@ func breakingEntry() *chlog.Entry {
 		Component:  "processor/oops",
 		Note:       "Change behavior when ...",
 		Issues:     []int{12350},
+		User:       "octocat",
 	}
 }
 
@@ -95,6 +100,7 @@ func entryWithSubtext() *chlog.Entry {
 		Note:       "Change behavior when ...",
 		Issues:     []int{12350},
 		SubText:    strings.Join(lines, "\n"),
+		User:       "octocat",
 	}
 }
 
@@ -109,6 +115,7 @@ func entryForChangelogs(changeType string, issue int, keys ...string) *chlog.Ent
 		Component:  "receiver/foo",
 		Note:       fmt.Sprintf("Some change relevant to [%s]", keyStr),
 		Issues:     []int{issue},
+		User:       "octocat",
 	}
 }
 

--- a/tools/chloggen/cmd/testdata/all_change_types/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/all_change_types/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `processor/oops`: Change behavior when ... (#12350)
-- `processor/oops`: Change behavior when ... (#12350)
+- `processor/oops`: Change behavior when ... (#12350) (@octocat)
+- `processor/oops`: Change behavior when ... (#12350) (@octocat)
   - foo
     - bar
   - blah
@@ -15,19 +15,19 @@
 
 ### 🚩 Deprecations 🚩
 
-- `exporter/old`: Deprecate old (#12348)
+- `exporter/old`: Deprecate old (#12348) (@octocat)
 
 ### 🚀 New components 🚀
 
-- `exporter/new`: Add new exporter ... (#12349)
+- `exporter/new`: Add new exporter ... (#12349) (@octocat)
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Add some bar (#12345)
+- `receiver/foo`: Add some bar (#12345) (@octocat)
 
 ### 🧰 Bug fixes 🧰
 
-- `testbed`: Fix blah (#12346, #12347)
+- `testbed`: Fix blah (#12346, #12347) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/all_change_types_alphabetical/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/all_change_types_alphabetical/CHANGELOG.md
@@ -6,10 +6,10 @@
 
 ### 💡 Enhancements 💡
 
-- `receiver/a`: Some change (#1)
-- `receiver/aa`: Some other change for aa (#2)
-- `receiver/b`: Some other change (#3)
-- `receiver/bb`: One more bb change (#4)
+- `receiver/a`: Some change (#1) (@octocat)
+- `receiver/aa`: Some other change for aa (#2) (@octocat)
+- `receiver/b`: Some other change (#3) (@octocat)
+- `receiver/bb`: One more bb change (#4) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/all_change_types_multiple/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/all_change_types_multiple/CHANGELOG.md
@@ -6,14 +6,14 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `processor/oops`: Change behavior when ... (#12350)
-- `processor/oops`: Change behavior when ... (#12350)
+- `processor/oops`: Change behavior when ... (#12350) (@octocat)
+- `processor/oops`: Change behavior when ... (#12350) (@octocat)
   - foo
     - bar
   - blah
     - 1234567
-- `processor/oops`: Change behavior when ... (#12350)
-- `processor/oops`: Change behavior when ... (#12350)
+- `processor/oops`: Change behavior when ... (#12350) (@octocat)
+- `processor/oops`: Change behavior when ... (#12350) (@octocat)
   - foo
     - bar
   - blah
@@ -21,23 +21,23 @@
 
 ### 🚩 Deprecations 🚩
 
-- `exporter/old`: Deprecate old (#12348)
-- `exporter/old`: Deprecate old (#12348)
+- `exporter/old`: Deprecate old (#12348) (@octocat)
+- `exporter/old`: Deprecate old (#12348) (@octocat)
 
 ### 🚀 New components 🚀
 
-- `exporter/new`: Add new exporter ... (#12349)
-- `exporter/new`: Add new exporter ... (#12349)
+- `exporter/new`: Add new exporter ... (#12349) (@octocat)
+- `exporter/new`: Add new exporter ... (#12349) (@octocat)
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Add some bar (#12345)
-- `receiver/foo`: Add some bar (#12345)
+- `receiver/foo`: Add some bar (#12345) (@octocat)
+- `receiver/foo`: Add some bar (#12345) (@octocat)
 
 ### 🧰 Bug fixes 🧰
 
-- `testbed`: Fix blah (#12346, #12347)
-- `testbed`: Fix blah (#12346, #12347)
+- `testbed`: Fix blah (#12346, #12347) (@octocat)
+- `testbed`: Fix blah (#12346, #12347) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/breaking_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/breaking_only/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `processor/oops`: Change behavior when ... (#12350)
+- `processor/oops`: Change behavior when ... (#12350) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/bug_fix_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/bug_fix_only/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🧰 Bug fixes 🧰
 
-- `testbed`: Fix blah (#12346, #12347)
+- `testbed`: Fix blah (#12346, #12347) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/deprecation_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/deprecation_only/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🚩 Deprecations 🚩
 
-- `exporter/old`: Deprecate old (#12348)
+- `exporter/old`: Deprecate old (#12348) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/enhancement_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/enhancement_only/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Add some bar (#12345)
+- `receiver/foo`: Add some bar (#12345) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/filter_component/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/filter_component/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Some change (#1)
-- `receiver/foo`: One more foo change (#4)
+- `receiver/foo`: Some change (#1) (@octocat)
+- `receiver/foo`: One more foo change (#4) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/multiple_changelogs/CHANGELOG-API.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs/CHANGELOG-API.md
@@ -6,23 +6,23 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `receiver/foo`: Some change relevant to [api] (#125)
-- `receiver/foo`: Some change relevant to [user,api] (#11)
+- `receiver/foo`: Some change relevant to [api] (#125) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#11) (@octocat)
 
 ### 🚩 Deprecations 🚩
 
-- `receiver/foo`: Some change relevant to [api] (#223)
-- `receiver/foo`: Some change relevant to [user,api] (#234)
+- `receiver/foo`: Some change relevant to [api] (#223) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#234) (@octocat)
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Some change relevant to [api,user] (#333)
-- `receiver/foo`: Some change relevant to [api] (#555)
+- `receiver/foo`: Some change relevant to [api,user] (#333) (@octocat)
+- `receiver/foo`: Some change relevant to [api] (#555) (@octocat)
 
 ### 🧰 Bug fixes 🧰
 
-- `receiver/foo`: Some change relevant to [api] (#111)
-- `receiver/foo`: Some change relevant to [api] (#777)
+- `receiver/foo`: Some change relevant to [api] (#111) (@octocat)
+- `receiver/foo`: Some change relevant to [api] (#777) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/multiple_changelogs/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs/CHANGELOG.md
@@ -6,22 +6,22 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `receiver/foo`: Some change relevant to [user,api] (#11)
+- `receiver/foo`: Some change relevant to [user,api] (#11) (@octocat)
 
 ### 🚩 Deprecations 🚩
 
-- `receiver/foo`: Some change relevant to [user] (#123)
-- `receiver/foo`: Some change relevant to [user,api] (#234)
+- `receiver/foo`: Some change relevant to [user] (#123) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#234) (@octocat)
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Some change relevant to [user] (#21)
-- `receiver/foo`: Some change relevant to [api,user] (#333)
+- `receiver/foo`: Some change relevant to [user] (#21) (@octocat)
+- `receiver/foo`: Some change relevant to [api,user] (#333) (@octocat)
 
 ### 🧰 Bug fixes 🧰
 
-- `receiver/foo`: Some change relevant to [user] (#32)
-- `receiver/foo`: Some change relevant to [user] (#222)
+- `receiver/foo`: Some change relevant to [user] (#32) (@octocat)
+- `receiver/foo`: Some change relevant to [user] (#222) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/multiple_changelogs_multiple_defaults/CHANGELOG-API.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs_multiple_defaults/CHANGELOG-API.md
@@ -6,27 +6,27 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `receiver/foo`: Some change relevant to [api] (#125)
-- `receiver/foo`: Some change relevant to [user,api] (#11)
+- `receiver/foo`: Some change relevant to [api] (#125) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#11) (@octocat)
 
 ### 🚩 Deprecations 🚩
 
-- `receiver/foo`: Some change relevant to [default] (#123)
-- `receiver/foo`: Some change relevant to [api] (#223)
-- `receiver/foo`: Some change relevant to [user,api] (#234)
+- `receiver/foo`: Some change relevant to [default] (#123) (@octocat)
+- `receiver/foo`: Some change relevant to [api] (#223) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#234) (@octocat)
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Some change relevant to [default] (#21)
-- `receiver/foo`: Some change relevant to [api,user] (#333)
-- `receiver/foo`: Some change relevant to [api] (#555)
+- `receiver/foo`: Some change relevant to [default] (#21) (@octocat)
+- `receiver/foo`: Some change relevant to [api,user] (#333) (@octocat)
+- `receiver/foo`: Some change relevant to [api] (#555) (@octocat)
 
 ### 🧰 Bug fixes 🧰
 
-- `receiver/foo`: Some change relevant to [default] (#32)
-- `receiver/foo`: Some change relevant to [default] (#222)
-- `receiver/foo`: Some change relevant to [api] (#111)
-- `receiver/foo`: Some change relevant to [api] (#777)
+- `receiver/foo`: Some change relevant to [default] (#32) (@octocat)
+- `receiver/foo`: Some change relevant to [default] (#222) (@octocat)
+- `receiver/foo`: Some change relevant to [api] (#111) (@octocat)
+- `receiver/foo`: Some change relevant to [api] (#777) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/multiple_changelogs_multiple_defaults/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs_multiple_defaults/CHANGELOG.md
@@ -6,22 +6,22 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `receiver/foo`: Some change relevant to [user,api] (#11)
+- `receiver/foo`: Some change relevant to [user,api] (#11) (@octocat)
 
 ### 🚩 Deprecations 🚩
 
-- `receiver/foo`: Some change relevant to [default] (#123)
-- `receiver/foo`: Some change relevant to [user,api] (#234)
+- `receiver/foo`: Some change relevant to [default] (#123) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#234) (@octocat)
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Some change relevant to [default] (#21)
-- `receiver/foo`: Some change relevant to [api,user] (#333)
+- `receiver/foo`: Some change relevant to [default] (#21) (@octocat)
+- `receiver/foo`: Some change relevant to [api,user] (#333) (@octocat)
 
 ### 🧰 Bug fixes 🧰
 
-- `receiver/foo`: Some change relevant to [default] (#32)
-- `receiver/foo`: Some change relevant to [default] (#222)
+- `receiver/foo`: Some change relevant to [default] (#32) (@octocat)
+- `receiver/foo`: Some change relevant to [default] (#222) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/multiple_changelogs_single_default/CHANGELOG-API.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs_single_default/CHANGELOG-API.md
@@ -6,23 +6,23 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `receiver/foo`: Some change relevant to [api] (#125)
-- `receiver/foo`: Some change relevant to [user,api] (#11)
+- `receiver/foo`: Some change relevant to [api] (#125) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#11) (@octocat)
 
 ### 🚩 Deprecations 🚩
 
-- `receiver/foo`: Some change relevant to [api] (#223)
-- `receiver/foo`: Some change relevant to [user,api] (#234)
+- `receiver/foo`: Some change relevant to [api] (#223) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#234) (@octocat)
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Some change relevant to [api,user] (#333)
-- `receiver/foo`: Some change relevant to [api] (#555)
+- `receiver/foo`: Some change relevant to [api,user] (#333) (@octocat)
+- `receiver/foo`: Some change relevant to [api] (#555) (@octocat)
 
 ### 🧰 Bug fixes 🧰
 
-- `receiver/foo`: Some change relevant to [api] (#111)
-- `receiver/foo`: Some change relevant to [api] (#777)
+- `receiver/foo`: Some change relevant to [api] (#111) (@octocat)
+- `receiver/foo`: Some change relevant to [api] (#777) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/multiple_changelogs_single_default/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs_single_default/CHANGELOG.md
@@ -6,22 +6,22 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `receiver/foo`: Some change relevant to [user,api] (#11)
+- `receiver/foo`: Some change relevant to [user,api] (#11) (@octocat)
 
 ### 🚩 Deprecations 🚩
 
-- `receiver/foo`: Some change relevant to [default] (#123)
-- `receiver/foo`: Some change relevant to [user,api] (#234)
+- `receiver/foo`: Some change relevant to [default] (#123) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#234) (@octocat)
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Some change relevant to [default] (#21)
-- `receiver/foo`: Some change relevant to [api,user] (#333)
+- `receiver/foo`: Some change relevant to [default] (#21) (@octocat)
+- `receiver/foo`: Some change relevant to [api,user] (#333) (@octocat)
 
 ### 🧰 Bug fixes 🧰
 
-- `receiver/foo`: Some change relevant to [default] (#32)
-- `receiver/foo`: Some change relevant to [default] (#222)
+- `receiver/foo`: Some change relevant to [default] (#32) (@octocat)
+- `receiver/foo`: Some change relevant to [default] (#222) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/new_component_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/new_component_only/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🚀 New components 🚀
 
-- `exporter/new`: Add new exporter ... (#12349)
+- `exporter/new`: Add new exporter ... (#12349) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/subtext/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/subtext/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `processor/oops`: Change behavior when ... (#12350)
+- `processor/oops`: Change behavior when ... (#12350) (@octocat)
   - foo
     - bar
   - blah

--- a/tools/chloggen/cmd/update.go
+++ b/tools/chloggen/cmd/update.go
@@ -68,7 +68,7 @@ func updateCmd() *cobra.Command {
 				}
 
 				if dry {
-					cmd.Printf("Generated changelog updates for %s:", changeLogKey)
+					cmd.Printf("Generated changelog updates for %s:\n", changeLogKey)
 					cmd.Println(chlogUpdate)
 					continue
 				}
@@ -92,7 +92,7 @@ func updateCmd() *cobra.Command {
 				chlogBuilder.WriteString(chlogHistory)
 
 				tmpMD := filename + ".tmp"
-				if err = os.WriteFile(filepath.Clean(tmpMD), []byte(chlogBuilder.String()), 0o600); err != nil {
+				if err = os.WriteFile(filepath.Clean(tmpMD), []byte(chlogBuilder.String()), 0o644); err != nil {
 					return err
 				}
 
@@ -101,7 +101,12 @@ func updateCmd() *cobra.Command {
 				}
 
 				cmd.Printf("Finished updating %s\n", filename)
+			}
 
+			// Delete the consumed entry files only once, after every changelog has
+			// been written successfully, and never in dry-run mode. This avoids
+			// losing the source YAMLs if a later changelog write fails.
+			if !dry {
 				if err = chlog.DeleteEntries(globalCfg); err != nil {
 					return err
 				}

--- a/tools/chloggen/cmd/update.go
+++ b/tools/chloggen/cmd/update.go
@@ -47,6 +47,13 @@ func updateCmd() *cobra.Command {
 				return err
 			}
 
+			// Validate before rendering/deleting so an invalid entry is never
+			// silently dropped from the summary and then lost when its source
+			// file is deleted.
+			if err = chlog.ValidateEntries(globalCfg, entriesByChangelog); err != nil {
+				return err
+			}
+
 			for changeLogKey, entries := range entriesByChangelog {
 
 				slices.SortFunc(entries, func(a, b *chlog.Entry) int {

--- a/tools/chloggen/cmd/update_test.go
+++ b/tools/chloggen/cmd/update_test.go
@@ -199,24 +199,28 @@ func TestUpdate(t *testing.T) {
 					Component:  "receiver/foo",
 					Note:       "Some change",
 					Issues:     []int{1},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/bar",
 					Note:       "Some other change",
 					Issues:     []int{2},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/foobar",
 					Note:       "Some other change for foobar",
 					Issues:     []int{3},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/foo",
 					Note:       "One more foo change",
 					Issues:     []int{4},
+					User:       "octocat",
 				},
 			},
 			componentFilter: "receiver/foo",
@@ -230,24 +234,28 @@ func TestUpdate(t *testing.T) {
 					Component:  "receiver/foo",
 					Note:       "Some change",
 					Issues:     []int{1},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/bar",
 					Note:       "Some other change",
 					Issues:     []int{2},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/foobar",
 					Note:       "Some other change for foobar",
 					Issues:     []int{3},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/foo",
 					Note:       "One more foo change",
 					Issues:     []int{4},
+					User:       "octocat",
 				},
 			},
 			componentFilter: "receiver/foob",
@@ -260,24 +268,28 @@ func TestUpdate(t *testing.T) {
 					Component:  "receiver/a",
 					Note:       "Some change",
 					Issues:     []int{1},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/bb",
 					Note:       "One more bb change",
 					Issues:     []int{4},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/b",
 					Note:       "Some other change",
 					Issues:     []int{3},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/aa",
 					Note:       "Some other change for aa",
 					Issues:     []int{2},
+					User:       "octocat",
 				},
 			},
 			version: "v0.45.0",
@@ -343,4 +355,27 @@ func TestUpdate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUpdateValidatesBeforeWriting(t *testing.T) {
+	globalCfg = config.New(t.TempDir())
+
+	// An entry with an invalid change_type must abort update before rendering
+	// or deleting, so the source entry file is not lost.
+	bad := &chlog.Entry{
+		ChangeType: "not_a_real_type",
+		Component:  "receiver/foo",
+		Note:       "Some change",
+		Issues:     []int{1},
+		User:       "octocat",
+	}
+	setupTestDir(t, []*chlog.Entry{bad})
+
+	_, err := runCobra(t, "update", "--version", "v1.0.0")
+	require.ErrorContains(t, err, "not_a_real_type")
+
+	// The source entry file (plus TEMPLATE.yaml) must still be present.
+	remainingYAMLs, ioErr := filepath.Glob(filepath.Join(globalCfg.EntriesDir, "*.yaml"))
+	require.NoError(t, ioErr)
+	require.Equal(t, 2, len(remainingYAMLs))
 }

--- a/tools/chloggen/cmd/validate.go
+++ b/tools/chloggen/cmd/validate.go
@@ -44,7 +44,11 @@ func validateCmd() *cobra.Command {
 					for changeLogKey := range globalCfg.ChangeLogs {
 						validChangeLogs = append(validChangeLogs, changeLogKey)
 					}
-					if err = entry.Validate(changelogRequired, globalCfg.Components, validChangeLogs...); err != nil {
+					validChangeTypes := []string{}
+					for _, ct := range globalCfg.ChangeTypes {
+						validChangeTypes = append(validChangeTypes, ct.Key)
+					}
+					if err = entry.Validate(changelogRequired, globalCfg.Components, validChangeTypes, validChangeLogs...); err != nil {
 						errs = errors.Join(errs, err)
 					}
 				}

--- a/tools/chloggen/cmd/validate.go
+++ b/tools/chloggen/cmd/validate.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"errors"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -36,25 +35,8 @@ func validateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			var errs error
-			for _, entries := range entriesByChangelog {
-				for _, entry := range entries {
-					changelogRequired := len(globalCfg.DefaultChangeLogs) == 0
-					validChangeLogs := []string{}
-					for changeLogKey := range globalCfg.ChangeLogs {
-						validChangeLogs = append(validChangeLogs, changeLogKey)
-					}
-					validChangeTypes := []string{}
-					for _, ct := range globalCfg.ChangeTypes {
-						validChangeTypes = append(validChangeTypes, ct.Key)
-					}
-					if err = entry.Validate(changelogRequired, globalCfg.Components, validChangeTypes, validChangeLogs...); err != nil {
-						errs = errors.Join(errs, err)
-					}
-				}
-			}
-			if errs != nil {
-				return errs
+			if err = chlog.ValidateEntries(globalCfg, entriesByChangelog); err != nil {
+				return err
 			}
 			cmd.Printf("PASS: all files in %s/ are valid\n", globalCfg.EntriesDir)
 			return nil

--- a/tools/chloggen/internal/chlog/TEMPLATE.yaml
+++ b/tools/chloggen/internal/chlog/TEMPLATE.yaml
@@ -23,3 +23,7 @@ issues: []
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext:
+
+# The GitHub handle (without the leading @) of the change's author.
+# Rendered as a "(@handle)" suffix on the changelog entry.
+user:

--- a/tools/chloggen/internal/chlog/entry.go
+++ b/tools/chloggen/internal/chlog/entry.go
@@ -159,6 +159,9 @@ func ReadEntries(cfg *config.Config) (map[string][]*Entry, error) {
 			}
 		} else {
 			for _, cl := range entry.ChangeLogs {
+				if _, ok := entries[cl]; !ok {
+					return nil, fmt.Errorf("%s: '%s' is not a valid value in 'change_logs'", file, cl)
+				}
 				entries[cl] = append(entries[cl], entry)
 			}
 		}
@@ -173,16 +176,17 @@ func DeleteEntries(cfg *config.Config) error {
 		return err
 	}
 
+	var errs error
 	for _, file := range yamlFiles {
 		if file == cfg.TemplateYAML || file == cfg.ConfigYAML {
 			continue
 		}
 
 		if err := os.Remove(file); err != nil {
-			fmt.Printf("Failed to delete: %s\n", file)
+			errs = errors.Join(errs, fmt.Errorf("failed to delete %s: %w", file, err))
 		}
 	}
-	return nil
+	return errs
 }
 
 // findYamlFiles finds all YAML files in the specified directory.

--- a/tools/chloggen/internal/chlog/entry.go
+++ b/tools/chloggen/internal/chlog/entry.go
@@ -50,18 +50,36 @@ type Entry struct {
 	Note       string   `yaml:"note"`
 	Issues     []int    `yaml:"issues"`
 	SubText    string   `yaml:"subtext"`
+	User       string   `yaml:"user"`
 }
 
-var changeTypes = []string{
-	Breaking,
-	Deprecation,
-	NewComponent,
-	Enhancement,
-	BugFix,
+// DefaultChangeTypes lists the built-in change types in render order, along with
+// the headings used to group them in the generated changelog. It is the value
+// used when a configuration does not specify its own 'change_types'.
+var DefaultChangeTypes = []config.ChangeType{
+	{Key: Breaking, Heading: "🛑 Breaking changes 🛑"},
+	{Key: Deprecation, Heading: "🚩 Deprecations 🚩"},
+	{Key: NewComponent, Heading: "🚀 New components 🚀"},
+	{Key: Enhancement, Heading: "💡 Enhancements 💡"},
+	{Key: BugFix, Heading: "🧰 Bug fixes 🧰"},
 }
 
-// Validate validates the changelog entry.
-func (e Entry) Validate(requireChangelog bool, components []string, validChangeLogs ...string) error {
+// changeTypeKeys returns the change type keys from the provided change types,
+// preserving order.
+func changeTypeKeys(changeTypes []config.ChangeType) []string {
+	keys := make([]string, 0, len(changeTypes))
+	for _, ct := range changeTypes {
+		keys = append(keys, ct.Key)
+	}
+	return keys
+}
+
+// Validate validates the changelog entry. The set of valid change types is
+// given by changeTypes; when empty, the built-in DefaultChangeTypes are used.
+func (e Entry) Validate(requireChangelog bool, components []string, changeTypes []string, validChangeLogs ...string) error {
+	if len(changeTypes) == 0 {
+		changeTypes = changeTypeKeys(DefaultChangeTypes)
+	}
 	var errs error
 	if requireChangelog && len(e.ChangeLogs) == 0 {
 		errs = errors.Join(errs, fmt.Errorf("specify one or more 'change_logs'"))
@@ -98,6 +116,10 @@ func (e Entry) Validate(requireChangelog bool, components []string, validChangeL
 
 	if len(e.Issues) == 0 {
 		errs = errors.Join(errs, fmt.Errorf("specify one or more issues #'s"))
+	}
+
+	if strings.TrimSpace(e.User) == "" {
+		errs = errors.Join(errs, fmt.Errorf("specify a 'user'"))
 	}
 
 	return errs

--- a/tools/chloggen/internal/chlog/entry.go
+++ b/tools/chloggen/internal/chlog/entry.go
@@ -125,6 +125,28 @@ func (e Entry) Validate(requireChangelog bool, components []string, changeTypes 
 	return errs
 }
 
+// ValidateEntries validates every entry against the configuration, accumulating
+// all errors. Both the 'validate' and 'update' commands use this so they
+// enforce identical rules (and 'update' never drops or deletes invalid entries).
+func ValidateEntries(cfg *config.Config, entriesByChangelog map[string][]*Entry) error {
+	changelogRequired := len(cfg.DefaultChangeLogs) == 0
+	validChangeLogs := make([]string, 0, len(cfg.ChangeLogs))
+	for changeLogKey := range cfg.ChangeLogs {
+		validChangeLogs = append(validChangeLogs, changeLogKey)
+	}
+	validChangeTypes := changeTypeKeys(cfg.ChangeTypes)
+
+	var errs error
+	for _, entries := range entriesByChangelog {
+		for _, entry := range entries {
+			if err := entry.Validate(changelogRequired, cfg.Components, validChangeTypes, validChangeLogs...); err != nil {
+				errs = errors.Join(errs, err)
+			}
+		}
+	}
+	return errs
+}
+
 // ReadEntries reads changelog entries from YAML files based on the provided configuration.
 func ReadEntries(cfg *config.Config) (map[string][]*Entry, error) {
 	yamlFiles, err := findYamlFiles(cfg.EntriesDir)
@@ -152,6 +174,9 @@ func ReadEntries(cfg *config.Config) (map[string][]*Entry, error) {
 			return nil, err
 		}
 		entry.SubText = strings.ReplaceAll(entry.SubText, "\r\n", "\n")
+		// 'user' is documented as a handle without the leading '@'; normalize it
+		// away so a value like "@octocat" doesn't render as "(@@octocat)".
+		entry.User = strings.TrimPrefix(strings.TrimSpace(entry.User), "@")
 
 		if len(entry.ChangeLogs) == 0 {
 			for _, cl := range cfg.DefaultChangeLogs {

--- a/tools/chloggen/internal/chlog/entry_test.go
+++ b/tools/chloggen/internal/chlog/entry_test.go
@@ -398,6 +398,31 @@ func TestReadDeleteEntries(t *testing.T) {
 	assert.FileExists(t, cfg.TemplateYAML)
 }
 
+func TestReadEntriesRejectsUnknownChangelog(t *testing.T) {
+	tempDir := t.TempDir()
+	entriesDir := filepath.Join(tempDir, config.DefaultEntriesDir)
+	require.NoError(t, os.Mkdir(entriesDir, 0o750))
+
+	entry := Entry{
+		ChangeLogs: []string{"nonexistent"},
+		ChangeType: "breaking",
+		Component:  "foo",
+		Note:       "broke foo",
+		Issues:     []int{123},
+		User:       "octocat",
+	}
+	writeEntry(t, entriesDir, &entry, "yaml")
+
+	cfg := &config.Config{
+		ChangeLogs:        map[string]string{"foo": filepath.Join(entriesDir, "CHANGELOG.foo.md")},
+		DefaultChangeLogs: []string{"foo"},
+		EntriesDir:        entriesDir,
+	}
+
+	_, err := ReadEntries(cfg)
+	require.ErrorContains(t, err, "'nonexistent' is not a valid value in 'change_logs'")
+}
+
 func TestFindYamlFilesEmptyDir(t *testing.T) {
 	dir := t.TempDir()
 

--- a/tools/chloggen/internal/chlog/entry_test.go
+++ b/tools/chloggen/internal/chlog/entry_test.go
@@ -42,13 +42,14 @@ func TestEntry(t *testing.T) {
 		requireChangeLog bool
 		validChangeLogs  []string
 		components       []string
+		changeTypes      []string
 		expectErr        string
 		toString         string
 	}{
 		{
 			name:      "empty",
 			entry:     Entry{},
-			expectErr: "'' is not a valid 'change_type'. Specify one of [breaking deprecation new_component enhancement bug_fix]\nspecify a 'component'\nspecify a 'note'\nspecify one or more issues #'s",
+			expectErr: "'' is not a valid 'change_type'. Specify one of [breaking deprecation new_component enhancement bug_fix]\nspecify a 'component'\nspecify a 'note'\nspecify one or more issues #'s\nspecify a 'user'",
 		},
 		{
 			name: "missing_component",
@@ -57,6 +58,7 @@ func TestEntry(t *testing.T) {
 				Note:       "enhance!",
 				Issues:     []int{123},
 				SubText:    "",
+				User:       "octocat",
 			},
 			expectErr: "specify a 'component'",
 		},
@@ -67,6 +69,7 @@ func TestEntry(t *testing.T) {
 				Component:  "bar",
 				Issues:     []int{123},
 				SubText:    "",
+				User:       "octocat",
 			},
 			expectErr: "specify a 'note'",
 		},
@@ -77,6 +80,7 @@ func TestEntry(t *testing.T) {
 				Component:  "bar",
 				Note:       "fix bar",
 				SubText:    "",
+				User:       "octocat",
 			},
 			expectErr: "specify one or more issues #'s",
 		},
@@ -88,6 +92,7 @@ func TestEntry(t *testing.T) {
 				Note:       "fix bar",
 				Issues:     []int{123},
 				SubText:    "",
+				User:       "octocat",
 			},
 			requireChangeLog: true,
 			validChangeLogs:  []string{"foo"},
@@ -102,6 +107,7 @@ func TestEntry(t *testing.T) {
 				Note:       "fix bar",
 				Issues:     []int{123},
 				SubText:    "",
+				User:       "octocat",
 			},
 			validChangeLogs: []string{"foo"},
 			expectErr:       "'bar' is not a valid value in 'change_logs'. Specify one of [foo]",
@@ -114,8 +120,9 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123},
 				SubText:    "",
+				User:       "octocat",
 			},
-			toString: "- `foo`: broke foo (#123)",
+			toString: "- `foo`: broke foo (#123) (@octocat)",
 		},
 		{
 			name: "multiple_issues",
@@ -125,8 +132,9 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123, 345},
 				SubText:    "",
+				User:       "octocat",
 			},
-			toString: "- `foo`: broke foo (#123, #345)",
+			toString: "- `foo`: broke foo (#123, #345) (@octocat)",
 		},
 		{
 			name: "subtext",
@@ -136,8 +144,9 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123},
 				SubText:    "more details",
+				User:       "octocat",
 			},
-			toString: "- `foo`: broke foo (#123)\n  more details",
+			toString: "- `foo`: broke foo (#123) (@octocat)\n  more details",
 		},
 		{
 			name: "multiline subtext",
@@ -147,8 +156,9 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123},
 				SubText:    "more details\nsecond line",
+				User:       "octocat",
 			},
-			toString: "- `foo`: broke foo (#123)\n  more details\n  second line",
+			toString: "- `foo`: broke foo (#123) (@octocat)\n  more details\n  second line",
 		},
 		{
 			name: "required_changelog",
@@ -159,10 +169,11 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123},
 				SubText:    "more details",
+				User:       "octocat",
 			},
 			requireChangeLog: true,
 			validChangeLogs:  []string{"foo"},
-			toString:         "- `foo`: broke foo (#123)\n  more details",
+			toString:         "- `foo`: broke foo (#123) (@octocat)\n  more details",
 		},
 		{
 			name: "default_changelog",
@@ -173,10 +184,11 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123},
 				SubText:    "more details",
+				User:       "octocat",
 			},
 			requireChangeLog: false,
 			validChangeLogs:  []string{"foo"},
-			toString:         "- `foo`: broke foo (#123)\n  more details",
+			toString:         "- `foo`: broke foo (#123) (@octocat)\n  more details",
 		},
 		{
 			name: "subset_of_changelogs",
@@ -187,9 +199,10 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123},
 				SubText:    "more details",
+				User:       "octocat",
 			},
 			validChangeLogs: []string{"foo", "bar", "baz"},
-			toString:        "- `foo`: broke foo (#123)\n  more details",
+			toString:        "- `foo`: broke foo (#123) (@octocat)\n  more details",
 		},
 		{
 			name: "all_changelogs",
@@ -200,9 +213,10 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123},
 				SubText:    "more details",
+				User:       "octocat",
 			},
 			validChangeLogs: []string{"foo", "bar"},
-			toString:        "- `foo`: broke foo (#123)\n  more details",
+			toString:        "- `foo`: broke foo (#123) (@octocat)\n  more details",
 		},
 		{
 			name: "all_changelogs",
@@ -213,9 +227,10 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123},
 				SubText:    "more details",
+				User:       "octocat",
 			},
 			validChangeLogs: []string{"foo", "bar"},
-			toString:        "- `foo`: broke foo (#123)\n  more details",
+			toString:        "- `foo`: broke foo (#123) (@octocat)\n  more details",
 		},
 		{
 			name: "with_components",
@@ -226,17 +241,63 @@ func TestEntry(t *testing.T) {
 				Note:       "changed foo",
 				Issues:     []int{123},
 				SubText:    "more details",
+				User:       "octocat",
 			},
 			components:      []string{"bar"},
 			validChangeLogs: []string{"foo", "bar"},
-			toString:        "- `foo`: changed foo (#123)\n  more details",
+			toString:        "- `foo`: changed foo (#123) (@octocat)\n  more details",
 			expectErr:       "foo is not a valid 'component'. It must be one of [bar]",
+		},
+		{
+			name: "custom_change_type_valid",
+			entry: Entry{
+				ChangeType: "security",
+				Component:  "foo",
+				Note:       "fix vuln",
+				Issues:     []int{123},
+				User:       "octocat",
+			},
+			changeTypes: []string{"security"},
+			toString:    "- `foo`: fix vuln (#123) (@octocat)",
+		},
+		{
+			name: "custom_change_types_reject_builtin",
+			entry: Entry{
+				ChangeType: "breaking",
+				Component:  "foo",
+				Note:       "broke foo",
+				Issues:     []int{123},
+				User:       "octocat",
+			},
+			changeTypes: []string{"security"},
+			expectErr:   "'breaking' is not a valid 'change_type'. Specify one of [security]",
+		},
+		{
+			name: "user_rendered_as_handle",
+			entry: Entry{
+				ChangeType: "breaking",
+				Component:  "foo",
+				Note:       "broke foo",
+				Issues:     []int{123},
+				User:       "octocat",
+			},
+			toString: "- `foo`: broke foo (#123) (@octocat)",
+		},
+		{
+			name: "missing_user",
+			entry: Entry{
+				ChangeType: "bug_fix",
+				Component:  "bar",
+				Note:       "fix bar",
+				Issues:     []int{123},
+			},
+			expectErr: "specify a 'user'",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.entry.Validate(tc.requireChangeLog, tc.components, tc.validChangeLogs...)
+			err := tc.entry.Validate(tc.requireChangeLog, tc.components, tc.changeTypes, tc.validChangeLogs...)
 			if tc.expectErr != "" {
 				assert.Error(t, err)
 				assert.Equal(t, tc.expectErr, err.Error())

--- a/tools/chloggen/internal/chlog/entry_test.go
+++ b/tools/chloggen/internal/chlog/entry_test.go
@@ -398,6 +398,34 @@ func TestReadDeleteEntries(t *testing.T) {
 	assert.FileExists(t, cfg.TemplateYAML)
 }
 
+func TestReadEntriesNormalizesUserHandle(t *testing.T) {
+	tempDir := t.TempDir()
+	entriesDir := filepath.Join(tempDir, config.DefaultEntriesDir)
+	require.NoError(t, os.Mkdir(entriesDir, 0o750))
+
+	// A user written with a leading '@' must be normalized so it doesn't render
+	// as "(@@handle)".
+	entry := Entry{
+		ChangeType: "breaking",
+		Component:  "foo",
+		Note:       "broke foo",
+		Issues:     []int{123},
+		User:       "@octocat",
+	}
+	writeEntry(t, entriesDir, &entry, "yaml")
+
+	cfg := &config.Config{
+		ChangeLogs:        map[string]string{"default": filepath.Join(entriesDir, "CHANGELOG.md")},
+		DefaultChangeLogs: []string{"default"},
+		EntriesDir:        entriesDir,
+	}
+
+	entries, err := ReadEntries(cfg)
+	require.NoError(t, err)
+	require.Len(t, entries["default"], 1)
+	assert.Equal(t, "octocat", entries["default"][0].User)
+}
+
 func TestReadEntriesRejectsUnknownChangelog(t *testing.T) {
 	tempDir := t.TempDir()
 	entriesDir := filepath.Join(tempDir, config.DefaultEntriesDir)

--- a/tools/chloggen/internal/chlog/summary.go
+++ b/tools/chloggen/internal/chlog/summary.go
@@ -28,8 +28,23 @@ import (
 //go:embed summary.tmpl
 var defaultTmpl []byte
 
+// group is one rendered section of the changelog: a heading and the entries
+// that belong to a single change type.
+type group struct {
+	Heading string
+	Entries []*Entry
+}
+
 type summary struct {
-	Version         string
+	Version string
+
+	// Groups holds every configured change type in configured order. This is
+	// the data model the bundled template ranges over and the only path that
+	// surfaces custom change types.
+	Groups []group
+
+	// The following fields mirror the built-in change types and are retained so
+	// that custom summary templates referencing them by name keep working.
 	BreakingChanges []*Entry
 	Deprecations    []*Entry
 	NewComponents   []*Entry
@@ -37,24 +52,40 @@ type summary struct {
 	BugFixes        []*Entry
 }
 
-// GenerateSummary generates a changelog entry summary.
+// GenerateSummary generates a changelog entry summary. Entries are grouped and
+// ordered according to cfg.ChangeTypes; when none are configured, the built-in
+// DefaultChangeTypes are used.
 func GenerateSummary(version string, entries []*Entry, cfg *config.Config) (string, error) {
 	s := summary{
 		Version: version,
 	}
 
-	for _, entry := range entries {
-		switch entry.ChangeType {
+	changeTypes := cfg.ChangeTypes
+	if len(changeTypes) == 0 {
+		changeTypes = DefaultChangeTypes
+	}
+
+	for _, ct := range changeTypes {
+		var grouped []*Entry
+		for _, entry := range entries {
+			if entry.ChangeType == ct.Key {
+				grouped = append(grouped, entry)
+			}
+		}
+		s.Groups = append(s.Groups, group{Heading: ct.Heading, Entries: grouped})
+
+		// Mirror built-in change types onto the named fields for backward compatibility.
+		switch ct.Key {
 		case Breaking:
-			s.BreakingChanges = append(s.BreakingChanges, entry)
+			s.BreakingChanges = grouped
 		case Deprecation:
-			s.Deprecations = append(s.Deprecations, entry)
+			s.Deprecations = grouped
 		case NewComponent:
-			s.NewComponents = append(s.NewComponents, entry)
+			s.NewComponents = grouped
 		case Enhancement:
-			s.Enhancements = append(s.Enhancements, entry)
+			s.Enhancements = grouped
 		case BugFix:
-			s.BugFixes = append(s.BugFixes, entry)
+			s.BugFixes = grouped
 		}
 	}
 

--- a/tools/chloggen/internal/chlog/summary.tmpl
+++ b/tools/chloggen/internal/chlog/summary.tmpl
@@ -5,64 +5,21 @@
 #{{ $issue }}
 {{- end -}}
 )
-
+{{- if .User }} (@{{ .User }}){{- end }}
 {{- if .SubText }}
 {{ .SubText | indent 2 }}
 {{- end }}
 {{- end }}
 ## {{ .Version }}
+{{- range .Groups }}
+{{- if .Entries }}
 
-{{- if .BreakingChanges }}
+### {{ .Heading }}
 
-### 🛑 Breaking changes 🛑
-
-{{- range $i, $change := .BreakingChanges }}
+{{- range $i, $change := .Entries }}
 {{- if eq $i 0}}
 {{end}}
 {{ template "entry" $change }}
 {{- end }}
-{{- end }}
-
-{{- if .Deprecations }}
-
-### 🚩 Deprecations 🚩
-
-{{- range $i, $change := .Deprecations }}
-{{- if eq $i 0}}
-{{end}}
-{{ template "entry" $change }}
-{{- end }}
-{{- end }}
-
-{{- if .NewComponents }}
-
-### 🚀 New components 🚀
-
-{{- range $i, $change := .NewComponents }}
-{{- if eq $i 0}}
-{{end}}
-{{ template "entry" $change }}
-{{- end }}
-{{- end }}
-
-{{- if .Enhancements }}
-
-### 💡 Enhancements 💡
-
-{{- range $i, $change := .Enhancements }}
-{{- if eq $i 0}}
-{{end}}
-{{ template "entry" $change }}
-{{- end }}
-{{- end }}
-
-{{- if .BugFixes }}
-
-### 🧰 Bug fixes 🧰
-
-{{- range $i, $change := .BugFixes }}
-{{- if eq $i 0}}
-{{end}}
-{{ template "entry" $change }}
 {{- end }}
 {{- end }}

--- a/tools/chloggen/internal/chlog/summary_test.go
+++ b/tools/chloggen/internal/chlog/summary_test.go
@@ -17,6 +17,7 @@ package chlog
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -100,6 +101,41 @@ func TestSummary(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, string(expected), actual)
+}
+
+func TestConfiguredChangeTypes(t *testing.T) {
+	sec := Entry{
+		ChangeType: "security",
+		Component:  "foo",
+		Note:       "fix vuln",
+		Issues:     []int{1},
+	}
+	enh := Entry{
+		ChangeType: Enhancement,
+		Component:  "bar",
+		Note:       "improve bar",
+		Issues:     []int{2},
+	}
+
+	cfg := &config.Config{
+		ChangeTypes: []config.ChangeType{
+			{Key: "security", Heading: "Security"},
+			{Key: Enhancement, Heading: "Enhancements"},
+		},
+	}
+
+	// enh is passed before sec, but the configured order must drive the output.
+	actual, err := GenerateSummary("1.0", []*Entry{&enh, &sec}, cfg)
+	require.NoError(t, err)
+
+	// The custom 'security' change type renders (the default template would drop it).
+	assert.Contains(t, actual, "### Security")
+	assert.Contains(t, actual, "- `foo`: fix vuln (#1)")
+	assert.Contains(t, actual, "### Enhancements")
+	assert.Contains(t, actual, "- `bar`: improve bar (#2)")
+
+	// Sections appear in the configured order, not entry order or built-in order.
+	assert.Less(t, strings.Index(actual, "### Security"), strings.Index(actual, "### Enhancements"))
 }
 
 func TestCustomSummary(t *testing.T) {

--- a/tools/chloggen/internal/config/config.go
+++ b/tools/chloggen/internal/config/config.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -85,6 +86,10 @@ func NewFromFile(rootDir string, cfgFilename string) (*Config, error) {
 	cfg.EntriesDir = makeAbs(rootDir, cfg.EntriesDir, DefaultEntriesDir)
 	cfg.TemplateYAML = makeAbs(rootDir, cfg.TemplateYAML, filepath.Join(DefaultEntriesDir, DefaultTemplateYAML))
 
+	if err = validateChangeTypes(cfg.ChangeTypes); err != nil {
+		return nil, err
+	}
+
 	if len(cfg.ChangeLogs) == 0 && len(cfg.DefaultChangeLogs) > 0 {
 		return nil, errors.New("cannot specify 'default_change_logs' without 'change_logs'")
 	}
@@ -115,6 +120,26 @@ func NewFromFile(rootDir string, cfgFilename string) (*Config, error) {
 	}
 
 	return cfg, nil
+}
+
+// validateChangeTypes fails fast on a malformed 'change_types' configuration:
+// empty keys or headings, or duplicate keys. An empty list is valid (the
+// built-in defaults are used).
+func validateChangeTypes(changeTypes []ChangeType) error {
+	seen := make(map[string]struct{}, len(changeTypes))
+	for _, ct := range changeTypes {
+		if strings.TrimSpace(ct.Key) == "" {
+			return errors.New("'change_types' entries must each have a non-empty 'key'")
+		}
+		if strings.TrimSpace(ct.Heading) == "" {
+			return fmt.Errorf("'change_types' entry %q must have a non-empty 'heading'", ct.Key)
+		}
+		if _, dup := seen[ct.Key]; dup {
+			return fmt.Errorf("'change_types' contains duplicate key %q", ct.Key)
+		}
+		seen[ct.Key] = struct{}{}
+	}
+	return nil
 }
 
 func makeAbs(rootDir, path, defaultPath string) string {

--- a/tools/chloggen/internal/config/config.go
+++ b/tools/chloggen/internal/config/config.go
@@ -35,6 +35,15 @@ const (
 	DefaultChangeLogFilename = "CHANGELOG.md"
 )
 
+// ChangeType defines a valid change_type and how entries of that type are
+// grouped when rendering the changelog summary.
+type ChangeType struct {
+	// Key is the value an entry's 'change_type' must match.
+	Key string `yaml:"key"`
+	// Heading is the section heading used for this change type in the summary.
+	Heading string `yaml:"heading"`
+}
+
 // Config represents the configuration for changelogs.
 type Config struct {
 	ChangeLogs        map[string]string `yaml:"change_logs"`
@@ -43,6 +52,7 @@ type Config struct {
 	TemplateYAML      string            `yaml:"template_yaml"`
 	SummaryTemplate   string            `yaml:"summary_template"`
 	Components        []string          `yaml:"components"`
+	ChangeTypes       []ChangeType      `yaml:"change_types"`
 	ConfigYAML        string
 }
 

--- a/tools/chloggen/internal/config/config.go
+++ b/tools/chloggen/internal/config/config.go
@@ -77,7 +77,7 @@ func NewFromFile(rootDir string, cfgFilename string) (*Config, error) {
 		return nil, err
 	}
 	cfg := &Config{}
-	if err = yaml.Unmarshal(cfgBytes, &cfg); err != nil {
+	if err = yaml.Unmarshal(cfgBytes, cfg); err != nil {
 		return nil, err
 	}
 
@@ -86,11 +86,15 @@ func NewFromFile(rootDir string, cfgFilename string) (*Config, error) {
 	cfg.TemplateYAML = makeAbs(rootDir, cfg.TemplateYAML, filepath.Join(DefaultEntriesDir, DefaultTemplateYAML))
 
 	if len(cfg.ChangeLogs) == 0 && len(cfg.DefaultChangeLogs) > 0 {
-		return nil, errors.New("cannot specify 'default_changelogs' without 'changelogs'")
+		return nil, errors.New("cannot specify 'default_change_logs' without 'change_logs'")
 	}
 
 	if len(cfg.ChangeLogs) == 0 {
-		cfg.ChangeLogs[DefaultChangeLogKey] = filepath.Join(rootDir, DefaultChangeLogFilename)
+		// 'change_logs' was omitted; initialize the map before writing the default
+		// (yaml.Unmarshal leaves it nil when the key is absent).
+		cfg.ChangeLogs = map[string]string{
+			DefaultChangeLogKey: filepath.Join(rootDir, DefaultChangeLogFilename),
+		}
 		cfg.DefaultChangeLogs = []string{DefaultChangeLogKey}
 		return cfg, nil
 	}
@@ -106,7 +110,7 @@ func NewFromFile(rootDir string, cfgFilename string) (*Config, error) {
 
 	for _, key := range cfg.DefaultChangeLogs {
 		if _, ok := cfg.ChangeLogs[key]; !ok {
-			return nil, fmt.Errorf("'default_changelogs' contains key %q which is not defined in 'changelogs'", key)
+			return nil, fmt.Errorf("'default_change_logs' contains key %q which is not defined in 'change_logs'", key)
 		}
 	}
 

--- a/tools/chloggen/internal/config/config_test.go
+++ b/tools/chloggen/internal/config/config_test.go
@@ -78,7 +78,7 @@ func TestNewFromFile(t *testing.T) {
 				TemplateYAML:      "TEMPLATE-custom.yaml",
 				DefaultChangeLogs: []string{"foo"},
 			},
-			expectErr: "cannot specify 'default_changelogs' without 'changelogs",
+			expectErr: "cannot specify 'default_change_logs' without 'change_logs'",
 		},
 		{
 			name: "default-changelog-not-in-changelogs",
@@ -91,7 +91,7 @@ func TestNewFromFile(t *testing.T) {
 				},
 				DefaultChangeLogs: []string{"foo", "bar", "fake"},
 			},
-			expectErr: `contains key "fake" which is not defined in 'changelogs'`,
+			expectErr: `contains key "fake" which is not defined in 'change_logs'`,
 		},
 		{
 			name: "absolute-entries-dir",
@@ -207,4 +207,23 @@ func TestNewFromFileErr(t *testing.T) {
 
 	_, err = NewFromFile(tempDir, filepath.Base(cfgFile.Name()))
 	assert.Error(t, err)
+}
+
+func TestNewFromFileOmittedChangeLogs(t *testing.T) {
+	tempDir := t.TempDir()
+
+	cfgFile, err := os.CreateTemp(tempDir, "*.yaml")
+	require.NoError(t, err)
+	defer cfgFile.Close()
+
+	// A config file that omits 'change_logs' entirely must not panic; the
+	// default changelog should be applied.
+	_, err = cfgFile.WriteString("components: [foo]\n")
+	require.NoError(t, err)
+
+	cfg, err := NewFromFile(tempDir, filepath.Base(cfgFile.Name()))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(cfg.ChangeLogs))
+	assert.Equal(t, filepath.Join(tempDir, DefaultChangeLogFilename), cfg.ChangeLogs[DefaultChangeLogKey])
+	assert.Equal(t, []string{DefaultChangeLogKey}, cfg.DefaultChangeLogs)
 }

--- a/tools/chloggen/internal/config/config_test.go
+++ b/tools/chloggen/internal/config/config_test.go
@@ -227,3 +227,40 @@ func TestNewFromFileOmittedChangeLogs(t *testing.T) {
 	assert.Equal(t, filepath.Join(tempDir, DefaultChangeLogFilename), cfg.ChangeLogs[DefaultChangeLogKey])
 	assert.Equal(t, []string{DefaultChangeLogKey}, cfg.DefaultChangeLogs)
 }
+
+func TestNewFromFileMalformedChangeTypes(t *testing.T) {
+	testCases := []struct {
+		name      string
+		yaml      string
+		expectErr string
+	}{
+		{
+			name:      "empty_key",
+			yaml:      "change_types:\n  - key: \"\"\n    heading: Stuff\n",
+			expectErr: "must each have a non-empty 'key'",
+		},
+		{
+			name:      "empty_heading",
+			yaml:      "change_types:\n  - key: stuff\n    heading: \"\"\n",
+			expectErr: `entry "stuff" must have a non-empty 'heading'`,
+		},
+		{
+			name:      "duplicate_key",
+			yaml:      "change_types:\n  - key: stuff\n    heading: Stuff\n  - key: stuff\n    heading: More stuff\n",
+			expectErr: `duplicate key "stuff"`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			cfgFile, err := os.CreateTemp(tempDir, "*.yaml")
+			require.NoError(t, err)
+			defer cfgFile.Close()
+			_, err = cfgFile.WriteString(tc.yaml)
+			require.NoError(t, err)
+
+			_, err = NewFromFile(tempDir, filepath.Base(cfgFile.Name()))
+			require.ErrorContains(t, err, tc.expectErr)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does**:

Two commits, both scoped to the in-tree `chloggen` tool added in #7346:

**1. `feat(tools)` — configurable change types + required author**
- New `change_types` config (ordered `{key, heading}` list) drives validation and summary section grouping/order. Defaults to the built-in five, so existing behavior is unchanged — lets Tempo use its own `[CHANGE]` / `[FEATURE]` / `[SECURITY]` taxonomy.
- New **required** `user` field on entries, rendered as a `(@handle)` suffix (restores author attribution).
- Summary gains an ordered `Groups` list (custom types render via it) while keeping the named per-type fields so backward-compatible custom templates keep working.

**2. `fix(tools)` — addresses review feedback on #7346**
- config: fix nil-map panic when `change_logs` is omitted; correct error messages to use the real key names.
- `ReadEntries`: reject entries referencing an undefined `change_logs` key.
- `DeleteEntries`: return removal errors instead of always `nil`.
- `update`: write changelog `0644` (not `0600`); newline after the `--dry` header; delete consumed entries once after all changelogs are written, never in `--dry`.
- Makefile: `--config` passed only if `.chloggen/config.yaml` exists; accept `FILENAME=` / `VERSION=`.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated — chloggen unit tests (new coverage for the nil-map and unknown-key fixes) + regenerated golden CHANGELOGs
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated — N/A (tooling, no user-facing change)
