### PR TITLE
[backendscheduler] redaction: honor batch barrier in retention; surface missing redaction blocks

### DIFF
--- a/.chloggen/redaction-block-missing-metric.yaml
+++ b/.chloggen/redaction-block-missing-metric.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: backend-worker
+note: add `tempo_backend_worker_redaction_block_missing_total` and a warning log when a redaction job's target block is absent from the live blocklist, so a coverage gap is observable rather than a silent no-op.
+issues: [7358]
+subtext:
+user: zalegrala

--- a/.chloggen/redaction-retention-barrier.yaml
+++ b/.chloggen/redaction-retention-barrier.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: backend-scheduler
+note: retention now gates on the redaction batch barrier (`TenantPending`) instead of only in-flight redaction jobs, so retention cannot mark a block compacted while a redaction batch is awaiting its rescan.
+issues: [7358]
+subtext:
+user: zalegrala

--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -293,9 +293,12 @@ func (s *BackendScheduler) Next(ctx context.Context, req *tempopb.NextJobRequest
 				switch j.GetType() {
 				case tempopb.JobType_JOB_TYPE_RETENTION:
 					// A redaction may have been submitted after this job was emitted.
-					// Drop and retry to avoid running retention over a mid-redaction tenant.
-					if s.work.HasJobsForTenant(j.Tenant(), tempopb.JobType_JOB_TYPE_REDACTION) {
-						level.Debug(log.Logger).Log("msg", "dropping stale retention job: tenant has pending redaction",
+					// Drop and retry to avoid running retention over a mid-redaction
+					// tenant. Gate on the batch barrier (TenantPending), not just
+					// in-flight redaction jobs, so a batch in its rescan-wait window
+					// (no jobs in flight) still blocks retention.
+					if s.work.TenantPending(j.Tenant()) {
+						level.Debug(log.Logger).Log("msg", "dropping stale retention job: tenant has active redaction batch",
 							"job_id", j.ID, "tenant", j.Tenant())
 						metricJobsDropped.WithLabelValues(j.Tenant(), j.GetType().String()).Inc()
 						drop = true

--- a/modules/backendscheduler/provider/retention.go
+++ b/modules/backendscheduler/provider/retention.go
@@ -88,8 +88,13 @@ func (p *RetentionProvider) emitRetentionJobs(ctx context.Context, jobs chan<- *
 		if p.sched.HasJobsForTenant(tenantID, tempopb.JobType_JOB_TYPE_RETENTION) {
 			continue
 		}
-		if p.sched.HasJobsForTenant(tenantID, tempopb.JobType_JOB_TYPE_REDACTION) {
-			level.Debug(p.logger).Log("msg", "skipping retention for tenant with pending redaction", "tenant", tenantID)
+		// Gate on the redaction batch barrier, not just in-flight redaction jobs.
+		// A batch in its rescan-wait window has no jobs in flight but must still
+		// block retention: otherwise retention can mark the skipped compaction
+		// output block compacted before the rescan covers it. This matches the
+		// compaction provider, which already gates on TenantPending.
+		if p.sched.TenantPending(tenantID) {
+			level.Debug(p.logger).Log("msg", "skipping retention for tenant with active redaction batch", "tenant", tenantID)
 			continue
 		}
 

--- a/modules/backendscheduler/provider/retention_test.go
+++ b/modules/backendscheduler/provider/retention_test.go
@@ -198,6 +198,6 @@ func TestRetentionProviderGatesOnActiveBatch(t *testing.T) {
 		job.Start()
 	}
 
-	require.False(t, seen["tenant-a"], "F-011: retention must be skipped while a redaction batch is active")
+	require.False(t, seen["tenant-a"], "retention must be skipped while a redaction batch is active")
 	require.True(t, seen["tenant-b"], "retention must still run for tenants without an active batch")
 }

--- a/modules/backendscheduler/provider/retention_test.go
+++ b/modules/backendscheduler/provider/retention_test.go
@@ -73,12 +73,19 @@ func TestRetentionProviderSkipsRedactionPending(t *testing.T) {
 	workCfg.RegisterFlagsAndApplyDefaults("", &flag.FlagSet{})
 	w := work.New(workCfg)
 
-	// Enqueue a pending redaction job for tenant-a.
+	// Submit a redaction for tenant-a the way production does: a batch plus a
+	// pending redaction job. The batch is what marks the tenant pending.
+	require.NoError(t, w.AddBatch(&tempopb.RedactionBatch{
+		BatchId:  "batch-1",
+		TenantId: "tenant-a",
+		TraceIds: [][]byte{[]byte("trace-1")},
+	}))
 	err := w.AddPendingJobs([]*work.Job{{
 		ID:   "redact-1",
 		Type: tempopb.JobType_JOB_TYPE_REDACTION,
 		JobDetail: tempopb.JobDetail{
 			Tenant:    "tenant-a",
+			BatchId:   "batch-1",
 			Redaction: &tempopb.RedactionDetail{BlockId: "block-1"},
 		},
 	}})
@@ -144,4 +151,53 @@ func TestRetentionProviderRolloutCompat(t *testing.T) {
 
 	// No per-tenant jobs should be emitted while a global job is in flight.
 	require.Empty(t, receivedJobs, "no jobs should be emitted while a global retention job is running")
+}
+
+// TestRetentionProviderGatesOnActiveBatch covers the rescan-wait window: a
+// redaction batch is active (TenantPending true) but no redaction jobs are in
+// flight, so HasJobsForTenant(REDACTION) is false. Retention must still skip the
+// tenant — otherwise it can compact-out a skipped block before the rescan covers
+// it.
+func TestRetentionProviderGatesOnActiveBatch(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	cfg := RetentionConfig{}
+	cfg.RegisterFlagsAndApplyDefaults("", &flag.FlagSet{})
+	cfg.Interval = 10 * time.Millisecond
+
+	workCfg := work.Config{}
+	workCfg.RegisterFlagsAndApplyDefaults("", &flag.FlagSet{})
+	w := work.New(workCfg)
+
+	// Active redaction batch for tenant-a in its rescan-wait window: the batch
+	// exists with a pending rescan, but there are NO redaction jobs in flight.
+	require.NoError(t, w.AddBatch(&tempopb.RedactionBatch{
+		BatchId:                 "batch-1",
+		TenantId:                "tenant-a",
+		TraceIds:                [][]byte{[]byte("trace-1")},
+		SkippedCompactionJobIds: []string{"comp-1"},
+		RescanAfterUnixNano:     time.Now().Add(time.Hour).UnixNano(),
+	}))
+	require.True(t, w.TenantPending("tenant-a"))
+	require.False(t, w.HasJobsForTenant("tenant-a", tempopb.JobType_JOB_TYPE_REDACTION),
+		"precondition: no redaction jobs in flight during the rescan-wait window")
+
+	tenants := &staticTenantLister{tenants: []string{"tenant-a", "tenant-b"}}
+	logger := log.NewLogfmtLogger(os.Stderr)
+
+	limits, err := overrides.NewOverrides(overrides.Config{Defaults: overrides.Overrides{}}, nil, prometheus.NewRegistry())
+	require.NoError(t, err)
+	p := NewRetentionProvider(cfg, logger, tenants, limits, w)
+	jobChan := p.Start(ctx)
+
+	seen := make(map[string]bool)
+	for job := range jobChan {
+		seen[job.Tenant()] = true
+		require.NoError(t, w.AddJob(job))
+		job.Start()
+	}
+
+	require.False(t, seen["tenant-a"], "F-011: retention must be skipped while a redaction batch is active")
+	require.True(t, seen["tenant-b"], "retention must still run for tenants without an active batch")
 }

--- a/modules/backendworker/backendworker.go
+++ b/modules/backendworker/backendworker.go
@@ -381,8 +381,13 @@ func (w *BackendWorker) processRedactionJob(ctx context.Context, resp *tempopb.N
 		}
 	}
 	if meta == nil {
-		// Block no longer present (e.g. already compacted away); treat as clean.
-		level.Debug(log.Logger).Log("msg", "redaction block not found, completing as no-op", "job_id", resp.JobId, "block_id", blockIDStr)
+		// Block absent from the live blocklist (e.g. compacted or retained away).
+		// Completing as a no-op is correct only because the scheduler re-targets a
+		// moved trace via the batch's coverage logic; surface it so a genuine
+		// coverage gap is visible rather than a silent "successful" redaction.
+		metricRedactionBlockMissing.WithLabelValues(tenantID).Inc()
+		level.Warn(log.Logger).Log("msg", "redaction block not found in live blocklist, completing as no-op",
+			"job_id", resp.JobId, "block_id", blockIDStr, "tenant", tenantID)
 		return w.completeRedactionJob(ctx, resp.JobId, 0)
 	}
 

--- a/modules/backendworker/backendworker_test.go
+++ b/modules/backendworker/backendworker_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/grafana/tempo/tempodb/encoding/common"
 	"github.com/grafana/tempo/tempodb/wal"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -247,6 +248,40 @@ func writeTraceToWal(t require.TestingT, b common.WALBlock, dec model.SegmentDec
 
 	err = b.Append(id, b2, start, end, true)
 	require.NoError(t, err, "unexpected error writing req")
+}
+
+// TestProcessRedactionJobMissingBlockObservable verifies that a redaction job
+// whose target block is absent from the live blocklist is counted (and logged),
+// rather than silently completing as a no-op. The completion stays non-fatal —
+// the scheduler's coverage logic is responsible for re-targeting moved blocks —
+// but the event must be observable.
+func TestProcessRedactionJobMissingBlockObservable(t *testing.T) {
+	limitCfg := overrides.Config{}
+	limitCfg.RegisterFlagsAndApplyDefaults(&flag.FlagSet{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	workerCfg, schedulerClientCfg, overridesSvc, _, store := setupDependencies(ctx, t, limitCfg)
+	defer func() {
+		cancel()
+		store.StopAsync()
+		_ = store.AwaitTerminated(context.Background())
+	}()
+
+	w, err := New(workerCfg, schedulerClientCfg, store, overridesSvc, prometheus.NewRegistry())
+	require.NoError(t, err)
+	w.backendScheduler = &mockScheduler{updateJob: updateJobNoop}
+
+	before := testutil.ToFloat64(metricRedactionBlockMissing.WithLabelValues(tenant))
+	err = w.processRedactionJob(ctx, &tempopb.NextJobResponse{
+		JobId: "job-missing-block",
+		Detail: tempopb.JobDetail{
+			Tenant:    tenant,
+			Redaction: &tempopb.RedactionDetail{BlockId: uuid.New().String()},
+		},
+	})
+	require.NoError(t, err, "a missing block must complete as a non-fatal no-op")
+	after := testutil.ToFloat64(metricRedactionBlockMissing.WithLabelValues(tenant))
+	require.Equal(t, before+1, after, "a missing redaction block must be counted, not silently dropped")
 }
 
 func TestIsSharded(t *testing.T) {

--- a/modules/backendworker/metrics.go
+++ b/modules/backendworker/metrics.go
@@ -21,4 +21,9 @@ var (
 		Name:      "backend_worker_call_retries_total",
 		Help:      "Total number of retries for calls",
 	}, []string{})
+	metricRedactionBlockMissing = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "tempo",
+		Name:      "backend_worker_redaction_block_missing_total",
+		Help:      "Redaction jobs whose target block was absent from the live blocklist (potential redaction coverage gap).",
+	}, []string{"tenant"})
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Two independent redaction-correctness improvements in the backend scheduler. Each stands on its own.

- **Retention now honors the redaction batch barrier.** The retention provider previously skipped a tenant only while redaction *jobs* were in flight (`HasJobsForTenant(JOB_TYPE_REDACTION)`). A redaction batch can be active while awaiting a follow-up rescan with no jobs in flight; during that window retention could run for the tenant and mark a block compacted while the batch still needed it. Retention now gates on `TenantPending` — the same batch barrier the compaction provider already uses — in both the provider and the scheduler's stale-job drop path in `Next`.

- **Missing redaction blocks are observable.** When a redaction job's target block is no longer in the live blocklist (compacted or retained away), the worker completes it as a no-op. This was logged only at debug level, so a genuine coverage gap was indistinguishable from normal operation. This adds the `tempo_backend_worker_redaction_block_missing_total` counter and a warning log. The completion remains non-fatal.

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)
