### PR TITLE
chore(chloggen): backport changelog tooling to release-v3.0

### DIFF
--- a/.chloggen/README.md
+++ b/.chloggen/README.md
@@ -1,0 +1,51 @@
+# Changelog entries
+
+Tempo manages `CHANGELOG.md` with [chloggen](../tools/chloggen) (the in-tree tool
+at `tools/chloggen`). Instead of editing `CHANGELOG.md` directly, every PR adds a
+small YAML file to this directory; the files are collated into the changelog at
+release time. This avoids merge conflicts on a shared file.
+
+## Add an entry
+
+```bash
+make chlog-new        # creates .chloggen/<your-branch>.yaml from TEMPLATE.yaml
+```
+
+Edit the generated file:
+
+```yaml
+change_type: enhancement       # breaking | change | feature | enhancement | bug_fix | security
+component: metrics-generator   # must be in the components allowlist in config.yaml
+note: A brief description of the change.
+issues: [1234]                 # PR or issue number(s)
+subtext:                       # optional extra detail
+user: your-github-handle       # rendered as "(@your-github-handle)"
+```
+
+`change_type` keywords render under these sections:
+
+| keyword       | section               |
+| ------------- | --------------------- |
+| `breaking`    | 🛑 Breaking changes 🛑 |
+| `change`      | 🔧 Changes 🔧          |
+| `feature`     | 🚀 Features 🚀         |
+| `enhancement` | 💡 Enhancements 💡     |
+| `bug_fix`     | 🧰 Bug fixes 🧰        |
+| `security`    | 🔒 Security 🔒         |
+
+`component` must be one of the values in the `components` allowlist in
+[`config.yaml`](./config.yaml); `chlog-validate` rejects anything else. Adding a
+new component? Add it to that list in the same PR.
+
+## Validate / preview
+
+```bash
+make chlog-validate   # validate all entry files
+make chlog-preview    # render the pending entries to stdout
+```
+
+## Release (maintainers)
+
+```bash
+make chlog-update VERSION=v2.11.0   # collate entries into CHANGELOG.md and delete them
+```

--- a/.chloggen/README.md
+++ b/.chloggen/README.md
@@ -8,19 +8,32 @@ release time. This avoids merge conflicts on a shared file.
 ## Add an entry
 
 ```bash
-make chlog-new        # creates .chloggen/<your-branch>.yaml from TEMPLATE.yaml
+make chlog-new                     # creates .chloggen/<your-branch>.yaml from TEMPLATE.yaml
+make chlog-new FILENAME=my-change  # optional: name the file explicitly
 ```
 
-Edit the generated file:
+The filename defaults to the current branch name; pass `FILENAME=` to override
+it (required on `main`/`master` or a detached HEAD). Edit the generated file:
 
 ```yaml
 change_type: enhancement       # breaking | change | feature | enhancement | bug_fix | security
 component: metrics-generator   # must be in the components allowlist in config.yaml
 note: A brief description of the change.
-issues: [1234]                 # PR or issue number(s)
+issues: []                     # (optional) PR number(s); blank = auto-filled at release
 subtext:                       # optional extra detail
 user: your-github-handle       # rendered as "(@your-github-handle)"
 ```
+
+`issues` is optional. If you leave it blank, `chlog-update` fills it at release
+time with the PR number parsed from the commit that added this file (Tempo
+squash-merges PRs as `... (#1234)`). On a release branch the file is added by the
+backport PR, so the backport PR number is used; to pin a specific number instead,
+set `issues` explicitly.
+
+If the PR cannot be determined (for example the entry was committed directly to
+`main`, or its PR is not yet merged), both `chlog-update` and `chlog-preview`
+fail and list the entries needing an explicit `issues` — they never render an
+entry without a PR link.
 
 `change_type` keywords render under these sections:
 

--- a/.chloggen/TEMPLATE.yaml
+++ b/.chloggen/TEMPLATE.yaml
@@ -10,7 +10,8 @@ component:
 # A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
 note:
 
-# One or more PR or issue numbers, e.g. [1234].
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
 issues: []
 
 # (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.

--- a/.chloggen/TEMPLATE.yaml
+++ b/.chloggen/TEMPLATE.yaml
@@ -1,0 +1,20 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type:
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component:
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note:
+
+# One or more PR or issue numbers, e.g. [1234].
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user:

--- a/.chloggen/config.yaml
+++ b/.chloggen/config.yaml
@@ -1,0 +1,64 @@
+# Configuration for chloggen (the in-tree tool at tools/chloggen).
+# See .chloggen/README.md for usage.
+
+# Directory holding individual, unreleased changelog entries (one YAML per change).
+entries_dir: .chloggen
+
+# Template copied by `chloggen new` / `make chlog-new`.
+template_yaml: .chloggen/TEMPLATE.yaml
+
+# Custom render template producing Tempo's CHANGELOG.md format.
+summary_template: .chloggen/summary.tmpl
+
+# Target changelog file(s). Tempo uses a single changelog.
+change_logs:
+  default: CHANGELOG.md
+
+# Changelog used when an entry does not set `change_logs`.
+default_change_logs: [default]
+
+# Change types, in render order, with their section headings. Derived from Tempo's
+# historical CHANGELOG categories ([CHANGE], [FEATURE], [ENHANCEMENT], [BUGFIX],
+# [SECURITY]) plus breaking changes (historically the `**BREAKING CHANGE**` marker).
+change_types:
+  - key: security
+    heading: 🔒 Security 🔒
+  - key: breaking
+    heading: 🛑 Breaking changes 🛑
+  - key: feature
+    heading: 🚀 Features 🚀
+  - key: enhancement
+    heading: 💡 Enhancements 💡
+  - key: bug_fix
+    heading: 🧰 Bug fixes 🧰
+  - key: change
+    heading: 🔧 Changes 🔧
+
+# Allowlist of valid `component` values. Entries with a component outside this
+# list fail `chlog-validate`. Add a new component here when introducing one.
+components:
+  # services / modules
+  - distributor
+  - querier
+  - query-frontend
+  - compactor
+  - metrics-generator
+  - block-builder
+  - live-store
+  - backend-scheduler
+  - backend-worker
+  - overrides
+  - cache
+  # storage / core
+  - storage
+  - traceql
+  - api
+  # binaries
+  - tempo
+  - tempo-cli
+  - tempo-query
+  - tempo-vulture
+  # operations / tooling / meta
+  - operations
+  - docs
+  - deps

--- a/.chloggen/summary.tmpl
+++ b/.chloggen/summary.tmpl
@@ -1,0 +1,24 @@
+{{- define "entry" -}}
+- `{{ .Component }}`: {{ .Note }} (
+{{- range $i, $issue := .Issues }}
+{{- if $i }}, {{ end -}}
+[#{{ $issue }}](https://github.com/grafana/tempo/issues/{{ $issue }})
+{{- end -}}
+)
+{{- if .User }} (@{{ .User }}){{- end }}
+{{- if .SubText }}
+{{ .SubText | indent 2 }}
+{{- end }}
+{{- end }}
+# {{ .Version }}
+{{- range .Groups }}
+{{- if .Entries }}
+
+## {{ .Heading }}
+{{- range $i, $change := .Entries }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,4 +12,4 @@ Fixes #<issue number>
 **Checklist**
 - [ ] Tests updated
 - [ ] Documentation added
-- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
+- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`; see `.chloggen/README.md`)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,4 +12,4 @@ Fixes #<issue number>
 **Checklist**
 - [ ] Tests updated
 - [ ] Documentation added
-- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`; see `.chloggen/README.md`)
+- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,63 @@
+# Requires every PR targeting main to add a .chloggen entry.
+# Skip by adding the "Skip Changelog" label or using a "chore:" / "chore(scope):" / "[chore]" PR title.
+name: changelog
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request'
+      && !contains(github.event.pull_request.labels.*.name, 'dependencies')
+      && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog')
+      && !contains(github.event.pull_request.title, '[chore]')
+      && !startsWith(github.event.pull_request.title, 'chore:')
+      && !startsWith(github.event.pull_request.title, 'chore(')
+    env:
+      PR_HEAD: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Ensure CHANGELOG.md was not edited directly
+        run: |
+          base=$(git merge-base origin/main "$PR_HEAD")
+          if [[ -n "$(git diff --name-only "$base" "$PR_HEAD" ./CHANGELOG.md)" ]]; then
+            echo "CHANGELOG.md should not be edited directly."
+            echo "Add a .yaml file under ./.chloggen/ instead (run 'make chlog-new')."
+            echo "See .chloggen/README.md, or use a 'chore:' title / 'Skip Changelog' label to skip."
+            exit 1
+          fi
+          echo "CHANGELOG.md was not modified."
+
+      - name: Ensure a .chloggen entry was added
+        run: |
+          base=$(git merge-base origin/main "$PR_HEAD")
+          added=$(git diff --diff-filter=A --name-only "$base" "$PR_HEAD" ./.chloggen | grep -cE '\.ya?ml$' || true)
+          if [[ "$added" -lt 1 ]]; then
+            echo "No changelog entry was added under ./.chloggen/."
+            echo "Run 'make chlog-new' to create one. See .chloggen/README.md."
+            echo "Use a 'chore:' title / 'Skip Changelog' label to skip."
+            exit 1
+          fi
+          echo "A .chloggen entry was added."
+
+      - name: Validate .chloggen entries
+        run: make chlog-validate

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Ensure a .chloggen entry was added
         run: |
           base=$(git merge-base origin/main "$PR_HEAD")
-          added=$(git diff --diff-filter=A --name-only "$base" "$PR_HEAD" ./.chloggen | grep -cE '\.ya?ml$' || true)
+          added=$(git diff --diff-filter=AM --name-only "$base" "$PR_HEAD" ./.chloggen | grep -cE '\.ya?ml$' || true)
           if [[ "$added" -lt 1 ]]; then
             echo "No changelog entry was added under ./.chloggen/."
             echo "Run 'make chlog-new' to create one. See .chloggen/README.md."

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,5 +1,5 @@
 # Requires every PR targeting main to add a .chloggen entry.
-# Skip by adding the "Skip Changelog" label or using a "chore:" / "chore(scope):" / "[chore]" PR title.
+# Skip by adding the "Skip Changelog", "dependencies", or "type/docs" label, or using a "chore:" / "chore(scope):" / "[chore]" PR title.
 name: changelog
 
 on:
@@ -18,6 +18,7 @@ jobs:
       github.event_name == 'pull_request'
       && !contains(github.event.pull_request.labels.*.name, 'dependencies')
       && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog')
+      && !contains(github.event.pull_request.labels.*.name, 'type/docs')
       && !contains(github.event.pull_request.title, '[chore]')
       && !startsWith(github.event.pull_request.title, 'chore:')
       && !startsWith(github.event.pull_request.title, 'chore(')

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,4 +1,4 @@
-# Requires every PR targeting main to add a .chloggen entry.
+# Requires every PR targeting release-v3.0 to add a .chloggen entry.
 # Skip by adding the "Skip Changelog", "dependencies", or "type/docs" label, or using a "chore:" / "chore(scope):" / "[chore]" PR title.
 name: changelog
 
@@ -6,7 +6,7 @@ on:
   pull_request:
     types: [opened, ready_for_review, synchronize, reopened, labeled, unlabeled]
     branches:
-      - main
+      - release-v3.0
 
 permissions:
   contents: read
@@ -39,7 +39,7 @@ jobs:
 
       - name: Ensure CHANGELOG.md was not edited directly
         run: |
-          base=$(git merge-base origin/main "$PR_HEAD")
+          base=$(git merge-base origin/release-v3.0 "$PR_HEAD")
           if [[ -n "$(git diff --name-only "$base" "$PR_HEAD" ./CHANGELOG.md)" ]]; then
             echo "CHANGELOG.md should not be edited directly."
             echo "Add a .yaml file under ./.chloggen/ instead (run 'make chlog-new')."
@@ -50,7 +50,7 @@ jobs:
 
       - name: Ensure a .chloggen entry was added
         run: |
-          base=$(git merge-base origin/main "$PR_HEAD")
+          base=$(git merge-base origin/release-v3.0 "$PR_HEAD")
           added=$(git diff --diff-filter=AM --name-only "$base" "$PR_HEAD" ./.chloggen | grep -cE '\.ya?ml$' || true)
           if [[ "$added" -lt 1 ]]; then
             echo "No changelog entry was added under ./.chloggen/."

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -1,0 +1,30 @@
+# Runs the unit tests for the separate `tools` Go module (tools/go.mod), which
+# the main CI unit-tests job does not cover. Runs on every PR (no path filter)
+# so it can be a required status check without blocking PRs that don't touch
+# the tools module.
+name: Tools Unit Tests
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  tools-tests:
+    name: Run tools unit tests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: 'tools/go.mod'
+
+      - name: Run tools unit tests
+        working-directory: tools
+        run: go test ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## main / unreleased
+<!-- next version -->
 
 # v3.0.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -386,7 +386,7 @@ Before marking a PR ready for review, confirm:
 
 - [ ] Tests updated or added for the changed behavior
 - [ ] Documentation added or updated (refer to the [Documentation](#documentation) section)
-- [ ] `CHANGELOG.md` updated (refer to the [Changelog entries](#changelog-entries) section)
+- [ ] Changelog entry added under `.chloggen/` (refer to the [Changelog entries](#changelog-entries) section)
 
 ### Commit messages
 
@@ -415,23 +415,37 @@ chore(deps): update module google.golang.org/api to v0.267.0
 
 ### Changelog entries
 
-All PRs that change behavior (features, enhancements, bug fixes, breaking changes) must include a `CHANGELOG.md` entry. Dependency-only updates and pure internal refactors do not require one.
+All PRs that change behavior (features, enhancements, bug fixes, breaking changes) must include a changelog entry. Dependency-only updates and pure internal refactors do not require one (label such PRs `Skip Changelog` or `dependencies`, or prefix the title with `chore:`).
 
-Add your entry under `## main / unreleased` in this format:
+Tempo manages `CHANGELOG.md` with [chloggen](./tools/chloggen): instead of editing `CHANGELOG.md`, add a YAML file under `.chloggen/`. This avoids merge conflicts on the shared changelog.
 
-```
-* [TYPE] Short description of the change [#<PR>](https://github.com/grafana/tempo/pull/<PR>) (@your-github-handle)
-```
+Create an entry:
 
-Valid types in order of precedence: `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
-
-Mark breaking changes explicitly:
-
-```
-* [CHANGE] **BREAKING CHANGE** Description of what changed and what users must do [#<PR>](https://github.com/grafana/tempo/pull/<PR>) (@your-github-handle)
+```bash
+make chlog-new
 ```
 
-Keep entries ordered as `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]` within each release section.
+Edit the generated `.chloggen/<branch>.yaml`:
+
+```yaml
+change_type: enhancement       # breaking | change | feature | enhancement | bug_fix | security
+component: metrics-generator   # must be in the components allowlist in .chloggen/config.yaml
+note: Short description of the change.
+issues: [<PR or issue number>]
+subtext:                       # optional extra detail
+user: <your-github-handle>     # rendered as "(@your-github-handle)"
+```
+
+`change_type` keywords render under these sections: `breaking` → Breaking changes, `change` → Changes, `feature` → Features, `enhancement` → Enhancements, `bug_fix` → Bug fixes, `security` → Security.
+
+Validate and preview before pushing:
+
+```bash
+make chlog-validate
+make chlog-preview
+```
+
+See `.chloggen/README.md` for details.
 
 ### Keeping your PR up to date
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -415,28 +415,33 @@ chore(deps): update module google.golang.org/api to v0.267.0
 
 ### Changelog entries
 
-All PRs that change behavior (features, enhancements, bug fixes, breaking changes) must include a changelog entry. Dependency-only updates and pure internal refactors do not require one (label such PRs `Skip Changelog` or `dependencies`, or prefix the title with `chore:`).
+All PRs that change behavior (features, enhancements, bug fixes, breaking changes) must include a changelog entry. Dependency-only updates, docs-only changes, and pure internal refactors do not require one (label such PRs `Skip Changelog`, `dependencies`, or `type/docs`, or prefix the title with `chore:`).
 
 Tempo manages `CHANGELOG.md` with [chloggen](./tools/chloggen): instead of editing `CHANGELOG.md`, add a YAML file under `.chloggen/`. This avoids merge conflicts on the shared changelog.
 
 Create an entry:
 
 ```bash
-make chlog-new
+make chlog-new                     # names the file after your branch
+make chlog-new FILENAME=my-change  # optional: choose the filename explicitly
 ```
 
-Edit the generated `.chloggen/<branch>.yaml`:
+The filename defaults to the current branch name. Pass `FILENAME=` to override
+it (required when on `main`/`master` or a detached HEAD). Edit the generated
+`.chloggen/<name>.yaml`:
 
 ```yaml
 change_type: enhancement       # breaking | change | feature | enhancement | bug_fix | security
 component: metrics-generator   # must be in the components allowlist in .chloggen/config.yaml
 note: Short description of the change.
-issues: [<PR or issue number>]
+issues: []                     # (optional) PR number(s); blank = auto-filled at release
 subtext:                       # optional extra detail
 user: <your-github-handle>     # rendered as "(@your-github-handle)"
 ```
 
 `change_type` keywords render under these sections: `breaking` → Breaking changes, `change` → Changes, `feature` → Features, `enhancement` → Enhancements, `bug_fix` → Bug fixes, `security` → Security.
+
+`issues` is optional: leave it blank and `chlog-update` backfills the PR number from the commit that adds the entry file at release time (see [`.chloggen/README.md`](./.chloggen/README.md) for details, including how this behaves on release branches).
 
 Validate and preview before pushing:
 

--- a/Makefile
+++ b/Makefile
@@ -431,5 +431,32 @@ tempo-mixin: tools-image
 tempo-mixin-check: tools-image
 	$(TOOLS_CMD) make -C operations/tempo-mixin check
 
+##@ Changelog
+
+# chloggen is vendored under tools/chloggen and built from the tools module.
+# It must run from the repo root so it can find .chloggen/ and CHANGELOG.md.
+CHLOGGEN ?= $(CURDIR)/bin/chloggen
+CHLOGGEN_CONFIG := .chloggen/config.yaml
+
+.PHONY: $(CHLOGGEN)
+$(CHLOGGEN):
+	cd $(CURDIR)/tools/chloggen && go build -o $(CHLOGGEN) .
+
+.PHONY: chlog-new
+chlog-new: $(CHLOGGEN) ## Create a new changelog entry under .chloggen/
+	$(CHLOGGEN) new --config $(CHLOGGEN_CONFIG)
+
+.PHONY: chlog-validate
+chlog-validate: $(CHLOGGEN) ## Validate the pending changelog entries
+	$(CHLOGGEN) validate --config $(CHLOGGEN_CONFIG)
+
+.PHONY: chlog-preview
+chlog-preview: $(CHLOGGEN) ## Render the pending changelog entries to stdout
+	$(CHLOGGEN) update --config $(CHLOGGEN_CONFIG) --dry
+
+.PHONY: chlog-update
+chlog-update: $(CHLOGGEN) ## Collate pending entries into CHANGELOG.md (VERSION=vX.Y.Z)
+	$(CHLOGGEN) update --config $(CHLOGGEN_CONFIG) --version "$(VERSION)"
+
 # Import fragments
 include build/tools.mk

--- a/Makefile
+++ b/Makefile
@@ -435,18 +435,26 @@ tempo-mixin-check: tools-image
 
 # chloggen is built from the tools module and run from the repo root so it can
 # find .chloggen/ and CHANGELOG.md. A .chloggen/config.yaml is used only if it
-# exists. Pass FILENAME=... to chlog-new and VERSION=vX.Y.Z to chlog-update.
+# exists. chlog-new defaults the entry filename to the current branch; override
+# with FILENAME=... . Pass VERSION=vX.Y.Z to chlog-update.
 CHLOGGEN ?= $(CURDIR)/bin/chloggen
 CHLOGGEN_CONFIG := .chloggen/config.yaml
 CHLOGGEN_CONFIG_ARG := $(if $(wildcard $(CHLOGGEN_CONFIG)),--config $(CHLOGGEN_CONFIG),)
+CHLOG_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
+CHLOG_FILENAME := $(if $(FILENAME),$(FILENAME),$(CHLOG_BRANCH))
 
 .PHONY: $(CHLOGGEN)
 $(CHLOGGEN):
 	cd $(CURDIR)/tools/chloggen && go build -o $(CHLOGGEN) .
 
 .PHONY: chlog-new
-chlog-new: $(CHLOGGEN) ## Create a new changelog entry under .chloggen/ (FILENAME=... optional)
-	$(CHLOGGEN) new $(CHLOGGEN_CONFIG_ARG) $(if $(FILENAME),--filename $(FILENAME))
+chlog-new: $(CHLOGGEN) ## Create a new changelog entry under .chloggen/ (defaults to branch name; override with FILENAME=...)
+	@if [ -z "$(CHLOG_FILENAME)" ] || [ "$(CHLOG_FILENAME)" = "HEAD" ] || \
+	    [ "$(CHLOG_FILENAME)" = "main" ] || [ "$(CHLOG_FILENAME)" = "master" ]; then \
+	  echo "Cannot default the changelog filename from branch '$(CHLOG_BRANCH)'; pass FILENAME=<name>."; \
+	  exit 1; \
+	fi
+	$(CHLOGGEN) new $(CHLOGGEN_CONFIG_ARG) --filename "$(CHLOG_FILENAME)"
 
 .PHONY: chlog-validate
 chlog-validate: $(CHLOGGEN) ## Validate the pending changelog entries

--- a/Makefile
+++ b/Makefile
@@ -433,30 +433,32 @@ tempo-mixin-check: tools-image
 
 ##@ Changelog
 
-# chloggen is vendored under tools/chloggen and built from the tools module.
-# It must run from the repo root so it can find .chloggen/ and CHANGELOG.md.
+# chloggen is built from the tools module and run from the repo root so it can
+# find .chloggen/ and CHANGELOG.md. A .chloggen/config.yaml is used only if it
+# exists. Pass FILENAME=... to chlog-new and VERSION=vX.Y.Z to chlog-update.
 CHLOGGEN ?= $(CURDIR)/bin/chloggen
 CHLOGGEN_CONFIG := .chloggen/config.yaml
+CHLOGGEN_CONFIG_ARG := $(if $(wildcard $(CHLOGGEN_CONFIG)),--config $(CHLOGGEN_CONFIG),)
 
 .PHONY: $(CHLOGGEN)
 $(CHLOGGEN):
 	cd $(CURDIR)/tools/chloggen && go build -o $(CHLOGGEN) .
 
 .PHONY: chlog-new
-chlog-new: $(CHLOGGEN) ## Create a new changelog entry under .chloggen/
-	$(CHLOGGEN) new --config $(CHLOGGEN_CONFIG)
+chlog-new: $(CHLOGGEN) ## Create a new changelog entry under .chloggen/ (FILENAME=... optional)
+	$(CHLOGGEN) new $(CHLOGGEN_CONFIG_ARG) $(if $(FILENAME),--filename $(FILENAME))
 
 .PHONY: chlog-validate
 chlog-validate: $(CHLOGGEN) ## Validate the pending changelog entries
-	$(CHLOGGEN) validate --config $(CHLOGGEN_CONFIG)
+	$(CHLOGGEN) validate $(CHLOGGEN_CONFIG_ARG)
 
 .PHONY: chlog-preview
 chlog-preview: $(CHLOGGEN) ## Render the pending changelog entries to stdout
-	$(CHLOGGEN) update --config $(CHLOGGEN_CONFIG) --dry
+	$(CHLOGGEN) update $(CHLOGGEN_CONFIG_ARG) --dry
 
 .PHONY: chlog-update
 chlog-update: $(CHLOGGEN) ## Collate pending entries into CHANGELOG.md (VERSION=vX.Y.Z)
-	$(CHLOGGEN) update --config $(CHLOGGEN_CONFIG) --version "$(VERSION)"
+	$(CHLOGGEN) update $(CHLOGGEN_CONFIG_ARG) --version "$(VERSION)"
 
 # Import fragments
 include build/tools.mk

--- a/RELEASES.MD
+++ b/RELEASES.MD
@@ -1,7 +1,9 @@
 # Release Candidates
 
-- Create a branch named `changelog-<version>-<rc.#>`. Clean up the changelog, add the version heading
-  and merge to main. 
+- Create a branch named `changelog-<version>-<rc.#>`. Generate the changelog section from the
+  `.chloggen/` entries by running `make chlog-update VERSION=v<version>-<rc.#>` (this collates the
+  entries into `CHANGELOG.md` under the version heading and deletes the consumed files). Review the
+  result, then merge to main.
 - Push a semver tag to main on the merge commit above.  Something like:
   - `git tag -a v1.2.0-rc.0`
   - `git push origin v1.2.0-rc.0`
@@ -27,10 +29,10 @@ This document details release procedures for Tempo.
     - `git tag -a v1.2.0`
     - `git push origin v1.2.0`
   - Make sure that the "This is a pre-release" is unchecked when publishing the release.
-- Submit a PR cleaning up the changelog and moving everything under "main/unreleased" to be under
-  the newly minted version.
-  - Given that the changelog was already cleaned up for the RC above. This will likely be simply
-    renaming the release candidate to the full version.
+- Submit a PR updating the changelog for the full version. Because the RC above already ran
+  `make chlog-update` (consuming the `.chloggen/` entries), this is usually just renaming the
+  `# v<version>-<rc.#>` heading in `CHANGELOG.md` to the final `# v<version>`. If new entries landed
+  since the RC, run `make chlog-update VERSION=v<version>` instead to collate them.
 - Update the tempo image tag in example configs and operations files, then regenerate compiled jsonnet.
   Run `make bump-tempo-image-tag TEMPO_IMAGE_TAG=X.Y.Z && make jsonnet` and open a PR to the release
   branch. This is intentionally done before tagging so that users referencing the examples or docs
@@ -57,8 +59,9 @@ You need to cherry-pick each commit and open a PR to be merged into the release 
   `git cherry-pick <commit hash>`
 
 ## 3. Update the changelog
-- Verify all backported fixes have entries in the CHANGELOG. Cross-reference the commits on the release branch since the last tag (`git log --oneline $(git describe --tags --abbrev=0)..release-vX.Y`) against the CHANGELOG entries.
-- Add any missing entries and update the heading from `main / unreleased` to the new patch version (e.g. `v2.10.1`).
+- Verify all backported fixes have a `.chloggen/` entry on the release branch. Cross-reference the commits since the last tag (`git log --oneline $(git describe --tags --abbrev=0)..release-vX.Y`) against the entries in `.chloggen/`.
+- Add any missing entries with `make chlog-new`.
+- Generate the release section: `make chlog-update VERSION=vX.Y.Z` (e.g. `v2.10.1`). This collates all `.chloggen/*.yaml` files into `CHANGELOG.md` under the new version heading and deletes the consumed entry files.
 - Open a PR with the changelog update to the release branch.
 
 ## 4. Update the tempo image tag
@@ -91,4 +94,4 @@ Check that all workflows triggered by the tag succeeded:
 In [GitHub Releases](https://github.com/grafana/tempo/releases) there should be a "Draft" release. Add the changelog entries to the release notes. Make sure "Set as the latest release" is checked and hit "Publish release".
 
 ## 8. Submit a changelog PR to main
-Submit a PR to `main` moving the relevant entries from "main/unreleased" to be under the newly minted version.
+Submit a PR to `main` adding the new version's section to `CHANGELOG.md` so the released notes are reflected on `main`. Either cherry-pick the changelog commit from the release branch (step 3), or run `make chlog-update VERSION=vX.Y.Z` against the corresponding `.chloggen/` entries on `main`.

--- a/tools/chloggen/FORK.md
+++ b/tools/chloggen/FORK.md
@@ -1,0 +1,13 @@
+# chloggen — attribution
+
+Tempo's in-tree tool for managing `CHANGELOG.md` from per-PR entry files. It is
+part of the `tools` module and is maintained directly in this repository.
+
+The code originates from the OpenTelemetry `chloggen` tool
+(https://github.com/open-telemetry/opentelemetry-go-build-tools/tree/main/chloggen)
+and is **not** synced with upstream.
+
+- License: Apache-2.0 (see `LICENSE`). The OpenTelemetry copyright headers on
+  each `.go` file are retained as required by the license.
+- Modified for Tempo (import paths, formatting, and ongoing changes); details
+  are tracked in Tempo's git history.

--- a/tools/chloggen/LICENSE
+++ b/tools/chloggen/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/tools/chloggen/README.md
+++ b/tools/chloggen/README.md
@@ -1,0 +1,17 @@
+# Changelog generator
+
+Tool that can be used to generate a CHANGELOG file from individual change
+files written in YAML.
+
+Usage:
+
+```sh
+    # generates a new change YAML file from a template
+    chloggen new -filename <filename>
+    # validates all change YAML files
+    chloggen validate
+    # provide a preview of the generated changelog file
+    chloggen update -dry
+    # updates the changelog file
+    chloggen update -version <version>
+```

--- a/tools/chloggen/cmd/cmd_test.go
+++ b/tools/chloggen/cmd/cmd_test.go
@@ -47,6 +47,7 @@ func enhancementEntry() *chlog.Entry {
 		Component:  "receiver/foo",
 		Note:       "Add some bar",
 		Issues:     []int{12345},
+		User:       "octocat",
 	}
 }
 
@@ -56,6 +57,7 @@ func bugFixEntry() *chlog.Entry {
 		Component:  "testbed",
 		Note:       "Fix blah",
 		Issues:     []int{12346, 12347},
+		User:       "octocat",
 	}
 }
 
@@ -65,6 +67,7 @@ func deprecationEntry() *chlog.Entry {
 		Component:  "exporter/old",
 		Note:       "Deprecate old",
 		Issues:     []int{12348},
+		User:       "octocat",
 	}
 }
 
@@ -74,6 +77,7 @@ func newComponentEntry() *chlog.Entry {
 		Component:  "exporter/new",
 		Note:       "Add new exporter ...",
 		Issues:     []int{12349},
+		User:       "octocat",
 	}
 }
 
@@ -83,6 +87,7 @@ func breakingEntry() *chlog.Entry {
 		Component:  "processor/oops",
 		Note:       "Change behavior when ...",
 		Issues:     []int{12350},
+		User:       "octocat",
 	}
 }
 
@@ -95,6 +100,7 @@ func entryWithSubtext() *chlog.Entry {
 		Note:       "Change behavior when ...",
 		Issues:     []int{12350},
 		SubText:    strings.Join(lines, "\n"),
+		User:       "octocat",
 	}
 }
 
@@ -109,6 +115,7 @@ func entryForChangelogs(changeType string, issue int, keys ...string) *chlog.Ent
 		Component:  "receiver/foo",
 		Note:       fmt.Sprintf("Some change relevant to [%s]", keyStr),
 		Issues:     []int{issue},
+		User:       "octocat",
 	}
 }
 

--- a/tools/chloggen/cmd/cmd_test.go
+++ b/tools/chloggen/cmd/cmd_test.go
@@ -1,0 +1,167 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/grafana/tempo/tools/chloggen/internal/chlog"
+	"github.com/grafana/tempo/tools/chloggen/internal/config"
+)
+
+func getSampleEntries() []*chlog.Entry {
+	return []*chlog.Entry{
+		enhancementEntry(),
+		bugFixEntry(),
+		deprecationEntry(),
+		newComponentEntry(),
+		breakingEntry(),
+		entryWithSubtext(),
+	}
+}
+
+func enhancementEntry() *chlog.Entry {
+	return &chlog.Entry{
+		ChangeType: chlog.Enhancement,
+		Component:  "receiver/foo",
+		Note:       "Add some bar",
+		Issues:     []int{12345},
+	}
+}
+
+func bugFixEntry() *chlog.Entry {
+	return &chlog.Entry{
+		ChangeType: chlog.BugFix,
+		Component:  "testbed",
+		Note:       "Fix blah",
+		Issues:     []int{12346, 12347},
+	}
+}
+
+func deprecationEntry() *chlog.Entry {
+	return &chlog.Entry{
+		ChangeType: chlog.Deprecation,
+		Component:  "exporter/old",
+		Note:       "Deprecate old",
+		Issues:     []int{12348},
+	}
+}
+
+func newComponentEntry() *chlog.Entry {
+	return &chlog.Entry{
+		ChangeType: chlog.NewComponent,
+		Component:  "exporter/new",
+		Note:       "Add new exporter ...",
+		Issues:     []int{12349},
+	}
+}
+
+func breakingEntry() *chlog.Entry {
+	return &chlog.Entry{
+		ChangeType: chlog.Breaking,
+		Component:  "processor/oops",
+		Note:       "Change behavior when ...",
+		Issues:     []int{12350},
+	}
+}
+
+func entryWithSubtext() *chlog.Entry {
+	lines := []string{"- foo\n  - bar\n- blah\n  - 1234567"}
+
+	return &chlog.Entry{
+		ChangeType: chlog.Breaking,
+		Component:  "processor/oops",
+		Note:       "Change behavior when ...",
+		Issues:     []int{12350},
+		SubText:    strings.Join(lines, "\n"),
+	}
+}
+
+func entryForChangelogs(changeType string, issue int, keys ...string) *chlog.Entry {
+	keyStr := "default"
+	if len(keys) > 0 {
+		keyStr = strings.Join(keys, ",")
+	}
+	return &chlog.Entry{
+		ChangeLogs: keys,
+		ChangeType: changeType,
+		Component:  "receiver/foo",
+		Note:       fmt.Sprintf("Some change relevant to [%s]", keyStr),
+		Issues:     []int{issue},
+	}
+}
+
+func setupTestDir(t *testing.T, entries []*chlog.Entry) {
+	require.NotNil(t, globalCfg, "test should instantiate globalCfg before calling setupTestDir")
+
+	// Create dummy changelogs which may be updated by the test
+	changelogBytes, err := readBytes(filepath.Join("testdata", config.DefaultChangeLogFilename))
+	require.NoError(t, err)
+	for _, filename := range globalCfg.ChangeLogs {
+		require.NoError(t, os.MkdirAll(filepath.Dir(filename), os.FileMode(0o755)))
+		require.NoError(t, os.WriteFile(filename, changelogBytes, os.FileMode(0o755)))
+	}
+
+	// Create the entries directory
+	require.NoError(t, os.MkdirAll(globalCfg.EntriesDir, os.FileMode(0o755)))
+
+	// Copy the entry template, for tests that ensure it is not deleted
+	templateInRootDir := config.New("testdata").TemplateYAML
+	templateBytes, err := readBytes(filepath.Clean(templateInRootDir))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(globalCfg.TemplateYAML, templateBytes, os.FileMode(0o755)))
+
+	// Write the entries to the entries directory
+	for i, entry := range entries {
+		entryBytes, err := yaml.Marshal(entry)
+		require.NoError(t, err)
+		path := filepath.Join(globalCfg.EntriesDir, fmt.Sprintf("%d.yaml", i))
+		require.NoError(t, os.WriteFile(path, entryBytes, os.FileMode(0o755)))
+	}
+}
+
+func runCobra(t *testing.T, args ...string) (string, error) {
+	cmd := rootCmd()
+
+	outBytes := bytes.NewBufferString("")
+	cmd.SetOut(outBytes)
+
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+
+	out, ioErr := io.ReadAll(outBytes)
+	require.NoError(t, ioErr, "read stdout")
+
+	return string(out), err
+}
+
+func readBytes(path string) ([]byte, error) {
+	file, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	return io.ReadAll(file)
+}

--- a/tools/chloggen/cmd/new.go
+++ b/tools/chloggen/cmd/new.go
@@ -1,0 +1,79 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var filename string
+
+func newCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "new",
+		Short: "Creates new change file",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			sanitizedName := filepath.Base(cleanFileName(filename))
+			if sanitizedName == "." || sanitizedName == ".." || sanitizedName == "" {
+				return fmt.Errorf("invalid filename %q", filename)
+			}
+
+			path := filepath.Join(globalCfg.EntriesDir, sanitizedName)
+			var pathWithExt string
+			switch ext := filepath.Ext(path); ext {
+			case ".yaml":
+				pathWithExt = path
+			case ".yml":
+				pathWithExt = strings.TrimSuffix(path, ".yml") + ".yaml"
+			default:
+				pathWithExt = path + ".yaml"
+			}
+
+			templateFile, err := os.Open(filepath.Clean(globalCfg.TemplateYAML))
+			if err != nil {
+				return err
+			}
+			defer templateFile.Close()
+
+			templateBytes, err := io.ReadAll(templateFile)
+			if err != nil {
+				return err
+			}
+			err = os.WriteFile(filepath.Clean(pathWithExt), templateBytes, os.FileMode(0o644))
+			if err != nil {
+				return err
+			}
+			cmd.Printf("Changelog entry template copied to: %s\n", pathWithExt)
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&filename, "filename", "f", "", "name of the file to add")
+	if err := cmd.MarkFlagRequired("filename"); err != nil {
+		cmd.PrintErrf("could not mark filename flag as required: %v", err)
+		os.Exit(1)
+	}
+	return cmd
+}
+
+func cleanFileName(filename string) string {
+	replace := strings.NewReplacer("/", "_", "\\", "_")
+	return replace.Replace(filename)
+}

--- a/tools/chloggen/cmd/new_test.go
+++ b/tools/chloggen/cmd/new_test.go
@@ -1,0 +1,91 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/tempo/tools/chloggen/internal/chlog"
+	"github.com/grafana/tempo/tools/chloggen/internal/config"
+)
+
+const newUsage = `Usage:
+  chloggen new [flags]
+
+Flags:
+  -f, --filename string   name of the file to add
+  -h, --help              help for new
+
+Global Flags:
+      --config string   (optional) chloggen config file`
+
+func TestNewErr(t *testing.T) {
+	var out string
+	var err error
+
+	out, err = runCobra(t, "new", "--help")
+	assert.Contains(t, out, newUsage)
+	assert.Empty(t, err)
+
+	out, err = runCobra(t, "new")
+	assert.Contains(t, out, newUsage)
+	assert.ErrorContains(t, err, `required flag(s) "filename" not set`)
+
+	out, err = runCobra(t, "new", "--filename", "my-change")
+	assert.Contains(t, out, newUsage)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+}
+
+func TestNew(t *testing.T) {
+	globalCfg = config.New(t.TempDir())
+	setupTestDir(t, []*chlog.Entry{})
+
+	var out string
+	var err error
+
+	out, err = runCobra(t, "new", "--filename", "my-change")
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.EntriesDir, "my-change.yaml")))
+	assert.Empty(t, err)
+
+	out, err = runCobra(t, "new", "--filename", "some-change.yaml")
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.EntriesDir, "some-change.yaml")))
+	assert.Empty(t, err)
+
+	out, err = runCobra(t, "new", "--filename", "some-change.yml")
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.EntriesDir, "some-change.yaml")))
+	assert.Empty(t, err)
+
+	out, err = runCobra(t, "new", "--filename", "replace/forward/slash")
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.EntriesDir, "replace_forward_slash.yaml")))
+	assert.Empty(t, err)
+
+	out, err = runCobra(t, "new", "--filename", "not.an.extension")
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.EntriesDir, "not.an.extension.yaml")))
+	assert.Empty(t, err)
+
+	out, err = runCobra(t, "new", "--filename", "my-change.txt")
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.EntriesDir, "my-change.txt.yaml")))
+	assert.Empty(t, err)
+}
+
+func TestCleanFilename(t *testing.T) {
+	assert.Equal(t, "fix_some_bug", cleanFileName("fix/some_bug"))
+	assert.Equal(t, "fix_some_bug", cleanFileName("fix\\some_bug"))
+}

--- a/tools/chloggen/cmd/root.go
+++ b/tools/chloggen/cmd/root.go
@@ -1,0 +1,80 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cmd provides the command line interface for the chloggen tool.
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/grafana/tempo/tools/chloggen/internal/config"
+)
+
+var (
+	configFile string
+	globalCfg  *config.Config
+)
+
+func rootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "chloggen",
+		Short: "Updates CHANGELOG.MD to include all new changes",
+		Long:  `chloggen is a tool used to automate the generation of CHANGELOG files using individual yaml files as the source.`,
+	}
+	cmd.SetOut(os.Stdout)
+	cmd.PersistentFlags().StringVar(&configFile, "config", "", "(optional) chloggen config file")
+	cmd.AddCommand(newCmd())
+	cmd.AddCommand(updateCmd())
+	cmd.AddCommand(validateCmd())
+	return cmd
+}
+
+// Execute executes the root command.
+func Execute() {
+	cobra.CheckErr(rootCmd().Execute())
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+}
+
+func initConfig() {
+	// Don't override if already set in tests
+	if globalCfg != nil {
+		return
+	}
+
+	if configFile == "" {
+		globalCfg = config.New(repoRoot())
+	} else {
+		var err error
+		globalCfg, err = config.NewFromFile(repoRoot(), configFile)
+		if err != nil {
+			fmt.Printf("FAIL: Could not load config file: %s\n", err.Error())
+			os.Exit(1)
+		}
+	}
+}
+
+func repoRoot() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		// This is not expected, but just in case
+		fmt.Println("FAIL: Could not determine current working directory")
+	}
+	return dir
+}

--- a/tools/chloggen/cmd/root_test.go
+++ b/tools/chloggen/cmd/root_test.go
@@ -1,0 +1,60 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const rootUsage = `chloggen is a tool used to automate the generation of CHANGELOG files using individual yaml files as the source.
+
+Usage:
+  chloggen [command]
+
+Available Commands:
+  completion  Generate the autocompletion script for the specified shell
+  help        Help about any command
+  new         Creates new change file
+  update      Updates CHANGELOG.MD to include all new changes
+  validate    Validates the files in the changelog directory
+
+Flags:
+      --config string   (optional) chloggen config file
+  -h, --help            help for chloggen
+
+Use "chloggen [command] --help" for more information about a command.`
+
+func TestRoot(t *testing.T) {
+	var out string
+	var err error
+
+	out, err = runCobra(t)
+	assert.Contains(t, out, rootUsage)
+	assert.Empty(t, err)
+
+	out, err = runCobra(t, "--help")
+	assert.Contains(t, out, rootUsage)
+	assert.Empty(t, err)
+
+	out, err = runCobra(t, "--config", "foo.yaml")
+	assert.Contains(t, out, rootUsage)
+	assert.Empty(t, err)
+}
+
+func TestRepoRoot(t *testing.T) {
+	assert.DirExists(t, repoRoot())
+}

--- a/tools/chloggen/cmd/testdata/.chloggen/TEMPLATE.yaml
+++ b/tools/chloggen/cmd/testdata/.chloggen/TEMPLATE.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type:
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component:
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/tools/chloggen/cmd/testdata/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/all_change_types/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/all_change_types/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🛑 Breaking changes 🛑
+
+- `processor/oops`: Change behavior when ... (#12350)
+- `processor/oops`: Change behavior when ... (#12350)
+  - foo
+    - bar
+  - blah
+    - 1234567
+
+### 🚩 Deprecations 🚩
+
+- `exporter/old`: Deprecate old (#12348)
+
+### 🚀 New components 🚀
+
+- `exporter/new`: Add new exporter ... (#12349)
+
+### 💡 Enhancements 💡
+
+- `receiver/foo`: Add some bar (#12345)
+
+### 🧰 Bug fixes 🧰
+
+- `testbed`: Fix blah (#12346, #12347)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/all_change_types/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/all_change_types/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `processor/oops`: Change behavior when ... (#12350)
-- `processor/oops`: Change behavior when ... (#12350)
+- `processor/oops`: Change behavior when ... (#12350) (@octocat)
+- `processor/oops`: Change behavior when ... (#12350) (@octocat)
   - foo
     - bar
   - blah
@@ -15,19 +15,19 @@
 
 ### 🚩 Deprecations 🚩
 
-- `exporter/old`: Deprecate old (#12348)
+- `exporter/old`: Deprecate old (#12348) (@octocat)
 
 ### 🚀 New components 🚀
 
-- `exporter/new`: Add new exporter ... (#12349)
+- `exporter/new`: Add new exporter ... (#12349) (@octocat)
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Add some bar (#12345)
+- `receiver/foo`: Add some bar (#12345) (@octocat)
 
 ### 🧰 Bug fixes 🧰
 
-- `testbed`: Fix blah (#12346, #12347)
+- `testbed`: Fix blah (#12346, #12347) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/all_change_types_alphabetical/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/all_change_types_alphabetical/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 💡 Enhancements 💡
+
+- `receiver/a`: Some change (#1)
+- `receiver/aa`: Some other change for aa (#2)
+- `receiver/b`: Some other change (#3)
+- `receiver/bb`: One more bb change (#4)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/all_change_types_alphabetical/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/all_change_types_alphabetical/CHANGELOG.md
@@ -6,10 +6,10 @@
 
 ### 💡 Enhancements 💡
 
-- `receiver/a`: Some change (#1)
-- `receiver/aa`: Some other change for aa (#2)
-- `receiver/b`: Some other change (#3)
-- `receiver/bb`: One more bb change (#4)
+- `receiver/a`: Some change (#1) (@octocat)
+- `receiver/aa`: Some other change for aa (#2) (@octocat)
+- `receiver/b`: Some other change (#3) (@octocat)
+- `receiver/bb`: One more bb change (#4) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/all_change_types_multiple/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/all_change_types_multiple/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🛑 Breaking changes 🛑
+
+- `processor/oops`: Change behavior when ... (#12350)
+- `processor/oops`: Change behavior when ... (#12350)
+  - foo
+    - bar
+  - blah
+    - 1234567
+- `processor/oops`: Change behavior when ... (#12350)
+- `processor/oops`: Change behavior when ... (#12350)
+  - foo
+    - bar
+  - blah
+    - 1234567
+
+### 🚩 Deprecations 🚩
+
+- `exporter/old`: Deprecate old (#12348)
+- `exporter/old`: Deprecate old (#12348)
+
+### 🚀 New components 🚀
+
+- `exporter/new`: Add new exporter ... (#12349)
+- `exporter/new`: Add new exporter ... (#12349)
+
+### 💡 Enhancements 💡
+
+- `receiver/foo`: Add some bar (#12345)
+- `receiver/foo`: Add some bar (#12345)
+
+### 🧰 Bug fixes 🧰
+
+- `testbed`: Fix blah (#12346, #12347)
+- `testbed`: Fix blah (#12346, #12347)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/all_change_types_multiple/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/all_change_types_multiple/CHANGELOG.md
@@ -6,14 +6,14 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `processor/oops`: Change behavior when ... (#12350)
-- `processor/oops`: Change behavior when ... (#12350)
+- `processor/oops`: Change behavior when ... (#12350) (@octocat)
+- `processor/oops`: Change behavior when ... (#12350) (@octocat)
   - foo
     - bar
   - blah
     - 1234567
-- `processor/oops`: Change behavior when ... (#12350)
-- `processor/oops`: Change behavior when ... (#12350)
+- `processor/oops`: Change behavior when ... (#12350) (@octocat)
+- `processor/oops`: Change behavior when ... (#12350) (@octocat)
   - foo
     - bar
   - blah
@@ -21,23 +21,23 @@
 
 ### 🚩 Deprecations 🚩
 
-- `exporter/old`: Deprecate old (#12348)
-- `exporter/old`: Deprecate old (#12348)
+- `exporter/old`: Deprecate old (#12348) (@octocat)
+- `exporter/old`: Deprecate old (#12348) (@octocat)
 
 ### 🚀 New components 🚀
 
-- `exporter/new`: Add new exporter ... (#12349)
-- `exporter/new`: Add new exporter ... (#12349)
+- `exporter/new`: Add new exporter ... (#12349) (@octocat)
+- `exporter/new`: Add new exporter ... (#12349) (@octocat)
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Add some bar (#12345)
-- `receiver/foo`: Add some bar (#12345)
+- `receiver/foo`: Add some bar (#12345) (@octocat)
+- `receiver/foo`: Add some bar (#12345) (@octocat)
 
 ### 🧰 Bug fixes 🧰
 
-- `testbed`: Fix blah (#12346, #12347)
-- `testbed`: Fix blah (#12346, #12347)
+- `testbed`: Fix blah (#12346, #12347) (@octocat)
+- `testbed`: Fix blah (#12346, #12347) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/breaking_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/breaking_only/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🛑 Breaking changes 🛑
+
+- `processor/oops`: Change behavior when ... (#12350)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/breaking_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/breaking_only/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `processor/oops`: Change behavior when ... (#12350)
+- `processor/oops`: Change behavior when ... (#12350) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/bug_fix_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/bug_fix_only/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🧰 Bug fixes 🧰
+
+- `testbed`: Fix blah (#12346, #12347)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/bug_fix_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/bug_fix_only/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🧰 Bug fixes 🧰
 
-- `testbed`: Fix blah (#12346, #12347)
+- `testbed`: Fix blah (#12346, #12347) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/deprecation_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/deprecation_only/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🚩 Deprecations 🚩
+
+- `exporter/old`: Deprecate old (#12348)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/deprecation_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/deprecation_only/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🚩 Deprecations 🚩
 
-- `exporter/old`: Deprecate old (#12348)
+- `exporter/old`: Deprecate old (#12348) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/dry_run/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/dry_run/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/enhancement_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/enhancement_only/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 💡 Enhancements 💡
+
+- `receiver/foo`: Add some bar (#12345)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/enhancement_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/enhancement_only/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Add some bar (#12345)
+- `receiver/foo`: Add some bar (#12345) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/filter_component/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/filter_component/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 💡 Enhancements 💡
+
+- `receiver/foo`: Some change (#1)
+- `receiver/foo`: One more foo change (#4)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/filter_component/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/filter_component/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Some change (#1)
-- `receiver/foo`: One more foo change (#4)
+- `receiver/foo`: Some change (#1) (@octocat)
+- `receiver/foo`: One more foo change (#4) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/filter_component_no_match/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/filter_component_no_match/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/multiple_changelogs/CHANGELOG-API.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs/CHANGELOG-API.md
@@ -1,0 +1,40 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🛑 Breaking changes 🛑
+
+- `receiver/foo`: Some change relevant to [api] (#125)
+- `receiver/foo`: Some change relevant to [user,api] (#11)
+
+### 🚩 Deprecations 🚩
+
+- `receiver/foo`: Some change relevant to [api] (#223)
+- `receiver/foo`: Some change relevant to [user,api] (#234)
+
+### 💡 Enhancements 💡
+
+- `receiver/foo`: Some change relevant to [api,user] (#333)
+- `receiver/foo`: Some change relevant to [api] (#555)
+
+### 🧰 Bug fixes 🧰
+
+- `receiver/foo`: Some change relevant to [api] (#111)
+- `receiver/foo`: Some change relevant to [api] (#777)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/multiple_changelogs/CHANGELOG-API.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs/CHANGELOG-API.md
@@ -6,23 +6,23 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `receiver/foo`: Some change relevant to [api] (#125)
-- `receiver/foo`: Some change relevant to [user,api] (#11)
+- `receiver/foo`: Some change relevant to [api] (#125) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#11) (@octocat)
 
 ### 🚩 Deprecations 🚩
 
-- `receiver/foo`: Some change relevant to [api] (#223)
-- `receiver/foo`: Some change relevant to [user,api] (#234)
+- `receiver/foo`: Some change relevant to [api] (#223) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#234) (@octocat)
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Some change relevant to [api,user] (#333)
-- `receiver/foo`: Some change relevant to [api] (#555)
+- `receiver/foo`: Some change relevant to [api,user] (#333) (@octocat)
+- `receiver/foo`: Some change relevant to [api] (#555) (@octocat)
 
 ### 🧰 Bug fixes 🧰
 
-- `receiver/foo`: Some change relevant to [api] (#111)
-- `receiver/foo`: Some change relevant to [api] (#777)
+- `receiver/foo`: Some change relevant to [api] (#111) (@octocat)
+- `receiver/foo`: Some change relevant to [api] (#777) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/multiple_changelogs/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🛑 Breaking changes 🛑
+
+- `receiver/foo`: Some change relevant to [user,api] (#11)
+
+### 🚩 Deprecations 🚩
+
+- `receiver/foo`: Some change relevant to [user] (#123)
+- `receiver/foo`: Some change relevant to [user,api] (#234)
+
+### 💡 Enhancements 💡
+
+- `receiver/foo`: Some change relevant to [user] (#21)
+- `receiver/foo`: Some change relevant to [api,user] (#333)
+
+### 🧰 Bug fixes 🧰
+
+- `receiver/foo`: Some change relevant to [user] (#32)
+- `receiver/foo`: Some change relevant to [user] (#222)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/multiple_changelogs/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs/CHANGELOG.md
@@ -6,22 +6,22 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `receiver/foo`: Some change relevant to [user,api] (#11)
+- `receiver/foo`: Some change relevant to [user,api] (#11) (@octocat)
 
 ### 🚩 Deprecations 🚩
 
-- `receiver/foo`: Some change relevant to [user] (#123)
-- `receiver/foo`: Some change relevant to [user,api] (#234)
+- `receiver/foo`: Some change relevant to [user] (#123) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#234) (@octocat)
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Some change relevant to [user] (#21)
-- `receiver/foo`: Some change relevant to [api,user] (#333)
+- `receiver/foo`: Some change relevant to [user] (#21) (@octocat)
+- `receiver/foo`: Some change relevant to [api,user] (#333) (@octocat)
 
 ### 🧰 Bug fixes 🧰
 
-- `receiver/foo`: Some change relevant to [user] (#32)
-- `receiver/foo`: Some change relevant to [user] (#222)
+- `receiver/foo`: Some change relevant to [user] (#32) (@octocat)
+- `receiver/foo`: Some change relevant to [user] (#222) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/multiple_changelogs_multiple_defaults/CHANGELOG-API.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs_multiple_defaults/CHANGELOG-API.md
@@ -1,0 +1,44 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🛑 Breaking changes 🛑
+
+- `receiver/foo`: Some change relevant to [api] (#125)
+- `receiver/foo`: Some change relevant to [user,api] (#11)
+
+### 🚩 Deprecations 🚩
+
+- `receiver/foo`: Some change relevant to [default] (#123)
+- `receiver/foo`: Some change relevant to [api] (#223)
+- `receiver/foo`: Some change relevant to [user,api] (#234)
+
+### 💡 Enhancements 💡
+
+- `receiver/foo`: Some change relevant to [default] (#21)
+- `receiver/foo`: Some change relevant to [api,user] (#333)
+- `receiver/foo`: Some change relevant to [api] (#555)
+
+### 🧰 Bug fixes 🧰
+
+- `receiver/foo`: Some change relevant to [default] (#32)
+- `receiver/foo`: Some change relevant to [default] (#222)
+- `receiver/foo`: Some change relevant to [api] (#111)
+- `receiver/foo`: Some change relevant to [api] (#777)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/multiple_changelogs_multiple_defaults/CHANGELOG-API.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs_multiple_defaults/CHANGELOG-API.md
@@ -6,27 +6,27 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `receiver/foo`: Some change relevant to [api] (#125)
-- `receiver/foo`: Some change relevant to [user,api] (#11)
+- `receiver/foo`: Some change relevant to [api] (#125) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#11) (@octocat)
 
 ### 🚩 Deprecations 🚩
 
-- `receiver/foo`: Some change relevant to [default] (#123)
-- `receiver/foo`: Some change relevant to [api] (#223)
-- `receiver/foo`: Some change relevant to [user,api] (#234)
+- `receiver/foo`: Some change relevant to [default] (#123) (@octocat)
+- `receiver/foo`: Some change relevant to [api] (#223) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#234) (@octocat)
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Some change relevant to [default] (#21)
-- `receiver/foo`: Some change relevant to [api,user] (#333)
-- `receiver/foo`: Some change relevant to [api] (#555)
+- `receiver/foo`: Some change relevant to [default] (#21) (@octocat)
+- `receiver/foo`: Some change relevant to [api,user] (#333) (@octocat)
+- `receiver/foo`: Some change relevant to [api] (#555) (@octocat)
 
 ### 🧰 Bug fixes 🧰
 
-- `receiver/foo`: Some change relevant to [default] (#32)
-- `receiver/foo`: Some change relevant to [default] (#222)
-- `receiver/foo`: Some change relevant to [api] (#111)
-- `receiver/foo`: Some change relevant to [api] (#777)
+- `receiver/foo`: Some change relevant to [default] (#32) (@octocat)
+- `receiver/foo`: Some change relevant to [default] (#222) (@octocat)
+- `receiver/foo`: Some change relevant to [api] (#111) (@octocat)
+- `receiver/foo`: Some change relevant to [api] (#777) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/multiple_changelogs_multiple_defaults/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs_multiple_defaults/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🛑 Breaking changes 🛑
+
+- `receiver/foo`: Some change relevant to [user,api] (#11)
+
+### 🚩 Deprecations 🚩
+
+- `receiver/foo`: Some change relevant to [default] (#123)
+- `receiver/foo`: Some change relevant to [user,api] (#234)
+
+### 💡 Enhancements 💡
+
+- `receiver/foo`: Some change relevant to [default] (#21)
+- `receiver/foo`: Some change relevant to [api,user] (#333)
+
+### 🧰 Bug fixes 🧰
+
+- `receiver/foo`: Some change relevant to [default] (#32)
+- `receiver/foo`: Some change relevant to [default] (#222)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/multiple_changelogs_multiple_defaults/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs_multiple_defaults/CHANGELOG.md
@@ -6,22 +6,22 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `receiver/foo`: Some change relevant to [user,api] (#11)
+- `receiver/foo`: Some change relevant to [user,api] (#11) (@octocat)
 
 ### 🚩 Deprecations 🚩
 
-- `receiver/foo`: Some change relevant to [default] (#123)
-- `receiver/foo`: Some change relevant to [user,api] (#234)
+- `receiver/foo`: Some change relevant to [default] (#123) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#234) (@octocat)
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Some change relevant to [default] (#21)
-- `receiver/foo`: Some change relevant to [api,user] (#333)
+- `receiver/foo`: Some change relevant to [default] (#21) (@octocat)
+- `receiver/foo`: Some change relevant to [api,user] (#333) (@octocat)
 
 ### 🧰 Bug fixes 🧰
 
-- `receiver/foo`: Some change relevant to [default] (#32)
-- `receiver/foo`: Some change relevant to [default] (#222)
+- `receiver/foo`: Some change relevant to [default] (#32) (@octocat)
+- `receiver/foo`: Some change relevant to [default] (#222) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/multiple_changelogs_single_default/CHANGELOG-API.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs_single_default/CHANGELOG-API.md
@@ -1,0 +1,40 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🛑 Breaking changes 🛑
+
+- `receiver/foo`: Some change relevant to [api] (#125)
+- `receiver/foo`: Some change relevant to [user,api] (#11)
+
+### 🚩 Deprecations 🚩
+
+- `receiver/foo`: Some change relevant to [api] (#223)
+- `receiver/foo`: Some change relevant to [user,api] (#234)
+
+### 💡 Enhancements 💡
+
+- `receiver/foo`: Some change relevant to [api,user] (#333)
+- `receiver/foo`: Some change relevant to [api] (#555)
+
+### 🧰 Bug fixes 🧰
+
+- `receiver/foo`: Some change relevant to [api] (#111)
+- `receiver/foo`: Some change relevant to [api] (#777)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/multiple_changelogs_single_default/CHANGELOG-API.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs_single_default/CHANGELOG-API.md
@@ -6,23 +6,23 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `receiver/foo`: Some change relevant to [api] (#125)
-- `receiver/foo`: Some change relevant to [user,api] (#11)
+- `receiver/foo`: Some change relevant to [api] (#125) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#11) (@octocat)
 
 ### 🚩 Deprecations 🚩
 
-- `receiver/foo`: Some change relevant to [api] (#223)
-- `receiver/foo`: Some change relevant to [user,api] (#234)
+- `receiver/foo`: Some change relevant to [api] (#223) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#234) (@octocat)
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Some change relevant to [api,user] (#333)
-- `receiver/foo`: Some change relevant to [api] (#555)
+- `receiver/foo`: Some change relevant to [api,user] (#333) (@octocat)
+- `receiver/foo`: Some change relevant to [api] (#555) (@octocat)
 
 ### 🧰 Bug fixes 🧰
 
-- `receiver/foo`: Some change relevant to [api] (#111)
-- `receiver/foo`: Some change relevant to [api] (#777)
+- `receiver/foo`: Some change relevant to [api] (#111) (@octocat)
+- `receiver/foo`: Some change relevant to [api] (#777) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/multiple_changelogs_single_default/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs_single_default/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🛑 Breaking changes 🛑
+
+- `receiver/foo`: Some change relevant to [user,api] (#11)
+
+### 🚩 Deprecations 🚩
+
+- `receiver/foo`: Some change relevant to [default] (#123)
+- `receiver/foo`: Some change relevant to [user,api] (#234)
+
+### 💡 Enhancements 💡
+
+- `receiver/foo`: Some change relevant to [default] (#21)
+- `receiver/foo`: Some change relevant to [api,user] (#333)
+
+### 🧰 Bug fixes 🧰
+
+- `receiver/foo`: Some change relevant to [default] (#32)
+- `receiver/foo`: Some change relevant to [default] (#222)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/multiple_changelogs_single_default/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs_single_default/CHANGELOG.md
@@ -6,22 +6,22 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `receiver/foo`: Some change relevant to [user,api] (#11)
+- `receiver/foo`: Some change relevant to [user,api] (#11) (@octocat)
 
 ### 🚩 Deprecations 🚩
 
-- `receiver/foo`: Some change relevant to [default] (#123)
-- `receiver/foo`: Some change relevant to [user,api] (#234)
+- `receiver/foo`: Some change relevant to [default] (#123) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#234) (@octocat)
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Some change relevant to [default] (#21)
-- `receiver/foo`: Some change relevant to [api,user] (#333)
+- `receiver/foo`: Some change relevant to [default] (#21) (@octocat)
+- `receiver/foo`: Some change relevant to [api,user] (#333) (@octocat)
 
 ### 🧰 Bug fixes 🧰
 
-- `receiver/foo`: Some change relevant to [default] (#32)
-- `receiver/foo`: Some change relevant to [default] (#222)
+- `receiver/foo`: Some change relevant to [default] (#32) (@octocat)
+- `receiver/foo`: Some change relevant to [default] (#222) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/new_component_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/new_component_only/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🚀 New components 🚀
+
+- `exporter/new`: Add new exporter ... (#12349)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/new_component_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/new_component_only/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🚀 New components 🚀
 
-- `exporter/new`: Add new exporter ... (#12349)
+- `exporter/new`: Add new exporter ... (#12349) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/subtext/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/subtext/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🛑 Breaking changes 🛑
+
+- `processor/oops`: Change behavior when ... (#12350)
+  - foo
+    - bar
+  - blah
+    - 1234567
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/subtext/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/subtext/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `processor/oops`: Change behavior when ... (#12350)
+- `processor/oops`: Change behavior when ... (#12350) (@octocat)
   - foo
     - bar
   - blah

--- a/tools/chloggen/cmd/update.go
+++ b/tools/chloggen/cmd/update.go
@@ -47,6 +47,13 @@ func updateCmd() *cobra.Command {
 				return err
 			}
 
+			// Validate before rendering/deleting so an invalid entry is never
+			// silently dropped from the summary and then lost when its source
+			// file is deleted.
+			if err = chlog.ValidateEntries(globalCfg, entriesByChangelog); err != nil {
+				return err
+			}
+
 			for changeLogKey, entries := range entriesByChangelog {
 
 				slices.SortFunc(entries, func(a, b *chlog.Entry) int {
@@ -68,7 +75,7 @@ func updateCmd() *cobra.Command {
 				}
 
 				if dry {
-					cmd.Printf("Generated changelog updates for %s:", changeLogKey)
+					cmd.Printf("Generated changelog updates for %s:\n", changeLogKey)
 					cmd.Println(chlogUpdate)
 					continue
 				}
@@ -92,7 +99,7 @@ func updateCmd() *cobra.Command {
 				chlogBuilder.WriteString(chlogHistory)
 
 				tmpMD := filename + ".tmp"
-				if err = os.WriteFile(filepath.Clean(tmpMD), []byte(chlogBuilder.String()), 0o600); err != nil {
+				if err = os.WriteFile(filepath.Clean(tmpMD), []byte(chlogBuilder.String()), 0o644); err != nil {
 					return err
 				}
 
@@ -101,7 +108,12 @@ func updateCmd() *cobra.Command {
 				}
 
 				cmd.Printf("Finished updating %s\n", filename)
+			}
 
+			// Delete the consumed entry files only once, after every changelog has
+			// been written successfully, and never in dry-run mode. This avoids
+			// losing the source YAMLs if a later changelog write fails.
+			if !dry {
 				if err = chlog.DeleteEntries(globalCfg); err != nil {
 					return err
 				}

--- a/tools/chloggen/cmd/update.go
+++ b/tools/chloggen/cmd/update.go
@@ -1,0 +1,116 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/grafana/tempo/tools/chloggen/internal/chlog"
+)
+
+const (
+	insertPoint = "<!-- next version -->\n"
+)
+
+var (
+	version         string
+	dry             bool
+	componentFilter string
+)
+
+func updateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Updates CHANGELOG.MD to include all new changes",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			entriesByChangelog, err := chlog.ReadEntries(globalCfg)
+			if err != nil {
+				return err
+			}
+
+			for changeLogKey, entries := range entriesByChangelog {
+
+				slices.SortFunc(entries, func(a, b *chlog.Entry) int {
+					return strings.Compare(a.Component, b.Component)
+				})
+
+				if componentFilter != "" {
+					filteredEntries := make([]*chlog.Entry, 0, len(entries))
+					for _, e := range entries {
+						if e.Component == componentFilter {
+							filteredEntries = append(filteredEntries, e)
+						}
+					}
+					entries = filteredEntries
+				}
+				chlogUpdate, err := chlog.GenerateSummary(version, entries, globalCfg)
+				if err != nil {
+					return err
+				}
+
+				if dry {
+					cmd.Printf("Generated changelog updates for %s:", changeLogKey)
+					cmd.Println(chlogUpdate)
+					continue
+				}
+
+				filename := globalCfg.ChangeLogs[changeLogKey]
+				oldChlogBytes, err := os.ReadFile(filepath.Clean(filename))
+				if err != nil {
+					return err
+				}
+				chlogParts := bytes.Split(oldChlogBytes, []byte(insertPoint))
+				if len(chlogParts) != 2 {
+					return fmt.Errorf("expected one instance of %s", insertPoint)
+				}
+
+				chlogHeader, chlogHistory := string(chlogParts[0]), string(chlogParts[1])
+
+				var chlogBuilder strings.Builder
+				chlogBuilder.WriteString(chlogHeader)
+				chlogBuilder.WriteString(insertPoint)
+				chlogBuilder.WriteString(chlogUpdate)
+				chlogBuilder.WriteString(chlogHistory)
+
+				tmpMD := filename + ".tmp"
+				if err = os.WriteFile(filepath.Clean(tmpMD), []byte(chlogBuilder.String()), 0o600); err != nil {
+					return err
+				}
+
+				if err = os.Rename(tmpMD, filename); err != nil {
+					return err
+				}
+
+				cmd.Printf("Finished updating %s\n", filename)
+
+				if err = chlog.DeleteEntries(globalCfg); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&version, "version", "v", "vTODO", "will be rendered directly into the update text")
+	cmd.Flags().BoolVarP(&dry, "dry", "d", false, "will generate the update text and print to stdout")
+	cmd.Flags().StringVarP(&componentFilter, "component", "c", "", "only select entries with this exact component")
+	return cmd
+}

--- a/tools/chloggen/cmd/update.go
+++ b/tools/chloggen/cmd/update.go
@@ -54,6 +54,31 @@ func updateCmd() *cobra.Command {
 				return err
 			}
 
+			// Backfill empty 'issues' from git here, not in validate, so the PR-CI
+			// validation of an unmerged entry doesn't depend on git history. Dedupe
+			// by pointer: one entry can appear under several changelogs, and a
+			// failed backfill would otherwise re-spawn git for it each time.
+			backfilled := make(map[*chlog.Entry]bool)
+			for _, entries := range entriesByChangelog {
+				for _, e := range entries {
+					if backfilled[e] {
+						continue
+					}
+					backfilled[e] = true
+					e.BackfillIssues()
+				}
+			}
+
+			// Never render an entry without a PR link: fail, listing all of them.
+			if missing := chlog.MissingIssues(entriesByChangelog); len(missing) > 0 {
+				noun := "entry"
+				if len(missing) > 1 {
+					noun = "entries"
+				}
+				return fmt.Errorf("could not determine a PR number for %d changelog %s; set 'issues' explicitly in:\n  %s",
+					len(missing), noun, strings.Join(missing, "\n  "))
+			}
+
 			for changeLogKey, entries := range entriesByChangelog {
 
 				slices.SortFunc(entries, func(a, b *chlog.Entry) int {

--- a/tools/chloggen/cmd/update_test.go
+++ b/tools/chloggen/cmd/update_test.go
@@ -1,0 +1,346 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/tempo/tools/chloggen/internal/chlog"
+	"github.com/grafana/tempo/tools/chloggen/internal/config"
+)
+
+const updateUsage = `Usage:
+  chloggen update [flags]
+
+Flags:
+  -c, --component string   only select entries with this exact component
+  -d, --dry                will generate the update text and print to stdout
+  -h, --help               help for update
+  -v, --version string     will be rendered directly into the update text (default "vTODO")
+
+Global Flags:
+      --config string   (optional) chloggen config file`
+
+func TestUpdateErr(t *testing.T) {
+	globalCfg = config.New(t.TempDir())
+	setupTestDir(t, []*chlog.Entry{})
+
+	var out string
+	var err error
+
+	out, err = runCobra(t, "update", "--help")
+	assert.Contains(t, out, updateUsage)
+	assert.NoError(t, err)
+
+	badEntry, ioErr := os.CreateTemp(globalCfg.EntriesDir, "*.yaml")
+	require.NoError(t, ioErr)
+	defer badEntry.Close()
+
+	_, ioErr = badEntry.Write([]byte("bad yaml"))
+	require.NoError(t, ioErr)
+	out, err = runCobra(t, "update")
+	assert.Contains(t, out, updateUsage)
+	assert.ErrorContains(t, err, "yaml: unmarshal errors")
+}
+
+func TestUpdate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows line breaks cause comparison failures w/ golden files.")
+	}
+
+	tests := []struct {
+		name              string
+		entries           []*chlog.Entry
+		changeLogs        map[string]string
+		defaultChangeLogs []string
+		version           string
+		dry               bool
+		componentFilter   string
+	}{
+		{
+			name:    "all_change_types",
+			entries: getSampleEntries(),
+			version: "v0.45.0",
+		},
+		{
+			name:    "all_change_types_multiple",
+			entries: append(getSampleEntries(), getSampleEntries()...),
+			version: "v0.45.0",
+		},
+		{
+			name:    "dry_run",
+			entries: getSampleEntries(),
+			version: "v0.45.0",
+			dry:     true,
+		},
+		{
+			name:    "deprecation_only",
+			entries: []*chlog.Entry{deprecationEntry()},
+			version: "v0.45.0",
+		},
+		{
+			name:    "new_component_only",
+			entries: []*chlog.Entry{newComponentEntry()},
+			version: "v0.45.0",
+		},
+		{
+			name:    "bug_fix_only",
+			entries: []*chlog.Entry{bugFixEntry()},
+			version: "v0.45.0",
+		},
+		{
+			name:    "enhancement_only",
+			entries: []*chlog.Entry{enhancementEntry()},
+			version: "v0.45.0",
+		},
+		{
+			name:    "breaking_only",
+			entries: []*chlog.Entry{breakingEntry()},
+			version: "v0.45.0",
+		},
+		{
+			name:    "subtext",
+			entries: []*chlog.Entry{entryWithSubtext()},
+			version: "v0.45.0",
+		},
+		{
+			name: "multiple_changelogs",
+			entries: []*chlog.Entry{
+				entryForChangelogs(chlog.Deprecation, 123, "user"),
+				entryForChangelogs(chlog.Breaking, 125, "api"),
+				entryForChangelogs(chlog.Enhancement, 333, "api", "user"),
+				entryForChangelogs(chlog.BugFix, 222, "user"),
+				entryForChangelogs(chlog.Deprecation, 223, "api"),
+				entryForChangelogs(chlog.BugFix, 111, "api"),
+				entryForChangelogs(chlog.Breaking, 11, "user", "api"),
+				entryForChangelogs(chlog.Enhancement, 555, "api"),
+				entryForChangelogs(chlog.BugFix, 777, "api"),
+				entryForChangelogs(chlog.Deprecation, 234, "user", "api"),
+				entryForChangelogs(chlog.Enhancement, 21, "user"),
+				entryForChangelogs(chlog.BugFix, 32, "user"),
+			},
+			changeLogs: map[string]string{
+				"user": "CHANGELOG.md",
+				"api":  "CHANGELOG-API.md",
+			},
+			version: "v0.45.0",
+		},
+		{
+			name: "multiple_changelogs_single_default",
+			entries: []*chlog.Entry{
+				entryForChangelogs(chlog.Deprecation, 123),
+				entryForChangelogs(chlog.Breaking, 125, "api"),
+				entryForChangelogs(chlog.Enhancement, 333, "api", "user"),
+				entryForChangelogs(chlog.BugFix, 222),
+				entryForChangelogs(chlog.Deprecation, 223, "api"),
+				entryForChangelogs(chlog.BugFix, 111, "api"),
+				entryForChangelogs(chlog.Breaking, 11, "user", "api"),
+				entryForChangelogs(chlog.Enhancement, 555, "api"),
+				entryForChangelogs(chlog.BugFix, 777, "api"),
+				entryForChangelogs(chlog.Deprecation, 234, "user", "api"),
+				entryForChangelogs(chlog.Enhancement, 21),
+				entryForChangelogs(chlog.BugFix, 32),
+			},
+			changeLogs: map[string]string{
+				"user": "CHANGELOG.md",
+				"api":  "CHANGELOG-API.md",
+			},
+			defaultChangeLogs: []string{"user"},
+			version:           "v0.45.0",
+		},
+		{
+			name: "multiple_changelogs_multiple_defaults",
+			entries: []*chlog.Entry{
+				entryForChangelogs(chlog.Deprecation, 123),
+				entryForChangelogs(chlog.Breaking, 125, "api"),
+				entryForChangelogs(chlog.Enhancement, 333, "api", "user"),
+				entryForChangelogs(chlog.BugFix, 222),
+				entryForChangelogs(chlog.Deprecation, 223, "api"),
+				entryForChangelogs(chlog.BugFix, 111, "api"),
+				entryForChangelogs(chlog.Breaking, 11, "user", "api"),
+				entryForChangelogs(chlog.Enhancement, 555, "api"),
+				entryForChangelogs(chlog.BugFix, 777, "api"),
+				entryForChangelogs(chlog.Deprecation, 234, "user", "api"),
+				entryForChangelogs(chlog.Enhancement, 21),
+				entryForChangelogs(chlog.BugFix, 32),
+			},
+			changeLogs: map[string]string{
+				"user": "CHANGELOG.md",
+				"api":  "CHANGELOG-API.md",
+			},
+			defaultChangeLogs: []string{"user", "api"},
+			version:           "v0.45.0",
+		},
+		{
+			name:    "filter_component",
+			version: "v0.45.0",
+			entries: []*chlog.Entry{
+				{
+					ChangeType: "enhancement",
+					Component:  "receiver/foo",
+					Note:       "Some change",
+					Issues:     []int{1},
+				},
+				{
+					ChangeType: "enhancement",
+					Component:  "receiver/bar",
+					Note:       "Some other change",
+					Issues:     []int{2},
+				},
+				{
+					ChangeType: "enhancement",
+					Component:  "receiver/foobar",
+					Note:       "Some other change for foobar",
+					Issues:     []int{3},
+				},
+				{
+					ChangeType: "enhancement",
+					Component:  "receiver/foo",
+					Note:       "One more foo change",
+					Issues:     []int{4},
+				},
+			},
+			componentFilter: "receiver/foo",
+		},
+		{
+			name:    "filter_component_no_match",
+			version: "v0.45.0",
+			entries: []*chlog.Entry{
+				{
+					ChangeType: "enhancement",
+					Component:  "receiver/foo",
+					Note:       "Some change",
+					Issues:     []int{1},
+				},
+				{
+					ChangeType: "enhancement",
+					Component:  "receiver/bar",
+					Note:       "Some other change",
+					Issues:     []int{2},
+				},
+				{
+					ChangeType: "enhancement",
+					Component:  "receiver/foobar",
+					Note:       "Some other change for foobar",
+					Issues:     []int{3},
+				},
+				{
+					ChangeType: "enhancement",
+					Component:  "receiver/foo",
+					Note:       "One more foo change",
+					Issues:     []int{4},
+				},
+			},
+			componentFilter: "receiver/foob",
+		},
+		{
+			name: "all_change_types_alphabetical",
+			entries: []*chlog.Entry{
+				{
+					ChangeType: "enhancement",
+					Component:  "receiver/a",
+					Note:       "Some change",
+					Issues:     []int{1},
+				},
+				{
+					ChangeType: "enhancement",
+					Component:  "receiver/bb",
+					Note:       "One more bb change",
+					Issues:     []int{4},
+				},
+				{
+					ChangeType: "enhancement",
+					Component:  "receiver/b",
+					Note:       "Some other change",
+					Issues:     []int{3},
+				},
+				{
+					ChangeType: "enhancement",
+					Component:  "receiver/aa",
+					Note:       "Some other change for aa",
+					Issues:     []int{2},
+				},
+			},
+			version: "v0.45.0",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			globalCfg = config.New(tempDir)
+			if len(tc.changeLogs) > 0 {
+				globalCfg.ChangeLogs = make(map[string]string)
+				for key, filename := range tc.changeLogs {
+					globalCfg.ChangeLogs[key] = filepath.Join(tempDir, filename)
+				}
+			}
+			if len(tc.defaultChangeLogs) > 0 {
+				globalCfg.DefaultChangeLogs = tc.defaultChangeLogs
+			}
+
+			setupTestDir(t, tc.entries)
+
+			args := []string{"update", "--version", tc.version}
+			if tc.dry {
+				args = append(args, "--dry")
+			}
+			if tc.componentFilter != "" {
+				args = append(args, "--component", tc.componentFilter)
+			}
+
+			var out string
+			var err error
+
+			out, err = runCobra(t, args...)
+
+			assert.Empty(t, err)
+			if tc.dry {
+				assert.Contains(t, out, "Generated changelog updates for")
+			} else {
+				for _, filename := range globalCfg.ChangeLogs {
+					assert.Contains(t, out, fmt.Sprintf("Finished updating %s", filename))
+				}
+			}
+
+			for _, filename := range globalCfg.ChangeLogs {
+				actualBytes, ioErr := os.ReadFile(filename) // nolint:gosec
+				require.NoError(t, ioErr)
+
+				expectedChangelogMD := filepath.Join("testdata", tc.name, filepath.Base(filename))
+				expectedBytes, ioErr := os.ReadFile(filepath.Clean(expectedChangelogMD))
+				require.NoError(t, ioErr)
+
+				require.Equal(t, string(expectedBytes), string(actualBytes))
+
+				remainingYAMLs, ioErr := filepath.Glob(filepath.Join(globalCfg.EntriesDir, "*.yaml"))
+				require.NoError(t, ioErr)
+				if tc.dry {
+					require.Equal(t, 1+len(tc.entries), len(remainingYAMLs))
+				} else {
+					require.Equal(t, 1, len(remainingYAMLs))
+					require.Equal(t, globalCfg.TemplateYAML, remainingYAMLs[0])
+				}
+			}
+		})
+	}
+}

--- a/tools/chloggen/cmd/update_test.go
+++ b/tools/chloggen/cmd/update_test.go
@@ -379,3 +379,63 @@ func TestUpdateValidatesBeforeWriting(t *testing.T) {
 	require.NoError(t, ioErr)
 	require.Equal(t, 2, len(remainingYAMLs))
 }
+
+func TestUpdateFailsWhenPRUnresolved(t *testing.T) {
+	globalCfg = config.New(t.TempDir())
+
+	// A valid entry that left 'issues' empty. The temp dir is not a git repo, so
+	// the PR can't be backfilled.
+	entry := &chlog.Entry{
+		ChangeType: chlog.BugFix,
+		Component:  "receiver/foo",
+		Note:       "Fix something",
+		User:       "octocat",
+	}
+	setupTestDir(t, []*chlog.Entry{entry})
+
+	// Both --dry and a real update fail rather than emit an entry with no link.
+	_, err := runCobra(t, "update", "--dry")
+	require.ErrorContains(t, err, "could not determine a PR number")
+
+	_, err = runCobra(t, "update")
+	require.ErrorContains(t, err, "could not determine a PR number")
+
+	// The source entry file must not be deleted when the update fails.
+	remainingYAMLs, ioErr := filepath.Glob(filepath.Join(globalCfg.EntriesDir, "*.yaml"))
+	require.NoError(t, ioErr)
+	require.Equal(t, 2, len(remainingYAMLs))
+}
+
+func TestUpdateListsAllUnresolvedPRs(t *testing.T) {
+	globalCfg = config.New(t.TempDir())
+
+	// Two unresolvable entries plus one with an explicit issue: both unresolved
+	// files must appear in a single error, not just the first.
+	resolvable := &chlog.Entry{
+		ChangeType: chlog.Enhancement,
+		Component:  "receiver/foo",
+		Note:       "Has a PR",
+		Issues:     []int{42},
+		User:       "octocat",
+	}
+	missingA := &chlog.Entry{
+		ChangeType: chlog.BugFix,
+		Component:  "receiver/foo",
+		Note:       "Missing A",
+		User:       "octocat",
+	}
+	missingB := &chlog.Entry{
+		ChangeType: chlog.BugFix,
+		Component:  "receiver/foo",
+		Note:       "Missing B",
+		User:       "octocat",
+	}
+	setupTestDir(t, []*chlog.Entry{resolvable, missingA, missingB})
+
+	_, err := runCobra(t, "update")
+	require.ErrorContains(t, err, "could not determine a PR number for 2 changelog")
+	// setupTestDir writes entries as 0.yaml (resolvable), 1.yaml, 2.yaml.
+	assert.ErrorContains(t, err, "1.yaml")
+	assert.ErrorContains(t, err, "2.yaml")
+	assert.NotContains(t, err.Error(), "0.yaml")
+}

--- a/tools/chloggen/cmd/update_test.go
+++ b/tools/chloggen/cmd/update_test.go
@@ -199,24 +199,28 @@ func TestUpdate(t *testing.T) {
 					Component:  "receiver/foo",
 					Note:       "Some change",
 					Issues:     []int{1},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/bar",
 					Note:       "Some other change",
 					Issues:     []int{2},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/foobar",
 					Note:       "Some other change for foobar",
 					Issues:     []int{3},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/foo",
 					Note:       "One more foo change",
 					Issues:     []int{4},
+					User:       "octocat",
 				},
 			},
 			componentFilter: "receiver/foo",
@@ -230,24 +234,28 @@ func TestUpdate(t *testing.T) {
 					Component:  "receiver/foo",
 					Note:       "Some change",
 					Issues:     []int{1},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/bar",
 					Note:       "Some other change",
 					Issues:     []int{2},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/foobar",
 					Note:       "Some other change for foobar",
 					Issues:     []int{3},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/foo",
 					Note:       "One more foo change",
 					Issues:     []int{4},
+					User:       "octocat",
 				},
 			},
 			componentFilter: "receiver/foob",
@@ -260,24 +268,28 @@ func TestUpdate(t *testing.T) {
 					Component:  "receiver/a",
 					Note:       "Some change",
 					Issues:     []int{1},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/bb",
 					Note:       "One more bb change",
 					Issues:     []int{4},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/b",
 					Note:       "Some other change",
 					Issues:     []int{3},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/aa",
 					Note:       "Some other change for aa",
 					Issues:     []int{2},
+					User:       "octocat",
 				},
 			},
 			version: "v0.45.0",
@@ -343,4 +355,27 @@ func TestUpdate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUpdateValidatesBeforeWriting(t *testing.T) {
+	globalCfg = config.New(t.TempDir())
+
+	// An entry with an invalid change_type must abort update before rendering
+	// or deleting, so the source entry file is not lost.
+	bad := &chlog.Entry{
+		ChangeType: "not_a_real_type",
+		Component:  "receiver/foo",
+		Note:       "Some change",
+		Issues:     []int{1},
+		User:       "octocat",
+	}
+	setupTestDir(t, []*chlog.Entry{bad})
+
+	_, err := runCobra(t, "update", "--version", "v1.0.0")
+	require.ErrorContains(t, err, "not_a_real_type")
+
+	// The source entry file (plus TEMPLATE.yaml) must still be present.
+	remainingYAMLs, ioErr := filepath.Glob(filepath.Join(globalCfg.EntriesDir, "*.yaml"))
+	require.NoError(t, ioErr)
+	require.Equal(t, 2, len(remainingYAMLs))
 }

--- a/tools/chloggen/cmd/validate.go
+++ b/tools/chloggen/cmd/validate.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"errors"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -36,21 +35,8 @@ func validateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			var errs error
-			for _, entries := range entriesByChangelog {
-				for _, entry := range entries {
-					changelogRequired := len(globalCfg.DefaultChangeLogs) == 0
-					validChangeLogs := []string{}
-					for changeLogKey := range globalCfg.ChangeLogs {
-						validChangeLogs = append(validChangeLogs, changeLogKey)
-					}
-					if err = entry.Validate(changelogRequired, globalCfg.Components, validChangeLogs...); err != nil {
-						errs = errors.Join(errs, err)
-					}
-				}
-			}
-			if errs != nil {
-				return errs
+			if err = chlog.ValidateEntries(globalCfg, entriesByChangelog); err != nil {
+				return err
 			}
 			cmd.Printf("PASS: all files in %s/ are valid\n", globalCfg.EntriesDir)
 			return nil

--- a/tools/chloggen/cmd/validate.go
+++ b/tools/chloggen/cmd/validate.go
@@ -1,0 +1,60 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"errors"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/grafana/tempo/tools/chloggen/internal/chlog"
+)
+
+func validateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Validates the files in the changelog directory",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if _, err := os.Stat(globalCfg.EntriesDir); err != nil {
+				return err
+			}
+
+			entriesByChangelog, err := chlog.ReadEntries(globalCfg)
+			if err != nil {
+				return err
+			}
+			var errs error
+			for _, entries := range entriesByChangelog {
+				for _, entry := range entries {
+					changelogRequired := len(globalCfg.DefaultChangeLogs) == 0
+					validChangeLogs := []string{}
+					for changeLogKey := range globalCfg.ChangeLogs {
+						validChangeLogs = append(validChangeLogs, changeLogKey)
+					}
+					if err = entry.Validate(changelogRequired, globalCfg.Components, validChangeLogs...); err != nil {
+						errs = errors.Join(errs, err)
+					}
+				}
+			}
+			if errs != nil {
+				return errs
+			}
+			cmd.Printf("PASS: all files in %s/ are valid\n", globalCfg.EntriesDir)
+			return nil
+		},
+	}
+	return cmd
+}

--- a/tools/chloggen/cmd/validate_test.go
+++ b/tools/chloggen/cmd/validate_test.go
@@ -1,0 +1,205 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"io/fs"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/tempo/tools/chloggen/internal/chlog"
+	"github.com/grafana/tempo/tools/chloggen/internal/config"
+)
+
+const validateUsage = `Usage:
+  chloggen validate [flags]
+
+Flags:
+  -h, --help   help for validate
+
+Global Flags:
+      --config string   (optional) chloggen config file`
+
+func TestValidateErr(t *testing.T) {
+	var out string
+	var err error
+
+	out, err = runCobra(t, "validate", "--help")
+	assert.Contains(t, out, validateUsage)
+	assert.Empty(t, err)
+
+	out, err = runCobra(t, "validate")
+	assert.Contains(t, out, validateUsage)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfgFn   func(*config.Config)
+		entries []*chlog.Entry
+		wantErr string
+	}{
+		{
+			name:    "all_valid",
+			entries: getSampleEntries(),
+		},
+		{
+			name: "invalid_change_type",
+			entries: func() []*chlog.Entry {
+				return append(getSampleEntries(), &chlog.Entry{
+					ChangeType: "fake",
+					Component:  "receiver/foo",
+					Note:       "Add some bar",
+					Issues:     []int{12345},
+				})
+			}(),
+			wantErr: "'fake' is not a valid 'change_type'",
+		},
+		{
+			name: "missing_component",
+			entries: func() []*chlog.Entry {
+				return append(getSampleEntries(), &chlog.Entry{
+					ChangeType: chlog.BugFix,
+					Component:  "",
+					Note:       "Add some bar",
+					Issues:     []int{12345},
+				})
+			}(),
+			wantErr: "specify a 'component'",
+		},
+		{
+			name: "empty_component",
+			entries: func() []*chlog.Entry {
+				return append(getSampleEntries(), &chlog.Entry{
+					ChangeType: chlog.BugFix,
+					Component:  " ",
+					Note:       "Add some bar",
+					Issues:     []int{12345},
+				})
+			}(),
+			wantErr: "specify a 'component'",
+		},
+		{
+			name: "missing_note",
+			entries: func() []*chlog.Entry {
+				return append(getSampleEntries(), &chlog.Entry{
+					ChangeType: chlog.BugFix,
+					Component:  "receiver/foo",
+					Note:       "",
+					Issues:     []int{12345},
+				})
+			}(),
+			wantErr: "specify a 'note'",
+		},
+		{
+			name: "empty_note",
+			entries: func() []*chlog.Entry {
+				return append(getSampleEntries(), &chlog.Entry{
+					ChangeType: chlog.BugFix,
+					Component:  "receiver/foo",
+					Note:       " ",
+					Issues:     []int{12345},
+				})
+			}(),
+			wantErr: "specify a 'note'",
+		},
+		{
+			name: "missing_issue",
+			entries: func() []*chlog.Entry {
+				return append(getSampleEntries(), &chlog.Entry{
+					ChangeType: chlog.BugFix,
+					Component:  "receiver/foo",
+					Note:       "Add some bar",
+					Issues:     []int{},
+				})
+			}(),
+			wantErr: "specify one or more issues #'s",
+		},
+		{
+			name: "all_invalid",
+			entries: func() []*chlog.Entry {
+				sampleEntries := getSampleEntries()
+				for _, e := range sampleEntries {
+					e.ChangeType = "fake"
+				}
+				return sampleEntries
+			}(),
+			wantErr: "'fake' is not a valid 'change_type'",
+		},
+		{
+			name: "gomodule_validation",
+			cfgFn: func(cfg *config.Config) {
+				cfg.Components = []string{"github.com/foo/bar/receiver", "github.com/foo/bar/exporter"}
+			},
+			entries: func() []*chlog.Entry {
+				sampleEntries := getSampleEntries()
+				for _, e := range sampleEntries {
+					e.Component = "foo"
+				}
+				return sampleEntries
+			}(),
+			wantErr: "foo is not a valid 'component'. It must be one of [github.com/foo/bar/receiver github.com/foo/bar/exporter]",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.New(t.TempDir())
+			if tc.cfgFn != nil {
+				tc.cfgFn(cfg)
+			}
+			globalCfg = cfg
+			setupTestDir(t, tc.entries)
+
+			out, err := runCobra(t, "validate")
+
+			if tc.wantErr != "" {
+				assert.ErrorContains(t, err, tc.wantErr)
+			} else {
+				assert.Empty(t, err)
+				assert.Contains(t, out, fmt.Sprintf("PASS: all files in %s/ are valid", globalCfg.EntriesDir))
+			}
+		})
+	}
+}
+
+func TestValidateAccumulatesErrors(t *testing.T) {
+	entries := []*chlog.Entry{
+		{
+			ChangeType: "fake_type",
+			Component:  "component",
+			Note:       "note",
+			Issues:     []int{123},
+		},
+		{
+			ChangeType: "bug_fix",
+			Component:  "",
+			Note:       "note",
+			Issues:     []int{456},
+		},
+	}
+
+	cfg := config.New(t.TempDir())
+	globalCfg = cfg
+	setupTestDir(t, entries)
+
+	_, err := runCobra(t, "validate")
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "'fake_type' is not a valid 'change_type'")
+	assert.ErrorContains(t, err, "specify a 'component'")
+}

--- a/tools/chloggen/cmd/validate_test.go
+++ b/tools/chloggen/cmd/validate_test.go
@@ -119,16 +119,18 @@ func TestValidate(t *testing.T) {
 			wantErr: "specify a 'note'",
 		},
 		{
-			name: "missing_issue",
+			// 'issues' is optional; update backfills it from git history, so an
+			// entry without issues must pass validation.
+			name: "no_issues_is_valid",
 			entries: func() []*chlog.Entry {
 				return append(getSampleEntries(), &chlog.Entry{
 					ChangeType: chlog.BugFix,
 					Component:  "receiver/foo",
 					Note:       "Add some bar",
 					Issues:     []int{},
+					User:       "octocat",
 				})
 			}(),
-			wantErr: "specify one or more issues #'s",
 		},
 		{
 			name: "all_invalid",

--- a/tools/chloggen/internal/chlog/TEMPLATE.yaml
+++ b/tools/chloggen/internal/chlog/TEMPLATE.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type:
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component:
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/tools/chloggen/internal/chlog/TEMPLATE.yaml
+++ b/tools/chloggen/internal/chlog/TEMPLATE.yaml
@@ -23,3 +23,7 @@ issues: []
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext:
+
+# The GitHub handle (without the leading @) of the change's author.
+# Rendered as a "(@handle)" suffix on the changelog entry.
+user:

--- a/tools/chloggen/internal/chlog/entry.go
+++ b/tools/chloggen/internal/chlog/entry.go
@@ -17,11 +17,15 @@
 package chlog
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -51,6 +55,10 @@ type Entry struct {
 	Issues     []int    `yaml:"issues"`
 	SubText    string   `yaml:"subtext"`
 	User       string   `yaml:"user"`
+
+	// path is the source file (not part of the on-disk format); BackfillIssues
+	// uses it to recover the PR number from git.
+	path string
 }
 
 // DefaultChangeTypes lists the built-in change types in render order, along with
@@ -114,15 +122,61 @@ func (e Entry) Validate(requireChangelog bool, components []string, changeTypes 
 		errs = errors.Join(errs, fmt.Errorf("specify a 'note'"))
 	}
 
-	if len(e.Issues) == 0 {
-		errs = errors.Join(errs, fmt.Errorf("specify one or more issues #'s"))
-	}
+	// 'issues' is optional; 'update' backfills it from git (see BackfillIssues).
 
 	if strings.TrimSpace(e.User) == "" {
 		errs = errors.Join(errs, fmt.Errorf("specify a 'user'"))
 	}
 
 	return errs
+}
+
+// prSuffix captures the PR number from a squash-merge subject like "title (#1234)".
+var prSuffix = regexp.MustCompile(`\(#(\d+)\)\s*$`)
+
+// BackfillIssues fills Issues from the PR number in the commit that added the
+// entry file, when the author left 'issues' empty. Best-effort: on any failure
+// Issues stays empty and 'update' then fails via MissingIssues.
+func (e *Entry) BackfillIssues() {
+	if len(e.Issues) > 0 || e.path == "" {
+		return
+	}
+	if pr, ok := prFromGitHistory(e.path); ok {
+		e.Issues = []int{pr}
+	}
+}
+
+// MissingIssues returns the de-duplicated source paths of entries that still
+// have no 'issues' after backfill.
+func MissingIssues(entriesByChangelog map[string][]*Entry) []string {
+	seen := make(map[string]bool)
+	var paths []string
+	for _, entries := range entriesByChangelog {
+		for _, e := range entries {
+			if len(e.Issues) == 0 && !seen[e.path] {
+				seen[e.path] = true
+				paths = append(paths, e.path)
+			}
+		}
+	}
+	slices.Sort(paths)
+	return paths
+}
+
+func prFromGitHistory(path string) (int, bool) {
+	// -C <dir> so resolution doesn't depend on the process working directory.
+	dir, base := filepath.Dir(path), filepath.Base(path)
+	// Only the commit that added the file; a later edit could carry a different PR.
+	out, err := exec.Command("git", "-C", dir, "log", "-1", "--diff-filter=A", "--format=%s", "--", base).Output()
+	if err != nil {
+		return 0, false
+	}
+	if m := prSuffix.FindSubmatch(bytes.TrimSpace(out)); m != nil {
+		if n, err := strconv.Atoi(string(m[1])); err == nil {
+			return n, true
+		}
+	}
+	return 0, false
 }
 
 // ValidateEntries validates every entry against the configuration, accumulating
@@ -173,6 +227,7 @@ func ReadEntries(cfg *config.Config) (map[string][]*Entry, error) {
 		if err = yaml.Unmarshal(fileBytes, entry); err != nil {
 			return nil, err
 		}
+		entry.path = file
 		entry.SubText = strings.ReplaceAll(entry.SubText, "\r\n", "\n")
 		// 'user' is documented as a handle without the leading '@'; normalize it
 		// away so a value like "@octocat" doesn't render as "(@@octocat)".

--- a/tools/chloggen/internal/chlog/entry.go
+++ b/tools/chloggen/internal/chlog/entry.go
@@ -1,0 +1,180 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package chlog provides internal functionality for the generation of
+// changelogs for OpenTelemetry Go projects.
+package chlog
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/grafana/tempo/tools/chloggen/internal/config"
+)
+
+const (
+	// Breaking is a breaking change.
+	Breaking = "breaking"
+	// Deprecation is a deprecation change.
+	Deprecation = "deprecation"
+	// NewComponent is a new component change.
+	NewComponent = "new_component"
+	// Enhancement is an enhancement change.
+	Enhancement = "enhancement"
+	// BugFix is a bug fix change.
+	BugFix = "bug_fix"
+)
+
+// Entry represents a changelog entry.
+type Entry struct {
+	ChangeLogs []string `yaml:"change_logs"`
+	ChangeType string   `yaml:"change_type"`
+	Component  string   `yaml:"component"`
+	Note       string   `yaml:"note"`
+	Issues     []int    `yaml:"issues"`
+	SubText    string   `yaml:"subtext"`
+}
+
+var changeTypes = []string{
+	Breaking,
+	Deprecation,
+	NewComponent,
+	Enhancement,
+	BugFix,
+}
+
+// Validate validates the changelog entry.
+func (e Entry) Validate(requireChangelog bool, components []string, validChangeLogs ...string) error {
+	var errs error
+	if requireChangelog && len(e.ChangeLogs) == 0 {
+		errs = errors.Join(errs, fmt.Errorf("specify one or more 'change_logs'"))
+	}
+	for _, cl := range e.ChangeLogs {
+		var valid bool
+		for _, vcl := range validChangeLogs {
+			if cl == vcl {
+				valid = true
+			}
+		}
+		if !valid {
+			errs = errors.Join(errs, fmt.Errorf("'%s' is not a valid value in 'change_logs'. Specify one of %v", cl, validChangeLogs))
+		}
+	}
+
+	if !slices.Contains(changeTypes, e.ChangeType) {
+		errs = errors.Join(errs, fmt.Errorf("'%s' is not a valid 'change_type'. Specify one of %v", e.ChangeType, changeTypes))
+	}
+
+	if strings.TrimSpace(e.Component) == "" {
+		errs = errors.Join(errs, fmt.Errorf("specify a 'component'"))
+	}
+
+	found := slices.Contains(components, e.Component)
+	// only apply component validation if one or more values are present.
+	if len(components) > 0 && !found {
+		errs = errors.Join(errs, fmt.Errorf("%s is not a valid 'component'. It must be one of %v", e.Component, components))
+	}
+
+	if strings.TrimSpace(e.Note) == "" {
+		errs = errors.Join(errs, fmt.Errorf("specify a 'note'"))
+	}
+
+	if len(e.Issues) == 0 {
+		errs = errors.Join(errs, fmt.Errorf("specify one or more issues #'s"))
+	}
+
+	return errs
+}
+
+// ReadEntries reads changelog entries from YAML files based on the provided configuration.
+func ReadEntries(cfg *config.Config) (map[string][]*Entry, error) {
+	yamlFiles, err := findYamlFiles(cfg.EntriesDir)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make(map[string][]*Entry)
+	for key := range cfg.ChangeLogs {
+		entries[key] = make([]*Entry, 0)
+	}
+
+	for _, file := range yamlFiles {
+		if file == cfg.TemplateYAML || file == cfg.ConfigYAML {
+			continue
+		}
+
+		fileBytes, err := os.ReadFile(filepath.Clean(file))
+		if err != nil {
+			return nil, err
+		}
+
+		entry := &Entry{}
+		if err = yaml.Unmarshal(fileBytes, entry); err != nil {
+			return nil, err
+		}
+		entry.SubText = strings.ReplaceAll(entry.SubText, "\r\n", "\n")
+
+		if len(entry.ChangeLogs) == 0 {
+			for _, cl := range cfg.DefaultChangeLogs {
+				entries[cl] = append(entries[cl], entry)
+			}
+		} else {
+			for _, cl := range entry.ChangeLogs {
+				entries[cl] = append(entries[cl], entry)
+			}
+		}
+	}
+	return entries, nil
+}
+
+// DeleteEntries deletes changelog entries from YAML files based on the provided configuration.
+func DeleteEntries(cfg *config.Config) error {
+	yamlFiles, err := findYamlFiles(cfg.EntriesDir)
+	if err != nil {
+		return err
+	}
+
+	for _, file := range yamlFiles {
+		if file == cfg.TemplateYAML || file == cfg.ConfigYAML {
+			continue
+		}
+
+		if err := os.Remove(file); err != nil {
+			fmt.Printf("Failed to delete: %s\n", file)
+		}
+	}
+	return nil
+}
+
+// findYamlFiles finds all YAML files in the specified directory.
+// It includes files with both .yaml and .yml extensions.
+func findYamlFiles(dir string) ([]string, error) {
+	yamlFiles, err := filepath.Glob(filepath.Join(dir, "*.yaml"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to find YAML files in %s: %w", dir, err)
+	}
+
+	ymlFiles, err := filepath.Glob(filepath.Join(dir, "*.yml"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to find YML files in %s: %w", dir, err)
+	}
+
+	return slices.Concat(yamlFiles, ymlFiles), nil
+}

--- a/tools/chloggen/internal/chlog/entry.go
+++ b/tools/chloggen/internal/chlog/entry.go
@@ -50,18 +50,36 @@ type Entry struct {
 	Note       string   `yaml:"note"`
 	Issues     []int    `yaml:"issues"`
 	SubText    string   `yaml:"subtext"`
+	User       string   `yaml:"user"`
 }
 
-var changeTypes = []string{
-	Breaking,
-	Deprecation,
-	NewComponent,
-	Enhancement,
-	BugFix,
+// DefaultChangeTypes lists the built-in change types in render order, along with
+// the headings used to group them in the generated changelog. It is the value
+// used when a configuration does not specify its own 'change_types'.
+var DefaultChangeTypes = []config.ChangeType{
+	{Key: Breaking, Heading: "🛑 Breaking changes 🛑"},
+	{Key: Deprecation, Heading: "🚩 Deprecations 🚩"},
+	{Key: NewComponent, Heading: "🚀 New components 🚀"},
+	{Key: Enhancement, Heading: "💡 Enhancements 💡"},
+	{Key: BugFix, Heading: "🧰 Bug fixes 🧰"},
 }
 
-// Validate validates the changelog entry.
-func (e Entry) Validate(requireChangelog bool, components []string, validChangeLogs ...string) error {
+// changeTypeKeys returns the change type keys from the provided change types,
+// preserving order.
+func changeTypeKeys(changeTypes []config.ChangeType) []string {
+	keys := make([]string, 0, len(changeTypes))
+	for _, ct := range changeTypes {
+		keys = append(keys, ct.Key)
+	}
+	return keys
+}
+
+// Validate validates the changelog entry. The set of valid change types is
+// given by changeTypes; when empty, the built-in DefaultChangeTypes are used.
+func (e Entry) Validate(requireChangelog bool, components []string, changeTypes []string, validChangeLogs ...string) error {
+	if len(changeTypes) == 0 {
+		changeTypes = changeTypeKeys(DefaultChangeTypes)
+	}
 	var errs error
 	if requireChangelog && len(e.ChangeLogs) == 0 {
 		errs = errors.Join(errs, fmt.Errorf("specify one or more 'change_logs'"))
@@ -100,6 +118,32 @@ func (e Entry) Validate(requireChangelog bool, components []string, validChangeL
 		errs = errors.Join(errs, fmt.Errorf("specify one or more issues #'s"))
 	}
 
+	if strings.TrimSpace(e.User) == "" {
+		errs = errors.Join(errs, fmt.Errorf("specify a 'user'"))
+	}
+
+	return errs
+}
+
+// ValidateEntries validates every entry against the configuration, accumulating
+// all errors. Both the 'validate' and 'update' commands use this so they
+// enforce identical rules (and 'update' never drops or deletes invalid entries).
+func ValidateEntries(cfg *config.Config, entriesByChangelog map[string][]*Entry) error {
+	changelogRequired := len(cfg.DefaultChangeLogs) == 0
+	validChangeLogs := make([]string, 0, len(cfg.ChangeLogs))
+	for changeLogKey := range cfg.ChangeLogs {
+		validChangeLogs = append(validChangeLogs, changeLogKey)
+	}
+	validChangeTypes := changeTypeKeys(cfg.ChangeTypes)
+
+	var errs error
+	for _, entries := range entriesByChangelog {
+		for _, entry := range entries {
+			if err := entry.Validate(changelogRequired, cfg.Components, validChangeTypes, validChangeLogs...); err != nil {
+				errs = errors.Join(errs, err)
+			}
+		}
+	}
 	return errs
 }
 
@@ -130,6 +174,9 @@ func ReadEntries(cfg *config.Config) (map[string][]*Entry, error) {
 			return nil, err
 		}
 		entry.SubText = strings.ReplaceAll(entry.SubText, "\r\n", "\n")
+		// 'user' is documented as a handle without the leading '@'; normalize it
+		// away so a value like "@octocat" doesn't render as "(@@octocat)".
+		entry.User = strings.TrimPrefix(strings.TrimSpace(entry.User), "@")
 
 		if len(entry.ChangeLogs) == 0 {
 			for _, cl := range cfg.DefaultChangeLogs {
@@ -137,6 +184,9 @@ func ReadEntries(cfg *config.Config) (map[string][]*Entry, error) {
 			}
 		} else {
 			for _, cl := range entry.ChangeLogs {
+				if _, ok := entries[cl]; !ok {
+					return nil, fmt.Errorf("%s: '%s' is not a valid value in 'change_logs'", file, cl)
+				}
 				entries[cl] = append(entries[cl], entry)
 			}
 		}
@@ -151,16 +201,17 @@ func DeleteEntries(cfg *config.Config) error {
 		return err
 	}
 
+	var errs error
 	for _, file := range yamlFiles {
 		if file == cfg.TemplateYAML || file == cfg.ConfigYAML {
 			continue
 		}
 
 		if err := os.Remove(file); err != nil {
-			fmt.Printf("Failed to delete: %s\n", file)
+			errs = errors.Join(errs, fmt.Errorf("failed to delete %s: %w", file, err))
 		}
 	}
-	return nil
+	return errs
 }
 
 // findYamlFiles finds all YAML files in the specified directory.

--- a/tools/chloggen/internal/chlog/entry_test.go
+++ b/tools/chloggen/internal/chlog/entry_test.go
@@ -42,13 +42,14 @@ func TestEntry(t *testing.T) {
 		requireChangeLog bool
 		validChangeLogs  []string
 		components       []string
+		changeTypes      []string
 		expectErr        string
 		toString         string
 	}{
 		{
 			name:      "empty",
 			entry:     Entry{},
-			expectErr: "'' is not a valid 'change_type'. Specify one of [breaking deprecation new_component enhancement bug_fix]\nspecify a 'component'\nspecify a 'note'\nspecify one or more issues #'s",
+			expectErr: "'' is not a valid 'change_type'. Specify one of [breaking deprecation new_component enhancement bug_fix]\nspecify a 'component'\nspecify a 'note'\nspecify one or more issues #'s\nspecify a 'user'",
 		},
 		{
 			name: "missing_component",
@@ -57,6 +58,7 @@ func TestEntry(t *testing.T) {
 				Note:       "enhance!",
 				Issues:     []int{123},
 				SubText:    "",
+				User:       "octocat",
 			},
 			expectErr: "specify a 'component'",
 		},
@@ -67,6 +69,7 @@ func TestEntry(t *testing.T) {
 				Component:  "bar",
 				Issues:     []int{123},
 				SubText:    "",
+				User:       "octocat",
 			},
 			expectErr: "specify a 'note'",
 		},
@@ -77,6 +80,7 @@ func TestEntry(t *testing.T) {
 				Component:  "bar",
 				Note:       "fix bar",
 				SubText:    "",
+				User:       "octocat",
 			},
 			expectErr: "specify one or more issues #'s",
 		},
@@ -88,6 +92,7 @@ func TestEntry(t *testing.T) {
 				Note:       "fix bar",
 				Issues:     []int{123},
 				SubText:    "",
+				User:       "octocat",
 			},
 			requireChangeLog: true,
 			validChangeLogs:  []string{"foo"},
@@ -102,6 +107,7 @@ func TestEntry(t *testing.T) {
 				Note:       "fix bar",
 				Issues:     []int{123},
 				SubText:    "",
+				User:       "octocat",
 			},
 			validChangeLogs: []string{"foo"},
 			expectErr:       "'bar' is not a valid value in 'change_logs'. Specify one of [foo]",
@@ -114,8 +120,9 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123},
 				SubText:    "",
+				User:       "octocat",
 			},
-			toString: "- `foo`: broke foo (#123)",
+			toString: "- `foo`: broke foo (#123) (@octocat)",
 		},
 		{
 			name: "multiple_issues",
@@ -125,8 +132,9 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123, 345},
 				SubText:    "",
+				User:       "octocat",
 			},
-			toString: "- `foo`: broke foo (#123, #345)",
+			toString: "- `foo`: broke foo (#123, #345) (@octocat)",
 		},
 		{
 			name: "subtext",
@@ -136,8 +144,9 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123},
 				SubText:    "more details",
+				User:       "octocat",
 			},
-			toString: "- `foo`: broke foo (#123)\n  more details",
+			toString: "- `foo`: broke foo (#123) (@octocat)\n  more details",
 		},
 		{
 			name: "multiline subtext",
@@ -147,8 +156,9 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123},
 				SubText:    "more details\nsecond line",
+				User:       "octocat",
 			},
-			toString: "- `foo`: broke foo (#123)\n  more details\n  second line",
+			toString: "- `foo`: broke foo (#123) (@octocat)\n  more details\n  second line",
 		},
 		{
 			name: "required_changelog",
@@ -159,10 +169,11 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123},
 				SubText:    "more details",
+				User:       "octocat",
 			},
 			requireChangeLog: true,
 			validChangeLogs:  []string{"foo"},
-			toString:         "- `foo`: broke foo (#123)\n  more details",
+			toString:         "- `foo`: broke foo (#123) (@octocat)\n  more details",
 		},
 		{
 			name: "default_changelog",
@@ -173,10 +184,11 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123},
 				SubText:    "more details",
+				User:       "octocat",
 			},
 			requireChangeLog: false,
 			validChangeLogs:  []string{"foo"},
-			toString:         "- `foo`: broke foo (#123)\n  more details",
+			toString:         "- `foo`: broke foo (#123) (@octocat)\n  more details",
 		},
 		{
 			name: "subset_of_changelogs",
@@ -187,9 +199,10 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123},
 				SubText:    "more details",
+				User:       "octocat",
 			},
 			validChangeLogs: []string{"foo", "bar", "baz"},
-			toString:        "- `foo`: broke foo (#123)\n  more details",
+			toString:        "- `foo`: broke foo (#123) (@octocat)\n  more details",
 		},
 		{
 			name: "all_changelogs",
@@ -200,9 +213,10 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123},
 				SubText:    "more details",
+				User:       "octocat",
 			},
 			validChangeLogs: []string{"foo", "bar"},
-			toString:        "- `foo`: broke foo (#123)\n  more details",
+			toString:        "- `foo`: broke foo (#123) (@octocat)\n  more details",
 		},
 		{
 			name: "all_changelogs",
@@ -213,9 +227,10 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123},
 				SubText:    "more details",
+				User:       "octocat",
 			},
 			validChangeLogs: []string{"foo", "bar"},
-			toString:        "- `foo`: broke foo (#123)\n  more details",
+			toString:        "- `foo`: broke foo (#123) (@octocat)\n  more details",
 		},
 		{
 			name: "with_components",
@@ -226,17 +241,63 @@ func TestEntry(t *testing.T) {
 				Note:       "changed foo",
 				Issues:     []int{123},
 				SubText:    "more details",
+				User:       "octocat",
 			},
 			components:      []string{"bar"},
 			validChangeLogs: []string{"foo", "bar"},
-			toString:        "- `foo`: changed foo (#123)\n  more details",
+			toString:        "- `foo`: changed foo (#123) (@octocat)\n  more details",
 			expectErr:       "foo is not a valid 'component'. It must be one of [bar]",
+		},
+		{
+			name: "custom_change_type_valid",
+			entry: Entry{
+				ChangeType: "security",
+				Component:  "foo",
+				Note:       "fix vuln",
+				Issues:     []int{123},
+				User:       "octocat",
+			},
+			changeTypes: []string{"security"},
+			toString:    "- `foo`: fix vuln (#123) (@octocat)",
+		},
+		{
+			name: "custom_change_types_reject_builtin",
+			entry: Entry{
+				ChangeType: "breaking",
+				Component:  "foo",
+				Note:       "broke foo",
+				Issues:     []int{123},
+				User:       "octocat",
+			},
+			changeTypes: []string{"security"},
+			expectErr:   "'breaking' is not a valid 'change_type'. Specify one of [security]",
+		},
+		{
+			name: "user_rendered_as_handle",
+			entry: Entry{
+				ChangeType: "breaking",
+				Component:  "foo",
+				Note:       "broke foo",
+				Issues:     []int{123},
+				User:       "octocat",
+			},
+			toString: "- `foo`: broke foo (#123) (@octocat)",
+		},
+		{
+			name: "missing_user",
+			entry: Entry{
+				ChangeType: "bug_fix",
+				Component:  "bar",
+				Note:       "fix bar",
+				Issues:     []int{123},
+			},
+			expectErr: "specify a 'user'",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.entry.Validate(tc.requireChangeLog, tc.components, tc.validChangeLogs...)
+			err := tc.entry.Validate(tc.requireChangeLog, tc.components, tc.changeTypes, tc.validChangeLogs...)
 			if tc.expectErr != "" {
 				assert.Error(t, err)
 				assert.Equal(t, tc.expectErr, err.Error())
@@ -335,6 +396,59 @@ func TestReadDeleteEntries(t *testing.T) {
 	// Ensure these weren't deleted
 	assert.FileExists(t, cfg.ConfigYAML)
 	assert.FileExists(t, cfg.TemplateYAML)
+}
+
+func TestReadEntriesNormalizesUserHandle(t *testing.T) {
+	tempDir := t.TempDir()
+	entriesDir := filepath.Join(tempDir, config.DefaultEntriesDir)
+	require.NoError(t, os.Mkdir(entriesDir, 0o750))
+
+	// A user written with a leading '@' must be normalized so it doesn't render
+	// as "(@@handle)".
+	entry := Entry{
+		ChangeType: "breaking",
+		Component:  "foo",
+		Note:       "broke foo",
+		Issues:     []int{123},
+		User:       "@octocat",
+	}
+	writeEntry(t, entriesDir, &entry, "yaml")
+
+	cfg := &config.Config{
+		ChangeLogs:        map[string]string{"default": filepath.Join(entriesDir, "CHANGELOG.md")},
+		DefaultChangeLogs: []string{"default"},
+		EntriesDir:        entriesDir,
+	}
+
+	entries, err := ReadEntries(cfg)
+	require.NoError(t, err)
+	require.Len(t, entries["default"], 1)
+	assert.Equal(t, "octocat", entries["default"][0].User)
+}
+
+func TestReadEntriesRejectsUnknownChangelog(t *testing.T) {
+	tempDir := t.TempDir()
+	entriesDir := filepath.Join(tempDir, config.DefaultEntriesDir)
+	require.NoError(t, os.Mkdir(entriesDir, 0o750))
+
+	entry := Entry{
+		ChangeLogs: []string{"nonexistent"},
+		ChangeType: "breaking",
+		Component:  "foo",
+		Note:       "broke foo",
+		Issues:     []int{123},
+		User:       "octocat",
+	}
+	writeEntry(t, entriesDir, &entry, "yaml")
+
+	cfg := &config.Config{
+		ChangeLogs:        map[string]string{"foo": filepath.Join(entriesDir, "CHANGELOG.foo.md")},
+		DefaultChangeLogs: []string{"foo"},
+		EntriesDir:        entriesDir,
+	}
+
+	_, err := ReadEntries(cfg)
+	require.ErrorContains(t, err, "'nonexistent' is not a valid value in 'change_logs'")
 }
 
 func TestFindYamlFilesEmptyDir(t *testing.T) {

--- a/tools/chloggen/internal/chlog/entry_test.go
+++ b/tools/chloggen/internal/chlog/entry_test.go
@@ -1,0 +1,403 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chlog
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/grafana/tempo/tools/chloggen/internal/config"
+)
+
+func TestEntry(t *testing.T) {
+	tmpl := template.Must(
+		template.
+			New("summary.tmpl").
+			Funcs(TemplateFuncMap()).
+			Option("missingkey=error").
+			Parse(string(defaultTmpl)))
+
+	testCases := []struct {
+		name             string
+		entry            Entry
+		requireChangeLog bool
+		validChangeLogs  []string
+		components       []string
+		expectErr        string
+		toString         string
+	}{
+		{
+			name:      "empty",
+			entry:     Entry{},
+			expectErr: "'' is not a valid 'change_type'. Specify one of [breaking deprecation new_component enhancement bug_fix]\nspecify a 'component'\nspecify a 'note'\nspecify one or more issues #'s",
+		},
+		{
+			name: "missing_component",
+			entry: Entry{
+				ChangeType: "enhancement",
+				Note:       "enhance!",
+				Issues:     []int{123},
+				SubText:    "",
+			},
+			expectErr: "specify a 'component'",
+		},
+		{
+			name: "missing_note",
+			entry: Entry{
+				ChangeType: "bug_fix",
+				Component:  "bar",
+				Issues:     []int{123},
+				SubText:    "",
+			},
+			expectErr: "specify a 'note'",
+		},
+		{
+			name: "missing_issue",
+			entry: Entry{
+				ChangeType: "bug_fix",
+				Component:  "bar",
+				Note:       "fix bar",
+				SubText:    "",
+			},
+			expectErr: "specify one or more issues #'s",
+		},
+		{
+			name: "missing_required_changelog",
+			entry: Entry{
+				ChangeType: "bug_fix",
+				Component:  "bar",
+				Note:       "fix bar",
+				Issues:     []int{123},
+				SubText:    "",
+			},
+			requireChangeLog: true,
+			validChangeLogs:  []string{"foo"},
+			expectErr:        "specify one or more 'change_logs'",
+		},
+		{
+			name: "invalid_changelog",
+			entry: Entry{
+				ChangeLogs: []string{"bar"},
+				ChangeType: "bug_fix",
+				Component:  "bar",
+				Note:       "fix bar",
+				Issues:     []int{123},
+				SubText:    "",
+			},
+			validChangeLogs: []string{"foo"},
+			expectErr:       "'bar' is not a valid value in 'change_logs'. Specify one of [foo]",
+		},
+		{
+			name: "valid",
+			entry: Entry{
+				ChangeType: "breaking",
+				Component:  "foo",
+				Note:       "broke foo",
+				Issues:     []int{123},
+				SubText:    "",
+			},
+			toString: "- `foo`: broke foo (#123)",
+		},
+		{
+			name: "multiple_issues",
+			entry: Entry{
+				ChangeType: "breaking",
+				Component:  "foo",
+				Note:       "broke foo",
+				Issues:     []int{123, 345},
+				SubText:    "",
+			},
+			toString: "- `foo`: broke foo (#123, #345)",
+		},
+		{
+			name: "subtext",
+			entry: Entry{
+				ChangeType: "breaking",
+				Component:  "foo",
+				Note:       "broke foo",
+				Issues:     []int{123},
+				SubText:    "more details",
+			},
+			toString: "- `foo`: broke foo (#123)\n  more details",
+		},
+		{
+			name: "multiline subtext",
+			entry: Entry{
+				ChangeType: "breaking",
+				Component:  "foo",
+				Note:       "broke foo",
+				Issues:     []int{123},
+				SubText:    "more details\nsecond line",
+			},
+			toString: "- `foo`: broke foo (#123)\n  more details\n  second line",
+		},
+		{
+			name: "required_changelog",
+			entry: Entry{
+				ChangeLogs: []string{"foo"},
+				ChangeType: "breaking",
+				Component:  "foo",
+				Note:       "broke foo",
+				Issues:     []int{123},
+				SubText:    "more details",
+			},
+			requireChangeLog: true,
+			validChangeLogs:  []string{"foo"},
+			toString:         "- `foo`: broke foo (#123)\n  more details",
+		},
+		{
+			name: "default_changelog",
+			entry: Entry{
+				ChangeLogs: []string{"foo"},
+				ChangeType: "breaking",
+				Component:  "foo",
+				Note:       "broke foo",
+				Issues:     []int{123},
+				SubText:    "more details",
+			},
+			requireChangeLog: false,
+			validChangeLogs:  []string{"foo"},
+			toString:         "- `foo`: broke foo (#123)\n  more details",
+		},
+		{
+			name: "subset_of_changelogs",
+			entry: Entry{
+				ChangeLogs: []string{"foo", "bar"},
+				ChangeType: "breaking",
+				Component:  "foo",
+				Note:       "broke foo",
+				Issues:     []int{123},
+				SubText:    "more details",
+			},
+			validChangeLogs: []string{"foo", "bar", "baz"},
+			toString:        "- `foo`: broke foo (#123)\n  more details",
+		},
+		{
+			name: "all_changelogs",
+			entry: Entry{
+				ChangeLogs: []string{"foo", "bar"},
+				ChangeType: "breaking",
+				Component:  "foo",
+				Note:       "broke foo",
+				Issues:     []int{123},
+				SubText:    "more details",
+			},
+			validChangeLogs: []string{"foo", "bar"},
+			toString:        "- `foo`: broke foo (#123)\n  more details",
+		},
+		{
+			name: "all_changelogs",
+			entry: Entry{
+				ChangeLogs: []string{"foo", "bar"},
+				ChangeType: "breaking",
+				Component:  "foo",
+				Note:       "broke foo",
+				Issues:     []int{123},
+				SubText:    "more details",
+			},
+			validChangeLogs: []string{"foo", "bar"},
+			toString:        "- `foo`: broke foo (#123)\n  more details",
+		},
+		{
+			name: "with_components",
+			entry: Entry{
+				ChangeLogs: []string{"foo", "bar"},
+				ChangeType: "enhancement",
+				Component:  "foo",
+				Note:       "changed foo",
+				Issues:     []int{123},
+				SubText:    "more details",
+			},
+			components:      []string{"bar"},
+			validChangeLogs: []string{"foo", "bar"},
+			toString:        "- `foo`: changed foo (#123)\n  more details",
+			expectErr:       "foo is not a valid 'component'. It must be one of [bar]",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.entry.Validate(tc.requireChangeLog, tc.components, tc.validChangeLogs...)
+			if tc.expectErr != "" {
+				assert.Error(t, err)
+				assert.Equal(t, tc.expectErr, err.Error())
+				return
+			}
+			assert.NoError(t, err)
+
+			buf := bytes.Buffer{}
+			err = tmpl.ExecuteTemplate(&buf, "entry", tc.entry)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.toString, buf.String())
+		})
+	}
+}
+
+func TestReadDeleteEntries(t *testing.T) {
+	tempDir := t.TempDir()
+	entriesDir := filepath.Join(tempDir, config.DefaultEntriesDir)
+	require.NoError(t, os.Mkdir(entriesDir, 0o750))
+
+	entryA := Entry{
+		ChangeLogs: []string{"foo"},
+		ChangeType: "breaking",
+		Component:  "foo",
+		Note:       "broke foo",
+		Issues:     []int{123},
+	}
+	writeEntry(t, entriesDir, &entryA, "yaml")
+
+	entryB := Entry{
+		ChangeLogs: []string{"bar"},
+		ChangeType: "bug_fix",
+		Component:  "bar",
+		Note:       "fix bar",
+		Issues:     []int{345, 678},
+		SubText:    "more details",
+	}
+	writeEntry(t, entriesDir, &entryB, "yml")
+
+	entryC := Entry{
+		ChangeLogs: []string{},
+		ChangeType: "enhancement",
+		Component:  "other",
+		Note:       "enhance!",
+		Issues:     []int{555},
+	}
+	writeEntry(t, entriesDir, &entryC, "yaml")
+
+	entryD := Entry{
+		ChangeLogs: []string{"foo", "bar"},
+		ChangeType: "deprecation",
+		Component:  "foobar",
+		Note:       "deprecate something",
+		Issues:     []int{999},
+	}
+	writeEntry(t, entriesDir, &entryD, "yml")
+
+	// Put config and template files in entries_dir to ensure they are ignored when reading/deleting entries
+	configYAML, err := os.Create(filepath.Join(entriesDir, "config.yaml")) //nolint:gosec
+	require.NoError(t, err)
+	defer configYAML.Close()
+
+	templateYAML, err := os.Create(filepath.Join(entriesDir, "TEMPLATE.yaml")) //nolint:gosec
+	require.NoError(t, err)
+	defer templateYAML.Close()
+
+	cfg := &config.Config{
+		ConfigYAML:   configYAML.Name(),
+		TemplateYAML: templateYAML.Name(),
+		ChangeLogs: map[string]string{
+			"foo": filepath.Join(entriesDir, "CHANGELOG.foo.md"),
+			"bar": filepath.Join(entriesDir, "CHANGELOG.bar.md"),
+		},
+		DefaultChangeLogs: []string{"foo"},
+		EntriesDir:        entriesDir,
+	}
+
+	changeLogEntries, err := ReadEntries(cfg)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 2, len(changeLogEntries))
+
+	assert.Contains(t, changeLogEntries, "foo")
+	assert.Contains(t, changeLogEntries, "bar")
+
+	assert.ElementsMatch(t, []*Entry{&entryA, &entryC, &entryD}, changeLogEntries["foo"])
+	assert.ElementsMatch(t, []*Entry{&entryB, &entryD}, changeLogEntries["bar"])
+
+	assert.NoError(t, DeleteEntries(cfg))
+	changeLogEntries, err = ReadEntries(cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(changeLogEntries))
+	assert.Empty(t, changeLogEntries["foo"])
+	assert.Empty(t, changeLogEntries["bar"])
+
+	// Ensure these weren't deleted
+	assert.FileExists(t, cfg.ConfigYAML)
+	assert.FileExists(t, cfg.TemplateYAML)
+}
+
+func TestFindYamlFilesEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+
+	files, err := findYamlFiles(dir)
+	require.NoError(t, err)
+	assert.Empty(t, files)
+}
+
+func TestFindYamlFilesBothExtensions(t *testing.T) {
+	dir := t.TempDir()
+
+	yamlFile, err := os.Create(filepath.Join(dir, "one.yaml")) //nolint:gosec
+	require.NoError(t, err)
+	defer yamlFile.Close()
+
+	ymlFile, err := os.Create(filepath.Join(dir, "two.yml")) //nolint:gosec
+	require.NoError(t, err)
+	defer ymlFile.Close()
+
+	// Non-YAML file should be ignored
+	txtFile, err := os.Create(filepath.Join(dir, "ignore.txt")) //nolint:gosec
+	require.NoError(t, err)
+	defer txtFile.Close()
+
+	files, err := findYamlFiles(dir)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{yamlFile.Name(), ymlFile.Name()}, files)
+}
+
+func TestFindYamlFilesNonRecursive(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a YAML file in the root dir
+	rootYAML, err := os.Create(filepath.Join(dir, "root.yaml")) //nolint:gosec
+	require.NoError(t, err)
+	defer rootYAML.Close()
+
+	// Create a subdirectory with a YAML file inside it
+	subdir := filepath.Join(dir, "nested")
+	require.NoError(t, os.Mkdir(subdir, 0o750))
+
+	nestedYML, err := os.Create(filepath.Join(subdir, "nested.yml")) //nolint:gosec
+	require.NoError(t, err)
+	defer nestedYML.Close()
+
+	files, err := findYamlFiles(dir)
+	require.NoError(t, err)
+	// Should only include files directly under dir, not nested ones
+	assert.ElementsMatch(t, []string{rootYAML.Name()}, files)
+}
+
+func writeEntry(t *testing.T, dir string, entry *Entry, ext string) {
+	require.Contains(t, []string{"yaml", "yml"}, ext, "ext must be 'yaml' or 'yml'")
+
+	entryBytes, err := yaml.Marshal(entry)
+	require.NoError(t, err)
+
+	entryFile, err := os.CreateTemp(dir, "*."+ext)
+	require.NoError(t, err)
+	defer entryFile.Close()
+
+	_, err = entryFile.Write(entryBytes)
+	require.NoError(t, err)
+}

--- a/tools/chloggen/internal/chlog/entry_test.go
+++ b/tools/chloggen/internal/chlog/entry_test.go
@@ -17,6 +17,7 @@ package chlog
 import (
 	"bytes"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"text/template"
@@ -49,7 +50,7 @@ func TestEntry(t *testing.T) {
 		{
 			name:      "empty",
 			entry:     Entry{},
-			expectErr: "'' is not a valid 'change_type'. Specify one of [breaking deprecation new_component enhancement bug_fix]\nspecify a 'component'\nspecify a 'note'\nspecify one or more issues #'s\nspecify a 'user'",
+			expectErr: "'' is not a valid 'change_type'. Specify one of [breaking deprecation new_component enhancement bug_fix]\nspecify a 'component'\nspecify a 'note'\nspecify a 'user'",
 		},
 		{
 			name: "missing_component",
@@ -74,7 +75,10 @@ func TestEntry(t *testing.T) {
 			expectErr: "specify a 'note'",
 		},
 		{
-			name: "missing_issue",
+			// 'issues' is optional and validates when empty; update fails before
+			// rendering such an entry, so the bare "()" here is never reached in
+			// practice.
+			name: "no_issues",
 			entry: Entry{
 				ChangeType: "bug_fix",
 				Component:  "bar",
@@ -82,7 +86,7 @@ func TestEntry(t *testing.T) {
 				SubText:    "",
 				User:       "octocat",
 			},
-			expectErr: "specify one or more issues #'s",
+			toString: "- `bar`: fix bar () (@octocat)",
 		},
 		{
 			name: "missing_required_changelog",
@@ -451,6 +455,71 @@ func TestReadEntriesRejectsUnknownChangelog(t *testing.T) {
 	require.ErrorContains(t, err, "'nonexistent' is not a valid value in 'change_logs'")
 }
 
+func TestBackfillIssues(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	dir := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput()
+		require.NoError(t, err, string(out))
+	}
+	runGit("init")
+	runGit("config", "user.email", "test@example.com")
+	runGit("config", "user.name", "Test")
+
+	// Simulate Tempo's squash-merge: the commit that adds the entry file carries
+	// the PR number in its subject.
+	path := filepath.Join(dir, "my-change.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("note: x\n"), 0o600))
+	runGit("add", "my-change.yaml")
+	runGit("commit", "-m", "Add a thing (#4242)")
+
+	t.Run("backfills PR from git when empty", func(t *testing.T) {
+		e := &Entry{path: path}
+		e.BackfillIssues()
+		assert.Equal(t, []int{4242}, e.Issues)
+	})
+
+	t.Run("keeps issues set by the author", func(t *testing.T) {
+		e := &Entry{path: path, Issues: []int{1}}
+		e.BackfillIssues()
+		assert.Equal(t, []int{1}, e.Issues)
+	})
+
+	t.Run("no-op when the file has no git history", func(t *testing.T) {
+		e := &Entry{path: filepath.Join(t.TempDir(), "untracked.yaml")}
+		e.BackfillIssues()
+		assert.Empty(t, e.Issues)
+	})
+
+	t.Run("uses the adding commit, not a later edit", func(t *testing.T) {
+		p := filepath.Join(dir, "edited.yaml")
+		require.NoError(t, os.WriteFile(p, []byte("note: a\n"), 0o600))
+		runGit("add", "edited.yaml")
+		runGit("commit", "-m", "Add edited (#100)")
+		require.NoError(t, os.WriteFile(p, []byte("note: b\n"), 0o600))
+		runGit("commit", "-am", "Tweak edited (#200)")
+
+		e := &Entry{path: p}
+		e.BackfillIssues()
+		assert.Equal(t, []int{100}, e.Issues)
+	})
+
+	t.Run("not found when the adding commit has no PR", func(t *testing.T) {
+		p := filepath.Join(dir, "nopr.yaml")
+		require.NoError(t, os.WriteFile(p, []byte("note: c\n"), 0o600))
+		runGit("add", "nopr.yaml")
+		runGit("commit", "-m", "local wip, no pr number")
+
+		e := &Entry{path: p}
+		e.BackfillIssues()
+		assert.Empty(t, e.Issues)
+	})
+}
+
 func TestFindYamlFilesEmptyDir(t *testing.T) {
 	dir := t.TempDir()
 
@@ -514,4 +583,8 @@ func writeEntry(t *testing.T, dir string, entry *Entry, ext string) {
 
 	_, err = entryFile.Write(entryBytes)
 	require.NoError(t, err)
+
+	// Record the source path so it matches what ReadEntries sets on the entries
+	// it returns (used by struct-equality assertions and BackfillIssues).
+	entry.path = entryFile.Name()
 }

--- a/tools/chloggen/internal/chlog/summary.go
+++ b/tools/chloggen/internal/chlog/summary.go
@@ -1,0 +1,102 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chlog
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/grafana/tempo/tools/chloggen/internal/config"
+)
+
+//go:embed summary.tmpl
+var defaultTmpl []byte
+
+type summary struct {
+	Version         string
+	BreakingChanges []*Entry
+	Deprecations    []*Entry
+	NewComponents   []*Entry
+	Enhancements    []*Entry
+	BugFixes        []*Entry
+}
+
+// GenerateSummary generates a changelog entry summary.
+func GenerateSummary(version string, entries []*Entry, cfg *config.Config) (string, error) {
+	s := summary{
+		Version: version,
+	}
+
+	for _, entry := range entries {
+		switch entry.ChangeType {
+		case Breaking:
+			s.BreakingChanges = append(s.BreakingChanges, entry)
+		case Deprecation:
+			s.Deprecations = append(s.Deprecations, entry)
+		case NewComponent:
+			s.NewComponents = append(s.NewComponents, entry)
+		case Enhancement:
+			s.Enhancements = append(s.Enhancements, entry)
+		case BugFix:
+			s.BugFixes = append(s.BugFixes, entry)
+		}
+	}
+
+	return s.String(cfg.SummaryTemplate)
+}
+
+// TemplateFuncMap returns a map of functions to be used in the template.
+func TemplateFuncMap() template.FuncMap {
+	return template.FuncMap{
+		"indent": func(n int, s string) string {
+			indent := strings.Repeat(" ", n)
+			return indent + strings.ReplaceAll(s, "\n", "\n"+indent)
+		},
+	}
+}
+
+// String renders the summary using the provided template.
+func (s summary) String(summaryTemplate string) (string, error) {
+	var tmpl *template.Template
+	var err error
+
+	if summaryTemplate != "" {
+		tmpl, err = template.
+			New(filepath.Base(summaryTemplate)).
+			Funcs(TemplateFuncMap()).
+			Option("missingkey=error").
+			ParseFiles(summaryTemplate)
+	} else {
+		tmpl, err = template.
+			New("summary.tmpl").
+			Funcs(TemplateFuncMap()).
+			Option("missingkey=error").
+			Parse(string(defaultTmpl))
+	}
+	if err != nil {
+		return "", err
+	}
+
+	buf := bytes.Buffer{}
+	if err := tmpl.Execute(&buf, s); err != nil {
+		return "", fmt.Errorf("failed executing template: %w", err)
+	}
+
+	return buf.String(), nil
+}

--- a/tools/chloggen/internal/chlog/summary.go
+++ b/tools/chloggen/internal/chlog/summary.go
@@ -28,8 +28,23 @@ import (
 //go:embed summary.tmpl
 var defaultTmpl []byte
 
+// group is one rendered section of the changelog: a heading and the entries
+// that belong to a single change type.
+type group struct {
+	Heading string
+	Entries []*Entry
+}
+
 type summary struct {
-	Version         string
+	Version string
+
+	// Groups holds every configured change type in configured order. This is
+	// the data model the bundled template ranges over and the only path that
+	// surfaces custom change types.
+	Groups []group
+
+	// The following fields mirror the built-in change types and are retained so
+	// that custom summary templates referencing them by name keep working.
 	BreakingChanges []*Entry
 	Deprecations    []*Entry
 	NewComponents   []*Entry
@@ -37,24 +52,40 @@ type summary struct {
 	BugFixes        []*Entry
 }
 
-// GenerateSummary generates a changelog entry summary.
+// GenerateSummary generates a changelog entry summary. Entries are grouped and
+// ordered according to cfg.ChangeTypes; when none are configured, the built-in
+// DefaultChangeTypes are used.
 func GenerateSummary(version string, entries []*Entry, cfg *config.Config) (string, error) {
 	s := summary{
 		Version: version,
 	}
 
-	for _, entry := range entries {
-		switch entry.ChangeType {
+	changeTypes := cfg.ChangeTypes
+	if len(changeTypes) == 0 {
+		changeTypes = DefaultChangeTypes
+	}
+
+	for _, ct := range changeTypes {
+		var grouped []*Entry
+		for _, entry := range entries {
+			if entry.ChangeType == ct.Key {
+				grouped = append(grouped, entry)
+			}
+		}
+		s.Groups = append(s.Groups, group{Heading: ct.Heading, Entries: grouped})
+
+		// Mirror built-in change types onto the named fields for backward compatibility.
+		switch ct.Key {
 		case Breaking:
-			s.BreakingChanges = append(s.BreakingChanges, entry)
+			s.BreakingChanges = grouped
 		case Deprecation:
-			s.Deprecations = append(s.Deprecations, entry)
+			s.Deprecations = grouped
 		case NewComponent:
-			s.NewComponents = append(s.NewComponents, entry)
+			s.NewComponents = grouped
 		case Enhancement:
-			s.Enhancements = append(s.Enhancements, entry)
+			s.Enhancements = grouped
 		case BugFix:
-			s.BugFixes = append(s.BugFixes, entry)
+			s.BugFixes = grouped
 		}
 	}
 

--- a/tools/chloggen/internal/chlog/summary.tmpl
+++ b/tools/chloggen/internal/chlog/summary.tmpl
@@ -1,0 +1,68 @@
+{{- define "entry" -}}
+- `{{ .Component }}`: {{ .Note }} (
+{{- range $i, $issue := .Issues }}
+{{- if $i }}, {{ end -}}
+#{{ $issue }}
+{{- end -}}
+)
+
+{{- if .SubText }}
+{{ .SubText | indent 2 }}
+{{- end }}
+{{- end }}
+## {{ .Version }}
+
+{{- if .BreakingChanges }}
+
+### 🛑 Breaking changes 🛑
+
+{{- range $i, $change := .BreakingChanges }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .Deprecations }}
+
+### 🚩 Deprecations 🚩
+
+{{- range $i, $change := .Deprecations }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .NewComponents }}
+
+### 🚀 New components 🚀
+
+{{- range $i, $change := .NewComponents }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .Enhancements }}
+
+### 💡 Enhancements 💡
+
+{{- range $i, $change := .Enhancements }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .BugFixes }}
+
+### 🧰 Bug fixes 🧰
+
+{{- range $i, $change := .BugFixes }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}

--- a/tools/chloggen/internal/chlog/summary.tmpl
+++ b/tools/chloggen/internal/chlog/summary.tmpl
@@ -5,64 +5,21 @@
 #{{ $issue }}
 {{- end -}}
 )
-
+{{- if .User }} (@{{ .User }}){{- end }}
 {{- if .SubText }}
 {{ .SubText | indent 2 }}
 {{- end }}
 {{- end }}
 ## {{ .Version }}
+{{- range .Groups }}
+{{- if .Entries }}
 
-{{- if .BreakingChanges }}
+### {{ .Heading }}
 
-### 🛑 Breaking changes 🛑
-
-{{- range $i, $change := .BreakingChanges }}
+{{- range $i, $change := .Entries }}
 {{- if eq $i 0}}
 {{end}}
 {{ template "entry" $change }}
 {{- end }}
-{{- end }}
-
-{{- if .Deprecations }}
-
-### 🚩 Deprecations 🚩
-
-{{- range $i, $change := .Deprecations }}
-{{- if eq $i 0}}
-{{end}}
-{{ template "entry" $change }}
-{{- end }}
-{{- end }}
-
-{{- if .NewComponents }}
-
-### 🚀 New components 🚀
-
-{{- range $i, $change := .NewComponents }}
-{{- if eq $i 0}}
-{{end}}
-{{ template "entry" $change }}
-{{- end }}
-{{- end }}
-
-{{- if .Enhancements }}
-
-### 💡 Enhancements 💡
-
-{{- range $i, $change := .Enhancements }}
-{{- if eq $i 0}}
-{{end}}
-{{ template "entry" $change }}
-{{- end }}
-{{- end }}
-
-{{- if .BugFixes }}
-
-### 🧰 Bug fixes 🧰
-
-{{- range $i, $change := .BugFixes }}
-{{- if eq $i 0}}
-{{end}}
-{{ template "entry" $change }}
 {{- end }}
 {{- end }}

--- a/tools/chloggen/internal/chlog/summary_test.go
+++ b/tools/chloggen/internal/chlog/summary_test.go
@@ -17,6 +17,7 @@ package chlog
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -100,6 +101,41 @@ func TestSummary(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, string(expected), actual)
+}
+
+func TestConfiguredChangeTypes(t *testing.T) {
+	sec := Entry{
+		ChangeType: "security",
+		Component:  "foo",
+		Note:       "fix vuln",
+		Issues:     []int{1},
+	}
+	enh := Entry{
+		ChangeType: Enhancement,
+		Component:  "bar",
+		Note:       "improve bar",
+		Issues:     []int{2},
+	}
+
+	cfg := &config.Config{
+		ChangeTypes: []config.ChangeType{
+			{Key: "security", Heading: "Security"},
+			{Key: Enhancement, Heading: "Enhancements"},
+		},
+	}
+
+	// enh is passed before sec, but the configured order must drive the output.
+	actual, err := GenerateSummary("1.0", []*Entry{&enh, &sec}, cfg)
+	require.NoError(t, err)
+
+	// The custom 'security' change type renders (the default template would drop it).
+	assert.Contains(t, actual, "### Security")
+	assert.Contains(t, actual, "- `foo`: fix vuln (#1)")
+	assert.Contains(t, actual, "### Enhancements")
+	assert.Contains(t, actual, "- `bar`: improve bar (#2)")
+
+	// Sections appear in the configured order, not entry order or built-in order.
+	assert.Less(t, strings.Index(actual, "### Security"), strings.Index(actual, "### Enhancements"))
 }
 
 func TestCustomSummary(t *testing.T) {

--- a/tools/chloggen/internal/chlog/summary_test.go
+++ b/tools/chloggen/internal/chlog/summary_test.go
@@ -1,0 +1,128 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chlog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/tempo/tools/chloggen/internal/config"
+)
+
+func TestSummary(t *testing.T) {
+	brk1 := Entry{
+		ChangeType: Breaking,
+		Component:  "foo",
+		Note:       "broke foo",
+		Issues:     []int{123},
+	}
+	brk2 := Entry{
+		ChangeType: Breaking,
+		Component:  "bar",
+		Note:       "broke bar",
+		Issues:     []int{345, 678},
+		SubText:    "more details",
+	}
+	dep1 := Entry{
+		ChangeType: Deprecation,
+		Component:  "foo",
+		Note:       "deprecate foo",
+		Issues:     []int{1234},
+	}
+	dep2 := Entry{
+		ChangeType: Deprecation,
+		Component:  "bar",
+		Note:       "deprecate bar",
+		Issues:     []int{3456, 6789},
+		SubText:    "more details",
+	}
+	enh1 := Entry{
+		ChangeType: Enhancement,
+		Component:  "foo",
+		Note:       "enhance foo",
+		Issues:     []int{12},
+	}
+	enh2 := Entry{
+		ChangeType: Enhancement,
+		Component:  "bar",
+		Note:       "enhance bar",
+		Issues:     []int{34, 67},
+		SubText:    "more details",
+	}
+	bug1 := Entry{
+		ChangeType: BugFix,
+		Component:  "foo",
+		Note:       "bug foo",
+		Issues:     []int{1},
+	}
+	bug2 := Entry{
+		ChangeType: BugFix,
+		Component:  "bar",
+		Note:       "bug bar",
+		Issues:     []int{3, 6},
+		SubText:    "more details",
+	}
+	new1 := Entry{
+		ChangeType: NewComponent,
+		Component:  "foo",
+		Note:       "new foo",
+		Issues:     []int{2},
+	}
+	new2 := Entry{
+		ChangeType: NewComponent,
+		Component:  "bar",
+		Note:       "new bar",
+		Issues:     []int{4, 7},
+		SubText:    "more details",
+	}
+
+	actual, err := GenerateSummary("1.0", []*Entry{&brk1, &brk2, &dep1, &dep2, &enh1, &enh2, &bug1, &bug2, &new1, &new2}, &config.Config{})
+	assert.NoError(t, err)
+
+	// This file is not meant to be the entire changelog so will not pass markdownlint if named with .md extension.
+	expected, err := os.ReadFile(filepath.Join("testdata", "CHANGELOG"))
+	require.NoError(t, err)
+
+	assert.Equal(t, string(expected), actual)
+}
+
+func TestCustomSummary(t *testing.T) {
+	brk1 := Entry{
+		ChangeType: Breaking,
+		Component:  "foo",
+		Note:       "broke foo",
+		Issues:     []int{123},
+	}
+	brk2 := Entry{
+		ChangeType: Breaking,
+		Component:  "bar",
+		Note:       "broke bar",
+		Issues:     []int{345, 678},
+		SubText:    "more details",
+	}
+
+	actual, err := GenerateSummary("1.0", []*Entry{&brk1, &brk2}, &config.Config{SummaryTemplate: filepath.Join("testdata", "custom.tmpl")})
+	require.NoError(t, err)
+
+	// This file is not meant to be the entire changelog so will not pass markdownlint if named with .md extension.
+	expected, err := os.ReadFile(filepath.Join("testdata", "CHANGELOG_custom"))
+	require.NoError(t, err)
+
+	assert.Equal(t, string(expected), actual)
+}

--- a/tools/chloggen/internal/chlog/testdata/CHANGELOG
+++ b/tools/chloggen/internal/chlog/testdata/CHANGELOG
@@ -1,0 +1,32 @@
+
+## 1.0
+
+### 🛑 Breaking changes 🛑
+
+- `foo`: broke foo (#123)
+- `bar`: broke bar (#345, #678)
+  more details
+
+### 🚩 Deprecations 🚩
+
+- `foo`: deprecate foo (#1234)
+- `bar`: deprecate bar (#3456, #6789)
+  more details
+
+### 🚀 New components 🚀
+
+- `foo`: new foo (#2)
+- `bar`: new bar (#4, #7)
+  more details
+
+### 💡 Enhancements 💡
+
+- `foo`: enhance foo (#12)
+- `bar`: enhance bar (#34, #67)
+  more details
+
+### 🧰 Bug fixes 🧰
+
+- `foo`: bug foo (#1)
+- `bar`: bug bar (#3, #6)
+  more details

--- a/tools/chloggen/internal/chlog/testdata/CHANGELOG_custom
+++ b/tools/chloggen/internal/chlog/testdata/CHANGELOG_custom
@@ -1,0 +1,8 @@
+
+## 1.0
+
+### 🛑 Breaking changes 🛑
+
+- `foo`: broke foo ([#123](https://github.com/open-telemetry/opentelemetry-go-build-tools/issues/123))
+- `bar`: broke bar ([#345](https://github.com/open-telemetry/opentelemetry-go-build-tools/issues/345), [#678](https://github.com/open-telemetry/opentelemetry-go-build-tools/issues/678))
+  more details

--- a/tools/chloggen/internal/chlog/testdata/custom.tmpl
+++ b/tools/chloggen/internal/chlog/testdata/custom.tmpl
@@ -1,0 +1,68 @@
+{{- define "entry" -}}
+- `{{ .Component }}`: {{ .Note }} (
+{{- range $i, $issue := .Issues }}
+{{- if $i }}, {{ end -}}
+[#{{ $issue }}](https://github.com/open-telemetry/opentelemetry-go-build-tools/issues/{{ $issue }})
+{{- end -}}
+)
+
+{{- if .SubText }}
+{{ .SubText | indent 2 }}
+{{- end }}
+{{- end }}
+## {{ .Version }}
+
+{{- if .BreakingChanges }}
+
+### 🛑 Breaking changes 🛑
+
+{{- range $i, $change := .BreakingChanges }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .Deprecations }}
+
+### 🚩 Deprecations 🚩
+
+{{- range $i, $change := .Deprecations }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .NewComponents }}
+
+### 🚀 New components 🚀
+
+{{- range $i, $change := .NewComponents }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .Enhancements }}
+
+### 💡 Enhancements 💡
+
+{{- range $i, $change := .Enhancements }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .BugFixes }}
+
+### 🧰 Bug fixes 🧰
+
+{{- range $i, $change := .BugFixes }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}

--- a/tools/chloggen/internal/config/config.go
+++ b/tools/chloggen/internal/config/config.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -35,6 +36,15 @@ const (
 	DefaultChangeLogFilename = "CHANGELOG.md"
 )
 
+// ChangeType defines a valid change_type and how entries of that type are
+// grouped when rendering the changelog summary.
+type ChangeType struct {
+	// Key is the value an entry's 'change_type' must match.
+	Key string `yaml:"key"`
+	// Heading is the section heading used for this change type in the summary.
+	Heading string `yaml:"heading"`
+}
+
 // Config represents the configuration for changelogs.
 type Config struct {
 	ChangeLogs        map[string]string `yaml:"change_logs"`
@@ -43,6 +53,7 @@ type Config struct {
 	TemplateYAML      string            `yaml:"template_yaml"`
 	SummaryTemplate   string            `yaml:"summary_template"`
 	Components        []string          `yaml:"components"`
+	ChangeTypes       []ChangeType      `yaml:"change_types"`
 	ConfigYAML        string
 }
 
@@ -67,7 +78,7 @@ func NewFromFile(rootDir string, cfgFilename string) (*Config, error) {
 		return nil, err
 	}
 	cfg := &Config{}
-	if err = yaml.Unmarshal(cfgBytes, &cfg); err != nil {
+	if err = yaml.Unmarshal(cfgBytes, cfg); err != nil {
 		return nil, err
 	}
 
@@ -75,12 +86,20 @@ func NewFromFile(rootDir string, cfgFilename string) (*Config, error) {
 	cfg.EntriesDir = makeAbs(rootDir, cfg.EntriesDir, DefaultEntriesDir)
 	cfg.TemplateYAML = makeAbs(rootDir, cfg.TemplateYAML, filepath.Join(DefaultEntriesDir, DefaultTemplateYAML))
 
+	if err = validateChangeTypes(cfg.ChangeTypes); err != nil {
+		return nil, err
+	}
+
 	if len(cfg.ChangeLogs) == 0 && len(cfg.DefaultChangeLogs) > 0 {
-		return nil, errors.New("cannot specify 'default_changelogs' without 'changelogs'")
+		return nil, errors.New("cannot specify 'default_change_logs' without 'change_logs'")
 	}
 
 	if len(cfg.ChangeLogs) == 0 {
-		cfg.ChangeLogs[DefaultChangeLogKey] = filepath.Join(rootDir, DefaultChangeLogFilename)
+		// 'change_logs' was omitted; initialize the map before writing the default
+		// (yaml.Unmarshal leaves it nil when the key is absent).
+		cfg.ChangeLogs = map[string]string{
+			DefaultChangeLogKey: filepath.Join(rootDir, DefaultChangeLogFilename),
+		}
 		cfg.DefaultChangeLogs = []string{DefaultChangeLogKey}
 		return cfg, nil
 	}
@@ -96,11 +115,31 @@ func NewFromFile(rootDir string, cfgFilename string) (*Config, error) {
 
 	for _, key := range cfg.DefaultChangeLogs {
 		if _, ok := cfg.ChangeLogs[key]; !ok {
-			return nil, fmt.Errorf("'default_changelogs' contains key %q which is not defined in 'changelogs'", key)
+			return nil, fmt.Errorf("'default_change_logs' contains key %q which is not defined in 'change_logs'", key)
 		}
 	}
 
 	return cfg, nil
+}
+
+// validateChangeTypes fails fast on a malformed 'change_types' configuration:
+// empty keys or headings, or duplicate keys. An empty list is valid (the
+// built-in defaults are used).
+func validateChangeTypes(changeTypes []ChangeType) error {
+	seen := make(map[string]struct{}, len(changeTypes))
+	for _, ct := range changeTypes {
+		if strings.TrimSpace(ct.Key) == "" {
+			return errors.New("'change_types' entries must each have a non-empty 'key'")
+		}
+		if strings.TrimSpace(ct.Heading) == "" {
+			return fmt.Errorf("'change_types' entry %q must have a non-empty 'heading'", ct.Key)
+		}
+		if _, dup := seen[ct.Key]; dup {
+			return fmt.Errorf("'change_types' contains duplicate key %q", ct.Key)
+		}
+		seen[ct.Key] = struct{}{}
+	}
+	return nil
 }
 
 func makeAbs(rootDir, path, defaultPath string) string {

--- a/tools/chloggen/internal/config/config.go
+++ b/tools/chloggen/internal/config/config.go
@@ -1,0 +1,114 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package config provides changelog configuration.
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// DefaultEntriesDir is the default directory for changelog entries.
+	DefaultEntriesDir = ".chloggen"
+	// DefaultTemplateYAML is the default template file for changelog entries.
+	DefaultTemplateYAML = "TEMPLATE.yaml"
+	// DefaultChangeLogKey is the default key for the changelog.
+	DefaultChangeLogKey = "default"
+	// DefaultChangeLogFilename is the default filename for the changelog.
+	DefaultChangeLogFilename = "CHANGELOG.md"
+)
+
+// Config represents the configuration for changelogs.
+type Config struct {
+	ChangeLogs        map[string]string `yaml:"change_logs"`
+	DefaultChangeLogs []string          `yaml:"default_change_logs"`
+	EntriesDir        string            `yaml:"entries_dir"`
+	TemplateYAML      string            `yaml:"template_yaml"`
+	SummaryTemplate   string            `yaml:"summary_template"`
+	Components        []string          `yaml:"components"`
+	ConfigYAML        string
+}
+
+// New returns a new Config with default values.
+func New(rootDir string) *Config {
+	return &Config{
+		ChangeLogs:        map[string]string{DefaultChangeLogKey: filepath.Join(rootDir, DefaultChangeLogFilename)},
+		DefaultChangeLogs: []string{DefaultChangeLogKey},
+		EntriesDir:        filepath.Join(rootDir, DefaultEntriesDir),
+		TemplateYAML:      filepath.Join(rootDir, DefaultEntriesDir, DefaultTemplateYAML),
+	}
+}
+
+// NewFromFile returns a new Config from the specified YAML file.
+func NewFromFile(rootDir string, cfgFilename string) (*Config, error) {
+	if !filepath.IsAbs(cfgFilename) {
+		cfgFilename = filepath.Join(rootDir, cfgFilename)
+	}
+	cfgYAML := filepath.Clean(cfgFilename)
+	cfgBytes, err := os.ReadFile(cfgYAML) // nolint:gosec // false positive
+	if err != nil {
+		return nil, err
+	}
+	cfg := &Config{}
+	if err = yaml.Unmarshal(cfgBytes, &cfg); err != nil {
+		return nil, err
+	}
+
+	cfg.ConfigYAML = cfgYAML
+	cfg.EntriesDir = makeAbs(rootDir, cfg.EntriesDir, DefaultEntriesDir)
+	cfg.TemplateYAML = makeAbs(rootDir, cfg.TemplateYAML, filepath.Join(DefaultEntriesDir, DefaultTemplateYAML))
+
+	if len(cfg.ChangeLogs) == 0 && len(cfg.DefaultChangeLogs) > 0 {
+		return nil, errors.New("cannot specify 'default_changelogs' without 'changelogs'")
+	}
+
+	if len(cfg.ChangeLogs) == 0 {
+		cfg.ChangeLogs[DefaultChangeLogKey] = filepath.Join(rootDir, DefaultChangeLogFilename)
+		cfg.DefaultChangeLogs = []string{DefaultChangeLogKey}
+		return cfg, nil
+	}
+
+	// The user specified at least one changelog. Interpret filename as a relative path from rootDir
+	// (unless they specified an absolute path including rootDir)
+	for key, filename := range cfg.ChangeLogs {
+		if !filepath.IsAbs(filename) {
+			cfg.ChangeLogs[key] = filepath.Join(rootDir, filename)
+		}
+		cfg.ChangeLogs[key] = filepath.Clean(cfg.ChangeLogs[key])
+	}
+
+	for _, key := range cfg.DefaultChangeLogs {
+		if _, ok := cfg.ChangeLogs[key]; !ok {
+			return nil, fmt.Errorf("'default_changelogs' contains key %q which is not defined in 'changelogs'", key)
+		}
+	}
+
+	return cfg, nil
+}
+
+func makeAbs(rootDir, path, defaultPath string) string {
+	if path == "" {
+		return filepath.Clean(filepath.Join(rootDir, defaultPath))
+	}
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	return filepath.Clean(filepath.Join(rootDir, path))
+}

--- a/tools/chloggen/internal/config/config.yaml
+++ b/tools/chloggen/internal/config/config.yaml
@@ -1,0 +1,26 @@
+# The directory that stores individual changelog entries.
+# Each entry is stored in a dedicated yaml file.
+# - 'chloggen new' will copy the 'template_yaml' to this directory as a new entry file.
+# - 'chloggen validate' will validate that all entry files are valid.
+# - 'chloggen update' will read and delete all entry files in this directory, and update 'changelog_md'.
+# Specify as relative path from root of repo.
+# (Optional) Default: .chloggen
+# entries_dir:
+
+# This file is used as the input for individual changelog entries.
+# Specify as relative path from root of repo.
+# (Optional) Default: .chloggen/TEMPLATE.yaml
+# template_yaml:
+
+# The CHANGELOG file or files to which 'chloggen update' will write new entries
+# (Optional) Default filename: CHANGELOG.md
+# change_logs:
+#   default: CHANGELOG.md
+
+# The default change_log or change_logs to which an entry should be added.
+# If 'change_logs' is specified in this file, and no value is specified for 'default_change_logs',
+# then 'change_logs' MUST be specified in every entry file.
+# default_change_logs: []
+
+# The component values accepted. If empty, any component value is accepted.
+# components: []

--- a/tools/chloggen/internal/config/config_test.go
+++ b/tools/chloggen/internal/config/config_test.go
@@ -78,7 +78,7 @@ func TestNewFromFile(t *testing.T) {
 				TemplateYAML:      "TEMPLATE-custom.yaml",
 				DefaultChangeLogs: []string{"foo"},
 			},
-			expectErr: "cannot specify 'default_changelogs' without 'changelogs",
+			expectErr: "cannot specify 'default_change_logs' without 'change_logs'",
 		},
 		{
 			name: "default-changelog-not-in-changelogs",
@@ -91,7 +91,7 @@ func TestNewFromFile(t *testing.T) {
 				},
 				DefaultChangeLogs: []string{"foo", "bar", "fake"},
 			},
-			expectErr: `contains key "fake" which is not defined in 'changelogs'`,
+			expectErr: `contains key "fake" which is not defined in 'change_logs'`,
 		},
 		{
 			name: "absolute-entries-dir",
@@ -207,4 +207,60 @@ func TestNewFromFileErr(t *testing.T) {
 
 	_, err = NewFromFile(tempDir, filepath.Base(cfgFile.Name()))
 	assert.Error(t, err)
+}
+
+func TestNewFromFileOmittedChangeLogs(t *testing.T) {
+	tempDir := t.TempDir()
+
+	cfgFile, err := os.CreateTemp(tempDir, "*.yaml")
+	require.NoError(t, err)
+	defer cfgFile.Close()
+
+	// A config file that omits 'change_logs' entirely must not panic; the
+	// default changelog should be applied.
+	_, err = cfgFile.WriteString("components: [foo]\n")
+	require.NoError(t, err)
+
+	cfg, err := NewFromFile(tempDir, filepath.Base(cfgFile.Name()))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(cfg.ChangeLogs))
+	assert.Equal(t, filepath.Join(tempDir, DefaultChangeLogFilename), cfg.ChangeLogs[DefaultChangeLogKey])
+	assert.Equal(t, []string{DefaultChangeLogKey}, cfg.DefaultChangeLogs)
+}
+
+func TestNewFromFileMalformedChangeTypes(t *testing.T) {
+	testCases := []struct {
+		name      string
+		yaml      string
+		expectErr string
+	}{
+		{
+			name:      "empty_key",
+			yaml:      "change_types:\n  - key: \"\"\n    heading: Stuff\n",
+			expectErr: "must each have a non-empty 'key'",
+		},
+		{
+			name:      "empty_heading",
+			yaml:      "change_types:\n  - key: stuff\n    heading: \"\"\n",
+			expectErr: `entry "stuff" must have a non-empty 'heading'`,
+		},
+		{
+			name:      "duplicate_key",
+			yaml:      "change_types:\n  - key: stuff\n    heading: Stuff\n  - key: stuff\n    heading: More stuff\n",
+			expectErr: `duplicate key "stuff"`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			cfgFile, err := os.CreateTemp(tempDir, "*.yaml")
+			require.NoError(t, err)
+			defer cfgFile.Close()
+			_, err = cfgFile.WriteString(tc.yaml)
+			require.NoError(t, err)
+
+			_, err = NewFromFile(tempDir, filepath.Base(cfgFile.Name()))
+			require.ErrorContains(t, err, tc.expectErr)
+		})
+	}
 }

--- a/tools/chloggen/internal/config/config_test.go
+++ b/tools/chloggen/internal/config/config_test.go
@@ -1,0 +1,210 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestNew(t *testing.T) {
+	root := "/tmp"
+	cfg := New(root)
+	assert.Equal(t, filepath.Join(root, DefaultEntriesDir), cfg.EntriesDir)
+	assert.Equal(t, filepath.Join(root, DefaultEntriesDir, DefaultTemplateYAML), cfg.TemplateYAML)
+
+	assert.Equal(t, 1, len(cfg.ChangeLogs))
+	assert.NotNil(t, cfg.ChangeLogs[DefaultChangeLogKey])
+	assert.Equal(t, filepath.Join(root, DefaultChangeLogFilename), cfg.ChangeLogs[DefaultChangeLogKey])
+
+	assert.Equal(t, 1, len(cfg.DefaultChangeLogs))
+	assert.Equal(t, DefaultChangeLogKey, cfg.DefaultChangeLogs[0])
+}
+
+func TestNewFromFile(t *testing.T) {
+	testCases := []struct {
+		name      string
+		cfg       *Config
+		expectErr string
+	}{
+		{
+			name: "empty",
+			cfg:  &Config{},
+		},
+		{
+			name: "multi-changelog-no-default",
+			cfg: &Config{
+				EntriesDir:   ".test",
+				TemplateYAML: "TEMPLATE-custom.yaml",
+				ChangeLogs: map[string]string{
+					"foo": "CHANGELOG-1.md",
+					"bar": "CHANGELOG-2.md",
+				},
+			},
+		},
+		{
+			name: "multi-changelog-with-default",
+			cfg: &Config{
+				EntriesDir:   ".test",
+				TemplateYAML: "TEMPLATE-custom.yaml",
+				ChangeLogs: map[string]string{
+					"foo": "CHANGELOG-1.md",
+					"bar": "CHANGELOG-2.md",
+				},
+				DefaultChangeLogs: []string{"foo"},
+			},
+		},
+		{
+			name: "default-changelogs-without-changelogs",
+			cfg: &Config{
+				EntriesDir:        ".test",
+				TemplateYAML:      "TEMPLATE-custom.yaml",
+				DefaultChangeLogs: []string{"foo"},
+			},
+			expectErr: "cannot specify 'default_changelogs' without 'changelogs",
+		},
+		{
+			name: "default-changelog-not-in-changelogs",
+			cfg: &Config{
+				EntriesDir:   ".test",
+				TemplateYAML: "TEMPLATE-custom.yaml",
+				ChangeLogs: map[string]string{
+					"foo": "CHANGELOG-1.md",
+					"bar": "CHANGELOG-2.md",
+				},
+				DefaultChangeLogs: []string{"foo", "bar", "fake"},
+			},
+			expectErr: `contains key "fake" which is not defined in 'changelogs'`,
+		},
+		{
+			name: "absolute-entries-dir",
+			cfg: &Config{
+				EntriesDir: "/tmp/abs_entries",
+			},
+		},
+		{
+			name: "absolute-template-yaml",
+			cfg: &Config{
+				TemplateYAML: "/tmp/abs_template.yaml",
+			},
+		},
+		{
+			name: "absolute-changelog",
+			cfg: &Config{
+				ChangeLogs: map[string]string{
+					"default": "/tmp/abs_changelog.md",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+
+			cfgBytes, err := yaml.Marshal(tc.cfg)
+			require.NoError(t, err)
+
+			cfgFile, err := os.CreateTemp(tempDir, "*.yaml")
+			require.NoError(t, err)
+			defer cfgFile.Close()
+
+			_, err = cfgFile.Write(cfgBytes)
+			require.NoError(t, err)
+
+			actualCfg, err := NewFromFile(tempDir, filepath.Base(cfgFile.Name()))
+			if tc.expectErr != "" {
+				require.ErrorContains(t, err, tc.expectErr)
+				return
+			}
+			assert.NoError(t, err)
+
+			// This would be the default config is no values were specified in the config file.
+			// Instantiate it here to compare against the actual config as appropriate.
+			defaultCfg := New(tempDir)
+
+			expectedEntriesDir := defaultCfg.EntriesDir
+			if tc.cfg.EntriesDir != "" {
+				if filepath.IsAbs(tc.cfg.EntriesDir) {
+					expectedEntriesDir = filepath.Clean(tc.cfg.EntriesDir)
+				} else {
+					expectedEntriesDir = filepath.Join(tempDir, tc.cfg.EntriesDir)
+				}
+			}
+			assert.Equal(t, expectedEntriesDir, actualCfg.EntriesDir)
+
+			expectedTemplateYAML := defaultCfg.TemplateYAML
+			if tc.cfg.TemplateYAML != "" {
+				if filepath.IsAbs(tc.cfg.TemplateYAML) {
+					expectedTemplateYAML = filepath.Clean(tc.cfg.TemplateYAML)
+				} else {
+					expectedTemplateYAML = filepath.Join(tempDir, tc.cfg.TemplateYAML)
+				}
+			}
+			assert.Equal(t, expectedTemplateYAML, actualCfg.TemplateYAML)
+
+			if len(tc.cfg.ChangeLogs) == 0 {
+				assert.Equal(t, 1, len(actualCfg.ChangeLogs))
+				assert.NotNil(t, actualCfg.ChangeLogs[DefaultChangeLogKey])
+				assert.Equal(t, filepath.Join(tempDir, DefaultChangeLogFilename), actualCfg.ChangeLogs[DefaultChangeLogKey])
+
+				// When no changelogs are specified, the default changelog must be the only default changelog.
+				assert.Equal(t, 1, len(actualCfg.DefaultChangeLogs))
+				assert.Equal(t, DefaultChangeLogKey, actualCfg.DefaultChangeLogs[0])
+			} else {
+				assert.Equal(t, len(tc.cfg.ChangeLogs), len(actualCfg.ChangeLogs))
+				for key, filename := range tc.cfg.ChangeLogs {
+					assert.NotNil(t, actualCfg.ChangeLogs[key])
+					expectedFilename := filename
+					if !filepath.IsAbs(filename) {
+						expectedFilename = filepath.Join(tempDir, filename)
+					}
+					assert.Equal(t, filepath.Clean(expectedFilename), actualCfg.ChangeLogs[key])
+				}
+
+				// When changelogs are specified, the default changelogs must be a subset of the changelogs.
+				// It is acceptable to have no default changelog.
+				assert.Equal(t, len(tc.cfg.DefaultChangeLogs), len(actualCfg.DefaultChangeLogs))
+			}
+
+			for _, key := range actualCfg.DefaultChangeLogs {
+				assert.NotNil(t, actualCfg.ChangeLogs[key])
+			}
+		})
+	}
+}
+
+func TestNewFromFileErr(t *testing.T) {
+	tempDir := t.TempDir()
+
+	_, err := NewFromFile(tempDir, "nonexistent.yaml")
+	assert.Error(t, err)
+
+	// Write a file with invalid YAML and then read it back to get expected error
+	cfgFile, err := os.CreateTemp(tempDir, "*.yaml")
+	require.NoError(t, err)
+	defer cfgFile.Close()
+
+	_, err = cfgFile.WriteString("!@#$%^&*())")
+	require.NoError(t, err)
+
+	_, err = NewFromFile(tempDir, filepath.Base(cfgFile.Name()))
+	assert.Error(t, err)
+}

--- a/tools/chloggen/main.go
+++ b/tools/chloggen/main.go
@@ -1,0 +1,24 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Chloggen generates changelog entries.
+package main
+
+import (
+	"github.com/grafana/tempo/tools/chloggen/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -14,6 +14,12 @@ tool (
 )
 
 require (
+	github.com/spf13/cobra v1.10.2
+	github.com/stretchr/testify v1.11.1
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
 	4d63.com/gocheckcompilerdirectives v1.3.0 // indirect
 	4d63.com/gochecknoglobals v0.2.2 // indirect
 	codeberg.org/chavacava/garif v0.2.0 // indirect
@@ -183,14 +189,12 @@ require (
 	github.com/sourcegraph/go-diff v0.7.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
-	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spf13/viper v1.12.0 // indirect
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.3.1 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/tetafro/godot v1.5.4 // indirect
 	github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67 // indirect
@@ -227,7 +231,6 @@ require (
 	google.golang.org/protobuf v1.36.8 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/gotestsum v1.13.0 // indirect
 	honnef.co/go/tools v0.7.0 // indirect
 	mvdan.cc/gofumpt v0.9.2 // indirect


### PR DESCRIPTION
Backports the changelog-tooling (chloggen) work to `release-v3.0`.

### Cherry-picked PRs (in order)

1. #7346 — chore(tools): add chloggen for changelog management (the in-tree fork)
2. #7351 — chore(tools): configurable chloggen change types and required entry author
3. #7339 — chore: adopt chloggen for changelog management
4. #7366 — chore: update changelog check to include modified files
5. #7368 — chore(chloggen): branch-name default, optional auto-filled PR, type/docs skip

### Backport adaptations

- **Dropped** the 28 `.chloggen/_migrated_*.yaml` files introduced by #7339. Those captured *main's* post-v3.0.0 unreleased entries; none of those PRs are in `release-v3.0`'s history, so they don't belong here.
- **CHANGELOG.md**: `release-v3.0`'s `## main / unreleased` section was empty, so it's simply replaced with the `<!-- next version -->` marker (no entries to migrate).
- **changelog workflow** (`.github/workflows/changelog.yml`): retargeted from `main` to `release-v3.0` (PR trigger branch + `git merge-base` base) so the check runs on backport PRs to this branch. Added as a separate adaptation commit.

### Verification

- `make chlog-validate` passes; `go test ./...` in `tools/chloggen` is green.
