### PR TITLE
[DOC] Add sections for handling http_headers for metrics-gen

### DIFF
--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -887,6 +887,9 @@ metrics_generator:
 
         # A list of remote write endpoints.
         # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
+        # To send sensitive header values, such as authentication tokens, use http_headers
+        # with secrets instead of the headers map. Values in the headers map are stored and
+        # displayed in plaintext. Refer to the caution that follows this configuration block.
         remote_write:
             [- <Prometheus remote write config>]
 
@@ -898,6 +901,26 @@ metrics_generator:
     # Overrides the key used to register the metrics-generator in the ring.
     [override_ring_key: <string> | default = "metrics-generator"]
 ```
+
+{{< admonition type="caution" >}}
+Header values that you set under `headers` in a `remote_write` endpoint are stored and displayed in plaintext.
+They appear in the configuration that the [`/status/config` endpoint](https://grafana.com/docs/tempo/<TEMPO_VERSION>/api_docs/#status) returns, which can expose secrets such as authentication tokens.
+
+To send sensitive header values, use `http_headers` with `secrets` instead of `headers`.
+Tempo masks values that you configure under `secrets` as `<secret>` in the displayed configuration.
+To read a value from a file, use `files` instead.
+
+```yaml
+metrics_generator:
+  storage:
+    remote_write:
+      - url: https://prometheus.example.com/api/v1/write
+        http_headers:
+          X-Custom-Token:
+            secrets:
+              - <SECRET_VALUE>
+```
+{{< /admonition >}}
 
 ## Query-frontend
 

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -889,7 +889,7 @@ metrics_generator:
         # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
         # To send sensitive header values, such as authentication tokens, use http_headers
         # with secrets instead of the headers map. Values in the headers map are stored and
-        # displayed in plaintext. Refer to the caution that follows this configuration block.
+        # displayed in plaintext. Refer to the section that follows this configuration block.
         remote_write:
             [- <Prometheus remote write config>]
 
@@ -902,13 +902,32 @@ metrics_generator:
     [override_ring_key: <string> | default = "metrics-generator"]
 ```
 
-{{< admonition type="caution" >}}
+### Use `http_headers` with `secrets` to send sensitive header values
+
 Header values that you set under `headers` in a `remote_write` endpoint are stored and displayed in plaintext.
 They appear in the configuration that the [`/status/config` endpoint](https://grafana.com/docs/tempo/<TEMPO_VERSION>/api_docs/#status) returns, which can expose secrets such as authentication tokens.
 
 To send sensitive header values, use `http_headers` with `secrets` instead of `headers`.
+Each header under `http_headers` supports three optional fields:
+
+```yaml
+# Custom HTTP headers to send with each remote write request.
+http_headers:
+    # Header name.
+    [<string>]:
+        # Plaintext header values. Stored and displayed in plaintext.
+        [values: <list of strings>]
+        # Header values that Tempo masks as <secret> in the displayed configuration.
+        [secrets: <list of secrets>]
+        # Files that Tempo reads header values from.
+        [files: <list of strings>]
+```
+
+Use `secrets` for sensitive values, such as authentication tokens.
 Tempo masks values that you configure under `secrets` as `<secret>` in the displayed configuration.
-To read a value from a file, use `files` instead.
+Use `values` for non-sensitive values, and `files` to read a value from a file on disk.
+
+For example:
 
 ```yaml
 metrics_generator:
@@ -916,11 +935,19 @@ metrics_generator:
     remote_write:
       - url: https://prometheus.example.com/api/v1/write
         http_headers:
+          # Masked as <secret> in the displayed configuration.
           X-Custom-Token:
             secrets:
               - <SECRET_VALUE>
+          # Stored and displayed in plaintext.
+          X-Custom-Header:
+            values:
+              - custom-value
+          # Read from a file on disk.
+          X-Token-From-File:
+            files:
+              - /etc/tempo/custom-token
 ```
-{{< /admonition >}}
 
 ## Query-frontend
 
@@ -3007,4 +3034,4 @@ cache:
 
 ## Configure authentication
 
-Grafana Tempo does not come with any included authentication layer. You must run an authenticating reverse proxy in front of your services to prevent unauthorized access to Tempo (for example, nginx). [Manage authentication](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/authentication/) for more details
+Grafana Tempo doesn't come with any included authentication layer. You must run an authenticating reverse proxy in front of your services to prevent unauthorized access to Tempo (for example, nginx). Refer to [Manage authentication](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/authentication/) for more details.

--- a/docs/sources/tempo/metrics-from-traces/metrics-generator/multitenancy.md
+++ b/docs/sources/tempo/metrics-from-traces/metrics-generator/multitenancy.md
@@ -49,3 +49,7 @@ export PROM_B_BEARER_AUTH="Bearer $(cat /token-prometheus-b)"
 In this example, `PROM_A_BASIC_AUTH` and `PROM_B_BEARER_AUTH` are environment variables that contain the respective tenants' authorization tokens.
 The `remote_write_headers` override is used to specify the `Authorization` header for each tenant.
 The `Authorization` header is used to authenticate the remote write request to the Prometheus remote write endpoint.
+
+Tempo masks values set with `remote_write_headers` in the displayed configuration.
+If you configure headers directly in the `metrics_generator.storage.remote_write` block instead, use `http_headers` with `secrets` for sensitive values.
+For more information, refer to the [Metrics-generator](/docs/tempo/<TEMPO_VERSION>/configuration/#metrics-generator) section of the Tempo Configuration documentation.

--- a/docs/sources/tempo/metrics-from-traces/metrics-generator/multitenancy.md
+++ b/docs/sources/tempo/metrics-from-traces/metrics-generator/multitenancy.md
@@ -50,6 +50,7 @@ In this example, `PROM_A_BASIC_AUTH` and `PROM_B_BEARER_AUTH` are environment va
 The `remote_write_headers` override is used to specify the `Authorization` header for each tenant.
 The `Authorization` header is used to authenticate the remote write request to the Prometheus remote write endpoint.
 
-Tempo masks values set with `remote_write_headers` in the displayed configuration.
-If you configure headers directly in the `metrics_generator.storage.remote_write` block instead, use `http_headers` with `secrets` for sensitive values.
+Because `remote_write_headers` is an override, its values appear in the [`/status/runtime_config` endpoint](/docs/tempo/<TEMPO_VERSION>/api_docs/#status), where Tempo masks them as `<secret>`. They don't appear in `/status/config`, which excludes per-tenant overrides.
+
+If you configure headers directly in the `metrics_generator.storage.remote_write` block instead of using overrides, don't use the `headers` map for sensitive values. Those values appear in plaintext in the `/status/config` endpoint. Use `http_headers` with `secrets` instead, which Tempo masks as `<secret>`.
 For more information, refer to the [Metrics-generator](/docs/tempo/<TEMPO_VERSION>/configuration/#metrics-generator) section of the Tempo Configuration documentation.


### PR DESCRIPTION
**What this PR does**:

Adds documentation to recommend that header secrets should be put in http_headers and configured as such for the metrics generator documentation. 

**Which issue(s) this PR fixes**:
Fixes #

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`; see `.chloggen/README.md`)