### PR TITLE
jsonnet: add Prometheus-trigger autoscaling option for metrics-generator

### DIFF
--- a/.chloggen/generator-autoscaling-prometheus-trigger.yaml
+++ b/.chloggen/generator-autoscaling-prometheus-trigger.yaml
@@ -1,6 +1,6 @@
 change_type: enhancement
 component: operations
 note: "jsonnet: support Prometheus-based KEDA autoscaling for the metrics-generator"
-issues: []
+issues: [7362]
 subtext:
 user: mapno

--- a/.chloggen/generator-autoscaling-prometheus-trigger.yaml
+++ b/.chloggen/generator-autoscaling-prometheus-trigger.yaml
@@ -1,6 +1,6 @@
 change_type: enhancement
 component: operations
 note: "jsonnet: support Prometheus-based KEDA autoscaling for the metrics-generator"
-issues: [7362]
+issues: []
 subtext:
 user: mapno

--- a/.chloggen/generator-autoscaling-prometheus-trigger.yaml
+++ b/.chloggen/generator-autoscaling-prometheus-trigger.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: operations
+note: "jsonnet: support Prometheus-based KEDA autoscaling for the metrics-generator"
+issues: [7362]
+subtext:
+user: mapno

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,31 @@
 <!-- next version -->
+## main / unreleased
+
+* [ENHANCEMENT] jsonnet: support Prometheus-based KEDA autoscaling for the metrics-generator via `metrics_generator.keda.query`, to keep replicas from exceeding the live-store partition count. Falls back to the existing CPU trigger when unset. [#PRNUM](https://github.com/grafana/tempo/pull/PRNUM) (@mapno)
+* [ENHANCEMENT] cache: enforce a configurable MaxItemSize for Redis. [#7311](https://github.com/grafana/tempo/pull/7311) (@electron0zero)
+* [SECURITY] jsonnet: bump `memcached` to `1.6.42-alpine` and `prom/memcached-exporter` to `v0.16.0` to clear accumulated CVEs. [#7244](https://github.com/grafana/tempo/pull/7244) (@zhxiaogg)
+* [ENHANCEMENT] tempo-mixin: update backendwork dashboard with a Redaction section (active jobs, created/completed/failed/dropped by tenant, job duration), add Dropped and Job Duration panels to the Jobs row, and fix the Retry metric name (`jobs_retry` -> `jobs_retry_total`). [#7184](https://github.com/grafana/tempo/pull/7184) (@zalegrala)
+* [ENHANCEMENT] querier: limit external endpoint response size to querier grpc MaxSendMsgSize. [#7240](https://github.com/grafana/tempo/pull/7240) (@electron0zero)
+* [FEATURE] jsonnet: Add KEDA autoscaling for live-store via Prometheus trigger on expected bytes held. Enable with `live_store.keda.enabled: true`. Configure block-builder coupling via `live_store.keda.block_builder_scaling`: `'rollout-operator'` (default, requires `rollout_operator_replica_template_access_enabled: true`) mirrors live-store zone-a replicas to block-builder; `'keda'` creates a dedicated block-builder KEDA ScaledObject using a kubernetes-workload trigger without requiring rollout-operator RBAC. [#7142](https://github.com/grafana/tempo/pull/7142) (@zachfi)
+* [SECURITY] backend-scheduler: fix cross-tenant escalation in SubmitRedaction -- tenant is now sourced exclusively from the authenticated request context (X-Scope-OrgID header) and the body tenant_id field is ignored. [#7153](https://github.com/grafana/tempo/pull/7153) (@zalegrala)
+* [ENHANCEMENT] backend-scheduler: eliminate O(256·M) shard scan in `HasJobsForTenant` and O(N) prefix scan in `BusyBlocksForTenant` via secondary indexes; `HasJobsForTenant` is now O(1), `BusyBlocksForTenant` is now O(|tenant blocks|). Add `splitPendingBlockKey` helper to centralise pending-block key parsing and decouple all index maintenance sites from the encoded key format. [#7141](https://github.com/grafana/tempo/pull/7141) (@zalegrala)
+* [ENHANCEMENT] tempodb: add `tempodb_cache_store_size_bytes` histogram labelled by `role` recording the size of every item written to the backend cache. [#7152](https://github.com/grafana/tempo/pull/7152) (@javiermolinar)
+* [ENHANCEMENT] Add `TempoDistributorKafkaProduceFailing` alert that triggers when Kafka records cannot be produced by the distributor. [#7148](https://github.com/grafana/tempo/pull/7148) (@javiermolinar)
+* [ENHANCEMENT] **BREAKING CHANGE** Query-frontend: new job sharding approach for trace lookups, using a new config option `blocks_per_shard` which replaces `query_shards`. [#7105](https://github.com/grafana/tempo/pull/7105) (@mdisibio)
+* [ENHANCEMENT] jsonnet: add `autoscaling_prometheus_url` and `autoscaling_prometheus_tenant` top-level config fields for KEDA autoscaling. Setting `autoscaling_prometheus_tenant` sends an `X-Scope-OrgID` header on all Prometheus trigger requests, which is required when the backend is a multi-tenant system such as Grafana Mimir. [#7099](https://github.com/grafana/tempo/pull/7099) (@zachfi)
+* [ENHANCEMENT] live-store: expose query inspected bytes as a metric. [#7162](https://github.com/grafana/tempo/pull/7162) [#7163](https://github.com/grafana/tempo/pull/7163) (@zhxiaogg)
+* [ENHANCEMENT] tempodb: evict bloom filter and trace-id-index cache entries for blocks deleted during retention, freeing cache space for active blocks sooner. [#7204](https://github.com/grafana/tempo/pull/7204) (@zalegrala)
+* [ENHANCEMENT] cache: add `Remove` method to the `Cache` interface, implemented for memcached and redis. [#7204](https://github.com/grafana/tempo/pull/7204) (@zalegrala)
+* [BUGFIX] backend-scheduler: fix redaction batch not cleaned up after dead-job timeout, leaving tenant permanently blocked from new redaction submissions and compaction. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
+* [BUGFIX] backend-scheduler: fix outstanding-blocks metric suppressed to zero during active redaction batch, causing autoscaler to scale down workers mid-redaction. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
+* [BUGFIX] backend-scheduler: fix O(N) lock contention in GetJobForWorker under concurrent worker load; replace shard scan with O(1) index lookup. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
+* [BUGFIX] livestore: write the per-block query-range response cache atomically (temp file + rename) and log+ignore cache read errors. [#7155](https://github.com/grafana/tempo/pull/7155) (@zhxiaogg)
+* [ENHANCEMENT] TraceQL metrics: enable new span-only fetch by default. Can be disabled per-tenant via `metrics_spanonly_fetch: false` or per-query via the unsafe hint `with(spanonly_fetch=false)`. [#7179](https://github.com/grafana/tempo/pull/7179) (@mdisibio)
+* [BUGFIX] Better validation for query_range endpoint: do not accept negative step [#7221](https://github.com/grafana/tempo/pull/7221) (@ruslan-mikhailov)
+* [BUGFIX] user-configurable overrides: emit duration fields as flat YAML scalars on `/status/overrides/{tenant}` and omit `generate_native_histograms` when unset. [#7138](https://github.com/grafana/tempo/pull/7138) (@electron0zero)
+* [BUGFIX] Fix unsafe quoting in query attributes [#7220](https://github.com/grafana/tempo/pull/7220) (@ruslan-mikhailov)
+* [FEATURE] Support arithmetic operations in TraceQL Metrics [#6866](https://github.com/grafana/tempo/pull/6866) (@ruslan-mikhailov)
+* [BUGFIX] Fix rare cache collision between instant and range metrics queries [#7290](https://github.com/grafana/tempo/pull/7290) (@ruslan-mikhailov)
 
 # v3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- next version -->
 ## main / unreleased
 
-* [ENHANCEMENT] jsonnet: support Prometheus-based KEDA autoscaling for the metrics-generator via `metrics_generator.keda.query`, to keep replicas from exceeding the live-store partition count. Falls back to the existing CPU trigger when unset. [#PRNUM](https://github.com/grafana/tempo/pull/PRNUM) (@mapno)
+* [ENHANCEMENT] jsonnet: support Prometheus-based KEDA autoscaling for the metrics-generator via `metrics_generator.keda.query`, to keep replicas from exceeding the live-store partition count. Falls back to the existing CPU trigger when unset. [#7362](https://github.com/grafana/tempo/pull/7362) (@mapno)
 * [ENHANCEMENT] cache: enforce a configurable MaxItemSize for Redis. [#7311](https://github.com/grafana/tempo/pull/7311) (@electron0zero)
 * [SECURITY] jsonnet: bump `memcached` to `1.6.42-alpine` and `prom/memcached-exporter` to `v0.16.0` to clear accumulated CVEs. [#7244](https://github.com/grafana/tempo/pull/7244) (@zhxiaogg)
 * [ENHANCEMENT] tempo-mixin: update backendwork dashboard with a Redaction section (active jobs, created/completed/failed/dropped by tenant, job duration), add Dropped and Job Duration panels to the Jobs row, and fix the Retry metric name (`jobs_retry` -> `jobs_retry_total`). [#7184](https://github.com/grafana/tempo/pull/7184) (@zalegrala)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,4 @@
 <!-- next version -->
-## main / unreleased
-
-* [ENHANCEMENT] jsonnet: support Prometheus-based KEDA autoscaling for the metrics-generator. [#7362](https://github.com/grafana/tempo/pull/7362) (@mapno)
-* [ENHANCEMENT] cache: enforce a configurable MaxItemSize for Redis. [#7311](https://github.com/grafana/tempo/pull/7311) (@electron0zero)
-* [SECURITY] jsonnet: bump `memcached` to `1.6.42-alpine` and `prom/memcached-exporter` to `v0.16.0` to clear accumulated CVEs. [#7244](https://github.com/grafana/tempo/pull/7244) (@zhxiaogg)
-* [ENHANCEMENT] tempo-mixin: update backendwork dashboard with a Redaction section (active jobs, created/completed/failed/dropped by tenant, job duration), add Dropped and Job Duration panels to the Jobs row, and fix the Retry metric name (`jobs_retry` -> `jobs_retry_total`). [#7184](https://github.com/grafana/tempo/pull/7184) (@zalegrala)
-* [ENHANCEMENT] querier: limit external endpoint response size to querier grpc MaxSendMsgSize. [#7240](https://github.com/grafana/tempo/pull/7240) (@electron0zero)
-* [FEATURE] jsonnet: Add KEDA autoscaling for live-store via Prometheus trigger on expected bytes held. Enable with `live_store.keda.enabled: true`. Configure block-builder coupling via `live_store.keda.block_builder_scaling`: `'rollout-operator'` (default, requires `rollout_operator_replica_template_access_enabled: true`) mirrors live-store zone-a replicas to block-builder; `'keda'` creates a dedicated block-builder KEDA ScaledObject using a kubernetes-workload trigger without requiring rollout-operator RBAC. [#7142](https://github.com/grafana/tempo/pull/7142) (@zachfi)
-* [SECURITY] backend-scheduler: fix cross-tenant escalation in SubmitRedaction -- tenant is now sourced exclusively from the authenticated request context (X-Scope-OrgID header) and the body tenant_id field is ignored. [#7153](https://github.com/grafana/tempo/pull/7153) (@zalegrala)
-* [ENHANCEMENT] backend-scheduler: eliminate O(256·M) shard scan in `HasJobsForTenant` and O(N) prefix scan in `BusyBlocksForTenant` via secondary indexes; `HasJobsForTenant` is now O(1), `BusyBlocksForTenant` is now O(|tenant blocks|). Add `splitPendingBlockKey` helper to centralise pending-block key parsing and decouple all index maintenance sites from the encoded key format. [#7141](https://github.com/grafana/tempo/pull/7141) (@zalegrala)
-* [ENHANCEMENT] tempodb: add `tempodb_cache_store_size_bytes` histogram labelled by `role` recording the size of every item written to the backend cache. [#7152](https://github.com/grafana/tempo/pull/7152) (@javiermolinar)
-* [ENHANCEMENT] Add `TempoDistributorKafkaProduceFailing` alert that triggers when Kafka records cannot be produced by the distributor. [#7148](https://github.com/grafana/tempo/pull/7148) (@javiermolinar)
-* [ENHANCEMENT] **BREAKING CHANGE** Query-frontend: new job sharding approach for trace lookups, using a new config option `blocks_per_shard` which replaces `query_shards`. [#7105](https://github.com/grafana/tempo/pull/7105) (@mdisibio)
-* [ENHANCEMENT] jsonnet: add `autoscaling_prometheus_url` and `autoscaling_prometheus_tenant` top-level config fields for KEDA autoscaling. Setting `autoscaling_prometheus_tenant` sends an `X-Scope-OrgID` header on all Prometheus trigger requests, which is required when the backend is a multi-tenant system such as Grafana Mimir. [#7099](https://github.com/grafana/tempo/pull/7099) (@zachfi)
-* [ENHANCEMENT] live-store: expose query inspected bytes as a metric. [#7162](https://github.com/grafana/tempo/pull/7162) [#7163](https://github.com/grafana/tempo/pull/7163) (@zhxiaogg)
-* [ENHANCEMENT] tempodb: evict bloom filter and trace-id-index cache entries for blocks deleted during retention, freeing cache space for active blocks sooner. [#7204](https://github.com/grafana/tempo/pull/7204) (@zalegrala)
-* [ENHANCEMENT] cache: add `Remove` method to the `Cache` interface, implemented for memcached and redis. [#7204](https://github.com/grafana/tempo/pull/7204) (@zalegrala)
-* [BUGFIX] backend-scheduler: fix redaction batch not cleaned up after dead-job timeout, leaving tenant permanently blocked from new redaction submissions and compaction. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
-* [BUGFIX] backend-scheduler: fix outstanding-blocks metric suppressed to zero during active redaction batch, causing autoscaler to scale down workers mid-redaction. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
-* [BUGFIX] backend-scheduler: fix O(N) lock contention in GetJobForWorker under concurrent worker load; replace shard scan with O(1) index lookup. [#6992](https://github.com/grafana/tempo/pull/6992) (@zalegrala)
-* [BUGFIX] livestore: write the per-block query-range response cache atomically (temp file + rename) and log+ignore cache read errors. [#7155](https://github.com/grafana/tempo/pull/7155) (@zhxiaogg)
-* [ENHANCEMENT] TraceQL metrics: enable new span-only fetch by default. Can be disabled per-tenant via `metrics_spanonly_fetch: false` or per-query via the unsafe hint `with(spanonly_fetch=false)`. [#7179](https://github.com/grafana/tempo/pull/7179) (@mdisibio)
-* [BUGFIX] Better validation for query_range endpoint: do not accept negative step [#7221](https://github.com/grafana/tempo/pull/7221) (@ruslan-mikhailov)
-* [BUGFIX] user-configurable overrides: emit duration fields as flat YAML scalars on `/status/overrides/{tenant}` and omit `generate_native_histograms` when unset. [#7138](https://github.com/grafana/tempo/pull/7138) (@electron0zero)
-* [BUGFIX] Fix unsafe quoting in query attributes [#7220](https://github.com/grafana/tempo/pull/7220) (@ruslan-mikhailov)
-* [FEATURE] Support arithmetic operations in TraceQL Metrics [#6866](https://github.com/grafana/tempo/pull/6866) (@ruslan-mikhailov)
-* [BUGFIX] Fix rare cache collision between instant and range metrics queries [#7290](https://github.com/grafana/tempo/pull/7290) (@ruslan-mikhailov)
 
 # v3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- next version -->
 ## main / unreleased
 
-* [ENHANCEMENT] jsonnet: support Prometheus-based KEDA autoscaling for the metrics-generator via `metrics_generator.keda.query`, to keep replicas from exceeding the live-store partition count. Falls back to the existing CPU trigger when unset. [#7362](https://github.com/grafana/tempo/pull/7362) (@mapno)
+* [ENHANCEMENT] jsonnet: support Prometheus-based KEDA autoscaling for the metrics-generator. [#7362](https://github.com/grafana/tempo/pull/7362) (@mapno)
 * [ENHANCEMENT] cache: enforce a configurable MaxItemSize for Redis. [#7311](https://github.com/grafana/tempo/pull/7311) (@electron0zero)
 * [SECURITY] jsonnet: bump `memcached` to `1.6.42-alpine` and `prom/memcached-exporter` to `v0.16.0` to clear accumulated CVEs. [#7244](https://github.com/grafana/tempo/pull/7244) (@zhxiaogg)
 * [ENHANCEMENT] tempo-mixin: update backendwork dashboard with a Redaction section (active jobs, created/completed/failed/dropped by tenant, job duration), add Dropped and Job Duration panels to the Jobs row, and fix the Retry metric name (`jobs_retry` -> `jobs_retry_total`). [#7184](https://github.com/grafana/tempo/pull/7184) (@zalegrala)

--- a/operations/jsonnet-compiled/jsonnetfile.lock.json
+++ b/operations/jsonnet-compiled/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "2fa424c33e81967fb375e687b51ff2e9cf7f1b79",
+      "version": "08dd6a95dfc7384236f4f331d72d4b37cb59669a",
       "sum": "0y3AFX9LQSpfWTxWKSwoLgbt0Wc9nnCwhMH2szKzHv0="
     },
     {
@@ -18,7 +18,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "2fa424c33e81967fb375e687b51ff2e9cf7f1b79",
+      "version": "08dd6a95dfc7384236f4f331d72d4b37cb59669a",
       "sum": "zNTCDRaCqJUHjQSQRsxGR3jLrMP9tU7YNQb13dbm1bU="
     },
     {

--- a/operations/jsonnet/microservices/autoscaling.libsonnet
+++ b/operations/jsonnet/microservices/autoscaling.libsonnet
@@ -273,7 +273,8 @@
     if $._config.distributor.keda.enabled then $.removeReplicasFromSpec else {},
 
   //
-  // Metrics Generator: CPU-based autoscaling.
+  // Metrics Generator: CPU-based autoscaling by default, or Prometheus-based
+  // autoscaling when metrics_generator.keda.query is set.
   //
   tempo_metrics_generator_scaled_object:
     if $._config.metrics_generator.keda.enabled then

--- a/operations/jsonnet/microservices/autoscaling.libsonnet
+++ b/operations/jsonnet/microservices/autoscaling.libsonnet
@@ -45,26 +45,21 @@
         paused_replicas: 0,
         // Target CPU per pod for the default CPU-based trigger (used when 'query' is empty).
         target_cpu: '500m',
-        // Optional PromQL query for Prometheus-based scaling. When empty (default), a
-        // CPU trigger using target_cpu is used. When set, a Prometheus trigger is used
-        // instead: the query must return the exact desired pod count (see metricType
-        // Value / threshold 1 below), and autoscaling_prometheus_url must be configured.
+        // Optional PromQL query for Prometheus-based scaling. When empty (default),
+        // a CPU trigger using target_cpu is used.
         //
         // Use a Prometheus query to keep replicas from exceeding the partition count.
         // The metrics-generator reads from the live-store partitions, so scaling beyond
         // the partition count adds pods that have no partition to own and just sit idle.
-        // CPU alone cannot express that ceiling; a query can clamp CPU-derived demand to
-        // the partition count (see the example below).
         //
-        // Example that clamps CPU-derived demand to the partition count so generators
-        // never exceed the number of partitions (0.5 == 500m CPU target per pod):
+        // Example (0.5 == 500m CPU target per pod):
         //   (
-        //     ceil(sum(rate(container_cpu_usage_seconds_total{pod=~"metrics-generator-.*", cluster="<cluster>", namespace="<namespace>"}[1h])) / 0.5)
+        //     ceil(sum(rate(container_cpu_usage_seconds_total{pod=~"metrics-generator-.*"}[1h])) / 0.5)
         //     <
-        //     max(sum by (instance) (tempo_partition_ring_partitions{name="livestore-partitions", state=~"Active|Inactive", cluster="<cluster>", namespace="<namespace>"}))
+        //     max(sum by (instance) (tempo_partition_ring_partitions{name="livestore-partitions", state=~"Active|Inactive"}))
         //   )
         //   or
-        //     max(sum by (instance) (tempo_partition_ring_partitions{name="livestore-partitions", state=~"Active|Inactive", cluster="<cluster>", namespace="<namespace>"}))
+        //     max(sum by (instance) (tempo_partition_ring_partitions{name="livestore-partitions", state=~"Active|Inactive"}))
         query: '',
         scale_up_stabilization_window_seconds: 60,
         scale_up_pods: 5,

--- a/operations/jsonnet/microservices/autoscaling.libsonnet
+++ b/operations/jsonnet/microservices/autoscaling.libsonnet
@@ -43,7 +43,29 @@
         min_replicas: 1,
         max_replicas: 200,
         paused_replicas: 0,
+        // Target CPU per pod for the default CPU-based trigger (used when 'query' is empty).
         target_cpu: '500m',
+        // Optional PromQL query for Prometheus-based scaling. When empty (default), a
+        // CPU trigger using target_cpu is used. When set, a Prometheus trigger is used
+        // instead: the query must return the exact desired pod count (see metricType
+        // Value / threshold 1 below), and autoscaling_prometheus_url must be configured.
+        //
+        // Use a Prometheus query to keep replicas from exceeding the partition count.
+        // The metrics-generator reads from the live-store partitions, so scaling beyond
+        // the partition count adds pods that have no partition to own and just sit idle.
+        // CPU alone cannot express that ceiling; a query can clamp CPU-derived demand to
+        // the partition count (see the example below).
+        //
+        // Example that clamps CPU-derived demand to the partition count so generators
+        // never exceed the number of partitions (0.5 == 500m CPU target per pod):
+        //   (
+        //     ceil(sum(rate(container_cpu_usage_seconds_total{pod=~"metrics-generator-.*", cluster="<cluster>", namespace="<namespace>"}[1h])) / 0.5)
+        //     <
+        //     max(sum by (instance) (tempo_partition_ring_partitions{name="livestore-partitions", state=~"Active|Inactive", cluster="<cluster>", namespace="<namespace>"}))
+        //   )
+        //   or
+        //     max(sum by (instance) (tempo_partition_ring_partitions{name="livestore-partitions", state=~"Active|Inactive", cluster="<cluster>", namespace="<namespace>"}))
+        query: '',
         scale_up_stabilization_window_seconds: 60,
         scale_up_pods: 5,
         scale_up_period_seconds: 60,
@@ -260,14 +282,34 @@
   //
   tempo_metrics_generator_scaled_object:
     if $._config.metrics_generator.keda.enabled then
+      local config = $._config.metrics_generator.keda;
       $.scaledObjectForController($.tempo_metrics_generator_statefulset, 'metrics_generator')
-      + scaledObject.spec.withTriggersMixin([{
-        type: 'cpu',
-        metricType: 'AverageValue',
-        metadata: {
-          value: $._config.metrics_generator.keda.target_cpu,
-        },
-      }])
+      + (
+        if config.query != '' then
+          // Prometheus-based scaling. The query must return the exact desired pod count.
+          // For more details about how HPA uses the query and threshold to calculate
+          // desired replicas, see:
+          // https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details
+          assert $._config.autoscaling_prometheus_url != '' : 'autoscaling_prometheus_url is required for metrics_generator Prometheus autoscaling';
+          scaledObject.spec.withTriggersMixin([
+            // metricType Value with threshold 1 → desiredReplicas = ceil(queryResult / 1) = queryResult.
+            // The default AverageValue would multiply by currentReplicas and cause runaway scaling.
+            $.prometheusTrigger(
+              query=config.query,
+              metricName='metrics_generator_desired_replicas',
+              threshold='1',
+            ) + { metricType: 'Value' },
+          ])
+        else
+          // CPU-based scaling.
+          scaledObject.spec.withTriggersMixin([{
+            type: 'cpu',
+            metricType: 'AverageValue',
+            metadata: {
+              value: config.target_cpu,
+            },
+          }])
+      )
     else {},
 
   tempo_metrics_generator_statefulset+:

--- a/operations/jsonnet/microservices/test/test1.jsonnet
+++ b/operations/jsonnet/microservices/test/test1.jsonnet
@@ -11,6 +11,15 @@ local withBackendWorkerKeda(url, tenant='') = default {
   },
 };
 
+// Helper: metrics-generator KEDA enabled. With a query it uses a Prometheus trigger;
+// without one it falls back to the CPU trigger.
+local withMetricsGeneratorKeda(url='', query='') = default {
+  _config+:: {
+    autoscaling_prometheus_url: url,
+    metrics_generator+: { keda+: { enabled: true, query: query } },
+  },
+};
+
 // Helper: live-store KEDA only (no block-builder autoscaling).
 local withLiveStoreKeda(url, tenant='') = default {
   _config+:: {
@@ -298,5 +307,54 @@ test.new(std.thisFile)
   test.expect.eq(
     withBlockBuilderKedaKedaOnly('http://prometheus:9090').tempo_block_builder_scaled_object.spec.scaleTargetRef.name,
     'block-builder'
+  )
+)
++ test.case.new(
+  'metrics_generator KEDA defaults to a CPU trigger when query is empty',
+  test.expect.eq(
+    withMetricsGeneratorKeda().tempo_metrics_generator_scaled_object.spec.triggers[0].type,
+    'cpu'
+  )
+)
++ test.case.new(
+  'metrics_generator KEDA CPU trigger uses target_cpu from config',
+  test.expect.eq(
+    withMetricsGeneratorKeda().tempo_metrics_generator_scaled_object.spec.triggers[0].metadata.value,
+    '500m'
+  )
+)
++ test.case.new(
+  'metrics_generator KEDA uses a Prometheus trigger when query is set',
+  test.expect.eq(
+    withMetricsGeneratorKeda('http://prometheus:9090', 'max(some_metric)').tempo_metrics_generator_scaled_object.spec.triggers[0].type,
+    'prometheus'
+  )
+)
++ test.case.new(
+  'metrics_generator KEDA Prometheus trigger uses metricType Value',
+  test.expect.eq(
+    withMetricsGeneratorKeda('http://prometheus:9090', 'max(some_metric)').tempo_metrics_generator_scaled_object.spec.triggers[0].metricType,
+    'Value'
+  )
+)
++ test.case.new(
+  'metrics_generator KEDA Prometheus trigger uses threshold 1',
+  test.expect.eq(
+    withMetricsGeneratorKeda('http://prometheus:9090', 'max(some_metric)').tempo_metrics_generator_scaled_object.spec.triggers[0].metadata.threshold,
+    '1'
+  )
+)
++ test.case.new(
+  'metrics_generator KEDA Prometheus trigger uses autoscaling_prometheus_url',
+  test.expect.eq(
+    withMetricsGeneratorKeda('http://prometheus:9090', 'max(some_metric)').tempo_metrics_generator_scaled_object.spec.triggers[0].metadata.serverAddress,
+    'http://prometheus:9090'
+  )
+)
++ test.case.new(
+  'metrics_generator KEDA Prometheus trigger passes the configured query through',
+  test.expect.eq(
+    withMetricsGeneratorKeda('http://prometheus:9090', 'max(some_metric)').tempo_metrics_generator_scaled_object.spec.triggers[0].metadata.query,
+    'max(some_metric)'
   )
 )


### PR DESCRIPTION
**What this PR does**:

Adds an optional Prometheus-based KEDA trigger for the metrics-generator autoscaler, alongside the existing CPU trigger.

 - `metrics_generator.keda.query == ''`: existing CPU trigger (`target_cpu`, unchanged behavior).
 - `metrics_generator.keda.query != ''`: KEDA Prometheus trigger via the shared `prometheusTrigger` helper, using `metricType: Value` with `threshold: 1` — the query must return the exact desired pod count.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`