### PR TITLE
chore(chloggen): branch-name default, optional auto-filled PR, type/docs skip

### DIFF
--- a/.chloggen/README.md
+++ b/.chloggen/README.md
@@ -8,19 +8,32 @@ release time. This avoids merge conflicts on a shared file.
 ## Add an entry
 
 ```bash
-make chlog-new        # creates .chloggen/<your-branch>.yaml from TEMPLATE.yaml
+make chlog-new                     # creates .chloggen/<your-branch>.yaml from TEMPLATE.yaml
+make chlog-new FILENAME=my-change  # optional: name the file explicitly
 ```
 
-Edit the generated file:
+The filename defaults to the current branch name; pass `FILENAME=` to override
+it (required on `main`/`master` or a detached HEAD). Edit the generated file:
 
 ```yaml
 change_type: enhancement       # breaking | change | feature | enhancement | bug_fix | security
 component: metrics-generator   # must be in the components allowlist in config.yaml
 note: A brief description of the change.
-issues: [1234]                 # PR or issue number(s)
+issues: []                     # (optional) PR number(s); blank = auto-filled at release
 subtext:                       # optional extra detail
 user: your-github-handle       # rendered as "(@your-github-handle)"
 ```
+
+`issues` is optional. If you leave it blank, `chlog-update` fills it at release
+time with the PR number parsed from the commit that added this file (Tempo
+squash-merges PRs as `... (#1234)`). On a release branch the file is added by the
+backport PR, so the backport PR number is used; to pin a specific number instead,
+set `issues` explicitly.
+
+If the PR cannot be determined (for example the entry was committed directly to
+`main`, or its PR is not yet merged), both `chlog-update` and `chlog-preview`
+fail and list the entries needing an explicit `issues` — they never render an
+entry without a PR link.
 
 `change_type` keywords render under these sections:
 

--- a/.chloggen/TEMPLATE.yaml
+++ b/.chloggen/TEMPLATE.yaml
@@ -10,7 +10,8 @@ component:
 # A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
 note:
 
-# One or more PR or issue numbers, e.g. [1234].
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
 issues: []
 
 # (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,4 +12,4 @@ Fixes #<issue number>
 **Checklist**
 - [ ] Tests updated
 - [ ] Documentation added
-- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`; see `.chloggen/README.md`)
+- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,5 +1,5 @@
 # Requires every PR targeting main to add a .chloggen entry.
-# Skip by adding the "Skip Changelog" label or using a "chore:" / "chore(scope):" / "[chore]" PR title.
+# Skip by adding the "Skip Changelog", "dependencies", or "type/docs" label, or using a "chore:" / "chore(scope):" / "[chore]" PR title.
 name: changelog
 
 on:
@@ -18,6 +18,7 @@ jobs:
       github.event_name == 'pull_request'
       && !contains(github.event.pull_request.labels.*.name, 'dependencies')
       && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog')
+      && !contains(github.event.pull_request.labels.*.name, 'type/docs')
       && !contains(github.event.pull_request.title, '[chore]')
       && !startsWith(github.event.pull_request.title, 'chore:')
       && !startsWith(github.event.pull_request.title, 'chore(')

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -1,0 +1,30 @@
+# Runs the unit tests for the separate `tools` Go module (tools/go.mod), which
+# the main CI unit-tests job does not cover. Runs on every PR (no path filter)
+# so it can be a required status check without blocking PRs that don't touch
+# the tools module.
+name: Tools Unit Tests
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  tools-tests:
+    name: Run tools unit tests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: 'tools/go.mod'
+
+      - name: Run tools unit tests
+        working-directory: tools
+        run: go test ./...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -415,28 +415,33 @@ chore(deps): update module google.golang.org/api to v0.267.0
 
 ### Changelog entries
 
-All PRs that change behavior (features, enhancements, bug fixes, breaking changes) must include a changelog entry. Dependency-only updates and pure internal refactors do not require one (label such PRs `Skip Changelog` or `dependencies`, or prefix the title with `chore:`).
+All PRs that change behavior (features, enhancements, bug fixes, breaking changes) must include a changelog entry. Dependency-only updates, docs-only changes, and pure internal refactors do not require one (label such PRs `Skip Changelog`, `dependencies`, or `type/docs`, or prefix the title with `chore:`).
 
 Tempo manages `CHANGELOG.md` with [chloggen](./tools/chloggen): instead of editing `CHANGELOG.md`, add a YAML file under `.chloggen/`. This avoids merge conflicts on the shared changelog.
 
 Create an entry:
 
 ```bash
-make chlog-new
+make chlog-new                     # names the file after your branch
+make chlog-new FILENAME=my-change  # optional: choose the filename explicitly
 ```
 
-Edit the generated `.chloggen/<branch>.yaml`:
+The filename defaults to the current branch name. Pass `FILENAME=` to override
+it (required when on `main`/`master` or a detached HEAD). Edit the generated
+`.chloggen/<name>.yaml`:
 
 ```yaml
 change_type: enhancement       # breaking | change | feature | enhancement | bug_fix | security
 component: metrics-generator   # must be in the components allowlist in .chloggen/config.yaml
 note: Short description of the change.
-issues: [<PR or issue number>]
+issues: []                     # (optional) PR number(s); blank = auto-filled at release
 subtext:                       # optional extra detail
 user: <your-github-handle>     # rendered as "(@your-github-handle)"
 ```
 
 `change_type` keywords render under these sections: `breaking` → Breaking changes, `change` → Changes, `feature` → Features, `enhancement` → Enhancements, `bug_fix` → Bug fixes, `security` → Security.
+
+`issues` is optional: leave it blank and `chlog-update` backfills the PR number from the commit that adds the entry file at release time (see [`.chloggen/README.md`](./.chloggen/README.md) for details, including how this behaves on release branches).
 
 Validate and preview before pushing:
 

--- a/Makefile
+++ b/Makefile
@@ -435,18 +435,26 @@ tempo-mixin-check: tools-image
 
 # chloggen is built from the tools module and run from the repo root so it can
 # find .chloggen/ and CHANGELOG.md. A .chloggen/config.yaml is used only if it
-# exists. Pass FILENAME=... to chlog-new and VERSION=vX.Y.Z to chlog-update.
+# exists. chlog-new defaults the entry filename to the current branch; override
+# with FILENAME=... . Pass VERSION=vX.Y.Z to chlog-update.
 CHLOGGEN ?= $(CURDIR)/bin/chloggen
 CHLOGGEN_CONFIG := .chloggen/config.yaml
 CHLOGGEN_CONFIG_ARG := $(if $(wildcard $(CHLOGGEN_CONFIG)),--config $(CHLOGGEN_CONFIG),)
+CHLOG_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
+CHLOG_FILENAME := $(if $(FILENAME),$(FILENAME),$(CHLOG_BRANCH))
 
 .PHONY: $(CHLOGGEN)
 $(CHLOGGEN):
 	cd $(CURDIR)/tools/chloggen && go build -o $(CHLOGGEN) .
 
 .PHONY: chlog-new
-chlog-new: $(CHLOGGEN) ## Create a new changelog entry under .chloggen/ (FILENAME=... optional)
-	$(CHLOGGEN) new $(CHLOGGEN_CONFIG_ARG) $(if $(FILENAME),--filename $(FILENAME))
+chlog-new: $(CHLOGGEN) ## Create a new changelog entry under .chloggen/ (defaults to branch name; override with FILENAME=...)
+	@if [ -z "$(CHLOG_FILENAME)" ] || [ "$(CHLOG_FILENAME)" = "HEAD" ] || \
+	    [ "$(CHLOG_FILENAME)" = "main" ] || [ "$(CHLOG_FILENAME)" = "master" ]; then \
+	  echo "Cannot default the changelog filename from branch '$(CHLOG_BRANCH)'; pass FILENAME=<name>."; \
+	  exit 1; \
+	fi
+	$(CHLOGGEN) new $(CHLOGGEN_CONFIG_ARG) --filename "$(CHLOG_FILENAME)"
 
 .PHONY: chlog-validate
 chlog-validate: $(CHLOGGEN) ## Validate the pending changelog entries

--- a/tools/chloggen/cmd/update.go
+++ b/tools/chloggen/cmd/update.go
@@ -54,6 +54,31 @@ func updateCmd() *cobra.Command {
 				return err
 			}
 
+			// Backfill empty 'issues' from git here, not in validate, so the PR-CI
+			// validation of an unmerged entry doesn't depend on git history. Dedupe
+			// by pointer: one entry can appear under several changelogs, and a
+			// failed backfill would otherwise re-spawn git for it each time.
+			backfilled := make(map[*chlog.Entry]bool)
+			for _, entries := range entriesByChangelog {
+				for _, e := range entries {
+					if backfilled[e] {
+						continue
+					}
+					backfilled[e] = true
+					e.BackfillIssues()
+				}
+			}
+
+			// Never render an entry without a PR link: fail, listing all of them.
+			if missing := chlog.MissingIssues(entriesByChangelog); len(missing) > 0 {
+				noun := "entry"
+				if len(missing) > 1 {
+					noun = "entries"
+				}
+				return fmt.Errorf("could not determine a PR number for %d changelog %s; set 'issues' explicitly in:\n  %s",
+					len(missing), noun, strings.Join(missing, "\n  "))
+			}
+
 			for changeLogKey, entries := range entriesByChangelog {
 
 				slices.SortFunc(entries, func(a, b *chlog.Entry) int {

--- a/tools/chloggen/cmd/update_test.go
+++ b/tools/chloggen/cmd/update_test.go
@@ -379,3 +379,63 @@ func TestUpdateValidatesBeforeWriting(t *testing.T) {
 	require.NoError(t, ioErr)
 	require.Equal(t, 2, len(remainingYAMLs))
 }
+
+func TestUpdateFailsWhenPRUnresolved(t *testing.T) {
+	globalCfg = config.New(t.TempDir())
+
+	// A valid entry that left 'issues' empty. The temp dir is not a git repo, so
+	// the PR can't be backfilled.
+	entry := &chlog.Entry{
+		ChangeType: chlog.BugFix,
+		Component:  "receiver/foo",
+		Note:       "Fix something",
+		User:       "octocat",
+	}
+	setupTestDir(t, []*chlog.Entry{entry})
+
+	// Both --dry and a real update fail rather than emit an entry with no link.
+	_, err := runCobra(t, "update", "--dry")
+	require.ErrorContains(t, err, "could not determine a PR number")
+
+	_, err = runCobra(t, "update")
+	require.ErrorContains(t, err, "could not determine a PR number")
+
+	// The source entry file must not be deleted when the update fails.
+	remainingYAMLs, ioErr := filepath.Glob(filepath.Join(globalCfg.EntriesDir, "*.yaml"))
+	require.NoError(t, ioErr)
+	require.Equal(t, 2, len(remainingYAMLs))
+}
+
+func TestUpdateListsAllUnresolvedPRs(t *testing.T) {
+	globalCfg = config.New(t.TempDir())
+
+	// Two unresolvable entries plus one with an explicit issue: both unresolved
+	// files must appear in a single error, not just the first.
+	resolvable := &chlog.Entry{
+		ChangeType: chlog.Enhancement,
+		Component:  "receiver/foo",
+		Note:       "Has a PR",
+		Issues:     []int{42},
+		User:       "octocat",
+	}
+	missingA := &chlog.Entry{
+		ChangeType: chlog.BugFix,
+		Component:  "receiver/foo",
+		Note:       "Missing A",
+		User:       "octocat",
+	}
+	missingB := &chlog.Entry{
+		ChangeType: chlog.BugFix,
+		Component:  "receiver/foo",
+		Note:       "Missing B",
+		User:       "octocat",
+	}
+	setupTestDir(t, []*chlog.Entry{resolvable, missingA, missingB})
+
+	_, err := runCobra(t, "update")
+	require.ErrorContains(t, err, "could not determine a PR number for 2 changelog")
+	// setupTestDir writes entries as 0.yaml (resolvable), 1.yaml, 2.yaml.
+	assert.ErrorContains(t, err, "1.yaml")
+	assert.ErrorContains(t, err, "2.yaml")
+	assert.NotContains(t, err.Error(), "0.yaml")
+}

--- a/tools/chloggen/cmd/validate_test.go
+++ b/tools/chloggen/cmd/validate_test.go
@@ -119,16 +119,18 @@ func TestValidate(t *testing.T) {
 			wantErr: "specify a 'note'",
 		},
 		{
-			name: "missing_issue",
+			// 'issues' is optional; update backfills it from git history, so an
+			// entry without issues must pass validation.
+			name: "no_issues_is_valid",
 			entries: func() []*chlog.Entry {
 				return append(getSampleEntries(), &chlog.Entry{
 					ChangeType: chlog.BugFix,
 					Component:  "receiver/foo",
 					Note:       "Add some bar",
 					Issues:     []int{},
+					User:       "octocat",
 				})
 			}(),
-			wantErr: "specify one or more issues #'s",
 		},
 		{
 			name: "all_invalid",

--- a/tools/chloggen/internal/chlog/entry.go
+++ b/tools/chloggen/internal/chlog/entry.go
@@ -17,11 +17,15 @@
 package chlog
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -51,6 +55,10 @@ type Entry struct {
 	Issues     []int    `yaml:"issues"`
 	SubText    string   `yaml:"subtext"`
 	User       string   `yaml:"user"`
+
+	// path is the source file (not part of the on-disk format); BackfillIssues
+	// uses it to recover the PR number from git.
+	path string
 }
 
 // DefaultChangeTypes lists the built-in change types in render order, along with
@@ -114,15 +122,61 @@ func (e Entry) Validate(requireChangelog bool, components []string, changeTypes 
 		errs = errors.Join(errs, fmt.Errorf("specify a 'note'"))
 	}
 
-	if len(e.Issues) == 0 {
-		errs = errors.Join(errs, fmt.Errorf("specify one or more issues #'s"))
-	}
+	// 'issues' is optional; 'update' backfills it from git (see BackfillIssues).
 
 	if strings.TrimSpace(e.User) == "" {
 		errs = errors.Join(errs, fmt.Errorf("specify a 'user'"))
 	}
 
 	return errs
+}
+
+// prSuffix captures the PR number from a squash-merge subject like "title (#1234)".
+var prSuffix = regexp.MustCompile(`\(#(\d+)\)\s*$`)
+
+// BackfillIssues fills Issues from the PR number in the commit that added the
+// entry file, when the author left 'issues' empty. Best-effort: on any failure
+// Issues stays empty and 'update' then fails via MissingIssues.
+func (e *Entry) BackfillIssues() {
+	if len(e.Issues) > 0 || e.path == "" {
+		return
+	}
+	if pr, ok := prFromGitHistory(e.path); ok {
+		e.Issues = []int{pr}
+	}
+}
+
+// MissingIssues returns the de-duplicated source paths of entries that still
+// have no 'issues' after backfill.
+func MissingIssues(entriesByChangelog map[string][]*Entry) []string {
+	seen := make(map[string]bool)
+	var paths []string
+	for _, entries := range entriesByChangelog {
+		for _, e := range entries {
+			if len(e.Issues) == 0 && !seen[e.path] {
+				seen[e.path] = true
+				paths = append(paths, e.path)
+			}
+		}
+	}
+	slices.Sort(paths)
+	return paths
+}
+
+func prFromGitHistory(path string) (int, bool) {
+	// -C <dir> so resolution doesn't depend on the process working directory.
+	dir, base := filepath.Dir(path), filepath.Base(path)
+	// Only the commit that added the file; a later edit could carry a different PR.
+	out, err := exec.Command("git", "-C", dir, "log", "-1", "--diff-filter=A", "--format=%s", "--", base).Output()
+	if err != nil {
+		return 0, false
+	}
+	if m := prSuffix.FindSubmatch(bytes.TrimSpace(out)); m != nil {
+		if n, err := strconv.Atoi(string(m[1])); err == nil {
+			return n, true
+		}
+	}
+	return 0, false
 }
 
 // ValidateEntries validates every entry against the configuration, accumulating
@@ -173,6 +227,7 @@ func ReadEntries(cfg *config.Config) (map[string][]*Entry, error) {
 		if err = yaml.Unmarshal(fileBytes, entry); err != nil {
 			return nil, err
 		}
+		entry.path = file
 		entry.SubText = strings.ReplaceAll(entry.SubText, "\r\n", "\n")
 		// 'user' is documented as a handle without the leading '@'; normalize it
 		// away so a value like "@octocat" doesn't render as "(@@octocat)".

--- a/tools/chloggen/internal/chlog/entry_test.go
+++ b/tools/chloggen/internal/chlog/entry_test.go
@@ -17,6 +17,7 @@ package chlog
 import (
 	"bytes"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"text/template"
@@ -49,7 +50,7 @@ func TestEntry(t *testing.T) {
 		{
 			name:      "empty",
 			entry:     Entry{},
-			expectErr: "'' is not a valid 'change_type'. Specify one of [breaking deprecation new_component enhancement bug_fix]\nspecify a 'component'\nspecify a 'note'\nspecify one or more issues #'s\nspecify a 'user'",
+			expectErr: "'' is not a valid 'change_type'. Specify one of [breaking deprecation new_component enhancement bug_fix]\nspecify a 'component'\nspecify a 'note'\nspecify a 'user'",
 		},
 		{
 			name: "missing_component",
@@ -74,7 +75,10 @@ func TestEntry(t *testing.T) {
 			expectErr: "specify a 'note'",
 		},
 		{
-			name: "missing_issue",
+			// 'issues' is optional and validates when empty; update fails before
+			// rendering such an entry, so the bare "()" here is never reached in
+			// practice.
+			name: "no_issues",
 			entry: Entry{
 				ChangeType: "bug_fix",
 				Component:  "bar",
@@ -82,7 +86,7 @@ func TestEntry(t *testing.T) {
 				SubText:    "",
 				User:       "octocat",
 			},
-			expectErr: "specify one or more issues #'s",
+			toString: "- `bar`: fix bar () (@octocat)",
 		},
 		{
 			name: "missing_required_changelog",
@@ -451,6 +455,71 @@ func TestReadEntriesRejectsUnknownChangelog(t *testing.T) {
 	require.ErrorContains(t, err, "'nonexistent' is not a valid value in 'change_logs'")
 }
 
+func TestBackfillIssues(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	dir := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput()
+		require.NoError(t, err, string(out))
+	}
+	runGit("init")
+	runGit("config", "user.email", "test@example.com")
+	runGit("config", "user.name", "Test")
+
+	// Simulate Tempo's squash-merge: the commit that adds the entry file carries
+	// the PR number in its subject.
+	path := filepath.Join(dir, "my-change.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("note: x\n"), 0o600))
+	runGit("add", "my-change.yaml")
+	runGit("commit", "-m", "Add a thing (#4242)")
+
+	t.Run("backfills PR from git when empty", func(t *testing.T) {
+		e := &Entry{path: path}
+		e.BackfillIssues()
+		assert.Equal(t, []int{4242}, e.Issues)
+	})
+
+	t.Run("keeps issues set by the author", func(t *testing.T) {
+		e := &Entry{path: path, Issues: []int{1}}
+		e.BackfillIssues()
+		assert.Equal(t, []int{1}, e.Issues)
+	})
+
+	t.Run("no-op when the file has no git history", func(t *testing.T) {
+		e := &Entry{path: filepath.Join(t.TempDir(), "untracked.yaml")}
+		e.BackfillIssues()
+		assert.Empty(t, e.Issues)
+	})
+
+	t.Run("uses the adding commit, not a later edit", func(t *testing.T) {
+		p := filepath.Join(dir, "edited.yaml")
+		require.NoError(t, os.WriteFile(p, []byte("note: a\n"), 0o600))
+		runGit("add", "edited.yaml")
+		runGit("commit", "-m", "Add edited (#100)")
+		require.NoError(t, os.WriteFile(p, []byte("note: b\n"), 0o600))
+		runGit("commit", "-am", "Tweak edited (#200)")
+
+		e := &Entry{path: p}
+		e.BackfillIssues()
+		assert.Equal(t, []int{100}, e.Issues)
+	})
+
+	t.Run("not found when the adding commit has no PR", func(t *testing.T) {
+		p := filepath.Join(dir, "nopr.yaml")
+		require.NoError(t, os.WriteFile(p, []byte("note: c\n"), 0o600))
+		runGit("add", "nopr.yaml")
+		runGit("commit", "-m", "local wip, no pr number")
+
+		e := &Entry{path: p}
+		e.BackfillIssues()
+		assert.Empty(t, e.Issues)
+	})
+}
+
 func TestFindYamlFilesEmptyDir(t *testing.T) {
 	dir := t.TempDir()
 
@@ -514,4 +583,8 @@ func writeEntry(t *testing.T, dir string, entry *Entry, ext string) {
 
 	_, err = entryFile.Write(entryBytes)
 	require.NoError(t, err)
+
+	// Record the source path so it matches what ReadEntries sets on the entries
+	// it returns (used by struct-equality assertions and BackfillIssues).
+	entry.path = entryFile.Name()
 }


### PR DESCRIPTION
**What this PR does**:

Quality-of-life improvements to the new chloggen-based changelog tooling.

- **`make chlog-new` defaults the entry filename to the current branch.** A bare `make chlog-new` previously failed (the tool requires `--filename` but the Makefile didn't pass it); it now works as the docs describe. Override with `FILENAME=...`. Defaulting is refused on `main`/`master`/detached HEAD with a clear message.
- **`issues` is now optional.** When left blank, the PR number is backfilled from the commit that *added* the entry file (Tempo squash-merges as `... (#1234)`). Resolution happens in Go *before* the summary is rendered. On a release branch the file is added by the backport PR, so the backport PR number is used; set `issues` explicitly to pin a specific number.
- **Strict resolution.** Both `chlog-update` and `chlog-preview` (`--dry`) fail if any entry's PR cannot be determined, listing every unresolved entry in one error — they never render or write an entry without a link. (Earlier drafts left preview lenient; it is now strict in both modes. Set `issues` explicitly when no PR exists, e.g. a direct-to-`main` commit.)
- **PRs labeled `type/docs` skip the required changelog check** (alongside `Skip Changelog`, `dependencies`, and `chore:` titles).
- **New `Tools Unit Tests` workflow** runs `go test ./...` for the separate `tools` module (`tools/go.mod`) on every PR, so chloggen's tests run in CI (the main unit-test jobs only cover the root module). Runs on every PR so it can be marked a required check without blocking unrelated PRs.
- **Docs/comments clarified** in `TEMPLATE.yaml`, `.chloggen/README.md`, and `CONTRIBUTING.md`: `issues` holds the PR number (an issue number also works) and can be left blank.

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Tests updated (`tools/chloggen` suite green; added `TestBackfillIssues` and update fail-path tests)
- [x] Documentation added
- [ ] Changelog entry — N/A, tooling-only `chore:` change